### PR TITLE
Support subquery negation operator in SemanticMediaWiki queries.

### DIFF
--- a/SemanticMediaWiki.settings.php
+++ b/SemanticMediaWiki.settings.php
@@ -277,7 +277,8 @@ $GLOBALS['smwgQMaxDepth'] = 4; // Maximal property depth of queries, e.g. [[rel:
 // anything but disjunctions:  $GLOBALS['smwgQFeatures'] = SMW_ANY_QUERY & ~SMW_DISJUNCTION_QUERY;
 // The default is to support all basic features.
 $GLOBALS['smwgQFeatures'] = SMW_PROPERTY_QUERY | SMW_CATEGORY_QUERY | SMW_CONCEPT_QUERY |
-                 SMW_NAMESPACE_QUERY | SMW_CONJUNCTION_QUERY | SMW_DISJUNCTION_QUERY;
+                 SMW_NAMESPACE_QUERY | SMW_CONJUNCTION_QUERY | SMW_DISJUNCTION_QUERY |
+                 SMW_NEGATION_QUERY;
 
 ### Settings about printout of (especially inline) queries:
 $GLOBALS['smwgQDefaultLimit'] = 50;      // Default number of rows returned in a query. Can be increased with limit=num in #ask

--- a/includes/Defines.php
+++ b/includes/Defines.php
@@ -57,6 +57,7 @@ define( 'SMW_CONCEPT_QUERY', 4 );      // [[Concept:...]]
 define( 'SMW_NAMESPACE_QUERY', 8 );    // [[User:+]] etc.
 define( 'SMW_CONJUNCTION_QUERY', 16 ); // any conjunctions
 define( 'SMW_DISJUNCTION_QUERY', 32 ); // any disjunctions (OR, ||)
+define( 'SMW_NEGATION_QUERY', 64 );     // any negation (!)
 define( 'SMW_ANY_QUERY', 0xFFFFFFFF );  // subsumes all other options
 /**@}*/
 

--- a/languages/SMW_Messages.php
+++ b/languages/SMW_Messages.php
@@ -149,6 +149,7 @@ Results might not be as expected.',
 	'smw_noqueryfeature'    => 'Some query feature was not supported in this wiki and part of the query was dropped ($1).',
 	'smw_noconjunctions'    => 'Conjunctions in queries are not supported in this wiki and part of the query was dropped ($1).',
 	'smw_nodisjunctions'    => 'Disjunctions in queries are not supported in this wiki and part of the query was dropped ($1).',
+	'smw_nonegations'       => 'Negations in queries are not supported in this wiki and part of the query was dropped ($1).',
 	'smw_querytoolarge'     => 'The following query conditions could not be considered due to the wikis restrictions in query size or depth: $1.',
 	'smw_notemplategiven'   => 'Provide a value for the parameter "template" for this query format to work.',
 
@@ -620,6 +621,8 @@ See also:
 	'smw_noconjunctions' => 'This is an error/warning message. Parameters:
 * $1 holds the part(s) of the query which were dropped.',
 	'smw_nodisjunctions' => 'This is an error/warning message. Parameters:
+* $1 holds the part(s) of the query which were dropped.',
+	'smw_nonegations' => 'This is an error/warning message. Parameters:
 * $1 holds the part(s) of the query which were dropped.',
 	'smw_querytoolarge' => 'This is an error/warning message. Parameters:
 * $1 holds the part(s) of the query which were dropped.',
@@ -12305,6 +12308,7 @@ $messages['ru'] = array(
 	'smw_noqueryfeature' => 'Часть запроса была опущена, так как некоторые из возможностей языка запросов не поддерживаются на этом вики-сайте ($1).',
 	'smw_noconjunctions' => 'Часть запроса была опущена, так как операция «Логическое И» не поддерживается на этом вики-сайте ($1).',
 	'smw_nodisjunctions' => 'Ошибка: Дизъюнкции (логическое ИЛИ) не поддерживаются данным сайтом, поэтому использующая их часть запроса была проигнорирована ($1).',
+	'smw_nonegations' => 'Ошибка: Логическое отрицание не поддерживаются данным сайтом, поэтому использующая их часть запроса была проигнорирована ($1).',
 	'smw_querytoolarge' => 'Ошибка: Указанные условия запроса “$1” не могут быть выполнены из-за ограничения на глубину или размер запроса.',
 	'smw_notemplategiven' => 'Чтобы данный запрос выполнялся, необходимо задать значение для параметра «template».',
 	'smw_db_sparqlqueryproblem' => 'Не удалось получить результат запроса к базе данных SPARQL. Эта может быть временная ошибка или проблема в программном обеспечении базы данных.',


### PR DESCRIPTION
The syntax is {{#ask: [[prop::val]] !<q>...subquery...</q> }}
or just {{#ask: [[prop::val]] ![[prop2::val2]] }}.

Change-Id: I107d7f6905860379684a011ba1bf0c44a150c575
