### PR TITLE
Disable type enforcement for properties with names equal to type names.

### DIFF
--- a/includes/dataitems/SMW_DI_Property.php
+++ b/includes/dataitems/SMW_DI_Property.php
@@ -379,8 +379,8 @@ class DIProperty extends SMWDataItem {
 
 		$datatypeLabels = $smwgContLang->getDatatypeLabels();
 
-		self::$m_prop_labels  = $smwgContLang->getPropertyLabels() + $datatypeLabels;
-		self::$m_prop_aliases = $smwgContLang->getPropertyAliases() + $smwgContLang->getDatatypeAliases();
+		self::$m_prop_labels  = $smwgContLang->getPropertyLabels();
+		self::$m_prop_aliases = $smwgContLang->getPropertyAliases();
 
 		// Setup built-in predefined properties.
 		// NOTE: all ids must start with underscores. The translation


### PR DESCRIPTION
Now if you try to use some property named like an SMW builtin type (for example, "[[Telephone number::jqlqdjq]]"), its type will be always forced to be Telephone number, i.e. you can't override it with [[has type::]]. I think this is an unevident and undocumented behaviour, so this patch disables it.

Change-Id: I4b4922c6d5df4d3455d667f98732e13bab403769
