### PR TITLE
Use prepareTextForEdit or prepareContentForEdit

### DIFF
--- a/includes/hooks/NewRevisionFromEditComplete.php
+++ b/includes/hooks/NewRevisionFromEditComplete.php
@@ -62,12 +62,42 @@ class NewRevisionFromEditComplete extends FunctionHook {
 	 */
 	public function process() {
 
-		$parserOutput = $this->wikiPage->getParserOutput(
-			$this->wikiPage->makeParserOptions( $this->user ),
-			$this->revision->getId()
-		);
+		$parserOutput = $this->retrieveParserOutput();
 
 		return $parserOutput instanceof ParserOutput ? $this->performUpdate( $parserOutput ) : true;
+	}
+
+	/**
+	 * @since 1.9
+	 *
+	 * @return ParserOutput|null
+	 */
+	protected function retrieveParserOutput() {
+
+		$editInfo = false;
+
+		if ( method_exists( 'WikiPage', 'prepareContentForEdit' ) ) {
+
+			$content  = $this->revision->getContent();
+
+			$editInfo = $this->wikiPage->prepareContentForEdit(
+				$content,
+				null,
+				$this->user,
+				$content->getContentHandler()->getDefaultFormat()
+			);
+
+		} else {
+
+			$editInfo = $this->wikiPage->prepareTextForEdit(
+				$this->revision->getRawText(),
+				null,
+				$this->user
+			);
+
+		}
+
+		return $editInfo ? $editInfo->output : null;
 	}
 
 	/**

--- a/tests/phpunit/includes/SetupTest.php
+++ b/tests/phpunit/includes/SetupTest.php
@@ -10,6 +10,7 @@ use SMW\ExtensionContext;
  *
  * @group SMW
  * @group SMWExtension
+ * @group medium
  *
  * @licence GNU GPL v2+
  * @since 1.9
@@ -155,6 +156,9 @@ class SetupTest extends SemanticMediaWikiTestCase {
 		$empty = '';
 		$emptyArray = array();
 
+		$editInfo = (object)array();
+		$editInfo->output = null;
+
 		// Evade execution by setting the title object as isSpecialPage
 		// the hook class should always ensure that isSpecialPage is checked
 		$title =  $this->newMockBuilder()->newObject( 'Title', array(
@@ -188,13 +192,15 @@ class SetupTest extends SemanticMediaWikiTestCase {
 		$parserOptions = $this->newMockBuilder()->newObject( 'ParserOptions' );
 
 		$wikiPage = $this->newMockBuilder()->newObject( 'WikiPage', array(
-			'getTitle'          => $title,
-			'getParserOutput'   => null,
-			'makeParserOptions' => $parserOptions
+			'prepareContentForEdit' => $editInfo,
+			'prepareTextForEdit'    => $editInfo,
+			'getTitle' => $title,
 		) );
 
 		$revision = $this->newMockBuilder()->newObject( 'Revision', array(
-			'getTitle' => $title
+			'getTitle'   => $title,
+			'getRawText' => 'Foo',
+			'getContent' => $this->newMockContent()
 		) );
 
 		$user = $this->newMockBuilder()->newObject( 'User' );
@@ -577,4 +583,24 @@ class SetupTest extends SemanticMediaWikiTestCase {
 		return $provider;
 	}
 
+	/**
+	 * @return Content|null
+	 */
+	public function newMockContent() {
+
+		$content = null;
+
+		if ( class_exists( 'ContentHandler' ) ) {
+
+			$contentHandler = $this->newMockBuilder()->newObject( 'ContentHandler', array(
+				'getDefaultFormat' => 'Foo'
+			) );
+
+			$content = $this->newMockBuilder()->newObject( 'Content', array(
+				'getContentHandler' => $contentHandler,
+			) );
+		}
+
+		return $content;
+	}
 }

--- a/tests/phpunit/mocks/MediaWikiMockObjectRepository.php
+++ b/tests/phpunit/mocks/MediaWikiMockObjectRepository.php
@@ -389,15 +389,52 @@ class MediaWikiMockObjectRepository extends \PHPUnit_Framework_TestCase implemen
 	 */
 	public function Content() {
 
+		$methods = $this->builder->getInvokedMethods();
+
 		$content = $this->getMockBuilder( 'Content' )
 			->disableOriginalConstructor()
 			->getMock();
 
-		$content->expects( $this->any() )
-			->method( 'getParserOutput' )
-			->will( $this->returnValue( $this->builder->setValue( 'getParserOutput' ) ) );
+		foreach ( $methods as $method ) {
+
+			$content->expects( $this->any() )
+				->method( $method )
+				->will( $this->builder->setCallback( $method ) );
+
+		}
 
 		return $content;
+	}
+
+	/**
+	 * @since 1.9
+	 *
+	 * @return ContentHandler
+	 */
+	public function ContentHandler() {
+
+		$requiredAbstractMethods = array(
+			'serializeContent',
+			'unserializeContent',
+			'makeEmptyContent'
+		);
+
+		$methods = array_unique( array_merge( $requiredAbstractMethods, $this->builder->getInvokedMethods() ) );
+
+		$contentHandler = $this->getMockBuilder( 'ContentHandler' )
+			->disableOriginalConstructor()
+			->setMethods( $methods )
+			->getMock();
+
+		foreach ( $methods as $method ) {
+
+			$contentHandler->expects( $this->any() )
+				->method( $method )
+				->will( $this->builder->setCallback( $method ) );
+
+		}
+
+		return $contentHandler;
 	}
 
 	/**


### PR DESCRIPTION
Avoid content re-parse during NewRevisionFromEditComplete by fetching ParserOutput either from prepareTextForEdit or prepareContentForEdit.

https://gerrit.wikimedia.org/r/#/c/95519/
https://gerrit.wikimedia.org/r/#/c/95530/
