### PR TITLE
(Bug 52642) Add query duration as meta data option

### DIFF
--- a/SemanticMediaWiki.classes.php
+++ b/SemanticMediaWiki.classes.php
@@ -250,12 +250,13 @@ return array(
 	'SMW\DocumentationParserFunction'    => 'includes/parserhooks/DocumentationParserFunction.php',
 	'SMW\ParserFunctionFactory'          => 'includes/parserhooks/ParserFunctionFactory.php',
 
-	// ProfileAnnotator
+	// QueryProfiler
 	'SMW\Query\Profiler\ProfileAnnotator'          => 'includes/query/profiler/ProfileAnnotator.php',
 	'SMW\Query\Profiler\ProfileAnnotatorDecorator' => 'includes/query/profiler/ProfileAnnotatorDecorator.php',
 	'SMW\Query\Profiler\NullProfile'           => 'includes/query/profiler/NullProfile.php',
 	'SMW\Query\Profiler\DescriptionProfile'    => 'includes/query/profiler/DescriptionProfile.php',
 	'SMW\Query\Profiler\FormatProfile'         => 'includes/query/profiler/FormatProfile.php',
+	'SMW\Query\Profiler\DurationProfile'       => 'includes/query/profiler/DurationProfile.php',
 
 	// Query related classes
 	'SMWQueryProcessor'          => 'includes/query/SMW_QueryProcessor.php',

--- a/SemanticMediaWiki.settings.php
+++ b/SemanticMediaWiki.settings.php
@@ -681,3 +681,19 @@ $GLOBALS['smwgFactboxCacheRefreshOnPurge'] = true;
 ##
 $GLOBALS['smwgShowHiddenCategories'] = true;
 ##
+
+###
+# QueryProfiler related setting to enable/disable specific monitorable profile
+# data
+#
+# @note If these settings are changed, please ensure to run update.php
+#
+# - smwgQueryDurationEnabled to record query duration (the time
+# between the query result selection and output its)
+#
+# @since 1.9
+##
+$GLOBALS['smwgQueryProfiler'] = array(
+	'smwgQueryDurationEnabled' => false,
+);
+##

--- a/includes/Settings.php
+++ b/includes/Settings.php
@@ -122,7 +122,8 @@ class Settings extends SimpleDictionary {
 			'smwgPropertyZeroCountDisplay' => $GLOBALS['smwgPropertyZeroCountDisplay'],
 			'smwgShowHiddenCategories' => $GLOBALS['smwgShowHiddenCategories'],
 			'smwgFactboxUseCache' => $GLOBALS['smwgFactboxUseCache'],
-			'smwgFactboxCacheRefreshOnPurge' => $GLOBALS['smwgFactboxCacheRefreshOnPurge']
+			'smwgFactboxCacheRefreshOnPurge' => $GLOBALS['smwgFactboxCacheRefreshOnPurge'],
+			'smwgQueryProfiler' => $GLOBALS['smwgQueryProfiler']
 		);
 
 		if ( self::$instance === null ) {

--- a/includes/dataitems/SMW_DI_Property.php
+++ b/includes/dataitems/SMW_DI_Property.php
@@ -415,6 +415,7 @@ class DIProperty extends SMWDataItem {
 				'_ASKFO' =>  array( '_txt', true ), // "has query format"
 				'_ASKSI' =>  array( '_num', true ), // "has query size"
 				'_ASKDE' =>  array( '_num', true ), // "has query depth"
+				'_ASKDU' =>  array( '_num', true ), // "has query duration"
 			);
 
 		foreach ( $datatypeLabels as $typeid => $label ) {

--- a/includes/dic/SharedDependencyContainer.php
+++ b/includes/dic/SharedDependencyContainer.php
@@ -442,6 +442,7 @@ class SharedDependencyContainer extends BaseDependencyContainer {
 
 			$profiler = new \SMW\Query\Profiler\DescriptionProfile( $profiler, $builder->getArgument( 'QueryDescription' ) );
 			$profiler = new \SMW\Query\Profiler\FormatProfile( $profiler, $builder->getArgument( 'QueryFormat' ) );
+			$profiler = new \SMW\Query\Profiler\DurationProfile( $profiler, $builder->getArgument( 'QueryDuration' ) );
 
 			return $profiler;
 		};

--- a/includes/parserhooks/AskParserFunction.php
+++ b/includes/parserhooks/AskParserFunction.php
@@ -107,6 +107,14 @@ class AskParserFunction {
 	 * @since  1.9
 	 */
 	private function runQueryProcessor( array $rawParams ) {
+
+		// FIXME QueryDuration should be a property of the QueryProcessor or
+		// QueryEngine but since we don't want to open the pandora's box and
+		// increase issues within the current QueryProcessor implementation
+		// we will track the time outside of the actual execution framework
+		$this->queryDuration = 0;
+		$start = microtime( true );
+
 		list( $this->query, $this->params ) = SMWQueryProcessor::getQueryAndParamsFromFunctionParams(
 			$rawParams,
 			SMW_OUTPUT_WIKI,
@@ -120,6 +128,11 @@ class AskParserFunction {
 			SMW_OUTPUT_WIKI,
 			SMWQueryProcessor::INLINE_QUERY
 		);
+
+		if ( $this->context->getSettings()->get( 'smwgQueryDurationEnabled' ) ) {
+			$this->queryDuration = microtime( true ) - $start;
+		}
+
 	}
 
 	/**
@@ -131,6 +144,7 @@ class AskParserFunction {
 			'QueryDescription' => $this->query->getDescription(),
 			'QueryParameters'  => $rawParams,
 			'QueryFormat'      => $this->params['format']->getValue(),
+			'QueryDuration'    => $this->queryDuration,
 			'Title'            => $this->parserData->getTitle(),
 		) );
 

--- a/includes/query/profiler/DurationProfile.php
+++ b/includes/query/profiler/DurationProfile.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace SMW\Query\Profiler;
+
+use SMW\DIProperty;
+use SMWDINumber as DINumber;
+
+/**
+ * Adds duration profiling annotation
+ *
+ * @ingroup SMW
+ *
+ * @licence GNU GPL v2+
+ * @since 1.9
+ *
+ * @author mwjames
+ */
+class DurationProfile extends ProfileAnnotatorDecorator {
+
+	/** @var integer */
+	protected $duration;
+
+	/**
+	 * @since 1.9
+	 *
+	 * @param ProfileAnnotator $profileAnnotator
+	 */
+	public function __construct( ProfileAnnotator $profileAnnotator, $duration ) {
+		parent::__construct( $profileAnnotator );
+		$this->duration = $duration;
+	}
+
+	/**
+	 * @since 1.9
+	 */
+	protected function addPropertyValues() {
+		if ( $this->duration > 0 ) {
+			$this->addGreaterThanZeroQueryDuration( $this->duration );
+		}
+	}
+
+	/**
+	 * @since 1.9
+	 */
+	private function addGreaterThanZeroQueryDuration( $duration ) {
+		$this->getSemanticData()->addPropertyObjectValue(
+			new DIProperty( '_ASKDU' ),
+			new DINumber( $duration )
+		);
+	}
+
+}

--- a/includes/storage/SQLStore/SMW_SQLStore3.php
+++ b/includes/storage/SQLStore/SMW_SQLStore3.php
@@ -155,7 +155,7 @@ class SMWSQLStore3 extends SMWStore {
 		// property declarations
 		'_TYPE', '_UNIT', '_CONV', '_PVAL', '_LIST', '_SERV',
 		// query statistics (very frequently used)
-		'_ASK', '_ASKDE', '_ASKSI', '_ASKFO', '_ASKST',
+		'_ASK', '_ASKDE', '_ASKSI', '_ASKFO', '_ASKST', '_ASKDU',
 		// subproperties, classes, and instances
 		'_SUBP', '_SUBC', '_INST',
 		// redirects

--- a/languages/SMW_Language.php
+++ b/languages/SMW_Language.php
@@ -91,6 +91,7 @@ abstract class SMWLanguage {
 		'Has query format'  => '_ASKFO',
 		'Has query size'    => '_ASKSI',
 		'Has query depth'   => '_ASKDE',
+		'Has query duration' => '_ASKDU',
 	);
 
 	public function __construct() {

--- a/languages/SMW_LanguageEn.php
+++ b/languages/SMW_LanguageEn.php
@@ -77,6 +77,7 @@ class SMWLanguageEn extends SMWLanguage {
 		'_ASKFO'=> 'Query format',
 		'_ASKSI'=> 'Query size',
 		'_ASKDE'=> 'Query depth',
+		'_ASKDU'=> 'Query duration',
 	);
 
 	protected $m_SpecialPropertyAliases = array(

--- a/tests/phpunit/includes/dic/SharedDependencyContainerTest.php
+++ b/tests/phpunit/includes/dic/SharedDependencyContainerTest.php
@@ -208,6 +208,7 @@ class SharedDependencyContainerTest extends SemanticMediaWikiTestCase {
 				'QueryDescription' => $this->newMockBuilder()->newObject( 'QueryDescription' ),
 				'QueryParameters'  => array( 'Foo' ),
 				'QueryFormat'      => 'Foo',
+				'QueryDuration'    => 0,
 				'Title'            => $this->newMockBuilder()->newObject( 'Title' ),
 				)
 			)

--- a/tests/phpunit/includes/parserhooks/AskParserFunctionTest.php
+++ b/tests/phpunit/includes/parserhooks/AskParserFunctionTest.php
@@ -53,13 +53,16 @@ class AskParserFunctionTest extends ParserTestCase {
 		}
 
 		if ( $settings === null ) {
-			$settings = $this->newSettings();
+			$settings = $this->newSettings( array(
+				'smwgQueryDurationEnabled' => false
+			) );
 		}
 
 		$context = new ExtensionContext();
-		$context->getDependencyBuilder()
-			->getContainer()
-			->registerObject( 'MessageFormatter', new MessageFormatter( $title->getPageLanguage() ) );
+		$container = $context->getDependencyBuilder()->getContainer();
+
+		$container->registerObject( 'MessageFormatter', new MessageFormatter( $title->getPageLanguage() ) );
+		$container->registerObject( 'Settings', $settings );
 
 		return new AskParserFunction(
 			$this->newParserData( $title, $parserOutput ),
@@ -291,6 +294,23 @@ class AskParserFunctionTest extends ParserTestCase {
 			),
 			array(
 				'smwgQueryDurationEnabled' => false
+			)
+		);
+
+		// #5 QueryTime enabled
+		$provider[] = array(
+			array(
+				'[[Modification date::+]][[Category:Foo]]',
+				'?Modification date',
+				'?Has title',
+				'format=lula'
+			),
+			array(
+				'propertyCount' => 5,
+				'propertyKey'   => array( '_ASKST', '_ASKSI', '_ASKDE', '_ASKFO', '_ASKDU' ),
+			),
+			array(
+				'smwgQueryDurationEnabled' => true
 			)
 		);
 

--- a/tests/phpunit/includes/parserhooks/ShowParserFunctionTest.php
+++ b/tests/phpunit/includes/parserhooks/ShowParserFunctionTest.php
@@ -47,10 +47,15 @@ class ShowParserFunctionTest extends ParserTestCase {
 			$parserOutput = $this->newParserOutput();
 		}
 
+		$settings = $this->newSettings( array(
+			'smwgQueryDurationEnabled' => false
+		) );
+
 		$context = new ExtensionContext();
-		$context->getDependencyBuilder()
-			->getContainer()
-			->registerObject( 'MessageFormatter', new MessageFormatter( $title->getPageLanguage() ) );
+		$container = $context->getDependencyBuilder()->getContainer();
+
+		$container->registerObject( 'MessageFormatter', new MessageFormatter( $title->getPageLanguage() ) );
+		$container->registerObject( 'Settings', $settings );
 
 		return new ShowParserFunction(
 			$this->newParserData( $title, $parserOutput ),

--- a/tests/phpunit/includes/query/profiler/DurationProfileTest.php
+++ b/tests/phpunit/includes/query/profiler/DurationProfileTest.php
@@ -1,0 +1,88 @@
+<?php
+
+namespace SMW\Test;
+
+use SMW\Query\Profiler\DurationProfile;
+use SMW\Query\Profiler\NullProfile;
+use SMW\HashIdGenerator;
+use SMW\Subobject;
+
+/**
+ * @covers \SMW\Query\Profiler\DurationProfile
+ *
+ * @ingroup Test
+ *
+ * @group SMW
+ * @group SMWExtension
+ *
+ * @licence GNU GPL v2+
+ * @since 1.9
+ *
+ * @author mwjames
+ */
+class DurationProfileTest extends SemanticMediaWikiTestCase {
+
+	/**
+	 * @return string|false
+	 */
+	public function getClass() {
+		return '\SMW\Query\Profiler\DurationProfile';
+	}
+
+	/**
+	 * @since 1.9
+	 *
+	 * @return DurationProfile
+	 */
+	private function newInstance( $duration = 0 ) {
+
+		$profiler = new NullProfile(
+			new Subobject( $this->newTitle() ),
+			new HashIdGenerator( 'Foo' )
+		);
+
+		return new DurationProfile( $profiler, $duration );
+	}
+
+	/**
+	 * @since 1.9
+	 */
+	public function testConstructor() {
+		$this->assertInstanceOf( $this->getClass(), $this->newInstance() );
+	}
+
+	/**
+	 * @dataProvider durationDataProvider
+	 *
+	 * @since 1.9
+	 */
+	public function testCreateProfile( $duration, $expected ) {
+
+		$instance = $this->newInstance( $duration );
+		$instance->addAnnotation();
+
+		$this->assertSemanticData( $instance->getContainer()->getSemanticData(), $expected );
+
+	}
+
+	/**
+	 * @since 1.9
+	 */
+	public function durationDataProvider() {
+
+		$provider = array();
+
+		$provider[] = array( 0, array(
+			'propertyCount' => 0
+		) );
+
+		$provider[] = array( 0.9001, array(
+			'propertyCount' => 1,
+			'propertyKey'   => array( '_ASKDU' ),
+			'propertyValue' => array( 0.9001 )
+		) );
+
+		return $provider;
+	}
+
+}


### PR DESCRIPTION
QueryDuration is designed to be an opt-in meta data (by default this options
is disabled) and enabling it requires to run update.php.

$GLOBALS['smwgQueryProfiler'] = array(
    'smwgQueryDurationEnabled' => true, // enabled
);
