### PR TITLE
QueryResultSerializer check instanceof Title to avoid failure on a non-o...

### DIFF
--- a/includes/serializer/Serializers/QueryResultSerializer.php
+++ b/includes/serializer/Serializers/QueryResultSerializer.php
@@ -9,6 +9,7 @@ use SMWResultArray;
 use SMWQueryResult as QueryResult;
 
 use OutOfBoundsException;
+use Title;
 
 /**
  * Class for serializing SMWDataItem and SMWQueryResult objects to a context
@@ -63,6 +64,8 @@ class QueryResultSerializer implements Serializer {
 	 * @return mixed
 	 */
 	public static function getSerialization( DataItem $dataItem, $printRequest = null ) {
+		$result = array();
+
 		switch ( $dataItem->getDIType() ) {
 			case DataItem::TYPE_WIKIPAGE:
 				$title = $dataItem->getTitle();
@@ -133,6 +136,11 @@ class QueryResultSerializer implements Serializer {
 		 * @var SMWPrintRequest $printRequest
 		 */
 		foreach ( $queryResult->getResults() as $diWikiPage ) {
+
+			if ( !($diWikiPage->getTitle() instanceof Title ) ) {
+				continue;
+			}
+
 			$result = array( 'printouts' => array() );
 
 			foreach ( $queryResult->getPrintRequests() as $printRequest ) {
@@ -156,6 +164,7 @@ class QueryResultSerializer implements Serializer {
 			}
 
 			$results[$diWikiPage->getTitle()->getFullText()] = $result;
+
 		}
 
 		return array( 'printrequests' => $printRequests, 'results' => $results);

--- a/tests/phpunit/includes/serializer/QueryResultSerializerTest.php
+++ b/tests/phpunit/includes/serializer/QueryResultSerializerTest.php
@@ -74,6 +74,29 @@ class QueryResultSerializerTest extends SemanticMediaWikiTestCase {
 	}
 
 	/**
+	 * @since  1.9
+	 */
+	public function testQueryResultSerializerOnMockOnDIWikiPageNonTitle() {
+
+		$dataItem = $this->newMockBuilder()->newObject( 'DataItem', array(
+			'getDIType' => DataItem::TYPE_WIKIPAGE,
+			'getTitle'  => null
+		) );
+
+		$queryResult = $this->newMockBuilder()->newObject( 'QueryResult', array(
+			'getPrintRequests'  => array(),
+			'getResults'        => array( $dataItem ),
+		) );
+
+		$results = $this->newSerializerInstance()->serialize( $queryResult );
+
+		$this->assertInternalType( 'array' , $results );
+		$this->assertEmpty( $results['printrequests'] );
+		$this->assertEmpty( $results['results'] );
+
+	}
+
+	/**
 	 * @return array
 	 */
 	public function numberDataProvider() {

--- a/tests/phpunit/mocks/CoreMockObjectRepository.php
+++ b/tests/phpunit/mocks/CoreMockObjectRepository.php
@@ -541,22 +541,28 @@ class CoreMockObjectRepository extends \PHPUnit_Framework_TestCase implements Mo
 	 */
 	public function DataItem() {
 
+		$requiredMethods = array(
+			'getNumber',
+			'getDIType',
+			'getSortKey',
+			'equals',
+			'getSerialization',
+		);
+
+		$methods = array_unique( array_merge( $requiredMethods, $this->builder->getInvokedMethods() ) );
+
 		$dataItem = $this->getMockBuilder( 'SMWDataItem' )
 			->disableOriginalConstructor()
-			->setMethods( array( 'getNumber', 'getDIType', 'getSortKey', 'equals', 'getSerialization' ) )
+			->setMethods( $methods )
 			->getMock();
 
-		$dataItem->expects( $this->any() )
-			->method( 'getDIType' )
-			->will( $this->returnValue( $this->builder->setValue( 'getDIType' ) ) );
+		foreach ( $methods as $method ) {
 
-		$dataItem->expects( $this->any() )
-			->method( 'getSortKey' )
-			->will( $this->returnValue( $this->builder->setValue( 'getSortKey' ) ) );
+			$dataItem->expects( $this->any() )
+				->method( $method )
+				->will( $this->builder->setCallback( $method ) );
 
-		$dataItem->expects( $this->any() )
-			->method( 'getNumber' )
-			->will( $this->returnValue( $this->builder->setValue( 'getNumber' ) ) );
+		}
 
 		return $dataItem;
 	}


### PR DESCRIPTION
...bject

Avoid failure Fatal error: Call to a member function getFullText() on a non-object
