### PR TITLE
Use --prefer-source because of GitHub quota

### DIFF
--- a/build/travis/before_script.sh
+++ b/build/travis/before_script.sh
@@ -36,7 +36,7 @@ function runSMWInstaller {
 		cd extensions
 		cp -r $originalDirectory SemanticMediaWiki
 		cd SemanticMediaWiki
-		composer install
+		composer install --prefer-source
 		cd ../..
 	fi
 }


### PR DESCRIPTION
[1] showed Composer\Downloader\TransportException during Travis initialization
which according to [2] is because of a GitHub quota

[1] https://github.com/SemanticMediaWiki/SemanticMediaWiki/pull/47

[2] https://github.com/travis-ci/travis-core/issues/186
