### PR TITLE
Avoid issues prior Composer MW 1.22 installation

### DIFF
--- a/SemanticMediaWiki.php
+++ b/SemanticMediaWiki.php
@@ -79,6 +79,9 @@ define( 'SEMANTIC_EXTENSION_TYPE', true );
 // Load global constants
 require_once( __DIR__ . '/includes/Defines.php' );
 
+// Temporary measure to ease Composer/MW 1.22 migration
+require_once __DIR__ . '/includes/NamespaceManager.php';
+
 // Load global functions
 require_once( __DIR__ . '/includes/GlobalFunctions.php' );
 


### PR DESCRIPTION
If a user runs Composer from a local SMW directory, the Composer autoload prior MW 1.22
is run at later point and to ensure LocalSettings remains untouched we register
'SMW\NamespaceManager' to enable enableSemantics() to work its magic.

Class 'SMW\NamespaceManager' not found in ...\includes\GlobalFunctions.php on line 287

Enables to run composer install/update from the SMW root directory for MW 1.19
without the need to change LocalSettings or to install an extra extension.
