### PR TITLE
(Bug 58991) Enable listed SpecialPages for InternalParseBeforeLinks hook (incl. SMW\ContentProcessor)

### DIFF
--- a/SemanticMediaWiki.settings.php
+++ b/SemanticMediaWiki.settings.php
@@ -681,3 +681,11 @@ $GLOBALS['smwgQueryProfiler'] = array(
 	'smwgQueryDurationEnabled' => false,
 );
 ##
+
+###
+# Enables SMW specific annotation and content processing for listed SpecialPages
+#
+# @since 1.9
+##
+$GLOBALS['smwgEnabledSpecialPage'] = array( 'Ask' );
+##

--- a/includes/Settings.php
+++ b/includes/Settings.php
@@ -123,7 +123,8 @@ class Settings extends SimpleDictionary {
 			'smwgShowHiddenCategories' => $GLOBALS['smwgShowHiddenCategories'],
 			'smwgFactboxUseCache' => $GLOBALS['smwgFactboxUseCache'],
 			'smwgFactboxCacheRefreshOnPurge' => $GLOBALS['smwgFactboxCacheRefreshOnPurge'],
-			'smwgQueryProfiler' => $GLOBALS['smwgQueryProfiler']
+			'smwgQueryProfiler' => $GLOBALS['smwgQueryProfiler'],
+			'smwgEnabledSpecialPage' => $GLOBALS['smwgEnabledSpecialPage']
 		);
 
 		if ( self::$instance === null ) {

--- a/tests/phpunit/includes/hooks/InternalParseBeforeLinksTest.php
+++ b/tests/phpunit/includes/hooks/InternalParseBeforeLinksTest.php
@@ -120,7 +120,19 @@ class InternalParseBeforeLinksTest extends ParserTestCase {
 
 		// #1 Title is a special page
 		$title = $this->newMockBuilder()->newObject( 'Title', array(
-			'isSpecialPage'   => true,
+			'isSpecialPage' => true,
+		) );
+
+		// #2 Title is a special page
+		$title = $this->newMockBuilder()->newObject( 'Title', array(
+			'isSpecialPage' => true,
+			'isSpecial'     => true,
+		) );
+
+		// #3 Title is a special page
+		$title = $this->newMockBuilder()->newObject( 'Title', array(
+			'isSpecialPage' => true,
+			'isSpecial'     => false,
 		) );
 
 		$provider[] = array( $title );
@@ -155,6 +167,50 @@ class InternalParseBeforeLinksTest extends ParserTestCase {
 					'propertyCount' => 3,
 					'propertyLabel' => array( 'Foo', 'Bar', 'FooBar' ),
 					'propertyValue' => array( 'Dictumst', 'Tincidunt semper', '9001' )
+				)
+		);
+
+		// #1 NS_SPECIAL, processed but no annotations
+		$provider[] = array(
+			array(
+				'title'    => $this->newTitle( NS_SPECIAL, 'Ask' ),
+				'settings' => array(
+					'smwgNamespacesWithSemanticLinks' => array( NS_MAIN => true ),
+					'smwgLinksInValues' => false,
+					'smwgInlineErrors'  => true,
+					'smwgEnabledSpecialPage' => array( 'Ask', 'Foo' )
+				),
+				'text'  => 'Lorem ipsum dolor sit &$% [[FooBar::dictumst|寒い]]' .
+					' [[Bar::tincidunt semper]] facilisi {{volutpat}} Ut quis' .
+					' [[foo::9001]] et Donec.',
+				),
+				array(
+					'resultText' => 'Lorem ipsum dolor sit &$% [[:Dictumst|寒い]]' .
+						' [[:Tincidunt semper|tincidunt semper]] facilisi {{volutpat}} Ut quis' .
+						' [[:9001|9001]] et Donec.',
+					'propertyCount' => 0
+				)
+		);
+
+		// #2 NS_SPECIAL, not processed
+		$provider[] = array(
+			array(
+				'title'    => $this->newTitle( NS_SPECIAL, 'Foo' ),
+				'settings' => array(
+					'smwgNamespacesWithSemanticLinks' => array( NS_MAIN => true ),
+					'smwgLinksInValues' => false,
+					'smwgInlineErrors'  => true,
+					'smwgEnabledSpecialPage' => array( 'Ask', 'Foo' )
+				),
+				'text'  => 'Lorem ipsum dolor sit &$% [[FooBar::dictumst|寒い]]' .
+					' [[Bar::tincidunt semper]] facilisi {{volutpat}} Ut quis' .
+					' [[foo::9001]] et Donec.',
+				),
+				array(
+					'resultText' => 'Lorem ipsum dolor sit &$% [[FooBar::dictumst|寒い]]' .
+						' [[Bar::tincidunt semper]] facilisi {{volutpat}} Ut quis' .
+						' [[foo::9001]] et Donec.',
+					'propertyCount' => 0
 				)
 		);
 

--- a/tests/phpunit/mocks/MediaWikiMockObjectRepository.php
+++ b/tests/phpunit/mocks/MediaWikiMockObjectRepository.php
@@ -195,6 +195,10 @@ class MediaWikiMockObjectRepository extends \PHPUnit_Framework_TestCase implemen
 			->will( $this->returnValue( $this->builder->setValue( 'isSpecialPage', false ) ) );
 
 		$title->expects( $this->any() )
+			->method( 'isSpecial' )
+			->will( $this->returnValue( $this->builder->setValue( 'isSpecial', false ) ) );
+
+		$title->expects( $this->any() )
 			->method( 'getContentModel' )
 			->will( $this->returnValue( $this->builder->setValue( 'getContentModel', $contentModel ) ) );
 


### PR DESCRIPTION
https://bugzilla.wikimedia.org/show_bug.cgi?id=58991

Adds $smwgEnabledSpecialPage and can be used to pages like RunQuery etc.
### Default

$GLOBALS['smwgEnabledSpecialPage'] = array( 'Ask' );
### SMW + SF related settings

$GLOBALS['smwgEnabledSpecialPage'] = array( 'Ask', 'RunQuery' );
