### PR TITLE
Fix Use of SpecialPage::getTitle was deprecated in MediaWiki 1.23

### DIFF
--- a/includes/specials/SMW_SpecialAsk.php
+++ b/includes/specials/SMW_SpecialAsk.php
@@ -334,10 +334,13 @@ class SMWAskPage extends SMWQuerySpecialPage {
 
 		$result = '';
 
+		// Deprecated: Use of SpecialPage::getTitle was deprecated in MediaWiki 1.23
+		$title = method_exists( $this, 'getPageTitle') ? $this->getPageTitle() : $this->getTitle();
+
 		if ( $this->m_editquery ) {
 			$result .= Html::openElement( 'form',
 				array( 'action' => $wgScript, 'name' => 'ask', 'method' => 'get' ) );
-			$result .= Html::hidden( 'title', $this->getTitle()->getPrefixedDBKey() );
+			$result .= Html::hidden( 'title', $title->getPrefixedDBKey() );
 
 			// Table for main query and printouts.
 			$result .= '<table style="width: 100%;"><tr><th>' . wfMessage( 'smw_ask_queryhead' )->text() . "</th>\n<th>" . wfMessage( 'smw_ask_printhead' )->text() . "<br />\n" .

--- a/includes/specials/SMW_SpecialPageProperty.php
+++ b/includes/specials/SMW_SpecialPageProperty.php
@@ -142,8 +142,10 @@ class SMWPageProperty extends SpecialPage {
 			$html .= $navigation;
 		}
 
+		// Deprecated: Use of SpecialPage::getTitle was deprecated in MediaWiki 1.23
+		$spectitle = method_exists( $this, 'getPageTitle') ? $this->getPageTitle() : $this->getTitle();
+
 		// Display query form
-		$spectitle = $this->getTitle();
 		$html .= '<p>&#160;</p>';
 		$html .= '<form name="pageproperty" action="' . htmlspecialchars( $spectitle->getLocalURL() ) . '" method="get">' . "\n" .
 		         '<input type="hidden" name="title" value="' . $spectitle->getPrefixedText() . '"/>' ;

--- a/includes/specials/SpecialConcepts.php
+++ b/includes/specials/SpecialConcepts.php
@@ -68,6 +68,9 @@ class SpecialConcepts extends SpecialPage {
 		$pageLister   = new SMWPageLister( $diWikiPages, null, $limit, $from, $until );
 		$key = $resultNumber == 0 ? 'smw-sp-concept-empty' : 'smw-sp-concept-count';
 
+		// Deprecated: Use of SpecialPage::getTitle was deprecated in MediaWiki 1.23
+		$title = method_exists( $this, 'getPageTitle') ? $this->getPageTitle() : $this->getTitle();
+
 		return Html::rawElement(
 			'span',
 			array( 'class' => 'smw-sp-concept-docu' ),
@@ -86,7 +89,7 @@ class SpecialConcepts extends SpecialPage {
 					array( 'class' => $key ),
 					$this->msg( $key, $resultNumber )->parse()
 				) .	' ' .
-				$pageLister->getNavigationLinks( $this->getTitle() ) .
+				$pageLister->getNavigationLinks( $title ) .
 				$pageLister->formatList()
 			);
 	}

--- a/tests/phpunit/SpecialPageTestCase.php
+++ b/tests/phpunit/SpecialPageTestCase.php
@@ -55,7 +55,10 @@ abstract class SpecialPageTestCase extends SemanticMediaWikiTestCase {
 		$page = $this->getInstance();
 		$page->setContext( $context );
 
-		$out->setTitle( $page->getTitle() );
+		// Deprecated: Use of SpecialPage::getTitle was deprecated in MediaWiki 1.23
+		$title = method_exists( $page, 'getPageTitle') ? $page->getPageTitle() : $page->getTitle();
+
+		$out->setTitle( $title );
 
 		ob_start();
 		$page->execute( $sub );

--- a/tests/phpunit/includes/specials/SpecialsTest.php
+++ b/tests/phpunit/includes/specials/SpecialsTest.php
@@ -139,7 +139,11 @@ class SpecialsTest extends SemanticMediaWikiTestCase {
 			if ( array_key_exists( $special, $GLOBALS['wgSpecialPages'] ) ) {
 
 				$specialPage = SpecialPageFactory::getPage( $special );
-				$context = RequestContext::newExtraneousContext( $specialPage->getTitle() );
+
+				// Deprecated: Use of SpecialPage::getTitle was deprecated in MediaWiki 1.23
+				$title = method_exists( $specialPage, 'getPageTitle') ? $specialPage->getPageTitle() : $specialPage->getTitle();
+
+				$context = RequestContext::newExtraneousContext( $title );
 				$context->setRequest( $request );
 
 				$specialPage->setContext( clone $context );


### PR DESCRIPTION
https://s3.amazonaws.com/archive.travis-ci.org/jobs/16240057/log.txt
