### PR TITLE
Fix double prefixing issue in SMWSQLStore3Readers::getProperties

### DIFF
--- a/includes/storage/SMW_Store.php
+++ b/includes/storage/SMW_Store.php
@@ -88,10 +88,12 @@ abstract class Store {
 	 * Get an array of all properties for which the given subject has some
 	 * value. The result is an array of SMWDIProperty objects.
 	 *
-	 * @param $subject SMWDIWikiPage denoting the subject
-	 * @param $requestoptions SMWRequestOptions optionally defining further options
+	 * @param SMWDIWikiPage $subject denoting the subject
+	 * @param SMWRequestOptions|null $requestOptions optionally defining further options
+	 *
+	 * @return SMWDataItem
 	 */
-	public abstract function getProperties( SMWDIWikiPage $subject, $requestoptions = null );
+	public abstract function getProperties( SMWDIWikiPage $subject, $requestOptions = null );
 
 	/**
 	 * Get an array of all properties for which there is some subject that

--- a/includes/storage/SQLStore/SMW_SQLStore3.php
+++ b/includes/storage/SQLStore/SMW_SQLStore3.php
@@ -7,6 +7,7 @@ use SMW\SQLStore\PropertiesCollector;
 use SMW\SQLStore\StatisticsCollector;
 use SMW\DataTypeRegistry;
 use SMW\Settings;
+use SMW\SQLStore\TableDefinition;
 
 /**
  * SQL-based implementation of SMW's storage abstraction layer.
@@ -570,7 +571,7 @@ class SMWSQLStore3 extends SMWStore {
 	 * @since 1.8
 	 * @param array $data array of SMWDataItem objects
 	 * @param SMWRequestOptions|null $requestoptions
-	 * @return array of SMWDataItem objects
+	 * @return SMWDataItem[]
 	 */
 	public function applyRequestOptions( array $data, SMWRequestOptions $requestoptions = null ) {
 		wfProfileIn( "SMWSQLStore3::applyRequestOptions (SMW)" );
@@ -794,7 +795,7 @@ class SMWSQLStore3 extends SMWStore {
 	 * the table that they refer to.
 	 *
 	 * @since 1.8
-	 * @return SMWSQLStore3Table[]
+	 * @return TableDefinition[]
 	 */
 	public static function getPropertyTables() {
 


### PR DESCRIPTION
This method really should be its own class. Also not sure why this
just happened for sqlite. Perhaps the affected branch of the if is
just generally broken and another bug that is sqlite specific caused
it to be executed for sqlite?

This is supposed to fix #71 
