### PR TITLE
JSON_PRETTY_PRINT introduced only with PHP 5.4

### DIFF
--- a/includes/Settings.php
+++ b/includes/Settings.php
@@ -128,6 +128,10 @@ class Settings extends SimpleDictionary {
 			'smwgOnDeleteAction' => $GLOBALS['smwgOnDeleteAction']
 		);
 
+		$settings = $settings + array(
+			'smwgCanonicalNames' => NamespaceManager::getCanonicalNames()
+		);
+
 		if ( self::$instance === null ) {
 			self::$instance = self::newFromArray( $settings ) ;
 		}

--- a/includes/specials/SMW_SpecialSMWAdmin.php
+++ b/includes/specials/SMW_SpecialSMWAdmin.php
@@ -26,7 +26,7 @@ class SMWAdmin extends SpecialPage {
 
 	public function execute( $par ) {
 
-		if ( !$this->userCanExecute( $GLOBALS['wgUser'] ) ) {
+		if ( !$this->userCanExecute( $this->getUser() ) ) {
 			// If the user is not authorized, show an error.
 			$this->displayRestrictionError();
 			return;
@@ -53,7 +53,7 @@ class SMWAdmin extends SpecialPage {
 		}
 
 		/**** Execute actions if any ****/
-		switch ( $GLOBALS['wgRequest']->getText( 'action' ) ) {
+		switch ( $this->getRequest()->getText( 'action' ) ) {
 			case 'listsettings':
 				return $this->actionListSettings();
 			case 'updatetables':
@@ -181,8 +181,8 @@ class SMWAdmin extends SpecialPage {
 	}
 
 	protected function actionListSettings() {
-		$this->printRawOutput( function() {
-			print '<pre>' . json_encode( Settings::newFromGlobals()->toArray(), JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE ) . '</pre>';
+		$this->printRawOutput( function( $instance ) {
+			print '<pre>' . $instance->encodeJson( Settings::newFromGlobals()->toArray() ) . '</pre>';
 		} );
 	}
 
@@ -191,7 +191,7 @@ class SMWAdmin extends SpecialPage {
 		ob_start();
 
 		print "<!DOCTYPE html PUBLIC \"-//W3C//DTD XHTML 1.0 Transitional//EN\"  \"http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd\">\n<html xmlns=\"http://www.w3.org/1999/xhtml\" xml:lang=\"en\" lang=\"en\" dir=\"ltr\">\n<head><meta http-equiv=\"Content-Type\" content=\"text/html; charset=utf-8\" /><title>Semantic MediaWiki</title></head><body><p><pre>";
-		header( "Content-type: text/html; charset=UTF-8" );
+		// header( "Content-type: text/html; charset=UTF-8" );
 		is_callable( $text ) ? $text( $this ) : $text;
 		print '</pre></p>';
 		print '<b> ' . wfMessage( 'smw_smwadmin_return', '<a href="' . htmlspecialchars( SpecialPage::getTitleFor( 'SMWAdmin' )->getFullURL() ) . '">Special:SMWAdmin</a>' )->text() . "</b>\n";
@@ -199,6 +199,19 @@ class SMWAdmin extends SpecialPage {
 
 		ob_flush();
 		flush();
+	}
+
+	/**
+	 * @note JSON_PRETTY_PRINT, JSON_UNESCAPED_SLASHES, and
+	 * JSON_UNESCAPED_UNICOD were only added with 5.4
+	 */
+	public function encodeJson( array $input ) {
+
+		if ( defined( 'JSON_PRETTY_PRINT' ) ) {
+			return json_encode( $input, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE );
+		}
+
+		return FormatJson::encode( $input, true );
 	}
 
 }

--- a/tests/phpunit/SpecialPageTestCase.php
+++ b/tests/phpunit/SpecialPageTestCase.php
@@ -42,7 +42,7 @@ abstract class SpecialPageTestCase extends SemanticMediaWikiTestCase {
 	 * @param string      $sub The subpage parameter to call the page with
 	 * @param \WebRequest $request Web request that may contain URL parameters, etc
 	 */
-	protected function execute( $sub = '', WebRequest $request = null ) {
+	protected function execute( $sub = '', WebRequest $request = null, $user = null ) {
 
 		$request  = $request === null ? new FauxRequest() : $request;
 		$response = $request->response();
@@ -51,6 +51,10 @@ abstract class SpecialPageTestCase extends SemanticMediaWikiTestCase {
 		$out = new OutputPage( $context );
 		$context->setOutput( $out );
 		$context->setLanguage( $this->getLanguage() );
+
+		if ( $user !== null ) {
+			$context->setUser( $user );
+		}
 
 		$page = $this->getInstance();
 		$page->setContext( $context );

--- a/tests/phpunit/includes/specials/SpecialSMWAdminTest.php
+++ b/tests/phpunit/includes/specials/SpecialSMWAdminTest.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace SMW\Test;
+
+use SMWAdmin;
+use FauxRequest;
+
+/**
+ * @covers \SMWAdmin
+ *
+ * @ingroup Test
+ *
+ * @group SMW
+ * @group SMWExtension
+ * @group medium
+ *
+ * @licence GNU GPL v2+
+ * @since 1.9.0.2
+ *
+ * @author mwjames
+ */
+class SpecialSMWAdminTest extends SpecialPageTestCase {
+
+	/**
+	 * @return string|false
+	 */
+	public function getClass() {
+		return '\SMWAdmin';
+	}
+
+	/**
+	 * @return SMWAdmin
+	 */
+	protected function getInstance() {
+		return new SMWAdmin();
+	}
+
+	/**
+	 * @since 1.9.0.2
+	 */
+	public function testCanConstruct() {
+		$this->assertInstanceOf( $this->getClass(), $this->getInstance() );
+	}
+
+	/**
+	 * @since 1.9.0.2
+	 */
+	public function testExecuteWithMissingPermissionThrowsException() {
+
+		$this->setExpectedException( 'PermissionsError' );
+
+		$this->getInstance();
+		$this->execute( '', null, new \User );
+
+	}
+
+	/**
+	 * @since 1.9.0.2
+	 */
+	public function testExecute() {
+
+		$this->getInstance();
+		$this->execute( '', null, new MockSuperUser );
+
+		$this->assertInternalType( 'string', $this->getText() );
+	}
+
+	/**
+	 * @since 1.9.0.2
+	 */
+	public function testExecuteOnActionListSettings() {
+
+		$this->getInstance();
+
+		ob_start();
+		$this->execute( '', new FauxRequest( array( 'action' => 'listsettings' ) ), new MockSuperUser );
+		ob_clean();
+
+		$this->assertInternalType( 'string', $this->getText() );
+	}
+
+}


### PR DESCRIPTION
Apparently JSON_PRETTY_PRINT option was only introduced with PHP 5.4 therefore we use FormatJson::encode() which does pretty print in PHP 5.3
