### PR TITLE
Improve DeleteSubjectJob when run as DeferredJob

### DIFF
--- a/SemanticMediaWiki.php
+++ b/SemanticMediaWiki.php
@@ -71,6 +71,7 @@ class_alias( 'SMW\ResultPrinter', 'SMWResultPrinter' );
 class_alias( 'SMW\SQLStore\TableDefinition', 'SMWSQLStore3Table' );
 class_alias( 'SMW\AggregatablePrinter', 'SMWAggregatablePrinter' );
 class_alias( 'SMW\ListResultPrinter', 'SMWListResultPrinter' );
+class_alias( 'SMW\DIConcept', 'SMWDIConcept' );
 
 // A flag used to indicate SMW defines a semantic extension type for extension credits.
 // @deprecated, removal in SMW 1.11

--- a/SemanticMediaWiki.settings.php
+++ b/SemanticMediaWiki.settings.php
@@ -693,22 +693,26 @@ $GLOBALS['smwgEnabledSpecialPage'] = array( 'Ask' );
 ###
 # Page / subject deletion (action=delete)
 #
-# Configuration to improve the update process for when a page / property and its
-# value assignments are deleted. Due to performance implications it is advisable
-# that in case of 'smwgDeleteSubjectWithAssociatesRefresh' => TRUE the deletion
-# process is being handled as deferred background job
-# 'smwgDeleteSubjectAsDeferredJob' => TRUE
+# In case of 'smwgDeleteSubjectWithAssociatesRefresh' => TRUE the deletion
+# process will initiate a refresh/update process of associative entities.
 #
-# In case the deletion is executed as deferred job it is further suggested that the
-# JobQueue is being run repeatedly within a narrow time frame to avoid an increased
-# backlog.
+# It is suggested that the dispatch process of those entities are being carried
+# out as deferred job 'smwgDeleteSubjectAsDeferredJob' => TRUE and the to minimize
+# any performance degradation that can occur when a large pool of associates is
+# assigned to the deleted subject.
 #
-# Legacy behaviour where a subject is directly deleted when action=delete is executed
+# When 'smwgDeleteSubjectAsDeferredJob' => TRUE, MW 1.19/1.20 will return a
+# 'Array to string conversion in JobQueue' because of an outdated JobQueue class
+# it is therefore advised to update to a newer MW version or not to use this
+# feature.
+#
+# The subject is always removed directly (without delay) and if selected the update
+# of associative entities will always be carried out through a background job (as long as
+# smwgEnableUpdateJobs is set true).
+#
+# Legacy behaviour
 # -'smwgDeleteSubjectAsDeferredJob' => false
 # -'smwgDeleteSubjectWithAssociatesRefresh' => false
-#
-# If 'smwgEnableUpdateJobs' is disabled then the deletion process will always run
-# directly even though 'smwgDeleteSubjectAsDeferredJob' is enabled.
 #
 # @since 1.9.0.1
 ##

--- a/includes/Setup.php
+++ b/includes/Setup.php
@@ -400,8 +400,8 @@ final class Setup implements ContextAware {
 		$this->globals['wgHooks']['ArticleDelete'][] = function ( &$wikiPage, &$user, &$reason, &$error ) use ( $settings, $context ) {
 
 			$deleteSubject = new DeleteSubjectJob( $wikiPage->getTitle(), array(
-				'asDeferredJob' => $settings->get( 'smwgDeleteSubjectAsDeferredJob' ),
-				'withRefresh'   => $settings->get( 'smwgDeleteSubjectWithAssociatesRefresh' )
+				'asDeferredJob'  => $settings->get( 'smwgDeleteSubjectAsDeferredJob' ),
+				'withAssociates' => $settings->get( 'smwgDeleteSubjectWithAssociatesRefresh' )
 			) );
 
 			$deleteSubject->invokeContext( $context );

--- a/includes/dataitems/DIConcept.php
+++ b/includes/dataitems/DIConcept.php
@@ -197,11 +197,5 @@ class DIConcept extends \SMWDataItem {
 		}
 		return $di->getSerialization() === $this->getSerialization();
 	}
-}
 
-/**
- * SMWDIConcept
- *
- * @deprecated since SMW 1.9
- */
-class_alias( 'SMW\DIConcept', 'SMWDIConcept' );
+}

--- a/includes/storage/SQLStore/SMW_SQLStore3_Readers.php
+++ b/includes/storage/SQLStore/SMW_SQLStore3_Readers.php
@@ -261,7 +261,8 @@ class SMWSQLStore3Readers {
 		$diHandler = $this->store->getDataItemHandlerForDIType( $proptable->getDiType() );
 
 		// ***  First build $from, $select, and $where for the DB query  ***//
-		$from   = $db->tableName( $proptable->getName() ); // always use actual table
+		$from   = $proptable->getName(); // always use actual table
+
 		$select = '';
 		$where  = '';
 

--- a/includes/storage/SQLStore/SMW_SQLStore3_Writers.php
+++ b/includes/storage/SQLStore/SMW_SQLStore3_Writers.php
@@ -60,8 +60,10 @@ class SMWSQLStore3Writers {
 			$db->delete( SMWSQLStore3::CONCEPT_CACHE_TABLE, array( 'o_id' => $id ), 'SMW::deleteSubject::Conccache' );
 		}
 
-		///FIXME: if a property page is deleted, more pages may need to be updated by jobs!
-		///TODO: who is responsible for these updates? Some update jobs are currently created in SMW_Hooks, some internally in the store
+		// 1.9.0.1
+		// The update of possible associative entities is handled by DeleteSubjectJob which is invoked during
+		// the ArticleDelete hook
+
 		///TODO: Possibly delete ID here (at least for non-properties/categories, if not used in any place in rels2)
 
 		wfRunHooks( 'SMWSQLStore3::deleteSubjectAfter', array( $this->store, $subject ) );

--- a/tests/phpunit/MwIntegrationTestCase.php
+++ b/tests/phpunit/MwIntegrationTestCase.php
@@ -99,9 +99,9 @@ abstract class MwIntegrationTestCase extends \MediaWikiTestCase {
 		return $store;
 	}
 
-	protected function createPage( Title $title ) {
+	protected function createPage( Title $title, $editContent = '' ) {
 		$pageCreator = new PageCreator();
-		$pageCreator->createPage( $title );
+		$pageCreator->createPage( $title, $editContent );
 	}
 
 	protected function deletePage( Title $title ) {
@@ -113,10 +113,10 @@ abstract class MwIntegrationTestCase extends \MediaWikiTestCase {
 
 class PageCreator {
 
-	public function createPage( Title $title ) {
+	public function createPage( Title $title, $editContent = '' ) {
 		$page = new \WikiPage( $title );
 
-		$pageContent = 'Content of ' . $title->getFullText();
+		$pageContent = 'Content of ' . $title->getFullText() . ' ' . $editContent;
 		$editMessage = 'SMW system test: create page';
 
 		if ( class_exists( 'WikitextContent' ) ) {

--- a/tests/phpunit/includes/jobs/DeleteSubjectJobTest.php
+++ b/tests/phpunit/includes/jobs/DeleteSubjectJobTest.php
@@ -4,6 +4,8 @@ namespace SMW\Test;
 
 use SMW\ExtensionContext;
 use SMW\DeleteSubjectJob;
+use SMW\DIWikiPage;
+use SMW\SemanticData;
 
 use Title;
 
@@ -54,8 +56,8 @@ class DeleteSubjectJobTest extends SemanticMediaWikiTestCase {
 		$settings  = $this->newSettings( array_merge( $defaultSettings, $settings ) );
 
 		$mockStore = $this->newMockBuilder()->newObject( 'Store', array(
-			'deleteSubject' => array( $this, 'mockStoreDeleteSubjectCallback' ),
-			'getProperties' => array()
+			'deleteSubject'   => array( $this, 'mockStoreDeleteSubjectCallback' ),
+			'getSemanticData' => new SemanticData( DIWikiPage::newFromTitle( $title ) )
 		) );
 
 		$context   = new ExtensionContext();
@@ -65,8 +67,8 @@ class DeleteSubjectJobTest extends SemanticMediaWikiTestCase {
 		$container->registerObject( 'Settings', $settings );
 
 		$parameters = array(
-			'asDeferredJob' => $settings->get( 'smwgDeleteSubjectAsDeferredJob' ),
-			'withRefresh'   => $settings->get( 'smwgDeleteSubjectWithAssociatesRefresh' )
+			'asDeferredJob'  => $settings->get( 'smwgDeleteSubjectAsDeferredJob' ),
+			'withAssociates' => $settings->get( 'smwgDeleteSubjectWithAssociatesRefresh' )
 		);
 
 		$instance = new DeleteSubjectJob( $title, $parameters );
@@ -145,7 +147,7 @@ class DeleteSubjectJobTest extends SemanticMediaWikiTestCase {
 			),
 			array(
 				'jobCount' => 1,
-				'deleteSubjectWasCalled' => false
+				'deleteSubjectWasCalled' => true
 			)
 		);
 
@@ -211,8 +213,9 @@ class DeleteSubjectJobTest extends SemanticMediaWikiTestCase {
 				"Asserts that the job instance is of type {$this->getClass()}"
 			);
 
+			$this->assertTrue( $job->hasParameter( 'withAssociates' ) );
 			$this->assertTrue( $job->hasParameter( 'asDeferredJob' ) );
-			$this->assertTrue( $job->hasParameter( 'withRefresh' ) );
+			$this->assertTrue( $job->hasParameter( 'semanticData' ) );
 
 		}
 

--- a/tests/phpunit/mocks/CoreMockObjectRepository.php
+++ b/tests/phpunit/mocks/CoreMockObjectRepository.php
@@ -468,6 +468,10 @@ class CoreMockObjectRepository extends \PHPUnit_Framework_TestCase implements Mo
 			->will( $this->builder->setCallback( 'getProperties', array() ) );
 
 		$store->expects( $this->any() )
+			->method( 'getInProperties' )
+			->will( $this->builder->setCallback( 'getInProperties', array() ) );
+
+		$store->expects( $this->any() )
 			->method( 'getStatisticsTable' )
 			->will( $this->returnValue( 'smw_statistics_table_test' ) );
 


### PR DESCRIPTION
The deletion job was forced to neglect historic data (Store has no knowledge of any revision data), where it solely depended on the Store's data fetch at the time of execution which influenced as to when to schedule the update and removal.

SMW 1.9 deployes a SemanticData serializer/deserializer which enables to serialize SemanticData at any time and can be used before the subject and its data are removed.

Running [1] the serializer adds a diminutive overhead during the deletion process which enables to delete a subject immediately without delay but enables to schedule the dispatch and refresh associative entities as deferred job [2].

[1] 'smwgDeleteSubjectWithAssociatesRefresh' => true
[2] 'smwgDeleteSubjectAsDeferredJob' => true
