### PR TITLE
Strict standards and ns usage

### DIFF
--- a/includes/storage/SQLStore/SMW_Sql3StubSemanticData.php
+++ b/includes/storage/SQLStore/SMW_Sql3StubSemanticData.php
@@ -1,6 +1,7 @@
 <?php
 
 use SMW\DataTypeRegistry;
+use SMW\DIProperty;
 
 /**
  * This class provides a subclass of SMWSemanticData that can store
@@ -101,11 +102,11 @@ class SMWSql3StubSemanticData extends SMWSemanticData {
 	 *
 	 * @since 1.8
 	 *
-	 * @param $property SMWDIProperty
+	 * @param DIProperty $property
 	 *
 	 * @return array of SMWDataItem
 	 */
-	public function getPropertyValues( SMWDIProperty $property ) {
+	public function getPropertyValues( DIProperty $property ) {
 		if ( $property->isInverse() ) { // we never have any data for inverses
 			return array();
 		}
@@ -153,7 +154,7 @@ class SMWSql3StubSemanticData extends SMWSemanticData {
 	 *
 	 * @since 1.8
 	 */
-	public function removePropertyObjectValue( SMWDIProperty $property, SMWDataItem $dataItem ) {
+	public function removePropertyObjectValue( DIProperty $property, SMWDataItem $dataItem ) {
 		$this->unstubProperties();
 		$this->getPropertyValues( $property );
 		parent::removePropertyObjectValue($property, $dataItem);
@@ -243,7 +244,7 @@ class SMWSql3StubSemanticData extends SMWSemanticData {
 	protected function unstubProperty( $propertyKey, $diProperty = null ) {
 		if ( !array_key_exists( $propertyKey, $this->mProperties ) ) {
 			if ( is_null( $diProperty ) ) {
-				$diProperty = new SMWDIProperty( $propertyKey, false );
+				$diProperty = new DIProperty( $propertyKey, false );
 			}
 
 			$this->mProperties[$propertyKey] = $diProperty;

--- a/tests/phpunit/SemanticMediaWikiTestCase.php
+++ b/tests/phpunit/SemanticMediaWikiTestCase.php
@@ -229,6 +229,16 @@ abstract class SemanticMediaWikiTestCase extends \PHPUnit_Framework_TestCase {
 
 	}
 
+	protected function getStore() {
+		$store = StoreFactory::getStore();
+
+		if ( !( $store instanceof \SMWSQLStore3 ) ) {
+			$this->markTestSkipped( 'Test only applicable for SMWSQLStore3' );
+		}
+
+		return $store;
+	}
+
 	/**
 	 * Utility method taking an array of elements and wrapping
 	 * each element in it's own array. Useful for data providers

--- a/tests/phpunit/includes/storage/sqlstore/Sql3StubSemanticDataTest.php
+++ b/tests/phpunit/includes/storage/sqlstore/Sql3StubSemanticDataTest.php
@@ -1,0 +1,120 @@
+<?php
+
+namespace SMW\Test\SQLStore;
+
+use SMW\SemanticData;
+use SMW\DIWikiPage;
+use SMW\DIProperty;
+use SMWDITime as DITime;
+use SMWSql3StubSemanticData;
+
+use Title;
+
+/**
+ * @covers \SMWSql3StubSemanticData
+ *
+ * @ingroup Test
+ *
+ * @group SMW
+ * @group SMWExtension
+ *
+ * @licence GNU GPL v2+
+ * @since 1.9.0.2
+ *
+ * @author mwjames
+ */
+class Sql3StubSemanticDataTest extends \SMW\Test\SemanticMediaWikiTestCase {
+
+	/**
+	 * @return string|false
+	 */
+	public function getClass() {
+		return 'SMWSql3StubSemanticData';
+	}
+
+	/**
+	 * @return SMWSql3StubSemanticData
+	 */
+	protected function newInstance( SemanticData $semanticData = null ) {
+
+		if ( $semanticData === null ) {
+			$semanticData = $this->newMockBuilder()->newObject( 'SemanticData', array(
+				'getSubject' => $this->newMockBuilder()->newObject( 'DIWikiPage' )
+			) );
+		}
+
+		return SMWSql3StubSemanticData::newFromSemanticData( $semanticData, $this->getStore() );
+	}
+
+	/**
+	 * @since 1.9.0.2
+	 */
+	public function testCanConstruct() {
+		$this->assertInstanceOf( $this->getClass(), $this->newInstance() );
+	}
+
+	/**
+	 * @since 1.9.0.2
+	 */
+	public function testGetPropertyValues() {
+
+		$instance = $this->newInstance( new SemanticData( DIWikiPage::newFromTitle( Title::newFromText( 'Foo' ) ) ) );
+
+		$this->assertInstanceOf( 'SMW\DIWikiPage', $instance->getSubject() );
+
+		$this->assertTrue(
+			$instance->getPropertyValues( new DIProperty( 'Foo', true ) ) === array() ,
+			'Asserts that an inverse Property returns an empty array'
+		);
+
+		$this->assertTrue(
+			$instance->getPropertyValues( new DIProperty( 'Foo' ) ) === array() ,
+			'Asserts that an unknown Property returns an empty array'
+		);
+
+	}
+
+	/**
+	 * @dataProvider removePropertyObjectProvider
+	 *
+	 * @since 1.9.0.2
+	 */
+	public function testRemovePropertyObjectValue( $title, $property, $dataItem ) {
+
+		$instance = $this->newInstance( new SemanticData( DIWikiPage::newFromTitle( $title ) ) );
+		$instance->addPropertyObjectValue( $property, $dataItem );
+
+		$this->assertFalse(
+			$instance->isEmpty() ,
+			'Asserts that isEmpty() returns false'
+		);
+
+		$instance->removePropertyObjectValue( $property, $dataItem );
+
+		$this->assertTrue(
+			$instance->isEmpty() ,
+			'Asserts that isEmpty() returns true'
+		);
+
+	}
+
+	/**
+	 * @return array
+	 */
+	public function removePropertyObjectProvider() {
+
+		$provider = array();
+
+		$title = Title::newFromText( 'Foo' );
+
+		// #0
+		$provider[] = array(
+			$title,
+			new DIProperty( '_MDAT'),
+			DITime::newFromTimestamp( 1272508903 )
+		);
+
+		return $provider;
+	}
+
+}


### PR DESCRIPTION
Strict Standards: Declaration of
SMWSql3StubSemanticData::getPropertyValues() should be compatible with that
of SMW\SemanticData::getPropertyValues() in
/var/www/html/w/extensions/SemanticMediaWiki/includes/storage/SQLStore/SMW_Sql3StubSemanticData.php
on line 262

Strict Standards: Declaration of
SMWSql3StubSemanticData::removePropertyObjectValue() should be compatible
with that of SMW\SemanticData::removePropertyObjectValue() in
/var/www/html/w/extensions/SemanticMediaWiki/includes/storage/SQLStore/SMW_Sql3StubSemanticData.php
on line 262
## Reason for the notice

The difference in the namespace usage (as seen below):

SMWSql3StubSemanticData::removePropertyObjectValue( SMWDIProperty $property, SMWDataItem $dataItem ) {

SMW\SemanticData::removePropertyObjectValue( DIProperty $property, SMWDataItem $dataItem ) {
