### PR TITLE
Decouple wfGetDB from Store (SMWSQLStore3Readers)

### DIFF
--- a/includes/src/MediaWiki/Database.php
+++ b/includes/src/MediaWiki/Database.php
@@ -1,0 +1,128 @@
+<?php
+
+namespace SMW\MediaWiki;
+
+use SMW\DBConnectionProvider;
+use ResultWrapper;
+use UnexpectedValueException;
+
+/**
+ * This adapter class covers MW DB specific operations. Changes to the
+ * interface are likely therefore this class should not be used other than by
+ * SMW itself.
+ *
+ * @ingroup SMW
+ *
+ * @licence GNU GPL v2+
+ * @since 1.9
+ *
+ * @author mwjames
+ */
+class Database {
+
+	protected $dbConnection;
+
+	public function __construct( DBConnectionProvider $dbConnection ) {
+		$this->dbConnection = $dbConnection;
+	}
+
+	/**
+	 * @since 1.9.0.2
+	 *
+	 * @return DatabaseBase
+	 */
+	public function getDB() {
+		return $this->dbConnection->getConnection();
+	}
+
+	/**
+	 * @see DatabaseBase::tableName
+	 *
+	 * @since 1.9.0.2
+	 *
+	 * @param string $tableName
+	 *
+	 * @return string
+	 */
+	public function tableName( $tableName ) {
+
+		if ( $GLOBALS['wgDBtype'] == 'sqlite' ) {
+			return $tableName;
+		}
+
+		return $this->getDB()->tableName( $tableName );
+	}
+
+	/**
+	 * @see DatabaseBase::addQuotes
+	 *
+	 * @since 1.9.0.2
+	 *
+	 * @param string $tableName
+	 *
+	 * @return string
+	 */
+	public function addQuotes( $value ) {
+		return $this->getDB()->addQuotes( $value );
+	}
+
+	/**
+	 * @see DatabaseBase::numRows
+	 *
+	 * @since 1.9.0.2
+	 *
+	 * @param mixed $results
+	 *
+	 * @return integer
+	 */
+	public function numRows( $results ) {
+		return $this->getDB()->numRows( $results );
+	}
+
+	/**
+	 * @see DatabaseBase::freeResult
+	 *
+	 * @since 1.9.0.2
+	 *
+	 * @param ResultWrapper $results
+	 */
+	public function freeResult( $results ) {
+		$this->getDB()->freeResult( $results );
+	}
+
+	/**
+	 * @see DatabaseBase::select
+	 *
+	 * @since 1.9.0.2
+	 *
+	 * @param string $tableName
+	 * @param $fields
+	 * @param $conditions
+	 * @param array $options
+	 *
+	 * @return ResultWrapper
+	 * @throws UnexpectedValueException
+	 */
+	public function select( $tableName, $fields, $conditions = '', $fname, array $options = array() ) {
+
+		$results = $this->getDB()->select(
+			$tableName,
+			$fields,
+			$conditions,
+			$fname,
+			$options
+		);
+
+		if ( $results instanceof ResultWrapper ) {
+			return $results;
+		}
+
+		throw new UnexpectedValueException(
+			'Expected a ResultWrapper instance as query result for ' .
+			$tableName . '#' .
+			$fields . '#' .
+			$conditions
+		);
+	}
+
+}

--- a/includes/storage/SQLStore/SMW_SQLStore3.php
+++ b/includes/storage/SQLStore/SMW_SQLStore3.php
@@ -8,6 +8,8 @@ use SMW\SQLStore\StatisticsCollector;
 use SMW\DataTypeRegistry;
 use SMW\Settings;
 use SMW\SQLStore\TableDefinition;
+use SMW\MediaWiki\Database;
+use SMW\LazyDBConnectionProvider as DBConnectionProvider;
 
 /**
  * SQL-based implementation of SMW's storage abstraction layer.
@@ -68,6 +70,12 @@ class SMWSQLStore3 extends SMWStore {
 	 * @var SMWSql3SmwIds
 	 */
 	public $smwIds;
+
+	/**
+	 * @var Database
+	 * @since  1.9.0.2
+	 */
+	protected $database = null;
 
 	/**
 	 * The reader object used by this store. Initialized by getReader()
@@ -839,4 +847,32 @@ class SMWSQLStore3 extends SMWStore {
 	public function getStatisticsTable() {
 		return self::PROPERTY_STATISTICS_TABLE;
 	}
+
+	/**
+	 * @since  1.9.0.2
+	 *
+	 * @param Database $database
+	 */
+	public function setDatabase( Database $database ) {
+		$this->database = $database;
+		return $this;
+	}
+
+	/**
+	 * @note DB_SLAVE (for read queries) or DB_MASTER (for write queries and read
+	 * queries that need the newest information)
+	 *
+	 * @since  1.9.0.2
+	 *
+	 * @return Database
+	 */
+	public function getDatabase() {
+
+		if ( $this->database === null ) {
+			$this->database = new Database( new DBConnectionProvider( DB_SLAVE ) );
+		}
+
+		return $this->database;
+	}
+
 }

--- a/tests/phpunit/includes/MediaWiki/DatabaseTest.php
+++ b/tests/phpunit/includes/MediaWiki/DatabaseTest.php
@@ -1,0 +1,97 @@
+<?php
+
+namespace SMW\Tests\MediaWiki;
+
+use SMW\MediaWiki\Database;
+
+/**
+ * @covers \SMW\MediaWiki\Database
+ *
+ * @ingroup Test
+ *
+ * @group SMW
+ * @group SMWExtension
+ *
+ * @licence GNU GPL v2+
+ * @since 1.9.0.2
+ *
+ * @author mwjames
+ */
+class DatabaseTest extends \PHPUnit_Framework_TestCase {
+
+	public function getClass() {
+		return '\SMW\MediaWiki\Database';
+	}
+
+	public function testCanConstruct() {
+		$this->assertInstanceOf(
+			$this->getClass(),
+			new Database( $this->getMockForAbstractClass( '\SMW\DBConnectionProvider' ) )
+		);
+	}
+
+	public function testMethodsWithSimpleReturnCoverage() {
+
+		$resultWrapper = $this->getMockBuilder( 'ResultWrapper' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$connection = $this->getMockBuilder( 'DatabaseMysql' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$connection->expects( $this->any() )
+			->method( 'tableName' )
+			->with( $this->equalTo( 'Foo' ) )
+			->will( $this->returnValue( 'Foo' ) );
+
+		$connection->expects( $this->once() )
+			->method( 'addQuotes' )
+			->with( $this->equalTo( 'Fan' ) )
+			->will( $this->returnValue( 'Fan' ) );
+
+		$connection->expects( $this->once() )
+			->method( 'numRows' )
+			->with( $this->equalTo( 'Fuyu' ) )
+			->will( $this->returnValue( 1 ) );
+
+		$connection->expects( $this->once() )
+			->method( 'select' )
+			->will( $this->returnValue( $resultWrapper ) );
+
+		$provider = $this->getMockForAbstractClass( '\SMW\DBConnectionProvider' );
+
+		$provider->expects( $this->any() )
+			->method( 'getConnection' )
+			->will( $this->returnValue( $connection ) );
+
+		$instance = new Database( $provider );
+
+		$this->assertEquals( 'Foo', $instance->tableName( 'Foo' ) );
+		$this->assertEquals( 'Fan', $instance->addQuotes( 'Fan' ) );
+		$this->assertEquals( 1, $instance->numRows( 'Fuyu' ) );
+		$this->assertInstanceOf( 'ResultWrapper', $instance->select( 'Foo', 'Bar', '', __METHOD__ ) );
+
+	}
+
+	public function testSelectThrowsException() {
+
+		$this->setExpectedException( 'UnexpectedValueException' );
+
+		$connection = $this->getMockBuilder( 'DatabaseMysql' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$provider = $this->getMockForAbstractClass( '\SMW\DBConnectionProvider' );
+
+		$provider->expects( $this->any() )
+			->method( 'getConnection' )
+			->will( $this->returnValue( $connection ) );
+
+		$instance = new Database( $provider );
+
+		$this->assertInstanceOf( 'ResultWrapper', $instance->select( 'Foo', 'Bar', '', __METHOD__ ) );
+
+	}
+
+}

--- a/tests/phpunit/includes/storage/StoreTest.php
+++ b/tests/phpunit/includes/storage/StoreTest.php
@@ -1,14 +1,13 @@
 <?php
-/**
- * @file
- * @since 1.8
- * @ingroup SMW
- * @ingroup Test
- */
 
 namespace SMW\Test;
 
-use Title, SMWDIProperty, SMWDIWikiPage, SMWQueryProcessor;
+use SMW\StoreFactory;
+use SMW\DIProperty;
+use SMW\DIWikiPage;
+
+use Title;
+use SMWQueryProcessor;
 use SMWRequestOptions;
 
 /**
@@ -42,11 +41,11 @@ class StoreTest extends \MediaWikiTestCase {
 	*/
 	public function testGetSemanticData( $titleText ,$filter = false) {
 		$title = Title::newFromText( $titleText );
-		$subject = SMWDIWikiPage::newFromTitle( $title );
-		$store = \SMW\StoreFactory::getStore();
+		$subject = DIWikiPage::newFromTitle( $title );
+		$store = StoreFactory::getStore();
 
 		$this->assertInstanceOf(
-			'\SMWSemanticData',
+			'\SMW\SemanticData',
 			$store->getSemanticData( $subject, $filter ),
 			"Result should be instance of SMWSemanticData."
 		);
@@ -54,8 +53,8 @@ class StoreTest extends \MediaWikiTestCase {
 
 	public function getPropertyValuesDataProvider() {
 		return array(
-			array( Title::newMainPage()->getFullText(), new SMWDIProperty('_MDAT') ),
-			array( Title::newMainPage()->getFullText(), SMWDIProperty::newFromUserLabel('Age') ),
+			array( Title::newMainPage()->getFullText(), new DIProperty('_MDAT') ),
+			array( Title::newMainPage()->getFullText(), DIProperty::newFromUserLabel('Age') ),
 			#add more pages and properties here, make sure they exist
 			#array( Test, Property ),
 		);
@@ -64,10 +63,10 @@ class StoreTest extends \MediaWikiTestCase {
 	/**
 	* @dataProvider getPropertyValuesDataProvider
 	*/
-	public function testGetPropertyValues( $titleText, SMWDIProperty $property, $requestOptions = null ) {
+	public function testGetPropertyValues( $titleText, DIProperty $property, $requestOptions = null ) {
 		$title = Title::newFromText( $titleText );
-		$subject = SMWDIWikiPage::newFromTitle( $title );
-		$store = \SMW\StoreFactory::getStore();
+		$subject = DIWikiPage::newFromTitle( $title );
+		$store = StoreFactory::getStore();
 		$result = $store->getPropertyValues( $subject, $property, $requestOptions );
 
 		$this->assertTrue( is_array( $result ) );
@@ -83,7 +82,7 @@ class StoreTest extends \MediaWikiTestCase {
 
 	public function getPropertySubjectsDataProvider() {
 		return array(
-			array( new SMWDIProperty('_MDAT'), null ),
+			array( new DIProperty('_MDAT'), null ),
 			#add more properties and values (SMWDataItem) here, make sure they exist
 			#array( Property, value ),
 		);
@@ -92,17 +91,17 @@ class StoreTest extends \MediaWikiTestCase {
 	/**
 	* @dataProvider getPropertySubjectsDataProvider
 	*/
-	public function testGetPropertySubjects( SMWDIProperty $property, $value, $requestOptions = null ) {
-		$store = \SMW\StoreFactory::getStore();
+	public function testGetPropertySubjects( DIProperty $property, $value, $requestOptions = null ) {
+		$store = StoreFactory::getStore();
 		$result = $store->getPropertySubjects( $property, $value, $requestOptions );
 
 		$this->assertTrue( is_array( $result ) );
 
 		foreach( $result as $page ) {
 			$this->assertInstanceOf(
-				'\SMWDIWikiPage',
+				'\SMW\DIWikiPage',
 				$page,
-				"Result should be instance of SMWDIWikiPage."
+				"Result should be instance of DIWikiPage."
 			);
 		}
 	}
@@ -120,17 +119,17 @@ class StoreTest extends \MediaWikiTestCase {
 	*/
 	public function testGetProperties( $titleText, $requestOptions = null ) {
 		$title = Title::newFromText( $titleText );
-		$subject = SMWDIWikiPage::newFromTitle( $title );
-		$store = \SMW\StoreFactory::getStore();
+		$subject = DIWikiPage::newFromTitle( $title );
+		$store = StoreFactory::getStore();
 		$result = $store->getProperties( $subject, $requestOptions );
 
 		$this->assertTrue( is_array( $result ) );
 
 		foreach( $result as $property ) {
 			$this->assertInstanceOf(
-				'\SMWDIProperty',
+				'\SMW\DIProperty',
 				$property,
-				"Result should be instance of SMWDIProperty."
+				"Result should be instance of DIProperty."
 			);
 		}
 	}
@@ -186,9 +185,9 @@ class StoreTest extends \MediaWikiTestCase {
 			$this->assertEquals( 2, sizeof( $row ) );
 
 			$this->assertInstanceOf(
-				'\SMWDIProperty',
+				'\DIProperty',
 				$row[0],
-				"Result should be instance of SMWDIProperty."
+				"Result should be instance of DIProperty."
 			);
 		}
 	}
@@ -200,35 +199,45 @@ class StoreTest extends \MediaWikiTestCase {
 		$this->assertInstanceOf( '\SMW\ResultCollector', $result );
 		foreach( $result->getResults() as $row ) {
 			$this->assertInstanceOf(
-				'\SMWDIProperty',
+				'\DIProperty',
 				$row,
-				"Result should be instance of SMWDIProperty."
+				"Result should be instance of DIProperty."
 			);
 		}
 	}
 
 	public function testGetWantedPropertiesSpecial() {
-		$store = \SMW\StoreFactory::getStore();
+		$store = StoreFactory::getStore();
 		$result = $store->getWantedPropertiesSpecial( new SMWRequestOptions() );
 
 		$this->assertInstanceOf( '\SMW\ResultCollector', $result );
 		foreach( $result->getResults() as $row ) {
 			$this->assertInstanceOf(
-				'\SMWDIProperty',
+				'\SMW\DIProperty',
 				$row[0],
-				"Result should be instance of SMWDIProperty."
+				"Result should be instance of DIProperty."
 			);
 		}
 	}
 
 	public function testGetStatistics() {
-		$store = \SMW\StoreFactory::getStore();
+		$store = StoreFactory::getStore();
 		$result = $store->getStatistics();
 
 		$this->assertTrue( is_array( $result ) );
 		$this->assertArrayHasKey( 'PROPUSES', $result );
 		$this->assertArrayHasKey( 'USEDPROPS', $result );
 		$this->assertArrayHasKey( 'DECLPROPS', $result );
+	}
+
+	public function testSetGetDatabase() {
+
+		$store = StoreFactory::getStore();
+		$database = $store->getDatabase();
+
+		$this->assertInstanceOf( '\SMW\MediaWiki\Database', $database );
+		$this->assertTrue( $database === $store->setDatabase( $database )->getDatabase() );
+
 	}
 
 }


### PR DESCRIPTION
- Add setter/getter for Database
- Add SMW\MediaWiki\Database to handle MW specific tasks

SMW\MediaWiki\Database only contains methods used for the SMWSQLStore3Readers replacement. This will at least ensure proper tablename prefixing and enables to implement individual tests.
## Reference
#99, #101
