### PR TITLE
Fix MW 1.19/relbuild test

### DIFF
--- a/tests/phpunit/system/import/PageAnnotationImportSystemTest.php
+++ b/tests/phpunit/system/import/PageAnnotationImportSystemTest.php
@@ -33,7 +33,7 @@ use User;
  */
 class PageAnnotationImportSystemTest extends \MediaWikiTestCase {
 
-	protected $enabledAssertOnMySql = true;
+	protected $enabledAssertOnMySql = false;
 
 	function run( \PHPUnit_Framework_TestResult $result = null ) {
 
@@ -42,9 +42,11 @@ class PageAnnotationImportSystemTest extends \MediaWikiTestCase {
 			// Only where teardownTestDB is available (excludes 1.19/1.20), we are
 			// able to rebuild the DB (exclude temporary table usage) otherwise
 			// some tests will fail with "Error: 1137 Can't reopen table" on mysql
-			$this->enabledAssertOnMySql = method_exists( $this, 'teardownTestDB' );
+			if ( method_exists( $this, 'teardownTestDB' ) ) {
+				$this->enabledOnMySql = true;
+				$this->teardownTestDB();
+			}
 
-			$this->teardownTestDB();
 			$this->setCliArg( 'use-normal-tables', true );
 		}
 


### PR DESCRIPTION
relbuild didn't fail before because it lags behind the
actual commit, already fixed in #112 but it fails now
because relbuild again is one step behind.
