### PR TITLE
LinksUpdate and SMW 1.9

### DIFF
--- a/tests/phpunit/MwIntegrationTestCase.php
+++ b/tests/phpunit/MwIntegrationTestCase.php
@@ -9,6 +9,7 @@ use SMW\DIProperty;
 use SMW\Setup;
 
 use Title;
+use UnexpectedValueException;
 
 /**
  * This TestCase should only be used in case a real Database integration with
@@ -113,35 +114,56 @@ abstract class MwIntegrationTestCase extends \MediaWikiTestCase {
 
 class PageCreator {
 
+	/** @var WikiPage */
 	protected $page = null;
 
+	/**
+	 * @since 1.9.0.3
+	 *
+	 * @return WikiPage
+	 * @throws UnexpectedValueException
+	 */
 	public function getPage() {
-		return $this->page;
+
+		if ( $this->page instanceof \WikiPage ) {
+			return $this->page;
+		}
+
+		throw new UnexpectedValueException( 'Expected a WikiPage instance, use createPage first' );
 	}
 
+	/**
+	 * @since 1.9.0.3
+	 *
+	 * @return PageCreator
+	 */
 	public function createPage( Title $title, $editContent = '' ) {
+
 		$this->page = new \WikiPage( $title );
 
 		$pageContent = 'Content of ' . $title->getFullText() . ' ' . $editContent;
 		$editMessage = 'SMW system test: create page';
 
-		$this->doEdit( $pageContent, $editMessage );
-
-		return $this;
+		return $this->doEdit( $pageContent, $editMessage );
 	}
 
+	/**
+	 * @since 1.9.0.3
+	 *
+	 * @return PageCreator
+	 */
 	public function doEdit( $pageContent = '', $editMessage = '' ) {
 
 		if ( class_exists( 'WikitextContent' ) ) {
 			$content = new \WikitextContent( $pageContent );
 
-			$this->page->doEditContent(
+			$this->getPage()->doEditContent(
 				$content,
 				$editMessage
 			);
 
 		} else {
-			$this->page->doEdit( $pageContent, $editMessage );
+			$this->getPage()->doEdit( $pageContent, $editMessage );
 		}
 
 		return $this;


### PR DESCRIPTION
[1] describes an issue where LinksUpdate apparently no longer works with SMW 1.9. The provided MwLinksUpdateWithSQLStoreDBIntegrationTest proves otherwise (it is an integration tests between the Store and its database).

If LinksUpdate is executed manually together with an inappropriate use of Parse/Revision/ParserOutput then of course "doUpdate" will override existing data but as the test shows when used in suitable manner, data
from different revisions are updated correctly.

[1] http://wikimedia.7.x6.nabble.com/SMW-no-longer-works-with-a-manual-LinksUpdate-call-td5020561.html
