### PR TITLE
(Bug 19487) Fix predefined property annotation for file upload

### DIFF
--- a/includes/MediaWikiPageInfoProvider.php
+++ b/includes/MediaWikiPageInfoProvider.php
@@ -70,7 +70,7 @@ class MediaWikiPageInfoProvider implements PageInfoProvider {
 	 * @return boolean
 	 */
 	public function isNewPage() {
-		return $this->revision->getParentId() !== '';
+		return $this->revision ? $this->revision->getParentId() !== '' : null;
 	}
 
 	/**
@@ -79,7 +79,34 @@ class MediaWikiPageInfoProvider implements PageInfoProvider {
 	 * @return Title
 	 */
 	public function getLastEditor() {
-		return $this->user->getUserPage();
+		return $this->user ? $this->user->getUserPage() : null;
+	}
+
+	/**
+	 * @since 1.9.0.4
+	 *
+	 * @return boolean
+	 */
+	public function isFilePage() {
+		return $this->wikiPage instanceof \WikiFilePage;
+	}
+
+	/**
+	 * @since 1.9.0.4
+	 *
+	 * @return string|null
+	 */
+	public function getMediaType() {
+		return $this->isFilePage() ? $this->wikiPage->getFile()->getMediaType() : null;
+	}
+
+	/**
+	 * @since 1.9.0.4
+	 *
+	 * @return string|null
+	 */
+	public function getMimeType() {
+		return $this->isFilePage() ? $this->wikiPage->getFile()->getMimeType() : null;
 	}
 
 }

--- a/includes/Setup.php
+++ b/includes/Setup.php
@@ -456,6 +456,15 @@ final class Setup implements ContextAware {
 			return true;
 		};
 
+		/**
+		 * @see https://www.mediawiki.org/wiki/Manual:Hooks/FileUpload
+		 *
+		 * @since 1.9.0.4
+		 */
+		$this->globals['wgHooks']['FileUpload'][] = function ( $file ) use ( $functionHook ) {
+			return $functionHook->register( new FileUpload( $file ) )->process();
+		};
+
 		// Old-style registration
 
 		$this->globals['wgHooks']['LoadExtensionSchemaUpdates'][] = 'SMWHooks::onSchemaUpdate';

--- a/includes/annotator/PageInfoProvider.php
+++ b/includes/annotator/PageInfoProvider.php
@@ -50,4 +50,29 @@ interface PageInfoProvider {
 	 */
 	public function getLastEditor();
 
+	/**
+	 * @since 1.9.0.4
+	 *
+	 * @return boolean
+	 */
+	public function isFilePage();
+
+	/**
+	 * @see File::getMediaType
+	 *
+	 * @since 1.9.0.4
+	 *
+	 * @return string|null
+	 */
+	public function getMediaType();
+
+	/**
+	 * @see File::getMimeType
+	 *
+	 * @since 1.9.0.4
+	 *
+	 * @return string|null
+	 */
+	public function getMimeType();
+
 }

--- a/includes/annotator/PredefinedPropertyAnnotator.php
+++ b/includes/annotator/PredefinedPropertyAnnotator.php
@@ -88,10 +88,16 @@ class PredefinedPropertyAnnotator extends PropertyAnnotatorDecorator {
 				$dataItem = DITime::newFromTimestamp( $this->pageInfo->getCreationDate() );
 				break;
 			case DIProperty::TYPE_NEW_PAGE :
-				$dataItem = new DIBoolean( $this->pageInfo->isNewPage() );
+				$dataItem = $this->pageInfo->isNewPage() ? new DIBoolean( $this->pageInfo->isNewPage() ) : null;
 				break;
 			case DIProperty::TYPE_LAST_EDITOR :
-				$dataItem = DIWikiPage::newFromTitle( $this->pageInfo->getLastEditor() );
+				$dataItem = $this->pageInfo->getLastEditor() ? DIWikiPage::newFromTitle( $this->pageInfo->getLastEditor() ) : null;
+				break;
+			case DIProperty::TYPE_MEDIA :
+				$dataItem = $this->pageInfo->isFilePage() ? new DIBlob( $this->pageInfo->getMediaType() ) : null;
+				break;
+			case DIProperty::TYPE_MIME :
+				$dataItem = $this->pageInfo->isFilePage() ? new DIBlob( $this->pageInfo->getMimeType() ) : null;
 				break;
 		}
 

--- a/includes/dataitems/SMW_DI_Property.php
+++ b/includes/dataitems/SMW_DI_Property.php
@@ -46,6 +46,11 @@ class DIProperty extends SMWDataItem {
 	// Property "has query"
 	const TYPE_ASKQUERY = '_ASK';
 
+	// Property "has media type"
+	const TYPE_MEDIA = '_MEDIA';
+	// Property "has mime type"
+	const TYPE_MIME = '_MIME';
+
 	/**
 	 * Array for assigning types to predefined properties. Each
 	 * property is associated with an array with the following
@@ -416,6 +421,8 @@ class DIProperty extends SMWDataItem {
 				'_ASKSI' =>  array( '_num', true ), // "has query size"
 				'_ASKDE' =>  array( '_num', true ), // "has query depth"
 				'_ASKDU' =>  array( '_num', true ), // "has query duration"
+				self::TYPE_MEDIA => array( '_txt', true ), // "has media type"
+				self::TYPE_MIME  => array( '_txt', true ), // "has mime type"
 			);
 
 		foreach ( $datatypeLabels as $typeid => $label ) {

--- a/includes/hooks/FileUpload.php
+++ b/includes/hooks/FileUpload.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace SMW;
+
+use WikiFilePage;
+use File;
+
+/**
+ * Fires when a local file upload occurs
+ *
+ * @see https://www.mediawiki.org/wiki/Manual:Hooks/FileUpload
+ *
+ * @ingroup FunctionHook
+ *
+ * @licence GNU GPL v2+
+ * @since 1.9.0.4
+ *
+ * @author mwjames
+ */
+class FileUpload extends FunctionHook {
+
+	/** @var File */
+	protected $file = null;
+
+	/**
+	 * @since  1.9.0.4
+	 *
+	 * @param File $file
+	 */
+	public function __construct( File $file ) {
+		$this->file = $file;
+	}
+
+	/**
+	 * @see FunctionHook::process
+	 *
+	 * @since 1.9.0.4
+	 *
+	 * @return true
+	 */
+	public function process() {
+
+		$title = $this->file->getTitle();
+
+		$wikiPage = new WikiFilePage( $title );
+		$wikiPage->setFile( $this->file );
+
+		$contentParser = $this->withContext()->getDependencyBuilder()->newObject( 'ContentParser', array(
+			'Title' => $title
+		) );
+
+		$contentParser->parse();
+
+		$parserData = $this->withContext()->getDependencyBuilder()->newObject( 'ParserData', array(
+			'Title'        => $title,
+			'ParserOutput' => $contentParser->getOutput()
+		) );
+
+		$propertyAnnotator = $this->withContext()->getDependencyBuilder()->newObject( 'PredefinedPropertyAnnotator', array(
+			'SemanticData' => $parserData->getSemanticData(),
+			'WikiPage' => $wikiPage
+		) );
+
+		$propertyAnnotator->attach( $parserData )->addAnnotation();
+
+		$parserData->updateStore();
+
+		return true;
+	}
+
+}

--- a/includes/storage/SQLStore/SMW_SQLStore3.php
+++ b/includes/storage/SQLStore/SMW_SQLStore3.php
@@ -160,7 +160,7 @@ class SMWSQLStore3 extends SMWStore {
 	 */
 	protected static $special_tables = array(
 		// page metadata tables
-		'_MDAT', '_CDAT', '_NEWP', '_LEDT',
+		'_MDAT', '_CDAT', '_NEWP', '_LEDT', '_MIME', '_MEDIA',
 		// property declarations
 		'_TYPE', '_UNIT', '_CONV', '_PVAL', '_LIST', '_SERV',
 		// query statistics (very frequently used)

--- a/languages/SMW_Language.php
+++ b/languages/SMW_Language.php
@@ -92,6 +92,8 @@ abstract class SMWLanguage {
 		'Has query size'    => '_ASKSI',
 		'Has query depth'   => '_ASKDE',
 		'Has query duration' => '_ASKDU',
+		'Has media type'     => '_MEDIA',
+		'Has mime type'      => '_MIME',
 	);
 
 	public function __construct() {

--- a/languages/SMW_LanguageAr.php
+++ b/languages/SMW_LanguageAr.php
@@ -71,6 +71,8 @@ class SMWLanguageAr extends SMWLanguage {
 		'_ASKSI'=> 'Query size', // TODO: translate
 		'_ASKDE'=> 'Query depth', // TODO: translate
 		'_ASKDU'=> 'Query duration', // TODO: translate
+		'_MEDIA'=> 'Media type',
+		'_MIME' => 'Mime type'
 	);
 
 	protected $m_SpecialPropertyAliases = array(

--- a/languages/SMW_LanguageArz.php
+++ b/languages/SMW_LanguageArz.php
@@ -71,6 +71,8 @@ class SMWLanguageArz extends SMWLanguage {
 		'_ASKSI'=> 'Query size', // TODO: translate
 		'_ASKDE'=> 'Query depth', // TODO: translate
 		'_ASKDU'=> 'Query duration', // TODO: translate
+		'_MEDIA'=> 'Media type',
+		'_MIME' => 'Mime type'
 	);
 
 	protected $m_SpecialPropertyAliases = array(

--- a/languages/SMW_LanguageCa.php
+++ b/languages/SMW_LanguageCa.php
@@ -76,6 +76,8 @@ class SMWLanguageCa extends SMWLanguage {
 		'_ASKSI'=> 'Mida de consulta',
 		'_ASKDE'=> 'Profunditat de consulta',
 		'_ASKDU'=> 'Durada de consulta',
+		'_MEDIA'=> 'Media type',
+		'_MIME' => 'Mime type'
 	);
 
 	protected $m_SpecialPropertyAliases = array(

--- a/languages/SMW_LanguageDe.php
+++ b/languages/SMW_LanguageDe.php
@@ -81,6 +81,8 @@ class SMWLanguageDe extends SMWLanguage {
 		'_ASKSI'=> 'Abfragegröße',
 		'_ASKDE'=> 'Abfragetiefe',
 		'_ASKDU'=> 'Abfragedauer',
+		'_MEDIA'=> 'Media type',
+		'_MIME' => 'Mime type'
 	);
 
 	protected $m_SpecialPropertyAliases = array(

--- a/languages/SMW_LanguageEn.php
+++ b/languages/SMW_LanguageEn.php
@@ -78,6 +78,8 @@ class SMWLanguageEn extends SMWLanguage {
 		'_ASKSI'=> 'Query size',
 		'_ASKDE'=> 'Query depth',
 		'_ASKDU'=> 'Query duration',
+		'_MEDIA'=> 'Media type',
+		'_MIME' => 'Mime type'
 	);
 
 	protected $m_SpecialPropertyAliases = array(

--- a/languages/SMW_LanguageEs.php
+++ b/languages/SMW_LanguageEs.php
@@ -72,6 +72,8 @@ class SMWLanguageEs extends SMWLanguage {
 		'_ASKSI'=> 'Tamaño de consulta',
 		'_ASKDE'=> 'Profundidad de consulta',
 		'_ASKDU'=> 'Duración de consulta',
+		'_MEDIA'=> 'Media type',
+		'_MIME' => 'Mime type'
 	);
 
 	protected $m_SpecialPropertyAliases = array(

--- a/languages/SMW_LanguageFi.php
+++ b/languages/SMW_LanguageFi.php
@@ -68,6 +68,8 @@ class SMWLanguageFi extends SMWLanguage {
 		'_ASKSI'=> 'Query size', // TODO: translate
 		'_ASKDE'=> 'Query depth', // TODO: translate
 		'_ASKDU'=> 'Query duration', // TODO: translate
+		'_MEDIA'=> 'Media type',
+		'_MIME' => 'Mime type'
 	);
 
 	protected $m_Namespaces = array(

--- a/languages/SMW_LanguageFr.php
+++ b/languages/SMW_LanguageFr.php
@@ -71,7 +71,9 @@ class SMWLanguageFr extends SMWLanguage {
 		'_ASKFO'=> 'Format de requête',
 		'_ASKSI'=> 'Taille de la requête',
 		'_ASKDE'=> 'Profondeur de la requête',
-		'_ASKDU'=> 'Durée de la requête'
+		'_ASKDU'=> 'Durée de la requête',
+		'_MEDIA'=> 'Media type',
+		'_MIME' => 'Mime type'
 	);
 
 	protected $m_SpecialPropertyAliases = array(

--- a/languages/SMW_LanguageHe.php
+++ b/languages/SMW_LanguageHe.php
@@ -71,6 +71,8 @@ class SMWLanguageHe extends SMWLanguage {
 		'_ASKSI'=> 'גודל השאילתא',
 		'_ASKDE'=> 'עומק שאילתא',
 		'_ASKDU'=> 'Query duration', // TODO: translate
+		'_MEDIA'=> 'Media type',
+		'_MIME' => 'Mime type'
 	);
 
 	protected $m_SpecialPropertyAliases = array(

--- a/languages/SMW_LanguageId.php
+++ b/languages/SMW_LanguageId.php
@@ -72,6 +72,8 @@ class SMWLanguageId extends SMWLanguage {
 		'_ASKSI'=> 'Query size', // TODO: translate
 		'_ASKDE'=> 'Query depth', // TODO: translate
 		'_ASKDU'=> 'Query duration', // TODO: translate
+		'_MEDIA'=> 'Media type',
+		'_MIME' => 'Mime type'
 	);
 
 	protected $m_SpecialPropertyAliases = array(

--- a/languages/SMW_LanguageIt.php
+++ b/languages/SMW_LanguageIt.php
@@ -74,6 +74,8 @@ class SMWLanguageIt extends SMWLanguage {
 		'_ASKSI'=> 'Query size', // TODO: translate
 		'_ASKDE'=> 'Query depth', // TODO: translate
 		'_ASKDU'=> 'Query duration', // TODO: translate
+		'_MEDIA'=> 'Media type',
+		'_MIME' => 'Mime type'
 	);
 
 	protected $m_SpecialPropertyAliases = array(

--- a/languages/SMW_LanguageNb.php
+++ b/languages/SMW_LanguageNb.php
@@ -80,7 +80,9 @@ class SMWLanguageNb extends SMWLanguage {
 		'_ASKFO'=> 'Spørringsformat',
 		'_ASKSI'=> 'Spørringsstørrelse',
 		'_ASKDE'=> 'Spørringsdybde',
-		'_ASKDU'=> 'Spørringsvarighet'
+		'_ASKDU'=> 'Spørringsvarighet',
+		'_MEDIA'=> 'Media type',
+		'_MIME' => 'Mime type'
 	);
 
 	protected $m_SpecialPropertyAliases = array(

--- a/languages/SMW_LanguageNl.php
+++ b/languages/SMW_LanguageNl.php
@@ -73,7 +73,9 @@ class SMWLanguageNl extends SMWLanguage {
 		'_ASKFO'=> 'Zoekopdracht-opmaak',
 		'_ASKSI'=> 'Zoekopdracht-omvang',
 		'_ASKDE'=> 'Zoekdiepte',
-		'_ASKDU'=> 'Zoekduur'
+		'_ASKDU'=> 'Zoekduur',
+		'_MEDIA'=> 'Media type',
+		'_MIME' => 'Mime type'
 	);
 
 	protected $m_SpecialPropertyAliases = array(

--- a/languages/SMW_LanguagePl.php
+++ b/languages/SMW_LanguagePl.php
@@ -90,6 +90,8 @@ class SMWLanguagePl extends SMWLanguage {
 		'_ASKSI'=> 'Query size', // TODO: translate
 		'_ASKDE'=> 'Query depth', // TODO: translate
 		'_ASKDU'=> 'Query duration', // TODO: translate
+		'_MEDIA'=> 'Media type',
+		'_MIME' => 'Mime type'
 	);
 
 	protected $m_SpecialPropertyAliases = array(

--- a/languages/SMW_LanguagePt.php
+++ b/languages/SMW_LanguagePt.php
@@ -79,6 +79,8 @@ class SMWLanguagePt extends SMWLanguage {
 		'_ASKSI'=> 'Tamanho da consulta',
 		'_ASKDE'=> 'Profundidade da consulta',
 		'_ASKDU'=> 'Query duration', // TODO: translate
+		'_MEDIA'=> 'Media type',
+		'_MIME' => 'Mime type'
 	);
 
 	protected $m_SpecialPropertyAliases = array(

--- a/languages/SMW_LanguageRu.php
+++ b/languages/SMW_LanguageRu.php
@@ -72,7 +72,9 @@ class SMWLanguageRu extends SMWLanguage {
 		'_ASKFO'=> 'Формат запроса',
 		'_ASKSI'=> 'Размер запроса',
 		'_ASKDE'=> 'Глубина запроса',
-		'_ASKDU'=> 'Длительность запроса'
+		'_ASKDU'=> 'Длительность запроса',
+		'_MEDIA'=> 'Media type',
+		'_MIME' => 'Mime type'
 	);
 
 	protected $m_SpecialPropertyAliases = array(

--- a/languages/SMW_LanguageSk.php
+++ b/languages/SMW_LanguageSk.php
@@ -71,6 +71,8 @@ class SMWLanguageSk extends SMWLanguage {
 		'_ASKSI'=> 'Veľkosť požiadavky',
 		'_ASKDE'=> 'Hĺbka požiadavky',
 		'_ASKDU'=> 'Query duration', // TODO: translate
+		'_MEDIA'=> 'Media type',
+		'_MIME' => 'Mime type'
 	);
 
 	protected $m_SpecialPropertyAliases = array(

--- a/languages/SMW_LanguageZh_cn.php
+++ b/languages/SMW_LanguageZh_cn.php
@@ -77,8 +77,9 @@ class SMWLanguageZh_cn extends SMWLanguage {
 		'_ASKSI'=> 'Query size', // TODO: translate
 		'_ASKDE'=> 'Query depth', // TODO: translate
 		'_ASKDU'=> 'Query duration', // TODO: translate
+		'_MEDIA'=> 'Media type',
+		'_MIME' => 'Mime type'
 	);
-
 
 	protected $m_SpecialPropertyAliases = array(
 		'Display unit' => '_UNIT'

--- a/languages/SMW_LanguageZh_tw.php
+++ b/languages/SMW_LanguageZh_tw.php
@@ -75,8 +75,9 @@ class SMWLanguageZh_tw extends SMWLanguage {
 		'_ASKSI'=> 'Query size', // TODO: translate
 		'_ASKDE'=> 'Query depth', // TODO: translate
 		'_ASKDU'=> 'Query duration', // TODO: translate
+		'_MEDIA'=> 'Media type',
+		'_MIME' => 'Mime type'
 	);
-
 
 	protected $m_SpecialPropertyAliases = array(
 		'Display unit' => '_UNIT'


### PR DESCRIPTION
Even though it is called Semantic-Media-Wiki, media 'file' upload annotation has been broken since 2009.

As for the original Bug [0], predefined properties are now correctly updated whenever a new upload takes place and moreover MEDIA and MIME are now set automatically (if configuration enables it).

Relates to #162

[0] https://bugzilla.wikimedia.org/show_bug.cgi?id=19487
