### PR TITLE
Add lookup for internal object Id via SMWAdmin

### DIFF
--- a/languages/SMW_Messages.php
+++ b/languages/SMW_Messages.php
@@ -432,6 +432,9 @@ Estimated progress of current update:',
 	'smw-sp-admin-settings-title' => 'Configuration settings',
 	'smw-sp-admin-settings-docu' => 'Displays a list of all <code>default</code> and <code>localized settings</code> that are relevant to the Semantic MediaWiki environment. For details on individual settings, please consult the [https://semantic-mediawiki.org/wiki/Help:Configuration configuration] help page.',
 	'smw-sp-admin-settings-button' => 'Generate settings list',
+	'smw-sp-admin-idlookup-title' => 'ObjectId lookup',
+	'smw-sp-admin-idlookup-docu' => 'Displays details about an internal object Id that represents individual entities (wikipage, subobject etc.) in Semantic MediaWiki.',
+	'smw-sp-admin-idlookup-objectid' => 'Object Id:',
 
 );
 
@@ -1024,6 +1027,9 @@ Preceded by the heading {{msg-mw|Smw-sp-admin-settings-title}}.',
 
 Preceded by introduction:
 * {{msg-mw|Smw-sp-admin-settings-docu}}',
+	'smw-sp-admin-idlookup-title' => 'A header title',
+	'smw-sp-admin-idlookup-docu' => 'Introductory text for the objectId lookup section in [[Special:SMWAdmin]]',
+	'smw-sp-admin-idlookup-objectid' => 'A label',
 );
 
 /** Afrikaans (Afrikaans)

--- a/tests/phpunit/SpecialPageTestCase.php
+++ b/tests/phpunit/SpecialPageTestCase.php
@@ -24,6 +24,7 @@ use OutputPage;
 abstract class SpecialPageTestCase extends \PHPUnit_Framework_TestCase {
 
 	protected $obLevel;
+	protected $store = null;
 
 	protected function setUp() {
 		parent::setUp();
@@ -46,6 +47,10 @@ abstract class SpecialPageTestCase extends \PHPUnit_Framework_TestCase {
 	 */
 	protected abstract function getInstance();
 
+	protected function setStore( $store ) {
+		$this->store = $store;
+	}
+
 	/**
 	 * Borrowed from \Wikibase\Test\SpecialPageTestBase
 	 *
@@ -58,6 +63,11 @@ abstract class SpecialPageTestCase extends \PHPUnit_Framework_TestCase {
 		$response = $request->response();
 
 		$page = $this->getInstance();
+
+		if ( $this->store !== null ) {
+			$page->setStore( $this->store );
+		}
+
 		$page->setContext( $this->makeRequestContext(
 			$request,
 			$user,

--- a/tests/phpunit/mocks/FakeClass.php
+++ b/tests/phpunit/mocks/FakeClass.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace SMW\Test;
+
+use RuntimeException;
+
+/**
+ * @ingroup Test
+ *
+ * @group SMW
+ * @group SMWExtension
+ *
+ * @licence GNU GPL v2+
+ * @since 1.9.1.1
+ *
+ * @author mwjames
+ */
+class FakeClass {
+
+	public function __call( $method, $args ) {
+
+		if ( isset( $this->$method ) && is_callable( $this->$method ) ) {
+			$func = $this->$method;
+			return call_user_func_array( $func, $args );
+		}
+
+		throw new RuntimeException( "Expected a callable '{$method}' method" );
+	}
+
+}


### PR DESCRIPTION
During setup or refresh it can happen the processing stops at a specific Id. In order to aid the investigation of what is causing the problem, the lookup can be used to identify the title and namespace.
