### PR TITLE
Avoid unnecessary processing when data is empty

### DIFF
--- a/includes/ContentParser.php
+++ b/includes/ContentParser.php
@@ -178,10 +178,6 @@ class ContentParser {
 		return $this;
 	}
 
-	protected function hasContentHandler() {
-		return class_exists( 'ContentHandler' );
-	}
-
 	protected function msgForNullRevision( $fname = __METHOD__ ) {
 		$this->errors = array( $fname . " No revision available for {$this->getTitle()->getPrefixedDBkey()}" );
 		return $this;
@@ -212,6 +208,10 @@ class ContentParser {
 		}
 
 		return $this->revision;
+	}
+
+	protected function hasContentHandler() {
+		return defined( 'CONTENT_MODEL_WIKITEXT' );
 	}
 
 }

--- a/includes/annotator/RedirectPropertyAnnotator.php
+++ b/includes/annotator/RedirectPropertyAnnotator.php
@@ -57,7 +57,7 @@ class RedirectPropertyAnnotator extends PropertyAnnotatorDecorator {
 	}
 
 	protected function hasContentHandler() {
-		return class_exists( 'ContentHandler' );
+		return defined( 'CONTENT_MODEL_WIKITEXT' );
 	}
 
 }

--- a/includes/hooks/InternalParseBeforeLinks.php
+++ b/includes/hooks/InternalParseBeforeLinks.php
@@ -103,6 +103,11 @@ class InternalParseBeforeLinks extends FunctionHook {
 
 		$contentProcessor->parse( $this->text );
 
+		$this->parser->getOutput()->setProperty(
+			'smw-semanticdata-status',
+			$parserData->getSemanticData()->getProperties() !== array()
+		);
+
 		return true;
 	}
 

--- a/tests/phpunit/includes/hooks/ParserAfterTidyTest.php
+++ b/tests/phpunit/includes/hooks/ParserAfterTidyTest.php
@@ -20,9 +20,6 @@ use SMW\ExtensionContext;
  */
 class ParserAfterTidyTest extends ParserTestCase {
 
-	/**
-	 * @return string|false
-	 */
 	public function getClass() {
 		return '\SMW\ParserAfterTidy';
 	}
@@ -82,6 +79,7 @@ class ParserAfterTidyTest extends ParserTestCase {
 	public function testProcess( $setup, $expected ) {
 
 		$parser = $this->newParser( $setup['title'], $this->getUser() );
+		$parser->getOutput()->setProperty( 'smw-semanticdata-status', $setup['data-status'] );
 		$text   = '';
 
 		$instance = $this->newInstance( $parser, $text );
@@ -126,6 +124,7 @@ class ParserAfterTidyTest extends ParserTestCase {
 		$parser = $this->newParser( $title, $this->getUser() );
 		$parser->getOutput()->addCategory( 'Foo', 'Foo' );
 		$parser->getOutput()->addCategory( 'Bar', 'Bar' );
+		$parser->getOutput()->setProperty( 'smw-semanticdata-status', true );
 
 		// Expected semantic data
 		$expected = array(
@@ -178,7 +177,8 @@ class ParserAfterTidyTest extends ParserTestCase {
 		$provider[] = array(
 			array(
 				'title'    => $title,
-				'cache'    => true
+				'cache'    => true,
+				'data-status' => true
 			),
 			array(
 				'observer' => 'runStoreUpdater'
@@ -193,7 +193,8 @@ class ParserAfterTidyTest extends ParserTestCase {
 		$provider[] = array(
 			array(
 				'title'    => $title,
-				'cache'    => false
+				'cache'    => false,
+				'data-status' => true
 			),
 			array(
 				'observer' => null
@@ -208,7 +209,8 @@ class ParserAfterTidyTest extends ParserTestCase {
 		$provider[] = array(
 			array(
 				'title'    => $title,
-				'cache'    => false
+				'cache'    => false,
+				'data-status' => true
 			),
 			array(
 				'observer' => null
@@ -224,10 +226,11 @@ class ParserAfterTidyTest extends ParserTestCase {
 		$provider[] = array(
 			array(
 				'title'    => $title,
-				'cache'    => true
+				'cache'    => true,
+				'data-status' => true
 			),
 			array(
-				'observer' => null
+				'observer' => 'runStoreUpdater'
 			)
 		);
 

--- a/tests/phpunit/integration/ContentParserFunctionHookIntegrationTest.php
+++ b/tests/phpunit/integration/ContentParserFunctionHookIntegrationTest.php
@@ -1,0 +1,115 @@
+<?php
+
+namespace SMW\Test;
+
+use SMW\ContentParser;
+use SMW\ParserData;
+
+use Title;
+use Parser;
+
+/**
+ * @covers \SMW\ContentParser
+ *
+ * @group SMW
+ * @group SMWExtension
+ * @group medium
+ *
+ * @license GNU GPL v2+
+ * @since   1.9.1.1
+ *
+ * @author mwjames
+ */
+class ContentParserFunctionHookIntegrationTest extends \PHPUnit_Framework_TestCase {
+
+	/**
+	 * @dataProvider textDataProvider
+	 */
+	public function testTextParse( $parameters, $expected ) {
+
+		$instance = new ContentParser( $parameters['title'], new Parser() );
+		$instance->parse( $parameters['text'] );
+
+		$this->assertInstanceAfterParse( $instance );
+		$this->assertSemanticDataAfterParse( $instance, $expected );
+	}
+
+	protected function assertInstanceAfterParse( $instance ) {
+		$this->assertInstanceOf( 'ParserOutput', $instance->getOutput() );
+		$this->assertInternalType( 'string', $instance->getOutput()->getText() );
+	}
+
+	protected function assertSemanticDataAfterParse( $instance, $expected ) {
+
+		$parserData = new ParserData( $instance->getTitle(), $instance->getOutput() );
+
+		$semanticDataValidator = new SemanticDataValidator;
+		$semanticDataValidator->assertThatPropertiesAreSet(
+			$expected,
+			$parserData->getSemanticData()
+		);
+	}
+
+	/**
+	 * @return array
+	 */
+	public function textDataProvider() {
+
+		$title = Title::newFromText( __METHOD__ );
+
+		$provider = array();
+
+		// #0 Empty
+		$provider[] = array(
+			array(
+				'text'  => '',
+				'title' => $title
+			),
+			array(
+				'propertyCount' => 0
+			)
+		);
+
+		// #1 With a single category
+		$provider[] = array(
+			array(
+				'text'  => '[[Category:Foo]]',
+				'title' => $title
+			),
+			array(
+				'propertyCount'  => 2,
+				'propertyKey'    => array( '_INST', '_SKEY' ),
+				'propertyValues' => array( 'Foo', $title->getText() )
+			)
+		);
+
+		// #2 With a sortkey
+		$provider[] = array(
+			array(
+				'text'  => '{{DEFAULTSORTKEY:Bar}}',
+				'title' => $title
+			),
+			array(
+				'propertyCount'  => 1,
+				'propertyKey'    => '_SKEY',
+				'propertyValues' => array( 'Bar' )
+			)
+		);
+
+		// #3 Combined
+		$provider[] = array(
+			array(
+				'text'  => '[[Fuyu::Natsu]], [[Category:Foo]], {{DEFAULTSORTKEY:Bar}}',
+				'title' => $title
+			),
+			array(
+				'propertyCount'  => 3,
+				'propertyKey'    => array( '_SKEY', '_INST', 'Fuyu' ),
+				'propertyValues' => array( 'Bar', 'Foo', 'Natsu' )
+			)
+		);
+
+		return $provider;
+	}
+
+}

--- a/tests/phpunit/integration/ContentParserParserFunctionIntegrationTest.php
+++ b/tests/phpunit/integration/ContentParserParserFunctionIntegrationTest.php
@@ -24,7 +24,7 @@ use Parser;
  *
  * @author mwjames
  */
-class ParserFunctionIntegrationTest extends SemanticMediaWikiTestCase {
+class ContentParserParserFunctionIntegrationTest extends SemanticMediaWikiTestCase {
 
 	/** @var array */
 	private $parserHook = array();

--- a/tests/phpunit/integration/MwLinksUpdateWithSQLStoreDBIntegrationTest.php
+++ b/tests/phpunit/integration/MwLinksUpdateWithSQLStoreDBIntegrationTest.php
@@ -203,16 +203,16 @@ class MwLinksUpdateWithSQLStoreDBIntegrationTest extends MwIntegrationTestCase {
 			),
 			'afterAlterationRevId' => array(
 				'poBefore'  => array(
-					'count' => 1,
-					'msg'   => 'Asserts property _SKEY exists only before the update'
+					'count' => 0,
+					'msg'   => 'Asserts no property exists before the update'
 				),
 				'storeBefore' => array(
 					'count'   => 4,
 					'msg'     => 'Asserts property Aa, Fuyu, _SKEY, and _MDAT from the previous state as no update has been made yet'
 				),
 				'poAfter'    => array(
-					'count'  => 2,
-					'msg'    => 'Asserts property _SKEY, _MDAT exists after the update'
+					'count'  => 1,
+					'msg'    => 'Asserts property _MDAT exists after the update'
 				),
 				'storeAfter' => array(
 					'count'  => 2,


### PR DESCRIPTION
This avoids unnecessary calls when it is known that no semantic data are available.

InternalParseBeforeLinks will indicate whether semantic data have been processed or not, this is especially important where MessageCache->parse() runs through the same parser hooks or when edit mode is processed.
- This resolves the ambiguate case of $title->inNamespace( NS_FILE ).
- Use defined( 'CONTENT_MODEL_WIKITEXT' ) instead of class_exists( 'ContentHandler' )
  to avoid having the autoloader being executed which decreases the check from 100 ms to 0.1 ms
- Solves the issue with ApprovedRevs (doPurge executed by ApprovedRevs) when it sends an
  empty ParserOutput object
