### PR TITLE
Remove hook usage/invocation during test

### DIFF
--- a/tests/phpunit/includes/storage/sqlstore/PropertyTableDefinitionBuilderTest.php
+++ b/tests/phpunit/includes/storage/sqlstore/PropertyTableDefinitionBuilderTest.php
@@ -4,7 +4,7 @@ namespace SMW\Test\SQLStore;
 
 use SMW\SQLStore\PropertyTableDefinitionBuilder;
 
-use SMWDataItem;
+use SMWDataItem as DataItem;
 
 /**
  * @covers \SMW\SQLStore\PropertyTableDefinitionBuilder
@@ -13,67 +13,77 @@ use SMWDataItem;
  *
  * @group SMW
  * @group SMWExtension
+ * @group StoreTest
  *
  * @licence GNU GPL v2+
  * @since 1.9
  *
  * @author mwjames
  */
-class PropertyTableDefinitionBuilderTest extends \SMW\Test\SemanticMediaWikiTestCase {
+class PropertyTableDefinitionBuilderTest extends \PHPUnit_Framework_TestCase {
 
-	/**
-	 * @return string|false
-	 */
+	protected $hooks = array();
+
+	protected function setUp() {
+		parent::setUp();
+
+		if ( isset( $GLOBALS['wgHooks']['SMW::SQLStore::updatePropertyTableDefinitions'] ) ) {
+			$this->hooks = $GLOBALS['wgHooks']['SMW::SQLStore::updatePropertyTableDefinitions'];
+			$GLOBALS['wgHooks']['SMW::SQLStore::updatePropertyTableDefinitions'] = array();
+		}
+	}
+
+	protected function tearDown() {
+
+		if ( $this->hooks !== array() ) {
+			$GLOBALS['wgHooks']['SMW::SQLStore::updatePropertyTableDefinitions'] = $this->hooks;
+		}
+
+		parent::tearDown();
+	}
+
 	public function getClass() {
 		return '\SMW\SQLStore\PropertyTableDefinitionBuilder';
 	}
 
 	/**
-	 * @since 1.9
-	 *
 	 * @return PropertyTableDefinitionBuilder
 	 */
-	private function newInstance( $dataItems = array(), $specials = array(), $fixed = array() ) {
+	private function acquireInstance( $dataItems = array(), $specials = array(), $fixed = array() ) {
 		return new PropertyTableDefinitionBuilder( $dataItems, $specials, $fixed );
 	}
 
-	/**
-	 * @since 1.9
-	 */
-	public function testConstructor() {
-		$this->assertInstanceOf( $this->getClass(), $this->newInstance() );
+	public function testCanConstruct() {
+		$this->assertInstanceOf( $this->getClass(), $this->acquireInstance() );
 	}
 
-	/**
-	 * @since 1.9
-	 */
-	public function testDITypes() {
+	public function testDataItemTypes() {
 
-		$test = array( SMWDataItem::TYPE_NUMBER => 'smw_di_number' );
+		$parameters = array( DataItem::TYPE_NUMBER => 'smw_di_number' );
 
-		$instance = $this->newInstance( $test );
+		$instance = $this->acquireInstance( $parameters );
 		$instance->runBuilder();
 
-		$definition = $instance->getDefinition( SMWDataItem::TYPE_NUMBER, 'smw_di_number' );
-		$expected = array( 'smw_di_number' => $definition );
+		$definition = $instance->getDefinition( DataItem::TYPE_NUMBER, 'smw_di_number' );
+
+		$expected = array(
+			'smw_di_number' => $definition
+		);
 
 		$this->assertEquals( $expected, $instance->getTableDefinitions() );
-
 	}
 
-	/**
-	 * @since 1.9
-	 */
 	public function testFixedProperties() {
 
-		$propertyKey = $this->newRandomString();
-		$test = array( $propertyKey => SMWDataItem::TYPE_NUMBER );
+		$propertyKey = 'Foo';
+		$parameters = array( $propertyKey => DataItem::TYPE_NUMBER );
 
-		$instance = $this->newInstance( array(), array(), $test );
+		$instance = $this->acquireInstance( array(), array(), $parameters );
 		$instance->runBuilder();
 
 		$tableName = $instance->getTablePrefix() . '_' . md5( $propertyKey );
-		$definition = $instance->getDefinition( SMWDataItem::TYPE_NUMBER, $tableName, $propertyKey );
+		$definition = $instance->getDefinition( DataItem::TYPE_NUMBER, $tableName, $propertyKey );
+
 		$expected = array(
 			'definition' => array( $tableName => $definition ),
 			'tableId' => array( $propertyKey => $tableName, '_SKEY' => null )
@@ -81,45 +91,37 @@ class PropertyTableDefinitionBuilderTest extends \SMW\Test\SemanticMediaWikiTest
 
 		$this->assertEquals( $expected['definition'], $instance->getTableDefinitions() );
 		$this->assertEquals( $expected['tableId'], $instance->getTableIds() );
-
 	}
 
-	/**
-	 * @since 1.9
-	 */
 	public function testSpecialProperties() {
 
 		$propertyKey = '_MDAT';
-		$test = array( $propertyKey );
+		$parameters = array( $propertyKey );
 
-		$instance = $this->newInstance( array(), $test, array() );
+		$instance = $this->acquireInstance( array(), $parameters, array() );
 		$instance->runBuilder();
 
 		$tableName = $instance->getTablePrefix() . strtolower( $propertyKey );
-		$definition = $instance->getDefinition( SMWDataItem::TYPE_TIME, $tableName, $propertyKey );
+		$definition = $instance->getDefinition( DataItem::TYPE_TIME, $tableName, $propertyKey );
 		$expected = array( $tableName => $definition );
 
 		$this->assertEquals( $expected, $instance->getTableDefinitions() );
-
 	}
 
-	/**
-	 * @since 1.9
-	 */
 	public function testRedirects() {
 
 		$propertyKey = '_REDI';
-		$test = array( $propertyKey );
+		$parameters = array( $propertyKey );
 
-		$instance = $this->newInstance( array(), $test, array() );
+		$instance = $this->acquireInstance( array(), $parameters, array() );
 		$instance->runBuilder();
 
 		$tableName = $instance->getTablePrefix() . strtolower( $propertyKey );
-		$definition = $instance->getDefinition( SMWDataItem::TYPE_WIKIPAGE, $tableName, $propertyKey );
+		$definition = $instance->getDefinition( DataItem::TYPE_WIKIPAGE, $tableName, $propertyKey );
 		$expected = array( $tableName => $definition );
 		$tableDefinitions = $instance->getTableDefinitions();
 
 		$this->assertFalse( $tableDefinitions[$tableName]->usesIdSubject() );
-
 	}
+
 }


### PR DESCRIPTION
Had a case where SESP is using "SMW::SQLStore::updatePropertyTableDefinitions" and interferes with the test.
