### PR TITLE
ListResultPrinter add extra information to the template output

### DIFF
--- a/includes/queryprinters/ListResultPrinter.php
+++ b/includes/queryprinters/ListResultPrinter.php
@@ -160,7 +160,7 @@ class ListResultPrinter extends ResultPrinter {
 		$result .= $this->header;
 
 		if ( $this->mIntroTemplate !== '' ) {
-			$result .= "{{" . $this->mIntroTemplate . "}}";
+			$result .= "{{" . $this->mIntroTemplate . $this->addCommonTemplateParameters( $queryResult ) . "}}";
 		}
 
 		while ( $row = $queryResult->getNext() ) {
@@ -168,7 +168,7 @@ class ListResultPrinter extends ResultPrinter {
 		}
 
 		if ( $this->mOutroTemplate !== '' ) {
-			$result .= "{{" . $this->mOutroTemplate . "}}";
+			$result .= "{{" . $this->mOutroTemplate . $this->addCommonTemplateParameters( $queryResult ) . "}}";
 		}
 
 		// Make label for finding further results
@@ -271,7 +271,7 @@ class ListResultPrinter extends ResultPrinter {
 
 		if ( $this->mTemplate !== '' ) { // Build template code
 			$this->hasTemplates = true;
-			$content = $this->mTemplate . $this->getTemplateContent( $row );
+			$content = $this->mTemplate . $this->getTemplateContent( $row ) . $this->addCommonTemplateParameters( $res );
 			$result .= $this->getRowStart( $res ) . '{{' . $content . '}}';
 		} else { // Build simple list
 			$content = $this->getRowListContent( $row );
@@ -387,7 +387,7 @@ class ListResultPrinter extends ResultPrinter {
 	 * @return string
 	 */
 	protected function getTemplateContent( $row ){
-		$wikitext = $this->mUserParam ? "|userparam=$this->mUserParam" : '';
+		$wikitext = '';
 
 		foreach ( $row as $i => $field ) {
 			$wikitext .= '|' . ( $this->mNamedArgs ? '?' . $field->getPrintRequest()->getLabel() : $i + 1 ) . '=';
@@ -405,6 +405,11 @@ class ListResultPrinter extends ResultPrinter {
 
 		$wikitext .= "|#={$this->numRows}";
 		return $wikitext;
+	}
+
+	protected function addCommonTemplateParameters( $queryResult ) {
+		return ( $this->mUserParam ? "|userparam=$this->mUserParam" : '' ) .
+			"|swm-resultquerycondition=" . $queryResult->getQuery()->getQueryString();
 	}
 
 	/**


### PR DESCRIPTION
- Make {{{userparam}}} available to intro and outro template as well
- Make the result querystring available to a template via {{{smw-resultquerycondition}}}

When using {{{smw-resultquerycondition}}} as parameter a template inherits the query condition from the source which enables to add additional output information (e.g. sum, average etc.) without having a
template to carry an explicit query condition.

The output (selection of printouts) is directly bound to the template definition but the query condition is template independent. 

```
{{#ask: [[Category:Country]]
 | ?Population
 | ?GDP
 | template=Country/Table
 | introtemplate=Country/Table/Intro
 | outrotemplate=Country/Table/Outro
 | format=template
 | link=none
}}

Template:Country/Table/Outro
<includeonly>
 | Total
 | {{#ask: {{{smw-resultquerycondition|}}} |?Population |format=sum}}
 | {{#ask: {{{smw-resultquerycondition|}}} |?GDP |format=sum}}
|}
</includeonly>
```
