### PR TITLE
Add custom ExecutionTimeTestListener

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -11,6 +11,14 @@
          stopOnSkipped="false"
          strict="true"
          verbose="true">
+    <listeners>
+        <listener file="tests/phpunit/ExecutionTimeTestListener.php" class="SMW\Test\ExecutionTimeTestListener">
+           <arguments>
+              <boolean>true</boolean>
+              <integer>10</integer>
+           </arguments>
+        </listener>
+    </listeners>
     <testsuites>
         <testsuite name="SemanticMediaWiki">
             <directory>tests/phpunit</directory>

--- a/tests/phpunit/ExecutionTimeTestListener.php
+++ b/tests/phpunit/ExecutionTimeTestListener.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace SMW\Test;
+
+use PHPUnit_Framework_TestSuite;
+use PHPUnit_Framework_TestListener;
+use PHPUnit_Framework_Test;
+use PHPUnit_Framework_AssertionFailedError;
+use Exception;
+
+class ExecutionTimeTestListener implements PHPUnit_Framework_TestListener {
+
+	protected $testCollector = array();
+	protected $executionTimeThresholdInSeconds = 10;
+	protected $isEnabledToListen = true;
+
+	public function __construct( $isEnabledToListen, $executionTimeThresholdInSeconds ) {
+		$this->isEnabledToListen = $isEnabledToListen;
+		$this->executionTimeThresholdInSeconds = $executionTimeThresholdInSeconds;
+	}
+
+	/**
+	 * @see PHPUnit_Framework_TestListener::startTest
+	 */
+	public function startTest( PHPUnit_Framework_Test $test ) {}
+
+	/**
+	 * @see PHPUnit_Framework_TestListener::endTest
+	 */
+	public function endTest( PHPUnit_Framework_Test $test, $length ) {
+		if ( $this->isEnabledToListen && ( $length > $this->executionTimeThresholdInSeconds ) ) {
+			$this->testCollector[ $test->getName() ] = round( $length, 3 );
+		}
+	}
+
+	/**
+	 * @see PHPUnit_Framework_TestListener::addError
+	 */
+	public function addError( PHPUnit_Framework_Test $test, Exception $e, $time ) {}
+
+	/**
+	 * @see PHPUnit_Framework_TestListener::addFailure
+	 */
+	public function addFailure( PHPUnit_Framework_Test $test, PHPUnit_Framework_AssertionFailedError $e, $time ) {}
+
+	/**
+	 * @see PHPUnit_Framework_TestListener::addError
+	 */
+	public function addIncompleteTest( PHPUnit_Framework_Test $test, Exception $e, $time ) {}
+
+	/**
+	 * @see PHPUnit_Framework_TestListener::addSkippedTest
+	 */
+	public function addSkippedTest( PHPUnit_Framework_Test $test, Exception $e, $time ) {}
+
+	/**
+	 * @see PHPUnit_Framework_TestListener::startTestSuite
+	 */
+	public function startTestSuite( PHPUnit_Framework_TestSuite $suite ) {}
+
+	/**
+	 * @see PHPUnit_Framework_TestListener::endTestSuite
+	 */
+	public function endTestSuite( PHPUnit_Framework_TestSuite $suite ) {
+		foreach ( $this->testCollector as $name => $length ) {
+			print( "\n" . $suite->getName() . " {$name} ran for {$length} seconds" . "\n" );
+			unset( $this->testCollector[ $name ] );
+		}
+	}
+
+}


### PR DESCRIPTION
Enables to report long running test. The `phpunit.xml` supports the following settings:
- First argument enables/disables the output of the listener
- Second argument specifies the threshold in seconds as to when the listener should report a test.

```
<listeners>
<listener ...>
   <arguments>
      <boolean>true</boolean>
      <integer>10</integer>
   </arguments>
</listener>
</listeners>
```
