### PR TITLE
Add SimplePageRedirectRegressionTest

### DIFF
--- a/tests/phpunit/helper/JobQueueRunner.php
+++ b/tests/phpunit/helper/JobQueueRunner.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace SMW\Test;
+
+use Job;
+
+/**
+ * Partly copied from the MW 1.19 RunJobs maintenance script
+ *
+ * @ingroup Test
+ *
+ * @group SMW
+ * @group SMWExtension
+ *
+ * @licence GNU GPL v2+
+ * @since 1.9.2
+ */
+class JobQueueRunner {
+
+	protected $type = null;
+	protected $status = array();
+	protected $dbConnection = null;
+
+	/**
+	 * @since 1.9.2
+	 *
+	 * @return string $type
+	 */
+	public function __construct( $type = null ) {
+		$this->type = $type;
+	}
+
+	/**
+	 * @since 1.9.2
+	 */
+	public function execute() {
+
+		$conds = '';
+
+		if ( $this->type !== null ) {
+			$conds = "job_cmd = " . $this->getDatabase()->addQuotes( $this->type );
+		}
+
+		while ( $this->getDatabase()->selectField( 'job', 'job_id', $conds, __METHOD__ ) ) {
+			$offset = 0;
+
+			$job = $this->type === null ? Job::pop( $offset ) : Job::pop_type( $this->type );
+
+			if ( !$job ) {
+				break;
+			}
+
+			wfWaitForSlaves();
+
+			$this->status[] = array(
+				'type'   => $job->command,
+				'status' => $job->run()
+			);
+		}
+	}
+
+	/**
+	 * @since 1.9.2
+	 *
+	 * @return array
+	 */
+	public function getStatus() {
+		return $this->status;
+	}
+
+	protected function getDatabase() {
+
+		if ( $this->dbConnection === null ) {
+			$this->dbConnection = wfGetDB( DB_MASTER );
+		}
+
+		return $this->dbConnection;
+	}
+
+}

--- a/tests/phpunit/regression/SimplePageRedirectRegressionTest.php
+++ b/tests/phpunit/regression/SimplePageRedirectRegressionTest.php
@@ -1,0 +1,163 @@
+<?php
+
+namespace SMW\Test;
+
+use SMW\DIWikiPage;
+use SMW\DIProperty;
+
+use Title;
+
+/**
+ * @ingroup Test
+ *
+ * @group SMW
+ * @group SMWExtension
+ * @group RegressionTest
+ * @group Database
+ * @group medium
+ *
+ * @licence GNU GPL v2+
+ * @since 1.9.2
+ *
+ * @author mwjames
+ */
+class SimplePageRedirectRegressionTest extends MwRegressionTestCase {
+
+	public function getSourceFile() {
+		return __DIR__ . '/data/' . 'SimplePageRedirectRegressionTest-Mw-1-19-7.xml';
+	}
+
+	public function acquirePoolOfTitles() {
+		return array(
+			'SimplePageRedirectRegressionTest',
+			'ToBeSimplePageRedirect'
+		);
+	}
+
+	public function assertDataImport() {
+
+		$main = Title::newFromText( 'SimplePageRedirectRegressionTest' );
+
+		$expectedCategoryAsWikiValue = array(
+			'property' => new DIProperty( DIProperty::TYPE_CATEGORY ),
+			'propertyValues' => array(
+				'Regression test',
+				'Redirect test',
+				'Simple redirect test'
+			)
+		);
+
+		$expectedSomeProperties = array(
+			'properties' => array(
+				new DIProperty( 'Has regression test' )
+			)
+		);
+
+		$expectedRedirectAsWikiValue = array(
+			'property' => new DIProperty( '_REDI' ),
+			'propertyValues' => array(
+				'ToBeSimplePageRedirect',
+				'NewTargetPageRedirectRegressionTest'
+			)
+		);
+
+		$newRedirectPage = $this->createPageWithRedirectFor(
+			'NewPageRedirectRegressionTest',
+			'SimplePageRedirectRegressionTest'
+		);
+
+		$this->movePageToTargetWithRedirect(
+			$newRedirectPage,
+			'NewTargetPageRedirectRegressionTest'
+		);
+
+		$this->executeJobQueueRunner( 'SMW\UpdateJob' );
+
+		$this->semanticDataValidator = new SemanticDataValidator;
+
+		$semanticDataFinder = new ByPageSemanticDataFinder;
+		$semanticDataFinder->setTitle( $main )->setStore( $this->getStore() );
+
+		$semanticDataBatches = array(
+			$semanticDataFinder->fetchFromOutput(),
+			$semanticDataFinder->fetchFromStore()
+		);
+
+		$incomingSemanticData = $semanticDataFinder->fetchIncomingDataFromStore();
+
+		foreach ( $semanticDataBatches as $semanticData ) {
+
+			$this->semanticDataValidator->assertThatCategoriesAreSet(
+				$expectedCategoryAsWikiValue,
+				$semanticData
+			);
+
+			$this->semanticDataValidator->assertThatPropertiesAreSet(
+				$expectedSomeProperties,
+				$semanticData
+			);
+		}
+
+		// Due to a ContentHandler issue in MW 1.23 the assert should not check
+		// for empty, for now we use empty in order to monitor the issue
+		// @see #212 and bug 62856
+		$this->assertEmpty( $incomingSemanticData->getPropertyValues( new DIProperty( '_REDI' ) ) );
+
+		// Same issue as above
+		//	$this->assertThatSemanticDataValuesForPropertyAreSet(
+		//		$expectedRedirectAsWikiValue,
+		//		$incomingSemanticData
+		//	);
+	}
+
+	protected function assertThatSemanticDataValuesForPropertyAreSet( $expected, $semanticData ) {
+
+		$runValueAssert = false;
+
+		foreach ( $semanticData->getProperties() as $property ) {
+
+			if ( $property->equals( $expected['property'] ) ) {
+				$runValueAssert = true;
+				$this->semanticDataValidator->assertThatPropertyValuesAreSet(
+					$expected,
+					$property,
+					$semanticData->getPropertyValues( $property )
+				);
+			}
+
+		}
+
+		// Issue #124 needs to be resolved first
+		// $this->assertTrue( $runValueAssert, __METHOD__ );
+	}
+
+	protected function createPageWithRedirectFor( $source, $target ) {
+
+		$pageCreator = new PageCreator();
+		$pageCreator
+			->createPage( Title::newFromText( $source ) )
+			->doEdit( "#REDIRECT [[{$target}]]" );
+
+		return $pageCreator->getPage();
+	}
+
+	protected function movePageToTargetWithRedirect( $page, $target ) {
+
+		$moveToTargetTitle = Title::newFromText( $target );
+
+		return $page->getTitle()->moveTo(
+			$moveToTargetTitle,
+			false,
+			'create redirect',
+			true
+		);
+	}
+
+	protected function executeJobQueueRunner( $type = null ) {
+		$jobQueueRunner = new JobQueueRunner( $type );
+		$jobQueueRunner->execute();
+
+		return $jobQueueRunner;
+	}
+
+}

--- a/tests/phpunit/regression/data/SimplePageRedirectRegressionTest-Mw-1-19-7.xml
+++ b/tests/phpunit/regression/data/SimplePageRedirectRegressionTest-Mw-1-19-7.xml
@@ -1,0 +1,80 @@
+<mediawiki xmlns="http://www.mediawiki.org/xml/export-0.6/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.mediawiki.org/xml/export-0.6/ http://www.mediawiki.org/xml/export-0.6.xsd" version="0.6" xml:lang="en-gb">
+  <siteinfo>
+    <sitename>MW-19</sitename>
+    <base>http://localhost:8080/w/index.php/Main_Page</base>
+    <generator>MediaWiki 1.19.7</generator>
+    <case>first-letter</case>
+    <namespaces>
+      <namespace key="-2" case="first-letter">Media</namespace>
+      <namespace key="-1" case="first-letter">Special</namespace>
+      <namespace key="0" case="first-letter" />
+      <namespace key="1" case="first-letter">Talk</namespace>
+      <namespace key="2" case="first-letter">User</namespace>
+      <namespace key="3" case="first-letter">User talk</namespace>
+      <namespace key="4" case="first-letter">MW-19</namespace>
+      <namespace key="5" case="first-letter">MW-19 talk</namespace>
+      <namespace key="6" case="first-letter">File</namespace>
+      <namespace key="7" case="first-letter">File talk</namespace>
+      <namespace key="8" case="first-letter">MediaWiki</namespace>
+      <namespace key="9" case="first-letter">MediaWiki talk</namespace>
+      <namespace key="10" case="first-letter">Template</namespace>
+      <namespace key="11" case="first-letter">Template talk</namespace>
+      <namespace key="12" case="first-letter">Help</namespace>
+      <namespace key="13" case="first-letter">Help talk</namespace>
+      <namespace key="14" case="first-letter">Category</namespace>
+      <namespace key="15" case="first-letter">Category talk</namespace>
+      <namespace key="102" case="first-letter">Property</namespace>
+      <namespace key="103" case="first-letter">Property talk</namespace>
+      <namespace key="104" case="first-letter">Type</namespace>
+      <namespace key="105" case="first-letter">Type talk</namespace>
+      <namespace key="108" case="first-letter">Concept</namespace>
+      <namespace key="109" case="first-letter">Concept talk</namespace>
+      <namespace key="160" case="first-letter">Foo</namespace>
+      <namespace key="161" case="first-letter">Foo talk</namespace>
+    </namespaces>
+  </siteinfo>
+  <page>
+    <title>Property:Has regression test</title>
+    <ns>102</ns>
+    <id>487</id>
+      <sha1>byqsaznmj8muv1x9qm7hky0dlasesr9</sha1>
+    <revision>
+      <id>1308</id>
+      <timestamp>2014-03-19T20:18:21Z</timestamp>
+      <contributor>
+        <username>Tester</username>
+      </contributor>
+      <comment>Created page with &quot;[[Has type::Page]]&quot;</comment>
+      <text xml:space="preserve" bytes="18">[[Has type::Page]]</text>
+    </revision>
+  </page>
+  <page>
+    <title>ToBeSimplePageRedirect</title>
+    <ns>0</ns>
+    <id>484</id>
+    <redirect title="SimplePageRedirectRegressionTest" />
+      <sha1>cbkrfrdppwskfozybbkna7avfn6fkz4</sha1>
+    <revision>
+      <id>1309</id>
+      <timestamp>2014-03-19T20:19:25Z</timestamp>
+      <contributor>
+        <username>Tester</username>
+      </contributor>
+      <text xml:space="preserve" bytes="80">#REDIRECT [[SimplePageRedirectRegressionTest]] [[Category:Simple redirect test]]</text>
+    </revision>
+  </page>
+  <page>
+    <title>SimplePageRedirectRegressionTest</title>
+    <ns>0</ns>
+    <id>483</id>
+      <sha1>d4d7j2mio0bveyg8dqqmumbz5pcie9n</sha1>
+    <revision>
+      <id>1307</id>
+      <timestamp>2014-03-19T20:17:57Z</timestamp>
+      <contributor>
+        <username>Tester</username>
+      </contributor>
+      <text xml:space="preserve" bytes="184">This is part of the [[PageRedirectRegressionTest]] [[Category:Regression test]] [[Category:Redirect test]] [[Category:Simple redirect test]] {{#set:|Has regression test=Redirect test}}</text>
+    </revision>
+  </page>
+</mediawiki>


### PR DESCRIPTION
Adds a minimal regression test for redirects. A quick test to avoid failures as seen by #230 due to missing test coverage.

Also relates to #231, #212
