### PR TITLE
SMW\Store\Maintenance\DataRebuilder pre-fetch data for filters

### DIFF
--- a/includes/src/MediaWiki/MwTitleLookup.php
+++ b/includes/src/MediaWiki/MwTitleLookup.php
@@ -1,0 +1,149 @@
+<?php
+
+namespace SMW\MediaWiki;
+
+use Title;
+use UnexpectedValueException;
+
+/**
+ * A convenience class to encapsulate MW related database interaction
+ *
+ * @note This is an internal class and should not be used outside of smw-core
+ *
+ * @ingroup SMW
+ *
+ * @licence GNU GPL v2+
+ * @since 1.9.2
+ *
+ * @author mwjames
+ */
+class MwTitleLookup {
+
+	/** @var Database */
+	protected $database = null;
+
+	protected $namespace = null;
+
+	/**
+	 * @since 1.9.2
+	 *
+	 * @param Database $database
+	 */
+	public function __construct( Database $database ) {
+		$this->database = $database;
+	}
+
+	/**
+	 * @since 1.9.2
+	 *
+	 * @param int $namespace
+	 *
+	 * @return TitleLookup
+	 */
+	public function byNamespace( $namespace ) {
+		$this->namespace = $namespace;
+		return $this;
+	}
+
+	/**
+	 * @since 1.9.2
+	 *
+	 * @return Title[]
+	 * @throws UnexpectedValueException
+	 */
+	public function selectAll() {
+
+		if ( $this->namespace === null ) {
+			throw new UnexpectedValueException( 'Unrestricted selection without a namespace is not supported' );
+		}
+
+		if ( $this->namespace === NS_CATEGORY ) {
+			$tableName = 'category';
+			$fields = array( 'cat_title' );
+			$conditions = '';
+			$options = array( 'USE INDEX' => 'cat_title' );
+		} else {
+			$tableName = 'page';
+			$fields = array( 'page_namespace', 'page_title' );
+			$conditions = array( 'page_namespace' => $this->namespace );
+			$options = array( 'USE INDEX' => 'PRIMARY' );
+		}
+
+		$res = $this->database->select(
+			$tableName,
+			$fields,
+			$conditions,
+			__METHOD__,
+			$options
+		);
+
+		return $this->makeTitlesFromSelection( $res );
+	}
+
+	/**
+	 * @since 1.9.2
+	 *
+	 * @param int $startId
+	 * @param int $endId
+	 *
+	 * @return Title[]
+	 * @throws UnexpectedValueException
+	 */
+	public function selectByIdRange( $startId = 0, $endId = 0 ) {
+
+		if ( $this->namespace === null ) {
+			throw new UnexpectedValueException( 'Unrestricted selection without a namespace is not supported' );
+		}
+
+		if ( $this->namespace === NS_CATEGORY ) {
+			$tableName = 'category';
+			$fields = array( 'cat_title', 'cat_id' );
+			$conditions = array( "cat_id BETWEEN $startId AND $endId" );
+			$options = array( 'ORDER BY' => 'cat_id ASC', 'USE INDEX' => 'cat_title' );
+		} else {
+			$tableName = 'page';
+			$fields = array( 'page_namespace', 'page_title', 'page_id' );
+			$conditions = array( "page_id BETWEEN $startId AND $endId" ) + array( 'page_namespace' => $this->namespace );
+			$options = array( 'ORDER BY' => 'page_id ASC', 'USE INDEX' => 'PRIMARY' );
+		}
+
+		$res = $this->database->select(
+			$tableName,
+			$fields,
+			$conditions,
+			__METHOD__,
+			$options
+		);
+
+		return $this->makeTitlesFromSelection( $res );
+	}
+
+	protected function makeTitlesFromSelection( $res ) {
+
+		$pages = array();
+
+		if ( $res === false ) {
+			return $pages;
+		}
+
+		foreach ( $res as $row ) {
+			$pages[] = $this->newTitleFromRow( $row );
+		}
+
+		return $pages;
+	}
+
+	private function newTitleFromRow( $row ) {
+
+		if ( $this->namespace === NS_CATEGORY ) {
+			$ns = NS_CATEGORY;
+			$title = $row->cat_title;
+		} else {
+			$ns =  $row->page_namespace;
+			$title = $row->page_title;
+		}
+
+		return Title::makeTitle( $ns, $title );
+	}
+
+}

--- a/maintenance/SMW_refreshData.php
+++ b/maintenance/SMW_refreshData.php
@@ -3,7 +3,7 @@
 /**
  * This script will be forwarded to rebuildData.php.
  *
- * @Deprecated 1.9.2 This maintenance script has been deprecated, please use
+ * @deprecated 1.9.2 This maintenance script has been deprecated, please use
  * rebuildData.php instead.
  */
 require_once ( 'rebuildData.php' );

--- a/tests/phpunit/includes/MediaWiki/MwTitleLookupTest.php
+++ b/tests/phpunit/includes/MediaWiki/MwTitleLookupTest.php
@@ -1,0 +1,185 @@
+<?php
+
+namespace SMW\Tests\MediaWiki;
+
+use SMW\MediaWiki\MwTitleLookup;
+
+use Title;
+
+/**
+ * @covers \SMW\MediaWiki\MwTitleLookup
+ *
+ * @ingroup Test
+ *
+ * @group SMW
+ * @group SMWExtension
+ * @group semantic-mediawiki-unit
+ * @group mediawiki-databaseless
+ *
+ * @license GNU GPL v2+
+ * @since 1.9.2
+ *
+ * @author mwjames
+ */
+class MwTitleLookupTest extends \PHPUnit_Framework_TestCase {
+
+	public function testCanConstruct() {
+
+		$database = $this->getMockBuilder( '\SMW\MediaWiki\Database' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$this->assertInstanceOf(
+			'\SMW\MediaWiki\MwTitleLookup',
+			new MwTitleLookup( $database )
+		);
+	}
+
+	public function testSelectAllOnCategoryNamespace() {
+
+		$row = new \stdClass;
+		$row->cat_title = 'Foo';
+
+		$database = $this->getMockBuilder( '\SMW\MediaWiki\Database' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$database->expects( $this->any() )
+			->method( 'select' )
+			->with( $this->stringContains( 'category' ),
+				$this->anything(),
+				$this->anything(),
+				$this->anything(),
+				$this->anything() )
+			->will( $this->returnValue( array( $row ) ) );
+
+		$instance = new MwTitleLookup( $database );
+
+		$this->assertArrayOfTitles( $instance->byNamespace( NS_CATEGORY )->selectAll() );
+	}
+
+	public function testSelectAllOnMainNamespace() {
+
+		$row = new \stdClass;
+		$row->page_namespace = NS_MAIN;
+		$row->page_title = 'Bar';
+
+		$database = $this->getMockBuilder( '\SMW\MediaWiki\Database' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$database->expects( $this->any() )
+			->method( 'select' )
+			->with( $this->anything(),
+				$this->anything(),
+				$this->equalTo( array( 'page_namespace' => NS_MAIN ) ),
+				$this->anything(),
+				$this->anything() )
+			->will( $this->returnValue( array( $row ) ) );
+
+		$instance = new MwTitleLookup( $database );
+
+		$this->assertArrayOfTitles( $instance->byNamespace( NS_MAIN )->selectAll() );
+	}
+
+	public function testSelectByRangeOnCategoryNamespace() {
+
+		$row = new \stdClass;
+		$row->cat_title = 'Foo';
+
+		$database = $this->getMockBuilder( '\SMW\MediaWiki\Database' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$database->expects( $this->any() )
+			->method( 'select' )
+			->with( $this->stringContains( 'category' ),
+				$this->anything(),
+				$this->equalTo( array( "cat_id BETWEEN 1 AND 5" ) ),
+				$this->anything(),
+				$this->anything() )
+			->will( $this->returnValue( array( $row ) ) );
+
+		$instance = new MwTitleLookup( $database );
+
+		$this->assertArrayOfTitles( $instance->byNamespace( NS_CATEGORY )->selectByIdRange( 1, 5 ) );
+	}
+
+	public function testSelectByRangeOnMainNamespace() {
+
+		$row = new \stdClass;
+		$row->page_namespace = NS_MAIN;
+		$row->page_title = 'Bar';
+
+		$database = $this->getMockBuilder( '\SMW\MediaWiki\Database' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$database->expects( $this->any() )
+			->method( 'select' )
+			->with( $this->anything(),
+				$this->anything(),
+				$this->equalTo( array( "page_id BETWEEN 6 AND 10", 'page_namespace' => NS_MAIN ) ),
+				$this->anything(),
+				$this->anything() )
+			->will( $this->returnValue( array( $row ) ) );
+
+		$instance = new MwTitleLookup( $database );
+
+		$this->assertArrayOfTitles( $instance->byNamespace( NS_MAIN )->selectByIdRange( 6, 10 ) );
+	}
+
+	public function testSelectAllOnMainNamespaceWithEmptyResult() {
+
+		$database = $this->getMockBuilder( '\SMW\MediaWiki\Database' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$database->expects( $this->any() )
+			->method( 'select' )
+			->with( $this->anything(),
+				$this->anything(),
+				$this->equalTo( array( 'page_namespace' => NS_MAIN ) ),
+				$this->anything(),
+				$this->anything() )
+			->will( $this->returnValue( false ) );
+
+		$instance = new MwTitleLookup( $database );
+
+		$this->assertArrayOfTitles( $instance->byNamespace( NS_MAIN )->selectAll() );
+	}
+
+	public function testSelectAllOnMissingNamespaceThrowsException() {
+
+		$this->setExpectedException( 'UnexpectedValueException' );
+
+		$database = $this->getMockBuilder( '\SMW\MediaWiki\Database' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$instance = new MwTitleLookup( $database );
+		$instance->selectAll();
+	}
+
+	public function testSelectByRangeOnMissingNamespaceThrowsException() {
+
+		$this->setExpectedException( 'UnexpectedValueException' );
+
+		$database = $this->getMockBuilder( '\SMW\MediaWiki\Database' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$instance = new MwTitleLookup( $database );
+		$instance->selectByIdRange( 1, 5 );
+	}
+
+	protected function assertArrayOfTitles( $arrayOfTitles ) {
+
+		$this->assertInternalType( 'array', $arrayOfTitles );
+
+		foreach ( $arrayOfTitles as $title ) {
+			$this->assertInstanceOf( 'Title', $title );
+		}
+	}
+
+}

--- a/tests/phpunit/includes/Store/Maintenance/DataRebuilderTest.php
+++ b/tests/phpunit/includes/Store/Maintenance/DataRebuilderTest.php
@@ -13,6 +13,8 @@ use Title;
  *
  * @group SMW
  * @group SMWExtension
+ * @group semantic-mediawiki-unit
+ * @group mediawiki-databaseless
  *
  * @license GNU GPL v2+
  * @since 1.9.2
@@ -207,6 +209,95 @@ class DataRebuilderTest extends \PHPUnit_Framework_TestCase {
 
 		$instance->setParameters( array(
 			'query' => '[[Category:Foo]]'
+		) );
+
+		$this->assertTrue( $instance->rebuild() );
+	}
+
+	public function testRebuildSelectedPagesWithCategoryNamespaceFilter() {
+
+		$row = new \stdClass;
+		$row->cat_title = 'Foo';
+
+		$database = $this->getMockBuilder( '\SMW\MediaWiki\Database' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$database->expects( $this->any() )
+			->method( 'select' )
+			->with( $this->stringContains( 'category' ),
+				$this->anything(),
+				$this->anything(),
+				$this->anything(),
+				$this->anything() )
+			->will( $this->returnValue( array( $row ) ) );
+
+		$store = $this->getMockBuilder( '\SMWSQLStore3' )
+			->disableOriginalConstructor()
+			->setMethods( array( 'getDatabase' ) )
+			->getMock();
+
+		$store->expects( $this->once() )
+			->method( 'getDatabase' )
+			->will( $this->returnValue( $database ) );
+
+		$messagereporter = $this->getMockBuilder( '\SMW\Messagereporter' )
+			->disableOriginalConstructor()
+			->setMethods( array( 'reportMessage' ) )
+			->getMock();
+
+		$instance = new DataRebuilder(
+			$store,
+			$messagereporter
+		);
+
+		$instance->setParameters( array(
+			'c' => true
+		) );
+
+		$this->assertTrue( $instance->rebuild() );
+	}
+
+	public function testRebuildSelectedPagesWithPropertyNamespaceFilter() {
+
+		$row = new \stdClass;
+		$row->page_namespace = SMW_NS_PROPERTY;
+		$row->page_title = 'Bar';
+
+		$database = $this->getMockBuilder( '\SMW\MediaWiki\Database' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$database->expects( $this->any() )
+			->method( 'select' )
+			->with( $this->anything(),
+				$this->anything(),
+				$this->equalTo( array( 'page_namespace' => SMW_NS_PROPERTY ) ),
+				$this->anything(),
+				$this->anything() )
+			->will( $this->returnValue( array( $row ) ) );
+
+		$store = $this->getMockBuilder( '\SMWSQLStore3' )
+			->disableOriginalConstructor()
+			->setMethods( array( 'getDatabase' ) )
+			->getMock();
+
+		$store->expects( $this->once() )
+			->method( 'getDatabase' )
+			->will( $this->returnValue( $database ) );
+
+		$messagereporter = $this->getMockBuilder( '\SMW\Messagereporter' )
+			->disableOriginalConstructor()
+			->setMethods( array( 'reportMessage' ) )
+			->getMock();
+
+		$instance = new DataRebuilder(
+			$store,
+			$messagereporter
+		);
+
+		$instance->setParameters( array(
+			'p' => true
 		) );
 
 		$this->assertTrue( $instance->rebuild() );


### PR DESCRIPTION
For options `-c/-p` `$this->store->refreshData( ... )` is being swamped with unrelated Id's that do not belong to a selected filter and to avoid unnecessary waste of resources by calling `refreshData`, data are pre-fetched from the DB in order to match the filter.
