### PR TITLE
Start to remove GLOBAL state from Store / add StoreConfig

### DIFF
--- a/includes/src/Cache/InMemoryCache.php
+++ b/includes/src/Cache/InMemoryCache.php
@@ -1,0 +1,112 @@
+<?php
+
+namespace SMW\Cache;
+
+/**
+ * @ingroup Cache
+ *
+ * @license GNU GPL v2+
+ * @since 1.9.3
+ *
+ * @author mwjames
+ */
+class InMemoryCache {
+
+	protected $cache = array();
+	protected $expiry = array();
+
+	/**
+	 * @since 1.9.3
+	 *
+	 * @param array $cache
+	 */
+	public function __construct( $cache = array() ) {
+		$this->cache = $cache;
+	}
+
+	/**
+	 * @since 1.9.3
+	 *
+	 * @param string $key
+	 *
+	 * @return boolean
+	 */
+	public function has( $key ) {
+		return isset( $this->cache[ $key ] ) || array_key_exists( $key, $this->cache );
+	}
+
+	/**
+	 * @since 1.9.3
+	 *
+	 * @param string $key
+	 *
+	 * @return mixed|false
+	 */
+	public function get( $key ) {
+
+		if ( $this->has( $key ) ) {
+			return $this->fetchValueOrRemoveIfNotExists( $key );
+		}
+
+		return false;
+	}
+
+	/**
+	 * @since 1.9.3
+	 *
+	 * @param string $key
+	 * @param mixed $value
+	 * @param integer $expiryTime in seconds
+	 *
+	 * @return boolean
+	 */
+	public function set( $key, $value, $expiryTime = 0 ) {
+
+		$this->cache[ $key ] = $value;
+
+		if ( $expiryTime !== 0 ) {
+			$this->expiry[ $key ] = time() + $expiryTime;
+		}
+
+		return true;
+	}
+
+	/**
+	 * @since 1.9.3
+	 *
+	 * @param string $key
+	 *
+	 * @return boolean
+	 */
+	public function delete( $key ) {
+
+		if ( $this->has( $key ) ) {
+			unset( $this->cache[ $key ] );
+			unset( $this->expiry[ $key ] );
+			return true;
+		}
+
+		return false;
+	}
+
+	/**
+	 * @since 1.9.3
+	 *
+	 * @return boolean
+	 */
+	public function isSafe() {
+		return true;
+	}
+
+	private function fetchValueOrRemoveIfNotExists( $key ) {
+
+		if ( !isset( $this->expiry[ $key ] ) || $this->expiry[ $key ] >= time() ) {
+			return $this->cache[ $key ];
+		}
+
+		$this->delete( $key );
+
+		return false;
+	}
+
+}

--- a/includes/src/Store/StoreConfig.php
+++ b/includes/src/Store/StoreConfig.php
@@ -1,0 +1,112 @@
+<?php
+
+namespace SMW\Store;
+
+use SMW\Cache\InMemoryCache;
+use SMW\Settings;
+
+use InvalidArgumentException;
+
+/**
+ * Provide access to configurations only relevant to a Store
+ *
+ * @ingroup Configuration
+ *
+ * @license GNU GPL v2+
+ * @since 1.9.3
+ *
+ * @author mwjames
+ */
+class StoreConfig {
+
+	/** @var InMemoryCache */
+	protected $configuration = null;
+
+	/** @var array */
+	protected $supportedConfigurationKeys = array(
+		'smwgDefaultStore',
+		'smwgFixedProperties',
+		'smwgPageSpecialProperties',
+		'smwgIgnoreQueryErrors',
+		'smwgQSortingSupport',
+		'smwgQRandSortingSupport',
+		'smwgAutoRefreshSubject',
+		'smwgQMaxLimit',
+		'smwgQMaxSize',
+		'smwgQConceptFeatures',
+		'smwgQConceptCaching',
+		'smwgQSubpropertyDepth',
+		'smwgQSubcategoryDepth',
+		'smwgQEqualitySupport',
+		'smwgEnableUpdateJobs'
+	);
+
+	/**
+	 * @since 1.9.3
+	 *
+	 * @param Settings|null $settings
+	 */
+	public function __construct( Settings $settings = null ) {
+		$this->configuration = $this->initConfigurationFromSettings( $settings );
+	}
+
+	/**
+	 * @since 1.9.3
+	 *
+	 * @param string $key
+	 *
+	 * @return mixed
+	 * @throws InvalidArgumentException
+	 */
+	public function get( $key ) {
+
+		if ( $this->configuration->has( $key ) ) {
+			return $this->configuration->get( $key );
+		}
+
+		throw new InvalidArgumentException( "Expected a valid {$key} key" );
+	}
+
+	/**
+	 * @since 1.9.3
+	 *
+	 * @param $key
+	 * @param $value
+	 *
+	 * @return StoreConfig
+	 */
+	public function set( $key, $value ) {
+
+		$this->configuration->set(
+			$this->isSupportedConfigurationKeyOrThrowException( $key ),
+			$value
+		);
+
+		return $this;
+	}
+
+	private function initConfigurationFromSettings( Settings $settings = null ) {
+
+		if ( $settings === null ) {
+			$settings = Settings::newFromGlobals();
+		}
+
+		$configuration = new InMemoryCache();
+
+		foreach ( $this->supportedConfigurationKeys as $key ) {
+			$configuration->set( $key, $settings->get( $key ) );
+		}
+
+		return $configuration;
+	}
+
+	private function isSupportedConfigurationKeyOrThrowException( $key ) {
+
+		if ( in_array( $key, $this->supportedConfigurationKeys ) ) {
+			return $key;
+		}
+
+		throw new InvalidArgumentException( "{$key} is not supported as configuration key" );
+	}
+
+}

--- a/includes/storage/SMW_Store.php
+++ b/includes/storage/SMW_Store.php
@@ -2,6 +2,8 @@
 
 namespace SMW;
 
+use SMW\Store\StoreConfig;
+
 use HTMLFileCache;
 use SMWDataItem;
 use SMWDIProperty;
@@ -34,14 +36,9 @@ use Title;
 abstract class Store {
 
 	/**
-	 * FIXME THIS SHOULD NOT BE STATIC
-	 *
-	 * getPropertyTables is used all over the Store in a static manner
-	 * but its needs needs access to the configuration therefore once
-	 * all static calls are removed, turn this into a normal protected
-	 * variable
+	 * @var StoreConfig
 	 */
-	protected static $configuration = null;
+	protected $configuration = null;
 
 ///// Reading methods /////
 
@@ -456,10 +453,17 @@ abstract class Store {
 	}
 
 	/**
-	 * @since 1.9.1.1
+	 * @since 1.9.3
 	 */
-	public function setConfiguration( Settings $configuration ) {
-		self::$configuration = $configuration;
+	public function setConfiguration( StoreConfig $configuration ) {
+		$this->configuration = $configuration;
+	}
+
+	/**
+	 * @since 1.9.3
+	 */
+	public function getConfiguration() {
+		return $this->configuration;
 	}
 
 }

--- a/includes/storage/SQLStore/SMW_SQLStore3.php
+++ b/includes/storage/SQLStore/SMW_SQLStore3.php
@@ -834,10 +834,7 @@ class SMWSQLStore3 extends SMWStore {
 		$enabledSpecialProperties = self::$fixedSpecialProperties;
 		$customizableSpecialProperties = array_flip( self::$customizableSpecialProperties );
 
-		$customFixedProperties = self::$configuration->get( 'smwgFixedProperties' );
-		$customSpecialProperties = self::$configuration->get( 'smwgPageSpecialProperties' );
-
-		foreach ( $customSpecialProperties as $property ) {
+		foreach ( $this->getConfiguration()->get( 'smwgPageSpecialProperties' ) as $property ) {
 			if ( isset( $customizableSpecialProperties[$property] ) ) {
 				$enabledSpecialProperties[] = $property;
 			}
@@ -846,7 +843,7 @@ class SMWSQLStore3 extends SMWStore {
 		$definitionBuilder = new PropertyTableDefinitionBuilder(
 			self::$di_type_tables,
 			$enabledSpecialProperties,
-			$customFixedProperties
+			$this->getConfiguration()->get( 'smwgFixedProperties' )
 		);
 
 		$definitionBuilder->runBuilder();

--- a/includes/storage/SQLStore/SMW_SQLStore3_Writers.php
+++ b/includes/storage/SQLStore/SMW_SQLStore3_Writers.php
@@ -690,9 +690,9 @@ class SMWSQLStore3Writers {
 	 * @param integer $redirid
 	 */
 	public function changeTitle( Title $oldtitle, Title $newtitle, $pageid, $redirid = 0 ) {
-		global $smwgQEqualitySupport;
 		wfProfileIn( "SMWSQLStore3::changeTitle (SMW)" );
 
+		$smwgQEqualitySupport = $this->store->getConfiguration()->get( 'smwgQEqualitySupport' );
 		$db = $this->store->getDatabase();
 
 		// get IDs but do not resolve redirects:
@@ -910,7 +910,9 @@ class SMWSQLStore3Writers {
 	 * @return integer the new canonical ID of the subject
 	 */
 	protected function updateRedirects( $subject_t, $subject_ns, $curtarget_t = '', $curtarget_ns = -1 ) {
-		global $smwgQEqualitySupport, $smwgEnableUpdateJobs;
+
+		$smwgQEqualitySupport = $this->store->getConfiguration()->get( 'smwgQEqualitySupport' );
+		$smwgEnableUpdateJobs = $this->store->getConfiguration()->get( 'smwgEnableUpdateJobs' );
 
 		$count = 0; //track count changes for redi property
 		$db = $this->store->getDatabase();
@@ -1042,7 +1044,6 @@ class SMWSQLStore3Writers {
 			}
 		}
 
-		/// NOTE: this only happens if $smwgEnableUpdateJobs is true
 		if ( $smwgEnableUpdateJobs ) {
 			Job::batchInsert( $jobs );
 		}

--- a/maintenance/rebuildData.php
+++ b/maintenance/rebuildData.php
@@ -98,14 +98,10 @@ class RebuildData extends \Maintenance {
 		$reporter = new ObservableMessageReporter();
 		$reporter->registerReporterCallback( array( $this, 'reportMessage' ) );
 
-		$settings = Settings::newFromGlobals();
+		$store = StoreFactory::getStore( $this->hasOption( 'b' ) ? $this->getOption( 'b' ) : null );
 
 		// Do not fork additional update jobs while running this script
-		$settings->set( 'smwgEnableUpdateJobs', false );
-		$GLOBALS['smwgEnableUpdateJobs'] = false; // Some Store classes still rely on GLOBALS
-
-		$store = StoreFactory::getStore( $this->hasOption( 'b' ) ? $this->getOption( 'b' ) : null );
-		$store->setConfiguration( $settings );
+		$store->getConfiguration()->set( 'smwgEnableUpdateJobs', false );
 
 		$dataRebuilder = new DataRebuilder( $store, $reporter );
 		$dataRebuilder->setParameters( $this->mOptions );

--- a/tests/phpunit/includes/Store/SqlStore/SqlStoreWriterChangeTitleTest.php
+++ b/tests/phpunit/includes/Store/SqlStore/SqlStoreWriterChangeTitleTest.php
@@ -2,7 +2,9 @@
 
 namespace SMW\Tests\Store\SqlStore;
 
-use \SMWSQLStore3Writers;
+use SMW\Store\StoreConfig;
+
+use SMWSQLStore3Writers;
 use SMW\SemanticData;
 use SMW\DIWikiPage;
 
@@ -92,6 +94,10 @@ class SqlStoreWriterChangeTitleTest extends \PHPUnit_Framework_TestCase {
 			->method( 'getPropertyTables' )
 			->will( $this->returnValue( array() ) );
 
+		$parentStore->expects( $this->atLeastOnce() )
+			->method( 'getConfiguration' )
+			->will( $this->returnValue( new StoreConfig() ) );
+
 		$instance = new SMWSQLStore3Writers( $parentStore );
 
 		$instance->changeTitle(
@@ -161,6 +167,10 @@ class SqlStoreWriterChangeTitleTest extends \PHPUnit_Framework_TestCase {
 		$parentStore->expects( $this->atLeastOnce() )
 			->method( 'getPropertyTables' )
 			->will( $this->returnValue( array() ) );
+
+		$parentStore->expects( $this->atLeastOnce() )
+			->method( 'getConfiguration' )
+			->will( $this->returnValue( new StoreConfig() ) );
 
 		$instance = new SMWSQLStore3Writers( $parentStore );
 

--- a/tests/phpunit/includes/Store/SqlStore/SqlStoreWriterDataUpdateTest.php
+++ b/tests/phpunit/includes/Store/SqlStore/SqlStoreWriterDataUpdateTest.php
@@ -2,7 +2,9 @@
 
 namespace SMW\Tests\Store\SqlStore;
 
-use \SMWSQLStore3Writers;
+use SMW\Store\StoreConfig;
+
+use SMWSQLStore3Writers;
 use SMW\SemanticData;
 use SMW\DIWikiPage;
 
@@ -99,6 +101,10 @@ class SqlStoreWriterDataUpdateTest extends \PHPUnit_Framework_TestCase {
 			->method( 'getPropertyTables' )
 			->will( $this->returnValue( array() ) );
 
+		$parentStore->expects( $this->atLeastOnce() )
+			->method( 'getConfiguration' )
+			->will( $this->returnValue( new StoreConfig() ) );
+
 		$instance = new SMWSQLStore3Writers( $parentStore );
 		$instance->doDataUpdate( $semanticData );
 	}
@@ -164,6 +170,10 @@ class SqlStoreWriterDataUpdateTest extends \PHPUnit_Framework_TestCase {
 			->method( 'getPropertyTables' )
 			->will( $this->returnValue( array() ) );
 
+		$parentStore->expects( $this->atLeastOnce() )
+			->method( 'getConfiguration' )
+			->will( $this->returnValue( new StoreConfig() ) );
+
 		$instance = new SMWSQLStore3Writers( $parentStore );
 		$instance->doDataUpdate( $semanticData );
 	}
@@ -216,6 +226,10 @@ class SqlStoreWriterDataUpdateTest extends \PHPUnit_Framework_TestCase {
 		$parentStore->expects( $this->atLeastOnce() )
 			->method( 'getDatabase' )
 			->will( $this->returnValue( $database ) );
+
+		$parentStore->expects( $this->atLeastOnce() )
+			->method( 'getConfiguration' )
+			->will( $this->returnValue( new StoreConfig() ) );
 
 		$instance = new SMWSQLStore3Writers( $parentStore );
 		$instance->doDataUpdate( $semanticData );

--- a/tests/phpunit/includes/Store/SqlStore/SqlStoreWriterDeleteSubjectTest.php
+++ b/tests/phpunit/includes/Store/SqlStore/SqlStoreWriterDeleteSubjectTest.php
@@ -2,7 +2,9 @@
 
 namespace SMW\Tests\Store\SqlStore;
 
-use \SMWSQLStore3Writers;
+use SMW\Store\StoreConfig;
+
+use SMWSQLStore3Writers;
 
 use Title;
 
@@ -92,6 +94,10 @@ class SqlStoreWriterDeleteSubjectTest extends \PHPUnit_Framework_TestCase {
 			->method( 'getPropertyTables' )
 			->will( $this->returnValue( array() ) );
 
+		$parentStore->expects( $this->atLeastOnce() )
+			->method( 'getConfiguration' )
+			->will( $this->returnValue( new StoreConfig() ) );
+
 		$instance = new SMWSQLStore3Writers( $parentStore );
 		$instance->deleteSubject( $title );
 	}
@@ -153,6 +159,10 @@ class SqlStoreWriterDeleteSubjectTest extends \PHPUnit_Framework_TestCase {
 		$parentStore->expects( $this->exactly( 4 ) )
 			->method( 'getPropertyTables' )
 			->will( $this->returnValue( array() ) );
+
+		$parentStore->expects( $this->atLeastOnce() )
+			->method( 'getConfiguration' )
+			->will( $this->returnValue( new StoreConfig() ) );
 
 		$parentStore->setDatabase( $database );
 

--- a/tests/phpunit/includes/Store/StoreConfigTest.php
+++ b/tests/phpunit/includes/Store/StoreConfigTest.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace SMW\Tests\Store;
+
+use SMW\Store\StoreConfig;
+use SMW\Settings;
+
+/**
+ * @uses \SMW\Store\StoreConfig
+ *
+ * @ingroup Test
+ *
+ * @group SMW
+ * @group SMWExtension
+ * @group semantic-mediawiki-unit
+ * @group mediawiki-databaseless
+ *
+ * @license GNU GPL v2+
+ * @since 1.9.3
+ *
+ * @author mwjames
+ */
+class StoreConfigTest extends \PHPUnit_Framework_TestCase {
+
+	public function testCanConstruct() {
+
+		$this->assertInstanceOf(
+			'\SMW\Store\StoreConfig',
+			new StoreConfig
+		);
+	}
+
+	public function testChangesOnStoreConfigDefaultInvocation() {
+
+		$instance = new StoreConfig;
+
+		$this->assertNotEmpty( $instance->get( 'smwgDefaultStore' ) );
+
+		$this->assertInstanceOf(
+			'\SMW\Store\StoreConfig',
+			$instance->set( 'smwgDefaultStore', 'Foo' )
+		);
+
+		$this->assertEquals( 'Foo' , $instance->get( 'smwgDefaultStore' ) );
+	}
+
+	public function testGetOnUnsupportedKeyThrowsException() {
+
+		$instance = new StoreConfig;
+
+		$this->setExpectedException( 'InvalidArgumentException' );
+		$instance->get( 'Foo' );
+	}
+
+	public function testSetOnUnsupportedKeyThrowsException() {
+
+		$instance = new StoreConfig;
+
+		$this->setExpectedException( 'InvalidArgumentException' );
+		$instance->set( 'Foo', 'Bar' );
+	}
+
+	public function testCreateInstanceOnEmptySettingsThrowsException() {
+
+		$this->setExpectedException( 'SMW\InvalidSettingsArgumentException' );
+		new StoreConfig( Settings::newFromArray( array() ) );
+	}
+
+}

--- a/tests/phpunit/includes/cache/InMemoryCacheTest.php
+++ b/tests/phpunit/includes/cache/InMemoryCacheTest.php
@@ -1,0 +1,96 @@
+<?php
+
+namespace SMW\Tests\Cache;
+
+use SMW\Cache\InMemoryCache;
+
+/**
+ * @uses \SMW\Cache\InMemoryCache
+ *
+ * @ingroup Test
+ *
+ * @group SMW
+ * @group SMWExtension
+ * @group semantic-mediawiki-unit
+ * @group mediawiki-databaseless
+ *
+ * @license GNU GPL v2+
+ * @since 1.9.3
+ *
+ * @author mwjames
+ */
+class InMemoryCacheTest extends \PHPUnit_Framework_TestCase {
+
+	public function testCanConstruct() {
+
+		$this->assertInstanceOf(
+			'\SMW\Cache\InMemoryCache',
+			new InMemoryCache
+		);
+	}
+
+	public function testSetSingleEntry() {
+
+		$instance = new InMemoryCache;
+
+		$this->assertTrue( $instance->isSafe() );
+
+		$this->assertFalse( $instance->has( 'foo' ) );
+		$this->assertFalse( $instance->get( 'foo' ) );
+
+		$instance->set( 'foo', 'bar' );
+		$this->assertEquals( 'bar', $instance->get( 'foo' ) );
+	}
+
+	public function testSetNullValue() {
+
+		$instance = new InMemoryCache;
+
+		$instance->set( 'foo', null );
+
+		$this->assertTrue( $instance->has( 'foo' ) );
+		$this->assertNull( $instance->get( 'foo' ) );
+	}
+
+	public function testSetValueWithNonExpiredCacheTime() {
+
+		$instance = new InMemoryCache;
+
+		$instance->set( 'foo', 'bar', 100000 );
+
+		$this->assertTrue( $instance->has( 'foo' ) );
+		$this->assertEquals( 'bar', $instance->get( 'foo' ) );
+	}
+
+	public function testSetValueWithExpiredCacheTime() {
+
+		$instance = new InMemoryCache;
+
+		$instance->set( 'foo', 'bar', -10 );
+
+		$this->assertTrue( $instance->has( 'foo' ) );
+		$this->assertFalse( $instance->get( 'foo' ) );
+
+		$this->assertFalse(
+			$instance->has( 'foo' ),
+			'Asserts that once a key has been detected as expired, it is also removed'
+		);
+	}
+
+	public function testBulkThatIsSetToHaveNoExpiry() {
+
+		$instance = new InMemoryCache( array( 'foo' => 'bar', 'bar' => null ) );
+
+		$this->assertEquals( 'bar', $instance->get( 'foo' ) );
+		$this->assertEquals(  null, $instance->get( 'bar' ) );
+	}
+
+	public function testDeleteEntry() {
+
+		$instance = new InMemoryCache( array( 'foo' => 'bar') );
+
+		$this->assertFalse( $instance->delete( 'bar' ) );
+		$this->assertTrue( $instance->delete( 'foo' ) );
+	}
+
+}

--- a/tests/phpunit/includes/storage/StoreFactoryTest.php
+++ b/tests/phpunit/includes/storage/StoreFactoryTest.php
@@ -3,7 +3,6 @@
 namespace SMW\Test;
 
 use SMW\StoreFactory;
-use SMW\Settings;
 
 /**
  * @covers \SMW\StoreFactory
@@ -13,62 +12,60 @@ use SMW\Settings;
  * @group SMW
  * @group SMWExtension
  *
- * @licence GNU GPL v2+
+ * @license GNU GPL v2+
  * @since 1.9
  *
  * @author mwjames
  */
 class StoreFactoryTest extends \PHPUnit_Framework_TestCase {
 
-	public function testGetStore() {
+	protected function tearDown() {
+		StoreFactory::clear();
 
-		$settings = Settings::newFromGlobals();
+		parent::tearDown();
+	}
 
-		// Default is handled by the method itself
+	public function testGetDefaultStore() {
+
 		$instance = StoreFactory::getStore();
-		$this->assertInstanceOf( $settings->get( 'smwgDefaultStore' ), $instance );
+
+		$this->assertInstanceOf(
+			$instance->getConfiguration()->get( 'smwgDefaultStore' ),
+			$instance
+		);
 
 		$this->assertSame(
 			StoreFactory::getStore(),
 			$instance
 		);
 
-		// Reset static instance
 		StoreFactory::clear();
 
 		$this->assertNotSame(
 			StoreFactory::getStore(),
 			$instance
 		);
-
-		// Inject default store
-		$defaulStore = $settings->get( 'smwgDefaultStore' );
-		$instance = StoreFactory::getStore( $defaulStore );
-		$this->assertInstanceOf( $defaulStore, $instance );
 	}
 
-	public function testNewInstance() {
+	public function testDifferentStoreIdInstanceInvocation() {
 
-		$settings = Settings::newFromGlobals();
-
-		$defaulStore = $settings->get( 'smwgDefaultStore' );
-		$instance = StoreFactory::newInstance( $defaulStore );
-		$this->assertInstanceOf( $defaulStore, $instance );
+		$this->assertInstanceOf( 'SMW\Store', StoreFactory::getStore( '\SMWSQLStore3' ) );
+		$this->assertInstanceOf( 'SMW\Store', StoreFactory::getStore( '\SMWSparqlStore' ) );
 
 		$this->assertNotSame(
-			StoreFactory::newInstance( $defaulStore ),
-			$instance
+			StoreFactory::getStore( '\SMWSQLStore3' ),
+			StoreFactory::getStore( '\SMWSparqlStore' )
 		);
 	}
 
 	public function testStoreInstanceException() {
 		$this->setExpectedException( '\SMW\InvalidStoreException' );
-		StoreFactory::newInstance( '\SMW\StoreFactory' );
+		StoreFactory::getStore( '\SMW\StoreFactory' );
 	}
 
 	public function testStoreWithInvalidClassThrowsException() {
 		$this->setExpectedException( 'RuntimeException' );
-		StoreFactory::newInstance( 'foo' );
+		StoreFactory::getStore( 'foo' );
 	}
 
 	/**
@@ -78,6 +75,7 @@ class StoreFactoryTest extends \PHPUnit_Framework_TestCase {
 	 */
 	public function testSmwfGetStore() {
 		$store = smwfGetStore();
+
 		$this->assertInstanceOf( 'SMWStore', $store );
 		$this->assertInstanceOf( 'SMW\Store', $store );
 	}

--- a/tests/phpunit/includes/storage/sqlstore/SQLStoreTest.php
+++ b/tests/phpunit/includes/storage/sqlstore/SQLStoreTest.php
@@ -2,8 +2,8 @@
 
 namespace SMW\Test\SQLStore;
 
+use SMW\Store\StoreConfig;
 use SMWSQLStore3;
-use SMW\Settings;
 
 /**
  * @covers \SMWSQLStore3
@@ -23,27 +23,33 @@ class SQLStoreTest extends \PHPUnit_Framework_TestCase {
 	/** @var array */
 	protected $defaultPropertyTableCount = 0;
 
-	public function getClass() {
-		return '\SMWSQLStore3';
+	/** @var StoreConfig */
+	protected $instance = null;
+
+	protected function setUp() {
+		parent::setUp();
+
+		$this->instance = new SMWSQLStore3();
+
+		$storeConfig = new StoreConfig();
+		$storeConfig->set( 'smwgFixedProperties', array() );
+		$storeConfig->set( 'smwgPageSpecialProperties', array() );
+
+		$this->instance->setConfiguration( $storeConfig );
+
+		$this->defaultPropertyTableCount = count( $this->instance->getPropertyTables() );
+		$this->instance->clear();
 	}
 
-	private function acquireInstance() {
-		$instance = new SMWSQLStore3();
+	protected function tearDown() {
+		$this->instance->clear();
 
-		$instance->setConfiguration( Settings::newFromArray( array(
-			'smwgFixedProperties' => array(),
-			'smwgPageSpecialProperties' => array()
-		) ) );
-
-		$this->defaultPropertyTableCount = count( $instance->getPropertyTables() );
-		$instance->clear();
-
-		return $instance;
+		parent::tearDown();
 	}
+
 
 	public function testCanConstruct() {
-		$instance = $this->acquireInstance();
-		$this->assertInstanceOf( $this->getClass(), $instance );
+		$this->assertInstanceOf( '\SMWSQLStore3', $this->instance );
 	}
 
 	/**
@@ -51,16 +57,9 @@ class SQLStoreTest extends \PHPUnit_Framework_TestCase {
 	 */
 	public function testGetPropertyTables() {
 
-		$instance = $this->acquireInstance();
+		$this->assertInternalType( 'array', $this->instance->getPropertyTables() );
 
-		$instance->setConfiguration( Settings::newFromArray( array(
-			'smwgFixedProperties' => array(),
-			'smwgPageSpecialProperties' => array()
-		) ) );
-
-		$this->assertInternalType( 'array', $instance->getPropertyTables() );
-
-		foreach ( $instance->getPropertyTables() as $tid => $propTable ) {
+		foreach ( $this->instance->getPropertyTables() as $tid => $propTable ) {
 			$this->assertInstanceOf( '\SMW\SQLStore\TableDefinition', $propTable );
 		}
 	}
@@ -70,15 +69,9 @@ class SQLStoreTest extends \PHPUnit_Framework_TestCase {
 	 */
 	public function testPropertyTablesValidCustomizableProperty() {
 
-		$instance = $this->acquireInstance();
+		$this->instance->getConfiguration()->set( 'smwgPageSpecialProperties', array( '_MDAT' ) );
 
-		$instance->setConfiguration( Settings::newFromArray( array(
-			'smwgFixedProperties' => array(),
-			'smwgPageSpecialProperties' => array( '_MDAT' )
-		) ) );
-
-		$this->assertCount( $this->defaultPropertyTableCount + 1, $instance->getPropertyTables() );
-		$instance->clear();
+		$this->assertCount( $this->defaultPropertyTableCount + 1, $this->instance->getPropertyTables() );
 	}
 
 	/**
@@ -86,15 +79,9 @@ class SQLStoreTest extends \PHPUnit_Framework_TestCase {
 	 */
 	public function testPropertyTablesWithInvalidCustomizableProperty() {
 
-		$instance = $this->acquireInstance();
+		$this->instance->getConfiguration()->set( 'smwgPageSpecialProperties', array( '_MDAT', 'Foo' ) );
 
-		$instance->setConfiguration( Settings::newFromArray( array(
-			'smwgFixedProperties' => array(),
-			'smwgPageSpecialProperties' => array( '_MDAT', 'Foo' )
-		) ) );
-
-		$this->assertCount( $this->defaultPropertyTableCount + 1, $instance->getPropertyTables() );
-		$instance->clear();
+		$this->assertCount( $this->defaultPropertyTableCount + 1, $this->instance->getPropertyTables() );
 	}
 
 	/**
@@ -102,24 +89,18 @@ class SQLStoreTest extends \PHPUnit_Framework_TestCase {
 	 */
 	public function testPropertyTablesWithValidCustomizableProperties() {
 
-		$instance = $this->acquireInstance();
+		$this->instance->getConfiguration()->set( 'smwgPageSpecialProperties', array( '_MDAT', '_MEDIA' ) );
 
-		$instance->setConfiguration( Settings::newFromArray( array(
-			'smwgFixedProperties' => array(),
-			'smwgPageSpecialProperties' => array( '_MDAT', '_MEDIA' )
-		) ) );
-
-		$this->assertCount( $this->defaultPropertyTableCount + 2, $instance->getPropertyTables() );
-		$instance->clear();
+		$this->assertCount( $this->defaultPropertyTableCount + 2, $this->instance->getPropertyTables() );
 	}
 
 	public function testGetStatisticsTable() {
-		$this->assertInternalType( 'string', $this->acquireInstance()->getStatisticsTable() );
+		$this->assertInternalType( 'string', $this->instance->getStatisticsTable() );
 	}
 
 	public function testGetObjectIds() {
-		$this->assertInternalType( 'object', $this->acquireInstance()->getObjectIds() );
-		$this->assertInternalType( 'string', $this->acquireInstance()->getObjectIds()->getIdTable() );
+		$this->assertInternalType( 'object', $this->instance->getObjectIds() );
+		$this->assertInternalType( 'string', $this->instance->getObjectIds()->getIdTable() );
 	}
 
 }


### PR DESCRIPTION
- Removed Settings from StoreFactory (replaced by StoreConfig)
- Turn StoreFactory::newInstance into a private method
- Removed $GLOBALS['smwgEnableUpdateJobs'] setting from RebuildData
- Removed global $smwgQEqualitySupport from SMWSQLStore3Writers::changeTitle
- Removed global $smwgQEqualitySupport, $smwgEnableUpdateJobs from SMWSQLStore3Writers::updateRedirects
- Removed static $configuration reference from SMW\Store
- Removed static self::$configuration from SMWSQLStore3::getPropertyTables

Tests:
- Added StoreConfigTest
- Added InMemoryCacheTest
- Modified SqlStoreWriterChangeTitleTest
- Modified SqlStoreWriterDataUpdateTest
- Modified SqlStoreWriterDeleteSubjectTest
- Modified StoreFactoryTest
- Modified SQLStoreTest
