### PR TITLE
Add removeDuplicates option to SMW\MediaWiki\Jobs\UpdateJob

### DIFF
--- a/includes/src/MediaWiki/Jobs/UpdateJob.php
+++ b/includes/src/MediaWiki/Jobs/UpdateJob.php
@@ -40,6 +40,7 @@ class UpdateJob extends JobBase {
 	 */
 	function __construct( Title $title ) {
 		parent::__construct( 'SMW\UpdateJob', $title );
+		$this->removeDuplicates = true;
 	}
 
 	/**


### PR DESCRIPTION
@SemanticMediaWiki/testers I'd like people to test this option as it should decrease the amount of update jobs during refresh or by other means of execution. The results (page content, and query update etc.) should be the same only that jobs (for the same title) which are inserted more than once (can happen for subobjects that have the same "root" title) will be removed automatically from the queue.
#297
