### PR TITLE
Use prefixed DBkey for caching in SMW\Store\Maintenance\DataRebuilder

### DIFF
--- a/includes/src/Store/Maintenance/DataRebuilder.php
+++ b/includes/src/Store/Maintenance/DataRebuilder.php
@@ -157,7 +157,7 @@ class DataRebuilder {
 
 			$title = $this->makeTitleOf( $page );
 
-			if ( $title !== null && !isset( $titleCache[ $title->getDBKey() ] ) ) {
+			if ( $title !== null && !isset( $titleCache[ $title->getPrefixedDBkey() ] ) ) {
 
 				$this->rebuildCount++;
 
@@ -166,9 +166,8 @@ class DataRebuilder {
 				$updatejob = new UpdateJob( $title );
 				$updatejob->run();
 
-				$titleCache[ $title->getDBKey() ] = true;
+				$titleCache[ $title->getPrefixedDBkey() ] = true;
 			}
-
 		}
 
 		$this->reportMessage( "$this->rebuildCount pages refreshed.\n" );

--- a/tests/phpunit/includes/Store/Maintenance/DataRebuilderTest.php
+++ b/tests/phpunit/includes/Store/Maintenance/DataRebuilderTest.php
@@ -331,16 +331,21 @@ class DataRebuilderTest extends \PHPUnit_Framework_TestCase {
 
 		$instance->expects( $this->at( 2 ) )
 			->method( 'makeTitleOf' )
+			->with( $this->equalTo( 'Help:Main page' ) )
+			->will( $this->returnValue( Title::newFromText( 'Main page', NS_HELP ) ) );
+
+		$instance->expects( $this->at( 3 ) )
+			->method( 'makeTitleOf' )
 			->with( $this->equalTo( 'Main page' ) )
 			->will( $this->returnValue( Title::newFromText( 'Main page' ) ) );
 
 		$instance->setParameters( array(
-			'page'  => 'Main page|Some other page|Main page'
+			'page'  => 'Main page|Some other page|Help:Main page|Main page'
 		) );
 
 		$this->assertTrue( $instance->rebuild() );
 
-		$this->assertEquals( 2, $instance->getRebuildCount() );
+		$this->assertEquals( 3, $instance->getRebuildCount() );
 	}
 
 	/**


### PR DESCRIPTION
Use getPrefixedDBkey to ensure that pages with the same name but different prefix are cached separately.
