### PR TITLE
Temp fix for SMW\Test\QueryPrinterRegistryTestCase

### DIFF
--- a/SemanticMediaWiki.php
+++ b/SemanticMediaWiki.php
@@ -97,6 +97,15 @@ $GLOBALS['wgExtensionMessagesFiles']['SemanticMediaWikiMagic'] = $GLOBALS['smwgI
 $GLOBALS['wgExtensionMessagesFiles']['SemanticMediaWikiNamespaces'] = $GLOBALS['smwgIP'] . 'languages/SemanticMediaWiki.namespaces.php';
 
 /**
+ * @since 1.9.3
+ *
+ * TEMPORARY FIX until an appropriate testLoader is provided for third-party
+ * extensions that rely on some test classes to be present
+ */
+$GLOBALS['wgAutoloadClasses']['SMW\Test\QueryPrinterTestCase']   = __DIR__ . '/tests/phpunit/QueryPrinterTestCase.php';
+$GLOBALS['wgAutoloadClasses']['SMW\Test\QueryPrinterRegistryTestCase']   = __DIR__ . '/tests/phpunit/QueryPrinterRegistryTestCase.php';
+
+/**
  * Setup and initialization
  *
  * @note $wgExtensionFunctions variable is an array that stores

--- a/tests/phpunit/QueryPrinterTestCase.php
+++ b/tests/phpunit/QueryPrinterTestCase.php
@@ -26,7 +26,7 @@ use ReflectionClass;
  * @group SMW
  * @group SMWExtension
  */
-abstract class QueryPrinterTestCase extends SemanticMediaWikiTestCase {
+abstract class QueryPrinterTestCase extends \PHPUnit_Framework_TestCase {
 
 	/**
 	 * Helper method sets result printer parameters
@@ -58,4 +58,14 @@ abstract class QueryPrinterTestCase extends SemanticMediaWikiTestCase {
 		return $instance;
 
 	}
+
+	protected function arrayWrap( array $elements ) {
+		return array_map(
+			function ( $element ) {
+				return array( $element );
+			},
+			$elements
+		);
+	}
+
 }

--- a/tests/phpunit/includes/queryprinters/AggregatablePrinterTest.php
+++ b/tests/phpunit/includes/queryprinters/AggregatablePrinterTest.php
@@ -2,8 +2,13 @@
 
 namespace SMW\Test;
 
+use SMW\Tests\Util\Mock\MockObjectBuilder;
+use SMW\Tests\Util\Mock\CoreMockObjectRepository;
+
 use SMWDataItem;
 use SMWDINumber;
+
+use ReflectionClass;
 
 /**
  * Tests for the AggregatablePrinter class
@@ -55,7 +60,7 @@ class AggregatablePrinterTest extends QueryPrinterTestCase {
 		$instance    = $this->newInstance( $setup['parameters'] );
 		$queryResult = $setup['queryResult'];
 
-		$reflection = $this->newReflector();
+		$reflection = new ReflectionClass( '\SMW\AggregatablePrinter' );
 		$method = $reflection->getMethod( 'getResultText' );
 		$method->setAccessible( true );
 
@@ -79,7 +84,7 @@ class AggregatablePrinterTest extends QueryPrinterTestCase {
 		$expected = array();
 		$keys = array( 'test', 'foo', 'bar' );
 
-		$reflector = $this->newReflector();
+		$reflector = new ReflectionClass( '\SMW\AggregatablePrinter' );
 		$method = $reflector->getMethod( 'addNumbersForDataItem' );
 		$method->setAccessible( true );
 
@@ -116,7 +121,7 @@ class AggregatablePrinterTest extends QueryPrinterTestCase {
 
 		$instance  = $this->newInstance( $setup['parameters'] );
 
-		$reflector = $this->newReflector();
+		$reflector = new ReflectionClass( '\SMW\AggregatablePrinter' );
 		$method = $reflector->getMethod( 'getNumericResults' );
 		$method->setAccessible( true );
 
@@ -141,13 +146,15 @@ class AggregatablePrinterTest extends QueryPrinterTestCase {
 	 */
 	public function errorMessageProvider() {
 
+		$mockBuilder = new MockObjectBuilder();
+		$mockBuilder->registerRepository( new CoreMockObjectRepository() );
+
 		$message = wfMessage( 'smw-qp-aggregatable-empty-data' )->inContentLanguage()->text();
 
 		$provider = array();
 
-		// #0
-		$queryResult = $this->newMockBuilder()->newObject( 'QueryResult', array(
-			'getErrors' => array( $message )
+		$queryResult = $mockBuilder->newObject( 'QueryResult', array(
+			'getErrors'  => array( $message )
 		) );
 
 		$provider[] = array(
@@ -230,31 +237,34 @@ class AggregatablePrinterTest extends QueryPrinterTestCase {
 	 */
 	private function buildMockQueryResult( $setup ) {
 
+		$mockBuilder = new MockObjectBuilder();
+		$mockBuilder->registerRepository( new CoreMockObjectRepository() );
+
 		$printRequests = array();
 		$resultArray   = array();
 
 		foreach ( $setup as $value ) {
 
-			$printRequest = $this->newMockBuilder()->newObject( 'PrintRequest', array(
+			$printRequest = $mockBuilder->newObject( 'PrintRequest', array(
 				'getText'  => $value['printRequest'],
 				'getLabel' => $value['printRequest']
 			) );
 
 			$printRequests[] = $printRequest;
 
-			$dataItem = $this->newMockBuilder()->newObject( 'DataItem', array(
+			$dataItem = $mockBuilder->newObject( 'DataItem', array(
 				'getDIType' => SMWDataItem::TYPE_NUMBER,
 				'getNumber' => $value['number']
 			) );
 
-			$dataValue = $this->newMockBuilder()->newObject( 'DataValue', array(
+			$dataValue = $mockBuilder->newObject( 'DataValue', array(
 				'DataValueType'    => 'SMWNumberValue',
 				'getTypeID'        => '_num',
 				'getShortWikiText' => $value['dataValue'],
 				'getDataItem'      => $dataItem
 			) );
 
-			$resultArray[] = $this->newMockBuilder()->newObject( 'ResultArray', array(
+			$resultArray[] = $mockBuilder->newObject( 'ResultArray', array(
 				'getText'          => $value['printRequest'],
 				'getPrintRequest'  => $printRequest,
 				'getNextDataValue' => $dataValue,
@@ -263,7 +273,7 @@ class AggregatablePrinterTest extends QueryPrinterTestCase {
 
 		}
 
-		$queryResult = $this->newMockBuilder()->newObject( 'QueryResult', array(
+		$queryResult = $mockBuilder->newObject( 'QueryResult', array(
 			'getPrintRequests'  => $printRequests,
 			'getNext'           => $resultArray,
 			'getLink'           => new \SMWInfolink( true, 'Lala' , 'Lula' ),

--- a/tests/phpunit/includes/queryprinters/CsvResultPrinterTest.php
+++ b/tests/phpunit/includes/queryprinters/CsvResultPrinterTest.php
@@ -2,8 +2,13 @@
 
 namespace SMW\Test;
 
+use SMW\Tests\Util\Mock\MockObjectBuilder;
+use SMW\Tests\Util\Mock\CoreMockObjectRepository;
+
 use SMW\CsvResultPrinter;
 use SMWDataItem;
+
+use ReflectionClass;
 
 /**
  * Tests for the CsvResultPrinter class
@@ -25,6 +30,15 @@ use SMWDataItem;
  * @group SMWExtension
  */
 class CsvResultPrinterTest extends QueryPrinterTestCase {
+
+	protected $mockBuilder;
+
+	protected function setUp(){
+		parent::setUp();
+
+		$this->mockBuilder = new MockObjectBuilder();
+		$this->mockBuilder->registerRepository( new CoreMockObjectRepository() );
+	}
 
 	/**
 	 * Returns the name of the class to be tested
@@ -63,7 +77,7 @@ class CsvResultPrinterTest extends QueryPrinterTestCase {
 		$filename = 'FooQueey';
 		$instance = $this->newInstance( array( 'filename' => $filename ) );
 
-		$this->assertEquals( $filename, $instance->getFileName( $this->newMockBuilder()->newObject( 'QueryResult' ) ) );
+		$this->assertEquals( $filename, $instance->getFileName( $this->mockBuilder->newObject( 'QueryResult' ) ) );
 	}
 
 	/**
@@ -75,7 +89,7 @@ class CsvResultPrinterTest extends QueryPrinterTestCase {
 	public function testGetResultText(  $setup, $expected  ) {
 
 		$instance  = $this->newInstance( $setup['parameters'] );
-		$reflector = $this->newReflector();
+		$reflector = new ReflectionClass( '\SMW\CsvResultPrinter' );
 
 		$property = $reflector->getProperty( 'fullParams' );
 		$property->setAccessible( true );
@@ -146,23 +160,26 @@ class CsvResultPrinterTest extends QueryPrinterTestCase {
 	 */
 	private function buildMockQueryResult( $setup ) {
 
+		$mockBuilder = new MockObjectBuilder();
+		$mockBuilder->registerRepository( new CoreMockObjectRepository() );
+
 		$printRequests = array();
 		$resultArray   = array();
 
 		foreach ( $setup as $value ) {
 
-			$printRequest = $this->newMockBuilder()->newObject( 'PrintRequest', array(
+			$printRequest = $mockBuilder->newObject( 'PrintRequest', array(
 				'getText'  => $value['printRequest'],
 				'getLabel' => $value['printRequest']
 			) );
 
 			$printRequests[] = $printRequest;
 
-			$dataItem = $this->newMockBuilder()->newObject( 'DataItem', array(
+			$dataItem = $mockBuilder->newObject( 'DataItem', array(
 				'getDIType'  => SMWDataItem::TYPE_WIKIPAGE,
 			) );
 
-			$dataValue = $this->newMockBuilder()->newObject( 'DataValue', array(
+			$dataValue = $mockBuilder->newObject( 'DataValue', array(
 				'DataValueType'    => 'SMWWikiPageValue',
 				'getTypeID'        => '_wpg',
 				'getShortWikiText' => $value['dataValue'],
@@ -170,7 +187,7 @@ class CsvResultPrinterTest extends QueryPrinterTestCase {
 				'getDataItem'      => $dataItem
 			) );
 
-			$resultArray[] = $this->newMockBuilder()->newObject( 'ResultArray', array(
+			$resultArray[] = $mockBuilder->newObject( 'ResultArray', array(
 				'getText'          => $value['printRequest'],
 				'getPrintRequest'  => $printRequest,
 				'getNextDataValue' => $dataValue,
@@ -179,7 +196,7 @@ class CsvResultPrinterTest extends QueryPrinterTestCase {
 
 		}
 
-		$queryResult = $this->newMockBuilder()->newObject( 'QueryResult', array(
+		$queryResult = $mockBuilder->newObject( 'QueryResult', array(
 			'getPrintRequests'  => $printRequests,
 			'getNext'           => $resultArray,
 			'getLink'           => new \SMWInfolink( true, 'Lala' , 'Lula' ),

--- a/tests/phpunit/includes/queryprinters/FeedResultPrinterTest.php
+++ b/tests/phpunit/includes/queryprinters/FeedResultPrinterTest.php
@@ -4,6 +4,8 @@ namespace SMW\Test;
 
 use SMW\FeedResultPrinter;
 
+use ReflectionClass;
+
 /**
  * Tests for the FeedResultPrinter class
  *
@@ -62,7 +64,7 @@ class FeedResultPrinterTest extends QueryPrinterTestCase {
 
 		$instance = $this->newInstance();
 
-		$reflector = $this->newReflector();
+		$reflector = new ReflectionClass( '\SMW\FeedResultPrinter' );
 		$method = $reflector->getMethod( 'feedItemDescription' );
 		$method->setAccessible( true );
 

--- a/tests/phpunit/includes/queryprinters/JsonResultPrinterTest.php
+++ b/tests/phpunit/includes/queryprinters/JsonResultPrinterTest.php
@@ -2,8 +2,13 @@
 
 namespace SMW\Test;
 
+use SMW\Tests\Util\Mock\MockObjectBuilder;
+use SMW\Tests\Util\Mock\CoreMockObjectRepository;
+
 use SMW\JsonResultPrinter;
 use SMW\ResultPrinter;
+
+use ReflectionClass;
 
 /**
  * @covers \SMW\JsonResultPrinter
@@ -20,6 +25,15 @@ use SMW\ResultPrinter;
  * @author mwjames
  */
 class JsonResultPrinterTest extends QueryPrinterTestCase {
+
+	protected $mockBuilder;
+
+	protected function setUp(){
+		parent::setUp();
+
+		$this->mockBuilder = new MockObjectBuilder();
+		$this->mockBuilder->registerRepository( new CoreMockObjectRepository() );
+	}
 
 	/**
 	 * @return string|false
@@ -51,7 +65,7 @@ class JsonResultPrinterTest extends QueryPrinterTestCase {
 
 		$this->assertEquals(
 			'application/json',
-			$this->newInstance()->getMimeType( $this->newMockBuilder()->newObject( 'QueryResult' ) ),
+			$this->newInstance()->getMimeType( $this->mockBuilder->newObject( 'QueryResult' ) ),
 			'Asserts that getMimeType() yields an expected result'
 		);
 
@@ -68,7 +82,7 @@ class JsonResultPrinterTest extends QueryPrinterTestCase {
 
 		$this->assertEquals(
 			$expected,
-			$instance->getFileName( $this->newMockBuilder()->newObject( 'QueryResult' ) ),
+			$instance->getFileName( $this->mockBuilder->newObject( 'QueryResult' ) ),
 			'Asserts that getFileName() yields an expected result');
 	}
 
@@ -92,19 +106,19 @@ class JsonResultPrinterTest extends QueryPrinterTestCase {
 	public function testGetResultText() {
 
 		$result = array(
-			'lala' => $this->newRandomString(),
-			'lula' => $this->newRandomString()
+			'lala' => __METHOD__,
+			'lula' => 999388383838
 		);
 
 		$expected = array_merge( $result, array( 'rows' => count( $result ) ) );
 
 		$instance = $this->newInstance( array( 'prettyprint' => false ) );
 
-		$reflector = $this->newReflector();
+		$reflector = new ReflectionClass( '\SMW\JsonResultPrinter' );
 		$getResultText = $reflector->getMethod( 'getResultText' );
 		$getResultText->setAccessible( true );
 
-		$queryResult = $this->newMockBuilder()->newObject( 'QueryResult', array(
+		$queryResult = $this->mockBuilder->newObject( 'QueryResult', array(
 			'serializeToArray' => $result,
 			'getCount'         => count( $result )
 		) );

--- a/tests/phpunit/includes/queryprinters/TableResultPrinterTest.php
+++ b/tests/phpunit/includes/queryprinters/TableResultPrinterTest.php
@@ -2,7 +2,14 @@
 
 namespace SMW\Test;
 
+use SMW\Tests\Util\Mock\MockObjectBuilder;
+use SMW\Tests\Util\Mock\CoreMockObjectRepository;
+
 use SMW\TableResultPrinter;
+use SMW\DIWikiPage;
+
+use ReflectionClass;
+use Title;
 
 /**
  * Tests for the TableResultPrinter class
@@ -64,7 +71,7 @@ class TableResultPrinterTest extends QueryPrinterTestCase {
 	public function testGetResultText(  $setup, $expected  ) {
 
 		$instance  = $this->newInstance( $setup['parameters'] );
-		$reflector = $this->newReflector();
+		$reflector = new ReflectionClass( '\SMW\TableResultPrinter' );
 
 		$property = $reflector->getProperty( 'fullParams' );
 		$property->setAccessible( true );
@@ -98,6 +105,9 @@ class TableResultPrinterTest extends QueryPrinterTestCase {
 	 */
 	public function standardTableDataProvider() {
 
+		$mockBuilder = new MockObjectBuilder();
+		$mockBuilder->registerRepository( new CoreMockObjectRepository() );
+
 		$provider = array();
 
 		$labels = array(
@@ -109,29 +119,29 @@ class TableResultPrinterTest extends QueryPrinterTestCase {
 
 		$printRequests = array();
 
-		$printRequests['pr-1'] = $this->newMockBuilder()->newObject( 'PrintRequest', array(
+		$printRequests['pr-1'] = $mockBuilder->newObject( 'PrintRequest', array(
 			'getText' => $labels['pr-1']
 		) );
 
-		$printRequests['pr-2'] = $this->newMockBuilder()->newObject( 'PrintRequest', array(
+		$printRequests['pr-2'] = $mockBuilder->newObject( 'PrintRequest', array(
 			'getText' => $labels['pr-2']
 		) );
 
 		$datItems = array();
 
-		$datItems['ra-1'] = $this->newSubject( $this->newTitle( NS_MAIN, $labels['ra-1'] ) );
-		$datItems['ra-2'] = $this->newMockBuilder()->newObject( 'DataItem', array( 'getSortKey' => $labels['ra-2'] ) );
+		$datItems['ra-1'] = DIWikiPage::newFromTitle( Title::newFromText( $labels['ra-1'], NS_MAIN ) );
+		$datItems['ra-2'] = $mockBuilder->newObject( 'DataItem', array( 'getSortKey' => $labels['ra-2'] ) );
 
 		$dataValues = array();
 
-		$dataValues['ra-1'] = $this->newMockBuilder()->newObject( 'DataValue', array(
+		$dataValues['ra-1'] = $mockBuilder->newObject( 'DataValue', array(
 			'DataValueType'    => 'SMWWikiPageValue',
 			'getTypeID'        => '_wpg',
 			'getShortText'     => $labels['ra-1'],
 			'getDataItem'      => $datItems['ra-1']
 		) );
 
-		$dataValues['ra-2'] = $this->newMockBuilder()->newObject( 'DataValue', array(
+		$dataValues['ra-2'] = $mockBuilder->newObject( 'DataValue', array(
 			'DataValueType'    => 'SMWNumberValue',
 			'getTypeID'        => '_num',
 			'getShortText'     => $labels['ra-2'],
@@ -140,19 +150,19 @@ class TableResultPrinterTest extends QueryPrinterTestCase {
 
 		$resultArray = array();
 
-		$resultArray['ra-1'] = $this->newMockBuilder()->newObject( 'ResultArray', array(
+		$resultArray['ra-1'] = $mockBuilder->newObject( 'ResultArray', array(
 			'getText'          => $labels['ra-1'],
 			'getPrintRequest'  => $printRequests['pr-1'],
 			'getNextDataValue' => $dataValues['ra-1'],
 		) );
 
-		$resultArray['ra-2'] = $this->newMockBuilder()->newObject( 'ResultArray', array(
+		$resultArray['ra-2'] = $mockBuilder->newObject( 'ResultArray', array(
 			'getText'          => $labels['ra-2'],
 			'getPrintRequest'  => $printRequests['pr-2'],
 			'getNextDataValue' => $dataValues['ra-2'],
 		) );
 
-		$queryResult = $this->newMockBuilder()->newObject( 'QueryResult', array(
+		$queryResult = $mockBuilder->newObject( 'QueryResult', array(
 			'getPrintRequests'  => array( $printRequests['pr-1'], $printRequests['pr-2'] ),
 			'getNext'           => array( $resultArray['ra-1'], $resultArray['ra-2'] ),
 			'getLink'           => new \SMWInfolink( true, 'Lala' , 'Lula' ),


### PR DESCRIPTION
Due to changes as to when test classes are loaded, some third-party extension make assumptions about available test cases.

Removed SemanticMediaWikiTestCase dependency and solely depend on \PHPUnit_Framework_TestCase

Only glanced over some of those tests but they need some serious re-factoring.
