### PR TITLE
Some renaming SubobjectParserFunction/Subobject

### DIFF
--- a/includes/Subobject.php
+++ b/includes/Subobject.php
@@ -10,13 +10,11 @@ use Title;
 use InvalidArgumentException;
 
 /**
- * Provides a subobject
- *
  * @see http://www.semantic-mediawiki.org/wiki/Help:Subobject
  *
  * @ingroup SMW
  *
- * @licence GNU GPL v2+
+ * @license GNU GPL v2+
  * @since 1.9
  *
  * @author mwjames
@@ -25,9 +23,6 @@ class Subobject {
 
 	/** @var Title */
 	 protected $title;
-
-	/** @var string */
-	 protected $identifier;
 
 	/** @var SMWContainerSemanticData */
 	 protected $semanticData;
@@ -63,7 +58,7 @@ class Subobject {
 	 * @return string
 	 */
 	public function getId() {
-		return $this->identifier;
+		return $this->getSemanticData()->getSubject()->getSubobjectName();
 	}
 
 	/**
@@ -102,22 +97,18 @@ class Subobject {
 	}
 
 	/**
-	 * Initializes the semantic data container for a given identifier
-	 * and its invoked subject
-	 *
-	 * @since 1.9
+	 * @since 1.9.3
 	 *
 	 * @param string $identifier
 	 *
+	 * @return self
 	 * @throws InvalidArgumentException
 	 */
-	public function setSemanticData( $identifier ) {
+	public function setEmptySemanticDataForId( $identifier ) {
 
 		if ( $identifier === '' ) {
-			throw new InvalidArgumentException( 'The identifier is empty' );
+			throw new InvalidArgumentException( 'Expected a valid (non-empty) indentifier' );
 		}
-
-		$this->identifier = $identifier;
 
 		$subWikiPage = new DIWikiPage(
 			$this->title->getDBkey(),
@@ -128,6 +119,14 @@ class Subobject {
 
 		$this->semanticData = new SMWContainerSemanticData( $subWikiPage );
 
+		return $this;
+	}
+
+	/**
+	 * @deprecated since 1.9.3
+	 */
+	public function setSemanticData( $identifier ) {
+		$this->setEmptySemanticDataForId( $identifier );
 	}
 
 	/**
@@ -169,17 +168,6 @@ class Subobject {
 	}
 
 	/**
-	 * Adds a data value object to the semantic data container
-	 *
-	 * @par Example:
-	 * @code
-	 *  $dataValue = DataValueFactory::getInstance()->newPropertyValue( $userProperty, $userValue )
-	 *
-	 *  $subobject = new Subobject( 'Foo' );
-	 *  $subobject->setSemanticData( 'Bar' );
-	 *  $subobject->addDataValue( $dataValue )
-	 * @endcode
-	 *
 	 * @since 1.9
 	 *
 	 * @param DataValue $dataValue

--- a/includes/parserhooks/RecurringEventsParserFunction.php
+++ b/includes/parserhooks/RecurringEventsParserFunction.php
@@ -9,22 +9,14 @@ use Parser;
  *
  * @see http://semantic-mediawiki.org/wiki/Help:Recurring_events
  *
- * @file
- *
  * @license GNU GPL v2+
  * @since   1.9
  *
  * @author mwjames
  */
-
-/**
- * Class that provides the {{#set_recurring_event}} parser function
- *
- * @ingroup ParserFunction
- */
 class RecurringEventsParserFunction extends SubobjectParserFunction {
 
-	/** @var MessageFormatter */
+	/** @var Settings */
 	protected $settings;
 
 	/** @var RecurringEvents */
@@ -35,16 +27,16 @@ class RecurringEventsParserFunction extends SubobjectParserFunction {
 	 *
 	 * @param ParserData $parserData
 	 * @param Subobject $subobject
-	 * @param MessageFormatter $msgFormatter
+	 * @param MessageFormatter $messageFormatter
 	 * @param Settings $settings
 	 */
 	public function __construct(
 		ParserData $parserData,
 		Subobject $subobject,
-		MessageFormatter $msgFormatter,
+		MessageFormatter $messageFormatter,
 		Settings $settings
 	) {
-		parent::__construct ( $parserData, $subobject, $msgFormatter );
+		parent::__construct ( $parserData, $subobject, $messageFormatter );
 		$this->settings = $settings;
 	}
 
@@ -59,11 +51,12 @@ class RecurringEventsParserFunction extends SubobjectParserFunction {
 	 * @return string|null
 	 */
 	public function parse( ArrayFormatter $parameters ) {
-		$this->setObjectReference( true );
+
+		$this->setFirstElementAsProperty( true );
 
 		// Get recurring events
 		$this->events = new RecurringEvents( $parameters->toArray(), $this->settings );
-		$this->msgFormatter->addFromArray( $this->events->getErrors() );
+		$this->messageFormatter->addFromArray( $this->events->getErrors() );
 
 		foreach ( $this->events->getDates() as $date_str ) {
 
@@ -74,25 +67,24 @@ class RecurringEventsParserFunction extends SubobjectParserFunction {
 			// Add the date string as individual property / value parameter
 			$parameters->addParameter( $this->events->getProperty(), $date_str );
 
-			// Register object values
 			// @see SubobjectParserFunction::addSubobjectValues
-			$this->addSubobjectValues( $parameters );
+			$this->addDataValuesToSubobject( $parameters );
 
 			//  Each new $parameters set will add an additional subobject
 			//  to the instance
-			$this->parserData->getData()->addPropertyObjectValue(
+			$this->parserData->getSemanticData()->addPropertyObjectValue(
 				$this->subobject->getProperty(),
 				$this->subobject->getContainer()
 			);
 
 			// Collect errors that occurred during processing
-			$this->msgFormatter->addFromArray( $this->subobject->getErrors() );
+			$this->messageFormatter->addFromArray( $this->subobject->getErrors() );
 		}
 
 		// Update ParserOutput
 		$this->parserData->updateOutput();
 
-		return $this->msgFormatter->getHtml();
+		return $this->messageFormatter->getHtml();
 	}
 
 	/**

--- a/includes/parserhooks/SubobjectParserFunction.php
+++ b/includes/parserhooks/SubobjectParserFunction.php
@@ -9,9 +9,7 @@ use Parser;
  *
  * @see http://www.semantic-mediawiki.org/wiki/Help:ParserFunction
  *
- * @ingroup ParserFunction
- *
- * @licence GNU GPL v2+
+ * @license GNU GPL v2+
  * @since 1.9
  *
  * @author mwjames
@@ -27,42 +25,37 @@ class SubobjectParserFunction {
 	protected $subobject;
 
 	/** @var MessageFormatter */
-	protected $msgFormatter;
+	protected $messageFormatter;
 
 	/** @var boolean */
-	protected $objectReference = false;
+	protected $firstElementAsProperty = false;
 
 	/**
 	 * @since 1.9
 	 *
 	 * @param ParserData $parserData
 	 * @param Subobject $subobject
-	 * @param MessageFormatter $msgFormatter
+	 * @param MessageFormatter $messageFormatter
 	 */
-	public function __construct( ParserData $parserData, Subobject $subobject, MessageFormatter $msgFormatter ) {
+	public function __construct( ParserData $parserData, Subobject $subobject, MessageFormatter $messageFormatter ) {
 		$this->parserData = $parserData;
 		$this->subobject = $subobject;
-		$this->msgFormatter = $msgFormatter;
+		$this->messageFormatter = $messageFormatter;
 	}
 
 	/**
-	 * Enables/disables to create an object reference pointing to the original
-	 * subject
-	 *
 	 * @since 1.9
 	 *
-	 * @param boolean $objectReference
+	 * @param boolean $firstElementAsProperty
 	 *
 	 * @return SubobjectParserFunction
 	 */
-	public function setObjectReference( $objectReference ) {
-		$this->objectReference = $objectReference;
+	public function setFirstElementAsProperty( $firstElementAsProperty = true ) {
+		$this->firstElementAsProperty = (bool)$firstElementAsProperty;
 		return $this;
 	}
 
 	/**
-	 * Parse parameters and return results to the ParserOutput object
-	 *
 	 * @since 1.9
 	 *
 	 * @param ArrayFormatter $params
@@ -71,7 +64,7 @@ class SubobjectParserFunction {
 	 */
 	public function parse( ArrayFormatter $parameters ) {
 
-		$this->addSubobjectValues( $parameters );
+		$this->addDataValuesToSubobject( $parameters );
 
 		$this->parserData->getSemanticData()->addPropertyObjectValue(
 			$this->subobject->getProperty(),
@@ -80,18 +73,18 @@ class SubobjectParserFunction {
 
 		$this->parserData->updateOutput();
 
-		return $this->msgFormatter
+		return $this->messageFormatter
 			->addFromArray( $this->subobject->getErrors() )
 			->addFromArray( $this->parserData->getErrors() )
 			->addFromArray( $parameters->getErrors() )
 			->getHtml();
 	}
 
-	protected function addSubobjectValues( ArrayFormatter $parameters ) {
+	protected function addDataValuesToSubobject( ArrayFormatter $parameters ) {
 
 		$subject = $this->parserData->getSemanticData()->getSubject();
 
-		$this->subobject->setSemanticData( $this->createSubobjectId( $parameters ) );
+		$this->subobject->setEmptySemanticDataForId( $this->createSubobjectId( $parameters ) );
 
 		foreach ( $this->transformParametersToArray( $parameters ) as $property => $values ) {
 
@@ -117,9 +110,9 @@ class SubobjectParserFunction {
 
 		$isAnonymous = in_array( $parameters->getFirst(), array( null, '' ,'-' ) );
 
-		$this->objectReference = $this->objectReference && !$isAnonymous;
+		$this->firstElementAsProperty = $this->firstElementAsProperty && !$isAnonymous;
 
-		if ( $this->objectReference || $isAnonymous ) {
+		if ( $this->firstElementAsProperty || $isAnonymous ) {
 			return $this->subobject->generateId( new HashIdGenerator( $parameters->toArray(), '_' ) );
 		}
 
@@ -128,7 +121,7 @@ class SubobjectParserFunction {
 
 	protected function transformParametersToArray( ArrayFormatter $parameters ) {
 
-		if ( $this->objectReference ) {
+		if ( $this->firstElementAsProperty ) {
 			$parameters->addParameter(
 				$parameters->getFirst(),
 				$this->parserData->getTitle()->getPrefixedText()

--- a/tests/phpunit/includes/parserhooks/RecurringEventsParserFunctionTest.php
+++ b/tests/phpunit/includes/parserhooks/RecurringEventsParserFunctionTest.php
@@ -11,23 +11,17 @@ use Title;
 use ParserOutput;
 
 /**
- * Tests for the RecurringEventsParserFunction class.
- *
- * @file
- *
- * @license GNU GPL v2+
- * @since   1.9
- *
- * @author mwjames
- */
-
-/**
  * @covers \SMW\RecurringEventsParserFunction
  *
  * @ingroup Test
  *
  * @group SMW
  * @group SMWExtension
+ *
+ * @license GNU GPL v2+
+ * @since   1.9
+ *
+ * @author mwjames
  */
 class RecurringEventsParserFunctionTest extends ParserTestCase {
 

--- a/tests/phpunit/includes/parserhooks/SubobjectParserFunctionTest.php
+++ b/tests/phpunit/includes/parserhooks/SubobjectParserFunctionTest.php
@@ -23,7 +23,7 @@ use ParserOutput;
  * @group SMW
  * @group SMWExtension
  *
- * @licence GNU GPL v2+
+ * @license GNU GPL v2+
  * @since 1.9
  *
  * @author mwjames
@@ -97,11 +97,9 @@ class SubobjectParserFunctionTest extends ParserTestCase {
 	}
 
 	/**
-	 * @dataProvider getObjectReferenceDataProvider
-	 *
-	 * @since 1.9
+	 * @dataProvider firstElementDataProvider
 	 */
-	public function testObjectReference( $isEnabled, array $params, array $expected, array $info ) {
+	public function testFirstElementAsProperty( $isEnabled, array $params, array $expected, array $info ) {
 
 		$parserOutput = $this->newParserOutput();
 		$title        = $this->newTitle();
@@ -109,7 +107,7 @@ class SubobjectParserFunctionTest extends ParserTestCase {
 
 		// Initialize and parse
 		$instance = $this->newInstance( $subobject, $parserOutput );
-		$instance->setObjectReference( $isEnabled );
+		$instance->setFirstElementAsProperty( $isEnabled );
 		$instance->parse( $this->getParserParameterFormatter( $params ) );
 
 		// If it is enabled only check for the first character {0} that should
@@ -314,12 +312,7 @@ class SubobjectParserFunctionTest extends ParserTestCase {
 		);
 	}
 
-	/**
-	 * Subject reference data provider
-	 *
-	 * @return array
-	 */
-	public function getObjectReferenceDataProvider() {
+	public function firstElementDataProvider() {
 		return array(
 
 			// #0


### PR DESCRIPTION
- Deprecated setSemanticData in Subobject and replaced by a more approriate setEmptySemanticDataForId
- Renamed setObjectReference in SubobjectParserFunction to setFirstElementAsProperty
