### PR TITLE
Fix filenames for downloadable query results

### DIFF
--- a/includes/queryprinters/FileExportPrinter.php
+++ b/includes/queryprinters/FileExportPrinter.php
@@ -49,7 +49,9 @@ abstract class FileExportPrinter extends ResultPrinter implements ExportPrinter 
 		$fileName = $this->getFileName( $queryResult );
 
 		if ( $fileName !== false ) {
-			header( "content-disposition: attachment; filename=$fileName" );
+			$utf8Name = rawurlencode( $fileName );
+			$fileName = iconv( "UTF-8", "ASCII//TRANSLIT", $fileName );
+			header( "content-disposition: attachment; filename=\"$fileName\"; filename*=UTF-8''$utf8Name;" );
 		}
 
 		echo $result;


### PR DESCRIPTION
Filenames conatining spaces ("foo bar.csv") or non-ASCII characters were
garbled when sent to the client.

The filename parameter of the content-disposition header line should only
contain ASCII characters according to spec (RFC 2183). Modern browsers
recognize an additional filename\* parameter, which allows specification of
UTF8-encoded file names (RFC 5987).
