### PR TITLE
PHPUnit 4.2 compat

### DIFF
--- a/includes/storage/SQLStore/SMW_SQLStore3.php
+++ b/includes/storage/SQLStore/SMW_SQLStore3.php
@@ -704,9 +704,9 @@ class SMWSQLStore3 extends SMWStore {
 	 * @param string $typeid
 	 * @return string
 	 */
-	public static function findTypeTableId( $typeid ) {
+	public function findTypeTableId( $typeid ) {
 		$dataItemId = DataTypeRegistry::getInstance()->getDataItemId( $typeid );
-		return self::findDiTypeTableId( $dataItemId );
+		return $this->findDiTypeTableId( $dataItemId );
 	}
 
 	/**
@@ -718,7 +718,7 @@ class SMWSQLStore3 extends SMWStore {
 	 * @param integer $dataItemId
 	 * @return string
 	 */
-	public static function findDiTypeTableId( $dataItemId ) {
+	public function findDiTypeTableId( $dataItemId ) {
 		if ( array_key_exists( $dataItemId, self::$di_type_tables ) ) {
 			return self::$di_type_tables[$dataItemId];
 		} else {

--- a/tests/phpunit/Integration/MediaWiki/NamespaceRegistrationDBIntegrationTest.php
+++ b/tests/phpunit/Integration/MediaWiki/NamespaceRegistrationDBIntegrationTest.php
@@ -38,7 +38,7 @@ class NamespaceRegistrationDBIntegrationTest extends MwDBSQLStoreIntegrationTest
 		$smwBasePath = __DIR__ . '../../../..';
 
 		$instance = $this->getMock( '\SMW\NamespaceManager',
-			array( 'assertConstantIsDefined' ),
+			array( 'isDefinedConstant' ),
 			array(
 				&$default,
 				$smwBasePath
@@ -46,7 +46,7 @@ class NamespaceRegistrationDBIntegrationTest extends MwDBSQLStoreIntegrationTest
 		);
 
 		$instance->expects( $this->any() )
-			->method( 'assertConstantIsDefined' )
+			->method( 'isDefinedConstant' )
 			->will( $this->returnValue( false ) );
 
 		$this->assertTrue( $instance->run() );

--- a/tests/phpunit/includes/MediaWiki/DatabaseTest.php
+++ b/tests/phpunit/includes/MediaWiki/DatabaseTest.php
@@ -13,7 +13,7 @@ use SMW\MediaWiki\Database;
  * @group SMW
  * @group SMWExtension
  *
- * @licence GNU GPL v2+
+ * @license GNU GPL v2+
  * @since 1.9.0.2
  *
  * @author mwjames
@@ -150,19 +150,27 @@ class DatabaseTest extends \PHPUnit_Framework_TestCase {
 
 	public function testSelectThrowsException() {
 
+		$instance = new Database( new MockDBConnectionProvider );
+
 		$this->setExpectedException( 'RuntimeException' );
 
-		$instance = new Database( new MockDBConnectionProvider );
-		$this->assertInstanceOf( 'ResultWrapper', $instance->select( 'Foo', 'Bar', '', __METHOD__ ) );
-
+		$this->assertInstanceOf(
+			'ResultWrapper',
+			$instance->select( 'Foo', 'Bar', '', __METHOD__ )
+		);
 	}
 
 	public function testQueryThrowsException() {
 
-		$this->setExpectedException( 'RuntimeException' );
+		// FIXME MW 1.19/1.21
+		if ( version_compare( $GLOBALS['wgVersion'], '1.22', '<' ) ) {
+			$this->markTestSkipped(
+				"MW 1.22 or higher is required for the test (see DBError)"
+			);
+		}
 
 		$DBError = $this->getMockBuilder( 'DBError' )
-			->disableOriginalConstructor()
+			->setConstructorArgs( array( null, 'foo' ) )
 			->getMock();
 
 		$connectionProvider = new MockDBConnectionProvider();
@@ -173,8 +181,13 @@ class DatabaseTest extends \PHPUnit_Framework_TestCase {
 			->will( $this->throwException( $DBError ) );
 
 		$instance = new Database( $connectionProvider );
-		$this->assertInstanceOf( 'ResultWrapper', $instance->query( 'Foo', __METHOD__ ) );
 
+		$this->setExpectedException( 'RuntimeException' );
+
+		$this->assertInstanceOf(
+			'ResultWrapper',
+			$instance->query( 'Foo', __METHOD__ )
+		);
 	}
 
 	public function testMissingWriteConnectionThrowsException() {

--- a/tests/phpunit/includes/Store/Maintenance/DataRebuilderTest.php
+++ b/tests/phpunit/includes/Store/Maintenance/DataRebuilderTest.php
@@ -86,8 +86,7 @@ class DataRebuilderTest extends \PHPUnit_Framework_TestCase {
 			->disableOriginalConstructor()
 			->setMethods( array(
 				'refreshData',
-				'drop',
-				'setupStore' ) )
+				'drop' ) )
 			->getMockForAbstractClass();
 
 		$store->expects( $this->once() )
@@ -96,9 +95,6 @@ class DataRebuilderTest extends \PHPUnit_Framework_TestCase {
 
 		$store->expects( $this->once() )
 			->method( 'drop' );
-
-		$store::staticExpects( $this->once() )
-			->method( 'setupStore' );
 
 		$instance = new DataRebuilder( $store, null );
 

--- a/tests/phpunit/includes/storage/sqlstore/WantedPropertiesCollectorTest.php
+++ b/tests/phpunit/includes/storage/sqlstore/WantedPropertiesCollectorTest.php
@@ -195,7 +195,7 @@ class WantedPropertiesCollectorTest extends \SMW\Test\SemanticMediaWikiTestCase 
 			->method( 'getPropertyTables' )
 			->will( $this->returnValue( array( 'Foo' => $tableDefinition ) ) );
 
-		$store::staticExpects( $this->atLeastOnce() )
+		$store->expects( $this->atLeastOnce() )
 			->method( 'findTypeTableId' )
 			->will( $this->returnValue( 'Foo' ) );
 


### PR DESCRIPTION
- Removed `::staticExpects` (see [0])
- Removed static caller where necessary (only used within `SMWSQLStore3`), `public static function findTypeTableId`, `public static function findDiTypeTableId`
- `SMW\Store::setupStore` remains static, dropped mock instead

[0] https://github.com/sebastianbergmann/phpunit/wiki/Release-Announcement-for-PHPUnit-4.0.0#backwards-compatibility-issues
