### PR TITLE
Add SMW\Tests\ClassAutoLoader

### DIFF
--- a/SemanticMediaWiki.php
+++ b/SemanticMediaWiki.php
@@ -98,15 +98,6 @@ $GLOBALS['wgExtensionMessagesFiles']['SemanticMediaWikiMagic'] = $GLOBALS['smwgI
 $GLOBALS['wgExtensionMessagesFiles']['SemanticMediaWikiNamespaces'] = $GLOBALS['smwgIP'] . 'languages/SemanticMediaWiki.namespaces.php';
 
 /**
- * @since 1.9.3
- *
- * TEMPORARY FIX until an appropriate testLoader is provided for third-party
- * extensions that rely on some test classes to be present
- */
-$GLOBALS['wgAutoloadClasses']['SMW\Test\QueryPrinterTestCase']   = __DIR__ . '/tests/phpunit/QueryPrinterTestCase.php';
-$GLOBALS['wgAutoloadClasses']['SMW\Test\QueryPrinterRegistryTestCase']   = __DIR__ . '/tests/phpunit/QueryPrinterRegistryTestCase.php';
-
-/**
  * Setup and initialization
  *
  * @note $wgExtensionFunctions variable is an array that stores

--- a/tests/ClassAutoLoader.php
+++ b/tests/ClassAutoLoader.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace SMW\Tests;
+
+use Composer\Autoload\ClassLoader ;
+
+/**
+ * @license GNU GPL v2+
+ * @since 1.9.3
+ *
+ * @author mwjames
+ */
+class ClassAutoLoader {
+
+	protected $classLoader = null;
+
+	/**
+	 * @since 1.9.3
+	 *
+	 * @param ClassLoader $classLoader
+	 */
+	public function __construct( ClassLoader $classLoader ) {
+		$this->classLoader = $classLoader;
+	}
+
+	/**
+	 * @since 1.9.3
+	 */
+	public function addClassesToRunFullTest() {
+		print( "Add SemanticMediaWiki tests ...\n\n" );
+
+		$this->classLoader->addPsr4( 'SMW\\Test\\', __DIR__ . '/phpunit' );
+		$this->classLoader->addPsr4( 'SMW\\Tests\\', __DIR__ . '/phpunit' );
+
+		// FIXME
+		$this->classLoader->addClassMap( array(
+			'SMW\Tests\DataItemTest'                     => __DIR__ . '/phpunit/includes/dataitems/DataItemTest.php',
+			'SMW\Tests\Reporter\MessageReporterTestCase' => __DIR__ . '/phpunit/includes/Reporter/MessageReporterTestCase.php',
+			'SMW\Maintenance\RebuildConceptCache'        => __DIR__ . '/../maintenance/rebuildConceptCache.php',
+			'SMW\Maintenance\RebuildData'                => __DIR__ . '/../maintenance/rebuildData.php',
+			'SMW\Maintenance\RebuildPropertyStatistics'  => __DIR__ . '/../maintenance/rebuildPropertyStatistics.php'
+		) );
+	}
+
+	/**
+	 * @note mostly used by external extensions that require to test
+	 * integration with SMW
+	 *
+	 * @since 1.9.3
+	 */
+	public function addClassesToSupportIntegrationTests() {
+		print( "Add SemanticMediaWiki integration tests ...\n\n" );
+
+		$this->classLoader->addPsr4( 'SMW\\Tests\\', __DIR__ . '/phpunit' );
+
+		// FIXME PSR-4 laoding does't work here yet since it uses SMW\Test\....
+		$this->classLoader->addClassMap( array(
+			'SMW\Test\QueryPrinterRegistryTestCase' => __DIR__ . '/phpunit/QueryPrinterRegistryTestCase.php',
+			'SMW\Test\QueryPrinterTestCase' => __DIR__ . '/phpunit/QueryPrinterTestCase.php'
+		) );
+	}
+
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -5,7 +5,7 @@ if ( php_sapi_name() !== 'cli' ) {
 }
 
 if ( !defined( 'MEDIAWIKI' ) ) {
-	die( 'MediaWiki is not available for the test environment' );
+	die( 'MediaWiki is required for the test environment' );
 }
 
 function registerAutoloaderPath( $identifier, $path ) {
@@ -28,17 +28,8 @@ function runTestAutoLoader() {
 		return false;
 	}
 
-	$autoLoader->addPsr4( 'SMW\\Test\\', __DIR__ . '/phpunit' );
-	$autoLoader->addPsr4( 'SMW\\Tests\\', __DIR__ . '/phpunit' );
-
-	// FIXME
-	$autoLoader->addClassMap( array(
-		'SMW\Tests\DataItemTest'                     => __DIR__ . '/phpunit/includes/dataitems/DataItemTest.php',
-		'SMW\Tests\Reporter\MessageReporterTestCase' => __DIR__ . '/phpunit/includes/Reporter/MessageReporterTestCase.php',
-		'SMW\Maintenance\RebuildConceptCache'        => __DIR__ . '/../maintenance/rebuildConceptCache.php',
-		'SMW\Maintenance\RebuildData'                => __DIR__ . '/../maintenance/rebuildData.php',
-		'SMW\Maintenance\RebuildPropertyStatistics'  => __DIR__ . '/../maintenance/rebuildPropertyStatistics.php'
-	) );
+	$classAutoLoader = new \SMW\Tests\ClassAutoLoader( $autoLoader );
+	$classAutoLoader->addClassesToRunFullTest();
 
 	return true;
 }


### PR DESCRIPTION
For internal and external use to explicitly invoke classes to allow integration tests.

```
$classAutoLoader = new \SMW\Tests\ClassAutoLoader( $composerAutoLoader );
$classAutoLoader->addClassesToSupportIntegrationTests();
```
