### PR TITLE
Enable Jena Fuseki SPARQL as service on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,8 @@ matrix:
       php: 5.6
     - env: DBTYPE=mysql; MW=1.19.0; TYPE=relbuild
       php: 5.4
+    - env: DBTYPE=mysql; MW=1.23.0; FUSEKI=1.0.2
+      php: 5.4
     - env: DBTYPE=sqlite; MW=1.22.6;
       php: 5.5
     - env: DBTYPE=postgres; MW=1.19.0
@@ -21,6 +23,7 @@ matrix:
     - env: THENEEDFORTHIS=FAIL
   allow_failures:
     - env: DBTYPE=mysql; MW=1.19.0; TYPE=relbuild
+    - env: DBTYPE=mysql; MW=1.23.0; FUSEKI=1.0.2
     - php: hhvm
 
 before_script: bash ./build/travis/before_script.sh

--- a/tests/phpunit/MwDBSQLStoreIntegrationTestCase.php
+++ b/tests/phpunit/MwDBSQLStoreIntegrationTestCase.php
@@ -25,11 +25,6 @@ use UnexpectedValueException;
  */
 abstract class MwDBSQLStoreIntegrationTestCase extends MwDBaseUnitTestCase {
 
-	/**
-	 * In order for the test not being influenced by an exisiting setup
-	 * registration we temporary remove from the GLOBALS configuration
-	 * in order to enable hook and context assignment freely during testing
-	 */
 	private $wgHooks = array();
 
 	protected function setUp() {
@@ -48,17 +43,6 @@ abstract class MwDBSQLStoreIntegrationTestCase extends MwDBaseUnitTestCase {
 	protected function runExtensionSetup( $context, $directory = 'Foo' ) {
 		$setup = new Setup( $GLOBALS, $directory, $context );
 		$setup->run();
-	}
-
-	protected function getStore() {
-
-		$store = parent::getStore();
-
-		if ( !( $store instanceof \SMWSQLStore3 ) ) {
-			$this->markTestSkipped( 'Test only applicable for SMWSQLStore3' );
-		}
-
-		return $store;
 	}
 
 	protected function createPage( Title $title, $editContent = '' ) {

--- a/tests/phpunit/Regression/RebuildConceptCacheMaintenanceRegressionTest.php
+++ b/tests/phpunit/Regression/RebuildConceptCacheMaintenanceRegressionTest.php
@@ -50,6 +50,10 @@ class RebuildConceptCacheMaintenanceRegressionTest extends MwRegressionTestCase 
 
 	public function assertDataImport() {
 
+		if ( $this->getStore() instanceof \SMWSparqlStore ) {
+			$this->markTestSkipped( "Can't be tested because of undefined method SMWSparqlStore::getConceptCacheStatus" );
+		}
+
 		$conceptPage = $this->createConceptPage( 'Lorem ipsum concept', '[[Category:Lorem ipsum]]' );
 
 		$maintenanceRunner = new MaintenanceRunner( 'SMW\Maintenance\RebuildConceptCache' );

--- a/tests/phpunit/includes/storage/StoreTest.php
+++ b/tests/phpunit/includes/storage/StoreTest.php
@@ -235,6 +235,11 @@ class StoreTest extends MwDBaseUnitTestCase {
 	public function testSetGetDatabase() {
 
 		$store = StoreFactory::getStore();
+
+		if ( !( $store instanceof \SMWSQLStore3 ) ) {
+			$this->markTestSkipped( 'Test is only available for SMWSQLStore3' );
+		}
+
 		$database = $store->getDatabase();
 
 		$this->assertInstanceOf( '\SMW\MediaWiki\Database', $database );


### PR DESCRIPTION
Runs Jena Fuseki SPARQL 1.0.2 as service.

It will currently return an error because `JSON` is expected as default ("&output=xml" to $parameterString in the doQuery function) [0].

```
1) SMW\Tests\Integration\QuerySourceIntegrationTest::testQueryRoutingWithDefaultSource
SMWSparqlDatabaseError: A SPARQL query error has occurred
Query: PREFIX wiki: <http://example.org/id/>
PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
PREFIX owl: <http://www.w3.org/2002/07/owl#>
PREFIX swivt: <http://semantic-mediawiki.org/swivt/1.0#>
PREFIX property: <http://example.org/id/Property-3A>
PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
SELECT DISTINCT ?result WHERE {
?result swivt:page ?url .

}
OFFSET 
LIMIT 1
Error: Malformed query
Endpoint: http://localhost:3030/db/query
HTTP response code: 400
```

But Travis sucessfully runs the service with SPARQL queries like:

```
20:45:20 INFO  [8261] exec/select
20:45:20 INFO  [8261] 200 OK (1 ms) 
20:45:20 INFO  [8262] POST http://localhost:3030/db/query
20:45:20 INFO  [8262] Query = PREFIX wiki: <http://example.org/id/> PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#> PREFIX owl: <http://www.w3.org/2002/07/owl#> PREFIX swivt: <http://semantic-mediawiki.org/swivt/1.0#> PREFIX property: <http://example.org/id/Property-3A> PREFIX xsd: <http://www.w3.org/2001/XMLSchema#> SELECT * WHERE { swivt:page swivt:wikiPageSortKey ?s  OPTIONAL { swivt:page swivt:redirectsTo ?r } } LIMIT 1
20:45:20 INFO  [8262] exec/select
20:45:20 INFO  [8262] 200 OK (1 ms) 
20:45:20 INFO  [8263] POST http://localhost:3030/db/query
```

For the first time it will be possible to actually test [1] the `SMWSparqlDatabase` implementation.

[0] http://semantic-mediawiki.org/wiki/Help:Using_SPARQL_and_RDF_stores#Jena_Fuseki
[1] https://api.travis-ci.org/jobs/27900842/log.txt?deansi=true
