### PR TITLE
Tidy some tests

### DIFF
--- a/tests/phpunit/Integration/SimpleQueryResultQueryProcessorIntegrationTest.php
+++ b/tests/phpunit/Integration/SimpleQueryResultQueryProcessorIntegrationTest.php
@@ -1,7 +1,8 @@
 <?php
 
-namespace SMW\Test;
+namespace SMW\Tests\Integration;
 
+use SMW\StoreFactory;
 use SMWQueryProcessor;
 
 /**
@@ -13,25 +14,32 @@ use SMWQueryProcessor;
  * @license GNU GPL v2+
  * @author mwjames
  */
-class QueryResultTest extends SemanticMediaWikiTestCase {
+class SimpleQueryResultQueryProcessorIntegrationTest extends \PHPUnit_Framework_TestCase {
 
 	/**
-	 * Returns the name of the class to be tested
-	 *
-	 * @return string
+	 * @dataProvider queryDataProvider
 	 */
-	public function getClass() {
-		return '\SMWQueryResult';
+	public function testCanConstructor( array $test ) {
+
+		$this->assertInstanceOf(
+			'\SMWQueryResult',
+			$this->getQueryResultFor( $test['query'] )
+		);
 	}
 
 	/**
-	 * Helper method that returns a QueryResult object
-	 *
-	 * @since 1.9
+	 * @dataProvider queryDataProvider
 	 */
-	private function newQueryResultOnSQLStore( $queryString ) {
+	public function testToArray( array $test, array $expected ) {
 
-		$this->runOnlyOnSQLStore();
+		$instance = $this->getQueryResultFor( $test['query'] );
+		$results  = $instance->toArray();
+
+		$this->assertEquals( $expected[0], $results['printrequests'][0] );
+		$this->assertEquals( $expected[1], $results['printrequests'][1] );
+	}
+
+	private function getQueryResultFor( $queryString ) {
 
 		list( $query, $formattedParams ) = SMWQueryProcessor::getQueryAndParamsFromFunctionParams(
 			$queryString,
@@ -40,36 +48,9 @@ class QueryResultTest extends SemanticMediaWikiTestCase {
 			false
 		);
 
-		return \SMW\StoreFactory::getStore()->getQueryResult( $query );
+		return StoreFactory::getStore()->getQueryResult( $query );
 	}
 
-	/**
-	 * @dataProvider queryDataProvider
-	 *
-	 * @since 1.9
-	 */
-	public function testConstructor( array $test ) {
-		$this->assertInstanceOf( $this->getClass(), $this->newQueryResultOnSQLStore( $test['query'] ) );
-	}
-
-	/**
-	 * @dataProvider queryDataProvider
-	 *
-	 * @since  1.9
-	 */
-	public function testToArray( array $test, array $expected ) {
-
-		$instance = $this->newQueryResultOnSQLStore( $test['query'] );
-		$results  = $instance->toArray();
-
-		//  Compare array structure
-		$this->assertEquals( $expected[0], $results['printrequests'][0] );
-		$this->assertEquals( $expected[1], $results['printrequests'][1] );
-	}
-
-	/**
-	 * @return array
-	 */
 	public function queryDataProvider() {
 
 		$provider = array();

--- a/tests/phpunit/includes/api/AskArgsTest.php
+++ b/tests/phpunit/includes/api/AskArgsTest.php
@@ -10,35 +10,24 @@ use SMW\Api\AskArgs;
  *
  * @group SMW
  * @group SMWExtension
- * @group API
+ * @group semantic-mediawiki-api
+ * @group mediawiki-api
  *
- * @licence GNU GPL v2+
+ * @license GNU GPL v2+
  * @since 1.9
  *
  * @author mwjames
  */
 class AskArgsTest extends ApiTestCase {
 
-	/**
-	 * @return string
-	 */
 	public function getClass() {
 		return '\SMW\Api\AskArgs';
 	}
 
 	/**
 	 * @dataProvider queryDataProvider
-	 *
-	 * This test only verifies if either an error result or
-	 * a "normal" query result array is returned. The test makes
-	 * only an assymptions about a predefinied property
-	 * "Modification date" printrequests
-	 *
-	 * @since 1.9
 	 */
-	public function testExecuteOnSQLStore( array $query, array $expected ) {
-
-		$this->runOnlyOnSQLStore();
+	public function testExecuteOnStore( array $query, array $expected ) {
 
 		$results = $this->doApiRequest( array(
 			'action'     => 'askargs',
@@ -50,11 +39,13 @@ class AskArgsTest extends ApiTestCase {
 		$this->assertInternalType( 'array', $results );
 
 		if ( isset( $expected['error'] ) ) {
-			$this->assertArrayHasKey( 'error', $results );
-		} else {
-			$this->assertEquals( $expected, $results['query']['printrequests'] );
+			return $this->assertArrayHasKey( 'error', $results );
 		}
 
+		$this->assertEquals(
+			$expected,
+			$results['query']['printrequests']
+		);
 	}
 
 	/**

--- a/tests/phpunit/includes/api/BrowseBySubjectTest.php
+++ b/tests/phpunit/includes/api/BrowseBySubjectTest.php
@@ -12,32 +12,24 @@ use SMW\DIWikiPage;
  *
  * @group SMW
  * @group SMWExtension
- * @group API
+ * @group semantic-mediawiki-api
+ * @group mediawiki-api
  *
- * @licence GNU GPL v2+
+ * @license GNU GPL v2+
  * @since 1.9
  *
  * @author mwjames
  */
 class BrowseBySubjectTest extends ApiTestCase {
 
-	/**
-	 * @return string|false
-	 */
 	public function getClass() {
 		return '\SMW\Api\BrowseBySubject';
 	}
 
-	/**
-	 * @since 1.9
-	 */
 	private function newSemanticData( $text ) {
 		return $data = new SemanticData( DIWikiPage::newFromTitle( $this->newTitle( NS_MAIN, $text ) ) );
 	}
 
-	/**
-	 * @since 1.9
-	 */
 	public function testInvokeContext() {
 
 		$instance = new BrowseBySubject( $this->getApiMain( array( 'subject' => 'Foo' ) ), 'browsebysubject' );
@@ -47,35 +39,28 @@ class BrowseBySubjectTest extends ApiTestCase {
 
 		$instance->invokeContext( $instance->withContext() );
 		$this->assertTrue( $context === $instance->withContext() );
-
 	}
 
 	/**
 	 * @dataProvider subjectDataProvider
-	 *
-	 * @since 1.9
 	 */
-	public function testExecuteOnSQLStore( $setup ) {
-
-		$this->runOnlyOnSQLStore();
+	public function testExecuteOnStore( $setup ) {
 
 		$result = $this->doApiRequest( array(
 			'action'  => 'browsebysubject',
 			'subject' => $setup['subject']
 		) );
 
-		$this->assertStructuralIntegrity( $setup, $result );
-
+		$this->assertStructuralIntegrity(
+			$setup,
+			$result
+		);
 	}
 
 	/**
 	 * @dataProvider invalidTitleDataProvider
-	 *
-	 * @since 1.9
 	 */
-	public function testInvalidTitleExecuteOnSQLStore( $setup ) {
-
-		$this->runOnlyOnSQLStore();
+	public function testInvalidTitleExecuteOnStore( $setup ) {
 
 		$this->setExpectedException( 'Exception' );
 
@@ -84,8 +69,10 @@ class BrowseBySubjectTest extends ApiTestCase {
 			'subject' => $setup['subject']
 		) );
 
-		$this->assertStructuralIntegrity( $setup, $result );
-
+		$this->assertStructuralIntegrity(
+			$setup,
+			$result
+		);
 	}
 
 	/**
@@ -116,13 +103,12 @@ class BrowseBySubjectTest extends ApiTestCase {
 			$this->assertTrue( true );
 		};
 
-		$this->assertStructuralIntegrity( $setup, $instance->getResultData() );
-
+		$this->assertStructuralIntegrity(
+			$setup,
+			$instance->getResultData()
+		);
 	}
 
-	/**
-	 * @since 1.9
-	 */
 	public function assertStructuralIntegrity( $setup, $result ) {
 
 		$this->assertInternalArrayStructure( $setup, $result, 'hasError',   'array',  function( $r ) { return $r['error']; } );
@@ -130,7 +116,6 @@ class BrowseBySubjectTest extends ApiTestCase {
 		$this->assertInternalArrayStructure( $setup, $result, 'hasSubject', 'string', function( $r ) { return $r['query']['subject']; } );
 		$this->assertInternalArrayStructure( $setup, $result, 'hasData',    'array',  function( $r ) { return $r['query']['data']; } );
 		$this->assertInternalArrayStructure( $setup, $result, 'hasSobj',    'array',  function( $r ) { return $r['query']['sobj']; } );
-
 	}
 
 	protected function assertInternalArrayStructure( $setup, $result, $field, $internalType, $definition ) {
@@ -139,9 +124,6 @@ class BrowseBySubjectTest extends ApiTestCase {
 		}
 	}
 
-	/**
-	 * @return array
-	 */
 	public function subjectDataProvider() {
 
 		$provider = array();
@@ -158,9 +140,6 @@ class BrowseBySubjectTest extends ApiTestCase {
 		return $provider;
 	}
 
-	/**
-	 * @return array
-	 */
 	public function redirectDataProvider() {
 
 		$mockStore = $this->newMockBuilder()->newObject( 'Store', array(
@@ -205,9 +184,6 @@ class BrowseBySubjectTest extends ApiTestCase {
 		return $provider;
 	}
 
-	/**
-	 * @return array
-	 */
 	public function invalidTitleDataProvider() {
 
 		$provider = array();

--- a/tests/phpunit/includes/api/InfoTest.php
+++ b/tests/phpunit/includes/api/InfoTest.php
@@ -10,30 +10,24 @@ use SMW\Api\Info;
  *
  * @group SMW
  * @group SMWExtension
- * @group API
+ * @group semantic-mediawiki-api
+ * @group mediawiki-api
  *
- * @licence GNU GPL v2+
+ * @license GNU GPL v2+
  * @since 1.9
  *
  * @author mwjames
  */
 class InfoTest extends ApiTestCase {
 
-	/**
-	 * @return string|false
-	 */
 	public function getClass() {
 		return '\SMW\Api\Info';
 	}
 
 	/**
 	 * @dataProvider typeDataProvider
-	 *
-	 * @since 1.9
 	 */
-	public function testExecuteOnSQLStore( $queryParameters, $expectedType ) {
-
-		$this->runOnlyOnSQLStore();
+	public function testExecuteOnStore( $queryParameters, $expectedType ) {
 
 		$result = $this->doApiRequest( array(
 				'action' => 'smwinfo',
@@ -46,16 +40,10 @@ class InfoTest extends ApiTestCase {
 		} else {
 			$this->assertInternalType( 'array', $result['info'][$queryParameters] );
 		}
-
 	}
 
 	/**
 	 * @dataProvider countDataProvider
-	 *
-	 * Test against a mock store to ensure that methods are executed
-	 * regardless whether a "real" Store is available or not
-	 *
-	 * @since 1.9
 	 */
 	public function testExecuteOnMockStore( $test, $type, $expected ) {
 
@@ -87,13 +75,12 @@ class InfoTest extends ApiTestCase {
 				'info' => 'Foo'
 		) );
 
-		$this->assertInternalType( 'array', $data['warnings'] );
-
+		$this->assertInternalType(
+			'array',
+			$data['warnings']
+		);
 	}
 
-	/**
-	 * @return array
-	 */
 	public function countDataProvider() {
 		return array(
 			array( array( 'QUERYFORMATS' => array( 'table' => 3 ) ), 'formatcount', array( 'table' => 3 ) ),
@@ -108,9 +95,6 @@ class InfoTest extends ApiTestCase {
 		);
 	}
 
-	/**
-	 * @return array
-	 */
 	public function typeDataProvider() {
 		return array(
 			array( 'proppagecount',     'integer' ),

--- a/tests/phpunit/includes/storage/StoreFactoryTest.php
+++ b/tests/phpunit/includes/storage/StoreFactoryTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace SMW\Test;
+namespace SMW\Tests;
 
 use SMW\StoreFactory;
 use SMW\Settings;
@@ -13,62 +13,60 @@ use SMW\Settings;
  * @group SMW
  * @group SMWExtension
  *
- * @licence GNU GPL v2+
+ * @license GNU GPL v2+
  * @since 1.9
  *
  * @author mwjames
  */
 class StoreFactoryTest extends \PHPUnit_Framework_TestCase {
 
-	public function testGetStore() {
+	protected function tearDown() {
+		StoreFactory::clear();
 
-		$settings = Settings::newFromGlobals();
+		parent::tearDown();
+	}
 
-		// Default is handled by the method itself
+	public function testGetDefaultStore() {
+
 		$instance = StoreFactory::getStore();
-		$this->assertInstanceOf( $settings->get( 'smwgDefaultStore' ), $instance );
+
+		$this->assertInstanceOf(
+			Settings::newFromGlobals()->get( 'smwgDefaultStore' ),
+			$instance
+		);
 
 		$this->assertSame(
 			StoreFactory::getStore(),
 			$instance
 		);
 
-		// Reset static instance
 		StoreFactory::clear();
 
 		$this->assertNotSame(
 			StoreFactory::getStore(),
 			$instance
 		);
-
-		// Inject default store
-		$defaulStore = $settings->get( 'smwgDefaultStore' );
-		$instance = StoreFactory::getStore( $defaulStore );
-		$this->assertInstanceOf( $defaulStore, $instance );
 	}
 
-	public function testNewInstance() {
+	public function testDifferentStoreIdInstanceInvocation() {
 
-		$settings = Settings::newFromGlobals();
-
-		$defaulStore = $settings->get( 'smwgDefaultStore' );
-		$instance = StoreFactory::newInstance( $defaulStore );
-		$this->assertInstanceOf( $defaulStore, $instance );
+		$this->assertInstanceOf( 'SMW\Store', StoreFactory::getStore( '\SMWSQLStore3' ) );
+		$this->assertInstanceOf( 'SMW\Store', StoreFactory::getStore( '\SMWSparqlStore' ) );
 
 		$this->assertNotSame(
-			StoreFactory::newInstance( $defaulStore ),
-			$instance
+			StoreFactory::getStore( '\SMWSQLStore3' ),
+			StoreFactory::getStore( '\SMWSparqlStore' )
 		);
 	}
 
 	public function testStoreInstanceException() {
 		$this->setExpectedException( '\SMW\InvalidStoreException' );
-		StoreFactory::newInstance( '\SMW\StoreFactory' );
+		StoreFactory::getStore( '\SMW\StoreFactory' );
 	}
 
 	public function testStoreWithInvalidClassThrowsException() {
 		$this->setExpectedException( 'RuntimeException' );
-		StoreFactory::newInstance( 'foo' );
+		StoreFactory::getStore( 'foo' );
 	}
 
 	/**
@@ -78,6 +76,7 @@ class StoreFactoryTest extends \PHPUnit_Framework_TestCase {
 	 */
 	public function testSmwfGetStore() {
 		$store = smwfGetStore();
+
 		$this->assertInstanceOf( 'SMWStore', $store );
 		$this->assertInstanceOf( 'SMW\Store', $store );
 	}


### PR DESCRIPTION
- Added `StoreFactory::setDefaultStoreForUnitTest` to set a mock instance during testing
- ConceptParserFunctionTest extends \PHPUnit_Framework_TestCase
- SemanticDataTest extends \PHPUnit_Framework_TestCase
- SimpleQueryResultQueryProcessorIntegrationTest extends \PHPUnit_Framework_TestCase
- StoreFactoryTest
- AskArgsTest
- BrowseBySubjectTest
- InfoTest
### Fuseki-run
- Before: Tests: 2031, Assertions: 6018, Failures: 4, Skipped: 75
- After : Tests: 2030, Assertions: 6051, Failures: 4, Skipped: 54.

Relates to #337, #339
