### PR TITLE
Tidy more tests

### DIFF
--- a/tests/phpunit/MwDBaseUnitTestCase.php
+++ b/tests/phpunit/MwDBaseUnitTestCase.php
@@ -29,6 +29,9 @@ abstract class MwDBaseUnitTestCase extends \PHPUnit_Framework_TestCase {
 	/* @var array|null */
 	protected $databaseToBeExcluded = null;
 
+	/* @var array */
+	protected $storeToBeExcluded = array();
+
 	protected $destroyDatabaseTablesOnEachRun = false;
 	protected $isUsableUnitTestDatabase = true;
 
@@ -83,9 +86,21 @@ abstract class MwDBaseUnitTestCase extends \PHPUnit_Framework_TestCase {
 	}
 
 	protected function checkIfDatabaseCanBeUsedOtherwiseSkipTest() {
+
 		if ( !$this->isUsableUnitTestDatabase ) {
 			$this->markTestSkipped(
-				"Required database type is not available or is excluded"
+				"Database type is not available or was excluded"
+			);
+		}
+	}
+
+	protected function checkIfStoreCanBeUsedOtherwiseSkipTest() {
+
+		$store = get_class( $this->getStore() );
+
+		if ( in_array( $store, $this->storeToBeExcluded ) ) {
+			$this->markTestSkipped(
+				"{$store} was excluded"
 			);
 		}
 	}

--- a/tests/phpunit/MwRegressionTestCase.php
+++ b/tests/phpunit/MwRegressionTestCase.php
@@ -72,6 +72,7 @@ abstract class MwRegressionTestCase extends MwDBaseUnitTestCase {
 	public function testDataImport() {
 
 		$this->checkIfDatabaseCanBeUsedOtherwiseSkipTest();
+		$this->checkIfStoreCanBeUsedOtherwiseSkipTest();
 
 		$importRunner = new XmlImportRunner( $this->getSourceFile() );
 		$importRunner->setVerbose( true );

--- a/tests/phpunit/Regression/RebuildConceptCacheMaintenanceRegressionTest.php
+++ b/tests/phpunit/Regression/RebuildConceptCacheMaintenanceRegressionTest.php
@@ -25,6 +25,11 @@ use Title;
  */
 class RebuildConceptCacheMaintenanceRegressionTest extends MwRegressionTestCase {
 
+	/**
+	 * FIXME SMWSparqlStore::getConceptCacheStatus doesn't exist
+	 */
+	protected $storeToBeExcluded = array( 'SMWSparqlStore' );
+
 	public function getSourceFile() {
 		return __DIR__ . '/data/' . 'GenericLoremIpsumTest-Mw-1-19-7.xml';
 	}
@@ -49,10 +54,6 @@ class RebuildConceptCacheMaintenanceRegressionTest extends MwRegressionTestCase 
 	}
 
 	public function assertDataImport() {
-
-		if ( $this->getStore() instanceof \SMWSparqlStore ) {
-			$this->markTestSkipped( "SMWSparqlStore currently does not support getConceptCacheStatus" );
-		}
 
 		$conceptPage = $this->createConceptPage( 'Lorem ipsum concept', '[[Category:Lorem ipsum]]' );
 

--- a/tests/phpunit/Regression/RebuildPropertyStatisticsMaintenanceRegressionTest.php
+++ b/tests/phpunit/Regression/RebuildPropertyStatisticsMaintenanceRegressionTest.php
@@ -22,6 +22,11 @@ use SMW\Test\MwRegressionTestCase;
  */
 class RebuildPropertyStatisticsMaintenanceRegressionTest extends MwRegressionTestCase {
 
+	/**
+	 * FIXME SMWSparqlStore::getPropertyTables doesn't exist
+	 */
+	protected $storeToBeExcluded = array( 'SMWSparqlStore' );
+
 	public function getSourceFile() {
 		return __DIR__ . '/data/' . 'GenericLoremIpsumTest-Mw-1-19-7.xml';
 	}

--- a/tests/phpunit/includes/storage/StoreFactoryTest.php
+++ b/tests/phpunit/includes/storage/StoreFactoryTest.php
@@ -59,6 +59,20 @@ class StoreFactoryTest extends \PHPUnit_Framework_TestCase {
 		);
 	}
 
+	public function testSetDefaultStoreForUnitTest() {
+
+		$store = $this->getMockBuilder( '\SMWSQLStore3' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		StoreFactory::setDefaultStoreForUnitTest( $store );
+
+		$this->assertSame(
+			$store,
+			StoreFactory::getStore()
+		);
+	}
+
 	public function testStoreInstanceException() {
 		$this->setExpectedException( '\SMW\InvalidStoreException' );
 		StoreFactory::getStore( '\SMW\StoreFactory' );

--- a/tests/phpunit/includes/storage/sqlstore/PropertyStatisticsTableTest.php
+++ b/tests/phpunit/includes/storage/sqlstore/PropertyStatisticsTableTest.php
@@ -37,9 +37,6 @@ class PropertyStatisticsTableTest extends MwDBaseUnitTestCase {
 	}
 
 	public function testDeleteAll() {
-		if ( !( $this->getStore() instanceof \SMWSQLStore3 ) ) {
-			$this->markTestSkipped( 'Test only applicable to SMWSQLStore3' );
-		}
 
 		$statsTable = new PropertyStatisticsTable(
 			$this->getStore()->getDatabase(),
@@ -95,9 +92,6 @@ class PropertyStatisticsTableTest extends MwDBaseUnitTestCase {
 	 * @param int $usageCount
 	 */
 	public function testInsertUsageCount( $propId, $usageCount ) {
-		if ( !( $this->getStore() instanceof \SMWSQLStore3 ) ) {
-			$this->markTestSkipped( 'Test only applicable to SMWSQLStore3' );
-		}
 
 		$table = $this->getTable();
 
@@ -119,9 +113,6 @@ class PropertyStatisticsTableTest extends MwDBaseUnitTestCase {
 	}
 
 	public function testAddToUsageCounts() {
-		if ( !( $this->getStore() instanceof \SMWSQLStore3 ) ) {
-			$this->markTestSkipped( 'Test only applicable to SMWSQLStore3' );
-		}
 
 		$statsTable = new PropertyStatisticsTable(
 			$this->getStore()->getDatabase(),


### PR DESCRIPTION
- StoreFactoryTest
- Added `MwDBaseUnitTestCase::checkIfStoreCanBeUsedOtherwiseSkipTest`
- RebuildConceptCacheMaintenanceRegressionTest skip due to `SMWSparqlStore::getConceptCacheStatus`
- RebuildPropertyStatisticsMaintenanceRegressionTest skip due to `SMWSparqlStore::getPropertyTables`
- PropertyStatisticsTableTest
- Sql3StubSemanticDataTest extends \PHPUnit_Framework_TestCase
### Fuseki-run
- Before: Tests: 2030, Assertions: 6051, Failures: 4, Skipped: 54
- After Tests: 2034, Assertions: 6435, Failures: 1, Skipped: 6

Relates to #340, #337 
