### PR TITLE
Add FusekiDatabaseSimpleQueryLookupIntegrationTest

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,6 @@ matrix:
     - env: THENEEDFORTHIS=FAIL
   allow_failures:
     - env: DBTYPE=mysql; MW=1.19.0; TYPE=relbuild
-    - env: DBTYPE=mysql; MW=1.23.0; FUSEKI=1.0.2
     - php: hhvm
 
 before_script: bash ./build/travis/before_script.sh

--- a/SemanticMediaWiki.settings.php
+++ b/SemanticMediaWiki.settings.php
@@ -69,6 +69,33 @@ $GLOBALS['smwgSparqlDataEndpoint'] = 'http://localhost:8080/data/';
 $GLOBALS['smwgSparqlDefaultGraph'] = '';
 ##
 
+##
+# SparqlDBConnectionProvider
+#
+# Identifies a database connector that ought to be used together with the
+# SPARQLStore
+#
+# List of standard connectors ($smwgSparqlDatabase will have no effect)
+# - 'fuseki'
+# - 'virtuoso'
+# - '4store'
+# - 'default'
+#
+# With 1.9.3 it is suggested to assign the necessary connector to
+# $smwgSparqlDatabaseConnector in order to avoid arbitrary class assignments in
+# $smwgSparqlDatabase (which can change in future releases without further notice).
+#
+# In case $smwgSparqlDatabaseConnector = 'custom' is maintained, $smwgSparqlDatabase
+# is expected to contain a custom class connector where $smwgSparqlDatabase is only
+# to be sued for when a custom database connector is necessary.
+#
+# $smwgSparqlDatabaseConnector = 'custom' is set as legacy setting to allow for
+# existing (prior 1.9.3) customizing to work without changes.
+#
+# @since 1.9.3
+##
+$GLOBALS['smwgSparqlDatabaseConnector'] = 'custom';
+
 ###
 # Setting this option to true before including this file to enable the old
 # Type: namespace that SMW used up to version 1.5.*. This should only be

--- a/build/travis/before_script.sh
+++ b/build/travis/before_script.sh
@@ -137,7 +137,7 @@ function configureLocalSettings {
 	if [ "$FUSEKI" != "" ]
 	then
 		echo '$smwgDefaultStore = "SMWSparqlStore";' >> LocalSettings.php
-		echo '$smwgSparqlDatabase = "SMW\SPARQLStore\FusekiHttpDatabaseConnector";' >> LocalSettings.php
+		echo '$smwgSparqlDatabaseConnector = "Fuseki";' >> LocalSettings.php
 		echo '$smwgSparqlQueryEndpoint = "http://localhost:3030/db/query";' >> LocalSettings.php
 		echo '$smwgSparqlUpdateEndpoint = "http://localhost:3030/db/update";' >> LocalSettings.php
 		echo '$smwgSparqlDataEndpoint = "";' >> LocalSettings.php

--- a/includes/GlobalFunctions.php
+++ b/includes/GlobalFunctions.php
@@ -1,6 +1,7 @@
 <?php
 
 use SMW\NamespaceManager;
+use SMW\SPARQLStore\SparqlDBConnectionProvider;
 
 /**
  * Global functions specified and used by Semantic MediaWiki. In general, it is
@@ -231,13 +232,13 @@ function &smwfGetStore() {
  * @return SMWSparqlDatabase or null
  */
 function &smwfGetSparqlDatabase() {
-	global $smwgSparqlDatabase, $smwgSparqlDefaultGraph, $smwgSparqlQueryEndpoint,
-		$smwgSparqlUpdateEndpoint, $smwgSparqlDataEndpoint, $smwgSparqlDatabaseMaster;
-	if ( !isset( $smwgSparqlDatabaseMaster ) ) {
-		$smwgSparqlDatabaseMaster = new $smwgSparqlDatabase( $smwgSparqlDefaultGraph,
-			$smwgSparqlQueryEndpoint, $smwgSparqlUpdateEndpoint, $smwgSparqlDataEndpoint );
+
+	if ( !isset( $GLOBALS['smwgSparqlDatabaseMaster'] ) ) {
+		$connectionProvider = new SparqlDBConnectionProvider();
+		$GLOBALS['smwgSparqlDatabaseMaster'] = $connectionProvider->getConnection();
 	}
-	return $smwgSparqlDatabaseMaster;
+
+	return $GLOBALS['smwgSparqlDatabaseMaster'];
 }
 
 /**

--- a/includes/Settings.php
+++ b/includes/Settings.php
@@ -48,6 +48,7 @@ class Settings extends SimpleDictionary {
 			'smwgScriptPath' => $GLOBALS['smwgScriptPath'],
 			'smwgIP' => $GLOBALS['smwgIP'],
 			'smwgDefaultStore' => $GLOBALS['smwgDefaultStore'],
+			'smwgSparqlDatabaseConnector' => $GLOBALS['smwgSparqlDatabaseConnector'],
 			'smwgSparqlDatabase' => $GLOBALS['smwgSparqlDatabase'],
 			'smwgSparqlQueryEndpoint' => $GLOBALS['smwgSparqlQueryEndpoint'],
 			'smwgSparqlUpdateEndpoint' => $GLOBALS['smwgSparqlUpdateEndpoint'],

--- a/includes/src/Configuration/Configuration.php
+++ b/includes/src/Configuration/Configuration.php
@@ -57,6 +57,21 @@ class Configuration {
 		throw new InvalidArgumentException( 'Configuration key is unkown' );
 	}
 
+	/**
+	 * @since 1.9.3
+	 *
+	 * @param string $key
+	 * @param mixed $value
+	 */
+	public function set( $key, $value ) {
+
+		if ( is_string( $key ) ) {
+			$this->container[ $key ] = $value;
+		}
+
+		return $this;
+	}
+
 	protected function setContainer( $container ) {
 		$this->container = $container;
 		return $this;

--- a/includes/src/SPARQLStore/SMW_SparqlDatabase.php
+++ b/includes/src/SPARQLStore/SMW_SparqlDatabase.php
@@ -172,8 +172,9 @@ class SMWSparqlDatabase {
 		curl_setopt( $this->m_curlhandle, CURLOPT_FORBID_REUSE, false );
 		curl_setopt( $this->m_curlhandle, CURLOPT_FRESH_CONNECT, false );
 		curl_setopt( $this->m_curlhandle, CURLOPT_RETURNTRANSFER, true ); // put result into variable
-		curl_setopt( $this->m_curlhandle, CURLOPT_CONNECTTIMEOUT, 10 ); // timeout in seconds
 		curl_setopt( $this->m_curlhandle, CURLOPT_FAILONERROR, true );
+
+		$this->setConnectionTimeoutInSeconds( 10 );
 	}
 
 	/**
@@ -202,6 +203,7 @@ class SMWSparqlDatabase {
 		if ( $endpointType == self::EP_TYPE_QUERY ) {
 			curl_setopt( $this->m_curlhandle, CURLOPT_URL, $this->m_queryEndpoint );
 			curl_setopt( $this->m_curlhandle, CURLOPT_NOBODY, true );
+			curl_setopt( $this->m_curlhandle, CURLOPT_POST, true );
 		} elseif ( $endpointType == self::EP_TYPE_UPDATE ) {
 			if ( $this->m_updateEndpoint === '' ) {
 				return false;
@@ -368,7 +370,7 @@ class SMWSparqlDatabase {
 	 * @return boolean stating whether the operations succeeded
 	 */
 	public function deleteContentByValue( $propertyName, $objectName, $extraNamespaces = array() ) {
-		return smwfGetSparqlDatabase()->delete( "?s ?p ?o", "?s $propertyName $objectName . ?s ?p ?o", $extraNamespaces );
+		return $this->delete( "?s ?p ?o", "?s $propertyName $objectName . ?s ?p ?o", $extraNamespaces );
 	}
 
 	/**
@@ -602,6 +604,18 @@ class SMWSparqlDatabase {
 		} else {
 			throw new Exception( "Failed to communicate with SPARQL store.\n Endpoint: " . $endpoint . "\n Curl error: '" . curl_error( $this->m_curlhandle ) . "' ($error)" );
 		}
+	}
+
+	/**
+	 * @since  1.9.3
+	 *
+	 * @param integer $timeout
+	 *
+	 * @return SMWSparqlDatabase
+	 */
+	public function setConnectionTimeoutInSeconds( $timeout = 10 ) {
+		curl_setopt( $this->m_curlhandle, CURLOPT_CONNECTTIMEOUT, $timeout );
+		return $this;
 	}
 
 }

--- a/includes/src/SPARQLStore/SparqlDBConnectionProvider.php
+++ b/includes/src/SPARQLStore/SparqlDBConnectionProvider.php
@@ -1,0 +1,167 @@
+<?php
+
+namespace SMW\SPARQLStore;
+
+use SMW\DBConnectionProvider;
+
+use SMWSparqlDatabase as SparqlDatabase;
+use RuntimeException;
+
+/**
+ * @ingroup SMW
+ *
+ * @license GNU GPL v2+
+ * @since 1.9.3
+ *
+ * @author mwjames
+ */
+class SparqlDBConnectionProvider implements DBConnectionProvider {
+
+	/**
+	 * List of supported standard connectors
+	 *
+	 * @var array
+	 */
+	private $connectorIdToClass = array(
+		'default'   => 'SMWSparqlDatabase',
+		'fuseki'    => 'SMW\SPARQLStore\FusekiHttpDatabaseConnector',
+		'virtuoso'  => 'SMWSparqlDatabaseVirtuoso',
+		'4store'    => 'SMWSparqlDatabase4Store',
+	);
+
+	/**
+	 * @var SparqlDatabase
+	 */
+	private $connection = null;
+
+	/**
+	 * @var string|null
+	 */
+	private $connectorId = null;
+
+	/**
+	 * @var string|null
+	 */
+	private $defaultGraph = null;
+
+	/**
+	 * @var string|null
+	 */
+	private $queryEndpoint = null;
+
+	/**
+	 * @var string|null
+	 */
+	private $updateEndpoint = null;
+
+	/**
+	 * @var string|null
+	 */
+	private $dataEndpoint = null;
+
+	/**
+	 * @since 1.9.3
+	 *
+	 * @param string|null $connectorId
+	 * @param string|null $defaultGraph
+	 * @param string|null $queryEndpoint
+	 * @param string|null $updateEndpoint
+	 * @param string|null $dataEndpoint
+	 */
+	public function __construct( $connectorId = null, $defaultGraph = null, $queryEndpoint = null, $updateEndpoint = null, $dataEndpoint = null ) {
+		$this->connectorId = $connectorId;
+
+		if ( $this->connectorId === null ) {
+			$this->connectorId = $GLOBALS['smwgSparqlDatabaseConnector'];
+		}
+
+		$this->defaultGraph = $defaultGraph;
+		$this->queryEndpoint = $queryEndpoint;
+		$this->updateEndpoint = $updateEndpoint;
+		$this->dataEndpoint = $dataEndpoint;
+	}
+
+	/**
+	 * @see DBConnectionProvider::getConnection
+	 *
+	 * @since 1.9.3
+	 *
+	 * @return SparqlDatabase
+	 * @throws RuntimeException
+	 */
+	public function getConnection() {
+
+		if ( $this->connection === null ) {
+			$this->connection = $this->connectTo( strtolower( $this->connectorId ) );
+		}
+
+		return $this->connection;
+	}
+
+	/**
+	 * @see DBConnectionProvider::releaseConnection
+	 *
+	 * @since 1.9.3
+	 */
+	public function releaseConnection() {
+		$this->connection = null;
+	}
+
+	private function connectTo( $connectorId ) {
+
+		$databaseConnector = $this->mapConnectorIdToClass( $connectorId );
+
+		if ( $this->defaultGraph === null ) {
+			$this->defaultGraph = $GLOBALS['smwgSparqlDefaultGraph'];
+		}
+
+		if ( $this->queryEndpoint === null ) {
+			$this->queryEndpoint = $GLOBALS['smwgSparqlQueryEndpoint'];
+		}
+
+		if ( $this->updateEndpoint === null ) {
+			$this->updateEndpoint = $GLOBALS['smwgSparqlUpdateEndpoint'];
+		}
+
+		if ( $this->dataEndpoint === null ) {
+			$this->dataEndpoint = $GLOBALS['smwgSparqlDataEndpoint'];
+		}
+
+		$connection = new $databaseConnector(
+			$this->defaultGraph,
+			$this->queryEndpoint,
+			$this->updateEndpoint,
+			$this->dataEndpoint
+		);
+
+		if ( $this->isSparqlDatabase( $connection ) ) {
+			return $connection;
+		}
+
+		throw new RuntimeException( 'Expected a SparqlDatabase instance' );
+	}
+
+	private function mapConnectorIdToClass( $connectorId ) {
+
+		$databaseConnector = $this->connectorIdToClass[ 'default' ];
+
+		if ( isset( $this->connectorIdToClass[ $connectorId ] ) ) {
+			$databaseConnector = $this->connectorIdToClass[ $connectorId ];
+		}
+
+		if ( $connectorId === 'custom' ) {
+			$databaseConnector = $GLOBALS['smwgSparqlDatabase'];
+		}
+
+		if ( !class_exists( $databaseConnector ) ) {
+			throw new RuntimeException( "{$databaseConnector} is not available" );
+		}
+
+		return $databaseConnector;
+	}
+
+	private function isSparqlDatabase( $connection ) {
+		return $connection instanceof SparqlDatabase;
+	}
+
+}

--- a/tests/phpunit/Integration/SPARQLStore/FusekiDatabaseSimpleQueryLookupIntegrationTest.php
+++ b/tests/phpunit/Integration/SPARQLStore/FusekiDatabaseSimpleQueryLookupIntegrationTest.php
@@ -1,0 +1,293 @@
+<?php
+
+namespace SMW\Tests\Integration\SPARQLStore;
+
+use SMW\Tests\MwDBaseUnitTestCase;
+
+use SMW\SPARQLStore\SparqlDBConnectionProvider;
+
+use SMW\DIWikiPage;
+use SMW\DIProperty;
+use SMW\SemanticData;
+use SMW\DataValueFactory;
+
+use SMWDIBlob as DIBlob;
+use SMWDINumber as DINumber;
+use SMWQuery as Query;
+use SMWSomeProperty as SomeProperty;
+use SMWPrintRequest as PrintRequest;
+use SMWPropertyValue as PropertyValue;
+use SMWThingDescription as ThingDescription;
+
+use Title;
+
+/**
+ * @covers \SMW\SPARQLStore\FusekiHttpDatabaseConnector
+ *
+ * @ingroup Test
+ *
+ * @group SMW
+ * @group SMWExtension
+ * @group semantic-mediawiki-integration
+ * @group semantic-mediawiki-sparql
+ * @group semantic-mediawiki-query
+ * @group mediawiki-database
+ * @group medium
+ *
+ * @license GNU GPL v2+
+ * @since 1.9.3
+ *
+ * @author mwjames
+ */
+class FusekiDatabaseSimpleQueryLookupIntegrationTest extends MwDBaseUnitTestCase {
+
+	/** @var SparqlDBConnectionProvider */
+	private $connectionProvider;
+
+	/** @var DIWikiPage */
+	private $subject;
+
+	/** @var DataValueFactory */
+	private $dataValueFactory;
+
+	protected function setUp() {
+		parent::setUp();
+
+		$this->connectionProvider = new SparqlDBConnectionProvider( 'Fuseki' );
+		$this->subject = DIWikiPage::newFromTitle( Title::newFromText( __METHOD__ ) );
+		$this->dataValueFactory = DataValueFactory::getInstance();
+	}
+
+	public function testCanConnect() {
+
+		$connection = $this->connectionProvider->getConnection();
+
+		$this->assertInstanceOf(
+			'\SMW\SPARQLStore\FusekiHttpDatabaseConnector',
+			$connection
+		);
+
+		$connection->setConnectionTimeoutInSeconds( 5 );
+
+		if ( !$connection->ping() ) {
+			$this->markTestSkipped( 'Fuseki is not accessible' );
+		}
+	}
+
+	/**
+	 * @depends testCanConnect
+	 */
+	public function testQueryPropertyBeforeAfterDataRemoval() {
+
+		$property = new DIProperty( 'SomePagePropertyBeforeAfter' );
+		$property->setPropertyTypeId( '_wpg' );
+
+		$this->assertEmpty(
+			$this->getQueryResultForProperty( $property )->getResults()
+		);
+
+		$dataItem = DIWikiPage::newFromTitle( Title::newFromText( __METHOD__ ) );
+
+		$this->addTripleToStore(
+			$this->subject,
+			$property,
+			$this->dataValueFactory->newDataItemValue( $dataItem, $property )
+		);
+
+		$this->assertDataItemEquals(
+			$dataItem,
+			$this->getQueryResultForProperty( $property )
+		);
+
+		$this->assertNotEmpty(
+			$this->getQueryResultForProperty( $property )->getResults()
+		);
+
+		$this->getStore()->clearData( $this->subject );
+
+		$this->assertEmpty(
+			$this->getQueryResultForProperty( $property )->getResults()
+		);
+	}
+
+	/**
+	 * @depends testCanConnect
+	 */
+	public function testQueryUserDefinedBlobProperty() {
+
+		$property = new DIProperty( 'SomeBlobProperty' );
+		$property->setPropertyTypeId( '_txt' );
+
+		$dataItem = new DIBlob( 'SomePropertyBlobValue' );
+
+		$this->addTripleToStore(
+			$this->subject,
+			$property,
+			$this->dataValueFactory->newDataItemValue( $dataItem, $property )
+		);
+
+		$this->assertDataItemEquals(
+			$dataItem,
+			$this->getQueryResultForProperty( $property )
+		);
+	}
+
+	/**
+	 * @depends testCanConnect
+	 */
+	public function testQueryUserDefinedNumericProperty() {
+
+		$property = new DIProperty( 'SomeNumericProperty' );
+		$property->setPropertyTypeId( '_num' );
+
+		$dataItem = new DINumber( 9999 );
+
+		$this->addTripleToStore(
+			$this->subject,
+			$property,
+			$this->dataValueFactory->newDataItemValue( $dataItem, $property )
+		);
+
+		$this->assertDataItemEquals(
+			$dataItem,
+			$this->getQueryResultForProperty( $property )
+		);
+	}
+
+	/**
+	 * @depends testCanConnect
+	 */
+	public function testQueryUserDefinedQuantityProperty() {
+
+		$property = new DIProperty( 'SomeQuantityProperty' );
+		$property->setPropertyTypeId( '_qty' );
+
+		$this->addConversionValuesToProperty(
+			$property,
+			array( '1 km', '1000 m' )
+		);
+
+		$dataValue = $this->dataValueFactory->newPropertyObjectValue( $property, '100 km' );
+
+		$this->addTripleToStore(
+			$this->subject,
+			$property,
+			$dataValue
+		);
+
+		$this->assertDataItemEquals(
+			$dataValue->getDataItem(),
+			$this->getQueryResultForProperty( $property )
+		);
+	}
+
+	/**
+	 * @depends testCanConnect
+	 */
+	public function testQueryUserDefinedTemperatureProperty() {
+
+		$property = new DIProperty( 'SomeTemperatureProperty' );
+		$property->setPropertyTypeId( '_tem' );
+
+		$dataValue = $this->dataValueFactory->newPropertyObjectValue( $property, '1 °C' );
+
+		$this->addTripleToStore(
+			$this->subject,
+			$property,
+			$dataValue
+		);
+
+		$this->assertDataItemEquals(
+			$dataValue->getDataItem(),
+			$this->getQueryResultForProperty( $property )
+		);
+	}
+
+	/**
+	 * @depends testCanConnect
+	 */
+	public function testQueryCategory() {
+
+		$property = new DIProperty( '_INST' );
+
+		$dataValue = $this->dataValueFactory->newPropertyObjectValue( $property, 'SomeCategory' );
+
+		$this->addTripleToStore(
+			$this->subject,
+			$property,
+			$dataValue
+		);
+
+		$this->assertDataItemEquals(
+			$dataValue->getDataItem(),
+			$this->getQueryResultForProperty( $property )
+		);
+	}
+
+	private function addConversionValuesToProperty( DIProperty $property, array $conversionValues ) {
+
+		$this->getStore()->setSparqlDatabase( $this->connectionProvider->getConnection() );
+
+		$semanticData = new SemanticData( $property->getDiWikiPage() );
+
+		foreach( $conversionValues as $conversionValue ) {
+			$semanticData->addDataValue(
+				$this->dataValueFactory->newPropertyObjectValue( new DIProperty( '_CONV' ), $conversionValue )
+			);
+		}
+
+		$this->getStore()->updateData( $semanticData );
+	}
+
+	private function addTripleToStore( $subject, $property, $dataValue ) {
+
+		$this->getStore()->setSparqlDatabase( $this->connectionProvider->getConnection() );
+
+		$semanticData = new SemanticData( $subject );
+		$semanticData->addDataValue( $dataValue );
+
+		$this->getStore()->updateData( $semanticData );
+
+		$this->assertArrayHasKey(
+			$property->getKey(),
+			$this->getStore()->getSemanticData( $subject )->getProperties()
+		);
+	}
+
+	private function getQueryResultForProperty( $property ) {
+
+		$propertyValue = new PropertyValue( '__pro' );
+		$propertyValue->setDataItem( $property );
+
+		$description = new SomeProperty(
+			$property,
+			new ThingDescription()
+		);
+
+		$description->addPrintRequest(
+			new PrintRequest( PrintRequest::PRINT_PROP, null, $propertyValue )
+		);
+
+		$query = new Query(
+			$description,
+			false,
+			false
+		);
+
+		$query->querymode = Query::MODE_INSTANCES;
+
+		return $this->getStore()->getQueryResult( $query );
+	}
+
+	private function assertDataItemEquals( $expectedDataItem, $queryResult ) {
+
+		while ( $resultArray = $queryResult->getNext() ) {
+			foreach ( $resultArray as $result ) {
+				while ( ( $di = $result->getNextDataItem() ) !== false ) {
+					$this->assertEquals( $expectedDataItem, $di );
+				}
+			}
+		}
+	}
+
+}

--- a/tests/phpunit/MwDBaseUnitTestCase.php
+++ b/tests/phpunit/MwDBaseUnitTestCase.php
@@ -29,11 +29,18 @@ abstract class MwDBaseUnitTestCase extends \PHPUnit_Framework_TestCase {
 	/* @var array|null */
 	protected $databaseToBeExcluded = null;
 
-	/* @var array */
-	protected $storeToBeExcluded = array();
+	/* @var array|null */
+	protected $storesToBeExcluded = null;
 
 	protected $destroyDatabaseTablesOnEachRun = false;
 	protected $isUsableUnitTestDatabase = true;
+
+	protected function setUp() {
+		parent::setUp();
+
+		$this->checkIfDatabaseCanBeUsedOtherwiseSkipTest();
+		$this->checkIfStoreCanBeUsedOtherwiseSkipTest();
+	}
 
 	/**
 	 * It is assumed that each test that makes use of the TestCase is requesting
@@ -73,6 +80,10 @@ abstract class MwDBaseUnitTestCase extends \PHPUnit_Framework_TestCase {
 		return StoreFactory::getStore();
 	}
 
+	protected function setStoresToBeExcluded( array $storesToBeExcluded ) {
+		return $this->storesToBeExcluded = $storesToBeExcluded;
+	}
+
 //	protected function getDBConnection() {
 //		return $this->mwDatabaseTableBuilder->getDBConnection();
 //	}
@@ -89,7 +100,7 @@ abstract class MwDBaseUnitTestCase extends \PHPUnit_Framework_TestCase {
 
 		if ( !$this->isUsableUnitTestDatabase ) {
 			$this->markTestSkipped(
-				"Database type is not available or was excluded"
+				"Database is not available or was excluded"
 			);
 		}
 	}
@@ -98,7 +109,7 @@ abstract class MwDBaseUnitTestCase extends \PHPUnit_Framework_TestCase {
 
 		$store = get_class( $this->getStore() );
 
-		if ( in_array( $store, $this->storeToBeExcluded ) ) {
+		if ( in_array( $store, (array)$this->storesToBeExcluded ) ) {
 			$this->markTestSkipped(
 				"{$store} was excluded"
 			);

--- a/tests/phpunit/README.md
+++ b/tests/phpunit/README.md
@@ -26,7 +26,23 @@ The use of `MediaWikiTestCase` is discouraged as its binds tests and the test en
 * `SemanticMediaWikiTestCase` derives from <code>PHPUnit_Framework_TestCase</code> and adds some convenient functions
 * `ApiTestCase` derives from `SemanticMediaWikiTestCase` and provides a framework for unit tests that directly require access to the MediaWiki Api interface
 
-### Miscellaneous
+## Integration testing
+
+### Fuseki integration
+
+When running integration tests with [Jena Fuseki][fuseki] it is suggested that the `in-memory` option is used to avoid potential loss of production data during test execution.
+
+```
+fuseki-server --update --port=3030 --mem /db
+```
+```
+$smwgSparqlDatabaseConnector = 'Fuseki';
+$smwgSparqlQueryEndpoint = 'http://localhost:3030/db/query';
+$smwgSparqlUpdateEndpoint = 'http://localhost:3030/db/update';
+$smwgSparqlDataEndpoint = '';
+```
+
+## Miscellaneous
 * [Using mocks during a test](mocks/README.md)
 * [Writing testable code](https://semantic-mediawiki.org/wiki/Help:Writing_testable_code)
 * [Code coverage in a nutshell](https://semantic-mediawiki.org/wiki/Help:Code_coverage_in_a_nutshell)
@@ -34,3 +50,4 @@ The use of `MediaWikiTestCase` is discouraged as its binds tests and the test en
 [phpunit]: http://phpunit.de/manual/4.1/en/index.html
 [smw]: https://www.semantic-mediawiki.org/wiki/PHPUnit_tests
 [mw-testing]: https://www.mediawiki.org/wiki/Manual:PHP_unit_testing
+[fuseki]: https://jena.apache.org/

--- a/tests/phpunit/Regression/RebuildConceptCacheMaintenanceRegressionTest.php
+++ b/tests/phpunit/Regression/RebuildConceptCacheMaintenanceRegressionTest.php
@@ -28,7 +28,7 @@ class RebuildConceptCacheMaintenanceRegressionTest extends MwRegressionTestCase 
 	/**
 	 * FIXME SMWSparqlStore::getConceptCacheStatus doesn't exist
 	 */
-	protected $storeToBeExcluded = array( 'SMWSparqlStore' );
+	protected $storesToBeExcluded = array( 'SMWSparqlStore' );
 
 	public function getSourceFile() {
 		return __DIR__ . '/data/' . 'GenericLoremIpsumTest-Mw-1-19-7.xml';

--- a/tests/phpunit/Regression/RebuildPropertyStatisticsMaintenanceRegressionTest.php
+++ b/tests/phpunit/Regression/RebuildPropertyStatisticsMaintenanceRegressionTest.php
@@ -25,7 +25,7 @@ class RebuildPropertyStatisticsMaintenanceRegressionTest extends MwRegressionTes
 	/**
 	 * FIXME SMWSparqlStore::getPropertyTables doesn't exist
 	 */
-	protected $storeToBeExcluded = array( 'SMWSparqlStore' );
+	protected $storesToBeExcluded = array( 'SMWSparqlStore' );
 
 	public function getSourceFile() {
 		return __DIR__ . '/data/' . 'GenericLoremIpsumTest-Mw-1-19-7.xml';

--- a/tests/phpunit/Regression/SimplePageRedirectRegressionTest.php
+++ b/tests/phpunit/Regression/SimplePageRedirectRegressionTest.php
@@ -29,6 +29,11 @@ use Title;
  */
 class SimplePageRedirectRegressionTest extends MwRegressionTestCase {
 
+	/**
+	 * FIXME
+	 */
+	protected $storesToBeExcluded = array( 'SMWSparqlStore' );
+
 	public function getSourceFile() {
 		return __DIR__ . '/data/' . 'SimplePageRedirectRegressionTest-Mw-1-19-7.xml';
 	}

--- a/tests/phpunit/Regression/TimeDataTypeRegressionTest.php
+++ b/tests/phpunit/Regression/TimeDataTypeRegressionTest.php
@@ -20,12 +20,17 @@ use Title;
  * @group Database
  * @group medium
  *
- * @licence GNU GPL v2+
+ * @license GNU GPL v2+
  * @since 1.9.1
  *
  * @author mwjames
  */
 class TimeDataTypeRegressionTest extends MwRegressionTestCase {
+
+	/**
+	 * FIXME
+	 */
+	protected $storesToBeExcluded = array( 'SMWSparqlStore' );
 
 	public function getSourceFile() {
 		return __DIR__ . '/data/' . 'TimeDataTypeRegressionTest-Mw-1-19-7.xml';

--- a/tests/phpunit/includes/SPARQLStore/SparqlDBConnectionProviderTest.php
+++ b/tests/phpunit/includes/SPARQLStore/SparqlDBConnectionProviderTest.php
@@ -1,0 +1,192 @@
+<?php
+
+namespace SMW\Tests\SPARQLStore;
+
+use SMW\SPARQLStore\SparqlDBConnectionProvider;
+use SMW\Configuration\Configuration;
+
+/**
+ * @covers \SMW\SPARQLStore\SparqlDBConnectionProvider
+ *
+ * @ingroup Test
+ *
+ * @group SMW
+ * @group SMWExtension
+ * @group semantic-mediawiki-sparql
+ *
+ * @license GNU GPL v2+
+ * @since 1.9.3
+ *
+ * @author mwjames
+ */
+class SparqlDBConnectionProviderTest extends \PHPUnit_Framework_TestCase {
+
+	private $configuration;
+	private $smwgSparqlDatabase;
+	private $smwgSparqlDatabaseConnector;
+
+	protected function setUp() {
+		parent::setUp();
+
+		$this->configuration = Configuration::getInstance();
+
+		$this->smwgSparqlDatabaseConnector = $this->configuration->get( 'smwgSparqlDatabaseConnector' );
+		$this->smwgSparqlDatabase = $this->configuration->get( 'smwgSparqlDatabase' );
+	}
+
+	protected function tearDown() {
+
+		$this->configuration->set(
+			'smwgSparqlDatabaseConnector',
+			$this->smwgSparqlDatabaseConnector
+		);
+
+		$this->configuration->set(
+			'smwgSparqlDatabase',
+			$this->smwgSparqlDatabase
+		);
+	}
+
+	public function testCanConstruct() {
+
+		$instance = new SparqlDBConnectionProvider();
+
+		$this->assertInstanceOf(
+			'\SMW\SPARQLStore\SparqlDBConnectionProvider',
+			$instance
+		);
+
+		$this->assertInstanceOf(
+			'\SMW\DBConnectionProvider',
+			$instance
+		);
+	}
+
+	public function testGetDefaultConnection() {
+
+		$instance = new SparqlDBConnectionProvider( 'default' );
+
+		$this->assertInstanceOf(
+			'\SMWSparqlDatabase',
+			$instance->getConnection()
+		);
+
+		$connection = $instance->getConnection();
+
+		$this->assertSame(
+			$connection,
+			$instance->getConnection()
+		);
+
+		$instance->releaseConnection();
+
+		$this->assertNotSame(
+			$connection,
+			$instance->getConnection()
+		);
+	}
+
+	public function testGetFusekiConnection() {
+
+		$instance = new SparqlDBConnectionProvider( 'fuSEKi' );
+
+		$this->assertInstanceOf(
+			'\SMW\SPARQLStore\FusekiHttpDatabaseConnector',
+			$instance->getConnection()
+		);
+	}
+
+	public function testGetVirtuosoConnection() {
+
+		$instance = new SparqlDBConnectionProvider( 'virtuoso' );
+
+		$this->assertInstanceOf(
+			'\SMWSparqlDatabaseVirtuoso',
+			$instance->getConnection()
+		);
+	}
+
+	public function testGet4StoreConnection() {
+
+		$instance = new SparqlDBConnectionProvider( '4STORE' );
+
+		$this->assertInstanceOf(
+			'\SMWSparqlDatabase4Store',
+			$instance->getConnection()
+		);
+	}
+
+	public function testGetDefaultConnectorForUnknownConnectorId() {
+
+		$this->configuration->set(
+			'smwgSparqlDatabaseConnector',
+			'default'
+		);
+
+		$instance = new SparqlDBConnectionProvider( 'foo' );
+
+		$this->assertInstanceOf(
+			'\SMWSparqlDatabase',
+			$instance->getConnection()
+		);
+	}
+
+	public function testGetDefaultConnectorForEmptyConnectorId() {
+
+		$this->configuration->set(
+			'smwgSparqlDatabaseConnector',
+			'default'
+		);
+
+		$instance = new SparqlDBConnectionProvider();
+
+		$this->assertInstanceOf(
+			'\SMWSparqlDatabase',
+			$instance->getConnection()
+		);
+	}
+
+	public function testGetDefaultConnectorForUnMappedId() {
+
+		$this->configuration->set(
+			'smwgSparqlDatabaseConnector',
+			'idThatCanNotBeMapped'
+		);
+
+		$instance = new SparqlDBConnectionProvider();
+
+		$this->assertInstanceOf(
+			'\SMWSparqlDatabase',
+			$instance->getConnection()
+		);
+	}
+
+	public function testInvalidCustomClassConnectorThrowsException() {
+
+		$this->configuration->set(
+			'smwgSparqlDatabase',
+			'InvalidCustomClassConnector'
+		);
+
+		$instance = new SparqlDBConnectionProvider( 'custom' );
+
+		$this->setExpectedException( 'RuntimeException' );
+		$instance->getConnection();
+	}
+
+	public function testInvalidCustomSparqlClassConnectorThrowsException() {
+
+		$this->configuration->set(
+			'smwgSparqlDatabase',
+			'\SMW\Tests\SPARQLStore\InvalidCustomSparqlClassConnector'
+		);
+
+		$instance = new SparqlDBConnectionProvider( 'custom' );
+
+		$this->setExpectedException( 'RuntimeException' );
+		$instance->getConnection();
+	}
+
+}
+
+class InvalidCustomSparqlClassConnector {}


### PR DESCRIPTION
- Runs simple live query lookups against a Fuseki SPARQL instance
- Adds `SparqlDBConnectionProvider`
- Adds `$smwgSparqlDatabaseConnector` setting which can contain `fuseki`, `4store`, `virtuoso`, `default`, and `custom`
- Make Travis vote the Fuseki-run 
### Fuseki-run

Passes Tests: 2051, Assertions: 6432, Skipped: 8
### Follow-up task
- [ ] SimplePageRedirectRegressionTest
- [ ] TimeDataTypeRegressionTest
- [ ] RebuildPropertyStatisticsMaintenanceRegressionTest
- [ ] RebuildConceptCacheMaintenanceRegressionTest

Relates to #337
