### PR TITLE
Fixes RDF export of subobjects

### DIFF
--- a/tests/phpunit/includes/export/SMWExporterTest.php
+++ b/tests/phpunit/includes/export/SMWExporterTest.php
@@ -2,6 +2,16 @@
 
 namespace SMW\Test;
 
+use SMW\DIWikiPage;
+use SMW\SemanticData;
+use SMW\Subobject;
+use SMW\DataValueFactory;
+use SMW\DIProperty;
+
+use SMWDITime as DITime;
+
+use Title;
+
 /**
  * @covers \SMWExporter
  *
@@ -53,7 +63,56 @@ class SMWExporterTest extends CompatibilityTestCase {
 
 		$provider[] = array( new \SMWDIConcept( 'Foo', '', '', '', '' ), null );
 
+		$provider[] = array( DIWikiPage::newFromTitle( Title::newFromText( __METHOD__ ) ), 'SMWExpResource' );
+
 		return $provider;
+	}
+
+	/**
+	*
+	*/
+	public function testGetResourceElementForWikiPage() {
+
+		$this->assertInstanceOf(
+			'SMWExpResource',
+			\SMWExporter::getResourceElementForWikiPage( DIWikiPage::newFromTitle( Title::newFromText( __METHOD__ ) ) )
+		);
+	}
+
+	/**
+	*
+	*/
+	public function testMakeExportData() {
+
+		$title = Title::newFromText( __METHOD__ );
+
+		$semData = new SemanticData( DIWikiPage::newFromTitle( $title ) );
+                $semData->addPropertyObjectValue(
+                        new DIProperty( '_MDAT' ),
+                        DITime::newFromTimestamp( 1272508903 )
+                );
+
+		$subobject = new Subobject( $title );
+		$subobject->setEmptySemanticDataForId( 'ID_1234' );
+		$dataValue = DataValueFactory::getInstance()->newPropertyValue( 'myProperty', 'Baar' );
+		$subobject->addDataValue( $dataValue );
+
+		$semData->addSubSemanticData( $subobject->getSemanticData() );
+
+		$exportData = \SMWExporter::makeExportData( $semData );
+
+		$this->assertInternalType(
+			'array',
+			$exportData
+		);
+
+		$this->assertTrue( count($exportData) > 0 );
+
+		$this->assertInstanceOf(
+			'\SMWExpData',
+			$exportData[0]
+		);
+
 	}
 
 }


### PR DESCRIPTION
Adds SemanticData from subobjects to the RDF export fixing https://bugzilla.wikimedia.org/show_bug.cgi?id=48708

Note: This is a partial integration of the patch https://gerrit.wikimedia.org/r/#/c/70047/4
Credits to Dbeeson

Code changes in short:
The Export code for RDF now understands that SemanticData has recursive information about subobjects and tries to iterate over them to add to the RDF export.
