### PR TITLE
Add test autoloader

### DIFF
--- a/SemanticMediaWiki.php
+++ b/SemanticMediaWiki.php
@@ -98,15 +98,6 @@ $GLOBALS['wgExtensionMessagesFiles']['SemanticMediaWikiMagic'] = $GLOBALS['smwgI
 $GLOBALS['wgExtensionMessagesFiles']['SemanticMediaWikiNamespaces'] = $GLOBALS['smwgIP'] . 'languages/SemanticMediaWiki.namespaces.php';
 
 /**
- * @since 1.9.3
- *
- * TEMPORARY FIX until an appropriate testLoader is provided for third-party
- * extensions that rely on some test classes to be present
- */
-$GLOBALS['wgAutoloadClasses']['SMW\Test\QueryPrinterTestCase']   = __DIR__ . '/tests/phpunit/QueryPrinterTestCase.php';
-$GLOBALS['wgAutoloadClasses']['SMW\Test\QueryPrinterRegistryTestCase']   = __DIR__ . '/tests/phpunit/QueryPrinterRegistryTestCase.php';
-
-/**
  * Setup and initialization
  *
  * @note $wgExtensionFunctions variable is an array that stores

--- a/tests/autoloader.php
+++ b/tests/autoloader.php
@@ -1,0 +1,48 @@
+<?php
+
+/**
+ * Convenience autoloader to pre-register test classes
+ *
+ * Third-party users that require SMW as integration platform should
+ * add the following to the bootstrap.php
+ *
+ * require __DIR__ . '/../../SemanticMediaWiki/tests/autoloader.php'
+ */
+
+if ( php_sapi_name() !== 'cli' ) {
+	die( 'Not an entry point' );
+}
+
+if ( !defined( 'MEDIAWIKI' ) ) {
+	die( 'MediaWiki is not available.' );
+}
+
+if ( !defined( 'SMW_VERSION' ) ) {
+	die( 'SemanticMediaWiki is not available.' );
+}
+
+if ( is_readable( $path = __DIR__ . '/../vendor/autoload.php' ) ) {
+	print( "\nUsing the local vendor autoloader ...\n\n" );
+} elseif ( is_readable( $path = __DIR__ . '/../../../vendor/autoload.php' ) ) {
+	print( "\nUsing the MediaWiki vendor autoloader ...\n\n" );
+} else {
+	die( 'To run tests it is required that packages are installed using Composer.' );
+}
+
+$autoloader = require $path;
+
+/**
+ * Available to third-party extensions therefore any change should be made with
+ * care
+ *
+ * @since  1.9.3
+ */
+$autoloader->addPsr4( 'SMW\\Tests\\Util\\', __DIR__ . '/phpunit/Util' );
+
+$autoloader->addClassMap( array(
+	'SMW\Tests\MwDBaseUnitTestCase'         => __DIR__ . '/phpunit/MwDBaseUnitTestCase.php',
+	'SMW\Test\QueryPrinterTestCase'         => __DIR__ . '/phpunit/QueryPrinterTestCase.php',
+	'SMW\Test\QueryPrinterRegistryTestCase' => __DIR__ . '/phpunit/QueryPrinterRegistryTestCase.php',
+) );
+
+return $autoloader;

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -4,45 +4,15 @@ if ( php_sapi_name() !== 'cli' ) {
 	die( 'Not an entry point' );
 }
 
-if ( !defined( 'MEDIAWIKI' ) ) {
-	die( 'MediaWiki is not available for the test environment' );
-}
+$autoloader = require __DIR__ . '/autoloader.php';
 
-function registerAutoloaderPath( $identifier, $path ) {
-	print( "\nUsing the {$identifier} vendor autoloader ...\n\n" );
-	return require $path;
-}
+$autoloader->addPsr4( 'SMW\\Test\\', __DIR__ . '/phpunit' );
+$autoloader->addPsr4( 'SMW\\Tests\\', __DIR__ . '/phpunit' );
 
-function runTestAutoLoader() {
-
-	$mwVendorPath = __DIR__ . '/../../../vendor/autoload.php';
-	$localVendorPath = __DIR__ . '/../vendor/autoload.php';
-
-	if ( is_readable( $localVendorPath ) ) {
-		$autoLoader = registerAutoloaderPath( 'local', $localVendorPath );
-	} elseif ( is_readable( $mwVendorPath ) ) {
-		$autoLoader = registerAutoloaderPath( 'MediaWiki', $mwVendorPath );
-	}
-
-	if ( !$autoLoader instanceof \Composer\Autoload\ClassLoader ) {
-		return false;
-	}
-
-	$autoLoader->addPsr4( 'SMW\\Test\\', __DIR__ . '/phpunit' );
-	$autoLoader->addPsr4( 'SMW\\Tests\\', __DIR__ . '/phpunit' );
-
-	// FIXME
-	$autoLoader->addClassMap( array(
-		'SMW\Tests\DataItemTest'                     => __DIR__ . '/phpunit/includes/dataitems/DataItemTest.php',
-		'SMW\Tests\Reporter\MessageReporterTestCase' => __DIR__ . '/phpunit/includes/Reporter/MessageReporterTestCase.php',
-		'SMW\Maintenance\RebuildConceptCache'        => __DIR__ . '/../maintenance/rebuildConceptCache.php',
-		'SMW\Maintenance\RebuildData'                => __DIR__ . '/../maintenance/rebuildData.php',
-		'SMW\Maintenance\RebuildPropertyStatistics'  => __DIR__ . '/../maintenance/rebuildPropertyStatistics.php'
-	) );
-
-	return true;
-}
-
-if ( !runTestAutoLoader() ) {
-	die( 'The required test autoloader was not accessible' );
-}
+$autoloader->addClassMap( array(
+	'SMW\Tests\DataItemTest'                     => __DIR__ . '/phpunit/includes/dataitems/DataItemTest.php',
+	'SMW\Tests\Reporter\MessageReporterTestCase' => __DIR__ . '/phpunit/includes/Reporter/MessageReporterTestCase.php',
+	'SMW\Maintenance\RebuildConceptCache'        => __DIR__ . '/../maintenance/rebuildConceptCache.php',
+	'SMW\Maintenance\RebuildData'                => __DIR__ . '/../maintenance/rebuildData.php',
+	'SMW\Maintenance\RebuildPropertyStatistics'  => __DIR__ . '/../maintenance/rebuildPropertyStatistics.php'
+) );

--- a/tests/mw-phpunit-runner.php
+++ b/tests/mw-phpunit-runner.php
@@ -40,4 +40,4 @@ function addArguments( $args ) {
 $mw = isReadablePath( __DIR__ . "/../../../tests/phpunit/phpunit.php" );
 $config = isReadablePath( __DIR__ . "/../phpunit.xml.dist" );
 
-passthru( "php {$mw} -c {$config} " . implode( ' ', addArguments( $GLOBALS['argv'] ) ) );
+return passthru( "php {$mw} -c {$config} " . implode( ' ', addArguments( $GLOBALS['argv'] ) ) );


### PR DESCRIPTION
Third-party users that require SMW as integration platform should add the following to their `bootstrap.php`.

```
$autoloader = require __DIR__ . '/../../SemanticMediaWiki/tests/autoloader.php'

$autoloader->addPsr4( ... );
```
### Follow-up

Instead of packages assuming that classes (such as`SMW\Test\QueryPrinterTestCase`) are freely available, the test environment should explicit invoke the autoloader to gain access to required objects.
- [x] SemanticResultFormts
- [x] SemanticMaps
- [ ] SemanticGlossary
