### PR TITLE
Sql3StubSemanticData to load SubSemanticData on request

### DIFF
--- a/includes/DataTypeRegistry.php
+++ b/includes/DataTypeRegistry.php
@@ -338,6 +338,7 @@ class DataTypeRegistry {
 			'__con' => 'SMWConceptValue', // Special concept page type
 			'__sps' => 'SMWStringValue', // Special string type
 			'__spu' => 'SMWURIValue', // Special uri type
+			'__sob' => 'SMWWikiPageValue', // Special subobject type
 			'__sup' => 'SMWWikiPageValue', // Special subproperty type
 			'__suc' => 'SMWWikiPageValue', // Special subcategory type
 			'__spf' => 'SMWWikiPageValue', // Special Form page type for Semantic Forms
@@ -375,6 +376,7 @@ class DataTypeRegistry {
 			'__con' => DataItem::TYPE_CONCEPT, // Special concept page type
 			'__sps' => DataItem::TYPE_BLOB, // Special string type
 			'__spu' => DataItem::TYPE_URI, // Special uri type
+			'__sob' => DataItem::TYPE_WIKIPAGE, // Special subobject type
 			'__sup' => DataItem::TYPE_WIKIPAGE, // Special subproperty type
 			'__suc' => DataItem::TYPE_WIKIPAGE, // Special subcategory type
 			'__spf' => DataItem::TYPE_WIKIPAGE, // Special Form page type for Semantic Forms

--- a/includes/dataitems/SMW_DI_Property.php
+++ b/includes/dataitems/SMW_DI_Property.php
@@ -444,8 +444,8 @@ class DIProperty extends SMWDataItem {
 				self::TYPE_SORTKEY =>  array( '__key', false ), // sort key of a page
 				'_SF_DF' => array( '__spf', true ), // Semantic Form's default form property
 				'_SF_AF' => array( '__spf', true ),  // Semantic Form's alternate form property
-				self::TYPE_SUBOBJECT =>  array( '_wpg', true ), // "has subobject"
-				self::TYPE_ASKQUERY  =>  array( '_wpg', false ), // "has query"
+				self::TYPE_SUBOBJECT =>  array( '__sob', true ), // "has subobject"
+				self::TYPE_ASKQUERY  =>  array( '__sob', false ), // "has query"
 				'_ASKST' =>  array( '_cod', true ), // "has query string"
 				'_ASKFO' =>  array( '_txt', true ), // "has query format"
 				'_ASKSI' =>  array( '_num', true ), // "has query size"

--- a/includes/specials/SMW_SpecialBrowse.php
+++ b/includes/specials/SMW_SpecialBrowse.php
@@ -242,7 +242,7 @@ class SMWSpecialBrowse extends SpecialPage {
 
 		$html = $dataValue->getLongHTMLText( $linker );
 
-		if ( $dataValue->getTypeID() == '_wpg' ) {
+		if ( $dataValue->getDataItem() === '_wpg' || $dataValue->getTypeID() === '__sob' ) {
 			$html .= "&#160;" . SMWInfolink::newBrowsingLink( '+', $dataValue->getLongWikiText() )->getHTML( $linker );
 		} elseif ( $incoming && $property->isVisible() ) {
 			$html .= "&#160;" . SMWInfolink::newInversePropertySearchLink( '+', $dataValue->getTitle(), $property->getDataItem()->getLabel(), 'smwsearch' )->getHTML( $linker );

--- a/tests/phpunit/Integration/SemanticDataSerializationDBIntegrationTest.php
+++ b/tests/phpunit/Integration/SemanticDataSerializationDBIntegrationTest.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace SMW\Tests\Integration;
+
+use SMW\Tests\MwDBaseUnitTestCase;
+use SMW\Tests\Util\SemanticDataValidator;
+
+use SMW\DIWikiPage;
+use SMW\DIProperty;
+use SMW\SemanticData;
+use SMW\DataValueFactory;
+use SMW\Subobject;
+use SMW\SerializerFactory;
+
+use SMWDIBlob as DIBlob;
+
+use Title;
+
+/**
+ * @group SMW
+ * @group SMWExtension
+ * @group semantic-mediawiki-integration
+ * @group mediawiki-database
+ * @group medium
+ *
+ * @license GNU GPL v2+
+ * @since 1.9.3
+ *
+ * @author mwjames
+ */
+class SemanticDataSerializationDBIntegrationTest extends MwDBaseUnitTestCase {
+
+	public function testRoundtripOfSerializedSemanticDataAfterStoreUpdate() {
+
+		$subject = DIWikiPage::newFromTitle( Title::newFromText( __METHOD__ ) );
+		$semanticDataBeforeUpdate = new SemanticData( $subject );
+
+		$subobject = new Subobject( $subject->getTitle() );
+		$subobject->setEmptySemanticDataForId( 'SomeSubobjectToSerialize' );
+
+		$subobject->getSemanticData()->addDataValue(
+			DataValueFactory::getInstance()->newPropertyValue( 'Foo', 'Bar' )
+		);
+
+		$semanticDataBeforeUpdate->addPropertyObjectValue(
+			$subobject->getProperty(),
+			$subobject->getContainer()
+		);
+
+		$this->getStore()->updateData( $semanticDataBeforeUpdate );
+
+		$semanticDataAfterUpdate = $this->getStore()->getSemanticData( $subject );
+
+		$this->assertNotEquals(
+			$semanticDataBeforeUpdate->getHash(),
+			$semanticDataAfterUpdate->getHash(),
+			'Assert that the hash is not comparable due to the added _SKEY property during the update'
+		);
+
+		$serializerFactory = new SerializerFactory();
+
+		$this->assertEquals(
+			$semanticDataAfterUpdate->getHash(),
+			$serializerFactory->deserialize( $serializerFactory->serialize( $semanticDataAfterUpdate ) )->getHash()
+		);
+	}
+
+}


### PR DESCRIPTION
- Add `__sob` as datatype to identify subobjects
- Only if `SubSemanticData` are requested by `Sql3StubSemanticData::getSubSemanticData` data are loaded from the StorageEngine
- `hasSubSemanticData` and `getSubSemanticData` are adapted to care for the lazy load
