### PR TITLE
4Store (1.1.4) compliance

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -31,22 +31,20 @@ The use of `MediaWikiTestCase` is discouraged as its binds tests and the test en
 
 ## Integration testing
 
-### SPARQL integration
-
 Additional services can be enabled on Travis-CI to expand the test environment, available at present:
 
 - `FUSEKI`: Jena Fuskei 1.0.2 is integrated and testable
 - `FOURSTORE`: 4Store is installable but not testable due to [issue #110](https://github.com/garlik/4store/issues/110)
 - `VIRTUOSO`: Virtuoso-opensource-6.1 is installable but has not been tested
 
-#### Jena Fuseki
+### Jena Fuseki integration
 
 When running integration tests with [Jena Fuseki][fuseki] it is suggested that the `in-memory` option is used to avoid potential loss of production data during test execution.
 
-```
+```sh
 fuseki-server --update --port=3030 --mem /db
 ```
-```
+```php
 $smwgSparqlDatabaseConnector = 'Fuseki';
 $smwgSparqlQueryEndpoint = 'http://localhost:3030/db/query';
 $smwgSparqlUpdateEndpoint = 'http://localhost:3030/db/update';
@@ -55,14 +53,32 @@ $smwgSparqlDataEndpoint = '';
 
 Fuseki supports [TDB Dynamic Datasets][fuseki-dataset] (in SPARQL known as [RDF dataset][sparql-dataset]) which are currently not considered for testing but can be enabled using the following settings.
 
-```
+```sh
 fuseki-server --update --port=3030 --memTDB --set tdb:unionDefaultGraph=true /db
 ```
-```
+```php
 $smwgSparqlDatabaseConnector = 'Fuseki';
 $smwgSparqlQueryEndpoint = 'http://localhost:3030/db/query';
 $smwgSparqlUpdateEndpoint = 'http://localhost:3030/db/update';
 $smwgSparqlDataEndpoint = '';
+$smwgSparqlDefaultGraph = 'http://example.org/mydefaultgraphname';
+```
+### 4Store integration
+
+Currently, Travis-CI doesn't support `4Store` (1.1.4-2) as service but the following configuration has been sucessfully tested with the available test suite.
+
+```sh
+apt-get install 4store
+4s-backend-setup smw
+4s-backend smw
+4s-httpd -p 8088 smw
+```
+
+```php
+$smwgSparqlDatabaseConnector = '4store';
+$smwgSparqlQueryEndpoint = 'http://localhost:8088/sparql/';
+$smwgSparqlUpdateEndpoint = 'http://localhost:8088/update/';
+$smwgSparqlDataEndpoint = 'http://localhost:8088/data/';
 $smwgSparqlDefaultGraph = 'http://example.org/mydefaultgraphname';
 ```
 

--- a/tests/phpunit/Util/FakeQueryResultProvider.php
+++ b/tests/phpunit/Util/FakeQueryResultProvider.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace SMW\Tests\Util;
+
+/**
+ * @ingroup Test
+ *
+ * @group SMW
+ * @group SMWExtension
+ * @group semantic-mediawiki-sparql
+ *
+ * @license GNU GPL v2+
+ * @since 1.9.3
+ *
+ * @author mwjames
+ */
+class FakeQueryResultProvider {
+
+	/**
+	 * @see https://www.w3.org/TR/rdf-sparql-query/#ask
+	 */
+	public function getEmptySparqlResultXml() {
+		return '<?xml version="1.0"?>
+			<sparql xmlns="http://www.w3.org/2005/sparql-results#">
+			  <head>
+			    <variable name="s"/>
+			    <variable name="r"/>
+			  </head>
+			  <results>
+			  </results>
+			</sparql>';
+	}
+
+}

--- a/tests/phpunit/includes/SPARQLStore/DatabaseConnectorExceptionTest.php
+++ b/tests/phpunit/includes/SPARQLStore/DatabaseConnectorExceptionTest.php
@@ -3,6 +3,9 @@
 namespace SMW\Tests\SPARQLStore;
 
 /**
+ * @covers \SMW\SPARQLStore\FusekiHttpDatabaseConnector
+ * @covers \SMWSparqlDatabase4Store
+ * @covers \SMWSparqlDatabaseVirtuoso
  * @covers \SMWSparqlDatabase
  *
  * @ingroup Test
@@ -15,18 +18,25 @@ namespace SMW\Tests\SPARQLStore;
  *
  * @author mwjames
  */
-class ForcedConnectorExceptionTest extends \PHPUnit_Framework_TestCase {
+class DatabaseConnectorExceptionTest extends \PHPUnit_Framework_TestCase {
 
 	private $defaultGraph;
+
+	private $databaseConnectors = array(
+		'SMWSparqlDatabase',
+		'\SMW\SPARQLStore\FusekiHttpDatabaseConnector',
+		'SMWSparqlDatabase4Store',
+		'SMWSparqlDatabaseVirtuoso'
+	);
 
 	protected function setUp() {
 		parent::setUp();
 
-		$this->defaultGraph = 'http://example.org/mydefaultgraphname';
+		$this->defaultGraph = 'http://foo/myDefaultGraph';
 	}
 
 	/**
-	 * @dataProvider httpConnectorNameProvider
+	 * @dataProvider httpDatabaseConnectorInstanceNameProvider
 	 */
 	public function testCanConstruct( $httpConnector ) {
 
@@ -37,7 +47,21 @@ class ForcedConnectorExceptionTest extends \PHPUnit_Framework_TestCase {
 	}
 
 	/**
-	 * @dataProvider httpConnectorNameProvider
+	 * @dataProvider httpDatabaseConnectorInstanceNameProvider
+	 */
+	public function testDoQueryForEmptyQueryEndpointThrowsException( $httpConnector ) {
+
+		$instance = new $httpConnector(
+			$this->defaultGraph,
+			''
+		);
+
+		$this->setExpectedException( '\SMW\SPARQLStore\BadHttpDatabaseResponseException' );
+		$instance->doQuery( '' );
+	}
+
+	/**
+	 * @dataProvider httpDatabaseConnectorInstanceNameProvider
 	 */
 	public function testDoUpdateForEmptyUpdateEndpointThrowsException( $httpConnector ) {
 
@@ -52,7 +76,7 @@ class ForcedConnectorExceptionTest extends \PHPUnit_Framework_TestCase {
 	}
 
 	/**
-	 * @dataProvider httpConnectorNameProvider
+	 * @dataProvider httpDatabaseConnectorInstanceNameProvider
 	 */
 	public function testDoHttpPostForEmptyDataEndpointThrowsException( $httpConnector ) {
 
@@ -68,7 +92,7 @@ class ForcedConnectorExceptionTest extends \PHPUnit_Framework_TestCase {
 	}
 
 	/**
-	 * @dataProvider httpConnectorNameProvider
+	 * @dataProvider httpDatabaseConnectorInstanceNameProvider
 	 */
 	public function testDoHttpPostForUnreachableDataEndpointThrowsException( $httpConnector ) {
 
@@ -83,14 +107,11 @@ class ForcedConnectorExceptionTest extends \PHPUnit_Framework_TestCase {
 		$instance->doHttpPost( '' );
 	}
 
-	public function httpConnectorNameProvider() {
+	public function httpDatabaseConnectorInstanceNameProvider() {
 
-		$provider = array(
-			array( 'SMWSparqlDatabase' ),
-			array( '\SMW\SPARQLStore\FusekiHttpDatabaseConnector' ),
-			array( 'SMWSparqlDatabase4Store' ),
-			array( 'SMWSparqlDatabaseVirtuoso' )
-		);
+		foreach ( $this->databaseConnectors as $databaseConnector ) {
+			$provider[] = array( $databaseConnector );
+		}
 
 		return $provider;
 	}

--- a/tests/phpunit/includes/SPARQLStore/DatabaseConnectorHttpRequestIntegrityTest.php
+++ b/tests/phpunit/includes/SPARQLStore/DatabaseConnectorHttpRequestIntegrityTest.php
@@ -1,0 +1,185 @@
+<?php
+
+namespace SMW\Tests\SPARQLStore;
+
+use SMW\Tests\Util\FakeQueryResultProvider;
+use SMW\SPARQLStore\FusekiHttpDatabaseConnector;
+
+/**
+ * @covers \SMW\SPARQLStore\FusekiHttpDatabaseConnector
+ * @covers \SMWSparqlDatabase4Store
+ * @covers \SMWSparqlDatabaseVirtuoso
+ * @covers \SMWSparqlDatabase
+ *
+ * @ingroup Test
+ *
+ * @group SMW
+ * @group SMWExtension
+ * @group semantic-mediawiki-sparql
+ *
+ * @license GNU GPL v2+
+ * @since 1.9.3
+ *
+ * @author mwjames
+ */
+class DatabaseConnectorHttpRequestIntegrityTest extends \PHPUnit_Framework_TestCase {
+
+	private $databaseConnectors = array(
+		'SMWSparqlDatabase',
+		'\SMW\SPARQLStore\FusekiHttpDatabaseConnector',
+		'SMWSparqlDatabase4Store',
+		'SMWSparqlDatabaseVirtuoso'
+	);
+
+	/**
+	 * @dataProvider httpDatabaseConnectorInstanceNameForAskProvider
+	 *
+	 * @see https://www.w3.org/TR/rdf-sparql-query/#ask
+	 */
+	public function testAskToQueryEndpointOnMockedHttpRequest( $httpDatabaseConnector, $expectedPostField ) {
+
+		$queryResultXmlProvider = new FakeQueryResultProvider();
+
+		$httpRequest = $this->getMockBuilder( '\SMW\HttpRequest' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$httpRequest->expects( $this->at( 3 ) )
+			->method( 'setOption' )
+			->with(
+				$this->equalTo( CURLOPT_POSTFIELDS ),
+				$this->stringContains( $expectedPostField ) )
+			->will( $this->returnValue( true ) );
+
+		$httpRequest->expects( $this->once() )
+			->method( 'execute' )
+			->will( $this->returnValue( $queryResultXmlProvider->getEmptySparqlResultXml() ) );
+
+		$instance = new $httpDatabaseConnector(
+			'http://foo/myDefaultGraph',
+			'http://localhost:9999/query'
+		);
+
+		$instance->setHttpRequest( $httpRequest );
+
+		$resultWrapper = $instance->ask(
+			'?x foaf:name "Foo"',
+			array( 'foaf' => 'http://xmlns.com/foaf/0.1/>' )
+		);
+
+		$this->assertInstanceOf( '\SMWSparqlResultWrapper', $resultWrapper );
+	}
+
+	/**
+	 * @dataProvider httpDatabaseConnectorInstanceNameForDeleteProvider
+	 *
+	 * @see http://www.w3.org/TR/sparql11-update/#deleteInsert
+	 */
+	public function testDeleteToUpdateEndpointOnMockedHttpRequest( $httpDatabaseConnector, $expectedPostField ) {
+
+		$httpRequest = $this->getMockBuilder( '\SMW\HttpRequest' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$httpRequest->expects( $this->at( 2 ) )
+			->method( 'setOption' )
+			->with(
+				$this->equalTo( CURLOPT_POSTFIELDS ),
+				$this->stringContains( $expectedPostField ) )
+			->will( $this->returnValue( true ) );
+
+		$httpRequest->expects( $this->once() )
+			->method( 'getLastErrorCode' )
+			->will( $this->returnValue( 0 ) );
+
+		$instance = new $httpDatabaseConnector(
+			'http://foo/myDefaultGraph',
+			'http://localhost:9999/query',
+			'http://localhost:9999/update'
+		);
+
+		$instance->setHttpRequest( $httpRequest );
+
+		$this->assertTrue( $instance->delete( 'wiki:Foo ?p ?o', 'wiki:Foo ?p ?o' ) );
+	}
+
+	/**
+	 * @dataProvider httpDatabaseConnectorInstanceNameForInsertProvider
+	 *
+	 * @see http://www.w3.org/TR/sparql11-http-rdf-update/#http-post
+	 */
+	public function testInsertToDataPointOnMockedHttpRequest( $httpDatabaseConnector ) {
+
+		$httpRequest = $this->getMockBuilder( '\SMW\HttpRequest' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$httpRequest->expects( $this->once() )
+			->method( 'getLastErrorCode' )
+			->will( $this->returnValue( 0 ) );
+
+		$instance = new $httpDatabaseConnector(
+			'http://foo/myDefaultGraph',
+			'http://localhost:9999/query',
+			'http://localhost:9999/update',
+			'http://localhost:9999/data'
+		);
+
+		$instance->setHttpRequest( $httpRequest );
+
+		$this->assertTrue( $instance->insertData( 'property:Foo  wiki:Bar;' ) );
+	}
+
+	public function httpDatabaseConnectorInstanceNameForAskProvider() {
+
+		$encodedDefaultGraph = urlencode( 'http://foo/myDefaultGraph' );
+
+		foreach ( $this->databaseConnectors as $databaseConnector ) {
+
+			switch ( $databaseConnector ) {
+				case '\SMW\SPARQLStore\FusekiHttpDatabaseConnector':
+					$expectedPostField = '&default-graph-uri=' . $encodedDefaultGraph . '&output=xml';
+					break;
+				case 'SMWSparqlDatabase4Store':
+					$expectedPostField = "&restricted=1" . '&default-graph-uri=' . $encodedDefaultGraph;
+					break;
+				default:
+					$expectedPostField = '&default-graph-uri=' . $encodedDefaultGraph;
+					break;
+			};
+
+			$provider[] = array( $databaseConnector, $expectedPostField );
+		}
+
+		return $provider;
+	}
+
+	public function httpDatabaseConnectorInstanceNameForDeleteProvider() {
+
+		foreach ( $this->databaseConnectors as $databaseConnector ) {
+
+			switch ( $databaseConnector ) {
+				case 'SMWSparqlDatabaseVirtuoso':
+					$expectedPostField = 'query=';
+					break;
+				default:
+					$expectedPostField = 'update=';
+					break;
+			};
+
+			$provider[] = array( $databaseConnector, $expectedPostField );
+		}
+
+		return $provider;
+	}
+
+	public function httpDatabaseConnectorInstanceNameForInsertProvider() {
+
+		foreach ( $this->databaseConnectors as $databaseConnector ) {
+			$provider[] = array( $databaseConnector );
+		}
+
+		return $provider;
+	}
+
+}


### PR DESCRIPTION
- `4Store` (1.1.4) compliance
- Replace curl_\* operations with the appropriate $httpRequest operation
- `4Store` encoding issue has been pointed out by Dbeeson in [gerrit70047](https://gerrit.wikimedia.org/r/#/c/70047/4/includes/sparql/SMW_SparqlDatabase4Store.php)
### Test environment

The following settings have been used to run all tests and `php rebuildData.php -v` against `4Store` v1.1.4-2

```
4s-httpd -p 8088 smw
$smwgSparqlDatabaseConnector = '4store';
$smwgSparqlQueryEndpoint = 'http://localhost:8088/sparql/';
$smwgSparqlUpdateEndpoint = 'http://localhost:8088/update/';
$smwgSparqlDataEndpoint = 'http://localhost:8088/data/';
$smwgSparqlDefaultGraph = 'http://example.org/mydefaultgraphname';
```
### Bugs to be solved
- https://bugzilla.wikimedia.org/show_bug.cgi?id=43708
- https://bugzilla.wikimedia.org/show_bug.cgi?id=44700
### Test coverage changes

[Changes](https://scrutinizer-ci.com/g/SemanticMediaWiki/SemanticMediaWiki/inspections/99dd45d0-9408-452c-991a-ab81b905a549/code-structure/test-coverage)
