### PR TITLE
SMW\SPARQLStore tidy some classes + renaming

### DIFF
--- a/SemanticMediaWiki.php
+++ b/SemanticMediaWiki.php
@@ -74,6 +74,9 @@ class_alias( 'SMW\AggregatablePrinter', 'SMWAggregatablePrinter' );
 class_alias( 'SMW\ListResultPrinter', 'SMWListResultPrinter' );
 class_alias( 'SMW\DIConcept', 'SMWDIConcept' );
 
+class_alias( 'SMW\SPARQLStore\FourstoreHttpDatabaseConnector', 'SMWSparqlDatabase4Store' );
+class_alias( 'SMW\SPARQLStore\VirtuosoHttpDatabaseConnector', 'SMWSparqlDatabaseVirtuoso' );
+
 // A flag used to indicate SMW defines a semantic extension type for extension credits.
 // @deprecated, removal in SMW 1.11
 define( 'SEMANTIC_EXTENSION_TYPE', true );

--- a/includes/src/SPARQLStore/SparqlDBConnectionProvider.php
+++ b/includes/src/SPARQLStore/SparqlDBConnectionProvider.php
@@ -25,8 +25,8 @@ class SparqlDBConnectionProvider implements DBConnectionProvider {
 	private $connectorIdToClass = array(
 		'default'   => 'SMWSparqlDatabase',
 		'fuseki'    => 'SMW\SPARQLStore\FusekiHttpDatabaseConnector',
-		'virtuoso'  => 'SMWSparqlDatabaseVirtuoso',
-		'4store'    => 'SMWSparqlDatabase4Store',
+		'virtuoso'  => 'SMW\SPARQLStore\VirtuosoHttpDatabaseConnector',
+		'4store'    => 'SMW\SPARQLStore\FourstoreHttpDatabaseConnector',
 	);
 
 	/**

--- a/includes/src/SPARQLStore/VirtuosoHttpDatabaseConnector.php
+++ b/includes/src/SPARQLStore/VirtuosoHttpDatabaseConnector.php
@@ -1,6 +1,8 @@
 <?php
 
-use SMW\SPARQLStore\BadHttpDatabaseResponseException as SMWSparqlDatabaseError;
+namespace SMW\SPARQLStore;
+
+use SMWSparqlDatabase as SparqlDatabase;
 
 /**
  * Virtuoso specific adjustments for SparqlDatabase
@@ -40,7 +42,7 @@ use SMW\SPARQLStore\BadHttpDatabaseResponseException as SMWSparqlDatabaseError;
  *
  * @author Markus Krötzsch
  */
-class SMWSparqlDatabaseVirtuoso extends SMWSparqlDatabase {
+class VirtuosoHttpDatabaseConnector extends SparqlDatabase {
 
 	/**
 	 * DELETE wrapper.
@@ -141,7 +143,7 @@ class SMWSparqlDatabaseVirtuoso extends SMWSparqlDatabase {
 	public function doUpdate( $sparql ) {
 
 		if ( $this->m_updateEndpoint === '' ) {
-			throw new SMWSparqlDatabaseError( SMWSparqlDatabaseError::ERROR_NOSERVICE, $sparql, 'not specified' );
+			throw new BadHttpDatabaseResponseException( BadHttpDatabaseResponseException::ERROR_NOSERVICE, $sparql, 'not specified' );
 		}
 
 		$this->httpRequest->setOption( CURLOPT_URL, $this->m_updateEndpoint );

--- a/tests/phpunit/Integration/QueryResultQueryProcessorIntegrationTest.php
+++ b/tests/phpunit/Integration/QueryResultQueryProcessorIntegrationTest.php
@@ -14,7 +14,7 @@ use SMWQueryProcessor;
  * @license GNU GPL v2+
  * @author mwjames
  */
-class SimpleQueryResultQueryProcessorIntegrationTest extends \PHPUnit_Framework_TestCase {
+class QueryResultQueryProcessorIntegrationTest extends \PHPUnit_Framework_TestCase {
 
 	/**
 	 * @dataProvider queryDataProvider

--- a/tests/phpunit/includes/SPARQLStore/DatabaseConnectorExceptionTest.php
+++ b/tests/phpunit/includes/SPARQLStore/DatabaseConnectorExceptionTest.php
@@ -4,8 +4,8 @@ namespace SMW\Tests\SPARQLStore;
 
 /**
  * @covers \SMW\SPARQLStore\FusekiHttpDatabaseConnector
- * @covers \SMWSparqlDatabase4Store
- * @covers \SMWSparqlDatabaseVirtuoso
+ * @covers \SMW\SPARQLStore\FourstoreHttpDatabaseConnector
+ * @covers \SMW\SPARQLStore\VirtuosoHttpDatabaseConnector
  * @covers \SMWSparqlDatabase
  *
  * @ingroup Test
@@ -25,6 +25,10 @@ class DatabaseConnectorExceptionTest extends \PHPUnit_Framework_TestCase {
 	private $databaseConnectors = array(
 		'SMWSparqlDatabase',
 		'\SMW\SPARQLStore\FusekiHttpDatabaseConnector',
+		'\SMW\SPARQLStore\FourstoreHttpDatabaseConnector',
+		'\SMW\SPARQLStore\VirtuosoHttpDatabaseConnector',
+
+		// Legacy and should be removed once obsolete
 		'SMWSparqlDatabase4Store',
 		'SMWSparqlDatabaseVirtuoso'
 	);
@@ -108,6 +112,8 @@ class DatabaseConnectorExceptionTest extends \PHPUnit_Framework_TestCase {
 	}
 
 	public function httpDatabaseConnectorInstanceNameProvider() {
+
+		$provider = array();
 
 		foreach ( $this->databaseConnectors as $databaseConnector ) {
 			$provider[] = array( $databaseConnector );

--- a/tests/phpunit/includes/SPARQLStore/DatabaseConnectorHttpRequestIntegrityTest.php
+++ b/tests/phpunit/includes/SPARQLStore/DatabaseConnectorHttpRequestIntegrityTest.php
@@ -3,12 +3,11 @@
 namespace SMW\Tests\SPARQLStore;
 
 use SMW\Tests\Util\FakeQueryResultProvider;
-use SMW\SPARQLStore\FusekiHttpDatabaseConnector;
 
 /**
  * @covers \SMW\SPARQLStore\FusekiHttpDatabaseConnector
- * @covers \SMWSparqlDatabase4Store
- * @covers \SMWSparqlDatabaseVirtuoso
+ * @covers \SMW\SPARQLStore\FourstoreHttpDatabaseConnector
+ * @covers \SMW\SPARQLStore\VirtuosoHttpDatabaseConnector
  * @covers \SMWSparqlDatabase
  *
  * @ingroup Test
@@ -27,6 +26,10 @@ class DatabaseConnectorHttpRequestIntegrityTest extends \PHPUnit_Framework_TestC
 	private $databaseConnectors = array(
 		'SMWSparqlDatabase',
 		'\SMW\SPARQLStore\FusekiHttpDatabaseConnector',
+		'\SMW\SPARQLStore\FourstoreHttpDatabaseConnector',
+		'\SMW\SPARQLStore\VirtuosoHttpDatabaseConnector',
+
+		// Legacy and should be removed once obsolete
 		'SMWSparqlDatabase4Store',
 		'SMWSparqlDatabaseVirtuoso'
 	);
@@ -108,7 +111,7 @@ class DatabaseConnectorHttpRequestIntegrityTest extends \PHPUnit_Framework_TestC
 	 *
 	 * @see http://www.w3.org/TR/sparql11-http-rdf-update/#http-post
 	 */
-	public function testInsertToDataPointOnMockedHttpRequest( $httpDatabaseConnector ) {
+	public function testInsertViaHttpPostToDataPointOnMockedHttpRequest( $httpDatabaseConnector ) {
 
 		$httpRequest = $this->getMockBuilder( '\SMW\HttpRequest' )
 			->disableOriginalConstructor()
@@ -132,6 +135,7 @@ class DatabaseConnectorHttpRequestIntegrityTest extends \PHPUnit_Framework_TestC
 
 	public function httpDatabaseConnectorInstanceNameForAskProvider() {
 
+		$provider = array();
 		$encodedDefaultGraph = urlencode( 'http://foo/myDefaultGraph' );
 
 		foreach ( $this->databaseConnectors as $databaseConnector ) {
@@ -141,6 +145,7 @@ class DatabaseConnectorHttpRequestIntegrityTest extends \PHPUnit_Framework_TestC
 					$expectedPostField = '&default-graph-uri=' . $encodedDefaultGraph . '&output=xml';
 					break;
 				case 'SMWSparqlDatabase4Store':
+				case '\SMW\SPARQLStore\FourstoreHttpDatabaseConnector':
 					$expectedPostField = "&restricted=1" . '&default-graph-uri=' . $encodedDefaultGraph;
 					break;
 				default:
@@ -156,10 +161,13 @@ class DatabaseConnectorHttpRequestIntegrityTest extends \PHPUnit_Framework_TestC
 
 	public function httpDatabaseConnectorInstanceNameForDeleteProvider() {
 
+		$provider = array();
+
 		foreach ( $this->databaseConnectors as $databaseConnector ) {
 
 			switch ( $databaseConnector ) {
 				case 'SMWSparqlDatabaseVirtuoso':
+				case '\SMW\SPARQLStore\VirtuosoHttpDatabaseConnector':
 					$expectedPostField = 'query=';
 					break;
 				default:
@@ -174,6 +182,8 @@ class DatabaseConnectorHttpRequestIntegrityTest extends \PHPUnit_Framework_TestC
 	}
 
 	public function httpDatabaseConnectorInstanceNameForInsertProvider() {
+
+		$provider = array();
 
 		foreach ( $this->databaseConnectors as $databaseConnector ) {
 			$provider[] = array( $databaseConnector );

--- a/tests/phpunit/includes/SPARQLStore/SparqlDBConnectionProviderTest.php
+++ b/tests/phpunit/includes/SPARQLStore/SparqlDBConnectionProviderTest.php
@@ -101,6 +101,12 @@ class SparqlDBConnectionProviderTest extends \PHPUnit_Framework_TestCase {
 		$instance = new SparqlDBConnectionProvider( 'virtuoso' );
 
 		$this->assertInstanceOf(
+			'\SMW\SPARQLStore\VirtuosoHttpDatabaseConnector',
+			$instance->getConnection()
+		);
+
+		// Legacy
+		$this->assertInstanceOf(
 			'\SMWSparqlDatabaseVirtuoso',
 			$instance->getConnection()
 		);
@@ -110,6 +116,12 @@ class SparqlDBConnectionProviderTest extends \PHPUnit_Framework_TestCase {
 
 		$instance = new SparqlDBConnectionProvider( '4STORE' );
 
+		$this->assertInstanceOf(
+			'\SMW\SPARQLStore\FourstoreHttpDatabaseConnector',
+			$instance->getConnection()
+		);
+
+		// Legacy
 		$this->assertInstanceOf(
 			'\SMWSparqlDatabase4Store',
 			$instance->getConnection()


### PR DESCRIPTION
- Move `SMWSparqlDatabaseVirtuoso` to `VirtuosoHttpDatabaseConnector`
- Move `SMWSparqlDatabase4Store` to `FourstoreHttpDatabaseConnector`
- Previous class names are kept as alias to aid transition
