### PR TITLE
Modernize dumpRDF script

### DIFF
--- a/maintenance/SMW_dumpRDF.php
+++ b/maintenance/SMW_dumpRDF.php
@@ -1,80 +1,9 @@
 <?php
+
 /**
- * Usage:
- * php SMW_dumpRDF.php [options...]
+ * This script will be forwarded to dumpRDF.php.
  *
- * Note: if SMW is not installed in its standard path under ./extensions
- *       then the MW_INSTALL_PATH environment variable must be set.
- *       See README in the maintenance directory.
- *
- * -o <filename>  output file, stdout is used if omitted;
- *                file output is generally better and strongly recommended for large wikis
- * --categories   do only categories
- * --concepts     do only concepts
- * --classes      do only concepts and categories
- * --properties   do only properties
- * --types        do only types
- * --individuals  do only pages that are no categories, properties, or types
- * -d <delay>     slows down the export in order to stress the server less,
- *                sleeping for <delay> milliseconds every now and then
- * -e <each>      after how many exported entities should the process take a nap?
- * --server=<server> The protocol and server name to as base URLs, e.g.
- *                http://en.wikipedia.org. This is sometimes necessary because
- *                server name detection may fail in command line scripts.
- *
- * @author Markus Krötzsch
- * @file
- * @ingroup SMWMaintenance
+ * @deprecated 1.9.3 This maintenance script has been deprecated, please use
+ * dumpRDF.php instead.
  */
-
-$optionsWithArgs = array( 'o', 'd', 'e', 'server' );
-
-require_once ( getenv( 'MW_INSTALL_PATH' ) !== false
-	? getenv( 'MW_INSTALL_PATH' ) . "/maintenance/commandLine.inc"
-	: dirname( __FILE__ ) . '/../../../maintenance/commandLine.inc' );
-global $smwgIP, $wgServer;
-//require_once( "$smwgIP/specials/Export/SMW_SpecialOWLExport.php" );
-
-if ( !empty( $options['o'] ) ) {
-	$outfile = $options['o'];
-} else {
-	$outfile = false;
-}
-if ( !empty( $options['d'] ) ) {
-	$delay = intval( $options['d'] ) * 1000;
-} else {
-	$delay = 0;
-}
-if ( !empty( $options['e'] ) ) {
-	$delayeach = intval( $options['e'] );
-} else {
-	$delayeach = ( $delay === 0 ) ? 0 : 1;
-}
-
-
-if ( array_key_exists( 'categories', $options ) ) {
-	$export_ns = NS_CATEGORY;
-} elseif ( array_key_exists( 'concepts', $options ) ) {
-	$export_ns = SMW_NS_CONCEPT;
-} elseif ( array_key_exists( 'classes', $options ) ) {
-	$export_ns = array( NS_CATEGORY, SMW_NS_CONCEPT );
-} elseif ( array_key_exists( 'properties', $options ) ) {
-	$export_ns = SMW_NS_PROPERTY;
-} elseif ( array_key_exists( 'types', $options ) ) {
-	$export_ns = SMW_NS_TYPE;
-} elseif ( array_key_exists( 'individuals', $options ) ) {
-	$export_ns = - 1;
-} else {
-	$export_ns = false;
-}
-
-if ( isset( $options['server'] ) ) {
-	$wgServer = $options['server'];
-}
-
-if ( $outfile && empty( $options['q'] ) ) {
-	print "\nWriting OWL/RDF dump to file \"$outfile\" ...\n";
-}
-
-$exRDF = new SMWExportController( new SMWRDFXMLSerializer() );
-$exRDF->printAll( $outfile, $export_ns, $delay, $delayeach );
+require_once ( 'dumpRDF.php' );

--- a/maintenance/dumpRDF.php
+++ b/maintenance/dumpRDF.php
@@ -1,0 +1,164 @@
+<?php
+
+namespace SMW\Maintenance;
+
+use SMWExportController as ExportController;
+use SMWRDFXMLSerializer as RDFXMLSerializer;
+
+$basePath = getenv( 'MW_INSTALL_PATH' ) !== false ? getenv( 'MW_INSTALL_PATH' ) : __DIR__ . '/../../..';
+
+require_once $basePath . '/maintenance/Maintenance.php';
+
+/**
+ * Usage:
+ * php dumpRDF.php [options...]
+ *
+ * -f <filename>  output file, stdout is used if omitted;
+ *                file output is generally better and strongly recommended for large wikis
+ * --categories   do only categories
+ * --concepts     do only concepts
+ * --classes      do only concepts and categories
+ * --properties   do only properties
+ * --types        do only types
+ * --individuals  do only pages that are no categories, properties, or types
+ * -d <delay>     slows down the export in order to stress the server less,
+ *                sleeping for <delay> milliseconds every now and then
+ * -e <each>      after how many exported entities should the process take a nap?
+ * --server=<server> The protocol and server name to as base URLs, e.g.
+ *                http://en.wikipedia.org. This is sometimes necessary because
+ *                server name detection may fail in command line scripts.
+ *
+ * @ingroup SMWMaintenance
+ *
+ * @license GNU GPL v2+
+ * @since 1.9.3
+ *
+ * @author Markus Krötzsch
+ * @author mwjames
+ */
+class DumpRdf extends \Maintenance {
+
+	private $delay = 0;
+	private $delayeach = 0;
+
+	/** @var boolean|array */
+	private $restrictNamespaceTo = false;
+
+	/**
+	 * @since 2.0
+	 */
+	public function __construct() {
+		parent::__construct();
+
+		$this->addDescription( "\n" ."Complete RDF export of existing triples. \n" );
+		$this->addDefaultParams();
+	}
+
+	/**
+	 * @see Maintenance::addDefaultParams
+	 *
+	 * @since 2.0
+	 */
+	protected function addDefaultParams() {
+
+		$this->addOption( 'd', '<delay> Wait for this many milliseconds after processing, useful for limiting server load.', false, true );
+		$this->addOption( 'e', '<each> after how many exported entities should the process take a nap.', false, true );
+		$this->addOption( 'file', '<file> output file.', false, true, 'o' );
+
+		$this->addOption( 'categories', 'Export only categories', false );
+		$this->addOption( 'concepts', 'Export only concepts', false );
+		$this->addOption( 'classes', 'Export only classes', false );
+		$this->addOption( 'properties', 'Export only properties', false );
+		$this->addOption( 'types', 'Export only types', false );
+		$this->addOption( 'individuals', 'Export only individuals', false );
+
+		$this->addOption( 'server', '<server> The protocol and server name to as base URLs, e.g. http://en.wikipedia.org. This is sometimes necessary because server name detection may fail in command line scripts.', false, true );
+		$this->addOption( 'quiet', 'Do not give any output', false, false, 'q' );
+	}
+
+	/**
+	 * @see Maintenance::execute
+	 *
+	 * @since 2.0
+	 */
+	public function execute() {
+
+		if ( !defined( 'SMW_VERSION' ) ) {
+			$this->output( "You need to have SMW enabled in order to use this maintenance script!\n\n" );
+			exit;
+		}
+
+		$this->reportMessage( "\nWriting OWL/RDF dump to " . $this->getOption( 'file' ) . " ...\n" );
+		$this->setParameters()->generateRdfToChannel( );
+
+		return true;
+	}
+
+	/**
+	 * @see Maintenance::reportMessage
+	 *
+	 * @since 2.0
+	 *
+	 * @param string $message
+	 */
+	public function reportMessage( $message ) {
+		$this->output( $message );
+	}
+
+	private function setParameters() {
+
+		if ( $this->hasOption( 'd' ) ) {
+			$this->delay = intval( $this->getOption( 'd' ) ) * 1000;
+		}
+
+		$this->delayeach = ( $this->delay === 0 ) ? 0 : 1;
+
+		if ( $this->hasOption( 'e' ) ) {
+			$this->delayeach = intval( $this->getOption( 'e' )  );
+		}
+
+		if ( $this->hasOption( 'categories' ) ) {
+			$this->restrictNamespaceTo = NS_CATEGORY;
+		} elseif ( $this->hasOption( 'concepts' ) ) {
+			$this->restrictNamespaceTo = SMW_NS_CONCEPT;
+		} elseif ( $this->hasOption( 'classes' ) ) {
+			$this->restrictNamespaceTo = array( NS_CATEGORY, SMW_NS_CONCEPT );
+		} elseif ( $this->hasOption( 'properties' ) ) {
+			$this->restrictNamespaceTo = SMW_NS_PROPERTY;
+		} elseif ( $this->hasOption( 'types' ) ) {
+			$this->restrictNamespaceTo = SMW_NS_TYPE;
+		} elseif ( $this->hasOption( 'individuals' ) ) {
+			$this->restrictNamespaceTo = - 1;
+		}
+
+		if ( $this->hasOption( 'server' ) ) {
+			$GLOBALS['wgServer'] = $this->getOption( 'server' );
+		}
+
+		return $this;
+	}
+
+	private function generateRdfToChannel() {
+
+		$exportController = new ExportController( new RDFXMLSerializer() );
+
+		if ( $this->hasOption( 'file' ) ) {
+			return $exportController->printAllToFile(
+				$this->getOption( 'file' ),
+				$this->restrictNamespaceTo,
+				$this->delay,
+				$this->delayeach
+			);
+		}
+
+		$exportController->printAllToOutput(
+			$this->restrictNamespaceTo,
+			$this->delay,
+			$this->delayeach
+		);
+	}
+
+}
+
+$maintClass = 'SMW\Maintenance\DumpRdf';
+require_once( RUN_MAINTENANCE_IF_MAIN );

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -14,5 +14,6 @@ $autoloader->addClassMap( array(
 	'SMW\Tests\Reporter\MessageReporterTestCase' => __DIR__ . '/phpunit/includes/Reporter/MessageReporterTestCase.php',
 	'SMW\Maintenance\RebuildConceptCache'        => __DIR__ . '/../maintenance/rebuildConceptCache.php',
 	'SMW\Maintenance\RebuildData'                => __DIR__ . '/../maintenance/rebuildData.php',
-	'SMW\Maintenance\RebuildPropertyStatistics'  => __DIR__ . '/../maintenance/rebuildPropertyStatistics.php'
+	'SMW\Maintenance\RebuildPropertyStatistics'  => __DIR__ . '/../maintenance/rebuildPropertyStatistics.php',
+	'SMW\Maintenance\DumpRdf'                    => __DIR__ . '/../maintenance/dumpRDF.php'
 ) );

--- a/tests/phpunit/Integration/RdfXmlSerializationExportDBIntegrationTest.php
+++ b/tests/phpunit/Integration/RdfXmlSerializationExportDBIntegrationTest.php
@@ -1,0 +1,108 @@
+<?php
+
+namespace SMW\Tests\Integration;
+
+use SMW\Tests\MwDBaseUnitTestCase;
+use SMW\Tests\Util\PageCreator;
+use SMW\Tests\Util\PageDeleter;
+
+use SMWExportController as ExportController;
+use SMWRDFXMLSerializer as RDFXMLSerializer;
+
+use Title;
+
+/**
+ * @ingroup Test
+ *
+ * @group SMW
+ * @group SMWExtension
+ * @group semantic-mediawiki-integration
+ * @group semantic-mediawiki-rdf
+ *
+ * @license GNU GPL v2+
+ * @since 2.0
+ *
+ * @author mwjames
+ */
+class RdfXmlSerializationExportDBIntegrationTest extends MwDBaseUnitTestCase {
+
+	protected $databaseToBeExcluded = array( 'sqlite' );
+
+	public function testCanConstruct() {
+
+		$this->assertInstanceOf(
+			'\SMWExportController',
+			new ExportController( new RDFXMLSerializer() )
+		);
+	}
+
+	public function testPrintRdfXmlForPageWithPropertyAnnotation() {
+
+		$pageCreator = new PageCreator();
+
+		$pageCreator
+			->createPage( Title::newFromText( 'TestPrintRdfXmlForPageWithPropertyAnnotation', SMW_NS_PROPERTY ) )
+			->doEdit( '[[Has type::Page]]' );
+
+		$pageCreator
+			->createPage( Title::newFromText( __METHOD__ ) )
+			->doEdit(
+				'{{#set:|TestPrintRdfXmlForPageWithPropertyAnnotation=I--99--O|SomeOtherProperty=11PP33}}' );
+
+		$instance = new ExportController( new RDFXMLSerializer() );
+
+		ob_start();
+		$instance->printPages( array( __METHOD__ ) );
+		$output = ob_get_clean();
+
+		$expectedOutputContent = array(
+			'<swivt:wikiNamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</swivt:wikiNamespace>',
+			'<property:TestPrintRdfXmlForPageWithPropertyAnnotation rdf:resource="&wiki;I-2D-2D99-2D-2DO"/>',
+			'<property:SomeOtherProperty rdf:resource="&wiki;11PP33"/>'
+		);
+
+		$this->assertThatOutputContains(
+			$expectedOutputContent,
+			$output
+		);
+	}
+
+	public function testPrintRdfXmlForPageWithSubobjectPropertyAnnotation() {
+
+		$this->markTestSkipped( "RDF export for subobjects is currently not supported" );
+
+		$pageCreator = new PageCreator();
+
+		$pageCreator
+			->createPage( Title::newFromText( 'TestPrintRdfXmlForPageWithSubobjectPropertyAnnotation', SMW_NS_PROPERTY ) )
+			->doEdit( '[[Has type::Page]]' );
+
+		$pageCreator
+			->createPage( Title::newFromText( __METHOD__ ) )
+			->doEdit(
+				'{{#subobject:|TestPrintRdfXmlForPageWithSubobjectPropertyAnnotation=I--11--O|@sortkey=X99Y}}' );
+
+		$instance = new ExportController( new RDFXMLSerializer() );
+
+		ob_start();
+		$instance->printPages( array( __METHOD__ ) );
+		$output = ob_get_clean();
+
+		$expectedOutputContent = array(
+			'<property:TestPrintRdfXmlForPageWithSubobjectPropertyAnnotation rdf:resource="&wiki;I-2D-2D11-2D-2DO"/>',
+			'<swivt:wikiPageSortKey rdf:datatype="http://www.w3.org/2001/XMLSchema#string">X99Y</swivt:wikiPageSortKey>'
+		);
+
+		$this->assertThatOutputContains(
+			$expectedOutputContent,
+			$output
+		);
+	}
+
+	private function assertThatOutputContains( array $content, $output ) {
+		foreach ( $content as $item ) {
+			$this->assertContains( $item, $output );
+		}
+	}
+
+}

--- a/tests/phpunit/Regression/DumpRdfMaintenanceRegressionTest.php
+++ b/tests/phpunit/Regression/DumpRdfMaintenanceRegressionTest.php
@@ -1,0 +1,91 @@
+<?php
+
+namespace SMW\Tests\Regression;
+
+use SMW\Tests\Util\SemanticDataValidator;
+use SMW\Tests\Util\ByPageSemanticDataFinder;
+use SMW\Tests\Util\MaintenanceRunner;
+use SMW\Test\MwRegressionTestCase;
+
+use SMW\DIProperty;
+
+use Title;
+
+/**
+ * @ingroup Test
+ *
+ * @group SMW
+ * @group SMWExtension
+ * @group semantic-mediawiki-regression
+ * @group semantic-mediawiki-maintenance
+ * @group semantic-mediawiki-rdf
+ * @group mediawiki-database
+ * @group medium
+ *
+ * @license GNU GPL v2+
+ * @since 2.0
+ *
+ * @author mwjames
+ */
+class DumpRdfMaintenanceRegressionTest extends MwRegressionTestCase {
+
+	protected $maintenanceRunner = null;
+	protected $semanticDataValidator = null;
+	protected $semanticDataFinder = null;
+
+	public function getSourceFile() {
+		return __DIR__ . '/data/' . 'GenericLoremIpsumTest-Mw-1-19-7.xml';
+	}
+
+	public function acquirePoolOfTitles() {
+		return array(
+			'Category:Lorem ipsum',
+			'Lorem ipsum',
+			'Elit Aliquam urna interdum',
+			'Platea enim hendrerit',
+			'Property:Has Url',
+			'Property:Has annotation uri',
+			'Property:Has boolean',
+			'Property:Has date',
+			'Property:Has email',
+			'Property:Has number',
+			'Property:Has page',
+			'Property:Has quantity',
+			'Property:Has temperature',
+			'Property:Has text'
+		);
+	}
+
+	public function assertDataImport() {
+
+		$expectedOutputContent = array(
+			'<rdf:type rdf:resource="&wiki;Category-3ALorem_ipsum"/>',
+			'<rdfs:label>Lorem ipsum</rdfs:label>',
+			'<rdfs:label>Has annotation uri</rdfs:label>',
+			'<rdfs:label>Has boolean</rdfs:label>',
+			'<rdfs:label>Has date</rdfs:label>',
+			'<rdfs:label>Has email</rdfs:label>',
+			'<rdfs:label>Has number</rdfs:label>',
+			'<rdfs:label>Has page</rdfs:label>',
+			'<rdfs:label>Has quantity</rdfs:label>',
+			'<rdfs:label>Has temperature</rdfs:label>',
+			'<rdfs:label>Has text</rdfs:label>',
+			'<rdfs:label>Has Url</rdfs:label>',
+		);
+
+		$this->maintenanceRunner = new MaintenanceRunner( 'SMW\Maintenance\DumpRdf' );
+		$this->maintenanceRunner->setQuiet()->run();
+
+		$this->assertThatOutputContains(
+			$expectedOutputContent,
+			$this->maintenanceRunner->getOutput()
+		);
+	}
+
+	private function assertThatOutputContains( array $content, $output ) {
+		foreach ( $content as $item ) {
+			$this->assertContains( $item, $output );
+		}
+	}
+
+}


### PR DESCRIPTION
- Fix bug 35679
- General script hygiene
- `SMWExportController::printAll` is now protected, the public interface
  `printAllToOutput` and `printAllToFile` are two dedicated methods to do
  only things they are responsible for
- Add `DumpRdfMaintenanceRegressionTest`

Relates to #257
