### PR TITLE
SPARQLStore / QE / Count query results

### DIFF
--- a/includes/query/SMW_QueryProcessor.php
+++ b/includes/query/SMW_QueryProcessor.php
@@ -510,6 +510,11 @@ class SMWQueryProcessor {
 
 			return $result;
 		} else { // result for counting or debugging is just a string or number
+
+			if ( $res instanceof SMWQueryResult ) {
+				$res = $res->getCountValue();
+			}
+
 			if ( is_numeric( $res ) ) {
 				$res = strval( $res );
 			}

--- a/includes/storage/SMW_QueryResult.php
+++ b/includes/storage/SMW_QueryResult.php
@@ -54,6 +54,12 @@ class SMWQueryResult {
 	protected $mStore;
 
 	/**
+	 * Holds a value that belongs to a count query result
+	 * @var integer|null
+	 */
+	private $countValue;
+
+	/**
 	 * Initialise the object with an array of SMWPrintRequest objects, which
 	 * define the structure of the result "table" (one for each column).
 	 *
@@ -147,7 +153,7 @@ class SMWQueryResult {
 	/**
 	 * Return array of print requests (needed for printout since they contain
 	 * property labels).
-	 * 
+	 *
 	 * @return SMWPrintRequest[]
 	 */
 	public function getPrintRequests() {
@@ -171,6 +177,24 @@ class SMWQueryResult {
 	 */
 	public function hasFurtherResults() {
 		return $this->mFurtherResults;
+	}
+
+	/**
+	 * @since  2.0
+	 *
+	 * @param integer $countValue
+	 */
+	public function setCountValue( $countValue ) {
+		$this->countValue = (int)$countValue;
+	}
+
+	/**
+	 * @since  2.0
+	 *
+	 * @return integer|null
+	 */
+	public function getCountValue() {
+		return $this->countValue;
 	}
 
 	/**

--- a/tests/phpunit/Integration/MediaWiki/ParserFunctionInPageEmbeddedForQueryResultLookupDBIntegrationTest.php
+++ b/tests/phpunit/Integration/MediaWiki/ParserFunctionInPageEmbeddedForQueryResultLookupDBIntegrationTest.php
@@ -92,9 +92,11 @@ class ParserFunctionInPageEmbeddedForQueryResultLookupDBIntegrationTest extends 
 
 		$query->querymode = Query::MODE_COUNT;
 
+		$result = $this->getStore()->getQueryResult( $query );
+
 		$this->assertEquals(
 			2,
-			$this->getStore()->getQueryResult( $query )
+			$result instanceOf \SMWQueryResult ? $result->getCountValue() : $result
 		);
 
 		$query->querymode = Query::MODE_INSTANCES;
@@ -151,9 +153,11 @@ class ParserFunctionInPageEmbeddedForQueryResultLookupDBIntegrationTest extends 
 
 		$query->querymode = Query::MODE_COUNT;
 
+		$result = $this->getStore()->getQueryResult( $query );
+
 		$this->assertEquals(
 			3,
-			$this->getStore()->getQueryResult( $query )
+			$result instanceOf \SMWQueryResult ? $result->getCountValue() : $result
 		);
 
 		$query->querymode = Query::MODE_INSTANCES;


### PR DESCRIPTION
Count query results are returned as an integer which makes it impossible to return a proper object or for that matter possible errors
- Add `SMWQueryResult::setCountValue`, `SMWQueryResult::getCountValue`
- `SMWQueryProcessor` is modified in away that it detects an integer or object and acts accordingly

```
$queryResult->setCountValue( $resultWrapper->getNumericValue() );
```

Relates to #375 
