### PR TITLE
Add Query::setUnboundLimit

### DIFF
--- a/includes/query/SMW_Query.php
+++ b/includes/query/SMW_Query.php
@@ -178,6 +178,20 @@ class SMWQuery {
 	}
 
 	/**
+	 * @note Sets an unbound limit that is independent from GLOBAL settings
+	 *
+	 * @since 2.0
+	 *
+	 * @param integer $limit
+	 *
+	 * @return Query
+	 */
+	public function setUnboundLimit( $limit ) {
+		$this->m_limit = (int)$limit;
+		return $this;
+	}
+
+	/**
 	 * Apply structural restrictions to the current description.
 	 */
 	public function applyRestrictions() {

--- a/includes/src/Store/Maintenance/DataRebuilder.php
+++ b/includes/src/Store/Maintenance/DataRebuilder.php
@@ -301,7 +301,7 @@ class DataRebuilder {
 			SMWQueryProcessor::getProcessedParams( array( 'format' => 'count' ) )
 		);
 
-		$numberOfPages = (int)$this->store->getQueryResult( $query );
+		$result = $this->store->getQueryResult( $query );
 
 		// get pages and add them to the pages explicitly listed in the 'page' parameter
 		$query = SMWQueryProcessor::createQuery(
@@ -309,14 +309,7 @@ class DataRebuilder {
 			SMWQueryProcessor::getProcessedParams( array() )
 		);
 
-		// FIXME SMWQuery setLimit
-		// Manipulating GLOBAL state as below is not a good design practice and
-		// should be avoided at all cost but since we rely on SMWQuery class we
-		// need to introduce a hack
-		$beforeMaxLimitManipulation = $GLOBALS['smwgQMaxLimit'];
-		$GLOBALS['smwgQMaxLimit'] = $numberOfPages;
-		$query->setLimit( $numberOfPages, false );
-		$GLOBALS['smwgQMaxLimit'] = $beforeMaxLimitManipulation;
+		$query->setUnboundLimit( $result instanceof \SMWQueryResult ? $result->getCountValue() : $result );
 
 		return $this->store->getQueryResult( $query )->getResults();
 	}

--- a/tests/phpunit/Regression/RebuildDataMaintenanceRegressionTest.php
+++ b/tests/phpunit/Regression/RebuildDataMaintenanceRegressionTest.php
@@ -86,7 +86,8 @@ class RebuildDataMaintenanceRegressionTest extends MwRegressionTestCase {
 		$this->assertRunWithFullDeleteOption( $expectedSomeProperties );
 		$this->assertRunWithIdRangeOption( $expectedSomeProperties );
 		$this->assertRunWithCategoryOption( $expectedSomeProperties );
-		$this->assertRunWithSparqlStore( $expectedSomeProperties );
+		$this->assertRunWithSparqlStoreForPropertyOption( $expectedSomeProperties );
+		$this->assertRunWithSparqlStoreForQueryOption( $expectedSomeProperties );
 	}
 
 	protected function assertRunWithoutOptions( $expectedSomeProperties ) {
@@ -117,11 +118,20 @@ class RebuildDataMaintenanceRegressionTest extends MwRegressionTestCase {
 		);
 	}
 
-	protected function assertRunWithSparqlStore( $expectedSomeProperties ) {
+	protected function assertRunWithSparqlStoreForPropertyOption( $expectedSomeProperties ) {
 		$this->assertThatPropertiesAreSet(
 			$expectedSomeProperties,
 			$this->maintenanceRunner->setOptions( array(
 				'p' => true,
+				'b' => 'SMWSparqlStore' ) )->run()
+		);
+	}
+
+	protected function assertRunWithSparqlStoreForQueryOption( $expectedSomeProperties ) {
+		$this->assertThatPropertiesAreSet(
+			$expectedSomeProperties,
+			$this->maintenanceRunner->setOptions( array(
+				'query' => '[[Has Url::+]]',
 				'b' => 'SMWSparqlStore' ) )->run()
 		);
 	}

--- a/tests/phpunit/includes/query/QueryTest.php
+++ b/tests/phpunit/includes/query/QueryTest.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace SMW\Tests;
+
+use SMWQuery as Query;
+
+/**
+ * @covers \SMWQuery
+ *
+ * @ingroup Test
+ *
+ * @group SMW
+ * @group SMWExtension
+ *
+ * @license GNU GPL v2+
+ * @since 2.0
+ *
+ * @author mwjames
+ */
+class QueryTest extends \PHPUnit_Framework_TestCase {
+
+	public function testCanConstruct() {
+
+		$description = $this->getMockForAbstractClass( '\SMWDescription' );
+
+		$this->assertInstanceOf(
+			'\SMWQuery',
+			new Query( $description )
+		);
+	}
+
+	public function testSetGetLimitForInlineQueryWhereUpperboundIsRestrictedByGLOBALRequirements() {
+
+		$description = $this->getMockForAbstractClass( '\SMWDescription' );
+
+		$instance = new Query( $description, true, false );
+
+		$upperboundLimit = 999999999;
+		$lowerboundLimit = 1;
+
+		$smwgQMaxLimit = $GLOBALS['smwgQMaxLimit'];
+		$smwgQMaxInlineLimit = $GLOBALS['smwgQMaxInlineLimit'];
+
+		$this->assertLessThan( $upperboundLimit, $smwgQMaxLimit );
+		$this->assertLessThan( $upperboundLimit, $smwgQMaxInlineLimit );
+
+		$this->assertGreaterThan( $lowerboundLimit, $smwgQMaxLimit );
+		$this->assertGreaterThan( $lowerboundLimit, $smwgQMaxInlineLimit );
+
+		$instance->setLimit( $upperboundLimit, true );
+		$this->assertEquals( $smwgQMaxInlineLimit, $instance->getLimit() );
+
+		$instance->setLimit( $upperboundLimit, false );
+		$this->assertEquals( $smwgQMaxLimit, $instance->getLimit() );
+
+		$instance->setLimit( $lowerboundLimit, true );
+		$this->assertEquals( $lowerboundLimit, $instance->getLimit() );
+
+		$instance->setLimit( $lowerboundLimit, false );
+		$this->assertEquals( $lowerboundLimit, $instance->getLimit() );
+	}
+
+	public function testSetGetLimitForInlineQueryWhereUnboundLimitIsUnrestricted() {
+
+		$description = $this->getMockForAbstractClass( '\SMWDescription' );
+
+		$instance = new Query( $description, true, false );
+
+		$upperboundLimit = 999999999;
+		$lowerboundLimit = 1;
+
+		$instance->setUnboundLimit( $upperboundLimit );
+		$this->assertEquals( $upperboundLimit, $instance->getLimit() );
+
+		$instance->setUnboundLimit( $lowerboundLimit );
+		$this->assertEquals( $lowerboundLimit, $instance->getLimit() );
+	}
+
+}


### PR DESCRIPTION
`Query::setLimit` uses GLOBAL state to determine additional requirements but sometimes an unbound limit is expected.
