### PR TITLE
Add SMW JobQueue statistics

### DIFF
--- a/SemanticMediaWiki.settings.php
+++ b/SemanticMediaWiki.settings.php
@@ -748,3 +748,11 @@ $GLOBALS['smwgOnDeleteAction'] = array(
 	'smwgDeleteSubjectWithAssociatesRefresh' => false
 );
 ##
+
+###
+# Whether to show SMW specific JobQueue statistics on Special:Statistics
+#
+# @since 2.0
+##
+$GLOBALS['smwgShowJobQueueStatistics'] = true;
+##

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -295,5 +295,9 @@
 	"smw-sp-admin-idlookup-title": "ObjectId lookup",
 	"smw-sp-admin-idlookup-docu": "Displays details about an internal object Id that represents individual entities (wikipage, subobject etc.) in Semantic MediaWiki.",
 	"smw-sp-admin-idlookup-objectid": "Object Id:",
-	"smw-livepreview-loading": "Loading..."
+	"smw-livepreview-loading": "Loading...",
+	"smw-statistics-jobqueue": "JobQueue statistics",
+	"smw-statistics-jobqueue-update-count": "Update {{PLURAL:$1|job|jobs}}",
+	"smw-statistics-jobqueue-refresh-count": "Refresh {{PLURAL:$1|job|jobs}}",
+	"smw-statistics-jobqueue-delete-count": "Delete {{PLURAL:$1|job|jobs}}"
 }

--- a/i18n/qqq.json
+++ b/i18n/qqq.json
@@ -310,5 +310,9 @@
 	"smw-sp-admin-idlookup-title": "A header title",
 	"smw-sp-admin-idlookup-docu": "Introductory text for the objectId lookup section in [[Special:SMWAdmin]]",
 	"smw-sp-admin-idlookup-objectid": "A label",
-	"smw-livepreview-loading": "{{Identical|Loading}}Message displayed while data is loading."
+	"smw-livepreview-loading": "{{Identical|Loading}}Message displayed while data is loading.",
+	"smw-statistics-jobqueue": "Is a label that is displayed on the [[Special:Statistics|Statistics]] page.\n{{Identical|Semantic statistics}}",
+	"smw-statistics-jobqueue-update-count": "Used as a label that is displayed on the [[Special:Statistics|Statistics]] page.\n\nParameters:\n* $1 - number of values",
+	"smw-statistics-jobqueue-refresh-count": "Used as a label that is displayed on the [[Special:Statistics|Statistics]] page.\n\nParameters:\n* $1 - number of values",
+	"smw-statistics-jobqueue-delete-count": "Used as a label that is displayed on the [[Special:Statistics|Statistics]] page.\n\nParameters:\n* $1 - number of values"
 }

--- a/includes/Settings.php
+++ b/includes/Settings.php
@@ -126,7 +126,8 @@ class Settings extends SimpleDictionary {
 			'smwgFactboxCacheRefreshOnPurge' => $GLOBALS['smwgFactboxCacheRefreshOnPurge'],
 			'smwgQueryProfiler' => $GLOBALS['smwgQueryProfiler'],
 			'smwgEnabledSpecialPage' => $GLOBALS['smwgEnabledSpecialPage'],
-			'smwgOnDeleteAction' => $GLOBALS['smwgOnDeleteAction']
+			'smwgOnDeleteAction' => $GLOBALS['smwgOnDeleteAction'],
+			'smwgShowJobQueueStatistics' => $GLOBALS['smwgShowJobQueueStatistics']
 		);
 
 		$settings = $settings + array(

--- a/includes/src/MediaWiki/Database.php
+++ b/includes/src/MediaWiki/Database.php
@@ -345,4 +345,13 @@ class Database {
 		return $this->acquireReadConnection()->selectField( $table, $fieldName, $conditions, $fname, $options );
 	}
 
+	/**
+	 * @see DatabaseBase::estimateRowCount
+	 *
+	 * @since 2.0
+	 */
+	public function estimateRowCount( $table, $vars = '*', $conditions = '', $fname = __METHOD__, $options = array() ) {
+		return $this->acquireReadConnection()->estimateRowCount( $table, $vars, $conditions, $fname, $options );
+	}
+
 }

--- a/includes/src/MediaWiki/JobQueueLookup.php
+++ b/includes/src/MediaWiki/JobQueueLookup.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace SMW\MediaWiki;
+
+/**
+ * @ingroup SMW
+ *
+ * @license GNU GPL v2+
+ * @since 2.0
+ *
+ * @author mwjames
+ */
+class JobQueueLookup {
+
+	/**
+	 * @var Database
+	 */
+	protected $dbConnection = null;
+
+	/**
+	 * @since 2.0
+	 *
+	 * @param Database $database
+	 */
+	public function __construct( Database $dbConnection ) {
+		$this->dbConnection = $dbConnection;
+	}
+
+	/**
+	 * @since 2.0
+	 *
+	 * @return array
+	 */
+	public function getStatistics() {
+		return array(
+			'UPDATEJOB'  => $this->estimateJobCountFor( 'SMW\UpdateJob' ),
+			'REFRESHJOB' => $this->estimateJobCountFor( 'SMW\RefreshJob' ),
+			'DELETEJOB'  => $this->estimateJobCountFor( 'SMW\DeleteSubjectJob' )
+		);
+	}
+
+	private function estimateJobCountFor( $jobName ) {
+
+		$count = 0;
+
+		$count = $this->dbConnection->estimateRowCount(
+			'job',
+			'*',
+			array( 'job_cmd' => $jobName )
+		);
+
+		return (int)$count;
+	}
+
+}

--- a/tests/phpunit/includes/MediaWiki/JobQueueLookupTest.php
+++ b/tests/phpunit/includes/MediaWiki/JobQueueLookupTest.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace SMW\Tests\MediaWiki;
+
+use SMW\MediaWiki\JobQueueLookup;
+
+/**
+ * @covers \SMW\MediaWiki\JobQueueLookup
+ *
+ * @ingroup Test
+ *
+ * @group SMW
+ * @group SMWExtension
+ *
+ * @license GNU GPL v2+
+ * @since 2.0
+ *
+ * @author mwjames
+ */
+class JobQueueLookupTest extends \PHPUnit_Framework_TestCase {
+
+	public function testCanConstruct() {
+
+		$database = $this->getMockBuilder( '\SMW\MediaWiki\Database' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$this->assertInstanceOf(
+			'\SMW\MediaWiki\JobQueueLookup',
+			new JobQueueLookup( $database )
+		);
+	}
+
+	public function testGetJobQueueStatisticsOnMockedStore() {
+
+		$database = $this->getMockBuilder( '\SMW\MediaWiki\Database' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$database->expects( $this->exactly( 3 ) )
+			->method( 'estimateRowCount' )
+			->with( $this->equalTo( 'job' ),
+					$this->anything(),
+					$this->anything(),
+					$this->anything() )
+			->will( $this->returnValue( 9999 ) );
+
+		$instance = new JobQueueLookup( $database );
+
+		$this->assertInternalType(
+			'array',
+			$instance->getStatistics()
+		);
+	}
+
+}

--- a/tests/phpunit/includes/SetupTest.php
+++ b/tests/phpunit/includes/SetupTest.php
@@ -36,6 +36,7 @@ class SetupTest extends SemanticMediaWikiTestCase {
 		$settings = $context->getSettings();
 		$settings->set( 'smwgCacheType', CACHE_NONE );
 		$settings->set( 'smwgEnableUpdateJobs', false );
+		$settings->set( 'smwgShowJobQueueStatistics', false );
 
 		$context->getDependencyBuilder()
 			->getContainer()


### PR DESCRIPTION
Allows some insight about SMW related jobs and display them via `Special:Statistics`. `$smwgShowJobQueueStatistics` can be used to disable the display.

[0] http://wikimedia.7.x6.nabble.com/Re-Job-queue-affecting-semantic-queries-in-MW-1-22-tp5029433.html
