### PR TITLE
MW 1.24+ / Hotfix for missing Redirect caused by bug 62856

### DIFF
--- a/includes/ContentParser.php
+++ b/includes/ContentParser.php
@@ -38,6 +38,11 @@ class ContentParser {
 	protected $errors = array();
 
 	/**
+	 * @var boolean
+	 */
+	private $enabledToUseContentHandler = true;
+
+	/**
 	 * @note Injecting new Parser() alone will not yield an expected result and
 	 * doing new Parser( $GLOBALS['wgParserConf'] brings no benefits therefore
 	 * we stick to the GLOBAL as fallback if no parser is injected.
@@ -64,6 +69,15 @@ class ContentParser {
 	public function setRevision( Revision $revision = null ) {
 		$this->revision = $revision;
 		return $this;
+	}
+
+	/**
+	 * @bug 62856 and #212
+	 *
+	 * @since 2.0
+	 */
+	public function forceToUseParser() {
+		$this->enabledToUseContentHandler = false;
 	}
 
 	/**
@@ -108,7 +122,7 @@ class ContentParser {
 			return $this->parseText( $text );
 		}
 
-		if ( $this->hasContentHandler() ) {
+		if ( $this->hasContentHandler() && $this->enabledToUseContentHandler ) {
 			return $this->fetchFromContent();
 		}
 

--- a/includes/src/MediaWiki/Jobs/UpdateJob.php
+++ b/includes/src/MediaWiki/Jobs/UpdateJob.php
@@ -103,6 +103,7 @@ class UpdateJob extends JobBase {
 			'Title' => $this->getTitle()
 		) );
 
+		$contentParser->forceToUseParser();
 		$contentParser->parse();
 
 		if ( !( $contentParser->getOutput() instanceof ParserOutput ) ) {

--- a/tests/phpunit/Util/PageRefresher.php
+++ b/tests/phpunit/Util/PageRefresher.php
@@ -55,6 +55,7 @@ class PageRefresher {
 		}
 
 		$contentParser = new ContentParser( $title );
+		$contentParser->forceToUseParser();
 
 		$parserData = Application::getInstance()->newParserData(
 			$title,


### PR DESCRIPTION
MW-core has yet to provide a working solution (which it hasn't)  but to avoid further delay (due the ContentHandler on redirects #212 ) and to fix the problem `forceToUseParser` is added to avoid the `ContentHandler` usage during the Update.

SimplePageRedirectRegressionTest is running again on MW 1.24+
