### PR TITLE
SemanticMediaWiki.hooks clean-up

### DIFF
--- a/SemanticMediaWiki.hooks.php
+++ b/SemanticMediaWiki.hooks.php
@@ -216,51 +216,6 @@ final class SMWHooks {
 	}
 
 	/**
-	 * Register tables to be added to temporary tables for parser tests.
-	 *
-	 * @since 1.7.1
-	 *
-	 * @param array $tables
-	 *
-	 * @return boolean
-	 */
-	public static function onParserTestTables( array &$tables ) {
-		// @codeCoverageIgnoreStart
-		$tables = array_merge(
-			$tables,
-			\SMW\StoreFactory::getStore()->getParserTestTables()
-		);
-
-		return true;
-		// @codeCoverageIgnoreEnd
-	}
-
-	/**
-	 * Alter the structured navigation links in SkinTemplates.
-	 * @see https://www.mediawiki.org/wiki/Manual:Hooks/SkinTemplateNavigation
-	 *
-	 * @since 1.8
-	 *
-	 * @param SkinTemplate $skinTemplate
-	 * @param array $links
-	 *
-	 * @return boolean
-	 */
-	public static function onSkinTemplateNavigation( SkinTemplate &$skinTemplate, array &$links ) {
-		// @codeCoverageIgnoreStart
-		if ( $skinTemplate->getUser()->isAllowed( 'purge' ) ) {
-			$links['actions']['purge'] = array(
-				'class' => false,
-				'text' => $skinTemplate->msg( 'smw_purge' )->text(),
-				'href' => $skinTemplate->getTitle()->getLocalUrl( array( 'action' => 'purge' ) )
-			);
-		}
-
-		return true;
-		// @codeCoverageIgnoreEnd
-	}
-
-	/**
 	 * Add new JavaScript/QUnit testing modules
 	 * @see https://www.mediawiki.org/wiki/Manual:Hooks/ResourceLoaderTestModules
 	 *
@@ -305,87 +260,6 @@ final class SMWHooks {
 			'localBasePath' => __DIR__,
 			'remoteExtPath' => '..' . substr( __DIR__, strlen( $GLOBALS['IP'] ) ),
 		);
-
-		return true;
-	}
-
-	/**
-	 * Hook: GetPreferences adds user preference
-	 * @see https://www.mediawiki.org/wiki/Manual:Hooks/GetPreferences
-	 *
-	 * @param User $user
-	 * @param array $preferences
-	 *
-	 * @return true
-	 */
-	public static function onGetPreferences( $user, &$preferences ) {
-
-		// Intro text
-		$preferences['smw-prefs-intro'] =
-			array(
-				'type' => 'info',
-				'label' => '&#160;',
-				'default' => Xml::tags( 'tr', array(),
-					Xml::tags( 'td', array( 'colspan' => 2 ),
-						wfMessage(  'smw-prefs-intro-text' )->parseAsBlock() ) ),
-				'section' => 'smw',
-				'raw' => 1,
-				'rawrow' => 1,
-			);
-
-		// Option to enable tooltip info
-		$preferences['smw-prefs-ask-options-tooltip-display'] = array(
-			'type' => 'toggle',
-			'label-message' => 'smw-prefs-ask-options-tooltip-display',
-			'section' => 'smw/ask-options',
-		);
-
-		// Preference to set option box be collapsed by default
-		$preferences['smw-prefs-ask-options-collapsed-default'] = array(
-			'type' => 'toggle',
-			'label-message' => 'smw-prefs-ask-options-collapsed-default',
-			'section' => 'smw/ask-options',
-		);
-
-		return true;
-	}
-
-	/**
-	 * Hook: ResourceLoaderGetConfigVars called right before
-	 * ResourceLoaderStartUpModule::getConfig and exports static configuration
-	 * variables to JavaScript. Things that depend on the current
-	 * page/request state should use MakeGlobalVariablesScript instead
-	 *
-	 * @see https://www.mediawiki.org/wiki/Manual:Hooks/ResourceLoaderGetConfigVars
-	 *
-	 * @since  1.9
-	 *
-	 * @param &$vars Array of variables to be added into the output of the startup module.
-	 *
-	 * @return true
-	 */
-	public static function onResourceLoaderGetConfigVars( &$vars ) {
-		$vars['smw-config'] = array(
-			'version' => SMW_VERSION,
-			'settings' => array(
-				'smwgQMaxLimit' => $GLOBALS['smwgQMaxLimit'],
-				'smwgQMaxInlineLimit' => $GLOBALS['smwgQMaxInlineLimit'],
-			)
-		);
-
-		// Available semantic namespaces
-		foreach ( array_keys( $GLOBALS['smwgNamespacesWithSemanticLinks'] ) as $ns ) {
-			$name = MWNamespace::getCanonicalName( $ns );
-			$vars['smw-config']['settings']['namespace'][$name] = $ns;
-		}
-
-		foreach ( array_keys( $GLOBALS['smwgResultFormats'] ) as $format ) {
-			// Special formats "count" and "debug" currently not supported.
-			if ( $format != 'broadtable' && $format != 'count' && $format != 'debug' ) {
-				$printer = SMWQueryProcessor::getResultPrinter( $format, SMWQueryProcessor::SPECIAL_PAGE );
-				$vars['smw-config']['formats'][$format] = $printer->getName();
-			}
-		}
 
 		return true;
 	}

--- a/includes/Setup.php
+++ b/includes/Setup.php
@@ -15,6 +15,9 @@ use SMW\MediaWiki\Hooks\BeforePageDisplay;
 use SMW\MediaWiki\Hooks\FileUpload;
 use SMW\MediaWiki\Hooks\NewRevisionFromEditComplete;
 use SMW\MediaWiki\Hooks\ParserAfterTidy;
+use SMW\MediaWiki\Hooks\ResourceLoaderGetConfigVars;
+use SMW\MediaWiki\Hooks\GetPreferences;
+use SMW\MediaWiki\Hooks\SkinTemplateNavigation;
 
 /**
  * Extension setup and registration
@@ -478,6 +481,21 @@ final class Setup implements ContextAware {
 			return $fileUpload->process();
 		};
 
+		$this->globals['wgHooks']['ResourceLoaderGetConfigVars'][] = function ( &$vars ) {
+			$resourceLoaderGetConfigVars = new ResourceLoaderGetConfigVars( $vars );
+			return $resourceLoaderGetConfigVars->process();
+		};
+
+		$this->globals['wgHooks']['GetPreferences'][] = function ( $user, &$preferences ) {
+			$getPreferences = new GetPreferences( $user, $preferences );
+			return $getPreferences->process();
+		};
+
+		$this->globals['wgHooks']['SkinTemplateNavigation'][] = function ( &$skinTemplate, &$links ) {
+			$skinTemplateNavigation = new SkinTemplateNavigation( $skinTemplate, $links );
+			return $skinTemplateNavigation->process();
+		};
+
 		// Old-style registration
 
 		$this->globals['wgHooks']['LoadExtensionSchemaUpdates'][] = 'SMWHooks::onSchemaUpdate';
@@ -485,12 +503,9 @@ final class Setup implements ContextAware {
 		$this->globals['wgHooks']['AdminLinks'][]          = 'SMWHooks::addToAdminLinks';
 		$this->globals['wgHooks']['PageSchemasRegisterHandlers'][] = 'SMWHooks::onPageSchemasRegistration';
 		$this->globals['wgHooks']['ArticleFromTitle'][] = 'SMWHooks::onArticleFromTitle';
-		$this->globals['wgHooks']['SkinTemplateNavigation'][] = 'SMWHooks::onSkinTemplateNavigation';
 		$this->globals['wgHooks']['ResourceLoaderTestModules'][] = 'SMWHooks::registerQUnitTests';
-		$this->globals['wgHooks']['GetPreferences'][] = 'SMWHooks::onGetPreferences';
 		$this->globals['wgHooks']['TitleIsAlwaysKnown'][] = 'SMWHooks::onTitleIsAlwaysKnown';
 		$this->globals['wgHooks']['BeforeDisplayNoArticleText'][] = 'SMWHooks::onBeforeDisplayNoArticleText';
-		$this->globals['wgHooks']['ResourceLoaderGetConfigVars'][] = 'SMWHooks::onResourceLoaderGetConfigVars';
 		$this->globals['wgHooks']['ExtensionTypes'][] = 'SMWHooks::addSemanticExtensionType';
 
 	}

--- a/includes/src/MediaWiki/Hooks/GetPreferences.php
+++ b/includes/src/MediaWiki/Hooks/GetPreferences.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace SMW\MediaWiki\Hooks;
+
+use User;
+use Xml;
+
+/**
+ * Hook: GetPreferences adds user preference
+ *
+ * @see https://www.mediawiki.org/wiki/Manual:Hooks/GetPreferences
+ *
+ * @license GNU GPL v2+
+ * @since 2.0
+ *
+ * @author mwjames
+ */
+class GetPreferences {
+
+	/**
+	 * @var User
+	 */
+	private $user = null;
+
+	/**
+	 * @var array
+	 */
+	private $preferences;
+
+	/**
+	 * @since  2.0
+	 *
+	 * @param User $user
+	 * @param array $preferences
+	 */
+	public function __construct( User $user, &$preferences ) {
+		$this->user = $user;
+		$this->preferences =& $preferences;
+	}
+
+	/**
+	 * @since 2.0
+	 *
+	 * @return true
+	 */
+	public function process() {
+
+		// Intro text
+		$this->preferences['smw-prefs-intro'] =
+			array(
+				'type' => 'info',
+				'label' => '&#160;',
+				'default' => Xml::tags( 'tr', array(),
+					Xml::tags( 'td', array( 'colspan' => 2 ),
+						wfMessage(  'smw-prefs-intro-text' )->parseAsBlock() ) ),
+				'section' => 'smw',
+				'raw' => 1,
+				'rawrow' => 1,
+			);
+
+		// Option to enable tooltip info
+		$this->preferences['smw-prefs-ask-options-tooltip-display'] = array(
+			'type' => 'toggle',
+			'label-message' => 'smw-prefs-ask-options-tooltip-display',
+			'section' => 'smw/ask-options',
+		);
+
+		// Preference to set option box be collapsed by default
+		$this->preferences['smw-prefs-ask-options-collapsed-default'] = array(
+			'type' => 'toggle',
+			'label-message' => 'smw-prefs-ask-options-collapsed-default',
+			'section' => 'smw/ask-options',
+		);
+
+		return true;
+	}
+
+}

--- a/includes/src/MediaWiki/Hooks/README.md
+++ b/includes/src/MediaWiki/Hooks/README.md
@@ -30,4 +30,10 @@ Rendering the Factbox and updating the FactboxCache.
 #### TitleMoveComplete
 Update the Store after an article has been deleted.
 
+#### ResourceLoaderGetConfigVars
+
+#### GetPreferences
+
+#### SkinTemplateNavigation
+
 [hooks]: https://www.mediawiki.org/wiki/Hooks "Manual:Hooks"

--- a/includes/src/MediaWiki/Hooks/ResourceLoaderGetConfigVars.php
+++ b/includes/src/MediaWiki/Hooks/ResourceLoaderGetConfigVars.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace SMW\MediaWiki\Hooks;
+
+use SMWQueryProcessor;
+use MWNamespace;
+
+/**
+ * Hook: ResourceLoaderGetConfigVars called right before
+ * ResourceLoaderStartUpModule::getConfig and exports static configuration
+ * variables to JavaScript. Things that depend on the current
+ * page/request state should use MakeGlobalVariablesScript instead
+ *
+ * @see https://www.mediawiki.org/wiki/Manual:Hooks/ResourceLoaderGetConfigVars
+ *
+ * @license GNU GPL v2+
+ * @since 2.0
+ *
+ * @author mwjames
+ */
+class ResourceLoaderGetConfigVars {
+
+	/**
+	 * @var array
+	 */
+	protected $vars;
+
+	/**
+	 * @since  2.0
+	 *
+	 * @param array $vars
+	 */
+	public function __construct( array &$vars ) {
+		$this->vars =& $vars;
+	}
+
+	/**
+	 * @since 1.9
+	 *
+	 * @return boolean
+	 */
+	public function process() {
+
+		$this->vars['smw-config'] = array(
+			'version' => SMW_VERSION,
+			'settings' => array(
+				'smwgQMaxLimit' => $GLOBALS['smwgQMaxLimit'],
+				'smwgQMaxInlineLimit' => $GLOBALS['smwgQMaxInlineLimit'],
+			)
+		);
+
+		// Available semantic namespaces
+		foreach ( array_keys( $GLOBALS['smwgNamespacesWithSemanticLinks'] ) as $ns ) {
+			$name = MWNamespace::getCanonicalName( $ns );
+			$this->vars['smw-config']['settings']['namespace'][$name] = $ns;
+		}
+
+		foreach ( array_keys( $GLOBALS['smwgResultFormats'] ) as $format ) {
+			// Special formats "count" and "debug" currently not supported.
+			if ( $format != 'broadtable' && $format != 'count' && $format != 'debug' ) {
+				$printer = SMWQueryProcessor::getResultPrinter( $format, SMWQueryProcessor::SPECIAL_PAGE );
+				$this->vars['smw-config']['formats'][$format] = $printer->getName();
+			}
+		}
+
+		return true;
+	}
+
+}

--- a/includes/src/MediaWiki/Hooks/SkinTemplateNavigation.php
+++ b/includes/src/MediaWiki/Hooks/SkinTemplateNavigation.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace SMW\MediaWiki\Hooks;
+
+use SkinTemplate;
+
+/**
+ * Alter the structured navigation links in SkinTemplates.
+ *
+ * @see https://www.mediawiki.org/wiki/Manual:Hooks/SkinTemplateNavigation
+ *
+ * @license GNU GPL v2+
+ * @since 2.0
+ *
+ * @author mwjames
+ */
+class SkinTemplateNavigation {
+
+	/**
+	 * @var SkinTemplate
+	 */
+	private $skinTemplate = null;
+
+	/**
+	 * @var array
+	 */
+	private $links;
+
+	/**
+	 * @since  2.0
+	 *
+	 * @param SkinTemplate $skinTemplate
+	 * @param array $links
+	 */
+	public function __construct( SkinTemplate &$skinTemplate, array &$links ) {
+		$this->skinTemplate = $skinTemplate;
+		$this->links =& $links;
+	}
+
+	/**
+	 * @since 2.0
+	 *
+	 * @return true
+	 */
+	public function process() {
+
+		if ( $this->skinTemplate->getUser()->isAllowed( 'purge' ) ) {
+			$this->links['actions']['purge'] = array(
+				'class' => false,
+				'text' => $this->skinTemplate->msg( 'smw_purge' )->text(),
+				'href' => $this->skinTemplate->getTitle()->getLocalUrl( array( 'action' => 'purge' ) )
+			);
+		}
+
+		return true;
+	}
+
+}

--- a/tests/phpunit/includes/HooksTest.php
+++ b/tests/phpunit/includes/HooksTest.php
@@ -35,17 +35,6 @@ use LinksUpdate;
 class HooksTest extends MwDBaseUnitTestCase {
 
 	/**
-	 * Helper method that returns a normalized path
-	 *
-	 * @since 1.9
-	 *
-	 * @return string
-	 */
-	private function normalizePath( $path ) {
-		return str_replace( array( '/', '\\' ), DIRECTORY_SEPARATOR, $path );
-	}
-
-	/**
 	 * Helper method that returns a random string
 	 *
 	 * @since 1.9
@@ -243,74 +232,6 @@ class HooksTest extends MwDBaseUnitTestCase {
 			$this->getArticleMock( $this->getTitle( 'Modification date', SMW_NS_PROPERTY ) )
 		), 'Failed asserting "false" for a predefined property' );
 
-	}
-
-	/*
-	 * @test SMWHooks::onArticleDelete
-	 *
-	 * @since 1.9
-	 *
-	public function testOnArticleDelete() {
-		if ( method_exists( 'WikiPage', 'doEditContent' ) ) {
-
-			$wikiPage = $this->newPage();
-			$user = $this->getUser();
-			$revision = $wikiPage->getRevision();
-			$reason = '';
-			$error = '';
-
-			$result = SMWHooks::onArticleDelete(
-				$wikiPage,
-				$user,
-				$reason,
-				$error
-			);
-
-			$this->assertTrue( $result );
-		} else {
-			$this->markTestSkipped(
-				'Skipped test due to missing method (probably MW 1.19 or lower).'
-			);
-		}
-	}*/
-
-	/**
-	 * @test SMWHooks::onSkinTemplateNavigation
-	 *
-	 * @since 1.9
-	 */
-	public function testOnSkinTemplateNavigation() {
-		$skinTemplate = new \SkinTemplate();
-		$skinTemplate->getContext()->setLanguage( \Language::factory( 'en' ) );
-		$links = array();
-
-		$result = SMWHooks::onSkinTemplateNavigation( $skinTemplate, $links );
-		$this->assertTrue( $result );
-	}
-
-
-	/**
-	 * @test SMWHooks::onResourceLoaderGetConfigVars
-	 *
-	 * @since 1.9
-	 */
-	public function testOnResourceLoaderGetConfigVars() {
-		$vars = array();
-
-		$result = SMWHooks::onResourceLoaderGetConfigVars( $vars );
-		$this->assertTrue( $result );
-	}
-
-	/**
-	 * @test SMWHooks::onGetPreferences
-	 *
-	 * @since 1.9
-	 */
-	public function testOnGetPreferences() {
-		$preferences = array();
-
-		$result = SMWHooks::onGetPreferences( $this->getUser(), $preferences );
-		$this->assertTrue( $result );
 	}
 
 }

--- a/tests/phpunit/includes/MediaWiki/Hooks/GetPreferencesTest.php
+++ b/tests/phpunit/includes/MediaWiki/Hooks/GetPreferencesTest.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace SMW\Tests\MediaWiki\Hooks;
+
+use SMW\MediaWiki\Hooks\GetPreferences;
+
+/**
+ * @covers \SMW\MediaWiki\Hooks\GetPreferences
+ *
+ * @ingroup Test
+ *
+ * @group SMW
+ * @group SMWExtension
+ *
+ * @license GNU GPL v2+
+ * @since 2.0
+ *
+ * @author mwjames
+ */
+class GetPreferencesTest extends \PHPUnit_Framework_TestCase {
+
+	public function testCanConstruct() {
+
+		$user = $this->getMockBuilder( '\User' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$preferences = array();
+
+		$this->assertInstanceOf(
+			'\SMW\MediaWiki\Hooks\GetPreferences',
+			new GetPreferences( $user, $preferences )
+		);
+	}
+
+	public function testProcess() {
+
+		$user = $this->getMockBuilder( '\User' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$preferences = array();
+
+		$instance = new GetPreferences( $user, $preferences );
+		$instance->process();
+
+		$this->assertArrayHasKey( 'smw-prefs-intro', $preferences );
+		$this->assertArrayHasKey( 'smw-prefs-ask-options-tooltip-display', $preferences );
+		$this->assertArrayHasKey( 'smw-prefs-ask-options-collapsed-default', $preferences );
+	}
+
+}

--- a/tests/phpunit/includes/MediaWiki/Hooks/ResourceLoaderGetConfigVarsTest.php
+++ b/tests/phpunit/includes/MediaWiki/Hooks/ResourceLoaderGetConfigVarsTest.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace SMW\Tests\MediaWiki\Hooks;
+
+use SMW\MediaWiki\Hooks\ResourceLoaderGetConfigVars;
+
+/**
+ * @covers \SMW\MediaWiki\Hooks\ResourceLoaderGetConfigVars
+ *
+ * @ingroup Test
+ *
+ * @group SMW
+ * @group SMWExtension
+ *
+ * @license GNU GPL v2+
+ * @since 2.0
+ *
+ * @author mwjames
+ */
+class ResourceLoaderGetConfigVarsTest extends \PHPUnit_Framework_TestCase {
+
+	public function testCanConstruct() {
+
+		$vars = array();
+
+		$this->assertInstanceOf(
+			'\SMW\MediaWiki\Hooks\ResourceLoaderGetConfigVars',
+			new ResourceLoaderGetConfigVars( $vars )
+		);
+	}
+
+	public function testProcess() {
+
+		$vars = array();
+
+		$instance = new ResourceLoaderGetConfigVars( $vars );
+		$instance->process();
+
+		$this->assertArrayHasKey( 'smw-config', $vars );
+	}
+
+}

--- a/tests/phpunit/includes/MediaWiki/Hooks/SkinTemplateNavigationTest.php
+++ b/tests/phpunit/includes/MediaWiki/Hooks/SkinTemplateNavigationTest.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace SMW\Tests\MediaWiki\Hooks;
+
+use SMW\MediaWiki\Hooks\SkinTemplateNavigation;
+
+/**
+ * @covers \SMW\MediaWiki\Hooks\SkinTemplateNavigation
+ *
+ * @ingroup Test
+ *
+ * @group SMW
+ * @group SMWExtension
+ *
+ * @license GNU GPL v2+
+ * @since 2.0
+ *
+ * @author mwjames
+ */
+class SkinTemplateNavigationTest extends \PHPUnit_Framework_TestCase {
+
+	public function testCanConstruct() {
+
+		$skinTemplate = $this->getMockBuilder( '\SkinTemplate' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$links = array();
+
+		$this->assertInstanceOf(
+			'\SMW\MediaWiki\Hooks\SkinTemplateNavigation',
+			new SkinTemplateNavigation( $skinTemplate, $links )
+		);
+	}
+
+	public function testProcess() {
+
+		$title = $this->getMockBuilder( '\Title' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$message = $this->getMockBuilder( '\Message' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$user = $this->getMockBuilder( '\User' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$user->expects( $this->atLeastOnce() )
+			->method( 'isAllowed' )
+			->will( $this->returnValue( true ) );
+
+		$skinTemplate = $this->getMockBuilder( '\SkinTemplate' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$skinTemplate->expects( $this->atLeastOnce() )
+			->method( 'getUser' )
+			->will( $this->returnValue( $user ) );
+
+		$skinTemplate->expects( $this->atLeastOnce() )
+			->method( 'msg' )
+			->will( $this->returnValue( $message ) );
+
+		$skinTemplate->expects( $this->atLeastOnce() )
+			->method( 'getTitle' )
+			->will( $this->returnValue( $title ) );
+
+		$links = array();
+
+		$instance = new SkinTemplateNavigation( $skinTemplate, $links );
+		$instance->process();
+
+		$this->assertArrayHasKey( 'purge', $links['actions'] );
+	}
+
+}

--- a/tests/phpunit/includes/SetupTest.php
+++ b/tests/phpunit/includes/SetupTest.php
@@ -167,6 +167,14 @@ class SetupTest extends SemanticMediaWikiTestCase {
 			'isSpecialPage' => true
 		) );
 
+		$user = $this->getMockBuilder( '\User' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$user->expects( $this->any() )
+			->method( 'isAllowed' )
+			->will( $this->returnValue( false ) );
+
 		$parserOutput = $this->newMockBuilder()->newObject( 'ParserOutput' );
 
 		$outputPage = $this->newMockBuilder()->newObject( 'OutputPage', array(
@@ -187,9 +195,17 @@ class SetupTest extends SemanticMediaWikiTestCase {
 			'getOutput' => $outputPage
 		) );
 
-		$skinTemplate = $this->newMockBuilder()->newObject( 'SkinTemplate', array(
-			'getSkin' => $skin
-		) );
+		$skinTemplate = $this->getMockBuilder( '\SkinTemplate' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$skinTemplate->expects( $this->any() )
+			->method( 'getSkin' )
+			->will( $this->returnValue( $skin ) );
+
+		$skinTemplate->expects( $this->any() )
+			->method( 'getUser' )
+			->will( $this->returnValue( $user ) );
 
 		$parserOptions = $this->newMockBuilder()->newObject( 'ParserOptions' );
 
@@ -208,8 +224,6 @@ class SetupTest extends SemanticMediaWikiTestCase {
 			'getRawText' => 'Foo',
 			'getContent' => $this->newMockContent()
 		) );
-
-		$user = $this->newMockBuilder()->newObject( 'User' );
 
 		switch ( $hook ) {
 			case 'SkinAfterContent':
@@ -253,6 +267,15 @@ class SetupTest extends SemanticMediaWikiTestCase {
 				break;
 			case 'FileUpload':
 				$result = $this->callObject( $object, array( $file, $empty ) );
+				break;
+			case 'ResourceLoaderGetConfigVars':
+				$result = $this->callObject( $object, array( &$emptyArray ) );
+				break;
+			case 'GetPreferences':
+				$result = $this->callObject( $object, array( $user, &$emptyArray ) );
+				break;
+			case 'SkinTemplateNavigation':
+				$result = $this->callObject( $object, array( &$skinTemplate, &$emptyArray ) );
 				break;
 			case 'ParserFirstCallInit':
 
@@ -450,10 +473,7 @@ class SetupTest extends SemanticMediaWikiTestCase {
 			'AdminLinks',
 			'PageSchemasRegisterHandlers',
 			'ArticleFromTitle',
-			'SkinTemplateNavigation',
 			'ResourceLoaderTestModules',
-			'ResourceLoaderGetConfigVars',
-			'GetPreferences',
 			'TitleIsAlwaysKnown',
 			'BeforeDisplayNoArticleText',
 			'ExtensionTypes',
@@ -481,7 +501,10 @@ class SetupTest extends SemanticMediaWikiTestCase {
 			'SpecialStatsAddExtra',
 			'BaseTemplateToolbox',
 			'CanonicalNamespaces',
-			'FileUpload'
+			'FileUpload',
+			'ResourceLoaderGetConfigVars',
+			'GetPreferences',
+			'SkinTemplateNavigation',
 		);
 
 		return $this->buildDataProvider( 'wgHooks', $hooks, array() );


### PR DESCRIPTION
Added:
- SMW\MediaWiki\Hooks\ResourceLoaderGetConfigVars;
- SMW\MediaWiki\Hooks\GetPreferences;
- SMW\MediaWiki\Hooks\SkinTemplateNavigation;

Removed:
- `onParserTestTables` which was never used
