### PR TITLE
MW 1.24 / Mysqli / Error while sending QUERY packet / SqlBagOStuff [DNM]

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: php
 
 env:
   - THENEEDFORTHIS=FAIL
-
+ 
 matrix:
   fast_finish: true
   include:


### PR DESCRIPTION
Just checking under which condition does the following error occur.

```
SMW\Tests\Regression\PageWithTemplateInclusionRegressionTest::testDataImport
RuntimeException: Import failed with 
Error while sending QUERY packet. PID=2394##0 [internal function]: PHPUnit_Util_ErrorHandler::handleError(2, 'Error while sen...', '/home/travis/bu...', 38, Array)
#1 /home/travis/build/SemanticMediaWiki/mw/includes/db/DatabaseMysqli.php(38): mysqli->query('SELECT /* SqlBa...')
#2 /home/travis/build/SemanticMediaWiki/mw/includes/db/Database.php(1120): DatabaseMysqli->doQuery('SELECT /* SqlBa...')
#3 /home/travis/build/SemanticMediaWiki/mw/includes/db/Database.php(1623): DatabaseBase->query('SELECT  keyname...', 'SqlBagOStuff::g...')
#4 /home/travis/build/SemanticMediaWiki/mw/includes/objectcache/SqlBagOStuff.php(246): DatabaseBase->select('objectcache', Array, Array, 'SqlBagOStuff::g...', Array)
```
