### PR TITLE
Fix Master/Slave for DB->query()

### DIFF
--- a/includes/src/MediaWiki/Database.php
+++ b/includes/src/MediaWiki/Database.php
@@ -205,7 +205,7 @@ class Database {
 		}
 
 		try {
-			$results = $this->acquireReadConnection()->query(
+			$results = $this->acquireWriteConnection()->query(
 				$sql,
 				$fname,
 				$ignoreException

--- a/tests/phpunit/includes/MediaWiki/DatabaseTest.php
+++ b/tests/phpunit/includes/MediaWiki/DatabaseTest.php
@@ -131,21 +131,27 @@ class DatabaseTest extends \PHPUnit_Framework_TestCase {
 			->disableOriginalConstructor()
 			->getMock();
 
-		$connectionProvider = new MockDBConnectionProvider();
-		$database = $connectionProvider->getMockDatabase();
+		$readConnection = new MockDBConnectionProvider();
+		$read = $readConnection->getMockDatabase();
 
-		$database->expects( $this->any() )
+		$read->expects( $this->any() )
 			->method( 'getType' )
 			->will( $this->returnValue( 'sqlite' ) );
 
-		$database->expects( $this->once() )
+		$writeConnection = new MockDBConnectionProvider();
+		$write = $writeConnection->getMockDatabase();
+
+		$write->expects( $this->once() )
 			->method( 'query' )
 			->with( $this->equalTo( 'TEMP' ) )
 			->will( $this->returnValue( $resultWrapper ) );
 
-		$instance = new Database( $connectionProvider );
-		$this->assertInstanceOf( 'ResultWrapper', $instance->query( 'TEMPORARY' ) );
+		$instance = new Database( $readConnection, $writeConnection );
 
+		$this->assertInstanceOf(
+			'ResultWrapper',
+			$instance->query( 'TEMPORARY' )
+		);
 	}
 
 	public function testSelectThrowsException() {


### PR DESCRIPTION
Use a write/master connection for query() to avoid potential problems [0] in a master-slave [1]
environment where the SQLStore excutes $db->query(  'INSERT ' ... );

[0] http://wikimedia.7.x6.nabble.com/RuntimeException-due-to-read-only-when-upgrading-SMW-tp5032521.html
[1] https://www.mediawiki.org/wiki/Manual:$wgDBservers
