### PR TITLE
Adds a search engine to allow semantic queries directly from MW's standard search

### DIFF
--- a/SemanticMediaWiki.php
+++ b/SemanticMediaWiki.php
@@ -98,6 +98,7 @@ class_alias( 'SMW\Query\Language\ValueDescription', 'SMWValueDescription' );
 class_alias( 'SMW\Query\Language\Conjunction', 'SMWConjunction' );
 class_alias( 'SMW\Query\Language\Disjunction', 'SMWDisjunction' );
 class_alias( 'SMW\Query\Language\SomeProperty', 'SMWSomeProperty' );
+class_alias( 'SMW\MediaWiki\Search\Search', 'SMWSearch' );
 
 // A flag used to indicate SMW defines a semantic extension type for extension credits.
 // @deprecated, removal in SMW 1.11

--- a/SemanticMediaWiki.settings.php
+++ b/SemanticMediaWiki.settings.php
@@ -748,3 +748,16 @@ $GLOBALS['smwgOnDeleteAction'] = array(
 	'smwgDeleteSubjectWithAssociatesRefresh' => false
 );
 ##
+
+###
+# Search engine to fall back to in case SMWSearch is used as custom search
+# engine but is unable to interpret the search term as an SMW query
+#
+# Leave as null to select the default search engine for the selected database
+# type (e.g. SearchMySQL, SearchPostgres or SearchOracle), or set to a class
+# name to override to a custom search engine.
+#
+# @since 2.1
+##
+$GLOBALS['smwgFallbackSearchType'] = null;
+##

--- a/docs/RELEASE-NOTES.md
+++ b/docs/RELEASE-NOTES.md
@@ -2,7 +2,8 @@
 
 This is not a release yet.
 
-## Internal changes 
+## Internal changes
 
 * #350 Passes all unit tests on `HHVM` 3.3+
 * #486 Added support for `Jena Fuseki` 1.1.0
+* #450 Adds a search engine to allow semantic queries directly from MW's standard search

--- a/includes/Settings.php
+++ b/includes/Settings.php
@@ -126,7 +126,8 @@ class Settings extends SimpleDictionary {
 			'smwgFactboxCacheRefreshOnPurge' => $GLOBALS['smwgFactboxCacheRefreshOnPurge'],
 			'smwgQueryProfiler' => $GLOBALS['smwgQueryProfiler'],
 			'smwgEnabledSpecialPage' => $GLOBALS['smwgEnabledSpecialPage'],
-			'smwgOnDeleteAction' => $GLOBALS['smwgOnDeleteAction']
+			'smwgOnDeleteAction' => $GLOBALS['smwgOnDeleteAction'],
+			'smwgFallbackSearchType' => $GLOBALS['smwgFallbackSearchType'],
 		);
 
 		$settings = $settings + array(

--- a/includes/src/MediaWiki/Search/Search.php
+++ b/includes/src/MediaWiki/Search/Search.php
@@ -1,0 +1,346 @@
+<?php
+
+namespace SMW\MediaWiki\Search;
+
+use Content;
+use DatabaseBase;
+use SMW\Application;
+use SMW\Settings;
+use SMWQuery;
+use Title;
+
+/**
+ * Search engine that will try to find wiki pages by interpreting the search term as an SMW query.
+ *
+ * If successful, the pages according to the query will be returned.
+ * If not it falls back to the default search engine.
+ *
+ * @ingroup SMW
+ *
+ * @licence GNU GPL v2+
+ * @since   2.1
+ *
+ * @author  Stephan Gambke
+ */
+class Search extends \SearchEngine {
+
+	private $fallbackSearch = null;
+
+	private $database = null;
+	private $settings = null;
+
+	private $queryCache = array();
+
+	/**
+	 * @param null|\SearchEngine $fallbackSearch
+	 */
+	public function setFallbackSearchEngine( \SearchEngine $fallbackSearch = null ) {
+		$this->fallbackSearch = $fallbackSearch;
+	}
+
+	/**
+	 * @return \SearchEngine
+	 */
+	public function getFallbackSearchEngine() {
+
+		if ( $this->fallbackSearch === null ) {
+
+			$class = $this->getSettings()->get( 'smwgFallbackSearchType' );
+
+			$dbr = $this->getDB();
+
+			if ( $class === null ) {
+
+				$class = $dbr->getSearchEngine();
+
+			}
+
+			$this->fallbackSearch = new $class( $dbr );
+		}
+
+		return $this->fallbackSearch;
+	}
+
+	/**
+	 * @param DatabaseBase $connection
+	 */
+	public function setDB( DatabaseBase $connection ) {
+		$this->database = $connection;
+		$this->fallbackSearch = null;
+	}
+
+	/**
+	 * @return DatabaseBase
+	 */
+	public function getDB() {
+
+		if ( $this->database === null ) {
+			$this->database = wfGetDB( DB_SLAVE );
+		}
+
+		return $this->database;
+	}
+
+	/**
+	 * @param \SMW\Settings $settings
+	 */
+	public function setSettings( Settings $settings ) {
+		$this->settings = $settings;
+	}
+
+	/**
+	 * @return Settings
+	 */
+	public function getSettings() {
+
+		if ( $this->settings === null ) {
+			$this->settings = Application::getInstance()->getSettings();
+		}
+
+		return $this->settings;
+	}
+
+	/**
+	 * @param String $term
+	 *
+	 * @return SMWQuery | null
+	 */
+	private function getSearchQuery( $term ) {
+
+		if ( ! is_string( $term ) || trim( $term ) === '' ) {
+			return null;
+		}
+
+		if ( !array_key_exists( $term, $this->queryCache ) ) {
+
+			$params = \SMWQueryProcessor::getProcessedParams( array() );
+			$query = \SMWQueryProcessor::createQuery( $term, $params );
+
+			$description = $query->getDescription();
+
+			if ( $description === null || is_a( $description, 'SMWThingDescription' ) ) {
+				$query = null;
+			}
+
+			$this->queryCache[ $term ] = $query;
+		}
+
+		return $this->queryCache[ $term ];
+	}
+
+	private function searchFallbackSearchEngine( $term, $fulltext ) {
+
+		$f = $this->getFallbackSearchEngine();
+		$f->prefix = $this->prefix;
+		$f->namespaces = $this->namespaces;
+
+		$term = $f->transformSearchTerm( $term );
+		$term = $f->replacePrefixes( $term );
+
+		return $fulltext ? $f->searchText( $term ) : $f->searchTitle( $term );
+
+	}
+
+	/**
+	 * Perform a title-only search query and return a result set.
+	 *
+	 * This method will try to find wiki pages by interpreting the search term as an SMW query.
+	 *
+	 * If successful, the pages according to the query will be returned.
+	 * If not, it falls back to the default search engine.
+	 *
+	 * @param string $term Raw search term
+	 *
+	 * @return SearchResultSet|null
+	 */
+	public function searchTitle( $term ) {
+
+		$query = $this->getSearchQuery( $term );
+
+		if ( $query !== null ) {
+
+			$namespacesDisjunction = new \SMWDisjunction(
+				array_map( function ( $ns ) {
+					return new \SMWNamespaceDescription( $ns );
+				}, $this->namespaces )
+			);
+
+			$description = new \SMWConjunction( array( $query->getDescription(), $namespacesDisjunction ) );
+
+			$query->setDescription( $description );
+			$query->setOffset( $this->offset );
+			$query->setLimit( $this->limit, false );
+
+			$store = Application::getInstance()->getStore();
+
+			$result = $store->getQueryResult( $query );
+
+			$query->querymode = SMWQuery::MODE_COUNT;
+			$query->setOffset( 0 );
+
+			$count = $store->getQueryResult( $query );
+
+			return new SearchResultSet( $result, $count );
+
+		} else {
+
+			return $this->searchFallbackSearchEngine( $term, false );
+		}
+
+	}
+
+	/**
+	 * Perform a full text search query and return a result set.
+	 * If title searches are not supported or disabled, return null.
+	 *
+	 * @param string $term Raw search term
+	 *
+	 * @return SearchResultSet|\Status|null
+	 */
+	public function searchText( $term ) {
+
+		if ( $this->getSearchQuery( $term ) !== null ) {
+			// No fulltext search for semantic queries
+			return null;
+		} else {
+			return $this->searchFallbackSearchEngine( $term, true );
+		}
+	}
+
+	/**
+	 * @param string $feature
+	 *
+	 * @return bool
+	 */
+	public function supports( $feature ) {
+		return $this->getFallbackSearchEngine()->supports( $feature );
+	}
+
+	/**
+	 * May performs database-specific conversions on text to be used for
+	 * searching or updating search index.
+	 *
+	 * @param string $string String to process
+	 *
+	 * @return string
+	 */
+	public function normalizeText( $string ) {
+		return $this->getFallbackSearchEngine()->normalizeText( $string );
+	}
+
+	public function getTextFromContent( Title $t, Content $c = null ) {
+		return $this->getFallbackSearchEngine()->getTextFromContent( $t, $c );
+	}
+
+	public function textAlreadyUpdatedForIndex() {
+		return $this->getFallbackSearchEngine()->textAlreadyUpdatedForIndex();
+	}
+
+	/**
+	 * Create or update the search index record for the given page.
+	 * Title and text should be pre-processed.
+	 *
+	 * @param int    $id
+	 * @param string $title
+	 * @param string $text
+	 */
+	public function update( $id, $title, $text ) {
+		$this->getFallbackSearchEngine()->update( $id, $title, $text );
+	}
+
+	/**
+	 * Update a search index record's title only.
+	 * Title should be pre-processed.
+	 *
+	 * @param int    $id
+	 * @param string $title
+	 */
+	public function updateTitle( $id, $title ) {
+		$this->getFallbackSearchEngine()->updateTitle( $id, $title );
+	}
+
+	/**
+	 * Delete an indexed page
+	 * Title should be pre-processed.
+	 *
+	 * @param int    $id    Page id that was deleted
+	 * @param string $title Title of page that was deleted
+	 */
+	public function delete( $id, $title ) {
+		$this->getFallbackSearchEngine()->delete( $id, $title );
+	}
+
+	public function setFeatureData( $feature, $data ) {
+		parent::setFeatureData( $feature, $data );
+		$this->getFallbackSearchEngine()->setFeatureData( $feature, $data );
+	}
+
+	/**
+	 * @param String $feature
+	 * @return array
+	 */
+	public function getFeatureData( $feature ) {
+		if ( array_key_exists( $feature, $this->features ) ) {
+			return $this->features[ $feature ];
+		} else {
+			return null;
+		}
+	}
+
+	/**
+	 * SMW queries do not have prefixes. Returns query as is.
+	 *
+	 * @param string $query
+	 *
+	 * @return string
+	 */
+	public function replacePrefixes( $query ) {
+		return $query;
+	}
+
+	/**
+	 * No Transformation needed. Returns term as is.
+	 * @param $term
+	 * @return mixed
+	 */
+	public function transformSearchTerm( $term ) {
+		return $term;
+	}
+
+	/**
+	 * @return int
+	 */
+	public function getLimit() {
+		return $this->limit;
+	}
+
+	/**
+	 * @return int
+	 */
+	public function getOffset() {
+		return $this->offset;
+	}
+
+	/**
+	 * @return boolean
+	 */
+	public function getShowSuggestion() {
+		return $this->showSuggestion;
+	}
+
+
+	public function setLimitOffset( $limit, $offset = 0 ) {
+		parent::setLimitOffset( $limit, $offset );
+		$this->getFallbackSearchEngine()->setLimitOffset( $limit, $offset );
+	}
+
+	public function setNamespaces( $namespaces ) {
+		parent::setNamespaces( $namespaces );
+		$this->getFallbackSearchEngine()->setNamespaces( $namespaces );
+	}
+
+	public function setShowSuggestion( $showSuggestion ) {
+		parent::setShowSuggestion( $showSuggestion );
+		$this->getFallbackSearchEngine()->setShowSuggestion( $showSuggestion );
+	}
+}

--- a/includes/src/MediaWiki/Search/SearchResultSet.php
+++ b/includes/src/MediaWiki/Search/SearchResultSet.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace SMW\MediaWiki\Search;
+
+use SearchResult;
+
+/**
+ * @ingroup SMW
+ *
+ * @licence GNU GPL v2+
+ * @since   2.1
+ *
+ * @author  Stephan Gambke
+ */
+class SearchResultSet extends \SearchResultSet {
+
+	private $pages;
+	private $count = null;
+
+	public function __construct( \SMWQueryResult $result, $count = null ) {
+
+		$this->pages = $result->getResults();
+		$this->count = $count;
+	}
+
+	/**
+	 * Return number of rows included in this result set.
+	 *
+	 * @return int|void
+	 */
+	public function numRows() {
+		return count( $this->pages );
+	}
+
+	/**
+	 * Return true if results are included in this result set.
+	 *
+	 * @return bool
+	 */
+	public function hasResults() {
+		return $this->numRows() > 0;
+	}
+
+	/**
+	 * Fetches next search result, or false.
+	 *
+	 * @return SearchResult
+	 */
+	public function next() {
+		return ( list( , $page ) = each( $this->pages ) ) !== false ? ( SearchResult::newFromTitle( $page->getTitle() ) ) : false;
+	}
+
+	/**
+	 * Returns true, so Special:Search won't offer the user a link to a create
+	 * a page named by the search string because the name would contain the
+	 * search syntax, i.e. the SMW query.
+	 *
+	 * @return bool
+	 */
+	public function searchContainedSyntax() {
+		return true;
+	}
+
+	public function getTotalHits() {
+		return $this->count;
+	}
+
+}

--- a/tests/phpunit/includes/MediaWiki/Search/SearchResultSetTest.php
+++ b/tests/phpunit/includes/MediaWiki/Search/SearchResultSetTest.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace SMW\Tests\MediaWiki\Search;
+
+use SMW\MediaWiki\Search\SearchResultSet;
+
+/**
+ * @covers  \SMW\MediaWiki\Search\SearchResultSet
+ *
+ * @ingroup Test
+ *
+ * @group   SMW
+ * @group   SMWExtension
+ *
+ * @licence GNU GPL v2+
+ * @since   2.1
+ *
+ * @author  Stephan Gambke
+ */
+class SearchResultSetTest extends \PHPUnit_Framework_TestCase {
+
+	/**
+	 * @var SearchResultSet The search result set under test
+	 */
+	protected $resultSet;
+
+	protected function setUp() {
+
+		$queryResultMock = $this->getMockBuilder( 'SMWQueryResult' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$pageMock = $this->getMockBuilder( 'SMW\DIWikiPage' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$pageMock->expects( $this->any() )
+			->method( 'getTitle' )
+			->will( $this->returnValue( null ) );
+
+		$queryResultMock->expects( $this->any() )
+			->method( 'getResults' )
+			->will( $this->returnValue( array( $pageMock, $pageMock, $pageMock ) ) );
+
+		$this->resultSet = new SearchResultSet( $queryResultMock, 42 );
+
+	}
+
+	public function testCanConstruct() {
+		$this->assertInstanceOf( '\SMW\MediaWiki\Search\SearchResultSet', $this->resultSet );
+	}
+
+	public function testNumRows() {
+		$this->assertEquals( 3, $this->resultSet->numRows() );
+	}
+
+	public function testHasResults() {
+		$this->assertGreaterThan( 0, $this->resultSet->hasResults() );
+	}
+
+	public function testNext() {
+		$this->assertInstanceOf( 'SearchResult', $this->resultSet->next() );
+		$this->assertInstanceOf( 'SearchResult', $this->resultSet->next() );
+		$this->assertInstanceOf( 'SearchResult', $this->resultSet->next() );
+		$this->assertFalse( $this->resultSet->next() );
+	}
+
+	public function testSearchContainedSyntax() {
+		$this->assertTrue( $this->resultSet->searchContainedSyntax() );
+	}
+
+	public function testGetTotalHits() {
+		$this->assertEquals( 42, $this->resultSet->getTotalHits() );
+	}
+
+}

--- a/tests/phpunit/includes/MediaWiki/Search/SearchTest.php
+++ b/tests/phpunit/includes/MediaWiki/Search/SearchTest.php
@@ -1,0 +1,488 @@
+<?php
+
+namespace SMW\Tests\MediaWiki\Search;
+
+use SMW\Application;
+use SMW\MediaWiki\Search\Search;
+use SMWQuery;
+
+/**
+ * @covers  \SMW\MediaWiki\Search\Search
+ *
+ * @ingroup Test
+ *
+ * @group   SMW
+ * @group   SMWExtension
+ *
+ * @licence GNU GPL v2+
+ * @since   2.1
+ *
+ * @author  Stephan Gambke
+ */
+class SearchTest extends \PHPUnit_Framework_TestCase {
+
+	public function testCanConstruct() {
+
+		$this->assertInstanceOf(
+			'\SMW\MediaWiki\Search\Search',
+			new Search()
+		);
+	}
+
+	public function testGetDB() {
+
+		$search = new Search();
+		$this->assertInstanceOf( 'DatabaseBase', $search->getDB() );
+
+	}
+
+	public function testSetGetDB() {
+
+		$dbMock = $this->getMockBuilder( 'DatabaseBase' )
+			->disableOriginalConstructor()
+			->getMockForAbstractClass();
+
+		$search = new Search();
+		$search->setDB( $dbMock );
+
+		$this->assertEquals( $dbMock, $search->getDB() );
+
+	}
+
+	public function testGetSettings() {
+
+		$search = new Search();
+		$this->assertInstanceOf( '\SMW\Settings', $search->getSettings() );
+
+	}
+
+	public function testSetGetSettings() {
+
+		$settings = $this->getMockBuilder( '\SMW\Settings' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$search = new Search();
+		$search->setSettings( $settings );
+
+		$this->assertEquals( $settings, $search->getSettings() );
+
+	}
+
+	public function testGetFallbackSearchEngine() {
+
+		$dbMock = $this->getMockBuilder( '\DatabaseBase' )
+			->disableOriginalConstructor()
+			->setMethods( array( 'getSearchEngine' ) )
+			->getMockForAbstractClass();
+
+		$dbMock->expects( $this->once() )
+			->method( 'getSearchEngine' )
+			->will( $this->returnValue( 'SearchEngine' ) );
+
+
+		$settings = $this->getMockBuilder( '\SMW\Settings' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$settings->expects( $this->any() )
+			->method( 'get' )
+			->will( $this->returnValue( null ) );
+
+
+		$search = new Search();
+		$search->setDB( $dbMock );
+		$search->setSettings( $settings );
+
+		$this->assertInstanceOf( 'SearchEngine', $search->getFallbackSearchEngine() );
+	}
+
+	public function testSetGetFallbackSearchEngine() {
+
+		$searchEngine = $this->getMockBuilder( 'SearchEngine' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$search = new Search();
+		$search->setFallbackSearchEngine( $searchEngine );
+
+		$this->assertEquals( $searchEngine, $search->getFallbackSearchEngine() );
+
+	}
+
+	public function testSearchTitle_withNonsemanticQuery() {
+
+		$term = 'Some string that can not be interpreted as a semantic query';
+
+		$searchResultSet = $this->getMockBuilder( 'SearchResultSet' )
+			->disableOriginalConstructor()
+			->getMock();
+
+
+		$searchEngine = $this->getMockBuilder( 'SearchEngine' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$searchEngine->expects( $this->once() )
+			->method( 'transformSearchTerm' )
+			->will( $this->returnArgument( 0 ) );
+
+		$searchEngine->expects( $this->once() )
+			->method( 'replacePrefixes' )
+			->will( $this->returnArgument( 0 ) );
+
+		$searchEngine->expects( $this->once() )
+			->method( 'searchTitle')
+			->will( $this->returnValueMap( array( array( $term, $searchResultSet ) ) ) );
+
+
+		$search = new Search();
+		$search->setFallbackSearchEngine( $searchEngine );
+
+		$this->assertEquals( $searchResultSet, $search->searchTitle( $term) );
+
+	}
+
+	public function testSearchTitle_withEmptyQuery() {
+
+		$term = '   ';
+
+		$searchResultSet = $this->getMockBuilder( 'SearchResultSet' )
+			->disableOriginalConstructor()
+			->getMock();
+
+
+		$searchEngine = $this->getMockBuilder( 'SearchEngine' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$searchEngine->expects( $this->once() )
+			->method( 'transformSearchTerm' )
+			->will( $this->returnArgument( 0 ) );
+
+		$searchEngine->expects( $this->once() )
+			->method( 'replacePrefixes' )
+			->will( $this->returnArgument( 0 ) );
+
+		$searchEngine->expects( $this->once() )
+			->method( 'searchTitle')
+			->will( $this->returnValueMap( array( array( $term, $searchResultSet ) ) ) );
+
+
+		$search = new Search();
+		$search->setFallbackSearchEngine( $searchEngine );
+
+		$this->assertEquals( $searchResultSet, $search->searchTitle( $term) );
+
+	}
+
+	public function testSearchTitle_withSemanticQuery() {
+
+		$term = '[[Some string that can be interpreted as a semantic query]]';
+
+		$queryResult = $this->getMockBuilder( '\SMWQueryResult' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$store = $this->getMockBuilder( '\SMW\Store' )
+			->disableOriginalConstructor()
+			->getMockForAbstractClass();
+
+		$store->expects( $this->exactly( 2 ) )
+			->method( 'getQueryResult' )
+			->will( $this->returnCallback( function ( SMWQuery $query ) use ( $queryResult ) {
+				return $query->querymode === SMWQuery::MODE_COUNT ? 9001 : $queryResult;
+			} ) );
+
+		$application = Application::getInstance()->registerObject( 'Store', $store );
+
+		$search = new Search();
+
+		$result = $search->searchTitle( $term);
+
+		$application->clear();
+
+		$this->assertInstanceOf( 'SMW\MediaWiki\Search\SearchResultSet', $result );
+		$this->assertEquals( 9001, $result->getTotalHits() );
+
+	}
+
+	public function testSearchText_withNonsemanticQuery() {
+
+		$term = 'Some string that can not be interpreted as a semantic query';
+
+		$searchResultSet = $this->getMockBuilder( 'SearchResultSet' )
+			->disableOriginalConstructor()
+			->getMock();
+
+
+		$searchEngine = $this->getMockBuilder( 'SearchEngine' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$searchEngine->expects( $this->once() )
+			->method( 'transformSearchTerm' )
+			->will( $this->returnArgument( 0 ) );
+
+		$searchEngine->expects( $this->once() )
+			->method( 'replacePrefixes' )
+			->will( $this->returnArgument( 0 ) );
+
+		$searchEngine->expects( $this->once() )
+			->method( 'searchText')
+			->will( $this->returnValueMap( array( array( $term, $searchResultSet ) ) ) );
+
+		$search = new Search();
+		$search->setFallbackSearchEngine( $searchEngine );
+
+		$this->assertEquals( $searchResultSet, $search->searchText( $term ) );
+
+	}
+
+	public function testSearchText_withSemanticQuery() {
+
+		$term = '[[Some string that can be interpreted as a semantic query]]';
+
+		$search = new Search();
+
+		$this->assertNull( $search->searchText( $term ) );
+
+	}
+
+	public function testSupports() {
+
+		$searchEngine = $this->getMockBuilder( 'SearchEngine' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$searchEngine->expects( $this->once() )
+			->method( 'supports')
+			->with( $this->equalTo( 'Some feature' ) )
+			->will( $this->returnValueMap( array( array( 'Some feature', true ) ) ) );
+
+		$search = new Search();
+		$search->setFallbackSearchEngine( $searchEngine );
+
+		$this->assertEquals( true, $search->supports( 'Some feature' ) );
+	}
+
+	public function testNormalizeText() {
+
+		$searchEngine = $this->getMockBuilder( 'SearchEngine' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$searchEngine->expects( $this->once() )
+			->method( 'normalizeText')
+			->with( $this->equalTo( 'Some text' ) )
+			->will( $this->returnValueMap( array( array( 'Some text', 'Some normalized text' ) ) ) );
+
+		$search = new Search();
+		$search->setFallbackSearchEngine( $searchEngine );
+
+		$this->assertEquals( 'Some normalized text', $search->normalizeText( 'Some text' ) );
+	}
+
+	public function testGetTextFromContent() {
+
+		if ( ! method_exists( 'SearchEngine', 'getTextFromContent' ) ) {
+			$this->markTestSkipped( 'SearchEngine::getTextFromContent() is undefined. Probably not yet present in the tested MW version.' );
+			return;
+		}
+
+		$title = $this->getMockBuilder( 'Title' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$content = $this->getMockBuilder( 'Content' )
+			->disableOriginalConstructor()
+			->getMockForAbstractClass();
+
+		$searchEngine = $this->getMockBuilder( 'SearchEngine' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$searchEngine->expects( $this->once() )
+			->method( 'getTextFromContent')
+			->with( $this->equalTo( $title ), $this->equalTo( $content ) )
+			->will( $this->returnValueMap( array( array( $title, $content, 'text from content for title' ) ) ) );
+
+		$search = new Search();
+		$search->setFallbackSearchEngine( $searchEngine );
+
+		$this->assertEquals( 'text from content for title', $search->getTextFromContent( $title, $content ) );
+	}
+
+
+	public function testTextAlreadyUpdatedForIndex() {
+
+		if ( ! method_exists( 'SearchEngine', 'textAlreadyUpdatedForIndex' ) ) {
+			$this->markTestSkipped( 'SearchEngine::textAlreadyUpdatedForIndex() is undefined. Probably not yet present in the tested MW version.' );
+			return;
+		}
+
+		$searchEngine = $this->getMockBuilder( 'SearchEngine' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$searchEngine->expects( $this->once() )
+			->method( 'textAlreadyUpdatedForIndex')
+			->with()
+			->will( $this->returnValue( true ) );
+
+		$search = new Search();
+		$search->setFallbackSearchEngine( $searchEngine );
+
+		$this->assertEquals( true, $search->textAlreadyUpdatedForIndex( 'Some text' ) );
+	}
+
+	public function testUpdate() {
+
+		$searchEngine = $this->getMockBuilder( 'SearchEngine' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$searchEngine->expects( $this->once() )
+			->method( 'update')
+			->with( $this->equalTo( 42 ), $this->equalTo( 'Some title' ), $this->equalTo( 'Some text' ) );
+
+		$search = new Search();
+		$search->setFallbackSearchEngine( $searchEngine );
+
+		$search->update( 42, 'Some title', 'Some text' );
+	}
+
+	public function testUpdateTitle() {
+
+		$searchEngine = $this->getMockBuilder( 'SearchEngine' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$searchEngine->expects( $this->once() )
+			->method( 'updateTitle')
+			->with( $this->equalTo( 42 ), $this->equalTo( 'Some title' ) );
+
+		$search = new Search();
+		$search->setFallbackSearchEngine( $searchEngine );
+
+		$search->updateTitle( 42, 'Some title' );
+	}
+
+	public function testDelete() {
+
+		if ( ! method_exists( 'SearchEngine', 'delete' ) ) {
+			$this->markTestSkipped( 'SearchEngine::delete() is undefined. Probably not yet present in the tested MW version.' );
+			return;
+		}
+
+		$searchEngine = $this->getMockBuilder( 'SearchEngine' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$searchEngine->expects( $this->once() )
+			->method( 'delete')
+			->with( $this->equalTo( 42 ), $this->equalTo( 'Some title' ) );
+
+		$search = new Search();
+		$search->setFallbackSearchEngine( $searchEngine );
+
+		$search->delete( 42, 'Some title' );
+	}
+
+	public function testSetFeatureData() {
+
+		if ( ! method_exists( 'SearchEngine', 'delete' ) ) {
+			$this->markTestSkipped( 'SearchEngine::delete() is undefined. Probably not yet present in the tested MW version.' );
+			return;
+		}
+
+		$searchEngine = $this->getMockBuilder( 'SearchEngine' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$searchEngine->expects( $this->once() )
+			->method( 'setFeatureData')
+			->with( $this->equalTo( 'Some feature name' ), $this->equalTo( 'Some feature expression' ) );
+
+		$search = new Search();
+		$search->setFallbackSearchEngine( $searchEngine );
+
+		$search->setFeatureData( 'Some feature name', 'Some feature expression' );
+
+		$this->assertEquals( 'Some feature expression', $search->getFeatureData( 'Some feature name' ) );
+		$this->assertNull( $search->getFeatureData( 'Some non-existent feature name' ) );
+	}
+
+	public function testReplacePrefixes() {
+
+		$search = new Search();
+		$this->assertEquals( 'Some query', $search->replacePrefixes( 'Some query' ) );
+	}
+
+	public function testTransformSearchTerm() {
+
+		$search = new Search();
+		$this->assertEquals( 'Some query', $search->transformSearchTerm( 'Some query' ) );
+	}
+
+	public function testSetLimitOffset() {
+
+		$searchEngine = $this->getMockBuilder( 'SearchEngine' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$searchEngine->expects( $this->once() )
+			->method( 'setLimitOffset')
+			->with( $this->equalTo( 9001 ), $this->equalTo( 42 ) );
+
+		$search = new Search();
+		$search->setFallbackSearchEngine( $searchEngine );
+
+		$search->setLimitOffset( 9001, 42 );
+
+		$this->assertEquals( 9001, $search->getLimit() );
+		$this->assertEquals( 42, $search->getOffset() );
+	}
+
+	public function testSetNamespaces() {
+
+		$searchEngine = $this->getMockBuilder( 'SearchEngine' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$searchEngine->expects( $this->once() )
+			->method( 'setNamespaces')
+			->with( $this->equalTo( array( 1, 2, 3, 5, 8 ) ) );
+
+		$search = new Search();
+		$search->setFallbackSearchEngine( $searchEngine );
+
+		$search->setNamespaces( array( 1, 2, 3, 5, 8 ) );
+
+		$this->assertEquals( array( 1, 2, 3, 5, 8 ), $search->namespaces );
+	}
+
+	public function testSetShowSuggestion() {
+
+		if ( ! method_exists( 'SearchEngine', 'setShowSuggestion' ) ) {
+			$this->markTestSkipped( 'SearchEngine::setShowSuggestion() is undefined. Probably not yet present in the tested MW version.' );
+			return;
+		}
+
+		$searchEngine = $this->getMockBuilder( 'SearchEngine' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$searchEngine->expects( $this->once() )
+			->method( 'setShowSuggestion')
+			->with( $this->equalTo( true ) );
+
+		$search = new Search();
+		$search->setFallbackSearchEngine( $searchEngine );
+
+		$search->setShowSuggestion( true );
+
+		$this->assertEquals( true, $search->getShowSuggestion() );
+	}
+
+}


### PR DESCRIPTION
Activate it by setting in LocalSettings.php:
  $wgSearchType = 'SMWSearch';

This search engine will try to interpret the search term as a semantic query.

If succesful, the pages according to the query will be returned.
If not it falls back to the default search engine.

A custom fallback search engine different from the standard search engine can be set using $smwgFallbackSearchType. This is basically a replacement for $wgSearchType that is now used for SMWSearch
