### PR TITLE
Fix #452 / Subobject subqueries

### DIFF
--- a/includes/dataitems/SMW_DI_Property.php
+++ b/includes/dataitems/SMW_DI_Property.php
@@ -243,6 +243,7 @@ class DIProperty extends SMWDataItem {
 		}
 
 		if ( !$this->isUserDefined() && $propertyTypeId === self::getPredefinedPropertyTypeId( $this->m_key ) ) {
+			$this->m_proptypeid = $propertyTypeId;
 			return $this;
 		}
 

--- a/includes/query/SMW_QueryParser.php
+++ b/includes/query/SMW_QueryParser.php
@@ -314,7 +314,7 @@ class SMWQueryParser {
 		$inverse = false;
 
 		foreach ( $propertynames as $name ) {
-			if ( $typeid != '_wpg' ) { // non-final property in chain was no wikipage: not allowed
+			if ( $typeid !== '_wpg' && $typeid !== '__sob' ) { // non-final property in chain was no wikipage: not allowed
 				$this->m_errors[] = wfMessage(
 					'smw_valuesubquery',
 					$name

--- a/tests/phpunit/MwDBaseUnitTestCase.php
+++ b/tests/phpunit/MwDBaseUnitTestCase.php
@@ -95,9 +95,9 @@ abstract class MwDBaseUnitTestCase extends \PHPUnit_Framework_TestCase {
 		return $this->storesToBeExcluded = $storesToBeExcluded;
 	}
 
-//	protected function getDBConnection() {
-//		return $this->mwDatabaseTableBuilder->getDBConnection();
-//	}
+	protected function getDBConnection() {
+		return $this->mwDatabaseTableBuilder->getDBConnection();
+	}
 
 	protected function getDBConnectionProvider() {
 		return $this->mwDatabaseTableBuilder->getDBConnectionProvider();


### PR DESCRIPTION
Fixes #452

Add tests for:
- `{{#ask: [[LocatedIn.MemberOf::Wonderland]] }}`
- `{{#ask: [[LocatedIn::<q>[[MemberOf::Wonderland]]</q>]] }}`
- `{{#ask: [[Category:HappyPlaces]] [[LocatedIn.MemberOf::Wonderland]] }}`

Skipped for `postgres` (#455)
- `{{#ask: [[Category:WickedPlaces]] OR [[LocatedIn.MemberOf::Wonderland]] }}`

Skipped for `SPARQLStore`:
- `{{#ask: [[LocatedIn.Has subobject.MemberOf::Wonderland]] }}`
- `{{#ask: [[LocatedIn.Has subobject.MemberOf::+]] }}`

While testing it came to light that things like `[[LocatedIn.Has subobject.MemberOf::Wonderland]]` that involves a subobject as subquery component currently does not work with SPARQLStore because the Exporter needs to add addtional information about `Has subobject` as auxiliary property which at moment it does not do.
