### PR TITLE
Add Subcategory / Subproperty query tests

### DIFF
--- a/includes/dataitems/SMW_DI_WikiPage.php
+++ b/includes/dataitems/SMW_DI_WikiPage.php
@@ -12,7 +12,7 @@ use Title;
  *
  * @since 1.6
  * @ingroup SMWDataItems
- * 
+ *
  * @author Markus Krötzsch
  */
 class DIWikiPage extends SMWDataItem {
@@ -52,13 +52,13 @@ class DIWikiPage extends SMWDataItem {
 	 * @param string $interwiki
 	 * @param string $subobjectname
 	 */
-	public function __construct( $dbkey, $namespace, $interwiki, $subobjectname = '' ) {
+	public function __construct( $dbkey, $namespace, $interwiki = '', $subobjectname = '' ) {
 		// Check if the provided value holds an integer
 		// (it can be of type string or float as well, as long as the value is an int)
 		if ( !ctype_digit( ltrim( (string)$namespace, '-' ) ) ) {
 			throw new DataItemException( "Given namespace '$namespace' is not an integer." );
 		}
-		
+
 		$this->m_dbkey = $dbkey;
 		$this->m_namespace = (int)$namespace; // really make this an integer
 		$this->m_interwiki = $interwiki;
@@ -141,7 +141,7 @@ class DIWikiPage extends SMWDataItem {
 			return new self( $parts[0], intval( $parts[1] ), $parts[2], $parts[3] );
 		} else {
 			throw new DataItemException( "Unserialization failed: the string \"$serialization\" was not understood." );
-		} 
+		}
 	}
 
 	/**

--- a/tests/phpunit/Integration/Query/SubcategoryQueryDBIntegrationTest.php
+++ b/tests/phpunit/Integration/Query/SubcategoryQueryDBIntegrationTest.php
@@ -1,0 +1,120 @@
+<?php
+
+namespace SMW\Tests\Integration\Query;
+
+use SMW\Tests\MwDBaseUnitTestCase;
+use SMW\Tests\Util\SemanticDataFactory;
+use SMW\Tests\Util\QueryResultValidator;
+
+use SMW\DIWikiPage;
+use SMW\DIProperty;
+use SMW\DataValueFactory;
+
+use SMWQuery as Query;
+use SMWClassDescription as ClassDescription;
+
+/**
+ * @ingroup Test
+ *
+ * @group SMW
+ * @group SMWExtension
+ * @group semantic-mediawiki-integration
+ * @group semantic-mediawiki-query
+ * @group mediawiki-database
+ * @group medium
+ *
+ * @license GNU GPL v2+
+ * @since 2.0
+ *
+ * @author mwjames
+ */
+class SubcategoryQueryDBIntegrationTest extends MwDBaseUnitTestCase {
+
+	protected $databaseToBeExcluded = array( 'sqlite' );
+
+	private $subjectsToBeCleared = array();
+	private $semanticDataFactory;
+	private $dataValueFactory;
+	private $queryResultValidator;
+
+	protected function setUp() {
+		parent::setUp();
+
+		$this->dataValueFactory = DataValueFactory::getInstance();
+		$this->semanticDataFactory = new SemanticDataFactory();
+		$this->queryResultValidator = new QueryResultValidator();
+	}
+
+	protected function tearDown() {
+
+		foreach ( $this->subjectsToBeCleared as $subject ) {
+			$this->getStore()->deleteSubject( $subject->getTitle() );
+		}
+
+		parent::tearDown();
+	}
+
+	public function testSubcategoryHierarchyToQueryAllMembersOfTopCategory() {
+
+		if ( $this->getDBConnection()->getType() == 'postgres' ) {
+			$this->markTestSkipped( "Issue with postgres, for details see #462" );
+		}
+
+		if ( !$this->getStore() instanceOf \SMWSQLStore3 ) {
+			$this->markTestSkipped( "Subcategory/category hierarchies are currently only supported by the SQLStore" );
+		}
+
+		$property = new DIProperty( '_INST' );
+
+		$semanticDataOfTopCategory = $this->semanticDataFactory
+			->setSubject( new DIWikiPage( 'TopCategory', NS_CATEGORY, '' ) )
+			->newEmptySemanticData();
+
+		$semanticDataOfOtherCategory = $this->semanticDataFactory
+			->setSubject( new DIWikiPage( 'OtherCategory', NS_CATEGORY, '' ) )
+			->newEmptySemanticData();
+
+		$dataValueOfSubproperty = $this->dataValueFactory->newDataItemValue(
+			$semanticDataOfTopCategory->getSubject(),
+			new DIProperty( '_SUBC' )
+		);
+
+		$semanticDataOfOtherCategory->addDataValue( $dataValueOfSubproperty	);
+
+		$dataValue = $this->dataValueFactory->newDataItemValue(
+			$semanticDataOfOtherCategory->getSubject(),
+			$property
+		);
+
+		$semanticData = $this->semanticDataFactory->newEmptySemanticData( __METHOD__ );
+		$semanticData->addDataValue( $dataValue	);
+
+		$this->getStore()->updateData( $semanticDataOfTopCategory );
+		$this->getStore()->updateData( $semanticDataOfOtherCategory );
+		$this->getStore()->updateData( $semanticData );
+
+		$description = new ClassDescription(
+			new DIWikiPage( 'TopCategory', NS_CATEGORY, '' )
+		);
+
+		$query = new Query(
+			$description,
+			false,
+			false
+		);
+
+		$query->querymode = Query::MODE_INSTANCES;
+
+		$this->queryResultValidator->assertThatQueryResultHasSubjects(
+			$semanticData->getSubject(),
+			$this->getStore()->getQueryResult( $query )
+		);
+
+		$this->subjectsToBeCleared = array(
+			$semanticData->getSubject(),
+			$semanticDataOfOtherCategory->getSubject(),
+			$semanticDataOfTopCategory->getSubject(),
+		);
+	}
+
+}

--- a/tests/phpunit/Integration/Query/SubpropertyQueryDBIntegrationTest.php
+++ b/tests/phpunit/Integration/Query/SubpropertyQueryDBIntegrationTest.php
@@ -1,0 +1,135 @@
+<?php
+
+namespace SMW\Tests\Integration\Query;
+
+use SMW\Tests\MwDBaseUnitTestCase;
+use SMW\Tests\Util\SemanticDataFactory;
+use SMW\Tests\Util\QueryResultValidator;
+
+use SMW\DIWikiPage;
+use SMW\DIProperty;
+use SMW\DataValueFactory;
+
+use SMWQuery as Query;
+use SMWSomeProperty as SomeProperty;
+use SMWPrintRequest as PrintRequest;
+use SMWPropertyValue as PropertyValue;
+use SMWThingDescription as ThingDescription;
+
+/**
+ * @ingroup Test
+ *
+ * @group SMW
+ * @group SMWExtension
+ * @group semantic-mediawiki-integration
+ * @group semantic-mediawiki-query
+ * @group mediawiki-database
+ * @group medium
+ *
+ * @license GNU GPL v2+
+ * @since 2.0
+ *
+ * @author mwjames
+ */
+class SubpropertyQueryDBIntegrationTest extends MwDBaseUnitTestCase {
+
+	protected $databaseToBeExcluded = array( 'sqlite' );
+
+	private $subjectsToBeCleared = array();
+	private $semanticDataFactory;
+	private $dataValueFactory;
+	private $queryResultValidator;
+
+	protected function setUp() {
+		parent::setUp();
+
+		$this->dataValueFactory = DataValueFactory::getInstance();
+		$this->semanticDataFactory = new SemanticDataFactory();
+		$this->queryResultValidator = new QueryResultValidator();
+	}
+
+	protected function tearDown() {
+
+		foreach ( $this->subjectsToBeCleared as $subject ) {
+			$this->getStore()->deleteSubject( $subject->getTitle() );
+		}
+
+		parent::tearDown();
+	}
+
+	public function testSubpropertyToQueryFromTopHierarchy() {
+
+		if ( $this->getDBConnection()->getType() == 'postgres' ) {
+			$this->markTestSkipped( "Issue with postgres, for details see #462" );
+		}
+
+		if ( !$this->getStore() instanceOf \SMWSQLStore3 ) {
+			$this->markTestSkipped( "Subproperty/property hierarchies are currently only supported by the SQLStore" );
+		}
+
+		$semanticDataOfSpouse = $this->semanticDataFactory
+			->setSubject( new DIWikiPage( 'Spouse', SMW_NS_PROPERTY, '' ) )
+			->newEmptySemanticData();
+
+		$property = new DIProperty( 'Wife' );
+		$property->setPropertyTypeId( '_wpg' );
+
+		$this->addPropertyHierarchy( $property, 'Spouse' );
+
+		$dataValue = $this->dataValueFactory->newPropertyObjectValue(
+			$property,
+			'Lien'
+		);
+
+		$semanticData = $this->semanticDataFactory->newEmptySemanticData( __METHOD__ );
+		$semanticData->addDataValue( $dataValue	);
+
+		$this->getStore()->updateData( $semanticDataOfSpouse );
+		$this->getStore()->updateData( $semanticData );
+
+		$description = new SomeProperty(
+			new DIProperty( 'Spouse' ),
+			new ThingDescription()
+		);
+
+		$propertyValue = new PropertyValue( '__pro' );
+		$propertyValue->setDataItem( $property );
+
+		$description->addPrintRequest(
+			new PrintRequest( PrintRequest::PRINT_PROP, null, $propertyValue )
+		);
+
+		$query = new Query(
+			$description,
+			false,
+			false
+		);
+
+		$query->querymode = Query::MODE_INSTANCES;
+
+		$queryResult = $this->getStore()->getQueryResult( $query );
+
+		$this->queryResultValidator->assertThatQueryResultContains(
+			$dataValue,
+			$queryResult
+		);
+
+		$this->subjectsToBeCleared = array(
+			$semanticData->getSubject(),
+			$semanticDataOfSpouse->getSubject(),
+			$property->getDiWikiPage()
+		);
+	}
+
+	private function addPropertyHierarchy( DIProperty $property, $targetHierarchy ) {
+
+		$semanticData = $this->semanticDataFactory->setSubject( $property->getDiWikiPage() )->newEmptySemanticData();
+
+		$semanticData->addDataValue(
+				$this->dataValueFactory->newPropertyObjectValue( new DIProperty( '_SUBP' ), $targetHierarchy )
+		);
+
+		$this->getStore()->updateData( $semanticData );
+	}
+
+}


### PR DESCRIPTION
Relates to #460

Skipping `SPARQLStore` because:
- Subproperty queries of type `rdfs:subPropertyOf` are not supported by the `SPARQLStore`
- Subcategory queries of type `rdfs:subClassOf` are not supported by the `SPARQLStore`

Skipping `Postgres` due to:
- Issue #462
