### PR TITLE
SPARQLStore / Support for subobject subqueries and predefined property queries

### DIFF
--- a/includes/export/SMW_Exporter.php
+++ b/includes/export/SMW_Exporter.php
@@ -246,6 +246,11 @@ class SMWExporter {
 						$expData->addPropertyObjectValue( $pe, $ed );
 						$peUri = self::getSpecialPropertyResource( '_URI' );
 						$expData->addPropertyObjectValue( $peUri, $ed );
+					} elseif ( !$property->isUserDefined() && !self::hasSpecialPropertyResource( $property )  ) {
+						$expData->addPropertyObjectValue(
+							self::getResourceElementForWikiPage( $property->getDiWikiPage(), 'aux' ),
+							$ed
+						);
 					} else {
 						$expData->addPropertyObjectValue( $pe, $ed );
 					}
@@ -473,6 +478,8 @@ class SMWExporter {
 				return self::getSpecialNsResource( 'swivt', 'wikiPageSortKey' );
 			case '_TYPE':
 				return self::getSpecialNsResource( 'swivt', 'type' );
+			case '_IMPO':
+				return self::getSpecialNsResource( 'swivt', 'specialImportedFrom' );
 			default:
 				return self::getSpecialNsResource( 'swivt', 'specialProperty' . $propertyKey );
 		}
@@ -689,11 +696,12 @@ class SMWExporter {
 	 * Check whether the values of a given type of dataitem have helper
 	 * values in the sense of SMWExporter::getDataItemHelperExpElement().
 	 *
-	 * @param $dataItemType integer type ID of dataitem (see SMWDataItem)
+	 * @param DIProperty $property
+	 *
 	 * @return boolean
 	 */
-	static public function hasHelperExpElement( $dataItemType ) {
-		return ( $dataItemType == SMWDataItem::TYPE_TIME );
+	static public function hasHelperExpElement( DIProperty $property ) {
+		return ( $property->findPropertyTypeID() === '_dat' ) || ( !$property->isUserDefined() && !self::hasSpecialPropertyResource( $property ) );
 	}
 
 	static protected function hasSpecialPropertyResource( DIProperty $property ) {

--- a/includes/src/SPARQLStore/QueryEngine/QueryConditionBuilder.php
+++ b/includes/src/SPARQLStore/QueryEngine/QueryConditionBuilder.php
@@ -381,9 +381,8 @@ class QueryConditionBuilder {
 		}
 
 		//*** Build the condition ***//
-		$diType = DataTypeRegistry::getInstance()->getDataItemId( $diProperty->findPropertyTypeID() );
-		// for types that use helper properties in encoding values, refer to this helper property:
-		if ( Exporter::hasHelperExpElement( $diType ) ) {
+		// Use helper properties in encoding values, refer to this helper property:
+		if ( Exporter::hasHelperExpElement( $diProperty ) ) {
 			$propertyExpElement = Exporter::getResourceElementForProperty( $diNonInverseProperty, true );
 		} else {
 			$propertyExpElement = Exporter::getResourceElementForProperty( $diNonInverseProperty );

--- a/tests/phpunit/Integration/MediaWiki/ParserFunctionInPageEmbeddedForQueryResultLookupDBIntegrationTest.php
+++ b/tests/phpunit/Integration/MediaWiki/ParserFunctionInPageEmbeddedForQueryResultLookupDBIntegrationTest.php
@@ -221,10 +221,6 @@ class ParserFunctionInPageEmbeddedForQueryResultLookupDBIntegrationTest extends 
 
 	public function testCreatePageWithSubobjectPropertyChainQueryResultLookup() {
 
-		if ( !$this->getStore() instanceOf \SMWSQLStore3 ) {
-			$this->markTestSkipped( "Property chain sub-queries with subobjects are currently only supported by the SQLStore" );
-		}
-
 		$pageCreator = new PageCreator();
 
 		$this->titles[] = Title::newFromText( 'Dreamland' );

--- a/tests/phpunit/Integration/Query/SubqueryDBIntegrationTest.php
+++ b/tests/phpunit/Integration/Query/SubqueryDBIntegrationTest.php
@@ -158,10 +158,6 @@ class SubqueryDBIntegrationTest extends MwDBaseUnitTestCase {
 	 */
 	public function testSubqueryForCombinedSubobjectPropertyChainThatComparesEqualToValue() {
 
-		if ( !$this->getStore() instanceOf \SMWSQLStore3 ) {
-			$this->markTestSkipped( "Property chain sub-queries with subobjects are currently only supported by the SQLStore" );
-		}
-
 		/**
 		 * Page ...-dreamland annotated with [[LocatedIn::BananaWonderland]]
 		 */
@@ -248,10 +244,6 @@ class SubqueryDBIntegrationTest extends MwDBaseUnitTestCase {
 	 * {{#ask: [[LocatedIn.Has subobject.MemberOf::+]] }}
 	 */
 	public function testSubqueryForCombinedSubobjectPropertyChainForWilcardSearch() {
-
-		if ( !$this->getStore() instanceOf \SMWSQLStore3 ) {
-			$this->markTestSkipped( "Property chain sub-queries with subobjects are currently only supported by the SQLStore" );
-		}
 
 		/**
 		 * Page ...-dreamland annotated with [[LocatedIn::BananaWonderland]]

--- a/tests/phpunit/includes/SPARQLStore/QueryEngine/QueryConditionBuilderTest.php
+++ b/tests/phpunit/includes/SPARQLStore/QueryEngine/QueryConditionBuilderTest.php
@@ -270,4 +270,32 @@ class QueryConditionBuilderTest extends \PHPUnit_Framework_TestCase {
 		);
 	}
 
+	public function testSingleSubobjectBuildAsAuxiliaryProperty() {
+
+		$property = new DIProperty( '_SOBJ' );
+
+		$description = new SomeProperty(
+			$property,
+			new ThingDescription()
+		);
+
+		$instance = new QueryConditionBuilder();
+
+		$condition = $instance->buildCondition( $description );
+
+		$this->assertInstanceOf(
+			'\SMW\SPARQLStore\QueryEngine\Condition\WhereCondition',
+			$condition
+		);
+
+		$expectedConditionString = $this->stringBuilder
+			->addString( '?result property:Has_subobject-23aux ?v1 .' )->addNewLine()
+			->getString();
+
+		$this->assertEquals(
+			$expectedConditionString,
+			$instance->convertConditionToString( $condition )
+		);
+	}
+
 }

--- a/tests/phpunit/includes/export/ExportSemanticDataTest.php
+++ b/tests/phpunit/includes/export/ExportSemanticDataTest.php
@@ -15,6 +15,8 @@ use SMWExpNsResource as ExpNsResource;
 use SMWExpResource as ExpResource;
 
 /**
+ * @covers \SMWExporter
+ *
  * @ingroup Test
  *
  * @group SMW
@@ -252,6 +254,55 @@ class ExportSemanticDataTest extends \PHPUnit_Framework_TestCase {
 		$this->exportDataValidator->assertThatExportDataContainsResource(
 			$expectedResourceElement,
 			Exporter::getSpecialNsResource( 'rdfs', 'subClassOf' ),
+			$exportData
+		);
+	}
+
+	public function testExportSubobject() {
+
+		$semanticData = $this->semanticDataFactory->newEmptySemanticData( __METHOD__ );
+
+		$subobject = new Subobject( $semanticData->getSubject()->getTitle() );
+		$subobject->setEmptySemanticDataforId( 'Foo' );
+
+		$semanticData->addPropertyObjectValue(
+			$subobject->getProperty(),
+			$subobject->getContainer()
+		);
+
+		$exportData = Exporter::makeExportData( $semanticData );
+
+		$expectedProperty = new ExpNsResource(
+			$this->transformPropertyLabelToAuxiliary( $subobject->getProperty() ),
+			Exporter::getNamespaceUri( 'property' ),
+			'property',
+			new DIWikiPage( 'Has_subobject', SMW_NS_PROPERTY )
+		);
+
+		$this->assertTrue(
+			Exporter::hasHelperExpElement( $subobject->getProperty() )
+		);
+
+		$this->assertCount(
+			1,
+			$exportData->getValues( $expectedProperty )
+		);
+
+		$this->exportDataValidator->assertThatExportDataContainsProperty(
+			$expectedProperty,
+			$exportData
+		);
+
+		$expectedResource = new ExpNsResource(
+			Exporter::getEncodedPageName( $subobject->getSemanticData()->getSubject() ) . '-23' . 'Foo',
+			Exporter::getNamespaceUri( 'wiki' ),
+			'wiki',
+			$subobject->getSemanticData()->getSubject()
+		);
+
+		$this->exportDataValidator->assertThatExportDataContainsResource(
+			$expectedResource,
+			$expectedProperty,
 			$exportData
 		);
 	}


### PR DESCRIPTION
Solves #460

Constructs like `<swivt:specialProperty_ASK ...>/<swivt:specialProperty_SOBJ ...>` are now replaced by a queryable representation of `<property:Has_subobject-23aux ...> or <propert:Has_query-aux ...>` to enable queries like:
- `[[Query format::+]]`
- `[[Located in.Has subobject.Member of::+]]`

Plus, special properties from third-party extensions (e.g. SESP) are now directly available and queryable.
