### PR TITLE
SPARQLStore / Fix redirect target resource

### DIFF
--- a/includes/src/SPARQLStore/RedirectLookup.php
+++ b/includes/src/SPARQLStore/RedirectLookup.php
@@ -107,7 +107,7 @@ class RedirectLookup {
 		$wikiNamespace = Exporter::getNamespaceUri( 'wiki' );
 
 		if ( strpos( $rediTargetUri, $wikiNamespace ) === 0 ) {
-			return new ExpNsResource( substr( $rediTargetUri, 0, strlen( $wikiNamespace ) ), $wikiNamespace, 'wiki' );
+			return new ExpNsResource( substr( $rediTargetUri, strlen( $wikiNamespace ) ), $wikiNamespace, 'wiki' );
 		}
 
 		return $expNsResource;

--- a/tests/phpunit/includes/SPARQLStore/RedirectLookupTest.php
+++ b/tests/phpunit/includes/SPARQLStore/RedirectLookupTest.php
@@ -4,6 +4,7 @@ namespace SMW\Tests\SPARQLStore;
 
 use SMW\SPARQLStore\RedirectLookup;
 use SMW\DIWikiPage;
+use SMW\DIProperty;
 
 use SMWExpNsResource as ExpNsResource;
 use SMWExpLiteral as ExpLiteral;
@@ -136,11 +137,13 @@ class RedirectLookupTest extends \PHPUnit_Framework_TestCase {
 
 	public function testRedirectTragetForDBLookupWithMultipleEntriesForcesNewResource() {
 
+		$propertyPage = new DIWikiPage( 'Foo', SMW_NS_PROPERTY );
+
 		$resource = new ExpNsResource(
 			'Foo',
 			Exporter::getNamespaceUri( 'property' ),
 			'property',
-			new DIWikiPage( 'Foo', SMW_NS_PROPERTY, '' )
+			$propertyPage
 		);
 
 		$sparqlDatabase = $this->createMockSparqlDatabaseFor( array( $resource, $resource ) );
@@ -151,14 +154,26 @@ class RedirectLookupTest extends \PHPUnit_Framework_TestCase {
 		$expNsResource = new ExpNsResource( 'Foo', 'Bar', '', $dataItem );
 		$exists = null;
 
+		$targetResource = $instance->findRedirectTargetResource( $expNsResource, $exists );
+
 		$this->assertNotSame(
 			$expNsResource,
-			$instance->findRedirectTargetResource( $expNsResource, $exists )
+			$targetResource
+		);
+
+		$expectedResource = new ExpNsResource(
+			Exporter::getInstance()->getEncodedPageName( $propertyPage ),
+			Exporter::getNamespaceUri( 'wiki' ),
+			'wiki'
+		);
+
+		$this->assertEquals(
+			$expectedResource,
+			$targetResource
 		);
 
 		$this->assertTrue( $exists );
 	}
-
 
 	public function testRedirectTragetForDBLookupWithForNonMultipleResourceEntryThrowsException() {
 


### PR DESCRIPTION
Relates to #467:

Doing `substr( $rediTargetUri, 0, strlen( $wikiNamespace ) )` will return `http://example.org/id/http://example.org/id/` which is not what we want
and instead we expect something like `http://example.org/id/Foo`
