### PR TITLE
Virtuoso allows `false` to be a valid raw result

### DIFF
--- a/build/travis/install-services.sh
+++ b/build/travis/install-services.sh
@@ -11,7 +11,7 @@ fi
 if [ "$FUSEKI" != "" ]
 then
 
-	wget https://www.apache.org/dist/jena/binaries/jena-fuseki-$FUSEKI-distribution.tar.gz
+	wget http://ftp.fau.de/apache//jena/binaries/jena-fuseki-$FUSEKI-distribution.tar.gz
 	tar -zxf jena-fuseki-$FUSEKI-distribution.tar.gz
 	mv jena-fuseki-$FUSEKI fuseki
 

--- a/includes/src/SPARQLStore/FourstoreHttpDatabaseConnector.php
+++ b/includes/src/SPARQLStore/FourstoreHttpDatabaseConnector.php
@@ -54,7 +54,7 @@ class FourstoreHttpDatabaseConnector extends GenericHttpDatabaseConnector {
 
 		if ( $this->httpRequest->getLastErrorCode() == 0 ) {
 			$rawResultParser = new RawResultParser();
-			$result = $rawResultParser->parseXmlToInternalResultFormat( $xmlResult );
+			$result = $rawResultParser->parse( $xmlResult );
 		} else {
 			$this->mapHttpRequestError( $this->m_queryEndpoint, $sparql );
 			$result = new FederateResultList( array(), array(), array(), FederateResultList::ERROR_UNREACHABLE );

--- a/includes/src/SPARQLStore/FusekiHttpDatabaseConnector.php
+++ b/includes/src/SPARQLStore/FusekiHttpDatabaseConnector.php
@@ -39,7 +39,7 @@ class FusekiHttpDatabaseConnector extends GenericHttpDatabaseConnector {
 
 		if ( $this->httpRequest->getLastErrorCode() == 0 ) {
 			$rawResultParser = new RawResultParser();
-			return $rawResultParser->parseXmlToInternalResultFormat( $xmlResult );
+			return $rawResultParser->parse( $xmlResult );
 		}
 
 		$this->mapHttpRequestError( $this->m_queryEndpoint, $sparql );

--- a/includes/src/SPARQLStore/GenericHttpDatabaseConnector.php
+++ b/includes/src/SPARQLStore/GenericHttpDatabaseConnector.php
@@ -437,7 +437,7 @@ class GenericHttpDatabaseConnector {
 
 		if ( $this->httpRequest->getLastErrorCode() == 0 ) {
 			$rawResultParser = new RawResultParser();
-			return $rawResultParser->parseXmlToInternalResultFormat( $xmlResult );
+			return $rawResultParser->parse( $xmlResult );
 		}
 
 		$this->mapHttpRequestError( $this->m_queryEndpoint, $sparql );

--- a/includes/src/SPARQLStore/QueryEngine/RawResultParser.php
+++ b/includes/src/SPARQLStore/QueryEngine/RawResultParser.php
@@ -90,30 +90,25 @@ class RawResultParser {
 	 * Parse the given XML result and return an FederateResultList for
 	 * the contained data.
 	 *
-	 * @param string $xmlResultData
+	 * @param string $rawData
 	 *
 	 * @return FederateResultList
 	 */
-	public function parseXmlToInternalResultFormat( $xmlResultData ) {
+	public function parse( $rawResult ) {
 
 		$this->xmlOpenTags = array();
 		$this->header = array();
 		$this->data = array();
 		$this->comments = array();
 
-		if ( !$this->parse( $xmlResultData ) ) {
-			// XmlResultParserException
-			throw new RuntimeException( "Parser error: " . $this->getLastError() );
+		if ( $rawResult == 'false' || is_bool( $rawResult ) || $this->parseXml( $rawResult ) ) {
+			return new FederateResultList( $this->header, $this->data, $this->comments );
 		}
 
-		return new FederateResultList(
-			$this->header,
-			$this->data,
-			$this->comments
-		);
+		throw new RuntimeException( "Parser error: " . $this->getLastError() );
 	}
 
-	private function parse( $xmlResultData ) {
+	private function parseXml( $xmlResultData ) {
 		return xml_parse( $this->parser, $xmlResultData , true );
 	}
 

--- a/tests/phpunit/Integration/Query/NullQueryResultTest.php
+++ b/tests/phpunit/Integration/Query/NullQueryResultTest.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace SMW\Tests\SPARQLStore;
+
+use SMW\DIWikiPage;
+use SMW\Application;
+
+use SMWQuery as Query;
+use SMWValueDescription as ValueDescription;
+use SMWConjunction as Conjunction;
+use SMWDisjunction as Disjunction;
+use SMWNamespaceDescription as NamespaceDescription;
+
+/**
+ * @ingroup Test
+ *
+ * @group SMW
+ * @group SMWExtension
+ *
+ * @license GNU GPL v2+
+ * @since 2.0
+ *
+ * @author mwjames
+ */
+class NullQueryResultTest extends \PHPUnit_Framework_TestCase {
+
+	public function testNullQueryResult() {
+
+		$term = '[[Some_string_to_query]]';
+
+		$description = new ValueDescription(
+			new DIWikiPage( $term, NS_MAIN ),
+			null
+		);
+
+		$query = new Query(
+			$description,
+			false,
+			false
+		);
+
+		$query->querymode = Query::MODE_INSTANCES;
+
+		$description = $query->getDescription();
+
+		$namespacesDisjunction = new Disjunction(
+			array_map( function ( $ns ) {
+				return new NamespaceDescription( $ns );
+			}, array( NS_MAIN ) )
+		);
+
+		$description = new Conjunction( array( $description, $namespacesDisjunction ) );
+
+		$query->setDescription( $description );
+
+		$this->assertInstanceOf(
+			'\SMWQueryResult',
+			Application::getInstance()->getStore()->getQueryResult( $query )
+		);
+	}
+
+}

--- a/tests/phpunit/Integration/Query/README.md
+++ b/tests/phpunit/Integration/Query/README.md
@@ -1,0 +1,1 @@
+- `NullQueryResultTest::testNullQueryResult` to test `[[Some_string_to_query]]` (Virtuoso would return a `false` string as raw result)

--- a/tests/phpunit/includes/SPARQLStore/QueryEngine/RawResultParserTest.php
+++ b/tests/phpunit/includes/SPARQLStore/QueryEngine/RawResultParserTest.php
@@ -37,7 +37,7 @@ class RawResultParserTest extends \PHPUnit_Framework_TestCase {
 	public function testXmlParse( $rawXmlResult, $expectedResultRowItemInstance ) {
 
 		$instance = new RawResultParser();
-		$resultFormat = $instance->parseXmlToInternalResultFormat( $rawXmlResult );
+		$resultFormat = $instance->parse( $rawXmlResult );
 
 		$this->assertInstanceOf(
 			'\SMW\SPARQLStore\QueryEngine\FederateResultList',
@@ -57,7 +57,7 @@ class RawResultParserTest extends \PHPUnit_Framework_TestCase {
 		$instance = new RawResultParser();
 
 		$this->setExpectedException( 'RuntimeException' );
-		$instance->parseXmlToInternalResultFormat( $rawResultProvider->getInvalidSparqlResultXml() );
+		$instance->parse( $rawResultProvider->getInvalidSparqlResultXml() );
 	}
 
 	protected function assertResultFormat( $expectedResultRowItemInstance, $results ) {
@@ -131,6 +131,18 @@ class RawResultParserTest extends \PHPUnit_Framework_TestCase {
 				new ExpResource( 'http://example.org/id/Bar' ),
 				new ExpLiteral( 'Quux', 'http://www.w3.org/2001/XMLSchema#string' )
 			)
+		);
+
+		#7 #450
+		$provider[] = array(
+			false,
+			null
+		);
+
+		#8 #450
+		$provider[] = array(
+			'false',
+			null
 		);
 
 		return $provider;


### PR DESCRIPTION
Based on how the `query` was composed (see https://github.com/SemanticMediaWiki/SemanticMediaWiki/pull/450#discussion_r15725606); Virtuoso would return a `false` string instead of an xml
