### PR TITLE
HHVM / Fix Fatal error: Switch statements may only contain one default

### DIFF
--- a/includes/src/SPARQLStore/Exception/BadHttpDatabaseResponseException.php
+++ b/includes/src/SPARQLStore/Exception/BadHttpDatabaseResponseException.php
@@ -64,7 +64,7 @@ class BadHttpDatabaseResponseException extends \Exception {
 			case self::ERROR_GRAPH_EXISTS:
 				$errorName = 'Graph already exists';
 				break;
-			case self::ERROR_NOSERVICE: default:
+			case self::ERROR_NOSERVICE:
 				$errorName = 'Required service has not been defined';
 				break;
 			default:


### PR DESCRIPTION
Fatal error: Switch statements may only contain one default:
clause in /home/travis/build/SemanticMediaWiki/mw/extensions/SemanticMediaWiki/includes/src/SPARQLStore/Exception/BadHttpDatabaseResponseException.php on line 72

Failed on VM 3.3.0-dev+2014.08.12 (rel); Did work on VM 3.3.0-dev+2014.08.10
