### PR TITLE
Table format: Add printout parameter 'sep'

### DIFF
--- a/includes/query/SMW_PrintRequest.php
+++ b/includes/query/SMW_PrintRequest.php
@@ -244,13 +244,13 @@ class SMWPrintRequest {
 
 	/**
 	 * Returns the value of a named parameter.
-	 * 
+	 *
 	 * @param $key string the name of the parameter key
-	 * 
-	 * @return string Value of the paramer, if set (else FALSE)
+	 * @param bool $default
+	 * @return string Value of the paramer, if set (else $default)
 	 */
-	public function getParameter( $key ) {
-		return array_key_exists( $key, $this->m_params ) ? $this->m_params[$key] : false;
+	public function getParameter( $key, $default = false ) {
+		return array_key_exists( $key, $this->m_params ) ? $this->m_params[$key] : $default;
 	}
 
 	/**

--- a/includes/queryprinters/TableResultPrinter.php
+++ b/includes/queryprinters/TableResultPrinter.php
@@ -126,7 +126,8 @@ class TableResultPrinter extends ResultPrinter {
 	 * @since 1.6.1
 	 *
 	 * @param SMWResultArray $resultArray
-	 * @param $outputmode
+	 * @param int $outputmode
+	 * @param string $columnClass
 	 *
 	 * @return string
 	 */
@@ -158,7 +159,8 @@ class TableResultPrinter extends ResultPrinter {
 			$content = $this->getCellContent(
 				$dataValues,
 				$outputmode,
-				$resultArray->getPrintRequest()->getMode() == SMWPrintRequest::PRINT_THIS
+				$resultArray->getPrintRequest()->getMode() == SMWPrintRequest::PRINT_THIS,
+				$resultArray->getPrintRequest()->getParameter( 'sep', '<br>' )
 			);
 		}
 
@@ -170,13 +172,14 @@ class TableResultPrinter extends ResultPrinter {
 	 *
 	 * @since 1.6.1
 	 *
-	 * @param array $dataValues
-	 * @param $outputmode
+	 * @param \SMWDataValue[] $dataValues
+	 * @param int $outputmode
 	 * @param boolean $isSubject
 	 *
+	 * @param string $separator
 	 * @return string
 	 */
-	protected function getCellContent( array /* of SMWDataValue */ $dataValues, $outputmode, $isSubject ) {
+	protected function getCellContent( array /* of SMWDataValue */ $dataValues, $outputmode, $isSubject, $separator ) {
 		$values = array();
 
 		foreach ( $dataValues as $dv ) {
@@ -184,7 +187,7 @@ class TableResultPrinter extends ResultPrinter {
 			$values[] = $value;
 		}
 
-		return implode( '<br />', $values );
+		return implode( $separator, $values );
 	}
 
 	/**

--- a/tests/phpunit/includes/queryprinters/TableResultPrinterTest.php
+++ b/tests/phpunit/includes/queryprinters/TableResultPrinterTest.php
@@ -113,8 +113,10 @@ class TableResultPrinterTest extends QueryPrinterTestCase {
 		$labels = array(
 			'pr-1' => 'PrintRequest-PageValue',
 			'pr-2' => 'PrintRequest-NumberValue',
+			'pr-3' => 'PrintRequest-ValueList',
 			'ra-1' => 'ResultArray-PageValue',
-			'ra-2' =>  9001
+			'ra-2' =>  9001,
+			'ra-3' => array( 'Foo', 'Bar', 'Baz' ),
 		);
 
 		$printRequests = array();
@@ -127,10 +129,20 @@ class TableResultPrinterTest extends QueryPrinterTestCase {
 			'getText' => $labels['pr-2']
 		) );
 
+		$printRequests['pr-3'] = $mockBuilder->newObject( 'PrintRequest', array(
+			'getText' => $labels['pr-3'],
+			'getParameter' => ', ',
+		) );
+
 		$datItems = array();
 
 		$datItems['ra-1'] = DIWikiPage::newFromTitle( Title::newFromText( $labels['ra-1'], NS_MAIN ) );
 		$datItems['ra-2'] = $mockBuilder->newObject( 'DataItem', array( 'getSortKey' => $labels['ra-2'] ) );
+
+		$datItems['ra-3'] = array();
+		foreach ( $labels['ra-3'] as $key => $label ) {
+			$datItems['ra-3'][ $key ] = $mockBuilder->newObject( 'DataItem', array( 'getSortKey' => $label ) );
+		}
 
 		$dataValues = array();
 
@@ -148,6 +160,16 @@ class TableResultPrinterTest extends QueryPrinterTestCase {
 			'getDataItem'      => $datItems['ra-2']
 		) );
 
+		$dataValues['ra-3'] = array();
+		foreach ( $labels['ra-3'] as $key => $label ) {
+			$dataValues['ra-3'][] = $mockBuilder->newObject( 'DataValue', array(
+				'DataValueType'    => 'SMWStringValue',
+				'getTypeID'        => '_txt',
+				'getShortText'     => $label,
+				'getDataItem'      => $datItems['ra-3'][ $key ]
+			) );
+		}
+
 		$resultArray = array();
 
 		$resultArray['ra-1'] = $mockBuilder->newObject( 'ResultArray', array(
@@ -162,9 +184,15 @@ class TableResultPrinterTest extends QueryPrinterTestCase {
 			'getNextDataValue' => $dataValues['ra-2'],
 		) );
 
+		$resultArray['ra-3'] = $mockBuilder->newObject( 'ResultArray', array(
+			'getText'          => implode( ', ', $labels['ra-3'] ),
+			'getPrintRequest'  => $printRequests['pr-3'],
+			'getNextDataValue' => $dataValues['ra-3'],
+		) );
+
 		$queryResult = $mockBuilder->newObject( 'QueryResult', array(
-			'getPrintRequests'  => array( $printRequests['pr-1'], $printRequests['pr-2'] ),
-			'getNext'           => array( $resultArray['ra-1'], $resultArray['ra-2'] ),
+			'getPrintRequests'  => array( $printRequests['pr-1'], $printRequests['pr-2'], $printRequests['pr-3'] ),
+			'getNext'           => array( $resultArray['ra-1'], $resultArray['ra-2'], $resultArray['ra-3'] ),
 			'getLink'           => new \SMWInfolink( true, 'Lala' , 'Lula' ),
 			'hasFurtherResults' => true
 		) );
@@ -183,12 +211,14 @@ class TableResultPrinterTest extends QueryPrinterTestCase {
 			'descendant' => array(
 				'tag' => 'th', 'content' => $labels['pr-1'], 'attributes' => array( 'class' => $labels['pr-1'] ),
 				'tag' => 'th', 'content' => $labels['pr-2'], 'attributes' => array( 'class' => $labels['pr-2'] ),
+				'tag' => 'th', 'content' => $labels['pr-3'], 'attributes' => array( 'class' => $labels['pr-3'] ),
 			),
 			'descendant' => array(
 				'tag' => 'tr',
 				'child' => array(
 					'tag' => 'td', 'content' => $labels['ra-1'], 'attributes' => array( 'class' => $labels['pr-1'] ),
-					'tag' => 'td', 'content' => $labels['ra-2'], 'attributes' => array( 'class' => $labels['pr-2'] )
+					'tag' => 'td', 'content' => $labels['ra-2'], 'attributes' => array( 'class' => $labels['pr-2'] ),
+					'tag' => 'td', 'content' => implode( ', ', $labels['ra-3']), 'attributes' => array( 'class' => $labels['pr-3'] ),
 				)
 			),
 			'descendant' => array(
@@ -224,12 +254,14 @@ class TableResultPrinterTest extends QueryPrinterTestCase {
 			'descendant' => array(
 				'tag' => 'th', 'content' => $labels['pr-1'], 'attributes' => array( 'class' => $labels['pr-1'] ),
 				'tag' => 'th', 'content' => $labels['pr-2'], 'attributes' => array( 'class' => $labels['pr-2'] ),
+				'tag' => 'th', 'content' => $labels['pr-3'], 'attributes' => array( 'class' => $labels['pr-3'] ),
 			),
 			'descendant' => array(
 				'tag' => 'tr',
 				'child' => array(
 					'tag' => 'td', 'content' => $labels['ra-1'], 'attributes' => array( 'class' => $labels['pr-1'] ),
-					'tag' => 'td', 'content' => $labels['ra-2'], 'attributes' => array( 'class' => $labels['pr-2'] )
+					'tag' => 'td', 'content' => $labels['ra-2'], 'attributes' => array( 'class' => $labels['pr-2'] ),
+					'tag' => 'td', 'content' => implode( ', ', $labels['ra-3']), 'attributes' => array( 'class' => $labels['pr-3'] ),
 				)
 			),
 			'descendant' => array(
@@ -265,12 +297,14 @@ class TableResultPrinterTest extends QueryPrinterTestCase {
 			'descendant' => array(
 				'tag' => 'th', 'content' => $labels['pr-1'], 'attributes' => array(),
 				'tag' => 'th', 'content' => $labels['pr-2'], 'attributes' => array(),
+				'tag' => 'th', 'content' => $labels['pr-3'], 'attributes' => array(),
 			),
 			'descendant' => array(
 				'tag' => 'tr',
 				'child' => array(
 					'tag' => 'td', 'content' => $labels['ra-1'], 'attributes' => array(),
-					'tag' => 'td', 'content' => $labels['ra-2'], 'attributes' => array()
+					'tag' => 'td', 'content' => $labels['ra-2'], 'attributes' => array(),
+					'tag' => 'td', 'content' => implode( ', ', $labels['ra-3'] ), 'attributes' => array(),
 				)
 			),
 			'descendant' => array(


### PR DESCRIPTION
This parameter allows to specify a separator between values different from '<br />'

Also fixed use of '&lt;br />' to '&lt;br>'.

I'd like to add some testing, but I have no clue at all how this whole setup works. Just specifying arrays instead of singular values does not cut it.