### PR TITLE
Fix highlighting of results

### DIFF
--- a/includes/src/MediaWiki/Search/SearchResultSet.php
+++ b/includes/src/MediaWiki/Search/SearchResultSet.php
@@ -65,4 +65,24 @@ class SearchResultSet extends \SearchResultSet {
 		return $this->count;
 	}
 
+	/**
+	 * Return an array of regular expression fragments for matching
+	 * the search terms as parsed by the engine in a text extract.
+	 *
+	 * This is a temporary hack for MW versions that can not cope
+	 * with no search term being returned (<1.24).
+	 *
+	 * @deprecated remove once min supported MW version has \SearchHighlighter::highlightNone()
+	 *
+	 * @return string[]
+	 */
+	public function termMatches() {
+
+		if ( method_exists( '\SearchHighlighter', 'highlightNone' ) ) {
+			return array();
+		}
+
+		// Will cause the highlighter to match every line start, thus returning the first few lines of found pages.
+		return array( '^' );
+	}
 }


### PR DESCRIPTION
SMWSearch did not supply search terms to MW to apply highlighting to the
search results. So MW's SearchHighlighter put an empty span between each and
every byte of the result snippets.

This patch will return a search term that will match on every line start of the
article text so that the highlighter will output the first few characters of
the first few lines of the articles contained in the search result

Those lines will be truncated after 75 characters or so, so this may not
really give the correct beginning of the article, but it should be good enough
as a temporary solution.

Do we need testing for this?
