### PR TITLE
Display `distinct` query results

### DIFF
--- a/includes/storage/SQLStore/SMW_SQLStore3_Readers.php
+++ b/includes/storage/SQLStore/SMW_SQLStore3_Readers.php
@@ -319,8 +319,12 @@ class SMWSQLStore3Readers {
 				) );
 
 		foreach ( $res as $row ) {
+
+			$hash = '';
+
 			if ( $issubject ) { // use joined or predefined property name
 				$propertykey = $proptable->isFixedPropertyTable() ? $proptable->getFixedProperty() : $row->prop;
+				$hash = $propertykey;
 			}
 
 			// Use enclosing array only for results with many values:
@@ -334,10 +338,15 @@ class SMWSQLStore3Readers {
 				$valuekeys = $row->v0;
 			}
 
+			// Using the GROUP BY option during the SQL select was not sufficient
+			// therefore using a hash as post-processing method to map existing
+			// values of the same content to avoid any duplicate display
+			$hash = is_array( $valuekeys ) ? $hash . md5( implode( '#', $valuekeys ) ) : $hash . md5( $valuekeys );
+
 			// Filter out any accidentally retrieved internal things (interwiki starts with ":"):
 			if ( $valuecount < 3 || implode( '', $fields ) != 'p' ||
 			     $valuekeys[2] === '' ||  $valuekeys[2]{0} != ':' ) {
-				$result[] = $issubject ? array( $propertykey, $valuekeys ) : $valuekeys;
+				$result[ $hash ] = $issubject ? array( $propertykey, $valuekeys ) : $valuekeys;
 			}
 		}
 


### PR DESCRIPTION
Relates to #191

This change does not solve the problem of #191 (where duplicates entries are created in `smw_objects_ids` etc.) but it will avoid having duplicate entries being displayed.

### QueryEngine

~~Use `GROUP BY` to allow for INNER JOIN values the be distinctive as well. See also [distinct-vs-group][distinct-vs-group].~~

Using the `!isset( $dataItemCache[ $dataItem->getHash() ] )` to determine whether the subject has already been selected or not.

### fetchSemanticData

Using a `hash` to determine whether a specific column value has been already processed and avoid its output duplication during `getPropertyValues()` or `getSemanticData`.

[distinct-vs-group]: http://sqlmag.com/database-performance-tuning/distinct-vs-group