### PR TITLE
Add Benchmark tests

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -35,10 +35,26 @@
         <testsuite name="semantic-mediawiki-system">
             <directory>tests/phpunit/System</directory>
         </testsuite>
+        <testsuite name="semantic-mediawiki-benchmark">
+            <directory>tests/phpunit/Benchmark</directory>
+        </testsuite>
     </testsuites>
+    <groups>
+      <exclude>
+        <group>semantic-mediawiki-benchmark</group>
+      </exclude>
+    </groups>
     <filter>
         <whitelist addUncoveredFilesFromWhitelist="true">
             <directory suffix=".php">includes</directory>
         </whitelist>
     </filter>
+    <php>
+       <var name="benchmarkQueryRepetitionExecutionThreshold" value="5"/>
+       <var name="benchmarkQueryLimit" value="500"/>
+       <var name="benchmarkQueryOffset" value="0"/>
+       <var name="benchmarkPageCopyThreshold" value="100"/>
+       <var name="benchmarkShowMemoryUsage" value="true"/>
+       <var name="benchmarkReuseDatasets" value="true"/>
+    </php>
 </phpunit>

--- a/tests/phpunit/Benchmark/BenchmarkRunner.php
+++ b/tests/phpunit/Benchmark/BenchmarkRunner.php
@@ -1,0 +1,109 @@
+<?php
+
+namespace SMW\Tests\Benchmark;
+
+use SMW\Tests\MwDBaseUnitTestCase;
+
+use SMW\Tests\Util\PageDeleter;
+use SMW\Tests\Util\PageReader;
+use SMW\Tests\Util\PageCreator;
+
+use SMW\Tests\Util\XmlImportRunner;
+use SMW\Tests\Util\JobQueueRunner;
+
+use SMW\MediaWiki\Jobs\RefreshJob;
+
+use Title;
+
+/**
+ * @license GNU GPL v2+
+ * @since 2.1
+ *
+ * @author mwjames
+ */
+class BenchmarkRunner {
+
+	/**
+	 * @var array
+	 */
+	private $messages = array();
+
+	/**
+	 * @since 2.1
+	 *
+	 * @param string $xmlFileSource
+	 */
+	public function doImportXmlDatasetFixture( $xmlFileSource ) {
+
+		$importRunner = new XmlImportRunner( $xmlFileSource );
+		$importRunner->setVerbose( true );
+
+		if ( !$importRunner->run() ) {
+			$importRunner->reportFailedImport();
+		}
+
+		$this->addMessage(
+			" |- " . $importRunner->getElapsedImportTimeInSeconds() . " (sec) elapsed XML import time"
+		);
+	}
+
+	/**
+	 * @since 2.1
+	 *
+	 * @param Title $title
+	 * @param integer $pageCopyThreshold
+	 * @param string $baseName
+	 */
+	public function copyPageContentFrom( Title $title, $pageCopyThreshold, $baseName = '' ) {
+
+		$pageReader = new PageReader();
+		$text = $pageReader->getContentAsText( $title );
+
+		$pageCreator = new PageCreator();
+
+		$start = microtime( true );
+
+		if ( $baseName === '' ) {
+			$baseName = 'CopyOf' . $title->getText();
+		}
+
+		for ( $i = 0; $i < $pageCopyThreshold; $i++ ) {
+			$pageCreator->createPage( Title::newFromText( $baseName .'-' . $i ), $text );
+		}
+
+		$sum  = round( microtime( true ) - $start, 7 );
+		$mean = $sum / $pageCopyThreshold;
+
+		$this->addMessage(
+			" |- $mean (mean) $sum (total) (sec) for $i content copies of page '{$title->getText()}'"
+		);
+	}
+
+	/**
+	 * @since 2.1
+	 *
+	 * @param string $message
+	 */
+	public function addMessage( $message ) {
+		$this->messages[] = $message;
+	}
+
+	/**
+	 * @since 2.1
+	 */
+	public function printMessages() {
+		foreach ( $this->messages as $message ) {
+			print( $message . "\n" );
+		}
+	}
+
+	/**
+	 * @since 2.1
+	 *
+	 * @return string
+	 */
+	public function getQueryEngine() {
+		return "{$GLOBALS['smwgDefaultStore']}" . ( strpos( $GLOBALS['smwgDefaultStore'], 'SQL' ) ? '' : ' [ ' . $GLOBALS['smwgSparqlDatabaseConnector'] . ' ] ' );
+	}
+
+}

--- a/tests/phpunit/Benchmark/Fixtures/GenericLoremIpsumDataset.v1.xml
+++ b/tests/phpunit/Benchmark/Fixtures/GenericLoremIpsumDataset.v1.xml
@@ -1,0 +1,326 @@
+<mediawiki xmlns="http://www.mediawiki.org/xml/export-0.6/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.mediawiki.org/xml/export-0.6/ http://www.mediawiki.org/xml/export-0.6.xsd" version="0.6" xml:lang="en-gb">
+  <siteinfo>
+    <sitename>MW-19</sitename>
+    <base>http://localhost:8080/w/index.php/Main_Page</base>
+    <generator>MediaWiki 1.19.7</generator>
+    <case>first-letter</case>
+    <namespaces>
+      <namespace key="-2" case="first-letter">Media</namespace>
+      <namespace key="-1" case="first-letter">Special</namespace>
+      <namespace key="0" case="first-letter" />
+      <namespace key="1" case="first-letter">Talk</namespace>
+      <namespace key="2" case="first-letter">User</namespace>
+      <namespace key="3" case="first-letter">User talk</namespace>
+      <namespace key="4" case="first-letter">MW-19</namespace>
+      <namespace key="5" case="first-letter">MW-19 talk</namespace>
+      <namespace key="6" case="first-letter">File</namespace>
+      <namespace key="7" case="first-letter">File talk</namespace>
+      <namespace key="8" case="first-letter">MediaWiki</namespace>
+      <namespace key="9" case="first-letter">MediaWiki talk</namespace>
+      <namespace key="10" case="first-letter">Template</namespace>
+      <namespace key="11" case="first-letter">Template talk</namespace>
+      <namespace key="12" case="first-letter">Help</namespace>
+      <namespace key="13" case="first-letter">Help talk</namespace>
+      <namespace key="14" case="first-letter">Category</namespace>
+      <namespace key="15" case="first-letter">Category talk</namespace>
+      <namespace key="102" case="first-letter">Property</namespace>
+      <namespace key="103" case="first-letter">Property talk</namespace>
+      <namespace key="104" case="first-letter">Type</namespace>
+      <namespace key="105" case="first-letter">Type talk</namespace>
+      <namespace key="108" case="first-letter">Concept</namespace>
+      <namespace key="109" case="first-letter">Concept talk</namespace>
+      <namespace key="160" case="first-letter">Foo</namespace>
+      <namespace key="161" case="first-letter">Foo talk</namespace>
+    </namespaces>
+  </siteinfo>
+  <page>
+    <title>Property:Has annotation uri</title>
+    <ns>102</ns>
+    <id>503</id>
+      <sha1>ifvt9xhpsfkv04ehcnhpw3i88s0fsb8</sha1>
+    <revision>
+      <id>1342</id>
+      <timestamp>2014-03-29T16:51:25Z</timestamp>
+      <contributor>
+        <username>Tester</username>
+        <id>1</id>
+      </contributor>
+      <text xml:space="preserve" bytes="53">[[Has type::Annotation URI]] [[Category:Lorem ipsum]]</text>
+    </revision>
+  </page>
+  <page>
+    <title>Property:Has boolean</title>
+    <ns>102</ns>
+    <id>502</id>
+      <sha1>l3b3eelfib1em61uurletnc4kb1xlzh</sha1>
+    <revision>
+      <id>1338</id>
+      <timestamp>2014-03-29T16:47:13Z</timestamp>
+      <contributor>
+        <username>Tester</username>
+        <id>1</id>
+      </contributor>
+      <comment>Created page with &quot;[[Has type::Boolean]] [[Category:Lorem ipsum]]&quot;</comment>
+      <text xml:space="preserve" bytes="46">[[Has type::Boolean]] [[Category:Lorem ipsum]]</text>
+    </revision>
+  </page>
+  <page>
+    <title>Property:Has date</title>
+    <ns>102</ns>
+    <id>14</id>
+      <sha1>473nf5knraq99k8zsrg6z7o3812tu61</sha1>
+    <revision>
+      <id>1330</id>
+      <timestamp>2014-03-29T16:38:59Z</timestamp>
+      <contributor>
+        <username>Tester</username>
+        <id>1</id>
+      </contributor>
+      <text xml:space="preserve" bytes="43">[[Has type::Date]] [[Category:Lorem ipsum]]</text>
+    </revision>
+  </page>
+  <page>
+    <title>Property:Has email</title>
+    <ns>102</ns>
+    <id>500</id>
+      <sha1>9puenjhr9dntyg9obgtwhvaenn98rav</sha1>
+    <revision>
+      <id>1334</id>
+      <timestamp>2014-03-29T16:42:38Z</timestamp>
+      <contributor>
+        <username>Tester</username>
+        <id>1</id>
+      </contributor>
+      <comment>Created page with &quot;[[Has type::Email]] [[Category:Lorem ipsum]]&quot;</comment>
+      <text xml:space="preserve" bytes="44">[[Has type::Email]] [[Category:Lorem ipsum]]</text>
+    </revision>
+  </page>
+  <page>
+    <title>Property:Has number</title>
+    <ns>102</ns>
+    <id>494</id>
+      <sha1>9fqf0pft61g8qqb8qtz1i5ayr1rmu30</sha1>
+    <revision>
+      <id>1321</id>
+      <timestamp>2014-03-29T16:30:26Z</timestamp>
+      <contributor>
+        <username>Tester</username>
+        <id>1</id>
+      </contributor>
+      <comment>Created page with &quot;[[Has type::Number]] [[Category:Lorem ipsum]]&quot;</comment>
+      <text xml:space="preserve" bytes="45">[[Has type::Number]] [[Category:Lorem ipsum]]</text>
+    </revision>
+  </page>
+  <page>
+    <title>Property:Has page</title>
+    <ns>102</ns>
+    <id>489</id>
+      <sha1>4sq0eljhm3yty9cifkvel3mv646ag0y</sha1>
+    <revision>
+      <id>1319</id>
+      <timestamp>2014-03-29T16:29:46Z</timestamp>
+      <contributor>
+        <username>Tester</username>
+        <id>1</id>
+      </contributor>
+      <text xml:space="preserve" bytes="43">[[Has type::Page]] [[Category:Lorem ipsum]]</text>
+    </revision>
+  </page>
+  <page>
+    <title>Property:Has quantity</title>
+    <ns>102</ns>
+    <id>495</id>
+      <sha1>1ulyevjgdofvfrp7b6b17n7p0p6oy4w</sha1>
+    <revision>
+      <id>1323</id>
+      <timestamp>2014-03-29T16:34:24Z</timestamp>
+      <contributor>
+        <username>Tester</username>
+        <id>1</id>
+      </contributor>
+      <text xml:space="preserve" bytes="219">[[Has type::Quantity]] [[Category:Lorem ipsum]]
+
+* [[Corresponds to::1 km²]]
+* [[Corresponds to::0.38610 sq mi]]   
+* [[Corresponds to::1000 m²]]
+* [[Corresponds to::247.1054 acre]]
+* [[Corresponds to::988.4215 rood]]</text>
+    </revision>
+  </page>
+  <page>
+    <title>Property:Has wattage</title>
+    <ns>102</ns>
+    <id>503</id>
+      <sha1>1ulyevjgdofvfrp7b6b17n7p0p6oy4w</sha1>
+    <revision>
+      <id>1355</id>
+      <timestamp>2014-03-29T16:34:24Z</timestamp>
+      <contributor>
+        <username>Tester</username>
+        <id>1</id>
+      </contributor>
+      <text xml:space="preserve" bytes="219">[[Has type::Quantity]] [[Display units::kW]] [[Category:Lorem ipsum]]
+
+* [[Corresponds to::1 W, Watt, Watts]]
+* [[Corresponds to::0.001 kW]]
+* [[Corresponds to::0.0013410220 hp, bhp, horsepower]]</text>
+    </revision>
+  </page>
+  <page>
+    <title>Property:Has status</title>
+    <ns>102</ns>
+    <id>504</id>
+      <sha1>1ulyevjgdofvfrp7b6b17n7p0p6oy4w</sha1>
+    <revision>
+      <id>1365</id>
+      <timestamp>2014-03-29T16:34:24Z</timestamp>
+      <contributor>
+        <username>Tester</username>
+        <id>1</id>
+      </contributor>
+      <text xml:space="preserve" bytes="219">[[Has type::Text]] [[Category:Lorem ipsum]]
+
+* [[Allows value::open]]
+* [[Allows value::closed]]</text>
+    </revision>
+  </page>
+  <page>
+    <title>Property:Has telephone number</title>
+    <ns>102</ns>
+    <id>505</id>
+      <sha1>1ulyevjgdofvfrp7b6b17n7p0p6oy4w</sha1>
+    <revision>
+      <id>1375</id>
+      <timestamp>2014-03-29T16:34:24Z</timestamp>
+      <contributor>
+        <username>Tester</username>
+        <id>1</id>
+      </contributor>
+      <text xml:space="preserve" bytes="219">[[Has type::Telephone number]] [[Category:Lorem ipsum]]</text>
+    </revision>
+  </page>
+  <page>
+    <title>Property:Has record</title>
+    <ns>102</ns>
+    <id>506</id>
+      <sha1>1ulyevjgdofvfrp7b6b17n7p0p6oy4w</sha1>
+    <revision>
+      <id>1385</id>
+      <timestamp>2014-03-29T16:34:24Z</timestamp>
+      <contributor>
+        <username>Tester</username>
+        <id>1</id>
+      </contributor>
+      <text xml:space="preserve" bytes="219">[[Has type::Record]] [[Has fields::Has text; Has status]] [[Category:Lorem ipsum]]</text>
+    </revision>
+  </page>
+  <page>
+    <title>Property:Has temperature</title>
+    <ns>102</ns>
+    <id>501</id>
+      <sha1>925639l5wc4pwdmufjgza10rstpb2oa</sha1>
+    <revision>
+      <id>1336</id>
+      <timestamp>2014-03-29T16:45:35Z</timestamp>
+      <contributor>
+        <username>Tester</username>
+        <id>1</id>
+      </contributor>
+      <comment>Created page with &quot;[[Has type::Temperature]] [[Category:Lorem ipsum]]&quot;</comment>
+      <text xml:space="preserve" bytes="50">[[Has type::Temperature]] [[Category:Lorem ipsum]]</text>
+    </revision>
+  </page>
+  <page>
+    <title>Property:Has text</title>
+    <ns>102</ns>
+    <id>491</id>
+      <sha1>qi7oxp4101tdesdm3vavpgpfn1qe68u</sha1>
+    <revision>
+      <id>1320</id>
+      <timestamp>2014-03-29T16:30:07Z</timestamp>
+      <contributor>
+        <username>Tester</username>
+        <id>1</id>
+      </contributor>
+      <text xml:space="preserve" bytes="43">[[Has type::Text]] [[Category:Lorem ipsum]]</text>
+    </revision>
+  </page>
+  <page>
+    <title>Property:Has Url</title>
+    <ns>102</ns>
+    <id>499</id>
+      <sha1>1fw7q2wts7v11q1z6d31g89zorhco0i</sha1>
+    <revision>
+      <id>1332</id>
+      <timestamp>2014-03-29T16:40:28Z</timestamp>
+      <contributor>
+        <username>Tester</username>
+        <id>1</id>
+      </contributor>
+      <comment>Created page with &quot;[[Has type::URL]] [[Category:Lorem ipsum]]&quot;</comment>
+      <text xml:space="preserve" bytes="42">[[Has type::URL]] [[Category:Lorem ipsum]]</text>
+    </revision>
+  </page>
+  <page>
+    <title>Lorem ipsum</title>
+    <ns>0</ns>
+    <id>493</id>
+      <sha1>94lztkh4kgb0mvjr87iyjfq4iv7ltlh</sha1>
+    <revision>
+      <id>1358</id>
+      <timestamp>2014-04-04T22:55:04Z</timestamp>
+      <contributor>
+        <username>Tester</username>
+        <id>1</id>
+      </contributor>
+      <text xml:space="preserve" bytes="979">[[Has text::Lorem ipsum dolor sit amet consectetuer Maecenas adipiscing Pellentesque id sem]]. [[Has page::Elit Aliquam urna interdum]] morbi faucibus id tellus ipsum semper wisi. [[Has page::Platea enim hendrerit]] pellentesque consectetuer scelerisque Sed est felis felis quis. Auctor Proin In dolor id et ipsum vel at vitae ut. Praesent elit convallis Praesent aliquet pellentesque vel dolor pellentesque lacinia vitae. At tortor lacus Sed In interdum pulvinar et.
+
+* Has number: [[Has number::1001]]
+* Has quantity: [[Has quantity::10.25 km²]]
+* Has date: [[Has date::1 Jan 2014]]
+* Has Url: [[Has Url::http://loremipsum.org/]]
+* Has annotation uri: [[Has annotation uri::http://loremipsum.org/foaf.rdf]]
+* Has email: [[Has email::Lorem@ipsum.org]]
+* Has temperature: [[Has temperature::100 °C]]
+* Has wattage: [[Has wattage::9001]], [[Has wattage::9002 W]], [[Has wattage::10 kW]]
+* Has telephone number: [[Has telephone number::+1-201-555-0123]]
+* Has record: [[Has record::Lorem ipsum; closed]]
+* Has status: [[Has status::open]]
+* Has boolean: [[Has boolean::true]]
+
+{{#subobject:|Has wattage=42 hp|Has status=closed|Has number=1111|Has quantity=25 sqmi|Has date=January 4, 2010 7:00 pm|Has Url=http://example.org/some/|Has annotation uri=http://example.org/foaf.rdf|Has email=Lorem@example.org|Has temperature=100 °F|Has boolean=false}}
+
+[[Category:Lorem ipsum]]</text>
+    </revision>
+  </page>
+  <page>
+    <title>Lorem Ipsum</title>
+    <ns>0</ns>
+    <id>600</id>
+      <sha1>94lztkh4kgb0mvjr87iyjfq4iv7ltlh</sha1>
+    <revision>
+      <id>1400</id>
+      <timestamp>2014-04-04T22:55:04Z</timestamp>
+      <contributor>
+        <username>Tester</username>
+        <id>1</id>
+      </contributor>
+      <text xml:space="preserve" bytes="979">#REDIRECT [[Lorem ipsum]]</text>
+    </revision>
+  </page>
+  <page>
+    <title>Category:Lorem ipsum</title>
+    <ns>14</ns>
+    <id>496</id>
+      <sha1>sir97j6uzt9ev2uyhaz1aj4i3spogih</sha1>
+    <revision>
+      <id>1355</id>
+      <timestamp>2014-04-04T22:29:18Z</timestamp>
+      <contributor>
+        <username>Tester</username>
+        <id>1</id>
+      </contributor>
+      <text xml:space="preserve" bytes="17">[[Category:Main]]</text>
+    </revision>
+  </page>
+</mediawiki>

--- a/tests/phpunit/Benchmark/JobQueueBenchmarkTest.php
+++ b/tests/phpunit/Benchmark/JobQueueBenchmarkTest.php
@@ -1,0 +1,121 @@
+<?php
+
+namespace SMW\Tests\Benchmark;
+
+use SMW\Tests\MwDBaseUnitTestCase;
+use SMW\Tests\Util\JobQueueRunner;
+
+use SMW\MediaWiki\Jobs\RefreshJob;
+
+use Title;
+
+/**
+ * @group semantic-mediawiki-benchmark
+ * @large
+ *
+ * @license GNU GPL v2+
+ * @since 2.1
+ *
+ * @author mwjames
+ */
+class JobQueueBenchmarkTest extends MwDBaseUnitTestCase {
+
+	/**
+	 * @var array
+	 */
+	protected $databaseToBeExcluded = array( 'postgres', 'sqlite' );
+
+	/**
+	 * @var boolean
+	 */
+	protected $destroyDatabaseTablesOnEachRun = false;
+
+	/**
+	 * @var BenchmarkRunner
+	 */
+	private $benchmarkRunner = null;
+
+	private	$repetitionExecutionThreshold = 1;
+	private	$pageCopyThreshold = 50;
+	private $showMemoryUsage = false;
+	private $reuseDatasets = true;
+
+	protected function setUp() {
+		parent::setUp();
+
+		// Variable set using phpunit.xml
+		if ( isset( $GLOBALS['benchmarkPageCopyThreshold'] ) ) {
+			$this->pageCopyThreshold = $GLOBALS['benchmarkPageCopyThreshold'];
+		}
+
+		if ( isset( $GLOBALS['benchmarkShowMemoryUsage'] ) ) {
+			$this->showMemoryUsage = $GLOBALS['benchmarkShowMemoryUsage'];
+		}
+
+		if ( isset( $GLOBALS['benchmarkReuseDatasets'] ) ) {
+			$this->reuseDatasets = $GLOBALS['benchmarkReuseDatasets'];
+		}
+
+		$this->benchmarkRunner = new BenchmarkRunner();
+	}
+
+	/**
+	 * @test
+	 */
+	public function doBenchmark() {
+
+		$dataset = 'GenericLoremIpsumDataset.v1.xml';
+		$datasetFixture = Title::newFromText( 'Lorem ipsum' );
+
+		$this->benchmarkRunner->addMessage( "\n" . "Use $dataset on MW " . $GLOBALS['wgVersion'] . ', ' . $this->benchmarkRunner->getQueryEngine() );
+		$this->benchmarkRunner->addMessage( " |- repetitionExecutionThreshold: " . $this->repetitionExecutionThreshold );
+		$this->benchmarkRunner->addMessage( " |- pageCopyThreshold: " . $this->pageCopyThreshold );
+		$this->benchmarkRunner->addMessage( " |- showMemoryUsage: " . var_export( $this->showMemoryUsage, true ) );
+		$this->benchmarkRunner->addMessage( " |- reuseDatasets: " . var_export( $this->reuseDatasets, true ) );
+
+		if ( !$datasetFixture->exists() || !$this->reuseDatasets ) {
+			$this->benchmarkRunner->addMessage( "\n" . 'Data preparation benchmarks' );
+			$this->benchmarkRunner->doImportXmlDatasetFixture( __DIR__ . '/'. 'Fixtures' . '/' . $dataset );
+			$this->benchmarkRunner->copyPageContentFrom( $datasetFixture, $this->pageCopyThreshold );
+		}
+
+		$this->assertTrue( $datasetFixture->exists() );
+
+		$this->benchmarkRunner->addMessage( "\n" . 'JobQueue benchmarks' );
+
+		$refreshJob = new RefreshJob( Title::newFromText( __METHOD__ ) );
+		$refreshJob->insert();
+
+		$this->createJobQueueBenchmarks( 'SMW\RefreshJob' );
+		$this->createJobQueueBenchmarks( 'SMW\UpdateJob' );
+
+		$this->benchmarkRunner->printMessages();
+	}
+
+	private function createJobQueueBenchmarks( $job ) {
+
+		$jobQueueRunner = new JobQueueRunner( $job );
+
+		$repetitionTimeContainer = array();
+		$memoryBefore = memory_get_peak_usage( false );
+
+		for ( $i = 0; $i < $this->repetitionExecutionThreshold; $i++ ) {
+			$start = microtime( true );
+			$jobQueueRunner->run();
+			$repetitionTimeContainer[] = round( microtime( true ) - $start, 7 );
+		}
+
+		$memoryAfter = memory_get_peak_usage( false );
+		$memoryDiff  = $memoryAfter - $memoryBefore;
+
+		$sum  = array_sum( $repetitionTimeContainer );
+		$mean = $sum / $this->repetitionExecutionThreshold;
+
+		$this->benchmarkRunner->addMessage( " |- $job $mean (mean) $sum (total) (sec)" );
+
+		if ( $this->showMemoryUsage ) {
+			$this->benchmarkRunner->addMessage( " +-- $memoryBefore (before) $memoryAfter (after) $memoryDiff (diff)" );
+		}
+	}
+
+}

--- a/tests/phpunit/Benchmark/QueryEngineBenchmarkTest.php
+++ b/tests/phpunit/Benchmark/QueryEngineBenchmarkTest.php
@@ -1,0 +1,265 @@
+<?php
+
+namespace SMW\Tests\Benchmark;
+
+use SMW\Tests\MwDBaseUnitTestCase;
+
+use SMW\DIProperty;
+use SMWPropertyValue as PropertyValue;
+use SMWPrintRequest as PrintRequest;
+
+use SMWQueryParser as QueryParser;
+use SMWQuery as Query;
+use SMWQueryResult as QueryResult;
+
+use Title;
+
+/**
+ * @group semantic-mediawiki-benchmark
+ * @large
+ *
+ * @license GNU GPL v2+
+ * @since 2.1
+ *
+ * @author mwjames
+ */
+class QueryEngineBenchmarkTest extends MwDBaseUnitTestCase {
+
+	/**
+	 * @var array
+	 */
+	protected $databaseToBeExcluded = array( 'postgres', 'sqlite' );
+
+	/**
+	 * @var boolean
+	 */
+	protected $destroyDatabaseTablesOnEachRun = false;
+
+	/**
+	 * @var BenchmarkRunner
+	 */
+	private $benchmarkRunner = null;
+
+	/**
+	 * @var QueryParser
+	 */
+	private $queryParser;
+
+	private	$queryLimit = 1000;
+	private	$queryOffset = 0;
+	private	$pageCopyThreshold = 50;
+	private $repetitionExecutionThreshold = 5;
+	private $showMemoryUsage = false;
+	private $reuseDatasets = true;
+
+	private $benchmarkSummaryContainer = array(
+		'count'     => array(),
+		'instance'  => array(),
+		'serialize' => array(),
+		'instance (n)'  => array(),
+		'serialize (n)' => array(),
+	);
+
+	protected function setUp() {
+		parent::setUp();
+
+		// Variable set using phpunit.xml
+		if ( isset( $GLOBALS['benchmarkQueryRepetitionExecutionThreshold'] ) ) {
+			$this->repetitionExecutionThreshold = $GLOBALS['benchmarkQueryRepetitionExecutionThreshold'];
+		}
+
+		if ( isset( $GLOBALS['benchmarkPageCopyThreshold'] ) ) {
+			$this->pageCopyThreshold = $GLOBALS['benchmarkPageCopyThreshold'];
+		}
+
+		if ( isset( $GLOBALS['benchmarkShowMemoryUsage'] ) ) {
+			$this->showMemoryUsage = (bool)$GLOBALS['benchmarkShowMemoryUsage'];
+		}
+
+		if ( isset( $GLOBALS['benchmarkQueryLimit'] ) ) {
+			$this->queryLimit = $GLOBALS['benchmarkQueryLimit'];
+		}
+
+		if ( isset( $GLOBALS['benchmarkQueryOffset'] ) ) {
+			$this->queryOffset = $GLOBALS['benchmarkQueryOffset'];
+		}
+
+		if ( isset( $GLOBALS['benchmarkReuseDatasets'] ) ) {
+			$this->reuseDatasets = $GLOBALS['benchmarkReuseDatasets'];
+		}
+
+		$this->queryParser = new QueryParser();
+		$this->benchmarkRunner = new BenchmarkRunner();
+	}
+
+	/**
+	 * @test
+	 */
+	public function doBenchmark() {
+
+		$dataset = 'GenericLoremIpsumDataset.v1.xml';
+		$datasetFixture = Title::newFromText( 'Lorem ipsum' );
+
+		$this->benchmarkRunner->addMessage( "\n" . "Use $dataset on MW " . $GLOBALS['wgVersion'] . ', ' . $this->benchmarkRunner->getQueryEngine() );
+		$this->benchmarkRunner->addMessage( " |- repetitionExecutionThreshold: " . $this->repetitionExecutionThreshold );
+		$this->benchmarkRunner->addMessage( " |- pageCopyThreshold: " . $this->pageCopyThreshold );
+		$this->benchmarkRunner->addMessage( " |- showMemoryUsage: " . var_export( $this->showMemoryUsage, true ) );
+		$this->benchmarkRunner->addMessage( " |- reuseDatasets: " . var_export( $this->reuseDatasets, true ) );
+		$this->benchmarkRunner->addMessage( " |- queryLimit: " . $this->queryLimit );
+		$this->benchmarkRunner->addMessage( " |- queryOffset: " . $this->queryOffset );
+
+		if ( !$datasetFixture->exists() || !$this->reuseDatasets ) {
+			$this->benchmarkRunner->addMessage( "\n" . 'Data preparation benchmarks' );
+			$this->benchmarkRunner->doImportXmlDatasetFixture( __DIR__ . '/'. 'Fixtures' . '/' . $dataset );
+			$this->benchmarkRunner->copyPageContentFrom( $datasetFixture, $this->pageCopyThreshold );
+		}
+
+		$this->assertTrue( $datasetFixture->exists() );
+
+		$this->benchmarkRunner->addMessage( "\n" . 'Query result benchmarks (C = count, I = instance, S = serialization)' );
+		$this->createQueryBenchmarks();
+
+		$this->benchmarkRunner->printMessages();
+	}
+
+	private function createQueryBenchmarks() {
+
+		// $queryCondition, $printouts, $comments
+		$querySets = array(
+			array( '[[:+]]', array(), '' ),
+			array( '[[Category: Lorem ipsum]]', array(), '' ),
+			array( '[[Category: Lorem ipsum]] AND [[Property:+]]', array(), '' ),
+			array( '[[Has Url::+]]', array( 'Has Url' ), '(includes subobjects)' ),
+			array( '[[Has quantity::+]]', array( 'Has quantity' ), '(includes subobjects)' ),
+			array( '[[Has Url::+]][[Category: Lorem ipsum]]', array( 'Has Url' ), '(does not include subobjects)' ),
+			array( '[[Has number::1111]] AND [[Has quantity::25 sqmi]]', array( 'Has number', 'Has quantity' ), '(only subobjects)' ),
+			array( '[[Has number::1111]] OR [[Has quantity::25 sqmi]]', array( 'Has number', 'Has quantity' ), '(only subobjects)' ),
+			array( '[[Has date::1 Jan 2014]]', array( 'Has date' ), '(does not include subobjects)' ),
+			array( '[[Has text::~Lorem ipsum dolor*]]', array( 'Has text' ), '(does not include subobjects)' ),
+		);
+
+		foreach ( $querySets as $setNumber => $querySet ) {
+			$this->createCombinedQuerySetBenchmark( $setNumber, $querySet[0], $querySet[1], $querySet[2] );
+		}
+
+		$setCount = count( $querySets );
+
+		$this->benchmarkRunner->addMessage( "\n" . "Benchmark summary (mean for query sets of $setCount, n = normalized over the result count)" );
+
+		foreach ( $this->benchmarkSummaryContainer as $key => $container ) {
+			$value = round( array_sum( $container ) / $setCount, 7 );
+			$this->benchmarkRunner->addMessage( " |- $value $key" );
+		}
+	}
+
+	private function createCombinedQuerySetBenchmark( $setNumber, $queryCondition, $printouts = array(), $comments = '' ) {
+
+		$this->benchmarkRunner->addMessage( "($setNumber) " . $queryCondition . ' ' . $comments );
+
+		$query = $this->createQuery( $queryCondition, Query::MODE_COUNT );
+		$this->benchmarkQueryResultSerialization( $this->benchmarkQueryExecution( $query ) );
+
+		$query = $this->createQuery( $queryCondition, Query::MODE_INSTANCES, $printouts );
+		$this->benchmarkQueryResultSerialization( $this->benchmarkQueryExecution( $query ) );
+	}
+
+	private function benchmarkQueryExecution( Query $query ) {
+
+		$repetitionTimeContainer = array();
+		$memoryBefore = memory_get_peak_usage( false );
+
+		for ( $i = 0; $i < $this->repetitionExecutionThreshold; $i++ ) {
+			$start = microtime( true );
+			$queryResult = $this->getStore()->getQueryResult( $query );
+			$repetitionTimeContainer[] = round( microtime( true ) - $start, 7 );
+		}
+
+		$memoryAfter = memory_get_peak_usage( false );
+		$memoryDiff  = $memoryAfter - $memoryBefore;
+
+		$sum  = array_sum( $repetitionTimeContainer );
+		$mean = $sum / $this->repetitionExecutionThreshold;
+
+		if ( $query->querymode === Query::MODE_COUNT ) {
+			$count = $queryResult instanceof QueryResult ? $queryResult->getCountValue() : $queryResult;
+			$columnCount = 0;
+			$mode  = 'C';
+			$this->benchmarkSummaryContainer['count'][] = $mean;
+		} else {
+			$count = $queryResult->getCount();
+			$columnCount = $queryResult->getColumnCount();
+			$mode  = 'I';
+			$this->benchmarkSummaryContainer['instance'][] = $mean;
+			$this->benchmarkSummaryContainer['instance (n)'][] = $mean / $count;
+		}
+
+		$this->benchmarkRunner->addMessage( " $mode- $mean (mean) $sum (total) (sec) resultCount: $count columnCount: $columnCount" );
+
+		if ( $this->showMemoryUsage ) {
+			$this->benchmarkRunner->addMessage( " +-- $memoryBefore (before) $memoryAfter (after) $memoryDiff (diff)" );
+		}
+
+		return $queryResult;
+	}
+
+	private function benchmarkQueryResultSerialization( $queryResult ) {
+
+		if ( !$queryResult instanceof QueryResult || $queryResult->getCount() == 0 ) {
+			$this->benchmarkRunner->addMessage( " S-- no serialization" );
+			return;
+		}
+
+		$repetitionTimeContainer = array();
+		$memoryBefore = memory_get_peak_usage( false );
+
+		for ( $i = 0; $i < $this->repetitionExecutionThreshold; $i++ ) {
+			$start = microtime( true );
+			$queryResult->toArray();
+			$repetitionTimeContainer[] = round( microtime( true ) - $start, 7 );
+		}
+
+		$memoryAfter = memory_get_peak_usage( false );
+		$memoryDiff  = $memoryAfter - $memoryBefore;
+
+		$sum  = array_sum( $repetitionTimeContainer );
+		$mean = $sum / $this->repetitionExecutionThreshold;
+
+		$this->benchmarkSummaryContainer['serialize'][] = $mean;
+		$this->benchmarkSummaryContainer['serialize (n)'][] = $mean / $queryResult->getCount();
+
+		$this->benchmarkRunner->addMessage( " S-- $mean (mean) $sum (total) (sec)" );
+
+		if ( $this->showMemoryUsage ) {
+			$this->benchmarkRunner->addMessage( " +--- $memoryBefore (before) $memoryAfter (after) $memoryDiff (diff)" );
+		}
+	}
+
+	private function createQuery( $queryString, $mode, array $printouts = array() ) {
+
+		$description = $this->queryParser->getQueryDescription( $queryString );
+
+		foreach ( $printouts as $printout ) {
+			$property = DIProperty::newFromUserLabel( $printout );
+
+			$propertyValue = new PropertyValue( '__pro' );
+			$propertyValue->setDataItem( $property );
+
+			$description->addPrintRequest(
+				new PrintRequest( PrintRequest::PRINT_PROP, null, $propertyValue )
+			);
+		}
+
+		$query = new Query(
+			$description,
+			false,
+			false
+		);
+
+		$query->setUnboundlimit( $this->queryLimit );
+		$query->setOffset( $this->queryOffset );
+		$query->querymode = $mode;
+
+		return $query;
+	}
+
+}

--- a/tests/phpunit/Benchmark/README.md
+++ b/tests/phpunit/Benchmark/README.md
@@ -1,0 +1,27 @@
+## Benchmark tests
+
+Benchmark tests use PHPUnit as integration platform and not always the right tool to represent a performance yardstick (depends on different environmental parameters such as hardware and software constraints which are outside of the control of the test environment) but can identify performance regressions among newly introduced features.
+
+- `QueryEngineBenchmarkTest` to perform tests on different query conditions
+- `JobQueueBenchmarkTest` to gather data on update and refresh jobs
+- `RebuildDataBenchmarkTest` to gather data on the rebuild data script
+
+Benchmarks are not performed in isolation and use the `MediaWiki` infrastucture as integral part to determine the overall performance during execution.
+
+### Use PHPUnit
+
+When running PHPUnit, use `--group semantic-mediawiki-benchmark` to indicate whether an annotated benchmark test is expected to perform an output.
+
+### Benchmark git changes
+
+When using `git`, it is relatively easy to run tests and see if a change introduces a significant regression or improvement in terms of performance over the existing `master` branch by comparing test results of the `master` against a `feature` branch.
+
+### Benchmark conditions
+
+`phpunit.xml.dist` can be used to adjust basic conditions of the benchmark environment. Available parameters are:
+- `benchmarkQueryRepetitionExecutionThreshold` a value that specifies how many repetitions should be made per query (is to increase the mean value computation accuracy)
+- `benchmarkQueryLimit` a value to specify the query limit
+- `benchmarkQueryOffset` a value to specify the query offset
+- `benchmarkPageCopyThreshold` a value to specify how many pages should be copied and made available during a test
+- `benchmarkShowMemoryUsage` setting to display memory usage during a benchmark test
+- `benchmarkReuseDatasets` indicating whether to reuse existing datasets during a benchmark run or not (to be used for large datasets like `benchmarkPageCopyThreshold` > 500 )

--- a/tests/phpunit/Benchmark/RebuildDataBenchmarkTest.php
+++ b/tests/phpunit/Benchmark/RebuildDataBenchmarkTest.php
@@ -1,0 +1,119 @@
+<?php
+
+namespace SMW\Tests\Benchmark;
+
+use SMW\Tests\MwDBaseUnitTestCase;
+use SMW\Tests\Util\MaintenanceRunner;
+
+use Title;
+
+/**
+ * @group semantic-mediawiki-benchmark
+ * @large
+ *
+ * @license GNU GPL v2+
+ * @since 2.1
+ *
+ * @author mwjames
+ */
+class RebuildDataBenchmarkTest extends MwDBaseUnitTestCase {
+
+	/**
+	 * @var array
+	 */
+	protected $databaseToBeExcluded = array( 'postgres', 'sqlite' );
+
+	/**
+	 * @var boolean
+	 */
+	protected $destroyDatabaseTablesOnEachRun = false;
+
+	/**
+	 * @var BenchmarkRunner
+	 */
+	private $benchmarkRunner = null;
+
+	private	$repetitionExecutionThreshold = 1;
+	private	$pageCopyThreshold = 50;
+	private $showMemoryUsage = false;
+	private $reuseDatasets = true;
+
+	protected function setUp() {
+		parent::setUp();
+
+		// Variable set using phpunit.xml
+		if ( isset( $GLOBALS['benchmarkPageCopyThreshold'] ) ) {
+			$this->pageCopyThreshold = $GLOBALS['benchmarkPageCopyThreshold'];
+		}
+
+		if ( isset( $GLOBALS['benchmarkShowMemoryUsage'] ) ) {
+			$this->showMemoryUsage = $GLOBALS['benchmarkShowMemoryUsage'];
+		}
+
+		if ( isset( $GLOBALS['benchmarkReuseDatasets'] ) ) {
+			$this->reuseDatasets = $GLOBALS['benchmarkReuseDatasets'];
+		}
+
+		$this->fullDelete = true;
+
+		$this->benchmarkRunner = new BenchmarkRunner();
+	}
+
+	/**
+	 * @test
+	 */
+	public function doBenchmark() {
+
+		$dataset = 'GenericLoremIpsumDataset.v1.xml';
+		$datasetFixture = Title::newFromText( 'Lorem ipsum' );
+
+		$this->benchmarkRunner->addMessage( "\n" . "Use $dataset on MW " . $GLOBALS['wgVersion'] . ', ' . $this->benchmarkRunner->getQueryEngine() );
+		$this->benchmarkRunner->addMessage( " |- repetitionExecutionThreshold: " . $this->repetitionExecutionThreshold );
+		$this->benchmarkRunner->addMessage( " |- pageCopyThreshold: " . $this->pageCopyThreshold );
+		$this->benchmarkRunner->addMessage( " |- showMemoryUsage: " . var_export( $this->showMemoryUsage, true ) );
+		$this->benchmarkRunner->addMessage( " |- reuseDatasets: " . var_export( $this->reuseDatasets, true ) );
+		$this->benchmarkRunner->addMessage( " |- fullDelete: " . var_export( $this->fullDelete, true ) );
+
+		if ( !$datasetFixture->exists() || !$this->reuseDatasets ) {
+			$this->benchmarkRunner->addMessage( "\n" . 'Data preparation benchmarks' );
+			$this->benchmarkRunner->doImportXmlDatasetFixture( __DIR__ . '/'. 'Fixtures' . '/' . $dataset );
+			$this->benchmarkRunner->copyPageContentFrom( $datasetFixture, $this->pageCopyThreshold );
+		}
+
+		$this->assertTrue( $datasetFixture->exists() );
+
+		$this->benchmarkRunner->addMessage( "\n" . 'RebuildData benchmarks' );
+		$this->createRebuildDataBenchmarks();
+
+		$this->benchmarkRunner->printMessages();
+	}
+
+	private function createRebuildDataBenchmarks() {
+
+		$maintenanceRunner = new MaintenanceRunner( 'SMW\Maintenance\RebuildData' );
+		$maintenanceRunner->setQuiet();
+		$maintenanceRunner->setOptions( array( 'f' => $this->fullDelete ) );
+
+		$repetitionTimeContainer = array();
+		$memoryBefore = memory_get_peak_usage( false );
+
+		for ( $i = 0; $i < $this->repetitionExecutionThreshold; $i++ ) {
+			$start = microtime( true );
+			$maintenanceRunner->run();
+			$repetitionTimeContainer[] = round( microtime( true ) - $start, 7 );
+		}
+
+		$memoryAfter = memory_get_peak_usage( false );
+		$memoryDiff  = $memoryAfter - $memoryBefore;
+
+		$sum  = array_sum( $repetitionTimeContainer );
+		$mean = $sum / $this->repetitionExecutionThreshold;
+
+		$this->benchmarkRunner->addMessage( " |- $mean (mean) $sum (total) (sec)" );
+
+		if ( $this->showMemoryUsage ) {
+			$this->benchmarkRunner->addMessage( " +-- $memoryBefore (before) $memoryAfter (after) $memoryDiff (diff)" );
+		}
+	}
+
+}

--- a/tests/phpunit/Util/PageReader.php
+++ b/tests/phpunit/Util/PageReader.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace SMW\Tests\Util;
+
+use Title;
+use TextContent;
+
+use UnexpectedValueException;
+
+/**
+ * @license GNU GPL v2+
+ * @since 2.1
+ *
+ * @author mwjames
+ */
+class PageReader {
+
+	/**
+	 * @var WikiPage
+	 */
+	private $page = null;
+
+	/**
+	 * @since 2.1
+	 *
+	 * @return WikiPage
+	 * @throws UnexpectedValueException
+	 */
+	public function getPage() {
+
+		if ( $this->page instanceof \WikiPage ) {
+			return $this->page;
+		}
+
+		throw new UnexpectedValueException( 'Expected a WikiPage instance, use createPage first' );
+	}
+
+	/**
+	 * @since 2.1
+	 *
+	 * @param Title $title
+	 *
+	 * @return text
+	 */
+	public function getContentAsText( Title $title ) {
+
+		$this->page = new \WikiPage( $title );
+
+		if ( method_exists( $this->page, 'getContent' ) ) {
+			$content = $this->page->getContent();
+
+			if ( $content instanceof TextContent ) {
+				return $content->getNativeData();
+			} else {
+				return '';
+			}
+		}
+
+		return $this->page->getText();
+	}
+
+}

--- a/tests/phpunit/Util/XmlImportRunner.php
+++ b/tests/phpunit/Util/XmlImportRunner.php
@@ -109,7 +109,7 @@ class XmlImportRunner {
 	/**
 	 * @return integer
 	 */
-	public function getImportTimeAsSeconds() {
+	public function getElapsedImportTimeInSeconds() {
 		return round( $this->importTime, 7 );
 	}
 


### PR DESCRIPTION
Benchmarks are written as PHPUnit to make use of MwDBaseUnitTestCase and take advantage of the infrastructure such as to import data via XML or use a cloned DB.

Group `semantic-mediawiki-benchmark` is generally excluded from unit testing but doing `php mw-phpunit-runner.php --group semantic-mediawiki-benchmark` will allow to run benchmarks individually that are assigned to the `semantic-mediawiki-benchmark` group.

Relates to #510 
