### PR TITLE
Travis to run benchmarks on HHVM/1000

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,8 @@ matrix:
       php: 5.4
     - env: DB=sqlite; MW=master; PHPUNIT=4.1.*
       php: hhvm-nightly
+    - env: DB=mysql; MW=master; PHPUNIT=4.1.*; TYPE=benchmark
+      php: hhvm-nightly
   exclude:
     - env: THENEEDFORTHIS=FAIL
   allow_failures:

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -58,7 +58,7 @@
        <var name="benchmarkQueryRepetitionExecutionThreshold" value="5"/>
        <var name="benchmarkQueryLimit" value="500"/>
        <var name="benchmarkQueryOffset" value="0"/>
-       <var name="benchmarkPageCopyThreshold" value="100"/>
+       <var name="benchmarkPageCopyThreshold" value="1000"/>
        <var name="benchmarkShowMemoryUsage" value="false"/>
        <var name="benchmarkReuseDatasets" value="true"/>
     </php>


### PR DESCRIPTION
Running benchmarks for a 1000 page load takes about 8 min to complete on Zend therefore using HHVM which just takes about 3 min.
