### PR TITLE
[WIP] Add verbose flag to refreshData and output the PrefixedDBKey

### DIFF
--- a/includes/src/SPARQLStore/SPARQLStore.php
+++ b/includes/src/SPARQLStore/SPARQLStore.php
@@ -341,8 +341,8 @@ class SPARQLStore extends Store {
 	 * @see Store::refreshData()
 	 * @since 1.8
 	 */
-	public function refreshData( &$index, $count, $namespaces = false, $usejobs = true ) {
-		return $this->baseStore->refreshData( $index, $count, $namespaces, $usejobs );
+	public function refreshData( &$index, $count, $namespaces = false, $usejobs = true, $verbose = false ) {
+		return $this->baseStore->refreshData( $index, $count, $namespaces, $usejobs, $verbose );
 	}
 
 	/**

--- a/includes/src/Store/Maintenance/DataRebuilder.php
+++ b/includes/src/Store/Maintenance/DataRebuilder.php
@@ -209,7 +209,7 @@ class DataRebuilder {
 
 			$this->reportMessage( "($this->rebuildCount) Processing ID " . $id . " ...\n", $this->verbose );
 
-			$this->store->refreshData( $id, 1, false, false );
+			$this->store->refreshData( $id, 1, false, false, $this->verbose );
 
 			if ( $this->delay !== false ) {
 				usleep( $this->delay );

--- a/includes/storage/SMW_Store.php
+++ b/includes/storage/SMW_Store.php
@@ -378,7 +378,7 @@ abstract class Store {
 	 *
 	 * @return float between 0 and 1 to indicate the overall progress of the refreshing
 	 */
-	public abstract function refreshData( &$index, $count, $namespaces = false, $usejobs = true );
+	public abstract function refreshData( &$index, $count, $namespaces = false, $usejobs = true, $verbose = false );
 
 	/**
 	 * Setup the store.

--- a/includes/storage/SQLStore/SMW_SQLStore3.php
+++ b/includes/storage/SQLStore/SMW_SQLStore3.php
@@ -408,8 +408,8 @@ class SMWSQLStore3 extends SMWStore {
 		return $this->getSetupHandler()->drop( $verbose );
 	}
 
-	public function refreshData( &$index, $count, $namespaces = false, $usejobs = true ) {
-		return $this->getSetupHandler()->refreshData( $index, $count, $namespaces, $usejobs );
+	public function refreshData( &$index, $count, $namespaces = false, $usejobs = true, $verbose = false ) {
+		return $this->getSetupHandler()->refreshData( $index, $count, $namespaces, $usejobs, $verbose );
 	}
 
 

--- a/includes/storage/SQLStore/SMW_SQLStore3_SetupHandlers.php
+++ b/includes/storage/SQLStore/SMW_SQLStore3_SetupHandlers.php
@@ -315,7 +315,7 @@ class SMWSQLStore3SetupHandlers implements MessageReporter {
 	 *
 	 * @return decimal between 0 and 1 to indicate the overall progress of the refreshing
 	 */
-	public function refreshData( &$index, $count, $namespaces = false, $usejobs = true ) {
+	public function refreshData( &$index, $count, $namespaces = false, $usejobs = true, $verbose = false ) {
 		$updatejobs = array();
 		$emptyrange = true; // was nothing done in this run?
 
@@ -398,6 +398,7 @@ class SMWSQLStore3SetupHandlers implements MessageReporter {
 			Job::batchInsert( $updatejobs );
 		} else {
 			foreach ( $updatejobs as $job ) {
+				$this->reportProgress( ' |-' . $job->getTitle()->getPrefixedDBKey() . "\n", $verbose );
 				$job->run();
 			}
 		}


### PR DESCRIPTION
Knowing the `PrefixedDBKey` on which an update occurs is more informative then displaying a title Id.

http://wikimedia.7.x6.nabble.com/rebuildData-script-says-the-content-format-CONTENT-FORMAT-TEXT-is-not-supported-for-this-content-mod-tp5035335.html