### PR TITLE
Add HtmlFormBuilder

### DIFF
--- a/includes/src/Application.php
+++ b/includes/src/Application.php
@@ -5,12 +5,15 @@ namespace SMW;
 use SMW\MediaWiki\Jobs\JobFactory;
 use SMW\Annotator\PropertyAnnotatorFactory;
 use SMW\MediaWiki\MagicWordFinder;
+use SMW\MediaWiki\HtmlFormBuilder;
+use SMW\MediaWiki\MessageBuilder;
 use SMW\MediaWiki\RedirectTargetFinder;
 use SMW\Factbox\FactboxBuilder;
 use SMW\Query\Profiler\QueryProfilerFactory;
 
 use ParserOutput;
 use Parser;
+use Language;
 use Title;
 
 /**
@@ -209,6 +212,25 @@ class Application {
 		return $this->builder->newObject( 'ContentParser', array(
 			'Title' => $title
 		) );
+	}
+
+	/**
+	 * @since 2.1
+	 *
+	 * @param Title $title
+	 * @param Language|null $language
+	 *
+	 * @return HtmlFormBuilder
+	 */
+	public function newHtmlFormBuilder( Title $title, Language $language = null ) {
+
+		if ( $language === null ) {
+			$language = $title->getPageLanguage();
+		}
+
+		$messageBuilder = new MessageBuilder( $language );
+
+		return new HtmlFormBuilder( $title, $messageBuilder );
 	}
 
 	private static function registerBuilder( DependencyBuilder $builder = null ) {

--- a/includes/src/Localizer.php
+++ b/includes/src/Localizer.php
@@ -57,6 +57,15 @@ class Localizer {
 	/**
 	 * @since 2.1
 	 *
+	 * @return Language
+	 */
+	public function getContentLanguage() {
+		return $this->contentLanguage;
+	}
+
+	/**
+	 * @since 2.1
+	 *
 	 * @param integer $namespaceId
 	 *
 	 * @return string

--- a/includes/src/MediaWiki/HtmlFormBuilder.php
+++ b/includes/src/MediaWiki/HtmlFormBuilder.php
@@ -1,0 +1,471 @@
+<?php
+
+namespace SMW\MediaWiki;
+
+use Xml;
+use Html;
+use Title;
+
+/**
+ * Convenience class to build a html form by using a fluid interface
+ *
+ * @par Example:
+ * @code
+ * $htmlFormBuilder = new HtmlFormBuilder( $this->title, new MessageBuilder() );
+ * $htmlFormBuilder
+ * 	->setName( 'Foo' )
+ * 	->setParameter( 'foo', 'someValue' )
+ * 	->addPaging( 10, 0, 5 )
+ * 	->addHorizontalRule()
+ * 	->addInputField( 'BarLabel', 'bar', 'someValue' )
+ * 	->addSubmitButton()
+ * 	->getForm();
+ * @endcode
+ *
+ * @license GNU GPL v2+
+ * @since   2.1
+ *
+ * @author mwjames
+ */
+class HtmlFormBuilder {
+
+	/**
+	 * @var Title
+	 */
+	private $title = null;
+
+	/**
+	 * @var MessageBuilder
+	 */
+	private $messageBuilder = null;
+
+	/**
+	 * @var array
+	 */
+	private $queryParameters = array();
+
+	/**
+	 * @var string
+	 */
+	private $name ='';
+
+	/**
+	 * @var string|boolean
+	 */
+	private $method = false;
+
+	/**
+	 * @var string|boolean
+	 */
+	private $useFieldset = false;
+
+	/**
+	 * @var string|boolean
+	 */
+	private $actionUrl = false;
+
+	/**
+	 * @var string
+	 */
+	private $content = array();
+
+	/**
+	 * @var string
+	 */
+	private $defaultPrefix = 'smw-form';
+
+	/**
+	 * @since 2.1
+	 *
+	 * @param Title $title
+	 * @param MessageBuilder $messageBuilder
+	 */
+	public function __construct( Title $title, MessageBuilder $messageBuilder ) {
+		$this->title = $title;
+		$this->messageBuilder = $messageBuilder;
+	}
+
+	/**
+	 * @since 2.1
+	 *
+	 * @return HtmlFormBuilder
+	 */
+	public function clear() {
+		$this->queryParameters = array();
+		$this->content = array();
+		$this->name = '';
+		$this->method = false;
+		$this->useFieldset = false;
+		$this->actionUrl = false;
+
+		return $this;
+	}
+
+	/**
+	 * @since 2.1
+	 *
+	 * @return MessageBuilder
+	 */
+	public function getMessageBuilder() {
+		return $this->messageBuilder;
+	}
+
+	/**
+	 * @since 2.1
+	 *
+	 * @param string $name
+	 *
+	 * @return HtmlFormBuilder
+	 */
+	public function setName( $name ) {
+		$this->name = $name;
+		return $this;
+	}
+
+	/**
+	 * @since 2.1
+	 *
+	 * @param string $actionUrl
+	 *
+	 * @return HtmlFormBuilder
+	 */
+	public function setActionUrl( $actionUrl ) {
+		$this->actionUrl = $actionUrl;
+		return $this;
+	}
+
+	/**
+	 * @since 2.1
+	 *
+	 * @return HtmlFormBuilder
+	 */
+	public function withFieldset() {
+		$this->useFieldset = true;
+		return $this;
+	}
+
+	/**
+	 * @since 2.1
+	 *
+	 * @param string $method
+	 *
+	 * @return HtmlFormBuilder
+	 */
+	public function setMethod( $method ) {
+		$this->method = strtolower( $method );
+		return $this;
+	}
+
+	/**
+	 * @since 2.1
+	 *
+	 * @param string $key
+	 * @param string $value
+	 *
+	 * @return HtmlFormBuilder
+	 */
+	public function addQueryParameter( $key, $value ) {
+		$this->queryParameters[ $key ] = $value;
+		return $this;
+	}
+
+	/**
+	 * @since 2.1
+	 *
+	 * @return array
+	 */
+	public function getQueryParameter() {
+		return $this->queryParameters;;
+	}
+
+	/**
+	 * @since 2.1
+	 *
+	 * @param string $description
+	 * @param array $attributes
+	 *
+	 * @return HtmlFormBuilder
+	 */
+	public function addParagraph( $text, $attributes = array() ) {
+
+		if ( $attributes === array() ) {
+			$attributes = array( 'class' => $this->defaultPrefix . '-paragraph' );
+		}
+
+		$this->content[] = Xml::tags( 'p', $attributes, $text );
+		return $this;
+	}
+
+	/**
+	 * @since 2.1
+	 *
+	 * @param array $attributes
+	 *
+	 * @return HtmlFormBuilder
+	 */
+	public function addHorizontalRule( $attributes = array() ) {
+
+		if ( $attributes === array() ) {
+			$attributes = array( 'class' => $this->defaultPrefix . '-horizontalrule' );
+		}
+
+		$this->content[] = Xml::tags( 'hr', $attributes, '' );
+		return $this;
+	}
+
+	/**
+	 * @since 2.1
+	 *
+	 * @param $level
+	 * @param $text
+	 *
+	 * @return HtmlFormBuilder
+	 */
+	public function addHeader( $level, $text ) {
+
+		$level = strtolower( $level );
+		$level = in_array( $level, array( 'h2', 'h3', 'h4' ) ) ? $level : 'h2';
+
+		$this->content[] = Html::element( $level, array(), $text );
+		return $this;
+	}
+
+	/**
+	 * @since 2.1
+	 *
+	 * @return HtmlFormBuilder
+	 */
+	public function addLineBreak() {
+		$this->content[] = Html::element( 'br', array(), '' );
+		return $this;
+	}
+
+	/**
+	 * @since 2.1
+	 *
+	 * @return HtmlFormBuilder
+	 */
+	public function addNonBreakingSpace() {
+		$this->content[] = '&nbsp;';
+		return $this;
+	}
+
+	/**
+	 * @since 2.1
+	 *
+	 * @param string|null $text
+	 *
+	 * @return HtmlFormBuilder
+	 */
+	public function addSubmitButton( $text ) {
+		$this->content[] = Xml::submitButton( $text );
+		return $this;
+	}
+
+	/**
+	 * @since 2.1
+	 *
+	 * @param string $label
+	 * @param string $inputName
+	 * @param string $inputValue
+	 * @param string|null $id
+	 * @param integer $length
+	 * @param string $placeholder
+	 *
+	 * @return HtmlFormBuilder
+	 */
+	public function addInputField( $label, $inputName, $inputValue, $id = null, $length = 20, $placeholder = '' ) {
+
+		if ( $id === null ) {
+			$id = $inputName;
+		}
+
+		$this->addQueryParameter( $inputName, $inputValue );
+
+		$this->content[] = Xml::inputLabel(
+			$label,
+			$inputName,
+			$id,
+			$length,
+			$inputValue,
+			array( 'class' => $this->defaultPrefix . '-input', 'placeholder' => $placeholder )
+		);
+
+		return $this;
+	}
+
+	/**
+	 * @since 2.1
+	 *
+	 * @param string $inputName
+	 * @param string $inputValue
+	 *
+	 * @return HtmlFormBuilder
+	 */
+	public function addHiddenField( $inputName, $inputValue ) {
+
+		$this->addQueryParameter( $inputName, $inputValue );
+
+		$this->content[] = Html::hidden( $inputName, $inputValue );
+		return $this;
+	}
+
+	/**
+	 * @since 2.1
+	 *
+	 * @param string $label
+	 * @param string $inputName
+	 * @param string $inputValue
+	 * @param array $options
+	 * @param string|null $id
+	 *
+	 * @return HtmlFormBuilder
+	 */
+	public function addOptionSelectList( $label, $inputName, $inputValue, $options, $id = null ) {
+
+		if ( $id === null ) {
+			$id = $inputName;
+		}
+
+		$this->addQueryParameter( $inputName, $inputValue );
+
+		ksort( $options );
+
+		$html = '';
+		$optionsHtml = array();
+
+		foreach ( $options as $internalId => $name ) {
+			$optionsHtml[] = Html::element(
+				'option', array(
+				//	'disabled' => false,
+					'value' => $internalId,
+					'selected' => $internalId == $inputValue,
+				), $name
+			);
+		}
+
+		$html .= Html::element( 'label', array( 'for' => $id ), $label ) . '&#160;';
+
+		$html .= Html::openElement(
+			'select',
+			array(
+				'name' => $inputName,
+				'id' => $id,
+				'class' => $this->defaultPrefix . '-select' ) ) . "\n" .
+			implode( "\n", $optionsHtml ) . "\n" .
+			Html::closeElement( 'select' );
+
+		$this->content[] = $html;
+		return $this;
+	}
+
+	/**
+	 * @since 2.1
+	 *
+	 * @param string $label
+	 * @param string $inputName
+	 * @param string $inputValue
+	 * @param boolean $isChecked
+	 * @param string|null $id
+	 *
+	 * @return HtmlFormBuilder
+	 */
+	public function addCheckbox( $label, $inputName, $inputValue, $isChecked = false, $id = null ) {
+
+		if ( $id === null ) {
+			$id = $inputName;
+		}
+
+		$this->addQueryParameter( $inputName, $inputValue );
+
+		$html = Xml::checkLabel(
+			$label,
+			$inputName,
+			$id,
+			$isChecked,
+			array(
+				'id' => $id,
+				'class' => $this->defaultPrefix . '-checkbox',
+				'value' => $inputValue ) + ( $isChecked ? array( 'checked' => 'checked' ) : array() )
+		);
+
+		$this->content[] = $html;
+		return $this;
+	}
+
+	/**
+	 * @since 2.1
+	 *
+	 * @note Encapsulate as closure to ensure that the build contains all query
+	 * parameters that are necessary to build the paging links
+	 *
+	 * @param integer $limit,
+	 * @param integer $offset,
+	 * @param integer $count,
+	 *
+	 * @return HtmlFormBuilder
+	 */
+	public function addPaging( $limit, $offset, $count ) {
+
+		$title = $this->title;
+
+		$this->content[] = function( $instance ) use ( $title, $limit, $offset, $count ) {
+
+			$resultCount = $instance->getMessageBuilder()
+				->getMessage( 'showingresults' )
+				->numParams( ( $count > $limit ? $count - 1 : $count ), $offset + 1 )
+				->parse();
+
+			$paging = $instance->getMessageBuilder()->prevNextToText(
+				$title,
+				$limit,
+				$offset,
+				$instance->getQueryParameter(),
+				$count < $limit
+			);
+
+			return Xml::tags( 'p', array(), $resultCount ) . Xml::tags( 'p', array(), $paging );
+		};
+
+		return $this;
+	}
+
+	/**
+	 * @since 2.1
+	 *
+	 * @return string
+	 */
+	public function getForm() {
+
+		$content = '';
+
+		foreach ( $this->content as $value ) {
+			$content .= is_callable( $value ) ? $value( $this ) : $value;
+		}
+
+		if ( $this->useFieldset ) {
+			$content = Xml::fieldset(
+				$this->messageBuilder->getMessage( $this->name )->text(),
+				$content,
+				array(
+					'id' => $this->defaultPrefix . "-fieldset-{$this->name}"
+				)
+			);
+		}
+
+		$form = Xml::tags( 'form', array(
+			'id'     => $this->defaultPrefix . "-{$this->name}",
+			'name'   => $this->name,
+			'method' => in_array( $this->method, array( 'get', 'post' ) ) ? $this->method : 'get',
+			'action' => htmlspecialchars( $this->actionUrl ? $this->actionUrl : $GLOBALS['wgScript'] )
+		), Html::hidden(
+			'title',
+			strtok( $this->title->getPrefixedText(), '/' )
+		) . $content );
+
+		$this->clear();
+
+		return $form;
+	}
+
+}

--- a/includes/src/MediaWiki/MessageBuilder.php
+++ b/includes/src/MediaWiki/MessageBuilder.php
@@ -1,0 +1,130 @@
+<?php
+
+namespace SMW\MediaWiki;
+
+use Message;
+use Language;
+use Title;
+use IContextSource;
+
+use RuntimeException;
+
+/**
+ * Convenience class to build language dependant messages and special text
+ * components and decrease depdencency on the Language object with SMW's code
+ * base
+ *
+ * @license GNU GPL v2+
+ * @since   2.1
+ *
+ * @author mwjames
+ */
+class MessageBuilder {
+
+	/**
+	 * @var Language
+	 */
+	private $language = null;
+
+	/**
+	 * @since 2.1
+	 *
+	 * @param Language|null $language
+	 */
+	public function __construct( Language $language = null ) {
+		$this->language = $language;
+	}
+
+	/**
+	 * @since 2.1
+	 *
+	 * @param Language $language
+	 *
+	 * @return MessageBuilder
+	 */
+	public function setLanguage( Language $language ) {
+		$this->language = $language;
+		return $this;
+	}
+
+	/**
+	 * @since 2.1
+	 *
+	 * @param IContextSource $context
+	 *
+	 * @return MessageBuilder
+	 */
+	public function setLanguageFromContext( IContextSource $context ) {
+		$this->language = $context->getLanguage();
+		return $this;
+	}
+
+	/**
+	 * @since 2.1
+	 *
+	 * @param mixed $number
+	 * @param boolean $useForSpecialNumbers set to true for numbers like dates
+	 *
+	 * @return string
+	 */
+	public function formatNumberToText( $number, $useForSpecialNumbers = false ) {
+		return $this->getLanguage()->formatNum( $number, $useForSpecialNumbers );
+	}
+
+	/**
+	 * @since 2.1
+	 *
+	 * @param array $list
+	 *
+	 * @return string
+	 */
+	public function listToCommaSeparatedText( array $list ) {
+		return $this->getLanguage()->listToText( $list );
+	}
+
+	/**
+	 * @since 2.1
+	 *
+	 * @param Title $title,
+	 * @param integer $offset,
+	 * @param integer $offset,
+	 * @param array $query,
+	 * @param boolean|null $isAtTheEnd
+	 *
+	 * @return string
+	 */
+	public function prevNextToText( Title $title, $limit, $offset, array $query, $isAtTheEnd ) {
+		return $this->getLanguage()->viewPrevNext( $title, $offset,$limit, $query, $isAtTheEnd );
+	}
+
+	/**
+	 * @since 2.1
+	 *
+	 * @param string $key
+	 *
+	 * @return Message
+	 */
+	public function getMessage( $key ) {
+
+		$params = func_get_args();
+		array_shift( $params );
+
+		if ( isset( $params[0] ) && is_array( $params[0] ) ) {
+			$params = $params[0];
+		}
+
+		$message = new Message( $key, $params );
+
+		return $message->inLanguage( $this->getLanguage() );
+	}
+
+	private function getLanguage() {
+
+		if ( $this->language instanceOf Language ) {
+			return $this->language;
+		}
+
+		throw new RuntimeException( 'Expected a valid language object' );
+	}
+
+}

--- a/tests/phpunit/includes/ApplicationTest.php
+++ b/tests/phpunit/includes/ApplicationTest.php
@@ -147,4 +147,25 @@ class ApplicationTest extends \PHPUnit_Framework_TestCase {
 		);
 	}
 
+	public function testCanConstructHtmlFormBuilder() {
+
+		$title = $this->getMockBuilder( '\Title' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$this->assertInstanceOf(
+			'\SMW\MediaWiki\HtmlFormBuilder',
+			$this->application->newHtmlFormBuilder( $title )
+		);
+
+		$language = $this->getMockBuilder( '\Language' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$this->assertInstanceOf(
+			'\SMW\MediaWiki\HtmlFormBuilder',
+			$this->application->newHtmlFormBuilder( $title, $language )
+		);
+	}
+
 }

--- a/tests/phpunit/includes/LocalizerTest.php
+++ b/tests/phpunit/includes/LocalizerTest.php
@@ -9,7 +9,6 @@ use Language;
 /**
  * @covers \SMW\Localizer
  *
- *
  * @group SMW
  * @group SMWExtension
  *
@@ -35,6 +34,27 @@ class LocalizerTest extends \PHPUnit_Framework_TestCase {
 			'\SMW\Localizer',
 			Localizer::getInstance()
 		);
+	}
+
+	public function testGetContentLanguage() {
+
+		$language = $this->getMockBuilder( '\Language' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$instance = new Localizer( $language );
+
+		$this->assertSame(
+			$language,
+			$instance->getContentLanguage()
+		);
+
+		$this->assertSame(
+			$GLOBALS['wgContLang'],
+			Localizer::getInstance()->getContentLanguage()
+		);
+
+		Localizer::clear();
 	}
 
 	public function testNamespaceTextById() {

--- a/tests/phpunit/includes/MediaWiki/HtmlFormBuilderTest.php
+++ b/tests/phpunit/includes/MediaWiki/HtmlFormBuilderTest.php
@@ -1,0 +1,227 @@
+<?php
+
+namespace SMW\Tests\MediaWiki;
+
+use SMW\Tests\Util\UtilityFactory;
+use SMW\MediaWiki\HtmlFormBuilder;
+
+/**
+ * @covers \SMW\MediaWiki\HtmlFormBuilder
+ *
+ * @group SMW
+ * @group SMWExtension
+ *
+ * @license GNU GPL v2+
+ * @since 2.1
+ *
+ * @author mwjames
+ */
+class HtmlFormBuilderTest extends \PHPUnit_Framework_TestCase {
+
+	private $stringValidator;
+
+	protected function setUp() {
+		parent::setUp();
+
+		$this->stringValidator = UtilityFactory::getInstance()->newValidatorFactory()->newStringValidator();
+	}
+
+	public function testCanConstruct() {
+
+		$title = $this->getMockBuilder( '\Title' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$messageBuilder = $this->getMockBuilder( '\SMW\MediaWiki\MessageBuilder' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$this->assertInstanceOf(
+			'\SMW\MediaWiki\HtmlFormBuilder',
+			new HtmlFormBuilder( $title, $messageBuilder )
+		);
+	}
+
+	public function testGetMessageBuilder() {
+
+		$title = $this->getMockBuilder( '\Title' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$messageBuilder = $this->getMockBuilder( '\SMW\MediaWiki\MessageBuilder' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$instance = new HtmlFormBuilder( $title, $messageBuilder );
+
+		$this->assertSame(
+			$messageBuilder,
+			$instance->getMessageBuilder()
+		);
+	}
+
+	public function testGetForm() {
+
+		$title = $this->getMockBuilder( '\Title' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$message = $this->getMockBuilder( '\Message' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$message->expects( $this->any() )
+			->method( 'title' )
+			->will( $this->returnSelf() );
+
+		$message->expects( $this->any() )
+			->method( 'numParams' )
+			->will( $this->returnSelf() );
+
+		$message->expects( $this->any() )
+			->method( 'rawParams' )
+			->will( $this->returnSelf() );
+
+		$message->expects( $this->any() )
+			->method( 'text' )
+			->will( $this->returnValue( 'SomeText' ) );
+
+		$messageBuilder = $this->getMockBuilder( '\SMW\MediaWiki\MessageBuilder' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$messageBuilder->expects( $this->any() )
+			->method( 'getMessage' )
+			->will( $this->returnValue( $message ) );
+
+		$instance = new HtmlFormBuilder( $title, $messageBuilder );
+
+		$instance
+			->setName( 'SomeForm' )
+			->withFieldset()
+			->addParagraph( 'SomeDescription' )
+			->addQueryParameter( 'SomeQueryParameter', 'SomeQueryValue' )
+			->addPaging( 10, 0, 5 )
+			->addHorizontalRule()
+			->addInputField( 'SomeInputFieldLabel', 'foo', 'Foo', 'FooId', 333 )
+			->addLineBreak()
+			->addNonBreakingSpace()
+			->addInputField( 'AnotherInputFieldLabel', 'AnotherInputFieldName', 'AnotherInputFieldValue' )
+			->addSubmitButton( 'FindFoo' );
+
+		$expected = array(
+			'form id="smw-form-SomeForm" name="SomeForm" method="get"',
+			'<p class="smw-form-paragraph">SomeDescription</p>',
+			'input name="foo" size="333" value="Foo" id="FooId"',
+			'input name="AnotherInputFieldName" size="20" value="AnotherInputFieldValue" id="AnotherInputFieldName"',
+			'input type="submit" value="FindFoo"',
+			'<br />&nbsp;'
+		);
+
+		$this->stringValidator->assertThatStringContains(
+			$expected,
+			$instance->getForm()
+		);
+	}
+
+	public function testOptionsSelecList() {
+
+		$title = $this->getMockBuilder( '\Title' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$message = $this->getMockBuilder( '\Message' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$message->expects( $this->any() )
+			->method( 'text' )
+			->will( $this->returnValue( 'SomeText' ) );
+
+		$messageBuilder = $this->getMockBuilder( '\SMW\MediaWiki\MessageBuilder' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$messageBuilder->expects( $this->any() )
+			->method( 'getMessage' )
+			->will( $this->returnValue( $message ) );
+
+		$instance = new HtmlFormBuilder( $title, $messageBuilder );
+
+		$instance
+			->setName( 'optionsSelecListForm' )
+			->withFieldset()
+			->setMethod( 'isNeithergetNorPostMethodUseDefaultInstead' )
+			->addOptionSelectList(
+				'optionlistLabel',
+				'optionlistName',
+				'b',
+				array( 'f' => 'foo', 'b' =>'bar' ),
+				'optionslistId');
+
+		$expected = array(
+			'form id="smw-form-optionsSelecListForm" name="optionsSelecListForm" method="get"',
+			'<fieldset id="smw-form-fieldset-optionsSelecListForm">',
+			'<label for="optionslistId">optionlistLabel</label>&#160;',
+			'<select name="optionlistName" id="optionslistId" class="smw-form-select">',
+			'<option value="b" selected="">bar</option>',
+			'<option value="f">foo</option>'
+		);
+
+		$this->stringValidator->assertThatStringContains(
+			$expected,
+			$instance->getForm()
+		);
+	}
+
+	public function testCheckbox() {
+
+		$title = $this->getMockBuilder( '\Title' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$message = $this->getMockBuilder( '\Message' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$message->expects( $this->any() )
+			->method( 'text' )
+			->will( $this->returnValue( 'SomeText' ) );
+
+		$messageBuilder = $this->getMockBuilder( '\SMW\MediaWiki\MessageBuilder' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$messageBuilder->expects( $this->any() )
+			->method( 'getMessage' )
+			->will( $this->returnValue( $message ) );
+
+		$instance = new HtmlFormBuilder( $title, $messageBuilder );
+
+		$instance
+			->setName( 'checkboxForm' )
+			->addHeader( 'invalidLevel', 'someHeader' )
+			->withFieldset()
+			->setMethod( 'post' )
+			->setActionUrl( 'http://example.org/foo' )
+			->addCheckbox(
+				'checkboxLabel',
+				'checkboxName',
+				true,
+				'checkBoxId' );
+
+		$expected = array(
+			'<form id="smw-form-checkboxForm" name="checkboxForm" method="post" action="http://example.org/foo">',
+			'<h2>someHeader</h2>',
+			'<fieldset id="smw-form-fieldset-checkboxForm">',
+			'<input name="checkboxName" type="checkbox" value="1" checked="checked" id="checkboxName" class="smw-form-checkbox" />',
+			'<label for="checkboxName" class="smw-form-checkbox">checkboxLabel</label>'
+		);
+
+		$this->stringValidator->assertThatStringContains(
+			$expected,
+			$instance->getForm()
+		);
+	}
+
+}

--- a/tests/phpunit/includes/MediaWiki/MessageBuilderTest.php
+++ b/tests/phpunit/includes/MediaWiki/MessageBuilderTest.php
@@ -1,0 +1,111 @@
+<?php
+
+namespace SMW\Tests\MediaWiki;
+
+use SMW\MediaWiki\MessageBuilder;
+
+/**
+ * @covers \SMW\MediaWiki\MessageBuilder
+ *
+ * @group SMW
+ * @group SMWExtension
+ *
+ * @license GNU GPL v2+
+ * @since 2.1
+ *
+ * @author mwjames
+ */
+class MessageBuilderTest extends \PHPUnit_Framework_TestCase {
+
+	public function testCanConstruct() {
+
+		$language = $this->getMockBuilder( '\Language' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$this->assertInstanceOf(
+			'\SMW\MediaWiki\MessageBuilder',
+			new MessageBuilder( $language )
+		);
+	}
+
+	public function testFormatNumberToText() {
+
+		$language = $this->getMockBuilder( '\Language' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$language->expects( $this->once() )
+			->method( 'formatNum' );
+
+		$instance = new MessageBuilder();
+
+		$instance
+			->setLanguage( $language )
+			->formatNumberToText( 42 );
+	}
+
+	public function testListToCommaSeparatedText() {
+
+		$language = $this->getMockBuilder( '\Language' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$language->expects( $this->once() )
+			->method( 'listToText' );
+
+		$context = $this->getMockBuilder( '\IContextSource' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$context->expects( $this->once() )
+			->method( 'getLanguage' )
+			->will( $this->returnValue( $language ) );
+
+		$instance = new MessageBuilder();
+
+		$instance
+			->setLanguageFromContext( $context )
+			->listToCommaSeparatedText( array( 'a', 'b' ) );
+	}
+
+	public function testPrevNextToText() {
+
+		$title = $this->getMockBuilder( '\Title' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$language = $this->getMockBuilder( '\Language' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$language->expects( $this->once() )
+			->method( 'viewPrevNext' );
+
+		$instance = new MessageBuilder( $language );
+		$instance->prevNextToText( $title, 20, 0, array(), false );
+	}
+
+	public function testGetForm() {
+
+		$language = $this->getMockBuilder( '\Language' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$instance = new MessageBuilder( $language );
+
+		$this->assertInstanceOf(
+			'\Message',
+			$instance->getMessage( 'properties' )
+		);
+	}
+
+	public function testNullLanguageThrowsException() {
+
+		$instance = new MessageBuilder();
+
+		$this->setExpectedException( 'RuntimeException' );
+		$instance->getMessage( 'properties' );
+	}
+
+}


### PR DESCRIPTION
Relates to #537 

`HtmlFormBuilder` to easily create a form using a fluid interface and avoid
things like `'<form name="searchbyproperty" action="' . '" method="get">' . "\n" . ...` within a script to avoid manual templates.

``` php
$html = $htmlFormBuilder
    ->setName( 'searchbyproperty' )
    ->withFieldadd()
    ->addParagraph( $resultMessage )
    ->addPaging(
        $this->queryOptions->limit,
        $this->queryOptions->offadd,
        $resultCount )
    ->addHorizontalRule()
    ->addInputField(
        $this->messageBuilder->getMessage( 'smw_sbv_property' )->text(),
        'property',
        $this->queryOptions->propertyString,
        'smw-property-input' )
    ->addNonBreakingSpace()
    ->addInputField(
        $this->messageBuilder->getMessage( 'smw_sbv_value' )->text(),
        'value',
        $this->queryOptions->valueString,
        'smw-value-input' )
    ->addNonBreakingSpace()
    ->addSubmitButton( $this->messageBuilder->getMessage( 'smw_sbv_submit' )->text() )
    ->getForm();
```

``` php
$html = $this->htmlFormBuilder
    ->setName( 'buildtables' )
    ->addMethod( 'post' )
    ->addParagraph( $this->messageBuilder->getMessage( 'smw_smwadmin_docu' )->text() )
    ->addHiddenField( 'action', 'updatetables' )
    ->addHeader( 'h2', $this->messageBuilder->getMessage( 'smw_smwadmin_db' )->text() )
    ->addParagraph( $this->messageBuilder->getMessage( 'smw_smwadmin_dbdocu' )->text() )
    ->addParagraph( $this->messageBuilder->getMessage( 'smw_smwadmin_permissionswarn' )->text() )
    ->addHiddenField( 'udsure', 'yes' )
    ->addSubmitButton( $this->messageBuilder->getMessage( 'smw_smwadmin_dbbutton' )->text() )
    ->getForm();
```

The final form (as `string` representation) is generated when `getForm` is called and by doing so all existing parameters and variables are reset to a default value.
