### PR TITLE
Add SMW_CONCEPT_QUERY to enable concept in concepts (Bug 44467)

### DIFF
--- a/SemanticMediaWiki.settings.php
+++ b/SemanticMediaWiki.settings.php
@@ -353,9 +353,9 @@ $GLOBALS['smwgQConceptCaching'] = CONCEPT_CACHE_HARD; // Which concepts should b
 $GLOBALS['smwgQConceptMaxSize'] = 20; // Same as $smwgQMaxSize, but for concepts
 $GLOBALS['smwgQConceptMaxDepth'] = 8; // Same as $smwgQMaxDepth, but for concepts
 
-// Same as $smwgQFeatures but for concepts (note: using concepts in concepts is currently not supported!)
+// Same as $smwgQFeatures but for concepts
 $GLOBALS['smwgQConceptFeatures'] = SMW_PROPERTY_QUERY | SMW_CATEGORY_QUERY | SMW_NAMESPACE_QUERY |
-                        SMW_CONJUNCTION_QUERY | SMW_DISJUNCTION_QUERY;
+                        SMW_CONJUNCTION_QUERY | SMW_DISJUNCTION_QUERY | SMW_CONCEPT_QUERY;
 
 // Cache life time in minutes. If a concept cache exists but is older than
 // this, SMW tries to recompute it, and will only use the cache if this is not

--- a/includes/storage/SQLStore/SMW_SQLStore3_Queries.php
+++ b/includes/storage/SQLStore/SMW_SQLStore3_Queries.php
@@ -155,7 +155,7 @@ class SMWSQLStore3QueryEngine {
 			$this->executeQueries( $this->m_queries[$qid] ); // execute query tree, resolve all dependencies
 			$qobj = $this->m_queries[$qid];
 
-			if ( $qobj->joinfield === '' ) {
+			if ( $qobj->joinfield === '' || $qobj->jointable === '' ) {
 				return;
 			}
 

--- a/tests/phpunit/Integration/Query/ConceptQueryDBIntegrationTest.php
+++ b/tests/phpunit/Integration/Query/ConceptQueryDBIntegrationTest.php
@@ -1,0 +1,205 @@
+<?php
+
+namespace SMW\Tests\Integration\Query;
+
+use SMW\Tests\MwDBaseUnitTestCase;
+use SMW\Tests\Util\UtilityFactory;
+
+use SMW\Query\Language\Description;
+use SMW\Query\Language\ConceptDescription;
+use SMW\Query\Language\SomeProperty;
+use SMW\Query\Language\ThingDescription;
+use SMW\Query\Language\ValueDescription;
+use SMW\Query\Language\Conjunction;
+
+use SMW\DIWikiPage;
+use SMW\DIProperty;
+use SMW\DIConcept;
+
+use SMWQuery as Query;
+
+/**
+ * @group SMW
+ * @group SMWExtension
+ * @group semantic-mediawiki-integration
+ * @group semantic-mediawiki-query
+ * @group mediawiki-database
+ * @group medium
+ *
+ * @license GNU GPL v2+
+ * @since 2.1
+ *
+ * @author mwjames
+ */
+class ConceptQueryDBIntegrationTest extends MwDBaseUnitTestCase {
+
+	protected $databaseToBeExcluded = array( 'sqlite', 'postgres' );
+	protected $storesToBeExcluded = array( 'SMW\SPARQLStore\SPARQLStore' );
+
+	private $fixturesProvider;
+	private $subjectsToBePurged = array();
+
+	private $semanticDataFactory;
+
+	protected function setUp() {
+		parent::setUp();
+
+		$this->semanticDataFactory = UtilityFactory::getInstance()->newSemanticDataFactory();
+
+		$this->fixturesProvider = UtilityFactory::getInstance()->newFixturesFactory()->newFixturesProvider();
+		$this->fixturesProvider->setupDependencies( $this->getStore() );
+	}
+
+	protected function tearDown() {
+
+		$fixturesCleaner = UtilityFactory::getInstance()->newFixturesFactory()->newFixturesCleaner();
+		$fixturesCleaner
+			->purgeAllKnownFacts()
+			->purgeSubjects( $this->subjectsToBePurged );
+
+		parent::tearDown();
+	}
+
+	public function testToCombineDifferentConceptsIntoConjunctiveConceptQuery() {
+
+		$this->getStore()->updateData(
+			$this->fixturesProvider->getFactsheet( 'Berlin' )->asEntity()
+		);
+
+		$this->getStore()->updateData(
+			$this->fixturesProvider->getFactsheet( 'Paris' )->asEntity()
+		);
+
+		/**
+		 * @query {{#concept: [[Population::+]] }}
+		 */
+		$containsAllPopulationPropertyConcept = new DIWikiPage( 'ContainsAllPopulationProperty', SMW_NS_CONCEPT );
+
+		$populationProperty = $this->fixturesProvider->getProperty( 'Population' );
+
+		$description = new SomeProperty(
+			$populationProperty,
+			new ThingDescription()
+		);
+
+		$this->createConceptFor(
+			$containsAllPopulationPropertyConcept,
+			$description,
+			'Query for all subjects that contain a population property'
+		);
+
+		/**
+		 * @query {{#concept: [[Area::SomeDistinctValue]] }}
+		 */
+		$areaValue = $this->fixturesProvider->getFactsheet( 'Berlin' )->getAreaValue();
+
+		$containsOnlySpecificAreaValueConcept = new DIWikiPage( 'ContainsOnlySpecificAreaValue', SMW_NS_CONCEPT );
+
+		$description = new SomeProperty(
+			$areaValue->getProperty(),
+			new ValueDescription( $areaValue->getDataItem(), null, SMW_CMP_EQ )
+		);
+
+		$this->createConceptFor(
+			$containsOnlySpecificAreaValueConcept,
+			$description,
+			'Query for a specific area value'
+		);
+
+		/**
+		 * @query {{#concept: [[Concept::ContainsAllPopulationProperty]][[Concept::ContainsOnlySpecificAreaValue]] }}
+		 */
+		$combinedConceptQueryConcept = new DIWikiPage( 'CombinedConceptQuery', SMW_NS_CONCEPT );
+
+		$description = new Conjunction();
+		$description->addDescription( new ConceptDescription( $containsAllPopulationPropertyConcept ) );
+		$description->addDescription( new ConceptDescription( $containsOnlySpecificAreaValueConcept ) );
+
+		$this->createConceptFor(
+			$combinedConceptQueryConcept,
+			$description,
+			'Combined concept query'
+		);
+
+		$this->assertConceptQueryCount(
+			6,
+			$containsAllPopulationPropertyConcept
+		);
+
+		$this->assertConceptQueryCount(
+			2,
+			$containsOnlySpecificAreaValueConcept
+		);
+
+		$this->assertConceptQueryCount(
+			2,
+			$combinedConceptQueryConcept
+		);
+
+		$this->getStore()->refreshConceptCache( $containsAllPopulationPropertyConcept->getTitle() );
+		$this->getStore()->refreshConceptCache( $containsOnlySpecificAreaValueConcept->getTitle() );
+		$this->getStore()->refreshConceptCache( $combinedConceptQueryConcept->getTitle() );
+
+		$this->assertEquals(
+			6,
+			$this->getStore()->getConceptCacheStatus( $containsAllPopulationPropertyConcept )->getCacheCount()
+		);
+
+		$this->assertEquals(
+			2,
+			$this->getStore()->getConceptCacheStatus( $containsOnlySpecificAreaValueConcept )->getCacheCount()
+		);
+
+		$this->assertEquals(
+			2,
+			$this->getStore()->getConceptCacheStatus( $combinedConceptQueryConcept )->getCacheCount()
+		);
+	}
+
+	private function createConceptFor( DIWikiPage $concept, Description $description, $documentation = '' ) {
+
+		$this->subjectsToBePurged[] = $concept;
+
+		$semanticData = $this->semanticDataFactory->setSubject( $concept )->newEmptySemanticData();
+
+		$query = new Query(
+			$description,
+			false,
+			true
+		);
+
+		$semanticData->addPropertyObjectValue(
+			new DIProperty( '_CONC' ),
+			new DIConcept(
+				$query->getDescription()->getQueryString(),
+				$documentation,
+				$query->getDescription()->getQueryFeatures(),
+				$query->getDescription()->getSize(),
+				$query->getDescription()->getDepth()
+			)
+		);
+
+		$this->getStore()->updateData( $semanticData );
+	}
+
+	private function assertConceptQueryCount( $expected, DIWikiPage $concept ) {
+
+		$description = new ConceptDescription( $concept );
+
+		$query = new Query(
+			$description,
+			false,
+			true
+		);
+
+		$query->querymode = Query::MODE_INSTANCES;
+
+		$queryResult = $this->getStore()->getQueryResult( $query );
+
+		$this->assertCount(
+			$expected,
+			$queryResult->getResults()
+		);
+	}
+
+}


### PR DESCRIPTION
- https://bugzilla.wikimedia.org/show_bug.cgi?id=44467
- https://bugzilla.wikimedia.org/show_bug.cgi?id=15316
## Integration test
- Create `Concept:ContainsAllPopulationProperty` with `{{#concept: [[Population::+]] }}`
- Create `Concept:ContainsOnlySpecificAreaValue` with `{{#concept: [[Area::SomeDistinctValue]] }}`
- Create `Concept:CombinedConceptQuery` with  `{{#concept: [[Concept::ContainsAllPopulationProperty]][[Concept::ContainsOnlySpecificAreaValue]] }}`
