### PR TITLE
Add QueryResultSelection hooks

### DIFF
--- a/docs/technical/hooks.md
+++ b/docs/technical/hooks.md
@@ -1,17 +1,19 @@
-This document contains details about event handlers (also known as [Hooks][hooks]) provided by Semantic MediaWiki to enable users to extent and integrate custom specific solutions. Implementing a hook should be made in consideration of the expected performance impact for a front-end (additional DB read/write etc.) and/or back-end (prolonged job backlog etc.) process.
+This document contains details about event handlers (also known as [Hooks][hooks]) provided by Semantic MediaWiki to enable users to extent and integrate custom specific solutions.
+
+Implementing a hook should be made in consideration of the expected performance impact for the front-end (additional DB read/write transactions etc.) and/or the back-end (prolonged job backlog etc.) process.
 
 ### SMW::Factbox::showContent
-<code>SMW::Factbox::showContent</code>(since SMW 1.9 resides in <code>\SMW\Factbox</code>) enables to replace or amend text elements shown in the Factbox. Information can be added or redacted but only existing data for an entity (page) is provided which means this hook can not be used to alter the SemanticData container itself.
+`SMW::Factbox::showContent` enables to replace or amend text elements shown in the Factbox. Information can be added or redacted but only existing data for an entity (page) is provided which means this hook can not be used to alter the SemanticData container itself.
 
-In cases where the Factbox content is cached (<code>$smwgFactboxUseCache</code> is set true and only after a revision change, is being re-build and successively re-cached) it is suggested to disable the <code>$smwgFactboxUseCache</code> in order for custom code to be executed on each request.
+If `$smwgFactboxUseCache` is set `TRUE`, content is retrieved from cache without executing the hook and only after a new revision is available, the Factbox is being re-build and re-cached. If you want to allow that custom code to being executed on each request it is suggested to set the `$smwgFactboxUseCache` to `FALSE`.
 
 ```php
-$GLOBALS['wgHooks']['SMW::Factbox::showContent'][] = function ( &$text, \SMW\SemanticData $semanticData ) {
+$GLOBALS['wgHooks']['SMW::Factbox::showContent'][] = function ( &$text, SemanticData $semanticData ) {
 
 	// Access to the Page language can be achieved by using
 	$language = $semanticData->getSubject()->getTitle()->getPageLanguage()
 
-	// Amend information, formatted as string
+	// Add formatted information as string
 	$text = ...;
 
 	// If returned false, only custom information will be displayed
@@ -21,22 +23,22 @@ $GLOBALS['wgHooks']['SMW::Factbox::showContent'][] = function ( &$text, \SMW\Sem
 	return true;
 };
 ```
-The use of <code>smwShowFactbox</code> was deprecated with SMW 1.9.
+Available since SMW 1.9 where the use of `smwShowFactbox` was deprecated with 1.9.
 
-### SMW::Dispatcher::updateJobs (SMW 1.9)
-<code>SMW::Dispatcher::updateJobs</code> (<code>\SMW\UpdateDispatcherJob</code>) enables to add additional update jobs for a property and its related subjects.
+### SMW::Dispatcher::updateJobs
+`SMW::Dispatcher::updateJobs` enables to add additional update jobs for a property and its related subjects.
 
 ```php
-$GLOBALS['wgHooks']['SMW::Dispatcher::updateJobs'][] = function ( \SMW\DIProperty $property, &$jobs ) {
+$GLOBALS['wgHooks']['SMW::Dispatcher::updateJobs'][] = function ( DIProperty $property, &$jobs ) {
 
 	$jobs[] = new UpdateJob( ... );
 
 	return true;
 };
 ```
-Before 1.9 it was called smwUpdatePropertySubjects with a different interface.
+Available since SMW 1.9 and before 1.9 it was called smwUpdatePropertySubjects with a different interface.
 
-### SMW::DataType::initTypes (SMW 1.9)
+### SMW::DataType::initTypes
 Adds support for additional DataTypes.
 
 ```php
@@ -47,14 +49,39 @@ $GLOBALS['wgHooks']['SMW::DataType::initTypes'][] = function () {
 	return true;
 };
 ```
-Before 1.9 it was called smwInitDatatypes.
+Available since SMW 1.9 and before 1.9 it was called smwInitDatatypes.
 
-## SQLStore
-### SMW::SQLStore::updatePropertyTableDefinitions (SMW 1.9)
-<code>SMW::SQLStore::updatePropertyTableDefinitions</code>(<code>\SMW\SQLStore\PropertyTableDefinitionBuilder</code>) is called during initialization of available property table definitions
+## Store
+
+### SMW::Store::selectQueryResultBefore
+
+Enables to return a `QueryResult` object before the standard selection process is executed and to suppress the standard selection process completely return `FALSE`.
 
 ```php
-$GLOBALS['wgHooks']['SMW::SQLStore::updatePropertyTableDefinitions'][] = function ( \SMW\SQLStore\TableDefinition &$tableDefinitions ) {
+$GLOBALS['wgHooks']['SMW::Store::selectQueryResultBefore'][] = function ( Store $store, Query $query, QueryResult &$result ) {
+
+	return true or false;
+};
+```
+Available since SMW 2.1.
+
+### SMW::Store::selectQueryResultAfter
+
+```php
+$GLOBALS['wgHooks']['SMW::Store::selectQueryResultAfter'][] = function ( Store $store, QueryResult &$result ) {
+
+	// A return value has no explicit meaning for the following processing
+};
+```
+Available since SMW 2.1.
+
+## SQLStore
+
+### SMW::SQLStore::updatePropertyTableDefinitions
+`SMW::SQLStore::updatePropertyTableDefinitions` is called during initialization of available property table definitions.
+
+```php
+$GLOBALS['wgHooks']['SMW::SQLStore::updatePropertyTableDefinitions'][] = function ( TableDefinition &$tableDefinitions ) {
 
 	// Amend information
 	$tableDefinitions[] = new TableDefinition( ... );
@@ -62,24 +89,26 @@ $GLOBALS['wgHooks']['SMW::SQLStore::updatePropertyTableDefinitions'][] = functio
 	return true;
 };
 ```
+Available since SMW 1.9.
 
-## List of available hooks
+## Other available hooks
+
 Subsequent hooks should be renamed to follow a common naming practice that help distinguish them from other hook providers. In any case this list needs details and examples.
 
-* <code>\SMW\DIProperty</code>, smwInitProperties (SMW::DataItem::initProperties)
-* <code>\SMW\DataValueFactory</code>, smwInitDatatypes (SMW::DataValue::initDataTypes)
-* <code>SMWExportController</code>, smwAddToRDFExport
-* <code>SMWParamFormat</code>, SMWResultFormat
-* <code>\SMW\Store</code>, SMWStore::updateDataBefore (SMW::Store::updateDataBefore)
-* <code>\SMW\Store</code>, SMWStore::updateDataAfter (SMW::Store::updateDataAfter)
-* <code>\SMW\Store</code>, smwInitializeTables (SMW::Store::initTables)
-* <code>SMWSQLStore3SetupHandlers</code>, SMWCustomSQLStoreFieldType
-* <code>SMWSQLStore3SetupHandlers</code>, smwRefreshDataJobs (SMW::SQLStore::updateJobs)
-* <code>SMWSQLStore3Writers</code>, SMWSQLStore3::deleteSubjectBefore (SMW::SQLStore::deleteSubjectBefore)
-* <code>SMWSQLStore3Writers</code>, SMWSQLStore3::deleteSubjectAfter (SMW::SQLStore::deleteSubjectAfter)
-* <code>SMWSQLStore3Writers</code>, SMWSQLStore3::updateDataBefore (SMW::SQLStore::updateDataBefore)
-* <code>SMWSQLStore3Writers</code>, SMWSQLStore3::updateDataAfter (SMW::SQLStore::updateDataAfter)
-* <code>SMWSetupScript</code>, smwDropTables (SMW::Setup::dropTables)
-* <code>SMW_refreshData</code>, smwDropTables (SMW::Setup::dropTables)
+* `\SMW\DIProperty`, smwInitProperties (SMW::DataItem::initProperties)
+* `\SMW\DataValueFactory`, smwInitDatatypes (SMW::DataValue::initDataTypes)
+* `SMWExportController`, smwAddToRDFExport
+* `SMWParamFormat`, SMWResultFormat
+* `\SMW\Store`, SMWStore::updateDataBefore (SMW::Store::updateDataBefore)
+* `\SMW\Store`, SMWStore::updateDataAfter (SMW::Store::updateDataAfter)
+* `\SMW\Store`, smwInitializeTables (SMW::Store::initTables)
+* `SMWSQLStore3SetupHandlers`, SMWCustomSQLStoreFieldType
+* `SMWSQLStore3SetupHandlers`, smwRefreshDataJobs (SMW::SQLStore::updateJobs)
+* `SMWSQLStore3Writers`, SMWSQLStore3::deleteSubjectBefore (SMW::SQLStore::deleteSubjectBefore)
+* `SMWSQLStore3Writers`, SMWSQLStore3::deleteSubjectAfter (SMW::SQLStore::deleteSubjectAfter)
+* `SMWSQLStore3Writers`, SMWSQLStore3::updateDataBefore (SMW::SQLStore::updateDataBefore)
+* `SMWSQLStore3Writers`, SMWSQLStore3::updateDataAfter (SMW::SQLStore::updateDataAfter)
+* `SMWSetupScript`, smwDropTables (SMW::Setup::dropTables)
+* `SMW_refreshData`, smwDropTables (SMW::Setup::dropTables)
 
 [hooks]: https://www.mediawiki.org/wiki/Hooks "Manual:Hooks"

--- a/includes/src/SPARQLStore/SPARQLStore.php
+++ b/includes/src/SPARQLStore/SPARQLStore.php
@@ -246,10 +246,25 @@ class SPARQLStore extends Store {
 	}
 
 	/**
-	 * @see Store::getQueryResult()
+	 * @note Move hooks to the base class in 3.*
+	 *
+	 * @see Store::getQueryResult
 	 * @since 1.6
 	 */
 	public function getQueryResult( Query $query ) {
+
+		$result = null;
+
+		if ( wfRunHooks( 'SMW::Store::selectQueryResultBefore', array( $this, $query, &$result ) ) ) {
+			$result = $this->fetchQueryResult( $query );
+		}
+
+		wfRunHooks( 'SMW::Store::selectQueryResultAfter', array( $this, &$result ) );
+
+		return $result;
+	}
+
+	protected function fetchQueryResult( Query $query ) {
 
 		$queryEngine = new QueryEngine(
 			$this->getSparqlDatabase(),
@@ -257,11 +272,12 @@ class SPARQLStore extends Store {
 			new QueryResultFactory( $this )
 		);
 
-		return $queryEngine
+		$queryEngine
 			->setIgnoreQueryErrors( $GLOBALS['smwgIgnoreQueryErrors'] )
 			->setSortingSupport( $GLOBALS['smwgQSortingSupport'] )
-			->setRandomSortingSupport( $GLOBALS['smwgQRandSortingSupport'] )
-			->getQueryResult( $query );
+			->setRandomSortingSupport( $GLOBALS['smwgQRandSortingSupport'] );
+
+		return $queryEngine->getQueryResult( $query );
 	}
 
 	/**

--- a/includes/storage/SMW_Store.php
+++ b/includes/storage/SMW_Store.php
@@ -242,6 +242,9 @@ abstract class Store {
 ///// Query answering /////
 
 	/**
+	 * @note Change the signature in 3.* to avoid for subclasses to manage the
+	 * hooks; keep the current signature to adhere semver for the 2.* branch
+	 *
 	 * Execute the provided query and return the result as an
 	 * SMWQueryResult if the query was a usual instance retrieval query. In
 	 * the case that the query asked for a plain string (querymode
@@ -253,6 +256,17 @@ abstract class Store {
 	 * @return SMWQueryResult
 	 */
 	public abstract function getQueryResult( SMWQuery $query );
+
+	/**
+	 * @note Change the signature to abstract for the 3.* branch
+	 *
+	 * @since  2.1
+	 *
+	 * @param SMWQuery $query
+	 *
+	 * @return SMWQueryResult
+	 */
+	protected function fetchQueryResult( SMWQuery $query ) {}
 
 ///// Special page functions /////
 

--- a/includes/storage/SQLStore/SMW_SQLStore3.php
+++ b/includes/storage/SQLStore/SMW_SQLStore3.php
@@ -330,7 +330,9 @@ class SMWSQLStore3 extends SMWStore {
 ///// Query answering /////
 
 	/**
-	 * @see SMWStore::getQueryResult
+	 * @note Move hooks to the base class in 3.*
+	 *
+	 * @see SMWStore::fetchQueryResult
 	 *
 	 * @since 1.8
 	 * @param SMWQuery $query
@@ -338,10 +340,20 @@ class SMWSQLStore3 extends SMWStore {
 	 */
 	public function getQueryResult( SMWQuery $query ) {
 
-		$qe = new SMWSQLStore3QueryEngine( $this, wfGetDB( DB_SLAVE ) );
-		$result = $qe->getQueryResult( $query );
+		$result = null;
+
+		if ( wfRunHooks( 'SMW::Store::selectQueryResultBefore', array( $this, $query, &$result ) ) ) {
+			$result = $this->fetchQueryResult( $query );
+		}
+
+		wfRunHooks( 'SMW::Store::selectQueryResultAfter', array( $this, &$result ) );
 
 		return $result;
+	}
+
+	protected function fetchQueryResult( SMWQuery $query ) {
+		$qe = new SMWSQLStore3QueryEngine( $this, wfGetDB( DB_SLAVE ) );
+		return $qe->getQueryResult( $query );
 	}
 
 ///// Special page functions /////

--- a/tests/phpunit/Integration/MediaWiki/Hooks/InternalParseBeforeLinksIntegrationTest.php
+++ b/tests/phpunit/Integration/MediaWiki/Hooks/InternalParseBeforeLinksIntegrationTest.php
@@ -34,7 +34,7 @@ class InternalParseBeforeLinksIntegrationTest extends \PHPUnit_Framework_TestCas
 		$this->mwHooksHandler = UtilityFactory::getInstance()->newMwHooksHandler();
 		$this->mwHooksHandler->deregisterListedHooks();
 
-		$this->mwHooksHandler->registerHook(
+		$this->mwHooksHandler->register(
 			'InternalParseBeforeLinks',
 			$this->mwHooksHandler->getHookRegistry()->getDefinition( 'InternalParseBeforeLinks' )
 		);

--- a/tests/phpunit/Integration/MediaWiki/Hooks/ParserAfterTidyIntegrationTest.php
+++ b/tests/phpunit/Integration/MediaWiki/Hooks/ParserAfterTidyIntegrationTest.php
@@ -34,7 +34,7 @@ class ParserAfterTidyIntegrationTest extends \PHPUnit_Framework_TestCase {
 		$this->mwHooksHandler = UtilityFactory::getInstance()->newMwHooksHandler();
 		$this->mwHooksHandler->deregisterListedHooks();
 
-		$this->mwHooksHandler->registerHook(
+		$this->mwHooksHandler->register(
 			'ParserAfterTidy',
 			$this->mwHooksHandler->getHookRegistry()->getDefinition( 'ParserAfterTidy' )
 		);

--- a/tests/phpunit/Integration/SemanticMediaWikiProvidedHookInterfaceIntegrationTest.php
+++ b/tests/phpunit/Integration/SemanticMediaWikiProvidedHookInterfaceIntegrationTest.php
@@ -1,0 +1,157 @@
+<?php
+
+namespace SMW\Tests\Integration;
+
+use SMW\Tests\Util\UtilityFactory;
+
+use RuntimeException;
+
+/**
+ * @group SMW
+ * @group SMWExtension
+ * @group semantic-mediawiki-integration
+ *
+ * @license GNU GPL v2+
+ * @since 2.1
+ *
+ * @author mwjames
+ */
+class SemanticMediaWikiProvidedHookInterfaceIntegrationTest extends \PHPUnit_Framework_TestCase {
+
+	private $mwHooksHandler;
+
+	protected function setUp() {
+		parent::setUp();
+
+		$this->mwHooksHandler = UtilityFactory::getInstance()->newMwHooksHandler();
+		$this->mwHooksHandler->deregisterListedHooks();
+	}
+
+	protected function tearDown() {
+		$this->mwHooksHandler->restoreListedHooks();
+
+		parent::tearDown();
+	}
+
+	/**
+	 * @dataProvider storeClassProvider
+	 */
+	public function testUnregisteredQueryResultHook( $storeClass ) {
+
+		$query = $this->getMockBuilder( '\SMWQuery' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$store = $this->getMockBuilder( $storeClass )
+			->disableOriginalConstructor()
+			->setMethods( array( 'fetchQueryResult' ) )
+			->getMock();
+
+		$store->expects( $this->once() )
+			->method( 'fetchQueryResult' );
+
+		$store->getQueryResult( $query );
+	}
+
+	/**
+	 * @dataProvider storeClassProvider
+	 */
+	public function testRegisteredSMWStoreSelectQueryResultBeforeHookThatIncludesFetchingOfQueryResult( $storeClass ) {
+
+		$query = $this->getMockBuilder( '\SMWQuery' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$store = $this->getMockBuilder( $storeClass )
+			->disableOriginalConstructor()
+			->setMethods( array( 'fetchQueryResult' ) )
+			->getMock();
+
+		$store->expects( $this->once() )
+			->method( 'fetchQueryResult' );
+
+		$this->mwHooksHandler->register( 'SMW::Store::selectQueryResultBefore', function( $store, $query, &$queryResult ) {
+			$queryResult = 'Foo';
+			return true;
+		} );
+
+		$this->assertNotEquals(
+			'Foo',
+			$store->getQueryResult( $query )
+		);
+	}
+
+	/**
+	 * @dataProvider storeClassProvider
+	 */
+	public function testRegisteredSMWStoreSelectQueryResultBeforeHookToSuppressDefaultQueryResultFetch( $storeClass ) {
+
+		$query = $this->getMockBuilder( '\SMWQuery' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$store = $this->getMockBuilder( $storeClass )
+			->disableOriginalConstructor()
+			->setMethods( array( 'fetchQueryResult' ) )
+			->getMock();
+
+		$store->expects( $this->never() )
+			->method( 'fetchQueryResult' );
+
+		$this->mwHooksHandler->register( 'SMW::Store::selectQueryResultBefore', function( $store, $query, &$queryResult ) {
+
+			$queryResult = 'Foo';
+
+			// Return false to suppress additional calls to fetchQueryResult
+			return false;
+		} );
+
+		$this->assertEquals(
+			'Foo',
+			$store->getQueryResult( $query )
+		);
+	}
+
+	/**
+	 * @dataProvider storeClassProvider
+	 */
+	public function testRegisteredSMWStoreSelectQueryResultAfterHook( $storeClass ) {
+
+		$queryResult = $this->getMockBuilder( '\SMWQueryResult' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$query = $this->getMockBuilder( '\SMWQuery' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$store = $this->getMockBuilder( $storeClass )
+			->disableOriginalConstructor()
+			->setMethods( array( 'fetchQueryResult' ) )
+			->getMock();
+
+		$store->expects( $this->once() )
+			->method( 'fetchQueryResult' )
+			->will( $this->returnValue( $queryResult ) );
+
+		$this->mwHooksHandler->register( 'SMW::Store::selectQueryResultAfter', function( $store, &$queryResult ) {
+
+			if ( !$queryResult instanceOf \SMWQueryResult ) {
+				throw new RuntimeException( 'Expected a SMWQueryResult instance' );
+			}
+
+			return true;
+		} );
+
+		$store->getQueryResult( $query );
+	}
+
+	public function storeClassProvider() {
+
+		$provider[] = array( '\SMWSQLStore3' );
+		$provider[] = array( '\SMW\SPARQLStore\SPARQLStore' );
+
+		return $provider;
+	}
+
+}


### PR DESCRIPTION
Relates to #555
- `SMW::Store::selectQueryResultBefore` can be used to implement a QueryCache
- `SMW::Store::selectQueryResultAfter` can be used to implement a UsageTracker
