### PR TITLE
Add DataItem::__toString

### DIFF
--- a/includes/dataitems/SMW_DataItem.php
+++ b/includes/dataitems/SMW_DataItem.php
@@ -141,6 +141,15 @@ abstract class SMWDataItem {
 	}
 
 	/**
+	 * @since 2.1
+	 *
+	 * @return string
+	 */
+	public function __toString() {
+		return $this->getSerialization();
+	}
+
+	/**
 	 * Create a data item of the given dataitem ID based on the the
 	 * provided serialization string and (optional) typeid.
 	 *

--- a/tests/phpunit/includes/dataitems/CommonDataItemTest.php
+++ b/tests/phpunit/includes/dataitems/CommonDataItemTest.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace SMW\Tests;
+
+/**
+ * @covers \SMWDataItem
+ *
+ * @group SMW
+ * @group SMWExtension
+ *
+ * @license GNU GPL v2+
+ * @since 2.1
+ *
+ * @author mwjames
+ */
+class CommonDataItemTest extends \PHPUnit_Framework_TestCase {
+
+	public function testSerializationToFilterSameStringRepresentation() {
+
+		$items = array();
+
+		foreach ( array( 'Foo', 'Bar', 'Foo' ) as  $value ) {
+
+			$dataItem = $this->getMockBuilder( '\SMWDataItem' )
+				->disableOriginalConstructor()
+				->getMockForAbstractClass();
+
+			$dataItem->expects( $this->any() )
+				->method( 'getSerialization' )
+				->will( $this->returnValue( $value ) );
+
+			$items[] = $dataItem;
+		}
+
+		$this->assertCount(
+			2,
+			array_unique( $items )
+		);
+	}
+
+}


### PR DESCRIPTION
Relates to #555

Allows to exercise `array_unique( $dataItems )` around dataItems.
