### PR TITLE
Fix #566 / SPARQLStore to clean-up after page has moved

### DIFF
--- a/tests/phpunit/Integration/MediaWiki/Hooks/TitleMoveCompleteIntegrationTest.php
+++ b/tests/phpunit/Integration/MediaWiki/Hooks/TitleMoveCompleteIntegrationTest.php
@@ -1,0 +1,174 @@
+<?php
+
+namespace SMW\Tests\Integration\MediaWiki\Hooks;
+
+use SMW\Tests\Util\UtilityFactory;
+use SMW\Tests\MwDBaseUnitTestCase;
+
+use SMW\Query\Language\SomeProperty;
+use SMW\Query\Language\ValueDescription;
+use SMW\Query\Language\ThingDescription;
+
+use SMW\Application;
+use SMW\DIProperty;
+use SMW\DIWikiPage;
+
+use SMWQuery as Query;
+
+use Title;
+use WikiPage;
+
+/**
+ * @group SMW
+ * @group SMWExtension
+ * @group semantic-mediawiki-integration
+ * @group medium
+ *
+ * @license GNU GPL v2+
+ * @since   2.1
+ *
+ * @author mwjames
+ */
+class TitleMoveCompleteIntegrationTest extends MwDBaseUnitTestCase {
+
+	private $mwHooksHandler;
+	private $queryResultValidator;
+	private $application;
+	private $toBeDeleted = array();
+	private $pageCreator;
+
+	protected function setUp() {
+		parent::setUp();
+
+		$utilityFactory = UtilityFactory::getInstance();
+
+		$this->application = Application::getInstance();
+		$this->queryResultValidator = $utilityFactory->newValidatorFactory()->newQueryResultValidator();
+
+		$this->mwHooksHandler = $utilityFactory->newMwHooksHandler();
+		$this->mwHooksHandler->deregisterListedHooks();
+
+		$this->mwHooksHandler->register(
+			'TitleMoveComplete',
+			$this->mwHooksHandler->getHookRegistry()->getDefinition( 'TitleMoveComplete' )
+		);
+
+		$this->pageCreator = $utilityFactory->newPageCreator();
+	}
+
+	protected function tearDown() {
+
+		$this->mwHooksHandler->restoreListedHooks();
+		$this->application->clear();
+
+		$pageDeleter = UtilityFactory::getInstance()->newPageDeleter();
+		$pageDeleter->doDeletePoolOfPages( $this->toBeDeleted );
+
+		parent::tearDown();
+	}
+
+	public function testPageMoveWithCreationOfRedirectTarget() {
+
+		$oldTitle = Title::newFromText( __METHOD__ . '-old' );
+		$newTitle = Title::newFromText( __METHOD__ . '-new' );
+
+		$this->assertNull(
+			WikiPage::factory( $newTitle )->getRevision()
+		);
+
+		$this->pageCreator
+			->createPage( $oldTitle )
+			->doEdit( '[[Has function hook test::PageRedirectMove]]' );
+
+		$this->pageCreator
+			->getPage()
+			->getTitle()
+			->moveTo( $newTitle, false, 'test', true );
+
+		$this->assertNotNull(
+			WikiPage::factory( $oldTitle )->getRevision()
+		);
+
+		$this->assertNotNull(
+			WikiPage::factory( $newTitle )->getRevision()
+		);
+
+		$this->toBeDeleted = array( $oldTitle, $newTitle );
+	}
+
+	public function testPageMoveWithRemovalOfOldPage() {
+
+		// PHPUnit query issue
+		$this->skipTestForDatabase( array( 'postgres', 'sqlite' ) );
+
+		// Revison showed an issue on 1.19 not being null after the move
+		$this->skipTestForMediaWikiVersionLowerThan( '1.21' );
+
+		// Further hooks required to ensure in-text annotations can be used for queries
+		$this->mwHooksHandler->register(
+			'InternalParseBeforeLinks',
+			$this->mwHooksHandler->getHookRegistry()->getDefinition( 'InternalParseBeforeLinks' )
+		);
+
+		$this->mwHooksHandler->register(
+			'LinksUpdateConstructed',
+			$this->mwHooksHandler->getHookRegistry()->getDefinition( 'LinksUpdateConstructed' )
+		);
+
+		$oldTitle = Title::newFromText( __METHOD__ . '-old' );
+		$newTitle = Title::newFromText( __METHOD__ . '-new' );
+
+		$this->assertNull(
+			WikiPage::factory( $newTitle )->getRevision()
+		);
+
+		$this->pageCreator
+			->createPage( $oldTitle )
+			->doEdit( '[[Has function hook test::PageCompleteMove]]' );
+
+		$this->pageCreator
+			->getPage()
+			->getTitle()
+			->moveTo( $newTitle, false, 'test', false );
+
+		$this->assertNull(
+			WikiPage::factory( $oldTitle )->getRevision()
+		);
+
+		$this->assertNotNull(
+			WikiPage::factory( $newTitle )->getRevision()
+		);
+
+		/**
+		 * @query {{#ask: [[Has function hook test::PageCompleteMove]] }}
+		 */
+		$description = new SomeProperty(
+			DIProperty::newFromUserLabel( 'Has function hook test' ),
+			new ValueDescription( new DIWikiPage( 'PageCompleteMove', 0 ), null, SMW_CMP_EQ )
+		);
+
+		$query = new Query(
+			$description,
+			false,
+			true
+		);
+
+		$query->querymode = Query::MODE_INSTANCES;
+
+		$queryResult = $this->getStore()->getQueryResult( $query );
+
+		// #566
+		$this->assertCount(
+			1,
+			$queryResult->getResults()
+		);
+
+		$this->queryResultValidator->assertThatQueryResultHasSubjects(
+			DIWikiPage::newFromTitle( $newTitle ),
+			$queryResult
+		);
+
+		$this->toBeDeleted = array( $oldTitle, $newTitle );
+	}
+
+}

--- a/tests/phpunit/Integration/MediaWiki/IndirectFunctionHookValidationDBIntegrationTest.php
+++ b/tests/phpunit/Integration/MediaWiki/IndirectFunctionHookValidationDBIntegrationTest.php
@@ -183,29 +183,4 @@ class IndirectFunctionHookValidationDBIntegrationTest extends MwDBaseUnitTestCas
 		}
 	}
 
-	public function testPageMove() {
-
-		$this->title = Title::newFromText( __METHOD__ . '-old' );
-		$newTitle = Title::newFromText( __METHOD__ . '-new' );
-
-		$this->assertNull(
-			WikiPage::factory( $newTitle )->getRevision()
-		);
-
-		$pageCreator = new PageCreator();
-
-		$pageCreator
-			->createPage( $this->title )
-			->doEdit( '[[Has function hook test::page move]]' );
-
-		$pageCreator
-			->getPage()
-			->getTitle()
-			->moveTo( $newTitle, false, 'test', true );
-
-		$this->assertNotNull(
-			WikiPage::factory( $newTitle )->getRevision()
-		);
-	}
-
 }

--- a/tests/phpunit/MwDBaseUnitTestCase.php
+++ b/tests/phpunit/MwDBaseUnitTestCase.php
@@ -112,6 +112,22 @@ abstract class MwDBaseUnitTestCase extends \PHPUnit_Framework_TestCase {
 		return $this->storesToBeExcluded = $storesToBeExcluded;
 	}
 
+	protected function skipTestForMediaWikiVersionLowerThan( $version ) {
+		if ( version_compare( $GLOBALS['wgVersion'], $version, '<' ) ) {
+			$this->markTestSkipped(
+				"This test is skipped for MediaWiki version {$GLOBALS['wgVersion']}"
+			);
+		}
+	}
+
+	protected function skipTestForDatabase( array $excludedDatabase ) {
+		if ( in_array( $this->getDBConnection()->getType(), $excludedDatabase ) ) {
+			$this->markTestSkipped(
+				"Database was excluded and is expected not to support this test"
+			);
+		}
+	}
+
 	protected function getDBConnection() {
 		return $this->mwDatabaseTableBuilder->getDBConnection();
 	}

--- a/tests/phpunit/includes/SPARQLStore/SparqlStoreTest.php
+++ b/tests/phpunit/includes/SPARQLStore/SparqlStoreTest.php
@@ -15,7 +15,6 @@ use Title;
 /**
  * @covers \SMW\SPARQLStore\SPARQLStore
  *
- *
  * @group SMW
  * @group SMWExtension
  *
@@ -134,6 +133,30 @@ class SPARQLStoreTest extends \PHPUnit_Framework_TestCase {
 		$instance->setSparqlDatabase( $sparqlDatabase );
 
 		$instance->doSparqlDataUpdate( $semanticData );
+	}
+
+	public function testCallToChangeTitleForCompletePageMove() {
+
+		$oldTitle = Title::newFromText( __METHOD__ . '-old' );
+		$newTitle = Title::newFromText( __METHOD__ . '-new' );
+
+		$store = $this->getMockBuilder( '\SMW\Store' )
+			->disableOriginalConstructor()
+			->getMockForAbstractClass();
+
+		$store->expects( $this->once() )
+			->method( 'changeTitle' );
+
+		$instance = $this->getMockBuilder( '\SMW\SPARQLStore\SPARQLStore' )
+			->setConstructorArgs( array( $store ) )
+			->setMethods( array( 'doSparqlDataDelete', 'insertDelete' ) )
+			->getMock();
+
+		$instance->expects( $this->once() )
+			->method( 'doSparqlDataDelete' )
+			->with(	$this->equalTo( DIWikiPage::newFromTitle( $oldTitle ) ) );
+
+		$instance->changeTitle( $oldTitle, $newTitle, 42, 0 );
 	}
 
 }


### PR DESCRIPTION
Relates to #566
