### PR TITLE
HashBuilder usage and QueryProfilerFactory clean-up

### DIFF
--- a/includes/Subobject.php
+++ b/includes/Subobject.php
@@ -104,7 +104,7 @@ class Subobject {
 	 * @return self
 	 * @throws InvalidArgumentException
 	 */
-	public function setEmptySemanticDataForId( $identifier ) {
+	public function setEmptyContainerForId( $identifier ) {
 
 		if ( $identifier === '' ) {
 			throw new InvalidArgumentException( 'Expected a valid (non-empty) indentifier' );
@@ -126,7 +126,7 @@ class Subobject {
 	 * @deprecated since 2.0
 	 */
 	public function setSemanticData( $identifier ) {
-		$this->setEmptySemanticDataForId( $identifier );
+		$this->setEmptyContainerForId( $identifier );
 	}
 
 	/**

--- a/includes/parserhooks/RecurringEventsParserFunction.php
+++ b/includes/parserhooks/RecurringEventsParserFunction.php
@@ -52,7 +52,7 @@ class RecurringEventsParserFunction extends SubobjectParserFunction {
 	 */
 	public function parse( ArrayFormatter $parameters ) {
 
-		$this->setFirstElementAsProperty( true );
+		$this->setFirstElementForPropertyLabel( true );
 
 		// Get recurring events
 		$this->events = new RecurringEvents( $parameters->toArray(), $this->settings );

--- a/includes/parserhooks/SubobjectParserFunction.php
+++ b/includes/parserhooks/SubobjectParserFunction.php
@@ -18,17 +18,25 @@ class SubobjectParserFunction {
 
 	const PARAM_SORTKEY = '@sortkey';
 
-	/** @var ParserData */
+	/**
+	 * @var ParserData
+	 */
 	protected $parserData;
 
-	/** @var Subobject */
+	/**
+	 * @var Subobject
+	 */
 	protected $subobject;
 
-	/** @var MessageFormatter */
+	/**
+	 * @var MessageFormatter
+	 */
 	protected $messageFormatter;
 
-	/** @var boolean */
-	protected $firstElementAsProperty = false;
+	/**
+	 * @var boolean
+	 */
+	private $useFirstElementForPropertyLabel = false;
 
 	/**
 	 * @since 1.9
@@ -46,12 +54,12 @@ class SubobjectParserFunction {
 	/**
 	 * @since 1.9
 	 *
-	 * @param boolean $firstElementAsProperty
+	 * @param boolean $useFirstElementForPropertyLabel
 	 *
 	 * @return SubobjectParserFunction
 	 */
-	public function setFirstElementAsProperty( $firstElementAsProperty = true ) {
-		$this->firstElementAsProperty = (bool)$firstElementAsProperty;
+	public function setFirstElementForPropertyLabel( $useFirstElementForPropertyLabel = true ) {
+		$this->useFirstElementForPropertyLabel = (bool)$useFirstElementForPropertyLabel;
 		return $this;
 	}
 
@@ -84,7 +92,7 @@ class SubobjectParserFunction {
 
 		$subject = $this->parserData->getSemanticData()->getSubject();
 
-		$this->subobject->setEmptySemanticDataForId( $this->createSubobjectId( $parameters ) );
+		$this->subobject->setEmptyContainerForId( $this->createSubobjectId( $parameters ) );
 
 		foreach ( $this->transformParametersToArray( $parameters ) as $property => $values ) {
 
@@ -106,22 +114,22 @@ class SubobjectParserFunction {
 		}
 	}
 
-	protected function createSubobjectId( ArrayFormatter $parameters ) {
+	private function createSubobjectId( ArrayFormatter $parameters ) {
 
 		$isAnonymous = in_array( $parameters->getFirst(), array( null, '' ,'-' ) );
 
-		$this->firstElementAsProperty = $this->firstElementAsProperty && !$isAnonymous;
+		$this->useFirstElementForPropertyLabel = $this->useFirstElementForPropertyLabel && !$isAnonymous;
 
-		if ( $this->firstElementAsProperty || $isAnonymous ) {
+		if ( $this->useFirstElementForPropertyLabel || $isAnonymous ) {
 			return HashBuilder::createHashIdForContent( $parameters->toArray(), '_' );
 		}
 
 		return $parameters->getFirst();
 	}
 
-	protected function transformParametersToArray( ArrayFormatter $parameters ) {
+	private function transformParametersToArray( ArrayFormatter $parameters ) {
 
-		if ( $this->firstElementAsProperty ) {
+		if ( $this->useFirstElementForPropertyLabel ) {
 			$parameters->addParameter(
 				$parameters->getFirst(),
 				$this->parserData->getTitle()->getPrefixedText()

--- a/includes/query/profiler/DescriptionProfile.php
+++ b/includes/query/profiler/DescriptionProfile.php
@@ -4,37 +4,36 @@ namespace SMW\Query\Profiler;
 
 use SMW\DIProperty;
 
-use SMW\Query\Language\Description as QueryDescription;
+use SMW\Query\Language\Description;
 use SMWDINumber as DINumber;
 use SMWDIBlob as DIBlob;
 
 /**
- * Provides access to some QueryDescription profiling data
- *
- * @ingroup SMW
- *
- * @licence GNU GPL v2+
+ * @license GNU GPL v2+
  * @since 1.9
  *
  * @author mwjames
  */
 class DescriptionProfile extends ProfileAnnotatorDecorator {
 
-	/** @var QueryDescription */
-	protected $description;
+	/**
+	 * @var Description
+	 */
+	private $description;
 
 	/**
 	 * @since 1.9
 	 *
 	 * @param ProfileAnnotator $profileAnnotator
+	 * @param Description $description
 	 */
-	public function __construct( ProfileAnnotator $profileAnnotator, QueryDescription $description ) {
+	public function __construct( ProfileAnnotator $profileAnnotator, Description $description ) {
 		parent::__construct( $profileAnnotator );
 		$this->description = $description;
 	}
 
 	/**
-	 * @since 1.9
+	 * ProfileAnnotatorDecorator::addPropertyValues
 	 */
 	protected function addPropertyValues() {
 		$this->addQueryString( $this->description->getQueryString() );
@@ -42,9 +41,6 @@ class DescriptionProfile extends ProfileAnnotatorDecorator {
 		$this->addQueryDepth( $this->description->getDepth() );
 	}
 
-	/**
-	 * @since 1.9
-	 */
 	private function addQueryString( $queryString ) {
 		$this->getSemanticData()->addPropertyObjectValue(
 			new DIProperty( '_ASKST' ),
@@ -52,9 +48,6 @@ class DescriptionProfile extends ProfileAnnotatorDecorator {
 		);
 	}
 
-	/**
-	 * @since 1.9
-	 */
 	private function addQuerySize( $size ) {
 		$this->getSemanticData()->addPropertyObjectValue(
 			new DIProperty( '_ASKSI' ),
@@ -62,9 +55,6 @@ class DescriptionProfile extends ProfileAnnotatorDecorator {
 		);
 	}
 
-	/**
-	 * @since 1.9
-	 */
 	private function addQueryDepth( $depth ) {
 		$this->getSemanticData()->addPropertyObjectValue(
 			new DIProperty( '_ASKDE' ),

--- a/includes/query/profiler/DurationProfile.php
+++ b/includes/query/profiler/DurationProfile.php
@@ -6,24 +6,23 @@ use SMW\DIProperty;
 use SMWDINumber as DINumber;
 
 /**
- * Adds duration profiling annotation
- *
- * @ingroup SMW
- *
- * @licence GNU GPL v2+
+ * @license GNU GPL v2+
  * @since 1.9
  *
  * @author mwjames
  */
 class DurationProfile extends ProfileAnnotatorDecorator {
 
-	/** @var integer */
-	protected $duration;
+	/**
+	 * @var integer
+	 */
+	private $duration;
 
 	/**
 	 * @since 1.9
 	 *
 	 * @param ProfileAnnotator $profileAnnotator
+	 * @param integer $duration
 	 */
 	public function __construct( ProfileAnnotator $profileAnnotator, $duration ) {
 		parent::__construct( $profileAnnotator );
@@ -31,7 +30,7 @@ class DurationProfile extends ProfileAnnotatorDecorator {
 	}
 
 	/**
-	 * @since 1.9
+	 * ProfileAnnotatorDecorator::addPropertyValues
 	 */
 	protected function addPropertyValues() {
 		if ( $this->duration > 0 ) {
@@ -39,9 +38,6 @@ class DurationProfile extends ProfileAnnotatorDecorator {
 		}
 	}
 
-	/**
-	 * @since 1.9
-	 */
 	private function addGreaterThanZeroQueryDuration( $duration ) {
 		$this->getSemanticData()->addPropertyObjectValue(
 			new DIProperty( '_ASKDU' ),

--- a/includes/query/profiler/FormatProfile.php
+++ b/includes/query/profiler/FormatProfile.php
@@ -6,24 +6,23 @@ use SMW\DIProperty;
 use SMWDIBlob as DIBlob;
 
 /**
- * Provides access to Format profiling data
- *
- * @ingroup SMW
- *
- * @licence GNU GPL v2+
+ * @license GNU GPL v2+
  * @since 1.9
  *
  * @author mwjames
  */
 class FormatProfile extends ProfileAnnotatorDecorator {
 
-	/** @var array */
-	protected $format;
+	/**
+	 * @var string
+	 */
+	private $format;
 
 	/**
 	 * @since 1.9
 	 *
 	 * @param ProfileAnnotator $profileAnnotator
+	 * @param string $format
 	 */
 	public function __construct( ProfileAnnotator $profileAnnotator, $format ) {
 		parent::__construct( $profileAnnotator );
@@ -31,15 +30,12 @@ class FormatProfile extends ProfileAnnotatorDecorator {
 	}
 
 	/**
-	 * @since 1.9
+	 * ProfileAnnotatorDecorator::addPropertyValues
 	 */
 	protected function addPropertyValues() {
 		$this->addQueryFormat( $this->format );
 	}
 
-	/**
-	 * @since 1.9
-	 */
 	private function addQueryFormat( $format ) {
 		$this->getSemanticData()->addPropertyObjectValue(
 			new DIProperty( '_ASKFO' ),

--- a/includes/query/profiler/NullProfile.php
+++ b/includes/query/profiler/NullProfile.php
@@ -3,41 +3,38 @@
 namespace SMW\Query\Profiler;
 
 use SMW\Subobject;
-use SMW\IdGenerator;
 use SMW\DIProperty;
 
 /**
- * Provides access to the Null object for handling profiling data
- *
- * @ingroup SMW
- *
- * @licence GNU GPL v2+
+ * @license GNU GPL v2+
  * @since 1.9
  *
  * @author mwjames
  */
 class NullProfile implements ProfileAnnotator {
 
-	/** @var Subobject */
-	protected $subobject;
+	/**
+	 * @var Subobject
+	 */
+	private $subobject;
 
-	/** @var string */
-	protected $queryId = null;
+	/**
+	 * @var string
+	 */
+	private $queryId = null;
 
 	/**
 	 * @since 1.9
 	 *
 	 * @param Subobject $subobject
-	 * @param IdGenerator $queryId
+	 * @param string $queryId
 	 */
-	public function __construct( Subobject $subobject, IdGenerator $queryId ) {
+	public function __construct( Subobject $subobject, $queryId ) {
 		$this->subobject = $subobject;
 		$this->queryId = $queryId;
 	}
 
 	/**
-	 * Returns errors collected during processing
-	 *
 	 * @since 1.9
 	 *
 	 * @return array
@@ -85,9 +82,12 @@ class NullProfile implements ProfileAnnotator {
 	 * @since 1.9
 	 */
 	public function addAnnotation() {
-		$this->subobject->setSemanticData(
-			$this->subobject->generateId( $this->queryId->setPrefix( '_QUERY' ) )
-		);
+		$this->subobject->setEmptyContainerForId( '_QUERY' . $this->queryId );
+
+	//	$this->getSemanticData()->addPropertyObjectValue(
+	//		new DIProperty( '_ASKID' ),
+	//		new DIBlob( $this->queryId )
+	//	);
 	}
 
 }

--- a/includes/query/profiler/QueryProfilerFactory.php
+++ b/includes/query/profiler/QueryProfilerFactory.php
@@ -5,7 +5,7 @@ namespace SMW\Query\Profiler;
 use SMW\Query\Language\Description;
 
 use SMW\Subobject;
-use SMW\HashIdGenerator;
+use SMWQuery as Query;
 
 use Title;
 
@@ -20,18 +20,23 @@ class QueryProfilerFactory {
 	/**
 	 * @since 2.1
 	 *
+	 * @param Title $title
+	 * @param Query $query
+	 * @param string $format
+	 * @param integer|null $duration
+	 *
 	 * @return ProfileAnnotator
 	 */
-	public function newQueryProfiler( Title $title, Description $description, array $queryParameters, $queryFormat, $queryDuration ) {
+	public function newQueryProfiler( Title $title, Query $query, $format, $duration = null ) {
 
 		$profiler = new NullProfile(
 			new Subobject( $title ),
-			new HashIdGenerator( $queryParameters )
+			$query->getHash()
 		);
 
-		$profiler = new DescriptionProfile( $profiler, $description );
-		$profiler = new FormatProfile( $profiler, $queryFormat );
-		$profiler = new DurationProfile( $profiler, $queryDuration );
+		$profiler = new DescriptionProfile( $profiler, $query->getDescription() );
+		$profiler = new FormatProfile( $profiler, $format );
+		$profiler = new DurationProfile( $profiler, $duration );
 
 		return $profiler;
 	}

--- a/tests/phpunit/Integration/MediaWiki/ApiBrowseBySubjectDBIntegrationTest.php
+++ b/tests/phpunit/Integration/MediaWiki/ApiBrowseBySubjectDBIntegrationTest.php
@@ -105,7 +105,7 @@ class ApiBrowseBySubjectDBIntegrationTest extends MwDBaseUnitTestCase {
 		);
 
 		$subobject = new Subobject( $semanticData->getSubject()->getTitle() );
-		$subobject->setEmptySemanticDataForId( 'Foo' );
+		$subobject->setEmptyContainerForId( 'Foo' );
 
 		$subobject->addDataValue(
 			$this->dataValueFactory->newPropertyValue( __METHOD__ , 'Bam' )

--- a/tests/phpunit/Integration/Query/NumericPropertyValueQueryDBIntegrationTest.php
+++ b/tests/phpunit/Integration/Query/NumericPropertyValueQueryDBIntegrationTest.php
@@ -130,7 +130,7 @@ class NumericPropertyValueQueryDBIntegrationTest extends MwDBaseUnitTestCase {
 		);
 
 		$subobject = new Subobject( $semanticData->getSubject()->getTitle() );
-		$subobject->setEmptySemanticDataForId( 'SomeSubobject' );
+		$subobject->setEmptyContainerForId( 'SomeSubobject' );
 
 		$subobject->addDataValue( $expectedDataValueToMatchCondition );
 
@@ -225,7 +225,7 @@ class NumericPropertyValueQueryDBIntegrationTest extends MwDBaseUnitTestCase {
 		);
 
 		$subobject = new Subobject( $semanticDataWithSubobject->getSubject()->getTitle() );
-		$subobject->setEmptySemanticDataForId( 'SomeSubobjectToDifferentSubject' );
+		$subobject->setEmptyContainerForId( 'SomeSubobjectToDifferentSubject' );
 
 		$subobject->addDataValue( $expectedDataValueToMatchCondition );
 

--- a/tests/phpunit/Integration/Query/SubqueryDBIntegrationTest.php
+++ b/tests/phpunit/Integration/Query/SubqueryDBIntegrationTest.php
@@ -176,7 +176,7 @@ class SubqueryDBIntegrationTest extends MwDBaseUnitTestCase {
 			->newEmptySemanticData();
 
 		$subobject = new Subobject( $semanticDataOfWonderland->getSubject()->getTitle() );
-		$subobject->setEmptySemanticDataForId( 'SomeSubobjectOnWonderland' );
+		$subobject->setEmptyContainerForId( 'SomeSubobjectOnWonderland' );
 
 		$subobject->addDataValue(
 			$this->newDataValueForPagePropertyValue( 'MemberOf', 'Wonderland' )
@@ -274,7 +274,7 @@ class SubqueryDBIntegrationTest extends MwDBaseUnitTestCase {
 			->newEmptySemanticData();
 
 		$subobject = new Subobject( $semanticDataOfWonderland->getSubject()->getTitle() );
-		$subobject->setEmptySemanticDataForId( 'SomeSubobjectOnWonderland' );
+		$subobject->setEmptyContainerForId( 'SomeSubobjectOnWonderland' );
 
 		$subobject->addDataValue(
 			$this->newDataValueForPagePropertyValue( 'MemberOf', 'Wonderland' )

--- a/tests/phpunit/Integration/SPARQLStore/QueryResultLookupWithoutBaseStoreIntegrationTest.php
+++ b/tests/phpunit/Integration/SPARQLStore/QueryResultLookupWithoutBaseStoreIntegrationTest.php
@@ -173,7 +173,7 @@ class QueryResultLookupWithoutBaseStoreIntegrationTest extends \PHPUnit_Framewor
 		$semanticData = $this->semanticDataFactory->newEmptySemanticData( __METHOD__ );
 
 		$subobject = new Subobject( $semanticData->getSubject()->getTitle() );
-		$subobject->setEmptySemanticDataForId( 'SubobjectToTestReferenceAfterUpdate' );
+		$subobject->setEmptyContainerForId( 'SubobjectToTestReferenceAfterUpdate' );
 
 		$property = new DIProperty( 'SomeNumericPropertyToCompareReference' );
 		$property->setPropertyTypeId( '_num' );

--- a/tests/phpunit/Integration/SemanticDataSerializationDBIntegrationTest.php
+++ b/tests/phpunit/Integration/SemanticDataSerializationDBIntegrationTest.php
@@ -36,7 +36,7 @@ class SemanticDataSerializationDBIntegrationTest extends MwDBaseUnitTestCase {
 		$semanticDataBeforeUpdate = new SemanticData( $subject );
 
 		$subobject = new Subobject( $subject->getTitle() );
-		$subobject->setEmptySemanticDataForId( 'SomeSubobjectToSerialize' );
+		$subobject->setEmptyContainerForId( 'SomeSubobjectToSerialize' );
 
 		$subobject->getSemanticData()->addDataValue(
 			DataValueFactory::getInstance()->newPropertyValue( 'Foo', 'Bar' )

--- a/tests/phpunit/Integration/SemanticDataStorageDBIntegrationTest.php
+++ b/tests/phpunit/Integration/SemanticDataStorageDBIntegrationTest.php
@@ -100,7 +100,7 @@ class SemanticDataStorageDBIntegrationTest extends MwDBaseUnitTestCase {
 		$semanticData = new SemanticData( $subject );
 
 		$subobject = new Subobject( $subject->getTitle() );
-		$subobject->setEmptySemanticDataForId( 'SomeSubobject' );
+		$subobject->setEmptyContainerForId( 'SomeSubobject' );
 
 		$subobject->getSemanticData()->addDataValue(
 			DataValueFactory::getInstance()->newPropertyValue( 'Foo', 'Bar' )

--- a/tests/phpunit/Util/Fixtures/Facts/BerlinFactsheet.php
+++ b/tests/phpunit/Util/Fixtures/Facts/BerlinFactsheet.php
@@ -202,7 +202,7 @@ class BerlinFactsheet {
 		}
 
 		$subobject = new Subobject( $this->targetSubject->getTitle() );
-		$subobject->setEmptySemanticDataforId( 'Berlin#Demographics' );
+		$subobject->setEmptyContainerForId( 'Berlin#Demographics' );
 
 		$yearProperty = new YearProperty();
 

--- a/tests/phpunit/Util/Fixtures/Facts/ParisFactsheet.php
+++ b/tests/phpunit/Util/Fixtures/Facts/ParisFactsheet.php
@@ -203,7 +203,7 @@ class ParisFactsheet {
 		}
 
 		$subobject = new Subobject( $this->targetSubject->getTitle() );
-		$subobject->setEmptySemanticDataforId( 'Paris#Demographics' );
+		$subobject->setEmptyContainerForId( 'Paris#Demographics' );
 
 		$yearProperty = new YearProperty();
 

--- a/tests/phpunit/includes/SemanticDataTest.php
+++ b/tests/phpunit/includes/SemanticDataTest.php
@@ -478,7 +478,7 @@ class SemanticDataTest extends \PHPUnit_Framework_TestCase {
 	private function newSubobject( Title $title, $property = 'Quuy', $value = 'Xeer' ) {
 
 		$subobject = new Subobject( $title );
-		$subobject->setEmptySemanticDataForId( 'Foo' );
+		$subobject->setEmptyContainerForId( 'Foo' );
 
 		$subobject->addDataValue(
 			DataValueFactory::getInstance()->newPropertyValue( $property, $value )

--- a/tests/phpunit/includes/SubobjectTest.php
+++ b/tests/phpunit/includes/SubobjectTest.php
@@ -50,7 +50,7 @@ class SubobjectTest extends \PHPUnit_Framework_TestCase {
 	public function testSetEmptySemanticData() {
 
 		$instance = new Subobject( Title::newFromText( __METHOD__ ) );
-		$instance->setEmptySemanticDataForId( 'Foo' );
+		$instance->setEmptyContainerForId( 'Foo' );
 
 		$this->assertInstanceOf(
 			'\Title',
@@ -386,7 +386,7 @@ class SubobjectTest extends \PHPUnit_Framework_TestCase {
 			$id = $instance->generateId( new HashIdGenerator( rand( 10, 10000 ), '_' ) );
 		}
 
-		$instance->setEmptySemanticDataForId( $id );
+		$instance->setEmptyContainerForId( $id );
 
 		return $instance;
 	}

--- a/tests/phpunit/includes/export/ExportSemanticDataTest.php
+++ b/tests/phpunit/includes/export/ExportSemanticDataTest.php
@@ -267,7 +267,7 @@ class ExportSemanticDataTest extends \PHPUnit_Framework_TestCase {
 		$semanticData = $this->semanticDataFactory->newEmptySemanticData( __METHOD__ );
 
 		$subobject = new Subobject( $semanticData->getSubject()->getTitle() );
-		$subobject->setEmptySemanticDataforId( 'Foo' );
+		$subobject->setEmptyContainerForId( 'Foo' );
 
 		$semanticData->addPropertyObjectValue(
 			$subobject->getProperty(),

--- a/tests/phpunit/includes/parserhooks/SubobjectParserFunctionTest.php
+++ b/tests/phpunit/includes/parserhooks/SubobjectParserFunctionTest.php
@@ -93,14 +93,14 @@ class SubobjectParserFunctionTest extends \PHPUnit_Framework_TestCase {
 	/**
 	 * @dataProvider firstElementDataProvider
 	 */
-	public function testFirstElementAsProperty( $isEnabled , array $parameters, array $expected ) {
+	public function testFirstElementForPropertyLabel( $isEnabled , array $parameters, array $expected ) {
 
 		$parserOutput = new ParserOutput();
 		$title        = Title::newFromText( __METHOD__ );
 		$subobject    = new Subobject( $title );
 
 		$instance = $this->acquireInstance( $subobject, $parserOutput );
-		$instance->setFirstElementAsProperty( $isEnabled  );
+		$instance->setFirstElementForPropertyLabel( $isEnabled  );
 
 		$instance->parse( new ParserParameterFormatter( $parameters ) );
 
@@ -143,7 +143,7 @@ class SubobjectParserFunctionTest extends \PHPUnit_Framework_TestCase {
 		);
 	}
 
-	public function testSubobjectIdStabilityForFixedParameterSet() {
+	public function testSubobjectIdStabilityForFixedSetOfParameters() {
 
 		$parameters = array(
 			'Foo=Bar'

--- a/tests/phpunit/includes/query/profiler/DurationProfileTest.php
+++ b/tests/phpunit/includes/query/profiler/DurationProfileTest.php
@@ -1,12 +1,11 @@
 <?php
 
-namespace SMW\Test;
+namespace SMW\Tests\Query\Profiler;
 
-use SMW\Tests\Util\Validators\SemanticDataValidator;
+use SMW\Tests\Util\UtilityFactory;
 
 use SMW\Query\Profiler\DurationProfile;
 use SMW\Query\Profiler\NullProfile;
-use SMW\HashIdGenerator;
 use SMW\Subobject;
 
 use Title;
@@ -14,62 +13,55 @@ use Title;
 /**
  * @covers \SMW\Query\Profiler\DurationProfile
  *
- *
  * @group SMW
  * @group SMWExtension
  *
- * @licence GNU GPL v2+
+ * @license GNU GPL v2+
  * @since 1.9
  *
  * @author mwjames
  */
 class DurationProfileTest extends \PHPUnit_Framework_TestCase {
 
-	public function getClass() {
-		return '\SMW\Query\Profiler\DurationProfile';
+	private $semanticDataValidator;
+
+	protected function setUp() {
+		parent::setUp();
+
+		$this->semanticDataValidator = UtilityFactory::getInstance()->newValidatorFactory()->newSemanticDataValidator();
 	}
 
-	/**
-	 * @return DurationProfile
-	 */
-	private function newInstance( $duration = 0 ) {
-
-		$profiler = new NullProfile(
-			new Subobject( Title::newFromText( __METHOD__ ) ),
-			new HashIdGenerator( 'Foo' )
-		);
-
-		return new DurationProfile( $profiler, $duration );
-	}
-
-	/**
-	 * @since 1.9
-	 */
 	public function testCanConstruct() {
-		$this->assertInstanceOf( $this->getClass(), $this->newInstance() );
+
+		$profileAnnotator = $this->getMockBuilder( '\SMW\Query\Profiler\ProfileAnnotator' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$this->assertInstanceOf(
+			'\SMW\Query\Profiler\DurationProfile',
+			new DurationProfile( $profileAnnotator, 0.42 )
+		);
 	}
 
 	/**
 	 * @dataProvider durationDataProvider
-	 *
-	 * @since 1.9
 	 */
 	public function testCreateProfile( $duration, $expected ) {
 
-		$instance = $this->newInstance( $duration );
+		$profiler = new NullProfile(
+			new Subobject( Title::newFromText( __METHOD__ ) ),
+			'foo'
+		);
+
+		$instance = new DurationProfile( $profiler, $duration );
 		$instance->addAnnotation();
 
-		$semanticDataValidator = new SemanticDataValidator;
-		$semanticDataValidator->assertThatPropertiesAreSet(
+		$this->semanticDataValidator->assertThatPropertiesAreSet(
 			$expected,
 			$instance->getContainer()->getSemanticData()
 		);
-
 	}
 
-	/**
-	 * @since 1.9
-	 */
 	public function durationDataProvider() {
 
 		$provider = array();

--- a/tests/phpunit/includes/query/profiler/FormatProfileTest.php
+++ b/tests/phpunit/includes/query/profiler/FormatProfileTest.php
@@ -1,12 +1,11 @@
 <?php
 
-namespace SMW\Test;
+namespace SMW\Tests\Query\Profiler;
 
-use SMW\Tests\Util\Validators\SemanticDataValidator;
+use SMW\Tests\Util\UtilityFactory;
 
 use SMW\Query\Profiler\FormatProfile;
 use SMW\Query\Profiler\NullProfile;
-use SMW\HashIdGenerator;
 use SMW\Subobject;
 
 use Title;
@@ -14,61 +13,56 @@ use Title;
 /**
  * @covers \SMW\Query\Profiler\FormatProfile
  *
- *
  * @group SMW
  * @group SMWExtension
  *
- * @licence GNU GPL v2+
+ * @license GNU GPL v2+
  * @since 1.9
  *
  * @author mwjames
  */
 class FormatProfileTest extends \PHPUnit_Framework_TestCase {
 
-	public function getClass() {
-		return '\SMW\Query\Profiler\FormatProfile';
+	private $semanticDataValidator;
+
+	protected function setUp() {
+		parent::setUp();
+
+		$this->semanticDataValidator = UtilityFactory::getInstance()->newValidatorFactory()->newSemanticDataValidator();
 	}
 
-	/**
-	 * @return FormatProfile
-	 */
-	private function newInstance( $format = 'Foo' ) {
+	public function testCanConstruct() {
+
+		$profileAnnotator = $this->getMockBuilder( '\SMW\Query\Profiler\ProfileAnnotator' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$this->assertInstanceOf(
+			'\SMW\Query\Profiler\FormatProfile',
+			new FormatProfile( $profileAnnotator, 'table' )
+		);
+	}
+
+	public function testCreateProfile() {
 
 		$profiler = new NullProfile(
 			new Subobject( Title::newFromText( __METHOD__ ) ),
-			new HashIdGenerator( 'Foo' )
+			'foo'
 		);
 
-		return new FormatProfile( $profiler, $format );
-	}
-
-	/**
-	 * @since 1.9
-	 */
-	public function testCanConstruct() {
-		$this->assertInstanceOf( $this->getClass(), $this->newInstance() );
-	}
-
-	/**
-	 * @since 1.9
-	 */
-	public function testCreateProfile() {
-
-		$instance = $this->newInstance( 'Foo' );
+		$instance = new FormatProfile( $profiler, 'table' );
 		$instance->addAnnotation();
 
 		$expected = array(
 			'propertyCount'  => 1,
 			'propertyKeys'   => array( '_ASKFO' ),
-			'propertyValues' => array( 'Foo' )
+			'propertyValues' => array( 'table' )
 		);
 
-		$semanticDataValidator = new SemanticDataValidator;
-		$semanticDataValidator->assertThatPropertiesAreSet(
+		$this->semanticDataValidator->assertThatPropertiesAreSet(
 			$expected,
 			$instance->getContainer()->getSemanticData()
 		);
-
 	}
 
 }

--- a/tests/phpunit/includes/query/profiler/NullProfileTest.php
+++ b/tests/phpunit/includes/query/profiler/NullProfileTest.php
@@ -1,64 +1,67 @@
 <?php
 
-namespace SMW\Test;
+namespace SMW\Tests\Query\Profiler;
 
-use SMW\HashIdGenerator;
 use SMW\Query\Profiler\NullProfile;
 use SMW\Subobject;
+
+use Title;
 
 /**
  * @covers \SMW\Query\Profiler\NullProfile
  *
- *
  * @group SMW
  * @group SMWExtension
  *
- * @licence GNU GPL v2+
+ * @license GNU GPL v2+
  * @since 1.9
  *
  * @author mwjames
  */
-class NullProfileTest extends SemanticMediaWikiTestCase {
+class NullProfileTest extends \PHPUnit_Framework_TestCase {
 
-	/**
-	 * @return string|false
-	 */
-	public function getClass() {
-		return '\SMW\Query\Profiler\NullProfile';
-	}
+	public function testCanConstruct() {
 
-	/**
-	 * @since 1.9
-	 *
-	 * @return NullProfile
-	 */
-	private function newInstance() {
-		return new NullProfile(
-			new Subobject( $this->newTitle() ),
-			new HashIdGenerator( 'Foo' )
+		$subobject = $this->getMockBuilder( '\SMW\Subobject' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$this->assertInstanceOf(
+			'\SMW\Query\Profiler\NullProfile',
+			new NullProfile( $subobject, 'abc' )
 		);
 	}
 
-	/**
-	 * @since 1.9
-	 */
-	public function testConstructor() {
-		$this->assertInstanceOf( $this->getClass(), $this->newInstance() );
-	}
+	public function testMethodAccess() {
 
-	/**
-	 * @since 1.9
-	 */
-	public function testAvailableMethods() {
+		$subobject = new Subobject( Title::newFromText( __METHOD__ ) );
+		$instance = new NullProfile( $subobject, 'adcb944aa33b2c972470b73964c547c0' );
 
-		$instance = $this->newInstance();
 		$instance->addAnnotation();
 
-		$this->assertInstanceOf( '\SMW\DIProperty', $instance->getProperty() );
-		$this->assertInstanceOf( '\SMWDIContainer', $instance->getContainer() );
-		$this->assertInstanceOf( '\SMWContainerSemanticData', $instance->getSemanticData() );
-		$this->assertEmpty( $instance->getErrors() );
+		$this->assertInstanceOf(
+			'\SMW\DIProperty',
+			$instance->getProperty()
+		);
 
+		$this->assertInstanceOf(
+			'\SMWDIContainer',
+			$instance->getContainer()
+		);
+
+		$this->assertInstanceOf(
+			'\SMWContainerSemanticData',
+			$instance->getSemanticData()
+		);
+
+		$this->assertEmpty(
+			$instance->getErrors()
+		);
+
+		$this->assertEquals(
+			'_QUERYadcb944aa33b2c972470b73964c547c0',
+			$subobject->getId()
+		);
 	}
 
 }


### PR DESCRIPTION
- Use simpler approach in `SubobjectParserFunction` to access `HashBuilder` directly
- Use `Query::getHash` for the QueryId in the `QueryProfiler`
- Clean-up `QueryProfilerFactory` interface for simpler usage
- Clean-up some of the profiler tests to ensure better readable

Also relates to #555 
