### PR TITLE
Travis / Adapt mediawiki GitHub download

### DIFF
--- a/build/travis/install-mediawiki.sh
+++ b/build/travis/install-mediawiki.sh
@@ -5,7 +5,7 @@ cd ..
 
 wget https://github.com/wikimedia/mediawiki-core/archive/$MW.tar.gz
 tar -zxf $MW.tar.gz
-mv mediawiki-core-$MW mw
+mv mediawiki-$MW mw
 
 cd mw
 


### PR DESCRIPTION
https://github.com/wikimedia/mediawiki-core is now
https://github.com/wikimedia/mediawiki
