### PR TITLE
Add FileUploadIntegrationTest to test FileUpload hook

### DIFF
--- a/tests/phpunit/Integration/MediaWiki/Hooks/FileUploadIntegrationTest.php
+++ b/tests/phpunit/Integration/MediaWiki/Hooks/FileUploadIntegrationTest.php
@@ -1,0 +1,119 @@
+<?php
+
+namespace SMW\Tests\Integration\MediaWiki\Hooks;
+
+use SMW\Tests\Util\UtilityFactory;
+use SMW\Tests\MwDBaseUnitTestCase;
+
+use SMW\DIWikiPage;
+use SMW\Application;
+
+use Title;
+
+/**
+ * @group SMW
+ * @group SMWExtension
+ *
+ * @group semantic-mediawiki-integration
+ * @group mediawiki-database
+ *
+ * @group medium
+ *
+ * @license GNU GPL v2+
+ * @since   2.1
+ *
+ * @author mwjames
+ */
+class FileUploadIntegrationTest extends MwDBaseUnitTestCase {
+
+	private $mwHooksHandler;
+	private $fixturesFileProvider;
+	private $semanticDataValidator;
+
+	/**
+	 * MW GLOBALS to be restored after the test
+	 */
+	private $wgFileExtensions;
+	private $wgEnableUploads;
+	private $wgVerifyMimeType;
+
+	protected function setUp() {
+		parent::setUp();
+
+		$utilityFactory = UtilityFactory::getInstance();
+
+		$this->fixturesFileProvider = $utilityFactory->newFixturesFactory()->newFixturesFileProvider();
+		$this->semanticDataValidator = $utilityFactory->newValidatorFactory()->newSemanticDataValidator();
+
+		$this->mwHooksHandler = $utilityFactory->newMwHooksHandler();
+		$this->mwHooksHandler->deregisterListedHooks();
+
+		$this->application = Application::getInstance();
+
+		$settings = array(
+			'smwgPageSpecialProperties' => array( '_MEDIA', '_MIME' ),
+			'smwgNamespacesWithSemanticLinks' => array( NS_MAIN => true, NS_FILE => true ),
+			'smwgCacheType' => 'hash',
+		);
+
+		foreach ( $settings as $key => $value ) {
+			$this->application->getSettings()->set( $key, $value );
+		}
+
+		$this->wgEnableUploads  = $GLOBALS['wgEnableUploads'];
+		$this->wgFileExtensions = $GLOBALS['wgFileExtensions'];
+		$this->wgVerifyMimeType = $GLOBALS['wgVerifyMimeType'];
+
+		$this->mwHooksHandler->register(
+			'FileUpload',
+			$this->mwHooksHandler->getHookRegistry()->getDefinition( 'FileUpload' )
+		);
+
+		$this->mwHooksHandler->register(
+			'InternalParseBeforeLinks',
+			$this->mwHooksHandler->getHookRegistry()->getDefinition( 'InternalParseBeforeLinks' )
+		);
+
+		$this->mwHooksHandler->register(
+			'LinksUpdateConstructed',
+			$this->mwHooksHandler->getHookRegistry()->getDefinition( 'LinksUpdateConstructed' )
+		);
+	}
+
+	protected function tearDown() {
+		$this->mwHooksHandler->restoreListedHooks();
+
+		$GLOBALS['wgEnableUploads'] = $this->wgEnableUploads;
+		$GLOBALS['wgFileExtensions'] = $this->wgFileExtensions;
+		$GLOBALS['wgVerifyMimeType'] = $this->wgVerifyMimeType;
+
+		parent::tearDown();
+	}
+
+	public function testFileUploadForDummyTextFile() {
+
+		$GLOBALS['wgEnableUploads'] = true;
+		$GLOBALS['wgFileExtensions'] = array( 'txt' );
+		$GLOBALS['wgVerifyMimeType'] = true;
+
+		$subject = new DIWikiPage( 'Foo.txt', NS_FILE );
+
+		$dummyTextFile = $this->fixturesFileProvider->newUploadForDummyTextFile( 'Foo.txt' );
+
+		$this->assertTrue(
+			$dummyTextFile->doUpload( '[[HasFile::File:Foo.txt]]' )
+		);
+
+		$expected = array(
+			'propertyCount'  => 4,
+			'propertyKeys'   => array( 'HasFile', '_MEDIA', '_MIME', '_SKEY' ),
+			'propertyValues' => array( 'File:Foo.txt', 'TEXT', 'text/plain', 'Foo.txt' )
+		);
+
+		$this->semanticDataValidator->assertThatPropertiesAreSet(
+			$expected,
+			$this->getStore()->getSemanticData( $subject )
+		);
+	}
+
+}

--- a/tests/phpunit/Util/Fixtures/File/DummyFileCreator.php
+++ b/tests/phpunit/Util/Fixtures/File/DummyFileCreator.php
@@ -1,0 +1,88 @@
+<?php
+
+namespace SMW\Tests\Util\Fixtures\File;
+
+use SMW\Tests\Util\Mock\MockSuperUser;
+
+use RuntimeException;
+
+/**
+ * @license GNU GPL v2+
+ * @since 2.1
+ *
+ * @author mwjames
+ */
+class DummyFileCreator {
+
+	/**
+	 * @var string
+	 */
+	private $desiredDestName;
+
+	/**
+	 * @var integer
+	 */
+	private $size = 100;
+
+	/**
+	 * @since 2.1
+	 *
+	 * @param string $desiredDestName
+	 */
+	public function __construct( $desiredDestName ) {
+		$this->desiredDestName = $desiredDestName;
+	}
+
+	/**
+	 * @since 2.1
+	 *
+	 * @return string
+	 */
+	public function createEmptyFile() {
+		return $this->createFile();
+	}
+
+	/**
+	 * @since 2.1
+	 *
+	 * @param string $contentCopyPath
+	 *
+	 * @return string
+	 */
+	public function createFileByCopyContentOf( $contentCopyPath ) {
+		return $this->createFile( file_get_contents( $this->canReadFile( $contentCopyPath ) ) );
+	}
+
+	private function createFile( $content = '' ) {
+
+		$filename = $this->makeTemporaryFile();
+
+		$fh = fopen( $filename, 'w' );
+
+		if ( $content === '' ) {
+			ftruncate( $fh, $this->size );
+		} else {
+			fwrite( $fh, $content );
+		}
+
+		fclose( $fh );
+
+		return $this->canReadFile( $filename );
+	}
+
+	private function makeTemporaryFile() {
+		return tempnam( sys_get_temp_dir(), $this->desiredDestName );
+	}
+
+	private function canReadFile( $path ) {
+
+		$path = str_replace( array( '\\', '/' ), DIRECTORY_SEPARATOR, $path );
+
+		if ( is_readable( $path ) ) {
+			return $path;
+		}
+
+		throw new RuntimeException( "Expected an accessible {$path}" );
+	}
+
+}

--- a/tests/phpunit/Util/Fixtures/File/FixturesFileProvider.php
+++ b/tests/phpunit/Util/Fixtures/File/FixturesFileProvider.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace SMW\Tests\Util\Fixtures\File;
+
+/**
+ * @license GNU GPL v2+
+ * @since 2.1
+ *
+ * @author mwjames
+ */
+class FixturesFileProvider {
+
+	/**
+	 * @since 2.1
+	 *
+	 * @param string $desiredDestName
+	 *
+	 * @return LocalFileUpload
+	 */
+	public function newUploadForDummyTextFile( $desiredDestName ) {
+
+		$dummyFileCreator = new DummyFileCreator( $desiredDestName );
+
+		return new LocalFileUpload(
+			$dummyFileCreator->createFileByCopyContentOf( __DIR__ . '/' . 'LoremIpsum.txt' ),
+			$desiredDestName
+		);
+	}
+
+}

--- a/tests/phpunit/Util/Fixtures/File/LocalFileUpload.php
+++ b/tests/phpunit/Util/Fixtures/File/LocalFileUpload.php
@@ -1,0 +1,100 @@
+<?php
+
+namespace SMW\Tests\Util\Fixtures\File;
+
+use SMW\Tests\Util\Mock\MockSuperUser;
+
+use UploadBase;
+use RuntimeException;
+
+/**
+ * @license GNU GPL v2+
+ * @since 2.1
+ *
+ * @author mwjames
+ */
+class LocalFileUpload extends UploadBase {
+
+	/**
+	 * @var boolean
+	 */
+	private $removeTemporaryFile = true;
+
+	/**
+	 * @var string
+	 */
+	private $localUploadPath;
+
+	/**
+	 * @var string
+	 */
+	private $desiredDestName;
+
+	/**
+	 * @since 2.1
+	 *
+	 * @param string $localUploadPath
+	 * @param string $desiredDestName
+	 */
+	public function __construct( $localUploadPath, $desiredDestName ) {
+		$this->localUploadPath = $localUploadPath;
+		$this->desiredDestName = $desiredDestName;
+	}
+
+	/**
+	 * @since 2.1
+	 *
+	 * @param string $pageText
+	 * @param string $comment
+	 *
+	 * @return boolean
+	 */
+	public function doUpload( $pageText = '', $comment = '' ) {
+
+		$localUploadPath = $this->canReadUploadPath( $this->localUploadPath );
+
+		$this->initializePathInfo(
+			$this->desiredDestName,
+			$localUploadPath,
+			filesize( $localUploadPath ),
+			$this->removeTemporaryFile
+		);
+
+		$status = $this->performUpload(
+			$comment,
+			$pageText,
+			false,
+			new MockSuperUSer()
+		);
+
+		if ( !$status->isGood() ) {
+			return false;
+		}
+
+		return true;
+	}
+
+	/**
+	 * @see UploadBase::initializeFromRequest
+	 */
+	function initializeFromRequest( &$request ) {}
+
+	/**
+	 * @see UploadBase::getSourceType
+	 */
+	public function getSourceType() {
+		return 'file';
+	}
+
+	private function canReadUploadPath( $path ) {
+
+		$path = str_replace( array( '\\', '/' ), DIRECTORY_SEPARATOR, $path );
+
+		if ( is_readable( $path ) ) {
+			return $path;
+		}
+
+		throw new RuntimeException( "Expected an accessible {$path}" );
+	}
+
+}

--- a/tests/phpunit/Util/Fixtures/File/LoremIpsum.txt
+++ b/tests/phpunit/Util/Fixtures/File/LoremIpsum.txt
@@ -1,0 +1,3 @@
+Lorem ipsum dolor sit amet consectetuer eu vitae consectetuer ac accumsan. Tellus Aenean porta odio volutpat vel cursus et wisi eu ac. Id Curabitur nec congue dolor magna Pellentesque Suspendisse et est Nulla. Pharetra neque Nullam ornare mauris feugiat ultrices pellentesque dui pretium libero. Tellus Curabitur Lorem et enim id.
+
+Justo id convallis interdum a nibh laoreet Mauris Aenean neque augue. Pretium non eget Phasellus malesuada justo ut gravida Maecenas orci ante. Vestibulum sociis Lorem Nulla Phasellus at Nam adipiscing ac Sed ut. Mauris rhoncus ut faucibus tempus laoreet lorem morbi eu nascetur fermentum. Consectetuer congue ut aliquam leo nibh eget auctor nibh ullamcorper nonummy. Ac nibh.

--- a/tests/phpunit/Util/Fixtures/FixturesFactory.php
+++ b/tests/phpunit/Util/Fixtures/FixturesFactory.php
@@ -2,6 +2,8 @@
 
 namespace SMW\Tests\Util\Fixtures;
 
+use SMW\Tests\Util\Fixtures\File\FixturesFileProvider;
+
 /**
  * @license GNU GPL v2+
  * @since 2.1
@@ -26,6 +28,15 @@ class FixturesFactory {
 	 */
 	public function newFixturesCleaner() {
 		return new FixturesCleaner();
+	}
+
+	/**
+	 * @since 2.1
+	 *
+	 * @return FixturesFileProvider
+	 */
+	public function newFixturesFileProvider() {
+		return new FixturesFileProvider();
 	}
 
 }


### PR DESCRIPTION
The `FixturesFileProvider` provides a "real" temporary file to be uploaded using the `LocalFileUpload` helper to verify that annotations are created by the `FileUpload` hook.
