### PR TITLE
[WIP] Add 'SMW::DataValue::canUse' / 'SMW::PropertyPage::canView' hook

### DIFF
--- a/i18n/en.json
+++ b/i18n/en.json
@@ -300,5 +300,8 @@
 	"smw-sp-searchbyproperty-description": "This page provides a simple [https://www.semantic-mediawiki.org/wiki/Help:Browsing_interfaces browsing interface] for finding entities described by a property and a named value. Other available search interfaces include the [[Special:PageProperty|page property search]], and the [[Special:Ask|ask query builder]].",
 	"smw-sp-searchbyproperty-resultlist-header": "List of results",
 	"smw-sp-searchbyproperty-nonvaluequery": "A list of values that have the property \"$1\" assigned.",
-	"smw-sp-searchbyproperty-valuequery": "A list of pages that have property \"$1\" with value \"$2\" annotated."
+	"smw-sp-searchbyproperty-valuequery": "A list of pages that have property \"$1\" with value \"$2\" annotated.",
+	"smw-datavalue-improper-canuse-permission": "The current element can not be displayed due to an improper permission.",
+	"smw-propertypage-improper-canview-permission": "The content of the current property page can not be displayed due to an improper permission."
+
 }

--- a/i18n/qqq.json
+++ b/i18n/qqq.json
@@ -316,5 +316,7 @@
 	"smw-sp-searchbyproperty-description": "Extended description text for the [[Special:SearchByProperty]] page.",
 	"smw-sp-searchbyproperty-resultlist-header": "A header label",
 	"smw-sp-searchbyproperty-nonvaluequery": "A description for a query result without values.\n\nParameters:\n* $1 - Name of the property",
-	"smw-sp-searchbyproperty-valuequery": "A description for a query result with values.\n\nParameters:\n* $1 - Name of the property\n* $2 - Name of the value"
+	"smw-sp-searchbyproperty-valuequery": "A description for a query result with values.\n\nParameters:\n* $1 - Name of the property\n* $2 - Name of the value",
+	"smw-datavalue-improper-canuse-permission": "A description text",
+	"smw-propertypage-improper-canview-permission": "A description text"
 }

--- a/includes/SemanticData.php
+++ b/includes/SemanticData.php
@@ -352,6 +352,16 @@ class SemanticData {
 				return;
 			}
 
+			if ( !$propertyDV->canUse() ) {
+				$this->addPropertyObjectValue(
+					new DIProperty( DIProperty::TYPE_ERROR ),
+					$propertyDV->getProperty()->getDiWikiPage()
+				);
+
+				$this->addError( $propertyDV->getErrors() );
+				return;
+			}
+
 			$property = $propertyDV->getDataItem();
 		}
 
@@ -371,6 +381,14 @@ class SemanticData {
 		}
 
 		if ( !$dataValue->isValid() ) {
+
+			$this->addPropertyObjectValue(
+				new DIProperty( DIProperty::TYPE_ERROR ),
+				$dataValue->getProperty()->getDiWikiPage()
+			);
+
+			$this->addError( $dataValue->getErrors() );
+		} elseif ( !$dataValue->canUse() ) {
 
 			$this->addPropertyObjectValue(
 				new DIProperty( DIProperty::TYPE_ERROR ),

--- a/includes/articlepages/SMW_PropertyPage.php
+++ b/includes/articlepages/SMW_PropertyPage.php
@@ -29,8 +29,14 @@ class SMWPropertyPage extends SMWOrderedListPage {
 	 */
 	protected function getHtml() {
 
+		$result = $this->getPredefinedPropertyIntro();
+
+		if ( !wfRunHooks( 'SMW::PropertyPage::canView', array( $this->mTitle ) ) ) {
+			return $result . Html::element( 'div', array( 'id' => 'smw-propertypage-improper-canview-permission' ), wfMessage( 'smw-propertypage-improper-canview-permission' )->inContentLanguage()->text() );
+		}
+
 		$list = $this->getSubpropertyList() . $this->getPropertyValueList();
-		$result = $this->getPredefinedPropertyIntro() . ( $list !== '' ? Html::element( 'br', array( 'id' => 'smwfootbr' ) ) . $list : '' );
+		$result = $list !== '' ? Html::element( 'br', array( 'id' => 'smwfootbr' ) ) . $list : '';
 
 		return $result;
 	}

--- a/includes/datavalues/SMW_DataValue.php
+++ b/includes/datavalues/SMW_DataValue.php
@@ -691,6 +691,23 @@ abstract class SMWDataValue {
 	}
 
 	/**
+	 * @since  2.1
+	 *
+	 * @return boolean
+	 */
+	public function canUse() {
+
+		if ( wfRunHooks( 'SMW::DataValue::canUse', array( $this ) ) ) {
+			return true;
+		}
+
+		$this->addError( wfMessage( 'smw-datavalue-improper-canuse-permission' )->inContentLanguage()->text() );
+		$this->m_dataitem = new SMWDIProperty( 'ERROR', false );
+
+		return false;
+	}
+
+	/**
 	 * Return a string that displays all error messages as a tooltip, or
 	 * an empty string if no errors happened.
 	 *

--- a/includes/storage/SMW_ResultArray.php
+++ b/includes/storage/SMW_ResultArray.php
@@ -164,7 +164,12 @@ class SMWResultArray {
 		if ( $this->mPrintRequest->getOutputFormat() ) {
 			$dv->setOutputFormat( $this->mPrintRequest->getOutputFormat() );
 		}
-		return $dv;
+
+		if ( $dv->canUse() ) {
+			return $dv;
+		}
+
+		return false;
 	}
 
 	/**
@@ -212,7 +217,7 @@ class SMWResultArray {
 			break;
 			case SMWPrintRequest::PRINT_PROP:
 				$propertyValue = $this->mPrintRequest->getData();
-				if ( $propertyValue->isValid() ) {
+				if ( $propertyValue->isValid() && $propertyValue->canUse() ) {
 					$this->mContent = $this->mStore->getPropertyValues( $this->mResult,
 						$propertyValue->getDataItem(), $this->getRequestOptions() );
 				} else {


### PR DESCRIPTION
Can be used to supress the display (and the storage) of property/values related.