### PR TITLE
ValueConditionBuilder to return FalseCondition for non-supported DataIte...

### DIFF
--- a/tests/phpunit/Integration/MediaWiki/SearchInPageDBIntegrationTest.php
+++ b/tests/phpunit/Integration/MediaWiki/SearchInPageDBIntegrationTest.php
@@ -83,7 +83,13 @@ class SearchInPageDBIntegrationTest extends MwDBaseUnitTestCase {
 			$results
 		);
 
-		$this->assertEquals( 1, $results->getTotalHits() );
+		// Geo is currently not supported by the SPARQLStore
+		$expectedHits = is_a( $this->getStore(), '\SMWSQLStore3' ) ? 1 : 0;
+
+		$this->assertEquals(
+			$expectedHits,
+			$results->getTotalHits()
+		);
 
 		$pageDeleter = new PageDeleter();
 		$pageDeleter->deletePage( $targetPage );

--- a/tests/phpunit/includes/SPARQLStore/QueryEngine/ConditionBuilder/ValueConditionBuilderTest.php
+++ b/tests/phpunit/includes/SPARQLStore/QueryEngine/ConditionBuilder/ValueConditionBuilderTest.php
@@ -58,6 +58,30 @@ class ValueConditionBuilderTest extends \PHPUnit_Framework_TestCase {
 	}
 
 	/**
+	 * @dataProvider notSupportedDataItemTypeProvider
+	 */
+	public function testCreateFalseConditionForNotSupportedDataItemType( $dataItem ) {
+
+		$resultVariable = 'result';
+
+		$compoundConditionBuilder = $this->getMockBuilder( '\SMW\SPARQLStore\QueryEngine\CompoundConditionBuilder' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$instance = new ValueConditionBuilder( $compoundConditionBuilder );
+
+		$description = new ValueDescription(
+			$dataItem,
+			null
+		);
+
+		$this->assertInstanceOf(
+			'\SMW\SPARQLStore\QueryEngine\Condition\FalseCondition',
+			$instance->buildCondition( $description, $resultVariable, null )
+		);
+	}
+
+	/**
 	 * @dataProvider comparatorProvider
 	 */
 	public function testValueConditionForDifferentComparators( $description, $expectedConditionType, $expectedConditionString ) {
@@ -320,6 +344,27 @@ class ValueConditionBuilderTest extends \PHPUnit_Framework_TestCase {
 			$description,
 			$conditionType,
 			$expected
+		);
+
+		return $provider;
+	}
+
+	public function notSupportedDataItemTypeProvider() {
+
+		$dataItem = $this->getMockBuilder( '\SMWDIGeoCoord' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$provider[] = array(
+			$dataItem
+		);
+
+		$dataItem = $this->getMockBuilder( '\SMW\DIConcept' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$provider[] = array(
+			$dataItem
 		);
 
 		return $provider;


### PR DESCRIPTION
- `SMWDIGeoCoord` \ `_geo`
- `SMW\DIConcept`

Avoids an exception for when `null` is returned which surfaced during the encounter with [0].

This fixes #500 in a way that it doesn't raise an exception and returns a `FalseCondition`. In future someone can implement a proper `SemanticMaps` \ `Geo` integration using [1, 2, 3].

[0] https://github.com/SemanticMediaWiki/SemanticMaps/pull/29
[1] http://www.opengeospatial.org/standards/geosparql
[2] http://jena.apache.org/documentation/query/spatial-query.html
[3] http://www.w3.org/2003/01/geo/wgs84_pos#
