### PR TITLE
SPARQLStore RedirectLookup check for non-redirectable resources

### DIFF
--- a/includes/src/SPARQLStore/RedirectLookup.php
+++ b/includes/src/SPARQLStore/RedirectLookup.php
@@ -42,7 +42,10 @@ class RedirectLookup {
 	 */
 	public function __construct( SparqlDatabase $connection, Cache $cache = null ) {
 		$this->connection = $connection;
-		self::$resourceUriTargetCache = $cache;
+
+		if ( $cache !== null ) {
+			self::$resourceUriTargetCache = $cache;
+		}
 	}
 
 	/**
@@ -72,7 +75,7 @@ class RedirectLookup {
 
 		$exists = true;
 
-		if ( $expNsResource->isBlankNode() ) {
+		if ( $expNsResource->isBlankNode() || $this->isNonRedirectableResource( $expNsResource ) ) {
 			$exists = false;
 			return $expNsResource;
 		}
@@ -98,6 +101,13 @@ class RedirectLookup {
 		}
 
 		return $expNsResource;
+	}
+
+	private function isNonRedirectableResource( ExpNsResource $expNsResource ) {
+		return $expNsResource->getNamespaceId() === 'swivt' ||
+			$expNsResource->getNamespaceId() === 'rdf' ||
+			$expNsResource->getNamespaceId() === 'rdfs' ||
+			( $expNsResource->getNamespaceId() === 'property' && strrpos( $expNsResource->getLocalName(), 'aux' ) );
 	}
 
 	private function lookupResourceUriTargetFromDatabase( ExpNsResource $expNsResource ) {

--- a/tests/phpunit/includes/SPARQLStore/RedirectLookupTest.php
+++ b/tests/phpunit/includes/SPARQLStore/RedirectLookupTest.php
@@ -230,6 +230,32 @@ class RedirectLookupTest extends \PHPUnit_Framework_TestCase {
 		$instance->clear();
 	}
 
+	/**
+	 * @dataProvider nonRedirectableResourceProvider
+	 */
+	public function testRedirectTargetForNonRedirectableResource( $expNsResource ) {
+
+		$cache = $this->getMockBuilder( '\SMW\Cache\Cache' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$cache->expects( $this->never() )
+			->method( 'contains' );
+
+		$connection = $this->getMockBuilder( '\SMWSparqlDatabase' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$instance = new RedirectLookup( $connection, $cache );
+
+		$exists = null;
+
+		$instance->findRedirectTargetResource( $expNsResource, $exists );
+
+		$this->assertFalse( $exists );
+		$instance->clear();
+	}
+
 	private function createMockSparqlDatabaseFor( $listReturnValue ) {
 
 		$federateResultSet = $this->getMockBuilder( '\SMW\SPARQLStore\QueryEngine\FederateResultSet' )
@@ -249,6 +275,31 @@ class RedirectLookupTest extends \PHPUnit_Framework_TestCase {
 			->will( $this->returnValue( $federateResultSet ) );
 
 		return $sparqlDatabase;
+	}
+
+	public function nonRedirectableResourceProvider() {
+
+		$provider[] = array(
+			Exporter::getInstance()->getSpecialPropertyResource( '_INST' )
+		);
+
+		$provider[] = array(
+			Exporter::getInstance()->getSpecialPropertyResource( '_SUBC' )
+		);
+
+		$provider[] = array(
+			Exporter::getInstance()->getSpecialPropertyResource( '_REDI' )
+		);
+
+		$provider[] = array(
+			Exporter::getInstance()->getSpecialPropertyResource( '_MDAT' )
+		);
+
+		$provider[] = array(
+			Exporter::getInstance()->getResourceElementForProperty( new DIProperty( 'Foo' ), true )
+		);
+
+		return $provider;
 	}
 
 }

--- a/tests/phpunit/includes/SPARQLStore/SPARQLStoreTest.php
+++ b/tests/phpunit/includes/SPARQLStore/SPARQLStoreTest.php
@@ -7,6 +7,7 @@ use SMW\Tests\Util\UtilityFactory;
 use SMW\SPARQLStore\SPARQLStore;
 
 use SMW\DIWikiPage;
+use SMW\DIProperty;
 use SMW\SemanticData;
 use SMW\Subobject;
 
@@ -119,7 +120,12 @@ class SPARQLStoreTest extends \PHPUnit_Framework_TestCase {
 
 	public function testDoSparqlDataUpdateOnMockBaseStore() {
 
-		$semanticData = new SemanticData( new DIWikiPage( 'Foo', NS_MAIN, '' ) );
+		$semanticData = new SemanticData( new DIWikiPage( __METHOD__, NS_MAIN ) );
+
+		$semanticData->addPropertyObjectValue(
+			new DIProperty( 'Foo' ),
+			$semanticData->getSubject()
+		);
 
 		$listReturnValue = $this->getMockBuilder( '\SMW\SPARQLStore\QueryEngine\FederateResultSet' )
 			->disableOriginalConstructor()


### PR DESCRIPTION
Should slightly improve performance during write/update as well as during query execution as now only redirect query requests are made for an object that can have a redirect.
