### PR TITLE
Make pre-defined property page non-movable

### DIFF
--- a/includes/src/MediaWiki/Hooks/HookRegistry.php
+++ b/includes/src/MediaWiki/Hooks/HookRegistry.php
@@ -474,6 +474,14 @@ class HookRegistry {
 			return $articleFromTitle->process();
 		};
 
+		/**
+		 * @see https://www.mediawiki.org/wiki/Manual:Hooks/TitleIsMovable
+		 */
+		$functionHookDefinition['TitleIsMovable'] = function ( $title, &$isMovable ) {
+			$titleIsMovable = new TitleIsMovable( $title, $isMovable );
+			return $titleIsMovable->process();
+		};
+
 		return $functionHookDefinition;
 	}
 

--- a/includes/src/MediaWiki/Hooks/TitleIsMovable.php
+++ b/includes/src/MediaWiki/Hooks/TitleIsMovable.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace SMW\MediaWiki\Hooks;
+
+use SMW\DIProperty;
+use Title;
+
+/**
+ * @see https://www.mediawiki.org/wiki/Manual:Hooks/TitleIsMovable
+ *
+ * @license GNU GPL v2+
+ * @since 2.1
+ *
+ * @author mwjames
+ */
+class TitleIsMovable {
+
+	/**
+	 * @var Title
+	 */
+	private $title = null;
+
+	/**
+	 * @var boolean
+	 */
+	private $isMovable = true;
+
+	/**
+	 * @since  2.1
+	 *
+	 * @param Title &$title
+	 * @param boolean &$isMovable
+	 */
+	public function __construct( Title $title, &$isMovable ) {
+		$this->title = $title;
+		$this->isMovable = &$isMovable;
+	}
+
+	/**
+	 * @since 2.1
+	 *
+	 * @return boolean
+	 */
+	public function process() {
+		return $this->isPropertyNamespace() ? $this->detectMovabilityForProperty() : true;
+	}
+
+	private function isPropertyNamespace() {
+		return $this->title->getNamespace() === SMW_NS_PROPERTY;
+	}
+
+	private function detectMovabilityForProperty() {
+		$this->isMovable = DIProperty::newFromUserLabel( $this->title->getText() )->isUserDefined();
+		return true;
+	}
+
+}

--- a/tests/README.md
+++ b/tests/README.md
@@ -5,7 +5,7 @@ In general there are two different types of testing a manual (without using any 
 
 If you choose to do manual testing you just download a related branch using `composer require "mediawiki/semantic-media-wiki:dev-foo` where `foo` refers to the branch name and after the download run `composer dump-autoload` to ensure that all classes are correctly initialized before starting a test.
 
-For the automated approach, Semantic MediaWiki uses [PHPUnit][phpunit] as script based testing methodology. Scripted tests are developed to verify an expected behaviour for specified requirements that allows to decide whether a result should be rejected or can be accepted and ultimately is used to decribe a behaviour.
+For the automated approach, Semantic MediaWiki uses [PHPUnit][phpunit] as scripted testing methodology. Scripted tests are used to verify that an expected behaviour occurs for specified requirements and enables to decide whether a result can be accepted or has to be rejected.
 
 - Unit test in most cases refers to a test that confirms an expected result for a unit, module, or class
 - Integration test normally combines multiple components into a single process to verify that the integration produces an expected result

--- a/tests/phpunit/includes/MediaWiki/Hooks/TitleIsMovableTest.php
+++ b/tests/phpunit/includes/MediaWiki/Hooks/TitleIsMovableTest.php
@@ -1,0 +1,84 @@
+<?php
+
+namespace SMW\Tests\MediaWiki\Hooks;
+
+use SMW\MediaWiki\Hooks\TitleIsMovable;
+
+use Title;
+
+/**
+ * @covers \SMW\MediaWiki\Hooks\TitleIsMovable
+ *
+ * @group SMW
+ * @group SMWExtension
+ *
+ * @license GNU GPL v2+
+ * @since 2.1
+ *
+ * @author mwjames
+ */
+class TitleIsMovableTest extends \PHPUnit_Framework_TestCase {
+
+	public function testCanConstruct() {
+
+		$title = $this->getMockBuilder( '\Title' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$isMovable = true;
+
+		$this->assertInstanceOf(
+			'\SMW\MediaWiki\Hooks\TitleIsMovable',
+			new TitleIsMovable( $title, $isMovable )
+		);
+	}
+
+	public function testPredefinedPropertyPageIsNotMovable() {
+
+		$title = Title::newFromText( 'Modification date', SMW_NS_PROPERTY );
+		$isMovable = true;
+
+		$instance = new TitleIsMovable( $title, $isMovable );
+
+		$this->assertTrue(
+			$instance->process()
+		);
+
+		$this->assertFalse(
+			$isMovable
+		);
+	}
+
+	public function testUserdefinedPropertyPageIsMovable() {
+
+		$title = Title::newFromText( 'Foo', SMW_NS_PROPERTY );
+		$isMovable = true;
+
+		$instance = new TitleIsMovable( $title, $isMovable );
+
+		$this->assertTrue(
+			$instance->process()
+		);
+
+		$this->assertTrue(
+			$isMovable
+		);
+	}
+
+	public function testNonPropertyPageIsAlwaysMovable() {
+
+		$title = Title::newFromText( 'Foo', NS_MAIN );
+		$isMovable = true;
+
+		$instance = new TitleIsMovable( $title, $isMovable );
+
+		$this->assertTrue(
+			$instance->process()
+		);
+
+		$this->assertTrue(
+			$isMovable
+		);
+	}
+
+}


### PR DESCRIPTION
Pre-defined (aka fixed) properties are fixed for a reason therefore prevent a property page that represents a pre-defined property to be non-movable.

Relates to #600.
