### PR TITLE
Fix circular reference for redirects (reverts #204)

### DIFF
--- a/includes/storage/SQLStore/SMW_SQLStore3_Writers.php
+++ b/includes/storage/SQLStore/SMW_SQLStore3_Writers.php
@@ -956,14 +956,6 @@ class SMWSQLStore3Writers {
 				false,
 				true
 			);
-
-			$jobs = $this->makeUpdateJobsForNewRedirect(
-				$subject_t,
-				$subject_ns,
-				$curtarget_t,
-				$curtarget_ns
-			);
-
 		} elseif ( $old_tid != 0 ) { // existing redirect is changed or deleted
 			$db->delete(
 				'smw_fpt_redi',
@@ -1156,21 +1148,6 @@ class SMWSQLStore3Writers {
 		);
 
 		return ( $new_tid == 0 ) ? $sid : $new_tid;
-	}
-
-	private function makeUpdateJobsForNewRedirect( $subjectDBKey, $subjectNS, $targetDBKey, $targetNS ) {
-
-		$jobs = array();
-
-		$title = Title::makeTitleSafe( $subjectNS, $subjectDBKey );
-		$jobs[] = new UpdateJob( $title );
-
-		if ( $targetDBKey !== '' && $targetNS !== -1 ) {
-			$title = Title::makeTitleSafe( $targetNS, $targetDBKey );
-			$jobs[] = new UpdateJob( $title );
-		}
-
-		return $jobs;
 	}
 
 }


### PR DESCRIPTION
What thought as a simple precaution against a non-updated redirect #204 (which might have been caused by a MW issue outlined in #212) can create a circular reference.
- Create page `A` to `#REDIRECT [[B]]`
- Create page `B` to `#REDIRECT [[C]]`
- Create page `C` to `#REDIRECT [[A]]`

Above schema will create an infinite `UpdateJob` Queue (tested with `$wgJobRunRate = 0.01;`).

See also [0].

[0] http://wikimedia.7.x6.nabble.com/MediaWiki-Job-queue-problem-tp5036690p5037600.html
