### PR TITLE
Remove ambiguous responsibility from TitleCreator, add DeepRedirectTarge...

### DIFF
--- a/includes/src/ApplicationFactory.php
+++ b/includes/src/ApplicationFactory.php
@@ -5,7 +5,6 @@ namespace SMW;
 use SMW\MediaWiki\Jobs\JobFactory;
 use SMW\Annotator\PropertyAnnotatorFactory;
 use SMW\MediaWiki\MwCollaboratorFactory;
-
 use SMW\Factbox\FactboxBuilder;
 use SMW\Query\Profiler\QueryProfilerFactory;
 

--- a/includes/src/MediaWiki/DeepRedirectTargetResolver.php
+++ b/includes/src/MediaWiki/DeepRedirectTargetResolver.php
@@ -1,0 +1,97 @@
+<?php
+
+namespace SMW\MediaWiki;
+
+use Title;
+use RuntimeException;
+
+/**
+ * @license GNU GPL v2+
+ * @since 2.1
+ *
+ * @author mwjames
+ */
+class DeepRedirectTargetResolver {
+
+	/**
+	 * @var PageCreator
+	 */
+	private $pageCreator = null;
+
+	/**
+	 * Track titles to prevent circular references caused by double redirects
+	 * on the same title
+	 *
+	 * @var array
+	 */
+	private $knownRedirects = array();
+
+	/**
+	 * @since 2.1
+	 *
+	 * @param PageCreator $pageCreator
+	 */
+	public function __construct( PageCreator $pageCreator ) {
+		$this->pageCreator = $pageCreator;
+	}
+
+	/**
+	 * @since  2.1
+	 *
+	 * @param Title $title
+	 *
+	 * @return Title|null
+	 * @throws RuntimeException
+	 */
+	public function findRedirectTargetFor( Title $title ) {
+		return $this->doResolveRedirectTarget( $title );
+	}
+
+	protected function isValidRedirectTarget( $title ) {
+		return $title instanceof Title && $title->isValidRedirectTarget();
+	}
+
+	protected function isRedirect( $title ) {
+		return $title instanceOf Title && $title->isRedirect();
+	}
+
+	private function doResolveRedirectTarget( Title $title ) {
+
+		if ( $this->isCircularByKnownRedirects( $title ) ) {
+			throw new RuntimeException( "Circular redirect for {$title->getPrefixedDBkey()} detected." );
+		}
+
+		if ( $this->isRedirect( $title ) ) {
+			$title = $this->pageCreator->createPage( $title )->getRedirectTarget();
+
+			if ( $title instanceOf Title ) {
+				$this->addToKnownRedirects( $title );
+				$title = $this->doResolveRedirectTarget( $title );
+			}
+		}
+
+		if ( $this->isValidRedirectTarget( $title ) ) {
+			return $title;
+		}
+
+		throw new RuntimeException( "Redirect target is unresolvable" );
+	}
+
+	private function addToKnownRedirects( $title ) {
+
+		if ( !isset( $this->knownRedirects[ $title->getPrefixedDBkey() ] ) ) {
+			return $this->knownRedirects[ $title->getPrefixedDBkey() ] = false;
+		}
+
+		return $this->knownRedirects[ $title->getPrefixedDBkey() ] = true;
+	}
+
+	/**
+	 * If a title is already tracked then it was inserted during a previous recurive
+	 * run which means that it reached the starting point of a circular reference
+	 */
+	private function isCircularByKnownRedirects( $title ) {
+		return isset( $this->knownRedirects[ $title->getPrefixedDBkey() ] ) && $this->knownRedirects[ $title->getPrefixedDBkey() ];
+	}
+
+}

--- a/includes/src/MediaWiki/MwCollaboratorFactory.php
+++ b/includes/src/MediaWiki/MwCollaboratorFactory.php
@@ -61,6 +61,15 @@ class MwCollaboratorFactory {
 	/**
 	 * @since 2.1
 	 *
+	 * @return DeepRedirectTargetResolver
+	 */
+	public function newDeepRedirectTargetResolver() {
+		return new DeepRedirectTargetResolver( $this->applicationFactory->newPageCreator() );
+	}
+
+	/**
+	 * @since 2.1
+	 *
 	 * @param Title $title
 	 * @param Language|null $language
 	 *

--- a/includes/src/MediaWiki/TitleCreator.php
+++ b/includes/src/MediaWiki/TitleCreator.php
@@ -14,83 +14,14 @@ use RuntimeException;
 class TitleCreator {
 
 	/**
-	 * @var PageCreator
-	 */
-	private $pageCreator = null;
-
-	/**
-	 * @var Title
-	 */
-	private $title = null;
-
-	/**
-	 * @since 2.0
-	 *
-	 * @param PageCreator|null $pageCreator
-	 */
-	public function __construct( PageCreator $pageCreator = null ) {
-		$this->pageCreator = $pageCreator;
-	}
-
-	/**
 	 * @since  2.0
 	 *
 	 * @param  string $text
 	 *
-	 * @return TitleCreator
+	 * @return Title|null
 	 */
-	public function createFromText( $text ) {
-		$this->title = Title::newFromText( $text );
-		return $this;
-	}
-
-	/**
-	 * @since  2.0
-	 *
-	 * @return Title
-	 */
-	public function getTitle() {
-		return $this->title;
-	}
-
-	/**
-	 * @since  2.0
-	 *
-	 * @return TitleCreator
-	 * @throws RuntimeException
-	 */
-	public function findRedirect() {
-
-		if ( $this->pageCreator === null ) {
-			throw new RuntimeException( "Expected a PageCreator instance" );
-		}
-
-		$this->title = $this->resolveRedirectTargetRecursively( $this->title );
-
-		return $this;
-	}
-
-	protected function isValidRedirectTarget( $title ) {
-		return $title instanceof Title && $title->isValidRedirectTarget();
-	}
-
-	protected function isRedirect( $title ) {
-		return $title instanceOf Title && $title->isRedirect();
-	}
-
-	private function resolveRedirectTargetRecursively( $title ) {
-
-		if ( $this->isRedirect( $title ) ) {
-			$title = $this->resolveRedirectTargetRecursively(
-				$this->pageCreator->createPage( $title )->getRedirectTarget()
-			);
-		}
-
-		if ( $this->isValidRedirectTarget( $title ) ) {
-			return $title;
-		}
-
-		throw new RuntimeException( "Redirect target can not be resolved" );
+	public function createFromText( $text, $namespace = NS_MAIN ) {
+		return Title::newFromText( $text, $namespace );
 	}
 
 }

--- a/tests/phpunit/Util/Mock/MockTitle.php
+++ b/tests/phpunit/Util/Mock/MockTitle.php
@@ -29,6 +29,10 @@ class MockTitle extends \PHPUnit_Framework_TestCase {
 			->will( $instance->returnValue( str_replace( ' ', '_', $text ) ) );
 
 		$title->expects( $instance->any() )
+			->method( 'getPrefixedDBkey' )
+			->will( $instance->returnValue( str_replace( ' ', '_', $text ) ) );
+
+		$title->expects( $instance->any() )
 			->method( 'getContentModel' )
 			->will( $instance->returnValue( $contentModel ) );
 

--- a/tests/phpunit/Util/SemanticDataFactory.php
+++ b/tests/phpunit/Util/SemanticDataFactory.php
@@ -57,11 +57,13 @@ class SemanticDataFactory {
 	 */
 	public function newEmptySemanticData( $title = null ) {
 
-		if ( $title !== null ) {
+		if ( $title instanceOf DIWikiPage ) {
+			$this->setSubject( $title );
+		} elseif ( $title !== null ) {
 			$this->setTitle( $title );
 		}
 
-		if ( $this->subject instanceOf DIWikiPage ) {
+		if ( $this->subject !== null ) {
 			return new SemanticData( $this->subject );
 		}
 

--- a/tests/phpunit/Util/UtilityFactory.php
+++ b/tests/phpunit/Util/UtilityFactory.php
@@ -37,6 +37,15 @@ class UtilityFactory {
 	/**
 	 * @since 2.1
 	 *
+	 * @return MwApiFactory
+	 */
+	public function newMwApiFactory() {
+		return new MwApiFactory();
+	}
+
+	/**
+	 * @since 2.1
+	 *
 	 * @return ValidatorFactory
 	 */
 	public function newValidatorFactory() {

--- a/tests/phpunit/includes/MediaWiki/DeepRedirectTargetResolverTest.php
+++ b/tests/phpunit/includes/MediaWiki/DeepRedirectTargetResolverTest.php
@@ -1,0 +1,141 @@
+<?php
+
+namespace SMW\Tests\MediaWiki;
+
+use SMW\MediaWiki\DeepRedirectTargetResolver;
+use SMW\Tests\Util\Mock\MockTitle;
+
+/**
+ * @covers \SMW\MediaWiki\DeepRedirectTargetResolver
+ *
+ * @group SMW
+ * @group SMWExtension
+ *
+ * @license GNU GPL v2+
+ * @since   2.1
+ *
+ * @author mwjames
+ */
+class DeepRedirectTargetResolverTest extends \PHPUnit_Framework_TestCase {
+
+	public function testCanConstruct() {
+
+		$pageCreator = $this->getMockBuilder( '\SMW\MediaWiki\PageCreator' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$this->assertInstanceOf(
+			'\SMW\MediaWiki\DeepRedirectTargetResolver',
+			 new DeepRedirectTargetResolver( $pageCreator )
+		);
+	}
+
+	public function testResolveRedirectTarget() {
+
+		$title = MockTitle::buildMock( 'Uuuuuuuuuu' );
+
+		$wikiPage = $this->getMockBuilder( '\WikiPage' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$wikiPage->expects( $this->atLeastOnce() )
+			->method( 'getRedirectTarget' )
+			->will( $this->returnValue( MockTitle::buildMock( 'Ooooooo' ) ) );
+
+		$pageCreator = $this->getMockBuilder( '\SMW\MediaWiki\PageCreator' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$pageCreator->expects( $this->any() )
+			->method( 'createPage' )
+			->will( $this->returnValue( $wikiPage ) );
+
+		$instance = $this->getMockBuilder( '\SMW\MediaWiki\DeepRedirectTargetResolver' )
+			->setConstructorArgs( array( $pageCreator ) )
+			->setMethods( array( 'isValidRedirectTarget', 'isRedirect' ) )
+			->getMock();
+
+		$instance->expects( $this->atLeastOnce() )
+			->method( 'isValidRedirectTarget' )
+			->will( $this->returnValue( true ) );
+
+		$instance->expects( $this->at( 0 ) )
+			->method( 'isRedirect' )
+			->will( $this->returnValue( true ) );
+
+		$this->assertInstanceOf(
+			'\Title',
+			 $instance->findRedirectTargetFor( $title )
+		);
+	}
+
+	public function testResolveRedirectTargetThrowsException() {
+
+		$title = MockTitle::buildMock( 'Uuuuuuuuuu' );
+
+		$wikiPage = $this->getMockBuilder( '\WikiPage' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$wikiPage->expects( $this->never() )
+			->method( 'getRedirectTarget' );
+
+		$pageCreator = $this->getMockBuilder( '\SMW\MediaWiki\PageCreator' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$pageCreator->expects( $this->any() )
+			->method( 'createPage' )
+			->will( $this->returnValue( $wikiPage ) );
+
+		$instance = $this->getMockBuilder( '\SMW\MediaWiki\DeepRedirectTargetResolver' )
+			->setConstructorArgs( array( $pageCreator ) )
+			->setMethods( array( 'isValidRedirectTarget', 'isRedirect' ) )
+			->getMock();
+
+		$instance->expects( $this->atLeastOnce() )
+			->method( 'isValidRedirectTarget' )
+			->will( $this->returnValue( false ) );
+
+		$instance->expects( $this->at( 0 ) )
+			->method( 'isRedirect' )
+			->will( $this->returnValue( false ) );
+
+		$this->setExpectedException( 'RuntimeException' );
+		$instance->findRedirectTargetFor( $title );
+	}
+
+	public function testTryToResolveCircularRedirectThrowsException() {
+
+		$title = MockTitle::buildMock( 'Uuuuuuuuuu' );
+
+		$wikiPage = $this->getMockBuilder( '\WikiPage' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$wikiPage->expects( $this->atLeastOnce() )
+			->method( 'getRedirectTarget' )
+			->will( $this->returnValue( $title ) );
+
+		$pageCreator = $this->getMockBuilder( '\SMW\MediaWiki\PageCreator' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$pageCreator->expects( $this->any() )
+			->method( 'createPage' )
+			->will( $this->returnValue( $wikiPage ) );
+
+		$instance = $this->getMockBuilder( '\SMW\MediaWiki\DeepRedirectTargetResolver' )
+			->setConstructorArgs( array( $pageCreator ) )
+			->setMethods( array( 'isRedirect' ) )
+			->getMock();
+
+		$instance->expects( $this->any() )
+			->method( 'isRedirect' )
+			->will( $this->returnValue( true ) );
+
+		$this->setExpectedException( 'RuntimeException' );
+		$instance->findRedirectTargetFor( $title );
+	}
+
+}

--- a/tests/phpunit/includes/MediaWiki/MwCollaboratorFactoryTest.php
+++ b/tests/phpunit/includes/MediaWiki/MwCollaboratorFactoryTest.php
@@ -81,6 +81,28 @@ class MwCollaboratorFactoryTest extends \PHPUnit_Framework_TestCase {
 		);
 	}
 
+	public function testCanConstructDeepRedirectTargetResolver() {
+
+		$pageCreator = $this->getMockBuilder( '\SMW\MediaWiki\PageCreator' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$applicationFactory = $this->getMockBuilder( '\SMW\ApplicationFactory' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$applicationFactory->expects( $this->atLeastOnce() )
+			->method( 'newPageCreator' )
+			->will( $this->returnValue( $pageCreator ) );
+
+		$instance = new MwCollaboratorFactory( $applicationFactory );
+
+		$this->assertInstanceOf(
+			'\SMW\MediaWiki\DeepRedirectTargetResolver',
+			$instance->newDeepRedirectTargetResolver()
+		);
+	}
+
 	public function testCanConstructHtmlFormBuilder() {
 
 		$instance = new MwCollaboratorFactory( new ApplicationFactory() );

--- a/tests/phpunit/includes/MediaWiki/TitleCreatorTest.php
+++ b/tests/phpunit/includes/MediaWiki/TitleCreatorTest.php
@@ -8,7 +8,6 @@ use SMW\Tests\Util\Mock\MockTitle;
 /**
  * @covers \SMW\MediaWiki\TitleCreator
  *
- *
  * @group SMW
  * @group SMWExtension
  *
@@ -27,87 +26,14 @@ class TitleCreatorTest extends \PHPUnit_Framework_TestCase {
 		);
 	}
 
-	public function testCreateTitleToNotResolveRedirectTarget() {
+	public function testCreateTitleFromText() {
 
 		$instance = new TitleCreator();
 
 		$this->assertInstanceOf(
-			'\SMW\MediaWiki\TitleCreator',
+			'\Title',
 			 $instance->createFromText( __METHOD__ )
 		);
-
-		$this->assertInstanceOf(
-			'\Title',
-			 $instance->createFromText( __METHOD__ )->getTitle()
-		);
-	}
-
-	public function testCreateTitleTryToResolveRedirectOnMissingPageCreatorThrowsException() {
-
-		$instance = new TitleCreator();
-
-		$this->setExpectedException( 'RuntimeException' );
-		$instance->createFromText( __METHOD__ )->findRedirect();
-	}
-
-	public function testCreateTitleToResolveRedirectTarget() {
-
-		$instance = $this->createInstanceWithResolvableRedirect();
-
-		$this->assertInstanceOf(
-			'\Title',
-			 $instance->createFromText( __METHOD__ )->findRedirect()->getTitle()
-		);
-	}
-
-	public function testCreateTitleWithResolvingRedirectTargetThrowsException() {
-
-		$instance = $this->createInstanceWithUnresolvableRedirect();
-
-		$this->setExpectedException( 'RuntimeException' );
-		$instance->createFromText( __METHOD__ )->findRedirect();
-	}
-
-	private function createInstanceWithResolvableRedirect() {
-		return $this->createInstance( true, true );
-	}
-
-	private function createInstanceWithUnresolvableRedirect() {
-		return $this->createInstance( false, false );
-	}
-
-	private function createInstance( $isRedirect, $isValidRedirectTarget ) {
-
-		$wikiPage = $this->getMockBuilder( '\WikiPage' )
-			->disableOriginalConstructor()
-			->getMock();
-
-		$wikiPage->expects( ( $isRedirect ? $this->atLeastOnce() : $this->never() ) )
-			->method( 'getRedirectTarget' )
-			->will( $this->returnValue( MockTitle::buildMock( 'Ooooooo' ) ) );
-
-		$pageCreator = $this->getMockBuilder( '\SMW\MediaWiki\PageCreator' )
-			->disableOriginalConstructor()
-			->getMock();
-
-		$pageCreator->expects( $this->any() )
-			->method( 'createPage' )
-			->will( $this->returnValue( $wikiPage ) );
-
-		$instance = $this->getMockBuilder( '\SMW\MediaWiki\TitleCreator' )
-			->setConstructorArgs( array( $pageCreator ) )
-			->setMethods( array( 'isValidRedirectTarget', 'isRedirect' ) )
-			->getMock();
-
-		$instance->expects( $this->atLeastOnce() )
-			->method( 'isValidRedirectTarget' )
-			->will( $this->returnValue( $isValidRedirectTarget ) );
-
-		$instance->expects( $this->at( 0 ) )
-			->method( 'isRedirect' )
-			->will( $this->returnValue( $isRedirect ) );
-
-		return $instance;
 	}
 
 }


### PR DESCRIPTION
...tResolver
- Add `DeepRedirectTargetResolver`
- Protect against circular redirects
- Update `BrowseBySubject` to use `DeepRedirectTargetResolver`
- Add subobject parameter to `BrowseBySubject`
- Add `BrowseBySubjectTest::testRawJsonPrintOutput`
- Follow-up on #401
