### PR TITLE
Fix infinite UpdateJob

### DIFF
--- a/includes/StoreUpdater.php
+++ b/includes/StoreUpdater.php
@@ -163,6 +163,8 @@ class StoreUpdater {
 
 		Profiler::In();
 
+		$this->store->setUpdateJobsEnabledState( $this->updateJobsEnabledState );
+
 		if ( $this->processSemantics ) {
 			$this->store->updateData( $this->semanticData );
 		} else {

--- a/includes/src/SPARQLStore/SPARQLStore.php
+++ b/includes/src/SPARQLStore/SPARQLStore.php
@@ -392,6 +392,15 @@ class SPARQLStore extends Store {
 	}
 
 	/**
+	 * @since 2.1
+	 *
+	 * @param boolean $status
+	 */
+	public function setUpdateJobsEnabledState( $status ) {
+		$this->baseStore->setUpdateJobsEnabledState( $status );
+	}
+
+	/**
 	 * @since  1.9.2
 	 *
 	 * @return GenericHttpDatabaseConnector

--- a/includes/storage/SMW_Store.php
+++ b/includes/storage/SMW_Store.php
@@ -41,6 +41,11 @@ abstract class Store {
 	 */
 	protected static $configuration = null;
 
+	/**
+	 * @var boolean
+	 */
+	private $updateJobsEnabledState = true;
+
 ///// Reading methods /////
 
 	/**
@@ -427,6 +432,24 @@ abstract class Store {
 	 */
 	public function setConfiguration( Settings $configuration ) {
 		self::$configuration = $configuration;
+	}
+
+	/**
+	 * @since 2.1
+	 *
+	 * @param boolean $status
+	 */
+	public function setUpdateJobsEnabledState( $status ) {
+		$this->updateJobsEnabledState = $status;
+	}
+
+	/**
+	 * @since 2.1
+	 *
+	 * @return boolean
+	 */
+	public function getUpdateJobsEnabledState() {
+		return $this->updateJobsEnabledState && $GLOBALS['smwgEnableUpdateJobs'];
 	}
 
 }

--- a/includes/storage/SQLStore/SMW_SQLStore3_Writers.php
+++ b/includes/storage/SQLStore/SMW_SQLStore3_Writers.php
@@ -974,7 +974,7 @@ class SMWSQLStore3Writers {
 
 			$count--;
 
-			if ( $smwgEnableUpdateJobs && ( $smwgQEqualitySupport != SMW_EQ_NONE ) ) {
+			if ( $this->store->getUpdateJobsEnabledState() && ( $smwgQEqualitySupport != SMW_EQ_NONE ) ) {
 				// entries that refer to old target may in fact refer to subject,
 				// but we don't know which: schedule affected pages for update
 				$propertyTables = $this->store->getPropertyTables();
@@ -1039,8 +1039,7 @@ class SMWSQLStore3Writers {
 			}
 		}
 
-		/// NOTE: this only happens if $smwgEnableUpdateJobs is true
-		if ( $smwgEnableUpdateJobs ) {
+		if ( $this->store->getUpdateJobsEnabledState() ) {
 			JobBase::batchInsert( $jobs );
 		}
 

--- a/maintenance/rebuildData.php
+++ b/maintenance/rebuildData.php
@@ -104,14 +104,8 @@ class RebuildData extends \Maintenance {
 		$reporter = new ObservableMessageReporter();
 		$reporter->registerReporterCallback( array( $this, 'reportMessage' ) );
 
-		$settings = Settings::newFromGlobals();
-
-		// Do not fork additional update jobs while running this script
-		$settings->set( 'smwgEnableUpdateJobs', false );
-		$GLOBALS['smwgEnableUpdateJobs'] = false; // Some Store classes still rely on GLOBALS
-
 		$store = StoreFactory::getStore( $this->hasOption( 'b' ) ? $this->getOption( 'b' ) : null );
-		$store->setConfiguration( $settings );
+		$store->setUpdateJobsEnabledState( false );
 
 		$dataRebuilder = new DataRebuilder( $store, $reporter );
 		$dataRebuilder->setParameters( $this->mOptions );

--- a/tests/phpunit/Util/Runners/JobQueueRunner.php
+++ b/tests/phpunit/Util/Runners/JobQueueRunner.php
@@ -41,6 +41,18 @@ class JobQueueRunner {
 	/**
 	 * @since 2.1
 	 *
+	 * @param string $type
+	 *
+	 * @return JobQueueRunner
+	 */
+	public function setType( $type ) {
+		$this->type = $type;
+		return $this;
+	}
+
+	/**
+	 * @since 2.1
+	 *
 	 * @param DBConnectionProvider $dbConnectionProvider
 	 *
 	 * @return JobQueueRunner


### PR DESCRIPTION
- Remove GLOBAL state from `SMWSQLStore3Writers::updateRedirects`
- Add `JobQueueDBIntegrationTest::testNoInfiniteUpdateJobsForCircularRedirect`

Relates to #606, [0], [1], #330, #297, #212

[0] http://wikimedia.7.x6.nabble.com/MediaWiki-Job-queue-problem-tp5036690p5037600.html
[1] http://wikimedia.7.x6.nabble.com/dumpRDF-php-script-in-SMW-2-0-fails-problems-with-subobjects-and-redirects-causes-jobqueue-to-loop-tp5038930.html
