### PR TITLE
Re-enable SQLite query tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,14 +79,8 @@ have a look at the contribution guideline.
 
 ### Tests
 
-This extension provides unit and integration tests that are normally run by a
-[continues integration platform][travis] but tests can also manually be executed using the
-`mw-phpunit-runner.php` script or [`phpunit`][mw-testing] together with the PHPUnit configuration
-file found in the root directory.
-
-```sh
-php mw-phpunit-runner.php [options]
-```
+This extension provides unit and integration tests that are normally run by a [continues integration platform][travis]
+but can also be executed manually. A more comprehensive introduction can be found in the [test section](/tests/README.md#running-tests).
 
 ## License
 

--- a/includes/storage/SQLStore/PropertyStatisticsTable.php
+++ b/includes/storage/SQLStore/PropertyStatisticsTable.php
@@ -181,7 +181,7 @@ class PropertyStatisticsTable implements PropertyStatisticsStore {
 		}
 
 		$propertyStatistics = $this->dbConnection->select(
-			$this->table,
+			$this->dbConnection->tablename( $this->table ),
 			array(
 				'usage_count',
 				'p_id',

--- a/includes/storage/SQLStore/SMW_SQLStore3_Queries.php
+++ b/includes/storage/SQLStore/SMW_SQLStore3_Queries.php
@@ -571,9 +571,8 @@ class SMWSQLStore3QueryEngine {
 				$query->jointable = '';
 				$query->joinfield = '';
 			} else { // Instance query with disjunction of classes (categories)
-				$query->jointable = $this->m_dbs->tableName(
-					$this->m_store->findPropertyTableID(
-						new SMWDIProperty( '_INST' ) ) );
+				$query->jointable = $this->m_store->findPropertyTableID(
+						new SMWDIProperty( '_INST' ) );
 				$query->joinfield = "$query->alias.s_id";
 				$query->components[$cqid] = "$query->alias.o_id";
 				$this->m_queries[$cqid] = $cquery;

--- a/includes/storage/SQLStore/SMW_SQLStore3_Writers.php
+++ b/includes/storage/SQLStore/SMW_SQLStore3_Writers.php
@@ -208,7 +208,8 @@ class SMWSQLStore3Writers {
 
 		$db = $this->store->getDatabase();
 
-		$res = $db->select( SMWSql3SmwIds::tableName,
+		$res = $db->select(
+			$db->tablename( SMWSql3SmwIds::tableName ),
 			'smw_id,smw_subobject',
 			'smw_title = ' . $db->addQuotes( $subject->getDBkey() ) . ' AND ' .
 			'smw_namespace = ' . $db->addQuotes( $subject->getNamespace() ) . ' AND ' .
@@ -486,7 +487,7 @@ class SMWSQLStore3Writers {
 		$db = $this->store->getDatabase();
 
 		$result = $db->select(
-			$propertyTable->getName(),
+			$db->tablename( $propertyTable->getName() ),
 			'*',
 			array( 's_id' => $sid ),
 			__METHOD__

--- a/tests/README.md
+++ b/tests/README.md
@@ -15,6 +15,8 @@ For the automated approach, Semantic MediaWiki uses [PHPUnit][phpunit] as script
 
 Most scripted tests for SMW are written for and executed by PHPUnit. PHPUnit provides the necessary environment to execute unit tests within PHP. Information about how to work with PHPunit can be found at [smw.org][smw] and [mediawiki.org][mw-phpunit-testing].
 
+## Running tests
+
 In case PHUnit is not already installed, use `composer require phpunit/phpunit:~4.1` to install the package and execute the tests by simply running the `mw-phpunit-runner.php` script from the test directory or use [`phpunit`][mw-phpunit-testing] together with the PHPUnit configuration file and MediaWiki's `phpunit.php` loader.
 
 ```sh

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -6,7 +6,7 @@ if ( php_sapi_name() !== 'cli' ) {
 
 $autoloader = require __DIR__ . '/autoloader.php';
 
-print( "{$GLOBALS['smwgDefaultStore']}" . ( strpos( $GLOBALS['smwgDefaultStore'], 'SQL' ) ? '' : ' & ' . $GLOBALS['smwgSparqlDatabaseConnector'] ) . " ...\n\n" );
+print( "{$GLOBALS['smwgDefaultStore']} ({$GLOBALS['wgDBtype']})" . ( strpos( $GLOBALS['smwgDefaultStore'], 'SQL' ) ? '' : ' & ' . $GLOBALS['smwgSparqlDatabaseConnector'] ) . " ...\n\n" );
 
 $autoloader->addPsr4( 'SMW\\Test\\', __DIR__ . '/phpunit' );
 $autoloader->addPsr4( 'SMW\\Tests\\', __DIR__ . '/phpunit' );

--- a/tests/mw-phpunit-runner.php
+++ b/tests/mw-phpunit-runner.php
@@ -12,32 +12,18 @@ if ( php_sapi_name() !== 'cli' ) {
 
 print( "\nMediaWiki phpunit runnner ... \n" );
 
-function isReadablePath( $path ) {
+function isAccessiblePath( $path ) {
 
 	if ( is_readable( $path ) ) {
 		return $path;
 	}
 
-	throw new RuntimeException( "Expected an accessible {$path} path" );
+	die( "Expected an accessible {$path}" );
 }
 
-function addArguments( $args ) {
+$mw = isAccessiblePath( __DIR__ . "/../../../tests/phpunit/phpunit.php" );
+$config = isAccessiblePath( __DIR__ . "/../phpunit.xml.dist" );
 
-	$arguments = array();
+array_shift( $GLOBALS['argv'] );
 
-	for ( $arg = reset( $args ); $arg !== false; $arg = next( $args ) ) {
-
-		if ( $arg === basename( __FILE__ ) ) {
-			continue;
-		}
-
-		$arguments[] = $arg;
-	}
-
-	return $arguments;
-}
-
-$mw = isReadablePath( __DIR__ . "/../../../tests/phpunit/phpunit.php" );
-$config = isReadablePath( __DIR__ . "/../phpunit.xml.dist" );
-
-return passthru( "php {$mw} -c {$config} " . implode( ' ', addArguments( $GLOBALS['argv'] ) ) );
+return passthru( "php {$mw} -c {$config} ". implode( ' ', $GLOBALS['argv'] ) );

--- a/tests/phpunit/Integration/MediaWiki/Hooks/TitleMoveCompleteIntegrationTest.php
+++ b/tests/phpunit/Integration/MediaWiki/Hooks/TitleMoveCompleteIntegrationTest.php
@@ -101,7 +101,7 @@ class TitleMoveCompleteIntegrationTest extends MwDBaseUnitTestCase {
 	public function testPageMoveWithRemovalOfOldPage() {
 
 		// PHPUnit query issue
-		$this->skipTestForDatabase( array( 'postgres', 'sqlite' ) );
+		$this->skipTestForDatabase( array( 'postgres' ) );
 
 		// Revison showed an issue on 1.19 not being null after the move
 		$this->skipTestForMediaWikiVersionLowerThan( '1.21' );

--- a/tests/phpunit/Integration/MediaWiki/MediaWikiIntegrationForRegisteredHookTest.php
+++ b/tests/phpunit/Integration/MediaWiki/MediaWikiIntegrationForRegisteredHookTest.php
@@ -131,7 +131,7 @@ class MediaWikiIntegrationForRegisteredHookTest extends MwDBaseUnitTestCase {
 
 		$pageCreator
 			->createPage( $this->title )
-			->doEdit( '[[Has function hook test::new revision]]' );
+			->doEdit( '[[EditPageToGetNewRevisionHookTest::Foo]]' );
 
 		$parserOutput = $pageCreator->getEditInfo()->output;
 
@@ -146,7 +146,7 @@ class MediaWikiIntegrationForRegisteredHookTest extends MwDBaseUnitTestCase {
 		);
 
 		$expected = array(
-			'propertyKeys' => array( '_SKEY', '_MDAT', 'Has_function_hook_test' )
+			'propertyKeys' => array( '_SKEY', '_MDAT', 'EditPageToGetNewRevisionHookTest' )
 		);
 
 		$this->semanticDataValidator->assertThatPropertiesAreSet(

--- a/tests/phpunit/Integration/MediaWiki/ParserFunctionInPageEmbeddedForQueryResultLookupDBIntegrationTest.php
+++ b/tests/phpunit/Integration/MediaWiki/ParserFunctionInPageEmbeddedForQueryResultLookupDBIntegrationTest.php
@@ -35,13 +35,6 @@ use Title;
  */
 class ParserFunctionInPageEmbeddedForQueryResultLookupDBIntegrationTest extends MwDBaseUnitTestCase {
 
-	/**
-	 * FIXME SQLStore QueryEngine is in shambles when it comes to unit testability
-	 * on sqlite. It would require considerable effort to get the QueryEngine
-	 * testable therefore we exclude sqlite from running.
-	 */
-	protected $databaseToBeExcluded = array( 'sqlite' );
-
 	protected $titles = array();
 
 	private $queryResultValidator;

--- a/tests/phpunit/Integration/MediaWiki/SearchInPageDBIntegrationTest.php
+++ b/tests/phpunit/Integration/MediaWiki/SearchInPageDBIntegrationTest.php
@@ -13,8 +13,10 @@ use Title;
 /**
  * @group SMW
  * @group SMWExtension
+ *
  * @group semantic-mediawiki-integration
  * @group mediawiki-database
+ *
  * @group medium
  *
  * @license GNU GPL v2+
@@ -23,8 +25,6 @@ use Title;
  * @author mwjames
  */
 class SearchInPageDBIntegrationTest extends MwDBaseUnitTestCase {
-
-	protected $databaseToBeExcluded = array( 'sqlite' );
 
 	public function testSearchForPageValueAsTerm() {
 

--- a/tests/phpunit/Integration/Query/BlobPropertyValueQueryDBIntegrationTest.php
+++ b/tests/phpunit/Integration/Query/BlobPropertyValueQueryDBIntegrationTest.php
@@ -6,6 +6,9 @@ use SMW\Tests\MwDBaseUnitTestCase;
 use SMW\Tests\Util\SemanticDataFactory;
 use SMW\Tests\Util\Validators\QueryResultValidator;
 
+use SMW\Query\Language\ThingDescription;
+use SMW\Query\Language\SomeProperty;
+
 use SMW\DIWikiPage;
 use SMW\DIProperty;
 use SMW\DataValueFactory;
@@ -15,17 +18,16 @@ use SMWQuery as Query;
 use SMWQueryResult as QueryResult;
 use SMWDataValue as DataValue;
 use SMWDataItem as DataItem;
-use SMW\Query\Language\SomeProperty as SomeProperty;
 use SMWPrintRequest as PrintRequest;
 use SMWPropertyValue as PropertyValue;
-use SMW\Query\Language\ThingDescription as ThingDescription;
 
 /**
- *
  * @group SMW
  * @group SMWExtension
+ *
  * @group semantic-mediawiki-integration
  * @group semantic-mediawiki-query
+ *
  * @group mediawiki-database
  * @group medium
  *
@@ -35,8 +37,6 @@ use SMW\Query\Language\ThingDescription as ThingDescription;
  * @author mwjames
  */
 class BlobPropertyValueQueryDBIntegrationTest extends MwDBaseUnitTestCase {
-
-	protected $databaseToBeExcluded = array( 'sqlite' );
 
 	private $subjectsToBeCleared = array();
 	private $semanticDataFactory;

--- a/tests/phpunit/Integration/Query/CategoryClassQueryDBIntegrationTest.php
+++ b/tests/phpunit/Integration/Query/CategoryClassQueryDBIntegrationTest.php
@@ -3,8 +3,11 @@
 namespace SMW\Tests\Integration\Query;
 
 use SMW\Tests\MwDBaseUnitTestCase;
-use SMW\Tests\Util\SemanticDataFactory;
-use SMW\Tests\Util\Validators\QueryResultValidator;
+use SMW\Tests\Util\UtilityFactory;
+
+use SMW\Query\Language\ThingDescription;
+use SMW\Query\Language\ClassDescription;
+use SMW\Query\Language\SomeProperty;
 
 use SMW\DIWikiPage;
 use SMW\DIProperty;
@@ -15,18 +18,16 @@ use SMWQuery as Query;
 use SMWQueryResult as QueryResult;
 use SMWDataValue as DataValue;
 use SMWDataItem as DataItem;
-use SMW\Query\Language\SomeProperty as SomeProperty;
 use SMWPrintRequest as PrintRequest;
 use SMWPropertyValue as PropertyValue;
-use SMW\Query\Language\ThingDescription as ThingDescription;
-use SMW\Query\Language\ClassDescription as ClassDescription;
 
 /**
- *
  * @group SMW
  * @group SMWExtension
+ *
  * @group semantic-mediawiki-integration
  * @group semantic-mediawiki-query
+ *
  * @group mediawiki-database
  * @group medium
  *
@@ -37,10 +38,9 @@ use SMW\Query\Language\ClassDescription as ClassDescription;
  */
 class CategoryClassQueryDBIntegrationTest extends MwDBaseUnitTestCase {
 
-	protected $databaseToBeExcluded = array( 'sqlite' );
-
 	private $subjectsToBeCleared = array();
 	private $semanticDataFactory;
+
 	private $dataValueFactory;
 	private $queryResultValidator;
 
@@ -48,8 +48,8 @@ class CategoryClassQueryDBIntegrationTest extends MwDBaseUnitTestCase {
 		parent::setUp();
 
 		$this->dataValueFactory = DataValueFactory::getInstance();
-		$this->semanticDataFactory = new SemanticDataFactory();
-		$this->queryResultValidator = new QueryResultValidator();
+		$this->queryResultValidator = UtilityFactory::getInstance()->newValidatorFactory()->newQueryResultValidator();
+		$this->semanticDataFactory = UtilityFactory::getInstance()->newSemanticDataFactory();
 	}
 
 	protected function tearDown() {

--- a/tests/phpunit/Integration/Query/ComparatorFilterConditionQueryDBIntegrationTest.php
+++ b/tests/phpunit/Integration/Query/ComparatorFilterConditionQueryDBIntegrationTest.php
@@ -3,11 +3,14 @@
 namespace SMW\Tests\Integration\Query;
 
 use SMW\Tests\MwDBaseUnitTestCase;
-use SMW\Tests\Util\SemanticDataFactory;
-use SMW\Tests\Util\Validators\QueryResultValidator;
+use SMW\Tests\Util\UtilityFactory;
 
 use SMW\SPARQLStore\SPARQLStore;
 use SMW\SPARQLStore\VirtuosoHttpDatabaseConnector;
+
+use SMW\Query\Language\ValueDescription;
+use SMW\Query\Language\SomeProperty;
+use SMW\Query\Language\ThingDescription;
 
 use SMW\DIWikiPage;
 use SMW\DIProperty;
@@ -17,17 +20,15 @@ use SMWDIBlob as DIBlob;
 use SMWDITime as DITime;
 use SMWQuery as Query;
 use SMWQueryResult as QueryResult;
-use SMW\Query\Language\SomeProperty as SomeProperty;
-use SMW\Query\Language\ThingDescription as ThingDescription;
 use SMwConjunction as Conjunction;
-use SMW\Query\Language\ValueDescription as ValueDescription;
 
 /**
- *
  * @group SMW
  * @group SMWExtension
+ *
  * @group semantic-mediawiki-integration
  * @group semantic-mediawiki-query
+ *
  * @group mediawiki-database
  * @group medium
  *
@@ -38,8 +39,6 @@ use SMW\Query\Language\ValueDescription as ValueDescription;
  */
 class ComparatorFilterConditionQueryDBIntegrationTest extends MwDBaseUnitTestCase {
 
-	protected $databaseToBeExcluded = array( 'sqlite' );
-
 	private $subjectsToBeCleared = array();
 	private $semanticDataFactory;
 	private $queryResultValidator;
@@ -47,8 +46,8 @@ class ComparatorFilterConditionQueryDBIntegrationTest extends MwDBaseUnitTestCas
 	protected function setUp() {
 		parent::setUp();
 
-		$this->semanticDataFactory = new SemanticDataFactory();
-		$this->queryResultValidator = new QueryResultValidator();
+		$this->queryResultValidator = UtilityFactory::getInstance()->newValidatorFactory()->newQueryResultValidator();
+		$this->semanticDataFactory = UtilityFactory::getInstance()->newSemanticDataFactory();
 	}
 
 	protected function tearDown() {

--- a/tests/phpunit/Integration/Query/ConceptQueryDBIntegrationTest.php
+++ b/tests/phpunit/Integration/Query/ConceptQueryDBIntegrationTest.php
@@ -21,8 +21,10 @@ use SMWQuery as Query;
 /**
  * @group SMW
  * @group SMWExtension
+ *
  * @group semantic-mediawiki-integration
  * @group semantic-mediawiki-query
+ *
  * @group mediawiki-database
  * @group medium
  *
@@ -33,7 +35,7 @@ use SMWQuery as Query;
  */
 class ConceptQueryDBIntegrationTest extends MwDBaseUnitTestCase {
 
-	protected $databaseToBeExcluded = array( 'sqlite', 'postgres' );
+	protected $databaseToBeExcluded = array( 'postgres' );
 	protected $storesToBeExcluded = array( 'SMW\SPARQLStore\SPARQLStore' );
 
 	private $fixturesProvider;

--- a/tests/phpunit/Integration/Query/ConjunctionQueryDBIntegrationTest.php
+++ b/tests/phpunit/Integration/Query/ConjunctionQueryDBIntegrationTest.php
@@ -5,6 +5,13 @@ namespace SMW\Tests\Integration\Query;
 use SMW\Tests\MwDBaseUnitTestCase;
 use SMW\Tests\Util\UtilityFactory;
 
+use SMW\Query\Language\SomeProperty;
+use SMW\Query\Language\ThingDescription;
+use SMW\Query\Language\ValueDescription;
+use SMW\Query\Language\Conjunction;
+use SMW\Query\Language\Disjunction;
+use SMW\Query\Language\ClassDescription;
+
 use SMW\DIWikiPage;
 use SMW\DIProperty;
 use SMW\SemanticData;
@@ -13,12 +20,6 @@ use SMWQueryParser as QueryParser;
 use SMWDIBlob as DIBlob;
 use SMWDINumber as DINumber;
 use SMWQuery as Query;
-use SMW\Query\Language\SomeProperty as SomeProperty;
-use SMW\Query\Language\ThingDescription as ThingDescription;
-use SMW\Query\Language\ValueDescription as ValueDescription;
-use SMW\Query\Language\Conjunction as Conjunction;
-use SMW\Query\Language\Disjunction as Disjunction;
-use SMW\Query\Language\ClassDescription as ClassDescription;
 
 /**
  * @group SMW
@@ -36,8 +37,6 @@ use SMW\Query\Language\ClassDescription as ClassDescription;
  * @author mwjames
  */
 class ConjunctionQueryDBIntegrationTest extends MwDBaseUnitTestCase {
-
-	protected $databaseToBeExcluded = array( 'sqlite' );
 
 	private $subjectsToBeCleared = array();
 	private $semanticDataFactory;

--- a/tests/phpunit/Integration/Query/CustomUnitDataTypeQueryDBIntegrationTest.php
+++ b/tests/phpunit/Integration/Query/CustomUnitDataTypeQueryDBIntegrationTest.php
@@ -18,8 +18,10 @@ use SMWQuery as Query;
 /**
  * @group SMW
  * @group SMWExtension
+ *
  * @group semantic-mediawiki-integration
  * @group semantic-mediawiki-query
+ *
  * @group mediawiki-database
  * @group medium
  *
@@ -29,8 +31,6 @@ use SMWQuery as Query;
  * @author mwjames
  */
 class CustomUnitDataTypeQueryDBIntegrationTest extends MwDBaseUnitTestCase {
-
-	protected $databaseToBeExcluded = array( 'sqlite' );
 
 	private $fixturesProvider;
 	private $semanticDataFactory;

--- a/tests/phpunit/Integration/Query/DatePropertyValueQueryDBIntegrationTest.php
+++ b/tests/phpunit/Integration/Query/DatePropertyValueQueryDBIntegrationTest.php
@@ -25,8 +25,10 @@ use SMWExporter as Exporter;
 /**
  * @group SMW
  * @group SMWExtension
+ *
  * @group semantic-mediawiki-integration
  * @group semantic-mediawiki-query
+ *
  * @group mediawiki-database
  * @group medium
  *
@@ -36,8 +38,6 @@ use SMWExporter as Exporter;
  * @author mwjames
  */
 class DatePropertyValueQueryDBIntegrationTest extends MwDBaseUnitTestCase {
-
-	protected $databaseToBeExcluded = array( 'sqlite' );
 
 	private $subjectsToBeCleared = array();
 	private $semanticDataFactory;

--- a/tests/phpunit/Integration/Query/DisjunctionQueryDBIntegrationTest.php
+++ b/tests/phpunit/Integration/Query/DisjunctionQueryDBIntegrationTest.php
@@ -3,8 +3,14 @@
 namespace SMW\Tests\Integration\Query;
 
 use SMW\Tests\MwDBaseUnitTestCase;
-use SMW\Tests\Util\SemanticDataFactory;
-use SMW\Tests\Util\Validators\QueryResultValidator;
+use SMW\Tests\Util\UtilityFactory;
+
+use SMW\Query\Language\ThingDescription;
+use SMW\Query\Language\ValueDescription;
+use SMW\Query\Language\Conjunction;
+use SMW\Query\Language\Disjunction;
+use SMW\Query\Language\ClassDescription;
+use SMW\Query\Language\SomeProperty;
 
 use SMW\DIWikiPage;
 use SMW\DIProperty;
@@ -14,13 +20,7 @@ use SMWQueryParser as QueryParser;
 use SMWDIBlob as DIBlob;
 use SMWDINumber as DINumber;
 use SMWQuery as Query;
-use SMW\Query\Language\SomeProperty as SomeProperty;
 use SMWPropertyValue as PropertyValue;
-use SMW\Query\Language\ThingDescription as ThingDescription;
-use SMW\Query\Language\ValueDescription as ValueDescription;
-use SMW\Query\Language\Conjunction as Conjunction;
-use SMW\Query\Language\Disjunction as Disjunction;
-use SMW\Query\Language\ClassDescription as ClassDescription;
 
 /**
  *
@@ -41,7 +41,7 @@ class DisjunctionQueryDBIntegrationTest extends MwDBaseUnitTestCase {
 	/**
 	 * Issues with postgres + disjunction, for details see #454
 	 */
-	protected $databaseToBeExcluded = array( 'sqlite', 'postgres' );
+	protected $databaseToBeExcluded = array( 'postgres' );
 
 	private $subjectsToBeCleared = array();
 	private $semanticDataFactory;
@@ -51,8 +51,8 @@ class DisjunctionQueryDBIntegrationTest extends MwDBaseUnitTestCase {
 	protected function setUp() {
 		parent::setUp();
 
-		$this->semanticDataFactory = new SemanticDataFactory();
-		$this->queryResultValidator = new QueryResultValidator();
+		$this->queryResultValidator = UtilityFactory::getInstance()->newValidatorFactory()->newQueryResultValidator();
+		$this->semanticDataFactory = UtilityFactory::getInstance()->newSemanticDataFactory();
 		$this->queryParser = new QueryParser();
 
 	//	$this->getStore()->getSparqlDatabase()->deleteAll();

--- a/tests/phpunit/Integration/Query/GeneralQueryDBIntegrationTest.php
+++ b/tests/phpunit/Integration/Query/GeneralQueryDBIntegrationTest.php
@@ -3,8 +3,10 @@
 namespace SMW\Tests\Integration\Query;
 
 use SMW\Tests\MwDBaseUnitTestCase;
-use SMW\Tests\Util\SemanticDataFactory;
-use SMW\Tests\Util\Validators\QueryResultValidator;
+use SMW\Tests\Util\UtilityFactory;
+
+use SMW\Query\Language\ThingDescription;
+use SMW\Query\Language\SomeProperty;
 
 use SMW\DIWikiPage;
 use SMW\DIProperty;
@@ -12,17 +14,16 @@ use SMW\DataValueFactory;
 
 use SMWQuery as Query;
 use SMWQueryResult as QueryResult;
-use SMW\Query\Language\SomeProperty as SomeProperty;
 use SMWPrintRequest as PrintRequest;
 use SMWPropertyValue as PropertyValue;
-use SMW\Query\Language\ThingDescription as ThingDescription;
 
 /**
- *
  * @group SMW
  * @group SMWExtension
+ *
  * @group semantic-mediawiki-integration
  * @group semantic-mediawiki-query
+ *
  * @group mediawiki-database
  * @group medium
  *
@@ -33,10 +34,9 @@ use SMW\Query\Language\ThingDescription as ThingDescription;
  */
 class GeneralQueryDBIntegrationTest extends MwDBaseUnitTestCase {
 
-	protected $databaseToBeExcluded = array( 'sqlite' );
-
 	private $subjectsToBeCleared = array();
 	private $subject;
+
 	private $dataValueFactory;
 	private $queryResultValidator;
 
@@ -44,8 +44,8 @@ class GeneralQueryDBIntegrationTest extends MwDBaseUnitTestCase {
 		parent::setUp();
 
 		$this->dataValueFactory = DataValueFactory::getInstance();
-		$this->queryResultValidator = new QueryResultValidator();
-		$this->semanticDataFactory = new SemanticDataFactory();
+		$this->queryResultValidator = UtilityFactory::getInstance()->newValidatorFactory()->newQueryResultValidator();
+		$this->semanticDataFactory = UtilityFactory::getInstance()->newSemanticDataFactory();
 	}
 
 	protected function tearDown() {

--- a/tests/phpunit/Integration/Query/InversePropertyRelationshipDBIntegrationTest.php
+++ b/tests/phpunit/Integration/Query/InversePropertyRelationshipDBIntegrationTest.php
@@ -3,8 +3,11 @@
 namespace SMW\Tests\Integration\Query;
 
 use SMW\Tests\MwDBaseUnitTestCase;
-use SMW\Tests\Util\SemanticDataFactory;
-use SMW\Tests\Util\Validators\QueryResultValidator;
+use SMW\Tests\Util\UtilityFactory;
+
+use SMW\Query\Language\ThingDescription;
+use SMW\Query\Language\ValueDescription;
+use SMW\Query\Language\SomeProperty;
 
 use SMW\DIWikiPage;
 use SMW\DIProperty;
@@ -19,20 +22,18 @@ use SMWQuery as Query;
 use SMWQueryResult as QueryResult;
 use SMWDataValue as DataValue;
 use SMWDataItem as DataItem;
-use SMW\Query\Language\SomeProperty as SomeProperty;
 use SMWPrintRequest as PrintRequest;
 use SMWPropertyValue as PropertyValue;
-use SMW\Query\Language\ThingDescription as ThingDescription;
-use SMW\Query\Language\ValueDescription as ValueDescription;
 
 /**
  * @see http://semantic-mediawiki.org/wiki/Inverse_Properties
  *
- *
  * @group SMW
  * @group SMWExtension
+ *
  * @group semantic-mediawiki-integration
  * @group semantic-mediawiki-query
+ *
  * @group mediawiki-database
  * @group medium
  *
@@ -43,20 +44,21 @@ use SMW\Query\Language\ValueDescription as ValueDescription;
  */
 class InversePropertyRelationshipDBIntegrationTest extends MwDBaseUnitTestCase {
 
-	protected $databaseToBeExcluded = array( 'sqlite' );
-
 	private $subjectsToBeCleared = array();
+
 	private $semanticDataFactory;
 	private $dataValueFactory;
+
 	private $queryResultValidator;
 	private $queryParser;
 
 	protected function setUp() {
 		parent::setUp();
 
+		$this->queryResultValidator = UtilityFactory::getInstance()->newValidatorFactory()->newQueryResultValidator();
+		$this->semanticDataFactory = UtilityFactory::getInstance()->newSemanticDataFactory();
+
 		$this->dataValueFactory = DataValueFactory::getInstance();
-		$this->semanticDataFactory = new SemanticDataFactory();
-		$this->queryResultValidator = new QueryResultValidator();
 		$this->queryParser = new QueryParser();
 	}
 

--- a/tests/phpunit/Integration/Query/NamespaceQueryDBIntegrationTest.php
+++ b/tests/phpunit/Integration/Query/NamespaceQueryDBIntegrationTest.php
@@ -15,8 +15,10 @@ use SMWQuery as Query;
 /**
  * @group SMW
  * @group SMWExtension
+ *
  * @group semantic-mediawiki-integration
  * @group semantic-mediawiki-query
+ *
  * @group mediawiki-database
  * @group medium
  *
@@ -26,8 +28,6 @@ use SMWQuery as Query;
  * @author mwjames
  */
 class NamespaceQueryDBIntegrationTest extends MwDBaseUnitTestCase {
-
-	protected $databaseToBeExcluded = array( 'sqlite' );
 
 	private $fixturesProvider;
 	private $semanticDataFactory;

--- a/tests/phpunit/Integration/Query/NullQueryResultTest.php
+++ b/tests/phpunit/Integration/Query/NullQueryResultTest.php
@@ -1,18 +1,17 @@
 <?php
 
-namespace SMW\Tests\SPARQLStore;
+namespace SMW\Tests\Integration\Query;
 
 use SMW\DIWikiPage;
 use SMW\ApplicationFactory;
 
 use SMWQuery as Query;
-use SMW\Query\Language\ValueDescription as ValueDescription;
-use SMW\Query\Language\Conjunction as Conjunction;
-use SMW\Query\Language\Disjunction as Disjunction;
-use SMW\Query\Language\NamespaceDescription as NamespaceDescription;
+use SMW\Query\Language\ValueDescription;
+use SMW\Query\Language\Conjunction;
+use SMW\Query\Language\Disjunction;
+use SMW\Query\Language\NamespaceDescription;
 
 /**
- *
  * @group SMW
  * @group SMWExtension
  *

--- a/tests/phpunit/Integration/Query/NumericPropertyValueQueryDBIntegrationTest.php
+++ b/tests/phpunit/Integration/Query/NumericPropertyValueQueryDBIntegrationTest.php
@@ -3,8 +3,11 @@
 namespace SMW\Tests\Integration\Query;
 
 use SMW\Tests\MwDBaseUnitTestCase;
-use SMW\Tests\Util\SemanticDataFactory;
-use SMW\Tests\Util\Validators\QueryResultValidator;
+use SMW\Tests\Util\UtilityFactory;
+
+use SMW\Query\Language\ThingDescription;
+use SMW\Query\Language\ValueDescription;
+use SMW\Query\Language\SomeProperty;
 
 use SMW\DIWikiPage;
 use SMW\DIProperty;
@@ -17,18 +20,16 @@ use SMWQuery as Query;
 use SMWQueryResult as QueryResult;
 use SMWDataValue as DataValue;
 use SMWDataItem as DataItem;
-use SMW\Query\Language\SomeProperty as SomeProperty;
 use SMWPrintRequest as PrintRequest;
 use SMWPropertyValue as PropertyValue;
-use SMW\Query\Language\ThingDescription as ThingDescription;
-use SMW\Query\Language\ValueDescription as ValueDescription;
 
 /**
- *
  * @group SMW
  * @group SMWExtension
+ *
  * @group semantic-mediawiki-integration
  * @group semantic-mediawiki-query
+ *
  * @group mediawiki-database
  * @group medium
  *
@@ -39,20 +40,20 @@ use SMW\Query\Language\ValueDescription as ValueDescription;
  */
 class NumericPropertyValueQueryDBIntegrationTest extends MwDBaseUnitTestCase {
 
-	protected $databaseToBeExcluded = array( 'sqlite' );
-
 	private $subjectsToBeCleared = array();
 	private $semanticDataFactory;
 	private $dataValueFactory;
+
 	private $queryResultValidator;
 	private $queryParser;
 
 	protected function setUp() {
 		parent::setUp();
 
+		$this->queryResultValidator = UtilityFactory::getInstance()->newValidatorFactory()->newQueryResultValidator();
+		$this->semanticDataFactory = UtilityFactory::getInstance()->newSemanticDataFactory();
+
 		$this->dataValueFactory = DataValueFactory::getInstance();
-		$this->semanticDataFactory = new SemanticDataFactory();
-		$this->queryResultValidator = new QueryResultValidator();
 		$this->queryParser = new QueryParser();
 	}
 

--- a/tests/phpunit/Integration/Query/RecordTypeQueryTest.php
+++ b/tests/phpunit/Integration/Query/RecordTypeQueryTest.php
@@ -18,8 +18,8 @@ use SMWExporter as Exporter;
  *
  * @group semantic-mediawiki-integration
  * @group semantic-mediawiki-query
- * @group semantic-mediawiki-database
  *
+ * @group semantic-mediawiki-database
  * @group medium
  *
  * @license GNU GPL v2+
@@ -28,8 +28,6 @@ use SMWExporter as Exporter;
  * @author mwjames
  */
 class RecordTypeQueryTest extends MwDBaseUnitTestCase {
-
-	protected $databaseToBeExcluded = array( 'sqlite' );
 
 	private $queryResultValidator;
 	private $fixturesProvider;

--- a/tests/phpunit/Integration/Query/SortableQueryDBIntegrationTest.php
+++ b/tests/phpunit/Integration/Query/SortableQueryDBIntegrationTest.php
@@ -3,8 +3,7 @@
 namespace SMW\Tests\Integration\Query;
 
 use SMW\Tests\MwDBaseUnitTestCase;
-use SMW\Tests\Util\SemanticDataFactory;
-use SMW\Tests\Util\Validators\QueryResultValidator;
+use SMW\Tests\Util\UtilityFactory;
 
 use SMW\Query\Language\SomeProperty;
 use SMW\Query\Language\ThingDescription;
@@ -19,8 +18,10 @@ use SMWPropertyValue as PropertyValue;
 /**
  * @group SMW
  * @group SMWExtension
+ *
  * @group semantic-mediawiki-integration
  * @group semantic-mediawiki-query
+ *
  * @group mediawiki-database
  * @group medium
  *
@@ -31,8 +32,6 @@ use SMWPropertyValue as PropertyValue;
  */
 class SortableQueryDBIntegrationTest extends MwDBaseUnitTestCase {
 
-	protected $databaseToBeExcluded = array( 'sqlite' );
-
 	private $subjectsToBeCleared = array();
 	private $semanticDataFactory;
 	private $queryResultValidator;
@@ -40,8 +39,8 @@ class SortableQueryDBIntegrationTest extends MwDBaseUnitTestCase {
 	protected function setUp() {
 		parent::setUp();
 
-		$this->semanticDataFactory = new SemanticDataFactory();
-		$this->queryResultValidator = new QueryResultValidator();
+		$this->queryResultValidator = UtilityFactory::getInstance()->newValidatorFactory()->newQueryResultValidator();
+		$this->semanticDataFactory = UtilityFactory::getInstance()->newSemanticDataFactory();
 	}
 
 	protected function tearDown() {

--- a/tests/phpunit/Integration/Query/SpecialCharactersQueryDBIntegrationTest.php
+++ b/tests/phpunit/Integration/Query/SpecialCharactersQueryDBIntegrationTest.php
@@ -3,8 +3,10 @@
 namespace SMW\Tests\Integration\Query;
 
 use SMW\Tests\MwDBaseUnitTestCase;
-use SMW\Tests\Util\SemanticDataFactory;
-use SMW\Tests\Util\Validators\QueryResultValidator;
+use SMW\Tests\Util\UtilityFactory;
+
+use SMW\Query\Language\ThingDescription;
+use SMW\Query\Language\SomeProperty;
 
 use SMW\DIWikiPage;
 use SMW\DIProperty;
@@ -16,17 +18,16 @@ use SMWQuery as Query;
 use SMWQueryResult as QueryResult;
 use SMWDataValue as DataValue;
 use SMWDataItem as DataItem;
-use SMW\Query\Language\SomeProperty as SomeProperty;
 use SMWPrintRequest as PrintRequest;
 use SMWPropertyValue as PropertyValue;
-use SMW\Query\Language\ThingDescription as ThingDescription;
 
 /**
- *
  * @group SMW
  * @group SMWExtension
+ *
  * @group semantic-mediawiki-integration
  * @group semantic-mediawiki-query
+ *
  * @group mediawiki-database
  * @group medium
  *
@@ -37,8 +38,6 @@ use SMW\Query\Language\ThingDescription as ThingDescription;
  */
 class SpecialCharactersQueryDBIntegrationTest extends MwDBaseUnitTestCase {
 
-	protected $databaseToBeExcluded = array( 'sqlite' );
-
 	private $subjectsToBeCleared = array();
 	private $semanticDataFactory;
 	private $dataValueFactory;
@@ -48,8 +47,8 @@ class SpecialCharactersQueryDBIntegrationTest extends MwDBaseUnitTestCase {
 		parent::setUp();
 
 		$this->dataValueFactory = DataValueFactory::getInstance();
-		$this->semanticDataFactory = new SemanticDataFactory();
-		$this->queryResultValidator = new QueryResultValidator();
+		$this->queryResultValidator = UtilityFactory::getInstance()->newValidatorFactory()->newQueryResultValidator();
+		$this->semanticDataFactory = UtilityFactory::getInstance()->newSemanticDataFactory();
 	}
 
 	protected function tearDown() {

--- a/tests/phpunit/Integration/Query/SubcategoryQueryDBIntegrationTest.php
+++ b/tests/phpunit/Integration/Query/SubcategoryQueryDBIntegrationTest.php
@@ -3,22 +3,23 @@
 namespace SMW\Tests\Integration\Query;
 
 use SMW\Tests\MwDBaseUnitTestCase;
-use SMW\Tests\Util\SemanticDataFactory;
-use SMW\Tests\Util\Validators\QueryResultValidator;
+use SMW\Tests\Util\UtilityFactory;
+
+use SMW\Query\Language\ClassDescription;
 
 use SMW\DIWikiPage;
 use SMW\DIProperty;
 use SMW\DataValueFactory;
 
 use SMWQuery as Query;
-use SMW\Query\Language\ClassDescription as ClassDescription;
 
 /**
- *
  * @group SMW
  * @group SMWExtension
+ *
  * @group semantic-mediawiki-integration
  * @group semantic-mediawiki-query
+ *
  * @group mediawiki-database
  * @group medium
  *
@@ -29,10 +30,9 @@ use SMW\Query\Language\ClassDescription as ClassDescription;
  */
 class SubcategoryQueryDBIntegrationTest extends MwDBaseUnitTestCase {
 
-	protected $databaseToBeExcluded = array( 'sqlite' );
-
 	private $subjectsToBeCleared = array();
 	private $semanticDataFactory;
+
 	private $dataValueFactory;
 	private $queryResultValidator;
 
@@ -40,8 +40,8 @@ class SubcategoryQueryDBIntegrationTest extends MwDBaseUnitTestCase {
 		parent::setUp();
 
 		$this->dataValueFactory = DataValueFactory::getInstance();
-		$this->semanticDataFactory = new SemanticDataFactory();
-		$this->queryResultValidator = new QueryResultValidator();
+		$this->semanticDataFactory = UtilityFactory::getInstance()->newSemanticDataFactory();
+		$this->queryResultValidator = UtilityFactory::getInstance()->newValidatorFactory()->newQueryResultValidator();
 	}
 
 	protected function tearDown() {

--- a/tests/phpunit/Integration/Query/SubpropertyQueryDBIntegrationTest.php
+++ b/tests/phpunit/Integration/Query/SubpropertyQueryDBIntegrationTest.php
@@ -3,25 +3,26 @@
 namespace SMW\Tests\Integration\Query;
 
 use SMW\Tests\MwDBaseUnitTestCase;
-use SMW\Tests\Util\SemanticDataFactory;
-use SMW\Tests\Util\Validators\QueryResultValidator;
+use SMW\Tests\Util\UtilityFactory;
+
+use SMW\Query\Language\ThingDescription;
+use SMW\Query\Language\SomeProperty;
 
 use SMW\DIWikiPage;
 use SMW\DIProperty;
 use SMW\DataValueFactory;
 
 use SMWQuery as Query;
-use SMW\Query\Language\SomeProperty as SomeProperty;
 use SMWPrintRequest as PrintRequest;
 use SMWPropertyValue as PropertyValue;
-use SMW\Query\Language\ThingDescription as ThingDescription;
 
 /**
- *
  * @group SMW
  * @group SMWExtension
+ *
  * @group semantic-mediawiki-integration
  * @group semantic-mediawiki-query
+ *
  * @group mediawiki-database
  * @group medium
  *
@@ -32,10 +33,9 @@ use SMW\Query\Language\ThingDescription as ThingDescription;
  */
 class SubpropertyQueryDBIntegrationTest extends MwDBaseUnitTestCase {
 
-	protected $databaseToBeExcluded = array( 'sqlite' );
-
 	private $subjectsToBeCleared = array();
 	private $semanticDataFactory;
+
 	private $dataValueFactory;
 	private $queryResultValidator;
 
@@ -43,8 +43,8 @@ class SubpropertyQueryDBIntegrationTest extends MwDBaseUnitTestCase {
 		parent::setUp();
 
 		$this->dataValueFactory = DataValueFactory::getInstance();
-		$this->semanticDataFactory = new SemanticDataFactory();
-		$this->queryResultValidator = new QueryResultValidator();
+		$this->queryResultValidator = UtilityFactory::getInstance()->newValidatorFactory()->newQueryResultValidator();
+		$this->semanticDataFactory = UtilityFactory::getInstance()->newSemanticDataFactory();
 	}
 
 	protected function tearDown() {

--- a/tests/phpunit/Integration/Query/SubqueryDBIntegrationTest.php
+++ b/tests/phpunit/Integration/Query/SubqueryDBIntegrationTest.php
@@ -3,8 +3,12 @@
 namespace SMW\Tests\Integration\Query;
 
 use SMW\Tests\MwDBaseUnitTestCase;
-use SMW\Tests\Util\SemanticDataFactory;
-use SMW\Tests\Util\Validators\QueryResultValidator;
+use SMW\Tests\Util\UtilityFactory;
+
+use SMW\Query\Language\ThingDescription;
+use SMW\Query\Language\ValueDescription;
+use SMW\Query\Language\ClassDescription;
+use SMW\Query\Language\SomeProperty;
 
 use SMW\DIWikiPage;
 use SMW\DIProperty;
@@ -19,19 +23,16 @@ use SMWQuery as Query;
 use SMWQueryResult as QueryResult;
 use SMWDataValue as DataValue;
 use SMWDataItem as DataItem;
-use SMW\Query\Language\SomeProperty as SomeProperty;
 use SMWPrintRequest as PrintRequest;
 use SMWPropertyValue as PropertyValue;
-use SMW\Query\Language\ThingDescription as ThingDescription;
-use SMW\Query\Language\ValueDescription as ValueDescription;
-use SMW\Query\Language\ClassDescription as ClassDescription;
 
 /**
- *
  * @group SMW
  * @group SMWExtension
+ *
  * @group semantic-mediawiki-integration
  * @group semantic-mediawiki-query
+ *
  * @group mediawiki-database
  * @group medium
  *
@@ -42,11 +43,10 @@ use SMW\Query\Language\ClassDescription as ClassDescription;
  */
 class SubqueryDBIntegrationTest extends MwDBaseUnitTestCase {
 
-	protected $databaseToBeExcluded = array( 'sqlite' );
-
 	private $subjectsToBeCleared = array();
 	private $semanticDataFactory;
 	private $dataValueFactory;
+
 	private $queryResultValidator;
 	private $queryParser;
 
@@ -54,9 +54,10 @@ class SubqueryDBIntegrationTest extends MwDBaseUnitTestCase {
 		parent::setUp();
 
 		$this->dataValueFactory = DataValueFactory::getInstance();
-		$this->semanticDataFactory = new SemanticDataFactory();
-		$this->queryResultValidator = new QueryResultValidator();
 		$this->queryParser = new QueryParser();
+
+		$this->queryResultValidator = UtilityFactory::getInstance()->newValidatorFactory()->newQueryResultValidator();
+		$this->semanticDataFactory = UtilityFactory::getInstance()->newSemanticDataFactory();
 
 	//	$this->getStore()->getSparqlDatabase()->deleteAll();
 	}

--- a/tests/phpunit/Integration/RdfXmlSerializationExportDBIntegrationTest.php
+++ b/tests/phpunit/Integration/RdfXmlSerializationExportDBIntegrationTest.php
@@ -18,7 +18,9 @@ use Title;
  *
  * @group semantic-mediawiki-integration
  * @group semantic-mediawiki-export
+ *
  * @group semantic-mediawiki-database
+ * @group medium
  *
  * @license GNU GPL v2+
  * @since 2.0
@@ -26,8 +28,6 @@ use Title;
  * @author mwjames
  */
 class RdfXmlSerializationExportDBIntegrationTest extends MwDBaseUnitTestCase {
-
-	protected $databaseToBeExcluded = array( 'sqlite' );
 
 	private $pageCreator;
 	private $stringValidator;

--- a/tests/phpunit/Integration/SemanticDataStorageDBIntegrationTest.php
+++ b/tests/phpunit/Integration/SemanticDataStorageDBIntegrationTest.php
@@ -200,12 +200,6 @@ class SemanticDataStorageDBIntegrationTest extends MwDBaseUnitTestCase {
 
 	public function testFetchSemanticDataForPreExistingDoubleRedirect() {
 
-		// Only the 1.22.2 sqlite instance wasn't working, don't know why
-		// therefore skipping sqlite for now
-		$this->skipTestForDatabase( array( 'sqlite' ) );
-
-		$this->applicationFactory->clear();
-
 		$this->pageCreator
 			->createPage( Title::newFromText( 'Foo-B' ) )
 			->doEdit( '#REDIRECT [[Foo-C]]' );


### PR DESCRIPTION
The issue was caused by double prefixing and non-prefixing of inner joints during the `select` by MW's DB interface.
