### PR TITLE
Add `smwgUpdateStrategy` option

### DIFF
--- a/SemanticMediaWiki.settings.php
+++ b/SemanticMediaWiki.settings.php
@@ -765,3 +765,16 @@ $GLOBALS['smwgOnDeleteAction'] = array(
 ##
 $GLOBALS['smwgFallbackSearchType'] = null;
 ##
+
+###
+# SMW_DIFF_UPDATE (default) - This option will compute the `diff` of an existing
+# data set and only update the difference.
+#
+# SMW_REPLACEMENT_UPDATE - This option is meant to be used to force a complete
+# replacement of a data set during an update but comes with a cost of additional
+# DB writes during the update to safeguard data integrity.
+#
+# @since 2.1
+##
+$GLOBALS['smwgUpdateStrategy'] = SMW_DIFF_UPDATE;
+##

--- a/includes/Defines.php
+++ b/includes/Defines.php
@@ -108,3 +108,10 @@ define( 'SMW_MONTH', 4 );  // an entered digit can be a month
 define( 'SMW_DAY_MONTH_YEAR', 7 ); // an entered digit can be a day, month or year
 define( 'SMW_DAY_YEAR', 3 ); // an entered digit can be either a month or a year
 /**@}*/
+
+/**@{
+ * Constants for update strategies
+ */
+define( 'SMW_DIFF_UPDATE', 0 );
+define( 'SMW_REPLACEMENT_UPDATE', 1 );
+/**@}*/

--- a/includes/Settings.php
+++ b/includes/Settings.php
@@ -128,6 +128,7 @@ class Settings extends SimpleDictionary {
 			'smwgEnabledSpecialPage' => $GLOBALS['smwgEnabledSpecialPage'],
 			'smwgOnDeleteAction' => $GLOBALS['smwgOnDeleteAction'],
 			'smwgFallbackSearchType' => $GLOBALS['smwgFallbackSearchType'],
+			'smwgUpdateStrategy' => $GLOBALS['smwgUpdateStrategy']
 		);
 
 		$settings = $settings + array(

--- a/includes/StoreUpdater.php
+++ b/includes/StoreUpdater.php
@@ -130,7 +130,7 @@ class StoreUpdater {
 
 	private function updateSemanticData( Title $title, WikiPage $wikiPage, $revision ) {
 
-		$this->processSemantics = $revision !== null && $this->isEnabledNamespace( $title );
+		$this->processSemantics = $revision !== null && $this->isSemanticEnabledNamespace( $title );
 
 		if ( !$this->processSemantics ) {
 			return $this->semanticData = new SemanticData( $this->getSubject() );
@@ -161,21 +161,20 @@ class StoreUpdater {
 
 	private function doRealUpdate() {
 
-		Profiler::In();
-
 		$this->store->setUpdateJobsEnabledState( $this->updateJobsEnabledState );
 
-		if ( $this->processSemantics ) {
-			$this->store->updateData( $this->semanticData );
-		} else {
+		if ( !$this->processSemantics || $this->applicationFactory->getSettings()->get( 'smwgUpdateStrategy' ) === SMW_REPLACEMENT_UPDATE ) {
 			$this->store->clearData( $this->semanticData->getSubject() );
 		}
 
-		Profiler::Out();
+		if ( $this->processSemantics ) {
+			$this->store->updateData( $this->semanticData );
+		}
+
 		return true;
 	}
 
-	private function isEnabledNamespace( $title ) {
+	private function isSemanticEnabledNamespace( $title ) {
 		return $this->applicationFactory->getNamespaceExaminer()->isSemanticEnabled( $title->getNamespace() );
 	}
 

--- a/tests/phpunit/includes/SettingsTest.php
+++ b/tests/phpunit/includes/SettingsTest.php
@@ -7,11 +7,10 @@ use SMW\Settings;
 /**
  * @covers \SMW\Settings
  *
- *
  * @group SMW
  * @group SMWExtension
  *
- * @licence GNU GPL v2+
+ * @license GNU GPL v2+
  * @since 1.9
  *
  * @author mwjames


### PR DESCRIPTION
Adds `SMW_REPLACEMENT_UPDATE` as an update strategy to value data integrity over diff accuracy during each update.

Still unable to find the cause for duplicate entries as described in #191 but the added option should allow to choose a different update strategy which will ensure that any possible duplicates are removed by a replacement update.
