### PR TITLE
Fix #618 / Subobject subquery

### DIFF
--- a/includes/query/SMW_QueryParser.php
+++ b/includes/query/SMW_QueryParser.php
@@ -311,7 +311,7 @@ class SMWQueryParser {
 		$inverse = false;
 
 		foreach ( $propertynames as $name ) {
-			if ( $typeid !== '_wpg' && $typeid !== '__sob' ) { // non-final property in chain was no wikipage: not allowed
+			if ( !$this->isPagePropertyType( $typeid ) ) { // non-final property in chain was no wikipage: not allowed
 				$this->m_errors[] = wfMessage(
 					'smw_valuesubquery',
 					$name
@@ -339,7 +339,7 @@ class SMWQueryParser {
 
 			switch ( $chunk ) {
 				case '+': // wildcard, add namespaces for page-type properties
-					if ( !is_null( $this->m_defaultns ) && ( ( $typeid == '_wpg' ) || $inverse ) ) {
+					if ( !is_null( $this->m_defaultns ) && ( $this->isPagePropertyType( $typeid ) || $inverse ) ) {
 						$innerdesc = $this->addDescription( $innerdesc, $this->m_defaultns, false );
 					} else {
 						$innerdesc = $this->addDescription( $innerdesc, new SMWThingDescription(), false );
@@ -347,7 +347,7 @@ class SMWQueryParser {
 					$chunk = $this->readChunk();
 				break;
 				case '<q>': // subquery, set default namespaces
-					if ( ( $typeid == '_wpg' ) || $inverse ) {
+					if ( $this->isPagePropertyType( $typeid ) || $inverse ) {
 						$this->pushDelimiter( '</q>' );
 						$setsubNS = true;
 						$innerdesc = $this->addDescription( $innerdesc, $this->getSubqueryDescription( $setsubNS ), false );
@@ -399,7 +399,7 @@ class SMWQueryParser {
 		}
 
 		if ( is_null( $innerdesc ) ) { // make a wildcard search
-			$innerdesc = ( !is_null( $this->m_defaultns ) && ( $typeid == '_wpg' ) ) ?
+			$innerdesc = ( !is_null( $this->m_defaultns ) && $this->isPagePropertyType( $typeid ) ) ?
 							$this->addDescription( $innerdesc, $this->m_defaultns, false ) :
 							$this->addDescription( $innerdesc, new SMWThingDescription(), false );
 			$this->m_errors[] = wfMessage(
@@ -656,4 +656,9 @@ class SMWQueryParser {
 			}
 		}
 	}
+
+	private function isPagePropertyType( $typeid ) {
+		return $typeid == '_wpg' || $typeid == '__sob';
+	}
+
 }

--- a/includes/src/MediaWiki/Database.php
+++ b/includes/src/MediaWiki/Database.php
@@ -32,10 +32,11 @@ class Database {
 	private $writeDBConnection = null;
 
 	/**
-	 * @var boolean
+	 * @since 1.9
+	 *
+	 * @param DBConnectionProvider $readDBConnection
+	 * @param DBConnectionProvider|null $writeDBConnection
 	 */
-	private $useWriteConnection = false;
-
 	public function __construct( DBConnectionProvider $readDBConnection, DBConnectionProvider $writeDBConnection = null ) {
 		$this->readDBConnection = $readDBConnection;
 		$this->writeDBConnection = $writeDBConnection;

--- a/tests/phpunit/Integration/MediaWiki/JobQueueDBIntegrationTest.php
+++ b/tests/phpunit/Integration/MediaWiki/JobQueueDBIntegrationTest.php
@@ -255,11 +255,6 @@ class JobQueueDBIntegrationTest extends MwDBaseUnitTestCase {
 			->createPage( Title::newFromText( 'Foo-C' ) )
 			->doEdit( '#REDIRECT [[Foo-A]]' );
 
-//		$this->assertEquals(
-//			3,
-//			$this->jobQueueLookup->estimateJobCountFor( 'SMW\UpdateJob' )
-//		);
-
 		$this->jobQueueRunner
 			->setType( 'SMW\UpdateJob' )
 			->run();

--- a/tests/phpunit/includes/Query/QueryParserTest.php
+++ b/tests/phpunit/includes/Query/QueryParserTest.php
@@ -2,6 +2,14 @@
 
 namespace SMW\Tests\Query;
 
+use SMW\Query\Language\SomeProperty;
+use SMW\Query\Language\ThingDescription;
+use SMW\Query\Language\ValueDescription;
+use SMW\Query\Language\Conjunction;
+use SMW\Query\Language\Disjunction;
+use SMW\Query\Language\ClassDescription;
+use SMW\Query\Language\NamespaceDescription;
+
 use SMW\DIWikiPage;
 use SMW\DIProperty;
 
@@ -9,17 +17,9 @@ use SMWQueryParser as QueryParser;
 use SMWDIBlob as DIBlob;
 use SMWDINumber as DINumber;
 use SMWQuery as Query;
-use SMW\Query\Language\SomeProperty as SomeProperty;
-use SMW\Query\Language\ThingDescription as ThingDescription;
-use SMW\Query\Language\ValueDescription as ValueDescription;
-use SMW\Query\Language\Conjunction as Conjunction;
-use SMW\Query\Language\Disjunction as Disjunction;
-use SMW\Query\Language\ClassDescription as ClassDescription;
-use SMW\Query\Language\NamespaceDescription as NamespaceDescription;
 
 /**
  * @covers \SMWQueryParser
- *
  *
  * @group SMW
  * @group SMWExtension
@@ -301,6 +301,33 @@ class QueryParserTest extends \PHPUnit_Framework_TestCase {
 		$this->assertEquals(
 			$description,
 			$this->queryParser->getQueryDescription( '[[born in::<q>[[Category:City]] [[located in::Outback]]</q>]]' )
+		);
+	}
+
+	public function testRestrictedDefaultNamespace() {
+
+		$property = DIProperty::newFromUserLabel( 'Foo' );
+		$property->setPropertyTypeId( '_wpg' );
+
+		$description = new SomeProperty(
+			$property,
+			new ValueDescription( new DIWikiPage( 'Bar', NS_MAIN ), $property )
+		);
+
+		$description = new Conjunction( array(
+			$description,
+			new NamespaceDescription( NS_MAIN )
+		) );
+
+		$this->queryParser->setDefaultNamespaces( array( NS_MAIN ) );
+
+		$this->assertEquals(
+			$description,
+			$this->queryParser->getQueryDescription( '<q>[[Foo::Bar]]</q>[[:+]]' )
+		);
+
+		$this->assertEmpty(
+			$this->queryParser->getErrors()
 		);
 	}
 


### PR DESCRIPTION
- Relates to #618, #454
- Requires #626
- Add `SMWQueryParser::isPagePropertyType`
- Add test for  `[[Has subobject::<q>[[Area::891.85 km²]] OR [[Population::2234105||3517424]]</q>]]` or `[[Berlin]] [[Has subobject::<q>[[Area::891.85 km²]] [[Population::3517424]]</q>]]`.
