### PR TITLE
Recognize x= request parameter

### DIFF
--- a/includes/specials/SMW_SpecialBrowse.php
+++ b/includes/specials/SMW_SpecialBrowse.php
@@ -56,6 +56,12 @@ class SMWSpecialBrowse extends SpecialPage {
 		$this->setHeaders();
 		// get the GET parameters
 		$this->articletext = $wgRequest->getVal( 'article' );
+
+		// @see SMWInfolink::encodeParameters
+		if ( $query === null && $this->getRequest()->getCheck( 'x' ) ) {
+			$query = $this->getRequest()->getVal( 'x' );
+		}
+
 		// no GET parameters? Then try the URL
 		if ( is_null( $this->articletext ) ) {
 			$this->articletext = UrlEncoder::decode( $query );

--- a/includes/src/MediaWiki/Specials/SearchByProperty/PageRequestOptions.php
+++ b/includes/src/MediaWiki/Specials/SearchByProperty/PageRequestOptions.php
@@ -26,6 +26,11 @@ class PageRequestOptions {
 	private $requestOptions;
 
 	/**
+	 * @var UrlEncoder
+	 */
+	private $urlEncoder;
+
+	/**
 	 * @var PropertyValue
 	 */
 	public $property;
@@ -62,10 +67,14 @@ class PageRequestOptions {
 
 	/**
 	 * @since 2.1
+	 *
+	 * @param string $queryString
+	 * @param array $requestOptions
 	 */
 	public function __construct( $queryString, array $requestOptions ) {
 		$this->queryString = $queryString;
 		$this->requestOptions = $requestOptions;
+		$this->urlEncoder = new UrlEncoder();
 	}
 
 	/**
@@ -82,8 +91,8 @@ class PageRequestOptions {
 		$property = isset( $this->requestOptions['property'] ) ? $this->requestOptions['property'] : current( $params );
 		$value = isset( $this->requestOptions['value'] ) ? $this->requestOptions['value'] : next( $params );
 
-		$property = UrlEncoder::decode( $property );
-		$value = UrlEncoder::decode( $value );
+		$property = $this->urlEncoder->decode( $property );
+		$value = $this->urlEncoder->decode( $value );
 
 		$this->property = PropertyValue::makeUserProperty( $property );
 
@@ -96,7 +105,7 @@ class PageRequestOptions {
 
 			$this->value = DataValueFactory::getInstance()->newPropertyObjectValue(
 				$this->property->getDataItem(),
-				$value
+				$this->urlEncoder->decode( $value )
 			);
 
 			$this->valueString = $this->value->isValid() ? $this->value->getWikiValue() : $value;

--- a/includes/src/MediaWiki/Specials/SpecialSearchByProperty.php
+++ b/includes/src/MediaWiki/Specials/SpecialSearchByProperty.php
@@ -46,6 +46,11 @@ class SpecialSearchByProperty extends SpecialPage {
 
 		list( $limit, $offset ) = $this->getLimitOffset();
 
+		// @see SMWInfolink::encodeParameters
+		if ( $query === null && $this->getRequest()->getCheck( 'x' ) ) {
+			$query = $this->getRequest()->getVal( 'x' );
+		}
+
 		$applicationFactory = ApplicationFactory::getInstance();
 
 		$requestOptions = array(

--- a/tests/phpunit/includes/MediaWiki/Specials/SpecialSearchByPropertyTest.php
+++ b/tests/phpunit/includes/MediaWiki/Specials/SpecialSearchByPropertyTest.php
@@ -13,6 +13,7 @@ use Title;
  *
  * @group SMW
  * @group SMWExtension
+ *
  * @group semantic-mediawiki-specials
  *
  * @license GNU GPL v2+
@@ -60,12 +61,34 @@ class SpecialSearchByPropertyTest extends \PHPUnit_Framework_TestCase {
 	/**
 	 * @dataProvider queryParameterProvider
 	 */
-	public function testExecute( $query, $expected ) {
+	public function testQueryParameter( $query, $expected ) {
 
 		$instance = new SpecialSearchByProperty();
 		$instance->getContext()->setTitle( Title::newFromText( 'SearchByProperty' ) );
 
 		$instance->execute( $query );
+
+		$this->stringValidator->assertThatStringContains(
+			$expected,
+			$instance->getOutput()->getHtml()
+		);
+	}
+
+	public function testXRequestParameter() {
+
+		$request = array(
+			'x' => 'Has-20subobject/Foo-23%7B%7D'
+		);
+
+		$expected = array(
+			'property=Has+subobject', 'value=Foo%23%7B%7D'
+		);
+
+		$instance = new SpecialSearchByProperty();
+		$instance->getContext()->setTitle( Title::newFromText( 'SearchByProperty' ) );
+		$instance->getContext()->setRequest( new \FauxRequest( $request, true ) );
+
+		$instance->execute( null );
 
 		$this->stringValidator->assertThatStringContains(
 			$expected,
@@ -85,6 +108,12 @@ class SpecialSearchByPropertyTest extends \PHPUnit_Framework_TestCase {
 		$provider[] = array(
 			'Foo/Bar',
 			array( 'property=Foo', 'value=Bar' )
+		);
+
+		#2
+		$provider[] = array(
+			'Has-20foo/http:-2F-2Fexample.org-2Fid-2FCurly-2520Brackets-257B-257D',
+			array( 'property=Has+foo', 'value=http%3A%2F%2Fexample.org%2Fid%2FCurly-20Brackets-7B-7D' )
 		);
 
 		return $provider;


### PR DESCRIPTION
It can happen that `SMWInfolink::encodeParameters` uses `x=` as query parameter
