### PR TITLE
Fix 35452 / #633 to make uri representation layer human readable

### DIFF
--- a/includes/datavalues/SMW_DV_URI.php
+++ b/includes/datavalues/SMW_DV_URI.php
@@ -1,4 +1,7 @@
 <?php
+
+use SMW\UrlEncoder;
+
 /**
  * @ingroup SMWDataValues
  */
@@ -31,6 +34,11 @@ class SMWURIValue extends SMWDataValue {
 	 */
 	private $m_mode;
 
+	/**
+	 * @var UrlEncoder
+	 */
+	private $urlEncoder;
+
 	public function __construct( $typeid ) {
 		parent::__construct( $typeid );
 		switch ( $typeid ) {
@@ -47,6 +55,8 @@ class SMWURIValue extends SMWDataValue {
 				$this->m_mode = SMW_URI_MODE_URI;
 			break;
 		}
+
+		$this->urlEncoder = new UrlEncoder();
 	}
 
 	protected function parseUserValue( $value ) {
@@ -181,56 +191,67 @@ class SMWURIValue extends SMWDataValue {
 	}
 
 	public function getShortWikiText( $linked = null ) {
-		$url = $this->getURL();
+
+		$url = $this->urlEncoder->decode( $this->getURL() );
+		$caption = $this->urlEncoder->decode( $this->m_caption );
+
 		if ( is_null( $linked ) || ( $linked === false ) || ( $url === '' ) ||
 			( $this->m_outformat == '-' ) || ( $this->m_caption === '' ) ) {
-			return $this->m_caption;
+			return $caption;
 		} elseif ( $this->m_outformat == 'nowiki' ) {
-			return $this->makeNonlinkedWikiText( $this->m_caption );
+			return $this->makeNonlinkedWikiText( $caption );
 		} else {
-			return '[' . $url . ' ' . $this->m_caption . ']';
+			return '[' . $url . ' ' . $caption . ']';
 		}
 	}
 
 	public function getShortHTMLText( $linker = null ) {
-		$url = $this->getURL();
+
+		$url = $this->urlEncoder->decode( $this->getURL() );
+		$caption = $this->urlEncoder->decode( $this->m_caption );
+
 		if ( is_null( $linker ) || ( !$this->isValid() ) || ( $url === '' ) ||
 			( $this->m_outformat == '-' ) || ( $this->m_outformat == 'nowiki' ) ||
 			( $this->m_caption === '' ) ) {
-			return $this->m_caption;
+			return $caption;
 		} else {
-			return $linker->makeExternalLink( $url, $this->m_caption );
+			return $linker->makeExternalLink( $url, $caption );
 		}
 	}
 
 	public function getLongWikiText( $linked = null ) {
+
 		if ( !$this->isValid() ) {
 			return $this->getErrorText();
 		}
-		$url = $this->getURL();
+
+		$url = $this->urlEncoder->decode( $this->getURL() );
+		$wikitext = $this->urlEncoder->decode( $this->m_wikitext );
 
 		if ( is_null( $linked ) || ( $linked === false ) || ( $url === '' ) ||
 			( $this->m_outformat == '-' ) ) {
-			return $this->m_wikitext;
+			return $wikitext;
 		} elseif ( $this->m_outformat == 'nowiki' ) {
-			return $this->makeNonlinkedWikiText( $this->m_wikitext );
+			return $this->makeNonlinkedWikiText( $wikitext );
 		} else {
-			return '[' . $url . ' ' . $this->m_wikitext . ']';
+			return '[' . $url . ' ' . $wikitext . ']';
 		}
 	}
 
 	public function getLongHTMLText( $linker = null ) {
+
 		if ( !$this->isValid() ) {
 			return $this->getErrorText();
 		}
 
-		$url = $this->getURL();
+		$url = $this->urlEncoder->decode( $this->getURL() );
+		$wikitext = $this->urlEncoder->decode( $this->m_wikitext );
 
 		if ( is_null( $linker ) || ( !$this->isValid() ) || ( $url === '' ) ||
 			( $this->m_outformat == '-' ) || ( $this->m_outformat == 'nowiki' ) ) {
-			return htmlspecialchars( $this->m_wikitext );
+			return $wikitext;
 		} else {
-			return $linker->makeExternalLink( $url, $this->m_wikitext );
+			return $linker->makeExternalLink( $url, $wikitext );
 		}
 	}
 

--- a/includes/src/MediaWiki/Specials/SearchByProperty/PageRequestOptions.php
+++ b/includes/src/MediaWiki/Specials/SearchByProperty/PageRequestOptions.php
@@ -91,7 +91,7 @@ class PageRequestOptions {
 		$property = isset( $this->requestOptions['property'] ) ? $this->requestOptions['property'] : current( $params );
 		$value = isset( $this->requestOptions['value'] ) ? $this->requestOptions['value'] : next( $params );
 
-		$property = $this->urlEncoder->decode( $property );
+		$property = str_replace( '_', ' ', $this->urlEncoder->decode( $property ) );
 		$value = $this->urlEncoder->decode( $value );
 
 		$this->property = PropertyValue::makeUserProperty( $property );

--- a/includes/src/UrlEncoder.php
+++ b/includes/src/UrlEncoder.php
@@ -25,7 +25,6 @@ class UrlEncoder {
 		// Sanitize remaining string content
 		$string = trim( htmlspecialchars( $string, ENT_NOQUOTES ) );
 		$string = str_replace( '&nbsp;', ' ', str_replace( '&#160;', ' ', str_replace( '&amp;', '&', $string ) ) );
-		$string = str_replace( '_', ' ', $string );
 
 		return $string;
 	}

--- a/tests/phpunit/includes/DataValues/UriValueTest.php
+++ b/tests/phpunit/includes/DataValues/UriValueTest.php
@@ -1,0 +1,284 @@
+<?php
+
+namespace SMW\Tests\DataValues;
+
+use SMWURIValue as UriValue;
+
+/**
+ * @covers \SMWURIValue
+ *
+ * @group SMW
+ * @group SMWExtension
+ *
+ * @license GNU GPL v2+
+ * @since 2.1
+ *
+ * @author mwjames
+ */
+class UriValueTest extends \PHPUnit_Framework_TestCase {
+
+	public function testCanConstruct() {
+
+		$this->assertInstanceOf(
+			'\SMWURIValue',
+			new UriValue( '_uri' )
+		);
+	}
+
+	/**
+	 * @dataProvider uriProvider
+	 */
+	public function testOutputFormatting( $uri, $caption = false, $linker = null, $expected ) {
+
+		$instance = new UriValue( '_uri' );
+		$instance->setUserValue( $uri, $caption );
+
+		$this->assertEquals(
+			$expected['wikiValue'],
+			$instance->getWikiValue()
+		);
+
+		$this->assertEquals(
+			$expected['longHTMLText'],
+			$instance->getLongHTMLText( $linker )
+		);
+
+		$this->assertEquals(
+			$expected['longWikiText'],
+			$instance->getLongWikiText( $linker )
+		);
+
+		$this->assertEquals(
+			$expected['shortHTMLText'],
+			$instance->getShortHTMLText( $linker )
+		);
+
+		$this->assertEquals(
+			$expected['shortWikiText'],
+			$instance->getShortWikiText( $linker )
+		);
+	}
+
+	public function uriProvider() {
+
+		$linker = smwfGetLinker();
+
+		// FIXME MW 1.19*
+		$noFollowAttribute = version_compare( $GLOBALS['wgVersion'], '1.20', '<' ) ? '' : ' rel="nofollow"';
+
+		// https://github.com/lanthaler/IRI/blob/master/Test/IriTest.php
+		$provider[] = array(
+			'http://example.org/aaa/bbb#ccc',
+			false,
+			null,
+			array(
+				'wikiValue'     => 'http://example.org/aaa/bbb#ccc',
+				'longHTMLText'  => 'http://example.org/aaa/bbb#ccc',
+				'longWikiText'  => 'http://example.org/aaa/bbb#ccc',
+				'shortHTMLText' => 'http://example.org/aaa/bbb#ccc',
+				'shortWikiText' => 'http://example.org/aaa/bbb#ccc'
+			)
+		);
+
+		$provider[] = array(
+			'http://example.org/aaa/bbb#ccc',
+			'Foo',
+			null,
+			array(
+				'wikiValue'     => 'http://example.org/aaa/bbb#ccc',
+				'longHTMLText'  => 'http://example.org/aaa/bbb#ccc',
+				'longWikiText'  => 'http://example.org/aaa/bbb#ccc',
+				'shortHTMLText' => 'Foo',
+				'shortWikiText' => 'Foo'
+			)
+		);
+
+		$provider[] = array(
+			'http://example.org/aaa/bbb#ccc',
+			false,
+			$linker,
+			array(
+				'wikiValue'     => 'http://example.org/aaa/bbb#ccc',
+				'longHTMLText'  => '<a class="external"' . $noFollowAttribute . ' href="http://example.org/aaa/bbb#ccc">http://example.org/aaa/bbb#ccc</a>',
+				'longWikiText'  => '[http://example.org/aaa/bbb#ccc http://example.org/aaa/bbb#ccc]',
+				'shortHTMLText' => '<a class="external"' . $noFollowAttribute . ' href="http://example.org/aaa/bbb#ccc">http://example.org/aaa/bbb#ccc</a>',
+				'shortWikiText' => '[http://example.org/aaa/bbb#ccc http://example.org/aaa/bbb#ccc]'
+			)
+		);
+
+		$provider[] = array(
+			'http://example.org/aaa/bbb#ccc',
+			'Foo',
+			$linker,
+			array(
+				'wikiValue'     => 'http://example.org/aaa/bbb#ccc',
+				'longHTMLText'  => '<a class="external"' . $noFollowAttribute . ' href="http://example.org/aaa/bbb#ccc">http://example.org/aaa/bbb#ccc</a>',
+				'longWikiText'  => '[http://example.org/aaa/bbb#ccc http://example.org/aaa/bbb#ccc]',
+				'shortHTMLText' => '<a class="external"' . $noFollowAttribute . ' href="http://example.org/aaa/bbb#ccc">Foo</a>',
+				'shortWikiText' => '[http://example.org/aaa/bbb#ccc Foo]',
+			)
+		);
+
+		//
+		$provider[] = array(
+			'http://example.org/aaa%2fbbb#ccc',
+			false,
+			null,
+			array(
+				'wikiValue'     => 'http://example.org/aaa%2fbbb#ccc',
+				'longHTMLText'  => 'http://example.org/aaa/bbb#ccc',
+				'longWikiText'  => 'http://example.org/aaa/bbb#ccc',
+				'shortHTMLText' => 'http://example.org/aaa/bbb#ccc',
+				'shortWikiText' => 'http://example.org/aaa/bbb#ccc'
+			)
+		);
+
+		$provider[] = array(
+			'http://example.org/aaa%2fbbb#ccc',
+			'Foo',
+			null,
+			array(
+				'wikiValue'     => 'http://example.org/aaa%2fbbb#ccc',
+				'longHTMLText'  => 'http://example.org/aaa/bbb#ccc',
+				'longWikiText'  => 'http://example.org/aaa/bbb#ccc',
+				'shortHTMLText' => 'Foo',
+				'shortWikiText' => 'Foo'
+			)
+		);
+
+		$provider[] = array(
+			'http://example.org/aaa%2fbbb#ccc',
+			false,
+			$linker,
+			array(
+				'wikiValue'     => 'http://example.org/aaa%2fbbb#ccc',
+				'longHTMLText'  => '<a class="external"' . $noFollowAttribute . ' href="http://example.org/aaa/bbb#ccc">http://example.org/aaa/bbb#ccc</a>',
+				'longWikiText'  => '[http://example.org/aaa/bbb#ccc http://example.org/aaa/bbb#ccc]',
+				'shortHTMLText' => '<a class="external"' . $noFollowAttribute . ' href="http://example.org/aaa/bbb#ccc">http://example.org/aaa/bbb#ccc</a>',
+				'shortWikiText' => '[http://example.org/aaa/bbb#ccc http://example.org/aaa/bbb#ccc]'
+			)
+		);
+
+		$provider[] = array(
+			'http://example.org/aaa%2fbbb#ccc',
+			'Foo',
+			$linker,
+			array(
+				'wikiValue'     => 'http://example.org/aaa%2fbbb#ccc',
+				'longHTMLText'  => '<a class="external"' . $noFollowAttribute . ' href="http://example.org/aaa/bbb#ccc">http://example.org/aaa/bbb#ccc</a>',
+				'longWikiText'  => '[http://example.org/aaa/bbb#ccc http://example.org/aaa/bbb#ccc]',
+				'shortHTMLText' => '<a class="external"' . $noFollowAttribute . ' href="http://example.org/aaa/bbb#ccc">Foo</a>',
+				'shortWikiText' => '[http://example.org/aaa/bbb#ccc Foo]',
+			)
+		);
+
+		// UTF-8 encoded string
+		$provider[] = array(
+			'http://example.org/%E3%82%88%E3%81%86%E3%81%93%E3%81%9D-23-7B-7D',
+			false,
+			null,
+			array(
+				'wikiValue'     => 'http://example.org/%E3%82%88%E3%81%86%E3%81%93%E3%81%9D-23-7B-7D',
+				'longHTMLText'  => 'http://example.org/ようこそ#{}',
+				'longWikiText'  => 'http://example.org/ようこそ#{}',
+				'shortHTMLText' => 'http://example.org/ようこそ#{}',
+				'shortWikiText' => 'http://example.org/ようこそ#{}'
+			)
+		);
+
+		$provider[] = array(
+			'http://example.org/%E3%82%88%E3%81%86%E3%81%93%E3%81%9D-23-7B-7D',
+			'%20%E4%B8%80%E4%BA%8C%E4%B8%89',
+			null,
+			array(
+				'wikiValue'     => 'http://example.org/%E3%82%88%E3%81%86%E3%81%93%E3%81%9D-23-7B-7D',
+				'longHTMLText'  => 'http://example.org/ようこそ#{}',
+				'longWikiText'  => 'http://example.org/ようこそ#{}',
+				'shortHTMLText' => '一二三',
+				'shortWikiText' => '一二三'
+			)
+		);
+
+		$provider[] = array(
+			'http://example.org/%E3%82%88%E3%81%86%E3%81%93%E3%81%9D-23-7B-7D',
+			false,
+			$linker,
+			array(
+				'wikiValue'     => 'http://example.org/%E3%82%88%E3%81%86%E3%81%93%E3%81%9D-23-7B-7D',
+				'longHTMLText'  => '<a class="external"' . $noFollowAttribute . ' href="http://example.org/ようこそ#{}">http://example.org/ようこそ#{}</a>',
+				'longWikiText'  => '[http://example.org/ようこそ#{} http://example.org/ようこそ#{}]',
+				'shortHTMLText' => '<a class="external"' . $noFollowAttribute . ' href="http://example.org/ようこそ#{}">http://example.org/ようこそ#{}</a>',
+				'shortWikiText' => '[http://example.org/ようこそ#{} http://example.org/ようこそ#{}]'
+			)
+		);
+
+		$provider[] = array(
+			'http://example.org/%E3%82%88%E3%81%86%E3%81%93%E3%81%9D-23-7B-7D',
+			'%20%E4%B8%80%E4%BA%8C%E4%B8%89',
+			$linker,
+			array(
+				'wikiValue'     => 'http://example.org/%E3%82%88%E3%81%86%E3%81%93%E3%81%9D-23-7B-7D',
+				'longHTMLText'  => '<a class="external"' . $noFollowAttribute . ' href="http://example.org/ようこそ#{}">http://example.org/ようこそ#{}</a>',
+				'longWikiText'  => '[http://example.org/ようこそ#{} http://example.org/ようこそ#{}]',
+				'shortHTMLText' => '<a class="external"' . $noFollowAttribute . ' href="http://example.org/ようこそ#{}">一二三</a>',
+				'shortWikiText' => '[http://example.org/ようこそ#{} 一二三]',
+			)
+		);
+
+		// ...
+		$provider[] = array(
+			'http://example.org/api?query=!_:;@*#Foo&=-3DBar',
+			false,
+			null,
+			array(
+				'wikiValue'     => 'http://example.org/api?query=!_:;@*#Foo&=-3DBar',
+				'longHTMLText'  => 'http://example.org/api?query=!_:;@*#Foo&==Bar',
+				'longWikiText'  => 'http://example.org/api?query=!_:;@*#Foo&==Bar',
+				'shortHTMLText' => 'http://example.org/api?query=!_:;@*#Foo&==Bar',
+				'shortWikiText' => 'http://example.org/api?query=!_:;@*#Foo&==Bar'
+			)
+		);
+
+		$provider[] = array(
+			'http://example.org/api?query=!_:;@*#Foo&=-3DBar',
+			'&!_:;@*#Foo',
+			null,
+			array(
+				'wikiValue'     => 'http://example.org/api?query=!_:;@*#Foo&=-3DBar',
+				'longHTMLText'  => 'http://example.org/api?query=!_:;@*#Foo&==Bar',
+				'longWikiText'  => 'http://example.org/api?query=!_:;@*#Foo&==Bar',
+				'shortHTMLText' => '&!_:;@*#Foo',
+				'shortWikiText' => '&!_:;@*#Foo'
+			)
+		);
+
+		$provider[] = array(
+			'http://example.org/api?query=!_:;@*#Foo&=-3DBar',
+			false,
+			$linker,
+			array(
+				'wikiValue'     => 'http://example.org/api?query=!_:;@*#Foo&=-3DBar',
+				'longHTMLText'  => '<a class="external"' . $noFollowAttribute . ' href="http://example.org/api?query=!_:;@*#Foo&amp;==Bar">http://example.org/api?query=!_:;@*#Foo&amp;==Bar</a>',
+				'longWikiText'  => '[http://example.org/api?query=!_:;@*#Foo&==Bar http://example.org/api?query=!_:;@*#Foo&==Bar]',
+				'shortHTMLText' => '<a class="external"' . $noFollowAttribute . ' href="http://example.org/api?query=!_:;@*#Foo&amp;==Bar">http://example.org/api?query=!_:;@*#Foo&amp;==Bar</a>',
+				'shortWikiText' => '[http://example.org/api?query=!_:;@*#Foo&==Bar http://example.org/api?query=!_:;@*#Foo&==Bar]'
+			)
+		);
+
+		$provider[] = array(
+			'http://example.org/api?query=!_:;@*#Foo&=-3DBar',
+			'&!_:;@*#Foo',
+			$linker,
+			array(
+				'wikiValue'     => 'http://example.org/api?query=!_:;@*#Foo&=-3DBar',
+				'longHTMLText'  => '<a class="external"' . $noFollowAttribute . ' href="http://example.org/api?query=!_:;@*#Foo&amp;==Bar">http://example.org/api?query=!_:;@*#Foo&amp;==Bar</a>',
+				'longWikiText'  => '[http://example.org/api?query=!_:;@*#Foo&==Bar http://example.org/api?query=!_:;@*#Foo&==Bar]',
+				'shortHTMLText' => '<a class="external"' . $noFollowAttribute . ' href="http://example.org/api?query=!_:;@*#Foo&amp;==Bar">&amp;!_:;@*#Foo</a>',
+				'shortWikiText' => '[http://example.org/api?query=!_:;@*#Foo&==Bar &!_:;@*#Foo]'
+			)
+		);
+
+		return $provider;
+	}
+
+}

--- a/tests/phpunit/includes/MediaWiki/Specials/SearchByProperty/PageRequestOptionsTest.php
+++ b/tests/phpunit/includes/MediaWiki/Specials/SearchByProperty/PageRequestOptionsTest.php
@@ -76,12 +76,12 @@ class PageRequestOptionsTest extends \PHPUnit_Framework_TestCase {
 
 		#2
 		$provider[] = array(
-			'Foo/Bar',
+			'Foo_nu/Bar',
 			array(),
 			array(
 				'limit'  => 20,
 				'offset' => 0,
-				'propertyString' => 'Foo',
+				'propertyString' => 'Foo nu',
 				'valueString'    => 'Bar',
 				'nearbySearch'   => false
 			)

--- a/tests/phpunit/includes/UrlEncoderTest.php
+++ b/tests/phpunit/includes/UrlEncoderTest.php
@@ -59,18 +59,18 @@ class UrlEncoderTest extends \PHPUnit_Framework_TestCase {
 		$provider[] = array( 'Foo(-3-)', 'Foo(-3-)' );
 		$provider[] = array( '"Fo"o', '"Fo"o' );
 
-		$provider[] = array( 'Foo_bar', 'Foo bar' );
+		$provider[] = array( 'Foo_bar', 'Foo_bar' );
 		$provider[] = array( 'Has-20url', 'Has url' );
 
 		$provider[] = array( 'F &oo=?', 'F &oo=?' );
 		$provider[] = array( 'F+%26oo%3D%3F', 'F+&oo=?' );
-		$provider[] = array( 'F_%26oo%3D%3F', 'F &oo=?' );
+		$provider[] = array( 'F_%26oo%3D%3F', 'F_&oo=?' );
 
 		$provider[] = array( 'search&foo=Bar&', 'search&foo=Bar&' );
 		$provider[] = array( 'âêîôûëïçé', 'âêîôûëïçé' );
 
 		$provider[] = array( 'Has+Foo%28-3-%29%26', 'Has+Foo(-3-)&' );
-		$provider[] = array( 'Has_Foo(-3-)%26', 'Has Foo(-3-)&' );
+		$provider[] = array( 'Has_Foo(-3-)%26', 'Has_Foo(-3-)&' );
 
 		return $provider;
 	}


### PR DESCRIPTION
The internal representation remains encoded but the output display is being transformed to make them human readable
- https://bugzilla.wikimedia.org/show_bug.cgi?id=35452
- #633
