### PR TITLE
Fix 32955 to support `=` within the query condition

### DIFF
--- a/includes/query/SMW_QueryProcessor.php
+++ b/includes/query/SMW_QueryProcessor.php
@@ -284,6 +284,12 @@ class SMWQueryProcessor {
 				$rawParam = implode( ',', array_keys( $rawParam ) );
 			}
 
+			// Bug 32955
+			// Only modify the condition string which is assumed to be enclosed by [[ ... ]]
+			if ( strpos( $rawParam, '[[') !== false && strpos( $rawParam, ']]' ) !== false ) {
+				$rawParam = str_replace( array( '=' ), array( '-3D' ), $rawParam );
+			}
+
 			// accept 'name' => 'value' just as '' => 'name=value':
 			if ( is_string( $name ) && ( $name !== '' ) ) {
 				$rawParam = $name . '=' . $rawParam;
@@ -318,7 +324,8 @@ class SMWQueryProcessor {
 			}
 		}
 
-		$queryString = str_replace( array( '&lt;', '&gt;' ), array( '<', '>' ), $queryString );
+		$queryString = str_replace( array( '&lt;', '&gt;', '-3D' ), array( '<', '>', '=' ), $queryString );
+
 		if ( $showMode ) {
 			$queryString = "[[:$queryString]]";
 		}

--- a/tests/phpunit/includes/Query/QueryProcessorTest.php
+++ b/tests/phpunit/includes/Query/QueryProcessorTest.php
@@ -56,4 +56,57 @@ class SMWQueryProcessorTest extends MwDBaseUnitTestCase {
 		);
 	}
 
+	/**
+	 * @dataProvider rawParamsProvider
+	 */
+	public function testQuerStringFromRawParameters( $rawParams, $expected ) {
+
+		list( $queryString, $parameters, $printouts ) = SMWQueryProcessor::getComponentsFromFunctionParams( $rawParams, false );
+
+		$this->assertEquals(
+			$expected,
+			$queryString
+		);
+	}
+
+	public function rawParamsProvider() {
+
+		$provider[] = array(
+			array( 'Foo', 'bar' ),
+			'Foobar'
+		);
+
+		$provider[] = array(
+			array( 'Foo=', 'Bar' ),
+			'Bar'
+		);
+
+		$provider[] = array(
+			array( '[[Foo::Foo=Bar]]', '+Foo' ),
+			'[[Foo::Foo=Bar]]'
+		);
+
+		$provider[] = array(
+			array( '[[Modification date::+]]', '?Modification date=Date', 'limit=1' ),
+			'[[Modification date::+]]'
+		);
+
+		$provider[] = array(
+			array( '?Foo', 'limit=1', '[[Modification date::+]] OR [[Foo::Foo=Bar]]' ),
+			'[[Modification date::+]] OR [[Foo::Foo=Bar]]'
+		);
+
+		$provider[] = array(
+			array( '[[Modification date::+]] OR <q>[[Foo::Bar]]</q>', '?Modification date=Date', '?Foo=F', 'limit=1' ),
+			'[[Modification date::+]] OR <q>[[Foo::Bar]]</q>'
+		);
+
+		$provider[] = array(
+			array( '[[Has url::http://example.org/api.php?action=Foo]]', '?Has url=url', 'limit=1' ),
+			'[[Has url::http://example.org/api.php?action=Foo]]'
+		);
+
+		return $provider;
+	}
+
 }


### PR DESCRIPTION
```
{{#ask: [[Has url::http://example.org/api.php?action=Foo]]
 |?Has url=URL
 |limit=3
}}
```

https://bugzilla.wikimedia.org/show_bug.cgi?id=32955
https://bugzilla.wikimedia.org/show_bug.cgi?id=36351
