### PR TITLE
Fix 631 / Factbox to disable display of service links

### DIFF
--- a/includes/datavalues/SMW_DataValue.php
+++ b/includes/datavalues/SMW_DataValue.php
@@ -122,6 +122,11 @@ abstract class SMWDataValue {
 	private $mHasErrors = false;
 
 	/**
+	 * @var boolean
+	 */
+	private $serviceLinksRenderState = true;
+
+	/**
 	 * Constructor.
 	 *
 	 * @param string $typeid
@@ -624,6 +629,14 @@ abstract class SMWDataValue {
 	}
 
 	/**
+	 * @since 2.1
+	 * @param boolean $renderState
+	 */
+	public function setServiceLinksRenderState( $renderState = true ) {
+		$this->serviceLinksRenderState = $renderState;
+	}
+
+	/**
 	 * Return an array of SMWLink objects that provide additional resources
 	 * for the given value. Captions can contain some HTML markup which is
 	 * admissible for wiki text, but no more. Result might have no entries
@@ -637,7 +650,7 @@ abstract class SMWDataValue {
 					$this->m_property->getLabel(), $this->getWikiValue() );
 			}
 
-			if ( !$this->mHasServiceLinks ) { // add further service links
+			if ( !$this->mHasServiceLinks && $this->serviceLinksRenderState ) { // add further service links
 				$this->addServiceLinks();
 			}
 		}

--- a/includes/src/Factbox/Factbox.php
+++ b/includes/src/Factbox/Factbox.php
@@ -370,6 +370,7 @@ class Factbox {
 			foreach ( $semanticData->getPropertyValues( $propertyDi ) as $dataItem ) {
 
 				$dataValue = $this->dataValueFactory->newDataItemValue( $dataItem, $propertyDi );
+				$dataValue->setServiceLinksRenderState( false );
 
 				if ( $dataValue->isValid() ) {
 					$valuesHtml[] = Sanitizer::removeHTMLtags(


### PR DESCRIPTION
Add `DataValue::setServiceLinksRenderState` to disable/enable rendering of service links on an individual basis.

Relates to #631 
