### PR TITLE
Improve error msg for when _num contains alphanumerics

### DIFF
--- a/i18n/en.json
+++ b/i18n/en.json
@@ -300,5 +300,6 @@
 	"smw-sp-searchbyproperty-description": "This page provides a simple [https://www.semantic-mediawiki.org/wiki/Help:Browsing_interfaces browsing interface] for finding entities described by a property and a named value. Other available search interfaces include the [[Special:PageProperty|page property search]], and the [[Special:Ask|ask query builder]].",
 	"smw-sp-searchbyproperty-resultlist-header": "List of results",
 	"smw-sp-searchbyproperty-nonvaluequery": "A list of values that have the property \"$1\" assigned.",
-	"smw-sp-searchbyproperty-valuequery": "A list of pages that have property \"$1\" with value \"$2\" annotated."
+	"smw-sp-searchbyproperty-valuequery": "A list of pages that have property \"$1\" with value \"$2\" annotated.",
+	"smw-datavalue-number-textnotallowed": "\"$1\" can not be assigned to a declared number type with value $2."
 }

--- a/i18n/qqq.json
+++ b/i18n/qqq.json
@@ -114,6 +114,7 @@
 	"smw_nofloat": "This is an error/warning message. Parameters:\n* $1 holds the property value causing the error/warning.",
 	"smw_infinite": "This is an error/warning message. Parameters:\n* $1 holds the property value causing the error/warning.",
 	"smw_unitnotallowed": "This is an error/warning message. Parameters:\n* $1 holds the unit causing the error/warning.",
+	"smw-datavalue-number-textnotallowed": "This is an error/warning message. Parameters:\n* $1 holds the text causing the error/warning.\n* $2 holds the property value supposed to be used.",
 	"smw_nounitsdeclared": "This is an error/warning message.",
 	"smw_novalues": "This is an error/warning message.",
 	"smw_nodatetime": "This is an error/warning message. Parameters:\n* $1 holds the property value causing the error/warning.",

--- a/includes/datavalues/SMW_DV_Number.php
+++ b/includes/datavalues/SMW_DV_Number.php
@@ -102,10 +102,13 @@ class SMWNumberValue extends SMWDataValue {
 		$this->m_unitvalues = false;
 		$number = $unit = '';
 		$error = self::parseNumberValue( $value, $number, $unit );
+
 		if ( $error == 1 ) { // no number found
 			$this->addError( wfMessage( 'smw_nofloat', $value )->inContentLanguage()->text() );
 		} elseif ( $error == 2 ) { // number is too large for this platform
 			$this->addError( wfMessage( 'smw_infinite', $value )->inContentLanguage()->text() );
+		} elseif ( $this->getTypeID() === '_num' && $unit !== '' ) {
+			$this->addError( wfMessage( 'smw-datavalue-number-textnotallowed', $unit, $number )->inContentLanguage()->text() );
 		} elseif ( $this->convertToMainUnit( $number, $unit ) === false ) { // so far so good: now convert unit and check if it is allowed
 			$this->addError( wfMessage( 'smw_unitnotallowed', $unit )->inContentLanguage()->text() );
 		} // note that convertToMainUnit() also sets m_dataitem if valid


### PR DESCRIPTION
If _num is declared don't output something about quantities.

E.g [[Has number::42a]]
