### PR TITLE
Add UiAttributeFinder

### DIFF
--- a/SemanticMediaWiki.settings.php
+++ b/SemanticMediaWiki.settings.php
@@ -765,3 +765,13 @@ $GLOBALS['smwgOnDeleteAction'] = array(
 ##
 $GLOBALS['smwgFallbackSearchType'] = null;
 ##
+
+###
+# Enables to set default class attributes to effortless improve ui integration
+# where existing attributes (deployed by a skin or extension) can be pre-set
+# without a requirement to modify SMW related .less or .css files
+#
+# @since 2.1
+##
+$GLOBALS['smwgUiClassAttributes'] = array();
+##

--- a/includes/Settings.php
+++ b/includes/Settings.php
@@ -128,6 +128,7 @@ class Settings extends SimpleDictionary {
 			'smwgEnabledSpecialPage' => $GLOBALS['smwgEnabledSpecialPage'],
 			'smwgOnDeleteAction' => $GLOBALS['smwgOnDeleteAction'],
 			'smwgFallbackSearchType' => $GLOBALS['smwgFallbackSearchType'],
+			'smwgUiClassAttributes' => $GLOBALS['smwgUiClassAttributes']
 		);
 
 		$settings = $settings + array(

--- a/includes/queryprinters/TableResultPrinter.php
+++ b/includes/queryprinters/TableResultPrinter.php
@@ -195,10 +195,12 @@ class TableResultPrinter extends ResultPrinter {
 	public function getParamDefinitions( array $definitions ) {
 		$params = parent::getParamDefinitions( $definitions );
 
+		$uiClass = UiAttributeFinder::getClassForId( 'resultprinter-table' );
+
 		$params['class'] = array(
 			'name' => 'class',
 			'message' => 'smw-paramdesc-table-class',
-			'default' => 'sortable wikitable smwtable',
+			'default' => $uiClass !== '' ? $uiClass : 'sortable wikitable smwtable',
 		);
 
 		$params['transpose'] = array(

--- a/includes/specials/SMW_SpecialBrowse.php
+++ b/includes/specials/SMW_SpecialBrowse.php
@@ -2,6 +2,7 @@
 
 use SMW\UrlEncoder;
 use SMW\DIProperty;
+use SMW\UiAttributeFinder;
 
 /**
  * @ingroup SMWSpecialPage
@@ -155,8 +156,9 @@ class SMWSpecialBrowse extends SpecialPage {
 		// Some of the CSS classes are different for the left or the right side.
 		// In this case, there is an "i" after the "smwb-". This is set here.
 		$ccsPrefix = $left ? 'smwb-' : 'smwb-i';
+		$uiClass = UiAttributeFinder::getClassForId( 'browse-table' );
 
-		$html = "<table class=\"{$ccsPrefix}factbox\" cellpadding=\"0\" cellspacing=\"0\">\n";
+		$html = "<table class=\"{$ccsPrefix}factbox {$uiClass}\" cellpadding=\"0\" cellspacing=\"0\">\n";
 
 		$diProperties = $data->getProperties();
 		$noresult = true;
@@ -268,8 +270,10 @@ class SMWSpecialBrowse extends SpecialPage {
 	private function displayHead() {
 		global $wgOut;
 
+		$uiClass = UiAttributeFinder::getClassForId( 'browse-head' );
+
 		$wgOut->setHTMLTitle( $this->subject->getTitle() );
-		$html = "<table class=\"smwb-factbox\" cellpadding=\"0\" cellspacing=\"0\">\n" .
+		$html = "<table class=\"smwb-factbox {$uiClass}\" cellpadding=\"0\" cellspacing=\"0\">\n" .
 			"<tr class=\"smwb-title\"><td colspan=\"2\">\n" .
 			$this->subject->getLongHTMLText( smwfGetLinker() ) . "\n" .
 			"</td></tr>\n</table>\n";

--- a/includes/src/Factbox/Factbox.php
+++ b/includes/src/Factbox/Factbox.php
@@ -284,9 +284,11 @@ class Factbox {
 			$this->getTableContent( $semanticData );
 
 			$text .= Html::rawElement( 'div',
-				array( 'class' => 'smwfact' ),
+				array( 'class' => 'smwfact ' . UiAttributeFinder::getClassForId( 'factbox-head' ) ),
 				$this->tableBuilder->getHeaderItems() .
-				$this->tableBuilder->getHtml( array( 'class' => 'smwfacttable' ) )
+				$this->tableBuilder->getHtml( array(
+					'class' => 'smwfacttable ' . UiAttributeFinder::getClassForId( 'factbox-table' )
+				) )
 			);
 		}
 

--- a/includes/src/UiAttributeFinder.php
+++ b/includes/src/UiAttributeFinder.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace SMW;
+
+use Title;
+
+/**
+ * Utility class to modify style attributes
+ *
+ * @license GNU GPL v2+
+ * @since 2.1
+ *
+ * @author mwjames
+ */
+class UiAttributeFinder {
+
+	/**
+	 * @since 2.1
+	 *
+	 * @param string $id
+	 *
+	 * @return string
+	 */
+	public static function getClassForId( $id ) {
+
+		$id = strtolower( $id );
+
+		if ( isset( $GLOBALS['smwgUiClassAttributes'][ $id ] ) ) {
+			return htmlspecialchars( $GLOBALS['smwgUiClassAttributes'][ $id ] );
+		}
+
+		return '';
+	}
+
+}


### PR DESCRIPTION
Allows SMW to be skin agnostic but at the same time apply skin related style attributes by simply extending the `$GLOBALS['smwgUiClassAttributes']` setting.
