### PR TITLE
Fix T23926 / extra semicolon in record breaks field detection

### DIFF
--- a/includes/datavalues/SMW_DV_Record.php
+++ b/includes/datavalues/SMW_DV_Record.php
@@ -58,6 +58,10 @@ class SMWRecordValue extends SMWDataValue {
 			$semanticData = new SMWContainerSemanticData( $subject );
 		}
 
+		// Bug 21926 / T23926
+		// Values can be html encoded which adds additional semicolons
+		$value = htmlspecialchars_decode( $value, ENT_QUOTES );
+
 		$values = preg_split( '/[\s]*;[\s]*/u', trim( $value ) );
 		$valueIndex = 0; // index in value array
 		$propertyIndex = 0; // index in property list
@@ -187,6 +191,19 @@ class SMWRecordValue extends SMWDataValue {
 	public function setProperty( SMWDIProperty $property ) {
 		parent::setProperty( $property );
 		$this->m_diProperties = null;
+	}
+
+	/**
+	 * @since 2.1
+	 *
+	 * @param SMWDIProperty[] $properties
+	 */
+	public function setFieldProperties( array $properties ) {
+		foreach ( $properties as $property ) {
+			if ( $property instanceOf SMWDIProperty ) {
+				$this->m_diProperties[] = $property;
+			}
+		}
 	}
 
 ////// Additional API for value lists

--- a/tests/phpunit/Utils/Fixtures/FixturesProvider.php
+++ b/tests/phpunit/Utils/Fixtures/FixturesProvider.php
@@ -11,6 +11,7 @@ use SMW\Tests\Utils\Fixtures\Properties\PopulationProperty;
 use SMW\Tests\Utils\Fixtures\Properties\FoundedProperty;
 use SMW\Tests\Utils\Fixtures\Properties\LocatedInProperty;
 use SMW\Tests\Utils\Fixtures\Properties\CityCategory;
+use SMW\Tests\Utils\Fixtures\Properties\BookRecordProperty;
 
 use SMW\Tests\Utils\Fixtures\Facts\BerlinFactsheet;
 use SMW\Tests\Utils\Fixtures\Facts\ParisFactsheet;
@@ -72,7 +73,8 @@ class FixturesProvider {
 			'status' => new StatusProperty(),
 			'population' => new PopulationProperty(),
 			'founded' => new FoundedProperty(),
-			'locatedin' => new LocatedInProperty()
+			'locatedin' => new LocatedInProperty(),
+			'bookrecord' => new BookRecordProperty()
 		);
 	}
 

--- a/tests/phpunit/Utils/Fixtures/Properties/BookRecordProperty.php
+++ b/tests/phpunit/Utils/Fixtures/Properties/BookRecordProperty.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace SMW\Tests\Utils\Fixtures\Properties;
+
+use SMW\SemanticData;
+use SMW\DIProperty;
+
+use SMWDIBlob as DIBlob;
+
+/**
+ * Simplified book record
+ *
+ * @license GNU GPL v2+
+ * @since 2.1
+ *
+ * @author mwjames
+ */
+class BookRecordProperty extends FixtureProperty {
+
+	/**
+	 * @since 2.1
+	 */
+	public function __construct() {
+		$this->property = DIProperty::newFromUserLabel( 'Book record' );
+		$this->property->setPropertyTypeId( '_rec' );
+	}
+
+	/**
+	 * @since 2.1
+	 *
+	 * @return SemanticData
+	 */
+	public function getDependencies() {
+
+		$semanticData = parent::getDependencies();
+
+		$titleProperty = new TitleProperty();
+		$yearProperty = new YearProperty();
+
+		$semanticData->addPropertyObjectValue(
+			new DIProperty( '_LIST' ),
+			new DIBlob(
+				$titleProperty->getProperty()->getKey() . ';' .
+				$yearProperty->getProperty()->getKey()
+			)
+		);
+
+		return $semanticData;
+	}
+
+}

--- a/tests/phpunit/Utils/Fixtures/Properties/TitleProperty.php
+++ b/tests/phpunit/Utils/Fixtures/Properties/TitleProperty.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace SMW\Tests\Utils\Fixtures\Properties;
+
+use SMW\SemanticData;
+use SMW\DIProperty;
+
+/**
+ * @license GNU GPL v2+
+ * @since 2.1
+ *
+ * @author mwjames
+ */
+class TitleProperty extends FixtureProperty {
+
+	/**
+	 * @since 2.1
+	 */
+	public function __construct() {
+		$this->property = DIProperty::newFromUserLabel( 'Title' );
+		$this->property->setPropertyTypeId( '_wpg' );
+	}
+
+}

--- a/tests/phpunit/includes/DataValues/RecordValueTest.php
+++ b/tests/phpunit/includes/DataValues/RecordValueTest.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace SMW\Tests\DataValues;
+
+use SMW\DIProperty;
+use SMWRecordValue as RecordValue;
+
+/**
+ * @covers \SMWRecordValue
+ *
+ * @group SMW
+ * @group SMWExtension
+ *
+ * @license GNU GPL v2+
+ * @since 2.1
+ *
+ * @author mwjames
+ */
+class RecordValueTest extends \PHPUnit_Framework_TestCase {
+
+	public function testCanConstruct() {
+
+		$this->assertInstanceOf(
+			'\SMWRecordValue',
+			new RecordValue( '_rec' )
+		);
+	}
+
+	/**
+	 * @dataProvider valueProvider
+	 */
+	public function testGetQueryDescription( $properties, $value, $expected ) {
+
+		$instance = new RecordValue( '_rec' );
+		$instance->setFieldProperties( $properties );
+
+		$description = $instance->getQueryDescription( htmlspecialchars( $value ) );
+
+		$this->assertEquals(
+			$expected,
+			$description->getQueryString()
+		);
+	}
+
+	public function valueProvider() {
+
+		$properties = array(
+			new DIProperty( 'Foo'),
+			new DIProperty( 'Bar' ),
+			'InvalidFieldPropertyNotSet'
+		);
+
+		$provider[] = array(
+			$properties,
+			"Title without special characters;2001",
+			"[[Foo::Title without special characters]] [[Bar::2001]]"
+		);
+
+		$provider[] = array(
+			$properties,
+			"Title with $&%'* special characters;(..&^%..)",
+			"[[Foo::Title with $&%'* special characters]] [[Bar::(..&^%..)]]"
+		);
+
+		$provider[] = array(
+			$properties,
+			" Title with space before ; After the divider ",
+			"[[Foo::Title with space before]] [[Bar::After the divider]]"
+		);
+
+		return $provider;
+	}
+
+}


### PR DESCRIPTION
Caused by things like `&amp;`, see [0].

[0] https://phabricator.wikimedia.org/T23926
