### PR TITLE
Fix 649 / sortkey and enable page-type regex search

### DIFF
--- a/includes/dataitems/SMW_DI_WikiPage.php
+++ b/includes/dataitems/SMW_DI_WikiPage.php
@@ -22,22 +22,30 @@ class DIWikiPage extends SMWDataItem {
 	 * @var string
 	 */
 	protected $m_dbkey;
+
 	/**
 	 * MediaWiki namespace integer.
 	 * @var integer
 	 */
 	protected $m_namespace;
+
 	/**
 	 * MediaWiki interwiki prefix.
 	 * @var string
 	 */
 	protected $m_interwiki;
+
 	/**
 	 * Name for subobjects of pages, or empty string if the given object is
 	 * the page itself (not a subobject).
 	 * @var string
 	 */
 	protected $m_subobjectname;
+
+	/**
+	 * @var string
+	 */
+	private $sortkey = null;
 
 	/**
 	 * Contructor. We do not bother with too much detailed validation here,
@@ -86,13 +94,27 @@ class DIWikiPage extends SMWDataItem {
 	}
 
 	/**
+	 * @since  2.1
+	 *
+	 * @param string $sortkey
+	 */
+	public function setSortKey( $sortkey ) {
+		$this->sortkey = str_replace( '_', ' ', $sortkey );
+	}
+
+	/**
 	 * Get the sortkey of the wiki page data item. Note that this is not
 	 * the sortkey that might have been set for the corresponding wiki
 	 * page. To obtain the latter, query for the values of the property
 	 * "new SMWDIProperty( '_SKEY' )".
 	 */
 	public function getSortKey() {
-		return $this->m_dbkey;
+
+		if ( $this->sortkey === null || $this->sortkey === '' ) {
+			$this->sortkey = str_replace( '_', ' ', $this->m_dbkey );
+		}
+
+		return $this->sortkey;
 	}
 
 	/**

--- a/includes/src/Annotator/SortkeyPropertyAnnotator.php
+++ b/includes/src/Annotator/SortkeyPropertyAnnotator.php
@@ -37,7 +37,7 @@ class SortkeyPropertyAnnotator extends PropertyAnnotatorDecorator {
 
 	protected function addPropertyValues() {
 
-		$sortkey = $this->defaultSort ? $this->defaultSort : str_replace( '_', ' ', $this->getSemanticData()->getSubject()->getDBkey() );
+		$sortkey = $this->defaultSort ? $this->defaultSort : $this->getSemanticData()->getSubject()->getSortKey();
 
 		$this->getSemanticData()->addPropertyObjectValue(
 			new DIProperty( DIProperty::TYPE_SORTKEY ),

--- a/includes/storage/SQLStore/SMW_DIHandler_WikiPage.php
+++ b/includes/storage/SQLStore/SMW_DIHandler_WikiPage.php
@@ -117,10 +117,25 @@ class SMWDIHandlerWikiPage extends SMWDataItemHandler {
 					return $wikipage;
 				}
 			} else {
-				return new SMWDIWikiPage( $dbkeys[0], $namespace, $dbkeys[2], $dbkeys[4] );
+				return $this->newDiWikiPage( $dbkeys );
 			}
 		}
 
 		throw new SMWDataItemException( 'Failed to create data item from DB keys.' );
 	}
+
+	private function newDiWikiPage( $dbkeys ) {
+
+		$diWikiPage = new SMWDIWikiPage(
+			$dbkeys[0],
+			intval( $dbkeys[1] ),
+			$dbkeys[2],
+			$dbkeys[4]
+		);
+
+		$diWikiPage->setSortKey( $dbkeys[3] );
+
+		return $diWikiPage;
+	}
+
 }

--- a/includes/storage/SQLStore/SMW_SQLStore3.php
+++ b/includes/storage/SQLStore/SMW_SQLStore3.php
@@ -882,7 +882,8 @@ class SMWSQLStore3 extends SMWStore {
 	 */
 	public function clear() {
 		parent::clear();
-
+		$this->m_semdata = array();
+		$this->m_sdstate = array();
 		self::$prop_tables = null;
 		$this->getObjectIds()->clearCaches();
 	}

--- a/includes/storage/SQLStore/SMW_SQLStore3_Readers.php
+++ b/includes/storage/SQLStore/SMW_SQLStore3_Readers.php
@@ -37,11 +37,18 @@ class SMWSQLStore3Readers {
 
 		// *** Find out if this subject exists ***//
 		$sortkey = '';
-		$sid = $this->store->smwIds->getSMWPageIDandSort( $subject->getDBkey(),
-							$subject->getNamespace(),
-							$subject->getInterwiki(),
-							$subject->getSubobjectName(),
-							$sortkey, true, true );
+
+		$sid = $this->store->smwIds->getSMWPageIDandSort(
+			$subject->getDBkey(),
+			$subject->getNamespace(),
+			$subject->getInterwiki(),
+			$subject->getSubobjectName(),
+			$sortkey,
+			true,
+			true
+		);
+
+		$subject->setSortKey( $sortkey );
 
 		if ( $sid == 0 ) {
 			// We consider redirects for getting $sid,
@@ -76,7 +83,6 @@ class SMWSQLStore3Readers {
 		$this->store->m_semdata[$sid]->addPropertyStubValue( '_SKEY', array( '', $sortkey ) );
 		self::$in_getSemanticData--;
 
-
 		return $this->store->m_semdata[$sid];
 	}
 
@@ -89,6 +95,7 @@ class SMWSQLStore3Readers {
 	 * @since 1.8
 	 */
 	protected function initSemanticDataCache( $sid, SMWDIWikiPage $subject ) {
+
 		// *** Prepare the cache ***//
 		if ( !array_key_exists( $sid, $this->store->m_semdata ) ) { // new cache entry
 			$this->store->m_semdata[$sid] = new SMWSql3StubSemanticData( $subject, $this->store, false );

--- a/includes/storage/SQLStore/SMW_SQLStore3_Writers.php
+++ b/includes/storage/SQLStore/SMW_SQLStore3_Writers.php
@@ -182,8 +182,12 @@ class SMWSQLStore3Writers {
 		if ( $sortkeyDataItem instanceof SMWDIBlob ) {
 			$sortkey = $sortkeyDataItem->getString();
 		} else { // default sortkey
-			$sortkey = str_replace( '_', ' ', $subject->getDBkey() );
+			$sortkey = $subject->getSortKey();
 		}
+
+		// #649 Be consistent about how sortkeys are stored therefore always
+		// normalize even for usages like {{DEFAULTSORT: Foo_bar }}
+		$sortkey = str_replace( '_', ' ', $sortkey );
 
 		// Always make an ID; this also writes sortkey and namespace data
 		$sid = $this->store->getObjectIds()->makeSMWPageID(
@@ -231,7 +235,7 @@ class SMWSQLStore3Writers {
 
 		$res = $db->select(
 			$db->tablename( SMWSql3SmwIds::tableName ),
-			'smw_id,smw_subobject',
+			'smw_id,smw_subobject,smw_sortkey',
 			'smw_title = ' . $db->addQuotes( $subject->getDBkey() ) . ' AND ' .
 			'smw_namespace = ' . $db->addQuotes( $subject->getNamespace() ) . ' AND ' .
 			'smw_iw = ' . $db->addQuotes( $subject->getInterwiki() ) . ' AND ' .
@@ -247,7 +251,7 @@ class SMWSQLStore3Writers {
 				$subject->getDBkey(),
 				$subject->getNamespace(),
 				$subject->getInterwiki(),
-				'',
+				$row->smw_sortkey,
 				$row->smw_subobject
 			) );
 		}

--- a/tests/phpunit/Integration/MediaWiki/Import/Maintenance/DumpRdfMaintenanceTest.php
+++ b/tests/phpunit/Integration/MediaWiki/Import/Maintenance/DumpRdfMaintenanceTest.php
@@ -110,7 +110,7 @@ class DumpRdfMaintenanceTest extends MwDBaseUnitTestCase {
 			'<rdfs:label>Lorem ipsum</rdfs:label>',
 			'<swivt:masterPage rdf:resource="&wiki;Lorem_ipsum"/>',
 			'<property:Has_subobject-23aux rdf:resource="&wiki;Lorem_ipsum-23_017ced50ca5208f4cc77f90c43a0d4a9"/>',
-			'<swivt:wikiPageSortKey>Lorem ipsum# 017ced50ca5208f4cc77f90c43a0d4a9</swivt:wikiPageSortKey>'
+			'<swivt:wikiPageSortKey rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Lorem ipsum</swivt:wikiPageSortKey>'
 		);
 
 		$maintenanceRunner

--- a/tests/phpunit/Integration/Query/PageTypeRegexQueryTest.php
+++ b/tests/phpunit/Integration/Query/PageTypeRegexQueryTest.php
@@ -1,0 +1,193 @@
+<?php
+
+namespace SMW\Tests\Integration\Query;
+
+use SMW\Tests\MwDBaseUnitTestCase;
+use SMW\Tests\Utils\UtilityFactory;
+
+use SMW\Query\Language\SomeProperty;
+use SMW\DataValueFactory;
+
+use SMWQueryParser as QueryParser;
+use SMWQuery as Query;
+use SMWPrintRequest as PrintRequest;
+use SMWPropertyValue as PropertyValue;
+use SMWExporter as Exporter;
+
+/**
+ * @group SMW
+ * @group SMWExtension
+ *
+ * @group semantic-mediawiki-integration
+ * @group semantic-mediawiki-query
+ *
+ * @group semantic-mediawiki-database
+ * @group medium
+ *
+ * @license GNU GPL v2+
+ * @since 2.1
+ *
+ * @author mwjames
+ */
+class PageTypeRegexQueryTest extends MwDBaseUnitTestCase {
+
+	private $queryResultValidator;
+	private $fixturesProvider;
+
+	private $semanticDataFactory;
+	private $dataValueFactory;
+
+	private $queryParser;
+	private $subjects = array();
+
+	protected function setUp() {
+		parent::setUp();
+
+		$utilityFactory = UtilityFactory::getInstance();
+
+		$this->dataValueFactory = DataValueFactory::getInstance();
+		$this->semanticDataFactory = $utilityFactory->newSemanticDataFactory();
+
+		$this->queryResultValidator = $utilityFactory->newValidatorFactory()->newQueryResultValidator();
+
+		$this->fixturesProvider = $utilityFactory->newFixturesFactory()->newFixturesProvider();
+		$this->fixturesProvider->setupDependencies( $this->getStore() );
+
+		$this->queryParser = new QueryParser();
+	}
+
+	protected function tearDown() {
+
+		$fixturesCleaner = UtilityFactory::getInstance()->newFixturesFactory()->newFixturesCleaner();
+		$fixturesCleaner
+			->purgeSubjects( $this->subjects )
+			->purgeAllKnownFacts();
+
+		parent::tearDown();
+	}
+
+	/**
+	 * #649
+	 */
+	public function testPageLikeNotLikeWildcardSearch() {
+
+		// Doesn't support this feature currently
+		$this->skipTestForStore( 'SMW\SPARQLStore\SPARQLStore' );
+
+		$property = $this->fixturesProvider->getProperty( 'title' );
+
+		$semanticData = $this->semanticDataFactory
+			->newEmptySemanticData( __METHOD__ . '-0' );
+
+		$this->subjects['sample-0'] = $semanticData->getSubject();
+
+		$dataValue = $this->dataValueFactory->newPropertyObjectValue(
+			$property,
+			"Title never to be selected"
+		);
+
+		$semanticData = $this->semanticDataFactory
+			->newEmptySemanticData( __METHOD__ . '-1' );
+
+		$this->subjects['sample-1'] = $semanticData->getSubject();
+
+		$dataValue = $this->dataValueFactory->newPropertyObjectValue(
+			$property,
+			"Sample text with spaces"
+		);
+
+		$semanticData->addDataValue( $dataValue	);
+
+		$this->getStore()->updateData( $semanticData );
+
+		$semanticData = $this->semanticDataFactory
+			->newEmptySemanticData( __METHOD__ .'-2'  );
+
+		$this->subjects['sample-2'] = $semanticData->getSubject();
+
+		$dataValue = $this->dataValueFactory->newPropertyObjectValue(
+			$property,
+			"Sample test with spaces"
+		);
+
+		$semanticData->addDataValue( $dataValue	);
+
+		$this->getStore()->updateData( $semanticData );
+
+		/**
+		 * @query "[[Title::~Sample te*]]"
+		 */
+		$this->assertThatQueryReturns(
+			"[[Title::~Sample te*]]" ,
+			array(
+				$this->subjects['sample-1'],
+				$this->subjects['sample-2']
+			)
+		);
+
+		/**
+		 * @query "[[Title::~Sample tes*]]"
+		 */
+		$this->assertThatQueryReturns(
+			"[[Title::~Sample tes*]]",
+			array(
+				$this->subjects['sample-2']
+			)
+		);
+
+		/**
+		 * @query "[[Title::~Sample te?t with spaces]]"
+		 */
+		$this->assertThatQueryReturns(
+			"[[Title::~Sample te?t with spaces]]",
+			array(
+				$this->subjects['sample-1'],
+				$this->subjects['sample-2']
+			)
+		);
+
+		/**
+		 * @query "[[Title::~Sample*]] [[Title::!~Sample tes*]]"
+		 */
+		$this->assertThatQueryReturns(
+			"[[Title::~Sample*]] [[Title::!~Sample tes*]]",
+			array(
+				$this->subjects['sample-1']
+			)
+		);
+
+		/**
+		 * @query "[[Title::~Sample tes*]] OR [[Title::~Sample tex*]]"
+		 */
+		$this->assertThatQueryReturns(
+			"[[Title::~Sample tes*]] OR [[Title::~Sample tex*]]",
+			array(
+				$this->subjects['sample-1'],
+				$this->subjects['sample-2']
+			)
+		);
+	}
+
+	private function assertThatQueryReturns( $queryString, $expected ) {
+
+		$description = $this->queryParser
+			->getQueryDescription( $queryString );
+
+		$query = new Query(
+			$description,
+			false,
+			true
+		);
+
+		$query->sort = true;
+		$query->sortkeys = array(
+			'Title' => 'desc'
+		);
+
+		$this->queryResultValidator->assertThatQueryResultHasSubjects(
+			$expected,
+			$this->getStore()->getQueryResult( $query )
+		);
+	}
+
+}

--- a/tests/phpunit/Integration/RdfXmlSerializationExportDBIntegrationTest.php
+++ b/tests/phpunit/Integration/RdfXmlSerializationExportDBIntegrationTest.php
@@ -146,7 +146,8 @@ class RdfXmlSerializationExportDBIntegrationTest extends MwDBaseUnitTestCase {
 			'<property:RdfXmlSerializationForDateProperty-23aux rdf:datatype="http://www.w3.org/2001/XMLSchema#double">2457022.5</property:RdfXmlSerializationForDateProperty-23aux>',
 
 			// Subobject
-			'<swivt:wikiPageSortKey>SMW\Tests\Integration\RdfXmlSerializationExportDBIntegrationTest::testRdfXmlSerializationPrintoutForDatePropertyAnnotation# edab041aad45f1b607fc26802f7c7cd2</swivt:wikiPageSortKey>',
+			'<swivt:wikiPageSortKey rdf:datatype="http://www.w3.org/2001/XMLSchema#string">SMW\Tests\Integration\RdfXmlSerializationExportDBIntegrationTest::testRdfXmlSerializationPrintoutForDatePropertyAnnotation</swivt:wikiPageSortKey>',
+
 			'<swivt:wikiPageSortKey rdf:datatype="http://www.w3.org/2001/XMLSchema#string">SMW\Tests\Integration\RdfXmlSerializationExportDBIntegrationTest::testRdfXmlSerializationPrintoutForDatePropertyAnnotation</swivt:wikiPageSortKey>',
 			'<swivt:wikiNamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</swivt:wikiNamespace>',
 			'<property:RdfXmlSerializationForDateProperty rdf:datatype="http://www.w3.org/2001/XMLSchema#date">1970-01-01Z</property:RdfXmlSerializationForDateProperty>',

--- a/tests/phpunit/Integration/SemanticDataSerializationDBIntegrationTest.php
+++ b/tests/phpunit/Integration/SemanticDataSerializationDBIntegrationTest.php
@@ -42,20 +42,11 @@ class SemanticDataSerializationDBIntegrationTest extends MwDBaseUnitTestCase {
 			DataValueFactory::getInstance()->newPropertyValue( 'Foo', 'Bar' )
 		);
 
-		$semanticDataBeforeUpdate->addPropertyObjectValue(
-			$subobject->getProperty(),
-			$subobject->getContainer()
-		);
+		$semanticDataBeforeUpdate->addSubobject( $subobject );
 
 		$this->getStore()->updateData( $semanticDataBeforeUpdate );
 
 		$semanticDataAfterUpdate = $this->getStore()->getSemanticData( $subject );
-
-		$this->assertNotEquals(
-			$semanticDataBeforeUpdate->getHash(),
-			$semanticDataAfterUpdate->getHash(),
-			'Assert that the hash is not comparable due to the added _SKEY property during the update'
-		);
 
 		$serializerFactory = new SerializerFactory();
 

--- a/tests/phpunit/Integration/SemanticDataSortKeyUpdateDBIntegrationTest.php
+++ b/tests/phpunit/Integration/SemanticDataSortKeyUpdateDBIntegrationTest.php
@@ -1,0 +1,103 @@
+<?php
+
+namespace SMW\Tests\Integration;
+
+use SMW\Tests\MwDBaseUnitTestCase;
+use SMW\Tests\Utils\UtilityFactory;
+
+use SMW\DIWikiPage;
+use SMW\DIProperty;
+use SMW\SemanticData;
+use SMW\DataValueFactory;
+use SMW\Subobject;
+use SMW\SerializerFactory;
+
+use SMWDIBlob as DIBlob;
+
+use Title;
+
+/**
+ * @group SMW
+ * @group SMWExtension
+ *
+ * @group semantic-mediawiki-integration
+ * @group mediawiki-database
+ *
+ * @group medium
+ *
+ * @license GNU GPL v2+
+ * @since 2.1
+ *
+ * @author mwjames
+ */
+class SemanticDataSortKeyUpdateDBIntegrationTest extends MwDBaseUnitTestCase {
+
+	private $semanticDataFactory;
+
+	protected function setUp() {
+		parent::setUp();
+
+		$this->semanticDataFactory = UtilityFactory::getInstance()->newSemanticDataFactory();
+	}
+
+	protected function tearDown() {
+		parent::tearDown();
+	}
+
+	public function testSubjectSortKeySetter() {
+
+		$semanticData = $this->semanticDataFactory
+			->newEmptySemanticData( __METHOD__ );
+
+		$subject = $semanticData->getSubject();
+		$subject->setSortKey( 'a_b_c' );
+
+		$this->getStore()->updateData( $semanticData );
+
+		$semanticDataFromDB = $this->getStore()->getSemanticData( $subject );
+
+		$this->assertEquals(
+			'a b c',
+			$semanticDataFromDB->getSubject()->getSortKey()
+		);
+
+		foreach ( $semanticDataFromDB->getPropertyValues( new DIProperty( '_SKEY' ) ) as $value ) {
+			$this->assertEquals(
+				'a b c',
+				$value->getString()
+			);
+		}
+	}
+
+	public function testDefinedSortKeyTakesPrecedenceOverSubjectSortKey() {
+
+		$semanticData = $this->semanticDataFactory
+			->newEmptySemanticData( __METHOD__ );
+
+		$subject = $semanticData->getSubject();
+		$subject->setSortKey( '1_2_3' );
+
+		$semanticData->addPropertyObjectValue(
+			new DIProperty( '_SKEY' ),
+			new DIBlob( 'x_y_z' )
+		);
+
+		$this->getStore()->updateData( $semanticData );
+		$this->getStore()->clear();
+
+		$semanticDataFromDB = $this->getStore()->getSemanticData( $subject );
+
+		$this->assertEquals(
+			'x y z',
+			$semanticDataFromDB->getSubject()->getSortKey()
+		);
+
+		foreach ( $semanticDataFromDB->getPropertyValues( new DIProperty( '_SKEY' ) ) as $value ) {
+			$this->assertEquals(
+				'x y z',
+				$value->getString()
+			);
+		}
+	}
+
+}

--- a/tests/phpunit/includes/dataitems/DIWikiPageTest.php
+++ b/tests/phpunit/includes/dataitems/DIWikiPageTest.php
@@ -50,4 +50,48 @@ class DIWikiPageTest extends DataItemTest {
 		$this->assertTrue( $newDi->equals( $di ) );
 	}
 
+	/**
+	 * @dataProvider sortKeyProvider
+	 */
+	public function testSortKeyRoundtrip( $title, $sortkey, $expected ) {
+
+		$instance = new DIWikiPage( $title, NS_MAIN );
+
+		$instance->setSortKey( $sortkey );
+
+		$this->assertEquals(
+			$expected,
+			$instance->getSortKey()
+		);
+	}
+
+	public function sortKeyProvider() {
+
+		$provider[] = array(
+			'Some_title',
+			null,
+			'Some title'
+		);
+
+		$provider[] = array(
+			'Some_title',
+			'',
+			'Some title'
+		);
+
+		$provider[] = array(
+			'Some_title',
+			'abc',
+			'abc'
+		);
+
+		$provider[] = array(
+			'Some_title',
+			'abc_def',
+			'abc def'
+		);
+
+		return $provider;
+	}
+
 }


### PR DESCRIPTION
Fixes to #649 for the `SQLStore`

Supported test scenarios:
- Dataset includes page 1 with `[[Title::Sample text with spaces]]`, page 2 with `[[Title::Sample test with spaces]]`
- Queries include `[[Title::~Sample te*]]`, `[[Title::~Sample tes*]]`, `[[Title::~Sample te?t with spaces]]`, `[[Title::~Sample*]] AND [[Title::!~Sample tes*]]`, `[[Title::~Sample tes*]] OR [[Title::~Sample tex*]]`
