### PR TITLE
Fix 663 / VARCHAR(32) binary -> VARBINARY(32)

### DIFF
--- a/includes/storage/SMW_SQLHelpers.php
+++ b/includes/storage/SMW_SQLHelpers.php
@@ -30,7 +30,7 @@ class SMWSQLHelpers {
 			case 'id': return $wgDBtype == 'postgres' ? 'SERIAL' : ($wgDBtype == 'sqlite' ? 'INTEGER' :'INT(8) UNSIGNED'); // like page_id in MW page table
 			case 'namespace': return $wgDBtype == 'postgres' ? 'BIGINT' : 'INT(11)'; // like page_namespace in MW page table
 			case 'title': return $wgDBtype == 'postgres' ? 'TEXT' : 'VARBINARY(255)'; // like page_title in MW page table
-			case 'iw': return ($wgDBtype == 'postgres' || $wgDBtype == 'sqlite') ? 'TEXT' : 'VARCHAR(32) binary'; // like iw_prefix in MW interwiki table
+			case 'iw': return ($wgDBtype == 'postgres' || $wgDBtype == 'sqlite') ? 'TEXT' : 'VARBINARY(32)'; // like iw_prefix in MW interwiki table
 			case 'blob': return $wgDBtype == 'postgres' ? 'BYTEA' : 'MEDIUMBLOB'; // larger blobs of character data, usually not subject to SELECT conditions
 		}
 


### PR DESCRIPTION
#668 fix for 2.\* and should be revised in 3.\* because of the difference between MW `page_title`, `iw_prefix` and SMW's schema definition.
