### PR TITLE
Add NumberFormatter::formatNumberToLocalizedText

### DIFF
--- a/includes/GlobalFunctions.php
+++ b/includes/GlobalFunctions.php
@@ -1,6 +1,7 @@
 <?php
 
 use SMW\NamespaceManager;
+use SMW\NumberFormatter;
 use SMW\SPARQLStore\SparqlDBConnectionProvider;
 
 /**
@@ -83,84 +84,10 @@ function smwfHTMLtoUTF8( $text ) {
 }
 
 /**
- * @codeCoverageIgnore
- *
- * This method formats a float number value according to the given language and
- * precision settings, with some intelligence to produce readable output. Used
- * to format a number that was not hand-formatted by a user.
- *
- * @param mixed $value input number
- * @param integer $decplaces optional positive integer, controls how many digits after
- * the decimal point are shown
+ * @deprecated since 2.1, use NumberFormatter instead
  */
 function smwfNumberFormat( $value, $decplaces = 3 ) {
-	global $smwgMaxNonExpNumber;
-
-	$decseparator = wfMessage( 'smw_decseparator' )->text();
-
-	// If number is a trillion or more, then switch to scientific
-	// notation. If number is less than 0.0000001 (i.e. twice decplaces),
-	// then switch to scientific notation. Otherwise print number
-	// using number_format. This may lead to 1.200, so then use trim to
-	// remove trailing zeroes.
-	$doScientific = false;
-
-	// @todo: Don't do all this magic for integers, since the formatting does not fit there
-	//       correctly. E.g. one would have integers formatted as 1234e6, not as 1.234e9, right?
-	// The "$value!=0" is relevant: we want to scientify numbers that are close to 0, but never 0!
-	if ( ( $decplaces > 0 ) && ( $value != 0 ) ) {
-		$absValue = abs( $value );
-		if ( $absValue >= $smwgMaxNonExpNumber ) {
-			$doScientific = true;
-		} elseif ( $absValue <= pow( 10, - $decplaces ) ) {
-			$doScientific = true;
-		} elseif ( $absValue < 1 ) {
-			if ( $absValue <= pow( 10, - $decplaces ) ) {
-				$doScientific = true;
-			} else {
-				// Increase decimal places for small numbers, e.g. .00123 should be 5 places.
-				for ( $i = 0.1; $absValue <= $i; $i *= 0.1 ) {
-					$decplaces++;
-				}
-			}
-		}
-	}
-
-	if ( $doScientific ) {
-		// Should we use decimal places here?
-		$value = sprintf( "%1.6e", $value );
-		// Make it more readable by removing trailing zeroes from n.n00e7.
-		$value = preg_replace( '/(\\.\\d+?)0*e/u', '${1}e', $value, 1 );
-		// NOTE: do not use the optional $count parameter with preg_replace. We need to
-		//      remain compatible with PHP 4.something.
-		if ( $decseparator !== '.' ) {
-			$value = str_replace( '.', $decseparator, $value );
-		}
-	} else {
-		// Format to some level of precision; number_format does rounding and locale formatting,
-		// x and y are used temporarily since number_format supports only single characters for either
-		$value = number_format( $value, $decplaces, 'x', 'y' );
-		$value = str_replace(
-			array( 'x', 'y' ),
-			array( $decseparator, wfMessage( 'smw_kiloseparator' )->inContentLanguage()->text() ),
-			$value
-		);
-
-		// Make it more readable by removing ending .000 from nnn.000
-		//    Assumes substr is faster than a regular expression replacement.
-		$end = $decseparator . str_repeat( '0', $decplaces );
-		$lenEnd = strlen( $end );
-
-		if ( substr( $value, - $lenEnd ) === $end ) {
-			$value = substr( $value, 0, - $lenEnd );
-		} else {
-			// If above replacement occurred, no need to do the next one.
-			// Make it more readable by removing trailing zeroes from nn.n00.
-			$value = preg_replace( "/(\\$decseparator\\d+?)0*$/u", '$1', $value, 1 );
-		}
-	}
-
-	return $value;
+	return NumberFormatter::getInstance()->formatNumberToLocalizedText( $value, $decplaces );
 }
 
 /**

--- a/includes/datavalues/SMW_DV_Number.php
+++ b/includes/datavalues/SMW_DV_Number.php
@@ -1,4 +1,7 @@
 <?php
+
+use SMW\NumberFormatter;
+
 /**
  * @ingroup SMWDataValues
  */
@@ -65,8 +68,8 @@ class SMWNumberValue extends SMWDataValue {
 	 */
 	static protected function parseNumberValue( $value, &$number, &$unit ) {
 		// Parse to find $number and (possibly) $unit
-		$decseparator = wfMessage( 'smw_decseparator' )->inContentLanguage()->text();
-		$kiloseparator = wfMessage( 'smw_kiloseparator' )->inContentLanguage()->text();
+		$decseparator = NumberFormatter::getInstance()->getDecimalSeparatorForContentLanguage();
+		$kiloseparator = NumberFormatter::getInstance()->getThousandsSeparatorForContentLanguage();
 
 		$parts = preg_split( '/([-+]?\s*\d+(?:\\' . $kiloseparator . '\d\d\d)*' .
 		                      '(?:\\' . $decseparator . '\d+)?\s*(?:[eE][-+]?\d+)?)/u',
@@ -154,7 +157,7 @@ class SMWNumberValue extends SMWDataValue {
 			$sep = '';
 			foreach ( $this->m_unitvalues as $unit => $value ) {
 				if ( $unit != $this->m_unitin ) {
-					$tooltip .= $sep . smwfNumberFormat( $value );
+					$tooltip .= $sep . NumberFormatter::getInstance()->formatNumberToLocalizedText( $value );
 					if ( $unit !== '' ) {
 						$tooltip .= '&#160;' . $unit;
 					}
@@ -196,7 +199,7 @@ class SMWNumberValue extends SMWDataValue {
 				} elseif ( $i > 1 ) {
 					$result .= ', ';
 				}
-				$result .= ( $this->m_outformat != '-' ? smwfNumberFormat( $value ) : $value );
+				$result .= ( $this->m_outformat != '-' ? NumberFormatter::getInstance()->formatNumberToLocalizedText( $value ) : $value );
 				if ( $unit !== '' ) {
 					$result .= '&#160;' . $unit;
 				}
@@ -223,7 +226,7 @@ class SMWNumberValue extends SMWDataValue {
 	public function getWikiValue() {
 		if ( $this->isValid() ) {
 			$unit = $this->getUnit();
-			return smwfNumberFormat( $this->m_dataitem->getSerialization() ) . ( $unit !== '' ? ' ' . $unit : '' );
+			return NumberFormatter::getInstance()->formatNumberToLocalizedText( $this->m_dataitem->getSerialization() ) . ( $unit !== '' ? ' ' . $unit : '' );
 		} else {
 			return 'error';
 		}
@@ -315,7 +318,7 @@ class SMWNumberValue extends SMWDataValue {
 	protected function makeUserValue() {
 		$this->m_caption = '';
 		if ( $this->m_outformat != '-u' ) { // -u is the format for displaying the unit only
-			$this->m_caption .= ( ( $this->m_outformat != '-' ) && ( $this->m_outformat != '-n' ) ? smwfNumberFormat( $this->m_dataitem->getNumber() ) : $this->m_dataitem->getNumber() );
+			$this->m_caption .= ( ( $this->m_outformat != '-' ) && ( $this->m_outformat != '-n' ) ? NumberFormatter::getInstance()->formatNumberToLocalizedText( $this->m_dataitem->getNumber() ) : $this->m_dataitem->getNumber() );
 		}
 		// no unit ever, so nothing to do about this
 		$this->m_unitin = '';

--- a/includes/datavalues/SMW_DV_Quantity.php
+++ b/includes/datavalues/SMW_DV_Quantity.php
@@ -1,4 +1,7 @@
 <?php
+
+use SMW\NumberFormatter;
+
 /**
  * @ingroup SMWDataValues
  */
@@ -110,7 +113,7 @@ class SMWQuantityValue extends SMWNumberValue {
 
 		$this->m_caption = '';
 		if ( $this->m_outformat != '-u' ) { // -u is the format for displaying the unit only
-			$this->m_caption .= ( ( $this->m_outformat != '-' ) && ( $this->m_outformat != '-n' ) ? smwfNumberFormat( $value ) : $value );
+			$this->m_caption .= ( ( $this->m_outformat != '-' ) && ( $this->m_outformat != '-n' ) ? NumberFormatter::getInstance()->formatNumberToLocalizedText( $value ) : $value );
 		}
 
 		if ( ( $printunit !== '' ) && ( $this->m_outformat != '-n' ) ) { // -n is the format for displaying the number only

--- a/includes/datavalues/SMW_DV_Temperature.php
+++ b/includes/datavalues/SMW_DV_Temperature.php
@@ -1,4 +1,7 @@
 <?php
+
+use SMW\NumberFormatter;
+
 /**
  * @ingroup SMWDataValues
  */
@@ -81,7 +84,7 @@ class SMWTemperatureValue extends SMWNumberValue {
 
 		$this->m_caption = '';
 		if ( $this->m_outformat != '-u' ) { // -u is the format for displaying the unit only
-			$this->m_caption .= ( ( $this->m_outformat != '-' ) && ( $this->m_outformat != '-n' ) ? smwfNumberFormat( $value ) : $value );
+			$this->m_caption .= ( ( $this->m_outformat != '-' ) && ( $this->m_outformat != '-n' ) ? NumberFormatter::getInstance()->formatNumberToLocalizedText( $value ) : $value );
 		}
 		if ( ( $printunit !== '' ) && ( $this->m_outformat != '-n' ) ) { // -n is the format for displaying the number only
 			if ( $this->m_outformat != '-u' ) {

--- a/includes/src/NumberFormatter.php
+++ b/includes/src/NumberFormatter.php
@@ -1,0 +1,193 @@
+<?php
+
+namespace SMW;
+
+/**
+ * @license GNU GPL v2+
+ * @since 2.1
+ *
+ * @author Markus Krötzsch
+ * @author mwjames
+ */
+class NumberFormatter {
+
+	/**
+	 * @var NumberFormatter
+	 */
+	private static $instance = null;
+
+	/**
+	 * @var integer
+	 */
+	private $maxNonExpNumber = null;
+
+	/**
+	 * @var string|null
+	 */
+	private	$thousandsSeparatorInContentLanguage = null;
+
+	/**
+	 * @var string|null
+	 */
+	private $decimalSeparatorInContentLanguage = null;
+
+	/**
+	 * @var string|null
+	 */
+	private $decimalSeparatorInUserLanguage = null;
+
+	/**
+	 * @since 2.1
+	 *
+	 * @param Language $contentLanguage
+	 */
+	public function __construct( $maxNonExpNumber ) {
+		$this->maxNonExpNumber = $maxNonExpNumber;
+	}
+
+	/**
+	 * @since 2.1
+	 *
+	 * @return Localizer
+	 */
+	public static function getInstance() {
+
+		if ( self::$instance === null ) {
+			self::$instance = new self( $GLOBALS['smwgMaxNonExpNumber'] );
+		}
+
+		return self::$instance;
+	}
+
+	/**
+	 * @since 2.1
+	 */
+	public static function clear() {
+		self::$instance = null;
+	}
+
+	/**
+	 * This method formats a float number value according to the given language and
+	 * precision settings, with some intelligence to produce readable output. Used
+	 * to format a number that was not hand-formatted by a user.
+	 *
+	 * @param mixed $value input number
+	 * @param integer $decplaces optional positive integer, controls how many digits after
+	 * the decimal point are shown
+	 *
+	 * @since 2.1
+	 *
+	 * @return string
+	 */
+	public function formatNumberToLocalizedText( $value, $decplaces = 3 ) {
+
+		$decseparator = $this->getDecimalSeparatorForUserLanguage();
+
+		// If number is a trillion or more, then switch to scientific
+		// notation. If number is less than 0.0000001 (i.e. twice decplaces),
+		// then switch to scientific notation. Otherwise print number
+		// using number_format. This may lead to 1.200, so then use trim to
+		// remove trailing zeroes.
+		$doScientific = false;
+
+		// @todo: Don't do all this magic for integers, since the formatting does not fit there
+		//       correctly. E.g. one would have integers formatted as 1234e6, not as 1.234e9, right?
+		// The "$value!=0" is relevant: we want to scientify numbers that are close to 0, but never 0!
+		if ( ( $decplaces > 0 ) && ( $value != 0 ) ) {
+			$absValue = abs( $value );
+			if ( $absValue >= $this->maxNonExpNumber ) {
+				$doScientific = true;
+			} elseif ( $absValue <= pow( 10, - $decplaces ) ) {
+				$doScientific = true;
+			} elseif ( $absValue < 1 ) {
+				if ( $absValue <= pow( 10, - $decplaces ) ) {
+					$doScientific = true;
+				} else {
+					// Increase decimal places for small numbers, e.g. .00123 should be 5 places.
+					for ( $i = 0.1; $absValue <= $i; $i *= 0.1 ) {
+						$decplaces++;
+					}
+				}
+			}
+		}
+
+		if ( $doScientific ) {
+			// Should we use decimal places here?
+			$value = sprintf( "%1.6e", $value );
+			// Make it more readable by removing trailing zeroes from n.n00e7.
+			$value = preg_replace( '/(\\.\\d+?)0*e/u', '${1}e', $value, 1 );
+			// NOTE: do not use the optional $count parameter with preg_replace. We need to
+			//      remain compatible with PHP 4.something.
+			if ( $decseparator !== '.' ) {
+				$value = str_replace( '.', $decseparator, $value );
+			}
+		} else {
+			// Format to some level of precision; number_format does rounding and locale formatting,
+			// x and y are used temporarily since number_format supports only single characters for either
+			$value = number_format( $value, $decplaces, 'x', 'y' );
+			$value = str_replace(
+				array( 'x', 'y' ),
+				array( $decseparator, $this->getThousandsSeparatorForContentLanguage() ),
+				$value
+			);
+
+			// Make it more readable by removing ending .000 from nnn.000
+			//    Assumes substr is faster than a regular expression replacement.
+			$end = $decseparator . str_repeat( '0', $decplaces );
+			$lenEnd = strlen( $end );
+
+			if ( substr( $value, - $lenEnd ) === $end ) {
+				$value = substr( $value, 0, - $lenEnd );
+			} else {
+				// If above replacement occurred, no need to do the next one.
+				// Make it more readable by removing trailing zeroes from nn.n00.
+				$value = preg_replace( "/(\\$decseparator\\d+?)0*$/u", '$1', $value, 1 );
+			}
+		}
+
+		return $value;
+	}
+
+	/**
+	 * @since 2.1
+	 *
+	 * @return string
+	 */
+	public function getThousandsSeparatorForContentLanguage() {
+
+		if ( $this->thousandsSeparatorInContentLanguage === null ) {
+			$this->thousandsSeparatorInContentLanguage = wfMessage( 'smw_kiloseparator' )->inContentLanguage()->text();
+		}
+
+		return $this->thousandsSeparatorInContentLanguage;
+	}
+
+	/**
+	 * @since 2.1
+	 *
+	 * @return string
+	 */
+	public function getDecimalSeparatorForContentLanguage() {
+
+		if ( $this->decimalSeparatorInContentLanguage === null ) {
+			$this->decimalSeparatorInContentLanguage = wfMessage( 'smw_decseparator' )->inContentLanguage()->text();
+		}
+
+		return $this->decimalSeparatorInContentLanguage;
+	}
+
+	/**
+	 * @since 2.1
+	 *
+	 * @return string
+	 */
+	public function getDecimalSeparatorForUserLanguage() {
+
+		if ( $this->decimalSeparatorInUserLanguage === null ) {
+			$this->decimalSeparatorInUserLanguage = wfMessage( 'smw_decseparator' )->text();
+		}
+
+		return $this->decimalSeparatorInUserLanguage;
+	}
+
+}

--- a/tests/phpunit/includes/NumberFormatterTest.php
+++ b/tests/phpunit/includes/NumberFormatterTest.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace SMW\Tests;
+
+use SMW\NumberFormatter;
+
+use Language;
+
+/**
+ * @covers \SMW\NumberFormatter
+ *
+ * @group SMW
+ * @group SMWExtension
+ *
+ * @license GNU GPL v2+
+ * @since 2.1
+ *
+ * @author mwjames
+ */
+class NumberFormatterTest extends \PHPUnit_Framework_TestCase {
+
+	public function testCanConstruct() {
+
+		$this->assertInstanceOf(
+			'\SMW\NumberFormatter',
+			new NumberFormatter( 10000 )
+		);
+
+		$this->assertInstanceOf(
+			'\SMW\NumberFormatter',
+			NumberFormatter::getInstance()
+		);
+	}
+
+	/**
+	 * @dataProvider numberProvider
+	 */
+	public function testFormatNumberToLocalizedText( $maxNonExpNumber, $number, $expected ) {
+
+		$instance = new NumberFormatter( $maxNonExpNumber );
+
+		$this->assertEquals(
+			$expected,
+			$instance->formatNumberToLocalizedText( $number )
+		);
+	}
+
+	public function numberProvider() {
+
+		$provider[] = array(
+			10000,
+			1000,
+			'1,000'
+		);
+
+		$provider[] = array(
+			10000,
+			1000.42,
+			'1,000.42'
+		);
+
+		$provider[] = array(
+			10000,
+			1000000,
+			'1.0e+6'
+		);
+
+		$provider[] = array(
+			10000000,
+			1000000,
+			'1,000,000'
+		);
+
+		return $provider;
+	}
+
+}


### PR DESCRIPTION
Move code from `smwfNumberFormat` to `NumberFormatter::formatNumberToLocalizedText`
in order to cache message text (especially costly when used on a repeated basis).

Before

```
- (0): [[Has subobject.Has temperature::100 °F]] 
- C: 0.0027824 (mean) 0.0139122 (total) 0.0050724 (sd) (sec) resultCount: 1001 columnCount: 0
- S: no serialization
- I: 0.0094004 (mean) 0.0470018 (total) 0.0022846 (sd) (sec) resultCount: 500 columnCount: 8
- S: 0.842563 (mean) 4.212815 (total) 0.0127321 (sd) (sec)
------------------------------------------------------------------------------------------
- (1): <q>[[Has page.Has number::1001]][[Has page.Has telephone number::+1-201-555-0123]]</q> OR [[Has subobject.Has temperature::100 °F]][[Category:!Lorem enim]] 
- C: 0.0414686 (mean) 0.2073429 (total) 0.0043786 (sd) (sec) resultCount: 2002 columnCount: 0
- S: no serialization
- I: 0.0486034 (mean) 0.2430172 (total) 0.0006431 (sd) (sec) resultCount: 500 columnCount: 8
- S: 0.8097425 (mean) 4.0487123 (total) 0.0485891 (sd) (sec)
```

After

```
- (0): [[Has subobject.Has temperature::100 °F]] 
- C: 0.0027912 (mean) 0.0139561 (total) 0.005127 (sd) (sec) resultCount: 1001 columnCount: 0
- S: no serialization
- I: 0.0095984 (mean) 0.047992 (total) 0.0022553 (sd) (sec) resultCount: 500 columnCount: 8
- S: 0.6628716 (mean) 3.314358 (total) 0.010816 (sd) (sec)
------------------------------------------------------------------------------------------
- (1): <q>[[Has page.Has number::1001]][[Has page.Has telephone number::+1-201-555-0123]]</q> OR [[Has subobject.Has temperature::100 °F]][[Category:!Lorem enim]] 
- C: 0.0434748 (mean) 0.2173741 (total) 0.0051097 (sd) (sec) resultCount: 2002 columnCount: 0
- S: no serialization
- I: 0.0507008 (mean) 0.253504 (total) 0.000662 (sd) (sec) resultCount: 500 columnCount: 8
- S: 0.671049 (mean) 3.3552449 (total) 0.0600068 (sd) (sec)
```
