### PR TITLE
Ignore $wgCapitalLinks setting for the property namespace

### DIFF
--- a/includes/src/DataValueFactory.php
+++ b/includes/src/DataValueFactory.php
@@ -159,7 +159,12 @@ class DataValueFactory {
 	public function newPropertyValue( $propertyName, $valueString,
 		$caption = false, DIWikiPage $contextPage = null ) {
 
-		Profiler::In( __METHOD__, true );
+		// Enforce upper case for the first character on annotations that are used
+		// within the property namespace in order to avoid confusion when
+		// $wgCapitalLinks setting is disabled
+		if ( $contextPage !== null && $contextPage->getNamespace() === SMW_NS_PROPERTY ) {
+			$propertyName = ucfirst( $propertyName );
+		}
 
 		$propertyDV = SMWPropertyValue::makeUserProperty( $propertyName );
 
@@ -194,7 +199,6 @@ class DataValueFactory {
 			);
 		}
 
-		Profiler::Out( __METHOD__, true );
 		return $dataValue;
 	}
 

--- a/tests/phpunit/Integration/MediaWiki/InTextParseParserOutputIntegrationTest.php
+++ b/tests/phpunit/Integration/MediaWiki/InTextParseParserOutputIntegrationTest.php
@@ -46,6 +46,31 @@ class InTextParseParserOutputIntegrationTest extends \PHPUnit_Framework_TestCase
 		);
 	}
 
+	/**
+	 * @dataProvider textDataProvider
+	 */
+	public function testTextParseForDisabledCapitalLinks( $parameters, $expected ) {
+
+		$wgCapitalLinks = $GLOBALS['wgCapitalLinks'];
+		$GLOBALS['wgCapitalLinks'] = false;
+
+		$instance = new ContentParser(
+			$parameters['title'],
+			ParserFactory::newFromTitle( $parameters['title'] )
+		);
+
+		$instance->parse( $parameters['text'] );
+
+		$this->assertInstanceAfterParse( $instance );
+
+		$this->assertSemanticDataAfterParse(
+			$instance,
+			$expected
+		);
+
+		$GLOBALS['wgCapitalLinks'] = $wgCapitalLinks;
+	}
+
 	protected function assertInstanceAfterParse( $instance ) {
 		$this->assertInstanceOf( 'ParserOutput', $instance->getOutput() );
 		$this->assertInternalType( 'string', $instance->getOutput()->getText() );
@@ -118,6 +143,19 @@ class InTextParseParserOutputIntegrationTest extends \PHPUnit_Framework_TestCase
 				'propertyCount'  => 3,
 				'propertyKey'    => array( '_SKEY', '_INST', 'Fuyu' ),
 				'propertyValues' => array( 'Bar', 'Foo', 'Natsu' )
+			)
+		);
+
+		// #4 SMW_NS_PROPERTY
+		$provider[] = array(
+			array(
+				'text'  => '[[has type::number]], {{#set:|has type=boolean}}, [[has Type::Page]] {{DEFAULTSORTKEY:Foo_Bar}}',
+				'title' => Title::newFromText( __METHOD__, SMW_NS_PROPERTY )
+			),
+			array(
+				'propertyCount'  => 3,
+				'propertyKey'    => array( '_SKEY', 'Has type', 'has Type' ),
+				'propertyValues' => array( 'Foo_Bar', 'Number', 'Boolean', 'Page' )
 			)
 		);
 

--- a/tests/phpunit/includes/DataValueFactoryTest.php
+++ b/tests/phpunit/includes/DataValueFactoryTest.php
@@ -207,6 +207,31 @@ class DataValueFactoryTest extends \PHPUnit_Framework_TestCase {
 	}
 
 	/**
+	 * Issue 673
+	 */
+	public function testEnforceFirstUpperCaseForDisabledCapitalLinks() {
+
+		$wgCapitalLinks = $GLOBALS['wgCapitalLinks'];
+		$GLOBALS['wgCapitalLinks'] = false;
+
+		$instance = DataValueFactory::getInstance();
+
+		$dataValue = $instance->newPropertyValue(
+			'has type',
+			'number',
+			null,
+			new DIWikiPage( 'Foo', SMW_NS_PROPERTY )
+		);
+
+		$this->assertEquals(
+			'_TYPE',
+			$dataValue->getProperty()->getKey()
+		);
+
+		$GLOBALS['wgCapitalLinks'] = $wgCapitalLinks;
+	}
+
+	/**
 	 * @dataProvider newDataItemValueDataProvider
 	 */
 	public function testNewDataItemValue( $setup ) {

--- a/tests/phpunit/includes/InTextAnnotationParserTest.php
+++ b/tests/phpunit/includes/InTextAnnotationParserTest.php
@@ -407,6 +407,23 @@ class InTextAnnotationParserTest extends \PHPUnit_Framework_TestCase {
 			)
 		);
 
+		// #7 673
+		$provider[] = array(
+			SMW_NS_PROPERTY,
+			array(
+				'smwgNamespacesWithSemanticLinks' => array( SMW_NS_PROPERTY => true ),
+				'smwgLinksInValues' => false,
+				'smwgInlineErrors'  => true,
+			),
+			'[[has type::number]], [[has Type::page]] ',
+			array(
+				'resultText'     => '[[Special:Types/Number|number]], [[:Page|page]]',
+				'propertyCount'  => 2,
+				'propertyLabels' => array( 'Has type', 'Has Type' ),
+				'propertyValues' => array( 'Number', 'Page' )
+			)
+		);
+
 		return $provider;
 	}
 


### PR DESCRIPTION
If `$wgCapitalLinks` = false [0] then annotations like `[[has type:: ... ]]` will fail because of the inactive conversion rule `has -> Has` [1].

[0] https://www.mediawiki.org/wiki/Manual:$wgCapitalLinks
[1] https://www.semantic-mediawiki.org/wiki/Thread:Help_talk:Properties_and_types/Is_any_part_of_the_data_type_declaration_case-sensitive%3F
