### PR TITLE
SPARQLStore / Support for page-type, url-type regex query search

### DIFF
--- a/includes/src/SPARQLStore/QueryEngine/CompoundConditionBuilder.php
+++ b/includes/src/SPARQLStore/QueryEngine/CompoundConditionBuilder.php
@@ -18,6 +18,7 @@ use SMWDataItem as DataItem;
 use SMWExporter as Exporter;
 use SMWTurtleSerializer as TurtleSerializer;
 use SMWExpNsResource as ExpNsResource;
+use SMWExpElement as ExpElement;
 
 use RuntimeException;
 
@@ -130,7 +131,12 @@ class CompoundConditionBuilder {
 		if ( $condition instanceof SingletonCondition ) { // prepare for ASK, maybe rather use BIND?
 
 			$matchElement = $condition->matchElement;
-			$matchElementName = TurtleSerializer::getTurtleNameForExpElement( $matchElement );
+
+			if ( $matchElement instanceof ExpElement ) {
+				$matchElementName = TurtleSerializer::getTurtleNameForExpElement( $matchElement );
+			} else {
+				$matchElementName = $matchElement;
+			}
 
 			if ( $matchElement instanceof ExpNsResource ) {
 				$condition->namespaces[$matchElement->getNamespaceId()] = $matchElement->getNamespace();

--- a/tests/phpunit/Integration/Query/PageTypeRegexQueryTest.php
+++ b/tests/phpunit/Integration/Query/PageTypeRegexQueryTest.php
@@ -71,9 +71,6 @@ class PageTypeRegexQueryTest extends MwDBaseUnitTestCase {
 	 */
 	public function testPageLikeNotLikeWildcardSearch() {
 
-		// Doesn't support this feature currently
-		$this->skipTestForStore( 'SMW\SPARQLStore\SPARQLStore' );
-
 		$property = $this->fixturesProvider->getProperty( 'title' );
 
 		$semanticData = $this->semanticDataFactory
@@ -187,6 +184,8 @@ class PageTypeRegexQueryTest extends MwDBaseUnitTestCase {
 		$query->sortkeys = array(
 			'Title' => 'desc'
 		);
+
+		$query->setUnboundLimit( 1000 );
 
 		$this->queryResultValidator->assertThatQueryResultHasSubjects(
 			$expected,

--- a/tests/phpunit/Integration/Query/UriTypeQueryTest.php
+++ b/tests/phpunit/Integration/Query/UriTypeQueryTest.php
@@ -79,9 +79,6 @@ class UriTypeQueryTest extends MwDBaseUnitTestCase {
 	 */
 	public function testQuerySearchPatternForUriType() {
 
-		// Doesn't support this feature currently
-		$this->skipTestForStore( 'SMW\SPARQLStore\SPARQLStore' );
-
 		$property = $this->fixturesProvider->getProperty( 'url' );
 
 		$semanticData = $this->semanticDataFactory

--- a/tests/phpunit/MwDBaseUnitTestCase.php
+++ b/tests/phpunit/MwDBaseUnitTestCase.php
@@ -6,6 +6,7 @@ use SMW\Tests\Utils\MwDatabaseTableBuilder;
 use SMW\StoreFactory;
 use SMW\ApplicationFactory;
 use SMW\NamespaceExaminer;
+use SMW\PropertyRegistry;
 use SMW\Settings;
 
 use SMWExporter as Exporter;
@@ -70,6 +71,7 @@ abstract class MwDBaseUnitTestCase extends \PHPUnit_Framework_TestCase {
 	protected function tearDown() {
 		ApplicationFactory::clear();
 		NamespaceExaminer::clear();
+		PropertyRegistry::clear();
 		Settings::clear();
 		Exporter::clear();
 

--- a/tests/phpunit/includes/SPARQLStore/QueryEngine/ConditionBuilder/DisjunctionConditionBuilderTest.php
+++ b/tests/phpunit/includes/SPARQLStore/QueryEngine/ConditionBuilder/DisjunctionConditionBuilderTest.php
@@ -187,7 +187,7 @@ class DisjunctionConditionBuilderTest extends \PHPUnit_Framework_TestCase {
 		);
 
 		# 4
-		$conditionType = '\SMW\SPARQLStore\QueryEngine\Condition\TrueCondition';
+		$conditionType = '\SMW\SPARQLStore\QueryEngine\Condition\SingletonCondition';
 
 		$description = new ValueDescription(
 			new DIWikiPage( 'SomePropertyPageValue', NS_MAIN ), null, SMW_CMP_LIKE
@@ -201,7 +201,8 @@ class DisjunctionConditionBuilderTest extends \PHPUnit_Framework_TestCase {
 		$sortkeys = array();
 
 		$expected = $stringBuilder
-			->addString( '?result swivt:page ?url .' )->addNewLine()
+			->addString( 'FILTER( regex( ?v1, "^SomePropertyPageValue$", "s") )' )->addNewLine()
+			->addString( '?result swivt:wikiPageSortKey ?v1 .' )->addNewLine()
 			->getString();
 
 		$provider[] = array(


### PR DESCRIPTION
`SPARQLStore` support for page-type queries like `[[Title::~Sample*]] [[Title::!~Sample tes*]]` or uri-type queries like `[[Url::~http://*query=*]] OR [[Url::~*ccc*]]`

Relates to #649
