### PR TITLE
Support subpages for SMW_NS_CONCEPT_TALK by default (previously missing)

### DIFF
--- a/includes/NamespaceManager.php
+++ b/includes/NamespaceManager.php
@@ -127,7 +127,8 @@ class NamespaceManager {
 		// Support subpages only for talk pages by default
 		$this->globalVars['wgNamespacesWithSubpages'] = $this->globalVars['wgNamespacesWithSubpages'] + array(
 			SMW_NS_PROPERTY_TALK => true,
-			SMW_NS_TYPE_TALK => true
+			SMW_NS_TYPE_TALK => true,
+			SMW_NS_CONCEPT_TALK => true,
 		);
 
 		// not modified for Semantic MediaWiki


### PR DESCRIPTION
This removes a very minor inconsistency: by default, subpage support is enabled for SMW talk namespaces, except the Concept talk namespace (probably forgotten).
