### PR TITLE
Better approach to match `=` in query condition

### DIFF
--- a/includes/query/SMW_QueryProcessor.php
+++ b/includes/query/SMW_QueryProcessor.php
@@ -284,11 +284,15 @@ class SMWQueryProcessor {
 				$rawParam = implode( ',', array_keys( $rawParam ) );
 			}
 
-			// Bug 32955
-			// Only modify the condition string which is assumed to be enclosed by [[ ... ]]
-			if ( strpos( $rawParam, '[[') !== false && strpos( $rawParam, ']]' ) !== false ) {
-				$rawParam = str_replace( array( '=' ), array( '-3D' ), $rawParam );
-			}
+			// Bug 32955 / #640
+			// Modify (e.g. replace `=`) a condition string only if enclosed by [[ ... ]]
+			$rawParam = preg_replace_callback(
+				'/\[\[(?:([^:][^]]*):[=:])+([^\[\]]*)\]\]/xu',
+				function( array $matches ) {
+					return str_replace( array( '=' ), array( '-3D' ), $matches[0] );
+				},
+				$rawParam
+			);
 
 			// accept 'name' => 'value' just as '' => 'name=value':
 			if ( is_string( $name ) && ( $name !== '' ) ) {

--- a/tests/phpunit/Integration/Query/CustomUnitDataTypeQueryDBIntegrationTest.php
+++ b/tests/phpunit/Integration/Query/CustomUnitDataTypeQueryDBIntegrationTest.php
@@ -39,6 +39,8 @@ class CustomUnitDataTypeQueryDBIntegrationTest extends MwDBaseUnitTestCase {
 	private $dataValueFactory;
 	private $printRequestFactory;
 
+	private $subjects = array();
+
 	protected function setUp() {
 		parent::setUp();
 
@@ -55,7 +57,9 @@ class CustomUnitDataTypeQueryDBIntegrationTest extends MwDBaseUnitTestCase {
 	protected function tearDown() {
 
 		$fixturesCleaner = UtilityFactory::getInstance()->newFixturesFactory()->newFixturesCleaner();
-		$fixturesCleaner->purgeAllKnownFacts();
+		$fixturesCleaner
+			->purgeSubjects( $this->subjects )
+			->purgeAllKnownFacts();
 
 		parent::tearDown();
 	}
@@ -63,6 +67,7 @@ class CustomUnitDataTypeQueryDBIntegrationTest extends MwDBaseUnitTestCase {
 	public function testUserDefinedQuantityProperty() {
 
 		$semanticData = $this->semanticDataFactory->newEmptySemanticData( __METHOD__ );
+		$this->subjects[] = $semanticData->getSubject();
 
 		$factsheet = $this->fixturesProvider->getFactsheet( 'Berlin' );
 		$factsheet->setTargetSubject( $semanticData->getSubject() );
@@ -109,6 +114,7 @@ class CustomUnitDataTypeQueryDBIntegrationTest extends MwDBaseUnitTestCase {
 	public function testUserDefinedTemperatureProperty() {
 
 		$semanticData = $this->semanticDataFactory->newEmptySemanticData( __METHOD__ );
+		$this->subjects[] = $semanticData->getSubject();
 
 		$factsheet = $this->fixturesProvider->getFactsheet( 'Berlin' );
 		$factsheet->setTargetSubject( $semanticData->getSubject() );

--- a/tests/phpunit/includes/Query/QueryProcessorTest.php
+++ b/tests/phpunit/includes/Query/QueryProcessorTest.php
@@ -106,6 +106,17 @@ class SMWQueryProcessorTest extends MwDBaseUnitTestCase {
 			'[[Has url::http://example.org/api.php?action=Foo]]'
 		);
 
+		// Produced by smw.org, Template:Invert-property
+		$provider[] = array(
+			array( '[[Located in::Foo]]', 'link=none', 'sep=| ]][[Location of::' ),
+			'[[Located in::Foo]]'
+		);
+
+		$provider[] = array(
+			array( '[[Located in::Foo]]', 'link=none', 'sep=| ]][[Location of::', '[[Has url::http://example.org/api.php?action=Foo]]' ),
+			'[[Located in::Foo]][[Has url::http://example.org/api.php?action=Foo]]'
+		);
+
 		return $provider;
 	}
 


### PR DESCRIPTION
The #640 apporach was too simplistic, it broke the smw.org@`Template:Invert-property` which produces strings like `sep=| ]][[Location of::` as part of the template transclustion during the `#ask` execution.