### PR TITLE
Recognize annotations made by an #ask transcluded template

### DIFF
--- a/includes/parserhooks/AskParserFunction.php
+++ b/includes/parserhooks/AskParserFunction.php
@@ -132,6 +132,12 @@ class AskParserFunction {
 			SMWQueryProcessor::INLINE_QUERY
 		);
 
+		// FIXME Should be injected
+		// A printer run its own isolated wgParser process therefore if the printer
+		// or a template inclusion is used by a printer, possible extra annotations
+		// need to be imported for further usage
+		$this->parserData->importFromParserOutput( $GLOBALS['wgParser']->getOutput() );
+
 		if ( $this->applicationFactory->getSettings()->get( 'smwgQueryDurationEnabled' ) ) {
 			$queryDuration = microtime( true ) - $start;
 		}

--- a/tests/phpunit/Integration/MediaWiki/AskParserFunctionDBIntegrationTest.php
+++ b/tests/phpunit/Integration/MediaWiki/AskParserFunctionDBIntegrationTest.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace SMW\Tests\Integration\MediaWiki;
+
+use SMW\Tests\MwDBaseUnitTestCase;
+use SMW\Tests\Utils\UtilityFactory;
+
+use SMW\DIWikiPage;
+use SMW\DIProperty;
+
+use Title;
+
+/**
+ * @group SMW
+ * @group SMWExtension
+ *
+ * @group semantic-mediawiki-integration
+ * @group mediawiki-databas
+ *
+ * @group medium
+ *
+ * @license GNU GPL v2+
+ * @since   2.1
+ *
+ * @author mwjames
+ */
+class AskParserFunctionDBIntegrationTest extends MwDBaseUnitTestCase {
+
+	private $pageCreator;
+	private $semanticDataValidator;
+
+	protected function setUp() {
+		parent::setUp();
+
+		$this->pageCreator = UtilityFactory::getInstance()->newPageCreator();
+		$this->semanticDataValidator = UtilityFactory::getInstance()->newValidatorFactory()->newSemanticDataValidator();
+	}
+
+	public function testAskToCreatePropertyAnnotationFromTranscludedTemplate() {
+
+		$subject = DIWikiPage::newFromTitle( Title::newFromText( __METHOD__ ) );
+
+		$this->pageCreator
+			->createPage( Title::newFromText( 'AskTemplateToAddPropertyAnnotation', NS_TEMPLATE ) )
+			->doEdit( '<includeonly>{{#set:|SetPropertyByAskTemplate=1234}}</includeonly>' );
+
+		$this->pageCreator
+			->createPage( Title::newFromText( __METHOD__ . '00' ) )
+			->doEdit( '{{#set:|TestPropertyByAskTemplate=TestValueByAskTemplate}}' );
+
+		$this->pageCreator
+			->createPage( $subject->getTitle() )
+			->doEdit(
+				'{{#ask:[[TestPropertyByAskTemplate::TestValueByAskTemplate]]|link=none|sep=|template=AskTemplateToAddPropertyAnnotation}}' );
+
+		$expected = array(
+			'propertyCount' => 4,
+			'propertyKeys'  => array( '_ASK', '_MDAT', '_SKEY', 'SetPropertyByAskTemplate' )
+		);
+
+		$this->semanticDataValidator->assertThatPropertiesAreSet(
+			$expected,
+			$this->getStore()->getSemanticData( $subject )
+		);
+	}
+
+}

--- a/tests/phpunit/includes/ParserDataTest.php
+++ b/tests/phpunit/includes/ParserDataTest.php
@@ -298,4 +298,40 @@ class ParserDataTest extends \PHPUnit_Framework_TestCase {
 		);
 	}
 
+	public function testImportFromParserOutput() {
+
+		$import = new ParserData(
+			Title::newFromText( __METHOD__ ),
+			new ParserOutput()
+		);
+
+		$import->addDataValue(
+			$this->dataValueFactory->newPropertyValue(
+				'Foo',
+				'Bar'
+			)
+		);
+
+		$import->pushSemanticDataToParserOutput();
+
+		$instance = new ParserData(
+			Title::newFromText( __METHOD__ ),
+			new ParserOutput()
+		);
+
+		$instance->importFromParserOutput( null );
+
+		$this->assertNotEquals(
+			$import->getSemanticData()->getHash(),
+			$instance->getSemanticData()->getHash()
+		);
+
+		$instance->importFromParserOutput( $import->getOutput() );
+
+		$this->assertEquals(
+			$import->getSemanticData()->getHash(),
+			$instance->getSemanticData()->getHash()
+		);
+	}
+
 }


### PR DESCRIPTION
refs #710, After looking at  smw.org@`Template:Invert-property` on how #ask is used in connection with templates to generate/annotate invert property annotations, this PR will allow to use a more simplified approach.

Use `{{InvertPropertyFinder|Located in|Location of}}` 

`InvertPropertyFinder`
```
<includeonly>{{#ask:[[{{{1}}}::{{PAGENAME}}]]|link=none|sep=|template=InvertPropertySetter|userparam={{{2}}} }}</includeonly>
```
`InvertPropertySetter`
```
<includeonly>{{#set:|{{{userparam}}}={{{1}}} }}</includeonly>
```