### PR TITLE
Update TravisCI build config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ matrix:
     - env: THENEEDFORTHIS=FAIL
   allow_failures:
     - env: DB=mysql; MW=1.19.20; TYPE=relbuild
-    - env: DB=postgres; MW=1.19.20;
+    - env: DB=sqlite; MW=master@5cc1f1d; TYPE=composer
     - php: hhvm-nightly
 
 install:


### PR DESCRIPTION
The "composer" type build can encounter false failures when certain types
of changes are made, due to the nature of this build, and not a defect
in those changes. Hence it should be optional (as it originally was).