### PR TITLE
Support wgCategoryCollation in CategoryResultPrinter, refs #699

### DIFF
--- a/includes/queryprinters/CategoryResultPrinter.php
+++ b/includes/queryprinters/CategoryResultPrinter.php
@@ -74,11 +74,7 @@ class CategoryResultPrinter extends ResultPrinter {
 				continue;
 			}
 
-			$cur_first_char = $wgContLang->firstChar(
-				$content[0]->getDIType() == SMWDataItem::TYPE_WIKIPAGE ?
-					$res->getStore()->getWikiPageSortKey( $content[0] )
-					: $content[0]->getSortKey()
-			);
+			$cur_first_char = $this->getFirstLetterForCategory( $res, $content );
 
 			if ( $rowindex % $rows_per_column == 0 ) {
 				$result .= "\n			<div style=\"float: left; width: $column_width%;\">\n";
@@ -212,6 +208,17 @@ class CategoryResultPrinter extends ResultPrinter {
 				'default' => '',
 			),
 		) );
+	}
+
+	private function getFirstLetterForCategory( SMWQueryResult $res, $content ) {
+
+		$sortKey = $content[0]->getSortKey();
+
+		if ( $content[0]->getDIType() == SMWDataItem::TYPE_WIKIPAGE ) {
+			$sortKey = $res->getStore()->getWikiPageSortKey( $content[0] );
+		}
+
+		return ByLanguageCollationMapper::getInstance()->findFirstLetterForCategory( $sortKey );
 	}
 
 }

--- a/src/ByLanguageCollationMapper.php
+++ b/src/ByLanguageCollationMapper.php
@@ -1,0 +1,108 @@
+<?php
+
+namespace SMW;
+
+use Language;
+
+/**
+ * @license GNU GPL v2+
+ * @since 2.2
+ *
+ * @author mwjames
+ */
+class ByLanguageCollationMapper {
+
+	/**
+	 * @var ByLanguageCollationMapper
+	 */
+	private static $instance = null;
+
+	/**
+	 * @var string
+	 */
+	private $categoryCollation = null;
+
+	/**
+	 * @var Language
+	 */
+	private $language = null;
+
+	/**
+	 * @since 2.2
+	 *
+	 * @param string $categoryCollation
+	 */
+	public function __construct( $categoryCollation ) {
+		$this->categoryCollation = $categoryCollation;
+	}
+
+	/**
+	 * @since 2.2
+	 *
+	 * @return CollationFormatter
+	 */
+	public static function getInstance() {
+
+		if ( self::$instance === null ) {
+			self::$instance = new self( $GLOBALS['wgCategoryCollation'] );
+		}
+
+		return self::$instance;
+	}
+
+	/**
+	 * @since 2.2
+	 */
+	public static function clear() {
+		self::$instance = null;
+	}
+
+	/**
+	 * @since 2.2
+	 *
+	 * @return string
+	 */
+	public function findFirstLetterForCategory( $string ) {
+
+		// Currently MW's `uca-default`, `xx-uca-ckb`, `xx-uca-et` are
+		// not supported
+
+		switch ( $this->categoryCollation ) {
+			case 'uppercase':
+				return $this->formatByUppercaseCollation( $string );
+			case 'identity':
+			default:
+				return $this->formatByIdentityCollation( $string );
+		}
+	}
+
+	private function formatByUppercaseCollation( $string ) {
+
+		// Use the generic UTF-8 uppercase function
+		if ( $this->language === null ) {
+			$this->language = Language::factory( 'en' );
+		}
+
+		// Note sure what this is for, for details see Collation.php
+		if ( $string[0] == "\0" ) {
+			$string = mb_substr( $string, 0, 1, 'UTF-8' );
+		}
+
+		return $this->language->ucfirst( $this->language->firstChar( $string ) );
+	}
+
+	private function formatByIdentityCollation( $string ) {
+
+		if ( $this->language === null ) {
+			$this->language = $GLOBALS['wgContLang'];
+		}
+
+		// Note sure what this is for, for details see Collation.php
+		if ( $string[0] == "\0" ) {
+			$string =  mb_substr( $string, 0, 1, 'UTF-8' );
+		}
+
+		return $this->language->firstChar( $string );
+	}
+
+}

--- a/tests/phpunit/Integration/MediaWiki/RedirectTargetFinderIntegrationTest.php
+++ b/tests/phpunit/Integration/MediaWiki/RedirectTargetFinderIntegrationTest.php
@@ -20,7 +20,7 @@ use Title;
  *
  * @author mwjames
  */
-class RedirectParseDBIntegrationTest extends MwDBaseUnitTestCase {
+class RedirectTargetFinderIntegrationTest extends MwDBaseUnitTestCase {
 
 	private $deletePoolOfPages = array();
 

--- a/tests/phpunit/Integration/Query/ResultPrinter/CategoryQueryResultPrinterIntegrationTest.php
+++ b/tests/phpunit/Integration/Query/ResultPrinter/CategoryQueryResultPrinterIntegrationTest.php
@@ -1,0 +1,98 @@
+<?php
+
+namespace SMW\Tests\Integration\Query\ResultPrinter;
+
+use SMW\Tests\MwDBaseUnitTestCase;
+use SMW\Tests\Utils\UtilityFactory;
+
+use Title;
+
+/**
+ * @group semantic-mediawiki-integration
+ * @group medium
+ *
+ * @license GNU GPL v2+
+ * @since 2.2
+ *
+ * @author mwjames
+ */
+class CategoryQueryResultPrinterIntegrationTest extends MwDBaseUnitTestCase {
+
+	private $subjects = array();
+	private $pageCreator;
+
+	private $stringBuilder;
+	private $stringValidator;
+
+	protected function setUp() {
+		parent::setUp();
+
+		$utilityFactory = UtilityFactory::getInstance();
+
+		$this->pageCreator = $utilityFactory->newPageCreator();
+		$this->stringBuilder = $utilityFactory->newStringBuilder();
+		$this->stringValidator = $utilityFactory->newValidatorFactory()->newStringValidator();
+	}
+
+	protected function tearDown() {
+
+		$pageDeleter = UtilityFactory::getInstance()->newPageDeleter();
+
+		$pageDeleter
+			->doDeletePoolOfPages( $this->subjects );
+
+		parent::tearDown();
+	}
+
+	/**
+	 * @query {{#ask: [[Modification date::+]] [[Category:...]] |format=category }}
+	 */
+	public function testLimitedSortedCategoryFormatForFilteredValue() {
+
+		foreach ( array( 'Foo', 'Bar', 'テスト' ) as $title ) {
+
+			$this->pageCreator
+				->createPage( Title::newFromText( $title ) )
+				->doEdit( '[[Category:LimitedSortedFormatCategoryForFilteredValue]]');
+
+			$this->subjects[] = $this->pageCreator->getPage();
+		}
+
+		$this->stringBuilder
+			->addString( '{{#ask:' )
+			->addString( '[[Modification date::+]][[Category:LimitedSortedFormatCategoryForFilteredValue]]' )
+			->addString( '|?Modification date' )
+			->addString( '|format=category' )
+			->addString( '|limit=10' )
+			->addString( '|sort=Modification date' )
+			->addString( '|order=desc' )
+			->addString( '}}' );
+
+		$this->pageCreator
+			->createPage( Title::newFromText( __METHOD__ ) )
+			->doEdit( $this->stringBuilder->getString() );
+
+		$this->subjects[] = $this->pageCreator->getPage();
+
+		$parserOutput = $this->pageCreator->getEditInfo()->output;
+
+		$expected = array(
+			'<div style="float: left; width: 33%;">',
+			'id=".E3.83.86">テ</span>',
+			'title="テスト">テスト</a>',
+			'<div style="float: left; width: 33%;">',
+			'id="B">B</span>',
+			'title="Bar">Bar</a>',
+			'<div style="float: left; width: 33%;">',
+			'id="F">F</span>',
+			'title="Foo">Foo</a>',
+			'<br style="clear: both;" />'
+		);
+
+		$this->stringValidator->assertThatStringContains(
+			$expected,
+			$parserOutput->getText()
+		);
+	}
+
+}

--- a/tests/phpunit/Utils/PageDeleter.php
+++ b/tests/phpunit/Utils/PageDeleter.php
@@ -50,6 +50,3 @@ class PageDeleter {
 	}
 
 }
-
-// FIXME SemanticGlossary usage
-class_alias( 'SMW\Tests\Utils\PageDeleter', 'SMW\Tests\Util\PageDeleter' );

--- a/tests/phpunit/includes/ByLanguageCollationMapperTest.php
+++ b/tests/phpunit/includes/ByLanguageCollationMapperTest.php
@@ -1,0 +1,123 @@
+<?php
+
+namespace SMW\Tests;
+
+use SMW\ByLanguageCollationMapper;
+
+/**
+ * @covers \SMW\ByLanguageCollationMapper
+ *
+ * @group semantic-mediawiki
+ *
+ * @license GNU GPL v2+
+ * @since 2.2
+ *
+ * @author mwjames
+ */
+class ByLanguageCollationMapperTest extends \PHPUnit_Framework_TestCase {
+
+	public function testCanConstruct() {
+
+		$this->assertInstanceOf(
+			'\SMW\ByLanguageCollationMapper',
+			new ByLanguageCollationMapper( 'Foo' )
+		);
+
+		$this->assertInstanceOf(
+			'\SMW\ByLanguageCollationMapper',
+			ByLanguageCollationMapper::getInstance()
+		);
+
+		ByLanguageCollationMapper::clear();
+	}
+
+	/**
+	 * @dataProvider letterForUppercaseProvider
+	 */
+	public function testfindFirstLetterForCategoryByUppercaseCollation( $category, $expected ) {
+
+		$instance = new ByLanguageCollationMapper( 'uppercase' );
+
+		$this->assertSame(
+			$expected,
+			$instance->findFirstLetterForCategory( $category )
+		);
+	}
+
+	/**
+	 * @dataProvider letterForIdentityProvider
+	 */
+	public function testfindFirstLetterForCategoryByIdentityCollation( $category, $expected ) {
+
+		$instance = new ByLanguageCollationMapper( 'identity' );
+
+		$this->assertSame(
+			$expected,
+			$instance->findFirstLetterForCategory( $category )
+		);
+	}
+
+	/**
+	 * @dataProvider letterForIdentityProvider
+	 */
+	public function testfindFirstLetterForCategoryByUnknownCollation( $category, $expected ) {
+
+		$instance = new ByLanguageCollationMapper( 'foo' );
+
+		$this->assertSame(
+			$expected,
+			$instance->findFirstLetterForCategory( $category )
+		);
+	}
+
+	public function letterForUppercaseProvider() {
+
+		$provider[] = array(
+			'Foo',
+			'F'
+		);
+
+		$provider[] = array(
+			'foo',
+			'F'
+		);
+
+		$provider[] = array(
+			'テスト',
+			'テ'
+		);
+
+		$provider[] = array(
+			'\0テスト',
+			'\\'
+		);
+
+		return $provider;
+	}
+
+	public function letterForIdentityProvider() {
+
+		$provider[] = array(
+			'Foo',
+			'F'
+		);
+
+		$provider[] = array(
+			'foo',
+			'f'
+		);
+
+		$provider[] = array(
+			'テスト',
+			'テ'
+		);
+
+		$provider[] = array(
+			'\0テスト',
+			'\\'
+		);
+
+		return $provider;
+	}
+
+}


### PR DESCRIPTION
Add `ByLanguageCollationMapper` to map settings from `$GLOBALS['wgCategoryCollation']` which
if `uppercase` is maintained will sort `c` and `C` as `C`

Fixes #699, and https://phabricator.wikimedia.org/T40853