### PR TITLE
Use WikitextTemplateRenderer in ListResultPrinter

### DIFF
--- a/src/MediaWiki/MwCollaboratorFactory.php
+++ b/src/MediaWiki/MwCollaboratorFactory.php
@@ -161,13 +161,22 @@ class MwCollaboratorFactory {
 	/**
 	 * @since 2.2
 	 *
+	 * @return WikitextTemplateRenderer
+	 */
+	public function newWikitextTemplateRenderer() {
+		return new WikitextTemplateRenderer();
+	}
+
+	/**
+	 * @since 2.2
+	 *
 	 * @param Parser $parser
 	 *
 	 * @return HtmlTemplateRenderer
 	 */
 	public function newHtmlTemplateRenderer( Parser $parser ) {
 		return new HtmlTemplateRenderer(
-			new WikitextTemplateRenderer(),
+			$this->newWikitextTemplateRenderer(),
 			$parser
 		);
 	}

--- a/tests/phpunit/Integration/Query/ResultPrinter/TemplateQueryResultPrinterIntegrationTest.php
+++ b/tests/phpunit/Integration/Query/ResultPrinter/TemplateQueryResultPrinterIntegrationTest.php
@@ -72,10 +72,10 @@ class TemplateQueryResultPrinterIntegrationTest extends MwDBaseUnitTestCase {
 
 		foreach ( array( 'Foo', 'Bar', '123' ) as $title ) {
 
-		$this->stringBuilder
-			->addString( '[[Category:TemplateOutputUsingUnnamedArgumentsForNonUnicode]]' )
-			->addString( '[[Has page value::ABC]]' )
-			->addString( '[[Has page value::DEF]]' );
+			$this->stringBuilder
+				->addString( '[[Category:TemplateOutputUsingUnnamedArgumentsForNonUnicode]]' )
+				->addString( '[[Has page value::ABC]]' )
+				->addString( '[[Has page value::DEF]]' );
 
 			$this->pageCreator
 				->createPage( Title::newFromText( $title ) )
@@ -131,7 +131,7 @@ class TemplateQueryResultPrinterIntegrationTest extends MwDBaseUnitTestCase {
 		$this->stringBuilder
 			->addString( '<includeonly>' )
 			->addString( '[{{{#}}}]:' )
-		//	->addString( '{{{1}}}:' )
+			->addString( '{{{1}}}:' )
 			->addString( '{{{?Has page value}}}:' )
 			->addString( '{{{userparam}}}:' )
 			->addString( '</includeonly>' );
@@ -142,10 +142,10 @@ class TemplateQueryResultPrinterIntegrationTest extends MwDBaseUnitTestCase {
 
 		foreach ( array( 'Foo', 'Bar', 'テスト', '123' ) as $title ) {
 
-		$this->stringBuilder
-			->addString( '[[Category:TemplateOutputUsingNamedArgumentsForUnicodeIncludedSubject]]' )
-			->addString( '[[Has page value::123]]' )
-			->addString( '[[Has page value::456]]' );
+			$this->stringBuilder
+				->addString( '[[Category:TemplateOutputUsingNamedArgumentsForUnicodeIncludedSubject]]' )
+				->addString( '[[Has page value::123]]' )
+				->addString( '[[Has page value::456]]' );
 
 			$this->pageCreator
 				->createPage( Title::newFromText( $title ) )
@@ -176,10 +176,10 @@ class TemplateQueryResultPrinterIntegrationTest extends MwDBaseUnitTestCase {
 		$parserOutput = $this->pageCreator->getEditInfo()->output;
 
 		$this->stringBuilder
-			->addString( '[0]:123, 456:[$%&amp;*==42]:' )
-			->addString( '[1]:123, 456:[$%&amp;*==42]:' )
-			->addString( '[2]:123, 456:[$%&amp;*==42]:' )
-			->addString( '[3]:123, 456:[$%&amp;*==42]:' );
+			->addString( '[0]:123:123; 456:[$%&amp;*==42]:' )
+			->addString( '[1]:Bar:123; 456:[$%&amp;*==42]:' )
+			->addString( '[2]:Foo:123; 456:[$%&amp;*==42]:' )
+			->addString( '[3]:テスト:123; 456:[$%&amp;*==42]:' );
 
 		$this->stringValidator->assertThatStringContains(
 			$this->stringBuilder->getString(),

--- a/tests/phpunit/includes/MediaWiki/MwCollaboratorFactoryTest.php
+++ b/tests/phpunit/includes/MediaWiki/MwCollaboratorFactoryTest.php
@@ -8,8 +8,7 @@ use SMW\ApplicationFactory;
 /**
  * @covers \SMW\MediaWiki\MwCollaboratorFactory
  *
- * @group SMW
- * @group SMWExtension
+ * @group semantic-mediawiki
  *
  * @license GNU GPL v2+
  * @since 2.1
@@ -209,6 +208,20 @@ class MwCollaboratorFactoryTest extends \PHPUnit_Framework_TestCase {
 		$this->assertInstanceOf(
 			'\SMW\MediaWiki\PageUpdater',
 			$instance->newPageUpdater()
+		);
+	}
+
+	public function testCanConstructWikitextTemplateRenderer() {
+
+		$applicationFactory = $this->getMockBuilder( '\SMW\ApplicationFactory' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$instance = new MwCollaboratorFactory( $applicationFactory );
+
+		$this->assertInstanceOf(
+			'\SMW\MediaWiki\WikitextTemplateRenderer',
+			$instance->newWikitextTemplateRenderer()
 		);
 	}
 


### PR DESCRIPTION
- If `named args=yes` and the subject does not have a named parameter it can now be accessed through something like `{{{1}}}`; all parameters that have not a name will get a continued number and handled if it was `named args=no`
- `sep=;` can now be used (or any another separator) to divide multiple values of a property