### PR TITLE
Assert that Title::moveTo() returned true

### DIFF
--- a/tests/phpunit/Integration/MediaWiki/Hooks/TitleMoveCompleteIntegrationTest.php
+++ b/tests/phpunit/Integration/MediaWiki/Hooks/TitleMoveCompleteIntegrationTest.php
@@ -79,10 +79,11 @@ class TitleMoveCompleteIntegrationTest extends MwDBaseUnitTestCase {
 		$this->pageCreator
 			->createPage( $oldTitle );
 
-		$this->pageCreator
+		$result = $this->pageCreator
 			->getPage()
 			->getTitle()
 			->moveTo( $expectedNewTitle, false, 'test', true );
+		$this->assertTrue( $result );
 
 		$this->assertNotNull(
 			WikiPage::factory( $oldTitle )->getRevision()


### PR DESCRIPTION
If the move fails, it will return an array of errors, which will be useful in debugging.