### PR TITLE
Add TextStripMarkerDecoder to support <nowiki></nowiki>, refs #232

### DIFF
--- a/DefaultSettings.php
+++ b/DefaultSettings.php
@@ -1239,6 +1239,20 @@ return array(
 	'smwgEnabledInTextAnnotationParserStrictMode' => true,
 	##
 
+	###
+	# InText unstrip support
+	#
+	# Support decoding (unstripping) of hidden text elements (e.g. `<nowiki>` as in
+	# `[[Has description::<nowiki>{{#ask: HasStripMarkers }}</nowiki>]]` etc.)
+	# within an annotation value (can only be stored together with a `_txt` type
+	# property).
+	#
+	# @since 3.0
+	# @default false
+	##
+	'smwgDecodeTextAnnotationWithStripMarker' => false,
+	##
+
 	##
 	# Features or restrictions for specific DataValue types
 	#

--- a/includes/Settings.php
+++ b/includes/Settings.php
@@ -160,6 +160,7 @@ class Settings extends Options {
 			'smwgQueryDependencyPropertyExemptionList' => $GLOBALS['smwgQueryDependencyPropertyExemptionList'],
 			'smwgQueryDependencyAffiliatePropertyDetectionList' => $GLOBALS['smwgQueryDependencyAffiliatePropertyDetectionList'],
 			'smwgEnabledInTextAnnotationParserStrictMode' => $GLOBALS['smwgEnabledInTextAnnotationParserStrictMode'],
+			'smwgDecodeTextAnnotationWithStripMarker' => $GLOBALS['smwgDecodeTextAnnotationWithStripMarker'],
 			'smwgDVFeatures' => $GLOBALS['smwgDVFeatures'],
 			'smwgEnabledFulltextSearch' => $GLOBALS['smwgEnabledFulltextSearch'],
 			'smwgFulltextDeferredUpdate' => $GLOBALS['smwgFulltextDeferredUpdate'],

--- a/src/MediaWiki/Hooks/HookRegistry.php
+++ b/src/MediaWiki/Hooks/HookRegistry.php
@@ -228,10 +228,11 @@ class HookRegistry {
 		 *
 		 * @see https://www.mediawiki.org/wiki/Manual:Hooks/InternalParseBeforeLinks
 		 */
-		$this->handlers['InternalParseBeforeLinks'] = function ( &$parser, &$text ) use ( $applicationFactory ) {
+		$this->handlers['InternalParseBeforeLinks'] = function ( &$parser, &$text, &$stripState ) use ( $applicationFactory ) {
 
 			$internalParseBeforeLinks = new InternalParseBeforeLinks(
-				$parser
+				$parser,
+				$stripState
 			);
 
 			$internalParseBeforeLinks->setEnabledSpecialPage(

--- a/src/MediaWiki/Hooks/InternalParseBeforeLinks.php
+++ b/src/MediaWiki/Hooks/InternalParseBeforeLinks.php
@@ -5,6 +5,8 @@ namespace SMW\MediaWiki\Hooks;
 use Parser;
 use SMW\ApplicationFactory;
 use SMW\Parser\InTextAnnotationParser;
+use SMW\MediaWiki\StripMarkerDecoder;
+use StripState;
 
 /**
  * Hook: InternalParseBeforeLinks is used to process the expanded wiki
@@ -33,6 +35,11 @@ class InternalParseBeforeLinks {
 	private $parser;
 
 	/**
+	 * @var StripState
+	 */
+	private $stripState;
+
+	/**
 	 * @var array
 	 */
 	private $enabledSpecialPage = array();
@@ -41,9 +48,11 @@ class InternalParseBeforeLinks {
 	 * @since 1.9
 	 *
 	 * @param Parser $parser
+	 * @param StripState $stripState
 	 */
-	public function __construct( Parser &$parser ) {
+	public function __construct( Parser &$parser, $stripState ) {
 		$this->parser = $parser;
+		$this->stripState = $stripState;
 	}
 
 	/**
@@ -125,7 +134,18 @@ class InternalParseBeforeLinks {
 			$parserData
 		);
 
-		$inTextAnnotationParser->setRedirectTarget( $this->getRedirectTarget() );
+		$stripMarkerDecoder = $applicationFactory->newMwCollaboratorFactory()->newStripMarkerDecoder(
+			$this->stripState
+		);
+
+		$inTextAnnotationParser->setStripMarkerDecoder(
+			$stripMarkerDecoder
+		);
+
+		$inTextAnnotationParser->setRedirectTarget(
+			$this->getRedirectTarget()
+		);
+
 		$inTextAnnotationParser->parse( $text );
 
 		$parserData->setSemanticDataStateToParserOutputProperty();

--- a/src/MediaWiki/MwCollaboratorFactory.php
+++ b/src/MediaWiki/MwCollaboratorFactory.php
@@ -14,6 +14,7 @@ use SMW\MediaWiki\Renderer\WikitextTemplateRenderer;
 use Title;
 use User;
 use WikiPage;
+use StripState;
 
 /**
  * @license GNU GPL v2+
@@ -201,6 +202,26 @@ class MwCollaboratorFactory {
 	 */
 	public function newMediaWikiNsContentReader() {
 		return new MediaWikiNsContentReader();
+	}
+
+	/**
+	 * @since 3.0
+	 *
+	 * @param StripState $stripState
+	 *
+	 * @return StripMarkerDecoder
+	 */
+	public function newStripMarkerDecoder( StripState $stripState ) {
+
+		$stripMarkerDecoder = new StripMarkerDecoder(
+			$stripState
+		);
+
+		$stripMarkerDecoder->isSupported(
+			$this->applicationFactory->getSettings()->get( 'smwgDecodeTextAnnotationWithStripMarker' )
+		);
+
+		return $stripMarkerDecoder;
 	}
 
 }

--- a/src/MediaWiki/StripMarkerDecoder.php
+++ b/src/MediaWiki/StripMarkerDecoder.php
@@ -1,0 +1,119 @@
+<?php
+
+namespace SMW\MediaWiki;
+
+use StripState;
+use Parser;
+
+/**
+ * @license GNU GPL v2+
+ * @since 3.0
+ *
+ * @author mwjames
+ */
+class StripMarkerDecoder {
+
+	/**
+	 * @var StripState
+	 */
+	private $stripState;
+
+	/**
+	 * @var boolean
+	 */
+	private $isSupported = false;
+
+	/**
+	 * @since 3.0
+	 *
+	 * @param StripState $stripState
+	 */
+	public function __construct( StripState $stripState ) {
+		$this->stripState = $stripState;
+	}
+
+	/**
+	 * @since 3.0
+	 *
+	 * @param boolean $decoderState
+	 */
+	public function isSupported( $isSupported ) {
+		$this->isSupported = $isSupported;
+	}
+
+	/**
+	 * @since 3.0
+	 *
+	 * @return boolean
+	 */
+	public function canUse() {
+		return $this->isSupported;
+	}
+
+	/**
+	 * @since 3.0
+	 *
+	 * @param string $text
+	 *
+	 * @return boolean
+	 */
+	public function hasStripMarker( $text ) {
+		return strpos( $text, Parser::MARKER_SUFFIX );
+	}
+
+	/**
+	 * @since 3.0
+	 *
+	 * @param string $value
+	 *
+	 * @return boolean
+	 */
+	public function decode( $value ) {
+
+		$hasStripMarker = false;
+
+		if ( $this->canUse() ) {
+			$hasStripMarker = $this->hasStripMarker( $value );
+		}
+
+		if ( $hasStripMarker ) {
+			$value = $this->unstrip( $value );
+		}
+
+		return $value;
+	}
+
+	/**
+	 * @since 3.0
+	 *
+	 * @return text
+	 */
+	public function unstrip( $text ) {
+
+		// Escape the text case to avoid any HTML elements
+		// cause an issue during parsing
+		return str_replace(
+			array( '<', '>', ' ', '[', '{', '=', "'", ':', "\n" ),
+			array( '&lt;', '&gt;', ' ', '&#x005B;', '&#x007B;', '&#x003D;', '&#x0027;', '&#58;', "<br />" ),
+			$this->doUnstrip( $text )
+		);
+	}
+
+	public function doUnstrip( $text ) {
+
+		if ( ( $value = $this->stripState->unstripNoWiki( $text ) ) !== '' && !$this->hasStripMarker( $value ) ) {
+			return $this->addNoWikiToUnstripValue( $value );
+		}
+
+		if ( ( $value = $this->stripState->unstripGeneral( $text ) ) !== '' && !$this->hasStripMarker( $value ) ) {
+			return $value;
+		}
+
+	    return $this->doUnstrip( $value );
+	}
+
+	private function addNoWikiToUnstripValue( $text ) {
+		return '<nowiki>' . $text . '</nowiki>';
+	}
+
+}

--- a/src/ParserFunctionFactory.php
+++ b/src/ParserFunctionFactory.php
@@ -161,12 +161,20 @@ class ParserFunctionFactory {
 			$parser->getTargetLanguage()
 		);
 
-		$templateRenderer = $applicationFactory->newMwCollaboratorFactory()->newWikitextTemplateRenderer();
+		$mediaWikiCollaboratorFactory = $applicationFactory->newMwCollaboratorFactory();
+
+		$stripMarkerDecoder = $mediaWikiCollaboratorFactory->newStripMarkerDecoder(
+			$parser->mStripState
+		);
 
 		$setParserFunction = new SetParserFunction(
 			$parserData,
 			$messageFormatter,
-			$templateRenderer
+			$mediaWikiCollaboratorFactory->newWikitextTemplateRenderer()
+		);
+
+		$setParserFunction->setStripMarkerDecoder(
+			$stripMarkerDecoder
 		);
 
 		return $setParserFunction;
@@ -232,6 +240,14 @@ class ParserFunctionFactory {
 
 		$subobjectParserFunction->isComparableContent(
 			$applicationFactory->getSettings()->get( 'smwgUseComparableContentHash' )
+		);
+
+		$stripMarkerDecoder = $applicationFactory->newMwCollaboratorFactory()->newStripMarkerDecoder(
+			$parser->mStripState
+		);
+
+		$subobjectParserFunction->setStripMarkerDecoder(
+			$stripMarkerDecoder
 		);
 
 		return $subobjectParserFunction;

--- a/src/ParserFunctions/SetParserFunction.php
+++ b/src/ParserFunctions/SetParserFunction.php
@@ -8,6 +8,7 @@ use SMW\MessageFormatter;
 use SMW\DataValueFactory;
 use SMW\ParserParameterProcessor;
 use SMW\MediaWiki\Renderer\WikitextTemplateRenderer;
+use SMW\MediaWiki\StripMarkerDecoder;
 
 /**
  * Class that provides the {{#set}} parser function
@@ -40,6 +41,11 @@ class SetParserFunction {
 	private $templateRenderer;
 
 	/**
+	 * @var StripMarkerDecoder
+	 */
+	private $stripMarkerDecoder;
+
+	/**
 	 * @since 1.9
 	 *
 	 * @param ParserData $parserData
@@ -50,6 +56,15 @@ class SetParserFunction {
 		$this->parserData = $parserData;
 		$this->messageFormatter = $messageFormatter;
 		$this->templateRenderer = $templateRenderer;
+	}
+
+	/**
+	 * @since 3.0
+	 *
+	 * @param StripMarkerDecoder $stripMarkerDecoder
+	 */
+	public function setStripMarkerDecoder( StripMarkerDecoder $stripMarkerDecoder ) {
+		$this->stripMarkerDecoder = $stripMarkerDecoder;
 	}
 
 	/**
@@ -77,6 +92,10 @@ class SetParserFunction {
 			$last = count( $values ) - 1; // -1 because the key starts with 0
 
 			foreach ( $values as $key => $value ) {
+
+				if ( $this->stripMarkerDecoder !== null ) {
+					$value = $this->stripMarkerDecoder->decode( $value );
+				}
 
 				$dataValue = DataValueFactory::getInstance()->newDataValueByText(
 						$property,

--- a/tests/phpunit/Integration/JSONScript/JsonTestCaseScriptRunnerTest.php
+++ b/tests/phpunit/Integration/JSONScript/JsonTestCaseScriptRunnerTest.php
@@ -206,6 +206,7 @@ class JsonTestCaseScriptRunnerTest extends JsonTestCaseScriptRunner {
 			'smwgQSubcategoryDepth',
 			'smwgQConceptCaching',
 			'smwgEnabledInTextAnnotationParserStrictMode',
+			'smwgDecodeTextAnnotationWithStripMarker',
 			'smwgMaxNonExpNumber',
 			'smwgDVFeatures',
 			'smwgEnabledQueryDependencyLinksStore',

--- a/tests/phpunit/Integration/JSONScript/TestCases/p-0455.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/p-0455.json
@@ -1,0 +1,241 @@
+{
+	"description": "Test paser/in-text annotation with unstripped tags (nowiki etc.) (`smwgDecodeTextAnnotationWithStripMarker`)",
+	"setup": [
+		{
+			"namespace": "SMW_NS_PROPERTY",
+			"page": "Has description",
+			"contents": "[[Has type::Text]]"
+		},
+		{
+			"page": "Example/P0455/1",
+			"contents": "[[Has description::<nowiki>Contains nowiki tag</nowiki>]]"
+		},
+		{
+			"page": "Example/P0455/2",
+			"contents": "[[Has description::<pre>Contains pre tag</pre>]]"
+		},
+		{
+			"page": "Example/P0455/3",
+			"contents": "[[Has description::<code><nowiki>{{#ask: [[Has strip::Markers]] }}</nowiki></code>]]"
+		},
+		{
+			"page": "Example/P0455/4",
+			"contents": "{{#set: Has description=<nowiki>Contains nowiki tag</nowiki> }}"
+		},
+		{
+			"page": "Example/P0455/5",
+			"contents": "{{#set: Has description=<pre>Contains pre tag</pre> }}"
+		},
+		{
+			"page": "Example/P0455/6",
+			"contents": "{{#set: Has description=<code><nowiki>{{#ask: [[Has strip::Markers]] }}</nowiki></code> }}"
+		},
+		{
+			"page": "Example/P0455/7",
+			"contents": "{{#subobject: Has description=<nowiki>Contains nowiki tag</nowiki> }}"
+		},
+		{
+			"page": "Example/P0455/8",
+			"contents": "{{#subobject: Has description=<pre>Contains pre tag</pre> }}"
+		},
+		{
+			"page": "Example/P0455/9",
+			"contents": "{{#subobject: Has description=<code><nowiki>{{#ask: [[Has strip::Markers]] }}</nowiki></code> }}"
+		}
+	],
+	"tests": [
+		{
+			"type": "parser",
+			"about": "#0 nowiki parse/unstrip",
+			"subject": "Example/P0455/1",
+			"assert-store": {
+				"semantic-data": {
+					"strict-mode-valuematch": false,
+					"propertyCount": 3,
+					"propertyKeys": [
+						"Has_description",
+						"_MDAT",
+						"_SKEY"
+					],
+					"propertyValues": [
+						"&lt;nowiki&gt;Contains nowiki tag&lt;/nowiki&gt;"
+					]
+				}
+			},
+			"assert-output": {
+				"to-contain": [
+					"Contains nowiki tag"
+				]
+			}
+		},
+		{
+			"type": "parser",
+			"about": "#1 pre parse/unstrip",
+			"subject": "Example/P0455/2",
+			"assert-store": {
+				"semantic-data": {
+					"strict-mode-valuematch": false,
+					"propertyCount": 3,
+					"propertyKeys": [
+						"Has_description",
+						"_MDAT",
+						"_SKEY"
+					],
+					"propertyValues": [
+						"&lt;pre&gt;Contains pre tag&lt;/pre&gt;"
+					]
+				}
+			},
+			"assert-output": {
+				"to-contain": [
+					"<pre>Contains pre tag</pre>"
+				]
+			}
+		},
+		{
+			"type": "parser",
+			"about": "#2 code/nowiki recursive parse/unstrip",
+			"subject": "Example/P0455/3",
+			"assert-store": {
+				"semantic-data": {
+					"strict-mode-valuematch": false,
+					"propertyCount": 3,
+					"propertyKeys": [
+						"Has_description",
+						"_MDAT",
+						"_SKEY"
+					],
+					"propertyValues": [
+						"&lt;nowiki&gt;&lt;code&gt;&#x007B;&#x007B;#ask&#58; &#x005B;&#x005B;Has strip&#58;&#58;Markers]] }}&lt;/code&gt;&lt;/nowiki&gt;"
+					]
+				}
+			},
+			"assert-output": {
+				"to-contain": [
+					"<code>{{#ask: [[Has strip::Markers]] }}</code>"
+				]
+			}
+		},
+		{
+			"type": "parser",
+			"about": "#3 #set nowiki parse/unstrip",
+			"subject": "Example/P0455/4",
+			"assert-store": {
+				"semantic-data": {
+					"strict-mode-valuematch": false,
+					"propertyCount": 3,
+					"propertyKeys": [
+						"Has_description",
+						"_MDAT",
+						"_SKEY"
+					],
+					"propertyValues": [
+						"&lt;nowiki&gt;Contains nowiki tag&lt;/nowiki&gt;"
+					]
+				}
+			}
+		},
+		{
+			"type": "parser",
+			"about": "#4 #set pre parse/unstrip",
+			"subject": "Example/P0455/5",
+			"assert-store": {
+				"semantic-data": {
+					"strict-mode-valuematch": false,
+					"propertyCount": 3,
+					"propertyKeys": [
+						"Has_description",
+						"_MDAT",
+						"_SKEY"
+					],
+					"propertyValues": [
+						"&lt;pre&gt;Contains pre tag&lt;/pre&gt;"
+					]
+				}
+			}
+		},
+		{
+			"type": "parser",
+			"about": "#5 #set code/nowiki recursive parse/unstrip",
+			"subject": "Example/P0455/6",
+			"assert-store": {
+				"semantic-data": {
+					"strict-mode-valuematch": false,
+					"propertyCount": 3,
+					"propertyKeys": [
+						"Has_description",
+						"_MDAT",
+						"_SKEY"
+					],
+					"propertyValues": [
+						"&lt;nowiki&gt;&lt;code&gt;&#x007B;&#x007B;#ask&#58; &#x005B;&#x005B;Has strip&#58;&#58;Markers]] }}&lt;/code&gt;&lt;/nowiki&gt;"
+					]
+				}
+			}
+		},
+		{
+			"type": "parser",
+			"about": "#6 #subobject nowiki parse/unstrip",
+			"subject": "Example/P0455/7#_726a6109c10cb1ff73b7d5659ad54a18",
+			"assert-store": {
+				"semantic-data": {
+					"strict-mode-valuematch": false,
+					"propertyCount": 2,
+					"propertyKeys": [
+						"Has_description",
+						"_SKEY"
+					],
+					"propertyValues": [
+						"&lt;nowiki&gt;Contains nowiki tag&lt;/nowiki&gt;"
+					]
+				}
+			}
+		},
+		{
+			"type": "parser",
+			"about": "#7 #subobject pre parse/unstrip",
+			"subject": "Example/P0455/8#_74c67f7dc0f33736ec2d8f4f2132a585",
+			"assert-store": {
+				"semantic-data": {
+					"strict-mode-valuematch": false,
+					"propertyCount": 2,
+					"propertyKeys": [
+						"Has_description",
+						"_SKEY"
+					],
+					"propertyValues": [
+						"&lt;pre&gt;Contains pre tag&lt;/pre&gt;"
+					]
+				}
+			}
+		},
+		{
+			"type": "parser",
+			"about": "#8 #subobject code/nowiki recursive parse/unstrip",
+			"subject": "Example/P0455/9#_4bb289f3707ef1e08395efb545cae8f3",
+			"assert-store": {
+				"semantic-data": {
+					"strict-mode-valuematch": false,
+					"propertyCount": 2,
+					"propertyKeys": [
+						"Has_description",
+						"_SKEY"
+					],
+					"propertyValues": [
+						"&lt;nowiki&gt;&lt;code&gt;&#x007B;&#x007B;#ask&#58; &#x005B;&#x005B;Has strip&#58;&#58;Markers]] }}&lt;/code&gt;&lt;/nowiki&gt;"
+					]
+				}
+			}
+		}
+	],
+	"settings": {
+		"wgContLang": "en",
+		"wgLang": "en",
+		"smwgDecodeTextAnnotationWithStripMarker": true
+	},
+	"meta": {
+		"version": "2",
+		"is-incomplete": false,
+		"debug": false
+	}
+}

--- a/tests/phpunit/Unit/MediaWiki/Hooks/HookRegistryTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Hooks/HookRegistryTest.php
@@ -317,6 +317,10 @@ class HookRegistryTest extends \PHPUnit_Framework_TestCase {
 			->method( 'getTitle' )
 			->will( $this->returnValue( $this->title ) );
 
+		$stripState = $this->getMockBuilder( '\StripState' )
+			->disableOriginalConstructor()
+			->getMock();
+
 		$text = '';
 
 		$this->assertTrue(
@@ -325,7 +329,7 @@ class HookRegistryTest extends \PHPUnit_Framework_TestCase {
 
 		$this->assertThatHookIsExcutable(
 			$instance->getHandlerFor( $handler ),
-			array( &$parser, &$text )
+			array( &$parser, &$text, &$stripState )
 		);
 	}
 

--- a/tests/phpunit/Unit/MediaWiki/Hooks/InternalParseBeforeLinksTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Hooks/InternalParseBeforeLinksTest.php
@@ -31,6 +31,10 @@ class InternalParseBeforeLinksTest extends \PHPUnit_Framework_TestCase {
 		$this->semanticDataValidator = $this->testEnvironment->getUtilityFactory()->newValidatorFactory()->newSemanticDataValidator();
 		$this->parserFactory = $this->testEnvironment->getUtilityFactory()->newParserFactory();
 
+		$this->stripState = $this->getMockBuilder( '\StripState' )
+			->disableOriginalConstructor()
+			->getMock();
+
 		$store = $this->getMockBuilder( '\SMW\Store' )
 			->disableOriginalConstructor()
 			->getMockForAbstractClass();
@@ -51,7 +55,7 @@ class InternalParseBeforeLinksTest extends \PHPUnit_Framework_TestCase {
 
 		$this->assertInstanceOf(
 			'\SMW\MediaWiki\Hooks\InternalParseBeforeLinks',
-			new InternalParseBeforeLinks( $parser )
+			new InternalParseBeforeLinks( $parser, $this->stripState )
 		);
 	}
 
@@ -67,7 +71,8 @@ class InternalParseBeforeLinksTest extends \PHPUnit_Framework_TestCase {
 			->method( 'getOptions' );
 
 		$instance = new InternalParseBeforeLinks(
-			$parser
+			$parser,
+			$this->stripState
 		);
 
 		$this->assertTrue(
@@ -108,7 +113,8 @@ class InternalParseBeforeLinksTest extends \PHPUnit_Framework_TestCase {
 			->will( $this->returnValue( $title ) );
 
 		$instance = new InternalParseBeforeLinks(
-			$parser
+			$parser,
+			$this->stripState
 		);
 
 		$this->assertTrue(
@@ -162,7 +168,8 @@ class InternalParseBeforeLinksTest extends \PHPUnit_Framework_TestCase {
 			->will( $this->returnValue( $parserOptions ) );
 
 		$instance = new InternalParseBeforeLinks(
-			$parser
+			$parser,
+			$this->stripState
 		);
 
 		$instance->setEnabledSpecialPage(
@@ -218,7 +225,8 @@ class InternalParseBeforeLinksTest extends \PHPUnit_Framework_TestCase {
 			->will( $this->returnValue( $title ) );
 
 		$instance = new InternalParseBeforeLinks(
-			$parser
+			$parser,
+			$this->stripState
 		);
 
 		$instance->process( $text );
@@ -233,7 +241,8 @@ class InternalParseBeforeLinksTest extends \PHPUnit_Framework_TestCase {
 		$parser = $this->parserFactory->newFromTitle( $title );
 
 		$instance = new InternalParseBeforeLinks(
-			$parser
+			$parser,
+			$this->stripState
 		);
 
 		$this->assertTrue(
@@ -254,7 +263,8 @@ class InternalParseBeforeLinksTest extends \PHPUnit_Framework_TestCase {
 		$parser = $this->parserFactory->newFromTitle( $parameters['title'] );
 
 		$instance = new InternalParseBeforeLinks(
-			$parser
+			$parser,
+			$this->stripState
 		);
 
 		$instance->setEnabledSpecialPage(

--- a/tests/phpunit/Unit/MediaWiki/StripMarkerDecoderTest.php
+++ b/tests/phpunit/Unit/MediaWiki/StripMarkerDecoderTest.php
@@ -1,0 +1,108 @@
+<?php
+
+namespace SMW\Tests\MediaWiki;
+
+use SMW\MediaWiki\StripMarkerDecoder;
+use Title;
+
+/**
+ * @covers \SMW\MediaWiki\StripMarkerDecoder
+ * @group semantic-mediawiki
+ *
+ * @license GNU GPL v2+
+ * @since  3.0
+ *
+ * @author mwjames
+ */
+class StripMarkerDecoderTest extends \PHPUnit_Framework_TestCase {
+
+	public function testCanConstruct() {
+
+		$stripState = $this->getMockBuilder( '\StripState' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$this->assertInstanceOf(
+			StripMarkerDecoder::class,
+			new StripMarkerDecoder( $stripState )
+		);
+	}
+
+	public function testIsSupported() {
+
+		$stripState = $this->getMockBuilder( '\StripState' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$instance = new StripMarkerDecoder(
+			$stripState
+		);
+
+		$instance->isSupported( true );
+
+		$this->assertTrue(
+			$instance->canUse()
+		);
+	}
+
+	public function testDecodeWithoutStrip() {
+
+		$stripState = $this->getMockBuilder( '\StripState' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$instance = new StripMarkerDecoder(
+			$stripState
+		);
+
+		$instance->isSupported( true );
+
+		$this->assertEquals(
+			'<pre>Foo</pre>',
+			$instance->decode( '<pre>Foo</pre>' )
+		);
+	}
+
+	public function testUnstripNoWiki() {
+
+		$stripState = $this->getMockBuilder( '\StripState' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$stripState->expects( $this->once() )
+			->method( 'unstripNoWiki' )
+			->will( $this->returnArgument( 0 ) );
+
+		$instance = new StripMarkerDecoder(
+			$stripState
+		);
+
+		$this->assertEquals(
+			'&lt;nowiki&gt;&lt;pre&gt;Foo&lt;/pre&gt;&lt;/nowiki&gt;',
+			$instance->unstrip( '<pre>Foo</pre>' )
+		);
+	}
+
+	public function testUnstripGeneral() {
+
+		$stripState = $this->getMockBuilder( '\StripState' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$stripState->expects( $this->once() )
+			->method( 'unstripNoWiki' )
+			->will( $this->returnValue( '' ) );
+
+		$stripState->expects( $this->once() )
+			->method( 'unstripGeneral' );
+
+		$instance = new StripMarkerDecoder(
+			$stripState
+		);
+
+		$instance->isSupported( true );
+
+		$instance->unstrip( '<pre>Foo</pre>' );
+	}
+
+}


### PR DESCRIPTION
This PR is made in reference to: #232

This PR addresses or contains:

- Adds `$smwgDecodeTextAnnotationWithStripMarker` setting (disabled by default) to support annotations like:
  - `[[Has description::<pre>sample pre text</pre>]]`
  - `[[Has description::<nowiki>{{#ask: HasStripMarkers }}</nowiki>]]`  
  - `[[Has description::<code><nowiki>{{#ask: HasStripMarkers }}</nowiki></code>]]`
  - Decoding of `<ref>...</rev>` is not supported
- Only supported for text type values

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed

Fixes #232