### PR TITLE
Introduce SemanticDataCache

### DIFF
--- a/SemanticMediaWiki.settings.php
+++ b/SemanticMediaWiki.settings.php
@@ -557,6 +557,9 @@ $GLOBALS['smwgCacheType'] = CACHE_ANYTHING;
 # - smwgStatisticsCache Enable to serve statistics from cache
 # - smwgStatisticsCacheExpiry Number of seconds before the cache expires
 #
+# - smwgSemanticDataCache to improve internal read/write access to SemanticData during
+# an update process.
+#
 # @since 1.9
 ##
 $GLOBALS['smwgCacheUsage'] = array(
@@ -568,6 +571,7 @@ $GLOBALS['smwgCacheUsage'] = array(
 	'smwgPropertiesCacheExpiry' => 3600,
 	'smwgStatisticsCache' => true,
 	'smwgStatisticsCacheExpiry' => 3600,
+	'smwgSemanticDataCache' => true
 );
 
 ###

--- a/composer.json
+++ b/composer.json
@@ -42,6 +42,7 @@
 		"mediawiki/validator": "~2.0,>=2.0.4",
 		"serialization/serialization": "~3.2",
 		"onoi/message-reporter": "~1.0",
+		"onoi/cache": "~1.0",
 		"doctrine/dbal": "~2.5"
 	},
 	"replace": {

--- a/includes/SemanticData.php
+++ b/includes/SemanticData.php
@@ -551,6 +551,24 @@ class SemanticData {
 	}
 
 	/**
+	 * @since 2.2
+	 *
+	 * @param DIProperty $property
+	 *
+	 * @return boolean
+	 */
+	public function hasProperty( DIProperty $property ) {
+
+		foreach ( $this->getProperties() as $semanticDataProperty ) {
+			if ( $semanticDataProperty->equals( $property ) ) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	/**
 	 * Whether the SemanticData has a SubSemanticData container and if
 	 * specified has a particular subobject using its name as identifier
 	 *

--- a/includes/Setup.php
+++ b/includes/Setup.php
@@ -81,10 +81,19 @@ final class Setup {
 	}
 
 	private function registerSettings() {
+
 		$this->applicationFactory->registerObject(
 			'Settings',
 			Settings::newFromGlobals( $this->globalVars )
 		);
+
+		$cacheFactory = $this->applicationFactory->newCacheFactory();
+
+		$compositeCache = $cacheFactory->newMediaWikiCompositeCache(
+			$GLOBALS['smwgCacheType']
+		);
+
+		$cacheFactory->getSemanticDataCache()->setCache( $compositeCache );
 	}
 
 	private function registerConnectionProviders() {

--- a/maintenance/rebuildData.php
+++ b/maintenance/rebuildData.php
@@ -5,8 +5,8 @@ namespace SMW\Maintenance;
 use SMW\Maintenance\DataRebuilder;
 use SMW\Maintenance\MaintenanceHelper;
 use Onoi\MessageReporter\MessageReporterFactory;
+use SMW\ApplicationFactory;
 use SMW\StoreFactory;
-use SMW\Settings;
 
 $basePath = getenv( 'MW_INSTALL_PATH' ) !== false ? getenv( 'MW_INSTALL_PATH' ) : __DIR__ . '/../../..';
 
@@ -106,6 +106,7 @@ class RebuildData extends \Maintenance {
 
 		if ( $this->hasOption( 'no-cache' ) ) {
 			$maintenanceHelper->setGlobalToValue( 'wgMainCacheType', CACHE_NONE );
+			ApplicationFactory::getInstance()->getSettings()->set( 'smwgSemanticDataCache', false );
 		}
 
 		if ( $this->hasOption( 'debug' ) ) {

--- a/src/ApplicationFactory.php
+++ b/src/ApplicationFactory.php
@@ -11,6 +11,7 @@ use SMW\MediaWiki\Jobs\JobFactory;
 use SMW\MediaWiki\MwCollaboratorFactory;
 use SMW\MediaWiki\PageCreator;
 use SMW\MediaWiki\TitleCreator;
+use SMW\Cache\CacheFactory;
 use SMW\Query\Profiler\QueryProfilerFactory;
 use SMWQueryParser as QueryParser;
 use Title;
@@ -239,6 +240,15 @@ class ApplicationFactory {
 	 */
 	public function newMwCollaboratorFactory() {
 		return new MwCollaboratorFactory( $this );
+	}
+
+	/**
+	 * @since 2.2
+	 *
+	 * @return CacheFactory
+	 */
+	public function newCacheFactory() {
+		return new CacheFactory( $this );
 	}
 
 	/**

--- a/src/Cache/CacheFactory.php
+++ b/src/Cache/CacheFactory.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace SMW\Cache;
+
+use Onoi\Cache\Cache;
+use Onoi\Cache\CacheFactory as OnoiCacheFactory;
+use SMW\ApplicationFactory;
+use ObjectCache;
+use Title;
+
+/**
+ * @license GNU GPL v2+
+ * @since 2.2
+ *
+ * @author mwjames
+ */
+class CacheFactory {
+
+	/**
+	 * @var ApplicationFactory
+	 */
+	private $applicationFactory;
+
+	/**
+	 * @var CacheFactory
+	 */
+	private $cacheFactory;
+
+	/**
+	 * @since 2.1
+	 *
+	 * @param ApplicationFactory $applicationFactory
+	 */
+	public function __construct( ApplicationFactory $applicationFactory ) {
+		$this->applicationFactory = $applicationFactory;
+		$this->cacheFactory = OnoiCacheFactory::getInstance();
+	}
+
+	/**
+	 * @since 2.2
+	 *
+	 * @param integer $cacheSize
+	 *
+	 * @return Cache
+	 */
+	public function newFixedInMemoryCache( $cacheSize = 500 ) {
+		return $this->cacheFactory->newFixedInMemoryCache( $cacheSize );
+	}
+
+	/**
+	 * @since 2.2
+	 *
+	 * @param integer|string $mediaWikiCacheType
+	 *
+	 * @return Cache
+	 */
+	public function newMediaWikiCompositeCache( $mediaWikiCacheType ) {
+
+		$mediaWikiCache = ObjectCache::getInstance( $mediaWikiCacheType );
+
+		$compositeCache = $this->cacheFactory->newCompositeCache( array(
+			$this->newFixedInMemoryCache( 500 ),
+			$this->cacheFactory->newMediaWikiCache( $mediaWikiCache )
+		) );
+
+		return $compositeCache;
+	}
+
+	/**
+	 * @since 2.2
+	 *
+	 * @return SemanticDataCache
+	 */
+	public function getSemanticDataCache() {
+		return SemanticDataCache::getInstance();
+	}
+
+}

--- a/src/Cache/SemanticDataCache.php
+++ b/src/Cache/SemanticDataCache.php
@@ -1,0 +1,169 @@
+<?php
+
+namespace SMW\Cache;
+
+use Onoi\Cache\Cache;
+use SMW\ApplicationFactory;
+use SMW\DIWikiPage;
+use SMW\SemanticData;
+use SMW\HashBuilder;
+use Title;
+use RuntimeException;
+
+/**
+ * Storing and retrieving of a serialized SemanticData from/to a cache
+ *
+ * @license GNU GPL v2+
+ * @since 2.2
+ *
+ * @author mwjames
+ */
+class SemanticDataCache {
+
+	/**
+	 * Identifies an auxiliary of the key part that is stable but can be modfied
+	 * in order for all keys to be rebuild if necessary
+	 */
+	const auxiliaryKeyModifier = '01';
+
+	/**
+	 * @var SemanticDataCache
+	 */
+	private static $instance = null;
+
+	/**
+	 * @var Cache
+	 */
+	private $cache;
+
+	/**
+	 * @var string
+	 */
+	private $cachePrefix = '';
+
+	/**
+	 * @since 2.2
+	 *
+	 * @param Cache $cache
+	 * @param string $cachePrefix
+	 */
+	public function __construct( Cache $cache, $cachePrefix ) {
+		$this->cache = $cache;
+		$this->cachePrefix = $cachePrefix;
+	}
+
+	/**
+	 * @since 2.2
+	 *
+	 * @return SemanticDataCache
+	 */
+	public static function getInstance() {
+
+		if ( self::$instance === null ) {
+
+			// The memory-cache is used as fallback and it is expected that
+			// the instance is being setup using `setCache`
+			$cache = ApplicationFactory::getInstance()->newCacheFactory()->newFixedInMemoryCache( 500 );
+
+			self::$instance = new self(
+				$cache,
+				$GLOBALS['wgCachePrefix'] === false ? wfWikiID() : $GLOBALS['wgCachePrefix']
+			);
+		}
+
+		return self::$instance;
+	}
+
+	/**
+	 * @since 2.2
+	 */
+	public static function clear() {
+		self::$instance = null;
+	}
+
+	/**
+	 * @since 2.2
+	 *
+	 * @param Cache $cache
+	 */
+	public function setCache( Cache $cache ) {
+		$this->cache = $cache;
+	}
+
+	/**
+	 * @since 2.2
+	 *
+	 * @param SemanticData $semanticData
+	 */
+	public function save( SemanticData $semanticData ) {
+
+		// By default getUpdateIdentifier contains the LatestRevID which means
+		// that any new edit (with a new revId) will inevitably replace
+		// the data for the subject hash therefore no extra means are necessary
+		// to invalidate an entry where the verification will made against the
+		// revId
+		$data = array(
+			'updateIdentifier' => $semanticData->getUpdateIdentifier(),
+			'data' => ApplicationFactory::getInstance()->newSerializerFactory()->serialize( $semanticData )
+		);
+
+		$this->cache->save(
+			$this->getPageCacheKey( $semanticData->getSubject() ),
+			$data
+		);
+	}
+
+	/**
+	 * @since 2.2
+	 *
+	 * @param Title $title
+	 *
+	 * @param boolean
+	 */
+	public function has( Title $title ) {
+
+		$data = $this->cache->fetch(
+			$this->getPageCacheKey( DIWikiPage::newFromTitle( $title ) )
+		);
+
+		if ( $data !== false && $data['updateIdentifier'] === $title->getLatestRevID() ) {
+			return true;
+		}
+
+		return false;
+	}
+
+	/**
+	 * @since 2.2
+	 *
+	 * @param Title $title
+	 *
+	 * @return SemanticData
+	 * @throws RuntimeException
+	 */
+	public function get( Title $title ) {
+
+		$data = $this->cache->fetch(
+			$this->getPageCacheKey( DIWikiPage::newFromTitle( $title ) )
+		);
+
+		if ( $data !== false && $data['data'] !== '' ) {
+			$data = ApplicationFactory::getInstance()->newSerializerFactory()->deserialize( $data['data'] );
+		}
+
+		if ( $data instanceOf SemanticData ) {
+			return $data;
+		}
+
+		throw new RuntimeException( "Something went wrong during de-serialization" );
+	}
+
+	private function getPageCacheKey( DIWikiPage $page ) {
+		return $this->getCachePrefix() . 'sem-cache:' . md5( HashBuilder::getHashIdForDiWikiPage( $page ) . self::auxiliaryKeyModifier );
+	}
+
+	private function getCachePrefix() {
+		return $this->cachePrefix . ':' . 'smw:';
+	}
+
+}

--- a/src/MediaWiki/Hooks/LinksUpdateConstructed.php
+++ b/src/MediaWiki/Hooks/LinksUpdateConstructed.php
@@ -5,6 +5,7 @@ namespace SMW\MediaWiki\Hooks;
 use LinksUpdate;
 use SMW\ApplicationFactory;
 use SMW\SemanticData;
+use SMW\SemanticDataCache;
 
 /**
  * LinksUpdateConstructed hook is called at the end of LinksUpdate()
@@ -29,6 +30,11 @@ class LinksUpdateConstructed {
 	private $applicationFactory = null;
 
 	/**
+	 * @var CacheFactory
+	 */
+	private $cacheFactory = null;
+
+	/**
 	 * @since  1.9
 	 *
 	 * @param LinksUpdate $linksUpdate
@@ -45,17 +51,20 @@ class LinksUpdateConstructed {
 	public function process() {
 
 		$this->applicationFactory = ApplicationFactory::getInstance();
+		$this->cacheFactory = $this->applicationFactory->newCacheFactory();
 
 		/**
 		 * @var ParserData $parserData
 		 */
-		$parserData = $this->applicationFactory
-			->newParserData( $this->linksUpdate->getTitle(), $this->linksUpdate->getParserOutput() );
+		$parserData = $this->applicationFactory->newParserData(
+			$this->linksUpdate->getTitle(),
+			$this->linksUpdate->getParserOutput() );
 
-		if ( $parserData->getSemanticData()->isEmpty() &&
-			( $semanticData = $this->refetchSemanticData() ) instanceOf SemanticData ) {
-			$parserData->setSemanticData( $semanticData );
+		if ( $parserData->getSemanticData()->isEmpty() ) {
+			$this->updateEmptySemanticData( $parserData, $this->linksUpdate->getTitle() );
 		}
+
+		$this->cacheFactory->getSemanticDataCache()->save( $parserData->getSemanticData() );
 
 		$parserData->updateStore();
 
@@ -66,7 +75,7 @@ class LinksUpdateConstructed {
 	 * #347 showed that an external process (e.g. RefreshLinksJob) can inject a
 	 * ParserOutput without/cleared SemanticData which forces the Store updater
 	 * to create an empty container that will clear all existing data.
-	 * 
+	 *
 	 * To ensure that for a Title and its current revision an empty ParserOutput
 	 * object is really meant to be "empty" (e.g. delete action initiated by a
 	 * human) the content is re-parsed in order to fetch the newest available data
@@ -74,10 +83,24 @@ class LinksUpdateConstructed {
 	 * @note Parsing is expensive but it is more expensive to loose data or to
 	 * expect that an external process adheres the object contract
 	 */
-	private function refetchSemanticData() {
-		wfDebug( __METHOD__ . ' Empty SemanticData / re-parsing: ' . $this->linksUpdate->getTitle()->getPrefixedDBkey() . "\n" );
+	private function updateEmptySemanticData( &$parserData, $title ) {
 
-		$contentParser = $this->applicationFactory->newContentParser( $this->linksUpdate->getTitle() );
+		wfDebug( __METHOD__ . ' Empty SemanticData : ' . $title->getPrefixedDBkey() . "\n" );
+
+		if ( $this->cacheFactory->getSemanticDataCache()->has( $title ) ) {
+			$semanticData = $this->cacheFactory->getSemanticDataCache()->get( $title );
+		} else {
+			$semanticData = $this->reparseToFetchSemanticData( $title );
+		}
+
+		if ( $semanticData instanceOf SemanticData ) {
+			$parserData->setSemanticData( $semanticData );
+		}
+	}
+
+	private function reparseToFetchSemanticData( $title ) {
+
+		$contentParser = $this->applicationFactory->newContentParser( $title );
 		$parserOutput = $contentParser->parse()->getOutput();
 
 		if ( $parserOutput === null ) {

--- a/src/MediaWiki/Hooks/ParserAfterTidy.php
+++ b/src/MediaWiki/Hooks/ParserAfterTidy.php
@@ -111,7 +111,16 @@ class ParserAfterTidy {
 
 		if( $cache->get() ) {
 			$cache->delete();
+
+			// FIXME
+			// I don't remember why we do an updateStore and not a simple
+			// pageUpdate which would only refresh the ParserCache instead
+			// of doing a full back-end update
 			$parserData->updateStore();
+
+			//$pageUpdater = $this->applicationFactory->newMwCollaboratorFactory()->newPageUpdater();
+			//$pageUpdater->addPage( $parserData->getTitle() );
+			//$pageUpdater->doPurgeParserCache();
 		}
 
 		return true;

--- a/tests/phpunit/Integration/MediaWiki/LinksUpdateSQLStoreDBIntegrationTest.php
+++ b/tests/phpunit/Integration/MediaWiki/LinksUpdateSQLStoreDBIntegrationTest.php
@@ -202,6 +202,9 @@ class LinksUpdateSQLStoreDBIntegrationTest extends MwDBaseUnitTestCase {
 		// Property _SKEY is always present even within an empty container
 		// po = ParserOutput, before means prior LinksUpdate
 
+		// MW 19 has an issue with revision update during the test
+		$storeAfterCount = version_compare( $GLOBALS['wgVersion'], '1.20', '<' ) ? 2 : 4;
+
 		$provider = array();
 
 		$provider[] = array( array(
@@ -237,7 +240,7 @@ class LinksUpdateSQLStoreDBIntegrationTest extends MwDBaseUnitTestCase {
 					'msg'    => 'Asserts property _MDAT exists after the update'
 				),
 				'storeAfter' => array(
-					'count'  => 2,
+					'count'  => $storeAfterCount,
 					'msg'    => 'Asserts property _SKEY, _MDAT exists after the update'
 				)
 			)

--- a/tests/phpunit/includes/MediaWiki/Jobs/UpdateJobTest.php
+++ b/tests/phpunit/includes/MediaWiki/Jobs/UpdateJobTest.php
@@ -11,9 +11,7 @@ use Title;
 /**
  * @covers \SMW\MediaWiki\Jobs\UpdateJob
  *
- *
- * @group SMW
- * @group SMWExtension
+ * @group semantic-mediawiki
  *
  * @license GNU GPL v2+
  * @since 1.9
@@ -30,8 +28,9 @@ class UpdateJobTest extends \PHPUnit_Framework_TestCase {
 		$this->applicationFactory = ApplicationFactory::getInstance();
 
 		$settings = Settings::newFromArray( array(
-			'smwgCacheType'        => 'hash',
-			'smwgEnableUpdateJobs' => false
+			'smwgCacheType'         => 'hash',
+			'smwgEnableUpdateJobs'  => false,
+			'smwgSemanticDataCache' => false
 		) );
 
 		$store = $this->getMockBuilder( '\SMW\Store' )
@@ -77,6 +76,10 @@ class UpdateJobTest extends \PHPUnit_Framework_TestCase {
 			->method( 'exists' )
 			->will( $this->returnValue( true ) );
 
+		$title->expects( $this->any() )
+			->method( 'getNamespace' )
+			->will( $this->returnValue( 0 ) );
+
 		$instance = new UpdateJob( $title );
 		$instance->setJobQueueEnabledState( false );
 
@@ -93,6 +96,10 @@ class UpdateJobTest extends \PHPUnit_Framework_TestCase {
 			->method( 'exists' )
 			->will( $this->returnValue( false ) );
 
+		$title->expects( $this->any() )
+			->method( 'getNamespace' )
+			->will( $this->returnValue( 0 ) );
+
 		$this->applicationFactory->registerObject( 'ContentParser', null );
 
 		$instance = new UpdateJob( $title );
@@ -103,6 +110,8 @@ class UpdateJobTest extends \PHPUnit_Framework_TestCase {
 
 	public function testJobWithNoRevisionAvailable() {
 
+		$this->applicationFactory->getSettings()->set( 'smwgSemanticDataCache', true );
+
 		$title = $this->getMockBuilder( 'Title' )
 			->disableOriginalConstructor()
 			->getMock();
@@ -110,6 +119,10 @@ class UpdateJobTest extends \PHPUnit_Framework_TestCase {
 		$title->expects( $this->once() )
 			->method( 'exists' )
 			->will( $this->returnValue( true ) );
+
+		$title->expects( $this->once() )
+			->method( 'getNamespace' )
+			->will( $this->returnValue( 0 ) );
 
 		$contentParser = $this->getMockBuilder( '\SMW\ContentParser' )
 			->disableOriginalConstructor()
@@ -133,15 +146,15 @@ class UpdateJobTest extends \PHPUnit_Framework_TestCase {
 			->disableOriginalConstructor()
 			->getMock();
 
-		$title->expects( $this->once() )
+		$title->expects( $this->atLeastOnce() )
 			->method( 'getDBkey' )
 			->will( $this->returnValue( __METHOD__ ) );
 
-		$title->expects( $this->once() )
+		$title->expects( $this->atLeastOnce() )
 			->method( 'getNamespace' )
 			->will( $this->returnValue( 0 ) );
 
-		$title->expects( $this->once() )
+		$title->expects( $this->atLeastOnce() )
 			->method( 'exists' )
 			->will( $this->returnValue( true ) );
 


### PR DESCRIPTION
Parsing pages is an expensive endeavour and therefore liable to the amount of time spent on each page during an update (re-parse).

Using the `SemanticDataCache` can reduce the burden and processing times significantly by making a decision on whether a page needs a "real" update (revId to identify the content status) or it is merely enough to re-fetch the data from cache and provide the input.

The premis is that if the revision hasn't changed then the `SemanticData` haven't changed either hence the data from cache can be used.

- If `rebuildData.php` is run with option `--no-cache` then no `SemanticDataCache` is used.
- In case the de-serialization returns with an error a re-parse of a page is automatically triggered during the `UpdateJob` run.
- Currently `smwgCacheType` is used to identify the cache type for building the `CompositeCache` for the `SemanticDataCache` object.

Sample using `rebuildData.php -s 1 -e 40 --runtime`:
- without-cache: Memory used: 24309648 (b: 8997048, a: 33306696) with a runtime of 82.89 sec (1.38 min)
- with-cache: Memory used: 14102776 (b: 8997048, a: 23099824) with a runtime of 36.71 sec