### PR TITLE
[Demo] Special:DataContainer to import sample CSV data, refs #838

### DIFF
--- a/i18n/en.json
+++ b/i18n/en.json
@@ -198,6 +198,7 @@
 	"smw-ask-sorting": "Sorting",
 	"smw-ask-format-selection-help": "For a detailed description, please visit the $1 help page.",
 	"searchbyproperty": "Search by property",
+	"datacontainer": "DataContainer",
 	"smw_sbv_docu": "Search for all pages that have a given property and value.",
 	"smw_sbv_novalue": "Enter a valid value for the property, or view all property values for \"$1\".",
 	"smw_sbv_displayresult": "A list of all pages that have property \"$1\" with value \"$2\"",

--- a/includes/Setup.php
+++ b/includes/Setup.php
@@ -218,6 +218,10 @@ final class Setup {
 				'page' => 'SMW\SpecialWantedProperties',
 				'group' => 'maintenance'
 			),
+			'DataContainer' => array(
+				'page' => 'SMW\MediaWiki\Specials\DataContainer',
+				'group' => 'smw_group'
+			),
 		);
 
 		// Register data

--- a/languages/SMW_Aliases.php
+++ b/languages/SMW_Aliases.php
@@ -20,6 +20,7 @@ $specialPageAliases['en'] = array(
 	'Concepts' => array( 'Concepts' ),
 	'SMWAdmin' => array( 'SMWAdmin' ),
 	'SearchByProperty' => array( 'SearchByProperty' ),
+	'DataContainer' => array( 'DataContainer' ),
 	'SemanticStatistics' => array( 'SemanticStatistics' ),
 	'Types' => array( 'Types' ),
 	'URIResolver' => array( 'URIResolver' ),

--- a/src/ExternalDataContainer.php
+++ b/src/ExternalDataContainer.php
@@ -1,0 +1,134 @@
+<?php
+
+namespace SMW;
+
+use SMWDataValue as DataValue;
+use RuntimeException;
+
+/**
+ * @license GNU GPL v2+
+ * @since 2.2
+ *
+ * @author mwjames
+ */
+class ExternalDataContainer {
+
+	/**
+	 * @var string|null
+	 */
+	private $dataSource = null;
+
+	/**
+	 * @var SemanticData
+	 */
+	private $semanticData;
+
+	/**
+	 * @var DataValueFactory
+	 */
+	private $dataValueFactory;
+
+	/**
+	 * @var string|null
+	 */
+	private $dataGroup = null;
+
+	/**
+	 * @var Subobject|null
+	 */
+	private $subobject = null;
+
+	/**
+	 * @since 2.2
+	 *
+	 * @param string $dataSource
+	 */
+	public function __construct( $dataSource ) {
+		$this->dataSource = $dataSource;
+		$this->semanticData = new SemanticData( new DIWikiPage( 'DataContainer', NS_SPECIAL ) );
+		$this->dataValueFactory = DataValueFactory::getInstance();
+	}
+
+	/**
+	 * @since 2.2
+	 *
+	 * @return DIWikiPage
+	 */
+	public function getSubject() {
+		return $this->semanticData->getSubject();
+	}
+
+	/**
+	 * @since 2.2
+	 *
+	 * @param string $dataGroup
+	 */
+	public function setDataGroup( $dataGroup ) {
+		$this->dataGroup = $dataGroup;
+	}
+
+	/**
+	 * @since 2.2
+	 *
+	 * @param string $dataIdentifier
+	 * @throws RuntimeException
+	 */
+	public function setEmptyContainerForDataIdentifier( $dataIdentifier ) {
+
+		if ( $this->dataGroup === '' || $dataIdentifier === '' ) {
+			throw new RuntimeException( "Missing a group or storage identifier" );
+		}
+
+		$subject = $this->semanticData->getSubject();
+		$this->subobject = new Subobject( $subject->getTitle() );
+		$this->subobject->setEmptyContainerForId( '_' . $this->dataSource . '.' . $this->dataGroup . '.' . $dataIdentifier );
+
+		$this->addFixedDataToContainer( 'Has external data source', $this->dataSource );
+		$this->addFixedDataToContainer( 'Has external data group', $this->dataGroup );
+		$this->addFixedDataToContainer( 'Has external data id', $dataIdentifier );
+	}
+
+	/**
+	 * @since 2.2
+	 *
+	 * @param DataValue $dataValue
+	 */
+	public function addDataValueToContainer( DataValue $dataValue ) {
+
+		if ( $this->subobject === null ) {
+			throw new RuntimeException( "Missing a storage" );
+		}
+
+		$this->subobject->addDataValue( $dataValue );
+	}
+
+	/**
+	 * @since 2.2
+	 */
+	public function copyContainerToSemanticData() {
+		$this->semanticData->addSubobject( $this->subobject );
+		$this->subobject = null;
+	}
+
+	/**
+	 * @since 2.2
+	 *
+	 * @return SemanticData
+	 */
+	public function getSemanticData() {
+		return $this->semanticData;
+	}
+
+	private function addFixedDataToContainer( $property, $value ) {
+
+		$dataValue = $this->dataValueFactory->newPropertyValue(
+				$property,
+				$value,
+				false,
+				$this->getSubject()
+			);
+
+		$this->addDataValueToContainer( $dataValue );
+	}
+
+}

--- a/src/MediaWiki/Specials/DataContainer.php
+++ b/src/MediaWiki/Specials/DataContainer.php
@@ -1,0 +1,118 @@
+<?php
+
+namespace SMW\MediaWiki\Specials;
+
+use SMW\ExternalDataContainer;
+use SMW\ApplicationFactory;
+use SMW\DataValueFactory;
+use SMW\SemanticData;
+use SMW\Subobject;
+use SMW\DIWikiPage;
+use SMW\DIProperty;
+
+use SpecialPage;
+
+/**
+ * @license GNU GPL v2+
+ * @since   2.2
+ *
+ * @author mwjames
+ */
+class DataContainer extends SpecialPage {
+
+	/**
+	 * http://www.ferc.gov/docs-filing/eqr/soft-tools/sample-csv/transaction.txt
+	 */
+	private $csvSampleData = 'transaction_unique_identifier,seller_company_name,customer_company_name,customer_duns_number,tariff_reference,contract_service_agreement,trans_id,transaction_begin_date,transaction_end_date,time_zone,point_of_delivery_control_area,specific location,class_name,term_name,increment_name,increment_peaking_name,product_name,transaction_quantity,price,units,total_transmission_charge,transaction_charge
+T1,The Electric Company,"The Electric Marketing Co., LLC",23456789,FERC Electric Tariff Original Volume No. 2,Service Agreement 1,8700,200401010000,200403312359,ES,PJM,BUS 4321,UP,LT,Y,FP,ENERGY,22574,39,$/MWH,0,880386
+T2,The Electric Company,The Power Company,45653333,FERC Electric Tariff Original Volume No. 10,2,8701,200401010000,200402010000,CS,DPL,Green Sub Busbar,F,ST,M,FP,ENERGY,16800,32,$/MWH,0,537600
+T3,The Electric Company,The Power Company,45653333,FERC Electric Tariff Original Volume No. 10,2,8702,200402010000,200403010000,CS,DPL,Green Sub Busbar,F,ST,M,FP,ENERGY,16800,32,$/MWH,0,537600';
+
+	/**
+	 * @codeCoverageIgnore
+	 */
+	public function __construct() {
+		parent::__construct( 'DataContainer' );
+		$this->dataValueFactory = DataValueFactory::getInstance();
+		$this->applicationFactory = ApplicationFactory::getInstance();
+	}
+
+	/**
+	 * @see SpecialPage::execute
+	 */
+	public function execute( $query ) {
+
+		$output = $this->getOutput();
+		$output->setPageTitle( $this->msg( 'datacontainer' )->text() );
+
+		$externalDataContainer = new ExternalDataContainer( 'www.ferc.gov' );
+		$externalDataContainer->setDataGroup( 'csv.transaction' );
+
+		// We just delete any data before the demo
+		$this->applicationFactory->getStore()->deleteSubject(
+			$externalDataContainer->getSubject()->getTitle()
+		);
+
+		foreach ( $this->parseCsv( $this->csvSampleData ) as $line ) {
+			$this->addValuesToExternalDataContainer(
+				$externalDataContainer,
+				$line
+			);
+		}
+
+		$this->applicationFactory->getStore()->updateData(
+			$externalDataContainer->getSemanticData()
+		);
+
+		$count = count( $this->applicationFactory->getStore()->getSemanticData(
+			$externalDataContainer->getSubject() )->getPropertyValues( new DIProperty( '_SOBJ' )
+		) );
+
+		$output->addHTML( '<div><b>A demonstration on how to add external data to the storage engine without requiring a wikipage.</b></div>' );
+		$output->addHTML( 'Number of added subobjects: ' . $count );
+	}
+
+	private function addValuesToExternalDataContainer( $externalDataContainer, array $data ) {
+
+		$externalDataContainer->setEmptyContainerForDataIdentifier( sha1( json_encode( $data ) ) );
+		$subject = $externalDataContainer->getSubject();
+
+		foreach ( $data as $property => $value ) {
+
+			$dataValue = $this->dataValueFactory->newPropertyValue(
+					$property,
+					$value,
+					false,
+					$subject
+				);
+
+			$externalDataContainer->addDataValueToContainer( $dataValue );
+		}
+
+		$externalDataContainer->copyContainerToSemanticData();
+	}
+
+	private function parseCsv( $csv, $delimiter = ',' ) {
+
+		$limit = 5 * 1024 * 1024; // 5MB;
+		$handle = fopen( "php://temp/maxmemory:$limit", 'r+' );
+		fputs( $handle, $csv );
+		rewind( $handle );
+
+		$header = null;
+		$data = array();
+
+		while ( ( $row = fgetcsv( $handle, 1000, $delimiter ) ) !== false ) {
+			if ( !$header ) {
+				$header = $row;
+			} else {
+				$data[] = array_combine( $header, $row);
+			}
+		}
+
+		fclose( $handle );
+
+		return $data;
+	}
+
+}


### PR DESCRIPTION
!THIS IS NO PRODUCTION CODE!

refs #838, a quick hack to demonstrate on how to store non-page related data.

The execution of `Special:DataContainer` will just add the sample data in order to run a `#ask` query such as:

![datacontainer](https://cloud.githubusercontent.com/assets/1245473/6323129/8ff77946-bb67-11e4-80c1-3948b45c7afb.png)