### PR TITLE
Guard against possible circular by a template self-reference

### DIFF
--- a/includes/parserhooks/ParserFunctionFactory.php
+++ b/includes/parserhooks/ParserFunctionFactory.php
@@ -62,6 +62,8 @@ class ParserFunctionFactory {
 	 */
 	public function newAskParserFunction() {
 
+		$circularReferenceGuard = new CircularReferenceGuard( 'ask-parser' );
+
 		$parserData = ApplicationFactory::getInstance()->newParserData(
 			$this->parser->getTitle(),
 			$this->parser->getOutput()
@@ -71,7 +73,8 @@ class ParserFunctionFactory {
 
 		$instance = new AskParserFunction(
 			$parserData,
-			$messageFormatter
+			$messageFormatter,
+			$circularReferenceGuard
 		);
 
 		return $instance;
@@ -84,6 +87,8 @@ class ParserFunctionFactory {
 	 */
 	public function newShowParserFunction() {
 
+		$circularReferenceGuard = new CircularReferenceGuard( 'show-parser' );
+
 		$parserData = ApplicationFactory::getInstance()->newParserData(
 			$this->parser->getTitle(),
 			$this->parser->getOutput()
@@ -93,7 +98,8 @@ class ParserFunctionFactory {
 
 		$instance = new ShowParserFunction(
 			$parserData,
-			$messageFormatter
+			$messageFormatter,
+			$circularReferenceGuard
 		);
 
 		return $instance;

--- a/includes/parserhooks/ShowParserFunction.php
+++ b/includes/parserhooks/ShowParserFunction.php
@@ -23,14 +23,21 @@ class ShowParserFunction {
 	private $messageFormatter;
 
 	/**
+	 * @var CircularReferenceGuard
+	 */
+	private $circularReferenceGuard;
+
+	/**
 	 * @since 1.9
 	 *
 	 * @param ParserData $parserData
 	 * @param MessageFormatter $messageFormatter
+	 * @param CircularReferenceGuard $circularReferenceGuard
 	 */
-	public function __construct( ParserData $parserData, MessageFormatter $messageFormatter ) {
+	public function __construct( ParserData $parserData, MessageFormatter $messageFormatter, CircularReferenceGuard $circularReferenceGuard ) {
 		$this->parserData = $parserData;
 		$this->messageFormatter = $messageFormatter;
+		$this->circularReferenceGuard = $circularReferenceGuard;
 	}
 
 	/**
@@ -48,8 +55,16 @@ class ShowParserFunction {
 	 * @return string|null
 	 */
 	public function parse( array $rawParams ) {
-		$ask = new AskParserFunction( $this->parserData, $this->messageFormatter );
-		return $ask->setShowMode( true )->parse( $rawParams );
+
+		$instance = new AskParserFunction(
+			$this->parserData,
+			$this->messageFormatter,
+			$this->circularReferenceGuard
+		);
+
+		$instance->setShowMode( true );
+
+		return $instance->parse( $rawParams );
 	}
 
 	/**

--- a/src/CircularReferenceGuard.php
+++ b/src/CircularReferenceGuard.php
@@ -1,0 +1,110 @@
+<?php
+
+namespace SMW;
+
+/**
+ * @license GNU GPL v2+
+ * @since 2.2
+ *
+ * @author mwjames
+ */
+class CircularReferenceGuard {
+
+	/**
+	 * @var array
+	 */
+	private static $circularRefGuard = array();
+
+	/**
+	 * @var string
+	 */
+	private $namespace = '';
+
+	/**
+	 * @var integer
+	 */
+	private $maxRecursionDepth = 1;
+
+	/**
+	 * @since 2.2
+	 *
+	 * @param string $namespace
+	 */
+	public function __construct( $namespace = '' ) {
+		$this->namespace = $namespace;
+	}
+
+	/**
+	 * @since 2.2
+	 *
+	 * @param integer $maxRecursionDepth
+	 */
+	public function setMaxRecursionDepth( $maxRecursionDepth ) {
+		$this->maxRecursionDepth = (int)$maxRecursionDepth;
+	}
+
+	/**
+	 * @since 2.2
+	 *
+	 * @param string $hash
+	 */
+	public function mark( $hash ) {
+
+		if ( !isset( self::$circularRefGuard[ $this->namespace ][ $hash ] ) ) {
+			self::$circularRefGuard[ $this->namespace ][ $hash ] = 0;
+		}
+
+		self::$circularRefGuard[ $this->namespace ][ $hash ]++;
+	}
+
+	/**
+	 * @since 2.2
+	 *
+	 * @param string $hash
+	 */
+	public function unmark( $hash ) {
+
+		if ( isset( self::$circularRefGuard[ $this->namespace ][ $hash ] ) && self::$circularRefGuard[ $this->namespace ][ $hash ] > 0 ) {
+			return self::$circularRefGuard[ $this->namespace ][ $hash ]--;
+		}
+
+		unset( self::$circularRefGuard[ $this->namespace ][ $hash ] );
+	}
+
+	/**
+	 * @since 2.2
+	 *
+	 * @param string $hash
+	 *
+	 * @return boolean
+	 */
+	public function isCircularByRecursion( $hash ) {
+		return $this->get( $hash ) > $this->maxRecursionDepth;
+	}
+
+	/**
+	 * @since 2.2
+	 *
+	 * @param string $hash
+	 *
+	 * @return integer
+	 */
+	public function get( $hash ) {
+
+		if ( isset( self::$circularRefGuard[ $this->namespace ][ $hash ] ) ) {
+			return self::$circularRefGuard[ $this->namespace ][ $hash ];
+		}
+
+		return 0;
+	}
+
+	/**
+	 * @since 2.2
+	 *
+	 * @param string $namespace
+	 */
+	public function reset( $namespace ) {
+		self::$circularRefGuard[ $namespace ] =  array();
+	}
+
+}

--- a/tests/phpunit/ByJsonTestCaseProvider.php
+++ b/tests/phpunit/ByJsonTestCaseProvider.php
@@ -136,7 +136,11 @@ abstract class ByJsonTestCaseProvider extends MwDBaseUnitTestCase {
 			$this->markTestIncomplete( $jsonTestCaseFileHandler->getReasonForSkip() );
 		}
 
-		if ( $jsonTestCaseFileHandler->requiredToSkipForVersion( $this->getJsonTestCaseVersion() ) ) {
+		if ( $jsonTestCaseFileHandler->requiredToSkipForJsonVersion( $this->getJsonTestCaseVersion() ) ) {
+			$this->markTestSkipped( $jsonTestCaseFileHandler->getReasonForSkip() );
+		}
+
+		if ( $jsonTestCaseFileHandler->requiredToSkipForMwVersion( $GLOBALS['wgVersion'] ) ) {
 			$this->markTestSkipped( $jsonTestCaseFileHandler->getReasonForSkip() );
 		}
 

--- a/tests/phpunit/Integration/Query/Fixtures/format-template-self-reference-001.json
+++ b/tests/phpunit/Integration/Query/Fixtures/format-template-self-reference-001.json
@@ -1,0 +1,117 @@
+{
+	"description": "Query to test/guard against template self-reference in ask/show query",
+	"properties": [
+		{
+			"name": "Has blob property",
+			"contents": "[[Has type::Text]]"
+		},
+		{
+			"name": "Has page property",
+			"contents": "[[Has type::Page]]"
+		}
+	],
+	"subjects": [
+		{
+			"name": "Page with annotation for template usage",
+			"contents": "[[Has blob property::Template one]] [[Has page property::Template two]]"
+		},
+		{
+			"name": "TemplateWithReferenceToItself",
+			"namespace": "NS_TEMPLATE",
+			"contents": "<includeonly>{{#ask: [[Has page property::Template two]] OR [[Has page property::Template three]]|format=template|template=TemplateWithReferenceToItself}}</includeonly>"
+		},
+		{
+			"name": "PageContainsAskWithTemplateUsage",
+			"contents": "{{#ask: [[Has blob property::Template one]]|format=template|template=TemplateWithReferenceToItself}}"
+		},
+		{
+			"name": "PageContainsTemplateTransclusion",
+			"contents": "[[Has page property::Template three]] {{TemplateWithReferenceToItself}}"
+		}
+	],
+	"queries": [
+		{
+			"about": "#0 query profile (use invert query)",
+			"condition": "[[-Has query::PageContainsAskWithTemplateUsage]]",
+			"printouts" : [ "Query size", "Query string", "Query depth" ],
+			"parameters" : {
+			  "limit" : "10"
+			},
+			"queryresult": {
+				"results": [
+					"PageContainsAskWithTemplateUsage#0##_QUERY79869d791f05c5123300513f7746bdd9",
+					"PageContainsAskWithTemplateUsage#0##_QUERYce80902a7df821d01b8f9c6f06ad9d6c"
+				],
+				"count": "2",
+				"datavalues": [
+					{
+						"property": "Query size",
+						"value": "1"
+					},
+					{
+						"property": "Query depth",
+						"value": "1"
+					},
+					{
+						"property": "Query string",
+						"value": "[[Has blob property::Template one]]"
+					},
+					{
+						"property": "Query size",
+						"value": "4"
+					},
+					{
+						"property": "Query depth",
+						"value": "1"
+					},
+					{
+						"property": "Query string",
+						"value": " <q> <q>[[Has page property::Template two]]</q>  OR  <q>[[Has page property::Template three]]</q> </q> "
+					}
+				]
+			}
+		},
+		{
+			"about": "#1 query profile on page/template transcluded page (use invert query)",
+			"condition": "[[-Has query::PageContainsTemplateTransclusion]]",
+			"printouts" : [ "Query size", "Query string", "Query depth" ],
+			"parameters" : {
+			  "limit" : "10"
+			},
+			"queryresult": {
+				"results": [
+					"PageContainsTemplateTransclusion#0##_QUERY79869d791f05c5123300513f7746bdd9"
+				],
+				"count": "1",
+				"datavalues": [
+					{
+						"property": "Query size",
+						"value": "4"
+					},
+					{
+						"property": "Query depth",
+						"value": "1"
+					},
+					{
+						"property": "Query string",
+						"value": " <q> <q>[[Has page property::Template two]]</q>  OR  <q>[[Has page property::Template three]]</q> </q> "
+					}
+				]
+			}
+		}
+	],
+	"settings": {
+		"smwgNamespacesWithSemanticLinks": {
+			"NS_MAIN": true,
+			"SMW_NS_PROPERTY": true
+		}
+	},
+	"meta": {
+		"skip-on": {
+			"mw-1.22.12": "I have no idea why #1 fails on Travis/1.22.12."
+		},
+		"version": "0.1",
+		"is-incomplete": false,
+		"debug": false
+	}
+}

--- a/tests/phpunit/JsonTestCaseFileHandler.php
+++ b/tests/phpunit/JsonTestCaseFileHandler.php
@@ -97,12 +97,39 @@ class JsonTestCaseFileHandler {
 	 *
 	 * @return boolean
 	 */
-	public function requiredToSkipForVersion( $version ) {
+	public function requiredToSkipForJsonVersion( $version ) {
 
 		$meta = $this->getFileContentsFor( 'meta' );
 
 		if ( version_compare( $version, $meta['version'], 'lt' ) ) {
 			$this->reasonToSkip = $meta['version'] . ' as file version is not supported';
+		}
+
+		return $this->reasonToSkip !== '';
+	}
+
+	/**
+	 * @since 2.2
+	 *
+	 * @return boolean
+	 */
+	public function requiredToSkipForMwVersion( $mwVersion ) {
+
+		$meta = $this->getFileContentsFor( 'meta' );
+		$skipOn = isset( $meta['skip-on'] ) ? $meta['skip-on'] : array();
+
+		foreach ( $skipOn as $id => $reason ) {
+
+			if ( strpos( $id, 'mw-' ) === false ) {
+				continue;
+			}
+
+			list( $mw, $versionToSkip ) = explode( "mw-", $id, 2 );
+
+			if ( version_compare( $mwVersion, $versionToSkip, '=' ) ) {
+				$this->reasonToSkip = "MediaWiki " . $mwVersion . " version is not supported ({$reason})";
+				break;
+			}
 		}
 
 		return $this->reasonToSkip !== '';

--- a/tests/phpunit/includes/CircularReferenceGuardTest.php
+++ b/tests/phpunit/includes/CircularReferenceGuardTest.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace SMW\Tests;
+
+use SMW\CircularReferenceGuard;
+
+/**
+ * @covers \SMW\CircularReferenceGuard
+ *
+ * @group semantic-mediawiki
+ *
+ * @license GNU GPL v2+
+ * @since 2.2
+ *
+ * @author mwjames
+ */
+class CircularReferenceGuardTest extends \PHPUnit_Framework_TestCase {
+
+	public function testCanConstruct() {
+
+		$this->assertInstanceOf(
+			'\SMW\CircularReferenceGuard',
+			new CircularReferenceGuard()
+		);
+	}
+
+	public function testRoundtripForRegisteredNamespace() {
+
+		$instance = new CircularReferenceGuard( 'bar' );
+		$instance->setMaxRecursionDepth( 1 );
+
+		$this->assertEquals(
+			0,
+			$instance->get( 'Foo' )
+		);
+
+		$instance->mark( 'Foo' );
+		$instance->mark( 'Foo' );
+
+		$this->assertEquals(
+			2,
+			$instance->get( 'Foo' )
+		);
+
+		$this->assertTrue(
+			$instance->isCircularByRecursion( 'Foo' )
+		);
+
+		$instance->unmark( 'Foo' );
+
+		$this->assertEquals(
+			1,
+			$instance->get( 'Foo' )
+		);
+
+		$this->assertFalse(
+			$instance->isCircularByRecursion( 'Foo' )
+		);
+
+		$instance->unmark( 'notBeenMarkedBefore' );
+	}
+
+	/**
+	 * @depends testRoundtripForRegisteredNamespace
+	 */
+	public function testVerifyRetainedReferenceFromPreviousInvocation() {
+
+		$instance = new CircularReferenceGuard( 'bar' );
+
+		$this->assertEquals(
+			1,
+			$instance->get( 'Foo' )
+		);
+
+		$instance->reset( 'bar' );
+
+		$this->assertEquals(
+			0,
+			$instance->get( 'Foo' )
+		);
+	}
+
+}

--- a/tests/phpunit/includes/parserhooks/AskParserFunctionTest.php
+++ b/tests/phpunit/includes/parserhooks/AskParserFunctionTest.php
@@ -59,9 +59,13 @@ class AskParserFunctionTest extends \PHPUnit_Framework_TestCase {
 			->disableOriginalConstructor()
 			->getMock();
 
+		$circularReferenceGuard = $this->getMockBuilder( '\SMW\CircularReferenceGuard' )
+			->disableOriginalConstructor()
+			->getMock();
+
 		$this->assertInstanceOf(
 			'\SMW\AskParserFunction',
-			new AskParserFunction( $parserData, $messageFormatter )
+			new AskParserFunction( $parserData, $messageFormatter, $circularReferenceGuard )
 		);
 	}
 
@@ -79,9 +83,14 @@ class AskParserFunctionTest extends \PHPUnit_Framework_TestCase {
 			->disableOriginalConstructor()
 			->getMock();
 
+		$circularReferenceGuard = $this->getMockBuilder( '\SMW\CircularReferenceGuard' )
+			->disableOriginalConstructor()
+			->getMock();
+
 		$instance = new AskParserFunction(
 			$parserData,
-			$messageFormatter
+			$messageFormatter,
+			$circularReferenceGuard
 		);
 
 		$this->assertInternalType(
@@ -107,9 +116,14 @@ class AskParserFunctionTest extends \PHPUnit_Framework_TestCase {
 		$messageFormatter->expects( $this->once() )
 			->method( 'getHtml' );
 
+		$circularReferenceGuard = $this->getMockBuilder( '\SMW\CircularReferenceGuard' )
+			->disableOriginalConstructor()
+			->getMock();
+
 		$instance = new AskParserFunction(
 			$parserData,
-			$messageFormatter
+			$messageFormatter,
+			$circularReferenceGuard
 		);
 
 		$instance->isQueryDisabled();
@@ -125,7 +139,15 @@ class AskParserFunctionTest extends \PHPUnit_Framework_TestCase {
 			->disableOriginalConstructor()
 			->getMock();
 
-		$instance = new AskParserFunction( $parserData, $messageFormatter );
+		$circularReferenceGuard = $this->getMockBuilder( '\SMW\CircularReferenceGuard' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$instance = new AskParserFunction(
+			$parserData,
+			$messageFormatter,
+			$circularReferenceGuard
+		);
 
 		$reflector = new ReflectionClass( '\SMW\AskParserFunction' );
 		$showMode = $reflector->getProperty( 'showMode' );
@@ -135,6 +157,44 @@ class AskParserFunctionTest extends \PHPUnit_Framework_TestCase {
 		$instance->setShowMode( true );
 
 		$this->assertTrue( $showMode->getValue( $instance ) );
+	}
+
+	public function testCircularGuard() {
+
+		$parserData = $this->applicationFactory->newParserData(
+			Title::newFromText( __METHOD__ ),
+			new ParserOutput()
+		);
+
+		$messageFormatter = $this->getMockBuilder( '\SMW\MessageFormatter' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$circularReferenceGuard = $this->getMockBuilder( '\SMW\CircularReferenceGuard' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$circularReferenceGuard->expects( $this->once() )
+			->method( 'mark' );
+
+		$circularReferenceGuard->expects( $this->never() )
+			->method( 'unmark' );
+
+		$circularReferenceGuard->expects( $this->once() )
+			->method( 'isCircularByRecursion' )
+			->will( $this->returnValue( true ) );
+
+		$instance = new AskParserFunction(
+			$parserData,
+			$messageFormatter,
+			$circularReferenceGuard
+		);
+
+		$params = array();
+
+		$this->assertEmpty(
+			$instance->parse( $params )
+		);
 	}
 
 	public function testQueryIdStabilityForFixedSetOfParameters() {
@@ -148,9 +208,14 @@ class AskParserFunctionTest extends \PHPUnit_Framework_TestCase {
 			->disableOriginalConstructor()
 			->getMock();
 
+		$circularReferenceGuard = $this->getMockBuilder( '\SMW\CircularReferenceGuard' )
+			->disableOriginalConstructor()
+			->getMock();
+
 		$instance = new AskParserFunction(
 			$parserData,
-			$messageFormatter
+			$messageFormatter,
+			$circularReferenceGuard
 		);
 
 		$params = array(
@@ -200,9 +265,14 @@ class AskParserFunctionTest extends \PHPUnit_Framework_TestCase {
 			->disableOriginalConstructor()
 			->getMock();
 
+		$circularReferenceGuard = $this->getMockBuilder( '\SMW\CircularReferenceGuard' )
+			->disableOriginalConstructor()
+			->getMock();
+
 		$instance = new AskParserFunction(
 			$parserData,
-			$messageFormatter
+			$messageFormatter,
+			$circularReferenceGuard
 		);
 
 		$instance->parse( $params );

--- a/tests/phpunit/includes/parserhooks/ShowParserFunctionTest.php
+++ b/tests/phpunit/includes/parserhooks/ShowParserFunctionTest.php
@@ -51,9 +51,13 @@ class ShowParserFunctionTest extends \PHPUnit_Framework_TestCase {
 			->disableOriginalConstructor()
 			->getMock();
 
+		$circularReferenceGuard = $this->getMockBuilder( '\SMW\CircularReferenceGuard' )
+			->disableOriginalConstructor()
+			->getMock();
+
 		$this->assertInstanceOf(
 			'\SMW\ShowParserFunction',
-			new ShowParserFunction( $parserData, $messageFormatter )
+			new ShowParserFunction( $parserData, $messageFormatter, $circularReferenceGuard )
 		);
 	}
 
@@ -71,14 +75,19 @@ class ShowParserFunctionTest extends \PHPUnit_Framework_TestCase {
 			->disableOriginalConstructor()
 			->getMock();
 
+		$circularReferenceGuard = $this->getMockBuilder( '\SMW\CircularReferenceGuard' )
+			->disableOriginalConstructor()
+			->getMock();
+
 		$instance = new ShowParserFunction(
 			$parserData,
-			$messageFormatter
+			$messageFormatter,
+			$circularReferenceGuard
 		);
 
 		$result = $instance->parse( $params );
 
-		if (  $expected['output'] === '' ) {
+		if ( $expected['output'] === '' ) {
 			$this->assertEmpty( $result );
 		} else {
 			$this->assertContains( $expected['output'], $result );
@@ -102,9 +111,14 @@ class ShowParserFunctionTest extends \PHPUnit_Framework_TestCase {
 		$messageFormatter->expects( $this->once() )
 			->method( 'getHtml' );
 
+		$circularReferenceGuard = $this->getMockBuilder( '\SMW\CircularReferenceGuard' )
+			->disableOriginalConstructor()
+			->getMock();
+
 		$instance = new ShowParserFunction(
 			$parserData,
-			$messageFormatter
+			$messageFormatter,
+			$circularReferenceGuard
 		);
 
 		$instance->isQueryDisabled();
@@ -124,9 +138,14 @@ class ShowParserFunctionTest extends \PHPUnit_Framework_TestCase {
 			->disableOriginalConstructor()
 			->getMock();
 
+		$circularReferenceGuard = $this->getMockBuilder( '\SMW\CircularReferenceGuard' )
+			->disableOriginalConstructor()
+			->getMock();
+
 		$instance = new ShowParserFunction(
 			$parserData,
-			$messageFormatter
+			$messageFormatter,
+			$circularReferenceGuard
 		);
 
 		$instance->parse( $params );
@@ -146,12 +165,12 @@ class ShowParserFunctionTest extends \PHPUnit_Framework_TestCase {
 		$provider = array();
 
 		// #0
-		// {{#show: Foo
+		// {{#show: Foo-show
 		// |?Modification date
 		// }}
 		$provider[] = array(
 			array(
-				'Foo',
+				'Foo-show',
 				'?Modification date',
 			),
 			array(


### PR DESCRIPTION
Add `CircularReferenceGuard` to monitor the execution of queries invoked by the parser. `query-template-001.json` to describe a test that uses template self-references on a `#ask` query.