### PR TITLE
Strict type declaration for properties with import reference

### DIFF
--- a/i18n/en.json
+++ b/i18n/en.json
@@ -314,8 +314,9 @@
 	"log-name-smw": "Semantic MediaWiki log",
 	"log-description-smw": "Activities for [https://www.semantic-mediawiki.org/wiki/Help:Logging enabled event types] that have been reported by Semantic MediaWiki and its components.",
 	"smw-datavalue-import-unknownns":"The import namespace \"$1\" is unknown. Please ensure that owl import details are available via [[MediaWiki:Smw import $1]]",
-	"smw-datavalue-import-missing-nsuri":"Uable to find a \"$1\" namespace URI in the [[MediaWiki:Smw import $1]] import.",
-	"smw-datavalue-import-missing-type":"No type definition was found for \"$1\" in the [[MediaWiki:Smw import $2]] import.",
+	"smw-datavalue-import-missing-nsuri":"Uable to find a \"$1\" namespace URI in the [[MediaWiki:Smw import $1|$1 import]].",
+	"smw-datavalue-import-missing-type":"No type definition was found for \"$1\" in the [[MediaWiki:Smw import $2|$2 import]].",
+	"smw-datavalue-import-link":"[[MediaWiki:Smw import $1|$1 import]]",
 	"smw-pa-property-predefined_impo": "\"$1\" is a predefined property that describes a relation to an [https://semantic-mediawiki.org/wiki/Help:Import_vocabulary imported vocabulary].",
 	"smw-pa-property-predefined_type": "\"$1\" is a predefined property that describes the [[Special:Types|datatype]] of a property.",
 	"smw-pa-property-predefined_sobj": "\"$1\" is a predefined property representing a container construct that allows to accumulate property-value assignments similar to that of a normal wiki page."

--- a/includes/export/SMW_Exporter.php
+++ b/includes/export/SMW_Exporter.php
@@ -271,6 +271,22 @@ class SMWExporter {
 								}
 							}
 						}
+					} elseif ( $property->getKey() == '_IMPO' ) {
+
+						$dataValue = DataValueFactory::getInstance()->newDataItemValue(
+							$dataItem,
+							$property
+						);
+
+						if ( !$dataValue instanceof \SMWImportValue ) {
+							continue;
+						}
+
+						$expData->addPropertyObjectValue(
+							$pe,
+							self::getDataItemExpElement( new SMWDIBlob( $dataValue->getImportedFromReference() ) )
+						);
+
 					} elseif ( $property->getKey() == '_REDI' ) {
 						$expData->addPropertyObjectValue( $pe, $ed );
 						$peUri = self::getSpecialPropertyResource( '_URI' );

--- a/src/Annotator/PropertyAnnotatorFactory.php
+++ b/src/Annotator/PropertyAnnotatorFactory.php
@@ -5,6 +5,7 @@ namespace SMW\Annotator;
 use SMw\MediaWiki\RedirectTargetFinder;
 use SMW\PageInfo;
 use SMW\SemanticData;
+use SMW\Store;
 
 /**
  * @license GNU GPL v2+
@@ -82,6 +83,19 @@ class PropertyAnnotatorFactory {
 		return new CategoryPropertyAnnotator(
 			$this->newNullPropertyAnnotator( $semanticData ),
 			$categories
+		);
+	}
+
+	/**
+	 * @since 2.2
+	 *
+	 * @param SemanticData $semanticData
+	 *
+	 * @return TypeByImportPropertyAnnotator
+	 */
+	public function newTypeByImportPropertyAnnotator( SemanticData $semanticData ) {
+		return new TypeByImportPropertyAnnotator(
+			$this->newNullPropertyAnnotator( $semanticData )
 		);
 	}
 

--- a/src/Annotator/TypeByImportPropertyAnnotator.php
+++ b/src/Annotator/TypeByImportPropertyAnnotator.php
@@ -1,0 +1,98 @@
+<?php
+
+namespace SMW\Annotator;
+
+use SMW\DIProperty;
+use SMW\PropertyAnnotator;
+use SMW\DataValueFactory;
+use SMW\DataTypeRegistry;
+use SMW\Store;
+use SMWErrorValue as ErrorValue;
+
+/**
+ * Adding type from an import reference
+ *
+ * @license GNU GPL v2+
+ * @since 2.2
+ *
+ * @author mwjames
+ */
+class TypeByImportPropertyAnnotator extends PropertyAnnotatorDecorator {
+
+	/**
+	 * @since 2.2
+	 *
+	 * @param PropertyAnnotator $propertyAnnotator
+	 * @param Store $store
+	 */
+	public function __construct( PropertyAnnotator $propertyAnnotator ) {
+		parent::__construct( $propertyAnnotator );
+	}
+
+	protected function addPropertyValues() {
+
+		$subject = $this->getSemanticData()->getSubject();
+
+		if ( $subject->getNamespace() !== SMW_NS_PROPERTY ) {
+			return;
+		}
+
+		$property = DIProperty::newFromUserLabel( str_replace( '_', ' ', $subject->getDBKey() ) );
+
+		if ( !$property->isUserDefined() ) {
+			return;
+		}
+
+		$dataItems = $this->getSemanticData()->getPropertyValues(
+			new DIProperty( '_IMPO' )
+		);
+
+		if ( $dataItems === null || $dataItems === array() ) {
+			return;
+		}
+
+		$this->addTypeFromImportVocabulary( current( $dataItems ) );
+	}
+
+	private function addTypeFromImportVocabulary( $dataItem ) {
+
+		$importValue = DataValueFactory::getInstance()->newDataItemValue(
+			$dataItem,
+			new DIProperty( '_IMPO' )
+		);
+
+		if ( strpos( $importValue->getTermType(), ':' ) === false ) {
+			return;
+		}
+
+		$property = new DIProperty( '_TYPE' );
+
+		list( $ns, $type ) = explode( ':', $importValue->getTermType(), 2 );
+
+		$typeId = DataTypeRegistry::getInstance()->findTypeId( $type );
+
+		if ( $typeId === '' ) {
+			return;
+		}
+
+		$dataValue = DataValueFactory::getInstance()->newPropertyObjectValue(
+			$property,
+			$typeId
+		);
+
+		$this->replaceAnyTypeByImportType( $property, $dataValue );
+	}
+
+	private function replaceAnyTypeByImportType( DIProperty $property, $dataValue ) {
+
+		foreach ( $this->getSemanticData()->getPropertyValues( $property ) as $dataItem ) {
+			$this->getSemanticData()->removePropertyObjectValue(
+				$property,
+				$dataItem
+			);
+		}
+
+		$this->getSemanticData()->addDataValue( $dataValue );
+	}
+
+}

--- a/src/MediaWiki/Hooks/ParserAfterTidy.php
+++ b/src/MediaWiki/Hooks/ParserAfterTidy.php
@@ -72,30 +72,44 @@ class ParserAfterTidy {
 
 		$this->applicationFactory = ApplicationFactory::getInstance();
 
-		$parserData = $this->applicationFactory
-			->newParserData( $this->parser->getTitle(), $this->parser->getOutput() );
+		$parserData = $this->applicationFactory->newParserData(
+			$this->parser->getTitle(),
+			$this->parser->getOutput()
+		);
 
-		$propertyAnnotator = $this->applicationFactory
-			->newPropertyAnnotatorFactory()
-			->newSortkeyPropertyAnnotator(
-				$parserData->getSemanticData(),
-				$this->parser->getDefaultSort() );
-
-		$propertyAnnotator->addAnnotation();
-
-		$propertyAnnotator = $this->applicationFactory
-			->newPropertyAnnotatorFactory()
-			->newCategoryPropertyAnnotator(
-				$parserData->getSemanticData(),
-				$this->parser->getOutput()->getCategoryLinks() );
-
-		$propertyAnnotator->addAnnotation();
+		$this->updateAnnotionsForAfterParse(
+			$this->applicationFactory->newPropertyAnnotatorFactory(),
+			$parserData->getSemanticData()
+		);
 
 		$parserData->pushSemanticDataToParserOutput();
 
 		$this->checkForRequestedUpdateByPagePurge( $parserData );
 
 		return true;
+	}
+
+	private function updateAnnotionsForAfterParse( $propertyAnnotatorFactory, $semanticData ) {
+
+		$propertyAnnotator = $propertyAnnotatorFactory->newSortkeyPropertyAnnotator(
+			$semanticData,
+			$this->parser->getDefaultSort()
+		);
+
+		$propertyAnnotator->addAnnotation();
+
+		$propertyAnnotator = $propertyAnnotatorFactory->newCategoryPropertyAnnotator(
+			$semanticData,
+			$this->parser->getOutput()->getCategoryLinks()
+		);
+
+		$propertyAnnotator->addAnnotation();
+
+		$propertyAnnotator = $propertyAnnotatorFactory->newTypeByImportPropertyAnnotator(
+			$semanticData
+		);
+
+		$propertyAnnotator->addAnnotation();
 	}
 
 	/**

--- a/tests/phpunit/Integration/Rdf/rdf-003-import-foaf.json
+++ b/tests/phpunit/Integration/Rdf/rdf-003-import-foaf.json
@@ -10,7 +10,12 @@
 		{
 			"name": "Foaf:homepage",
 			"namespace": "SMW_NS_PROPERTY",
-			"contents": "[[Has type::URL]] [[Imported from::foaf:homepage]]"
+			"contents": "[[Imported from::foaf:homepage]]"
+		},
+		{
+			"name": "Foaf:mbox",
+			"namespace": "SMW_NS_PROPERTY",
+			"contents": "[[Has type::Text]] [[Imported from::foaf:mbox]]"
 		},
 		{
 			"name": "Foaf:name",
@@ -93,6 +98,40 @@
 					"<swivt:specialImportedFrom rdf:datatype=\"http://www.w3.org/2001/XMLSchema#string\">foaf knows http://xmlns.com/foaf/0.1/</swivt:specialImportedFrom>",
 					"<swivt:type rdf:resource=\"http://semantic-mediawiki.org/swivt/1.0#_wpg\"/>",
 					"<owl:ObjectProperty rdf:about=\"http://semantic-mediawiki.org/swivt/1.0#type\" />"
+				]
+			}
+		},
+		{
+			"about": "#3 type definition fetched from import reference",
+			"exportcontroller-print-pages" : [ "Property:Foaf:homepage" ],
+			"parameters" : {
+				"backlinks" : false,
+				"recursion" : "1",
+				"revisiondate" : false
+			},
+			"output": {
+				"as-string": [
+					"<owl:ObjectProperty rdf:about=\"http://xmlns.com/foaf/0.1/homepage\">",
+					"<swivt:specialImportedFrom rdf:datatype=\"http://www.w3.org/2001/XMLSchema#string\">foaf homepage http://xmlns.com/foaf/0.1/</swivt:specialImportedFrom>",
+					"<swivt:type rdf:resource=\"http://semantic-mediawiki.org/swivt/1.0#_uri\"/>",
+					"<owl:DatatypeProperty rdf:about=\"http://semantic-mediawiki.org/swivt/1.0#specialImportedFrom\" />"
+				]
+			}
+		},
+		{
+			"about": "#4 user declared type definition being replaced by import type reference",
+			"exportcontroller-print-pages" : [ "Property:Foaf:mbox" ],
+			"parameters" : {
+				"backlinks" : false,
+				"recursion" : "1",
+				"revisiondate" : false
+			},
+			"output": {
+				"as-string": [
+					"<owl:ObjectProperty rdf:about=\"http://xmlns.com/foaf/0.1/mbox\">",
+					"<swivt:specialImportedFrom rdf:datatype=\"http://www.w3.org/2001/XMLSchema#string\">foaf mbox http://xmlns.com/foaf/0.1/</swivt:specialImportedFrom>",
+					"<swivt:type rdf:resource=\"http://semantic-mediawiki.org/swivt/1.0#_ema\"/>",
+					"<owl:DatatypeProperty rdf:about=\"http://semantic-mediawiki.org/swivt/1.0#specialImportedFrom\" />"
 				]
 			}
 		}

--- a/tests/phpunit/includes/Annotator/PropertyAnnotatorFactoryTest.php
+++ b/tests/phpunit/includes/Annotator/PropertyAnnotatorFactoryTest.php
@@ -105,4 +105,18 @@ class PropertyAnnotatorFactoryTest extends \PHPUnit_Framework_TestCase {
 		);
 	}
 
+	public function testNewTypeByImportPropertyAnnotator() {
+
+		$semanticData = $this->getMockBuilder( '\SMW\SemanticData' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$instance = new PropertyAnnotatorFactory();
+
+		$this->assertInstanceOf(
+			'\SMW\Annotator\TypeByImportPropertyAnnotator',
+			$instance->newTypeByImportPropertyAnnotator( $semanticData )
+		);
+	}
+
 }

--- a/tests/phpunit/includes/Annotator/TypeByImportPropertyAnnotatorTest.php
+++ b/tests/phpunit/includes/Annotator/TypeByImportPropertyAnnotatorTest.php
@@ -1,0 +1,236 @@
+<?php
+
+namespace SMW\Tests\Annotator;
+
+use SMW\Tests\Utils\UtilityFactory;
+
+use SMW\Annotator\TypeByImportPropertyAnnotator;
+use SMW\Annotator\NullPropertyAnnotator;
+use SMW\DIProperty;
+use SMW\DIWikiPage;
+use SMW\DataValueFactory;
+use SMWDIBlob as DIBlob;
+use SMWDIUri as DIUri;
+
+/**
+ * @covers \SMW\Annotator\TypeByImportPropertyAnnotator
+ *
+ * @group semantic-mediawiki
+ *
+ * @license GNU GPL v2+
+ * @since 2.2
+ *
+ * @author mwjames
+ */
+class TypeByImportPropertyAnnotatorTest extends \PHPUnit_Framework_TestCase {
+
+	private $semanticDataFactory;
+	private $semanticDataValidator;
+
+	protected function setUp() {
+		parent::setUp();
+
+		$this->semanticDataFactory = UtilityFactory::getInstance()->newSemanticDataFactory();
+		$this->semanticDataValidator = UtilityFactory::getInstance()->newValidatorFactory()->newSemanticDataValidator();
+	}
+
+	public function testCanConstruct() {
+
+		$semanticData = $this->getMockBuilder( '\SMW\SemanticData' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$instance = new TypeByImportPropertyAnnotator(
+			new NullPropertyAnnotator( $semanticData )
+		);
+
+		$this->assertInstanceOf(
+			'\SMW\Annotator\TypeByImportPropertyAnnotator',
+			$instance
+		);
+	}
+
+	public function testNoImportForNoProperty() {
+
+		$subject = DIWikiPage::newFromText( __METHOD__ );
+
+		$semanticData = $this->getMockBuilder( '\SMW\SemanticData' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$semanticData->expects( $this->once() )
+			->method( 'getSubject' )
+			->will( $this->returnValue( $subject ) );
+
+		$semanticData->expects( $this->never() )
+			->method( 'getPropertyValues' );
+
+		$instance = new TypeByImportPropertyAnnotator(
+			new NullPropertyAnnotator( $semanticData )
+		);
+
+		$instance->addAnnotation();
+	}
+
+	public function testNoImportForPredefinedProperty() {
+
+		$subject = DIWikiPage::newFromText( 'Modification date', SMW_NS_PROPERTY );
+
+		$semanticData = $this->getMockBuilder( '\SMW\SemanticData' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$semanticData->expects( $this->once() )
+			->method( 'getSubject' )
+			->will( $this->returnValue( $subject ) );
+
+		$semanticData->expects( $this->never() )
+			->method( 'getPropertyValues' );
+
+		$instance = new TypeByImportPropertyAnnotator(
+			new NullPropertyAnnotator( $semanticData )
+		);
+
+		$instance->addAnnotation();
+	}
+
+	public function testValidImportTypeReferenceToSetType() {
+
+		$semanticData = $this->semanticDataFactory->newEmptySemanticData(
+			DIWikiPage::newFromText( __METHOD__, SMW_NS_PROPERTY )
+		);
+
+		$importValue = DataValueFactory::getInstance()->newDataItemValue(
+			new DIBlob( 'foo' . ' ' . 'bar' . ' ' . 'buz' . ' ' . 'Type:Text' ),
+			new DIProperty( '_IMPO' )
+		);
+
+		$semanticData->addDataValue( $importValue );
+
+		$instance = new TypeByImportPropertyAnnotator(
+			new NullPropertyAnnotator( $semanticData )
+		);
+
+		$instance->addAnnotation();
+
+		$expected = array(
+			'properties' => array( new DIProperty( '_TYPE' ), new DIProperty( '_IMPO' ) ),
+			'propertyValues' => array( 'Text', 'foo:bar' )
+		);
+
+		$this->semanticDataValidator->assertThatPropertiesAreSet(
+			$expected,
+			$instance->getSemanticData()
+		);
+	}
+
+	public function testValidImportTypeReferenceToOverrideUserType() {
+
+		$semanticData = $this->semanticDataFactory->newEmptySemanticData(
+			DIWikiPage::newFromText( __METHOD__, SMW_NS_PROPERTY )
+		);
+
+		$importValue = DataValueFactory::getInstance()->newDataItemValue(
+			new DIBlob( 'foo' . ' ' . 'bar' . ' ' . 'buz' . ' ' . 'Type:Page' ),
+			new DIProperty( '_IMPO' )
+		);
+
+		$semanticData->addDataValue( $importValue );
+
+		$typeValue = DataValueFactory::getInstance()->newDataItemValue(
+			new DIUri( 'http', 'semantic-mediawiki.org/swivt/1.0', '', '_txt' ),
+			new DIProperty( '_TYPE' )
+		);
+
+		$semanticData->addDataValue( $typeValue );
+
+		$instance = new TypeByImportPropertyAnnotator(
+			new NullPropertyAnnotator( $semanticData )
+		);
+
+		// Check before
+		$expected = array(
+			'properties' => array( new DIProperty( '_TYPE' ), new DIProperty( '_IMPO' ) ),
+			'propertyValues' => array( 'Text', 'foo:bar' )
+		);
+
+		$this->semanticDataValidator->assertThatPropertiesAreSet(
+			$expected,
+			$instance->getSemanticData()
+		);
+
+		$instance->addAnnotation();
+
+		// Check after
+		$expected = array(
+			'properties' => array( new DIProperty( '_TYPE' ), new DIProperty( '_IMPO' ) ),
+			'propertyValues' => array( 'Page', 'foo:bar' )
+		);
+
+		$this->semanticDataValidator->assertThatPropertiesAreSet(
+			$expected,
+			$instance->getSemanticData()
+		);
+	}
+
+	public function testInvalidImportTypeReferenceDoesNotSetAnyType() {
+
+		$semanticData = $this->semanticDataFactory->newEmptySemanticData(
+			DIWikiPage::newFromText( __METHOD__, SMW_NS_PROPERTY )
+		);
+
+		$importValue = DataValueFactory::getInstance()->newDataItemValue(
+			new DIBlob( 'foo' . ' ' . 'bar' . ' ' . 'buz' . ' ' . 'Type-Text' ),
+			new DIProperty( '_IMPO' )
+		);
+
+		$semanticData->addDataValue( $importValue );
+
+		$instance = new TypeByImportPropertyAnnotator(
+			new NullPropertyAnnotator( $semanticData )
+		);
+
+		$instance->addAnnotation();
+
+		$expected = array(
+			'properties' => array( new DIProperty( '_IMPO' ) ),
+			'propertyValues' => array( 'foo:bar' )
+		);
+
+		$this->semanticDataValidator->assertThatPropertiesAreSet(
+			$expected,
+			$instance->getSemanticData()
+		);
+	}
+
+	public function testBogusImportTypeDoesNotSetAnyType() {
+
+		$semanticData = $this->semanticDataFactory->newEmptySemanticData(
+			DIWikiPage::newFromText( __METHOD__, SMW_NS_PROPERTY )
+		);
+
+		$importValue = DataValueFactory::getInstance()->newDataItemValue(
+			new DIBlob( 'foo' . ' ' . 'bar' . ' ' . 'buz' . ' ' . 'Type:Bogus' ),
+			new DIProperty( '_IMPO' )
+		);
+
+		$semanticData->addDataValue( $importValue );
+
+		$instance = new TypeByImportPropertyAnnotator(
+			new NullPropertyAnnotator( $semanticData )
+		);
+
+		$instance->addAnnotation();
+
+		$expected = array(
+			'properties' => array( new DIProperty( '_IMPO' ) ),
+			'propertyValues' => array( 'foo:bar' )
+		);
+
+		$this->semanticDataValidator->assertThatPropertiesAreSet(
+			$expected,
+			$instance->getSemanticData()
+		);
+	}
+
+}

--- a/tests/phpunit/includes/MediaWiki/Hooks/ParserAfterTidyTest.php
+++ b/tests/phpunit/includes/MediaWiki/Hooks/ParserAfterTidyTest.php
@@ -38,6 +38,12 @@ class ParserAfterTidyTest extends \PHPUnit_Framework_TestCase {
 		$this->semanticDataValidator = new SemanticDataValidator();
 		$this->applicationFactory = ApplicationFactory::getInstance();
 		$this->parserFactory = new ParserFactory();
+
+		$store = $this->getMockBuilder( '\SMW\Store' )
+			->disableOriginalConstructor()
+			->getMockForAbstractClass();
+
+		$this->applicationFactory->registerObject( 'Store', $store );
 	}
 
 	protected function tearDown() {


### PR DESCRIPTION
A user-defined property with a reference to an imported property `Imported from` could define a different datatype than that of the imported property. This can introduce inconsistencies for type declarations in properties.

`TypeByImportPropertyAnnotator` will use the type definition if it finds an import property reference `Imported from` and replace it with any other datatype specified.

`[[Has type::Page]] [[Imported from::foaf:name]]` with `foaf:name` declared as `Text` will take precedence over the `Page` type declaration.

refs #886, #464