### PR TITLE
Exporter to add <swivt:file> to point to "real" file resource

### DIFF
--- a/includes/export/SMW_Exporter.php
+++ b/includes/export/SMW_Exporter.php
@@ -197,11 +197,25 @@ class SMWExporter {
 				$result->addPropertyObjectValue( self::getSpecialNsResource( 'rdfs', 'isDefinedBy' ), $ed );
 				$ed = new SMWExpLiteral( strval( $diWikiPage->getNamespace() ), 'http://www.w3.org/2001/XMLSchema#integer' );
 				$result->addPropertyObjectValue( self::getSpecialNsResource( 'swivt', 'wikiNamespace' ), $ed );
+
 				if ( $addStubData ) {
 					// Add a default sort key; for pages that exist in the wiki,
 					// this is set during parsing
 					$defaultSortkey = new SMWExpLiteral( $diWikiPage->getSortKey() );
 					$result->addPropertyObjectValue( self::getSpecialPropertyResource( '_SKEY' ), $defaultSortkey );
+				}
+
+				if ( $diWikiPage->getNamespace() === NS_FILE ) {
+
+					$title = Title::makeTitle( $diWikiPage->getNamespace(), $diWikiPage->getDBkey() ) ;
+					$file = wfFindFile( $title );
+
+					if ( $file !== false ) {
+						$result->addPropertyObjectValue(
+							self::getSpecialNsResource( 'swivt', 'file' ),
+							new SMWExpResource( $file->getFullURL() )
+						);
+					}
 				}
 			}
 		}
@@ -346,13 +360,6 @@ class SMWExporter {
 	 * @return SMWExpResource
 	 */
 	static public function getResourceElementForWikiPage( SMWDIWikiPage $diWikiPage, $modifier = '' ) {
-		if ( $diWikiPage->getNamespace() == NS_MEDIA ) { // special handling for linking media files directly (object only)
-			$title = Title::makeTitle( $diWikiPage->getNamespace(), $diWikiPage->getDBkey() ) ;
-			$file = wfFindFile( $title );
-			if ( $file !== false ) {
-				return new SMWExpResource( $file->getFullURL() );
-			} // else: Medialink to non-existing file :-/ fall through
-		}
 
 		$hash = $diWikiPage->getHash() . $modifier;
 

--- a/tests/phpunit/Integration/Rdf/RdfFileResourceTest.php
+++ b/tests/phpunit/Integration/Rdf/RdfFileResourceTest.php
@@ -1,0 +1,107 @@
+<?php
+
+namespace SMW\Tests\Integration\MediaWiki\Hooks;
+
+use SMW\Tests\Utils\UtilityFactory;
+use SMW\Tests\MwDBaseUnitTestCase;
+
+use SMW\DIWikiPage;
+use SMW\Localizer;
+use SMW\ApplicationFactory;
+use SMWExportController as ExportController;
+use SMWRDFXMLSerializer as RDFXMLSerializer;
+use Title;
+
+/**
+ * @group semantic-mediawiki-integration
+ * @group medium
+ *
+ * @license GNU GPL v2+
+ * @since   2.2
+ *
+ * @author mwjames
+ */
+class RdfFileResourceTest extends MwDBaseUnitTestCase {
+
+	private $fixturesFileProvider;
+	private $stringValidator;
+
+	/**
+	 * MW GLOBALS to be restored after the test
+	 */
+	private $wgFileExtensions;
+	private $wgEnableUploads;
+	private $wgVerifyMimeType;
+
+	protected function setUp() {
+		parent::setUp();
+
+		$utilityFactory = UtilityFactory::getInstance();
+
+		$this->fixturesFileProvider = $utilityFactory->newFixturesFactory()->newFixturesFileProvider();
+		$this->stringValidator = UtilityFactory::getInstance()->newValidatorFactory()->newStringValidator();
+
+		$this->applicationFactory = ApplicationFactory::getInstance();
+
+		$settings = array(
+			'smwgPageSpecialProperties' => array( '_MEDIA', '_MIME' ),
+			'smwgNamespacesWithSemanticLinks' => array( NS_MAIN => true, NS_FILE => true ),
+			'smwgCacheType' => 'hash',
+		);
+
+		foreach ( $settings as $key => $value ) {
+			$this->applicationFactory->getSettings()->set( $key, $value );
+		}
+
+		$this->wgEnableUploads  = $GLOBALS['wgEnableUploads'];
+		$this->wgFileExtensions = $GLOBALS['wgFileExtensions'];
+		$this->wgVerifyMimeType = $GLOBALS['wgVerifyMimeType'];
+
+		$GLOBALS['wgEnableUploads'] = true;
+		$GLOBALS['wgFileExtensions'] = array( 'txt' );
+		$GLOBALS['wgVerifyMimeType'] = true;
+	}
+
+	protected function tearDown() {
+
+		$GLOBALS['wgEnableUploads'] = $this->wgEnableUploads;
+		$GLOBALS['wgFileExtensions'] = $this->wgFileExtensions;
+		$GLOBALS['wgVerifyMimeType'] = $this->wgVerifyMimeType;
+
+		parent::tearDown();
+	}
+
+	public function testFileUploadForDummyTextFile() {
+
+		$subject = new DIWikiPage( 'RdfLinkedFile.txt', NS_FILE );
+		$fileNS = Localizer::getInstance()->getNamespaceTextById( NS_FILE );
+
+		$dummyTextFile = $this->fixturesFileProvider->newUploadForDummyTextFile( 'RdfLinkedFile.txt' );
+		$dummyTextFile->doUpload( '[[HasFile::File:RdfLinkedFile.txt]]' );
+
+		$exportController = new ExportController( new RDFXMLSerializer() );
+		$exportController->enableBacklinks( false );
+
+		ob_start();
+
+		$exportController->printPages(
+			array( $subject->getTitle()->getPrefixedDBKey() )
+		);
+
+		$output = ob_get_clean();
+
+		$expected = array(
+			"<rdfs:label>{$fileNS}:RdfLinkedFile.txt</rdfs:label>",
+			'<swivt:file rdf:resource="' . $dummyTextFile->getLocalFile()->getFullURL() . '"/>',
+			'<property:Media_type-23aux rdf:datatype="http://www.w3.org/2001/XMLSchema#string">TEXT</property:Media_type-23aux>',
+			'<property:MIME_type-23aux rdf:datatype="http://www.w3.org/2001/XMLSchema#string">text/plain</property:MIME_type-23aux>'
+		);
+
+		$this->stringValidator->assertThatStringContains(
+			$expected,
+			$output
+		);
+	}
+
+
+}


### PR DESCRIPTION
The `File` namespace can host pages that can contain annotations as any other page therefore the assumptions about "special handling for linking media files directly (object only)" is incorrect. Adding an extra `<swivt:file>` statement allows to point the the "real" resource that the `File` page is a placeholder for.