### PR TITLE
Fix coding style issues #899 in tests/

### DIFF
--- a/includes/ParameterInput.php
+++ b/includes/ParameterInput.php
@@ -123,7 +123,7 @@ class ParameterInput {
 			$html = $this->param->isList() ? $this->getCheckboxListInput( $valueList ) : $this->getSelectInput( $valueList );
 		}
 
-			return $html;
+		return $html;
 	}
 
 	/**

--- a/includes/ParameterInput.php
+++ b/includes/ParameterInput.php
@@ -101,7 +101,7 @@ class ParameterInput {
 		if ( is_array( $this->param->getAllowedValues() ) ) {
 			$valueList = $this->param->getAllowedValues();
 		}
-		
+
 		if ( $valueList === array() ) {
 			switch ( $this->param->getType() ) {
 				case 'char':
@@ -117,13 +117,13 @@ class ParameterInput {
 				default:
 					$html = $this->getStrInput();
 					break;
-					}
-					}
-        else {
-			$html = $this->param->isList() ? $this->getCheckboxListInput( $valueList ) : $this->getSelectInput( $valueList );
 			}
-        
-        return $html;
+		}
+		else {
+			$html = $this->param->isList() ? $this->getCheckboxListInput( $valueList ) : $this->getSelectInput( $valueList );
+		}
+
+			return $html;
 	}
 
 	/**

--- a/includes/ParameterInput.php
+++ b/includes/ParameterInput.php
@@ -9,54 +9,54 @@ use Xml;
 /**
  * Simple class to get a HTML input for the parameter.
  * Usable for when creating a GUI from a parameter list.
- * 
+ *
  * Based on 'addOptionInput' from Special:Ask in SMW 1.5.6.
- * 
+ *
  * TODO: nicify HTML
- * 
+ *
  * @since 1.9
- * 
+ *
  * @ingroup SMW
- * 
+ *
  * @licence GNU GPL v2+
  * @author Jeroen De Dauw < jeroendedauw@gmail.com >
  */
 class ParameterInput {
-	
+
 	/**
 	 * The parameter to print an input for.
-	 * 
+	 *
 	 * @since 1.9
-	 * 
+	 *
 	 * @var ParamDefinition
 	 */
 	protected $param;
-	
+
 	/**
 	 * The current value for the parameter. When provided,
 	 * it'll be used as value for the input, otherwise the
 	 * parameters default value will be used.
-	 * 
+	 *
 	 * @since 1.9
-	 * 
+	 *
 	 * @var mixed: string or false
 	 */
 	protected $currentValue;
-	
+
 	/**
 	 * Name for the input.
-	 * 
+	 *
 	 * @since 1.9
-	 * 
+	 *
 	 * @var string
 	 */
 	protected $inputName;
-	
+
 	/**
 	 * Constructor.
-	 * 
+	 *
 	 * @since 1.9
-	 * 
+	 *
 	 * @param ParamDefinition $param
 	 * @param mixed $currentValue
 	 */
@@ -65,34 +65,34 @@ class ParameterInput {
 		$this->inputName = $param->getName();
 		$this->param = $param;
 	}
-	
+
 	/**
 	 * Sets the current value.
-	 * 
+	 *
 	 * @since 1.9
-	 * 
+	 *
 	 * @param mixed $currentValue
-	 */	
+	 */
 	public function setCurrentValue( $currentValue ) {
 		$this->currentValue = $currentValue;
 	}
-	
+
 	/**
 	 * Sets the name for the input; defaults to the name of the parameter.
-	 * 
+	 *
 	 * @since 1.9
-	 * 
+	 *
 	 * @param string $name
 	 */
 	public function setInputName( $name ) {
 		$this->inputName = $name;
 	}
-	
+
 	/**
 	 * Returns the HTML for the parameter input.
-	 * 
+	 *
 	 * @since 1.9
-	 * 
+	 *
 	 * @return string
 	 */
 	public function getHtml() {
@@ -122,34 +122,34 @@ class ParameterInput {
         else {
 			$html = $this->param->isList() ? $this->getCheckboxListInput( $valueList ) : $this->getSelectInput( $valueList );
         }
-        
+
         return $html;
 	}
-	
+
 	/**
 	 * Returns the value to initially display with the input.
-	 * 
+	 *
 	 * @since 1.9
-	 * 
+	 *
 	 * @return string
 	 */
 	protected function getValueToUse() {
 		$value = $this->currentValue === false ? $this->param->getDefault() : $this->currentValue;
-		
+
 		if ( $this->param->isList() && is_array( $value ) ) {
 			$value = implode( $this->param->getDelimiter(), $value );
 		}
-		
+
 		return $value;
 	}
-	
+
 	/**
 	 * Gets a short text input suitable for numbers.
-	 * 
+	 *
 	 * @since 1.9
-	 * 
+	 *
 	 * @return string
-	 */		
+	 */
 	protected function getNumberInput() {
 		return Html::input(
 			$this->inputName,
@@ -161,14 +161,14 @@ class ParameterInput {
 			)
 		);
 	}
-	
+
 	/**
 	 * Gets a text input for a string.
-	 * 
+	 *
 	 * @since 1.9
-	 * 
+	 *
 	 * @return string
-	 */		
+	 */
 	protected function getStrInput() {
 		return Html::input(
 			$this->inputName,
@@ -180,39 +180,39 @@ class ParameterInput {
 			)
 		);
 	}
-	
+
 	/**
 	 * Gets a checkbox.
-	 * 
+	 *
 	 * @since 1.9
-	 * 
+	 *
 	 * @return string
-	 */	
+	 */
 	protected function getBooleanInput() {
 		return Xml::check(
 			$this->inputName,
 			$this->getValueToUse()
 		);
-	}	
-	
+	}
+
 	/**
 	 * Gets a select menu for the provided values.
-	 * 
+	 *
 	 * @since 1.9
-	 * 
+	 *
 	 * @param array $valueList
-	 * 
+	 *
 	 * @return string
-	 */	
+	 */
 	protected function getSelectInput( array $valueList ) {
 		$options = array();
 		$options[] = '<option value=""></option>';
-		
+
 		$currentValues = (array)$this->getValueToUse();
 		if ( is_null( $currentValues ) ) {
 			$currentValues = array();
 		}
-		
+
 		foreach ( $valueList as $value ) {
 			$options[] =
 				'<option value="' . htmlspecialchars( $value ) . '"' .
@@ -228,14 +228,14 @@ class ParameterInput {
 			implode( "\n", $options )
 		);
 	}
-	
+
 	/**
 	 * Gets a list of input boxes for the provided values.
-	 * 
+	 *
 	 * @since 1.9
-	 * 
+	 *
 	 * @param array $valueList
-	 * 
+	 *
 	 * @return string
 	 */
 	protected function getCheckboxListInput( array $valueList ) {
@@ -245,7 +245,7 @@ class ParameterInput {
 		if ( is_null( $currentValues ) ) {
 			$currentValues = array();
 		}
-		
+
 		foreach ( $valueList as $value ) {
 			$boxes[] = Html::rawElement(
 				'span',
@@ -259,8 +259,8 @@ class ParameterInput {
 				Html::element( 'tt', array(), $value )
 			);
 		}
-		
+
 		return implode( "\n", $boxes );
 	}
-	
+
 }

--- a/includes/ParameterInput.php
+++ b/includes/ParameterInput.php
@@ -101,8 +101,8 @@ class ParameterInput {
 		if ( is_array( $this->param->getAllowedValues() ) ) {
 			$valueList = $this->param->getAllowedValues();
 		}
-
-        if ( $valueList === array() ) {
+		
+		if ( $valueList === array() ) {
 			switch ( $this->param->getType() ) {
 				case 'char':
 				case 'float':
@@ -117,12 +117,12 @@ class ParameterInput {
 				default:
 					$html = $this->getStrInput();
 					break;
-			}
-        }
+					}
+					}
         else {
 			$html = $this->param->isList() ? $this->getCheckboxListInput( $valueList ) : $this->getSelectInput( $valueList );
-        }
-
+			}
+        
         return $html;
 	}
 

--- a/includes/SMW_Outputs.php
+++ b/includes/SMW_Outputs.php
@@ -40,15 +40,15 @@ class SMWOutputs {
 	 * to the output.
 	 */
 	protected static $scripts = array();
-	
+
 	/// Protected member for temporarily storing resource modules.
 	protected static $resourceModules = array();
 
 	/**
 	 * Adds a resource module to the parser output.
-	 * 
+	 *
 	 * @since 1.5.3
-	 * 
+	 *
 	 * @param string $moduleName
 	 */
 	public static function requireResource( $moduleName ) {
@@ -60,17 +60,17 @@ class SMWOutputs {
 	 * enclosing script tags. Note that the same could be achieved with
 	 * requireHeadItems, but scripts use a special method "addScript" in
 	 * MediaWiki OutputPage, hence we distinguish them.
-	 * 
+	 *
 	 * The id is used to avoid that the requirement for one script is
 	 * recorded multiple times in SMWOutputs.
-	 * 
+	 *
 	 * @param string $id
 	 * @param string $item
 	 */
 	public static function requireScript( $id, $script ) {
 		self::$scripts[$id] = $script;
 	}
-	
+
 	/**
 	 * Adds head items that are not Resource Loader modules. Should only
 	 * be used for custom head items such as RSS fedd links.
@@ -80,7 +80,7 @@ class SMWOutputs {
 	 *
 	 * Support for calling this with the old constants SMW_HEADER_STYLE
 	 * and SMW_HEADER_TOOLTIP will vanish in SMW 1.7 at the latest.
-	 * 
+	 *
 	 * @param mixed $id
 	 * @param string $item
 	 */

--- a/includes/SMW_PageLister.php
+++ b/includes/SMW_PageLister.php
@@ -10,9 +10,9 @@ use SMW\Query\PrintRequest;
  * different places where similar lists are used.
  *
  * Some code adapted from CategoryPage.php
- * 
+ *
  * @ingroup SMW
- * 
+ *
  * @author Nikolas Iwan
  * @author Markus Krötzsch
  * @author Jeroen De Dauw
@@ -96,7 +96,7 @@ class SMWPageLister {
 
 	/**
 	 * Format an HTML link with the given text and parameters.
-	 * 
+	 *
 	 * @return string
 	 */
 	protected function makeSelfLink( Title $title, $linkText, array $parameters ) {
@@ -199,17 +199,17 @@ class SMWPageLister {
 	/**
 	 * Format a list of SMWDIWikiPage objects chunked by letter in a three-column
 	 * list, ordered vertically.
-	 * 
+	 *
 	 * @param $start integer
 	 * @param $end integer
 	 * @param $diWikiPages array of SMWDIWikiPage
 	 * @param $diProperty SMWDIProperty that the wikipages are values of, or null
-	 * 
+	 *
 	 * @return string
 	 */
 	public static function getColumnList( $start, $end, array $diWikiPages, $diProperty ) {
 		global $wgContLang;
-		
+
 		// Divide list into three equal chunks.
 		$chunk = (int) ( ( $end - $start + 1 ) / 3 );
 
@@ -268,12 +268,12 @@ class SMWPageLister {
 
 	/**
 	 * Format a list of diWikiPages chunked by letter in a bullet list.
-	 * 
+	 *
 	 * @param $start integer
 	 * @param $end integer
 	 * @param $diWikiPages array of SMWDataItem
 	 * @param $diProperty SMWDIProperty that the wikipages are values of, or null
-	 * 
+	 *
 	 * @return string
 	 */
 	public static function getShortList( $start, $end, array $diWikiPages, $diProperty ) {

--- a/includes/dataitems/SMW_DI_GeoCoord.php
+++ b/includes/dataitems/SMW_DI_GeoCoord.php
@@ -16,23 +16,23 @@ class SMWDIGeoCoord extends SMWDataItem {
 
 	/**
 	 * The locations latitude.
-	 * 
+	 *
 	 * @since 1.6
 	 * @var float
 	 */
 	protected $latitude;
-	
+
 	/**
 	 * The locations longitude.
-	 * 
+	 *
 	 * @since 1.6
 	 * @var float
 	 */
 	protected $longitude;
-	
+
 	/**
 	 * The locations altitude.
-	 * 
+	 *
 	 * @since 1.7
 	 * @var float|null
 	 */
@@ -43,19 +43,19 @@ class SMWDIGeoCoord extends SMWDataItem {
 	 * Takes a latitude and longitude, and optionally an altitude. These can be provided in 2 forms:
 	 * * An associative array with lat, lon and alt keys
 	 * * Lat, lon and alt arguments
-	 * 
+	 *
 	 * The second way to provide the arguments, as well as the altitude argument, where introduced in SMW 1.7.
 	 */
 	public function __construct() {
 		$args = func_get_args();
-		
+
 		$count = count( $args );
-		
+
 		if ( $count === 1 && is_array( $args[0] ) ) {
 			if ( array_key_exists( 'lat', $args[0] ) && array_key_exists( 'lon', $args[0] ) ) {
 				$this->latitude = (float)$args[0]['lat'];
 				$this->longitude = (float)$args[0]['lon'];
-				
+
 				if ( array_key_exists( 'alt', $args[0] ) ) {
 					$this->altitude = (float)$args[0]['alt'];
 				}
@@ -67,7 +67,7 @@ class SMWDIGeoCoord extends SMWDataItem {
 		elseif ( $count === 2 || $count === 3 ) {
 			$this->latitude = (float)$args[0];
 			$this->longitude = (float)$args[1];
-			
+
 			if ( $count === 3 ) {
 				$this->altitude = (float)$args[2];
 			}
@@ -84,22 +84,22 @@ class SMWDIGeoCoord extends SMWDataItem {
 	public function getDIType() {
 		return SMWDataItem::TYPE_GEO;
 	}
-	
+
 	/**
 	 * Returns the coordinate set as an array with lat and long (and alt) keys
 	 * pointing to float values.
-	 * 
+	 *
 	 * @since 1.6
 	 *
 	 * @return array
 	 */
 	public function getCoordinateSet() {
 		$coords = array( 'lat' => $this->latitude, 'lon' => $this->longitude );
-		
+
 		if ( !is_null( $this->altitude ) ) {
 			$coords['alt'] = $this->altitude;
 		}
-		
+
 		return $coords;
 	}
 
@@ -125,57 +125,57 @@ class SMWDIGeoCoord extends SMWDataItem {
 	 * ID.
 	 * @note PHP can convert any string to some number, so we do not do
 	 * validation here (because this would require less efficient parsing).
-	 * 
+	 *
 	 * @since 1.6
-	 * 
+	 *
 	 * @param string $serialization
-	 * 
+	 *
 	 * @return SMWDIGeoCoord
 	 */
 	public static function doUnserialize( $serialization ) {
 		$parts = explode( ',', $serialization );
 		$count = count( $parts );
-		
+
 		if ( $count !== 2 && $count !== 3 ) {
 			throw new DataItemException( 'Unserialization of coordinates failed' );
 		}
-		
+
 		$coords = array( 'lat' => (float)$parts[0], 'lon' => (float)$parts[1] );
-		
+
 		if ( $count === 3 ) {
 			$coords['alt'] = (float)$parts[2];
 		}
 
 		return new self( $coords );
 	}
-	
+
 	/**
 	 * Returns the latitude.
-	 * 
+	 *
 	 * @since 1.6
-	 * 
+	 *
 	 * @return float
 	 */
 	public function getLatitude() {
 		return $this->latitude;
 	}
-	
+
 	/**
 	 * Returns the longitude.
-	 * 
+	 *
 	 * @since 1.6
-	 * 
+	 *
 	 * @return float
 	 */
 	public function getLongitude() {
 		return $this->longitude;
 	}
-	
+
 	/**
 	 * Returns the altitude if set, null otherwise.
-	 * 
+	 *
 	 * @since 1.7
-	 * 
+	 *
 	 * @return float|null
 	 */
 	public function getAltitude() {

--- a/includes/dataitems/SMW_DI_Time.php
+++ b/includes/dataitems/SMW_DI_Time.php
@@ -10,7 +10,7 @@ use SMW\DataItemException;
  * Even when not specified, the data item always assumes default values for the
  * missing parts, so the item really captures one point in time, no intervals.
  * Times are always assumed to be in UTC.
- * 
+ *
  * "Y0K issue": Neither the Gregorian nor the Julian calendar assume a year 0,
  * i.e. the year 1 BC(E) was followed by 1 AD/CE. See
  * http://en.wikipedia.org/wiki/Year_zero
@@ -88,7 +88,7 @@ class SMWDITime extends SMWDataItem {
 	 * be false to indicate that they are not specified. This will affect
 	 * the internal precision setting. The missing values are initialised
 	 * to minimal values (0 or 1) for internal calculations.
-	 * 
+	 *
 	 * @param $calendarmodel integer one of SMWDITime::CM_GREGORIAN or SMWDITime::CM_JULIAN
 	 * @param $year integer number of the year (possibly negative)
 	 * @param $month mixed integer number or false
@@ -199,9 +199,9 @@ class SMWDITime extends SMWDataItem {
 
 	/**
 	 * Returns a MW timestamp representatation of the value.
-	 * 
+	 *
 	 * @since 1.6.2
-	 * 
+	 *
 	 * @param $outputtype
 	 *
 	 * @return mixed
@@ -283,7 +283,7 @@ class SMWDITime extends SMWDataItem {
 	public static function doUnserialize( $serialization ) {
 		$parts = explode( '/', $serialization, 7 );
 		$values = array();
-		
+
 		for ( $i = 0; $i < 7; $i += 1 ) {
 			if ( $i < count( $parts ) ) {
 				if ( is_numeric( $parts[$i] ) ) {
@@ -295,11 +295,11 @@ class SMWDITime extends SMWDataItem {
 				$values[$i] = false;
 			}
 		}
-		
+
 		if ( count( $parts ) <= 1 ) {
 			throw new DataItemException( "Unserialization failed: the string \"$serialization\" is no valid URI." );
 		}
-		
+
 		return new self( $values[0], $values[1], $values[2], $values[3], $values[4], $values[5], $values[6] );
 	}
 

--- a/includes/dataitems/SMW_DI_URI.php
+++ b/includes/dataitems/SMW_DI_URI.php
@@ -68,7 +68,7 @@ class SMWDIUri extends SMWDataItem {
 		$schemesWithDoubleslesh = array(
 			'http', 'https', 'ftp'
 		);
-		
+
 		$uri = $this->m_scheme . ':'
 			. ( in_array( $this->m_scheme, $schemesWithDoubleslesh ) ? '//' : '' )
 			. $this->m_hierpart
@@ -125,9 +125,9 @@ class SMWDIUri extends SMWDataItem {
 			$hierpart = $parts[0];
 			$fragment = ( count( $parts ) == 2 ) ? $parts[1] : '';
 		}
-		
+
 		$hierpart = ltrim( $hierpart, '/' );
-		
+
 		return new SMWDIUri( $scheme, $hierpart, $query, $fragment );
 	}
 

--- a/includes/export/SMW_Exp_Element.php
+++ b/includes/export/SMW_Exp_Element.php
@@ -51,7 +51,7 @@ abstract class SMWExpElement {
  * objects of class SMWExpElement or any of its subclasses represent a blank
  * node if their name is empty or of the form "_id" where "id" is any
  * identifier string. IDs are local to the current context, such as a list of
- * triples or an SMWExpData container. 
+ * triples or an SMWExpData container.
  *
  * @ingroup SMW
  */
@@ -80,7 +80,7 @@ class SMWExpResource extends SMWExpElement {
 
 		$this->uri = $uri;
 	}
-	
+
 	/**
 	 * Return true if this resource represents a blank node.
 	 *
@@ -213,7 +213,7 @@ class SMWExpNsResource extends SMWExpResource {
 /**
  * A single datatype literal for export. Defined by a literal value and a
  * datatype URI.
- * 
+ *
  * @todo Currently no support for language tags.
  *
  * @ingroup SMW
@@ -225,7 +225,7 @@ class SMWExpLiteral extends SMWExpElement {
 	 * @var string
 	 */
 	protected $datatype;
-	
+
 	/**
 	 * Lexical form of the literal.
 	 * @var string

--- a/includes/params/SMW_ParamFormat.php
+++ b/includes/params/SMW_ParamFormat.php
@@ -6,13 +6,13 @@ use SMW\Query\PrintRequest;
 
 /**
  * Definition for the format parameter.
- * 
+ *
  * @since 1.6.2
  * @deprecated since 1.9
- * 
+ *
  * @ingroup SMW
  * @ingroup ParamDefinition
- * 
+ *
  * @licence GNU GPL v2+
  * @author Jeroen De Dauw < jeroendedauw@gmail.com >
  */
@@ -22,9 +22,9 @@ class SMWParamFormat extends StringParam {
 	 * List of the queries print requests, used to determine the format
 	 * when it's not provided. Set with setPrintRequests before passing
 	 * to Validator.
-	 * 
+	 *
 	 * @since 1.6.2
-	 * 
+	 *
 	 * @var PrintRequest[]
 	 */
 	protected $printRequests = array();
@@ -33,18 +33,18 @@ class SMWParamFormat extends StringParam {
 	 * Takes a format name, which can be an alias and returns a format name
 	 * which will be valid for sure. Aliases are resolved. If the given
 	 * format name is invalid, the predefined default format will be returned.
-	 * 
+	 *
 	 * @since 1.6.2
-	 * 
+	 *
 	 * @param string $value
-	 * 
+	 *
 	 * @return string
 	 */
 	protected function getValidFormatName( $value ) {
 		global $smwgResultFormats;
-		
+
 		$value = strtolower( trim( $value ) );
-		
+
 		if ( !array_key_exists( $value, $smwgResultFormats ) ) {
 			$isAlias = self::resolveFormatAliases( $value );
 
@@ -56,7 +56,7 @@ class SMWParamFormat extends StringParam {
 
 		return $value;
 	}
-	
+
 	/**
 	 * Turns format aliases into main formats.
 	 *
@@ -81,13 +81,13 @@ class SMWParamFormat extends StringParam {
 
 		return $isAlias;
 	}
-	
+
 	/**
 	 * Determines and returns the default format, based on the queries print
 	 * requests, if provided.
-	 * 
+	 *
 	 * @since 1.6.2
-	 * 
+	 *
 	 * @return string Array key in $smwgResultFormats
 	 */
 	protected function getDefaultFormat() {
@@ -96,30 +96,30 @@ class SMWParamFormat extends StringParam {
 		}
 		else {
 			$format = false;
-			
+
 			/**
 			 * This hook allows extensions to override SMWs implementation of default result
 			 * format handling.
-			 * 
+			 *
 			 * @since 1.5.2
 			 */
-			wfRunHooks( 'SMWResultFormat', array( &$format, $this->printRequests, array() ) );		
+			wfRunHooks( 'SMWResultFormat', array( &$format, $this->printRequests, array() ) );
 
 			// If no default was set by an extension, use a table or list, depending on the column count.
 			if ( $format === false ) {
 				$format = count( $this->printRequests ) == 1 ? 'list' : 'table';
 			}
-			
+
 			return $format;
 		}
 	}
-	
+
 	/**
 	 * Sets the print requests of the query, used for determining
 	 * the default format if none is provided.
-	 * 
+	 *
 	 * @since 1.6.2
-	 * 
+	 *
 	 * @param PrintRequest[] $printRequests
 	 */
 	public function setPrintRequests( array $printRequests ) {

--- a/includes/parserhooks/ConceptParserFunction.php
+++ b/includes/parserhooks/ConceptParserFunction.php
@@ -123,8 +123,7 @@ class ConceptParserFunction {
 	}
 
 	private function buildQuery( $conceptQueryString ) {
-
- 		$rawParams = array( $conceptQueryString );
+		$rawParams = array( $conceptQueryString );
 
 		list( $query, ) = SMWQueryProcessor::getQueryAndParamsFromFunctionParams(
 			$rawParams,

--- a/includes/query/SMW_Query.php
+++ b/includes/query/SMW_Query.php
@@ -157,7 +157,7 @@ class SMWQuery {
 	 */
 	public function setOffset( $offset ) {
 		global $smwgQMaxLimit;
- 		$this->offset = min( $smwgQMaxLimit, $offset ); // select integer between 0 and maximal limit;
+		$this->offset = min( $smwgQMaxLimit, $offset ); // select integer between 0 and maximal limit;
 		$this->limit = min( $smwgQMaxLimit - $this->offset, $this->limit ); // note that limit might become 0 here
 		return $this->offset;
 	}

--- a/includes/query/SMW_QueryLanguage.php
+++ b/includes/query/SMW_QueryLanguage.php
@@ -2,53 +2,53 @@
 
 /**
  * Static class for functions related to the SMW query language.
- * 
+ *
  * Note: the query language "definition" is located at various places in the SMW codebase.
  * SMWQueryParser defines most of the actual query syntax.
  * SMWDescription defines the semantic elements of the query language.
  * This class is an attempt to gradualy migrate to having all the stuff at one location,
  * clearly distinguised from non-language code.
- * 
+ *
  * @since 1.5.3
- * 
+ *
  * @ingroup SMW
- * 
+ *
  * @author Jeroen De Dauw
  */
 final class SMWQueryLanguage {
-	
+
 	/**
 	 * Associative array that maps the comparator strings (keys) to
 	 * the SMW_CMP_ enum (values). Call initializeComparators before using.
-	 * 
+	 *
 	 * @since 1.5.3
-	 * 
+	 *
 	 * @var array
 	 */
 	protected static $comparators = array();
-	
+
 	/**
 	 * Gets an array with all suported comparator strings.
 	 * The string for SMW_CMP_EQ, which is an empty string, is not in this list.
-	 * 
+	 *
 	 * @since 1.5.3
-	 * 
+	 *
 	 * @return array
 	 */
 	public static function getComparatorStrings() {
 		self::initializeComparators();
 		return array_keys( self::$comparators );
 	}
-	
+
 	/**
 	 * Gets the SMW_CMP_ for a string comparator, falling back to the
 	 * $defaultComparator when none is found.
-	 * 
+	 *
 	 * @since 1.5.3
-	 * 
+	 *
 	 * @param string $string
 	 * @param integer $defaultComparator Item of the SMW_CMP_ enum
-	 * 
+	 *
 	 * @return integer Item of the SMW_CMP_ enum
 	 */
 	public static function getComparatorFromString( $string, $defaultComparator = SMW_CMP_EQ ) {
@@ -56,14 +56,14 @@ final class SMWQueryLanguage {
 		if ( $string === '' ) return SMW_CMP_EQ;
 		return array_key_exists( $string, self::$comparators ) ? self::$comparators[$string] : $defaultComparator;
 	}
-	
+
 	/**
-	 * Gets the comparator string for a comparator. 
-	 * 
+	 * Gets the comparator string for a comparator.
+	 *
 	 * @since 1.5.3
-	 * 
+	 *
 	 * @param $comparator
-	 * 
+	 *
 	 * @return string
 	 */
 	public static function getStringForComparator( $comparator ) {
@@ -82,10 +82,10 @@ final class SMWQueryLanguage {
 			throw new Exception( "Comparator $comparator does not have a string representatation" );
 		}
 	}
-	
+
 	/**
 	 * Initializes the $comparators field.
-	 * 
+	 *
 	 * @since 1.5.3
 	 */
 	protected static function initializeComparators() {
@@ -95,9 +95,9 @@ final class SMWQueryLanguage {
 		if ( $initialized ) {
 			return;
 		}
-		
+
 		$initialized = true;
-		
+
 		// Note: Comparators that contain other comparators at the beginning of the string need to be at beginning of the array.
 		$comparators = array(
 			'!~' => SMW_CMP_NLKE,
@@ -111,8 +111,8 @@ final class SMWQueryLanguage {
 			'~' => SMW_CMP_LIKE,
 		);
 
-		$allowedComparators = explode( '|', $smwgQComparators );		
-		
+		$allowedComparators = explode( '|', $smwgQComparators );
+
 		// Remove the comparators that are not allowed.
 		foreach ( $comparators as $string => $comparator ) {
 			if ( !in_array( $string, $allowedComparators ) ) {
@@ -122,5 +122,5 @@ final class SMWQueryLanguage {
 
 		self::$comparators = $comparators;
 	}
-	
+
 }

--- a/includes/specials/SMW_SpecialBrowse.php
+++ b/includes/specials/SMW_SpecialBrowse.php
@@ -429,7 +429,7 @@ class SMWSpecialBrowse extends SpecialPage {
 	 */
 	private function unbreak( $text ) {
 		$nonBreakingSpace = html_entity_decode( '&#160;', ENT_NOQUOTES, 'UTF-8' );
- 		$text = preg_replace( '/[\s]/u', $nonBreakingSpace, $text, - 1, $count );
+		$text = preg_replace( '/[\s]/u', $nonBreakingSpace, $text, - 1, $count );
  		return $count > 2 ? preg_replace( '/($nonBreakingSpace)/u', ' ', $text, max( 0, $count - 2 ) ):$text;
 	}
 }

--- a/includes/specials/SMW_SpecialBrowse.php
+++ b/includes/specials/SMW_SpecialBrowse.php
@@ -430,6 +430,6 @@ class SMWSpecialBrowse extends SpecialPage {
 	private function unbreak( $text ) {
 		$nonBreakingSpace = html_entity_decode( '&#160;', ENT_NOQUOTES, 'UTF-8' );
 		$text = preg_replace( '/[\s]/u', $nonBreakingSpace, $text, - 1, $count );
- 		return $count > 2 ? preg_replace( '/($nonBreakingSpace)/u', ' ', $text, max( 0, $count - 2 ) ):$text;
+		return $count > 2 ? preg_replace( '/($nonBreakingSpace)/u', ' ', $text, max( 0, $count - 2 ) ):$text;
 	}
 }

--- a/includes/specials/SMW_SpecialOWLExport.php
+++ b/includes/specials/SMW_SpecialOWLExport.php
@@ -77,9 +77,9 @@ class SMWSpecialOWLExport extends SpecialPage {
 		global $wgOut, $wgUser, $smwgAllowRecursiveExport, $smwgExportBacklinks, $smwgExportAll;
 
 		$html = '<form name="tripleSearch" action="" method="POST">' . "\n" .
-                '<p>' . wfMessage( 'smw_exportrdf_docu' )->text() . "</p>\n" .
-                '<input type="hidden" name="postform" value="1"/>' . "\n" .
-                '<textarea name="pages" cols="40" rows="10"></textarea><br />' . "\n";
+					'<p>' . wfMessage( 'smw_exportrdf_docu' )->text() . "</p>\n" .
+					'<input type="hidden" name="postform" value="1"/>' . "\n" .
+					'<textarea name="pages" cols="40" rows="10"></textarea><br />' . "\n";
 
 		if ( $wgUser->isAllowed( 'delete' ) || $smwgAllowRecursiveExport ) {
 			$html .= '<input type="checkbox" name="recursive" value="1" id="rec">&#160;<label for="rec">' . wfMessage( 'smw_exportrdf_recursive' )->text() . '</label></input><br />' . "\n";

--- a/includes/storage/SMW_ResultArray.php
+++ b/includes/storage/SMW_ResultArray.php
@@ -5,31 +5,31 @@ use SMW\Query\PrintRequest;
  * Container for the contents of a single result field of a query result,
  * i.e. basically an array of SMWDataItems with some additional parameters.
  * The content of the array is fetched on demand only.
- * 
+ *
  * @ingroup SMWQuery
- * 
+ *
  * @author Markus Krötzsch
  * @author Jeroen De Dauw < jeroendedauw@gmail.com >
  */
 class SMWResultArray {
-	
+
 	/**
 	 * @var PrintRequest
 	 */
 	protected $mPrintRequest;
-	
+
 	/**
 	 * @var SMWDIWikiPage
 	 */
 	protected $mResult;
-	
+
 	/**
 	 * @var SMWStore
 	 */
 	protected $mStore;
-	
+
 	/**
-	 * @var array of SMWDataItem or false 
+	 * @var array of SMWDataItem or false
 	 */
 	protected $mContent;
 
@@ -38,7 +38,7 @@ class SMWResultArray {
 
 	/**
 	 * Constructor.
-	 * 
+	 *
 	 * @param SMWDIWikiPage $resultPage
 	 * @param PrintRequest $printRequest
 	 * @param SMWStore $store
@@ -63,7 +63,7 @@ class SMWResultArray {
 	 * Returns the SMWDIWikiPage object to which this SMWResultArray refers.
 	 * If you only care for those objects, consider using SMWQueryResult::getResults()
 	 * directly.
-	 * 
+	 *
 	 * @return SMWDIWikiPage
 	 */
 	public function getResultSubject() {
@@ -73,7 +73,7 @@ class SMWResultArray {
 	/**
 	 * Returns an array of SMWDataItem objects that contain the results of
 	 * the given print request for the given result object.
-	 * 
+	 *
 	 * @return array of SMWDataItem or false
 	 */
 	public function getContent() {
@@ -84,7 +84,7 @@ class SMWResultArray {
 	/**
 	 * Return a PrintRequest object describing what is contained in this
 	 * result set.
-	 * 
+	 *
 	 * @return PrintRequest
 	 */
 	public function getPrintRequest() {
@@ -101,9 +101,9 @@ class SMWResultArray {
 
 	/**
 	 * Return the next SMWDataItem object or false if no further object exists.
-	 * 
+	 *
 	 * @since 1.6
-	 * 
+	 *
 	 * @return SMWDataItem or false
 	 */
 	public function getNextDataItem() {
@@ -117,9 +117,9 @@ class SMWResultArray {
 	 * Set the internal pointer of the array of SMWDataItem objects to its first
 	 * element. Return the first SMWDataItem object or false if the array is
 	 * empty.
-	 * 
+	 *
 	 * @since 1.7.1
-	 * 
+	 *
 	 * @return SMWDataItem or false
 	 */
 	public function reset() {
@@ -130,9 +130,9 @@ class SMWResultArray {
 	/**
 	 * Return an SMWDataValue object for the next SMWDataItem object or
 	 * false if no further object exists.
-	 * 
+	 *
 	 * @since 1.6
-	 * 
+	 *
 	 * @return SMWDataValue or false
 	 */
 	public function getNextDataValue() {
@@ -195,7 +195,7 @@ class SMWResultArray {
 	 */
 	protected function loadContent() {
 		if ( $this->mContent !== false ) return;
-		
+
 
 		switch ( $this->mPrintRequest->getMode() ) {
 			case PrintRequest::PRINT_THIS: // NOTE: The limit is ignored here.
@@ -206,7 +206,7 @@ class SMWResultArray {
 				self::$catCache = $this->mStore->getPropertyValues( $this->mResult,
 					new SMWDIProperty( '_INST' ), $this->getRequestOptions( false ) );
 				self::$catCacheObj = $this->mResult->getHash();
-				
+
 				$limit = $this->mPrintRequest->getParameter( 'limit' );
 				$this->mContent = ( $limit === false ) ? ( self::$catCache ) :
 					array_slice( self::$catCache, 0, $limit );
@@ -223,7 +223,7 @@ class SMWResultArray {
 				// Print one component of a multi-valued string.
 				// Known limitation: the printrequest still is of type _rec, so if printers check
 				// for this then they will not recognize that it returns some more concrete type.
-				if ( ( $this->mPrintRequest->getTypeID() == '_rec' ) && 
+				if ( ( $this->mPrintRequest->getTypeID() == '_rec' ) &&
 				     ( $this->mPrintRequest->getParameter( 'index' ) !== false ) ) {
 					$pos = $this->mPrintRequest->getParameter( 'index' ) - 1;
 					$newcontent = array();
@@ -231,7 +231,7 @@ class SMWResultArray {
 					foreach ( $this->mContent as $diContainer ) {
 						/* SMWRecordValue */ $recordValue = \SMW\DataValueFactory::getInstance()->newDataItemValue( $diContainer, $propertyValue->getDataItem() );
 						$dataItems = $recordValue->getDataItems();
-						
+
 						if ( array_key_exists( $pos, $dataItems ) &&
 							( !is_null( $dataItems[$pos] ) ) ) {
 							$newcontent[] = $dataItems[$pos];
@@ -260,9 +260,9 @@ class SMWResultArray {
 			break;
 			default: $this->mContent = array(); // Unknown print request.
 		}
-		
+
 		reset( $this->mContent );
-		
+
 	}
 
 	/**
@@ -270,21 +270,21 @@ class SMWResultArray {
 	 * return NULL if no such object is required. The parameter defines
 	 * if the limit should be taken into account, which is not always desired
 	 * (especially if results are to be cached for future use).
-	 * 
+	 *
 	 * @param boolean $useLimit
-	 * 
+	 *
 	 * @return SMWRequestOptions or null
 	 */
 	protected function getRequestOptions( $useLimit = true ) {
 		$limit = $useLimit ? $this->mPrintRequest->getParameter( 'limit' ) : false;
 		$order = trim( $this->mPrintRequest->getParameter( 'order' ) );
-		
+
 		// Important: use "!=" for order, since trim() above does never return "false", use "!==" for limit since "0" is meaningful here.
-		if ( ( $limit !== false ) || ( $order != false ) ) { 
+		if ( ( $limit !== false ) || ( $order != false ) ) {
 			$options = new SMWRequestOptions();
-			
+
 			if ( $limit !== false ) $options->limit = trim( $limit );
-			
+
 			if ( ( $order == 'descending' ) || ( $order == 'reverse' ) || ( $order == 'desc' ) ) {
 				$options->sort = true;
 				$options->ascending = false;
@@ -295,8 +295,8 @@ class SMWResultArray {
 		} else {
 			$options = null;
 		}
-		
+
 		return $options;
 	}
-	
+
 }

--- a/includes/storage/SQLStore/SMW_SQLStore3_Queries.php
+++ b/includes/storage/SQLStore/SMW_SQLStore3_Queries.php
@@ -246,8 +246,8 @@ class SMWSQLStore3QueryEngine {
 
 		// Possibly stop if new errors happened:
 		if ( !$smwgIgnoreQueryErrors &&
-                     $query->querymode != SMWQuery::MODE_DEBUG &&
-                     count( $this->errors ) > 0 ) {
+				$query->querymode != SMWQuery::MODE_DEBUG &&
+				count( $this->errors ) > 0 ) {
 			$query->addErrors( $this->errors );
 			return new SMWQueryResult( $query->getDescription()->getPrintrequests(), $query, array(), $this->store, false );
 		}

--- a/includes/storage/SQLStore/SMW_SQLStore3_Readers.php
+++ b/includes/storage/SQLStore/SMW_SQLStore3_Readers.php
@@ -39,7 +39,7 @@ class SMWSQLStore3Readers {
 	/**
 	 * @see SMWStore::getSemanticData()
 	 * @since 1.8
-	 * 
+	 *
 	 * @param DIWikiPage $subject
 	 * @param string[]|bool $filter
 	 */

--- a/includes/storage/SQLStore/SMW_SQLStore3_Writers.php
+++ b/includes/storage/SQLStore/SMW_SQLStore3_Writers.php
@@ -201,7 +201,7 @@ class SMWSQLStore3Writers {
 		);
 
 		// Take care of all remaining property table data
- 		list( $deleteRows, $insertRows, $newHashes ) = $this->preparePropertyTableUpdates( $sid, $data );
+		list( $deleteRows, $insertRows, $newHashes ) = $this->preparePropertyTableUpdates( $sid, $data );
 
 		$this->writePropertyTableUpdates(
 			$sid,

--- a/tests/phpunit/Utils/Fixtures/FixturesProvider.php
+++ b/tests/phpunit/Utils/Fixtures/FixturesProvider.php
@@ -106,7 +106,7 @@ class FixturesProvider {
 		$id = strtolower( $id );
 
 		if ( $this->properties === null ) {
-			$this->properties = $this->getListOfPropertyInstances();;
+			$this->properties = $this->getListOfPropertyInstances();
 		};
 
 		if ( isset( $this->properties[$id] ) ) {
@@ -127,7 +127,7 @@ class FixturesProvider {
 		$id = strtolower( $id );
 
 		if ( $this->categories === null ) {
-			$this->categories = $this->getListOfCategoryInstances();;
+			$this->categories = $this->getListOfCategoryInstances();
 		};
 
 		if ( isset( $this->categories[$id] ) ) {
@@ -148,7 +148,7 @@ class FixturesProvider {
 		$id = strtolower( $id );
 
 		if ( $this->factsheets === null ) {
-			$this->factsheets = $this->getListOfFactsheetInstances();;
+			$this->factsheets = $this->getListOfFactsheetInstances();
 		};
 
 		if ( isset( $this->factsheets[$id] ) ) {

--- a/tests/phpunit/Utils/Runners/JobQueueRunner.php
+++ b/tests/phpunit/Utils/Runners/JobQueueRunner.php
@@ -121,7 +121,7 @@ class JobQueueRunner {
 	 * @see https://gerrit.wikimedia.org/r/#/c/162009/
 	 */
 	private function pop() {
- 		$offset = 0;
+		$offset = 0;
 
 		if ( class_exists( 'JobQueueGroup' ) ) {
 			return JobQueueGroup::singleton()->pop();


### PR DESCRIPTION
I summarized the ones that are left in [tests/](https://github.com/jongfeli/Code-violations-SemanticMediaWiki/blob/master/tests.txt). I am more then happy to fix those that can be fixed or improved but not without help. I would appreciate if someone could mark the ones that can be fixed or improved and if so explain how to do this, when possible. 

And for the ones that can not be fixed but should be sniffed should we use @codingStandardsIgnoreStart and @codingStandardsIgnoreEnd tags like suggested in #899 but how? I had look in [ConjunctionConditionBuilder.php] but I am not sure if this is correct:

Now:
```php
            if ( $subCondition instanceof FalseCondition ) {
				return new FalseCondition();
			} elseif ( $subCondition instanceof TrueCondition ) {
				// ignore true conditions in a conjunction
			} elseif ( $subCondition instanceof WhereCondition ) {
				$subConditionElements->condition .= $subCondition->condition;
			} elseif ( $subCondition instanceof FilterCondition ) {
```

Becomes:
```php
            if ( $subCondition instanceof FalseCondition ) {
				return new FalseCondition();
			} // @codingStandardsIgnoreStart
			elseif ( $subCondition instanceof TrueCondition ) {
				// ignore true conditions in a conjunction
			} // @codingStandardsIgnoreEnd
			elseif ( $subCondition instanceof WhereCondition ) {
				$subConditionElements->condition .= $subCondition->condition;
			} elseif ( $subCondition instanceof FilterCondition ) {
```