### PR TITLE
Guard against circular reference in a concept query

### DIFF
--- a/i18n/en.json
+++ b/i18n/en.json
@@ -326,5 +326,6 @@
 	"smw-pa-property-predefined_errp": "\"$1\" is a predefined property to track input errors for irregular value annotations that was likely caused by type or [[Property:Allows value|allowed value]] restrictions.",
 	"smw-pa-property-predefined_pval": "[https://www.semantic-mediawiki.org/wiki/Help:Special_property_Allows_value\"$1\"] is a predefined property that can define a list of permissible values to restrict value assignments for a property.",
 	"smw-datavalue-property-restricted-use": "Property \"$1\" was marked for restricted use.",
-	"smw-datavalue-restricted-use": "This datavalue was marked for restricted use. $1"
+	"smw-datavalue-restricted-use": "This datavalue was marked for restricted use. $1",
+	"smw-query-condition-circular": "A possible circular condition has been detected in \"$1\"."
 }

--- a/includes/parserhooks/AskParserFunction.php
+++ b/includes/parserhooks/AskParserFunction.php
@@ -138,12 +138,11 @@ class AskParserFunction {
 		$queryHash = $this->query->getHash();
 
 		$this->circularReferenceGuard->mark( $queryHash );
-		$this->circularReferenceGuard->setMaxRecursionDepth( 2 );
 
 		// If we caught in a circular loop (due to a template referencing to itself)
 		// then we stop here before the next query execution to avoid an infinite
 		// self-reference
-		if ( $this->circularReferenceGuard->isCircularByRecursion( $queryHash ) ) {
+		if ( $this->circularReferenceGuard->isCircularByRecursionFor( $queryHash ) ) {
 			return '';
 		}
 

--- a/includes/parserhooks/ParserFunctionFactory.php
+++ b/includes/parserhooks/ParserFunctionFactory.php
@@ -63,6 +63,7 @@ class ParserFunctionFactory {
 	public function newAskParserFunction() {
 
 		$circularReferenceGuard = new CircularReferenceGuard( 'ask-parser' );
+		$circularReferenceGuard->setMaxRecursionDepth( 2 );
 
 		$parserData = ApplicationFactory::getInstance()->newParserData(
 			$this->parser->getTitle(),
@@ -88,6 +89,7 @@ class ParserFunctionFactory {
 	public function newShowParserFunction() {
 
 		$circularReferenceGuard = new CircularReferenceGuard( 'show-parser' );
+		$circularReferenceGuard->setMaxRecursionDepth( 2 );
 
 		$parserData = ApplicationFactory::getInstance()->newParserData(
 			$this->parser->getTitle(),

--- a/src/CircularReferenceGuard.php
+++ b/src/CircularReferenceGuard.php
@@ -78,7 +78,7 @@ class CircularReferenceGuard {
 	 *
 	 * @return boolean
 	 */
-	public function isCircularByRecursion( $hash ) {
+	public function isCircularByRecursionFor( $hash ) {
 		return $this->get( $hash ) > $this->maxRecursionDepth;
 	}
 

--- a/src/SPARQLStore/QueryEngine/CompoundConditionBuilder.php
+++ b/src/SPARQLStore/QueryEngine/CompoundConditionBuilder.php
@@ -5,6 +5,7 @@ namespace SMW\SPARQLStore\QueryEngine;
 use RuntimeException;
 use SMW\DataTypeRegistry;
 use SMW\DIProperty;
+use SMW\CircularReferenceGuard;
 use SMW\Query\Language\Description;
 use SMW\Query\Language\SomeProperty;
 use SMW\Query\Language\ThingDescription;
@@ -29,9 +30,19 @@ use SMWTurtleSerializer as TurtleSerializer;
 class CompoundConditionBuilder {
 
 	/**
+	 * @var CircularReferenceGuard
+	 */
+	private $circularReferenceGuard = null;
+
+	/**
 	 * @var ConditionBuilderStrategyFinder
 	 */
 	private $conditionBuilderStrategyFinder = null;
+
+	/**
+	 * @var array
+	 */
+	private $errors = array();
 
 	/**
 	 * Counter used to generate globally fresh variables.
@@ -78,6 +89,42 @@ class CompoundConditionBuilder {
 	 */
 	public function getSortKeys() {
 		return $this->sortkeys;
+	}
+
+	/**
+	 * @since 2.2
+	 *
+	 * @return array
+	 */
+	public function getErrors() {
+		return $this->errors;
+	}
+
+	/**
+	 * @since 2.2
+	 *
+	 * @param string $error
+	 */
+	public function addError( $error ) {
+		$this->errors[] = $error;
+	}
+
+	/**
+	 * @since 2.2
+	 *
+	 * @param CircularReferenceGuard $circularReferenceGuard
+	 */
+	public function setCircularReferenceGuard( CircularReferenceGuard $circularReferenceGuard ) {
+		$this->circularReferenceGuard = $circularReferenceGuard;
+	}
+
+	/**
+	 * @since 2.2
+	 *
+	 * @return CircularReferenceGuard
+	 */
+	public function getCircularReferenceGuard() {
+		return $this->circularReferenceGuard;
 	}
 
 	/**

--- a/src/SQLStore/QueryEngine/QueryBuilder.php
+++ b/src/SQLStore/QueryEngine/QueryBuilder.php
@@ -14,6 +14,7 @@ use SMW\SQLStore\QueryEngine\Interpreter\ThingDescriptionInterpreter;
 use SMW\SQLStore\QueryEngine\Interpreter\ValueDescriptionInterpreter;
 use SMW\SQLStore\QueryEngine\Interpreter\DispatchingInterpreter;
 use SMW\Store;
+use SMW\CircularReferenceGuard;
 
 /**
  * @license GNU GPL v2+
@@ -80,6 +81,9 @@ class QueryBuilder {
 		$this->dispatchingInterpreter->addInterpreter( new ClassDescriptionInterpreter( $this ) );
 		$this->dispatchingInterpreter->addInterpreter( new ValueDescriptionInterpreter( $this ) );
 		$this->dispatchingInterpreter->addInterpreter( new ConceptDescriptionInterpreter( $this ) );
+
+		$this->circularReferenceGuard = new CircularReferenceGuard( 'sql-query' );
+		$this->circularReferenceGuard->setMaxRecursionDepth( 2 );
 	}
 
 	/**
@@ -110,6 +114,15 @@ class QueryBuilder {
 	 */
 	public function getSortKeys() {
 		return $this->sortKeys;
+	}
+
+	/**
+	 * @since 2.2
+	 *
+	 * @return CircularReferenceGuard
+	 */
+	public function getCircularReferenceGuard() {
+		return $this->circularReferenceGuard;
 	}
 
 	/**

--- a/tests/phpunit/Integration/Query/Fixtures/query-concept-001.json
+++ b/tests/phpunit/Integration/Query/Fixtures/query-concept-001.json
@@ -49,7 +49,7 @@
 			"contents": "{{#concept: [[Concept:Concept for any value selection]] OR [[Concept:Concept for distinct value selection]] }}"
 		}
 	],
-	"concepts": [
+	"concept-testcases": [
 		{
 			"about": "#0 Simple concept member list",
 			"condition": "[[Concept:Concept for any value selection]]",

--- a/tests/phpunit/Integration/Query/Fixtures/query-concept-002-circular.json
+++ b/tests/phpunit/Integration/Query/Fixtures/query-concept-002-circular.json
@@ -1,0 +1,94 @@
+{
+	"description": "Check guard against circular/self-reference, otherwise it would fail with 'Maximum function nesting level ... reached, aborting' ",
+	"properties": [
+		{
+			"name": "Has concept description",
+			"contents": "[[Has type::Text]]"
+		}
+	],
+	"subjects": [
+		{
+			"name": "Page one",
+			"contents": "[[Has concept description::Bar]]"
+		},
+		{
+			"name": "Page two",
+			"contents": "[[Has concept description::Foo]]"
+		},
+		{
+			"name": "Concept-is-not-circular",
+			"namespace": "SMW_NS_CONCEPT",
+			"contents": "{{#concept: [[Has concept description::+]] }}"
+		},
+		{
+			"name": "Concept-is-circular",
+			"namespace": "SMW_NS_CONCEPT",
+			"contents": "{{#concept: [[Concept:Concept-is-circular]] }}"
+		},
+		{
+			"name": "Concept-is-circular-extra",
+			"namespace": "SMW_NS_CONCEPT",
+			"contents": "{{#concept: [[Has concept description::+]] [[Concept:Concept-is-circular-extra]] }}"
+		}
+	],
+	"concept-testcases": [
+		{
+			"about": "#0 Check simple concept list",
+			"condition": "[[Concept:Concept-is-not-circular]]",
+			"parameters" : {
+				"limit" : "10"
+			},
+			"queryresult": {
+				"count": "2"
+			},
+			"conceptcache": [
+				{
+					"concept": "Concept-is-not-circular",
+					"count": "2"
+				}
+			]
+		},
+		{
+			"about": "#1 Check for circular concept",
+			"condition": "[[Concept:Concept-is-circular]]",
+			"parameters" : {
+				"limit" : "10"
+			},
+			"queryresult": {
+				"count": 0,
+				"error": 1
+			},
+			"conceptcache": [
+				{
+					"concept": "Concept-is-circular",
+					"count": null
+				}
+			]
+		},
+		{
+			"about": "#2 Check for circular concept",
+			"condition": "[[Concept:Concept-is-circular-extra]]",
+			"parameters" : {
+				"limit" : "10"
+			},
+			"queryresult": {
+				"count": 0,
+				"error": 1
+			},
+			"conceptcache": [
+				{
+					"concept": "Concept-is-circular-extra",
+					"count": null
+				}
+			]
+		}
+	],
+	"settings": {},
+	"meta": {
+		"skip-on": {
+			"postgres": "Unable to run concept tests on postgres, see #781"
+		},
+		"version": "0.1",
+		"is-incomplete": false
+	}
+}

--- a/tests/phpunit/Integration/Query/QueryTestCaseInterpreter.php
+++ b/tests/phpunit/Integration/Query/QueryTestCaseInterpreter.php
@@ -191,6 +191,20 @@ class QueryTestCaseInterpreter {
 	/**
 	 * @since 2.2
 	 *
+	 * @return integer
+	 */
+	public function getExpectedErrorCount() {
+
+		if ( !isset( $this->contents['queryresult']['error'] )  ) {
+			return 0;
+		}
+
+		return (int)$this->contents['queryresult']['error'];
+	}
+
+	/**
+	 * @since 2.2
+	 *
 	 * @return string
 	 */
 	public function fetchTextOutputForFormatPage() {
@@ -228,7 +242,7 @@ class QueryTestCaseInterpreter {
 	 * @return []
 	 */
 	public function getExpectedConceptCache() {
-		return $this->contents['conceptcache'];
+		return isset( $this->contents['conceptcache'] ) ? $this->contents['conceptcache'] : array();
 	}
 
 }

--- a/tests/phpunit/Integration/Query/QueryTestCaseProcessor.php
+++ b/tests/phpunit/Integration/Query/QueryTestCaseProcessor.php
@@ -101,6 +101,12 @@ class QueryTestCaseProcessor extends \PHPUnit_Framework_TestCase {
 			'Failed asserting query result count on ' . $queryTestCaseInterpreter->isAbout()
 		);
 
+		$this->assertCount(
+			$queryTestCaseInterpreter->getExpectedErrorCount(),
+			$queryResult->getErrors(),
+			'Failed asserting error count ' . $queryTestCaseInterpreter->isAbout()
+		);
+
 		$this->queryResultValidator->assertThatQueryResultHasSubjects(
 			$queryTestCaseInterpreter->getExpectedSubjects(),
 			$queryResult,
@@ -155,6 +161,12 @@ class QueryTestCaseProcessor extends \PHPUnit_Framework_TestCase {
 			$queryTestCaseInterpreter->getExpectedCount(),
 			$queryResult->getCount(),
 			'Failed asserting query result count on ' . $queryTestCaseInterpreter->isAbout()
+		);
+
+		$this->assertCount(
+			$queryTestCaseInterpreter->getExpectedErrorCount(),
+			$queryResult->getErrors(),
+			'Failed asserting error count ' . $queryTestCaseInterpreter->isAbout()
 		);
 
 		foreach ( $queryTestCaseInterpreter->getExpectedConceptCache() as $expectedConceptCache ) {

--- a/tests/phpunit/JsonTestCaseFileHandler.php
+++ b/tests/phpunit/JsonTestCaseFileHandler.php
@@ -207,12 +207,12 @@ class JsonTestCaseFileHandler {
 	public function findRdfTestCases() {
 
 		try{
-			$queries = $this->getFileContentsFor( 'rdf-testcases' );
+			$testcases = $this->getFileContentsFor( 'rdf-testcases' );
 		} catch( \Exception $e ) {
-			$queries = array();
+			$testcases = array();
 		}
 
-		return $queries;
+		return $testcases;
 	}
 
 	/**
@@ -223,12 +223,12 @@ class JsonTestCaseFileHandler {
 	public function findParserTestCases() {
 
 		try{
-			$queries = $this->getFileContentsFor( 'parser' );
+			$testcases = $this->getFileContentsFor( 'parser' );
 		} catch( \Exception $e ) {
-			$queries = array();
+			$testcases = array();
 		}
 
-		return $queries;
+		return $testcases;
 	}
 
 	/**
@@ -239,12 +239,12 @@ class JsonTestCaseFileHandler {
 	public function findFormatTestCases() {
 
 		try{
-			$formats = $this->getFileContentsFor( 'format' );
+			$testcases = $this->getFileContentsFor( 'format' );
 		} catch( \Exception $e ) {
-			$formats = array();
+			$testcases = array();
 		}
 
-		return $formats;
+		return $testcases;
 	}
 
 	/**
@@ -255,12 +255,12 @@ class JsonTestCaseFileHandler {
 	public function findQueryTestCases() {
 
 		try{
-			$queries = $this->getFileContentsFor( 'queries' );
+			$testcases = $this->getFileContentsFor( 'queries' );
 		} catch( \Exception $e ) {
-			$queries = array();
+			$testcases = array();
 		}
 
-		return $queries;
+		return $testcases;
 	}
 
 	/**
@@ -271,12 +271,12 @@ class JsonTestCaseFileHandler {
 	public function findConceptTestCases() {
 
 		try{
-			$queries = $this->getFileContentsFor( 'concepts' );
+			$testcases = $this->getFileContentsFor( 'concept-testcases' );
 		} catch( \Exception $e ) {
-			$queries = array();
+			$testcases = array();
 		}
 
-		return $queries;
+		return $testcases;
 	}
 
 	private function getFileContentsFor( $index ) {

--- a/tests/phpunit/includes/CircularReferenceGuardTest.php
+++ b/tests/phpunit/includes/CircularReferenceGuardTest.php
@@ -43,7 +43,7 @@ class CircularReferenceGuardTest extends \PHPUnit_Framework_TestCase {
 		);
 
 		$this->assertTrue(
-			$instance->isCircularByRecursion( 'Foo' )
+			$instance->isCircularByRecursionFor( 'Foo' )
 		);
 
 		$instance->unmark( 'Foo' );
@@ -54,7 +54,7 @@ class CircularReferenceGuardTest extends \PHPUnit_Framework_TestCase {
 		);
 
 		$this->assertFalse(
-			$instance->isCircularByRecursion( 'Foo' )
+			$instance->isCircularByRecursionFor( 'Foo' )
 		);
 
 		$instance->unmark( 'notBeenMarkedBefore' );

--- a/tests/phpunit/includes/SPARQLStore/QueryEngine/ConditionBuilder/ConceptConditionBuilderTest.php
+++ b/tests/phpunit/includes/SPARQLStore/QueryEngine/ConditionBuilder/ConceptConditionBuilderTest.php
@@ -90,8 +90,13 @@ class ConceptConditionBuilderTest extends \PHPUnit_Framework_TestCase {
 
 		$resultVariable = 'result';
 
+		$circularReferenceGuard = $this->getMockBuilder( '\SMW\CircularReferenceGuard' )
+			->disableOriginalConstructor()
+			->getMock();
+
 		$compoundConditionBuilder = new CompoundConditionBuilder();
 		$compoundConditionBuilder->setResultVariable( $resultVariable );
+		$compoundConditionBuilder->setCircularReferenceGuard( $circularReferenceGuard );
 
 		$instance = new ConceptConditionBuilder();
 		$instance->setCompoundConditionBuilder( $compoundConditionBuilder );
@@ -110,6 +115,10 @@ class ConceptConditionBuilderTest extends \PHPUnit_Framework_TestCase {
 	}
 
 	public function testConceptConditionBuilderForAnyValueConceptUsingMockedStore() {
+
+		$circularReferenceGuard = $this->getMockBuilder( '\SMW\CircularReferenceGuard' )
+			->disableOriginalConstructor()
+			->getMock();
 
 		$semanticData = $this->getMockBuilder( '\SMW\SemanticData' )
 			->disableOriginalConstructor()
@@ -139,6 +148,7 @@ class ConceptConditionBuilderTest extends \PHPUnit_Framework_TestCase {
 
 		$compoundConditionBuilder = new CompoundConditionBuilder();
 		$compoundConditionBuilder->setResultVariable( $resultVariable );
+		$compoundConditionBuilder->setCircularReferenceGuard( $circularReferenceGuard );
 
 		$instance = new ConceptConditionBuilder();
 		$instance->setCompoundConditionBuilder( $compoundConditionBuilder );

--- a/tests/phpunit/includes/SPARQLStore/QueryEngine/QueryEngineTest.php
+++ b/tests/phpunit/includes/SPARQLStore/QueryEngine/QueryEngineTest.php
@@ -13,8 +13,7 @@ use SMWQuery as Query;
 /**
  * @covers \SMW\SPARQLStore\QueryEngine\QueryEngine
  *
- * @group SMW
- * @group SMWExtension
+ * @group semantic-mediawiki
  *
  * @license GNU GPL v2+
  * @since 2.0
@@ -62,7 +61,12 @@ class QueryEngineTest extends \PHPUnit_Framework_TestCase {
 		$engineOptions = new EngineOptions();
 		$engineOptions->ignoreQueryErrors = false;
 
-		$instance = new QueryEngine( $connection, $compoundConditionBuilder, new QueryResultFactory( $store ), $engineOptions );
+		$instance = new QueryEngine(
+			$connection,
+			$compoundConditionBuilder,
+			new QueryResultFactory( $store ),
+			$engineOptions
+		);
 
 		$query = new Query( $description );
 		$query->addErrors( array( 'Foo' ) );
@@ -74,6 +78,59 @@ class QueryEngineTest extends \PHPUnit_Framework_TestCase {
 
 		$this->assertEmpty(
 			$instance->getQueryResult( $query )->getResults()
+		);
+	}
+
+	public function testConditionBuilderReturnsErrors() {
+
+		$condition = $this->getMockForAbstractClass( '\SMW\SPARQLStore\QueryEngine\Condition\Condition' );
+
+		$connection = $this->getMockBuilder( '\SMWSparqlDatabase' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$store = $this->getMockBuilder( '\SMW\Store' )
+			->disableOriginalConstructor()
+			->getMockForAbstractClass();
+
+		$compoundConditionBuilder = $this->getMockBuilder( '\SMW\SPARQLStore\QueryEngine\CompoundConditionBuilder' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$compoundConditionBuilder->expects( $this->any() )
+			->method( 'getErrors' )
+			->will( $this->returnValue( array( 'bogus-error' ) ) );
+
+		$compoundConditionBuilder->expects( $this->atLeastOnce() )
+			->method( 'buildCondition' )
+			->will( $this->returnValue( $condition ) );
+
+		$description = $this->getMockForAbstractClass( '\SMWDescription' );
+
+		$engineOptions = new EngineOptions();
+		$engineOptions->ignoreQueryErrors = false;
+
+		$instance = new QueryEngine(
+			$connection,
+			$compoundConditionBuilder,
+			new QueryResultFactory( $store ),
+			$engineOptions
+		);
+
+		$query = new Query( $description );
+
+		$this->assertInstanceOf(
+			'\SMWQueryResult',
+			$instance->getQueryResult( $query )
+		);
+
+		$this->assertEmpty(
+			$instance->getQueryResult( $query )->getResults()
+		);
+
+		$this->assertEquals(
+			array( 'bogus-error' ),
+			$query->getErrors()
 		);
 	}
 
@@ -93,7 +150,11 @@ class QueryEngineTest extends \PHPUnit_Framework_TestCase {
 
 		$description = $this->getMockForAbstractClass( '\SMWDescription' );
 
-		$instance = new QueryEngine( $connection, $compoundConditionBuilder, new QueryResultFactory( $store ) );
+		$instance = new QueryEngine(
+			$connection,
+			$compoundConditionBuilder,
+			new QueryResultFactory( $store )
+		);
 
 		$query = new Query( $description );
 		$query->querymode = Query::MODE_NONE;
@@ -123,6 +184,10 @@ class QueryEngineTest extends \PHPUnit_Framework_TestCase {
 		$compoundConditionBuilder = $this->getMockBuilder( '\SMW\SPARQLStore\QueryEngine\CompoundConditionBuilder' )
 			->disableOriginalConstructor()
 			->getMock();
+
+		$compoundConditionBuilder->expects( $this->any() )
+			->method( 'getErrors' )
+			->will( $this->returnValue( array() ) );
 
 		$compoundConditionBuilder->expects( $this->atLeastOnce() )
 			->method( 'setSortKeys' )
@@ -154,6 +219,10 @@ class QueryEngineTest extends \PHPUnit_Framework_TestCase {
 		$compoundConditionBuilder = $this->getMockBuilder( '\SMW\SPARQLStore\QueryEngine\CompoundConditionBuilder' )
 			->disableOriginalConstructor()
 			->getMock();
+
+		$compoundConditionBuilder->expects( $this->any() )
+			->method( 'getErrors' )
+			->will( $this->returnValue( array() ) );
 
 		$compoundConditionBuilder->expects( $this->atLeastOnce() )
 			->method( 'setSortKeys' )
@@ -209,6 +278,10 @@ class QueryEngineTest extends \PHPUnit_Framework_TestCase {
 			->disableOriginalConstructor()
 			->getMock();
 
+		$compoundConditionBuilder->expects( $this->any() )
+			->method( 'getErrors' )
+			->will( $this->returnValue( array() ) );
+
 		$compoundConditionBuilder->expects( $this->atLeastOnce() )
 			->method( 'setSortKeys' )
 			->will( $this->returnValue( $compoundConditionBuilder ) );
@@ -219,11 +292,17 @@ class QueryEngineTest extends \PHPUnit_Framework_TestCase {
 
 		$description = $this->getMockForAbstractClass( '\SMWDescription' );
 
-		$instance = new QueryEngine( $connection, $compoundConditionBuilder, new QueryResultFactory( $store ) );
+		$instance = new QueryEngine(
+			$connection,
+			$compoundConditionBuilder,
+			new QueryResultFactory( $store )
+		);
+
+		$query = new Query( $description );
 
 		$this->assertInstanceOf(
 			'\SMWQueryResult',
-			$instance->getCountQueryResult( new Query( $description ) )
+			$instance->getCountQueryResult( $query )
 		);
 	}
 

--- a/tests/phpunit/includes/parserhooks/AskParserFunctionTest.php
+++ b/tests/phpunit/includes/parserhooks/AskParserFunctionTest.php
@@ -181,7 +181,7 @@ class AskParserFunctionTest extends \PHPUnit_Framework_TestCase {
 			->method( 'unmark' );
 
 		$circularReferenceGuard->expects( $this->once() )
-			->method( 'isCircularByRecursion' )
+			->method( 'isCircularByRecursionFor' )
 			->will( $this->returnValue( true ) );
 
 		$instance = new AskParserFunction(


### PR DESCRIPTION
For example, a concept `Concept:Modification date` with a self-reference to its own concept is just not possible.
```
{{#concept: [[Modification date::+]][[Concept:Modification date]]
 |Modification date
}}
``` 