### PR TITLE
Rename PropertyTypeDiffFinder to PropertySpecDiffFinder

### DIFF
--- a/includes/StoreUpdater.php
+++ b/includes/StoreUpdater.php
@@ -122,7 +122,7 @@ class StoreUpdater {
 		$revision = $wikiPage->getRevision();
 
 		$this->updateSemanticData( $title, $wikiPage, $revision );
-		$this->doRealUpdate( $this->inspectPropertyType() );
+		$this->doRealUpdate( $this->inspectPropertySpecification() );
 
 		return true;
 	}
@@ -153,19 +153,19 @@ class StoreUpdater {
 	 * @note Comparison must happen *before* the storage update;
 	 * even finding uses of a property fails after its type changed.
 	 */
-	private function inspectPropertyType() {
+	private function inspectPropertySpecification() {
 
 		if ( !$this->updateJobsEnabledState ) {
 			return;
 		}
 
-		$propertyTypeDiffFinder = new PropertyTypeDiffFinder( $this->store, $this->semanticData );
+		$propertySpecDiffFinder = new PropertySpecDiffFinder( $this->store, $this->semanticData );
 
-		$propertyTypeDiffFinder->setPropertiesToCompare(
+		$propertySpecDiffFinder->setPropertiesToCompare(
 			$this->applicationFactory->getSettings()->get( 'smwgDeclarationProperties' )
 		);
 
-		$propertyTypeDiffFinder->findDiff();
+		$propertySpecDiffFinder->findDiff();
 	}
 
 	private function doRealUpdate() {

--- a/src/EventListenerRegistry.php
+++ b/src/EventListenerRegistry.php
@@ -40,7 +40,7 @@ class EventListenerRegistry implements EventListenerCollection {
 	private function addListenersToCollection() {
 
 		$this->eventListenerCollection->registerCallback(
-			'property.type.change', function( $dispatchContext ) {
+			'property.spec.change', function( $dispatchContext ) {
 
 				$title = $dispatchContext->get( 'subject' )->getTitle();
 

--- a/tests/phpunit/includes/EventListenerRegistryTest.php
+++ b/tests/phpunit/includes/EventListenerRegistryTest.php
@@ -78,7 +78,7 @@ class EventListenerRegistryTest extends \PHPUnit_Framework_TestCase {
 		$dispatchContext = EventDispatcherFactory::getInstance()->newDispatchContext();
 		$dispatchContext->set( 'subject', new DIWikiPage( 'Foo', NS_MAIN ) );
 
-		$this->assertListenerExecuteFor( 'property.type.change', $instance, $dispatchContext );
+		$this->assertListenerExecuteFor( 'property.spec.change', $instance, $dispatchContext );
 	}
 
 	private function assertListenerExecuteFor( $eventName, $instance, $dispatchContext = null ) {

--- a/tests/phpunit/includes/PropertySpecDiffFinderTest.php
+++ b/tests/phpunit/includes/PropertySpecDiffFinderTest.php
@@ -2,7 +2,7 @@
 
 namespace SMW\Tests;
 
-use SMW\PropertyTypeDiffFinder;
+use SMW\PropertySpecDiffFinder;
 use SMW\DIProperty;
 use SMW\DIWikiPage;
 use SMW\Settings;
@@ -10,7 +10,7 @@ use SMW\ApplicationFactory;
 use Title;
 
 /**
- * @covers \SMW\PropertyTypeDiffFinder
+ * @covers \SMW\PropertySpecDiffFinder
  *
  * @group semantic-mediawiki
  *
@@ -19,7 +19,7 @@ use Title;
  *
  * @author mwjames
  */
-class PropertyTypeDiffFinderTest extends \PHPUnit_Framework_TestCase {
+class PropertySpecDiffFinderTest extends \PHPUnit_Framework_TestCase {
 
 	/** @var DIWikiPage[] */
 	protected $storeValues;
@@ -63,8 +63,8 @@ class PropertyTypeDiffFinderTest extends \PHPUnit_Framework_TestCase {
 			->getMock();
 
 		$this->assertInstanceOf(
-			'\SMW\PropertyTypeDiffFinder',
-			new PropertyTypeDiffFinder( $store, $semanticData )
+			'\SMW\PropertySpecDiffFinder',
+			new PropertySpecDiffFinder( $store, $semanticData )
 		);
 	}
 
@@ -118,7 +118,7 @@ class PropertyTypeDiffFinderTest extends \PHPUnit_Framework_TestCase {
 			->method( 'getPropertyValues' )
 			->will( $this->returnValue( $dataValues ) );
 
-		$instance = new PropertyTypeDiffFinder( $store, $semanticData );
+		$instance = new PropertySpecDiffFinder( $store, $semanticData );
 		$instance->setPropertiesToCompare( $propertiesToCompare );
 		$instance->findDiff();
 


### PR DESCRIPTION
This class does more than finding a diff for a type definition, it compares conversion rules or constraint definitions.

+ simplified code

refs #948