### PR TITLE
Add UpdateDispatcherJob::createUpdateJobsFromListBySecondaryRun

### DIFF
--- a/tests/phpunit/Integration/MediaWiki/JobQueueDBIntegrationTest.php
+++ b/tests/phpunit/Integration/MediaWiki/JobQueueDBIntegrationTest.php
@@ -286,6 +286,16 @@ class JobQueueDBIntegrationTest extends MwDBaseUnitTestCase {
 			->createPage( $propertyPage )
 			->doEdit( '[[Has type::Number]]' );
 
+		// Secondary dispatch process
+		$this->assertGreaterThan(
+			0,
+			$this->jobQueueLookup->estimateJobCountFor( 'SMW\UpdateDispatcherJob' )
+		);
+
+		$this->jobQueueRunner
+			->setType( 'SMW\UpdateDispatcherJob' )
+			->run();
+
 		$this->assertGreaterThan(
 			0,
 			$this->jobQueueLookup->estimateJobCountFor( 'SMW\UpdateJob' )


### PR DESCRIPTION
It changes the way `UpdateJobs` are dispatched:

1. `UpdateDispatcherJob`'s first run is to use the store to create a list of unique subjects with the raw list being send in chunks (of 5000) for the secondary run of the `UpdateDispatcherJob`
2. `UpdateDispatcherJob`'s secondary run (which is scheduled through the job queue) is to use the raw list and create `UpdateJob` instances and push them into the job queue

refs #948