### PR TITLE
Fix sniffs=Generic.ControlStructures.InlineControlStructure in includes/

### DIFF
--- a/includes/RecurringEvents.php
+++ b/includes/RecurringEvents.php
@@ -288,7 +288,9 @@ class RecurringEvents {
 				$prev_year = $cur_date->getYear();
 
 				$new_month = ( $prev_month + $period ) % 12;
-				if ( $new_month == 0 ) $new_month = 12;
+				if ( $new_month == 0 ) {
+					$new_month = 12;
+				}
 
 				$new_year = $prev_year + floor( ( $prev_month + $period - 1 ) / 12 );
 				$cur_date_jd += ( 28 * $period ) - 7;

--- a/includes/SemanticData.php
+++ b/includes/SemanticData.php
@@ -441,8 +441,9 @@ class SemanticData {
 			unset( $this->mPropVals[$property->getKey()][$dataItem->getHash()] );
 		} else {
 			foreach( $this->mPropVals[$property->getKey()] as $index => $di ) {
-				if( $di->equals( $dataItem ) )
+				if( $di->equals( $dataItem ) ) {
 					unset( $this->mPropVals[$property->getKey()][$index] );
+				}
 			}
 			$this->mPropVals[$property->getKey()] = array_values( $this->mPropVals[$property->getKey()] );
 		}

--- a/includes/datavalues/SMW_DV_Bool.php
+++ b/includes/datavalues/SMW_DV_Bool.php
@@ -61,7 +61,9 @@ class SMWBoolValue extends SMWDataValue {
 	}
 
 	public function setOutputFormat( $formatstring ) {
-		if ( $formatstring == $this->m_outformat ) return;
+		if ( $formatstring == $this->m_outformat ) {
+			return;
+		}
 		unset( $this->m_truecaption );
 		unset( $this->m_falsecaption );
 		if ( $formatstring === '' ) { // no format
@@ -114,7 +116,9 @@ class SMWBoolValue extends SMWDataValue {
 	 * @return string
 	 */
 	protected function getStandardCaption( $useformat ) {
-		if ( !$this->isValid() ) return false;
+		if ( !$this->isValid() ) {
+			return false;
+		}
 		if ( $useformat && ( isset( $this->m_truecaption ) ) ) {
 			return $this->m_dataitem->getBoolean() ? $this->m_truecaption : $this->m_falsecaption;
 		} else {

--- a/includes/datavalues/SMW_DV_PropertyList.php
+++ b/includes/datavalues/SMW_DV_PropertyList.php
@@ -114,7 +114,9 @@ class SMWPropertyListValue extends SMWDataValue {
 		$result = '';
 		$sep = ( $type == 4 ) ? '; ' : ', ';
 		foreach ( $this->m_diProperties as $diProperty ) {
-			if ( $result !== '' ) $result .= $sep;
+			if ( $result !== '' ) {
+				$result .= $sep;
+			}
 			$propertyValue = \SMW\DataValueFactory::getInstance()->newDataItemValue( $diProperty, null );
 			$result .= $this->makeValueOutputText( $type, $propertyValue, $linker );
 		}

--- a/includes/datavalues/SMW_DV_Quantity.php
+++ b/includes/datavalues/SMW_DV_Quantity.php
@@ -206,7 +206,9 @@ class SMWQuantityValue extends SMWNumberValue {
 	 * This method initializes $m_displayunits.
 	 */
 	protected function initDisplayData() {
-		if ( $this->m_displayunits !== false ) return; // do the below only once
+		if ( $this->m_displayunits !== false ) {
+			return; // do the below only once
+		}
 		$this->initConversionData(); // needed to normalise unit strings
 		$this->m_displayunits = array();
 

--- a/includes/datavalues/SMW_DV_Record.php
+++ b/includes/datavalues/SMW_DV_Record.php
@@ -334,7 +334,9 @@ class SMWRecordValue extends SMWDataValue {
 				$result .= '?';
 			}
 		}
-		if ( ( $i > 1 ) && ( $type != 4 ) ) $result .= ')';
+		if ( ( $i > 1 ) && ( $type != 4 ) ) {
+			$result .= ')';
+		}
 
 		return $result;
 	}

--- a/includes/datavalues/SMW_DV_Temperature.php
+++ b/includes/datavalues/SMW_DV_Temperature.php
@@ -44,7 +44,9 @@ class SMWTemperatureValue extends SMWNumberValue {
 
 	protected function makeConversionValues() {
 		/// NOTE This class currently ignores display units.
-		if ( $this->m_unitvalues !== false ) return; // do this only once
+		if ( $this->m_unitvalues !== false ) {
+			return; // do this only once
+		}
 		if ( !$this->isValid() ) {
 			$this->m_unitvalues = array();
 		} else {

--- a/includes/datavalues/SMW_DV_Time.php
+++ b/includes/datavalues/SMW_DV_Time.php
@@ -157,7 +157,9 @@ class SMWTimeValue extends SMWDataValue {
 				if ( ( $era === false ) && ( $hours === false ) && ( $timeoffset == 0 ) ) {
 					try {
 						$jd = floatval( reset( $datecomponents ) );
-						if ( $calendarmodel == 'MJD' ) $jd += self::MJD_EPOCH;
+						if ( $calendarmodel == 'MJD' ) {
+							$jd += self::MJD_EPOCH;
+						}
 						$this->m_dataitem = SMWDITime::newFromJD( $jd, SMWDITime::CM_GREGORIAN, SMWDITime::PREC_YMDT, $this->m_typeid );
 					} catch ( SMWDataItemException $e ) {
 						$this->addError( wfMessage( 'smw_nodatetime', $this->m_wikivalue )->inContentLanguage()->text() );
@@ -752,7 +754,9 @@ class SMWTimeValue extends SMWDataValue {
 		$precision = $dataitem->getPrecision();
 
 		$year = $this->getYear();
-		if ( $year < 0 || $year > 9999 ) $year = '0000';
+		if ( $year < 0 || $year > 9999 ) {
+			$year = '0000';
+		}
 		$year = str_pad( $year, 4, "0", STR_PAD_LEFT );
 
 		if ( $precision <= SMWDITime::PREC_Y ) {

--- a/includes/export/SMW_ExportController.php
+++ b/includes/export/SMW_ExportController.php
@@ -412,10 +412,14 @@ class SMWExportController {
 		// transform pages into queued short titles
 		foreach ( $pages as $page ) {
 			$title = Title::newFromText( $page );
-			if ( null === $title ) continue; // invalid title name given
+			if ( null === $title ) {
+				continue; // invalid title name given
+			}
 			if ( $revisiondate !== '' ) { // filter page list by revision date
 				$rev = Revision::getTimeStampFromID( $title, $title->getLatestRevID() );
-				if ( $rev < $revisiondate ) continue;
+				if ( $rev < $revisiondate ) {
+					continue;
+				}
 			}
 
 			$diPage = SMWDIWikiPage::newFromTitle( $title );
@@ -497,8 +501,12 @@ class SMWExportController {
 
 		for ( $id = 1; $id <= $end; $id += 1 ) {
 			$title = Title::newFromID( $id );
-			if ( is_null( $title ) || !smwfIsSemanticsProcessed( $title->getNamespace() ) ) continue;
-			if ( !SMWExportController::fitsNsRestriction( $ns_restriction, $title->getNamespace() ) ) continue;
+			if ( is_null( $title ) || !smwfIsSemanticsProcessed( $title->getNamespace() ) ) {
+				continue;
+			}
+			if ( !SMWExportController::fitsNsRestriction( $ns_restriction, $title->getNamespace() ) ) {
+				continue;
+			}
 			$a_count += 1; // DEBUG
 
 			$diPage = SMWDIWikiPage::newFromTitle( $title );
@@ -555,7 +563,9 @@ class SMWExportController {
 		$query = '';
 		foreach ( $smwgNamespacesWithSemanticLinks as $ns => $enabled ) {
 			if ( $enabled ) {
-				if ( $query !== '' ) $query .= ' OR ';
+				if ( $query !== '' ) {
+					$query .= ' OR ';
+				}
 				$query .= 'page_namespace = ' . $db->addQuotes( $ns );
 			}
 		}
@@ -718,9 +728,15 @@ class SMWExportController {
 	 * @param $ns integer the namespace constant to be checked
 	 */
 	static public function fitsNsRestriction( $res, $ns ) {
-		if ( $res === false ) return true;
-		if ( is_array( $res ) ) return in_array( $ns, $res );
-		if ( $res >= 0 ) return ( $res == $ns );
+		if ( $res === false ) {
+			return true;
+		}
+		if ( is_array( $res ) ) {
+			return in_array( $ns, $res );
+		}
+		if ( $res >= 0 ) {
+			return ( $res == $ns );
+		}
 		return ( ( $res != NS_CATEGORY ) && ( $res != SMW_NS_PROPERTY ) && ( $res != SMW_NS_TYPE ) );
 	}
 

--- a/includes/export/SMW_Exporter.php
+++ b/includes/export/SMW_Exporter.php
@@ -67,7 +67,9 @@ class SMWExporter {
 	 * Make sure that necessary base URIs are initialised properly.
 	 */
 	static public function initBaseURIs() {
-		if ( self::$m_exporturl !== false ) return;
+		if ( self::$m_exporturl !== false ) {
+			return;
+		}
 		global $wgContLang, $wgServer, $wgArticlePath;
 
 		global $smwgNamespace; // complete namespace for URIs (with protocol, usually http://)
@@ -264,7 +266,9 @@ class SMWExporter {
 			}
 
 			$pe = self::getSpecialPropertyResource( $property->getKey(), $diSubject->getNamespace() );
-			if ( is_null( $pe ) ) return; // unknown special property, not exported
+			if ( is_null( $pe ) ) {
+				return; // unknown special property, not exported
+			}
 			// have helper property ready before entering the for loop, even if not needed:
 			$peHelper = self::getResourceElementForProperty( $property, true );
 

--- a/includes/export/SMW_Serializer.php
+++ b/includes/export/SMW_Serializer.php
@@ -140,9 +140,15 @@ abstract class SMWSerializer {
 	public function serializeDeclarations() {
 		foreach ( $this->decl_todo as $name => $flag ) {
 			$types = array();
-			if ( $flag & SMW_SERIALIZER_DECL_CLASS ) $types[] = 'owl:Class';
-			if ( $flag & SMW_SERIALIZER_DECL_OPROP ) $types[] = 'owl:ObjectProperty';
-			if ( $flag & SMW_SERIALIZER_DECL_APROP ) $types[] = 'owl:DatatypeProperty';
+			if ( $flag & SMW_SERIALIZER_DECL_CLASS ) {
+				$types[] = 'owl:Class';
+			}
+			if ( $flag & SMW_SERIALIZER_DECL_OPROP ) {
+				$types[] = 'owl:ObjectProperty';
+			}
+			if ( $flag & SMW_SERIALIZER_DECL_APROP ) {
+				$types[] = 'owl:DatatypeProperty';
+			}
 			foreach ( $types as $typename ) {
 				$this->serializeDeclaration( $name, $typename );
 			}
@@ -177,7 +183,9 @@ abstract class SMWSerializer {
 	 * (what is flushed is gone).
 	 */
 	public function flushContent() {
-		if ( ( $this->pre_ns_buffer === '' ) && ( $this->post_ns_buffer === '' ) ) return '';
+		if ( ( $this->pre_ns_buffer === '' ) && ( $this->post_ns_buffer === '' ) ) {
+			return '';
+		}
 		$this->serializeNamespaces();
 		$result = $this->pre_ns_buffer . $this->post_ns_buffer;
 		$this->pre_ns_buffer = '';
@@ -229,7 +237,9 @@ abstract class SMWSerializer {
 			}
 		}
 		// Do not declare blank nodes:
-		if ( $resource->isBlankNode() ) return;
+		if ( $resource->isBlankNode() ) {
+			return;
+		}
 
 		$name = $resource->getUri();
 		if ( array_key_exists( $name, $this->decl_done ) && ( $this->decl_done[$name] & $decltype ) ) {

--- a/includes/export/SMW_Serializer_Turtle.php
+++ b/includes/export/SMW_Serializer_Turtle.php
@@ -129,7 +129,9 @@ class SMWTurtleSerializer extends SMWSerializer{
 	 * @param $indent string specifying a prefix for indentation (usually a sequence of tabs)
 	 */
 	protected function serializeNestedExpData( SMWExpData $data, $indent ) {
-		if ( count( $data->getProperties() ) == 0 ) return; // nothing to export
+		if ( count( $data->getProperties() ) == 0 ) {
+			return; // nothing to export
+		}
 		$this->recordDeclarationTypes( $data );
 
 		$bnode = false;

--- a/includes/parserhooks/DocumentationParserFunction.php
+++ b/includes/parserhooks/DocumentationParserFunction.php
@@ -135,7 +135,9 @@ class DocumentationParserFunction extends \ParserHook {
 
 		foreach ( $paramDefinitions as $parameter ) {
 			$hasAliases = count( $parameter->getAliases() ) != 0;
-			if ( $hasAliases ) break;
+			if ( $hasAliases ) {
+				break;
+			}
 		}
 
 		foreach ( $paramDefinitions as $parameter ) {
@@ -194,7 +196,9 @@ class DocumentationParserFunction extends \ParserHook {
 			$default = $default ? 'yes' : 'no';
 		}
 
-		if ( $default === '' ) $default = "''" . $this->msg( 'validator-describe-empty' ) . "''";
+		if ( $default === '' ) {
+			$default = "''" . $this->msg( 'validator-describe-empty' ) . "''";
+		}
 
 		return "| {$parameter->getName()}\n"
 . ( $hasAliases ? '| ' . $aliases . "\n" : '' ) .

--- a/includes/query/SMW_QueryLanguage.php
+++ b/includes/query/SMW_QueryLanguage.php
@@ -53,7 +53,9 @@ final class SMWQueryLanguage {
 	 */
 	public static function getComparatorFromString( $string, $defaultComparator = SMW_CMP_EQ ) {
 		self::initializeComparators();
-		if ( $string === '' ) return SMW_CMP_EQ;
+		if ( $string === '' ) {
+			return SMW_CMP_EQ;
+		}
 		return array_key_exists( $string, self::$comparators ) ? self::$comparators[$string] : $defaultComparator;
 	}
 

--- a/includes/querypages/QueryPage.php
+++ b/includes/querypages/QueryPage.php
@@ -217,8 +217,9 @@ abstract class QueryPage extends \QueryPage {
 
 		if ( $num > 0 ) {
 			$s = array();
-			if ( ! $this->listoutput )
+			if ( ! $this->listoutput ) {
 				$s[] = $this->openList( $offset );
+			}
 
 			foreach ( $res as $r ) {
 				$format = $this->formatResult( $sk, $r );
@@ -227,8 +228,9 @@ abstract class QueryPage extends \QueryPage {
 				}
 			}
 
-			if ( ! $this->listoutput )
+			if ( ! $this->listoutput ) {
 				$s[] = $this->closeList();
+			}
 			$str = $this->listoutput ? $this->getLanguage()->listToText( $s ) : implode( '', $s );
 			$out->addHTML( $str );
 		}

--- a/includes/queryprinters/CategoryResultPrinter.php
+++ b/includes/queryprinters/CategoryResultPrinter.php
@@ -76,15 +76,17 @@ class CategoryResultPrinter extends ResultPrinter {
 
 			if ( $rowindex % $rows_per_column == 0 ) {
 				$result .= "\n			<div style=\"float: left; width: $column_width%;\">\n";
-				if ( $cur_first_char == $prev_first_char )
+				if ( $cur_first_char == $prev_first_char ) {
 					$result .= "				<h3>$cur_first_char " . wfMessage( 'listingcontinuesabbrev' )->text() . "</h3>\n				<ul>\n";
+				}
 			}
 
 			// if we're at a new first letter, end
 			// the last list and start a new one
 			if ( $cur_first_char != $prev_first_char ) {
-				if ( $rowindex % $rows_per_column > 0 )
+				if ( $rowindex % $rows_per_column > 0 ) {
 					$result .= "				</ul>\n";
+				}
 				$result .= "				<h3>$cur_first_char</h3>\n				<ul>\n";
 			}
 			$prev_first_char = $cur_first_char;
@@ -142,7 +144,9 @@ class CategoryResultPrinter extends ResultPrinter {
 					$first_col = false;
 				}
 
-				if ( $found_values ) $result .= ')';
+				if ( $found_values ) {
+					$result .= ')';
+				}
 			}
 
 			$result .= '</li>';

--- a/includes/queryprinters/ListResultPrinter.php
+++ b/includes/queryprinters/ListResultPrinter.php
@@ -381,7 +381,9 @@ class ListResultPrinter extends ResultPrinter {
 
 			$firstField = false;
 		}
-		if ( $extraFields ) $result .= ')';
+		if ( $extraFields ) {
+			$result .= ')';
+		}
 
 		return $result;
 	}

--- a/includes/specials/SMW_SpecialAsk.php
+++ b/includes/specials/SMW_SpecialAsk.php
@@ -76,15 +76,18 @@ class SMWAskPage extends SMWQuerySpecialPage {
 		if ( $wgRequest->getCheck( 'q' ) ) { // called by own Special, ignore full param string in that case
 			$query_val = $wgRequest->getVal( 'p' );
 
-			if ( !empty( $query_val ) )
+			if ( !empty( $query_val ) ) {
 				// p is used for any additional parameters in certain links.
 				$rawparams = SMWInfolink::decodeParameters( $query_val, false );
+			}
 			else {
 				$query_values = $wgRequest->getArray( 'p' );
 
 				if ( is_array( $query_values ) ) {
 					foreach ( $query_values as $key => $val ) {
-						if ( empty( $val ) ) unset( $query_values[$key] );
+						if ( empty( $val ) ) {
+							unset( $query_values[$key] );
+						}
 					}
 				}
 
@@ -133,7 +136,9 @@ class SMWAskPage extends SMWQuerySpecialPage {
 				$this->m_params['order'] = '';
 
 				foreach ( $order_values as $order_value ) {
-					if ( $order_value === '' ) $order_value = 'ASC';
+					if ( $order_value === '' ) {
+						$order_value = 'ASC';
+					}
 					$this->m_params['order'] .= ( $this->m_params['order'] !== '' ? ',' : '' ) . $order_value;
 				}
 			}
@@ -151,7 +156,9 @@ class SMWAskPage extends SMWQuerySpecialPage {
 
 		if ( !array_key_exists( 'offset', $this->m_params ) ) {
 			$this->m_params['offset'] = $wgRequest->getVal( 'offset' );
-			if ( $this->m_params['offset'] === '' )  $this->m_params['offset'] = 0;
+			if ( $this->m_params['offset'] === '' )  {
+				$this->m_params['offset'] = 0;
+			}
 		}
 
 		if ( !array_key_exists( 'limit', $this->m_params ) ) {
@@ -510,9 +517,13 @@ class SMWAskPage extends SMWQuerySpecialPage {
 			$result .=  "<div id=\"sort_div_$i\">" . wfMessage( 'smw_ask_sortby' )->escaped() . ' <input type="text" name="sort[' . $i . ']" value="' .
 				    htmlspecialchars( $sorts[$i] ) . "\" size=\"35\"/>\n" . '<select name="order[' . $i . ']"><option ';
 
-			if ( $order == 'ASC' ) $result .= 'selected="selected" ';
+			if ( $order == 'ASC' ) {
+				$result .= 'selected="selected" ';
+			}
 			$result .=  'value="ASC">' . wfMessage( 'smw_ask_ascorder' )->escaped() . '</option><option ';
-			if ( $order == 'DESC' ) $result .= 'selected="selected" ';
+			if ( $order == 'DESC' ) {
+				$result .= 'selected="selected" ';
+			}
 
 			$result .=  'value="DESC">' . wfMessage( 'smw_ask_descorder' )->escaped() . "</option></select>\n";
 			$result .= '[<a class="smw-ask-delete" data-target="sort_div_' . $i . '" href="#">' . wfMessage( 'delete' )->escaped() . '</a>]' . "\n";
@@ -609,7 +620,9 @@ class SMWAskPage extends SMWQuerySpecialPage {
 		$first = true;
 
 		foreach ( array( 20, 50, 100, 250, 500 ) as $l ) {
-			if ( $l > $smwgQMaxInlineLimit ) break;
+			if ( $l > $smwgQMaxInlineLimit ) {
+				break;
+			}
 
 			if ( $first ) {
 				$navigation .= '&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;(';

--- a/includes/specials/SMW_SpecialBrowse.php
+++ b/includes/specials/SMW_SpecialBrowse.php
@@ -355,7 +355,9 @@ class SMWSpecialBrowse extends SpecialPage {
 		$options = new SMWRequestOptions();
 		$options->sort = true;
 		$options->limit = SMWSpecialBrowse::$incomingpropertiescount;
-		if ( $this->offset > 0 ) $options->offset = $this->offset;
+		if ( $this->offset > 0 ) {
+			$options->offset = $this->offset;
+		}
 
 		$inproperties = \SMW\StoreFactory::getStore()->getInProperties( $this->subject->getDataItem(), $options );
 

--- a/includes/specials/SMW_SpecialPageProperty.php
+++ b/includes/specials/SMW_SpecialPageProperty.php
@@ -122,7 +122,9 @@ class SMWPageProperty extends SpecialPage {
 
 				foreach ( $results as $di ) {
 					$count--;
-					if ( $count < 1 ) continue;
+					if ( $count < 1 ) {
+						continue;
+					}
 
 					$dv = \SMW\DataValueFactory::getInstance()->newDataItemValue( $di, $property->getDataItem() );
 					$html .= '<li>' . $dv->getLongHTMLText( $linker ); // do not show infolinks, the magnifier "+" is ambiguous with the browsing '+' for '_wpg' (see below)

--- a/includes/specials/SMW_SpecialTypes.php
+++ b/includes/specials/SMW_SpecialTypes.php
@@ -59,7 +59,9 @@ class SMWSpecialTypes extends SpecialPage {
 	protected function getTypeProperties( $typeLabel ) {
 		global $wgRequest, $smwgTypePagingLimit;
 
-		if ( $smwgTypePagingLimit <= 0 ) return ''; // not too useful, but we comply to this request
+		if ( $smwgTypePagingLimit <= 0 ) {
+			return ''; // not too useful, but we comply to this request
+		}
 
 		$from = $wgRequest->getVal( 'from' );
 		$until = $wgRequest->getVal( 'until' );

--- a/includes/storage/SMW_QueryResult.php
+++ b/includes/storage/SMW_QueryResult.php
@@ -101,7 +101,9 @@ class SMWQueryResult {
 		$page = current( $this->mResults );
 		next( $this->mResults );
 
-		if ( $page === false ) return false;
+		if ( $page === false ) {
+			return false;
+		}
 
 		$row = array();
 

--- a/includes/storage/SMW_ResultArray.php
+++ b/includes/storage/SMW_ResultArray.php
@@ -194,8 +194,9 @@ class SMWResultArray {
 	 * done when needed.
 	 */
 	protected function loadContent() {
-		if ( $this->mContent !== false ) return;
-
+		if ( $this->mContent !== false ) {
+			return;
+		}
 
 		switch ( $this->mPrintRequest->getMode() ) {
 			case PrintRequest::PRINT_THIS: // NOTE: The limit is ignored here.
@@ -283,7 +284,9 @@ class SMWResultArray {
 		if ( ( $limit !== false ) || ( $order != false ) ) {
 			$options = new SMWRequestOptions();
 
-			if ( $limit !== false ) $options->limit = trim( $limit );
+			if ( $limit !== false ) {
+				$options->limit = trim( $limit );
+			}
 
 			if ( ( $order == 'descending' ) || ( $order == 'reverse' ) || ( $order == 'desc' ) ) {
 				$options->sort = true;

--- a/includes/storage/SMW_SQLHelpers.php
+++ b/includes/storage/SMW_SQLHelpers.php
@@ -127,7 +127,9 @@ class SMWSQLHelpers {
 
 		$isPostgres = $wgDBtype == 'postgres';
 
-		if ( !$isPostgres ) $position = 'FIRST';
+		if ( !$isPostgres ) {
+			$position = 'FIRST';
+		}
 
 		// Loop through all the field definitions, and handle each definition for either postgres or MySQL.
 		foreach ( $fields as $fieldName => $fieldType ) {
@@ -518,7 +520,9 @@ EOT;
 	 * @param object $receiver
 	 */
 	private static function reportProgress( $msg, $receiver ) {
-		if ( !is_null( $receiver ) ) $receiver->reportProgress( $msg );
+		if ( !is_null( $receiver ) ) {
+			$receiver->reportProgress( $msg );
+		}
 	}
 
 }

--- a/includes/storage/SQLStore/SMW_SQLStore3.php
+++ b/includes/storage/SQLStore/SMW_SQLStore3.php
@@ -213,8 +213,9 @@ class SMWSQLStore3 extends SMWStore {
 ///// Reading methods /////
 
 	public function getReader() {
-		if( $this->reader == false )
+		if( $this->reader == false ) {
 			$this->reader = new SMWSQLStore3Readers( $this );//Initialize if not done already
+		}
 
 		return $this->reader;
 	}
@@ -255,8 +256,9 @@ class SMWSQLStore3 extends SMWStore {
 
 
 	public function getWriter() {
-		if( $this->writer == false )
+		if( $this->writer == false ) {
 			$this->writer = new SMWSQLStore3Writers( $this );//Initialize if not done already
+		}
 
 		return $this->writer;
 	}
@@ -406,8 +408,9 @@ class SMWSQLStore3 extends SMWStore {
 ///// Setup store /////
 
 	public function getSetupHandler() {
-		if( $this->setupHandler == false )
+		if( $this->setupHandler == false ) {
 			$this->setupHandler = new SMWSQLStore3SetupHandlers( $this );//Initialize if not done already
+		}
 
 		return $this->setupHandler;
 	}

--- a/includes/storage/SQLStore/SMW_SQLStore3_Readers.php
+++ b/includes/storage/SQLStore/SMW_SQLStore3_Readers.php
@@ -78,9 +78,13 @@ class SMWSQLStore3Readers {
 				foreach ( $filter as $typeId ) {
 					$diType = DataTypeRegistry::getInstance()->getDataItemId( $typeId );
 					$relevant = $relevant || ( $proptable->getDiType() == $diType );
-					if ( $relevant ) break;
+					if ( $relevant ) {
+						break;
+					}
 				}
-				if ( !$relevant ) continue;
+				if ( !$relevant ) {
+					continue;
+				}
 			}
 
 			$this->getSemanticDataFromTable( $sid, $subject, $proptable );
@@ -275,8 +279,9 @@ class SMWSQLStore3Readers {
 		// properties always need to be given as object,
 		// subjects at least if !$proptable->idsubject
 		if ( ( $id == 0 ) ||
-			( is_null( $object ) && ( !$isSubject || !$propTable->usesIdSubject() ) ) )
-			return array();
+			( is_null( $object ) && ( !$isSubject || !$propTable->usesIdSubject() ) ) ) {
+				return array();
+			}
 
 		$result = array();
 		$db = $this->store->getConnection();

--- a/includes/storage/SQLStore/SMW_SQLStore3_SetupHandlers.php
+++ b/includes/storage/SQLStore/SMW_SQLStore3_SetupHandlers.php
@@ -354,7 +354,9 @@ class SMWSQLStore3SetupHandlers implements MessageReporter {
 		foreach ( $res as $row ) {
 			$emptyrange = false; // note this even if no jobs were created
 
-			if ( $namespaces && !in_array( $row->smw_namespace, $namespaces ) ) continue;
+			if ( $namespaces && !in_array( $row->smw_namespace, $namespaces ) ) {
+				continue;
+			}
 
 			// Find page to refresh, even for special properties:
 			if ( $row->smw_title != '' && $row->smw_title{0} != '_' ) {

--- a/includes/storage/SQLStore/SMW_Sql3SmwIds.php
+++ b/includes/storage/SQLStore/SMW_Sql3SmwIds.php
@@ -721,7 +721,9 @@ class SMWSql3SmwIds {
 			__METHOD__
 		);
 
-		if ( $row === false ) return; // no id at current position, ignore
+		if ( $row === false ) {
+			return; // no id at current position, ignore
+		}
 
 		if ( $targetid == 0 ) { // append new id
 			$sequenceValue = $db->nextSequenceValue( $this->getIdTable() . '_smw_id_seq' ); // Bug 42659
@@ -1054,7 +1056,9 @@ class SMWSql3SmwIds {
 	 * @param $propertyTableHash string
 	 */
 	protected function setPropertyTableHashesCache( $id, $propertyTableHash ) {
-		if ( $id == 0 ) return; // never cache 0
+		if ( $id == 0 ) {
+			return; // never cache 0
+		}
 		//print "Cache set for $id.\n";
 		$this->hashCacheId = $id;
 		$this->hashCacheContents = $propertyTableHash;
@@ -1079,7 +1083,9 @@ class SMWSql3SmwIds {
 	 */
 	public static function debugDumpCacheStats() {
 		$that = self::$singleton_debug;
-		if ( is_null( $that ) ) return;
+		if ( is_null( $that ) ) {
+			return;
+		}
 
 		$debugString =
 			"Statistics for SMWSql3SmwIds:\n" .


### PR DESCRIPTION
I am not sure about one in:
```
FILE: ...manticMediaWiki/includes/queryprinters/CategoryResultPrinter.php
----------------------------------------------------------------------
FOUND 2 ERRORS AFFECTING 1 LINE
----------------------------------------------------------------------
 105 | ERROR | [x] Inline control structures are not allowed
     |       |     (Generic.ControlStructures.InlineControlStructure.NotAllowed)
 105 | ERROR | [x] Inline control structures are not allowed
     |       |     (Generic.ControlStructures.InlineControlStructure.NotAllowed)
----------------------------------------------------------------------
PHPCBF CAN FIX THE 2 MARKED SNIFF VIOLATIONS AUTOMATICALLY
----------------------------------------------------------------------
```
This:
```php
	while ( ( $text = $field->getNextText( SMW_OUTPUT_WIKI, $this->getLinker( $first_col ) ) ) !== false ) {
		if ( $first_value ) $first_value = false; else $wikitext .= $this->mDelim . ' ';
		$wikitext .= $text;
	}
```
Becomes:
```php
	while ( ( $text = $field->getNextText( SMW_OUTPUT_WIKI, $this->getLinker( $first_col ) ) ) !== false ) {
		if ( $first_value ) {
			$first_value = false;
		} else {
			$wikitext .= $this->mDelim . ' ';
		}
		$wikitext .= $text;
	}
```
Is this correct?