### PR TITLE
QueryResolver for QuerySegmentList / ConceptQuery

### DIFF
--- a/includes/storage/SQLStore/SMW_SQLStore3.php
+++ b/includes/storage/SQLStore/SMW_SQLStore3.php
@@ -300,7 +300,7 @@ class SMWSQLStore3 extends SMWStore {
 	}
 
 	protected function fetchQueryResult( SMWQuery $query ) {
-		return $this->factory->newSalveQueryEngine()->getQueryResult( $query );
+		return $this->factory->newSlaveQueryEngine()->getQueryResult( $query );
 	}
 
 ///// Special page functions /////
@@ -411,7 +411,7 @@ class SMWSQLStore3 extends SMWStore {
 	 * @return array of error strings (empty if no errors occurred)
 	 */
 	public function refreshConceptCache( Title $concept ) {
-		return $this->factory->newMasterQueryEngine()->refreshConceptCache( $concept );
+		return $this->factory->newMasterConceptCache()->refreshConceptCache( $concept );
 	}
 
 	/**
@@ -421,7 +421,7 @@ class SMWSQLStore3 extends SMWStore {
 	 * @param Title $concept
 	 */
 	public function deleteConceptCache( $concept ) {
-		$this->factory->newMasterQueryEngine()->deleteConceptCache( $concept );
+		$this->factory->newMasterConceptCache()->deleteConceptCache( $concept );
 	}
 
 	/**

--- a/includes/storage/SQLStore/SMW_SQLStore3_Queries.php
+++ b/includes/storage/SQLStore/SMW_SQLStore3_Queries.php
@@ -7,7 +7,8 @@ use SMW\QueryOutputFormatter;
 use SMW\SQLStore\QueryEngine\ConceptCache;
 use SMW\SQLStore\QueryEngine\QueryBuilder;
 use SMW\SQLStore\QueryEngine\SqlQueryPart as SMWSQLStore3Query;
-use SMW\SQLStore\QueryEngine\SqlQueryPart;
+use SMW\SQLStore\QueryEngine\QuerySegmentListResolver;
+use SMW\SQLStore\QueryEngine\ResolverOptions;
 use SMW\SQLStore\TemporaryIdTableCreator;
 
 /**
@@ -15,11 +16,6 @@ use SMW\SQLStore\TemporaryIdTableCreator;
  * @ingroup SMWStore
  */
 class SMWSQLStore3QueryEngine {
-
-	/**
-	 * @var DatabaseBase
-	 */
-	private $dbs;
 
 	/**
 	 * Parent SMWSQLStore3.
@@ -43,13 +39,6 @@ class SMWSQLStore3QueryEngine {
 	private $queryParts = array();
 
 	/**
-	 * Array of arrays of executed queries, indexed by the temporary table names results were fed into.
-	 *
-	 * @var array
-	 */
-	private $executedQueries = array();
-
-	/**
 	 * Array of sorting requests ("Property_name" => "ASC"/"DESC"). Used during query
 	 * processing (where these property names are searched while compiling the query
 	 * conditions).
@@ -57,13 +46,6 @@ class SMWSQLStore3QueryEngine {
 	 * @var string[]
 	 */
 	private $sortKeys;
-
-	/**
-	 * Cache of computed hierarchy queries for reuse ("catetgory/property value string" => "tablename").
-	 *
-	 * @var string[]
-	 */
-	private $hierarchyCache = array();
 
 	/**
 	 * Local collection of error strings, passed on to callers if possible.
@@ -78,23 +60,35 @@ class SMWSQLStore3QueryEngine {
 	private $queryBuilder = null;
 
 	/**
-	 * @var TemporaryIdTableCreator
+	 * @var QuerySegmentListResolver
 	 */
-	private $tempIdTableCreator;
+	private $querySegmentListResolver = null;
 
 	/**
 	 * @param SMWSQLStore3 $parentStore
-	 * @param DatabaseBase $db
 	 * @param TemporaryIdTableCreator $temporaryIdTableCreator
 	 */
-	public function __construct( SMWSQLStore3 $parentStore, DatabaseBase $db, TemporaryIdTableCreator $temporaryIdTableCreator ) {
+	public function __construct( SMWSQLStore3 $parentStore, TemporaryIdTableCreator $temporaryIdTableCreator ) {
 		$this->store = $parentStore;
-		$this->dbs = $db;
 
 		// Should be injected but for now we use the hidden construction
 		$this->queryBuilder = new QueryBuilder( $this->store );
 
-		$this->tempIdTableCreator = $temporaryIdTableCreator;
+		$resolverOptions = new ResolverOptions();
+
+		$resolverOptions->set(
+			'hierarchytables',
+			array(
+				'_SUBP' => $this->store->findPropertyTableID( new SMWDIProperty( '_SUBP' ) ),
+				'_SUBC' => $this->store->findPropertyTableID( new SMWDIProperty( '_SUBC' ) )
+			)
+		);
+
+		$this->querySegmentListResolver = new QuerySegmentListResolver(
+			$this->store->getConnection( 'mw.db' ),
+			$temporaryIdTableCreator,
+			$resolverOptions
+		);
 	}
 
 	/**
@@ -109,7 +103,8 @@ class SMWSQLStore3QueryEngine {
 
 		$errors = $conceptCache->refresh( $concept );
 
-		$this->cleanUp();
+		$this->querySegmentListResolver->setQueryMode( $this->queryMode );
+		$this->querySegmentListResolver->cleanUp();
 
 		return array_merge( $this->queryBuilder->getErrors(), $errors );
 	}
@@ -124,10 +119,8 @@ class SMWSQLStore3QueryEngine {
 
 		$this->queryMode = SMWQuery::MODE_INSTANCES;
 		$this->queryParts = array();
-		$this->hierarchyCache = array();
-		$this->executedQueries = array();
 		$this->sortKeys = array();
-		SqlQueryPart::$qnum = 0;
+		SMWSQLStore3Query::$qnum = 0;
 
 		$this->queryBuilder->setSortKeys( $this->sortKeys );
 
@@ -142,7 +135,9 @@ class SMWSQLStore3QueryEngine {
 		}
 
 		// execute query tree, resolve all dependencies
-		$this->executeQueries( $this->queryParts[$qid] );
+		$this->querySegmentListResolver->setQueryMode( $this->queryMode );
+		$this->querySegmentListResolver->setQuerySegmentList( $this->queryParts );
+		$this->querySegmentListResolver->resolveForSegmentId( $qid );
 
 		return $this->queryParts[$qid];
 	}
@@ -201,10 +196,11 @@ class SMWSQLStore3QueryEngine {
 			return new SMWQueryResult( $query->getDescription()->getPrintrequests(), $query, array(), $this->store, true );
 		}
 
+		$db = $this->store->getConnection( 'mw.db' );
+
 		$this->queryMode = $query->querymode;
 		$this->queryParts = array();
-		$this->hierarchyCache = array();
-		$this->executedQueries = array();
+
 		$this->errors = array();
 		SMWSQLStore3Query::$qnum = 0;
 		$this->sortKeys = $query->sortkeys;
@@ -222,7 +218,7 @@ class SMWSQLStore3QueryEngine {
 			$q = new SMWSQLStore3Query();
 			$q->joinTable = SMWSql3SmwIds::tableName;
 			$q->joinfield = "$q->alias.smw_id";
-			$q->where = "$q->alias.smw_iw!=" . $this->dbs->addQuotes( SMW_SQL3_SMWIW_OUTDATED ) . " AND $q->alias.smw_iw!=" . $this->dbs->addQuotes( SMW_SQL3_SMWREDIIW ) . " AND $q->alias.smw_iw!=" . $this->dbs->addQuotes( SMW_SQL3_SMWBORDERIW ) . " AND $q->alias.smw_iw!=" . $this->dbs->addQuotes( SMW_SQL3_SMWINTDEFIW );
+			$q->where = "$q->alias.smw_iw!=" . $db->addQuotes( SMW_SQL3_SMWIW_OUTDATED ) . " AND $q->alias.smw_iw!=" . $db->addQuotes( SMW_SQL3_SMWREDIIW ) . " AND $q->alias.smw_iw!=" . $db->addQuotes( SMW_SQL3_SMWBORDERIW ) . " AND $q->alias.smw_iw!=" . $db->addQuotes( SMW_SQL3_SMWINTDEFIW );
 			$this->queryParts[$qid] = $q;
 		}
 
@@ -253,7 +249,11 @@ class SMWSQLStore3QueryEngine {
 		}
 
 		// *** Now execute the computed query ***//
-		$this->executeQueries( $this->queryParts[$rootid] ); // execute query tree, resolve all dependencies
+		$this->querySegmentListResolver->setQueryMode( $this->queryMode );
+		$this->querySegmentListResolver->setQuerySegmentList( $this->queryParts );
+
+		// execute query tree, resolve all dependencies
+		$this->querySegmentListResolver->resolveForSegmentId( $rootid );
 
 		switch ( $query->querymode ) {
 			case SMWQuery::MODE_DEBUG:
@@ -267,7 +267,7 @@ class SMWSQLStore3QueryEngine {
 			break;
 		}
 
-		$this->cleanUp();
+		$this->querySegmentListResolver->cleanUp();
 		$query->addErrors( $this->errors );
 
 		return $result;
@@ -303,7 +303,7 @@ class SMWSQLStore3QueryEngine {
 		}
 
 		$auxtables = '';
-		foreach ( $this->executedQueries as $table => $log ) {
+		foreach ( $this->querySegmentListResolver->getListOfResolvedQueries() as $table => $log ) {
 			$auxtables .= "<li>Temporary table $table";
 			foreach ( $log as $q ) {
 				$auxtables .= "<br />&#160;&#160;<tt>$q</tt>";
@@ -336,13 +336,22 @@ class SMWSQLStore3QueryEngine {
 			return 0;
 		}
 
+		$db = $this->store->getConnection( 'mw.db' );
+
 		$sql_options = array( 'LIMIT' => $query->getLimit() + 1, 'OFFSET' => $query->getOffset() );
-		$res = $this->dbs->select( $this->dbs->tableName( $qobj->joinTable ) . " AS $qobj->alias" . $qobj->from, "COUNT(DISTINCT $qobj->alias.smw_id) AS count", $qobj->where, 'SMW::getQueryResult', $sql_options );
-		$row = $this->dbs->fetchObject( $res );
+
+		$res = $db->select(
+			$db->tableName( $qobj->joinTable ) . " AS $qobj->alias" . $qobj->from,
+			"COUNT(DISTINCT $qobj->alias.smw_id) AS count",
+			$qobj->where,
+			__METHOD__,
+			$sql_options
+		);
+
+		$row = $db->fetchObject( $res );
 
 		$count = $row->count;
-		$this->dbs->freeResult( $res );
-
+		$db->freeResult( $res );
 
 		return $count;
 	}
@@ -382,10 +391,14 @@ class SMWSQLStore3QueryEngine {
 		// Selecting those is required in standard SQL (but MySQL does not require it).
 		$sortfields = implode( $qobj->sortfields, ',' );
 
-		$res = $db->select( $db->tableName( $qobj->joinTable ) . " AS $qobj->alias" . $qobj->from,
+		$res = $db->select(
+			$db->tableName( $qobj->joinTable ) . " AS $qobj->alias" . $qobj->from,
 			"DISTINCT $qobj->alias.smw_id AS id,$qobj->alias.smw_title AS t,$qobj->alias.smw_namespace AS ns,$qobj->alias.smw_iw AS iw,$qobj->alias.smw_subobject AS so,$qobj->alias.smw_sortkey AS sortkey" .
 			  ( $wgDBtype == 'postgres' ? ( ( $sortfields ? ',' : '' ) . $sortfields ) : '' ),
-			$qobj->where, 'SMW::getQueryResult', $sql_options );
+			$qobj->where,
+			__METHOD__,
+			$sql_options
+		);
 
 		$qr = array();
 
@@ -451,241 +464,6 @@ class SMWSQLStore3QueryEngine {
 		$result = new SMWQueryResult( $prs, $query, $qr, $this->store, $hasFurtherResults );
 
 		return $result;
-	}
-
-	/**
-	 * Process stored queries and change store accordingly. The query obj is modified
-	 * so that it contains non-recursive description of a select to execute for getting
-	 * the actual result.
-	 *
-	 * @param SMWSQLStore3Query $query
-	 */
-	private function executeQueries( SMWSQLStore3Query &$query ) {
-		global $wgDBtype;
-
-		$db = $this->store->getConnection();
-
-		switch ( $query->type ) {
-			case SMWSQLStore3Query::Q_TABLE: // Normal query with conjunctive subcondition.
-				foreach ( $query->components as $qid => $joinField ) {
-					$subQuery = $this->queryParts[$qid];
-					$this->executeQueries( $subQuery );
-
-					if ( $subQuery->joinTable !== '' ) { // Join with jointable.joinfield
-						$query->from .= ' INNER JOIN ' . $db->tableName( $subQuery->joinTable ) . " AS $subQuery->alias ON $joinField=" . $subQuery->joinfield;
-					} elseif ( $subQuery->joinfield !== '' ) { // Require joinfield as "value" via WHERE.
-						$condition = '';
-
-						foreach ( $subQuery->joinfield as $value ) {
-							$condition .= ( $condition ? ' OR ':'' ) . "$joinField=" . $db->addQuotes( $value );
-						}
-
-						if ( count( $subQuery->joinfield ) > 1 ) {
-							$condition = "($condition)";
-						}
-
-						$query->where .= ( ( $query->where === '' ) ? '':' AND ' ) . $condition;
-					} else { // interpret empty joinfields as impossible condition (empty result)
-						$query->joinfield = ''; // make whole query false
-						$query->joinTable = '';
-						$query->where = '';
-						$query->from = '';
-						break;
-					}
-
-					if ( $subQuery->where !== '' ) {
-						$query->where .= ( ( $query->where === '' ) ? '':' AND ' ) . '(' . $subQuery->where . ')';
-					}
-
-					$query->from .= $subQuery->from;
-				}
-
-				$query->components = array();
-			break;
-			case SMWSQLStore3Query::Q_CONJUNCTION:
-				// pick one subquery with jointable as anchor point ...
-				reset( $query->components );
-				$key = false;
-
-				foreach ( $query->components as $qkey => $qid ) {
-					if ( $this->queryParts[$qkey]->joinTable !== '' ) {
-						$key = $qkey;
-						break;
-					}
-				}
-
-				if ( $key !== false ) {
-					$result = $this->queryParts[$key];
-					unset( $query->components[$key] );
-
-					// Execute it first (may change jointable and joinfield, e.g. when making temporary tables)
-					$this->executeQueries( $result );
-
-					// ... and append to this query the remaining queries.
-					foreach ( $query->components as $qid => $joinField ) {
-						$result->components[$qid] = $result->joinfield;
-					}
-
-					// Second execute, now incorporating remaining conditions.
-					$this->executeQueries( $result );
-				} else { // Only fixed values in conjunction, make a new value without joining.
-					$key = $qkey;
-					$result = $this->queryParts[$key];
-					unset( $query->components[$key] );
-
-					foreach ( $query->components as $qid => $joinField ) {
-						if ( $result->joinfield != $this->queryParts[$qid]->joinfield ) {
-							$result->joinfield = ''; // all other values should already be ''
-							break;
-						}
-					}
-				}
-				$query = $result;
-			break;
-			case SMWSQLStore3Query::Q_DISJUNCTION:
-				if ( $this->queryMode !== SMWQuery::MODE_DEBUG ) {
-					$db->query( $this->getCreateTempIDTableSQL( $db->tableName( $query->alias ) ), 'SMW::executeQueries' );
-				}
-
-				$this->executedQueries[$query->alias] = array();
-
-				foreach ( $query->components as $qid => $joinField ) {
-					$subQuery = $this->queryParts[$qid];
-					$this->executeQueries( $subQuery );
-					$sql = '';
-
-					if ( $subQuery->joinTable !== '' ) {
-						$sql = 'INSERT ' . ( ( $wgDBtype == 'postgres' ) ? '':'IGNORE ' ) . 'INTO ' .
-						       $db->tableName( $query->alias ) .
-							   " SELECT $subQuery->joinfield FROM " . $db->tableName( $subQuery->joinTable ) .
-							   " AS $subQuery->alias $subQuery->from" . ( $subQuery->where ? " WHERE $subQuery->where":'' );
-					} elseif ( $subQuery->joinfield !== '' ) {
-						// NOTE: this works only for single "unconditional" values without further
-						// WHERE or FROM. The execution must take care of not creating any others.
-						$values = '';
-
-						foreach ( $subQuery->joinfield as $value ) {
-							$values .= ( $values ? ',' : '' ) . '(' . $db->addQuotes( $value ) . ')';
-						}
-
-						$sql = 'INSERT ' . ( ( $wgDBtype == 'postgres' ) ? '':'IGNORE ' ) .  'INTO ' . $db->tableName( $query->alias ) . " (id) VALUES $values";
-					} // else: // interpret empty joinfields as impossible condition (empty result), ignore
-					if ( $sql ) {
-						$this->executedQueries[$query->alias][] = $sql;
-
-						if ( $this->queryMode !== SMWQuery::MODE_DEBUG ) {
-							$db->query( $sql, 'SMW::executeQueries' );
-						}
-					}
-				}
-
-				$query->joinTable = $query->alias;
-				$query->joinfield = "$query->alias.id";
-				$query->sortfields = array(); // Make sure we got no sortfields.
-				// TODO: currently this eliminates sortkeys, possibly keep them (needs different temp table format though, maybe not such a good thing to do)
-			break;
-			case SMWSQLStore3Query::Q_PROP_HIERARCHY:
-			case SMWSQLStore3Query::Q_CLASS_HIERARCHY: // make a saturated hierarchy
-				$this->executeHierarchyQuery( $query );
-			break;
-			case SMWSQLStore3Query::Q_VALUE:
-			break; // nothing to do
-		}
-	}
-
-	/**
-	 * Find subproperties or subcategories. This may require iterative computation,
-	 * and temporary tables are used in many cases.
-	 *
-	 * @param SMWSQLStore3Query $query
-	 */
-	private function executeHierarchyQuery( SMWSQLStore3Query &$query ) {
-		global $wgDBtype, $smwgQSubpropertyDepth, $smwgQSubcategoryDepth;
-
-		$db = $this->store->getConnection();
-
-		$depth = ( $query->type == SMWSQLStore3Query::Q_PROP_HIERARCHY ) ? $smwgQSubpropertyDepth : $smwgQSubcategoryDepth;
-
-		if ( $depth <= 0 ) { // treat as value, no recursion
-			$query->type = SMWSQLStore3Query::Q_VALUE;
-			return;
-		}
-
-		$values = '';
-		$valuecond = '';
-
-		foreach ( $query->joinfield as $value ) {
-			$values .= ( $values ? ',':'' ) . '(' . $db->addQuotes( $value ) . ')';
-			$valuecond .= ( $valuecond ? ' OR ':'' ) . 'o_id=' . $db->addQuotes( $value );
-		}
-
-		$propertyKey = ( $query->type == SMWSQLStore3Query::Q_PROP_HIERARCHY ) ? '_SUBP' : '_SUBC';
-		$smwtable = $db->tableName(
-				$this->store->findPropertyTableID( new SMWDIProperty( $propertyKey ) ) );
-
-		// Try to safe time (SELECT is cheaper than creating/dropping 3 temp tables):
-		$res = $db->select( $smwtable, 's_id', $valuecond, __METHOD__, array( 'LIMIT' => 1 ) );
-
-		if ( !$db->fetchObject( $res ) ) { // no subobjects, we are done!
-			$db->freeResult( $res );
-			$query->type = SMWSQLStore3Query::Q_VALUE;
-			return;
-		}
-
-		$db->freeResult( $res );
-		$tablename = $db->tableName( $query->alias );
-		$this->executedQueries[$query->alias] = array( "Recursively computed hierarchy for element(s) $values." );
-		$query->joinTable = $query->alias;
-		$query->joinfield = "$query->alias.id";
-
-		if ( $this->queryMode == SMWQuery::MODE_DEBUG ) {
-			return; // No real queries in debug mode.
-		}
-
-		$db->query( $this->getCreateTempIDTableSQL( $tablename ), 'SMW::executeHierarchyQuery' );
-
-		if ( array_key_exists( $values, $this->hierarchyCache ) ) { // Just copy known result.
-			$db->query( "INSERT INTO $tablename (id) SELECT id" .
-								' FROM ' . $this->hierarchyCache[$values],
-								'SMW::executeHierarchyQuery' );
-			return;
-		}
-
-		// NOTE: we use two helper tables. One holds the results of each new iteration, one holds the
-		// results of the previous iteration. One could of course do with only the above result table,
-		// but then every iteration would use all elements of this table, while only the new ones
-		// obtained in the previous step are relevant. So this is a performance measure.
-		$tmpnew = 'smw_new';
-		$tmpres = 'smw_res';
-		$db->query( $this->getCreateTempIDTableSQL( $tmpnew ), 'SMW::executeQueries' );
-		$db->query( $this->getCreateTempIDTableSQL( $tmpres ), 'SMW::executeQueries' );
-		$db->query( "INSERT " . ( ( $wgDBtype == 'postgres' ) ? "" : "IGNORE" ) . " INTO $tablename (id) VALUES $values", 'SMW::executeHierarchyQuery' );
-		$db->query( "INSERT " . ( ( $wgDBtype == 'postgres' ) ? "" : "IGNORE" ) . " INTO $tmpnew (id) VALUES $values", 'SMW::executeHierarchyQuery' );
-
-		for ( $i = 0; $i < $depth; $i++ ) {
-			$db->query( "INSERT " . ( ( $wgDBtype == 'postgres' ) ? '' : 'IGNORE ' ) .  "INTO $tmpres (id) SELECT s_id" . ( $wgDBtype == 'postgres' ? '::integer':'' ) . " FROM $smwtable, $tmpnew WHERE o_id=id",
-						'SMW::executeHierarchyQuery' );
-			if ( $db->affectedRows() == 0 ) { // no change, exit loop
-				break;
-			}
-
-			$db->query( "INSERT " . ( ( $wgDBtype == 'postgres' ) ? '' : 'IGNORE ' ) . "INTO $tablename (id) SELECT $tmpres.id FROM $tmpres",
-						'SMW::executeHierarchyQuery' );
-
-			if ( $db->affectedRows() == 0 ) { // no change, exit loop
-				break;
-			}
-
-			$db->query( 'TRUNCATE TABLE ' . $tmpnew, 'SMW::executeHierarchyQuery' ); // empty "new" table
-			$tmpname = $tmpnew;
-			$tmpnew = $tmpres;
-			$tmpres = $tmpname;
-		}
-
-		$this->hierarchyCache[$values] = $tablename;
-		$db->query( ( ( $wgDBtype == 'postgres' ) ? 'DROP TABLE IF EXISTS smw_new' : 'DROP TEMPORARY TABLE smw_new' ), 'SMW::executeHierarchyQuery' );
-		$db->query( ( ( $wgDBtype == 'postgres' ) ? 'DROP TABLE IF EXISTS smw_res' : 'DROP TEMPORARY TABLE smw_res' ), 'SMW::executeHierarchyQuery' );
-
 	}
 
 	/**
@@ -786,38 +564,6 @@ class SMWSQLStore3QueryEngine {
 			}
 		}
 		return $result;
-	}
-
-	/**
-	 * After querying, make sure no temporary database tables are left.
-	 * @todo I might be better to keep the tables and possibly reuse them later
-	 * on. Being temporary, the tables will vanish with the session anyway.
-	 */
-	private function cleanUp() {
-		global $wgDBtype;
-
-		$db = $this->store->getConnection();
-
-		if ( $this->queryMode !== SMWQuery::MODE_DEBUG ) {
-			foreach ( $this->executedQueries as $table => $log ) {
-				$db->query( ( ( $wgDBtype == 'postgres' ) ? "DROP TABLE IF EXISTS ":"DROP TEMPORARY TABLE " ) . $db->tableName( $table ), 'SMW::getQueryResult' );
-			}
-		}
-	}
-
-	/**
-	 * Get SQL code suitable to create a temporary table of the given name, used to store ids.
-	 * MySQL can do that simply by creating new temporary tables. PostgreSQL first checks if such
-	 * a table exists, so the code is ready to reuse existing tables if the code was modified to
-	 * keep them after query answering. Also, PostgreSQL tables will use a RULE to achieve built-in
-	 * duplicate elimination. The latter is done using INSERT IGNORE in MySQL.
-	 *
-	 * @param string $tableName
-	 *
-	 * @return string
-	 */
-	private function getCreateTempIDTableSQL( $tableName ) {
-		return $this->tempIdTableCreator->getSqlToCreate( $tableName );
 	}
 
 }

--- a/src/MediaWiki/Database.php
+++ b/src/MediaWiki/Database.php
@@ -214,7 +214,12 @@ class Database {
 	 */
 	public function query( $sql, $fname = __METHOD__, $ignoreException = false ) {
 
+		if ( $this->getType() !== 'postgres' ) {
+			$sql = str_replace( '@INT', '', $sql );
+		}
+
 		if ( $this->getType() == 'postgres' ) {
+			$sql = str_replace( '@INT', '::integer', $sql );
 			$sql = str_replace( 'IGNORE', '', $sql );
 			$sql = str_replace( 'DROP TEMPORARY TABLE', 'DROP TABLE IF EXISTS', $sql );
 			$sql = str_replace( 'RAND()', ( strpos( $sql, 'DISTINCT' ) !== false ? '' : 'RANDOM()' ), $sql );

--- a/src/SQLStore/QueryEngine/ConceptQueryResolver.php
+++ b/src/SQLStore/QueryEngine/ConceptQueryResolver.php
@@ -1,0 +1,99 @@
+<?php
+
+namespace SMW\SQLStore\QueryEngine;
+
+use SMWSQLStore3QueryEngine;
+use SMW\SQLStore\QueryEngine\SqlQueryPart as SMWSQLStore3Query;
+use SMWQueryParser as QueryParser;
+use SMWQuery as Query;
+
+/**
+ * @license GNU GPL v2+
+ * @since 2.2
+ *
+ * @author mwjames
+ */
+class ConceptQueryResolver {
+
+	/**
+	 * @var SMWSQLStore3QueryEngine
+	 */
+	private $queryEngine;
+
+	/**
+	 * @var integer
+	 */
+	private $conceptFeatures;
+
+	/**
+	 * @since 2.2
+	 *
+	 * @param SMWSQLStore3QueryEngine $queryEngine
+	 */
+	public function __construct( SMWSQLStore3QueryEngine $queryEngine ) {
+		$this->queryEngine = $queryEngine;
+	}
+
+	/**
+	 * @since 2.2
+	 *
+	 * @param integer $conceptFeatures
+	 */
+	public function setConceptFeatures( $conceptFeatures ) {
+		$this->conceptFeatures = $conceptFeatures;
+	}
+
+	/**
+	 * @param string $conceptDescriptionText
+	 *
+	 * @return SqlQueryPart|null
+	 */
+	public function prepareQuerySegmentFor( $conceptDescriptionText ) {
+
+		$querySegements = array();
+		SMWSQLStore3Query::$qnum = 0;
+
+		$queryBuilder = $this->queryEngine->getQueryBuilder();
+		$queryBuilder->setSortKeys( array() );
+
+		$qp = new QueryParser( $this->conceptFeatures );
+
+		$queryBuilder->buildSqlQueryPartFor(
+			$qp->getQueryDescription( $conceptDescriptionText )
+		);
+
+		$qid = $queryBuilder->getLastSqlQueryPartId();
+		$querySegements = $queryBuilder->getSqlQueryParts();
+
+		if ( $qid < 0 ) {
+			return null;
+		}
+
+		// execute query tree, resolve all dependencies
+		$querySegmentListResolver = $this->queryEngine->getQuerySegmentListResolver();
+
+		$querySegmentListResolver->setQueryMode( Query::MODE_INSTANCES );
+		$querySegmentListResolver->setQuerySegmentList( $querySegements );
+		$querySegmentListResolver->resolveForSegmentId( $qid );
+
+		return $querySegements[$qid];
+	}
+
+	/**
+	 * @since 2.2
+	 */
+	public function cleanUp() {
+		$this->queryEngine->getQuerySegmentListResolver()->setQueryMode( Query::MODE_INSTANCES );
+		$this->queryEngine->getQuerySegmentListResolver()->cleanUp();
+	}
+
+	/**
+	 * @since 2.2
+	 *
+	 * @return array
+	 */
+	public function getErrors() {
+		return $this->queryEngine->getQueryBuilder()->getErrors();
+	}
+
+}

--- a/src/SQLStore/QueryEngine/QuerySegmentListResolver.php
+++ b/src/SQLStore/QueryEngine/QuerySegmentListResolver.php
@@ -1,0 +1,441 @@
+<?php
+
+namespace SMW\SQLStore\QueryEngine;
+
+use SMW\MediaWiki\Database;
+use SMW\SQLStore\TemporaryIdTableCreator;
+use SMW\SQLStore\QueryEngine\SqlQueryPart as SMWSQLStore3Query;
+use SMWQuery as Query;
+use RuntimeException;
+
+/**
+ * @license GNU GPL v2+
+ * @since 2.2
+ *
+ * @author Markus Krötzsch
+ * @author Jeroen De Dauw
+ * @author mwjames
+ */
+class QuerySegmentListResolver {
+
+	/**
+	 * @var Database
+	 */
+	private $connection;
+
+	/**
+	 * @var TemporaryIdTableCreator
+	 */
+	private $tempIdTableCreator;
+
+	/**
+	 * @var ResolverOptions
+	 */
+	private $resolverOptions;
+
+	/**
+	 * Array of arrays of executed queries, indexed by the temporary table names
+	 * results were fed into.
+	 *
+	 * @var array
+	 */
+	private $executedQueries = array();
+
+	/**
+	 * Cache of computed hierarchy queries for reuse ("catetgory/property value
+	 * string" => "tablename").
+	 *
+	 * @var string[]
+	 */
+	private $hierarchyCache = array();
+
+	/**
+	 * Query mode copied from given query. Some submethods act differently when
+	 * in Query::MODE_DEBUG.
+	 *
+	 * @var int
+	 */
+	private $queryMode;
+
+	/**
+	 * @var array
+	 */
+	private $querySegments = array();
+
+	/**
+	 * @param Database $connection
+	 * @param TemporaryIdTableCreator $temporaryIdTableCreator
+	 * @param ResolverOptions $resolverOptions
+	 */
+	public function __construct( Database $connection, TemporaryIdTableCreator $temporaryIdTableCreator, ResolverOptions $resolverOptions ) {
+		$this->connection = $connection;
+		$this->tempIdTableCreator = $temporaryIdTableCreator;
+		$this->resolverOptions = $resolverOptions;
+	}
+
+	/**
+	 * @since 2.2
+	 *
+	 * @return array
+	 */
+	public function getListOfResolvedQueries() {
+		return $this->executedQueries;
+	}
+
+	/**
+	 * @since 2.2
+	 *
+	 * @param &$querySegments
+	 */
+	public function setQuerySegmentList( &$querySegments ) {
+		$this->querySegments =& $querySegments;
+	}
+
+	/**
+	 * @since 2.2
+	 *
+	 * @param integer
+	 */
+	public function setQueryMode( $queryMode ) {
+		$this->queryMode = $queryMode;
+	}
+
+	/**
+	 * Process stored queries and change store accordingly. The query obj is modified
+	 * so that it contains non-recursive description of a select to execute for getting
+	 * the actual result.
+	 *
+	 * @param integer $id
+	 * @throws RuntimeException
+	 */
+	public function resolveForSegmentId( $id ) {
+
+		$this->hierarchyCache = array();
+		$this->executedQueries = array();
+
+		// Should never happen
+		if ( !isset( $this->querySegments[$id] ) ) {
+			throw new RuntimeException( "$id doesn't exist" );
+		}
+
+		$this->resolveForSegment( $this->querySegments[$id] );
+	}
+
+	/**
+	 * Process stored queries and change store accordingly. The query obj is modified
+	 * so that it contains non-recursive description of a select to execute for getting
+	 * the actual result.
+	 *
+	 * @param SMWSQLStore3Query $query
+	 */
+	public function resolveForSegment( SMWSQLStore3Query &$query ) {
+
+		$db = $this->connection;
+
+		switch ( $query->type ) {
+			case SMWSQLStore3Query::Q_TABLE: // Normal query with conjunctive subcondition.
+				foreach ( $query->components as $qid => $joinField ) {
+					$subQuery = $this->querySegments[$qid];
+					$this->resolveForSegment( $subQuery );
+
+					if ( $subQuery->joinTable !== '' ) { // Join with jointable.joinfield
+						$query->from .= ' INNER JOIN ' . $db->tableName( $subQuery->joinTable ) . " AS $subQuery->alias ON $joinField=" . $subQuery->joinfield;
+					} elseif ( $subQuery->joinfield !== '' ) { // Require joinfield as "value" via WHERE.
+						$condition = '';
+
+						foreach ( $subQuery->joinfield as $value ) {
+							$condition .= ( $condition ? ' OR ':'' ) . "$joinField=" . $db->addQuotes( $value );
+						}
+
+						if ( count( $subQuery->joinfield ) > 1 ) {
+							$condition = "($condition)";
+						}
+
+						$query->where .= ( ( $query->where === '' ) ? '':' AND ' ) . $condition;
+					} else { // interpret empty joinfields as impossible condition (empty result)
+						$query->joinfield = ''; // make whole query false
+						$query->joinTable = '';
+						$query->where = '';
+						$query->from = '';
+						break;
+					}
+
+					if ( $subQuery->where !== '' ) {
+						$query->where .= ( ( $query->where === '' ) ? '':' AND ' ) . '(' . $subQuery->where . ')';
+					}
+
+					$query->from .= $subQuery->from;
+				}
+
+				$query->components = array();
+			break;
+			case SMWSQLStore3Query::Q_CONJUNCTION:
+				// pick one subquery with jointable as anchor point ...
+				reset( $query->components );
+				$key = false;
+
+				foreach ( $query->components as $qkey => $qid ) {
+					if ( $this->querySegments[$qkey]->joinTable !== '' ) {
+						$key = $qkey;
+						break;
+					}
+				}
+
+				if ( $key !== false ) {
+					$result = $this->querySegments[$key];
+					unset( $query->components[$key] );
+
+					// Execute it first (may change jointable and joinfield, e.g. when making temporary tables)
+					$this->resolveForSegment( $result );
+
+					// ... and append to this query the remaining queries.
+					foreach ( $query->components as $qid => $joinField ) {
+						$result->components[$qid] = $result->joinfield;
+					}
+
+					// Second execute, now incorporating remaining conditions.
+					$this->resolveForSegment( $result );
+				} else { // Only fixed values in conjunction, make a new value without joining.
+					$key = $qkey;
+					$result = $this->querySegments[$key];
+					unset( $query->components[$key] );
+
+					foreach ( $query->components as $qid => $joinField ) {
+						if ( $result->joinfield != $this->querySegments[$qid]->joinfield ) {
+							$result->joinfield = ''; // all other values should already be ''
+							break;
+						}
+					}
+				}
+				$query = $result;
+			break;
+			case SMWSQLStore3Query::Q_DISJUNCTION:
+				if ( $this->queryMode !== Query::MODE_DEBUG ) {
+					$db->query(
+						$this->getCreateTempIDTableSQL( $db->tableName( $query->alias ) ),
+						__METHOD__
+					);
+				}
+
+				$this->executedQueries[$query->alias] = array();
+
+				foreach ( $query->components as $qid => $joinField ) {
+					$subQuery = $this->querySegments[$qid];
+					$this->resolveForSegment( $subQuery );
+					$sql = '';
+
+					if ( $subQuery->joinTable !== '' ) {
+						$sql = 'INSERT ' . 'IGNORE ' . 'INTO ' .
+						       $db->tableName( $query->alias ) .
+							   " SELECT $subQuery->joinfield FROM " . $db->tableName( $subQuery->joinTable ) .
+							   " AS $subQuery->alias $subQuery->from" . ( $subQuery->where ? " WHERE $subQuery->where":'' );
+					} elseif ( $subQuery->joinfield !== '' ) {
+						// NOTE: this works only for single "unconditional" values without further
+						// WHERE or FROM. The execution must take care of not creating any others.
+						$values = '';
+
+						foreach ( $subQuery->joinfield as $value ) {
+							$values .= ( $values ? ',' : '' ) . '(' . $db->addQuotes( $value ) . ')';
+						}
+
+						$sql = 'INSERT ' . 'IGNORE ' .  'INTO ' . $db->tableName( $query->alias ) . " (id) VALUES $values";
+					} // else: // interpret empty joinfields as impossible condition (empty result), ignore
+					if ( $sql ) {
+						$this->executedQueries[$query->alias][] = $sql;
+
+						if ( $this->queryMode !== Query::MODE_DEBUG ) {
+							$db->query(
+								$sql,
+								__METHOD__
+							);
+						}
+					}
+				}
+
+				$query->joinTable = $query->alias;
+				$query->joinfield = "$query->alias.id";
+				$query->sortfields = array(); // Make sure we got no sortfields.
+				// TODO: currently this eliminates sortkeys, possibly keep them (needs different temp table format though, maybe not such a good thing to do)
+			break;
+			case SMWSQLStore3Query::Q_PROP_HIERARCHY:
+			case SMWSQLStore3Query::Q_CLASS_HIERARCHY: // make a saturated hierarchy
+				$this->resolveHierarchyForSegment( $query );
+			break;
+			case SMWSQLStore3Query::Q_VALUE:
+			break; // nothing to do
+		}
+	}
+
+	/**
+	 * Find subproperties or subcategories. This may require iterative computation,
+	 * and temporary tables are used in many cases.
+	 *
+	 * @param SMWSQLStore3Query $query
+	 */
+	private function resolveHierarchyForSegment( SMWSQLStore3Query &$query ) {
+
+		$db = $this->connection;
+
+		if ( $query->type === SMWSQLStore3Query::Q_PROP_HIERARCHY ) {
+			$depth = $this->resolverOptions->get( 'subpropertyDepth' );
+		} else {
+			$depth = $this->resolverOptions->get( 'subcategoryDepth' );
+		}
+
+		if ( $depth <= 0 ) { // treat as value, no recursion
+			$query->type = SMWSQLStore3Query::Q_VALUE;
+			return;
+		}
+
+		$values = '';
+		$valuecond = '';
+
+		foreach ( $query->joinfield as $value ) {
+			$values .= ( $values ? ',':'' ) . '(' . $db->addQuotes( $value ) . ')';
+			$valuecond .= ( $valuecond ? ' OR ':'' ) . 'o_id=' . $db->addQuotes( $value );
+		}
+
+		$propertyKey = ( $query->type == SMWSQLStore3Query::Q_PROP_HIERARCHY ) ? '_SUBP' : '_SUBC';
+
+		$hierarchytables = $this->resolverOptions->get( 'hierarchytables' );
+		$smwtable = $db->tableName( $hierarchytables[$propertyKey] );
+
+		// Try to safe time (SELECT is cheaper than creating/dropping 3 temp tables):
+		$res = $db->select( $smwtable, 's_id', $valuecond, __METHOD__, array( 'LIMIT' => 1 ) );
+
+		if ( !$db->fetchObject( $res ) ) { // no subobjects, we are done!
+			$db->freeResult( $res );
+			$query->type = SMWSQLStore3Query::Q_VALUE;
+			return;
+		}
+
+		$db->freeResult( $res );
+		$tablename = $db->tableName( $query->alias );
+		$this->executedQueries[$query->alias] = array( "Recursively computed hierarchy for element(s) $values." );
+		$query->joinTable = $query->alias;
+		$query->joinfield = "$query->alias.id";
+
+		if ( $this->queryMode == Query::MODE_DEBUG ) {
+			return; // No real queries in debug mode.
+		}
+
+		$db->query(
+			$this->getCreateTempIDTableSQL( $tablename ),
+			__METHOD__
+		);
+
+		if ( array_key_exists( $values, $this->hierarchyCache ) ) { // Just copy known result.
+
+			$db->query(
+				"INSERT INTO $tablename (id) SELECT id" . ' FROM ' . $this->hierarchyCache[$values],
+				__METHOD__
+			);
+
+			return;
+		}
+
+		// NOTE: we use two helper tables. One holds the results of each new iteration, one holds the
+		// results of the previous iteration. One could of course do with only the above result table,
+		// but then every iteration would use all elements of this table, while only the new ones
+		// obtained in the previous step are relevant. So this is a performance measure.
+		$tmpnew = 'smw_new';
+		$tmpres = 'smw_res';
+
+		$db->query(
+			$this->getCreateTempIDTableSQL( $tmpnew ),
+			__METHOD__
+		);
+
+		$db->query(
+			$this->getCreateTempIDTableSQL( $tmpres ),
+			__METHOD__
+		);
+
+		$db->query(
+			"INSERT " . "IGNORE" . " INTO $tablename (id) VALUES $values",
+			__METHOD__
+		);
+
+		$db->query(
+			"INSERT " . "IGNORE" . " INTO $tmpnew (id) VALUES $values",
+			__METHOD__
+		);
+
+		for ( $i = 0; $i < $depth; $i++ ) {
+			$db->query(
+				"INSERT " . 'IGNORE ' .  "INTO $tmpres (id) SELECT s_id" . '@INT' . " FROM $smwtable, $tmpnew WHERE o_id=id",
+				__METHOD__
+			);
+
+			if ( $db->affectedRows() == 0 ) { // no change, exit loop
+				break;
+			}
+
+			$db->query(
+				"INSERT " . 'IGNORE ' . "INTO $tablename (id) SELECT $tmpres.id FROM $tmpres",
+				__METHOD__
+			);
+
+			if ( $db->affectedRows() == 0 ) { // no change, exit loop
+				break;
+			}
+
+ 			// empty "new" table
+			$db->query(
+				'TRUNCATE TABLE ' . $tmpnew,
+				__METHOD__
+			);
+
+			$tmpname = $tmpnew;
+			$tmpnew = $tmpres;
+			$tmpres = $tmpname;
+		}
+
+		$this->hierarchyCache[$values] = $tablename;
+
+		$db->query(
+			'DROP TEMPORARY TABLE smw_new',
+			__METHOD__
+		);
+
+		$db->query(
+			'DROP TEMPORARY TABLE smw_res',
+			__METHOD__
+		);
+	}
+
+	/**
+	 * After querying, make sure no temporary database tables are left.
+	 * @todo I might be better to keep the tables and possibly reuse them later
+	 * on. Being temporary, the tables will vanish with the session anyway.
+	 */
+	public function cleanUp() {
+
+		if ( $this->queryMode  === Query::MODE_DEBUG ) {
+			return;
+		}
+
+		foreach ( $this->executedQueries as $table => $log ) {
+			$this->connection->query(
+				"DROP TEMPORARY TABLE " . $this->connection->tableName( $table ),
+				__METHOD__
+			);
+		}
+	}
+
+	/**
+	 * Get SQL code suitable to create a temporary table of the given name, used to store ids.
+	 * MySQL can do that simply by creating new temporary tables. PostgreSQL first checks if such
+	 * a table exists, so the code is ready to reuse existing tables if the code was modified to
+	 * keep them after query answering. Also, PostgreSQL tables will use a RULE to achieve built-in
+	 * duplicate elimination. The latter is done using INSERT IGNORE in MySQL.
+	 *
+	 * @param string $tableName
+	 *
+	 * @return string
+	 */
+	private function getCreateTempIDTableSQL( $tableName ) {
+		return $this->tempIdTableCreator->getSqlToCreate( $tableName );
+	}
+
+}

--- a/src/SQLStore/QueryEngine/ResolverOptions.php
+++ b/src/SQLStore/QueryEngine/ResolverOptions.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace SMW\SQLStore\QueryEngine;
+
+use InvalidArgumentException;
+
+/**
+ * @license GNU GPL v2+
+ * @since 2.2
+ *
+ * @author mwjames
+ */
+class ResolverOptions {
+
+	/**
+	 * @var array
+	 */
+	private $options = array();
+
+	/**
+	 * @since 2.2
+	 */
+	public function __construct() {
+		$this->set( 'subpropertyDepth', $GLOBALS['smwgQSubpropertyDepth'] );
+		$this->set( 'subcategoryDepth', $GLOBALS['smwgQSubcategoryDepth'] );
+	}
+
+	/**
+	 * @since 2.2
+	 *
+	 * @param string $key
+	 * @param mixed $value
+	 */
+	public function set( $key, $value ) {
+		$this->options[$key] = $value;
+	}
+
+	/**
+	 * @since 2.2
+	 *
+	 * @param string $key
+	 *
+	 * @return boolean
+	 */
+	public function has( $key ) {
+		return isset( $this->options[$key] ) || array_key_exists( $key, $this->options );
+	}
+
+	/**
+	 * @since 2.2
+	 *
+	 * @param string $key
+	 *
+	 * @return string
+	 * @throws InvalidArgumentException
+	 */
+	public function get( $key ) {
+
+		if ( $this->has( $key ) ) {
+			return $this->options[$key];
+		}
+
+		throw new InvalidArgumentException( "{$key} is an unregistered option" );
+	}
+
+}

--- a/src/SQLStore/SQLStoreFactory.php
+++ b/src/SQLStore/SQLStoreFactory.php
@@ -39,7 +39,6 @@ class SQLStoreFactory {
 	public function newSalveQueryEngine() {
 		return new SMWSQLStore3QueryEngine(
 			$this->store,
-			wfGetDB( DB_SLAVE ),
 			$this->newTemporaryIdTableCreator()
 		);
 	}
@@ -47,7 +46,6 @@ class SQLStoreFactory {
 	public function newMasterQueryEngine() {
 		return new SMWSQLStore3QueryEngine(
 			$this->store,
-			wfGetDB( DB_SLAVE ),
 			$this->newTemporaryIdTableCreator()
 		);
 	}

--- a/tests/phpunit/includes/SQLStore/ConceptCacheTest.php
+++ b/tests/phpunit/includes/SQLStore/ConceptCacheTest.php
@@ -1,0 +1,94 @@
+<?php
+
+namespace SMW\Tests\SQLStore;
+
+use SMW\SQLStore\ConceptCache;
+use Title;
+
+/**
+ * @covers \SMW\SQLStore\ConceptCache
+ *
+ * @group semantic-mediawiki
+ *
+ * @license GNU GPL v2+
+ * @since 2.2
+ *
+ * @author mwjames
+ */
+class ConceptCacheTest extends \PHPUnit_Framework_TestCase {
+
+	public function testCanConstruct() {
+
+		$store = $this->getMockBuilder( '\SMWSQLStore3' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$conceptQueryResolver = $this->getMockBuilder( '\SMW\SQLStore\QueryEngine\ConceptQueryResolver' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$this->assertInstanceOf(
+			'\SMW\SQLStore\ConceptCache',
+			new ConceptCache( $store, $conceptQueryResolver )
+		);
+	}
+
+	public function testRefreshConceptCache() {
+
+		$conceptQueryResolver = $this->getMockBuilder( '\SMW\SQLStore\QueryEngine\ConceptQueryResolver' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$conceptQueryResolver->expects( $this->once() )
+			->method( 'getErrors' )
+			->will( $this->returnValue( array() ) );
+
+		$instance = new ConceptCache(
+			new \SMWSQLStore3(),
+			$conceptQueryResolver
+		);
+
+		$instance->refreshConceptCache(
+			Title::newFromText( 'Foo', SMW_NS_CONCEPT )
+		);
+	}
+
+	public function testDeleteConceptCache() {
+
+		$connection = $this->getMockBuilder( '\SMW\MediaWiki\Database' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$connection->expects( $this->any() )
+			->method( 'selectRow' )
+			->will( $this->returnValue( false ) );
+
+		$connection->expects( $this->once() )
+			->method( 'delete' );
+
+		$connectionManager = $this->getMockBuilder( '\SMW\ConnectionManager' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$connectionManager->expects( $this->atLeastOnce() )
+			->method( 'getConnection' )
+			->will( $this->returnValue( $connection ) );
+
+		$store = new \SMWSQLStore3();
+		$store->setConnectionManager( $connectionManager );
+
+		$conceptQueryResolver = $this->getMockBuilder( '\SMW\SQLStore\QueryEngine\ConceptQueryResolver' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$instance = new ConceptCache(
+			$store,
+			$conceptQueryResolver
+		);
+
+		$instance->deleteConceptCache(
+			Title::newFromText( 'Foo', SMW_NS_CONCEPT )
+		);
+	}
+
+}

--- a/tests/phpunit/includes/SQLStore/QueryEngine/ConceptQueryResolverTest.php
+++ b/tests/phpunit/includes/SQLStore/QueryEngine/ConceptQueryResolverTest.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace SMW\Tests\SQLStore\QueryEngine;
+
+use SMW\SQLStore\QueryEngine\ConceptQueryResolver;
+use Title;
+
+/**
+ * @covers \SMW\SQLStore\QueryEngine\ConceptQueryResolver
+ *
+ * @group semantic-mediawiki
+ *
+ * @license GNU GPL v2+
+ * @since 2.2
+ *
+ * @author mwjames
+ */
+class ConceptQueryResolverTest extends \PHPUnit_Framework_TestCase {
+
+	public function testCanConstruct() {
+
+		$queryEngine = $this->getMockBuilder( '\SMWSQLStore3QueryEngine' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$this->assertInstanceOf(
+			'\SMW\SQLStore\QueryEngine\ConceptQueryResolver',
+			new ConceptQueryResolver( $queryEngine )
+		);
+	}
+
+	public function testPrepareQuerySegmentForNull() {
+
+		$queryBuilder = $this->getMockBuilder( '\SMW\SQLStore\QueryEngine\QueryBuilder' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$querySegmentListResolver = $this->getMockBuilder( '\SMW\SQLStore\QueryEngine\QuerySegmentListResolver' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$queryEngine = $this->getMockBuilder( '\SMWSQLStore3QueryEngine' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$queryEngine->expects( $this->any() )
+			->method( 'getQueryBuilder' )
+			->will( $this->returnValue( $queryBuilder ) );
+
+		$queryEngine->expects( $this->any() )
+			->method( 'getQuerySegmentListResolver' )
+			->will( $this->returnValue( $querySegmentListResolver ) );
+
+		$instance = new ConceptQueryResolver( $queryEngine );
+
+		$this->assertNull(
+			$instance->prepareQuerySegmentFor( '[[Foo]]' )
+		);
+	}
+
+}

--- a/tests/phpunit/includes/SQLStore/QueryEngine/QuerySegmentListResolverTest.php
+++ b/tests/phpunit/includes/SQLStore/QueryEngine/QuerySegmentListResolverTest.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace SMW\Tests\SQLStore\QueryEngine;
+
+use SMW\SQLStore\QueryEngine\QuerySegmentListResolver;
+
+/**
+ * @covers \SMW\SQLStore\QueryEngine\QuerySegmentListResolver
+ *
+ * @group semantic-mediawiki
+ *
+ * @license GNU GPL v2+
+ * @since 2.2
+ *
+ * @author mwjames
+ */
+class QuerySegmentListResolverTest extends \PHPUnit_Framework_TestCase {
+
+	public function testCanConstruct() {
+
+		$connection = $this->getMockBuilder( '\SMW\MediaWiki\Database' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$temporaryIdTableCreator = $this->getMockBuilder( '\SMW\SQLStore\TemporaryIdTableCreator' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$resolverOptions = $this->getMockBuilder( '\SMW\SQLStore\QueryEngine\ResolverOptions' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$this->assertInstanceOf(
+			'\SMW\SQLStore\QueryEngine\QuerySegmentListResolver',
+			new QuerySegmentListResolver( $connection, $temporaryIdTableCreator, $resolverOptions )
+		);
+	}
+
+	public function testTryResolveSegmentForInvalidIdThrowsException() {
+
+		$connection = $this->getMockBuilder( '\SMW\MediaWiki\Database' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$temporaryIdTableCreator = $this->getMockBuilder( '\SMW\SQLStore\TemporaryIdTableCreator' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$resolverOptions = $this->getMockBuilder( '\SMW\SQLStore\QueryEngine\ResolverOptions' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$instance = new QuerySegmentListResolver(
+			$connection,
+			$temporaryIdTableCreator,
+			$resolverOptions
+		);
+
+		$this->setExpectedException( 'RuntimeException' );
+		$instance->resolveForSegmentId( 42 );
+	}
+
+}

--- a/tests/phpunit/includes/SQLStore/QueryEngine/ResolverOptionsTest.php
+++ b/tests/phpunit/includes/SQLStore/QueryEngine/ResolverOptionsTest.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace SMW\Tests\SQLStore\QueryEngine;
+
+use SMW\SQLStore\QueryEngine\ResolverOptions;
+
+/**
+ * @covers \SMW\SQLStore\QueryEngine\ResolverOptions
+ *
+ * @group semantic-mediawiki
+ *
+ * @license GNU GPL v2+
+ * @since 2.2
+ *
+ * @author mwjames
+ */
+class ResolverOptionsTest extends \PHPUnit_Framework_TestCase {
+
+	public function testCanConstruct() {
+
+		$this->assertInstanceOf(
+			'\SMW\SQLStore\QueryEngine\ResolverOptions',
+			new ResolverOptions()
+		);
+	}
+
+	public function testInitialState() {
+
+		$instance = new ResolverOptions();
+
+		$this->assertInternalType(
+			'integer',
+			$instance->get( 'subpropertyDepth' )
+		);
+
+		$this->assertInternalType(
+			'integer',
+			$instance->get( 'subcategoryDepth' )
+		);
+	}
+
+	public function testAddOption() {
+
+		$instance = new ResolverOptions();
+
+		$this->assertFalse(
+			$instance->has( 'Foo' )
+		);
+
+		$instance->set( 'Foo', 42 );
+
+		$this->assertEquals(
+			42,
+			$instance->get( 'Foo' )
+		);
+	}
+
+	public function testUnregisteredKeyThrowsException() {
+
+		$instance = new ResolverOptions();
+
+		$this->setExpectedException( 'InvalidArgumentException' );
+		$instance->get( 'Foo' );
+	}
+
+}

--- a/tests/phpunit/includes/SQLStore/SQLStoreFactoryTest.php
+++ b/tests/phpunit/includes/SQLStore/SQLStoreFactoryTest.php
@@ -7,24 +7,37 @@ use SMW\Store;
 use SMWSQLStore3;
 
 /**
- * @covers SMW\SQLStore\SQLStoreFactory
+ * @covers \SMW\SQLStore\SQLStoreFactory
  *
- * @group SMW
- * @group SMWExtension
+ * @group semantic-mediawiki
  *
- * @licence GNU GPL v2+
+ * @license GNU GPL v2+
+ * @since 2.2
+ *
  * @author Jeroen De Dauw < jeroendedauw@gmail.com >
  */
 class SQLStoreFactoryTest extends \PHPUnit_Framework_TestCase {
+
+	public function testCanConstruct() {
+
+		$store = $this->getMockBuilder( '\SMWSQLStore3' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$this->assertInstanceOf(
+			'\SMW\SQLStore\SQLStoreFactory',
+			new SQLStoreFactory( $store )
+		);
+	}
 
 	private function newInstance() {
 		return new SQLStoreFactory( new SMWSQLStore3() );
 	}
 
-	public function testNewSalveQueryEngineReturnType() {
+	public function testNewSlaveQueryEngineReturnType() {
 		$this->assertInstanceOf(
 			'SMWSQLStore3QueryEngine',
-			$this->newInstance()->newSalveQueryEngine()
+			$this->newInstance()->newSlaveQueryEngine()
 		);
 	}
 
@@ -35,9 +48,16 @@ class SQLStoreFactoryTest extends \PHPUnit_Framework_TestCase {
 		);
 	}
 
-	public function testNewSlaveConceptCacheReturnType() {
+	public function testNewMasterConceptCache() {
 		$this->assertInstanceOf(
-			'SMW\SQLStore\QueryEngine\ConceptCache',
+			'SMW\SQLStore\ConceptCache',
+			$this->newInstance()->newMasterConceptCache()
+		);
+	}
+
+	public function testNewSlaveConceptCache() {
+		$this->assertInstanceOf(
+			'SMW\SQLStore\ConceptCache',
 			$this->newInstance()->newSlaveConceptCache()
 		);
 	}


### PR DESCRIPTION
This isolates the whole `SMWSQLStore3QueryEngine::executeQueries` stuff and moves it into its own component `QuerySegmentListResolver`.

- `QuerySegmentListResolver` is made DB agnostic, any special treatment is handled by the `SMW\MediaWiki\Database`.
- `QuerySegmentListResolver` needs some serious re-factoring but it is not part of this PR, it merely moves the code to an isolatable class.

Follow-up:
- ~~Use the `SQLStoreFactory` to create objects and inject them into the constructor~~
- Rename `SqlQueyPart` (never got warm with this class name) to `QuerySegment`

The `QueryBuilder` spits out a `QuerySegmentList` which is resolved by the `QuerySegmentListResolver` (flatten hierarchies, build non-recursive sql segments etc.) and ultimately forwarded to the ` $db->select( ... )` command.
