### PR TITLE
Exporter / Performance / use object for inmemory-cache

### DIFF
--- a/includes/export/SMW_Exp_Data.php
+++ b/includes/export/SMW_Exp_Data.php
@@ -50,6 +50,11 @@ class SMWExpData implements Element {
 	protected $m_edges = array();
 
 	/**
+	 * @var string|null
+	 */
+	private $hash = null;
+
+	/**
 	 * Constructor. $subject is the SMWExpResource for the
 	 * subject about which this SMWExpData is.
 	 */
@@ -74,21 +79,28 @@ class SMWExpData implements Element {
 	 */
 	public function getHash() {
 
-		$hash = array();
-		$hash[] = $this->m_subject->getHash();
+		if ( $this->hash !== null ) {
+			return $this->hash;
+		}
+
+		$hashes = array();
+		$hashes[] = $this->m_subject->getHash();
 
 		foreach ( $this->getProperties() as $property ) {
 
-			$hash[] = $property->getHash();
+			$hashes[] = $property->getHash();
 
 			foreach ( $this->getValues( $property ) as $child ) {
-				$hash[] = $child->getHash();
+				$hashes[] = $child->getHash();
 			}
 		}
 
-		sort( $hash );
+		sort( $hashes );
 
-		return md5( implode( '#', $hash ) );
+		$this->hash = md5( implode( '#', $hashes ) );
+		unset( $hashes );
+
+		return $this->hash;
 	}
 
 	/**
@@ -141,6 +153,8 @@ class SMWExpData implements Element {
 	 * @param Element $child
 	 */
 	public function addPropertyObjectValue( SMWExpNsResource $property, Element $child ) {
+
+		$this->hash = null;
 
 		if ( !array_key_exists( $property->getUri(), $this->m_edges ) ) {
 			$this->m_children[$property->getUri()] = array();

--- a/src/Exporter/CachedDataItemToExpResourceEncoder.php
+++ b/src/Exporter/CachedDataItemToExpResourceEncoder.php
@@ -141,8 +141,11 @@ class CachedDataItemToExpResourceEncoder {
 
 		$hash = $this->cachePrefix . $diWikiPage->getHash() . $modifier;
 
+		// If a persistent cache is injected use the ExpElement serializer because
+		// not all cache layers support object de/serialization
+		// ExpElement::newFromSerialization
 		if ( $this->cache->contains( $hash ) ) {
-			return ExpElement::newFromSerialization( $this->cache->fetch( $hash ) );
+			return $this->cache->fetch( $hash );
 		}
 
 		if ( $diWikiPage->getSubobjectName() !== '' ) {
@@ -166,7 +169,7 @@ class CachedDataItemToExpResourceEncoder {
 
 		$this->cache->save(
 			$hash,
-			$resource->getSerialization()
+			$resource
 		);
 
 		return $resource;


### PR DESCRIPTION
Using the object directly pays-off especially for long lists (subject that contains large subobjects) and is crucial for a smooth `SPARQLStore` update performance.

![export-perform](https://cloud.githubusercontent.com/assets/1245473/7317705/9568f252-eabe-11e4-933e-a8be5e76dbad.png)