### PR TITLE
Add BeforeMagicWordsFinder hook and extend HtmlColumnListRenderer

### DIFF
--- a/docs/technical/hooks.md
+++ b/docs/technical/hooks.md
@@ -21,6 +21,11 @@ Implementing a hook should be made in consideration of the expected performance 
 - `SMW::SQLStore::AfterDeleteSubjectComplete` called after deletion of a subject is completed.
 - `SMW::SQLStore::BeforeChangeTitleComplete` called before change to a subject is completed.
 
+### 2.2
+
+- `SMW::Parser::BeforeMagicWordsFinder` allows to extend the magic words list that the `InTextAnnotationParser` should
+  search for the wikitext.
+
 For implementation details and examples, see the [integration test](https://github.com/SemanticMediaWiki/SemanticMediaWiki/blob/master/tests/phpunit/Integration/SemanticMediaWikiProvidedHookInterfaceIntegrationTest.php).
 
 ## Other available hooks

--- a/resources/smw/ext.smw.css
+++ b/resources/smw/ext.smw.css
@@ -404,3 +404,8 @@ label.smw-form-checkbox {
 	overflow: hidden;
 	padding-top: .5em;
 }
+
+.smw-column {
+	float: left;
+	word-wrap: break-word;
+}

--- a/src/InTextAnnotationParser.php
+++ b/src/InTextAnnotationParser.php
@@ -6,6 +6,7 @@ use SMW\MediaWiki\MagicWordFinder;
 use SMW\MediaWiki\RedirectTargetFinder;
 use SMWOutputs;
 use Title;
+use Hooks;
 
 /**
  * Class collects all functions for wiki text parsing / processing that are
@@ -321,7 +322,14 @@ class InTextAnnotationParser {
 
 		$this->magicWordFinder->setOutput( $this->parserData->getOutput() );
 
-		foreach ( array( 'SMW_NOFACTBOX', 'SMW_SHOWFACTBOX' ) as $magicWord ) {
+		$magicWords = array(
+			'SMW_NOFACTBOX',
+			'SMW_SHOWFACTBOX'
+		);
+
+		Hooks::run( 'SMW::Parser::BeforeMagicWordsFinder', array( &$magicWords ) );
+
+		foreach ( $magicWords as $magicWord ) {
 			$words = $words + $this->magicWordFinder->matchAndRemove( $magicWord, $text );
 		}
 

--- a/src/MediaWiki/MwCollaboratorFactory.php
+++ b/src/MediaWiki/MwCollaboratorFactory.php
@@ -186,4 +186,13 @@ class MwCollaboratorFactory {
 		);
 	}
 
+	/**
+	 * @since 2.2
+	 *
+	 * @return MediaWikiNsContentReader
+	 */
+	public function newMediaWikiNsContentReader() {
+		return new MediaWikiNsContentReader();
+	}
+
 }

--- a/src/MediaWiki/Renderer/HtmlColumnListRenderer.php
+++ b/src/MediaWiki/Renderer/HtmlColumnListRenderer.php
@@ -52,6 +52,23 @@ class HtmlColumnListRenderer {
 	private $listType = 'ul';
 
 	/**
+	 * @var string
+	 */
+	private $columnListClass = 'smw-columnlist-container';
+
+	/**
+	 * @since 2.2
+	 *
+	 * @param string $columnListClass
+	 *
+	 * @return HtmlColumnListRenderer
+	 */
+	public function setColumnListClass( $columnListClass ) {
+		$this->columnListClass = htmlspecialchars( $columnListClass );
+		return $this;
+	}
+
+	/**
 	 * @since 2.1
 	 *
 	 * @param integer $numberOfColumns
@@ -77,6 +94,24 @@ class HtmlColumnListRenderer {
 		}
 
 		return $this;
+	}
+
+	/**
+	 * @since 2.1
+	 *
+	 * @param string[] $contentsByNoIndex
+	 *
+	 * @return HtmlColumnListRenderer
+	 */
+	public function addContentsByNoIndex( array $contentsByNoIndex ) {
+
+		$contentsByEmptyIndex[''] = array();
+
+		foreach ( $contentsByNoIndex as $value ) {
+			$contentsByEmptyIndex[''][] = $value;
+		}
+
+		return $this->addContentsByIndex( $contentsByEmptyIndex );
 	}
 
 	/**
@@ -126,7 +161,7 @@ class HtmlColumnListRenderer {
 
 		return Html::rawElement(
 			'div',
-			array( 'class' => 'smw-columnlist-container' ),
+			array( 'class' => $this->columnListClass ),
 			$result . "\n" . '<br style="clear: both;"/>'
 		);
 	}
@@ -139,12 +174,12 @@ class HtmlColumnListRenderer {
 		foreach ( $resultItems as $resultItem ) {
 
 			if ( $this->numRows % $this->rowsPerColumn == 0 ) {
-				$result .= "<div class=\"smw-column\" style=\"float: left; width:$this->columnWidth%; word-wrap: break-word;\">";
+				$result .= "<div class=\"smw-column\" style=\"width:$this->columnWidth%;\">";
 
 				$numRowsInColumn = $this->numRows + 1;
 
 				if ( $key == $previousKey ) {
-					$result .= "<div class=\"smw-column-header\">$key " . $listContinuesAbbrev . "</div><{$this->listType} start={$numRowsInColumn}>";
+					$result .= ( $key !== '' ? Html::element( 'div', array( 'class' => 'smw-column-header' ), "$key $listContinuesAbbrev" ) : '' ) . "<{$this->listType} start={$numRowsInColumn}>";
 				}
 			}
 
@@ -152,7 +187,7 @@ class HtmlColumnListRenderer {
 			// the last list and start a new one
 			if ( $key != $previousKey ) {
 				$result .= $this->numRows % $this->rowsPerColumn > 0 ? "</{$this->listType}>" : '';
-				$result .= "<div class=\"smw-column-header\">$key</div><{$this->listType}>";
+				$result .= ( $key !== '' ? Html::element( 'div', array( 'class' => 'smw-column-header' ), $key ) : '' ) . "<{$this->listType}>";
 			}
 
 			$previousKey = $key;

--- a/tests/phpunit/Integration/Query/Fixtures/format-03-01-category-en.json
+++ b/tests/phpunit/Integration/Query/Fixtures/format-03-01-category-en.json
@@ -137,7 +137,7 @@
 					"<div class=\"smw-columnlist-container\">",
 					"<div class=\"smw-column-header\">テ</div><ul><li>テスト (Has page property Test)</li></ul>",
 					"<div class=\"smw-column-header\">F</div><ul><li>Foo (Has page property Test)</li></ul></div>",
-					"<div class=\"smw-column\" style=\"float: left; width:50%; word-wrap: break-word;\"><div class=\"smw-column-header\">F cont.</div><ul><li>",
+					"<div class=\"smw-column\" style=\"width:50%;\"><div class=\"smw-column-header\">F cont.</div><ul><li>",
 					"Special:Ask/-5B-5BHas-20page-20property::Test-5D-5D/-3FHas-20page-20property/format=category/limit=2/link=none/order=desc/headers=plain/searchlabel=Test-20more/columns=2\">Test more</a></li></ul></div>",
 					"<br style=\"clear: both;\" />"
 				]

--- a/tests/phpunit/Integration/SemanticMediaWikiProvidedHookInterfaceIntegrationTest.php
+++ b/tests/phpunit/Integration/SemanticMediaWikiProvidedHookInterfaceIntegrationTest.php
@@ -378,6 +378,9 @@ class SemanticMediaWikiProvidedHookInterfaceIntegrationTest extends \PHPUnit_Fra
 
 		$this->mwHooksHandler->register( 'SMW::Parser::BeforeMagicWordsFinder', function( &$magicWords ) {
 			$magicWords = array( 'Foo' );
+
+			// Just to make MW 1.19 happy, otherwise it is not really needed
+			return true;
 		} );
 
 		$text = '';

--- a/tests/phpunit/Integration/SemanticMediaWikiProvidedHookInterfaceIntegrationTest.php
+++ b/tests/phpunit/Integration/SemanticMediaWikiProvidedHookInterfaceIntegrationTest.php
@@ -328,6 +328,63 @@ class SemanticMediaWikiProvidedHookInterfaceIntegrationTest extends \PHPUnit_Fra
 		);
 	}
 
+	public function testRegisteredParserBeforeMagicWordsFinder() {
+
+		$parserOutput = $this->getMockBuilder( '\ParserOutput' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$title = \Title::newFromText( __METHOD__ );
+
+		$semanticData = $this->getMockBuilder( '\SMW\SemanticData' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$parserData = $this->getMockBuilder( '\SMW\ParserData' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$parserData->expects( $this->any() )
+			->method( 'getOutput' )
+			->will( $this->returnValue( $parserOutput ) );
+
+		$parserData->expects( $this->any() )
+			->method( 'getSemanticData' )
+			->will( $this->returnValue( $semanticData ) );
+
+		$parserData->expects( $this->any() )
+			->method( 'getTitle' )
+			->will( $this->returnValue( $title ) );
+
+		$magicWordFinder = $this->getMockBuilder( '\SMW\MediaWiki\MagicWordFinder' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$magicWordFinder->expects( $this->once() )
+			->method( 'matchAndRemove' )
+			->with(
+				$this->equalTo( 'Foo' ),
+				$this->anything() )
+			->will( $this->returnValue( array() ) );
+
+		$redirectTargetFinder = $this->getMockBuilder( '\SMW\MediaWiki\RedirectTargetFinder' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$inTextAnnotationParser = $this->getMockBuilder( '\SMW\InTextAnnotationParser' )
+			->setConstructorArgs( array( $parserData, $magicWordFinder, $redirectTargetFinder ) )
+			->setMethods( null )
+			->getMock();
+
+		$this->mwHooksHandler->register( 'SMW::Parser::BeforeMagicWordsFinder', function( &$magicWords ) {
+			$magicWords = array( 'Foo' );
+		} );
+
+		$text = '';
+
+		$inTextAnnotationParser->parse( $text );
+	}
+
 	public function storeClassProvider() {
 
 		$provider[] = array( '\SMWSQLStore3' );

--- a/tests/phpunit/Utils/MwHooksHandler.php
+++ b/tests/phpunit/Utils/MwHooksHandler.php
@@ -32,7 +32,8 @@ class MwHooksHandler {
 		'SMW::Store::AfterQueryResultLookupComplete',
 		'SMW::SQLStore::BeforeChangeTitleComplete',
 		'SMW::SQLStore::BeforeDeleteSubjectComplete',
-		'SMW::SQLStore::AfterDeleteSubjectComplete'
+		'SMW::SQLStore::AfterDeleteSubjectComplete',
+		'SMW::Parser::BeforeMagicWordsFinder'
 	);
 
 	/**

--- a/tests/phpunit/includes/MediaWiki/MwCollaboratorFactoryTest.php
+++ b/tests/phpunit/includes/MediaWiki/MwCollaboratorFactoryTest.php
@@ -243,4 +243,18 @@ class MwCollaboratorFactoryTest extends \PHPUnit_Framework_TestCase {
 		);
 	}
 
+	public function testCanConstructMediaWikiNsContentReader() {
+
+		$applicationFactory = $this->getMockBuilder( '\SMW\ApplicationFactory' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$instance = new MwCollaboratorFactory( $applicationFactory );
+
+		$this->assertInstanceOf(
+			'\SMW\MediaWiki\MediaWikiNsContentReader',
+			$instance->newMediaWikiNsContentReader()
+		);
+	}
+
 }

--- a/tests/phpunit/includes/MediaWiki/Renderer/HtmlColumnListRendererTest.php
+++ b/tests/phpunit/includes/MediaWiki/Renderer/HtmlColumnListRendererTest.php
@@ -44,7 +44,7 @@ class HtmlColumnListFormatterTest extends \PHPUnit_Framework_TestCase {
 
 		$expected = array(
 			'<div class="smw-columnlist-container">',
-			'<div class="smw-column" style="float: left; width:100%; word-wrap: break-word;">',
+			'<div class="smw-column" style="width:100%;">',
 			'<div class="smw-column-header">a</div><ul><li>Foo</li><li>Bar</li></ul>',
 			'<div class="smw-column-header">B</div><ul><li>Ichi</li><li>Ni</li></ul></div>'
 		);
@@ -61,19 +61,23 @@ class HtmlColumnListFormatterTest extends \PHPUnit_Framework_TestCase {
 
 		$instance->setNumberOfColumns( 2 );
 
-		$listContinuesAbbrev = wfMessage( 'listingcontinuesabbrev' )->text();
-
 		$instance->addContentsByIndex( array(
 			'a' => array( 'Foo', 'Bar' ),
-			'B' => array( 'Ichi', 'Ni' )
+			'B' => array( 'Baz', 'Fom', 'Fin', 'Fum' )
 		) );
+
+		$listContinuesAbbrev = wfMessage( 'listingcontinuesabbrev' )->text();
 
 		$expected = array(
 			'<div class="smw-columnlist-container">',
-			'<div class="smw-column" style="float: left; width:50%; word-wrap: break-word;">',
-			'<div class="smw-column-header">a</div><ul><li>Foo</li><li>Bar</li></ul></div> <!-- end column -->',
-			'<div class="smw-column" style="float: left; width:50%; word-wrap: break-word;">',
-			'<div class="smw-column-header">B</div><ul><li>Ichi</li><li>Ni</li></ul></div> <!-- end column -->'
+			'<div class="smw-column" style="width:50%;">',
+			'<div class="smw-column-header">a</div>',
+			'<ul><li>Foo</li><li>Bar</li></ul>',
+			'<div class="smw-column-header">B</div><ul><li>Baz</li></ul></div> <!-- end column -->',
+			'<div class="smw-column" style="width:50%;">',
+			'<div class="smw-column-header">B ' . $listContinuesAbbrev .'</div>',
+			'<ul start=4><li>Fom</li><li>Fin</li><li>Fum</li></ul></div> <!-- end column -->',
+			'<br style="clear: both;"/></div>'
 		);
 
 		$this->stringValidator->assertThatStringContains(
@@ -95,9 +99,9 @@ class HtmlColumnListFormatterTest extends \PHPUnit_Framework_TestCase {
 
 		$expected = array(
 			'<div class="smw-columnlist-container">',
-			'<div class="smw-column" style="float: left; width:33%; word-wrap: break-word;">',
+			'<div class="smw-column" style="width:33%;">',
 			'<div class="smw-column-header">a</div><ul><li>Foo</li><li>Bar</li></ul></div>',
-			'<div class="smw-column" style="float: left; width:33%; word-wrap: break-word;">',
+			'<div class="smw-column" style="width:33%;">',
 			'<div class="smw-column-header">B</div><ul><li>Ichi</li><li>Ni</li></ul></div>'
 		);
 
@@ -115,8 +119,6 @@ class HtmlColumnListFormatterTest extends \PHPUnit_Framework_TestCase {
 			->setNumberOfColumns( 2 )
 			->setListType( 'ol' );
 
-		$listContinuesAbbrev = wfMessage( 'listingcontinuesabbrev' )->text();
-
 		$instance->addContentsByIndex( array(
 			'a' => array( 'Foo', 'Bar' ),
 			'B' => array( 'Ichi', 'Ni' )
@@ -124,10 +126,37 @@ class HtmlColumnListFormatterTest extends \PHPUnit_Framework_TestCase {
 
 		$expected = array(
 			'<div class="smw-columnlist-container">',
-			'<div class="smw-column" style="float: left; width:50%; word-wrap: break-word;">',
+			'<div class="smw-column" style="width:50%;">',
 			'<div class="smw-column-header">a</div><ol><li>Foo</li><li>Bar</li></ol></div> <!-- end column -->',
-			'<div class="smw-column" style="float: left; width:50%; word-wrap: break-word;">',
+			'<div class="smw-column" style="width:50%;">',
 			'<div class="smw-column-header">B</div><ol><li>Ichi</li><li>Ni</li></ol></div> <!-- end column -->'
+		);
+
+		$this->stringValidator->assertThatStringContains(
+			$expected,
+			$instance->getHtml()
+		);
+	}
+
+	public function testTwoColumnOrderedListNoHeader() {
+
+		$instance = new HtmlColumnListRenderer();
+
+		$instance
+			->setNumberOfColumns( 2 )
+			->setColumnListClass( 'foo-class' )
+			->setListType( 'ul' );
+
+		$instance->addContentsByNoIndex(
+			array( 'Foo', 'Baz', 'Bar' )
+		);
+
+		$expected = array(
+			'<div class="foo-class">',
+			'<div class="smw-column" style="width:50%;">',
+			'<ul start=1><li>Foo</li><li>Baz</li></ul></div> <!-- end column -->',
+			'<div class="smw-column" style="width:50%;">',
+			'<ul start=3><li>Bar</li></ul></div> <!-- end column -->'
 		);
 
 		$this->stringValidator->assertThatStringContains(


### PR DESCRIPTION
Core changes needed to make `Semantic Cite` to work as flawless as seen in [0]. Also moved the fixed style in `HtmlColumnListRenderer` for columns into its own css style (allows them later to switch with rtl style) 

Add `SMW::Parser::BeforeMagicWordsFinder` to allow to make use of the existing in-text parser and avoids doing similar parsing in an extension.

[0] https://vimeo.com/126189455