### PR TITLE
SPARQLStore / Add support for prop/val redirects, refs #467

### DIFF
--- a/SemanticMediaWiki.settings.php
+++ b/SemanticMediaWiki.settings.php
@@ -97,6 +97,21 @@ $GLOBALS['smwgSparqlDefaultGraph'] = '';
 ##
 $GLOBALS['smwgSparqlDatabaseConnector'] = 'custom';
 
+##
+# Sparql query features that are expected to be supported by the repository:
+#
+# - SMW_SPARQL_QF_NONE does not support any features (as required by SPARQL 1.1)
+# - SMW_SPARQL_QF_REDI to support finding redirects using inverse property paths,
+#   can only be used for repositories with full SPARQL 1.1 support (e.g. Fuseki,
+#   Sesame)
+#
+# Please check with your repository provider whether SPARQL 1.1 is fully
+# supported or not, and if not SMW_SPARQL_QF_NONE should be set.
+#
+# @since 2.3
+##
+$GLOBALS['smwgSparqlQFeatures'] = SMW_SPARQL_QF_REDI;
+
 ###
 # Setting this option to true before including this file to enable the old
 # Type: namespace that SMW used up to version 1.5.*. This should only be

--- a/includes/Defines.php
+++ b/includes/Defines.php
@@ -116,3 +116,11 @@ define( 'SMW_DIFF_UPDATE', 0 );
 define( 'SMW_REPLACEMENT_UPDATE', 2 );
 define( 'SMW_TRX_UPDATE', 4 );
 /**@}*/
+
+/**@{
+ * Constants for SPARQL supported features (mostly SPARQL 1.1) because we are unable
+ * to verify against the REST API whether a feature is supported or not
+ */
+define( 'SMW_SPARQL_QF_NONE', 0 ); // does not support any features
+define( 'SMW_SPARQL_QF_REDI', 2 ); // support for inverse property paths to find redirects
+/**@}*/

--- a/includes/Settings.php
+++ b/includes/Settings.php
@@ -130,7 +130,8 @@ class Settings extends SimpleDictionary {
 			'smwgFallbackSearchType' => $GLOBALS['smwgFallbackSearchType'],
 			'smwgEnabledEditPageHelp' => $GLOBALS['smwgEnabledEditPageHelp'],
 			'smwgUFeatures' => $GLOBALS['smwgUFeatures'],
-			'smwgLogEventTypes' => $GLOBALS['smwgLogEventTypes']
+			'smwgLogEventTypes' => $GLOBALS['smwgLogEventTypes'],
+			'smwgSparqlQFeatures' => $GLOBALS['smwgSparqlQFeatures']
 		);
 
 		$settings = $settings + array(

--- a/src/SPARQLStore/QueryEngine/Interpreter/SomePropertyInterpreter.php
+++ b/src/SPARQLStore/QueryEngine/Interpreter/SomePropertyInterpreter.php
@@ -90,7 +90,7 @@ class SomePropertyInterpreter implements DescriptionInterpreter {
 			$joinVariable
 		);
 
-		$propertyName = $this->getPropertyNameByUsingTurtleSerializer(
+		$propertyName = $this->findMostSuitablePropertyRepresentation(
 			$property,
 			$nonInverseProperty,
 			$namespaces
@@ -165,7 +165,16 @@ class SomePropertyInterpreter implements DescriptionInterpreter {
 		return $objectName;
 	}
 
-	private function getPropertyNameByUsingTurtleSerializer( DIProperty $property, DIProperty $nonInverseProperty, &$namespaces ) {
+	private function findMostSuitablePropertyRepresentation( DIProperty $property, DIProperty $nonInverseProperty, &$namespaces ) {
+
+		$redirectByVariable = $this->compoundConditionBuilder->tryToFindRedirectVariableForDataItem(
+			$nonInverseProperty->getDiWikiPage()
+		);
+
+		// If the property is represented by a redirect then use the variable instead
+		if ( $redirectByVariable !== null ) {
+			return $redirectByVariable;
+		}
 
 		// Use helper properties in encoding values, refer to this helper property:
 		if ( $this->exporter->hasHelperExpElement( $property ) ) {

--- a/src/SPARQLStore/QueryEngine/Interpreter/ValueDescriptionInterpreter.php
+++ b/src/SPARQLStore/QueryEngine/Interpreter/ValueDescriptionInterpreter.php
@@ -121,6 +121,14 @@ class ValueDescriptionInterpreter implements DescriptionInterpreter {
 
 		$result = new SingletonCondition( $expElement );
 
+		$redirectByVariable = $this->compoundConditionBuilder->tryToFindRedirectVariableForDataItem(
+			$dataItem
+		);
+
+		if ( $redirectByVariable !== null ) {
+			$result->matchElement = $redirectByVariable;
+		}
+
 		$this->compoundConditionBuilder->addOrderByDataForProperty(
 			$result,
 			$joinVariable,
@@ -155,6 +163,14 @@ class ValueDescriptionInterpreter implements DescriptionInterpreter {
 			$comparator,
 			$pattern
 		);
+
+		$redirectByVariable = $this->compoundConditionBuilder->tryToFindRedirectVariableForDataItem(
+			$dataItem
+		);
+
+		if ( $redirectByVariable !== null ) {
+			$condition->matchElement = $redirectByVariable;
+		}
 
 		$this->compoundConditionBuilder->addOrderByDataForProperty(
 			$condition,

--- a/tests/phpunit/Integration/Query/Fixtures/query-06-04-page-property-value-redirects.json
+++ b/tests/phpunit/Integration/Query/Fixtures/query-06-04-page-property-value-redirects.json
@@ -1,0 +1,140 @@
+{
+	"description": "Verfiy property/values redirects in queries, refs #467",
+	"properties": [
+		{
+			"name": "Has firstPage",
+			"contents": "[[Has type::Page]]"
+		},
+		{
+			"name": "Has secondPage",
+			"contents": "[[Has type::Page]]"
+		},
+		{
+			"name": "PropertyToBeRedirected",
+			"contents": "#REDIRECT [[Property:Has firstPage]]"
+		}
+	],
+	"subjects": [
+		{
+			"name": "PageValueToBeRedirected",
+			"contents": "#REDIRECT [[PageRedirectTarget]]"
+		},
+		{
+			"name": "Page-one",
+			"contents": "[[PropertyToBeRedirected::One]]"
+		},
+		{
+			"name": "Page-two",
+			"contents": "{{#subobject:PropertyToBeRedirected=Two}}"
+		},
+		{
+			"name": "Page-three",
+			"contents": "[[Has secondPage::PageValueToBeRedirected]]"
+		},
+		{
+			"name": "Page-four",
+			"contents": "{{#subobject:Has secondPage=PageValueToBeRedirected}}"
+		},
+		{
+			"name": "Page-five-combined",
+			"contents": "[[PropertyToBeRedirected::PageValueToBeRedirected]]"
+		}
+	],
+	"query-testcases": [
+		{
+			"about": "#0 any value query for redirected property",
+			"condition": "[[PropertyToBeRedirected::+]]",
+			"printouts" : [ "PropertyToBeRedirected", "Has firstPage" ],
+			"parameters" : {
+			  "limit" : 10
+			},
+			"queryresult": {
+				"count": 3,
+				"results": [
+					"Page-one#0##",
+					"Page-two#0##_b60804b67d37b781ac15c6e78102d13c",
+					"Page-five-combined#0##"
+				],
+				"datavalues": [
+					{
+						"property": "PropertyToBeRedirected",
+						"value": "One"
+					},
+					{
+						"property": "PropertyToBeRedirected",
+						"value": "Two"
+					},
+					{
+						"property": "PropertyToBeRedirected",
+						"value": "PageValueToBeRedirected"
+					}
+				]
+			}
+		},
+		{
+			"about": "#1 any value query for redirected value",
+			"condition": "[[Has secondPage::+]]",
+			"printouts" : [ "Has secondPage" ],
+			"parameters" : {
+			  "limit" : 10
+			},
+			"queryresult": {
+				"count": 2,
+				"results": [
+					"Page-three#0##",
+					"Page-four#0##_f5bb3e35482aaa5d1eef24749c24af30"
+				],
+				"datavalues": [
+					{
+						"property": "Has secondPage",
+						"value": "PageValueToBeRedirected"
+					},
+					{
+						"property": "Has secondPage",
+						"value": "PageValueToBeRedirected"
+					}
+				]
+			}
+		},
+		{
+			"about": "#2 disjunction query on discrete value search",
+			"condition": "[[PropertyToBeRedirected::One]] OR [[PropertyToBeRedirected::Two]] OR [[Has secondPage::PageValueToBeRedirected]]",
+			"printouts" : [],
+			"parameters" : {
+			  "limit" : 10
+			},
+			"queryresult": {
+				"count": 4,
+				"results": [
+					"Page-one#0##",
+					"Page-two#0##_b60804b67d37b781ac15c6e78102d13c",
+					"Page-three#0##",
+					"Page-four#0##_f5bb3e35482aaa5d1eef24749c24af30"
+				]
+			}
+		},
+		{
+			"about": "#3 combined property/value redirect discrete value search",
+			"condition": "[[PropertyToBeRedirected::PageValueToBeRedirected]]",
+			"printouts" : [],
+			"parameters" : {
+			  "limit" : 10
+			},
+			"queryresult": {
+				"count": 1,
+				"results": [
+					"Page-five-combined#0##"
+				]
+			}
+		}
+	],
+	"settings": {},
+	"meta": {
+		"skip-on": {
+			"virtuoso": "Virtuoso 6.1 does not support property paths / SPARQL compiler, line 0: Invalid character in SPARQL expression at '^'"
+		},
+		"version": "0.1",
+		"is-incomplete": false,
+		"debug": false
+	}
+}


### PR DESCRIPTION
refs #467, Using SPARQL 1.1/inverse property paths [0] to find known redirects in the TDB

`$GLOBALS['smwgSparqlQFeatures'] = SMW_SPARQL_QF_REDI;` is enabled by default as it is expected that any "modern" TDB supports SPARQL 1.1 and for those that don't (Virtuoso 6.1, 4Store don't  fully support SPARQL 1.1) the feature should be disabled by setting `SMW_SPARQL_QF_NONE`.

[0] http://www.w3.org/TR/sparql11-query/#propertypaths