### PR TITLE
SPARQLStore / Subproperty support

### DIFF
--- a/SemanticMediaWiki.settings.php
+++ b/SemanticMediaWiki.settings.php
@@ -104,13 +104,14 @@ $GLOBALS['smwgSparqlDatabaseConnector'] = 'custom';
 # - SMW_SPARQL_QF_REDI to support finding redirects using inverse property paths,
 #   can only be used for repositories with full SPARQL 1.1 support (e.g. Fuseki,
 #   Sesame)
+# - SMW_SPARQL_QF_SUBP to resolve subproperties
 #
 # Please check with your repository provider whether SPARQL 1.1 is fully
 # supported or not, and if not SMW_SPARQL_QF_NONE should be set.
 #
 # @since 2.3
 ##
-$GLOBALS['smwgSparqlQFeatures'] = SMW_SPARQL_QF_REDI;
+$GLOBALS['smwgSparqlQFeatures'] = SMW_SPARQL_QF_REDI | SMW_SPARQL_QF_SUBP;
 
 ###
 # Setting this option to true before including this file to enable the old

--- a/includes/Defines.php
+++ b/includes/Defines.php
@@ -123,4 +123,5 @@ define( 'SMW_TRX_UPDATE', 4 );
  */
 define( 'SMW_SPARQL_QF_NONE', 0 ); // does not support any features
 define( 'SMW_SPARQL_QF_REDI', 2 ); // support for inverse property paths to find redirects
+define( 'SMW_SPARQL_QF_SUBP', 4 ); // support for rdfs:subPropertyOf*
 /**@}*/

--- a/includes/storage/SQLStore/SMW_Sql3SmwIds.php
+++ b/includes/storage/SQLStore/SMW_Sql3SmwIds.php
@@ -335,13 +335,23 @@ class SMWSql3SmwIds {
 		global $smwgQEqualitySupport;
 
 		$db = $this->store->getConnection();
+		$id = false;
 
-		$id = $this->getCachedId(
-			$title,
-			$namespace,
-			$iw,
-			$subobjectName
-		);
+		// Integration test "query-04-02-subproperty-dc-import-marc21.json"
+		// showed a deterministic failure (due to a wrong cache id during querying
+		// for redirects) hence we force to read directly from the RedirectInfoStore
+		// for objects marked as redirect
+		if ( $iw === SMW_SQL3_SMWREDIIW && $canonical &&
+			$smwgQEqualitySupport !== SMW_EQ_NONE && $subobjectName === '' ) {
+			$id = $this->findRedirectIdFor( $title, $namespace );
+		} else {
+			$id = $this->getCachedId(
+				$title,
+				$namespace,
+				$iw,
+				$subobjectName
+			);
+		}
 
 		if ( $id !== false ) { // cache hit
 			$sortkey = $this->getCachedSortKey( $title, $namespace, $iw, $subobjectName );

--- a/src/SPARQLStore/HierarchyFinder.php
+++ b/src/SPARQLStore/HierarchyFinder.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace SMW\SPARQLStore;
+
+use Onoi\Cache\Cache;
+use SMW\Store;
+use SMW\DIProperty;
+use SMWRequestOptions as RequestOptions;
+
+/**
+ * @license GNU GPL v2+
+ * @since 2.3
+ *
+ * @author mwjames
+ */
+class HierarchyFinder {
+
+	/**
+	 * @var Store
+	 */
+	private $store = null;
+
+	/**
+	 * @var Cache|null
+	 */
+	private $cache = null;
+
+	/**
+	 * @since 2.3
+	 *
+	 * @param Store $store
+	 * @param Cache|null $cache
+	 */
+	public function __construct( Store $store, Cache $cache ) {
+		$this->store = $store;
+		$this->cache = $cache;
+	}
+
+	/**
+	 * @note There are different ways to find out whether a property
+	 * has a subproperty or not.
+	 *
+	 * In SPARQL one could try using FILTER NOT EXISTS { ?s my:property ?o }
+	 *
+	 * @since 2.3
+	 *
+	 * @param DIProperty $property
+	 *
+	 * @return  boolean
+	 */
+	public function hasSubpropertyFor( DIProperty $property ) {
+
+		if ( $this->cache->contains( $property->getKey() ) ) {
+			return $this->cache->fetch( $property->getKey() );
+		}
+
+		$requestOptions = new RequestOptions();
+		$requestOptions->limit = 1;
+
+		$result = $this->store->getPropertySubjects(
+			new DIProperty( '_SUBP' ),
+			$property->getDiWikiPage(),
+			$requestOptions
+		);
+
+		$this->cache->save(
+			$property->getKey(),
+			$result !== array()
+		);
+
+		return $result !== array();
+	}
+
+}

--- a/src/SPARQLStore/QueryEngine/EngineOptions.php
+++ b/src/SPARQLStore/QueryEngine/EngineOptions.php
@@ -24,6 +24,9 @@ class EngineOptions {
 		$this->set( 'smwgIgnoreQueryErrors', $GLOBALS['smwgIgnoreQueryErrors'] );
 		$this->set( 'smwgQSortingSupport', $GLOBALS['smwgQSortingSupport'] );
 		$this->set( 'smwgQRandSortingSupport', $GLOBALS['smwgQRandSortingSupport'] );
+		$this->set( 'smwgQSubpropertyDepth', $GLOBALS['smwgQSubpropertyDepth'] );
+		$this->set( 'smwgQSubcategoryDepth', $GLOBALS['smwgQSubcategoryDepth'] );
+		$this->set( 'smwgSparqlQFeatures', $GLOBALS['smwgSparqlQFeatures'] );
 	}
 
 	/**

--- a/src/SPARQLStore/QueryEngine/Interpreter/SomePropertyInterpreter.php
+++ b/src/SPARQLStore/QueryEngine/Interpreter/SomePropertyInterpreter.php
@@ -186,7 +186,10 @@ class SomePropertyInterpreter implements DescriptionInterpreter {
 		if ( $this->exporter->hasHelperExpElement( $property ) ) {
 			$propertyExpElement = $this->exporter->getResourceElementForProperty( $nonInverseProperty, true );
 		} elseif( !$property->isUserDefined() ) {
-			$propertyExpElement = $this->exporter->getSpecialPropertyResource( $nonInverseProperty->getKey() );
+			$propertyExpElement = $this->exporter->getSpecialPropertyResource(
+				$nonInverseProperty->getKey(),
+				SMW_NS_PROPERTY
+			);
 		} else {
 			$propertyExpElement = $this->exporter->getResourceElementForProperty( $nonInverseProperty );
 		}

--- a/tests/phpunit/Integration/Query/ByJsonQueryTestCaseRunnerTest.php
+++ b/tests/phpunit/Integration/Query/ByJsonQueryTestCaseRunnerTest.php
@@ -65,7 +65,8 @@ class ByJsonQueryTestCaseRunnerTest extends ByJsonTestCaseProvider {
 			'wgLang',
 			'smwgQMaxSize',
 			'smwStrictComparators',
-			'smwgNamespacesWithSemanticLinks'
+			'smwgNamespacesWithSemanticLinks',
+			'smwgQSubpropertyDepth'
 		);
 
 		foreach ( $permittedSettings as $key ) {

--- a/tests/phpunit/Integration/Query/Fixtures/query-04-01-subproperty-family.json
+++ b/tests/phpunit/Integration/Query/Fixtures/query-04-01-subproperty-family.json
@@ -100,12 +100,12 @@
 			}
 		}
 	],
-	"settings": {},
+	"settings": {
+		"smwgQSubpropertyDepth": 10
+	},
 	"meta": {
 		"skip-on": {
-			"fuseki": "Subproperty/property hierarchies are currently not implemented",
-			"sesame": "Subproperty/property hierarchies are currently not implemented",
-			"virtuoso": "Subproperty/property hierarchies are currently not implemented"
+			"virtuoso": "Virtuoso 6.1 rdfs / subproperty/property hierarchies are currently not implemented"
 		},
 		"version": "0.1",
 		"is-incomplete": false,

--- a/tests/phpunit/Integration/Query/Fixtures/query-04-01-subproperty-family.json
+++ b/tests/phpunit/Integration/Query/Fixtures/query-04-01-subproperty-family.json
@@ -98,6 +98,36 @@
 					}
 				]
 			}
+		},
+		{
+			"about": "#2 find members of a super property",
+			"condition": "[[Subproperty of::Property:Spouse]]",
+			"printouts" : [],
+			"parameters" : {
+			  "limit" : 10
+			},
+			"queryresult": {
+				"count": 2,
+				"results": [
+					"Has wife#102##",
+					"Has husband#102##"
+				]
+			}
+		},
+		{
+			"about": "#3 find the super properties (invert)",
+			"condition": "[[-Subproperty of::Property:Has wife]]",
+			"printouts" : [],
+			"parameters" : {
+			  "limit" : 10
+			},
+			"queryresult": {
+				"count": 2,
+				"results": [
+					"Spouse#102##",
+					"Family#102##"
+				]
+			}
 		}
 	],
 	"settings": {

--- a/tests/phpunit/Integration/Query/Fixtures/query-04-02-subproperty-dc-import-marc21.json
+++ b/tests/phpunit/Integration/Query/Fixtures/query-04-02-subproperty-dc-import-marc21.json
@@ -1,0 +1,206 @@
+{
+	"description": "Mapping DC import with MARC 21 bibliographic terms, http://www.loc.gov/marc/bibliographic/bd20x24x.html",
+	"properties": [
+		{
+			"name": "Smw import dc",
+			"namespace": "NS_MEDIAWIKI",
+			"contents": "http://purl.org/dc/elements/1.1/|[http://purl.org/dc/elements/1.1/ dc]\n title|Type:Text\n type|Type:Text\n date|Type:Date\n description|Type:Text\n creator|Type:Page\n"
+		},
+		{
+			"name": "Dc:title",
+			"contents": "[[Imported from::dc:title]]"
+		},
+		{
+			"name": "Dc:creator",
+			"contents": "[[Imported from::dc:creator]]"
+		},
+		{
+			"name": "Marc:title",
+			"contents": "[[Has type::Text]] [[Subproperty of::Dc:title]]"
+		},
+		{
+			"name": "Marc:main entry personal name",
+			"contents": "[[Has type::Page]] [[Subproperty of::Dc:creator]]"
+		},
+		{
+			"name": "Marc:title statement",
+			"contents": "[[Has type::Text]] [[Subproperty of::Marc:title]]"
+		},
+		{
+			"name": "Marc:varying form of title",
+			"contents": "[[Has type::Text]] [[Subproperty of::Marc:title]]"
+		},
+		{
+			"name": "Has author",
+			"contents": "#REDIRECT [[Property:Marc:main entry personal name]]"
+		}
+	],
+	"subjects": [
+		{
+			"name": "Animal farm",
+			"contents": "[[Marc:title statement::George Orwell's Animal farm]] [[Has author::George Orwell]]"
+		},
+		{
+			"name": "War and Peace",
+			"contents": "[[Marc:title statement::War and Peace]] [[Has author::Leo Tolstoy]]"
+		},
+		{
+			"name": "King Lear",
+			"contents": "#REDIRECT [[Shakespeare's King Lear]]"
+		},
+		{
+			"name": "Shakespeare",
+			"contents": "#REDIRECT [[William Shakespeare]]"
+		},
+		{
+			"name": "Shakespeare's King Lear",
+			"contents": "[[Marc:title::King Lear]] [[Has author::William Shakespeare]]"
+		}
+	],
+	"query-testcases": [
+		{
+			"about": "#0 any value for Marc:title statement",
+			"condition": "[[Marc:title statement::+]]",
+			"printouts" : [ "Has author" ],
+			"parameters" : {
+			  "limit" : 10
+			},
+			"queryresult": {
+				"count": 2,
+				"results": [
+					"Animal farm#0##",
+					"War and Peace#0##"
+				],
+				"datavalues": [
+					{
+						"property": "Has author",
+						"value": "Leo Tolstoy"
+					},
+					{
+						"property": "Has author",
+						"value": "George Orwell"
+					}
+				]
+			}
+		},
+		{
+			"about": "#1 any value for Marc:title on level one of the subproperty hierarchy",
+			"condition": "[[Marc:title::+]]",
+			"printouts" : [ "Has author" ],
+			"parameters" : {
+			  "limit" : 10
+			},
+			"queryresult": {
+				"count": 3,
+				"results": [
+					"Animal farm#0##",
+					"War and Peace#0##",
+					"Shakespeare's King Lear#0##"
+				],
+				"datavalues": [
+					{
+						"property": "Has author",
+						"value": "Leo Tolstoy"
+					},
+					{
+						"property": "Has author",
+						"value": "George Orwell"
+					},
+					{
+						"property": "Has author",
+						"value": "William Shakespeare"
+					}
+				]
+			}
+		},
+		{
+			"about": "#2 any value for Dc:title on level two of the subproperty hierarchy",
+			"condition": "[[Dc:title::+]]",
+			"printouts" : [ "Has author" ],
+			"parameters" : {
+			  "limit" : 10
+			},
+			"queryresult": {
+				"count": 3,
+				"results": [
+					"Animal farm#0##",
+					"War and Peace#0##",
+					"Shakespeare's King Lear#0##"
+				],
+				"datavalues": [
+					{
+						"property": "Has author",
+						"value": "Leo Tolstoy"
+					},
+					{
+						"property": "Has author",
+						"value": "George Orwell"
+					},
+					{
+						"property": "Has author",
+						"value": "William Shakespeare"
+					}
+				]
+			}
+		},
+		{
+			"about": "#3 distinct value for Dc:title on level two of the subproperty hierarchy",
+			"condition": "[[Dc:title::~*Animal*]]",
+			"printouts" : [ "Has author" ],
+			"parameters" : {
+			  "limit" : 10
+			},
+			"queryresult": {
+				"count": 1,
+				"results": [
+					"Animal farm#0##"
+				],
+				"datavalues": [
+					{
+						"property": "Has author",
+						"value": "George Orwell"
+					}
+				]
+			}
+		},
+		{
+			"about": "#4 distinct value for Has author / redirected value / subproperty level zero",
+			"condition": "[[Has author::Shakespeare]]",
+			"printouts" : [],
+			"parameters" : {
+			  "limit" : 10
+			},
+			"queryresult": {
+				"count": 1,
+				"results": [
+					"Shakespeare's King Lear#0##"
+				]
+			}
+		},
+		{
+			"about": "#5 distinct value for Dc:creator / redirected value / subproperty level one",
+			"condition": "[[Dc:creator::Shakespeare]]",
+			"printouts" : [],
+			"parameters" : {
+			  "limit" : 10
+			},
+			"queryresult": {
+				"count": 1,
+				"results": [
+					"Shakespeare's King Lear#0##"
+				]
+			}
+		}
+	],
+	"settings": {
+		"smwgQSubpropertyDepth": 10
+	},
+	"meta": {
+		"skip-on": {
+			"virtuoso": "Virtuoso 6.1 rdfs / subproperty/property hierarchies are currently not implemented"
+		},
+		"version": "0.1",
+		"is-incomplete": false,
+		"debug": false
+	}
+}

--- a/tests/phpunit/Integration/Query/Fixtures/query-06-04-page-property-value-redirects.json
+++ b/tests/phpunit/Integration/Query/Fixtures/query-06-04-page-property-value-redirects.json
@@ -1,5 +1,5 @@
 {
-	"description": "Verfiy property/values redirects in queries, refs #467",
+	"description": "Resolve property/values redirects in queries, refs #467",
 	"properties": [
 		{
 			"name": "Has firstPage",

--- a/tests/phpunit/Utils/Fixtures/FixturesProvider.php
+++ b/tests/phpunit/Utils/Fixtures/FixturesProvider.php
@@ -72,7 +72,7 @@ class FixturesProvider {
 		return array(
 			'area' => new AreaProperty(),
 			'populationdensity' => new PopulationDensityProperty(),
-			'capitalof' => new CapitalOfProperty(),
+		//	'capitalof' => new CapitalOfProperty(),
 			'status' => new StatusProperty(),
 			'population' => new PopulationProperty(),
 			'founded' => new FoundedProperty(),

--- a/tests/phpunit/includes/SPARQLStore/HierarchyFinderTest.php
+++ b/tests/phpunit/includes/SPARQLStore/HierarchyFinderTest.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace SMW\Tests\SPARQLStore;
+
+use SMW\SPARQLStore\HierarchyFinder;
+use SMW\DIProperty;
+
+/**
+ * @covers \SMW\SPARQLStore\HierarchyFinder
+ *
+ * @group semantic-mediawiki
+ *
+ * @license GNU GPL v2+
+ * @since 2.3
+ *
+ * @author mwjames
+ */
+class HierarchyFinderTest extends \PHPUnit_Framework_TestCase {
+
+	public function testCanConstruct() {
+
+		$store = $this->getMockBuilder( '\SMW\SPARQLStore\SPARQLStore' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$cache = $this->getMockBuilder( '\Onoi\Cache\Cache' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$this->assertInstanceOf(
+			'\SMW\SPARQLStore\HierarchyFinder',
+			new HierarchyFinder( $store, $cache )
+		);
+	}
+
+	public function testVerifyForSubpropertyOnNonCached() {
+
+		$store = $this->getMockBuilder( '\SMW\SPARQLStore\SPARQLStore' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$store->expects( $this->once() )
+			->method( 'getPropertySubjects' )
+			->will( $this->returnValue( array() ) );
+
+		$cache = $this->getMockBuilder( '\Onoi\Cache\Cache' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$cache->expects( $this->once() )
+			->method( 'contains' )
+			->will( $this->returnValue( false ) );
+
+		$cache->expects( $this->once() )
+			->method( 'save' )
+			->with(
+				$this->equalTo( 'Foo' ),
+				$this->equalTo( false ) );
+
+		$instance = new HierarchyFinder( $store, $cache );
+
+		$this->assertInternalType(
+			'boolean',
+			$instance->hasSubpropertyFor( new DIProperty( 'Foo' ) )
+		);
+	}
+
+}

--- a/tests/phpunit/includes/SPARQLStore/QueryEngine/CompoundConditionBuilderTest.php
+++ b/tests/phpunit/includes/SPARQLStore/QueryEngine/CompoundConditionBuilderTest.php
@@ -767,7 +767,7 @@ class CompoundConditionBuilderTest extends \PHPUnit_Framework_TestCase {
 			->setMethods( array( 'canUseQFeature' ) )
 			->getMock();
 
-		$instance->expects( $this->atLeastOnce() )
+		$instance->expects( $this->at( 0 ) )
 			->method( 'canUseQFeature' )
 			->with( $this->equalTo( SMW_SPARQL_QF_REDI ) )
 			->will( $this->returnValue( true ) );

--- a/tests/phpunit/includes/SPARQLStore/QueryEngine/EngineOptionsTest.php
+++ b/tests/phpunit/includes/SPARQLStore/QueryEngine/EngineOptionsTest.php
@@ -24,23 +24,16 @@ class EngineOptionsTest extends \PHPUnit_Framework_TestCase {
 		);
 	}
 
-	public function testInitialState() {
+	/**
+	 * @dataProvider initialSettingsProvider
+	 */
+	public function testInitialState( $setting, $expected ) {
 
 		$instance = new EngineOptions();
 
 		$this->assertInternalType(
-			'boolean',
-			$instance->get( 'smwgIgnoreQueryErrors' )
-		);
-
-		$this->assertInternalType(
-			'boolean',
-			$instance->get( 'smwgQSortingSupport' )
-		);
-
-		$this->assertInternalType(
-			'boolean',
-			$instance->get( 'smwgQRandSortingSupport' )
+			$expected,
+			$instance->get( $setting )
 		);
 	}
 
@@ -66,6 +59,41 @@ class EngineOptionsTest extends \PHPUnit_Framework_TestCase {
 
 		$this->setExpectedException( 'InvalidArgumentException' );
 		$instance->get( 'Foo' );
+	}
+
+	public function initialSettingsProvider() {
+
+		$provider[] = array(
+			'smwgIgnoreQueryErrors',
+			'boolean'
+		);
+
+		$provider[] = array(
+			'smwgQSortingSupport',
+			'boolean'
+		);
+
+		$provider[] = array(
+			'smwgQRandSortingSupport',
+			'boolean'
+		);
+
+		$provider[] = array(
+			'smwgQSubpropertyDepth',
+			'integer'
+		);
+
+		$provider[] = array(
+			'smwgQSubcategoryDepth',
+			'integer'
+		);
+
+		$provider[] = array(
+			'smwgSparqlQFeatures',
+			'integer'
+		);
+
+		return $provider;
 	}
 
 }

--- a/tests/phpunit/includes/SPARQLStore/QueryEngine/Interpreter/SomePropertyInterpreterTest.php
+++ b/tests/phpunit/includes/SPARQLStore/QueryEngine/Interpreter/SomePropertyInterpreterTest.php
@@ -492,7 +492,30 @@ class SomePropertyInterpreterTest extends \PHPUnit_Framework_TestCase {
 			$expected
 		);
 
-		# 13 aux-property
+		# 13
+		$conditionType = '\SMW\SPARQLStore\QueryEngine\Condition\WhereCondition';
+
+		$property = new DIProperty( '_SUBP' );
+
+		$description = new SomeProperty(
+			$property,
+			new ValueDescription( new DIWikiPage( 'Bar', SMW_NS_PROPERTY ) )
+		);
+
+		$expected = $stringBuilder
+			->addString( '?result swivt:wikiPageSortKey ?resultsk .' )->addNewLine()
+			->addString( '?result rdfs:subPropertyOf property:Bar .' )->addNewLine()
+			->getString();
+
+		$provider[] = array(
+			$description,
+			$orderByProperty,
+			$sortkeys,
+			$conditionType,
+			$expected
+		);
+
+		# 14 aux-property
 		$conditionType = '\SMW\SPARQLStore\QueryEngine\Condition\WhereCondition';
 
 		$property = new DIProperty( '_MDAT' );


### PR DESCRIPTION
Follow-up on #1001:
 
- `$GLOBALS['smwgSparqlQFeatures'] = SMW_SPARQL_QF_SUBP;` for repositories that fully support SPARQL 1.1 by making use of `rdfs:subPropertyOf*`
- A larger use case with different hierarchy queries can be found in `query-04-02-subproperty-dc-import-marc21.json` including property/value redirects and regex value search