### PR TITLE
Add PropertyTableRowDiffer, refs #682

### DIFF
--- a/includes/storage/SQLStore/SMW_Sql3SmwIds.php
+++ b/includes/storage/SQLStore/SMW_Sql3SmwIds.php
@@ -307,9 +307,9 @@ class SMWSql3SmwIds {
 	public function getSMWPageIDandSort( $title, $namespace, $iw, $subobjectName, &$sortkey, $canonical, $fetchHashes = false ) {
 		$id = $this->getPredefinedData( $title, $namespace, $iw, $subobjectName, $sortkey );
 		if ( $id != 0 ) {
-			return $id;
+			return (int)$id;
 		} else {
-			return $this->getDatabaseIdAndSort( $title, $namespace, $iw, $subobjectName, $sortkey, $canonical, $fetchHashes );
+			return (int)$this->getDatabaseIdAndSort( $title, $namespace, $iw, $subobjectName, $sortkey, $canonical, $fetchHashes );
 		}
 	}
 
@@ -486,9 +486,9 @@ class SMWSql3SmwIds {
 	public function makeSMWPageID( $title, $namespace, $iw, $subobjectName, $canonical = true, $sortkey = '', $fetchHashes = false ) {
 		$id = $this->getPredefinedData( $title, $namespace, $iw, $subobjectName, $sortkey );
 		if ( $id != 0 ) {
-			return $id;
+			return (int)$id;
 		} else {
-			return $this->makeDatabaseId( $title, $namespace, $iw, $subobjectName, $canonical, $sortkey, $fetchHashes );
+			return (int)$this->makeDatabaseId( $title, $namespace, $iw, $subobjectName, $canonical, $sortkey, $fetchHashes );
 		}
 	}
 
@@ -534,7 +534,7 @@ class SMWSql3SmwIds {
 				__METHOD__
 			);
 
-			$id = $db->insertId();
+			$id = (int)$db->insertId();
 
 			// Properties also need to be in the property statistics table
 			if( $namespace === SMW_NS_PROPERTY ) {
@@ -646,9 +646,9 @@ class SMWSql3SmwIds {
 	 */
 	public function makeSMWPropertyID( SMWDIProperty $property ) {
 		if ( array_key_exists( $property->getKey(), self::$special_ids ) ) {
-			return self::$special_ids[$property->getKey()];
+			return (int)self::$special_ids[$property->getKey()];
 		} else {
-			return $this->makeDatabaseId(
+			return (int)$this->makeDatabaseId(
 				$property->getKey(),
 				SMW_NS_PROPERTY,
 				$this->getPropertyInterwiki( $property ),
@@ -854,7 +854,7 @@ class SMWSql3SmwIds {
 		if ( $namespace == SMW_NS_PROPERTY && $interwiki === '' && $subobject === '' ) {
 			if ( array_key_exists( $title, $this->prop_ids ) ) {
 				$this->prophit_debug++;
-				return $this->prop_ids[$title];
+				return (int)$this->prop_ids[$title];
 			} else {
 				$this->propmiss_debug++;
 				return false;
@@ -863,7 +863,7 @@ class SMWSql3SmwIds {
 			$hashKey = HashBuilder::createHashIdFromSegments( $title, $namespace, $interwiki, $subobject );
 			if ( array_key_exists( $hashKey, $this->regular_ids ) ) {
 				$this->reghit_debug++;
-				return $this->regular_ids[$hashKey];
+				return (int)$this->regular_ids[$hashKey];
 			} else {
 				$this->regmiss_debug++;
 				return false;

--- a/src/SQLStore/PropertyTableRowDiffer.php
+++ b/src/SQLStore/PropertyTableRowDiffer.php
@@ -1,0 +1,350 @@
+<?php
+
+namespace SMW\SQLStore;
+
+use SMW\MediaWiki\Database;
+use SMW\SemanticData;
+use SMW\Store;
+use SMWDIError as DIError;
+use InvalidArgumentException;
+
+/**
+ * @license GNU GPL v2+
+ * @since 2.3
+ *
+ * @author Markus Krötzsch
+ * @author Nischay Nahata
+ * @author mwjames
+ */
+class PropertyTableRowDiffer {
+
+	/**
+	 * @var Store
+	 */
+	private $store = null;
+
+	/**
+	 * @since 2.3
+	 *
+	 * @param Store $store
+	 */
+	public function __construct( Store $store ) {
+		$this->store = $store;
+	}
+
+	/**
+	 * Compute necessary insertions, deletions, and new table hashes for
+	 * updating the database to contain $newData for the subject with ID
+	 * $sid. Insertions and deletions are returned in as an array mapping
+	 * table names to arrays of table rows. Each row is an array mapping
+	 * column names to values as usual. The table hashes are returned as
+	 * an array mapping table names to hash values.
+	 *
+	 * It is ensured that table names (keys) in the returned insert
+	 * data are exaclty the same as the table names (keys) in the delete
+	 * data, even if one of them maps to an empty array (no changes). If
+	 * a table needs neither insertions nor deletions, then it will not
+	 * be mentioned as a key anywhere.
+	 *
+	 * The given database is only needed for reading the data that is
+	 * related assigned to sid.
+	 *
+	 * @since 2.3
+	 *
+	 * @param integer $sid
+	 * @param SemanticData $semanticData
+	 *
+	 * @return array
+	 */
+	public function computeTableRowDiffFor( $sid, SemanticData $semanticData ) {
+
+		$tablesDeleteRows = array();
+		$tablesInsertRows = array();
+
+		$newHashes = array();
+
+		$newData = $this->mapToInsertValueFormat(
+			$sid,
+			$semanticData
+		);
+
+		$oldHashes = $this->fetchPropertyTableHashesForId( $sid );
+		$propertyTables = $this->store->getPropertyTables();
+
+		foreach ( $propertyTables as $propertyTable ) {
+
+			if ( !$propertyTable->usesIdSubject() ) { // ignore; only affects redirects anyway
+				continue;
+			}
+
+			$tableName = $propertyTable->getName();
+
+			if ( array_key_exists( $tableName, $newData ) ) {
+				// Note: the order within arrays should remain the same while page is not updated.
+				// Hence we do not sort before serializing. It is hoped that this assumption is valid.
+				$newHashes[$tableName] = $this->createNewHashForTable(
+					$tableName,
+					$newData
+				);
+
+				if ( array_key_exists( $tableName, $oldHashes ) && $newHashes[$tableName] == $oldHashes[$tableName] ) {
+					// Table contains data and should contain the same data after update
+					continue;
+				} else { // Table contains no data or contains data that is different from the new
+					list( $tablesInsertRows[$tableName], $tablesDeleteRows[$tableName] ) = $this->arrayDeleteMatchingValues(
+						$this->fetchCurrentContentsForPropertyTable( $sid, $propertyTable ),
+						$newData[$tableName]
+					);
+				}
+			} elseif ( array_key_exists( $tableName, $oldHashes ) ) {
+				// Table contains data but should not contain any after update
+				$tablesInsertRows[$tableName] = array();
+				$tablesDeleteRows[$tableName] = $this->fetchCurrentContentsForPropertyTable(
+					$sid,
+					$propertyTable
+				);
+			}
+		}
+
+		return array( $tablesInsertRows, $tablesDeleteRows, $newHashes );
+	}
+
+	private function fetchPropertyTableHashesForId( $sid ) {
+		return $this->store->getObjectIds()->getPropertyTableHashes( $sid );
+	}
+
+	/**
+	 * The hashModifier can be used to force a modification in order to detect
+	 * content edits where text has been changed but the md5 table hash remains
+	 * unchanged and therefore would not re-compute the diff and misses out
+	 * critical updates on property tables.
+	 *
+	 * The phenomenon has been observed in connection with a page turned from
+	 * a redirect to a normal page or for undeleted pages.
+	 */
+	private function createNewHashForTable( $tableName, $newData, $hashModifier = '' ) {
+		return md5( serialize( array_values( $newData[ $tableName ] ) ) . $hashModifier );
+	}
+
+	/**
+	 * Get the current data stored for the given ID in the given database
+	 * table. The result is an array of updates, formatted like the one of
+	 * the table insertion arrays created by preparePropertyTableInserts().
+	 *
+	 * @note Tables without IDs as subject are not supported. They will
+	 * hopefully vanish soon anyway.
+	 *
+	 * @since 1.8
+	 * @param integer $sid
+	 * @param TableDefinition $tableDeclaration
+	 * @return array
+	 */
+	private function fetchCurrentContentsForPropertyTable( $sid, TableDefinition $propertyTable ) {
+
+		if ( !$propertyTable->usesIdSubject() ) { // does not occur, but let's be strict
+			throw new InvalidArgumentException('Operation not supported for tables without subject IDs.');
+		}
+
+		$contents = array();
+		$connection = $this->store->getConnection( 'mw.db' );
+
+		$result = $connection->select(
+			$connection->tablename( $propertyTable->getName() ),
+			'*',
+			array( 's_id' => $sid ),
+			__METHOD__
+		);
+
+		foreach( $result as $row ) {
+			if ( is_object( $row ) ) {
+
+				$resultRow = (array)$row;
+
+				// Always make sure to use int values for ids so
+				// that the compare/hash will be of the same type
+				if ( isset( $resultRow['s_id'] ) ) {
+					$resultRow['s_id'] = (int)$resultRow['s_id'];
+				}
+
+				if ( isset( $resultRow['p_id'] ) ) {
+					$resultRow['p_id'] = (int)$resultRow['p_id'];
+				}
+
+				if ( isset( $resultRow['o_id'] ) ) {
+					$resultRow['o_id'] = (int)$resultRow['o_id'];
+				}
+
+				$contents[] = $resultRow;
+			}
+		}
+
+		return $contents;
+	}
+
+	/**
+	 * Delete all matching values from old and new arrays and return the
+	 * remaining new values as insert values and the remaining old values as
+	 * delete values.
+	 *
+	 * @param array $oldValues
+	 * @param array $newValues
+	 * @return array
+	 */
+	private function arrayDeleteMatchingValues( $oldValues, $newValues ) {
+
+		// cycle through old values
+		foreach ( $oldValues as $oldKey => $oldValue ) {
+
+			// cycle through new values
+			foreach ( $newValues as $newKey => $newValue ) {
+
+				// delete matching values;
+				// use of == is intentional to account for oldValues only
+				// containing strings while new values might also contain other
+				// types
+				if ( $newValue == $oldValue ) {
+					unset( $newValues[$newKey] );
+					unset( $oldValues[$oldKey] );
+				}
+			}
+		};
+
+		// arrays have to be renumbered because database functions expect an
+		// element with index 0 to be present in the array
+		return array( array_values( $newValues ), array_values( $oldValues ) );
+	}
+
+	/**
+	 * Create an array of rows to insert into property tables in order to
+	 * store the given SMWSemanticData. The given $sid (subject page id) is
+	 * used directly and must belong to the subject of the data container.
+	 * Sortkeys are ignored since they are not stored in a property table
+	 * but in the ID table.
+	 *
+	 * The returned array uses property table names as keys and arrays of
+	 * table rows as values. Each table row is an array mapping column
+	 * names to values.
+	 *
+	 * @note Property tables that do not use ids as subjects are ignored.
+	 * This just excludes redirects that are handled differently anyway;
+	 * it would not make a difference to include them here.
+	 *
+	 * @since 1.8
+	 *
+	 * @param integer $sid
+	 * @param SemanticData $semanticData
+	 *
+	 * @return array
+	 */
+	private function mapToInsertValueFormat( $sid, SemanticData $semanticData ) {
+		$updates = array();
+
+		$subject = $semanticData->getSubject();
+		$propertyTables = $this->store->getPropertyTables();
+
+		foreach ( $semanticData->getProperties() as $property ) {
+
+			$tableId = $this->store->findPropertyTableID( $property );
+
+			// not stored in a property table, e.g., sortkeys
+			if ( $tableId === null ) {
+				continue;
+			}
+
+			$propertyTable = $propertyTables[$tableId];
+
+			// not using subject ids, e.g., redirects
+			if ( !$propertyTable->usesIdSubject() ) {
+				continue;
+			}
+
+			$insertValues = array( 's_id' => $sid );
+
+			if ( !$propertyTable->isFixedPropertyTable() ) {
+				$insertValues['p_id'] = $this->store->getObjectIds()->makeSMWPropertyID( $property );
+			}
+
+			foreach ( $semanticData->getPropertyValues( $property ) as $dataItem ) {
+
+				if ( $dataItem instanceof DIError ) { // ignore error values
+					continue;
+				}
+
+				if ( !array_key_exists( $propertyTable->getName(), $updates ) ) {
+					$updates[$propertyTable->getName()] = array();
+				}
+
+				$dataItemValues = $this->store->getDataItemHandlerForDIType( $dataItem->getDIType() )->getInsertValues( $dataItem );
+
+				// Ensure that the sortkey is a string
+				if ( isset( $dataItemValues['o_sortkey'] ) ) {
+					$dataItemValues['o_sortkey'] = (string)$dataItemValues['o_sortkey'];
+				}
+
+				// Make sure to build a unique set without duplicates which could happen
+				// if an annotation is made to a property that has a redirect pointing
+				// to the same p_id
+				$insertValues = array_merge( $insertValues, $dataItemValues );
+				$insertValuesHash = md5( implode( '#', $insertValues ) );
+
+				$updates[$propertyTable->getName()][$insertValuesHash] = $insertValues;
+			}
+		}
+
+		// Special handling of Concepts
+		if ( $subject->getNamespace() === SMW_NS_CONCEPT && $subject->getSubobjectName() == '' ) {
+			$this->fetchConceptTableInserts( $sid, $updates );
+		}
+
+		return $updates;
+	}
+
+	/**
+	 * Add cache information to concept data and make sure that there is
+	 * exactly one value for the concept table.
+	 *
+	 * @note This code will vanish when concepts have a more standard
+	 * handling. So not point in optimizing this much now.
+	 *
+	 * @since 1.8
+	 * @param integer $sid
+	 * @param &array $insertData
+	 */
+	private function fetchConceptTableInserts( $sid, &$insertData ) {
+
+		$connection = $this->store->getConnection( 'mw.db' );
+
+		// Make sure that there is exactly one row to be written:
+		if ( array_key_exists( 'smw_fpt_conc', $insertData ) && !empty( $insertData['smw_fpt_conc'] ) ) {
+			$insertValues = end( $insertData['smw_fpt_conc'] );
+		} else {
+			$insertValues = array(
+				's_id'          => $sid,
+				'concept_txt'   => '',
+				'concept_docu'  => '',
+				'concept_features' => 0,
+				'concept_size'  => -1,
+				'concept_depth' => -1
+			);
+		}
+
+		// Add existing cache status data to this row:
+		$row = $connection->selectRow(
+			'smw_fpt_conc',
+			array( 'cache_date', 'cache_count' ),
+			array( 's_id' => $sid ),
+			__METHOD__
+		);
+
+		if ( $row === false ) {
+			$insertValues['cache_date'] = null;
+			$insertValues['cache_count'] = null;
+		} else {
+			$insertValues['cache_date'] = $row->cache_date;
+			$insertValues['cache_count'] = $row->cache_count;
+		}
+
+		$insertData['smw_fpt_conc'] = array( $insertValues );
+	}
+
+}

--- a/tests/phpunit/includes/SQLStore/PropertyTableRowDifferTest.php
+++ b/tests/phpunit/includes/SQLStore/PropertyTableRowDifferTest.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace SMW\Tests\SQLStore;
+
+use SMW\SQLStore\PropertyTableRowDiffer;
+use SMW\SQLStore\SQLStore;
+use SMW\DIWikiPage;
+use SMW\SemanticData;
+
+/**
+ * @covers \SMW\SQLStore\PropertyTableRowDiffer
+ *
+ * @group semantic-mediawiki
+ *
+ * @license GNU GPL v2+
+ * @since 2.3
+ *
+ * @author mwjames
+ */
+class PropertyTableRowDifferTest extends \PHPUnit_Framework_TestCase {
+
+	public function testCanConstruct() {
+
+		$store = $this->getMockBuilder( '\SMW\Store' )
+			->disableOriginalConstructor()
+			->getMockForAbstractClass();
+
+		$this->assertInstanceOf(
+			'\SMW\SQLStore\PropertyTableRowDiffer',
+			new PropertyTableRowDiffer( $store )
+		);
+	}
+
+	public function testComputeTableRowDiffForEmptyPropertyTables() {
+
+		$semanticData = new SemanticData(
+			new DIWikiPage( 'Foo', NS_MAIN )
+		);
+
+		$propertyTables = array();
+
+		$store = $this->getMockBuilder( '\SMW\SQLStore\SQLStore' )
+			->setMethods( array( 'getPropertyTables' ) )
+			->getMock();
+
+		$store->expects( $this->any() )
+			->method( 'getPropertyTables' )
+			->will( $this->returnValue( $propertyTables ) );
+
+		$instance = new PropertyTableRowDiffer( $store );
+
+		$result = $instance->computeTableRowDiffFor(
+			42,
+			$semanticData
+		);
+
+		$this->assertInternalType(
+			'array',
+			$result
+		);
+	}
+
+}


### PR DESCRIPTION
- Code responsible for computing row diffs was moved to its own component
- `SMWSql3SmwIds` now always returns `int` for id's to avoid id mismatch as seen in #682