### PR TITLE
Fixed assumption that always an array is sent to JobBase for booleans

### DIFF
--- a/docs/RELEASE-NOTES.md
+++ b/docs/RELEASE-NOTES.md
@@ -15,6 +15,7 @@ This is not a release yet.
 ## Bug fixes
 
 * #1005 Fixed syntax error in `SQLStore`(`sqlite`) for temporary tables when a disjuntive category/subcategory query is executed
+* #1033 Fixed assumption that always an array is sent to `JobBase` for booleans
 
 ## Internal changes
 

--- a/src/MediaWiki/Jobs/JobBase.php
+++ b/src/MediaWiki/Jobs/JobBase.php
@@ -103,6 +103,14 @@ abstract class JobBase extends Job {
 	 *
 	 * @return boolean
 	 */
+	 
+	 /**
+	  * see https://github.com/SemanticMediaWiki/SemanticMediaWiki/issues/1033
+	  */
+	 if ( !is_array( $this->params ) ) {
+	 	return false;
+	 }
+	 	
 	public function hasParameter( $key ) {
 		return isset( $this->params[$key] ) || array_key_exists( $key, $this->params );
 	}

--- a/src/MediaWiki/Jobs/JobBase.php
+++ b/src/MediaWiki/Jobs/JobBase.php
@@ -104,14 +104,12 @@ abstract class JobBase extends Job {
 	 * @return boolean
 	 */
 	 
-	 /**
-	  * see https://github.com/SemanticMediaWiki/SemanticMediaWiki/issues/1033
-	  */
-	 if ( !is_array( $this->params ) ) {
-	 	return false;
-	 }
-	 	
 	public function hasParameter( $key ) {
+		
+		if ( !is_array( $this->params ) ) {
+			return false;
+		}
+		
 		return isset( $this->params[$key] ) || array_key_exists( $key, $this->params );
 	}
 


### PR DESCRIPTION
Addresses issue https://github.com/SemanticMediaWiki/SemanticMediaWiki/issues/1033. Thanks go to @mwjames 