### PR TITLE
Fix Fatal error: Call to undefined method SMWDIError::getString()

### DIFF
--- a/includes/dataitems/SMW_DI_Error.php
+++ b/includes/dataitems/SMW_DI_Error.php
@@ -37,6 +37,10 @@ class SMWDIError extends SMWDataItem {
 		return 'error';
 	}
 
+	public function getString() {
+		return $this->getSerialization();
+	}
+
 	public function getSerialization() {
 		return serialize( $this->m_errors );
 	}


### PR DESCRIPTION
Caused by https://github.com/SemanticMediaWiki/SemanticMediaWiki/commit/70b1d39e8e73c58cd656a8628310af1031252231#diff-6ae5b9348e96e38f0a49fccad8b7c1e4


```
Fatal error: Call to undefined method SMWDIError::getString() in ...\SemanticMediaWiki\includes\storage\SQLStore\SMW_DIHandler_Blob.php on line 61
Call Stack
#	Time	Memory	Function	Location
1	0.0002	131888	{main}( )	..\index.php:0
2	0.1237	1839768	MediaWiki->run( )	..\index.php:46
3	0.1239	1840344	MediaWiki->main( )	..\MediaWiki.php:435
4	0.2188	2346568	MediaWiki->performRequest( )	..\MediaWiki.php:584
5	0.2335	2550968	MediaWiki->performAction( )	..\MediaWiki.php:282
6	0.2343	2551152	ViewAction->show( )	..\MediaWiki.php:414
7	0.2343	2551200	SMWOrderedListPage->view( )	..\ViewAction.php:44
8	0.7584	3775400	SMWOrderedListPage->showList( )	..\SMW_OrderedListPage.php:66
9	0.7594	3777680	SMWPropertyPage->getHtml( )	..\SMW_OrderedListPage.php:81
10	0.7654	3783648	SMWPropertyPage->getPropertyValueList( )	..\SMW_PropertyPage.php:49
11	0.7788	3805280	SMWSQLStore3->getQueryResult( )	..\SMW_PropertyPage.php:167
12	0.7789	3805344	SMWSQLStore3->fetchQueryResult( )	..\SMW_SQLStore3.php:287
13	0.7958	3852288	SMW\SQLStore\QueryEngine\QueryEngine->getQueryResult( )	..\SMW_SQLStore3.php:296
14	0.7960	3852296	SMW\SQLStore\QueryEngine\QueryBuilder->buildQuerySegmentFor( )	..\QueryEngine.php:170
15	0.7960	3852344	SMW\SQLStore\QueryEngine\Interpreter\DispatchingInterpreter->interpretDescription( )	..\QueryBuilder.php:211
16	0.7960	3852384	SMW\SQLStore\QueryEngine\Interpreter\SomePropertyInterpreter->interpretDescription( )	..\DispatchingInterpreter.php:54
17	0.7961	3853472	SMW\SQLStore\QueryEngine\Interpreter\SomePropertyInterpreter->interpretPropertyConditionForDescription( )	..\SomePropertyInterpreter.php:79
18	0.7969	3854792	SMW\SQLStore\QueryEngine\Interpreter\SomePropertyInterpreter->interpretInnerValueDescription( )	..\SomePropertyInterpreter.php:186
19	0.7969	3854968	SMW\SQLStore\QueryEngine\Interpreter\SomePropertyInterpreter->mapValueDescription( )	..\SomePropertyInterpreter.php:208
20	0.7970	3855104	SMWDIHandlerBlob->getWhereConds( )	..\SomePropertyInterpreter.php:260
```