### PR TITLE
rebuildData to inform about estimated % progress, refs #778

### DIFF
--- a/includes/storage/SQLStore/SMW_SQLStore3.php
+++ b/includes/storage/SQLStore/SMW_SQLStore3.php
@@ -397,7 +397,7 @@ class SMWSQLStore3 extends SMWStore {
 		$byIdDataRebuildDispatcher->setNamespacesTo( $namespaces );
 		$byIdDataRebuildDispatcher->setUpdateJobToUseJobQueueScheduler( $usejobs );
 
-		return $byIdDataRebuildDispatcher->dispatchRebuildFor( $id );
+		return $byIdDataRebuildDispatcher;
 	}
 
 

--- a/src/MediaWiki/Jobs/RefreshJob.php
+++ b/src/MediaWiki/Jobs/RefreshJob.php
@@ -79,10 +79,17 @@ class RefreshJob extends JobBase {
 	 * @param $spos start index
 	 */
 	protected function refreshData( $spos ) {
-		Profiler::In();
 
 		$run  = $this->hasParameter( 'run' ) ? $this->getParameter( 'run' ) : 1;
-		$prog = ApplicationFactory::getInstance()->getStore()->refreshData( $spos, 20, $this->getNamespace( $run ) );
+
+		$byIdDataRebuildDispatcher = ApplicationFactory::getInstance()->getStore()->refreshData(
+			$spos,
+			20,
+			$this->getNamespace( $run )
+		);
+
+		$byIdDataRebuildDispatcher->dispatchRebuildFor( $spos );
+		$prog = $byIdDataRebuildDispatcher->getEstimatedProgress();
 
 		if ( $spos > 0 ) {
 
@@ -93,7 +100,7 @@ class RefreshJob extends JobBase {
 				'run'  => $run
 			) );
 
-		} elseif ( $this->getParameter( 'rc' ) > $run ) { // do another run from the beginning
+		} elseif ( $this->hasParameter( 'rc' ) && $this->getParameter( 'rc' ) > $run ) { // do another run from the beginning
 
 			$this->createNextJob( array(
 				'spos' => 1,
@@ -104,7 +111,6 @@ class RefreshJob extends JobBase {
 
 		}
 
-		Profiler::Out();
 		return true;
 	}
 
@@ -114,6 +120,11 @@ class RefreshJob extends JobBase {
 	}
 
 	protected function getNamespace( $run ) {
+
+		if ( !$this->hasParameter( 'rc' ) ) {
+			return false;
+		}
+
 		return ( ( $this->getParameter( 'rc' ) > 1 ) && ( $run == 1 ) ) ? array( SMW_NS_PROPERTY, SMW_NS_TYPE ) : false;
 	}
 

--- a/tests/phpunit/Integration/MediaWiki/JobQueueDBIntegrationTest.php
+++ b/tests/phpunit/Integration/MediaWiki/JobQueueDBIntegrationTest.php
@@ -161,7 +161,7 @@ class JobQueueDBIntegrationTest extends MwDBaseUnitTestCase {
 
 		$index = 1; //pass-by-reference
 
-		$this->getStore()->refreshData( $index, 1, false, true );
+		$this->getStore()->refreshData( $index, 1, false, true )->dispatchRebuildFor( $index );
 		$this->assertJob( 'SMW\UpdateJob' );
 	}
 

--- a/tests/phpunit/Integration/SQLStore/RefreshSQLStoreDBIntegrationTest.php
+++ b/tests/phpunit/Integration/SQLStore/RefreshSQLStoreDBIntegrationTest.php
@@ -81,14 +81,19 @@ class RefreshSQLStoreDBIntegrationTest extends MwDBaseUnitTestCase {
 	protected function assertStoreHasDataToRefresh( $useJobs ) {
 		$refreshPosition = $this->title->getArticleID();
 
-		$refreshProgress = $this->getStore()->refreshData(
+		$byIdDataRebuildDispatcher = $this->getStore()->refreshData(
 			$refreshPosition,
 			1,
 			false,
 			$useJobs
 		);
 
-		$this->assertGreaterThan( 0, $refreshProgress );
+		$byIdDataRebuildDispatcher->dispatchRebuildFor( $refreshPosition );
+
+		$this->assertGreaterThan(
+			0,
+			$byIdDataRebuildDispatcher->getEstimatedProgress()
+		);
 	}
 
 	public function titleProvider() {

--- a/tests/phpunit/includes/Maintenance/DataRebuilderTest.php
+++ b/tests/phpunit/includes/Maintenance/DataRebuilderTest.php
@@ -60,6 +60,18 @@ class DataRebuilderTest extends \PHPUnit_Framework_TestCase {
 	 */
 	public function testRebuildAllWithoutOptions() {
 
+		$byIdDataRebuildDispatcher = $this->getMockBuilder( '\SMW\SQLStore\ByIdDataRebuildDispatcher' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$byIdDataRebuildDispatcher->expects( $this->once() )
+			->method( 'dispatchRebuildFor' )
+			->will( $this->returnCallback( array( $this, 'refreshDataOnMockCallback' ) ) );
+
+		$byIdDataRebuildDispatcher->expects( $this->any() )
+			->method( 'getMaxId' )
+			->will( $this->returnValue( 1000 ) );
+
 		$store = $this->getMockBuilder( '\SMW\Store' )
 			->disableOriginalConstructor()
 			->setMethods( array( 'refreshData' ) )
@@ -67,7 +79,7 @@ class DataRebuilderTest extends \PHPUnit_Framework_TestCase {
 
 		$store->expects( $this->once() )
 			->method( 'refreshData' )
-			->will( $this->returnCallback( array( $this, 'refreshDataOnMockCallback' ) ) );
+			->will( $this->returnValue( $byIdDataRebuildDispatcher ) );
 
 		$titleCreator = $this->getMockBuilder( '\SMW\MediaWiki\TitleCreator' )
 			->disableOriginalConstructor()
@@ -88,6 +100,18 @@ class DataRebuilderTest extends \PHPUnit_Framework_TestCase {
 	 */
 	public function testRebuildAllWithFullDelete() {
 
+		$byIdDataRebuildDispatcher = $this->getMockBuilder( '\SMW\SQLStore\ByIdDataRebuildDispatcher' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$byIdDataRebuildDispatcher->expects( $this->atLeastOnce() )
+			->method( 'dispatchRebuildFor' )
+			->will( $this->returnCallback( array( $this, 'refreshDataOnMockCallback' ) ) );
+
+		$byIdDataRebuildDispatcher->expects( $this->any() )
+			->method( 'getMaxId' )
+			->will( $this->returnValue( 1000 ) );
+
 		$store = $this->getMockBuilder( '\SMW\Store' )
 			->disableOriginalConstructor()
 			->setMethods( array(
@@ -97,7 +121,7 @@ class DataRebuilderTest extends \PHPUnit_Framework_TestCase {
 
 		$store->expects( $this->once() )
 			->method( 'refreshData' )
-			->will( $this->returnCallback( array( $this, 'refreshDataOnMockCallback' ) ) );
+			->will( $this->returnValue( $byIdDataRebuildDispatcher ) );
 
 		$store->expects( $this->once() )
 			->method( 'drop' );
@@ -122,14 +146,26 @@ class DataRebuilderTest extends \PHPUnit_Framework_TestCase {
 	 */
 	public function testRebuildAllWithStopRangeOption() {
 
+		$byIdDataRebuildDispatcher = $this->getMockBuilder( '\SMW\SQLStore\ByIdDataRebuildDispatcher' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$byIdDataRebuildDispatcher->expects( $this->exactly( 6 ) )
+			->method( 'dispatchRebuildFor' )
+			->will( $this->returnCallback( array( $this, 'refreshDataOnMockCallback' ) ) );
+
+		$byIdDataRebuildDispatcher->expects( $this->any() )
+			->method( 'getMaxId' )
+			->will( $this->returnValue( 1000 ) );
+
 		$store = $this->getMockBuilder( '\SMW\Store' )
 			->disableOriginalConstructor()
 			->setMethods( array( 'refreshData' ) )
 			->getMockForAbstractClass();
 
-		$store->expects( $this->exactly( 6 ) )
+		$store->expects( $this->once() )
 			->method( 'refreshData' )
-			->will( $this->returnCallback( array( $this, 'refreshDataOnMockCallback' ) ) );
+			->will( $this->returnValue( $byIdDataRebuildDispatcher ) );
 
 		$titleCreator = $this->getMockBuilder( '\SMW\MediaWiki\TitleCreator' )
 			->disableOriginalConstructor()


### PR DESCRIPTION
Follow-up on #1041, refs #778

The verbose mode will output something like:

```
Processing all IDs from 1 to 3116 ...
(1/3116 0%) Processing ID 2 ...
(2/3116 0%) Processing ID 3 ...
(3/3116 0%) Processing ID 4 ...
(4/3116 0%) Processing ID 5 ...
(5/3116 0%) Processing ID 6 ...
(6/3116 0%) Processing ID 7 ...
(7/3116 0%) Processing ID 8 ...
(8/3116 0%) Processing ID 9 ...
(9/3116 0%) Processing ID 10 ...
(10/3116 0%) Processing ID 11 ...
(11/3116 0%) Processing ID 12 ...
(12/3116 0%) Processing ID 13 ...
(13/3116 0%) Processing ID 14 ...
(14/3116 0%) Processing ID 15 ...
(15/3116 0%) Processing ID 16 ...
(16/3116 0%) Processing ID 17 ...
(17/3116 1%) Processing ID 18 ...
(18/3116 1%) Processing ID 19 ...
(19/3116 1%) Processing ID 20 ...
(20/3116 1%) Processing ID 21 ...
```
and for the non-verbose output mode
```
Processing all IDs from 1 to 3116 ...

............................................................ 2%
............................................................ 4%
....................................
```