### PR TITLE
Distinguish display of a "normal" link and a subobject

### DIFF
--- a/resources/smw/ext.smw.css
+++ b/resources/smw/ext.smw.css
@@ -446,3 +446,9 @@ label.smw-form-checkbox {
 	font-family: inherit;
 	font-weight: 500;
 }
+
+/* Distinguish subobjects from other titles */
+
+.smw-subobject-entity {
+	font-style: italic;
+}


### PR DESCRIPTION
Sometimes it can be hard to distinguish between a standard subject and a subobject when displayed next to each other because the fragment (the part that represents the subobject id) is generally hidden in html. A subject that is identified as subobject now gets a `smw-subobject-entity` class assigned which by default is styled as `italic`.

![image](https://cloud.githubusercontent.com/assets/1245473/7958501/5da18644-09f0-11e5-8e7d-1fe11591e4af.png)

![image](https://cloud.githubusercontent.com/assets/1245473/7958509/6ccd1110-09f0-11e5-97d2-344d4fc90d9f.png)
