### PR TITLE
Apply changes from refs #19

### DIFF
--- a/tests/phpunit/Integration/Query/Fixtures/query-09-01-disjunction-conjunction-19-1056.json
+++ b/tests/phpunit/Integration/Query/Fixtures/query-09-01-disjunction-conjunction-19-1056.json
@@ -29,7 +29,7 @@
 		},
 		{
 			"name": "Sample/1",
-			"contents": "[[Category:Sample-1]] [[Has page-1::Value 1]][[Has text-1::Value 1]]"
+			"contents": "[[Category:Sample-1]] [[Has page-1::Value 1]][[Has text-1::Value 1]] [[Has text-1::Value 3]]"
 		},
 		{
 			"name": "Sample/1/1",
@@ -41,7 +41,7 @@
 		},
 		{
 			"name": "Sample/2",
-			"contents": "[[Category:Sample-1]] [[Has page-2::Value 1]][[Has text-2::Value 1]]"
+			"contents": "[[Category:Sample-1]] [[Has page-2::Value 1]][[Has text-2::Value 1]] [[Has page-1::Value 3]]"
 		},
 		{
 			"name": "Sample/2/1",
@@ -112,7 +112,7 @@
 			}
 		},
 		{
-			"about": "#3 same as #2",
+			"about": "#3 equivalent to #2",
 			"condition": "[[Has page-1::Value 1]] AND <q>[[Has text-1::Value 1]] OR [[Has text-1::Value 2]]</q>",
 			"printouts" : [],
 			"parameters" : {
@@ -191,7 +191,7 @@
 			}
 		},
 		{
-			"about": "#8 same as #7",
+			"about": "#8 equivalent to #7",
 			"condition": "[[Category:Sample-1||Sample-2]] AND [[Has page-2::<q> [[Has text-1::Value 1]] OR [[Has text-2::Value 2]] </q>]]",
 			"printouts" : [],
 			"parameters" : {
@@ -221,7 +221,7 @@
 			}
 		},
 		{
-			"about": "#10 same as #9 only in chain notation",
+			"about": "#10 equivalent to #9 only in chain notation",
 			"condition": "[[Has page-1.Has page-2:: <q> [[Has text-1::Value 1]] OR [[Has text-2::Value 2]]</q> ]]",
 			"printouts" : [],
 			"parameters" : {
@@ -261,6 +261,82 @@
 				"results": [
 					"Sample/4/1#0##",
 					"Sample/4/2#0##"
+				]
+			}
+		},
+		{
+			"about": "#13, see issue #19",
+			"condition": "[[Has page-1::Value 1||Value 2]] [[Has text-1::Value 1||Value 2]]",
+			"printouts" : [],
+			"parameters" : {
+				"limit" : "10"
+			},
+			"queryresult": {
+				"count": 3,
+				"results": [
+					"Sample/1#0##",
+					"Sample/1/1#0##",
+					"Sample/1/2#0##"
+				]
+			}
+		},
+		{
+			"about": "#14 equivalent to #13",
+			"condition": "<q>[[Has page-1::Value 1]] OR [[Has page-1::Value 2]]</q> AND <q>[[Has text-1::Value 1]] OR [[Has text-1::Value 2]]</q>",
+			"printouts" : [],
+			"parameters" : {
+				"limit" : "10"
+			},
+			"queryresult": {
+				"count": 3,
+				"results": [
+					"Sample/1#0##",
+					"Sample/1/1#0##",
+					"Sample/1/2#0##"
+				]
+			}
+		},
+		{
+			"about": "#15",
+			"condition": "<q>[[Has page-1::Value 1]] OR [[Has page-2::Value 1]]</q> AND <q>[[Has text-1::Value 1]] OR [[Has text-2::Value 1]]</q> AND <q>[[Has text-1::Value 3]] OR [[Has page-1::Value 3]]</q>",
+			"printouts" : [],
+			"parameters" : {
+				"limit" : "10"
+			},
+			"queryresult": {
+				"count": 2,
+				"results": [
+					"Sample/1#0##",
+					"Sample/2#0##"
+				]
+			}
+		},
+		{
+			"about": "#16",
+			"condition": "[[Has page-2:: <q>[[Has page-1::Value 1||Value 2]] [[Has text-1::Value 1||Value 2]]</q> ]]",
+			"printouts" : [],
+			"parameters" : {
+				"limit" : "10"
+			},
+			"queryresult": {
+				"count": 1,
+				"results": [
+					"Sample/3/1#0##"
+				]
+			}
+		},
+		{
+			"about": "#17",
+			"condition": "[[Has page-2:: <q>[[Has page-1::Value 1||Value 2]] [[Has text-1::Value 1||Value 2]]</q> || <q> [[Has page-2::Value 1||Value 2]]</q> ]]",
+			"printouts" : [],
+			"parameters" : {
+				"limit" : "10"
+			},
+			"queryresult": {
+				"count": 2,
+				"results": [
+					"Sample/3/1#0##",
+					"Sample/3/2#0##"
 				]
 			}
 		}

--- a/tests/phpunit/Integration/Query/Fixtures/query-09-03-disjunction-regex-comparator.json
+++ b/tests/phpunit/Integration/Query/Fixtures/query-09-03-disjunction-regex-comparator.json
@@ -41,11 +41,11 @@
 		},
 		{
 			"name": "Sample/Title/4",
-			"contents": "[[Has text::oO]] [[Has page::aBc]]"
+			"contents": "[[Has text::FoO]] [[Has page::aBc]]"
 		},
 		{
 			"name": "Sample/Title/5",
-			"contents": "[[Has text::oO]] [[Has page::Sample/Title/2]]"
+			"contents": "[[Has text::FoO]] [[Has page::Sample/Title/2]]"
 		}
 	],
 	"query-testcases": [
@@ -200,6 +200,22 @@
 				"results": [
 					"Sample/Title/4#0##",
 					"Sample/Title/5#0##"
+				]
+			}
+		},
+		{
+			"about": "#10, see issue #19",
+			"condition": "[[Has page::~*b*||~*B*]] AND [[Has text::~*oO*||~*OO*||~*oo*]]",
+			"printouts" : [],
+			"parameters" : {
+				"limit" : "10"
+			},
+			"queryresult": {
+				"count": 3,
+				"results": [
+					"Sample/Title/2#0##",
+					"Sample/Title/3#0##",
+					"Sample/Title/4#0##"
 				]
 			}
 		}

--- a/tests/phpunit/Integration/Query/Fixtures/query-09-04-disjunction-subproperty.json
+++ b/tests/phpunit/Integration/Query/Fixtures/query-09-04-disjunction-subproperty.json
@@ -1,0 +1,131 @@
+{
+	"description": "Disjunction in connection with property hierarchy",
+	"properties": [
+		{
+			"name": "Has page",
+			"contents": "[[Has type::Page]]"
+		},
+		{
+			"name": "Has page-1",
+			"contents": "[[Has type::Page]] [[Subproperty of::Has page]]"
+		},
+		{
+			"name": "Has page-2",
+			"contents": "[[Has type::Page]] [[Subproperty of::Has page]]"
+		},
+		{
+			"name": "Has text",
+			"contents": "[[Has type::Text]]"
+		},
+		{
+			"name": "Has text-1",
+			"contents": "[[Has type::Text]] [[Subproperty of::Has text]]"
+		},
+		{
+			"name": "Has text-2",
+			"contents": "[[Has type::Text]] [[Subproperty of::Has text]]"
+		}
+	],
+	"subjects": [
+		{
+			"name": "Sample/1/1",
+			"contents": "[[Has text-1::Value 1]] [[Has page-1::Value 1]]"
+		},
+		{
+			"name": "Sample/1/2",
+			"contents": "[[Has text-2::Value 1]] [[Has page-2::Value 1]]"
+		},
+		{
+			"name": "Sample/2/1",
+			"contents": "[[Has text-1::Value 2]] [[Has page-1::Value 2]]"
+		},
+		{
+			"name": "Sample/2/2",
+			"contents": "[[Has text-2::Value 2]] [[Has page-2::Value 2]]"
+		},
+		{
+			"name": "Sample/2/3",
+			"contents": "[[Has text-2::Value 3]] [[Has page-2::Value 3]]"
+		}
+	],
+	"query-testcases": [
+		{
+			"about": "#0",
+			"condition": "[[Has text-1::Value 1||Value 2]] AND [[Has page::Value 1]]",
+			"printouts" : [],
+			"parameters" : {
+				"limit" : "10"
+			},
+			"queryresult": {
+				"count": 1,
+				"results": [
+					"Sample/1/1#0##"
+				]
+			}
+		},
+		{
+			"about": "#1",
+			"condition": "[[Has text-1::Value 1||Value 2]] AND [[Has page::Value 1||Value 2]]",
+			"printouts" : [],
+			"parameters" : {
+				"limit" : "10"
+			},
+			"queryresult": {
+				"count": 2,
+				"results": [
+					"Sample/1/1#0##",
+					"Sample/2/1#0##"
+				]
+			}
+		},
+		{
+			"about": "#2 equivalent to #1",
+			"condition": "<q>[[Has text-1::Value 1]] OR [[Has text-1::Value 2]]</q> AND <q>[[Has page::Value 1]] OR [[Has page::Value 2]]</q>",
+			"printouts" : [],
+			"parameters" : {
+				"limit" : "10"
+			},
+			"queryresult": {
+				"count": 2,
+				"results": [
+					"Sample/1/1#0##",
+					"Sample/2/1#0##"
+				]
+			}
+		},
+		{
+			"about": "#3",
+			"condition": "<q>[[Has text-1::~*1*||~*2*]] OR [[Has text-2::Value 3]]</q> AND [[Has page::Value 1||Value 3]]",
+			"printouts" : [],
+			"parameters" : {
+				"limit" : "10"
+			},
+			"queryresult": {
+				"count": 2,
+				"results": [
+					"Sample/1/1#0##",
+					"Sample/2/3#0##"
+				]
+			}
+		}
+	],
+	"settings": {
+		"smwgNamespacesWithSemanticLinks": {
+			"NS_MAIN": true,
+			"NS_CATEGORY": true,
+			"SMW_NS_PROPERTY": true
+		},
+		"wgContLang": "en",
+		"smwgQSubpropertyDepth": 10,
+		"smwgQSubcategoryDepth": 10
+	},
+	"meta": {
+		"skip-on": {
+			"postgres": "pg_query(): Query failed: ERROR:  duplicate key value violates unique constraint",
+			"virtuoso": "Virtuoso 6.1 rdfs / subproperty/property hierarchies are currently not implemented"
+		},
+		"version": "0.1",
+		"is-incomplete": false,
+		"debug": false
+	}
+}


### PR DESCRIPTION
#19, @vitalif applied the changes and added some integration tests.

```
{{#ask:
 <q>[[Has page-1::Value 1]] OR [[Has page-2::Value 1]]</q> AND
 <q>[[Has text-1::Value 1]] OR [[Has text-2::Value 1]]</q> AND
 <q>[[Has text-1::Value 3]] OR [[Has page-1::Value 3]]</q>
 |format=debug
}}
```
Before the change the above query would have not been resolved while after the change we get something like:
```
Debug Output by SQLStore
Generated Wiki-Query
  [[Has page-1::Value 1]]  OR  [[Has page-2::Value 1]]     [[Has text-1::Value 1]]  OR  [[Has text-2::Value 1]]     [[Has text-1::Value 3]]  OR  [[Has page-1::Value 3]]  
Query Metrics
Query-Size:12
Query-Depth:1
SQL Query
SELECT DISTINCT t22.smw_title AS t,t22.smw_namespace AS ns FROM `abcsmw_object_ids` AS t22 INNER JOIN `abct1` AS t1 ON t22.smw_id=t1.id INNER JOIN `abct8` AS t8 ON t1.id=t8.id INNER JOIN `abct15` AS t15 ON t1.id=t15.id ORDER BY t22.smw_sortkey ASC LIMIT 55 OFFSET 0;
Auxilliary Tables Used
Temporary table t1
  INSERT IGNORE INTO `abct1` SELECT t2.s_id FROM `abcsmw_di_wikipage` AS t2 WHERE t2.p_id='0' AND t2.o_id='2387'
  INSERT IGNORE INTO `abct1` SELECT t5.s_id FROM `abcsmw_di_wikipage` AS t5 WHERE t5.p_id='0' AND t5.o_id='2387'
Temporary table t8
  INSERT IGNORE INTO `abct8` SELECT t9.s_id FROM `abcsmw_di_wikipage` AS t9 WHERE t9.p_id='0' AND t9.o_id='2387'
  INSERT IGNORE INTO `abct8` SELECT t12.s_id FROM `abcsmw_di_wikipage` AS t12 WHERE t12.p_id='0' AND t12.o_id='2387'
Temporary table t15
  INSERT IGNORE INTO `abct15` SELECT t16.s_id FROM `abcsmw_di_wikipage` AS t16 WHERE t16.p_id='0' AND t16.o_id='2391'
  INSERT IGNORE INTO `abct15` SELECT t19.s_id FROM `abcsmw_di_wikipage` AS t19 WHERE t19.p_id='0' AND t19.o_id='2391'
Errors and Warnings
None
```

Only for completeness (and not related to this PR since the `SPARQLStore` did resolve the query correctly)

```
Debug Output by SPARQLStore
Generated Wiki-Query
  [[Has page-1::Value 1]]  OR  [[Has page-2::Value 1]]     [[Has text-1::Value 1]]  OR  [[Has text-2::Value 1]]     [[Has text-1::Value 3]]  OR  [[Has page-1::Value 3]]  
Query Metrics
Query-Size:12
Query-Depth:1
SPARQL Query
PREFIX wiki: <http://example.org/id/>
PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
PREFIX owl: <http://www.w3.org/2002/07/owl#>
PREFIX swivt: <http://semantic-mediawiki.org/swivt/1.0#>
PREFIX property: <http://example.org/id/Property-3A>
PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
SELECT DISTINCT ?result WHERE {
?result swivt:wikiPageSortKey ?resultsk .
{
?result property:Has_page-2D1 wiki:Value_1 .
} UNION {
?result property:Has_page-2D2 wiki:Value_1 .
}{
?result property:Has_text-2D1 wiki:Value_1 .
} UNION {
?result property:Has_text-2D2 wiki:Value_1 .
}{
?result property:Has_text-2D1 wiki:Value_3 .
} UNION {
?result property:Has_page-2D1 wiki:Value_3 .
}
}
ORDER BY ASC(?resultsk) 
OFFSET 0


LIMIT 51
```