### PR TITLE
Follow-up on #1035

### DIFF
--- a/SemanticMediaWiki.settings.php
+++ b/SemanticMediaWiki.settings.php
@@ -561,26 +561,22 @@ $GLOBALS['smwgMainCacheType'] = CACHE_ANYTHING; // Isn't used yet
 
 ###
 # Separate cache type to allow for adding a more responsive cache layer
-# (redis, riak) to operations that require it. It is currently used by:
+# (redis, riak) when requesting value lookups from the SQLStore.
 #
-# - ByBlobStoreIntermediaryValueLookup (#1035)
-#
-# CACHE_NONE = disabled for all features that require this cache layer
+# CACHE_NONE = disabled, uses the standard SQLStore DB access for all
+# lookups
 #
 # @since 2.3
 #
-# @default: CACHE_NONE (legacy); users need to actively enable it in order
+# @default: CACHE_NONE, users need to actively enable it in order
 # to make use of it
 ##
-$GLOBALS['smwgBlobCacheType'] = CACHE_NONE;
+$GLOBALS['smwgValueLookupCacheType'] = CACHE_NONE;
 ##
 
 ###
-# While not absolute necessary (because entities will self-invalidate when a change
-# occurs) it is nevertheless possible to set a limit (in seconds) for items handled
-# by `ByBlobStoreIntermediaryValueLookup`.
-#
-# If set to 0 an item is kept until it is replaced, flushed, or dropped.
+# Declares a lifetime of a cached item for `smwgValueLookupCacheType` until it
+# is removed if not invalidated before.
 #
 # @since 2.3
 ##

--- a/composer.json
+++ b/composer.json
@@ -44,7 +44,7 @@
 		"onoi/message-reporter": "~1.0",
 		"onoi/cache": "~1.2",
 		"onoi/event-dispatcher": "~1.0",
-		"onoi/blob-store": "~1.0",
+		"onoi/blob-store": "~1.1",
 		"doctrine/dbal": "~2.5"
 	},
 	"require-dev": {

--- a/includes/Settings.php
+++ b/includes/Settings.php
@@ -119,7 +119,7 @@ class Settings extends SimpleDictionary {
 			'smwgCacheUsage' => $GLOBALS['smwgCacheUsage'],
 			'smwgCacheType' => $GLOBALS['smwgCacheType'],
 			'smwgMainCacheType' => $GLOBALS['smwgMainCacheType'],
-			'smwgBlobCacheType' => $GLOBALS['smwgBlobCacheType'],
+			'smwgValueLookupCacheType' => $GLOBALS['smwgValueLookupCacheType'],
 			'smwgValueLookupCacheLifetime' => $GLOBALS['smwgValueLookupCacheLifetime'],
 			'smwgFixedProperties' => $GLOBALS['smwgFixedProperties'],
 			'smwgPropertyLowUsageThreshold' => $GLOBALS['smwgPropertyLowUsageThreshold'],

--- a/includes/storage/SQLStore/SMW_SQLStore3.php
+++ b/includes/storage/SQLStore/SMW_SQLStore3.php
@@ -134,9 +134,9 @@ class SMWSQLStore3 extends SMWStore {
 	public $m_sdstate = array();
 
 	/**
-	 * @var ByBlobStoreIntermediaryValueLookup
+	 * @var CachedValueLookupStore
 	 */
-	private $byBlobStoreIntermediaryValueLookup = null;
+	private $cachedValueLookupStore = null;
 
 	/**
 	 * @since 1.8
@@ -145,7 +145,7 @@ class SMWSQLStore3 extends SMWStore {
 		$this->smwIds = new SMWSql3SmwIds( $this );
 		$this->factory = new SQLStoreFactory( $this );
 
-		$this->byBlobStoreIntermediaryValueLookup = $this->factory->newByBlobStoreIntermediaryValueLookup();
+		$this->cachedValueLookupStore = $this->factory->newCachedValueLookupStore();
 	}
 
 	/**
@@ -221,7 +221,7 @@ class SMWSQLStore3 extends SMWStore {
 
 	public function getSemanticData( DIWikiPage $subject, $filter = false ) {
 
-		$result = $this->byBlobStoreIntermediaryValueLookup->getSemanticData(
+		$result = $this->cachedValueLookupStore->getSemanticData(
 			$subject,
 			$filter
 		);
@@ -238,7 +238,7 @@ class SMWSQLStore3 extends SMWStore {
 	 */
 	public function getPropertyValues( $subject, DIProperty $property, $requestOptions = null ) {
 
-		$result = $this->byBlobStoreIntermediaryValueLookup->getPropertyValues(
+		$result = $this->cachedValueLookupStore->getPropertyValues(
 			$subject,
 			$property,
 			$requestOptions
@@ -248,7 +248,14 @@ class SMWSQLStore3 extends SMWStore {
 	}
 
 	public function getPropertySubjects( DIProperty $property, $dataItem, $requestOptions = null ) {
-		return $this->getReader()->getPropertySubjects( $property, $dataItem, $requestOptions );
+
+		$result = $this->cachedValueLookupStore->getPropertySubjects(
+			$property,
+			$dataItem,
+			$requestOptions
+		);
+
+		return $result;
 	}
 
 	public function getAllPropertySubjects( DIProperty $property, $requestoptions = null ) {
@@ -257,7 +264,7 @@ class SMWSQLStore3 extends SMWStore {
 
 	public function getProperties( DIWikiPage $subject, $requestOptions = null ) {
 
-		$result = $this->byBlobStoreIntermediaryValueLookup->getProperties(
+		$result = $this->cachedValueLookupStore->getProperties(
 			$subject,
 			$requestOptions
 		);
@@ -283,7 +290,7 @@ class SMWSQLStore3 extends SMWStore {
 
 	public function deleteSubject( Title $subject ) {
 
-		$this->byBlobStoreIntermediaryValueLookup->deleteFor(
+		$this->cachedValueLookupStore->deleteFor(
 			DIWikiPage::newfromTitle( $subject )
 		);
 
@@ -292,7 +299,7 @@ class SMWSQLStore3 extends SMWStore {
 
 	protected function doDataUpdate( SemanticData $semanticData ) {
 
-		$this->byBlobStoreIntermediaryValueLookup->deleteFor(
+		$this->cachedValueLookupStore->deleteFor(
 			$semanticData->getSubject()
 		);
 
@@ -301,8 +308,12 @@ class SMWSQLStore3 extends SMWStore {
 
 	public function changeTitle( Title $oldtitle, Title $newtitle, $pageid, $redirid = 0 ) {
 
-		$this->byBlobStoreIntermediaryValueLookup->deleteFor(
+		$this->cachedValueLookupStore->deleteFor(
 			DIWikiPage::newfromTitle( $oldtitle )
+		);
+
+		$this->cachedValueLookupStore->deleteFor(
+			DIWikiPage::newfromTitle( $newtitle )
 		);
 
 		$this->getWriter()->changeTitle( $oldtitle, $newtitle, $pageid, $redirid );

--- a/includes/storage/SQLStore/SMW_SQLStore3_Readers.php
+++ b/includes/storage/SQLStore/SMW_SQLStore3_Readers.php
@@ -58,6 +58,13 @@ class SMWSQLStore3Readers {
 			true
 		);
 
+		// Ensures that a cached item to contain an expected sortKey when
+		// for example the ID was just created and the sortKey from the DB
+		// is empty otherwise the DB wins over the invoked sortKey
+		if ( !$sortKey ) {
+			$sortKey = $subject->getSortKey();
+		}
+
 		$subject->setSortKey( $sortKey );
 
 		if ( $sid == 0 ) {

--- a/maintenance/rebuildData.php
+++ b/maintenance/rebuildData.php
@@ -117,6 +117,7 @@ class RebuildData extends \Maintenance {
 
 		if ( $this->hasOption( 'no-cache' ) ) {
 			$maintenanceHelper->setGlobalToValue( 'wgMainCacheType', CACHE_NONE );
+			$maintenanceHelper->setGlobalToValue( 'smwgValueLookupCacheType', CACHE_NONE );
 		}
 
 		if ( $this->hasOption( 'debug' ) ) {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -58,7 +58,7 @@
     </filter>
     <php>
        <var name="smwgSparqlDefaultGraph" value="http://example.org/phpunit-testrun"/>
-       <var name="smwgBlobCacheType" value="hash"/>
+       <var name="smwgValueLookupCacheType" value="hash"/>
        <var name="benchmarkQueryRepetitionExecutionThreshold" value="5"/>
        <var name="benchmarkQueryLimit" value="500"/>
        <var name="benchmarkQueryOffset" value="0"/>

--- a/src/Cache/CacheFactory.php
+++ b/src/Cache/CacheFactory.php
@@ -21,24 +21,12 @@ class CacheFactory {
 	private $mainCacheType;
 
 	/**
-	 * @var string|integer
-	 */
-	private $blobCacheType;
-
-	/**
 	 * @since 2.2
 	 *
 	 * @param string|integer $mainCacheType
-	 * @param string|integer|null $blobCacheType
 	 */
-	public function __construct( $mainCacheType, $blobCacheType = null ) {
+	public function __construct( $mainCacheType ) {
 		$this->mainCacheType = $mainCacheType;
-		$this->blobCacheType = $blobCacheType;
-
-		if ( $this->blobCacheType === null ) {
-			$this->blobCacheType = $GLOBALS['smwgBlobCacheType'];
-		}
-
 	}
 
 	/**
@@ -48,15 +36,6 @@ class CacheFactory {
 	 */
 	public function getMainCacheType() {
 		return $this->mainCacheType;
-	}
-
-	/**
-	 * @since 2.3
-	 *
-	 * @return string|integer
-	 */
-	public function getBlobCacheType() {
-		return $this->blobCacheType;
 	}
 
 	/**

--- a/src/SQLStore/SQLStoreFactory.php
+++ b/src/SQLStore/SQLStoreFactory.php
@@ -241,9 +241,9 @@ class SQLStoreFactory {
 	/**
 	 * @since 2.3
 	 *
-	 * @return ByBlobStoreIntermediaryValueLookup
+	 * @return CachedValueLookupStore
 	 */
-	public function newByBlobStoreIntermediaryValueLookup() {
+	public function newCachedValueLookupStore() {
 
 		$circularReferenceGuard = new CircularReferenceGuard( 'vl:store' );
 		$circularReferenceGuard->setMaxRecursionDepth( 2 );
@@ -252,12 +252,12 @@ class SQLStoreFactory {
 
 		$blobStore = new BlobStore(
 			'smw:vl:store',
-			$cacheFactory->newMediaWikiCompositeCache( $cacheFactory->getBlobCacheType() )
+			$cacheFactory->newMediaWikiCompositeCache( $GLOBALS['smwgValueLookupCacheType'] )
 		);
 
 		// If CACHE_NONE is selected, disable the usage
 		$blobStore->setUsageState(
-			$cacheFactory->getBlobCacheType() !== CACHE_NONE
+			$GLOBALS['smwgValueLookupCacheType'] !== CACHE_NONE
 		);
 
 		$blobStore->setExpiryInSeconds(
@@ -268,22 +268,16 @@ class SQLStoreFactory {
 			$cacheFactory->getCachePrefix()
 		);
 
-		$byBlobStoreIntermediaryValueLookup = new ByBlobStoreIntermediaryValueLookup(
+		$cachedValueLookupStore = new CachedValueLookupStore(
 			$this->store,
 			$blobStore
 		);
 
-		$byBlobStoreIntermediaryValueLookup->setCircularReferenceGuard(
+		$cachedValueLookupStore->setCircularReferenceGuard(
 			$circularReferenceGuard
 		);
 
-		// Register blob instance with the event handler because only at this point
-		// we create and know about 'smw:vl:store'
-		EventHandler::getInstance()->addCallbackListener( 'blobstore.drop', function() use( $blobStore ) {
-			$blobStore->drop();
-		} );
-
-		return $byBlobStoreIntermediaryValueLookup;
+		return $cachedValueLookupStore;
 	}
 
 	private function newTemporaryIdTableCreator() {

--- a/tests/phpunit/includes/SQLStore/SQLStoreFactoryTest.php
+++ b/tests/phpunit/includes/SQLStore/SQLStoreFactoryTest.php
@@ -130,17 +130,13 @@ class SQLStoreFactoryTest extends \PHPUnit_Framework_TestCase {
 		);
 	}
 
-	public function testCanConstructByBlobStoreIntermediaryValueLookup() {
+	public function testCanConstrucCachedValueLookupStore() {
 
 		$instance = new SQLStoreFactory( $this->store );
 
 		$this->assertInstanceOf(
-			'SMW\SQLStore\ByBlobStoreIntermediaryValueLookup',
-			$instance->newByBlobStoreIntermediaryValueLookup()
-		);
-
-		$this->assertTrue(
-			\SMW\EventHandler::getInstance()->getEventDispatcher()->hasEvent( 'blobstore.drop' )
+			'SMW\SQLStore\CachedValueLookupStore',
+			$instance->newCachedValueLookupStore()
 		);
 	}
 

--- a/tests/phpunit/includes/cache/CacheFactoryTest.php
+++ b/tests/phpunit/includes/cache/CacheFactoryTest.php
@@ -42,16 +42,6 @@ class CacheFactoryTest extends \PHPUnit_Framework_TestCase {
 		);
 	}
 
-	public function testGetBlobCacheType() {
-
-		$instance = new CacheFactory( 'hash' );
-
-		$this->assertEquals(
-			'hash',
-			$instance->getBlobCacheType()
-		);
-	}
-
 	public function testGetCachePrefix() {
 
 		$instance = new CacheFactory( 'hash' );


### PR DESCRIPTION
refs #1035; `$GLOBALS['smwgValueLookupCacheType']` is for opt-in only and it is expected that an optimized cache provider is used. MW's `SqlBagOStuff` pseudo cache or `CACHE_ANYTHING` should not be used.

- Add support for `Store::getPropertySubjects`
- Split some lists as those provide better performance when combined with other objects also use an extra container for `SemanticData`

## Some data 

The following data will not stand a rigour statistical analysis but it should allow to draw some conclusions about the impact of `$GLOBALS['smwgValueLookupCacheType']`.

Measurement based on:
- MediaWiki: 1.23.9 PHP: 5.6.8 with enabled `$wgDebugToolbar = true;` (with only one user at the time of the query execution).
- SPARQLStore Sesame 2.7.14
- SQLStore
- redis 2.8* / Windowsx64

For easy verification, the following data set have been used as base for the sample query (properties are appropriately typed).
```
{{#set_recurring_event:Sample query
 |property=has date
 |Has page=Sample query
 |Has location=London,Berlin,Paris|+sep=,
 |Has area=891.85 km²;64 sqmi;67 sqmi|+sep=;
 |Has wattage=12+33 hp+450 W+15 kW|+sep=+
 |Has text=Simple recurring events text
 |start=June 8, 2010
 |unit=day
 |period=1
 |limit=1000
 |duration=7200
 |include=March 16, 2010;March 23, 2010|+sep=;
 |exclude=March 15, 2010;March 22, 2010|+sep=;
}}
```
Query used via `Special:Ask` to measure data presented below.

```
{{#ask: [[Has page::Sample query]] [[Has area::+]] [[Has wattage::+]]
 |?Has area
 |?Has wattage
 |?Has location
 |?Has date
 |format=broadtable
 |sort=Has date,Has area
}}
```

For `$GLOBALS['smwgValueLookupCacheType'] = CACHE_NONE;` (= legacy behaviour) set

Limit   | SPARQLStore| SQLStore 
------- | -------------------------- | -------------
20      | Q: 218  T: 1.32  M: 4.79 | Q: 199   T: 1.12  M: 4.67 
50      |  Q: 342  T: 2.20  M: 5.14 | Q: 289   T: 1.77  M: 4.98
250     | Q: 1190 T: 6.65  M: 6.18 | Q: 937   T: 6.12  M: 6.35 
500     | Q: 2242 T: 11.95 M: 9.12 |  Q: 1749  T: 11.18 M: 9.78

For `$GLOBALS['smwgValueLookupCacheType'] = redis;`set

Limit   | SPARQLStore | SQLStore                       
------- | ------------------------------ | -------------
20      | Q: 124   T: 1.20  M: 4.86 (*)  |
        | Q: 120   T: 1.20  M: 4.86      | Q: 124  T: 1.06  M: 4.77
50      | Q: 240   T: 2.07  M: 5.56 (*)  |
        | Q: 120   T: 1.80  M: 5.28      | Q: 120  T: 1.42  M: 5.19
250     | Q: 920   T: 7.88  M: 8.94 (*)  |
        | Q: 120   T: __4.70__  M: 7.99      | Q: 120  T: __4.17__  M: 7.88
500     | Q: 1120  T: 12.85 M: 12.49 (*) |
        | Q: 120   T: __7.62__  M: 11.35     | Q: 120  T: __7.51__  M: 11.12

- `Q:` refers to queries, `T:` to time in sec, and `M:` memory in MB displayed by `$wgDebugToolbar`
- (*) refers to items not yet cached / warm-up
- The use of `CACHE_ANYTHING` (MW's internal SqlBagOStuff pseudo cache) did not elevate lookup performance in a way `redis` did therefore it is not recommended to use `CACHE_ANYTHING` as sample data suggest it to be a poor replacement on large lists (250+) for `redis`.
- Lookup is done on an atomic (per item, not per list) level which means once an item is cached it will decrease the amount of queries necessary to lookup an item (see `Q`) 
- If a `#ask` query makes less query requests then it means other user can access those resources more quickly
- After an object is cached response performance for a large list can improve significantly as shown above