### PR TITLE
Improve MagicWordsFinder

### DIFF
--- a/src/ApplicationFactory.php
+++ b/src/ApplicationFactory.php
@@ -222,7 +222,7 @@ class ApplicationFactory {
 
 		return new InTextAnnotationParser(
 			$parserData,
-			$mwCollaboratorFactory->newMagicWordFinder(),
+			$mwCollaboratorFactory->newMagicWordsFinder(),
 			$mwCollaboratorFactory->newRedirectTargetFinder()
 		);
 	}

--- a/src/InTextAnnotationParser.php
+++ b/src/InTextAnnotationParser.php
@@ -2,7 +2,7 @@
 
 namespace SMW;
 
-use SMW\MediaWiki\MagicWordFinder;
+use SMW\MediaWiki\MagicWordsFinder;
 use SMW\MediaWiki\RedirectTargetFinder;
 use SMWOutputs;
 use Title;
@@ -30,17 +30,17 @@ class InTextAnnotationParser {
 	/**
 	 * @var ParserData
 	 */
-	protected $parserData;
+	private $parserData;
 
 	/**
-	 * @var MagicWordFinder
+	 * @var MagicWordsFinder
 	 */
-	protected $magicWordFinder;
+	private $magicWordsFinder;
 
 	/**
 	 * @var RedirectTargetFinder
 	 */
-	protected $redirectTargetFinder;
+	private $redirectTargetFinder;
 
 	/**
 	 * @var DataValueFactory
@@ -73,12 +73,12 @@ class InTextAnnotationParser {
 	 * @since 1.9
 	 *
 	 * @param ParserData $parserData
-	 * @param MagicWordFinder $magicWordFinder
+	 * @param MagicWordsFinder $magicWordsFinder
 	 * @param RedirectTargetFinder $redirectTargetFinder
 	 */
-	public function __construct( ParserData $parserData, MagicWordFinder $magicWordFinder, RedirectTargetFinder $redirectTargetFinder ) {
+	public function __construct( ParserData $parserData, MagicWordsFinder $magicWordsFinder, RedirectTargetFinder $redirectTargetFinder ) {
 		$this->parserData = $parserData;
-		$this->magicWordFinder = $magicWordFinder;
+		$this->magicWordsFinder = $magicWordsFinder;
 		$this->redirectTargetFinder = $redirectTargetFinder;
 		$this->dataValueFactory = DataValueFactory::getInstance();
 		$this->applicationFactory = ApplicationFactory::getInstance();
@@ -320,7 +320,7 @@ class InTextAnnotationParser {
 
 		$words = array();
 
-		$this->magicWordFinder->setOutput( $this->parserData->getOutput() );
+		$this->magicWordsFinder->setOutput( $this->parserData->getOutput() );
 
 		$magicWords = array(
 			'SMW_NOFACTBOX',
@@ -330,10 +330,10 @@ class InTextAnnotationParser {
 		Hooks::run( 'SMW::Parser::BeforeMagicWordsFinder', array( &$magicWords ) );
 
 		foreach ( $magicWords as $magicWord ) {
-			$words = $words + $this->magicWordFinder->matchAndRemove( $magicWord, $text );
+			$words[] = $this->magicWordsFinder->findMagicWordInText( $magicWord, $text );
 		}
 
-		$this->magicWordFinder->pushMagicWordsToParserOutput( $words );
+		$this->magicWordsFinder->pushMagicWordsToParserOutput( $words );
 
 		return $words;
 	}

--- a/src/MediaWiki/MagicWordsFinder.php
+++ b/src/MediaWiki/MagicWordsFinder.php
@@ -11,7 +11,7 @@ use ParserOutput;
  *
  * @author mwjames
  */
-class MagicWordFinder {
+class MagicWordsFinder {
 
 	/**
 	 * @var ParserOutput
@@ -40,27 +40,24 @@ class MagicWordFinder {
 	}
 
 	/**
-	 * Remove relevant SMW magic words from the given text and return
-	 * an array of the names of all discovered magic words.
+	 * Find the magic word and have it removed from the text
 	 *
 	 * @since 2.0
 	 *
 	 * @param $magicWord
 	 * @param &$text
 	 *
-	 * @return array
+	 * @return string
 	 */
-	public function matchAndRemove( $magicWord, &$text ) {
-
-		$words = array();
+	public function findMagicWordInText( $magicWord, &$text ) {
 
 		$mw = MagicWord::get( $magicWord );
 
 		if ( $mw->matchAndRemove( $text ) ) {
-			$words[] = $magicWord;
+			return $magicWord;
 		}
 
-		return $words;
+		return '';
 	}
 
 	/**
@@ -69,6 +66,9 @@ class MagicWordFinder {
 	 * @param array $words
 	 */
 	public function pushMagicWordsToParserOutput( array $words ) {
+
+		// Filter empty lines
+		$words = array_values( array_filter( $words ) );
 
 		if ( $this->hasExtensionData() ) {
 			return $this->parserOutput->setExtensionData( 'smwmagicwords', $words );

--- a/src/MediaWiki/MwCollaboratorFactory.php
+++ b/src/MediaWiki/MwCollaboratorFactory.php
@@ -62,10 +62,10 @@ class MwCollaboratorFactory {
 	/**
 	 * @since 2.1
 	 *
-	 * @return MagicWordFinder
+	 * @return MagicWordsFinder
 	 */
-	public function newMagicWordFinder() {
-		return new MagicWordFinder();
+	public function newMagicWordsFinder() {
+		return new MagicWordsFinder();
 	}
 
 	/**

--- a/tests/phpunit/Integration/SemanticMediaWikiProvidedHookInterfaceIntegrationTest.php
+++ b/tests/phpunit/Integration/SemanticMediaWikiProvidedHookInterfaceIntegrationTest.php
@@ -350,12 +350,12 @@ class SemanticMediaWikiProvidedHookInterfaceIntegrationTest extends \PHPUnit_Fra
 			->method( 'getTitle' )
 			->will( $this->returnValue( $title ) );
 
-		$magicWordFinder = $this->getMockBuilder( '\SMW\MediaWiki\MagicWordFinder' )
+		$magicWordsFinder = $this->getMockBuilder( '\SMW\MediaWiki\MagicWordsFinder' )
 			->disableOriginalConstructor()
 			->getMock();
 
-		$magicWordFinder->expects( $this->once() )
-			->method( 'matchAndRemove' )
+		$magicWordsFinder->expects( $this->once() )
+			->method( 'findMagicWordInText' )
 			->with(
 				$this->equalTo( 'Foo' ),
 				$this->anything() )
@@ -366,7 +366,7 @@ class SemanticMediaWikiProvidedHookInterfaceIntegrationTest extends \PHPUnit_Fra
 			->getMock();
 
 		$inTextAnnotationParser = $this->getMockBuilder( '\SMW\InTextAnnotationParser' )
-			->setConstructorArgs( array( $parserData, $magicWordFinder, $redirectTargetFinder ) )
+			->setConstructorArgs( array( $parserData, $magicWordsFinder, $redirectTargetFinder ) )
 			->setMethods( null )
 			->getMock();
 

--- a/tests/phpunit/includes/InTextAnnotationParserTemplateTransclusionTest.php
+++ b/tests/phpunit/includes/InTextAnnotationParserTemplateTransclusionTest.php
@@ -3,23 +3,19 @@
 namespace SMW\Test;
 
 use SMW\Tests\Utils\Validators\SemanticDataValidator;
-
 use SMW\InTextAnnotationParser;
-use SMW\MediaWiki\MagicWordFinder;
+use SMW\MediaWiki\MagicWordsFinder;
 use SMW\MediaWiki\RedirectTargetFinder;
-
 use SMW\Settings;
 use SMW\ParserData;
 use SMW\ApplicationFactory;
-
 use Title;
 use ParserOutput;
 
 /**
  * @covers \SMW\InTextAnnotationParser
  *
- * @group SMW
- * @group SMWExtension
+ * @group semantic-mediawiki
  *
  * @license GNU GPL v2+
  * @since 1.9
@@ -92,7 +88,7 @@ class InTextAnnotationParserTemplateTransclusionTest extends \PHPUnit_Framework_
 
 		$instance = new InTextAnnotationParser(
 			$parserData,
-			new MagicWordFinder(),
+			new MagicWordsFinder(),
 			new RedirectTargetFinder()
 		);
 

--- a/tests/phpunit/includes/InTextAnnotationParserTest.php
+++ b/tests/phpunit/includes/InTextAnnotationParserTest.php
@@ -4,7 +4,7 @@ namespace SMW\Tests;
 
 use SMW\Tests\Utils\Validators\SemanticDataValidator;
 
-use SMW\MediaWiki\MagicWordFinder;
+use SMW\MediaWiki\MagicWordsFinder;
 use SMW\MediaWiki\RedirectTargetFinder;
 
 use SMW\InTextAnnotationParser;
@@ -63,7 +63,7 @@ class InTextAnnotationParserTest extends \PHPUnit_Framework_TestCase {
 
 		$instance =	new InTextAnnotationParser(
 			new ParserData( $title, $parserOutput ),
-			new MagicWordFinder(),
+			new MagicWordsFinder(),
 			$redirectTargetFinder
 		);
 
@@ -83,11 +83,11 @@ class InTextAnnotationParserTest extends \PHPUnit_Framework_TestCase {
 			new ParserOutput()
 		);
 
-		$magicWordFinder = new MagicWordFinder( $parserData->getOutput() );
+		$magicWordsFinder = new MagicWordsFinder( $parserData->getOutput() );
 
 		$instance = new InTextAnnotationParser(
 			$parserData,
-			$magicWordFinder,
+			$magicWordsFinder,
 			new RedirectTargetFinder()
 		);
 
@@ -95,7 +95,7 @@ class InTextAnnotationParserTest extends \PHPUnit_Framework_TestCase {
 
 		$this->assertEquals(
 			$expected,
-			$magicWordFinder->getMagicWords()
+			$magicWordsFinder->getMagicWords()
 		);
 	}
 
@@ -111,7 +111,7 @@ class InTextAnnotationParserTest extends \PHPUnit_Framework_TestCase {
 
 		$instance = new InTextAnnotationParser(
 			$parserData,
-			new MagicWordFinder(),
+			new MagicWordsFinder(),
 			new RedirectTargetFinder()
 		);
 
@@ -165,7 +165,7 @@ class InTextAnnotationParserTest extends \PHPUnit_Framework_TestCase {
 
 		$instance = new InTextAnnotationParser(
 			$parserData,
-			new MagicWordFinder(),
+			new MagicWordsFinder(),
 			$redirectTargetFinder
 		);
 
@@ -209,7 +209,7 @@ class InTextAnnotationParserTest extends \PHPUnit_Framework_TestCase {
 
 		$instance = new InTextAnnotationParser(
 			$parserData,
-			new MagicWordFinder(),
+			new MagicWordsFinder(),
 			$redirectTargetFinder
 		);
 
@@ -231,7 +231,7 @@ class InTextAnnotationParserTest extends \PHPUnit_Framework_TestCase {
 
 		$instance = new InTextAnnotationParser(
 			$parserData,
-			new MagicWordFinder(),
+			new MagicWordsFinder(),
 			new RedirectTargetFinder()
 		);
 
@@ -456,14 +456,14 @@ class InTextAnnotationParserTest extends \PHPUnit_Framework_TestCase {
 		$provider[] = array(
 			NS_HELP,
 			'Lorem ipsum dolor [[Foo::dictumst cursus]] facilisi __NOFACTBOX__ __SHOWFACTBOX__',
-			array( 'SMW_NOFACTBOX' )
+			array( 'SMW_NOFACTBOX', 'SMW_SHOWFACTBOX' )
 		);
 
 		// #3 __SHOWFACTBOX__, __NOFACTBOX__
 		$provider[] = array(
 			NS_HELP,
 			'Lorem ipsum dolor [[Foo::dictumst cursus]] facilisi __SHOWFACTBOX__ __NOFACTBOX__',
-			array( 'SMW_NOFACTBOX' )
+			array( 'SMW_NOFACTBOX', 'SMW_SHOWFACTBOX' )
 		);
 		return $provider;
 	}

--- a/tests/phpunit/includes/MediaWiki/MwCollaboratorFactoryTest.php
+++ b/tests/phpunit/includes/MediaWiki/MwCollaboratorFactoryTest.php
@@ -70,7 +70,7 @@ class MwCollaboratorFactoryTest extends \PHPUnit_Framework_TestCase {
 		);
 	}
 
-	public function testCanConstructMagicWordFinder() {
+	public function testCanConstructMagicWordsFinder() {
 
 		$applicationFactory = $this->getMockBuilder( '\SMW\ApplicationFactory' )
 			->disableOriginalConstructor()
@@ -79,8 +79,8 @@ class MwCollaboratorFactoryTest extends \PHPUnit_Framework_TestCase {
 		$instance = new MwCollaboratorFactory( $applicationFactory );
 
 		$this->assertInstanceOf(
-			'\SMW\MediaWiki\MagicWordFinder',
-			$instance->newMagicWordFinder()
+			'\SMW\MediaWiki\MagicWordsFinder',
+			$instance->newMagicWordsFinder()
 		);
 	}
 


### PR DESCRIPTION
This ensures that the hook `SMW::Parser::BeforeMagicWordsFinder` works as expected when things like [0, 1] are added in combination with other magicwords.

[0] 'SMW::Parser::BeforeMagicWordsFinder'
[1] https://github.com/SemanticMediaWiki/SemanticCite/blob/master/src/HookRegistry.php#L100-L102