### PR TITLE
Fix #set to return ('isHTML' => false)

### DIFF
--- a/includes/dataitems/SMW_DI_WikiPage.php
+++ b/includes/dataitems/SMW_DI_WikiPage.php
@@ -67,6 +67,11 @@ class DIWikiPage extends SMWDataItem {
 			throw new DataItemException( "Given namespace '$namespace' is not an integer." );
 		}
 
+		// Check for a potential fragment such as Foo#Bar, Bar#_49c8ab
+		if ( strpos( $dbkey, '#' ) !== false ) {
+			list( $dbkey, $subobjectname ) = explode( '#', $dbkey );
+		}
+
 		$this->m_dbkey = $dbkey;
 		$this->m_namespace = (int)$namespace; // really make this an integer
 		$this->m_interwiki = $interwiki;

--- a/includes/parserhooks/SetParserFunction.php
+++ b/includes/parserhooks/SetParserFunction.php
@@ -102,7 +102,7 @@ class SetParserFunction {
 			->addFromArray( $parameters->getErrors() )
 			->getHtml();
 
-		return array( $html, 'noparse' => true, 'isHTML' => true );
+		return array( $html, 'noparse' => true, 'isHTML' => false );
 	}
 
 	private function addFieldsToTemplate( $template, $dataValue, $property, $value, &$count ) {

--- a/tests/phpunit/Integration/Parser/parser-02-03-set-subobject-template.json
+++ b/tests/phpunit/Integration/Parser/parser-02-03-set-subobject-template.json
@@ -1,0 +1,81 @@
+{
+	"description": "Use case provided by Jethro Waanders",
+	"properties": [
+		{
+			"name": "Paragraph number",
+			"contents": "[[Has type::Number]]"
+		},
+		{
+			"name": "Paragraph",
+			"contents": "[[Has type::Text]]"
+		},
+		{
+			"name": "Paragraph backlink",
+			"contents": "[[Has type::Page]]"
+		}
+	],
+	"subjects": [
+		{
+			"name": "SimpleSetTemplate",
+			"namespace": "NS_TEMPLATE",
+			"contents": "<includeonly>Lorem ipsum.{{#set:Reference=Test}}</includeonly>"
+		},
+		{
+			"name": "CreateParagraphAsSubobject",
+			"namespace": "NS_TEMPLATE",
+			"contents": "<includeonly><div style=\"display:none;\">{{#subobject:|Paragraph number={{{Paragraph number|}}}|Paragraph={{{Paragraph|}}}|Paragraph backlink={{PAGENAME}} }}</div></includeonly>"
+		},
+		{
+			"name": "Transclude-Template",
+			"contents": "{{CreateParagraphAsSubobject|Paragraph number=1|Paragraph=Test1 {{SimpleSetTemplate}} }} {{SimpleSetTemplate}}"
+		},
+		{
+			"name": "Ask-For-Transclude-Template",
+			"contents": "{{#ask:[[Paragraph backlink::Transclude-Template]]|?Paragraph}}"
+		}
+	],
+	"parser-testcases": [
+		{
+			"about": "#0",
+			"subject": "Transclude-Template",
+			"store": {
+				"semantic-data": {
+					"strict-mode-valuematch": false,
+					"propertyCount": 4,
+					"propertyKeys": [ "_MDAT", "_SKEY", "Reference", "_SOBJ" ],
+					"propertyValues": [ "Test", "Transclude-Template#_49c8abd563e00e4dcf6debf1d61b5408" ]
+				}
+			}
+		},
+		{
+			"about": "#1 subobject check",
+			"subject": "Transclude-Template#_49c8abd563e00e4dcf6debf1d61b5408",
+			"store": {
+				"semantic-data": {
+					"strict-mode-valuematch": false,
+					"propertyCount": 4,
+					"propertyKeys": [ "Paragraph", "Paragraph_backlink", "Paragraph_number", "_SKEY" ],
+					"propertyValues": [ "1", "Test1 Lorem ipsum.", "Transclude-Template" ]
+				}
+			}
+		},
+		{
+			"about": "#2 check for the ask output",
+			"subject": "Ask-For-Transclude-Template",
+			"expected-output": {
+				"to-contain": [
+					"title=\"Transclude-Template\">Transclude-Template</a>",
+					"<td class=\"Paragraph smwtype_txt\">Test1 Lorem ipsum.</td>"
+				]
+			}
+		}
+	],
+	"settings": {
+		"smwgPageSpecialProperties": [ "_MDAT" ]
+	},
+	"meta": {
+		"version": "0.1",
+		"is-incomplete": false,
+		"debug": false
+	}
+}


### PR DESCRIPTION
Use case provided by Jethro Waanders / [0] with `parser-02-03-set-subobject-template.json` containing the integration test.

Regression caused by #758, 

[0] http://wikimedia.7.x6.nabble.com/set-breaks-parsing-value-subobject-after-upgrading-to-SMW-2-2-tp5049139.html