### PR TITLE
Don't fail during a DB setup

### DIFF
--- a/includes/storage/SQLStore/SMW_SQLStore3_SetupHandlers.php
+++ b/includes/storage/SQLStore/SMW_SQLStore3_SetupHandlers.php
@@ -157,7 +157,15 @@ class SMWSQLStore3SetupHandlers implements MessageReporter {
 		$addedCustomTypeSignatures = false;
 
 		foreach ( $this->store->getPropertyTables() as $proptable ) {
-			$diHandler = $this->store->getDataItemHandlerForDIType( $proptable->getDiType() );
+
+			// Only extensions that aren't setup correctly can force an exception
+			// and to avoid a failure during setup, ensure that standard tables
+			// are correctly initialized otherwise SMW can't recover
+			try {
+				$diHandler = $this->store->getDataItemHandlerForDIType( $proptable->getDiType() );
+			} catch ( \Exception $e ) {
+				continue;
+			}
 
 			// Prepare indexes. By default, property-value tables
 			// have the following indexes:

--- a/tests/phpunit/Integration/Query/Fixtures/query-06-05-page-regex-search.json
+++ b/tests/phpunit/Integration/Query/Fixtures/query-06-05-page-regex-search.json
@@ -2,28 +2,28 @@
 	"description": "Regex search pattern for page type values",
 	"properties": [
 		{
-			"name": "Has page",
+			"name": "Has regexpage",
 			"contents": "[[Has type::Page]]"
 		}
 	],
 	"subjects": [
 		{
 			"name": "Page-1-with-spaces",
-			"contents": "[[Has page::Annotation test with spaces]]"
+			"contents": "[[Has regexpage::Annotation test with spaces]]"
 		},
 		{
 			"name": "Page-2-with-spaces",
-			"contents": "[[Has page::Annotation text with spaces]]"
+			"contents": "[[Has regexpage::Annotation text with spaces]]"
 		},
 		{
 			"name": "Page-3-without-spaces",
-			"contents": "[[Has page::AnnotationTestWithoutSpaces]]"
+			"contents": "[[Has regexpage::AnnotationTestWithoutSpaces]]"
 		}
 	],
 	"query-testcases": [
 		{
 			"about": "#0",
-			"condition": "[[Has page::~Annotation te*]]",
+			"condition": "[[Has regexpage::~Annotation te*]]",
 			"printouts" : [],
 			"parameters" : {
 				"limit" : "10"
@@ -38,7 +38,7 @@
 		},
 		{
 			"about": "#1",
-			"condition": "[[Has page::~Annotation tes*]]",
+			"condition": "[[Has regexpage::~Annotation tes*]]",
 			"printouts" : [],
 			"parameters" : {
 				"limit" : "10"
@@ -52,7 +52,7 @@
 		},
 		{
 			"about": "#2",
-			"condition": "[[Has page::~An??tation*]]",
+			"condition": "[[Has regexpage::~An??tation*]]",
 			"printouts" : [],
 			"parameters" : {
 				"limit" : "10"
@@ -68,7 +68,7 @@
 		},
 		{
 			"about": "#3",
-			"condition": "[[Has page::~Annotation*]] [[Has page::!~Annotation tex*]]",
+			"condition": "[[Has regexpage::~Annotation*]] [[Has regexpage::!~Annotation tex*]]",
 			"printouts" : [],
 			"parameters" : {
 				"limit" : "10"
@@ -83,7 +83,7 @@
 		},
 		{
 			"about": "#4",
-			"condition": "[[Has page::~Annotation tes*]] OR [[Has page::~Annotation tex*]]",
+			"condition": "[[Has regexpage::~Annotation tes*]] OR [[Has regexpage::~Annotation tex*]]",
 			"printouts" : [],
 			"parameters" : {
 				"limit" : "10"
@@ -98,7 +98,7 @@
 		},
 		{
 			"about": "#5",
-			"condition": "[[Has page::~Annotation te?t with spaces]]",
+			"condition": "[[Has regexpage::~Annotation te?t with spaces]]",
 			"printouts" : [],
 			"parameters" : {
 				"limit" : "10"
@@ -113,7 +113,7 @@
 		},
 		{
 			"about": "#6",
-			"condition": "[[Has page::+]][[Has page::!~Annotation te?t with spaces]]",
+			"condition": "[[Has regexpage::+]][[Has regexpage::!~Annotation te?t with spaces]]",
 			"printouts" : [],
 			"parameters" : {
 				"limit" : "10"


### PR DESCRIPTION
This should be a rare case but it is possible during a release change that an extension with tables changed its schema and an old property is trying to access a type definition no longer present.

Aftercare is to manually remove the no longer used table.