### PR TITLE
Simplify registration for custom fixed property tables

### DIFF
--- a/docs/technical/hooks.md
+++ b/docs/technical/hooks.md
@@ -29,6 +29,7 @@ Implementing a hook should be made in consideration of the expected performance 
 ### 2.3
 
 - `SMW::SQLStore::BeforeDataRebuildJobInsert` to add update jobs while running the rebuild process.<sup>Use of `smwRefreshDataJobs` was deprecated with 2.3</sup>
+- `SMW::SQLStore::AddCustomFixedPropertyTables` to add fixed property table definitions
 
 For implementation details and examples, see the [integration test](https://github.com/SemanticMediaWiki/SemanticMediaWiki/blob/master/tests/phpunit/Integration/SemanticMediaWikiProvidedHookInterfaceIntegrationTest.php).
 

--- a/tests/phpunit/Integration/SemanticMediaWikiProvidedHookInterfaceIntegrationTest.php
+++ b/tests/phpunit/Integration/SemanticMediaWikiProvidedHookInterfaceIntegrationTest.php
@@ -382,6 +382,25 @@ class SemanticMediaWikiProvidedHookInterfaceIntegrationTest extends \PHPUnit_Fra
 		$inTextAnnotationParser->parse( $text );
 	}
 
+	public function testRegisteredAddCustomFixedPropertyTables() {
+
+		$store = $this->getMockBuilder( '\SMW\SQLStore\SQLStore' )
+			->disableOriginalConstructor()
+			->setMethods( null )
+			->getMock();
+
+		$this->mwHooksHandler->register( 'SMW::SQLStore::AddCustomFixedPropertyTables', function( &$customFixedProperties ) {
+			$customFixedProperties['Foo'] = '_Bar';
+
+			return true;
+		} );
+
+		$this->assertEquals(
+			'smw_fpt_bar',
+			$store->findPropertyTableID( new \SMW\DIProperty( 'Foo' ) )
+		);
+	}
+
 	public function storeClassProvider() {
 
 		$provider[] = array( '\SMWSQLStore3' );

--- a/tests/phpunit/Utils/MwHooksHandler.php
+++ b/tests/phpunit/Utils/MwHooksHandler.php
@@ -34,7 +34,8 @@ class MwHooksHandler {
 		'SMW::SQLStore::BeforeDeleteSubjectComplete',
 		'SMW::SQLStore::AfterDeleteSubjectComplete',
 		'SMW::Parser::BeforeMagicWordsFinder',
-		'SMW::SQLStore::BeforeDataRebuildJobInsert'
+		'SMW::SQLStore::BeforeDataRebuildJobInsert',
+		'SMW::SQLStore::AddCustomFixedPropertyTables'
 	);
 
 	/**


### PR DESCRIPTION
The current approach in `'SMW::SQLStore::updatePropertyTableDefinitions'` requires internal SMW knowledge [0] therefore adding `'SMW::SQLStore::AddCustomFixedPropertyTables'` where only property keys are being assigned and have the builder to figure out all necessary attributes to finalize the table definition.

Just add properties like:

```
$this->handlers['SMW::SQLStore::AddCustomFixedPropertyTables'] = function( &$customFixedProperties ) use( $propertyRegistry ) {

	$customFixedProperties = array();

	$properties = array(
		$propertyRegistry::SCI_CITE_KEY,
		$propertyRegistry::SCI_CITE_REFERENCE,
		$propertyRegistry::SCI_CITE_TEXT,
		$propertyRegistry::SCI_CITE,
		$propertyRegistry::SCI_DOI
	);

	foreach ( $properties as $property ) {
		$customFixedProperties[$property] = str_replace( '__', '_', $property );
	}

	return true;
};
```

Whether `'SMW::SQLStore::updatePropertyTableDefinitions'` should be deprecated in
favour of `'SMW::SQLStore::AddCustomFixedPropertyTables'` is not part of this PR.

[0] https://github.com/SemanticMediaWiki/SemanticExtraSpecialProperties/blob/master/src/PropertyRegistry.php#L111-L126