### PR TITLE
Some hook/test tidy

### DIFF
--- a/includes/NamespaceExaminer.php
+++ b/includes/NamespaceExaminer.php
@@ -8,14 +8,12 @@ use MWNamespace;
  * Examines if a specific namespace is enabled for the usage of the
  * Semantic MediaWiki extension
  *
- * @ingroup SMW
- *
- * @licence GNU GPL v2+
+ * @license GNU GPL v2+
  * @since 1.9
  *
  * @author mwjames
  */
-final class NamespaceExaminer {
+class NamespaceExaminer {
 
 	/** @var array */
 	private static $instance = null;

--- a/includes/datavalues/SMW_DataValue.php
+++ b/includes/datavalues/SMW_DataValue.php
@@ -127,6 +127,13 @@ abstract class SMWDataValue {
 	private $serviceLinksRenderState = true;
 
 	/**
+	 * Extraneous services and object container
+	 *
+	 * @var array
+	 */
+	private $extraneousFunctions = array();
+
+	/**
 	 * Constructor.
 	 *
 	 * @param string $typeid
@@ -727,6 +734,35 @@ abstract class SMWDataValue {
 	 */
 	public function canUse() {
 		return true;
+	}
+
+	/**
+	 * @note Normally set by the DataValueFactory, or during tests
+	 *
+	 * @since 2.3
+	 *
+	 * @param array
+	 */
+	public function setExtraneousFunctions( array $extraneousFunctions ) {
+		$this->extraneousFunctions = $extraneousFunctions;
+	}
+
+	/**
+	 * @since 2.3
+	 *
+	 * @param string $name
+	 * @param array $parameters
+	 *
+	 * @return mixed
+	 * @throws RuntimeException
+	 */
+	public function getExtraneousFunctionFor( $name, array $parameters = array() ) {
+
+		if ( isset( $this->extraneousFunctions[$name] ) && is_callable( $this->extraneousFunctions[$name] ) ) {
+			return call_user_func_array( $this->extraneousFunctions[$name], $parameters );
+		}
+
+		throw new RuntimeException( "$name is not registered as extraneous function." );
 	}
 
 	/**

--- a/src/DataTypeRegistry.php
+++ b/src/DataTypeRegistry.php
@@ -88,6 +88,12 @@ class DataTypeRegistry {
 		//DataItem::TYPE_ERROR => '',
 	);
 
+
+	/**
+	 * @var Closure[]
+	 */
+	private $extraneousFunctions = array();
+
 	/**
 	 * Returns a DataTypeRegistry instance
 	 *
@@ -126,7 +132,7 @@ class DataTypeRegistry {
 	 * @param array $typeLabels
 	 * @param array $typeAliases
 	 */
-	public function __construct( array $typeLabels, array $typeAliases, array $canonicalLabels ) {
+	public function __construct( array $typeLabels = array() , array $typeAliases = array(), array $canonicalLabels = array() ) {
 		foreach ( $typeLabels as $typeId => $typeLabel ) {
 			$this->registerTypeLabel( $typeId, $typeLabel );
 		}
@@ -431,7 +437,29 @@ class DataTypeRegistry {
 		wfRunHooks( 'smwInitDatatypes' );
 
 		// Since 1.9
-		wfRunHooks( 'SMW::DataType::initTypes' );
+		\Hooks::run( 'SMW::DataType::initTypes', array( $this ) );
+	}
+
+	/**
+	 * Inject services and objects that are planned to be used during the invocation of
+	 * a DataValue
+	 *
+	 * @since 2.3
+	 *
+	 * @param string  $name
+	 * @param \Closure $callback
+	 */
+	public function registerExtraneousFunction( $name, \Closure $callback ) {
+		$this->extraneousFunctions[$name] = $callback;
+	}
+
+	/**
+	 * @since 2.3
+	 *
+	 * @return Closure[]
+	 */
+	public function getExtraneousFunctions() {
+		return $this->extraneousFunctions;
 	}
 
 }

--- a/src/DataValueFactory.php
+++ b/src/DataValueFactory.php
@@ -81,6 +81,10 @@ class DataValueFactory {
 				$valueString, $caption );
 		}
 
+		$result->setExtraneousFunctions(
+			$dataTypeRegistry->getExtraneousFunctions()
+		);
+
 		if ( $property !== null ) {
 			$result->setProperty( $property );
 		}

--- a/src/MediaWiki/MediaWikiNsContentReader.php
+++ b/src/MediaWiki/MediaWikiNsContentReader.php
@@ -16,15 +16,13 @@ class MediaWikiNsContentReader {
 	/**
 	 * @var boolean
 	 */
-	private $useDatabaseForFallback = true;
+	private $skipMessageCache = false;
 
 	/**
-	 * @since 2.2
-	 *
-	 * @param boolean $useDatabaseForFallback
+	 * @since 2.3
 	 */
-	public function useDatabaseForFallback( $useDatabaseForFallback ) {
-		$this->useDatabaseForFallback = (bool)$useDatabaseForFallback;
+	public function skipMessageCache() {
+		$this->skipMessageCache = true;
 	}
 
 	/**
@@ -38,18 +36,18 @@ class MediaWikiNsContentReader {
 
 		$content = '';
 
-		if ( wfMessage( $name )->exists() ) {
+		if ( !$this->skipMessageCache && wfMessage( $name )->exists() ) {
 			$content = wfMessage( $name )->inContentLanguage()->text();
 		}
 
-		if ( $content === '' && $this->useDatabaseForFallback ) {
-			$content = $this->tryLoadingFromDatabase( $name );
+		if ( $content === '' ) {
+			$content = $this->tryReadFromDatabase( $name );
 		}
 
 		return $content;
 	}
 
-	private function tryLoadingFromDatabase( $name ) {
+	private function tryReadFromDatabase( $name ) {
 
 		$title = Title::makeTitleSafe( NS_MEDIAWIKI, ucfirst( $name ) );
 

--- a/src/PropertyRegistry.php
+++ b/src/PropertyRegistry.php
@@ -331,7 +331,7 @@ class PropertyRegistry {
 		// @deprecated since 2.1
 		wfRunHooks( 'smwInitProperties' );
 
-		wfRunHooks( 'SMW::Property::initProperties' );
+		\Hooks::run( 'SMW::Property::initProperties', array( $this ) );
 	}
 
 	private function registerPropertyLabel( $id, $label ) {

--- a/tests/phpunit/Integration/MediaWiki/LinksUpdateTest.php
+++ b/tests/phpunit/Integration/MediaWiki/LinksUpdateTest.php
@@ -184,7 +184,7 @@ class LinksUpdateTest extends MwDBaseUnitTestCase {
 	/**
 	 * @depends testDoUpdateUsingNoAnnotations
 	 */
-	public function testDoUpdateResetRevision( $firstRunRevision ) {
+	public function testReparseFirstRevision( $firstRunRevision ) {
 
 		$contentParser = $this->applicationFactory->newContentParser( $this->title );
 		$contentParser->forceToUseParser();
@@ -210,18 +210,6 @@ class LinksUpdateTest extends MwDBaseUnitTestCase {
 		$this->semanticDataValidator->assertThatPropertiesAreSet(
 			$expected,
 			$semanticData
-		);
-
-		if ( !$this->title->getArticleID() ) {
-			$this->markTestSkipped( "The Title object did not provide an article ID" );
-		}
-
-		$linksUpdate = new \LinksUpdate( $this->title, $contentParser->getOutput() );
-		$linksUpdate->doUpdate();
-
-		$this->assertCount(
-			2,
-			$this->getStore()->getSemanticData( DIWikiPage::newFromTitle( $this->title ) )->getProperties()
 		);
 	}
 

--- a/tests/phpunit/Utils/MwHooksHandler.php
+++ b/tests/phpunit/Utils/MwHooksHandler.php
@@ -26,6 +26,8 @@ class MwHooksHandler {
 	private $listOfSmwHooks = array(
 		'SMWStore::updateDataBefore',
 		'smwInitProperties',
+		'SMW::Property::initProperties',
+		'SMW::DataType::initTypes',
 		'SMW::Factbox::BeforeContentGeneration',
 		'SMW::SQLStore::updatePropertyTableDefinitions',
 		'SMW::Store::BeforeQueryResultLookupComplete',
@@ -51,6 +53,11 @@ class MwHooksHandler {
 		);
 
 		foreach ( $listOfHooks as $hook ) {
+
+			// MW 1.19
+			if ( method_exists( 'Hooks', 'clear' ) ) {
+				\Hooks::clear( $hook );
+			}
 
 			if ( !isset( $GLOBALS['wgHooks'][$hook] ) ) {
 				continue;

--- a/tests/phpunit/includes/DataTypeRegistryTest.php
+++ b/tests/phpunit/includes/DataTypeRegistryTest.php
@@ -165,6 +165,24 @@ class DataTypeRegistryTest extends \PHPUnit_Framework_TestCase {
 		);
 	}
 
+	public function testExtraneousCallbackFunction() {
+
+		$instance = new DataTypeRegistry();
+		$arg = 'foo';
+
+		$instance->registerExtraneousFunction(
+			'foo',
+			function ( $arg ) {
+				return 'bar' . $arg ;
+			}
+		);
+
+		$this->assertInternalType(
+			'array',
+			$instance->getExtraneousFunctions()
+		);
+	}
+
 	public function testLookupByLabelIsCaseInsensitive() {
 		$caseVariants = array(
 			'page',

--- a/tests/phpunit/includes/InTextAnnotationParserTest.php
+++ b/tests/phpunit/includes/InTextAnnotationParserTest.php
@@ -436,11 +436,11 @@ class InTextAnnotationParserTest extends \PHPUnit_Framework_TestCase {
 				'smwgLinksInValues' => false,
 				'smwgInlineErrors'  => true,
 			),
-			'[[Foo::Bar::Foobar]], [[IPv6::fc00:123:8000::/64]] [[DOI::10.1002/::AID-MRM16::]]',
+			'[[Foo::Bar::Foobar]], [[IPv6::fc00:123:8000::/64]] [[ABC::10.1002/::AID-MRM16::]]',
 			array(
 				'resultText'     => '[[:Bar::Foobar|Bar::Foobar]], [[:Fc00:123:8000::/64|fc00:123:8000::/64]] [[:10.1002/::AID-MRM16::|10.1002/::AID-MRM16::]]',
 				'propertyCount'  => 3,
-				'propertyLabels' => array( 'Foo', 'IPv6', 'DOI' ),
+				'propertyLabels' => array( 'Foo', 'IPv6', 'ABC' ),
 				'propertyValues' => array( 'Bar::Foobar', 'Fc00:123:8000::/64', '10.1002/::AID-MRM16::' )
 			)
 		);

--- a/tests/phpunit/includes/MediaWiki/MediaWikiNsContentReaderTest.php
+++ b/tests/phpunit/includes/MediaWiki/MediaWikiNsContentReaderTest.php
@@ -43,21 +43,10 @@ class MediaWikiNsContentReaderTest extends \PHPUnit_Framework_TestCase {
 		);
 	}
 
-	public function testNotUseDatabaseForFallback() {
+	public function testSkipMessageCache() {
 
 		$instance = new MediaWikiNsContentReader();
-		$instance->useDatabaseForFallback( false );
-
-		$this->assertInternalType(
-			'string',
-			$instance->read( __METHOD__ )
-		);
-	}
-
-	public function testUseDatabaseForFallback() {
-
-		$instance = new MediaWikiNsContentReader();
-		$instance->useDatabaseForFallback( true );
+		$instance->skipMessageCache();
 
 		$this->assertInternalType(
 			'string',

--- a/tests/phpunit/includes/SQLStore/PropertyTableDefinitionBuilderTest.php
+++ b/tests/phpunit/includes/SQLStore/PropertyTableDefinitionBuilderTest.php
@@ -3,6 +3,7 @@
 namespace SMW\Tests\SQLStore;
 
 use SMW\SQLStore\PropertyTableDefinitionBuilder;
+use SMW\Tests\Utils\MwHooksHandler;
 use SMWDataItem as DataItem;
 
 /**
@@ -17,22 +18,18 @@ use SMWDataItem as DataItem;
  */
 class PropertyTableDefinitionBuilderTest extends \PHPUnit_Framework_TestCase {
 
-	protected $hooks = array();
+	protected $mwHooksHandler;
 
 	protected function setUp() {
 		parent::setUp();
 
-		if ( isset( $GLOBALS['wgHooks']['SMW::SQLStore::updatePropertyTableDefinitions'] ) ) {
-			$this->hooks = $GLOBALS['wgHooks']['SMW::SQLStore::updatePropertyTableDefinitions'];
-			$GLOBALS['wgHooks']['SMW::SQLStore::updatePropertyTableDefinitions'] = array();
-		}
+		$this->mwHooksHandler = new MwHooksHandler();
+		$this->mwHooksHandler->deregisterListedHooks();
 	}
 
 	protected function tearDown() {
 
-		if ( $this->hooks !== array() ) {
-			$GLOBALS['wgHooks']['SMW::SQLStore::updatePropertyTableDefinitions'] = $this->hooks;
-		}
+		$this->mwHooksHandler->restoreListedHooks();
 
 		parent::tearDown();
 	}


### PR DESCRIPTION
- Ensures that the hook registry is cleared in order for tests that run with other SMW extensions to pass
- 'SMW::DataType::initTypes' now has access to its instance, no BC
- 'SMW::Property::initProperties' now has access to its instance, no BC
- Add `DataTypeRegistry::registerExtraneousFunction` to allow to register services
- Simplify `MediaWikiNsContentReader`