### PR TITLE
travis: Run "composer selfupdate" before anything

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,6 +35,7 @@ matrix:
     - env: DB=sqlite; MW=master; PHPUNIT=4.6.*
 
 install:
+  - composer selfupdate
   - bash ./build/travis/install-services.sh
   - bash ./build/travis/install-mediawiki.sh
   - bash ./build/travis/install-semantic-mediawiki.sh


### PR DESCRIPTION
To make sure the tests run the latest version of composer. Would work
around issues like https://github.com/wikimedia/composer-merge-plugin/issues/42.

Based on https://github.com/search?l=yaml&q=composer+selfupdate&type=Code&utf8=%E2%9C%93 this seems to be a common thing.