### PR TITLE
Fix fatal error on Special:Ask when ParamProcessor returns a value object

### DIFF
--- a/includes/specials/SMW_SpecialAsk.php
+++ b/includes/specials/SMW_SpecialAsk.php
@@ -431,12 +431,10 @@ class SMWAskPage extends SMWQuerySpecialPage {
 			$result .= '|' . $printout->getSerialisation() . "\n";
 		}
 
-		// Find parameters
 		foreach ( $this->params as $param ) {
 			if ( !$param->wasSetToDefault() ) {
-					$result .= '|' . htmlspecialchars( $param->getName() ) . '=';
-					// e.g. sorting returns with an array
-					$result .= $param->getDefinition()->isList() ? implode( $param->getDefinition()->getDelimiter(), $param->getValue() ) . "\n" : $param->getValue() . "\n";
+				$result .= '|' . htmlspecialchars( $param->getName() ) . '=';
+				$result .= htmlspecialchars( $this->m_params[$param->getName()] );
 			}
 		}
 


### PR DESCRIPTION
Issue reported at https://github.com/SemanticMediaWiki/SemanticMaps/issues/43
by https://github.com/megasquall

Presumably introduced in https://github.com/SemanticMediaWiki/SemanticMediaWiki/commit/4df21015358dc37844f25a117883f0bd07d223cf