### PR TITLE
Redirect property alias to base property

### DIFF
--- a/includes/articlepages/SMW_OrderedListPage.php
+++ b/includes/articlepages/SMW_OrderedListPage.php
@@ -1,5 +1,8 @@
 <?php
 
+use SMW\PropertyRegistry;
+use SMW\DIProperty;
+
 /**
  * Abstract subclass of MediaWiki's Article that handles the common tasks of
  * article pages for Concept and Property pages. This is mainly parameter
@@ -57,6 +60,10 @@ abstract class SMWOrderedListPage extends Article {
 	public function view() {
 		global $wgRequest, $wgUser;
 
+		if ( $this->getTitle()->getNamespace() === SMW_NS_PROPERTY ) {
+			$this->findBasePropertyToRedirectFor( $this->getTitle()->getText() );
+		}
+
 		parent::view();
 
 		// Copied from CategoryPage
@@ -64,6 +71,18 @@ abstract class SMWOrderedListPage extends Article {
 		$diffOnly = $wgRequest->getBool( 'diffonly', $wgUser->getOption( 'diffonly' ) );
 		if ( !isset( $diff ) || !$diffOnly ) {
 			$this->showList();
+		}
+	}
+
+	private function findBasePropertyToRedirectFor( $label ) {
+
+		$property = new DIProperty(
+			PropertyRegistry::getInstance()->findPropertyIdByLabel( $label )
+		);
+
+		if ( $property->getLabel() !== '' && $label !== $property->getLabel() ) {
+			$outputPage = $this->getContext()->getOutput();
+			$outputPage->redirect( $property->getDiWikiPage()->getTitle()->getFullURL() );
 		}
 	}
 


### PR DESCRIPTION
If `Property:Doi` is an alias for `Property:DOI` then this ensures that it always redirects to the base property.

This avoids confusion where `Property:DOI` specifies extras (`_IMPO`) but when displayed as `Property:Doi` the information is not visible due to `Property:Doi` being not `Property:DOI`.

`Geographic coordinate` (deprecated) forwards to `Geographic coordinates`

This only touches the article view for `SMW_NS_PROPERTY`.