### PR TITLE
Fix comparison in SMWQueryResult::getQueryLink()

### DIFF
--- a/includes/storage/SMW_QueryResult.php
+++ b/includes/storage/SMW_QueryResult.php
@@ -236,7 +236,7 @@ class SMWQueryResult {
 	public function getQueryLink( $caption = false ) {
 		$link = $this->getLink();
 
-		if ( $caption == false ) {
+		if ( $caption === false ) {
 			// The space is right here, not in the QPs!
 			$caption = ' ' . wfMessage( 'smw_iq_moreresults' )->inContentLanguage()->text();
 		}


### PR DESCRIPTION
Was '$caption == false' instead of '$caption === false'.  This did not
affect display of further results link in #ask queries. However, some
strings could be ignored if using the method directly, e.g. from another
extension.