### PR TITLE
Add SMW_SQL3_SMWDELETEIW marker

### DIFF
--- a/includes/storage/SQLStore/SMW_SQLStore3.php
+++ b/includes/storage/SQLStore/SMW_SQLStore3.php
@@ -26,6 +26,7 @@ define( 'SMW_SQL3_SMWIW_OUTDATED', ':smw' ); // virtual "interwiki prefix" for o
 define( 'SMW_SQL3_SMWREDIIW', ':smw-redi' ); // virtual "interwiki prefix" for SMW objects that are redirected
 define( 'SMW_SQL3_SMWBORDERIW', ':smw-border' ); // virtual "interwiki prefix" separating very important pre-defined properties from the rest
 define( 'SMW_SQL3_SMWINTDEFIW', ':smw-intprop' ); // virtual "interwiki prefix" marking internal (invisible) predefined properties
+define( 'SMW_SQL3_SMWDELETEIW', ':smw-delete' ); // virtual "interwiki prefix" marking a deleted subject, see #1100
 
 /**
  * Storage access class for using the standard MediaWiki SQL database for

--- a/includes/storage/SQLStore/SMW_Sql3SmwIds.php
+++ b/includes/storage/SQLStore/SMW_Sql3SmwIds.php
@@ -598,12 +598,13 @@ class SMWSql3SmwIds {
 	 *
 	 * @param integer $sid
 	 * @param DIWikiPage $subject
+	 * @param integer|string|null $interWiki
 	 */
-	public function updateInterwikiField( $sid, DIWikiPage $subject ) {
+	public function updateInterwikiField( $sid, DIWikiPage $subject, $interWiki = null ) {
 
 		$this->store->getConnection()->update(
 			self::tableName,
-			array( 'smw_iw' => $subject->getInterWiki() ),
+			array( 'smw_iw' => $interWiki !== null ? $interWiki : $subject->getInterWiki() ),
 			array( 'smw_id' => $sid ),
 			__METHOD__
 		);

--- a/src/MediaWiki/Jobs/UpdateJob.php
+++ b/src/MediaWiki/Jobs/UpdateJob.php
@@ -7,6 +7,7 @@ use ParserOutput;
 use SMW\ApplicationFactory;
 use SMW\EventHandler;
 use SMW\DIProperty;
+use SMW\DIWikiPage;
 use Title;
 
 /**
@@ -83,7 +84,9 @@ class UpdateJob extends JobBase {
 			return $this->doPrepareForUpdate();
 		}
 
-		$this->applicationFactory->getStore()->deleteSubject( $this->getTitle() );
+		$this->applicationFactory->getStore()->clearData(
+			DIWikiPage::newFromTitle( $this->getTitle() )
+		);
 
 		return true;
 	}

--- a/src/SQLStore/ByIdDataRebuildDispatcher.php
+++ b/src/SQLStore/ByIdDataRebuildDispatcher.php
@@ -236,7 +236,7 @@ class ByIdDataRebuildDispatcher {
 				$titleKey = '';
 			}
 
-			if ( $row->smw_subobject !== '' ) {
+			if ( $row->smw_subobject !== '' && $row->smw_iw !== SMW_SQL3_SMWDELETEIW ) {
 				// leave subobjects alone; they ought to be changed with their pages
 			} elseif ( ( $row->smw_iw === '' || $row->smw_iw == SMW_SQL3_SMWREDIIW ) &&
 				$titleKey != '' ) {
@@ -248,7 +248,7 @@ class ByIdDataRebuildDispatcher {
 				if ( $title !== null && !$title->exists() ) {
 					$updatejobs[] = $this->newUpdateJob( $title );
 				}
-			} elseif ( $row->smw_iw == SMW_SQL3_SMWIW_OUTDATED ) { // remove outdated internal object references
+			} elseif ( $row->smw_iw == SMW_SQL3_SMWIW_OUTDATED || $row->smw_iw == SMW_SQL3_SMWDELETEIW ) { // remove outdated internal object references
 
 				foreach ( $this->store->getPropertyTables() as $proptable ) {
 					if ( $proptable->usesIdSubject() ) {

--- a/tests/phpunit/includes/MediaWiki/Jobs/UpdateJobTest.php
+++ b/tests/phpunit/includes/MediaWiki/Jobs/UpdateJobTest.php
@@ -89,6 +89,14 @@ class UpdateJobTest extends \PHPUnit_Framework_TestCase {
 			->disableOriginalConstructor()
 			->getMock();
 
+		$title->expects( $this->any() )
+			->method( 'getNamespace' )
+			->will( $this->returnValue( 0 ) );
+
+		$title->expects( $this->any() )
+			->method( 'getDBKey' )
+			->will( $this->returnValue( 'Foo' ) );
+
 		$title->expects( $this->once() )
 			->method( 'exists' )
 			->will( $this->returnValue( false ) );

--- a/tests/phpunit/includes/SQLStore/Writer/DeleteSubjectTest.php
+++ b/tests/phpunit/includes/SQLStore/Writer/DeleteSubjectTest.php
@@ -58,7 +58,7 @@ class DeleteSubjectTest extends \PHPUnit_Framework_TestCase {
 			->disableOriginalConstructor()
 			->getMock();
 
-		$database->expects( $this->once() )
+		$database->expects( $this->atLeastOnce() )
 			->method( 'select' )
 			->will( $this->returnValue( array() ) );
 
@@ -66,7 +66,7 @@ class DeleteSubjectTest extends \PHPUnit_Framework_TestCase {
 			->disableOriginalConstructor()
 			->getMock();
 
-		$parentStore->expects( $this->exactly( 5 ) )
+		$parentStore->expects( $this->exactly( 7 ) )
 			->method( 'getObjectIds' )
 			->will( $this->returnValue( $objectIdGenerator ) );
 
@@ -104,7 +104,7 @@ class DeleteSubjectTest extends \PHPUnit_Framework_TestCase {
 			->disableOriginalConstructor()
 			->getMock();
 
-		$database->expects( $this->once() )
+		$database->expects( $this->atLeastOnce() )
 			->method( 'select' )
 			->will( $this->returnValue( array() ) );
 
@@ -124,7 +124,7 @@ class DeleteSubjectTest extends \PHPUnit_Framework_TestCase {
 			->method( 'getConnection' )
 			->will( $this->returnValue( $database ) );
 
-		$parentStore->expects( $this->exactly( 6 ) )
+		$parentStore->expects( $this->exactly( 7 ) )
 			->method( 'getObjectIds' )
 			->will( $this->returnValue( $objectIdGenerator ) );
 


### PR DESCRIPTION
This picks up the [0] discussion about deleted subjects and properties that have a type annotation.

Applies a two-step approach:
- If a subject is deleted then it is cleared of all references and marked
with `SMW_SQL3_SMWDELETEIW` in the object table
- `ByIdDataRebuildDispatcher` will remove those marked with `SMW_SQL3_SMWDELETEIW` and remove any remaining
references from related property tables

[0] http://wikimedia.7.x6.nabble.com/Quick-question-about-property-deletion-tp5050929p5050932.html