### PR TITLE
Filter deleted redirect-target, refs #1100

### DIFF
--- a/includes/storage/SQLStore/SMW_SQLStore3_Readers.php
+++ b/includes/storage/SQLStore/SMW_SQLStore3_Readers.php
@@ -382,7 +382,7 @@ class SMWSQLStore3Readers {
 
 			// #Issue 615
 			// If the iw field contains a redirect marker then remove it
-			if ( isset( $valuekeys[2] ) && $valuekeys[2] === SMW_SQL3_SMWREDIIW ) {
+			if ( isset( $valuekeys[2] ) && ( $valuekeys[2] === SMW_SQL3_SMWREDIIW || $valuekeys[2] === SMW_SQL3_SMWDELETEIW ) ) {
 				$valuekeys[2] = '';
 			}
 

--- a/tests/phpunit/Integration/Parser/ByJsonParserTestCaseRunnerTest.php
+++ b/tests/phpunit/Integration/Parser/ByJsonParserTestCaseRunnerTest.php
@@ -101,6 +101,12 @@ class ByJsonParserTestCaseRunnerTest extends ByJsonTestCaseProvider {
 			isset( $case['namespace'] ) ? constant( $case['namespace'] ) : NS_MAIN
 		);
 
+		// Allows for data to be re-read from the DB instead of being fetched
+		// from the store-id-cache
+		if ( isset( $case['store']['clear-cache'] ) && $case['store']['clear-cache'] ) {
+			$this->getStore()->clear();
+		}
+
 		$semanticData = $this->getStore()->getSemanticData( $subject );
 
 		if ( $debug ) {

--- a/tests/phpunit/Integration/Parser/parser-09-02-redirect-delete-lookup.json
+++ b/tests/phpunit/Integration/Parser/parser-09-02-redirect-delete-lookup.json
@@ -1,0 +1,51 @@
+{
+	"description": "Redirect target delete lookup combination",
+	"properties": [
+		{
+			"name": "HasPropertyForUse",
+			"contents": "[[Has type::Page]]"
+		}
+	],
+	"subjects": [
+		{
+			"name": "Page/09/02/1",
+			"contents": "#REDIRECT [[Page/09/02/2]]"
+		},
+		{
+			"name": "Page/09/02/2",
+			"contents": "[[HasPropertyForUse::ABC]]",
+			"do-delete": true
+		},
+		{
+			"name": "Page/09/02/3",
+			"contents": "[[HasPropertyForUse::Page/09/02/1]]"
+		}
+	],
+	"parser-testcases": [
+		{
+			"about": "#0 check annotation for a deleted redirected target subject",
+			"subject": "Page/09/02/3",
+			"store": {
+				"clear-cache": true,
+				"semantic-data": {
+					"strict-mode-valuematch": false,
+					"propertyCount": 3,
+					"propertyKeys": [ "_MDAT", "_SKEY", "HasPropertyForUse" ],
+					"propertyValues": [ "Page/09/02/2" ]
+				}
+			}
+		}
+	],
+	"settings": {
+		"smwgPageSpecialProperties": [ "_MDAT" ],
+		"smwgNamespacesWithSemanticLinks": {
+			"NS_MAIN": true,
+			"SMW_NS_PROPERTY": true
+		}
+	},
+	"meta": {
+		"version": "0.1",
+		"is-incomplete": false,
+		"debug": false
+	}
+}


### PR DESCRIPTION
refs #615, #1100

This is an edge but nevertheless is now being handled correctly. If a subject `Foo` is being redirected to `Bar` and `Bar` gets deleted and later is used as annotation on a different page with something like`[[SomeProperty::Bar]]` while still contain the deleted marker (because `rebuildData` has not yet cleaned marked ids).

09-02 contains the use/test case
