### PR TITLE
rebuildData / Add `--skip-properties` / remove marked for deletion first

### DIFF
--- a/maintenance/rebuildData.php
+++ b/maintenance/rebuildData.php
@@ -85,6 +85,8 @@ class RebuildData extends \Maintenance {
 		$this->addOption( 'p', 'Will refresh only property pages (and other explicitly named namespaces)', false );
 		$this->addOption( 't', 'Will refresh only type pages (and other explicitly named namespaces)', false );
 
+		$this->addOption( 'skip-properties', 'Skip the default properties rebuild (only recommended when successive build steps are used)', false );
+
 		$this->addOption( 'page', '<pagelist> Will refresh only the pages of the given names, with | used as a separator. ' .
 								'Example: --page "Page 1|Page 2" refreshes Page 1 and Page 2 Options -s, -e, -n, ' .
 								'--startidfile, -c, -p, -t are ignored if --page is given.', false, true );


### PR DESCRIPTION
- `--skip-properties` to skip the default properties rebuild (only recommended when successive build steps are used)
- Ensure that marked for deletion items are removed first in order for the following rebuild to pick-up redirects/pages that relied upon a deleted entity

Follow up on #1100, now that is possible for subjects to be marked for deletion.

```
$ php maintenance/rebuildData.php -s 1655 -e 1700 --skip-properties

Running for storage: SMWSQLStore3

Removing marked for deletion entries.

..

2 IDs removed.

Refreshing all semantic data in the database!
---
 Some versions of PHP suffer from memory leaks in long-running
 scripts. If your machine gets very slow after many pages
 (typically more than 1000) were refreshed, please abort with
 CTRL-C and resume this script at the last processed page id
 using the parameter -s (use -v to display page ids during
 refresh). Continue this until all pages have been refreshed.
---
 The progress displayed is an estimation which can change
 during the run with (*) indicating an adjustment.
---
Processing all IDs from 1655 to 1700 ...

............................

28 IDs refreshed.
```