### PR TITLE
Add CompositePropertyTableDiffIterator

### DIFF
--- a/docs/technical/hooks.md
+++ b/docs/technical/hooks.md
@@ -31,6 +31,8 @@ Implementing a hook should be made in consideration of the expected performance 
 - `SMW::SQLStore::BeforeDataRebuildJobInsert` to add update jobs while running the rebuild process.<sup>Use of `smwRefreshDataJobs` was deprecated with 2.3</sup>
 - `SMW::SQLStore::AddCustomFixedPropertyTables` to add fixed property table definitions
 - `SMW::Browse::AfterInPropertiesLookupComplete` to extend the incoming properties display for `Special:Browse`
+- `SMW::SQLStore::AfterDataUpdateComplete` to add processing after the update has been completed and provides `CompositePropertyTableDiffIterator` to identify entities
+   that have been added/removed during the update. <sup>Use of `SMWSQLStore3::updateDataAfter` was deprecated with 2.3</sup>
 
 For implementation details and examples, see the [integration test](https://github.com/SemanticMediaWiki/SemanticMediaWiki/blob/master/tests/phpunit/Integration/SemanticMediaWikiProvidedHookInterfaceIntegrationTest.php).
 
@@ -46,7 +48,6 @@ Subsequent hooks should be renamed to follow a common naming practice that help 
 * `SMWSQLStore3SetupHandlers`, SMWCustomSQLStoreFieldType
 * `SMWSQLStore3SetupHandlers`, smwRefreshDataJobs (SMW::SQLStore::AfterRefreshDataJob)
 * `SMWSQLStore3Writers`, SMWSQLStore3::updateDataBefore (SMW::SQLStore::BeforeDataUpdateComplete)
-* `SMWSQLStore3Writers`, SMWSQLStore3::updateDataAfter (SMW::SQLStore::AfterDataUpdateComplete)
 * `SMWSetupScript`, smwDropTables (SMW::Store::dropTables)
 * `SMW_refreshData`, smwDropTables (SMW::Store::dropTables)
 

--- a/includes/storage/SQLStore/SMW_SQLStore3_Writers.php
+++ b/includes/storage/SQLStore/SMW_SQLStore3_Writers.php
@@ -132,6 +132,9 @@ class SMWSQLStore3Writers {
 		$subject = $semanticData->getSubject();
 
 
+		// Reset diff before starting the update
+		$this->propertyTableRowDiffer->resetCompositePropertyTableDiff();
+
 		// Update data about our main subject
 		$this->doFlatDataUpdate( $semanticData );
 
@@ -152,9 +155,14 @@ class SMWSQLStore3Writers {
 			}
 		}
 
-		// TODO Make overall diff SMWSemanticData containers and run a hook
-
+		// Deprecated since 2.3, use SMW::SQLStore::AfterDataUpdateComplete
 		wfRunHooks( 'SMWSQLStore3::updateDataAfter', array( $this->store, $semanticData ) );
+
+		wfRunHooks( 'SMW::SQLStore::AfterDataUpdateComplete', array(
+			$this->store,
+			$semanticData,
+			$this->propertyTableRowDiffer->getCompositePropertyTableDiff()
+		) );
 	}
 
 	/**

--- a/src/SQLStore/CompositePropertyTableDiffIterator.php
+++ b/src/SQLStore/CompositePropertyTableDiffIterator.php
@@ -1,0 +1,152 @@
+<?php
+
+namespace SMW\SQLStore;
+
+use IteratorAggregate;
+use ArrayIterator;
+
+/**
+ * @license GNU GPL v2+
+ * @since 2.3
+ *
+ * @author mwjames
+ */
+class CompositePropertyTableDiffIterator implements IteratorAggregate {
+
+	/**
+	 * @var array
+	 */
+	private $diff = array();
+
+	/**
+	 * @var array
+	 */
+	private $fixedPropertyRecords = array();
+
+	/**
+	 * @since 2.3
+	 *
+	 * @param array $diff
+	 */
+	public function __construct( array $diff = array() ) {
+		$this->diff = $diff;
+	}
+
+	/**
+	 * @since 2.3
+	 *
+	 * @return ArrayIterator
+	 */
+	public function getIterator() {
+		return new ArrayIterator( $this->diff );
+	}
+
+	/**
+	 * @since 2.3
+	 *
+	 * @param array $insertRecord
+	 * @param array $deleteRecord
+	 */
+	public function addTableRowsToCompositeDiff( array $insertRecord, array $deleteRecord ) {
+		$this->diff[] = array(
+			'insert' => $insertRecord,
+			'delete' => $deleteRecord
+		);
+	}
+
+	/**
+	 * @since 2.3
+	 *
+	 * @param array $fixedPropertyRecord
+	 */
+	public function addFixedPropertyRecord( $tableName, array $fixedPropertyRecord ) {
+		$this->fixedPropertyRecords[$tableName] = $fixedPropertyRecord;
+	}
+
+	/**
+	 * Simplified (ordered by table) diff array to allow for an easier
+	 * post-processing
+	 *
+	 * @since 2.3
+	 *
+	 * @return array
+	 */
+	public function getOrderedDiffByTable( $table = null ) {
+
+		$ordered = array();
+
+		foreach ( $this as $diff ) {
+			foreach ( $diff as $key => $value ) {
+				foreach ( $value as $tableName => $val ) {
+
+					if ( $val === array() || ( $table !== null && $table !== $tableName ) ) {
+						continue;
+					}
+
+					if ( isset( $this->fixedPropertyRecords[$tableName] ) ) {
+						$ordered[$tableName]['property'] = $this->fixedPropertyRecords[$tableName];
+					}
+
+					if ( !isset( $ordered[$tableName] ) ) {
+						$ordered[$tableName] = array();
+					}
+
+					if ( !isset( $ordered[$tableName][$key] ) ) {
+						$ordered[$tableName][$key] = array();
+					}
+
+					foreach ( $val as $v ) {
+						$ordered[$tableName][$key][] = $v;
+					}
+				}
+			}
+		}
+
+		return $ordered;
+	}
+
+	/**
+	 * @since 2.3
+	 *
+	 * @return array
+	 */
+	public function getCombinedIdListForChangedEntities() {
+
+		$list = array();
+
+		foreach ( $this->getOrderedDiffByTable() as $diff ) {
+
+			if ( isset( $diff['insert'] )  ) {
+				$this->addToIdList( $list, $diff['insert'] );
+			}
+
+			if ( isset( $diff['delete'] )  ) {
+				$this->addToIdList( $list, $diff['delete'] );
+			}
+
+			if ( isset( $diff['property'] )  ) {
+				$list[$diff['property']['p_id']] = null;
+			}
+		}
+
+		return array_keys( $list );
+	}
+
+	private function addToIdList( &$list, $value ) {
+		foreach ( $value as $element ) {
+
+			if ( isset( $element['p_id'] ) ) {
+				$list[$element['p_id']] = null;
+			}
+
+			if ( isset( $element['s_id'] ) ) {
+				$list[$element['s_id']] = null;
+			}
+
+			if ( isset( $element['o_id'] ) ) {
+				$list[$element['o_id']] = null;
+			}
+		}
+	}
+
+}

--- a/tests/phpunit/Utils/MwHooksHandler.php
+++ b/tests/phpunit/Utils/MwHooksHandler.php
@@ -37,7 +37,8 @@ class MwHooksHandler {
 		'SMW::SQLStore::AfterDeleteSubjectComplete',
 		'SMW::Parser::BeforeMagicWordsFinder',
 		'SMW::SQLStore::BeforeDataRebuildJobInsert',
-		'SMW::SQLStore::AddCustomFixedPropertyTables'
+		'SMW::SQLStore::AddCustomFixedPropertyTables',
+		'SMW::SQLStore::AfterDataUpdateComplete'
 	);
 
 	/**

--- a/tests/phpunit/includes/SQLStore/CompositePropertyTableDiffIteratorTest.php
+++ b/tests/phpunit/includes/SQLStore/CompositePropertyTableDiffIteratorTest.php
@@ -1,0 +1,249 @@
+<?php
+
+namespace SMW\Tests\SQLStore;
+
+use SMW\SQLStore\CompositePropertyTableDiffIterator;
+
+/**
+ * @covers \SMW\SQLStore\CompositePropertyTableDiffIterator
+ * @group semantic-mediawiki
+ *
+ * @license GNU GPL v2+
+ * @since 2.3
+ *
+ * @author mwjames
+ */
+class CompositePropertyTableDiffIteratorTest extends \PHPUnit_Framework_TestCase {
+
+	public function testCanConstruct() {
+
+		$this->assertInstanceOf(
+			'\SMW\SQLStore\CompositePropertyTableDiffIterator',
+			new CompositePropertyTableDiffIterator()
+		);
+	}
+
+	/**
+	 * @dataProvider diffDataProvider
+	 */
+	public function testDiff( $list, $fixedPropertyRecord, $expectedOrdered, $expectedList ) {
+
+		$instance = new CompositePropertyTableDiffIterator(
+			$list
+		);
+
+		$instance->addFixedPropertyRecord(
+			$fixedPropertyRecord[0],
+			$fixedPropertyRecord[1]
+		);
+
+		$this->assertEquals(
+			$expectedOrdered,
+			$instance->getOrderedDiffByTable()
+		);
+
+		$this->assertEquals(
+			$expectedList,
+			$instance->getCombinedIdListForChangedEntities()
+		);
+	}
+
+	public function diffDataProvider() {
+
+		$provider[] = array(
+			array(),
+			array( 'foo', array() ),
+			array(),
+			array(),
+		);
+
+		// Insert
+		$provider[] = array(
+			array(
+				0 => array(
+				'insert' => array(
+				'smw_di_number' =>
+				  array( 0 => array(
+					  's_id' => 3668,
+					  'p_id' => 61,
+					  'o_serialized' => '123',
+					  'o_sortkey' => '123',
+					),
+				  ),
+				'smw_fpt_mdat' =>
+				  array( 0 => array(
+					  's_id' => 3668,
+					  'o_serialized' => '1/2015/8/16/9/28/39',
+					  'o_sortkey' => '2457250.8948958',
+					),
+				  ),
+				),
+				'delete' => array(
+				'smw_di_number' =>
+				  array(),
+				'smw_fpt_mdat' =>
+				  array(),
+				),
+			  ),
+			),
+			array(
+			  'smw_fpt_mdat',
+			  array(
+				'key' => '_MDAT',
+				'p_id' => 29,
+			  ),
+			),
+			array(
+				'smw_di_number' => array(
+				'insert' =>
+				array( 0 => array(
+					's_id' => 3668,
+					'p_id' => 61,
+					'o_serialized' => '123',
+					'o_sortkey' => '123',
+				  ),
+				),
+			  ),
+			  'smw_fpt_mdat' => array(
+				'property' =>
+				array(
+				  'key' => '_MDAT',
+				  'p_id' => 29,
+				),
+				'insert' => array(
+				  0 => array(
+					's_id' => 3668,
+					'o_serialized' => '1/2015/8/16/9/28/39',
+					'o_sortkey' => '2457250.8948958',
+				  ),
+				),
+			  ),
+			),
+			array(
+			  0 => 61,
+			  1 => 3668,
+			  2 => 29,
+			)
+		);
+
+		// Insert / Delete
+		$provider[] = array(
+			array(
+			  0 =>
+			  array(
+				'insert' =>
+				array(
+				  'smw_di_number' =>
+				  array(
+					0 =>
+					array(
+					  's_id' => 3668,
+					  'p_id' => 61,
+					  'o_serialized' => '1001',
+					  'o_sortkey' => '1001',
+					),
+				  ),
+				  'smw_fpt_mdat' =>
+				  array(
+					0 =>
+					array(
+					  's_id' => 3668,
+					  'o_serialized' => '1/2015/8/16/9/56/53',
+					  'o_sortkey' => '2457250.9145023',
+					),
+				  ),
+				),
+				'delete' =>
+				array(
+				  'smw_di_number' =>
+				  array(
+					0 =>
+					array(
+					  's_id' => 3668,
+					  'p_id' => 61,
+					  'o_serialized' => '123',
+					  'o_sortkey' => '123',
+					),
+				  ),
+				  'smw_fpt_mdat' =>
+				  array(
+					0 =>
+					array(
+					  's_id' => 3668,
+					  'o_serialized' => '1/2015/8/16/9/28/39',
+					  'o_sortkey' => '2457250.8948958',
+					),
+				  ),
+				),
+			  ),
+			),
+			array(
+			  'smw_fpt_mdat',
+			  array(
+				'key' => '_MDAT',
+				'p_id' => 29,
+			  ),
+			),
+			array(
+			  'smw_di_number' =>
+			  array(
+				'insert' =>
+				array(
+				  0 =>
+				  array(
+					's_id' => 3668,
+					'p_id' => 61,
+					'o_serialized' => '1001',
+					'o_sortkey' => '1001',
+				  ),
+				),
+				'delete' =>
+				array(
+				  0 =>
+				  array(
+					's_id' => 3668,
+					'p_id' => 61,
+					'o_serialized' => '123',
+					'o_sortkey' => '123',
+				  ),
+				),
+			  ),
+			  'smw_fpt_mdat' =>
+			  array(
+				'property' =>
+				array(
+				  'key' => '_MDAT',
+				  'p_id' => 29,
+				),
+				'insert' =>
+				array(
+				  0 =>
+				  array(
+					's_id' => 3668,
+					'o_serialized' => '1/2015/8/16/9/56/53',
+					'o_sortkey' => '2457250.9145023',
+				  ),
+				),
+				'delete' =>
+				array(
+				  0 =>
+				  array(
+					's_id' => 3668,
+					'o_serialized' => '1/2015/8/16/9/28/39',
+					'o_sortkey' => '2457250.8948958',
+				  ),
+				),
+			  ),
+			),
+			array(
+			  0 => 61,
+			  1 => 3668,
+			  2 => 29,
+			)
+		);
+
+		return $provider;
+	}
+
+
+}

--- a/tests/phpunit/includes/SQLStore/PropertyTableRowDifferTest.php
+++ b/tests/phpunit/includes/SQLStore/PropertyTableRowDifferTest.php
@@ -60,4 +60,34 @@ class PropertyTableRowDifferTest extends \PHPUnit_Framework_TestCase {
 		);
 	}
 
+	public function testCompositePropertyTableDiffIterator() {
+
+		$semanticData = new SemanticData(
+			new DIWikiPage( 'Foo', NS_MAIN )
+		);
+
+		$propertyTables = array();
+
+		$store = $this->getMockBuilder( '\SMW\SQLStore\SQLStore' )
+			->setMethods( array( 'getPropertyTables' ) )
+			->getMock();
+
+		$store->expects( $this->any() )
+			->method( 'getPropertyTables' )
+			->will( $this->returnValue( $propertyTables ) );
+
+		$instance = new PropertyTableRowDiffer( $store );
+		$instance->resetCompositePropertyTableDiff();
+
+		$result = $instance->computeTableRowDiffFor(
+			42,
+			$semanticData
+		);
+
+		$this->assertInstanceOf(
+			'\SMW\SQLStore\CompositePropertyTableDiffIterator',
+			$instance->getCompositePropertyTableDiff()
+		);
+	}
+
 }


### PR DESCRIPTION
A composite view of row inserts/deletes computed by `PropertyTableRowDiffer` for further processing after update.

refs #1018; removes TODO from `SQLStore`

```
array (
  'smw_di_number' => 
  array (
    'insert' => 
    array (
      0 => 
      array (
        's_id' => 3668,
        'p_id' => 61,
        'o_serialized' => '1001',
        'o_sortkey' => '1001',
      ),
    ),
    'delete' => 
    array (
      0 => 
      array (
        's_id' => 3668,
        'p_id' => 61,
        'o_serialized' => '123',
        'o_sortkey' => '123',
      ),
    ),
  ),
  'smw_fpt_mdat' => 
  array (
    'property' => 
    array (
      'key' => '_MDAT',
      'p_id' => 29,
    ),
    'insert' => 
    array (
      0 => 
      array (
        's_id' => 3668,
        'o_serialized' => '1/2015/8/16/9/56/53',
        'o_sortkey' => '2457250.9145023',
      ),
    ),
    'delete' => 
    array (
      0 => 
      array (
        's_id' => 3668,
        'o_serialized' => '1/2015/8/16/9/28/39',
        'o_sortkey' => '2457250.8948958',
      ),
    ),
  ),
)
```