### PR TITLE
Add feature flags to CachedValueLookupStore

### DIFF
--- a/SemanticMediaWiki.settings.php
+++ b/SemanticMediaWiki.settings.php
@@ -601,6 +601,27 @@ $GLOBALS['smwgValueLookupCacheType'] = CACHE_NONE;
 $GLOBALS['smwgValueLookupCacheLifetime'] = 60 * 60 * 24 * 7; // a week
 ##
 
+##
+# Features expected to be enabled in CachedValueLookupStore
+#
+# Flags that declare a enable/disable state of a supported functionality. If a
+# feature is disabled then a connection is always established to the standard
+# Repository/DB backend.
+#
+# The settings are only relevant for cases where `smwgValueLookupCacheType` is
+# set.
+#
+# - SMW_VL_SD: corresponds to Store::getSemanticData
+# - SMW_VL_PL: corresponds to Store::getProperties
+# - SMW_VL_PV: corresponds to Store::getPropertyValues
+# - SMW_VL_PS: corresponds to Store::getPropertySubjects
+#
+# @since 2.3
+#
+# @default: all features are enabled
+##
+$GLOBALS['smwgValueLookupFeatures'] = SMW_VL_SD | SMW_VL_PL | SMW_VL_PV | SMW_VL_PS;
+
 ###
 # An array containing cache related settings used within Semantic MediaWiki
 # and requires $smwgCacheType be set otherwise caching will have no effect.

--- a/includes/Defines.php
+++ b/includes/Defines.php
@@ -118,3 +118,12 @@ define( 'SMW_SPARQL_QF_REDI', 2 ); // support for inverse property paths to find
 define( 'SMW_SPARQL_QF_SUBP', 4 ); // support for rdfs:subPropertyOf*
 define( 'SMW_SPARQL_QF_SUBC', 8 ); // support for rdfs:subClassOf*
 /**@}*/
+
+ /**@{
+  * Constants for VL store
+  */
+define( 'SMW_VL_SD', 1 );
+define( 'SMW_VL_PL', 2 );
+define( 'SMW_VL_PV', 4 );
+define( 'SMW_VL_PS', 8 );
+/**@}*/

--- a/includes/Settings.php
+++ b/includes/Settings.php
@@ -121,6 +121,7 @@ class Settings extends SimpleDictionary {
 			'smwgMainCacheType' => $GLOBALS['smwgMainCacheType'],
 			'smwgValueLookupCacheType' => $GLOBALS['smwgValueLookupCacheType'],
 			'smwgValueLookupCacheLifetime' => $GLOBALS['smwgValueLookupCacheLifetime'],
+			'smwgValueLookupFeatures' => $GLOBALS['smwgValueLookupFeatures'],
 			'smwgFixedProperties' => $GLOBALS['smwgFixedProperties'],
 			'smwgPropertyLowUsageThreshold' => $GLOBALS['smwgPropertyLowUsageThreshold'],
 			'smwgPropertyZeroCountDisplay' => $GLOBALS['smwgPropertyZeroCountDisplay'],

--- a/src/SQLStore/CachedValueLookupStore.php
+++ b/src/SQLStore/CachedValueLookupStore.php
@@ -54,6 +54,11 @@ class CachedValueLookupStore {
 	private $blobStore;
 
 	/**
+	 * @var integer
+	 */
+	private $valueLookupFeatures = 0;
+
+	/**
 	 * @var CircularReferenceGuard
 	 */
 	private $circularReferenceGuard;
@@ -67,6 +72,26 @@ class CachedValueLookupStore {
 	public function __construct( Store $store, BlobStore $blobStore ) {
 		$this->store = $store;
 		$this->blobStore = $blobStore;
+	}
+
+	/**
+	 * @since 2.3
+	 *
+	 * @param integer $valueLookupFeatures
+	 */
+	public function setValueLookupFeatures( $valueLookupFeatures ) {
+		$this->valueLookupFeatures = $valueLookupFeatures;
+	}
+
+	/**
+	 * @since 2.3
+	 *
+	 * @param integer $valueLookupFeature
+	 *
+	 * @return boolean
+	 */
+	public function canUseValueLookupFeature( $valueLookupFeature ) {
+		return $this->valueLookupFeatures === ( $this->valueLookupFeatures | $valueLookupFeature );
 	}
 
 	/**
@@ -90,7 +115,7 @@ class CachedValueLookupStore {
 	 */
 	public function getSemanticData( DIWikiPage $subject, $filter = false ) {
 
-		if ( !$this->blobStore->canUse() ) {
+		if ( !$this->blobStore->canUse() || !$this->canUseValueLookupFeature( SMW_VL_SD ) ) {
 			return $this->store->getReader()->getSemanticData( $subject, $filter );
 		}
 
@@ -145,7 +170,7 @@ class CachedValueLookupStore {
 	 */
 	public function getProperties( DIWikiPage $subject, $requestOptions = null ) {
 
-		if ( !$this->blobStore->canUse() ) {
+		if ( !$this->blobStore->canUse() || !$this->canUseValueLookupFeature( SMW_VL_PL ) ) {
 			return $this->store->getReader()->getProperties( $subject, $requestOptions );
 		}
 
@@ -197,7 +222,7 @@ class CachedValueLookupStore {
 
 		// The cache is not used for $subject === null (means all values for
 		// the given property are returned)
-		if ( $subject === null || !$this->blobStore->canUse() ) {
+		if ( $subject === null || !$this->blobStore->canUse() || !$this->canUseValueLookupFeature( SMW_VL_PV ) ) {
 			return $this->store->getReader()->getPropertyValues( $subject, $property, $requestOptions );
 		}
 
@@ -255,7 +280,7 @@ class CachedValueLookupStore {
 
 		// The cache is not used for $dataItem === null (means all values for
 		// the given property are returned)
-		if ( $dataItem === null || !$dataItem instanceof DIWikiPage || !$this->blobStore->canUse() ) {
+		if ( $dataItem === null || !$dataItem instanceof DIWikiPage || !$this->blobStore->canUse() || !$this->canUseValueLookupFeature( SMW_VL_PS ) ) {
 			return $this->store->getReader()->getPropertySubjects( $property, $dataItem, $requestOptions );
 		}
 

--- a/src/SQLStore/SQLStoreFactory.php
+++ b/src/SQLStore/SQLStoreFactory.php
@@ -273,6 +273,10 @@ class SQLStoreFactory {
 			$blobStore
 		);
 
+		$cachedValueLookupStore->setValueLookupFeatures(
+			$GLOBALS['smwgValueLookupFeatures']
+		);
+
 		$cachedValueLookupStore->setCircularReferenceGuard(
 			$circularReferenceGuard
 		);

--- a/tests/phpunit/includes/SQLStore/CachedValueLookupStoreTest.php
+++ b/tests/phpunit/includes/SQLStore/CachedValueLookupStoreTest.php
@@ -35,6 +35,47 @@ class CachedValueLookupStoreTest extends \PHPUnit_Framework_TestCase {
 		);
 	}
 
+	public function testGetSemanticDataFromFallbackForDisabledFeature() {
+
+		$subject = new DIWikiPage( 'Foo', NS_MAIN );
+
+		$reader = $this->getMockBuilder( '\SMWSQLStore3Readers' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$reader->expects( $this->once() )
+			->method( 'getSemanticData' )
+			->with(
+				$this->equalTo( $subject ),
+				$this->anything() );
+
+		$store = $this->getMockBuilder( '\SMW\SQLStore\SQLStore' )
+			->disableOriginalConstructor()
+			->setMethods( array( 'getReader' ) )
+			->getMock();
+
+		$store->expects( $this->once() )
+			->method( 'getReader' )
+			->will( $this->returnValue( $reader ) );
+
+		$blobStore = $this->getMockBuilder( '\Onoi\BlobStore\BlobStore' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$blobStore->expects( $this->once() )
+			->method( 'canUse' )
+			->will( $this->returnValue( true ) );
+
+		$instance = new CachedValueLookupStore(
+			$store,
+			$blobStore
+		);
+
+		$instance->setValueLookupFeatures( SMW_VL_PL );
+
+		$instance->getSemanticData( $subject );
+	}
+
 	public function testGetSemanticDataFromFallbackForDisabledBlobStore() {
 
 		$subject = new DIWikiPage( 'Foo', NS_MAIN );
@@ -133,6 +174,8 @@ class CachedValueLookupStoreTest extends \PHPUnit_Framework_TestCase {
 			$blobStore
 		);
 
+		$instance->setValueLookupFeatures( SMW_VL_SD );
+
 		$instance->getSemanticData( $subject );
 	}
 
@@ -174,6 +217,8 @@ class CachedValueLookupStoreTest extends \PHPUnit_Framework_TestCase {
 			$store,
 			$blobStore
 		);
+
+		$instance->setValueLookupFeatures( SMW_VL_SD );
 
 		$this->assertEquals(
 			'Foo',
@@ -236,6 +281,7 @@ class CachedValueLookupStoreTest extends \PHPUnit_Framework_TestCase {
 		);
 
 		$instance->setCircularReferenceGuard( $circularReferenceGuard );
+		$instance->setValueLookupFeatures( SMW_VL_PL );
 
 		$this->assertEquals(
 			$expected,
@@ -298,6 +344,7 @@ class CachedValueLookupStoreTest extends \PHPUnit_Framework_TestCase {
 		);
 
 		$instance->setCircularReferenceGuard( $circularReferenceGuard );
+		$instance->setValueLookupFeatures( SMW_VL_PV );
 
 		$this->assertEquals(
 			$expected,
@@ -355,6 +402,7 @@ class CachedValueLookupStoreTest extends \PHPUnit_Framework_TestCase {
 		);
 
 		$instance->setCircularReferenceGuard( $circularReferenceGuard );
+		$instance->setValueLookupFeatures( SMW_VL_PS );
 
 		$this->assertEquals(
 			$expected,
@@ -420,6 +468,8 @@ class CachedValueLookupStoreTest extends \PHPUnit_Framework_TestCase {
 			$store,
 			$blobStore
 		);
+
+		$instance->setValueLookupFeatures( SMW_VL_SD );
 
 		$instance->deleteFor( $subject );
 	}


### PR DESCRIPTION
Allows a more fine-grained setting as to which lookup should be cached or not.

Default setting is `$GLOBALS['smwgValueLookupFeatures'] = SMW_VL_SD | SMW_VL_PL | SMW_VL_PV | SMW_VL_PS;`

refs #1035, #1063 