### PR TITLE
EmbeddedQueryDependencyLinksStore to track/update pages with embedded…

### DIFF
--- a/SemanticMediaWiki.settings.php
+++ b/SemanticMediaWiki.settings.php
@@ -866,3 +866,16 @@ $GLOBALS['smwgEnabledEditPageHelp'] = true;
 ##
 $GLOBALS['smwgEnabledAsyncJobDispatcher'] = true;
 ##
+
+###
+# If enabled it will store dependencies for queries allowing it to invalidate
+# the ParserCache on subjects with embedded queries that contain altered entities.
+#
+# The setting requires to run `update.php` (as it creates an extra table). Also
+# as noted in #1117, `SMW\ParserCachePurgeJob` should be scheduled accordingly.
+#
+# @since 2.4
+# @default false (for testing it is enabled)
+##
+$GLOBALS['smwgTrackQueryDependencyLinks'] = true;
+##

--- a/SemanticMediaWiki.settings.php
+++ b/SemanticMediaWiki.settings.php
@@ -584,7 +584,7 @@ $GLOBALS['smwgMainCacheType'] = CACHE_ANYTHING; // Isn't used yet
 # CACHE_NONE = disabled, uses the standard SQLStore DB access for all
 # lookups
 #
-# @since 2.3
+# @since 2.3 (experimental)
 #
 # @default: CACHE_NONE, users need to actively enable it in order
 # to make use of it
@@ -868,14 +868,16 @@ $GLOBALS['smwgEnabledAsyncJobDispatcher'] = true;
 ##
 
 ###
-# If enabled it will store dependencies for queries allowing it to invalidate
+# If enabled it will store dependencies for queries allowing it to purge
 # the ParserCache on subjects with embedded queries that contain altered entities.
 #
-# The setting requires to run `update.php` (as it creates an extra table). Also
+# The setting requires to run `update.php` (it creates an extra table). Also
 # as noted in #1117, `SMW\ParserCachePurgeJob` should be scheduled accordingly.
 #
-# @since 2.4
-# @default false (for testing it is enabled)
+# Requires `smwgEnabledAsyncJobDispatcher` to be set true.
+#
+# @since 2.3 (experimental)
+# @default false
 ##
-$GLOBALS['smwgTrackQueryDependencyLinks'] = true;
+$GLOBALS['smwgEnabledQueryDependencyLinksStore'] = false;
 ##

--- a/includes/Settings.php
+++ b/includes/Settings.php
@@ -136,7 +136,7 @@ class Settings extends SimpleDictionary {
 			'smwgSparqlQFeatures' => $GLOBALS['smwgSparqlQFeatures'],
 			'smwgEnabledResultFormatsWithRecursiveAnnotationSupport' => $GLOBALS['smwgEnabledResultFormatsWithRecursiveAnnotationSupport'],
 			'smwgEnabledAsyncJobDispatcher' => $GLOBALS['smwgEnabledAsyncJobDispatcher'],
-			'smwgTrackQueryDependencyLinks' => $GLOBALS['smwgTrackQueryDependencyLinks']
+			'smwgEnabledQueryDependencyLinksStore' => $GLOBALS['smwgEnabledQueryDependencyLinksStore']
 		);
 
 		$settings = $settings + array(

--- a/includes/Settings.php
+++ b/includes/Settings.php
@@ -135,7 +135,8 @@ class Settings extends SimpleDictionary {
 			'smwgEnabledEditPageHelp' => $GLOBALS['smwgEnabledEditPageHelp'],
 			'smwgSparqlQFeatures' => $GLOBALS['smwgSparqlQFeatures'],
 			'smwgEnabledResultFormatsWithRecursiveAnnotationSupport' => $GLOBALS['smwgEnabledResultFormatsWithRecursiveAnnotationSupport'],
-			'smwgEnabledAsyncJobDispatcher' => $GLOBALS['smwgEnabledAsyncJobDispatcher']
+			'smwgEnabledAsyncJobDispatcher' => $GLOBALS['smwgEnabledAsyncJobDispatcher'],
+			'smwgTrackQueryDependencyLinks' => $GLOBALS['smwgTrackQueryDependencyLinks']
 		);
 
 		$settings = $settings + array(

--- a/includes/Setup.php
+++ b/includes/Setup.php
@@ -143,6 +143,7 @@ final class Setup {
 		$this->globalVars['wgJobClasses']['SMW\RefreshJob'] = 'SMW\MediaWiki\Jobs\RefreshJob';
 		$this->globalVars['wgJobClasses']['SMW\UpdateDispatcherJob'] = 'SMW\MediaWiki\Jobs\UpdateDispatcherJob';
 		$this->globalVars['wgJobClasses']['SMW\DeleteSubjectJob'] = 'SMW\MediaWiki\Jobs\DeleteSubjectJob';
+		$this->globalVars['wgJobClasses']['SMW\ParserCachePurgeJob'] = 'SMW\MediaWiki\Jobs\ParserCachePurgeJob';
 
 		// Legacy definition to be removed with 1.10
 		$this->globalVars['wgJobClasses']['SMWUpdateJob']  = 'SMW\MediaWiki\Jobs\UpdateJob';

--- a/includes/storage/SMW_QueryResult.php
+++ b/includes/storage/SMW_QueryResult.php
@@ -134,6 +134,13 @@ class SMWQueryResult {
 	}
 
 	/**
+	 * @since 2.3
+	 */
+	public function reset() {
+		return reset( $this->mResults );
+	}
+
+	/**
 	 * Returns the query object of the current result set
 	 *
 	 * @since 1.8

--- a/includes/storage/SQLStore/SMW_SQLStore3.php
+++ b/includes/storage/SQLStore/SMW_SQLStore3.php
@@ -62,6 +62,11 @@ class SMWSQLStore3 extends SMWStore {
 	const PROPERTY_STATISTICS_TABLE = 'smw_prop_stats';
 
 	/**
+	 * Name of the table that manages the query dependency links
+	 */
+	const QUERY_LINKS_TABLE = 'smw_query_links';
+
+	/**
 	 * Name of the table that manages the Store IDs
 	 */
 	const ID_TABLE = 'smw_object_ids';
@@ -302,7 +307,7 @@ class SMWSQLStore3 extends SMWStore {
 	public function deleteSubject( Title $subject ) {
 
 		$this->cachedValueLookupStore->deleteFor(
-			DIWikiPage::newfromTitle( $subject )
+			DIWikiPage::newFromTitle( $subject )
 		);
 
 		$this->getWriter()->deleteSubject( $subject );
@@ -320,11 +325,11 @@ class SMWSQLStore3 extends SMWStore {
 	public function changeTitle( Title $oldtitle, Title $newtitle, $pageid, $redirid = 0 ) {
 
 		$this->cachedValueLookupStore->deleteFor(
-			DIWikiPage::newfromTitle( $oldtitle )
+			DIWikiPage::newFromTitle( $oldtitle )
 		);
 
 		$this->cachedValueLookupStore->deleteFor(
-			DIWikiPage::newfromTitle( $newtitle )
+			DIWikiPage::newFromTitle( $newtitle )
 		);
 
 		$this->getWriter()->changeTitle( $oldtitle, $newtitle, $pageid, $redirid );

--- a/includes/storage/SQLStore/SMW_SQLStore3_SetupHandlers.php
+++ b/includes/storage/SQLStore/SMW_SQLStore3_SetupHandlers.php
@@ -127,6 +127,25 @@ class SMWSQLStore3SetupHandlers implements MessageReporter {
 
 		SMWSQLHelpers::setupIndex( SMWSQLStore3::CONCEPT_CACHE_TABLE, array( 'o_id' ), $db );
 
+		SMWSQLHelpers::setupTable(
+			SMWSQLStore3::QUERY_LINKS_TABLE,
+			array(
+				's_id' => $dbtypes['p'] . ' NOT NULL',
+				'o_id' => $dbtypes['p'] . ' NOT NULL'
+			),
+			$db,
+			$reportTo
+		);
+
+		SMWSQLHelpers::setupIndex( SMWSQLStore3::QUERY_LINKS_TABLE,
+			array(
+				's_id',
+				'o_id',
+				's_id,o_id'
+			),
+			$db
+		);
+
 		// Set up table for stats on Properties (only counts for now)
 		SMWSQLHelpers::setupTable(
 			SMWSQLStore3::PROPERTY_STATISTICS_TABLE,
@@ -301,7 +320,8 @@ class SMWSQLStore3SetupHandlers implements MessageReporter {
 		$tables = array(
 			SMWSQLStore3::ID_TABLE,
 			SMWSQLStore3::CONCEPT_CACHE_TABLE,
-			SMWSQLStore3::PROPERTY_STATISTICS_TABLE
+			SMWSQLStore3::PROPERTY_STATISTICS_TABLE,
+			SMWSQLStore3::QUERY_LINKS_TABLE
 		);
 
 		foreach ( $this->store->getPropertyTables() as $proptable ) {

--- a/includes/storage/SQLStore/SMW_Sql3SmwIds.php
+++ b/includes/storage/SQLStore/SMW_Sql3SmwIds.php
@@ -853,6 +853,17 @@ class SMWSql3SmwIds {
 	}
 
 	/**
+	 * @since 2.3
+	 *
+	 * @param integer $id
+	 *
+	 * @return string[]
+	 */
+	public function getDataItemPoolHashListFor( array $idlist ) {
+		return $this->byIdDataItemFinder->getDataItemPoolHashListFor( $idlist );
+	}
+
+	/**
 	 * Get a cached SMW ID, or false if no cache entry is found.
 	 *
 	 * @since 1.8

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -62,6 +62,7 @@
        <var name="smwgSparqlDefaultGraph" value="http://example.org/phpunit-testrun"/>
        <var name="smwgValueLookupCacheType" value="hash"/>
        <var name="smwgEnabledAsyncJobDispatcher" value="false"/>
+       <var name="smwgEnabledQueryDependencyLinksStore" value="true"/>
        <var name="benchmarkQueryRepetitionExecutionThreshold" value="5"/>
        <var name="benchmarkQueryLimit" value="500"/>
        <var name="benchmarkQueryOffset" value="0"/>

--- a/src/MediaWiki/Hooks/HookRegistry.php
+++ b/src/MediaWiki/Hooks/HookRegistry.php
@@ -9,6 +9,8 @@ use SMW\ApplicationFactory;
 use SMW\EventHandler;
 use SMW\NamespaceManager;
 use SMW\SQLStore\EmbeddedQueryDependencyLinksStore;
+use SMW\AsyncJobDispatchManager;
+use Onoi\HttpRequest\HttpRequestFactory;
 
 /**
  * @license GNU GPL v2+
@@ -474,25 +476,37 @@ class HookRegistry {
 
 		$this->handlers['SMW::SQLStore::AfterDataUpdateComplete'] = function ( $store, $semanticData, $compositePropertyTableDiffIterator ) use ( $applicationFactory ) {
 
-			$embeddedQueryResultLinksUpdater = new EmbeddedQueryDependencyLinksStore( $store );
-			$embeddedQueryResultLinksUpdater->purgeOutdatedTargetLinks( $compositePropertyTableDiffIterator );
+			$embeddedQueryDependencyLinksStore = new EmbeddedQueryDependencyLinksStore( $store );
 
-			$purgeParserCacheJob = $applicationFactory->newJobFactory()->newParserCachePurgeJob(
-				$semanticData->getSubject()->getTitle(),
-				array(
-					'idlist' => $compositePropertyTableDiffIterator->getCombinedIdListForChangedEntities()
-				)
+			$embeddedQueryDependencyLinksStore->setEnabledState(
+				$applicationFactory->getSettings()->get( 'smwgEnabledQueryDependencyLinksStore' )
 			);
 
-			$purgeParserCacheJob->run();
+			$embeddedQueryDependencyLinksStore->pruneOutdatedTargetLinks( $compositePropertyTableDiffIterator );
+
+			$httpRequestFactory = new HttpRequestFactory();
+			$curlRequest = $httpRequestFactory->newCurlRequest();
+
+			$asyncJobDispatchManager = new AsyncJobDispatchManager( $curlRequest );
+
+			$asyncJobDispatchManager->dispatchJobFor(
+				'SMW\ParserCachePurgeJob',
+				$semanticData->getSubject()->getTitle(),
+				$embeddedQueryDependencyLinksStore->buildParserCachePurgeJobParametersFrom( $compositePropertyTableDiffIterator )
+			);
 
 			return true;
 		};
 
-		$this->handlers['SMW::Store::AfterQueryResultLookupComplete'] = function ( $store, &$result ) {
+		$this->handlers['SMW::Store::AfterQueryResultLookupComplete'] = function ( $store, &$result ) use ( $applicationFactory ) {
 
-			$embeddedQueryResultLinksUpdater = new EmbeddedQueryDependencyLinksStore( $store );
-			$embeddedQueryResultLinksUpdater->addDependenciesFromQueryResult( $result );
+			$embeddedQueryDependencyLinksStore = new EmbeddedQueryDependencyLinksStore( $store );
+
+			$embeddedQueryDependencyLinksStore->setEnabledState(
+				$applicationFactory->getSettings()->get( 'smwgEnabledQueryDependencyLinksStore' )
+			);
+
+			$embeddedQueryDependencyLinksStore->addDependenciesFromQueryResult( $result );
 
 			return true;
 		};

--- a/src/MediaWiki/Jobs/JobFactory.php
+++ b/src/MediaWiki/Jobs/JobFactory.php
@@ -36,4 +36,15 @@ class JobFactory {
 		return new UpdateDispatcherJob( $title, $parameters );
 	}
 
+	/**
+	 * @since 2.0
+	 *
+	 * @param Title $title
+	 *
+	 * @return ParserCachePurgeJob
+	 */
+	public function newParserCachePurgeJob( Title $title, array $parameters = array() ) {
+		return new ParserCachePurgeJob( $title, $parameters );
+	}
+
 }

--- a/src/MediaWiki/Jobs/ParserCachePurgeJob.php
+++ b/src/MediaWiki/Jobs/ParserCachePurgeJob.php
@@ -46,7 +46,6 @@ class ParserCachePurgeJob extends JobBase {
 	 */
 	public function __construct( Title $title, $params = array() ) {
 		parent::__construct( 'SMW\ParserCachePurgeJob', $title, $params );
-		//$this->removeDuplicates = true;
 	}
 
 	/**
@@ -71,10 +70,14 @@ class ParserCachePurgeJob extends JobBase {
 			$this->findEmbeddedQueryTargetLinksBatches( $this->getParameter( 'idlist' ) );
 		}
 
+		wfDebugLog( 'smw', __METHOD__  . ' with limit set to ' . $this->limit . "\n" );
+
 		$this->pageUpdater->addPage( $this->getTitle() );
 		$this->pageUpdater->doPurgeParserCache();
 
 		Hooks::run( 'SMW::Job::AfterParserCachePurgeComplete', array( $this ) );
+
+		return true;
 	}
 
 	/**
@@ -118,7 +121,7 @@ class ParserCachePurgeJob extends JobBase {
 				'offset' => $this->limit
 			) );
 
-			$job->insert();
+			$job->run();
 		}
 
 		$hashList = $this->doBuildUniqueTargetLinksHashList(
@@ -149,7 +152,7 @@ class ParserCachePurgeJob extends JobBase {
 	private function addPagesToUpdater( array $hashList ) {
 		foreach ( $hashList as $hash ) {
 			$this->pageUpdater->addPage(
-				HashBuilder::newDiWikiPageFromHash( $hash )->getTitle()
+				HashBuilder::newTitleFromHash( $hash )
 			);
 		}
 	}

--- a/src/MediaWiki/Jobs/ParserCachePurgeJob.php
+++ b/src/MediaWiki/Jobs/ParserCachePurgeJob.php
@@ -1,0 +1,157 @@
+<?php
+
+namespace SMW\MediaWiki\Jobs;
+
+use SMW\ApplicationFactory;
+use SMW\SQLStore\EmbeddedQueryDependencyLinksStore;
+use SMW\DIWikiPage;
+use SMW\HashBuilder;
+use Title;
+use Hooks;
+
+/**
+ * @license GNU GPL v2+
+ * @since 2.3
+ *
+ * @author mwjames
+ */
+class ParserCachePurgeJob extends JobBase {
+
+	/**
+	 * A balanced size that should be carefully monitored in order to not have a
+	 * negative impact when running the initial update in online mode.
+	 */
+	const CHUNK_SIZE = 200;
+
+	/**
+	 * @var integer
+	 */
+	private $limit = self::CHUNK_SIZE;
+
+	/**
+	 * @var integer
+	 */
+	private $offset = 0;
+
+	/**
+	 * @var PageUpdater
+	 */
+	protected $pageUpdater;
+
+	/**
+	 * @since 2.3
+	 *
+	 * @param Title $title
+	 * @param array $params job parameters
+	 */
+	public function __construct( Title $title, $params = array() ) {
+		parent::__construct( 'SMW\ParserCachePurgeJob', $title, $params );
+		//$this->removeDuplicates = true;
+	}
+
+	/**
+	 * @see Job::run
+	 *
+	 * @since  2.3
+	 */
+	public function run() {
+
+		$this->pageUpdater = ApplicationFactory::getInstance()->newMwCollaboratorFactory()->newPageUpdater();
+		$this->store = ApplicationFactory::getInstance()->getStore();
+
+		if ( $this->hasParameter( 'limit' ) ) {
+			$this->limit = $this->getParameter( 'limit' );
+		}
+
+		if ( $this->hasParameter( 'offset' ) ) {
+			$this->offset = $this->getParameter( 'offset' );
+		}
+
+		if ( $this->hasParameter( 'idlist' ) ) {
+			$this->findEmbeddedQueryTargetLinksBatches( $this->getParameter( 'idlist' ) );
+		}
+
+		$this->pageUpdater->addPage( $this->getTitle() );
+		$this->pageUpdater->doPurgeParserCache();
+
+		Hooks::run( 'SMW::Job::AfterParserCachePurgeComplete', array( $this ) );
+	}
+
+	/**
+	 * Based on the CHUNK_SIZE, target links are purged in an instant if those
+	 * selected entities are < CHUNK_SIZE which should be enough for most
+	 * common queries that only share a limited amount of dependencies, yet for
+	 * queries that expect a large subject/dependency pool, doing an online update
+	 * for all at once is not feasible hence the iterative process of creating
+	 * batches that run through the job scheduler.
+	 *
+	 * @param array $idList
+	 */
+	private function findEmbeddedQueryTargetLinksBatches( array $idList ) {
+
+		if ( $idList === array() ) {
+			return true;
+		}
+
+		$embeddedQueryDependencyLinksStore = new EmbeddedQueryDependencyLinksStore(
+			$this->store
+		);
+
+		// +1 to look ahead
+		$hashList = $embeddedQueryDependencyLinksStore->findPartialEmbeddedQueryTargetLinksHashListFor(
+			$idList,
+			$this->limit + 1,
+			$this->offset
+		);
+
+		if ( $hashList === array() ) {
+			return true;
+		}
+
+		// If more results are available then use an iterative increase to fetch
+		// the remaining updates by creating successive jobs
+		if ( count( $hashList ) > $this->limit ) {
+
+			$job = new self( $this->getTitle(), array(
+				'idlist' => $idList,
+				'limit'  => $this->limit + self::CHUNK_SIZE,
+				'offset' => $this->limit
+			) );
+
+			$job->insert();
+		}
+
+		$hashList = $this->doBuildUniqueTargetLinksHashList(
+			$hashList
+		);
+
+		$this->addPagesToUpdater( $hashList );
+	}
+
+	private function doBuildUniqueTargetLinksHashList( array $targetLinksHashList ) {
+
+		$uniqueTargetLinksHashList = array();
+
+		foreach ( $targetLinksHashList as $targetLinkHash ) {
+
+			list( $title, $namespace, $iw ) = explode( '#', $targetLinkHash, 4 );
+
+			// We make an assumption (as we avoid to query the DB) about that a
+			// query is bind to its subject by simply removing the subobject
+			// identifier (_QUERY*) and creating the base (or root) subject for
+			// the selected target (embedded query)
+			$uniqueTargetLinksHashList[HashBuilder::createHashIdFromSegments( $title, $namespace, $iw )] = true;
+		}
+
+		return array_keys( $uniqueTargetLinksHashList );
+	}
+
+	private function addPagesToUpdater( array $hashList ) {
+		foreach ( $hashList as $hash ) {
+			$this->pageUpdater->addPage(
+				HashBuilder::newDiWikiPageFromHash( $hash )->getTitle()
+			);
+		}
+	}
+
+}

--- a/src/MediaWiki/Jobs/UpdateJob.php
+++ b/src/MediaWiki/Jobs/UpdateJob.php
@@ -106,6 +106,9 @@ class UpdateJob extends JobBase {
 		);
 
 		if ( $lastModified === \WikiPage::factory( $title )->getTimestamp() ) {
+			$pageUpdater = $this->applicationFactory->newMwCollaboratorFactory()->newPageUpdater();
+			$pageUpdater->addPage( $title );
+			$pageUpdater->doPurgeParserCache();
 			return true;
 		}
 

--- a/src/MediaWiki/Specials/SpecialAsyncJobDispatcher.php
+++ b/src/MediaWiki/Specials/SpecialAsyncJobDispatcher.php
@@ -104,6 +104,9 @@ class SpecialAsyncJobDispatcher extends SpecialPage {
 		}
 
 		switch ( $type ) {
+			case 'SMW\ParserCachePurgeJob':
+				$this->runParserCachePurgeJob( $title, $parameters );
+				break;
 			case 'SMW\UpdateJob':
 				$this->runUpdateJob( $title, $parameters );
 				break;
@@ -123,6 +126,22 @@ class SpecialAsyncJobDispatcher extends SpecialPage {
 		print $message;
 		ob_flush();
 		flush();
+	}
+
+	private function runParserCachePurgeJob( $title, $parameters ) {
+
+		$idlist = array();
+
+		if ( !isset( $parameters['idlist'] ) || ( $idlist = explode( '|', $parameters['idlist'] ) ) === array() ) {
+			return;
+		}
+
+		$purgeParserCacheJob = ApplicationFactory::getInstance()->newJobFactory()->newParserCachePurgeJob(
+			$title,
+			array( 'idlist' => $idlist )
+		);
+
+		$purgeParserCacheJob->run();
 	}
 
 	private function runUpdateJob( $title, $parameters ) {

--- a/src/SPARQLStore/SPARQLStore.php
+++ b/src/SPARQLStore/SPARQLStore.php
@@ -367,6 +367,13 @@ class SPARQLStore extends Store {
 	}
 
 	/**
+	 * @since 2.3
+	 */
+	public function getObjectIds() {
+		return $this->baseStore->getObjectIds();
+	}
+
+	/**
 	 * @since  1.9.2
 	 */
 	public function clear() {

--- a/src/SQLStore/ByIdDataItemFinder.php
+++ b/src/SQLStore/ByIdDataItemFinder.php
@@ -69,6 +69,41 @@ class ByIdDataItemFinder {
 	}
 
 	/**
+	 * @since 2.3
+	 *
+	 * @param array $idList
+	 *
+	 * @return DIWikiPage[]
+	 */
+	public function getDataItemPoolHashListFor( array $idList ) {
+
+		$rows = $this->connection->select(
+			\SMWSQLStore3::ID_TABLE,
+			array(
+				'smw_title',
+				'smw_namespace',
+				'smw_iw',
+				'smw_subobject'
+			),
+			array( 'smw_id' => $idList ),
+			__METHOD__
+		);
+
+		$dataItemPoolHashList = array();
+
+		foreach ( $rows as $row ) {
+			$dataItemPoolHashList[] = HashBuilder::createHashIdFromSegments(
+				$row->smw_title,
+				$row->smw_namespace,
+				$row->smw_iw,
+				$row->smw_subobject
+			);
+		}
+
+		return $dataItemPoolHashList;
+	}
+
+	/**
 	 * @since 2.1
 	 *
 	 * @param integer $id

--- a/src/SQLStore/EmbeddedQueryDependencyLinksStore.php
+++ b/src/SQLStore/EmbeddedQueryDependencyLinksStore.php
@@ -1,0 +1,361 @@
+<?php
+
+namespace SMW\SQLStore;
+
+use SMW\Store;
+use SMWQueryResult as QueryResult;
+use SMWSQLStore3;
+use SMW\DIWikiPage;
+use SMW\DIProperty;
+use SMW\HashBuilder;
+use SMW\SemanticData;
+use SMW\ApplicationFactory;
+use SMW\EventHandler;
+use SMW\Query\Language\ConceptDescription;
+use SMW\Query\Language\SomeProperty;
+use SMW\Query\Language\ValueDescription;
+use SMW\Query\Language\Disjunction;
+use SMW\Query\Language\Conjunction;
+use SMW\Query\Language\ClassDescription;
+use SMW\Query\Language\ThingDescription;
+
+/**
+ * @license GNU GPL v2+
+ * @since 2.3
+ *
+ * @author mwjames
+ */
+class EmbeddedQueryDependencyLinksStore {
+
+	/**
+	 * @var Store
+	 */
+	private $store = null;
+
+	/**
+	 * @var Database
+	 */
+	private $connection = null;
+
+	/**
+	 * @var boolean
+	 */
+	private $dependencyLinksTrackingState = true;
+
+	/**
+	 * @since 2.3
+	 *
+	 * @param Store $store
+	 */
+	public function __construct( Store $store ) {
+		$this->store = $store;
+		$this->connection = $this->store->getConnection( 'mw.db' );
+	}
+
+	/**
+	 * @since 2.3
+	 *
+	 * @return boolean
+	 */
+	public function canTrackDependencyLinks() {
+		return $this->dependencyLinksTrackingState;
+	}
+
+	/**
+	 * @since 2.3
+	 *
+	 * @param boolean $dependencyLinksTrackingState
+	 */
+	public function setDependencyLinksTrackingState( $dependencyLinksTrackingState ) {
+		$this->dependencyLinksTrackingState = (bool)$dependencyLinksTrackingState;
+	}
+
+	/**
+	 * @since 2.3
+	 *
+	 * @param CompositePropertyTableDiffIterator $compositePropertyTableDiffIterator
+	 */
+	public function purgeOutdatedTargetLinks( CompositePropertyTableDiffIterator $compositePropertyTableDiffIterator ) {
+
+		if ( !$this->canTrackDependencyLinks() ) {
+			return null;
+		}
+
+		$diff = $compositePropertyTableDiffIterator->getOrderedDiffByTable( 'smw_fpt_ask' );
+
+		// Remove any dependency for queries that are no longer used
+		if ( isset( $diff['smw_fpt_ask']['delete'] ) ) {
+
+			$deleteIdList = array();
+
+			foreach ( $diff['smw_fpt_ask']['delete'] as $delete ) {
+				$deleteIdList[] = $delete['o_id'];
+			}
+
+			wfDebugLog( 'smw' , __METHOD__ . ' remove ' . implode( ',', $deleteIdList ) . "\n" );
+
+			$this->connection->delete(
+				SMWSQLStore3::QUERY_LINKS_TABLE,
+				array(
+					's_id' => $deleteIdList
+				),
+				__METHOD__
+			);
+		}
+
+		// Dispatch any event registered earlier during the QueryResult processing
+		// that didn't match a sid
+		EventHandler::getInstance()->getEventDispatcher()->dispatch(
+			'deferred.embedded.query.dep.update'
+		);
+	}
+
+	/**
+	 * Finds a partial list (given limit and offset) of registered subjects that
+	 * that represent a dependency on something like a subject in a query list,
+	 * a property, or a printrequest.
+	 *
+	 * `s_id` contains the subject id that links to the query that fulfills one
+	 * of the conditions cited above.
+	 *
+	 * Prefetched Ids are turned into a hash list that can later be split into
+	 * chunks to work either in online or batch mode without creating a huge memory
+	 * foothold.
+	 *
+	 * @note Select a list is crucial for performance as any selectRow would /
+	 * single Id select would strain the system on large list connected to a
+	 * query
+	 *
+	 * @since 2.3
+	 *
+	 * @param array $idlist
+	 * @param integer $limit
+	 * @param integer $offset
+	 *
+	 * @return array
+	 */
+	public function findPartialEmbeddedQueryTargetLinksHashListFor( array $idlist, $limit, $offset ) {
+
+		if ( $idlist === array() || !$this->canTrackDependencyLinks() ) {
+			return array();
+		}
+
+		$options = array(
+			'LIMIT'    => $limit,
+			'OFFSET'   => $offset,
+			'GROUP BY' => 's_id',
+			'ORDER BY' => 's_id'
+		);
+
+		$rows = $this->connection->select(
+			SMWSQLStore3::QUERY_LINKS_TABLE,
+			array( 's_id' ),
+			array(
+				'o_id' => $idlist
+			),
+			__METHOD__,
+			$options
+		);
+
+		$targetLinksIdList = array();
+
+		foreach ( $rows as $row ) {
+			$targetLinksIdList[] = $row->s_id;
+		}
+
+		if ( $targetLinksIdList === array() ) {
+			return array();
+		}
+
+		return $this->store->getObjectIds()->getDataItemPoolHashListFor(
+			$targetLinksIdList
+		);
+	}
+
+	/**
+	 * @since 2.3
+	 *
+	 * @param QueryResult $result
+	 */
+	public function addDependenciesFromQueryResult( $result ) {
+
+		if ( !$this->canTrackDependencyLinks() || !$result instanceof QueryResult ) {
+			return null;
+		}
+
+		if ( $result->getQuery() === null || $result->getQuery()->getSubject() === null ) {
+			return null;
+		}
+
+		$subject = $result->getQuery()->getSubject();
+
+		$dependencyList = array(
+			$subject
+		);
+
+		// Find entities described by the query
+		$this->doResolveDependenciesFromDescription(
+			$dependencyList,
+			$result->getQuery()->getDescription()
+		);
+
+		$this->doResolveDependenciesFromPrintRequest(
+			$dependencyList,
+			$result->getQuery()->getDescription()->getPrintRequests()
+		);
+
+		$dependencyList = array_merge(
+			$dependencyList,
+			$result->getResults()
+		);
+
+		$result->reset();
+
+		$hash = $result->getQuery()->getQueryId();
+		$sid = $this->getIdForSubject( $subject, $hash );
+
+		if ( $sid > 0 ) {
+			return $this->updateDependencyList( $sid, $dependencyList );
+		}
+
+		// SID is unknown because the storage update/process has not been finalized
+		// hence an event is registered and triggered once the update process
+		// is being completed
+
+		// PHP 5.3 compatibility
+		$embeddedQueryResultLinksUpdater = $this;
+
+		EventHandler::getInstance()->addCallbackListener( 'deferred.embedded.query.dep.update', function() use ( $embeddedQueryResultLinksUpdater, $dependencyList, $subject, $hash ) {
+
+			wfDebugLog( 'smw', __METHOD__ . ' deferred.embedded.query.dep.update for ' . $hash . "\n" );
+
+			$embeddedQueryResultLinksUpdater->updateDependencyList(
+				$embeddedQueryResultLinksUpdater->getIdForSubject( $subject, $hash ),
+				$dependencyList
+			);
+		} );
+	}
+
+	/**
+	 * @since 2.3
+	 *
+	 * @param integer $sid
+	 * @param array $dependencyList
+	 */
+	public function updateDependencyList( $sid, array $dependencyList ) {
+
+		// Before an insert, delete all matches for the criteria which is cheaper
+		// then doing an individual upsert or selectRow
+		$this->connection->delete(
+			SMWSQLStore3::QUERY_LINKS_TABLE,
+			array(
+				's_id' => $sid
+			),
+			__METHOD__
+		);
+
+		$inserts = array();
+
+		foreach ( $dependencyList as $dependency ) {
+
+			$oid = $this->getIdForSubject( $dependency );
+
+			$inserts[ $sid . $oid ] = array(
+				's_id' => $sid,
+				'o_id' => $oid
+			);
+		}
+
+		if ( $inserts === array() ) {
+			return null;
+		}
+
+		// MW's multi-array insert needs a numeric dimensional array but the key
+		// was used with a hash to avoid duplicate entries hence the re-copy
+		$inserts = array_values( $inserts );
+
+		wfDebugLog( 'smw' , __METHOD__ . ' insert ' . count( $inserts ) . ' to ' . $sid . "\n" );
+
+		$this->connection->insert(
+			SMWSQLStore3::QUERY_LINKS_TABLE,
+			$inserts,
+			__METHOD__
+		);
+	}
+
+	private function doResolveDependenciesFromDescription( &$subjects, $description ) {
+
+		if ( $description instanceof ValueDescription && $description->getDataItem() instanceof DIWikiPage ) {
+			$subjects[] = $description->getDataItem();
+		}
+
+		if ( $description instanceof ConceptDescription ) {
+			$subjects[] = $description->getConcept();
+			$this->doResolveDependenciesFromDescription(
+				$subjects,
+				$this->getConceptDescription( $description->getConcept() )
+			);
+		}
+
+		if ( $description instanceof ClassDescription ) {
+			foreach ( $description->getCategories() as $category ) {
+				$subjects[] = $category;
+			}
+		}
+
+		if ( $description instanceof SomeProperty ) {
+			$this->doResolveDependenciesFromDescription( $subjects, $description->getDescription() );
+			$subjects[] = $description->getProperty()->getDiWikiPage();
+		}
+
+		if ( $description instanceof Conjunction || $description instanceof Disjunction ) {
+			foreach ( $description->getDescriptions() as $description ) {
+				$this->doResolveDependenciesFromDescription( $subjects, $description );
+			}
+		}
+	}
+
+	private function doResolveDependenciesFromPrintRequest( &$subjects, array $printRequests ) {
+
+		foreach ( $printRequests as $printRequest ) {
+			$data = $printRequest->getData();
+
+			if ( $data instanceof \SMWPropertyValue ) {
+				$subjects[] = $data->getDataItem()->getDiWikiPage();
+			}
+
+			// Category
+			if ( $data instanceof \Title ) {
+				$subjects[] = DIWikiPage::newFromTitle( $data );
+			}
+		}
+	}
+
+	public function getIdForSubject( DIWikiPage $subject, $subobjectName = '' ) {
+		return $this->store->getObjectIds()->getSMWPageID(
+			$subject->getDBkey(),
+			$subject->getNamespace(),
+			$subject->getInterwiki(),
+			$subobjectName,
+			false
+		);
+	}
+
+	private function getConceptDescription( DIWikiPage $concept ) {
+
+		$value = $this->store->getSemanticData( $concept )->getPropertyValues(
+			new DIProperty( '_CONC' )
+		);
+
+		if ( $value === null || $value === array() ) {
+			return new ThingDescription();
+		}
+
+		$value = end( $value );
+
+		return ApplicationFactory::getInstance()->newQueryParser()->getQueryDescription(
+			$value->getConceptQuery()
+		);
+	}
+
+}

--- a/src/SQLStore/QueryEngine/QueryEngine.php
+++ b/src/SQLStore/QueryEngine/QueryEngine.php
@@ -290,6 +290,16 @@ class QueryEngine {
 	 */
 	private function getCountQueryResult( Query $query, $rootid ) {
 
+		$queryResult = new QueryResult(
+			$query->getDescription()->getPrintrequests(),
+			$query,
+			array(),
+			$this->store,
+			false
+		);
+
+		$queryResult->setCountValue( 0 );
+
 		$qobj = $this->querySegments[$rootid];
 
 		if ( $qobj->joinfield === '' ) { // empty result, no query needed
@@ -313,7 +323,9 @@ class QueryEngine {
 		$count = $row->count;
 		$db->freeResult( $res );
 
-		return $count;
+		$queryResult->setCountValue( $count );
+
+		return $queryResult;
 	}
 
 	/**

--- a/tests/phpunit/Integration/SemanticMediaWikiProvidedHookInterfaceIntegrationTest.php
+++ b/tests/phpunit/Integration/SemanticMediaWikiProvidedHookInterfaceIntegrationTest.php
@@ -48,7 +48,6 @@ class SemanticMediaWikiProvidedHookInterfaceIntegrationTest extends \PHPUnit_Fra
 			->getMock();
 
 		$store = $this->getMockBuilder( $storeClass )
-			->disableOriginalConstructor()
 			->setMethods( array( 'fetchQueryResult' ) )
 			->getMock();
 
@@ -68,7 +67,6 @@ class SemanticMediaWikiProvidedHookInterfaceIntegrationTest extends \PHPUnit_Fra
 			->getMock();
 
 		$store = $this->getMockBuilder( $storeClass )
-			->disableOriginalConstructor()
 			->setMethods( array( 'fetchQueryResult' ) )
 			->getMock();
 
@@ -96,7 +94,6 @@ class SemanticMediaWikiProvidedHookInterfaceIntegrationTest extends \PHPUnit_Fra
 			->getMock();
 
 		$store = $this->getMockBuilder( $storeClass )
-			->disableOriginalConstructor()
 			->setMethods( array( 'fetchQueryResult' ) )
 			->getMock();
 
@@ -131,7 +128,6 @@ class SemanticMediaWikiProvidedHookInterfaceIntegrationTest extends \PHPUnit_Fra
 			->getMock();
 
 		$store = $this->getMockBuilder( $storeClass )
-			->disableOriginalConstructor()
 			->setMethods( array( 'fetchQueryResult' ) )
 			->getMock();
 

--- a/tests/phpunit/Unit/AsyncJobDispatchManagerTest.php
+++ b/tests/phpunit/Unit/AsyncJobDispatchManagerTest.php
@@ -31,7 +31,7 @@ class AsyncJobDispatchManagerTest extends \PHPUnit_Framework_TestCase {
 	/**
 	 * @dataProvider dispatchableJobProvider
 	 */
-	public function testDispatchFor( $type, $dispatchableAsyncUsageState ) {
+	public function testDispatchFor( $type, $dispatchableAsyncUsageState, $parameters = array() ) {
 
 		$httpRequest = $this->getMockBuilder( '\Onoi\HttpRequest\HttpRequest' )
 			->disableOriginalConstructor()
@@ -42,10 +42,32 @@ class AsyncJobDispatchManagerTest extends \PHPUnit_Framework_TestCase {
 			->will( $this->returnValue( true ) );
 
 		$instance = new AsyncJobDispatchManager( $httpRequest );
+		$instance->reset();
 		$instance->setDispatchableAsyncUsageState( $dispatchableAsyncUsageState );
 
 		$this->assertTrue(
-			$instance->dispatchJobFor( $type , DIWikiPage::newFromText( __METHOD__ )->getTitle() )
+			$instance->dispatchJobFor( $type , DIWikiPage::newFromText( __METHOD__ )->getTitle(), $parameters )
+		);
+	}
+
+	/**
+	 * @dataProvider preliminaryCheckProvider
+	 */
+	public function testPreliminaryCheckForType( $type, $parameters = array() ) {
+
+		$httpRequest = $this->getMockBuilder( '\Onoi\HttpRequest\HttpRequest' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$httpRequest->expects( $this->any() )
+			->method( 'ping' )
+			->will( $this->returnValue( true ) );
+
+		$instance = new AsyncJobDispatchManager( $httpRequest );
+		$instance->reset();
+
+		$this->assertNull(
+			$instance->dispatchJobFor( $type , DIWikiPage::newFromText( __METHOD__ )->getTitle(), $parameters )
 		);
 	}
 
@@ -62,13 +84,30 @@ class AsyncJobDispatchManagerTest extends \PHPUnit_Framework_TestCase {
 		);
 
 		$provider[] = array(
-			'UnknownJob',
-			false
+			'SMW\ParserCachePurgeJob',
+			false,
+			array( 'idlist' => '1|2' )
 		);
 
 		$provider[] = array(
-			'UnknownJob',
-			true
+			'SMW\ParserCachePurgeJob',
+			true,
+			array( 'idlist' => '1|2' )
+		);
+
+		return $provider;
+	}
+
+	public function preliminaryCheckProvider() {
+
+		$provider[] = array(
+			'SMW\ParserCachePurgeJob',
+			array()
+		);
+
+
+		$provider[] = array(
+			'UnknownJob'
 		);
 
 		return $provider;

--- a/tests/phpunit/Unit/SQLStore/ByIdDataItemFinderTest.php
+++ b/tests/phpunit/Unit/SQLStore/ByIdDataItemFinderTest.php
@@ -4,6 +4,7 @@ namespace SMW\Tests\SQLStore;
 
 use SMW\SQLStore\ByIdDataItemFinder;
 use SMW\ApplicationFactory;
+use SMW\DIWikiPage;
 
 /**
  * @covers \SMW\SQLStore\ByIdDataItemFinder
@@ -188,6 +189,37 @@ class ByIdDataItemFinderTest extends \PHPUnit_Framework_TestCase {
 
 		$this->assertNull(
 			$instance->getDataItemForId( 42 )
+		);
+	}
+
+	public function testGetDataItemPoolHashListFor() {
+
+		$row = new \stdClass;
+		$row->smw_title = 'Foo';
+		$row->smw_namespace = 0;
+		$row->smw_iw = '';
+		$row->smw_subobject ='';
+
+		$connection = $this->getMockBuilder( '\SMW\MediaWiki\Database' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$connection->expects( $this->once() )
+			->method( 'select' )
+			->with(
+				$this->anything(),
+				$this->anything(),
+				$this->equalTo( array( 'smw_id' => array( 42 ) ) ) )
+			->will( $this->returnValue( array( $row ) ) );
+
+		$instance = new ByIdDataItemFinder(
+			$connection,
+			$this->cache
+		);
+
+		$this->assertEquals(
+			array( 'Foo#0##' ),
+			$instance->getDataItemPoolHashListFor( array( 42 ) )
 		);
 	}
 

--- a/tests/phpunit/Unit/SQLStore/EmbeddedQueryDependencyLinksStoreTest.php
+++ b/tests/phpunit/Unit/SQLStore/EmbeddedQueryDependencyLinksStoreTest.php
@@ -1,0 +1,277 @@
+<?php
+
+namespace SMW\Tests\SQLStore;
+
+use SMW\SQLStore\EmbeddedQueryDependencyLinksStore;
+use SMW\ApplicationFactory;
+use SMW\SQLStore\SQLStore;
+use SMW\DIWikiPage;
+use SMW\DIProperty;
+use SMW\SemanticData;
+use SMW\Query\Language\SomeProperty;
+use SMW\Query\Language\ValueDescription;
+use SMWQuery as Query;
+
+/**
+ * @covers \SMW\SQLStore\EmbeddedQueryDependencyLinksStore
+ * @group semantic-mediawiki
+ *
+ * @license GNU GPL v2+
+ * @since 2.3
+ *
+ * @author mwjames
+ */
+class EmbeddedQueryDependencyLinksStoreTest extends \PHPUnit_Framework_TestCase {
+
+	private $applicationFactory;
+
+	protected function setUp() {
+		parent::setUp();
+
+		$this->applicationFactory = ApplicationFactory::getInstance();
+
+		$store = $this->getMockBuilder( '\SMW\Store' )
+			->disableOriginalConstructor()
+			->setMethods( array( 'getWikiPageLastModifiedTimestamp' ) )
+			->getMockForAbstractClass();
+
+		$store->expects( $this->any() )
+			->method( 'getWikiPageLastModifiedTimestamp' )
+			->will( $this->returnValue( 0 ) );
+
+		$this->applicationFactory->registerObject( 'Store', $store );
+	}
+
+	protected function tearDown() {
+		$this->applicationFactory->clear();
+
+		parent::tearDown();
+	}
+
+	public function testCanConstruct() {
+
+		$store = $this->getMockBuilder( '\SMW\Store' )
+			->disableOriginalConstructor()
+			->getMockForAbstractClass();
+
+		$this->assertInstanceOf(
+			'\SMW\SQLStore\EmbeddedQueryDependencyLinksStore',
+			new EmbeddedQueryDependencyLinksStore( $store )
+		);
+	}
+
+	public function testPruneOutdatedTargetLinks() {
+
+		$store = $this->getMockBuilder( '\SMW\SQLStore\SQLStore' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$compositePropertyTableDiffIterator = $this->getMockBuilder( '\SMW\SQLStore\CompositePropertyTableDiffIterator' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$instance = new EmbeddedQueryDependencyLinksStore( $store );
+
+		$this->assertTrue(
+			$instance->pruneOutdatedTargetLinks( $compositePropertyTableDiffIterator )
+		);
+	}
+
+	public function testPruneOutdatedTargetLinksBeingDisabled() {
+
+		$store = $this->getMockBuilder( '\SMW\SQLStore\SQLStore' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$compositePropertyTableDiffIterator = $this->getMockBuilder( '\SMW\SQLStore\CompositePropertyTableDiffIterator' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$instance = new EmbeddedQueryDependencyLinksStore( $store );
+		$instance->setEnabledState( false );
+
+		$this->assertNull(
+			$instance->pruneOutdatedTargetLinks( $compositePropertyTableDiffIterator )
+		);
+	}
+
+	public function testBuildParserCachePurgeJobParameters() {
+
+		$store = $this->getMockBuilder( '\SMW\SQLStore\SQLStore' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$compositePropertyTableDiffIterator = $this->getMockBuilder( '\SMW\SQLStore\CompositePropertyTableDiffIterator' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$compositePropertyTableDiffIterator->expects( $this->any() )
+			->method( 'getCombinedIdListForChangedEntities' )
+			->will( $this->returnValue( array( 1, 2 ) ) );
+
+		$instance = new EmbeddedQueryDependencyLinksStore( $store );
+
+		$this->assertEquals(
+			array( 'idlist' => array( 1, 2 ) ),
+			$instance->buildParserCachePurgeJobParametersFrom( $compositePropertyTableDiffIterator )
+		);
+	}
+
+	public function testBuildParserCachePurgeJobParametersBeingDisabled() {
+
+		$store = $this->getMockBuilder( '\SMW\SQLStore\SQLStore' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$compositePropertyTableDiffIterator = $this->getMockBuilder( '\SMW\SQLStore\CompositePropertyTableDiffIterator' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$instance = new EmbeddedQueryDependencyLinksStore( $store );
+		$instance->setEnabledState( false );
+
+		$this->assertEmpty(
+			$instance->buildParserCachePurgeJobParametersFrom( $compositePropertyTableDiffIterator )
+		);
+	}
+
+	public function testFindPartialEmbeddedQueryTargetLinksHashListFor() {
+
+		$row = new \stdClass;
+		$row->s_id = 1001;
+
+		$idTable = $this->getMockBuilder( '\stdClass' )
+			->setMethods( array( 'getDataItemPoolHashListFor' ) )
+			->getMock();
+
+		$idTable->expects( $this->once() )
+			->method( 'getDataItemPoolHashListFor' );
+
+		$connection = $this->getMockBuilder( '\SMW\MediaWiki\Database' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$connection->expects( $this->once() )
+			->method( 'select' )
+			->with(
+				$this->equalTo( \SMWSQLStore3::QUERY_LINKS_TABLE ),
+				$this->anything(),
+				$this->equalTo( array( 'o_id' => array( 42 ) ) ) )
+			->will( $this->returnValue( array( $row ) ) );
+
+		$connectionManager = $this->getMockBuilder( '\SMW\ConnectionManager' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$connectionManager->expects( $this->any() )
+			->method( 'getConnection' )
+			->will( $this->returnValue( $connection ) );
+
+		$store = $this->getMockBuilder( '\SMW\SQLStore\SQLStore' )
+			->disableOriginalConstructor()
+			->setMethods( array( 'getObjectIds' ) )
+			->getMockForAbstractClass();
+
+		$store->setConnectionManager( $connectionManager );
+
+		$store->expects( $this->any() )
+			->method( 'getObjectIds' )
+			->will( $this->returnValue( $idTable ) );
+
+		$instance = new EmbeddedQueryDependencyLinksStore( $store );
+
+		$instance->findPartialEmbeddedQueryTargetLinksHashListFor( array( 42 ), 1, 200 );
+	}
+
+	public function testAddDependenciesFromQueryResultBeingDisabled() {
+
+		$store = $this->getMockBuilder( '\SMW\Store' )
+			->disableOriginalConstructor()
+			->getMockForAbstractClass();
+
+		$instance = new EmbeddedQueryDependencyLinksStore( $store );
+		$instance->setEnabledState( false );
+
+		$this->assertNull(
+			$instance->addDependenciesFromQueryResult( '' )
+		);
+	}
+
+	public function testAddDependenciesFromQueryResult() {
+
+		$description = new SomeProperty(
+			new DIProperty( 'Foo' ),
+			new ValueDescription( DIWikiPage::newFromText( 'Bar' ) )
+		);
+
+		$query = new Query(
+			$description
+		);
+
+		$query->setSubject( DIWikiPage::newFromText( __METHOD__ ) );
+
+		$queryResult = $this->getMockBuilder( '\SMWQueryResult' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$queryResult->expects( $this->once() )
+			->method( 'getResults' )
+			->will( $this->returnValue( array() ) );
+
+		$queryResult->expects( $this->any() )
+			->method( 'getQuery' )
+			->will( $this->returnValue( $query ) );
+
+		$idTable = $this->getMockBuilder( '\stdClass' )
+			->setMethods( array( 'getSMWPageID' ) )
+			->getMock();
+
+		$idTable->expects( $this->any() )
+			->method( 'getSMWPageID' )
+			->will( $this->onConsecutiveCalls( 42, 1001 ) );
+
+		$connection = $this->getMockBuilder( '\SMW\MediaWiki\Database' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$connection->expects( $this->once() )
+			->method( 'delete' )
+			->with(
+				$this->equalTo( \SMWSQLStore3::QUERY_LINKS_TABLE ),
+				$this->equalTo( array( 's_id' => 42 ) ) );
+
+		$insert[] = array(
+			's_id' => 42,
+			'o_id' => 1001
+		);
+
+		$connection->expects( $this->once() )
+			->method( 'insert' )
+			->with(
+				$this->equalTo( \SMWSQLStore3::QUERY_LINKS_TABLE ),
+				$this->equalTo( $insert ) );
+
+		$connectionManager = $this->getMockBuilder( '\SMW\ConnectionManager' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$connectionManager->expects( $this->any() )
+			->method( 'getConnection' )
+			->will( $this->returnValue( $connection ) );
+
+		$store = $this->getMockBuilder( '\SMW\SQLStore\SQLStore' )
+			->disableOriginalConstructor()
+			->setMethods( array( 'getObjectIds' ) )
+			->getMockForAbstractClass();
+
+		$store->setConnectionManager( $connectionManager );
+
+		$store->expects( $this->any() )
+			->method( 'getObjectIds' )
+			->will( $this->returnValue( $idTable ) );
+
+		$instance = new EmbeddedQueryDependencyLinksStore( $store );
+		$instance->addDependenciesFromQueryResult( $queryResult );
+	}
+
+}

--- a/tests/phpunit/includes/MediaWiki/Jobs/ParserCachePurgeJobTest.php
+++ b/tests/phpunit/includes/MediaWiki/Jobs/ParserCachePurgeJobTest.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace SMW\Tests\MediaWiki\Jobs;
+
+use SMW\MediaWiki\Jobs\ParserCachePurgeJob;
+use SMW\ApplicationFactory;
+use SMW\DIWikiPage;
+
+/**
+ * @covers \SMW\MediaWiki\Jobs\ParserCachePurgeJob
+ * @group semantic-mediawiki
+ *
+ * @license GNU GPL v2+
+ * @since 2.3
+ *
+ * @author mwjames
+ */
+class ParserCachePurgeJobTest extends \PHPUnit_Framework_TestCase {
+
+	private $applicationFactory;
+
+	protected function setUp() {
+		parent::setUp();
+
+		$this->applicationFactory = ApplicationFactory::getInstance();
+
+		$store = $this->getMockBuilder( '\SMW\SQLStore\SQLStore' )
+			->getMockForAbstractClass();
+
+		$this->applicationFactory->registerObject( 'Store', $store );
+	}
+
+	protected function tearDown() {
+		$this->applicationFactory->clear();
+
+		parent::tearDown();
+	}
+
+	public function testCanConstruct() {
+
+		$title = $this->getMockBuilder( 'Title' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$this->assertInstanceOf(
+			'SMW\MediaWiki\Jobs\ParserCachePurgeJob',
+			new ParserCachePurgeJob( $title )
+		);
+	}
+
+	public function testJobWithIdList() {
+
+		$subject = DIWikiPage::newFromText( __METHOD__ );
+
+		$parameters = array(
+			'idlist' => array( 1, 2 )
+		);
+
+		$instance = new ParserCachePurgeJob(
+			$subject->getTitle(),
+			$parameters
+		);
+
+		$this->assertTrue(
+			$instance->run()
+		);
+	}
+
+}

--- a/tests/phpunit/includes/MediaWiki/Specials/SpecialAsyncJobDispatcherTest.php
+++ b/tests/phpunit/includes/MediaWiki/Specials/SpecialAsyncJobDispatcherTest.php
@@ -73,7 +73,7 @@ class SpecialAsyncJobDispatcherTest extends \PHPUnit_Framework_TestCase {
 		);
 	}
 
-	public function testValidPostAsyncJob() {
+	public function testValidPostAsyncUpdateJob() {
 
 		if ( version_compare( $GLOBALS['wgVersion'], '1.20', '<' ) ) {
 			$this->markTestSkipped( "Skipping test because of missing method" );
@@ -85,6 +85,42 @@ class SpecialAsyncJobDispatcherTest extends \PHPUnit_Framework_TestCase {
 			'timestamp' => $timestamp,
 			'sessionToken' => SpecialAsyncJobDispatcher::getSessionToken( $timestamp ),
 			'async-job' => 'SMW\UpdateJob|Foo'
+		);
+
+		$instance = new SpecialAsyncJobDispatcher();
+		$instance->disallowToModifyHttpHeader();
+
+		$instance->getContext()->setRequest(
+			new \FauxRequest( $request, true )
+		);
+
+		$this->assertTrue(
+			$instance->execute( '' )
+		);
+	}
+
+	public function testValidPostAsyncParserCachePurgeJob() {
+
+		if ( version_compare( $GLOBALS['wgVersion'], '1.20', '<' ) ) {
+			$this->markTestSkipped( "Skipping test because of missing method" );
+		}
+
+		$store = $this->getMockBuilder( '\SMW\SQLStore\SQLStore' )
+			->getMockForAbstractClass();
+
+		$store->expects( $this->any() )
+			->method( 'getPropertySubjects' )
+			->will( $this->returnValue( array() ) );
+
+		$this->applicationFactory->registerObject( 'Store', $store );
+
+		$timestamp =  time();
+
+		$request = array(
+			'timestamp' => $timestamp,
+			'sessionToken' => SpecialAsyncJobDispatcher::getSessionToken( $timestamp ),
+			'async-job' => 'SMW\ParserCachePurgeJob|Foo',
+			'idlist' => '1|2'
 		);
 
 		$instance = new SpecialAsyncJobDispatcher();


### PR DESCRIPTION
… queries

The biggest obstacle for #ask queries to display refreshed(new) results is the `ParserCache` by which an article decides whether it should be re-parsed or use the data available in cache.

`EmbeddedQueryDependencyLinksStore` tracks known embedded queries and its dependencies. If a dependency (property, subject etc.) has been altered then `ParserCachePurgeJob` will initiate an invalidation of the `ParserCache` for those targets that have an altered dependency.

Once the `ParserCache` for an article has been invalidated the next view to this article will schedule a re-parse including the embedded #ask queries.

Because performance is crucial during an update/edit/delete, only the first 200 (`ParserCachePurgeJob::CHUNK_SIZE`) entities are updated immediately (online) while the rest is added as batch job in order for the job scheduler to run the task on a regular basis.

`ParserCachePurgeJob` is a light job and can (or better should) run at least each 15 min to minimize the amount of possible backlogs.

- `EmbeddedQueryDependencyLinksStore` to track and store dependencies  in the `smw_query_links` table
- `ParserCachePurgeJob` job the handled the invalidation of selected entities
- Changes to queries are detected using the `SMW::SQLStore::AfterDataUpdateComplete`
hook together with the `CompositePropertyTableDiffIterator`.
- Dependencies are resolved for properties, categories, and concepts (non cached)
- Requires to run __`update.php`__

refs #555, #1108 

https://phabricator.wikimedia.org/T109411

![smw-query-links-table](https://cloud.githubusercontent.com/assets/1245473/9419992/27bcb6d4-4861-11e5-8835-47fd0bd747af.png)