### PR TITLE
Skip InTextAnnoationParser when Factbox content is generated

### DIFF
--- a/includes/ContentParser.php
+++ b/includes/ContentParser.php
@@ -43,6 +43,11 @@ class ContentParser {
 	private $enabledToUseContentHandler = true;
 
 	/**
+	 * @var boolean
+	 */
+	private $skipInTextAnnotationParser = false;
+
+	/**
 	 * @note Injecting new Parser() alone will not yield an expected result and
 	 * doing new Parser( $GLOBALS['wgParserConf'] brings no benefits therefore
 	 * we stick to the GLOBAL as fallback if no parser is injected.
@@ -114,6 +119,10 @@ class ContentParser {
 	 */
 	public function getErrors() {
 		return $this->errors;
+	}
+
+	public function skipInTextAnnotationParser() {
+		return $this->skipInTextAnnotationParser = true;
 	}
 
 	/**
@@ -208,7 +217,13 @@ class ContentParser {
 			$user = User::newFromId( $this->getRevision()->getUser() );
 		}
 
-		return new ParserOptions( $user );
+		$parserOptions = new ParserOptions( $user );
+
+		// Use the InterfaceMessage marker to skip InTextAnnotationParser
+		// processing
+		$parserOptions->setInterfaceMessage( $this->skipInTextAnnotationParser );
+
+		return $parserOptions;
 	}
 
 	protected function getRevision() {

--- a/src/Factbox/CachedFactbox.php
+++ b/src/Factbox/CachedFactbox.php
@@ -208,6 +208,7 @@ class CachedFactbox {
 		if ( $factbox->doBuild()->isVisible() ) {
 
 			$contentParser = $applicationFactory->newContentParser( $title );
+			$contentParser->skipInTextAnnotationParser();
 			$contentParser->parse( $factbox->getContent() );
 
 			$text = $contentParser->getOutput()->getText();

--- a/tests/phpunit/Integration/Parser/parser-04-03-intext-disabled-during-factbox-parse.json
+++ b/tests/phpunit/Integration/Parser/parser-04-03-intext-disabled-during-factbox-parse.json
@@ -1,0 +1,37 @@
+{
+	"description": "Test annotations are disabled for Factbox parse",
+	"properties": [
+		{
+			"name": "Has url",
+			"contents": "[[Has type::URL]]"
+		}
+	],
+	"subjects": [
+		{
+			"name": "ShowFactbox",
+			"contents": "[[Has url::http://example.org/api.php?action=ask&query=%5B%5BModification%20date::%2B%5D%5D%7C%3FModification%20date%7Csort%3DModification%20date%7Corder%3Ddesc|api.php?action=ask&query=]] __SHOWFACTBOX__"
+		}
+	],
+	"parser-testcases": [
+		{
+			"about": "#0 don't expected to see a Modification date annotation due to %5B%5BModification%20date::%2B%5D%5D => [[Modification::+]]",
+			"subject": "ShowFactbox",
+			"store": {
+				"semantic-data": {
+					"strict-mode-valuematch": false,
+					"propertyCount": 3,
+					"propertyKeys": [ "_SKEY", "_MDAT", "Has_url" ],
+					"propertyValues": [ "ShowFactbox", "http://example.org/api.php?action=ask&query=%5B%5BModification%20date::%2B%5D%5D%7C%3FModification%20date%7Csort%3DModification%20date%7Corder%3Ddesc" ]
+				}
+			}
+		}
+	],
+	"settings": {
+		"smwgPageSpecialProperties": [ "_MDAT" ]
+	},
+	"meta": {
+		"version": "0.1",
+		"is-incomplete": false,
+		"debug": false
+	}
+}


### PR DESCRIPTION
Avoids that annotations are added by the Factbox content when entities contain something like [[ ... ]] in rendered text elements.

```
[[Has url::http://example.org/api.php?action=ask&query=%5B%5BModification%20date::%2B%5D%5D%7C%3FModification%20date%7Csort%3DModification%20date%7Corder%3Ddesc|api.php?action=ask&query=]]
```