### PR TITLE
Add --shallow-update to rebuildData, refs #1100

### DIFF
--- a/includes/Defines.php
+++ b/includes/Defines.php
@@ -119,11 +119,18 @@ define( 'SMW_SPARQL_QF_SUBP', 4 ); // support for rdfs:subPropertyOf*
 define( 'SMW_SPARQL_QF_SUBC', 8 ); // support for rdfs:subClassOf*
 /**@}*/
 
- /**@{
-  * Constants for VL store
+/**@{
+  * Constants for ValueLookupStore
   */
-define( 'SMW_VL_SD', 1 );
-define( 'SMW_VL_PL', 2 );
-define( 'SMW_VL_PV', 4 );
-define( 'SMW_VL_PS', 8 );
+define( 'SMW_VL_SD', 1 ); // enables ValueLookupStore::getSemanticData
+define( 'SMW_VL_PL', 2 ); // enables ValueLookupStore::getProperties
+define( 'SMW_VL_PV', 4 ); // enables ValueLookupStore::getPropertyValues
+define( 'SMW_VL_PS', 8 ); // enables ValueLookupStore::getPropertySubject
+/**@}*/
+
+/**@{
+  * Constants for UpdateJob ParserMode
+  */
+define( 'SMW_UJ_PM_NP', 2 );    // use a new parser
+define( 'SMW_UJ_PM_CLASTMDATE', 4 ); // compare last modified
 /**@}*/

--- a/includes/storage/SMW_Store.php
+++ b/includes/storage/SMW_Store.php
@@ -131,6 +131,27 @@ abstract class Store {
 	}
 
 	/**
+	 * Convenience method to find last modified MW timestamp for a subject that
+	 * has been added using the storage-engine.
+	 *
+	 * @since 2.3
+	 *
+	 * @param DIWikiPage $wikiPage
+	 *
+	 * @return integer
+	 */
+	public function getWikiPageLastModifiedTimestamp( DIWikiPage $wikiPage ) {
+
+		$dataItems = $this->getPropertyValues( $wikiPage, new DIProperty( '_MDAT' ) );
+
+		if ( $dataItems !== array() ) {
+			return end( $dataItems )->getMwTimestamp( TS_MW );
+		}
+
+		return 0;
+	}
+
+	/**
 	 * Convenience method to find the redirect target of a DIWikiPage
 	 * or DIProperty object. Returns a dataitem of the same type that
 	 * the input redirects to, or the input itself if there is no redirect.

--- a/includes/storage/SQLStore/SMW_SQLStore3_SetupHandlers.php
+++ b/includes/storage/SQLStore/SMW_SQLStore3_SetupHandlers.php
@@ -107,6 +107,7 @@ class SMWSQLStore3SetupHandlers implements MessageReporter {
 			array(
 				'smw_id',
 				'smw_id,smw_sortkey',
+				'smw_iw', // iw match lookup
 				'smw_title,smw_namespace,smw_iw,smw_subobject', // id lookup
 				'smw_sortkey' // select by sortkey (range queries)
 			),

--- a/includes/storage/SQLStore/SMW_SQLStore3_Writers.php
+++ b/includes/storage/SQLStore/SMW_SQLStore3_Writers.php
@@ -720,14 +720,10 @@ class SMWSQLStore3Writers {
 		// Set 'pm' (parser-mode) to 2 indicating to use a new Parser
 		// instance when running the job
 
-		$jobs[] = new UpdateJob( $newTitle, array(
-			'pm' => 2
-		) );
+		$jobs[] = new UpdateJob( $newTitle, array( 'pm' => SMW_UJ_PM_NP ) );
 
 		if ( $redirectId != 0 ) {
-			$jobs[] = new UpdateJob( $oldTitle, array(
-				'pm' => 2
-			) );
+			$jobs[] = new UpdateJob( $oldTitle, array( 'pm' => SMW_UJ_PM_NP ) );
 		}
 
 		$db->onTransactionIdle( function() use ( $jobs ) {

--- a/maintenance/rebuildData.php
+++ b/maintenance/rebuildData.php
@@ -5,6 +5,7 @@ namespace SMW\Maintenance;
 use Onoi\MessageReporter\MessageReporterFactory;
 use SMW\ApplicationFactory;
 use SMW\StoreFactory;
+use SMW\Options;
 
 $basePath = getenv( 'MW_INSTALL_PATH' ) !== false ? getenv( 'MW_INSTALL_PATH' ) : __DIR__ . '/../../..';
 
@@ -33,7 +34,6 @@ require_once $basePath . '/maintenance/Maintenance.php';
  * -v           Be verbose about the progress.
  * -c           Will refresh only category pages (and other explicitly named namespaces)
  * -p           Will refresh only property pages (and other explicitly named namespaces)
- * -t           Will refresh only type pages (and other explicitly named namespaces)
  * --page=<pagelist> will refresh only the pages of the given names, with | used as a separator.
  *              Example: --page="Page 1|Page 2" refreshes Page 1 and Page 2
  *              Options -s, -e, -n, --startidfile, -c, -p, -t are ignored if --page is given.
@@ -83,9 +83,9 @@ class RebuildData extends \Maintenance {
 		$this->addOption( 'v', 'Be verbose about the progress', false );
 		$this->addOption( 'c', 'Will refresh only category pages (and other explicitly named namespaces)', false );
 		$this->addOption( 'p', 'Will refresh only property pages (and other explicitly named namespaces)', false );
-		$this->addOption( 't', 'Will refresh only type pages (and other explicitly named namespaces)', false );
 
 		$this->addOption( 'skip-properties', 'Skip the default properties rebuild (only recommended when successive build steps are used)', false );
+		$this->addOption( 'shallow-update', 'Skip processing of entitites that compare to the last known revision date', false );
 
 		$this->addOption( 'page', '<pagelist> Will refresh only the pages of the given names, with | used as a separator. ' .
 								'Example: --page "Page 1|Page 2" refreshes Page 1 and Page 2 Options -s, -e, -n, ' .
@@ -136,7 +136,7 @@ class RebuildData extends \Maintenance {
 
 		$dataRebuilder = $maintenanceFactory->newDataRebuilder( $store );
 		$dataRebuilder->setMessageReporter( $reporter );
-		$dataRebuilder->setParameters( $this->mOptions );
+		$dataRebuilder->setOptions( new Options( $this->mOptions ) );
 
 		$result = $this->checkForRebuildState( $dataRebuilder->rebuild() );
 

--- a/src/Options.php
+++ b/src/Options.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace SMW;
+
+use InvalidArgumentException;
+
+/**
+ * @license GNU GPL v2+
+ * @since 2.3
+ *
+ * @author mwjames
+ */
+class Options {
+
+	/**
+	 * @var array
+	 */
+	private $options = array();
+
+	/**
+	 * @since 2.3
+	 */
+	public function __construct( array $options = array() ) {
+		$this->options = $options;
+	}
+
+	/**
+	 * @since 2.3
+	 *
+	 * @param string $key
+	 * @param mixed $value
+	 */
+	public function set( $key, $value ) {
+		$this->options[$key] = $value;
+	}
+
+	/**
+	 * @since 2.3
+	 *
+	 * @param string $key
+	 *
+	 * @return boolean
+	 */
+	public function has( $key ) {
+		return isset( $this->options[$key] ) || array_key_exists( $key, $this->options );
+	}
+
+	/**
+	 * @since 2.3
+	 *
+	 * @param string $key
+	 *
+	 * @return string
+	 * @throws InvalidArgumentException
+	 */
+	public function get( $key ) {
+
+		if ( $this->has( $key ) ) {
+			return $this->options[$key];
+		}
+
+		throw new InvalidArgumentException( "{$key} is an unregistered option" );
+	}
+
+}

--- a/src/SQLStore/ByIdDataRebuildDispatcher.php
+++ b/src/SQLStore/ByIdDataRebuildDispatcher.php
@@ -29,9 +29,9 @@ class ByIdDataRebuildDispatcher {
 	private $store = null;
 
 	/**
-	 * @var boolean
+	 * @var integer
 	 */
-	private $useUpdateJobParseMode = true;
+	private $updateJobParseMode;
 
 	/**
 	 * @var boolean
@@ -65,10 +65,10 @@ class ByIdDataRebuildDispatcher {
 	/**
 	 * @since 2.3
 	 *
-	 * @param boolean $updateJobParseMode
+	 * @param integer $updateJobParseMode
 	 */
-	public function setUpdateJobToUseParseMode( $updateJobParseMode ) {
-		$this->useUpdateJobParseMode = (bool)$updateJobParseMode;
+	public function setUpdateJobParseMode( $updateJobParseMode ) {
+		$this->updateJobParseMode = $updateJobParseMode;
 	}
 
 	/**
@@ -316,7 +316,7 @@ class ByIdDataRebuildDispatcher {
 	}
 
 	private function newUpdateJob( $title ) {
-		return new UpdateJob( $title, array( 'pm' => $this->useUpdateJobParseMode ) );
+		return new UpdateJob( $title, array( 'pm' => $this->updateJobParseMode ) );
 	}
 
 }

--- a/tests/phpunit/Unit/OptionsTest.php
+++ b/tests/phpunit/Unit/OptionsTest.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace SMW\Tests;
+
+use SMW\Options;
+
+/**
+ * @covers \SMW\Options
+ * @group semantic-mediawiki
+ *
+ * @license GNU GPL v2+
+ * @since   1.2
+ *
+ * @author mwjames
+ */
+class OptionsTest extends \PHPUnit_Framework_TestCase {
+
+	public function testCanConstruct() {
+
+		$this->assertInstanceOf(
+			'\SMW\Options',
+			new Options()
+		);
+	}
+
+	public function testAddOption() {
+
+		$instance = new Options();
+
+		$this->assertFalse(
+			$instance->has( 'Foo' )
+		);
+
+		$instance->set( 'Foo', 42 );
+
+		$this->assertEquals(
+			42,
+			$instance->get( 'Foo' )
+		);
+	}
+
+	public function testUnregisteredKeyThrowsException() {
+
+		$instance = new Options();
+
+		$this->setExpectedException( 'InvalidArgumentException' );
+		$instance->get( 'Foo' );
+	}
+
+}

--- a/tests/phpunit/Unit/SQLStore/ByIdDataRebuildDispatcherTest.php
+++ b/tests/phpunit/Unit/SQLStore/ByIdDataRebuildDispatcherTest.php
@@ -29,7 +29,12 @@ class ByIdDataRebuildDispatcherTest extends \PHPUnit_Framework_TestCase {
 
 		$store = $this->getMockBuilder( '\SMW\Store' )
 			->disableOriginalConstructor()
+			->setMethods( array( 'getWikiPageLastModifiedTimestamp' ) )
 			->getMockForAbstractClass();
+
+		$store->expects( $this->any() )
+			->method( 'getWikiPageLastModifiedTimestamp' )
+			->will( $this->returnValue( 0 ) );
 
 		$this->applicationFactory->registerObject( 'Store', $store );
 		$this->applicationFactory->getSettings()->set( 'smwgCacheType', 'hash' );
@@ -81,9 +86,11 @@ class ByIdDataRebuildDispatcherTest extends \PHPUnit_Framework_TestCase {
 			->will( $this->returnValue( $connection ) );
 
 		$instance = new ByIdDataRebuildDispatcher( $store );
-		$instance->setIterationLimit( 1 );
-		$instance->setUpdateJobToUseJobQueueScheduler( false );
 
+		$instance->setIterationLimit( 1 );
+		$instance->setUpdateJobParseMode( SMW_UJ_PM_CLASTMDATE );
+
+		$instance->setUpdateJobToUseJobQueueScheduler( false );
 		$instance->dispatchRebuildFor( $id );
 
 		$this->assertSame(

--- a/tests/phpunit/includes/Maintenance/DataRebuilderTest.php
+++ b/tests/phpunit/includes/Maintenance/DataRebuilderTest.php
@@ -3,12 +3,11 @@
 namespace SMW\Tests\Maintenance;
 
 use SMW\Maintenance\DataRebuilder;
-
+use SMW\Options;
 use Title;
 
 /**
  * @covers \SMW\Maintenance\DataRebuilder
- *
  * @group semantic-mediawiki
  * @group medium
  *
@@ -108,9 +107,9 @@ class DataRebuilderTest extends \PHPUnit_Framework_TestCase {
 		$instance = new DataRebuilder( $store, $titleCreator );
 
 		// Needs an end otherwise phpunit is caught up in an infinite loop
-		$instance->setParameters( array(
+		$instance->setOptions( new Options( array(
 			'e' => 1
-		) );
+		) ) );
 
 		$this->assertTrue( $instance->rebuild() );
 	}
@@ -154,11 +153,11 @@ class DataRebuilderTest extends \PHPUnit_Framework_TestCase {
 
 		$instance = new DataRebuilder( $store, $titleCreator );
 
-		$instance->setParameters( array(
+		$instance->setOptions( new Options( array(
 			'e' => 1,
 			'f' => true,
 			'verbose' => false
-		) );
+		) ) );
 
 		$this->assertTrue( $instance->rebuild() );
 	}
@@ -197,11 +196,11 @@ class DataRebuilderTest extends \PHPUnit_Framework_TestCase {
 
 		$instance = new DataRebuilder( $store, $titleCreator );
 
-		$instance->setParameters( array(
+		$instance->setOptions( new Options( array(
 			's' => 2,
 			'n' => 5,
 			'verbose' => false
-		) );
+		) ) );
 
 		$this->assertTrue( $instance->rebuild() );
 	}
@@ -247,9 +246,9 @@ class DataRebuilderTest extends \PHPUnit_Framework_TestCase {
 
 		$instance = new DataRebuilder( $store, $titleCreator );
 
-		$instance->setParameters( array(
+		$instance->setOptions( new Options( array(
 			'query' => '[[Category:Foo]]'
-		) );
+		) ) );
 
 		$this->assertTrue( $instance->rebuild() );
 	}
@@ -286,9 +285,9 @@ class DataRebuilderTest extends \PHPUnit_Framework_TestCase {
 
 		$instance = new DataRebuilder( $store, $titleCreator );
 
-		$instance->setParameters( array(
+		$instance->setOptions( new Options( array(
 			'c' => true
-		) );
+		) ) );
 
 		$this->assertTrue( $instance->rebuild() );
 	}
@@ -326,9 +325,9 @@ class DataRebuilderTest extends \PHPUnit_Framework_TestCase {
 
 		$instance = new DataRebuilder( $store, $titleCreator );
 
-		$instance->setParameters( array(
+		$instance->setOptions( new Options( array(
 			'p' => true
-		) );
+		) ) );
 
 		$this->assertTrue( $instance->rebuild() );
 	}
@@ -365,9 +364,9 @@ class DataRebuilderTest extends \PHPUnit_Framework_TestCase {
 
 		$instance = new DataRebuilder( $store, $titleCreator );
 
-		$instance->setParameters( array(
+		$instance->setOptions( new Options( array(
 			'page'  => 'Main page|Some other page|Help:Main page|Main page'
-		) );
+		) ) );
 
 		$this->assertTrue( $instance->rebuild() );
 


### PR DESCRIPTION
The `--shallow-update` option allows to only parse those entities that have a different last modified timestamp compared to that of the last revision.

This enables to run `rebuildData` updates on deleted, redirects, and other out of sync entities and reduces the runtime and memory usage considerably.
- If `--shallow-update` is not used then all pages will be parsed (as before) using the `Parser::parse`.
- `smw_iw` field was added as index to `smw_object_ids` in order for the DB select to use an appropriate index selection. To make us of `smw_iw` index, `update.php` is required to be executed,
- option `-t` was removed from `rebuildData`  since `Type` pages are no longer used
refs #1100