### PR TITLE
Extend ~* search pattern for _ema/_tel

### DIFF
--- a/includes/datavalues/SMW_DataValue.php
+++ b/includes/datavalues/SMW_DataValue.php
@@ -134,6 +134,14 @@ abstract class SMWDataValue {
 	private $extraneousFunctions = array();
 
 	/**
+	 * Indicates whether a value is being used by a query condition or not which
+	 * can lead to a modified validation of a value.
+	 *
+	 * @var boolean
+	 */
+	protected $isUsedByQueryCondition = false;
+
+	/**
 	 * Constructor.
 	 *
 	 * @param string $typeid
@@ -202,6 +210,15 @@ abstract class SMWDataValue {
 		$this->mErrors = $this->m_infolinks = array();
 		$this->mHasErrors = $this->mHasSearchLink = $this->mHasServiceLinks = $this->m_caption = false;
 		return $this->loadDataItem( $dataItem );
+	}
+
+	/**
+	 * @since 2.3
+	 *
+	 * @param boolean $usedByQueryCondition
+	 */
+	public function setQueryConditionUsage( $usedByQueryCondition ){
+		$this->isUsedByQueryCondition = (bool)$usedByQueryCondition;
 	}
 
 	/**

--- a/includes/query/SMW_QueryParser.php
+++ b/includes/query/SMW_QueryParser.php
@@ -398,6 +398,7 @@ class SMWQueryParser {
 					} ///NOTE: at this point, we normally already read one more chunk behind the value
 
 					$dv = \SMW\DataValueFactory::getInstance()->newPropertyObjectValue( $property->getDataItem() );
+					$dv->setQueryConditionUsage( true );
 					$vd = $dv->getQueryDescription( $value );
 					$innerdesc = $this->addDescription( $innerdesc, $vd, false );
 					$this->errorMessages = $this->errorMessages + $dv->getErrors();
@@ -458,6 +459,7 @@ class SMWQueryParser {
 				}
 			} else {
 				$value = \SMW\DataValueFactory::getInstance()->newTypeIDValue( '_wpg', $chunk );
+				$value->setQueryConditionUsage( true );
 				if ( $value->isValid() ) {
 					$result = $this->addDescription( $result, new ValueDescription( $value->getDataItem(), null ), false );
 				}

--- a/tests/phpunit/Integration/Parser/parser-04-03-intext-disabled-during-factbox-parse.json
+++ b/tests/phpunit/Integration/Parser/parser-04-03-intext-disabled-during-factbox-parse.json
@@ -23,6 +23,11 @@
 					"propertyKeys": [ "_SKEY", "_MDAT", "Has_url" ],
 					"propertyValues": [ "ShowFactbox", "http://example.org/api.php?action=ask&query=%5B%5BModification%20date::%2B%5D%5D%7C%3FModification%20date%7Csort%3DModification%20date%7Corder%3Ddesc" ]
 				}
+			},
+			"expected-output": {
+				"to-contain": [
+					"href=\"http://example.org/api.php?action=ask&amp;query=%5B%5BModification%20date::%2B%5D%5D%7C%3FModification%20date%7Csort%3DModification%20date%7Corder%3Ddesc\">api.php?action=ask&amp;query=</a>"
+				]
 			}
 		}
 	],

--- a/tests/phpunit/Integration/Query/Fixtures/query-07-02-other-uri-search-pattern.json
+++ b/tests/phpunit/Integration/Query/Fixtures/query-07-02-other-uri-search-pattern.json
@@ -1,0 +1,128 @@
+{
+	"description": "Other uri format annotation/search pattern testing",
+	"properties": [
+		{
+			"name": "Has telephone number",
+			"contents": "[[Has type::Telephone number]]"
+		},
+		{
+			"name": "Has email",
+			"contents": "[[Has type::Email]]"
+		}
+	],
+	"subjects": [
+		{
+			"name": "Page/07/02/1",
+			"contents": "[[Has telephone number::+1-2012-555-0123]]"
+		},
+		{
+			"name": "Page/07/02/2",
+			"contents": "[[Has telephone number::+1-2012-555-5555]]"
+		},
+		{
+			"name": "Page/07/02/3",
+			"contents": "[[Has email::Lorem@ipsum.org]]"
+		},
+		{
+			"name": "Page/07/02/4",
+			"contents": "[[Has email::Lorem@123.org]]"
+		}
+	],
+	"query-testcases": [
+		{
+			"about": "#0",
+			"condition": "[[Has telephone number::+1-2012-555-5555]]",
+			"printouts" : [ "Has telephone number" ],
+			"parameters" : {
+				"limit" : "10"
+			},
+			"queryresult": {
+				"count": "1",
+				"results": [
+					"Page/07/02/2#0##"
+				],
+				"datavalues": [
+					{
+						"property": "Has telephone number",
+						"value": "tel:+1-2012-555-5555"
+					}
+				]
+			}
+		},
+		{
+			"about": "#1 search phone number that contains 123",
+			"condition": "[[Has telephone number::~*123*]]",
+			"printouts" : [ "Has telephone number" ],
+			"parameters" : {
+				"limit" : "10"
+			},
+			"queryresult": {
+				"count": "1",
+				"results": [
+					"Page/07/02/1#0##"
+				],
+				"datavalues": [
+					{
+						"property": "Has telephone number",
+						"value": "tel:+1-2012-555-0123"
+					}
+				]
+			}
+		},
+		{
+			"about": "#2 search phone number that contains 555",
+			"condition": "[[Has telephone number::~*555*]]",
+			"printouts" : [],
+			"parameters" : {
+				"limit" : "10"
+			},
+			"queryresult": {
+				"count": "2",
+				"results": [
+					"Page/07/02/1#0##",
+					"Page/07/02/2#0##"
+				]
+			}
+		},
+		{
+			"about": "#3",
+			"condition": "[[Has email::Lorem@ipsum.org]]",
+			"printouts" : [],
+			"parameters" : {
+				"limit" : "10"
+			},
+			"queryresult": {
+				"count": "1",
+				"results": [
+					"Page/07/02/3#0##"
+				]
+			}
+		},
+		{
+			"about": "#4",
+			"condition": "[[Has email::~*123.org]]",
+			"printouts" : [ "Has email" ],
+			"parameters" : {
+				"limit" : "10"
+			},
+			"queryresult": {
+				"count": "1",
+				"results": [
+					"Page/07/02/4#0##"
+				],
+				"datavalues": [
+					{
+						"property": "Has email",
+						"value": "mailto:Lorem@123.org"
+					}
+				]
+			}
+		}
+	],
+	"settings": {},
+	"meta": {
+		"version": "0.1",
+		"is-incomplete": false,
+		"debug": false
+	}
+}

--- a/tests/phpunit/includes/DataValues/UriValueTest.php
+++ b/tests/phpunit/includes/DataValues/UriValueTest.php
@@ -165,6 +165,7 @@ class UriValueTest extends \PHPUnit_Framework_TestCase {
 			)
 		);
 
+		#3
 		$provider[] = array(
 			'http://example.org/aaa/bbb#ccc',
 			'Foo',
@@ -178,123 +179,139 @@ class UriValueTest extends \PHPUnit_Framework_TestCase {
 			)
 		);
 
-		//
+		#4
 		$provider[] = array(
-			'http://example.org/aaa%2fbbb#ccc',
+			'http://example.org/aaa%2Fbbb#ccc',
 			false,
 			null,
 			array(
-				'wikiValue'     => 'http://example.org/aaa%2fbbb#ccc',
-				'longHTMLText'  => 'http://example.org/aaa/bbb#ccc',
-				'longWikiText'  => 'http://example.org/aaa/bbb#ccc',
-				'shortHTMLText' => 'http://example.org/aaa/bbb#ccc',
-				'shortWikiText' => 'http://example.org/aaa/bbb#ccc'
+				'wikiValue'     => 'http://example.org/aaa%2Fbbb#ccc',
+				'longHTMLText'  => 'http://example.org/aaa%2Fbbb#ccc',
+				'longWikiText'  => 'http://example.org/aaa%2Fbbb#ccc',
+				'shortHTMLText' => 'http://example.org/aaa%2Fbbb#ccc',
+				'shortWikiText' => 'http://example.org/aaa%2Fbbb#ccc'
 			)
 		);
 
 		$provider[] = array(
-			'http://example.org/aaa%2fbbb#ccc',
+			'http://example.org/aaa%2Fbbb#ccc',
 			'Foo',
 			null,
 			array(
-				'wikiValue'     => 'http://example.org/aaa%2fbbb#ccc',
-				'longHTMLText'  => 'http://example.org/aaa/bbb#ccc',
-				'longWikiText'  => 'http://example.org/aaa/bbb#ccc',
+				'wikiValue'     => 'http://example.org/aaa%2Fbbb#ccc',
+				'longHTMLText'  => 'http://example.org/aaa%2Fbbb#ccc',
+				'longWikiText'  => 'http://example.org/aaa%2Fbbb#ccc',
 				'shortHTMLText' => 'Foo',
 				'shortWikiText' => 'Foo'
 			)
 		);
 
+		#6
 		$provider[] = array(
-			'http://example.org/aaa%2fbbb#ccc',
+			'http://example.org/aaa%2Fbbb#ccc',
 			false,
 			$linker,
 			array(
-				'wikiValue'     => 'http://example.org/aaa%2fbbb#ccc',
-				'longHTMLText'  => '<a class="external"' . $noFollowAttribute . ' href="http://example.org/aaa/bbb#ccc">http://example.org/aaa/bbb#ccc</a>',
-				'longWikiText'  => '[http://example.org/aaa/bbb#ccc http://example.org/aaa/bbb#ccc]',
-				'shortHTMLText' => '<a class="external"' . $noFollowAttribute . ' href="http://example.org/aaa/bbb#ccc">http://example.org/aaa/bbb#ccc</a>',
-				'shortWikiText' => '[http://example.org/aaa/bbb#ccc http://example.org/aaa/bbb#ccc]'
+				'wikiValue'     => 'http://example.org/aaa%2Fbbb#ccc',
+				'longHTMLText'  => '<a class="external"' . $noFollowAttribute . ' href="http://example.org/aaa/bbb#ccc">http://example.org/aaa%2Fbbb#ccc</a>',
+				'longWikiText'  => '[http://example.org/aaa/bbb#ccc http://example.org/aaa%2Fbbb#ccc]',
+				'shortHTMLText' => '<a class="external"' . $noFollowAttribute . ' href="http://example.org/aaa/bbb#ccc">http://example.org/aaa%2Fbbb#ccc</a>',
+				'shortWikiText' => '[http://example.org/aaa/bbb#ccc http://example.org/aaa%2Fbbb#ccc]'
 			)
 		);
 
 		$provider[] = array(
-			'http://example.org/aaa%2fbbb#ccc',
+			'http://example.org/aaa%2Fbbb#ccc',
 			'Foo',
 			$linker,
 			array(
-				'wikiValue'     => 'http://example.org/aaa%2fbbb#ccc',
-				'longHTMLText'  => '<a class="external"' . $noFollowAttribute . ' href="http://example.org/aaa/bbb#ccc">http://example.org/aaa/bbb#ccc</a>',
-				'longWikiText'  => '[http://example.org/aaa/bbb#ccc http://example.org/aaa/bbb#ccc]',
+				'wikiValue'     => 'http://example.org/aaa%2Fbbb#ccc',
+				'longHTMLText'  => '<a class="external"' . $noFollowAttribute . ' href="http://example.org/aaa/bbb#ccc">http://example.org/aaa%2Fbbb#ccc</a>',
+				'longWikiText'  => '[http://example.org/aaa/bbb#ccc http://example.org/aaa%2Fbbb#ccc]',
 				'shortHTMLText' => '<a class="external"' . $noFollowAttribute . ' href="http://example.org/aaa/bbb#ccc">Foo</a>',
 				'shortWikiText' => '[http://example.org/aaa/bbb#ccc Foo]',
 			)
 		);
 
-		// UTF-8 encoded string
+		#8 UTF-8 encoded string
+		$provider[] = array(
+			'http://example.org/ようこそ--23-7B-7D',
+			false,
+			null,
+			array(
+				'wikiValue'     => 'http://example.org/ようこそ--23-7B-7D',
+				'longHTMLText'  => 'http://example.org/ようこそ--23-7B-7D',
+				'longWikiText'  => 'http://example.org/ようこそ--23-7B-7D',
+				'shortHTMLText' => 'http://example.org/ようこそ--23-7B-7D',
+				'shortWikiText' => 'http://example.org/ようこそ--23-7B-7D'
+			)
+		);
+
+		#9
 		$provider[] = array(
 			'http://example.org/%E3%82%88%E3%81%86%E3%81%93%E3%81%9D-23-7B-7D',
 			false,
 			null,
 			array(
 				'wikiValue'     => 'http://example.org/%E3%82%88%E3%81%86%E3%81%93%E3%81%9D-23-7B-7D',
-				'longHTMLText'  => 'http://example.org/ようこそ-23-7B-7D',
-				'longWikiText'  => 'http://example.org/ようこそ-23-7B-7D',
-				'shortHTMLText' => 'http://example.org/ようこそ-23-7B-7D',
-				'shortWikiText' => 'http://example.org/ようこそ-23-7B-7D'
+				'longHTMLText'  => 'http://example.org/%E3%82%88%E3%81%86%E3%81%93%E3%81%9D-23-7B-7D',
+				'longWikiText'  => 'http://example.org/%E3%82%88%E3%81%86%E3%81%93%E3%81%9D-23-7B-7D',
+				'shortHTMLText' => 'http://example.org/%E3%82%88%E3%81%86%E3%81%93%E3%81%9D-23-7B-7D',
+				'shortWikiText' => 'http://example.org/%E3%82%88%E3%81%86%E3%81%93%E3%81%9D-23-7B-7D'
 			)
 		);
 
 		$provider[] = array(
 			'http://example.org/%E3%82%88%E3%81%86%E3%81%93%E3%81%9D-23-7B-7D',
-			'%20%E4%B8%80%E4%BA%8C%E4%B8%89',
+			'一二三',
 			null,
 			array(
 				'wikiValue'     => 'http://example.org/%E3%82%88%E3%81%86%E3%81%93%E3%81%9D-23-7B-7D',
-				'longHTMLText'  => 'http://example.org/ようこそ-23-7B-7D',
-				'longWikiText'  => 'http://example.org/ようこそ-23-7B-7D',
+				'longHTMLText'  => 'http://example.org/%E3%82%88%E3%81%86%E3%81%93%E3%81%9D-23-7B-7D',
+				'longWikiText'  => 'http://example.org/%E3%82%88%E3%81%86%E3%81%93%E3%81%9D-23-7B-7D',
 				'shortHTMLText' => '一二三',
 				'shortWikiText' => '一二三'
 			)
 		);
 
+		# 11
 		$provider[] = array(
 			'http://example.org/%E3%82%88%E3%81%86%E3%81%93%E3%81%9D-23-7B-7D',
 			false,
 			$linker,
 			array(
 				'wikiValue'     => 'http://example.org/%E3%82%88%E3%81%86%E3%81%93%E3%81%9D-23-7B-7D',
-				'longHTMLText'  => '<a class="external"' . $noFollowAttribute . ' href="http://example.org/ようこそ-23-7B-7D">http://example.org/ようこそ-23-7B-7D</a>',
-				'longWikiText'  => '[http://example.org/ようこそ-23-7B-7D http://example.org/ようこそ-23-7B-7D]',
-				'shortHTMLText' => '<a class="external"' . $noFollowAttribute . ' href="http://example.org/ようこそ-23-7B-7D">http://example.org/ようこそ-23-7B-7D</a>',
-				'shortWikiText' => '[http://example.org/ようこそ-23-7B-7D http://example.org/ようこそ-23-7B-7D]'
+				'longHTMLText'  => '<a class="external"' . $noFollowAttribute . ' href="http://example.org/%E3%82%88%E3%81%86%E3%81%93%E3%81%9D-23-7B-7D">http://example.org/%E3%82%88%E3%81%86%E3%81%93%E3%81%9D-23-7B-7D</a>',
+				'longWikiText'  => '[http://example.org/%E3%82%88%E3%81%86%E3%81%93%E3%81%9D-23-7B-7D http://example.org/%E3%82%88%E3%81%86%E3%81%93%E3%81%9D-23-7B-7D]',
+				'shortHTMLText' => '<a class="external"' . $noFollowAttribute . ' href="http://example.org/%E3%82%88%E3%81%86%E3%81%93%E3%81%9D-23-7B-7D">http://example.org/%E3%82%88%E3%81%86%E3%81%93%E3%81%9D-23-7B-7D</a>',
+				'shortWikiText' => '[http://example.org/%E3%82%88%E3%81%86%E3%81%93%E3%81%9D-23-7B-7D http://example.org/%E3%82%88%E3%81%86%E3%81%93%E3%81%9D-23-7B-7D]'
 			)
 		);
 
 		$provider[] = array(
 			'http://example.org/%E3%82%88%E3%81%86%E3%81%93%E3%81%9D-23-7B-7D',
-			'%20%E4%B8%80%E4%BA%8C%E4%B8%89',
+			'一二三',
 			$linker,
 			array(
 				'wikiValue'     => 'http://example.org/%E3%82%88%E3%81%86%E3%81%93%E3%81%9D-23-7B-7D',
-				'longHTMLText'  => '<a class="external"' . $noFollowAttribute . ' href="http://example.org/ようこそ-23-7B-7D">http://example.org/ようこそ-23-7B-7D</a>',
-				'longWikiText'  => '[http://example.org/ようこそ-23-7B-7D http://example.org/ようこそ-23-7B-7D]',
-				'shortHTMLText' => '<a class="external"' . $noFollowAttribute . ' href="http://example.org/ようこそ-23-7B-7D">一二三</a>',
-				'shortWikiText' => '[http://example.org/ようこそ-23-7B-7D 一二三]',
+				'longHTMLText'  => '<a class="external"' . $noFollowAttribute . ' href="http://example.org/%E3%82%88%E3%81%86%E3%81%93%E3%81%9D-23-7B-7D">http://example.org/%E3%82%88%E3%81%86%E3%81%93%E3%81%9D-23-7B-7D</a>',
+				'longWikiText'  => '[http://example.org/%E3%82%88%E3%81%86%E3%81%93%E3%81%9D-23-7B-7D http://example.org/%E3%82%88%E3%81%86%E3%81%93%E3%81%9D-23-7B-7D]',
+				'shortHTMLText' => '<a class="external"' . $noFollowAttribute . ' href="http://example.org/%E3%82%88%E3%81%86%E3%81%93%E3%81%9D-23-7B-7D">一二三</a>',
+				'shortWikiText' => '[http://example.org/%E3%82%88%E3%81%86%E3%81%93%E3%81%9D-23-7B-7D 一二三]',
 			)
 		);
 
-		// ...
+		# 13
 		$provider[] = array(
 			'http://example.org/api?query=!_:;@* #Foo&=%20-3DBar',
 			false,
 			null,
 			array(
 				'wikiValue'     => 'http://example.org/api?query=!_:;@* #Foo&=%20-3DBar',
-				'longHTMLText'  => 'http://example.org/api?query=!_:;@* #Foo&= -3DBar',
-				'longWikiText'  => 'http://example.org/api?query=!_:;@* #Foo&= -3DBar',
-				'shortHTMLText' => 'http://example.org/api?query=!_:;@* #Foo&= -3DBar',
-				'shortWikiText' => 'http://example.org/api?query=!_:;@* #Foo&= -3DBar'
+				'longHTMLText'  => 'http://example.org/api?query=!_:;@* #Foo&=%20-3DBar',
+				'longWikiText'  => 'http://example.org/api?query=!_:;@* #Foo&=%20-3DBar',
+				'shortHTMLText' => 'http://example.org/api?query=!_:;@* #Foo&=%20-3DBar',
+				'shortWikiText' => 'http://example.org/api?query=!_:;@* #Foo&=%20-3DBar'
 			)
 		);
 
@@ -304,8 +321,8 @@ class UriValueTest extends \PHPUnit_Framework_TestCase {
 			null,
 			array(
 				'wikiValue'     => 'http://example.org/api?query=!_:;@* #Foo&=%20-3DBar',
-				'longHTMLText'  => 'http://example.org/api?query=!_:;@* #Foo&= -3DBar',
-				'longWikiText'  => 'http://example.org/api?query=!_:;@* #Foo&= -3DBar',
+				'longHTMLText'  => 'http://example.org/api?query=!_:;@* #Foo&=%20-3DBar',
+				'longWikiText'  => 'http://example.org/api?query=!_:;@* #Foo&=%20-3DBar',
 				'shortHTMLText' => '&!_:;@*#Foo',
 				'shortWikiText' => '&!_:;@*#Foo'
 			)
@@ -317,10 +334,10 @@ class UriValueTest extends \PHPUnit_Framework_TestCase {
 			$linker,
 			array(
 				'wikiValue'     => 'http://example.org/api?query=!_:;@* #Foo&=%20-3DBar', // @codingStandardsIgnoreStart phpcs, ignore --sniffs=Generic.Files.LineLength
-				'longHTMLText'  => '<a class="external"' . $noFollowAttribute . ' href="http://example.org/api?query=!_:;@*_#Foo&amp;=_-3DBar">http://example.org/api?query=!_:;@* #Foo&amp;= -3DBar</a>', // @codingStandardsIgnoreEnd
-				'longWikiText'  => '[http://example.org/api?query=!_:;@*_#Foo&=_-3DBar http://example.org/api?query=!_:;@* #Foo&= -3DBar]', // @codingStandardsIgnoreStart phpcs, ignore --sniffs=Generic.Files.LineLength
-				'shortHTMLText' => '<a class="external"' . $noFollowAttribute . ' href="http://example.org/api?query=!_:;@*_#Foo&amp;=_-3DBar">http://example.org/api?query=!_:;@* #Foo&amp;= -3DBar</a>', // @codingStandardsIgnoreEnd
-				'shortWikiText' => '[http://example.org/api?query=!_:;@*_#Foo&=_-3DBar http://example.org/api?query=!_:;@* #Foo&= -3DBar]'
+				'longHTMLText'  => '<a class="external"' . $noFollowAttribute . ' href="http://example.org/api?query=%21_:%3B@%2A%20#Foo&amp;=%20-3DBar">http://example.org/api?query=!_:;@* #Foo&amp;=%20-3DBar</a>', // @codingStandardsIgnoreEnd
+				'longWikiText'  => '[http://example.org/api?query=%21_:%3B@%2A%20#Foo&=%20-3DBar http://example.org/api?query=!_:;@* #Foo&=%20-3DBar]', // @codingStandardsIgnoreStart phpcs, ignore --sniffs=Generic.Files.LineLength
+				'shortHTMLText' => '<a class="external"' . $noFollowAttribute . ' href="http://example.org/api?query=%21_:%3B@%2A%20#Foo&amp;=%20-3DBar">http://example.org/api?query=!_:;@* #Foo&amp;=%20-3DBar</a>', // @codingStandardsIgnoreEnd
+				'shortWikiText' => '[http://example.org/api?query=%21_:%3B@%2A%20#Foo&=%20-3DBar http://example.org/api?query=!_:;@* #Foo&=%20-3DBar]'
 			)
 		);
 
@@ -330,10 +347,10 @@ class UriValueTest extends \PHPUnit_Framework_TestCase {
 			$linker,
 			array(
 				'wikiValue'     => 'http://example.org/api?query=!_:;@* #Foo&=%20-3DBar', // @codingStandardsIgnoreStart phpcs, ignore --sniffs=Generic.Files.LineLength
-				'longHTMLText'  => '<a class="external"' . $noFollowAttribute . ' href="http://example.org/api?query=!_:;@*_#Foo&amp;=_-3DBar">http://example.org/api?query=!_:;@* #Foo&amp;= -3DBar</a>', // @codingStandardsIgnoreEnd
-				'longWikiText'  => '[http://example.org/api?query=!_:;@*_#Foo&=_-3DBar http://example.org/api?query=!_:;@* #Foo&= -3DBar]',
-				'shortHTMLText' => '<a class="external"' . $noFollowAttribute . ' href="http://example.org/api?query=!_:;@*_#Foo&amp;=_-3DBar">&amp;!_:;@* #Foo</a>',
-				'shortWikiText' => '[http://example.org/api?query=!_:;@*_#Foo&=_-3DBar &!_:;@* #Foo]'
+				'longHTMLText'  => '<a class="external"' . $noFollowAttribute . ' href="http://example.org/api?query=%21_:%3B@%2A%20#Foo&amp;=%20-3DBar">http://example.org/api?query=!_:;@* #Foo&amp;=%20-3DBar</a>', // @codingStandardsIgnoreEnd
+				'longWikiText'  => '[http://example.org/api?query=%21_:%3B@%2A%20#Foo&=%20-3DBar http://example.org/api?query=!_:;@* #Foo&=%20-3DBar]',
+				'shortHTMLText' => '<a class="external"' . $noFollowAttribute . ' href="http://example.org/api?query=%21_:%3B@%2A%20#Foo&amp;=%20-3DBar">&amp;!_:;@* #Foo</a>',
+				'shortWikiText' => '[http://example.org/api?query=%21_:%3B@%2A%20#Foo&=%20-3DBar &!_:;@* #Foo]'
 			)
 		);
 


### PR DESCRIPTION
Enables to search for:
- `[[Has telephone number::~*0123*]]`
- `[[Has email::~*123.org]]`

Also expected to solve mentioned issue in [0].

[0] http://wikimedia.7.x6.nabble.com/Encoded-URLs-appear-to-get-decoded-in-properties-td5050062.html