### PR TITLE
Add AsyncJobDispatchManager to decouple jobs during update

### DIFF
--- a/SemanticMediaWiki.settings.php
+++ b/SemanticMediaWiki.settings.php
@@ -859,16 +859,10 @@ $GLOBALS['smwgEnabledEditPageHelp'] = true;
 
 ###
 #
-# Log settings
+# Improves performance for selected operations that can be executed
+# in asynchronous processing mode.
 #
-# - `smwgLogEventTypes` make event types loggable and viewable in Special:Log
-#
-# - `sqlstore-query-execution` (default = false) to log events during query execution
-# of the SQLStore
-#
-# @since 2.1
+# @since 2.3
 ##
-$GLOBALS['smwgLogEventTypes'] = array(
-	'sqlstore-query-execution' => false
-);
+$GLOBALS['smwgEnabledAsyncJobDispatcher'] = true;
 ##

--- a/includes/Settings.php
+++ b/includes/Settings.php
@@ -133,9 +133,9 @@ class Settings extends SimpleDictionary {
 			'smwgOnDeleteAction' => $GLOBALS['smwgOnDeleteAction'],
 			'smwgFallbackSearchType' => $GLOBALS['smwgFallbackSearchType'],
 			'smwgEnabledEditPageHelp' => $GLOBALS['smwgEnabledEditPageHelp'],
-			'smwgLogEventTypes' => $GLOBALS['smwgLogEventTypes'],
 			'smwgSparqlQFeatures' => $GLOBALS['smwgSparqlQFeatures'],
-			'smwgEnabledResultFormatsWithRecursiveAnnotationSupport' => $GLOBALS['smwgEnabledResultFormatsWithRecursiveAnnotationSupport']
+			'smwgEnabledResultFormatsWithRecursiveAnnotationSupport' => $GLOBALS['smwgEnabledResultFormatsWithRecursiveAnnotationSupport'],
+			'smwgEnabledAsyncJobDispatcher' => $GLOBALS['smwgEnabledAsyncJobDispatcher']
 		);
 
 		$settings = $settings + array(

--- a/includes/Setup.php
+++ b/includes/Setup.php
@@ -220,6 +220,10 @@ final class Setup {
 				'page' => 'SMW\SpecialWantedProperties',
 				'group' => 'maintenance'
 			),
+			'AsyncJobDispatcher' => array(
+				'page' => 'SMW\MediaWiki\Specials\SpecialAsyncJobDispatcher',
+				'group' => 'maintenance'
+			),
 		);
 
 		// Register data

--- a/languages/SMW_Aliases.php
+++ b/languages/SMW_Aliases.php
@@ -25,6 +25,7 @@ $specialPageAliases['en'] = array(
 	'URIResolver' => array( 'URIResolver' ),
 	'UnusedProperties' => array( 'UnusedProperties' ),
 	'WantedProperties' => array( 'WantedProperties' ),
+	'AsyncJobDispatcher' => array( 'AsyncJobDispatcher' ),
 );
 
 /** Afrikaans (Afrikaans) */

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -61,6 +61,7 @@
     <php>
        <var name="smwgSparqlDefaultGraph" value="http://example.org/phpunit-testrun"/>
        <var name="smwgValueLookupCacheType" value="hash"/>
+       <var name="smwgEnabledAsyncJobDispatcher" value="false"/>
        <var name="benchmarkQueryRepetitionExecutionThreshold" value="5"/>
        <var name="benchmarkQueryLimit" value="500"/>
        <var name="benchmarkQueryOffset" value="0"/>

--- a/src/AsyncJobDispatchManager.php
+++ b/src/AsyncJobDispatchManager.php
@@ -1,0 +1,203 @@
+<?php
+
+namespace SMW;
+
+use Title;
+use Onoi\HttpRequest\HttpRequest;
+use SMW\MediaWiki\Specials\SpecialAsyncJobDispatcher;
+
+/**
+ * During the storage of a page, sometimes it is necessary the create extra
+ * processing requests that should be executed asynchronously (due to large DB
+ * processing time) but without delay of the current transaction. This class
+ * initiates and creates a separate request to be handled by the receiving
+ * `SpecialAsyncJobDispatcher` endpoint (if it can connect).
+ *
+ * `AsyncJobDispatchManager` allows to invoke jobs independent from the job
+ * scheduler with the objective to be run timely to the current transaction
+ * without having to wait on the job scheduler and without blocking the current
+ * request.
+ *
+ * @license GNU GPL v2+
+ * @since 2.3
+ *
+ * @author mwjames
+ */
+class AsyncJobDispatchManager {
+
+	/**
+	 * @var HttpRequest
+	 */
+	private $httpRequest;
+
+	/**
+	 * @var string
+	 */
+	private $url = '';
+
+	/**
+	 * Is kept static in order for the cli process to only make the check once
+	 * and verify it can/cannot connect.
+	 *
+	 * @var boolean|null
+	 */
+	private static $canConnectToUrl = null;
+
+	/**
+	 * During the unit tests this setting is set false to ensure that execution
+	 * and test result match.
+	 *
+	 * @var boolean
+	 */
+	private $dispatchableAsyncState = true;
+
+	/**
+	 * @since 2.3
+	 *
+	 * @param HttpRequest $httpRequest
+	 */
+	public function __construct( HttpRequest $httpRequest) {
+		$this->httpRequest = $httpRequest;
+		$this->url = SpecialAsyncJobDispatcher::getTargetURL();
+	}
+
+	/**
+	 * @since 2.3
+	 */
+	public function reset() {
+		self::$canConnectToUrl = null;
+	}
+
+	/**
+	 * @since 2.3
+	 */
+	public function setDispatchableAsyncUsageState( $dispatchableAsyncState ) {
+		$this->dispatchableAsyncState = (bool)$dispatchableAsyncState;
+	}
+
+	/**
+	 * @since 2.3
+	 *
+	 * @param string $type
+	 * @param Title $title
+	 * @param array $parameters
+	 */
+	public function dispatchJobFor( $type, Title $title, $parameters = array() ) {
+
+		$dispatchableCallbackJob = $this->getDispatchableCallbackJobFor( $type );
+
+		$parameters['timestamp'] = time();
+		$parameters['sessionToken'] = SpecialAsyncJobDispatcher::getSessionToken( $parameters['timestamp'] );
+
+		if ( $this->canConnectToUrl() && $this->dispatchableAsyncState ) {
+			return $this->doDispatchAsyncJobFor( $type, $title, $parameters, $dispatchableCallbackJob );
+		}
+
+		call_user_func_array(
+			$dispatchableCallbackJob,
+			array( $title, $parameters )
+		);
+
+		return true;
+	}
+
+	/**
+	 * @since 2.3
+	 *
+	 * @param string $type
+	 *
+	 * @return Closure
+	 */
+	public function getDispatchableCallbackJobFor( $type ) {
+
+		$jobFactory = ApplicationFactory::getInstance()->newJobFactory();
+
+		switch ( $type ) {
+			case 'SMW\UpdateJob':
+				return function ( $title, $parameters ) use ( $jobFactory ) {
+					$updateJob = $jobFactory->newUpdateJob(
+						$title,
+						$parameters
+					);
+
+					$updateJob->run();
+				};
+			default:
+				return function () {}; // avoids any error when the type cannot be matched
+		}
+	}
+
+	private function canConnectToUrl() {
+
+		if ( self::$canConnectToUrl !== null ) {
+			return self::$canConnectToUrl;
+		}
+
+		$this->httpRequest->setOption( CURLOPT_URL, $this->url );
+
+		return self::$canConnectToUrl = $this->httpRequest->ping();
+	}
+
+	private function doDispatchAsyncJobFor( $type, $title, $parameters, $dispatchableCallbackJob ) {
+
+		$parameters['async-job'] = array(
+			'type'  => $type,
+			'title' => $title->getPrefixedDBkey()
+		);
+
+		$async = function ( $url, $params = array() ) use( $title, $dispatchableCallbackJob ) {
+			$post_params = array();
+			$httpMessage = '';
+
+			foreach ( $params as $key => $val ) {
+
+				if ( is_array( $val ) ) {
+					$val = implode( '|', $val );
+				}
+
+				$post_params[] = $key . '=' . urlencode( $val );
+			}
+
+			$post_string = implode( '&', $post_params );
+			$parts = parse_url( $url );
+
+			$remoteSocket = $parts['host'] . ':' .  ( isset( $parts['port'] ) ? $parts['port'] : 80 );
+
+			$res = @stream_socket_client(
+				$remoteSocket,
+				$errno,
+				$errstr,
+				30,
+				STREAM_CLIENT_ASYNC_CONNECT | STREAM_CLIENT_CONNECT
+			);
+
+			if ( !$res ) {
+				wfDebugLog( 'smw', __METHOD__  . " $errstr ($errno)". "\n" );
+				call_user_func_array( $dispatchableCallbackJob, array( $title, $params ) );
+			} else {
+
+				$httpMessage .= "POST " . $parts['path'] . " HTTP/1.1\r\n";
+				$httpMessage .= "Host: " . $parts['host'] . "\r\n";
+				$httpMessage .= "Content-Type: application/x-www-form-urlencoded\r\n";
+				$httpMessage .= "Content-Length: " . strlen( $post_string ) . "\r\n";
+				$httpMessage .= "Connection: Close\r\n\r\n";
+				$httpMessage .= $post_string;
+
+				if ( !@fwrite( $res, $httpMessage ) ) {
+					wfDebugLog( 'smw', __METHOD__  . " connection to {$remoteSocket} failed, try again " . "\n" );
+					if ( !@fwrite( $res, $httpMessage ) ) {
+						wfDebugLog( 'smw', __METHOD__  . " connection to {$remoteSocket} failed again, add job for " . $title->getPrefixedDBkey() . "\n" );
+						call_user_func_array( $dispatchableCallbackJob, array( $title, $params ) );
+					}
+				}
+
+				fclose( $res );
+			}
+		};
+
+		call_user_func_array( $async, array( $this->url, $parameters ) );
+
+		return true;
+	}
+
+}

--- a/src/MediaWiki/Hooks/HookRegistry.php
+++ b/src/MediaWiki/Hooks/HookRegistry.php
@@ -442,7 +442,12 @@ class HookRegistry {
 		/**
 		 * @see https://www.mediawiki.org/wiki/Manual:Hooks/EditPage::showEditForm:initial
 		 */
-		$this->handlers['EditPage::showEditForm:initial'] = function ( $editPage, $output ) use ( $applicationFactory ) {
+		$this->handlers['EditPage::showEditForm:initial'] = function ( $editPage, $output = null ) use ( $applicationFactory ) {
+
+			// 1.19 hook interface is missing the output object
+			if ( !$output instanceOf \OutputPage ) {
+				$output = $GLOBALS['wgOut'];
+			}
 
 			$htmlFormRenderer = $applicationFactory->newMwCollaboratorFactory()->newHtmlFormRenderer(
 				$editPage->getTitle(),

--- a/src/MediaWiki/Jobs/JobFactory.php
+++ b/src/MediaWiki/Jobs/JobFactory.php
@@ -5,8 +5,6 @@ namespace SMW\MediaWiki\Jobs;
 use Title;
 
 /**
- * Access MediaWiki Job instances
- *
  * @license GNU GPL v2+
  * @since 2.0
  *
@@ -18,11 +16,12 @@ class JobFactory {
 	 * @since 2.0
 	 *
 	 * @param Title $title
+	 * @param array $parameters
 	 *
 	 * @return UpdateJob
 	 */
-	public function newUpdateJob( Title $title ) {
-		return new UpdateJob( $title );
+	public function newUpdateJob( Title $title, array $parameters = array() ) {
+		return new UpdateJob( $title, $parameters );
 	}
 
 	/**

--- a/src/MediaWiki/Jobs/UpdateJob.php
+++ b/src/MediaWiki/Jobs/UpdateJob.php
@@ -97,7 +97,7 @@ class UpdateJob extends JobBase {
 
 	private function matchWikiPageLastModifiedToRevisionLastModified( $title ) {
 
-		if ( $this->getParameter( 'pm' ) !== SMW_UJ_PM_CLASTMDATE ) {
+		if ( $this->getParameter( 'pm' ) !== ( $this->getParameter( 'pm' ) | SMW_UJ_PM_CLASTMDATE ) ) {
 			return false;
 		}
 
@@ -123,7 +123,7 @@ class UpdateJob extends JobBase {
 
 		$contentParser = $this->applicationFactory->newContentParser( $this->getTitle() );
 
-		if ( $this->getParameter( 'pm' ) === SMW_UJ_PM_NP ) {
+		if ( $this->getParameter( 'pm' ) === ( $this->getParameter( 'pm' ) | SMW_UJ_PM_NP ) ) {
 			$contentParser->setParser(
 				new \Parser( $GLOBALS['wgParserConf'] )
 			);

--- a/src/MediaWiki/Specials/SpecialAsyncJobDispatcher.php
+++ b/src/MediaWiki/Specials/SpecialAsyncJobDispatcher.php
@@ -1,0 +1,150 @@
+<?php
+
+namespace SMW\MediaWiki\Specials;
+
+use SpecialPage;
+use SMW\ApplicationFactory;
+use Onoi\HttpRequest\HttpRequestFactory;
+use Title;
+
+/**
+ * This class is the receiving endpoint for the `AsyncJobDispatchManager` invoked
+ * job request.
+ *
+ * This special page is not expected to interact with a user and therefore it is
+ * unlisted.
+ *
+ * @license GNU GPL v2+
+ * @since   2.3
+ *
+ * @author mwjames
+ */
+class SpecialAsyncJobDispatcher extends SpecialPage {
+
+	/**
+	 * @var boolean
+	 */
+	private $allowedToModifyHttpHeader = true;
+
+	/**
+	 * @codeCoverageIgnore
+	 */
+	public function __construct() {
+		parent::__construct( 'AsyncJobDispatcher', '', false );
+	}
+
+	/**
+	 * @see SpecialPage::getGroupName
+	 */
+	protected function getGroupName() {
+		return 'maintenance';
+	}
+
+	/**
+	 * Only used during unit testing
+	 *
+	 * @since 2.3
+	 */
+	public function disallowToModifyHttpHeader() {
+		$this->allowedToModifyHttpHeader = false;
+	}
+
+	/**
+	 * @since 2.3
+	 *
+	 * @return string
+	 */
+	public static function getTargetURL() {
+		return SpecialPage::getTitleFor( 'AsyncJobDispatcher')->getFullURL();
+	}
+
+	/**
+	 * @since 2.3
+	 *
+	 * @param string $key
+	 *
+	 * @return string
+	 */
+	public static function getSessionToken( $key ) {
+		return md5( $key . $GLOBALS['wgSecretKey'] );
+	}
+
+	/**
+	 * @see SpecialPage::execute
+	 */
+	public function execute( $query ) {
+
+		$this->getOutput()->disable();
+
+		if ( $this->isHttpRequestMethod( 'GET' ) ) {
+			return $this->modifyHttpHeader( "HTTP/1.0 400 Bad Request", 'The special page requires a POST/HEAD request.' );
+		}
+
+		$parameters = $this->getRequest()->getValues();
+
+		if ( $this->isHttpRequestMethod( 'POST' ) && self::getSessionToken( $parameters['timestamp'] ) !== $parameters['sessionToken'] ) {
+			return $this->modifyHttpHeader( "HTTP/1.0 400 Bad Request", 'Invalid or staled sessionToken was provided for the request' );
+		}
+
+		$this->modifyHttpHeader( "HTTP/1.0 202 Accepted" );
+
+		if ( !isset( $parameters['async-job'] ) ) {
+			return;
+		}
+
+		$type  = '';
+		$title = '';
+
+		list( $type, $title ) = explode( '|', $parameters['async-job'] );
+		$title = Title::newFromDBkey( $title );
+
+		if ( $title === null ) {
+			wfDebugLog( 'smw', __METHOD__  . " invalid title" . "\n" );
+			return;
+		}
+
+		switch ( $type ) {
+			case 'SMW\UpdateJob':
+				$this->runUpdateJob( $title, $parameters );
+				break;
+		}
+
+		return true;
+	}
+
+	private function modifyHttpHeader( $header, $message = '' ) {
+
+		if ( !$this->allowedToModifyHttpHeader ) {
+			return null;
+		}
+
+		ignore_user_abort( true );
+		header( $header );
+		print $message;
+		ob_flush();
+		flush();
+	}
+
+	private function runUpdateJob( $title, $parameters ) {
+
+		wfDebugLog( 'smw', __METHOD__ . ' dispatched for '.  $title->getPrefixedDBkey() . "\n" );
+
+		$updateJob = ApplicationFactory::getInstance()->newJobFactory()->newUpdateJob(
+			$title,
+			$parameters
+		);
+
+		$updateJob->run();
+	}
+
+	// 1.19 doesn't have a getMethod
+	private function isHttpRequestMethod( $key ) {
+
+		if ( method_exists( $this->getRequest(), 'getMethod') ) {
+			return $this->getRequest()->getMethod() == $key;
+		}
+
+		return isset( $_SERVER['REQUEST_METHOD'] ) ? $_SERVER['REQUEST_METHOD'] == $key : false;
+	}
+
+}

--- a/src/SQLStore/PropertyTableRowDiffer.php
+++ b/src/SQLStore/PropertyTableRowDiffer.php
@@ -101,7 +101,8 @@ class PropertyTableRowDiffer {
 				// Hence we do not sort before serializing. It is hoped that this assumption is valid.
 				$newHashes[$tableName] = $this->createNewHashForTable(
 					$tableName,
-					$newData
+					$newData,
+					$semanticData->getLastModified()
 				);
 
 				if ( array_key_exists( $tableName, $oldHashes ) && $newHashes[$tableName] == $oldHashes[$tableName] ) {

--- a/tests/phpunit/Unit/AsyncJobDispatchManagerTest.php
+++ b/tests/phpunit/Unit/AsyncJobDispatchManagerTest.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace SMW\Tests;
+
+use SMW\AsyncJobDispatchManager;
+use SMW\DIWikiPage;
+
+/**
+ * @covers \SMW\AsyncJobDispatchManager
+ * @group semantic-mediawiki
+ *
+ * @license GNU GPL v2+
+ * @since   2.3
+ *
+ * @author mwjames
+ */
+class AsyncJobDispatchManagerTest extends \PHPUnit_Framework_TestCase {
+
+	public function testCanConstruct() {
+
+		$httpRequest = $this->getMockBuilder( '\Onoi\HttpRequest\HttpRequest' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$this->assertInstanceOf(
+			'\SMW\AsyncJobDispatchManager',
+			new AsyncJobDispatchManager( $httpRequest )
+		);
+	}
+
+	/**
+	 * @dataProvider dispatchableJobProvider
+	 */
+	public function testDispatchFor( $type, $dispatchableAsyncUsageState ) {
+
+		$httpRequest = $this->getMockBuilder( '\Onoi\HttpRequest\HttpRequest' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$httpRequest->expects( $this->any() )
+			->method( 'ping' )
+			->will( $this->returnValue( true ) );
+
+		$instance = new AsyncJobDispatchManager( $httpRequest );
+		$instance->setDispatchableAsyncUsageState( $dispatchableAsyncUsageState );
+
+		$this->assertTrue(
+			$instance->dispatchJobFor( $type , DIWikiPage::newFromText( __METHOD__ )->getTitle() )
+		);
+	}
+
+	public function dispatchableJobProvider() {
+
+		$provider[] = array(
+			'SMW\UpdateJob',
+			false
+		);
+
+		$provider[] = array(
+			'SMW\UpdateJob',
+			true
+		);
+
+		$provider[] = array(
+			'UnknownJob',
+			false
+		);
+
+		$provider[] = array(
+			'UnknownJob',
+			true
+		);
+
+		return $provider;
+	}
+
+}

--- a/tests/phpunit/includes/MediaWiki/Specials/SpecialAsyncJobDispatcherTest.php
+++ b/tests/phpunit/includes/MediaWiki/Specials/SpecialAsyncJobDispatcherTest.php
@@ -1,0 +1,147 @@
+<?php
+
+namespace SMW\Tests\MediaWiki\Specials;
+
+use SMW\Tests\Utils\UtilityFactory;
+use SMW\MediaWiki\Specials\SpecialAsyncJobDispatcher;
+use SMW\ApplicationFactory;
+use Title;
+
+/**
+ * @covers \SMW\MediaWiki\Specials\SpecialAsyncJobDispatcher
+ * @group semantic-mediawiki
+ *
+ * @license GNU GPL v2+
+ * @since 2.3
+ *
+ * @author mwjames
+ */
+class SpecialAsyncJobDispatcherTest extends \PHPUnit_Framework_TestCase {
+
+	private $applicationFactory;
+	private $stringValidator;
+
+	protected function setUp() {
+		parent::setUp();
+
+		$this->applicationFactory = ApplicationFactory::getInstance();
+
+		$store = $this->getMockBuilder( '\SMW\Store' )
+			->disableOriginalConstructor()
+			->getMockForAbstractClass();
+
+		$store->expects( $this->any() )
+			->method( 'getPropertySubjects' )
+			->will( $this->returnValue( array() ) );
+
+		$this->applicationFactory->registerObject( 'Store', $store );
+
+		$this->stringValidator = UtilityFactory::getInstance()->newValidatorFactory()->newStringValidator();
+	}
+
+	protected function tearDown() {
+		$this->applicationFactory->clear();
+		parent::tearDown();
+	}
+
+	public function testCanConstruct() {
+
+		$this->assertInstanceOf(
+			'\SMW\MediaWiki\Specials\SpecialAsyncJobDispatcher',
+			new SpecialAsyncJobDispatcher()
+		);
+	}
+
+	public function testGetTargetURL() {
+
+		$this->assertContains(
+			':AsyncJobDispatcher',
+			SpecialAsyncJobDispatcher::getTargetURL()
+		);
+	}
+
+	public function testGetSessionToken() {
+
+		$this->assertInternalType(
+			'string',
+			SpecialAsyncJobDispatcher::getSessionToken( 'Foo' )
+		);
+
+		$this->assertNotSame(
+			SpecialAsyncJobDispatcher::getSessionToken( 'Bar' ),
+			SpecialAsyncJobDispatcher::getSessionToken( 'Foo' )
+		);
+	}
+
+	public function testValidPostAsyncJob() {
+
+		if ( version_compare( $GLOBALS['wgVersion'], '1.20', '<' ) ) {
+			$this->markTestSkipped( "Skipping test because of missing method" );
+		}
+
+		$timestamp =  time();
+
+		$request = array(
+			'timestamp' => $timestamp,
+			'sessionToken' => SpecialAsyncJobDispatcher::getSessionToken( $timestamp ),
+			'async-job' => 'SMW\UpdateJob|Foo'
+		);
+
+		$instance = new SpecialAsyncJobDispatcher();
+		$instance->disallowToModifyHttpHeader();
+
+		$instance->getContext()->setRequest(
+			new \FauxRequest( $request, true )
+		);
+
+		$this->assertTrue(
+			$instance->execute( '' )
+		);
+	}
+
+	public function testInvalidPostSessionToken() {
+
+		if ( version_compare( $GLOBALS['wgVersion'], '1.20', '<' ) ) {
+			$this->markTestSkipped( "Skipping test because of missing method" );
+		}
+
+		$timestamp =  time();
+
+		$request = array(
+			'timestamp' => $timestamp,
+			'sessionToken' => SpecialAsyncJobDispatcher::getSessionToken( 'Foo' )
+		);
+
+		$instance = new SpecialAsyncJobDispatcher();
+		$instance->disallowToModifyHttpHeader();
+
+		$instance->getContext()->setRequest(
+			new \FauxRequest( $request, true )
+		);
+
+		$this->assertNull(
+			$instance->execute( '' )
+		);
+	}
+
+	public function testGetRequestForAsyncJob() {
+
+		if ( version_compare( $GLOBALS['wgVersion'], '1.20', '<' ) ) {
+			$this->markTestSkipped( "Skipping test because of missing method" );
+		}
+
+		$request = array();
+
+		$instance = new SpecialAsyncJobDispatcher();
+		$instance->disallowToModifyHttpHeader();
+
+		$instance->getContext()->setRequest(
+			new \FauxRequest( $request, false )
+		);
+
+		$this->assertNull(
+			$instance->execute( '' )
+		);
+	}
+
+}


### PR DESCRIPTION
Instead of `$db->onTransactionIdle( function() use ( $jobs ) ` use `AsyncJobDispatchManager ::dispatchJobFor` because tests showed that redirects with subapges can easily be blocked during the copy process and making the recovery of moved pages rather unstable do to a required update parse for each page.

refs Builds on work done for https://github.com/SemanticMediaWiki/SemanticMediaWiki/pull/1117#issuecomment-134388161