### PR TITLE
Add PropertyDependencyDetectionExclusionList, refs #1117

### DIFF
--- a/SemanticMediaWiki.settings.php
+++ b/SemanticMediaWiki.settings.php
@@ -881,3 +881,19 @@ $GLOBALS['smwgEnabledAsyncJobDispatcher'] = true;
 ##
 $GLOBALS['smwgEnabledQueryDependencyLinksStore'] = false;
 ##
+
+###
+# Relates to `smwgEnabledQueryDependencyLinksStore` and defines property keys
+# to be excluded from the dependency detection.
+#
+# For example, to avoid a purge process being triggered for each altered subobject
+# '_SOBJ' is excluded from the processing but it will not exclude any properties
+# defined by a subobject (given that it is not part of an extended exclusion list).
+#
+# `_MDAT` is excluded to avoid a purge on each page edit with a `Modification date`
+# change that would otherwise trigger a dependency update.
+#
+# @since 2.3 (experimental)
+##
+$GLOBALS['smwgPropertyDependencyDetectionBlacklist'] = array( '_MDAT', '_SOBJ' );
+##

--- a/includes/Settings.php
+++ b/includes/Settings.php
@@ -136,7 +136,8 @@ class Settings extends SimpleDictionary {
 			'smwgSparqlQFeatures' => $GLOBALS['smwgSparqlQFeatures'],
 			'smwgEnabledResultFormatsWithRecursiveAnnotationSupport' => $GLOBALS['smwgEnabledResultFormatsWithRecursiveAnnotationSupport'],
 			'smwgEnabledAsyncJobDispatcher' => $GLOBALS['smwgEnabledAsyncJobDispatcher'],
-			'smwgEnabledQueryDependencyLinksStore' => $GLOBALS['smwgEnabledQueryDependencyLinksStore']
+			'smwgEnabledQueryDependencyLinksStore' => $GLOBALS['smwgEnabledQueryDependencyLinksStore'],
+			'smwgPropertyDependencyDetectionBlacklist' => $GLOBALS['smwgPropertyDependencyDetectionBlacklist']
 		);
 
 		$settings = $settings + array(

--- a/src/AsyncJobDispatchManager.php
+++ b/src/AsyncJobDispatchManager.php
@@ -163,6 +163,7 @@ class AsyncJobDispatchManager {
 		}
 
 		$this->httpRequest->setOption( CURLOPT_URL, $this->url );
+		$this->httpRequest->setOption( CURLOPT_SSL_VERIFYPEER, false );
 
 		return self::$canConnectToUrl = $this->httpRequest->ping();
 	}

--- a/src/MediaWiki/Hooks/HookRegistry.php
+++ b/src/MediaWiki/Hooks/HookRegistry.php
@@ -506,6 +506,10 @@ class HookRegistry {
 				$applicationFactory->getSettings()->get( 'smwgEnabledQueryDependencyLinksStore' )
 			);
 
+			$embeddedQueryDependencyLinksStore->setPropertyDependencyDetectionBlacklist(
+				$applicationFactory->getSettings()->get( 'smwgPropertyDependencyDetectionBlacklist' )
+			);
+
 			$embeddedQueryDependencyLinksStore->addDependenciesFromQueryResult( $result );
 
 			return true;

--- a/src/MediaWiki/Jobs/ParserCachePurgeJob.php
+++ b/src/MediaWiki/Jobs/ParserCachePurgeJob.php
@@ -70,8 +70,6 @@ class ParserCachePurgeJob extends JobBase {
 			$this->findEmbeddedQueryTargetLinksBatches( $this->getParameter( 'idlist' ) );
 		}
 
-		wfDebugLog( 'smw', __METHOD__  . ' with limit set to ' . $this->limit . "\n" );
-
 		$this->pageUpdater->addPage( $this->getTitle() );
 		$this->pageUpdater->doPurgeParserCache();
 
@@ -111,9 +109,11 @@ class ParserCachePurgeJob extends JobBase {
 			return true;
 		}
 
+		$countedHashListEntries = count( $hashList );
+
 		// If more results are available then use an iterative increase to fetch
 		// the remaining updates by creating successive jobs
-		if ( count( $hashList ) > $this->limit ) {
+		if ( $countedHashListEntries > $this->limit ) {
 
 			$job = new self( $this->getTitle(), array(
 				'idlist' => $idList,
@@ -123,6 +123,8 @@ class ParserCachePurgeJob extends JobBase {
 
 			$job->run();
 		}
+
+		wfDebugLog( 'smw', __METHOD__  . ' limit set to ' . $this->limit . ' for counted entries of ' . $countedHashListEntries . "\n" );
 
 		$hashList = $this->doBuildUniqueTargetLinksHashList(
 			$hashList


### PR DESCRIPTION
Listed properties are excluded from detection (see explanation https://github.com/SemanticMediaWiki/SemanticMediaWiki/pull/1135/files#diff-459c39f2cf2f2b2afa68a2a8fd32e0e2R889).

Default setting is `$GLOBALS['smwgPropertyDependencyDetectionBlacklist'] = array( '_MDAT', '_SOBJ' );`
refs #1117