### PR TITLE
Add skew factor to evaluate an update time frame, refs #1117

### DIFF
--- a/tests/phpunit/Unit/SQLStore/EmbeddedQueryDependencyLinksStoreTest.php
+++ b/tests/phpunit/Unit/SQLStore/EmbeddedQueryDependencyLinksStoreTest.php
@@ -355,6 +355,77 @@ class EmbeddedQueryDependencyLinksStoreTest extends \PHPUnit_Framework_TestCase 
 		$instance->addDependenciesFromQueryResult( $queryResult );
 	}
 
+	public function testTryToAddDependenciesWithinSkewLimit() {
+
+		$description = $this->getMockBuilder( '\SMW\Query\Language\Description' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$query = new Query(
+			$description
+		);
+
+		$title = $this->getMockBuilder( '\Title' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$title->expects( $this->once() )
+			->method( 'getTouched' )
+			->will( $this->returnValue( wfTimestamp( TS_MW ) + 10 ) );
+
+		$subject = $this->getMockBuilder( '\SMW\DIWikiPage' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$subject->expects( $this->once() )
+			->method( 'getTitle' )
+			->will( $this->returnValue( $title ) );
+
+		$query->setSubject( $subject );
+
+		$queryResult = $this->getMockBuilder( '\SMWQueryResult' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$queryResult->expects( $this->any() )
+			->method( 'getQuery' )
+			->will( $this->returnValue( $query ) );
+
+		$idTable = $this->getMockBuilder( '\stdClass' )
+			->setMethods( array( 'getSMWPageID' ) )
+			->getMock();
+
+		$idTable->expects( $this->once() )
+			->method( 'getSMWPageID' )
+			->will( $this->returnValue( 42 ) );
+
+		$connection = $this->getMockBuilder( '\SMW\MediaWiki\Database' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$connectionManager = $this->getMockBuilder( '\SMW\ConnectionManager' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$connectionManager->expects( $this->any() )
+			->method( 'getConnection' )
+			->will( $this->returnValue( $connection ) );
+
+		$store = $this->getMockBuilder( '\SMW\SQLStore\SQLStore' )
+			->disableOriginalConstructor()
+			->setMethods( array( 'getObjectIds' ) )
+			->getMockForAbstractClass();
+
+		$store->setConnectionManager( $connectionManager );
+
+		$store->expects( $this->any() )
+			->method( 'getObjectIds' )
+			->will( $this->returnValue( $idTable ) );
+
+		$instance = new EmbeddedQueryDependencyLinksStore( $store );
+		$instance->addDependenciesFromQueryResult( $queryResult );
+	}
+
 	public function descriptionProvider() {
 
 		$description = new SomeProperty(

--- a/tests/phpunit/includes/MediaWiki/Jobs/ParserCachePurgeJobTest.php
+++ b/tests/phpunit/includes/MediaWiki/Jobs/ParserCachePurgeJobTest.php
@@ -48,13 +48,12 @@ class ParserCachePurgeJobTest extends \PHPUnit_Framework_TestCase {
 		);
 	}
 
-	public function testJobWithIdList() {
+	/**
+	 * @dataProvider parametersProvider
+	 */
+	public function testJobWithIdList( $parameters ) {
 
 		$subject = DIWikiPage::newFromText( __METHOD__ );
-
-		$parameters = array(
-			'idlist' => array( 1, 2 )
-		);
 
 		$instance = new ParserCachePurgeJob(
 			$subject->getTitle(),
@@ -64,6 +63,19 @@ class ParserCachePurgeJobTest extends \PHPUnit_Framework_TestCase {
 		$this->assertTrue(
 			$instance->run()
 		);
+	}
+
+	public function parametersProvider() {
+
+		$provider[] = array(
+			'idlist' => array( 1, 2 )
+		);
+
+		$provider[] = array(
+			'idlist' => '1|2'
+		);
+
+		return $provider;
 	}
 
 }


### PR DESCRIPTION
If an update occurs within the skewed time frame then avoid an unnecessary DB transaction.

refs #1117