### PR TITLE
Split EmbeddedQueryDependencyLinksStore, add detection of hierarchies…

### DIFF
--- a/src/PropertyHierarchyExaminer.php
+++ b/src/PropertyHierarchyExaminer.php
@@ -27,10 +27,24 @@ class PropertyHierarchyExaminer {
 	private $cache = null;
 
 	/**
+	 * Use 0 to disable the hierarchy lookup
+	 *
+	 * @var integer
+	 */
+	private $subcategoryDepth = 10;
+
+	/**
+	 * Use 0 to disable the hierarchy lookup
+	 *
+	 * @var integer
+	 */
+	private $subpropertyDepth = 10;
+
+	/**
 	 * @since 2.3
 	 *
 	 * @param Store $store
-	 * @param Cache|null $cache
+	 * @param Cache $cache
 	 */
 	public function __construct( Store $store, Cache $cache ) {
 		$this->store = $store;
@@ -38,11 +52,24 @@ class PropertyHierarchyExaminer {
 	}
 
 	/**
-	 * @note There are different ways to find out whether a property
-	 * has a subproperty or not.
+	 * @since 2.3
 	 *
-	 * In SPARQL one could try using FILTER NOT EXISTS { ?s my:property ?o }
+	 * @param integer $subcategoryDepth
+	 */
+	public function setSubcategoryDepth( $subcategoryDepth ) {
+		$this->subcategoryDepth = (int)$subcategoryDepth;
+	}
+
+	/**
+	 * @since 2.3
 	 *
+	 * @param integer $subpropertyDepth
+	 */
+	public function setSubpropertyDepth( $subpropertyDepth ) {
+		$this->subpropertyDepth = (int)$subpropertyDepth;
+	}
+
+	/**
 	 * @since 2.3
 	 *
 	 * @param DIProperty $property
@@ -50,6 +77,11 @@ class PropertyHierarchyExaminer {
 	 * @return  boolean
 	 */
 	public function hasSubpropertyFor( DIProperty $property ) {
+
+		if ( $this->subpropertyDepth < 1 ) {
+			return false;
+		}
+
 		return $this->hasMatchFor( '_SUBP', $property->getKey(), $property->getDiWikiPage() );
 	}
 
@@ -58,15 +90,42 @@ class PropertyHierarchyExaminer {
 	 *
 	 * @param DIWikiPage $category
 	 *
-	 * @return  boolean
+	 * @return boolean
 	 */
 	public function hasSubcategoryFor( DIWikiPage $category ) {
+
+		if ( $this->subcategoryDepth < 1 ) {
+			return false;
+		}
+
 		return $this->hasMatchFor( '_SUBC', $category->getDBKey(), $category );
+	}
+
+	/**
+	 * @since 2.3
+	 *
+	 * @param DIProperty $property
+	 *
+	 * @return DIProperty[]
+	 */
+	public function findSubpropertListFor( DIProperty $property ) {
+		return $this->findMatchesFor( '_SUBP', $property->getKey(), $property->getDiWikiPage() );
+	}
+
+	/**
+	 * @since 2.3
+	 *
+	 * @param DIWikiPage $category
+	 *
+	 * @return DIWikiPage[]
+	 */
+	public function findSubcategoryListFor( DIWikiPage $category ) {
+		return $this->findMatchesFor( '_SUBC', $category->getDBKey(), $category );
 	}
 
 	private function hasMatchFor( $id, $key, DIWikiPage $subject ) {
 
-		$key = $id . '#' . $key;
+		$key = 'm#' . $id . '#' . $key;
 
 		if ( $this->cache->contains( $key ) ) {
 			return $this->cache->fetch( $key );
@@ -87,6 +146,32 @@ class PropertyHierarchyExaminer {
 		);
 
 		return $result !== array();
+	}
+
+	private function findMatchesFor( $id, $key, DIWikiPage $subject ) {
+
+		$key = 'f#' . $id . '#' . $key;
+
+		if ( $this->cache->contains( $key ) ) {
+			return unserialize( $this->cache->fetch( $key ) );
+		}
+
+		$requestOptions = new RequestOptions();
+
+		$result = $this->store->getPropertySubjects(
+			new DIProperty( $id ),
+			$subject,
+			$requestOptions
+		);
+
+		$this->cache->save(
+			$key,
+			serialize( $result )
+		);
+
+		wfDebugLog( 'smw', __METHOD__ . " {$id} and " . $subject->getDBKey() . "\n" );
+
+		return $result;
 	}
 
 }

--- a/src/PropertyHierarchyLookup.php
+++ b/src/PropertyHierarchyLookup.php
@@ -14,7 +14,7 @@ use SMWRequestOptions as RequestOptions;
  *
  * @author mwjames
  */
-class PropertyHierarchyExaminer {
+class PropertyHierarchyLookup {
 
 	/**
 	 * @var Store
@@ -106,7 +106,7 @@ class PropertyHierarchyExaminer {
 	 *
 	 * @param DIProperty $property
 	 *
-	 * @return DIProperty[]
+	 * @return DIWikiPage[]|[]
 	 */
 	public function findSubpropertListFor( DIProperty $property ) {
 		return $this->findMatchesFor( '_SUBP', $property->getKey(), $property->getDiWikiPage() );
@@ -117,7 +117,7 @@ class PropertyHierarchyExaminer {
 	 *
 	 * @param DIWikiPage $category
 	 *
-	 * @return DIWikiPage[]
+	 * @return DIWikiPage[]|[]
 	 */
 	public function findSubcategoryListFor( DIWikiPage $category ) {
 		return $this->findMatchesFor( '_SUBC', $category->getDBKey(), $category );

--- a/src/SPARQLStore/QueryEngine/CompoundConditionBuilder.php
+++ b/src/SPARQLStore/QueryEngine/CompoundConditionBuilder.php
@@ -7,7 +7,7 @@ use SMW\DataTypeRegistry;
 use SMW\DIProperty;
 use SMW\DIWikiPage;
 use SMW\CircularReferenceGuard;
-use SMW\PropertyHierarchyExaminer;
+use SMW\PropertyHierarchyLookup;
 use SMW\SPARQLStore\HierarchyFinder;
 use SMW\Query\Language\Description;
 use SMW\Query\Language\SomeProperty;
@@ -60,9 +60,9 @@ class CompoundConditionBuilder {
 	private $circularReferenceGuard = null;
 
 	/**
-	 * @var PropertyHierarchyExaminer
+	 * @var PropertyHierarchyLookup
 	 */
-	private $propertyHierarchyExaminer = null;
+	private $propertyHierarchyLookup = null;
 
 	/**
 	 * @var array
@@ -203,19 +203,19 @@ class CompoundConditionBuilder {
 	/**
 	 * @since 2.3
 	 *
-	 * @param PropertyHierarchyExaminer $propertyHierarchyExaminer
+	 * @param PropertyHierarchyLookup $propertyHierarchyLookup
 	 */
-	public function setPropertyHierarchyExaminer( PropertyHierarchyExaminer $propertyHierarchyExaminer ) {
-		$this->propertyHierarchyExaminer = $propertyHierarchyExaminer;
+	public function setPropertyHierarchyLookup( PropertyHierarchyLookup $propertyHierarchyLookup ) {
+		$this->propertyHierarchyLookup = $propertyHierarchyLookup;
 	}
 
 	/**
 	 * @since 2.3
 	 *
-	 * @return PropertyHierarchyExaminer
+	 * @return PropertyHierarchyLookup
 	 */
-	public function getPropertyHierarchyExaminer() {
-		return $this->propertyHierarchyExaminer;
+	public function getPropertyHierarchyLookup() {
+		return $this->propertyHierarchyLookup;
 	}
 
 	/**

--- a/src/SPARQLStore/QueryEngine/Interpreter/ClassDescriptionInterpreter.php
+++ b/src/SPARQLStore/QueryEngine/Interpreter/ClassDescriptionInterpreter.php
@@ -115,7 +115,7 @@ class ClassDescriptionInterpreter implements DescriptionInterpreter {
 			return '';
 		}
 
-		if ( $this->compoundConditionBuilder->getPropertyHierarchyExaminer() === null || !$this->compoundConditionBuilder->getPropertyHierarchyExaminer()->hasSubcategoryFor( $category ) ) {
+		if ( $this->compoundConditionBuilder->getPropertyHierarchyLookup() === null || !$this->compoundConditionBuilder->getPropertyHierarchyLookup()->hasSubcategoryFor( $category ) ) {
 			return '';
 		}
 

--- a/src/SPARQLStore/QueryEngine/Interpreter/SomePropertyInterpreter.php
+++ b/src/SPARQLStore/QueryEngine/Interpreter/SomePropertyInterpreter.php
@@ -246,7 +246,7 @@ class SomePropertyInterpreter implements DescriptionInterpreter {
 			return null;
 		}
 
-		if ( $this->compoundConditionBuilder->getPropertyHierarchyExaminer() == null || !$this->compoundConditionBuilder->getPropertyHierarchyExaminer()->hasSubpropertyFor( $property ) ) {
+		if ( $this->compoundConditionBuilder->getPropertyHierarchyLookup() == null || !$this->compoundConditionBuilder->getPropertyHierarchyLookup()->hasSubpropertyFor( $property ) ) {
 			return null;
 		}
 

--- a/src/SPARQLStore/SPARQLStoreFactory.php
+++ b/src/SPARQLStore/SPARQLStoreFactory.php
@@ -6,7 +6,7 @@ use SMW\Store;
 use SMW\StoreFactory;
 use SMW\ConnectionManager;
 use SMW\ApplicationFactory;
-use SMW\PropertyHierarchyExaminer;
+use SMW\PropertyHierarchyLookup;
 use SMW\CircularReferenceGuard;
 use SMW\SPARQLStore\QueryEngine\CompoundConditionBuilder;
 use SMW\SPARQLStore\QueryEngine\EngineOptions;
@@ -52,10 +52,19 @@ class SPARQLStoreFactory {
 	public function newMasterQueryEngine() {
 
 		$engineOptions = new EngineOptions();
+		$applicationFactory = ApplicationFactory::getInstance();
 
-		$propertyHierarchyExaminer = new PropertyHierarchyExaminer(
+		$propertyHierarchyLookup = new PropertyHierarchyLookup(
 			$this->store,
-			ApplicationFactory::getInstance()->newCacheFactory()->newFixedInMemoryCache( 500 )
+			$applicationFactory->newCacheFactory()->newFixedInMemoryCache( 500 )
+		);
+
+		$propertyHierarchyLookup->setSubcategoryDepth(
+			$applicationFactory->getSettings()->get( 'smwgQSubcategoryDepth' )
+		);
+
+		$propertyHierarchyLookup->setSubpropertyDepth(
+			$applicationFactory->getSettings()->get( 'smwgQSubpropertyDepth' )
 		);
 
 		$circularReferenceGuard = new CircularReferenceGuard( 'sparql-query' );
@@ -69,8 +78,8 @@ class SPARQLStoreFactory {
 			$circularReferenceGuard
 		);
 
-		$compoundConditionBuilder->setPropertyHierarchyExaminer(
-			$propertyHierarchyExaminer
+		$compoundConditionBuilder->setPropertyHierarchyLookup(
+			$propertyHierarchyLookup
 		);
 
 		$queryEngine = new QueryEngine(

--- a/src/SQLStore/EmbeddedQueryDependencyListResolver.php
+++ b/src/SQLStore/EmbeddedQueryDependencyListResolver.php
@@ -1,0 +1,267 @@
+<?php
+
+namespace SMW\SQLStore;
+
+use SMW\Store;
+use SMWQuery as Query;
+use SMWQueryResult as QueryResult;
+use SMW\DIWikiPage;
+use SMW\DIProperty;
+use SMW\ApplicationFactory;
+use SMW\PropertyHierarchyExaminer;
+use SMW\Query\Language\ConceptDescription;
+use SMW\Query\Language\SomeProperty;
+use SMW\Query\Language\ValueDescription;
+use SMW\Query\Language\Disjunction;
+use SMW\Query\Language\Conjunction;
+use SMW\Query\Language\ClassDescription;
+use SMW\Query\Language\ThingDescription;
+
+/**
+ * @license GNU GPL v2+
+ * @since 2.3
+ *
+ * @author mwjames
+ */
+class EmbeddedQueryDependencyListResolver {
+
+	/**
+	 * @var Store
+	 */
+	private $store = null;
+
+	/**
+	 * Specifies a list of property keys to be excluded from the detection
+	 * process.
+	 *
+	 * @var array
+	 */
+	private $propertyDependencyDetectionBlacklist = array();
+
+	/**
+	 * @var PropertyHierarchyExaminer
+	 */
+	private $propertyHierarchyExaminer;
+
+	/**
+	 * @var QueryResult
+	 */
+	private $queryResult;
+
+	/**
+	 * @since 2.3
+	 *
+	 * @param Store $store
+	 * @param PropertyHierarchyExaminer $propertyHierarchyExaminer
+	 */
+	public function __construct( Store $store, PropertyHierarchyExaminer $propertyHierarchyExaminer ) {
+		$this->store = $store;
+		$this->propertyHierarchyExaminer = $propertyHierarchyExaminer;
+	}
+
+	/**
+	 * @since 2.3
+	 *
+	 * @param array $propertyDependencyDetectionBlacklist
+	 */
+	public function setPropertyDependencyDetectionBlacklist( array $propertyDependencyDetectionBlacklist ) {
+		// Make sure that user defined properties are correctly normalized and flip
+		// to build an index based map
+		$this->propertyDependencyDetectionBlacklist = array_flip(
+			str_replace( ' ', '_', $propertyDependencyDetectionBlacklist )
+		);
+	}
+
+	/**
+	 * @since 2.3
+	 *
+	 * @param $queryResult
+	 */
+	public function setQueryResult( $queryResult ) {
+		$this->queryResult = $queryResult;
+	}
+
+	/**
+	 * @since 2.3
+	 *
+	 * @return Query|null
+	 */
+	public function getQuery() {
+		return $this->queryResult instanceof QueryResult ? $this->queryResult->getQuery() : null;
+	}
+
+	/**
+	 * @since 2.3
+	 *
+	 * @return string|null
+	 */
+	public function getQueryId() {
+		return $this->getQuery() !== null ? $this->getQuery()->getQueryId() : null;
+	}
+
+	/**
+	 * @since 2.3
+	 *
+	 * @return DIWikiPage|null
+	 */
+	public function getSubject() {
+		return $this->getQuery() !== null ? $this->getQuery()->getSubject() : null;
+	}
+
+	/**
+	 * @since 2.3
+	 *
+	 * @return DIWikiPage[]|[]
+	 */
+	public function getQueryDependencySubjectList() {
+
+		if ( $this->getSubject() === null ) {
+			return array();
+		}
+
+		$description = $this->getQuery()->getDescription();
+
+		$dependencySubjectList = array(
+			$this->getSubject(),
+		);
+
+		// Find entities described by the query
+		$this->doResolveDependenciesFromDescription(
+			$dependencySubjectList,
+			$description
+		);
+
+		$this->doResolveDependenciesFromPrintRequest(
+			$dependencySubjectList,
+			$description->getPrintRequests()
+		);
+
+		$dependencySubjectList = array_merge(
+			$dependencySubjectList,
+			$this->queryResult->getResults()
+		);
+
+		$this->queryResult->reset();
+
+		return $dependencySubjectList;
+	}
+
+	private function doResolveDependenciesFromDescription( &$subjects, $description ) {
+
+		if ( $description instanceof ValueDescription && $description->getDataItem() instanceof DIWikiPage ) {
+			$subjects[] = $description->getDataItem();
+		}
+
+		if ( $description instanceof ConceptDescription ) {
+			$subjects[] = $description->getConcept();
+			$this->doResolveDependenciesFromDescription(
+				$subjects,
+				$this->getConceptDescription( $description->getConcept() )
+			);
+		}
+
+		if ( $description instanceof ClassDescription ) {
+			foreach ( $description->getCategories() as $category ) {
+
+				if ( $this->propertyHierarchyExaminer->hasSubcategoryFor( $category ) ) {
+					$this->doMatchSubcategory( $subjects, $category );
+				}
+
+				$subjects[] = $category;
+			}
+		}
+
+		if ( $description instanceof SomeProperty ) {
+			$this->doResolveDependenciesFromDescription( $subjects, $description->getDescription() );
+			$this->doMatchProperty( $subjects, $description->getProperty() );
+		}
+
+		if ( $description instanceof Conjunction || $description instanceof Disjunction ) {
+			foreach ( $description->getDescriptions() as $description ) {
+				$this->doResolveDependenciesFromDescription( $subjects, $description );
+			}
+		}
+	}
+
+	private function doMatchProperty( &$subjects, DIProperty $property ) {
+
+		if ( $property->isInverse() ) {
+			$property = new DIProperty( $property->getKey() );
+		}
+
+		if ( $this->propertyHierarchyExaminer->hasSubpropertyFor( $property ) ) {
+			$this->doMatchSubproperty( $subjects, $property );
+		}
+
+		$key = str_replace( ' ', '_', $property->getKey() );
+
+		if ( !isset( $this->propertyDependencyDetectionBlacklist[$key] ) ) {
+			$subjects[] = $property->getDiWikiPage();
+		}
+	}
+
+	private function doMatchSubcategory( &$subjects, DIWikiPage $category ) {
+
+		$subcategories = $this->propertyHierarchyExaminer->findSubcategoryListFor( $category );
+
+		foreach ( $subcategories as $subcategory ) {
+
+			if ( $this->propertyHierarchyExaminer->hasSubcategoryFor( $subcategory ) ) {
+				$this->doMatchSubcategory( $subjects, $subcategory );
+			}
+
+			$subjects[] = $subcategory;
+		}
+	}
+
+	private function doMatchSubproperty( &$subjects, DIProperty $property ) {
+
+		$subproperties = $this->propertyHierarchyExaminer->findSubpropertListFor( $property );
+
+		foreach ( $subproperties as $subproperty ) {
+
+			$subp = new DIProperty( $subproperty->getDBKey() );
+
+			if ( $this->propertyHierarchyExaminer->hasSubpropertyFor( $subp ) ) {
+				$this->doMatchSubproperty( $subjects, $subp );
+			}
+
+			$subjects[] = $subproperty;
+		}
+	}
+
+	private function doResolveDependenciesFromPrintRequest( &$subjects, array $printRequests ) {
+
+		foreach ( $printRequests as $printRequest ) {
+			$data = $printRequest->getData();
+
+			if ( $data instanceof \SMWPropertyValue ) {
+				$subjects[] = $data->getDataItem()->getDiWikiPage();
+			}
+
+			// Category
+			if ( $data instanceof \Title ) {
+				$subjects[] = DIWikiPage::newFromTitle( $data );
+			}
+		}
+	}
+
+	private function getConceptDescription( DIWikiPage $concept ) {
+
+		$value = $this->store->getPropertyValues(
+			$concept,
+			new DIProperty( '_CONC' )
+		);
+
+		if ( $value === null || $value === array() ) {
+			return new ThingDescription();
+		}
+
+		$value = end( $value );
+
+		return ApplicationFactory::getInstance()->newQueryParser()->getQueryDescription(
+			$value->getConceptQuery()
+		);
+	}
+
+}

--- a/src/SQLStore/EmbeddedQueryDependencyListResolver.php
+++ b/src/SQLStore/EmbeddedQueryDependencyListResolver.php
@@ -226,7 +226,11 @@ class EmbeddedQueryDependencyListResolver {
 				$this->doMatchSubproperty( $subjects, $subp );
 			}
 
-			$subjects[] = $subproperty;
+			$key = str_replace( ' ', '_', $subp->getKey() );
+
+			if ( !isset( $this->propertyDependencyDetectionBlacklist[$key] ) ) {
+				$subjects[] = $subproperty;
+			}
 		}
 	}
 

--- a/src/SQLStore/EmbeddedQueryDependencyListResolver.php
+++ b/src/SQLStore/EmbeddedQueryDependencyListResolver.php
@@ -8,7 +8,7 @@ use SMWQueryResult as QueryResult;
 use SMW\DIWikiPage;
 use SMW\DIProperty;
 use SMW\ApplicationFactory;
-use SMW\PropertyHierarchyExaminer;
+use SMW\PropertyHierarchyLookup;
 use SMW\Query\Language\ConceptDescription;
 use SMW\Query\Language\SomeProperty;
 use SMW\Query\Language\ValueDescription;
@@ -39,9 +39,9 @@ class EmbeddedQueryDependencyListResolver {
 	private $propertyDependencyDetectionBlacklist = array();
 
 	/**
-	 * @var PropertyHierarchyExaminer
+	 * @var PropertyHierarchyLookup
 	 */
-	private $propertyHierarchyExaminer;
+	private $propertyHierarchyLookup;
 
 	/**
 	 * @var QueryResult
@@ -52,11 +52,11 @@ class EmbeddedQueryDependencyListResolver {
 	 * @since 2.3
 	 *
 	 * @param Store $store
-	 * @param PropertyHierarchyExaminer $propertyHierarchyExaminer
+	 * @param PropertyHierarchyLookup $propertyHierarchyLookup
 	 */
-	public function __construct( Store $store, PropertyHierarchyExaminer $propertyHierarchyExaminer ) {
+	public function __construct( Store $store, PropertyHierarchyLookup $propertyHierarchyLookup ) {
 		$this->store = $store;
-		$this->propertyHierarchyExaminer = $propertyHierarchyExaminer;
+		$this->propertyHierarchyLookup = $propertyHierarchyLookup;
 	}
 
 	/**
@@ -163,7 +163,7 @@ class EmbeddedQueryDependencyListResolver {
 		if ( $description instanceof ClassDescription ) {
 			foreach ( $description->getCategories() as $category ) {
 
-				if ( $this->propertyHierarchyExaminer->hasSubcategoryFor( $category ) ) {
+				if ( $this->propertyHierarchyLookup->hasSubcategoryFor( $category ) ) {
 					$this->doMatchSubcategory( $subjects, $category );
 				}
 
@@ -189,7 +189,7 @@ class EmbeddedQueryDependencyListResolver {
 			$property = new DIProperty( $property->getKey() );
 		}
 
-		if ( $this->propertyHierarchyExaminer->hasSubpropertyFor( $property ) ) {
+		if ( $this->propertyHierarchyLookup->hasSubpropertyFor( $property ) ) {
 			$this->doMatchSubproperty( $subjects, $property );
 		}
 
@@ -202,11 +202,11 @@ class EmbeddedQueryDependencyListResolver {
 
 	private function doMatchSubcategory( &$subjects, DIWikiPage $category ) {
 
-		$subcategories = $this->propertyHierarchyExaminer->findSubcategoryListFor( $category );
+		$subcategories = $this->propertyHierarchyLookup->findSubcategoryListFor( $category );
 
 		foreach ( $subcategories as $subcategory ) {
 
-			if ( $this->propertyHierarchyExaminer->hasSubcategoryFor( $subcategory ) ) {
+			if ( $this->propertyHierarchyLookup->hasSubcategoryFor( $subcategory ) ) {
 				$this->doMatchSubcategory( $subjects, $subcategory );
 			}
 
@@ -216,13 +216,13 @@ class EmbeddedQueryDependencyListResolver {
 
 	private function doMatchSubproperty( &$subjects, DIProperty $property ) {
 
-		$subproperties = $this->propertyHierarchyExaminer->findSubpropertListFor( $property );
+		$subproperties = $this->propertyHierarchyLookup->findSubpropertListFor( $property );
 
 		foreach ( $subproperties as $subproperty ) {
 
 			$subp = new DIProperty( $subproperty->getDBKey() );
 
-			if ( $this->propertyHierarchyExaminer->hasSubpropertyFor( $subp ) ) {
+			if ( $this->propertyHierarchyLookup->hasSubpropertyFor( $subp ) ) {
 				$this->doMatchSubproperty( $subjects, $subp );
 			}
 

--- a/tests/phpunit/Unit/SQLStore/EmbeddedQueryDependencyListResolverTest.php
+++ b/tests/phpunit/Unit/SQLStore/EmbeddedQueryDependencyListResolverTest.php
@@ -1,0 +1,452 @@
+<?php
+
+namespace SMW\Tests\SQLStore;
+
+use SMW\SQLStore\EmbeddedQueryDependencyListResolver;
+use SMW\Query\Language\SomeProperty;
+use SMW\Query\Language\ValueDescription;
+use SMW\Query\Language\ClassDescription;
+use SMW\Query\Language\ConceptDescription;
+use SMW\Query\Language\NamespaceDescription;
+use SMW\Query\Language\Conjunction;
+use SMW\Query\Language\Disjunction;
+use SMW\ApplicationFactory;
+use SMW\DIWikiPage;
+use SMW\DIProperty;
+use SMWQuery as Query;
+use SMWDIBlob as DIBlob;
+
+/**
+ * @covers \SMW\SQLStore\EmbeddedQueryDependencyListResolver
+ * @group semantic-mediawiki
+ *
+ * @license GNU GPL v2+
+ * @since 2.3
+ *
+ * @author mwjames
+ */
+class EmbeddedQueryDependencyListResolverTest extends \PHPUnit_Framework_TestCase {
+
+	private $applicationFactory;
+
+	protected function setUp() {
+		parent::setUp();
+
+		$this->applicationFactory = ApplicationFactory::getInstance();
+
+		$store = $this->getMockBuilder( '\SMW\Store' )
+			->disableOriginalConstructor()
+			->getMockForAbstractClass();
+
+		$this->applicationFactory->registerObject( 'Store', $store );
+	}
+
+	protected function tearDown() {
+		$this->applicationFactory->clear();
+
+		parent::tearDown();
+	}
+
+	public function testCanConstruct() {
+
+		$store = $this->getMockBuilder( '\SMW\Store' )
+			->disableOriginalConstructor()
+			->getMockForAbstractClass();
+
+		$propertyHierarchyExaminer = $this->getMockBuilder( '\SMW\PropertyHierarchyExaminer' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$this->assertInstanceOf(
+			'\SMW\SQLStore\EmbeddedQueryDependencyListResolver',
+			new EmbeddedQueryDependencyListResolver( $store, $propertyHierarchyExaminer )
+		);
+	}
+
+	public function testGetQueryDependencySubjectListForNonSetQueryResult() {
+
+		$store = $this->getMockBuilder( '\SMW\Store' )
+			->disableOriginalConstructor()
+			->getMockForAbstractClass();
+
+		$propertyHierarchyExaminer = $this->getMockBuilder( '\SMW\PropertyHierarchyExaminer' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$instance = new EmbeddedQueryDependencyListResolver(
+			$store,
+			$propertyHierarchyExaminer
+		);
+
+		$this->assertNull(
+			$instance->getQueryId()
+		);
+
+		$this->assertNull(
+			$instance->getSubject()
+		);
+
+		$this->assertEmpty(
+			$instance->getQueryDependencySubjectList()
+		);
+	}
+
+	public function testExcludePropertyFromDependencyDetection() {
+
+		$subject = DIWikiPage::newFromText( 'Foo' );
+
+		$description = new SomeProperty(
+			new DIProperty( 'Foobar' ),
+			new ValueDescription( DIWikiPage::newFromText( 'Bar' ) )
+		);
+
+		$query = new Query( $description );
+		$query->setSubject( $subject );
+
+		$queryResult = $this->getMockBuilder( '\SMWQueryResult' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$queryResult->expects( $this->once() )
+			->method( 'getResults' )
+			->will( $this->returnValue( array() ) );
+
+		$queryResult->expects( $this->any() )
+			->method( 'getQuery' )
+			->will( $this->returnValue( $query ) );
+
+		$store = $this->getMockBuilder( '\SMW\Store' )
+			->disableOriginalConstructor()
+			->getMockForAbstractClass();
+
+		$propertyHierarchyExaminer = $this->getMockBuilder( '\SMW\PropertyHierarchyExaminer' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$instance = new EmbeddedQueryDependencyListResolver(
+			$store,
+			$propertyHierarchyExaminer
+		);
+
+		$instance->setQueryResult( $queryResult );
+		$instance->setPropertyDependencyDetectionBlacklist( array( 'Foobar' ) );
+
+		$expected = array(
+			DIWikiPage::newFromText( 'Foo' ),
+			DIWikiPage::newFromText( 'Bar' )
+		//	DIWikiPage::newFromText( 'Foobar', SMW_NS_PROPERTY ) removed
+		);
+
+		$this->assertEquals(
+			$expected,
+			$instance->getQueryDependencySubjectList()
+		);
+	}
+
+	/**
+	 * @dataProvider queryProvider
+	 */
+	public function testGetQueryDependencySubjectList( $query, $expected ) {
+
+		$queryResult = $this->getMockBuilder( '\SMWQueryResult' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$queryResult->expects( $this->once() )
+			->method( 'getResults' )
+			->will( $this->returnValue( array() ) );
+
+		$queryResult->expects( $this->any() )
+			->method( 'getQuery' )
+			->will( $this->returnValue( $query ) );
+
+		$store = $this->getMockBuilder( '\SMW\Store' )
+			->disableOriginalConstructor()
+			->getMockForAbstractClass();
+
+		$propertyHierarchyExaminer = $this->getMockBuilder( '\SMW\PropertyHierarchyExaminer' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$instance = new EmbeddedQueryDependencyListResolver(
+			$store,
+			$propertyHierarchyExaminer
+		);
+
+		$instance->setQueryResult( $queryResult );
+
+		$this->assertEquals(
+			$expected,
+			$instance->getQueryDependencySubjectList()
+		);
+	}
+
+	public function testResolvePropertyHierarchy() {
+
+		$subject = DIWikiPage::newFromText( 'Foo' );
+
+		$description = new SomeProperty(
+			new DIProperty( 'Foobar' ),
+			new ValueDescription( DIWikiPage::newFromText( 'Bar' ) )
+		);
+
+		$query = new Query( $description );
+		$query->setSubject( $subject );
+
+		$queryResult = $this->getMockBuilder( '\SMWQueryResult' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$queryResult->expects( $this->once() )
+			->method( 'getResults' )
+			->will( $this->returnValue( array() ) );
+
+		$queryResult->expects( $this->any() )
+			->method( 'getQuery' )
+			->will( $this->returnValue( $query ) );
+
+		$store = $this->getMockBuilder( '\SMW\Store' )
+			->disableOriginalConstructor()
+			->getMockForAbstractClass();
+
+		$propertyHierarchyExaminer = $this->getMockBuilder( '\SMW\PropertyHierarchyExaminer' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$propertyHierarchyExaminer->expects( $this->any() )
+			->method( 'hasSubpropertyFor' )
+			->will( $this->returnValue( true ) );
+
+		$propertyHierarchyExaminer->expects( $this->at( 1 ) )
+			->method( 'findSubpropertListFor' )
+			->with( $this->equalTo( new DIProperty( 'Foobar' ) ) )
+			->will( $this->returnValue(
+				array( DIWikiPage::newFromText( 'Subprop', SMW_NS_PROPERTY ) ) ) );
+
+		$propertyHierarchyExaminer->expects( $this->at( 3 ) )
+			->method( 'findSubpropertListFor' )
+			->with( $this->equalTo( new DIProperty( 'Subprop' ) ) )
+			->will( $this->returnValue( array() ) );
+
+		$instance = new EmbeddedQueryDependencyListResolver(
+			$store,
+			$propertyHierarchyExaminer
+		);
+
+		$instance->setQueryResult( $queryResult );
+
+		$expected = array(
+			DIWikiPage::newFromText( 'Foo' ),
+			DIWikiPage::newFromText( 'Bar' ),
+			DIWikiPage::newFromText( 'Subprop', SMW_NS_PROPERTY ),
+			DIWikiPage::newFromText( 'Foobar', SMW_NS_PROPERTY )
+		);
+
+		$this->assertEquals(
+			$expected,
+			$instance->getQueryDependencySubjectList()
+		);
+	}
+
+	public function testResolveCategoryHierarchy() {
+
+		$subject = DIWikiPage::newFromText( 'Foo' );
+
+		$description = new ClassDescription(
+			DIWikiPage::newFromText( 'Foocat', NS_CATEGORY )
+		);
+
+		$query = new Query( $description );
+		$query->setSubject( $subject );
+
+		$queryResult = $this->getMockBuilder( '\SMWQueryResult' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$queryResult->expects( $this->once() )
+			->method( 'getResults' )
+			->will( $this->returnValue( array() ) );
+
+		$queryResult->expects( $this->any() )
+			->method( 'getQuery' )
+			->will( $this->returnValue( $query ) );
+
+		$store = $this->getMockBuilder( '\SMW\Store' )
+			->disableOriginalConstructor()
+			->getMockForAbstractClass();
+
+		$propertyHierarchyExaminer = $this->getMockBuilder( '\SMW\PropertyHierarchyExaminer' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$propertyHierarchyExaminer->expects( $this->any() )
+			->method( 'hasSubcategoryFor' )
+			->will( $this->returnValue( true ) );
+
+		$propertyHierarchyExaminer->expects( $this->at( 1 ) )
+			->method( 'findSubcategoryListFor' )
+			->with( $this->equalTo( DIWikiPage::newFromText( 'Foocat', NS_CATEGORY ) ) )
+			->will( $this->returnValue(
+				array( DIWikiPage::newFromText( 'Subcat', NS_CATEGORY ) ) ) );
+
+		$propertyHierarchyExaminer->expects( $this->at( 3 ) )
+			->method( 'findSubcategoryListFor' )
+			->with( $this->equalTo( DIWikiPage::newFromText( 'Subcat', NS_CATEGORY ) ) )
+			->will( $this->returnValue( array() ) );
+
+		$instance = new EmbeddedQueryDependencyListResolver(
+			$store,
+			$propertyHierarchyExaminer
+		);
+
+		$instance->setQueryResult( $queryResult );
+
+		$expected = array(
+			DIWikiPage::newFromText( 'Foo' ),
+			DIWikiPage::newFromText( 'Subcat', NS_CATEGORY ),
+			DIWikiPage::newFromText( 'Foocat', NS_CATEGORY )
+		);
+
+		$this->assertEquals(
+			$expected,
+			$instance->getQueryDependencySubjectList()
+		);
+	}
+
+	public function queryProvider() {
+
+		$subject = DIWikiPage::newFromText( 'Foo' );
+
+		#0
+		$description = new SomeProperty(
+			new DIProperty( 'Foobar' ),
+			new ValueDescription( DIWikiPage::newFromText( 'Bar' ) )
+		);
+
+		$query = new Query( $description );
+		$query->setSubject( $subject );
+
+		$provider[] = array(
+			$query,
+			array(
+				DIWikiPage::newFromText( 'Foo' ),
+				DIWikiPage::newFromText( 'Bar' ),
+				DIWikiPage::newFromText( 'Foobar', SMW_NS_PROPERTY )
+			)
+		);
+
+		#1
+		$description = new SomeProperty(
+			new DIProperty( 'Foobar' ),
+			new ValueDescription( new DIBlob( 'Bar' ) )
+		);
+
+		$query = new Query( $description );
+		$query->setSubject( $subject );
+
+		$provider[] = array(
+			$query,
+			array(
+				DIWikiPage::newFromText( 'Foo' ),
+				DIWikiPage::newFromText( 'Foobar', SMW_NS_PROPERTY )
+			)
+		);
+
+		#2 uses inverse property declaration
+		$description = new SomeProperty(
+			new DIProperty( 'Foobar', true ),
+			new ValueDescription( DIWikiPage::newFromText( 'Bar' ) )
+		);
+
+		$query = new Query( $description );
+		$query->setSubject( $subject );
+
+		$provider[] = array(
+			$query,
+			array(
+				DIWikiPage::newFromText( 'Foo' ),
+				DIWikiPage::newFromText( 'Bar' ),
+				DIWikiPage::newFromText( 'Foobar', SMW_NS_PROPERTY )
+			)
+		);
+
+		#3 Conjunction
+		$description = new SomeProperty(
+			new DIProperty( 'Foobar' ),
+			new ValueDescription( DIWikiPage::newFromText( 'Bar' ) )
+		);
+
+		$query = new Query( new Conjunction( array(
+			$description,
+			new NamespaceDescription( NS_MAIN )
+		) ) );
+
+		$query->setSubject( $subject );
+
+		$provider[] = array(
+			$query,
+			array(
+				DIWikiPage::newFromText( 'Foo' ),
+				DIWikiPage::newFromText( 'Bar' ),
+				DIWikiPage::newFromText( 'Foobar', SMW_NS_PROPERTY )
+			)
+		);
+
+		#4 Disjunction
+		$description = new SomeProperty(
+			new DIProperty( 'Foobar' ),
+			new ValueDescription( DIWikiPage::newFromText( 'Bar' ) )
+		);
+
+		$query = new Query( new Disjunction( array(
+			$description,
+			new NamespaceDescription( NS_MAIN )
+		) ) );
+
+		$query->setSubject( $subject );
+
+		$provider[] = array(
+			$query,
+			array(
+				DIWikiPage::newFromText( 'Foo' ),
+				DIWikiPage::newFromText( 'Bar' ),
+				DIWikiPage::newFromText( 'Foobar', SMW_NS_PROPERTY )
+			)
+		);
+
+		#5
+		$description = new ClassDescription(
+			DIWikiPage::newFromText( 'Foocat', NS_CATEGORY )
+		);
+
+		$query = new Query( $description );
+		$query->setSubject( $subject );
+
+		$provider[] = array(
+			$query,
+			array(
+				DIWikiPage::newFromText( 'Foo' ),
+				DIWikiPage::newFromText( 'Foocat', NS_CATEGORY )
+			)
+		);
+
+		#6
+		$description = new ConceptDescription(
+			DIWikiPage::newFromText( 'FooConcept', SMW_NS_CONCEPT )
+		);
+
+		$query = new Query( $description );
+		$query->setSubject( $subject );
+
+		$provider[] = array(
+			$query,
+			array(
+				DIWikiPage::newFromText( 'Foo' ),
+				DIWikiPage::newFromText( 'FooConcept', SMW_NS_CONCEPT )
+			)
+		);
+
+		return $provider;
+	}
+
+}

--- a/tests/phpunit/Unit/SQLStore/EmbeddedQueryDependencyListResolverTest.php
+++ b/tests/phpunit/Unit/SQLStore/EmbeddedQueryDependencyListResolverTest.php
@@ -53,13 +53,13 @@ class EmbeddedQueryDependencyListResolverTest extends \PHPUnit_Framework_TestCas
 			->disableOriginalConstructor()
 			->getMockForAbstractClass();
 
-		$propertyHierarchyExaminer = $this->getMockBuilder( '\SMW\PropertyHierarchyExaminer' )
+		$propertyHierarchyLookup = $this->getMockBuilder( '\SMW\PropertyHierarchyLookup' )
 			->disableOriginalConstructor()
 			->getMock();
 
 		$this->assertInstanceOf(
 			'\SMW\SQLStore\EmbeddedQueryDependencyListResolver',
-			new EmbeddedQueryDependencyListResolver( $store, $propertyHierarchyExaminer )
+			new EmbeddedQueryDependencyListResolver( $store, $propertyHierarchyLookup )
 		);
 	}
 
@@ -69,13 +69,13 @@ class EmbeddedQueryDependencyListResolverTest extends \PHPUnit_Framework_TestCas
 			->disableOriginalConstructor()
 			->getMockForAbstractClass();
 
-		$propertyHierarchyExaminer = $this->getMockBuilder( '\SMW\PropertyHierarchyExaminer' )
+		$propertyHierarchyLookup = $this->getMockBuilder( '\SMW\PropertyHierarchyLookup' )
 			->disableOriginalConstructor()
 			->getMock();
 
 		$instance = new EmbeddedQueryDependencyListResolver(
 			$store,
-			$propertyHierarchyExaminer
+			$propertyHierarchyLookup
 		);
 
 		$this->assertNull(
@@ -119,13 +119,13 @@ class EmbeddedQueryDependencyListResolverTest extends \PHPUnit_Framework_TestCas
 			->disableOriginalConstructor()
 			->getMockForAbstractClass();
 
-		$propertyHierarchyExaminer = $this->getMockBuilder( '\SMW\PropertyHierarchyExaminer' )
+		$propertyHierarchyLookup = $this->getMockBuilder( '\SMW\PropertyHierarchyLookup' )
 			->disableOriginalConstructor()
 			->getMock();
 
 		$instance = new EmbeddedQueryDependencyListResolver(
 			$store,
-			$propertyHierarchyExaminer
+			$propertyHierarchyLookup
 		);
 
 		$instance->setQueryResult( $queryResult );
@@ -164,13 +164,13 @@ class EmbeddedQueryDependencyListResolverTest extends \PHPUnit_Framework_TestCas
 			->disableOriginalConstructor()
 			->getMockForAbstractClass();
 
-		$propertyHierarchyExaminer = $this->getMockBuilder( '\SMW\PropertyHierarchyExaminer' )
+		$propertyHierarchyLookup = $this->getMockBuilder( '\SMW\PropertyHierarchyLookup' )
 			->disableOriginalConstructor()
 			->getMock();
 
 		$instance = new EmbeddedQueryDependencyListResolver(
 			$store,
-			$propertyHierarchyExaminer
+			$propertyHierarchyLookup
 		);
 
 		$instance->setQueryResult( $queryResult );
@@ -209,28 +209,28 @@ class EmbeddedQueryDependencyListResolverTest extends \PHPUnit_Framework_TestCas
 			->disableOriginalConstructor()
 			->getMockForAbstractClass();
 
-		$propertyHierarchyExaminer = $this->getMockBuilder( '\SMW\PropertyHierarchyExaminer' )
+		$propertyHierarchyLookup = $this->getMockBuilder( '\SMW\PropertyHierarchyLookup' )
 			->disableOriginalConstructor()
 			->getMock();
 
-		$propertyHierarchyExaminer->expects( $this->any() )
+		$propertyHierarchyLookup->expects( $this->any() )
 			->method( 'hasSubpropertyFor' )
 			->will( $this->returnValue( true ) );
 
-		$propertyHierarchyExaminer->expects( $this->at( 1 ) )
+		$propertyHierarchyLookup->expects( $this->at( 1 ) )
 			->method( 'findSubpropertListFor' )
 			->with( $this->equalTo( new DIProperty( 'Foobar' ) ) )
 			->will( $this->returnValue(
 				array( DIWikiPage::newFromText( 'Subprop', SMW_NS_PROPERTY ) ) ) );
 
-		$propertyHierarchyExaminer->expects( $this->at( 3 ) )
+		$propertyHierarchyLookup->expects( $this->at( 3 ) )
 			->method( 'findSubpropertListFor' )
 			->with( $this->equalTo( new DIProperty( 'Subprop' ) ) )
 			->will( $this->returnValue( array() ) );
 
 		$instance = new EmbeddedQueryDependencyListResolver(
 			$store,
-			$propertyHierarchyExaminer
+			$propertyHierarchyLookup
 		);
 
 		$instance->setQueryResult( $queryResult );
@@ -275,28 +275,28 @@ class EmbeddedQueryDependencyListResolverTest extends \PHPUnit_Framework_TestCas
 			->disableOriginalConstructor()
 			->getMockForAbstractClass();
 
-		$propertyHierarchyExaminer = $this->getMockBuilder( '\SMW\PropertyHierarchyExaminer' )
+		$propertyHierarchyLookup = $this->getMockBuilder( '\SMW\PropertyHierarchyLookup' )
 			->disableOriginalConstructor()
 			->getMock();
 
-		$propertyHierarchyExaminer->expects( $this->any() )
+		$propertyHierarchyLookup->expects( $this->any() )
 			->method( 'hasSubcategoryFor' )
 			->will( $this->returnValue( true ) );
 
-		$propertyHierarchyExaminer->expects( $this->at( 1 ) )
+		$propertyHierarchyLookup->expects( $this->at( 1 ) )
 			->method( 'findSubcategoryListFor' )
 			->with( $this->equalTo( DIWikiPage::newFromText( 'Foocat', NS_CATEGORY ) ) )
 			->will( $this->returnValue(
 				array( DIWikiPage::newFromText( 'Subcat', NS_CATEGORY ) ) ) );
 
-		$propertyHierarchyExaminer->expects( $this->at( 3 ) )
+		$propertyHierarchyLookup->expects( $this->at( 3 ) )
 			->method( 'findSubcategoryListFor' )
 			->with( $this->equalTo( DIWikiPage::newFromText( 'Subcat', NS_CATEGORY ) ) )
 			->will( $this->returnValue( array() ) );
 
 		$instance = new EmbeddedQueryDependencyListResolver(
 			$store,
-			$propertyHierarchyExaminer
+			$propertyHierarchyLookup
 		);
 
 		$instance->setQueryResult( $queryResult );

--- a/tests/phpunit/Unit/SQLStore/EmbeddedQueryDependencyListResolverTest.php
+++ b/tests/phpunit/Unit/SQLStore/EmbeddedQueryDependencyListResolverTest.php
@@ -123,17 +123,33 @@ class EmbeddedQueryDependencyListResolverTest extends \PHPUnit_Framework_TestCas
 			->disableOriginalConstructor()
 			->getMock();
 
+		$propertyHierarchyLookup->expects( $this->any() )
+			->method( 'hasSubpropertyFor' )
+			->will( $this->returnValue( true ) );
+
+		$propertyHierarchyLookup->expects( $this->at( 1 ) )
+			->method( 'findSubpropertListFor' )
+			->with( $this->equalTo( new DIProperty( 'Foobar' ) ) )
+			->will( $this->returnValue(
+				array( DIWikiPage::newFromText( 'Subprop', SMW_NS_PROPERTY ) ) ) );
+
+		$propertyHierarchyLookup->expects( $this->at( 3 ) )
+			->method( 'findSubpropertListFor' )
+			->with( $this->equalTo( new DIProperty( 'Subprop' ) ) )
+			->will( $this->returnValue( array() ) );
+
 		$instance = new EmbeddedQueryDependencyListResolver(
 			$store,
 			$propertyHierarchyLookup
 		);
 
 		$instance->setQueryResult( $queryResult );
-		$instance->setPropertyDependencyDetectionBlacklist( array( 'Foobar' ) );
+		$instance->setPropertyDependencyDetectionBlacklist( array( 'Foobar', 'Subprop' ) );
 
 		$expected = array(
 			DIWikiPage::newFromText( 'Foo' ),
 			DIWikiPage::newFromText( 'Bar' )
+		//	DIWikiPage::newFromText( 'Subprop', SMW_NS_PROPERTY ) removed
 		//	DIWikiPage::newFromText( 'Foobar', SMW_NS_PROPERTY ) removed
 		);
 

--- a/tests/phpunit/includes/PropertyHierarchyLookupTest.php
+++ b/tests/phpunit/includes/PropertyHierarchyLookupTest.php
@@ -2,12 +2,12 @@
 
 namespace SMW\Tests;
 
-use SMW\PropertyHierarchyExaminer;
+use SMW\PropertyHierarchyLookup;
 use SMW\DIProperty;
 use SMW\DIWikiPage;
 
 /**
- * @covers \SMW\PropertyHierarchyExaminer
+ * @covers \SMW\PropertyHierarchyLookup
  * @group semantic-mediawiki
  *
  * @license GNU GPL v2+
@@ -15,7 +15,7 @@ use SMW\DIWikiPage;
  *
  * @author mwjames
  */
-class PropertyHierarchyExaminerTest extends \PHPUnit_Framework_TestCase {
+class PropertyHierarchyLookupTest extends \PHPUnit_Framework_TestCase {
 
 	public function testCanConstruct() {
 
@@ -28,8 +28,8 @@ class PropertyHierarchyExaminerTest extends \PHPUnit_Framework_TestCase {
 			->getMock();
 
 		$this->assertInstanceOf(
-			'\SMW\PropertyHierarchyExaminer',
-			new PropertyHierarchyExaminer( $store, $cache )
+			'\SMW\PropertyHierarchyLookup',
+			new PropertyHierarchyLookup( $store, $cache )
 		);
 	}
 
@@ -57,7 +57,7 @@ class PropertyHierarchyExaminerTest extends \PHPUnit_Framework_TestCase {
 				$this->equalTo( 'm#_SUBP#Foo' ),
 				$this->equalTo( false ) );
 
-		$instance = new PropertyHierarchyExaminer( $store, $cache );
+		$instance = new PropertyHierarchyLookup( $store, $cache );
 
 		$this->assertInternalType(
 			'boolean',
@@ -95,7 +95,7 @@ class PropertyHierarchyExaminerTest extends \PHPUnit_Framework_TestCase {
 				$this->equalTo( 'f#_SUBP#Foo' ),
 				$this->anything() );
 
-		$instance = new PropertyHierarchyExaminer( $store, $cache );
+		$instance = new PropertyHierarchyLookup( $store, $cache );
 
 		$expected = array(
 			DIWikiPage::newFromText( 'Bar', SMW_NS_PROPERTY )
@@ -137,7 +137,7 @@ class PropertyHierarchyExaminerTest extends \PHPUnit_Framework_TestCase {
 				$this->equalTo( 'f#_SUBC#Foo' ),
 				$this->anything() );
 
-		$instance = new PropertyHierarchyExaminer( $store, $cache );
+		$instance = new PropertyHierarchyLookup( $store, $cache );
 
 		$expected = array(
 			DIWikiPage::newFromText( 'Bar', NS_CATEGORY )
@@ -163,7 +163,7 @@ class PropertyHierarchyExaminerTest extends \PHPUnit_Framework_TestCase {
 			->method( 'contains' )
 			->will( $this->returnValue( false ) );
 
-		$instance = new PropertyHierarchyExaminer( $store, $cache );
+		$instance = new PropertyHierarchyLookup( $store, $cache );
 		$instance->setSubpropertyDepth( 0 );
 
 		$this->assertFalse(
@@ -185,7 +185,7 @@ class PropertyHierarchyExaminerTest extends \PHPUnit_Framework_TestCase {
 			->method( 'contains' )
 			->will( $this->returnValue( false ) );
 
-		$instance = new PropertyHierarchyExaminer( $store, $cache );
+		$instance = new PropertyHierarchyLookup( $store, $cache );
 		$instance->setSubcategoryDepth( 0 );
 
 		$this->assertFalse(

--- a/tests/phpunit/includes/SPARQLStore/QueryEngine/CompoundConditionBuilderTest.php
+++ b/tests/phpunit/includes/SPARQLStore/QueryEngine/CompoundConditionBuilderTest.php
@@ -27,7 +27,6 @@ use SMWPropertyValue as PropertyValue;
 
 /**
  * @covers \SMW\SPARQLStore\QueryEngine\CompoundConditionBuilder
- *
  * @group semantic-mediawiki
  *
  * @license GNU GPL v2+

--- a/tests/phpunit/includes/SPARQLStore/QueryEngine/Interpreter/ClassDescriptionInterpreterTest.php
+++ b/tests/phpunit/includes/SPARQLStore/QueryEngine/Interpreter/ClassDescriptionInterpreterTest.php
@@ -11,7 +11,6 @@ use SMW\DIProperty;
 
 /**
  * @covers \SMW\SPARQLStore\QueryEngine\Interpreter\ClassDescriptionInterpreter
- *
  * @group semantic-mediawiki
  *
  * @license GNU GPL v2+
@@ -85,11 +84,11 @@ class ClassDescriptionInterpreterTest extends \PHPUnit_Framework_TestCase {
 			\SMWExporter::getInstance()->getResourceElementForWikiPage( $category )
 		);
 
-		$propertyHierarchyExaminer = $this->getMockBuilder( '\SMW\PropertyHierarchyExaminer' )
+		$propertyHierarchyLookup = $this->getMockBuilder( '\SMW\PropertyHierarchyLookup' )
 			->disableOriginalConstructor()
 			->getMock();
 
-		$propertyHierarchyExaminer->expects( $this->once() )
+		$propertyHierarchyLookup->expects( $this->once() )
 			->method( 'hasSubcategoryFor' )
 			->with( $this->equalTo( $category ) )
 			->will( $this->returnValue( true ) );
@@ -97,7 +96,7 @@ class ClassDescriptionInterpreterTest extends \PHPUnit_Framework_TestCase {
 		$resultVariable = 'result';
 
 		$compoundConditionBuilder = new CompoundConditionBuilder();
-		$compoundConditionBuilder->setPropertyHierarchyExaminer( $propertyHierarchyExaminer );
+		$compoundConditionBuilder->setPropertyHierarchyLookup( $propertyHierarchyLookup );
 		$compoundConditionBuilder->setResultVariable( $resultVariable );
 		$compoundConditionBuilder->setJoinVariable( $resultVariable );
 

--- a/tests/phpunit/includes/SPARQLStore/QueryEngine/Interpreter/SomePropertyInterpreterTest.php
+++ b/tests/phpunit/includes/SPARQLStore/QueryEngine/Interpreter/SomePropertyInterpreterTest.php
@@ -63,14 +63,14 @@ class SomePropertyInterpreterTest extends \PHPUnit_Framework_TestCase {
 	 */
 	public function testSomeProperty( $description, $orderByProperty, $sortkeys, $expectedConditionType, $expectedConditionString ) {
 
-		$propertyHierarchyExaminer = $this->getMockBuilder( '\SMW\PropertyHierarchyExaminer' )
+		$propertyHierarchyLookup = $this->getMockBuilder( '\SMW\PropertyHierarchyLookup' )
 			->disableOriginalConstructor()
 			->getMock();
 
 		$resultVariable = 'result';
 
 		$compoundConditionBuilder = new CompoundConditionBuilder();
-		$compoundConditionBuilder->setPropertyHierarchyExaminer( $propertyHierarchyExaminer );
+		$compoundConditionBuilder->setPropertyHierarchyLookup( $propertyHierarchyLookup );
 		$compoundConditionBuilder->setResultVariable( $resultVariable );
 		$compoundConditionBuilder->setSortKeys( $sortkeys );
 		$compoundConditionBuilder->setJoinVariable( $resultVariable );
@@ -95,11 +95,11 @@ class SomePropertyInterpreterTest extends \PHPUnit_Framework_TestCase {
 
 		$property = new DIProperty( 'Foo' );
 
-		$propertyHierarchyExaminer = $this->getMockBuilder( '\SMW\PropertyHierarchyExaminer' )
+		$propertyHierarchyLookup = $this->getMockBuilder( '\SMW\PropertyHierarchyLookup' )
 			->disableOriginalConstructor()
 			->getMock();
 
-		$propertyHierarchyExaminer->expects( $this->once() )
+		$propertyHierarchyLookup->expects( $this->once() )
 			->method( 'hasSubpropertyFor' )
 			->with( $this->equalTo( $property ) )
 			->will( $this->returnValue( true ) );
@@ -107,7 +107,7 @@ class SomePropertyInterpreterTest extends \PHPUnit_Framework_TestCase {
 		$resultVariable = 'result';
 
 		$compoundConditionBuilder = new CompoundConditionBuilder();
-		$compoundConditionBuilder->setPropertyHierarchyExaminer( $propertyHierarchyExaminer );
+		$compoundConditionBuilder->setPropertyHierarchyLookup( $propertyHierarchyLookup );
 		$compoundConditionBuilder->setResultVariable( $resultVariable );
 		$compoundConditionBuilder->setJoinVariable( $resultVariable );
 

--- a/tests/phpunit/includes/SPARQLStore/SPARQLStoreFactoryTest.php
+++ b/tests/phpunit/includes/SPARQLStore/SPARQLStoreFactoryTest.php
@@ -6,7 +6,6 @@ use SMW\SPARQLStore\SPARQLStoreFactory;
 
 /**
  * @covers \SMW\SPARQLStore\SPARQLStoreFactory
- *
  * @group semantic-mediawiki
  *
  * @license GNU GPL v2+


### PR DESCRIPTION
…, refs #1117

- Move dependencies detection from `EmbeddedQueryDependencyLinksStore` to `EmbeddedQueryDependencyListResolver`
- Add ability for `EmbeddedQueryDependencyListResolver` to resolve hierarchies

![image](https://cloud.githubusercontent.com/assets/1245473/9701813/39d40b04-543e-11e5-8436-eae2d2b195d4.png)

If a property:Bar (which is a subproperty of property:Foo) is changed/added then `EmbeddedQueryDependencyLinksStore` will notify related queries that have either property:Bar or property:Foo as part of the dependency list.

Improved SRP in terms of:
- `EmbeddedQueryDependencyLinksStore` is responsible to interact with the `QUERY_LINKS_TABLE`
- `EmbeddedQueryDependencyListResolver` is responsible to collect and resolve
subject dependencies for a QueryResult (Query) object
