### PR TITLE
Use 'noparse' => false in #set when template is used, refs #1067

### DIFF
--- a/includes/ParserData.php
+++ b/includes/ParserData.php
@@ -213,7 +213,7 @@ class ParserData {
 	 */
 	public function pushSemanticDataToParserOutput() {
 
-		$this->parserOutput->setTimestamp( wfTimestampNow() );
+		$this->setSemanticDataStateToParserOutputProperty();
 
 		if ( $this->hasExtensionData() ) {
 			return $this->parserOutput->setExtensionData( 'smwdata', $this->semanticData );

--- a/includes/parserhooks/SetParserFunction.php
+++ b/includes/parserhooks/SetParserFunction.php
@@ -2,7 +2,7 @@
 
 namespace SMW;
 
-use SMW\MediaWiki\Renderer\HtmlTemplateRenderer;
+use SMW\MediaWiki\Renderer\WikitextTemplateRenderer;
 
 use Parser;
 
@@ -32,7 +32,7 @@ class SetParserFunction {
 	private $messageFormatter;
 
 	/**
-	 * @var HtmlTemplateRenderer
+	 * @var WikitextTemplateRenderer
 	 */
 	private $templateRenderer;
 
@@ -41,9 +41,9 @@ class SetParserFunction {
 	 *
 	 * @param ParserData $parserData
 	 * @param MessageFormatter $messageFormatter
-	 * @param HtmlTemplateRenderer $templateRenderer
+	 * @param WikitextTemplateRenderer $templateRenderer
 	 */
-	public function __construct( ParserData $parserData, MessageFormatter $messageFormatter, HtmlTemplateRenderer $templateRenderer ) {
+	public function __construct( ParserData $parserData, MessageFormatter $messageFormatter, WikitextTemplateRenderer $templateRenderer ) {
 		$this->parserData = $parserData;
 		$this->messageFormatter = $messageFormatter;
 		$this->templateRenderer = $templateRenderer;
@@ -105,7 +105,7 @@ class SetParserFunction {
 			->addFromArray( $parameters->getErrors() )
 			->getHtml();
 
-		return array( $html, 'noparse' => true, 'isHTML' => false );
+		return array( $html, 'noparse' => $template === '', 'isHTML' => false );
 	}
 
 	private function addFieldsToTemplate( $template, $dataValue, $property, $value, $isLastElement, &$count ) {

--- a/src/ParserFunctionFactory.php
+++ b/src/ParserFunctionFactory.php
@@ -129,9 +129,7 @@ class ParserFunctionFactory {
 			$this->parser->getTargetLanguage()
 		);
 
-		$templateRenderer = $applicationFactory
-			->newMwCollaboratorFactory()
-			->newHtmlTemplateRenderer( $this->parser );
+		$templateRenderer = $applicationFactory->newMwCollaboratorFactory()->newWikitextTemplateRenderer();
 
 		$instance = new SetParserFunction(
 			$parserData,

--- a/tests/phpunit/Integration/Parser/parser-02-02-set-template-use.json
+++ b/tests/phpunit/Integration/Parser/parser-02-02-set-template-use.json
@@ -45,6 +45,16 @@
 					"propertyValues": [ "Has date" ]
 				}
 			}
+		},
+		{
+			"about": "#3 ",
+			"subject": "Transclude-Template-Using-Set",
+			"expected-output": {
+				"to-contain": [
+					"<span class=\"smw-list-furtherresults\">",
+					"searchlabel=SetParserTemplateValue/offset=0\">SetParserTemplateValue</a>"
+				]
+			}
 		}
 	],
 	"settings": {},

--- a/tests/phpunit/includes/parserhooks/SetParserFunctionTest.php
+++ b/tests/phpunit/includes/parserhooks/SetParserFunctionTest.php
@@ -6,7 +6,6 @@ use SMW\Tests\Utils\UtilityFactory;
 
 use SMW\SetParserFunction;
 use SMW\ParameterFormatterFactory;
-use SMW\MediaWiki\Renderer\HtmlTemplateRenderer;
 use SMW\MediaWiki\Renderer\WikitextTemplateRenderer;
 use SMW\ApplicationFactory;
 
@@ -15,7 +14,6 @@ use ParserOutput;
 
 /**
  * @covers \SMW\SetParserFunction
- *
  * @group semantic-mediawiki
  *
  * @license GNU GPL v2+
@@ -51,7 +49,7 @@ class SetParserFunctionTest extends \PHPUnit_Framework_TestCase {
 			->disableOriginalConstructor()
 			->getMock();
 
-		$templateRenderer = $this->getMockBuilder( '\SMW\MediaWiki\Renderer\HtmlTemplateRenderer' )
+		$templateRenderer = $this->getMockBuilder( '\SMW\MediaWiki\Renderer\WikitextTemplateRenderer' )
 			->disableOriginalConstructor()
 			->getMock();
 
@@ -83,7 +81,7 @@ class SetParserFunctionTest extends \PHPUnit_Framework_TestCase {
 			->method( 'getHtml' )
 			->will( $this->returnValue( 'Foo' ) );
 
-		$templateRenderer = $this->getMockBuilder( '\SMW\MediaWiki\Renderer\HtmlTemplateRenderer' )
+		$templateRenderer = $this->getMockBuilder( '\SMW\MediaWiki\Renderer\WikitextTemplateRenderer' )
 			->disableOriginalConstructor()
 			->getMock();
 
@@ -117,7 +115,7 @@ class SetParserFunctionTest extends \PHPUnit_Framework_TestCase {
 			->method( 'addFromArray' )
 			->will( $this->returnSelf() );
 
-		$templateRenderer = $this->getMockBuilder( '\SMW\MediaWiki\Renderer\HtmlTemplateRenderer' )
+		$templateRenderer = $this->getMockBuilder( '\SMW\MediaWiki\Renderer\WikitextTemplateRenderer' )
 			->disableOriginalConstructor()
 			->getMock();
 
@@ -159,22 +157,7 @@ class SetParserFunctionTest extends \PHPUnit_Framework_TestCase {
 			->method( 'addFromArray' )
 			->will( $this->returnSelf() );
 
-		$parser = $this->getMockBuilder( '\Parser' )
-			->disableOriginalConstructor()
-			->getMock();
-
-		$parser->expects( $this->once() )
-			->method( 'recursiveTagParse' )
-			->with(
-				$this->stringContains(
-					'{{FooTemplate|property=Foo|value=bar|last-element=|#=0}}' .
-					'{{FooTemplate|property=Foo|value=foobar|last-element=1|#=1}}' .
-					'{{FooTemplate|property=BarFoo|value=9001|last-element=1|#=2}}' ) );
-
-		$templateRenderer = new HtmlTemplateRenderer(
-			new WikitextTemplateRenderer(),
-			$parser
-		);
+		$templateRenderer = new WikitextTemplateRenderer();
 
 		$instance = new SetParserFunction(
 			$parserData,


### PR DESCRIPTION
Use the parser itself to handle rendering of template supported output.