### PR TITLE
Add responsive option to CategoryResultPrinter

### DIFF
--- a/includes/queryprinters/CategoryResultPrinter.php
+++ b/includes/queryprinters/CategoryResultPrinter.php
@@ -169,6 +169,12 @@ class CategoryResultPrinter extends ResultPrinter {
 		$htmlColumnListRenderer->setNumberOfColumns( $this->mNumColumns );
 		$htmlColumnListRenderer->addContentsByIndex( $contentsByIndex );
 
+		// Per convention, an explicit 0 setting forces the columns to behave responsive
+		if ( $this->params['columns'] == 0 ) {
+			$htmlColumnListRenderer->setColumnClass( 'smw-column-responsive' );
+			$htmlColumnListRenderer->setNumberOfColumns( 1 );
+		}
+
 		return $htmlColumnListRenderer->getHtml();
 	}
 

--- a/res/smw/ext.smw.css
+++ b/res/smw/ext.smw.css
@@ -410,6 +410,20 @@ label.smw-form-checkbox {
 	word-wrap: break-word;
 }
 
+.smw-column-responsive {
+	-webkit-column-width: 25em;
+	-moz-column-width: 25em;
+	column-width: 25em;
+}
+
+.smw-column[dir="rtl"] {
+	float: right;
+}
+
+.smw-column-responsive[dir="rtl"] {
+	float: right;
+}
+
 /* Thanks to the bootstrap css*/
 .smw-callout {
 	padding: 10px;

--- a/src/MediaWiki/Renderer/HtmlColumnListRenderer.php
+++ b/src/MediaWiki/Renderer/HtmlColumnListRenderer.php
@@ -57,6 +57,16 @@ class HtmlColumnListRenderer {
 	private $columnListClass = 'smw-columnlist-container';
 
 	/**
+	 * @var string
+	 */
+	private $columnClass = 'smw-column';
+
+	/**
+	 * @var boolean
+	 */
+	private $isRTL = false;
+
+	/**
 	 * @since 2.2
 	 *
 	 * @param string $columnListClass
@@ -65,6 +75,28 @@ class HtmlColumnListRenderer {
 	 */
 	public function setColumnListClass( $columnListClass ) {
 		$this->columnListClass = htmlspecialchars( $columnListClass );
+		return $this;
+	}
+
+	/**
+	 * @since 2.2
+	 *
+	 * @param string $columnListClass
+	 *
+	 * @return HtmlColumnListRenderer
+	 */
+	public function setColumnClass( $columnClass ) {
+		$this->columnClass = htmlspecialchars( $columnClass );
+		return $this;
+	}
+
+	/**
+	 * @since 2.3
+	 *
+	 * @param boolean $isRTL
+	 */
+	public function setColumnRTLDirectionalityState( $isRTL ) {
+		$this->isRTL = (bool)$isRTL;
 		return $this;
 	}
 
@@ -139,7 +171,14 @@ class HtmlColumnListRenderer {
 		$this->numRows = 0;
 
 		$this->rowsPerColumn = ceil( $this->numberOfResults / $this->numberOfColumns );
-		$this->columnWidth = floor( 100 / $this->numberOfColumns );
+
+		// Class to determine whether we want responsive columns width
+		if ( strpos( $this->columnClass, 'responsive' ) !== false ) {
+			$this->columnWidth = 100;
+		} else {
+			$this->columnWidth = floor( 100 / $this->numberOfColumns );
+		}
+
 		$listContinuesAbbrev = wfMessage( 'listingcontinuesabbrev' )->text();
 
 		foreach ( $this->contentsByIndex as $key => $resultItems ) {
@@ -162,7 +201,10 @@ class HtmlColumnListRenderer {
 
 		return Html::rawElement(
 			'div',
-			array( 'class' => $this->columnListClass ),
+			array(
+				'class' => $this->columnListClass,
+				'dir'   => $this->isRTL ? 'rtl' : 'ltr'
+			),
 			$result . "\n" . '<br style="clear: both;"/>'
 		);
 	}
@@ -171,11 +213,12 @@ class HtmlColumnListRenderer {
 
 		$result = '';
 		$previousKey = "";
+		$dir = $this->isRTL ? 'rtl' : 'ltr';
 
 		foreach ( $resultItems as $resultItem ) {
 
 			if ( $this->numRows % $this->rowsPerColumn == 0 ) {
-				$result .= "<div class=\"smw-column\" style=\"width:$this->columnWidth%;\">";
+				$result .= "<div class=\"$this->columnClass\" style=\"width:$this->columnWidth%;\" dir=\"$dir\">";
 
 				$numRowsInColumn = $this->numRows + 1;
 

--- a/tests/phpunit/Integration/Query/Fixtures/format-03-01-category-en.json
+++ b/tests/phpunit/Integration/Query/Fixtures/format-03-01-category-en.json
@@ -80,7 +80,7 @@
 			"subject": "template-output-named-args-asc",
 			"expected-output": {
 				"to-contain": [
-					"<div class=\"smw-columnlist-container\">",
+					"<div class=\"smw-columnlist-container\" dir=\"ltr\">",
 					"<div class=\"smw-column-header\">1</div><ul><li>123, Test Test2</li></ul>",
 					"<div class=\"smw-column-header\">B</div><ul><li>Bar, Test</li></ul></div>",
 					"<div class=\"smw-column-header\">F</div><ul><li>Foo, Test</li></ul>",
@@ -94,7 +94,7 @@
 			"subject": "template-output-named-args-desc",
 			"expected-output": {
 				"to-contain": [
-					"<div class=\"smw-columnlist-container\">",
+					"<div class=\"smw-columnlist-container\" dir=\"ltr\">",
 					"<div class=\"smw-column-header\">テ</div><ul><li>テスト, Test</li></ul>",
 					"<div class=\"smw-column-header\">F</div><ul><li>Foo, Test</li></ul></div>",
 					"<div class=\"smw-column-header\">B</div><ul><li>Bar, Test</li></ul>",
@@ -108,7 +108,7 @@
 			"subject": "template-output-unnamed-args-asc",
 			"expected-output": {
 				"to-contain": [
-					"<div class=\"smw-columnlist-container\">",
+					"<div class=\"smw-columnlist-container\" dir=\"ltr\">",
 					"<div class=\"smw-column-header\">1</div><ul><li>123, Test Test2</li></ul>",
 					"<div class=\"smw-column-header\">B</div><ul><li>Bar, Test</li></ul></div>",
 					"<div class=\"smw-column-header\">F</div><ul><li>Foo, Test</li></ul>",
@@ -122,7 +122,7 @@
 			"subject": "template-output-unnamed-args-desc",
 			"expected-output": {
 				"to-contain": [
-					"<div class=\"smw-columnlist-container\">",
+					"<div class=\"smw-columnlist-container\" dir=\"ltr\">",
 					"<div class=\"smw-column-header\">テ</div><ul><li>テスト, Test</li></ul>",
 					"<div class=\"smw-column-header\">F</div><ul><li>Foo, Test</li></ul></div>",
 					"<div class=\"smw-column-header\">B</div><ul><li>Bar, Test</li></ul>",
@@ -136,7 +136,7 @@
 			"subject": "one-column-plainlist-output-asc",
 			"expected-output": {
 				"to-contain": [
-					"<div class=\"smw-columnlist-container\">",
+					"<div class=\"smw-columnlist-container\" dir=\"ltr\">",
 					"<div class=\"smw-column-header\">1</div><ul><li>123 (Has page property Test, Test2)</li></ul>",
 					"<div class=\"smw-column-header\">B</div><ul><li>Bar (Has page property Test)</li></ul>",
 					"<div class=\"smw-column-header\">F</div><ul><li>Foo (Has page property Test)</li></ul>",
@@ -150,10 +150,10 @@
 			"subject": "limited-two-column-plainlist-output-desc",
 			"expected-output": {
 				"to-contain": [
-					"<div class=\"smw-columnlist-container\">",
+					"<div class=\"smw-columnlist-container\" dir=\"ltr\">",
 					"<div class=\"smw-column-header\">テ</div><ul><li>テスト (Has page property Test)</li></ul>",
 					"<div class=\"smw-column-header\">F</div><ul><li>Foo (Has page property Test)</li></ul></div>",
-					"<div class=\"smw-column\" style=\"width:50%;\"><div class=\"smw-column-header\">F cont.</div><ul><li>",
+					"<div class=\"smw-column\" style=\"width:50%;\" dir=\"ltr\"><div class=\"smw-column-header\">F cont.</div><ul><li>",
 					"Special:Ask/-5B-5BHas-20page-20property::Test-5D-5D/-3FHas-20page-20property/format=category/limit=2/link=none/order=desc/headers=plain/searchlabel=Test-20more/columns=2/offset=2\">Test more</a></span></li></ul></div>",
 					"<br style=\"clear: both;\" />"
 				]
@@ -164,8 +164,8 @@
 			"subject": "one-column-plainlist-output-with-default-sort-asc",
 			"expected-output": {
 				"to-contain": [
-					"<div class=\"smw-columnlist-container\">",
-					"<div class=\"smw-column\" style=\"width:100%;\"><div class=\"smw-column-header\">1</div><ul><li>123 (Has page property Test, Test2)</li></ul>",
+					"<div class=\"smw-columnlist-container\" dir=\"ltr\">",
+					"<div class=\"smw-column\" style=\"width:100%;\" dir=\"ltr\"><div class=\"smw-column-header\">1</div><ul><li>123 (Has page property Test, Test2)</li></ul>",
 					"<div class=\"smw-column-header\">A</div><ul><li>Είναι απλά (Has page property Test2)</li></ul>",
 					"<div class=\"smw-column-header\">B</div><ul><li>Је једноставно модел (Has page property Test2)</li></ul></div>",
 					"<br style=\"clear: both;\" />"
@@ -177,10 +177,10 @@
 			"subject": "template-output-unnamed-args-with-default-sort-asc",
 			"expected-output": {
 				"to-contain": [
-					"<div class=\"smw-columnlist-container\">",
-					"<div class=\"smw-column\" style=\"width:33%;\"><div class=\"smw-column-header\">1</div><ul><li>123, Test Test2</li></ul></div>",
-					"<div class=\"smw-column\" style=\"width:33%;\"><div class=\"smw-column-header\">A</div><ul><li>Είναι απλά, Test2</li></ul></div>",
-					"<div class=\"smw-column\" style=\"width:33%;\"><div class=\"smw-column-header\">B</div><ul><li>Је једноставно модел, Test2</li></ul></div>",
+					"<div class=\"smw-columnlist-container\" dir=\"ltr\">",
+					"<div class=\"smw-column\" style=\"width:33%;\" dir=\"ltr\"><div class=\"smw-column-header\">1</div><ul><li>123, Test Test2</li></ul></div>",
+					"<div class=\"smw-column\" style=\"width:33%;\" dir=\"ltr\"><div class=\"smw-column-header\">A</div><ul><li>Είναι απλά, Test2</li></ul></div>",
+					"<div class=\"smw-column\" style=\"width:33%;\" dir=\"ltr\"><div class=\"smw-column-header\">B</div><ul><li>Је једноставно модел, Test2</li></ul></div>",
 					"<br style=\"clear: both;\" />"
 				]
 			}

--- a/tests/phpunit/Integration/Query/Fixtures/format-03-02-category-defaultsort-en.json
+++ b/tests/phpunit/Integration/Query/Fixtures/format-03-02-category-defaultsort-en.json
@@ -46,7 +46,7 @@
 			"subject": "one-column-plainlist-output-asc",
 			"expected-output": {
 				"to-contain": [
-					"<div class=\"smw-columnlist-container\">",
+					"<div class=\"smw-columnlist-container\" dir=\"ltr\">",
 					"<div class=\"smw-column-header\">S</div><ul>",
 					"<li>Saaa (Has text aaa; aba; abb)</li>",
 					"<li>Sbaa (Has text baa)</li>",
@@ -63,7 +63,7 @@
 			"subject": "one-column-plainlist-output-desc",
 			"expected-output": {
 				"to-contain": [
-					"<div class=\"smw-columnlist-container\">",
+					"<div class=\"smw-columnlist-container\" dir=\"ltr\">",
 					"<div class=\"smw-column-header\">S</div><ul>",
 					"<li>Soaa (Has text oaa)</li>",
 					"<li>Seba (Has text eba)</li>",

--- a/tests/phpunit/Unit/MediaWiki/Renderer/HtmlColumnListRendererTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Renderer/HtmlColumnListRendererTest.php
@@ -42,8 +42,8 @@ class HtmlColumnListFormatterTest extends \PHPUnit_Framework_TestCase {
 		) );
 
 		$expected = array(
-			'<div class="smw-columnlist-container">',
-			'<div class="smw-column" style="width:100%;">',
+			'<div class="smw-columnlist-container" dir="ltr">',
+			'<div class="smw-column" style="width:100%;" dir="ltr">',
 			'<div class="smw-column-header">a</div><ul><li>Foo</li><li>Bar</li></ul>',
 			'<div class="smw-column-header">B</div><ul><li>Ichi</li><li>Ni</li></ul></div>'
 		);
@@ -68,12 +68,12 @@ class HtmlColumnListFormatterTest extends \PHPUnit_Framework_TestCase {
 		$listContinuesAbbrev = wfMessage( 'listingcontinuesabbrev' )->text();
 
 		$expected = array(
-			'<div class="smw-columnlist-container">',
-			'<div class="smw-column" style="width:50%;">',
+			'<div class="smw-columnlist-container" dir="ltr">',
+			'<div class="smw-column" style="width:50%;" dir="ltr">',
 			'<div class="smw-column-header">a</div>',
 			'<ul><li>Foo</li><li>Bar</li></ul>',
 			'<div class="smw-column-header">B</div><ul><li>Baz</li></ul></div> <!-- end column -->',
-			'<div class="smw-column" style="width:50%;">',
+			'<div class="smw-column" style="width:50%;" dir="ltr">',
 			'<div class="smw-column-header">B ' . $listContinuesAbbrev .'</div>',
 			'<ul start=4><li>Fom</li><li>Fin</li><li>Fum</li></ul></div> <!-- end column -->',
 			'<br style="clear: both;"/></div>'
@@ -97,10 +97,10 @@ class HtmlColumnListFormatterTest extends \PHPUnit_Framework_TestCase {
 		) );
 
 		$expected = array(
-			'<div class="smw-columnlist-container">',
-			'<div class="smw-column" style="width:33%;">',
+			'<div class="smw-columnlist-container" dir="ltr">',
+			'<div class="smw-column" style="width:33%;" dir="ltr">',
 			'<div class="smw-column-header">a</div><ul><li>Foo</li><li>Bar</li></ul></div>',
-			'<div class="smw-column" style="width:33%;">',
+			'<div class="smw-column" style="width:33%;" dir="ltr">',
 			'<div class="smw-column-header">B</div><ul><li>Ichi</li><li>Ni</li></ul></div>'
 		);
 
@@ -124,10 +124,10 @@ class HtmlColumnListFormatterTest extends \PHPUnit_Framework_TestCase {
 		) );
 
 		$expected = array(
-			'<div class="smw-columnlist-container">',
-			'<div class="smw-column" style="width:50%;">',
+			'<div class="smw-columnlist-container" dir="ltr">',
+			'<div class="smw-column" style="width:50%;" dir="ltr">',
 			'<div class="smw-column-header">a</div><ol><li>Foo</li><li>Bar</li></ol></div> <!-- end column -->',
-			'<div class="smw-column" style="width:50%;">',
+			'<div class="smw-column" style="width:50%;" dir="ltr">',
 			'<div class="smw-column-header">B</div><ol><li>Ichi</li><li>Ni</li></ol></div> <!-- end column -->'
 		);
 
@@ -144,6 +144,7 @@ class HtmlColumnListFormatterTest extends \PHPUnit_Framework_TestCase {
 		$instance
 			->setNumberOfColumns( 2 )
 			->setColumnListClass( 'foo-class' )
+			->setColumnClass( 'bar-class' )
 			->setListType( 'ul' );
 
 		$instance->addContentsByNoIndex(
@@ -151,11 +152,35 @@ class HtmlColumnListFormatterTest extends \PHPUnit_Framework_TestCase {
 		);
 
 		$expected = array(
-			'<div class="foo-class">',
-			'<div class="smw-column" style="width:50%;">',
+			'<div class="foo-class" dir="ltr">',
+			'<div class="bar-class" style="width:50%;" dir="ltr">',
 			'<ul start=1><li>Foo</li><li>Baz</li></ul></div> <!-- end column -->',
-			'<div class="smw-column" style="width:50%;">',
+			'<div class="bar-class" style="width:50%;" dir="ltr">',
 			'<ul start=3><li>Bar</li></ul></div> <!-- end column -->'
+		);
+
+		$this->stringValidator->assertThatStringContains(
+			$expected,
+			$instance->getHtml()
+		);
+	}
+
+	public function testResponsiveColumnsToBeDeterminedByBrowser() {
+
+		$instance = new HtmlColumnListRenderer();
+
+		$instance->setColumnListClass( 'foo-class' )
+			->setColumnClass( 'bar-responsive' )
+			->setColumnRTLDirectionalityState( true )
+			->setListType( 'ul' );
+
+		$instance->addContentsByNoIndex(
+			array( 'Foo', 'Baz', 'Bar' )
+		);
+
+		$expected = array(
+			'<div class="foo-class" dir="rtl"><div class="bar-responsive" style="width:100%;" dir="rtl">',
+			'<ul start=1><li>Foo</li><li>Baz</li><li>Bar</li></ul></div> <!-- end column -->'
 		);
 
 		$this->stringValidator->assertThatStringContains(


### PR DESCRIPTION
Instead of fixed columns, have the browser determine the columns based on the `smw-column-responsive` css rule.

```
{{#ask: [[Category:Sample pages]]
 |format=category
 |columns=0
}}
```
![image](https://cloud.githubusercontent.com/assets/1245473/9803206/9d69cfe2-5820-11e5-823f-d562b096ada1.png)

![image](https://cloud.githubusercontent.com/assets/1245473/9803218/af39d67c-5820-11e5-9a62-00c78c082159.png)


 