### PR TITLE
Add InMemoryPoolCache

### DIFF
--- a/includes/dataitems/SMW_DI_WikiPage.php
+++ b/includes/dataitems/SMW_DI_WikiPage.php
@@ -48,6 +48,11 @@ class DIWikiPage extends SMWDataItem {
 	private $sortkey = null;
 
 	/**
+	 * @var string
+	 */
+	private $contextReference = null;
+
+	/**
 	 * Contructor. We do not bother with too much detailed validation here,
 	 * regarding the known namespaces, canonicity of the dbkey (namespace
 	 * exrtacted?), validity of interwiki prefix (known?), and general use
@@ -120,6 +125,26 @@ class DIWikiPage extends SMWDataItem {
 		}
 
 		return $this->sortkey;
+	}
+
+	/**
+	 * @since  2.3
+	 *
+	 * @param string $contextReference
+	 */
+	public function setContextReference( $contextReference ) {
+		$this->contextReference = $contextReference;
+	}
+
+	/**
+	 * Returns a reference for the processing context (parser etc.).
+	 *
+	 * @since 2.3
+	 *
+	 * @return string
+	 */
+	public function getContextReference() {
+		return $this->contextReference;
 	}
 
 	/**

--- a/includes/export/SMW_Exporter.php
+++ b/includes/export/SMW_Exporter.php
@@ -2,7 +2,7 @@
 
 use SMW\DataTypeRegistry;
 use SMW\DataValueFactory;
-use SMW\Exporter\CachedDataItemToExpResourceEncoder;
+use SMW\Exporter\DataItemToExpResourceEncoder;
 use SMW\Exporter\DataItemToElementEncoder;
 use SMW\Exporter\Escaper;
 use SMW\ApplicationFactory;
@@ -23,9 +23,9 @@ class SMWExporter {
 	private static $instance = null;
 
 	/**
-	 * @var CachedDataItemToExpResourceEncoder
+	 * @var DataItemToExpResourceEncoder
 	 */
-	private static $cachedDataItemToExpResourceEncoder = null;
+	private static $dataItemToExpResourceEncoder = null;
 
 	/**
 	 * @var DataItemToElementEncoder
@@ -54,14 +54,11 @@ class SMWExporter {
 			// There is no better way of getting around the static use without BC
 			self::$dataItemToElementEncoder = new DataItemToElementEncoder();
 
-			self::$cachedDataItemToExpResourceEncoder = new CachedDataItemToExpResourceEncoder(
-				ApplicationFactory::getInstance()->getStore(),
-				$cacheFactory->newFixedInMemoryCache( 500 )
+			self::$dataItemToExpResourceEncoder = new DataItemToExpResourceEncoder(
+				ApplicationFactory::getInstance()->getStore()
 			);
 
-			self::$cachedDataItemToExpResourceEncoder->setCachePrefix(
-				$cacheFactory->getCachePrefix()
-			);
+			self::$dataItemToExpResourceEncoder->reset();
 		}
 
 		return self::$instance;
@@ -79,7 +76,7 @@ class SMWExporter {
 	 * @since 2.2
 	 */
 	public function resetCacheFor( SMWDIWikiPage $diWikiPage ) {
-		self::$cachedDataItemToExpResourceEncoder->resetCacheFor( $diWikiPage );
+		self::$dataItemToExpResourceEncoder->resetCacheFor( $diWikiPage );
 	}
 
 	/**
@@ -346,17 +343,17 @@ class SMWExporter {
 	}
 
 	/**
-	 * @see CachedDataItemToExpResourceEncoder::mapPropertyToResourceElement
+	 * @see DataItemToExpResourceEncoder::mapPropertyToResourceElement
 	 */
 	static public function getResourceElementForProperty( SMWDIProperty $diProperty, $helperProperty = false ) {
-		return self::$cachedDataItemToExpResourceEncoder->mapPropertyToResourceElement( $diProperty, $helperProperty );
+		return self::$dataItemToExpResourceEncoder->mapPropertyToResourceElement( $diProperty, $helperProperty );
 	}
 
 	/**
-	 * @see CachedDataItemToExpResourceEncoder::mapWikiPageToResourceElement
+	 * @see DataItemToExpResourceEncoder::mapWikiPageToResourceElement
 	 */
 	static public function getResourceElementForWikiPage( SMWDIWikiPage $diWikiPage, $markForAuxiliaryUsage = false ) {
-		return self::$cachedDataItemToExpResourceEncoder->mapWikiPageToResourceElement( $diWikiPage, $markForAuxiliaryUsage );
+		return self::$dataItemToExpResourceEncoder->mapWikiPageToResourceElement( $diWikiPage, $markForAuxiliaryUsage );
 	}
 
 	/**

--- a/src/InMemoryPoolCache.php
+++ b/src/InMemoryPoolCache.php
@@ -1,0 +1,91 @@
+<?php
+
+namespace SMW;
+
+use SMW\ApplicationFactory;
+use Onoi\BlobStore\BlobStore;
+
+/**
+ * A multipurpose non-persistent static pool cache to keep selected items for
+ * the duration of a request cacheable.
+ *
+ * @license GNU GPL v2+
+ * @since 2.3
+ *
+ * @author mwjames
+ */
+class InMemoryPoolCache {
+
+	/**
+	 * @var FixedInMemoryCache
+	 */
+	private static $instance = null;
+
+	/**
+	 * @var array
+	 */
+	private $poolCacheList = array();
+
+	/**
+	 * @since 2.3
+	 *
+	 * @return FixedInMemoryCache
+	 */
+	public static function getInstance() {
+
+		if ( self::$instance === null ) {
+			self::$instance = new self();
+		}
+
+		return self::$instance;
+	}
+
+	/**
+	 * @since 2.3
+	 */
+	public static function clear() {
+		self::$instance = null;
+	}
+
+	/**
+	 * @since 2.3
+	 *
+	 * @param string $poolCacheName
+	 */
+	public function resetPoolCacheFor( $poolCacheName ) {
+		unset( $this->poolCacheList[$poolCacheName] );
+	}
+
+	/**
+	 * @since 2.2
+	 *
+	 * @return array
+	 */
+	public function getStats() {
+
+		$stats = array();
+
+		foreach ( $this->poolCacheList as $key => $value ) {
+			$stats[$key] = $value->getStats();
+		}
+
+		return $stats;
+	}
+
+	/**
+	 * @since 2.2
+	 *
+	 * @param string $poolCacheName
+	 *
+	 * @return Cache
+	 */
+	public function getPoolCacheFor( $poolCacheName ) {
+
+		if ( !isset( $this->poolCacheList[$poolCacheName] ) ) {
+			$this->poolCacheList[$poolCacheName] = ApplicationFactory::getInstance()->newCacheFactory()->newFixedInMemoryCache( 1500 );
+		}
+
+		return $this->poolCacheList[$poolCacheName];
+	}
+
+}

--- a/src/InTextAnnotationParser.php
+++ b/src/InTextAnnotationParser.php
@@ -74,7 +74,7 @@ class InTextAnnotationParser {
 	 *
 	 * @var string
 	 */
-	private $uniqid;
+	private $contextReference;
 
 	/**
 	 * @since 1.9
@@ -104,7 +104,7 @@ class InTextAnnotationParser {
 		$title = $this->parserData->getTitle();
 		$this->settings = $this->applicationFactory->getSettings();
 
-		$this->uniqid = uniqid();
+		$this->contextReference = 'intp:' . uniqid();
 		$this->doStripMagicWordsFromText( $text );
 
 		$this->setSemanticEnabledNamespaceState( $title );
@@ -308,7 +308,7 @@ class InTextAnnotationParser {
 		$subject = $this->parserData->getSemanticData()->getSubject();
 
 		// Set a context to a subject to idenitify the parser run
-		$subject->uniqid = $this->uniqid;
+		$subject->setContextReference( $this->contextReference );
 
 		// Add properties to the semantic container
 		foreach ( $properties as $property ) {

--- a/src/SPARQLStore/RedirectLookup.php
+++ b/src/SPARQLStore/RedirectLookup.php
@@ -5,11 +5,11 @@ namespace SMW\SPARQLStore;
 use RuntimeException;
 use Onoi\Cache\Cache;
 use SMW\ApplicationFactory;
+use SMW\InMemoryPoolCache;
 use SMW\DIWikiPage;
 use SMWExpNsResource as ExpNsResource;
 use SMWExporter as Exporter;
 use SMWExpResource as ExpResource;
-use SMWSparqlDatabase as SparqlDatabase;
 use SMWTurtleSerializer as TurtleSerializer;
 
 /**
@@ -22,34 +22,24 @@ use SMWTurtleSerializer as TurtleSerializer;
 class RedirectLookup {
 
 	/**
-	 * @var SMWSparqlDatabase
+	 * @var RepositoryConnection
 	 */
-	private $connection = null;
-
-	/**
-	 * @var Cache|null
-	 */
-	private static $resourceUriTargetCache = null;
+	private $repositoryConnection;
 
 	/**
 	 * @since 2.0
 	 *
-	 * @param SparqlDatabase $connection
-	 * @param Cache|null $cache
+	 * @param RepositoryConnection $repositoryConnection
 	 */
-	public function __construct( SparqlDatabase $connection, Cache $cache = null ) {
-		$this->connection = $connection;
-
-		if ( $cache !== null ) {
-			self::$resourceUriTargetCache = $cache;
-		}
+	public function __construct( RepositoryConnection $repositoryConnection ) {
+		$this->repositoryConnection = $repositoryConnection;
 	}
 
 	/**
 	 * @since 2.1
 	 */
-	public function clear() {
-		self::$resourceUriTargetCache = null;
+	public static function reset() {
+		InMemoryPoolCache::getInstance()->resetPoolCacheFor( 'sparql.store.redirectlookup' );
 	}
 
 	/**
@@ -82,11 +72,7 @@ class RedirectLookup {
 			return $expNsResource;
 		}
 
-		if ( !$this->getCache()->contains( $expNsResource->getUri() ) ) {
-			$this->getCache()->save( $expNsResource->getUri(), $this->lookupResourceUriTargetFromDatabase( $expNsResource ) );
-		}
-
-		$firstRow = $this->getCache()->fetch( $expNsResource->getUri() );
+		$firstRow = $this->doLookupResourceUriTargetFor( $expNsResource );
 
 		if ( $firstRow === false ) {
 			$exists = false;
@@ -98,6 +84,20 @@ class RedirectLookup {
 		}
 
 		return $expNsResource;
+	}
+
+	private function doLookupResourceUriTargetFor( ExpNsResource $expNsResource ) {
+
+		$poolCache = InMemoryPoolCache::getInstance()->getPoolCacheFor( 'sparql.store.redirectlookup' );
+
+		if ( !$poolCache->contains( $expNsResource->getUri() ) ) {
+			$poolCache->save(
+				$expNsResource->getUri(),
+				$this->lookupResourceUriTargetFromDatabase( $expNsResource )
+			);
+		}
+
+		return $poolCache->fetch( $expNsResource->getUri() );
 	}
 
 	private function isNonRedirectableResource( ExpNsResource $expNsResource ) {
@@ -113,7 +113,7 @@ class RedirectLookup {
 		$rediUri = TurtleSerializer::getTurtleNameForExpElement( Exporter::getInstance()->getSpecialPropertyResource( '_REDI' ) );
 		$skeyUri = TurtleSerializer::getTurtleNameForExpElement( Exporter::getInstance()->getSpecialPropertyResource( '_SKEY' ) );
 
-		$respositoryResult = $this->connection->select(
+		$respositoryResult = $this->repositoryConnection->select(
 			'*',
 			"$resourceUri $skeyUri ?s  OPTIONAL { $resourceUri $rediUri ?r }",
 			array( 'LIMIT' => 1 ),
@@ -137,15 +137,6 @@ class RedirectLookup {
 		}
 
 		return $expNsResource;
-	}
-
-	private function getCache() {
-
-		if ( self::$resourceUriTargetCache === null ) {
-			self::$resourceUriTargetCache = ApplicationFactory::getInstance()->newCacheFactory()->newFixedInMemoryCache( 500 );
-		}
-
-		return self::$resourceUriTargetCache;
 	}
 
 }

--- a/src/SPARQLStore/SPARQLStore.php
+++ b/src/SPARQLStore/SPARQLStore.php
@@ -185,6 +185,11 @@ class SPARQLStore extends Store {
 		foreach( $semanticData->getSubSemanticData() as $subSemanticData ) {
 			 $this->doSparqlFlatDataUpdate( $subSemanticData );
 		}
+
+		//wfDebugLog( 'smw', ' InMemoryPoolCache: ' . json_encode( \SMW\InMemoryPoolCache::getInstance()->getStats() ) );
+
+		// Reset internal cache
+		TurtleTriplesBuilder::reset();
 	}
 
 	/**

--- a/src/SPARQLStore/TurtleTriplesBuilder.php
+++ b/src/SPARQLStore/TurtleTriplesBuilder.php
@@ -113,6 +113,15 @@ class TurtleTriplesBuilder {
 		return $this->hasTriplesForUpdate;
 	}
 
+	/**
+	 * @since 2.0
+	 *
+	 * @return boolean
+	 */
+	public static function reset() {
+		TurtleSerializer::reset();
+	}
+
 	private function serializeToTurtleRepresentation() {
 
 		$this->hasTriplesForUpdate = false;

--- a/tests/phpunit/Integration/SPARQLStore/RedirectLookupIntegrationTest.php
+++ b/tests/phpunit/Integration/SPARQLStore/RedirectLookupIntegrationTest.php
@@ -51,7 +51,7 @@ class RedirectLookupIntegrationTest extends \PHPUnit_Framework_TestCase {
 	public function testRedirectTragetLookupForNonExistingEntry( $expNsResource ) {
 
 		$instance = new RedirectLookup( $this->sparqlDatabase );
-		$instance->clear();
+		$instance->reset();
 
 		$exists = null;
 
@@ -79,7 +79,7 @@ class RedirectLookupIntegrationTest extends \PHPUnit_Framework_TestCase {
 		);
 
 		$instance = new RedirectLookup( $this->sparqlDatabase );
-		$instance->clear();
+		$instance->reset();
 
 		$exists = null;
 

--- a/tests/phpunit/Unit/InMemoryPoolCacheTest.php
+++ b/tests/phpunit/Unit/InMemoryPoolCacheTest.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace SMW\Tests;
+
+use SMW\InMemoryPoolCache;
+
+/**
+ * @covers \SMW\InMemoryPoolCache
+ * @group semantic-mediawiki
+ *
+ * @license GNU GPL v2+
+ * @since   1.2
+ *
+ * @author mwjames
+ */
+class InMemoryPoolCacheTest extends \PHPUnit_Framework_TestCase {
+
+	public function testCanConstruct() {
+
+		$this->assertInstanceOf(
+			'\SMW\InMemoryPoolCache',
+			new InMemoryPoolCache()
+		);
+
+		$this->assertInstanceOf(
+			'\SMW\InMemoryPoolCache',
+			InMemoryPoolCache::getInstance()
+		);
+
+		InMemoryPoolCache::getInstance()->clear();
+	}
+
+	public function testPoolCache() {
+
+		$instance = new InMemoryPoolCache();
+
+		$this->assertInstanceOf(
+			'\Onoi\Cache\Cache',
+			$instance->getPoolCacheFor( 'Foo' )
+		);
+
+		$instance->getPoolCacheFor( 'Foo' )->save( 'Bar', 42 );
+
+		$this->assertEquals(
+			42,
+			$instance->getPoolCacheFor( 'Foo' )->fetch( 'Bar' )
+		);
+
+		$instance->resetPoolCacheFor( 'Foo' );
+
+		$this->assertEmpty(
+			$instance->getStats( 'Foo' )
+		);
+	}
+
+}


### PR DESCRIPTION
This improves performance for the TurtleSerializer/SPARQLStore especially when a large set
of subobjects or queries on a single subject are involved.

A subject can easily pass cache utilization of:
```
{
"exporter.dataitem.resource.encoder":{"inserts":96,"deletes":0,"max":1500,"count":96,"hits":485,"misses":0},
"sparql.store.redirectlookup":{"inserts":36,"deletes":0,"max":1500,"count":36,"hits":68,"misses":0},
"turtle.serializer":{"inserts":7,"deletes":0,"max":1500,"count":7,"hits":150,"misses":0}
}
```
A more hypothetical #set_recurring_event use case will show
a cache utilization of:

```
{{#set_recurring_event:some
 |property=has date
 |Has page=Recurring events
 |Has location=London,Berlin,Paris|+sep=,
 |Has text=Simple recurring events text
 |start=June 8, 2010
 |unit=day
 |period=1
 |limit=1000
 |duration=7200
 |include=March 16, 2010;March 23, 2010|+sep=;
 |exclude=March 15, 2010;March 22, 2010|+sep=;
}}
```
```
{
"exporter.dataitem.resource.encoder":{"inserts":1041,"deletes":0,"max":1500,"count":1041,"hits":22080,"misses":0},
"sparql.store.redirectlookup":{"inserts":12,"deletes":0,"max":1500,"count":12,"hits":13042,"misses":0},
"turtle.serializer":{"inserts":9,"deletes":0,"max":1500,"count":9,"hits":1007,"misses":0}
}
```