### PR TITLE
Removes unmatched "ghost" pages from the ID_TABLE, refs #1110

### DIFF
--- a/includes/storage/SQLStore/SMW_Sql3SmwIds.php
+++ b/includes/storage/SQLStore/SMW_Sql3SmwIds.php
@@ -191,6 +191,7 @@ class SMWSql3SmwIds {
 // 		'_3' => 25,
 // 		'_4' => 26,
 // 		'_5' => 27,
+// 		'_SOBJ' => 27
 		'_LIST' => 28,
 		'_MDAT' => 29,
 		'_CDAT' => 30,
@@ -443,6 +444,43 @@ class SMWSql3SmwIds {
 		}
 
 		return $id;
+	}
+
+	/**
+	 * @since 2.3
+	 *
+	 * @param string $title DB key
+	 * @param integer $namespace namespace
+	 * @param string $iw interwiki prefix
+	 * @param string $subobjectName name of subobject
+	 *
+	 * @param array
+	 */
+	public function getListOfIdMatchesFor( $title, $namespace, $iw, $subobjectName = '' ) {
+
+		$matches = array();
+
+		$rows = $this->store->getConnection( 'mw.db' )->select(
+			self::tableName,
+			$select = array( 'smw_id' ),
+			array(
+				'smw_title' => $title,
+				'smw_namespace' => $namespace,
+				'smw_iw' => $iw,
+				'smw_subobject' => $subobjectName
+			),
+			__METHOD__
+		);
+
+		if ( $rows === false ) {
+			return $matches;
+		}
+
+		foreach ( $rows as $row ) {
+			$matches[] = $row->smw_id;
+		}
+
+		return $matches;
 	}
 
 	/**

--- a/src/SQLStore/Lookup/PropertyUsageListLookup.php
+++ b/src/SQLStore/Lookup/PropertyUsageListLookup.php
@@ -86,7 +86,7 @@ class PropertyUsageListLookup implements ListLookup {
 	 * @return string
 	 */
 	public function getLookupIdentifier() {
-		return 'smwgPropertiesCache' . json_encode( (array)$this->requestOptions );
+		return 'smwgPropertiesCache#' . json_encode( (array)$this->requestOptions );
 	}
 
 	private function selectPropertiesFromTable() {

--- a/src/SQLStore/Lookup/UndeclaredPropertyListLookup.php
+++ b/src/SQLStore/Lookup/UndeclaredPropertyListLookup.php
@@ -93,7 +93,7 @@ class UndeclaredPropertyListLookup implements ListLookup {
 	 * @return string
 	 */
 	public function getLookupIdentifier() {
-		return __METHOD__ . json_encode( (array)$this->requestOptions );
+		return __METHOD__. '#' . json_encode( (array)$this->requestOptions );
 	}
 
 	private function selectPropertiesFromTable( $propertyTable ) {

--- a/src/SQLStore/Lookup/UnusedPropertyListLookup.php
+++ b/src/SQLStore/Lookup/UnusedPropertyListLookup.php
@@ -87,7 +87,7 @@ class UnusedPropertyListLookup implements ListLookup {
 	 * @return string
 	 */
 	public function getLookupIdentifier() {
-		return __METHOD__ . json_encode( (array)$this->requestOptions );
+		return __METHOD__ . '#' . json_encode( (array)$this->requestOptions );
 	}
 
 	private function selectPropertiesFromTable() {

--- a/src/SQLStore/SQLStoreFactory.php
+++ b/src/SQLStore/SQLStoreFactory.php
@@ -138,7 +138,7 @@ class SQLStoreFactory {
 	 *
 	 * @return ListLookup
 	 */
-	public function newUsageStatisticsListLookup() {
+	public function newUsageStatisticsCachedListLookup() {
 
 		$usageStatisticsListLookup = new UsageStatisticsListLookup(
 			$this->store,
@@ -157,9 +157,9 @@ class SQLStoreFactory {
 	 *
 	 * @param RequestOptions|null $requestOptions
 	 *
-	 * @return ListLookup
+	 * @return CachedListLookup
 	 */
-	public function newPropertyUsageListLookup( RequestOptions $requestOptions = null ) {
+	public function newPropertyUsageCachedListLookup( RequestOptions $requestOptions = null ) {
 
 		$propertyUsageListLookup = new PropertyUsageListLookup(
 			$this->store,
@@ -179,9 +179,9 @@ class SQLStoreFactory {
 	 *
 	 * @param RequestOptions|null $requestOptions
 	 *
-	 * @return ListLookup
+	 * @return CachedListLookup
 	 */
-	public function newUnusedPropertyListLookup( RequestOptions $requestOptions = null ) {
+	public function newUnusedPropertyCachedListLookup( RequestOptions $requestOptions = null ) {
 
 		$unusedPropertyListLookup = new UnusedPropertyListLookup(
 			$this->store,
@@ -201,9 +201,9 @@ class SQLStoreFactory {
 	 *
 	 * @param RequestOptions|null $requestOptions
 	 *
-	 * @return ListLookup
+	 * @return CachedListLookup
 	 */
-	public function newUndeclaredPropertyListLookup( RequestOptions $requestOptions = null ) {
+	public function newUndeclaredPropertyCachedListLookup( RequestOptions $requestOptions = null ) {
 
 		$undeclaredPropertyListLookup = new UndeclaredPropertyListLookup(
 			$this->store,

--- a/tests/phpunit/Integration/SemanticMediaWikiProvidedHookInterfaceIntegrationTest.php
+++ b/tests/phpunit/Integration/SemanticMediaWikiProvidedHookInterfaceIntegrationTest.php
@@ -267,8 +267,8 @@ class SemanticMediaWikiProvidedHookInterfaceIntegrationTest extends \PHPUnit_Fra
 			->getMock();
 
 		$idGenerator->expects( $this->any() )
-			->method( 'getSMWPageIDandSort' )
-			->will( $this->returnValue( 42 ) );
+			->method( 'getListOfIdMatchesFor' )
+			->will( $this->returnValue( array( 42 ) ) );
 
 		$store = $this->getMockBuilder( $storeClass )
 			->setMethods( array( 'getPropertyTables', 'getObjectIds' ) )
@@ -305,8 +305,8 @@ class SemanticMediaWikiProvidedHookInterfaceIntegrationTest extends \PHPUnit_Fra
 			->getMock();
 
 		$idGenerator->expects( $this->any() )
-			->method( 'getSMWPageIDandSort' )
-			->will( $this->returnValue( 42 ) );
+			->method( 'getListOfIdMatchesFor' )
+			->will( $this->returnValue( array( 42 ) ) );
 
 		$store = $this->getMockBuilder( $storeClass )
 			->setMethods( array( 'getPropertyTables', 'getObjectIds' ) )

--- a/tests/phpunit/Unit/SQLStore/SQLStoreFactoryTest.php
+++ b/tests/phpunit/Unit/SQLStore/SQLStoreFactoryTest.php
@@ -75,43 +75,43 @@ class SQLStoreFactoryTest extends \PHPUnit_Framework_TestCase {
 		);
 	}
 
-	public function testCanConstructUsageStatisticsListLookup() {
+	public function testCanConstructUsageStatisticsCachedListLookup() {
 
 		$instance = new SQLStoreFactory( new SMWSQLStore3() );
 
 		$this->assertInstanceOf(
 			'SMW\SQLStore\Lookup\CachedListLookup',
-			$instance->newUsageStatisticsListLookup()
+			$instance->newUsageStatisticsCachedListLookup()
 		);
 	}
 
-	public function testCanConstructPropertyUsageListLookup() {
+	public function testCanConstructPropertyUsageCachedListLookup() {
 
 		$instance = new SQLStoreFactory( new SMWSQLStore3() );
 
 		$this->assertInstanceOf(
 			'SMW\SQLStore\Lookup\CachedListLookup',
-			$instance->newPropertyUsageListLookup( null )
+			$instance->newPropertyUsageCachedListLookup( null )
 		);
 	}
 
-	public function testCanConstructUnusedPropertyListLookup() {
+	public function testCanConstructUnusedPropertyCachedListLookup() {
 
 		$instance = new SQLStoreFactory( new SMWSQLStore3() );
 
 		$this->assertInstanceOf(
 			'SMW\SQLStore\Lookup\CachedListLookup',
-			$instance->newUnusedPropertyListLookup( null )
+			$instance->newUnusedPropertyCachedListLookup( null )
 		);
 	}
 
-	public function testCanConstructUndeclaredPropertyListLookup() {
+	public function testCanConstructUndeclaredPropertyCachedListLookup() {
 
 		$instance = new SQLStoreFactory( new SMWSQLStore3() );
 
 		$this->assertInstanceOf(
 			'SMW\SQLStore\Lookup\CachedListLookup',
-			$instance->newUndeclaredPropertyListLookup( null, '_foo' )
+			$instance->newUndeclaredPropertyCachedListLookup( null, '_foo' )
 		);
 	}
 

--- a/tests/phpunit/includes/SQLStore/Writer/DeleteSubjectTest.php
+++ b/tests/phpunit/includes/SQLStore/Writer/DeleteSubjectTest.php
@@ -8,12 +8,7 @@ use Title;
 
 /**
  * @covers \SMWSQLStore3Writers
- *
- * @group SMW
- * @group SMWExtension
- *
- * @group semantic-mediawiki-sqlstore
- * @group mediawiki-databaseless
+ * @group semantic-mediawiki
  *
  * @license GNU GPL v2+
  * @since 1.9.2
@@ -56,12 +51,8 @@ class DeleteSubjectTest extends \PHPUnit_Framework_TestCase {
 			->getMock();
 
 		$objectIdGenerator->expects( $this->once() )
-			->method( 'getSMWPageIDandSort' )
-			->will( $this->returnValue( 0 ) );
-
-		$objectIdGenerator->expects( $this->once() )
-			->method( 'makeSMWPageID' )
-			->will( $this->returnValue( 0 ) );
+			->method( 'getListOfIdMatchesFor' )
+			->will( $this->returnValue( array( 0 ) ) );
 
 		$objectIdGenerator->expects( $this->once() )
 			->method( 'getPropertyTableHashes' )
@@ -104,14 +95,13 @@ class DeleteSubjectTest extends \PHPUnit_Framework_TestCase {
 			->getMock();
 
 		$objectIdGenerator->expects( $this->once() )
-			->method( 'getSMWPageID' )
+			->method( 'getListOfIdMatchesFor' )
 			->with(
 				$this->equalTo( $title->getDBkey() ),
 				$this->equalTo( $title->getNamespace() ),
 				$this->equalTo( $title->getInterwiki() ),
-				'',
-				false )
-			->will( $this->returnValue( 0 ) );
+				'' )
+			->will( $this->returnValue( array( 0 ) ) );
 
 		$database = $this->getMockBuilder( '\SMW\MediaWiki\Database' )
 			->disableOriginalConstructor()


### PR DESCRIPTION
refs #1100

- Matches (and returns) all ids for the DBKey/NS pattern that can include possible ghost pages
- Removes the special pages cache for properties deleted