### PR TITLE
Use canonical identifiers in export

### DIFF
--- a/SemanticMediaWiki.settings.php
+++ b/SemanticMediaWiki.settings.php
@@ -474,6 +474,15 @@ $GLOBALS['smwgExportBacklinks'] = true; // should backlinks be included by defau
 // http://semanticweb.org/id/FOAF
 ##
 
+##
+# Use canonical identifiers (Category:, Property:) instead of localized names
+# to ensure that RDF/Query statements are language agnostic and do work even
+# after the site/content language changes.
+#
+# @since 2.3
+##
+$GLOBALS['smwgExportToUseCanonicalForm'] = true;
+
 ###
 # The maximal number that SMW will normally display without using scientific exp
 # notation. The deafult is rather large since some users have problems understanding

--- a/includes/Settings.php
+++ b/includes/Settings.php
@@ -137,7 +137,8 @@ class Settings extends SimpleDictionary {
 			'smwgEnabledResultFormatsWithRecursiveAnnotationSupport' => $GLOBALS['smwgEnabledResultFormatsWithRecursiveAnnotationSupport'],
 			'smwgEnabledAsyncJobDispatcher' => $GLOBALS['smwgEnabledAsyncJobDispatcher'],
 			'smwgEnabledQueryDependencyLinksStore' => $GLOBALS['smwgEnabledQueryDependencyLinksStore'],
-			'smwgPropertyDependencyDetectionBlacklist' => $GLOBALS['smwgPropertyDependencyDetectionBlacklist']
+			'smwgPropertyDependencyDetectionBlacklist' => $GLOBALS['smwgPropertyDependencyDetectionBlacklist'],
+			'smwgExportToUseCanonicalForm' => $GLOBALS['smwgExportToUseCanonicalForm']
 		);
 
 		$settings = $settings + array(

--- a/includes/export/SMW_Exporter.php
+++ b/includes/export/SMW_Exporter.php
@@ -35,6 +35,7 @@ class SMWExporter {
 	static protected $m_exporturl = false;
 	static protected $m_ent_wiki = false;
 	static protected $m_ent_property = false;
+	static protected $m_ent_category = false;
 	static protected $m_ent_wikiurl = false;
 
 	/**
@@ -101,7 +102,13 @@ class SMWExporter {
 		// The article name must be the last part of wiki URLs for proper OWL/RDF export:
 		self::$m_ent_wikiurl  = $wgServer . str_replace( '$1', '', $wgArticlePath );
 		self::$m_ent_wiki     = $smwgNamespace;
-		self::$m_ent_property = self::$m_ent_wiki . Escaper::encodeUri( urlencode( str_replace( ' ', '_', $wgContLang->getNsText( SMW_NS_PROPERTY ) . ':' ) ) );
+
+		$property = $GLOBALS['smwgExportToUseCanonicalForm'] ? 'Property' : urlencode( str_replace( ' ', '_', $wgContLang->getNsText( SMW_NS_PROPERTY ) ) );
+		$category = $GLOBALS['smwgExportToUseCanonicalForm'] ? 'Category' : urlencode( str_replace( ' ', '_', $wgContLang->getNsText( NS_CATEGORY ) ) );
+
+		self::$m_ent_property = self::$m_ent_wiki . Escaper::encodeUri( $property . ':' );
+		self::$m_ent_category = self::$m_ent_wiki . Escaper::encodeUri( $category . ':' );
+
 		$title = SpecialPage::getTitleFor( 'ExportRDF' );
 		self::$m_exporturl    = self::$m_ent_wikiurl . $title->getPrefixedURL();
 	}
@@ -524,8 +531,8 @@ class SMWExporter {
 	 */
 	static public function expandURI( $uri ) {
 		self::initBaseURIs();
-		$uri = str_replace( array( '&wiki;', '&wikiurl;', '&property;', '&owl;', '&rdf;', '&rdfs;', '&swivt;', '&export;' ),
-		                    array( self::$m_ent_wiki, self::$m_ent_wikiurl, self::$m_ent_property, 'http://www.w3.org/2002/07/owl#', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#', 'http://www.w3.org/2000/01/rdf-schema#', 'http://semantic-mediawiki.org/swivt/1.0#',
+		$uri = str_replace( array( '&wiki;', '&wikiurl;', '&property;', '&category;', '&owl;', '&rdf;', '&rdfs;', '&swivt;', '&export;' ),
+		                    array( self::$m_ent_wiki, self::$m_ent_wikiurl, self::$m_ent_property, self::$m_ent_category, 'http://www.w3.org/2002/07/owl#', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#', 'http://www.w3.org/2000/01/rdf-schema#', 'http://semantic-mediawiki.org/swivt/1.0#',
 		                    self::$m_exporturl ),
 		                    $uri );
 		return $uri;
@@ -547,6 +554,8 @@ class SMWExporter {
 			return self::$m_ent_wikiurl;
 			case 'property':
 			return self::$m_ent_property;
+			case 'category':
+			return self::$m_ent_category;
 			case 'export':
 			return self::$m_exporturl;
 			case 'owl':

--- a/includes/export/SMW_Serializer_RDFXML.php
+++ b/includes/export/SMW_Serializer_RDFXML.php
@@ -51,6 +51,7 @@ class SMWRDFXMLSerializer extends SMWSerializer{
 			// A note on "wiki": this namespace is crucial as a fallback when it would be illegal to start e.g. with a number.
 			// In this case, one can always use wiki:... followed by "_" and possibly some namespace, since _ is legal as a first character.
 			"\t<!ENTITY wiki "  . $this->makeValueEntityString( SMWExporter::getInstance()->expandURI( '&wiki;' ) ) . ">\n" .
+			"\t<!ENTITY category " . $this->makeValueEntityString( SMWExporter::getInstance()->expandURI( '&category;' ) ) . ">\n" .
 			"\t<!ENTITY property " . $this->makeValueEntityString( SMWExporter::getInstance()->expandURI( '&property;' ) ) . ">\n" .
 			"\t<!ENTITY wikiurl " . $this->makeValueEntityString( SMWExporter::getInstance()->expandURI( '&wikiurl;' ) ) . ">\n" .
 			"]>\n\n" .
@@ -60,8 +61,9 @@ class SMWRDFXMLSerializer extends SMWSerializer{
 			"\txmlns:owl =\"&owl;\"\n" .
 			"\txmlns:swivt=\"&swivt;\"\n" .
 			"\txmlns:wiki=\"&wiki;\"\n" .
+			"\txmlns:category=\"&category;\"\n" .
 			"\txmlns:property=\"&property;\"";
-		$this->global_namespaces = array( 'rdf' => true, 'rdfs' => true, 'owl' => true, 'swivt' => true, 'wiki' => true, 'property' => true );
+		$this->global_namespaces = array( 'rdf' => true, 'rdfs' => true, 'owl' => true, 'swivt' => true, 'wiki' => true, 'property' => true, 'category' => true );
 		$this->post_ns_buffer .= ">\n\n";
 	}
 

--- a/includes/export/SMW_Serializer_Turtle.php
+++ b/includes/export/SMW_Serializer_Turtle.php
@@ -82,6 +82,7 @@ class SMWTurtleSerializer extends SMWSerializer{
 				"owl" => SMWExporter::getInstance()->expandURI( '&owl;' ),
 				"swivt" => SMWExporter::getInstance()->expandURI( '&swivt;' ),
 				"wiki" => SMWExporter::getInstance()->expandURI( '&wiki;' ),
+				"category" => SMWExporter::getInstance()->expandURI( '&category;' ),
 				"property" => SMWExporter::getInstance()->expandURI( '&property;' ),
 				"xsd" => "http://www.w3.org/2001/XMLSchema#" ,
 				"wikiurl" => SMWExporter::getInstance()->expandURI( '&wikiurl;' )
@@ -95,11 +96,12 @@ class SMWTurtleSerializer extends SMWSerializer{
 			// A note on "wiki": this namespace is crucial as a fallback when it would be illegal to start e.g. with a number.
 			// In this case, one can always use wiki:... followed by "_" and possibly some namespace, since _ is legal as a first character.
 			"@prefix wiki: <" . SMWExporter::getInstance()->expandURI( '&wiki;' ) . "> .\n" .
+			"@prefix category: <" . SMWExporter::getInstance()->expandURI( '&category;' ) . "> .\n" .
 			"@prefix property: <" . SMWExporter::getInstance()->expandURI( '&property;' ) . "> .\n" .
 			"@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .\n" . // note that this XSD URI is hardcoded below (its unlikely to change, of course)
 			"@prefix wikiurl: <" . SMWExporter::getInstance()->expandURI( '&wikiurl;' ) . "> .\n";
 		}
-		$this->global_namespaces = array( 'rdf' => true, 'rdfs' => true, 'owl' => true, 'swivt' => true, 'wiki' => true, 'property' => true );
+		$this->global_namespaces = array( 'rdf' => true, 'rdfs' => true, 'owl' => true, 'swivt' => true, 'wiki' => true, 'property' => true, 'category' => true );
 		$this->post_ns_buffer = "\n";
 	}
 

--- a/includes/query/SMW_QueryProcessor.php
+++ b/includes/query/SMW_QueryProcessor.php
@@ -358,17 +358,18 @@ class SMWQueryProcessor {
 
 		$parts = explode( '=', $printRequestString, 2 );
 		$propparts = explode( '#', $parts[0], 2 );
+		$printRequestLabel = trim( $propparts[0] );
 
 		$data = null;
 
-		if ( trim( $propparts[0] ) === '' ) { // print "this"
+		if ( $printRequestLabel === '' ) { // print "this"
 			$printmode = PrintRequest::PRINT_THIS;
 			$label = ''; // default
-		} elseif ( $wgContLang->getNsText( NS_CATEGORY ) == ucfirst( trim( $propparts[0] ) ) ) { // print categories
+		} elseif ( $wgContLang->getNsText( NS_CATEGORY ) == mb_convert_case( $printRequestLabel, MB_CASE_TITLE ) || $printRequestLabel == 'Category' ) { // print categories
 			$printmode = PrintRequest::PRINT_CATS;
 			$label = $showMode ? '' : $wgContLang->getNSText( NS_CATEGORY ); // default
 		} else { // print property or check category
-			$title = Title::newFromText( trim( $propparts[0] ), SMW_NS_PROPERTY ); // trim needed for \n
+			$title = Title::newFromText( $printRequestLabel, SMW_NS_PROPERTY ); // trim needed for \n
 			if ( is_null( $title ) ) { // not a legal property/category name; give up
 				return null;
 			}
@@ -379,7 +380,7 @@ class SMWQueryProcessor {
 				$label = $showMode ? '' : $title->getText();  // default
 			} else { // enforce interpretation as property (even if it starts with something that looks like another namespace)
 				$printmode = PrintRequest::PRINT_PROP;
-				$data = SMWPropertyValue::makeUserProperty( trim( $propparts[0] ) );
+				$data = SMWPropertyValue::makeUserProperty( $printRequestLabel );
 				if ( !$data->isValid() ) { // not a property; give up
 					return null;
 				}

--- a/src/Exporter/DataItemToExpResourceEncoder.php
+++ b/src/Exporter/DataItemToExpResourceEncoder.php
@@ -184,6 +184,12 @@ class DataItemToExpResourceEncoder {
 
 		$localName = '';
 
+		if ( $diWikiPage->getNamespace() === NS_CATEGORY ) {
+			$namespace = Exporter::getInstance()->getNamespaceUri( 'category' );
+			$namespaceId = 'category';
+			$localName = Escaper::encodeUri( rawurlencode( $diWikiPage->getDBkey() ) );
+		}
+
 		if ( $diWikiPage->getNamespace() === SMW_NS_PROPERTY ) {
 			$namespace = Exporter::getInstance()->getNamespaceUri( 'property' );
 			$namespaceId = 'property';

--- a/tests/phpunit/Integration/Rdf/ByJsonRdfTestCaseRunnerTest.php
+++ b/tests/phpunit/Integration/Rdf/ByJsonRdfTestCaseRunnerTest.php
@@ -58,7 +58,8 @@ class ByJsonRdfTestCaseRunnerTest extends ByJsonTestCaseProvider {
 			'smwgNamespace',
 			'smwgNamespacesWithSemanticLinks',
 			'wgLanguageCode',
-			'wgContLang'
+			'wgContLang',
+			'smwgExportToUseCanonicalForm'
 		);
 
 		foreach ( $permittedSettings as $key ) {

--- a/tests/phpunit/Integration/Rdf/rdf-003-import-foaf.json
+++ b/tests/phpunit/Integration/Rdf/rdf-003-import-foaf.json
@@ -165,7 +165,7 @@
 					"<owl:Class rdf:about=\"http://xmlns.com/foaf/0.1/Organization\">",
 					"<rdfs:label>Organization</rdfs:label>",
 					"<swivt:specialImportedFrom rdf:datatype=\"http://www.w3.org/2001/XMLSchema#string\">foaf Organization http://xmlns.com/foaf/0.1/</swivt:specialImportedFrom>",
-					"<rdfs:subClassOf rdf:resource=\"&wiki;Category-3ASocial_entity\"/>",
+					"<rdfs:subClassOf rdf:resource=\"http://example.org/id/Category-3ASocial_entity\"/>",
 					"<owl:DatatypeProperty rdf:about=\"http://semantic-mediawiki.org/swivt/1.0#specialImportedFrom\" />",
 					"<owl:Class rdf:about=\"http://example.org/id/Category-3ASocial_entity\" />"
 				]
@@ -174,6 +174,7 @@
 	],
 	"settings": {
 		"wgContLang": "en",
+		"smwgExportToUseCanonicalForm": true,
 		"smwgNamespace": "http://example.org/id/",
 		"smwgNamespacesWithSemanticLinks": {
 			"NS_MAIN": true,

--- a/tests/phpunit/Integration/Rdf/rdf-004-en-category-subcategory.json
+++ b/tests/phpunit/Integration/Rdf/rdf-004-en-category-subcategory.json
@@ -35,7 +35,7 @@
 					"<rdfs:label>Rdf-1-category</rdfs:label>",
 					"<owl:Class rdf:about=\"http://example.org/id/Category-3ARdf-2D2-2Dsubcategory\">",
 					"<rdfs:label>Rdf-2-subcategory</rdfs:label>",
-					"<rdfs:subClassOf rdf:resource=\"&wiki;Category-3ARdf-2D1-2Dcategory\"/>"
+					"<rdfs:subClassOf rdf:resource=\"http://example.org/id/Category-3ARdf-2D1-2Dcategory\"/>"
 				]
 			}
 		},
@@ -51,14 +51,16 @@
 			},
 			"expected-output": {
 				"to-contain": [
+					"<!ENTITY category 'http://example.org/id/Category-3A'>",
+					"<!ENTITY property 'http://example.org/id/Property-3A'>",
 					"<owl:Class rdf:about=\"http://example.org/id/Category-3ARdf-2D1-2Dcategory\">",
 					"<rdfs:label>Rdf-1-category</rdfs:label>",
 					"<owl:Class rdf:about=\"http://example.org/id/Category-3ARdf-2D2-2Dsubcategory\">",
 					"<rdfs:label>Rdf-2-subcategory</rdfs:label>",
-					"<rdfs:subClassOf rdf:resource=\"&wiki;Category-3ARdf-2D1-2Dcategory\"/>",
+					"<rdfs:subClassOf rdf:resource=\"http://example.org/id/Category-3ARdf-2D1-2Dcategory\"/>",
 					"<owl:Class rdf:about=\"http://example.org/id/Category-3ARdf-2D3-2Dsubsubcategory\">",
 					"<rdfs:label>Rdf-3-subsubcategory</rdfs:label>",
-					"<rdfs:subClassOf rdf:resource=\"&wiki;Category-3ARdf-2D2-2Dsubcategory\"/>",
+					"<rdfs:subClassOf rdf:resource=\"http://example.org/id/Category-3ARdf-2D2-2Dsubcategory\"/>",
 					"<owl:ObjectProperty rdf:about=\"http://example.org/id/Property-3ASubcategory_of\">",
 					"<rdfs:label>Subcategory of</rdfs:label>"
 				]
@@ -66,6 +68,7 @@
 		}
 	],
 	"settings": {
+		"smwgExportToUseCanonicalForm": true,
 		"smwgNamespacesWithSemanticLinks": {
 			"NS_MAIN": true,
 			"NS_CATEGORY": true,

--- a/tests/phpunit/includes/export/ExportSemanticDataTest.php
+++ b/tests/phpunit/includes/export/ExportSemanticDataTest.php
@@ -219,9 +219,9 @@ class ExportSemanticDataTest extends \PHPUnit_Framework_TestCase {
 		);
 
 		$expectedResourceElement = new ExpNsResource(
-			Escaper::encodePage( new DIWikiPage( 'SomeCategory', NS_CATEGORY ) ),
-			Exporter::getInstance()->getNamespaceUri( 'wiki' ),
-			'wiki',
+			'SomeCategory',
+			Exporter::getInstance()->getNamespaceUri( 'category' ),
+			'category',
 			new DIWikiPage( 'SomeCategory', NS_CATEGORY )
 		);
 
@@ -250,9 +250,9 @@ class ExportSemanticDataTest extends \PHPUnit_Framework_TestCase {
 		);
 
 		$expectedResourceElement = new ExpNsResource(
-			Escaper::encodePage( new DIWikiPage( 'SomeTopCategory', NS_CATEGORY ) ),
-			Exporter::getInstance()->getNamespaceUri( 'wiki' ),
-			'wiki',
+			'SomeTopCategory',
+			Exporter::getInstance()->getNamespaceUri( 'category' ),
+			'category',
 			new DIWikiPage( 'SomeTopCategory', NS_CATEGORY )
 		);
 


### PR DESCRIPTION
Use canonical identifiers (Category:, Property:) instead of localized names to ensure that RDF/Query statements are language agnostic and do work even after site/content language is changed.

Use `$GLOBALS['smwgExportToUseCanonicalForm'] = false;` to return to the language dependent export.

The canonical form will always resolve to a proper resource but the lang. form doesn't.

Also fixes the assumption on `ucfirst( trim( $propparts[0] )` for UTF-8 which doesn't work, use `mb_convert_case( $printRequestLabel, MB_CASE_TITLE )` instead to make print request labels work correctly for something like:

```
{{#ask: [[カテゴリ:Sample pages]]
 |?Category
 |?カテゴリ
 |limit=5
}}
```
Queries can now use `category:` as stable indentifer to describe a `rdf:type`.

```
PREFIX wiki: <http://example.org/id/>
PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
PREFIX owl: <http://www.w3.org/2002/07/owl#>
PREFIX swivt: <http://semantic-mediawiki.org/swivt/1.0#>
PREFIX property: <http://example.org/id/Property-3A>
PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
PREFIX category: <http://example.org/id/Category-3A>
SELECT DISTINCT ?result WHERE {
?result swivt:wikiPageSortKey ?resultsk .
{ ?result rdf:type category:Sample_pages . }
}
ORDER BY ASC(?resultsk)
OFFSET 0
LIMIT 6
```