### PR TITLE
Simple _geo support in SPARQLStore

### DIFF
--- a/includes/dataitems/SMW_DI_GeoCoord.php
+++ b/includes/dataitems/SMW_DI_GeoCoord.php
@@ -108,8 +108,7 @@ class SMWDIGeoCoord extends SMWDataItem {
 	 * @see SMWDataItem::getSortKey()
 	 */
 	public function getSortKey() {
-		// Maybe also add longitude here? Or is there a more meaningfull value we can return?
-		return $this->latitude;
+		return $this->latitude . ',' . $this->longitude . ( $this->altitude !== null ? ','. $this->altitude : '' );
 	}
 
 	/**

--- a/includes/export/SMW_Exporter.php
+++ b/includes/export/SMW_Exporter.php
@@ -539,6 +539,13 @@ class SMWExporter {
 	}
 
 	/**
+	 * @return string
+	 */
+	public function decodeURI( $uri ) {
+		return Escaper::decodeUri( $uri );
+	}
+
+	/**
 	 * Get the URI of a standard namespace prefix used in SMW, or the empty
 	 * string if the prefix is not known.
 	 *
@@ -628,12 +635,16 @@ class SMWExporter {
 	 * @return SMWExpElement or null
 	 */
 	static public function getDataItemHelperExpElement( SMWDataItem $dataItem ) {
+
 		if ( $dataItem->getDIType() == SMWDataItem::TYPE_TIME ) {
-			$lit = new SMWExpLiteral( (string)$dataItem->getSortKey(), 'http://www.w3.org/2001/XMLSchema#double', '', $dataItem );
-			return $lit;
-		} else {
-			return null;
+			return new SMWExpLiteral( (string)$dataItem->getSortKey(), 'http://www.w3.org/2001/XMLSchema#double', '', $dataItem );
 		}
+
+		if ( $dataItem->getDIType() == SMWDataItem::TYPE_GEO ) {
+			return new SMWExpLiteral( (string)$dataItem->getSortKey(), 'http://www.w3.org/2001/XMLSchema#string', '', $dataItem );
+		}
+
+		return null;
 	}
 
 	/**
@@ -645,7 +656,7 @@ class SMWExporter {
 	 * @return boolean
 	 */
 	static public function hasHelperExpElement( DIProperty $property ) {
-		return ( $property->findPropertyTypeID() === '_dat' ) || ( !$property->isUserDefined() && !self::hasSpecialPropertyResource( $property ) );
+		return ( $property->findPropertyTypeID() === '_dat' || $property->findPropertyTypeID() === '_geo' ) || ( !$property->isUserDefined() && !self::hasSpecialPropertyResource( $property ) );
 	}
 
 	static protected function hasSpecialPropertyResource( DIProperty $property ) {


### PR DESCRIPTION
This uses a simple aux property to replicate the `_geo` sortkey in order
to support geo queries in SPARQLStore:

```
{{#ask: [[Has coordinates::52°31'N, 13°24'E]]
 |?Has coordinates
}}
```
```
PREFIX wiki: <http://example.org/id/>
PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
PREFIX owl: <http://www.w3.org/2002/07/owl#>
PREFIX swivt: <http://semantic-mediawiki.org/swivt/1.0#>
PREFIX property: <http://example.org/id/Property-3A>
PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
SELECT DISTINCT ?result WHERE {
?result swivt:wikiPageSortKey ?resultsk .
?result property:Has_coordinates-23aux "52.516666666667,13.4" .

}
ORDER BY ASC(?resultsk)
OFFSET 0
LIMIT 51
```

A http://www.w3.org/wiki/GeoInfo, http://www.w3.org/2003/01/geo/ encoding
is not part of this PR.