### PR TITLE
Limit property aux use in Exporter

### DIFF
--- a/SemanticMediaWiki.settings.php
+++ b/SemanticMediaWiki.settings.php
@@ -906,3 +906,22 @@ $GLOBALS['smwgEnabledQueryDependencyLinksStore'] = false;
 ##
 $GLOBALS['smwgPropertyDependencyDetectionBlacklist'] = array( '_MDAT', '_SOBJ' );
 ##
+
+###
+# The setting is introduced the keep backwards compatibility with existing Rdf/Turtle
+# exports. The `aux` marker is epxected only used to be used for selected properties
+# to generate a helper value and not for any other predefined property.
+#
+# Any property that does not explicitly require an auxiliary value (such `_dat`/
+# `_geo` type values) now uses its native as condition descriptor (`Has_subobject`
+# instead of `Has_subobject-23aux`)
+#
+# For SPARQL repository users that don't want to run an a  `rebuildData.php`,
+# the setting has to be TRUE.
+#
+# This BC setting is planned to vanish with 3.x.
+#
+# @since 2.3
+##
+$GLOBALS['smwgExportBCAuxiliaryUse'] = false;
+##

--- a/includes/Settings.php
+++ b/includes/Settings.php
@@ -138,7 +138,8 @@ class Settings extends SimpleDictionary {
 			'smwgEnabledAsyncJobDispatcher' => $GLOBALS['smwgEnabledAsyncJobDispatcher'],
 			'smwgEnabledQueryDependencyLinksStore' => $GLOBALS['smwgEnabledQueryDependencyLinksStore'],
 			'smwgPropertyDependencyDetectionBlacklist' => $GLOBALS['smwgPropertyDependencyDetectionBlacklist'],
-			'smwgExportToUseCanonicalForm' => $GLOBALS['smwgExportToUseCanonicalForm']
+			'smwgExportToUseCanonicalForm' => $GLOBALS['smwgExportToUseCanonicalForm'],
+			'smwgExportBCAuxiliaryUse' => $GLOBALS['smwgExportBCAuxiliaryUse']
 		);
 
 		$settings = $settings + array(

--- a/includes/export/SMW_Exporter.php
+++ b/includes/export/SMW_Exporter.php
@@ -60,6 +60,10 @@ class SMWExporter {
 			);
 
 			self::$dataItemToExpResourceEncoder->reset();
+
+			self::$dataItemToExpResourceEncoder->setBCAuxiliaryUse(
+				ApplicationFactory::getInstance()->getSettings()->get( 'smwgExportBCAuxiliaryUse' )
+			);
 		}
 
 		return self::$instance;
@@ -156,6 +160,7 @@ class SMWExporter {
 	 */
 	static public function makeExportDataForSubject( SMWDIWikiPage $diWikiPage, $addStubData = false ) {
 		global $wgContLang;
+
 		$wikiPageExpElement = self::getDataItemExpElement( $diWikiPage );
 		$result = new SMWExpData( $wikiPageExpElement );
 
@@ -187,6 +192,7 @@ class SMWExporter {
 			);
 
 		} else {
+
 			$pageTitle = str_replace( '_', ' ', $diWikiPage->getDBkey() );
 			if ( $diWikiPage->getNamespace() !== 0 ) {
 				$prefixedSubjectTitle = $wgContLang->getNsText( $diWikiPage->getNamespace()) . ":" . $pageTitle;
@@ -257,6 +263,7 @@ class SMWExporter {
 	 * @param $data SMWExpData to add the data to
 	 */
 	static public function addPropertyValues( SMWDIProperty $property, array $dataItems, SMWExpData &$expData ) {
+
 		if ( $property->isUserDefined() ) {
 			$pe = self::getResourceElementForProperty( $property );
 			$peHelper = self::getResourceElementForProperty( $property, true );
@@ -329,11 +336,14 @@ class SMWExporter {
 
 					} elseif ( $property->getKey() == '_REDI' ) {
 						$expData->addPropertyObjectValue( $pe, $ed );
-						$peUri = self::getSpecialPropertyResource( '_URI' );
-						$expData->addPropertyObjectValue( $peUri, $ed );
-					} elseif ( !$property->isUserDefined() && !self::hasSpecialPropertyResource( $property )  ) {
+
 						$expData->addPropertyObjectValue(
-							self::getResourceElementForWikiPage( $property->getDiWikiPage(), 'aux' ),
+							self::getSpecialPropertyResource( '_URI' ),
+							$ed
+						);
+					} elseif ( !$property->isUserDefined() && !self::hasSpecialPropertyResource( $property ) ) {
+						$expData->addPropertyObjectValue(
+							self::getResourceElementForProperty( $property, true ),
 							$ed
 						);
 					} else {
@@ -342,7 +352,8 @@ class SMWExporter {
 				}
 
 				$edHelper = self::getDataItemHelperExpElement( $dataItem );
-				if ( !is_null( $edHelper ) ) {
+
+				if ( $edHelper !== null ) {
 					$expData->addPropertyObjectValue( $peHelper, $edHelper );
 				}
 			}

--- a/src/SPARQLStore/TurtleTriplesBuilder.php
+++ b/src/SPARQLStore/TurtleTriplesBuilder.php
@@ -279,7 +279,7 @@ class TurtleTriplesBuilder {
 			$elementTarget = $expResource;
 		}
 
-		if ( !$exists && ( $elementTarget->getDataItem() instanceof DIWikiPage ) ) {
+		if ( !$exists && $elementTarget->getDataItem() instanceof DIWikiPage ) {
 
 			$diWikiPage = $elementTarget->getDataItem();
 			$hash = $diWikiPage->getHash();

--- a/tests/phpunit/Integration/MediaWiki/Import/Maintenance/DumpRdfMaintenanceTest.php
+++ b/tests/phpunit/Integration/MediaWiki/Import/Maintenance/DumpRdfMaintenanceTest.php
@@ -4,6 +4,8 @@ namespace SMW\Tests\Integration\MediaWiki\Import\Maintenance;
 
 use SMW\Tests\Utils\UtilityFactory;
 use SMW\Tests\MwDBaseUnitTestCase;
+use SMW\ApplicationFactory;
+use SMW\EventHandler;
 
 /**
  * @group SMW
@@ -37,6 +39,9 @@ class DumpRdfMaintenanceTest extends MwDBaseUnitTestCase {
 		$this->titleValidator = UtilityFactory::getInstance()->newValidatorFactory()->newTitleValidator();
 		$this->stringValidator = UtilityFactory::getInstance()->newValidatorFactory()->newStringValidator();
 
+		ApplicationFactory::getInstance()->getSettings()->set( 'smwgExportBCAuxiliaryUse', true );
+		EventHandler::getInstance()->getEventDispatcher()->dispatch( 'exporter.reset' );
+
 		$importRunner = $this->runnerFactory->newXmlImportRunner(
 			__DIR__ . '/../Fixtures/' . 'GenericLoremIpsumTest-Mw-1-19-7.xml'
 		);
@@ -48,6 +53,7 @@ class DumpRdfMaintenanceTest extends MwDBaseUnitTestCase {
 	}
 
 	protected function tearDown() {
+		ApplicationFactory::getInstance()->clear();
 
 		$pageDeleter = UtilityFactory::getInstance()->newPageDeleter();
 		$pageDeleter->doDeletePoolOfPages( $this->importedTitles );

--- a/tests/phpunit/Integration/Rdf/ByJsonRdfTestCaseRunnerTest.php
+++ b/tests/phpunit/Integration/Rdf/ByJsonRdfTestCaseRunnerTest.php
@@ -59,7 +59,8 @@ class ByJsonRdfTestCaseRunnerTest extends ByJsonTestCaseProvider {
 			'smwgNamespacesWithSemanticLinks',
 			'wgLanguageCode',
 			'wgContLang',
-			'smwgExportToUseCanonicalForm'
+			'smwgExportToUseCanonicalForm',
+			'smwgExportBCAuxiliaryUse'
 		);
 
 		foreach ( $permittedSettings as $key ) {

--- a/tests/phpunit/Integration/Rdf/RdfFileResourceTest.php
+++ b/tests/phpunit/Integration/Rdf/RdfFileResourceTest.php
@@ -47,6 +47,7 @@ class RdfFileResourceTest extends MwDBaseUnitTestCase {
 			'smwgPageSpecialProperties' => array( '_MEDIA', '_MIME' ),
 			'smwgNamespacesWithSemanticLinks' => array( NS_MAIN => true, NS_FILE => true ),
 			'smwgCacheType' => 'hash',
+			'smwgExportBCAuxiliaryUse' => true
 		);
 
 		foreach ( $settings as $key => $value ) {
@@ -60,6 +61,8 @@ class RdfFileResourceTest extends MwDBaseUnitTestCase {
 		$GLOBALS['wgEnableUploads'] = true;
 		$GLOBALS['wgFileExtensions'] = array( 'txt' );
 		$GLOBALS['wgVerifyMimeType'] = true;
+
+		\SMWExporter::clear();
 	}
 
 	protected function tearDown() {

--- a/tests/phpunit/Integration/Rdf/rdf-001.json
+++ b/tests/phpunit/Integration/Rdf/rdf-001.json
@@ -167,6 +167,7 @@
 		}
 	],
 	"settings": {
+		"smwgExportBCAuxiliaryUse": true,
 		"smwgNamespace": "http://example.org/id/",
 		"smwgNamespacesWithSemanticLinks": {
 			"NS_MAIN": true,

--- a/tests/phpunit/Unit/SPARQLStore/QueryEngine/CompoundConditionBuilderTest.php
+++ b/tests/phpunit/Unit/SPARQLStore/QueryEngine/CompoundConditionBuilderTest.php
@@ -540,7 +540,7 @@ class CompoundConditionBuilderTest extends \PHPUnit_Framework_TestCase {
 		);
 
 		$expectedConditionString = $this->stringBuilder
-			->addString( '?result property:Has_subobject-23aux ?v1 .' )->addNewLine()
+			->addString( '?result property:Has_subobject ?v1 .' )->addNewLine()
 			->getString();
 
 		$this->assertEquals(

--- a/tests/phpunit/Unit/SPARQLStore/RedirectLookupTest.php
+++ b/tests/phpunit/Unit/SPARQLStore/RedirectLookupTest.php
@@ -26,23 +26,23 @@ class RedirectLookupTest extends \PHPUnit_Framework_TestCase {
 
 	public function testCanConstruct() {
 
-		$sparqlDatabase = $this->getMockBuilder( '\SMWSparqlDatabase' )
+		$repositoryConnection = $this->getMockBuilder( '\SMW\SPARQLStore\RepositoryConnection' )
 			->disableOriginalConstructor()
 			->getMock();
 
 		$this->assertInstanceOf(
 			'\SMW\SPARQLStore\RedirectLookup',
-			new RedirectLookup( $sparqlDatabase )
+			new RedirectLookup( $repositoryConnection )
 		);
 	}
 
 	public function testRedirectTragetForBlankNode() {
 
-		$sparqlDatabase = $this->getMockBuilder( '\SMWSparqlDatabase' )
+		$repositoryConnection = $this->getMockBuilder( '\SMW\SPARQLStore\RepositoryConnection' )
 			->disableOriginalConstructor()
 			->getMock();
 
-		$instance = new RedirectLookup( $sparqlDatabase );
+		$instance = new RedirectLookup( $repositoryConnection );
 
 		$expNsResource = new ExpNsResource( '', '', '', null );
 		$exists = null;
@@ -57,11 +57,11 @@ class RedirectLookupTest extends \PHPUnit_Framework_TestCase {
 
 	public function testRedirectTragetForDataItemWithSubobject() {
 
-		$sparqlDatabase = $this->getMockBuilder( '\SMWSparqlDatabase' )
+		$repositoryConnection = $this->getMockBuilder( '\SMW\SPARQLStore\RepositoryConnection' )
 			->disableOriginalConstructor()
 			->getMock();
 
-		$instance = new RedirectLookup( $sparqlDatabase );
+		$instance = new RedirectLookup( $repositoryConnection );
 		$dataItem = new DIWikiPage( 'Foo', 1, '', 'beingASubobject' );
 
 		$expNsResource = new ExpNsResource( 'Foo', 'Bar', '', $dataItem );
@@ -77,9 +77,9 @@ class RedirectLookupTest extends \PHPUnit_Framework_TestCase {
 
 	public function testRedirectTragetForDBLookupWithNoEntry() {
 
-		$sparqlDatabase = $this->createRepositoryConnectionMockToUse( false );
+		$repositoryConnection = $this->createRepositoryConnectionMockToUse( false );
 
-		$instance = new RedirectLookup( $sparqlDatabase );
+		$instance = new RedirectLookup( $repositoryConnection );
 		$dataItem = new DIWikiPage( 'Foo', 1, '', '' );
 
 		$expNsResource = new ExpNsResource( 'Foo', 'Bar', '', $dataItem );
@@ -97,9 +97,9 @@ class RedirectLookupTest extends \PHPUnit_Framework_TestCase {
 
 		$expLiteral = new ExpLiteral( 'Redirect' );
 
-		$sparqlDatabase = $this->createRepositoryConnectionMockToUse( array( $expLiteral ) );
+		$repositoryConnection = $this->createRepositoryConnectionMockToUse( array( $expLiteral ) );
 
-		$instance = new RedirectLookup( $sparqlDatabase );
+		$instance = new RedirectLookup( $repositoryConnection );
 		$instance->reset();
 
 		$dataItem = new DIWikiPage( 'Foo', 1, '', '' );
@@ -119,9 +119,9 @@ class RedirectLookupTest extends \PHPUnit_Framework_TestCase {
 
 		$expLiteral = new ExpLiteral( 'Redirect' );
 
-		$sparqlDatabase = $this->createRepositoryConnectionMockToUse( array( $expLiteral, null ) );
+		$repositoryConnection = $this->createRepositoryConnectionMockToUse( array( $expLiteral, null ) );
 
-		$instance = new RedirectLookup( $sparqlDatabase );
+		$instance = new RedirectLookup( $repositoryConnection );
 		$instance->reset();
 
 		$dataItem = new DIWikiPage( 'Foo', 1, '', '' );
@@ -148,9 +148,9 @@ class RedirectLookupTest extends \PHPUnit_Framework_TestCase {
 			$propertyPage
 		);
 
-		$sparqlDatabase = $this->createRepositoryConnectionMockToUse( array( $resource, $resource ) );
+		$repositoryConnection = $this->createRepositoryConnectionMockToUse( array( $resource, $resource ) );
 
-		$instance = new RedirectLookup( $sparqlDatabase );
+		$instance = new RedirectLookup( $repositoryConnection );
 		$instance->reset();
 
 		$dataItem = new DIWikiPage( 'Foo', 1, '', '' );
@@ -183,9 +183,9 @@ class RedirectLookupTest extends \PHPUnit_Framework_TestCase {
 
 		$expLiteral = new ExpLiteral( 'Redirect' );
 
-		$sparqlDatabase = $this->createRepositoryConnectionMockToUse( array( $expLiteral, $expLiteral ) );
+		$repositoryConnection = $this->createRepositoryConnectionMockToUse( array( $expLiteral, $expLiteral ) );
 
-		$instance = new RedirectLookup( $sparqlDatabase );
+		$instance = new RedirectLookup( $repositoryConnection );
 		$instance->reset();
 
 		$dataItem = new DIWikiPage( 'Foo', 1, '', '' );
@@ -209,11 +209,11 @@ class RedirectLookupTest extends \PHPUnit_Framework_TestCase {
 			$expNsResource
 		);
 
-		$connection = $this->getMockBuilder( '\SMWSparqlDatabase' )
+		$repositoryConnection = $this->getMockBuilder( '\SMW\SPARQLStore\RepositoryConnection' )
 			->disableOriginalConstructor()
 			->getMock();
 
-		$instance = new RedirectLookup( $connection );
+		$instance = new RedirectLookup( $repositoryConnection );
 
 		$exists = null;
 
@@ -228,23 +228,17 @@ class RedirectLookupTest extends \PHPUnit_Framework_TestCase {
 	 */
 	public function testRedirectTargetForNonRedirectableResource( $expNsResource ) {
 
-		$cache = $this->getMockBuilder( '\Onoi\Cache\Cache' )
+		$repositoryConnection = $this->getMockBuilder( '\SMW\SPARQLStore\RepositoryConnection' )
 			->disableOriginalConstructor()
 			->getMock();
 
-		$cache->expects( $this->never() )
-			->method( 'contains' );
-
-		$connection = $this->getMockBuilder( '\SMWSparqlDatabase' )
-			->disableOriginalConstructor()
-			->getMock();
-
-		$instance = new RedirectLookup( $connection, $cache );
+		$instance = new RedirectLookup( $repositoryConnection );
 		$instance->reset();
 
 		$exists = null;
 
 		$instance->findRedirectTargetResource( $expNsResource, $exists );
+		$instance->reset();
 
 		$this->assertFalse( $exists );
 	}
@@ -259,15 +253,15 @@ class RedirectLookupTest extends \PHPUnit_Framework_TestCase {
 			->method( 'current' )
 			->will( $this->returnValue( $listReturnValue ) );
 
-		$sparqlDatabase = $this->getMockBuilder( '\SMWSparqlDatabase' )
+		$repositoryConnection = $this->getMockBuilder( '\SMW\SPARQLStore\RepositoryConnection' )
 			->disableOriginalConstructor()
 			->getMock();
 
-		$sparqlDatabase->expects( $this->once() )
+		$repositoryConnection->expects( $this->once() )
 			->method( 'select' )
 			->will( $this->returnValue( $repositoryResult ) );
 
-		return $sparqlDatabase;
+		return $repositoryConnection;
 	}
 
 	public function nonRedirectableResourceProvider() {
@@ -289,7 +283,7 @@ class RedirectLookupTest extends \PHPUnit_Framework_TestCase {
 		);
 
 		$provider[] = array(
-			Exporter::getInstance()->getResourceElementForProperty( new DIProperty( 'Foo' ), true )
+			Exporter::getInstance()->getSpecialPropertyResource( '_MDAT', true )
 		);
 
 		return $provider;

--- a/tests/phpunit/includes/export/ExportSemanticDataTest.php
+++ b/tests/phpunit/includes/export/ExportSemanticDataTest.php
@@ -342,7 +342,7 @@ class ExportSemanticDataTest extends \PHPUnit_Framework_TestCase {
 	}
 
 	private function transformPropertyLabelToAuxiliary( DIProperty $property ) {
-		return str_replace( ' ', '_', $property->getLabel() ) . '-23' . 'aux';
+		return str_replace( ' ', '_', $property->getLabel() );
 	}
 
 }


### PR DESCRIPTION
The use of auxiliary properties during the RDF export is now limited to
properties that really require a helper value other such as
(Has subobject etc.) will now use the standard property declaration.

This PR brings the SPARQL query closer to its #ask query.
```
{{#ask: [[Has subobject.Has page::abc]]
 |format=table
}}

```
```
...
?result swivt:wikiPageSortKey ?resultsk .
?result property:Has_subobject ?v1 .
{ ?v1 property:Has_page wiki:Abc .
}
...
```

Prior to this PR one would have to know assigned aux declaration.
```
...
?result swivt:wikiPageSortKey ?resultsk .
?result property:Has_subobject-23aux ?v1 .
{ ?v1 property:Has_page wiki:Abc .
}
...
```
To retain backwards compatibility (= not running `rebuildData.php`),
`$GLOBALS['smwgExportBCAuxiliaryUse'] = true;` should be set.