### PR TITLE
ParserAfterTidy hook to identify parser context, ref #1166

### DIFF
--- a/src/MediaWiki/Hooks/ParserAfterTidy.php
+++ b/src/MediaWiki/Hooks/ParserAfterTidy.php
@@ -126,6 +126,13 @@ class ParserAfterTidy {
 	 */
 	private function checkForRequestedUpdateByPagePurge( $parserData ) {
 
+		// Only carry out a purge where InTextAnnotationParser have set
+		// an appropriate context reference otherwise it is assumed that the hook
+		// call is part of another non SMW related parse
+		if ( $parserData->getSemanticData()->getSubject()->getContextReference() === null ) {
+			return true;
+		}
+
 		$cache = $this->applicationFactory->getCache();
 
 		$key = $this->applicationFactory->newCacheFactory()->getPurgeCacheKey(


### PR DESCRIPTION
refs #1166

The #tree interferes with when/how the `InternalParseBeforeLinks` hook is executed and forces an early update during action=purge by the `ParserAfterTidy` hook. `DIWikiPage::getContextReference` allows us to identify that a specific `ParserAfterTidy`call is part of a SMW related parse or not.