### PR TITLE
Ren AsyncJobDispatchManager to DeferredRequestDispatchManager, refs #1130

### DIFF
--- a/SemanticMediaWiki.settings.php
+++ b/SemanticMediaWiki.settings.php
@@ -859,12 +859,14 @@ $GLOBALS['smwgEnabledEditPageHelp'] = true;
 
 ###
 #
-# Improves performance for selected operations that can be executed
-# in asynchronous processing mode.
+# Improves performance for selected Job operations that can be executed in a deferred
+# processing mode (or asynchronous to the current transaction) as those (if enabled)
+# are send as request to a dispatcher in order for them to be decoupled from the
+# initial transaction.
 #
 # @since 2.3
 ##
-$GLOBALS['smwgEnabledAsyncJobDispatcher'] = true;
+$GLOBALS['smwgEnabledHttpDeferredJobRequest'] = true;
 ##
 
 ###
@@ -874,7 +876,7 @@ $GLOBALS['smwgEnabledAsyncJobDispatcher'] = true;
 # The setting requires to run `update.php` (it creates an extra table). Also
 # as noted in #1117, `SMW\ParserCachePurgeJob` should be scheduled accordingly.
 #
-# Requires `smwgEnabledAsyncJobDispatcher` to be set true.
+# Requires `smwgEnabledHttpDeferredJobRequest` to be set true.
 #
 # @since 2.3 (experimental)
 # @default false

--- a/includes/Settings.php
+++ b/includes/Settings.php
@@ -135,7 +135,7 @@ class Settings extends SimpleDictionary {
 			'smwgEnabledEditPageHelp' => $GLOBALS['smwgEnabledEditPageHelp'],
 			'smwgSparqlQFeatures' => $GLOBALS['smwgSparqlQFeatures'],
 			'smwgEnabledResultFormatsWithRecursiveAnnotationSupport' => $GLOBALS['smwgEnabledResultFormatsWithRecursiveAnnotationSupport'],
-			'smwgEnabledAsyncJobDispatcher' => $GLOBALS['smwgEnabledAsyncJobDispatcher'],
+			'smwgEnabledHttpDeferredJobRequest' => $GLOBALS['smwgEnabledHttpDeferredJobRequest'],
 			'smwgEnabledQueryDependencyLinksStore' => $GLOBALS['smwgEnabledQueryDependencyLinksStore'],
 			'smwgPropertyDependencyDetectionBlacklist' => $GLOBALS['smwgPropertyDependencyDetectionBlacklist'],
 			'smwgExportBCNonCanonicalFormUse' => $GLOBALS['smwgExportBCNonCanonicalFormUse'],

--- a/includes/Setup.php
+++ b/includes/Setup.php
@@ -226,8 +226,8 @@ final class Setup {
 				'page' => 'SMW\SpecialWantedProperties',
 				'group' => 'maintenance'
 			),
-			'AsyncJobDispatcher' => array(
-				'page' => 'SMW\MediaWiki\Specials\SpecialAsyncJobDispatcher',
+			'DeferredRequestDispatcher' => array(
+				'page' => 'SMW\MediaWiki\Specials\SpecialDeferredRequestDispatcher',
 				'group' => 'maintenance'
 			),
 		);

--- a/includes/storage/SQLStore/SMW_SQLStore3_Writers.php
+++ b/includes/storage/SQLStore/SMW_SQLStore3_Writers.php
@@ -5,7 +5,7 @@ use SMW\MediaWiki\Jobs\JobBase;
 
 use SMW\SQLStore\PropertyStatisticsTable;
 use SMW\SQLStore\PropertyTableRowDiffer;
-use SMW\AsyncJobDispatchManager;
+use SMW\DeferredRequestDispatchManager;
 use Onoi\HttpRequest\HttpRequestFactory;
 
 use SMW\SemanticData;
@@ -726,21 +726,21 @@ class SMWSQLStore3Writers {
 		// Set 'pm' (parser-mode) to 2 indicating to use a new Parser
 		// instance when running the job
 
-		$asyncJobDispatchManager = $this->newAsyncJobDispatchManager();
+		$deferredRequestDispatchManager = $this->newDeferredRequestDispatchManager();
 
 		$parameters = array(
 			'pm' => SMW_UJ_PM_NP
 		);
 
 		if ( $redirectId != 0 ) {
-			$asyncJobDispatchManager->dispatchJobFor(
+			$deferredRequestDispatchManager->dispatchJobRequestFor(
 				'SMW\UpdateJob',
 				$oldTitle,
 				$parameters
 			);
 		}
 
-		$asyncJobDispatchManager->dispatchJobFor(
+		$deferredRequestDispatchManager->dispatchJobRequestFor(
 			'SMW\UpdateJob',
 			$newTitle,
 			$parameters
@@ -1016,18 +1016,18 @@ class SMWSQLStore3Writers {
 		return ( $new_tid == 0 ) ? $sid : $new_tid;
 	}
 
-	private function newAsyncJobDispatchManager() {
+	private function newDeferredRequestDispatchManager() {
 		$httpRequestFactory = new HttpRequestFactory();
 
-		$asyncJobDispatchManager = new AsyncJobDispatchManager(
+		$deferredRequestDispatchManager = new DeferredRequestDispatchManager(
 			$httpRequestFactory->newSocketRequest()
 		);
 
-		$asyncJobDispatchManager->setEnabledState(
-			$GLOBALS['smwgEnabledAsyncJobDispatcher']
+		$deferredRequestDispatchManager->setEnabledHttpDeferredJobRequestState(
+			$GLOBALS['smwgEnabledHttpDeferredJobRequest']
 		);
 
-		return $asyncJobDispatchManager;
+		return $deferredRequestDispatchManager;
 	}
 
 }

--- a/languages/SMW_Aliases.php
+++ b/languages/SMW_Aliases.php
@@ -25,7 +25,7 @@ $specialPageAliases['en'] = array(
 	'URIResolver' => array( 'URIResolver' ),
 	'UnusedProperties' => array( 'UnusedProperties' ),
 	'WantedProperties' => array( 'WantedProperties' ),
-	'AsyncJobDispatcher' => array( 'AsyncJobDispatcher' ),
+	'DeferredRequestDispatcher' => array( 'DeferredRequestDispatcher' ),
 );
 
 /** Afrikaans (Afrikaans) */

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -61,7 +61,7 @@
     <php>
        <var name="smwgSparqlDefaultGraph" value="http://example.org/phpunit-testrun"/>
        <var name="smwgValueLookupCacheType" value="hash"/>
-       <var name="smwgEnabledAsyncJobDispatcher" value="false"/>
+       <var name="smwgEnabledHttpDeferredJobRequest" value="false"/>
        <var name="smwgEnabledQueryDependencyLinksStore" value="true"/>
        <var name="benchmarkQueryRepetitionExecutionThreshold" value="5"/>
        <var name="benchmarkQueryLimit" value="500"/>

--- a/src/MediaWiki/Hooks/HookRegistry.php
+++ b/src/MediaWiki/Hooks/HookRegistry.php
@@ -10,7 +10,7 @@ use SMW\EventHandler;
 use SMW\NamespaceManager;
 use SMW\SQLStore\EmbeddedQueryDependencyLinksStore;
 use SMW\SQLStore\EmbeddedQueryDependencyListResolver;
-use SMW\AsyncJobDispatchManager;
+use SMW\DeferredRequestDispatchManager;
 use SMW\PropertyHierarchyLookup;
 use Onoi\HttpRequest\HttpRequestFactory;
 
@@ -501,15 +501,15 @@ class HookRegistry {
 
 			$httpRequestFactory = new HttpRequestFactory();
 
-			$asyncJobDispatchManager = new AsyncJobDispatchManager(
+			$deferredRequestDispatchManager = new DeferredRequestDispatchManager(
 				$httpRequestFactory->newSocketRequest()
 			);
 
-			$asyncJobDispatchManager->setEnabledState(
-				$applicationFactory->getSettings()->get( 'smwgEnabledAsyncJobDispatcher' )
+			$deferredRequestDispatchManager->setEnabledHttpDeferredJobRequestState(
+				$applicationFactory->getSettings()->get( 'smwgEnabledHttpDeferredJobRequest' )
 			);
 
-			$asyncJobDispatchManager->dispatchJobFor(
+			$deferredRequestDispatchManager->dispatchJobRequestFor(
 				'SMW\ParserCachePurgeJob',
 				$semanticData->getSubject()->getTitle(),
 				$embeddedQueryDependencyLinksStore->buildParserCachePurgeJobParametersFrom( $compositePropertyTableDiffIterator )

--- a/src/MediaWiki/Specials/SpecialDeferredRequestDispatcher.php
+++ b/src/MediaWiki/Specials/SpecialDeferredRequestDispatcher.php
@@ -8,7 +8,7 @@ use Onoi\HttpRequest\HttpRequestFactory;
 use Title;
 
 /**
- * This class is the receiving endpoint for the `AsyncJobDispatchManager` invoked
+ * This class is the receiving endpoint for the `DeferredRequestDispatchManager` invoked
  * job request.
  *
  * This special page is not expected to interact with a user and therefore it is
@@ -19,7 +19,7 @@ use Title;
  *
  * @author mwjames
  */
-class SpecialAsyncJobDispatcher extends SpecialPage {
+class SpecialDeferredRequestDispatcher extends SpecialPage {
 
 	/**
 	 * @var boolean
@@ -30,7 +30,7 @@ class SpecialAsyncJobDispatcher extends SpecialPage {
 	 * @codeCoverageIgnore
 	 */
 	public function __construct() {
-		parent::__construct( 'AsyncJobDispatcher', '', false );
+		parent::__construct( 'DeferredRequestDispatcher', '', false );
 	}
 
 	/**
@@ -55,7 +55,7 @@ class SpecialAsyncJobDispatcher extends SpecialPage {
 	 * @return string
 	 */
 	public static function getTargetURL() {
-		return SpecialPage::getTitleFor( 'AsyncJobDispatcher')->getFullURL();
+		return SpecialPage::getTitleFor( 'DeferredRequestDispatcher')->getFullURL();
 	}
 
 	/**

--- a/src/SQLStore/QueryEngine/QueryEngine.php
+++ b/src/SQLStore/QueryEngine/QueryEngine.php
@@ -47,7 +47,7 @@ class QueryEngine {
 	 *
 	 * @var QuerySegment[]
 	 */
-	private $querySegments = array();
+	private $querySegmentList = array();
 
 	/**
 	 * Array of sorting requests ("Property_name" => "ASC"/"DESC"). Used during

--- a/tests/phpunit/Unit/DeferredRequestDispatchManagerTest.php
+++ b/tests/phpunit/Unit/DeferredRequestDispatchManagerTest.php
@@ -2,11 +2,11 @@
 
 namespace SMW\Tests;
 
-use SMW\AsyncJobDispatchManager;
+use SMW\DeferredRequestDispatchManager;
 use SMW\DIWikiPage;
 
 /**
- * @covers \SMW\AsyncJobDispatchManager
+ * @covers \SMW\DeferredRequestDispatchManager
  * @group semantic-mediawiki
  *
  * @license GNU GPL v2+
@@ -14,7 +14,7 @@ use SMW\DIWikiPage;
  *
  * @author mwjames
  */
-class AsyncJobDispatchManagerTest extends \PHPUnit_Framework_TestCase {
+class DeferredRequestDispatchManagerTest extends \PHPUnit_Framework_TestCase {
 
 	public function testCanConstruct() {
 
@@ -23,15 +23,15 @@ class AsyncJobDispatchManagerTest extends \PHPUnit_Framework_TestCase {
 			->getMock();
 
 		$this->assertInstanceOf(
-			'\SMW\AsyncJobDispatchManager',
-			new AsyncJobDispatchManager( $httpRequest )
+			'\SMW\DeferredRequestDispatchManager',
+			new DeferredRequestDispatchManager( $httpRequest )
 		);
 	}
 
 	/**
 	 * @dataProvider dispatchableJobProvider
 	 */
-	public function testDispatchFor( $type, $dispatchableAsyncUsageState, $parameters = array() ) {
+	public function testDispatchJobFor( $type, $deferredJobRequestState, $parameters = array() ) {
 
 		$httpRequest = $this->getMockBuilder( '\Onoi\HttpRequest\SocketRequest' )
 			->disableOriginalConstructor()
@@ -41,12 +41,12 @@ class AsyncJobDispatchManagerTest extends \PHPUnit_Framework_TestCase {
 			->method( 'ping' )
 			->will( $this->returnValue( true ) );
 
-		$instance = new AsyncJobDispatchManager( $httpRequest );
+		$instance = new DeferredRequestDispatchManager( $httpRequest );
 		$instance->reset();
-		$instance->setEnabledState( $dispatchableAsyncUsageState );
+		$instance->setEnabledHttpDeferredJobRequestState( $deferredJobRequestState );
 
 		$this->assertTrue(
-			$instance->dispatchJobFor( $type, DIWikiPage::newFromText( __METHOD__ )->getTitle(), $parameters )
+			$instance->dispatchJobRequestFor( $type, DIWikiPage::newFromText( __METHOD__ )->getTitle(), $parameters )
 		);
 	}
 
@@ -63,11 +63,11 @@ class AsyncJobDispatchManagerTest extends \PHPUnit_Framework_TestCase {
 			->method( 'ping' )
 			->will( $this->returnValue( true ) );
 
-		$instance = new AsyncJobDispatchManager( $httpRequest );
+		$instance = new DeferredRequestDispatchManager( $httpRequest );
 		$instance->reset();
 
 		$this->assertNull(
-			$instance->dispatchJobFor( $type, DIWikiPage::newFromText( __METHOD__ )->getTitle(), $parameters )
+			$instance->dispatchJobRequestFor( $type, DIWikiPage::newFromText( __METHOD__ )->getTitle(), $parameters )
 		);
 	}
 

--- a/tests/phpunit/Unit/MediaWiki/Specials/SpecialDeferredRequestDispatcherTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Specials/SpecialDeferredRequestDispatcherTest.php
@@ -3,12 +3,12 @@
 namespace SMW\Tests\MediaWiki\Specials;
 
 use SMW\Tests\Utils\UtilityFactory;
-use SMW\MediaWiki\Specials\SpecialAsyncJobDispatcher;
+use SMW\MediaWiki\Specials\SpecialDeferredRequestDispatcher;
 use SMW\ApplicationFactory;
 use Title;
 
 /**
- * @covers \SMW\MediaWiki\Specials\SpecialAsyncJobDispatcher
+ * @covers \SMW\MediaWiki\Specials\SpecialDeferredRequestDispatcher
  * @group semantic-mediawiki
  *
  * @license GNU GPL v2+
@@ -16,7 +16,7 @@ use Title;
  *
  * @author mwjames
  */
-class SpecialAsyncJobDispatcherTest extends \PHPUnit_Framework_TestCase {
+class SpecialDeferredRequestDispatcherTest extends \PHPUnit_Framework_TestCase {
 
 	private $applicationFactory;
 	private $stringValidator;
@@ -47,16 +47,16 @@ class SpecialAsyncJobDispatcherTest extends \PHPUnit_Framework_TestCase {
 	public function testCanConstruct() {
 
 		$this->assertInstanceOf(
-			'\SMW\MediaWiki\Specials\SpecialAsyncJobDispatcher',
-			new SpecialAsyncJobDispatcher()
+			'\SMW\MediaWiki\Specials\SpecialDeferredRequestDispatcher',
+			new SpecialDeferredRequestDispatcher()
 		);
 	}
 
 	public function testGetTargetURL() {
 
 		$this->assertContains(
-			':AsyncJobDispatcher',
-			SpecialAsyncJobDispatcher::getTargetURL()
+			':DeferredRequestDispatcher',
+			SpecialDeferredRequestDispatcher::getTargetURL()
 		);
 	}
 
@@ -64,12 +64,12 @@ class SpecialAsyncJobDispatcherTest extends \PHPUnit_Framework_TestCase {
 
 		$this->assertInternalType(
 			'string',
-			SpecialAsyncJobDispatcher::getSessionToken( 'Foo' )
+			SpecialDeferredRequestDispatcher::getSessionToken( 'Foo' )
 		);
 
 		$this->assertNotSame(
-			SpecialAsyncJobDispatcher::getSessionToken( 'Bar' ),
-			SpecialAsyncJobDispatcher::getSessionToken( 'Foo' )
+			SpecialDeferredRequestDispatcher::getSessionToken( 'Bar' ),
+			SpecialDeferredRequestDispatcher::getSessionToken( 'Foo' )
 		);
 	}
 
@@ -84,10 +84,10 @@ class SpecialAsyncJobDispatcherTest extends \PHPUnit_Framework_TestCase {
 		$parameters = json_encode( array(
 			'async-job' => array( 'type' => 'SMW\UpdateJob', 'title' => 'Foo' ),
 			'timestamp' => $timestamp,
-			'sessionToken' => SpecialAsyncJobDispatcher::getSessionToken( $timestamp ),
+			'sessionToken' => SpecialDeferredRequestDispatcher::getSessionToken( $timestamp ),
 		) );
 
-		$instance = new SpecialAsyncJobDispatcher();
+		$instance = new SpecialDeferredRequestDispatcher();
 		$instance->disallowToModifyHttpHeader();
 
 		$instance->getContext()->setRequest(
@@ -119,11 +119,11 @@ class SpecialAsyncJobDispatcherTest extends \PHPUnit_Framework_TestCase {
 		$parameters = json_encode( array(
 			'async-job' => array( 'type' => 'SMW\ParserCachePurgeJob', 'title' => 'Foo' ),
 			'timestamp' => $timestamp,
-			'sessionToken' => SpecialAsyncJobDispatcher::getSessionToken( $timestamp ),
+			'sessionToken' => SpecialDeferredRequestDispatcher::getSessionToken( $timestamp ),
 			'idlist' => array( 1, 2 )
 		) );
 
-		$instance = new SpecialAsyncJobDispatcher();
+		$instance = new SpecialDeferredRequestDispatcher();
 		$instance->disallowToModifyHttpHeader();
 
 		$instance->getContext()->setRequest(
@@ -145,10 +145,10 @@ class SpecialAsyncJobDispatcherTest extends \PHPUnit_Framework_TestCase {
 
 		$parameters = json_encode( array(
 			'timestamp' => $timestamp,
-			'sessionToken' => SpecialAsyncJobDispatcher::getSessionToken( 'Foo' )
+			'sessionToken' => SpecialDeferredRequestDispatcher::getSessionToken( 'Foo' )
 		) );
 
-		$instance = new SpecialAsyncJobDispatcher();
+		$instance = new SpecialDeferredRequestDispatcher();
 		$instance->disallowToModifyHttpHeader();
 
 		$instance->getContext()->setRequest(
@@ -168,7 +168,7 @@ class SpecialAsyncJobDispatcherTest extends \PHPUnit_Framework_TestCase {
 
 		$request = array();
 
-		$instance = new SpecialAsyncJobDispatcher();
+		$instance = new SpecialDeferredRequestDispatcher();
 		$instance->disallowToModifyHttpHeader();
 
 		$instance->getContext()->setRequest(

--- a/tests/phpunit/includes/SetupTest.php
+++ b/tests/phpunit/includes/SetupTest.php
@@ -223,6 +223,7 @@ class SetupTest extends \PHPUnit_Framework_TestCase {
 			'Properties',
 			'UnusedProperties',
 			'WantedProperties',
+			'DeferredRequestDispatcher'
 		);
 
 		return $this->buildDataProvider( 'wgSpecialPages', $specials, '' );


### PR DESCRIPTION
Rename `AsyncJobDispatchManager` to `DeferredRequestDispatchManager` as we might want to do other things besides Jobs, use deferred instead of async to avoid confusion with HHVM async support in `HH\Asio` [0].

Renamed `$GLOBALS['smwgEnabledAsyncJobDispatcher'] = true;` to `$GLOBALS['smwgEnabledHttpDeferredJobRequest'] = true;`

refs #1117, #1130, 8accffd3

[0] http://docs.hhvm.com/manual/en/book.hack.asio.php