### PR TITLE
Add SELECT Explain to format=debug

### DIFF
--- a/src/Query/DebugOutputFormatter.php
+++ b/src/Query/DebugOutputFormatter.php
@@ -29,10 +29,10 @@ class DebugOutputFormatter {
 
 		if ( $query instanceof Query ) {
 			$preEntries = array();
-			$preEntries['Generated Wiki-Query'] = '<pre>' . str_replace( '[', '&#x005B;', $query->getDescription()->getQueryString() ) . '</pre>';
-			$preEntries['Query Metrics'] = 'Query-Size:' . $query->getDescription()->getSize() . '<br />' .
-						'Query-Depth:' . $query->getDescription()->getDepth();
+			$preEntries['Ask query'] = '<div class="smwpre">' . str_replace( '[', '&#x005B;', $query->getDescription()->getQueryString() ) . '</div>';
 			$entries = array_merge( $preEntries, $entries );
+			$entries['Query Metrics'] = 'Query-Size:' . $query->getDescription()->getSize() . '<br />' .
+						'Query-Depth:' . $query->getDescription()->getDepth();
 			$errors = '';
 
 			foreach ( $query->getErrors() as $error ) {

--- a/src/SPARQLStore/QueryEngine/QueryEngine.php
+++ b/src/SPARQLStore/QueryEngine/QueryEngine.php
@@ -263,7 +263,7 @@ class QueryEngine {
 		}
 
 		$sparql = str_replace( array( '[',':',' ' ), array( '&#x005B;', '&#x003A;', '&#x0020;' ), $sparql );
-		$entries['SPARQL Query'] = "<pre>$sparql</pre>";
+		$entries['SPARQL Query'] = '<div class="smwpre">' . $sparql . '</div>';
 
 		return DebugOutputFormatter::formatOutputFor( 'SPARQLStore', $entries, $query );
 	}

--- a/src/SQLStore/QueryEngine/QuerySegmentListProcessor.php
+++ b/src/SQLStore/QueryEngine/QuerySegmentListProcessor.php
@@ -187,7 +187,7 @@ class QuerySegmentListProcessor {
 				$query = $result;
 			break;
 			case QuerySegment::Q_DISJUNCTION:
-				if ( $this->queryMode !== Query::MODE_DEBUG ) {
+				if ( $this->queryMode !== Query::MODE_NONE ) {
 					$db->query(
 						$this->getCreateTempIDTableSQL( $db->tableName( $query->alias ) ),
 						__METHOD__
@@ -224,7 +224,7 @@ class QuerySegmentListProcessor {
 					if ( $sql ) {
 						$this->executedQueries[$query->alias][] = $sql;
 
-						if ( $this->queryMode !== Query::MODE_DEBUG ) {
+						if ( $this->queryMode !== Query::MODE_NONE ) {
 							$db->query(
 								$sql,
 								__METHOD__
@@ -302,10 +302,6 @@ class QuerySegmentListProcessor {
 		$query->joinTable = $query->alias;
 		$query->joinfield = "$query->alias.id";
 
-		if ( $this->queryMode == Query::MODE_DEBUG ) {
-			return; // No real queries in debug mode.
-		}
-
 		$db->query(
 			$this->getCreateTempIDTableSQL( $tablename ),
 			__METHOD__
@@ -324,10 +320,6 @@ class QuerySegmentListProcessor {
 	 * on. Being temporary, the tables will vanish with the session anyway.
 	 */
 	public function cleanUp() {
-
-		if ( $this->queryMode  === Query::MODE_DEBUG ) {
-			return;
-		}
 
 		foreach ( $this->executedQueries as $table => $log ) {
 			$this->connection->query(

--- a/tests/phpunit/Integration/ByJsonScript/Fixtures/f-0001 debug output.json
+++ b/tests/phpunit/Integration/ByJsonScript/Fixtures/f-0001 debug output.json
@@ -1,0 +1,48 @@
+{
+	"description": "Debug output",
+	"properties": [
+		{
+			"name": "Has page",
+			"contents": "[[Has type::Page]]"
+		},
+		{
+			"name": "Has text",
+			"contents": "[[Has type::Text]]"
+		}
+	],
+	"subjects": [
+		{
+			"name": "Example/0001",
+			"contents": "[[Has page::Foo]] [[Has text::bar]]"
+		},
+		{
+			"name": "Example/0001/1",
+			"contents": "{{#ask:[[Has page::Foo]] [[Has page::42]] |?Has page |?Has text |format=debug }}"
+		}
+	],
+	"format-testcases": [
+		{
+			"about": "#0 simple debug output",
+			"subject": "Example/0001/1",
+			"expected-output": {
+				"to-contain": [
+					"&#x5b;&#x5b;Has page::Foo]] &#x5b;&#x5b;Has page::42]]",
+					"Query-Size:4",
+					"Query-Depth:1",
+					"None"
+				]
+			}
+		}
+	],
+	"settings": {
+		"smwgNamespacesWithSemanticLinks": {
+			"NS_MAIN": true,
+			"SMW_NS_PROPERTY": true
+		}
+	},
+	"meta": {
+		"version": "0.1",
+		"is-incomplete": false,
+		"debug": false
+	}
+}


### PR DESCRIPTION
Enables a more detailed analysis of the query plan [0] executed by the `#ask` query.

SELECT explain is displayed where possible otherwise it is "Not supported".

![image](https://cloud.githubusercontent.com/assets/1245473/10091651/69f041cc-633e-11e5-83b6-f7aabeca22fa.png)

`#ask` can be  examined by whether the transformed SQL query performs as expected as in case above or does a rather poor job in comparison below due to a full table scan ( "54908 rows / Using index condition; Using temporary; Using filesort") and the use of `filesort`.

![image](https://cloud.githubusercontent.com/assets/1245473/10091664/85236bb8-633e-11e5-8a6f-8a30f020732f.png)

[0] https://dev.mysql.com/doc/refman/5.0/en/explain-output.html