### PR TITLE
Add @category to #subobject

### DIFF
--- a/includes/parserhooks/SubobjectParserFunction.php
+++ b/includes/parserhooks/SubobjectParserFunction.php
@@ -16,9 +16,19 @@ use Parser;
  */
 class SubobjectParserFunction {
 
-	// Fixed identifier that describes the sortkey annotation
-	// parameter
+	/**
+	 * Fixed identifier that describes the sortkey annotation parameter
+	 */
 	const PARAM_SORTKEY = '@sortkey';
+
+	/**
+	 * Fixed identifier that describes the subobject category parameter.
+	 *
+	 * We keep it as a @ fixed parameter since the standard annotation would
+	 * require special attention (Category:;instead of ::) when annotating a
+	 * category
+	 */
+	const PARAM_CATEGORY = '@category';
 
 	/**
 	 * @var ParserData
@@ -104,6 +114,10 @@ class SubobjectParserFunction {
 
 			if ( $property === self::PARAM_SORTKEY ) {
 				$property = DIProperty::TYPE_SORTKEY;
+			}
+
+			if ( $property === self::PARAM_CATEGORY ) {
+				$property = DIProperty::TYPE_CATEGORY;
 			}
 
 			foreach ( $values as $value ) {

--- a/tests/phpunit/Integration/ByJsonScript/Fixtures/p-0301 [#1172] subobject category annotation.json
+++ b/tests/phpunit/Integration/ByJsonScript/Fixtures/p-0301 [#1172] subobject category annotation.json
@@ -1,0 +1,53 @@
+{
+	"description": "Subobject category annotation, #1172",
+	"properties": [
+		{
+			"name": "Has page",
+			"contents": "[[Has type::Page]]"
+		}
+	],
+	"subjects": [
+		{
+			"name": "Example/0301/1",
+			"contents": "{{#subobject:|Has page={{PAGENAME}}|@category=ABC;123|+sep=;}}"
+		}
+	],
+	"parser-testcases": [
+		{
+			"about": "#0 #subobject with category annotation",
+			"subject": "Example/0301/1#_033037fca2311e746bf1871d3be6984c",
+			"store": {
+				"semantic-data": {
+					"strict-mode-valuematch": false,
+					"propertyCount": 3,
+					"propertyKeys": [ "Has_page", "_SKEY", "_INST" ],
+					"propertyValues": [ "Example/0301/1", "ABC", "123" ]
+				}
+			}
+		}
+	],
+	"query-testcases": [
+		{
+			"about": "#0 query with subobject category",
+			"condition": "[[Category:ABC]][[Has page::Example/0301/1]]",
+			"printouts" : [],
+			"parameters" : {
+				"limit" : "10"
+			},
+			"queryresult": {
+				"results": [
+					"Example/0301/1#0##_033037fca2311e746bf1871d3be6984c"
+				],
+				"count": "1"
+			}
+		}
+	],
+	"settings": {
+		"smwgPageSpecialProperties": [ "_MDAT" ]
+	},
+	"meta": {
+		"version": "0.1",
+		"is-incomplete": false,
+		"debug": false
+	}
+}

--- a/tests/phpunit/includes/parserhooks/SubobjectParserFunctionTest.php
+++ b/tests/phpunit/includes/parserhooks/SubobjectParserFunctionTest.php
@@ -18,9 +18,7 @@ use ParserOutput;
 
 /**
  * @covers \SMW\SubobjectParserFunction
- *
- * @group SMW
- * @group SMWExtension
+ * @group semantic-mediawiki
  *
  * @license GNU GPL v2+
  * @since 1.9
@@ -135,7 +133,7 @@ class SubobjectParserFunctionTest extends \PHPUnit_Framework_TestCase {
 	}
 
 	/**
-	 * @dataProvider sortKeyProvider
+	 * @dataProvider tokuFixedParameterProvider
 	 */
 	public function testSortKeyAnnotation( array $parameters, array $expected ) {
 		$this->setupInstanceAndAssertSemanticData(
@@ -400,7 +398,7 @@ class SubobjectParserFunctionTest extends \PHPUnit_Framework_TestCase {
 		return $provider;
 	}
 
-	public function sortKeyProvider() {
+	public function tokuFixedParameterProvider() {
 
 		$provider = array();
 
@@ -436,6 +434,50 @@ class SubobjectParserFunctionTest extends \PHPUnit_Framework_TestCase {
 			array(
 				'Bar=foo Bar',
 				'@sortkey='
+			),
+			array(
+				'propertyCount'  => 1,
+				'properties'     => array(
+					new DIProperty( 'Bar' )
+				),
+				'propertyValues' => array(
+					'Foo Bar'
+				)
+			)
+		);
+
+		// #2 @category
+		// {{#subobject:
+		// |Bar=foo Bar
+		// |@category=1001
+		// }}
+		$provider[] = array(
+			array(
+				'Bar=foo Bar',
+				'@category=1001'
+			),
+			array(
+				'propertyCount'  => 2,
+				'properties'     => array(
+					new DIProperty( 'Bar' ),
+					new DIProperty( '_INST' )
+				),
+				'propertyValues' => array(
+					'Foo Bar',
+					'1001'
+				)
+			)
+		);
+
+		// #3 @category empty
+		// {{#subobject:
+		// |Bar=foo Bar
+		// |@category=
+		// }}
+		$provider[] = array(
+			array(
+				'Bar=foo Bar',
+				'@category='
 			),
 			array(
 				'propertyCount'  => 1,


### PR DESCRIPTION
Add `@category` to #subobject

```
{{#subobject:
 |Has page=Example/0301/1
 |@category=ABC;123|+sep=;
}}
```

While subobjects with categories can be queried as any other object, they will not appear in an individual `Category: ...` list as subobject/page as there are a SMW and not a MW concept (which requires a real mw page id to be listed as member of a category when viewed via `Category:...`).

```
{{#ask: [[Category:ABC]][[Has page::Example/0301/1]]
 |?Has page
 |?Category
}}
```