### PR TITLE
Add 'SMW::Browse::BeforeIncomingPropertyValuesFurtherLinkCreate' hook

### DIFF
--- a/docs/RELEASE-NOTES.md
+++ b/docs/RELEASE-NOTES.md
@@ -80,7 +80,8 @@ Added the following options (It is assumed that the selected TDB back-end suppor
 * #1071 Added `SMW::SQLStore::AddCustomFixedPropertyTables` hook to simplify registration of fixed property tables by extension developers
 * #1068 Added setting to support recursive annotation for selected formats (refs #1055, #711)
 * #1086 Changed redirect update logic to accommodate the manual #REDIRECT (refs #895, #1054)
-* Added `SMW::Browse::AfterInPropertiesLookupComplete` which allows to extend the incoming properties display for `Special:Browse`
+* Added `SMW::Browse::AfterIncomingPropertiesLookupComplete` which allows to extend the incoming properties display for `Special:Browse`
+* Added `SMW::Browse::BeforeIncomingPropertyValuesFurtherLinkCreate` which allows to replace the further result incoming link in `Special:Browse`
 * #1078 Renamed `ParserParameterFormatter` to `ParserParameterProcessor` and `ParameterFormatterFactory` to `ParameterProcessorFactory`
 * #1102 Added `onoi/http-request:~1.0` dependency
 * Decrease chunk size in `UpdateDispatcherJob` (refs #951)

--- a/docs/technical/hooks.md
+++ b/docs/technical/hooks.md
@@ -30,7 +30,8 @@ Implementing a hook should be made in consideration of the expected performance 
 
 - `SMW::SQLStore::BeforeDataRebuildJobInsert` to add update jobs while running the rebuild process.<sup>Use of `smwRefreshDataJobs` was deprecated with 2.3</sup>
 - `SMW::SQLStore::AddCustomFixedPropertyTables` to add fixed property table definitions
-- `SMW::Browse::AfterInPropertiesLookupComplete` to extend the incoming properties display for `Special:Browse`
+- `SMW::Browse::AfterIncomingPropertiesLookupComplete` to extend the incoming properties display for `Special:Browse`
+- `SMW::Browse::BeforeIncomingPropertyValuesFurtherLinkCreate` to replace the standard `SearchByProperty` with a custom link to an extended list of results (return `false` to replace the link)
 - `SMW::SQLStore::AfterDataUpdateComplete` to add processing after the update has been completed and provides `CompositePropertyTableDiffIterator` to identify entities
    that have been added/removed during the update. <sup>Use of `SMWSQLStore3::updateDataAfter` was deprecated with 2.3</sup>
 

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -337,5 +337,6 @@
 	"smw-sp-types_geo": "\"$1\" is a datatype that describes geographic locations and requires [https://semantic-mediawiki.org/wiki/Semantic_Maps Semantic Maps].",
 	"smw-sp-types_tel": "\"$1\" is a special datatype to describe international telephone numbers according to RFC 3966.",
 	"smw-sp-types_txt": "\"$1\" is a primitive datatype to describe strings of arbitrary length.",
-	"smw-sp-types_dat": "\"$1\" is a datatype to represent points in time in a unified format."
+	"smw-sp-types_dat": "\"$1\" is a datatype to represent points in time in a unified format.",
+	"smw-specials-browse-helplink": "https://semantic-mediawiki.org/wiki/Help:Special:Browse"
 }

--- a/i18n/qqq.json
+++ b/i18n/qqq.json
@@ -344,5 +344,7 @@
 	"smw-sp-types_geo": "This is an informatory message shown to the user.",
 	"smw-sp-types_tel": "This is an informatory message shown to the user.",
 	"smw-sp-types_txt": "This is an informatory message shown to the user.",
-	"smw-sp-types_dat": "This is an informatory message shown to the user."
+	"smw-sp-types_dat": "This is an informatory message shown to the user.",
+	"smw-specials-browse-helplink": "{{notranslate}}"
+
 }

--- a/includes/specials/SMW_SpecialBrowse.php
+++ b/includes/specials/SMW_SpecialBrowse.php
@@ -91,6 +91,8 @@ class SMWSpecialBrowse extends SpecialPage {
 		}
 
 		$wgOut->addHTML( $this->displayBrowse() );
+		$this->addExternalHelpLinkFor( 'smw-specials-browse-helplink' );
+
 		SMWOutputs::commitToOutputPage( $wgOut ); // make sure locally collected output data is pushed to the output!
 	}
 
@@ -205,7 +207,9 @@ class SMWSpecialBrowse extends SpecialPage {
 				         $this->displayValue( $dvProperty, $dv, $incoming ) . "</span>\n";
 			}
 
-			if ( $moreIncoming ) { // link to the remaining incoming pages:
+			// Added in 2.3
+			// link to the remaining incoming pages
+			if ( $moreIncoming && wfRunHooks( 'SMW::Browse::BeforeIncomingPropertyValuesFurtherLinkCreate', array( $diProperty, $this->subject->getDataItem(), &$body ) ) ) {
 				$body .= Html::element(
 					'a',
 					array(
@@ -381,7 +385,7 @@ class SMWSpecialBrowse extends SpecialPage {
 		}
 
 		// Added in 2.3
-		wfRunHooks( 'SMW::Browse::AfterInPropertiesLookupComplete', array( $store, $indata, $options ) );
+		wfRunHooks( 'SMW::Browse::AfterIncomingPropertiesLookupComplete', array( $store, $indata, $valoptions ) );
 
 		return array( $indata, $more );
 	}
@@ -437,5 +441,17 @@ class SMWSpecialBrowse extends SpecialPage {
 		$nonBreakingSpace = html_entity_decode( '&#160;', ENT_NOQUOTES, 'UTF-8' );
 		$text = preg_replace( '/[\s]/u', $nonBreakingSpace, $text, - 1, $count );
 		return $count > 2 ? preg_replace( '/($nonBreakingSpace)/u', ' ', $text, max( 0, $count - 2 ) ):$text;
+	}
+
+	/**
+	 * FIXME MW 1.25
+	 */
+	private function addExternalHelpLinkFor( $key ) {
+
+		if ( !method_exists( $this, 'addHelpLink' ) ) {
+			return null;
+		}
+
+		$this->addHelpLink( wfMessage( $key )->escaped(), true );
 	}
 }

--- a/tests/phpunit/Utils/MwHooksHandler.php
+++ b/tests/phpunit/Utils/MwHooksHandler.php
@@ -38,7 +38,9 @@ class MwHooksHandler {
 		'SMW::Parser::BeforeMagicWordsFinder',
 		'SMW::SQLStore::BeforeDataRebuildJobInsert',
 		'SMW::SQLStore::AddCustomFixedPropertyTables',
-		'SMW::SQLStore::AfterDataUpdateComplete'
+		'SMW::SQLStore::AfterDataUpdateComplete',
+		'SMW::Browse::AfterIncomingPropertiesLookupComplete',
+		'SMW::Browse::BeforeIncomingPropertyValuesFurtherLinkCreate'
 	);
 
 	/**


### PR DESCRIPTION
When injecting other incoming properties (those of a text type) via `AfterIncomingPropertiesLookupComplete` but more than the `incomingvaluescount = 21`
are accounted for, the further link to `Special:SearchByProperty` might not be sufficient hence to possibility to redirect via `SMW::Browse::BeforeIncomingPropertyValuesFurtherLinkCreate`
to another endpoint.