### PR TITLE
Use SELECT DISTINCT, refs #1165

### DIFF
--- a/src/SQLStore/QueryEngine/QuerySegmentListProcessor.php
+++ b/src/SQLStore/QueryEngine/QuerySegmentListProcessor.php
@@ -204,7 +204,7 @@ class QuerySegmentListProcessor {
 					if ( $subQuery->joinTable !== '' ) {
 						$sql = 'INSERT ' . 'IGNORE ' . 'INTO ' .
 						       $db->tableName( $query->alias ) .
-							   " SELECT $subQuery->joinfield FROM " . $db->tableName( $subQuery->joinTable ) .
+							   " SELECT DISTINCT $subQuery->joinfield FROM " . $db->tableName( $subQuery->joinTable ) .
 							   " AS $subQuery->alias $subQuery->from" . ( $subQuery->where ? " WHERE $subQuery->where":'' );
 					} elseif ( $subQuery->joinfield !== '' ) {
 						// NOTE: this works only for single "unconditional" values without further

--- a/tests/phpunit/Integration/ByJsonScript/Fixtures/q-0102 regex blob queries.json
+++ b/tests/phpunit/Integration/ByJsonScript/Fixtures/q-0102 regex blob queries.json
@@ -240,9 +240,6 @@
 		"smwgQMaxSize" : "25"
 	},
 	"meta": {
-		"skip-on": {
-			"postgres": "Unable to run concept tests on postgres, failed with duplicate key value violates unique constraint"
-		},
 		"version": "0.1",
 		"is-incomplete": false
 	}

--- a/tests/phpunit/Integration/ByJsonScript/Fixtures/q-0901 [#1057] common disjunction conjunction queries.json
+++ b/tests/phpunit/Integration/ByJsonScript/Fixtures/q-0901 [#1057] common disjunction conjunction queries.json
@@ -352,9 +352,6 @@
 		"smwgQSubcategoryDepth": 10
 	},
 	"meta": {
-		"skip-on": {
-			"postgres": "pg_query(): Query failed: ERROR:  duplicate key value violates unique constraint"
-		},
 		"version": "0.1",
 		"is-incomplete": false,
 		"debug": false

--- a/tests/phpunit/Integration/ByJsonScript/Fixtures/q-0902 [#556] text typed disjunctive queries.json
+++ b/tests/phpunit/Integration/ByJsonScript/Fixtures/q-0902 [#556] text typed disjunctive queries.json
@@ -57,9 +57,6 @@
 		}
 	},
 	"meta": {
-		"skip-on": {
-			"postgres": "Skip postgres because of Query failed: ERROR:  duplicate key value violates unique constraint, Key (id)=(146) already exists"
-		},
 		"version": "0.1",
 		"is-incomplete": false,
 		"debug": false

--- a/tests/phpunit/Integration/ByJsonScript/Fixtures/q-0903 [#1059] regex disjunctive queries.json
+++ b/tests/phpunit/Integration/ByJsonScript/Fixtures/q-0903 [#1059] regex disjunctive queries.json
@@ -231,9 +231,6 @@
 		"smwgQSubcategoryDepth": 10
 	},
 	"meta": {
-		"skip-on": {
-			"postgres": "pg_query(): Query failed: ERROR:  duplicate key value violates unique constraint"
-		},
 		"version": "0.1",
 		"is-incomplete": false,
 		"debug": false

--- a/tests/phpunit/Integration/ByJsonScript/Fixtures/q-0904 [#1060] disjunctive subproperty queries.json
+++ b/tests/phpunit/Integration/ByJsonScript/Fixtures/q-0904 [#1060] disjunctive subproperty queries.json
@@ -121,7 +121,6 @@
 	},
 	"meta": {
 		"skip-on": {
-			"postgres": "pg_query(): Query failed: ERROR:  duplicate key value violates unique constraint",
 			"virtuoso": "Virtuoso 6.1 rdfs / subproperty/property hierarchies are currently not implemented"
 		},
 		"version": "0.1",


### PR DESCRIPTION
Based on the [0] discussion which should avoid duplicate entries and eliminate `ERROR:  duplicate key value violates unique constraint, Key (id)=(146) already exists` in postgres.

Re-enabled skipped tests:
- q-0102 regex blob queries.json
- q-0901 [#1057] common disjunction conjunction queries.json
- q-0902 [#556] text typed disjunctive queries.json
- q-0903 [#1059] regex disjunctive queries.json
- q-0904 [#1060] disjunctive subproperty queries.json

[0] https://github.com/SemanticMediaWiki/SemanticMediaWiki/issues/1165#issuecomment-143191808