### PR TITLE
~/!~ support for the _dat type

### DIFF
--- a/includes/datavalues/SMW_DV_Record.php
+++ b/includes/datavalues/SMW_DV_Record.php
@@ -76,6 +76,7 @@ class SMWRecordValue extends SMWDataValue {
 			}
 
 			$values[$valueIndex] = str_replace( "-3B", ";", $values[$valueIndex] );
+			$beforePrepareValue = $values[$valueIndex];
 
 			if ( $queryMode ) { // special handling for supporting query parsing
 				$comparator = SMW_CMP_EQ;
@@ -92,11 +93,7 @@ class SMWRecordValue extends SMWDataValue {
 					if ( $queryMode ) {
 						$subdescriptions[] = new SMWSomeProperty(
 							$diProperty,
-							new SMWValueDescription(
-								$dataValue->getDataItem(),
-								$dataValue->getProperty(),
-								$comparator
-							)
+							$dataValue->getQueryDescription( $beforePrepareValue )
 						);
 					} else {
 						$semanticData->addPropertyObjectValue( $diProperty, $dataValue->getDataItem() );

--- a/src/Deserializers/DVDescriptionDeserializer/DispatchingDescriptionDeserializer.php
+++ b/src/Deserializers/DVDescriptionDeserializer/DispatchingDescriptionDeserializer.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace SMW\Deserializers\DVDescriptionDeserializer;
+
+use SMWDataValue as DataValue;
+use RuntimeException;
+
+/**
+ * @private
+ *
+ * @license GNU GPL v2+
+ * @since 2.3
+ *
+ * @author mwjames
+ */
+class DispatchingDescriptionDeserializer {
+
+	/**
+	 * @var DescriptionDeserializer[]
+	 */
+	private $descriptionDeserializers = array();
+
+	/**
+	 * @var DescriptionDeserializer[]
+	 */
+	private $defaultDescriptionDeserializer = null;
+
+	/**
+	 * @since  2.3
+	 *
+	 * @param DescriptionDeserializer $defaultInterpreter
+	 */
+	public function addDescriptionDeserializer( DescriptionDeserializer $descriptionDeserializer ) {
+		$this->descriptionDeserializers[] = $descriptionDeserializer;
+	}
+
+	/**
+	 * @since 2.2
+	 *
+	 * @param DescriptionDeserializer $defaultDescriptionDeserializer
+	 */
+	public function addDefaultDescriptionDeserializer( DescriptionDeserializer $defaultDescriptionDeserializer ) {
+		$this->defaultDescriptionDeserializer = $defaultDescriptionDeserializer;
+	}
+
+	/**
+	 * @since 2.3
+	 *
+	 * @param DataValue $dataValue
+	 *
+	 * @return DescriptionDeserializer
+	 * @throws RuntimeException
+	 */
+	public function getDescriptionDeserializerFor( DataValue $dataValue ) {
+
+		foreach ( $this->descriptionDeserializers as $descriptionDeserializer ) {
+
+			$descriptionDeserializer->setDataValue( $dataValue );
+
+			if ( $descriptionDeserializer->isDeserializerFor( $dataValue ) ) {
+				return $descriptionDeserializer;
+			}
+		}
+
+		if ( $this->defaultDescriptionDeserializer !== null && $this->defaultDescriptionDeserializer->isDeserializerFor( $dataValue ) ) {
+			$this->defaultDescriptionDeserializer->setDataValue( $dataValue );
+			return $this->defaultDescriptionDeserializer;
+		}
+
+		throw new RuntimeException( "Missing registered DescriptionDeserializer." );
+	}
+
+}

--- a/src/Deserializers/DVDescriptionDeserializer/SomeValueDescriptionDeserializer.php
+++ b/src/Deserializers/DVDescriptionDeserializer/SomeValueDescriptionDeserializer.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace SMW\Deserializers\DVDescriptionDeserializer;
+
+use SMWDataValue as DataValue;
+use SMW\Query\Language\ThingDescription;
+use SMW\Query\Language\ValueDescription;
+use InvalidArgumentException;
+
+/**
+ * @private
+ *
+ * @license GNU GPL v2+
+ * @since 2.3
+ *
+ * @author mwjames
+ */
+class SomeValueDescriptionDeserializer extends DescriptionDeserializer {
+
+	/**
+	 * @since 2.3
+	 *
+	 * {@inheritDoc}
+	 */
+	public function isDeserializerFor( $serialization ) {
+		return $serialization instanceof DataValue;
+	}
+
+	/**
+	 * @since 2.3
+	 *
+	 * @param string $value
+	 *
+	 * @return Description
+	 * @throws InvalidArgumentException
+	 */
+	public function deserialize( $value ) {
+
+		if ( !is_string( $value ) ) {
+			throw new InvalidArgumentException( 'value needs to be a string' );
+		}
+
+		$comparator = SMW_CMP_EQ;
+
+		$this->prepareValue( $value, $comparator );
+
+		if( $comparator == SMW_CMP_LIKE ) {
+			// ignore allowed values when the LIKE comparator is used (BUG 21893)
+			$this->dataValue->setUserValue( $value, false, true );
+		} else {
+			$this->dataValue->setUserValue( $value );
+		}
+
+		if ( $this->dataValue->isValid() ) {
+			return new ValueDescription( $this->dataValue->getDataItem(), $this->dataValue->getProperty(), $comparator );
+		}
+
+		return new ThingDescription();
+	}
+
+}

--- a/src/Deserializers/DVDescriptionDeserializer/TimeValueDescriptionDeserializer.php
+++ b/src/Deserializers/DVDescriptionDeserializer/TimeValueDescriptionDeserializer.php
@@ -1,0 +1,128 @@
+<?php
+
+namespace SMW\Deserializers\DVDescriptionDeserializer;
+
+use SMWTimeValue as TimeValue;
+use SMWDITime as DITime;
+use SMW\Query\Language\ThingDescription;
+use SMW\Query\Language\ValueDescription;
+use SMW\Query\Language\Disjunction;
+use SMW\Query\Language\Conjunction;
+use InvalidArgumentException;
+use DateTime;
+use DateInterval;
+
+/**
+ * @private
+ *
+ * @license GNU GPL v2+
+ * @since 2.3
+ *
+ * @author mwjames
+ */
+class TimeValueDescriptionDeserializer extends DescriptionDeserializer {
+
+	/**
+	 * @since 2.3
+	 *
+	 * {@inheritDoc}
+	 */
+	public function isDeserializerFor( $serialization ) {
+		return $serialization instanceof TimeValue;
+	}
+
+	/**
+	 * @since 2.3
+	 *
+	 * @param string $value
+	 *
+	 * @return Description
+	 * @throws InvalidArgumentException
+	 */
+	public function deserialize( $value ) {
+
+		if ( !is_string( $value ) ) {
+			throw new InvalidArgumentException( 'The value needs to be a string' );
+		}
+
+		$comparator = SMW_CMP_EQ;
+		$this->prepareValue( $value, $comparator );
+
+		if( $comparator !== SMW_CMP_LIKE && $comparator !== SMW_CMP_NLKE ) {
+
+			$this->dataValue->setUserValue( $value );
+
+			if ( $this->dataValue->isValid() ) {
+				return new ValueDescription( $this->dataValue->getDataItem(), $this->dataValue->getProperty(), $comparator );
+			} else {
+				return new ThingDescription();
+			}
+		}
+
+		$this->dataValue->setUserValue( $value, false, true );
+
+		if ( !$this->dataValue->isValid() ) {
+			return new ThingDescription();
+		}
+
+		$dataItem = $this->dataValue->getDataItem();
+		$property = $this->dataValue->getProperty();
+
+		$upperLimitDataItem = $this->getUpperLimit( $dataItem );
+
+		if ( $this->errors !== array() ) {
+			return new ThingDescription();
+		}
+
+		if( $comparator === SMW_CMP_LIKE ) {
+			$description = new Conjunction( array(
+				new ValueDescription( $dataItem, $property, SMW_CMP_GEQ ),
+				new ValueDescription( $upperLimitDataItem, $property, SMW_CMP_LESS )
+			) );
+		}
+
+		if( $comparator === SMW_CMP_NLKE ) {
+			$description = new Disjunction( array(
+				new ValueDescription( $dataItem, $property, SMW_CMP_LESS ),
+				new ValueDescription( $upperLimitDataItem, $property, SMW_CMP_GEQ )
+			) );
+		}
+
+		return $description;
+	}
+
+	private function getUpperLimit( $dataItem ) {
+
+		$prec = $dataItem->getPrecision();
+
+		$dateTime = new DateTime();
+		$dateTime->setDate( $dataItem->getYear(), $dataItem->getMonth(), $dataItem->getDay() );
+		$dateTime->setTime( $dataItem->getHour(), $dataItem->getMinute(), $dataItem->getSecond() );
+
+		if ( $dateTime === false ) {
+			return $this->errors[] = 'Cannot compute interval for ' . $dataItem->getSerialization();
+		}
+
+		if ( $prec === DITime::PREC_Y ) {
+			$dateTime->add( new DateInterval( 'P1Y' ) );
+		} elseif( $prec === DITime::PREC_YM ) {
+			$dateTime->add( new DateInterval( 'P1M' ) );
+		} elseif( $prec === DITime::PREC_YMD ) {
+			$dateTime->add( new DateInterval( 'P1D' ) );
+		} elseif( $prec === DITime::PREC_YMDT ) {
+
+			if ( $dataItem->getSecond() > 0 ) {
+				$dateTime->add( new DateInterval( 'PT1S' ) );
+			} elseif( $dataItem->getMinute() > 0 ) {
+				$dateTime->add( new DateInterval( 'PT1M' ) );
+			} elseif( $dataItem->getHour() > 0 ) {
+				$dateTime->add( new DateInterval( 'PT1H' ) );
+			} else {
+				$dateTime->add( new DateInterval( 'PT24H' ) );
+			}
+		}
+
+		return DITime::doUnserialize( $dataItem->getCalendarModel() . '/' . $dateTime->format( 'Y/m/d/H/i/s' ) );
+	}
+
+}

--- a/src/Deserializers/DVDescriptionDeserializerFactory.php
+++ b/src/Deserializers/DVDescriptionDeserializerFactory.php
@@ -1,0 +1,101 @@
+<?php
+
+namespace SMW\Deserializers;
+
+use SMW\Deserializers\DVDescriptionDeserializer\DispatchingDescriptionDeserializer;
+use SMW\Deserializers\DVDescriptionDeserializer\DescriptionDeserializer;
+use SMW\Deserializers\DVDescriptionDeserializer\TimeValueDescriptionDeserializer;
+use SMW\Deserializers\DVDescriptionDeserializer\SomeValueDescriptionDeserializer;
+use SMWDataValue as DataValue;
+
+/**
+ * @license GNU GPL v2+
+ * @since 2.3
+ *
+ * @author mwjames
+ */
+class DVDescriptionDeserializerFactory {
+
+	/**
+	 * @var DescriptionDeserializerFactory
+	 */
+	private static $instance = null;
+
+	/**
+	 * @var DispatchingDescriptionDeserializer
+	 */
+	private $dispatchingDescriptionDeserializer = null;
+
+	/**
+	 * @since 2.3
+	 *
+	 * @param DispatchingDescriptionDeserializer|null $dispatchingDescriptionDeserializer
+	 */
+	public function __construct( DispatchingDescriptionDeserializer $dispatchingDescriptionDeserializer = null ) {
+		$this->dispatchingDescriptionDeserializer = $dispatchingDescriptionDeserializer;
+	}
+
+	/**
+	 * @since 2.3
+	 *
+	 * @return self
+	 */
+	public static function getInstance() {
+
+		if ( self::$instance === null ) {
+			self::$instance = new self();
+		}
+
+		return self::$instance;
+	}
+
+	/**
+	 * @since 2.3
+	 */
+	public static function clear() {
+		self::$instance = null;
+	}
+
+	/**
+	 * @note This allows extensions to inject their own DescriptionDeserializer
+	 * without further violating SRP of the DataType or DataValue.
+	 *
+	 * @since 2.3
+	 *
+	 * @param DescriptionDeserializer $descriptionDeserializer
+	 */
+	public function registerDescriptionDeserializer( DescriptionDeserializer $descriptionDeserializer ) {
+
+		if ( $this->dispatchingDescriptionDeserializer === null ) {
+			$this->dispatchingDescriptionDeserializer = $this->newDispatchingDescriptionDeserializer();
+		}
+
+		return $this->dispatchingDescriptionDeserializer->addDescriptionDeserializer( $descriptionDeserializer );
+	}
+
+	/**
+	 * @since 2.3
+	 *
+	 * @param DataValue $dataValue
+	 *
+	 * @return DescriptionDeserializer
+	 */
+	public function getDescriptionDeserializerFor( DataValue $dataValue ) {
+
+		if ( $this->dispatchingDescriptionDeserializer === null ) {
+			$this->dispatchingDescriptionDeserializer = $this->newDispatchingDescriptionDeserializer();
+		}
+
+		return $this->dispatchingDescriptionDeserializer->getDescriptionDeserializerFor( $dataValue );
+	}
+
+	private function newDispatchingDescriptionDeserializer() {
+
+		$dispatchingDescriptionDeserializer = new DispatchingDescriptionDeserializer();
+		$dispatchingDescriptionDeserializer->addDescriptionDeserializer( new TimeValueDescriptionDeserializer() );
+		$dispatchingDescriptionDeserializer->addDefaultDescriptionDeserializer( new SomeValueDescriptionDeserializer() );
+
+		return $dispatchingDescriptionDeserializer;
+	}
+
+}

--- a/tests/phpunit/Integration/ByJsonScript/Fixtures/q-1004 date range like not like comparators.json
+++ b/tests/phpunit/Integration/ByJsonScript/Fixtures/q-1004 date range like not like comparators.json
@@ -1,0 +1,168 @@
+{
+	"description": "Date range for ~/!~ comparators, #285",
+	"properties": [
+		{
+			"name": "Has date",
+			"contents": "[[Has type::Date]]"
+		}
+	],
+	"subjects": [
+		{
+			"name": "Example/1004/15-Jun",
+			"contents": "{{#subobject:|@category=E-1004|Has date=15 Jun 2011 17:59:59}}{{#subobject:|@category=E-1004|Has date=15 Jun 2011 18:53}}{{#subobject:|@category=E-1004|Has date=15 Jun 2011 18:43}}{{#subobject:|@category=E-1004|Has date=15 Jun 2011 19:53}}"
+		},
+		{
+			"name": "Example/1004/16-Jun",
+			"contents": "{{#subobject:|@category=E-1004|Has date=16 Jul 2011 19:53}}"
+		},
+		{
+			"name": "Example/1004/17-Jun",
+			"contents": "{{#subobject:|@category=E-1004|Has date=17 Jun 2011 19:53:05}}{{#subobject:|@category=E-1004|Has date=17 Jun 2011 19:53:15}}{{#subobject:|@category=E-1004|Has date=17 Jun 2011 19:53:07}}{{#subobject:|@category=E-1004|Has date=17 Jun 2011 19:54:07}}"
+		},
+		{
+			"name": "Example/1004/17-Jun-1356",
+			"contents": "{{#subobject:|@category=E-1004|Has date=17 Jun 1356 19:53:05}}{{#subobject:|@category=E-1004|Has date=17 Jun 1356 19:53:15}}{{#subobject:|@category=E-1004|Has date=17 Jun 1356 19:53:07}}{{#subobject:|@category=E-1004|Has date=17 Jun 1356 19:54:07}}"
+		}
+	],
+	"query-testcases": [
+		{
+			"about": "#0 for the same hour",
+			"condition": "[[Category:E-1004]] [[Has date::~15 Jun 2011 18:00]]",
+			"printouts" : [],
+			"parameters" : {
+				"limit" : "10"
+			},
+			"queryresult": {
+				"count": 2,
+				"results": [
+					"Example/1004/15-Jun#0##_3ac75bf67c06e184b53c2fe47dc9838f",
+					"Example/1004/15-Jun#0##_25fd2aa8d8bc9c7fe64f1161beb1e53e"
+				]
+			}
+		},
+		{
+			"about": "#1 for the same day",
+			"condition": "[[Category:E-1004]] [[Has date::~15 Jun 2011]]",
+			"printouts" : [],
+			"parameters" : {
+				"limit" : "10"
+			},
+			"queryresult": {
+				"count": 4,
+				"results": [
+					"Example/1004/15-Jun#0##_3ac75bf67c06e184b53c2fe47dc9838f",
+					"Example/1004/15-Jun#0##_25fd2aa8d8bc9c7fe64f1161beb1e53e",
+					"Example/1004/15-Jun#0##_42f6ee5000aee48058fef6e89d988122",
+					"Example/1004/15-Jun#0##_93e03330595abc209f006bd389af97ca"
+				]
+			}
+		},
+		{
+			"about": "#2 for the same month",
+			"condition": "[[Category:E-1004]] [[Has date::~ Jun 2011]]",
+			"printouts" : [],
+			"parameters" : {
+				"limit" : "10"
+			},
+			"queryresult": {
+				"count": 8,
+				"results": [
+					"Example/1004/15-Jun#0##_3ac75bf67c06e184b53c2fe47dc9838f",
+					"Example/1004/15-Jun#0##_25fd2aa8d8bc9c7fe64f1161beb1e53e",
+					"Example/1004/15-Jun#0##_42f6ee5000aee48058fef6e89d988122",
+					"Example/1004/15-Jun#0##_93e03330595abc209f006bd389af97ca",
+					"Example/1004/17-Jun#0##_546d85f0e65445d6ddebc327d82bc9b4",
+					"Example/1004/17-Jun#0##_d6ae457c1063eb3280a01617e331ae16",
+					"Example/1004/17-Jun#0##_97d8169c6bcb5357c7d4ed617de6b683",
+					"Example/1004/17-Jun#0##_2321a4ca8cce9a9f1200e7bcc6530b32"
+				]
+			}
+		},
+		{
+			"about": "#3 not for the same month",
+			"condition": "[[Category:E-1004]] [[Has date::~ 2011]] [[Has date::!~ Jun 2011]]",
+			"printouts" : [],
+			"parameters" : {
+				"limit" : "10"
+			},
+			"queryresult": {
+				"count": 1,
+				"results": [
+					"Example/1004/16-Jun#0##_c13e26365fd030c4505450df0da097ca"
+				]
+			}
+		},
+		{
+			"about": "#4 for the same minute",
+			"condition": "[[Category:E-1004]] [[Has date::~ 17 Jun 2011 19:53 ]]",
+			"printouts" : [],
+			"parameters" : {
+				"limit" : "10"
+			},
+			"queryresult": {
+				"count": 3,
+				"results": [
+					"Example/1004/17-Jun#0##_546d85f0e65445d6ddebc327d82bc9b4",
+					"Example/1004/17-Jun#0##_d6ae457c1063eb3280a01617e331ae16",
+					"Example/1004/17-Jun#0##_97d8169c6bcb5357c7d4ed617de6b683"
+				]
+			}
+		},
+		{
+			"about": "#5 not for the same minute",
+			"condition": "[[Category:E-1004]] [[Has date::~ 17 Jun 2011 19:00]] [[Has date::!~ 17 Jun 2011 19:53]]",
+			"printouts" : [],
+			"parameters" : {
+				"limit" : "10"
+			},
+			"queryresult": {
+				"count": 1,
+				"results": [
+					"Example/1004/17-Jun#0##_2321a4ca8cce9a9f1200e7bcc6530b32"
+				]
+			}
+		},
+		{
+			"about": "#6 for the same sec",
+			"condition": "[[Category:E-1004]] [[Has date::~ 17 Jun 2011 19:53:05 ]]",
+			"printouts" : [],
+			"parameters" : {
+				"limit" : "10"
+			},
+			"queryresult": {
+				"count": 1,
+				"results": [
+					"Example/1004/17-Jun#0##_546d85f0e65445d6ddebc327d82bc9b4"
+				]
+			}
+		},
+		{
+			"about": "#7 for the same year",
+			"condition": "[[Category:E-1004]] [[Has date::!~ 2011 ]]",
+			"printouts" : [],
+			"parameters" : {
+				"limit" : "10"
+			},
+			"queryresult": {
+				"count": 4,
+				"results": [
+					"Example/1004/17-Jun-1356#0##_4034c283fdf86e4170912b3c85c970e8",
+					"Example/1004/17-Jun-1356#0##_c649d0effa6cd11dd6a4def82ac6523f",
+					"Example/1004/17-Jun-1356#0##_b080b00743a9e79d619f417b2268156f",
+					"Example/1004/17-Jun-1356#0##_af39ab3a77d159be5d8f2a1ddfc72d37"
+				]
+			}
+		}
+	],
+	"settings": {
+		"smwStrictComparators": false
+	},
+	"meta": {
+		"skip-on": {
+			"virtuoso": "Virtuoso 6.1 somwhow fails for >/>>"
+		},
+		"version": "0.1",
+		"is-incomplete": false,
+		"debug": false
+	}
+}

--- a/tests/phpunit/Integration/ByJsonScript/Fixtures/q-1102 record type to include date like not like comparators.json
+++ b/tests/phpunit/Integration/ByJsonScript/Fixtures/q-1102 record type to include date like not like comparators.json
@@ -1,0 +1,91 @@
+{
+	"description": "_rec type + _dat ~/!~ searc pattern",
+	"properties": [
+		{
+			"name": "Has status",
+			"contents": "[[Has type::Text]] [[Allows value::open]] [[Allows value::closed]] [[Allows value::in progress]]"
+		},
+		{
+			"name": "Has date",
+			"contents": "[[Has type::Date]]"
+		},
+		{
+			"name": "Has status record",
+			"contents": "[[Has type::Record]] [[Has fields::Has date; Has status]]"
+		}
+	],
+	"subjects": [
+		{
+			"name": "Example/1102/15-Dec-2007",
+			"contents": "{{#subobject:|@category=E-1102|Has status record=15 Dec 2007;closed}}{{#subobject:|@category=E-1102 |Has status record=15 Dec 2007;open}}"
+		},
+		{
+			"name": "Example/1102/16-Dec-2007",
+			"contents": "{{#subobject:|@category=E-1102 |Has status record=16 Dec 2007;closed}}"
+		},
+		{
+			"name": "Example/1102/345-BC",
+			"contents": "{{#subobject:|@category=E-1102|Has status record=345 BC;closed}}"
+		}
+	],
+	"query-testcases": [
+		{
+			"about": "#0 disjunctive match for any status",
+			"condition": "[[Category:E-1102]] [[Has status record::~Dec 2007;?]] OR [[Has status record::~345 BC;?]]",
+			"printouts" : [],
+			"parameters" : {
+				"limit" : "10"
+			},
+			"queryresult": {
+				"count": 4,
+				"results": [
+					"Example/1102/15-Dec-2007#0##_32971b257b2cfa9a364ae22e21ab4adf",
+					"Example/1102/15-Dec-2007#0##_a95f61c99770cf350f1388ae46e973bb",
+					"Example/1102/16-Dec-2007#0##_f1fd6537c6d2576390a45ba86e58ed5b",
+					"Example/1102/345-BC#0##_6f2d86633d90e76f0e9fa5e5d1fe6598"
+				]
+			}
+		},
+		{
+			"about": "#1 all closed in Dec 2007",
+			"condition": "[[Category:E-1102]] [[Has status record::~Dec 2007;closed]]",
+			"printouts" : [],
+			"parameters" : {
+				"limit" : "10"
+			},
+			"queryresult": {
+				"count": 2,
+				"results": [
+					"Example/1102/15-Dec-2007#0##_32971b257b2cfa9a364ae22e21ab4adf",
+					"Example/1102/16-Dec-2007#0##_f1fd6537c6d2576390a45ba86e58ed5b"
+				]
+			}
+		},
+		{
+			"about": "#2 all closed not at the 15 Dec 2007",
+			"condition": "[[Category:E-1102]] [[Has status record::!~ 15 Dec 2007;closed]]",
+			"printouts" : [],
+			"parameters" : {
+				"limit" : "10"
+			},
+			"queryresult": {
+				"count": 2,
+				"results": [
+					"Example/1102/16-Dec-2007#0##_f1fd6537c6d2576390a45ba86e58ed5b",
+					"Example/1102/345-BC#0##_6f2d86633d90e76f0e9fa5e5d1fe6598"
+				]
+			}
+		}
+	],
+	"settings": {
+		"smwStrictComparators": false
+	},
+	"meta": {
+		"skip-on": {
+			"virtuoso": "Virtuoso 6.1 fails for BC"
+		},
+		"version": "0.1",
+		"is-incomplete": false,
+		"debug": false
+	}
+}

--- a/tests/phpunit/Unit/Deserializers/DVDescriptionDeserializer/DispatchingDescriptionDeserializerTest.php
+++ b/tests/phpunit/Unit/Deserializers/DVDescriptionDeserializer/DispatchingDescriptionDeserializerTest.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace SMW\Tests\Deserializers\DVDescriptionDeserializer;
+
+use SMW\Deserializers\DVDescriptionDeserializer\DispatchingDescriptionDeserializer;
+
+/**
+ * @covers \SMW\Deserializers\DVDescriptionDeserializer\DispatchingDescriptionDeserializer
+ * @group semantic-mediawiki
+ *
+ * @license GNU GPL v2+
+ * @since 2.3
+ *
+ * @author mwjames
+ */
+class DispatchingDescriptionDeserializerTest extends \PHPUnit_Framework_TestCase {
+
+	public function testCanConstruct() {
+
+		$this->assertInstanceOf(
+			'\SMW\Deserializers\DVDescriptionDeserializer\DispatchingDescriptionDeserializer',
+			new DispatchingDescriptionDeserializer()
+		);
+	}
+
+	public function testGetDescriptionDeserializerForMatchableDataValue() {
+
+		$descriptionDeserializer = $this->getMockBuilder( '\SMW\Deserializers\DVDescriptionDeserializer\DescriptionDeserializer' )
+			->disableOriginalConstructor()
+			->getMockForAbstractClass();
+
+		$descriptionDeserializer->expects( $this->once() )
+			->method( 'isDeserializerFor' )
+			->will( $this->returnValue( true ) );
+
+		$dataValue = $this->getMockBuilder( '\SMWDataValue' )
+			->disableOriginalConstructor()
+			->getMockForAbstractClass();
+
+		$instance = new DispatchingDescriptionDeserializer();
+		$instance->addDescriptionDeserializer( $descriptionDeserializer );
+
+		$this->assertInstanceOf(
+			'\SMW\Deserializers\DVDescriptionDeserializer\DescriptionDeserializer',
+			$instance->getDescriptionDeserializerFor( $dataValue )
+		);
+	}
+
+	public function testGetDefaultDescriptionDeserializerForMatchableDataValue() {
+
+		$descriptionDeserializer = $this->getMockBuilder( '\SMW\Deserializers\DVDescriptionDeserializer\DescriptionDeserializer' )
+			->disableOriginalConstructor()
+			->getMockForAbstractClass();
+
+		$descriptionDeserializer->expects( $this->once() )
+			->method( 'isDeserializerFor' )
+			->will( $this->returnValue( true ) );
+
+		$dataValue = $this->getMockBuilder( '\SMWDataValue' )
+			->disableOriginalConstructor()
+			->getMockForAbstractClass();
+
+		$instance = new DispatchingDescriptionDeserializer();
+		$instance->addDefaultDescriptionDeserializer( $descriptionDeserializer );
+
+		$this->assertInstanceOf(
+			'\SMW\Deserializers\DVDescriptionDeserializer\DescriptionDeserializer',
+			$instance->getDescriptionDeserializerFor( $dataValue )
+		);
+	}
+
+	public function testTryToGetDescriptionDeserializerForNonDispatchableDataValueThrowsException() {
+
+		$descriptionDeserializer = $this->getMockBuilder( '\SMW\Deserializers\DVDescriptionDeserializer\DescriptionDeserializer' )
+			->disableOriginalConstructor()
+			->getMockForAbstractClass();
+
+		$descriptionDeserializer->expects( $this->once() )
+			->method( 'isDeserializerFor' )
+			->will( $this->returnValue( false ) );
+
+		$dataValue = $this->getMockBuilder( '\SMWDataValue' )
+			->disableOriginalConstructor()
+			->getMockForAbstractClass();
+
+		$instance = new DispatchingDescriptionDeserializer();
+		$instance->addDescriptionDeserializer( $descriptionDeserializer );
+
+		$this->setExpectedException( 'RuntimeException' );
+		$instance->getDescriptionDeserializerFor( $dataValue );
+	}
+
+}

--- a/tests/phpunit/Unit/Deserializers/DVDescriptionDeserializer/SomeValueDescriptionDeserializerTest.php
+++ b/tests/phpunit/Unit/Deserializers/DVDescriptionDeserializer/SomeValueDescriptionDeserializerTest.php
@@ -1,0 +1,113 @@
+<?php
+
+namespace SMW\Tests\Deserializers\DVDescriptionDeserializer;
+
+use SMW\Deserializers\DVDescriptionDeserializer\SomeValueDescriptionDeserializer;
+
+/**
+ * @covers \SMW\Deserializers\DVDescriptionDeserializer\SomeValueDescriptionDeserializer
+ * @group semantic-mediawiki
+ *
+ * @license GNU GPL v2+
+ * @since 2.3
+ *
+ * @author mwjames
+ */
+class SomeValueDescriptionDeserializerTest extends \PHPUnit_Framework_TestCase {
+
+	public function testCanConstruct() {
+
+		$this->assertInstanceOf(
+			'\SMW\Deserializers\DVDescriptionDeserializer\SomeValueDescriptionDeserializer',
+			new SomeValueDescriptionDeserializer()
+		);
+	}
+
+	public function testIsDeserializerForDataValue() {
+
+		$dataValue = $this->getMockBuilder( '\SMWDataValue' )
+			->disableOriginalConstructor()
+			->getMockForAbstractClass();
+
+		$instance = new SomeValueDescriptionDeserializer();
+
+		$this->assertTrue(
+			$instance->isDeserializerFor( $dataValue )
+		);
+	}
+
+	/**
+	 * @dataProvider valueProvider
+	 */
+	public function testDeserialize( $value, $decription ) {
+
+		$dataValue = $this->getMockBuilder( '\SMWDataValue' )
+			->disableOriginalConstructor()
+			->setMethods( array( 'isValid', 'getDataItem', 'getProperty' ) )
+			->getMockForAbstractClass();
+
+		$dataValue->expects( $this->any() )
+			->method( 'isValid' )
+			->will( $this->returnValue( true ) );
+
+		$dataValue->expects( $this->any() )
+			->method( 'getDataItem' )
+			->will( $this->returnValue( new \SMWDITime( 1, '1970' ) ) );
+
+		$dataValue->expects( $this->any() )
+			->method( 'getProperty' )
+			->will( $this->returnValue( new \SMW\DIProperty( 'Foo' ) ) );
+
+		$instance = new SomeValueDescriptionDeserializer();
+		$instance->setDataValue( $dataValue );
+
+		$this->assertInstanceOf(
+			$decription,
+			$instance->deserialize( $value )
+		);
+	}
+
+	public function testInvalidDataValueRetunsThingDescription() {
+
+		$dataValue = $this->getMockBuilder( '\SMWDataValue' )
+			->disableOriginalConstructor()
+			->setMethods( array( 'isValid' ) )
+			->getMockForAbstractClass();
+
+		$dataValue->expects( $this->any() )
+			->method( 'isValid' )
+			->will( $this->returnValue( false ) );
+
+		$instance = new SomeValueDescriptionDeserializer();
+		$instance->setDataValue( $dataValue );
+
+		$this->assertInstanceOf(
+			'\SMW\Query\Language\ThingDescription',
+			$instance->deserialize( 'Foo' )
+		);
+	}
+
+	public function testNonStringThrowsException() {
+
+		$dataValue = $this->getMockBuilder( '\SMWDataValue' )
+			->disableOriginalConstructor()
+			->getMockForAbstractClass();
+
+		$instance = new SomeValueDescriptionDeserializer();
+		$instance->setDataValue( $dataValue );
+
+		$this->setExpectedException( 'InvalidArgumentException' );
+		$instance->deserialize( array() );
+	}
+
+	public function valueProvider() {
+
+		$provider[] = array(
+			'Foo',
+			'\SMW\Query\Language\ValueDescription'
+		);
+
+		return $provider;
+	}
+
+}

--- a/tests/phpunit/Unit/Deserializers/DVDescriptionDeserializer/TimeValueDescriptionDeserializerTest.php
+++ b/tests/phpunit/Unit/Deserializers/DVDescriptionDeserializer/TimeValueDescriptionDeserializerTest.php
@@ -1,0 +1,121 @@
+<?php
+
+namespace SMW\Tests\Deserializers\DVDescriptionDeserializer;
+
+use SMW\Deserializers\DVDescriptionDeserializer\TimeValueDescriptionDeserializer;
+
+/**
+ * @covers \SMW\Deserializers\DVDescriptionDeserializer\TimeValueDescriptionDeserializer
+ * @group semantic-mediawiki
+ *
+ * @license GNU GPL v2+
+ * @since 2.3
+ *
+ * @author mwjames
+ */
+class TimeValueDescriptionDeserializerTest extends \PHPUnit_Framework_TestCase {
+
+	public function testCanConstruct() {
+
+		$this->assertInstanceOf(
+			'\SMW\Deserializers\DVDescriptionDeserializer\TimeValueDescriptionDeserializer',
+			new TimeValueDescriptionDeserializer()
+		);
+	}
+
+	public function testIsDeserializerForTimeValue() {
+
+		$dataValue = $this->getMockBuilder( '\SMWTimeValue' )
+			->disableOriginalConstructor()
+			->getMockForAbstractClass();
+
+		$instance = new TimeValueDescriptionDeserializer();
+
+		$this->assertTrue(
+			$instance->isDeserializerFor( $dataValue )
+		);
+	}
+
+	/**
+	 * @dataProvider valueProvider
+	 */
+	public function testDeserialize( $value, $decription ) {
+
+		$timeValue = $this->getMockBuilder( '\SMWTimeValue' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$timeValue->expects( $this->any() )
+			->method( 'isValid' )
+			->will( $this->returnValue( true ) );
+
+		$timeValue->expects( $this->any() )
+			->method( 'getDataItem' )
+			->will( $this->returnValue( new \SMWDITime( 1, '1970' ) ) );
+
+		$timeValue->expects( $this->any() )
+			->method( 'getProperty' )
+			->will( $this->returnValue( new \SMW\DIProperty( 'Foo' ) ) );
+
+		$instance = new TimeValueDescriptionDeserializer();
+		$instance->setDataValue( $timeValue );
+
+		$this->assertInstanceOf(
+			$decription,
+			$instance->deserialize( $value )
+		);
+	}
+
+	public function testInvalidTimeValueReturnsThingDescription() {
+
+		$timeValue = $this->getMockBuilder( '\SMWTimeValue' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$timeValue->expects( $this->any() )
+			->method( 'isValid' )
+			->will( $this->returnValue( false ) );
+
+		$instance = new TimeValueDescriptionDeserializer();
+		$instance->setDataValue( $timeValue );
+
+		$this->assertInstanceOf(
+			'\SMW\Query\Language\ThingDescription',
+			$instance->deserialize( 'Foo' )
+		);
+	}
+
+	public function testNonStringThrowsException() {
+
+		$timeValue = $this->getMockBuilder( '\SMWTimeValue' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$instance = new TimeValueDescriptionDeserializer();
+		$instance->setDataValue( $timeValue );
+
+		$this->setExpectedException( 'InvalidArgumentException' );
+		$instance->deserialize( array() );
+	}
+
+	public function valueProvider() {
+
+		$provider[] = array(
+			'Jan 1970',
+			'\SMW\Query\Language\ValueDescription'
+		);
+
+		$provider[] = array(
+			'~Jan 1970',
+			'\SMW\Query\Language\Conjunction'
+		);
+
+		$provider[] = array(
+			'!~Jan 1970',
+			'\SMW\Query\Language\Disjunction'
+		);
+
+		return $provider;
+	}
+
+}

--- a/tests/phpunit/Unit/Deserializers/DVDescriptionDeserializerFactoryTest.php
+++ b/tests/phpunit/Unit/Deserializers/DVDescriptionDeserializerFactoryTest.php
@@ -1,0 +1,91 @@
+<?php
+
+namespace SMW\Tests\Deserializers;
+
+use SMW\Deserializers\DVDescriptionDeserializerFactory;
+
+/**
+ * @covers \SMW\Deserializers\DVDescriptionDeserializerFactory
+ * @group semantic-mediawiki
+ *
+ * @license GNU GPL v2+
+ * @since 2.3
+ *
+ * @author mwjames
+ */
+class DVDescriptionDeserializerFactoryTest extends \PHPUnit_Framework_TestCase {
+
+	protected function tearDown() {
+		DVDescriptionDeserializerFactory::getInstance()->clear();
+		parent::tearDown();
+	}
+
+	public function testCanConstruct() {
+
+		$dispatchingDescriptionDeserializer = $this->getMockBuilder( '\SMW\Deserializers\DVDescriptionDeserializer\DispatchingDescriptionDeserializer' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$this->assertInstanceOf(
+			'\SMW\Deserializers\DVDescriptionDeserializerFactory',
+			new DVDescriptionDeserializerFactory( $dispatchingDescriptionDeserializer )
+		);
+
+		$this->assertInstanceOf(
+			'\SMW\Deserializers\DVDescriptionDeserializerFactory',
+			DVDescriptionDeserializerFactory::getInstance()
+		);
+	}
+
+	public function testCanConstructSomeValueDescriptionDeserializer() {
+
+		$dataValue = $this->getMockBuilder( '\SMWDataValue' )
+			->disableOriginalConstructor()
+			->getMockForAbstractClass();
+
+		$instance = new DVDescriptionDeserializerFactory();
+
+		$this->assertInstanceOf(
+			'\SMW\Deserializers\DVDescriptionDeserializer\SomeValueDescriptionDeserializer',
+			$instance->getDescriptionDeserializerFor( $dataValue )
+		);
+	}
+
+	public function testCanConstructTimeValueDescriptionDeserializer() {
+
+		$dataValue = $this->getMockBuilder( '\SMWTimeValue' )
+			->disableOriginalConstructor()
+			->getMockForAbstractClass();
+
+		$instance = new DVDescriptionDeserializerFactory();
+
+		$this->assertInstanceOf(
+			'\SMW\Deserializers\DVDescriptionDeserializer\TimeValueDescriptionDeserializer',
+			$instance->getDescriptionDeserializerFor( $dataValue )
+		);
+	}
+
+	public function testRegisterAdditionalDescriptionDeserializer() {
+
+		$descriptionDeserializer = $this->getMockBuilder( '\SMW\Deserializers\DVDescriptionDeserializer\DescriptionDeserializer' )
+			->disableOriginalConstructor()
+			->getMockForAbstractClass();
+
+		$descriptionDeserializer->expects( $this->once() )
+			->method( 'isDeserializerFor' )
+			->will( $this->returnValue( true ) );
+
+		$dataValue = $this->getMockBuilder( '\SMWDataValue' )
+			->disableOriginalConstructor()
+			->getMockForAbstractClass();
+
+		$instance = new DVDescriptionDeserializerFactory();
+		$instance->registerDescriptionDeserializer( $descriptionDeserializer );
+
+		$this->assertInstanceOf(
+			'\SMW\Deserializers\DVDescriptionDeserializer\DescriptionDeserializer',
+			$instance->getDescriptionDeserializerFor( $dataValue )
+		);
+	}
+
+}


### PR DESCRIPTION
Adds ~/!~ support for the _dat type and removes query related dependencies from the DV components and moves it into a separate `SMW\Deserializers\DVDescriptionDeserializer` NS.

- Match all subjects for Dec 2001

```
{{#ask: [[Has date::~ Dec 2001]]
 |?Has date
}}
```

- Match all subjects that have not been altered at the 15 Jun 2006

```
{{#ask: [[Modification date::!~ 15 Jun 2006]]
 |?Modification date
}}
```

- Match all subjects that have been closed in Dec 2007 (using a record)

```
{{#ask: [[Has status record::~Dec 2007;closed]]
 |?Has status record
}}
```