### PR TITLE
Use format as specified by #ask to set further link

### DIFF
--- a/includes/queryprinters/ResultPrinter.php
+++ b/includes/queryprinters/ResultPrinter.php
@@ -436,6 +436,8 @@ abstract class ResultPrinter extends \ContextSource implements QueryResultPrinte
 			$link->setStyle(  'smw-' . $this->params['format'] . '-' . Sanitizer::escapeClass( $classAffix ) );
 		}
 
+		$link->setParameter( $this->params['format'], 'format' );
+
 		/**
 		 * @var \IParam $param
 		 */

--- a/tests/phpunit/Integration/ByJsonScript/Fixtures/f-0302 [#699,en] category defaultsort.json
+++ b/tests/phpunit/Integration/ByJsonScript/Fixtures/f-0302 [#699,en] category defaultsort.json
@@ -38,6 +38,10 @@
 		{
 			"name": "one-column-plainlist-output-desc",
 			"contents": "{{#ask:[[Has text::+]]\n |?Has text\n |format=category\n |order=desc\n |link=none\n |headers=plain\n |limit=10\n |columns=1\n}}"
+		},
+		{
+			"name": "Example/0302/Further-link",
+			"contents": "{{#ask:[[Has text::+]]\n |?Has text\n |format=category\n |order=desc\n |link=none\n |headers=plain\n |limit=0\n |columns=1\n}}"
 		}
 	],
 	"format-testcases": [
@@ -74,8 +78,17 @@
 					"<br style=\"clear: both;\" />"
 				]
 			}
+		},
+		{
+			"about": "#3 Further link",
+			"subject": "Example/0302/Further-link",
+			"expected-output": {
+				"to-contain": [
+					"<span class=\"smw-category-furtherresults\">",
+					"format=category/link=none/order=desc/headers=plain/columns=1/offset=0"
+				]
+			}
 		}
-
 	],
 	"settings": {
 		"wgContLang": "en",


### PR DESCRIPTION
```
{{#ask: [[Category:Sample pages]]
 |format=category
}}
```

Points to `format=category` and not to `format=table` (by default).