### PR TITLE
Add PropertyTableOutdatedReferenceDisposer, refs #498

### DIFF
--- a/src/SQLStore/PropertyTableOutdatedReferenceDisposer.php
+++ b/src/SQLStore/PropertyTableOutdatedReferenceDisposer.php
@@ -1,0 +1,127 @@
+<?php
+
+namespace SMW\SQLStore;
+
+/**
+ * @license GNU GPL v2+
+ * @since 2.4
+ *
+ * @author mwjames
+ */
+class PropertyTableOutdatedReferenceDisposer {
+
+	/**
+	 * @var SQLStore
+	 */
+	private $store = null;
+
+	/**
+	 * @since 2.4
+	 *
+	 * @param SQLStore $store
+	 */
+	public function __construct( SQLStore $store ) {
+		$this->store = $store;
+	}
+
+	/**
+	 * After a property changed its type (_wpg -> _txt), object values in the
+	 * ID table are not removed at the time of the conversion process. This method
+	 * (as a post-processing during the ByIdDataRebuildDispatcher) checks
+	 * whether an ID is without reference and removes it if necessary.
+	 *
+	 * @note This method does not check for an ID being object or subject value
+	 * and has to be done prior calling this routine.
+	 *
+	 * @since 2.4
+	 *
+	 * @param integer $id
+	 */
+	public function attemptToRemoveOutdatedEntryFromIDTable( $id ) {
+
+		$db = $this->store->getConnection( 'mw.db' );
+		$canRemoveEntry = true;
+
+		foreach ( $this->store->getPropertyTables() as $proptable ) {
+			if ( $this->hasReferenceInPropertyTable( $proptable, $id ) ) {
+				$canRemoveEntry = false;
+				break;
+			}
+		}
+
+		if ( $canRemoveEntry ) {
+			$db->delete( SQLStore::ID_TABLE, array( 'smw_id' => $id ), __METHOD__ );
+		}
+	}
+
+	/**
+	 * @since 2.4
+	 *
+	 * @param integer $id
+	 */
+	public function removeAnyReferenceFromPropertyTablesFor( $id ) {
+
+		$db = $this->store->getConnection( 'mw.db' );
+
+		foreach ( $this->store->getPropertyTables() as $proptable ) {
+			if ( $proptable->usesIdSubject() ) {
+				$db->delete(
+					$proptable->getName(),
+					array( 's_id' => $id ),
+					__METHOD__
+				);
+			}
+
+			$fields = $proptable->getFields( $this->store );
+
+			// Match tables (including ftp_redi) that contain an object reference
+			if ( isset( $fields['o_id'] ) ) {
+				$db->delete(
+					$proptable->getName(),
+					array( 'o_id' => $id ),
+					__METHOD__
+				);
+			}
+		}
+
+		$db->delete(
+			SQLStore::ID_TABLE,
+			array( 'smw_id' => $id ),
+			__METHOD__
+		);
+	}
+
+	private function hasReferenceInPropertyTable( $proptable, $id ) {
+
+		$row = false;
+		$db = $this->store->getConnection( 'mw.db' );
+
+		if ( $proptable->usesIdSubject() ) {
+			$row = $db->selectRow(
+				$proptable->getName(),
+				array( 's_id' ),
+				array( 's_id' => $id ),
+				__METHOD__
+			);
+		}
+
+		if ( $row !== false ) {
+			return true;
+		}
+
+		$fields = $proptable->getFields( $this->store );
+
+		// Check whether an object reference exists or not
+		if ( isset( $fields['o_id'] ) ) {
+			$row = $db->selectRow(
+				$proptable->getName(),
+				array( 'o_id' ),
+				array( 'o_id' => $id ),
+				__METHOD__
+			);
+		}
+
+		return $row !== false;
+	}
+
+}

--- a/tests/phpunit/Unit/SQLStore/ByIdDataRebuildDispatcherTest.php
+++ b/tests/phpunit/Unit/SQLStore/ByIdDataRebuildDispatcherTest.php
@@ -48,9 +48,9 @@ class ByIdDataRebuildDispatcherTest extends \PHPUnit_Framework_TestCase {
 
 	public function testCanConstruct() {
 
-		$store = $this->getMockBuilder( '\SMW\Store' )
+		$store = $this->getMockBuilder( '\SMW\SQLStore\SQLStore' )
 			->disableOriginalConstructor()
-			->getMockForAbstractClass();
+			->getMock();
 
 		$this->assertInstanceOf(
 			'\SMW\SQLStore\ByIdDataRebuildDispatcher',

--- a/tests/phpunit/Unit/SQLStore/PropertyTableOutdatedReferenceDisposerTest.php
+++ b/tests/phpunit/Unit/SQLStore/PropertyTableOutdatedReferenceDisposerTest.php
@@ -1,0 +1,107 @@
+<?php
+
+namespace SMW\Tests\SQLStore;
+
+use SMW\SQLStore\PropertyTableOutdatedReferenceDisposer;
+use Title;
+
+/**
+ * @covers \SMW\SQLStore\PropertyTableOutdatedReferenceDisposer
+ * @group semantic-mediawiki
+ *
+ * @license GNU GPL v2+
+ * @since 2.4
+ *
+ * @author mwjames
+ */
+class PropertyTableOutdatedReferenceDisposerTest extends \PHPUnit_Framework_TestCase {
+
+	private $store;
+
+	protected function setUp() {
+		parent::setUp();
+
+		$this->store = $this->getMockBuilder( '\SMW\SQLStore\SQLStore' )
+			->disableOriginalConstructor()
+			->getMock();
+	}
+
+	public function testCanConstruct() {
+
+		$this->assertInstanceOf(
+			'\SMW\SQLStore\PropertyTableOutdatedReferenceDisposer',
+			new PropertyTableOutdatedReferenceDisposer( $this->store )
+		);
+	}
+
+	public function testTryToRemoveOutdatedEntryFromIDTable() {
+
+		$tableDefinition = $connection = $this->getMockBuilder( '\SMW\SQLStore\TableDefinition' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$connection = $this->getMockBuilder( '\SMW\MediaWiki\Database' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$connection->expects( $this->any() )
+			->method( 'selectRow' )
+			->will( $this->returnValue( false ) );
+
+		$connection->expects( $this->once() )
+			->method( 'delete' )
+			->with( $this->equalTo( \SMW\SQLStore\SQLStore::ID_TABLE ) );
+
+		$this->store->expects( $this->any() )
+			->method( 'getConnection' )
+			->will( $this->returnValue( $connection ) );
+
+		$this->store->expects( $this->any() )
+			->method( 'getPropertyTables' )
+			->will( $this->returnValue( array( $tableDefinition ) ) );
+
+		$instance = new PropertyTableOutdatedReferenceDisposer(
+			$this->store
+		);
+
+		$instance->attemptToRemoveOutdatedEntryFromIDTable( 42 );
+	}
+
+	public function testDeleteReferencesFromPropertyTablesFor() {
+
+		$tableDefinition = $connection = $this->getMockBuilder( '\SMW\SQLStore\TableDefinition' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$tableDefinition->expects( $this->once() )
+			->method( 'usesIdSubject' )
+			->will( $this->returnValue( true ) );
+
+		$connection = $this->getMockBuilder( '\SMW\MediaWiki\Database' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$connection->expects( $this->any() )
+			->method( 'selectRow' )
+			->will( $this->returnValue( false ) );
+
+		$connection->expects( $this->at( 1 ) )
+			->method( 'delete' )
+			->with( $this->equalTo( \SMW\SQLStore\SQLStore::ID_TABLE ) );
+
+		$this->store->expects( $this->any() )
+			->method( 'getConnection' )
+			->will( $this->returnValue( $connection ) );
+
+		$this->store->expects( $this->any() )
+			->method( 'getPropertyTables' )
+			->will( $this->returnValue( array( $tableDefinition ) ) );
+
+		$instance = new PropertyTableOutdatedReferenceDisposer(
+			$this->store
+		);
+
+		$instance->removeAnyReferenceFromPropertyTablesFor( 42 );
+	}
+
+}


### PR DESCRIPTION
When a property type is changed, a property is removed, or other object values are deleted chances are that some ID's remain (#498) in the ID_TABLE and to avoid a pile of garbage being collected in the ID_TABLE, `PropertyTableOutdatedReferenceDisposer` will check on ID's whether they can safely be removed or not (during the `rebuidData` run).

For the quick sweep run (without running the memory intensive `Parser::parse`) use `rebuildData.php --shallow-update`.

refs #498, #1100, #1151

Test case 1:

- Create a subject `Foo` with `[[SomeProperty:123]]`
- Delete subject `Foo`
- `Special:Properties` will list `SomeProperty`
- Run `rebuildData.php --shallow-update` and `SomeProperty` should no longer be displayed (== no longer exists in the ID_TABLE) as long it has no other references

Test case 2:

- Create a subject `Foo` with  `[[SomeProperty: ]]` (being empty hence `Has improper value for` annotation is added)
- Remove  `[[SomeProperty: ]]` from the subject
- `Special:Properties` will still list `SomeProperty`
- Run `rebuildData.php --shallow-update` and `SomeProperty` should no longer be displayed as long it has no other references