### PR TITLE
added support for displaytitle in JavaScript result formats

### DIFF
--- a/res/smw/data/ext.smw.data.js
+++ b/res/smw/data/ext.smw.data.js
@@ -97,7 +97,7 @@
 
 				$.each( value, function( subjectName, subject ) {
 					if( subject.hasOwnProperty( 'fulltext' ) ){
-						var nSubject = new smw.dataItem.wikiPage( subject.fulltext, subject.fullurl, subject.namespace, subject.exists );
+						var nSubject = new smw.dataItem.wikiPage( subject.fulltext, subject.fullurl, subject.namespace, subject.exists, subject.displaytitle );
 						nSubject.printouts = subject.printouts;
 						nResults[subjectName] = nSubject;
 					} else {
@@ -120,7 +120,7 @@
 					switch ( typeid ) {
 						case '_wpg':
 							$.map( value, function( w ) {
-								factoredValue.push( new smw.dataItem.wikiPage( w.fulltext, w.fullurl, w.namespace, w.exists ) );
+								factoredValue.push( new smw.dataItem.wikiPage( w.fulltext, w.fullurl, w.namespace, w.exists, w.displaytitle ) );
 							} );
 							break;
 						case '_uri':

--- a/res/smw/data/ext.smw.dataItem.wikiPage.js
+++ b/res/smw/data/ext.smw.dataItem.wikiPage.js
@@ -195,7 +195,7 @@
 			if ( linker && this.fullurl !== null ){
 				var attributes = this.exists ? { 'href': this.fullurl } : { 'href': this.fullurl, 'class': 'new' };
 				var displaytitle = this.getDisplayTitle();
-				if (displaytitle === null ) {
+				if ( displaytitle === null ) {
 					displaytitle = this.getText();
 				}
 				return html.element( 'a', attributes , displaytitle );

--- a/res/smw/data/ext.smw.dataItem.wikiPage.js
+++ b/res/smw/data/ext.smw.dataItem.wikiPage.js
@@ -55,11 +55,12 @@
 	 *
 	 * @return {smw.dataItem.wikiPage} this
 	 */
-	var wikiPage = function ( fulltext, fullurl, ns, exists ) {
+	var wikiPage = function ( fulltext, fullurl, ns, exists, displaytitle ) {
 		this.fulltext  = fulltext !== ''&& fulltext !==  undefined ? fulltext : null;
 		this.fullurl   = fullurl !== '' && fullurl !==  undefined ? fullurl : null;
 		this.ns        = ns !==  undefined ? ns : 0;
 		this.exists    = exists !==  undefined ? exists : true;
+		this.displaytitle  = displaytitle !== '' && displaytitle !==  undefined ? displaytitle : null;
 
 		// Get mw.Title inheritance
 		if ( this.fulltext !== null ){
@@ -78,9 +79,9 @@
 	 * @class
 	 * @constructor
 	 */
-	smw.dataItem.wikiPage = function( fulltext, fullurl, ns, exists ) {
+	smw.dataItem.wikiPage = function( fulltext, fullurl, ns, exists, displaytitle ) {
 		if ( $.type( fulltext ) === 'string' && $.type( fullurl ) === 'string' ) {
-			this.constructor( fulltext, fullurl, ns, exists );
+			this.constructor( fulltext, fullurl, ns, exists, displaytitle );
 		} else {
 			throw new Error( 'smw.dataItem.wikiPage: fulltext, fullurl must be a string' );
 		}
@@ -149,6 +150,17 @@
 		},
 
 		/**
+		 * Returns display title
+		 *
+		 * @since  2.3
+		 *
+		 * @return {string}
+		 */
+		getDisplayTitle: function() {
+			return this.displaytitle;
+		},
+
+		/**
 		 * Returns if the wikiPage is a known entity or not
 		 *
 		 * @since  1.9
@@ -182,7 +194,11 @@
 		getHtml: function( linker ) {
 			if ( linker && this.fullurl !== null ){
 				var attributes = this.exists ? { 'href': this.fullurl } : { 'href': this.fullurl, 'class': 'new' };
-				return html.element( 'a', attributes , this.getText() );
+				var displaytitle = this.getDisplayTitle();
+				if (displaytitle === null ) {
+					displaytitle = this.getText();
+				}
+				return html.element( 'a', attributes , displaytitle );
 			}
 			return this.getText();
 		}

--- a/src/MediaWiki/TitleLookup.php
+++ b/src/MediaWiki/TitleLookup.php
@@ -30,6 +30,11 @@ class TitleLookup {
 	private $namespace = null;
 
 	/**
+	 * @var string[]
+	 */
+	private $displayTitles = array();
+
+	/**
 	 * @since 1.9.2
 	 *
 	 * @param Database $connection
@@ -144,6 +149,46 @@ class TitleLookup {
 			false,
 			__METHOD__
 		);
+	}
+
+	/**
+	 * @since 1.9.2
+	 *
+	 * @param Title $title
+	 * @return string
+	 */
+	public function getDisplayTitleFor( Title $title ) {
+
+		$pageId = $title->getArticleID();
+		if ( $pageId < 1 ) {
+			return false;
+		}
+
+		if ( isset( $displayTitles[$pageId] ) ) {
+			return $displayTitles[$pageId];
+		}
+
+		$row = $this->connection->selectRow(
+			'page_props',
+			array( 'pp_value' ),
+			array(
+				'pp_page' => $pageId,
+				'pp_propname' => 'displaytitle'
+			),
+			__METHOD__
+		);
+
+		if ( $row !== false ) {
+			$displayTitle = $row->pp_value;
+			# make sure it is visible (remove tags and &nbsp;)
+			if ( trim( str_replace( '&#160;', '', strip_tags( $displayTitle ) ) ) == '' ) {
+				return false;
+			}
+			$displayTitles[$pageId] = $displayTitle;
+			return $displayTitle;
+		}
+
+		return false;
 	}
 
 	protected function makeTitlesFromSelection( $res ) {

--- a/src/Serializers/QueryResultSerializer.php
+++ b/src/Serializers/QueryResultSerializer.php
@@ -100,7 +100,6 @@ class QueryResultSerializer implements DispatchableSerializer {
 	public static function getSerialization( DataItem $dataItem, $printRequest = null ) {
 		switch ( $dataItem->getDIType() ) {
 			case DataItem::TYPE_WIKIPAGE:
-<<<<<<< 922ecc88576ae63b3afb0074d7feebcc4fc290e8
 
 				// Support for a deserializable _rec type with 0.6
 				if ( $printRequest !== null && strpos( $printRequest->getTypeID(), '_rec' ) !== false ) {
@@ -136,16 +135,6 @@ class QueryResultSerializer implements DispatchableSerializer {
 					);
 				}
 				$displayTitle = self::getDisplayTitle ($title->getArticleID() );
-=======
-				$title = $dataItem->getTitle();
-				$result = array(
-					'fulltext' => $title->getFullText(),
-					'fullurl' => $title->getFullUrl(),
-					'namespace' => $title->getNamespace(),
-					'exists' => $title->isKnown()
-				);
-				$displayTitle = self::getDisplayTitle ( $title->getArticleID() );
->>>>>>> fixed spaces and serialization verison number
 				if ( $displayTitle ) {
 					$result['displaytitle'] = $displayTitle;
 				}

--- a/src/Serializers/QueryResultSerializer.php
+++ b/src/Serializers/QueryResultSerializer.php
@@ -43,7 +43,7 @@ class QueryResultSerializer implements DispatchableSerializer {
 			throw new OutOfBoundsException( 'Object was not identified as a QueryResult instance' );
 		}
 
-		return $this->getSerializedQueryResult( $queryResult ) + array( 'serializer' => __CLASS__, 'version' => 0.9 );
+		return $this->getSerializedQueryResult( $queryResult ) + array( 'serializer' => __CLASS__, 'version' => 0.10 );
 	}
 
 	/**
@@ -100,6 +100,7 @@ class QueryResultSerializer implements DispatchableSerializer {
 	public static function getSerialization( DataItem $dataItem, $printRequest = null ) {
 		switch ( $dataItem->getDIType() ) {
 			case DataItem::TYPE_WIKIPAGE:
+<<<<<<< 922ecc88576ae63b3afb0074d7feebcc4fc290e8
 
 				// Support for a deserializable _rec type with 0.6
 				if ( $printRequest !== null && strpos( $printRequest->getTypeID(), '_rec' ) !== false ) {
@@ -135,6 +136,16 @@ class QueryResultSerializer implements DispatchableSerializer {
 					);
 				}
 				$displayTitle = self::getDisplayTitle ($title->getArticleID() );
+=======
+				$title = $dataItem->getTitle();
+				$result = array(
+					'fulltext' => $title->getFullText(),
+					'fullurl' => $title->getFullUrl(),
+					'namespace' => $title->getNamespace(),
+					'exists' => $title->isKnown()
+				);
+				$displayTitle = self::getDisplayTitle ( $title->getArticleID() );
+>>>>>>> fixed spaces and serialization verison number
 				if ( $displayTitle ) {
 					$result['displaytitle'] = $displayTitle;
 				}

--- a/src/Serializers/QueryResultSerializer.php
+++ b/src/Serializers/QueryResultSerializer.php
@@ -56,6 +56,39 @@ class QueryResultSerializer implements DispatchableSerializer {
 	}
 
 	/**
+	 * Get display title of a page.
+	 *
+	 * @param int $pageId page ID of page being queried
+	 *
+	 * @return string|bool display title value or false if not found
+	 */
+	public static function getDisplayTitle( $pageId ) {
+
+		if ( ! is_numeric( $pageId ) || $pageId < 1 ) {
+
+			return false;
+
+		}
+
+		$dbr = wfGetDB( DB_SLAVE );
+		$row = $dbr->selectRow(
+			'page_props',
+			array( 'pp_value' ),
+			array(
+				'pp_page' => $pageId,
+				'pp_propname' => 'displaytitle'
+			),
+			__METHOD__
+		);
+
+		if ( $row !== false ) {
+			return $row->pp_value;
+		}
+
+		return false;
+	}
+
+	/**
 	 * Get the serialization for the provided data item.
 	 *
 	 * @since 1.7
@@ -100,6 +133,10 @@ class QueryResultSerializer implements DispatchableSerializer {
 						'namespace' => $title->getNamespace(),
 						'exists' => $title->isKnown()
 					);
+				}
+				$displayTitle = self::getDisplayTitle ($title->getArticleID() );
+				if ( $displayTitle ) {
+					$result['displaytitle'] = $displayTitle;
 				}
 				break;
 			case DataItem::TYPE_NUMBER:

--- a/tests/phpunit/Unit/Serializers/QueryResultSerializerTest.php
+++ b/tests/phpunit/Unit/Serializers/QueryResultSerializerTest.php
@@ -93,7 +93,8 @@ class QueryResultSerializerTest extends \PHPUnit_Framework_TestCase {
 
 		$serialization = QueryResultSerializer::getSerialization(
 			\SMW\DIWikipage::newFromText( 'ABC' ),
-			$printRequestFactory->newPropertyPrintRequest( $property )
+			$printRequestFactory->newPropertyPrintRequest( $property ),
+			$store
 		);
 
 		$expected = array(
@@ -126,9 +127,14 @@ class QueryResultSerializerTest extends \PHPUnit_Framework_TestCase {
 
 		$printRequestFactory = new \SMW\Query\PrintRequestFactory();
 
+		$store = $this->getMockBuilder( '\SMW\Store' )
+			->disableOriginalConstructor()
+			->getMockForAbstractClass();
+
 		$serialization = QueryResultSerializer::getSerialization(
 			\SMWDITime::doUnserialize( '2/1393/1/1' ),
-			$printRequestFactory->newPropertyPrintRequest( $property )
+			$printRequestFactory->newPropertyPrintRequest( $property ),
+			$store
 		);
 
 		$expected = array(


### PR DESCRIPTION
This patch passes the value of displaytitle to JavaScript-based result formats such as datatables so they can use it for the link text. The DISPLAYTITLE magic word and the SemanticTitle extension both set the displaytitle property in the MediaWiki page_props table. This sets the title displayed on the page itself to alternate text (often a human-friendly title for pages auto-named numerically). SemanticTitle also displays this text as the link text on links to that page from elsewhere in the wiki and self links (a MediaWiki core patch providing this functionality has been proposed: https://gerrit.wikimedia.org/r/#/c/246246/). This allows all PHP-based result formats to display links to pages with the human-friendly link text, but not JavaScript-based result formats. Please consider merging this useful functionality.

Thanks,

Cindy