### PR TITLE
Bail out early for queries with limit < 1

### DIFF
--- a/src/SPARQLStore/QueryEngine/QueryEngine.php
+++ b/src/SPARQLStore/QueryEngine/QueryEngine.php
@@ -93,7 +93,7 @@ class QueryEngine {
 		}
 
 		// don't query, but return something to the printer
-		if ( $query->querymode == Query::MODE_NONE ) {
+		if ( $query->querymode == Query::MODE_NONE || $query->getLimit() < 1 ) {
 			return $this->queryResultFactory->newEmptyQueryResult( $query, true );
 		}
 

--- a/src/SQLStore/QueryEngine/QueryEngine.php
+++ b/src/SQLStore/QueryEngine/QueryEngine.php
@@ -151,7 +151,7 @@ class QueryEngine {
 			return new QueryResult( $query->getDescription()->getPrintrequests(), $query, array(), $this->store, false );
 			// NOTE: we check this here to prevent unnecessary work, but we check
 			// it after query processing below again in case more errors occurred.
-		} elseif ( $query->querymode == Query::MODE_NONE ) {
+		} elseif ( $query->querymode == Query::MODE_NONE || $query->getLimit() < 1 ) {
 			// don't query, but return something to printer
 			return new QueryResult( $query->getDescription()->getPrintrequests(), $query, array(), $this->store, true );
 		}

--- a/tests/phpunit/Integration/QuerySourceIntegrationTest.php
+++ b/tests/phpunit/Integration/QuerySourceIntegrationTest.php
@@ -116,7 +116,7 @@ class QuerySourceIntegrationTest extends \PHPUnit_Framework_TestCase {
 			->will( $this->returnValue( $description ) );
 
 		$query->expects( $this->atLeastOnce() )
-			->method( 'getOffset' )
+			->method( 'getLimit' )
 			->will( $this->returnValue( 0 ) );
 
 		$count = $this->setupStore( 'default' )

--- a/tests/phpunit/Unit/SPARQLStore/QueryEngine/QueryEngineTest.php
+++ b/tests/phpunit/Unit/SPARQLStore/QueryEngine/QueryEngineTest.php
@@ -356,6 +356,45 @@ class QueryEngineTest extends \PHPUnit_Framework_TestCase {
 		);
 	}
 
+	public function testGetImmediateEmptyQueryResultForLimitLessThanOne() {
+
+		$repositoryResult = $this->getMockBuilder( '\SMW\SPARQLStore\QueryEngine\RepositoryResult' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$connection = $this->getMockBuilder( '\SMW\SPARQLStore\RepositoryConnection' )
+			->disableOriginalConstructor()
+			->getMockForAbstractClass();
+
+		$store = $this->getMockBuilder( '\SMW\SPARQLStore\SPARQLStore' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$compoundConditionBuilder = $this->getMockBuilder( '\SMW\SPARQLStore\QueryEngine\CompoundConditionBuilder' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$compoundConditionBuilder->expects( $this->never() )
+			->method( 'setSortKeys' )
+			->will( $this->returnValue( $compoundConditionBuilder ) );
+
+		$description = $this->getMockForAbstractClass( '\SMW\Query\Language\Description' );
+
+		$instance = new QueryEngine(
+			$connection,
+			$compoundConditionBuilder,
+			new QueryResultFactory( $store )
+		);
+
+		$query = new Query( $description );
+		$query->setUnboundLimit( -1 );
+
+		$this->assertInstanceOf(
+			'\SMWQueryResult',
+			$instance->getQueryResult( $query )
+		);
+	}
+
 	public function testInstanceQueryResultForMockedSingletonCompostion() {
 
 		$repositoryResult = $this->getMockBuilder( '\SMW\SPARQLStore\QueryEngine\RepositoryResult' )

--- a/tests/phpunit/Unit/SQLStore/QueryEngine/QueryEngineTest.php
+++ b/tests/phpunit/Unit/SQLStore/QueryEngine/QueryEngineTest.php
@@ -84,4 +84,36 @@ class QueryEngineTest extends \PHPUnit_Framework_TestCase {
 		);
 	}
 
+	public function testGetImmediateEmptyQueryResultForLimitLessThanOne() {
+
+		$connection = $this->getMockBuilder( '\SMW\MediaWiki\Database' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$this->store->expects( $this->never() )
+			->method( 'getConnection' )
+			->will( $this->returnValue( $connection ) );
+
+		$this->querySegmentListBuilder->expects( $this->any() )
+			->method( 'getErrors' )
+			->will( $this->returnValue( array() ) );
+
+		$description = $this->getMockForAbstractClass( '\SMW\Query\Language\Description' );
+
+		$instance = new QueryEngine(
+			$this->store,
+			$this->querySegmentListBuilder,
+			$this->querySegmentListProcessor,
+			$this->engineOptions
+		);
+
+		$query = new Query( $description );
+		$query->setUnboundLimit( -1 );
+
+		$this->assertInstanceOf(
+			'\SMWQueryResult',
+			$instance->getQueryResult( $query )
+		);
+	}
+
 }


### PR DESCRIPTION
Instead of trying to resolve a query (and its segments) before returning a link to `Special:Ask`, create the link early in the process without the need to use a `DB` or `Respository` connection (which improves performance of pages that contain a lot of those "search on request" queries).