### PR TITLE
Make failed queries discoverable

### DIFF
--- a/includes/parserhooks/AskParserFunction.php
+++ b/includes/parserhooks/AskParserFunction.php
@@ -199,6 +199,15 @@ class AskParserFunction {
 
 	private function createQueryProfile( $query, $format, $duration ) {
 
+		// In case of an query error add a marker to the subject for
+		// discoverability of a failed query
+		if ( $query->getErrors() !== array() ) {
+			$this->parserData->getSemanticData()->addPropertyObjectValue(
+				new DIProperty( '_ERRP' ),
+				DIProperty::newFromUserLabel( '_ASK' )->getDiWikiPage()
+			);
+		}
+
 		$queryProfileAnnotatorFactory = $this->applicationFactory->newQueryProfileAnnotatorFactory();
 
 		$jointProfileAnnotator = $queryProfileAnnotatorFactory->newJointProfileAnnotator(

--- a/tests/phpunit/includes/parserhooks/AskParserFunctionTest.php
+++ b/tests/phpunit/includes/parserhooks/AskParserFunctionTest.php
@@ -287,6 +287,45 @@ class AskParserFunctionTest extends \PHPUnit_Framework_TestCase {
 		}
 	}
 
+	public function testEmbeddedQueryWithError() {
+
+		$params = array(
+			'[[--ABC·|DEF::123]]',
+			'format=table'
+		);
+
+		$expected = array(
+			'propertyCount'  => 2,
+			'propertyKeys'   => array( '_ASK', '_ERRP' ),
+		);
+
+		$parserData = $this->applicationFactory->newParserData(
+			Title::newFromText( __METHOD__ ),
+			new ParserOutput()
+		);
+
+		$messageFormatter = $this->getMockBuilder( '\SMW\MessageFormatter' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$circularReferenceGuard = $this->getMockBuilder( '\SMW\CircularReferenceGuard' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$instance = new AskParserFunction(
+			$parserData,
+			$messageFormatter,
+			$circularReferenceGuard
+		);
+
+		$instance->parse( $params );
+
+		$this->semanticDataValidator->assertThatPropertiesAreSet(
+			$expected,
+			$parserData->getSemanticData()
+		);
+	}
+
 	public function queryDataProvider() {
 
 		$categoryNS = Localizer::getInstance()->getNamespaceTextById( NS_CATEGORY );


### PR DESCRIPTION
Add a `_ERRP` annotation for queries with errors to make them discoverable
using the "[[Has improper value for::Has query]]" property list.

refs #893