### PR TITLE
Do not replace `_` in ImportValueParser

### DIFF
--- a/src/DataValues/ValueParsers/ImportValueParser.php
+++ b/src/DataValues/ValueParsers/ImportValueParser.php
@@ -172,7 +172,7 @@ class ImportValueParser implements ValueParser {
 			}
 
 			list( $secname, $typestring ) = explode( '|', $importDefintion, 2 );
-			$list[str_replace( '_', ' ', trim( $secname ) )] = $typestring;
+			$list[trim( $secname )] = $typestring;
 		}
 
 		return array( $uri, $name, $list );

--- a/tests/phpunit/includes/DataValues/ValueParsers/ImportValueParserTest.php
+++ b/tests/phpunit/includes/DataValues/ValueParsers/ImportValueParserTest.php
@@ -208,6 +208,19 @@ class ImportValueParserTest extends \PHPUnit_Framework_TestCase {
 			)
 		);
 
+		#2 mbox_sha1sum
+		$provider[] = array(
+			" http://xmlns.com/foaf/0.1/|[http://www.foaf-project.org/ Friend Of A Friend]\n   mbox_sha1sum|Type:Text\n",
+			'Foaf:mbox_sha1sum',
+			array(
+				'Foaf',
+				'mbox_sha1sum',
+				'http://xmlns.com/foaf/0.1/',
+				'[http://www.foaf-project.org/ Friend Of A Friend]',
+				'Type:Text'
+			)
+		);
+
 		return $provider;
 	}
 


### PR DESCRIPTION
Noted by [0] with an example at [1].

[0] http://wikimedia.7.x6.nabble.com/quot-No-type-definition-was-found-quot-in-external-vocabulary-td5054552.html

[1] http://sandbox.semantic-mediawiki.org/wiki/Property:Mbox_sha1sum