### PR TITLE
Check for property reference in non-fixed tables, refs #1216

### DIFF
--- a/src/SQLStore/PropertyTableOutdatedReferenceDisposer.php
+++ b/src/SQLStore/PropertyTableOutdatedReferenceDisposer.php
@@ -121,6 +121,18 @@ class PropertyTableOutdatedReferenceDisposer {
 			);
 		}
 
+		// If the property table is not a fixed table (== assigns a whole
+		// table to a specific property with the p_id column being suppressed)
+		// then check for the p_id field
+		if ( $row === false && !$proptable->isFixedPropertyTable() ) {
+			$row = $db->selectRow(
+				$proptable->getName(),
+				array( 'p_id' ),
+				array( 'p_id' => $id ),
+				__METHOD__
+			);
+		}
+
 		return $row !== false;
 	}
 

--- a/tests/phpunit/Integration/ByJsonScript/Fixtures/p-0207 set to use undeclared property.json
+++ b/tests/phpunit/Integration/ByJsonScript/Fixtures/p-0207 set to use undeclared property.json
@@ -1,0 +1,42 @@
+{
+	"description": "Verify that undeclared properties with references remain after rebuildData run",
+	"properties": [
+		{
+			"name": "Has number",
+			"contents": "[[Has type::Number]]"
+		}
+	],
+	"subjects": [
+		{
+			"name": "Example/0207",
+			"contents": "{{#set:Has number=12}} {{#set:Undeclared property=abc}} [[Undeclared prop::0207]]"
+		}
+	],
+	"maintenance-run": {
+		"rebuildData": true
+	},
+	"parser-testcases": [
+		{
+			"about": "#0 Rebuild + clear cache to verify that the disposer (#1216) didn't remove undeclared properties that still contain references",
+			"subject": "Example/0207",
+			"store": {
+				"clear-cache": true,
+				"semantic-data": {
+					"strict-mode-valuematch": false,
+					"propertyCount": 5,
+					"propertyKeys": [ "Has_number", "_ERRP", "_SKEY", "_MDAT", "Undeclared_property", "Undeclared_prop" ],
+					"propertyValues": [ 12, "Abc", "0207" ]
+				}
+			}
+		}
+	],
+	"settings": {
+		"wgContLang": "en",
+		"smwgPageSpecialProperties": [ "_MDAT" ]
+	},
+	"meta": {
+		"version": "0.1",
+		"is-incomplete": false,
+		"debug": false
+	}
+}


### PR DESCRIPTION
Follow-up on #1216 + integration test to verify that the state of undeclared properties with references remains untouched.