### PR TITLE
Support for QueryResult caching

### DIFF
--- a/includes/ParserData.php
+++ b/includes/ParserData.php
@@ -296,7 +296,7 @@ class ParserData {
 			$storeUpdater->doUpdate();
 		} );
 
-		$deferredCallableUpdate->setOrigin( __METHOD__ );
+		$deferredCallableUpdate->setOrigin( __METHOD__ . ' :: ' . $this->semanticData->getSubject()->getHash() );
 
 		$deferredCallableUpdate->enabledDeferredUpdate(
 			$enabledDeferredUpdate

--- a/includes/Settings.php
+++ b/includes/Settings.php
@@ -148,6 +148,10 @@ class Settings extends Options {
 			'smwgFulltextSearchMinTokenSize' => $GLOBALS['smwgFulltextSearchMinTokenSize'],
 			'smwgFulltextLanguageDetection' => $GLOBALS['smwgFulltextLanguageDetection'],
 			'smwgQTemporaryTablesAutoCommitMode' => $GLOBALS['smwgQTemporaryTablesAutoCommitMode'],
+			'smwgQueryResultCacheType' => $GLOBALS['smwgQueryResultCacheType'],
+			'smwgQueryResultCacheLifetime' => $GLOBALS['smwgQueryResultCacheLifetime'],
+			'smwgQueryResultNonEmbeddedCacheLifetime' => $GLOBALS['smwgQueryResultNonEmbeddedCacheLifetime'],
+			'smwgQueryResultCacheRefreshOnPurge' => $GLOBALS['smwgQueryResultCacheRefreshOnPurge'],
 		);
 
 		$settings = $settings + array(

--- a/includes/storage/SQLStore/SMW_SQLStore3.php
+++ b/includes/storage/SQLStore/SMW_SQLStore3.php
@@ -313,7 +313,7 @@ class SMWSQLStore3 extends SMWStore {
 		$result = null;
 		$start = microtime( true );
 
-		if ( \Hooks::run( 'SMW::Store::BeforeQueryResultLookupComplete', array( $this, $query, &$result ) ) ) {
+		if ( \Hooks::run( 'SMW::Store::BeforeQueryResultLookupComplete', array( $this, $query, &$result, $this->factory->newSlaveQueryEngine() ) ) ) {
 			$result = $this->fetchQueryResult( $query );
 		}
 

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -67,6 +67,7 @@
        <var name="smwgEnabledFulltextSearch" value="false"/>
        <var name="smwgEnabledHttpDeferredJobRequest" value="false"/>
        <var name="smwgEnabledQueryDependencyLinksStore" value="true"/>
+       <var name="smwgQueryResultCacheType" value="hash"/>
        <var name="benchmarkQueryRepetitionExecutionThreshold" value="5"/>
        <var name="benchmarkQueryLimit" value="500"/>
        <var name="benchmarkQueryOffset" value="0"/>

--- a/src/ApplicationFactory.php
+++ b/src/ApplicationFactory.php
@@ -166,6 +166,15 @@ class ApplicationFactory {
 	}
 
 	/**
+	 * @since 2.2
+	 *
+	 * @return CacheFactory
+	 */
+	public function getCacheFactory() {
+		return $this->callbackLoader->singleton( 'CacheFactory', $this->getSettings()->get( 'smwgCacheType' ) );
+	}
+
+	/**
 	 * @since 2.5
 	 *
 	 * @param string|null $source
@@ -345,6 +354,15 @@ class ApplicationFactory {
 	}
 
 	/**
+	 * @since 2.5
+	 *
+	 * @return CachedQueryResultPrefetcher
+	 */
+	public function getCachedQueryResultPrefetcher() {
+		return $this->callbackLoader->singleton( 'CachedQueryResultPrefetcher' );
+	}
+
+	/**
 	 * @since 2.4
 	 *
 	 * @return MediaWikiNsContentReader
@@ -429,6 +447,15 @@ class ApplicationFactory {
 	 */
 	public function getQueryFactory() {
 		return $this->callbackLoader->singleton( 'QueryFactory' );
+	}
+
+	/**
+	 * @since 2.5
+	 *
+	 * @return LoggerInterface
+	 */
+	public function getMediaWikiLogger() {
+		return $this->callbackLoader->singleton( 'MediaWikiLogger' );
 	}
 
 	private static function registerBuilder( CallbackLoader $callbackLoader = null ) {

--- a/src/CacheFactory.php
+++ b/src/CacheFactory.php
@@ -146,15 +146,7 @@ class CacheFactory {
 	 * @return BlobStore
 	 */
 	public function newBlobStore( $namespace, $cacheType = null, $cacheLifetime = 0 ) {
-
-		$blobStore = $this->callbackInstantiator->load( 'BlobStore', $namespace, $cacheType, $cacheLifetime );
-
-		// If CACHE_NONE is selected, disable the usage
-		$blobStore->setUsageState(
-			$cacheType !== CACHE_NONE
-		);
-
-		return $blobStore;
+		return $this->callbackInstantiator->load( 'BlobStore', $namespace, $cacheType, $cacheLifetime );
 	}
 
 }

--- a/src/CachedPropertyValuesPrefetcher.php
+++ b/src/CachedPropertyValuesPrefetcher.php
@@ -31,6 +31,11 @@ class CachedPropertyValuesPrefetcher {
 	const VERSION = '0.4.1';
 
 	/**
+	 * Namespace occupied by the BlobStore
+	 */
+	const CACHE_NAMESPACE = 'smw:pvp:store';
+
+	/**
 	 * @var Store
 	 */
 	private $store;

--- a/src/CachedQueryResultPrefetcher.php
+++ b/src/CachedQueryResultPrefetcher.php
@@ -1,0 +1,309 @@
+<?php
+
+namespace SMW;
+
+use Onoi\BlobStore\BlobStore;
+use SMWQuery as Query;
+use SMWQueryResult as QueryResult;
+use SMW\Store;
+use SMW\DIWikiPage;
+use SMW\QueryEngine;
+use SMW\QueryFactory;
+use Psr\Log\LoggerInterface;
+use Psr\Log\LoggerAwareInterface;
+
+/**
+ * The prefetcher only contains cached subject list from a computed a query
+ * condition. The result is processed before an individual
+ * query printer has access to the query result hence it does not interfere
+ * with the final string output manipulation.
+ *
+ * The main objective is to avoid unnecessary computing of results for queries
+ * that represent the same query signature. PrintRequests as part of a QueryResult
+ * object are not cached and are not part of a query signature.
+ *
+ * Cache eviction is carried out either manually (action=purge) or executed
+ * through the QueryDepedencyLinksStore.
+ *
+ * @license GNU GPL v2+
+ * @since 2.5
+ *
+ * @author mwjames
+ */
+class CachedQueryResultPrefetcher implements QueryEngine, LoggerAwareInterface {
+
+	/**
+	 * Update this version number when the serialization format
+	 * changes.
+	 */
+	const VERSION = '0.2';
+
+	/**
+	 * Namespace occupied by the BlobStore
+	 */
+	const CACHE_NAMESPACE = 'smw:query:store';
+
+	/**
+	 * @var Store
+	 */
+	private $store;
+
+	/**
+	 * @var QueryFactory
+	 */
+	private $queryFactory;
+
+	/**
+	 * @var BlobStore
+	 */
+	private $blobStore;
+
+	/**
+	 * @var QueryEngine
+	 */
+	private $queryEngine;
+
+	/**
+	 * @var integer|boolean
+	 */
+	private $nonEmbeddedCacheLifetime = false;
+
+	/**
+	 * @var integer
+	 */
+	private $start = 0;
+
+	/**
+	 * @var boolean
+	 */
+	private $enabled = true;
+
+	/**
+	 * loggerInterface
+	 */
+	private $logger;
+
+	/**
+	 * @since 2.5
+	 *
+	 * @param Store $store
+	 * @param QueryFactory $queryFactory
+	 * @param BlobStore $blobStore
+	 */
+	public function __construct( Store $store, QueryFactory $queryFactory, BlobStore $blobStore ) {
+		$this->store = $store;
+		$this->queryFactory = $queryFactory;
+		$this->blobStore = $blobStore;
+	}
+
+	/**
+	 * @see LoggerAwareInterface::setLogger
+	 *
+	 * @since 2.5
+	 *
+	 * @param LoggerInterface $logger
+	 */
+	public function setLogger( LoggerInterface $logger ) {
+		$this->logger = $logger;
+	}
+
+	/**
+	 * @since 2.5
+	 *
+	 * @param QueryEngine $queryEngine
+	 */
+	public function setQueryEngine( QueryEngine $queryEngine ) {
+		$this->queryEngine = $queryEngine;
+	}
+
+	/**
+	 * @since 2.5
+	 *
+	 * @param QueryEngine $queryEngine
+	 */
+	public function disableCache() {
+		$this->enabled = false;
+	}
+
+	/**
+	 * @since 2.5
+	 *
+	 * @param integer|boolean $nonEmbeddedCacheLifetime
+	 */
+	public function setNonEmbeddedCacheLifetime( $nonEmbeddedCacheLifetime ) {
+		$this->nonEmbeddedCacheLifetime = $nonEmbeddedCacheLifetime;
+	}
+
+	/**
+	 * @since 2.5
+	 *
+	 * @param Query $query
+	 *
+	 * @return QueryResult|string
+	 */
+	public function getQueryResult( Query $query ) {
+
+		if ( !$this->queryEngine instanceof QueryEngine ) {
+			throw new RuntimeException( "Missing a QueryEngine instance." );
+		}
+
+		if ( !$this->isEnabled( $query ) || $query->getLimit() < 1 ) {
+			return $this->queryEngine->getQueryResult( $query );
+		}
+
+		$this->start = microtime( true );
+
+		// Use the queryId without a subject to reuse the content among other
+		// entities that may have embedded a query with the same query signature
+		$queryId = $query->getQueryId();
+
+		$container = $this->blobStore->read(
+			$this->getHashFrom( $queryId )
+		);
+
+		if ( $container->has( 'results' ) ) {
+			return $this->newQueryResultFromCache( $queryId, $query, $container );
+		}
+
+		$queryResult = $this->queryEngine->getQueryResult( $query );
+
+		if ( $this->isEnabled( $query ) && $queryResult instanceof QueryResult ) {
+			$this->addQueryResultToCache( $queryResult, $queryId, $container, $query );
+		}
+
+		return $queryResult;
+	}
+
+	/**
+	 * @since 2.5
+	 *
+	 * @param DIWikiPage|array $list
+	 */
+	public function resetCacheBy( $item ) {
+
+		if ( !is_array( $item ) ) {
+			$item = array( $item );
+		}
+
+		foreach ( $item as $id ) {
+			$this->blobStore->delete( $this->getHashFrom( $id ) );
+		}
+	}
+
+	private function isEnabled( $query ) {
+		return $this->enabled && $this->blobStore->canUse() && ( $query->getContextPage() !== null || ( $query->getContextPage() === null && $this->nonEmbeddedCacheLifetime > 0 ) );
+	}
+
+	private function newQueryResultFromCache( $queryId, $query, $container ) {
+
+		$results = array();
+
+		foreach ( $container->get( 'results' ) as $hash ) {
+			$results[] = DIWikiPage::doUnserialize( $hash );
+		}
+
+		$queryResult = $this->queryFactory->newQueryResult(
+			$this->store,
+			$query,
+			$results,
+			$container->get( 'continue' )
+		);
+
+		$queryResult->setCountValue( $container->get( 'count' ) );
+		$queryResult->setFromCache( true );
+
+		$time = round( ( microtime( true ) - $this->start ), 5 );
+
+		$this->log( 'QueryResult from cache in (sec): ' . $time . " ($queryId) " );
+
+		return $queryResult;
+	}
+
+	private function addQueryResultToCache( $queryResult, $queryId, $container, $query ) {
+
+		$callback = function() use( $queryResult, $queryId, $container, $query ) {
+			$this->doCacheQueryResult( $queryResult, $queryId, $container, $query );
+		};
+
+		$deferredCallableUpdate = ApplicationFactory::getInstance()->newDeferredCallableUpdate(
+			$callback
+		);
+
+		$deferredCallableUpdate->setOrigin( __METHOD__ );
+		$deferredCallableUpdate->setFingerprint( __METHOD__ . $queryId );
+		$deferredCallableUpdate->pushToUpdateQueue();
+	}
+
+	private function doCacheQueryResult( $queryResult, $queryId, $container, $query ) {
+
+		$time = round( ( microtime( true ) - $this->start ), 5 );
+		$results = array();
+
+		// Keep the simple string representation to avoid unnecessary data cruft
+		// during using PHP serialize( ... )
+		foreach ( $queryResult->getResults() as $dataItem ) {
+			$results[] = $dataItem->getSerialization();
+		}
+
+		$container->set( 'results', $results );
+		$container->set( 'continue', $queryResult->hasFurtherResults() );
+		$container->set( 'count', $queryResult->getCountValue() );
+
+		$queryResult->reset();
+		$contextPage = $query->getContextPage();
+
+		if ( $contextPage === null ) {
+			$container->setExpiryInSeconds( $this->nonEmbeddedCacheLifetime );
+			$hash = 'nonEmbedded';
+		} else {
+			$this->addToLinkedList( $contextPage, $queryId );
+			$hash = $contextPage->getHash();
+		}
+
+		$this->blobStore->save(
+			$container
+		);
+
+		$this->log( 'QueryResult from backend in (sec): ' . $time . " ($queryId) " . $hash );
+
+		return $queryResult;
+	}
+
+	private function addToLinkedList( $contextPage, $queryId ) {
+
+		// Ensure that without QueryDependencyLinksStore being enabled recorded
+		// subjects related to a query can be discoverable and purged separately
+		$container = $this->blobStore->read(
+			$this->getHashFrom( $contextPage )
+		);
+
+		// If a subject gets purged the the linked list of queries associated
+		// with that subject allows for an immediate associated removal
+		$container->addToLinkedList(
+			$this->getHashFrom( $queryId )
+		);
+
+		$this->blobStore->save(
+			$container
+		);
+	}
+
+	private function getHashFrom( $subject ) {
+
+		if ( $subject instanceof DIWikiPage ) {
+			$subject = $subject->getHash();
+		}
+
+		return md5( $subject . self::VERSION );
+	}
+
+	private function log( $message, $context = array() ) {
+
+		if ( $this->logger === null ) {
+			return;
+		}
+
+		$this->logger->info( $message, $context );
+	}
+
+}

--- a/src/HashBuilder.php
+++ b/src/HashBuilder.php
@@ -61,6 +61,18 @@ class HashBuilder {
 	}
 
 	/**
+	 * @since 2.5
+	 *
+	 * @param array $hashableContent
+	 * @param string $prefix
+	 *
+	 * @return string
+	 */
+	public static function createFromArray( array $hashableContent, $prefix = '' ) {
+		return $prefix . md5( json_encode( $hashableContent ) );
+	}
+
+	/**
 	 * @since 2.4
 	 *
 	 * @return string

--- a/src/MediaWiki/Hooks/ArticlePurge.php
+++ b/src/MediaWiki/Hooks/ArticlePurge.php
@@ -3,6 +3,8 @@
 namespace SMW\MediaWiki\Hooks;
 
 use SMW\ApplicationFactory;
+use SMW\Cache\CacheFactory;
+use SMW\DIWikiPage;
 use WikiPage;
 
 /**
@@ -46,6 +48,11 @@ class ArticlePurge {
 			$cache->delete(
 				$cacheFactory->getFactboxCacheKey( $pageId )
 			);
+		}
+
+		if ( $settings->get( 'smwgQueryResultCacheRefreshOnPurge' ) ) {
+			$cachedQueryResultPrefetcher = $applicationFactory->getCachedQueryResultPrefetcher();
+			$cachedQueryResultPrefetcher->resetCacheBy( DIWikiPage::newFromTitle( $wikiPage->getTitle() ) );
 		}
 
 		return true;

--- a/src/QueryEngine.php
+++ b/src/QueryEngine.php
@@ -10,7 +10,7 @@ use SMWQueryResult as QueryResult;
  * provide the filtering and matching process for specific conditions against a
  * select back-end.
  *
- * @license GNU GPL v2
+ * @license GNU GPL v2+
  * @since 2.5
  *
  * @author mwjames

--- a/src/QueryFactory.php
+++ b/src/QueryFactory.php
@@ -9,6 +9,7 @@ use SMW\Query\ProfileAnnotatorFactory;
 use SMW\Query\ConfigurableQueryCreator;
 use SMWQuery as Query;
 use SMWQueryParser as QueryParser;
+use SMWQueryResult as QueryResult;
 
 /**
  * @license GNU GPL v2+
@@ -88,6 +89,29 @@ class QueryFactory {
 	 */
 	public function newQueryParser( $queryFeatures = false ) {
 		return new QueryParser( $queryFeatures );
+	}
+
+	/**
+	 * @since 2.5
+	 *
+	 * @param Store $store
+	 * @param Query $query
+	 * @param DIWikiPage[]|[] $results = array()
+	 * @param boolean $continue
+	 *
+	 * @return QueryResult
+	 */
+	public function newQueryResult( Store $store, Query $query, $results = array(), $continue = false ) {
+
+		$queryResult =  new QueryResult(
+			$query->getDescription()->getPrintrequests(),
+			$query,
+			$results,
+			$store,
+			$continue
+		);
+
+		return $queryResult;
 	}
 
 	/**

--- a/src/SPARQLStore/SPARQLStore.php
+++ b/src/SPARQLStore/SPARQLStore.php
@@ -274,7 +274,7 @@ class SPARQLStore extends Store {
 		$result = null;
 		$start = microtime( true );
 
-		if ( \Hooks::run( 'SMW::Store::BeforeQueryResultLookupComplete', array( $this, $query, &$result ) ) ) {
+		if ( \Hooks::run( 'SMW::Store::BeforeQueryResultLookupComplete', array( $this, $query, &$result, $this->factory->newMasterQueryEngine() ) ) ) {
 			$result = $this->fetchQueryResult( $query );
 		}
 

--- a/src/SPARQLStore/SPARQLStoreFactory.php
+++ b/src/SPARQLStore/SPARQLStoreFactory.php
@@ -82,7 +82,13 @@ class SPARQLStoreFactory {
 			$engineOptions
 		);
 
-		return $queryEngine;
+		$cachedQueryResultPrefetcher = ApplicationFactory::getInstance()->getCachedQueryResultPrefetcher();
+
+		$cachedQueryResultPrefetcher->setQueryEngine(
+			$queryEngine
+		);
+
+		return $cachedQueryResultPrefetcher;
 	}
 
 	/**

--- a/src/SQLStore/QueryDependency/QueryResultDependencyListResolver.php
+++ b/src/SQLStore/QueryDependency/QueryResultDependencyListResolver.php
@@ -122,6 +122,8 @@ class QueryResultDependencyListResolver {
 			$id
 		);
 
+		wfDebugLog( 'smw', 'getDependencyListByLateRetrieval ' . count( $dependencyList ) );
+
 		// Avoid a possible memory-leak by clearing the retrieved list
 		$entityListAccumulator->pruneEntityList(
 			$id

--- a/src/SQLStore/SQLStoreFactory.php
+++ b/src/SQLStore/SQLStoreFactory.php
@@ -62,7 +62,14 @@ class SQLStoreFactory {
 	 * @return QueryEngine
 	 */
 	public function newMasterQueryEngine() {
-		return $this->queryEngineFactory->newQueryEngine();
+
+		$cachedQueryResultPrefetcher = ApplicationFactory::getInstance()->getCachedQueryResultPrefetcher();
+
+		$cachedQueryResultPrefetcher->setQueryEngine(
+			$this->queryEngineFactory->newQueryEngine()
+		);
+
+		return $cachedQueryResultPrefetcher;
 	}
 
 	/**
@@ -71,7 +78,7 @@ class SQLStoreFactory {
 	 * @return QueryEngine
 	 */
 	public function newSlaveQueryEngine() {
-		return $this->queryEngineFactory->newQueryEngine();
+		return $this->newMasterQueryEngine();
 	}
 
 	/**
@@ -97,7 +104,7 @@ class SQLStoreFactory {
 	public function newMasterConceptCache() {
 
 		$conceptQueryResolver = new ConceptQueryResolver(
-			$this->newMasterQueryEngine()
+			$this->queryEngineFactory->newQueryEngine()
 		);
 
 		$conceptQueryResolver->setConceptFeatures(

--- a/tests/phpunit/Integration/ByJsonScript/ByJsonScriptFixtureTestCaseRunnerTest.php
+++ b/tests/phpunit/Integration/ByJsonScript/ByJsonScriptFixtureTestCaseRunnerTest.php
@@ -98,6 +98,7 @@ class ByJsonScriptFixtureTestCaseRunnerTest extends ByJsonTestCaseProvider {
 
 		// Make sure LocalSettings don't interfere with the default settings
 		$GLOBALS['smwgDVFeatures'] = $GLOBALS['smwgDVFeatures'] & ~SMW_DV_NUMV_USPACE;
+		$this->testEnvironment->addConfiguration( 'smwgQueryResultCacheType', false );
 	}
 
 	/**
@@ -179,6 +180,7 @@ class ByJsonScriptFixtureTestCaseRunnerTest extends ByJsonTestCaseProvider {
 			'smwgEnabledFulltextSearch',
 			'smwgFulltextDeferredUpdate',
 			'smwgPropertyZeroCountDisplay',
+			'smwgQueryResultCacheType',
 
 			// MW related
 			'wgLanguageCode',

--- a/tests/phpunit/Integration/ByJsonScript/Fixtures/f-0801.json
+++ b/tests/phpunit/Integration/ByJsonScript/Fixtures/f-0801.json
@@ -160,9 +160,8 @@
 		}
 	],
 	"settings": {
-		"smwgPageSpecialProperties": [
-			"_MDAT"
-		],
+		"smwgPageSpecialProperties": [ "_MDAT" ],
+		"smwgQueryResultCacheType": false,
 		"smwgNamespacesWithSemanticLinks": {
 			"NS_MAIN": true,
 			"SMW_NS_PROPERTY": true

--- a/tests/phpunit/Integration/ByJsonScript/Fixtures/f-0802.json
+++ b/tests/phpunit/Integration/ByJsonScript/Fixtures/f-0802.json
@@ -63,9 +63,8 @@
 		}
 	],
 	"settings": {
-		"smwgPageSpecialProperties": [
-			"_MDAT"
-		],
+		"smwgPageSpecialProperties": [ "_MDAT" ],
+		"smwgQueryResultCacheType": false,
 		"smwgNamespacesWithSemanticLinks": {
 			"NS_MAIN": true,
 			"SMW_NS_PROPERTY": true

--- a/tests/phpunit/Integration/ByJsonScript/Fixtures/p-0907.json
+++ b/tests/phpunit/Integration/ByJsonScript/Fixtures/p-0907.json
@@ -1,0 +1,81 @@
+{
+	"description": "Test the QueryResult cache feature (#1251, `wgContLang=en`, `wgLang=en`, `smwgQueryResultCacheType=true`)",
+	"setup": [
+		{
+			"namespace": "SMW_NS_PROPERTY",
+			"page": "Has page",
+			"contents": "[[Has type::Page]]"
+		},
+		{
+			"page": "Example/P0907/1",
+			"contents": "[[Has page::ABC]]"
+		},
+		{
+			"page": "Example/P0907/2",
+			"contents": "{{#ask:[[Has page::ABC]] |sort=Has page |order=asc |limit=10 }}"
+		}
+	],
+	"tests": [
+		{
+			"type": "parser",
+			"about": "#0",
+			"subject": "Example/P0907/2",
+			"store": {
+				"clear-cache": true
+			},
+			"assert-store": {
+				"semantic-data": {
+					"strict-mode-valuematch": false,
+					"propertyCount": 3,
+					"propertyKeys": [
+						"_MDAT",
+						"_SKEY",
+						"_ASK"
+					]
+				}
+			},
+			"assert-output": {
+				"to-contain": [
+					"Example/P0907/1"
+				]
+			}
+		},
+		{
+			"type": "query",
+			"about": "#1 query from the previous #ask with same description is fetched from cache",
+			"subject": "Foo",
+			"condition": "[[Has page::ABC]]",
+			"printouts": [],
+			"parameters": {
+				"limit": 10,
+				"sort": {
+					"Has_page": "ASC"
+				}
+			},
+			"queryresult": {
+				"isFromCache": true,
+				"count": 1,
+				"results": [
+					"Example/P0907/1#0##"
+				]
+			}
+		}
+	],
+	"settings": {
+		"wgContLang": "en",
+		"wgLang": "en",
+		"smwgQueryResultCacheType": "hash",
+		"smwgPageSpecialProperties": [
+			"_MDAT"
+		],
+		"smwgNamespacesWithSemanticLinks": {
+			"NS_MAIN": true,
+			"SMW_NS_PROPERTY": true
+		}
+	},
+	"meta": {
+		"version": "2",
+		"is-incomplete": false,
+		"debug": false
+	}
+}

--- a/tests/phpunit/Integration/ByJsonScript/QueryTestCaseInterpreter.php
+++ b/tests/phpunit/Integration/ByJsonScript/QueryTestCaseInterpreter.php
@@ -88,6 +88,24 @@ class QueryTestCaseInterpreter {
 	}
 
 	/**
+	 * @since 2.5
+	 *
+	 * @return DIWikiPage|null
+	 */
+	public function getSubject() {
+		return isset( $this->contents['subject'] ) ? DIWikiPage::newFromText( $this->contents['subject'] ) : null;
+	}
+
+	/**
+	 * @since 2.5
+	 *
+	 * @return boolean
+	 */
+	public function isFromCache() {
+		return isset( $this->contents['queryresult']['isFromCache'] ) ? (bool)$this->contents['queryresult']['isFromCache'] : null;
+	}
+
+	/**
 	 * @since 2.2
 	 *
 	 * @return array

--- a/tests/phpunit/Integration/ByJsonScript/QueryTestCaseProcessor.php
+++ b/tests/phpunit/Integration/ByJsonScript/QueryTestCaseProcessor.php
@@ -95,9 +95,12 @@ class QueryTestCaseProcessor extends \PHPUnit_Framework_TestCase {
 
 		$query->querymode = $queryTestCaseInterpreter->getQueryMode();
 		$query->setLimit( $queryTestCaseInterpreter->getLimit() );
+
 		$query->setOffset( $queryTestCaseInterpreter->getOffset() );
 		$query->setExtraPrintouts( $queryTestCaseInterpreter->getExtraPrintouts() );
+
 		$query->setSortKeys( $queryTestCaseInterpreter->getSortKeys() );
+		$query->setContextPage( $queryTestCaseInterpreter->getSubject() );
 
 		if ( $queryTestCaseInterpreter->isRequiredToClearStoreCache() ) {
 			$this->getStore()->clear();
@@ -125,6 +128,14 @@ class QueryTestCaseProcessor extends \PHPUnit_Framework_TestCase {
 
 		if ( $queryTestCaseInterpreter->getExpectedErrorCount() > 0 ) {
 			return null;
+		}
+
+		if ( $queryTestCaseInterpreter->isFromCache() !== null ) {
+			$this->assertEquals(
+				$queryTestCaseInterpreter->isFromCache(),
+				$queryResult->isFromCache(),
+				'Failed asserting isFromCache for ' . $queryTestCaseInterpreter->isAbout()
+			);
 		}
 
 		$this->queryResultValidator->assertThatQueryResultHasSubjects(

--- a/tests/phpunit/Integration/Query/GeneralQueryDBIntegrationTest.php
+++ b/tests/phpunit/Integration/Query/GeneralQueryDBIntegrationTest.php
@@ -41,6 +41,8 @@ class GeneralQueryDBIntegrationTest extends MwDBaseUnitTestCase {
 		$this->dataValueFactory = DataValueFactory::getInstance();
 		$this->queryResultValidator = UtilityFactory::getInstance()->newValidatorFactory()->newQueryResultValidator();
 		$this->semanticDataFactory = UtilityFactory::getInstance()->newSemanticDataFactory();
+
+		$this->testEnvironment->addConfiguration( 'smwgQueryResultCacheType', false );
 	}
 
 	protected function tearDown() {
@@ -126,9 +128,7 @@ class GeneralQueryDBIntegrationTest extends MwDBaseUnitTestCase {
 		);
 
 		$query = new Query(
-			$description,
-			false,
-			false
+			$description
 		);
 
 		$query->querymode = Query::MODE_INSTANCES;

--- a/tests/phpunit/Integration/SPARQLStore/QueryResultLookupWithoutBaseStoreIntegrationTest.php
+++ b/tests/phpunit/Integration/SPARQLStore/QueryResultLookupWithoutBaseStoreIntegrationTest.php
@@ -3,6 +3,7 @@
 namespace SMW\Tests\Integration\SPARQLStore;
 
 use SMW\DataValueFactory;
+use SMW\ApplicationFactory;
 use SMW\DIProperty;
 use SMW\DIWikiPage;
 use SMW\Query\Language\NamespaceDescription as NamespaceDescription;
@@ -10,7 +11,6 @@ use SMW\Query\Language\SomeProperty as SomeProperty;
 use SMW\Query\Language\ThingDescription as ThingDescription;
 use SMW\Query\Language\ValueDescription as ValueDescription;
 use SMW\SPARQLStore\SPARQLStore;
-use SMW\StoreFactory;
 use SMW\Subobject;
 use SMW\Tests\Utils\SemanticDataFactory;
 use SMW\Tests\Utils\Validators\QueryResultValidator;
@@ -18,12 +18,7 @@ use SMWDINumber as DINumber;
 use SMWQuery as Query;
 
 /**
- *
- * @group SMW
- * @group SMWExtension
- * @group semantic-mediawiki-integration
- * @group semantic-mediawiki-sparql
- * @group semantic-mediawiki-query
+ * @group semantic-mediawiki
  *
  * @license GNU GPL v2+
  * @since 2.0
@@ -39,7 +34,7 @@ class QueryResultLookupWithoutBaseStoreIntegrationTest extends \PHPUnit_Framewor
 
 	protected function setUp() {
 
-		$this->store = StoreFactory::getStore();
+		$this->store = ApplicationFactory::getInstance()->getStore();
 
 		if ( !$this->store instanceof SPARQLStore ) {
 			$this->markTestSkipped( "Requires a SPARQLStore instance" );
@@ -56,6 +51,8 @@ class QueryResultLookupWithoutBaseStoreIntegrationTest extends \PHPUnit_Framewor
 		$this->queryResultValidator = new QueryResultValidator();
 		$this->semanticDataFactory = new SemanticDataFactory();
 		$this->dataValueFactory = DataValueFactory::getInstance();
+
+		ApplicationFactory::getInstance()->getCachedQueryResultPrefetcher()->disableCache();
 	}
 
 	public function testQuerySubjects_afterUpdatingSemanticData() {

--- a/tests/phpunit/JsonTestCaseFileHandler.php
+++ b/tests/phpunit/JsonTestCaseFileHandler.php
@@ -211,6 +211,11 @@ class JsonTestCaseFileHandler {
 			return constant( $settings[$key] );
 		}
 
+		// Needs special attention due to constant usage
+		if ( strpos( $key, 'CacheType' ) !== false && isset( $settings[$key] ) ) {
+			return $settings[$key] === false ? CACHE_NONE : defined( $settings[$key] ) ? constant( $settings[$key] ) : $settings[$key];
+		}
+
 		if ( isset( $settings[$key] ) ) {
 			return $settings[$key];
 		}

--- a/tests/phpunit/Unit/ApplicationFactoryTest.php
+++ b/tests/phpunit/Unit/ApplicationFactoryTest.php
@@ -237,6 +237,14 @@ class ApplicationFactoryTest extends \PHPUnit_Framework_TestCase {
 		);
 	}
 
+	public function testCanConstructCachedQueryResultPrefetcher() {
+
+		$this->assertInstanceOf(
+			'\SMW\CachedQueryResultPrefetcher',
+			$this->applicationFactory->getCachedQueryResultPrefetcher()
+		);
+	}
+
 	public function testCanConstructQueryFactory() {
 
 		$this->assertInstanceOf(

--- a/tests/phpunit/Unit/CachedQueryResultPrefetcherTest.php
+++ b/tests/phpunit/Unit/CachedQueryResultPrefetcherTest.php
@@ -1,0 +1,117 @@
+<?php
+
+namespace SMW\Tests;
+
+use SMW\CachedQueryResultPrefetcher;
+use SMW\DIWikiPage;
+use Onoi\BlobStore\BlobStore;
+
+/**
+ * @covers \SMW\CachedQueryResultPrefetcher
+ * @group semantic-mediawiki
+ *
+ * @license GNU GPL v2+
+ * @since 2.5
+ *
+ * @author mwjames
+ */
+class CachedQueryResultPrefetcherTest extends \PHPUnit_Framework_TestCase {
+
+	public function testCanConstruct() {
+
+		$store = $this->getMockBuilder( '\SMW\Store' )
+			->disableOriginalConstructor()
+			->getMockForAbstractClass();
+
+		$queryFactory = $this->getMockBuilder( '\SMW\QueryFactory' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$blobStore = $this->getMockBuilder( BlobStore::class )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$this->assertInstanceOf(
+			CachedQueryResultPrefetcher::class,
+			new CachedQueryResultPrefetcher( $store, $queryFactory, $blobStore )
+		);
+	}
+
+	public function testGetQueryResultForEmptyQuery() {
+
+		$queryFactory = $this->getMockBuilder( '\SMW\QueryFactory' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$blobStore = $this->getMockBuilder( BlobStore::class )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$store = $this->getMockBuilder( '\SMW\Store' )
+			->disableOriginalConstructor()
+			->getMockForAbstractClass();
+
+		$query = $this->getMockBuilder( '\SMWQuery' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$queryEngine = $this->getMockBuilder( '\SMW\QueryEngine' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$queryEngine->expects( $this->once() )
+			->method( 'getQueryResult' )
+			->with($this->identicalTo( $query ) );
+
+		$instance = new CachedQueryResultPrefetcher( $store, $queryFactory, $blobStore );
+		$instance->setQueryEngine( $queryEngine );
+
+		$instance->getQueryResult( $query );
+	}
+
+	public function testPurgeCacheByQueryList() {
+
+		$queryFactory = $this->getMockBuilder( '\SMW\QueryFactory' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$store = $this->getMockBuilder( '\SMW\Store' )
+			->disableOriginalConstructor()
+			->getMockForAbstractClass();
+
+		$blobStore = $this->getMockBuilder( BlobStore::class )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$blobStore->expects( $this->atLeastOnce() )
+			->method( 'delete' );
+
+		$instance = new CachedQueryResultPrefetcher( $store, $queryFactory, $blobStore );
+		$instance->resetCacheBy( array( 'Foo' ) );
+	}
+
+	public function testPurgeCacheBySubject() {
+
+		$subject = new DIWikiPage( 'Foo', NS_MAIN );
+
+		$store = $this->getMockBuilder( '\SMW\Store' )
+			->disableOriginalConstructor()
+			->getMockForAbstractClass();
+
+		$queryFactory = $this->getMockBuilder( '\SMW\QueryFactory' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$blobStore = $this->getMockBuilder( BlobStore::class )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$blobStore->expects( $this->atLeastOnce() )
+			->method( 'delete' )
+			->with( $this->equalTo( '39e2606942246606c5daa2ddfec4ace8' ) );
+
+		$instance = new CachedQueryResultPrefetcher( $store, $queryFactory, $blobStore );
+		$instance->resetCacheBy( $subject );
+	}
+
+}

--- a/tests/phpunit/Unit/DeferredCallableUpdateTest.php
+++ b/tests/phpunit/Unit/DeferredCallableUpdateTest.php
@@ -131,4 +131,39 @@ class DeferredCallableUpdateTest extends \PHPUnit_Framework_TestCase {
 		);
 	}
 
+	public function testFilterDuplicateQueueEntryByFingerprint() {
+
+		$this->testEnvironment->clearPendingDeferredUpdates();
+
+		$test = $this->getMockBuilder( '\stdClass' )
+			->disableOriginalConstructor()
+			->setMethods( array( 'doTest' ) )
+			->getMock();
+
+		$test->expects( $this->once() )
+			->method( 'doTest' );
+
+		$callback = function() use ( $test ) {
+			$test->doTest();
+		};
+
+		$instance = new DeferredCallableUpdate(
+			$callback
+		);
+
+		$instance->setFingerprint( __METHOD__ );
+		$instance->markAsPending( true );
+		$instance->pushToUpdateQueue();
+
+		$instance = new DeferredCallableUpdate(
+			$callback
+		);
+
+		$instance->setFingerprint( __METHOD__ );
+		$instance->markAsPending( true );
+		$instance->pushToUpdateQueue();
+
+		$this->testEnvironment->executePendingDeferredUpdates();
+	}
+
 }

--- a/tests/phpunit/Unit/MediaWiki/Hooks/ArticlePurgeTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Hooks/ArticlePurgeTest.php
@@ -5,7 +5,7 @@ namespace SMW\Tests\MediaWiki\Hooks;
 use SMW\ApplicationFactory;
 use SMW\Factbox\FactboxCache;
 use SMW\MediaWiki\Hooks\ArticlePurge;
-use SMW\Settings;
+use SMW\Tests\TestEnvironment;
 use SMW\Tests\Utils\Mock\MockTitle;
 use WikiPage;
 
@@ -21,6 +21,7 @@ use WikiPage;
 class ArticlePurgeTest extends \PHPUnit_Framework_TestCase {
 
 	private $applicationFactory;
+	private $testEnvironment;
 	private $cache;
 
 	protected function setUp() {
@@ -28,14 +29,14 @@ class ArticlePurgeTest extends \PHPUnit_Framework_TestCase {
 
 		$this->applicationFactory = ApplicationFactory::getInstance();
 
-		$settings = Settings::newFromArray( array(
+		$settings = array(
 			'smwgFactboxUseCache' => true,
 			'smwgCacheType'       => 'hash',
 			'smwgLinksInValues'   => false,
 			'smwgInlineErrors'    => true
-		) );
+		);
 
-		$this->applicationFactory->registerObject( 'Settings', $settings );
+		$this->testEnvironment = new TestEnvironment( $settings );
 
 		$this->cache = $this->applicationFactory->newCacheFactory()->newFixedInMemoryCache();
 		$this->applicationFactory->registerObject( 'Cache', $this->cache );
@@ -43,6 +44,7 @@ class ArticlePurgeTest extends \PHPUnit_Framework_TestCase {
 
 	public function tearDown() {
 		$this->applicationFactory->clear();
+		$this->testEnvironment->tearDown();
 
 		parent::tearDown();
 	}
@@ -67,14 +69,19 @@ class ArticlePurgeTest extends \PHPUnit_Framework_TestCase {
 		$wikiPage = new WikiPage( $setup['title'] );
 		$pageId   = $wikiPage->getTitle()->getArticleID();
 
-		$this->applicationFactory->getSettings()->set(
+		$this->testEnvironment->addConfiguration(
 			'smwgAutoRefreshOnPurge',
 			$setup['smwgAutoRefreshOnPurge']
 		);
 
-		$this->applicationFactory->getSettings()->set(
+		$this->testEnvironment->addConfiguration(
 			'smwgFactboxCacheRefreshOnPurge',
 			$setup['smwgFactboxCacheRefreshOnPurge']
+		);
+
+		$this->testEnvironment->addConfiguration(
+			'smwgQueryResultCacheRefreshOnPurge',
+			$setup['smwgQueryResultCacheRefreshOnPurge']
 		);
 
 		$instance = new ArticlePurge();
@@ -136,7 +143,8 @@ class ArticlePurgeTest extends \PHPUnit_Framework_TestCase {
 			array(
 				'title'  => $validIdTitle,
 				'smwgAutoRefreshOnPurge'         => true,
-				'smwgFactboxCacheRefreshOnPurge' => true
+				'smwgFactboxCacheRefreshOnPurge' => true,
+				'smwgQueryResultCacheRefreshOnPurge' => false
 			),
 			array(
 				'factboxPreProcess'      => false,
@@ -157,7 +165,8 @@ class ArticlePurgeTest extends \PHPUnit_Framework_TestCase {
 			array(
 				'title'  => $validIdTitle,
 				'smwgAutoRefreshOnPurge'         => false,
-				'smwgFactboxCacheRefreshOnPurge' => false
+				'smwgFactboxCacheRefreshOnPurge' => false,
+				'smwgQueryResultCacheRefreshOnPurge' => false
 			),
 			array(
 				'factboxPreProcess'      => false,
@@ -178,7 +187,8 @@ class ArticlePurgeTest extends \PHPUnit_Framework_TestCase {
 			array(
 				'title'  => $nullIdTitle,
 				'smwgAutoRefreshOnPurge'         => true,
-				'smwgFactboxCacheRefreshOnPurge' => true
+				'smwgFactboxCacheRefreshOnPurge' => true,
+				'smwgQueryResultCacheRefreshOnPurge' => false
 			),
 			array(
 				'factboxPreProcess'      => false,
@@ -193,7 +203,8 @@ class ArticlePurgeTest extends \PHPUnit_Framework_TestCase {
 			array(
 				'title'  => $nullIdTitle,
 				'smwgAutoRefreshOnPurge'         => true,
-				'smwgFactboxCacheRefreshOnPurge' => false
+				'smwgFactboxCacheRefreshOnPurge' => false,
+				'smwgQueryResultCacheRefreshOnPurge' => false
 			),
 			array(
 				'factboxPreProcess'      => false,

--- a/tests/phpunit/Unit/MediaWiki/Hooks/HookRegistryTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Hooks/HookRegistryTest.php
@@ -39,6 +39,10 @@ class HookRegistryTest extends \PHPUnit_Framework_TestCase {
 			->disableOriginalConstructor()
 			->getMock();
 
+		$this->title->expects( $this->any() )
+			->method( 'getNamespace' )
+			->will( $this->returnValue( NS_MAIN ) );
+
 		$this->outputPage = $this->getMockBuilder( '\OutputPage' )
 			->disableOriginalConstructor()
 			->getMock();

--- a/tests/phpunit/Unit/QueryFactoryTest.php
+++ b/tests/phpunit/Unit/QueryFactoryTest.php
@@ -98,6 +98,32 @@ class QueryFactoryTest extends \PHPUnit_Framework_TestCase {
 		);
 	}
 
+	public function testCanConstructQueryResult() {
+
+		$description = $this->getMockBuilder( '\SMW\Query\Language\Description' )
+			->disableOriginalConstructor()
+			->getMockForAbstractClass();
+
+		$store = $this->getMockBuilder( '\SMW\Store' )
+			->disableOriginalConstructor()
+			->getMockForAbstractClass();
+
+		$query = $this->getMockBuilder( '\SMWQuery' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$query->expects( $this->once() )
+			->method( 'getDescription' )
+			->will( $this->returnValue( $description ) );
+
+		$instance = new QueryFactory();
+
+		$this->assertInstanceOf(
+			'\SMWQueryResult',
+			$instance->newQueryResult( $store, $query )
+		);
+	}
+
 	public function testCanConstructConfigurableQueryCreator() {
 
 		$instance = new QueryFactory();

--- a/tests/phpunit/Unit/SPARQLStore/SPARQLStoreFactoryTest.php
+++ b/tests/phpunit/Unit/SPARQLStore/SPARQLStoreFactoryTest.php
@@ -56,7 +56,7 @@ class SPARQLStoreFactoryTest extends \PHPUnit_Framework_TestCase {
 		$instance = new SPARQLStoreFactory( $this->store );
 
 		$this->assertInstanceOf(
-			'\SMW\SPARQLStore\QueryEngine\QueryEngine',
+			'\SMW\QueryEngine',
 			$instance->newMasterQueryEngine()
 		);
 	}

--- a/tests/phpunit/Unit/SQLStore/SQLStoreFactoryTest.php
+++ b/tests/phpunit/Unit/SQLStore/SQLStoreFactoryTest.php
@@ -44,7 +44,7 @@ class SQLStoreFactoryTest extends \PHPUnit_Framework_TestCase {
 		$instance = new SQLStoreFactory( new SMWSQLStore3() );
 
 		$this->assertInstanceOf(
-			'\SMW\SQLStore\QueryEngine\QueryEngine',
+			'\SMW\QueryEngine',
 			$instance->newSlaveQueryEngine()
 		);
 	}
@@ -54,7 +54,7 @@ class SQLStoreFactoryTest extends \PHPUnit_Framework_TestCase {
 		$instance = new SQLStoreFactory( new SMWSQLStore3() );
 
 		$this->assertInstanceOf(
-			'\SMW\SQLStore\QueryEngine\QueryEngine',
+			'\SMW\QueryEngine',
 			$instance->newMasterQueryEngine()
 		);
 	}


### PR DESCRIPTION
Most of the job is already done by the `QueryDependencyLinksStore` to track and update query dependencies.

To eliminate unnecessary SQL/SPARQL connections `QueryResultCache` ought to cache a subject list returned from the `QueryEngine`.

We don't cache the string result of a printer == it means we don't interfere with how the printer manipulates the data displayed, `QueryResultCache` as the name suggests caches the return object (aka `QueryResult`) from the QueryEngine before it is forwarded to an individual printer.

If for some reason `QueryDependencyLinksStore` is not enabled then auto-invalidation of the `QueryResultCache` items can not occur and instead (same as of now, meaning manual intervention using the purge button) setting `$GLOBALS['smwgQueryResultCacheRefreshOnPurge'] = true;` can
be used so that during an purge action event the cache is invalidated for all queries stored with a corresponding article (aka subject).

![image](https://cloud.githubusercontent.com/assets/1245473/18538893/edd86798-7b12-11e6-96bd-a33e7762329b.png)
## Features and limitations
- `limit=0`, `format=debug`, and `Special:Ask` queries are not cached
- `redis` is the preferred external StoreEngine in order to avoid issues during serialization as well as in terms of the amount of data to be stored/requested
- `$GLOBALS['smwgQueryResultCacheType']` is set to `CACHE_NONE` which means the feature is disabled, choosing an appropriate type is left to a administrator
- `$GLOBALS['smwgQueryResultCacheLifetime'] = 60 * 60 * 24; // a day` declares the lifetime of a cached item

refs  #1035, #1117
