### PR TITLE
Add InTextAnnotationParserStrictMode flag, refs #1252

### DIFF
--- a/SemanticMediaWiki.settings.php
+++ b/SemanticMediaWiki.settings.php
@@ -929,3 +929,18 @@ $GLOBALS['smwgExportBCAuxiliaryUse'] = false;
 # @since 2.3
 ##
 $GLOBALS['smwgExportBCNonCanonicalFormUse'] = false;
+
+##
+# The strict mode is to help to remove ambiguity during the annotation [[ ... :: ... ]]
+# parsing process.
+#
+# The default interpretation (strict) is to find a single triple such as
+# [[property::value:partOfTheValue::alsoPartOfTheValue]] where in case the strict
+# mode is disabled multiple properties can be assigned using a
+# [[property1::property2::value]] notation which may cause value strings to be
+# interpret unanticipated in case of additional colons.
+#
+# @since 2.3
+# @default true
+##
+$GLOBALS['smwgEnabledInTextAnnotationParserStrictMode'] = true;

--- a/includes/Settings.php
+++ b/includes/Settings.php
@@ -139,7 +139,8 @@ class Settings extends SimpleDictionary {
 			'smwgEnabledQueryDependencyLinksStore' => $GLOBALS['smwgEnabledQueryDependencyLinksStore'],
 			'smwgPropertyDependencyDetectionBlacklist' => $GLOBALS['smwgPropertyDependencyDetectionBlacklist'],
 			'smwgExportBCNonCanonicalFormUse' => $GLOBALS['smwgExportBCNonCanonicalFormUse'],
-			'smwgExportBCAuxiliaryUse' => $GLOBALS['smwgExportBCAuxiliaryUse']
+			'smwgExportBCAuxiliaryUse' => $GLOBALS['smwgExportBCAuxiliaryUse'],
+			'smwgEnabledInTextAnnotationParserStrictMode' => $GLOBALS['smwgEnabledInTextAnnotationParserStrictMode']
 		);
 
 		$settings = $settings + array(

--- a/src/ApplicationFactory.php
+++ b/src/ApplicationFactory.php
@@ -217,11 +217,17 @@ class ApplicationFactory {
 
 		$mwCollaboratorFactory = $this->newMwCollaboratorFactory();
 
-		return new InTextAnnotationParser(
+		$inTextAnnotationParser = new InTextAnnotationParser(
 			$parserData,
 			$mwCollaboratorFactory->newMagicWordsFinder(),
 			$mwCollaboratorFactory->newRedirectTargetFinder()
 		);
+
+		$inTextAnnotationParser->setStrictModeState(
+			$this->getSettings()->get( 'smwgEnabledInTextAnnotationParserStrictMode' )
+		);
+
+		return $inTextAnnotationParser;
 	}
 
 	/**
@@ -268,7 +274,7 @@ class ApplicationFactory {
 	 * @return NamespaceExaminer
 	 */
 	public function getNamespaceExaminer() {
-		return NamespaceExaminer::newFromArray( $this->getSettings()->get( 'smwgNamespacesWithSemanticLinks' ) );
+		return $this->callbackLoader->load( 'NamespaceExaminer' );
 	}
 
 	/**

--- a/src/InTextAnnotationParser.php
+++ b/src/InTextAnnotationParser.php
@@ -77,6 +77,11 @@ class InTextAnnotationParser {
 	private $contextReference;
 
 	/**
+	 * @var boolean
+	 */
+	private $strictModeState = true;
+
+	/**
 	 * @since 1.9
 	 *
 	 * @param ParserData $parserData
@@ -89,6 +94,19 @@ class InTextAnnotationParser {
 		$this->redirectTargetFinder = $redirectTargetFinder;
 		$this->dataValueFactory = DataValueFactory::getInstance();
 		$this->applicationFactory = ApplicationFactory::getInstance();
+	}
+
+	/**
+	 * Whether a strict interpretation (e.g [[property::value:partOfTheValue::alsoPartOfTheValue]])
+	 * or a more loose interpretation (e.g. [[property1::property2::value]]) for
+	 * annotations is to be applied.
+	 *
+	 * @since 2.3
+	 *
+	 * @param boolean $strictModeState
+	 */
+	public function setStrictModeState( $strictModeState ) {
+		$this->strictModeState = (bool)$strictModeState;
 	}
 
 	/**
@@ -252,12 +270,15 @@ class InTextAnnotationParser {
 
 		if ( array_key_exists( 1, $semanticLink ) ) {
 
-			// Check for colon(s) produced by something like [[Foo::Bar::Foobar]],
-			// [[Foo:::0049 30 12345678]]
+			// #1252 Strict mode being disabled for support of multi property
+			// assignments (e.g. [[property1::property2::value]])
+
+			// #1066 Strict mode is to check for colon(s) produced by something
+			// like [[Foo::Bar::Foobar]], [[Foo:::0049 30 12345678]]
 			// In case a colon appears (in what is expected to be a string without a colon)
 			// then concatenate the string again and split for the first :: occurrence
 			// only
-			if ( strpos( $semanticLink[1], ':' ) !== false && isset( $semanticLink[2] ) ) {
+			if ( $this->strictModeState && strpos( $semanticLink[1], ':' ) !== false && isset( $semanticLink[2] ) ) {
 				list( $semanticLink[1], $semanticLink[2] ) = explode( '::', $semanticLink[1] . '::' . $semanticLink[2], 2 );
 			}
 

--- a/tests/phpunit/Integration/ByJsonScript/ByJsonScriptFixtureTestCaseRunnerTest.php
+++ b/tests/phpunit/Integration/ByJsonScript/ByJsonScriptFixtureTestCaseRunnerTest.php
@@ -129,7 +129,8 @@ class ByJsonScriptFixtureTestCaseRunnerTest extends ByJsonTestCaseProvider {
 			'smwStrictComparators',
 			'smwgQSubpropertyDepth',
 			'smwgQSubcategoryDepth',
-			'smwgQConceptCaching'
+			'smwgQConceptCaching',
+			'smwgEnabledInTextAnnotationParserStrictMode'
 		);
 
 		foreach ( $permittedSettings as $key ) {

--- a/tests/phpunit/Integration/ByJsonScript/Fixtures/p-0408 [#1252] intext to use non-strict mode.json
+++ b/tests/phpunit/Integration/ByJsonScript/Fixtures/p-0408 [#1252] intext to use non-strict mode.json
@@ -1,0 +1,34 @@
+{
+	"description": "#1252 non strict mode suport",
+	"properties": [],
+	"subjects": [
+		{
+			"name": "Example/P0408/1",
+			"contents": "[[Testproperty1::Testproperty2::200]]"
+		}
+	],
+	"parser-testcases": [
+		{
+			"about": "#0 disabled strict mode allows for multi property assignment",
+			"subject": "Example/P0408/1",
+			"store": {
+				"semantic-data": {
+					"strict-mode-valuematch": false,
+					"propertyCount": 4,
+					"propertyKeys": [ "Testproperty1", "Testproperty2", "_SKEY", "_MDAT" ],
+					"propertyValues": [ "200" ]
+				}
+			}
+		}
+	],
+	"settings": {
+		"wgContLang": "en",
+		"smwgPageSpecialProperties": [ "_MDAT" ],
+		"smwgEnabledInTextAnnotationParserStrictMode": false
+	},
+	"meta": {
+		"version": "0.1",
+		"is-incomplete": false,
+		"debug": false
+	}
+}

--- a/tests/phpunit/Unit/Factbox/CachedFactboxTest.php
+++ b/tests/phpunit/Unit/Factbox/CachedFactboxTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace SMW\Test;
+namespace SMW\Tests\Factbox;
 
 use SMW\Tests\Utils\Mock\MockTitle;
 

--- a/tests/phpunit/Unit/Factbox/FactboxMagicWordsTest.php
+++ b/tests/phpunit/Unit/Factbox/FactboxMagicWordsTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace SMW\Tests;
+namespace SMW\Tests\Factbox;
 
 use SMW\ParserData;
 use SMW\Settings;
@@ -46,6 +46,7 @@ class FactboxMagicWordsTest extends \PHPUnit_Framework_TestCase {
 
 		$settings = Settings::newFromArray( array(
 			'smwgNamespacesWithSemanticLinks' => array( $title->getNamespace() => true ),
+			'smwgEnabledInTextAnnotationParserStrictMode' => true,
 			'smwgLinksInValues' => false,
 			'smwgInlineErrors'  => true,
 			)

--- a/tests/phpunit/Unit/Factbox/FactboxTest.php
+++ b/tests/phpunit/Unit/Factbox/FactboxTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace SMW\Tests;
+namespace SMW\Tests\Factbox;
 
 use SMW\Tests\Utils\UtilityFactory;
 use SMW\Tests\Utils\Mock\MockObjectBuilder;

--- a/tests/phpunit/Unit/InTextAnnotationParserTest.php
+++ b/tests/phpunit/Unit/InTextAnnotationParserTest.php
@@ -113,6 +113,10 @@ class InTextAnnotationParserTest extends \PHPUnit_Framework_TestCase {
 			new RedirectTargetFinder()
 		);
 
+		$instance->setStrictModeState(
+			isset( $settings['smwgEnabledInTextAnnotationParserStrictMode'] ) ? $settings['smwgEnabledInTextAnnotationParserStrictMode'] : true
+		);
+
 		$this->applicationFactory->registerObject(
 			'Settings',
 			Settings::newFromArray( $settings )
@@ -457,6 +461,24 @@ class InTextAnnotationParserTest extends \PHPUnit_Framework_TestCase {
 				'propertyCount'  => 2,
 				'propertyLabels' => array( 'Foo', 'Bar' ),
 				'propertyValues' => array( 'Foobar', '0049 30 12345678/::Foo', 'ABC' )
+			)
+		);
+
+		#10 #1252 (disabled strict mode)
+		$provider[] = array(
+			NS_MAIN,
+			array(
+				'smwgNamespacesWithSemanticLinks' => array( NS_MAIN => true ),
+				'smwgLinksInValues' => false,
+				'smwgInlineErrors'  => true,
+				'smwgEnabledInTextAnnotationParserStrictMode' => false
+			),
+			'[[Foo::Foobar::テスト]] [[Bar:::ABC|DEF]] [[Foo:::0049 30 12345678/::Foo]] ',
+			array(
+				'resultText'     => '[[:テスト|テスト]] [[:ABC|DEF]] [[:Foo|Foo]]',
+				'propertyCount'  => 4,
+				'propertyLabels' => array( 'Foo', 'Bar:', 'Foobar', ':0049 30 12345678/' ),
+				'propertyValues' => array( 'Foobar', 'Foo', 'ABC', 'テスト' )
 			)
 		);
 

--- a/tests/phpunit/Unit/MediaWiki/Hooks/InternalParseBeforeLinksTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Hooks/InternalParseBeforeLinksTest.php
@@ -213,6 +213,7 @@ class InternalParseBeforeLinksTest extends \PHPUnit_Framework_TestCase {
 				'title'    => $title,
 				'settings' => array(
 					'smwgNamespacesWithSemanticLinks' => array( NS_MAIN => true ),
+					'smwgEnabledInTextAnnotationParserStrictMode' => true,
 					'smwgLinksInValues' => false,
 					'smwgInlineErrors'  => true,
 				),
@@ -235,6 +236,7 @@ class InternalParseBeforeLinksTest extends \PHPUnit_Framework_TestCase {
 				'title'    => $title,
 				'settings' => array(
 					'smwgNamespacesWithSemanticLinks' => array( NS_MAIN => true ),
+					'smwgEnabledInTextAnnotationParserStrictMode' => true,
 					'smwgLinksInValues' => false,
 					'smwgInlineErrors'  => true,
 				),
@@ -256,6 +258,7 @@ class InternalParseBeforeLinksTest extends \PHPUnit_Framework_TestCase {
 				'title'    => $title,
 				'settings' => array(
 					'smwgNamespacesWithSemanticLinks' => array( NS_MAIN => true ),
+					'smwgEnabledInTextAnnotationParserStrictMode' => true,
 					'smwgLinksInValues' => false,
 					'smwgInlineErrors'  => true,
 					'smwgEnabledSpecialPage' => array( 'Ask', 'Foo' )
@@ -280,6 +283,7 @@ class InternalParseBeforeLinksTest extends \PHPUnit_Framework_TestCase {
 				'title'    => $title,
 				'settings' => array(
 					'smwgNamespacesWithSemanticLinks' => array( NS_MAIN => true ),
+					'smwgEnabledInTextAnnotationParserStrictMode' => true,
 					'smwgLinksInValues' => false,
 					'smwgInlineErrors'  => true,
 					'smwgEnabledSpecialPage' => array( 'Ask', 'Foo' )


### PR DESCRIPTION
By default (as of 2.3) a more strict parsing process is enforced to minimize annotation interpretation issues.

`$GLOBALS['smwgEnabledInTextAnnotationParserStrictMode']` can be set `false` to loosen the strictness which may result in certain features not being supported or can cause unanticipated misinterpretation in case of additional colons.

refs #1252