### PR TITLE
Support recursive annotation per query, refs #1255, #1068

### DIFF
--- a/SemanticMediaWiki.settings.php
+++ b/SemanticMediaWiki.settings.php
@@ -421,24 +421,6 @@ $GLOBALS['smwgResultFormats'] = array(
 $GLOBALS['smwgResultAliases'] = array( 'feed' => array( 'rss' ) );
 ##
 
-###
-#
-# Enables specific formats to import its annotation data into the
-# subject that resolves the result query.
-#
-# E.g. using ask query to search/set an invert property value
-#
-# This setting can be used to mitigate template parsing in connection with the
-# VisualEditor (#1055).
-#
-# @since 2.3
-##
-$GLOBALS['smwgEnabledResultFormatsWithRecursiveAnnotationSupport'] = array(
-	'template',
-	'list'
-);
-##
-
 ### Predefined sources for queries
 # Array of available sources for answering queries. Can be redefined in
 # the settings to register new sources (usually an extension will do so

--- a/includes/Settings.php
+++ b/includes/Settings.php
@@ -134,7 +134,6 @@ class Settings extends SimpleDictionary {
 			'smwgFallbackSearchType' => $GLOBALS['smwgFallbackSearchType'],
 			'smwgEnabledEditPageHelp' => $GLOBALS['smwgEnabledEditPageHelp'],
 			'smwgSparqlQFeatures' => $GLOBALS['smwgSparqlQFeatures'],
-			'smwgEnabledResultFormatsWithRecursiveAnnotationSupport' => $GLOBALS['smwgEnabledResultFormatsWithRecursiveAnnotationSupport'],
 			'smwgEnabledHttpDeferredJobRequest' => $GLOBALS['smwgEnabledHttpDeferredJobRequest'],
 			'smwgEnabledQueryDependencyLinksStore' => $GLOBALS['smwgEnabledQueryDependencyLinksStore'],
 			'smwgPropertyDependencyDetectionBlacklist' => $GLOBALS['smwgPropertyDependencyDetectionBlacklist'],

--- a/includes/parserhooks/AskParserFunction.php
+++ b/includes/parserhooks/AskParserFunction.php
@@ -75,19 +75,6 @@ class AskParserFunction {
 	}
 
 	/**
-	 * A printer run its own isolated wgParser process therefore if the printer
-	 * or a template inclusion is used by a printer, possible extra annotations
-	 * need to be imported for further usage
-	 *
-	 * @since 2.3
-	 *
-	 * @param array $enabledFormatsThatSupportRecursiveParse
-	 */
-	public function setEnabledFormatsThatSupportRecursiveParse( array $enabledFormatsThatSupportRecursiveParse ) {
-		$this->enabledFormatsThatSupportRecursiveParse = $enabledFormatsThatSupportRecursiveParse;
-	}
-
-	/**
 	 * {{#ask}} is disabled (see $smwgQEnabled)
 	 *
 	 * @since 1.9
@@ -178,7 +165,10 @@ class AskParserFunction {
 		$format = $this->params['format']->getValue();
 
 		// FIXME Parser should be injected into the ResultPrinter
-		if ( in_array( $format, $this->enabledFormatsThatSupportRecursiveParse ) ) {
+		// Enables specific formats to import its annotation data from
+		// a recursive parse process in the result format
+		// e.g. using ask query to search/set an invert property value
+		if ( isset( $this->params['import-annotation'] ) && $this->params['import-annotation']->getValue() ) {
 			$this->parserData->importFromParserOutput( $GLOBALS['wgParser']->getOutput() );
 		}
 

--- a/includes/queryprinters/CategoryResultPrinter.php
+++ b/includes/queryprinters/CategoryResultPrinter.php
@@ -207,6 +207,13 @@ class CategoryResultPrinter extends ResultPrinter {
 				'type' => 'boolean',
 				'message' => 'smw-paramdesc-named_args',
 				'default' => false,
+			),
+
+			array(
+				'name' => 'import-annotation',
+				'type' => 'boolean',
+				'message' => 'smw-paramdesc-import-annotation',
+				'default' => false,
 			)
 		) );
 	}

--- a/includes/queryprinters/ListResultPrinter.php
+++ b/includes/queryprinters/ListResultPrinter.php
@@ -506,6 +506,12 @@ class ListResultPrinter extends ResultPrinter {
 			'default' => '',
 		);
 
+		$params['import-annotation'] = array(
+			'message' => 'smw-paramdesc-import-annotation',
+			'type' => 'boolean',
+			'default' => false
+		);
+
 		return $params;
 	}
 }

--- a/includes/queryprinters/ResultPrinter.php
+++ b/includes/queryprinters/ResultPrinter.php
@@ -304,14 +304,14 @@ abstract class ResultPrinter extends \ContextSource implements QueryResultPrinte
 				self::$mRecursionDepth++;
 
 				if ( self::$mRecursionDepth <= self::$maxRecursionDepth ) { // restrict recursion
-					$result = in_array( $this->params['format'], $smwgEnabledResultFormatsWithRecursiveAnnotationSupport ) ? $wgParser->recursivePreprocess( $result ) :'[[SMW::off]]' . $wgParser->replaceVariables( $result ) . '[[SMW::on]]';
+					$result = isset( $this->params['import-annotation'] ) && $this->params['import-annotation'] ? $wgParser->recursivePreprocess( $result ) : '[[SMW::off]]' . $wgParser->replaceVariables( $result ) . '[[SMW::on]]';
 				} else {
 					$result = ''; /// TODO: explain problem (too much recursive parses)
 				}
 
 				self::$mRecursionDepth--;
 			} else { // not during parsing, no preprocessing needed, still protect the result
-				$result = in_array( $this->params['format'], $smwgEnabledResultFormatsWithRecursiveAnnotationSupport ) ? $result : '[[SMW::off]]' . $result . '[[SMW::on]]';
+				$result = isset( $this->params['import-annotation'] ) && $this->params['import-annotation'] ? $result : '[[SMW::off]]' . $result . '[[SMW::on]]';
 			}
 		}
 

--- a/src/ParserFunctionFactory.php
+++ b/src/ParserFunctionFactory.php
@@ -78,10 +78,6 @@ class ParserFunctionFactory {
 			$circularReferenceGuard
 		);
 
-		$instance->setEnabledFormatsThatSupportRecursiveParse(
-			ApplicationFactory::getInstance()->getSettings()->get( 'smwgEnabledResultFormatsWithRecursiveAnnotationSupport' )
-		);
-
 		return $instance;
 	}
 

--- a/tests/phpunit/Integration/ByJsonScript/ByJsonScriptFixtureTestCaseRunnerTest.php
+++ b/tests/phpunit/Integration/ByJsonScript/ByJsonScriptFixtureTestCaseRunnerTest.php
@@ -121,7 +121,6 @@ class ByJsonScriptFixtureTestCaseRunnerTest extends ByJsonTestCaseProvider {
 			'wgContLang',
 			'wgLang',
 			'wgCapitalLinks',
-			'smwgEnabledResultFormatsWithRecursiveAnnotationSupport',
 			'smwgNamespace',
 			'smwgExportBCNonCanonicalFormUse',
 			'smwgExportBCAuxiliaryUse',

--- a/tests/phpunit/Integration/ByJsonScript/Fixtures/f-0103 [#988] template with self reference.json
+++ b/tests/phpunit/Integration/ByJsonScript/Fixtures/f-0103 [#988] template with self reference.json
@@ -22,7 +22,7 @@
 		},
 		{
 			"name": "PageContainsAskWithTemplateUsage",
-			"contents": "{{#ask: [[Has blob property::Template one]]|format=template|template=TemplateWithReferenceToItself}}"
+			"contents": "{{#ask: [[Has blob property::Template one]]|format=template|template=TemplateWithReferenceToItself|import-annotation=true}}"
 		},
 		{
 			"name": "PageContainsTemplateTransclusion",

--- a/tests/phpunit/Integration/ByJsonScript/Fixtures/p-0205 [#1055] set ask parser recursive annotation via template.json
+++ b/tests/phpunit/Integration/ByJsonScript/Fixtures/p-0205 [#1055] set ask parser recursive annotation via template.json
@@ -13,11 +13,15 @@
 		},
 		{
 			"name": "Example/0205/Ask/List",
-			"contents": "{{#ask:[[TestPropertyByAskTemplate::TestValueByAskTemplate]]|link=none|sep=|format=list|template=AskTemplateToAddPropertyAnnotation}}"
+			"contents": "{{#ask:[[TestPropertyByAskTemplate::TestValueByAskTemplate]]|link=none|sep=|format=list|template=AskTemplateToAddPropertyAnnotation|import-annotation=true}}"
 		},
 		{
-			"name": "Example/0205/Ask/Embedded",
-			"contents": "{{#ask:[[TestPropertyByAskTemplate::TestValueByAskTemplate]]|link=none|sep=|format=embedded}}"
+			"name": "Example/0205/Ask/Embedded/1",
+			"contents": "{{#ask:[[TestPropertyByAskTemplate::TestValueByAskTemplate]]|link=none|sep=|format=embedded|import-annotation=false}}"
+		},
+		{
+			"name": "Example/0205/Ask/Embedded/2",
+			"contents": "{{#ask:[[ByAskTemplateToSetProperty::1234]]|link=none|sep=|format=embedded|import-annotation=false}}"
 		}
 	],
 	"parser-testcases": [
@@ -33,8 +37,19 @@
 			}
 		},
 		{
-			"about": "#1 embbeded is exluded from recursive support",
-			"subject": "Example/0205/Ask/Embedded",
+			"about": "#1 embbeded with disabled recursive parse support",
+			"subject": "Example/0205/Ask/Embedded/1",
+			"store": {
+				"semantic-data": {
+					"strict-mode-valuematch": false,
+					"propertyCount": 3,
+					"propertyKeys": [ "_ASK", "_MDAT", "_SKEY" ]
+				}
+			}
+		},
+		{
+			"about": "#2 embbeded with disabled recursive parse support",
+			"subject": "Example/0205/Ask/Embedded/2",
 			"store": {
 				"semantic-data": {
 					"strict-mode-valuematch": false,
@@ -45,7 +60,6 @@
 		}
 	],
 	"settings": {
-		"smwgEnabledResultFormatsWithRecursiveAnnotationSupport": [ "list" ],
 		"smwgPageSpecialProperties": [ "_MDAT" ]
 	},
 	"meta": {

--- a/tests/phpunit/Integration/ByJsonScript/Fixtures/p-0406 [#1055] unrestricted intext annotation via template ask parse.json
+++ b/tests/phpunit/Integration/ByJsonScript/Fixtures/p-0406 [#1055] unrestricted intext annotation via template ask parse.json
@@ -15,7 +15,7 @@
 		{
 			"name": "TemplateForUnrestrictedParse",
 			"namespace": "NS_TEMPLATE",
-			"contents": "<includeonly>{{#ask: [[HasUnrestrictedPage::{{{1}}}]]|?HasUnrestrictedPage|link=none|format=template|template=CreateAnnotationViaAskTemplate}}</includeonly>"
+			"contents": "<includeonly>{{#ask: [[HasUnrestrictedPage::{{{1}}}]]|?HasUnrestrictedPage|link=none|format=template|template=CreateAnnotationViaAskTemplate|import-annotation=true}}</includeonly>"
 		},
 		{
 			"name": "Page-with-annotation",
@@ -41,8 +41,7 @@
 		}
 	],
 	"settings": {
-		"smwgPageSpecialProperties": [ "_MDAT" ],
-		"smwgEnabledResultFormatsWithRecursiveAnnotationSupport": [ "template" ]
+		"smwgPageSpecialProperties": [ "_MDAT" ]
 	},
 	"meta": {
 		"version": "0.1",

--- a/tests/phpunit/Integration/ByJsonScript/Fixtures/p-0701 [#711] ask template invert annotation.json
+++ b/tests/phpunit/Integration/ByJsonScript/Fixtures/p-0701 [#711] ask template invert annotation.json
@@ -24,7 +24,7 @@
 		{
 			"name": "InvertPropertyDeclarator",
 			"namespace": "NS_TEMPLATE",
-			"contents": "<includeonly>{{#ask:[[{{{1}}}::{{PAGENAME}}]]|link=none|sep=|template=InvertPropertySetter|userparam={{{2}}}|format=template }}</includeonly>"
+			"contents": "<includeonly>{{#ask:[[{{{1}}}::{{PAGENAME}}]]|link=none|sep=|template=InvertPropertySetter|userparam={{{2}}}|format=template|import-annotation=true}}</includeonly>"
 		},
 		{
 			"name": "Belgium",
@@ -55,7 +55,6 @@
 	],
 	"settings": {
 		"wgCapitalLinks": true,
-		"smwgEnabledResultFormatsWithRecursiveAnnotationSupport": [ "template" ],
 		"smwgPageSpecialProperties": [ "_MDAT" ]
 	},
 	"meta": {


### PR DESCRIPTION
This removes `smwgEnabledResultFormatsWithRecursiveAnnotationSupport` (was only added with 2.3) setting and instead handles support for recursive annotation on an individual query level.

By default `|recursive-parse` is set `false`.

refs #1255, #1068