### PR TITLE
Removed pg_unescape_bytea-ing the result

### DIFF
--- a/includes/queryprinters/ResultPrinter.php
+++ b/includes/queryprinters/ResultPrinter.php
@@ -253,10 +253,6 @@ abstract class ResultPrinter extends \ContextSource implements QueryResultPrinte
 			$result = $this->handleNonFileResult( $result, $results, $outputMode );
 		}
 
-		if ( $GLOBALS['wgDBtype'] == 'postgres' ) {
-			$result = pg_unescape_bytea( $result );
-		}
-
 		return $result;
 	}
 


### PR DESCRIPTION
Since PostgreSQL 9.0 (earlier version are at end-of-life) the [default binary format is "hex"](http://www.postgresql.org/docs/9.0/static/datatype-binary.html). Unescaping bytea strings were only necessary in earlier PostgreSQL versions, which used "escape" format - forcing escapeing causes issues in rendering (see [here](https://github.com/SemanticMediaWiki/SemanticMaps/pull/47))