### PR TITLE
Add browsebyproperty API module

### DIFF
--- a/docs/technical/api.md
+++ b/docs/technical/api.md
@@ -1,4 +1,5 @@
-This file contains details about Semantic MediaWiki's API for external use with a description that is reflecting the current master branch (SMW 1.9). For more details on "how to use" MediaWiki's WebAPI, it is recommended to read this [website][api].
+This file contains details about Semantic MediaWiki's API for external use with a description
+of available interfaces. For more details on MediaWiki's WbeAPI, it is recommended to read this [website][guideline].
 
 ## api.php?action=ask
 The `Ask API` allows you to do ask queries against SMW using the MediaWiki API and get results back serialized in one of the formats it supports.
@@ -73,6 +74,7 @@ The following parameters are available and can be concatenate using the "|" char
 * querysize
 * subobjectcount
 * formatcount
+* errorcount
 
 #### Output serialization
 
@@ -137,6 +139,36 @@ An interface to browse facts (the equivalent of `Special:Browse`) of a subject (
 }
 ```
 
-For details on the serialization, see <code>/docs/serializer.md</code>.
+## api.php?action=browsebyproperty
+An interface to browse properties (the equivalent of `Special:Properties`).
+
+> api.php?action=browsebyproperty
+> api.php?action=browsebyproperty&limit=100&format=json&property=name
+
+#### Output serialization
+
+```php
+{
+    "xmlns:Foaf": "http://xmlns.com/foaf/0.1/",
+    "query": {
+        "Foaf:name": {
+            "label": "Foaf:name",
+            "isUserDefined": true,
+            "usageCount": 2
+        },
+        "Has_common_name": {
+            "label": "Has common name",
+            "isUserDefined": true,
+            "usageCount": 1
+        }
+    },
+    "version": 0.1,
+    "meta": {
+        "limit": 100,
+        "count": 2,
+        "isCached": true
+    }
+}
+```
 
 [api]: https://www.mediawiki.org/wiki/Api "Manual:Api"

--- a/includes/Setup.php
+++ b/includes/Setup.php
@@ -130,7 +130,8 @@ final class Setup {
 		$this->globalVars['wgAPIModules']['smwinfo'] = '\SMW\MediaWiki\Api\Info';
 		$this->globalVars['wgAPIModules']['ask']     = '\SMW\MediaWiki\Api\Ask';
 		$this->globalVars['wgAPIModules']['askargs'] = '\SMW\MediaWiki\Api\AskArgs';
-		$this->globalVars['wgAPIModules']['browsebysubject']  = '\SMW\MediaWiki\Api\BrowseBySubject';
+		$this->globalVars['wgAPIModules']['browsebysubject'] = '\SMW\MediaWiki\Api\BrowseBySubject';
+		$this->globalVars['wgAPIModules']['browsebyproperty'] = '\SMW\MediaWiki\Api\BrowseByProperty';
 	}
 
 	/**

--- a/includes/querypages/QueryPage.php
+++ b/includes/querypages/QueryPage.php
@@ -125,6 +125,7 @@ abstract class QueryPage extends \QueryPage {
 	public function getSearchForm( $property = '', $cacheDate = '' ) {
 
 		$this->useSerchForm = true;
+		$this->getOutput()->addModules( 'ext.smw.property' );
 
 		// No need to verify $this->selectOptions because its values are set
 		// during doQuery() which is processed before this form is generated
@@ -147,7 +148,7 @@ abstract class QueryPage extends \QueryPage {
 				Xml::tags( 'p', array(), $selection ) .
 				Xml::tags( 'p', array(), $cacheDate ) .
 				Xml::tags( 'hr', array( 'style' => 'margin-bottom:10px;' ), '' ) .
-				Xml::inputLabel( $this->msg( 'smw-sp-property-searchform' )->text(), 'property', 'property', 20, $property ) . ' ' .
+				Xml::inputLabel( $this->msg( 'smw-sp-property-searchform' )->text(), 'property', 'smw-property-input', 20, $property ) . ' ' .
 				Xml::submitButton( $this->msg( 'allpagessubmit' )->text() )
 			)
 		);

--- a/includes/specials/SMW_SpecialAsk.php
+++ b/includes/specials/SMW_SpecialAsk.php
@@ -44,6 +44,7 @@ class SMWAskPage extends SMWQuerySpecialPage {
 
 		$wgOut->addModules( 'ext.smw.style' );
 		$wgOut->addModules( 'ext.smw.ask' );
+		$wgOut->addModules( 'ext.smw.property' );
 
 		$this->setHeaders();
 
@@ -366,7 +367,7 @@ class SMWAskPage extends SMWQuerySpecialPage {
 			$result .= '<table class="smw-ask-query" style="width: 100%;"><tr><th>' . wfMessage( 'smw_ask_queryhead' )->escaped() . "</th>\n<th>" . wfMessage( 'smw_ask_printhead' )->escaped() . "<br />\n" .
 				'<span style="font-weight: normal;">' . wfMessage( 'smw_ask_printdesc' )->escaped() . '</span>' . "</th></tr>\n" .
 				'<tr><td style="padding-left: 0px;"><textarea class="smw-ask-query-condition" name="q" cols="20" rows="6">' . htmlspecialchars( $this->m_querystring ) . "</textarea></td>\n" .
-				'<td style="padding-left: 7px;"><textarea id="add_property" class="smw-ask-query-printout" name="po" cols="20" rows="6">' . htmlspecialchars( $printoutstring ) . '</textarea></td></tr></table>' . "\n";
+				'<td style="padding-left: 7px;"><textarea id="smw-property-input" class="smw-ask-query-printout" name="po" cols="20" rows="6">' . htmlspecialchars( $printoutstring ) . '</textarea></td></tr></table>' . "\n";
 
 			// Format selection
 			$result .= self::getFormatSelection ( $this->m_params );

--- a/includes/storage/SQLStore/SMW_SQLStore3.php
+++ b/includes/storage/SQLStore/SMW_SQLStore3.php
@@ -314,19 +314,7 @@ class SMWSQLStore3 extends SMWStore {
 		);
 
 		$this->getWriter()->deleteSubject( $title );
-		$this->doInvalidateCachedListLookupFor( $subject );
-	}
-
-	private function doInvalidateCachedListLookupFor( DIWikiPage $subject ) {
-
-		if ( $subject->getNamespace() !== SMW_NS_PROPERTY ) {
-			return null;
-		}
-
-		$this->factory->newPropertyUsageCachedListLookup()->deleteCache();
-		$this->factory->newUnusedPropertyCachedListLookup()->deleteCache();
-		$this->factory->newUndeclaredPropertyCachedListLookup()->deleteCache();
-		$this->factory->newUsageStatisticsCachedListLookup()->deleteCache();
+		$this->tryToInvalidateCachedListLookupEntryFor( $subject );
 	}
 
 	protected function doDataUpdate( SemanticData $semanticData ) {
@@ -336,6 +324,7 @@ class SMWSQLStore3 extends SMWStore {
 		);
 
 		$this->getWriter()->doDataUpdate( $semanticData );
+		$this->tryToInvalidateCachedListLookupEntryFor( $semanticData->getSubject() );
 	}
 
 	public function changeTitle( Title $oldtitle, Title $newtitle, $pageid, $redirid = 0 ) {
@@ -349,8 +338,20 @@ class SMWSQLStore3 extends SMWStore {
 		);
 
 		$this->getWriter()->changeTitle( $oldtitle, $newtitle, $pageid, $redirid );
+		$this->tryToInvalidateCachedListLookupEntryFor( DIWikiPage::newFromTitle( $oldtitle ) );
 	}
 
+	private function tryToInvalidateCachedListLookupEntryFor( DIWikiPage $subject ) {
+
+		if ( $subject->getNamespace() !== SMW_NS_PROPERTY ) {
+			return null;
+		}
+
+		$this->factory->newPropertyUsageCachedListLookup()->deleteCache();
+		$this->factory->newUnusedPropertyCachedListLookup()->deleteCache();
+		$this->factory->newUndeclaredPropertyCachedListLookup()->deleteCache();
+		$this->factory->newUsageStatisticsCachedListLookup()->deleteCache();
+	}
 
 ///// Query answering /////
 

--- a/res/Resources.php
+++ b/res/Resources.php
@@ -114,6 +114,12 @@ return array(
 		)
 	),
 
+	// https://github.com/devbridge/jQuery-Autocomplete
+	'ext.jquery.autocomplete' => $moduleTemplate + array(
+		'scripts' => 'jquery/jquery.autocomplete.js',
+		'targets' => array( 'mobile', 'desktop' )
+	),
+
 	// Tooltip qtip2 resources
 	'ext.jquery.qtip.styles' => $moduleTemplate + array(
 		'styles' => 'jquery/jquery.qtip.css',
@@ -200,6 +206,8 @@ return array(
 	// Special:SearchByProperty
 	'ext.smw.property' => $moduleTemplate + array(
 		'scripts' => 'smw/special/ext.smw.special.property.js',
-		'dependencies' => 'ext.smw.autocomplete'
+		'dependencies' => 'ext.jquery.autocomplete',
+		'position' => 'bottom',
+		'targets' => array( 'mobile', 'desktop' )
 	)
 );

--- a/res/jquery/jquery.autocomplete.js
+++ b/res/jquery/jquery.autocomplete.js
@@ -1,0 +1,979 @@
+/**
+*  Ajax Autocomplete for jQuery, version 1.2.24
+*  (c) 2015 Tomas Kirda
+*
+*  Ajax Autocomplete for jQuery is freely distributable under the terms of an MIT-style license.
+*  For details, see the web site: https://github.com/devbridge/jQuery-Autocomplete
+*/
+
+/*jslint  browser: true, white: true, plusplus: true, vars: true */
+/*global define, window, document, jQuery, exports, require */
+
+// Expose plugin as an AMD module if AMD loader is present:
+(function (factory) {
+    'use strict';
+    if (typeof define === 'function' && define.amd) {
+        // AMD. Register as an anonymous module.
+        define(['jquery'], factory);
+    } else if (typeof exports === 'object' && typeof require === 'function') {
+        // Browserify
+        factory(require('jquery'));
+    } else {
+        // Browser globals
+        factory(jQuery);
+    }
+}(function ($) {
+    'use strict';
+
+    var
+        utils = (function () {
+            return {
+                escapeRegExChars: function (value) {
+                    return value.replace(/[\-\[\]\/\{\}\(\)\*\+\?\.\\\^\$\|]/g, "\\$&");
+                },
+                createNode: function (containerClass) {
+                    var div = document.createElement('div');
+                    div.className = containerClass;
+                    div.style.position = 'absolute';
+                    div.style.display = 'none';
+                    return div;
+                }
+            };
+        }()),
+
+        keys = {
+            ESC: 27,
+            TAB: 9,
+            RETURN: 13,
+            LEFT: 37,
+            UP: 38,
+            RIGHT: 39,
+            DOWN: 40
+        };
+
+    function Autocomplete(el, options) {
+        var noop = function () { },
+            that = this,
+            defaults = {
+                ajaxSettings: {},
+                autoSelectFirst: false,
+                appendTo: document.body,
+                serviceUrl: null,
+                lookup: null,
+                onSelect: null,
+                width: 'auto',
+                minChars: 1,
+                maxHeight: 300,
+                deferRequestBy: 0,
+                params: {},
+                formatResult: Autocomplete.formatResult,
+                delimiter: null,
+                zIndex: 9999,
+                type: 'GET',
+                noCache: false,
+                onSearchStart: noop,
+                onSearchComplete: noop,
+                onSearchError: noop,
+                preserveInput: false,
+                containerClass: 'autocomplete-suggestions',
+                tabDisabled: false,
+                dataType: 'text',
+                currentRequest: null,
+                triggerSelectOnValidInput: true,
+                preventBadQueries: true,
+                lookupFilter: function (suggestion, originalQuery, queryLowerCase) {
+                    return suggestion.value.toLowerCase().indexOf(queryLowerCase) !== -1;
+                },
+                paramName: 'query',
+                transformResult: function (response) {
+                    return typeof response === 'string' ? $.parseJSON(response) : response;
+                },
+                showNoSuggestionNotice: false,
+                noSuggestionNotice: 'No results',
+                orientation: 'bottom',
+                forceFixPosition: false
+            };
+
+        // Shared variables:
+        that.element = el;
+        that.el = $(el);
+        that.suggestions = [];
+        that.badQueries = [];
+        that.selectedIndex = -1;
+        that.currentValue = that.element.value;
+        that.intervalId = 0;
+        that.cachedResponse = {};
+        that.onChangeInterval = null;
+        that.onChange = null;
+        that.isLocal = false;
+        that.suggestionsContainer = null;
+        that.noSuggestionsContainer = null;
+        that.options = $.extend({}, defaults, options);
+        that.classes = {
+            selected: 'autocomplete-selected',
+            suggestion: 'autocomplete-suggestion'
+        };
+        that.hint = null;
+        that.hintValue = '';
+        that.selection = null;
+
+        // Initialize and set options:
+        that.initialize();
+        that.setOptions(options);
+    }
+
+    Autocomplete.utils = utils;
+
+    $.Autocomplete = Autocomplete;
+
+    Autocomplete.formatResult = function (suggestion, currentValue) {
+        var pattern = '(' + utils.escapeRegExChars(currentValue) + ')';
+        
+        return suggestion.value
+            .replace(new RegExp(pattern, 'gi'), '<strong>$1<\/strong>')
+            .replace(/&/g, '&amp;')
+            .replace(/</g, '&lt;')
+            .replace(/>/g, '&gt;')
+            .replace(/"/g, '&quot;')
+            .replace(/&lt;(\/?strong)&gt;/g, '<$1>');
+    };
+
+    Autocomplete.prototype = {
+
+        killerFn: null,
+
+        initialize: function () {
+            var that = this,
+                suggestionSelector = '.' + that.classes.suggestion,
+                selected = that.classes.selected,
+                options = that.options,
+                container;
+
+            // Remove autocomplete attribute to prevent native suggestions:
+            that.element.setAttribute('autocomplete', 'off');
+
+            that.killerFn = function (e) {
+                if ($(e.target).closest('.' + that.options.containerClass).length === 0) {
+                    that.killSuggestions();
+                    that.disableKillerFn();
+                }
+            };
+
+            // html() deals with many types: htmlString or Element or Array or jQuery
+            that.noSuggestionsContainer = $('<div class="autocomplete-no-suggestion"></div>')
+                                          .html(this.options.noSuggestionNotice).get(0);
+
+            that.suggestionsContainer = Autocomplete.utils.createNode(options.containerClass);
+
+            container = $(that.suggestionsContainer);
+
+            container.appendTo(options.appendTo);
+
+            // Only set width if it was provided:
+            if (options.width !== 'auto') {
+                container.width(options.width);
+            }
+
+            // Listen for mouse over event on suggestions list:
+            container.on('mouseover.autocomplete', suggestionSelector, function () {
+                that.activate($(this).data('index'));
+            });
+
+            // Deselect active element when mouse leaves suggestions container:
+            container.on('mouseout.autocomplete', function () {
+                that.selectedIndex = -1;
+                container.children('.' + selected).removeClass(selected);
+            });
+
+            // Listen for click event on suggestions list:
+            container.on('click.autocomplete', suggestionSelector, function () {
+                that.select($(this).data('index'));
+            });
+
+            that.fixPositionCapture = function () {
+                if (that.visible) {
+                    that.fixPosition();
+                }
+            };
+
+            $(window).on('resize.autocomplete', that.fixPositionCapture);
+
+            that.el.on('keydown.autocomplete', function (e) { that.onKeyPress(e); });
+            that.el.on('keyup.autocomplete', function (e) { that.onKeyUp(e); });
+            that.el.on('blur.autocomplete', function () { that.onBlur(); });
+            that.el.on('focus.autocomplete', function () { that.onFocus(); });
+            that.el.on('change.autocomplete', function (e) { that.onKeyUp(e); });
+            that.el.on('input.autocomplete', function (e) { that.onKeyUp(e); });
+        },
+
+        onFocus: function () {
+            var that = this;
+            that.fixPosition();
+            if (that.options.minChars === 0 && that.el.val().length === 0) {
+                that.onValueChange();
+            }
+        },
+
+        onBlur: function () {
+            this.enableKillerFn();
+        },
+        
+        abortAjax: function () {
+            var that = this;
+            if (that.currentRequest) {
+                that.currentRequest.abort();
+                that.currentRequest = null;
+            }
+        },
+
+        setOptions: function (suppliedOptions) {
+            var that = this,
+                options = that.options;
+
+            $.extend(options, suppliedOptions);
+
+            that.isLocal = $.isArray(options.lookup);
+
+            if (that.isLocal) {
+                options.lookup = that.verifySuggestionsFormat(options.lookup);
+            }
+
+            options.orientation = that.validateOrientation(options.orientation, 'bottom');
+
+            // Adjust height, width and z-index:
+            $(that.suggestionsContainer).css({
+                'max-height': options.maxHeight + 'px',
+                'width': options.width + 'px',
+                'z-index': options.zIndex
+            });
+        },
+
+
+        clearCache: function () {
+            this.cachedResponse = {};
+            this.badQueries = [];
+        },
+
+        clear: function () {
+            this.clearCache();
+            this.currentValue = '';
+            this.suggestions = [];
+        },
+
+        disable: function () {
+            var that = this;
+            that.disabled = true;
+            clearInterval(that.onChangeInterval);
+            that.abortAjax();
+        },
+
+        enable: function () {
+            this.disabled = false;
+        },
+
+        fixPosition: function () {
+            // Use only when container has already its content
+
+            var that = this,
+                $container = $(that.suggestionsContainer),
+                containerParent = $container.parent().get(0);
+            // Fix position automatically when appended to body.
+            // In other cases force parameter must be given.
+            if (containerParent !== document.body && !that.options.forceFixPosition) {
+                return;
+            }
+
+            // Choose orientation
+            var orientation = that.options.orientation,
+                containerHeight = $container.outerHeight(),
+                height = that.el.outerHeight(),
+                offset = that.el.offset(),
+                styles = { 'top': offset.top, 'left': offset.left };
+
+            if (orientation === 'auto') {
+                var viewPortHeight = $(window).height(),
+                    scrollTop = $(window).scrollTop(),
+                    topOverflow = -scrollTop + offset.top - containerHeight,
+                    bottomOverflow = scrollTop + viewPortHeight - (offset.top + height + containerHeight);
+
+                orientation = (Math.max(topOverflow, bottomOverflow) === topOverflow) ? 'top' : 'bottom';
+            }
+
+            if (orientation === 'top') {
+                styles.top += -containerHeight;
+            } else {
+                styles.top += height;
+            }
+
+            // If container is not positioned to body,
+            // correct its position using offset parent offset
+            if(containerParent !== document.body) {
+                var opacity = $container.css('opacity'),
+                    parentOffsetDiff;
+
+                    if (!that.visible){
+                        $container.css('opacity', 0).show();
+                    }
+
+                parentOffsetDiff = $container.offsetParent().offset();
+                styles.top -= parentOffsetDiff.top;
+                styles.left -= parentOffsetDiff.left;
+
+                if (!that.visible){
+                    $container.css('opacity', opacity).hide();
+                }
+            }
+
+            // -2px to account for suggestions border.
+            if (that.options.width === 'auto') {
+                styles.width = (that.el.outerWidth() - 2) + 'px';
+            }
+
+            $container.css(styles);
+        },
+
+        enableKillerFn: function () {
+            var that = this;
+            $(document).on('click.autocomplete', that.killerFn);
+        },
+
+        disableKillerFn: function () {
+            var that = this;
+            $(document).off('click.autocomplete', that.killerFn);
+        },
+
+        killSuggestions: function () {
+            var that = this;
+            that.stopKillSuggestions();
+            that.intervalId = window.setInterval(function () {
+                if (that.visible) {
+                    that.el.val(that.currentValue);
+                    that.hide();
+                }
+                
+                that.stopKillSuggestions();
+            }, 50);
+        },
+
+        stopKillSuggestions: function () {
+            window.clearInterval(this.intervalId);
+        },
+
+        isCursorAtEnd: function () {
+            var that = this,
+                valLength = that.el.val().length,
+                selectionStart = that.element.selectionStart,
+                range;
+
+            if (typeof selectionStart === 'number') {
+                return selectionStart === valLength;
+            }
+            if (document.selection) {
+                range = document.selection.createRange();
+                range.moveStart('character', -valLength);
+                return valLength === range.text.length;
+            }
+            return true;
+        },
+
+        onKeyPress: function (e) {
+            var that = this;
+
+            // If suggestions are hidden and user presses arrow down, display suggestions:
+            if (!that.disabled && !that.visible && e.which === keys.DOWN && that.currentValue) {
+                that.suggest();
+                return;
+            }
+
+            if (that.disabled || !that.visible) {
+                return;
+            }
+
+            switch (e.which) {
+                case keys.ESC:
+                    that.el.val(that.currentValue);
+                    that.hide();
+                    break;
+                case keys.RIGHT:
+                    if (that.hint && that.options.onHint && that.isCursorAtEnd()) {
+                        that.selectHint();
+                        break;
+                    }
+                    return;
+                case keys.TAB:
+                    if (that.hint && that.options.onHint) {
+                        that.selectHint();
+                        return;
+                    }
+                    if (that.selectedIndex === -1) {
+                        that.hide();
+                        return;
+                    }
+                    that.select(that.selectedIndex);
+                    if (that.options.tabDisabled === false) {
+                        return;
+                    }
+                    break;
+                case keys.RETURN:
+                    if (that.selectedIndex === -1) {
+                        that.hide();
+                        return;
+                    }
+                    that.select(that.selectedIndex);
+                    break;
+                case keys.UP:
+                    that.moveUp();
+                    break;
+                case keys.DOWN:
+                    that.moveDown();
+                    break;
+                default:
+                    return;
+            }
+
+            // Cancel event if function did not return:
+            e.stopImmediatePropagation();
+            e.preventDefault();
+        },
+
+        onKeyUp: function (e) {
+            var that = this;
+
+            if (that.disabled) {
+                return;
+            }
+
+            switch (e.which) {
+                case keys.UP:
+                case keys.DOWN:
+                    return;
+            }
+
+            clearInterval(that.onChangeInterval);
+
+            if (that.currentValue !== that.el.val()) {
+                that.findBestHint();
+                if (that.options.deferRequestBy > 0) {
+                    // Defer lookup in case when value changes very quickly:
+                    that.onChangeInterval = setInterval(function () {
+                        that.onValueChange();
+                    }, that.options.deferRequestBy);
+                } else {
+                    that.onValueChange();
+                }
+            }
+        },
+
+        onValueChange: function () {
+            var that = this,
+                options = that.options,
+                value = that.el.val(),
+                query = that.getQuery(value);
+
+            if (that.selection && that.currentValue !== query) {
+                that.selection = null;
+                (options.onInvalidateSelection || $.noop).call(that.element);
+            }
+
+            clearInterval(that.onChangeInterval);
+            that.currentValue = value;
+            that.selectedIndex = -1;
+
+            // Check existing suggestion for the match before proceeding:
+            if (options.triggerSelectOnValidInput && that.isExactMatch(query)) {
+                that.select(0);
+                return;
+            }
+
+            if (query.length < options.minChars) {
+                that.hide();
+            } else {
+                that.getSuggestions(query);
+            }
+        },
+
+        isExactMatch: function (query) {
+            var suggestions = this.suggestions;
+
+            return (suggestions.length === 1 && suggestions[0].value.toLowerCase() === query.toLowerCase());
+        },
+
+        getQuery: function (value) {
+            var delimiter = this.options.delimiter,
+                parts;
+
+            if (!delimiter) {
+                return value;
+            }
+            parts = value.split(delimiter);
+            return $.trim(parts[parts.length - 1]);
+        },
+
+        getSuggestionsLocal: function (query) {
+            var that = this,
+                options = that.options,
+                queryLowerCase = query.toLowerCase(),
+                filter = options.lookupFilter,
+                limit = parseInt(options.lookupLimit, 10),
+                data;
+
+            data = {
+                suggestions: $.grep(options.lookup, function (suggestion) {
+                    return filter(suggestion, query, queryLowerCase);
+                })
+            };
+
+            if (limit && data.suggestions.length > limit) {
+                data.suggestions = data.suggestions.slice(0, limit);
+            }
+
+            return data;
+        },
+
+        getSuggestions: function (q) {
+            var response,
+                that = this,
+                options = that.options,
+                serviceUrl = options.serviceUrl,
+                params,
+                cacheKey,
+                ajaxSettings;
+
+            options.params[options.paramName] = q;
+            params = options.ignoreParams ? null : options.params;
+
+            if (options.onSearchStart.call(that.element, options.params) === false) {
+                return;
+            }
+
+            if ($.isFunction(options.lookup)){
+                options.lookup(q, function (data) {
+                    that.suggestions = data.suggestions;
+                    that.suggest();
+                    options.onSearchComplete.call(that.element, q, data.suggestions);
+                });
+                return;
+            }
+
+            if (that.isLocal) {
+                response = that.getSuggestionsLocal(q);
+            } else {
+                if ($.isFunction(serviceUrl)) {
+                    serviceUrl = serviceUrl.call(that.element, q);
+                }
+                cacheKey = serviceUrl + '?' + $.param(params || {});
+                response = that.cachedResponse[cacheKey];
+            }
+
+            if (response && $.isArray(response.suggestions)) {
+                that.suggestions = response.suggestions;
+                that.suggest();
+                options.onSearchComplete.call(that.element, q, response.suggestions);
+            } else if (!that.isBadQuery(q)) {
+                that.abortAjax();
+
+                ajaxSettings = {
+                    url: serviceUrl,
+                    data: params,
+                    type: options.type,
+                    dataType: options.dataType
+                };
+
+                $.extend(ajaxSettings, options.ajaxSettings);
+
+                that.currentRequest = $.ajax(ajaxSettings).done(function (data) {
+                    var result;
+                    that.currentRequest = null;
+                    result = options.transformResult(data, q);
+                    that.processResponse(result, q, cacheKey);
+                    options.onSearchComplete.call(that.element, q, result.suggestions);
+                }).fail(function (jqXHR, textStatus, errorThrown) {
+                    options.onSearchError.call(that.element, q, jqXHR, textStatus, errorThrown);
+                });
+            } else {
+                options.onSearchComplete.call(that.element, q, []);
+            }
+        },
+
+        isBadQuery: function (q) {
+            if (!this.options.preventBadQueries){
+                return false;
+            }
+
+            var badQueries = this.badQueries,
+                i = badQueries.length;
+
+            while (i--) {
+                if (q.indexOf(badQueries[i]) === 0) {
+                    return true;
+                }
+            }
+
+            return false;
+        },
+
+        hide: function () {
+            var that = this,
+                container = $(that.suggestionsContainer);
+
+            if ($.isFunction(that.options.onHide) && that.visible) {
+                that.options.onHide.call(that.element, container);
+            }
+
+            that.visible = false;
+            that.selectedIndex = -1;
+            clearInterval(that.onChangeInterval);
+            $(that.suggestionsContainer).hide();
+            that.signalHint(null);
+        },
+
+        suggest: function () {
+            if (this.suggestions.length === 0) {
+                if (this.options.showNoSuggestionNotice) {
+                    this.noSuggestions();
+                } else {
+                    this.hide();
+                }
+                return;
+            }
+
+            var that = this,
+                options = that.options,
+                groupBy = options.groupBy,
+                formatResult = options.formatResult,
+                value = that.getQuery(that.currentValue),
+                className = that.classes.suggestion,
+                classSelected = that.classes.selected,
+                container = $(that.suggestionsContainer),
+                noSuggestionsContainer = $(that.noSuggestionsContainer),
+                beforeRender = options.beforeRender,
+                html = '',
+                category,
+                formatGroup = function (suggestion, index) {
+                        var currentCategory = suggestion.data[groupBy];
+
+                        if (category === currentCategory){
+                            return '';
+                        }
+
+                        category = currentCategory;
+
+                        return '<div class="autocomplete-group"><strong>' + category + '</strong></div>';
+                    };
+
+            if (options.triggerSelectOnValidInput && that.isExactMatch(value)) {
+                that.select(0);
+                return;
+            }
+
+            // Build suggestions inner HTML:
+            $.each(that.suggestions, function (i, suggestion) {
+                if (groupBy){
+                    html += formatGroup(suggestion, value, i);
+                }
+
+                html += '<div class="' + className + '" data-index="' + i + '">' + formatResult(suggestion, value) + '</div>';
+            });
+
+            this.adjustContainerWidth();
+
+            noSuggestionsContainer.detach();
+            container.html(html);
+
+            if ($.isFunction(beforeRender)) {
+                beforeRender.call(that.element, container);
+            }
+
+            that.fixPosition();
+            container.show();
+
+            // Select first value by default:
+            if (options.autoSelectFirst) {
+                that.selectedIndex = 0;
+                container.scrollTop(0);
+                container.children('.' + className).first().addClass(classSelected);
+            }
+
+            that.visible = true;
+            that.findBestHint();
+        },
+
+        noSuggestions: function() {
+             var that = this,
+                 container = $(that.suggestionsContainer),
+                 noSuggestionsContainer = $(that.noSuggestionsContainer);
+
+            this.adjustContainerWidth();
+
+            // Some explicit steps. Be careful here as it easy to get
+            // noSuggestionsContainer removed from DOM if not detached properly.
+            noSuggestionsContainer.detach();
+            container.empty(); // clean suggestions if any
+            container.append(noSuggestionsContainer);
+
+            that.fixPosition();
+
+            container.show();
+            that.visible = true;
+        },
+
+        adjustContainerWidth: function() {
+            var that = this,
+                options = that.options,
+                width,
+                container = $(that.suggestionsContainer);
+
+            // If width is auto, adjust width before displaying suggestions,
+            // because if instance was created before input had width, it will be zero.
+            // Also it adjusts if input width has changed.
+            // -2px to account for suggestions border.
+            if (options.width === 'auto') {
+                width = that.el.outerWidth() - 2;
+                container.width(width > 0 ? width : 300);
+            }
+        },
+
+        findBestHint: function () {
+            var that = this,
+                value = that.el.val().toLowerCase(),
+                bestMatch = null;
+
+            if (!value) {
+                return;
+            }
+
+            $.each(that.suggestions, function (i, suggestion) {
+                var foundMatch = suggestion.value.toLowerCase().indexOf(value) === 0;
+                if (foundMatch) {
+                    bestMatch = suggestion;
+                }
+                return !foundMatch;
+            });
+
+            that.signalHint(bestMatch);
+        },
+
+        signalHint: function (suggestion) {
+            var hintValue = '',
+                that = this;
+            if (suggestion) {
+                hintValue = that.currentValue + suggestion.value.substr(that.currentValue.length);
+            }
+            if (that.hintValue !== hintValue) {
+                that.hintValue = hintValue;
+                that.hint = suggestion;
+                (this.options.onHint || $.noop)(hintValue);
+            }
+        },
+
+        verifySuggestionsFormat: function (suggestions) {
+            // If suggestions is string array, convert them to supported format:
+            if (suggestions.length && typeof suggestions[0] === 'string') {
+                return $.map(suggestions, function (value) {
+                    return { value: value, data: null };
+                });
+            }
+
+            return suggestions;
+        },
+
+        validateOrientation: function(orientation, fallback) {
+            orientation = $.trim(orientation || '').toLowerCase();
+
+            if($.inArray(orientation, ['auto', 'bottom', 'top']) === -1){
+                orientation = fallback;
+            }
+
+            return orientation;
+        },
+
+        processResponse: function (result, originalQuery, cacheKey) {
+            var that = this,
+                options = that.options;
+
+            result.suggestions = that.verifySuggestionsFormat(result.suggestions);
+
+            // Cache results if cache is not disabled:
+            if (!options.noCache) {
+                that.cachedResponse[cacheKey] = result;
+                if (options.preventBadQueries && result.suggestions.length === 0) {
+                    that.badQueries.push(originalQuery);
+                }
+            }
+
+            // Return if originalQuery is not matching current query:
+            if (originalQuery !== that.getQuery(that.currentValue)) {
+                return;
+            }
+
+            that.suggestions = result.suggestions;
+            that.suggest();
+        },
+
+        activate: function (index) {
+            var that = this,
+                activeItem,
+                selected = that.classes.selected,
+                container = $(that.suggestionsContainer),
+                children = container.find('.' + that.classes.suggestion);
+
+            container.find('.' + selected).removeClass(selected);
+
+            that.selectedIndex = index;
+
+            if (that.selectedIndex !== -1 && children.length > that.selectedIndex) {
+                activeItem = children.get(that.selectedIndex);
+                $(activeItem).addClass(selected);
+                return activeItem;
+            }
+
+            return null;
+        },
+
+        selectHint: function () {
+            var that = this,
+                i = $.inArray(that.hint, that.suggestions);
+
+            that.select(i);
+        },
+
+        select: function (i) {
+            var that = this;
+            that.hide();
+            that.onSelect(i);
+        },
+
+        moveUp: function () {
+            var that = this;
+
+            if (that.selectedIndex === -1) {
+                return;
+            }
+
+            if (that.selectedIndex === 0) {
+                $(that.suggestionsContainer).children().first().removeClass(that.classes.selected);
+                that.selectedIndex = -1;
+                that.el.val(that.currentValue);
+                that.findBestHint();
+                return;
+            }
+
+            that.adjustScroll(that.selectedIndex - 1);
+        },
+
+        moveDown: function () {
+            var that = this;
+
+            if (that.selectedIndex === (that.suggestions.length - 1)) {
+                return;
+            }
+
+            that.adjustScroll(that.selectedIndex + 1);
+        },
+
+        adjustScroll: function (index) {
+            var that = this,
+                activeItem = that.activate(index);
+
+            if (!activeItem) {
+                return;
+            }
+
+            var offsetTop,
+                upperBound,
+                lowerBound,
+                heightDelta = $(activeItem).outerHeight();
+
+            offsetTop = activeItem.offsetTop;
+            upperBound = $(that.suggestionsContainer).scrollTop();
+            lowerBound = upperBound + that.options.maxHeight - heightDelta;
+
+            if (offsetTop < upperBound) {
+                $(that.suggestionsContainer).scrollTop(offsetTop);
+            } else if (offsetTop > lowerBound) {
+                $(that.suggestionsContainer).scrollTop(offsetTop - that.options.maxHeight + heightDelta);
+            }
+
+            if (!that.options.preserveInput) {
+                that.el.val(that.getValue(that.suggestions[index].value));
+            }
+            that.signalHint(null);
+        },
+
+        onSelect: function (index) {
+            var that = this,
+                onSelectCallback = that.options.onSelect,
+                suggestion = that.suggestions[index];
+
+            that.currentValue = that.getValue(suggestion.value);
+
+            if (that.currentValue !== that.el.val() && !that.options.preserveInput) {
+                that.el.val(that.currentValue);
+            }
+
+            that.signalHint(null);
+            that.suggestions = [];
+            that.selection = suggestion;
+
+            if ($.isFunction(onSelectCallback)) {
+                onSelectCallback.call(that.element, suggestion);
+            }
+        },
+
+        getValue: function (value) {
+            var that = this,
+                delimiter = that.options.delimiter,
+                currentValue,
+                parts;
+
+            if (!delimiter) {
+                return value;
+            }
+
+            currentValue = that.currentValue;
+            parts = currentValue.split(delimiter);
+
+            if (parts.length === 1) {
+                return value;
+            }
+
+            return currentValue.substr(0, currentValue.length - parts[parts.length - 1].length) + value;
+        },
+
+        dispose: function () {
+            var that = this;
+            that.el.off('.autocomplete').removeData('autocomplete');
+            that.disableKillerFn();
+            $(window).off('resize.autocomplete', that.fixPositionCapture);
+            $(that.suggestionsContainer).remove();
+        }
+    };
+
+    // Create chainable jQuery plugin:
+    $.fn.autocomplete = $.fn.devbridgeAutocomplete = function (options, args) {
+        var dataKey = 'autocomplete';
+        // If function invoked without argument return
+        // instance of the first matched element:
+        if (arguments.length === 0) {
+            return this.first().data(dataKey);
+        }
+
+        return this.each(function () {
+            var inputElement = $(this),
+                instance = inputElement.data(dataKey);
+
+            if (typeof options === 'string') {
+                if (instance && typeof instance[options] === 'function') {
+                    instance[options](args);
+                }
+            } else {
+                // If instance already exists, destroy it:
+                if (instance && instance.dispose) {
+                    instance.dispose();
+                }
+                instance = new Autocomplete(this, options);
+                inputElement.data(dataKey, instance);
+            }
+        });
+    };
+}));

--- a/res/smw/ext.smw.css
+++ b/res/smw/ext.smw.css
@@ -466,3 +466,23 @@ label.smw-form-checkbox {
 .smw-subobject-entity {
 	font-style: italic;
 }
+
+/* jquery-autocomplete */
+.autocomplete-suggestions { border: 1px solid #999; background: #FFF; overflow: auto;}
+.autocomplete-suggestion { padding: 2px 5px; white-space: nowrap; overflow: hidden; font-size: 0.8em; }
+.autocomplete-selected { background: #F0F0F0; }
+.autocomplete-suggestions strong { font-weight: normal; color: #3399FF; }
+.autocomplete-group { padding: 2px 5px; }
+.autocomplete-group strong { display: block; border-bottom: 1px solid #000; }
+
+input#smw-property-input.autocomplete-suggestions {
+	height: 1.15em;
+	padding: 2px 2px;
+}
+
+.skin-chameleon input#smw-property-input.autocomplete-suggestions {
+	height: 27px;
+	padding: 2px 2px;
+}
+
+.skin-chameleon .autocomplete-suggestion { padding: 2px 5px; white-space: nowrap; overflow: hidden; font-size: 0.9em; }

--- a/res/smw/special/ext.smw.special.property.js
+++ b/res/smw/special/ext.smw.special.property.js
@@ -1,26 +1,41 @@
 /**
- * JavaScript for property related functions
+ * JavaScript for property autocomplete function
  *
- * @see https://www.mediawiki.org/wiki/Extension:Semantic_MediaWiki
+ * @license GNU GPL v2+
+ * @since 2.4
  *
- * @since 1.8
- * @release 0.1
- *
- * @file
- * @ingroup SMW
- *
- * @licence GNU GPL v2 or later
  * @author mwjames
  */
 
-( function( $ ) {
+( function( $, mw ) {
 	'use strict';
 
 	$( document ).ready( function() {
 
-		// Used in SMW_SpecialSearchByProperty.php
-		// Function is specified in ext.smw.autocomplete
-		$( '#smw-property-input' ).smwAutocomplete();
+		$( '#smw-property-input' ).addClass( 'autocomplete-suggestions' );
+
+		$( '#smw-property-input' ).autocomplete({
+			serviceUrl: mw.util.wikiScript( 'api' ),
+			dataType: 'json',
+			minChars: 3,
+			maxHeight: 150,
+			paramName: 'property',
+			delimiter: "\n",
+			params: {
+				'action': 'browsebyproperty',
+				'format': 'json'
+			},
+			onSearchStart: function( query ) {
+				query.property = query.property.replace( "?", '' );
+			},
+			transformResult: function( response ) {
+				return {
+					suggestions: $.map( response.query, function( dataItem, key ) {
+						return { value: dataItem.label, data: key };
+					} )
+				};
+			}
+		} );
 
 	} );
-} )( jQuery );
+} )( jQuery, mediaWiki );

--- a/src/MediaWiki/Api/BrowseByProperty.php
+++ b/src/MediaWiki/Api/BrowseByProperty.php
@@ -1,0 +1,160 @@
+<?php
+
+namespace SMW\MediaWiki\Api;
+
+use ApiBase;
+use SMW\ApplicationFactory;
+use SMW\NamespaceUriFinder;
+
+/**
+ * @license GNU GPL v2+
+ * @since 2.4
+ *
+ * @author mwjames
+ */
+class BrowseByProperty extends ApiBase {
+
+	/**
+	 * @see ApiBase::execute
+	 */
+	public function execute() {
+
+		$params = $this->extractRequestParams();
+
+		$propertyListByApiRequest = new PropertyListByApiRequest(
+			ApplicationFactory::getInstance()->getStore()
+		);
+
+		$propertyListByApiRequest->setLimit(
+			$params['limit']
+		);
+
+		$propertyListByApiRequest->findPropertyListFor(
+			$params['property']
+		);
+
+		foreach ( $propertyListByApiRequest->getNamespaces() as $ns ) {
+
+			$uri = NamespaceUriFinder::getUri( $ns );
+
+			if ( !$uri ) {
+				continue;
+			}
+
+			$this->getResult()->addValue(
+				null,
+				'xmlns:' . $ns,
+				$uri
+			);
+		}
+
+		$data = $propertyListByApiRequest->getPropertyList();
+
+		// I'm without words for this utter nonsense introduced here
+		// because property keys can have a underscore _MDAT or for that matter
+		// any other data field can
+		// https://www.mediawiki.org/wiki/API:JSON_version_2
+		// " ... can indicate that a property beginning with an underscore is not metadata using"
+		if ( method_exists( $this->getResult(), 'setPreserveKeysList') ) {
+			$this->getResult()->setPreserveKeysList(
+				$data,
+				array_keys( $data )
+			);
+		}
+
+		$this->getResult()->addValue(
+			null,
+			'query',
+			$data
+		);
+
+		$this->getResult()->addValue(
+			null,
+			'version',
+			0.1
+		);
+
+		$this->getResult()->addValue(
+			null,
+			'query-continue-offset',
+			$propertyListByApiRequest->getContinueOffset()
+		);
+
+		$this->getResult()->addValue(
+			null,
+			'meta',
+			$propertyListByApiRequest->getMeta()
+		);
+	}
+
+	/**
+	 * @codeCoverageIgnore
+	 * @see ApiBase::getAllowedParams
+	 *
+	 * @return array
+	 */
+	public function getAllowedParams() {
+		return array(
+			'property' => array(
+				ApiBase::PARAM_TYPE => 'string',
+				ApiBase::PARAM_ISMULTI => false,
+				ApiBase::PARAM_REQUIRED => false,
+			),
+			'limit' => array(
+				ApiBase::PARAM_TYPE => 'string',
+				ApiBase::PARAM_ISMULTI => false,
+				ApiBase::PARAM_DFLT => 50,
+				ApiBase::PARAM_REQUIRED => false,
+			)
+		);
+	}
+
+	/**
+	 * @codeCoverageIgnore
+	 * @see ApiBase::getParamDescription
+	 *
+	 * @return array
+	 */
+	public function getParamDescription() {
+		return array(
+			'property' => 'To select a specific property',
+			'limit' => 'To specify the size of the list request'
+		);
+	}
+
+	/**
+	 * @codeCoverageIgnore
+	 * @see ApiBase::getDescription
+	 *
+	 * @return array
+	 */
+	public function getDescription() {
+		return array(
+			'API module to query a property list or an individual property.'
+		);
+	}
+
+	/**
+	 * @codeCoverageIgnore
+	 * @see ApiBase::getExamples
+	 *
+	 * @return array
+	 */
+	protected function getExamples() {
+		return array(
+			'api.php?action=browsebyproperty&property=Modification_date',
+			'api.php?action=browsebyproperty&limit=50',
+		);
+	}
+
+	/**
+	 * @codeCoverageIgnore
+	 * @see ApiBase::getVersion
+	 *
+	 * @return string
+	 */
+	public function getVersion() {
+		return __CLASS__ . '-' . SMW_VERSION;
+	}
+
+}

--- a/src/MediaWiki/Api/PropertyListByApiRequest.php
+++ b/src/MediaWiki/Api/PropertyListByApiRequest.php
@@ -1,0 +1,174 @@
+<?php
+
+namespace SMW\MediaWiki\Api;
+
+use SMW\Store;
+use SMW\DIProperty;
+use SMW\NamespaceUriFinder;
+use SMW\RequestOptions;
+use SMW\StringCondition;
+
+/**
+ * @license GNU GPL v2+
+ * @since 2.4
+ *
+ * @author mwjames
+ */
+class PropertyListByApiRequest {
+
+	/**
+	 * @var Store
+	 */
+	private $store;
+
+	/**
+	 * @var RequestOptions
+	 */
+	private $requestOptions = null;
+
+	/**
+	 * @var array
+	 */
+	private $propertyList = array();
+
+	/**
+	 * @var array
+	 */
+	private $namespaces = array();
+
+	/**
+	 * @var array
+	 */
+	private $meta = array();
+
+	/**
+	 * @var array
+	 */
+	private $continueOffset = 0;
+
+	/**
+	 * @since 2.4
+	 *
+	 * @param Store $store
+	 */
+	public function __construct( Store $store ) {
+		$this->store = $store;
+		$this->requestOptions = new RequestOptions();
+		$this->requestOptions->sort = true;
+		$this->requestOptions->limit = 50;
+	}
+
+	/**
+	 * @since 2.4
+	 *
+	 * @param integer $limit
+	 */
+	public function setLimit( $limit ) {
+		$this->requestOptions->limit = (int)$limit;
+	}
+
+	/**
+	 * @since 2.4
+	 *
+	 * @param array
+	 */
+	public function getPropertyList() {
+		return $this->propertyList;
+	}
+
+	/**
+	 * @since 2.4
+	 *
+	 * @param array
+	 */
+	public function getNamespaces() {
+		return $this->namespaces;
+	}
+
+	/**
+	 * @since 2.4
+	 *
+	 * @param array
+	 */
+	public function getMeta() {
+		return $this->meta;
+	}
+
+	/**
+	 * @since 2.4
+	 *
+	 * @param array
+	 */
+	public function getContinueOffset() {
+		return $this->continueOffset;
+	}
+
+	/**
+	 * @since 2.4
+	 *
+	 * @param string $property
+	 *
+	 * @return boolean
+	 */
+	public function findPropertyListFor( $property = '' ) {
+
+		$this->meta = array();
+		$this->propertyList = array();
+		$this->namespaces = array();
+
+		$this->requestOptions->limit++; // increase by one to look ahead
+		$this->continueOffset = 1;
+
+		if ( $property !== '' ) {
+			$property = str_replace( "_", " ", $property );
+			$this->requestOptions->addStringCondition( $property, StringCondition::STRCOND_MID );
+
+			// Disjunctive condition to allow for auto searches of foaf OR Foaf
+			$this->requestOptions->addStringCondition( ucfirst( $property ), StringCondition::STRCOND_MID, true );
+		}
+
+		$propertyListLookup = $this->store->getPropertiesSpecial( $this->requestOptions );
+		$this->requestOptions->limit--;
+
+		foreach ( $propertyListLookup->fetchList() as $value ) {
+
+			if ( $this->continueOffset > $this->requestOptions->limit ) {
+				break;
+			}
+
+			$this->addPropertyToList( $value );
+			$this->continueOffset++;
+		}
+
+		$this->continueOffset = $this->continueOffset > $this->requestOptions->limit ? $this->requestOptions->limit : 0;
+		$this->namespaces = array_keys( $this->namespaces );
+
+		$this->meta = array(
+			'limit' => $this->requestOptions->limit,
+			'count' => count( $this->propertyList ),
+			'isCached' => $propertyListLookup->isCached()
+		);
+
+		return true;
+	}
+
+	private function addPropertyToList( array $value ) {
+
+		if ( $value === array() || !$value[0] instanceof DIProperty ) {
+			return;
+		}
+
+		$key = $value[0]->getKey();
+
+		if ( strpos( $key, ':' ) !== false ) {
+			$this->namespaces[substr( $key, 0, strpos( $key, ':' ) )] = true;
+		}
+
+		$this->propertyList[$key] = array(
+			'label' => $value[0]->getLabel(),
+			'isUserDefined' => $value[0]->isUserDefined(),
+			'usageCount' => $value[1]
+		);
+	}
+
+}

--- a/src/NamespaceUriFinder.php
+++ b/src/NamespaceUriFinder.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace SMW;
+
+/**
+ * @license GNU GPL v2+
+ * @since 2.4
+ *
+ * @author mwjames
+ */
+class NamespaceUriFinder {
+
+	/**
+	 * @var array
+	 */
+	private static $namespaceUriList = array(
+		'owl'   => 'http://www.w3.org/2002/07/owl#',
+		'rdf'   => 'http://www.w3.org/1999/02/22-rdf-syntax-ns#',
+		'rdfs'  => 'http://www.w3.org/2000/01/rdf-schema#',
+		'swivt' => 'http://semantic-mediawiki.org/swivt/1.0#',
+		'xsd'   => 'http://www.w3.org/2001/XMLSchema#',
+		'skos'  => 'http://www.w3.org/2004/02/skos/core#',
+		'foaf'  => 'http://xmlns.com/foaf/0.1/',
+		'dc'    => 'http://purl.org/dc/elements/1.1/'
+	);
+
+	/**
+	 * @since 2.4
+	 *
+	 * @param string $key
+	 *
+	 * @return false|string
+	 */
+	public static function getUri( $key ) {
+
+		$key = strtolower( $key );
+
+		if ( isset( self::$namespaceUriList[$key] ) ) {
+			return self::$namespaceUriList[$key];
+		}
+
+		return false;
+	}
+
+}

--- a/src/RequestOptions.php
+++ b/src/RequestOptions.php
@@ -65,7 +65,7 @@ class RequestOptions {
 	/**
 	 * @since 1.0
 	 *
-	 * @param srting $string to match
+	 * @param string $string to match
 	 * @param integer $condition one of STRCOND_PRE, STRCOND_POST, STRCOND_MID
 	 * @param boolean $asDisjunctiveCondition
 	 */

--- a/src/SQLStore/Lookup/PropertyUsageListLookup.php
+++ b/src/SQLStore/Lookup/PropertyUsageListLookup.php
@@ -97,7 +97,8 @@ class PropertyUsageListLookup implements ListLookup {
 
 		$conditions = array(
 			'smw_namespace' => SMW_NS_PROPERTY,
-			'smw_iw' => ''
+			'smw_iw' => '',
+			'smw_subobject' => ''
 		);
 
 		if ( $this->requestOptions->limit > 0 ) {

--- a/tests/phpunit/Unit/MediaWiki/Api/BrowseByPropertyTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Api/BrowseByPropertyTest.php
@@ -1,0 +1,113 @@
+<?php
+
+namespace SMW\Tests\MediaWiki\Api;
+
+use SMW\Tests\Utils\UtilityFactory;
+use SMW\MediaWiki\Api\BrowseByProperty;
+use SMW\ApplicationFactory;
+use SMW\DIProperty;
+
+/**
+ * @covers \SMW\MediaWiki\Api\BrowseByProperty
+ * @group semantic-mediawiki
+ *
+ * @license GNU GPL v2+
+ * @since 2.4
+ *
+ * @author mwjames
+ */
+class BrowseByPropertyTest extends \PHPUnit_Framework_TestCase {
+
+	private $store;
+	private $apiFactory;
+	private $applicationFactory;
+
+	protected function setUp() {
+		parent::setUp();
+
+		$this->store = $this->getMockBuilder( '\SMW\Store' )
+			->disableOriginalConstructor()
+			->getMockForAbstractClass();
+
+		$this->applicationFactory = ApplicationFactory::getInstance();
+		$this->applicationFactory->registerObject( 'Store', $this->store );
+
+		$this->apiFactory = UtilityFactory::getInstance()->newMwApiFactory();
+	}
+
+	protected function tearDown() {
+		$this->applicationFactory->clear();
+		parent::tearDown();
+	}
+
+	public function testCanConstruct() {
+
+		$instance = new BrowseByProperty(
+			$this->apiFactory->newApiMain( array() ),
+			'browsebyproperty'
+		);
+
+		$this->assertInstanceOf(
+			'SMW\MediaWiki\Api\BrowseByProperty',
+			$instance
+		);
+	}
+
+	public function testExecute() {
+
+		$list[] = array(
+			new DIProperty( 'Foo' ),
+			42
+		);
+
+		$list[] = array(
+			new DIProperty( 'Foaf:Foo' ),
+			1001
+		);
+
+		$list[] = array(
+			new DIProperty( 'Unknown:Foo' ),
+			1001
+		);
+
+		$cachedListLookup = $this->getMockBuilder( '\SMW\SQLStore\Lookup\CachedListLookup' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$cachedListLookup->expects( $this->once() )
+			->method( 'fetchList' )
+			->will( $this->returnValue( $list ) );
+
+		$this->store->expects( $this->once() )
+			->method( 'getPropertiesSpecial' )
+			->will( $this->returnValue( $cachedListLookup ) );
+
+		$this->applicationFactory->registerObject( 'Store', $this->store );
+
+		$result = $this->apiFactory->doApiRequest( array(
+			'action'  => 'browsebyproperty',
+			'property' => 'Foo'
+		) );
+
+		$this->assertArrayHasKey(
+			'query',
+			$result
+		);
+
+		$this->assertArrayHasKey(
+			'version',
+			$result
+		);
+
+		$this->assertArrayHasKey(
+			'query-continue-offset',
+			$result
+		);
+
+		$this->assertArrayHasKey(
+			'meta',
+			$result
+		);
+	}
+
+}

--- a/tests/phpunit/Unit/MediaWiki/Api/PropertyListByApiRequestTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Api/PropertyListByApiRequestTest.php
@@ -1,0 +1,127 @@
+<?php
+
+namespace SMW\Tests\MediaWiki\Api;
+
+use SMW\Tests\Utils\UtilityFactory;
+use SMW\MediaWiki\Api\PropertyListByApiRequest;
+use SMW\ApplicationFactory;
+use SMW\DIProperty;
+
+/**
+ * @covers \SMW\MediaWiki\Api\PropertyListByApiRequest
+ * @group semantic-mediawiki
+ *
+ * @license GNU GPL v2+
+ * @since 2.4
+ *
+ * @author mwjames
+ */
+class PropertyListByApiRequestTest extends \PHPUnit_Framework_TestCase {
+
+	private $store;
+
+	protected function setUp() {
+		parent::setUp();
+
+		$this->store = $this->getMockBuilder( '\SMW\Store' )
+			->disableOriginalConstructor()
+			->getMockForAbstractClass();
+	}
+
+	public function testCanConstruct() {
+
+		$this->assertInstanceOf(
+			'SMW\MediaWiki\Api\PropertyListByApiRequest',
+			new PropertyListByApiRequest( $this->store )
+		);
+	}
+
+	public function testGetSerializedListForProperty() {
+
+		$list[] = array(
+			new DIProperty( 'Foo' ),
+			42
+		);
+
+		$list[] = array(
+			new DIProperty( 'Foaf:Foo' ),
+			1001
+		);
+
+		$list[] = array(
+			new \SMWDIError( 'error' ),
+			-1
+		);
+
+		$list[] = array();
+
+		$isCached = true;
+
+		$expectedSerializedPropertyList = array(
+			'Foo' => array(
+				'label' => 'Foo',
+				'isUserDefined' => true,
+				'usageCount' => 42
+			),
+			'Foaf:Foo' => array(
+				'label' => 'Foaf:Foo',
+				'isUserDefined' => true,
+				'usageCount' => 1001
+			)
+		);
+
+		$expectedNamespaces = array(
+			'Foaf'
+		);
+
+		$expectedMeta = array(
+			'limit' => 3,
+			'count' => 2,
+			'isCached' => $isCached
+		);
+
+		$cachedListLookup = $this->getMockBuilder( '\SMW\SQLStore\Lookup\CachedListLookup' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$cachedListLookup->expects( $this->once() )
+			->method( 'fetchList' )
+			->will( $this->returnValue( $list ) );
+
+		$cachedListLookup->expects( $this->once() )
+			->method( 'isCached' )
+			->will( $this->returnValue( $isCached ) );
+
+		$this->store->expects( $this->once() )
+			->method( 'getPropertiesSpecial' )
+			->will( $this->returnValue( $cachedListLookup ) );
+
+		$instance = new PropertyListByApiRequest( $this->store );
+		$instance->setLimit( 3 );
+
+		$this->assertTrue(
+			$instance->findPropertyListFor( 'Foo' )
+		);
+
+		$this->assertEquals(
+			$expectedSerializedPropertyList,
+			$instance->getPropertyList()
+		);
+
+		$this->assertEquals(
+			$expectedNamespaces,
+			$instance->getNamespaces()
+		);
+
+		$this->assertEquals(
+			$expectedMeta,
+			$instance->getMeta()
+		);
+
+		$this->assertEquals(
+			3,
+			$instance->getContinueOffset()
+		);
+	}
+
+}

--- a/tests/phpunit/Unit/NamespaceUriFinderTest.php
+++ b/tests/phpunit/Unit/NamespaceUriFinderTest.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace SMW\Tests;
+
+use SMW\NamespaceUriFinder;
+
+/**
+ * @covers \SMW\NamespaceUriFinder
+ * @group semantic-mediawiki
+ *
+ * @license GNU GPL v2+
+ * @since 2.4
+ *
+ * @author mwjames
+ */
+class NamespaceUriFinderTest extends \PHPUnit_Framework_TestCase {
+
+	/**
+	 * @dataProvider namespaceProvider
+	 */
+	public function testGetUriForNamespaceKey( $key, $expected ) {
+		$this->assertInternalType(
+			$expected,
+			NamespaceUriFinder::getUri( $key )
+		);
+	}
+
+	public function namespaceProvider() {
+
+		$provider[] = array(
+			'Foo',
+			'boolean'
+		);
+
+		$ns = array(
+			'owl', 'rdf', 'rdfs', 'swivt', 'xsd', 'skos', 'foaf', 'dc',
+			'OWL'
+		);
+
+		foreach ( $ns as $key ) {
+			$provider[] = array(
+				$key,
+				'string'
+			);
+		}
+
+		return $provider;
+	}
+
+}

--- a/tests/phpunit/Unit/SQLStore/Lookup/CachedListLookupTest.php
+++ b/tests/phpunit/Unit/SQLStore/Lookup/CachedListLookupTest.php
@@ -33,7 +33,7 @@ class CachedListLookupTest extends \PHPUnit_Framework_TestCase {
 
 	public function testfetchListFromCache() {
 
-		$expectedCachedItem[md5('123')] = array(
+		$expectedCachedItem = array(
 			'time' => 42,
 			'list' => array( 'Foo' )
 		);
@@ -87,7 +87,7 @@ class CachedListLookupTest extends \PHPUnit_Framework_TestCase {
 
 	public function testRetrieveResultListFromInjectedListLookup() {
 
-		$expectedCacheItem[md5('123')] = array(
+		$expectedCacheItem = array(
 			'time' => 42,
 			'list' => array( 'Foo' )
 		);
@@ -108,7 +108,7 @@ class CachedListLookupTest extends \PHPUnit_Framework_TestCase {
 			->disableOriginalConstructor()
 			->getMock();
 
-		$cache->expects( $this->once() )
+		$cache->expects( $this->at( 1 ) )
 			->method( 'save' )
 			->with(
 				$this->stringContains( 'llc' ),
@@ -151,6 +151,10 @@ class CachedListLookupTest extends \PHPUnit_Framework_TestCase {
 			->getMock();
 
 		$cache->expects( $this->once() )
+			->method( 'fetch' )
+			->will( $this->returnValue( serialize( array( 'smw:llc:6283479db90b04ad3a6db333a3c89766' => true ) ) ) );
+
+		$cache->expects( $this->atLeastOnce() )
 			->method( 'delete' )
 			->with(
 				$this->stringContains( 'llc' ) );

--- a/tests/phpunit/includes/SetupTest.php
+++ b/tests/phpunit/includes/SetupTest.php
@@ -258,6 +258,7 @@ class SetupTest extends \PHPUnit_Framework_TestCase {
 			'smwinfo',
 			'askargs',
 			'browsebysubject',
+			'browsebyproperty'
 		);
 
 		return $this->buildDataProvider( 'wgAPIModules', $modules, '' );


### PR DESCRIPTION
- Add `browsebyproperty` API module (`BrowseByProperty` -> `PropertyListByApiRequest`) to make it possible to fetch a list of available properties or search for an individual property as demonstrated by the `ext.smw.property` RL module used in `Special:SearchByProperty`
- `PropertyUsageListLookup` (and eventually `CachedListLookup`) take care of returning cached results for either the whole list or any partial search string
- #1237 allows for performant lookup of a property list
- Access the same list as `Special:Properties` (current autcomplete gets only half the list without any predefined properties being suggested)
- JS clients can access the property list or a single property using `api.php?action=browsebyproperty&property=Modification_date` or `'api.php?action=browsebyproperty&limit=50`
- No longer rely on `jquery.ui.autocomplete` , added Ajax Autocomplete for jQuery, version 1.2.24 [0] 

refs #1266

Autocomplete

![image](https://cloud.githubusercontent.com/assets/1245473/11084138/ba1cb50e-8837-11e5-837c-b34823d01ca0.png)

XML

![image](https://cloud.githubusercontent.com/assets/1245473/11084141/d44bb2cc-8837-11e5-9a87-304bac289ec1.png)

JSON

![image](https://cloud.githubusercontent.com/assets/1245473/11084148/f4b1ba70-8837-11e5-8c7b-05ffcc696887.png)

[0] https://github.com/devbridge/jQuery-Autocomplete (is freely distributable under the terms of an MIT-style license)