### PR TITLE
Display correct property header for an inverse printout

### DIFF
--- a/includes/datavalues/SMW_DV_Property.php
+++ b/includes/datavalues/SMW_DV_Property.php
@@ -165,8 +165,18 @@ class SMWPropertyValue extends SMWDataValue {
 	 */
 	public function getWikiPageValue() {
 		if ( !isset( $this->m_wikipage ) ) {
+
 			$diWikiPage = $this->m_dataitem->getDiWikiPage();
-			if ( !is_null( $diWikiPage ) ) {
+
+			// A page representation for an inverse property is not possible
+			// therefore construct its non-inverse representation (label/caption
+			// remains and will show with an inverse indicator)
+			if ( $diWikiPage === null && $this->m_dataitem->isInverse() ) {
+				$property = new SMWDIProperty( $this->m_dataitem->getKey() );
+				$diWikiPage = $property->getDiWikiPage();
+			}
+
+			if ( $diWikiPage !== null ) {
 				$this->m_wikipage = \SMW\DataValueFactory::getInstance()->newDataItemValue( $diWikiPage, null, $this->m_caption );
 				$this->m_wikipage->setOutputFormat( $this->m_outformat );
 				$this->addError( $this->m_wikipage->getErrors() );

--- a/tests/phpunit/Integration/ByJsonScript/Fixtures/p-0702 [en] ask on inverse property.json
+++ b/tests/phpunit/Integration/ByJsonScript/Fixtures/p-0702 [en] ask on inverse property.json
@@ -1,0 +1,43 @@
+{
+	"description": "Inverse property table",
+	"properties": [
+		{
+			"name": "Has inverse prop",
+			"contents": "[[Has type::Page]]"
+		}
+	],
+	"subjects": [
+		{
+			"name": "Example/P0702/1",
+			"contents": "{{#subobject:|Has inverse prop=InverseExample|Has number=4040}}"
+		},
+		{
+			"name": "Example/P0702/2",
+			"contents": "{{#ask: [[-Has inverse prop::<q>[[-Has subobject::Example/P0702/1]]</q>]]|?-Has inverse prop||?-Has inverse prop=LabelOnInversePrintout|format=table}}"
+		}
+	],
+	"parser-testcases": [
+		{
+			"about": "#0 table output using inverse property (label is inverse, link is to normal property)",
+			"subject": "Example/P0702/2",
+			"expected-output": {
+				"to-contain": [
+					"Property:Has_inverse_prop\" title=\"Property:Has inverse prop\">-Has inverse prop</a>",
+					">InverseExample</a>",
+					"title=\"Example/P0702/1\">Example/P0702/1</a>",
+					">LabelOnInversePrintout</a>"
+				]
+			}
+		}
+	],
+	"settings": {
+		"wgContLang": "en",
+		"wgLang": "en",
+		"smwgPageSpecialProperties": [ "_MDAT" ]
+	},
+	"meta": {
+		"version": "0.1",
+		"is-incomplete": false,
+		"debug": false
+	}
+}


### PR DESCRIPTION
Discovered by Cheifgeek157 [0].

[0] https://semantic-mediawiki.org/wiki/Thread:Help_talk:Inline_queries/Header_name_for_inverse_properties_in_ask_queries