### PR TITLE
Add _rec QueryResultSerializer support, refs #1271

### DIFF
--- a/includes/datavalues/SMW_DV_PropertyList.php
+++ b/includes/datavalues/SMW_DV_PropertyList.php
@@ -1,6 +1,6 @@
 <?php
 
-use SMW\StoreFactory;
+use SMW\ApplicationFactory;
 
 /**
  * @ingroup SMWDataValues
@@ -83,7 +83,7 @@ class SMWPropertyListValue extends SMWDataValue {
 
 			if ( $property instanceof SMWDIProperty ) {
 				 // Find a possible redirect
-				$this->m_diProperties[] = StoreFactory::getStore()->getRedirectTarget( $property );
+				$this->m_diProperties[] = ApplicationFactory::getInstance()->getStore()->getRedirectTarget( $property );
 			}
 		}
 

--- a/includes/datavalues/SMW_DV_Record.php
+++ b/includes/datavalues/SMW_DV_Record.php
@@ -125,7 +125,7 @@ class SMWRecordValue extends SMWDataValue {
 			return true;
 		} elseif ( $dataItem->getDIType() == SMWDataItem::TYPE_WIKIPAGE ) {
 			$semanticData = new SMWContainerSemanticData( $dataItem );
-			$semanticData->copyDataFrom( \SMW\StoreFactory::getStore()->getSemanticData( $dataItem ) );
+			$semanticData->copyDataFrom( \SMW\ApplicationFactory::getInstance()->getStore()->getSemanticData( $dataItem ) );
 			$this->m_dataitem = new SMWDIContainer( $semanticData );
 			return true;
 		} else {
@@ -264,7 +264,7 @@ class SMWRecordValue extends SMWDataValue {
 
 			if ( !is_null( $propertyDiWikiPage ) ) {
 				$listDiProperty = new SMWDIProperty( '_LIST' );
-				$dataItems = \SMW\StoreFactory::getStore()->getPropertyValues( $propertyDiWikiPage, $listDiProperty );
+				$dataItems = \SMW\ApplicationFactory::getInstance()->getStore()->getPropertyValues( $propertyDiWikiPage, $listDiProperty );
 
 				if ( count( $dataItems ) == 1 ) {
 					$propertyListValue = new SMWPropertyListValue( '__pls' );


### PR DESCRIPTION
Serialization will contain something like:

```
{
    "query": {
        "printrequests": [
            {
                "label": "",
                "typeid": "_wpg",
                "mode": 2
            },
            {
                "label": "Has record",
                "typeid": "_rec",
                "mode": 1,
                "format": ""
            }
        ],
        "results": {
            "RecordApiTest# 64e71894c6c7c94ed6abae5adf39fb2b": {
                "printouts": {
                    "Has record": [
                        {
                            "Has text": {
                                "label": "Has text",
                                "typeid": "_txt",
                                "item": [
                                    "Test1"
                                ]
                            },
                            "Has status": {
                                "label": "Has status",
                                "typeid": "_txt",
                                "item": [
                                    "open"
                                ]
                            }
                        },
                        {
                            "Has text": {
                                "label": "Has text",
                                "typeid": "_txt",
                                "item": [
                                    "Test2"
                                ]
                            },
                            "Has status": {
                                "label": "Has status",
                                "typeid": "_txt",
                                "item": [
                                    "open"
                                ]
                            }
                        },
                        {
                            "Has text": {
                                "label": "Has text",
                                "typeid": "_txt",
                                "item": [
                                    "Test1"
                                ]
                            },
                            "Has status": {
                                "label": "Has status",
                                "typeid": "_txt",
                                "item": [
                                    "closed"
                                ]
                            }
                        }
                    ]
                },
                "fulltext": "RecordApiTest# 64e71894c6c7c94ed6abae5adf39fb2b",
                "fullurl": "http://localhost:8080/mw-25-01/index.php/RecordApiTest#_64e71894c6c7c94ed6abae5adf39fb2b",
                "namespace": 0,
                "exists": ""
            },
            "RecordApiTest": {
                "printouts": {
                    "Has record": []
                },
                "fulltext": "RecordApiTest",
                "fullurl": "http://localhost:8080/mw-25-01/index.php/RecordApiTest",
                "namespace": 0,
                "exists": ""
            }
        },
        "serializer": "SMW\\Serializers\\QueryResultSerializer",
        "version": 0.6,
        "meta": {
            "hash": "9e7ffdcd628cc0cdd3d90af5a43a5977",
            "count": 2,
            "offset": 0
        }
    }
}
```

refs #1271 