### PR TITLE
Exported API time format is insufficient

### DIFF
--- a/res/smw/data/ext.smw.data.js
+++ b/res/smw/data/ext.smw.data.js
@@ -130,7 +130,7 @@
 							break;
 						case '_dat':
 							$.map( value, function( t ) {
-								factoredValue.push( new smw.dataItem.time( t ) );
+								factoredValue.push( new smw.dataItem.time( ( t.hasOwnProperty( 'timestamp' ) ? t.timestamp : t ) ) );
 							} );
 							break;
 						case '_num':

--- a/src/Serializers/QueryResultSerializer.php
+++ b/src/Serializers/QueryResultSerializer.php
@@ -43,7 +43,7 @@ class QueryResultSerializer implements DispatchableSerializer {
 			throw new OutOfBoundsException( 'Object was not identified as a QueryResult instance' );
 		}
 
-		return $this->getSerializedQueryResult( $queryResult ) + array( 'serializer' => __CLASS__, 'version' => 0.6 );
+		return $this->getSerializedQueryResult( $queryResult ) + array( 'serializer' => __CLASS__, 'version' => 0.7 );
 	}
 
 	/**
@@ -124,7 +124,10 @@ class QueryResultSerializer implements DispatchableSerializer {
 				$result = $dataItem->getCoordinateSet();
 				break;
 			case DataItem::TYPE_TIME:
-				$result = $dataItem->getMwTimestamp();
+				$result = array(
+					'timestamp' => $dataItem->getMwTimestamp(),
+					'raw' => $dataItem->getSerialization()
+				);
 				break;
 			default:
 				$result = $dataItem->getSerialization();

--- a/tests/phpunit/Unit/Serializers/QueryResultSerializerTest.php
+++ b/tests/phpunit/Unit/Serializers/QueryResultSerializerTest.php
@@ -117,6 +117,28 @@ class QueryResultSerializerTest extends \PHPUnit_Framework_TestCase {
 		\SMW\ApplicationFactory::getInstance()->clear();
 	}
 
+	public function testSerializeFormatForTimeValue() {
+
+		$property = \SMW\DIProperty::newFromUserLabel( 'Foo' );
+		$property->setPropertyTypeId( '_dat' );
+
+		$printRequestFactory = new \SMW\Query\PrintRequestFactory();
+
+		$serialization = QueryResultSerializer::getSerialization(
+			\SMWDITime::doUnserialize( '2/1393/1/1' ),
+			$printRequestFactory->newPropertyPrintRequest( $property )
+		);
+
+		$expected = array(
+			'timestamp' => '-18208281600',
+			'raw' => '2/1393/1/1'
+		);
+
+		$this->assertEquals(
+			$expected,
+			$serialization
+		);
+	}
 
 	public function testQueryResultSerializerOnMockOnDIWikiPageNonTitle() {
 


### PR DESCRIPTION
The simple `getMwTimestamp` output (e.g. `-18208281600` for `1 Jan 1393`) is insufficient for a general workable API solution in order for a consumer to create a meaningful interpretation.

The output was extended to carry two representations, the previous timestamp and now the raw format (e.g. `2/1393/1/1`) which can can be used to deserialize the data into its original value depiction (with the intended precision).

`smw.dataItem.data` as been adjusted to find the correct timestamp element.

Consumers that use JS/`smw.dataItem.data` can work with both API results (< 0.7 >).

```
"Has date": [
    {
        "timestamp": "-2000101000000",
        "raw": "2/-200"
    },
    {
        "timestamp": "-18208281600",
        "raw": "2/1393/1/1"
    }
```