### PR TITLE
API/QueryResultSerializer, export the property key

### DIFF
--- a/src/Serializers/QueryResultSerializer.php
+++ b/src/Serializers/QueryResultSerializer.php
@@ -43,7 +43,7 @@ class QueryResultSerializer implements DispatchableSerializer {
 			throw new OutOfBoundsException( 'Object was not identified as a QueryResult instance' );
 		}
 
-		return $this->getSerializedQueryResult( $queryResult ) + array( 'serializer' => __CLASS__, 'version' => 0.7 );
+		return $this->getSerializedQueryResult( $queryResult ) + array( 'serializer' => __CLASS__, 'version' => 0.8 );
 	}
 
 	/**
@@ -82,6 +82,7 @@ class QueryResultSerializer implements DispatchableSerializer {
 
 						$recordDiValues[$label] = array(
 							'label'  => $label,
+							'key'    => $property->getKey(),
 							'typeid' => $property->findPropertyTypeID(),
 							'item'   => array()
 						);
@@ -152,9 +153,10 @@ class QueryResultSerializer implements DispatchableSerializer {
 
 		foreach ( $queryResult->getPrintRequests() as $printRequest ) {
 			$printRequests[] = array(
-				'label' => $printRequest->getLabel(),
+				'label'  => $printRequest->getLabel(),
+				'key'    => $printRequest->getMode() === PrintRequest::PRINT_PROP ? $printRequest->getData()->getDataItem()->getKey() : '',
 				'typeid' => $printRequest->getTypeID(),
-				'mode' => $printRequest->getMode(),
+				'mode'   => $printRequest->getMode(),
 				'format' => $printRequest->getOutputFormat()
 			);
 		}

--- a/tests/phpunit/Integration/QueryResultQueryProcessorIntegrationTest.php
+++ b/tests/phpunit/Integration/QueryResultQueryProcessorIntegrationTest.php
@@ -167,13 +167,15 @@ class QueryResultQueryProcessorIntegrationTest extends MwDBaseUnitTestCase {
 					'label'=> '',
 					'typeid' => '_wpg',
 					'mode' => 2,
-					'format' => false
+					'format' => false,
+					'key' => ''
 				),
 				array(
 					'label'=> 'Modification date',
 					'typeid' => '_dat',
 					'mode' => 1,
-					'format' => ''
+					'format' => '',
+					'key' => '_MDAT'
 				)
 			)
 		);
@@ -191,13 +193,15 @@ class QueryResultQueryProcessorIntegrationTest extends MwDBaseUnitTestCase {
 					'label'=> '',
 					'typeid' => '_wpg',
 					'mode' => 2,
-					'format' => false
+					'format' => false,
+					'key' => ''
 				),
 				array(
 					'label'=> 'Modification date',
 					'typeid' => '_dat',
 					'mode' => 1,
-					'format' => 'ISO'
+					'format' => 'ISO',
+					'key' => '_MDAT'
 				)
 			)
 		);

--- a/tests/phpunit/Unit/MediaWiki/Api/AskArgsTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Api/AskArgsTest.php
@@ -205,7 +205,8 @@ class AskArgsTest extends \PHPUnit_Framework_TestCase  {
 						'label'=> '',
 						'typeid' => '_wpg',
 						'mode' => 2,
-						'format' => false
+						'format' => false,
+						'key' => ''
 					)
 				)
 			),
@@ -222,13 +223,15 @@ class AskArgsTest extends \PHPUnit_Framework_TestCase  {
 						'label'=> '',
 						'typeid' => '_wpg',
 						'mode' => 2,
-						'format' => false
+						'format' => false,
+						'key' => ''
 					),
 					array(
 						'label'=> 'Modification date',
 						'typeid' => '_dat',
 						'mode' => 1,
-						'format' => ''
+						'format' => '',
+						'key' => '_MDAT'
 					)
 				)
 			),
@@ -245,13 +248,15 @@ class AskArgsTest extends \PHPUnit_Framework_TestCase  {
 						'label'=> '',
 						'typeid' => '_wpg',
 						'mode' => 2,
-						'format' => false
+						'format' => false,
+						'key' => ''
 					),
 					array(
 						'label'=> 'Modification date',
 						'typeid' => '_dat',
 						'mode' => 1,
-						'format' => ''
+						'format' => '',
+						'key' => '_MDAT'
 					)
 				)
 			),

--- a/tests/phpunit/Unit/MediaWiki/Api/AskTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Api/AskTest.php
@@ -72,13 +72,15 @@ class AskTest extends \PHPUnit_Framework_TestCase {
 					'label'=> '',
 					'typeid' => '_wpg',
 					'mode' => 2,
-					'format' => false
+					'format' => false,
+					'key' => ''
 				),
 				array(
 					'label'=> 'Modification date',
 					'typeid' => '_dat',
 					'mode' => 1,
-					'format' => ''
+					'format' => '',
+					'key' => '_MDAT'
 				)
 			)
 		);

--- a/tests/phpunit/Unit/Serializers/QueryResultSerializerTest.php
+++ b/tests/phpunit/Unit/Serializers/QueryResultSerializerTest.php
@@ -100,12 +100,14 @@ class QueryResultSerializerTest extends \PHPUnit_Framework_TestCase {
 			'BarList1' => array(
 				'label'  => 'BarList1',
 				'typeid' => '_wpg',
-				'item'   => array()
+				'item'   => array(),
+				'key'    => 'BarList1'
 			),
 			'BarList2' => array(
 				'label'  => 'BarList2',
 				'typeid' => '_wpg',
-				'item'   => array()
+				'item'   => array(),
+				'key'    => 'BarList2'
 			)
 		);
 
@@ -178,8 +180,8 @@ class QueryResultSerializerTest extends \PHPUnit_Framework_TestCase {
 				),
 			array(
 				'printrequests' => array(
-					array( 'label' => 'Foo-1', 'typeid' => '_num', 'mode' => 2, 'format' => false ),
-					array( 'label' => 'Foo-2', 'typeid' => '_num', 'mode' => 2, 'format' => false )
+					array( 'label' => 'Foo-1', 'typeid' => '_num', 'mode' => 2, 'format' => false, 'key' => '' ),
+					array( 'label' => 'Foo-2', 'typeid' => '_num', 'mode' => 2, 'format' => false, 'key' => '' )
 				),
 			)
 		);


### PR DESCRIPTION
Allow a property key to be recoverable.

If a predefined property is exported while using an arbitrary label (and therefore compares to the label and not to its key) the internal key needs to be recoverable to allow for a correct
deserialization.

```
{{#ask: [[Modification date::+]]
 |?Modification date
 |?Modification date=DateLabelToBeTheAPIOutputReference
}}
```

```
{
    "label": "Modification date",
    "key": "_MDAT",
    "typeid": "_dat",
    "mode": 1,
    "format": ""
},
{
    "label": "DateLabelToBeTheAPIOutputReference",
    "key": "_MDAT",
    "typeid": "_dat",
    "mode": 1,
    "format": ""
},
...
"printouts": {
    "Modification date": [
        {
            "timestamp": "1447907200",
            "raw": "1/2015/11/19/4/26/40"
        }
    ],
    "DateLabelToBeTheAPIOutputReference": [
        {
            "timestamp": "1447907200",
            "raw": "1/2015/11/19/4/26/40"
        }
    ],
```