### PR TITLE
Add extra search column to support case-insensitive regex searches

### DIFF
--- a/SemanticMediaWiki.settings.php
+++ b/SemanticMediaWiki.settings.php
@@ -926,3 +926,16 @@ $GLOBALS['smwgExportBCNonCanonicalFormUse'] = false;
 # @default true
 ##
 $GLOBALS['smwgEnabledInTextAnnotationParserStrictMode'] = true;
+
+##
+# This setting enables RegEx (like [~*...*], not like [!~...]) searches to operate
+# equally on all input strings without differentiation on lower or CAPITAl letters.
+#
+# It is required that `update.php` is run, followed by `rebuildData.php` because this
+# feature creates an additional search column that expects data to be populated
+# before any RegEx query can successfully return match results.
+#
+# @since 2.4
+# @default false
+##
+$GLOBALS['smwgEnabledEnhancedRegExMatchSearch'] = false;

--- a/includes/Settings.php
+++ b/includes/Settings.php
@@ -139,7 +139,8 @@ class Settings extends SimpleDictionary {
 			'smwgPropertyDependencyDetectionBlacklist' => $GLOBALS['smwgPropertyDependencyDetectionBlacklist'],
 			'smwgExportBCNonCanonicalFormUse' => $GLOBALS['smwgExportBCNonCanonicalFormUse'],
 			'smwgExportBCAuxiliaryUse' => $GLOBALS['smwgExportBCAuxiliaryUse'],
-			'smwgEnabledInTextAnnotationParserStrictMode' => $GLOBALS['smwgEnabledInTextAnnotationParserStrictMode']
+			'smwgEnabledInTextAnnotationParserStrictMode' => $GLOBALS['smwgEnabledInTextAnnotationParserStrictMode'],
+			'smwgEnabledEnhancedRegExMatchSearch' => $GLOBALS['smwgEnabledEnhancedRegExMatchSearch']
 		);
 
 		$settings = $settings + array(

--- a/includes/storage/SQLStore/SMW_DIHandler_Blob.php
+++ b/includes/storage/SQLStore/SMW_DIHandler_Blob.php
@@ -1,4 +1,7 @@
 <?php
+
+use SMW\SearchField;
+
 /**
  * @ingroup SMWDataItemsHandlers
  */
@@ -39,7 +42,16 @@ class SMWDIHandlerBlob extends SMWDataItemHandler {
 	 * @return array
 	 */
 	public function getTableFields() {
-		return array( 'o_blob' => 'l', 'o_hash' => 't' );
+		return array( 'o_blob' => 'l', 'o_hash' => 't', 'o_search' => 't' );
+	}
+
+	/**
+	 * @see SMWDataItemHandler::getTableIndexes()
+	 * @since 1.8
+	 * @return array
+	 */
+	public function getTableIndexes() {
+		return array( 'o_hash', 'o_search' );
 	}
 
 	/**
@@ -58,7 +70,10 @@ class SMWDIHandlerBlob extends SMWDataItemHandler {
 	 * @return array
 	 */
 	public function getWhereConds( SMWDataItem $dataItem ) {
-		return array( 'o_hash' => self::makeHash( $dataItem->getString() ) );
+		return array(
+			'o_hash'   => self::makeHash( $dataItem->getString() ),
+			'o_search' => SearchField::getSearchStringFrom( $dataItem->getString() )
+		);
 	}
 
 	/**
@@ -71,8 +86,9 @@ class SMWDIHandlerBlob extends SMWDataItemHandler {
 	public function getInsertValues( SMWDataItem $dataItem ) {
 		$text = $dataItem->getString();
 		return array(
-			'o_blob' => strlen( $text ) <= self::MAX_HASH_LENGTH ? null : $text,
-			'o_hash' => self::makeHash( $text ),
+			'o_blob'   => strlen( $text ) <= self::MAX_HASH_LENGTH ? null : $text,
+			'o_hash'   => self::makeHash( $text ),
+			'o_search' => SearchField::getIndexStringFrom( $text ),
 		);
 	}
 
@@ -83,6 +99,15 @@ class SMWDIHandlerBlob extends SMWDataItemHandler {
 	 */
 	public function getIndexField() {
 		return 'o_hash';
+	}
+
+	/**
+	 * @since 2.4
+	 *
+	 * @return string
+	 */
+	public function getExtraSearchIndexField() {
+		return 'o_search';
 	}
 
 	/**

--- a/includes/storage/SQLStore/SMW_DIHandler_URI.php
+++ b/includes/storage/SQLStore/SMW_DIHandler_URI.php
@@ -1,4 +1,7 @@
 <?php
+
+use SMW\SearchField;
+
 /**
  * @ingroup SMWDataItemsHandlers
  */
@@ -19,7 +22,16 @@ class SMWDIHandlerUri extends SMWDataItemHandler {
 	 * @return array
 	 */
 	public function getTableFields() {
-		return array( 'o_serialized' => 't' );
+		return array( 'o_serialized' => 't', 'o_search' => 't' );
+	}
+
+	/**
+	 * @see SMWDataItemHandler::getTableIndexes()
+	 * @since 1.8
+	 * @return array
+	 */
+	public function getTableIndexes() {
+		return array( 'o_serialized', 'o_search' );
 	}
 
 	/**
@@ -38,7 +50,10 @@ class SMWDIHandlerUri extends SMWDataItemHandler {
 	 * @return array
 	 */
 	public function getWhereConds( SMWDataItem $dataItem ) {
-		return array( 'o_serialized' => $dataItem->getSerialization() );
+		return array(
+			'o_serialized' => $dataItem->getSerialization(),
+			'o_search' => SearchField::getSearchStringFrom( $dataItem->getSerialization() )
+		);
 	}
 
 	/**
@@ -49,7 +64,10 @@ class SMWDIHandlerUri extends SMWDataItemHandler {
 	 * @return array
 	 */
 	public function getInsertValues( SMWDataItem $dataItem ) {
-		return array( 'o_serialized' => $dataItem->getSerialization() );
+		return array(
+			'o_serialized' => $dataItem->getSerialization(),
+			'o_search' => SearchField::getIndexStringFrom( $dataItem->getSerialization() )
+		);
 	}
 
 	/**
@@ -59,6 +77,15 @@ class SMWDIHandlerUri extends SMWDataItemHandler {
 	 */
 	public function getIndexField() {
 		return 'o_serialized';
+	}
+
+	/**
+	 * @since 2.4
+	 *
+	 * @return string
+	 */
+	public function getExtraSearchIndexField() {
+		return 'o_search';
 	}
 
 	/**

--- a/includes/storage/SQLStore/SMW_DataItemHandler.php
+++ b/includes/storage/SQLStore/SMW_DataItemHandler.php
@@ -113,6 +113,18 @@ abstract class SMWDataItemHandler {
 	abstract public function getIndexField();
 
 	/**
+	 * Return a different index field (getIndexField) to match values
+	 * (as in case of a blob).
+	 *
+	 * @since 2.4
+	 *
+	 * @return string
+	 */
+	public function getExtraSearchIndexField() {
+		return $this->getIndexField();
+	}
+
+	/**
 	 * Return the label field for this type of SMWDataItem. This should be
 	 * a string column in the database table that can be used for selecting
 	 * values using criteria such as "starts with". The return value can be

--- a/includes/storage/SQLStore/SMW_SQLStore3_SetupHandlers.php
+++ b/includes/storage/SQLStore/SMW_SQLStore3_SetupHandlers.php
@@ -96,6 +96,7 @@ class SMWSQLStore3SetupHandlers implements MessageReporter {
 				'smw_iw' => $dbtypes['w'] . ' NOT NULL',
 				'smw_subobject' => $dbtypes['t'] . ' NOT NULL',
 				'smw_sortkey' => $dbtypes['t']  . ' NOT NULL',
+				'smw_searchkey' => $dbtypes['t'],
 				'smw_proptable_hash' => $dbtypes['l']
 			),
 			$db,
@@ -107,9 +108,11 @@ class SMWSQLStore3SetupHandlers implements MessageReporter {
 			array(
 				'smw_id',
 				'smw_id,smw_sortkey',
+				'smw_id,smw_searchkey',
 				'smw_iw', // iw match lookup
 				'smw_title,smw_namespace,smw_iw,smw_subobject', // id lookup
-				'smw_sortkey' // select by sortkey (range queries)
+				'smw_sortkey', // select by sortkey (range queries)
+				'smw_searchkey'
 			),
 			$db
 		);
@@ -209,6 +212,10 @@ class SMWSQLStore3SetupHandlers implements MessageReporter {
 				$fieldarray['p_id'] = $dbtypes['p'] . ' NOT NULL';
 				$indexes['po'] = 'p_id,' . $indexes['po'];
 				$indexes['sp'] = $indexes['sp'] . ',p_id';
+
+				if ( $diHandler->getIndexField() !== $diHandler->getExtraSearchIndexField() ) {
+					$indexes['ps'] = 'p_id,' . $diHandler->getExtraSearchIndexField();
+				}
 			}
 
 			// TODO Special handling; concepts should be handled differently

--- a/includes/storage/SQLStore/SMW_Sql3SmwIds.php
+++ b/includes/storage/SQLStore/SMW_Sql3SmwIds.php
@@ -6,6 +6,7 @@ use SMW\SQLStore\RedirectInfoStore;
 use SMW\HashBuilder;
 use SMW\DIWikiPage;
 use SMW\ApplicationFactory;
+use SMW\SearchField;
 
 /**
  * @ingroup SMWStore
@@ -571,7 +572,8 @@ class SMWSql3SmwIds {
 					'smw_namespace' => $namespace,
 					'smw_iw' => $iw,
 					'smw_subobject' => $subobjectName,
-					'smw_sortkey' => $sortkey
+					'smw_sortkey' => $sortkey,
+					'smw_searchkey' => SearchField::getIndexStringFrom( $sortkey )
 				),
 				__METHOD__
 			);
@@ -598,7 +600,7 @@ class SMWSql3SmwIds {
 		} elseif ( $sortkey !== '' && $sortkey != $oldsort ) {
 			$db->update(
 				self::TABLE_NAME,
-				array( 'smw_sortkey' => $sortkey ),
+				array( 'smw_sortkey' => $sortkey, 'smw_searchkey' => SearchField::getIndexStringFrom( $sortkey ) ),
 				array( 'smw_id' => $id ),
 				__METHOD__
 			);
@@ -793,7 +795,8 @@ class SMWSql3SmwIds {
 					'smw_namespace' => $row->smw_namespace,
 					'smw_iw' => $row->smw_iw,
 					'smw_subobject' => $row->smw_subobject,
-					'smw_sortkey' => $row->smw_sortkey
+					'smw_sortkey' => $row->smw_sortkey,
+					'smw_searchkey' => SearchField::getIndexStringFrom( $row->smw_sortkey )
 				),
 				__METHOD__
 			);
@@ -807,7 +810,8 @@ class SMWSql3SmwIds {
 					'smw_namespace' => $row->smw_namespace,
 					'smw_iw' => $row->smw_iw,
 					'smw_subobject' => $row->smw_subobject,
-					'smw_sortkey' => $row->smw_sortkey
+					'smw_sortkey' => $row->smw_sortkey,
+					'smw_searchkey' => SearchField::getIndexStringFrom( $row->smw_sortkey )
 				),
 				__METHOD__
 			);

--- a/maintenance/rebuildSearchFieldContent.php
+++ b/maintenance/rebuildSearchFieldContent.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace SMW\Maintenance;
+
+use Onoi\MessageReporter\MessageReporterFactory;
+use SMW\ApplicationFactory;
+use SMW\StoreFactory;
+
+$basePath = getenv( 'MW_INSTALL_PATH' ) !== false ? getenv( 'MW_INSTALL_PATH' ) : __DIR__ . '/../../..';
+
+require_once $basePath . '/maintenance/Maintenance.php';
+
+/**
+ * @license GNU GPL v2+
+ * @since 2.4
+ *
+ * @author mwjames
+ */
+class RebuildSearchFieldContent extends \Maintenance {
+
+	public function __construct() {
+		parent::__construct();
+
+		$this->addDescription( "\n" .
+			"The script updates the search index field for tables that are known\n".
+			"to support RegEx searches via the SQLStore. \n"
+		);
+	}
+
+	/**
+	 * @see Maintenance::execute
+	 */
+	public function execute() {
+
+		if ( !defined( 'SMW_VERSION' ) ) {
+			$this->output( "You need to have SMW enabled in order to use this maintenance script!\n\n" );
+			exit;
+		}
+
+		$applicationFactory = ApplicationFactory::getInstance();
+		$maintenanceFactory = $applicationFactory->newMaintenanceFactory();
+
+		$this->reportMessage(
+			"\nThe script updates the index field for tables that support regex\n" .
+			"value searches. Any change of the index rules (altered stopword\n".
+			"list, new stemmer etc.) and/or a newly added or altered table\n".
+			"requires to run this script (or `rebuildData.php`) to ensure that\n" .
+			"the index complies to the rules set forth by the `SearchField`\n".
+			"class.\n\n" .
+			"Depending on the size of the tables selected, it may take a moment\n".
+			"before the update is completed.\n---\n"
+		);
+
+		$reporter = MessageReporterFactory::getInstance()->newObservableMessageReporter();
+		$reporter->registerReporterCallback( array( $this, 'reportMessage' ) );
+
+		$searchFieldContentRebuilder = $maintenanceFactory->newSearchFieldContentRebuilder(
+			StoreFactory::getStore( 'SMW\SQLStore\SQLStore' )
+		);
+
+		$searchFieldContentRebuilder->setMessageReporter( $reporter );
+		$searchFieldContentRebuilder->rebuild();
+	}
+
+	/**
+	 * @see Maintenance::reportMessage
+	 *
+	 * @since 2.4
+	 *
+	 * @param string $message
+	 */
+	public function reportMessage( $message ) {
+		$this->output( $message );
+	}
+
+}
+
+$maintClass = 'SMW\Maintenance\RebuildSearchFieldContent';
+require_once ( RUN_MAINTENANCE_IF_MAIN );

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -62,6 +62,7 @@
        <var name="smwgSparqlDefaultGraph" value="http://example.org/phpunit-testrun"/>
        <var name="smwgValueLookupCacheType" value="hash"/>
        <var name="smwgEnabledHttpDeferredJobRequest" value="false"/>
+       <var name="smwgEnabledEnhancedRegExMatchSearch" value="false"/>
        <var name="smwgEnabledQueryDependencyLinksStore" value="true"/>
        <var name="benchmarkQueryRepetitionExecutionThreshold" value="5"/>
        <var name="benchmarkQueryLimit" value="500"/>

--- a/src/Maintenance/MaintenanceFactory.php
+++ b/src/Maintenance/MaintenanceFactory.php
@@ -3,6 +3,7 @@
 namespace SMW\Maintenance;
 
 use SMW\Store;
+use SMW\SQLStore\SQLStore;
 use SMW\ApplicationFactory;
 use SMW\Store\PropertyStatisticsStore;
 
@@ -55,6 +56,17 @@ class MaintenanceFactory {
 	 */
 	public function newPropertyStatisticsRebuilder( Store $store, PropertyStatisticsStore $propertyStatisticsStore ) {
 		return new PropertyStatisticsRebuilder( $store, $propertyStatisticsStore );
+	}
+
+	/**
+	 * @since 2.4
+	 *
+	 * @param SQLStore $store
+	 *
+	 * @return SearchFieldContentRebuilder
+	 */
+	public function newSearchFieldContentRebuilder( SQLStore $store ) {
+		return new SearchFieldContentRebuilder( $store );
 	}
 
 }

--- a/src/Maintenance/SearchFieldContentRebuilder.php
+++ b/src/Maintenance/SearchFieldContentRebuilder.php
@@ -1,0 +1,163 @@
+<?php
+
+namespace SMW\Maintenance;
+
+use SMW\SQLStore\SQLStore;
+use Onoi\MessageReporter\MessageReporter;
+use Onoi\MessageReporter\MessageReporterFactory;
+use SMW\SearchField;
+
+/**
+ * @license GNU GPL v2+
+ * @since 2.4
+ *
+ * @author mwjames
+ */
+class SearchFieldContentRebuilder {
+
+	/**
+	 * @var Store
+	 */
+	private $store = null;
+
+	/**
+	 * @var MessageReporter
+	 */
+	private $reporter;
+
+	/**
+	 * @since 2.4
+	 *
+	 * @param SQLStore $store
+	 */
+	public function __construct( SQLStore $store ) {
+		$this->store = $store;
+		$this->reporter = MessageReporterFactory::getInstance()->newNullMessageReporter();
+	}
+
+	/**
+	 * @since  2.4
+	 *
+	 * @param MessageReporter $messageReporter
+	 */
+	public function setMessageReporter( MessageReporter $messageReporter ) {
+		$this->reporter = $messageReporter;
+	}
+
+	/**
+	 * @since 2.4
+	 */
+	public function rebuild() {
+		$this->doRebuildContentForPropertyTables();
+		$this->doRebuildContentForIdTable();
+	}
+
+	private function doRebuildContentForPropertyTables() {
+
+		$this->reportMessage( "\n" . "Starting the property tables update ... " ."\n\n" );
+		$connection = $this->store->getConnection( 'mw.db' );
+
+		foreach ( $this->store->getPropertyTables() as $proptable ) {
+
+			$diHandler = $this->store->getDataItemHandlerForDIType( $proptable->getDiType() );
+			$fields = $diHandler->getTableFields();
+
+			// Doesn't have a different search field so we leave ...
+			if ( $diHandler->getExtraSearchIndexField() === $diHandler->getIndexField() ) {
+				continue;
+			}
+
+			$this->doSelectRowsFor( $connection, $proptable, $diHandler );
+		}
+	}
+
+	private function doSelectRowsFor( $connection, $proptable, $diHandler ) {
+
+		// Fixed prop tables don't have a p_id field
+		$fetchFields = $proptable->isFixedPropertyTable() ? array( 's_id' ) : array( 's_id', 'p_id' );
+		$fetchFields = array_merge( $fetchFields, array_keys( $diHandler->getFetchFields() ) );
+
+		// We feel lucky by doing a unconditional select
+		$rows = $connection->select(
+			$proptable->getName(),
+			$fetchFields,
+			array(),
+			__METHOD__
+		);
+
+		if ( $rows === false ) {
+			return;
+		}
+
+		$i = 0;
+		$expected = $rows->numRows();
+		$table = $proptable->getName();
+
+		foreach ( $rows as $row ) {
+			$i++;
+			$this->reportMessage( "\r". sprintf( "%-20s%s", "- {$table}", sprintf("%4.0f%% (%s/%s)",( $i / $expected) * 100, $i, $expected ) ) );
+			$this->doRealUpdateOnRow( $connection, $proptable, $diHandler, $row );
+		}
+
+		$this->reportMessage( "\n" );
+	}
+
+	private function doRealUpdateOnRow( $connection, $proptable, $diHandler, $row ) {
+
+		// Get the original content and use indexer to create
+		// the search content
+		$condition = isset( $row->p_id ) ? array( 's_id' => $row->s_id, 'p_id' => $row->p_id ) : array( 's_id' => $row->s_id );
+		$searchString = isset( $row->o_serialized ) ? $row->o_serialized : ( $row->o_blob === null ? $row->o_hash : $row->o_blob );
+
+		if ( $searchString === '' || $searchString === null ) {
+			continue;
+		}
+
+		$connection->update(
+			$proptable->getName(),
+			array( $diHandler->getExtraSearchIndexField() => SearchField::getIndexStringFrom( $searchString ) ),
+			$condition,
+			__METHOD__
+		);
+	}
+
+	private function doRebuildContentForIdTable() {
+
+		$this->reportMessage( "\n" . "Starting the ID table update ... " ."\n\n" );
+		$connection = $this->store->getConnection( 'mw.db' );
+
+		$rows = $connection->select(
+			SQLStore::ID_TABLE,
+			array( 'smw_id', 'smw_sortkey' ),
+			array( 'smw_sortkey!=' . "''" ), // Postgres "empty quotes ..." to avoid zero-length delimited identifier at or near """"
+			__METHOD__
+		);
+
+		if ( $rows === false ) {
+			continue;
+		}
+
+		$i = 0;
+		$expected = $rows->numRows();
+		$table = SQLStore::ID_TABLE;
+
+		foreach ( $rows as $row ) {
+			$i++;
+			$this->reportMessage( "\r". sprintf( "%-20s%s", "- {$table}", sprintf("%4.0f%% (%s/%s)",( $i / $expected) * 100, $i, $expected ) ) );
+
+			$connection->update(
+				SQLStore::ID_TABLE,
+				array( 'smw_searchkey' => SearchField::getIndexStringFrom( $row->smw_sortkey ) ),
+				array( 'smw_id' => $row->smw_id ),
+				__METHOD__
+			);
+		}
+
+		$this->reportMessage( "\n" );
+	}
+
+	protected function reportMessage( $message ) {
+		$this->reporter->reportMessage( $message );
+	}
+
+}

--- a/src/SQLStore/QueryEngine/Interpreter/ComparatorMapper.php
+++ b/src/SQLStore/QueryEngine/Interpreter/ComparatorMapper.php
@@ -15,6 +15,49 @@ use SMWDIUri as DIUri;
 class ComparatorMapper {
 
 	/**
+	 * @var boolean
+	 */
+	private $enabledEnhancedRegExMatchSearch = false;
+
+	/**
+	 * @var array
+	 */
+	private $comparatorMap = array(
+		SMW_CMP_EQ   => '=',
+		SMW_CMP_LESS => '<',
+		SMW_CMP_GRTR => '>',
+		SMW_CMP_LEQ  => '<=',
+		SMW_CMP_GEQ  => '>=',
+		SMW_CMP_NEQ  => '!=',
+		SMW_CMP_LIKE => ' LIKE ',
+		SMW_CMP_NLKE => ' NOT LIKE '
+	);
+
+	/**
+	 * @since 2.4
+	 *
+	 * @param boolean $enabledEnhancedRegExMatchSearch
+	 */
+	public function __construct( $enabledEnhancedRegExMatchSearch = null ) {
+		$this->enabledEnhancedRegExMatchSearch = $enabledEnhancedRegExMatchSearch;
+
+		if ( $this->enabledEnhancedRegExMatchSearch === null ) {
+			$this->enabledEnhancedRegExMatchSearch = $GLOBALS['smwgEnabledEnhancedRegExMatchSearch'];
+		}
+	}
+
+	/**
+	 * @since 2.4
+	 *
+	 * @param ValueDescription $description
+	 *
+	 * @return boolean
+	 */
+	public function isEnabledEnhancedRegExMatchSearch( ValueDescription $description ) {
+		return $this->enabledEnhancedRegExMatchSearch && ( $description->getComparator() === SMW_CMP_LIKE || $description->getComparator() === SMW_CMP_NLKE );
+	}
+
+	/**
 	 * @since 2.2
 	 *
 	 * @param ValueDescription $description
@@ -25,27 +68,16 @@ class ComparatorMapper {
 	 */
 	public function mapComparator( ValueDescription $description, &$value ) {
 
-		$comparatorMap = array(
-			SMW_CMP_EQ   => '=',
-			SMW_CMP_LESS => '<',
-			SMW_CMP_GRTR => '>',
-			SMW_CMP_LEQ  => '<=',
-			SMW_CMP_GEQ  => '>=',
-			SMW_CMP_NEQ  => '!=',
-			SMW_CMP_LIKE => ' LIKE ',
-			SMW_CMP_NLKE => ' NOT LIKE '
-		);
-
 		$comparator = $description->getComparator();
 
-		if ( !isset( $comparatorMap[$comparator] ) ) {
+		if ( !isset( $this->comparatorMap[$comparator] ) ) {
 			throw new RuntimeException( "Unsupported comparator '" . $comparator . "' in value description." );
 		}
 
 		if ( $comparator === SMW_CMP_LIKE || $comparator === SMW_CMP_NLKE ) {
 
 			if ( $description->getDataItem() instanceof DIUri ) {
-				$value = str_replace( array( 'http://', 'https://', '%2A' ), array( '', '', '*' ), $value );
+				$value = str_replace( array( 'http://', 'https://', '%2A', '%2a' ), array( '', '', '*', '*' ), $value );
 			}
 
 			// Escape to prepare string matching:
@@ -56,7 +88,7 @@ class ComparatorMapper {
 			);
 		}
 
-		return $comparatorMap[$comparator];
+		return $this->comparatorMap[$comparator];
 	}
 
 }

--- a/src/SQLStore/QueryEngine/Interpreter/SomePropertyInterpreter.php
+++ b/src/SQLStore/QueryEngine/Interpreter/SomePropertyInterpreter.php
@@ -42,10 +42,11 @@ class SomePropertyInterpreter implements DescriptionInterpreter {
 	 * @since 2.2
 	 *
 	 * @param QuerySegmentListBuilder $querySegmentListBuilder
+	 * @param boolean|null $enabledEnhancedRegExMatchSearch
 	 */
-	public function __construct( QuerySegmentListBuilder $querySegmentListBuilder ) {
+	public function __construct( QuerySegmentListBuilder $querySegmentListBuilder, $enabledEnhancedRegExMatchSearch = null ) {
 		$this->querySegmentListBuilder = $querySegmentListBuilder;
-		$this->comparatorMapper = new ComparatorMapper();
+		$this->comparatorMapper = new ComparatorMapper( $enabledEnhancedRegExMatchSearch );
 	}
 
 	/**
@@ -257,7 +258,7 @@ class SomePropertyInterpreter implements DescriptionInterpreter {
 
 		// Do not support smw_id joined data for now.
 
-		$indexField = $diHandler->getIndexField();
+		$indexField = $this->comparatorMapper->isEnabledEnhancedRegExMatchSearch( $description ) ? $diHandler->getExtraSearchIndexField() : $diHandler->getIndexField();
 		//Hack to get to the field used as index
 		$keys = $diHandler->getWhereConds( $dataItem );
 		$value = $keys[$indexField];

--- a/src/SearchField.php
+++ b/src/SearchField.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace SMW;
+
+/**
+ * @license GNU GPL v2+
+ * @since 2.4
+ *
+ * @author mwjames
+ */
+class SearchField {
+
+	/**
+	 * @since 2.4
+	 *
+	 * @param string $string
+	 *
+	 * @return string
+	 */
+	public static function getSearchStringFrom( $string ) {
+		return self::getIndexStringFrom( $string );
+	}
+
+	/**
+	 * @since 2.4
+	 *
+	 * @param string $string
+	 *
+	 * @return string
+	 */
+	public static function getIndexStringFrom( $string ) {
+		$string = str_replace(
+			array( "http://", "https://", "mailto:", "tel:" ),
+			array( '' ),
+			$string
+		);
+
+		return mb_strtolower( $string );
+	}
+
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -16,5 +16,6 @@ $autoloader->addClassMap( array(
 	'SMW\Maintenance\RebuildData'                => __DIR__ . '/../maintenance/rebuildData.php',
 	'SMW\Maintenance\RebuildPropertyStatistics'  => __DIR__ . '/../maintenance/rebuildPropertyStatistics.php',
 	'SMW\Maintenance\DumpRdf'                    => __DIR__ . '/../maintenance/dumpRDF.php',
-	'SMW\Maintenance\SetupStore'                 => __DIR__ . '/../maintenance/setupStore.php'
+	'SMW\Maintenance\SetupStore'                 => __DIR__ . '/../maintenance/setupStore.php',
+	'SMW\Maintenance\RebuildSearchFieldContent'  => __DIR__ . '/../maintenance/rebuildSearchFieldContent.php'
 ) );

--- a/tests/phpunit/Integration/ByJsonScript/ByJsonScriptFixtureTestCaseRunnerTest.php
+++ b/tests/phpunit/Integration/ByJsonScript/ByJsonScriptFixtureTestCaseRunnerTest.php
@@ -129,7 +129,8 @@ class ByJsonScriptFixtureTestCaseRunnerTest extends ByJsonTestCaseProvider {
 			'smwgQSubpropertyDepth',
 			'smwgQSubcategoryDepth',
 			'smwgQConceptCaching',
-			'smwgEnabledInTextAnnotationParserStrictMode'
+			'smwgEnabledInTextAnnotationParserStrictMode',
+			'smwgEnabledEnhancedRegExMatchSearch'
 		);
 
 		foreach ( $permittedSettings as $key ) {

--- a/tests/phpunit/Integration/ByJsonScript/Fixtures/q-0903 [#1059] regex disjunctive queries.json
+++ b/tests/phpunit/Integration/ByJsonScript/Fixtures/q-0903 [#1059] regex disjunctive queries.json
@@ -221,6 +221,7 @@
 		}
 	],
 	"settings": {
+		"smwgEnabledEnhancedRegExMatchSearch" : false,
 		"smwgNamespacesWithSemanticLinks": {
 			"NS_MAIN": true,
 			"NS_CATEGORY": true,

--- a/tests/phpunit/Integration/ByJsonScript/Fixtures/q-0905 regex case-insensitive queries.json
+++ b/tests/phpunit/Integration/ByJsonScript/Fixtures/q-0905 regex case-insensitive queries.json
@@ -1,0 +1,190 @@
+{
+	"description": "Case insensitive regex queries",
+	"properties": [
+		{
+			"name": "Has text",
+			"contents": "[[Has type::Text]]"
+		},
+		{
+			"name": "Has url",
+			"contents": "[[Has type::URL]]"
+		}
+	],
+	"subjects": [
+		{
+			"name": "Example/Q0905/1",
+			"contents": "[[Category:Q0905]][[Has text::LOREM IPSUM]]"
+		},
+		{
+			"name": "Example/Q0905/2",
+			"contents": "[[Category:Q0905]][[Has text::lOReM iPSUm]]"
+		},
+		{
+			"name": "Example/Q0905/3",
+			"contents": "[[Category:Q0905]][[Has text::テスト]]"
+		},
+		{
+			"name": "Example/Q0905/4",
+			"contents": "[[Category:Q0905]][[Has url::http://example.org/lOReM iPSUm/テスト]]"
+		},
+		{
+			"name": "Example/Q0905/5",
+			"contents": "[[Category:Q0905]][[Has url::http://テスト.org/example/LOREM IPSUM]]"
+		},
+		{
+			"name": "Example/Q0905/6/lOReM iPSUm",
+			"contents": "[[Category:Q0905]]"
+		},
+		{
+			"name": "Example/Q0905/6/LOREM IPSUM",
+			"contents": "[[Category:Q0905]]"
+		},
+		{
+			"name": "Example/Q0905/7",
+			"contents": "[[Category:Q0905]][[Has text::øæåØÆÅabcABC]]"
+		},
+		{
+			"name": "Example/Q0905/8",
+			"contents": "[[Category:Q0905]][[Has text::øæåøæåabcabc]]"
+		}
+	],
+	"query-testcases": [
+		{
+			"about": "#0 blob regex like match (lowercase)",
+			"condition": "[[Category:Q0905]][[Has text::~lorem*]]",
+			"printouts" : [],
+			"parameters" : {
+				"limit" : "10"
+			},
+			"queryresult": {
+				"count": 2,
+				"results": [
+					"Example/Q0905/1#0##",
+					"Example/Q0905/2#0##"
+				]
+			}
+		},
+		{
+			"about": "#1 blob regex like match (capital case)",
+			"condition": "[[Category:Q0905]][[Has text::~*REM*]]",
+			"printouts" : [],
+			"parameters" : {
+				"limit" : "10"
+			},
+			"queryresult": {
+				"count": 2,
+				"results": [
+					"Example/Q0905/1#0##",
+					"Example/Q0905/2#0##"
+				]
+			}
+		},
+		{
+			"about": "#2 blob regex not like match",
+			"condition": "[[Category:Q0905]][[Has text::!~*REM*]]",
+			"printouts" : [],
+			"parameters" : {
+				"limit" : "10"
+			},
+			"queryresult": {
+				"count": 3,
+				"results": [
+					"Example/Q0905/3#0##",
+					"Example/Q0905/7#0##",
+					"Example/Q0905/8#0##"
+				]
+			}
+		},
+		{
+			"about": "#3 url regex like match",
+			"condition": "[[Category:Q0905]][[Has url::~*rem*]]",
+			"printouts" : [],
+			"parameters" : {
+				"limit" : "10"
+			},
+			"queryresult": {
+				"count": 2,
+				"results": [
+					"Example/Q0905/4#0##",
+					"Example/Q0905/5#0##"
+				]
+			}
+		},
+		{
+			"about": "#4 url regex like match",
+			"condition": "[[Category:Q0905]][[Has url::~*REm*]]",
+			"printouts" : [],
+			"parameters" : {
+				"limit" : "10"
+			},
+			"queryresult": {
+				"count": 2,
+				"results": [
+					"Example/Q0905/4#0##",
+					"Example/Q0905/5#0##"
+				]
+			}
+		},
+		{
+			"about": "#5 page value regex like match",
+			"condition": "[[Category:Q0905]][[~*/6/lore*]]",
+			"printouts" : [],
+			"parameters" : {
+				"limit" : "10"
+			},
+			"queryresult": {
+				"count": 2,
+				"results": [
+					"Example/Q0905/6/lOReM iPSUm#0##",
+					"Example/Q0905/6/LOREM IPSUM#0##"
+				]
+			}
+		},
+		{
+			"about": "#6 page value regex like match",
+			"condition": "[[Category:Q0905]][[~*/6/lORe*]]",
+			"printouts" : [],
+			"parameters" : {
+				"limit" : "10"
+			},
+			"queryresult": {
+				"count": 2,
+				"results": [
+					"Example/Q0905/6/lOReM iPSUm#0##",
+					"Example/Q0905/6/LOREM IPSUM#0##"
+				]
+			}
+		},
+		{
+			"about": "#7 blob value regex like match for non-English characters",
+			"condition": "[[Category:Q0905]][[Has text::~*æå*]]",
+			"printouts" : [],
+			"parameters" : {
+				"limit" : "10"
+			},
+			"queryresult": {
+				"count": 2,
+				"results": [
+					"Example/Q0905/7#0##",
+					"Example/Q0905/8#0##"
+				]
+			}
+		}
+	],
+	"settings": {
+		"smwgEnabledEnhancedRegExMatchSearch" : true,
+		"smwgNamespacesWithSemanticLinks": {
+			"NS_MAIN": true,
+			"NS_CATEGORY": true,
+			"SMW_NS_PROPERTY": true
+		},
+		"wgContLang": "en",
+		"smwgQSubpropertyDepth": 10,
+		"smwgQSubcategoryDepth": 10
+	},
+	"meta": {
+		"version": "0.1",
+		"is-incomplete": false,
+		"debug": false
+	}
+}

--- a/tests/phpunit/Integration/MediaWiki/Import/Maintenance/RebuildSearchFieldContentTest.php
+++ b/tests/phpunit/Integration/MediaWiki/Import/Maintenance/RebuildSearchFieldContentTest.php
@@ -6,18 +6,15 @@ use SMW\Tests\Utils\UtilityFactory;
 use SMW\Tests\MwDBaseUnitTestCase;
 
 /**
- * @group SMW
- * @group SMWExtension
- * @group semantic-mediawiki-import
- * @group mediawiki-database
+ * @group semantic-mediawiki
  * @group medium
  *
  * @license GNU GPL v2+
- * @since 2.0
+ * @since 2.4
  *
  * @author mwjames
  */
-class SetupStoreMaintenanceTest extends MwDBaseUnitTestCase {
+class RebuildSearchFieldContentMaintenanceTest extends MwDBaseUnitTestCase {
 
 	protected $destroyDatabaseTablesAfterRun = true;
 
@@ -42,37 +39,14 @@ class SetupStoreMaintenanceTest extends MwDBaseUnitTestCase {
 	}
 
 	protected function tearDown() {
-
 		$pageDeleter = UtilityFactory::getInstance()->newPageDeleter();
 		$pageDeleter->doDeletePoolOfPages( $this->importedTitles );
 
 		parent::tearDown();
 	}
 
-	public function testSetupStore() {
-
-		$this->importedTitles = array(
-			'Category:Lorem ipsum',
-			'Lorem ipsum',
-			'Elit Aliquam urna interdum',
-			'Platea enim hendrerit',
-			'Property:Has Url',
-			'Property:Has annotation uri',
-			'Property:Has boolean',
-			'Property:Has date',
-			'Property:Has email',
-			'Property:Has number',
-			'Property:Has page',
-			'Property:Has quantity',
-			'Property:Has temperature',
-			'Property:Has text'
-		);
-
-		// 1.19 Title/LinkCache goes nuts for when a page in a previous test got
-		// deleted
-		// $this->titleValidator->assertThatTitleIsKnown( $this->importedTitles );
-
-		$maintenanceRunner = $this->runnerFactory->newMaintenanceRunner( 'SMW\Maintenance\SetupStore' );
+	public function testRebuild() {
+		$maintenanceRunner = $this->runnerFactory->newMaintenanceRunner( 'SMW\Maintenance\RebuildSearchFieldContent' );
 		$maintenanceRunner->setQuiet()->run();
 	}
 

--- a/tests/phpunit/Unit/Maintenance/MaintenanceFactoryTest.php
+++ b/tests/phpunit/Unit/Maintenance/MaintenanceFactoryTest.php
@@ -79,4 +79,18 @@ class MaintenanceFactoryTest extends \PHPUnit_Framework_TestCase {
 		);
 	}
 
+	public function testCanConstructSearchFieldContentRebuilder() {
+
+		$instance = new MaintenanceFactory();
+
+		$store = $this->getMockBuilder( '\SMW\SQLStore\SQLStore' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$this->assertInstanceOf(
+			'\SMW\Maintenance\SearchFieldContentRebuilder',
+			$instance->newSearchFieldContentRebuilder( $store )
+		);
+	}
+
 }

--- a/tests/phpunit/Unit/Maintenance/SearchFieldContentRebuilderTest.php
+++ b/tests/phpunit/Unit/Maintenance/SearchFieldContentRebuilderTest.php
@@ -1,0 +1,101 @@
+<?php
+
+namespace SMW\Tests\Maintenance;
+
+use SMW\Maintenance\SearchFieldContentRebuilder;
+use FakeResultWrapper;
+
+/**
+ * @covers \SMW\Maintenance\SearchFieldContentRebuilder
+ * @group semantic-mediawiki
+ *
+ * @license GNU GPL v2+
+ * @since 2.4
+ *
+ * @author mwjames
+ */
+class SearchFieldContentRebuilderTest extends \PHPUnit_Framework_TestCase {
+
+	public function testCanConstruct() {
+
+		$store = $this->getMockBuilder( '\SMW\SQLStore\SQLStore' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$this->assertInstanceOf(
+			'\SMW\Maintenance\SearchFieldContentRebuilder',
+			new SearchFieldContentRebuilder( $store )
+		);
+	}
+
+	public function testRebuild() {
+
+		$arbitraryPropertyTableName = 'allornothing';
+
+		$selectResult = array(
+			'smw_title'   => 'Foo',
+			'smw_sortkey' => 'Foo',
+			'smw_id'      => 9999
+		);
+
+		$selectResultWrapper = new FakeResultWrapper( array( (object)$selectResult ) );
+
+		$diHandlerBlob = $this->getMockBuilder( '\SMWDIHandlerBlob' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$database = $this->getMockBuilder( '\SMW\MediaWiki\Database' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$database->expects( $this->atLeastOnce() )
+			->method( 'select' )
+			->will( $this->returnValue( $selectResultWrapper ) );
+
+		$store = $this->getMockBuilder( '\SMW\SQLStore\SQLStore' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$store->expects( $this->atLeastOnce() )
+			->method( 'getConnection' )
+			->will( $this->returnValue( $database ) );
+
+		$store->expects( $this->atLeastOnce() )
+			->method( 'getDataItemHandlerForDIType' )
+			->will( $this->returnValue( $diHandlerBlob ) );
+
+		$store->expects( $this->atLeastOnce() )
+			->method( 'getPropertyTables' )
+			->will( $this->returnValue( array(
+				$this->getNonFixedPropertyTableDefinition( $arbitraryPropertyTableName ) )
+			) );
+
+		$instance = new SearchFieldContentRebuilder(
+			$store
+		);
+
+		$instance->rebuild();
+	}
+
+	protected function getNonFixedPropertyTableDefinition( $propertyTableName ) {
+
+		$propertyTable = $this->getMockBuilder( '\SMW\SQLStore\TableDefinition' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$propertyTable->expects( $this->any() )
+			->method( 'isFixedPropertyTable' )
+			->will( $this->returnValue( false ) );
+
+		$propertyTable->expects( $this->any() )
+			->method( 'getName' )
+			->will( $this->returnValue( $propertyTableName ) );
+
+		$propertyTable->expects( $this->any() )
+			->method( 'getDiType' )
+			->will( $this->returnValue( 2 ) );
+
+		return $propertyTable;
+	}
+
+}

--- a/tests/phpunit/Unit/SQLStore/QueryEngine/Interpreter/ComparatorMapperTest.php
+++ b/tests/phpunit/Unit/SQLStore/QueryEngine/Interpreter/ComparatorMapperTest.php
@@ -63,6 +63,23 @@ class ComparatorMapperTest extends \PHPUnit_Framework_TestCase {
 		);
 	}
 
+	public function testIsEnabledForCaseInsensitiveSearch() {
+
+		$valueDescription = $this->getMockBuilder( '\SMW\Query\Language\ValueDescription' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$valueDescription->expects( $this->once() )
+			->method( 'getComparator' )
+			->will( $this->returnValue( SMW_CMP_LIKE ) );
+
+		$instance = new ComparatorMapper( true );
+
+		$this->assertTrue(
+			$instance->isEnabledEnhancedRegExMatchSearch( $valueDescription )
+		);
+	}
+
 	public function comparatorProvider() {
 
 		$provider[] = array( SMW_CMP_EQ,   'Foo%_*?', array( 'comparator' => '=',  'value' => 'Foo%_*?' ) );

--- a/tests/phpunit/Unit/SearchFieldTest.php
+++ b/tests/phpunit/Unit/SearchFieldTest.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace SMW\Tests;
+
+use SMW\SearchField;
+
+/**
+ * @covers \SMW\SearchField
+ * @group semantic-mediawiki
+ *
+ * @license GNU GPL v2+
+ * @since 2.4
+ *
+ * @author mwjames
+ */
+class SearchFieldTest extends \PHPUnit_Framework_TestCase {
+
+	/**
+	 * @dataProvider stringProvider
+	 */
+	public function testSearchField( $string, $expected ) {
+
+		$this->assertEquals(
+			$expected,
+			SearchField::getSearchStringFrom( $string )
+		);
+	}
+
+	/**
+	 * @dataProvider stringProvider
+	 */
+	public function testIndexField( $string, $expected ) {
+
+		$this->assertEquals(
+			$expected,
+			SearchField::getIndexStringFrom( $string )
+		);
+	}
+
+	public function stringProvider() {
+
+		$provider[] = array(
+			"ABC",
+			"abc"
+		);
+
+		$provider[] = array(
+			"lOrEm",
+			"lorem"
+		);
+
+		$provider[] = array(
+			"http://example.org",
+			"example.org"
+		);
+
+		return $provider;
+	}
+
+}


### PR DESCRIPTION
Instead of using the sortkey to match a text string, any regex search (if enabled) will use the normalized search index to allow for case-insensitive result matches.

A query condition such as `[[Has text::~lorem*]]` will return the same results as for a `[[Has text::~LOREM*]]` (or `[[Has text::~lOrEm*]]`) condition.

Test cases include:

- `[[Has text::~lorem*]]` and `[[Has text::~*REM*]]`
- `[[Has text::!~*REM*]]`
- `[[Has url::~*rem*]]` and `[[Has url::~*REm*]]`
- `[[~*/6/lore*]]` and `[[~*/6/lORe*]]`
- `[[Has text::~*æå*]]`

## Features and limitations 

- ~~`$GLOBALS['smwgEnabledCaseInsensitiveRegExMatchSearch']`~~ `$GLOBALS['smwgEnabledEnhancedRegExMatchSearch']` requires to be set true
- `update.php` and `rebuildData.php` both required to be run after the setting was enabled
- Any non regex search will use the standard sortkey to return correct matches of things like `=`, `>`, `<` 
- Something like `LIKE 'whatever%'` (as `[[Has text::~whatever*]]`) will use the extra index whereby `LIKE '%whatever%'` (as `[[Has text::~*whatever*]]`) will not (a limitation set by the SQL engine)


refs http://wikimedia.7.x6.nabble.com/semediawikiuser-Case-insensitive-search-still-not-at-option-td5055261.html