### PR TITLE
Ensure statement uniqueness during export for multiple sobj, refs #1275

### DIFF
--- a/includes/SemanticData.php
+++ b/includes/SemanticData.php
@@ -659,6 +659,12 @@ class SemanticData {
 		} else {
 			$semanticData->subContainerDepthCounter++;
 			foreach ( $semanticData->getSubSemanticData() as $subsubdata ) {
+
+				// Skip container that are known to be registered (avoids recursive statement extension)
+				if ( $this->hasSubSemanticData( $subsubdata->getSubject()->getSubobjectName() ) ) {
+					continue;
+				}
+
 				$this->addSubSemanticData( $subsubdata );
 			}
 			$semanticData->subSemanticData = array();

--- a/tests/phpunit/Integration/ByJsonScript/Fixtures/r-0006 record rdf ouput.json
+++ b/tests/phpunit/Integration/ByJsonScript/Fixtures/r-0006 record rdf ouput.json
@@ -22,6 +22,10 @@
 		{
 			"name": "Example/R0006/2",
 			"contents": "[[Category:R0006]] {{#subobject:|HasTextNumberRecord=Foo;123}}"
+		},
+		{
+			"name": "Example/R0006/3",
+			"contents": "[[Category:R0006]] [[HasTextNumberRecord::Foo;123]] {{#subobject:A1|Has number=123|HasTextNumberRecord=Foo;123}} {{#subobject:A2|Has number=456|HasTextNumberRecord=Foo;123}}"
 		}
 	],
 	"rdf-testcases": [
@@ -67,6 +71,30 @@
 					"<property:Has_text rdf:datatype=\"http://www.w3.org/2001/XMLSchema#string\">Foo</property:Has_text>",
 					"<owl:ObjectProperty rdf:about=\"http://example.org/id/Property-3AHas_subobject\" />",
 					"<owl:ObjectProperty rdf:about=\"http://example.org/id/Property-3AHasTextNumberRecord\" />"
+				]
+			}
+		},
+		{
+			"about": "#2 multiple subobject record annotation, test statement uniqueness (statement order is important)",
+			"store":{
+				"clear-cache": true
+			},
+			"exportcontroller" : {
+				"print-pages": [ "Example/R0006/3" ],
+				"parameters" : {
+					"backlinks" : true,
+					"recursion" : "1",
+					"revisiondate" : false
+				}
+			},
+			"expected-output": {
+				"to-contain": [
+				"<property:HasTextNumberRecord rdf:resource=\"&wiki;Example/R0006/3-23_e594fde0f37d237549009d2ecebce80e\"/>",
+					"<property:Has_subobject rdf:resource=\"&wiki;Example/R0006/3-23A1\"/>",
+					"<property:Has_subobject rdf:resource=\"&wiki;Example/R0006/3-23A2\"/>",
+					"<property:Has_number rdf:datatype=\"http://www.w3.org/2001/XMLSchema#double\">123</property:Has_number>\n\t\t<property:Has_text rdf:datatype=\"http://www.w3.org/2001/XMLSchema#string\">Foo</property:Has_text>\n\t\t<swivt:wikiPageSortKey rdf:datatype=\"http://www.w3.org/2001/XMLSchema#string\">Example/R0006/3</swivt:wikiPageSortKey>",
+					"<property:HasTextNumberRecord rdf:resource=\"&wiki;Example/R0006/3-23_e594fde0f37d237549009d2ecebce80e\"/>\n\t\t<property:Has_number rdf:datatype=\"http://www.w3.org/2001/XMLSchema#double\">123</property:Has_number>",
+					"<property:HasTextNumberRecord rdf:resource=\"&wiki;Example/R0006/3-23_e594fde0f37d237549009d2ecebce80e\"/>\n\t\t<property:Has_number rdf:datatype=\"http://www.w3.org/2001/XMLSchema#double\">456</property:Has_number>"
 				]
 			}
 		}

--- a/tests/phpunit/Integration/ByJsonScript/RdfTestCaseProcessor.php
+++ b/tests/phpunit/Integration/ByJsonScript/RdfTestCaseProcessor.php
@@ -50,6 +50,13 @@ class RdfTestCaseProcessor extends \PHPUnit_Framework_TestCase {
 	}
 
 	public function process( array $case ) {
+
+		// Allows for data to be re-read from the DB instead of being fetched
+		// from the store-id-cache
+		if ( isset( $case['store']['clear-cache'] ) && $case['store']['clear-cache'] ) {
+			$this->store->clear();
+		}
+
 		$this->assertRdfOutputForCase( $case );
 	}
 


### PR DESCRIPTION
This is an edge case where a record with the same signature (== same hash key) is used in different subobjects within in the same subject. It can generated something like below when exported because the reference to the record is added multiple times (each time for a subobject that contains the reference). The use case is now covered by a test and checks indirectly that no duplicate statements are to be found in a RDF export.

```
<property:Has_number rdf:datatype="http://www.w3.org/2001/XMLSchema#double">123</property:Has_number>
<property:Has_number rdf:datatype="http://www.w3.org/2001/XMLSchema#double">123</property:Has_number>
<property:Has_number rdf:datatype="http://www.w3.org/2001/XMLSchema#double">123</property:Has_number>
<property:Has_number rdf:datatype="http://www.w3.org/2001/XMLSchema#double">123</property:Has_number>
<property:Has_text rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Foo</property:Has_text>
<property:Has_text rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Foo</property:Has_text>
<property:Has_text rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Foo</property:Has_text>
<property:Has_text rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Foo</property:Has_text>
<swivt:wikiPageSortKey rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Example/R0006/3</swivt:wikiPageSortKey>
```

refs #1275