### PR TITLE
Register contextReference early in InTextAnnotationParser

### DIFF
--- a/src/InTextAnnotationParser.php
+++ b/src/InTextAnnotationParser.php
@@ -70,13 +70,6 @@ class InTextAnnotationParser {
 	protected $isAnnotation = true;
 
 	/**
-	 * Identifies the current parser run (especially when called recursively)
-	 *
-	 * @var string
-	 */
-	private $contextReference;
-
-	/**
 	 * @var boolean
 	 */
 	private $strictModeState = true;
@@ -122,7 +115,9 @@ class InTextAnnotationParser {
 		$title = $this->parserData->getTitle();
 		$this->settings = $this->applicationFactory->getSettings();
 
-		$this->contextReference = 'intp:' . uniqid();
+		// Identifies the current parser run (especially when called recursively)
+		$this->parserData->getSubject()->setContextReference( 'intp:' . uniqid() );
+
 		$this->doStripMagicWordsFromText( $text );
 
 		$this->setSemanticEnabledNamespaceState( $title );
@@ -326,10 +321,7 @@ class InTextAnnotationParser {
 	 */
 	protected function addPropertyValue( array $properties, $value, $valueCaption ) {
 
-		$subject = $this->parserData->getSemanticData()->getSubject();
-
-		// Set a context to a subject to idenitify the parser run
-		$subject->setContextReference( $this->contextReference );
+		$subject = $this->parserData->getSubject();
 
 		// Add properties to the semantic container
 		foreach ( $properties as $property ) {

--- a/tests/phpunit/Integration/MediaWiki/LinksUpdateSQLStoreDBIntegrationTest.php
+++ b/tests/phpunit/Integration/MediaWiki/LinksUpdateSQLStoreDBIntegrationTest.php
@@ -127,11 +127,11 @@ class LinksUpdateSQLStoreDBIntegrationTest extends MwDBaseUnitTestCase {
 		$revision = $wikiPage->getRevision();
 
 		$parserData = $this->retrieveAndLoadData();
-		$this->assertCount( 3, $parserData->getData()->getProperties() );
+		$this->assertCount( 3, $parserData->getSemanticData()->getProperties() );
 
 		$this->assertEquals(
-			$parserData->getData(),
-			$this->retrieveAndLoadData( $revision->getId() )->getData(),
+			$parserData->getSemanticData()->getHash(),
+			$this->retrieveAndLoadData( $revision->getId() )->getSemanticData()->getHash(),
 			'Asserts that data are equals with or without a revision'
 		);
 
@@ -166,7 +166,7 @@ class LinksUpdateSQLStoreDBIntegrationTest extends MwDBaseUnitTestCase {
 	protected function assertPropertyCount( $poExpected, $storeExpected, $parserData ) {
 		$this->semanticDataValidator->assertThatSemanticDataHasPropertyCountOf(
 			$poExpected['count'],
-			$parserData->getData(),
+			$parserData->getSemanticData(),
 			$poExpected['msg']
 		);
 

--- a/tests/phpunit/Integration/SemanticMediaWikiProvidedHookInterfaceIntegrationTest.php
+++ b/tests/phpunit/Integration/SemanticMediaWikiProvidedHookInterfaceIntegrationTest.php
@@ -352,6 +352,10 @@ class SemanticMediaWikiProvidedHookInterfaceIntegrationTest extends \PHPUnit_Fra
 			->will( $this->returnValue( $parserOutput ) );
 
 		$parserData->expects( $this->any() )
+			->method( 'getSubject' )
+			->will( $this->returnValue( DIWikiPage::newFromTitle( $title ) ) );
+
+		$parserData->expects( $this->any() )
 			->method( 'getSemanticData' )
 			->will( $this->returnValue( $semanticData ) );
 


### PR DESCRIPTION
For some edge cases this allows that even though annotations have not been altered to continue a purge and re-establish data integrity.

refs ca2c54151f