### PR TITLE
No redirect for resources that match an import vocab

### DIFF
--- a/src/Exporter/DataItemToExpResourceEncoder.php
+++ b/src/Exporter/DataItemToExpResourceEncoder.php
@@ -179,6 +179,8 @@ class DataItemToExpResourceEncoder {
 			$diWikiPage
 		);
 
+		$resource->wasMatchedToImportVocab = $importDataItem instanceof DataItem;
+
 		$poolCache->save(
 			$hash,
 			$resource

--- a/src/SPARQLStore/QueryEngine/CompoundConditionBuilder.php
+++ b/src/SPARQLStore/QueryEngine/CompoundConditionBuilder.php
@@ -373,6 +373,12 @@ class CompoundConditionBuilder {
 		}
 
 		$redirectExpElement = Exporter::getInstance()->getResourceElementForWikiPage( $dataItem );
+
+		// If the resource was matched to an imported vocab then no redirect is required
+		if ( isset( $redirectExpElement->wasMatchedToImportVocab ) && $redirectExpElement->wasMatchedToImportVocab ) {
+			return null;
+		}
+
 		$valueName = TurtleSerializer::getTurtleNameForExpElement( $redirectExpElement );
 
 		// Add unknow redirect target/variable for value

--- a/tests/phpunit/Integration/ByJsonScript/Fixtures/q-0301 [#891] import foaf typed queries.json
+++ b/tests/phpunit/Integration/ByJsonScript/Fixtures/q-0301 [#891] import foaf typed queries.json
@@ -23,6 +23,11 @@
 			"contents": "[[Imported from::foaf:knows]]"
 		},
 		{
+			"name": "Has name",
+			"namespace": "SMW_NS_PROPERTY",
+			"contents": "#REDIRECT [[Property:Foaf:name]]"
+		},
+		{
 			"name": "John Doe",
 			"contents": "[[Foaf:name::John Doe]], [[Foaf:homepage::http://example.org/JohnDoe]] [[Foaf:knows::Jane Doe]]"
 		},
@@ -89,9 +94,25 @@
 					}
 				]
 			}
+		},
+		{
+			"about": "#2 query on redirected property",
+			"condition": "[[Has name::John Doe]]",
+			"printouts" : [ ],
+			"parameters" : {
+			  "limit" : "10"
+			},
+			"queryresult": {
+				"count": 1,
+				"results": [
+					"John Doe#0##"
+				]
+			}
 		}
 	],
 	"settings": {
+		"wgContLang": "en",
+		"wgLang": "en",
 		"smwgNamespace": "http://example.org/id/",
 		"smwgNamespacesWithSemanticLinks": {
 			"NS_MAIN": true,

--- a/tests/phpunit/Integration/ByJsonScript/QueryTestCaseProcessor.php
+++ b/tests/phpunit/Integration/ByJsonScript/QueryTestCaseProcessor.php
@@ -107,6 +107,10 @@ class QueryTestCaseProcessor extends \PHPUnit_Framework_TestCase {
 
 		$this->printQueryResultToOutput( $queryResult );
 
+		if ( is_string( $queryResult ) ) {
+			return;
+		}
+
 		$this->assertEquals(
 			$queryTestCaseInterpreter->getExpectedCount(),
 			$queryResult->getCount(),
@@ -230,6 +234,10 @@ class QueryTestCaseProcessor extends \PHPUnit_Framework_TestCase {
 	}
 
 	private function printQueryResultToOutput( $queryResult ) {
+
+		if ( is_string( $queryResult ) ) {
+			return print_r( str_replace( array( "&#x0020;", "&#x003A;" ), array( " ", ":" ), $queryResult ) );
+		}
 
 		if ( !$this->debug ) {
 			return;

--- a/tests/phpunit/Unit/Exporter/DataItemToExpResourceEncoderTest.php
+++ b/tests/phpunit/Unit/Exporter/DataItemToExpResourceEncoderTest.php
@@ -137,6 +137,10 @@ class DataItemToExpResourceEncoderTest extends \PHPUnit_Framework_TestCase {
 			$dataItem
 		);
 
+		$this->assertTrue(
+			$resource->wasMatchedToImportVocab
+		);
+
 		$this->assertSame(
 			$expected,
 			$resource->getSerialization()

--- a/tests/phpunit/Utils/Validators/ExportDataValidator.php
+++ b/tests/phpunit/Utils/Validators/ExportDataValidator.php
@@ -39,7 +39,7 @@ class ExportDataValidator extends \PHPUnit_Framework_Assert {
 
 		foreach ( $expProperties as $expProperty ) {
 			foreach ( $expectedProperties as $expectedProperty ) {
-				if ( $expectedProperty == $expProperty ) {
+				if ( $expectedProperty->getHash() === $expProperty->getHash() ) {
 					$actualComparedToCount++;
 					$assertThatExportDataContainsProperty = true;
 				}
@@ -75,7 +75,7 @@ class ExportDataValidator extends \PHPUnit_Framework_Assert {
 
 		foreach ( $expElements as $expElement ) {
 			foreach ( $expectedResources as $expectedResource ) {
-				if ( $expectedResource == $expElement ) {
+				if ( $expectedResource->getHash() === $expElement->getHash() ) {
 					$actualComparedToCount++;
 					$assertThatExportDataContainsResource = true;
 				}


### PR DESCRIPTION
Results in

```
SELECT DISTINCT ?result WHERE {
?result foaf:name "John Doe" .
}
```

instead of

```
SELECT DISTINCT ?result WHERE {
?r2 ^swivt:redirectsTo foaf:name .
?result ?r2 "John Doe" .
}
```