### PR TITLE
PropertyValue to be fowarded to its redirect target

### DIFF
--- a/SemanticMediaWiki.settings.php
+++ b/SemanticMediaWiki.settings.php
@@ -934,10 +934,24 @@ $GLOBALS['smwgExportBCNonCanonicalFormUse'] = false;
 # The default interpretation (strict) is to find a single triple such as
 # [[property::value:partOfTheValue::alsoPartOfTheValue]] where in case the strict
 # mode is disabled multiple properties can be assigned using a
-# [[property1::property2::value]] notation which may cause value strings to be
+# [[property1::property2::value]] notation but may cause value strings to be
 # interpret unanticipated in case of additional colons.
 #
 # @since 2.3
 # @default true
 ##
 $GLOBALS['smwgEnabledInTextAnnotationParserStrictMode'] = true;
+
+##
+# If a property is redirected to a different target (Foo -> Bar) then follow it
+# by default in order toallow query results to be displayed equivalent for both
+# queries without having to adjust (or change) a query.
+#
+# @note This setting is mainly provided to restore backwards compatibility where
+# behaviour is not expected to be altered, nevertheless it is recommended that
+# the setting is enabled to improve user friendliness in terms of query execution.
+#
+# @since 2.4
+# @default true
+##
+$GLOBALS['smwgFollowPropertyRedirect'] = true;

--- a/includes/Settings.php
+++ b/includes/Settings.php
@@ -140,7 +140,8 @@ class Settings extends SimpleDictionary {
 			'smwgExportBCNonCanonicalFormUse' => $GLOBALS['smwgExportBCNonCanonicalFormUse'],
 			'smwgExportBCAuxiliaryUse' => $GLOBALS['smwgExportBCAuxiliaryUse'],
 			'smwgEnabledInTextAnnotationParserStrictMode' => $GLOBALS['smwgEnabledInTextAnnotationParserStrictMode'],
-			'smwgSparqlRepositoryConnectorForcedHttpVersion' => $GLOBALS['smwgSparqlRepositoryConnectorForcedHttpVersion']
+			'smwgSparqlRepositoryConnectorForcedHttpVersion' => $GLOBALS['smwgSparqlRepositoryConnectorForcedHttpVersion'],
+			'smwgFollowPropertyRedirect' => $GLOBALS['smwgFollowPropertyRedirect']
 		);
 
 		$settings = $settings + array(

--- a/includes/dataitems/SMW_DI_Property.php
+++ b/includes/dataitems/SMW_DI_Property.php
@@ -368,7 +368,7 @@ class DIProperty extends SMWDataItem {
 	 */
 	public static function newFromUserLabel( $label, $inverse = false ) {
 
-		$id = PropertyRegistry::getInstance()->findPropertyIdByLabel( $label );
+		$id = PropertyRegistry::getInstance()->findPropertyIdByLabel( str_replace( '_', ' ', $label ) );
 
 		if ( $id === false ) {
 			return new self( str_replace( ' ', '_', $label ), $inverse );

--- a/includes/dataitems/SMW_DI_Property.php
+++ b/includes/dataitems/SMW_DI_Property.php
@@ -235,6 +235,20 @@ class DIProperty extends SMWDataItem {
 	}
 
 	/**
+	 * @since 2.4
+	 *
+	 * @return DIProperty
+	 */
+	public function getRedirectTarget() {
+
+		if ( $this->m_inverse ) {
+			return $this;
+		}
+
+		return ApplicationFactory::getInstance()->getStore()->getRedirectTarget( $this );
+	}
+
+	/**
 	 * @since  2.0
 	 *
 	 * @return self
@@ -274,7 +288,7 @@ class DIProperty extends SMWDataItem {
 		if ( !isset( $this->m_proptypeid ) ) {
 			if ( $this->isUserDefined() ) { // normal property
 				$diWikiPage = new SMWDIWikiPage( $this->getKey(), SMW_NS_PROPERTY, $this->interwiki );
-				$typearray = StoreFactory::getStore()->getPropertyValues( $diWikiPage, new self( '_TYPE' ) );
+				$typearray = ApplicationFactory::getInstance()->getStore()->getPropertyValues( $diWikiPage, new self( '_TYPE' ) );
 
 				if ( count( $typearray ) >= 1 ) { // some types given, pick one (hopefully unique)
 					$typeDataItem = reset( $typearray );

--- a/includes/datavalues/SMW_DV_Property.php
+++ b/includes/datavalues/SMW_DV_Property.php
@@ -120,6 +120,9 @@ class SMWPropertyValue extends SMWDataValue {
 			$this->addError( wfMessage( 'smw_noproperty', $value )->inContentLanguage()->text() );
 			$this->m_dataitem = new SMWDIProperty( 'ERROR', false ); // just to have something
 		}
+
+		// Find the "real" target of a property that represents the valueString
+		$this->m_dataitem = $this->m_dataitem->getRedirectTarget();
 	}
 
 	/**

--- a/includes/datavalues/SMW_DV_PropertyList.php
+++ b/includes/datavalues/SMW_DV_PropertyList.php
@@ -83,7 +83,7 @@ class SMWPropertyListValue extends SMWDataValue {
 
 			if ( $property instanceof SMWDIProperty ) {
 				 // Find a possible redirect
-				$this->m_diProperties[] = ApplicationFactory::getInstance()->getStore()->getRedirectTarget( $property );
+				$this->m_diProperties[] = $property->getRedirectTarget();
 			}
 		}
 

--- a/includes/storage/SMW_Store.php
+++ b/includes/storage/SMW_Store.php
@@ -182,7 +182,7 @@ abstract class Store {
 
 		if ( count( $redirectDataItems ) > 0 ) {
 			if ( $dataItem->getDIType() == SMWDataItem::TYPE_PROPERTY ) {
-				$dataItem = new DIProperty( end( $redirectDataItems )->getDBkey() );
+				$dataItem = DIProperty::newFromUserLabel( end( $redirectDataItems )->getDBkey() );
 			} else {
 				$dataItem = end( $redirectDataItems );
 			}

--- a/src/Exporter/DataItemToExpResourceEncoder.php
+++ b/src/Exporter/DataItemToExpResourceEncoder.php
@@ -164,7 +164,22 @@ class DataItemToExpResourceEncoder {
 			$modifier = $diWikiPage->getSubobjectName();
 		}
 
-		$importDataItem = $this->tryToFindImportDataItem( $diWikiPage, $modifier );
+		$resource = $this->newExpNsResource(
+			$diWikiPage,
+			$modifier
+		);
+
+		$poolCache->save(
+			$hash,
+			$resource
+		);
+
+		return $resource;
+	}
+
+	private function newExpNsResource( $diWikiPage, $modifier ) {
+
+		 $importDataItem = $this->tryToFindImportDataItem( $diWikiPage, $modifier );
 
 		if ( $importDataItem instanceof DataItem ) {
 			list( $localName, $namespace, $namespaceId ) = $this->defineElementsForImportDataItem( $importDataItem );
@@ -180,11 +195,11 @@ class DataItemToExpResourceEncoder {
 		);
 
 		$resource->wasMatchedToImportVocab = $importDataItem instanceof DataItem;
+		$dbKey = $diWikiPage->getDBkey();
 
-		$poolCache->save(
-			$hash,
-			$resource
-		);
+		if ( $diWikiPage->getNamespace() === SMW_NS_PROPERTY && $dbKey !== '' && $dbKey{0} !== '-' ) {
+			$resource->isUserDefined = DIProperty::newFromUserLabel( $diWikiPage->getDBkey() )->isUserDefined();
+		}
 
 		return $resource;
 	}

--- a/src/SPARQLStore/RedirectLookup.php
+++ b/src/SPARQLStore/RedirectLookup.php
@@ -104,7 +104,8 @@ class RedirectLookup {
 		return $expNsResource->getNamespaceId() === 'swivt' ||
 			$expNsResource->getNamespaceId() === 'rdf' ||
 			$expNsResource->getNamespaceId() === 'rdfs' ||
-			( $expNsResource->getNamespaceId() === 'property' && strrpos( $expNsResource->getLocalName(), 'aux' ) );
+			( $expNsResource->getNamespaceId() === 'property' && strrpos( $expNsResource->getLocalName(), 'aux' ) ) ||
+			( isset( $expNsResource->isUserDefined ) && !$expNsResource->isUserDefined );
 	}
 
 	private function lookupResourceUriTargetFromDatabase( ExpNsResource $expNsResource ) {

--- a/tests/phpunit/Integration/ByJsonScript/Fixtures/p-0903 ask redirected printrequest.json
+++ b/tests/phpunit/Integration/ByJsonScript/Fixtures/p-0903 ask redirected printrequest.json
@@ -38,6 +38,7 @@
 			},
 			"expected-output": {
 				"to-contain": [
+					"Example/P0903/1",
 					"Example/P0903/2"
 				]
 			}

--- a/tests/phpunit/Integration/ByJsonScript/Fixtures/q-0402 [#1003] subproperty dc import on marc21 record.json
+++ b/tests/phpunit/Integration/ByJsonScript/Fixtures/q-0402 [#1003] subproperty dc import on marc21 record.json
@@ -62,8 +62,11 @@
 			"about": "#0 any value for Marc:title statement",
 			"condition": "[[Marc:title statement::+]]",
 			"printouts" : [ "Has author" ],
+			"store" : {
+				"clear-cache" : true
+			},
 			"parameters" : {
-			  "limit" : 10
+				"limit" : 10
 			},
 			"queryresult": {
 				"count": 2,
@@ -87,8 +90,11 @@
 			"about": "#1 any value for Marc:title on level one of the subproperty hierarchy",
 			"condition": "[[Marc:title::+]]",
 			"printouts" : [ "Has author" ],
+			"store" : {
+				"clear-cache" : true
+			},
 			"parameters" : {
-			  "limit" : 10
+				"limit" : 10
 			},
 			"queryresult": {
 				"count": 3,
@@ -117,8 +123,11 @@
 			"about": "#2 any value for Dc:title on level two of the subproperty hierarchy",
 			"condition": "[[Dc:title::+]]",
 			"printouts" : [ "Has author" ],
+			"store" : {
+				"clear-cache" : true
+			},
 			"parameters" : {
-			  "limit" : 10
+				"limit" : 10
 			},
 			"queryresult": {
 				"count": 3,
@@ -147,8 +156,11 @@
 			"about": "#3 distinct value for Dc:title on level two of the subproperty hierarchy",
 			"condition": "[[Dc:title::~*Animal*]]",
 			"printouts" : [ "Has author" ],
+			"store" : {
+				"clear-cache" : true
+			},
 			"parameters" : {
-			  "limit" : 10
+				"limit" : 10
 			},
 			"queryresult": {
 				"count": 1,
@@ -167,8 +179,11 @@
 			"about": "#4 distinct value for Has author / redirected value / subproperty level zero",
 			"condition": "[[Has author::Shakespeare]]",
 			"printouts" : [],
+			"store" : {
+				"clear-cache" : true
+			},
 			"parameters" : {
-			  "limit" : 10
+				"limit" : 10
 			},
 			"queryresult": {
 				"count": 1,
@@ -181,8 +196,11 @@
 			"about": "#5 distinct value for Dc:creator / redirected value / subproperty level one",
 			"condition": "[[Dc:creator::Shakespeare]]",
 			"printouts" : [],
+			"store" : {
+				"clear-cache" : true
+			},
 			"parameters" : {
-			  "limit" : 10
+				"limit" : 10
 			},
 			"queryresult": {
 				"count": 1,

--- a/tests/phpunit/Integration/ByJsonScript/QueryTestCaseInterpreter.php
+++ b/tests/phpunit/Integration/ByJsonScript/QueryTestCaseInterpreter.php
@@ -104,10 +104,17 @@ class QueryTestCaseInterpreter {
 
 		foreach ( $this->contents['printouts'] as $printout ) {
 
-			$propertyValue = new PropertyValue( '__pro' );
-			$propertyValue->setDataItem( DIProperty::newFromUserLabel( $printout ) );
+			$label = null;
 
-			$extraPrintouts[] = new PrintRequest( PrintRequest::PRINT_PROP, null, $propertyValue );
+			if ( strpos( $printout, '#') !== false ) {
+				list( $printout, $label ) = explode( '#', $printout );
+			}
+
+			$extraPrintouts[] = new PrintRequest(
+				PrintRequest::PRINT_PROP,
+				$label,
+				PropertyValue::makeUserProperty( $printout )
+			);
 		}
 
 		return $extraPrintouts;

--- a/tests/phpunit/Integration/QueryResultQueryProcessorIntegrationTest.php
+++ b/tests/phpunit/Integration/QueryResultQueryProcessorIntegrationTest.php
@@ -168,14 +168,16 @@ class QueryResultQueryProcessorIntegrationTest extends MwDBaseUnitTestCase {
 					'typeid' => '_wpg',
 					'mode' => 2,
 					'format' => false,
-					'key' => ''
+					'key' => '',
+					'redi' => ''
 				),
 				array(
 					'label'=> 'Modification date',
 					'typeid' => '_dat',
 					'mode' => 1,
 					'format' => '',
-					'key' => '_MDAT'
+					'key' => '_MDAT',
+					'redi' => ''
 				)
 			)
 		);
@@ -194,14 +196,16 @@ class QueryResultQueryProcessorIntegrationTest extends MwDBaseUnitTestCase {
 					'typeid' => '_wpg',
 					'mode' => 2,
 					'format' => false,
-					'key' => ''
+					'key' => '',
+					'redi' => ''
 				),
 				array(
 					'label'=> 'Modification date',
 					'typeid' => '_dat',
 					'mode' => 1,
 					'format' => 'ISO',
-					'key' => '_MDAT'
+					'key' => '_MDAT',
+					'redi' => ''
 				)
 			)
 		);

--- a/tests/phpunit/Unit/Factbox/FactboxMagicWordsTest.php
+++ b/tests/phpunit/Unit/Factbox/FactboxMagicWordsTest.php
@@ -28,6 +28,12 @@ class FactboxMagicWordsTest extends \PHPUnit_Framework_TestCase {
 		parent::setUp();
 
 		$this->applicationFactory = ApplicationFactory::getInstance();
+
+		$store = $this->getMockBuilder( '\SMW\Store' )
+			->disableOriginalConstructor()
+			->getMockForAbstractClass();
+
+		$this->applicationFactory->registerObject( 'Store', $store );
 	}
 
 	protected function tearDown() {

--- a/tests/phpunit/Unit/InTextAnnotationParserTemplateTransclusionTest.php
+++ b/tests/phpunit/Unit/InTextAnnotationParserTemplateTransclusionTest.php
@@ -128,6 +128,7 @@ class InTextAnnotationParserTemplateTransclusionTest extends \PHPUnit_Framework_
 				'smwgNamespacesWithSemanticLinks' => array( NS_MAIN => true ),
 				'smwgLinksInValues' => false,
 				'smwgInlineErrors'  => true,
+				'smwgCacheType'     => 'hash'
 			),
 			'[[Foo::{{Bam}}]]',
 			'?bar',

--- a/tests/phpunit/Unit/InTextAnnotationParserTemplateTransclusionTest.php
+++ b/tests/phpunit/Unit/InTextAnnotationParserTemplateTransclusionTest.php
@@ -31,6 +31,12 @@ class InTextAnnotationParserTemplateTransclusionTest extends \PHPUnit_Framework_
 
 		$this->semanticDataValidator = new SemanticDataValidator();
 		$this->applicationFactory = ApplicationFactory::getInstance();
+
+		$store = $this->getMockBuilder( '\SMW\Store' )
+			->disableOriginalConstructor()
+			->getMockForAbstractClass();
+
+		$this->applicationFactory->registerObject( 'Store', $store );
 	}
 
 	protected function tearDown() {

--- a/tests/phpunit/Unit/InTextAnnotationParserTest.php
+++ b/tests/phpunit/Unit/InTextAnnotationParserTest.php
@@ -36,6 +36,12 @@ class InTextAnnotationParserTest extends \PHPUnit_Framework_TestCase {
 
 		$this->semanticDataValidator = new SemanticDataValidator();
 		$this->applicationFactory = ApplicationFactory::getInstance();
+
+		$store = $this->getMockBuilder( '\SMW\Store' )
+			->disableOriginalConstructor()
+			->getMockForAbstractClass();
+
+		$this->applicationFactory->registerObject( 'Store', $store );
 	}
 
 	protected function tearDown() {

--- a/tests/phpunit/Unit/MediaWiki/Api/AskArgsTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Api/AskArgsTest.php
@@ -206,7 +206,8 @@ class AskArgsTest extends \PHPUnit_Framework_TestCase  {
 						'typeid' => '_wpg',
 						'mode' => 2,
 						'format' => false,
-						'key' => ''
+						'key' => '',
+						'redi' => ''
 					)
 				)
 			),
@@ -224,14 +225,16 @@ class AskArgsTest extends \PHPUnit_Framework_TestCase  {
 						'typeid' => '_wpg',
 						'mode' => 2,
 						'format' => false,
-						'key' => ''
+						'key' => '',
+						'redi' => ''
 					),
 					array(
 						'label'=> 'Modification date',
 						'typeid' => '_dat',
 						'mode' => 1,
 						'format' => '',
-						'key' => '_MDAT'
+						'key' => '_MDAT',
+						'redi' => ''
 					)
 				)
 			),
@@ -249,14 +252,16 @@ class AskArgsTest extends \PHPUnit_Framework_TestCase  {
 						'typeid' => '_wpg',
 						'mode' => 2,
 						'format' => false,
-						'key' => ''
+						'key' => '',
+						'redi' => ''
 					),
 					array(
 						'label'=> 'Modification date',
 						'typeid' => '_dat',
 						'mode' => 1,
 						'format' => '',
-						'key' => '_MDAT'
+						'key' => '_MDAT',
+						'redi' => ''
 					)
 				)
 			),

--- a/tests/phpunit/Unit/MediaWiki/Api/AskTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Api/AskTest.php
@@ -73,14 +73,16 @@ class AskTest extends \PHPUnit_Framework_TestCase {
 					'typeid' => '_wpg',
 					'mode' => 2,
 					'format' => false,
-					'key' => ''
+					'key' => '',
+					'redi' => ''
 				),
 				array(
 					'label'=> 'Modification date',
 					'typeid' => '_dat',
 					'mode' => 1,
 					'format' => '',
-					'key' => '_MDAT'
+					'key' => '_MDAT',
+					'redi' => ''
 				)
 			)
 		);

--- a/tests/phpunit/Unit/MediaWiki/Hooks/InternalParseBeforeLinksTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Hooks/InternalParseBeforeLinksTest.php
@@ -33,6 +33,12 @@ class InternalParseBeforeLinksTest extends \PHPUnit_Framework_TestCase {
 		$this->semanticDataValidator = UtilityFactory::getInstance()->newValidatorFactory()->newSemanticDataValidator();
 		$this->parserFactory = UtilityFactory::getInstance()->newParserFactory();
 		$this->applicationFactory = ApplicationFactory::getInstance();
+
+		$store = $this->getMockBuilder( '\SMW\Store' )
+			->disableOriginalConstructor()
+			->getMockForAbstractClass();
+
+		$this->applicationFactory->registerObject( 'Store', $store );
 	}
 
 	protected function tearDown() {

--- a/tests/phpunit/Unit/Serializers/QueryResultSerializerTest.php
+++ b/tests/phpunit/Unit/Serializers/QueryResultSerializerTest.php
@@ -180,8 +180,8 @@ class QueryResultSerializerTest extends \PHPUnit_Framework_TestCase {
 				),
 			array(
 				'printrequests' => array(
-					array( 'label' => 'Foo-1', 'typeid' => '_num', 'mode' => 2, 'format' => false, 'key' => '' ),
-					array( 'label' => 'Foo-2', 'typeid' => '_num', 'mode' => 2, 'format' => false, 'key' => '' )
+					array( 'label' => 'Foo-1', 'typeid' => '_num', 'mode' => 2, 'format' => false, 'key' => '', 'redi' => '' ),
+					array( 'label' => 'Foo-2', 'typeid' => '_num', 'mode' => 2, 'format' => false, 'key' => '', 'redi' => '' )
 				),
 			)
 		);


### PR DESCRIPTION
A property `Has name` is being redirected to `Foaf:name` which makes the following query not to display any pr-values (because `Has name` does not hold any value reference) therefore if a redirect target is known use it instead.

```
{{#ask: [[Has name::~*Doe]]
 |?Has name
}}
```

`$GLOBALS['smwgFollowPropertyRedirect']` (with option `false`) is provided as fallback to retain the behaviour as before this PR.

## Before the change

http://sandbox.semantic-mediawiki.org/wiki/ExampleWithPropertyRedirect

![image](https://cloud.githubusercontent.com/assets/1245473/11910525/fa0ac820-a5f8-11e5-949e-9b863104b742.png)

## API 
Same goes for the API, unless the requester knows the redirect target a query like `action=ask&query=[[Has name::~*Doe]]|?Has name` would currently return 

```json
{
	"query": {
		"printrequests": [
			{
				"label": "",
				"key": "",
				"typeid": "_wpg",
				"mode": 2
			},
			{
				"label": "Has name",
				"key": "Has_name",
				"typeid": "_txt",
				"mode": 1,
				"format": ""
			}
		],
		"results": {
			"John Doe": {
				"printouts": {
					"Has name": []
				},
				"fulltext": "John Doe",
				"fullurl": "http://localhost:8080/mw-25-01/index.php/John_Doe",
				"namespace": 0,
				"exists": ""
			}
		},
		"serializer": "SMW\\Serializers\\QueryResultSerializer",
		"version": 0.8,
		"meta": {
			"hash": "d8cd7fdf38538fe7397ddf1b10723382",
			"count": 1,
			"offset": 0,
			"source": ""
		}
	}
}
```

Instead the response to the redirect target will include

```json
{
	"query": {
		"printrequests": [
			{
				"label": "",
				"key": "",
				"typeid": "_wpg",
				"mode": 2
			},
			{
				"label": "Foaf:name",
				"key": "Foaf:name",
				"typeid": "_txt",
				"mode": 1,
				"format": ""
			}
		],
		"results": {
			"John Doe": {
				"printouts": {
					"Foaf:name": [
						"John Doe"
					]
				},
				"fulltext": "John Doe",
				"fullurl": "http://localhost:8080/mw-25-01/index.php/John_Doe",
				"namespace": 0,
				"exists": ""
			}
		},
		"serializer": "SMW\\Serializers\\QueryResultSerializer",
		"version": 0.8,
		"meta": {
			"hash": "a00283093cdc6721f85bd5659a2e8b89",
			"count": 1,
			"offset": 0,
			"source": ""
		}
	}
}
```
A `PropertyValue` will after this PR always point to the end target. If it necessary, the API can indicate that a property/printRequest was a `redirectedFrom: "Has_name"`

refs #1244