### PR TITLE
Isolate part of the SMWQueryParser

### DIFF
--- a/src/Query/DescriptionFactory.php
+++ b/src/Query/DescriptionFactory.php
@@ -1,0 +1,115 @@
+<?php
+
+namespace SMW\Query;
+
+use SMW\Query\Language\Conjunction;
+use SMW\Query\Language\Description;
+use SMW\Query\Language\Disjunction;
+use SMW\Query\Language\SomeProperty;
+use SMW\Query\Language\ValueDescription;
+use SMW\Query\Language\ThingDescription;
+use SMW\Query\Language\NamespaceDescription;
+use SMW\Query\Language\ClassDescription;
+use SMW\Query\Language\ConceptDescription;
+use SMW\DIWikiPage;
+use SMW\DIProperty;
+use SMWDataItem as DataItem;
+
+/**
+ * @license GNU GPL v2+
+ * @since 2.4
+ *
+ * @author mwjames
+ */
+class DescriptionFactory {
+
+	/**
+	 * @since 2.4
+	 *
+	 * @param DataItem $dataItem
+	 * @param DIProperty|null $property = null
+	 * @param integer $comparator
+	 *
+	 * @return ValueDescription
+	 */
+	public function newValueDescription( DataItem $dataItem, DIProperty $property = null, $comparator = SMW_CMP_EQ ) {
+		return new ValueDescription( $dataItem, $property, $comparator );
+	}
+
+	/**
+	 * @since 2.4
+	 *
+	 * @param DIProperty $property
+	 * @param Description $description
+	 *
+	 * @return SomeProperty
+	 */
+	public function newSomeProperty( DIProperty $property, Description $description ) {
+		return new SomeProperty( $property, $description );
+	}
+
+	/**
+	 * @since 2.4
+	 *
+	 * @return ThingDescription
+	 */
+	public function newThingDescription() {
+		return new ThingDescription();
+	}
+
+	/**
+	 * @since 2.4
+	 *
+	 * @param Description[] $descriptions
+	 *
+	 * @return Disjunction
+	 */
+	public function newDisjunction( $descriptions = array() ) {
+		return new Disjunction( $descriptions );
+	}
+
+	/**
+	 * @since 2.4
+	 *
+	 * @param Description[] $descriptions
+	 *
+	 * @return Conjunction
+	 */
+	public function newConjunction( $descriptions = array() ) {
+		return new Conjunction( $descriptions );
+	}
+
+	/**
+	 * @since 2.4
+	 *
+	 * @param integer $ns
+	 *
+	 * @return NamespaceDescription
+	 */
+	public function newNamespaceDescription( $ns ) {
+		return new NamespaceDescription( $ns );
+	}
+
+	/**
+	 * @since 2.4
+	 *
+	 * @param DIWikiPage $category
+	 *
+	 * @return ClassDescription
+	 */
+	public function newClassDescription( DIWikiPage $category ) {
+		return new ClassDescription( $category );
+	}
+
+	/**
+	 * @since 2.4
+	 *
+	 * @param DIWikiPage $concept
+	 *
+	 * @return ConceptDescription
+	 */
+	public function newConceptDescription( DIWikiPage $concept ) {
+		return new ConceptDescription( $concept );
+	}
+
+}

--- a/src/Query/Parser/DescriptionProcessor.php
+++ b/src/Query/Parser/DescriptionProcessor.php
@@ -1,0 +1,242 @@
+<?php
+
+namespace SMW\Query\Parser;
+
+use SMW\DataValueFactory;
+use SMW\Query\Language\Conjunction;
+use SMW\Query\Language\Description;
+use SMW\Query\Language\Disjunction;
+use SMW\Query\DescriptionFactory;
+use SMW\DIProperty;
+
+/**
+ * @license GNU GPL v2+
+ * @since 2.4
+ *
+ * @author mwjames
+ * @author Markus Krötzsch
+ */
+class DescriptionProcessor {
+
+	/**
+	 * @var DataValueFactory
+	 */
+	private $dataValueFactory;
+
+	/**
+	 * @var DescriptionFactory
+	 */
+	private $descriptionFactory;
+
+	/**
+	 * @var integer
+	 */
+	private $queryFeatures;
+
+	/**
+	 * @var array
+	 */
+	private $errors = array();
+
+	/**
+	 * @since 2.4
+	 *
+	 * @param integer $queryFeatures
+	 */
+	public function __construct( $queryFeatures = false ) {
+		$this->queryFeatures = $queryFeatures === false ? $GLOBALS['smwgQFeatures'] : $queryFeatures;
+		$this->dataValueFactory = DataValueFactory::getInstance();
+		$this->descriptionFactory = new DescriptionFactory();
+	}
+
+	/**
+	 * @since 2.4
+	 */
+	public function clear() {
+		$this->errors = array();
+	}
+
+	/**
+	 * @since 2.4
+	 *
+	 * @return array
+	 */
+	public function getErrors() {
+		return $this->errors;
+	}
+
+	/**
+	 * @since 2.4
+	 *
+	 * @param array|string $error
+	 */
+	public function addError( $error ) {
+		$this->errors = array_merge( $this->errors, (array)$error );
+	}
+
+	/**
+	 * @since 2.4
+	 *
+	 * @param string $msgKey
+	 */
+	public function addErrorWithMsgKey( $msgKey /*...*/ ) {
+
+		$params = func_get_args();
+		array_shift( $params );
+
+		$message = new \Message( $msgKey, $params );
+		$this->addError( str_replace( array( '[' ), array( '&#58;' ), $message->inContentLanguage()->text() ) );
+	}
+
+	/**
+	 * @since 2.4
+	 *
+	 * @param DIProperty $property
+	 * @param string $chunk
+	 *
+	 * @return Description|null
+	 */
+	public function getDescriptionForPropertyObjectValue( DIProperty $property, $chunk ) {
+
+		$dataValue = $this->dataValueFactory->newPropertyObjectValue( $property );
+		$dataValue->setQueryConditionUsage( true ); // FIXME
+
+		$description = $dataValue->getQueryDescription( $chunk );
+		$this->addError( $dataValue->getErrors() );
+
+		return $description;
+	}
+
+	/**
+	 * @since 2.4
+	 *
+	 * @param string $chunk
+	 *
+	 * @return Description|null
+	 */
+	public function getDescriptionForWikiPageValueChunk( $chunk ) {
+
+		// Only create a simple WpgValue to initiate the query description target
+		// operation. If the chunk contains something like "≤Issue/1220" then the
+		// WpgValue would return with an error as it cannot parse ≤ as/ legal
+		// character, the chunk itself is processed by
+		// DataValue::getQueryDescription hence no need to use it as input for
+		// the factory instance
+		$dataValue = $this->dataValueFactory->newTypeIDValue( '_wpg', 'QP_WPG_TITLE' );
+		$description = null;
+
+		if ( $dataValue->isValid() ) {
+			$description = $dataValue->getQueryDescription( $chunk );
+		} else {
+			$this->addError( $dataValue->getErrors() );
+		}
+
+		return $description;
+	}
+
+	/**
+	 * @since 2.4
+	 *
+	 * @param Description|null $currentDescription
+	 * @param Description|null $newDescription
+	 *
+	 * @return Description|null
+	 */
+	public function getDisjunctiveCompoundDescriptionFrom( Description $currentDescription = null, Description $newDescription = null ) {
+		return $this->getCompoundDescription( $currentDescription, $newDescription, SMW_DISJUNCTION_QUERY );
+	}
+
+	/**
+	 * @since 2.4
+	 *
+	 * @param Description|null $currentDescription
+	 * @param Description|null $newDescription
+	 *
+	 * @return Description|null
+	 */
+	public function getConjunctiveCompoundDescriptionFrom( Description $currentDescription = null, Description $newDescription = null ) {
+		return $this->getCompoundDescription( $currentDescription, $newDescription, SMW_CONJUNCTION_QUERY );
+	}
+
+	/**
+	 * Extend a given description by a new one, either by adding the new description
+	 * (if the old one is a container description) or by creating a new container.
+	 * The parameter $conjunction determines whether the combination of both descriptions
+	 * should be a disjunction or conjunction.
+	 *
+	 * In the special case that the current description is NULL, the new one will just
+	 * replace the current one.
+	 *
+	 * The return value is the expected combined description. The object $currentDescription will
+	 * also be changed (if it was non-NULL).
+	 */
+	private function getCompoundDescription( Description $currentDescription = null, Description $newDescription = null, $compoundType = SMW_CONJUNCTION_QUERY ) {
+
+		$notallowedmessage = 'smw_noqueryfeature';
+
+		if ( $newDescription instanceof SomeProperty ) {
+			$allowed = $this->queryFeatures & SMW_PROPERTY_QUERY;
+		} elseif ( $newDescription instanceof ClassDescription ) {
+			$allowed = $this->queryFeatures & SMW_CATEGORY_QUERY;
+		} elseif ( $newDescription instanceof ConceptDescription ) {
+			$allowed = $this->queryFeatures & SMW_CONCEPT_QUERY;
+		} elseif ( $newDescription instanceof Conjunction ) {
+			$allowed = $this->queryFeatures & SMW_CONJUNCTION_QUERY;
+			$notallowedmessage = 'smw_noconjunctions';
+		} elseif ( $newDescription instanceof Disjunction ) {
+			$allowed = $this->queryFeatures & SMW_DISJUNCTION_QUERY;
+			$notallowedmessage = 'smw_nodisjunctions';
+		} else {
+			$allowed = true;
+		}
+
+		if ( !$allowed ) {
+			$this->addErrorWithMsgKey( $notallowedmessage, $newDescription->getQueryString() );
+			return $currentDescription;
+		}
+
+		if ( $newDescription === null ) {
+			return $currentDescription;
+		} elseif ( $currentDescription === null ) {
+			return $newDescription;
+		} else { // we already found descriptions
+			return $this->newCompoundDescriptionFor( $compoundType, $currentDescription, $newDescription );
+		}
+	}
+
+	private function newCompoundDescriptionFor( $compoundType, $currentDescription, $newDescription ) {
+
+		if ( ( ( $compoundType & SMW_CONJUNCTION_QUERY ) != 0 && ( $currentDescription instanceof Conjunction ) ) ||
+		     ( ( $compoundType & SMW_DISJUNCTION_QUERY ) != 0 && ( $currentDescription instanceof Disjunction ) ) ) { // use existing container
+			$currentDescription->addDescription( $newDescription );
+			return $currentDescription;
+		} elseif ( ( $compoundType & SMW_CONJUNCTION_QUERY ) != 0 ) { // make new conjunction
+			return $this->newConjunctionFor( $currentDescription, $newDescription );
+		} elseif ( ( $compoundType & SMW_DISJUNCTION_QUERY ) != 0 ) { // make new disjunction
+			return $this->newDisjunctionFor( $currentDescription, $newDescription );
+		}
+	}
+
+	private function newConjunctionFor( $currentDescription, $newDescription ) {
+
+		if ( $this->queryFeatures & SMW_CONJUNCTION_QUERY ) {
+			return $this->descriptionFactory->newConjunction( array( $currentDescription, $newDescription ) );
+		}
+
+		$this->addErrorWithMsgKey( 'smw_noconjunctions', $newDescription->getQueryString() );
+
+		return $currentDescription;
+	}
+
+	private function newDisjunctionFor( $currentDescription, $newDescription ) {
+
+		if ( $this->queryFeatures & SMW_DISJUNCTION_QUERY ) {
+			return $this->descriptionFactory->newDisjunction( array( $currentDescription, $newDescription ) );
+		}
+
+		$this->addErrorWithMsgKey( 'smw_nodisjunctions', $newDescription->getQueryString() );
+
+		return $currentDescription;
+	}
+
+}

--- a/tests/phpunit/Integration/ByJsonScript/Fixtures/q-0610 [#1291] page type single value range queries.json
+++ b/tests/phpunit/Integration/ByJsonScript/Fixtures/q-0610 [#1291] page type single value range queries.json
@@ -1,0 +1,92 @@
+{
+	"description": "Single value page type range queries",
+	"properties": [],
+	"subjects": [
+		{
+			"name": "Example/Q0610-A",
+			"contents": "[[Category:Q0610]]"
+		},
+		{
+			"name": "Example/Q0610-AAA",
+			"contents": "[[Category:Q0610]]"
+		},
+		{
+			"name": "Example/Q0610-BBB",
+			"contents": "[[Category:Q0610]]"
+		},
+		{
+			"name": "Example/Q0610-CCC",
+			"contents": "[[Category:Q0610]]"
+		},
+		{
+			"name": "Example/Q0610-DDD",
+			"contents": "[[Category:Q0610]]"
+		},
+		{
+			"name": "Example/Q0610-ZZZ",
+			"contents": "[[Category:Q0610-Z]] {{DEFAULTSORT:Example/Q0610-CCC}}"
+		}
+	],
+	"query-testcases": [
+		{
+			"about": "#0 range >A <C (non strict comparator)",
+			"condition": "[[Category:Q0610]] [[>Example/Q0610-A]] [[<Example/Q0610-C]]",
+			"printouts" : [],
+			"parameters" : {
+				"limit" : 10
+			},
+			"queryresult": {
+				"count": 3,
+				"results": [
+					"Example/Q0610-A#0##",
+					"Example/Q0610-AAA#0##",
+					"Example/Q0610-BBB#0##"
+				]
+			}
+		},
+		{
+			"about": "#1 range >AA <CCC (non strict comparator)",
+			"condition": "[[Category:Q0610]] [[>Example/Q0610-AA]] [[<Example/Q0610-CCC]]",
+			"printouts" : [],
+			"parameters" : {
+				"limit" : 10
+			},
+			"queryresult": {
+				"count": 3,
+				"results": [
+					"Example/Q0610-AAA#0##",
+					"Example/Q0610-BBB#0##",
+					"Example/Q0610-CCC#0##"
+				]
+			}
+		},
+		{
+			"about": "#2 range >AA <CCC (non strict comparator), default sort change includes ZZZ object",
+			"condition": "<q>[[Category:Q0610]] OR [[Category:Q0610-Z]]</q> [[>Example/Q0610-AA]] [[<Example/Q0610-CCC]]",
+			"printouts" : [],
+			"parameters" : {
+				"limit" : 10
+			},
+			"queryresult": {
+				"count": 4,
+				"results": [
+					"Example/Q0610-AAA#0##",
+					"Example/Q0610-BBB#0##",
+					"Example/Q0610-CCC#0##",
+					"Example/Q0610-ZZZ#0##"
+				]
+			}
+		}
+	],
+	"settings": {
+		"smwStrictComparators" : false
+	},
+	"meta": {
+		"skip-on": {
+			"virtuoso": "Virtuoso 6.1 doesn't understand ranges, Failed asserting that 5 matches expected 3"
+		},
+		"version": "0.1",
+		"is-incomplete": false,
+		"debug": false
+	}
+}

--- a/tests/phpunit/Unit/Query/DescriptionFactoryTest.php
+++ b/tests/phpunit/Unit/Query/DescriptionFactoryTest.php
@@ -1,0 +1,165 @@
+<?php
+
+namespace SMW\Tests\Query\Parser;
+
+use SMW\Query\DescriptionFactory;
+use SMW\DIProperty;
+use SMW\Query\Language\Conjunction;
+use SMW\Query\Language\Disjunction;
+
+/**
+ * @covers SMW\Query\DescriptionFactory
+ * @group semantic-mediawiki
+ *
+ * @license GNU GPL v2+
+ * @since 2.4
+ *
+ * @author mwjames
+ */
+class DescriptionFactoryTest extends \PHPUnit_Framework_TestCase {
+
+	public function testCanConstruct() {
+
+		$this->assertInstanceOf(
+			'SMW\Query\DescriptionFactory',
+			new DescriptionFactory()
+		);
+	}
+
+	public function testCanConstructValueDescription() {
+
+		$dataItem = $this->getMockBuilder( '\SMWDataItem' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$instance = new DescriptionFactory();
+
+		$this->assertInstanceOf(
+			'SMW\Query\Language\ValueDescription',
+			$instance->newValueDescription( $dataItem )
+		);
+	}
+
+	public function testCanConstructSomeProperty() {
+
+		$property = $this->getMockBuilder( '\SMW\DIProperty' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$description = $this->getMockBuilder( '\SMW\Query\Language\Description' )
+			->disableOriginalConstructor()
+			->getMockForAbstractClass();
+
+		$instance = new DescriptionFactory();
+
+		$this->assertInstanceOf(
+			'SMW\Query\Language\SomeProperty',
+			$instance->newSomeProperty( $property, $description )
+		);
+	}
+
+	public function testCanConstructThingDescription() {
+
+		$instance = new DescriptionFactory();
+
+		$this->assertInstanceOf(
+			'SMW\Query\Language\ThingDescription',
+			$instance->newThingDescription()
+		);
+	}
+
+	public function testCanConstructDisjunction() {
+
+		$descriptions = array();
+
+		$description = $this->getMockBuilder( '\SMW\Query\Language\SomeProperty' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$description->expects( $this->once() )
+			->method( 'getPrintRequests' )
+			->will( $this->returnValue( array() ) );
+
+		$descriptions[] = $description;
+
+		$description = $this->getMockBuilder( '\SMW\Query\Language\ValueDescription' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$description->expects( $this->once() )
+			->method( 'getPrintRequests' )
+			->will( $this->returnValue( array() ) );
+
+		$descriptions[] = $description;
+
+		$instance = new DescriptionFactory();
+
+		$this->assertInstanceOf(
+			'SMW\Query\Language\Disjunction',
+			$instance->newDisjunction( $descriptions )
+		);
+	}
+
+	public function testCanConstructConjunction() {
+
+		$descriptions = array();
+
+		$description = $this->getMockBuilder( '\SMW\Query\Language\SomeProperty' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$descriptions[] = $description;
+
+		$description = $this->getMockBuilder( '\SMW\Query\Language\ValueDescription' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$descriptions[] = $description;
+
+		$instance = new DescriptionFactory();
+
+		$this->assertInstanceOf(
+			'SMW\Query\Language\Conjunction',
+			$instance->newConjunction( $descriptions )
+		);
+	}
+
+	public function testCanConstructNamespaceDescription() {
+
+		$instance = new DescriptionFactory();
+
+		$this->assertInstanceOf(
+			'SMW\Query\Language\NamespaceDescription',
+			$instance->newNamespaceDescription( SMW_NS_PROPERTY )
+		);
+	}
+
+	public function testCanConstructClassDescription() {
+
+		$category = $this->getMockBuilder( '\SMW\DIWikiPage' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$instance = new DescriptionFactory();
+
+		$this->assertInstanceOf(
+			'SMW\Query\Language\ClassDescription',
+			$instance->newClassDescription( $category )
+		);
+	}
+
+	public function testCanConstructConceptDescription() {
+
+		$concept = $this->getMockBuilder( '\SMW\DIWikiPage' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$instance = new DescriptionFactory();
+
+		$this->assertInstanceOf(
+			'SMW\Query\Language\ConceptDescription',
+			$instance->newConceptDescription( $concept )
+		);
+	}
+
+}

--- a/tests/phpunit/Unit/Query/Parser/DescriptionProcessorTest.php
+++ b/tests/phpunit/Unit/Query/Parser/DescriptionProcessorTest.php
@@ -1,0 +1,217 @@
+<?php
+
+namespace SMW\Tests\Query\Parser;
+
+use SMW\Query\Parser\DescriptionProcessor;
+use SMW\DIProperty;
+use SMW\Query\Language\Conjunction;
+use SMW\Query\Language\Disjunction;
+
+/**
+ * @covers SMW\Query\Parser\DescriptionProcessor
+ * @group semantic-mediawiki
+ *
+ * @license GNU GPL v2+
+ * @since 2.4
+ *
+ * @author mwjames
+ */
+class DescriptionProcessorTest extends \PHPUnit_Framework_TestCase {
+
+	public function testCanConstruct() {
+
+		$this->assertInstanceOf(
+			'SMW\Query\Parser\DescriptionProcessor',
+			new DescriptionProcessor()
+		);
+	}
+
+	public function testError() {
+
+		$instance = new DescriptionProcessor();
+		$instance->addError( 'abc' );
+
+		$this->assertEquals(
+			array( 'abc' ),
+			$instance->getErrors()
+		);
+
+		$instance->addErrorWithMsgKey( 'Foo' );
+
+		$this->assertCount(
+			2,
+			$instance->getErrors()
+		);
+	}
+
+	public function testGetDescriptionForPropertyObjectValue() {
+
+		$instance = new DescriptionProcessor();
+
+		$this->assertInstanceOf(
+			'SMW\Query\Language\Description',
+			$instance->getDescriptionForPropertyObjectValue( new DIProperty( 'Foo' ), 'bar' )
+		);
+	}
+
+	public function testGetDescriptionForWikiPageValueChunk() {
+
+		$instance = new DescriptionProcessor();
+
+		$this->assertInstanceOf(
+			'SMW\Query\Language\ValueDescription',
+			$instance->getDescriptionForWikiPageValueChunk( 'bar' )
+		);
+	}
+
+	public function testGetDisjunctiveCompoundDescription() {
+
+		$instance = new DescriptionProcessor();
+
+		$currentDescription = $instance->getDescriptionForWikiPageValueChunk( 'bar' );
+
+		$newDescription = $instance->getDescriptionForPropertyObjectValue(
+			new DIProperty( 'Foo' ),
+			'foobar'
+		);
+
+		$this->assertInstanceOf(
+			'SMW\Query\Language\Disjunction',
+			$instance->getDisjunctiveCompoundDescriptionFrom( $currentDescription, $newDescription )
+		);
+	}
+
+	public function testGetDisjunctiveCompoundDescriptionForCurrentConjunction() {
+
+		$instance = new DescriptionProcessor();
+
+		$currentDescription = new Conjunction();
+
+		$newDescription = $instance->getDescriptionForPropertyObjectValue(
+			new DIProperty( 'Foo' ),
+			'foobar'
+		);
+
+		$this->assertInstanceOf(
+			'SMW\Query\Language\Disjunction',
+			$instance->getDisjunctiveCompoundDescriptionFrom( $currentDescription, $newDescription )
+		);
+	}
+
+	public function testGetDisjunctiveCompoundDescriptionForCurrentDisjunction() {
+
+		$instance = new DescriptionProcessor();
+
+		$currentDescription = new Disjunction();
+
+		$newDescription = $instance->getDescriptionForPropertyObjectValue(
+			new DIProperty( 'Foo' ),
+			'foobar'
+		);
+
+		$this->assertInstanceOf(
+			'SMW\Query\Language\Disjunction',
+			$instance->getDisjunctiveCompoundDescriptionFrom( $currentDescription, $newDescription )
+		);
+	}
+
+	public function testTryToGetDisjunctiveCompoundDescriptionForNullNewDescription() {
+
+		$instance = new DescriptionProcessor();
+
+		$currentDescription = $instance->getDescriptionForWikiPageValueChunk( 'bar' );
+
+		$this->assertInstanceOf(
+			'SMW\Query\Language\ValueDescription',
+			$instance->getDisjunctiveCompoundDescriptionFrom( $currentDescription, null )
+		);
+	}
+
+	public function testTryToGetDisjunctiveCompoundDescriptionForNullCurrentDescription() {
+
+		$instance = new DescriptionProcessor();
+
+		$newDescription = $instance->getDescriptionForWikiPageValueChunk( 'bar' );
+
+		$this->assertInstanceOf(
+			'SMW\Query\Language\ValueDescription',
+			$instance->getDisjunctiveCompoundDescriptionFrom( null, $newDescription )
+		);
+	}
+
+	public function testGetConjunctiveCompoundDescription() {
+
+		$instance = new DescriptionProcessor();
+
+		$currentDescription = $instance->getDescriptionForWikiPageValueChunk( 'bar' );
+
+		$newDescription = $instance->getDescriptionForPropertyObjectValue(
+			new DIProperty( 'Foo' ),
+			'foobar'
+		);
+
+		$this->assertInstanceOf(
+			'SMW\Query\Language\Conjunction',
+			$instance->getConjunctiveCompoundDescriptionFrom( $currentDescription, $newDescription )
+		);
+	}
+
+	public function testGetConjunctiveCompoundDescriptionForCurrentConjunction() {
+
+		$instance = new DescriptionProcessor();
+
+		$currentDescription = new Conjunction();
+
+		$newDescription = $instance->getDescriptionForPropertyObjectValue(
+			new DIProperty( 'Foo' ),
+			'foobar'
+		);
+
+		$this->assertInstanceOf(
+			'SMW\Query\Language\Conjunction',
+			$instance->getConjunctiveCompoundDescriptionFrom( $currentDescription, $newDescription )
+		);
+	}
+
+	public function testGetConjunctiveCompoundDescriptionForCurrentDisjunction() {
+
+		$instance = new DescriptionProcessor();
+
+		$currentDescription = new Disjunction();
+
+		$newDescription = $instance->getDescriptionForPropertyObjectValue(
+			new DIProperty( 'Foo' ),
+			'foobar'
+		);
+
+		$this->assertInstanceOf(
+			'SMW\Query\Language\Conjunction',
+			$instance->getConjunctiveCompoundDescriptionFrom( $currentDescription, $newDescription )
+		);
+	}
+
+	public function testTryToGetConjunctiveCompoundDescriptionForNullNewDescription() {
+
+		$instance = new DescriptionProcessor();
+
+		$currentDescription = $instance->getDescriptionForWikiPageValueChunk( 'bar' );
+
+		$this->assertInstanceOf(
+			'SMW\Query\Language\ValueDescription',
+			$instance->getConjunctiveCompoundDescriptionFrom( $currentDescription, null )
+		);
+	}
+
+	public function testTryToGetConjunctiveCompoundDescriptionForNullCurrentDescription() {
+
+		$instance = new DescriptionProcessor();
+
+		$newDescription = $instance->getDescriptionForWikiPageValueChunk( 'bar' );
+
+		$this->assertInstanceOf(
+			'SMW\Query\Language\ValueDescription',
+			$instance->getConjunctiveCompoundDescriptionFrom( null, $newDescription )
+		);
+	}
+
+}


### PR DESCRIPTION
Move some parts from `SMWQueryParser` into `SMW\Query\Parser\DescriptionProcessor` to refactor the `QueryParser` to only handle string manipulation and syntax logic.

Add support for range queries as in `[[>Example/0608-A]] [[<Example/0608-C]]` (or
`[>Example/0608-AA]] [[<Example/0608-CCC]]`).

```json
{
	"about": "#0 range >A <C (non strict comparator)",
	"condition": "[[Category:Q0610]] [[>Example/Q0610-A]] [[<Example/Q0610-C]]",
	"printouts" : [],
	"parameters" : {
		"limit" : 10
	},
	"queryresult": {
		"count": 3,
		"results": [
			"Example/Q0610-A#0##",
			"Example/Q0610-AAA#0##",
			"Example/Q0610-BBB#0##"
		]
	}
},
{
	"about": "#1 range >AA <CCC (non strict comparator)",
	"condition": "[[Category:Q0610]] [[>Example/Q0610-AA]] [[<Example/Q0610-CCC]]",
	"printouts" : [],
	"parameters" : {
		"limit" : 10
	},
	"queryresult": {
		"count": 3,
		"results": [
			"Example/Q0610-AAA#0##",
			"Example/Q0610-BBB#0##",
			"Example/Q0610-CCC#0##"
		]
	}
}
```

refs #1246