### PR TITLE
Add _ERRC (container to store erroneous annotation), refs #1243

### DIFF
--- a/i18n/en.json
+++ b/i18n/en.json
@@ -321,7 +321,7 @@
 	"smw-datavalue-import-invalidvalue":"\"$1\" is not a valid format and is expected to consists of \"namespace\":\"identifier\" (e.g. \"foaf:name\").",
 	"smw-pa-property-predefined_impo": "\"$1\" is a predefined property that describes a relation to an [https://www.semantic-mediawiki.org/wiki/Help:Import_vocabulary imported vocabulary].",
 	"smw-pa-property-predefined_type": "\"$1\" is a predefined property that describes the [[Special:Types|datatype]] of a property.",
-	"smw-pa-property-predefined_sobj": "\"$1\" is a predefined property representing a container construct that allows to accumulate property-value assignments similar to that of a normal wiki page.",
+	"smw-pa-property-predefined_sobj": "\"$1\" is a predefined property representing a [https://www.semantic-mediawiki.org/wiki/Help:Container container] construct that allows to accumulate property-value assignments similar to that of a normal wiki page.",
 	"smw-pa-property-predefined_errp": "\"$1\" is a predefined property to track input errors for irregular value annotations that was likely caused by type or [[Property:Allows value|allowed value]] restrictions.",
 	"smw-pa-property-predefined_pval": "[https://www.semantic-mediawiki.org/wiki/Help:Special_property_Allows_value \"$1\"] is a predefined property that can define a list of permissible values to restrict value assignments for a property.",
 	"smw-datavalue-property-restricted-use": "Property \"$1\" was marked for restricted use.",
@@ -338,5 +338,7 @@
 	"smw-sp-types_tel": "\"$1\" is a special datatype to describe international telephone numbers according to RFC 3966.",
 	"smw-sp-types_txt": "\"$1\" is a primitive datatype to describe strings of arbitrary length.",
 	"smw-sp-types_dat": "\"$1\" is a datatype to represent points in time in a unified format.",
-	"smw-specials-browse-helplink": "https://www.semantic-mediawiki.org/wiki/Help:Special:Browse"
+	"smw-specials-browse-helplink": "https://www.semantic-mediawiki.org/wiki/Help:Special:Browse",
+	"smw-pa-property-predefined_errc": "\"$1\" is a predefined property representing a [https://www.semantic-mediawiki.org/wiki/Help:Container container] for errors that appeared in connection with improper value annotations or input processing.",
+	"smw-pa-property-predefined_errt": "\"$1\" is a predefined property containing a textual description of an error."
 }

--- a/i18n/qqq.json
+++ b/i18n/qqq.json
@@ -345,5 +345,7 @@
 	"smw-sp-types_tel": "This is an informatory message shown to the user.",
 	"smw-sp-types_txt": "This is an informatory message shown to the user.",
 	"smw-sp-types_dat": "This is an informatory message shown to the user.",
-	"smw-specials-browse-helplink": "{{notranslate}}"
+	"smw-specials-browse-helplink": "{{notranslate}}",
+	"smw-pa-property-predefined_errc": "This informatory message describes the [https://semantic-mediawiki.org/wiki/Help:Special_properties special property].",
+	"smw-pa-property-predefined_errt": "This informatory message describes the [https://semantic-mediawiki.org/wiki/Help:Special_properties special property]."
 }

--- a/includes/parserhooks/AskParserFunction.php
+++ b/includes/parserhooks/AskParserFunction.php
@@ -192,9 +192,14 @@ class AskParserFunction {
 		// In case of an query error add a marker to the subject for
 		// discoverability of a failed query
 		if ( $query->getErrors() !== array() ) {
+			$error = new Error( $this->parserData->getSubject() );
+
 			$this->parserData->getSemanticData()->addPropertyObjectValue(
-				new DIProperty( '_ERRP' ),
-				DIProperty::newFromUserLabel( '_ASK' )->getDiWikiPage()
+				$error->getProperty(),
+				$error->getContainerFor(
+					new DIProperty( '_ASK' ),
+					$query->getQueryString() . ' (' . implode( ' ', $query->getErrors() ) . ')'
+				)
 			);
 		}
 

--- a/languages/SMW_Language.php
+++ b/languages/SMW_Language.php
@@ -94,6 +94,8 @@ abstract class SMWLanguage {
 		'Has query duration' => '_ASKDU',
 		'Has media type'     => '_MEDIA',
 		'Has mime type'      => '_MIME',
+		'Has error'          => '_ERRC',
+		'Has error text'     => '_ERRT',
 	);
 
 	public function __construct() {

--- a/languages/SMW_LanguageAr.php
+++ b/languages/SMW_LanguageAr.php
@@ -74,7 +74,9 @@ class SMWLanguageAr extends SMWLanguage {
 		'_ASKDE'=> 'Query depth', // TODO: translate
 		'_ASKDU'=> 'Query duration', // TODO: translate
 		'_MEDIA'=> 'Media type',
-		'_MIME' => 'Mime type'
+		'_MIME' => 'MIME type',
+		'_ERRC' => 'Has error',
+		'_ERRT' => 'Has error text'
 	);
 
 	protected $m_SpecialPropertyAliases = array(

--- a/languages/SMW_LanguageArz.php
+++ b/languages/SMW_LanguageArz.php
@@ -74,7 +74,9 @@ class SMWLanguageArz extends SMWLanguage {
 		'_ASKDE'=> 'Query depth', // TODO: translate
 		'_ASKDU'=> 'Query duration', // TODO: translate
 		'_MEDIA'=> 'Media type',
-		'_MIME' => 'Mime type'
+		'_MIME' => 'MIME type',
+		'_ERRC' => 'Has error',
+		'_ERRT' => 'Has error text'
 	);
 
 	protected $m_SpecialPropertyAliases = array(

--- a/languages/SMW_LanguageCa.php
+++ b/languages/SMW_LanguageCa.php
@@ -78,7 +78,9 @@ class SMWLanguageCa extends SMWLanguage {
 		'_ASKDE'=> 'Profunditat de consulta',
 		'_ASKDU'=> 'Durada de consulta',
 		'_MEDIA'=> 'Tipus Media',
-		'_MIME' => 'Tipus MIME'
+		'_MIME' => 'Tipus MIME',
+		'_ERRC' => 'Has error',
+		'_ERRT' => 'Has error text'
 	);
 
 	protected $m_SpecialPropertyAliases = array(

--- a/languages/SMW_LanguageDe.php
+++ b/languages/SMW_LanguageDe.php
@@ -84,7 +84,9 @@ class SMWLanguageDe extends SMWLanguage {
 		'_ASKDE'=> 'Abfragetiefe',
 		'_ASKDU'=> 'Abfragedauer',
 		'_MEDIA'=> 'Medientyp',
-		'_MIME' => 'MIME-Typ'
+		'_MIME' => 'MIME-Typ',
+		'_ERRC' => 'Has error',
+		'_ERRT' => 'Has error text'
 	);
 
 	protected $m_SpecialPropertyAliases = array(

--- a/languages/SMW_LanguageEn.php
+++ b/languages/SMW_LanguageEn.php
@@ -81,7 +81,9 @@ class SMWLanguageEn extends SMWLanguage {
 		'_ASKDE'=> 'Query depth',
 		'_ASKDU'=> 'Query duration',
 		'_MEDIA'=> 'Media type',
-		'_MIME' => 'MIME type'
+		'_MIME' => 'MIME type',
+		'_ERRC' => 'Has error',
+		'_ERRT' => 'Has error text'
 	);
 
 	protected $m_SpecialPropertyAliases = array(

--- a/languages/SMW_LanguageEs.php
+++ b/languages/SMW_LanguageEs.php
@@ -75,7 +75,9 @@ class SMWLanguageEs extends SMWLanguage {
 		'_ASKDE'=> 'Profundidad de consulta',
 		'_ASKDU'=> 'Duración de consulta',
 		'_MEDIA'=> 'Tipo Media',
-		'_MIME' => 'Tipo MIME'
+		'_MIME' => 'Tipo MIME',
+		'_ERRC' => 'Has error',
+		'_ERRT' => 'Has error text'
 	);
 
 	protected $m_SpecialPropertyAliases = array(

--- a/languages/SMW_LanguageFi.php
+++ b/languages/SMW_LanguageFi.php
@@ -71,7 +71,9 @@ class SMWLanguageFi extends SMWLanguage {
 		'_ASKDE'=> 'Query depth', // TODO: translate
 		'_ASKDU'=> 'Query duration', // TODO: translate
 		'_MEDIA'=> 'Media type',
-		'_MIME' => 'Mime type'
+		'_MIME' => 'Mime type',
+		'_ERRC' => 'Has error',
+		'_ERRT' => 'Has error text'
 	);
 
 	protected $m_Namespaces = array(

--- a/languages/SMW_LanguageFr.php
+++ b/languages/SMW_LanguageFr.php
@@ -75,7 +75,9 @@ class SMWLanguageFr extends SMWLanguage {
 		'_ASKDE'=> 'Profondeur de la requête',
 		'_ASKDU'=> 'Durée de la requête',
 		'_MEDIA'=> 'Media type',
-		'_MIME' => 'Mime type'
+		'_MIME' => 'Mime type',
+		'_ERRC' => 'Has error',
+		'_ERRT' => 'Has error text'
 	);
 
 	protected $m_SpecialPropertyAliases = array(

--- a/languages/SMW_LanguageHe.php
+++ b/languages/SMW_LanguageHe.php
@@ -74,7 +74,9 @@ class SMWLanguageHe extends SMWLanguage {
 		'_ASKDE'=> 'עומק שאילתא',
 		'_ASKDU'=> 'Query duration', // TODO: translate
 		'_MEDIA'=> 'Media type',
-		'_MIME' => 'Mime type'
+		'_MIME' => 'Mime type',
+		'_ERRC' => 'Has error',
+		'_ERRT' => 'Has error text'
 	);
 
 	protected $m_SpecialPropertyAliases = array(

--- a/languages/SMW_LanguageHu.php
+++ b/languages/SMW_LanguageHu.php
@@ -79,7 +79,9 @@ class SMWLanguageHu extends SMWLanguage {
 		'_ASKDE'=> 'Lekérdezése mélysége',
 		'_ASKDU'=> 'Lekérdezése időtartama',
 		'_MEDIA'=> 'Médiatípusa',
-		'_MIME' => 'MIME-Típusa'
+		'_MIME' => 'MIME-Típusa',
+		'_ERRC' => 'Has error',
+		'_ERRT' => 'Has error text'
 	);
 
 	protected $m_SpecialPropertyAliases = array(

--- a/languages/SMW_LanguageId.php
+++ b/languages/SMW_LanguageId.php
@@ -75,7 +75,9 @@ class SMWLanguageId extends SMWLanguage {
 		'_ASKDE'=> 'Query depth', // TODO: translate
 		'_ASKDU'=> 'Query duration', // TODO: translate
 		'_MEDIA'=> 'Media type',
-		'_MIME' => 'Mime type'
+		'_MIME' => 'Mime type',
+		'_ERRC' => 'Has error',
+		'_ERRT' => 'Has error text'
 	);
 
 	protected $m_SpecialPropertyAliases = array(

--- a/languages/SMW_LanguageIt.php
+++ b/languages/SMW_LanguageIt.php
@@ -77,7 +77,9 @@ class SMWLanguageIt extends SMWLanguage {
 		'_ASKDE'=> 'Query depth', // TODO: translate
 		'_ASKDU'=> 'Query duration', // TODO: translate
 		'_MEDIA'=> 'Media type',
-		'_MIME' => 'Mime type'
+		'_MIME' => 'Mime type',
+		'_ERRC' => 'Has error',
+		'_ERRT' => 'Has error text'
 	);
 
 	protected $m_SpecialPropertyAliases = array(

--- a/languages/SMW_LanguageNb.php
+++ b/languages/SMW_LanguageNb.php
@@ -84,7 +84,9 @@ class SMWLanguageNb extends SMWLanguage {
 		'_ASKDE'=> 'Spørringsdybde',
 		'_ASKDU'=> 'Spørringsvarighet',
 		'_MEDIA'=> 'Mediatype',
-		'_MIME' => 'MIME-type'
+		'_MIME' => 'MIME-type',
+		'_ERRC' => 'Has error',
+		'_ERRT' => 'Has error text'
 	);
 
 	protected $m_SpecialPropertyAliases = array(

--- a/languages/SMW_LanguageNl.php
+++ b/languages/SMW_LanguageNl.php
@@ -77,7 +77,9 @@ class SMWLanguageNl extends SMWLanguage {
 		'_ASKDE'=> 'Zoekdiepte',
 		'_ASKDU'=> 'Zoekduur',
 		'_MEDIA'=> 'Heeft Mediatype',
-		'_MIME' => 'Heeft MIME-type'
+		'_MIME' => 'Heeft MIME-type',
+		'_ERRC' => 'Has error',
+		'_ERRT' => 'Has error text'
 	);
 
 	protected $m_SpecialPropertyAliases = array(

--- a/languages/SMW_LanguagePl.php
+++ b/languages/SMW_LanguagePl.php
@@ -93,7 +93,9 @@ class SMWLanguagePl extends SMWLanguage {
 		'_ASKDE'=> 'Query depth', // TODO: translate
 		'_ASKDU'=> 'Query duration', // TODO: translate
 		'_MEDIA'=> 'Media type',
-		'_MIME' => 'Mime type'
+		'_MIME' => 'Mime type',
+		'_ERRC' => 'Has error',
+		'_ERRT' => 'Has error text'
 	);
 
 	protected $m_SpecialPropertyAliases = array(

--- a/languages/SMW_LanguagePt.php
+++ b/languages/SMW_LanguagePt.php
@@ -82,7 +82,9 @@ class SMWLanguagePt extends SMWLanguage {
 		'_ASKDE'=> 'Profundidade da consulta',
 		'_ASKDU'=> 'Query duration', // TODO: translate
 		'_MEDIA'=> 'Media type',
-		'_MIME' => 'Mime type'
+		'_MIME' => 'Mime type',
+		'_ERRC' => 'Has error',
+		'_ERRT' => 'Has error text'
 	);
 
 	protected $m_SpecialPropertyAliases = array(

--- a/languages/SMW_LanguageRu.php
+++ b/languages/SMW_LanguageRu.php
@@ -77,7 +77,9 @@ class SMWLanguageRu extends SMWLanguage {
 		'_ASKDE'=> 'Глубина запроса',
 		'_ASKDU'=> 'Длительность запроса',
 		'_MEDIA'=> 'Тип медиа',
-		'_MIME' => 'MIME-тип'
+		'_MIME' => 'MIME-тип',
+		'_ERRC' => 'Has error',
+		'_ERRT' => 'Has error text'
 	);
 
 	protected $m_SpecialPropertyAliases = array(

--- a/languages/SMW_LanguageSk.php
+++ b/languages/SMW_LanguageSk.php
@@ -74,7 +74,9 @@ class SMWLanguageSk extends SMWLanguage {
 		'_ASKDE'=> 'Hĺbka požiadavky',
 		'_ASKDU'=> 'Query duration', // TODO: translate
 		'_MEDIA'=> 'Media type',
-		'_MIME' => 'Mime type'
+		'_MIME' => 'Mime type',
+		'_ERRC' => 'Has error',
+		'_ERRT' => 'Has error text'
 	);
 
 	protected $m_SpecialPropertyAliases = array(

--- a/languages/SMW_LanguageZh_cn.php
+++ b/languages/SMW_LanguageZh_cn.php
@@ -82,7 +82,9 @@ class SMWLanguageZh_cn extends SMWLanguage {
 		'_ASKDE'=> '查询深度', // Query depth
 		'_ASKDU'=> '查询持续时间', // Query duration
 		'_MEDIA'=> '媒体类型', //Media type
-		'_MIME' => 'MIME类型' //Mime type
+		'_MIME' => 'MIME类型', //Mime type
+		'_ERRC' => 'Has error',
+		'_ERRT' => 'Has error text'
 	);
 
 	protected $m_SpecialPropertyAliases = array(

--- a/languages/SMW_LanguageZh_tw.php
+++ b/languages/SMW_LanguageZh_tw.php
@@ -80,7 +80,9 @@ class SMWLanguageZh_tw extends SMWLanguage {
 		'_ASKDE'=> '查詢深度', // Query depth
 		'_ASKDU'=> '查詢持續時間', // Query duration
 		'_MEDIA'=> '媒體類型', // Media type
-		'_MIME' => 'MIME類型' // MIME type
+		'_MIME' => 'MIME類型', // MIME type
+		'_ERRC' => 'Has error',
+		'_ERRT' => 'Has error text'
 	);
 
 	protected $m_SpecialPropertyAliases = array(

--- a/src/Error.php
+++ b/src/Error.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace SMW;
+
+use SMWContainerSemanticData as ContainerSemanticData;
+use SMWDIContainer as DIContainer;
+use SMWDIBlob as DIBlob;
+
+/**
+ * @license GNU GPL v2+
+ * @since 2.4
+ *
+ * @author mwjames
+ */
+class Error {
+
+	/**
+	 * @var DIWikiPage
+	 */
+	private $subject;
+
+	/**
+	 * @since 2.4
+	 *
+	 * @param DIWikiPage $subject
+	 */
+	public function __construct( DIWikiPage $subject ) {
+		$this->subject = $subject;
+	}
+
+	/**
+	 * @since 2.4
+	 *
+	 * @return DIProperty
+	 */
+	public function getProperty() {
+		return new DIProperty( '_ERRC' );
+	}
+
+	/**
+	 * @since 2.4
+	 *
+	 * @param DIProperty $property
+	 * @param string $errorMsg
+	 *
+	 * @return DIContainer
+	 */
+	public function getContainerFor( DIProperty $property, $errorMsg = '' ) {
+
+		$subWikiPage = new DIWikiPage(
+			$this->subject->getDBkey(),
+			$this->subject->getNamespace(),
+			$this->subject->getInterwiki(),
+			'_ERR' . md5( $property->getKey() )
+		);
+
+		$containerSemanticData = new ContainerSemanticData( $subWikiPage );
+
+		$containerSemanticData->addPropertyObjectValue(
+			new DIProperty( '_ERRP' ),
+			$property->getDiWikiPage()
+		);
+
+		$containerSemanticData->addPropertyObjectValue(
+			new DIProperty( '_ERRT' ),
+			new DIBlob( $errorMsg )
+		);
+
+		return new DIContainer( $containerSemanticData );
+	}
+
+}

--- a/src/PropertyRegistry.php
+++ b/src/PropertyRegistry.php
@@ -305,6 +305,8 @@ class PropertyRegistry {
 			'_CDAT'  => array( '_dat', false, false ), // "creation date"
 			'_NEWP'  => array( '_boo', false, false ), // "is a new page"
 			'_LEDT'  => array( '_wpg', false, false ), // "last editor is"
+			'_ERRC'  => array( '__sob', false, false ), // "has error"
+			'_ERRT'  => array( '_txt', false, false ), // "has error text"
 			'_ERRP'  => array( '_wpp', false, false ), // "has improper value for"
 			'_LIST'  => array( '__pls', true, true ), // "has fields"
 			'_SKEY'  => array( '__key', false, true ), // sort key of a page

--- a/tests/phpunit/Unit/ErrorTest.php
+++ b/tests/phpunit/Unit/ErrorTest.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace SMW\Tests;
+
+use SMW\Tests\Utils\UtilityFactory;
+use SMW\Error;
+use SMW\DIWikiPage;
+use SMW\DIProperty;
+
+/**
+ * @covers \SMW\Error
+ * @group semantic-mediawiki
+ *
+ * @license GNU GPL v2+
+ * @since 2.4
+ *
+ * @author mwjames
+ */
+class ErrorTest extends \PHPUnit_Framework_TestCase {
+
+	private $semanticDataValidator;
+
+	protected function setUp() {
+		parent::setUp();
+
+		$this->semanticDataValidator = UtilityFactory::getInstance()->newValidatorFactory()->newSemanticDataValidator();
+	}
+
+	public function testCanConstruct() {
+
+		$subject = $this->getMockBuilder( '\SMW\DIWikiPage' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$this->assertInstanceOf(
+			'\SMW\Error',
+			new Error( $subject )
+		);
+	}
+
+	public function testErrorContainer() {
+
+		$instance = new Error( DIWikiPage::newFromText( 'Foo' ) );
+
+		$this->assertEquals(
+			new DIProperty( '_ERRC' ),
+			$instance->getProperty()
+		);
+
+		$container = $instance->getContainerFor( new DIProperty( 'Foo' ), 'Some error' );
+
+		$expected = array(
+			'propertyCount'  => 2,
+			'propertyKeys'   => array( '_ERRP', '_ERRT' ),
+		);
+
+		$this->semanticDataValidator->assertThatPropertiesAreSet(
+			$expected,
+			$container->getSemanticData()
+		);
+	}
+
+}

--- a/tests/phpunit/includes/parserhooks/AskParserFunctionTest.php
+++ b/tests/phpunit/includes/parserhooks/AskParserFunctionTest.php
@@ -296,7 +296,7 @@ class AskParserFunctionTest extends \PHPUnit_Framework_TestCase {
 
 		$expected = array(
 			'propertyCount'  => 2,
-			'propertyKeys'   => array( '_ASK', '_ERRP' ),
+			'propertyKeys'   => array( '_ASK', '_ERRC' ),
 		);
 
 		$parserData = $this->applicationFactory->newParserData(


### PR DESCRIPTION
Having only a link to a misguided property annotation might not always be enough to resolve the issue `_ERRC` is added as a container and can now store additional information about a problem.

- `_ERRP` remains a `_wpg` type to point to the erroneous property referenced
- `_ERRC` represents the error container and id internally hashed (i.e `_ERR6fd39e1d9c9c36a9cf917bdb3d80e0fb`)
- `_ERRT` contains a textual description of an identified issue

![image](https://cloud.githubusercontent.com/assets/1245473/11629536/18360ea8-9cf9-11e5-992b-e93b212e1198.png)

https://github.com/SemanticMediaWiki/SemanticMediaWiki/pull/1243#issuecomment-162519453