### PR TITLE
Check subobject named identifier

### DIFF
--- a/i18n/en.json
+++ b/i18n/en.json
@@ -340,5 +340,6 @@
 	"smw-sp-types_dat": "\"$1\" is a datatype to represent points in time in a unified format.",
 	"smw-specials-browse-helplink": "https://www.semantic-mediawiki.org/wiki/Help:Special:Browse",
 	"smw-pa-property-predefined_errc": "\"$1\" is a predefined property representing a [https://www.semantic-mediawiki.org/wiki/Help:Container container] for errors that appeared in connection with improper value annotations or input processing.",
-	"smw-pa-property-predefined_errt": "\"$1\" is a predefined property containing a textual description of an error."
+	"smw-pa-property-predefined_errt": "\"$1\" is a predefined property containing a textual description of an error.",
+	"smw-subobject-parser-invalid-naming-scheme": "A user-defined subobject used an invalid naming scheme. The dot notation ($1) is reserved to be used exclusively by extensions."
 }

--- a/i18n/qqq.json
+++ b/i18n/qqq.json
@@ -347,5 +347,6 @@
 	"smw-sp-types_dat": "This is an informatory message shown to the user.",
 	"smw-specials-browse-helplink": "{{notranslate}}",
 	"smw-pa-property-predefined_errc": "This informatory message describes the [https://semantic-mediawiki.org/wiki/Help:Special_properties special property].",
-	"smw-pa-property-predefined_errt": "This informatory message describes the [https://semantic-mediawiki.org/wiki/Help:Special_properties special property]."
+	"smw-pa-property-predefined_errt": "This informatory message describes the [https://semantic-mediawiki.org/wiki/Help:Special_properties special property].",
+	"smw-subobject-parser-invalid-naming-scheme": "This is an error message shown to the user in case a named identifier contains a dot (foo.bar)."
 }

--- a/includes/parserhooks/RecurringEventsParserFunction.php
+++ b/includes/parserhooks/RecurringEventsParserFunction.php
@@ -71,9 +71,9 @@ class RecurringEventsParserFunction extends SubobjectParserFunction {
 			// @see SubobjectParserFunction::addDataValuesToSubobject
 			// Each new $parameters set will add an additional subobject
 			// to the instance
-			$this->addDataValuesToSubobject( $parameters );
-
-			$this->parserData->getSemanticData()->addSubobject( $this->subobject );
+			if ( $this->addDataValuesToSubobject( $parameters ) ) {
+				$this->parserData->getSemanticData()->addSubobject( $this->subobject );
+			}
 
 			// Collect errors that occurred during processing
 			$this->messageFormatter->addFromArray( $this->subobject->getErrors() );
@@ -82,7 +82,9 @@ class RecurringEventsParserFunction extends SubobjectParserFunction {
 		// Update ParserOutput
 		$this->parserData->pushSemanticDataToParserOutput();
 
-		return $this->messageFormatter->getHtml();
+		return $this->messageFormatter
+			->addFromArray( $this->parserData->getErrors() )
+			->getHtml();
 	}
 
 }

--- a/src/Error.php
+++ b/src/Error.php
@@ -51,14 +51,21 @@ class Error {
 			$property = new DIProperty( $property->getKey() );
 		}
 
-		$subWikiPage = new DIWikiPage(
+		$errorMsg = is_array( $errorMsg ) ? implode( ' ', $errorMsg ) : $errorMsg;
+
+		$subject = new DIWikiPage(
 			$this->subject->getDBkey(),
 			$this->subject->getNamespace(),
 			$this->subject->getInterwiki(),
-			'_ERR' . md5( $property !== null ? $property->getKey() : 'UNKNOWN' )
+			'_ERR' . md5( ( $property !== null ? $property->getKey() : 'UNKNOWN' ) . $errorMsg )
 		);
 
-		$containerSemanticData = new ContainerSemanticData( $subWikiPage );
+		// Encode brackets to avoid an annotion is created/included
+		return $this->newDiContainer( $subject, $property, str_replace( '[', '&#x005B;', $errorMsg ) );
+	}
+
+	private function newDiContainer( $subject, $property, $errorMsg ) {
+		$containerSemanticData = new ContainerSemanticData( $subject );
 
 		if (  $property !== null ) {
 			$containerSemanticData->addPropertyObjectValue(
@@ -66,8 +73,6 @@ class Error {
 				$property->getDiWikiPage()
 			);
 		}
-
-		$errorMsg = is_array( $errorMsg ) ? implode( ' ', $errorMsg ) : $errorMsg;
 
 		$containerSemanticData->addPropertyObjectValue(
 			new DIProperty( '_ERRT' ),

--- a/src/Query/Parser/DescriptionProcessor.php
+++ b/src/Query/Parser/DescriptionProcessor.php
@@ -85,7 +85,7 @@ class DescriptionProcessor {
 		array_shift( $params );
 
 		$message = new \Message( $msgKey, $params );
-		$this->addError( str_replace( array( '[' ), array( '&#58;' ), $message->inContentLanguage()->text() ) );
+		$this->addError( str_replace( array( '[' ), array( '&#x005B;' ), $message->inContentLanguage()->text() ) );
 	}
 
 	/**

--- a/tests/phpunit/Integration/ByJsonScript/Fixtures/p-0302 [#1299,en] failed subobject.json
+++ b/tests/phpunit/Integration/ByJsonScript/Fixtures/p-0302 [#1299,en] failed subobject.json
@@ -1,0 +1,87 @@
+{
+	"description": "Subobjects to fail, #1299",
+	"properties": [
+		{
+			"name": "Has page",
+			"contents": "[[Has type::Page]]"
+		}
+	],
+	"subjects": [
+		{
+			"name": "Example/P0302/1",
+			"contents": "{{#subobject:invalid.name |@category=ABC;123|+sep=;}}"
+		},
+		{
+			"name": "Example/P0302/2",
+			"contents": "{{#subobject:|Modification date= 1 Jan 1970 }}"
+		},
+		{
+			"name": "Example/P0302/3",
+			"contents": "{{#subobject:|Date= InvalidValue }}"
+		},
+		{
+			"name": "Example/P0302/4",
+			"contents": "{{#set_recurring_event:some.foo|property=Has date |start=June 8, 2010 |unit=day |period=1 |limit=10 }}"
+		}
+	],
+	"parser-testcases": [
+		{
+			"about": "#0 dot scheme not permitted for user-defined named identifiers",
+			"subject": "Example/P0302/1",
+			"store": {
+				"semantic-data": {
+					"strict-mode-valuematch": false,
+					"propertyCount": 3,
+					"propertyKeys": [ "_ERRC", "_SKEY", "_MDAT" ],
+					"propertyValues": []
+				}
+			}
+		},
+		{
+			"about": "#1 restricted property",
+			"subject": "Example/P0302/2#_a0017273b0d05dedf1e2ca22e2035490",
+			"store": {
+				"semantic-data": {
+					"strict-mode-valuematch": false,
+					"propertyCount": 2,
+					"propertyKeys": [ "_ERRC", "_SKEY" ],
+					"propertyValues": []
+				}
+			}
+		},
+		{
+			"about": "#2 invalid value",
+			"subject": "Example/P0302/3#_d1e1d8ef8b81b9275dee98ab6795b179",
+			"store": {
+				"semantic-data": {
+					"strict-mode-valuematch": false,
+					"propertyCount": 2,
+					"propertyKeys": [ "_ERRC", "_SKEY" ],
+					"propertyValues": []
+				}
+			}
+		},
+		{
+			"about": "#3 recurring events invalid name",
+			"subject": "Example/P0302/4",
+			"store": {
+				"semantic-data": {
+					"strict-mode-valuematch": false,
+					"propertyCount": 3,
+					"propertyKeys": [  "_ERRC", "_SKEY", "_MDAT" ],
+					"propertyValues": []
+				}
+			}
+		}
+	],
+	"settings": {
+		"wgContLang": "en",
+		"wgLang": "en",
+		"smwgPageSpecialProperties": [ "_MDAT" ]
+	},
+	"meta": {
+		"version": "0.1",
+		"is-incomplete": false,
+		"debug": false
+	}
+}

--- a/tests/phpunit/Unit/ErrorTest.php
+++ b/tests/phpunit/Unit/ErrorTest.php
@@ -104,4 +104,36 @@ class ErrorTest extends \PHPUnit_Framework_TestCase {
 		);
 	}
 
+	public function testErrorContainerForSamePropertyAndMsg() {
+
+		$instance = new Error( DIWikiPage::newFromText( 'Foo' ) );
+		$property = new DIProperty( 'Foo' );
+
+		$container = $instance->getContainerFor(
+			$property,
+			array( 'Some error' )
+		);
+
+		$this->assertSame(
+			$container->getHash(),
+			$instance->getContainerFor( $property, array( 'Some error' ) )->getHash()
+		);
+	}
+
+	public function testErrorContainerForSamePropertyButDifferentMsg() {
+
+		$instance = new Error( DIWikiPage::newFromText( 'Foo' ) );
+		$property = new DIProperty( 'Foo' );
+
+		$container = $instance->getContainerFor(
+			$property,
+			array( 'Some error' )
+		);
+
+		$this->assertNotSame(
+			$container->getHash(),
+			$instance->getContainerFor( $property, array( 'Different error' ) )->getHash()
+		);
+	}
+
 }

--- a/tests/phpunit/includes/parserhooks/ShowParserFunctionTest.php
+++ b/tests/phpunit/includes/parserhooks/ShowParserFunctionTest.php
@@ -213,9 +213,18 @@ class ShowParserFunctionTest extends \PHPUnit_Framework_TestCase {
 			'propertyKeys'   => array( '_ERRP', '_ERRT' ),
 		);
 
+		$errorID = null;
+
+		foreach ( $parserData->getSemanticData()->getSubSemanticData() as $subSemanticData ) {
+			if ( strpos( $subSemanticData->getSubject()->getSubobjectName(), '_ERR' ) !== false ) {
+				$errorID = $subSemanticData->getSubject()->getSubobjectName();
+				break;
+			}
+		}
+
 		$this->semanticDataValidator->assertThatPropertiesAreSet(
 			$expected,
-			$parserData->getSemanticData()->findSubSemanticData( '_ERR6fd39e1d9c9c36a9cf917bdb3d80e0fb' )
+			$parserData->getSemanticData()->findSubSemanticData( $errorID )
 		);
 	}
 

--- a/tests/phpunit/includes/parserhooks/SubobjectParserFunctionTest.php
+++ b/tests/phpunit/includes/parserhooks/SubobjectParserFunctionTest.php
@@ -83,10 +83,12 @@ class SubobjectParserFunctionTest extends \PHPUnit_Framework_TestCase {
 		$instance = $this->acquireInstance( $subobject );
 		$instance->parse( new ParserParameterFormatter( $parameters ) );
 
-		$this->assertContains(
-			$expected['identifier'],
-			$subobject->getSubobjectId()
-		);
+		if ( $expected['identifier'] !== null ) {
+			$this->assertContains(
+				$expected['identifier'],
+				$subobject->getSubobjectId()
+			);
+		}
 	}
 
 	/**
@@ -359,6 +361,21 @@ class SubobjectParserFunctionTest extends \PHPUnit_Framework_TestCase {
 			array(
 				'hasErrors' => true,
 				'identifier' => 'Foo_bar_foo',
+				'strict-mode-valuematch' => false,
+				'propertyCount'  => 1,
+				'propertyKeys' => array( '_ERRC' )
+			)
+		);
+
+		#10 {{#subobject:foo.bar
+		// |Bar=foo Bar
+		// |Date=Foo
+		// }}
+		$provider[] = array(
+			array( 'foo.bar', 'Date=Foo' ),
+			array(
+				'hasErrors' => true,
+				'identifier' => null,
 				'strict-mode-valuematch' => false,
 				'propertyCount'  => 1,
 				'propertyKeys' => array( '_ERRC' )


### PR DESCRIPTION
Named identifiers containing a dot are reserved for extension use.

```
{{#subobject:foo.bar
 |foo=bar
}}
```