### PR TITLE
Less restrictive rule for sobj named identifiers, refs #1299

### DIFF
--- a/i18n/en.json
+++ b/i18n/en.json
@@ -341,5 +341,5 @@
 	"smw-specials-browse-helplink": "https://www.semantic-mediawiki.org/wiki/Help:Special:Browse",
 	"smw-pa-property-predefined_errc": "\"$1\" is a predefined property representing a [https://www.semantic-mediawiki.org/wiki/Help:Container container] for errors that appeared in connection with improper value annotations or input processing.",
 	"smw-pa-property-predefined_errt": "\"$1\" is a predefined property containing a textual description of an error.",
-	"smw-subobject-parser-invalid-naming-scheme": "A user-defined subobject used an invalid naming scheme. The dot notation ($1) is reserved to be used exclusively by extensions."
+	"smw-subobject-parser-invalid-naming-scheme": "A user-defined subobject used an invalid naming scheme. The dot notation in the first five characters ($1) is reserved to be used exclusively by extensions."
 }

--- a/includes/parserhooks/SubobjectParserFunction.php
+++ b/includes/parserhooks/SubobjectParserFunction.php
@@ -107,10 +107,11 @@ class SubobjectParserFunction {
 
 		$subject = $this->parserData->getSemanticData()->getSubject();
 
-		// Named subobjects that contain a "." are reserved to be used by extensions
-		// only in order to separate them from user land
+		// Named subobjects containing a "." in the first five characters are reserved to be
+		// used by extensions only in order to separate them from user land and avoid them
+		// accidentally to refer to the same named ID
 		// (i.e. different access restrictions etc.)
-		if ( strpos( $parameters->getFirst(), '.' ) !== false ) {
+		if ( strpos( mb_substr( $parameters->getFirst(), 0, 5 ), '.' ) !== false ) {
 			return $this->addErrorWithMsg(
 				$subject,
 				wfMessage( 'smw-subobject-parser-invalid-naming-scheme', $parameters->getFirst() )->escaped()

--- a/tests/phpunit/Integration/ByJsonScript/Fixtures/p-0302 [#1299,en] failed subobject.json
+++ b/tests/phpunit/Integration/ByJsonScript/Fixtures/p-0302 [#1299,en] failed subobject.json
@@ -9,7 +9,7 @@
 	"subjects": [
 		{
 			"name": "Example/P0302/1",
-			"contents": "{{#subobject:invalid.name |@category=ABC;123|+sep=;}}"
+			"contents": "{{#subobject:abc.name |@category=ABC;123|+sep=;}}"
 		},
 		{
 			"name": "Example/P0302/2",

--- a/tests/phpunit/includes/parserhooks/SubobjectParserFunctionTest.php
+++ b/tests/phpunit/includes/parserhooks/SubobjectParserFunctionTest.php
@@ -367,6 +367,7 @@ class SubobjectParserFunctionTest extends \PHPUnit_Framework_TestCase {
 			)
 		);
 
+		// Has dot restriction
 		#10 {{#subobject:foo.bar
 		// |Bar=foo Bar
 		// |Date=Foo
@@ -379,6 +380,22 @@ class SubobjectParserFunctionTest extends \PHPUnit_Framework_TestCase {
 				'strict-mode-valuematch' => false,
 				'propertyCount'  => 1,
 				'propertyKeys' => array( '_ERRC' )
+			)
+		);
+
+		// Not dot restriction
+		#11 {{#subobject:foobar.bar
+		// |Bar=foo Bar
+		// }}
+		$provider[] = array(
+			array( 'foobar.bar', 'Bar=foo Bar' ),
+			array(
+				'hasErrors' => false,
+				'identifier' => 'foobar.bar',
+				'strict-mode-valuematch' => false,
+				'propertyCount'  => 1,
+				'propertyKeys' => array( 'Bar' ),
+				'propertyValues' => array( 'Foo Bar' )
 			)
 		);
 


### PR DESCRIPTION
This is a bit less restrictive (#1299 banned all "." usage) but leaves enough room for extension usage.

```
{{#subobject:あいうえ.willNotWork
 |foo=bar
}}
```

```
{{#subobject:あいうえお.willWork
 |foo=bar
}}
```
```
{{#subobject:abc.willNotWork
 |foo=bar
}}
```

```
{{#subobject:abcde.willWork
 |foo=bar
}}
```

Named subobjects containing a "." in the first five characters are reserved to be used by extensions only in order to separate them from user land and avoid having them accidentally to refer to the same named ID.