### PR TITLE
Record in record is not permitted

### DIFF
--- a/i18n/en.json
+++ b/i18n/en.json
@@ -341,5 +341,6 @@
 	"smw-specials-browse-helplink": "https://www.semantic-mediawiki.org/wiki/Help:Special:Browse",
 	"smw-pa-property-predefined_errc": "\"$1\" is a predefined property representing a [https://www.semantic-mediawiki.org/wiki/Help:Container container] for errors that appeared in connection with improper value annotations or input processing.",
 	"smw-pa-property-predefined_errt": "\"$1\" is a predefined property containing a textual description of an error.",
-	"smw-subobject-parser-invalid-naming-scheme": "A user-defined subobject used an invalid naming scheme. The dot notation in the first five characters ($1) is reserved to be used exclusively by extensions."
+	"smw-subobject-parser-invalid-naming-scheme": "A user-defined subobject used an invalid naming scheme. The dot notation in the first five characters ($1) is reserved to be used exclusively by extensions.",
+	"smw-datavalue-record-invalid-property-declaration": "The record definition contains the \"$1\" property which itself is declared as record type and that is not permitted."
 }

--- a/i18n/qqq.json
+++ b/i18n/qqq.json
@@ -348,5 +348,6 @@
 	"smw-specials-browse-helplink": "{{notranslate}}",
 	"smw-pa-property-predefined_errc": "This informatory message describes the [https://semantic-mediawiki.org/wiki/Help:Special_properties special property].",
 	"smw-pa-property-predefined_errt": "This informatory message describes the [https://semantic-mediawiki.org/wiki/Help:Special_properties special property].",
-	"smw-subobject-parser-invalid-naming-scheme": "This is an error message shown to the user in case a named identifier contains a dot (foo.bar)."
+	"smw-subobject-parser-invalid-naming-scheme": "This is an error message shown to the user in case a named identifier contains a dot (foo.bar).",
+	"smw-datavalue-record-invalid-property-declaration": "This is an error message shown to the user."
 }

--- a/includes/datavalues/SMW_DV_Record.php
+++ b/includes/datavalues/SMW_DV_Record.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * @ingroup SMWDataValues
  */
@@ -81,7 +82,8 @@ class SMWRecordValue extends SMWDataValue {
 		$empty = true;
 
 		foreach ( $this->getPropertyDataItems() as $diProperty ) {
-			if ( !array_key_exists( $valueIndex, $values ) ) {
+
+			if ( !array_key_exists( $valueIndex, $values ) || $this->getErrors() !== array() ) {
 				break; // stop if there are no values left
 			}
 
@@ -107,7 +109,7 @@ class SMWRecordValue extends SMWDataValue {
 			++$propertyIndex;
 		}
 
-		if ( $empty ) {
+		if ( $empty && $this->getErrors() === array()  ) {
 			$this->addError( wfMessage( 'smw_novalues' )->text() );
 		}
 
@@ -239,6 +241,12 @@ class SMWRecordValue extends SMWDataValue {
 	public function getPropertyDataItems() {
 		if ( is_null( $this->m_diProperties ) ) {
 			$this->m_diProperties = self::findPropertyDataItems( $this->m_property );
+
+			foreach ( $this->m_diProperties as $property ) {
+				if ( strpos( $property->findPropertyTypeID(), '_rec' ) !== false ) {
+					$this->addError( wfMessage( 'smw-datavalue-record-invalid-property-declaration', $property->getLabel() )->text() );
+				}
+			}
 
 			if ( count( $this->m_diProperties ) == 0 ) { // TODO internalionalize
 				$this->addError( 'The list of properties to be used for the data fields has not been specified properly.' );

--- a/tests/phpunit/Integration/ByJsonScript/Fixtures/p-0409 record in record.json
+++ b/tests/phpunit/Integration/ByJsonScript/Fixtures/p-0409 record in record.json
@@ -1,0 +1,67 @@
+{
+	"description": "Record in record is not permitted",
+	"properties": [
+		{
+			"name": "Has text",
+			"contents": "[[Has type::Text]]"
+		},
+		{
+			"name": "Has number",
+			"contents": "[[Has type::Number]]"
+		},
+		{
+			"name": "Has record one",
+			"contents": "[[Has type::Record]] [[Has fields::Has text;Has number]]"
+		},
+		{
+			"name": "Has record two",
+			"contents": "[[Has type::Record]] [[Has fields::Has text;Has record one]]"
+		}
+	],
+	"subjects": [
+		{
+			"name": "Example/P0409/1",
+			"contents": "[[Has record two::Foo;abc;12]]"
+		},
+		{
+			"name": "Example/P0409/2",
+			"contents": "{{#subobject: |Has record two=Foo;abc;12 }}"
+		}
+	],
+	"parser-testcases": [
+		{
+			"about": "#0 no exception just a plain error message",
+			"subject": "Example/P0409/1",
+			"store": {
+				"semantic-data": {
+					"strict-mode-valuematch": false,
+					"propertyCount": 3,
+					"propertyKeys": [ "_ERRC", "_SKEY", "_MDAT" ],
+					"propertyValues": []
+				}
+			}
+		},
+		{
+			"about": "#1 no exception just a plain error message",
+			"subject": "Example/P0409/2#_679c1c67364994d58c9d9e51bbdfc026",
+			"store": {
+				"semantic-data": {
+					"strict-mode-valuematch": false,
+					"propertyCount": 2,
+					"propertyKeys": [ "_ERRC", "_SKEY" ],
+					"propertyValues": []
+				}
+			}
+		}
+	],
+	"settings": {
+		"wgContLang": "en",
+		"wgLang": "en"
+	},
+	"meta": {
+
+		"version": "0.1",
+		"is-incomplete": false,
+		"debug": false
+	}
+}


### PR DESCRIPTION
Instead of throwing an exception, we return an error for the user to fix.

```
[efb64a58] SMW\DataItemException from line 75 of ...\dataitems\SMW_DI_Container.php: This container has been classified as anonymous and by trying to access its subject (that has not been given any) an exception is raised to inform about the incorrect usage. The cotainer can only be used as a search pattern.

Backtrace:

#0 ...\SemanticData.php(647): SMWContainerSemanticData->getSubject()
#1 ...\SemanticData.php(337): SMW\SemanticData->addSubSemanticData(SMWContainerSemanticData)
#2 ...\datavalues\SMW_DV_Record.php(99): SMW\SemanticData->addPropertyObjectValue(SMW\DIProperty, SMWDIContainer)
#3 ...\datavalues\SMW_DataValue.php(185): SMWRecordValue->parseUserValue(string)
```

```
{
	"name": "Has record one",
	"contents": "[[Has type::Record]] [[Has fields::Has text;Has number]]"
},
{
	"name": "Has record two",
	"contents": "[[Has type::Record]] [[Has fields::Has text;Has record one]]"
}
```
![image](https://cloud.githubusercontent.com/assets/1245473/11702161/b2f5eb16-9ed4-11e5-9c69-df5518946685.png)
