### PR TITLE
Feed printer (rss/atom) to parse media files

### DIFF
--- a/src/Query/ResultPrinters/FeedExportPrinter.php
+++ b/src/Query/ResultPrinters/FeedExportPrinter.php
@@ -275,7 +275,14 @@ final class FeedExportPrinter extends ResultPrinter implements ExportPrinter {
 			// Loop over all values for the property.
 			while ( ( $dataValue = $field->getNextDataValue() ) !== false ) {
 				if ( $dataValue->getDataItem() instanceof SMWDIWikipage ) {
-					$itemSegments[] = Sanitizer::decodeCharReferences( $dataValue->getLongWikiText() );
+
+					$linker = null;
+
+					if ( $dataValue->getDataItem()->getSubobjectName() === '' && $this->params['link'] !== 'none' ) {
+						$linker = smwfGetLinker();
+					}
+
+					$itemSegments[] = Sanitizer::decodeCharReferences( $dataValue->getLongWikiText( $linker ) );
 				} else {
 					$itemSegments[] = Sanitizer::decodeCharReferences( $dataValue->getWikiValue() );
 				}

--- a/tests/phpunit/Integration/JSONScript/TestCases/s-0027.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/s-0027.json
@@ -1,5 +1,5 @@
 {
-	"description": "Test `format=feed` output via `Special:Ask`",
+	"description": "Test `format=feed` output via `Special:Ask` (`wgEnableUploads`, `wgFileExtensions`)",
 	"setup": [
 		{
 			"namespace": "SMW_NS_PROPERTY",
@@ -30,6 +30,16 @@
 			"namespace": "NS_MAIN",
 			"page": "S0027/4",
 			"contents": "[[Has text::DEF]] [[Has number::123]] [[Category:S0027]]"
+		},
+		{
+			"namespace": "NS_FILE",
+			"page": "S0027.png",
+			"contents": {
+				"upload": {
+					"file" : "/../Fixtures/image-upload-480.png",
+					"text" : "[[Has file::File:S0027.png]] [[Has caption::Test file]] [[Category:S0027]]"
+				}
+			}
 		}
 	],
 	"tests": [
@@ -58,6 +68,55 @@
 					"<title>S0027/4</title>"
 				]
 			}
+		},
+		{
+			"type": "special",
+			"about": "#1 (file)",
+			"special-page": {
+				"page": "Ask",
+				"request-parameters": {
+					"p": {
+						"limit": "10",
+						"offset": "0",
+						"mainlabel": "",
+						"format": "feed"
+					},
+					"q": "[[Has file::+]] [[Category:S0027]]",
+					"po": "?Has file|?Has caption"
+				}
+			},
+			"assert-output": {
+				"to-contain": [
+					"<title>File:S0027.png</title>",
+					"a href=.*File:S0027.png",
+					"img alt=&quot;File:S0027.png"
+				]
+			}
+		},
+		{
+			"type": "special",
+			"about": "#2 (file, link=none)",
+			"special-page": {
+				"page": "Ask",
+				"request-parameters": {
+					"p": {
+						"link": "none",
+						"limit": "10",
+						"offset": "0",
+						"mainlabel": "",
+						"format": "feed"
+					},
+					"q": "[[Has file::+]] [[Category:S0027]]",
+					"po": "?Has file|?Has caption"
+				}
+			},
+			"assert-output": {
+				"to-contain": [
+					"<title>File:S0027.png</title>",
+					"File:S0027.png",
+					"Test file"
+				]
+			}
 		}
 	],
 	"settings": {
@@ -67,8 +126,16 @@
 		"smwgPageSpecialProperties": [
 			"_MDAT"
 		],
+		"wgEnableUploads": true,
+		"wgFileExtensions": [
+			"png"
+		],
+		"wgDefaultUserOptions": {
+			"thumbsize": 5
+		},
 		"smwgNamespacesWithSemanticLinks": {
 			"NS_MAIN": true,
+			"NS_FILE": true,
 			"SMW_NS_PROPERTY": true
 		}
 	},


### PR DESCRIPTION
Based on the question raised by [0], it is to allow for a feed to display things like:

![image](https://cloud.githubusercontent.com/assets/1245473/11815714/4b446c9a-a34d-11e5-82d3-d7f29959854d.png)

[0] http://wikimedia.7.x6.nabble.com/display-specific-datas-in-RSS-feed-td5053425.html
