### PR TITLE
Travis (precise-gce) fix for long hostname

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ matrix:
       php: 5.5
     - env: DB=mysql; MW=1.23.5; VIRTUOSO=6.1
       php: 5.4
-    - env: DB=mysql; MW=1.24.1; SESAME=2.7.14
+    - env: DB=mysql; MW=1.25.3; SESAME=2.7.14
       php: 5.3
     - env: DB=sqlite; MW=1.22.12; SITELANG=ja
       php: 5.5
@@ -37,7 +37,17 @@ matrix:
     - env: DB=sqlite; MW=1.25.2; TYPE=composer
     - env: DB=sqlite; MW=master; PHPUNIT=4.6.*
     - env: DB=mysql; MW=1.25.2; PHPUNIT=4.3.*; TYPE=benchmark
-    - env: DB=mysql; MW=1.24.1; SESAME=2.7.14
+    - env: DB=mysql; MW=1.25.3; SESAME=2.7.14
+
+# Travis support wrote (Tomcat + Java):
+# bug in the JDK: http://bugs.java.com/bugdatabase/view_bug.do?bug_id=7089443.
+# The hostname for the precise-gce platform is longer than 64 characters on the
+# VM your job is running on
+before_install:
+  - cat /etc/hosts # optionally check the content *before*
+  - sudo hostname "$(hostname | cut -c1-63)"
+  - sed -e "s/^\\(127\\.0\\.0\\.1.*\\)/\\1 $(hostname | cut -c1-63)/" /etc/hosts | sudo tee /etc/hosts
+  - cat /etc/hosts # optionally check the content *after*
 
 install:
   - travis_retry composer self-update

--- a/tests/travis/install-services.sh
+++ b/tests/travis/install-services.sh
@@ -27,13 +27,19 @@ fi
 
 if [ "$SESAME" != "" ]
 then
-	sudo apt-get install tomcat6
+	TOMCAT_VERSION=tomcat6
+	sudo java -version
 
-	sudo chown $USER -R /var/lib/tomcat6/
-	sudo chmod g+rw -R /var/lib/tomcat6/
+	sudo apt-get install $TOMCAT_VERSION
 
-	sudo mkdir -p /usr/share/tomcat6/.aduna
-	sudo chown -R tomcat6:tomcat6 /usr/share/tomcat6
+	CATALINA_BASE=/var/lib/$TOMCAT_VERSION
+	CATALINA_HOME=/usr/share/$TOMCAT_VERSION
+
+	sudo chown $USER -R $CATALINA_BASE/
+	sudo chmod g+rw -R $CATALINA_BASE/
+
+	sudo mkdir -p $CATALINA_HOME/.aduna
+	sudo chown -R $TOMCAT_VERSION:$TOMCAT_VERSION $CATALINA_HOME
 
 	# One method to get the war files
 	# wget http://search.maven.org/remotecontent?filepath=org/openrdf/sesame/sesame-http-server/$SESAME/sesame-http-server-$SESAME.war -O openrdf-sesame.war
@@ -45,16 +51,21 @@ then
 
 	# tar caused a lone zero block, using zip instead
 	unzip -q openrdf-sesame-$SESAME-sdk.zip
-	cp openrdf-sesame-$SESAME/war/*.war /var/lib/tomcat6/webapps/
+	cp openrdf-sesame-$SESAME/war/*.war $CATALINA_BASE/webapps/
 
-	sudo service tomcat6 restart
-	sleep 3
+	sudo service $TOMCAT_VERSION restart
+	ps -ef | grep tomcat
+
+	sleep 5
 
 	if curl --output /dev/null --silent --head --fail "http://localhost:8080/openrdf-sesame"
+	#if curl --output /dev/null --silent --head --fail "http://localhost:8080/openrdf-sesame/home/overview.view"
 	then
 		echo "openrdf-sesame service url is reachable"
 	else
 		echo "openrdf-sesame service url is not reachable"
+		sudo cat $CATALINA_BASE/logs/*.log &
+		sudo cat $CATALINA_BASE/logs/catalina.out &
 		exit $E_UNREACHABLE
 	fi
 


### PR DESCRIPTION
After the change to the new precise-gce platform, issues with Tomcat, Java and Sesame emerged and the Travis support responded with "Looks like this is caused by this bug in the JDK: http://bugs.java.com/bugdatabase/view_bug.do?bug_id=7089443 [1]. The hostname is longer than 64 characters on the VM your job is running on, which is the condition for triggering this."