### PR TITLE
Add obscureAnnotation / removeAnnotation to InTextAnnotationParser, r…

### DIFF
--- a/includes/storage/SMW_ResultArray.php
+++ b/includes/storage/SMW_ResultArray.php
@@ -1,5 +1,7 @@
 <?php
 use SMW\Query\PrintRequest;
+use SMWDIBlob as DIBlob;
+use SMW\InTextAnnotationParser;
 
 /**
  * Container for the contents of a single result field of a query result,
@@ -162,6 +164,13 @@ class SMWResultArray {
 		} else {
 			$diProperty = null;
 		}
+
+		// refs #1314
+		if ( $this->mPrintRequest->getMode() == PrintRequest::PRINT_PROP &&
+			strpos( $this->mPrintRequest->getTypeID(), '_txt' ) !== false ) {
+			$di = new DIBlob( InTextAnnotationParser::removeAnnotation( $di->getString() ) );
+		}
+
 		$dv = \SMW\DataValueFactory::getInstance()->newDataItemValue( $di, $diProperty );
 		if ( $this->mPrintRequest->getOutputFormat() ) {
 			$dv->setOutputFormat( $this->mPrintRequest->getOutputFormat() );

--- a/src/Error.php
+++ b/src/Error.php
@@ -61,7 +61,7 @@ class Error {
 		);
 
 		// Encode brackets to avoid an annotion is created/included
-		return $this->newDiContainer( $subject, $property, str_replace( '[', '&#x005B;', $errorMsg ) );
+		return $this->newDiContainer( $subject, $property, InTextAnnotationParser::obscureAnnotation( $errorMsg ) );
 	}
 
 	private function newDiContainer( $subject, $property, $errorMsg ) {

--- a/src/Factbox/CachedFactbox.php
+++ b/src/Factbox/CachedFactbox.php
@@ -6,6 +6,7 @@ use ParserOutput;
 use OutputPage;
 use Onoi\Cache\Cache;
 use SMW\ApplicationFactory;
+use SMW\InTextAnnotationParser;
 use Title;
 
 /**
@@ -208,10 +209,11 @@ class CachedFactbox {
 		if ( $factbox->doBuild()->isVisible() ) {
 
 			$contentParser = $applicationFactory->newContentParser( $title );
-			$contentParser->skipInTextAnnotationParser();
 			$contentParser->parse( $factbox->getContent() );
 
-			$text = $contentParser->getOutput()->getText();
+			$text = InTextAnnotationParser::removeAnnotation(
+				$contentParser->getOutput()->getText()
+			);
 		}
 
 		return $text;

--- a/src/InTextAnnotationParser.php
+++ b/src/InTextAnnotationParser.php
@@ -141,6 +141,67 @@ class InTextAnnotationParser {
 	}
 
 	/**
+	 * @since 2.4
+	 *
+	 * @param string $text
+	 *
+	 * @return text
+	 */
+	public static function decodeSquareBracket( $text ) {
+		return str_replace( array( '%5B', '%5D' ), array( '[', ']' ), $text );
+	}
+
+	/**
+	 * @since 2.4
+	 *
+	 * @param string $text
+	 *
+	 * @return text
+	 */
+	public static function obscureAnnotation( $text ) {
+		return preg_replace_callback(
+			self::getRegexpPattern( false ),
+			function( array $matches ) {
+				return str_replace( '[', '&#x005B;', $matches[0] );
+			},
+			self::decodeSquareBracket( $text )
+		);
+	}
+
+	/**
+	 * @since 2.4
+	 *
+	 * @param string $text
+	 *
+	 * @return text
+	 */
+	public static function removeAnnotation( $text ) {
+		return preg_replace_callback(
+			self::getRegexpPattern( false ),
+			function( array $matches ) {
+				$caption = false;
+				$value = '';
+
+				// Strict mode matching
+				if ( array_key_exists( 1, $matches ) ) {
+					if ( strpos( $matches[1], ':' ) !== false && isset( $matches[2] ) ) {
+						list( $matches[1], $matches[2] ) = explode( '::', $matches[1] . '::' . $matches[2], 2 );
+					}
+				}
+
+				if ( array_key_exists( 2, $matches ) ) {
+					$parts = explode( '|', $matches[2] );
+					$value = array_key_exists( 0, $parts ) ? $parts[0] : '';
+					$caption = array_key_exists( 1, $parts ) ? $parts[1] : false;
+				}
+
+				return $caption !== false ? $caption : $value;
+			},
+			self::decodeSquareBracket( $text )
+		);
+	}
+
+	/**
 	 * @since 2.1
 	 *
 	 * @param Title|null $redirectTarget
@@ -195,7 +256,7 @@ class InTextAnnotationParser {
 	 *
 	 * @return string
 	 */
-	protected function getRegexpPattern( $linksInValues ) {
+	protected static function getRegexpPattern( $linksInValues ) {
 		if ( $linksInValues ) {
 			return '/\[\[             # Beginning of the link
 				(?:([^:][^]]*):[=:])+ # Property name (or a list of those)

--- a/tests/phpunit/Integration/ByJsonScript/Fixtures/p-0403 [#1126] intext disabled during factbox parse.json
+++ b/tests/phpunit/Integration/ByJsonScript/Fixtures/p-0403 [#1126] intext disabled during factbox parse.json
@@ -4,29 +4,79 @@
 		{
 			"name": "Has url",
 			"contents": "[[Has type::URL]]"
+		},
+		{
+			"name": "Has page",
+			"contents": "[[Has type::Page]]"
+		},
+		{
+			"name": "Has text",
+			"contents": "[[Has type::Text]]"
 		}
 	],
 	"subjects": [
 		{
-			"name": "ShowFactbox",
+			"name": "SetValue",
+			"namespace": "NS_TEMPLATE",
+			"contents": "<includeonly>{{{value}}}</includeonly>"
+		},
+		{
+			"name": "Example/P0403/1",
 			"contents": "[[Has url::http://example.org/api.php?action=ask&query=%5B%5BModification%20date::%2B%5D%5D%7C%3FModification%20date%7Csort%3DModification%20date%7Corder%3Ddesc|api.php?action=ask&query=]] __SHOWFACTBOX__"
+		},
+		{
+			"name": "Example/P0403/2",
+			"contents": "{{#set:|Has text=ABC [[Has page::DEF]] 123|template=SetValue}}"
+		},
+		{
+			"name": "Example/P0403/3",
+			"contents": "{{#ask: [[Example/P0403/2]] |?Has text}}"
 		}
 	],
 	"parser-testcases": [
 		{
 			"about": "#0 don't expected to see a Modification date annotation due to %5B%5BModification%20date::%2B%5D%5D => [[Modification::+]]",
-			"subject": "ShowFactbox",
+			"subject": "Example/P0403/1",
 			"store": {
 				"semantic-data": {
 					"strict-mode-valuematch": false,
 					"propertyCount": 3,
 					"propertyKeys": [ "_SKEY", "_MDAT", "Has_url" ],
-					"propertyValues": [ "ShowFactbox", "http://example.org/api.php?action=ask&query=%5B%5BModification%20date::%2B%5D%5D%7C%3FModification%20date%7Csort%3DModification%20date%7Corder%3Ddesc" ]
+					"propertyValues": [ "Example/P0403/1", "http://example.org/api.php?action=ask&query=%5B%5BModification%20date::%2B%5D%5D%7C%3FModification%20date%7Csort%3DModification%20date%7Corder%3Ddesc" ]
 				}
 			},
 			"expected-output": {
 				"to-contain": [
 					"href=\"http://example.org/api.php?action=ask&amp;query=%5B%5BModification%20date::%2B%5D%5D%7C%3FModification%20date%7Csort%3DModification%20date%7Corder%3Ddesc\">api.php?action=ask&amp;query=</a>"
+				]
+			}
+		},
+		{
+			"about": "#1, refs #1314",
+			"subject": "Example/P0403/2",
+			"store": {
+				"semantic-data": {
+					"strict-mode-valuematch": false,
+					"propertyCount": 4,
+					"propertyKeys": [ "_SKEY", "_MDAT", "Has_text", "Has_page" ],
+					"propertyValues": [ "Example/P0403/2", "ABC [[Has page::DEF]] 123", "DEF" ]
+				}
+			}
+		},
+		{
+			"about": "#2 does not contain any [[ :: ]] copied annotation values, refs #1314",
+			"subject": "Example/P0403/3",
+			"store": {
+				"semantic-data": {
+					"strict-mode-valuematch": false,
+					"propertyCount": 3,
+					"propertyKeys": [ "_SKEY", "_MDAT", "_ASK" ],
+					"propertyValues": []
+				}
+			},
+			"expected-output": {
+				"to-contain": [
+					"ABC DEF 123"
 				]
 			}
 		}

--- a/tests/phpunit/Unit/InTextAnnotationParserTest.php
+++ b/tests/phpunit/Unit/InTextAnnotationParserTest.php
@@ -255,6 +255,65 @@ class InTextAnnotationParserTest extends \PHPUnit_Framework_TestCase {
 		$this->assertEmpty( $result );
 	}
 
+	/**
+	 * @dataProvider textWithAnnotationProvider
+	 */
+	public function testStrip( $text, $expectedRemoval, $expectedObscuration ) {
+
+		$this->assertEquals(
+			$expectedRemoval,
+			InTextAnnotationParser::removeAnnotation( $text )
+		);
+
+		$this->assertEquals(
+			$expectedObscuration,
+			InTextAnnotationParser::obscureAnnotation( $text )
+		);
+	}
+
+	public function textWithAnnotationProvider() {
+
+		$provider = array();
+
+		$provider[] = array(
+			'Suspendisse [[Bar::tincidunt semper|abc]] facilisi',
+			'Suspendisse abc facilisi',
+			'Suspendisse &#x005B;&#x005B;Bar::tincidunt semper|abc]] facilisi'
+		);
+
+		$provider[] = array(
+			'Suspendisse [[Bar::tincidunt semper]] facilisi',
+			'Suspendisse tincidunt semper facilisi',
+			'Suspendisse &#x005B;&#x005B;Bar::tincidunt semper]] facilisi'
+		);
+
+		$provider[] = array(
+			'Suspendisse [[:Tincidunt semper|tincidunt semper]]',
+			'Suspendisse [[:Tincidunt semper|tincidunt semper]]',
+			'Suspendisse [[:Tincidunt semper|tincidunt semper]]'
+		);
+
+		$provider[] = array(
+			'[[Foo::Foobar::テスト]] [[Bar:::ABC|DEF]] [[Foo:::0049 30 12345678/::Foo]]',
+			'Foobar::テスト DEF :0049 30 12345678/::Foo',
+			'&#x005B;&#x005B;Foo::Foobar::テスト]] &#x005B;&#x005B;Bar:::ABC|DEF]] &#x005B;&#x005B;Foo:::0049 30 12345678/::Foo]]'
+		);
+
+		$provider[] = array(
+			'%5B%5BFoo%20Bar::foobaz%5D%5D',
+			'foobaz',
+			'&#x005B;&#x005B;Foo%20Bar::foobaz]]'
+		);
+
+		$provider[] = array(
+			'Suspendisse tincidunt semper facilisi',
+			'Suspendisse tincidunt semper facilisi',
+			'Suspendisse tincidunt semper facilisi'
+		);
+
+		return $provider;
+	}
+
 	public function textDataProvider() {
 
 		$provider = array();


### PR DESCRIPTION
…efs #1314

- `InTextAnnotationParser::removeAnnotation` to entirely remove traces of any annotation within the text
- `InTextAnnotationParser::obscureAnnotation` to encode part of the annotation so that
the `InTextAnnotationParser::parse` is not able to process that part of a text