### PR TITLE
Setting to force HttpVersion for RepositoryConnector, refs #1306

### DIFF
--- a/SemanticMediaWiki.settings.php
+++ b/SemanticMediaWiki.settings.php
@@ -114,6 +114,21 @@ $GLOBALS['smwgSparqlDatabaseConnector'] = 'custom';
 ##
 $GLOBALS['smwgSparqlQFeatures'] = SMW_SPARQL_QF_REDI | SMW_SPARQL_QF_SUBP | SMW_SPARQL_QF_SUBC;
 
+##
+# @see https://github.com/SemanticMediaWiki/SemanticMediaWiki/issues/1306
+#
+# Setting to explicitly force a CURLOPT_HTTP_VERSION for the endpoint communication
+# and should not be changed unless an error as in #1306 was encountered.
+#
+# @see http://curl.haxx.se/libcurl/c/CURLOPT_HTTP_VERSION.html reads "... libcurl
+# to use the specific HTTP versions. This is not sensible to do unless you have
+# a good reason.""
+#
+# @since 2.3
+# @default false === means to use the default as determined by cURL
+##
+$GLOBALS['smwgSparqlRepositoryConnectorForcedHttpVersion'] = false;
+
 ###
 # Setting this option to true before including this file to enable the old
 # Type: namespace that SMW used up to version 1.5.*. This should only be

--- a/includes/Settings.php
+++ b/includes/Settings.php
@@ -139,7 +139,8 @@ class Settings extends SimpleDictionary {
 			'smwgPropertyDependencyDetectionBlacklist' => $GLOBALS['smwgPropertyDependencyDetectionBlacklist'],
 			'smwgExportBCNonCanonicalFormUse' => $GLOBALS['smwgExportBCNonCanonicalFormUse'],
 			'smwgExportBCAuxiliaryUse' => $GLOBALS['smwgExportBCAuxiliaryUse'],
-			'smwgEnabledInTextAnnotationParserStrictMode' => $GLOBALS['smwgEnabledInTextAnnotationParserStrictMode']
+			'smwgEnabledInTextAnnotationParserStrictMode' => $GLOBALS['smwgEnabledInTextAnnotationParserStrictMode'],
+			'smwgSparqlRepositoryConnectorForcedHttpVersion' => $GLOBALS['smwgSparqlRepositoryConnectorForcedHttpVersion']
 		);
 
 		$settings = $settings + array(

--- a/src/SPARQLStore/RepositoryConnectionProvider.php
+++ b/src/SPARQLStore/RepositoryConnectionProvider.php
@@ -63,6 +63,11 @@ class RepositoryConnectionProvider implements DBConnectionProvider {
 	private $dataEndpoint = null;
 
 	/**
+	 * @var boolean|integer
+	 */
+	private $httpVersion = false;
+
+	/**
 	 * @since 2.0
 	 *
 	 * @param string|null $connectorId
@@ -82,6 +87,15 @@ class RepositoryConnectionProvider implements DBConnectionProvider {
 			$this->queryEndpoint = $queryEndpoint;
 			$this->updateEndpoint = $updateEndpoint;
 			$this->dataEndpoint = $dataEndpoint;
+	}
+
+	/**
+	 * @since 2.3
+	 *
+	 * @return integer $httpVersion
+	 */
+	public function setHttpVersionTo( $httpVersion ) {
+		$this->httpVersion = $httpVersion;
 	}
 
 	/**
@@ -130,9 +144,16 @@ class RepositoryConnectionProvider implements DBConnectionProvider {
 			$this->dataEndpoint = $GLOBALS['smwgSparqlDataEndpoint'];
 		}
 
+		$curlRequest = new CurlRequest( curl_init() );
+
+		// https://github.com/SemanticMediaWiki/SemanticMediaWiki/issues/1306
+		if ( $this->httpVersion ) {
+			$curlRequest->setOption( CURLOPT_HTTP_VERSION, $this->httpVersion );
+		}
+
 		$connection = new $repositoryConnector(
 			new RepositoryClient( $this->defaultGraph, $this->queryEndpoint, $this->updateEndpoint, $this->dataEndpoint ),
-			new CurlRequest( curl_init() )
+			$curlRequest
 		);
 
 		if ( $this->isRepositoryConnection( $connection ) ) {

--- a/src/SPARQLStore/SPARQLStoreFactory.php
+++ b/src/SPARQLStore/SPARQLStoreFactory.php
@@ -27,12 +27,18 @@ class SPARQLStoreFactory {
 	private $store;
 
 	/**
+	 * @var ApplicationFactory
+	 */
+	private $applicationFactory;
+
+	/**
 	 * @since 2.2
 	 *
 	 * @param SPARQLStore $store
 	 */
 	public function __construct( SPARQLStore $store ) {
 		$this->store = $store;
+		$this->applicationFactory = ApplicationFactory::getInstance();
 	}
 
 	/**
@@ -52,19 +58,18 @@ class SPARQLStoreFactory {
 	public function newMasterQueryEngine() {
 
 		$engineOptions = new EngineOptions();
-		$applicationFactory = ApplicationFactory::getInstance();
 
 		$propertyHierarchyLookup = new PropertyHierarchyLookup(
 			$this->store,
-			$applicationFactory->newCacheFactory()->newFixedInMemoryCache( 500 )
+			$this->applicationFactory->newCacheFactory()->newFixedInMemoryCache( 500 )
 		);
 
 		$propertyHierarchyLookup->setSubcategoryDepth(
-			$applicationFactory->getSettings()->get( 'smwgQSubcategoryDepth' )
+			$this->applicationFactory->getSettings()->get( 'smwgQSubcategoryDepth' )
 		);
 
 		$propertyHierarchyLookup->setSubpropertyDepth(
-			$applicationFactory->getSettings()->get( 'smwgQSubpropertyDepth' )
+			$this->applicationFactory->getSettings()->get( 'smwgQSubpropertyDepth' )
 		);
 
 		$circularReferenceGuard = new CircularReferenceGuard( 'sparql-query' );
@@ -101,9 +106,14 @@ class SPARQLStoreFactory {
 
 		$connectionManager = new ConnectionManager();
 
+		$repositoryConnectionProvider = new RepositoryConnectionProvider();
+		$repositoryConnectionProvider->setHttpVersionTo(
+			$this->applicationFactory->getSettings()->get( 'smwgSparqlRepositoryConnectorForcedHttpVersion' )
+		);
+
 		$connectionManager->registerConnectionProvider(
 			'sparql',
-			new RepositoryConnectionProvider()
+			$repositoryConnectionProvider
 		);
 
 		return $connectionManager;

--- a/tests/phpunit/Unit/SPARQLStore/RepositoryConnectionProviderTest.php
+++ b/tests/phpunit/Unit/SPARQLStore/RepositoryConnectionProviderTest.php
@@ -62,6 +62,7 @@ class RepositoryConnectionProviderTest extends \PHPUnit_Framework_TestCase {
 	public function testGetDefaultConnection() {
 
 		$instance = new RepositoryConnectionProvider( 'default' );
+		$instance->setHttpVersionTo( CURL_HTTP_VERSION_NONE );
 
 		$this->assertInstanceOf(
 			'\SMWSparqlDatabase',


### PR DESCRIPTION
Default setting is `$GLOBALS['smwgSparqlRepositoryConnectorForcedHttpVersion'] = false;`
and should not be changed unless error #1306 was encountered.