### PR TITLE
Include `QUERY_LINKS_TABLE` to check for object reference

### DIFF
--- a/src/SQLStore/PropertyTableOutdatedReferenceDisposer.php
+++ b/src/SQLStore/PropertyTableOutdatedReferenceDisposer.php
@@ -43,7 +43,7 @@ class PropertyTableOutdatedReferenceDisposer {
 		$canRemoveEntry = true;
 
 		foreach ( $this->store->getPropertyTables() as $proptable ) {
-			if ( $this->hasReferenceInPropertyTable( $proptable, $id ) ) {
+			if ( $this->hasReferenceByTable( $proptable, $id ) ) {
 				$canRemoveEntry = false;
 				break;
 			}
@@ -91,7 +91,7 @@ class PropertyTableOutdatedReferenceDisposer {
 		);
 	}
 
-	private function hasReferenceInPropertyTable( $proptable, $id ) {
+	private function hasReferenceByTable( $proptable, $id ) {
 
 		$row = false;
 		$db = $this->store->getConnection( 'mw.db' );
@@ -129,6 +129,18 @@ class PropertyTableOutdatedReferenceDisposer {
 				$proptable->getName(),
 				array( 'p_id' ),
 				array( 'p_id' => $id ),
+				__METHOD__
+			);
+		}
+
+		// If the query table contains a reference then we keep the object (could
+		// be a subject, property, or printrequest) where in case the query is
+		// removed the object will also loose its reference
+		if ( $row === false ) {
+			$row = $db->selectRow(
+				SQLStore::QUERY_LINKS_TABLE,
+				array( 'o_id' ),
+				array( 'o_id' => $id ),
 				__METHOD__
 			);
 		}

--- a/tests/phpunit/Unit/InTextAnnotationParserTemplateTransclusionTest.php
+++ b/tests/phpunit/Unit/InTextAnnotationParserTemplateTransclusionTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace SMW\Test;
+namespace SMW\Tests;
 
 use SMW\Tests\Utils\Validators\SemanticDataValidator;
 use SMW\InTextAnnotationParser;

--- a/tests/phpunit/Unit/StoreTest.php
+++ b/tests/phpunit/Unit/StoreTest.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace SMW\Tests;
+
+use SMW\Store;
+use SMW\DIWikiPage;
+use SMW\InMemoryPoolCache;
+
+/**
+ * @covers \SMW\Store
+ * @group semantic-mediawiki
+ *
+ * @license GNU GPL v2+
+ * @since 2.4
+ *
+ * @author mwjames
+ */
+class StoreTest extends \PHPUnit_Framework_TestCase {
+
+	public function testGetRedirectTargetFromInMemoryCache() {
+
+		$inMemoryPoolCache = InMemoryPoolCache::getInstance();
+
+		$instance = $this->getMockBuilder( '\SMW\Store' )
+			->disableOriginalConstructor()
+			->getMockForAbstractClass();
+
+		$wikipage = new DIWikiPage( 'Foo', NS_MAIN );
+		$expected = new DIWikiPage( 'Bar', NS_MAIN );
+
+		$inMemoryPoolCache->getPoolCacheFor( 'store.redirectTarget.lookup' )->save(
+			$wikipage->getHash(),
+			$expected
+		);
+
+		$this->assertEquals(
+			$expected,
+			$instance->getRedirectTarget( $wikipage )
+		);
+
+		$inMemoryPoolCache->resetPoolCacheFor( 'store.redirectTarget.lookup' );
+	}
+
+}


### PR DESCRIPTION
- Include `QUERY_LINKS_TABLE` to check for object reference
- Use `InMemoryPoolCache` to support `Store::getRedirectTarget`