### PR TITLE
Add positional preference for units

### DIFF
--- a/i18n/en.json
+++ b/i18n/en.json
@@ -269,7 +269,7 @@
 	"smw-prefs-ask-options-tooltip-display": "Display parameter text as an info tooltip",
 	"smw-prefs-ask-options-collapsed-default": "Enable option box to be collapsed by default",
 	"smw-ui-tooltip-title-property": "Property",
-	"smw-ui-tooltip-title-quantity": "Quantity",
+	"smw-ui-tooltip-title-quantity": "Unit conversion",
 	"smw-ui-tooltip-title-info": "Information",
 	"smw-ui-tooltip-title-service": "Service links",
 	"smw-ui-tooltip-title-warning": "Error",

--- a/tests/phpunit/Integration/ByJsonScript/Fixtures/f-0204.json
+++ b/tests/phpunit/Integration/ByJsonScript/Fixtures/f-0204.json
@@ -1,0 +1,52 @@
+{
+	"description": "Test `format=table` on `_qty` for different positional unit preference (#1329, en)",
+	"properties": [
+		{
+			"name": "Currency",
+			"contents": "[[Has type::Quantity]], [[Display units::€,£,¥]] [[Corresponds to::€ 1]] [[Corresponds to::1.06 US, US$, $]] [[Corresponds to::0.70 British Pound,GBP,£]] [[Corresponds to::¥,JPY,Japanese Yen 114.2121]]"
+		}
+	],
+	"subjects": [
+		{
+			"name": "Example/F0204/1",
+			"contents": "[[Currency::12 €]] [[Currency::¥ 500]] [[Currency::2 £]]"
+		},
+		{
+			"name": "Example/F0204/2",
+			"contents": "[[Currency::€ 20]] [[Currency::2000 JPY]] [[Currency::0.5 GBP]]"
+		},
+		{
+			"name": "Example/F0204/3",
+			"contents": "{{#ask: [[Currency::+]] |?Currency |format=table |headers=plain }}"
+		}
+	],
+	"format-testcases": [
+		{
+			"about": "#0 output with different positional preference",
+			"subject": "Example/F0204/3",
+			"expected-output": {
+				"to-contain": [
+					"<span class=\"smwtext\">€&#160;12</span><div class=\"smwttcontent\">8.4&#160;£ <br />¥&#160;1,370.545 <br /></div></span>",
+					"<span class=\"smwtext\">€&#160;4.378</span><div class=\"smwttcontent\">3.064&#160;£ <br />¥&#160;500 <br /></div></span>",
+					"<span class=\"smwtext\">€&#160;2.857</span><div class=\"smwttcontent\">2&#160;£ <br />¥&#160;326.32 <br /></div></span>",
+					"<span class=\"smwtext\">€&#160;20</span><div class=\"smwttcontent\">14&#160;£ <br />¥&#160;2,284.242 <br /></div></span>",
+					"<span class=\"smwtext\">€&#160;17.511</span><div class=\"smwttcontent\">12.258&#160;£ <br />¥&#160;2,000 <br /></div></span>",
+					"<span class=\"smwtext\">€&#160;0.714</span><div class=\"smwttcontent\">0.5&#160;£ <br />¥&#160;81.58 <br /></div></span>"
+				]
+			}
+		}
+	],
+	"settings": {
+		"wgContLang": "en",
+		"wgLang": "en",
+		"smwgNamespacesWithSemanticLinks": {
+			"NS_MAIN": true,
+			"SMW_NS_PROPERTY": true
+		}
+	},
+	"meta": {
+		"version": "0.1",
+		"is-incomplete": false,
+		"debug": false
+	}
+}

--- a/tests/phpunit/Integration/ByJsonScript/Fixtures/q-0503.json
+++ b/tests/phpunit/Integration/ByJsonScript/Fixtures/q-0503.json
@@ -1,0 +1,84 @@
+{
+	"description": "Test `_qty` on positional unit preference in query condition (#1329, `smwStrictComparators=false`)",
+	"properties": [
+		{
+			"name": "Currency",
+			"contents": "[[Has type::Quantity]], [[Display units::€,£,¥]] [[Corresponds to::€ 1]] [[Corresponds to::1.06 US, US$, $]] [[Corresponds to::0.70 British Pound,GBP,£]] [[Corresponds to::¥,JPY,Japanese Yen 114.2121]]"
+		}
+	],
+	"subjects": [
+		{
+			"name": "Example/Q0503/1",
+			"contents": "[[Currency::12 €]] [[Currency::¥ 500]] [[Currency::2 £]]"
+		},
+		{
+			"name": "Example/Q0503/2",
+			"contents": "[[Currency::€ 20]] [[Currency::2000 JPY]] [[Currency::0.5 GBP]]"
+		}
+	],
+	"query-testcases": [
+		{
+			"about": "#0",
+			"condition": "[[Currency::€ 20]]",
+			"printouts" : [],
+			"parameters" : {
+			  "limit" : "10"
+			},
+			"queryresult": {
+				"count": 1,
+				"results": [
+					"Example/Q0503/2#0##"
+				]
+			}
+		},
+		{
+			"about": "#1",
+			"condition": "[[Currency::<¥300]]",
+			"printouts" : [],
+			"parameters" : {
+			  "limit" : "10"
+			},
+			"queryresult": {
+				"count": 1,
+				"results": [
+					"Example/Q0503/2#0##"
+				]
+			}
+		},
+		{
+			"about": "#2",
+			"condition": "[[Currency::≥1400 JPY]]",
+			"printouts" : [],
+			"parameters" : {
+			  "limit" : "10"
+			},
+			"queryresult": {
+				"count": 1,
+				"results": [
+					"Example/Q0503/2#0##"
+				]
+			}
+		},
+		{
+			"about": "#3",
+			"condition": "[[Currency::< € .8]]",
+			"printouts" : [],
+			"parameters" : {
+			  "limit" : "10"
+			},
+			"queryresult": {
+				"count": 1,
+				"results": [
+					"Example/Q0503/2#0##"
+				]
+			}
+		}
+	],
+	"settings": {
+		"smwStrictComparators" : false
+	},
+	"meta": {
+		"version": "0.1",
+		"debug": false
+	}
+}

--- a/tests/phpunit/Integration/ByJsonScript/README.md
+++ b/tests/phpunit/Integration/ByJsonScript/README.md
@@ -1,5 +1,5 @@
 ## Fixtures
-Contains 84 files:
+Contains 86 files:
 
 ### F
 * [f-0001.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/ByJsonScript/Fixtures/f-0001.json) Test format=debug output
@@ -9,6 +9,7 @@ Contains 84 files:
 * [f-0201.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/ByJsonScript/Fixtures/f-0201.json) Test format=table on boolean table output formatting, #896
 * [f-0202.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/ByJsonScript/Fixtures/f-0202.json) Test format=table with sep cell formatting, #495 (en, skip 1.19)
 * [f-0203.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/ByJsonScript/Fixtures/f-0203.json) Test format=table to sort by category (#1286)
+* [f-0204.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/ByJsonScript/Fixtures/f-0204.json) Test `format=table` on `_qty` for different positional unit preference (#1329, en)
 * [f-0301.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/ByJsonScript/Fixtures/f-0301.json) Test format=category with template usage (#699, en, skip postgres)
 * [f-0302.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/ByJsonScript/Fixtures/f-0302.json) Test format=category and defaultsort (#699, en)
 * [f-0801.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/ByJsonScript/Fixtures/f-0801.json) Test format=embedded output (skip 1.19)
@@ -55,6 +56,7 @@ Contains 84 files:
 * [q-0402.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/ByJsonScript/Fixtures/q-0402.json) Test `_SUBP` to map DC imported vocabulary with MARC 21 bibliographic terms (#1003, http://www.loc.gov/marc/bibliographic/bd20x24x.html)
 * [q-0501.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/ByJsonScript/Fixtures/q-0501.json) Test `_qty` queries for custom unit (km²/°C) property value assignments
 * [q-0502.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/ByJsonScript/Fixtures/q-0502.json) Test `_qty` range queries using non strict comparators (`smwStrictComparators=false`)
+* [q-0503.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/ByJsonScript/Fixtures/q-0503.json) Test `_qty` on positional unit preference in query condition (#1329, `smwStrictComparators=false`)
 * [q-0601.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/ByJsonScript/Fixtures/q-0601.json) Test `_wpg` for property chain query queries
 * [q-0602.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/ByJsonScript/Fixtures/q-0602.json) Test `_wpg` sort query with #subobject annotated @sortkey content
 * [q-0603.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/ByJsonScript/Fixtures/q-0603.json) Test `_wpg` queries for various conditions using #set annotated content


### PR DESCRIPTION
The unit position declared in `[[Corresponds to::€ 1]]` vs `[[Corresponds to::1.06 USD, US$, $]]`
determines the positional preference (prefix, suffix).

https://github.com/SemanticMediaWiki/SemanticResultFormats/issues/135#issuecomment-159918758

http://sandbox.semantic-mediawiki.org/wiki/Issue/1329_%28Positional_unit_preference%29