### PR TITLE
Avoid "ErrorException ... Cannot modify header information" in MW 1.27

### DIFF
--- a/src/MediaWiki/Specials/SpecialDeferredRequestDispatcher.php
+++ b/src/MediaWiki/Specials/SpecialDeferredRequestDispatcher.php
@@ -127,6 +127,17 @@ class SpecialDeferredRequestDispatcher extends SpecialPage {
 		print $message;
 		ob_flush();
 		flush();
+
+		// @see SpecialRunJobs
+		// MW 1.27 / https://phabricator.wikimedia.org/T115413
+		// Once the client receives this response, it can disconnect
+		set_error_handler( function ( $errno, $errstr ) {
+			if ( strpos( $errstr, 'Cannot modify header information' ) !== false ) {
+				return true; // bug T115413
+			}
+			// Delegate unhandled errors to the default handlers
+			return false;
+		} );
 	}
 
 	private function runParserCachePurgeJob( $title, $parameters ) {


### PR DESCRIPTION
@see https://phabricator.wikimedia.org/T115413

```
error] [4eccbce0] /mw-core/index.php/Special:DeferredRequestDispatcher   ErrorException from line 136 of...\includes\WebResponse.php: PHP Warning: Cannot modify header information - headers already sent
#0 [internal function]: MWExceptionHandler::handleError(integer, string, string, integer, array)
#1 [internal function]: setcookie(string, string, integer, string, string, boolean, boolean)
#2...\includes\WebResponse.php(136): call_user_func(string, string, string, integer, string, string, boolean, boolean)
#3...\includes\MediaWiki.php(538): WebResponse->setCookie(string, string, integer, array)
#4...\includes\MediaWiki.php(494): MediaWiki::preOutputCommit(RequestContext)
#5...\includes\MediaWiki.php(704): MediaWiki->doPreOutputCommit()
#6...\includes\MediaWiki.php(474): MediaWiki->main()
#7...\index.php(43): MediaWiki->run()
```