### PR TITLE
Add possibility to specify precision for a numeric datatype, refs 1125

### DIFF
--- a/i18n/en.json
+++ b/i18n/en.json
@@ -352,5 +352,6 @@
 	"smw-pa-property-predefined_media": "\"$1\" is a predefined property that describes the media type of an uploaded file and is provided by [https://www.semantic-mediawiki.org/wiki/Help:Special_properties Semantic MediaWiki].",
 	"smw-pa-property-predefined_askfo": "\"$1\" is a predefined property that holds the name of the result format used in a query and is provided by [https://www.semantic-mediawiki.org/wiki/Help:Special_properties Semantic MediaWiki].",
 	"smw-pa-property-predefined_askst": "\"$1\" is a predefined property that describes the conditions of the query as a string and is provided by [https://www.semantic-mediawiki.org/wiki/Help:Special_properties Semantic MediaWiki].",
-	"smw-pa-property-predefined_askdu": "\"$1\" is a predefined property containing a time value (in seconds) the query had required to complete its execution and is provided by [https://www.semantic-mediawiki.org/wiki/Help:Special_properties Semantic MediaWiki]."
+	"smw-pa-property-predefined_askdu": "\"$1\" is a predefined property containing a time value (in seconds) the query had required to complete its execution and is provided by [https://www.semantic-mediawiki.org/wiki/Help:Special_properties Semantic MediaWiki].",
+	"smw-pa-property-predefined_prec": "\"$1\" is a predefined property that describes a [https://www.semantic-mediawiki.org/wiki/Help:Display_precision display precision] (in decimal digits) for numeric datatypes."
 }

--- a/i18n/qqq.json
+++ b/i18n/qqq.json
@@ -359,5 +359,6 @@
 	"smw-pa-property-predefined_media": "This informatory message describes the [https://semantic-mediawiki.org/wiki/Help:Special_properties special property].",
 	"smw-pa-property-predefined_askfo": "This informatory message describes the [https://semantic-mediawiki.org/wiki/Help:Special_properties special property].",
 	"smw-pa-property-predefined_askst": "This informatory message describes the [https://semantic-mediawiki.org/wiki/Help:Special_properties special property].",
-	"smw-pa-property-predefined_askdu": "This informatory message describes the [https://semantic-mediawiki.org/wiki/Help:Special_properties special property]."
+	"smw-pa-property-predefined_askdu": "This informatory message describes the [https://semantic-mediawiki.org/wiki/Help:Special_properties special property].",
+	"smw-pa-property-predefined_prec": "This informatory message describes the [https://semantic-mediawiki.org/wiki/Help:Special_properties special property]."
 }

--- a/includes/GlobalFunctions.php
+++ b/includes/GlobalFunctions.php
@@ -87,7 +87,7 @@ function smwfHTMLtoUTF8( $text ) {
  * @deprecated since 2.1, use NumberFormatter instead
  */
 function smwfNumberFormat( $value, $decplaces = 3 ) {
-	return NumberFormatter::getInstance()->formatNumberToLocalizedText( $value, $decplaces );
+	return NumberFormatter::getInstance()->getLocalizedFormattedNumber( $value, $decplaces );
 }
 
 /**

--- a/includes/datavalues/SMW_DV_Quantity.php
+++ b/includes/datavalues/SMW_DV_Quantity.php
@@ -1,6 +1,7 @@
 <?php
 
 use SMW\NumberFormatter;
+use SMW\ApplicationFactory;
 
 /**
  * @ingroup SMWDataValues
@@ -111,11 +112,13 @@ class SMWQuantityValue extends SMWNumberValue {
 
 		$this->m_unitin = $this->m_unitids[$printunit];
 		$this->m_unitvalues = false; // this array depends on m_unitin if displayunits were used, better invalidate it here
+
 		$value = $this->m_dataitem->getNumber() * $this->m_unitfactors[$this->m_unitin];
 
 		$this->m_caption = '';
+
 		if ( $this->m_outformat != '-u' ) { // -u is the format for displaying the unit only
-			$this->m_caption .= ( ( $this->m_outformat != '-' ) && ( $this->m_outformat != '-n' ) ? NumberFormatter::getInstance()->formatNumberToLocalizedText( $value ) : $value );
+			$this->m_caption .= ( ( $this->m_outformat != '-' ) && ( $this->m_outformat != '-n' ) ? NumberFormatter::getInstance()->getLocalizedFormattedNumber( $value, $this->getPrecision() ) : NumberFormatter::getInstance()->getUnformattedNumberByPrecision( $value, $this->getPrecision() ) );
 		}
 
 		if ( ( $printunit !== '' ) && ( $this->m_outformat != '-n' ) ) { // -n is the format for displaying the number only
@@ -164,7 +167,10 @@ class SMWQuantityValue extends SMWNumberValue {
 			return; // we cannot find conversion factors without the property
 		}
 
-		$factors = \SMW\StoreFactory::getStore()->getPropertyValues( $propertyDiWikiPage, new SMWDIProperty( '_CONV' ) );
+		$factors = ApplicationFactory::getInstance()->getStore()->getPropertyValues(
+			$propertyDiWikiPage,
+			new SMWDIProperty( '_CONV' )
+		);
 
 		if ( count( $factors ) == 0 ) { // no custom type
 			$this->addError( wfMessage( 'smw_nounitsdeclared' )->inContentLanguage()->text() );
@@ -225,7 +231,11 @@ class SMWQuantityValue extends SMWNumberValue {
 			return;
 		}
 
-		$dataItems = \SMW\StoreFactory::getStore()->getPropertyValues( $this->m_property->getDIWikiPage(), new SMWDIProperty( '_UNIT' ) );
+		$dataItems = ApplicationFactory::getInstance()->getStore()->getPropertyValues(
+			$this->m_property->getDIWikiPage(),
+			new SMWDIProperty( '_UNIT' )
+		);
+
 		$units = array();
 
 		foreach ( $dataItems as $di ) { // Join all if many annotations exist. Discouraged (random order) but possible.

--- a/includes/datavalues/SMW_DV_Temperature.php
+++ b/includes/datavalues/SMW_DV_Temperature.php
@@ -87,7 +87,7 @@ class SMWTemperatureValue extends SMWNumberValue {
 
 		$this->m_caption = '';
 		if ( $this->m_outformat != '-u' ) { // -u is the format for displaying the unit only
-			$this->m_caption .= ( ( $this->m_outformat != '-' ) && ( $this->m_outformat != '-n' ) ? NumberFormatter::getInstance()->formatNumberToLocalizedText( $value ) : $value );
+			$this->m_caption .= ( ( $this->m_outformat != '-' ) && ( $this->m_outformat != '-n' ) ? NumberFormatter::getInstance()->getLocalizedFormattedNumber( $value, $this->getPrecision() ) : NumberFormatter::getInstance()->getUnformattedNumberByPrecision( $value, $this->getPrecision() ) );
 		}
 		if ( ( $printunit !== '' ) && ( $this->m_outformat != '-n' ) ) { // -n is the format for displaying the number only
 			if ( $this->m_outformat != '-u' ) {

--- a/includes/storage/SQLStore/SMW_Sql3SmwIds.php
+++ b/includes/storage/SQLStore/SMW_Sql3SmwIds.php
@@ -176,6 +176,7 @@ class SMWSql3SmwIds {
 		'_INST' => 4,
 		'_UNIT' => 7,
 		'_IMPO' => 8,
+		'_PREC' => 11,
 		'_CONV' => 12,
 		'_SERV' => 13,
 		'_PVAL' => 14,
@@ -204,7 +205,7 @@ class SMWSql3SmwIds {
 		'_ASKSI' =>  36,
 		'_ASKDE' =>  37,
 //		'_ASKDU' =>  38,
-//		'_ASKID' =>  39
+//		'_ASKID' =>  39,
 	);
 
 	/**

--- a/languages/SMW_Language.php
+++ b/languages/SMW_Language.php
@@ -96,6 +96,7 @@ abstract class SMWLanguage {
 		'Has mime type'      => '_MIME',
 		'Has processing error'          => '_ERRC',
 		'Has processing error text'     => '_ERRT',
+		'Display precision of'  => '_PREC',
 	);
 
 	public function __construct() {

--- a/languages/SMW_LanguageAr.php
+++ b/languages/SMW_LanguageAr.php
@@ -76,7 +76,8 @@ class SMWLanguageAr extends SMWLanguage {
 		'_MEDIA'=> 'Media type',
 		'_MIME' => 'MIME type',
 		'_ERRC' => 'Has processing error',
-		'_ERRT' => 'Has processing error text'
+		'_ERRT' => 'Has processing error text',
+		'_PREC' => 'Display precision of'
 	);
 
 	protected $m_SpecialPropertyAliases = array(

--- a/languages/SMW_LanguageArz.php
+++ b/languages/SMW_LanguageArz.php
@@ -76,7 +76,8 @@ class SMWLanguageArz extends SMWLanguage {
 		'_MEDIA'=> 'Media type',
 		'_MIME' => 'MIME type',
 		'_ERRC' => 'Has processing error',
-		'_ERRT' => 'Has processing error text'
+		'_ERRT' => 'Has processing error text',
+		'_PREC' => 'Display precision of'
 	);
 
 	protected $m_SpecialPropertyAliases = array(

--- a/languages/SMW_LanguageCa.php
+++ b/languages/SMW_LanguageCa.php
@@ -80,7 +80,8 @@ class SMWLanguageCa extends SMWLanguage {
 		'_MEDIA'=> 'Tipus Media',
 		'_MIME' => 'Tipus MIME',
 		'_ERRC' => 'Has processing error',
-		'_ERRT' => 'Has processing error text'
+		'_ERRT' => 'Has processing error text',
+		'_PREC' => 'Display precision of'
 	);
 
 	protected $m_SpecialPropertyAliases = array(

--- a/languages/SMW_LanguageDe.php
+++ b/languages/SMW_LanguageDe.php
@@ -86,7 +86,8 @@ class SMWLanguageDe extends SMWLanguage {
 		'_MEDIA'=> 'Medientyp',
 		'_MIME' => 'MIME-Typ',
 		'_ERRC' => 'Verarbeitungsfehler',
-		'_ERRT' => 'Verarbeitungsfehlerhinweis'
+		'_ERRT' => 'Verarbeitungsfehlerhinweis',
+		'_PREC' => 'Display precision of'
 	);
 
 	protected $m_SpecialPropertyAliases = array(

--- a/languages/SMW_LanguageEn.php
+++ b/languages/SMW_LanguageEn.php
@@ -83,11 +83,13 @@ class SMWLanguageEn extends SMWLanguage {
 		'_MEDIA'=> 'Media type',
 		'_MIME' => 'MIME type',
 		'_ERRC' => 'Has processing error',
-		'_ERRT' => 'Has processing error text'
+		'_ERRT' => 'Has processing error text',
+		'_PREC' => 'Display precision of'
 	);
 
 	protected $m_SpecialPropertyAliases = array(
-		'Display unit' => '_UNIT'
+		'Display unit' => '_UNIT',
+		'Display precision' => '_PREC'
 	);
 
 	protected $m_Namespaces = array(

--- a/languages/SMW_LanguageEs.php
+++ b/languages/SMW_LanguageEs.php
@@ -77,7 +77,8 @@ class SMWLanguageEs extends SMWLanguage {
 		'_MEDIA'=> 'Tipo Media',
 		'_MIME' => 'Tipo MIME',
 		'_ERRC' => 'Has processing error',
-		'_ERRT' => 'Has processing error text'
+		'_ERRT' => 'Has processing error text',
+		'_PREC' => 'Display precision of'
 	);
 
 	protected $m_SpecialPropertyAliases = array(

--- a/languages/SMW_LanguageFi.php
+++ b/languages/SMW_LanguageFi.php
@@ -73,7 +73,8 @@ class SMWLanguageFi extends SMWLanguage {
 		'_MEDIA'=> 'Media type',
 		'_MIME' => 'Mime type',
 		'_ERRC' => 'Has processing error',
-		'_ERRT' => 'Has processing error text'
+		'_ERRT' => 'Has processing error text',
+		'_PREC' => 'Display precision of'
 	);
 
 	protected $m_Namespaces = array(

--- a/languages/SMW_LanguageFr.php
+++ b/languages/SMW_LanguageFr.php
@@ -77,7 +77,8 @@ class SMWLanguageFr extends SMWLanguage {
 		'_MEDIA'=> 'Media type',
 		'_MIME' => 'Mime type',
 		'_ERRC' => 'Has processing error',
-		'_ERRT' => 'Has processing error text'
+		'_ERRT' => 'Has processing error text',
+		'_PREC' => 'Display precision of'
 	);
 
 	protected $m_SpecialPropertyAliases = array(

--- a/languages/SMW_LanguageHe.php
+++ b/languages/SMW_LanguageHe.php
@@ -76,7 +76,8 @@ class SMWLanguageHe extends SMWLanguage {
 		'_MEDIA'=> 'Media type',
 		'_MIME' => 'Mime type',
 		'_ERRC' => 'Has processing error',
-		'_ERRT' => 'Has processing error text'
+		'_ERRT' => 'Has processing error text',
+		'_PREC' => 'Display precision of'
 	);
 
 	protected $m_SpecialPropertyAliases = array(

--- a/languages/SMW_LanguageHu.php
+++ b/languages/SMW_LanguageHu.php
@@ -81,7 +81,8 @@ class SMWLanguageHu extends SMWLanguage {
 		'_MEDIA'=> 'Médiatípusa',
 		'_MIME' => 'MIME-Típusa',
 		'_ERRC' => 'Has processing error',
-		'_ERRT' => 'Has processing error text'
+		'_ERRT' => 'Has processing error text',
+		'_PREC' => 'Display precision of'
 	);
 
 	protected $m_SpecialPropertyAliases = array(

--- a/languages/SMW_LanguageId.php
+++ b/languages/SMW_LanguageId.php
@@ -77,7 +77,8 @@ class SMWLanguageId extends SMWLanguage {
 		'_MEDIA'=> 'Media type',
 		'_MIME' => 'Mime type',
 		'_ERRC' => 'Has processing error',
-		'_ERRT' => 'Has processing error text'
+		'_ERRT' => 'Has processing error text',
+		'_PREC' => 'Display precision of'
 	);
 
 	protected $m_SpecialPropertyAliases = array(

--- a/languages/SMW_LanguageIt.php
+++ b/languages/SMW_LanguageIt.php
@@ -79,7 +79,8 @@ class SMWLanguageIt extends SMWLanguage {
 		'_MEDIA'=> 'Media type',
 		'_MIME' => 'Mime type',
 		'_ERRC' => 'Has processing error',
-		'_ERRT' => 'Has processing error text'
+		'_ERRT' => 'Has processing error text',
+		'_PREC' => 'Display precision of'
 	);
 
 	protected $m_SpecialPropertyAliases = array(

--- a/languages/SMW_LanguageNb.php
+++ b/languages/SMW_LanguageNb.php
@@ -86,7 +86,8 @@ class SMWLanguageNb extends SMWLanguage {
 		'_MEDIA'=> 'Mediatype',
 		'_MIME' => 'MIME-type',
 		'_ERRC' => 'Has processing error',
-		'_ERRT' => 'Has processing error text'
+		'_ERRT' => 'Has processing error text',
+		'_PREC' => 'Display precision of'
 	);
 
 	protected $m_SpecialPropertyAliases = array(

--- a/languages/SMW_LanguageNl.php
+++ b/languages/SMW_LanguageNl.php
@@ -79,7 +79,8 @@ class SMWLanguageNl extends SMWLanguage {
 		'_MEDIA'=> 'Heeft Mediatype',
 		'_MIME' => 'Heeft MIME-type',
 		'_ERRC' => 'Has processing error',
-		'_ERRT' => 'Has processing error text'
+		'_ERRT' => 'Has processing error text',
+		'_PREC' => 'Display precision of'
 	);
 
 	protected $m_SpecialPropertyAliases = array(

--- a/languages/SMW_LanguagePl.php
+++ b/languages/SMW_LanguagePl.php
@@ -95,7 +95,8 @@ class SMWLanguagePl extends SMWLanguage {
 		'_MEDIA'=> 'Media type',
 		'_MIME' => 'Mime type',
 		'_ERRC' => 'Has processing error',
-		'_ERRT' => 'Has processing error text'
+		'_ERRT' => 'Has processing error text',
+		'_PREC' => 'Display precision of'
 	);
 
 	protected $m_SpecialPropertyAliases = array(

--- a/languages/SMW_LanguagePt.php
+++ b/languages/SMW_LanguagePt.php
@@ -84,7 +84,8 @@ class SMWLanguagePt extends SMWLanguage {
 		'_MEDIA'=> 'Media type',
 		'_MIME' => 'Mime type',
 		'_ERRC' => 'Has processing error',
-		'_ERRT' => 'Has processing error text'
+		'_ERRT' => 'Has processing error text',
+		'_PREC' => 'Display precision of'
 	);
 
 	protected $m_SpecialPropertyAliases = array(

--- a/languages/SMW_LanguageRu.php
+++ b/languages/SMW_LanguageRu.php
@@ -79,7 +79,8 @@ class SMWLanguageRu extends SMWLanguage {
 		'_MEDIA'=> 'Тип медиа',
 		'_MIME' => 'MIME-тип',
 		'_ERRC' => 'Has processing error',
-		'_ERRT' => 'Has processing error text'
+		'_ERRT' => 'Has processing error text',
+		'_PREC' => 'Display precision of'
 	);
 
 	protected $m_SpecialPropertyAliases = array(

--- a/languages/SMW_LanguageSk.php
+++ b/languages/SMW_LanguageSk.php
@@ -76,7 +76,8 @@ class SMWLanguageSk extends SMWLanguage {
 		'_MEDIA'=> 'Media type',
 		'_MIME' => 'Mime type',
 		'_ERRC' => 'Has processing error',
-		'_ERRT' => 'Has processing error text'
+		'_ERRT' => 'Has processing error text',
+		'_PREC' => 'Display precision of'
 	);
 
 	protected $m_SpecialPropertyAliases = array(

--- a/languages/SMW_LanguageZh_cn.php
+++ b/languages/SMW_LanguageZh_cn.php
@@ -84,7 +84,8 @@ class SMWLanguageZh_cn extends SMWLanguage {
 		'_MEDIA'=> '媒体类型', //Media type
 		'_MIME' => 'MIME类型', //Mime type
 		'_ERRC' => 'Has processing error',
-		'_ERRT' => 'Has processing error text'
+		'_ERRT' => 'Has processing error text',
+		'_PREC' => 'Display precision of'
 	);
 
 	protected $m_SpecialPropertyAliases = array(

--- a/languages/SMW_LanguageZh_tw.php
+++ b/languages/SMW_LanguageZh_tw.php
@@ -82,7 +82,8 @@ class SMWLanguageZh_tw extends SMWLanguage {
 		'_MEDIA'=> '媒體類型', // Media type
 		'_MIME' => 'MIME類型', // MIME type
 		'_ERRC' => 'Has processing error',
-		'_ERRT' => 'Has processing error text'
+		'_ERRT' => 'Has processing error text',
+		'_PREC' => 'Display precision of'
 	);
 
 	protected $m_SpecialPropertyAliases = array(

--- a/src/NumberFormatter.php
+++ b/src/NumberFormatter.php
@@ -67,24 +67,74 @@ class NumberFormatter {
 	}
 
 	/**
+	 * @since 2.4
+	 *
+	 * @param mixed $value input number
+	 * @param integer|false $precision
+	 *
+	 * @return string
+	 */
+	public function getUnformattedNumberByPrecision( $value, $precision = false ) {
+
+		if ( $precision === false ) {
+			return $value;
+		}
+
+		return $this->doFormatByPrecision(
+			$value,
+			$precision,
+			$this->getDecimalSeparatorForUserLanguage(),
+			''
+		);
+	}
+
+	/**
+	 * @since 2.4
+	 *
+	 * @param mixed $value input number
+	 * @param integer|false $precision
+	 *
+	 * @return string
+	 */
+	public function getFormattedNumberByPrecision( $value, $precision = false ) {
+
+		if ( $precision === false ) {
+			return $value;
+		}
+
+		return $this->doFormatByPrecision(
+			$value,
+			$precision,
+			$this->getDecimalSeparatorForUserLanguage(),
+			$this->getThousandsSeparatorForContentLanguage()
+		);
+	}
+
+	/**
 	 * This method formats a float number value according to the given language and
 	 * precision settings, with some intelligence to produce readable output. Used
 	 * to format a number that was not hand-formatted by a user.
 	 *
 	 * @param mixed $value input number
-	 * @param integer $decplaces optional positive integer, controls how many digits after
+	 * @param integer|false $precision optional positive integer, controls how many digits after
 	 * the decimal point are shown
 	 *
 	 * @since 2.1
 	 *
 	 * @return string
 	 */
-	public function formatNumberToLocalizedText( $value, $decplaces = 3 ) {
+	public function getLocalizedFormattedNumber( $value, $precision = false ) {
 
+		if ( $precision !== false ) {
+			return $this->getFormattedNumberByPrecision( $value, $precision );
+		}
+
+		// BC configuration to keep default behaviour
+		$precision = 3;
 		$decseparator = $this->getDecimalSeparatorForUserLanguage();
 
 		// If number is a trillion or more, then switch to scientific
-		// notation. If number is less than 0.0000001 (i.e. twice decplaces),
+		// notation. If number is less than 0.0000001 (i.e. twice precision),
 		// then switch to scientific notation. Otherwise print number
 		// using number_format. This may lead to 1.200, so then use trim to
 		// remove trailing zeroes.
@@ -93,19 +143,19 @@ class NumberFormatter {
 		// @todo: Don't do all this magic for integers, since the formatting does not fit there
 		//       correctly. E.g. one would have integers formatted as 1234e6, not as 1.234e9, right?
 		// The "$value!=0" is relevant: we want to scientify numbers that are close to 0, but never 0!
-		if ( ( $decplaces > 0 ) && ( $value != 0 ) ) {
+		if ( ( $precision > 0 ) && ( $value != 0 ) ) {
 			$absValue = abs( $value );
 			if ( $absValue >= $this->maxNonExpNumber ) {
 				$doScientific = true;
-			} elseif ( $absValue < pow( 10, - $decplaces ) ) {
+			} elseif ( $absValue < pow( 10, - $precision ) ) {
 				$doScientific = true;
 			} elseif ( $absValue < 1 ) {
-				if ( $absValue < pow( 10, - $decplaces ) ) {
+				if ( $absValue < pow( 10, - $precision ) ) {
 					$doScientific = true;
 				} else {
 					// Increase decimal places for small numbers, e.g. .00123 should be 5 places.
 					for ( $i = 0.1; $absValue <= $i; $i *= 0.1 ) {
-						$decplaces++;
+						$precision++;
 					}
 				}
 			}
@@ -122,18 +172,16 @@ class NumberFormatter {
 				$value = str_replace( '.', $decseparator, $value );
 			}
 		} else {
-			// Format to some level of precision; number_format does rounding and locale formatting,
-			// x and y are used temporarily since number_format supports only single characters for either
-			$value = number_format( $value, $decplaces, 'x', 'y' );
-			$value = str_replace(
-				array( 'x', 'y' ),
-				array( $decseparator, $this->getThousandsSeparatorForContentLanguage() ),
-				$value
+			$value = $this->doFormatByPrecision(
+				$value,
+				$precision,
+				$decseparator,
+				$this->getThousandsSeparatorForContentLanguage()
 			);
 
 			// Make it more readable by removing ending .000 from nnn.000
 			//    Assumes substr is faster than a regular expression replacement.
-			$end = $decseparator . str_repeat( '0', $decplaces );
+			$end = $decseparator . str_repeat( '0', $precision );
 			$lenEnd = strlen( $end );
 
 			if ( substr( $value, - $lenEnd ) === $end ) {
@@ -188,6 +236,23 @@ class NumberFormatter {
 		}
 
 		return $this->decimalSeparatorInUserLanguage;
+	}
+
+	private function doFormatByPrecision( $value, $precision = false, $decimal, $thousand ) {
+		// Format to some level of precision; number_format does rounding and
+		// locale formatting, x and y are used temporarily since number_format
+		// supports only single characters for either
+		$value = number_format( (float)$value, $precision, 'x', 'y' );
+		$value = str_replace(
+			array( 'x', 'y' ),
+			array(
+				$decimal,
+				$thousand
+			),
+			$value
+		);
+
+		return $value;
 	}
 
 }

--- a/src/PropertyRegistry.php
+++ b/src/PropertyRegistry.php
@@ -324,6 +324,7 @@ class PropertyRegistry {
 			'_ASKDU' => array( '_num', true, true ), // "has query duration"
 			'_MEDIA' => array( '_txt', true, false ), // "has media type"
 			'_MIME'  => array( '_txt', true, false ), // "has mime type"
+			'_PREC'  => array( '_num', true, true ), // "Display precision of"
 		);
 
 		foreach ( $this->datatypeLabels as $id => $label ) {

--- a/src/PropertySpecificationChangeNotifier.php
+++ b/src/PropertySpecificationChangeNotifier.php
@@ -81,8 +81,9 @@ class PropertySpecificationChangeNotifier {
 			return;
 		}
 
-		$this->compareFor( DIProperty::TYPE_HAS_TYPE );
-		$this->compareFor( DIProperty::TYPE_CONVERSION );
+		$this->compareFor( '_TYPE' );
+		$this->compareFor( '_CONV' );
+		$this->compareFor( '_PREC' );
 
 		foreach ( $this->propertiesToCompare as $propertyKey ) {
 			$this->compareFor( $propertyKey );

--- a/src/SQLStore/PropertyTableInfoFetcher.php
+++ b/src/SQLStore/PropertyTableInfoFetcher.php
@@ -51,7 +51,7 @@ class PropertyTableInfoFetcher {
 	 */
 	private $fixedSpecialProperties = array(
 		// property declarations
-		'_TYPE', '_UNIT', '_CONV', '_PVAL', '_LIST', '_SERV',
+		'_TYPE', '_UNIT', '_CONV', '_PVAL', '_LIST', '_SERV', '_PREC',
 		// query statistics (very frequently used)
 		'_ASK', '_ASKDE', '_ASKSI', '_ASKFO', '_ASKST', '_ASKDU',
 		// subproperties, classes, and instances

--- a/tests/phpunit/Integration/ByJsonScript/Fixtures/p-0410.json
+++ b/tests/phpunit/Integration/ByJsonScript/Fixtures/p-0410.json
@@ -1,0 +1,419 @@
+{
+	"description": "Test in-text annotation on `_num`/`_tem`/`_qty` type with denoted precision (`_PREC`) and/or `-p<num>` printout precision marker (#1335, en)",
+	"properties": [
+		{
+			"name": "Has temperature with prec4",
+			"contents": "[[Has type::Temperature]] [[Display precision of::4]]"
+		},
+		{
+			"name": "Has temperature with prec2",
+			"contents": "[[Has type::Temperature]] [[Display precision of::2]]"
+		},
+		{
+			"name": "Has temperature",
+			"contents": "[[Has type::Temperature]]"
+		},
+		{
+			"name": "Has number with prec4",
+			"contents": "[[Has type::Number]] [[Display precision of::4]]"
+		},
+		{
+			"name": "Has number with prec2",
+			"contents": "[[Has type::Number]] [[Display precision of::2]]"
+		},
+		{
+			"name": "Has number",
+			"contents": "[[Has type::Number]]"
+		},
+		{
+			"name": "Has area",
+			"contents": "[[Has type::Quantity]] [[Corresponds to::1 km²]] [[Corresponds to::0.38610 sq mi]] [[Corresponds to::1000 m²]]"
+		},
+		{
+			"name": "Has area with prec4",
+			"contents": "[[Has type::Quantity]] [[Corresponds to::1 km²]] [[Corresponds to::0.38610 sq mi]] [[Corresponds to::1000 m²]] [[Display precision of::4]]"
+		},
+		{
+			"name": "Has area with prec2",
+			"contents": "[[Has type::Quantity]] [[Corresponds to::1 km²]] [[Corresponds to::0.38610 sq mi]] [[Corresponds to::1000 m²]] [[Display precision of::2]]"
+		},
+		{
+			"name": "Has area with prec0",
+			"contents": "[[Has type::Quantity]] [[Corresponds to::1 km²]] [[Corresponds to::0.38610 sq mi]] [[Corresponds to::1000 m²]] [[Display precision of::0]]"
+		},
+		{
+			"name": "Has currency with prec2",
+			"contents": "[[Has type::Quantity]] [[Display units::€, ¥]] [[Corresponds to:: € 1.00]] [[Corresponds to::¥,JPY,Japanese Yen 114.2121]] [[Display precision of::2]]"
+		},
+		{
+			"name": "Has currency with prec4",
+			"contents": "[[Has type::Quantity]] [[Display units::€, ¥]] [[Corresponds to:: € 1.00]] [[Corresponds to::¥,JPY,Japanese Yen 114.2121]] [[Display precision of::4]]"
+		}
+	],
+	"subjects": [
+		{
+			"name": "Example/P0410/1",
+			"contents": "[[Has temperature with prec4::32 °F]] [[Has temperature with prec4::100 °C]]"
+		},
+		{
+			"name": "Example/P0410/2",
+			"contents": "[[Has temperature with prec2::32 °F]] [[Has temperature with prec2::100 °C]]"
+		},
+		{
+			"name": "Example/P0410/1/1",
+			"contents": "{{#ask: [[Has temperature with prec4::32 °F]] |?Has temperature with prec4 |format=table }}"
+		},
+		{
+			"name": "Example/P0410/2/1",
+			"contents": "{{#ask: [[Has temperature with prec2::32 °F]] |?Has temperature with prec2 |format=table }}"
+		},
+		{
+			"name": "Example/P0410/3/1",
+			"contents": "[[Has number with prec4::.001]] [[Has number with prec2::.001]] [[Has number::.003]]"
+		},
+		{
+			"name": "Example/P0410/3/2",
+			"contents": "[[Has number with prec4::.005]] [[Has number with prec2::.005]] [[Has number::.008]]"
+		},
+		{
+			"name": "Example/P0410/3/3",
+			"contents": "[[Has number with prec2::42]] [[Has number::42]]"
+		},
+		{
+			"name": "Example/P0410/3/4",
+			"contents": "[[Has number with prec2::10,000]] [[Has number::10,000]]"
+		},
+		{
+			"name": "Example/P0410/3",
+			"contents": "{{#ask: [[~Example/P0410/3/*]] |?Has number with prec4 |?Has number with prec2 |?Has number |format=table }}"
+		},
+		{
+			"name": "Example/P0410/4/1",
+			"contents": "[[Has area with prec2::10,000 m²]] [[Has area with prec4::0.02 km²]] [[Has area with prec0::3.33 km²]]"
+		},
+		{
+			"name": "Example/P0410/4",
+			"contents": "{{#ask: [[~Example/P0410/4/*]] |?Has area with prec4 |?Has area with prec2 |?Has area with prec0 |format=table }}"
+		},
+		{
+			"name": "Example/P0410/5/1",
+			"contents": "[[Has currency with prec2::€ 5]] [[Has currency with prec4::¥ 100]]"
+		},
+		{
+			"name": "Example/P0410/5/2",
+			"contents": "[[Has currency with prec2::€ 5,000]] [[Has currency with prec4::¥ 0.50]]"
+		},
+		{
+			"name": "Example/P0410/5",
+			"contents": "{{#ask: [[~Example/P0410/5/*]] |?Has currency with prec4 |?Has currency with prec2 |format=table }}"
+		},
+		{
+			"name": "Example/P0410/6/1",
+			"contents": "[[Has number::10,000]] [[Has number::.005]] [[Has number::42.005]] [[Has number::1001]]"
+		},
+		{
+			"name": "Example/P0410/6a",
+			"contents": "{{#ask: [[~Example/P0410/6/*]] |?Has number#-p2 |format=table }}"
+		},
+		{
+			"name": "Example/P0410/6b",
+			"contents": "{{#ask: [[~Example/P0410/6/*]] |?Has number#-p4 |format=table }}"
+		},
+		{
+			"name": "Example/P0410/6c",
+			"contents": "{{#ask: [[~Example/P0410/6/*]] |?Has number#-p3-n |format=table }}"
+		},
+		{
+			"name": "Example/P0410/7/1",
+			"contents": "[[Has area::10,000 m²]] [[Has area::0.02 km²]] [[Has area::3.33 km²]]"
+		},
+		{
+			"name": "Example/P0410/7a",
+			"contents": "{{#ask: [[~Example/P0410/7/*]] |?Has area#-p2 |format=table }}"
+		},
+		{
+			"name": "Example/P0410/7b",
+			"contents": "{{#ask: [[~Example/P0410/7/*]] |?Has area#m²-p3 |format=table }}"
+		},
+		{
+			"name": "Example/P0410/7c",
+			"contents": "{{#ask: [[~Example/P0410/7/*]] |?Has area#-n-p2 |format=table }}"
+		},
+		{
+			"name": "Example/P0410/8/1",
+			"contents": "[[Has temperature::32 °F]] [[Has temperature::100 °C]]"
+		},
+		{
+			"name": "Example/P0410/8a",
+			"contents": "{{#ask: [[~Example/P0410/8/*]] |?Has temperature#-p2 |format=table }}"
+		},
+		{
+			"name": "Example/P0410/8b",
+			"contents": "{{#ask: [[~Example/P0410/8/*]] |?Has temperature#°C-p3 |format=table }}"
+		},
+		{
+			"name": "Example/P0410/8c",
+			"contents": "{{#ask: [[~Example/P0410/8/*]] |?Has temperature#-n-p2 |format=table }}"
+		}
+	],
+	"parser-testcases": [
+		{
+			"about": "#0",
+			"subject": "Example/P0410/1",
+			"store": {
+				"semantic-data": {
+					"strict-mode-valuematch": false,
+					"propertyCount": 3,
+					"propertyKeys": [ "Has_temperature_with_prec4", "_SKEY", "_MDAT" ],
+					"propertyValues": [ 273.15, 373.15 ]
+				}
+			}
+		},
+		{
+			"about": "#1",
+			"subject": "Example/P0410/2",
+			"store": {
+				"semantic-data": {
+					"strict-mode-valuematch": false,
+					"propertyCount": 3,
+					"propertyKeys": [ "Has_temperature_with_prec2", "_SKEY", "_MDAT" ],
+					"propertyValues": [ 273.15, 373.15 ]
+				}
+			}
+		},
+		{
+			"about": "#2",
+			"subject": "Example/P0410/1/1",
+			"expected-output": {
+				"to-contain": [
+					"data-sort-value=\"273.15\"",
+					"<span class=\"smwtext\">273.1500&#160;K</span>",
+					"0.0000&#160;°C",
+					"32.0000&#160;°F",
+					"491.6700&#160;°R",
+					"<span class=\"smwtext\">373.1500&#160;K</span>",
+					"100.0000&#160;°C",
+					"212.0000&#160;°F",
+					"671.6700&#160;°R"
+				]
+			}
+		},
+		{
+			"about": "#3",
+			"subject": "Example/P0410/2/1",
+			"expected-output": {
+				"to-contain": [
+					"data-sort-value=\"273.15\"",
+					"<span class=\"smwtext\">273.15&#160;K</span>",
+					"0.00&#160;°C",
+					"32.00&#160;°F",
+					"491.67&#160;°R",
+					"<span class=\"smwtext\">373.15&#160;K</span>",
+					"100.00&#160;°C",
+					"212.00&#160;°F",
+					"671.67&#160;°R"
+				]
+			}
+		},
+		{
+			"about": "#4 Prec2 vs Prec4 incl. rounding on output for plain number",
+			"subject": "Example/P0410/3",
+			"expected-output": {
+				"to-contain": [
+					"data-sort-value=\"0.001\" class=\"Has-number-with-prec4 smwtype_num\">0.0010",
+					"data-sort-value=\"0.001\" class=\"Has-number-with-prec2 smwtype_num\">0.00",
+					"data-sort-value=\"0.003\" class=\"Has-number smwtype_num\">0.003",
+					"data-sort-value=\"0.005\" class=\"Has-number-with-prec4 smwtype_num\">0.0050",
+					"data-sort-value=\"0.005\" class=\"Has-number-with-prec2 smwtype_num\">0.01",
+					"data-sort-value=\"0.008\" class=\"Has-number smwtype_num\">0.008",
+					"data-sort-value=\"42\" class=\"Has-number-with-prec2 smwtype_num\">42.00",
+					"data-sort-value=\"42\" class=\"Has-number smwtype_num\">42",
+					"data-sort-value=\"10000\" class=\"Has-number-with-prec2 smwtype_num\">10,000.00",
+					"data-sort-value=\"10000\" class=\"Has-number smwtype_num\">10,000"
+				]
+			}
+		},
+		{
+			"about": "#5 Prec2 vs Prec4 vs Prc0 quantity output",
+			"subject": "Example/P0410/4",
+			"expected-output": {
+				"to-contain": [
+					"data-sort-value=\"0.02\" class=\"Has-area-with-prec4 smwtype_qty\"",
+					"0.0200&#160;km²",
+					"0.0077&#160;sqmi",
+					"20.0000&#160;m²",
+					"data-sort-value=\"10\" class=\"Has-area-with-prec2 smwtype_qty\"",
+					"10.00&#160;km²",
+					"3.86&#160;sqmi",
+					"10,000.00&#160;m²",
+					"data-sort-value=\"3.33\" class=\"Has-area-with-prec0 smwtype_qty\"",
+					"3&#160;km²",
+					"1&#160;sqmi",
+					"3,330&#160;m²"
+				]
+			}
+		},
+		{
+			"about": "#6 on currency output",
+			"subject": "Example/P0410/5",
+			"expected-output": {
+				"to-contain": [
+					"data-sort-value=\"0.87556397264388\" class=\"Has-currency-with-prec4 smwtype_qty\"",
+					"€&#160;0.8756",
+					"¥&#160;100.0000",
+					"data-sort-value=\"5\" class=\"Has-currency-with-prec2 smwtype_qty\"",
+					"€&#160;5.00",
+					"¥&#160;571.06",
+					"data-sort-value=\"0.0043778198632194\" class=\"Has-currency-with-prec4 smwtype_qty\"",
+					"€&#160;0.0044",
+					"¥&#160;0.5000",
+					"data-sort-value=\"5000\" class=\"Has-currency-with-prec2 smwtype_qty\"",
+					"€&#160;5,000.00",
+					"¥&#160;571,060.50"
+				]
+			}
+		},
+		{
+			"about": "#7 on number output without property defined precision, uses -p4 printout marker",
+			"subject": "Example/P0410/6a",
+			"expected-output": {
+				"to-contain": [
+					"data-sort-value=\"10000\" class=\"Has-number smwtype_num\"",
+					"10,000.00",
+					"0.01",
+					"42.01",
+					"1,001.00"
+				]
+			}
+		},
+		{
+			"about": "#8 on number output without property defined precision, uses -p4 printout marker",
+			"subject": "Example/P0410/6b",
+			"expected-output": {
+				"to-contain": [
+					"data-sort-value=\"10000\" class=\"Has-number smwtype_num\"",
+					"10,000.0000",
+					"0.0050",
+					"42.0050",
+					"1,001.0000"
+				]
+			}
+		},
+		{
+			"about": "#9 on number output without property defined precision, uses -p3-n printout marker",
+			"subject": "Example/P0410/6c",
+			"expected-output": {
+				"to-contain": [
+					"data-sort-value=\"10000\" class=\"Has-number smwtype_num\"",
+					"10000.000",
+					"0.005",
+					"42.005",
+					"1001.000"
+				]
+			}
+		},
+		{
+			"about": "#10 on quantity output without property defined precision, uses -p2 printout marker",
+			"subject": "Example/P0410/7a",
+			"expected-output": {
+				"to-contain": [
+					"data-sort-value=\"10\" class=\"Has-area smwtype_qty\"",
+					"10.00&#160;km²",
+					"3.86&#160;sqmi",
+					"10,000.00&#160;m²",
+					"0.02&#160;km²",
+					"0.01&#160;sqmi",
+					"20.00&#160;m²",
+					"3.33&#160;km²",
+					"1.29&#160;sqmi",
+					"3,330.00&#160;m²"
+				]
+			}
+		},
+		{
+			"about": "#11 on quantity output without property defined precision, uses m²-p3 printout marker",
+			"subject": "Example/P0410/7b",
+			"expected-output": {
+				"to-contain": [
+					"data-sort-value=\"10\" class=\"Has-area smwtype_qty\"",
+					"10,000.000&#160;m²",
+					"10.000&#160;km²",
+					"3.861&#160;sqmi",
+					"20.000&#160;m²",
+					"0.020&#160;km²",
+					"0.008&#160;sqmi",
+					"3,330.000&#160;m²",
+					"3.330&#160;km²",
+					"1.286&#160;sqmi"
+				]
+			}
+		},
+		{
+			"about": "#12 on quantity output without property defined precision, uses -n-p2 printout marker",
+			"subject": "Example/P0410/7c",
+			"expected-output": {
+				"to-contain": [
+					"data-sort-value=\"10\" class=\"Has-area smwtype_qty\"",
+					"10.00",
+					"0.02",
+					"3.33"
+				]
+			}
+		},
+		{
+			"about": "#13 on temperature output without property defined precision, uses -p2 printout marker",
+			"subject": "Example/P0410/8a",
+			"expected-output": {
+				"to-contain": [
+					"data-sort-value=\"273.15\" class=\"Has-temperature smwtype_tem\"",
+					"class=\"smwtext\">273.15&#160;K",
+					"0.00&#160;°C",
+					"32.00&#160;°F",
+					"491.67&#160;°R",
+					"class=\"smwtext\">373.15&#160;K",
+					"100.00&#160;°C",
+					"212.00&#160;°F",
+					"671.67&#160;°R"
+				]
+			}
+		},
+		{
+			"about": "#14 on temperature output without property defined precision, uses °C-p3 printout marker",
+			"subject": "Example/P0410/8b",
+			"expected-output": {
+				"to-contain": [
+					"data-sort-value=\"273.15\" class=\"Has-temperature smwtype_tem\"",
+					"class=\"smwtext\">0.000&#160;°C",
+					"273.150&#160;K",
+					"32.000&#160;°F",
+					"491.670&#160;°R",
+					"class=\"smwtext\">100.000&#160;°C",
+					"373.150&#160;K",
+					"212.000&#160;°F",
+					"671.670&#160;°R"
+				]
+			}
+		},
+		{
+			"about": "#15 on temperature output without property defined precision, uses -n-p2 printout marker",
+			"subject": "Example/P0410/8c",
+			"expected-output": {
+				"to-contain": [
+					"data-sort-value=\"273.15\" class=\"Has-temperature smwtype_tem\"",
+					"273.15",
+					"373.15"
+				]
+			}
+		}
+	],
+	"settings": {
+		"wgContLang": "en",
+		"wgLang": "en"
+	},
+	"meta": {
+
+		"version": "0.1",
+		"is-incomplete": false,
+		"debug": false
+	}
+}

--- a/tests/phpunit/Integration/ByJsonScript/README.md
+++ b/tests/phpunit/Integration/ByJsonScript/README.md
@@ -1,5 +1,5 @@
 ## Fixtures
-Contains 86 files:
+Contains 87 files:
 
 ### F
 * [f-0001.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/ByJsonScript/Fixtures/f-0001.json) Test format=debug output
@@ -37,6 +37,7 @@ Contains 86 files:
 * [p-0407.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/ByJsonScript/Fixtures/p-0407.json) Test in-text annotation for a redirect that is pointing to a deleted target (#1105)
 * [p-0408.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/ByJsonScript/Fixtures/p-0408.json) Test in-text annotation for multiple property assignment using non-strict parser mode (#1252, en)
 * [p-0409.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/ByJsonScript/Fixtures/p-0409.json) Test in-text annotation (and #subobject) for when record type points to another record type and is used as annotation to return a `_ERRC` (#1303)
+* [p-0410.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/ByJsonScript/Fixtures/p-0410.json) Test in-text annotation on `_num`/`_tem`/`_qty` type with denoted precision (`_PREC`) and/or `-p<num>` printout precision marker (#1335, en)
 * [p-0701.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/ByJsonScript/Fixtures/p-0701.json) Test to create inverted annotation using a #ask/template combination (#711, `import-annotation=true`)
 * [p-0702.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/ByJsonScript/Fixtures/p-0702.json) Test #ask with `format=table` on inverse property/printrquest (#1270, en)
 * [p-0901.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/ByJsonScript/Fixtures/p-0901.json) Test #ask on moved redirected subject (#1086)
@@ -97,4 +98,4 @@ Contains 86 files:
 ### S
 * [s-0001.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/ByJsonScript/Fixtures/s-0001.json) Test output of `Special:Properties` (en, skip-on sqlite, 1.19)
 
--- Last updated on 2015-12-30 by `readmeContentsBuilder.php`
+-- Last updated on 2016-01-06 by `readmeContentsBuilder.php`

--- a/tests/phpunit/includes/NumberFormatterTest.php
+++ b/tests/phpunit/includes/NumberFormatterTest.php
@@ -35,13 +35,26 @@ class NumberFormatterTest extends \PHPUnit_Framework_TestCase {
 	/**
 	 * @dataProvider numberProvider
 	 */
-	public function testFormatNumberToLocalizedText( $maxNonExpNumber, $number, $expected ) {
+	public function testLocalizedFormattedNumber( $maxNonExpNumber, $number, $expected ) {
 
 		$instance = new NumberFormatter( $maxNonExpNumber );
 
 		$this->assertEquals(
 			$expected,
-			$instance->formatNumberToLocalizedText( $number )
+			$instance->getLocalizedFormattedNumber( $number )
+		);
+	}
+
+	/**
+	 * @dataProvider unformattedNumberByPrecisionProvider
+	 */
+	public function testGetUnformattedNumberByPrecision( $maxNonExpNumber, $number, $precision, $expected ) {
+
+		$instance = new NumberFormatter( $maxNonExpNumber );
+
+		$this->assertEquals(
+			$expected,
+			$instance->getUnformattedNumberByPrecision( $number, $precision )
 		);
 	}
 
@@ -69,6 +82,46 @@ class NumberFormatterTest extends \PHPUnit_Framework_TestCase {
 			10000000,
 			1000000,
 			'1,000,000'
+		);
+
+		return $provider;
+	}
+
+	public function unformattedNumberByPrecisionProvider() {
+
+		$provider[] = array(
+			10000,
+			1000,
+			2,
+			'1000.00'
+		);
+
+		$provider[] = array(
+			10000,
+			1000.42,
+			3,
+			'1000.420'
+		);
+
+		$provider[] = array(
+			10000,
+			1000000,
+			0,
+			'1000000'
+		);
+
+		$provider[] = array(
+			10000000,
+			1000000,
+			2,
+			'1000000.00'
+		);
+
+		$provider[] = array(
+			10000000,
+			1000000,
+			false,
+			'1000000'
 		);
 
 		return $provider;


### PR DESCRIPTION
`[[Display precision of::<int>]]` can declare a scale for decimal precision to a numeric property type so that display output can be restricted to something like 2 digits as in `€ 42.45, € 17.14, € 60.00`.

`Display precision of` only restricts output representation and does not interfere with the internal "full" precision.

It is expected that values are transformed using:

`[[Display precision of::2]]`

- 0.001 -> 0.00
- 0.005 -> 0.01
- € 60  -> € 60.00
- 30.445 € -> € 30.45 (3.00 ¥, 32.27 $, 21.31 £)
- 100 °F -> 310.93 K (37.78 °C, 100.00 °F, 559.67 °R)

`[[Display precision of::4]]`

- 100 °F -> 310.9278 K (37.7778 °C, 100.0000 °F, 559.6700 °R)
- 30.445 € -> € 30.4450 (3.0000 ¥, 32.2717 $, 21.3115 £)

refs #1125, https://phabricator.wikimedia.org/T46910