### PR TITLE
Add MonolingualTextValue

### DIFF
--- a/SemanticMediaWiki.settings.php
+++ b/SemanticMediaWiki.settings.php
@@ -959,6 +959,9 @@ $GLOBALS['smwgEnabledInTextAnnotationParserStrictMode'] = true;
 # behaviour is not expected to be altered, nevertheless it is recommended that
 # the setting is enabled to improve user friendliness in terms of query execution.
 #
+# - SMW_DV_MLTV_LCODE (MonolingualTextValue) is to require a language code in order
+# for a DV to be completed otherwise a MLTV can operate without a language code
+#
 # @since 2.4
 ##
-$GLOBALS['smwgDVFeatures'] = SMW_DV_PROV_REDI;
+$GLOBALS['smwgDVFeatures'] = SMW_DV_PROV_REDI | SMW_DV_MLTV_LCODE;

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -354,5 +354,13 @@
 	"smw-pa-property-predefined_askst": "\"$1\" is a predefined property that describes the conditions of the query as a string and is provided by [https://www.semantic-mediawiki.org/wiki/Help:Special_properties Semantic MediaWiki].",
 	"smw-pa-property-predefined_askdu": "\"$1\" is a predefined property containing a time value (in seconds) the query had required to complete its execution and is provided by [https://www.semantic-mediawiki.org/wiki/Help:Special_properties Semantic MediaWiki].",
 	"smw-pa-property-predefined_prec": "\"$1\" is a predefined property that describes a [https://www.semantic-mediawiki.org/wiki/Help:Display_precision display precision] (in decimal digits) for numeric datatypes.",
-	"smw-sp-types-geo-not-available": "[https://www.semantic-mediawiki.org/wiki/Semantic_Maps Semantic Maps] was not detected therefore \"$1\" is restricted in its capacity to operate."
+	"smw-sp-types-geo-not-available": "[https://www.semantic-mediawiki.org/wiki/Semantic_Maps Semantic Maps] was not detected therefore \"$1\" is restricted in its capacity to operate.",
+	"smw-datavalue-monolingual-dataitem-missing": "An expected item for building a monolingual compound value is missing.",
+	"smw-datavalue-monolingual-lcode-parenthesis":"($1)",
+	"smw-datavalue-languagecode-missing": "For the \"$1\" annotation, the parser was unable to determine a language code (i.e. \"foo@en\").",
+	"smw-datavalue-languagecode-invalid": "\"$1\" was not recognized as a supported language code.",
+	"smw-pa-property-predefined_lcode": "\"$1\" is a predefined property that represents a BCP47 formatted language code and is provided by [https://www.semantic-mediawiki.org/wiki/Help:Special_properties Semantic MediaWiki].",
+	"smw-sp-types_mlt_rec": "\"$1\" is a [https://www.semantic-mediawiki.org/wiki/Help:Container container] datatype that associates a text value with a specific [[Property:Language code|language code]].",
+	"smw-sp-types-mlt-lcode": "The datatype does {{PLURAL:$2|require|not require}} a language code (i.e. {{PLURAL:$2|a value annotation without a language code is not accepted|a value annotation without a language code is accepted}}).",
+	"smw-pa-property-predefined_text": "\"$1\" is a predefined property that represents text of arbitrary length and is provided by [https://www.semantic-mediawiki.org/wiki/Help:Special_properties Semantic MediaWiki]."
 }

--- a/includes/Defines.php
+++ b/includes/Defines.php
@@ -140,4 +140,5 @@ define( 'SMW_UJ_PM_CLASTMDATE', 4 ); // compare last modified
   */
 define( 'SMW_DV_NONE', 0 );
 define( 'SMW_DV_PROV_REDI', 2 );  // PropertyValue to follow a property redirect target
+define( 'SMW_DV_MLTV_LCODE', 4 );  // MonolingualTextValue requires language code
 /**@}*/

--- a/includes/specials/SMW_SpecialTypes.php
+++ b/includes/specials/SMW_SpecialTypes.php
@@ -149,10 +149,9 @@ class SMWSpecialTypes extends SpecialPage {
 			$typeValue->getDataItem()->getFragment()
 		);
 
+		$escapedTypeLabel = htmlspecialchars( $typeValue->getWikiValue() );
+
 		if ( $typeValue->getDataItem()->getFragment() === '_geo' ) {
-
-			$escapedTypeLabel = htmlspecialchars( $typeValue->getWikiValue() );
-
 			if ( $dataValue instanceof \SMWErrorValue ) {
 				$html = \Html::rawElement(
 					'p',
@@ -160,6 +159,14 @@ class SMWSpecialTypes extends SpecialPage {
 					wfMessage( 'smw-sp-types-geo-not-available', $escapedTypeLabel )->parse()
 				);
 			}
+		}
+
+		if ( $typeValue->getDataItem()->getFragment() === '_mlt_rec' ) {
+			$html = \Html::rawElement(
+				'p',
+				array(),
+				wfMessage( 'smw-sp-types-mlt-lcode', $escapedTypeLabel, ( $dataValue->needsLanguageCode() ? 1 : 2 ) )->parse()
+			);
 		}
 
 		return $html;

--- a/includes/storage/SQLStore/SMW_Sql3SmwIds.php
+++ b/includes/storage/SQLStore/SMW_Sql3SmwIds.php
@@ -205,7 +205,8 @@ class SMWSql3SmwIds {
 		'_ASKSI' =>  36,
 		'_ASKDE' =>  37,
 //		'_ASKDU' =>  38,
-//		'_ASKID' =>  39,
+		'_LCODE' =>  40,
+		'_TEXT'  =>  41,
 	);
 
 	/**

--- a/languages/SMW_Language.php
+++ b/languages/SMW_Language.php
@@ -66,7 +66,8 @@ abstract class SMWLanguage {
 		'Email'                 => '_ema',
 		'Annotation URI'        => '_anu',
 		'Telephone number'      => '_tel',
-		'Record'                => '_rec'
+		'Record'                => '_rec',
+		'Monolingual text'      => '_mlt_rec', // need the _rec to allow for special treatment
 	);
 	/// Default English aliases for special property names (typically used in all languages)
 	static protected $enPropertyAliases = array(
@@ -97,6 +98,8 @@ abstract class SMWLanguage {
 		'Has processing error'          => '_ERRC',
 		'Has processing error text'     => '_ERRT',
 		'Display precision of'  => '_PREC',
+		'Language code'  => '_LCODE',
+		'Text'           => '_TEXT',
 	);
 
 	public function __construct() {

--- a/languages/SMW_LanguageAr.php
+++ b/languages/SMW_LanguageAr.php
@@ -39,6 +39,7 @@ class SMWLanguageAr extends SMWLanguage {
 		'_tel' => 'رقم الهاتف',  // name of the telephone (URI) type
 		'_rec' => 'تسجيل', // name of record data type
 		'_qty' => 'Quantity', // name of the number type with units of measurement //TODO: translate
+		'_mlt_rec' => 'Monolingual text',
 	);
 
 	protected $m_DatatypeAliases = array(
@@ -77,7 +78,9 @@ class SMWLanguageAr extends SMWLanguage {
 		'_MIME' => 'MIME type',
 		'_ERRC' => 'Has processing error',
 		'_ERRT' => 'Has processing error text',
-		'_PREC' => 'Display precision of'
+		'_PREC'  => 'Display precision of',
+		'_LCODE' => 'Language code',
+		'_TEXT'  => 'Text',
 	);
 
 	protected $m_SpecialPropertyAliases = array(

--- a/languages/SMW_LanguageArz.php
+++ b/languages/SMW_LanguageArz.php
@@ -39,6 +39,7 @@ class SMWLanguageArz extends SMWLanguage {
 		'_tel' => 'Telephone number',  // name of the telephone (URI) type //TODO: translate
 		'_rec' => 'Record', // name of record data type //TODO: translate
 		'_qty' => 'Quantity', // name of the number type with units of measurement //TODO: translate
+		'_mlt_rec' => 'Monolingual text',
 	);
 
 	protected $m_DatatypeAliases = array(
@@ -77,7 +78,9 @@ class SMWLanguageArz extends SMWLanguage {
 		'_MIME' => 'MIME type',
 		'_ERRC' => 'Has processing error',
 		'_ERRT' => 'Has processing error text',
-		'_PREC' => 'Display precision of'
+		'_PREC'  => 'Display precision of',
+		'_LCODE' => 'Language code',
+		'_TEXT'  => 'Text',
 	);
 
 	protected $m_SpecialPropertyAliases = array(

--- a/languages/SMW_LanguageCa.php
+++ b/languages/SMW_LanguageCa.php
@@ -39,6 +39,7 @@ class SMWLanguageCa extends SMWLanguage {
 		'_tel' => 'Número de telèfon',  // name of the telephone (URI) type
 		'_rec' => 'Registre', // name of record data type
 		'_qty' => 'Quantitat', // name of the number type with units of measurement
+		'_mlt_rec' => 'Monolingual text',
 	);
 
 	protected $m_DatatypeAliases = array(
@@ -81,7 +82,9 @@ class SMWLanguageCa extends SMWLanguage {
 		'_MIME' => 'Tipus MIME',
 		'_ERRC' => 'Has processing error',
 		'_ERRT' => 'Has processing error text',
-		'_PREC' => 'Display precision of'
+		'_PREC'  => 'Display precision of',
+		'_LCODE' => 'Language code',
+		'_TEXT'  => 'Text',
 	);
 
 	protected $m_SpecialPropertyAliases = array(

--- a/languages/SMW_LanguageDe.php
+++ b/languages/SMW_LanguageDe.php
@@ -48,6 +48,7 @@ class SMWLanguageDe extends SMWLanguage {
 		'_tel' => 'Telefonnummer', // name of the telephone number URI datatype
 		'_rec' => 'Verbund', // name of the record datatype
 		'_qty' => 'Maß', // name of the quantity datatype
+		'_mlt_rec' => 'Monolingual text',
 	);
 
 	protected $m_DatatypeAliases = array(
@@ -87,7 +88,9 @@ class SMWLanguageDe extends SMWLanguage {
 		'_MIME' => 'MIME-Typ',
 		'_ERRC' => 'Verarbeitungsfehler',
 		'_ERRT' => 'Verarbeitungsfehlerhinweis',
-		'_PREC' => 'Display precision of'
+		'_PREC'  => 'Display precision of',
+		'_LCODE' => 'Language code',
+		'_TEXT'  => 'Text',
 	);
 
 	protected $m_SpecialPropertyAliases = array(

--- a/languages/SMW_LanguageEn.php
+++ b/languages/SMW_LanguageEn.php
@@ -42,6 +42,7 @@ class SMWLanguageEn extends SMWLanguage {
 		'_tel' => 'Telephone number',  // name of the telephone (URI) type
 		'_rec' => 'Record', // name of record data type
 		'_qty' => 'Quantity', // name of the number type with units of measurement
+		'_mlt_rec' => 'Monolingual text',
 	);
 
 	protected $m_DatatypeAliases = array(
@@ -84,7 +85,9 @@ class SMWLanguageEn extends SMWLanguage {
 		'_MIME' => 'MIME type',
 		'_ERRC' => 'Has processing error',
 		'_ERRT' => 'Has processing error text',
-		'_PREC' => 'Display precision of'
+		'_PREC'  => 'Display precision of',
+		'_LCODE' => 'Language code',
+		'_TEXT'  => 'Text',
 	);
 
 	protected $m_SpecialPropertyAliases = array(

--- a/languages/SMW_LanguageEs.php
+++ b/languages/SMW_LanguageEs.php
@@ -40,6 +40,7 @@ class SMWLanguageEs extends SMWLanguage {
 		'_tel' => 'Número de teléfono',  // name of the telephone (URI) type
 		'_rec' => 'Registro', // name of record data type
 		'_qty' => 'Cantidad', // name of the number type with units of measurement
+		'_mlt_rec' => 'Monolingual text',
 	);
 
 	protected $m_DatatypeAliases = array(
@@ -78,7 +79,9 @@ class SMWLanguageEs extends SMWLanguage {
 		'_MIME' => 'Tipo MIME',
 		'_ERRC' => 'Has processing error',
 		'_ERRT' => 'Has processing error text',
-		'_PREC' => 'Display precision of'
+		'_PREC'  => 'Display precision of',
+		'_LCODE' => 'Language code',
+		'_TEXT'  => 'Text',
 	);
 
 	protected $m_SpecialPropertyAliases = array(

--- a/languages/SMW_LanguageFi.php
+++ b/languages/SMW_LanguageFi.php
@@ -40,6 +40,7 @@ class SMWLanguageFi extends SMWLanguage {
 		'_tel' => 'Puhelinnumero',  // name of the telephone (URI) type
 		'_rec' => 'Tietue', // name of record data type
 		'_qty' => 'Määrä', // name of the number type with units of measurement
+		'_mlt_rec' => 'Monolingual text',
 	);
 
 	protected $m_DatatypeAliases = array(
@@ -74,7 +75,9 @@ class SMWLanguageFi extends SMWLanguage {
 		'_MIME' => 'Mime type',
 		'_ERRC' => 'Has processing error',
 		'_ERRT' => 'Has processing error text',
-		'_PREC' => 'Display precision of'
+		'_PREC'  => 'Display precision of',
+		'_LCODE' => 'Language code',
+		'_TEXT'  => 'Text',
 	);
 
 	protected $m_Namespaces = array(

--- a/languages/SMW_LanguageFr.php
+++ b/languages/SMW_LanguageFr.php
@@ -40,6 +40,7 @@ class SMWLanguageFr extends SMWLanguage {
 		'_tel' => 'Numéro de téléphone',  // name of the telephone (URI) type
 		'_rec' => 'Enregistrement', // name of record data type
 		'_qty' => 'Quantité', // name of the number type with units of measurement
+		'_mlt_rec' => 'Monolingual text',
 	);
 
 	protected $m_DatatypeAliases = array(
@@ -78,7 +79,9 @@ class SMWLanguageFr extends SMWLanguage {
 		'_MIME' => 'Mime type',
 		'_ERRC' => 'Has processing error',
 		'_ERRT' => 'Has processing error text',
-		'_PREC' => 'Display precision of'
+		'_PREC'  => 'Display precision of',
+		'_LCODE' => 'Language code',
+		'_TEXT'  => 'Text',
 	);
 
 	protected $m_SpecialPropertyAliases = array(

--- a/languages/SMW_LanguageHe.php
+++ b/languages/SMW_LanguageHe.php
@@ -40,6 +40,7 @@ class SMWLanguageHe extends SMWLanguage {
 		'_tel' => 'Telephone number',  // name of the telephone (URI) type //TODO: translate
 		'_rec' => 'Record', // name of record data type //TODO: translate
 		'_qty' => 'Quantity', // name of the number type with units of measurement //TODO: translate
+		'_mlt_rec' => 'Monolingual text',
 	);
 
 	protected $m_DatatypeAliases = array(
@@ -77,7 +78,9 @@ class SMWLanguageHe extends SMWLanguage {
 		'_MIME' => 'Mime type',
 		'_ERRC' => 'Has processing error',
 		'_ERRT' => 'Has processing error text',
-		'_PREC' => 'Display precision of'
+		'_PREC'  => 'Display precision of',
+		'_LCODE' => 'Language code',
+		'_TEXT'  => 'Text',
 	);
 
 	protected $m_SpecialPropertyAliases = array(

--- a/languages/SMW_LanguageHu.php
+++ b/languages/SMW_LanguageHu.php
@@ -48,6 +48,7 @@ class SMWLanguageHu extends SMWLanguage {
 		'_tel' => 'Telefonszám', // name of the telephone number URI datatype
 		'_rec' => 'Rekord', // name of the record datatype
 		'_qty' => 'Mennyiség', // name of the quantity datatype
+		'_mlt_rec' => 'Monolingual text',
 	);
 
 	protected $m_DatatypeAliases = array(
@@ -82,7 +83,9 @@ class SMWLanguageHu extends SMWLanguage {
 		'_MIME' => 'MIME-Típusa',
 		'_ERRC' => 'Has processing error',
 		'_ERRT' => 'Has processing error text',
-		'_PREC' => 'Display precision of'
+		'_PREC'  => 'Display precision of',
+		'_LCODE' => 'Language code',
+		'_TEXT'  => 'Text',
 	);
 
 	protected $m_SpecialPropertyAliases = array(

--- a/languages/SMW_LanguageId.php
+++ b/languages/SMW_LanguageId.php
@@ -42,6 +42,7 @@ class SMWLanguageId extends SMWLanguage {
 		'_tel' => 'Nomor telepon',  // name of the telephone (URI) type
 		'_rec' => 'Rekaman', // name of record data type
 		'_qty' => 'Quantity', // name of the number type with units of measurement //TODO: translate
+		'_mlt_rec' => 'Monolingual text',
 	);
 
 	protected $m_DatatypeAliases = array(
@@ -78,7 +79,9 @@ class SMWLanguageId extends SMWLanguage {
 		'_MIME' => 'Mime type',
 		'_ERRC' => 'Has processing error',
 		'_ERRT' => 'Has processing error text',
-		'_PREC' => 'Display precision of'
+		'_PREC'  => 'Display precision of',
+		'_LCODE' => 'Language code',
+		'_TEXT'  => 'Text',
 	);
 
 	protected $m_SpecialPropertyAliases = array(

--- a/languages/SMW_LanguageIt.php
+++ b/languages/SMW_LanguageIt.php
@@ -40,6 +40,7 @@ class SMWLanguageIt extends SMWLanguage {
 		'_tel' => 'Telephone number',  // name of the telephone (URI) type //TODO: translate
 		'_rec' => 'Record', // name of record data type //TODO: translate
 		'_qty' => 'Quantity', // name of the number type with units of measurement //TODO: translate
+		'_mlt_rec' => 'Monolingual text',
 	);
 
 	protected $m_DatatypeAliases = array(
@@ -80,7 +81,9 @@ class SMWLanguageIt extends SMWLanguage {
 		'_MIME' => 'Mime type',
 		'_ERRC' => 'Has processing error',
 		'_ERRT' => 'Has processing error text',
-		'_PREC' => 'Display precision of'
+		'_PREC'  => 'Display precision of',
+		'_LCODE' => 'Language code',
+		'_TEXT'  => 'Text',
 	);
 
 	protected $m_SpecialPropertyAliases = array(

--- a/languages/SMW_LanguageNb.php
+++ b/languages/SMW_LanguageNb.php
@@ -40,6 +40,7 @@ class SMWLanguageNb extends SMWLanguage {
 		'_tel' => 'Telefonnummer',  // name of the telephone (URI) type
 		'_rec' => 'Post', // name of record data type
 		'_qty' => 'Størrelse', // name of the number type with units of measurement
+		'_mlt_rec' => 'Monolingual text',
 	);
 
 	protected $m_DatatypeAliases = array(
@@ -87,7 +88,9 @@ class SMWLanguageNb extends SMWLanguage {
 		'_MIME' => 'MIME-type',
 		'_ERRC' => 'Has processing error',
 		'_ERRT' => 'Has processing error text',
-		'_PREC' => 'Display precision of'
+		'_PREC'  => 'Display precision of',
+		'_LCODE' => 'Language code',
+		'_TEXT'  => 'Text',
 	);
 
 	protected $m_SpecialPropertyAliases = array(

--- a/languages/SMW_LanguageNl.php
+++ b/languages/SMW_LanguageNl.php
@@ -42,6 +42,7 @@ class SMWLanguageNl extends SMWLanguage {
 		'_tel' => 'Telefoonnummer',  // name of the telephone (URI) type
 		'_rec' => 'Record', // name of record data type
 		'_qty' => 'Hoeveelheid', // name of the number type with units of measurement
+		'_mlt_rec' => 'Monolingual text',
 	);
 
 	protected $m_DatatypeAliases = array(
@@ -80,7 +81,9 @@ class SMWLanguageNl extends SMWLanguage {
 		'_MIME' => 'Heeft MIME-type',
 		'_ERRC' => 'Has processing error',
 		'_ERRT' => 'Has processing error text',
-		'_PREC' => 'Display precision of'
+		'_PREC'  => 'Display precision of',
+		'_LCODE' => 'Language code',
+		'_TEXT'  => 'Text',
 	);
 
 	protected $m_SpecialPropertyAliases = array(

--- a/languages/SMW_LanguagePl.php
+++ b/languages/SMW_LanguagePl.php
@@ -58,6 +58,7 @@ class SMWLanguagePl extends SMWLanguage {
 		'_tel' => 'Telephone number',  // name of the telephone (URI) type //TODO: translate
 		'_rec' => 'Record', // name of record data type //TODO: translate
 		'_qty' => 'Quantity', // name of the number type with units of measurement //TODO: translate
+		'_mlt_rec' => 'Monolingual text',
 	);
 
 	protected $m_DatatypeAliases = array(
@@ -96,7 +97,9 @@ class SMWLanguagePl extends SMWLanguage {
 		'_MIME' => 'Mime type',
 		'_ERRC' => 'Has processing error',
 		'_ERRT' => 'Has processing error text',
-		'_PREC' => 'Display precision of'
+		'_PREC'  => 'Display precision of',
+		'_LCODE' => 'Language code',
+		'_TEXT'  => 'Text',
 	);
 
 	protected $m_SpecialPropertyAliases = array(

--- a/languages/SMW_LanguagePt.php
+++ b/languages/SMW_LanguagePt.php
@@ -39,6 +39,7 @@ class SMWLanguagePt extends SMWLanguage {
 		'_tel' => 'Número de telefone',  // name of the telephone (URI) type
 		'_rec' => 'Registro', // name of record data type
 		'_qty' => 'Quantidade', // name of the number type with units of measurement
+		'_mlt_rec' => 'Monolingual text',
 	);
 
 	protected $m_DatatypeAliases = array(
@@ -85,7 +86,9 @@ class SMWLanguagePt extends SMWLanguage {
 		'_MIME' => 'Mime type',
 		'_ERRC' => 'Has processing error',
 		'_ERRT' => 'Has processing error text',
-		'_PREC' => 'Display precision of'
+		'_PREC'  => 'Display precision of',
+		'_LCODE' => 'Language code',
+		'_TEXT'  => 'Text',
 	);
 
 	protected $m_SpecialPropertyAliases = array(

--- a/languages/SMW_LanguageRu.php
+++ b/languages/SMW_LanguageRu.php
@@ -40,6 +40,7 @@ class SMWLanguageRu extends SMWLanguage {
 		'_tel' => 'Номер телефона',  // name of the telephone (URI) type
 		'_rec' => 'Запись', // name of record data type
 		'_qty' => 'Количество', // name of the number type with units of measurement
+		'_mlt_rec' => 'Monolingual text',
 	);
 
 	protected $m_DatatypeAliases = array(
@@ -80,7 +81,9 @@ class SMWLanguageRu extends SMWLanguage {
 		'_MIME' => 'MIME-тип',
 		'_ERRC' => 'Has processing error',
 		'_ERRT' => 'Has processing error text',
-		'_PREC' => 'Display precision of'
+		'_PREC'  => 'Display precision of',
+		'_LCODE' => 'Language code',
+		'_TEXT'  => 'Text',
 	);
 
 	protected $m_SpecialPropertyAliases = array(

--- a/languages/SMW_LanguageSk.php
+++ b/languages/SMW_LanguageSk.php
@@ -40,6 +40,7 @@ class SMWLanguageSk extends SMWLanguage {
 		'_tel' => 'Telefónne číslo',  // name of the telephone (URI) type
 		'_rec' => 'Record', // name of record data type //TODO: translate
 		'_qty' => 'Rozmer', // name of the number type with units of measurement
+		'_mlt_rec' => 'Monolingual text',
 	);
 
 	protected $m_DatatypeAliases = array(
@@ -77,7 +78,9 @@ class SMWLanguageSk extends SMWLanguage {
 		'_MIME' => 'Mime type',
 		'_ERRC' => 'Has processing error',
 		'_ERRT' => 'Has processing error text',
-		'_PREC' => 'Display precision of'
+		'_PREC'  => 'Display precision of',
+		'_LCODE' => 'Language code',
+		'_TEXT'  => 'Text',
 	);
 
 	protected $m_SpecialPropertyAliases = array(

--- a/languages/SMW_LanguageZh_cn.php
+++ b/languages/SMW_LanguageZh_cn.php
@@ -42,7 +42,8 @@ class SMWLanguageZh_cn extends SMWLanguage {
 		'_anu' => '注释URI型', // name of the annotation URI type (OWL annotation property)
 		'_tel' => '电话号码型', // name of the telephone (URI) type
 		'_rec' => '记录型', // name of record data type
-		'_qty' => '数量型' // name of the number type with units of measurement
+		'_qty' => '数量型', // name of the number type with units of measurement
+		'_mlt_rec' => 'Monolingual text',
 	);
 
 	protected $m_DatatypeAliases = array(
@@ -85,7 +86,9 @@ class SMWLanguageZh_cn extends SMWLanguage {
 		'_MIME' => 'MIME类型', //Mime type
 		'_ERRC' => 'Has processing error',
 		'_ERRT' => 'Has processing error text',
-		'_PREC' => 'Display precision of'
+		'_PREC'  => 'Display precision of',
+		'_LCODE' => 'Language code',
+		'_TEXT'  => 'Text',
 	);
 
 	protected $m_SpecialPropertyAliases = array(

--- a/languages/SMW_LanguageZh_tw.php
+++ b/languages/SMW_LanguageZh_tw.php
@@ -41,7 +41,8 @@ class SMWLanguageZh_tw extends SMWLanguage {
 		'_anu' => '注釋URI型', // name of the annotation URI type (OWL annotation property)
 		'_tel' => '電話號碼型',  // name of the telephone (URI) type
 		'_rec' => '記錄型', // name of record type
-		'_qty' => '數量型' // name of the number type with units of measurement
+		'_qty' => '數量型', // name of the number type with units of measurement
+		'_mlt_rec' => 'Monolingual text',
 	);
 
 	protected $m_DatatypeAliases = array(
@@ -83,7 +84,9 @@ class SMWLanguageZh_tw extends SMWLanguage {
 		'_MIME' => 'MIME類型', // MIME type
 		'_ERRC' => 'Has processing error',
 		'_ERRT' => 'Has processing error text',
-		'_PREC' => 'Display precision of'
+		'_PREC'  => 'Display precision of',
+		'_LCODE' => 'Language code',
+		'_TEXT'  => 'Text',
 	);
 
 	protected $m_SpecialPropertyAliases = array(

--- a/src/DataTypeRegistry.php
+++ b/src/DataTypeRegistry.php
@@ -403,6 +403,7 @@ class DataTypeRegistry {
 			'_dat'  => 'SMWTimeValue', // Time type
 			'_boo'  => 'SMWBoolValue', // Boolean type
 			'_rec'  => 'SMWRecordValue', // Value list type (replacing former nary properties)
+			'_mlt_rec'  => 'SMW\DataValues\MonolingualTextValue',
 			'_qty'  => 'SMWQuantityValue', // Type for numbers with units of measurement
 			// Special types are not avaialble directly for users (and have no local language name):
 			'__typ' => 'SMWTypesValue', // Special type page type
@@ -420,6 +421,7 @@ class DataTypeRegistry {
 			'__imp' => 'SMW\DataValues\ImportValue', // Special import vocabulary type
 			'__pro' => 'SMWPropertyValue', // Property type (possibly predefined, no always based on a page)
 			'__key' => 'SMWStringValue', // Sort key of a page
+			'__lcode' => 'SMW\DataValues\LanguageCodeValue',
 		);
 
 		$this->typeDataItemIds = array(
@@ -439,6 +441,7 @@ class DataTypeRegistry {
 			'_dat'  => DataItem::TYPE_TIME, // Time type
 			'_boo'  => DataItem::TYPE_BOOLEAN, // Boolean type
 			'_rec'  => DataItem::TYPE_WIKIPAGE, // Value list type (replacing former nary properties)
+			'_mlt_rec' => DataItem::TYPE_WIKIPAGE, // Monolingual text container
 			'_geo'  => DataItem::TYPE_GEO, // Geographical coordinates
 			'_gpo'  => DataItem::TYPE_BLOB, // Geographical polygon
 			'_qty'  => DataItem::TYPE_NUMBER, // Type for numbers with units of measurement
@@ -458,11 +461,13 @@ class DataTypeRegistry {
 			'__imp' => DataItem::TYPE_BLOB, // Special import vocabulary type
 			'__pro' => DataItem::TYPE_PROPERTY, // Property type (possibly predefined, no always based on a page)
 			'__key' => DataItem::TYPE_BLOB, // Sort key of a page
+			'__lcode' => DataItem::TYPE_BLOB, // Language code
 		);
 
 		$this->subDataTypes = array(
 			'__sob' => true,
-			'_rec'  => true
+			'_rec'  => true,
+			'_mlt_rec' => true
 		);
 
 		// Deprecated since 1.9

--- a/src/DataValues/LanguageCodeValue.php
+++ b/src/DataValues/LanguageCodeValue.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace SMW\DataValues;
+
+use SMWStringValue as StringValue;
+use SMW\Localizer;
+use SMWDIBlob as DIBlob;
+
+/**
+ * Handles a string value to adhere the BCP47 normative content declaration for
+ * a languge code tag
+ *
+ * @see https://en.wikipedia.org/wiki/IETF_language_tag
+ *
+ * @license GNU GPL v2+
+ * @since 2.4
+ *
+ * @author mwjames
+ */
+class LanguageCodeValue extends StringValue {
+
+	/**
+	 * @param string $typeid
+	 */
+	public function __construct( $typeid = '' ) {
+		parent::__construct( '__lcode' );
+	}
+
+	/**
+	 * @see DataValue::parseUserValue
+	 *
+	 * @param string $value
+	 */
+	protected function parseUserValue( $userValue ) {
+
+		$languageCode = Localizer::asBCP47FormattedLanguageCode( $userValue );
+
+		if ( $languageCode === '' ) {
+			$this->addError( wfMessage(
+				'smw-datavalue-languagecode-missing',
+				$this->m_property !== null ? $this->m_property->getLabel() : 'UNKNOWN' )->text()
+			);
+			return;
+		}
+
+		// Checks whether any localisation is available for that language tag in
+		// MediaWiki
+		if ( !Localizer::isSupportedLanguage( $languageCode ) ) {
+			$this->addError( wfMessage( 'smw-datavalue-languagecode-invalid', $languageCode )->text() );
+			return;
+		}
+
+		$this->m_dataitem = new DIBlob( $languageCode );
+	}
+
+}

--- a/src/DataValues/MonolingualTextValue.php
+++ b/src/DataValues/MonolingualTextValue.php
@@ -1,0 +1,403 @@
+<?php
+
+namespace SMW\DataValues;
+
+use SMWDataValue as DataValue;
+use SMW\DIProperty;
+use SMW\Localizer;
+use SMW\DIWikiPage;
+use SMW\DataValueFactory;
+use SMW\ApplicationFactory;
+use SMWContainerSemanticData as ContainerSemanticData;
+use SMWDIContainer as DIContainer;
+use SMWDataItem as DataItem;
+
+/**
+ * MonolingualTextValue requires two components, a language code and a
+ * text.
+ *
+ * A text `foo@en` is expected to be invoked with a BCP47 language
+ * code tag and a language dependent text component.
+ *
+ * Internally, the value is stored as container object that represents
+ * the language code and text as separate entities in order to be queried
+ * individually.
+ *
+ * External output representation depends on the context (wiki, html)
+ * whether the language code is omitted or not.
+ *
+ * @license GNU GPL v2+
+ * @since 2.4
+ *
+ * @author mwjames
+ */
+class MonolingualTextValue extends DataValue {
+
+	/**
+	 * @var DIProperty[]|null
+	 */
+	private static $properties = null;
+
+	/**
+	 * @var MonolingualTextValueParser
+	 */
+	private $monolingualTextValueParser = null;
+
+	/**
+	 * @param string $typeid
+	 */
+	public function __construct( $typeid = '' ) {
+		parent::__construct( '_mlt_rec' );
+		$this->monolingualTextValueParser = ValueParserFactory::getInstance()->newMonolingualTextValueParser();
+	}
+
+	/**
+	 * @see RecordValue::setFieldProperties
+	 *
+	 * @param SMWDIProperty[] $properties
+	 */
+	public function setFieldProperties( array $properties ) {
+		// Keep the interface, but the properties for this type
+		// are fixed.
+	}
+
+	/**
+	 * @since 2.4
+	 *
+	 * @return integer
+	 */
+	public function needsLanguageCode() {
+		return ( $this->getOptionValueFor( 'smwgDVFeatures' ) & SMW_DV_MLTV_LCODE ) != 0;
+	}
+
+	/**
+	 * @see DataValue::parseUserValue
+	 * @note called by DataValue::setUserValue
+	 *
+	 * @param string $value
+	 */
+	protected function parseUserValue( $userValue ) {
+
+		list( $text, $languageCode ) = $this->getValuesFromString( $userValue );
+
+		$languageCodeValue = $this->newLanguageCodeValue( $languageCode );
+
+		if (
+			( $languageCode !== '' && $languageCodeValue->getErrors() !== array() ) ||
+			( $languageCode === '' && $this->needsLanguageCode() ) ) {
+			$this->addError( $languageCodeValue->getErrors() );
+			return;
+		}
+
+		$dataValues = array();
+
+		foreach ( $this->getPropertyDataItems() as $property ) {
+
+			if (
+				( $languageCode === '' && $property->getKey() === '_LCODE' ) ||
+				( $text === '' && $property->getKey() === '_TEXT' ) ) {
+				continue;
+			}
+
+			$dataValue = DataValueFactory::getInstance()->newPropertyObjectValue(
+				$property,
+				$property->getKey() === '_LCODE' ? $languageCode : $text,
+				false,
+				$this->m_contextPage
+			);
+
+			$dataValues[] = $dataValue;
+		}
+
+		// Generate a hash from the normalized representation so that foo@en being
+		// the same as foo@EN independent of a user input
+		$containerSemanticData = $this->newContainerSemanticData( $text . '@' . $languageCode );
+
+		foreach ( $dataValues as $dataValue ) {
+			$containerSemanticData->addDataValue( $dataValue );
+		}
+
+		$this->m_dataitem = new DIContainer( $containerSemanticData );
+	}
+
+	/**
+	 * @note called by MonolingualTextValueDescriptionDeserializer::deserialize
+	 * and MonolingualTextValue::parseUserValue
+	 *
+	 * No explicit check is made on the validity of a language code and is
+	 * expected to be done before calling this method.
+	 *
+	 * @since 2.4
+	 *
+	 * @param string $userValue
+	 *
+	 * @return array
+	 */
+	public function getValuesFromString( $userValue ) {
+		return $this->monolingualTextValueParser->parse( $userValue );
+	}
+
+	/**
+	 * @see DataValue::loadDataItem
+	 *
+	 * @param DataItem $dataItem
+	 *
+	 * @return boolean
+	 */
+	protected function loadDataItem( DataItem $dataItem ) {
+
+		if ( $dataItem->getDIType() === DataItem::TYPE_CONTAINER ) {
+			$this->m_dataitem = $dataItem;
+			return true;
+		} elseif ( $dataItem->getDIType() === DataItem::TYPE_WIKIPAGE ) {
+			$semanticData = new ContainerSemanticData( $dataItem );
+			$semanticData->copyDataFrom( ApplicationFactory::getInstance()->getStore()->getSemanticData( $dataItem ) );
+			$this->m_dataitem = new DIContainer( $semanticData );
+			return true;
+		}
+
+		return false;
+	}
+
+	/**
+	 * @see DataValue::getShortWikiText
+	 */
+	public function getShortWikiText( $linked = null ) {
+
+		if ( $this->m_caption !== false ) {
+			return $this->m_caption;
+		}
+
+		return $this->makeOutputText( 0, $linked );
+	}
+
+	/**
+	 * @see DataValue::getShortHTMLText
+	 */
+	public function getShortHTMLText( $linker = null ) {
+
+		if ( $this->m_caption !== false ) {
+			return $this->m_caption;
+		}
+
+		return $this->makeOutputText( 1, $linker );
+	}
+
+	/**
+	 * @see DataValue::getLongWikiText
+	 */
+	public function getLongWikiText( $linked = null ) {
+		return $this->makeOutputText( 2, $linked );
+	}
+
+	/**
+	 * @see DataValue::getLongHTMLText
+	 */
+	public function getLongHTMLText( $linker = null ) {
+		return $this->makeOutputText( 3, $linker );
+	}
+
+	/**
+	 * @see DataValue::getWikiValue
+	 */
+	public function getWikiValue() {
+		return $this->makeOutputText( 4 );
+	}
+
+	/**
+	 * @since 2.4
+	 * @note called by SMWResultArray::getNextDataValue
+	 *
+	 * @return DIProperty[]
+	 */
+	public static function getPropertyDataItems() {
+
+		if ( self::$properties !== null && self::$properties !== array() ) {
+			return self::$properties;
+		}
+
+		foreach ( array( '_TEXT', '_LCODE' ) as  $id ) {
+			self::$properties[] = new DIProperty( $id );
+		}
+
+		return self::$properties;
+	}
+
+	/**
+	 * @since 2.4
+	 * @note called by SMWResultArray::loadContent
+	 *
+	 * @return DataItem[]
+	 */
+	public function getDataItems() {
+
+		if ( !$this->isValid() ) {
+			return array();
+		}
+
+		$result = array();
+		$index = 0;
+
+		foreach ( $this->getPropertyDataItems() as $diProperty ) {
+			$values = $this->getDataItem()->getSemanticData()->getPropertyValues( $diProperty );
+			if ( count( $values ) > 0 ) {
+				$result[$index] = reset( $values );
+			} else {
+				$result[$index] = null;
+			}
+			$index += 1;
+		}
+
+		return $result;
+	}
+
+	/**
+	 * @since 2.4
+	 *
+	 * @return DataValue|null
+	 */
+	public function getTextValueByLanguage( $languageCode ) {
+
+		if ( !$this->isValid() || $this->getDataItem() === array() ) {
+			return null;
+		}
+
+		$semanticData = $this->getDataItem()->getSemanticData();
+
+		$dataItems = $semanticData->getPropertyValues( new DIProperty( '_LCODE' ) );
+		$dataItem = reset( $dataItems );
+
+		if ( $dataItem->getString() !== Localizer::asBCP47FormattedLanguageCode( $languageCode ) ) {
+			return null;
+		}
+
+		$dataItems = $semanticData->getPropertyValues( new DIProperty( '_TEXT' ) );
+		$dataItem = reset( $dataItems );
+
+		if ( $dataItem === false ) {
+			continue;
+		}
+
+		$dataValue = DataValueFactory::getInstance()->newDataItemValue(
+			$dataItem,
+			new DIProperty( '_TEXT' )
+		);
+
+		return $dataValue;
+	}
+
+	protected function makeOutputText( $type = 0, $linker = null ) {
+
+		if ( !$this->isValid() ) {
+			return ( ( $type == 0 ) || ( $type == 1 ) ) ? '' : $this->getErrorText();
+		}
+
+		// For the inverse case, return the subject that contains the reference
+		// for Foo annotated with [[Bar::abc@en]] -> [[-Bar::Foo]]
+		if ( $this->m_property !== null && $this->m_property->isInverse() ) {
+
+			$dataItems = $this->m_dataitem->getSemanticData()->getPropertyValues( new DIProperty(  $this->m_property->getKey() ) );
+			$dataItem = reset( $dataItems );
+
+			if ( !$dataItem ) {
+				return '';
+			}
+
+			return $dataItem->getDBKey();
+		}
+
+		return $this->getFinalOutputTextFor( $type, $linker );
+	}
+
+	private function getFinalOutputTextFor( $type, $linker ) {
+
+		$text = '';
+		$languagecode = '';
+
+		foreach ( $this->getPropertyDataItems() as $property ) {
+
+			// If we wanted to omit the language code display for some outputs then
+			// this is the point to make it happen
+			if ( ( $type == 0 || $type == 4 ) && $property->getKey() === '_LCODE' ) {
+			// continue;
+			}
+
+			$dataItems = $this->m_dataitem->getSemanticData()->getPropertyValues( $property );
+
+			// Should not happen but just in case
+			if ( !$dataItems === array() ) {
+				$this->addError( wfMessage( 'smw-datavalue-monolingual-dataitem-missing' )->text() );
+				continue;
+			}
+
+			$dataItem = reset( $dataItems );
+
+			if ( $dataItem === false ) {
+				continue;
+			}
+
+			$dataValue = DataValueFactory::getInstance()->newDataItemValue(
+				$dataItem,
+				$property
+			);
+
+			$result = $this->makeValueOutputText(
+				$type,
+				$dataValue,
+				$linker
+			);
+
+			if ( $property->getKey() === '_LCODE' ) {
+				$languagecode = ' ' . wfMessage( 'smw-datavalue-monolingual-lcode-parenthesis', $result )->text();
+			} else {
+				$text = $result;
+			}
+		}
+
+		return $text . $languagecode;
+	}
+
+	private function makeValueOutputText( $type, $dataValue, $linker ) {
+		switch ( $type ) {
+			case 0: return $dataValue->getShortWikiText( $linker );
+			case 1: return $dataValue->getShortHTMLText( $linker );
+			case 2: return $dataValue->getShortWikiText( $linker );
+			case 3: return $dataValue->getShortHTMLText( $linker );
+			case 4: return $dataValue->getWikiValue();
+		}
+	}
+
+	private function newContainerSemanticData( $value ) {
+
+		if ( $this->m_contextPage === null ) {
+			$containerSemanticData = ContainerSemanticData::makeAnonymousContainer();
+		} else {
+			$subobjectName = '_ML' . md5( $value );
+
+			$subject = new DIWikiPage(
+				$this->m_contextPage->getDBkey(),
+				$this->m_contextPage->getNamespace(),
+				$this->m_contextPage->getInterwiki(),
+				$subobjectName
+			);
+
+			$containerSemanticData = new ContainerSemanticData( $subject );
+		}
+
+		return $containerSemanticData;
+	}
+
+	private function newLanguageCodeValue( $languageCode ) {
+
+		$languageCodeValue = new LanguageCodeValue();
+
+		if ( $this->m_property !== null ) {
+			$languageCodeValue->setProperty( $this->m_property );
+		}
+
+		$languageCodeValue->setUserValue( $languageCode );
+
+		return $languageCodeValue;
+	}
+
+}

--- a/src/DataValues/ValueParserFactory.php
+++ b/src/DataValues/ValueParserFactory.php
@@ -5,6 +5,7 @@ namespace SMW\DataValues;
 use SMW\ControlledVocabularyImportContentFetcher;
 use SMW\MediaWiki\MediaWikiNsContentReader;
 use SMW\DataValues\ValueParsers\ImportValueParser;
+use SMW\DataValues\ValueParsers\MonolingualTextValueParser;
 
 /**
  * @license GNU GPL v2+
@@ -52,6 +53,15 @@ class ValueParserFactory {
 		);
 
 		return new ImportValueParser( $controlledVocabularyImportContentFetcher );
+	}
+
+	/**
+	 * @since 2.4
+	 *
+	 * @return MonolingualTextValueParser
+	 */
+	public function newMonolingualTextValueParser() {
+		return new MonolingualTextValueParser();
 	}
 
 }

--- a/src/DataValues/ValueParsers/MonolingualTextValueParser.php
+++ b/src/DataValues/ValueParsers/MonolingualTextValueParser.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace SMW\DataValues\ValueParsers;
+
+use SMW\DataValues\MonolingualTextValue;
+use SMW\DataValueFactory;
+use SMW\Localizer;
+use SMWDataValue as DataValue;
+
+/**
+ * @private
+ *
+ * @license GNU GPL v2+
+ * @since 2.4
+ *
+ * @author mwjames
+ */
+class MonolingualTextValueParser implements ValueParser {
+
+	/**
+	 * @var MonolingualTextValue
+	 */
+	private $monolingualTextValue;
+
+	/**
+	 * @var array
+	 */
+	private $errors = array();
+
+	/**
+	 * @since 2.4
+	 *
+	 * @return array
+	 */
+	public function getErrors() {
+		return $this->errors;
+	}
+
+	/**
+	 * @since 2.4
+	 *
+	 * @param string $userValue
+	 *
+	 * @return array
+	 */
+	public function parse( $userValue ) {
+
+		$text = $userValue;
+		$dataValues = array();
+
+		$languageCode = mb_substr( strrchr( $userValue, "@" ), 1 );
+
+		// Remove the language code and marker from the text
+		if ( $languageCode !== '' ) {
+			$text = substr_replace( $userValue, '', ( mb_strlen( $languageCode ) + 1 ) * -1 );
+		}
+
+		return array( $text, Localizer::asBCP47FormattedLanguageCode( $languageCode ) );
+	}
+
+}

--- a/src/Deserializers/DVDescriptionDeserializer/MonolingualTextValueDescriptionDeserializer.php
+++ b/src/Deserializers/DVDescriptionDeserializer/MonolingualTextValueDescriptionDeserializer.php
@@ -1,0 +1,125 @@
+<?php
+
+namespace SMW\Deserializers\DVDescriptionDeserializer;
+
+use SMW\DataValues\MonolingualTextValue;
+use SMW\Query\Language\ThingDescription;
+use SMW\Query\Language\ValueDescription;
+use SMW\Query\Language\Conjunction;
+use SMW\Query\Language\SomeProperty;
+use SMW\DataValueFactory;
+use SMW\DIProperty;
+use SMWDIBlob as DIBlob;
+use InvalidArgumentException;
+
+/**
+ * @private
+ *
+ * @license GNU GPL v2+
+ * @since 2.4
+ *
+ * @author mwjames
+ */
+class MonolingualTextValueDescriptionDeserializer extends DescriptionDeserializer {
+
+	/**
+	 * @since 2.4
+	 *
+	 * {@inheritDoc}
+	 */
+	public function isDeserializerFor( $serialization ) {
+		return $serialization instanceof MonolingualTextValue;
+	}
+
+	/**
+	 * @since 2.4
+	 *
+	 * @param string $value
+	 *
+	 * @return Description
+	 * @throws InvalidArgumentException
+	 */
+	public function deserialize( $value ) {
+
+		if ( !is_string( $value ) ) {
+			throw new InvalidArgumentException( 'Value needs to be a string' );
+		}
+
+		if ( $value === '' ) {
+			$this->addError( wfMessage( 'smw_novalues' )->text() );
+			return new ThingDescription();
+		}
+
+		$subdescriptions = array();
+		list( $text, $languageCode ) = $this->dataValue->getValuesFromString( $value );
+
+		foreach ( $this->dataValue->getPropertyDataItems() as $property ) {
+
+			// If the DVFeature doesn't require a language code to be present then
+			// allow to skip it as conjunctive condition when it is empty
+			if (
+				( $languageCode === '' ) &&
+				( $property->getKey() === '_LCODE' ) &&
+				( !$this->dataValue->needsLanguageCode() ) ) {
+				continue;
+			}
+
+			$value = $property->getKey() === '_LCODE' ? $languageCode : $text;
+			$comparator = SMW_CMP_EQ;
+
+			$this->prepareValue( $value, $comparator );
+
+			// Directly use the DI instead of going through the DVFactory to
+			// avoid having ~zh-* being validated when building a DV
+			// If one of the values is empty use, ? so queries can be arbitrary
+			// in respect of the query condition
+			$dataValue = DataValueFactory::getInstance()->newDataItemValue(
+				new DIBlob( $value === '' ? '?' : $value ),
+				$property
+			);
+
+			if ( !$dataValue->isValid() ) {
+				$this->addError( $dataValue->getErrors() );
+				continue;
+			}
+
+			$subdescriptions[] = $this->newSubdescription( $dataValue, $comparator );
+		}
+
+		return $this->getFinalDescriptionFor( $subdescriptions );
+	}
+
+	private function getFinalDescriptionFor( $subdescriptions ) {
+
+		$count = count( $subdescriptions );
+
+		if ( $count == 0 ) {
+			return new ThingDescription();
+		}
+
+		if ( $count == 1 ) {
+			return  reset( $subdescriptions );
+		}
+
+		return new Conjunction( $subdescriptions );
+	}
+
+	private function newSubdescription( $dataValue, $comparator ) {
+
+		$description = new ValueDescription(
+			$dataValue->getDataItem(),
+			$dataValue->getProperty(),
+			$comparator
+		);
+
+		if ( $dataValue->getWikiValue() === '+' || $dataValue->getWikiValue() === '?' ) {
+			$description = new ThingDescription();
+		}
+
+		return new SomeProperty(
+			$dataValue->getProperty(),
+			$description
+		);
+	}
+
+}

--- a/src/Deserializers/DVDescriptionDeserializerFactory.php
+++ b/src/Deserializers/DVDescriptionDeserializerFactory.php
@@ -7,6 +7,7 @@ use SMW\Deserializers\DVDescriptionDeserializer\DescriptionDeserializer;
 use SMW\Deserializers\DVDescriptionDeserializer\TimeValueDescriptionDeserializer;
 use SMW\Deserializers\DVDescriptionDeserializer\RecordValueDescriptionDeserializer;
 use SMW\Deserializers\DVDescriptionDeserializer\SomeValueDescriptionDeserializer;
+use SMW\Deserializers\DVDescriptionDeserializer\MonolingualTextValueDescriptionDeserializer;
 use SMWDataValue as DataValue;
 
 /**
@@ -95,6 +96,8 @@ class DVDescriptionDeserializerFactory {
 		$dispatchingDescriptionDeserializer = new DispatchingDescriptionDeserializer();
 		$dispatchingDescriptionDeserializer->addDescriptionDeserializer( new TimeValueDescriptionDeserializer() );
 		$dispatchingDescriptionDeserializer->addDescriptionDeserializer( new RecordValueDescriptionDeserializer() );
+		$dispatchingDescriptionDeserializer->addDescriptionDeserializer( new MonolingualTextValueDescriptionDeserializer() );
+
 		$dispatchingDescriptionDeserializer->addDefaultDescriptionDeserializer( new SomeValueDescriptionDeserializer() );
 
 		return $dispatchingDescriptionDeserializer;

--- a/src/Localizer.php
+++ b/src/Localizer.php
@@ -85,4 +85,36 @@ class Localizer {
 		return $this->contentLanguage->getNsIndex( str_replace( ' ', '_', $namespaceName ) );
 	}
 
+	/**
+	 * @since 2.4
+	 *
+	 * @param string $languageCode
+	 *
+	 * @return boolean
+	 */
+	public static function isSupportedLanguage( $languageCode ) {
+
+		$languageCode = mb_strtolower( $languageCode );
+
+		// FIXME 1.19 doesn't know Language::isSupportedLanguage
+		if ( !method_exists( '\Language', 'isSupportedLanguage' ) ) {
+			return Language::isValidBuiltInCode( $languageCode );
+		}
+
+		return Language::isSupportedLanguage( $languageCode );
+	}
+
+	/**
+	 * @see IETF language tag / BCP 47 standards
+	 *
+	 * @since 2.4
+	 *
+	 * @param string $languageCode
+	 *
+	 * @return string
+	 */
+	public static function asBCP47FormattedLanguageCode( $languageCode ) {
+		return wfBCP47( $languageCode );
+	}
+
 }

--- a/src/PropertyRegistry.php
+++ b/src/PropertyRegistry.php
@@ -325,6 +325,8 @@ class PropertyRegistry {
 			'_MEDIA' => array( '_txt', true, false ), // "has media type"
 			'_MIME'  => array( '_txt', true, false ), // "has mime type"
 			'_PREC'  => array( '_num', true, true ), // "Display precision of"
+			'_LCODE' => array( '__lcode', true, true ), // "Language code"
+			'_TEXT'  => array( '_txt', true, true ), // "Text"
 		);
 
 		foreach ( $this->datatypeLabels as $id => $label ) {

--- a/src/SQLStore/PropertyTableInfoFetcher.php
+++ b/src/SQLStore/PropertyTableInfoFetcher.php
@@ -63,7 +63,9 @@ class PropertyTableInfoFetcher {
 		// vocabulary import and URI assignments
 		'_IMPO', '_URI',
 		// Concepts
-		'_CONC'
+		'_CONC',
+		// Monolingual text
+		'_LCODE', '_TEXT'
 	);
 
 	/**

--- a/tests/phpunit/Integration/ByJsonScript/Fixtures/p-0411.json
+++ b/tests/phpunit/Integration/ByJsonScript/Fixtures/p-0411.json
@@ -1,0 +1,142 @@
+{
+	"description": "Test in-text annotation (and #subobject) using a monolingual property (#1344, en)",
+	"properties": [
+		{
+			"name": "Has text with language",
+			"contents": "[[Has type::Monolingual text]]"
+		}
+	],
+	"subjects": [
+		{
+			"name": "Example/P0411/1",
+			"contents": "[[Has text with language::example one@en]]"
+		},
+		{
+			"name": "Example/P0411/1/1",
+			"contents": "{{#ask: [[Has text with language::example one@en]] |?Has text with language }}"
+		},
+		{
+			"name": "Example/P0411/1/2",
+			"contents": "{{#ask: [[-Has text with language::Example/P0411/1]] |?Language code |?Text }}"
+		},
+		{
+			"name": "Example/P0411/2",
+			"contents": "{{#subobject: |Has text with language=例の一@ja }}　{{#subobject: |Has text with language=pour l'exemple@fr }}"
+		},
+		{
+			"name": "Example/P0411/2/1",
+			"contents": "{{#ask: [[Has text with language::?@ja]] |?Has text with language }}"
+		},
+		{
+			"name": "Example/P0411/2/2",
+			"contents": "{{#ask: [[Language code::ja]] |?Text }}"
+		},
+		{
+			"name": "Example/P0411/2/3",
+			"contents": "{{#ask: [[Language code::ja]] |?-Has text with language }}"
+		},
+		{
+			"name": "Example/P0411/3",
+			"contents": "{{#subobject: |Has text with language=国@zh-hans }}　{{#subobject: |Has text with language=國@zh-hant }}"
+		},
+		{
+			"name": "Example/P0411/3/1",
+			"contents": "{{#ask: [[Has text with language::?@~zh*]] |?Has text with language=Text |+index=1 |?Has text with language=Code |+index=2 }}"
+		}
+	],
+	"parser-testcases": [
+		{
+			"about": "#0",
+			"subject": "Example/P0411/1",
+			"store": {
+				"semantic-data": {
+					"strict-mode-valuematch": false,
+					"propertyCount": 3,
+					"propertyKeys": [ "Has_text_with_language", "_SKEY", "_MDAT" ],
+					"propertyValues": []
+				}
+			},
+			"expected-output": {
+				"to-contain": [
+					"example one (en)"
+				]
+			}
+		},
+		{
+			"about": "#1 match subject",
+			"subject": "Example/P0411/1/1",
+			"expected-output": {
+				"to-contain": [
+					"Example/P0411/1",
+					"class=\"Has-text-with-language smwtype_mlt_rec\">example one (en)"
+				]
+			}
+		},
+		{
+			"about": "#2 inverse match",
+			"subject": "Example/P0411/1/2",
+			"expected-output": {
+				"to-contain": [
+					"Example/P0411/1#_ML3c1364d804527cd1594b4817b01c29f0",
+					"class=\"Language-code smwtype&#95;_lcode\">en",
+					"class=\"Text smwtype_txt\">example one"
+				]
+			}
+		},
+		{
+			"about": "#3 match specific language",
+			"subject": "Example/P0411/2/1",
+			"expected-output": {
+				"to-contain": [
+					"Example/P0411/2#_b88331e53ca614aea6f7c8b5f0d6f876",
+					"class=\"Has-text-with-language smwtype_mlt_rec\">例の一 (ja)"
+				]
+			}
+		},
+		{
+			"about": "#4 match specific language",
+			"subject": "Example/P0411/2/2",
+			"expected-output": {
+				"to-contain": [
+					"Example/P0411/2#_ML13e9d4c2ba826927d7210acab7def9ec",
+					"class=\"Text smwtype_txt\">例の一"
+				]
+			}
+		},
+		{
+			"about": "#5 match specific language with inverse printout",
+			"subject": "Example/P0411/2/3",
+			"expected-output": {
+				"to-contain": [
+					"Example/P0411/2#_ML13e9d4c2ba826927d7210acab7def9ec",
+					"title=\"Property:Has text with language\">-Has text with language",
+					"class=\"-Has-text-with-language smwtype_mlt_rec\">Example/P0411/2"
+				]
+			}
+		},
+		{
+			"about": "#6 using index display for columns",
+			"subject": "Example/P0411/3/1",
+			"expected-output": {
+				"to-contain": [
+					"Example/P0411/3#_a52273132da28d0c1fad5819e44958ab",
+					"class=\"Text smwtype_txt\">国",
+					"class=\"Code smwtype&#95;_lcode\">zh-Hans",
+					"Example/P0411/3#_4eac5791ab0478bb01dc9d181bc91ec8",
+					"class=\"Text smwtype_txt\">國",
+					"class=\"Code smwtype&#95;_lcode\">zh-Hant"
+				]
+			}
+		}
+	],
+	"settings": {
+		"wgContLang": "en",
+		"wgLang": "en"
+	},
+	"meta": {
+
+		"version": "0.1",
+		"is-incomplete": false,
+		"debug": false
+	}
+}

--- a/tests/phpunit/Integration/ByJsonScript/README.md
+++ b/tests/phpunit/Integration/ByJsonScript/README.md
@@ -1,5 +1,5 @@
 ## Fixtures
-Contains 88 files:
+Contains 91 files:
 
 ### F
 * [f-0001.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/ByJsonScript/Fixtures/f-0001.json) Test format=debug output
@@ -39,6 +39,8 @@ Contains 88 files:
 * [p-0408.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/ByJsonScript/Fixtures/p-0408.json) Test in-text annotation for multiple property assignment using non-strict parser mode (#1252, en)
 * [p-0409.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/ByJsonScript/Fixtures/p-0409.json) Test in-text annotation (and #subobject) for when record type points to another record type and is used as annotation to return a `_ERRC` (#1303)
 * [p-0410.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/ByJsonScript/Fixtures/p-0410.json) Test in-text annotation on `_num`/`_tem`/`_qty` type with denoted precision (`_PREC`) and/or `-p<num>` printout precision marker (#1335, en)
+* [p-0411.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/ByJsonScript/Fixtures/p-0411.json) Test in-text annotation (and #subobject) using a monolingual property (#1344, en)
+* [p-0412.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/ByJsonScript/Fixtures/p-0412.json) Test in-text annotation for `_boo` datatype (ja)
 * [p-0701.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/ByJsonScript/Fixtures/p-0701.json) Test to create inverted annotation using a #ask/template combination (#711, `import-annotation=true`)
 * [p-0702.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/ByJsonScript/Fixtures/p-0702.json) Test #ask with `format=table` on inverse property/printrquest (#1270, en)
 * [p-0901.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/ByJsonScript/Fixtures/p-0901.json) Test #ask on moved redirected subject (#1086)
@@ -78,6 +80,7 @@ Contains 88 files:
 * [q-0902.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/ByJsonScript/Fixtures/q-0902.json) Test `_txt` to correctly apply parentheses for somehting like (a OR b OR c) AND d (#556)
 * [q-0903.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/ByJsonScript/Fixtures/q-0903.json) Test `_wpg`/`_num`/`_txt` for disjunction OR || (T31866, #1059, en)
 * [q-0904.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/ByJsonScript/Fixtures/q-0904.json) Test `_wpg`/`_txt` disjunction in connection with property hierarchies (#1060, en, skip virtuoso)
+* [q-0905.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/ByJsonScript/Fixtures/q-0905.json) Test `_wpg`/`_txt` conjunction queries (#1362, #1060)
 * [q-1002.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/ByJsonScript/Fixtures/q-1002.json) Test `_dat` range for non strict comparators (#285, `smwStrictComparators=false`, skip virtuoso)
 * [q-1003.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/ByJsonScript/Fixtures/q-1003.json) Test `_dat` range for strict comparators (#285, `smwStrictComparators=true`, skip virtuoso)
 * [q-1004.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/ByJsonScript/Fixtures/q-1004.json) Test `_dat` range for `~`/`!~` comparators (#1178, `smwStrictComparators=false`, skip virtuoso)
@@ -99,4 +102,4 @@ Contains 88 files:
 ### S
 * [s-0001.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/ByJsonScript/Fixtures/s-0001.json) Test output of `Special:Properties` (en, skip-on sqlite, 1.19)
 
--- Last updated on 2016-01-08 by `readmeContentsBuilder.php`
+-- Last updated on 2016-01-17 by `readmeContentsBuilder.php`

--- a/tests/phpunit/Unit/DataValues/LanguageCodeValueTest.php
+++ b/tests/phpunit/Unit/DataValues/LanguageCodeValueTest.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace SMW\Tests\DataValues;
+
+use SMW\DataValues\LanguageCodeValue;
+
+/**
+ * @covers \SMW\DataValues\LanguageCodeValue
+ * @group semantic-mediawiki
+ *
+ * @license GNU GPL v2+
+ * @since 2.4
+ *
+ * @author mwjames
+ */
+class LanguageCodeValueTest extends \PHPUnit_Framework_TestCase {
+
+	public function testCanConstruct() {
+
+		$this->assertInstanceOf(
+			'\SMW\DataValues\LanguageCodeValue',
+			new LanguageCodeValue()
+		);
+	}
+
+	public function testHasErrorForMissingLanguageCode() {
+
+		$instance = new LanguageCodeValue();
+		$instance->setUserValue( '' );
+
+		$this->assertNotEmpty(
+			$instance->getErrors()
+		);
+	}
+
+	public function testHasErrorForInvalidLanguageCode() {
+
+		if ( version_compare( $GLOBALS['wgVersion'], '1.20', '<' ) ) {
+			$this->markTestSkipped( 'Skipping because `Language::isSupportedLanguage` is not supported on 1.19' );
+		}
+
+		$instance = new LanguageCodeValue();
+		$instance->setUserValue( '-Foo' );
+
+		$this->assertNotEmpty(
+			$instance->getErrors()
+		);
+	}
+
+	public function testNormalizationOnLanguageCodeOccurs() {
+
+		$mixedCase = new LanguageCodeValue();
+		$mixedCase->setUserValue( 'eN' );
+
+		$upperCase = new LanguageCodeValue();
+		$upperCase->setUserValue( 'EN' );
+
+		$this->assertEquals(
+			$mixedCase,
+			$upperCase
+		);
+
+		$this->assertEquals(
+			'en',
+			$mixedCase->getDataItem()->getString()
+		);
+
+		$this->assertEquals(
+			'en',
+			$upperCase->getDataItem()->getString()
+		);
+	}
+
+}

--- a/tests/phpunit/Unit/DataValues/MonolingualTextValueTest.php
+++ b/tests/phpunit/Unit/DataValues/MonolingualTextValueTest.php
@@ -1,0 +1,150 @@
+<?php
+
+namespace SMW\Tests\DataValues;
+
+use SMW\DataValues\MonolingualTextValue;
+use SMW\Options;
+
+/**
+ * @covers \SMW\DataValues\MonolingualTextValue
+ * @group semantic-mediawiki
+ *
+ * @license GNU GPL v2+
+ * @since 2.4
+ *
+ * @author mwjames
+ */
+class MonolingualTextValueTest extends \PHPUnit_Framework_TestCase {
+
+	public function testCanConstruct() {
+
+		$this->assertInstanceOf(
+			'\SMW\DataValues\MonolingualTextValue',
+			new MonolingualTextValue()
+		);
+	}
+
+	public function testErrorForMissingLanguageCode() {
+
+		$instance = new MonolingualTextValue();
+
+		$instance->setOptions(
+			new Options( array( 'smwgDVFeatures' => SMW_DV_MLTV_LCODE ) )
+		);
+
+		$instance->setUserValue( 'Foo' );
+
+		$this->assertNotEmpty(
+			$instance->getErrors()
+		);
+	}
+
+	public function testNoErrorForMissingLanguageCodeWhenFeatureIsDisabled() {
+
+		$instance = new MonolingualTextValue();
+
+		$instance->setOptions(
+			new Options( array( 'smwgDVFeatures' => false ) )
+		);
+
+		$instance->setUserValue( 'Foo' );
+
+		$this->assertEmpty(
+			$instance->getErrors()
+		);
+	}
+
+	public function testErrorForInvalidLanguageCode() {
+
+		if ( version_compare( $GLOBALS['wgVersion'], '1.20', '<' ) ) {
+			$this->markTestSkipped( 'Skipping because `Language::isSupportedLanguage` is not supported on 1.19' );
+		}
+
+		$instance = new MonolingualTextValue();
+		$instance->setUserValue( 'Foo@foobar' );
+
+		$this->assertNotEmpty(
+			$instance->getErrors()
+		);
+	}
+
+	public function testValidParsableUserValue() {
+
+		$instance = new MonolingualTextValue();
+		$instance->setUserValue( 'Foo@en' );
+
+		$this->assertEmpty(
+			$instance->getErrors()
+		);
+
+		$this->assertInstanceOf(
+			'\SMWDIContainer',
+			$instance->getDataItem()
+		);
+
+		foreach ( $instance->getDataItems() as $dataItem ) {
+			$this->assertInstanceOf(
+				'\SMWDIBlob',
+				$dataItem
+			);
+		}
+
+		$this->assertEquals(
+			'Foo',
+			$instance->getTextValueByLanguage( 'en' )->getDataItem()->getString()
+		);
+	}
+
+	public function testTryToGetTextValueByLanguageForUnrecognizedLanguagCode() {
+
+		$instance = new MonolingualTextValue();
+		$instance->setUserValue( 'Foo@en' );
+
+		$this->assertNull(
+			$instance->getTextValueByLanguage( 'bar' )
+		);
+	}
+
+	public function testGetWikiValueForValidMonolingualTextValue() {
+
+		$instance = new MonolingualTextValue();
+		$instance->setUserValue( 'Foo@en' );
+
+		$this->assertEquals(
+			'Foo (en)',
+			$instance->getWikiValue()
+		);
+	}
+
+	public function testGetWikiValueForInvalidMonolingualTextValue() {
+
+		if ( version_compare( $GLOBALS['wgVersion'], '1.20', '<' ) ) {
+			$this->markTestSkipped( 'Skipping because `Language::isSupportedLanguage` is not supported on 1.19' );
+		}
+
+		$instance = new MonolingualTextValue();
+		$instance->setUserValue( 'Foo@foobar' );
+
+		$this->assertContains(
+			'class="smw-highlighter" data-type="4"',
+			$instance->getWikiValue()
+		);
+	}
+
+	public function testGetProperties() {
+
+		$instance = new MonolingualTextValue();
+		$properties = $instance->getPropertyDataItems();
+
+		$this->assertEquals(
+			'_TEXT',
+			$properties[0]->getKey()
+		);
+
+		$this->assertEquals(
+			'_LCODE',
+			$properties[1]->getKey()
+		);
+	}
+
+}

--- a/tests/phpunit/Unit/DataValues/ValueParserFactoryTest.php
+++ b/tests/phpunit/Unit/DataValues/ValueParserFactoryTest.php
@@ -40,4 +40,15 @@ class ValueParserFactoryTest extends \PHPUnit_Framework_TestCase {
 		);
 	}
 
+
+	public function testCanConstructMonolingualTextValueParser() {
+
+		$instance = new ValueParserFactory();
+
+		$this->assertInstanceOf(
+			'\SMW\DataValues\ValueParsers\MonolingualTextValueParser',
+			$instance->newMonolingualTextValueParser()
+		);
+	}
+
 }

--- a/tests/phpunit/Unit/DataValues/ValueParsers/MonolingualTextValueParserTest.php
+++ b/tests/phpunit/Unit/DataValues/ValueParsers/MonolingualTextValueParserTest.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace SMW\Tests\DataValues\ValueParsers;
+
+use SMW\DataValues\ValueParsers\MonolingualTextValueParser;
+
+/**
+ * @covers \SMW\DataValues\ValueParsers\MonolingualTextValueParser
+ * @group semantic-mediawiki
+ *
+ * @license GNU GPL v2+
+ * @since 2.4
+ *
+ * @author mwjames
+ */
+class MonolingualTextValueParserTest extends \PHPUnit_Framework_TestCase {
+
+	public function testCanConstruct() {
+
+		$this->assertInstanceOf(
+			'\SMW\DataValues\ValueParsers\MonolingualTextValueParser',
+			new MonolingualTextValueParser()
+		);
+	}
+
+	/**
+	 * @dataProvider fullStringProvider
+	 */
+	public function testFullParsableString( $value, $expectedText, $expectedLanguageCode ) {
+
+		$instance = new MonolingualTextValueParser();
+		list( $text, $languageCode ) = $instance->parse( $value );
+
+		$this->assertEquals(
+			$expectedText,
+			$text
+		);
+
+		$this->assertEquals(
+			$expectedLanguageCode,
+			$languageCode
+		);
+	}
+
+	public function testParsableStringWithMissingLanguageCode() {
+
+		$instance = new MonolingualTextValueParser();
+		list( $text, $languageCode ) = $instance->parse( 'FooBar' );
+
+		$this->assertEquals(
+			'FooBar',
+			$text
+		);
+	}
+
+	public function fullStringProvider() {
+
+		$provider[] = array(
+			'Foo@EN',
+			'Foo',
+			'en'
+		);
+
+		$provider[] = array(
+			'testWith@example.org@zh-hans',
+			'testWith@example.org',
+			'zh-Hans'
+		);
+
+		return $provider;
+	}
+
+}

--- a/tests/phpunit/Unit/Deserializers/DVDescriptionDeserializer/MonolingualTextValueDescriptionDeserializerTest.php
+++ b/tests/phpunit/Unit/Deserializers/DVDescriptionDeserializer/MonolingualTextValueDescriptionDeserializerTest.php
@@ -1,0 +1,157 @@
+<?php
+
+namespace SMW\Tests\Deserializers\DVDescriptionDeserializer;
+
+use SMW\Deserializers\DVDescriptionDeserializer\MonolingualTextValueDescriptionDeserializer;
+use SMW\DataValues\MonolingualTextValue;
+use SMW\DIProperty;
+use SMW\Options;
+
+/**
+ * @covers \SMW\Deserializers\DVDescriptionDeserializer\MonolingualTextValueDescriptionDeserializer
+ * @group semantic-mediawiki
+ *
+ * @license GNU GPL v2+
+ * @since 2.4
+ *
+ * @author mwjames
+ */
+class MonolingualTextValueDescriptionDeserializerTest extends \PHPUnit_Framework_TestCase {
+
+	public function testCanConstruct() {
+
+		$this->assertInstanceOf(
+			'\SMW\Deserializers\DVDescriptionDeserializer\MonolingualTextValueDescriptionDeserializer',
+			new MonolingualTextValueDescriptionDeserializer()
+		);
+	}
+
+	public function testIsDeserializerForTimeValue() {
+
+		$dataValue = $this->getMockBuilder( '\SMW\DataValues\MonolingualTextValue' )
+			->disableOriginalConstructor()
+			->getMockForAbstractClass();
+
+		$instance = new MonolingualTextValueDescriptionDeserializer();
+
+		$this->assertTrue(
+			$instance->isDeserializerFor( $dataValue )
+		);
+	}
+
+	public function testNonStringThrowsException() {
+
+		$recordValue = $this->getMockBuilder( '\SMW\DataValues\MonolingualTextValue' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$instance = new MonolingualTextValueDescriptionDeserializer();
+		$instance->setDataValue( $recordValue );
+
+		$this->setExpectedException( 'InvalidArgumentException' );
+		$instance->deserialize( array() );
+	}
+
+	/**
+	 * @dataProvider valueProvider
+	 */
+	public function testDeserialize( $value, $decription, $queryString, $dvFeatures ) {
+
+		$monolingualTextValue = new MonolingualTextValue();
+
+		$monolingualTextValue->setOptions(
+			new Options( array( 'smwgDVFeatures' => $dvFeatures ) )
+		);
+
+		$instance = new MonolingualTextValueDescriptionDeserializer();
+		$instance->setDataValue( $monolingualTextValue );
+
+		$this->assertInstanceOf(
+			$decription,
+			$instance->deserialize( $value )
+		);
+
+		$this->assertEquals(
+			$queryString,
+			$instance->deserialize( $value )->getQueryString()
+		);
+	}
+
+	public function valueProvider() {
+
+		#0
+		$provider[] = array(
+			'Jan;1970',
+			'\SMW\Query\Language\Conjunction',
+			'[[Text::Jan;1970]] [[Language code::+]]',
+			SMW_DV_MLTV_LCODE
+		);
+
+		#1
+		$provider[] = array(
+			'Jan;1970',
+			'\SMW\Query\Language\SomeProperty',
+			'[[Text::Jan;1970]]',
+			SMW_DV_NONE
+		);
+
+		#2
+		$provider[] = array(
+			'Jan@en',
+			'\SMW\Query\Language\Conjunction',
+			'[[Text::Jan]] [[Language code::en]]',
+			SMW_DV_MLTV_LCODE
+		);
+
+		#3
+		$provider[] = array(
+			'@en',
+			'\SMW\Query\Language\Conjunction',
+			'[[Text::+]] [[Language code::en]]',
+			SMW_DV_MLTV_LCODE
+		);
+
+		#4
+		$provider[] = array(
+			'@EN',
+			'\SMW\Query\Language\Conjunction',
+			'[[Text::+]] [[Language code::en]]',
+			SMW_DV_MLTV_LCODE
+		);
+
+		#5
+		$provider[] = array(
+			'@~zh*',
+			'\SMW\Query\Language\Conjunction',
+			'[[Text::+]] [[Language code::~zh*]]',
+			SMW_DV_MLTV_LCODE
+		);
+
+		#6
+		$provider[] = array(
+			'?',
+			'\SMW\Query\Language\Conjunction',
+			'[[Text::+]] [[Language code::+]]',
+			SMW_DV_MLTV_LCODE
+		);
+
+		#7
+		$provider[] = array(
+			'?',
+			'\SMW\Query\Language\SomeProperty',
+			'[[Text::+]]',
+			SMW_DV_NONE
+		);
+
+		#8
+		$provider[] = array(
+			'',
+			'\SMW\Query\Language\ThingDescription',
+			'',
+			SMW_DV_MLTV_LCODE
+		);
+
+		return $provider;
+	}
+
+}

--- a/tests/phpunit/Unit/LocalizerTest.php
+++ b/tests/phpunit/Unit/LocalizerTest.php
@@ -3,14 +3,11 @@
 namespace SMW\Tests;
 
 use SMW\Localizer;
-
 use Language;
 
 /**
  * @covers \SMW\Localizer
- *
- * @group SMW
- * @group SMWExtension
+ * @group semantic-mediawiki
  *
  * @license GNU GPL v2+
  * @since 2.1
@@ -74,6 +71,35 @@ class LocalizerTest extends \PHPUnit_Framework_TestCase {
 		$this->assertEquals(
 			SMW_NS_PROPERTY,
 			$instance->getNamespaceIndexByName( 'property' )
+		);
+	}
+
+	public function testSupportedLanguageForLowerCaseLetter() {
+
+		if ( version_compare( $GLOBALS['wgVersion'], '1.20', '<' ) ) {
+			$this->markTestSkipped( 'Skipping because `Language::isSupportedLanguage` is not supported on 1.19' );
+		}
+
+		$this->assertTrue(
+			Localizer::isSupportedLanguage( 'en' )
+		);
+	}
+
+	public function testSupportedLanguageForUpperCaseLetter() {
+
+		if ( version_compare( $GLOBALS['wgVersion'], '1.20', '<' ) ) {
+			$this->markTestSkipped( 'Skipping because `Language::isSupportedLanguage` is not supported on 1.19' );
+		}
+
+		$this->assertTrue(
+			Localizer::isSupportedLanguage( 'ZH-HANS' )
+		);
+	}
+
+	public function testAsBCP47FormattedLanguageCode() {
+		$this->assertEquals(
+			'zh-Hans',
+			Localizer::asBCP47FormattedLanguageCode( 'zh-hans' )
 		);
 	}
 


### PR DESCRIPTION
This feature allows to associate a language code to a text component with something like:

```
Property:Has text with language

[[Has type::Monolingual text]]
```

```
[[Has text with language::example one@en]]

{{#subobject:
 |Has text with language=例の一@ja
}}
```

```
{{#ask: [[Has text with language::?@ja]]
 |?Has text with language
}}
```

This is prerequisite to support [0] multi-lingual property labels as demonstrated in [0].

[0] https://www.youtube.com/watch?v=jcau-ZA_uYc

refs #594
