### PR TITLE
Fix usage of `|+align=...` in `format=table`

### DIFF
--- a/includes/queryprinters/TableResultPrinter.php
+++ b/includes/queryprinters/TableResultPrinter.php
@@ -154,7 +154,7 @@ class TableResultPrinter extends ResultPrinter {
 			$alignment = trim( $resultArray->getPrintRequest()->getParameter( 'align' ) );
 
 			if ( in_array( $alignment, array( 'right', 'left', 'center' ) ) ) {
-				$attributes['style'] = "text-align:' . $alignment . ';";
+				$attributes['style'] = "text-align:$alignment;";
 			}
 			$attributes['class'] = $columnClass . ( $dataValueType !== '' ? ' smwtype' . $dataValueType : '' );
 

--- a/tests/phpunit/Integration/ByJsonScript/Fixtures/f-0205.json
+++ b/tests/phpunit/Integration/ByJsonScript/Fixtures/f-0205.json
@@ -1,0 +1,62 @@
+{
+	"description": "Test `format=table` on `|+align=`/`|+limit`/`|+order` extra printout parameters (T18571, en)",
+	"properties": [
+		{
+			"name": "Has number",
+			"contents": "[[Has type::Number]]"
+		}
+	],
+	"subjects": [
+		{
+			"name": "Example/F0205/1/1",
+			"contents": "[[Has number::1]] [[Has number::42]] [[Has number::.02]]"
+		},
+		{
+			"name": "Example/F0205/1/2",
+			"contents": "[[Has number::21]] [[Has number::1001]] [[Has number::2.02]]"
+		},
+		{
+			"name": "Example/F0205/1a",
+			"contents": "{{#ask: [[~Example/F0205/1/*]] |?Has number |+align=right |+limit=2 |+order=asc |format=table |headers=plain }}"
+		},
+		{
+			"name": "Example/F0205/1b",
+			"contents": "{{#ask: [[~Example/F0205/1/*]] |?Has number |+align=left |+limit=2 |+order=desc |format=table |headers=plain }}"
+		}
+	],
+	"format-testcases": [
+		{
+			"about": "#0",
+			"subject": "Example/F0205/1a",
+			"expected-output": {
+				"to-contain": [
+					"data-sort-value=\"0.02\" style=\"text-align:right;\" class=\"Has-number smwtype_num\">0.02<br />1",
+					"data-sort-value=\"2.02\" style=\"text-align:right;\" class=\"Has-number smwtype_num\">2.02<br />21"
+				]
+			}
+		},
+		{
+			"about": "#1",
+			"subject": "Example/F0205/1b",
+			"expected-output": {
+				"to-contain": [
+					"data-sort-value=\"42\" style=\"text-align:left;\" class=\"Has-number smwtype_num\">42<br />1",
+					"data-sort-value=\"1001\" style=\"text-align:left;\" class=\"Has-number smwtype_num\">1,001<br />21"
+				]
+			}
+		}
+	],
+	"settings": {
+		"wgContLang": "en",
+		"wgLang": "en",
+		"smwgNamespacesWithSemanticLinks": {
+			"NS_MAIN": true,
+			"SMW_NS_PROPERTY": true
+		}
+	},
+	"meta": {
+		"version": "0.1",
+		"is-incomplete": false,
+		"debug": false
+	}
+}

--- a/tests/phpunit/Integration/ByJsonScript/README.md
+++ b/tests/phpunit/Integration/ByJsonScript/README.md
@@ -1,5 +1,5 @@
 ## Fixtures
-Contains 87 files:
+Contains 88 files:
 
 ### F
 * [f-0001.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/ByJsonScript/Fixtures/f-0001.json) Test format=debug output
@@ -10,6 +10,7 @@ Contains 87 files:
 * [f-0202.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/ByJsonScript/Fixtures/f-0202.json) Test format=table with sep cell formatting, #495 (en, skip 1.19)
 * [f-0203.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/ByJsonScript/Fixtures/f-0203.json) Test format=table to sort by category (#1286)
 * [f-0204.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/ByJsonScript/Fixtures/f-0204.json) Test `format=table` on `_qty` for different positional unit preference (#1329, en)
+* [f-0205.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/ByJsonScript/Fixtures/f-0205.json) Test `format=table` on `|+align=`/`|+limit`/`|+order` extra printout parameters (T18571, en)
 * [f-0301.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/ByJsonScript/Fixtures/f-0301.json) Test format=category with template usage (#699, en, skip postgres)
 * [f-0302.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/ByJsonScript/Fixtures/f-0302.json) Test format=category and defaultsort (#699, en)
 * [f-0801.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/ByJsonScript/Fixtures/f-0801.json) Test format=embedded output (skip 1.19)
@@ -98,4 +99,4 @@ Contains 87 files:
 ### S
 * [s-0001.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/ByJsonScript/Fixtures/s-0001.json) Test output of `Special:Properties` (en, skip-on sqlite, 1.19)
 
--- Last updated on 2016-01-06 by `readmeContentsBuilder.php`
+-- Last updated on 2016-01-08 by `readmeContentsBuilder.php`


### PR DESCRIPTION
```
{{#ask: [[Currency::+]]
 |?Currency|+align=right|+limit=2
 |format=table
}}
```

https://phabricator.wikimedia.org/T18571