### PR TITLE
Fix conjunctional position for subquery, refs #1362

### DIFF
--- a/src/SPARQLStore/QueryEngine/Interpreter/ValueDescriptionInterpreter.php
+++ b/src/SPARQLStore/QueryEngine/Interpreter/ValueDescriptionInterpreter.php
@@ -209,7 +209,7 @@ class ValueDescriptionInterpreter implements DescriptionInterpreter {
 		$orderByVariable = $result->orderByVariable;
 
 		if ( $dataItem instanceof DIWikiPage ) {
-			$expElement = $this->exporter->getDataItemExpElement( $dataItem->getSortKeyDataItem() );
+			$expElement = $this->exporter->getDataItemExpElement( new DIBlob( $dataItem->getSortKey() ) );
 		} else {
 			$expElement = $this->exporter->getDataItemHelperExpElement( $dataItem );
 			if ( is_null( $expElement ) ) {

--- a/src/SQLStore/QueryEngine/QuerySegmentListProcessor.php
+++ b/src/SQLStore/QueryEngine/QuerySegmentListProcessor.php
@@ -168,7 +168,10 @@ class QuerySegmentListProcessor {
 				// Pick one subquery as anchor point ...
 				foreach ( $query->components as $qkey => $qid ) {
 					$key = $qkey;
-					break;
+
+					if ( $this->querySegmentList[$qkey]->joinTable !== '' ) {
+						break;
+					}
 				}
 
 				$result = $this->querySegmentList[$key];

--- a/tests/phpunit/Integration/ByJsonScript/Fixtures/q-0905.json
+++ b/tests/phpunit/Integration/ByJsonScript/Fixtures/q-0905.json
@@ -1,0 +1,197 @@
+{
+	"description": "Test `_wpg`/`_txt` conjunction queries (#1362, #1060)",
+	"properties": [
+		{
+			"name": "Has page",
+			"contents": "[[Has type::Page]]"
+		},
+		{
+			"name": "Has text",
+			"contents": "[[Has type::Text]]"
+		}
+	],
+	"subjects": [
+		{
+			"name": "Example/Q0905/1",
+			"contents": "[[Category:Q0905]] [[Has page::123]] [[Has page::ABC]] [[Has text::123]] [[Has text::ABC]]"
+		},
+		{
+			"name": "Example/Q0905/2",
+			"contents": "[[Category:Q0905]] [[Has page::1234]] [[Has page::ABCD]] [[Has text::1234]] [[Has text::ABCD]]"
+		}
+	],
+	"query-testcases": [
+		{
+			"about": "#0",
+			"condition": "[[Category:Q0905]] [[Has page::123]] [[Has page::!ABCD]]",
+			"printouts" : [],
+			"parameters" : {
+				"limit" : "10"
+			},
+			"queryresult": {
+				"count": 1,
+				"results": [
+					"Example/Q0905/1#0##"
+				]
+			}
+		},
+		{
+			"about": "#1",
+			"condition": "[[Category:Q0905]] [[Has page::123]] [[Has page::ABCD]] [[Example/Q0905/1]]",
+			"printouts" : [],
+			"parameters" : {
+				"limit" : "10"
+			},
+			"queryresult": {
+				"count": 0,
+				"results": []
+			}
+		},
+		{
+			"about": "#2 regression case",
+			"condition": "[[Example/Q0905/1]] [[Has page::123]] [[Has page::ABCD]] [[Category:Q0905]]",
+			"printouts" : [],
+			"parameters" : {
+				"limit" : "10"
+			},
+			"queryresult": {
+				"count": 0,
+				"results": []
+			}
+		},
+		{
+			"about": "#3",
+			"condition": "[[Category:Q0905]] [[Has page::123]] [[Has text::ABCD]] [[Example/Q0905/1]]",
+			"printouts" : [],
+			"parameters" : {
+				"limit" : "10"
+			},
+			"queryresult": {
+				"count": 0,
+				"results": []
+			}
+		},
+		{
+			"about": "#4 regression case",
+			"condition": "[[Example/Q0905/1]] [[Has page::123]] [[Has text::ABCD]] [[Category:Q0905]] ",
+			"printouts" : [],
+			"parameters" : {
+				"limit" : "10"
+			},
+			"queryresult": {
+				"count": 0,
+				"results": []
+			}
+		},
+		{
+			"about": "#5, C AND (A OR B)",
+			"condition": "[[Category:Q0905]] [[!Example/Q0905/1]] <q>[[Has page::123]] OR [[Has page::!ABCD]]</q>",
+			"printouts" : [],
+			"parameters" : {
+				"limit" : "10"
+			},
+			"queryresult": {
+				"count": 1,
+				"results": [
+					"Example/Q0905/2#0##"
+				]
+			}
+		},
+		{
+			"about": "#6, (A OR B) AND C",
+			"condition": "<q>[[Has page::123]] OR [[Has page::!ABCD]]</q> [[!Example/Q0905/1]] [[Category:Q0905]] ",
+			"printouts" : [],
+			"parameters" : {
+				"limit" : "10"
+			},
+			"queryresult": {
+				"count": 1,
+				"results": [
+					"Example/Q0905/2#0##"
+				]
+			}
+		},
+		{
+			"about": "#7, (A OR B) AND (C OR D)",
+			"condition": "[[Category:Q0905]] <q>[[Has page::123]] OR [[Has text::1234]]</q> <q>[[Has page::ABCD]] OR [[Has text::ABC]]</q>",
+			"printouts" : [],
+			"parameters" : {
+				"limit" : "10"
+			},
+			"queryresult": {
+				"count": 2,
+				"results": [
+					"Example/Q0905/1#0##",
+					"Example/Q0905/2#0##"
+				]
+			}
+		},
+		{
+			"about": "#8, (A OR B) AND (C OR D) AND E",
+			"condition": "[[Category:Q0905]] <q>[[Has page::123]] OR [[Has text::1234]]</q> <q>[[Has page::ABCD]] OR [[Has text::ABC]]</q> [[Has page::123]]",
+			"printouts" : [],
+			"parameters" : {
+				"limit" : "10"
+			},
+			"queryresult": {
+				"count": 1,
+				"results": [
+					"Example/Q0905/1#0##"
+				]
+			}
+		},
+		{
+			"about": "#9, E AND (A OR B) AND (C OR D)",
+			"condition": "[[Category:Q0905]] [[Has page::123]] <q>[[Has page::123]] OR [[Has text::1234]]</q> <q>[[Has page::ABCD]] OR [[Has text::ABC]]</q>",
+			"printouts" : [],
+			"parameters" : {
+				"limit" : "10"
+			},
+			"queryresult": {
+				"count": 1,
+				"results": [
+					"Example/Q0905/1#0##"
+				]
+			}
+		},
+		{
+			"about": "#10, (A OR B) AND (C OR D) AND !E AND F",
+			"condition": "<q>[[Has page::123]] OR [[Has page::ABCD]]</q><q>[[Has page::1234]] OR [[Has page::ABC]]</q>[[Has page::!123]][[Has page::ABCD]][[Category:Q0905]] ",
+			"printouts" : [],
+			"parameters" : {
+				"limit" : "10"
+			},
+			"queryresult": {
+				"count": 1,
+				"results": [
+					"Example/Q0905/2#0##"
+				]
+			}
+		},
+		{
+			"about": "#10, !E AND F AND (A OR B) AND (C OR D)",
+			"condition": "[[Category:Q0905]] [[Has page::!123]][[Has page::ABCD]]<q>[[Has page::123]] OR [[Has page::ABCD]]</q><q>[[Has page::1234]] OR [[Has page::ABC]]</q>",
+			"printouts" : [],
+			"parameters" : {
+				"limit" : "10"
+			},
+			"queryresult": {
+				"count": 1,
+				"results": [
+					"Example/Q0905/2#0##"
+				]
+			}
+		}
+	],
+	"settings": {
+		"smwgNamespacesWithSemanticLinks": {
+			"NS_MAIN": true,
+			"SMW_NS_PROPERTY": true
+		}
+	},
+	"meta": {
+		"version": "0.1",
+		"is-incomplete": false,
+		"debug": false
+	}
+}


### PR DESCRIPTION
refs #1362, #1060, #19 

`QuerySegmentListProcessor` is not to assume to use the first key as anchor when other subqueries can contain additional joins.

The added test cases uncovered an issue in `SPARQLStore` when the annotation contains  numeric values by which `$dataItem->getSortKeyDataItem()` would return a `DINumber` object and SPARQL would search for `"123"^^xsd:double` while we want `"123"` since all sort values are strings. (i.e. `[[Category:Q0905]] [[Has page::!123]] [[Has text::!ABCD]] [[Example/Q0905/1]]` would not return an appropriate result)