### PR TITLE
Add additional blob index, refs #1344

### DIFF
--- a/includes/storage/SQLStore/SMW_DIHandler_Blob.php
+++ b/includes/storage/SQLStore/SMW_DIHandler_Blob.php
@@ -53,6 +53,17 @@ class SMWDIHandlerBlob extends SMWDataItemHandler {
 	}
 
 	/**
+	 * @see SMWDataItemHandler::getTableIndexes
+	 *
+	 * @since 2.4
+	 *
+	 * @return array
+	 */
+	public function getTableIndexes() {
+		return array( 's_id,o_hash' );
+	}
+
+	/**
 	 * Method to return an array of fields=>values for a DataItem
 	 *
 	 * @return array


### PR DESCRIPTION
Thanks to our debug EXPLAIN #1171 the following was made visible and shows that the new `s_id_2` index is preferred for some queries. 

 refs #1344

## Example 1

![image](https://cloud.githubusercontent.com/assets/1245473/12314549/6cbf1a82-ba72-11e5-9bab-96f819c18296.png)

![image](https://cloud.githubusercontent.com/assets/1245473/12314616/e8c7e99c-ba72-11e5-91fd-00f8c2349b64.png)

```
1	SIMPLE	t6	ref	s_id,o_hash	o_hash	258	const	5	Using index condition; Using where; Distinct
1	SIMPLE	t5	ref	s_id	s_id	4	mw-25-01.t2.o_id	3	Using index; Distinct
```
vs
````
1	SIMPLE	t6	ref	s_id,o_hash,s_id_2	s_id_2	262	mw-25-01.t2.o_id,const	2	Using where; Using index; Distinct
1	SIMPLE	t5	ref	s_id,s_id_2	s_id	4	mw-25-01.t2.o_id	3	Using index; Distinct
```

## Example 2

![image](https://cloud.githubusercontent.com/assets/1245473/12314564/81f54cd2-ba72-11e5-9362-3b4d82192fa4.png)

![image](https://cloud.githubusercontent.com/assets/1245473/12314622/fd7cfdc8-ba72-11e5-8cbe-0b20f2fa0b70.png)


```
1	SIMPLE	t3	ref	s_id,o_hash	s_id	4	mw-25-01.t0.o_id	3	Using where; Distinct
1	SIMPLE	t4	ALL	s_id,o_hash				26	Using where; Distinct; Using join buffer (Block Nested Loop)
```
vs
```
1	SIMPLE	t3	ref	s_id,o_hash,s_id_2	s_id_2	262	mw-25-01.t0.o_id,const	2	Using where; Using index; Distinct
1	SIMPLE	t4	ref	s_id,o_hash,s_id_2	s_id_2	262	mw-25-01.t0.o_id,const	2	Using where; Using index; Distinct
```