### PR TITLE
Allows to inject options to the DVFactory

### DIFF
--- a/SemanticMediaWiki.settings.php
+++ b/SemanticMediaWiki.settings.php
@@ -946,15 +946,19 @@ $GLOBALS['smwgExportBCNonCanonicalFormUse'] = false;
 $GLOBALS['smwgEnabledInTextAnnotationParserStrictMode'] = true;
 
 ##
-# If a property is redirected to a different target (Foo -> Bar) then follow it
-# by default in order toallow query results to be displayed equivalent for both
-# queries without having to adjust (or change) a query.
+# Features or restrictions for specific DataValue types
 #
-# @note This setting is mainly provided to restore backwards compatibility where
+# - SMW_DV_NONE
+#
+# - SMW_DV_PROV_REDI (PropertyValue) If a property is redirected to a different
+# target (Foo -> Bar) then follow it by default in order to allow query results
+# to be displayed equivalent for both queries without having to adjust
+# (or change) a query.
+#
+# This flag is mainly provided to restore backwards compatibility where
 # behaviour is not expected to be altered, nevertheless it is recommended that
 # the setting is enabled to improve user friendliness in terms of query execution.
 #
 # @since 2.4
-# @default true
 ##
-$GLOBALS['smwgFollowPropertyRedirect'] = true;
+$GLOBALS['smwgDVFeatures'] = SMW_DV_PROV_REDI;

--- a/includes/Defines.php
+++ b/includes/Defines.php
@@ -134,3 +134,10 @@ define( 'SMW_VL_PS', 8 ); // enables ValueLookupStore::getPropertySubject
 define( 'SMW_UJ_PM_NP', 2 );    // use a new parser
 define( 'SMW_UJ_PM_CLASTMDATE', 4 ); // compare last modified
 /**@}*/
+
+/**@{
+  * Constants DV features
+  */
+define( 'SMW_DV_NONE', 0 );
+define( 'SMW_DV_PROV_REDI', 2 );  // PropertyValue to follow a property redirect target
+/**@}*/

--- a/includes/Settings.php
+++ b/includes/Settings.php
@@ -141,7 +141,7 @@ class Settings extends SimpleDictionary {
 			'smwgExportBCAuxiliaryUse' => $GLOBALS['smwgExportBCAuxiliaryUse'],
 			'smwgEnabledInTextAnnotationParserStrictMode' => $GLOBALS['smwgEnabledInTextAnnotationParserStrictMode'],
 			'smwgSparqlRepositoryConnectorForcedHttpVersion' => $GLOBALS['smwgSparqlRepositoryConnectorForcedHttpVersion'],
-			'smwgFollowPropertyRedirect' => $GLOBALS['smwgFollowPropertyRedirect']
+			'smwgDVFeatures' => $GLOBALS['smwgDVFeatures']
 		);
 
 		$settings = $settings + array(

--- a/includes/datavalues/SMW_DV_Property.php
+++ b/includes/datavalues/SMW_DV_Property.php
@@ -1,11 +1,6 @@
 <?php
-/**
- * File holding class SMWPropertyValue.
- *
- * @author Markus Krötzsch
- *
- * @ingroup SMWDataValues
- */
+
+use SMW\DataValueFactory;
 
 /**
  * Objects of this class represent properties in SMW.
@@ -52,18 +47,21 @@ class SMWPropertyValue extends SMWDataValue {
 	private $inceptiveProperty = null;
 
 	/**
-	 * @var boolean
-	 */
-	private $followPropertyRedirect = true;
-
-	/**
 	 * @since 2.4
 	 *
 	 * @param string $typeid
 	 */
 	public function __construct( $typeid ) {
 		parent::__construct( $typeid );
-		$this->followPropertyRedirect = $GLOBALS['smwgFollowPropertyRedirect'];
+	}
+
+	/**
+	 * @since 2.4
+	 *
+	 * @return boolean
+	 */
+	public function isToFindPropertyRedirect() {
+		return ( $this->getOptionValueFor( 'smwgDVFeatures' ) & SMW_DV_PROV_REDI ) != 0;
 	}
 
 	/**
@@ -77,10 +75,8 @@ class SMWPropertyValue extends SMWDataValue {
 	 *
 	 * @return SMWPropertyValue
 	 */
-	static public function makeUserProperty( $propertyName ) {
-		$property = new SMWPropertyValue( '__pro' );
-		$property->setUserValue( $propertyName );
-		return $property;
+	static public function makeUserProperty( $propertyLabel ) {
+		return DataValueFactory::getInstance()->newPropertyValueByLabel( $propertyLabel );
 	}
 
 	/**
@@ -156,8 +152,7 @@ class SMWPropertyValue extends SMWDataValue {
 
 		$this->inceptiveProperty = $this->m_dataitem;
 
-		// Find the "real" target of a property
-		if ( $this->followPropertyRedirect ) {
+		if ( $this->isToFindPropertyRedirect() ) {
 			$this->m_dataitem = $this->m_dataitem->getRedirectTarget();
 		}
 	}

--- a/includes/datavalues/SMW_DataValue.php
+++ b/includes/datavalues/SMW_DataValue.php
@@ -8,6 +8,7 @@
  * @ingroup SMW
  */
 use SMW\DataValueFactory;
+use SMW\Options;
 use SMW\Query\QueryComparator;
 use SMW\Deserializers\DVDescriptionDeserializerFactory;
 
@@ -134,6 +135,11 @@ abstract class SMWDataValue {
 	 * @var array
 	 */
 	private $extraneousFunctions = array();
+
+	/**
+	 * @var Options
+	 */
+	private $options;
 
 	/**
 	 * Indicates whether a value is being used by a query condition or not which
@@ -266,6 +272,38 @@ abstract class SMWDataValue {
 	 */
 	public function setContextPage( SMWDIWikiPage $contextPage ) {
 		$this->m_contextPage = $contextPage;
+	}
+
+	/**
+	 * @since 2.4
+	 *
+	 * @return DIWikiPage|null
+	 */
+	public function getContextPage() {
+		return $this->m_contextPage;
+	}
+
+	/**
+	 * @since 2.4
+	 *
+	 * @return Options $options
+	 */
+	public function setOptions( Options $options ) {
+		$this->options = $options;
+	}
+
+	/**
+	 * @since 2.4
+	 *
+	 * @return mixed|false
+	 */
+	public function getOptionValueFor( $key ) {
+
+		if ( $this->options !== null && $this->options->has( $key ) ) {
+			return $this->options->get( $key );
+		}
+
+		return false;
 	}
 
 	/**

--- a/src/DataTypeRegistry.php
+++ b/src/DataTypeRegistry.php
@@ -100,6 +100,11 @@ class DataTypeRegistry {
 	private $extraneousFunctions = array();
 
 	/**
+	 * @var Options
+	 */
+	private $options = null;
+
+	/**
 	 * Returns a DataTypeRegistry instance
 	 *
 	 * @since 1.9
@@ -117,6 +122,11 @@ class DataTypeRegistry {
 			);
 
 			self::$instance->initDatatypes();
+
+			self::$instance->setOption(
+				'smwgDVFeatures',
+				ApplicationFactory::getInstance()->getSettings()->get( 'smwgDVFeatures' )
+			);
 		}
 
 		return self::$instance;
@@ -482,6 +492,30 @@ class DataTypeRegistry {
 	 */
 	public function getExtraneousFunctions() {
 		return $this->extraneousFunctions;
+	}
+
+	/**
+	 * @since 2.4
+	 *
+	 * @return Options
+	 */
+	public function getOptions() {
+
+		if ( $this->options === null ) {
+			$this->options = new Options();
+		}
+
+		return $this->options;
+	}
+
+	/**
+	 * @since 2.4
+	 *
+	 * @param string $key
+	 * @param string $value
+	 */
+	public function setOption( $key, $value ) {
+		$this->getOptions()->set( $key, $value );
 	}
 
 }

--- a/src/DataValueFactory.php
+++ b/src/DataValueFactory.php
@@ -85,6 +85,10 @@ class DataValueFactory {
 			$dataTypeRegistry->getExtraneousFunctions()
 		);
 
+		$result->setOptions(
+			$dataTypeRegistry->getOptions()
+		);
+
 		if ( $property !== null ) {
 			$result->setProperty( $property );
 		}
@@ -160,7 +164,7 @@ class DataValueFactory {
 	 *
 	 * @return DataValue
 	 */
-	public function newPropertyValue( $propertyName, $valueString,
+	public function newPropertyObjectValueByText( $propertyName, $valueString,
 		$caption = false, DIWikiPage $contextPage = null ) {
 
 		// Enforce upper case for the first character on annotations that are used
@@ -170,7 +174,7 @@ class DataValueFactory {
 			$propertyName = ucfirst( $propertyName );
 		}
 
-		$propertyDV = SMWPropertyValue::makeUserProperty( $propertyName );
+		$propertyDV = $this->newPropertyValueByLabel( $propertyName );
 
 		if ( !$propertyDV->isValid() ) {
 			return $propertyDV;
@@ -236,6 +240,27 @@ class DataValueFactory {
 		}
 
 		return $dataValue;
+	}
+
+	/**
+	 * @deprecated since 2.4, use DataTypeRegistry::newPropertyObjectValueByText
+	 *
+	 * @return DataValue
+	 */
+	public function newPropertyValue( $propertyName, $valueString,
+		$caption = false, DIWikiPage $contextPage = null ) {
+		return $this->newPropertyObjectValueByText( $propertyName, $valueString, $caption, $contextPage );
+	}
+
+	/**
+	 * @since 2.4
+	 *
+	 * @param string $propertyName
+	 *
+	 * @return DataValue
+	 */
+	public function newPropertyValueByLabel( $propertyLabel ) {
+		return self::newTypeIdValue( '__pro', $propertyLabel );
 	}
 
 	/**

--- a/tests/phpunit/Unit/DataValueFactoryTest.php
+++ b/tests/phpunit/Unit/DataValueFactoryTest.php
@@ -104,9 +104,9 @@ class DataValueFactoryTest extends \PHPUnit_Framework_TestCase {
 	/**
 	 * @dataProvider propertyValueDataProvider
 	 */
-	public function testAddPropertyValue( $propertyName, $value, $expectedValue, $expectedInstance ) {
+	public function testAddPropertyValueByText( $propertyName, $value, $expectedValue, $expectedInstance ) {
 
-		$dataValue = DataValueFactory::getInstance()->newPropertyValue( $propertyName, $value );
+		$dataValue = DataValueFactory::getInstance()->newPropertyObjectValueByText( $propertyName, $value );
 
 		// Check the returned instance
 		$this->assertInstanceOf( $expectedInstance, $dataValue );
@@ -122,7 +122,7 @@ class DataValueFactoryTest extends \PHPUnit_Framework_TestCase {
 		}
 
 		// Check interface parameters
-		$dataValue = DataValueFactory::getInstance()->newPropertyValue(
+		$dataValue = DataValueFactory::getInstance()->newPropertyObjectValueByText(
 			$propertyName,
 			$value,
 			'FooCaption',
@@ -137,7 +137,7 @@ class DataValueFactoryTest extends \PHPUnit_Framework_TestCase {
 
 	public function testTryToCreateDataValueUsingRestrictedPropertyValue() {
 
-		$dataValue = DataValueFactory::getInstance()->newPropertyValue( 'Has subobject', 'Foo' );
+		$dataValue = DataValueFactory::getInstance()->newPropertyObjectValueByText( 'Has subobject', 'Foo' );
 
 		$this->assertInstanceOf(
 			'\SMWErrorValue',
@@ -146,6 +146,16 @@ class DataValueFactoryTest extends \PHPUnit_Framework_TestCase {
 
 		$this->assertNotEmpty(
 			$dataValue->getErrors()
+		);
+	}
+
+	public function testToCreateDataValueUsingLegacyNewPropertyValueMethod() {
+
+		$dataValue = DataValueFactory::getInstance()->newPropertyValue( 'Bar', 'Foo' );
+
+		$this->assertInstanceOf(
+			'\SMWDataValue',
+			$dataValue
 		);
 	}
 
@@ -228,7 +238,7 @@ class DataValueFactoryTest extends \PHPUnit_Framework_TestCase {
 
 		$instance = DataValueFactory::getInstance();
 
-		$dataValue = $instance->newPropertyValue(
+		$dataValue = $instance->newPropertyObjectValueByText(
 			'has type',
 			'number',
 			null,
@@ -241,6 +251,16 @@ class DataValueFactoryTest extends \PHPUnit_Framework_TestCase {
 		);
 
 		$GLOBALS['wgCapitalLinks'] = $wgCapitalLinks;
+	}
+
+	public function testNewPropertyValueByLabel() {
+
+		$dataValue = DataValueFactory::getInstance()->newPropertyValueByLabel( 'Foo' );
+
+		$this->assertInstanceOf(
+			'\SMWPropertyValue',
+			$dataValue
+		);
 	}
 
 	/**

--- a/tests/phpunit/includes/DataValues/PropertyValueTest.php
+++ b/tests/phpunit/includes/DataValues/PropertyValueTest.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace SMW\Tests\DataValues;
+
+use SMW\DIProperty;
+use SMWPropertyValue as PropertyValue;
+use SMW\Options;
+
+/**
+ * @covers \SMWPropertyValue
+ * @group semantic-mediawiki
+ *
+ * @license GNU GPL v2+
+ * @since 2.4
+ *
+ * @author mwjames
+ */
+class PropertyValueTest extends \PHPUnit_Framework_TestCase {
+
+	public function testCanConstruct() {
+
+		$this->assertInstanceOf(
+			'\SMWPropertyValue',
+			new PropertyValue( '__pro' )
+		);
+	}
+
+	/**
+	 * @dataProvider optionsProvider
+	 */
+	public function testNeedsToFindPropertyRedirectOrNotByOption( $options, $expected ) {
+
+		$instance = new PropertyValue( '__pro' );
+
+		$instance->setOptions(
+			new Options( array( 'smwgDVFeatures' => $options ) )
+		);
+
+		$this->assertEquals(
+			$expected,
+			$instance->isToFindPropertyRedirect()
+		);
+	}
+
+	public function optionsProvider() {
+
+		$provider[] = array(
+			SMW_DV_PROV_REDI,
+			true
+		);
+
+		$provider[] = array(
+			SMW_DV_NONE | SMW_DV_PROV_REDI,
+			true
+		);
+
+		$provider[] = array(
+			SMW_DV_NONE,
+			false
+		);
+
+		$provider[] = array(
+			false,
+			false
+		);
+
+		return $provider;
+	}
+
+}


### PR DESCRIPTION
```php
\Hooks::register( 'SMW::DataType::initTypes', function ( $dataTypeRegistry ) {

	$dataTypeRegistry->registerDatatype(
		'_foo_bar',
		'\Foo\DataValues\FooValue',
		DataItem::TYPE_BLOB
	);

	$dataTypeRegistry->setOption(
		'someSettingRelevantForTheFactoryProcess',
		42
	);

	return true;
};

```
```php
class FooValue extends DataValue {

	private function methodThatIsExcecutedDuringTheDVFactoryProcess() {
		if ( $this->getOptionValueFor( 'someSettingRelevantForTheFactoryProcess' ) === 42 ) {

		}
	}
}
```
```php
$fooValue = DataValueFactory::getInstance()->newTypeIdValue(
	'_foo_bar',
	'Bar'
)

$fooValue->doSomething();
```

- Required by #1344 but has been separated to test it independently
- Allows to clean-up [0, 1]
- refs #1290 (removes GLOBALS use)

[0] https://github.com/SemanticMediaWiki/SemanticCite/blob/master/src/DataValues/CitationReferenceValue.php#L47-L48
[1] https://github.com/SemanticMediaWiki/SemanticCite/blob/master/src/HookRegistry.php#L124-L154