### PR TITLE
Tidy

### DIFF
--- a/includes/parserhooks/DeclareParserFunction.php
+++ b/includes/parserhooks/DeclareParserFunction.php
@@ -108,7 +108,7 @@ class DeclareParserFunction {
 
 	private function addDataValue( $property, $value ) {
 
-		$dataValue = DataValueFactory::getInstance()->newPropertyValue(
+		$dataValue = DataValueFactory::getInstance()->newPropertyObjectValueByText(
 			$property,
 			$value,
 			false,

--- a/includes/parserhooks/SetParserFunction.php
+++ b/includes/parserhooks/SetParserFunction.php
@@ -75,7 +75,7 @@ class SetParserFunction {
 
 			foreach ( $values as $key => $value ) {
 
-				$dataValue = DataValueFactory::getInstance()->newPropertyValue(
+				$dataValue = DataValueFactory::getInstance()->newPropertyObjectValueByText(
 						$property,
 						$value,
 						false,

--- a/includes/parserhooks/SubobjectParserFunction.php
+++ b/includes/parserhooks/SubobjectParserFunction.php
@@ -134,7 +134,7 @@ class SubobjectParserFunction {
 
 			foreach ( $values as $value ) {
 
-				$dataValue = $this->dataValueFactory->newPropertyValue(
+				$dataValue = $this->dataValueFactory->newPropertyObjectValueByText(
 						$property,
 						$value,
 						false,

--- a/src/InTextAnnotationParser.php
+++ b/src/InTextAnnotationParser.php
@@ -386,7 +386,7 @@ class InTextAnnotationParser {
 
 		// Add properties to the semantic container
 		foreach ( $properties as $property ) {
-			$dataValue = $this->dataValueFactory->newPropertyValue(
+			$dataValue = $this->dataValueFactory->newPropertyObjectValueByText(
 				$property,
 				$value,
 				$valueCaption,

--- a/tests/phpunit/Integration/ByJsonScript/QueryTestCaseInterpreter.php
+++ b/tests/phpunit/Integration/ByJsonScript/QueryTestCaseInterpreter.php
@@ -214,7 +214,7 @@ class QueryTestCaseInterpreter {
 		}
 
 		foreach ( $this->contents['queryresult']['datavalues'] as $datavalue ) {
-			$dataValues[] = DataValueFactory::getInstance()->newPropertyValue(
+			$dataValues[] = DataValueFactory::getInstance()->newPropertyObjectValueByText(
 				$datavalue['property'],
 				$datavalue['value']
 			);

--- a/tests/phpunit/Integration/MediaWiki/ApiBrowseBySubjectDBIntegrationTest.php
+++ b/tests/phpunit/Integration/MediaWiki/ApiBrowseBySubjectDBIntegrationTest.php
@@ -70,7 +70,7 @@ class ApiBrowseBySubjectDBIntegrationTest extends MwDBaseUnitTestCase {
 		$semanticData = $this->semanticDataFactory->newEmptySemanticData( __METHOD__ );
 
 		$semanticData->addDataValue(
-			$this->dataValueFactory->newPropertyValue( __METHOD__, 'Bar' )
+			$this->dataValueFactory->newPropertyObjectValueByText( __METHOD__, 'Bar' )
 		);
 
 		$this->getStore()->updateData( $semanticData );
@@ -98,14 +98,14 @@ class ApiBrowseBySubjectDBIntegrationTest extends MwDBaseUnitTestCase {
 		$semanticData = $this->semanticDataFactory->newEmptySemanticData( __METHOD__ );
 
 		$semanticData->addDataValue(
-			$this->dataValueFactory->newPropertyValue( __METHOD__, 'Bar' )
+			$this->dataValueFactory->newPropertyObjectValueByText( __METHOD__, 'Bar' )
 		);
 
 		$subobject = new Subobject( $semanticData->getSubject()->getTitle() );
 		$subobject->setEmptyContainerForId( 'Foo' );
 
 		$subobject->addDataValue(
-			$this->dataValueFactory->newPropertyValue( __METHOD__, 'Bam' )
+			$this->dataValueFactory->newPropertyObjectValueByText( __METHOD__, 'Bam' )
 		);
 
 		$semanticData->addPropertyObjectValue(

--- a/tests/phpunit/Integration/SemanticDataSerializationDBIntegrationTest.php
+++ b/tests/phpunit/Integration/SemanticDataSerializationDBIntegrationTest.php
@@ -36,7 +36,7 @@ class SemanticDataSerializationDBIntegrationTest extends MwDBaseUnitTestCase {
 		$subobject->setEmptyContainerForId( 'SomeSubobjectToSerialize' );
 
 		$subobject->getSemanticData()->addDataValue(
-			DataValueFactory::getInstance()->newPropertyValue( 'Foo', 'Bar' )
+			DataValueFactory::getInstance()->newPropertyObjectValueByText( 'Foo', 'Bar' )
 		);
 
 		$semanticDataBeforeUpdate->addSubobject( $subobject );

--- a/tests/phpunit/Integration/SemanticDataSerializerDeserializerRoundtripTest.php
+++ b/tests/phpunit/Integration/SemanticDataSerializerDeserializerRoundtripTest.php
@@ -100,16 +100,16 @@ class SemanticDataSerializerDeserializerRoundtripTest extends \PHPUnit_Framework
 
 		// #1 Single entry
 		$foo = new SemanticData( DIWikiPage::newFromTitle( $title ) );
-		$foo->addDataValue( DataValueFactory::getInstance()->newPropertyValue( 'Has fooQuex', 'Bar' ) );
+		$foo->addDataValue( DataValueFactory::getInstance()->newPropertyObjectValueByText( 'Has fooQuex', 'Bar' ) );
 		$provider[] = array( $foo );
 
 		// #2 Single + single subobject entry
 		$foo = new SemanticData( DIWikiPage::newFromTitle( $title ) );
-		$foo->addDataValue( DataValueFactory::getInstance()->newPropertyValue( 'Has fooQuex', 'Bar' ) );
+		$foo->addDataValue( DataValueFactory::getInstance()->newPropertyObjectValueByText( 'Has fooQuex', 'Bar' ) );
 
 		$subobject = new Subobject( $title );
 		$subobject->setSemanticData( 'Foo' );
-		$subobject->addDataValue( DataValueFactory::getInstance()->newPropertyValue( 'Has subobjects', 'Bam' ) );
+		$subobject->addDataValue( DataValueFactory::getInstance()->newPropertyObjectValueByText( 'Has subobjects', 'Bam' ) );
 
 		$foo->addPropertyObjectValue( $subobject->getProperty(), $subobject->getContainer() );
 
@@ -117,16 +117,16 @@ class SemanticDataSerializerDeserializerRoundtripTest extends \PHPUnit_Framework
 
 		// #3 Multiple entries
 		$foo = new SemanticData( DIWikiPage::newFromTitle( $title ) );
-		$foo->addDataValue( DataValueFactory::getInstance()->newPropertyValue( 'Has fooQuex', 'Bar' ) );
-		$foo->addDataValue( DataValueFactory::getInstance()->newPropertyValue( 'Has queez', 'Xeey' ) );
+		$foo->addDataValue( DataValueFactory::getInstance()->newPropertyObjectValueByText( 'Has fooQuex', 'Bar' ) );
+		$foo->addDataValue( DataValueFactory::getInstance()->newPropertyObjectValueByText( 'Has queez', 'Xeey' ) );
 
 		$subobject = new Subobject( $title );
 		$subobject->setSemanticData( 'Foo' );
-		$subobject->addDataValue( DataValueFactory::getInstance()->newPropertyValue( 'Has subobjects', 'Bam' ) );
-		$subobject->addDataValue( DataValueFactory::getInstance()->newPropertyValue( 'Has fooQuex', 'Fuz' ) );
+		$subobject->addDataValue( DataValueFactory::getInstance()->newPropertyObjectValueByText( 'Has subobjects', 'Bam' ) );
+		$subobject->addDataValue( DataValueFactory::getInstance()->newPropertyObjectValueByText( 'Has fooQuex', 'Fuz' ) );
 
 		$subobject->setSemanticData( 'Bar' );
-		$subobject->addDataValue( DataValueFactory::getInstance()->newPropertyValue( 'Has fooQuex', 'Fuz' ) );
+		$subobject->addDataValue( DataValueFactory::getInstance()->newPropertyObjectValueByText( 'Has fooQuex', 'Fuz' ) );
 
 		$foo->addPropertyObjectValue( $subobject->getProperty(), $subobject->getContainer() );
 
@@ -148,7 +148,7 @@ class SemanticDataSerializerDeserializerRoundtripTest extends \PHPUnit_Framework
 		$subobject->setSemanticData( 'Foo' );
 
 		$foo = new SemanticData( DIWikiPage::newFromTitle( $title ) );
-		$foo->addDataValue( DataValueFactory::getInstance()->newPropertyValue( 'Has fooQuex', 'Bar' ) );
+		$foo->addDataValue( DataValueFactory::getInstance()->newPropertyObjectValueByText( 'Has fooQuex', 'Bar' ) );
 		$foo->addPropertyObjectValue( $subobject->getProperty(), $subobject->getSemanticData()->getSubject() );
 
 		$provider[] = array( $foo );
@@ -166,7 +166,7 @@ class SemanticDataSerializerDeserializerRoundtripTest extends \PHPUnit_Framework
 
 		// #0 Single entry
 		$foo = new SemanticData( DIWikiPage::newFromTitle( $title ) );
-		$foo->addDataValue( DataValueFactory::getInstance()->newPropertyValue( 'Has fooQuex', 'Bar' ) );
+		$foo->addDataValue( DataValueFactory::getInstance()->newPropertyObjectValueByText( 'Has fooQuex', 'Bar' ) );
 
 		$provider[] = array( $foo, 'Has_fooQuex' );
 
@@ -175,7 +175,7 @@ class SemanticDataSerializerDeserializerRoundtripTest extends \PHPUnit_Framework
 
 		$subobject = new Subobject( $title );
 		$subobject->setSemanticData( 'Foo' );
-		$subobject->addDataValue( DataValueFactory::getInstance()->newPropertyValue( 'Has fomQuex', 'Bam' ) );
+		$subobject->addDataValue( DataValueFactory::getInstance()->newPropertyObjectValueByText( 'Has fomQuex', 'Bam' ) );
 
 		$foo->addPropertyObjectValue( $subobject->getProperty(), $subobject->getContainer() );
 
@@ -183,7 +183,7 @@ class SemanticDataSerializerDeserializerRoundtripTest extends \PHPUnit_Framework
 
 		// #2 Combined
 		$foo = new SemanticData( DIWikiPage::newFromTitle( $title ) );
-		$foo->addDataValue( DataValueFactory::getInstance()->newPropertyValue( 'Has fooQuex', 'Bar' ) );
+		$foo->addDataValue( DataValueFactory::getInstance()->newPropertyObjectValueByText( 'Has fooQuex', 'Bar' ) );
 		$foo->addPropertyObjectValue( $subobject->getProperty(), $subobject->getContainer() );
 
 		$provider[] = array( $foo, 'Has_fomQuex' );

--- a/tests/phpunit/Integration/SemanticDataStorageDBIntegrationTest.php
+++ b/tests/phpunit/Integration/SemanticDataStorageDBIntegrationTest.php
@@ -118,7 +118,7 @@ class SemanticDataStorageDBIntegrationTest extends MwDBaseUnitTestCase {
 		$this->subjects[] = $subject = DIWikiPage::newFromTitle( Title::newFromText( __METHOD__ ) );
 		$semanticData = new SemanticData( $subject );
 
-		$dataValue = DataValueFactory::getInstance()->newPropertyValue(
+		$dataValue = DataValueFactory::getInstance()->newPropertyObjectValueByText(
 			$propertyAsString,
 			'Foo',
 			false,
@@ -144,7 +144,7 @@ class SemanticDataStorageDBIntegrationTest extends MwDBaseUnitTestCase {
 		$subobject->setEmptyContainerForId( 'SomeSubobject' );
 
 		$subobject->getSemanticData()->addDataValue(
-			DataValueFactory::getInstance()->newPropertyValue( 'Foo', 'Bar' )
+			DataValueFactory::getInstance()->newPropertyObjectValueByText( 'Foo', 'Bar' )
 		);
 
 		$semanticData->addPropertyObjectValue(

--- a/tests/phpunit/Unit/Serializers/SemanticDataSerializerTest.php
+++ b/tests/phpunit/Unit/Serializers/SemanticDataSerializerTest.php
@@ -68,16 +68,16 @@ class SemanticDataSerializerTest extends \PHPUnit_Framework_TestCase {
 
 		#1 Single entry
 		$foo = $this->semanticDataFactory->setSubject( DIWikiPage::newFromTitle( $title ) )->newEmptySemanticData();
-		$foo->addDataValue( $this->dataValueFactory->newPropertyValue( 'Has fooQuex', 'Bar' ) );
+		$foo->addDataValue( $this->dataValueFactory->newPropertyObjectValueByText( 'Has fooQuex', 'Bar' ) );
 		$provider[] = array( $foo );
 
 		// #2 Single + single subobject entry
 		$foo = $this->semanticDataFactory->setSubject( DIWikiPage::newFromTitle( $title ) )->newEmptySemanticData();
-		$foo->addDataValue( $this->dataValueFactory->newPropertyValue( 'Has fooQuex', 'Bar' ) );
+		$foo->addDataValue( $this->dataValueFactory->newPropertyObjectValueByText( 'Has fooQuex', 'Bar' ) );
 
 		$subobject = new Subobject( $title );
 		$subobject->setSemanticData( 'Foo' );
-		$subobject->addDataValue( $this->dataValueFactory->newPropertyValue( 'Has subobjects', 'Bam' ) );
+		$subobject->addDataValue( $this->dataValueFactory->newPropertyObjectValueByText( 'Has subobjects', 'Bam' ) );
 
 		$foo->addPropertyObjectValue(
 			$subobject->getProperty(),
@@ -88,16 +88,16 @@ class SemanticDataSerializerTest extends \PHPUnit_Framework_TestCase {
 
 		#3 Multiple entries
 		$foo = $this->semanticDataFactory->setSubject( DIWikiPage::newFromTitle( $title ) )->newEmptySemanticData();
-		$foo->addDataValue( $this->dataValueFactory->newPropertyValue( 'Has fooQuex', 'Bar' ) );
-		$foo->addDataValue( $this->dataValueFactory->newPropertyValue( 'Has queez', 'Xeey' ) );
+		$foo->addDataValue( $this->dataValueFactory->newPropertyObjectValueByText( 'Has fooQuex', 'Bar' ) );
+		$foo->addDataValue( $this->dataValueFactory->newPropertyObjectValueByText( 'Has queez', 'Xeey' ) );
 
 		$subobject = new Subobject( $title );
 		$subobject->setSemanticData( 'Foo' );
-		$subobject->addDataValue( $this->dataValueFactory->newPropertyValue( 'Has subobjects', 'Bam' ) );
-		$subobject->addDataValue( $this->dataValueFactory->newPropertyValue( 'Has fooQuex', 'Fuz' ) );
+		$subobject->addDataValue( $this->dataValueFactory->newPropertyObjectValueByText( 'Has subobjects', 'Bam' ) );
+		$subobject->addDataValue( $this->dataValueFactory->newPropertyObjectValueByText( 'Has fooQuex', 'Fuz' ) );
 
 		$subobject->setSemanticData( 'Bar' );
-		$subobject->addDataValue( $this->dataValueFactory->newPropertyValue( 'Has fooQuex', 'Fuz' ) );
+		$subobject->addDataValue( $this->dataValueFactory->newPropertyObjectValueByText( 'Has fooQuex', 'Fuz' ) );
 
 		$foo->addPropertyObjectValue(
 			$subobject->getProperty(),

--- a/tests/phpunit/includes/ParserDataTest.php
+++ b/tests/phpunit/includes/ParserDataTest.php
@@ -121,7 +121,7 @@ class ParserDataTest extends \PHPUnit_Framework_TestCase {
 		);
 
 		$instance->addDataValue(
-			$this->dataValueFactory->newPropertyValue( 'Foo', 'Bar' )
+			$this->dataValueFactory->newPropertyObjectValueByText( 'Foo', 'Bar' )
 		);
 
 		$this->assertFalse(
@@ -143,7 +143,7 @@ class ParserDataTest extends \PHPUnit_Framework_TestCase {
 		$instance = new ParserData( $title, $parserOutput );
 
 		$instance->addDataValue(
-			$this->dataValueFactory->newPropertyValue( 'Foo', 'Bar' )
+			$this->dataValueFactory->newPropertyObjectValueByText( 'Foo', 'Bar' )
 		);
 
 		$this->assertFalse( $instance->getSemanticData()->isEmpty() );
@@ -173,7 +173,7 @@ class ParserDataTest extends \PHPUnit_Framework_TestCase {
 		);
 
 		$semanticData->addDataValue(
-			$this->dataValueFactory->newPropertyValue( 'Foo', 'Bar' )
+			$this->dataValueFactory->newPropertyObjectValueByText( 'Foo', 'Bar' )
 		);
 
 		$instance->setSemanticData( $semanticData );
@@ -205,7 +205,7 @@ class ParserDataTest extends \PHPUnit_Framework_TestCase {
 		$instance = new ParserData( $title, $parserOutput );
 
 		$instance->addDataValue(
-			$this->dataValueFactory->newPropertyValue(
+			$this->dataValueFactory->newPropertyObjectValueByText(
 				$propertyName,
 				$value
 			)
@@ -285,7 +285,7 @@ class ParserDataTest extends \PHPUnit_Framework_TestCase {
 		);
 
 		$instance->addDataValue(
-			$this->dataValueFactory->newPropertyValue(
+			$this->dataValueFactory->newPropertyObjectValueByText(
 				'Foo',
 				'Bar'
 			)
@@ -306,7 +306,7 @@ class ParserDataTest extends \PHPUnit_Framework_TestCase {
 		);
 
 		$import->addDataValue(
-			$this->dataValueFactory->newPropertyValue(
+			$this->dataValueFactory->newPropertyObjectValueByText(
 				'Foo',
 				'Bar'
 			)

--- a/tests/phpunit/includes/SemanticDataTest.php
+++ b/tests/phpunit/includes/SemanticDataTest.php
@@ -114,7 +114,7 @@ class SemanticDataTest extends \PHPUnit_Framework_TestCase {
 		$instance = new SemanticData( DIWikiPage::newFromTitle( $title ) );
 
 		$instance->addDataValue(
-			DataValueFactory::getInstance()->newPropertyValue( 'Has fooQuex', 'Bar' )
+			DataValueFactory::getInstance()->newPropertyObjectValueByText( 'Has fooQuex', 'Bar' )
 		);
 
 		$subobject = $this->newSubobject( $title );
@@ -137,11 +137,11 @@ class SemanticDataTest extends \PHPUnit_Framework_TestCase {
 		);
 
 		$instance->addDataValue(
-			$this->dataValueFactory->newPropertyValue( 'Foo', 'Bar' )
+			$this->dataValueFactory->newPropertyObjectValueByText( 'Foo', 'Bar' )
 		);
 
 		$instance->addDataValue(
-			$this->dataValueFactory->newPropertyValue( 'Bar', 'Foo' )
+			$this->dataValueFactory->newPropertyObjectValueByText( 'Bar', 'Foo' )
 		);
 
 		$instanceToCheck = new SemanticData(
@@ -149,11 +149,11 @@ class SemanticDataTest extends \PHPUnit_Framework_TestCase {
 		);
 
 		$instanceToCheck->addDataValue(
-			$this->dataValueFactory->newPropertyValue( 'Bar', 'Foo' )
+			$this->dataValueFactory->newPropertyObjectValueByText( 'Bar', 'Foo' )
 		);
 
 		$instanceToCheck->addDataValue(
-			$this->dataValueFactory->newPropertyValue( 'Foo', 'Bar' )
+			$this->dataValueFactory->newPropertyObjectValueByText( 'Foo', 'Bar' )
 		);
 
 		$this->assertEquals(
@@ -168,11 +168,11 @@ class SemanticDataTest extends \PHPUnit_Framework_TestCase {
 		$subobject->setEmptyContainerForId( 'Foo' );
 
 		$subobject->addDataValue(
-			$this->dataValueFactory->newPropertyValue( 'Foo', 'Bar' )
+			$this->dataValueFactory->newPropertyObjectValueByText( 'Foo', 'Bar' )
 		);
 
 		$subobject->addDataValue(
-			$this->dataValueFactory->newPropertyValue( 'Bar', 'Foo' )
+			$this->dataValueFactory->newPropertyObjectValueByText( 'Bar', 'Foo' )
 		);
 
 		$instance = new SemanticData(
@@ -187,11 +187,11 @@ class SemanticDataTest extends \PHPUnit_Framework_TestCase {
 		$subobject->setEmptyContainerForId( 'Foo' );
 
 		$subobject->addDataValue(
-			$this->dataValueFactory->newPropertyValue( 'Bar', 'Foo' )
+			$this->dataValueFactory->newPropertyObjectValueByText( 'Bar', 'Foo' )
 		);
 
 		$subobject->addDataValue(
-			$this->dataValueFactory->newPropertyValue( 'Foo', 'Bar' )
+			$this->dataValueFactory->newPropertyObjectValueByText( 'Foo', 'Bar' )
 		);
 
 		$instanceToCheck = new SemanticData(
@@ -217,7 +217,7 @@ class SemanticDataTest extends \PHPUnit_Framework_TestCase {
 		$firstHash = $instance->getHash();
 
 		$instance->addDataValue(
-			$this->dataValueFactory->newPropertyValue( 'Foo', 'Bar' )
+			$this->dataValueFactory->newPropertyObjectValueByText( 'Foo', 'Bar' )
 		);
 
 		$secondHash = $instance->getHash();
@@ -231,7 +231,7 @@ class SemanticDataTest extends \PHPUnit_Framework_TestCase {
 		$subobject->setEmptyContainerForId( 'Foo' );
 
 		$subobject->addDataValue(
-			$this->dataValueFactory->newPropertyValue( 'Foo', 'Bar' )
+			$this->dataValueFactory->newPropertyObjectValueByText( 'Foo', 'Bar' )
 		);
 
 		$instance->addSubSemanticData(
@@ -450,7 +450,7 @@ class SemanticDataTest extends \PHPUnit_Framework_TestCase {
 		$instance = new SemanticData( DIWikiPage::newFromTitle( $title ) );
 
 		$instance->addDataValue(
-			DataValueFactory::getInstance()->newPropertyValue( 'Has fooQuex', 'Bar' )
+			DataValueFactory::getInstance()->newPropertyObjectValueByText( 'Has fooQuex', 'Bar' )
 		);
 
 		$this->assertTrue(
@@ -555,7 +555,7 @@ class SemanticDataTest extends \PHPUnit_Framework_TestCase {
 		// #0 Single DataValue is added
 		$provider[] = array(
 			array(
-				DataValueFactory::getInstance()->newPropertyValue( 'Foo', 'Bar' ),
+				DataValueFactory::getInstance()->newPropertyObjectValueByText( 'Foo', 'Bar' ),
 			),
 			array(
 				'error'         => 0,
@@ -568,8 +568,8 @@ class SemanticDataTest extends \PHPUnit_Framework_TestCase {
 		// #1 Equal Datavalues will only result in one added object
 		$provider[] = array(
 			array(
-				DataValueFactory::getInstance()->newPropertyValue( 'Foo', 'Bar' ),
-				DataValueFactory::getInstance()->newPropertyValue( 'Foo', 'Bar' ),
+				DataValueFactory::getInstance()->newPropertyObjectValueByText( 'Foo', 'Bar' ),
+				DataValueFactory::getInstance()->newPropertyObjectValueByText( 'Foo', 'Bar' ),
 			),
 			array(
 				'error'         => 0,
@@ -582,8 +582,8 @@ class SemanticDataTest extends \PHPUnit_Framework_TestCase {
 		// #2 Two different DataValue objects
 		$provider[] = array(
 			array(
-				DataValueFactory::getInstance()->newPropertyValue( 'Foo', 'Bar' ),
-				DataValueFactory::getInstance()->newPropertyValue( 'Lila', 'Lula' ),
+				DataValueFactory::getInstance()->newPropertyObjectValueByText( 'Foo', 'Bar' ),
+				DataValueFactory::getInstance()->newPropertyObjectValueByText( 'Lila', 'Lula' ),
 			),
 			array(
 				'error'         => 0,
@@ -596,7 +596,7 @@ class SemanticDataTest extends \PHPUnit_Framework_TestCase {
 		// #3 Error (Inverse)
 		$provider[] = array(
 			array(
-				DataValueFactory::getInstance()->newPropertyValue( '-Foo', 'Bar' ),
+				DataValueFactory::getInstance()->newPropertyObjectValueByText( '-Foo', 'Bar' ),
 			),
 			array(
 				'error'         => 1,
@@ -607,8 +607,8 @@ class SemanticDataTest extends \PHPUnit_Framework_TestCase {
 		// #4 One valid DataValue + an error object
 		$provider[] = array(
 			array(
-				DataValueFactory::getInstance()->newPropertyValue( 'Foo', 'Bar' ),
-				DataValueFactory::getInstance()->newPropertyValue( '-Foo', 'bar' ),
+				DataValueFactory::getInstance()->newPropertyObjectValueByText( 'Foo', 'Bar' ),
+				DataValueFactory::getInstance()->newPropertyObjectValueByText( '-Foo', 'bar' ),
 			),
 			array(
 				'error'         => 1,
@@ -622,7 +622,7 @@ class SemanticDataTest extends \PHPUnit_Framework_TestCase {
 		// #5 Error (Predefined)
 		$provider[] = array(
 			array(
-				DataValueFactory::getInstance()->newPropertyValue( '_Foo', 'Bar' ),
+				DataValueFactory::getInstance()->newPropertyObjectValueByText( '_Foo', 'Bar' ),
 			),
 			array(
 				'error'         => 1,
@@ -633,7 +633,7 @@ class SemanticDataTest extends \PHPUnit_Framework_TestCase {
 		// #6 Error (Known predefined property)
 		$provider[] = array(
 			array(
-				DataValueFactory::getInstance()->newPropertyValue( 'Modification date', 'Bar' ),
+				DataValueFactory::getInstance()->newPropertyObjectValueByText( 'Modification date', 'Bar' ),
 			),
 			array(
 				'error'         => 1,
@@ -650,7 +650,7 @@ class SemanticDataTest extends \PHPUnit_Framework_TestCase {
 		$subobject->setEmptyContainerForId( 'Foo' );
 
 		$subobject->addDataValue(
-			DataValueFactory::getInstance()->newPropertyValue( $property, $value )
+			DataValueFactory::getInstance()->newPropertyObjectValueByText( $property, $value )
 		);
 
 		return $subobject;

--- a/tests/phpunit/includes/SubobjectTest.php
+++ b/tests/phpunit/includes/SubobjectTest.php
@@ -121,7 +121,7 @@ class SubobjectTest extends \PHPUnit_Framework_TestCase {
 
 		foreach ( $parameters['properties'] as $property => $value ){
 
-			$dataValue = DataValueFactory::getInstance()->newPropertyValue(
+			$dataValue = DataValueFactory::getInstance()->newPropertyObjectValueByText(
 				$property,
 				$value
 			);


### PR DESCRIPTION
Replaces `newPropertyValue` (deprecated since 2.4) with `newPropertyObjectValueByText` (#1372).