### PR TITLE
Add support for MonolingualTextValue in Record type, refs #1344

### DIFF
--- a/src/DataValues/MonolingualTextValue.php
+++ b/src/DataValues/MonolingualTextValue.php
@@ -371,6 +371,7 @@ class MonolingualTextValue extends DataValue {
 
 		if ( $this->m_contextPage === null ) {
 			$containerSemanticData = ContainerSemanticData::makeAnonymousContainer();
+			$containerSemanticData->skipAnonymousCheck();
 		} else {
 			$subobjectName = '_ML' . md5( $value );
 

--- a/src/Deserializers/DVDescriptionDeserializer/MonolingualTextValueDescriptionDeserializer.php
+++ b/src/Deserializers/DVDescriptionDeserializer/MonolingualTextValueDescriptionDeserializer.php
@@ -75,7 +75,9 @@ class MonolingualTextValueDescriptionDeserializer extends DescriptionDeserialize
 			// in respect of the query condition
 			$dataValue = DataValueFactory::getInstance()->newDataItemValue(
 				new DIBlob( $value === '' ? '?' : $value ),
-				$property
+				$property,
+				false,
+				$this->dataValue->getContextPage()
 			);
 
 			if ( !$dataValue->isValid() ) {

--- a/src/Deserializers/DVDescriptionDeserializer/RecordValueDescriptionDeserializer.php
+++ b/src/Deserializers/DVDescriptionDeserializer/RecordValueDescriptionDeserializer.php
@@ -111,7 +111,9 @@ class RecordValueDescriptionDeserializer extends DescriptionDeserializer {
 
 		$dataValue = DataValueFactory::getInstance()->newPropertyObjectValue(
 			$diProperty,
-			$values[$valueIndex]
+			$values[$valueIndex],
+			false,
+			$this->dataValue->getContextPage()
 		);
 
 		if ( $dataValue->isValid() ) { // valid DV: keep

--- a/tests/autoloader.php
+++ b/tests/autoloader.php
@@ -34,7 +34,13 @@ if ( is_readable( $path = __DIR__ . '/../vendor/autoload.php' ) ) {
 }
 
 $dateTimeUtc = new \DateTime( 'now', new \DateTimeZone( 'UTC' ) );
-print sprintf( "\n%-20s%s\n\n", "Execution date:", $dateTimeUtc->format( 'Y-m-d h:i' ) );
+print sprintf( "\n%-20s%s\n", "Execution time:", $dateTimeUtc->format( 'Y-m-d h:i' ) );
+
+if ( extension_loaded('xdebug') && xdebug_is_enabled() ) {
+	print sprintf( "%-20s%s\n\n", "Xdebug:",  phpversion('xdebug') . ' (enabled)' );
+} else {
+	print sprintf( "%-20s%s\n\n", "Xdebug:", 'Disabled (or not installed)' );
+}
 
 /**
  * Available to aid third-party extensions therefore any change should be made with

--- a/tests/phpunit/Integration/ByJsonScript/Fixtures/p-0409.json
+++ b/tests/phpunit/Integration/ByJsonScript/Fixtures/p-0409.json
@@ -1,9 +1,13 @@
 {
-	"description": "Test in-text annotation (and #subobject) for when record type points to another record type and is used as annotation to return a `_ERRC` (#1303)",
+	"description": "Test in-text annotation for `_rec`/`_mlt_rec` (+ subobject) for when record type points to another record type (en)",
 	"properties": [
 		{
 			"name": "Has text",
 			"contents": "[[Has type::Text]]"
+		},
+		{
+			"name": "Has monolingual text",
+			"contents": "[[Has type::Monolingual text]]"
 		},
 		{
 			"name": "Has number",
@@ -16,41 +20,142 @@
 		{
 			"name": "Has record two",
 			"contents": "[[Has type::Record]] [[Has fields::Has text;Has record one]]"
+		},
+		{
+			"name": "Has record one mlt",
+			"contents": "[[Has type::Record]] [[Has fields::Has monolingual text;Has number]]"
+		},
+		{
+			"name": "Has record two mlt",
+			"contents": "[[Has type::Record]] [[Has fields::Has monolingual text;Has record one mlt]]"
 		}
 	],
 	"subjects": [
 		{
-			"name": "Example/P0409/1",
-			"contents": "[[Has record two::Foo;abc;12]]"
+			"name": "Example/P0409/1/1",
+			"contents": "[[Has record two::Foo;abc\\;12]]"
 		},
 		{
-			"name": "Example/P0409/2",
-			"contents": "{{#subobject: |Has record two=Foo;abc;12 }}"
+			"name": "Example/P0409/1/2",
+			"contents": "{{#subobject: |Has record two=Foo;abc\\;12 }}"
+		},
+		{
+			"name": "Example/P0409/2/1",
+			"contents": "[[Has record one mlt::test@en;42]]"
+		},
+		{
+			"name": "Example/P0409/2/2",
+			"contents": "{{#subobject: |Has record one mlt=test@en;42}}"
+		},
+		{
+			"name": "Example/P0409/3/1",
+			"contents": "[[Has record two mlt::one@en;two@fr\\;123]]"
+		},
+		{
+			"name": "Example/P0409/3/2",
+			"contents": "{{#subobject: |Has record two mlt=one@en;two@fr\\;123}}"
+		},
+		{
+			"name": "Example/P0409/3/2a",
+			"contents": "{{#ask: [[Has record two mlt::one@en;two@fr\\;123]] |?Has record two mlt}}"
+		},
+		{
+			"name": "Example/P0409/3/2b",
+			"contents": "{{#ask: [[Has record two mlt::one@en;two@fr\\;123]] |?Has record two mlt|+index=1 |?Has record two mlt|+index=2}}"
 		}
 	],
 	"parser-testcases": [
 		{
-			"about": "#0 no exception just a plain error message",
-			"subject": "Example/P0409/1",
+			"about": "#0",
+			"subject": "Example/P0409/1/1",
 			"store": {
 				"semantic-data": {
 					"strict-mode-valuematch": false,
 					"propertyCount": 3,
-					"propertyKeys": [ "_ERRC", "_SKEY", "_MDAT" ],
-					"propertyValues": []
+					"propertyKeys": [ "Has_record_two", "_SKEY", "_MDAT" ],
+					"propertyValues": [ "Foo; abc\\; 12" ]
 				}
 			}
 		},
 		{
-			"about": "#1 no exception just a plain error message",
-			"subject": "Example/P0409/2#_679c1c67364994d58c9d9e51bbdfc026",
+			"about": "#1",
+			"subject": "Example/P0409/1/2#_863c94681079337ad25674e3a7ce33e7",
 			"store": {
 				"semantic-data": {
 					"strict-mode-valuematch": false,
 					"propertyCount": 2,
-					"propertyKeys": [ "_ERRC", "_SKEY" ],
-					"propertyValues": []
+					"propertyKeys": [ "Has_record_two", "_SKEY" ],
+					"propertyValues": [ "Foo; abc\\; 12" ]
 				}
+			}
+		},
+		{
+			"about": "#2",
+			"subject": "Example/P0409/2/1",
+			"store": {
+				"semantic-data": {
+					"strict-mode-valuematch": false,
+					"propertyCount": 3,
+					"propertyKeys": [ "Has_record_one_mlt", "_SKEY", "_MDAT" ],
+					"propertyValues": [ "test (en); 42" ]
+				}
+			}
+		},
+		{
+			"about": "#3",
+			"subject": "Example/P0409/2/2#_aa886e35ba32dd0c6e43a026230362f4",
+			"store": {
+				"semantic-data": {
+					"strict-mode-valuematch": false,
+					"propertyCount": 2,
+					"propertyKeys": [ "Has_record_one_mlt", "_SKEY" ],
+					"propertyValues": [ "test (en); 42" ]
+				}
+			}
+		},
+		{
+			"about": "#4",
+			"subject": "Example/P0409/3/1",
+			"store": {
+				"semantic-data": {
+					"strict-mode-valuematch": false,
+					"propertyCount": 3,
+					"propertyKeys": [ "Has_record_two_mlt", "_SKEY", "_MDAT" ],
+					"propertyValues": [ "one (en); two (fr)\\; 123" ]
+				}
+			}
+		},
+		{
+			"about": "#5",
+			"subject": "Example/P0409/3/2#_4d3b4405d3a60255e63cde196092a367",
+			"store": {
+				"semantic-data": {
+					"strict-mode-valuematch": false,
+					"propertyCount": 2,
+					"propertyKeys": [ "Has_record_two_mlt", "_SKEY" ],
+					"propertyValues": [ "one (en); two (fr)\\; 123" ]
+				}
+			}
+		},
+		{
+			"about": "#6 (edge case that will probably never surface but we verify that the description can be decoded without failing the parser)",
+			"subject": "Example/P0409/3/2a",
+			"expected-output": {
+				"to-contain": [
+					"Example/P0409/3/2#_4d3b4405d3a60255e63cde196092a367",
+					"<td class=\"Has-record-two-mlt smwtype_rec\">one (en) (two (fr) (123))</td>"
+				]
+			}
+		},
+		{
+			"about": "#7 same as #6 (query condition is identical, printoutput is different)",
+			"subject": "Example/P0409/3/2b",
+			"expected-output": {
+				"to-contain": [
+					"Example/P0409/3/2#_4d3b4405d3a60255e63cde196092a367",
+					"<td class=\"Has-record-two-mlt smwtype_mlt_rec\">one (en)</td>",
+					"<td class=\"Has-record-two-mlt smwtype_rec\">two (fr) (123)</td>"
+				]
 			}
 		}
 	],

--- a/tests/phpunit/Integration/ByJsonScript/README.md
+++ b/tests/phpunit/Integration/ByJsonScript/README.md
@@ -37,7 +37,7 @@ Contains 91 files:
 * [p-0406.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/ByJsonScript/Fixtures/p-0406.json) Test in-text annotation for unrestricted template parse using `import-annotation=true` (#1055)
 * [p-0407.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/ByJsonScript/Fixtures/p-0407.json) Test in-text annotation for a redirect that is pointing to a deleted target (#1105)
 * [p-0408.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/ByJsonScript/Fixtures/p-0408.json) Test in-text annotation for multiple property assignment using non-strict parser mode (#1252, en)
-* [p-0409.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/ByJsonScript/Fixtures/p-0409.json) Test in-text annotation (and #subobject) for when record type points to another record type and is used as annotation to return a `_ERRC` (#1303)
+* [p-0409.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/ByJsonScript/Fixtures/p-0409.json) Test in-text annotation for `_rec`/`_mlt_rec` (+ subobject) for when record type points to another record type (en)
 * [p-0410.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/ByJsonScript/Fixtures/p-0410.json) Test in-text annotation on `_num`/`_tem`/`_qty` type with denoted precision (`_PREC`) and/or `-p<num>` printout precision marker (#1335, en)
 * [p-0411.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/ByJsonScript/Fixtures/p-0411.json) Test in-text annotation (and #subobject) using a monolingual property (#1344, en)
 * [p-0412.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/ByJsonScript/Fixtures/p-0412.json) Test in-text annotation for `_boo` datatype (ja)
@@ -102,4 +102,4 @@ Contains 91 files:
 ### S
 * [s-0001.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/ByJsonScript/Fixtures/s-0001.json) Test output of `Special:Properties` (en, skip-on sqlite, 1.19)
 
--- Last updated on 2016-01-17 by `readmeContentsBuilder.php`
+-- Last updated on 2016-01-18 by `readmeContentsBuilder.php`


### PR DESCRIPTION
```
Property:Has monolingual text record

[[Has type::Record]] [[Has fields::Has monolingual text;Has number]]

[[Has monolingual text record::test@en;42]]
```

refs #1344 (builds on previous changes incl. #1185, #1275)