### PR TITLE
Add localizable context help for properties, refs #1344

### DIFF
--- a/SemanticMediaWiki.php
+++ b/SemanticMediaWiki.php
@@ -151,6 +151,10 @@ $GLOBALS['wgExtensionMessagesFiles']['SemanticMediaWikiMagic'] = $GLOBALS['smwgI
  */
 $GLOBALS['wgExtensionFunctions'][] = function() {
 
+	// 3.x reverse the order to ensure that smwgMainCacheType is used
+	// as main and smwgCacheType being deprecated with 3.x
+	$GLOBALS['smwgMainCacheType'] = $GLOBALS['smwgCacheType'];
+
 	$applicationFactory = ApplicationFactory::getInstance();
 
 	$namespace = new NamespaceManager( $GLOBALS, __DIR__ );

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -362,5 +362,7 @@
 	"smw-pa-property-predefined_lcode": "\"$1\" is a predefined property that represents a BCP47 formatted language code and is provided by [https://www.semantic-mediawiki.org/wiki/Help:Special_properties Semantic MediaWiki].",
 	"smw-sp-types_mlt_rec": "\"$1\" is a [https://www.semantic-mediawiki.org/wiki/Help:Container container] datatype that associates a text value with a specific [[Property:Language code|language code]].",
 	"smw-sp-types-mlt-lcode": "The datatype does {{PLURAL:$2|require|not require}} a language code (i.e. {{PLURAL:$2|a value annotation without a language code is not accepted|a value annotation without a language code is accepted}}).",
-	"smw-pa-property-predefined_text": "\"$1\" is a predefined property that represents text of arbitrary length and is provided by [https://www.semantic-mediawiki.org/wiki/Help:Special_properties Semantic MediaWiki]."
+	"smw-pa-property-predefined_text": "\"$1\" is a predefined property that represents text of arbitrary length and is provided by [https://www.semantic-mediawiki.org/wiki/Help:Special_properties Semantic MediaWiki].",
+	"smw-pa-property-predefined_pdesc": "\"$1\" is a predefined property that allows to decribe a property in context of a language and is provided by [https://www.semantic-mediawiki.org/wiki/Help:Special_properties Semantic MediaWiki].",
+	"smw-pa-property-predefined_list": "\"$1\" is a predefined property to define a list of properties used with a [[Special:Types/Record|record]] typed property and is provided by [https://www.semantic-mediawiki.org/wiki/Help:Special_properties Semantic MediaWiki]."
 }

--- a/includes/Highlighter.php
+++ b/includes/Highlighter.php
@@ -176,6 +176,16 @@ class Highlighter extends ContextSource {
 	 * @return string
 	 */
 	private function getContainer() {
+
+		$captionclass = $this->options['captionclass'];
+
+		// 2.4+ can display context for user-defined properties, here we ensure
+		// to keep the style otherwise it displays italic which is by convention
+		// reserved for predefined properties
+		if ( $this->type === self::TYPE_PROPERTY && isset( $this->options['userDefined'] ) ) {
+			$captionclass = $this->options['userDefined'] ? 'smwtext' : $captionclass;
+		}
+
 		return Html::rawElement(
 			'span',
 			array(
@@ -186,7 +196,7 @@ class Highlighter extends ContextSource {
 			), Html::rawElement(
 					'span',
 					array(
-						'class' => $this->options['captionclass']
+						'class' => $captionclass
 					), $this->options['caption']
 				) . Html::rawElement(
 					'div',

--- a/includes/datavalues/SMW_DV_Property.php
+++ b/includes/datavalues/SMW_DV_Property.php
@@ -1,6 +1,8 @@
 <?php
 
 use SMW\DataValueFactory;
+use SMW\ApplicationFactory;
+use SMW\Highlighter;
 
 /**
  * Objects of this class represent properties in SMW.
@@ -322,17 +324,13 @@ class SMWPropertyValue extends SMWDataValue {
 	 */
 	protected function highlightText( $text, $linker = null ) {
 
-		if ( !$this->m_dataitem->isUserDefined() ) {
+		$propertySpecificationLookup = ApplicationFactory::getInstance()->getPropertySpecificationLookup();
 
-			$msgKey = 'smw-pa-property-predefined' . strtolower( $this->m_dataitem->getKey() );
-			$content = '';
-
-			if ( wfMessage( $msgKey )->exists() ) {
-				$content = $linker === null ? wfMessage( $msgKey, $this->getText() )->escaped() : wfMessage( $msgKey, $this->getText() )->parse();
-			}
+		if ( ( $content = $propertySpecificationLookup->getPropertyDescriptionFor( $this->m_dataitem, $linker ) ) !== '' ) {
 
 			$highlighter = SMW\Highlighter::factory( SMW\Highlighter::TYPE_PROPERTY );
 			$highlighter->setContent( array (
+				'userDefined' => $this->m_dataitem->isUserDefined(),
 				'caption' => $text,
 				'content' => $content !== '' ? $content : wfMessage( 'smw_isspecprop' )->text()
 			) );

--- a/includes/storage/SQLStore/SMW_Sql3SmwIds.php
+++ b/includes/storage/SQLStore/SMW_Sql3SmwIds.php
@@ -176,6 +176,7 @@ class SMWSql3SmwIds {
 		'_INST' => 4,
 		'_UNIT' => 7,
 		'_IMPO' => 8,
+		'_PDESC' => 10,
 		'_PREC' => 11,
 		'_CONV' => 12,
 		'_SERV' => 13,

--- a/languages/SMW_Language.php
+++ b/languages/SMW_Language.php
@@ -100,6 +100,7 @@ abstract class SMWLanguage {
 		'Display precision of'  => '_PREC',
 		'Language code'  => '_LCODE',
 		'Text'           => '_TEXT',
+		'Has property description'     => '_PDESC'
 	);
 
 	public function __construct() {

--- a/languages/SMW_LanguageAr.php
+++ b/languages/SMW_LanguageAr.php
@@ -81,6 +81,7 @@ class SMWLanguageAr extends SMWLanguage {
 		'_PREC'  => 'Display precision of',
 		'_LCODE' => 'Language code',
 		'_TEXT'  => 'Text',
+		'_PDESC' => 'Has property description'
 	);
 
 	protected $m_SpecialPropertyAliases = array(

--- a/languages/SMW_LanguageArz.php
+++ b/languages/SMW_LanguageArz.php
@@ -81,6 +81,7 @@ class SMWLanguageArz extends SMWLanguage {
 		'_PREC'  => 'Display precision of',
 		'_LCODE' => 'Language code',
 		'_TEXT'  => 'Text',
+		'_PDESC' => 'Has property description'
 	);
 
 	protected $m_SpecialPropertyAliases = array(

--- a/languages/SMW_LanguageCa.php
+++ b/languages/SMW_LanguageCa.php
@@ -85,6 +85,7 @@ class SMWLanguageCa extends SMWLanguage {
 		'_PREC'  => 'Display precision of',
 		'_LCODE' => 'Language code',
 		'_TEXT'  => 'Text',
+		'_PDESC' => 'Has property description'
 	);
 
 	protected $m_SpecialPropertyAliases = array(

--- a/languages/SMW_LanguageDe.php
+++ b/languages/SMW_LanguageDe.php
@@ -91,6 +91,7 @@ class SMWLanguageDe extends SMWLanguage {
 		'_PREC'  => 'Display precision of',
 		'_LCODE' => 'Language code',
 		'_TEXT'  => 'Text',
+		'_PDESC' => 'Has property description'
 	);
 
 	protected $m_SpecialPropertyAliases = array(

--- a/languages/SMW_LanguageEn.php
+++ b/languages/SMW_LanguageEn.php
@@ -88,11 +88,14 @@ class SMWLanguageEn extends SMWLanguage {
 		'_PREC'  => 'Display precision of',
 		'_LCODE' => 'Language code',
 		'_TEXT'  => 'Text',
+		'_TEXT'  => 'Text',
+		'_PDESC' => 'Has property description'
 	);
 
 	protected $m_SpecialPropertyAliases = array(
 		'Display unit' => '_UNIT',
-		'Display precision' => '_PREC'
+		'Display precision' => '_PREC',
+		'Property description'     => '_PDESC'
 	);
 
 	protected $m_Namespaces = array(

--- a/languages/SMW_LanguageEs.php
+++ b/languages/SMW_LanguageEs.php
@@ -82,6 +82,7 @@ class SMWLanguageEs extends SMWLanguage {
 		'_PREC'  => 'Display precision of',
 		'_LCODE' => 'Language code',
 		'_TEXT'  => 'Text',
+		'_PDESC' => 'Has property description'
 	);
 
 	protected $m_SpecialPropertyAliases = array(

--- a/languages/SMW_LanguageFi.php
+++ b/languages/SMW_LanguageFi.php
@@ -78,6 +78,7 @@ class SMWLanguageFi extends SMWLanguage {
 		'_PREC'  => 'Display precision of',
 		'_LCODE' => 'Language code',
 		'_TEXT'  => 'Text',
+		'_PDESC' => 'Has property description'
 	);
 
 	protected $m_Namespaces = array(

--- a/languages/SMW_LanguageFr.php
+++ b/languages/SMW_LanguageFr.php
@@ -82,6 +82,7 @@ class SMWLanguageFr extends SMWLanguage {
 		'_PREC'  => 'Display precision of',
 		'_LCODE' => 'Language code',
 		'_TEXT'  => 'Text',
+		'_PDESC' => 'Has property description'
 	);
 
 	protected $m_SpecialPropertyAliases = array(

--- a/languages/SMW_LanguageHe.php
+++ b/languages/SMW_LanguageHe.php
@@ -81,6 +81,7 @@ class SMWLanguageHe extends SMWLanguage {
 		'_PREC'  => 'Display precision of',
 		'_LCODE' => 'Language code',
 		'_TEXT'  => 'Text',
+		'_PDESC' => 'Has property description'
 	);
 
 	protected $m_SpecialPropertyAliases = array(

--- a/languages/SMW_LanguageHu.php
+++ b/languages/SMW_LanguageHu.php
@@ -86,6 +86,7 @@ class SMWLanguageHu extends SMWLanguage {
 		'_PREC'  => 'Display precision of',
 		'_LCODE' => 'Language code',
 		'_TEXT'  => 'Text',
+		'_PDESC' => 'Has property description'
 	);
 
 	protected $m_SpecialPropertyAliases = array(

--- a/languages/SMW_LanguageId.php
+++ b/languages/SMW_LanguageId.php
@@ -82,6 +82,7 @@ class SMWLanguageId extends SMWLanguage {
 		'_PREC'  => 'Display precision of',
 		'_LCODE' => 'Language code',
 		'_TEXT'  => 'Text',
+		'_PDESC' => 'Has property description'
 	);
 
 	protected $m_SpecialPropertyAliases = array(

--- a/languages/SMW_LanguageIt.php
+++ b/languages/SMW_LanguageIt.php
@@ -84,6 +84,7 @@ class SMWLanguageIt extends SMWLanguage {
 		'_PREC'  => 'Display precision of',
 		'_LCODE' => 'Language code',
 		'_TEXT'  => 'Text',
+		'_PDESC' => 'Has property description'
 	);
 
 	protected $m_SpecialPropertyAliases = array(

--- a/languages/SMW_LanguageNb.php
+++ b/languages/SMW_LanguageNb.php
@@ -91,6 +91,7 @@ class SMWLanguageNb extends SMWLanguage {
 		'_PREC'  => 'Display precision of',
 		'_LCODE' => 'Language code',
 		'_TEXT'  => 'Text',
+		'_PDESC' => 'Has property description'
 	);
 
 	protected $m_SpecialPropertyAliases = array(

--- a/languages/SMW_LanguageNl.php
+++ b/languages/SMW_LanguageNl.php
@@ -84,6 +84,7 @@ class SMWLanguageNl extends SMWLanguage {
 		'_PREC'  => 'Display precision of',
 		'_LCODE' => 'Language code',
 		'_TEXT'  => 'Text',
+		'_PDESC' => 'Has property description'
 	);
 
 	protected $m_SpecialPropertyAliases = array(

--- a/languages/SMW_LanguagePl.php
+++ b/languages/SMW_LanguagePl.php
@@ -100,6 +100,7 @@ class SMWLanguagePl extends SMWLanguage {
 		'_PREC'  => 'Display precision of',
 		'_LCODE' => 'Language code',
 		'_TEXT'  => 'Text',
+		'_PDESC' => 'Has property description'
 	);
 
 	protected $m_SpecialPropertyAliases = array(

--- a/languages/SMW_LanguagePt.php
+++ b/languages/SMW_LanguagePt.php
@@ -89,6 +89,7 @@ class SMWLanguagePt extends SMWLanguage {
 		'_PREC'  => 'Display precision of',
 		'_LCODE' => 'Language code',
 		'_TEXT'  => 'Text',
+		'_PDESC' => 'Has property description'
 	);
 
 	protected $m_SpecialPropertyAliases = array(

--- a/languages/SMW_LanguageRu.php
+++ b/languages/SMW_LanguageRu.php
@@ -84,6 +84,7 @@ class SMWLanguageRu extends SMWLanguage {
 		'_PREC'  => 'Display precision of',
 		'_LCODE' => 'Language code',
 		'_TEXT'  => 'Text',
+		'_PDESC' => 'Has property description'
 	);
 
 	protected $m_SpecialPropertyAliases = array(

--- a/languages/SMW_LanguageSk.php
+++ b/languages/SMW_LanguageSk.php
@@ -81,6 +81,7 @@ class SMWLanguageSk extends SMWLanguage {
 		'_PREC'  => 'Display precision of',
 		'_LCODE' => 'Language code',
 		'_TEXT'  => 'Text',
+		'_PDESC' => 'Has property description'
 	);
 
 	protected $m_SpecialPropertyAliases = array(

--- a/languages/SMW_LanguageZh_cn.php
+++ b/languages/SMW_LanguageZh_cn.php
@@ -89,6 +89,7 @@ class SMWLanguageZh_cn extends SMWLanguage {
 		'_PREC'  => 'Display precision of',
 		'_LCODE' => 'Language code',
 		'_TEXT'  => 'Text',
+		'_PDESC' => 'Has property description'
 	);
 
 	protected $m_SpecialPropertyAliases = array(

--- a/languages/SMW_LanguageZh_tw.php
+++ b/languages/SMW_LanguageZh_tw.php
@@ -87,6 +87,7 @@ class SMWLanguageZh_tw extends SMWLanguage {
 		'_PREC'  => 'Display precision of',
 		'_LCODE' => 'Language code',
 		'_TEXT'  => 'Text',
+		'_PDESC' => 'Has property description'
 	);
 
 	protected $m_SpecialPropertyAliases = array(

--- a/src/ApplicationFactory.php
+++ b/src/ApplicationFactory.php
@@ -278,6 +278,15 @@ class ApplicationFactory {
 	}
 
 	/**
+	 * @since 2.4
+	 *
+	 * @return PropertySpecificationLookup
+	 */
+	public function getPropertySpecificationLookup() {
+		return $this->callbackLoader->singleton( 'PropertySpecificationLookup' );
+	}
+
+	/**
 	 * @since 2.1
 	 *
 	 * @return QueryParser

--- a/src/CacheFactory.php
+++ b/src/CacheFactory.php
@@ -23,10 +23,14 @@ class CacheFactory {
 	/**
 	 * @since 2.2
 	 *
-	 * @param string|integer $mainCacheType
+	 * @param string|integer|null $mainCacheType
 	 */
-	public function __construct( $mainCacheType ) {
+	public function __construct( $mainCacheType = null ) {
 		$this->mainCacheType = $mainCacheType;
+
+		if ( $this->mainCacheType === null ) {
+			$this->mainCacheType = $GLOBALS['smwgMainCacheType'];
+		}
 	}
 
 	/**

--- a/src/DataValues/MonolingualTextValue.php
+++ b/src/DataValues/MonolingualTextValue.php
@@ -267,7 +267,7 @@ class MonolingualTextValue extends DataValue {
 		$dataItems = $semanticData->getPropertyValues( new DIProperty( '_LCODE' ) );
 		$dataItem = reset( $dataItems );
 
-		if ( $dataItem->getString() !== Localizer::asBCP47FormattedLanguageCode( $languageCode ) ) {
+		if ( $dataItem === false || ( $dataItem->getString() !== Localizer::asBCP47FormattedLanguageCode( $languageCode ) ) ) {
 			return null;
 		}
 

--- a/src/EventListenerRegistry.php
+++ b/src/EventListenerRegistry.php
@@ -67,15 +67,17 @@ class EventListenerRegistry implements EventListenerCollection {
 		$this->eventListenerCollection->registerCallback(
 			'property.spec.change', function( $dispatchContext ) {
 
+				$applicationFactory = ApplicationFactory::getInstance();
 				$subject = $dispatchContext->get( 'subject' );
 
-				$updateDispatcherJob = ApplicationFactory::getInstance()->newJobFactory()->newUpdateDispatcherJob(
+				$updateDispatcherJob = $applicationFactory->newJobFactory()->newUpdateDispatcherJob(
 					$subject->getTitle()
 				);
 
 				$updateDispatcherJob->run();
 
 				Exporter::getInstance()->resetCacheFor( $subject );
+				$applicationFactory->getPropertySpecificationLookup()->resetCacheFor( $subject );
 
 				$dispatchContext->set( 'propagationstop', true );
 			}

--- a/src/Localizer.php
+++ b/src/Localizer.php
@@ -23,11 +23,17 @@ class Localizer {
 	private $contentLanguage = null;
 
 	/**
+	 * @var Language
+	 */
+	private $userLanguage = null;
+
+	/**
 	 * @since 2.1
 	 *
 	 * @param Language $contentLanguage
+	 * @param Language|null $userLanguage
 	 */
-	public function __construct( Language $contentLanguage ) {
+	public function __construct( Language $contentLanguage) {
 		$this->contentLanguage = $contentLanguage;
 	}
 
@@ -37,8 +43,6 @@ class Localizer {
 	 * @return Localizer
 	 */
 	public static function getInstance() {
-
-		// Use $GLOBALS['wgLang'] as well at a later point
 
 		if ( self::$instance === null ) {
 			self::$instance = new self( $GLOBALS['wgContLang'] );
@@ -61,6 +65,15 @@ class Localizer {
 	 */
 	public function getContentLanguage() {
 		return $this->contentLanguage;
+	}
+
+	/**
+	 * @since 2.4
+	 *
+	 * @return Language
+	 */
+	public static function getUserLanguage() {
+		return $GLOBALS['wgLang'];
 	}
 
 	/**

--- a/src/MediaWiki/Api/BrowseByProperty.php
+++ b/src/MediaWiki/Api/BrowseByProperty.php
@@ -5,6 +5,7 @@ namespace SMW\MediaWiki\Api;
 use ApiBase;
 use SMW\ApplicationFactory;
 use SMW\NamespaceUriFinder;
+use SMW\PropertySpecificationLookup;
 
 /**
  * @license GNU GPL v2+
@@ -20,13 +21,19 @@ class BrowseByProperty extends ApiBase {
 	public function execute() {
 
 		$params = $this->extractRequestParams();
+		$applicationFactory = ApplicationFactory::getInstance();
 
 		$propertyListByApiRequest = new PropertyListByApiRequest(
-			ApplicationFactory::getInstance()->getStore()
+			$applicationFactory->getStore(),
+			$applicationFactory->getPropertySpecificationLookup()
 		);
 
 		$propertyListByApiRequest->setLimit(
 			$params['limit']
+		);
+
+		$propertyListByApiRequest->setLanguageCode(
+			$params['lang']
 		);
 
 		$propertyListByApiRequest->findPropertyListFor(
@@ -71,7 +78,7 @@ class BrowseByProperty extends ApiBase {
 		$this->getResult()->addValue(
 			null,
 			'version',
-			0.1
+			0.2
 		);
 
 		$this->getResult()->addValue(
@@ -104,6 +111,11 @@ class BrowseByProperty extends ApiBase {
 				ApiBase::PARAM_TYPE => 'string',
 				ApiBase::PARAM_ISMULTI => false,
 				ApiBase::PARAM_DFLT => 50,
+				ApiBase::PARAM_REQUIRED => false,
+			),
+			'lang' => array(
+				ApiBase::PARAM_TYPE => 'string',
+				ApiBase::PARAM_ISMULTI => false,
 				ApiBase::PARAM_REQUIRED => false,
 			)
 		);

--- a/src/PropertyRegistry.php
+++ b/src/PropertyRegistry.php
@@ -327,6 +327,7 @@ class PropertyRegistry {
 			'_PREC'  => array( '_num', true, true ), // "Display precision of"
 			'_LCODE' => array( '__lcode', true, true ), // "Language code"
 			'_TEXT'  => array( '_txt', true, true ), // "Text"
+			'_PDESC' => array( '_mlt_rec', true, true ), // "Property description"
 		);
 
 		foreach ( $this->datatypeLabels as $id => $label ) {

--- a/src/PropertySpecificationChangeNotifier.php
+++ b/src/PropertySpecificationChangeNotifier.php
@@ -84,6 +84,7 @@ class PropertySpecificationChangeNotifier {
 		$this->compareFor( '_TYPE' );
 		$this->compareFor( '_CONV' );
 		$this->compareFor( '_PREC' );
+		$this->compareFor( '_PDESC' );
 
 		foreach ( $this->propertiesToCompare as $propertyKey ) {
 			$this->compareFor( $propertyKey );

--- a/src/PropertySpecificationLookup.php
+++ b/src/PropertySpecificationLookup.php
@@ -1,0 +1,209 @@
+<?php
+
+namespace SMW;
+
+use RuntimeException;
+use Onoi\Cache\Cache;
+use Onoi\Cache\NullCache;
+
+/**
+ * This class should be accessed via ApplicationFactory::getPropertySpecificationLookup
+ * to ensure a singleton instance.
+ *
+ * @license GNU GPL v2+
+ * @since 2.4
+ *
+ * @author mwjames
+ */
+class PropertySpecificationLookup {
+
+	/**
+	 * @var string
+	 */
+	const VERSION = '0.1';
+
+	/**
+	 * @var Store
+	 */
+	private $store;
+
+	/**
+	 * @var string
+	 */
+	private $languageCode = 'en';
+
+	/**
+	 * @var Cache
+	 */
+	private $cache;
+
+	/**
+	 * @var string
+	 */
+	private $cachePrefix = ':smw:pspec:';
+
+	/**
+	 * @var integer
+	 */
+	private $ttl = 604800; // 7 * 24 * 3600
+
+	/**
+	 * @since 2.4
+	 *
+	 * @param Store $store
+	 * @param Cache|null $cache
+	 */
+	public function __construct( Store $store, Cache $cache = null ) {
+		$this->store = $store;
+		$this->cache = $cache;
+
+		if ( $this->cache === null ) {
+			$this->cache = new NullCache();
+		}
+	}
+
+	/**
+	 * @since 2.4
+	 */
+	public function resetCacheFor( DIWikiPage $subject ) {
+		$this->cache->delete(
+			$this->cachePrefix . md5( $subject->getHash() . self::VERSION )
+		);
+	}
+
+	/**
+	 * @since 2.4
+	 *
+	 * @param string $cachePrefix
+	 */
+	public function setCachePrefix( $cachePrefix ) {
+		$this->cachePrefix = $cachePrefix . $this->cachePrefix;
+	}
+
+	/**
+	 * @since 2.4
+	 *
+	 * @param string
+	 */
+	public function getLanguageCode() {
+		return $this->languageCode;
+	}
+
+	/**
+	 * @since 2.4
+	 *
+	 * @param string $languageCode
+	 */
+	public function setLanguageCode( $languageCode ) {
+		$this->languageCode = Localizer::asBCP47FormattedLanguageCode( $languageCode );
+	}
+
+	/**
+	 * We try to cache anything to avoid unnecessary store connections or DB
+	 * lookups. For cases where a property was changed, the EventDipatcher will
+	 * receive a 'property.spec.change' event (emitted as soon as the content of
+	 * a property page was altered) with PropertySpecificationLookup::resetCacheFor
+	 * being invoked to remove the cache entry for that specific property.
+	 *
+	 * @since 2.4
+	 *
+	 * @param DIProperty $property
+	 * @param mixed|null $linker
+	 *
+	 * @return string
+	 */
+	public function getPropertyDescriptionFor( DIProperty $property, $linker = null ) {
+
+		$description = array();
+
+		// Take the linker into account (Special vs. in page rendering etc.)
+		$key = $this->languageCode . ':' . ( $linker === null ? '-' : '+' );
+
+		$hash = $this->cachePrefix . md5(
+			$property->getDiWikiPage()->getHash() . self::VERSION
+		);
+
+		if ( $this->cache->contains( $hash ) ) {
+			$description = $this->cache->fetch( $hash );
+
+			if ( isset( $description[$key] ) ) {
+				return trim( $description[$key] );
+			}
+		}
+
+		$description[$key] = $this->tryToFindLocalPropertyDescription( $property, $linker );
+
+		// If a local property description wasn't available for a predefined property
+		// the try to find a system translation
+		if ( trim( $description[$key] ) === '' && !$property->isUserDefined() ) {
+			$description[$key] = $this->getPredefinedPropertyDescription( $property, $linker );
+		}
+
+		$this->cache->save(
+			$hash,
+			$description,
+			$this->ttl
+		);
+
+		// Ensure that we return an empty string in case it is just true
+		return trim( $description[$key] );
+	}
+
+	private function getPredefinedPropertyDescription( $property, $linker ) {
+
+		$description = ' ';
+		$msgKey = 'smw-pa-property-predefined' . strtolower( $property->getKey() );
+
+		if ( !wfMessage( $msgKey )->exists() ) {
+			return $description;
+		}
+
+		$message = wfMessage( $msgKey, $property->getLabel() )->inLanguage(
+			$this->languageCode
+		);
+
+		return $linker === null ? $message->escaped() : $message->parse();
+	}
+
+	private function tryToFindLocalPropertyDescription( $property, $linker ) {
+
+		$description = ' ';
+
+		$dataItems = $this->store->getPropertyValues(
+			$property->getDiWikiPage(),
+			new DIProperty( '_PDESC' )
+		);
+
+		if ( ( $dataValue = $this->findDataValueByLanguage( $dataItems, $this->languageCode ) ) !== null ) {
+			$description = $dataValue->getShortWikiText( $linker );
+		}
+
+		return $description;
+	}
+
+	private function findDataValueByLanguage( $dataItems, $languageCode ) {
+
+		if ( $dataItems === null || $dataItems === array() ) {
+			return null;
+		}
+
+		foreach ( $dataItems as $dataItem ) {
+
+			$dataValue = DataValueFactory::getInstance()->newDataItemValue(
+				$dataItem,
+				new DIProperty( '_PDESC' )
+			);
+
+			// Here a MonolingualTextValue was retunred therefore the method
+			// can be called without validation
+			$dv = $dataValue->getTextValueByLanguage( $languageCode );
+
+			if ( $dv !== null ) {
+				return $dv;
+			}
+		}
+
+		return null;
+	}
+
+}

--- a/tests/phpunit/Integration/ByJsonScript/Fixtures/f-0206.json
+++ b/tests/phpunit/Integration/ByJsonScript/Fixtures/f-0206.json
@@ -1,0 +1,44 @@
+{
+	"description": "Test `format=table` to display extra property description `_PDESC` (en)",
+	"properties": [
+		{
+			"name": "Has number",
+			"contents": "[[Has type::Number]] [[Has property description::A number to display ....@en]]"
+		}
+	],
+	"subjects": [
+		{
+			"name": "Example/F0206/1/1",
+			"contents": "[[Has number::1001]]"
+		},
+		{
+			"name": "Example/F0206/1a",
+			"contents": "{{#ask: [[~Example/F0206/1/*]] |?Has number |format=table }}"
+		}
+	],
+	"format-testcases": [
+		{
+			"about": "#0",
+			"subject": "Example/F0206/1a",
+			"expected-output": {
+				"to-contain": [
+					"<div class=\"smwttcontent\">A number to display ....</div>",
+					"<td data-sort-value=\"1001\" class=\"Has-number smwtype_num\">1,001</td>"
+				]
+			}
+		}
+	],
+	"settings": {
+		"wgContLang": "en",
+		"wgLang": "en",
+		"smwgNamespacesWithSemanticLinks": {
+			"NS_MAIN": true,
+			"SMW_NS_PROPERTY": true
+		}
+	},
+	"meta": {
+		"version": "0.1",
+		"is-incomplete": false,
+		"debug": false
+	}
+}

--- a/tests/phpunit/Integration/ByJsonScript/README.md
+++ b/tests/phpunit/Integration/ByJsonScript/README.md
@@ -1,5 +1,5 @@
 ## Fixtures
-Contains 91 files:
+Contains 92 files:
 
 ### F
 * [f-0001.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/ByJsonScript/Fixtures/f-0001.json) Test format=debug output
@@ -11,6 +11,7 @@ Contains 91 files:
 * [f-0203.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/ByJsonScript/Fixtures/f-0203.json) Test format=table to sort by category (#1286)
 * [f-0204.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/ByJsonScript/Fixtures/f-0204.json) Test `format=table` on `_qty` for different positional unit preference (#1329, en)
 * [f-0205.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/ByJsonScript/Fixtures/f-0205.json) Test `format=table` on `|+align=`/`|+limit`/`|+order` extra printout parameters (T18571, en)
+* [f-0206.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/ByJsonScript/Fixtures/f-0206.json) Test `format=table` to display extra property description `_PDESC` (en)
 * [f-0301.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/ByJsonScript/Fixtures/f-0301.json) Test format=category with template usage (#699, en, skip postgres)
 * [f-0302.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/ByJsonScript/Fixtures/f-0302.json) Test format=category and defaultsort (#699, en)
 * [f-0801.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/ByJsonScript/Fixtures/f-0801.json) Test format=embedded output (skip 1.19)
@@ -102,4 +103,4 @@ Contains 91 files:
 ### S
 * [s-0001.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/ByJsonScript/Fixtures/s-0001.json) Test output of `Special:Properties` (en, skip-on sqlite, 1.19)
 
--- Last updated on 2016-01-18 by `readmeContentsBuilder.php`
+-- Last updated on 2016-01-24 by `readmeContentsBuilder.php`

--- a/tests/phpunit/Unit/ApplicationFactoryTest.php
+++ b/tests/phpunit/Unit/ApplicationFactoryTest.php
@@ -197,4 +197,12 @@ class ApplicationFactoryTest extends \PHPUnit_Framework_TestCase {
 		);
 	}
 
+	public function testCanConstructPropertySpecificationLookup() {
+
+		$this->assertInstanceOf(
+			'\SMW\PropertySpecificationLookup',
+			$this->applicationFactory->getPropertySpecificationLookup()
+		);
+	}
+
 }

--- a/tests/phpunit/Unit/MediaWiki/Api/PropertyListByApiRequestTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Api/PropertyListByApiRequestTest.php
@@ -30,9 +30,13 @@ class PropertyListByApiRequestTest extends \PHPUnit_Framework_TestCase {
 
 	public function testCanConstruct() {
 
+		$propertySpecificationLookup = $this->getMockBuilder( '\SMW\PropertySpecificationLookup' )
+			->disableOriginalConstructor()
+			->getMock();
+
 		$this->assertInstanceOf(
 			'SMW\MediaWiki\Api\PropertyListByApiRequest',
-			new PropertyListByApiRequest( $this->store )
+			new PropertyListByApiRequest( $this->store, $propertySpecificationLookup )
 		);
 	}
 
@@ -60,13 +64,17 @@ class PropertyListByApiRequestTest extends \PHPUnit_Framework_TestCase {
 		$expectedSerializedPropertyList = array(
 			'Foo' => array(
 				'label' => 'Foo',
+				'key' => 'Foo',
 				'isUserDefined' => true,
-				'usageCount' => 42
+				'usageCount' => 42,
+				'description' => ''
 			),
 			'Foaf:Foo' => array(
 				'label' => 'Foaf:Foo',
+				'key' => 'Foaf:Foo',
 				'isUserDefined' => true,
-				'usageCount' => 1001
+				'usageCount' => 1001,
+				'description' => ''
 			)
 		);
 
@@ -96,7 +104,11 @@ class PropertyListByApiRequestTest extends \PHPUnit_Framework_TestCase {
 			->method( 'getPropertiesSpecial' )
 			->will( $this->returnValue( $cachedListLookup ) );
 
-		$instance = new PropertyListByApiRequest( $this->store );
+		$propertySpecificationLookup = $this->getMockBuilder( '\SMW\PropertySpecificationLookup' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$instance = new PropertyListByApiRequest( $this->store, $propertySpecificationLookup );
 		$instance->setLimit( 3 );
 
 		$this->assertTrue(

--- a/tests/phpunit/Unit/PropertySpecificationLookupTest.php
+++ b/tests/phpunit/Unit/PropertySpecificationLookupTest.php
@@ -1,0 +1,103 @@
+<?php
+
+namespace SMW\Tests;
+
+use SMW\PropertySpecificationLookup;
+use SMW\DIProperty;
+use SMWDIContainer as DIContainer;
+use SMWContainerSemanticData as ContainerSemanticData;
+
+/**
+ * @covers \SMW\PropertySpecificationLookup
+ * @group semantic-mediawiki
+ *
+ * @license GNU GPL v2+
+ * @since 2.4
+ *
+ * @author mwjames
+ */
+class PropertySpecificationLookupTest extends \PHPUnit_Framework_TestCase {
+
+	private $store;
+
+	protected function setUp() {
+		parent::setUp();
+
+		$this->store = $this->getMockBuilder( '\SMW\Store' )
+			->disableOriginalConstructor()
+			->getMockForAbstractClass();
+	}
+
+	public function testCanConstruct() {
+
+		$this->assertInstanceOf(
+			'\SMW\PropertySpecificationLookup',
+			new PropertySpecificationLookup( $this->store )
+		);
+	}
+
+	public function testGetPropertyDescriptionForPredefinedProperty() {
+
+		$instance = new PropertySpecificationLookup(
+			$this->store
+		);
+
+		$this->assertInternalType(
+			'string',
+			$instance->getPropertyDescriptionFor( new DIProperty( '_PDESC' ) )
+		);
+	}
+
+	public function testGetPropertyDescriptionForPredefinedPropertyViaCacheForLanguageCode() {
+
+		$cache = $this->getMockBuilder( '\Onoi\Cache\Cache' )
+			->disableOriginalConstructor()
+			->getMockForAbstractClass();
+
+		$cache->expects( $this->once() )
+			->method( 'contains' )
+			->will( $this->returnValue( true ) );
+
+		$cache->expects( $this->once() )
+			->method( 'fetch' )
+			->with( $this->stringContains( 'foo:smw:pspec:' ) )
+			->will( $this->returnValue( array( 'en:-' => 1001 ) ) );
+
+		$instance = new PropertySpecificationLookup(
+			$this->store,
+			$cache
+		);
+
+		$instance->setCachePrefix( 'foo' );
+		$instance->setLanguageCode( 'en' );
+
+		$this->assertEquals(
+			1001,
+			$instance->getPropertyDescriptionFor( new DIProperty( '_PDESC' ) )
+		);
+	}
+
+	public function testTryToGetLocalPropertyDescriptionForUserdefinedProperty() {
+
+		$property = new DIProperty( 'SomeProperty' );
+
+		$this->store->expects( $this->once() )
+			->method( 'getPropertyValues' )
+			->with(
+				$this->equalTo( $property->getDiWikiPage() ),
+				$this->equalTo( new DIProperty( '_PDESC' ) ),
+				$this->anything() )
+			->will( $this->returnValue( array(
+				new DIContainer( ContainerSemanticData::makeAnonymousContainer() ) ) ) );
+
+		$instance = new PropertySpecificationLookup(
+			$this->store
+		);
+
+		$this->assertInternalType(
+			'string',
+			$instance->getPropertyDescriptionFor( $property )
+		);
+	}
+
+}


### PR DESCRIPTION
"Has property description" is a predefined property and can be used to describe a local property in context of a language.

If a user switches its language preference (`wgLang`) and a property with description matches the language then it will be used during the highlight display.

If a predefined property contains a local "Has property description" then this information will be displayed instead of the standard message.

```
Property: SomeProperty

[[Has property description::Is a property that ...@en]]
[[Has property description::このプロパティは。。。@ja]]

```
The `browsebyproperty` API (#1267) has been amended to contain description information
such as:

```
api.php?action=browsebyproperty&property=SomeProperty&lang=en

{
    "query": {
        "SomeProperty": {
            "label": "SomeProperty",
            "key": "SomeProperty",
            "isUserDefined": "",
            "usageCount": 5343,
            "description": {
                "en": "Is a property that ..."
            }
        }
    },
    "version": 0.2,
    "query-continue-offset": 0,
    "meta": {
        "limit": 50,
        "count": 1
    }
}
```

refs #1344, #1267