### PR TITLE
Add DispatchingDataValueFormatter

### DIFF
--- a/includes/datavalues/SMW_DataValue.php
+++ b/includes/datavalues/SMW_DataValue.php
@@ -10,7 +10,8 @@
 use SMW\DataValueFactory;
 use SMW\Options;
 use SMW\Query\QueryComparator;
-use SMW\Deserializers\DVDescriptionDeserializerFactory;
+use SMW\Deserializers\DVDescriptionDeserializerRegistry;
+use SMW\DataValues\ValueFormatterRegistry;
 
 /**
  * Objects of this type represent all that is known about a certain user-provided
@@ -295,6 +296,8 @@ abstract class SMWDataValue {
 	/**
 	 * @since 2.4
 	 *
+	 * @param string $key
+	 *
 	 * @return mixed|false
 	 */
 	public function getOptionValueFor( $key ) {
@@ -314,6 +317,15 @@ abstract class SMWDataValue {
 	 */
 	public function setCaption( $caption ) {
 		$this->m_caption = $caption;
+	}
+
+	/**
+	 * @since 2.4
+	 *
+	 * @param string $caption
+	 */
+	public function getCaption() {
+		return $this->m_caption;
 	}
 
 	/**
@@ -398,6 +410,15 @@ abstract class SMWDataValue {
 	}
 
 	/**
+	 * @since 2.4
+	 *
+	 * @return string
+	 */
+	public function getOutputFormat() {
+		return $this->m_outformat;
+	}
+
+	/**
 	 * Add a new error string or array of such strings to the error list.
 	 *
 	 * @note Errors should not be escaped here in any way, in contradiction to what
@@ -474,14 +495,26 @@ abstract class SMWDataValue {
 	 */
 	public function getQueryDescription( $value ) {
 
-		$dvDescriptionDeserializerFactory = DVDescriptionDeserializerFactory::getInstance()->getDescriptionDeserializerFor( $this );
-		$description = $dvDescriptionDeserializerFactory->deserialize( $value );
+		$descriptionDeserializer = DVDescriptionDeserializerRegistry::getInstance()->getDescriptionDeserializerFor( $this );
+		$description = $descriptionDeserializer->deserialize( $value );
 
-		foreach ( $dvDescriptionDeserializerFactory->getErrors() as $error ) {
+		foreach ( $descriptionDeserializer->getErrors() as $error ) {
 			$this->addError( $error );
 		}
 
 		return $description;
+	}
+
+	/**
+	 * Returns a DataValueFormatter that was matched and dispatched for the current
+	 * DV instance.
+	 *
+	 * @since 2.4
+	 *
+	 * @return DataValueFormatter
+	 */
+	public function getDataValueFormatter() {
+		return ValueFormatterRegistry::getInstance()->getDataValueFormatterFor( $this );
 	}
 
 	/**
@@ -490,7 +523,7 @@ abstract class SMWDataValue {
 	 *
 	 * This method should no longer be used for direct public access, instead a
 	 * DataValue is expected to register a DescriptionDeserializer with
-	 * DVDescriptionDeserializerFactory.
+	 * DVDescriptionDeserializerRegistry.
 	 *
 	 * FIXME as of 2.3, SMGeoCoordsValue still uses this method and requires
 	 * migration before 3.0

--- a/src/DataTypeRegistry.php
+++ b/src/DataTypeRegistry.php
@@ -3,6 +3,10 @@
 namespace SMW;
 
 use SMWDataItem as DataItem;
+use SMW\DataValues\ValueFormatterRegistry;
+use SMW\DataValues\ValueFormatters\DataValueFormatter;
+use SMW\Deserializers\DVDescriptionDeserializerRegistry;
+use SMW\Deserializers\DVDescriptionDeserializer\DescriptionDeserializer;
 
 /**
  * DataTypes registry class
@@ -139,6 +143,8 @@ class DataTypeRegistry {
 	 */
 	public static function clear() {
 		self::$instance = null;
+		ValueFormatterRegistry::getInstance()->clear();
+		DVDescriptionDeserializerRegistry::getInstance()->clear();
 	}
 
 	/**
@@ -475,6 +481,24 @@ class DataTypeRegistry {
 
 		// Since 1.9
 		\Hooks::run( 'SMW::DataType::initTypes', array( $this ) );
+	}
+
+	/**
+	 * @since 2.4
+	 *
+	 * @param DataValueFormatter $dataValueFormatter
+	 */
+	public function registerDataValueFormatter( DataValueFormatter $dataValueFormatter ) {
+		ValueFormatterRegistry::getInstance()->registerDataValueFormatter( $dataValueFormatter );
+	}
+
+	/**
+	 * @since 2.4
+	 *
+	 * @param DescriptionDeserializer $descriptionDeserializer
+	 */
+	public function registerDVDescriptionDeserializer( DescriptionDeserializer $descriptionDeserializer ) {
+		DVDescriptionDeserializerRegistry::getInstance()->registerDescriptionDeserializer( $descriptionDeserializer );
 	}
 
 	/**

--- a/src/DataValueFactory.php
+++ b/src/DataValueFactory.php
@@ -72,14 +72,17 @@ class DataValueFactory {
 
 		$dataTypeRegistry = DataTypeRegistry::getInstance();
 
-		if ( $dataTypeRegistry->hasDataTypeClassById( $typeId ) ) {
-			$class  = $dataTypeRegistry->getDataTypeClassById( $typeId );
-			$result = new $class( $typeId );
-		} else {
-			return new ErrorValue( $typeId,
+		if ( !$dataTypeRegistry->hasDataTypeClassById( $typeId ) ) {
+			return new ErrorValue(
+				$typeId,
 				wfMessage( 'smw_unknowntype', $typeId )->inContentLanguage()->text(),
-				$valueString, $caption );
+				$valueString,
+				$caption
+			);
 		}
+
+		$class  = $dataTypeRegistry->getDataTypeClassById( $typeId );
+		$result = new $class( $typeId );
 
 		$result->setExtraneousFunctions(
 			$dataTypeRegistry->getExtraneousFunctions()

--- a/src/DataValues/ValueFormatterRegistry.php
+++ b/src/DataValues/ValueFormatterRegistry.php
@@ -1,0 +1,104 @@
+<?php
+
+namespace SMW\DataValues;
+
+use SMW\DataValues\ValueFormatters\DispatchingDataValueFormatter;
+use SMW\DataValues\ValueFormatters\MonolingualTextValueFormatter;
+use SMW\DataValues\ValueFormatters\NoValueFormatter;
+use SMW\DataValues\ValueFormatters\DataValueFormatter;
+use SMWDataValue as DataValue;
+
+/**
+ * @license GNU GPL v2+
+ * @since 2.4
+ *
+ * @author mwjames
+ */
+class ValueFormatterRegistry {
+
+	/**
+	 * @var ValueFormatterRegistry
+	 */
+	private static $instance = null;
+
+	/**
+	 * @var DispatchingDataValueFormatter
+	 */
+	private $dispatchingDataValueFormatter = null;
+
+	/**
+	 * @since 2.4
+	 *
+	 * @param DispatchingDataValueFormatter|null $dispatchingDataValueFormatter
+	 */
+	public function __construct( DispatchingDataValueFormatter $dispatchingDataValueFormatter = null ) {
+		$this->dispatchingDataValueFormatter = $dispatchingDataValueFormatter;
+	}
+
+	/**
+	 * @since 2.4
+	 *
+	 * @return self
+	 */
+	public static function getInstance() {
+
+		if ( self::$instance === null ) {
+			self::$instance = new self();
+		}
+
+		return self::$instance;
+	}
+
+	/**
+	 * @since 2.4
+	 */
+	public static function clear() {
+		self::$instance = null;
+	}
+
+	/**
+	 * @note This allows extensions to inject their own DataValueFormatter
+	 * without further violating SRP of the DataType or DataValue.
+	 *
+	 * @since 2.4
+	 *
+	 * @param DataValueFormatter $dataValueFormatter
+	 */
+	public function registerDataValueFormatter( DataValueFormatter $dataValueFormatter ) {
+
+		if ( $this->dispatchingDataValueFormatter === null ) {
+			$this->dispatchingDataValueFormatter = $this->newDispatchingDataValueFormatter();
+		}
+
+		return $this->dispatchingDataValueFormatter->addDataValueFormatter( $dataValueFormatter );
+	}
+
+	/**
+	 * @since 2.4
+	 *
+	 * @param DataValue $dataValue
+	 *
+	 * @return DataValueFormatter
+	 */
+	public function getDataValueFormatterFor( DataValue $dataValue ) {
+
+		if ( $this->dispatchingDataValueFormatter === null ) {
+			$this->dispatchingDataValueFormatter = $this->newDispatchingDataValueFormatter();
+		}
+
+		return $this->dispatchingDataValueFormatter->getDataValueFormatterFor( $dataValue );
+	}
+
+	private function newDispatchingDataValueFormatter() {
+
+		$dispatchingDataValueFormatter = new DispatchingDataValueFormatter();
+		$dispatchingDataValueFormatter->addDataValueFormatter( new MonolingualTextValueFormatter() );
+
+		// To be checked only after DispatchingDataValueFormatter::addDataValueFormatter did
+		// not match any previous registered DataValueFormatters
+		$dispatchingDataValueFormatter->addDefaultDataValueFormatter( new NoValueFormatter() );
+
+		return $dispatchingDataValueFormatter;
+	}
+
+}

--- a/src/DataValues/ValueFormatters/DataValueFormatter.php
+++ b/src/DataValues/ValueFormatters/DataValueFormatter.php
@@ -1,0 +1,124 @@
+<?php
+
+namespace SMW\DataValues\ValueFormatters;
+
+use SMWDataValue as DataValue;
+use SMW\Options;
+
+/**
+ * @license GNU GPL v2+
+ * @since 2.4
+ *
+ * @author mwjames
+ */
+abstract class DataValueFormatter implements ValueFormatter {
+
+	/**
+	 * Return the plain wiki version of the value, or FALSE if no such version
+	 * is available. The returned string suffices to reobtain the same DataValue
+	 * when passing it as an input string to DataValue::setUserValue.
+	 */
+	const VALUE = 0;
+
+	/**
+	 * Returns a short textual representation for this data value. If the value
+	 * was initialised from a user supplied string, then this original string
+	 * should be reflected in this short version (i.e. no normalisation should
+	 * normally happen). There might, however, be additional parts such as code
+	 * for generating tooltips. The output is in wiki text.
+	 */
+	const WIKI_SHORT = 1;
+
+	/**
+	 * Returns a short textual representation for this data value. If the value
+	 * was initialised from a user supplied string, then this original string
+	 * should be reflected in this short version (i.e. no normalisation should
+	 * normally happen). There might, however, be additional parts such as code
+	 * for generating tooltips. The output is in HTML text.
+	 */
+	const HTML_SHORT = 2;
+
+	/**
+	 * Return the long textual description of the value, as printed for example
+	 * in the factbox. If errors occurred, return the error message. The result
+	 * is always a wiki-source string.
+	 */
+	const WIKI_LONG = 3;
+
+	/**
+	 * Return the long textual description of the value, as printed for
+	 * example in the factbox. If errors occurred, return the error message
+	 * The result always is an HTML string.
+	 */
+	const HTML_LONG = 4;
+
+	/**
+	 * @var DataValue
+	 */
+	protected $dataValue;
+
+	/**
+	 * @var Options
+	 */
+	private $options = null;
+
+	/**
+	 * @since 2.4
+	 *
+	 * @param DataValue|null $dataValue
+	 */
+	public function __construct( DataValue $dataValue = null ) {
+		$this->dataValue = $dataValue;
+	}
+
+	/**
+	 * @since 2.4
+	 *
+	 * @param DataValue $dataValue
+	 *
+	 * @return boolean
+	 */
+	abstract public function isFormatterFor( DataValue $dataValue );
+
+	/**
+	 * @since 2.4
+	 *
+	 * @param DataValue $dataValue
+	 */
+	public function setDataValue( DataValue $dataValue ) {
+		$this->dataValue = $dataValue;
+		$this->options = null;
+	}
+
+	/**
+	 * @since 2.4
+	 *
+	 * @param string $key
+	 * @param mixed $value
+	 */
+	public function setOption( $key, $value ) {
+
+		if ( $this->options === null ) {
+			$this->options = new Options();
+		}
+
+		$this->options->set( $key, $value );
+	}
+
+	/**
+	 * @since 2.4
+	 *
+	 * @param string $key
+	 *
+	 * @return mixed|false
+	 */
+	public function getOptionValueFor( $key ) {
+
+		if ( $this->options !== null && $this->options->has( $key ) ) {
+			return $this->options->get( $key );
+		}
+
+		return false;
+	}
+
+}

--- a/src/DataValues/ValueFormatters/DispatchingDataValueFormatter.php
+++ b/src/DataValues/ValueFormatters/DispatchingDataValueFormatter.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace SMW\DataValues\ValueFormatters;
+
+use SMWDataValue as DataValue;
+use RuntimeException;
+
+/**
+ * @private
+ *
+ * @license GNU GPL v2+
+ * @since 2.4
+ *
+ * @author mwjames
+ */
+class DispatchingDataValueFormatter {
+
+	/**
+	 * @var DataValueFormatter[]
+	 */
+	private $dataValueFormatters = array();
+
+	/**
+	 * @var DataValueFormatter
+	 */
+	private $defaultDataValueFormatters = array();
+
+	/**
+	 * @since  2.4
+	 *
+	 * @param DataValueFormatter $dataValueFormatter
+	 */
+	public function addDataValueFormatter( DataValueFormatter $dataValueFormatter ) {
+		$this->dataValueFormatters[] = $dataValueFormatter;
+	}
+
+	/**
+	 * DataValueFormatters registered with this method are validated after
+	 * DispatchingDataValueFormatter::getDataValueFormatterFor was not able to
+	 * match any Formatter. This to ensure that a distinct FooStringValueFormatter
+	 * is tried before the default StringValueFormatter.
+	 *
+	 * @since 2.4
+	 *
+	 * @param DataValueFormatter $dataValueFormatter
+	 */
+	public function addDefaultDataValueFormatter( DataValueFormatter $dataValueFormatter ) {
+		$this->defaultDataValueFormatters[] = $dataValueFormatter;
+	}
+
+	/**
+	 * @since 2.4
+	 *
+	 * @param DataValue $dataValue
+	 *
+	 * @return DataValueFormatter
+	 * @throws RuntimeException
+	 */
+	public function getDataValueFormatterFor( DataValue $dataValue ) {
+
+		foreach ( $this->dataValueFormatters as $dataValueFormatter ) {
+			if ( $dataValueFormatter->isFormatterFor( $dataValue ) ) {
+				$dataValueFormatter->setDataValue( $dataValue );
+				return $dataValueFormatter;
+			}
+		}
+
+		foreach ( $this->defaultDataValueFormatters as $dataValueFormatter ) {
+			if ( $dataValueFormatter->isFormatterFor( $dataValue ) ) {
+				$dataValueFormatter->setDataValue( $dataValue );
+				return $dataValueFormatter;
+			}
+		}
+
+		throw new RuntimeException( "The dispatcher could not match a DataValueFormatter for " . get_class( $dataValue ) );
+	}
+
+}

--- a/src/DataValues/ValueFormatters/MonolingualTextValueFormatter.php
+++ b/src/DataValues/ValueFormatters/MonolingualTextValueFormatter.php
@@ -1,0 +1,132 @@
+<?php
+
+namespace SMW\DataValues\ValueFormatters;
+
+use SMW\DataValues\MonolingualTextValue;
+use SMW\DataValueFactory;
+use SMW\DIProperty;
+use SMWDataValue as DataValue;
+use RuntimeException;
+
+/**
+ * @license GNU GPL v2+
+ * @since 2.4
+ *
+ * @author mwjames
+ */
+class MonolingualTextValueFormatter extends DataValueFormatter {
+
+	/**
+	 * @since 2.4
+	 *
+	 * {@inheritDoc}
+	 */
+	public function isFormatterFor( DataValue $dataValue ) {
+		return $dataValue instanceOf MonolingualTextValue;
+	}
+
+	/**
+	 * @since 2.4
+	 *
+	 * {@inheritDoc}
+	 */
+	public function format( $type, $linker = null ) {
+
+		if ( !$this->dataValue instanceOf MonolingualTextValue ) {
+			throw new RuntimeException( "The formatter is missing a valid MonolingualTextValue object" );
+		}
+
+		if (
+			$this->dataValue->getCaption() !== false &&
+			( $type === self::WIKI_SHORT || $type === self::HTML_SHORT ) ) {
+			return $this->dataValue->getCaption();
+		}
+
+		return $this->getOutputText( $type, $linker );
+	}
+
+	protected function getOutputText( $type, $linker = null ) {
+
+		if ( !$this->dataValue->isValid() ) {
+			return ( ( $type == self::WIKI_SHORT ) || ( $type == self::HTML_SHORT ) ) ? '' : $this->dataValue->getErrorText();
+		}
+
+		// For the inverse case, return the subject that contains the reference
+		// for Foo annotated with [[Bar::abc@en]] -> [[-Bar::Foo]]
+		if ( $this->dataValue->getProperty() !== null && $this->dataValue->getProperty()->isInverse() ) {
+
+			$dataItems = $this->dataValue->getDataItem()->getSemanticData()->getPropertyValues(
+				new DIProperty(  $this->dataValue->getProperty()->getKey() )
+			);
+
+			$dataItem = reset( $dataItems );
+
+			if ( !$dataItem ) {
+				return '';
+			}
+
+			return $dataItem->getDBKey();
+		}
+
+		return $this->doFormatFinalOutputFor( $type, $linker );
+	}
+
+	private function doFormatFinalOutputFor( $type, $linker ) {
+
+		$text = '';
+		$languagecode = '';
+
+		foreach ( $this->dataValue->getPropertyDataItems() as $property ) {
+
+			// If we wanted to omit the language code display for some outputs then
+			// this is the point to make it happen
+			if ( ( $type == self::HTML_LONG || $type == self::WIKI_SHORT ) && $property->getKey() === '_LCODE' ) {
+			//continue;
+			}
+
+			$dataItems = $this->dataValue->getDataItem()->getSemanticData()->getPropertyValues( $property );
+
+			// Should not happen but just in case
+			if ( !$dataItems === array() ) {
+				$this->dataValue->addError( wfMessage( 'smw-datavalue-monolingual-dataitem-missing' )->text() );
+				continue;
+			}
+
+			$dataItem = reset( $dataItems );
+
+			if ( $dataItem === false ) {
+				continue;
+			}
+
+			$dataValue = DataValueFactory::getInstance()->newDataItemValue(
+				$dataItem,
+				$property
+			);
+
+			$result = $this->findValueOutputFor(
+				$type,
+				$dataValue,
+				$linker
+			);
+
+			if ( $property->getKey() === '_LCODE' ) {
+				$languagecode = ' ' . wfMessage( 'smw-datavalue-monolingual-lcode-parenthesis', $result )->text();
+			} else {
+				$text = $result;
+			}
+		}
+
+		return $text . $languagecode;
+	}
+
+	private function findValueOutputFor( $type, $dataValue, $linker ) {
+		switch ( $type ) {
+			case self::VALUE: return $dataValue->getWikiValue();
+			case self::WIKI_SHORT: return $dataValue->getShortWikiText( $linker );
+			case self::HTML_SHORT: return $dataValue->getShortHTMLText( $linker );
+			case self::WIKI_LONG: return $dataValue->getShortWikiText( $linker );
+			case self::HTML_LONG: return $dataValue->getShortHTMLText( $linker );
+		}
+	}
+
+}

--- a/src/DataValues/ValueFormatters/NoValueFormatter.php
+++ b/src/DataValues/ValueFormatters/NoValueFormatter.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace SMW\DataValues\ValueFormatters;
+
+use SMWDataValue as DataValue;
+use RuntimeException;
+
+/**
+ * @license GNU GPL v2+
+ * @since 2.4
+ *
+ * @author mwjames
+ */
+class NoValueFormatter extends DataValueFormatter {
+
+	/**
+	 * @since 2.4
+	 *
+	 * {@inheritDoc}
+	 */
+	public function isFormatterFor( DataValue $dataValue ) {
+		return $dataValue instanceOf DataValue;
+	}
+
+	/**
+	 * @since 2.4
+	 *
+	 * {@inheritDoc}
+	 */
+	public function format( $type, $linker = null ) {
+
+		if ( !$this->dataValue instanceOf DataValue ) {
+			throw new RuntimeException( "The formatter is missing a valid DataValue object" );
+		}
+
+		return $this->dataValue->getDataItem()->getSerialization();
+	}
+
+}

--- a/src/DataValues/ValueFormatters/ValueFormatter.php
+++ b/src/DataValues/ValueFormatters/ValueFormatter.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace SMW\DataValues\ValueFormatters;
+
+/**
+ * @license GNU GPL v2+
+ * @since 2.4
+ *
+ * @author mwjames
+ */
+interface ValueFormatter {
+
+	/**
+	 * @since 2.4
+	 *
+	 * @param mixed $type
+	 * @param mixed|null $linker
+	 *
+	 * @return mixed
+	 * @throws RuntimeException
+	 */
+	public function format( $type, $linker = null );
+
+}

--- a/src/Deserializers/DVDescriptionDeserializerRegistry.php
+++ b/src/Deserializers/DVDescriptionDeserializerRegistry.php
@@ -16,10 +16,10 @@ use SMWDataValue as DataValue;
  *
  * @author mwjames
  */
-class DVDescriptionDeserializerFactory {
+class DVDescriptionDeserializerRegistry {
 
 	/**
-	 * @var DescriptionDeserializerFactory
+	 * @var DVDescriptionDeserializerRegistry
 	 */
 	private static $instance = null;
 

--- a/tests/phpunit/Unit/DataTypeRegistryTest.php
+++ b/tests/phpunit/Unit/DataTypeRegistryTest.php
@@ -181,6 +181,32 @@ class DataTypeRegistryTest extends \PHPUnit_Framework_TestCase {
 		);
 	}
 
+	public function testRegisterDataValueFormatter() {
+
+		$dataValueFormatter = $this->getMockBuilder( '\SMW\DataValues\ValueFormatters\DataValueFormatter' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$dataValueFormatter->expects( $this->never() )
+			->method( 'isFormatterFor' );
+
+		$instance = new DataTypeRegistry();
+		$instance->registerDataValueFormatter( $dataValueFormatter );
+	}
+
+	public function testRegisterDVDescriptionDeserializer() {
+
+		$descriptionDeserializer = $this->getMockBuilder( '\SMW\Deserializers\DVDescriptionDeserializer\DescriptionDeserializer' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$descriptionDeserializer->expects( $this->never() )
+			->method( 'isDeserializerFor' );
+
+		$instance = new DataTypeRegistry();
+		$instance->registerDVDescriptionDeserializer( $descriptionDeserializer );
+	}
+
 	public function testLookupByLabelIsCaseInsensitive() {
 		$caseVariants = array(
 			'page',

--- a/tests/phpunit/Unit/DataValues/ValueFormatterRegistryTest.php
+++ b/tests/phpunit/Unit/DataValues/ValueFormatterRegistryTest.php
@@ -1,0 +1,92 @@
+<?php
+
+namespace SMW\Tests\DataValues;
+
+use SMW\DataValues\ValueFormatterRegistry;
+
+/**
+ * @covers \SMW\DataValues\ValueFormatterRegistry
+ * @group semantic-mediawiki
+ *
+ * @license GNU GPL v2+
+ * @since 2.4
+ *
+ * @author mwjames
+ */
+class ValueFormatterRegistryTest extends \PHPUnit_Framework_TestCase {
+
+	protected function tearDown() {
+		ValueFormatterRegistry::getInstance()->clear();
+		parent::tearDown();
+	}
+
+	public function testCanConstruct() {
+
+		$dispatchingDescriptionDeserializer = $this->getMockBuilder( '\SMW\DataValues\ValueFormatters\DispatchingDataValueFormatter' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$this->assertInstanceOf(
+			'\SMW\DataValues\ValueFormatterRegistry',
+			new ValueFormatterRegistry( $dispatchingDescriptionDeserializer )
+		);
+
+		$this->assertInstanceOf(
+			'\SMW\DataValues\ValueFormatterRegistry',
+			ValueFormatterRegistry::getInstance()
+		);
+	}
+
+	public function testCanConstructOnDefaultNoValueFormatter() {
+
+		$dataValue = $this->getMockBuilder( '\SMWDataValue' )
+			->disableOriginalConstructor()
+			->getMockForAbstractClass();
+
+		$instance = new ValueFormatterRegistry();
+
+		$this->assertInstanceOf(
+			'\SMW\DataValues\ValueFormatters\NoValueFormatter',
+			$instance->getDataValueFormatterFor( $dataValue )
+		);
+	}
+
+	public function testCanConstructMonolingualTextValue() {
+
+		$dataValue = $this->getMockBuilder( '\SMW\DataValues\MonolingualTextValue' )
+			->disableOriginalConstructor()
+			->getMockForAbstractClass();
+
+		$instance = new ValueFormatterRegistry();
+
+		$this->assertInstanceOf(
+			'\SMW\DataValues\ValueFormatters\MonolingualTextValueFormatter',
+			$instance->getDataValueFormatterFor( $dataValue )
+		);
+	}
+
+	public function testRegisterAdditionalDataValueFormatter() {
+
+		$dataValueFormatter = $this->getMockBuilder( '\SMW\DataValues\ValueFormatters\DataValueFormatter' )
+			->disableOriginalConstructor()
+			->setMethods( array( 'isFormatterFor' ) )
+			->getMockForAbstractClass();
+
+		$dataValueFormatter->expects( $this->once() )
+			->method( 'isFormatterFor' )
+			->will( $this->returnValue( true ) );
+
+		$dataValue = $this->getMockBuilder( '\SMWDataValue' )
+			->disableOriginalConstructor()
+			->getMockForAbstractClass();
+
+		$instance = new ValueFormatterRegistry();
+		$instance->registerDataValueFormatter( $dataValueFormatter );
+
+		$this->assertInstanceOf(
+			'\SMW\DataValues\ValueFormatters\DataValueFormatter',
+			$instance->getDataValueFormatterFor( $dataValue )
+		);
+	}
+
+}

--- a/tests/phpunit/Unit/DataValues/ValueFormatters/DispatchingDataValueFormatterTest.php
+++ b/tests/phpunit/Unit/DataValues/ValueFormatters/DispatchingDataValueFormatterTest.php
@@ -1,0 +1,124 @@
+<?php
+
+namespace SMW\Tests\DataValues\ValueFormatters;
+
+use SMW\DataValues\ValueFormatters\DispatchingDataValueFormatter;
+
+/**
+ * @covers \SMW\DataValues\ValueFormatters\DispatchingDataValueFormatter
+ * @group semantic-mediawiki
+ *
+ * @license GNU GPL v2+
+ * @since 2.4
+ *
+ * @author mwjames
+ */
+class DispatchingDataValueFormatterTest extends \PHPUnit_Framework_TestCase {
+
+	public function testCanConstruct() {
+
+		$this->assertInstanceOf(
+			'\SMW\DataValues\ValueFormatters\DispatchingDataValueFormatter',
+			new DispatchingDataValueFormatter()
+		);
+	}
+
+	public function testGetDataValueFormatterForMatchableDataValue() {
+
+		$dataValueFormatter = $this->getMockBuilder( '\SMW\DataValues\ValueFormatters\DataValueFormatter' )
+			->disableOriginalConstructor()
+			->getMockForAbstractClass();
+
+		$dataValueFormatter->expects( $this->once() )
+			->method( 'isFormatterFor' )
+			->will( $this->returnValue( true ) );
+
+		$dataValue = $this->getMockBuilder( '\SMWDataValue' )
+			->disableOriginalConstructor()
+			->getMockForAbstractClass();
+
+		$instance = new DispatchingDataValueFormatter();
+		$instance->addDataValueFormatter( $dataValueFormatter );
+
+		$this->assertInstanceOf(
+			'\SMW\DataValues\ValueFormatters\DataValueFormatter',
+			$instance->getDataValueFormatterFor( $dataValue )
+		);
+	}
+
+	public function testGetDefaultDispatchingDataValueFormatterForMatchableDataValue() {
+
+		$dataValueFormatter = $this->getMockBuilder( '\SMW\DataValues\ValueFormatters\DataValueFormatter' )
+			->disableOriginalConstructor()
+			->getMockForAbstractClass();
+
+		$dataValueFormatter->expects( $this->once() )
+			->method( 'isFormatterFor' )
+			->will( $this->returnValue( true ) );
+
+		$dataValue = $this->getMockBuilder( '\SMWDataValue' )
+			->disableOriginalConstructor()
+			->getMockForAbstractClass();
+
+		$instance = new DispatchingDataValueFormatter();
+		$instance->addDefaultDataValueFormatter( $dataValueFormatter );
+
+		$this->assertInstanceOf(
+			'\SMW\DataValues\ValueFormatters\DataValueFormatter',
+			$instance->getDataValueFormatterFor( $dataValue )
+		);
+	}
+
+	public function testPrioritizeDispatchableDataValueFormatter() {
+
+		$dataValueFormatter = $this->getMockBuilder( '\SMW\DataValues\ValueFormatters\DataValueFormatter' )
+			->disableOriginalConstructor()
+			->getMockForAbstractClass();
+
+		$dataValueFormatter->expects( $this->once() )
+			->method( 'isFormatterFor' )
+			->will( $this->returnValue( true ) );
+
+		$defaultDataValueFormatter = $this->getMockBuilder( '\SMW\DataValues\ValueFormatters\DataValueFormatter' )
+			->disableOriginalConstructor()
+			->getMockForAbstractClass();
+
+		$defaultDataValueFormatter->expects( $this->never() )
+			->method( 'isFormatterFor' );
+
+		$dataValue = $this->getMockBuilder( '\SMWDataValue' )
+			->disableOriginalConstructor()
+			->getMockForAbstractClass();
+
+		$instance = new DispatchingDataValueFormatter();
+		$instance->addDefaultDataValueFormatter( $defaultDataValueFormatter );
+		$instance->addDataValueFormatter( $dataValueFormatter );
+
+		$this->assertInstanceOf(
+			'\SMW\DataValues\ValueFormatters\DataValueFormatter',
+			$instance->getDataValueFormatterFor( $dataValue )
+		);
+	}
+
+	public function testTryToGetDataValueFormatterForNonDispatchableDataValueThrowsException() {
+
+		$dataValueFormatter = $this->getMockBuilder( '\SMW\DataValues\ValueFormatters\DataValueFormatter' )
+			->disableOriginalConstructor()
+			->getMockForAbstractClass();
+
+		$dataValueFormatter->expects( $this->once() )
+			->method( 'isFormatterFor' )
+			->will( $this->returnValue( false ) );
+
+		$dataValue = $this->getMockBuilder( '\SMWDataValue' )
+			->disableOriginalConstructor()
+			->getMockForAbstractClass();
+
+		$instance = new DispatchingDataValueFormatter();
+		$instance->addDataValueFormatter( $dataValueFormatter );
+
+		$this->setExpectedException( 'RuntimeException' );
+		$instance->getDataValueFormatterFor( $dataValue );
+	}
+
+}

--- a/tests/phpunit/Unit/DataValues/ValueFormatters/MonolingualTextValueFormatterTest.php
+++ b/tests/phpunit/Unit/DataValues/ValueFormatters/MonolingualTextValueFormatterTest.php
@@ -1,0 +1,122 @@
+<?php
+
+namespace SMW\Tests\DataValues\ValueFormatters;
+
+use SMW\DataValues\ValueFormatters\MonolingualTextValueFormatter;
+use SMW\DataValues\MonolingualTextValue;
+
+/**
+ * @covers \SMW\DataValues\ValueFormatters\MonolingualTextValueFormatter
+ * @group semantic-mediawiki
+ *
+ * @license GNU GPL v2+
+ * @since 2.4
+ *
+ * @author mwjames
+ */
+class MonolingualTextValueFormatterTest extends \PHPUnit_Framework_TestCase {
+
+	public function testCanConstruct() {
+
+		$this->assertInstanceOf(
+			'\SMW\DataValues\ValueFormatters\MonolingualTextValueFormatter',
+			new MonolingualTextValueFormatter()
+		);
+	}
+
+	public function testIsFormatterForValidation() {
+
+		$monolingualTextValue = $this->getMockBuilder( '\SMW\DataValues\MonolingualTextValue' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$instance = new MonolingualTextValueFormatter();
+
+		$this->assertTrue(
+			$instance->isFormatterFor( $monolingualTextValue )
+		);
+	}
+
+	public function testToUseCaptionOutput() {
+
+		$monolingualTextValue = new MonolingualTextValue();
+		$monolingualTextValue->setCaption( 'ABC' );
+
+		$instance = new MonolingualTextValueFormatter( $monolingualTextValue );
+
+		$this->assertEquals(
+			'ABC',
+			$instance->format( MonolingualTextValueFormatter::WIKI_SHORT )
+		);
+
+		$this->assertEquals(
+			'ABC',
+			$instance->format( MonolingualTextValueFormatter::HTML_SHORT )
+		);
+	}
+
+	/**
+	 * @dataProvider stringValueProvider
+	 */
+	public function testFormat( $stringValue, $type, $linker, $expected ) {
+
+		$monolingualTextValue = new MonolingualTextValue();
+		$monolingualTextValue->setUserValue( $stringValue );
+
+		$instance = new MonolingualTextValueFormatter( $monolingualTextValue );
+
+		$this->assertEquals(
+			$expected,
+			$instance->format( $type, $linker )
+		);
+	}
+
+	public function testTryToFormatOnMissingDataValueThrowsException() {
+
+		$instance = new MonolingualTextValueFormatter();
+
+		$this->setExpectedException( 'RuntimeException' );
+		$instance->format( MonolingualTextValueFormatter::VALUE );
+	}
+
+	public function stringValueProvider() {
+
+		$provider[] = array(
+			'foo@en',
+			MonolingualTextValueFormatter::VALUE,
+			null,
+			'foo (en)'
+		);
+
+		$provider[] = array(
+			'foo@en',
+			MonolingualTextValueFormatter::WIKI_SHORT,
+			null,
+			'foo (en)'
+		);
+
+		$provider[] = array(
+			'foo@en',
+			MonolingualTextValueFormatter::HTML_SHORT,
+			null,
+			'foo (en)'
+		);
+
+		$provider[] = array(
+			'foo@en',
+			MonolingualTextValueFormatter::WIKI_LONG,
+			null,
+			'foo (en)'
+		);
+
+		$provider[] = array(
+			'foo@en',
+			MonolingualTextValueFormatter::HTML_LONG,
+			null,
+			'foo (en)'
+		);
+
+		return $provider;
+	}
+
+}

--- a/tests/phpunit/Unit/DataValues/ValueFormatters/NoValueFormatterTest.php
+++ b/tests/phpunit/Unit/DataValues/ValueFormatters/NoValueFormatterTest.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace SMW\Tests\DataValues\ValueFormatters;
+
+use SMW\DataValues\ValueFormatters\NoValueFormatter;
+
+/**
+ * @covers \SMW\DataValues\ValueFormatters\NoValueFormatter
+ * @group semantic-mediawiki
+ *
+ * @license GNU GPL v2+
+ * @since 2.4
+ *
+ * @author mwjames
+ */
+class NoValueFormatterTest extends \PHPUnit_Framework_TestCase {
+
+	public function testCanConstruct() {
+
+		$this->assertInstanceOf(
+			'\SMW\DataValues\ValueFormatters\NoValueFormatter',
+			new NoValueFormatter()
+		);
+	}
+
+	public function testIsFormatterForValidation() {
+
+		$dataValue = $this->getMockBuilder( '\SMWDataValue' )
+			->disableOriginalConstructor()
+			->getMockForAbstractClass();
+
+		$instance = new NoValueFormatter();
+
+		$this->assertTrue(
+			$instance->isFormatterFor( $dataValue )
+		);
+	}
+
+	public function testFormat() {
+
+		$dataItem = $this->getMockBuilder( '\SMWDataItem' )
+			->disableOriginalConstructor()
+			->setMethods( array( 'getSerialization' ) )
+			->getMockForAbstractClass();
+
+		$dataItem->expects( $this->once() )
+			->method( 'getSerialization' )
+			->will( $this->returnValue( 'isFromSerializationMethod' ) );
+
+		$dataValue = $this->getMockBuilder( '\SMWDataValue' )
+			->disableOriginalConstructor()
+			->setMethods( array( 'isValid', 'getDataItem' ) )
+			->getMockForAbstractClass();
+
+		$dataValue->expects( $this->any() )
+			->method( 'isValid' )
+			->will( $this->returnValue( true ) );
+
+		$dataValue->expects( $this->once() )
+			->method( 'getDataItem' )
+			->will( $this->returnValue( $dataItem ) );
+
+		$instance = new NoValueFormatter( $dataValue );
+
+		$this->assertEquals(
+			'isFromSerializationMethod',
+			$instance->format( NoValueFormatter::VALUE )
+		);
+	}
+
+	public function testTryToFormatOnMissingDataValueThrowsException() {
+
+		$instance = new NoValueFormatter();
+
+		$this->setExpectedException( 'RuntimeException' );
+		$instance->format( NoValueFormatter::VALUE );
+	}
+
+}

--- a/tests/phpunit/Unit/Deserializers/DVDescriptionDeserializerRegistryTest.php
+++ b/tests/phpunit/Unit/Deserializers/DVDescriptionDeserializerRegistryTest.php
@@ -2,10 +2,10 @@
 
 namespace SMW\Tests\Deserializers;
 
-use SMW\Deserializers\DVDescriptionDeserializerFactory;
+use SMW\Deserializers\DVDescriptionDeserializerRegistry;
 
 /**
- * @covers \SMW\Deserializers\DVDescriptionDeserializerFactory
+ * @covers \SMW\Deserializers\DVDescriptionDeserializerRegistry
  * @group semantic-mediawiki
  *
  * @license GNU GPL v2+
@@ -13,10 +13,10 @@ use SMW\Deserializers\DVDescriptionDeserializerFactory;
  *
  * @author mwjames
  */
-class DVDescriptionDeserializerFactoryTest extends \PHPUnit_Framework_TestCase {
+class DVDescriptionDeserializerRegistryTest extends \PHPUnit_Framework_TestCase {
 
 	protected function tearDown() {
-		DVDescriptionDeserializerFactory::getInstance()->clear();
+		DVDescriptionDeserializerRegistry::getInstance()->clear();
 		parent::tearDown();
 	}
 
@@ -27,13 +27,13 @@ class DVDescriptionDeserializerFactoryTest extends \PHPUnit_Framework_TestCase {
 			->getMock();
 
 		$this->assertInstanceOf(
-			'\SMW\Deserializers\DVDescriptionDeserializerFactory',
-			new DVDescriptionDeserializerFactory( $dispatchingDescriptionDeserializer )
+			'\SMW\Deserializers\DVDescriptionDeserializerRegistry',
+			new DVDescriptionDeserializerRegistry( $dispatchingDescriptionDeserializer )
 		);
 
 		$this->assertInstanceOf(
-			'\SMW\Deserializers\DVDescriptionDeserializerFactory',
-			DVDescriptionDeserializerFactory::getInstance()
+			'\SMW\Deserializers\DVDescriptionDeserializerRegistry',
+			DVDescriptionDeserializerRegistry::getInstance()
 		);
 	}
 
@@ -43,7 +43,7 @@ class DVDescriptionDeserializerFactoryTest extends \PHPUnit_Framework_TestCase {
 			->disableOriginalConstructor()
 			->getMockForAbstractClass();
 
-		$instance = new DVDescriptionDeserializerFactory();
+		$instance = new DVDescriptionDeserializerRegistry();
 
 		$this->assertInstanceOf(
 			'\SMW\Deserializers\DVDescriptionDeserializer\SomeValueDescriptionDeserializer',
@@ -57,7 +57,7 @@ class DVDescriptionDeserializerFactoryTest extends \PHPUnit_Framework_TestCase {
 			->disableOriginalConstructor()
 			->getMockForAbstractClass();
 
-		$instance = new DVDescriptionDeserializerFactory();
+		$instance = new DVDescriptionDeserializerRegistry();
 
 		$this->assertInstanceOf(
 			'\SMW\Deserializers\DVDescriptionDeserializer\TimeValueDescriptionDeserializer',
@@ -71,7 +71,7 @@ class DVDescriptionDeserializerFactoryTest extends \PHPUnit_Framework_TestCase {
 			->disableOriginalConstructor()
 			->getMockForAbstractClass();
 
-		$instance = new DVDescriptionDeserializerFactory();
+		$instance = new DVDescriptionDeserializerRegistry();
 
 		$this->assertInstanceOf(
 			'\SMW\Deserializers\DVDescriptionDeserializer\RecordValueDescriptionDeserializer',
@@ -93,7 +93,7 @@ class DVDescriptionDeserializerFactoryTest extends \PHPUnit_Framework_TestCase {
 			->disableOriginalConstructor()
 			->getMockForAbstractClass();
 
-		$instance = new DVDescriptionDeserializerFactory();
+		$instance = new DVDescriptionDeserializerRegistry();
 		$instance->registerDescriptionDeserializer( $descriptionDeserializer );
 
 		$this->assertInstanceOf(


### PR DESCRIPTION
Allow to split formatter related code from a `DataValue` into a registered separate module using the `ValueFormatterRegistry::registerDataValueFormatter`:

- Interface `ValueFormatter`
- Abstract base class `DataValueFormatter` which defines `WIKI_SHORT`, `WIKI_LONG`, `HTML_SHORT`, `HTML_LONG`, and `VALUE`
- `DispatchingDataValueFormatter` will return a formatter based on the `isFormatterFor`
- Moved `MonolingualTextValue` (#1344) formatter related part to `MonolingualTextValueFormatter`

