### PR TITLE
Add free date/time formatting support

### DIFF
--- a/src/IntlTimeFormatter.php
+++ b/src/IntlTimeFormatter.php
@@ -1,0 +1,134 @@
+<?php
+
+namespace SMW;
+
+use DateTimeZone;
+use SMWDITime as DITime;
+use Language;
+
+/**
+ * @license GNU GPL v2+
+ * @since 2.4
+ *
+ * @author mwjames
+ */
+class IntlTimeFormatter {
+
+	/**
+	 * @var DITime
+	 */
+	private $dataItem;
+
+	/**
+	 * @var Language
+	 */
+	private $language;
+
+	/**
+	 * @since 2.4
+	 *
+	 * @param DITime $dataItem
+	 * @param Language|null $language
+	 */
+	public function __construct( DITime $dataItem, Language $language = null ) {
+		$this->dataItem = $dataItem;
+		$this->language = $language;
+
+		if ( $this->language === null ) {
+			$this->language = Localizer::getInstance()->getContentLanguage();
+		}
+	}
+
+	/**
+	 * Permitted formatting options are specified by http://php.net/manual/en/function.date.php
+	 *
+	 * @since 2.4
+	 *
+	 * @param string $format
+	 *
+	 * @return string
+	 */
+	public function format( $format ) {
+
+		$dateTime = $this->dataItem->asDateTime();
+
+		if ( !$dateTime ) {
+			return false;
+		}
+
+		$output = $this->getFormattedOutputWithTextualRepresentationReplacement(
+			$dateTime,
+			$format
+		);
+
+		if ( $this->dataItem->getCalendarModel() !== DITime::CM_GREGORIAN && $this->containsDateFormatRule( $format ) ) {
+			$output .= ' ' . $this->dataItem->getCalendarModelLiteral();
+		}
+
+		return $output;
+	}
+
+	private function containsDateFormatRule( $format ) {
+
+		foreach ( str_split( $format ) as $value ) {
+			if ( in_array( $value, array( 'd', 'D', 'j', 'l', 'N', 'w', 'W', 'F', 'M', 'm', 'n', 't', 'L', 'o', 'Y', 'y', "c", 'r' ) ) ) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	/**
+	 * DateTime generally outputs English textual representation
+	 *
+	 * - D	A textual representation of a day, three letters
+	 * - l (lowercase 'L'), A full textual representation of the day of the week
+	 * - F	A full textual representation of a month, such as January or March
+	 * - M	A short textual representation of a month, three letters
+	 * - a	Lowercase Ante meridiem and Post meridiem am or pm
+	 * - A	Uppercase Ante meridiem and Post meridiem
+	 */
+	private function getFormattedOutputWithTextualRepresentationReplacement( $dateTime, $format ) {
+
+		$output = $dateTime->format( $format );
+
+		$monthNumber = $dateTime->format( 'n' );
+		$dayNumber = $dateTime->format( 'N' );
+
+		if ( strpos( $format, 'F' ) !== false ) {
+			$output = str_replace(
+				$dateTime->format( 'F' ),
+				$this->language->getMonthName( $monthNumber ),
+				$output
+			);
+		}
+
+		if ( strpos( $format, 'M' ) !== false ) {
+			$output = str_replace(
+				$dateTime->format( 'M' ),
+				$this->language->getMonthAbbreviation( $monthNumber ),
+				$output
+			);
+		}
+
+		if ( strpos( $format, 'l' ) !== false ) {
+			$output = str_replace(
+				$dateTime->format( 'l' ),
+				$this->language->getWeekdayName( $dayNumber ),
+				$output
+			);
+		}
+
+		if ( strpos( $format, 'D' ) !== false ) {
+			$output = str_replace(
+				$dateTime->format( 'D' ),
+				$this->language->getWeekdayAbbreviation( $dayNumber ),
+				$output
+			);
+		}
+
+		return $output;
+	}
+
+}

--- a/tests/phpunit/Integration/ByJsonScript/Fixtures/p-0414.json
+++ b/tests/phpunit/Integration/ByJsonScript/Fixtures/p-0414.json
@@ -1,0 +1,95 @@
+{
+	"description": "Test in-text annotation/free format for `_dat` datatype (#1389, en)",
+	"properties": [
+		{
+			"name": "Has date",
+			"contents": "[[Has type::Date]]"
+		}
+	],
+	"subjects": [
+		{
+			"name": "Example/P0414/1",
+			"contents": "[[Has date::Feb 11 1389 10:00:01]]"
+		},
+		{
+			"name": "Example/P0414/1a",
+			"contents": "{{#ask: [[Example/P0414/1]] |?Has date#-F[H:i:s.u] |?Has date#-F[Y/m/d H:i] |?Has date#GR-F[Y/m/d H:i] |?Has date#JD=JD }}"
+		},
+		{
+			"name": "Example/P0414/2",
+			"contents": "[[Has date::100000 BC]]"
+		},
+		{
+			"name": "Example/P0414/2a",
+			"contents": "{{#ask: [[Example/P0414/2]] |?Has date#-F[H:i:s.u] |?Has date#-F[Y/m/d H:i] |?Has date#GR-F[Y/m/d H:i] |?Has date#JD=JD }}"
+		}
+	],
+	"parser-testcases": [
+		{
+			"about": "#0 JL calendar date with time",
+			"subject": "Example/P0414/1",
+			"store": {
+				"semantic-data": {
+					"strict-mode-valuematch": false,
+					"propertyCount": 3,
+					"propertyKeys": [ "Has_date", "_SKEY", "_MDAT" ],
+					"propertyValues": [ "1389-02-19T10:00:01" ]
+				}
+			},
+			"expected-output": {
+				"to-contain": [
+					"Feb 11 1389 10:00:01"
+				]
+			}
+		},
+		{
+			"about": "#1",
+			"subject": "Example/P0414/1a",
+			"expected-output": {
+				"to-contain": [
+					"<td data-sort-value=\"2228431.9166782\" class=\"Has-date smwtype_dat\">10:00:01.000000</td>",
+					"<td data-sort-value=\"2228431.9166782\" class=\"Has-date smwtype_dat\">1389/02/11 10:00 JL</td>",
+					"<td data-sort-value=\"2228431.9166782\" class=\"Has-date smwtype_dat\">1389/02/19 10:00</td>",
+					"<td data-sort-value=\"2228431.9166782\" class=\"JD smwtype_dat\">2228431.9166782</td>"
+				]
+			}
+		},
+		{
+			"about": "#2 Prehistory",
+			"subject": "Example/P0414/2",
+			"store": {
+				"semantic-data": {
+					"strict-mode-valuematch": false,
+					"propertyCount": 3,
+					"propertyKeys": [ "Has_date", "_SKEY", "_MDAT" ],
+					"propertyValues": [ "--100000-01-01" ]
+				}
+			},
+			"expected-output": {
+				"to-contain": [
+					"100000 BC"
+				]
+			}
+		},
+		{
+			"about": "#3",
+			"subject": "Example/P0414/2a",
+			"expected-output": {
+				"to-contain": [
+					"<td data-sort-value=\"-100001\" class=\"Has-date smwtype_dat\">--100000-01-01</td>",
+					"<td data-sort-value=\"-100001\" class=\"JD smwtype_dat\">-34802824.5</td>"
+				]
+			}
+		}
+	],
+	"settings": {
+		"wgContLang": "en",
+		"wgLang": "en"
+	},
+	"meta": {
+
+		"version": "0.1",
+		"is-incomplete": false,
+		"debug": false
+	}
+}

--- a/tests/phpunit/Integration/ByJsonScript/README.md
+++ b/tests/phpunit/Integration/ByJsonScript/README.md
@@ -1,5 +1,5 @@
 ## Fixtures
-Contains 93 files:
+Contains 94 files:
 
 ### F
 * [f-0001.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/ByJsonScript/Fixtures/f-0001.json) Test format=debug output
@@ -43,6 +43,7 @@ Contains 93 files:
 * [p-0411.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/ByJsonScript/Fixtures/p-0411.json) Test in-text annotation (and #subobject) using a monolingual property (#1344, en)
 * [p-0412.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/ByJsonScript/Fixtures/p-0412.json) Test in-text annotation for `_boo` datatype (ja)
 * [p-0413.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/ByJsonScript/Fixtures/p-0413.json) Test in-text annotation for different `_dat` input/output (en, skip virtuoso)
+* [p-0414.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/ByJsonScript/Fixtures/p-0414.json) Test in-text annotation/free format for `_dat` datatype (#1389, en)
 * [p-0701.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/ByJsonScript/Fixtures/p-0701.json) Test to create inverted annotation using a #ask/template combination (#711, `import-annotation=true`)
 * [p-0702.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/ByJsonScript/Fixtures/p-0702.json) Test #ask with `format=table` on inverse property/printrquest (#1270, en)
 * [p-0901.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/ByJsonScript/Fixtures/p-0901.json) Test #ask on moved redirected subject (#1086)
@@ -104,4 +105,4 @@ Contains 93 files:
 ### S
 * [s-0001.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/ByJsonScript/Fixtures/s-0001.json) Test output of `Special:Properties` (en, skip-on sqlite, 1.19)
 
--- Last updated on 2016-01-24 by `readmeContentsBuilder.php`
+-- Last updated on 2016-02-03 by `readmeContentsBuilder.php`

--- a/tests/phpunit/Unit/IntlTimeFormatterTest.php
+++ b/tests/phpunit/Unit/IntlTimeFormatterTest.php
@@ -1,0 +1,116 @@
+<?php
+
+namespace SMW\Tests;
+
+use SMW\IntlTimeFormatter;
+use SMWDITime as DITime;
+
+/**
+ * @covers \SMW\IntlTimeFormatter
+ * @group semantic-mediawiki
+ *
+ * @license GNU GPL v2+
+ * @since 2.4
+ *
+ * @author mwjames
+ */
+class IntlTimeFormatterTest extends \PHPUnit_Framework_TestCase {
+
+	public function testCanConstruct() {
+
+		$dataItem = $this->getMockBuilder( '\SMWDITime' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$this->assertInstanceOf(
+			'\SMW\IntlTimeFormatter',
+			new IntlTimeFormatter( $dataItem )
+		);
+	}
+
+	/**
+	 * @dataProvider formatProvider
+	 */
+	public function testFormat( $serialization, $formatOption, $expected ) {
+
+		$language = $this->getMockBuilder( '\Language' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$instance = new IntlTimeFormatter(
+			DITime::doUnserialize( $serialization ),
+			$language
+		);
+
+		$this->assertEquals(
+			$expected,
+			$instance->format( $formatOption )
+		);
+	}
+
+	public function testFormatWithLocalizedMonthReplacement() {
+
+		// F - A full textual representation of a month, such as January or March
+		$formatOption = 'F Y/m/d H:i:s';
+
+		$language = $this->getMockBuilder( '\Language' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$language->expects( $this->once() )
+			->method( 'getMonthName' )
+			->with( $this->equalTo( '12' ) )
+			->will( $this->returnValue( 'Foo' ) );
+
+		$instance = new IntlTimeFormatter(
+			DITime::doUnserialize( '1/2000/12/12/1/1/20.200' ),
+			$language
+		);
+
+		$this->assertEquals(
+			'Foo 2000/12/12 01:01:20',
+			$instance->format( $formatOption )
+		);
+	}
+
+	public function formatProvider() {
+
+		#0
+		$provider[] = array(
+			'1/2000/12/12/1/1/20/200',
+			'Y/m/d H:i:s',
+			'2000/12/12 01:01:20'
+		);
+
+		#1
+		$provider[] = array(
+			'2/2000/12/12/1/1/20/200',
+			'Y/m/d H:i:s',
+			'2000/12/12 01:01:20 JL'
+		);
+
+		#2
+		$provider[] = array(
+			'1/2000/12/12/1/1/20.200',
+			'Y/m/d H:i:s.u',
+			'2000/12/12 01:01:20.200000'
+		);
+
+		#3
+		$provider[] = array(
+			'2/1300/11/02/12/03/25.888499949',
+			'Y-m-d H:i:s.u',
+			'1300-11-02 12:03:25.888500 JL'
+		);
+
+		#4 time alone doesn't require a calendar model
+		$provider[] = array(
+			'2/1300/11/02/12/03/25.888499949',
+			'H:i:s.u',
+			'12:03:25.888500'
+		);
+
+		return $provider;
+	}
+
+}


### PR DESCRIPTION
- `-F[ ... ]` denotes the free format in form of
 `|?Date#-F[D M j G:i:s T Y]` or `|?Date#-F[l jS \of F Y h:i:s A]`
- Formatting options encapsulate by `-F[ ... ]` expected to adhere [0] rules
- Rules described by `-F[ ... ]` will use the `IntlTimeFormatter` to replace textual representation for available localizable text elements (e.g. Monday -> 日 or 日曜日)
- PHP's `DateTime` object handles the actual formatting hence [0]

## Example output

![image](https://cloud.githubusercontent.com/assets/1245473/12578849/bfd1bf94-c423-11e5-8963-c6056283db92.png)

## Features and limitations 

- Dates like `10000 BC` (prehistroy) are not supported by the formatter (the ISO date `--10000-01-01` is returned instead) other BC(E) dates like `2 Feb 900 BC` will be formatted as `-0900/01/25` or `-0900/02/02 JL`
- Dates stored with a JD(JL) are not automatically transformed and instead marked with `JL` to indicate its model

refs #1388

[0] http://php.net/manual/en/function.date.php