### PR TITLE
Cast string in DIHandlerGeoCoord

### DIFF
--- a/includes/storage/SQLStore/SMW_DIHandler_GeoCoord.php
+++ b/includes/storage/SQLStore/SMW_DIHandler_GeoCoord.php
@@ -62,8 +62,8 @@ class SMWDIHandlerGeoCoord extends SMWDataItemHandler {
 	public function getInsertValues( SMWDataItem $dataItem ) {
 		return array(
 			'o_serialized' => $dataItem->getSerialization(),
-			'o_lat' => $dataItem->getLatitude(),
-			'o_lon' => $dataItem->getLongitude()
+			'o_lat' => (string)$dataItem->getLatitude(),
+			'o_lon' => (string)$dataItem->getLongitude()
 		);
 	}
 


### PR DESCRIPTION
Return a string type for Lat, Long to ensure that the `PropertyTableRowDiffer::arrayDeleteMatchingValues` compares (currently it compares int with str) strings otherwise the `SQLStore` always deletes/inserts `geo` values.

This just came to light because the `EmbeddedQueryDependencyLinksStore` would always update `geo` values even for those that haven't changed because the `CompositePropertyTableDiffIterator` contained the diff result from the `PropertyTableRowDiffer::arrayDeleteMatchingValues` which compared int with string values and would judge that 15 != "15".