### PR TITLE
Serialize positive era information, refs #1348

### DIFF
--- a/includes/datavalues/SMW_DV_Time.php
+++ b/includes/datavalues/SMW_DV_Time.php
@@ -485,6 +485,12 @@ class SMWTimeValue extends SMWDataValue {
 		if ( ( $era == '-' ) && ( $date['y'] > 0 ) ) { // see class documentation on BC, "year 0", and ISO conformance ...
 			$date['y'] = -( $date['y'] );
 		}
+
+		// Keep information about the era
+		if ( ( $era == '+' ) && ( $date['y'] > 0 ) ) {
+			$date['y'] = $era . $date['y'];
+		}
+
 		// Old Style is a special case of Julian calendar model where the change of the year was 25 March:
 		if ( ( $calendarmodel == 'OS' ) &&
 		     ( ( $date['m'] < 3 ) || ( ( $date['m'] == 3 ) && ( $date['d'] < 25 ) ) ) ) {

--- a/src/DataValues/ValueFormatters/TimeValueFormatter.php
+++ b/src/DataValues/ValueFormatters/TimeValueFormatter.php
@@ -166,9 +166,14 @@ class TimeValueFormatter extends DataValueFormatter {
 
 		$extraneousLanguage = Localizer::getInstance()->getExtraneousLanguage();
 
+		// https://en.wikipedia.org/wiki/Anno_Domini
+		// "...placing the "AD" abbreviation before the year number ... BC is
+		// placed after the year number (for example: AD 2016, but 68 BC)..."
+		// Chicago Manual of Style 2010, pp. 476â€“7; Goldstein 2007, p. 6.
+
 		if ( $dataItem->getYear() > 0 ) {
-			$cestring = '';
-			$result = number_format( $dataItem->getYear(), 0, '.', '' ) . ( $cestring ? ( ' ' . $cestring ) : '' );
+			$cestring = $dataItem->getEra() > 0 ? 'AD' : '';
+			$result = ( $cestring ? ( $cestring . ' ' ) : '' ) . number_format( $dataItem->getYear(), 0, '.', '' );
 		} else {
 			$bcestring = 'BC';
 			$result = number_format( -( $dataItem->getYear() ), 0, '.', '' ) . ( $bcestring ? ( ' ' . $bcestring ) : '' );

--- a/tests/phpunit/Integration/ByJsonScript/Fixtures/p-0402.json
+++ b/tests/phpunit/Integration/ByJsonScript/Fixtures/p-0402.json
@@ -46,6 +46,10 @@
 		{
 			"name": "Page-error",
 			"contents": "[[Has page::::123|abc]] [[Has page::::xyz]]"
+		},
+		{
+			"name": "Example/P0402/7",
+			"contents": "[[Has date::-901 AD]]"
 		}
 	],
 	"parser-testcases": [
@@ -150,6 +154,22 @@
 			"expected-output": {
 				"to-contain": [
 					"&#58;123"
+				]
+			}
+		},
+		{
+			"about": "#6 negative year with AD/CE era is not allowed",
+			"subject": "Example/P0402/7",
+			"store": {
+				"semantic-data": {
+					"strict-mode-valuematch": false,
+					"propertyCount": 3,
+					"propertyKeys": [ "_SKEY", "_MDAT", "_ERRC" ]
+				}
+			},
+			"expected-output": {
+				"to-contain": [
+					"The date &quot;-901 AD&quot; was not understood."
 				]
 			}
 		}

--- a/tests/phpunit/Integration/ByJsonScript/Fixtures/p-0414.json
+++ b/tests/phpunit/Integration/ByJsonScript/Fixtures/p-0414.json
@@ -46,6 +46,14 @@
 		{
 			"name": "Example/P0414/5a",
 			"contents": "{{#ask: [[Example/P0414/5]] |?Has date#-F[H:i:s.u] |?Has date#-F[Y/m/d H:i] |?Has date#GR-F[Y/m/d H:i] |?Has date#JD=JD }}"
+		},
+		{
+			"name": "Example/P0414/6",
+			"contents": "[[Has date::1902 AD]]"
+		},
+		{
+			"name": "Example/P0414/6a",
+			"contents": "{{#ask: [[Example/P0414/6]]  |?Has date |?Has date#-F[Y] |?Has date#-F[Y/m/d] }}"
 		}
 	],
 	"parser-testcases": [
@@ -185,6 +193,34 @@
 				"to-contain": [
 					"<td data-sort-value=\"-100001\" class=\"Has-date smwtype_dat\">--100000-01-01</td>",
 					"<td data-sort-value=\"-100001\" class=\"JD smwtype_dat\">-34802824.5</td>"
+				]
+			}
+		},
+		{
+			"about": "#10 positive year only with era marker",
+			"subject": "Example/P0414/6",
+			"store": {
+				"semantic-data": {
+					"strict-mode-valuematch": false,
+					"propertyCount": 3,
+					"propertyKeys": [ "Has_date", "_SKEY", "_MDAT" ],
+					"propertyValues": [ "AD 1902-01-01" ]
+				}
+			},
+			"expected-output": {
+				"to-contain": [
+					"1902 AD"
+				]
+			}
+		},
+		{
+			"about": "#11",
+			"subject": "Example/P0414/6a",
+			"expected-output": {
+				"to-contain": [
+					"<td data-sort-value=\"2415750.5\" class=\"Has-date smwtype_dat\">AD 1902</td>",
+					"<td data-sort-value=\"2415750.5\" class=\"Has-date smwtype_dat\">1902</td>",
+					"<td data-sort-value=\"2415750.5\" class=\"Has-date smwtype_dat\">1902/01/01</td>"
 				]
 			}
 		}

--- a/tests/phpunit/Unit/DataValues/ValueFormatters/TimeValueFormatterTest.php
+++ b/tests/phpunit/Unit/DataValues/ValueFormatters/TimeValueFormatterTest.php
@@ -132,6 +132,19 @@ class TimeValueFormatterTest extends \PHPUnit_Framework_TestCase {
 		);
 	}
 
+	public function testGetCaptionFromDataItemForPositiveYearWithEraMarker() {
+
+		$timeValue = new TimeValue( '_dat' );
+		$timeValue->setUserValue( '2000 AD' );
+
+		$instance = new TimeValueFormatter( $timeValue );
+
+		$this->assertEquals(
+			'AD 2000',
+			$instance->getCaptionFromDataItem( $timeValue->getDataItem() )
+		);
+	}
+
 	public function testLeapYear() {
 
 		$timeValue = new TimeValue( '_dat' );


### PR DESCRIPTION
Keep positive era information serialized so that the display can account for what it was intended.

[0] noted "... is displayed without the 'AD' -- '910 AD' becomes '910' ... should not change the meaning of the date"

- If an era for a positive date was added then AD is placed in front indepedant of the actual annotated value (e.g. "AD 1902", "1902 AD").
- Internally, `-` indicates that it is a `BC(E)` era, we only mark a positive number with a `+` in case a positive year has an explicitly annotated `AD/CE` era and in all other cases the serialized number remains plain.
- `[[Date::-901 AD]]` is not allowed and has a test case

refs #1348

[0] https://phabricator.wikimedia.org/T49259