### PR TITLE
Support for microseconds

### DIFF
--- a/tests/phpunit/Integration/ByJsonScript/Fixtures/p-0402.json
+++ b/tests/phpunit/Integration/ByJsonScript/Fixtures/p-0402.json
@@ -32,7 +32,7 @@
 			"contents": "//::Page/::Foo:Bar is not allowed as title; [[Has text::::Text/::Foo:Bar]] [[Has url::http://example.org/:::Foo:Bar]]"
 		},
 		{
-			"name": "Date-error",
+			"name": "Example/P0402/3",
 			"contents": "[[Has date:::1 Jan 1970]]"
 		},
 		{
@@ -127,17 +127,17 @@
 		},
 		{
 			"about": "#4",
-			"subject": "Date-error",
+			"subject": "Example/P0402/3",
 			"store": {
 				"semantic-data": {
 					"strict-mode-valuematch": false,
 					"propertyCount": 3,
-					"propertyKeys": [ "_SKEY", "_MDAT", "_ERRC" ]
+					"propertyKeys": [ "_SKEY", "_MDAT", "Has_date" ]
 				}
 			},
 			"expected-output": {
 				"to-contain": [
-					"&#58;1 Jan 1970"
+					"1 Jan 1970"
 				]
 			}
 		},

--- a/tests/phpunit/Integration/ByJsonScript/Fixtures/p-0414.json
+++ b/tests/phpunit/Integration/ByJsonScript/Fixtures/p-0414.json
@@ -54,6 +54,14 @@
 		{
 			"name": "Example/P0414/6a",
 			"contents": "{{#ask: [[Example/P0414/6]]  |?Has date |?Has date#-F[Y] |?Has date#-F[Y/m/d] }}"
+		},
+		{
+			"name": "Example/P0414/7",
+			"contents": "[[Has date::2012-07-08 11:14:15.888499949]]"
+		},
+		{
+			"name": "Example/P0414/7a",
+			"contents": "{{#ask: [[Example/P0414/7]]  |?Has date |?Has date#-F[H:i:s.u] }}"
 		}
 	],
 	"parser-testcases": [
@@ -221,6 +229,33 @@
 					"<td data-sort-value=\"2415750.5\" class=\"Has-date smwtype_dat\">AD 1902</td>",
 					"<td data-sort-value=\"2415750.5\" class=\"Has-date smwtype_dat\">1902</td>",
 					"<td data-sort-value=\"2415750.5\" class=\"Has-date smwtype_dat\">1902/01/01</td>"
+				]
+			}
+		},
+		{
+			"about": "#12 micro sec",
+			"subject": "Example/P0414/7",
+			"store": {
+				"semantic-data": {
+					"strict-mode-valuematch": false,
+					"propertyCount": 3,
+					"propertyKeys": [ "Has_date", "_SKEY", "_MDAT" ],
+					"propertyValues": [ "2012-07-08T11:14:15" ]
+				}
+			},
+			"expected-output": {
+				"to-contain": [
+					"2012-07-08 11:14:15.888499949"
+				]
+			}
+		},
+		{
+			"about": "#13 `.888499949` is being rounded to `.888500`",
+			"subject": "Example/P0414/7a",
+			"expected-output": {
+				"to-contain": [
+					"<td data-sort-value=\"2456116.9682395\" class=\"Has-date smwtype_dat\">8 July 2012 11:14:15</td>",
+					"<td data-sort-value=\"2456116.9682395\" class=\"Has-date smwtype_dat\">11:14:15.888500</td>"
 				]
 			}
 		}

--- a/tests/phpunit/includes/dataitems/DITimeTest.php
+++ b/tests/phpunit/includes/dataitems/DITimeTest.php
@@ -1,0 +1,107 @@
+<?php
+
+namespace SMW\Tests;
+
+use SMWDITime as DITime;
+
+/**
+ * @covers \SMWDITime
+ *
+ * @license GNU GPL v2+
+ * @since 2.4
+ *
+ * @author mwjames
+ */
+class DITimeTest extends \PHPUnit_Framework_TestCase {
+
+	public function testCanConstruct() {
+
+		$this->assertInstanceOf(
+			'\SMWDITime',
+			new DITime(  DITime::CM_GREGORIAN, 1970 )
+		);
+	}
+
+	public function testNewFromTimestamp() {
+
+		$instance = DITime::newFromTimestamp( '1362200400' );
+
+		$this->assertInstanceOf(
+			'\SMWDITime',
+			$instance
+		);
+	}
+
+	public function testNewFromDateTime() {
+
+		$instance = DITime::newFromDateTime(
+			new \DateTime( '2012-07-08 11:14:15.638276' )
+		);
+
+		$this->assertEquals(
+			'15.638276',
+			$instance->getSecond()
+		);
+
+		$instance = DITime::newFromDateTime(
+			new \DateTime( '1582-10-04' )
+		);
+
+		$this->assertEquals(
+			DITime::CM_JULIAN,
+			$instance->getCalendarModel()
+		);
+
+		$instance = DITime::newFromDateTime(
+			new \DateTime( '1582-10-05' )
+		);
+
+		$this->assertEquals(
+			DITime::CM_GREGORIAN,
+			$instance->getCalendarModel()
+		);
+	}
+
+	public function testDateTimeRoundTrip() {
+
+		$dateTime = new \DateTime( '2012-07-08 11:14:15.638276' );
+
+		$instance = DITime::newFromDateTime(
+			$dateTime
+		);
+
+		$this->assertEquals(
+			$dateTime,
+			$instance->asDateTime()
+		);
+	}
+
+	public function testDateTimeWithLargeMs() {
+
+		$dateTime = new \DateTime( '1300-11-02 12:03:25.888500' );
+
+		$instance = new DITime(
+			2, 1300, 11, 02, 12, 03, 25.888499949
+		);
+
+		$this->assertEquals(
+			$dateTime,
+			$instance->asDateTime()
+		);
+	}
+
+	public function testDateTimeWithHistoricDate() {
+
+		$dateTime = new \DateTime( '-0900-02-02 00:00:00' );
+
+		$instance = new DITime(
+			2, -900, 02, 02
+		);
+
+		$this->assertEquals(
+			$dateTime,
+			$instance->asDateTime()
+		);
+	}
+
+}


### PR DESCRIPTION
While the standard formatter (ISO, MW) doesn't display a precision incorporating microseconds, the free formatter can be used `-F[H:i:s.u]` (#1389) instead.

SMW clearly distinguishes between `[[Date::2012-07-08 11:14:15.8884]]` and `[[Date::2012-07-08 11:14:15.8885]]`.