### PR TITLE
Semantics opt-out setting (a.k.a. disableSemantics)

### DIFF
--- a/SemanticMediaWiki.settings.php
+++ b/SemanticMediaWiki.settings.php
@@ -36,6 +36,20 @@ $GLOBALS['smwgExtraneousLanguageFileDir'] = __DIR__ . '/languages';
 ##
 
 ###
+# Semantic MediaWiki's operational state
+##
+$GLOBALS['smwgSemanticsEnabled'] = true;
+##
+
+###
+# CompatibilityMode is to force SMW to work with other extensions that may impact
+# performance in an unanticipated way.
+#
+##
+$GLOBALS['smwgEnabledCompatibilityMode'] = false;
+##
+
+###
 # Use another storage backend for Semantic MediaWiki. The default is suitable
 # for most uses of SMW.
 ##

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -7,6 +7,7 @@
 		]
 	},
 	"smw-desc": "Making your wiki more accessible - for machines ''and'' humans ([https://www.semantic-mediawiki.org/wiki/Help:User_manual online documentation])",
+	"smw-semantics-not-enabled": "Semantic MediaWiki functionality was not enabled for this wiki.",
 	"smw_viewasrdf": "RDF feed",
 	"smw_finallistconjunct": ", and",
 	"smw_factbox_head": "Facts about \"$1\"",

--- a/includes/GlobalFunctions.php
+++ b/includes/GlobalFunctions.php
@@ -2,6 +2,7 @@
 
 use SMW\NamespaceManager;
 use SMW\NumberFormatter;
+use SMW\CompatibilityMode;
 use SMW\SPARQLStore\SparqlDBConnectionProvider;
 
 /**
@@ -223,4 +224,16 @@ function enableSemantics( $namespace = null, $complete = false ) {
 	}
 
 	return true;
+}
+
+/**
+ * To disable Semantic MediaWiki's operational functionality
+ *
+ * @note This function can be used to temporary disable SMW but it is paramount
+ * that after SMW is re-enabled to run `rebuildData.php` in order for data to
+ * represent a state that mirrors the actual environment (deleted, moved pages
+ * are not tracked when disabled).
+ */
+function disableSemantics() {
+	CompatibilityMode::disableSemantics();
 }

--- a/includes/Settings.php
+++ b/includes/Settings.php
@@ -40,6 +40,8 @@ class Settings extends Options {
 			'smwgScriptPath' => $GLOBALS['smwgScriptPath'],
 			'smwgIP' => $GLOBALS['smwgIP'],
 			'smwgExtraneousLanguageFileDir' => $GLOBALS['smwgExtraneousLanguageFileDir'],
+			'smwgSemanticsEnabled' => $GLOBALS['smwgSemanticsEnabled'],
+			'smwgEnabledCompatibilityMode' => $GLOBALS['smwgEnabledCompatibilityMode'],
 			'smwgDefaultStore' => $GLOBALS['smwgDefaultStore'],
 			'smwgSparqlDatabaseConnector' => $GLOBALS['smwgSparqlDatabaseConnector'],
 			'smwgSparqlDatabase' => $GLOBALS['smwgSparqlDatabase'],

--- a/includes/Setup.php
+++ b/includes/Setup.php
@@ -89,6 +89,10 @@ final class Setup {
 			'Settings',
 			Settings::newFromGlobals( $this->globalVars )
 		);
+
+		if ( CompatibilityMode::requiresCompatibilityMode() ) {
+			CompatibilityMode::disableSemantics();
+		}
 	}
 
 	private function registerConnectionProviders() {
@@ -182,6 +186,11 @@ final class Setup {
 	 * @see https://www.mediawiki.org/wiki/Manual:$wgAPIModules
 	 */
 	private function registerWebApi() {
+
+		if ( !$this->applicationFactory->getSettings()->get( 'smwgSemanticsEnabled' ) ) {
+			return;
+		}
+
 		$this->globalVars['wgAPIModules']['smwinfo'] = '\SMW\MediaWiki\Api\Info';
 		$this->globalVars['wgAPIModules']['ask']     = '\SMW\MediaWiki\Api\Ask';
 		$this->globalVars['wgAPIModules']['askargs'] = '\SMW\MediaWiki\Api\AskArgs';
@@ -209,6 +218,10 @@ final class Setup {
 	 */
 	private function registerPermissions() {
 
+		if ( !$this->applicationFactory->getSettings()->get( 'smwgSemanticsEnabled' ) ) {
+			return;
+		}
+
 		// Rights
 		$this->globalVars['wgAvailableRights'][] = 'smw-admin';
 		$this->globalVars['wgAvailableRights'][] = 'smw-patternedit';
@@ -231,6 +244,10 @@ final class Setup {
 	 * @see https://www.mediawiki.org/wiki/Manual:$wgSpecialPages
 	 */
 	private function registerSpecialPages() {
+
+		if ( !$this->applicationFactory->getSettings()->get( 'smwgSemanticsEnabled' ) ) {
+			return;
+		}
 
 		$specials = array(
 			'Ask' => array(
@@ -311,6 +328,10 @@ final class Setup {
 	 */
 	private function registerFooterIcon() {
 
+		if ( !$this->applicationFactory->getSettings()->get( 'smwgSemanticsEnabled' ) ) {
+			return;
+		}
+
 		if( isset( $this->globalVars['wgFooterIcons']['poweredby']['semanticmediawiki'] ) ) {
 			return;
 		}
@@ -336,6 +357,10 @@ final class Setup {
 
 		$hookRegistry = new HookRegistry( $this->globalVars, $this->directory );
 		$hookRegistry->register();
+
+		if ( !$this->applicationFactory->getSettings()->get( 'smwgSemanticsEnabled' ) ) {
+			return;
+		}
 
 		// Old-style registration
 		$this->globalVars['wgHooks']['AdminLinks'][] = 'SMWHooks::addToAdminLinks';

--- a/includes/articlepages/SMW_OrderedListPage.php
+++ b/includes/articlepages/SMW_OrderedListPage.php
@@ -1,6 +1,7 @@
 <?php
 
 use SMW\DIProperty;
+
 use SMW\PropertyRegistry;
 use SMW\ApplicationFactory;
 
@@ -60,6 +61,12 @@ abstract class SMWOrderedListPage extends Article {
 	 */
 	public function view() {
 		global $wgRequest, $wgUser, $wgOut;
+
+		if ( !ApplicationFactory::getInstance()->getSettings()->get( 'smwgSemanticsEnabled' ) ) {
+			$wgOut->setPageTitle( $this->getTitle()->getPrefixedText() );
+			$wgOut->addHTML( wfMessage( 'smw-semantics-not-enabled' )->text() );
+			return;
+		}
 
 		if ( $this->getTitle()->getNamespace() === SMW_NS_PROPERTY ) {
 			$this->findBasePropertyToRedirectFor( $this->getTitle()->getText() );

--- a/includes/storage/SMW_Store.php
+++ b/includes/storage/SMW_Store.php
@@ -226,6 +226,10 @@ abstract class Store {
 	 */
 	public function updateData( SemanticData $semanticData ) {
 
+		if ( !ApplicationFactory::getInstance()->getSettings()->get( 'smwgSemanticsEnabled' ) ) {
+			return;
+		}
+
 		$subject = $semanticData->getSubject();
 
 		$dispatchContext = EventHandler::getInstance()->newDispatchContext();

--- a/src/CompatibilityMode.php
+++ b/src/CompatibilityMode.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace SMW;
+
+/**
+ * Internal benchmarks (XDebug) have shown that some extensions may affect the
+ * performance to a greater degree than expected and can impose a performance
+ * penalty to the overall system (templates, queries etc.).
+ *
+ * If a user is willing to incur those potential disadvantages by setting the
+ * `CompatibilityMode`, s(he) is to understand the latent possibility of those
+ * disadvantages.
+ *
+ * @license GNU GPL v2+
+ * @since 2.4
+ *
+ * @author mwjames
+ */
+class CompatibilityMode {
+
+	/**
+	 * @since 2.4
+	 *
+	 * @return boolean
+	 */
+	public static function requiresCompatibilityMode() {
+		return !$GLOBALS['smwgEnabledCompatibilityMode'] && defined( 'CARGO_VERSION' );
+	}
+
+	/**
+	 * @since 2.4
+	 */
+	public static function disableSemantics() {
+
+		$disabledSettings = array(
+			'smwgSemanticsEnabled' => false,
+			'smwgNamespacesWithSemanticLinks' => array(),
+			'smwgQEnabled' => false,
+			'smwgAutoRefreshOnPurge' => false,
+			'smwgAutoRefreshOnPageMove' => false,
+			'smwgFactboxCacheRefreshOnPurge' => false,
+			'smwgAdminRefreshStore' => false,
+			'smwgPageSpecialProperties' => array(),
+			'smwgEnableUpdateJobs' => false,
+			'smwgEnabledEditPageHelp' => false,
+			'smwgInlineErrors' => false,
+		);
+
+		foreach ( $disabledSettings as $key => $value) {
+			ApplicationFactory::getInstance()->getSettings()->set( $key, $value );
+			$GLOBALS[$key] = $value;
+		}
+	}
+
+}

--- a/src/MediaWiki/Hooks/SkinAfterContent.php
+++ b/src/MediaWiki/Hooks/SkinAfterContent.php
@@ -52,7 +52,7 @@ class SkinAfterContent {
 
 		$request = $this->skin->getContext()->getRequest();
 
-		if ( $request->getVal( 'action' ) === 'delete' || $request->getVal( 'action' ) === 'purge' ) {
+		if ( $request->getVal( 'action' ) === 'delete' || $request->getVal( 'action' ) === 'purge' || !ApplicationFactory::getInstance()->getSettings()->get( 'smwgSemanticsEnabled' ) ) {
 			return false;
 		}
 

--- a/src/MediaWiki/Hooks/SpecialStatsAddExtra.php
+++ b/src/MediaWiki/Hooks/SpecialStatsAddExtra.php
@@ -82,6 +82,11 @@ class SpecialStatsAddExtra {
 	 * @return true
 	 */
 	public function process() {
+
+		if ( !ApplicationFactory::getInstance()->getSettings()->get( 'smwgSemanticsEnabled' ) ) {
+			return true;
+		}
+
 		return version_compare( $this->version, '1.21', '<' ) ? $this->copyLegacyStatistics() : $this->copyStatistics();
 	}
 

--- a/src/ParserFunctionFactory.php
+++ b/src/ParserFunctionFactory.php
@@ -271,7 +271,7 @@ class ParserFunctionFactory {
 			);
 
 			if ( !$smwgQEnabled ) {
-				return $askParserFunction->isQueryDisabled();
+				return ApplicationFactory::getInstance()->getSettings()->get( 'smwgInlineErrors' ) ? $askParserFunction->isQueryDisabled(): '';
 			}
 
 			return $askParserFunction->parse( func_get_args() );
@@ -299,7 +299,7 @@ class ParserFunctionFactory {
 			);
 
 			if ( !$smwgQEnabled ) {
-				return $showParserFunction->isQueryDisabled();
+				return ApplicationFactory::getInstance()->getSettings()->get( 'smwgInlineErrors' ) ? $showParserFunction->isQueryDisabled(): '';
 			}
 
 			return $showParserFunction->parse( func_get_args() );

--- a/tests/phpunit/Unit/CompatibilityModeTest.php
+++ b/tests/phpunit/Unit/CompatibilityModeTest.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace SMW\Tests;
+
+use SMW\CompatibilityMode;
+
+/**
+ * @covers \SMW\CompatibilityMode
+ * @group semantic-mediawiki
+ *
+ * @license GNU GPL v2+
+ * @since 2.4
+ *
+ * @author mwjames
+ */
+class CompatibilityModeTest extends \PHPUnit_Framework_TestCase {
+
+	public function testRequiresCompatibilityMode() {
+
+		$this->assertInternalType(
+			'boolean',
+			CompatibilityMode::requiresCompatibilityMode()
+		);
+	}
+
+}

--- a/tests/phpunit/Unit/MediaWiki/Hooks/SkinAfterContentTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Hooks/SkinAfterContentTest.php
@@ -26,8 +26,9 @@ class SkinAfterContentTest extends \PHPUnit_Framework_TestCase {
 		$this->applicationFactory = ApplicationFactory::getInstance();
 
 		$settings = Settings::newFromArray( array(
-			'smwgFactboxUseCache' => true,
-			'smwgCacheType'       => 'hash'
+			'smwgFactboxUseCache'  => true,
+			'smwgCacheType'        => 'hash',
+			'smwgSemanticsEnabled' => true
 		) );
 
 		$this->applicationFactory->registerObject( 'Settings', $settings );

--- a/tests/phpunit/Unit/MediaWiki/Hooks/SpecialStatsAddExtraTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Hooks/SpecialStatsAddExtraTest.php
@@ -62,6 +62,7 @@ class SpecialStatsAddExtraTest extends \PHPUnit_Framework_TestCase {
 			->will( $this->returnValue( $setup['statistics'] ) );
 
 		ApplicationFactory::getInstance()->registerObject( 'Store', $store );
+		ApplicationFactory::getInstance()->getSettings()->set( 'smwgSemanticsEnabled', true );
 
 		$extraStats = $setup['extraStats'];
 		$version = $setup['version'];
@@ -82,6 +83,7 @@ class SpecialStatsAddExtraTest extends \PHPUnit_Framework_TestCase {
 			->getMock();
 
 		ApplicationFactory::getInstance()->registerObject( 'Store', StoreFactory::getStore() );
+		ApplicationFactory::getInstance()->getSettings()->set( 'smwgSemanticsEnabled', true );
 
 		$extraStats = array();
 		$version = '1.21';

--- a/tests/phpunit/includes/SetupTest.php
+++ b/tests/phpunit/includes/SetupTest.php
@@ -58,7 +58,8 @@ class SetupTest extends \PHPUnit_Framework_TestCase {
 			'wgVersion'         => '1.21',
 			'wgLanguageCode'    => 'en',
 			'wgLang'            => $language,
-			'IP'                => 'Foo'
+			'IP'                => 'Foo',
+			'smwgSemanticsEnabled' => true
 		);
 
 		foreach ( $this->defaultConfig as $key => $value ) {


### PR DESCRIPTION
refs [0]

`disableSemantics()` as a non-disruptive setting that can be added to the `LocalSettings` to temporary disable the storage and query capabilities of SMW for a selected instance.

- In-text annotation parsing remains active to avoid having `::` annotation clutter the display
- DB update for any extension that rely on SMW is disabled (== no DB activity)
- `#ask`/`#show` are disabled
- All SMW related special pages are disabled
- Special:Version will display the extension (as it is installed)
- Namespace Property/Concept remains available but is disabled
- API modules are disabled

[0] http://wikimedia.7.x6.nabble.com/Problems-installing-SMW-into-wiki-family-td5058854.html