### PR TITLE
Isolate JD computation

### DIFF
--- a/includes/datavalues/SMW_DV_Time.php
+++ b/includes/datavalues/SMW_DV_Time.php
@@ -143,7 +143,6 @@ class SMWTimeValue extends SMWDataValue {
 		}
 		$this->m_dataitem = null;
 
-		/// TODO Direct JD input currently cannot cope with decimal numbers
 		$datecomponents = array();
 		$calendarmodel = $era = $hours = $minutes = $seconds = $timeoffset = false;
 
@@ -160,11 +159,11 @@ class SMWTimeValue extends SMWDataValue {
 			if ( ( $calendarmodel == 'JD' ) || ( $calendarmodel == 'MJD' ) ) {
 				if ( ( $era === false ) && ( $hours === false ) && ( $timeoffset == 0 ) ) {
 					try {
-						$jd = floatval( reset( $datecomponents ) );
+						$jd = floatval( isset( $datecomponents[1] ) ? $datecomponents[0] . '.' . $datecomponents[1] : $datecomponents[0] );
 						if ( $calendarmodel == 'MJD' ) {
 							$jd += self::MJD_EPOCH;
 						}
-						$this->m_dataitem = SMWDITime::newFromJD( $jd, SMWDITime::CM_GREGORIAN, SMWDITime::PREC_YMDT, $this->m_typeid );
+						$this->m_dataitem = SMWDITime::newFromJD( $jd, SMWDITime::CM_GREGORIAN, SMWDITime::PREC_YMDT );
 					} catch ( SMWDataItemException $e ) {
 						$this->addError( wfMessage( 'smw_nodatetime', $this->m_wikivalue )->inContentLanguage()->text() );
 					}

--- a/src/DataValues/ValueFormatters/TimeValueFormatter.php
+++ b/src/DataValues/ValueFormatters/TimeValueFormatter.php
@@ -191,6 +191,10 @@ class TimeValueFormatter extends DataValueFormatter {
 			$result .= " " . $this->getTimeString();
 		}
 
+		if ( $dataItem->getCalendarModel() !== DITime::CM_GREGORIAN ) {
+			$result .= " " . $dataItem->getCalendarModelLiteral();
+		}
+
 		return $result;
 	}
 
@@ -279,8 +283,7 @@ class TimeValueFormatter extends DataValueFormatter {
 			( strpos( $format, 'JL' ) !== false ) ||
 			( $dataItem->getJD() < TimeValue::J1582 && strpos( $format, 'GR' ) === false ) ) {
 			$model = DITime::CM_JULIAN;
-//		} elseif ( strpos( $format, 'GR' ) !== false ) {
-		} else {
+		} elseif ( strpos( $format, 'GR' ) !== false ) {
 			$model = DITime::CM_GREGORIAN;
 		}
 

--- a/src/Deserializers/DVDescriptionDeserializer/TimeValueDescriptionDeserializer.php
+++ b/src/Deserializers/DVDescriptionDeserializer/TimeValueDescriptionDeserializer.php
@@ -94,10 +94,7 @@ class TimeValueDescriptionDeserializer extends DescriptionDeserializer {
 	private function getUpperLimit( $dataItem ) {
 
 		$prec = $dataItem->getPrecision();
-
-		$dateTime = new DateTime();
-		$dateTime->setDate( $dataItem->getYear(), $dataItem->getMonth(), $dataItem->getDay() );
-		$dateTime->setTime( $dataItem->getHour(), $dataItem->getMinute(), $dataItem->getSecond() );
+		$dateTime = $dataItem->asDateTime();
 
 		if ( $dateTime === false ) {
 			return $this->addError( 'Cannot compute interval for ' . $dataItem->getSerialization() );

--- a/src/JulianDay.php
+++ b/src/JulianDay.php
@@ -1,0 +1,224 @@
+<?php
+
+namespace SMW;
+
+use SMWDITime as DITime;
+use RuntimeException;
+
+/**
+ * Julian dates (abbreviated JD) are a continuous count of days and fractions
+ * since noon Universal Time on January 1, 4713 BCE (on the Julian calendar).
+ *
+ * It is assumed that the changeover from the Julian calendar to the Gregorian
+ * calendar occurred in October of 1582.
+ *
+ * For dates on or before 4 October 1582, the Julian calendar is used; for dates
+ * on or after 15 October 1582, the Gregorian calendar is used.
+ *
+ * @license GNU GPL v2+
+ * @since 2.4
+ *
+ * @author Markus Krötzsch
+ */
+class JulianDay {
+
+	/**
+	 * Moment of switchover to Gregorian calendar.
+	 */
+	const J1582 = 2299160.5;
+
+	/**
+	 * Offset of Julian Days for Modified JD inputs.
+	 */
+	const MJD = 2400000.5;
+
+	/**
+	 * Create a new time dataItem from a specified Julian Day number,
+	 * calendar model, presicion.
+	 *
+	 * @param double $jdValue
+	 * @param integer|null $calendarmodel
+	 * @param integer|null $precision
+	 *
+	 * @return DITime object
+	 */
+	public static function newDiFromJD( $jdValue, $calendarModel = null, $precision = null ) {
+
+		if ( $calendarModel === null ) { // 1582/10/15
+			$calendarModel = $jdValue < self::J1582 ? DITime::CM_JULIAN : DITime::CM_GREGORIAN;
+		}
+
+		if ( $precision === null ) {
+			$precision = strpos( strval( $jdValue ), '.5' ) !== false ? DITime::PREC_YMD : DITime::PREC_YMDT;
+		}
+
+		list( $year, $month, $day ) = self::JD2Date( $jdValue, $calendarModel );
+
+		if ( $precision <= DITime::PREC_YM ) {
+			$day = false;
+			if ( $precision === DITime::PREC_Y ) {
+				$month = false;
+			}
+		}
+
+		if ( $precision === DITime::PREC_YMDT ) {
+			list( $hour, $minute, $second ) = self::JD2Time( $jdValue );
+		} else {
+			$hour = $minute = $second = false;
+		}
+
+		return new DITime( $calendarModel, $year, $month, $day, $hour, $minute, $second );
+	}
+
+	/**
+	 * @since 2.4
+	 *
+	 * @param DITime $dataItem
+	 *
+	 * @return float
+	 */
+	public static function get( DITime $dataItem ) {
+
+		$jdValue = self::date2JD(
+			$dataItem->getYear(),
+			$dataItem->getMonth(),
+			$dataItem->getDay(),
+			$dataItem->getCalendarModel()
+		) + self::time2JDoffset(
+			$dataItem->getHour(),
+			$dataItem->getMinute(),
+			$dataItem->getSecond()
+		);
+
+		// Keep microseconds to a certain degree distinguishable
+		return floatval( number_format( $jdValue, 7, '.', '' ) );
+	}
+
+	/**
+	 * The MJD has a starting point of midnight on November 17, 1858 and is
+	 * computed by MJD = JD - 2400000.5
+	 *
+	 * @since 2.4
+	 *
+	 * @param DITime $dataItem
+	 *
+	 * @return float
+	 */
+	public static function getModifiedJulianDate( DITime $dataItem ) {
+		return self::get( $dataItem ) - self::MJD;
+	}
+
+	/**
+	 * Compute the Julian Day number from a given date in the specified
+	 * calendar model. This calculation assumes that neither calendar
+	 * has a year 0.
+	 *
+	 * @param $year integer representing the year
+	 * @param $month integer representing the month
+	 * @param $day integer representing the day
+	 * @param $calendarmodel integer either SMWDITime::CM_GREGORIAN or SMWDITime::CM_JULIAN
+	 *
+	 * @return float Julian Day number
+	 * @throws RuntimeException
+	 */
+	protected static function date2JD( $year, $month, $day, $calendarmodel ) {
+		$astroyear = ( $year < 1 ) ? ( $year + 1 ) : $year;
+
+		if ( $calendarmodel === DITime::CM_GREGORIAN ) {
+			$a = intval( ( 14 - $month ) / 12 );
+			$y = $astroyear + 4800 - $a;
+			$m = $month + 12 * $a - 3;
+			return $day + floor( ( 153 * $m + 2 ) / 5 ) + 365 * $y + floor( $y / 4 ) - floor( $y / 100 ) + floor( $y / 400 ) - 32045.5;
+		} elseif ( $calendarmodel === DITime::CM_JULIAN ) {
+			$y2 = ( $month <= 2 ) ? ( $astroyear - 1 ) : $astroyear;
+			$m2 = ( $month <= 2 ) ? ( $month + 12 ) : $month;
+			return floor( ( 365.25 * ( $y2 + 4716 ) ) ) + floor( ( 30.6001 * ( $m2 + 1 ) ) ) + $day - 1524.5;
+		}
+
+		throw new RuntimeException( "Unsupported calendar model ($calendarmodel)" );
+	}
+
+	/**
+	 * Compute the offset for the Julian Day number from a given time.
+	 * This computation is the same for all calendar models.
+	 *
+	 * @param $hours integer representing the hour
+	 * @param $minutes integer representing the minutes
+	 * @param $seconds integer representing the seconds
+	 *
+	 * @return float offset for a Julian Day number to get this time
+	 */
+	protected static function time2JDoffset( $hours, $minutes, $seconds ) {
+		return ( $hours / 24 ) + ( $minutes / ( 60 * 24 ) ) + ( $seconds / ( 3600 * 24 ) );
+	}
+
+	/**
+	 * Convert a Julian Day number to a date in the given calendar model.
+	 * This calculation assumes that neither calendar has a year 0.
+	 * @note The algorithm may fail for some cases, in particular since the
+	 * conversion to Gregorian needs positive JD. If this happens, wrong
+	 * values will be returned. Avoid date conversions before 10000 BCE.
+	 *
+	 * @param $jdvalue float number of Julian Days
+	 * @param $calendarmodel integer either SMWDITime::CM_GREGORIAN or SMWDITime::CM_JULIAN
+	 *
+	 * @return array( yearnumber, monthnumber, daynumber )
+	 * @throws RuntimeException
+	 */
+	protected static function JD2Date( $jdvalue, $calendarmodel ) {
+
+		if ( $calendarmodel === DITime::CM_GREGORIAN ) {
+			$jdvalue += 2921940; // add the days of 8000 years (this algorithm only works for positive JD)
+			$j = floor( $jdvalue + 0.5 ) + 32044;
+			$g = floor( $j / 146097 );
+			$dg = $j % 146097;
+			$c = floor( ( ( floor( $dg / 36524 ) + 1 ) * 3 ) / 4 );
+			$dc = $dg - $c * 36524;
+			$b = floor( $dc / 1461 );
+			$db = $dc % 1461;
+			$a = floor( ( ( floor( $db / 365 ) + 1 ) * 3 ) / 4 );
+			$da = $db - ( $a * 365 );
+			$y = $g * 400 + $c * 100 + $b * 4 + $a;
+			$m = floor( ( $da * 5 + 308 ) / 153 ) - 2;
+			$d = $da - floor( ( ( $m + 4 ) * 153 ) / 5 ) + 122;
+
+			$year  = $y - 4800 + floor( ( $m + 2 ) / 12 ) - 8000;
+			$month = ( ( $m + 2 ) % 12 + 1 );
+			$day   = $d + 1;
+		} elseif ( $calendarmodel === DITime::CM_JULIAN ) {
+			$b = floor( $jdvalue + 0.5 ) + 1524;
+			$c = floor( ( $b - 122.1 ) / 365.25 );
+			$d = floor( 365.25 * $c );
+			$e = floor( ( $b - $d ) / 30.6001 );
+
+			$month = floor( ( $e < 14 ) ? ( $e - 1 ) : ( $e - 13 ) );
+			$year = floor( ( $month > 2 ) ? ( $c - 4716 ) : ( $c - 4715 ) );
+			$day   = ( $b - $d - floor( 30.6001 * $e ) );
+		} else {
+			throw new RuntimeException( "Unsupported calendar model ($calendarmodel)" );
+		}
+
+		$year  = ( $year < 1 ) ? ( $year - 1 ) : $year; // correct "year 0" to -1 (= 1 BC(E))
+
+		return array( $year, $month, $day );
+	}
+
+	/**
+	 * Extract the time from a Julian Day number and return it as a string.
+	 * This conversion is the same for all calendar models.
+	 *
+	 * @param $jdvalue float number of Julian Days
+	 * @return array( hours, minutes, seconds )
+	 */
+	protected static function JD2Time( $jdvalue ) {
+		$wjd = $jdvalue + 0.5;
+		$fraction = $wjd - floor( $wjd );
+		$time = round( $fraction * 3600 * 24 );
+		$hours = floor( $time / 3600 );
+		$time = $time - $hours * 3600;
+		$minutes = floor( $time / 60 );
+		$seconds = floor( $time - $minutes * 60 );
+		return array( $hours, $minutes, $seconds );
+	}
+
+}

--- a/tests/phpunit/Integration/ByJsonScript/Fixtures/p-0413.json
+++ b/tests/phpunit/Integration/ByJsonScript/Fixtures/p-0413.json
@@ -96,7 +96,7 @@
 		},
 		{
 			"name": "Example/P0413/11a",
-			"contents": "{{#ask: [[Example/P0413/11]] |?Has date |?Has date#- |?Has date#ISO=ISO Date |?Has date#MEDIAWIKI=MW Date }}",
+			"contents": "{{#ask: [[Example/P0413/11]] |?Has date |?Has date#GR |?Has date#- |?Has date#ISO=ISO Date |?Has date#MEDIAWIKI=MW Date |?Has date#JD=JD }}",
 			"skip-on": {
 				"virtuoso": "Virtuoso 6.1 does not support BC/BCE dates"
 			}
@@ -160,6 +160,22 @@
 			"skip-on": {
 				"virtuoso": "Virtuoso 6.1 does not support BC/BCE dates"
 			}
+		},
+		{
+			"name": "Example/P0413/18",
+			"contents": "[[Has date::2488346.0804977 JD]]"
+		},
+		{
+			"name": "Example/P0413/18a",
+			"contents": "{{#ask: [[Example/P0413/18]] |?Has date |?Has date#- |?Has date#ISO=ISO Date |?Has date#MEDIAWIKI=MW Date |?Has date#JD=JD }}"
+		},
+		{
+			"name": "Example/P0413/19",
+			"contents": "[[Has date::2488346.0804977 MJD]]"
+		},
+		{
+			"name": "Example/P0413/19a",
+			"contents": "{{#ask: [[Example/P0413/19]] |?Has date |?Has date#- |?Has date#ISO=ISO Date |?Has date#MEDIAWIKI=MW Date |?Has date#JD=JD }}"
 		}
 	],
 	"parser-testcases": [
@@ -481,10 +497,12 @@
 			"subject": "Example/P0413/11a",
 			"expected-output": {
 				"to-contain": [
-					"<td data-sort-value=\"1611848.5\" class=\"Has-date smwtype_dat\">1 January 300 BC</td>",
+					"<td data-sort-value=\"1611848.5\" class=\"Has-date smwtype_dat\">1 January 300 BC JL</td>",
+					"<td data-sort-value=\"1611848.5\" class=\"Has-date smwtype_dat\">28 December 301 BC</td>",
 					"<td data-sort-value=\"1611848.5\" class=\"Has-date smwtype_dat\">--301-12-28</td>",
 					"<td data-sort-value=\"1611848.5\" class=\"ISO-Date smwtype_dat\">--301-12-28</td>",
-					"<td data-sort-value=\"1611848.5\" class=\"MW-Date smwtype_dat\">28 December 0000</td>"
+					"<td data-sort-value=\"1611848.5\" class=\"MW-Date smwtype_dat\">28 December 0000</td>",
+					"<td data-sort-value=\"1611848.5\" class=\"JD smwtype_dat\">1611848.5</td>"
 				]
 			}
 		},
@@ -510,11 +528,11 @@
 			"subject": "Example/P0413/13a",
 			"expected-output": {
 				"to-contain": [
-					"<td data-sort-value=\"2451598.5\" class=\"Has-date smwtype_dat\">24 February 2000</td>",
+					"<td data-sort-value=\"2451598.5\" class=\"Has-date smwtype_dat\">11 February 2000 JL</td>",
 					"<td data-sort-value=\"2451598.5\" class=\"Has-date smwtype_dat\">2000-02-24</td>",
 					"<td data-sort-value=\"2451598.5\" class=\"ISO-Date smwtype_dat\">2000-02-24</td>",
 					"<td data-sort-value=\"2451598.5\" class=\"MW-Date smwtype_dat\">24 February 2000</td>",
-					"<td data-sort-value=\"2451598.5\" class=\"JL-Date smwtype_dat\">11 February 2000</td>",
+					"<td data-sort-value=\"2451598.5\" class=\"JL-Date smwtype_dat\">11 February 2000 JL</td>",
 					"<td data-sort-value=\"2451598.5\" class=\"GR-Date smwtype_dat\">24 February 2000</td>"
 				]
 			}
@@ -541,11 +559,11 @@
 			"subject": "Example/P0413/14a",
 			"expected-output": {
 				"to-contain": [
-					"<td data-sort-value=\"2266042.5\" class=\"Has-date smwtype_dat\">2 February 1492</td>",
+					"<td data-sort-value=\"2266042.5\" class=\"Has-date smwtype_dat\">2 February 1492 JL</td>",
 					"<td data-sort-value=\"2266042.5\" class=\"Has-date smwtype_dat\">1492-02-11</td>",
 					"<td data-sort-value=\"2266042.5\" class=\"ISO-Date smwtype_dat\">1492-02-11</td>",
 					"<td data-sort-value=\"2266042.5\" class=\"MW-Date smwtype_dat\">11 February 1492</td>",
-					"<td data-sort-value=\"2266042.5\" class=\"JL-Date smwtype_dat\">2 February 1492</td>",
+					"<td data-sort-value=\"2266042.5\" class=\"JL-Date smwtype_dat\">2 February 1492 JL</td>",
 					"<td data-sort-value=\"2266042.5\" class=\"GR-Date smwtype_dat\">11 February 1492</td>"
 				]
 			}
@@ -576,7 +594,7 @@
 					"<td data-sort-value=\"2451585.9166667\" class=\"Has-date smwtype_dat\">2000-02-11T10:00:00</td>",
 					"<td data-sort-value=\"2451585.9166667\" class=\"ISO-Date smwtype_dat\">2000-02-11T10:00:00</td>",
 					"<td data-sort-value=\"2451585.9166667\" class=\"MW-Date smwtype_dat\">10:00, 11 February 2000</td>",
-					"<td data-sort-value=\"2451585.9166667\" class=\"JL-Date smwtype_dat\">29 January 2000 10:00:00</td>",
+					"<td data-sort-value=\"2451585.9166667\" class=\"JL-Date smwtype_dat\">29 January 2000 10:00:00 JL</td>",
 					"<td data-sort-value=\"2451585.9166667\" class=\"GR-Date smwtype_dat\">11 February 2000 10:00:00</td>"
 				]
 			}
@@ -642,6 +660,66 @@
 					"<td data-sort-value=\"-11001\" class=\"Has-date smwtype_dat\">--11000-01-01</td>",
 					"<td data-sort-value=\"-11001\" class=\"ISO-Date smwtype_dat\">--11000-01-01</td>",
 					"<td data-sort-value=\"-11001\" class=\"MW-Date smwtype_dat\">0000</td>"
+				]
+			}
+		},
+		{
+			"about": "#34 Direct JD input",
+			"subject": "Example/P0413/18",
+			"store": {
+				"semantic-data": {
+					"strict-mode-valuematch": false,
+					"propertyCount": 3,
+					"propertyKeys": [ "Has_date", "_SKEY", "_MDAT" ],
+					"propertyValues": [ "2100-10-04T13:55:55" ]
+				}
+			},
+			"expected-output": {
+				"to-contain": [
+					"2488346.0804977 JD"
+				]
+			}
+		},
+		{
+			"about": "#35",
+			"subject": "Example/P0413/18a",
+			"expected-output": {
+				"to-contain": [
+					"<td data-sort-value=\"2488346.0804977\" class=\"Has-date smwtype_dat\">4 October 2100 13:55:55</td>",
+					"<td data-sort-value=\"2488346.0804977\" class=\"Has-date smwtype_dat\">2100-10-04T13:55:55</td>",
+					"<td data-sort-value=\"2488346.0804977\" class=\"ISO-Date smwtype_dat\">2100-10-04T13:55:55</td>",
+					"<td data-sort-value=\"2488346.0804977\" class=\"MW-Date smwtype_dat\">13:55, 4 October 2100</td>",
+					"<td data-sort-value=\"2488346.0804977\" class=\"JD smwtype_dat\">2488346.0804977</td>"
+				]
+			}
+		},
+		{
+			"about": "#36 Direct MJD input",
+			"subject": "Example/P0413/19",
+			"store": {
+				"semantic-data": {
+					"strict-mode-valuematch": false,
+					"propertyCount": 3,
+					"propertyKeys": [ "Has_date", "_SKEY", "_MDAT" ],
+					"propertyValues": [ "8671-09-27T01:55:55" ]
+				}
+			},
+			"expected-output": {
+				"to-contain": [
+					"2488346.0804977 MJD"
+				]
+			}
+		},
+		{
+			"about": "#37",
+			"subject": "Example/P0413/19a",
+			"expected-output": {
+				"to-contain": [
+					"<td data-sort-value=\"4888346.5804977\" class=\"Has-date smwtype_dat\">27 September 8671 01:55:55</td>",
+					"<td data-sort-value=\"4888346.5804977\" class=\"Has-date smwtype_dat\">8671-09-27T01:55:55</td>",
+					"<td data-sort-value=\"4888346.5804977\" class=\"ISO-Date smwtype_dat\">8671-09-27T01:55:55</td>",
+					"<td data-sort-value=\"4888346.5804977\" class=\"MW-Date smwtype_dat\">01:55, 27 September 8671</td>",
+					"<td data-sort-value=\"4888346.5804977\" class=\"JD smwtype_dat\">4888346.5804977</td>"
 				]
 			}
 		}

--- a/tests/phpunit/Integration/MediaWiki/Import/TimeDataTypeTest.php
+++ b/tests/phpunit/Integration/MediaWiki/Import/TimeDataTypeTest.php
@@ -158,11 +158,11 @@ class TimeDataTypeTest extends MwDBaseUnitTestCase {
 			'valueFormatter' => $this->setWikiValueDateValueFormatter(),
 			'property'       => DIProperty::newFromUserLabel( 'Has calendar date' ),
 			'propertyValues' => array(
-				'1 January 300 BC', // 1 January 300 BC
+				'1 January 300 BC JL', // 1 January 300 BC
 				'2147483647 BC', // 2147483647 BC
 				'14000000000 BC',
-				'24 February 2000',
-				'2 February 1492'
+				'11 February 2000 JL',
+				'2 February 1492 JL'
 			)
 		);
 
@@ -182,11 +182,11 @@ class TimeDataTypeTest extends MwDBaseUnitTestCase {
 			'valueFormatter' => $this->setWikiValueDateWithJLCalendarModelValueFormatter(),
 			'property'       => DIProperty::newFromUserLabel( 'Has calendar date' ),
 			'propertyValues' => array(
-				'1 January 300 BC', // 1 January 300 BC
+				'1 January 300 BC JL', // 1 January 300 BC
 				'2147483647 BC', // 2147483647 BC
 				'14000000000 BC',
-				'11 February 2000',
-				'2 February 1492'
+				'11 February 2000 JL',
+				'2 February 1492 JL'
 			)
 		);
 

--- a/tests/phpunit/Unit/JulianDayTest.php
+++ b/tests/phpunit/Unit/JulianDayTest.php
@@ -1,0 +1,95 @@
+<?php
+
+namespace SMW\Tests;
+
+use SMW\JulianDay;
+use SMWDITime as DITime;
+
+/**
+ * @covers \SMW\JulianDay
+ * @group semantic-mediawiki
+ *
+ * @license GNU GPL v2+
+ * @since 2.4
+ *
+ * @author mwjames
+ */
+class JulianDayTest extends \PHPUnit_Framework_TestCase {
+
+	/**
+	 * @dataProvider valueProvider
+	 */
+	public function testConvert( $seralization, $jdValue ) {
+
+		$this->assertEquals(
+			$jdValue,
+			JulianDay::get( DITime::doUnserialize( $seralization ) )
+		);
+
+		$this->assertEquals(
+			DITime::doUnserialize( $seralization ),
+			JulianDay::newDiFromJD( $jdValue )
+		);
+	}
+
+	public function valueProvider() {
+
+		$provider[] = array(
+			'2/1352/01/01',
+			'2214875.500000'
+		);
+
+		$provider[] = array(
+			'1/2100/10/04',
+			'2488345.500000'
+		);
+
+		$provider[] = array(
+			'1/2100/10/04',
+			'2488345.500000'
+		);
+
+		$provider[] = array(
+			'2/1582/10/04',
+			'2299159.500000'
+		);
+
+		$provider[] = array(
+			'1/1582/10/15',
+			'2299160.5'
+		);
+
+		$provider[] = array(
+			'2/-900/10/4',
+			'1392974.500000'
+		);
+
+		$provider[] = array(
+			'2/-4713/01/02',
+			'0.5'
+		);
+
+		$provider[] = array(
+			'2/-4713/01/02/12/0/0',
+			'1'
+		);
+
+		$provider[] = array(
+			'2/-9000/10/4',
+			'-1565550.5'
+		);
+
+		$provider[] = array(
+			'1/2100/10/4/13/55/55',
+			'2488346.0804977'
+		);
+
+		$provider[] = array(
+			'1/2100/10/4/13/55/55',
+			2488346.0804977
+		);
+
+		return $provider;
+	}
+
+}


### PR DESCRIPTION
- A JL date is now explicitly marked as such
- Allows to annotate `[[Date::2488346.0804977 MJD]]` or `[[Date::2488346.0804977 JD]]`.

While the switch over year for the GR calendar is 1582/10/4 and the assumption that everybody knows the difference between JL/GR maybe valid, it still can create confusion as the what date is being used/displayed.

![image](https://cloud.githubusercontent.com/assets/1245473/12791830/23ec8bea-caa9-11e5-8417-005aa144a17e.png)

