### PR TITLE
Support for DISPLAYTITLE caption

### DIFF
--- a/SemanticMediaWiki.settings.php
+++ b/SemanticMediaWiki.settings.php
@@ -964,6 +964,17 @@ $GLOBALS['smwgEnabledInTextAnnotationParserStrictMode'] = true;
 # - SMW_DV_PVAP (Allows pattern) to allow regular expression pattern matching
 # when `Allows pattern` property is assigned to user-defined property
 #
+# - SMW_DV_WPV_DTITLE (WikiPageValue) is to allow requesting a lookup for a display
+# title and if present will be used as caption for the invoked subject
+#
+# - SMW_DV_PROV_DTITLE (PropertyValue) in combination with SMW_DV_WPV_DTITLE; If
+# enabled it will attempt to resolve a property label by matching it against a
+# possible assigned property "Display title of" value. For example, property
+# "Foo" has "Display title of" "hasFoolishFoo" where "hasFoolishFoo" is being
+# resolved as "Foo" when creating annotations. Currently, this uses an
+# uncached lookup and therefore is disabled by default to avoid a possible
+# performance impact (which has not been established or analyzed).
+#
 # @since 2.4
 ##
-$GLOBALS['smwgDVFeatures'] = SMW_DV_PROV_REDI | SMW_DV_MLTV_LCODE | SMW_DV_PVAP;
+$GLOBALS['smwgDVFeatures'] = SMW_DV_PROV_REDI | SMW_DV_MLTV_LCODE | SMW_DV_PVAP | SMW_DV_WPV_DTITLE;

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -382,5 +382,6 @@
 	"smw-datavalue-allows-pattern-mismatch": "\"$1\" was classified as invalid by the \"$2\" regular expression.",
 	"smw-datavalue-allows-pattern-reference-unknown": "The \"$1\" pattern reference could not be match to an entry in [[MediaWiki:Smw allows pattern]].",
 	"smw-datavalue-feature-not-supported": "The \"$1\" feature is not supported or was disabled on this wiki.",
-	"smw-pa-property-predefined_pvap": "\"$1\" is a predefined property that can specify a [[MediaWiki:Smw allows pattern|pattern reference]] to apply [https://en.wikipedia.org/wiki/Regular_expression regular expression] matching and is provided by [https://www.semantic-mediawiki.org/wiki/Help:Special_properties Semantic MediaWiki]."
+	"smw-pa-property-predefined_pvap": "\"$1\" is a predefined property that can specify a [[MediaWiki:Smw allows pattern|pattern reference]] to apply [https://en.wikipedia.org/wiki/Regular_expression regular expression] matching and is provided by [https://www.semantic-mediawiki.org/wiki/Help:Special_properties Semantic MediaWiki].",
+	"smw-pa-property-predefined_dtitle": "\"$1\" is a predefined property that can assign a distinct display title to an entity and is provided by [https://www.semantic-mediawiki.org/wiki/Help:Special_properties Semantic MediaWiki]."
 }

--- a/includes/Defines.php
+++ b/includes/Defines.php
@@ -142,4 +142,6 @@ define( 'SMW_DV_NONE', 0 );
 define( 'SMW_DV_PROV_REDI', 2 );  // PropertyValue to follow a property redirect target
 define( 'SMW_DV_MLTV_LCODE', 4 );  // MonolingualTextValue requires language code
 define( 'SMW_DV_PVAP', 16 );  // Allows pattern
+define( 'SMW_DV_WPV_DTITLE', 32 );  // WikiPageValue to use an explicit display title
+define( 'SMW_DV_PROV_DTITLE', 64 );  // PropertyValue allow to find a property using the display title
 /**@}*/

--- a/includes/SMW_Infolink.php
+++ b/includes/SMW_Infolink.php
@@ -461,14 +461,7 @@ class SMWInfolink {
 
 			foreach ( $ps as $p ) {
 				if ( $p !== '' ) {
-					$p = rawurldecode( str_replace( '-', '%', $p ) );
-					$parts = explode( '=', $p, 2 );
-
-					if ( count( $parts ) > 1 ) {
-						$result[$parts[0]] = $parts[1];
-					} else {
-						$result[] = $p;
-					}
+					$result[] = rawurldecode( str_replace( '-', '%', $p ) );
 				}
 			}
 		}

--- a/includes/articlepages/SMW_PropertyPage.php
+++ b/includes/articlepages/SMW_PropertyPage.php
@@ -153,10 +153,15 @@ class SMWPropertyPage extends SMWOrderedListPage {
 
 		if ( count( $diWikiPages ) > 0 ) {
 			$pageLister = new SMWPageLister( $diWikiPages, null, $this->limit, $this->from, $this->until );
+
 			$this->mTitle->setFragment( '#SMWResults' ); // Make navigation point to the result list.
 			$navigation = $pageLister->getNavigationLinks( $this->mTitle );
 
-			$titleText = htmlspecialchars( $this->mTitle->getText() );
+			$dvWikiPage = DataValueFactory::getInstance()->newDataItemValue(
+				$this->mProperty
+			);
+
+			$titleText = htmlspecialchars( $dvWikiPage->getWikiValue() );
 			$resultNumber = min( $this->limit, count( $diWikiPages ) );
 
 			$result .= "<a name=\"SMWResults\"></a><div id=\"mw-pages\">\n" .
@@ -210,7 +215,7 @@ class SMWPropertyPage extends SMWOrderedListPage {
 			}
 
 			// Property name
-			$searchlink = SMWInfolink::newBrowsingLink( '+', $dvWikiPage->getShortHTMLText() );
+			$searchlink = SMWInfolink::newBrowsingLink( '+', $dvWikiPage->getWikiValue() );
 			$r .= '<tr><td class="smwpropname">' . $dvWikiPage->getShortHTMLText( smwfGetLinker() ) .
 			      '&#160;' . $searchlink->getHTML( smwfGetLinker() ) . '</td><td class="smwprops">';
 

--- a/includes/datavalues/SMW_DV_Property.php
+++ b/includes/datavalues/SMW_DV_Property.php
@@ -58,15 +58,6 @@ class SMWPropertyValue extends SMWDataValue {
 	}
 
 	/**
-	 * @since 2.4
-	 *
-	 * @return boolean
-	 */
-	public function isToFindPropertyRedirect() {
-		return ( $this->getOptionValueFor( 'smwgDVFeatures' ) & SMW_DV_PROV_REDI ) != 0;
-	}
-
-	/**
 	 * Static function for creating a new property object from a
 	 * propertyname (string) as a user might enter it.
 	 * @note The resulting property object might be invalid if
@@ -152,9 +143,18 @@ class SMWPropertyValue extends SMWDataValue {
 			$this->m_dataitem = new SMWDIProperty( 'ERROR', false ); // just to have something
 		}
 
+		// @see the SMW_DV_PROV_DTITLE explanation
+		if ( $this->canFindPropertyByDisplayTitle() ) {
+			$dataItem = $this->getPropertySpecificationLookup()->getPropertyFromDisplayTitle(
+				$value
+			);
+
+			$this->m_dataitem = $dataItem ? $dataItem : $this->m_dataitem;
+		}
+
 		$this->inceptiveProperty = $this->m_dataitem;
 
-		if ( $this->isToFindPropertyRedirect() ) {
+		if ( $this->canFindPropertyRedirect() ) {
 			$this->m_dataitem = $this->m_dataitem->getRedirectTarget();
 		}
 	}
@@ -217,6 +217,7 @@ class SMWPropertyValue extends SMWDataValue {
 				$this->m_wikipage = null;
 			}
 		}
+
 		return $this->m_wikipage;
 	}
 
@@ -279,7 +280,16 @@ class SMWPropertyValue extends SMWDataValue {
 	}
 
 	public function getWikiValue() {
-		return $this->isVisible() ? $this->m_dataitem->getLabel() : '';
+
+		if ( !$this->isVisible() ) {
+			return '';
+		}
+
+		if ( $this->getWikiPageValue() !== null && $this->getWikiPageValue()->getDisplayTitle() !== '' ) {
+			return $this->getWikiPageValue()->getDisplayTitle();
+		}
+
+		return $this->m_dataitem->getLabel();
 	}
 
 	/**
@@ -339,6 +349,25 @@ class SMWPropertyValue extends SMWDataValue {
 		}
 
 		return $text;
+	}
+
+
+	/**
+	 * @since 2.4
+	 *
+	 * @return boolean
+	 */
+	protected function canFindPropertyRedirect() {
+		return ( $this->getOptionValueFor( 'smwgDVFeatures' ) & SMW_DV_PROV_REDI ) != 0;
+	}
+
+	/**
+	 * @since 2.4
+	 *
+	 * @return boolean
+	 */
+	protected function canFindPropertyByDisplayTitle() {
+		return ( $this->getOptionValueFor( 'smwgDVFeatures' ) & SMW_DV_PROV_DTITLE ) != 0;
 	}
 
 	/**

--- a/includes/storage/SMW_QueryResult.php
+++ b/includes/storage/SMW_QueryResult.php
@@ -304,6 +304,8 @@ class SMWQueryResult {
 	 */
 	public function toArray() {
 
+		$time = microtime( true );
+
 		// @note micro optimization: We call getSerializedQueryResult()
 		// only once and create the hash here instead of calling getHash()
 		// to avoid getSerializedQueryResult() being called again
@@ -315,7 +317,8 @@ class SMWQueryResult {
 				'hash'   => HashBuilder::createHashIdForContent( $serializeArray ),
 				'count'  => $this->getCount(),
 				'offset' => $this->mQuery->getOffset(),
-				'source' => $this->mQuery->getQuerySource()
+				'source' => $this->mQuery->getQuerySource(),
+				'time'   => number_format( ( microtime( true ) - $time ), 6, '.', '' )
 				)
 			)
 		);

--- a/includes/storage/SQLStore/SMW_Sql3SmwIds.php
+++ b/includes/storage/SQLStore/SMW_Sql3SmwIds.php
@@ -182,6 +182,7 @@ class SMWSql3SmwIds {
 		'_SERV' => 13,
 		'_PVAL' => 14,
 		'_REDI' => 15,
+		'_DTITLE' => 16,
 		'_SUBP' => 17,
 		'_SUBC' => 18,
 		'_CONC' => 19,

--- a/languages/SMW_Language.php
+++ b/languages/SMW_Language.php
@@ -101,7 +101,8 @@ abstract class SMWLanguage {
 		'Language code'  => '_LCODE',
 		'Text'           => '_TEXT',
 		'Has property description'     => '_PDESC',
-		'Allows pattern' => '_PVAP'
+		'Allows pattern' => '_PVAP',
+		'Display title of'     => '_DTITLE'
 	);
 
 	public function __construct() {

--- a/languages/SMW_LanguageAr.php
+++ b/languages/SMW_LanguageAr.php
@@ -82,7 +82,8 @@ class SMWLanguageAr extends SMWLanguage {
 		'_LCODE' => 'Language code',
 		'_TEXT'  => 'Text',
 		'_PDESC' => 'Has property description',
-		'_PVAP'  => 'Allows pattern'
+		'_PVAP'  => 'Allows pattern',
+		'_DTITLE' => 'Display title of'
 	);
 
 	protected $m_SpecialPropertyAliases = array(

--- a/languages/SMW_LanguageArz.php
+++ b/languages/SMW_LanguageArz.php
@@ -82,7 +82,8 @@ class SMWLanguageArz extends SMWLanguage {
 		'_LCODE' => 'Language code',
 		'_TEXT'  => 'Text',
 		'_PDESC' => 'Has property description',
-		'_PVAP'  => 'Allows pattern'
+		'_PVAP'  => 'Allows pattern',
+		'_DTITLE' => 'Display title of'
 	);
 
 	protected $m_SpecialPropertyAliases = array(

--- a/languages/SMW_LanguageCa.php
+++ b/languages/SMW_LanguageCa.php
@@ -86,7 +86,8 @@ class SMWLanguageCa extends SMWLanguage {
 		'_LCODE' => 'Language code',
 		'_TEXT'  => 'Text',
 		'_PDESC' => 'Has property description',
-		'_PVAP'  => 'Allows pattern'
+		'_PVAP'  => 'Allows pattern',
+		'_DTITLE' => 'Display title of'
 	);
 
 	protected $m_SpecialPropertyAliases = array(

--- a/languages/SMW_LanguageDe.php
+++ b/languages/SMW_LanguageDe.php
@@ -92,7 +92,8 @@ class SMWLanguageDe extends SMWLanguage {
 		'_LCODE' => 'Language code',
 		'_TEXT'  => 'Text',
 		'_PDESC' => 'Has property description',
-		'_PVAP'  => 'Allows pattern'
+		'_PVAP'  => 'Allows pattern',
+		'_DTITLE' => 'Display title of'
 	);
 
 	protected $m_SpecialPropertyAliases = array(

--- a/languages/SMW_LanguageEn.php
+++ b/languages/SMW_LanguageEn.php
@@ -88,16 +88,17 @@ class SMWLanguageEn extends SMWLanguage {
 		'_PREC'  => 'Display precision of',
 		'_LCODE' => 'Language code',
 		'_TEXT'  => 'Text',
-		'_TEXT'  => 'Text',
 		'_PDESC' => 'Has property description',
-		'_PVAP'  => 'Allows pattern'
+		'_PVAP'  => 'Allows pattern',
+		'_DTITLE' => 'Display title of'
 	);
 
 	protected $m_SpecialPropertyAliases = array(
 		'Display unit' => '_UNIT',
 		'Display precision' => '_PREC',
 		'Property description'     => '_PDESC',
-		'Allows pattern' => '_PVAP'
+		'Has allows pattern' => '_PVAP',
+		'Has display title of'     => '_DTITLE'
 	);
 
 	protected $m_Namespaces = array(

--- a/languages/SMW_LanguageEs.php
+++ b/languages/SMW_LanguageEs.php
@@ -83,7 +83,8 @@ class SMWLanguageEs extends SMWLanguage {
 		'_LCODE' => 'Language code',
 		'_TEXT'  => 'Text',
 		'_PDESC' => 'Has property description',
-		'_PVAP'  => 'Allows pattern'
+		'_PVAP'  => 'Allows pattern',
+		'_DTITLE' => 'Display title of'
 	);
 
 	protected $m_SpecialPropertyAliases = array(

--- a/languages/SMW_LanguageFi.php
+++ b/languages/SMW_LanguageFi.php
@@ -79,7 +79,8 @@ class SMWLanguageFi extends SMWLanguage {
 		'_LCODE' => 'Language code',
 		'_TEXT'  => 'Text',
 		'_PDESC' => 'Has property description',
-		'_PVAP'  => 'Allows pattern'
+		'_PVAP'  => 'Allows pattern',
+		'_DTITLE' => 'Display title of'
 	);
 
 	protected $m_Namespaces = array(

--- a/languages/SMW_LanguageFr.php
+++ b/languages/SMW_LanguageFr.php
@@ -83,7 +83,8 @@ class SMWLanguageFr extends SMWLanguage {
 		'_LCODE' => 'Language code',
 		'_TEXT'  => 'Text',
 		'_PDESC' => 'Has property description',
-		'_PVAP'  => 'Allows pattern'
+		'_PVAP'  => 'Allows pattern',
+		'_DTITLE' => 'Display title of'
 	);
 
 	protected $m_SpecialPropertyAliases = array(

--- a/languages/SMW_LanguageHe.php
+++ b/languages/SMW_LanguageHe.php
@@ -82,7 +82,8 @@ class SMWLanguageHe extends SMWLanguage {
 		'_LCODE' => 'Language code',
 		'_TEXT'  => 'Text',
 		'_PDESC' => 'Has property description',
-		'_PVAP'  => 'Allows pattern'
+		'_PVAP'  => 'Allows pattern',
+		'_DTITLE' => 'Display title of'
 	);
 
 	protected $m_SpecialPropertyAliases = array(

--- a/languages/SMW_LanguageHu.php
+++ b/languages/SMW_LanguageHu.php
@@ -87,7 +87,8 @@ class SMWLanguageHu extends SMWLanguage {
 		'_LCODE' => 'Language code',
 		'_TEXT'  => 'Text',
 		'_PDESC' => 'Has property description',
-		'_PVAP'  => 'Allows pattern'
+		'_PVAP'  => 'Allows pattern',
+		'_DTITLE' => 'Display title of'
 	);
 
 	protected $m_SpecialPropertyAliases = array(

--- a/languages/SMW_LanguageId.php
+++ b/languages/SMW_LanguageId.php
@@ -83,7 +83,8 @@ class SMWLanguageId extends SMWLanguage {
 		'_LCODE' => 'Language code',
 		'_TEXT'  => 'Text',
 		'_PDESC' => 'Has property description',
-		'_PVAP'  => 'Allows pattern'
+		'_PVAP'  => 'Allows pattern',
+		'_DTITLE' => 'Display title of'
 	);
 
 	protected $m_SpecialPropertyAliases = array(

--- a/languages/SMW_LanguageIt.php
+++ b/languages/SMW_LanguageIt.php
@@ -85,7 +85,8 @@ class SMWLanguageIt extends SMWLanguage {
 		'_LCODE' => 'Language code',
 		'_TEXT'  => 'Text',
 		'_PDESC' => 'Has property description',
-		'_PVAP'  => 'Allows pattern'
+		'_PVAP'  => 'Allows pattern',
+		'_DTITLE' => 'Display title of'
 	);
 
 	protected $m_SpecialPropertyAliases = array(

--- a/languages/SMW_LanguageNb.php
+++ b/languages/SMW_LanguageNb.php
@@ -92,7 +92,8 @@ class SMWLanguageNb extends SMWLanguage {
 		'_LCODE' => 'Language code',
 		'_TEXT'  => 'Text',
 		'_PDESC' => 'Has property description',
-		'_PVAP'  => 'Allows pattern'
+		'_PVAP'  => 'Allows pattern',
+		'_DTITLE' => 'Display title of'
 	);
 
 	protected $m_SpecialPropertyAliases = array(

--- a/languages/SMW_LanguageNl.php
+++ b/languages/SMW_LanguageNl.php
@@ -85,7 +85,8 @@ class SMWLanguageNl extends SMWLanguage {
 		'_LCODE' => 'Language code',
 		'_TEXT'  => 'Text',
 		'_PDESC' => 'Has property description',
-		'_PVAP'  => 'Allows pattern'
+		'_PVAP'  => 'Allows pattern',
+		'_DTITLE' => 'Display title of'
 	);
 
 	protected $m_SpecialPropertyAliases = array(

--- a/languages/SMW_LanguagePl.php
+++ b/languages/SMW_LanguagePl.php
@@ -101,7 +101,8 @@ class SMWLanguagePl extends SMWLanguage {
 		'_LCODE' => 'Language code',
 		'_TEXT'  => 'Text',
 		'_PDESC' => 'Has property description',
-		'_PVAP'  => 'Allows pattern'
+		'_PVAP'  => 'Allows pattern',
+		'_DTITLE' => 'Display title of'
 	);
 
 	protected $m_SpecialPropertyAliases = array(

--- a/languages/SMW_LanguagePt.php
+++ b/languages/SMW_LanguagePt.php
@@ -90,7 +90,8 @@ class SMWLanguagePt extends SMWLanguage {
 		'_LCODE' => 'Language code',
 		'_TEXT'  => 'Text',
 		'_PDESC' => 'Has property description',
-		'_PVAP'  => 'Allows pattern'
+		'_PVAP'  => 'Allows pattern',
+		'_DTITLE' => 'Display title of'
 	);
 
 	protected $m_SpecialPropertyAliases = array(

--- a/languages/SMW_LanguageRu.php
+++ b/languages/SMW_LanguageRu.php
@@ -85,7 +85,8 @@ class SMWLanguageRu extends SMWLanguage {
 		'_LCODE' => 'Language code',
 		'_TEXT'  => 'Text',
 		'_PDESC' => 'Has property description',
-		'_PVAP'  => 'Allows pattern'
+		'_PVAP'  => 'Allows pattern',
+		'_DTITLE' => 'Display title of'
 	);
 
 	protected $m_SpecialPropertyAliases = array(

--- a/languages/SMW_LanguageSk.php
+++ b/languages/SMW_LanguageSk.php
@@ -82,7 +82,8 @@ class SMWLanguageSk extends SMWLanguage {
 		'_LCODE' => 'Language code',
 		'_TEXT'  => 'Text',
 		'_PDESC' => 'Has property description',
-		'_PVAP'  => 'Allows pattern'
+		'_PVAP'  => 'Allows pattern',
+		'_DTITLE' => 'Display title of'
 	);
 
 	protected $m_SpecialPropertyAliases = array(

--- a/languages/SMW_LanguageZh_cn.php
+++ b/languages/SMW_LanguageZh_cn.php
@@ -90,7 +90,8 @@ class SMWLanguageZh_cn extends SMWLanguage {
 		'_LCODE' => 'Language code',
 		'_TEXT'  => 'Text',
 		'_PDESC' => 'Has property description',
-		'_PVAP'  => 'Allows pattern'
+		'_PVAP'  => 'Allows pattern',
+		'_DTITLE' => 'Display title of'
 	);
 
 	protected $m_SpecialPropertyAliases = array(

--- a/languages/SMW_LanguageZh_tw.php
+++ b/languages/SMW_LanguageZh_tw.php
@@ -88,7 +88,8 @@ class SMWLanguageZh_tw extends SMWLanguage {
 		'_LCODE' => 'Language code',
 		'_TEXT'  => 'Text',
 		'_PDESC' => 'Has property description',
-		'_PVAP'  => 'Allows pattern'
+		'_PVAP'  => 'Allows pattern',
+		'_DTITLE' => 'Display title of'
 	);
 
 	protected $m_SpecialPropertyAliases = array(

--- a/src/CachedPropertyValuesPrefetcher.php
+++ b/src/CachedPropertyValuesPrefetcher.php
@@ -108,6 +108,15 @@ class CachedPropertyValuesPrefetcher {
 	/**
 	 * @since 2.4
 	 *
+	 * @return Store
+	 */
+	public function getStore() {
+		return $this->store;
+	}
+
+	/**
+	 * @since 2.4
+	 *
 	 * @param DIWikiPage $subject
 	 *
 	 * @return string

--- a/src/Factbox/Factbox.php
+++ b/src/Factbox/Factbox.php
@@ -309,7 +309,7 @@ class Factbox {
 		$dataValue = $this->dataValueFactory->newDataItemValue( $subject, null );
 
 		$browselink = SMWInfolink::newBrowsingLink(
-			$dataValue->getText(),
+			$dataValue->getShortHTMLText(),
 			$dataValue->getWikiValue(),
 			'swmfactboxheadbrowse'
 		);

--- a/src/MediaWiki/Hooks/NewRevisionFromEditComplete.php
+++ b/src/MediaWiki/Hooks/NewRevisionFromEditComplete.php
@@ -83,18 +83,26 @@ class NewRevisionFromEditComplete {
 
 		$applicationFactory = ApplicationFactory::getInstance();
 
-		$parserData = $applicationFactory
-			->newParserData( $this->wikiPage->getTitle(), $this->parserOutput );
+		$parserData = $applicationFactory->newParserData(
+			$this->wikiPage->getTitle(),
+			$this->parserOutput
+		);
 
-		$pageInfoProvider = $applicationFactory
-			->newMwCollaboratorFactory()
-			->newPageInfoProvider( $this->wikiPage, $this->revision, $this->user );
+		$pageInfoProvider = $applicationFactory->newMwCollaboratorFactory()->newPageInfoProvider(
+			$this->wikiPage,
+			$this->revision,
+			$this->user
+		);
 
-		$propertyAnnotator = $applicationFactory
-			->newPropertyAnnotatorFactory()
-			->newPredefinedPropertyAnnotator( $parserData->getSemanticData(), $pageInfoProvider );
+		$propertyAnnotatorFactory = $applicationFactory->newPropertyAnnotatorFactory();
+
+		$propertyAnnotator = $propertyAnnotatorFactory->newPredefinedPropertyAnnotator(
+			$parserData->getSemanticData(),
+			$pageInfoProvider
+		);
 
 		$propertyAnnotator->addAnnotation();
+
 		$parserData->pushSemanticDataToParserOutput();
 
 		return true;

--- a/src/MediaWiki/Hooks/ParserAfterTidy.php
+++ b/src/MediaWiki/Hooks/ParserAfterTidy.php
@@ -63,6 +63,7 @@ class ParserAfterTidy {
 
 		// @see ParserData::setSemanticDataStateToParserOutputProperty
 		if ( $this->parser->getOutput()->getProperty( 'smw-semanticdata-status' ) ||
+			$this->parser->getOutput()->getProperty( 'displaytitle' ) ||
 			$this->parser->getOutput()->getCategoryLinks() ||
 			$this->parser->getDefaultSort() ) {
 			return true;
@@ -110,6 +111,13 @@ class ParserAfterTidy {
 
 		$propertyAnnotator = $propertyAnnotatorFactory->newMandatoryTypePropertyAnnotator(
 			$semanticData
+		);
+
+		$propertyAnnotator->addAnnotation();
+
+		$propertyAnnotator = $propertyAnnotatorFactory->newDisplayTitlePropertyAnnotator(
+			$semanticData,
+			$this->parser->getOutput()->getProperty( 'displaytitle' )
 		);
 
 		$propertyAnnotator->addAnnotation();

--- a/src/PropertyAnnotator/DisplayTitlePropertyAnnotator.php
+++ b/src/PropertyAnnotator/DisplayTitlePropertyAnnotator.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace SMW\PropertyAnnotator;
+
+use SMW\DIProperty;
+use SMW\PropertyAnnotator;
+use SMWDIBlob as DIBlob;
+
+/**
+ * @license GNU GPL v2+
+ * @since 2.4
+ *
+ * @author mwjames
+ */
+class DisplayTitlePropertyAnnotator extends PropertyAnnotatorDecorator {
+
+	/**
+	 * @var string|false
+	 */
+	private $displayTitle;
+
+	/**
+	 * @since 2.4
+	 *
+	 * @param PropertyAnnotator $propertyAnnotator
+	 * @param string|false $displayTitle
+	 */
+	public function __construct( PropertyAnnotator $propertyAnnotator, $displayTitle = false ) {
+		parent::__construct( $propertyAnnotator );
+		$this->displayTitle = $displayTitle;
+	}
+
+	protected function addPropertyValues() {
+
+		if ( !$this->displayTitle || $this->displayTitle === '' ) {
+			return;
+		}
+
+		$this->getSemanticData()->addPropertyObjectValue(
+			new DIProperty( '_DTITLE' ),
+			new DIBlob( $this->displayTitle )
+		);
+	}
+
+}

--- a/src/PropertyAnnotatorFactory.php
+++ b/src/PropertyAnnotatorFactory.php
@@ -8,6 +8,7 @@ use SMW\PropertyAnnotator\PredefinedPropertyAnnotator;
 use SMW\PropertyAnnotator\SortkeyPropertyAnnotator;
 use SMW\PropertyAnnotator\CategoryPropertyAnnotator;
 use SMW\PropertyAnnotator\MandatoryTypePropertyAnnotator;
+use SMW\PropertyAnnotator\DisplayTitlePropertyAnnotator;
 use SMw\MediaWiki\RedirectTargetFinder;
 use SMW\PageInfo;
 use SMW\SemanticData;
@@ -81,6 +82,21 @@ class PropertyAnnotatorFactory {
 		return new SortkeyPropertyAnnotator(
 			$this->newNullPropertyAnnotator( $semanticData ),
 			$sortkey
+		);
+	}
+
+	/**
+	 * @since 2.4
+	 *
+	 * @param SemanticData $semanticData
+	 * @param string|false $displayTitle
+	 *
+	 * @return DisplayTitlePropertyAnnotator
+	 */
+	public function newDisplayTitlePropertyAnnotator( SemanticData $semanticData, $displayTitle ) {
+		return new DisplayTitlePropertyAnnotator(
+			$this->newNullPropertyAnnotator( $semanticData ),
+			$displayTitle
 		);
 	}
 

--- a/src/PropertyRegistry.php
+++ b/src/PropertyRegistry.php
@@ -329,6 +329,7 @@ class PropertyRegistry {
 			'_TEXT'  => array( '_txt', true, true ), // "Text"
 			'_PDESC' => array( '_mlt_rec', true, true ), // "Property description"
 			'_PVAP'  => array( '__pvap', true, true ), // "Allows pattern"
+			'_DTITLE' => array( '_txt', false, true ), // "Display title of"
 		);
 
 		foreach ( $this->datatypeLabels as $id => $label ) {

--- a/src/Query/PrintRequest.php
+++ b/src/Query/PrintRequest.php
@@ -234,7 +234,7 @@ class PrintRequest {
 					}
 				}
 				else {
-					$printname = $this->m_data->getWikiValue();
+					$printname = $this->m_data->isVisible() ? $this->m_data->getDataItem()->getLabel() : '';
 					$result = '?' . $printname;
 
 					if ( $this->m_outputformat !== '' ) {

--- a/src/SQLStore/PropertyTableInfoFetcher.php
+++ b/src/SQLStore/PropertyTableInfoFetcher.php
@@ -65,7 +65,9 @@ class PropertyTableInfoFetcher {
 		// Concepts
 		'_CONC',
 		// Monolingual text
-		'_LCODE', '_TEXT'
+		'_LCODE', '_TEXT',
+		// Display title of
+		'_DTITLE'
 	);
 
 	/**

--- a/src/Serializers/QueryResultSerializer.php
+++ b/src/Serializers/QueryResultSerializer.php
@@ -94,11 +94,17 @@ class QueryResultSerializer implements DispatchableSerializer {
 					$result = $recordDiValues;
 				} else {
 					$title = $dataItem->getTitle();
+
+					//$wikiPageValue = DataValueFactory::getInstance()->newDataItemValue(
+					//	$dataItem
+					//);
+
 					$result = array(
 						'fulltext' => $title->getFullText(),
 						'fullurl' => $title->getFullUrl(),
 						'namespace' => $title->getNamespace(),
-						'exists' => $title->isKnown()
+						'exists' => $title->isKnown(),
+					//	'displaytitle' => $wikiPageValue->getDisplayTitle()
 					);
 				}
 				break;

--- a/src/SharedCallbackContainer.php
+++ b/src/SharedCallbackContainer.php
@@ -114,9 +114,8 @@ class SharedCallbackContainer implements CallbackContainer {
 
 	private function registerCallbackHandlersByFactory( $callbackLoader ) {
 
-		$callbackLoader->registerExpectedReturnType( 'BlobStore', '\Onoi\BlobStore\BlobStore' );
-
 		$callbackLoader->registerCallback( 'BlobStore', function( $namespace, $cacheType = null, $ttl = 0 ) use ( $callbackLoader ) {
+			$callbackLoader->registerExpectedReturnType( 'BlobStore', '\Onoi\BlobStore\BlobStore' );
 
 			$cacheFactory = $callbackLoader->load( 'CacheFactory' );
 
@@ -136,9 +135,8 @@ class SharedCallbackContainer implements CallbackContainer {
 			return $blobStore;
 		} );
 
-		$callbackLoader->registerExpectedReturnType( 'CachedPropertyValuesPrefetcher', '\SMW\CachedPropertyValuesPrefetcher' );
-
 		$callbackLoader->registerCallback( 'CachedPropertyValuesPrefetcher', function() use ( $callbackLoader ) {
+			$callbackLoader->registerExpectedReturnType( 'CachedPropertyValuesPrefetcher', '\SMW\CachedPropertyValuesPrefetcher' );
 
 			$cacheType = null;
 			$ttl = 604800; // 7 * 24 * 3600
@@ -151,9 +149,8 @@ class SharedCallbackContainer implements CallbackContainer {
 			return $cachedPropertyValuesPrefetcher;
 		} );
 
-		$callbackLoader->registerExpectedReturnType( 'PropertySpecificationLookup', '\SMW\PropertySpecificationLookup' );
-
 		$callbackLoader->registerCallback( 'PropertySpecificationLookup', function() use ( $callbackLoader ) {
+			$callbackLoader->registerExpectedReturnType( 'PropertySpecificationLookup', '\SMW\PropertySpecificationLookup' );
 
 			$propertySpecificationLookup = new PropertySpecificationLookup(
 				$callbackLoader->load( 'CachedPropertyValuesPrefetcher' )
@@ -168,9 +165,9 @@ class SharedCallbackContainer implements CallbackContainer {
 			return $propertySpecificationLookup;
 		} );
 
-		$callbackLoader->registerExpectedReturnType( 'PropertyHierarchyLookup', '\SMW\PropertyHierarchyLookup' );
 
 		$callbackLoader->registerCallback( 'PropertyHierarchyLookup', function() use ( $callbackLoader ) {
+			$callbackLoader->registerExpectedReturnType( 'PropertyHierarchyLookup', '\SMW\PropertyHierarchyLookup' );
 
 			$propertyHierarchyLookup = new PropertyHierarchyLookup(
 				$callbackLoader->load( 'Store' ),
@@ -187,7 +184,6 @@ class SharedCallbackContainer implements CallbackContainer {
 
 			return $propertyHierarchyLookup;
 		} );
-
 	}
 
 }

--- a/tests/phpunit/Integration/ByJsonScript/ByJsonScriptFixtureTestCaseRunnerTest.php
+++ b/tests/phpunit/Integration/ByJsonScript/ByJsonScriptFixtureTestCaseRunnerTest.php
@@ -142,7 +142,8 @@ class ByJsonScriptFixtureTestCaseRunnerTest extends ByJsonTestCaseProvider {
 			'smwgQSubcategoryDepth',
 			'smwgQConceptCaching',
 			'smwgEnabledInTextAnnotationParserStrictMode',
-			'smwgMaxNonExpNumber'
+			'smwgMaxNonExpNumber',
+			'wgRestrictDisplayTitle' // Restrict {{DISPLAYTITLE}} to titles ...
 		);
 
 		foreach ( $permittedSettings as $key ) {

--- a/tests/phpunit/Integration/ByJsonScript/Fixtures/p-0416.json
+++ b/tests/phpunit/Integration/ByJsonScript/Fixtures/p-0416.json
@@ -1,0 +1,101 @@
+{
+	"description": "Test in-text annotation with DISPLAYTITLE (#1410, `wgRestrictDisplayTitle`, en)",
+	"properties": [
+		{
+			"name": "Dwc:vernacularName",
+			"contents": "[[Has type::Text]] {{DISPLAYTITLE:dwc:vernacularName}}"
+		}
+	],
+	"subjects": [
+		{
+			"name": "Example/P0416/1",
+			"contents": "{{DISPLAYTITLE:Foo}} {{#subobject:Bar|text=abc|Display title of=123}}"
+		},
+		{
+			"name": "Example/P0416/1a",
+			"contents": "{{#ask: [[~Example/P0416/1*]] |?Display title of |format=table }}"
+		},
+		{
+			"name": "Example/P0416/2",
+			"contents": "{{DISPLAYTITLE:Foo}} {{#subobject:Bar|text=abc}}"
+		},
+		{
+			"name": "Example/P0416/2a",
+			"contents": "{{#ask: [[~Example/P0416/2*]] |?Display title of |format=table }}"
+		},
+		{
+			"name": "Example/P0416/3",
+			"contents": "[[dwc:vernacularName::Gewoon struisgras]] {{DISPLAYTITLE:Agrostis capillaris}}"
+		},
+		{
+			"name": "Example/P0416/3a",
+			"contents": "{{#ask: [[~Example/P0416/3*]] |?dwc:vernacularName |format=table }}"
+		}
+	],
+	"parser-testcases": [
+		{
+			"about": "#0",
+			"subject": "Example/P0416/1",
+			"store": {
+				"semantic-data": {
+					"strict-mode-valuematch": false,
+					"propertyCount": 4,
+					"propertyKeys": [ "_SKEY", "_MDAT", "_DTITLE", "_SOBJ" ],
+					"propertyValues": [ "Foo" ]
+				}
+			}
+		},
+		{
+			"about": "#1",
+			"subject": "Example/P0416/1#Bar",
+			"store": {
+				"semantic-data": {
+					"strict-mode-valuematch": false,
+					"propertyCount": 3,
+					"propertyKeys": [ "_DTITLE", "_TEXT", "_SKEY" ],
+					"propertyValues": [ "abc", "123" ]
+				}
+			}
+		},
+		{
+			"about": "#2",
+			"subject": "Example/P0416/1a",
+			"expected-output": {
+				"to-contain": [
+					"title=\"Example/P0416/1\">Foo</a></td><td class=\"Display-title-of smwtype_txt\">Foo</td>",
+					"title=\"Example/P0416/1\">123#Bar</a></span></td><td data-sort-value=\"123\" class=\"Display-title-of smwtype_txt\">123</td>"
+				]
+			}
+		},
+		{
+			"about": "#3",
+			"subject": "Example/P0416/2a",
+			"expected-output": {
+				"to-contain": [
+					"title=\"Example/P0416/2\">Foo</a></td><td class=\"Display-title-of smwtype_txt\">Foo</td>",
+					"title=\"Example/P0416/2\">Foo#Bar</a>"
+				]
+			}
+		},
+		{
+			"about": "#4",
+			"subject": "Example/P0416/3a",
+			"expected-output": {
+				"to-contain": [
+					"title=\"Example/P0416/3\">Agrostis capillaris</a></td><td class=\"dwc:vernacularName smwtype_txt\">Gewoon struisgras</td>",
+					"title=\"Property:Dwc:vernacularName\">dwc:vernacularName</a>"
+				]
+			}
+		}
+	],
+	"settings": {
+		"wgContLang": "en",
+		"wgLang": "en",
+		"wgRestrictDisplayTitle": false
+	},
+	"meta": {
+		"version": "0.1",
+		"is-incomplete": false,
+		"debug": false
+	}
+}

--- a/tests/phpunit/Integration/ByJsonScript/README.md
+++ b/tests/phpunit/Integration/ByJsonScript/README.md
@@ -1,5 +1,5 @@
 ## Fixtures
-Contains 95 files:
+Contains 99 files:
 
 ### F
 * [f-0001.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/ByJsonScript/Fixtures/f-0001.json) Test format=debug output
@@ -20,7 +20,7 @@ Contains 95 files:
 * [p-0101.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/ByJsonScript/Fixtures/p-0101.json) Test in-text annotation for use of restricted properties (#914, en)
 * [p-0106.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/ByJsonScript/Fixtures/p-0106.json) Test #info parser output (#1019, en)
 * [p-0107.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/ByJsonScript/Fixtures/p-0107.json) Test #smwdoc parser output (#1019, en)
-* [p-0202.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/ByJsonScript/Fixtures/p-0202.json) Test #set parser to use template for output (#1146)
+* [p-0202.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/ByJsonScript/Fixtures/p-0202.json) Test #set parser to use template for output (#1146, en)
 * [p-0203.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/ByJsonScript/Fixtures/p-0203.json) Test #set parser in combination with #subobject and template output (#1067, regression check)
 * [p-0204.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/ByJsonScript/Fixtures/p-0204.json) Test #set parser to produce error output (#870, en, verify that #set calls do not affect each other with previous errors)
 * [p-0205.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/ByJsonScript/Fixtures/p-0205.json) Test #set/#ask recursive annotation support (#711, #1055, recursive annotation using import-annotation=true via template)
@@ -45,6 +45,9 @@ Contains 95 files:
 * [p-0413.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/ByJsonScript/Fixtures/p-0413.json) Test in-text annotation for different `_dat` input/output (en, skip virtuoso)
 * [p-0414.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/ByJsonScript/Fixtures/p-0414.json) Test in-text annotation/free format for `_dat` datatype (#1389, en)
 * [p-0415.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/ByJsonScript/Fixtures/p-0415.json) Test in-text annotation on `_tem` with display unit preference (en)
+* [p-0416.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/ByJsonScript/Fixtures/p-0416.json) Test in-text annotation with DISPLAYTITLE (#1410, `wgRestrictDisplayTitle`, en)
+* [p-0417.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/ByJsonScript/Fixtures/p-0417.json) Test in-text annotation for `Allows pattern` to match regular expressions (en, skip-on postgres)
+* [p-0418.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/ByJsonScript/Fixtures/p-0418.json) Test in-text annotation using `_SERV` as provide service links (en)
 * [p-0701.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/ByJsonScript/Fixtures/p-0701.json) Test to create inverted annotation using a #ask/template combination (#711, `import-annotation=true`)
 * [p-0702.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/ByJsonScript/Fixtures/p-0702.json) Test #ask with `format=table` on inverse property/printrquest (#1270, en)
 * [p-0901.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/ByJsonScript/Fixtures/p-0901.json) Test #ask on moved redirected subject (#1086)
@@ -75,6 +78,7 @@ Contains 95 files:
 * [q-0608.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/ByJsonScript/Fixtures/q-0608.json) Test `_wpg` for single value approximate (`~/!~`) queries (#1246)
 * [q-0609.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/ByJsonScript/Fixtures/q-0609.json) Test `_wpg` for single value approximate (`~/!~`) queries with conjunctive category hierarchy (#1246, en, skip virtuoso)
 * [q-0610.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/ByJsonScript/Fixtures/q-0610.json) Test `_wpg` range queries (#1291, `smwStrictComparators=false`, skip virtuoso)
+* [q-0611.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/ByJsonScript/Fixtures/q-0611.json) Test `_wpg` namespace any value queries (#1301, en)
 * [q-0701.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/ByJsonScript/Fixtures/q-0701.json) Test `_uri` with some annotation/search pattern (T45264, #679)
 * [q-0702.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/ByJsonScript/Fixtures/q-0702.json) Test `_uri` with additional annotation/search (#1129)
 * [q-0801.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/ByJsonScript/Fixtures/q-0801.json) Test `_INST` query (#1004, en)
@@ -106,4 +110,4 @@ Contains 95 files:
 ### S
 * [s-0001.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/ByJsonScript/Fixtures/s-0001.json) Test output of `Special:Properties` (en, skip-on sqlite, 1.19)
 
--- Last updated on 2016-02-03 by `readmeContentsBuilder.php`
+-- Last updated on 2016-02-29 by `readmeContentsBuilder.php`

--- a/tests/phpunit/Unit/MediaWiki/Hooks/NewRevisionFromEditCompleteTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Hooks/NewRevisionFromEditCompleteTest.php
@@ -33,6 +33,12 @@ class NewRevisionFromEditCompleteTest extends \PHPUnit_Framework_TestCase {
 
 		$this->applicationFactory = ApplicationFactory::getInstance();
 		$this->semanticDataValidator = new SemanticDataValidator();
+
+		$store = $this->getMockBuilder( '\SMW\Store' )
+			->disableOriginalConstructor()
+			->getMockForAbstractClass();
+
+		$this->applicationFactory->registerObject( 'Store', $store );
 	}
 
 	protected function tearDown() {
@@ -168,7 +174,8 @@ class NewRevisionFromEditCompleteTest extends \PHPUnit_Framework_TestCase {
 				'wikiPage' => $wikiPage,
 				'revision' => $revision,
 				'settings' => array(
-					'smwgPageSpecialProperties' => array( DIProperty::TYPE_MODIFICATION_DATE )
+					'smwgPageSpecialProperties' => array( DIProperty::TYPE_MODIFICATION_DATE ),
+					'smwgDVFeatures' => ''
 				)
 			),
 			array(

--- a/tests/phpunit/Unit/MediaWiki/Hooks/ParserAfterTidyTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Hooks/ParserAfterTidyTest.php
@@ -115,11 +115,18 @@ class ParserAfterTidyTest extends \PHPUnit_Framework_TestCase {
 			$parameters['data-status']
 		);
 
+		$parser->getOutput()->setProperty(
+			'displaytitle',
+			isset( $parameters['displaytitle'] ) ? $parameters['displaytitle'] : false
+		);
+
 		$text   = '';
 
 		$instance = new ParserAfterTidy( $parser, $text );
 
-		$this->assertTrue( $instance->process() );
+		$this->assertTrue(
+			$instance->process()
+		);
 	}
 
 	public function testSemanticDataParserOuputUpdateIntegration() {
@@ -308,6 +315,39 @@ class ParserAfterTidyTest extends \PHPUnit_Framework_TestCase {
 				'cache-contains' => true,
 				'cache-fetch'    => false,
 				'data-status' => true
+			)
+		);
+
+		#5, 1410 displaytitle
+		$store = $this->getMockBuilder( 'SMW\Store' )
+			->disableOriginalConstructor()
+			->getMockForAbstractClass();
+
+		$store->expects( $this->once() )
+			->method( 'updateData' );
+
+		$title = MockTitle::buildMock( __METHOD__ );
+
+		$title->expects( $this->atLeastOnce() )
+			->method( 'getNamespace' )
+			->will( $this->returnValue( NS_MAIN ) );
+
+		$title->expects( $this->atLeastOnce() )
+			->method( 'inNamespace' )
+			->will( $this->returnValue( false ) );
+
+		$title->expects( $this->atLeastOnce() )
+			->method( 'getArticleID' )
+			->will( $this->returnValue( 5001 ) );
+
+		$provider[] = array(
+			array(
+				'store'    => $store,
+				'title'    => $title,
+				'cache-contains' => true,
+				'cache-fetch'    => true,
+				'data-status' => false,
+				'displaytitle' => 'Foo'
 			)
 		);
 

--- a/tests/phpunit/Unit/PropertyAnnotator/DisplayTitlePropertyAnnotatorTest.php
+++ b/tests/phpunit/Unit/PropertyAnnotator/DisplayTitlePropertyAnnotatorTest.php
@@ -1,0 +1,136 @@
+<?php
+
+namespace SMW\Tests\PropertyAnnotator;
+
+use SMW\Tests\TestEnvironment;
+use SMW\PropertyAnnotator\DisplayTitlePropertyAnnotator;
+use SMW\PropertyAnnotator\NullPropertyAnnotator;
+use SMW\DIWikiPage;
+
+/**
+ * @covers \SMW\PropertyAnnotator\DisplayTitlePropertyAnnotator
+ * @group semantic-mediawiki
+ *
+ * @license GNU GPL v2+
+ * @since 2.4
+ *
+ * @author mwjames
+ */
+class DisplayTitlePropertyAnnotatorTest extends \PHPUnit_Framework_TestCase {
+
+	private $semanticDataFactory;
+	private $semanticDataValidator;
+
+	protected function setUp() {
+		parent::setUp();
+
+		$testEnvironment = new TestEnvironment();
+
+		$this->semanticDataFactory = $testEnvironment->getUtilityFactory()->newSemanticDataFactory();
+		$this->semanticDataValidator = $testEnvironment->getUtilityFactory()->newValidatorFactory()->newSemanticDataValidator();
+	}
+
+	public function testCanConstruct() {
+
+		$semanticData = $this->getMockBuilder( '\SMW\SemanticData' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$instance = new DisplayTitlePropertyAnnotator(
+			new NullPropertyAnnotator( $semanticData )
+		);
+
+		$this->assertInstanceOf(
+			'\SMW\PropertyAnnotator\DisplayTitlePropertyAnnotator',
+			$instance
+		);
+	}
+
+	/**
+	 * @dataProvider displayTitleProvider
+	 */
+	public function testAddAnnotationForDisplayTitle( $title, $displayTitle, array $expected ) {
+
+		$semanticData = $this->semanticDataFactory->newEmptySemanticData(
+			$title
+		);
+
+		$instance = new DisplayTitlePropertyAnnotator(
+			new NullPropertyAnnotator( $semanticData ),
+			$displayTitle
+		);
+
+		$instance->addAnnotation();
+
+		$this->semanticDataValidator->assertThatPropertiesAreSet(
+			$expected,
+			$instance->getSemanticData()
+		);
+	}
+
+	public function testAddAnnotationForWhenPropertyNamespaceIsUsed() {
+
+		$semanticData = $this->semanticDataFactory->newEmptySemanticData(
+			new DIWikiPage( 'Foo', SMW_NS_PROPERTY )
+		);
+
+		$instance = new DisplayTitlePropertyAnnotator(
+			new NullPropertyAnnotator( $semanticData ),
+			'Bar'
+		);
+
+		$instance->addAnnotation();
+
+		$expected = array(
+			'propertyCount'  => 1,
+			'propertyKeys'   => '_DTITLE',
+			'propertyValues' => array( 'Bar' ),
+		);
+
+		$this->semanticDataValidator->assertThatPropertiesAreSet(
+			$expected,
+			$instance->getSemanticData()
+		);
+	}
+
+	public function displayTitleProvider() {
+
+		$provider = array();
+
+		#0 with title entry
+		$provider[] = array(
+			'Foo',
+			'Lala',
+			array(
+				'propertyCount'  => 1,
+				'propertyKeys'   => '_DTITLE',
+				'propertyValues' => array( 'Lala' ),
+			)
+		);
+
+		#1 Empty
+		$provider[] = array(
+			'Bar',
+			'',
+			array(
+				'propertyCount'  => 0,
+				'propertyKeys'   => '',
+				'propertyValues' => array(),
+			)
+		);
+
+		#2 Empty
+		$provider[] = array(
+			'Bar',
+			false,
+			array(
+				'propertyCount'  => 0,
+				'propertyKeys'   => '',
+				'propertyValues' => array(),
+			)
+		);
+
+		return $provider;
+	}
+
+}

--- a/tests/phpunit/Unit/PropertySpecificationLookupTest.php
+++ b/tests/phpunit/Unit/PropertySpecificationLookupTest.php
@@ -43,6 +43,40 @@ class PropertySpecificationLookupTest extends \PHPUnit_Framework_TestCase {
 		);
 	}
 
+	public function testGetPropertyFromDisplayTitle() {
+
+		$property = $this->dataItemFactory->newDIProperty( 'Foo' );
+
+		$queryResult = $this->getMockBuilder( '\SMWQueryResult' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$queryResult->expects( $this->once() )
+			->method( 'getResults' )
+			->will( $this->returnValue( array( $this->dataItemFactory->newDIWikiPage( 'Foo' ) ) ) );
+
+		$store = $this->getMockBuilder( '\SMW\Store' )
+			->disableOriginalConstructor()
+			->getMockForAbstractClass();
+
+		$store->expects( $this->once() )
+			->method( 'getQueryResult' )
+			->will( $this->returnValue( $queryResult ) );
+
+		$this->cachedPropertyValuesPrefetcher->expects( $this->once() )
+			->method( 'getStore' )
+			->will( $this->returnValue( $store ) );
+
+		$instance = new PropertySpecificationLookup(
+			$this->cachedPropertyValuesPrefetcher
+		);
+
+		$this->assertEquals(
+			$property,
+			$instance->getPropertyFromDisplayTitle( 'abc' )
+		);
+	}
+
 	public function testGetAllowedPattern() {
 
 		$property = $this->dataItemFactory->newDIProperty( 'Has allowed pattern' );

--- a/tests/phpunit/includes/DataValues/PropertyValueTest.php
+++ b/tests/phpunit/includes/DataValues/PropertyValueTest.php
@@ -28,7 +28,7 @@ class PropertyValueTest extends \PHPUnit_Framework_TestCase {
 	/**
 	 * @dataProvider optionsProvider
 	 */
-	public function testNeedsToFindPropertyRedirectOrNotByOption( $options, $expected ) {
+	public function testOptions( $options, $expected ) {
 
 		$instance = new PropertyValue( '__pro' );
 
@@ -38,7 +38,7 @@ class PropertyValueTest extends \PHPUnit_Framework_TestCase {
 
 		$this->assertEquals(
 			$expected,
-			$instance->isToFindPropertyRedirect()
+			$instance->getOptionValueFor( 'smwgDVFeatures' )
 		);
 	}
 


### PR DESCRIPTION
Adds general support for subjects that contain a `{{DISPLAYTITLE:Foo}}`. The pre-defined property `_DTITLE` is unrestricted therefore manually annotations via `Display title of` [0] are allowed.

Settings in connection with `{{DISPLAYTITLE:Foo}}`:

```
$wgAllowDisplayTitle = true;
$wgRestrictDisplayTitle = false;
```

[0] https://www.semantic-mediawiki.org/wiki/Help:Special_property_Display_title_of