### PR TITLE
Fix "MessageCache Non-string key given" exception caused by `_SERV`

### DIFF
--- a/includes/datavalues/SMW_DataValue.php
+++ b/includes/datavalues/SMW_DataValue.php
@@ -375,7 +375,7 @@ abstract class SMWDataValue {
 			}
 
 			$args[0] = 'smw_service_' . str_replace( ' ', '_', $dataItem->getString() ); // messages distinguish ' ' from '_'
-			$text = wfMessage( $args )->inContentLanguage()->text();
+			$text = call_user_func_array( 'wfMessage', $args )->inContentLanguage()->text();
 			$links = preg_split( "/[\n][\s]?/u", $text );
 
 			foreach ( $links as $link ) {

--- a/tests/phpunit/Integration/ByJsonScript/Fixtures/p-0418.json
+++ b/tests/phpunit/Integration/ByJsonScript/Fixtures/p-0418.json
@@ -1,0 +1,74 @@
+{
+	"description": "Test in-text annotation using `_SERV` as provide service links (en)",
+	"properties": [
+		{
+			"name": "PropertyWithServiceLink",
+			"contents": "[[Has type::Text]] [[Provides service::some links]]"
+		},
+		{
+			"name": "PropertyWithAnotherServiceLink",
+			"contents": "[[Has type::Text]] [[Provides service::some other links]]"
+		}
+	],
+	"subjects": [
+		{
+			"name": "Smw_service_some_other_links",
+			"namespace": "NS_MEDIAWIKI",
+			"contents": " label text1|http://someurl.com"
+		},
+		{
+			"name": "Example/P0418/1",
+			"contents": " [[PropertyWithServiceLink::123]]"
+		},
+		{
+			"name": "Example/P0418/2",
+			"contents": " [[PropertyWithAnotherServiceLink::ABC]]"
+		}
+	],
+	"parser-testcases": [
+		{
+			"about": "#0",
+			"subject": "PropertyWithServiceLink",
+			"namespace": "SMW_NS_PROPERTY",
+			"store": {
+				"clear-cache": true,
+				"semantic-data": {
+					"strict-mode-valuematch": false,
+					"propertyCount": 4,
+					"propertyKeys": [ "_TYPE", "_MDAT", "_SKEY", "_SERV" ],
+					"propertyValues": [ "some links" ]
+				}
+			}
+		},
+		{
+			"about": "#1",
+			"subject": "PropertyWithServiceLink",
+			"namespace": "SMW_NS_PROPERTY",
+			"expected-output": {
+				"to-contain": [
+					"some links"
+				]
+			}
+		},
+		{
+			"about": "#2",
+			"subject": "PropertyWithAnotherServiceLink",
+			"namespace": "SMW_NS_PROPERTY",
+			"expected-output": {
+				"to-contain": [
+					"some other links"
+				]
+			}
+		}
+	],
+	"settings": {
+		"wgContLang": "en",
+		"wgLang": "en"
+	},
+	"meta": {
+
+		"version": "0.1",
+		"is-incomplete": false,
+		"debug": false
+	}
+}


### PR DESCRIPTION
Just encountered this on [0] when trying to add `[[Provides service::online maps|online maps]]` where `MediaWiki:Smw service online maps` has been created yet.

```
[b98b39b5] /wiki/Property:Has_coordinates MWException from line 702 of /var/www/htdocs/mw/02100/w/includes/cache/MessageCache.php: Non-string key given

Backtrace:

#0 /var/www/htdocs/mw/02100/w/includes/Message.php(1075): MessageCache->get(double, boolean, Language)
#1 /var/www/htdocs/mw/02100/w/includes/Message.php(698): Message->fetchMessage()
#2 /var/www/htdocs/mw/02100/w/includes/Message.php(789): Message->toString()
#3 /var/www/htdocs/mw/02100/w/extensions/SemanticMediaWiki/includes/datavalues/SMW_DataValue.php(378): Message->text()
#4 /var/www/htdocs/mw/02100/w/extensions/SemanticMediaWiki/includes/datavalues/SMW_DataValue.php(749): SMWDataValue->addServiceLinks()
#5 /var/www/htdocs/mw/02100/w/extensions/SemanticMediaWiki/includes/datavalues/SMW_DataValue.php(690): SMWDataValue->getInfolinks()
#6 /var/www/htdocs/mw/02100/w/extensions/SemanticMediaWiki/includes/articlepages/SMW_PropertyPage.php(231): SMWDataValue->getInfolinkText(integer, DummyLinker)
#7 /var/www/htdocs/mw/02100/w/extensions/SemanticMediaWiki/includes/articlepages/SMW_PropertyPage.php(168): SMWPropertyPage->subjectObjectList(array)
#8 /var/www/htdocs/mw/02100/w/extensions/SemanticMediaWiki/includes/articlepages/SMW_PropertyPage.php(42): SMWPropertyPage->getPropertyValueList()
#9 /var/www/htdocs/mw/02100/w/extensions/SemanticMediaWiki/includes/articlepages/SMW_OrderedListPage.php(130): SMWPropertyPage->getHtml()
#10 /var/www/htdocs/mw/02100/w/extensions/SemanticMediaWiki/includes/articlepages/SMW_OrderedListPage.php(85): SMWOrderedListPage->showList()
#11 /var/www/htdocs/mw/02100/w/includes/actions/ViewAction.php(44): SMWOrderedListPage->view()
#12 /var/www/htdocs/mw/02100/w/includes/MediaWiki.php(463): ViewAction->show()
#13 /var/www/htdocs/mw/02100/w/includes/MediaWiki.php(269): MediaWiki->performAction(SMWPropertyPage, Title)
#14 /var/www/htdocs/mw/02100/w/includes/MediaWiki.php(634): MediaWiki->performRequest()
#15 /var/www/htdocs/mw/02100/w/includes/MediaWiki.php(482): MediaWiki->main()
#16 /var/www/htdocs/mw/02100/w/index.php(41): MediaWiki->run()
#17 {main}

```

[0] http://sandbox.semantic-mediawiki.org/wiki/Property:Has_coordinates