### PR TITLE
Add DeferredDependencyLinksUpdater

### DIFF
--- a/includes/storage/SQLStore/SMW_SQLStore3.php
+++ b/includes/storage/SQLStore/SMW_SQLStore3.php
@@ -372,6 +372,7 @@ class SMWSQLStore3 extends SMWStore {
 			$result = $this->fetchQueryResult( $query );
 		}
 
+		\Hooks::run( 'SMW::SQLStore::AfterQueryResultLookupComplete', array( $this, &$result ) );
 		\Hooks::run( 'SMW::Store::AfterQueryResultLookupComplete', array( $this, &$result ) );
 
 		return $result;

--- a/src/ApplicationFactory.php
+++ b/src/ApplicationFactory.php
@@ -287,6 +287,15 @@ class ApplicationFactory {
 	}
 
 	/**
+	 * @since 2.4
+	 *
+	 * @return PropertyHierarchyLookup
+	 */
+	public function newPropertyHierarchyLookup() {
+		return $this->callbackLoader->load( 'PropertyHierarchyLookup' );
+	}
+
+	/**
 	 * @since 2.1
 	 *
 	 * @return QueryParser

--- a/src/MediaWiki/Jobs/ParserCachePurgeJob.php
+++ b/src/MediaWiki/Jobs/ParserCachePurgeJob.php
@@ -3,7 +3,7 @@
 namespace SMW\MediaWiki\Jobs;
 
 use SMW\ApplicationFactory;
-use SMW\SQLStore\EmbeddedQueryDependencyLinksStore;
+use SMW\SQLStore\QueryDependencyLinksStoreFactory;
 use SMW\DIWikiPage;
 use SMW\HashBuilder;
 use Title;
@@ -98,12 +98,14 @@ class ParserCachePurgeJob extends JobBase {
 			return true;
 		}
 
-		$embeddedQueryDependencyLinksStore = new EmbeddedQueryDependencyLinksStore(
+		$queryDependencyLinksStoreFactory = new QueryDependencyLinksStoreFactory();
+
+		$queryDependencyLinksStore = $queryDependencyLinksStoreFactory->newQueryDependencyLinksStore(
 			$this->store
 		);
 
 		// +1 to look ahead
-		$hashList = $embeddedQueryDependencyLinksStore->findPartialEmbeddedQueryTargetLinksHashListFor(
+		$hashList = $queryDependencyLinksStore->findPartialEmbeddedQueryTargetLinksHashListFor(
 			$idList,
 			$this->limit + 1,
 			$this->offset

--- a/src/SPARQLStore/SPARQLStoreFactory.php
+++ b/src/SPARQLStore/SPARQLStoreFactory.php
@@ -6,7 +6,6 @@ use SMW\Store;
 use SMW\StoreFactory;
 use SMW\ConnectionManager;
 use SMW\ApplicationFactory;
-use SMW\PropertyHierarchyLookup;
 use SMW\CircularReferenceGuard;
 use SMW\SPARQLStore\QueryEngine\CompoundConditionBuilder;
 use SMW\SPARQLStore\QueryEngine\EngineOptions;
@@ -59,19 +58,6 @@ class SPARQLStoreFactory {
 
 		$engineOptions = new EngineOptions();
 
-		$propertyHierarchyLookup = new PropertyHierarchyLookup(
-			$this->store,
-			$this->applicationFactory->newCacheFactory()->newFixedInMemoryCache( 500 )
-		);
-
-		$propertyHierarchyLookup->setSubcategoryDepth(
-			$this->applicationFactory->getSettings()->get( 'smwgQSubcategoryDepth' )
-		);
-
-		$propertyHierarchyLookup->setSubpropertyDepth(
-			$this->applicationFactory->getSettings()->get( 'smwgQSubpropertyDepth' )
-		);
-
 		$circularReferenceGuard = new CircularReferenceGuard( 'sparql-query' );
 		$circularReferenceGuard->setMaxRecursionDepth( 2 );
 
@@ -84,7 +70,7 @@ class SPARQLStoreFactory {
 		);
 
 		$compoundConditionBuilder->setPropertyHierarchyLookup(
-			$propertyHierarchyLookup
+			$this->applicationFactory->newPropertyHierarchyLookup()
 		);
 
 		$queryEngine = new QueryEngine(

--- a/src/SQLStore/QueryDependency/DeferredDependencyLinksUpdater.php
+++ b/src/SQLStore/QueryDependency/DeferredDependencyLinksUpdater.php
@@ -1,0 +1,235 @@
+<?php
+
+namespace SMW\SQLStore\QueryDependency;
+
+use SMW\Store;
+use SMWQueryResult as QueryResult;
+use SMW\SQLStore\SQLStore;
+use SMW\DIWikiPage;
+use SMW\DIProperty;
+use SMW\HashBuilder;
+use SMW\SemanticData;
+use SMW\ApplicationFactory;
+use SMW\EventHandler;
+use DeferrableUpdate;
+use DeferredUpdates;
+
+/**
+ * Implements MW's DeferrableUpdate to avoid complains from the`TransactionProfiler`
+ * which started to appear with 1.26 due to our updates (insert/delete) on the
+ * QUERY_LINKS_TABLE taken place on a page view event for reparsed #ask results.
+ *
+ * @license GNU GPL v2+
+ * @since 2.4
+ *
+ * @author mwjames
+ */
+class DeferredDependencyLinksUpdater implements DeferrableUpdate {
+
+	/**
+	 * @var array
+	 */
+	private static $deferrableUpdates = array();
+
+	/**
+	 * @var Store
+	 */
+	private $store = null;
+
+	/**
+	 * @var Database
+	 */
+	private $connection = null;
+
+	/**
+	 * @var boolean
+	 */
+	private $disabledDeferredUpdate = false;
+
+	/**
+	 * @since 2.4
+	 *
+	 * @param Store $store
+	 */
+	public function __construct( Store $store ) {
+		$this->store = $store;
+		$this->connection = $this->store->getConnection( 'mw.db' );
+	}
+
+	/**
+	 * @since 2.4
+	 *
+	 * @return Store
+	 */
+	public function getStore() {
+		return $this->store;
+	}
+
+	/**
+	 * @note Only used during unit testing to disable DeferredUpdates
+	 *
+	 * @since 2.4
+	 */
+	public function disableDeferredUpdate() {
+		$this->disabledDeferredUpdate = true;
+	}
+
+	/**
+	 * @since 2.4
+	 */
+	public function clear() {
+		self::$deferrableUpdates = array();
+	}
+
+	/**
+	 * @since 2.4
+	 *
+	 * @param integer $sid
+	 * @param array $dependencyList
+	 */
+	public function addToDeferredUpdateList( $sid, array $dependencyList ) {
+
+		if ( $this->disabledDeferredUpdate ) {
+			self::$deferrableUpdates[$sid] = $dependencyList;
+		}
+
+		// An updater for the ID is unkown, register it!
+		if ( !isset( self::$deferrableUpdates[$sid] ) ) {
+			self::$deferrableUpdates[$sid] = $dependencyList;
+			wfDebugLog( 'smw', __METHOD__ . " for " . $sid  );
+			return DeferredUpdates::addUpdate( $this );
+		}
+
+		self::$deferrableUpdates[$sid] = array_merge( self::$deferrableUpdates[$sid], $dependencyList );
+	}
+
+	/**
+	 * @see DeferrableUpdate::doUpdate
+	 *
+	 * @since 2.4
+	 */
+	public function doUpdate() {
+		foreach ( self::$deferrableUpdates as $sid => $dependencyList ) {
+
+			if ( $dependencyList === array() ) {
+				continue;
+			}
+
+			wfDebugLog( 'smw', __METHOD__ . " for " . $sid  );
+
+			$this->updateDependencyList( $sid, $dependencyList );
+			self::$deferrableUpdates[$sid] = array();
+		}
+	}
+
+	/**
+	 * @since 2.4
+	 *
+	 * @param integer $sid
+	 * @param array $dependencyList
+	 */
+	public function updateDependencyList( $sid, array $dependencyList ) {
+
+		$this->connection->beginAtomicTransaction( __METHOD__ );
+
+		// Before an insert, delete all entries that for the criteria which is
+		// cheaper then doing an individual upsert or selectRow, this also ensures
+		// that entries are self-corrected for dependencies matched
+		$this->connection->delete(
+			SQLStore::QUERY_LINKS_TABLE,
+			array(
+				's_id' => $sid
+			),
+			__METHOD__
+		);
+
+		if ( $sid == 0 ) {
+			return $this->connection->endAtomicTransaction( __METHOD__ );
+		}
+
+		$inserts = array();
+
+		foreach ( $dependencyList as $dependency ) {
+
+			if ( !$dependency instanceof DIWikiPage ) {
+				continue;
+			}
+
+			$oid = $this->getIdForSubject( $dependency );
+
+			// If the ID_TABLE didn't contained an valid ID then we create one ourselves
+			// to ensure that object entities are tracked from the start
+			// This can happen when a query is added with object reference that have not
+			// yet been referenced as annotation and therefore do not recognized as
+			// value annotation
+			if ( $oid < 1 && ( ( $oid = $this->tryToMakeIdForSubject( $dependency ) ) < 1 ) ) {
+				continue;
+			}
+
+			$inserts[$sid . $oid] = array(
+				's_id' => $sid,
+				'o_id' => $oid
+			);
+		}
+
+		if ( $inserts === array() ) {
+			return $this->connection->endAtomicTransaction( __METHOD__ );
+		}
+
+		// MW's multi-array insert needs a numeric dimensional array but the key
+		// was used with a hash to avoid duplicate entries hence the re-copy
+		$inserts = array_values( $inserts );
+
+		wfDebugLog( 'smw', __METHOD__ . ' insert for SID ' . $sid . "\n" );
+
+		$this->connection->insert(
+			SQLStore::QUERY_LINKS_TABLE,
+			$inserts,
+			__METHOD__
+		);
+
+		$this->connection->endAtomicTransaction( __METHOD__ );
+	}
+
+	/**
+	 * @since 2.4
+	 *
+	 * @param DIWikiPage $subject, $subobjectName
+	 * @param string $subobjectName
+	 */
+	public function getIdForSubject( DIWikiPage $subject, $subobjectName = '' ) {
+		return $this->store->getObjectIds()->getSMWPageID(
+			$subject->getDBkey(),
+			$subject->getNamespace(),
+			$subject->getInterwiki(),
+			$subobjectName,
+			false
+		);
+	}
+
+	/**
+	 * @since 2.4
+	 *
+	 * @param DIWikiPage $subject, $subobjectName
+	 * @param string $subobjectName
+	 */
+	public function tryToMakeIdForSubject( DIWikiPage $subject, $subobjectName = '' ) {
+
+		if ( $subject->getNamespace() !== NS_CATEGORY && $subject->getNamespace() !== SMW_NS_PROPERTY ) {
+			return 0;
+		}
+
+		$id = $this->store->getObjectIds()->makeSMWPageID(
+			$subject->getDBkey(),
+			$subject->getNamespace(),
+			$subject->getInterwiki(),
+			$subobjectName,
+			false
+		);
+
+		wfDebugLog( 'smw', __METHOD__ . " add new {$id} ID for " . $subject->getHash() . " \n" );
+
+		return $id;
+	}
+
+}

--- a/src/SQLStore/QueryDependency/QueryResultDependencyListResolver.php
+++ b/src/SQLStore/QueryDependency/QueryResultDependencyListResolver.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace SMW\SQLStore;
+namespace SMW\SQLStore\QueryDependency;
 
 use SMW\Store;
 use SMWQuery as Query;
@@ -23,7 +23,7 @@ use SMW\Query\Language\ThingDescription;
  *
  * @author mwjames
  */
-class EmbeddedQueryDependencyListResolver {
+class QueryResultDependencyListResolver {
 
 	/**
 	 * @var QueryResult
@@ -99,7 +99,7 @@ class EmbeddedQueryDependencyListResolver {
 	 *
 	 * @return DIWikiPage[]|[]
 	 */
-	public function getQueryDependencySubjectList() {
+	public function getDependencyList() {
 
 		// Resolving dependencies for non-embedded queries or limit=0 (which only
 		// links to Special:Ask via further results) is not required

--- a/src/SQLStore/QueryDependencyLinksStoreFactory.php
+++ b/src/SQLStore/QueryDependencyLinksStoreFactory.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace SMW\SQLStore;
+
+use SMW\ApplicationFactory;
+use SMW\SQLStore\QueryDependency\QueryResultDependencyListResolver;
+use SMW\SQLStore\QueryDependency\QueryDependencyLinksStore;
+use SMW\SQLStore\QueryDependency\DeferredDependencyLinksUpdater;
+use SMW\Store;
+
+/**
+ * @private
+ *
+ * @license GNU GPL v2+
+ * @since 2.4
+ *
+ * @author mwjames
+ */
+class QueryDependencyLinksStoreFactory {
+
+	/**
+	 * @var $applicationFactory
+	 */
+	private $applicationFactory;
+
+	/**
+	 * @since 2.4
+	 */
+	public function __construct() {
+		$this->applicationFactory = ApplicationFactory::getInstance();
+	}
+
+	/**
+	 * @since 2.4
+	 *
+	 * @param QueryResult|string $queryResult
+	 *
+	 * @return QueryResultDependencyListResolver
+	 */
+	public function newQueryResultDependencyListResolver( $queryResult ) {
+
+		$queryResultDependencyListResolver = new QueryResultDependencyListResolver(
+			$queryResult,
+			$this->applicationFactory->newPropertyHierarchyLookup()
+		);
+
+		$queryResultDependencyListResolver->setPropertyDependencyDetectionBlacklist(
+			$this->applicationFactory->getSettings()->get( 'smwgPropertyDependencyDetectionBlacklist' )
+		);
+
+		return $queryResultDependencyListResolver;
+	}
+
+	/**
+	 * @since 2.4
+	 *
+	 * @param Store $store
+	 *
+	 * @return QueryDependencyLinksStore
+	 */
+	public function newQueryDependencyLinksStore( $store ) {
+
+		$queryDependencyLinksStore = new QueryDependencyLinksStore(
+			new DeferredDependencyLinksUpdater( $store )
+		);
+
+		$queryDependencyLinksStore->setEnabledState(
+			$this->applicationFactory->getSettings()->get( 'smwgEnabledQueryDependencyLinksStore' )
+		);
+
+		return $queryDependencyLinksStore;
+	}
+
+}
+

--- a/src/SharedCallbackContainer.php
+++ b/src/SharedCallbackContainer.php
@@ -150,6 +150,27 @@ class SharedCallbackContainer implements CallbackContainer {
 
 			return $propertySpecificationLookup;
 		} );
+
+		$callbackLoader->registerExpectedReturnType( 'PropertyHierarchyLookup', '\SMW\PropertyHierarchyLookup' );
+
+		$callbackLoader->registerCallback( 'PropertyHierarchyLookup', function() use ( $callbackLoader ) {
+
+			$propertyHierarchyLookup = new PropertyHierarchyLookup(
+				$callbackLoader->load( 'Store' ),
+				$callbackLoader->load( 'CacheFactory' )->newFixedInMemoryCache( 500 )
+			);
+
+			$propertyHierarchyLookup->setSubcategoryDepth(
+				$callbackLoader->load( 'Settings' )->get( 'smwgQSubcategoryDepth' )
+			);
+
+			$propertyHierarchyLookup->setSubpropertyDepth(
+				$callbackLoader->load( 'Settings' )->get( 'smwgQSubpropertyDepth' )
+			);
+
+			return $propertyHierarchyLookup;
+		} );
+
 	}
 
 }

--- a/tests/phpunit/Unit/ApplicationFactoryTest.php
+++ b/tests/phpunit/Unit/ApplicationFactoryTest.php
@@ -205,4 +205,12 @@ class ApplicationFactoryTest extends \PHPUnit_Framework_TestCase {
 		);
 	}
 
+	public function testCanConstructPropertyHierarchyLookup() {
+
+		$this->assertInstanceOf(
+			'\SMW\PropertyHierarchyLookup',
+			$this->applicationFactory->newPropertyHierarchyLookup()
+		);
+	}
+
 }

--- a/tests/phpunit/Unit/MediaWiki/Hooks/HookRegistryTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Hooks/HookRegistryTest.php
@@ -132,7 +132,7 @@ class HookRegistryTest extends \PHPUnit_Framework_TestCase {
 		$this->doTestExecutionForParserFirstCallInit( $instance );
 
 		// Usage of registered hooks in/by smw-core
-		$this->doTestExecutionForSMWStoreDropTables( $instance );
+		//$this->doTestExecutionForSMWStoreDropTables( $instance );
 		$this->doTestExecutionForSMWSQLStorAfterDataUpdateComplete( $instance );
 		$this->doTestExecutionForSMWStoreAfterQueryResultLookupComplete( $instance );
 	}

--- a/tests/phpunit/Unit/SQLStore/QueryDependency/DeferredDependencyLinksUpdaterTest.php
+++ b/tests/phpunit/Unit/SQLStore/QueryDependency/DeferredDependencyLinksUpdaterTest.php
@@ -1,0 +1,179 @@
+<?php
+
+namespace SMW\Tests\SQLStore\QueryDependency;
+
+use SMW\SQLStore\QueryDependency\DeferredDependencyLinksUpdater;
+use SMW\ApplicationFactory;
+use SMW\SQLStore\SQLStore;
+use SMW\DIWikiPage;
+
+/**
+ * @covers \SMW\SQLStore\QueryDependency\DeferredDependencyLinksUpdater
+ * @group semantic-mediawiki
+ *
+ * @license GNU GPL v2+
+ * @since 2.4
+ *
+ * @author mwjames
+ */
+class DeferredDependencyLinksUpdaterTest extends \PHPUnit_Framework_TestCase {
+
+	private $applicationFactory;
+
+	protected function setUp() {
+		parent::setUp();
+
+		$this->applicationFactory = ApplicationFactory::getInstance();
+
+		$store = $this->getMockBuilder( '\SMW\Store' )
+			->disableOriginalConstructor()
+			->getMockForAbstractClass();
+
+		$this->applicationFactory->registerObject( 'Store', $store );
+	}
+
+	protected function tearDown() {
+		$this->applicationFactory->clear();
+
+		parent::tearDown();
+	}
+
+	public function testCanConstruct() {
+
+		$store = $this->getMockBuilder( '\SMW\Store' )
+			->disableOriginalConstructor()
+			->getMockForAbstractClass();
+
+		$this->assertInstanceOf(
+			'\SMW\SQLStore\QueryDependency\DeferredDependencyLinksUpdater',
+			new DeferredDependencyLinksUpdater( $store )
+		);
+	}
+
+	public function testAddToDeferredUpdateList() {
+
+		$idTable = $this->getMockBuilder( '\stdClass' )
+			->setMethods( array( 'getSMWPageID' ) )
+			->getMock();
+
+		$idTable->expects( $this->any() )
+			->method( 'getSMWPageID' )
+			->will( $this->onConsecutiveCalls( 1001 ) );
+
+		$connection = $this->getMockBuilder( '\SMW\MediaWiki\Database' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$connection->expects( $this->once() )
+			->method( 'delete' )
+			->with(
+				$this->equalTo( \SMWSQLStore3::QUERY_LINKS_TABLE ),
+				$this->equalTo( array( 's_id' => 42 ) ) );
+
+		$insert[] = array(
+			's_id' => 42,
+			'o_id' => 1001
+		);
+
+		$connection->expects( $this->once() )
+			->method( 'insert' )
+			->with(
+				$this->equalTo( \SMWSQLStore3::QUERY_LINKS_TABLE ),
+				$this->equalTo( $insert ) );
+
+		$connectionManager = $this->getMockBuilder( '\SMW\ConnectionManager' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$connectionManager->expects( $this->any() )
+			->method( 'getConnection' )
+			->will( $this->returnValue( $connection ) );
+
+		$store = $this->getMockBuilder( '\SMW\SQLStore\SQLStore' )
+			->disableOriginalConstructor()
+			->setMethods( array( 'getObjectIds' ) )
+			->getMockForAbstractClass();
+
+		$store->setConnectionManager( $connectionManager );
+
+		$store->expects( $this->any() )
+			->method( 'getObjectIds' )
+			->will( $this->returnValue( $idTable ) );
+
+		$instance = new DeferredDependencyLinksUpdater(
+			$store
+		);
+
+		$instance->disableDeferredUpdate();
+		$instance->clear();
+
+		$instance->addToDeferredUpdateList( 42, array( DIWikiPage::newFromText( 'Bar' ) ) );
+		$instance->doUpdate();
+	}
+
+	public function testAddDependenciesFromQueryResultWhereObjectIdIsYetUnknownWhichRequiresToCreateTheIdOnTheFly() {
+
+		$idTable = $this->getMockBuilder( '\stdClass' )
+			->setMethods( array( 'getSMWPageID', 'makeSMWPageID' ) )
+			->getMock();
+
+		$idTable->expects( $this->any() )
+			->method( 'getSMWPageID' )
+			->will( $this->returnValue( 0 ) );
+
+		$idTable->expects( $this->any() )
+			->method( 'makeSMWPageID' )
+			->will( $this->returnValue( 1001 ) );
+
+		$connection = $this->getMockBuilder( '\SMW\MediaWiki\Database' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$connection->expects( $this->once() )
+			->method( 'delete' )
+			->with(
+				$this->equalTo( \SMWSQLStore3::QUERY_LINKS_TABLE ),
+				$this->equalTo( array( 's_id' => 42 ) ) );
+
+		$insert[] = array(
+			's_id' => 42,
+			'o_id' => 1001
+		);
+
+		$connection->expects( $this->once() )
+			->method( 'insert' )
+			->with(
+				$this->equalTo( \SMWSQLStore3::QUERY_LINKS_TABLE ),
+				$this->equalTo( $insert ) );
+
+		$connectionManager = $this->getMockBuilder( '\SMW\ConnectionManager' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$connectionManager->expects( $this->any() )
+			->method( 'getConnection' )
+			->will( $this->returnValue( $connection ) );
+
+		$store = $this->getMockBuilder( '\SMW\SQLStore\SQLStore' )
+			->disableOriginalConstructor()
+			->setMethods( array( 'getObjectIds' ) )
+			->getMockForAbstractClass();
+
+		$store->setConnectionManager( $connectionManager );
+
+		$store->expects( $this->any() )
+			->method( 'getObjectIds' )
+			->will( $this->returnValue( $idTable ) );
+
+		$instance = new DeferredDependencyLinksUpdater(
+			$store
+		);
+
+		$instance->disableDeferredUpdate();
+		$instance->clear();
+
+		$instance->addToDeferredUpdateList( 42, array( DIWikiPage::newFromText( 'Bar', SMW_NS_PROPERTY ) ) );
+		$instance->doUpdate();
+	}
+
+}

--- a/tests/phpunit/Unit/SQLStore/QueryDependency/QueryDependencyLinksStoreTest.php
+++ b/tests/phpunit/Unit/SQLStore/QueryDependency/QueryDependencyLinksStoreTest.php
@@ -1,14 +1,14 @@
 <?php
 
-namespace SMW\Tests\SQLStore;
+namespace SMW\Tests\SQLStore\QueryDependency;
 
-use SMW\SQLStore\EmbeddedQueryDependencyLinksStore;
+use SMW\SQLStore\QueryDependency\QueryDependencyLinksStore;
 use SMW\ApplicationFactory;
 use SMW\SQLStore\SQLStore;
 use SMW\DIWikiPage;
 
 /**
- * @covers \SMW\SQLStore\EmbeddedQueryDependencyLinksStore
+ * @covers \SMW\SQLStore\QueryDependency\QueryDependencyLinksStore
  * @group semantic-mediawiki
  *
  * @license GNU GPL v2+
@@ -16,20 +16,21 @@ use SMW\DIWikiPage;
  *
  * @author mwjames
  */
-class EmbeddedQueryDependencyLinksStoreTest extends \PHPUnit_Framework_TestCase {
+class QueryDependencyLinksStoreTest extends \PHPUnit_Framework_TestCase {
 
 	private $applicationFactory;
+	private $store;
 
 	protected function setUp() {
 		parent::setUp();
 
 		$this->applicationFactory = ApplicationFactory::getInstance();
 
-		$store = $this->getMockBuilder( '\SMW\Store' )
+		$this->store = $this->getMockBuilder( '\SMW\Store' )
 			->disableOriginalConstructor()
 			->getMockForAbstractClass();
 
-		$this->applicationFactory->registerObject( 'Store', $store );
+		$this->applicationFactory->registerObject( 'Store', $this->store );
 	}
 
 	protected function tearDown() {
@@ -40,13 +41,17 @@ class EmbeddedQueryDependencyLinksStoreTest extends \PHPUnit_Framework_TestCase 
 
 	public function testCanConstruct() {
 
-		$store = $this->getMockBuilder( '\SMW\Store' )
+		$deferredDependencyLinksUpdater = $this->getMockBuilder( '\SMW\SQLStore\QueryDependency\DeferredDependencyLinksUpdater' )
 			->disableOriginalConstructor()
-			->getMockForAbstractClass();
+			->getMock();
+
+		$deferredDependencyLinksUpdater->expects( $this->any() )
+			->method( 'getStore' )
+			->will( $this->returnValue( $this->store ) );
 
 		$this->assertInstanceOf(
-			'\SMW\SQLStore\EmbeddedQueryDependencyLinksStore',
-			new EmbeddedQueryDependencyLinksStore( $store )
+			'\SMW\SQLStore\QueryDependency\QueryDependencyLinksStore',
+			new QueryDependencyLinksStore( $deferredDependencyLinksUpdater )
 		);
 	}
 
@@ -68,7 +73,17 @@ class EmbeddedQueryDependencyLinksStoreTest extends \PHPUnit_Framework_TestCase 
 			->disableOriginalConstructor()
 			->getMock();
 
-		$instance = new EmbeddedQueryDependencyLinksStore( $store );
+		$deferredDependencyLinksUpdater = $this->getMockBuilder( '\SMW\SQLStore\QueryDependency\DeferredDependencyLinksUpdater' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$deferredDependencyLinksUpdater->expects( $this->any() )
+			->method( 'getStore' )
+			->will( $this->returnValue( $store ) );
+
+		$instance = new QueryDependencyLinksStore(
+			$deferredDependencyLinksUpdater
+		);
 
 		$this->assertTrue(
 			$instance->pruneOutdatedTargetLinks( $compositePropertyTableDiffIterator )
@@ -93,7 +108,18 @@ class EmbeddedQueryDependencyLinksStoreTest extends \PHPUnit_Framework_TestCase 
 			->disableOriginalConstructor()
 			->getMock();
 
-		$instance = new EmbeddedQueryDependencyLinksStore( $store );
+		$deferredDependencyLinksUpdater = $this->getMockBuilder( '\SMW\SQLStore\QueryDependency\DeferredDependencyLinksUpdater' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$deferredDependencyLinksUpdater->expects( $this->any() )
+			->method( 'getStore' )
+			->will( $this->returnValue( $store ) );
+
+		$instance = new QueryDependencyLinksStore(
+			$deferredDependencyLinksUpdater
+		);
+
 		$instance->setEnabledState( false );
 
 		$this->assertNull(
@@ -138,7 +164,17 @@ class EmbeddedQueryDependencyLinksStoreTest extends \PHPUnit_Framework_TestCase 
 			->method( 'getOrderedDiffByTable' )
 			->will( $this->returnValue( $tableDiff ) );
 
-		$instance = new EmbeddedQueryDependencyLinksStore( $store );
+		$deferredDependencyLinksUpdater = $this->getMockBuilder( '\SMW\SQLStore\QueryDependency\DeferredDependencyLinksUpdater' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$deferredDependencyLinksUpdater->expects( $this->any() )
+			->method( 'getStore' )
+			->will( $this->returnValue( $store ) );
+
+		$instance = new QueryDependencyLinksStore(
+			$deferredDependencyLinksUpdater
+		);
 
 		$this->assertEquals(
 			array( 'idlist' => array( 1 ) ),
@@ -156,7 +192,18 @@ class EmbeddedQueryDependencyLinksStoreTest extends \PHPUnit_Framework_TestCase 
 			->disableOriginalConstructor()
 			->getMock();
 
-		$instance = new EmbeddedQueryDependencyLinksStore( $store );
+		$deferredDependencyLinksUpdater = $this->getMockBuilder( '\SMW\SQLStore\QueryDependency\DeferredDependencyLinksUpdater' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$deferredDependencyLinksUpdater->expects( $this->any() )
+			->method( 'getStore' )
+			->will( $this->returnValue( $store ) );
+
+		$instance = new QueryDependencyLinksStore(
+			$deferredDependencyLinksUpdater
+		);
+
 		$instance->setEnabledState( false );
 
 		$this->assertEmpty(
@@ -207,30 +254,51 @@ class EmbeddedQueryDependencyLinksStoreTest extends \PHPUnit_Framework_TestCase 
 			->method( 'getObjectIds' )
 			->will( $this->returnValue( $idTable ) );
 
-		$instance = new EmbeddedQueryDependencyLinksStore( $store );
+		$deferredDependencyLinksUpdater = $this->getMockBuilder( '\SMW\SQLStore\QueryDependency\DeferredDependencyLinksUpdater' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$deferredDependencyLinksUpdater->expects( $this->any() )
+			->method( 'getStore' )
+			->will( $this->returnValue( $store ) );
+
+		$instance = new QueryDependencyLinksStore(
+			$deferredDependencyLinksUpdater
+		);
 
 		$instance->findPartialEmbeddedQueryTargetLinksHashListFor( array( 42 ), 1, 200 );
 	}
 
-	public function testTryToaddDependencyListWhileBeingDisabled() {
+	public function testTryDoUpdateDependenciesByWhileBeingDisabled() {
 
 		$store = $this->getMockBuilder( '\SMW\Store' )
 			->disableOriginalConstructor()
 			->getMockForAbstractClass();
 
-		$instance = new EmbeddedQueryDependencyLinksStore( $store );
+		$deferredDependencyLinksUpdater = $this->getMockBuilder( '\SMW\SQLStore\QueryDependency\DeferredDependencyLinksUpdater' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$deferredDependencyLinksUpdater->expects( $this->any() )
+			->method( 'getStore' )
+			->will( $this->returnValue( $store ) );
+
+		$instance = new QueryDependencyLinksStore(
+			$deferredDependencyLinksUpdater
+		);
+
 		$instance->setEnabledState( false );
 
-		$embeddedQueryDependencyListResolver = $this->getMockBuilder( '\SMW\SQLStore\EmbeddedQueryDependencyListResolver' )
+		$queryResultDependencyListResolver = $this->getMockBuilder( '\SMW\SQLStore\QueryDependency\QueryResultDependencyListResolver' )
 			->disableOriginalConstructor()
 			->getMock();
 
 		$this->assertNull(
-			$instance->addDependencyList( $embeddedQueryDependencyListResolver )
+			$instance->doUpdateDependenciesBy( $queryResultDependencyListResolver )
 		);
 	}
 
-	public function testTryToAddDependenciesForWhenDependencyListReturnsEmpty() {
+	public function testTryDoUpdateDependenciesByForWhenDependencyListReturnsEmpty() {
 
 		$idTable = $this->getMockBuilder( '\stdClass' )
 			->setMethods( array( 'getSMWPageID' ) )
@@ -249,27 +317,38 @@ class EmbeddedQueryDependencyLinksStoreTest extends \PHPUnit_Framework_TestCase 
 			->method( 'getObjectIds' )
 			->will( $this->returnValue( $idTable ) );
 
-		$instance = new EmbeddedQueryDependencyLinksStore( $store );
-		$instance->setEnabledState( true );
-
-		$embeddedQueryDependencyListResolver = $this->getMockBuilder( '\SMW\SQLStore\EmbeddedQueryDependencyListResolver' )
+		$deferredDependencyLinksUpdater = $this->getMockBuilder( '\SMW\SQLStore\QueryDependency\DeferredDependencyLinksUpdater' )
 			->disableOriginalConstructor()
 			->getMock();
 
-		$embeddedQueryDependencyListResolver->expects( $this->once() )
-			->method( 'getQueryDependencySubjectList' )
+		$deferredDependencyLinksUpdater->expects( $this->any() )
+			->method( 'getStore' )
+			->will( $this->returnValue( $store ) );
+
+		$instance = new QueryDependencyLinksStore(
+			$deferredDependencyLinksUpdater
+		);
+
+		$instance->setEnabledState( true );
+
+		$queryResultDependencyListResolver = $this->getMockBuilder( '\SMW\SQLStore\QueryDependency\QueryResultDependencyListResolver' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$queryResultDependencyListResolver->expects( $this->once() )
+			->method( 'getDependencyList' )
 			->will( $this->returnValue( array() ) );
 
-		$embeddedQueryDependencyListResolver->expects( $this->any() )
+		$queryResultDependencyListResolver->expects( $this->any() )
 			->method( 'getSubject' )
 			->will( $this->returnValue( DIWikiPage::newFromText( __METHOD__ ) ) );
 
 		$this->assertNull(
-			$instance->addDependencyList( $embeddedQueryDependencyListResolver )
+			$instance->doUpdateDependenciesBy( $queryResultDependencyListResolver )
 		);
 	}
 
-	public function testAddDependenciesFromQueryResult() {
+	public function testdoUpdateDependenciesByFromQueryResult() {
 
 		$idTable = $this->getMockBuilder( '\stdClass' )
 			->setMethods( array( 'getSMWPageID' ) )
@@ -283,37 +362,10 @@ class EmbeddedQueryDependencyLinksStoreTest extends \PHPUnit_Framework_TestCase 
 			->disableOriginalConstructor()
 			->getMock();
 
-		$connection->expects( $this->once() )
-			->method( 'delete' )
-			->with(
-				$this->equalTo( \SMWSQLStore3::QUERY_LINKS_TABLE ),
-				$this->equalTo( array( 's_id' => 42 ) ) );
-
-		$insert[] = array(
-			's_id' => 42,
-			'o_id' => 1001
-		);
-
-		$connection->expects( $this->once() )
-			->method( 'insert' )
-			->with(
-				$this->equalTo( \SMWSQLStore3::QUERY_LINKS_TABLE ),
-				$this->equalTo( $insert ) );
-
-		$connectionManager = $this->getMockBuilder( '\SMW\ConnectionManager' )
-			->disableOriginalConstructor()
-			->getMock();
-
-		$connectionManager->expects( $this->any() )
-			->method( 'getConnection' )
-			->will( $this->returnValue( $connection ) );
-
 		$store = $this->getMockBuilder( '\SMW\SQLStore\SQLStore' )
 			->disableOriginalConstructor()
 			->setMethods( array( 'getObjectIds', 'getPropertyValues' ) )
 			->getMockForAbstractClass();
-
-		$store->setConnectionManager( $connectionManager );
 
 		$store->expects( $this->any() )
 			->method( 'getObjectIds' )
@@ -323,23 +375,40 @@ class EmbeddedQueryDependencyLinksStoreTest extends \PHPUnit_Framework_TestCase 
 			->method( 'getPropertyValues' )
 			->will( $this->returnValue( array() ) );
 
-		$embeddedQueryDependencyListResolver = $this->getMockBuilder( '\SMW\SQLStore\EmbeddedQueryDependencyListResolver' )
+		$queryResultDependencyListResolver = $this->getMockBuilder( '\SMW\SQLStore\QueryDependency\QueryResultDependencyListResolver' )
 			->disableOriginalConstructor()
 			->getMock();
 
-		$embeddedQueryDependencyListResolver->expects( $this->any() )
+		$queryResultDependencyListResolver->expects( $this->any() )
 			->method( 'getSubject' )
 			->will( $this->returnValue( DIWikiPage::newFromText( __METHOD__ )  ) );
 
-		$embeddedQueryDependencyListResolver->expects( $this->any() )
-			->method( 'getQueryDependencySubjectList' )
+		$queryResultDependencyListResolver->expects( $this->any() )
+			->method( 'getDependencyList' )
 			->will( $this->returnValue( array( null, DIWikiPage::newFromText( 'Foo' ) ) ) );
 
-		$instance = new EmbeddedQueryDependencyLinksStore( $store );
-		$instance->addDependencyList( $embeddedQueryDependencyListResolver );
+		$deferredDependencyLinksUpdater = $this->getMockBuilder( '\SMW\SQLStore\QueryDependency\DeferredDependencyLinksUpdater' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$deferredDependencyLinksUpdater->expects( $this->once() )
+			->method( 'addToDeferredUpdateList' )
+			->with(
+				$this->equalTo( 42 ),
+				$this->anything() );
+
+		$deferredDependencyLinksUpdater->expects( $this->any() )
+			->method( 'getStore' )
+			->will( $this->returnValue( $store ) );
+
+		$instance = new QueryDependencyLinksStore(
+			$deferredDependencyLinksUpdater
+		);
+
+		$instance->doUpdateDependenciesBy( $queryResultDependencyListResolver );
 	}
 
-	public function testAddDependenciesFromQueryResultWhereObjectIdIsYetUnknownWhichRequiresToCreateTheIdOnTheFly() {
+	public function testdoUpdateDependenciesByFromQueryResultWhereObjectIdIsYetUnknownWhichRequiresToCreateTheIdOnTheFly() {
 
 		$idTable = $this->getMockBuilder( '\stdClass' )
 			->setMethods( array( 'getSMWPageID', 'makeSMWPageID' ) )
@@ -353,41 +422,10 @@ class EmbeddedQueryDependencyLinksStoreTest extends \PHPUnit_Framework_TestCase 
 			->method( 'makeSMWPageID' )
 			->will( $this->returnValue( 1001 ) );
 
-		$connection = $this->getMockBuilder( '\SMW\MediaWiki\Database' )
-			->disableOriginalConstructor()
-			->getMock();
-
-		$connection->expects( $this->once() )
-			->method( 'delete' )
-			->with(
-				$this->equalTo( \SMWSQLStore3::QUERY_LINKS_TABLE ),
-				$this->equalTo( array( 's_id' => 42 ) ) );
-
-		$insert[] = array(
-			's_id' => 42,
-			'o_id' => 1001
-		);
-
-		$connection->expects( $this->once() )
-			->method( 'insert' )
-			->with(
-				$this->equalTo( \SMWSQLStore3::QUERY_LINKS_TABLE ),
-				$this->equalTo( $insert ) );
-
-		$connectionManager = $this->getMockBuilder( '\SMW\ConnectionManager' )
-			->disableOriginalConstructor()
-			->getMock();
-
-		$connectionManager->expects( $this->any() )
-			->method( 'getConnection' )
-			->will( $this->returnValue( $connection ) );
-
 		$store = $this->getMockBuilder( '\SMW\SQLStore\SQLStore' )
 			->disableOriginalConstructor()
 			->setMethods( array( 'getObjectIds', 'getPropertyValues' ) )
 			->getMockForAbstractClass();
-
-		$store->setConnectionManager( $connectionManager );
 
 		$store->expects( $this->any() )
 			->method( 'getObjectIds' )
@@ -397,23 +435,40 @@ class EmbeddedQueryDependencyLinksStoreTest extends \PHPUnit_Framework_TestCase 
 			->method( 'getPropertyValues' )
 			->will( $this->returnValue( array() ) );
 
-		$embeddedQueryDependencyListResolver = $this->getMockBuilder( '\SMW\SQLStore\EmbeddedQueryDependencyListResolver' )
+		$queryResultDependencyListResolver = $this->getMockBuilder( '\SMW\SQLStore\QueryDependency\QueryResultDependencyListResolver' )
 			->disableOriginalConstructor()
 			->getMock();
 
-		$embeddedQueryDependencyListResolver->expects( $this->any() )
+		$queryResultDependencyListResolver->expects( $this->any() )
 			->method( 'getSubject' )
 			->will( $this->returnValue( DIWikiPage::newFromText( __METHOD__ )  ) );
 
-		$embeddedQueryDependencyListResolver->expects( $this->any() )
-			->method( 'getQueryDependencySubjectList' )
+		$queryResultDependencyListResolver->expects( $this->any() )
+			->method( 'getDependencyList' )
 			->will( $this->returnValue( array( DIWikiPage::newFromText( 'Foo', NS_CATEGORY ) ) ) );
 
-		$instance = new EmbeddedQueryDependencyLinksStore( $store );
-		$instance->addDependencyList( $embeddedQueryDependencyListResolver );
+		$deferredDependencyLinksUpdater = $this->getMockBuilder( '\SMW\SQLStore\QueryDependency\DeferredDependencyLinksUpdater' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$deferredDependencyLinksUpdater->expects( $this->once() )
+			->method( 'addToDeferredUpdateList' )
+			->with(
+				$this->equalTo( 42 ),
+				$this->anything() );
+
+		$deferredDependencyLinksUpdater->expects( $this->any() )
+			->method( 'getStore' )
+			->will( $this->returnValue( $store ) );
+
+		$instance = new QueryDependencyLinksStore(
+			$deferredDependencyLinksUpdater
+		);
+
+		$instance->doUpdateDependenciesBy( $queryResultDependencyListResolver );
 	}
 
-	public function testTryToAddDependenciesWithinSkewedTime() {
+	public function testTryDoUpdateDependenciesByWithinSkewedTime() {
 
 		$title = $this->getMockBuilder( '\Title' )
 			->disableOriginalConstructor()
@@ -462,16 +517,27 @@ class EmbeddedQueryDependencyLinksStoreTest extends \PHPUnit_Framework_TestCase 
 			->method( 'getObjectIds' )
 			->will( $this->returnValue( $idTable ) );
 
-		$embeddedQueryDependencyListResolver = $this->getMockBuilder( '\SMW\SQLStore\EmbeddedQueryDependencyListResolver' )
+		$queryResultDependencyListResolver = $this->getMockBuilder( '\SMW\SQLStore\QueryDependency\QueryResultDependencyListResolver' )
 			->disableOriginalConstructor()
 			->getMock();
 
-		$embeddedQueryDependencyListResolver->expects( $this->any() )
+		$queryResultDependencyListResolver->expects( $this->any() )
 			->method( 'getSubject' )
 			->will( $this->returnValue( $subject ) );
 
-		$instance = new EmbeddedQueryDependencyLinksStore( $store );
-		$instance->addDependencyList( $embeddedQueryDependencyListResolver );
+		$deferredDependencyLinksUpdater = $this->getMockBuilder( '\SMW\SQLStore\QueryDependency\DeferredDependencyLinksUpdater' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$deferredDependencyLinksUpdater->expects( $this->any() )
+			->method( 'getStore' )
+			->will( $this->returnValue( $store ) );
+
+		$instance = new QueryDependencyLinksStore(
+			$deferredDependencyLinksUpdater
+		);
+
+		$instance->doUpdateDependenciesBy( $queryResultDependencyListResolver );
 	}
 
 }

--- a/tests/phpunit/Unit/SQLStore/QueryDependency/QueryResultDependencyListResolverTest.php
+++ b/tests/phpunit/Unit/SQLStore/QueryDependency/QueryResultDependencyListResolverTest.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace SMW\Tests\SQLStore;
+namespace SMW\Tests\SQLStore\QueryDependency;
 
-use SMW\SQLStore\EmbeddedQueryDependencyListResolver;
+use SMW\SQLStore\QueryDependency\QueryResultDependencyListResolver;
 use SMW\Query\Language\SomeProperty;
 use SMW\Query\Language\ValueDescription;
 use SMW\Query\Language\ClassDescription;
@@ -18,7 +18,7 @@ use SMWQuery as Query;
 use SMWDIBlob as DIBlob;
 
 /**
- * @covers \SMW\SQLStore\EmbeddedQueryDependencyListResolver
+ * @covers \SMW\SQLStore\QueryDependency\QueryResultDependencyListResolver
  * @group semantic-mediawiki
  *
  * @license GNU GPL v2+
@@ -26,7 +26,7 @@ use SMWDIBlob as DIBlob;
  *
  * @author mwjames
  */
-class EmbeddedQueryDependencyListResolverTest extends \PHPUnit_Framework_TestCase {
+class QueryResultDependencyListResolverTest extends \PHPUnit_Framework_TestCase {
 
 	private $applicationFactory;
 	private $store;
@@ -56,18 +56,18 @@ class EmbeddedQueryDependencyListResolverTest extends \PHPUnit_Framework_TestCas
 			->getMock();
 
 		$this->assertInstanceOf(
-			'\SMW\SQLStore\EmbeddedQueryDependencyListResolver',
-			new EmbeddedQueryDependencyListResolver( null, $propertyHierarchyLookup )
+			'\SMW\SQLStore\QueryDependency\QueryResultDependencyListResolver',
+			new QueryResultDependencyListResolver( null, $propertyHierarchyLookup )
 		);
 	}
 
-	public function testTryToGetQueryDependencySubjectListForNonSetQueryResult() {
+	public function testTryToGetDependencyListForNonSetQueryResult() {
 
 		$propertyHierarchyLookup = $this->getMockBuilder( '\SMW\PropertyHierarchyLookup' )
 			->disableOriginalConstructor()
 			->getMock();
 
-		$instance = new EmbeddedQueryDependencyListResolver(
+		$instance = new QueryResultDependencyListResolver(
 			null,
 			$propertyHierarchyLookup
 		);
@@ -81,11 +81,11 @@ class EmbeddedQueryDependencyListResolverTest extends \PHPUnit_Framework_TestCas
 		);
 
 		$this->assertEmpty(
-			$instance->getQueryDependencySubjectList()
+			$instance->getDependencyList()
 		);
 	}
 
-	public function testTryToGetQueryDependencySubjectListForLimitZeroQuery() {
+	public function testTryToGetDependencyListForLimitZeroQuery() {
 
 		$subject = DIWikiPage::newFromText( 'Foo' );
 
@@ -114,13 +114,13 @@ class EmbeddedQueryDependencyListResolverTest extends \PHPUnit_Framework_TestCas
 			->disableOriginalConstructor()
 			->getMock();
 
-		$instance = new EmbeddedQueryDependencyListResolver(
+		$instance = new QueryResultDependencyListResolver(
 			$queryResult,
 			$propertyHierarchyLookup
 		);
 
 		$this->assertEmpty(
-			$instance->getQueryDependencySubjectList()
+			$instance->getDependencyList()
 		);
 	}
 
@@ -171,7 +171,7 @@ class EmbeddedQueryDependencyListResolverTest extends \PHPUnit_Framework_TestCas
 			->with( $this->equalTo( new DIProperty( 'Subprop' ) ) )
 			->will( $this->returnValue( array() ) );
 
-		$instance = new EmbeddedQueryDependencyListResolver(
+		$instance = new QueryResultDependencyListResolver(
 			$queryResult,
 			$propertyHierarchyLookup
 		);
@@ -187,14 +187,14 @@ class EmbeddedQueryDependencyListResolverTest extends \PHPUnit_Framework_TestCas
 
 		$this->assertEquals(
 			$expected,
-			$instance->getQueryDependencySubjectList()
+			$instance->getDependencyList()
 		);
 	}
 
 	/**
 	 * @dataProvider queryProvider
 	 */
-	public function testGetQueryDependencySubjectList( $query, $expected ) {
+	public function testgetDependencyList( $query, $expected ) {
 
 		$queryResult = $this->getMockBuilder( '\SMWQueryResult' )
 			->disableOriginalConstructor()
@@ -216,14 +216,14 @@ class EmbeddedQueryDependencyListResolverTest extends \PHPUnit_Framework_TestCas
 			->disableOriginalConstructor()
 			->getMock();
 
-		$instance = new EmbeddedQueryDependencyListResolver(
+		$instance = new QueryResultDependencyListResolver(
 			$queryResult,
 			$propertyHierarchyLookup
 		);
 
 		$this->assertEquals(
 			$expected,
-			$instance->getQueryDependencySubjectList()
+			$instance->getDependencyList()
 		);
 	}
 
@@ -274,7 +274,7 @@ class EmbeddedQueryDependencyListResolverTest extends \PHPUnit_Framework_TestCas
 			->with( $this->equalTo( new DIProperty( 'Subprop' ) ) )
 			->will( $this->returnValue( array() ) );
 
-		$instance = new EmbeddedQueryDependencyListResolver(
+		$instance = new QueryResultDependencyListResolver(
 			$queryResult,
 			$propertyHierarchyLookup
 		);
@@ -288,7 +288,7 @@ class EmbeddedQueryDependencyListResolverTest extends \PHPUnit_Framework_TestCas
 
 		$this->assertEquals(
 			$expected,
-			$instance->getQueryDependencySubjectList()
+			$instance->getDependencyList()
 		);
 	}
 
@@ -338,7 +338,7 @@ class EmbeddedQueryDependencyListResolverTest extends \PHPUnit_Framework_TestCas
 			->with( $this->equalTo( DIWikiPage::newFromText( 'Subcat', NS_CATEGORY ) ) )
 			->will( $this->returnValue( array() ) );
 
-		$instance = new EmbeddedQueryDependencyListResolver(
+		$instance = new QueryResultDependencyListResolver(
 			$queryResult,
 			$propertyHierarchyLookup
 		);
@@ -351,7 +351,7 @@ class EmbeddedQueryDependencyListResolverTest extends \PHPUnit_Framework_TestCas
 
 		$this->assertEquals(
 			$expected,
-			$instance->getQueryDependencySubjectList()
+			$instance->getDependencyList()
 		);
 	}
 

--- a/tests/phpunit/Unit/SQLStore/QueryDependencyLinksStoreFactoryTest.php
+++ b/tests/phpunit/Unit/SQLStore/QueryDependencyLinksStoreFactoryTest.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace SMW\Tests\SQLStore;
+
+use SMW\SQLStore\QueryDependencyLinksStoreFactory;
+
+/**
+ * @covers \SMW\SQLStore\QueryDependencyLinksStoreFactory
+ * @group semantic-mediawiki
+ *
+ * @license GNU GPL v2+
+ * @since 2.4
+ *
+ * @author mwjames
+ */
+class QueryDependencyLinksStoreFactoryTest extends \PHPUnit_Framework_TestCase {
+
+	public function testCanConstruct() {
+
+		$this->assertInstanceOf(
+			'\SMW\SQLStore\QueryDependencyLinksStoreFactory',
+			new QueryDependencyLinksStoreFactory()
+		);
+	}
+
+	public function canConstructQueryResultDependencyListResolver() {
+
+		$instance = new QueryDependencyLinksStoreFactory();
+
+		$this->assertInstanceOf(
+			'\SMW\SQLStore\QueryDependency\QueryResultDependencyListResolver',
+			$instance->newQueryResultDependencyListResolver( '' )
+		);
+	}
+
+	public function canConstructQueryDependencyLinksStore() {
+
+		$store = $this->getMockBuilder( '\SMW\Store' )
+			->disableOriginalConstructor()
+			->getMockForAbstractClass();
+
+		$instance = new QueryDependencyLinksStoreFactory();
+
+		$this->assertInstanceOf(
+			'\SMW\SQLStore\QueryDependency\QueryDependencyLinksStore',
+			$instance->newQueryDependencyLinksStore( $store )
+		);
+	}
+
+}


### PR DESCRIPTION
Add an `QUERY_LINKS_TABLE` updater with a `DeferrableUpdate` signature to avoid complains from the `TransactionProfiler` which starts to flood messages in 1.26+ on updates that appear during a page view action.