### PR TITLE
Add some responsive css

### DIFF
--- a/res/smw/ext.smw.css
+++ b/res/smw/ext.smw.css
@@ -461,6 +461,15 @@ label.smw-form-checkbox {
 	font-weight: 500;
 }
 
+/* Handling Long Words and URLs (Forcing Breaks, Hyphenation, Ellipsis */
+.smwb-value, .smwprops, .smwpropname, .smwtype_wpg, .smwtype_uri {
+	word-break: break-word;
+	word-wrap: break-word;
+	-webkit-hyphens: auto;
+	-moz-hyphens: auto;
+	hyphens: auto;
+}
+
 /* Distinguish subobjects from other titles */
 
 .smw-subobject-entity {


### PR DESCRIPTION
https://css-tricks.com/snippets/css/prevent-long-urls-from-breaking-out-of-container/

In combination with a mobile friendly skin such as `Chameleon` (Vector should work to a certain degree as well), wpg/uri values adapt and are displayed within the border of the display.

i-Pad

![image](https://cloud.githubusercontent.com/assets/1245473/13388969/d1513018-dec4-11e5-9517-1fd7f20403cb.png)

![image](https://cloud.githubusercontent.com/assets/1245473/13388982/eb3eedd0-dec4-11e5-9323-526f1b13bf66.png)

Galaxy-S4

![image](https://cloud.githubusercontent.com/assets/1245473/13389001/0d204714-dec5-11e5-8165-76adee1644f9.png)

![image](https://cloud.githubusercontent.com/assets/1245473/13389015/23c3d53a-dec5-11e5-93fc-d99a8d6720bd.png)

![image](https://cloud.githubusercontent.com/assets/1245473/13389037/42e30256-dec5-11e5-8ead-33830eb1154d.png)

MobileFrontend (i-Phone 6)

![image](https://cloud.githubusercontent.com/assets/1245473/13389252/b3239750-dec6-11e5-8435-01ca9c945831.png)

