### PR TITLE
rebuildData to output more verbose info, add `--ignore-exceptions`, r…

### DIFF
--- a/includes/formatters/MessageFormatter.php
+++ b/includes/formatters/MessageFormatter.php
@@ -206,17 +206,18 @@ class MessageFormatter {
 		foreach ( $messages as $msg ) {
 
 			if ( $msg instanceof \Message ) {
-				$newArray[] = $msg->inLanguage( $this->language )->text();
+				$text = $msg->inLanguage( $this->language )->text();
+				$newArray[md5( $text )] = $text;
 			} elseif ( (array)$msg === $msg ) {
 				foreach ( $this->doFormat( $msg ) as $m ) {
-					$newArray[] = $m;
+					$newArray[md5( $m )] = $m;
 				}
 			} elseif ( (string)$msg === $msg ) {
-				$newArray[] = $msg;
+				$newArray[md5( $msg )] = $msg;
 			}
 		}
 
-		return array_unique( $newArray );
+		return $newArray;
 	}
 
 	/**
@@ -232,9 +233,9 @@ class MessageFormatter {
 	protected function getString( $html = true ) {
 
 		if ( $this->escape ) {
-			$messages = array_map( 'htmlspecialchars', $this->doFormat( $this->messages ) );
+			$messages = array_map( 'htmlspecialchars', array_values( $this->doFormat( $this->messages ) ) );
 		} else {
-			$messages = $this->doFormat( $this->messages );
+			$messages = array_values( $this->doFormat( $this->messages ) );
 		}
 
 		if ( count( $messages ) == 1 ) {

--- a/maintenance/rebuildData.php
+++ b/maintenance/rebuildData.php
@@ -81,11 +81,15 @@ class RebuildData extends \Maintenance {
 								'May leave the wiki temporarily incomplete.', false );
 
 		$this->addOption( 'v', 'Be verbose about the progress', false );
-		$this->addOption( 'c', 'Will refresh only category pages (and other explicitly named namespaces)', false );
+		$this->addOption( 'categories', 'Will refresh only category pages (and other explicitly named namespaces)', false, false, 'c' );
 		$this->addOption( 'p', 'Will refresh only property pages (and other explicitly named namespaces)', false );
+		$this->addOption( 'redirects', 'Only refresh redirect pages', false );
 
 		$this->addOption( 'skip-properties', 'Skip the default properties rebuild (only recommended when successive build steps are used)', false );
 		$this->addOption( 'shallow-update', 'Skip processing of entitites that compare to the last known revision date', false );
+
+		$this->addOption( 'ignore-exceptions', 'Ignore exceptions and log exception to a file', false );
+		$this->addOption( 'exception-log', 'Exception log file location (e.g. /tmp/logs/)', false, true );
 
 		$this->addOption( 'page', '<pagelist> Will refresh only the pages of the given names, with | used as a separator. ' .
 								'Example: --page "Page 1|Page 2" refreshes Page 1 and Page 2 Options -s, -e, -n, ' .

--- a/src/Maintenance/DistinctEntityDataRebuilder.php
+++ b/src/Maintenance/DistinctEntityDataRebuilder.php
@@ -1,0 +1,297 @@
+<?php
+
+namespace SMW\Maintenance;
+
+use SMW\DIWikiPage;
+use SMW\MediaWiki\Jobs\UpdateJob;
+use SMW\MediaWiki\TitleCreator;
+use SMW\MediaWiki\TitleLookup;
+use Onoi\MessageReporter\MessageReporter;
+use Onoi\MessageReporter\MessageReporterFactory;
+use SMW\Store;
+use SMW\Options;
+use SMWQueryProcessor;
+use Title;
+
+/**
+ * @license GNU GPL v2+
+ * @since 2.4
+ *
+ * @author mwjames
+ */
+class DistinctEntityDataRebuilder {
+
+	/**
+	 * @var Store
+	 */
+	private $store;
+
+	/**
+	 * @var TitleCreator
+	 */
+	private $titleCreator;
+
+	/**
+	 * @var Options
+	 */
+	private $options;
+
+	/**
+	 * @var MessageReporter
+	 */
+	private $reporter;
+
+	/**
+	 * @var array
+	 */
+	private $pages = array();
+
+	/**
+	 * @var array
+	 */
+	private $exceptionLog = array();
+
+	/**
+	 * @var integer
+	 */
+	private $rebuildCount = 0;
+
+	/**
+	 * @since 2.4
+	 *
+	 * @param Store $store
+	 * @param TitleCreator $titleCreator
+	 */
+	public function __construct( Store $store, TitleCreator $titleCreator ) {
+		$this->store = $store;
+		$this->titleCreator = $titleCreator;
+		$this->reporter = MessageReporterFactory::getInstance()->newNullMessageReporter();
+	}
+
+	/**
+	 * @since 2.1
+	 *
+	 * @param MessageReporter $reporter
+	 */
+	public function setOptions( Options $options ) {
+		$this->options = $options;
+	}
+
+	/**
+	 * @since 2.1
+	 *
+	 * @param MessageReporter $reporter
+	 */
+	public function setMessageReporter( MessageReporter $reporter ) {
+		$this->reporter = $reporter;
+	}
+
+	/**
+	 * @since 2.4
+	 *
+	 * @return int
+	 */
+	public function getRebuildCount() {
+		return $this->rebuildCount;
+	}
+
+	/**
+	 * @since 2.4
+	 *
+	 * @return array
+	 */
+	public function getExceptionLog() {
+		return $this->exceptionLog;
+	}
+
+	/**
+	 * @since 2.4
+	 *
+	 * @return boolean
+	 */
+	public function doRebuild() {
+
+		$this->reportMessage(
+			"Refreshing selected pages"  .
+			( $this->options->has( 'redirects' ) ? ' (redirects)' : '' ) .
+			( $this->options->has( 'categories' ) ? ' (categories)' : '' ) .
+			( $this->options->has( 'query' ) ? ' (queries)' : '' ) .
+			( $this->options->has( 'p' ) ? ' (properties)' : '' ) .
+			".\n"
+		);
+
+		$pages = array();
+		$this->setNamespaceFiltersFromOptions();
+
+		if ( $this->options->has( 'page' ) ) {
+			$pages = explode( '|', $this->options->get( 'page' ) );
+		}
+
+		$pages = array_merge( $this->getPagesFromQuery(), $pages, $this->getPagesFromFilters(), $this->getRedirectPages() );
+
+		$this->normalizeBulkOfPages( $pages );
+		$numPages = count( $pages );
+
+		foreach ( $pages as $page ) {
+
+			$this->rebuildCount++;
+			$percentage = round( ( $this->rebuildCount / $numPages ) * 100 ) ."%";
+
+			$this->reportMessage(
+				sprintf( "%-16s%s\n", "($this->rebuildCount/$numPages $percentage)", "Page " . $page->getPrefixedDBkey() ),
+				$this->options->has( 'v' )
+			);
+
+			$this->doExecuteUpdateJobFor(
+				$page
+			);
+
+			$this->doPrintDotProgressIndicator(
+				$this->options->has( 'v' ),
+				$percentage
+			);
+		}
+
+		$this->reportMessage( "\n\n$this->rebuildCount pages refreshed.\n" );
+
+		return true;
+	}
+
+	private function doExecuteUpdateJobFor( $page ) {
+
+		$updatejob = new UpdateJob( $page, array(
+			'pm' => $this->options->has( 'shallow-update' ) ? SMW_UJ_PM_CLASTMDATE : false
+		) );
+
+		if ( !$this->options->has( 'ignore-exceptions' ) ) {
+			return $updatejob->run();
+		}
+
+		try {
+			$updatejob->run();
+		} catch ( \Exception $e ) {
+			$this->exceptionLog[$page->getPrefixedDBkey()] = array(
+				'msg'   => $e->getMessage(),
+				'trace' => $e->getTraceAsString()
+			);
+		}
+	}
+
+	private function setNamespaceFiltersFromOptions() {
+		$this->filters = array();
+
+		if ( $this->options->has( 'categories' ) ) {
+			$this->filters[] = NS_CATEGORY;
+		}
+
+		if ( $this->options->has( 'p' ) ) {
+			$this->filters[] = SMW_NS_PROPERTY;
+		}
+	}
+
+	private function hasFilters() {
+		return $this->filters !== array();
+	}
+
+	private function getPagesFromQuery() {
+
+		if ( !$this->options->has( 'query' ) ) {
+			return array();
+		}
+
+		$queryString = $this->options->get( 'query' );
+
+		// get number of pages and fix query limit
+		$query = SMWQueryProcessor::createQuery(
+			$queryString,
+			SMWQueryProcessor::getProcessedParams( array( 'format' => 'count' ) )
+		);
+
+		$result = $this->store->getQueryResult( $query );
+
+		// get pages and add them to the pages explicitly listed in the 'page' parameter
+		$query = SMWQueryProcessor::createQuery(
+			$queryString,
+			SMWQueryProcessor::getProcessedParams( array() )
+		);
+
+		$query->setUnboundLimit( $result instanceof \SMWQueryResult ? $result->getCountValue() : $result );
+
+		return $this->store->getQueryResult( $query )->getResults();
+	}
+
+	private function getPagesFromFilters() {
+
+		$pages = array();
+
+		if ( !$this->hasFilters() ) {
+			return $pages;
+		}
+
+		$titleLookup = new TitleLookup( $this->store->getConnection( 'mw.db' ) );
+
+		foreach ( $this->filters as $namespace ) {
+			$pages = array_merge( $pages, $titleLookup->setNamespace( $namespace )->selectAll() );
+		}
+
+		return $pages;
+	}
+
+	private function getRedirectPages() {
+
+		if ( !$this->options->has( 'redirects' ) ) {
+			return array();
+		}
+
+		$titleLookup = new TitleLookup(
+			$this->store->getConnection( 'mw.db' )
+		);
+
+		return $titleLookup->selectAllRedirectPages();
+	}
+
+	private function normalizeBulkOfPages( &$pages ) {
+
+		$titleCache = array();
+
+		foreach ( $pages as $key => &$page ) {
+
+			if ( $page instanceof DIWikiPage ) {
+				$page = $page->getTitle();
+			}
+
+			if ( !$page instanceof Title ) {
+				$page = $this->titleCreator->createFromText( $page );
+			}
+
+			// Filter out pages with fragments (subobjects)
+			if ( isset( $titleCache[$page->getPrefixedDBkey()] ) ) {
+				unset( $pages[$key] );
+			} else{
+				$titleCache[$page->getPrefixedDBkey()] = true;
+			}
+		}
+
+		unset( $titleCache );
+	}
+
+	private function reportMessage( $message, $output = true ) {
+		if ( $output ) {
+			$this->reporter->reportMessage( $message );
+		}
+	}
+
+	private function doPrintDotProgressIndicator( $verbose, $progress ) {
+
+		if ( ( $this->rebuildCount - 1 ) % 60 === 0 ) {
+			$this->reportMessage( "\n", !$verbose );
+		}
+
+		$this->reportMessage( '.', !$verbose );
+
+		if ( $this->rebuildCount % 60 === 0 ) {
+			$this->reportMessage( " $progress", !$verbose );
+		}
+	}
+
+}

--- a/src/Maintenance/ExceptionFileLogger.php
+++ b/src/Maintenance/ExceptionFileLogger.php
@@ -1,0 +1,109 @@
+<?php
+
+namespace SMW\Maintenance;
+
+use RuntimeException;
+use SMW\Options;
+
+/**
+ * @private
+ *
+ * @license GNU GPL v2+
+ * @since 2.4
+ *
+ * @author mwjames
+ */
+class ExceptionFileLogger {
+
+	/**
+	 * @var string
+	 */
+	private $namespace;
+
+	/**
+	 * @var string
+	 */
+	private $exceptionFile;
+
+	/**
+	 * @var integer
+	 */
+	private $exceptionCounter = 0;
+
+	/**
+	 * @since 2.4
+	 *
+	 * @param string $namespace
+	 */
+	public function __construct( $namespace = 'smw' ) {
+		$this->namespace = $namespace;
+	}
+
+	/**
+	 * @since 2.4
+	 *
+	 * @param Options $options
+	 */
+	public function setOptions( Options $options ) {
+
+		$dateTimeUtc = new \DateTime( 'now', new \DateTimeZone( 'UTC' ) );
+
+		$this->exceptionFile = $options->has( 'exception-log' ) ? $options->get( 'exception-log' ) : __DIR__ . "../../../" ;
+
+		if ( !is_writable( $this->exceptionFile ) ) {
+			die( "`$this->exceptionFile` is not writable.\n" );
+		}
+
+		$this->exceptionFile .= $this->namespace . "-exceptions-" . $dateTimeUtc->format( 'Y-m-d' ) . ".log";
+	}
+
+	/**
+	 * @since 2.4
+	 *
+	 * @return string
+	 */
+	public function getExceptionFile() {
+		return realpath( $this->exceptionFile );
+	}
+
+	/**
+	 * @since 2.4
+	 *
+	 * @return integer
+	 */
+	public function getExceptionCounter() {
+		return $this->exceptionCounter;
+	}
+
+	/**
+	 * @since 2.4
+	 *
+	 * @param array $exceptionLogMessages
+	 */
+	public function doWriteExceptionLog( array $exceptionLogMessages ) {
+		foreach ( $exceptionLogMessages as $id => $exception ) {
+
+			if ( !is_array( $exception ) ) {
+				continue;
+			}
+
+			$this->exceptionCounter++;
+			$this->writeLogFile( $id, $exception );
+		}
+	}
+
+	private function writeLogFile( $id, $exception ) {
+
+		$text = "\n======== EXCEPTION ======\n" .
+			"$id | " . $exception['msg'] . "\n\n" .
+			$exception['trace'] . "\n" .
+			"======== END ======" ."\n";
+
+		file_put_contents(
+			$this->exceptionFile,
+			$text,
+			FILE_APPEND
+		);
+	}
+
+}

--- a/src/MediaWiki/TitleLookup.php
+++ b/src/MediaWiki/TitleLookup.php
@@ -86,6 +86,30 @@ class TitleLookup {
 	}
 
 	/**
+	 * @since 2.4
+	 *
+	 * @return Title[]
+	 */
+	public function selectAllRedirectPages() {
+
+		$tableName = 'redirect';
+		$fields = array( 'rd_namespace', 'rd_title' );
+		//$conditions = array( 'page_namespace' => $this->namespace );
+		$conditions = array();
+		$options = array( 'USE INDEX' => 'PRIMARY' );
+
+		$res = $this->connection->select(
+			$tableName,
+			$fields,
+			$conditions,
+			__METHOD__,
+			$options
+		);
+
+		return $this->makeTitlesFromSelection( $res );
+	}
+
+	/**
 	 * @since 1.9.2
 	 *
 	 * @param int $startId
@@ -166,6 +190,9 @@ class TitleLookup {
 		if ( $this->namespace === NS_CATEGORY ) {
 			$ns = NS_CATEGORY;
 			$title = $row->cat_title;
+		} elseif ( isset( $row->rd_namespace ) ) {
+			$ns =  $row->rd_namespace;
+			$title = $row->rd_title;
 		} else {
 			$ns =  $row->page_namespace;
 			$title = $row->page_title;

--- a/tests/phpunit/Unit/Maintenance/DistinctEntityDataRebuilderTest.php
+++ b/tests/phpunit/Unit/Maintenance/DistinctEntityDataRebuilderTest.php
@@ -2,21 +2,21 @@
 
 namespace SMW\Tests\Maintenance;
 
-use SMW\Maintenance\DataRebuilder;
+use SMW\Maintenance\DistinctEntityDataRebuilder;
 use SMW\Options;
 use Title;
 
 /**
- * @covers \SMW\Maintenance\DataRebuilder
+ * @covers \SMW\Maintenance\DistinctEntityDataRebuilder
  * @group semantic-mediawiki
  * @group medium
  *
  * @license GNU GPL v2+
- * @since 1.9.2
+ * @since 2.4
  *
  * @author mwjames
  */
-class DataRebuilderTest extends \PHPUnit_Framework_TestCase {
+class DistinctEntityDataRebuilderTest extends \PHPUnit_Framework_TestCase {
 
 	protected $obLevel;
 	private $connectionManager;
@@ -67,154 +67,9 @@ class DataRebuilderTest extends \PHPUnit_Framework_TestCase {
 			->getMock();
 
 		$this->assertInstanceOf(
-			'\SMW\Maintenance\DataRebuilder',
-			new DataRebuilder( $store, $titleCreator )
+			'\SMW\Maintenance\DistinctEntityDataRebuilder',
+			new DistinctEntityDataRebuilder( $store, $titleCreator )
 		);
-	}
-
-	/**
-	 * @depends testCanConstruct
-	 */
-	public function testRebuildAllWithoutOptions() {
-
-		$byIdDataRebuildDispatcher = $this->getMockBuilder( '\SMW\SQLStore\ByIdDataRebuildDispatcher' )
-			->disableOriginalConstructor()
-			->getMock();
-
-		$byIdDataRebuildDispatcher->expects( $this->once() )
-			->method( 'dispatchRebuildFor' )
-			->will( $this->returnCallback( array( $this, 'refreshDataOnMockCallback' ) ) );
-
-		$byIdDataRebuildDispatcher->expects( $this->any() )
-			->method( 'getMaxId' )
-			->will( $this->returnValue( 1000 ) );
-
-		$byIdDataRebuildDispatcher->expects( $this->any() )
-			->method( 'getDispatchedEntities' )
-			->will( $this->returnValue( array() ) );
-
-		$store = $this->getMockBuilder( '\SMW\Store' )
-			->disableOriginalConstructor()
-			->setMethods( array( 'refreshData' ) )
-			->getMockForAbstractClass();
-
-		$store->expects( $this->once() )
-			->method( 'refreshData' )
-			->will( $this->returnValue( $byIdDataRebuildDispatcher ) );
-
-		$store->setConnectionManager( $this->connectionManager );
-
-		$titleCreator = $this->getMockBuilder( '\SMW\MediaWiki\TitleCreator' )
-			->disableOriginalConstructor()
-			->getMock();
-
-		$instance = new DataRebuilder( $store, $titleCreator );
-
-		// Needs an end otherwise phpunit is caught up in an infinite loop
-		$instance->setOptions( new Options( array(
-			'e' => 1
-		) ) );
-
-		$this->assertTrue( $instance->rebuild() );
-	}
-
-	/**
-	 * @depends testCanConstruct
-	 */
-	public function testRebuildAllWithFullDelete() {
-
-		$byIdDataRebuildDispatcher = $this->getMockBuilder( '\SMW\SQLStore\ByIdDataRebuildDispatcher' )
-			->disableOriginalConstructor()
-			->getMock();
-
-		$byIdDataRebuildDispatcher->expects( $this->atLeastOnce() )
-			->method( 'dispatchRebuildFor' )
-			->will( $this->returnCallback( array( $this, 'refreshDataOnMockCallback' ) ) );
-
-		$byIdDataRebuildDispatcher->expects( $this->any() )
-			->method( 'getMaxId' )
-			->will( $this->returnValue( 1000 ) );
-
-		$byIdDataRebuildDispatcher->expects( $this->any() )
-			->method( 'getDispatchedEntities' )
-			->will( $this->returnValue( array() ) );
-
-		$store = $this->getMockBuilder( '\SMW\Store' )
-			->disableOriginalConstructor()
-			->setMethods( array(
-				'refreshData',
-				'drop' ) )
-			->getMockForAbstractClass();
-
-		$store->expects( $this->once() )
-			->method( 'refreshData' )
-			->will( $this->returnValue( $byIdDataRebuildDispatcher ) );
-
-		$store->expects( $this->once() )
-			->method( 'drop' );
-
-		$store->setConnectionManager( $this->connectionManager );
-
-		$titleCreator = $this->getMockBuilder( '\SMW\MediaWiki\TitleCreator' )
-			->disableOriginalConstructor()
-			->getMock();
-
-		$instance = new DataRebuilder( $store, $titleCreator );
-
-		$instance->setOptions( new Options( array(
-			'e' => 1,
-			'f' => true,
-			'verbose' => false
-		) ) );
-
-		$this->assertTrue( $instance->rebuild() );
-	}
-
-	/**
-	 * @depends testCanConstruct
-	 */
-	public function testRebuildAllWithStopRangeOption() {
-
-		$byIdDataRebuildDispatcher = $this->getMockBuilder( '\SMW\SQLStore\ByIdDataRebuildDispatcher' )
-			->disableOriginalConstructor()
-			->getMock();
-
-		$byIdDataRebuildDispatcher->expects( $this->exactly( 6 ) )
-			->method( 'dispatchRebuildFor' )
-			->will( $this->returnCallback( array( $this, 'refreshDataOnMockCallback' ) ) );
-
-		$byIdDataRebuildDispatcher->expects( $this->any() )
-			->method( 'getMaxId' )
-			->will( $this->returnValue( 1000 ) );
-
-		$byIdDataRebuildDispatcher->expects( $this->any() )
-			->method( 'getDispatchedEntities' )
-			->will( $this->returnValue( array() ) );
-
-		$store = $this->getMockBuilder( '\SMW\Store' )
-			->disableOriginalConstructor()
-			->setMethods( array( 'refreshData' ) )
-			->getMockForAbstractClass();
-
-		$store->expects( $this->once() )
-			->method( 'refreshData' )
-			->will( $this->returnValue( $byIdDataRebuildDispatcher ) );
-
-		$store->setConnectionManager( $this->connectionManager );
-
-		$titleCreator = $this->getMockBuilder( '\SMW\MediaWiki\TitleCreator' )
-			->disableOriginalConstructor()
-			->getMock();
-
-		$instance = new DataRebuilder( $store, $titleCreator );
-
-		$instance->setOptions( new Options( array(
-			's' => 2,
-			'n' => 5,
-			'verbose' => false
-		) ) );
-
-		$this->assertTrue( $instance->rebuild() );
 	}
 
 	/**
@@ -256,13 +111,18 @@ class DataRebuilderTest extends \PHPUnit_Framework_TestCase {
 			->disableOriginalConstructor()
 			->getMock();
 
-		$instance = new DataRebuilder( $store, $titleCreator );
+		$instance = new DistinctEntityDataRebuilder(
+			$store,
+			$titleCreator
+		);
 
 		$instance->setOptions( new Options( array(
 			'query' => '[[Category:Foo]]'
 		) ) );
 
-		$this->assertTrue( $instance->rebuild() );
+		$this->assertTrue(
+			$instance->doRebuild()
+		);
 	}
 
 	public function testRebuildSelectedPagesWithCategoryNamespaceFilter() {
@@ -295,13 +155,18 @@ class DataRebuilderTest extends \PHPUnit_Framework_TestCase {
 			->disableOriginalConstructor()
 			->getMock();
 
-		$instance = new DataRebuilder( $store, $titleCreator );
+		$instance = new DistinctEntityDataRebuilder(
+			$store,
+			$titleCreator
+		);
 
 		$instance->setOptions( new Options( array(
 			'categories' => true
 		) ) );
 
-		$this->assertTrue( $instance->rebuild() );
+		$this->assertTrue(
+			$instance->doRebuild()
+		);
 	}
 
 	public function testRebuildSelectedPagesWithPropertyNamespaceFilter() {
@@ -335,13 +200,18 @@ class DataRebuilderTest extends \PHPUnit_Framework_TestCase {
 			->disableOriginalConstructor()
 			->getMock();
 
-		$instance = new DataRebuilder( $store, $titleCreator );
+		$instance = new DistinctEntityDataRebuilder(
+			$store,
+			$titleCreator
+		);
 
 		$instance->setOptions( new Options( array(
 			'p' => true
 		) ) );
 
-		$this->assertTrue( $instance->rebuild() );
+		$this->assertTrue(
+			$instance->doRebuild()
+		);
 	}
 
 	public function testRebuildSelectedPagesWithPageOption() {
@@ -374,13 +244,18 @@ class DataRebuilderTest extends \PHPUnit_Framework_TestCase {
 			->with( $this->equalTo( 'Main page' ) )
 			->will( $this->returnValue( Title::newFromText( 'Main page' ) ) );
 
-		$instance = new DataRebuilder( $store, $titleCreator );
+		$instance = new DistinctEntityDataRebuilder(
+			$store,
+			$titleCreator
+		);
 
 		$instance->setOptions( new Options( array(
 			'page'  => 'Main page|Some other page|Help:Main page|Main page'
 		) ) );
 
-		$this->assertTrue( $instance->rebuild() );
+		$this->assertTrue(
+			$instance->doRebuild()
+		);
 
 		$this->assertEquals(
 			3,

--- a/tests/phpunit/Unit/Maintenance/ExceptionFileLoggerTest.php
+++ b/tests/phpunit/Unit/Maintenance/ExceptionFileLoggerTest.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace SMW\Tests\Maintenance\Jobs;
+
+use SMW\Maintenance\ExceptionFileLogger;
+use SMW\Options;
+
+/**
+ * @covers \SMW\Maintenance\ExceptionFileLogger
+ * @group semantic-mediawiki
+ *
+ * @license GNU GPL v2+
+ * @since 2.4
+ *
+ * @author mwjames
+ */
+class ExceptionFileLoggerTest extends \PHPUnit_Framework_TestCase {
+
+	public function testCanConstruct() {
+
+		$this->assertInstanceOf(
+			'\SMW\Maintenance\ExceptionFileLogger',
+			new ExceptionFileLogger()
+		);
+	}
+
+	public function testGetter() {
+
+		$instance = new ExceptionFileLogger();
+		$instance->setOptions( new Options() );
+
+		$this->assertInternalType(
+			'boolean',
+			$instance->getExceptionFile()
+		);
+
+		$this->assertInternalType(
+			'integer',
+			$instance->getExceptionCounter()
+		);
+	}
+
+	public function testDoWriteExceptionLog() {
+
+		$instance = new ExceptionFileLogger();
+		$instance->setOptions( new Options() );
+
+		$instance->doWriteExceptionLog(
+			array( 'Foo' )
+		);
+
+		$this->assertEquals(
+			0,
+			$instance->getExceptionCounter()
+		);
+	}
+
+}

--- a/tests/phpunit/Unit/MediaWiki/TitleLookupTest.php
+++ b/tests/phpunit/Unit/MediaWiki/TitleLookupTest.php
@@ -153,6 +153,29 @@ class TitleLookupTest extends \PHPUnit_Framework_TestCase {
 		);
 	}
 
+	public function testSelectAllRedirectPages() {
+
+		$database = $this->getMockBuilder( '\SMW\MediaWiki\Database' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$database->expects( $this->any() )
+			->method( 'select' )
+			->with(
+				$this->equalTo( 'redirect' ),
+				$this->anything(),
+				$this->anything(),
+				$this->anything(),
+				$this->anything() )
+			->will( $this->returnValue( false ) );
+
+		$instance = new TitleLookup( $database );
+
+		$this->assertArrayOfTitles(
+			$instance->selectAllRedirectPages()
+		);
+	}
+
 	public function testMaxIdForMainNamespace() {
 
 		$database = $this->getMockBuilder( '\SMW\MediaWiki\Database' )


### PR DESCRIPTION
…efs #1327

Output more verbose information about what entity is being rebuild.

- Add `--ignore-exceptions` and `--redirects` option
- Option `--categories` is `-c`

![image](https://cloud.githubusercontent.com/assets/1245473/13539501/19a9cebc-e251-11e5-9881-bd2d3d91898c.png)

ID's marked with * are in reference to the MW `page` table where the same ID does not necessarily represent the same entity (see 30).

![image](https://cloud.githubusercontent.com/assets/1245473/13539589/a04f5c52-e251-11e5-8fed-40f23faaae91.png)
