### PR TITLE
Add tests/phpunit/ as the PSR-4 root for SMW\Tests\

### DIFF
--- a/tests/autoloader.php
+++ b/tests/autoloader.php
@@ -56,6 +56,7 @@ $autoloader->addClassMap( array(
 	'SMW\Tests\MwDBaseUnitTestCase'         => __DIR__ . '/phpunit/MwDBaseUnitTestCase.php',
 	'SMW\Tests\ByJsonTestCaseProvider'      => __DIR__ . '/phpunit/ByJsonTestCaseProvider.php',
 	'SMW\Tests\JsonTestCaseFileHandler'     => __DIR__ . '/phpunit/JsonTestCaseFileHandler.php',
+	'SMW\Tests\TestEnvironment'             => __DIR__ . '/phpunit/TestEnvironment.php',
 	'SMW\Test\QueryPrinterTestCase'         => __DIR__ . '/phpunit/QueryPrinterTestCase.php',
 	'SMW\Test\QueryPrinterRegistryTestCase' => __DIR__ . '/phpunit/QueryPrinterRegistryTestCase.php',
 ) );


### PR DESCRIPTION
To enable classes outside the tests/phpunit/ directory accessing classes inside that directory it has to be added as the PSR-4 root for SMW\Tests\.