### PR TITLE
Set "userlang" in ParserOutput, refs #1440

### DIFF
--- a/includes/parserhooks/AskParserFunction.php
+++ b/includes/parserhooks/AskParserFunction.php
@@ -121,6 +121,12 @@ class AskParserFunction {
 
 		$this->parserData->pushSemanticDataToParserOutput();
 
+		// Allow to reparse in case the user language changed
+		// 1.23+
+		if ( method_exists( $this->parserData->getOutput(), 'recordOption' ) ) {
+			$this->parserData->getOutput()->recordOption( 'userlang' );
+		}
+
 		return $result;
 	}
 


### PR DESCRIPTION
This will recognize a switch of the user language and allows queries to be re-parsed and adjust display.

refs #1440