### PR TITLE
Allow to block recursive annotation during an internal parse, refs 1076

### DIFF
--- a/includes/ParserData.php
+++ b/includes/ParserData.php
@@ -98,6 +98,24 @@ class ParserData {
 	}
 
 	/**
+	 * @since 2.4
+	 *
+	 * @return boolean
+	 */
+	public function canModifySemanticData() {
+
+		// getExtensionData returns null if no value was set for this key
+		if (
+			$this->hasExtensionData() &&
+			$this->parserOutput->getExtensionData( 'smw-blockannotation' ) !== null &&
+			$this->parserOutput->getExtensionData( 'smw-blockannotation' ) ) {
+			return false;
+		}
+
+		return true;
+	}
+
+	/**
 	 * @since 2.1
 	 *
 	 * @return boolean

--- a/includes/parserhooks/SetParserFunction.php
+++ b/includes/parserhooks/SetParserFunction.php
@@ -82,9 +82,9 @@ class SetParserFunction {
 						$subject
 					);
 
-				$this->parserData->addDataValue(
-					$dataValue
-				);
+				if ( $this->parserData->canModifySemanticData() ) {
+					$this->parserData->addDataValue( $dataValue );
+				}
 
 				$this->messageFormatter->addFromArray( $dataValue->getErrors() );
 

--- a/includes/parserhooks/SubobjectParserFunction.php
+++ b/includes/parserhooks/SubobjectParserFunction.php
@@ -90,7 +90,10 @@ class SubobjectParserFunction {
 	 */
 	public function parse( ParserParameterProcessor $parameters ) {
 
-		if ( $this->addDataValuesToSubobject( $parameters ) && !$this->subobject->getSemanticData()->isEmpty() ) {
+		if (
+			$this->parserData->canModifySemanticData() &&
+			$this->addDataValuesToSubobject( $parameters ) &&
+			!$this->subobject->getSemanticData()->isEmpty()  ) {
 			$this->parserData->getSemanticData()->addSubobject( $this->subobject );
 		}
 
@@ -108,8 +111,8 @@ class SubobjectParserFunction {
 		$subject = $this->parserData->getSemanticData()->getSubject();
 
 		// Named subobjects containing a "." in the first five characters are reserved to be
-		// used by extensions only in order to separate them from user land and avoid them
-		// accidentally to refer to the same named ID
+		// used by extensions only in order to separate them from user land and avoid having
+		// them accidentally to refer to the same named ID
 		// (i.e. different access restrictions etc.)
 		if ( strpos( mb_substr( $parameters->getFirst(), 0, 5 ), '.' ) !== false ) {
 			return $this->addErrorWithMsg(

--- a/includes/queryprinters/ResultPrinter.php
+++ b/includes/queryprinters/ResultPrinter.php
@@ -271,9 +271,19 @@ abstract class ResultPrinter extends \ContextSource implements QueryResultPrinte
 		/**
 		 * @var \Parser $wgParser
 		 */
-		global $wgParser, $smwgEnabledResultFormatsWithRecursiveAnnotationSupport;
+		global $wgParser;
 
 		$result .= $this->getErrorString( $results ); // append errors
+
+		// MW 1.21+
+		// Block recursive import of annotations unless otherwise specified for
+		// a specific use case
+		if ( method_exists( $wgParser->getOutput(), 'setExtensionData' ) ) {
+			$wgParser->getOutput()->setExtensionData(
+				'smw-blockannotation',
+				$this->params['format'] === 'embedded'
+			);
+		}
 
 		// Apply intro parameter
 		if ( ( $this->mIntro ) && ( $results->getCount() > 0 ) ) {

--- a/src/InTextAnnotationParser.php
+++ b/src/InTextAnnotationParser.php
@@ -404,7 +404,10 @@ class InTextAnnotationParser {
 				$subject
 			);
 
-			if ( $this->isEnabledNamespace && $this->isAnnotation ) {
+			if (
+				$this->isEnabledNamespace &&
+				$this->isAnnotation &&
+				$this->parserData->canModifySemanticData() ) {
 				$this->parserData->addDataValue( $dataValue );
 			}
 		}

--- a/tests/phpunit/Integration/ByJsonScript/Fixtures/f-0801.json
+++ b/tests/phpunit/Integration/ByJsonScript/Fixtures/f-0801.json
@@ -1,5 +1,5 @@
 {
-	"description": "Test format=embedded output (skip 1.19)",
+	"description": "Test `format=embedded` output (skip 1.19)",
 	"properties": [
 		{
 			"name": "HasSomePageProperty",
@@ -8,38 +8,87 @@
 	],
 	"subjects": [
 		{
-			"name": "Format/Embedded/1",
-			"contents": "[[HasSomePageProperty::ABC]] {{#subobject:HasSomePageProperty=123}} [[Category:Embedded format]]"
+			"name": "Format/Embedded/A/1",
+			"contents": "[[HasSomePageProperty::ABC]] {{#subobject:HasSomePageProperty=123}} [[Category:Embedded format/A]]"
 		},
 		{
-			"name": "Format/Embedded/2",
-			"contents": "[[HasSomePageProperty::DEF]] {{#subobject:HasSomePageProperty=456}} [[Category:Embedded format]]"
+			"name": "Format/Embedded/A/2",
+			"contents": "[[HasSomePageProperty::DEF]] {{#subobject:HasSomePageProperty=456}} [[Category:Embedded format/A]]"
 		},
 		{
-			"name": "Format/Embedded",
-			"contents": "{{#ask:[[Category:Embedded format]] |format=embedded |link=none |headers=show |embedformat=h1 }}"
+			"name": "Format/Embedded/B/1",
+			"contents": "[[HasSomePageProperty::ABC]] {{#subobject:HasSomePageProperty=123}} [[Category:Embedded format/B]]"
+		},
+		{
+			"name": "Format/Embedded/B/2",
+			"contents": "[[HasSomePageProperty::DEF]] {{#subobject:HasSomePageProperty=456}} [[Category:Embedded format/B]]"
+		},
+		{
+			"name": "Format/Embedded/A",
+			"contents": "{{#ask:[[Category:Embedded format/A]] |format=embedded |link=none |headers=show |embedformat=h1 }}"
+		},
+		{
+			"name": "Format/Embedded/B",
+			"contents": "{{#ask:[[Category:Embedded format]] |format=count/B}} {{#ask:[[Category:Embedded format/B]] |format=embedded |link=none |headers=show |embedformat=h1 }}"
+		},
+		{
+			"name": "Format/Embedded/C",
+			"contents": "{{:Format/Embedded/A/1}}"
 		}
 	],
 	"parser-testcases": [
 		{
 			"about": "#0",
-			"subject": "Format/Embedded",
+			"subject": "Format/Embedded/A",
 			"store": {
 				"semantic-data": {
 					"strict-mode-valuematch": false,
 					"propertyCount": 4,
 					"propertyKeys": [ "_INST", "_MDAT", "_SKEY", "_ASK" ],
-					"propertyValues": [ "Embedded format" ]
+					"propertyValues": [ "Embedded format/A" ]
 				}
 			},
 			"expected-output": {
 				"to-contain": [
-					"<h1><span class=\"mw-headline\" id=\"Format.2FEmbedded\"><strong class=\"selflink\">Format/Embedded</strong></span></h1>",
-					"<h1><span class=\"mw-headline\" id=\"Format.2FEmbedded.2F1\">",
-					"<h1><span class=\"mw-headline\" id=\"Format.2FEmbedded.2F2\">",
+					"<h1><span class=\"mw-headline\" id=\"Format.2FEmbedded.2FA\"><strong class=\"selflink\">Format/Embedded/A</strong></span></h1>",
+					"<h1><span class=\"mw-headline\" id=\"Format.2FEmbedded.2FA.2F1\">",
+					"<h1><span class=\"mw-headline\" id=\"Format.2FEmbedded.2FA.2F2\">",
 					"ABC",
 					"DEF"
 				]
+			}
+		},
+		{
+			"about": "#1",
+			"subject": "Format/Embedded/B",
+			"store": {
+				"semantic-data": {
+					"strict-mode-valuematch": false,
+					"propertyCount": 4,
+					"propertyKeys": [ "_INST", "_MDAT", "_SKEY", "_ASK" ],
+					"propertyValues": [ "Embedded format/B" ]
+				}
+			},
+			"expected-output": {
+				"to-contain": [
+					"<h1><span class=\"mw-headline\" id=\"Format.2FEmbedded.2FB\"><strong class=\"selflink\">Format/Embedded/B</strong></span></h1>",
+					"<h1><span class=\"mw-headline\" id=\"Format.2FEmbedded.2FB.2F1\">",
+					"<h1><span class=\"mw-headline\" id=\"Format.2FEmbedded.2FB.2F2\">",
+					"ABC",
+					"DEF"
+				]
+			}
+		},
+		{
+			"about": "#2 (manual embedded)",
+			"subject": "Format/Embedded/C",
+			"store": {
+				"semantic-data": {
+					"strict-mode-valuematch": false,
+					"propertyCount": 5,
+					"propertyKeys": [ "_INST", "_MDAT", "_SKEY", "_SOBJ", "HasSomePageProperty" ],
+					"propertyValues": [ "Embedded format/A", "ABC" ]
+				}
 			}
 		}
 	],

--- a/tests/phpunit/includes/ParserDataTest.php
+++ b/tests/phpunit/includes/ParserDataTest.php
@@ -364,4 +364,37 @@ class ParserDataTest extends \PHPUnit_Framework_TestCase {
 		$instance->addLimitReport( 'Foo', 'Bar' );
 	}
 
+	public function testCanModifySemanticData() {
+
+		$title = $this->getMockBuilder( 'Title' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$title->expects( $this->once() )
+			->method( 'getNamespace' )
+			->will( $this->returnValue( -1 ) );
+
+		$parserOutput = new ParserOutput();
+
+		// FIXME 1.21+
+		if ( !method_exists( $parserOutput, 'getExtensionData' ) ) {
+			$this->markTestSkipped( 'getExtensionData is not available.' );
+		}
+
+		$instance = new ParserData(
+			$title,
+			$parserOutput
+		);
+
+		$this->assertTrue(
+			$instance->canModifySemanticData()
+		);
+
+		$parserOutput->setExtensionData( 'smw-blockannotation', true );
+
+		$this->assertFalse(
+			$instance->canModifySemanticData()
+		);
+	}
+
 }


### PR DESCRIPTION
refs #1076

Use case: The `embedded` format no longer adds `#set`/`#subobject` annotations that are imported via an embedded page using `#ask`.

Categories remain special [0] as there are parsed and handled by MW.

[0] https://www.semantic-mediawiki.org/wiki/Help:Embedded_format#Limitations