### PR TITLE
composer.json: Require PHP extension mbstring

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -38,6 +38,7 @@
 	},
 	"require": {
 		"php": ">=5.3.0",
+		"ext-mbstring": "*",
 		"composer/installers": "1.*,>=1.0.1",
 		"mediawiki/parser-hooks": "~1.4",
 		"serialization/serialization": "~3.2",


### PR DESCRIPTION
RPM based systems (RedHat and friends) do not have mbstring installed together with PHP out of the box [1].
This change will make SMW depend on the mbstring extension and fail installing if the extension is not available [2].

[1] https://phabricator.wikimedia.org/T129435
[2] https://getcomposer.org/doc/02-libraries.md#platform-packages