### PR TITLE
Allow to track uniqueness of values, refs #178

### DIFF
--- a/SemanticMediaWiki.settings.php
+++ b/SemanticMediaWiki.settings.php
@@ -515,7 +515,7 @@ $GLOBALS['smwgPageSpecialProperties'] = array( '_MDAT' );
 # setting is not normally changed by users but by extensions that add new
 # types that have their own additional declaration properties.
 ##
-$GLOBALS['smwgDeclarationProperties'] = array( '_PVAL', '_LIST', '_PVAP' );
+$GLOBALS['smwgDeclarationProperties'] = array( '_PVAL', '_LIST', '_PVAP', '_PVUC' );
 ##
 
 // some default settings which usually need no modification
@@ -954,6 +954,11 @@ $GLOBALS['smwgEnabledInTextAnnotationParserStrictMode'] = true;
 # resolved as "Foo" when creating annotations. Currently, this uses an
 # uncached lookup and therefore is disabled by default to avoid a possible
 # performance impact (which has not been established or analyzed).
+#
+# - SMW_DV_PVUC (Uniqueness constraint) to specify that a property can only
+# assign a value that is unique in its literal representation (the state of
+# uniqueness for a value is established by the fact that it is assigned before
+# any other value of the same representation to a property).
 #
 # @since 2.4
 ##

--- a/composer.json
+++ b/composer.json
@@ -45,7 +45,7 @@
 		"onoi/message-reporter": "~1.0",
 		"onoi/cache": "~1.2",
 		"onoi/event-dispatcher": "~1.0",
-		"onoi/blob-store": "~1.1",
+		"onoi/blob-store": "~1.2",
 		"onoi/http-request": "~1.1",
 		"onoi/callback-container": "~1.0"
 	},

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -384,5 +384,8 @@
 	"smw-datavalue-allows-pattern-reference-unknown": "The \"$1\" pattern reference could not be match to an entry in [[MediaWiki:Smw allows pattern]].",
 	"smw-datavalue-feature-not-supported": "The \"$1\" feature is not supported or was disabled on this wiki.",
 	"smw-pa-property-predefined_pvap": "\"$1\" is a predefined property that can specify a [[MediaWiki:Smw allows pattern|pattern reference]] to apply [https://en.wikipedia.org/wiki/Regular_expression regular expression] matching and is provided by [https://www.semantic-mediawiki.org/wiki/Help:Special_properties Semantic MediaWiki].",
-	"smw-pa-property-predefined_dtitle": "\"$1\" is a predefined property that can assign a distinct display title to an entity and is provided by [https://www.semantic-mediawiki.org/wiki/Help:Special_properties Semantic MediaWiki]."
+	"smw-pa-property-predefined_dtitle": "\"$1\" is a predefined property that can assign a distinct display title to an entity and is provided by [https://www.semantic-mediawiki.org/wiki/Help:Special_properties Semantic MediaWiki].",
+	"smw-pa-property-predefined_pvuc": "\"$1\" is a predefined property indicating that value assignments to a property are expected to be unique and is provided by [https://www.semantic-mediawiki.org/wiki/Help:Special_properties Semantic MediaWiki].",
+	"smw-pa-property-predefined-long_pvuc": "Uniqueness is established when two values are not equal in its literal representation and any violation of this constraint will be categorized as error.",
+	"smw-datavalue-uniqueness-constraint-error": "Property \"$1\" only permits unique value assignments and ''$2'' was already annotated in subject \"$3\"."
 }

--- a/includes/Defines.php
+++ b/includes/Defines.php
@@ -144,4 +144,5 @@ define( 'SMW_DV_MLTV_LCODE', 4 );  // MonolingualTextValue requires language cod
 define( 'SMW_DV_PVAP', 16 );  // Allows pattern
 define( 'SMW_DV_WPV_DTITLE', 32 );  // WikiPageValue to use an explicit display title
 define( 'SMW_DV_PROV_DTITLE', 64 );  // PropertyValue allow to find a property using the display title
+define( 'SMW_DV_PVUC', 128 );  // Delcares a uniqueness constraint
 /**@}*/

--- a/includes/dataitems/SMW_DI_Container.php
+++ b/includes/dataitems/SMW_DI_Container.php
@@ -190,7 +190,33 @@ class SMWDIContainer extends SMWDataItem {
 	 * @return string
 	 */
 	public function getHash() {
-		return $this->m_semanticData->getHash();
+
+		$hash = $this->getValueHash( $this->m_semanticData );
+		sort( $hash );
+
+		return md5( implode( '#', $hash ) );
+
+		// We want a value hash, not an entity hash!!
+		// return $this->m_semanticData->getHash();
+	}
+
+	private function getValueHash( $semanticData ) {
+
+		$hash = array();
+
+		foreach ( $semanticData->getProperties() as $property ) {
+			$hash[] = $property->getKey();
+
+			foreach ( $semanticData->getPropertyValues( $property ) as $di ) {
+				$hash[] = $di->getHash();
+			}
+		}
+
+		foreach ( $semanticData->getSubSemanticData() as $data ) {
+			$hash[] = $this->getValueHash( $data );
+		}
+
+		return $hash;
 	}
 
 	/**

--- a/includes/datavalues/SMW_DataValue.php
+++ b/includes/datavalues/SMW_DataValue.php
@@ -318,6 +318,17 @@ abstract class SMWDataValue {
 	}
 
 	/**
+	 * @since 2.4
+	 *
+	 * @param integer $feature
+	 *
+	 * @return boolean
+	 */
+	public function isEnabledFeature( $feature ) {
+		return ( $this->getOptionValueFor( 'smwgDVFeatures' ) & $feature ) != 0;
+	}
+
+	/**
 	 * Change the caption (the text used for displaying this datavalue). The given
 	 * value must be a string.
 	 *

--- a/includes/formatters/MessageFormatter.php
+++ b/includes/formatters/MessageFormatter.php
@@ -101,7 +101,15 @@ class MessageFormatter {
 	 * @return MessageFormatter
 	 */
 	public function addFromArray( array $messages ) {
-		$this->messages = array_merge ( $messages, $this->messages );
+
+		foreach ( $messages as $message ) {
+			if ( is_string( $message ) ) {
+				$this->messages[md5( $message )] = $message;
+			} else{
+				$this->messages[] = $message;
+			}
+		}
+
 		return $this;
 	}
 

--- a/languages/SMW_Language.php
+++ b/languages/SMW_Language.php
@@ -115,7 +115,9 @@ abstract class SMWLanguage {
 		'Display precision' => '_PREC',
 		'Property description'     => '_PDESC',
 		'Has allows pattern' => '_PVAP',
-		'Has display title of'     => '_DTITLE'
+		'Has display title of'     => '_DTITLE',
+		'Has uniqueness constraint'     => '_PVUC',
+		'Uniqueness constraint'     => '_PVUC',
 	);
 
 	public function __construct() {

--- a/languages/SMW_LanguageAr.php
+++ b/languages/SMW_LanguageAr.php
@@ -83,7 +83,8 @@ class SMWLanguageAr extends SMWLanguage {
 		'_TEXT'  => 'Text',
 		'_PDESC' => 'Has property description',
 		'_PVAP'  => 'Allows pattern',
-		'_DTITLE' => 'Display title of'
+		'_DTITLE' => 'Display title of',
+		'_PVUC' => 'Has uniqueness constraint',
 	);
 
 	protected $m_SpecialPropertyAliases = array(

--- a/languages/SMW_LanguageArz.php
+++ b/languages/SMW_LanguageArz.php
@@ -83,7 +83,8 @@ class SMWLanguageArz extends SMWLanguage {
 		'_TEXT'  => 'Text',
 		'_PDESC' => 'Has property description',
 		'_PVAP'  => 'Allows pattern',
-		'_DTITLE' => 'Display title of'
+		'_DTITLE' => 'Display title of',
+		'_PVUC' => 'Has uniqueness constraint',
 	);
 
 	protected $m_SpecialPropertyAliases = array(

--- a/languages/SMW_LanguageCa.php
+++ b/languages/SMW_LanguageCa.php
@@ -87,7 +87,8 @@ class SMWLanguageCa extends SMWLanguage {
 		'_TEXT'  => 'Text',
 		'_PDESC' => 'Has property description',
 		'_PVAP'  => 'Allows pattern',
-		'_DTITLE' => 'Display title of'
+		'_DTITLE' => 'Display title of',
+		'_PVUC' => 'Has uniqueness constraint',
 	);
 
 	protected $m_SpecialPropertyAliases = array(

--- a/languages/SMW_LanguageDe.php
+++ b/languages/SMW_LanguageDe.php
@@ -93,7 +93,8 @@ class SMWLanguageDe extends SMWLanguage {
 		'_TEXT'  => 'Text',
 		'_PDESC' => 'Has property description',
 		'_PVAP'  => 'Allows pattern',
-		'_DTITLE' => 'Display title of'
+		'_DTITLE' => 'Display title of',
+		'_PVUC' => 'Has uniqueness constraint',
 	);
 
 	protected $m_SpecialPropertyAliases = array(

--- a/languages/SMW_LanguageEn.php
+++ b/languages/SMW_LanguageEn.php
@@ -90,7 +90,8 @@ class SMWLanguageEn extends SMWLanguage {
 		'_TEXT'  => 'Text',
 		'_PDESC' => 'Has property description',
 		'_PVAP'  => 'Allows pattern',
-		'_DTITLE' => 'Display title of'
+		'_DTITLE' => 'Display title of',
+		'_PVUC' => 'Has uniqueness constraint',
 	);
 
 	protected $m_SpecialPropertyAliases = array(

--- a/languages/SMW_LanguageEs.php
+++ b/languages/SMW_LanguageEs.php
@@ -84,7 +84,8 @@ class SMWLanguageEs extends SMWLanguage {
 		'_TEXT'  => 'Text',
 		'_PDESC' => 'Has property description',
 		'_PVAP'  => 'Allows pattern',
-		'_DTITLE' => 'Display title of'
+		'_DTITLE' => 'Display title of',
+		'_PVUC' => 'Has uniqueness constraint',
 	);
 
 	protected $m_SpecialPropertyAliases = array(

--- a/languages/SMW_LanguageFi.php
+++ b/languages/SMW_LanguageFi.php
@@ -80,7 +80,8 @@ class SMWLanguageFi extends SMWLanguage {
 		'_TEXT'  => 'Text',
 		'_PDESC' => 'Has property description',
 		'_PVAP'  => 'Allows pattern',
-		'_DTITLE' => 'Display title of'
+		'_DTITLE' => 'Display title of',
+		'_PVUC' => 'Has uniqueness constraint',
 	);
 
 	protected $m_Namespaces = array(

--- a/languages/SMW_LanguageFr.php
+++ b/languages/SMW_LanguageFr.php
@@ -84,7 +84,8 @@ class SMWLanguageFr extends SMWLanguage {
 		'_TEXT'  => 'Text',
 		'_PDESC' => 'Has property description',
 		'_PVAP'  => 'Allows pattern',
-		'_DTITLE' => 'Display title of'
+		'_DTITLE' => 'Display title of',
+		'_PVUC' => 'Has uniqueness constraint',
 	);
 
 	protected $m_SpecialPropertyAliases = array(

--- a/languages/SMW_LanguageHe.php
+++ b/languages/SMW_LanguageHe.php
@@ -83,7 +83,8 @@ class SMWLanguageHe extends SMWLanguage {
 		'_TEXT'  => 'Text',
 		'_PDESC' => 'Has property description',
 		'_PVAP'  => 'Allows pattern',
-		'_DTITLE' => 'Display title of'
+		'_DTITLE' => 'Display title of',
+		'_PVUC' => 'Has uniqueness constraint',
 	);
 
 	protected $m_SpecialPropertyAliases = array(

--- a/languages/SMW_LanguageHu.php
+++ b/languages/SMW_LanguageHu.php
@@ -88,7 +88,8 @@ class SMWLanguageHu extends SMWLanguage {
 		'_TEXT'  => 'Text',
 		'_PDESC' => 'Has property description',
 		'_PVAP'  => 'Allows pattern',
-		'_DTITLE' => 'Display title of'
+		'_DTITLE' => 'Display title of',
+		'_PVUC' => 'Has uniqueness constraint',
 	);
 
 	protected $m_SpecialPropertyAliases = array(

--- a/languages/SMW_LanguageId.php
+++ b/languages/SMW_LanguageId.php
@@ -84,7 +84,8 @@ class SMWLanguageId extends SMWLanguage {
 		'_TEXT'  => 'Text',
 		'_PDESC' => 'Has property description',
 		'_PVAP'  => 'Allows pattern',
-		'_DTITLE' => 'Display title of'
+		'_DTITLE' => 'Display title of',
+		'_PVUC' => 'Has uniqueness constraint',
 	);
 
 	protected $m_SpecialPropertyAliases = array(

--- a/languages/SMW_LanguageIt.php
+++ b/languages/SMW_LanguageIt.php
@@ -86,7 +86,8 @@ class SMWLanguageIt extends SMWLanguage {
 		'_TEXT'  => 'Text',
 		'_PDESC' => 'Has property description',
 		'_PVAP'  => 'Allows pattern',
-		'_DTITLE' => 'Display title of'
+		'_DTITLE' => 'Display title of',
+		'_PVUC' => 'Has uniqueness constraint',
 	);
 
 	protected $m_SpecialPropertyAliases = array(

--- a/languages/SMW_LanguageNb.php
+++ b/languages/SMW_LanguageNb.php
@@ -93,7 +93,8 @@ class SMWLanguageNb extends SMWLanguage {
 		'_TEXT'  => 'Text',
 		'_PDESC' => 'Has property description',
 		'_PVAP'  => 'Allows pattern',
-		'_DTITLE' => 'Display title of'
+		'_DTITLE' => 'Display title of',
+		'_PVUC' => 'Has uniqueness constraint',
 	);
 
 	protected $m_SpecialPropertyAliases = array(

--- a/languages/SMW_LanguageNl.php
+++ b/languages/SMW_LanguageNl.php
@@ -86,7 +86,8 @@ class SMWLanguageNl extends SMWLanguage {
 		'_TEXT'  => 'Text',
 		'_PDESC' => 'Has property description',
 		'_PVAP'  => 'Allows pattern',
-		'_DTITLE' => 'Display title of'
+		'_DTITLE' => 'Display title of',
+		'_PVUC' => 'Has uniqueness constraint',
 	);
 
 	protected $m_SpecialPropertyAliases = array(

--- a/languages/SMW_LanguagePl.php
+++ b/languages/SMW_LanguagePl.php
@@ -102,7 +102,8 @@ class SMWLanguagePl extends SMWLanguage {
 		'_TEXT'  => 'Text',
 		'_PDESC' => 'Has property description',
 		'_PVAP'  => 'Allows pattern',
-		'_DTITLE' => 'Display title of'
+		'_DTITLE' => 'Display title of',
+		'_PVUC' => 'Has uniqueness constraint',
 	);
 
 	protected $m_SpecialPropertyAliases = array(

--- a/languages/SMW_LanguagePt.php
+++ b/languages/SMW_LanguagePt.php
@@ -91,7 +91,8 @@ class SMWLanguagePt extends SMWLanguage {
 		'_TEXT'  => 'Text',
 		'_PDESC' => 'Has property description',
 		'_PVAP'  => 'Allows pattern',
-		'_DTITLE' => 'Display title of'
+		'_DTITLE' => 'Display title of',
+		'_PVUC' => 'Has uniqueness constraint',
 	);
 
 	protected $m_SpecialPropertyAliases = array(

--- a/languages/SMW_LanguageRu.php
+++ b/languages/SMW_LanguageRu.php
@@ -86,7 +86,8 @@ class SMWLanguageRu extends SMWLanguage {
 		'_TEXT'  => 'Text',
 		'_PDESC' => 'Has property description',
 		'_PVAP'  => 'Allows pattern',
-		'_DTITLE' => 'Display title of'
+		'_DTITLE' => 'Display title of',
+		'_PVUC' => 'Has uniqueness constraint',
 	);
 
 	protected $m_SpecialPropertyAliases = array(

--- a/languages/SMW_LanguageSk.php
+++ b/languages/SMW_LanguageSk.php
@@ -83,7 +83,8 @@ class SMWLanguageSk extends SMWLanguage {
 		'_TEXT'  => 'Text',
 		'_PDESC' => 'Has property description',
 		'_PVAP'  => 'Allows pattern',
-		'_DTITLE' => 'Display title of'
+		'_DTITLE' => 'Display title of',
+		'_PVUC' => 'Has uniqueness constraint',
 	);
 
 	protected $m_SpecialPropertyAliases = array(

--- a/languages/SMW_LanguageZh_cn.php
+++ b/languages/SMW_LanguageZh_cn.php
@@ -91,7 +91,8 @@ class SMWLanguageZh_cn extends SMWLanguage {
 		'_TEXT'  => 'Text',
 		'_PDESC' => 'Has property description',
 		'_PVAP'  => 'Allows pattern',
-		'_DTITLE' => 'Display title of'
+		'_DTITLE' => 'Display title of',
+		'_PVUC' => 'Has uniqueness constraint',
 	);
 
 	protected $m_SpecialPropertyAliases = array(

--- a/languages/SMW_LanguageZh_tw.php
+++ b/languages/SMW_LanguageZh_tw.php
@@ -89,7 +89,8 @@ class SMWLanguageZh_tw extends SMWLanguage {
 		'_TEXT'  => 'Text',
 		'_PDESC' => 'Has property description',
 		'_PVAP'  => 'Allows pattern',
-		'_DTITLE' => 'Display title of'
+		'_DTITLE' => 'Display title of',
+		'_PVUC' => 'Has uniqueness constraint',
 	);
 
 	protected $m_SpecialPropertyAliases = array(

--- a/src/ApplicationFactory.php
+++ b/src/ApplicationFactory.php
@@ -352,6 +352,15 @@ class ApplicationFactory {
 		return new QueryParser();
 	}
 
+	/**
+	 * @since 2.4
+	 *
+	 * @return QueryFactory
+	 */
+	public function newQueryFactory() {
+		return new QueryFactory();
+	}
+
 	private static function registerBuilder( CallbackLoader $callbackLoader = null ) {
 
 		if ( $callbackLoader === null ) {

--- a/src/CachedPropertyValuesPrefetcher.php
+++ b/src/CachedPropertyValuesPrefetcher.php
@@ -3,6 +3,7 @@
 namespace SMW;
 
 use Onoi\BlobStore\BlobStore;
+use SMWQuery as Query;
 
 /**
  * This class should be accessed via ApplicationFactory::getCachedPropertyValuesPrefetcher
@@ -99,6 +100,17 @@ class CachedPropertyValuesPrefetcher {
 	/**
 	 * @since 2.4
 	 *
+	 * @param Query $query
+	 *
+	 * @return array
+	 */
+	public function queryPropertyValuesFor( Query $query ) {
+		return $this->store->getQueryResult( $query )->getResults();
+	}
+
+	/**
+	 * @since 2.4
+	 *
 	 * @return BlobStore
 	 */
 	public function getBlobStore() {
@@ -123,6 +135,17 @@ class CachedPropertyValuesPrefetcher {
 	 */
 	public function getRootHashFor( DIWikiPage $subject ) {
 		return md5( $subject->asBase()->getHash() . self::VERSION );
+	}
+
+	/**
+	 * @since 2.4
+	 *
+	 * @param string $hash
+	 *
+	 * @return string
+	 */
+	public function getHashFor( $hash ) {
+		return md5( $hash . self::VERSION );
 	}
 
 }

--- a/src/DataItemFactory.php
+++ b/src/DataItemFactory.php
@@ -4,6 +4,7 @@ namespace SMW;
 
 use SMWDINumber as DINumber;
 use SMWDIBlob as DIBlob;
+use SMWDIBoolean as DIBoolean;
 use SMWDIError as DIError;
 use SMWDIContainer as DIContainer;
 use SMWContainerSemanticData as ContainerSemanticData;
@@ -86,6 +87,17 @@ class DataItemFactory {
 	 */
 	public function newDIBlob( $text ) {
 		return new DIBlob( $text );
+	}
+
+	/**
+	 * @since 2.4
+	 *
+	 * @param boolean $boolean
+	 *
+	 * @return DIBoolean
+	 */
+	public function newDIBoolean( $boolean ) {
+		return new DIBoolean( $boolean );
 	}
 
 }

--- a/src/DataTypeRegistry.php
+++ b/src/DataTypeRegistry.php
@@ -446,6 +446,7 @@ class DataTypeRegistry {
 			'__lcode' => 'SMW\DataValues\LanguageCodeValue',
 			'__pval' => 'SMW\DataValues\AllowsListValue',
 			'__pvap' => 'SMW\DataValues\AllowsPatternValue',
+			'__pvuc' => 'SMW\DataValues\UniquenessConstraintValue',
 		);
 
 		$this->typeDataItemIds = array(
@@ -488,6 +489,7 @@ class DataTypeRegistry {
 			'__key' => DataItem::TYPE_BLOB, // Sort key of a page
 			'__lcode' => DataItem::TYPE_BLOB, // Language code
 			'__pvap' => DataItem::TYPE_BLOB, // Allows pattern
+			'__pvuc' => DataItem::TYPE_BOOLEAN, // Uniqueness constraint
 		);
 
 		$this->subDataTypes = array(

--- a/src/DataValueFactory.php
+++ b/src/DataValueFactory.php
@@ -47,7 +47,7 @@ class DataValueFactory {
 	 *
 	 * @param DataTypeRegistry|null $dataTypeRegistry
 	 */
-	protected function __construct( DataTypeRegistry $dataTypeRegistry = null, ValueConstraintValidator $valueConstraintValidator ) {
+	protected function __construct( DataTypeRegistry $dataTypeRegistry = null, ValueConstraintValidator $valueConstraintValidator = null ) {
 		$this->dataTypeRegistry = $dataTypeRegistry;
 		$this->valueConstraintValidator = $valueConstraintValidator;
 	}
@@ -61,8 +61,7 @@ class DataValueFactory {
 
 		if ( self::$instance === null ) {
 			self::$instance = new self(
-				DataTypeRegistry::getInstance(),
-				ValueConstraintValidator::newInstance()
+				DataTypeRegistry::getInstance()
 			);
 		}
 
@@ -297,6 +296,11 @@ class DataValueFactory {
 	 * @return ValueConstraintValidator
 	 */
 	public function getValueConstraintValidator() {
+
+		if ( $this->valueConstraintValidator === null ) {
+			$this->valueConstraintValidator = ValueConstraintValidator::newInstance();
+		}
+
 		return $this->valueConstraintValidator;
 	}
 

--- a/src/DataValues/UniquenessConstraintValue.php
+++ b/src/DataValues/UniquenessConstraintValue.php
@@ -1,0 +1,194 @@
+<?php
+
+namespace SMW\DataValues;
+
+use SMW\DIProperty;
+use SMW\DIWikiPage;
+use SMW\ApplicationFactory;
+use SMW\CachedPropertyValuesPrefetcher;
+use SMWDataItem as DataItem;
+use SMWDataValue as DataValue;
+use SMWBoolValue as BooleanValue;
+
+/**
+ * Only allow values that are unique where uniqueness is establised for the first (
+ * in terms of time which also entails that after a full rebuild the first value
+ * found is being categorised as established value) value assigned to a property
+ * (that requires this trait) and any value that compares to an establised
+ * value with the same literal representation is being identified as violating the
+ * uniqueness constraint.
+ *
+ * @note This class is optimized for performance which means that each match will be
+ * cached to avoid making unnecessary query requests to the QueryEngine.
+ *
+ * A linked list will ensure that a subject which is associated with a unique value
+ * is being purged in case it is altered or its uniqueness constraint is no longer
+ * valid.
+ *
+ * @license GNU GPL v2+
+ * @since 2.4
+ *
+ * @author mwjames
+ */
+class UniquenessConstraintValue extends BooleanValue {
+
+	/**
+	 * @var CachedPropertyValuesPrefetcher
+	 */
+	private $cachedPropertyValuesPrefetcher;
+
+	/**
+	 * @var QueryFactory
+	 */
+	private $queryFactory;
+
+	/**
+	 * @var Store
+	 */
+	private $store;
+
+	/**
+	 * @since 2.4
+	 *
+	 * @param string $typeid
+	 * @param CachedPropertyValuesPrefetcher $cachedPropertyValuesPrefetcher
+	 */
+	public function __construct( $typeid = '', CachedPropertyValuesPrefetcher $cachedPropertyValuesPrefetcher = null ) {
+		parent::__construct( '__pvuc' );
+		$this->cachedPropertyValuesPrefetcher = $cachedPropertyValuesPrefetcher;
+
+		if ( $this->cachedPropertyValuesPrefetcher === null ) {
+			$this->cachedPropertyValuesPrefetcher = ApplicationFactory::getInstance()->getCachedPropertyValuesPrefetcher();
+		}
+
+		$this->queryFactory = ApplicationFactory::getInstance()->newQueryFactory();
+	}
+
+	/**
+	 * @see DataValue::parseUserValue
+	 *
+	 * @param string $value
+	 */
+	protected function parseUserValue( $userValue ) {
+
+		if ( !$this->isEnabledFeature( SMW_DV_PVUC ) ) {
+			$this->addErrorMsg(
+				array(
+					'smw-datavalue-feature-not-supported',
+					'SMW_DV_PVUC'
+				)
+			);
+		}
+
+		parent::parseUserValue( $userValue );
+	}
+
+	/**
+	 * @see ValueConstraintValidator::doValidate
+	 *
+	 * @since 2.4
+	 *
+	 * @param DataValue $dataValue
+	 */
+	public function doCheckUniquenessConstraintFor( DataValue $dataValue ) {
+
+		if ( $dataValue->getContextPage() === null || !$dataValue->isEnabledFeature( SMW_DV_PVUC ) ) {
+			return;
+		}
+
+		$dataItem = $dataValue->getDataItem();
+		$property = $dataValue->getProperty();
+
+		if ( !$this->getPropertySpecificationLookup()->hasUniquenessConstraintFor( $property ) ) {
+			return null;
+		}
+
+		$blobStore = $this->cachedPropertyValuesPrefetcher->getBlobStore();
+
+		$hash = $this->cachedPropertyValuesPrefetcher->getHashFor(
+			$property->getKey() . ':' . $dataItem->getHash()
+		);
+
+		$container = $blobStore->read(
+			$hash
+		);
+
+		$key = 'PVUC';
+
+		if ( !$container->has( $key ) ) {
+			$page = $this->tryFindMatchResultFor(
+				$hash,
+				$dataValue
+			);
+
+			$container->set( $key, $page );
+
+			$blobStore->save(
+				$container
+			);
+		}
+
+		$wikiPage = $container->get( $key );
+
+		// Verify that the contextPage (where the annotation has its origin) is
+		// matchable to the request and in case it is not a match inform the user
+		// about the origin
+		if ( $wikiPage instanceof DIWikiPage && !$dataValue->getContextPage()->equals( $wikiPage ) ) {
+			$this->addErrorMsg(
+				array(
+					'smw-datavalue-uniqueness-constraint-error',
+					$property->getLabel(),
+					$dataValue->getWikiValue(),
+					$wikiPage->getTitle()->getPrefixedText()
+				)
+			);
+		}
+	}
+
+	private function tryFindMatchResultFor( $hash, $dataValue ) {
+
+		$descriptionFactory = $this->queryFactory->newDescriptionFactory();
+		$contextPage = $dataValue->getContextPage();
+
+		// Exclude the current page from the result match to check whether another
+		// page matches the condition and if so then the value can no longer be
+		// assigned and is not unique
+		$description = $descriptionFactory->newConjunction( array(
+			$descriptionFactory->newFromDataValue( $dataValue ),
+			$descriptionFactory->newValueDescription( $contextPage, null, SMW_CMP_NEQ ) // NEQ
+		) );
+
+		$query = $this->queryFactory->newQuery( $description );
+		$query->setLimit( 1 );
+
+		$dataItems = $this->cachedPropertyValuesPrefetcher->queryPropertyValuesFor(
+			$query
+		);
+
+		if ( !is_array( $dataItems ) || $dataItems === array() ) {
+			// No other assignments were found therefore it is assumed that at
+			// the time of the query request, the "contextPage" holds a unique
+			// value for the property
+			$page = $contextPage;
+		} else {
+			$page = end( $dataItems );
+		}
+
+		// Create a linked list so that when the subject is altered or deleted
+		// the related uniqueness container can be removed as well
+		$blobStore = $this->cachedPropertyValuesPrefetcher->getBlobStore();
+
+		$container = $blobStore->read(
+			$this->cachedPropertyValuesPrefetcher->getRootHashFor( $page )
+		);
+
+		$container->addToLinkedList( $hash );
+
+		$blobStore->save(
+			$container
+		);
+
+		return $page;
+	}
+
+}

--- a/src/DataValues/ValueConstraintValidator.php
+++ b/src/DataValues/ValueConstraintValidator.php
@@ -28,17 +28,28 @@ class ValueConstraintValidator {
 	private $allowsListValue;
 
 	/**
+	 * @var UniquenessConstraintValue
+	 */
+	private $uniquenessConstraintValue;
+
+	/**
 	 * @since 2.4
 	 *
 	 * @param AllowsPatternValue $allowsPatternValue
 	 * @param AllowsListValue $allowsListValue
+	 * @param UniquenessConstraintValue $uniquenessConstraintValue
 	 */
-	public function __construct( AllowsPatternValue $allowsPatternValue, AllowsListValue $allowsListValue ) {
+	public function __construct( AllowsPatternValue $allowsPatternValue, AllowsListValue $allowsListValue, UniquenessConstraintValue $uniquenessConstraintValue ) {
 		$this->allowsPatternValue = $allowsPatternValue;
 		$this->allowsListValue = $allowsListValue;
+		$this->uniquenessConstraintValue = $uniquenessConstraintValue;
 	}
 
 	/**
+	 * @note Static access is done to improve performance during execution of the
+	 * DataValueFactory::getValueConstraintValidator and avoids that for each
+	 * DV request a new instance is created.
+	 *
 	 * @since 2.4
 	 *
 	 * @return ValueConstraintValidator
@@ -46,11 +57,19 @@ class ValueConstraintValidator {
 	public static function newInstance() {
 		return new self(
 			new AllowsPatternValue(),
-			new AllowsListValue()
+			new AllowsListValue(),
+			new UniquenessConstraintValue()
 		);
 	}
 
 	/**
+	 * @see DataValue::checkAllowedValues
+	 *
+	 * Any error produced during one of the checks (UniquenessConstraint,
+	 * AllowedPattern, AllowedValues) will yield an immediate processing stop
+	 * for a value assignment that has been categorized as not suitable in
+	 * context of the expressed constraints.
+	 *
 	 * @since 2.4
 	 *
 	 * @param DataValue $dataValue
@@ -61,24 +80,43 @@ class ValueConstraintValidator {
 			return;
 		}
 
+		$this->uniquenessConstraintValue->clearErrors();
+
+		$this->uniquenessConstraintValue->doCheckUniquenessConstraintFor(
+			$dataValue
+		);
+
+		$dataValue->addError(
+			$this->uniquenessConstraintValue->getErrors()
+		);
+
+		if ( $this->uniquenessConstraintValue->getErrors() !== array() ) {
+			return;
+		}
+
 		$this->allowsPatternValue->clearErrors();
-		$this->allowsListValue->clearErrors();
 
 		$this->allowsPatternValue->doCheckAllowedPatternFor(
 			$dataValue
 		);
 
-		$dataValue->addError( $this->allowsPatternValue->getErrors() );
+		$dataValue->addError(
+			$this->allowsPatternValue->getErrors()
+		);
 
 		if ( $this->allowsPatternValue->getErrors() !== array() ) {
 			return;
 		}
 
+		$this->allowsListValue->clearErrors();
+
 		$this->allowsListValue->doCheckAllowedValuesFor(
 			$dataValue
 		);
 
-		$dataValue->addError( $this->allowsListValue->getErrors() );
+		$dataValue->addError(
+			$this->allowsListValue->getErrors()
+		);
 	}
 
 }

--- a/src/MediaWiki/Hooks/ArticleDelete.php
+++ b/src/MediaWiki/Hooks/ArticleDelete.php
@@ -45,8 +45,9 @@ class ArticleDelete {
 
 		$semanticDataSerializer = $applicationFactory->newSerializerFactory()->newSemanticDataSerializer();
 		$jobFactory = $applicationFactory->newJobFactory();
+		$cachedPropertyValuesPrefetcher = $applicationFactory->getCachedPropertyValuesPrefetcher();
 
-		$deferredCallableUpdate = $applicationFactory->newDeferredCallableUpdate( function() use( $store, $title, $semanticDataSerializer, $jobFactory ) {
+		$deferredCallableUpdate = $applicationFactory->newDeferredCallableUpdate( function() use( $store, $title, $semanticDataSerializer, $jobFactory, $cachedPropertyValuesPrefetcher ) {
 
 			$subject = DIWikiPage::newFromTitle( $title );
 			wfDebugLog( 'smw', 'DeferredCallableUpdate on delete for ' . $subject->getHash() );
@@ -72,6 +73,10 @@ class ArticleDelete {
 			$jobFactory->newUpdateDispatcherJob( $title, array( 'job-list' => $jobList ) )->insert();
 			*/
 			$store->deleteSubject( $title );
+
+			$cachedPropertyValuesPrefetcher->resetCacheFor(
+				$subject
+			);
 		} );
 
 		$deferredCallableUpdate->pushToDeferredUpdateList();

--- a/src/PropertyRegistry.php
+++ b/src/PropertyRegistry.php
@@ -409,6 +409,7 @@ class PropertyRegistry {
 			'_PDESC' => array( '_mlt_rec', true, true ), // "Property description"
 			'_PVAP'  => array( '__pvap', true, true ), // "Allows pattern"
 			'_DTITLE' => array( '_txt', false, true ), // "Display title of"
+			'_PVUC'  => array( '__pvuc', true, true ), // Uniqueness constraint
 		);
 
 		foreach ( $this->datatypeLabels as $id => $label ) {

--- a/src/PropertySpecificationLookup.php
+++ b/src/PropertySpecificationLookup.php
@@ -88,7 +88,9 @@ class PropertySpecificationLookup {
 		$query = new Query( $description );
 		$query->setLimit( 1 );
 
-		$dataItems = $this->cachedPropertyValuesPrefetcher->getStore()->getQueryResult( $query )->getResults();
+		$dataItems = $this->cachedPropertyValuesPrefetcher->queryPropertyValuesFor(
+			$query
+		);
 
 		if ( is_array( $dataItems ) && $dataItems !== array() ) {
 			$dataItem = end( $dataItems );
@@ -100,6 +102,29 @@ class PropertySpecificationLookup {
 		}
 
 		return false;
+	}
+
+	/**
+	 * @since 2.4
+	 *
+	 * @param DIProperty $property
+	 *
+	 * @return boolean
+	 */
+	public function hasUniquenessConstraintFor( DIProperty $property ) {
+
+		$hasUniquenessConstraint = false;
+
+		$dataItems = $this->cachedPropertyValuesPrefetcher->getPropertyValues(
+			$property->getDiWikiPage(),
+			new DIProperty( '_PVUC' )
+		);
+
+		if ( is_array( $dataItems ) && $dataItems !== array() ) {
+			$hasUniquenessConstraint = end( $dataItems )->getBoolean();
+		}
+
+		return $hasUniquenessConstraint;
 	}
 
 	/**

--- a/src/Query/DescriptionFactory.php
+++ b/src/Query/DescriptionFactory.php
@@ -14,6 +14,8 @@ use SMW\Query\Language\ConceptDescription;
 use SMW\DIWikiPage;
 use SMW\DIProperty;
 use SMWDataItem as DataItem;
+use SMWDataValue as DataValue;
+use SMW\DataValue\MonolingualTextValue;
 
 /**
  * @license GNU GPL v2+
@@ -110,6 +112,40 @@ class DescriptionFactory {
 	 */
 	public function newConceptDescription( DIWikiPage $concept ) {
 		return new ConceptDescription( $concept );
+	}
+
+	/**
+	 * @since 2.4
+	 *
+	 * @param DataValue $dataValue
+	 *
+	 * @return Description
+	 */
+	public function newFromDataValue( DataValue $dataValue ) {
+
+		if ( !$dataValue->isValid() ) {
+			return $this->newThingDescription();
+		}
+
+		// RecordValue is missing
+
+		// FIXME This knowledge should reside with the DV itself
+		if ( $dataValue instanceof MonolingualTextValue ) {
+			$container =  $dataValue->getDataItem();
+
+			foreach ( $dataValue->getPropertyDataItems() as $property ) {
+				foreach ( $container->getSemanticData()->getPropertyValues( $property ) as $val ) {
+					$value .= ( $property->getKey() == '_LCODE' ? '@' : '' ) . $val->getString();
+				}
+			}
+
+			return $dataValue->getQueryDescription( $value );
+		}
+
+		return $this->newSomeProperty(
+			$dataValue->getProperty(),
+			$this->newValueDescription( $dataValue->getDataItem() )
+		);
 	}
 
 }

--- a/src/QueryFactory.php
+++ b/src/QueryFactory.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace SMW;
+
+use SMW\Query\Language\Description;
+use SMW\Query\DescriptionFactory;
+use SMW\Query\PrintRequestFactory;
+use SMWQuery as Query;
+use SMWQueryParser as QueryParser;
+
+/**
+ * @license GNU GPL v2+
+ * @since 2.4
+ *
+ * @author mwjames
+ */
+class QueryFactory {
+
+	/**
+	 * @since 2.4
+	 *
+	 * @param Description $description
+	 *
+	 * @return Query
+	 */
+	public function newQuery( Description $description ) {
+		return new Query( $description );
+	}
+
+	/**
+	 * @since 2.4
+	 *
+	 * @return DescriptionFactory
+	 */
+	public function newDescriptionFactory() {
+		return new DescriptionFactory();
+	}
+
+	/**
+	 * @since 2.4
+	 *
+	 * @return PrintRequestFactory
+	 */
+	public function newPrintRequestFactory() {
+		return new PrintRequestFactory();
+	}
+
+	/**
+	 * @since 2.4
+	 *
+	 * @return RequestOptions
+	 */
+	public function newRequestOptions() {
+		return new RequestOptions();
+	}
+
+	/**
+	 * @since 2.4
+	 *
+	 * @param string $string
+	 * @param integer $condition
+	 * @param boolean $isDisjunctiveCondition
+	 *
+	 * @return StringCondition
+	 */
+	public function newStringCondition( $string, $condition, $isDisjunctiveCondition = false ) {
+		return new StringCondition( $string, $condition, $isDisjunctiveCondition );
+	}
+
+	/**
+	 * @since 2.4
+	 *
+	 * @return QueryParser
+	 */
+	public function newQueryParser() {
+		return new QueryParser();
+	}
+
+}

--- a/src/SPARQLStore/QueryEngine/Interpreter/ValueDescriptionInterpreter.php
+++ b/src/SPARQLStore/QueryEngine/Interpreter/ValueDescriptionInterpreter.php
@@ -14,6 +14,7 @@ use SMW\SPARQLStore\QueryEngine\DescriptionInterpreter;
 use SMWDIBlob as DIBlob;
 use SMWDIUri as DIUri;
 use SMWExpNsResource as ExpNsResource;
+use SMWExpElement as ExpElement;
 use SMWExporter as Exporter;
 use SMWTurtleSerializer as TurtleSerializer;
 
@@ -116,7 +117,7 @@ class ValueDescriptionInterpreter implements DescriptionInterpreter {
 			$expElement = $this->exporter->getDataItemExpElement( $dataItem );
 		}
 
-		if ( $expElement === null ) {
+		if ( $expElement === null || !$expElement instanceof ExpElement ) {
 			return new FalseCondition();
 		}
 

--- a/tests/phpunit/Integration/ByJsonScript/ByJsonScriptFixtureTestCaseRunnerTest.php
+++ b/tests/phpunit/Integration/ByJsonScript/ByJsonScriptFixtureTestCaseRunnerTest.php
@@ -143,7 +143,8 @@ class ByJsonScriptFixtureTestCaseRunnerTest extends ByJsonTestCaseProvider {
 			'smwgQConceptCaching',
 			'smwgEnabledInTextAnnotationParserStrictMode',
 			'smwgMaxNonExpNumber',
-			'wgRestrictDisplayTitle' // Restrict {{DISPLAYTITLE}} to titles ...
+			'wgRestrictDisplayTitle', // Restrict {{DISPLAYTITLE}} to titles ...
+			'smwgDVFeatures'
 		);
 
 		foreach ( $permittedSettings as $key ) {

--- a/tests/phpunit/Integration/ByJsonScript/Fixtures/p-0419.json
+++ b/tests/phpunit/Integration/ByJsonScript/Fixtures/p-0419.json
@@ -1,0 +1,138 @@
+{
+	"description": "Test in-text annotation for `PRUC` to validate uniqueness",
+	"properties": [
+		{
+			"name": "Has Url",
+			"contents": "[[Has type::URL]] [[Has uniqueness constraint::true]]"
+		},
+		{
+			"name": "Has text",
+			"contents": "[[Has type::Text]] [[Has uniqueness constraint::true]]"
+		},
+		{
+			"name": "Has date",
+			"contents": "[[Has type::Date]] [[Has uniqueness constraint::true]]"
+		},
+		{
+			"name": "Has monolingual text",
+			"contents": "[[Has type::Monolingual text]] [[Has uniqueness constraint::true]]"
+		}
+	],
+	"subjects": [
+		{
+			"name": "Example/P0419/1",
+			"contents": "[[Has Url::http://example.org/Foo]]"
+		},
+		{
+			"name": "Example/P0419/2",
+			"contents": "[[Has Url::http://example.org/Foo]] [[Has Url::http://example.org/FoO]]"
+		},
+		{
+			"name": "Example/P0419/3",
+			"contents": "[[Has text::Foo]]"
+		},
+		{
+			"name": "Example/P0419/4",
+			"contents": "[[Has text::Foo]]"
+		},
+		{
+			"name": "Example/P0419/5",
+			"contents": "[[Has date::1 Jan 1970 12:50:12]]"
+		},
+		{
+			"name": "Example/P0419/6",
+			"contents": "{{#subobject:|Has date=1 Jan 1970 12:50:12}}"
+		},
+		{
+			"name": "Example/P0419/7",
+			"contents": "[[Has monolingual text::Foo@en]]"
+		},
+		{
+			"name": "Example/P0419/8",
+			"contents": "{{#subobject:|Has monolingual text=Foo@en}}"
+		}
+	],
+	"parser-testcases": [
+		{
+			"about": "#0",
+			"subject": "Example/P0419/1",
+			"store": {
+				"semantic-data": {
+					"strict-mode-valuematch": false,
+					"propertyCount": 3,
+					"propertyKeys": [ "_SKEY", "_MDAT", "Has_Url" ],
+					"propertyValues": [ "http://example.org/Foo" ]
+				}
+			}
+		},
+		{
+			"about": "#1",
+			"subject": "Example/P0419/2",
+			"store": {
+				"semantic-data": {
+					"strict-mode-valuematch": false,
+					"propertyCount": 4,
+					"propertyKeys": [ "_SKEY", "_MDAT", "_ERRC", "Has_Url" ],
+					"propertyValues": [ "http://example.org/FoO" ]
+				}
+			}
+		},
+		{
+			"about": "#2",
+			"subject": "Example/P0419/3",
+			"store": {
+				"semantic-data": {
+					"strict-mode-valuematch": false,
+					"propertyCount": 3,
+					"propertyKeys": [ "_SKEY", "_MDAT", "Has_text" ],
+					"propertyValues": [ "Foo" ]
+				}
+			}
+		},
+		{
+			"about": "#3 Fails uniqueness for the text annotated in Example/P0419/3",
+			"subject": "Example/P0419/4",
+			"store": {
+				"semantic-data": {
+					"strict-mode-valuematch": false,
+					"propertyCount": 3,
+					"propertyKeys": [ "_SKEY", "_MDAT", "_ERRC" ],
+					"propertyValues": []
+				}
+			}
+		},
+		{
+			"about": "#4 Fails uniqueness for date value annotated in Example/P0419/5",
+			"subject": "Example/P0419/6#_9fbec9d56750049a3420802d55db9a62",
+			"store": {
+				"semantic-data": {
+					"strict-mode-valuematch": false,
+					"propertyCount": 2,
+					"propertyKeys": [ "_SKEY", "_ERRC" ],
+					"propertyValues": []
+				}
+			}
+		},
+		{
+			"about": "#5 Fails uniqueness for monolingual text value annotated in Example/P0419/7",
+			"subject": "Example/P0419/8#_7d241515e1224e118e0cd09f9b055a79",
+			"store": {
+				"semantic-data": {
+					"strict-mode-valuematch": false,
+					"propertyCount": 2,
+					"propertyKeys": [ "_SKEY", "_ERRC" ],
+					"propertyValues": []
+				}
+			}
+		}
+	],
+	"settings": {
+		"smwgDVFeatures": [ "SMW_DV_PVUC" ],
+		"smwgPageSpecialProperties": [ "_MDAT" ]
+	},
+	"meta": {
+		"version": "0.1",
+		"is-incomplete": false,
+		"debug": false
+	}
+}

--- a/tests/phpunit/Integration/ByJsonScript/README.md
+++ b/tests/phpunit/Integration/ByJsonScript/README.md
@@ -1,5 +1,5 @@
 ## Fixtures
-Contains 100 files:
+Contains 103 files:
 
 ### F
 * [f-0001.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/ByJsonScript/Fixtures/f-0001.json) Test format=debug output
@@ -14,7 +14,9 @@ Contains 100 files:
 * [f-0206.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/ByJsonScript/Fixtures/f-0206.json) Test `format=table` to display extra property description `_PDESC` (en)
 * [f-0301.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/ByJsonScript/Fixtures/f-0301.json) Test format=category with template usage (#699, en, skip postgres)
 * [f-0302.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/ByJsonScript/Fixtures/f-0302.json) Test format=category and defaultsort (#699, en)
-* [f-0801.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/ByJsonScript/Fixtures/f-0801.json) Test format=embedded output (skip 1.19)
+* [f-0303.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/ByJsonScript/Fixtures/f-0303.json) Test `format=category` sort output using a template and DEFAULTSORT (#1459, en)
+* [f-0801.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/ByJsonScript/Fixtures/f-0801.json) Test `format=embedded` output (skip 1.19)
+* [f-0802.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/ByJsonScript/Fixtures/f-0802.json) Test `format=template` [[SMW::on/off]] regression using `named args=yes` (#1453, skip-on 1.19)
 
 ### P
 * [p-0101.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/ByJsonScript/Fixtures/p-0101.json) Test in-text annotation for use of restricted properties (#914, en)
@@ -48,6 +50,7 @@ Contains 100 files:
 * [p-0416.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/ByJsonScript/Fixtures/p-0416.json) Test in-text annotation with DISPLAYTITLE (#1410, `wgRestrictDisplayTitle`, en)
 * [p-0417.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/ByJsonScript/Fixtures/p-0417.json) Test in-text annotation for `Allows pattern` to match regular expressions (en, skip-on postgres)
 * [p-0418.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/ByJsonScript/Fixtures/p-0418.json) Test in-text annotation using `_SERV` as provide service links (en)
+* [p-0419.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/ByJsonScript/Fixtures/p-0419.json) Test in-text annotation for `PRUC` to validate uniqueness
 * [p-0701.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/ByJsonScript/Fixtures/p-0701.json) Test to create inverted annotation using a #ask/template combination (#711, `import-annotation=true`)
 * [p-0702.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/ByJsonScript/Fixtures/p-0702.json) Test #ask with `format=table` on inverse property/printrquest (#1270, en)
 * [p-0901.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/ByJsonScript/Fixtures/p-0901.json) Test #ask on moved redirected subject (#1086)
@@ -111,4 +114,4 @@ Contains 100 files:
 ### S
 * [s-0001.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/ByJsonScript/Fixtures/s-0001.json) Test output of `Special:Properties` (en, skip-on sqlite, 1.19)
 
--- Last updated on 2016-03-12 by `readmeContentsBuilder.php`
+-- Last updated on 2016-03-19 by `readmeContentsBuilder.php`

--- a/tests/phpunit/JsonTestCaseFileHandler.php
+++ b/tests/phpunit/JsonTestCaseFileHandler.php
@@ -180,6 +180,16 @@ class JsonTestCaseFileHandler {
 			return $smwgNamespacesWithSemanticLinks;
 		}
 
+		if ( $key === 'smwgDVFeatures' && isset( $settings[$key] ) ) {
+			$smwgDVFeatures = '';
+
+			foreach ( $settings[$key] as $value ) {
+				$smwgDVFeatures = constant( $value ) | $smwgDVFeatures;
+			}
+
+			return $smwgDVFeatures;
+		}
+
 		// Needs special attention due to constant usage
 		if ( $key === 'smwgQConceptCaching' && isset( $settings[$key] ) ) {
 			return constant( $settings[$key] );

--- a/tests/phpunit/Unit/ApplicationFactoryTest.php
+++ b/tests/phpunit/Unit/ApplicationFactoryTest.php
@@ -221,6 +221,14 @@ class ApplicationFactoryTest extends \PHPUnit_Framework_TestCase {
 		);
 	}
 
+	public function testCanConstructQueryFactory() {
+
+		$this->assertInstanceOf(
+			'\SMW\QueryFactory',
+			$this->applicationFactory->newQueryFactory()
+		);
+	}
+
 	public function testCanConstructDeferredCallableUpdate() {
 
 		$callback = function() {

--- a/tests/phpunit/Unit/CachedPropertyValuesPrefetcherTest.php
+++ b/tests/phpunit/Unit/CachedPropertyValuesPrefetcherTest.php
@@ -65,6 +65,39 @@ class CachedPropertyValuesPrefetcherTest extends \PHPUnit_Framework_TestCase {
 		);
 	}
 
+	public function testQueryPropertyValuesFor() {
+
+		$expected = array(
+			DIWikiPage::newFromText( 'Foo' )
+		);
+
+		$queryResult = $this->getMockBuilder( '\SMWQueryResult' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$queryResult->expects( $this->atLeastOnce() )
+			->method( 'getResults' )
+			->will( $this->returnValue( $expected ) );
+
+		$this->store->expects( $this->any() )
+			->method( 'getQueryResult' )
+			->will( $this->returnValue( $queryResult ) );
+
+		$query = $this->getMockBuilder( '\SMWQuery' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$instance = new CachedPropertyValuesPrefetcher(
+			$this->store,
+			$this->blobStore
+		);
+
+		$this->assertEquals(
+			$expected,
+			$instance->queryPropertyValuesFor( $query )
+		);
+	}
+
 	public function testGetPropertyValuesFromCache() {
 
 		$container = $this->getMockBuilder( '\Onoi\BlobStore\Container' )

--- a/tests/phpunit/Unit/DataItemFactoryTest.php
+++ b/tests/phpunit/Unit/DataItemFactoryTest.php
@@ -89,4 +89,14 @@ class DataItemFactoryTest extends \PHPUnit_Framework_TestCase {
 		);
 	}
 
+	public function testCanConstructDIBoolean() {
+
+		$instance = new DataItemFactory();
+
+		$this->assertInstanceOf(
+			'\SMWDIBoolean',
+			$instance->newDIBoolean( true )
+		);
+	}
+
 }

--- a/tests/phpunit/Unit/DataValues/UniquenessConstraintValueTest.php
+++ b/tests/phpunit/Unit/DataValues/UniquenessConstraintValueTest.php
@@ -1,0 +1,141 @@
+<?php
+
+namespace SMW\Tests\DataValues;
+
+use SMW\Tests\TestEnvironment;
+use SMW\DataValues\UniquenessConstraintValue;
+use SMW\Options;
+use SMW\DataItemFactory;
+
+/**
+ * @covers \SMW\DataValues\UniquenessConstraintValue
+ * @group semantic-mediawiki
+ *
+ * @license GNU GPL v2+
+ * @since 2.4
+ *
+ * @author mwjames
+ */
+class UniquenessConstraintValueTest extends \PHPUnit_Framework_TestCase {
+
+	private $testEnvironment;
+	private $dataItemFactory;
+	private $propertySpecificationLookup;
+	private $store;
+	private $blobStore;
+
+	protected function setUp() {
+		$this->testEnvironment = new TestEnvironment();
+		$this->dataItemFactory = new DataItemFactory();
+
+		$container = $this->getMockBuilder( '\Onoi\BlobStore\Container' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$this->blobStore = $this->getMockBuilder( '\Onoi\BlobStore\BlobStore' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$this->blobStore->expects( $this->any() )
+			->method( 'read' )
+			->will( $this->returnValue( $container ) );
+
+		$this->propertySpecificationLookup = $this->getMockBuilder( '\SMW\PropertySpecificationLookup' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$this->testEnvironment->registerObject( 'PropertySpecificationLookup', $this->propertySpecificationLookup );
+	}
+
+	protected function tearDown() {
+		$this->testEnvironment->tearDown();
+	}
+
+	public function testCanConstruct() {
+
+		$this->assertInstanceOf(
+			'\SMW\DataValues\UniquenessConstraintValue',
+			new UniquenessConstraintValue()
+		);
+	}
+
+	public function testErrorForMissingFeatureSetting() {
+
+		$instance = new UniquenessConstraintValue();
+
+		$instance->setOptions(
+			new Options( array( 'smwgDVFeatures' => '' ) )
+		);
+
+		$instance->setUserValue( 'Foo' );
+
+		$this->assertNotEmpty(
+			$instance->getErrors()
+		);
+	}
+
+	public function testErrorForInvalidBoolean() {
+
+		$instance = new UniquenessConstraintValue();
+
+		$instance->setOptions(
+			new Options( array( 'smwgDVFeatures' => SMW_DV_PVUC ) )
+		);
+
+		$instance->setUserValue( 'Foo' );
+
+		$this->assertNotEmpty(
+			$instance->getErrors()
+		);
+	}
+
+	public function testCheckUniquenessConstraintByUsingAMockedQueryEngine() {
+
+		$property = $this->dataItemFactory->newDIProperty( 'ValidAllowedValue' );
+
+		$cachedPropertyValuesPrefetcher = $this->getMockBuilder( '\SMW\CachedPropertyValuesPrefetcher' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$cachedPropertyValuesPrefetcher->expects( $this->atLeastOnce() )
+			->method( 'getBlobStore' )
+			->will( $this->returnValue( $this->blobStore ) );
+
+		$cachedPropertyValuesPrefetcher->expects( $this->atLeastOnce() )
+			->method( 'queryPropertyValuesFor' )
+			->will( $this->returnValue( array( $this->dataItemFactory->newDIWikiPage( 'UV', NS_MAIN ) ) ) );
+
+		$this->propertySpecificationLookup->expects( $this->once() )
+			->method( 'hasUniquenessConstraintFor' )
+			->will( $this->returnValue( true ) );
+
+		$dataValue = $this->getMockBuilder( '\SMWDataValue' )
+			->disableOriginalConstructor()
+			->setMethods( array( 'getProperty', 'getDataItem', 'getContextPage' ) )
+			->getMockForAbstractClass();
+
+		$dataValue->expects( $this->atLeastOnce() )
+			->method( 'getContextPage' )
+			->will( $this->returnValue( $this->dataItemFactory->newDIWikiPage( 'UV', NS_MAIN ) ) );
+
+		$dataValue->expects( $this->atLeastOnce() )
+			->method( 'getProperty' )
+			->will( $this->returnValue( $property ) );
+
+		$dataValue->expects( $this->atLeastOnce() )
+			->method( 'getDataItem' )
+			->will( $this->returnValue( $this->dataItemFactory->newDIBlob( 'Foo' ) ) );
+
+		$dataValue->setOptions(
+			new Options( array( 'smwgDVFeatures' => SMW_DV_PVUC ) )
+		);
+
+		$instance = new UniquenessConstraintValue(
+			'',
+			$cachedPropertyValuesPrefetcher
+		);
+
+		$instance->doCheckUniquenessConstraintFor( $dataValue );
+	}
+
+}

--- a/tests/phpunit/Unit/PropertySpecificationLookupTest.php
+++ b/tests/phpunit/Unit/PropertySpecificationLookupTest.php
@@ -47,25 +47,9 @@ class PropertySpecificationLookupTest extends \PHPUnit_Framework_TestCase {
 
 		$property = $this->dataItemFactory->newDIProperty( 'Foo' );
 
-		$queryResult = $this->getMockBuilder( '\SMWQueryResult' )
-			->disableOriginalConstructor()
-			->getMock();
-
-		$queryResult->expects( $this->once() )
-			->method( 'getResults' )
-			->will( $this->returnValue( array( $this->dataItemFactory->newDIWikiPage( 'Foo' ) ) ) );
-
-		$store = $this->getMockBuilder( '\SMW\Store' )
-			->disableOriginalConstructor()
-			->getMockForAbstractClass();
-
-		$store->expects( $this->once() )
-			->method( 'getQueryResult' )
-			->will( $this->returnValue( $queryResult ) );
-
 		$this->cachedPropertyValuesPrefetcher->expects( $this->once() )
-			->method( 'getStore' )
-			->will( $this->returnValue( $store ) );
+			->method( 'queryPropertyValuesFor' )
+			->will( $this->returnValue( array( $this->dataItemFactory->newDIWikiPage( 'Foo' ) ) ) );
 
 		$instance = new PropertySpecificationLookup(
 			$this->cachedPropertyValuesPrefetcher
@@ -74,6 +58,27 @@ class PropertySpecificationLookupTest extends \PHPUnit_Framework_TestCase {
 		$this->assertEquals(
 			$property,
 			$instance->getPropertyFromDisplayTitle( 'abc' )
+		);
+	}
+
+	public function testHasUniquenessConstraint() {
+
+		$property = $this->dataItemFactory->newDIProperty( 'Foo' );
+
+		$this->cachedPropertyValuesPrefetcher->expects( $this->once() )
+			->method( 'getPropertyValues' )
+			->with(
+				$this->equalTo( $property->getDiWikiPage() ),
+				$this->equalTo( $this->dataItemFactory->newDIProperty( '_PVUC' ) ),
+				$this->anything() )
+			->will( $this->returnValue( array( $this->dataItemFactory->newDIBoolean( true ) ) ) );
+
+		$instance = new PropertySpecificationLookup(
+			$this->cachedPropertyValuesPrefetcher
+		);
+
+		$this->assertTrue(
+			$instance->hasUniquenessConstraintFor( $property )
 		);
 	}
 

--- a/tests/phpunit/Unit/QueryFactoryTest.php
+++ b/tests/phpunit/Unit/QueryFactoryTest.php
@@ -1,0 +1,91 @@
+<?php
+
+namespace SMW\Tests;
+
+use SMW\QueryFactory;
+use SMW\StringCondition;
+
+/**
+ * @covers \SMW\QueryFactory
+ * @group semantic-mediawiki
+ *
+ * @license GNU GPL v2+
+ * @since 2.4
+ *
+ * @author mwjames
+ */
+class QueryFactoryTest extends \PHPUnit_Framework_TestCase {
+
+	public function testCanConstruct() {
+
+		$this->assertInstanceOf(
+			'\SMW\QueryFactory',
+			new QueryFactory()
+		);
+	}
+
+	public function testCanConstructQuery() {
+
+		$description = $this->getMockBuilder( '\SMW\Query\Language\Description' )
+			->disableOriginalConstructor()
+			->getMockForAbstractClass();
+
+		$instance = new QueryFactory();
+
+		$this->assertInstanceOf(
+			'\SMWQuery',
+			$instance->newQuery( $description )
+		);
+	}
+
+	public function testCanConstructDescriptionFactory() {
+
+		$instance = new QueryFactory();
+
+		$this->assertInstanceOf(
+			'\SMW\Query\DescriptionFactory',
+			$instance->newDescriptionFactory()
+		);
+	}
+
+	public function testCanConstructPrintRequestFactory() {
+
+		$instance = new QueryFactory();
+
+		$this->assertInstanceOf(
+			'\SMW\Query\PrintRequestFactory',
+			$instance->newPrintRequestFactory()
+		);
+	}
+
+	public function testCanConstructRequestOptions() {
+
+		$instance = new QueryFactory();
+
+		$this->assertInstanceOf(
+			'\SMW\RequestOptions',
+			$instance->newRequestOptions()
+		);
+	}
+
+	public function testCanConstructStringCondition() {
+
+		$instance = new QueryFactory();
+
+		$this->assertInstanceOf(
+			'\SMW\StringCondition',
+			$instance->newStringCondition( '', StringCondition::STRCOND_PRE )
+		);
+	}
+
+	public function testCanConstructQueryParser() {
+
+		$instance = new QueryFactory();
+
+		$this->assertInstanceOf(
+			'\SMWQueryParser',
+			$instance->newQueryParser()
+		);
+	}
+
+}


### PR DESCRIPTION
Sometimes it is necessary to only allow unique values to be assignable to a property (as for authority references).

For example, an authority reference to an entity like "Johann Sebastian Bach" (NDL ID 00432003 [0]) should only happen once.

The flag `SMW_DV_PVUC` is required to be added to `$GLOBALS['smwgDVFeatures']` (is not set by default) to enable the feature for general use.

A property which is expected to carry a uniqueness trait need to specify `[[Has uniqueness constraint::true]]`.

The first value the "system" finds and is not yet assigned will be the established (or unqiue) value with any value of the same literal representation being compared against.

refs #178

[0] 国立国会図書館典拠データ検索, http://id.ndl.go.jp/auth/ndlna/00432003