### PR TITLE
Filter "swivt:redirectsTo" in CompoundConditionBuilder

### DIFF
--- a/includes/export/SMW_Exporter.php
+++ b/includes/export/SMW_Exporter.php
@@ -313,8 +313,7 @@ class SMWExporter {
 				// Basic namespace filtering to ensure that types match for redirects etc.
 				/// TODO: currently no full check for avoiding OWL DL illegal redirects is done (OWL property type ignored)
 				if ( $filterNamespace && !( $dataItem instanceof SMWDIUri ) &&
-				     ( !( $dataItem instanceof SMWDIWikiPage ) ||
-				        ( $dataItem->getNamespace() != $diSubject->getNamespace() ) ) ) {
+				     ( !( $dataItem instanceof SMWDIWikiPage ) ) ) {
 					continue;
 				}
 

--- a/src/Maintenance/DistinctEntityDataRebuilder.php
+++ b/src/Maintenance/DistinctEntityDataRebuilder.php
@@ -247,7 +247,7 @@ class DistinctEntityDataRebuilder {
 			$this->store->getConnection( 'mw.db' )
 		);
 
-		return $titleLookup->selectAllRedirectPages();
+		return $titleLookup->getRedirectPages();
 	}
 
 	private function normalizeBulkOfPages( &$pages ) {

--- a/src/MediaWiki/TitleLookup.php
+++ b/src/MediaWiki/TitleLookup.php
@@ -90,20 +90,18 @@ class TitleLookup {
 	 *
 	 * @return Title[]
 	 */
-	public function selectAllRedirectPages() {
+	public function getRedirectPages() {
 
-		$tableName = 'redirect';
-		$fields = array( 'rd_namespace', 'rd_title' );
-		//$conditions = array( 'page_namespace' => $this->namespace );
 		$conditions = array();
-		$options = array( 'USE INDEX' => 'PRIMARY' );
+		$options = array();
 
 		$res = $this->connection->select(
-			$tableName,
-			$fields,
+			array( 'page', 'redirect' ),
+			array( 'page_namespace', 'page_title' ),
 			$conditions,
 			__METHOD__,
-			$options
+			$options,
+			array( 'page' => array( 'INNER JOIN', array( 'page_id=rd_from' ) ) )
 		);
 
 		return $this->makeTitlesFromSelection( $res );

--- a/src/SPARQLStore/QueryEngine/Condition/Condition.php
+++ b/src/SPARQLStore/QueryEngine/Condition/Condition.php
@@ -45,6 +45,14 @@ abstract class Condition {
 	public $weakConditions = array();
 
 	/**
+	 * Associative array of additional conditions that should can narrow
+	 * down the set of results,
+	 *
+	 * @var array of format "condition identifier" => "condition"
+	 */
+	public $cogentConditions = array();
+
+	/**
 	 * Associative array of additional namespaces that this condition
 	 * requires to be declared
 	 * @var array of format "shortName" => "namespace URI"
@@ -70,8 +78,16 @@ abstract class Condition {
 	 */
 	abstract public function isSafe();
 
+	public function addNamespaces( array $namespaces ) {
+		$this->namespaces = array_merge( $this->namespaces, $namespaces );
+	}
+
 	public function getWeakConditionString() {
 		return implode( '', $this->weakConditions );
+	}
+
+	public function getCogentConditionString() {
+		return implode( '', $this->cogentConditions );
 	}
 
 }

--- a/tests/phpunit/Integration/ByJsonScript/Fixtures/p-0904.json
+++ b/tests/phpunit/Integration/ByJsonScript/Fixtures/p-0904.json
@@ -1,0 +1,84 @@
+{
+	"description": "Test #ask with subject redirected to different NS (en)",
+	"properties": [
+		{
+			"name": "Has page",
+			"contents": "[[Has type::Page]]"
+		}
+	],
+	"subjects": [
+		{
+			"name": "Example/P0904/1",
+			"contents": "[[Has page::P0904]]"
+		},
+		{
+			"name": "Example/P0904/1",
+			"namespace" : "NS_HELP",
+			"contents": "[[Has page::P0904]]"
+		},
+		{
+			"name": "Example/P0904/1",
+			"contents": "#REDIRECT [[Help:Example/P0904/1]]"
+		},
+		{
+			"name": "Example/P0904/2",
+			"contents": "{{#ask: [[Has page::P0904]] |?Has page |format=table |link=none }}"
+		},
+		{
+			"name": "Example/P0904/3",
+			"contents": "{{#ask: [[~Example/P0904*]] |?Has page |format=table |link=none }}"
+		}
+	],
+	"parser-testcases": [
+		{
+			"about": "#0",
+			"subject": "Example/P0904/1",
+			"namespace" : "NS_HELP",
+			"store": {
+				"clear-cache": true,
+				"semantic-data": {
+					"strict-mode-valuematch": false,
+					"propertyCount": 3,
+					"propertyKeys": [ "_SKEY", "_MDAT", "Has_page" ],
+					"inproperty-keys":  [ "_REDI" ]
+				}
+			}
+		},
+		{
+			"about": "#1",
+			"subject": "Example/P0904/2",
+			"expected-output": {
+				"to-contain": [
+					"<td class=\"smwtype_wpg\">Help:Example/P0904/1</td><td class=\"Has-page smwtype_wpg\">P0904</td>"
+				]
+			}
+		},
+		{
+			"about": "#2 (redirected subject does not appear in result list)",
+			"subject": "Example/P0904/3",
+			"expected-output": {
+				"to-contain": [
+					"<td class=\"smwtype_wpg\">Help:Example/P0904/1</td><td class=\"Has-page smwtype_wpg\">P0904</td>"
+				],
+				"not-contain": [
+					"<td class=\"smwtype_wpg\">Example/P0904/1</td><td class=\"Has-page smwtype_wpg\">P0904</td>"
+				]
+			}
+		}
+	],
+	"settings": {
+		"wgContLang": "en",
+		"wgLang": "en",
+		"smwgPageSpecialProperties": [ "_MDAT" ],
+		"smwgNamespacesWithSemanticLinks": {
+			"NS_MAIN": true,
+			"NS_HELP": true,
+			"SMW_NS_PROPERTY": true
+		}
+	},
+	"meta": {
+		"version": "0.1",
+		"is-incomplete": false,
+		"debug": false
+	}
+}

--- a/tests/phpunit/Integration/ByJsonScript/ParserTestCaseProcessor.php
+++ b/tests/phpunit/Integration/ByJsonScript/ParserTestCaseProcessor.php
@@ -110,7 +110,7 @@ class ParserTestCaseProcessor extends \PHPUnit_Framework_TestCase {
 
 	private function assertParserOutputForCase( $case ) {
 
-		if ( !isset( $case['expected-output'] ) || !isset( $case['expected-output']['to-contain'] ) ) {
+		if ( !isset( $case['expected-output'] ) ) {
 			return;
 		}
 
@@ -121,11 +121,21 @@ class ParserTestCaseProcessor extends \PHPUnit_Framework_TestCase {
 
 		$parserOutput = UtilityFactory::getInstance()->newPageReader()->getEditInfo( $subject->getTitle() )->output;
 
-		$this->stringValidator->assertThatStringContains(
-			$case['expected-output']['to-contain'],
-			$parserOutput->getText(),
-			$case['about']
-		);
+		if ( isset( $case['expected-output']['to-contain'] ) ) {
+			$this->stringValidator->assertThatStringContains(
+				$case['expected-output']['to-contain'],
+				$parserOutput->getText(),
+				$case['about']
+			);
+		}
+
+		if ( isset( $case['expected-output']['not-contain'] ) ) {
+			$this->stringValidator->assertThatStringNotContains(
+				$case['expected-output']['not-contain'],
+				$parserOutput->getText(),
+				$case['about']
+			);
+		}
 	}
 
 	private function assertInProperties( DIWikiPage $subject, array $semanticdata, $about ) {

--- a/tests/phpunit/Unit/Maintenance/DistinctEntityDataRebuilderTest.php
+++ b/tests/phpunit/Unit/Maintenance/DistinctEntityDataRebuilderTest.php
@@ -3,6 +3,7 @@
 namespace SMW\Tests\Maintenance;
 
 use SMW\Maintenance\DistinctEntityDataRebuilder;
+use SMW\Tests\TestEnvironment;
 use SMW\Options;
 use Title;
 
@@ -20,11 +21,19 @@ class DistinctEntityDataRebuilderTest extends \PHPUnit_Framework_TestCase {
 
 	protected $obLevel;
 	private $connectionManager;
+	private $testEnvironment;
 
 	// The Store writes to the output buffer during drop/setupStore, to avoid
 	// inappropriate buffer settings which can cause interference during unit
 	// testing, we clean the output buffer
 	protected function setUp() {
+
+		$store = $this->getMockBuilder( '\SMW\Store' )
+			->disableOriginalConstructor()
+			->getMockForAbstractClass();
+
+		$this->testEnvironment = new TestEnvironment();
+		$this->testEnvironment->registerObject( 'Store', $store );
 
 		$connection = $this->getMockBuilder( '\SMW\MediaWiki\Database' )
 			->disableOriginalConstructor()
@@ -50,6 +59,7 @@ class DistinctEntityDataRebuilderTest extends \PHPUnit_Framework_TestCase {
 
 	protected function tearDown() {
 		parent::tearDown();
+		$this->testEnvironment->tearDown();
 
 		while ( ob_get_level() > $this->obLevel ) {
 			ob_end_clean();

--- a/tests/phpunit/Unit/MediaWiki/TitleLookupTest.php
+++ b/tests/phpunit/Unit/MediaWiki/TitleLookupTest.php
@@ -162,7 +162,7 @@ class TitleLookupTest extends \PHPUnit_Framework_TestCase {
 		$database->expects( $this->any() )
 			->method( 'select' )
 			->with(
-				$this->equalTo( 'redirect' ),
+				$this->equalTo( array( 'page', 'redirect' ) ),
 				$this->anything(),
 				$this->anything(),
 				$this->anything(),
@@ -172,7 +172,7 @@ class TitleLookupTest extends \PHPUnit_Framework_TestCase {
 		$instance = new TitleLookup( $database );
 
 		$this->assertArrayOfTitles(
-			$instance->selectAllRedirectPages()
+			$instance->getRedirectPages()
 		);
 	}
 

--- a/tests/phpunit/Unit/SPARQLStore/QueryEngine/CompoundConditionBuilderTest.php
+++ b/tests/phpunit/Unit/SPARQLStore/QueryEngine/CompoundConditionBuilderTest.php
@@ -72,6 +72,8 @@ class CompoundConditionBuilderTest extends \PHPUnit_Framework_TestCase {
 
 		$expectedConditionString = $this->stringBuilder
 			->addString( '?result property:Foo ?v1 .'  )->addNewLine()
+			->addString( ' OPTIONAL { ?result swivt:redirectsTo ?o2 } .'  )->addNewLine()
+			->addString( ' FILTER ( !bound( ?o2 ) ) .'  )->addNewLine()
 			->getString();
 
 		$this->assertEquals(
@@ -104,6 +106,8 @@ class CompoundConditionBuilderTest extends \PHPUnit_Framework_TestCase {
 			->addString( '?result property:Foo ?v1 .'  )->addNewLine()
 			->addString( '{ ?v1 swivt:wikiPageSortKey ?v1sk .'  )->addNewLine()
 			->addString( '}' )->addNewLine()
+			->addString( ' OPTIONAL { ?result swivt:redirectsTo ?o2 } .'  )->addNewLine()
+			->addString( ' FILTER ( !bound( ?o2 ) ) .'  )->addNewLine()
 			->getString();
 
 		$this->assertEquals(
@@ -137,6 +141,8 @@ class CompoundConditionBuilderTest extends \PHPUnit_Framework_TestCase {
 			->addString( '{ ?v2 swivt:wikiPageSortKey ?v2sk .'  )->addNewLine()
 			->addString( '}' )->addNewLine()
 			->addString( '?result property:Foo ?v1 .'  )->addNewLine()
+			->addString( ' OPTIONAL { ?result swivt:redirectsTo ?o3 } .'  )->addNewLine()
+			->addString( ' FILTER ( !bound( ?o3 ) ) .'  )->addNewLine()
 			->getString();
 
 		$this->assertEquals(
@@ -168,6 +174,8 @@ class CompoundConditionBuilderTest extends \PHPUnit_Framework_TestCase {
 		$expectedConditionString = $this->stringBuilder
 			->addString( '?result swivt:wikiPageSortKey ?resultsk .'  )->addNewLine()
 			->addString( '?result property:Foo ?v1 .'  )->addNewLine()
+			->addString( ' OPTIONAL { ?result swivt:redirectsTo ?o2 } .'  )->addNewLine()
+			->addString( ' FILTER ( !bound( ?o2 ) ) .'  )->addNewLine()
 			->getString();
 
 		$this->assertEquals(
@@ -210,6 +218,8 @@ class CompoundConditionBuilderTest extends \PHPUnit_Framework_TestCase {
 
 		$expectedConditionString = $this->stringBuilder
 			->addString( '"SomePropertyValue" swivt:page ?url .' )->addNewLine()
+			->addString( ' OPTIONAL { "SomePropertyValue" swivt:redirectsTo ?o1 } .'  )->addNewLine()
+			->addString( ' FILTER ( !bound( ?o1 ) ) .'  )->addNewLine()
 			->getString();
 
 		$this->assertEquals(
@@ -238,6 +248,8 @@ class CompoundConditionBuilderTest extends \PHPUnit_Framework_TestCase {
 
 		$expectedConditionString = $this->stringBuilder
 			->addString( '?result property:Foo "SomePropertyBlobValue" .'  )->addNewLine()
+			->addString( ' OPTIONAL { ?result swivt:redirectsTo ?o2 } .'  )->addNewLine()
+			->addString( ' FILTER ( !bound( ?o2 ) ) .'  )->addNewLine()
 			->getString();
 
 		$this->assertEquals(
@@ -269,6 +281,8 @@ class CompoundConditionBuilderTest extends \PHPUnit_Framework_TestCase {
 			->addString( '?result property:Foo ?v1 .' )->addNewLine()
 			->addString( 'FILTER( ?v1sk <= "SomePropertyPageValue" )' )->addNewLine()
 			->addString( '?v1 swivt:wikiPageSortKey ?v1sk .' )->addNewLine()
+			->addString( ' OPTIONAL { ?result swivt:redirectsTo ?o2 } .'  )->addNewLine()
+			->addString( ' FILTER ( !bound( ?o2 ) ) .'  )->addNewLine()
 			->getString();
 
 		$this->assertEquals(
@@ -299,6 +313,8 @@ class CompoundConditionBuilderTest extends \PHPUnit_Framework_TestCase {
 		$expectedConditionString = $this->stringBuilder
 			->addString( '?result property:Foo ?v1 .' )->addNewLine()
 			->addString( 'FILTER( !regex( ?v1, "^SomePropertyBlobValue$", "s") )' )->addNewLine()
+			->addString( ' OPTIONAL { ?result swivt:redirectsTo ?o2 } .'  )->addNewLine()
+			->addString( ' FILTER ( !bound( ?o2 ) ) .'  )->addNewLine()
 			->getString();
 
 		$this->assertEquals(
@@ -330,6 +346,8 @@ class CompoundConditionBuilderTest extends \PHPUnit_Framework_TestCase {
 
 		$expectedConditionString = $this->stringBuilder
 			->addString( "{ ?result rdf:type $categoryName . }" )->addNewLine()
+			->addString( ' OPTIONAL { ?result swivt:redirectsTo ?o1 } .'  )->addNewLine()
+			->addString( ' FILTER ( !bound( ?o1 ) ) .'  )->addNewLine()
 			->getString();
 
 		$this->assertEquals(
@@ -355,6 +373,8 @@ class CompoundConditionBuilderTest extends \PHPUnit_Framework_TestCase {
 
 		$expectedConditionString = $this->stringBuilder
 			->addString( '{ ?result swivt:wikiNamespace "12"^^xsd:integer . }' )->addNewLine()
+			->addString( ' OPTIONAL { ?result swivt:redirectsTo ?o1 } .'  )->addNewLine()
+			->addString( ' FILTER ( !bound( ?o1 ) ) .'  )->addNewLine()
 			->getString();
 
 		$this->assertEquals(
@@ -384,6 +404,8 @@ class CompoundConditionBuilderTest extends \PHPUnit_Framework_TestCase {
 		$expectedConditionString = $this->stringBuilder
 			->addString( '?result property:Foo "SomePropertyValue" .' )->addNewLine()
 			->addString( '?result property:Bar ?v2 .' )->addNewLine()
+			->addString( ' OPTIONAL { ?result swivt:redirectsTo ?o3 } .'  )->addNewLine()
+			->addString( ' FILTER ( !bound( ?o3 ) ) .'  )->addNewLine()
 			->getString();
 
 		$this->assertEquals(
@@ -417,6 +439,8 @@ class CompoundConditionBuilderTest extends \PHPUnit_Framework_TestCase {
 			->addString( 'FILTER( ?v1 >= "1"^^xsd:double )' )->addNewLine()
 			->addString( '?result property:Bar ?v2 .' )->addNewLine()
 			->addString( 'FILTER( ?v2 <= "9"^^xsd:double )' )->addNewLine()
+			->addString( ' OPTIONAL { ?result swivt:redirectsTo ?o3 } .'  )->addNewLine()
+			->addString( ' FILTER ( !bound( ?o3 ) ) .'  )->addNewLine()
 			->getString();
 
 		$this->assertEquals(
@@ -447,6 +471,9 @@ class CompoundConditionBuilderTest extends \PHPUnit_Framework_TestCase {
 			->addString( '} UNION {' )->addNewLine()
 			->addString( '?result property:Bar ?v2 .' )->addNewLine()
 			->addString( '}' )
+			->addString( ' OPTIONAL { ?result swivt:redirectsTo ?o3 } .'  )->addNewLine()
+			->addString( ' FILTER ( !bound( ?o3 ) ) .'  )->addNewLine()
+
 			->getString();
 
 		$this->assertEquals(
@@ -483,6 +510,8 @@ class CompoundConditionBuilderTest extends \PHPUnit_Framework_TestCase {
 			->addString( '?result property:Bar ?v2 .' )->addNewLine()
 			->addString( 'FILTER( !regex( ?v2, "^BB.$", "s") )' )->addNewLine()
 			->addString( '}' )
+			->addString( ' OPTIONAL { ?result swivt:redirectsTo ?o3 } .'  )->addNewLine()
+			->addString( ' FILTER ( !bound( ?o3 ) ) .'  )->addNewLine()
 			->getString();
 
 		$this->assertEquals(
@@ -513,6 +542,8 @@ class CompoundConditionBuilderTest extends \PHPUnit_Framework_TestCase {
 		$expectedConditionString = $this->stringBuilder
 			->addString( '?result property:SomeDateProperty-23aux ?v1 .' )->addNewLine()
 			->addString( 'FILTER( ?v1 >= "2440587.5423611"^^xsd:double )' )->addNewLine()
+			->addString( ' OPTIONAL { ?result swivt:redirectsTo ?o2 } .'  )->addNewLine()
+			->addString( ' FILTER ( !bound( ?o2 ) ) .'  )->addNewLine()
 			->getString();
 
 		$this->assertEquals(
@@ -541,6 +572,8 @@ class CompoundConditionBuilderTest extends \PHPUnit_Framework_TestCase {
 
 		$expectedConditionString = $this->stringBuilder
 			->addString( '?result property:Has_subobject ?v1 .' )->addNewLine()
+			->addString( ' OPTIONAL { ?result swivt:redirectsTo ?o2 } .'  )->addNewLine()
+			->addString( ' FILTER ( !bound( ?o2 ) ) .'  )->addNewLine()
 			->getString();
 
 		$this->assertEquals(
@@ -579,6 +612,8 @@ class CompoundConditionBuilderTest extends \PHPUnit_Framework_TestCase {
 		$expectedConditionString = $this->stringBuilder
 			->addString( '?result property:HasSomeProperty ?v1 .' )->addNewLine()
 			->addString( 'FILTER( ?v1 = wiki:Foo || ?v1 = wiki:Bar )' )->addNewLine()
+			->addString( ' OPTIONAL { ?result swivt:redirectsTo ?o2 } .'  )->addNewLine()
+			->addString( ' FILTER ( !bound( ?o2 ) ) .'  )->addNewLine()
 			->getString();
 
 		$this->assertEquals(
@@ -632,6 +667,8 @@ class CompoundConditionBuilderTest extends \PHPUnit_Framework_TestCase {
 			->addString( "{ ?v1 rdf:type $categoryName . }" )->addNewLine()
 			->addString( '?v1 property:Located_in wiki:Outback .' )->addNewLine()
 			->addString( '}' )->addNewLine()
+			->addString( ' OPTIONAL { ?result swivt:redirectsTo ?o3 } .'  )->addNewLine()
+			->addString( ' FILTER ( !bound( ?o3 ) ) .'  )->addNewLine()
 			->getString();
 
 		$this->assertEquals(
@@ -669,6 +706,8 @@ class CompoundConditionBuilderTest extends \PHPUnit_Framework_TestCase {
 			->addString( '?result property:LocatedIn ?v1 .' )->addNewLine()
 			->addString( '{ ?v1 property:MemberOf wiki:Wonderland .' )->addNewLine()
 			->addString( '}' )->addNewLine()
+			->addString( ' OPTIONAL { ?result swivt:redirectsTo ?o3 } .'  )->addNewLine()
+			->addString( ' FILTER ( !bound( ?o3 ) ) .'  )->addNewLine()
 			->getString();
 
 		$this->assertEquals(
@@ -781,6 +820,8 @@ class CompoundConditionBuilderTest extends \PHPUnit_Framework_TestCase {
 		$expectedConditionString = $this->stringBuilder
 			->addString( '?r2 ^swivt:redirectsTo wiki:Bar .' )->addNewLine()
 			->addString( '?result property:Foo ?r2 .' )->addNewLine()
+			->addString( ' OPTIONAL { ?result swivt:redirectsTo ?o3 } .'  )->addNewLine()
+			->addString( ' FILTER ( !bound( ?o3 ) ) .'  )->addNewLine()
 			->getString();
 
 		$this->assertEquals(
@@ -830,6 +871,8 @@ class CompoundConditionBuilderTest extends \PHPUnit_Framework_TestCase {
 			->addString( '?result swivt:wikiPageSortKey ?resultsk .' )->addNewLine()
 			->addString( '?r1 ^swivt:redirectsTo wiki:Bar .' )->addNewLine()
 			->addString( 'FILTER( ?result = ?r1 )' )->addNewLine()
+			->addString( ' OPTIONAL { ?result swivt:redirectsTo ?o2 } .'  )->addNewLine()
+			->addString( ' FILTER ( !bound( ?o2 ) ) .'  )->addNewLine()
 			->getString();
 
 		$this->assertEquals(
@@ -856,6 +899,8 @@ class CompoundConditionBuilderTest extends \PHPUnit_Framework_TestCase {
 		$expectedConditionString = $this->stringBuilder
 			->addString( 'FILTER( regex( ?v1, "^Foo.*$", "s") )' )->addNewLine()
 			->addString( '?result swivt:wikiPageSortKey ?v1 .' )->addNewLine()
+			->addString( ' OPTIONAL { ?result swivt:redirectsTo ?o2 } .'  )->addNewLine()
+			->addString( ' FILTER ( !bound( ?o2 ) ) .'  )->addNewLine()
 			->getString();
 
 		$this->assertEquals(

--- a/tests/phpunit/Utils/Validators/StringValidator.php
+++ b/tests/phpunit/Utils/Validators/StringValidator.php
@@ -17,7 +17,7 @@ class StringValidator extends \PHPUnit_Framework_Assert {
 	 * @param string $actual
 	 */
 	public function assertThatStringContains( $expected, $actual, $message = '' ) {
-		$this->doAssertFor( $expected, $actual, $message, function( $actual, &$expected, &$actualCounted ) {
+		$this->doAssertFor( $expected, $actual, $message, 'StringContains', function( $actual, &$expected, &$actualCounted ) {
 			foreach ( $expected as $key => $string ) {
 				if ( strpos( $actual, $string ) !== false ) {
 					$actualCounted++;
@@ -34,7 +34,7 @@ class StringValidator extends \PHPUnit_Framework_Assert {
 	 * @param string $actual
 	 */
 	public function assertThatStringNotContains( $expected, $actual, $message = '' ) {
-		$this->doAssertFor( $expected, $actual, $message, function( $actual, &$expected, &$actualCounted ) {
+		$this->doAssertFor( $expected, $actual, $message, 'StringNotContains', function( $actual, &$expected, &$actualCounted ) {
 			foreach ( $expected as $key => $string ) {
 				if ( strpos( $actual, $string ) === false ) {
 					$actualCounted++;
@@ -44,7 +44,7 @@ class StringValidator extends \PHPUnit_Framework_Assert {
 		} );
 	}
 
-	private function doAssertFor( $expected, $actual, $message = '', $callback ) {
+	private function doAssertFor( $expected, $actual, $message = '', $method = '', $callback ) {
 
 		if ( !is_array( $expected ) ) {
 			$expected = array( $expected );
@@ -72,7 +72,7 @@ class StringValidator extends \PHPUnit_Framework_Assert {
 		self::assertEquals(
 			$expectedToCount,
 			$actualCounted,
-			"Failed on `{$message}` for $actual with " . $this->toString( $expected )
+			"Failed on `{$message}` for $actual with ($method) " . $this->toString( $expected )
 		);
 	}
 


### PR DESCRIPTION
- Remove entities that contain a "swivt:redirectsTo" predicate to avoid results sets contain duplicate entries
- `TitleLookup` to actual return the redirect source not the targets (only relevent for `--redirects` option of `rebuildData.php`)