### PR TITLE
Add "native" fulltext search support (MySQL/MariaDB)

### DIFF
--- a/DefaultSettings.php
+++ b/DefaultSettings.php
@@ -990,3 +990,100 @@ $GLOBALS['smwgEnabledInTextAnnotationParserStrictMode'] = true;
 # @since 2.4
 ##
 $GLOBALS['smwgDVFeatures'] = SMW_DV_PROV_REDI | SMW_DV_MLTV_LCODE | SMW_DV_PVAP | SMW_DV_WPV_DTITLE | SMW_DV_TIMEV_CM;
+
+##
+# Fulltext search support
+#
+# If enabled, it will store text elements using a separate table in order for the
+# DB back-end to use special fulltext index operations.
+#
+# - Tested with MySQL/MariaDB
+#
+# @since 2.5
+##
+$GLOBALS['smwgEnabledFulltextSearch'] = false;
+
+##
+# Throttle the amount of expected index updates.
+#
+# It can be of advantage to postpone the update using a deferred job execution to
+# decouple changes to the storage back-end and the fulltext index table.
+#
+# In case `smwgFulltextDeferredUpdate` and `$GLOBALS['smwgEnabledDeferredUpdate']` are
+# enabled then the updater will try to open a new process for posting instructions
+# to execute the `SearchTableUpdateJob` immediately otherwise `SearchTableUpdateJob`
+# will be enqueued and `runJobs.php` is required to be schedule for execution.
+#
+# If a user wants to avoid the JobQueue for executing updates via `SearchTableUpdateJob`
+# then this setting should be disabled.
+#
+# @since 2.5
+# @default true
+##
+$GLOBALS['smwgFulltextDeferredUpdate'] = true;
+
+##
+# Fulltext search table options
+#
+# This setting directly influences how a ft table is created therefore please
+# change the content with caution.
+#
+# - MySQL version 5.6 or later with only MyISAM and InnoDB storage engines
+# to support full-text search (according to sources)
+#
+# - MariaDB full-text indexes can be used only with MyISAM and Aria tables,
+# from MariaDB 10.0.5 with InnoDB tables and from MariaDB 10.0.15
+# with Mroonga tables (according to sources)
+#
+# It is possible to extend the option decription (MySQL 5.7+)  with
+# 'mysql' => array( 'ENGINE=MyISAM, DEFAULT CHARSET=utf8', 'WITH PARSER ngram' )
+#
+# @since 2.5
+##
+$GLOBALS['smwgFulltextSearchTableOptions'] = array(
+	'mysql' => array( 'ENGINE=MyISAM, DEFAULT CHARSET=utf8' )
+);
+
+##
+# List of property keys for which value assignments are being exempted from the
+# fulltext indexing process because there are either insignificant or mostly
+# represent single terms which are not required to be searched via a FT or a
+# proximity.
+#
+# Listed properties will use the standard LIKE/NLIKE expression when used in
+# connection with the ~/!~ operator.
+#
+# @since 2.5
+##
+$GLOBALS['smwgFulltextSearchPropertyExemptionList'] = array(
+	'_ASKFO', '_ASKST', '_IMPO', '_LCODE', '_UNIT', '_CONV', '_TYPE', '_ERRT'
+);
+
+##
+# Describes the minimum word/token length to help to decide whether MATCH or LIKE
+# operators are to be used for a condition statement.
+#
+# For MySQL it is expected it corresponds to either innodb_ft_min_token_size or
+# ft_min_word_len
+#
+# @since 2.5
+##
+$GLOBALS['smwgFulltextSearchMinTokenSize'] = 3;
+
+##
+# To detect a possible language candidate from an indexable text element.
+#
+# TextCatLanguageDetector, a large list of languages does have a detrimental
+# influence on the performance when trying to detect a language from a free text.
+#
+# Stopwords are only applied after language detection has been enabled.
+#
+# @see https://github.com/wikimedia/wikimedia-textcat
+#
+# @since 2.5
+# @default empty list (language detection is disabled by default)
+##
+$GLOBALS['smwgFulltextLanguageDetection'] = array(
+//	'TextCatLanguageDetector' => array( 'en', 'de', 'fr', 'es', 'ja', 'zh' )
+//	'CdbNGramLanguageDetector' => array( 'en', 'de', 'fr', 'es', 'ja', 'zh' )
+);

--- a/composer.json
+++ b/composer.json
@@ -48,7 +48,8 @@
 		"onoi/event-dispatcher": "~1.0",
 		"onoi/blob-store": "~1.2",
 		"onoi/http-request": "~1.1",
-		"onoi/callback-container": "~1.0"
+		"onoi/callback-container": "~1.0",
+		"onoi/tesa": "~0.1"
 	},
 	"require-dev": {
 		"squizlabs/php_codesniffer": "~2.1",

--- a/includes/Settings.php
+++ b/includes/Settings.php
@@ -139,6 +139,12 @@ class Settings extends Options {
 			'smwgEnabledInTextAnnotationParserStrictMode' => $GLOBALS['smwgEnabledInTextAnnotationParserStrictMode'],
 			'smwgSparqlRepositoryConnectorForcedHttpVersion' => $GLOBALS['smwgSparqlRepositoryConnectorForcedHttpVersion'],
 			'smwgDVFeatures' => $GLOBALS['smwgDVFeatures'],
+			'smwgEnabledFulltextSearch' => $GLOBALS['smwgEnabledFulltextSearch'],
+			'smwgFulltextDeferredUpdate' => $GLOBALS['smwgFulltextDeferredUpdate'],
+			'smwgFulltextSearchTableOptions' => $GLOBALS['smwgFulltextSearchTableOptions'],
+			'smwgFulltextSearchPropertyExemptionList' => $GLOBALS['smwgFulltextSearchPropertyExemptionList'],
+			'smwgFulltextSearchMinTokenSize' => $GLOBALS['smwgFulltextSearchMinTokenSize'],
+			'smwgFulltextLanguageDetection' => $GLOBALS['smwgFulltextLanguageDetection']
 		);
 
 		$settings = $settings + array(
@@ -168,6 +174,27 @@ class Settings extends Options {
 	 */
 	public static function newFromArray( array $settings ) {
 		return new self( $settings );
+	}
+
+	/**
+	 * @since 2.5
+	 *
+	 * @param string $key
+	 * @param mixed $value
+	 */
+	public function add( $key, $value ) {
+
+		if ( !$this->has( $key ) ) {
+			return $this->set( $key, $value );
+		}
+
+		$val = $this->get( $key );
+
+		if ( is_array( $val ) ) {
+			$value = array_merge_recursive( $val, $value );
+		}
+
+		return $this->set( $key, $value );
 	}
 
 	/**

--- a/includes/Setup.php
+++ b/includes/Setup.php
@@ -206,6 +206,7 @@ final class Setup {
 		$this->globalVars['wgJobClasses']['SMW\RefreshJob'] = 'SMW\MediaWiki\Jobs\RefreshJob';
 		$this->globalVars['wgJobClasses']['SMW\UpdateDispatcherJob'] = 'SMW\MediaWiki\Jobs\UpdateDispatcherJob';
 		$this->globalVars['wgJobClasses']['SMW\ParserCachePurgeJob'] = 'SMW\MediaWiki\Jobs\ParserCachePurgeJob';
+		$this->globalVars['wgJobClasses']['SMW\SearchTableUpdateJob'] = 'SMW\MediaWiki\Jobs\SearchTableUpdateJob';
 
 		// Legacy definition to be removed with 1.10
 		$this->globalVars['wgJobClasses']['SMWUpdateJob']  = 'SMW\MediaWiki\Jobs\UpdateJob';

--- a/includes/storage/SQLStore/SMW_SQLStore3.php
+++ b/includes/storage/SQLStore/SMW_SQLStore3.php
@@ -77,6 +77,11 @@ class SMWSQLStore3 extends SMWStore {
 	const QUERY_LINKS_TABLE = 'smw_query_links';
 
 	/**
+	 * Name of the table that manages the fulltext index
+	 */
+	const FT_SEARCH_TABLE = 'smw_ft_search';
+
+	/**
 	 * Name of the table that manages the Store IDs
 	 */
 	const ID_TABLE = 'smw_object_ids';

--- a/includes/storage/SQLStore/SMW_SQLStore3_SetupHandlers.php
+++ b/includes/storage/SQLStore/SMW_SQLStore3_SetupHandlers.php
@@ -173,6 +173,36 @@ class SMWSQLStore3SetupHandlers implements MessageReporter {
 			)
 		);
 
+		// TEXT and BLOB is stored off the table with the table just having a pointer
+		// VARCHAR is stored inline with the table
+		$rdbmsTableBuilder->createTable(
+			SMWSQLStore3::FT_SEARCH_TABLE,
+			array(
+				'fields' => array(
+					's_id' => $dbtypes['p'] . ' NOT NULL',
+					'p_id' => $dbtypes['p'] . ' NOT NULL',
+					'o_text' => 'TEXT',
+					'o_sort' => $dbtypes['t'],
+				),
+				'wgDBname' => $GLOBALS['wgDBname'],
+				'wgDBTableOptions' => $GLOBALS['wgDBTableOptions'],
+				'ftSearchOptions'  => $GLOBALS['smwgFulltextSearchTableOptions']
+			)
+		);
+
+		$rdbmsTableBuilder->createIndex(
+			SMWSQLStore3::FT_SEARCH_TABLE,
+			array(
+				'indicies' => array(
+					's_id',
+					'p_id',
+					'o_sort',
+					array( 'o_text', 'FULLTEXT' )
+				),
+				'ftSearchOptions' => $GLOBALS['smwgFulltextSearchTableOptions']
+			)
+		);
+
 		// Set up table for stats on Properties (only counts for now)
 		$rdbmsTableBuilder->createTable(
 			SMWSQLStore3::PROPERTY_STATISTICS_TABLE,
@@ -345,7 +375,8 @@ class SMWSQLStore3SetupHandlers implements MessageReporter {
 			SMWSQLStore3::ID_TABLE,
 			SMWSQLStore3::CONCEPT_CACHE_TABLE,
 			SMWSQLStore3::PROPERTY_STATISTICS_TABLE,
-			SMWSQLStore3::QUERY_LINKS_TABLE
+			SMWSQLStore3::QUERY_LINKS_TABLE,
+			SMWSQLStore3::FT_SEARCH_TABLE
 		);
 
 		foreach ( $this->store->getPropertyTables() as $proptable ) {

--- a/maintenance/rebuildFulltextSearchTable.php
+++ b/maintenance/rebuildFulltextSearchTable.php
@@ -1,0 +1,123 @@
+<?php
+
+namespace SMW\Maintenance;
+
+use Onoi\MessageReporter\MessageReporterFactory;
+use SMW\SQLStore\QueryEngine\FulltextSearchTableFactory;
+use SMW\ApplicationFactory;
+
+$basePath = getenv( 'MW_INSTALL_PATH' ) !== false ? getenv( 'MW_INSTALL_PATH' ) : __DIR__ . '/../../..';
+
+require_once $basePath . '/maintenance/Maintenance.php';
+
+/**
+ * @license GNU GPL v2+
+ * @since 2.4
+ *
+ * @author mwjames
+ */
+class RebuildFulltextSearchTable extends \Maintenance {
+
+	public function __construct() {
+		$this->mDescription = 'Rebuild the fulltext search index (only works with SQLStore)';
+		$this->addOption( 'report-runtime', 'Report execution time and memory usage', false );
+
+		parent::__construct();
+	}
+
+	/**
+	 * @see Maintenance::execute
+	 */
+	public function execute() {
+
+		if ( !defined( 'SMW_VERSION' ) ) {
+			$this->output( "You need to have SMW enabled in order to use this maintenance script!\n\n" );
+			exit;
+		}
+
+		$applicationFactory = ApplicationFactory::getInstance();
+		$maintenanceFactory = $applicationFactory->newMaintenanceFactory();
+
+		$fulltextSearchTableFactory = new FulltextSearchTableFactory();
+
+		// Only the SQLStore is supported
+		$searchTableRebuilder = $fulltextSearchTableFactory->newSearchTableRebuilder(
+			$applicationFactory->getStore( '\SMW\SQLStore\SQLStore' )
+		);
+
+		$this->reportMessage(
+			"\nThe script rebuilds the search index from property tables that\n" .
+			"support a fulltext search. Any change of the index rules (altered\n".
+			"stopwords, new stemmer etc.) and/or a newly added or altered table\n".
+			"requires to run this script again to ensure that the index complies\n".
+			"with the rules set forth by the DB or Sanitizer.\n\n"
+		);
+
+		$searchTable = $searchTableRebuilder->getSearchTable();
+
+		foreach ( $searchTable->getTextSanitizer()->getVersions() as $key => $value ) {
+			$this->reportMessage( "\r". sprintf( "%-35s%s", "- {$key}", $value )  . "\n" );
+		}
+
+		$this->reportMessage(
+			"\nThe following properties are exempted from the fulltext search index.\n"
+		);
+
+		$exemptionList = '';
+
+		foreach ( $searchTable->getPropertyExemptionList() as $prop ) {
+			$exemptionList .= ( $exemptionList === '' ? '' : ', ' ) . $prop;
+
+			if ( strlen( $exemptionList ) > 60 ) {
+				$this->reportMessage( "\n- " . $exemptionList );
+				$exemptionList = '';
+			}
+		}
+
+		$this->reportMessage( "\n- " . $exemptionList . "\n\n" );
+
+		$this->reportMessage(
+			"The entire index table is going to be purged first and \n" .
+			"it may take a moment before the rebuild is completed due to\n" .
+			"dependencies on table content and selected options.\n"
+		);
+
+		$this->reportMessage( "\n" . 'Abort the rebuild with control-c in the next five seconds ...  ' );
+		wfCountDown( 5 );
+
+		$maintenanceHelper = $maintenanceFactory->newMaintenanceHelper();
+		$maintenanceHelper->initRuntimeValues();
+
+		// Need to instantiate an extra object here since we cannot make this class itself
+		// into a MessageReporter since the maintenance script does not load the interface in time.
+		$reporter = MessageReporterFactory::getInstance()->newObservableMessageReporter();
+		$reporter->registerReporterCallback( array( $this, 'reportMessage' ) );
+
+		$searchTableRebuilder->setMessageReporter( $reporter );
+		$result = $searchTableRebuilder->run();
+
+		if ( $result && $this->hasOption( 'report-runtime' ) ) {
+			$this->reportMessage(
+				"\n" . $maintenanceHelper->transformRuntimeValuesForOutput() . "\n"
+			);
+		}
+
+		$maintenanceHelper->reset();
+		return $result;
+	}
+
+	/**
+	 * @see Maintenance::reportMessage
+	 *
+	 * @since 1.9
+	 *
+	 * @param string $message
+	 */
+	public function reportMessage( $message ) {
+		$this->output( $message );
+	}
+
+}
+
+$maintClass = 'SMW\Maintenance\RebuildFulltextSearchTable';
+require_once ( RUN_MAINTENANCE_IF_MAIN );

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -64,6 +64,7 @@
        <var name="smwgSparqlDefaultGraph" value="http://example.org/phpunit-testrun"/>
        <var name="smwgValueLookupCacheType" value="hash"/>
        <var name="smwgEnabledDeferredUpdate" value="false"/>
+       <var name="smwgEnabledFulltextSearch" value="false"/>
        <var name="smwgEnabledHttpDeferredJobRequest" value="false"/>
        <var name="smwgEnabledQueryDependencyLinksStore" value="true"/>
        <var name="benchmarkQueryRepetitionExecutionThreshold" value="5"/>

--- a/src/MediaWiki/Hooks/HookRegistry.php
+++ b/src/MediaWiki/Hooks/HookRegistry.php
@@ -9,6 +9,7 @@ use ParserHooks\HookRegistrant;
 use SMW\ApplicationFactory;
 use SMW\DeferredRequestDispatchManager;
 use SMW\NamespaceManager;
+use SMW\SQLStore\QueryEngine\FulltextSearchTableFactory;
 use SMW\ParserFunctions\DocumentationParserFunction;
 use SMW\ParserFunctions\InfoParserFunction;
 use SMW\PermissionPthValidator;
@@ -518,6 +519,18 @@ class HookRegistry {
 			$deferredRequestDispatchManager->dispatchParserCachePurgeJobFor(
 				$semanticData->getSubject()->getTitle(),
 				$jobParameters
+			);
+
+			$fulltextSearchTableFactory = new FulltextSearchTableFactory();
+
+			$textByChangeUpdater = $fulltextSearchTableFactory->newTextByChangeUpdater(
+				$store
+			);
+
+			$textByChangeUpdater->pushUpdates(
+				$semanticData->getSubject(),
+				$compositePropertyTableDiffIterator,
+				$deferredRequestDispatchManager
 			);
 
 			return true;

--- a/src/MediaWiki/Jobs/JobFactory.php
+++ b/src/MediaWiki/Jobs/JobFactory.php
@@ -48,4 +48,16 @@ class JobFactory {
 		return new ParserCachePurgeJob( $title, $parameters );
 	}
 
+	/**
+	 * @since 2.5
+	 *
+	 * @param Title $title
+	 * @param array $parameters
+	 *
+	 * @return SearchTableUpdateJob
+	 */
+	public function newSearchTableUpdateJob( Title $title, array $parameters = array() ) {
+		return new SearchTableUpdateJob( $title, $parameters );
+	}
+
 }

--- a/src/MediaWiki/Jobs/SearchTableUpdateJob.php
+++ b/src/MediaWiki/Jobs/SearchTableUpdateJob.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace SMW\MediaWiki\Jobs;
+
+use Hooks;
+use SMW\ApplicationFactory;
+use SMW\SQLStore\QueryEngine\FulltextSearchTableFactory;
+use Title;
+
+/**
+ * @license GNU GPL v2+
+ * @since 2.5
+ *
+ * @author mwjames
+ */
+class SearchTableUpdateJob extends JobBase {
+
+	/**
+	 * @since 2.5
+	 *
+	 * @param Title $title
+	 * @param array $params job parameters
+	 */
+	public function __construct( Title $title, $params = array() ) {
+		parent::__construct( 'SMW\SearchTableUpdateJob', $title, $params );
+	}
+
+	/**
+	 * @see Job::run
+	 *
+	 * @since  2.5
+	 */
+	public function run() {
+
+		$fulltextSearchTableFactory = new FulltextSearchTableFactory();
+
+		$textByChangeUpdater = $fulltextSearchTableFactory->newTextByChangeUpdater(
+			ApplicationFactory::getInstance()->getStore( '\SMW\SQLStore\SQLStore' )
+		);
+
+		$textByChangeUpdater->pushUpdatesFromJobParameters(
+			$this->params
+		);
+
+		Hooks::run( 'SMW::Job::AfterSearchTableUpdateComplete', array( $this ) );
+
+		return true;
+	}
+
+}

--- a/src/MediaWiki/Specials/SpecialDeferredRequestDispatcher.php
+++ b/src/MediaWiki/Specials/SpecialDeferredRequestDispatcher.php
@@ -106,6 +106,9 @@ class SpecialDeferredRequestDispatcher extends SpecialPage {
 			case 'SMW\ParserCachePurgeJob':
 				$this->runParserCachePurgeJob( $title, $parameters );
 				break;
+			case 'SMW\SearchTableUpdateJob':
+				$this->runSearchTableUpdateJob( $title, $parameters );
+				break;
 			case 'SMW\UpdateJob':
 				$this->runUpdateJob( $title, $parameters );
 				break;
@@ -150,6 +153,16 @@ class SpecialDeferredRequestDispatcher extends SpecialPage {
 		);
 
 		$purgeParserCacheJob->run();
+	}
+
+	private function runSearchTableUpdateJob( $title, $parameters ) {
+
+		$searchTableUpdateJob = ApplicationFactory::getInstance()->newJobFactory()->newSearchTableUpdateJob(
+			$title,
+			$parameters
+		);
+
+		$searchTableUpdateJob->run();
 	}
 
 	private function runUpdateJob( $title, $parameters ) {

--- a/src/SQLStore/PropertyTableIdReferenceDisposer.php
+++ b/src/SQLStore/PropertyTableIdReferenceDisposer.php
@@ -124,6 +124,12 @@ class PropertyTableIdReferenceDisposer {
 			array( 'o_id' => $id ),
 			__METHOD__
 		);
+
+		$this->connection->delete(
+			SQLStore::FT_SEARCH_TABLE,
+			array( 's_id' => $id ),
+			__METHOD__
+		);
 	}
 
 }

--- a/src/SQLStore/QueryEngine/Fulltext/MySQLValueMatchConditionBuilder.php
+++ b/src/SQLStore/QueryEngine/Fulltext/MySQLValueMatchConditionBuilder.php
@@ -1,0 +1,181 @@
+<?php
+
+namespace SMW\SQLStore\QueryEngine\Fulltext;
+
+use SMW\Query\Language\ValueDescription;
+
+/**
+ * @license GNU GPL v2+
+ * @since 2.5
+ *
+ * @author mwjames
+ */
+class MySQLValueMatchConditionBuilder extends ValueMatchConditionBuilder {
+
+	/**
+	 * @var SearchTable
+	 */
+	private $searchTable;
+
+	/**
+	 * @since 2.5
+	 *
+	 * @param SearchTable $searchTable
+	 */
+	public function __construct( SearchTable $searchTable ) {
+		$this->searchTable = $searchTable;
+	}
+
+	/**
+	 * @since 2.5
+	 *
+	 * @return boolean
+	 */
+	public function isEnabled() {
+		return $this->searchTable->isEnabled();
+	}
+
+	/**
+	 * @since 2.5
+	 *
+	 * @return string
+	 */
+	public function getTableName() {
+		return $this->searchTable->getTableName();
+	}
+
+	/**
+	 * @since 2.5
+	 *
+	 * @param string $value
+	 *
+	 * @return boolean
+	 */
+	public function hasMinTokenLength( $value ) {
+		return mb_strlen( $value ) >= $this->searchTable->getMinTokenSize();
+	}
+
+	/**
+	 * @since 2.5
+	 *
+	 * @param string $temporaryTable
+	 *
+	 * @return string
+	 */
+	public function getSortIndexField( $temporaryTable = '' ) {
+		return ( $temporaryTable !== '' ? $temporaryTable . '.' : '' ) . $this->searchTable->getSortField();
+	}
+
+	/**
+	 * @since 2.5
+	 *
+	 * @param ValueDescription $description
+	 *
+	 * @return boolean
+	 */
+	public function canApplyFulltextSearchMatchCondition( ValueDescription $description ) {
+
+		if ( !$this->isEnabled() || $description->getProperty() === null ) {
+			return false;
+		}
+
+		if ( $this->searchTable->isExemptedProperty( $description->getProperty() ) ) {
+			return false;
+		}
+
+		$matchableText = $this->getMatchableTextFromDescription(
+			$description
+		);
+
+		$comparator = $description->getComparator();
+
+		if ( $matchableText && ( $comparator === SMW_CMP_LIKE || $comparator === SMW_CMP_NLKE ) ) {
+			// http://dev.mysql.com/doc/refman/5.7/en/fulltext-boolean.html
+			// innodb_ft_min_token_size and innodb_ft_max_token_size are used
+			// for InnoDB search indexes. ft_min_word_len and ft_max_word_len
+			// are used for MyISAM search indexes
+
+			// Don't count any wildcard
+			return $this->hasMinTokenLength( str_replace( '*', '', $matchableText ) );
+		}
+
+		return false;
+	}
+
+	/**
+	 * @since 2.5
+	 *
+	 * @param ValueDescription $description
+	 * @param string $temporaryTable
+	 *
+	 * @return string
+	 */
+	public function getWhereCondition( ValueDescription $description, $temporaryTable = '' ) {
+
+		$matchableText = $this->getMatchableTextFromDescription(
+			$description
+		);
+
+		$value = $this->searchTable->getTextSanitizer()->sanitize(
+			$matchableText,
+			true
+		);
+
+		// A leading or trailing minus sign indicates that this word must not
+		// be present in any of the rows that are returned.
+		// InnoDB only supports leading minus signs.
+		if ( $description->getComparator() === SMW_CMP_NLKE ) {
+			$value = '-' . $value;
+		}
+
+		$temporaryTable = $temporaryTable !== '' ? $temporaryTable . '.' : '';
+		$column = $temporaryTable . $this->searchTable->getIndexField();
+
+		$property = $description->getProperty();
+		$propertyCondition = '';
+
+		// Full text is collected in a single table therefore limit the match
+		// process by adding the PID as an additional condition
+		if ( $property !== null ) {
+			$propertyCondition = 'AND ' . $temporaryTable . 'p_id=' . $this->searchTable->getPropertyID( $property );
+		}
+
+		$querySearchModifier = $this->getQuerySearchModifier(
+			$value
+		);
+
+		return "MATCH($column) AGAINST (" . $this->searchTable->addQuotes( $value ) . " $querySearchModifier) $propertyCondition";
+	}
+
+	/**
+	 * @since 2.5
+	 *
+	 * @param  string &$value
+	 *
+	 * @return string
+	 */
+	public function getQuerySearchModifier( &$value ) {
+
+		//  @see http://dev.mysql.com/doc/refman/5.7/en/fulltext-boolean.html
+		// "MySQL can perform boolean full-text searches using the IN BOOLEAN
+		// MODE modifier. With this modifier, certain characters have special
+		// meaning at the beginning or end of words ..."
+		if ( strpos( $value, '&BOL' ) !== false ) {
+			$value = str_replace( '&BOL', '', $value );
+			return 'IN BOOLEAN MODE';
+		}
+
+		if ( strpos( $value, '&INL' ) !== false ) {
+			$value = str_replace( '&INL', '', $value );
+			return 'IN NATURAL LANGUAGE MODE';
+		}
+
+		if ( strpos( $value, '&QEX' ) !== false ) {
+			$value = str_replace( '&QEX', '', $value );
+			return 'WITH QUERY EXPANSION';
+		}
+
+		return 'IN BOOLEAN MODE';
+	}
+
+}

--- a/src/SQLStore/QueryEngine/Fulltext/SearchTable.php
+++ b/src/SQLStore/QueryEngine/Fulltext/SearchTable.php
@@ -1,0 +1,228 @@
+<?php
+
+namespace SMW\SQLStore\QueryEngine\Fulltext;
+
+use SMW\MediaWiki\Database;
+use SMW\DataTypeRegistry;
+use SMW\SQLStore\SQLStore;
+use SMW\DIProperty;
+use SMW\DIWikiPage;
+use SMWDataItem as DataItem;
+
+/**
+ * @license GNU GPL v2+
+ * @since 2.5
+ *
+ * @author mwjames
+ */
+class SearchTable {
+
+	/**
+	 * @var Store
+	 */
+	private $store;
+
+	/**
+	 * @var Database
+	 */
+	private $connection;
+
+	/**
+	 * @var TextSanitizer
+	 */
+	private $textSanitizer;
+
+	/**
+	 * @var boolean
+	 */
+	private $isEnabled = false;
+
+	/**
+	 * @var integer
+	 */
+	private $minTokenSize = 3;
+
+	/**
+	 * @var array
+	 */
+	private $propertyExemptionList = array();
+
+	/**
+	 * @since 2.5
+	 *
+	 * @param SQLStore $store
+	 * @param TextSanitizer $textSanitizer
+	 */
+	public function __construct( SQLStore $store, TextSanitizer $textSanitizer ) {
+		$this->store = $store;
+		$this->textSanitizer = $textSanitizer;
+		$this->connection = $store->getConnection( 'mw.db.queryengine' );
+	}
+
+	/**
+	 * @since 2.5
+	 *
+	 * @param array $propertyExemptionList
+	 */
+	public function setPropertyExemptionList( array $propertyExemptionList ) {
+		$this->propertyExemptionList = array_flip(
+			str_replace( ' ', '_', $propertyExemptionList )
+		);
+	}
+
+	/**
+	 * @since 2.5
+	 *
+	 * @return array
+	 */
+	public function getPropertyExemptionList() {
+		return array_keys( $this->propertyExemptionList );
+	}
+
+	/**
+	 * @since 2.5
+	 *
+	 * @param integer $id
+	 *
+	 * @return boolean
+	 */
+	public function isExemptedPropertyById( $id ) {
+
+		$dataItem = $this->store->getObjectIds()->getDataItemForId(
+			$id
+		);
+
+		if ( !$dataItem instanceof DIWikiPage || $dataItem->getDBKey() === '' ) {
+			return false;
+		}
+
+		return $this->isExemptedProperty(
+			DIProperty::newFromUserLabel( $dataItem->getDBKey() )
+		);
+	}
+
+	/**
+	 * @since 2.5
+	 *
+	 * @param DIProperty $property
+	 *
+	 * @return boolean
+	 */
+	public function isExemptedProperty( DIProperty $property ) {
+
+		$dataItemTypeId = DataTypeRegistry::getInstance()->getDataItemId(
+			$property->findPropertyTypeID()
+		);
+
+		// Is neither therefore is exempted
+		if ( $dataItemTypeId !== DataItem::TYPE_BLOB && $dataItemTypeId !== DataItem::TYPE_URI ) {
+			return true;
+		}
+
+		return isset( $this->propertyExemptionList[$property->getKey()] );
+	}
+
+	/**
+	 * @since 2.5
+	 *
+	 * @param boolean $enabled
+	 */
+	public function setEnabled( $enabled ) {
+		$this->isEnabled = (bool)$enabled;
+	}
+
+	/**
+	 * @since 2.5
+	 *
+	 * @return boolean
+	 */
+	public function isEnabled() {
+		return $this->isEnabled;
+	}
+
+	/**
+	 * @since 2.5
+	 *
+	 * @return string
+	 */
+	public function getTableName() {
+		return SQLStore::FT_SEARCH_TABLE;
+	}
+
+	/**
+	 * @since 2.5
+	 *
+	 * @return string
+	 */
+	public function getIndexField() {
+		return 'o_text';
+	}
+
+	/**
+	 * @since 2.5
+	 *
+	 * @return string
+	 */
+	public function getSortField() {
+		return 'o_sort';
+	}
+
+	/**
+	 * @since 2.5
+	 *
+	 * @return integer
+	 */
+	public function getMinTokenSize() {
+		return $this->minTokenSize;
+	}
+
+	/**
+	 * @since 2.5
+	 *
+	 * @return integer $minTokenSize
+	 */
+	public function setMinTokenSize( $minTokenSize ) {
+		$this->minTokenSize = (int)$minTokenSize;
+	}
+
+	/**
+	 * @since 2.5
+	 *
+	 * @return TextSanitizer
+	 */
+	public function getTextSanitizer() {
+		return $this->textSanitizer;
+	}
+
+	/**
+	 * @since 2.5
+	 *
+	 * @param DIProperty $property
+	 *
+	 * @return integer
+	 */
+	public function getPropertyID( DIProperty $property ) {
+		return $this->store->getObjectIds()->getIDFor( $property->getCanonicalDiWikiPage() );
+	}
+
+	/**
+	 * @since 2.5
+	 *
+	 * @return array
+	 */
+	public function getPropertyTables() {
+		return $this->store->getPropertyTables();
+	}
+
+	/**
+	 * @since 2.5
+	 *
+	 * @param string $value
+	 *
+	 * @return string
+	 */
+	public function addQuotes( $value ) {
+		return $this->connection->addQuotes( $value );
+	}
+
+}

--- a/src/SQLStore/QueryEngine/Fulltext/SearchTableRebuilder.php
+++ b/src/SQLStore/QueryEngine/Fulltext/SearchTableRebuilder.php
@@ -1,0 +1,176 @@
+<?php
+
+namespace SMW\SQLStore\QueryEngine\Fulltext;
+
+use Onoi\MessageReporter\MessageReporter;
+use Onoi\MessageReporter\MessageReporterFactory;
+use SMW\MediaWiki\Database;
+use SMW\DIProperty;
+use SMWDataItem as DataItem;
+use SMWDIBlob as DIBlob;
+
+/**
+ * @license GNU GPL v2+
+ * @since 2.5
+ *
+ * @author mwjames
+ */
+class SearchTableRebuilder {
+
+	/**
+	 * @var SearchTableUpdater
+	 */
+	private $searchTableUpdater;
+
+	/**
+	 * @var Database
+	 */
+	private $connection;
+
+	/**
+	 * @var MessageReporter
+	 */
+	private $messageReporter;
+
+	/**
+	 * @since 2.5
+	 *
+	 * @param SearchTableUpdater $searchTableUpdater
+	 * @param Database $connection
+	 */
+	public function __construct( SearchTableUpdater $searchTableUpdater, Database $connection ) {
+		$this->searchTableUpdater = $searchTableUpdater;
+		$this->connection = $connection;
+		$this->messageReporter = MessageReporterFactory::getInstance()->newNullMessageReporter();
+	}
+
+	/**
+	 * @since 2.5
+	 *
+	 * @return SearchTable
+	 */
+	public function getSearchTable() {
+		return $this->searchTableUpdater->getSearchTable();
+	}
+
+	/**
+	 * @since 2.5
+	 *
+	 * @param MessageReporter $messageReporter
+	 */
+	public function setMessageReporter( MessageReporter $messageReporter ) {
+		$this->messageReporter = $messageReporter;
+	}
+
+	/**
+	 * @see RebuildFulltextSearchTable::execute
+	 *
+	 * @since 2.5
+	 *
+	 * @return boolean
+	 */
+	public function run() {
+
+		if ( !$this->searchTableUpdater->isEnabled() ) {
+			return $this->messageReporter->reportMessage( "\n" . "FullText search indexing is not enabled or supported." ."\n\n" );
+		}
+
+		$this->searchTableUpdater->flushTable();
+
+		$this->messageReporter->reportMessage( "\n" . "The index table was purged." ."\n" );
+		$this->messageReporter->reportMessage( "\n" . "Rebuilding the text index from (rows finished/expected):" ."\n\n" );
+
+		foreach ( $this->searchTableUpdater->getPropertyTables() as $proptable ) {
+
+			// Only care for Blob/Uri tables
+			if ( $proptable->getDiType() !== DataItem::TYPE_BLOB && $proptable->getDiType() !== DataItem::TYPE_URI ) {
+				continue;
+			}
+
+			$this->doRebuildOnPropertyTable( $proptable );
+		}
+
+		return true;
+	}
+
+	private function doRebuildOnPropertyTable( $proptable ) {
+
+		$searchTable = $this->getSearchTable();
+
+		if ( $proptable->getDiType() === DataItem::TYPE_URI ) {
+			$fetchFields = array( 's_id', 'p_id', 'o_serialized' );
+		} else {
+			$fetchFields = array( 's_id', 'p_id', 'o_blob', 'o_hash' );
+		}
+
+		$table = $proptable->getName();
+		$pid = '';
+
+		// Fixed tables don't have a p_id column therefore get it
+		// from the ID TABLE
+		if ( $proptable->isFixedPropertyTable() ) {
+			unset( $fetchFields[1] ); // p_id
+
+			$pid = $searchTable->getPropertyID(
+				new DIProperty( $proptable->getFixedProperty() )
+			);
+
+			if ( $searchTable->isExemptedPropertyById( $pid ) ) {
+				return;
+			}
+		}
+
+		$rows = $this->connection->select(
+			$table,
+			$fetchFields,
+			array(),
+			__METHOD__
+		);
+
+		if ( $rows === false || $rows === null ) {
+			return;
+		}
+
+		$this->doRebuildFromRows( $searchTable, $table, $pid, $rows );
+	}
+
+	private function doRebuildFromRows( $searchTable, $table, $pid, $rows ) {
+
+		$i = 0;
+		$expected = $rows->numRows();
+
+		foreach ( $rows as $row ) {
+			$i++;
+
+			$sid = $row->s_id;
+			$pid = !isset( $row->p_id ) ? $pid : $row->p_id;
+
+			// Uri or blob?
+			if ( isset( $row->o_serialized ) ) {
+				$indexableText = $row->o_serialized;
+			} else {
+				$indexableText = $row->o_blob === null ? $row->o_hash : $row->o_blob;
+			}
+
+			if ( $searchTable->isExemptedPropertyById( $pid ) ) {
+				continue;
+			}
+
+			$this->messageReporter->reportMessage(
+				"\r". sprintf( "%-35s%s", "- {$table}", sprintf( "%4.0f%% (%s/%s)",( $i / $expected ) * 100, $i, $expected ) )
+			);
+
+			$text = $this->searchTableUpdater->read( $sid, $pid );
+
+			// Unkown, so let's create the row
+			if ( $text === false ) {
+				$this->searchTableUpdater->insert( $sid, $pid );
+			}
+
+			$this->searchTableUpdater->update( $sid, $pid, trim( $text ) . ' ' . trim( $indexableText ) );
+		}
+
+		$this->messageReporter->reportMessage( "\n" );
+	}
+
+}

--- a/src/SQLStore/QueryEngine/Fulltext/SearchTableUpdater.php
+++ b/src/SQLStore/QueryEngine/Fulltext/SearchTableUpdater.php
@@ -1,0 +1,162 @@
+<?php
+
+namespace SMW\SQLStore\QueryEngine\Fulltext;
+
+use SMW\MediaWiki\Database;
+
+/**
+ * @license GNU GPL v2+
+ * @since 2.5
+ *
+ * @author mwjames
+ */
+class SearchTableUpdater {
+
+	/**
+	 * @var SearchTable
+	 */
+	private $searchTable;
+
+	/**
+	 * @var Database
+	 */
+	private $connection;
+
+	/**
+	 * @since 2.5
+	 *
+	 * @param SearchTable $searchTable
+	 * @param Database $connection
+	 */
+	public function __construct( SearchTable $searchTable, Database $connection ) {
+		$this->searchTable = $searchTable;
+		$this->connection = $connection;
+	}
+
+	/**
+	 * @since 2.5
+	 *
+	 * @return SearchTable
+	 */
+	public function getSearchTable() {
+		return $this->searchTable;
+	}
+
+	/**
+	 * @since 2.5
+	 *
+	 * @return boolean
+	 */
+	public function isEnabled() {
+		return $this->searchTable->isEnabled();
+	}
+
+	/**
+	 * @since 2.5
+	 *
+	 * @return array
+	 */
+	public function getPropertyTables() {
+		return $this->searchTable->getPropertyTables();
+	}
+
+	/**
+	 * @since 2.5
+	 *
+	 * @param integer $sid
+	 * @param integer $pid
+	 *
+	 * @return false|string
+	 */
+	public function read( $sid, $pid ) {
+		$row = $this->connection->selectRow(
+			$this->searchTable->getTableName(),
+			array( 'o_text' ),
+			array(
+				's_id' => (int)$sid,
+				'p_id' => (int)$pid
+			),
+			__METHOD__
+		);
+
+		if ( $row === false ) {
+			return false;
+		}
+
+		return $this->searchTable->getTextSanitizer()->sanitize( $row->o_text );
+	}
+
+	/**
+	 * @since 2.5
+	 *
+	 * @param integer $sid
+	 * @param integer $pid
+	 * @param string $text
+	 */
+	public function update( $sid, $pid, $text ) {
+
+		if ( trim( $text ) === '' ) {
+			return $this->delete( $sid, $pid );
+		}
+
+		$this->connection->update(
+			$this->searchTable->getTableName(),
+			array(
+				'o_text' => $this->searchTable->getTextSanitizer()->sanitize( $text ),
+				'o_sort' => mb_substr( $text, 0, 32 )
+			),
+			array(
+				's_id' => (int)$sid,
+				'p_id' => (int)$pid
+			),
+			__METHOD__
+		);
+	}
+
+	/**
+	 * @since 2.5
+	 *
+	 * @param integer $sid
+	 * @param integer $pid
+	 */
+	public function insert( $sid, $pid ) {
+		$this->connection->insert(
+			$this->searchTable->getTableName(),
+			array(
+				's_id' => (int)$sid,
+				'p_id' => (int)$pid,
+				'o_text' => ''
+			),
+			__METHOD__
+		);
+	}
+
+	/**
+	 * @since 2.5
+	 *
+	 * @param integer $sid
+	 * @param integer $pid
+	 */
+	public function delete( $sid, $pid ) {
+		$this->connection->delete(
+			$this->searchTable->getTableName(),
+			array(
+				's_id' => (int)$sid,
+				'p_id' => (int)$pid
+			),
+			__METHOD__
+		);
+	}
+
+	/**
+	 * @since 2.5
+	 */
+	public function flushTable() {
+		$this->connection->delete(
+			$this->searchTable->getTableName(),
+			'*',
+			__METHOD__
+		);
+	}
+
+}

--- a/src/SQLStore/QueryEngine/Fulltext/TextByChangeUpdater.php
+++ b/src/SQLStore/QueryEngine/Fulltext/TextByChangeUpdater.php
@@ -1,0 +1,247 @@
+<?php
+
+namespace SMW\SQLStore\QueryEngine\Fulltext;
+
+use SMW\SQLStore\CompositePropertyTableDiffIterator;
+use SMW\SQLStore\ChangeOp\TableChangeOp;
+use SMW\MediaWiki\Database;
+use SMW\DeferredRequestDispatchManager;
+use SMW\DIWikiPage;
+
+/**
+ * @license GNU GPL v2+
+ * @since 2.5
+ *
+ * @author mwjames
+ */
+class TextByChangeUpdater {
+
+	/**
+	 * @var SearchTableUpdater
+	 */
+	private $searchTableUpdater;
+
+	/**
+	 * @var Database
+	 */
+	private $connection;
+
+	/**
+	 * @var boolean
+	 */
+	private $asDeferredUpdate = true;
+
+	/**
+	 * @since 2.5
+	 *
+	 * @param SearchTableUpdater $searchTableUpdater
+	 * @param Database $connection
+	 */
+	public function __construct( SearchTableUpdater $searchTableUpdater, Database $connection ) {
+		$this->searchTableUpdater = $searchTableUpdater;
+		$this->connection = $connection;
+	}
+
+	/**
+	 * @note See comments in the DefaultSettings.php on the smwgFulltextDeferredUpdate setting
+	 *
+	 * @since 2.5
+	 *
+	 * @param boolean $asDeferredUpdate
+	 */
+	public function asDeferredUpdate( $asDeferredUpdate ) {
+		$this->asDeferredUpdate = (bool)$asDeferredUpdate;
+	}
+
+	/**
+	 * @see SMW::SQLStore::AfterDataUpdateComplete hook
+	 *
+	 * @since 2.5
+	 *
+	 * @param DIWikiPage $subject
+	 * @param CompositePropertyTableDiffIterator $compositePropertyTableDiffIterator
+	 * @param DeferredRequestDispatchManager $deferredRequestDispatchManager
+	 */
+	public function pushUpdates( DIWikiPage $subject, CompositePropertyTableDiffIterator $compositePropertyTableDiffIterator, DeferredRequestDispatchManager $deferredRequestDispatchManager ) {
+
+		// Update within the same transaction as started by SMW::SQLStore::AfterDataUpdateComplete
+		if ( !$this->asDeferredUpdate ) {
+			return $this->pushUpdatesFromPropertyTableDiff( $compositePropertyTableDiffIterator );
+		}
+
+		$deferredRequestDispatchManager->dispatchSearchTableUpdateJobFor(
+			$subject->getTitle(),
+			$this->buildSearchTableUpdateJobParametersFrom( $compositePropertyTableDiffIterator )
+		);
+	}
+
+	/**
+	 * @since 2.5
+	 *
+	 * @param CompositePropertyTableDiffIterator $compositePropertyTableDiffIterator
+	 *
+	 * @return array
+	 */
+	public function buildSearchTableUpdateJobParametersFrom( CompositePropertyTableDiffIterator $compositePropertyTableDiffIterator ) {
+		return array(
+			'diff' => $compositePropertyTableDiffIterator->getOrderedDiffByTable()
+		);
+	}
+
+	/**
+	 * @see SearchTableUpdateJob::run
+	 *
+	 * @since 2.5
+	 *
+	 * @param array $parameters
+	 */
+	public function pushUpdatesFromJobParameters( array $parameters ) {
+
+		if ( !$this->searchTableUpdater->isEnabled() || !isset( $parameters['diff'] ) || $parameters['diff'] === false ) {
+			return;
+		}
+
+		foreach ( $parameters['diff'] as $tableName => $changeOp ) {
+			$this->doUpdateFromTableChangeOp( new TableChangeOp( $tableName, $changeOp ) );
+		}
+	}
+
+	/**
+	 * @since 2.5
+	 *
+	 * @param CompositePropertyTableDiffIterator $compositePropertyTableDiffIterator
+	 */
+	public function pushUpdatesFromPropertyTableDiff( CompositePropertyTableDiffIterator $compositePropertyTableDiffIterator ) {
+
+		if ( !$this->searchTableUpdater->isEnabled() ) {
+			return;
+		}
+
+		$start = microtime( true );
+
+		foreach ( $compositePropertyTableDiffIterator->getTableChangeOps() as $tableChangeOp ) {
+			$this->doUpdateFromTableChangeOp( $tableChangeOp );
+		}
+
+
+		wfDebugLog( 'smw', __METHOD__ . ' procTime (sec): '. round( ( microtime( true ) - $start ), 5 ) );
+	}
+
+	private function doUpdateFromTableChangeOp( TableChangeOp $tableChangeOp ) {
+
+		$deletes = array();
+		$inserts = array();
+
+		foreach ( $tableChangeOp->getFieldChangeOps( 'insert' ) as $insertFieldChangeOp ) {
+
+			// Copy fields temporarily
+			if ( $tableChangeOp->isFixedPropertyOp() ) {
+				$insertFieldChangeOp->set( 'p_id', $tableChangeOp->getFixedPropertyValueFor( 'p_id' ) );
+			}
+
+			$this->doAggregateFromFieldChangeOp( TableChangeOp::OP_INSERT, $insertFieldChangeOp, $inserts );
+		}
+
+		foreach ( $tableChangeOp->getFieldChangeOps( 'delete' ) as $deleteFieldChangeOp ) {
+
+			// Copy fields temporarily
+			if ( $tableChangeOp->isFixedPropertyOp() ) {
+				$deleteFieldChangeOp->set( 'p_id', $tableChangeOp->getFixedPropertyValueFor( 'p_id' ) );
+			}
+
+			$this->doAggregateFromFieldChangeOp( TableChangeOp::OP_DELETE, $deleteFieldChangeOp, $deletes );
+		}
+
+		$this->doUpdateOnAggregatedValues( $inserts, $deletes );
+	}
+
+	private function doAggregateFromFieldChangeOp( $type, $fieldChangeOp, &$aggregate ) {
+
+		$searchTable = $this->searchTableUpdater->getSearchTable();
+
+		// Exempted property -> out
+		if ( !$fieldChangeOp->has( 'p_id' ) || $searchTable->isExemptedPropertyById( $fieldChangeOp->get( 'p_id' ) ) ) {
+			return;
+		}
+
+		// Only text components
+		if ( !$fieldChangeOp->has( 'o_blob' ) && !$fieldChangeOp->has( 'o_hash' ) && !$fieldChangeOp->has( 'o_serialized' ) ) {
+			return;
+		}
+
+		// Re-map (url type)
+		if ( $fieldChangeOp->has( 'o_serialized' ) ) {
+			$fieldChangeOp->set( 'o_blob', $fieldChangeOp->get( 'o_serialized' ) );
+		}
+
+		// Build a temporary stable key for the diff match
+		$key = $fieldChangeOp->get( 's_id' ) . ':' . $fieldChangeOp->get( 'p_id' );
+
+		// If the blob value is empty then the DIHandler has put any text < 72
+		// into the hash field
+		$text = $fieldChangeOp->get( 'o_blob' );
+
+		if ( $text === null || $text === '' ) {
+			$text = $fieldChangeOp->get( 'o_hash' );
+		}
+
+		if ( !isset( $aggregate[$key] ) ) {
+			$aggregate[$key] = $type === TableChangeOp::OP_DELETE ? array() : '';
+		}
+
+		// Concatenate the inserts but keep the deletes separate to allow
+		// for them to be removed individually
+		if ( $type === TableChangeOp::OP_INSERT ) {
+			$aggregate[$key] = trim( $aggregate[$key] . ' ' . trim( $text ) );
+		} elseif ( $type === TableChangeOp::OP_DELETE ) {
+			$aggregate[$key][] = $searchTable->getTextSanitizer()->sanitize( $text );
+		}
+	}
+
+	private function doUpdateOnAggregatedValues( $inserts, $deletes ) {
+
+		// Remove any "deletes" first
+		foreach ( $deletes as $key => $values ) {
+			list( $sid, $pid ) = explode( ':', $key, 2 );
+
+			$text = $this->searchTableUpdater->read(
+				$sid,
+				$pid
+			);
+
+			if ( $text === false ) {
+				continue;
+			}
+
+			foreach ( $values as $k => $value ) {
+				$text = str_replace( $value, '', $text );
+			}
+
+			//wfDebugLog( 'smw', "Delete update on $sid with $pid" );
+
+			$this->searchTableUpdater->update( $sid, $pid, $text );
+		}
+
+		foreach ( $inserts as $key => $value ) {
+			list( $sid, $pid ) = explode( ':', $key, 2 );
+
+			if ( $value === '' ) {
+				continue;
+			}
+
+			$text = $this->searchTableUpdater->read(
+				$sid,
+				$pid
+			);
+
+			if ( $text === false ) {
+				$this->searchTableUpdater->insert( $sid, $pid );
+			}
+
+			//wfDebugLog( 'smw', "Insert update on $sid with $pid " );
+
+			$this->searchTableUpdater->update( $sid, $pid, $text . ' ' . $value );
+		}
+	}
+
+}

--- a/src/SQLStore/QueryEngine/Fulltext/TextSanitizer.php
+++ b/src/SQLStore/QueryEngine/Fulltext/TextSanitizer.php
@@ -1,0 +1,181 @@
+<?php
+
+namespace SMW\SQLStore\QueryEngine\Fulltext;
+
+use Onoi\Tesa\SanitizerFactory;
+use Onoi\Tesa\Sanitizer;
+use Onoi\Tesa\Normalizer;
+use Onoi\Tesa\Tokenizer\Tokenizer;
+use Onoi\Tesa\Transliterator;
+
+/**
+ * @license GNU GPL v2+
+ * @since 2.5
+ *
+ * @author mwjames
+ */
+class TextSanitizer {
+
+	/**
+	 * @var SanitizerFactory
+	 */
+	private $sanitizerFactory;
+
+	/**
+	 * @var array
+	 */
+	private $languageDetection = array();
+
+	/**
+	 * @var integer
+	 */
+	private $minTokenSize = 3;
+
+	/**
+	 * @since 2.5
+	 *
+	 * @param SanitizerFactory $sanitizerFactory
+	 */
+	public function __construct( SanitizerFactory $sanitizerFactory ) {
+		$this->sanitizerFactory = $sanitizerFactory;
+	}
+
+	/**
+	 * @since 2.5
+	 *
+	 * @return array
+	 */
+	public function getVersions() {
+
+		$languageDetector = '(disabled)';
+
+		if ( isset( $this->languageDetection['TextCatLanguageDetector'] ) ) {
+			$languageDetector = 'TextCatLanguageDetector (' . implode(', ', $this->languageDetection['TextCatLanguageDetector'] ) . ')';
+		}
+
+		return array(
+			'ICU (Intl) PHP-extension' => ( extension_loaded( 'intl' ) ? INTL_ICU_VERSION : '(disabled)' ),
+			'Tesa::Sanitizer'  => Sanitizer::VERSION,
+			'Tesa::Transliterator' => Transliterator::VERSION,
+			'Tesa::LanguageDetector' => $languageDetector
+		);
+	}
+
+	/**
+	 * @since 2.5
+	 *
+	 * @param array $languageDetection
+	 */
+	public function setLanguageDetection( array $languageDetection ) {
+		$this->languageDetection = $languageDetection;
+	}
+
+	/**
+	 * @since 2.5
+	 *
+	 * @param integer $minTokenSize
+	 */
+	public function setMinTokenSize( $minTokenSize ) {
+		$this->minTokenSize = $minTokenSize;
+	}
+
+	/**
+	 * @since 2.5
+	 *
+	 * @param string $text
+	 * @param boolean $isSearchTerm
+	 *
+	 * @return string
+	 */
+	public function sanitize( $text, $isSearchTerm = false ) {
+		$start = microtime( true );
+		$text = rawurldecode( trim( $text ) );
+
+		$affix = '';
+		$exemptionList = '';
+
+		// Those have special meaning when running a match search against
+		// the fulltext index (wildcard, phrase matching markers etc.)
+		if ( $isSearchTerm ) {
+			$exemptionList = array( '*', '"', '+', '-', '&', ',', '@' );
+		}
+
+		// MySQLValueMatchConditionBuilder::getQuerySearchModifier
+		// Any query modifier? Take care of it before any tokenizer or ngrams
+		// distort the marker
+		if ( $isSearchTerm &&
+			( $pos = strrpos( $text, '&BOL' ) ) !== false ||
+			( $pos = strrpos( $text, '&INL' ) ) !== false ||
+			( $pos = strrpos( $text, '&QEX' ) ) !== false ) {
+			$affix = mb_strcut( $text, $pos );
+			$text = str_replace( $affix, '', $text );
+		}
+
+		$sanitizer = $this->sanitizerFactory->newSanitizer( $text );
+		$sanitizer->toLowercase();
+		$sanitizer->applyTransliteration();
+		$sanitizer->convertDoubleWidth();
+
+		$sanitizer->replace(
+			array( 'http://', 'https://', 'mailto:', '%2A', '_', '&#x005B;', "\n", "\t" ),
+			array( '', '', '', '*', ' ', '[', "", "" )
+		);
+
+		$language = $this->predictLanguage( $text );
+
+		$sanitizer->setOption(
+			Sanitizer::WHITELIST,
+			$exemptionList
+		);
+
+		$sanitizer->setOption(
+			Sanitizer::MIN_LENGTH,
+			$this->minTokenSize
+		);
+
+		$tokenizer = $this->sanitizerFactory->newPreferredTokenizerByLanguage(
+			$text,
+			$language
+		);
+
+		$tokenizer->setOption(
+			Tokenizer::REGEX_EXEMPTION,
+			$exemptionList
+		);
+
+		$text = $sanitizer->sanitizeWith(
+			$tokenizer,
+			$this->sanitizerFactory->newStopwordAnalyzerByLanguage( $language ),
+			$this->sanitizerFactory->newSynonymizerByLanguage( $language )
+		);
+
+		// Remove possible spaces added by the tokenizer
+		$text = str_replace(
+			array( ' *', '* ', ' "', '" ', '+ ', '- ', '@ ' ),
+			array( '*', '*', '"', '"', '+', '-', '@' ),
+			$text
+		) . $affix;
+
+		//var_dump( $language, $text, (microtime( true ) - $start ) );
+		return $text;
+	}
+
+	private function predictLanguage( $text ) {
+
+		if ( $this->languageDetection === array() ) {
+			return null;
+		}
+
+		$languageDetector = $this->sanitizerFactory->newNullLanguageDetector();
+
+		if ( isset( $this->languageDetection['TextCatLanguageDetector'] ) ) {
+			$languageDetector = $this->sanitizerFactory->newTextCatLanguageDetector();
+			$languageDetector->setLanguageCandidates( $this->languageDetection['TextCatLanguageDetector'] );
+		}
+
+		return $languageDetector->detect(
+			Normalizer::reduceLengthTo( $text, 200 )
+		);
+	}
+
+}

--- a/src/SQLStore/QueryEngine/Fulltext/ValueMatchConditionBuilder.php
+++ b/src/SQLStore/QueryEngine/Fulltext/ValueMatchConditionBuilder.php
@@ -1,0 +1,95 @@
+<?php
+
+namespace SMW\SQLStore\QueryEngine\Fulltext;
+
+use SMW\Query\Language\ValueDescription;
+use SMWDIBlob as DIBlob;
+use SMWDIUri as DIUri;
+
+/**
+ * @license GNU GPL v2+
+ * @since 2.5
+ *
+ * @author mwjames
+ */
+class ValueMatchConditionBuilder {
+
+	/**
+	 * @since 2.5
+	 *
+	 * @return boolean
+	 */
+	public function isEnabled() {
+		return false;
+	}
+
+	/**
+	 * @since 2.5
+	 *
+	 * @return string
+	 */
+	public function getTableName() {
+		return '';
+	}
+
+	/**
+	 * @since 2.5
+	 *
+	 * @param string $value
+	 *
+	 * @return boolean
+	 */
+	public function hasMinTokenLength( $value ) {
+		return false;
+	}
+
+	/**
+	 * @since 2.5
+	 *
+	 * @param string $temporaryTable
+	 *
+	 * @return string
+	 */
+	public function getSortIndexField( $temporaryTable = '' ) {
+		return '';
+	}
+
+	/**
+	 * @since 2.5
+	 *
+	 * @param ValueDescription $description
+	 *
+	 * @return boolean
+	 */
+	public function canApplyFulltextSearchMatchCondition( ValueDescription $description ) {
+		return false;
+	}
+
+	/**
+	 * @since 2.5
+	 *
+	 * @param ValueDescription $description
+	 * @param string $temporaryTable
+	 *
+	 * @return string
+	 */
+	public function getWhereCondition( ValueDescription $description, $temporaryTable = '' ) {
+		return '';
+	}
+
+	protected function getMatchableTextFromDescription( $description ) {
+
+		$matchableText = false;
+
+		if ( $description->getDataItem() instanceof DIBlob ) {
+			$matchableText = $description->getDataItem()->getString();
+		}
+
+		if ( $description->getDataItem() instanceof DIUri ) {
+			$matchableText = $description->getDataItem()->getSortKey();
+		}
+
+		return $matchableText;
+	}
+
+}

--- a/src/SQLStore/QueryEngine/FulltextSearchTableFactory.php
+++ b/src/SQLStore/QueryEngine/FulltextSearchTableFactory.php
@@ -1,0 +1,152 @@
+<?php
+
+namespace SMW\SQLStore\QueryEngine;
+
+use SMW\SQLStore\SQLStore;
+use SMW\ApplicationFactory;
+use SMW\SQLStore\QueryEngine\Fulltext\ValueMatchConditionBuilder;
+use SMW\SQLStore\QueryEngine\Fulltext\MySQLValueMatchConditionBuilder;
+use SMW\SQLStore\QueryEngine\Fulltext\TextByChangeUpdater;
+use SMW\SQLStore\QueryEngine\Fulltext\TextSanitizer;
+use SMW\SQLStore\QueryEngine\Fulltext\SearchTable;
+use SMW\SQLStore\QueryEngine\Fulltext\SearchTableUpdater;
+use SMW\SQLStore\QueryEngine\Fulltext\SearchTableRebuilder;
+use Onoi\Tesa\SanitizerFactory;
+
+/**
+ * @license GNU GPL v2+
+ * @since 2.5
+ *
+ * @author mwjames
+ */
+class FulltextSearchTableFactory {
+
+	/**
+	 * @var ApplicationFactory
+	 */
+	private $applicationFactory;
+
+	/**
+	 * @since 2.5
+	 */
+	public function __construct() {
+		$this->applicationFactory = ApplicationFactory::getInstance();
+	}
+
+	/**
+	 * @since 2.5
+	 *
+	 * @param SQLStore $store
+	 *
+	 * @return ValueMatchConditionBuilder
+	 */
+	public function newValueMatchConditionBuilderByType( SQLStore $store ) {
+
+		$type = $store->getConnection( 'mw.db' )->getType();
+
+		switch ( $type ) {
+			case 'mysql':
+				return new MySQLValueMatchConditionBuilder(
+					$this->newSearchTable( $store )
+				);
+				break;
+		}
+
+		return new ValueMatchConditionBuilder();
+	}
+
+	/**
+	 * @since 2.5
+	 *
+	 * @param SQLStore $store
+	 *
+	 * @return SearchTable
+	 */
+	public function newSearchTable( SQLStore $store ) {
+
+		$settings = $this->applicationFactory->getSettings();
+
+		$textSanitizer = new TextSanitizer(
+			new SanitizerFactory()
+		);
+
+		$textSanitizer->setLanguageDetection(
+			$settings->get( 'smwgFulltextLanguageDetection' )
+		);
+
+		$textSanitizer->setMinTokenSize(
+			$settings->get( 'smwgFulltextSearchMinTokenSize' )
+		);
+
+		$searchTable = new SearchTable(
+			$store,
+			$textSanitizer
+		);
+
+		$searchTable->setEnabled(
+			$settings->get( 'smwgEnabledFulltextSearch' )
+		);
+
+		$searchTable->setPropertyExemptionList(
+			$settings->get( 'smwgFulltextSearchPropertyExemptionList' )
+		);
+
+		$searchTable->setMinTokenSize(
+			$settings->get( 'smwgFulltextSearchMinTokenSize' )
+		);
+
+		return $searchTable;
+	}
+
+	/**
+	 * @since 2.5
+	 *
+	 * @param SQLStore $store
+	 *
+	 * @return SearchTableUpdater
+	 */
+	public function newSearchTableUpdater( SQLStore $store ) {
+		return new SearchTableUpdater(
+			$this->newSearchTable( $store ),
+			$store->getConnection( 'mw.db' )
+		);
+	}
+
+	/**
+	 * @since 2.5
+	 *
+	 * @param SQLStore $store
+	 *
+	 * @return TextByChangeUpdater
+	 */
+	public function newTextByChangeUpdater( SQLStore $store ) {
+
+		$settings = $this->applicationFactory->getSettings();
+
+		$textByChangeUpdater = new TextByChangeUpdater(
+			$this->newSearchTableUpdater( $store ),
+			$store->getConnection( 'mw.db' )
+		);
+
+		$textByChangeUpdater->asDeferredUpdate(
+			$settings->get( 'smwgFulltextDeferredUpdate' )
+		);
+
+		return $textByChangeUpdater;
+	}
+
+	/**
+	 * @since 2.5
+	 *
+	 * @param SQLStore $store
+	 *
+	 * @return SearchTableRebuilder
+	 */
+	public function newSearchTableRebuilder( SQLStore $store ) {
+		return new SearchTableRebuilder(
+			$this->newSearchTableUpdater( $store ),
+			$store->getConnection( 'mw.db' )
+		);
+	}
+
+}

--- a/src/SQLStore/QueryEngine/Interpreter/SomePropertyInterpreter.php
+++ b/src/SQLStore/QueryEngine/Interpreter/SomePropertyInterpreter.php
@@ -17,6 +17,7 @@ use SMWDataItem as DataItem;
 use SMWDataItemHandler as DataItemHandler;
 use SMWSql3SmwIds;
 use SMWSQLStore3Table;
+use SMW\SQLStore\QueryEngine\FulltextSearchTableFactory;
 
 /**
  * @license GNU GPL v2+
@@ -39,6 +40,11 @@ class SomePropertyInterpreter implements DescriptionInterpreter {
 	private $comparatorMapper;
 
 	/**
+	 * @var FulltextSearchTableFactory
+	 */
+	private $fulltextSearchTableFactory;
+
+	/**
 	 * @since 2.2
 	 *
 	 * @param QuerySegmentListBuilder $querySegmentListBuilder
@@ -46,6 +52,7 @@ class SomePropertyInterpreter implements DescriptionInterpreter {
 	public function __construct( QuerySegmentListBuilder $querySegmentListBuilder ) {
 		$this->querySegmentListBuilder = $querySegmentListBuilder;
 		$this->comparatorMapper = new ComparatorMapper();
+		$this->fulltextSearchTableFactory = new FulltextSearchTableFactory();
 	}
 
 	/**
@@ -186,7 +193,7 @@ class SomePropertyInterpreter implements DescriptionInterpreter {
 			$query->joinfield = "{$query->alias}.s_id";
 			$this->interpretInnerValueDescription( $query, $description->getDescription(), $proptable, $diHandler, 'AND' );
 			if ( array_key_exists( $sortkey, $this->querySegmentListBuilder->getSortKeys() ) ) {
-				$query->sortfields[$sortkey] = "{$query->alias}.{$indexField}";
+				$query->sortfields[$sortkey] = isset( $query->sortIndexField ) ? $query->sortIndexField : "{$query->alias}.{$indexField}";
 			}
 		}
 	}
@@ -249,14 +256,18 @@ class SomePropertyInterpreter implements DescriptionInterpreter {
 		$dataItem = $description->getDataItem();
 		$db = $this->querySegmentListBuilder->getStore()->getConnection( 'mw.db.queryengine' );
 
+		$valueMatchConditionBuilder = $this->fulltextSearchTableFactory->newValueMatchConditionBuilderByType(
+			$this->querySegmentListBuilder->getStore()
+		);
+
 		// TODO Better get the handle from the property type
 		// Some comparators (e.g. LIKE) could use DI values of
 		// a different type; we care about the property table, not
 		// about the value
 
 		// Do not support smw_id joined data for now.
-
 		$indexField = $diHandler->getIndexField();
+
 		//Hack to get to the field used as index
 		$keys = $diHandler->getWhereConds( $dataItem );
 		$value = $keys[$indexField];
@@ -273,7 +284,12 @@ class SomePropertyInterpreter implements DescriptionInterpreter {
 			);
 		}
 
-		if ( $where == '' ) {
+		if ( $where == '' && $valueMatchConditionBuilder->canApplyFulltextSearchMatchCondition( $description ) ) {
+			$query->joinTable = $valueMatchConditionBuilder->getTableName();
+			$query->sortIndexField = $valueMatchConditionBuilder->getSortIndexField( $query->alias );
+			$query->components = array();
+			$where = $valueMatchConditionBuilder->getWhereCondition( $description, $query->alias );
+		} elseif ( $where == '' ) {
 
 			$comparator = $this->comparatorMapper->mapComparator(
 				$description,

--- a/src/SQLStore/QueryEngine/Interpreter/ValueDescriptionInterpreter.php
+++ b/src/SQLStore/QueryEngine/Interpreter/ValueDescriptionInterpreter.php
@@ -8,7 +8,9 @@ use SMW\Query\Language\ValueDescription;
 use SMW\SQLStore\QueryEngine\DescriptionInterpreter;
 use SMW\SQLStore\QueryEngine\QuerySegment;
 use SMW\SQLStore\QueryEngine\QuerySegmentListBuilder;
+use SMW\SQLStore\QueryEngine\FulltextSearchTableFactory;
 use SMWSql3SmwIds;
+use SMWDIBlob as DIBlob;
 
 /**
  * @license GNU GPL v2+
@@ -31,6 +33,11 @@ class ValueDescriptionInterpreter implements DescriptionInterpreter {
 	private $comparatorMapper;
 
 	/**
+	 * @var FulltextSearchTableFactory
+	 */
+	private $fulltextSearchTableFactory;
+
+	/**
 	 * @since 2.2
 	 *
 	 * @param QuerySegmentListBuilder $querySegmentListBuilder
@@ -38,6 +45,7 @@ class ValueDescriptionInterpreter implements DescriptionInterpreter {
 	public function __construct( QuerySegmentListBuilder $querySegmentListBuilder ) {
 		$this->querySegmentListBuilder = $querySegmentListBuilder;
 		$this->comparatorMapper = new ComparatorMapper();
+		$this->fulltextSearchTableFactory = new FulltextSearchTableFactory();
 	}
 
 	/**
@@ -66,7 +74,26 @@ class ValueDescriptionInterpreter implements DescriptionInterpreter {
 			return $query;
 		}
 
-		if ( $description->getComparator() === SMW_CMP_EQ ) {
+		$comparator = $description->getComparator();
+		$value = $description->getDataItem()->getSortKey();
+
+		// A simple value match using the `~~Foo` will initiate a fulltext
+		// search without being bound to a property allowing a broad match
+		// search
+		if ( ( $comparator === SMW_CMP_LIKE || $comparator === SMW_CMP_NLKE ) && strpos( $value, '~' ) !== false ) {
+
+			$fulltextSearchSupport = $this->addFulltextSearchCondition(
+				$query,
+				$comparator,
+				$value
+			);
+
+			if ( $fulltextSearchSupport ) {
+				return $query;
+			}
+		}
+
+		if ( $comparator === SMW_CMP_EQ ) {
 			$query->type = QuerySegment::Q_VALUE;
 
 			$oid = $this->querySegmentListBuilder->getStore()->getObjectIds()->getSMWPageID(
@@ -80,7 +107,6 @@ class ValueDescriptionInterpreter implements DescriptionInterpreter {
 		} else { // Join with SMW IDs table needed for other comparators (apply to title string).
 			$query->joinTable = SMWSql3SmwIds::TABLE_NAME;
 			$query->joinfield = "{$query->alias}.smw_id";
-			$value = $description->getDataItem()->getSortKey();
 
 			$comparator = $this->comparatorMapper->mapComparator(
 				$description,
@@ -91,6 +117,31 @@ class ValueDescriptionInterpreter implements DescriptionInterpreter {
 
 			$query->where = "{$query->alias}.smw_sortkey$comparator" . $db->addQuotes( $value );
 		}
+
+		return $query;
+	}
+
+	private function addFulltextSearchCondition( $query, $comparator, &$value ) {
+
+		// Remove remaining ~ from the search string
+		$value = str_replace( '~', '', $value );
+
+		$valueMatchConditionBuilder = $this->fulltextSearchTableFactory->newValueMatchConditionBuilderByType(
+			$this->querySegmentListBuilder->getStore()
+		);
+
+		if ( !$valueMatchConditionBuilder->isEnabled() || !$valueMatchConditionBuilder->hasMinTokenLength( $value ) ) {
+			return false;
+		}
+
+		$query->joinTable = $valueMatchConditionBuilder->getTableName();
+		$query->joinfield = "{$query->alias}.s_id";
+		$query->components = array();
+
+		$query->where = $valueMatchConditionBuilder->getWhereCondition(
+			new ValueDescription( new DIBlob( $value ), null, $comparator ),
+			$query->alias
+		);
 
 		return $query;
 	}

--- a/src/SQLStore/TableBuilder/PostgresRdbmsTableBuilder.php
+++ b/src/SQLStore/TableBuilder/PostgresRdbmsTableBuilder.php
@@ -210,9 +210,13 @@ EOT;
 	}
 
 	/**
-	 * Create an index using the suitable SQL for various RDBMS.
+	 * @see RdbmsTableBuilder::doCreateIndex
 	 */
-	protected function doCreateIndex( $tableName, $indexType, $indexName, $columns ) {
+	protected function doCreateIndex( $tableName, $indexType, $indexName, $columns, array $indexOptions ) {
+
+		if ( $indexType === 'FULLTEXT' ) {
+			return $this->reportMessage( "   ... skipping the fulltext index creation ..." );
+		}
 
 		$tableName = $this->connection->tableName( $tableName, 'raw' );
 		$indexName = "{$tableName}_index{$indexName}";

--- a/src/SQLStore/TableBuilder/RdbmsTableBuilder.php
+++ b/src/SQLStore/TableBuilder/RdbmsTableBuilder.php
@@ -163,7 +163,7 @@ abstract class RdbmsTableBuilder implements TableBuilder, MessageReporter {
 				$indexType = 'INDEX';
 			}
 
-			$this->doCreateIndex( $tableName, $indexType, $indexName, $columns );
+			$this->doCreateIndex( $tableName, $indexType, $indexName, $columns, $indexOptions );
 		}
 
 		$this->reportMessage( "   ... done.\n" );
@@ -222,7 +222,7 @@ abstract class RdbmsTableBuilder implements TableBuilder, MessageReporter {
 	 * @param string $indexName
 	 * @param $columns
 	 */
-	abstract protected function doCreateIndex( $tableName, $indexType, $indexName, $columns );
+	abstract protected function doCreateIndex( $tableName, $indexType, $indexName, $columns, array $indexOptions );
 
 	private function doCreateTable( $tableName, array $tableOptions = null ) {
 

--- a/src/SQLStore/TableBuilder/SQLiteRdbmsTableBuilder.php
+++ b/src/SQLStore/TableBuilder/SQLiteRdbmsTableBuilder.php
@@ -116,7 +116,7 @@ class SQLiteRdbmsTableBuilder extends MySQLRdbmsTableBuilder {
 	}
 
 	/**
-	 * @see GeneralTableCreator::doDropObsoleteIndicies
+	 * @see MySQLRdbmsTableBuilder::doDropObsoleteIndicies
 	 */
 	protected function doDropObsoleteIndicies( $tableName, array &$indicies ) {
 
@@ -130,9 +130,13 @@ class SQLiteRdbmsTableBuilder extends MySQLRdbmsTableBuilder {
 	}
 
 	/**
-	 * @see GeneralTableCreator::doCreateIndex
+	 * @see MySQLRdbmsTableBuilder::doCreateIndex
 	 */
-	protected function doCreateIndex( $tableName, $indexType, $indexName, $columns ) {
+	protected function doCreateIndex( $tableName, $indexType, $indexName, $columns, array $indexOptions ) {
+
+		if ( $indexType === 'FULLTEXT' ) {
+			return $this->reportMessage( "   ... skipping the fulltext index creation ..." );
+		}
 
 		$tableName = $this->connection->tableName( $tableName );
 		$indexName = "{$tableName}_index{$indexName}";

--- a/src/SharedCallbackContainer.php
+++ b/src/SharedCallbackContainer.php
@@ -40,7 +40,7 @@ class SharedCallbackContainer implements CallbackContainer {
 		$callbackLoader->registerExpectedReturnType( 'Store', '\SMW\Store' );
 
 		$callbackLoader->registerCallback( 'Store', function( $store = null ) use ( $callbackLoader ) {
-			return StoreFactory::getStore( $callbackLoader->singleton( 'Settings' )->get( 'smwgDefaultStore' ) );
+			return StoreFactory::getStore( $store !== null ? $store : $callbackLoader->singleton( 'Settings' )->get( 'smwgDefaultStore' ) );
 		} );
 
 		$callbackLoader->registerExpectedReturnType( 'CacheFactory', '\SMW\CacheFactory' );

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -18,6 +18,7 @@ $autoloader->addClassMap( array(
 	'SMW\Maintenance\RebuildConceptCache'        => __DIR__ . '/../maintenance/rebuildConceptCache.php',
 	'SMW\Maintenance\RebuildData'                => __DIR__ . '/../maintenance/rebuildData.php',
 	'SMW\Maintenance\RebuildPropertyStatistics'  => __DIR__ . '/../maintenance/rebuildPropertyStatistics.php',
+	'SMW\Maintenance\RebuildFulltextSearchTable' => __DIR__ . '/../maintenance/rebuildFulltextSearchTable.php',
 	'SMW\Maintenance\DumpRdf'                    => __DIR__ . '/../maintenance/dumpRDF.php',
 	'SMW\Maintenance\SetupStore'                 => __DIR__ . '/../maintenance/setupStore.php'
 ) );

--- a/tests/phpunit/Fixtures/Import/cicero-de-finibus.xml
+++ b/tests/phpunit/Fixtures/Import/cicero-de-finibus.xml
@@ -1,0 +1,69 @@
+<mediawiki xmlns="http://www.mediawiki.org/xml/export-0.10/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.mediawiki.org/xml/export-0.10/ http://www.mediawiki.org/xml/export-0.10.xsd" version="0.10" xml:lang="en">
+  <siteinfo>
+    <sitename>mw-test</sitename>
+    <dbname>mw-test</dbname>
+    <base>http://localhost:8080/mw-test/index.php/Main_Page</base>
+    <generator>MediaWiki 1.25.1</generator>
+    <case>first-letter</case>
+    <namespaces>
+      <namespace key="-2" case="first-letter">Media</namespace>
+      <namespace key="-1" case="first-letter">Special</namespace>
+      <namespace key="0" case="first-letter" />
+      <namespace key="1" case="first-letter">Talk</namespace>
+      <namespace key="2" case="first-letter">User</namespace>
+      <namespace key="3" case="first-letter">User talk</namespace>
+      <namespace key="4" case="first-letter">mw-test</namespace>
+      <namespace key="5" case="first-letter">mw-test talk</namespace>
+      <namespace key="6" case="first-letter">File</namespace>
+      <namespace key="7" case="first-letter">File talk</namespace>
+      <namespace key="8" case="first-letter">MediaWiki</namespace>
+      <namespace key="9" case="first-letter">MediaWiki talk</namespace>
+      <namespace key="10" case="first-letter">Template</namespace>
+      <namespace key="11" case="first-letter">Template talk</namespace>
+      <namespace key="12" case="first-letter">Help</namespace>
+      <namespace key="13" case="first-letter">Help talk</namespace>
+      <namespace key="14" case="first-letter">Category</namespace>
+      <namespace key="15" case="first-letter">Category talk</namespace>
+      <namespace key="102" case="first-letter">Property</namespace>
+      <namespace key="103" case="first-letter">Property talk</namespace>
+      <namespace key="108" case="first-letter">Concept</namespace>
+      <namespace key="109" case="first-letter">Concept talk</namespace>
+    </namespaces>
+  </siteinfo>
+  <page>
+    <title>Property:Has text</title>
+    <ns>102</ns>
+    <id>21</id>
+    <revision>
+      <id>4694</id>
+      <parentid>4693</parentid>
+      <timestamp>2015-08-05T20:09:22Z</timestamp>
+      <contributor>
+        <username>Tester</username>
+        <id>1</id>
+      </contributor>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="91">[[Has type::Text]] [[Has property description::To contain strings of arbitrary length.@en]]</text>
+      <sha1>izpf4um41xce5g993zndg9t34diz6ql</sha1>
+    </revision>
+  </page>
+  <page>
+    <title>De Finibus Bonorum et Malorum</title>
+    <ns>0</ns>
+    <id>1298</id>
+    <revision>
+      <id>4692</id>
+      <timestamp>2015-08-05T20:06:47Z</timestamp>
+      <contributor>
+        <username>Tester</username>
+        <id>1</id>
+      </contributor>
+      <comment>Created page with &quot;Has text::Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque laudantium, totam rem aperiam, eaque ipsa quae ab illo inventore veritatis et...&quot;</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="879">[[Has text::Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque laudantium, totam rem aperiam, eaque ipsa quae ab illo inventore veritatis et quasi architecto beatae vitae dicta sunt explicabo. Nemo enim ipsam voluptatem quia voluptas sit aspernatur aut odit aut fugit, sed quia consequuntur magni dolores eos qui ratione voluptatem sequi nesciunt. Neque porro quisquam est, qui dolorem ipsum quia dolor sit amet, consectetur, adipisci velit, sed quia non numquam eius modi tempora incidunt ut labore et dolore magnam aliquam quaerat voluptatem. Ut enim ad minima veniam, quis nostrum exercitationem ullam corporis suscipit laboriosam, nisi ut aliquid ex ea commodi consequatur? Quis autem vel eum iure reprehenderit qui in ea voluptate velit esse quam nihil molestiae consequatur, vel illum qui dolorem eum fugiat quo voluptas nulla pariatur?]]</text>
+      <sha1>cbgy9a7vlvh30498ruk2boehmc74tz9</sha1>
+    </revision>
+  </page>
+</mediawiki>

--- a/tests/phpunit/Fixtures/Import/dwc-import-example.xml
+++ b/tests/phpunit/Fixtures/Import/dwc-import-example.xml
@@ -1,0 +1,307 @@
+<mediawiki xmlns="http://www.mediawiki.org/xml/export-0.10/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.mediawiki.org/xml/export-0.10/ http://www.mediawiki.org/xml/export-0.10.xsd" version="0.10" xml:lang="en">
+  <siteinfo>
+    <sitename>mw-test</sitename>
+    <dbname>mw-test</dbname>
+    <base>http://localhost:8080/mw-test/index.php/Main_Page</base>
+    <generator>MediaWiki 1.25.1</generator>
+    <case>first-letter</case>
+    <namespaces>
+      <namespace key="-2" case="first-letter">Media</namespace>
+      <namespace key="-1" case="first-letter">Special</namespace>
+      <namespace key="0" case="first-letter" />
+      <namespace key="1" case="first-letter">Talk</namespace>
+      <namespace key="2" case="first-letter">User</namespace>
+      <namespace key="3" case="first-letter">User talk</namespace>
+      <namespace key="4" case="first-letter">mw-test</namespace>
+      <namespace key="5" case="first-letter">mw-test talk</namespace>
+      <namespace key="6" case="first-letter">File</namespace>
+      <namespace key="7" case="first-letter">File talk</namespace>
+      <namespace key="8" case="first-letter">MediaWiki</namespace>
+      <namespace key="9" case="first-letter">MediaWiki talk</namespace>
+      <namespace key="10" case="first-letter">Template</namespace>
+      <namespace key="11" case="first-letter">Template talk</namespace>
+      <namespace key="12" case="first-letter">Help</namespace>
+      <namespace key="13" case="first-letter">Help talk</namespace>
+      <namespace key="14" case="first-letter">Category</namespace>
+      <namespace key="15" case="first-letter">Category talk</namespace>
+      <namespace key="102" case="first-letter">Property</namespace>
+      <namespace key="103" case="first-letter">Property talk</namespace>
+      <namespace key="108" case="first-letter">Concept</namespace>
+      <namespace key="109" case="first-letter">Concept talk</namespace>
+    </namespaces>
+  </siteinfo>
+  <page>
+    <title>MediaWiki:Smw import dwc</title>
+    <ns>8</ns>
+    <id>1287</id>
+    <revision>
+      <id>4669</id>
+      <timestamp>2015-08-05T18:38:11Z</timestamp>
+      <contributor>
+        <username>Tester</username>
+        <id>1</id>
+      </contributor>
+      <comment>Created page with &quot;http://rs.tdwg.org/dwc/terms/|[http://rs.tdwg.org/dwc/terms/ Darwin Core Terms (DwC)]  scientificName|Type:Text  vernacularName|Type:Monolingual text  taxonID|Type:Text  kingd...&quot;</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="299">http://rs.tdwg.org/dwc/terms/|[http://rs.tdwg.org/dwc/terms/ Darwin Core Terms (DwC)]
+ scientificName|Type:Text
+ vernacularName|Type:Monolingual text
+ taxonID|Type:Text
+ kingdom|Type:Text
+ phylum|Type:Text
+ family|Type:Text
+ genus|Type:Text
+ order|Type:Text
+ class|Type:Text
+
+[[Category:Dwc import]]</text>
+      <sha1>14269h4v28zrlit9yhq25mj2nhzxomp</sha1>
+    </revision>
+  </page>
+  <page>
+    <title>Category:Dwc import</title>
+    <ns>14</ns>
+    <id>1291</id>
+    <revision>
+      <id>4673</id>
+      <timestamp>2015-08-05T18:39:29Z</timestamp>
+      <contributor>
+        <username>Tester</username>
+        <id>1</id>
+      </contributor>
+      <comment>Created page with &quot;http://rs.tdwg.org/dwc/terms/&quot;</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="29">http://rs.tdwg.org/dwc/terms/</text>
+      <sha1>gaz4e878f2b2sie5mo6b7aeyndbq0d4</sha1>
+    </revision>
+  </page>
+  <page>
+    <title>Property:Dwc:genus</title>
+    <ns>102</ns>
+    <id>1290</id>
+    <revision>
+      <id>4672</id>
+      <timestamp>2015-08-05T18:39:08Z</timestamp>
+      <contributor>
+        <username>Tester</username>
+        <id>1</id>
+      </contributor>
+      <comment>Created page with &quot;* [[Imported from::dwc:genus]] {{DISPLAYTITLE:dwc:genus}}  [[Category:Dwc import]]&quot;</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="82">* [[Imported from::dwc:genus]] {{DISPLAYTITLE:dwc:genus}}
+
+[[Category:Dwc import]]</text>
+      <sha1>gsxqimgmffeoojuc7mtdx7xjyzgrdua</sha1>
+    </revision>
+  </page>
+  <page>
+    <title>Property:Dwc:kingdom</title>
+    <ns>102</ns>
+    <id>1292</id>
+    <revision>
+      <id>4676</id>
+      <parentid>4675</parentid>
+      <timestamp>2015-08-05T18:41:15Z</timestamp>
+      <contributor>
+        <username>Tester</username>
+        <id>1</id>
+      </contributor>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="775">* [[Imported from::dwc:kingdom]] {{DISPLAYTITLE:dwc:kingdom}}
+* Property description:
+** [[Has property description::The full scientific name of the kingdom in which the taxon is classified. (&quot;Animalia&quot;, &quot;Plantae&quot;)@en]]
+** [[Has property description::El nombre científico completo del reino en el que se clasifica el taxón.@es]]
+** [[Has property description::分类单元所属界的完整学名。@zh-Hans]]
+** [[Has property description::その分類群が位置づけられている、分類上の「界」のフルネーム。@ja]]
+** [[Has property description::Le nom scientifique complet du règne dans lequel le taxon est classé@fr]]
+
+Retrieved 20:32, February 29, 2016 from http://terms.tdwg.org/w/index.php?title=dwc:kingdom&amp;oldid=10142
+
+[[Category:Dwc import]]</text>
+      <sha1>jdgcwwgncncbui9un4h14p4zyqki1m3</sha1>
+    </revision>
+  </page>
+  <page>
+    <title>Property:Dwc:order</title>
+    <ns>102</ns>
+    <id>1293</id>
+    <revision>
+      <id>4677</id>
+      <timestamp>2015-08-05T18:42:18Z</timestamp>
+      <contributor>
+        <username>Tester</username>
+        <id>1</id>
+      </contributor>
+      <comment>Created page with &quot;* [[Imported from::dwc:order]] {{DISPLAYTITLE:dwc:order}}  [[Category:Dwc import]]&quot;</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="82">* [[Imported from::dwc:order]] {{DISPLAYTITLE:dwc:order}}
+
+[[Category:Dwc import]]</text>
+      <sha1>asv9cxea8cm6lr4luptlimsvau0oagz</sha1>
+    </revision>
+  </page>
+  <page>
+    <title>Property:Dwc:phylum</title>
+    <ns>102</ns>
+    <id>1294</id>
+    <revision>
+      <id>4679</id>
+      <timestamp>2015-08-05T18:43:11Z</timestamp>
+      <contributor>
+        <username>Tester</username>
+        <id>1</id>
+      </contributor>
+      <comment>Created page with &quot;* [[Imported from::dwc:phylum]] {{DISPLAYTITLE:dwc:phylum}}  [[Category:Dwc import]]&quot;</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="84">* [[Imported from::dwc:phylum]] {{DISPLAYTITLE:dwc:phylum}}
+
+[[Category:Dwc import]]</text>
+      <sha1>i9rkmrniujg125dykx2ka2fkdv85kdc</sha1>
+    </revision>
+  </page>
+  <page>
+    <title>Property:Dwc:scientificName</title>
+    <ns>102</ns>
+    <id>1295</id>
+    <revision>
+      <id>4680</id>
+      <timestamp>2015-08-05T18:43:47Z</timestamp>
+      <contributor>
+        <username>Tester</username>
+        <id>1</id>
+      </contributor>
+      <comment>Created page with &quot;* [[Imported from::dwc:scientificName]] {{DISPLAYTITLE:dwc:scientificName}}  [[Category:Dwc import]]&quot;</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="100">* [[Imported from::dwc:scientificName]] {{DISPLAYTITLE:dwc:scientificName}}
+
+[[Category:Dwc import]]</text>
+      <sha1>4r77lhnl3jsbazjgxqrr3i4qdvm5bil</sha1>
+    </revision>
+  </page>
+  <page>
+    <title>Property:Dwc:taxonID</title>
+    <ns>102</ns>
+    <id>1296</id>
+    <revision>
+      <id>4681</id>
+      <timestamp>2015-08-05T18:45:07Z</timestamp>
+      <contributor>
+        <username>Tester</username>
+        <id>1</id>
+      </contributor>
+      <comment>Created page with &quot;* [[Imported from::dwc:taxonID]] {{DISPLAYTITLE:dwc:taxonID}}  [[Category:Dwc import]]&quot;</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="86">* [[Imported from::dwc:taxonID]] {{DISPLAYTITLE:dwc:taxonID}}
+
+[[Category:Dwc import]]</text>
+      <sha1>gzoh496mp6y6xzeihd08xitzd6fo18c</sha1>
+    </revision>
+  </page>
+  <page>
+    <title>Property:Dwc:vernacularName</title>
+    <ns>102</ns>
+    <id>1297</id>
+    <revision>
+      <id>4689</id>
+      <parentid>4688</parentid>
+      <timestamp>2015-08-05T18:54:18Z</timestamp>
+      <contributor>
+        <username>Tester</username>
+        <id>1</id>
+      </contributor>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="663">* [[Imported from::dwc:vernacularName]] {{DISPLAYTITLE:dwc:vernacularName}}
+* Property description:
+** [[Has property description::A common or vernacular name@en]]
+** [[Has property description::Nom commun ou vernaculaire@fr]]
+** [[Has property description::Ein geräuchlicher Name oder Volksname@de]]
+** [[Has property description::Ein geräuchlicher Name oder Volksname@de]]
+** [[Has property description::一般名、あるいは通俗名@ja]]
+** [[Has property description::一个常见或者俗名@zh-Hans]]
+** [[Has property description::Un nombre común o vernacular@es]]
+
+http://terms.tdwg.org/w/index.php?title=dwc:vernacularName
+
+[[Category:Dwc import]]</text>
+      <sha1>pdeh0ku8smvn732nlxvshf82km6j9km</sha1>
+    </revision>
+  </page>
+  <page>
+    <title>Property:Dwc:class</title>
+    <ns>102</ns>
+    <id>1288</id>
+    <revision>
+      <id>4683</id>
+      <parentid>4670</parentid>
+      <timestamp>2015-08-05T18:46:00Z</timestamp>
+      <contributor>
+        <username>Tester</username>
+        <id>1</id>
+      </contributor>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="82">* [[Imported from::dwc:class]] {{DISPLAYTITLE:dwc:class}}
+
+[[Category:Dwc import]]</text>
+      <sha1>mlkipjysemqufxpfqd96qro2pvrbdmq</sha1>
+    </revision>
+  </page>
+  <page>
+    <title>Property:Dwc:family</title>
+    <ns>102</ns>
+    <id>1289</id>
+    <revision>
+      <id>4684</id>
+      <parentid>4671</parentid>
+      <timestamp>2015-08-05T18:46:11Z</timestamp>
+      <contributor>
+        <username>Tester</username>
+        <id>1</id>
+      </contributor>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="84">* [[Imported from::dwc:family]] {{DISPLAYTITLE:dwc:family}}
+
+[[Category:Dwc import]]</text>
+      <sha1>ed6vrz42groes5xa8jhrrsbfdrdifmg</sha1>
+    </revision>
+  </page>
+  <page>
+    <title>GBIFID:2706490</title>
+    <ns>0</ns>
+    <id>1286</id>
+    <revision>
+      <id>4691</id>
+      <parentid>4690</parentid>
+      <timestamp>2015-08-05T18:55:46Z</timestamp>
+      <contributor>
+        <username>Tester</username>
+        <id>1</id>
+      </contributor>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="497">[[dwc:scientificName::Agrostis capillaris L.]]
+
+* [[dwc:kingdom::Plantea]]
+* [[dwc:phylum::Magnoliophyta]]
+* [[dwc:class::Liliopsida]]
+* [[dwc:order::Poales]]
+* [[dwc:family::Poaceae]]
+* [[dwc:genus::Agrostis]]
+* [[dwc:vernacularName::Gewoon struisgras@en]] [[dwc:vernacularName::Rotes Straußgras@de]] [[dwc:vernacularName::Agrostis commun@fr]] [[dwc:vernacularName::Agrostis capillaris@es]]
+* [[dwc:taxonID::1365]]
+
+[[Category:Dwc import]] __SHOWFACTBOX__ {{DISPLAYTITLE:Agrostis capillaris L.}}</text>
+      <sha1>77qals7ynkvp7t6spigid49yy59gkje</sha1>
+    </revision>
+  </page>
+</mediawiki>

--- a/tests/phpunit/Integration/ByJsonScript/ByJsonScriptFixtureTestCaseRunnerTest.php
+++ b/tests/phpunit/Integration/ByJsonScript/ByJsonScriptFixtureTestCaseRunnerTest.php
@@ -152,7 +152,9 @@ class ByJsonScriptFixtureTestCaseRunnerTest extends ByJsonTestCaseProvider {
 			'wgAllowDisplayTitle',
 			'wgRestrictDisplayTitle', // Restrict {{DISPLAYTITLE}} to titles ...
 			'smwgDVFeatures',
-			'smwgEnabledQueryDependencyLinksStore'
+			'smwgEnabledQueryDependencyLinksStore',
+			'smwgEnabledFulltextSearch',
+			'smwgFulltextDeferredUpdate'
 		);
 
 		foreach ( $permittedSettings as $key ) {
@@ -184,6 +186,14 @@ class ByJsonScriptFixtureTestCaseRunnerTest extends ByJsonTestCaseProvider {
 			);
 
 			$maintenanceRunner->setQuiet()->run();
+		}
+
+		foreach ( $jsonTestCaseFileHandler->findTestCasesFor( 'job-run' ) as $jobType ) {
+			$jobQueueRunner = UtilityFactory::getInstance()->newRunnerFactory()->newJobQueueRunner(
+				$jobType
+			);
+
+			$jobQueueRunner->run();
 		}
 
 		$this->tryToProcessParserTestCase( $jsonTestCaseFileHandler );

--- a/tests/phpunit/Integration/ByJsonScript/Fixtures/q-0104.json
+++ b/tests/phpunit/Integration/ByJsonScript/Fixtures/q-0104.json
@@ -1,0 +1,199 @@
+{
+	"description": "Test `_txt`/`~` with enabled Fulltext search support (only enabled for MySQL)",
+	"properties": [
+		{
+			"name": "Has text",
+			"contents": "[[Has type::Text]]"
+		}
+	],
+	"subjects": [
+		{
+			"name": "Example/Q0104/1",
+			"contents": "{{#subobject: |Has text=MySQL vs MariaDB database}} {{#subobject: |Has text=Oracle vs MariaDB database}} {{#subobject: |Has text=PostgreSQL vs MariaDB database and more of}} {{#subobject: |Has text=MariaDB overview}}"
+		},
+		{
+			"name": "Example/Q0104/2",
+			"contents": "{{#subobject: |Has text=Elastic search}} {{#subobject: |Has text=Sphinx search}}"
+		},
+		{
+			"name": "Example/Q0104/3",
+			"contents": "{{#subobject: |Has text=...a hyphenated phrase that has special significance when it appears at the beginning of text...}} {{#subobject: |Has text=...a hyphenated phrase that has NOT any special significance when it appears at the beginning of text...}}"
+		},
+		{
+			"name": "Example/Q0104/4",
+			"contents": "{{#subobject: |Has text=Text with a category|@category=Q0104}} {{#subobject: |Has text=Text without a category}}"
+		}
+	],
+	"job-run":[
+		"SMW\\SearchTableUpdateJob"
+	],
+	"query-testcases": [
+		{
+			"about": "#0 with boolean include/not include",
+			"condition": "[[Has text::~+MariaDB -database]]",
+			"printouts" : [],
+			"parameters" : {
+				"limit" : "10"
+			},
+			"queryresult": {
+				"count": 1,
+				"results": [
+					"Example/Q0104/1#0##_55b020117d21e4b7967cf5bf78cf6b32"
+				]
+			}
+		},
+		{
+			"about": "#1",
+			"condition": "[[Has text::~+database]]",
+			"printouts" : [],
+			"parameters" : {
+				"limit" : "10"
+			},
+			"queryresult": {
+				"count": 3,
+				"results": [
+					"Example/Q0104/1#0##_7980f674d00e51fbc91cc663a43054c5",
+					"Example/Q0104/1#0##_507a001e2e9e0e7659aa33e8c4b2d471",
+					"Example/Q0104/1#0##_1a377960fd7e6c287e97c519278761b4"
+				]
+			}
+		},
+		{
+			"about": "#2 (plus sorting)",
+			"condition": "[[Has text::~DATA*]]",
+			"printouts" : [],
+			"parameters" : {
+				"limit" : "10",
+				"sort": { "Has_text": "DESC" }
+			},
+			"queryresult": {
+				"count": 3,
+				"results": [
+					"Example/Q0104/1#0##_1a377960fd7e6c287e97c519278761b4",
+					"Example/Q0104/1#0##_507a001e2e9e0e7659aa33e8c4b2d471",
+					"Example/Q0104/1#0##_7980f674d00e51fbc91cc663a43054c5"
+				]
+			}
+		},
+		{
+			"about": "#3 (plus sorting)",
+			"condition": "[[Has text::~sear*]]",
+			"printouts" : [],
+			"parameters" : {
+				"limit" : "10",
+				"sort": { "Has_text": "ASC" }
+			},
+			"queryresult": {
+				"count": 2,
+				"results": [
+					"Example/Q0104/2#0##_977ae79c0c362dc7a2ceaf94859178e7",
+					"Example/Q0104/2#0##_29a504fbd2492700363d5491902958e9"
+				]
+			}
+		},
+		{
+			"about": "#4 include/not include",
+			"condition": "[[Has text::~sear*, -elas*]]",
+			"printouts" : [],
+			"parameters" : {
+				"limit" : "10",
+				"sort": { "Has_text": "DESC" }
+			},
+			"queryresult": {
+				"count": 1,
+				"results": [
+					"Example/Q0104/2#0##_29a504fbd2492700363d5491902958e9"
+				]
+			}
+		},
+		{
+			"about": "#5 same as #4",
+			"condition": "[[Has text::!~elastic*, +sear*]]",
+			"printouts" : [],
+			"parameters" : {
+				"limit" : "10"
+			},
+			"queryresult": {
+				"count": 1,
+				"results": [
+					"Example/Q0104/2#0##_29a504fbd2492700363d5491902958e9"
+				]
+			}
+		},
+		{
+			"about": "#6 phrase matching",
+			"condition": "[[Has text::~\"phrase that has special\"]]",
+			"printouts" : [],
+			"parameters" : {
+				"limit" : "10"
+			},
+			"queryresult": {
+				"count": 1,
+				"results": [
+					"Example/Q0104/3#0##_1aa6fcbe946e44dc061627ce545e0cd9"
+				]
+			}
+		},
+		{
+			"about": "#7 similar to #5 but not used in phrase matching mode",
+			"condition": "[[Has text::~phrase that has special]]",
+			"printouts" : [],
+			"parameters" : {
+				"limit" : "10"
+			},
+			"queryresult": {
+				"count": 2,
+				"results": [
+					"Example/Q0104/3#0##_1aa6fcbe946e44dc061627ce545e0cd9",
+					"Example/Q0104/3#0##_682a8c9f798c14548a4599b68d83b78e"
+				]
+			}
+		},
+		{
+			"about": "#8 free search",
+			"condition": "[[~~with a category]]",
+			"printouts" : [],
+			"parameters" : {
+				"limit" : "10"
+			},
+			"queryresult": {
+				"count": 2,
+				"results": [
+					"Example/Q0104/4#0##_5a524a435267f6e6d2d45d64a419c1da",
+					"Example/Q0104/4#0##_d4fe48d7241e6530c628f32168815beb"
+				]
+			}
+		},
+		{
+			"about": "#9 free search",
+			"condition": "[[~~with a category]] [[Category:Q0104]]",
+			"printouts" : [],
+			"parameters" : {
+				"limit" : "10"
+			},
+			"queryresult": {
+				"count": 1,
+				"results": [
+					"Example/Q0104/4#0##_d4fe48d7241e6530c628f32168815beb"
+				]
+			}
+		}
+	],
+	"settings": {
+		"smwgEnabledFulltextSearch": true,
+		"smwgFulltextDeferredUpdate": false
+	},
+	"meta": {
+		"skip-on": {
+			"postgres": "Not supported by PostgreSQL.",
+			"sqlite": "Not supported by SQLite.",
+			"sesame": "Not supported by SPARQLStore (Sesame).",
+			"virtuoso": "Not supported by SPARQLStore (Virtuoso).",
+			"fuseki": "Not supported by SPARQLStore (Fuskei).",
+			"blazegraph": "Not supported by SPARQLStore (Blazegraph)."
+		},
+		"version": "0.1",
+		"is-incomplete": false,
+		"debug": false
+	}
+}

--- a/tests/phpunit/Integration/MediaWiki/Import/Maintenance/RebuildFulltextSearchTableTest.php
+++ b/tests/phpunit/Integration/MediaWiki/Import/Maintenance/RebuildFulltextSearchTableTest.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace SMW\Tests\Integration\MediaWiki\Import\Maintenance;
+
+use SMW\Tests\MwDBaseUnitTestCase;
+
+/**
+ * @group semantic-mediawiki
+ * @group large
+ *
+ * @license GNU GPL v2+
+ * @since 2.5
+ *
+ * @author mwjames
+ */
+class RebuildFulltextSearchTableTest extends MwDBaseUnitTestCase {
+
+	protected $destroyDatabaseTablesAfterRun = true;
+
+	private $importedTitles = array();
+	private $runnerFactory;
+	private $titleValidator;
+
+	protected function setUp() {
+		parent::setUp();
+
+		$this->runnerFactory  = $this->testEnvironment->getUtilityFactory()->newRunnerFactory();
+		$this->titleValidator = $this->testEnvironment->getUtilityFactory()->newValidatorFactory()->newTitleValidator();
+
+		// Remove any predisposed settings
+		$this->testEnvironment->tearDown();
+
+		$importRunner = $this->runnerFactory->newXmlImportRunner(
+			$this->testEnvironment->getFixturesLocation( 'Import', 'cicero-de-finibus.xml' )
+		);
+
+		if ( !$importRunner->setVerbose( true )->run() ) {
+			$importRunner->reportFailedImport();
+			$this->markTestIncomplete( 'Test was marked as incomplete because the data import failed' );
+		}
+	}
+
+	protected function tearDown() {
+		$this->testEnvironment->flushPages( $this->importedTitles );
+		parent::tearDown();
+	}
+
+	public function testCanRun() {
+
+		$this->importedTitles = array(
+			'De Finibus Bonorum et Malorum'
+		);
+
+		$this->titleValidator->assertThatTitleIsKnown( $this->importedTitles );
+
+		$maintenanceRunner = $this->runnerFactory->newMaintenanceRunner( 'SMW\Maintenance\RebuildFulltextSearchTable' );
+		$maintenanceRunner->setQuiet()->run();
+	}
+
+}

--- a/tests/phpunit/TestEnvironment.php
+++ b/tests/phpunit/TestEnvironment.php
@@ -7,6 +7,7 @@ use SMW\DataValueFactory;
 use SMW\DeferredCallableUpdate;
 use SMW\Store;
 use SMW\Tests\Utils\UtilityFactory;
+use RuntimeException;
 
 /**
  * @license GNU GPL v2+
@@ -150,6 +151,16 @@ class TestEnvironment {
 		$this->dataValueFactory->clear();
 	}
 
+
+	/**
+	 * @since 2.5
+	 *
+	 * @param array $pages
+	 */
+	public function flushPages( $pages ) {
+		$this->getUtilityFactory()->newPageDeleter()->doDeletePoolOfPages( $pages );
+	}
+
 	/**
 	 * @since 2.4
 	 *
@@ -157,6 +168,27 @@ class TestEnvironment {
 	 */
 	public function getUtilityFactory() {
 		return UtilityFactory::getInstance();
+	}
+
+	/**
+	 * @since 2.5
+	 *
+	 * @param string $target
+	 * @param string $file
+	 *
+	 * @return string
+	 * @throws RuntimeException
+	 */
+	public function getFixturesLocation( $target = '', $file = '' ) {
+
+		$fixturesLocation = __DIR__ . '/Fixtures' . ( $target !== '' ? "/{$target}" :  '' ) . '/' . $file;
+		$fixturesLocation = str_replace( array( '\\', '/' ), DIRECTORY_SEPARATOR, $fixturesLocation );
+
+		if ( !file_exists( $fixturesLocation ) && !is_dir( $fixturesLocation ) ) {
+			throw new RuntimeException( "{$fixturesLocation} does not exist." );
+		}
+
+		return $fixturesLocation;
 	}
 
 }

--- a/tests/phpunit/Unit/MediaWiki/Hooks/HookRegistryTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Hooks/HookRegistryTest.php
@@ -881,6 +881,10 @@ class HookRegistryTest extends \PHPUnit_Framework_TestCase {
 
 		$handler = 'SMW::SQLStore::AfterDataUpdateComplete';
 
+		$connection = $this->getMockBuilder( '\SMW\MediaWiki\Database' )
+			->disableOriginalConstructor()
+			->getMock();
+
 		$propertyTableInfoFetcher = $this->getMockBuilder( '\SMW\SQLStore\PropertyTableInfoFetcher' )
 			->disableOriginalConstructor()
 			->getMock();
@@ -892,6 +896,10 @@ class HookRegistryTest extends \PHPUnit_Framework_TestCase {
 		$store->expects( $this->any() )
 			->method( 'getPropertyTableInfoFetcher' )
 			->will( $this->returnValue( $propertyTableInfoFetcher ) );
+
+		$store->expects( $this->any() )
+			->method( 'getConnection' )
+			->will( $this->returnValue( $connection ) );
 
 		$semanticData = $this->getMockBuilder( '\SMW\SemanticData' )
 			->disableOriginalConstructor()

--- a/tests/phpunit/Unit/MediaWiki/Jobs/JobFactoryTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Jobs/JobFactoryTest.php
@@ -54,4 +54,14 @@ class JobFactoryTest extends \PHPUnit_Framework_TestCase {
 		);
 	}
 
+	public function testCanConstructSearchTableUpdateJob() {
+
+		$instance = new JobFactory();
+
+		$this->assertInstanceOf(
+			'\SMW\MediaWiki\Jobs\SearchTableUpdateJob',
+			$instance->newSearchTableUpdateJob( Title::newFromText( __METHOD__ ) )
+		);
+	}
+
 }

--- a/tests/phpunit/Unit/MediaWiki/Jobs/SearchTableUpdateJobTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Jobs/SearchTableUpdateJobTest.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace SMW\Tests\MediaWiki\Jobs;
+
+use SMW\Tests\TestEnvironment;
+use SMW\DIWikiPage;
+use SMW\MediaWiki\Jobs\SearchTableUpdateJob;
+
+/**
+ * @covers \SMW\MediaWiki\Jobs\SearchTableUpdateJob
+ * @group semantic-mediawiki
+ *
+ * @license GNU GPL v2+
+ * @since 2.5
+ *
+ * @author mwjames
+ */
+class SearchTableUpdateJobTest extends \PHPUnit_Framework_TestCase {
+
+	private $testEnvironment;
+
+	protected function setUp() {
+		parent::setUp();
+
+		$this->testEnvironment = new TestEnvironment();
+
+		$this->testEnvironment->registerObject(
+			'Store',
+			$this->getMockBuilder( '\SMW\SQLStore\SQLStore' )->getMockForAbstractClass()
+		);
+	}
+
+	protected function tearDown() {
+		$this->testEnvironment->tearDown();
+		parent::tearDown();
+	}
+
+	public function testCanConstruct() {
+
+		$title = $this->getMockBuilder( 'Title' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$this->assertInstanceOf(
+			'SMW\MediaWiki\Jobs\SearchTableUpdateJob',
+			new SearchTableUpdateJob( $title )
+		);
+	}
+
+	/**
+	 * @dataProvider parametersProvider
+	 */
+	public function testJobRun( $parameters ) {
+
+		$subject = DIWikiPage::newFromText( __METHOD__ );
+
+		$instance = new SearchTableUpdateJob(
+			$subject->getTitle(),
+			$parameters
+		);
+
+		$this->assertTrue(
+			$instance->run()
+		);
+	}
+
+	public function parametersProvider() {
+
+		$provider[] = array(
+			'diff' => array( 1, 2 )
+		);
+
+		return $provider;
+	}
+
+}

--- a/tests/phpunit/Unit/SQLStore/QueryEngine/Fulltext/MySQLValueMatchConditionBuilderTest - Copy.php
+++ b/tests/phpunit/Unit/SQLStore/QueryEngine/Fulltext/MySQLValueMatchConditionBuilderTest - Copy.php
@@ -1,0 +1,224 @@
+<?php
+
+namespace SMW\Tests\SQLStore\QueryEngine\Fulltext;
+
+use SMW\SQLStore\QueryEngine\Fulltext\MySQLValueMatchConditionBuilder;
+use SMW\DataItemFactory;
+
+/**
+ * @covers \SMW\SQLStore\QueryEngine\Fulltext\MySQLValueMatchConditionBuilder
+ * @group semantic-mediawiki
+ *
+ * @license GNU GPL v2+
+ * @since 2.5
+ *
+ * @author mwjames
+ */
+class MySQLValueMatchConditionBuilderTest extends \PHPUnit_Framework_TestCase {
+
+	private $searchTable;
+	private $dataItemFactory;
+
+	protected function setUp() {
+
+		$this->dataItemFactory = new DataItemFactory();
+
+		$this->searchTable = $this->getMockBuilder( '\SMW\SQLStore\QueryEngine\Fulltext\SearchTable' )
+			->disableOriginalConstructor()
+			->getMock();
+	}
+
+	public function testCanConstruct() {
+
+		$this->assertInstanceOf(
+			'\SMW\SQLStore\QueryEngine\Fulltext\MySQLValueMatchConditionBuilder',
+			new MySQLValueMatchConditionBuilder( $this->searchTable )
+		);
+	}
+
+	public function testIsEnabled() {
+
+		$this->searchTable->expects( $this->once() )
+			->method( 'isEnabled' )
+			->will( $this->returnValue( true ) );
+
+		$instance = new MySQLValueMatchConditionBuilder(
+			$this->searchTable
+		);
+
+		$this->assertTrue(
+			$instance->isEnabled()
+		);
+	}
+
+	public function testGetTableName() {
+
+		$this->searchTable->expects( $this->once() )
+			->method( 'getTableName' )
+			->will( $this->returnValue( 'Foo' ) );
+
+		$instance = new MySQLValueMatchConditionBuilder(
+			$this->searchTable
+		);
+
+		$this->assertEquals(
+			'Foo',
+			$instance->getTableName()
+		);
+	}
+
+	public function testHasMinTokenLength() {
+
+		$this->searchTable->expects( $this->any() )
+			->method( 'getMinTokenSize' )
+			->will( $this->returnValue( 4 ) );
+
+		$instance = new MySQLValueMatchConditionBuilder(
+			$this->searchTable
+		);
+
+		$this->assertFalse(
+			$instance->hasMinTokenLength( 'bar' )
+		);
+
+		$this->assertFalse(
+			$instance->hasMinTokenLength( 'テスト' )
+		);
+
+		$this->assertTrue(
+			$instance->hasMinTokenLength( 'test' )
+		);
+	}
+
+	public function testGetSortIndexField() {
+
+		$this->searchTable->expects( $this->any() )
+			->method( 'getSortField' )
+			->will( $this->returnValue( 's_id' ) );
+
+		$instance = new MySQLValueMatchConditionBuilder(
+			$this->searchTable
+		);
+
+		$this->assertEquals(
+			'Foo.s_id',
+			$instance->getSortIndexField( 'Foo' )
+		);
+	}
+
+	public function testCanApplyFulltextSearchMatchCondition() {
+
+		$this->searchTable->expects( $this->once() )
+			->method( 'isEnabled' )
+			->will( $this->returnValue( true ) );
+
+		$this->searchTable->expects( $this->once() )
+			->method( 'isExemptedProperty' )
+			->will( $this->returnValue( false ) );
+
+		$instance = new MySQLValueMatchConditionBuilder(
+			$this->searchTable
+		);
+
+		$description = $this->getMockBuilder( '\SMW\Query\Language\ValueDescription' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$description->expects( $this->atLeastOnce() )
+			->method( 'getProperty' )
+			->will( $this->returnValue( $this->dataItemFactory->newDIProperty( 'Foo' ) ) );
+
+		$description->expects( $this->atLeastOnce() )
+			->method( 'getDataItem' )
+			->will( $this->returnValue( $this->dataItemFactory->newDIBlob( 'Bar' ) ) );
+
+		$description->expects( $this->once() )
+			->method( 'getComparator' )
+			->will( $this->returnValue( SMW_CMP_LIKE ) );
+
+		$this->assertTrue(
+			$instance->canApplyFulltextSearchMatchCondition( $description )
+		);
+	}
+
+	/**
+	 * @dataProvider searchTermProvider
+	 */
+	public function testGetWhereConditionWithoutProperty( $text, $indexField, $expected ) {
+
+		$textSanitizer = $this->getMockBuilder( '\SMW\SQLStore\QueryEngine\Fulltext\TextSanitizer' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$textSanitizer->expects( $this->once() )
+			->method( 'sanitize' )
+			->will( $this->returnValue( $text ) );
+
+		$this->searchTable->expects( $this->any() )
+			->method( 'isEnabled' )
+			->will( $this->returnValue( true ) );
+
+		$this->searchTable->expects( $this->once() )
+			->method( 'getTextSanitizer' )
+			->will( $this->returnValue( $textSanitizer ) );
+
+		$this->searchTable->expects( $this->once() )
+			->method( 'getIndexField' )
+			->will( $this->returnValue( $indexField ) );
+
+		$this->searchTable->expects( $this->once() )
+			->method( 'addQuotes' )
+			->will( $this->returnArgument( 0 ) );
+
+		$instance = new MySQLValueMatchConditionBuilder(
+			$this->searchTable
+		);
+
+		$description = $this->getMockBuilder( '\SMW\Query\Language\ValueDescription' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$description->expects( $this->atLeastOnce() )
+			->method( 'getDataItem' )
+			->will( $this->returnValue( $this->dataItemFactory->newDIBlob( 'Bar' ) ) );
+
+		$description->expects( $this->once() )
+			->method( 'getComparator' )
+			->will( $this->returnValue( SMW_CMP_LIKE ) );
+
+		$this->assertEquals(
+			$expected,
+			$instance->getWhereCondition( $description )
+		);
+	}
+
+	public function searchTermProvider() {
+
+		$provider[] = array(
+			'foooo',
+			'barColumn',
+			"MATCH(barColumn) AGAINST (foooo IN BOOLEAN MODE) "
+		);
+
+		$provider[] = array(
+			'foooo&BOL',
+			'barColumn',
+			"MATCH(barColumn) AGAINST (foooo IN BOOLEAN MODE) "
+		);
+
+		$provider[] = array(
+			'foooo&INL',
+			'barColumn',
+			"MATCH(barColumn) AGAINST (foooo IN NATURAL LANGUAGE MODE) "
+		);
+
+		$provider[] = array(
+			'foooo&QEX',
+			'barColumn',
+			"MATCH(barColumn) AGAINST (foooo WITH QUERY EXPANSION) "
+		);
+
+		return $provider;
+	}
+
+}

--- a/tests/phpunit/Unit/SQLStore/QueryEngine/Fulltext/SearchTableRebuilderTest.php
+++ b/tests/phpunit/Unit/SQLStore/QueryEngine/Fulltext/SearchTableRebuilderTest.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace SMW\Tests\SQLStore\QueryEngine\Fulltext;
+
+use SMW\SQLStore\QueryEngine\Fulltext\SearchTableRebuilder;
+use SMWDataItem as DataItem;
+
+/**
+ * @covers \SMW\SQLStore\QueryEngine\Fulltext\SearchTableRebuilder
+ * @group semantic-mediawiki
+ *
+ * @license GNU GPL v2+
+ * @since 2.5
+ *
+ * @author mwjames
+ */
+class SearchTableRebuilderTest extends \PHPUnit_Framework_TestCase {
+
+	private $searchTableUpdater;
+	private $connection;
+
+	protected function setUp() {
+
+		$this->searchTableUpdater = $this->getMockBuilder( '\SMW\SQLStore\QueryEngine\Fulltext\SearchTableUpdater' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$this->connection = $this->getMockBuilder( '\SMW\MediaWiki\Database' )
+			->disableOriginalConstructor()
+			->getMock();
+	}
+
+	public function testCanConstruct() {
+
+		$this->assertInstanceOf(
+			'\SMW\SQLStore\QueryEngine\Fulltext\SearchTableRebuilder',
+			new SearchTableRebuilder( $this->searchTableUpdater, $this->connection )
+		);
+	}
+
+	public function testRunWithoutUpdate() {
+
+		$tableDefinition = $this->getMockBuilder( '\SMW\SQLStore\TableDefinition' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$tableDefinition->expects( $this->atLeastOnce() )
+			->method( 'getDiType' )
+			->will( $this->returnValue( DataItem::TYPE_BLOB ) );
+
+		$this->searchTableUpdater->expects( $this->once() )
+			->method( 'isEnabled' )
+			->will( $this->returnValue( true ) );
+
+		$this->searchTableUpdater->expects( $this->atLeastOnce() )
+			->method( 'getPropertyTables' )
+			->will( $this->returnValue( array( $tableDefinition ) ) );
+
+		$instance = new SearchTableRebuilder(
+			$this->searchTableUpdater,
+			$this->connection
+		);
+
+		$instance->run();
+	}
+
+}

--- a/tests/phpunit/Unit/SQLStore/QueryEngine/Fulltext/SearchTableTest.php
+++ b/tests/phpunit/Unit/SQLStore/QueryEngine/Fulltext/SearchTableTest.php
@@ -1,0 +1,100 @@
+<?php
+
+namespace SMW\Tests\SQLStore\QueryEngine\Fulltext;
+
+use SMW\SQLStore\QueryEngine\Fulltext\SearchTable;
+use SMW\DataItemFactory;
+
+/**
+ * @covers \SMW\SQLStore\QueryEngine\Fulltext\SearchTable
+ * @group semantic-mediawiki
+ *
+ * @license GNU GPL v2+
+ * @since 2.5
+ *
+ * @author mwjames
+ */
+class SearchTableTest extends \PHPUnit_Framework_TestCase {
+
+	private $store;
+	private $textSanitizer;
+	private $dataItemFactory;
+
+	protected function setUp() {
+
+		$this->dataItemFactory = new DataItemFactory();
+
+		$this->store = $this->getMockBuilder( '\SMW\SQLStore\SQLStore' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$this->textSanitizer = $this->getMockBuilder( '\SMW\SQLStore\QueryEngine\Fulltext\TextSanitizer' )
+			->disableOriginalConstructor()
+			->getMock();
+	}
+
+	public function testCanConstruct() {
+
+		$this->assertInstanceOf(
+			'\SMW\SQLStore\QueryEngine\Fulltext\SearchTable',
+			new SearchTable( $this->store, $this->textSanitizer )
+		);
+	}
+
+	public function testIsEnabled() {
+
+		$instance = new SearchTable(
+			$this->store,
+			$this->textSanitizer
+		);
+
+		$instance->setEnabled( true );
+
+		$this->assertTrue(
+			$instance->isEnabled()
+		);
+	}
+
+	public function testGetPropertyExemptionList() {
+
+		$instance = new SearchTable(
+			$this->store,
+			$this->textSanitizer
+		);
+
+		$instance->setPropertyExemptionList(
+			array( '_TEXT','fo oo' )
+		);
+
+		$this->assertEquals(
+			array( '_TEXT', 'fo_oo' ),
+			$instance->getPropertyExemptionList()
+		);
+	}
+
+	public function testIsExemptedProperty() {
+
+		$instance = new SearchTable(
+			$this->store,
+			$this->textSanitizer
+		);
+
+		$instance->setPropertyExemptionList(
+			array( '_TEXT' )
+		);
+
+		$property = $this->dataItemFactory->newDIProperty( '_TEXT' );
+
+		$this->assertTrue(
+			$instance->isExemptedProperty( $property )
+		);
+
+		$property = $this->dataItemFactory->newDIProperty( 'Foo' );
+		$property->setPropertyTypeId( '_uri' );
+
+		$this->assertFalse(
+			$instance->isExemptedProperty( $property )
+		);
+	}
+
+}

--- a/tests/phpunit/Unit/SQLStore/QueryEngine/Fulltext/SearchTableUpdaterTest.php
+++ b/tests/phpunit/Unit/SQLStore/QueryEngine/Fulltext/SearchTableUpdaterTest.php
@@ -1,0 +1,159 @@
+<?php
+
+namespace SMW\Tests\SQLStore\QueryEngine\Fulltext;
+
+use SMW\SQLStore\QueryEngine\Fulltext\SearchTableUpdater;
+
+/**
+ * @covers \SMW\SQLStore\QueryEngine\Fulltext\SearchTableUpdater
+ * @group semantic-mediawiki
+ *
+ * @license GNU GPL v2+
+ * @since 2.5
+ *
+ * @author mwjames
+ */
+class SearchTableUpdaterTest extends \PHPUnit_Framework_TestCase {
+
+	private $searchTable;
+	private $connection;
+
+	protected function setUp() {
+
+		$this->searchTable = $this->getMockBuilder( '\SMW\SQLStore\QueryEngine\Fulltext\SearchTable' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$this->connection = $this->getMockBuilder( '\SMW\MediaWiki\Database' )
+			->disableOriginalConstructor()
+			->getMock();
+	}
+
+	public function testCanConstruct() {
+
+		$this->assertInstanceOf(
+			'\SMW\SQLStore\QueryEngine\Fulltext\SearchTableUpdater',
+			new SearchTableUpdater( $this->searchTable, $this->connection )
+		);
+	}
+
+	public function testRead() {
+
+		$textSanitizer = $this->getMockBuilder( '\SMW\SQLStore\QueryEngine\Fulltext\TextSanitizer' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$this->searchTable->expects( $this->once() )
+			->method( 'getTextSanitizer' )
+			->will( $this->returnValue( $textSanitizer ) );
+
+		$row = new \stdClass;
+		$row->o_text = 'Foo';
+
+		$this->connection->expects( $this->once() )
+			->method( 'selectRow' )
+			->with(
+				$this->anything(),
+				$this->equalTo( array( 'o_text' ) ),
+				$this->equalTo( array( 's_id' => 12, 'p_id' => 42 ) ) )
+			->will( $this->returnValue( $row ) );
+
+		$instance = new SearchTableUpdater(
+			$this->searchTable,
+			$this->connection
+		);
+
+		$instance->read( 12, 42 );
+	}
+
+	public function testUpdateWithText() {
+
+		$textSanitizer = $this->getMockBuilder( '\SMW\SQLStore\QueryEngine\Fulltext\TextSanitizer' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$this->searchTable->expects( $this->once() )
+			->method( 'getTextSanitizer' )
+			->will( $this->returnValue( $textSanitizer ) );
+
+		$this->connection->expects( $this->once() )
+			->method( 'update' );
+
+		$instance = new SearchTableUpdater(
+			$this->searchTable,
+			$this->connection
+		);
+
+		$instance->update( 12, 42, 'foo' );
+	}
+
+	public function testDeleteOnUpdateWithEmptyText() {
+
+		$this->connection->expects( $this->once() )
+			->method( 'delete' );
+
+		$this->connection->expects( $this->never() )
+			->method( 'update' );
+
+		$instance = new SearchTableUpdater(
+			$this->searchTable,
+			$this->connection
+		);
+
+		$instance->update( 12, 42, ' ' );
+	}
+
+	public function testInsert() {
+
+		$this->connection->expects( $this->once() )
+			->method( 'insert' )
+			->with(
+				$this->anything(),
+				$this->equalTo( array(
+					's_id' => 12,
+					'p_id' => 42,
+					'o_text' => '' ) ) );
+
+		$instance = new SearchTableUpdater(
+			$this->searchTable,
+			$this->connection
+		);
+
+		$instance->insert( 12, 42 );
+	}
+
+	public function testDelete() {
+
+		$this->connection->expects( $this->once() )
+			->method( 'delete' )
+			->with(
+				$this->anything(),
+				$this->equalTo( array(
+					's_id' => 12,
+					'p_id' => 42 ) ) );
+
+		$instance = new SearchTableUpdater(
+			$this->searchTable,
+			$this->connection
+		);
+
+		$instance->delete( 12, 42 );
+	}
+
+	public function testFlushTable() {
+
+		$this->connection->expects( $this->once() )
+			->method( 'delete' )
+			->with(
+				$this->anything(),
+				$this->equalTo( '*' ) );
+
+		$instance = new SearchTableUpdater(
+			$this->searchTable,
+			$this->connection
+		);
+
+		$instance->flushTable();
+	}
+
+}

--- a/tests/phpunit/Unit/SQLStore/QueryEngine/Fulltext/TextByChangeUpdaterTest.php
+++ b/tests/phpunit/Unit/SQLStore/QueryEngine/Fulltext/TextByChangeUpdaterTest.php
@@ -1,0 +1,110 @@
+<?php
+
+namespace SMW\Tests\SQLStore\QueryEngine\Fulltext;
+
+use SMW\SQLStore\QueryEngine\Fulltext\TextByChangeUpdater;
+use SMW\DataItemFactory;
+
+/**
+ * @covers \SMW\SQLStore\QueryEngine\Fulltext\TextByChangeUpdater
+ * @group semantic-mediawiki
+ *
+ * @license GNU GPL v2+
+ * @since 2.5
+ *
+ * @author mwjames
+ */
+class TextByChangeUpdaterTest extends \PHPUnit_Framework_TestCase {
+
+	private $searchTableUpdater;
+	private $connection;
+	private $dataItemFactory;
+
+	protected function setUp() {
+
+		$this->dataItemFactory = new DataItemFactory();
+
+		$this->searchTableUpdater = $this->getMockBuilder( '\SMW\SQLStore\QueryEngine\Fulltext\SearchTableUpdater' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$this->connection = $this->getMockBuilder( '\SMW\MediaWiki\Database' )
+			->disableOriginalConstructor()
+			->getMock();
+	}
+
+	public function testCanConstruct() {
+
+		$this->assertInstanceOf(
+			'\SMW\SQLStore\QueryEngine\Fulltext\TextByChangeUpdater',
+			new TextByChangeUpdater( $this->searchTableUpdater, $this->connection )
+		);
+	}
+
+	public function testPushUpdatesOnDisabledDeferredUpdateAndNullChange() {
+
+		$this->searchTableUpdater->expects( $this->once() )
+			->method( 'isEnabled' )
+			->will( $this->returnValue( true ) );
+
+		$compositePropertyTableDiffIterator = $this->getMockBuilder( '\SMW\SQLStore\CompositePropertyTableDiffIterator' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$compositePropertyTableDiffIterator->expects( $this->once() )
+			->method( 'getTableChangeOps' )
+			->will( $this->returnValue( array() ) );
+
+		$deferredRequestDispatchManager = $this->getMockBuilder( '\SMW\DeferredRequestDispatchManager' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$instance = new TextByChangeUpdater(
+			$this->searchTableUpdater,
+			$this->connection
+		);
+
+		$subject = $this->dataItemFactory->newDIWikiPage( 'Foo', NS_MAIN );
+
+		$instance->asDeferredUpdate( false );
+
+		$instance->pushUpdates(
+			$subject,
+			$compositePropertyTableDiffIterator,
+			$deferredRequestDispatchManager
+		);
+	}
+
+	public function testPushUpdatesAsDeferredUpdate() {
+
+		$compositePropertyTableDiffIterator = $this->getMockBuilder( '\SMW\SQLStore\CompositePropertyTableDiffIterator' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$deferredRequestDispatchManager = $this->getMockBuilder( '\SMW\DeferredRequestDispatchManager' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$deferredRequestDispatchManager->expects( $this->once() )
+			->method( 'dispatchSearchTableUpdateJobFor' )
+			->with(
+				$this->anything(),
+				$this->equalTo( array( 'diff' => null ) ) );
+
+		$instance = new TextByChangeUpdater(
+			$this->searchTableUpdater,
+			$this->connection
+		);
+
+		$subject = $this->dataItemFactory->newDIWikiPage( 'Foo', NS_MAIN );
+
+		$instance->asDeferredUpdate( true );
+
+		$instance->pushUpdates(
+			$subject,
+			$compositePropertyTableDiffIterator,
+			$deferredRequestDispatchManager
+		);
+	}
+
+}

--- a/tests/phpunit/Unit/SQLStore/QueryEngine/Fulltext/TextSanitizerTest.php
+++ b/tests/phpunit/Unit/SQLStore/QueryEngine/Fulltext/TextSanitizerTest.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace SMW\Tests\SQLStore\QueryEngine\Fulltext;
+
+use SMW\SQLStore\QueryEngine\Fulltext\TextSanitizer;
+
+/**
+ * @covers \SMW\SQLStore\QueryEngine\Fulltext\TextSanitizer
+ * @group semantic-mediawiki
+ *
+ * @license GNU GPL v2+
+ * @since 2.5
+ *
+ * @author mwjames
+ */
+class TextSanitizerTest extends \PHPUnit_Framework_TestCase {
+
+	private $sanitizerFactory;
+
+	protected function setUp() {
+
+		$this->sanitizerFactory = $this->getMockBuilder( '\Onoi\Tesa\SanitizerFactory' )
+			->disableOriginalConstructor()
+			->getMock();
+	}
+
+	public function testCanConstruct() {
+
+		$this->assertInstanceOf(
+			'\SMW\SQLStore\QueryEngine\Fulltext\TextSanitizer',
+			new TextSanitizer( $this->sanitizerFactory )
+		);
+	}
+
+	public function testSanitize() {
+
+		$sanitizer = $this->getMockBuilder( '\Onoi\Tesa\Sanitizer' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$stopwordAnalyzer = $this->getMockBuilder( '\Onoi\Tesa\StopwordAnalyzer\StopwordAnalyzer' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$synonymizer = $this->getMockBuilder( '\Onoi\Tesa\Synonymizer\Synonymizer' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$tokenizer = $this->getMockBuilder( '\Onoi\Tesa\Tokenizer\Tokenizer' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$this->sanitizerFactory->expects( $this->atLeastOnce() )
+			->method( 'newSanitizer' )
+			->will( $this->returnValue( $sanitizer ) );
+
+		$this->sanitizerFactory->expects( $this->atLeastOnce() )
+			->method( 'newPreferredTokenizerByLanguage' )
+			->will( $this->returnValue( $tokenizer ) );
+
+		$this->sanitizerFactory->expects( $this->atLeastOnce() )
+			->method( 'newStopwordAnalyzerByLanguage' )
+			->will( $this->returnValue( $stopwordAnalyzer ) );
+
+		$this->sanitizerFactory->expects( $this->atLeastOnce() )
+			->method( 'newSynonymizerByLanguage' )
+			->will( $this->returnValue( $synonymizer ) );
+
+		$instance = new TextSanitizer(
+			$this->sanitizerFactory
+		);
+
+		$instance->sanitize( 'foo' );
+	}
+
+}

--- a/tests/phpunit/Unit/SQLStore/QueryEngine/FulltextSearchTableFactoryTest.php
+++ b/tests/phpunit/Unit/SQLStore/QueryEngine/FulltextSearchTableFactoryTest.php
@@ -1,0 +1,131 @@
+<?php
+
+namespace SMW\Tests\SQLStore\QueryEngine;
+
+use SMW\SQLStore\QueryEngine\FulltextSearchTableFactory;
+
+/**
+ * @covers \SMW\SQLStore\QueryEngine\FulltextSearchTableFactory
+ * @group semantic-mediawiki
+ *
+ * @license GNU GPL v2+
+ * @since 2.5
+ *
+ * @author mwjames
+ */
+class FulltextSearchTableFactoryTest extends \PHPUnit_Framework_TestCase {
+
+	private $store;
+
+	protected function setUp() {
+
+		$this->store = $this->getMockBuilder( '\SMW\SQLStore\SQLStore' )
+			->disableOriginalConstructor()
+			->getMock();
+	}
+
+	public function testCanConstructValueMatchConditionBuilderOnUnknownConnectionType() {
+
+		$connection = $this->getMockBuilder( '\SMW\MediaWiki\Database' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$this->store->expects( $this->once() )
+			->method( 'getConnection' )
+			->will( $this->returnValue( $connection ) );
+
+		$instance = new FulltextSearchTableFactory();
+
+		$this->assertInstanceOf(
+			'\SMW\SQLStore\QueryEngine\Fulltext\ValueMatchConditionBuilder',
+			$instance->newValueMatchConditionBuilderByType( $this->store )
+		);
+	}
+
+	public function testCanConstructValueMatchConditionBuilderOnMySQLConnectionType() {
+
+		$connection = $this->getMockBuilder( '\SMW\MediaWiki\Database' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$connection->expects( $this->once() )
+			->method( 'getType' )
+			->will( $this->returnValue( 'mysql' ) );
+
+		$this->store->expects( $this->atLeastOnce() )
+			->method( 'getConnection' )
+			->will( $this->returnValue( $connection ) );
+
+		$instance = new FulltextSearchTableFactory();
+
+		$this->assertInstanceOf(
+			'\SMW\SQLStore\QueryEngine\Fulltext\MySQLValueMatchConditionBuilder',
+			$instance->newValueMatchConditionBuilderByType( $this->store )
+		);
+	}
+
+	public function testCanConstructSearchTable() {
+
+		$instance = new FulltextSearchTableFactory();
+
+		$this->assertInstanceOf(
+			'\SMW\SQLStore\QueryEngine\Fulltext\SearchTable',
+			$instance->newSearchTable( $this->store )
+		);
+	}
+
+	public function testCanConstructSearchTableUpdater() {
+
+		$connection = $this->getMockBuilder( '\SMW\MediaWiki\Database' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$this->store->expects( $this->atLeastOnce() )
+			->method( 'getConnection' )
+			->will( $this->returnValue( $connection ) );
+
+		$instance = new FulltextSearchTableFactory();
+
+		$this->assertInstanceOf(
+			'\SMW\SQLStore\QueryEngine\Fulltext\SearchTableUpdater',
+			$instance->newSearchTableUpdater( $this->store )
+		);
+	}
+
+	public function testCanConstructTextByChangeUpdater() {
+
+		$connection = $this->getMockBuilder( '\SMW\MediaWiki\Database' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$this->store->expects( $this->atLeastOnce() )
+			->method( 'getConnection' )
+			->will( $this->returnValue( $connection ) );
+
+		$instance = new FulltextSearchTableFactory();
+
+		$this->assertInstanceOf(
+			'\SMW\SQLStore\QueryEngine\Fulltext\TextByChangeUpdater',
+			$instance->newTextByChangeUpdater( $this->store )
+		);
+	}
+
+	public function testCanConstructSearchTableRebuilder() {
+
+		$connection = $this->getMockBuilder( '\SMW\MediaWiki\Database' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$this->store->expects( $this->atLeastOnce() )
+			->method( 'getConnection' )
+			->will( $this->returnValue( $connection ) );
+
+		$instance = new FulltextSearchTableFactory();
+
+		$this->assertInstanceOf(
+			'\SMW\SQLStore\QueryEngine\Fulltext\SearchTableRebuilder',
+			$instance->newSearchTableRebuilder( $this->store )
+		);
+	}
+
+}


### PR DESCRIPTION
## Problem

Using LIKE/NLIKE matches on values instance longer than 72 char is currently not supported [0] and even if the character length is extended it would most likely create performance issues due to [1].

## Solution
This PR adds MySQL [fulltext index](http://dev.mysql.com/doc/refman/5.7/en/fulltext-search.html) to help improve performance and match condition support (using LIKE/NLIKE on text fields can be an expensive endeavour [1], is case sensitive etc.) on text contents.

All `~`/`!~` operations remain, only that in case of `$GLOBALS['smwgEnabledFulltextSearch']` being enabled the new `smw_ft_search` table uses the `MATCH ... AGAINST` query syntax to match the MySQL/MariaDB fulltext implementation.

On the occasion that this feature was enabled, `setupStore.php` is required to be run first followed by the `rebuildFulltextSearchTable.php` script.

This experimental feature is not enabled by default (`$GLOBALS['smwgEnabledFulltextSearch'] = false;`) and is only implemented for MySQL/MariaDB.

### Features and limitations

- Text value indexing happens independently from existing tables using a dedicated `smw_ft_search` consolidation table with text values only being updated when `CompositePropertyTableDiffIterator` returns with an appropriate update entry
- Fulltext match search is only executed when the `~`/`!~` expression are used
- Text values longer than > 255 chars can be (DIBlob types) searched
- Support for phrase matching
-  `IN BOOLEAN MODE`[3] is enabled by default for queries
- Other MySQL search modifiers are supported by adding `&BOOL` (IN BOOLEAN MODE), `&INL` (IN NATURAL LANGUAGE MODE), and `&QE` (WITH QUERY EXPANSION) to a condition statement (e.g. `[[Has text::~+foo, -bar&BOOL]]`) [4]
- Only `DIBlob` values are selected for the index process

### Settings

- `smwgEnabledFulltextSearch` requires to be set `true` with `update.php` / `setupStore.php` being executed thereafter, and `rebuildFulltextSearchTable.php` to rebuild the index table
- `smwgFulltextSearchTableOptions` (internal table settings)
- `smwgFulltextSearchMinTokenSize` (default = 3) is expected to correspond to either `innodb_ft_min_token_size` or `ft_min_word_len` (this helps us to switch back to LIKE in cases where the min threshold is not applicable)
- `rebuildFulltextSearchTable.php` is provided to collect and rebuild the text index in its entirety

## Technical notes

After a subject is stored, the `CompositePropertyTableDiffIterator` contains all elements that have been deleted or inserted during the storage transaction and `FulltextSearchTableUpdater::addUpdatesFromPropertyTableDiff` is filtering and concatenating those values that are eligible for index storage (in the `smw_ft_search` table). Any indexing, tokenzing, stopword or stemmer application is left the MySQL/MariaDB backend to handle.

![image](https://cloud.githubusercontent.com/assets/1245473/14126577/2b394b88-f612-11e5-8feb-b2388ae0ff4b.png)

![image](https://cloud.githubusercontent.com/assets/1245473/14129359/c3355096-f629-11e5-8e80-a6d9d884251f.png)

[0] https://github.com/SemanticMediaWiki/SemanticMediaWiki/blob/master/includes/storage/SQLStore/SMW_DIHandler_Blob.php#L17-L34
[1] http://stackoverflow.com/questions/224714/what-is-full-text-search-vs-like and http://stackoverflow.com/questions/5629491/mysql-full-text-search-vs-like
[2] http://dev.mysql.com/doc/refman/5.7/en/fulltext-search.html
[3] http://dev.mysql.com/doc/refman/5.7/en/fulltext-boolean.html
[4] http://www.drdobbs.com/database/full-text-search-with-innodb/231902587?pgno=2