### PR TITLE
Add `SMW::FileUpload::BeforeUpdate`

### DIFF
--- a/docs/technical/code-snippets/hooks.fileupload.beforeupdate.md
+++ b/docs/technical/code-snippets/hooks.fileupload.beforeupdate.md
@@ -1,0 +1,28 @@
+## SMW::FileUpload::BeforeUpdate hook
+
+SMW 2.4
+
+```php
+use SMW\DataItemFactory
+
+$GLOBALS['wgHooks']['SMW::FileUpload::BeforeUpdate'][] = function ( $filePage, $semanticData ) {
+
+	$dataItemFactory = new DataItemFactory();
+
+	$property = $dataItemFactory->newDIProperty( '___ext_file_sha1' );
+
+	$semanticData->addPropertyObjectValue(
+		$property,
+		$dataItemFactory->newDIBlob( $filePage->getFile()->getSha1() )
+	);
+
+	$property = $dataItemFactory->newDIProperty( '___ext_file_size' );
+
+	$semanticData->addPropertyObjectValue(
+		$property,
+		$dataItemFactory->newDIBlob( $filePage->getFile()->getSize() )
+	);
+
+	return true;
+};
+```

--- a/docs/technical/hooks.md
+++ b/docs/technical/hooks.md
@@ -35,6 +35,10 @@ Implementing a hook should be made in consideration of the expected performance 
 - `SMW::SQLStore::AfterDataUpdateComplete` to add processing after the update has been completed and provides `CompositePropertyTableDiffIterator` to identify entities
    that have been added/removed during the update. <sup>Use of `SMWSQLStore3::updateDataAfter` was deprecated with 2.3</sup>
 
+### 2.4
+
+- `SMW::FileUpload::BeforeUpdate` to add extra annotations before the store update is triggered
+
 For implementation details and examples, see the [integration test](https://github.com/SemanticMediaWiki/SemanticMediaWiki/blob/master/tests/phpunit/Integration/SemanticMediaWikiProvidedHookInterfaceIntegrationTest.php).
 
 ## Other available hooks

--- a/src/MediaWiki/Hooks/FileUpload.php
+++ b/src/MediaWiki/Hooks/FileUpload.php
@@ -86,6 +86,9 @@ class FileUpload {
 
 		$propertyAnnotator->addAnnotation();
 
+		// 2.4+
+		\Hooks::run( 'SMW::FileUpload::BeforeUpdate', array( $filePage, $parserData->getSemanticData() ) );
+
 		$parserData->pushSemanticDataToParserOutput();
 		$parserData->updateStore( true );
 


### PR DESCRIPTION
A hook for the upload event to avoid having users to override
the method or trigger an extra `updateStore` event which causes symptoms
as described in [0].

[0] http://wikimedia.7.x6.nabble.com/Setting-new-predefined-property-tp5061956.html