### PR TITLE
Add statistics on outdated entities, refs #1100

### DIFF
--- a/i18n/en.json
+++ b/i18n/en.json
@@ -174,6 +174,7 @@
 	"smw-statistics-subobject-count": "{{PLURAL:$1|Subobject|Subobjects}}",
 	"smw-statistics-datatype-count": "[[Special:Types|{{PLURAL:$1|Datatype|Datatypes}}]]",
 	"smw-statistics-error-count": "{{PLURAL:$1|Property value|Property values}} ([[Property:Has improper value for|{{PLURAL:$1|improper annotation|improper annotations}}]])",
+	"smw-statistics-delete-count": "Outdated {{PLURAL:$1|entity|entities}} (marked for removal)",
 	"smw_uri_doc": "The URI resolver implements the [$1 W3C TAG finding on httpRange-14].\nIt takes care that humans do not turn into websites.",
 	"ask": "Semantic search",
 	"smw_ask_doculink": "https://www.semantic-mediawiki.org/wiki/Help:Semantic_search",

--- a/src/MediaWiki/Api/Info.php
+++ b/src/MediaWiki/Api/Info.php
@@ -29,6 +29,7 @@ class Info extends ApiBase {
 
 		if ( in_array( 'propcount', $requestedInfo )
 			|| in_array( 'errorcount', $requestedInfo )
+			|| in_array( 'deletecount', $requestedInfo )
 			|| in_array( 'usedpropcount', $requestedInfo )
 			|| in_array( 'proppagecount', $requestedInfo )
 			|| in_array( 'querycount', $requestedInfo )
@@ -43,6 +44,7 @@ class Info extends ApiBase {
 			$map = array(
 				'propcount' => 'PROPUSES',
 				'errorcount' => 'ERRORUSES',
+				'deletecount' => 'DELETECOUNT',
 				'usedpropcount' => 'USEDPROPS',
 				'declaredpropcount' => 'DECLPROPS',
 				'proppagecount' => 'OWNPAGE',
@@ -83,6 +85,7 @@ class Info extends ApiBase {
 				ApiBase::PARAM_TYPE => array(
 					'propcount',
 					'errorcount',
+					'deletecount',
 					'usedpropcount',
 					'declaredpropcount',
 					'proppagecount',

--- a/src/MediaWiki/Hooks/SpecialStatsAddExtra.php
+++ b/src/MediaWiki/Hooks/SpecialStatsAddExtra.php
@@ -52,14 +52,15 @@ class SpecialStatsAddExtra {
 	 * @var string[]
 	 */
 	protected $messageMapper = array(
-		'PROPUSES'   => 'smw-statistics-property-instance',
-		'ERRORUSES'  => 'smw-statistics-error-count',
-		'USEDPROPS'  => 'smw-statistics-property-total',
-		'OWNPAGE'    => 'smw-statistics-property-page',
-		'DECLPROPS'  => 'smw-statistics-property-type',
-		'SUBOBJECTS' => 'smw-statistics-subobject-count',
-		'QUERY'      => 'smw-statistics-query-inline',
-		'CONCEPTS'   => 'smw-statistics-concept-count',
+		'PROPUSES'    => 'smw-statistics-property-instance',
+		'ERRORUSES'   => 'smw-statistics-error-count',
+		'USEDPROPS'   => 'smw-statistics-property-total',
+		'OWNPAGE'     => 'smw-statistics-property-page',
+		'DECLPROPS'   => 'smw-statistics-property-type',
+		'DELETECOUNT' => 'smw-statistics-delete-count',
+		'SUBOBJECTS'  => 'smw-statistics-subobject-count',
+		'QUERY'       => 'smw-statistics-query-inline',
+		'CONCEPTS'    => 'smw-statistics-concept-count',
 	);
 
 	/**

--- a/src/SQLStore/Lookup/UsageStatisticsListLookup.php
+++ b/src/SQLStore/Lookup/UsageStatisticsListLookup.php
@@ -67,7 +67,8 @@ class UsageStatisticsListLookup implements ListLookup {
 			'DECLPROPS' => $this->getDeclaredPropertiesCount(),
 			'PROPUSES' => $this->getPropertyUsageCount(),
 			'USEDPROPS' => $this->getUsedPropertiesCount(),
-			'ERRORUSES' => $this->getImproperValueForCount()
+			'ERRORUSES' => $this->getImproperValueForCount(),
+			'DELETECOUNT' => $this->getDeleteCount()
 		);
 	}
 
@@ -251,6 +252,26 @@ class UsageStatisticsListLookup implements ListLookup {
 			array( $this->store->getStatisticsTable() ),
 			'Count( * ) AS count',
 			array( 'usage_count > 0' ),
+			__METHOD__
+		);
+
+		$count = $row ? $row->count : $count;
+
+		return (int)$count;
+	}
+
+	/**
+	 * @since 2.4
+	 *
+	 * @return number
+	 */
+	public function getDeleteCount() {
+		$count = 0;
+
+		$row = $this->store->getConnection()->selectRow(
+			SQLStore::ID_TABLE,
+			'Count( * ) AS count',
+			array( 'smw_iw' => ':smw-delete' ),
 			__METHOD__
 		);
 

--- a/tests/phpunit/Unit/SQLStore/Lookup/UsageStatisticsListLookupTest.php
+++ b/tests/phpunit/Unit/SQLStore/Lookup/UsageStatisticsListLookupTest.php
@@ -172,7 +172,8 @@ class UsageStatisticsListLookupTest extends \PHPUnit_Framework_TestCase {
 			array( 'DECLPROPS',    'integer' ),
 			array( 'USEDPROPS',    'integer' ),
 			array( 'PROPUSES',     'integer' ),
-			array( 'ERRORUSES',    'integer' )
+			array( 'ERRORUSES',    'integer' ),
+			array( 'DELETECOUNT',  'integer' )
 		);
 	}
 


### PR DESCRIPTION
Outdated entities are not removed immediately from the `ID_TABLE` and in instead "marked for removal" using the `smw:delete` indicator.

An administrator or curator (SMW) should ensure that this number is kept low by running the `rebuildData.php` script on a regular basis.

It is also an indicator (besides the error count) whether an installation is maintained routinately or not.

refs #1100