### PR TITLE
Silence the TransactionProfiler in 1.27+, refs #1295

### DIFF
--- a/src/MediaWiki/Hooks/HookRegistry.php
+++ b/src/MediaWiki/Hooks/HookRegistry.php
@@ -548,6 +548,13 @@ class HookRegistry {
 		 */
 		$this->handlers['ParserFirstCallInit'] = function ( &$parser ) use( $applicationFactory ) {
 
+			// We shouldn't care for this but 1.27 is spamming the logs with false
+			// DB performance expectation violations hence we silence it
+			// https://gerrit.wikimedia.org/r/#/c/279462/1
+			if ( method_exists( \Profiler::instance(), 'getTransactionProfiler' ) ) {
+				\Profiler::instance()->getTransactionProfiler()->resetExpectations();
+			}
+
 			$parserFunctionFactory = $applicationFactory->newParserFunctionFactory( $parser );
 
 			list( $name, $definition, $flag ) = $parserFunctionFactory->newAskParserFunctionDefinition();


### PR DESCRIPTION
 refs #1295 

```
[DBPerformance] Expectation (writes <= 0) by MediaWiki::main not met:
query-m: CREATE TEMPORARY TABLE `t3`( id INT UNSIGNED KEY ) ENGINE=MEMORY [TRX#a85b3b08e008]
TransactionProfiler.php line 311 calls wfBacktrace()
TransactionProfiler.php line 200 calls TransactionProfiler->reportExpectationViolated()
Database.php line 856 calls TransactionProfiler->recordQueryCompletion()
Database.php line 242 calls DatabaseBase->query()
QuerySegmentListProcessor.php line 303 calls SMW\MediaWiki\Database->query()
QuerySegmentListProcessor.php line 242 calls SMW\SQLStore\QueryEngine\QuerySegmentListProcessor->resolveHierarchyForSegment()
QuerySegmentListProcessor.php line 123 calls SMW\SQLStore\QueryEngine\QuerySegmentListProcessor->doResolveBySegment()
QuerySegmentListProcessor.php line 123 calls SMW\SQLStore\QueryEngine\QuerySegmentListProcessor->doResolveBySegment()
QuerySegmentListProcessor.php line 181 calls SMW\SQLStore\QueryEngine\QuerySegmentListProcessor->doResolveBySegment()
QuerySegmentListProcessor.php line 123 calls SMW\SQLStore\QueryEngine\QuerySegmentListProcessor->doResolveBySegment()
QuerySegmentListProcessor.php line 112 calls SMW\SQLStore\QueryEngine\QuerySegmentListProcessor->doResolveBySegment()
QueryEngine.php line 215 calls SMW\SQLStore\QueryEngine\QuerySegmentListProcessor->doExecuteSubqueryJoinDependenciesFor()
SMW_SQLStore3.php line 387 calls SMW\SQLStore\QueryEngine\QueryEngine->getQueryResult()
SMW_SQLStore3.php line 377 calls SMWSQLStore3->fetchQueryResult()
SMW_QueryProcessor.php line 514 calls SMWSQLStore3->getQueryResult()
AskParserFunction.php line 189 calls SMWQueryProcessor::getResultFromQuery()
AskParserFunction.php line 115 calls SMW\AskParserFunction->doFetchResultsForRawParameters()
ParserFunctionFactory.php line 248 calls SMW\AskParserFunction->parse()
```