### PR TITLE
Remove duplicated values from a PLURAL clause

### DIFF
--- a/i18n/en.json
+++ b/i18n/en.json
@@ -261,7 +261,7 @@
 	"smw_adminlinks_inlinequerieshelp": "Inline queries help",
 	"smw-property-page-indicator-usage-count": "Estimated [https://www.semantic-mediawiki.org/wiki/Help:Property_usage_count usage count]: {{PLURAL:$2|'''$2'''}}",
 	"smw-property-page-indicator-type-info": "{{PLURAL:$1|User|System}}",
-	"smw-concept-page-indicator-cache-count": "[https://www.semantic-mediawiki.org/wiki/Help:Concept_cache_count Cache count]: {{PLURAL:$1|'''$1'''|'''$1'''}} ($2)",
+	"smw-concept-page-indicator-cache-count": "[https://www.semantic-mediawiki.org/wiki/Help:Concept_cache_count Cache count]: {{PLURAL:$1|'''$1'''}} ($2)",
 	"smw-createproperty-isproperty": "It is a property of type $1.",
 	"smw-createproperty-allowedvals": "The allowed {{PLURAL:$1|value for this property is|values for this property are}}:",
 	"smw-paramdesc-category-delim": "The delimiter",

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -259,7 +259,7 @@
 	"smw_adminlinks_datastructure": "Data structure",
 	"smw_adminlinks_displayingdata": "Data display",
 	"smw_adminlinks_inlinequerieshelp": "Inline queries help",
-	"smw-property-page-indicator-usage-count": "Estimated [https://www.semantic-mediawiki.org/wiki/Help:Property_usage_count usage count]: {{PLURAL:$2|'''$2'''|'''$2'''}}",
+	"smw-property-page-indicator-usage-count": "Estimated [https://www.semantic-mediawiki.org/wiki/Help:Property_usage_count usage count]: {{PLURAL:$2|'''$2'''}}",
 	"smw-property-page-indicator-type-info": "{{PLURAL:$1|User|System}}",
 	"smw-concept-page-indicator-cache-count": "[https://www.semantic-mediawiki.org/wiki/Help:Concept_cache_count Cache count]: {{PLURAL:$1|'''$1'''|'''$1'''}} ($2)",
 	"smw-createproperty-isproperty": "It is a property of type $1.",


### PR DESCRIPTION
Identical values are not needed.