### PR TITLE
Grammar correction in smw-pa-property-predefined-long_pvuc

### DIFF
--- a/i18n/en.json
+++ b/i18n/en.json
@@ -387,6 +387,6 @@
 	"smw-pa-property-predefined_pvap": "\"$1\" is a predefined property that can specify a [[MediaWiki:Smw allows pattern|pattern reference]] to apply [https://en.wikipedia.org/wiki/Regular_expression regular expression] matching and is provided by [https://www.semantic-mediawiki.org/wiki/Help:Special_properties Semantic MediaWiki].",
 	"smw-pa-property-predefined_dtitle": "\"$1\" is a predefined property that can assign a distinct display title to an entity and is provided by [https://www.semantic-mediawiki.org/wiki/Help:Special_properties Semantic MediaWiki].",
 	"smw-pa-property-predefined_pvuc": "\"$1\" is a predefined property indicating that value assignments to a property are expected to be unique and is provided by [https://www.semantic-mediawiki.org/wiki/Help:Special_properties Semantic MediaWiki].",
-	"smw-pa-property-predefined-long_pvuc": "Uniqueness is established when two values are not equal in its literal representation and any violation of this constraint will be categorized as error.",
+	"smw-pa-property-predefined-long_pvuc": "Uniqueness is established when two values are not equal in their literal representation and any violation of this constraint will be categorized as error.",
 	"smw-datavalue-uniqueness-constraint-error": "Property \"$1\" only permits unique value assignments and ''$2'' was already annotated in subject \"$3\"."
 }


### PR DESCRIPTION
The sentence talks about values, so I suppose that it should be "their" and not "its". If I am misunderstanding something, please close this pull request and explain it [in the message's qqq](https://translatewiki.net/wiki/MediaWiki:Smw-pa-property-predefined-long_pvuc/qqq).