### PR TITLE
Tests for partial dates, refs #1524, #1401

### DIFF
--- a/includes/datavalues/SMW_DV_Time.php
+++ b/includes/datavalues/SMW_DV_Time.php
@@ -136,8 +136,10 @@ class SMWTimeValue extends SMWDataValue {
 	const PREHISTORY = -10000;
 
 	protected function parseUserValue( $value ) {
-		$value = trim( $value ); // ignore whitespace
+
+		$value = $this->convertDoubleWidth( $value );
 		$this->m_wikivalue = $value;
+
 		if ( $this->m_caption === false ) { // Store the caption now.
 			$this->m_caption = $value;
 		}
@@ -201,7 +203,7 @@ class SMWTimeValue extends SMWDataValue {
 		// * this does not allow localized time notations such as "10.34 pm"
 		// * this creates problems with keywords that contain "." such as "p.m."
 		// * yet "." is an essential date separation character in languages such as German
-		$parsevalue = str_replace( array( '/', '.', '&nbsp;', ',', '年', '月', '日', '時', '分' ), array( '-', ' ', ' ', ' ', '-', '-', ' ', ':', ' ' ), $string );
+		$parsevalue = str_replace( array( '/', '.', '&nbsp;', ',', '年', '月', '日', '時', '分' ), array( '-', ' ', ' ', ' ', ' ', ' ', ' ', ':', ' ' ), $string );
 
 		$matches = preg_split( "/([T]?[0-2]?[0-9]:[\:0-9]+[+\-]?[0-2]?[0-9\:]+|[\p{L}]+|[0-9]+|[ ])/u", $parsevalue, -1, PREG_SPLIT_DELIM_CAPTURE | PREG_SPLIT_NO_EMPTY );
 		$datecomponents = array();

--- a/includes/datavalues/SMW_DataValue.php
+++ b/includes/datavalues/SMW_DataValue.php
@@ -13,6 +13,7 @@ use SMW\DataValues\ValueValidatorRegistry;
 use SMW\Deserializers\DVDescriptionDeserializerRegistry;
 use SMW\Message;
 use SMW\Options;
+use SMW\Localizer;
 use SMW\Query\QueryComparator;
 
 /**
@@ -916,6 +917,17 @@ abstract class SMWDataValue {
 	 */
 	protected function checkAllowedValues() {
 		ValueValidatorRegistry::getInstance()->getConstraintValueValidator()->validate( $this );
+	}
+
+	/**
+	 * @since 2.4
+	 *
+	 * @param string $value
+	 *
+	 * @return string
+	 */
+	protected function convertDoubleWidth( $value ) {
+		return Localizer::convertDoubleWidth( $value );
 	}
 
 }

--- a/src/Localizer.php
+++ b/src/Localizer.php
@@ -163,4 +163,36 @@ class Localizer {
 		return $langCode !== '' ? $langCode : false;
 	}
 
+	/**
+	 * @see Language::convertDoubleWidth
+	 *
+	 * Convert double-width roman characters to single-width.
+	 * range: ff00-ff5f ~= 0020-007f
+	 *
+	 * @param string $string
+	 *
+	 * @return string
+	 */
+	public static function convertDoubleWidth( $string ) {
+		static $full = null;
+		static $half = null;
+
+		if ( $full === null ) {
+			$fullWidth = "０１２３４５６７８９ＡＢＣＤＥＦＧＨＩＪＫＬＭＮＯＰＱＲＳＴＵＶＷＸＹＺａｂｃｄｅｆｇｈｉｊｋｌｍｎｏｐｑｒｓｔｕｖｗｘｙｚ";
+			$halfWidth = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz";
+
+			// http://php.net/manual/en/function.str-split.php, mb_str_split
+			$length = mb_strlen( $fullWidth, "UTF-8" );
+			$full = array();
+
+			for ( $i = 0; $i < $length; $i += 1 ) {
+				$full[] = mb_substr( $fullWidth, $i, 1, "UTF-8" );
+			}
+
+			$half = str_split( $halfWidth );
+		}
+
+		return str_replace( $full, $half, trim( $string ) );
+	}
+
 }

--- a/tests/phpunit/Integration/ByJsonScript/Fixtures/p-0422.json
+++ b/tests/phpunit/Integration/ByJsonScript/Fixtures/p-0422.json
@@ -1,0 +1,90 @@
+{
+	"description": "Test in-text annotation `_dat` on partial dates (en)",
+	"properties": [
+		{
+			"name": "Has date",
+			"contents": "[[Has type::Date]]"
+		}
+	],
+	"subjects": [
+		{
+			"name": "Example/P0422/1",
+			"contents": "[[Has date::Jan 1990]], [[Has date::02 1990]], [[Has date::1782]], [[Has date::1990年6月]], [[Has date::1990年4月28日 7時01分]], [[Has date::１９９０年９月]]"
+		},
+		{
+			"name": "Example/P0422/Q/1",
+			"contents": "{{#show: Example/P0422/1 |?Has date }}"
+		},
+		{
+			"name": "Example/P0422/2",
+			"contents": "{{#subobject:|Has date=Jan 1923|@category=Partial dates}} {{#subobject:|Has date=Feb 1960|@category=Partial dates}} {{#subobject:|Has date=1645|@category=Partial dates}}"
+		},
+		{
+			"name": "Example/P0422/Q/2/1",
+			"contents": "{{#ask: [[Category:Partial dates]] |?Has date |sort=Has date|order=asc |link=none }}"
+		},
+		{
+			"name": "Example/P0422/Q/2/2",
+			"contents": "{{#ask: [[Category:Partial dates]] |?Has date |sort=Has date|order=desc |link=none }}"
+		}
+	],
+	"parser-testcases": [
+		{
+			"about": "#0",
+			"subject": "Example/P0422/1",
+			"store": {
+				"semantic-data": {
+					"strict-mode-valuematch": false,
+					"propertyCount": 3,
+					"propertyKeys": [ "_SKEY", "_MDAT", "Has_date" ],
+					"propertyValues": [ "1990-01-01", "1990-02-01", "1782-01-01", "1990-06-01", "1990-04-28T07:01:00", "1990-09-01" ]
+				}
+			}
+		},
+		{
+			"about": "#1",
+			"subject": "Example/P0422/Q/1",
+			"expected-output": {
+				"to-contain": [
+					"January 1990",
+					"February 1990",
+					"1782",
+					"June 1990",
+					"28 April 1990 07:01:00",
+					"September 1990"
+				]
+			}
+		},
+		{
+			"about": "#2 (sort asc)",
+			"subject": "Example/P0422/Q/2/1",
+			"expected-output": {
+				"to-contain": [
+					"<tr data-row-number=\"1\" class=\"row-odd\"><td class=\"smwtype_wpg\">Example/P0422/2#_519df0ee370ade5d506e5dd769a14b26</td><td data-sort-value=\"2321884.5\" class=\"Has-date smwtype_dat\">1645</td></tr>",
+					"<tr data-row-number=\"2\" class=\"row-even\"><td class=\"smwtype_wpg\">Example/P0422/2#_a9167ae46aa815bb052650683c4719d6</td><td data-sort-value=\"2423420.5\" class=\"Has-date smwtype_dat\">January 1923</td></tr>",
+					"<tr data-row-number=\"3\" class=\"row-odd\"><td class=\"smwtype_wpg\">Example/P0422/2#_803b6de7d53ad0173871f4e4210ce477</td><td data-sort-value=\"2436965.5\" class=\"Has-date smwtype_dat\">February 1960</td></tr>"
+				]
+			}
+		},
+		{
+			"about": "#3 (sort desc)",
+			"subject": "Example/P0422/Q/2/2",
+			"expected-output": {
+				"to-contain": [
+					"<tr data-row-number=\"1\" class=\"row-odd\"><td class=\"smwtype_wpg\">Example/P0422/2#_803b6de7d53ad0173871f4e4210ce477</td><td data-sort-value=\"2436965.5\" class=\"Has-date smwtype_dat\">February 1960</td></tr>",
+					"<tr data-row-number=\"2\" class=\"row-even\"><td class=\"smwtype_wpg\">Example/P0422/2#_a9167ae46aa815bb052650683c4719d6</td><td data-sort-value=\"2423420.5\" class=\"Has-date smwtype_dat\">January 1923</td></tr>",
+					"<tr data-row-number=\"3\" class=\"row-odd\"><td class=\"smwtype_wpg\">Example/P0422/2#_519df0ee370ade5d506e5dd769a14b26</td><td data-sort-value=\"2321884.5\" class=\"Has-date smwtype_dat\">1645</td></tr>"
+				]
+			}
+		}
+	],
+	"settings": {
+		"wgContLang": "en",
+		"wgLang": "en"
+	},
+	"meta": {
+		"version": "0.1",
+		"is-incomplete": false,
+		"debug": false
+	}
+}

--- a/tests/phpunit/Unit/LocalizerTest.php
+++ b/tests/phpunit/Unit/LocalizerTest.php
@@ -176,4 +176,17 @@ class LocalizerTest extends \PHPUnit_Framework_TestCase {
 		Localizer::clear();
 	}
 
+	public function testConvertDoubleWidth() {
+
+		$this->assertEquals(
+			'2000',
+			Localizer::convertDoubleWidth( '２０００' )
+		);
+
+		$this->assertEquals(
+			'aBc',
+			Localizer::getInstance()->convertDoubleWidth( 'ａＢｃ' )
+		);
+	}
+
 }


### PR DESCRIPTION
Extend test to verify that `[[Date::1990年6月]]` and double width `[[Date::１９９０年９月]]` annotations are correctly parsed.

 refs #1524, #1401