### PR TITLE
Simpler regex for condition that contains `=`, refs #710, #640

### DIFF
--- a/includes/query/SMW_QueryProcessor.php
+++ b/includes/query/SMW_QueryProcessor.php
@@ -296,7 +296,7 @@ class SMWQueryProcessor {
 			// Bug 32955 / #640
 			// Modify (e.g. replace `=`) a condition string only if enclosed by [[ ... ]]
 			$rawParam = preg_replace_callback(
-				'/\[\[(?:([^:][^]]*):[=:])+([^\[\]]*)\]\]/xu',
+				'/\[\[([^\[\]]*)\]\]/xu',
 				function( array $matches ) {
 					return str_replace( array( '=' ), array( '-3D' ), $matches[0] );
 				},

--- a/tests/phpunit/Integration/ByJsonScript/Fixtures/q-0612.json
+++ b/tests/phpunit/Integration/ByJsonScript/Fixtures/q-0612.json
@@ -1,0 +1,63 @@
+{
+	"description": "Test `_wpg` object value that contains `=` (#640, #710, en)",
+	"properties": [
+		{
+			"name": "Has page",
+			"contents": "[[Has type::Page]]"
+		}
+	],
+	"subjects": [
+		{
+			"name": "Example/Q0612/1(=)",
+			"contents": "[[Category:Q0612]] [[Has page::{{FULLPAGENAME}}]]"
+		}
+	],
+	"query-testcases": [
+		{
+			"about": "#0",
+			"store" : {
+				"clear-cache": true
+			},
+			"condition": "[[Category:Q0612]] [[Example/Q0612/1(=)]]",
+			"printouts" : [],
+			"parameters" : {
+				"limit" : 10
+			},
+			"queryresult": {
+				"count": 1,
+				"results": [
+					"Example/Q0612/1(=)#0##"
+				]
+			}
+		},
+		{
+			"about": "#1",
+			"condition": "[[Category:Q0612]] [[Has page::Example/Q0612/1(=)]]",
+			"printouts" : [],
+			"parameters" : {
+				"limit" : 10
+			},
+			"queryresult": {
+				"count": 1,
+				"results": [
+					"Example/Q0612/1(=)#0##"
+				]
+			}
+		}
+	],
+	"settings": {
+		"smwgNamespacesWithSemanticLinks": {
+			"NS_MAIN": true,
+			"NS_CATEGORY": true,
+			"SMW_NS_PROPERTY": true,
+			"NS_HELP": true
+		},
+		"wgContLang": "en",
+		"wgLang": "en"
+	},
+	"meta": {
+		"version": "0.1",
+		"is-incomplete": false,
+		"debug": false
+	}
+}

--- a/tests/phpunit/Integration/ByJsonScript/README.md
+++ b/tests/phpunit/Integration/ByJsonScript/README.md
@@ -90,6 +90,7 @@ Contains 119 files:
 * [q-0609.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/ByJsonScript/Fixtures/q-0609.json) Test `_wpg` for single value approximate (`~/!~`) queries with conjunctive category hierarchy (#1246, en, skip virtuoso)
 * [q-0610.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/ByJsonScript/Fixtures/q-0610.json) Test `_wpg` range queries (#1291, `smwStrictComparators=false`, skip virtuoso)
 * [q-0611.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/ByJsonScript/Fixtures/q-0611.json) Test `_wpg` namespace any value queries (#1301, en)
+* [q-0612.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/ByJsonScript/Fixtures/q-0612.json) Test `_wpg` object value that contains `=` (#640, #710, en)
 * [q-0701.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/ByJsonScript/Fixtures/q-0701.json) Test `_uri` with some annotation/search pattern (T45264, #679)
 * [q-0702.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/ByJsonScript/Fixtures/q-0702.json) Test `_uri` with additional annotation/search (#1129)
 * [q-0703.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/ByJsonScript/Fixtures/q-0703.json) Test to map `Foaf` property from back-end / using a localized predefined property `A le type@fr` (en)

--- a/tests/phpunit/includes/QueryProcessorTest.php
+++ b/tests/phpunit/includes/QueryProcessorTest.php
@@ -117,6 +117,11 @@ class SMWQueryProcessorTest extends MwDBaseUnitTestCase {
 			'[[Located in::Foo]][[Has url::http://example.org/api.php?action=Foo]]'
 		);
 
+		$provider[] = array(
+			array( '[[This has a = in it]]', 'link=none', 'sep=| ]][[Location of::', '[[Has url::http://example.org/api.php?action=Foo]]' ),
+			'[[This has a = in it]][[Has url::http://example.org/api.php?action=Foo]]'
+		);
+
 		return $provider;
 	}
 


### PR DESCRIPTION
This should allow for object values `[[This has a = in it]]` to be querable as well.

refs #710, #640