### PR TITLE
Improve navigation on property/concept page, refs #1326

### DIFF
--- a/includes/articlepages/SMW_OrderedListPage.php
+++ b/includes/articlepages/SMW_OrderedListPage.php
@@ -2,6 +2,7 @@
 
 use SMW\DIProperty;
 use SMW\PropertyRegistry;
+use SMW\ApplicationFactory;
 
 /**
  * Abstract subclass of MediaWiki's Article that handles the common tasks of
@@ -114,6 +115,44 @@ abstract class SMWOrderedListPage extends Article {
 	 */
 	protected function getIntroductoryText() {
 		return '';
+	}
+
+	/**
+	 * @since 2.4
+	 */
+	protected function getNavigationLinks( $msgKey, array $diWikiPages, $default = 50 ) {
+		global $wgRequest;
+
+		$mwCollaboratorFactory = ApplicationFactory::getInstance()->newMwCollaboratorFactory();
+
+		$messageBuilder = $mwCollaboratorFactory->newMessageBuilder(
+			$this->getContext()->getLanguage()
+		);
+
+		$title = $this->mTitle;
+		$title->setFragment( '#SMWResults' ); // Make navigation point to the result list.
+
+		$resultCount = count( $diWikiPages );
+		$navigation = '';
+
+		if ( $resultCount > 0 ) {
+			$navigation = $messageBuilder->prevNextToText(
+				$title,
+				$wgRequest->getVal( 'limit', $default ),
+				$wgRequest->getVal( 'offset', '0' ),
+				array(),
+				$resultCount < $wgRequest->getVal( 'limit', $default )
+			);
+
+			$navigation = Html::rawElement('div', array(), $navigation );
+		}
+
+		return Html::rawElement(
+			'p',
+			array(),
+			Html::element( 'span', array(), wfMessage( $msgKey, $resultCount )->parse() ) . '<br>' .
+			$navigation
+		);
 	}
 
 	/**

--- a/includes/datavalues/SMW_DV_Property.php
+++ b/includes/datavalues/SMW_DV_Property.php
@@ -192,7 +192,7 @@ class SMWPropertyValue extends SMWDataValue {
 	 *
 	 * @param array $linkAttributes
 	 */
-	public function setLinkAttributes( array $setLinkAttributes ) {
+	public function setLinkAttributes( array $linkAttributes ) {
 		$this->linkAttributes = $linkAttributes;
 
 		if ( $this->getWikiPageValue() instanceof SMWDataValue ) {

--- a/includes/querypages/PropertiesQueryPage.php
+++ b/includes/querypages/PropertiesQueryPage.php
@@ -193,6 +193,11 @@ class PropertiesQueryPage extends QueryPage {
 		$typestring = SMWTypesValue::newFromTypeId( $this->settings->get( 'smwgPDefaultType' ) )->getLongHTMLText( $this->getLinker() );
 
 		$label = htmlspecialchars( $property->getLabel() );
+		$linkAttributes = array();
+
+		if ( isset( $property->id ) ) {
+			$linkAttributes['title'] = 'ID: ' . $property->id;
+		}
 
 		if ( $title->exists() ) {
 
@@ -209,12 +214,12 @@ class PropertiesQueryPage extends QueryPage {
 				$this->getMessageFormatter()->addFromKey( 'smw_propertylackstype', $typestring );
 			}
 
-			$proplink = $this->getLinker()->link( $title, $label );
+			$proplink = $this->getLinker()->link( $title, $label, $linkAttributes );
 
 		} else {
 
 			$this->getMessageFormatter()->addFromKey( 'smw_propertylackspage' );
-			$proplink = $this->getLinker()->link( $title, $label, array(), array( 'action' => 'view' ) );
+			$proplink = $this->getLinker()->link( $title, $label, $linkAttributes, array( 'action' => 'view' ) );
 		}
 
 		return array( $typestring, $proplink );
@@ -230,9 +235,16 @@ class PropertiesQueryPage extends QueryPage {
 	 * @return array
 	 */
 	private function getPredefinedPropertyInfo( DIProperty $property ) {
+
+		$dv = DataValueFactory::getInstance()->newDataItemValue( $property, null );
+
+		$dv->setLinkAttributes( array(
+			'title' => 'ID: ' . ( isset( $property->id ) ? $property->id : 'N/A' ) . ' (' . $property->getKey() . ')'
+		) );
+
 		return array(
 			SMWTypesValue::newFromTypeId( $property->findPropertyTypeID() )->getLongHTMLText( $this->getLinker() ),
-			DataValueFactory::getInstance()->newDataItemValue( $property, null )->getShortHtmlText( $this->getLinker() )
+			$dv->getShortHtmlText( $this->getLinker() )
 		);
 	}
 

--- a/res/smw/ext.smw.css
+++ b/res/smw/ext.smw.css
@@ -121,9 +121,64 @@ td.smwpropname, th.smwpropname, td.smwspecname {
 	padding-right: 1em;
 }
 
+td.smwpropname {
+	width: 33%;
+}
+
 td.smwprops, td.smwspecs {
 	vertical-align: top;
 	width: 75%;
+}
+
+.property-page-results {
+	margin-top: 0.9em;
+}
+
+.property-page-results table {
+	border: none;
+}
+
+.property-page-results .header-row {
+	/* background-color: #f5f5f5; */
+}
+
+.property-page-results .value-row:hover {
+	background-color: #f5f5f5;
+}
+
+.property-page-results .header-row > th {
+	border-bottom: 0px solid #ddd;
+}
+
+.property-page-results tr.value-row > td {
+	padding-bottom: 0.2em;
+	padding-top: 0.2em;
+}
+
+.property-page-results .header-row + tr.value-row td {
+	padding-top: 0.3em;
+}
+
+.property-page-results .header-title {
+	font-weight: bold;
+	font-size: 1.17em;
+	line-height: 1.6;
+	margin-top: 0.0em;
+	color: #333;
+	overflow: hidden;
+	padding: 2px 3px;
+}
+
+.property-page-results tr.value-row:nth-child(even) {
+  /*  background-color: #f5f5f5; */
+}
+
+.smwtable-striped tbody > tr:nth-child(even) {
+   background-color: #f5f5f5;
+}
+
+.smwtable-striped tbody > tr:nth-child(odd) {
+   background-color: #fff;
 }
 
 div.smwhr hr {
@@ -411,9 +466,13 @@ label.smw-form-checkbox {
 }
 
 .smw-column-responsive {
-	-webkit-column-width: 25em;
-	-moz-column-width: 25em;
-	column-width: 25em;
+  -webkit-columns: 3 20em;
+     -moz-columns: 3 20em;
+          columns: 3 20em;
+  -webkit-column-gap: 1em;
+     -moz-column-gap: 1em;
+          column-gap: 1em;
+          margin-bottom: -2em;
 }
 
 .smw-column[dir="rtl"] {

--- a/src/MediaWiki/Specials/SearchByProperty/PageBuilder.php
+++ b/src/MediaWiki/Specials/SearchByProperty/PageBuilder.php
@@ -76,7 +76,9 @@ class PageBuilder {
 
 		list( $resultMessage, $resultList, $resultCount ) = $this->getResultHtml();
 
-		if ( ( $resultList === '' || $resultList === null ) && $this->pageRequestOptions->property->getDataItem() instanceof DIProperty ) {
+		if ( ( $resultList === '' || $resultList === null ) &&
+			$this->pageRequestOptions->property->getDataItem() instanceof DIProperty &&
+			$this->pageRequestOptions->valueString === '' ) {
 			list( $resultMessage, $resultList, $resultCount ) = $this->tryToFindAtLeastOnePropertyTableReferenceFor(
 				$this->pageRequestOptions->property->getDataItem()
 			);

--- a/src/MediaWiki/Specials/SearchByProperty/PageRequestOptions.php
+++ b/src/MediaWiki/Specials/SearchByProperty/PageRequestOptions.php
@@ -90,7 +90,10 @@ class PageRequestOptions {
 		$property = isset( $this->requestOptions['property'] ) ? $this->requestOptions['property'] : current( $params );
 		$value = isset( $this->requestOptions['value'] ) ? $this->requestOptions['value'] : next( $params );
 
-		$property = $this->urlEncoder->decode( $property );
+		$property = $this->urlEncoder->decode(
+			str_replace( array( '_' ), array( ' ' ), $property )
+		);
+
 		$value = str_replace( array( '-25', '_' ), array( '%', ' ' ), $value );
 
 		$this->property = PropertyValue::makeUserProperty( $property );

--- a/src/SQLStore/Lookup/PropertyUsageListLookup.php
+++ b/src/SQLStore/Lookup/PropertyUsageListLookup.php
@@ -113,7 +113,7 @@ class PropertyUsageListLookup implements ListLookup {
 
 		$res = $db->select(
 			array( $db->tableName( SQLStore::ID_TABLE ), $db->tableName( SQLStore::PROPERTY_STATISTICS_TABLE ) ),
-			array( 'smw_title', 'usage_count' ),
+			array( 'smw_id', 'smw_title', 'usage_count' ),
 			$conditions,
 			__METHOD__,
 			$options,
@@ -131,6 +131,7 @@ class PropertyUsageListLookup implements ListLookup {
 
 			try {
 				$property = new DIProperty( str_replace( ' ', '_', $row->smw_title ) );
+				$property->id = $row->smw_id;
 			} catch ( InvalidPropertyException $e ) {
 				$property = new DIError( new \Message( 'smw_noproperty', array( $row->smw_title ) ) );
 			}

--- a/tests/phpunit/Integration/ByJsonScript/Fixtures/s-0001.json
+++ b/tests/phpunit/Integration/ByJsonScript/Fixtures/s-0001.json
@@ -26,7 +26,8 @@
 			},
 			"expected-output": {
 				"to-contain": [
-					"title=\"Property:Has test blob property\">Has test blob property</a>"
+					"Property:Has_test_blob_property\" title=\"ID:",
+					"Has test blob property"
 				]
 			}
 		},
@@ -41,7 +42,7 @@
 			},
 			"expected-output": {
 				"to-contain": [
-					"title=\"Property:Allows value\">Allows value</a>"
+					"Property:Allows_value\" title=\"ID: 14 (_PVAL)\">Allows value</a>"
 				]
 			}
 		}

--- a/tests/phpunit/Unit/SQLStore/Lookup/PropertyUsageListLookupTest.php
+++ b/tests/phpunit/Unit/SQLStore/Lookup/PropertyUsageListLookupTest.php
@@ -111,6 +111,7 @@ class PropertyUsageListLookupTest extends \PHPUnit_Framework_TestCase {
 
 		$row = new \stdClass;
 		$row->smw_title = 'Foo';
+		$row->smw_id = 42;
 		$row->usage_count = $expectedCount;
 
 		$connection = $this->getMockBuilder( '\SMW\MediaWiki\Database' )
@@ -142,8 +143,11 @@ class PropertyUsageListLookupTest extends \PHPUnit_Framework_TestCase {
 			$result
 		);
 
+		$property = new DIProperty( 'Foo' );
+		$property->id = 42;
+
 		$expected = array(
-			new DIProperty( 'Foo' ),
+			$property,
 			$expectedCount
 		);
 
@@ -157,6 +161,7 @@ class PropertyUsageListLookupTest extends \PHPUnit_Framework_TestCase {
 
 		$row = new \stdClass;
 		$row->smw_title = '-Foo';
+		$row->smw_id = 42;
 		$row->usage_count = 42;
 
 		$connection = $this->getMockBuilder( '\SMW\MediaWiki\Database' )


### PR DESCRIPTION
- Concept columns made responsive
- Solved 1326 for both the concept and propery page
- `property-page-results` class can be used to adjust the display

refs #1326