### PR TITLE
Add #LOCL as TimeValue output format

### DIFF
--- a/SemanticMediaWiki.settings.php
+++ b/SemanticMediaWiki.settings.php
@@ -960,6 +960,9 @@ $GLOBALS['smwgEnabledInTextAnnotationParserStrictMode'] = true;
 # uniqueness for a value is established by the fact that it is assigned before
 # any other value of the same representation to a property).
 #
+# - SMW_DV_TIMEV_CM (TimeValue) to indicate the CalendarModel if is not a
+# CM_GREGORIAN
+#
 # @since 2.4
 ##
-$GLOBALS['smwgDVFeatures'] = SMW_DV_PROV_REDI | SMW_DV_MLTV_LCODE | SMW_DV_PVAP | SMW_DV_WPV_DTITLE;
+$GLOBALS['smwgDVFeatures'] = SMW_DV_PROV_REDI | SMW_DV_MLTV_LCODE | SMW_DV_PVAP | SMW_DV_WPV_DTITLE | SMW_DV_TIMEV_CM;

--- a/includes/Defines.php
+++ b/includes/Defines.php
@@ -110,6 +110,15 @@ define( 'SMW_DAY_YEAR', 3 ); // an entered digit can be either a month or a year
 /**@}*/
 
 /**@{
+ * Constants for date/time precision
+ */
+define( 'SMW_PREC_Y', 0 );
+define( 'SMW_PREC_YM', 1 );
+define( 'SMW_PREC_YMD', 2 );
+define( 'SMW_PREC_YMDT', 3 );
+/**@}*/
+
+/**@{
  * Constants for SPARQL supported features (mostly SPARQL 1.1) because we are unable
  * to verify against the REST API whether a feature is supported or not
  */
@@ -145,4 +154,5 @@ define( 'SMW_DV_PVAP', 16 );  // Allows pattern
 define( 'SMW_DV_WPV_DTITLE', 32 );  // WikiPageValue to use an explicit display title
 define( 'SMW_DV_PROV_DTITLE', 64 );  // PropertyValue allow to find a property using the display title
 define( 'SMW_DV_PVUC', 128 );  // Delcares a uniqueness constraint
+define( 'SMW_DV_TIMEV_CM', 256 );  // TimeValue to indicate calendar model
 /**@}*/

--- a/includes/dataitems/SMW_DI_Time.php
+++ b/includes/dataitems/SMW_DI_Time.php
@@ -31,10 +31,10 @@ class SMWDITime extends SMWDataItem {
 	const CM_GREGORIAN = 1;
 	const CM_JULIAN = 2;
 
-	const PREC_Y    = 0;
-	const PREC_YM   = 1;
-	const PREC_YMD  = 2;
-	const PREC_YMDT = 3;
+	const PREC_Y    = SMW_PREC_Y;
+	const PREC_YM   = SMW_PREC_YM;
+	const PREC_YMD  = SMW_PREC_YMD;
+	const PREC_YMDT = SMW_PREC_YMDT;
 
 	/**
 	 * The year before which we do not accept anything but year numbers and

--- a/includes/datavalues/SMW_DV_Time.php
+++ b/includes/datavalues/SMW_DV_Time.php
@@ -663,7 +663,7 @@ class SMWTimeValue extends SMWDataValue {
 	 * {@inheritDoc}
 	 */
 	public function getWikiValue() {
-		return $this->m_wikivalue ? $this->m_wikivalue : $this->getLongWikiText();
+		return $this->m_wikivalue ? $this->m_wikivalue : strip_tags( $this->getLongWikiText() );
 	}
 
 	/**

--- a/includes/specials/SMW_SpecialBrowse.php
+++ b/includes/specials/SMW_SpecialBrowse.php
@@ -275,6 +275,10 @@ class SMWSpecialBrowse extends SpecialPage {
 			Localizer::getInstance()->getUserLanguage()->getCode()
 		);
 
+		$dataValue->setContextPage(
+			$this->subject->getDataItem()
+		);
+
 		$html = $dataValue->getLongHTMLText( $linker );
 
 		if ( $dataValue->getTypeID() === '_wpg' || $dataValue->getTypeID() === '__sob' ) {

--- a/includes/storage/SMW_ResultArray.php
+++ b/includes/storage/SMW_ResultArray.php
@@ -184,6 +184,10 @@ class SMWResultArray {
 			\SMW\Localizer::getInstance()->getUserLanguage()->getCode()
 		);
 
+		$dv->setContextPage(
+			$this->mResult
+		);
+
 		return $dv;
 	}
 

--- a/languages/SMW_Language.php
+++ b/languages/SMW_Language.php
@@ -37,6 +37,14 @@ abstract class SMWLanguage {
 	/// each case, and the constants define the obvious order (e.g. SMW_YDM means "first Year,
 	/// then Day, then Month). Unlisted combinations will not be accepted at all.
 	protected $m_dateformats = array( array( SMW_Y ), array( SMW_MY, SMW_YM ), array( SMW_DMY, SMW_MDY, SMW_YMD, SMW_YDM ) );
+
+	protected $preferredDateFormatsByPrecision = array(
+		'SMW_PREC_Y'    => 'Y',
+		'SMW_PREC_YM'   => 'F Y',
+		'SMW_PREC_YMD'  => 'F j, Y',
+		'SMW_PREC_YMDT' => 'H:i:s, j F Y'
+	);
+
 	/// Should English default aliases be used in this language?
 	protected $m_useEnDefaultAliases = true;
 	/// Default English aliases for namespaces (typically used in all languages)
@@ -233,6 +241,10 @@ abstract class SMWLanguage {
 	 */
 	function getDateFormats() {
 		return $this->m_dateformats;
+	}
+
+	function getPreferredDateFormats() {
+		return $this->preferredDateFormatsByPrecision;
 	}
 
 	/**

--- a/languages/SMW_LanguageEs.php
+++ b/languages/SMW_LanguageEs.php
@@ -107,6 +107,12 @@ class SMWLanguageEs extends SMWLanguage {
 
 	protected $m_monthsshort = array( "ene", "feb", "mar", "abr", "may", "jun", "jul", "ago", "sep", "oct", "nov", "dic" );
 
+	protected $preferredDateFormatsByPrecision = array(
+		'SMW_PREC_Y'    => 'Y',
+		'SMW_PREC_YM'   => 'M Y',
+		'SMW_PREC_YMD'  => 'j M Y',
+		'SMW_PREC_YMDT' => 'H:i:s j M Y'
+	);
 }
 
 

--- a/languages/SMW_LanguageJa.php
+++ b/languages/SMW_LanguageJa.php
@@ -17,15 +17,11 @@ include_once ( $smwgIP . 'languages/SMW_Language.php' );
 
 
 /**
- * English language labels for important SMW labels (namespaces, datatypes,...).
- *
- * @author Markus Krötzsch
- * @ingroup SMWLanguage
- * @ingroup Language
+ * @since 2.4
  */
-class SMWLanguageEn extends SMWLanguage {
+class SMWLanguageJa extends SMWLanguage {
 
-	protected $m_useEnDefaultAliases = false; // not needed for English, obviously
+	protected $m_useEnDefaultAliases = true; // not needed for English, obviously
 
 	protected $m_DatatypeLabels = array(
 		'_wpg' => 'Page', // name of page datatype
@@ -118,10 +114,10 @@ class SMWLanguageEn extends SMWLanguage {
 	protected $m_monthsshort = array( "Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec" );
 
 	protected $preferredDateFormatsByPrecision = array(
-		'SMW_PREC_Y'    => 'Y',
-		'SMW_PREC_YM'   => 'F Y',
-		'SMW_PREC_YMD'  => 'F j, Y',
-		'SMW_PREC_YMDT' => 'H:i:s, j F Y'
+		'SMW_PREC_Y'    => 'Y年',
+		'SMW_PREC_YM'   => 'Y年n月',
+		'SMW_PREC_YMD'  => 'Y年n月j日 (D)',
+		'SMW_PREC_YMDT' => 'Y年n月j日 (D) H:i:s'
 	);
 }
 

--- a/src/ExtraneousLanguage.php
+++ b/src/ExtraneousLanguage.php
@@ -235,6 +235,27 @@ class ExtraneousLanguage {
 	}
 
 	/**
+	 * @since 2.4
+	 *
+	 * @param integer|null $precision
+	 *
+	 * @return string
+	 */
+	public function getPreferredDateFormatByPrecision( $precision = null ) {
+
+		$dateOutputFormats = $this->getLanguage()->getPreferredDateFormats();
+
+		foreach ( $dateOutputFormats as $key => $format ) {
+			if ( @constant( $key ) === $precision ) {
+				return $format;
+			}
+		}
+
+		// Fallback
+		return 'd F Y H:i:s';
+	}
+
+	/**
 	 * @deprecated use findMonthNumberByLabel
 	 */
 	public function findMonth( $label ) {

--- a/src/IntlTimeFormatter.php
+++ b/src/IntlTimeFormatter.php
@@ -39,13 +39,40 @@ class IntlTimeFormatter {
 	}
 
 	/**
+	 * @since 2.4
+	 *
+	 * @return string|boolean
+	 */
+	public function getLocalizedFormat() {
+
+		$dateTime = $this->dataItem->asDateTime();
+
+		if ( !$dateTime ) {
+			return false;
+		}
+
+		$extraneousLanguage = Localizer::getInstance()->getExtraneousLanguage(
+			$this->language
+		);
+
+		$preferredDateFormatByPrecision = $extraneousLanguage->getPreferredDateFormatByPrecision(
+			$this->dataItem->getPrecision()
+		);
+
+		return $this->formatWithLocalizedTextReplacement(
+			$dateTime,
+			$preferredDateFormatByPrecision
+		);
+	}
+
+	/**
 	 * Permitted formatting options are specified by http://php.net/manual/en/function.date.php
 	 *
 	 * @since 2.4
 	 *
 	 * @param string $format
 	 *
-	 * @return string
+	 * @return string|boolean
 	 */
 	public function format( $format ) {
 
@@ -55,19 +82,22 @@ class IntlTimeFormatter {
 			return false;
 		}
 
-		$output = $this->getFormattedOutputWithTextualRepresentationReplacement(
+		$output = $this->formatWithLocalizedTextReplacement(
 			$dateTime,
 			$format
 		);
 
-		if ( $this->dataItem->getCalendarModel() !== DITime::CM_GREGORIAN && $this->containsDateFormatRule( $format ) ) {
-			$output .= ' ' . $this->dataItem->getCalendarModelLiteral();
-		}
-
 		return $output;
 	}
 
-	private function containsDateFormatRule( $format ) {
+	/**
+	 * @since 2.4
+	 *
+	 * @param string $format
+	 *
+	 * @return boolean
+	 */
+	public function containsValidDateFormatRule( $format ) {
 
 		foreach ( str_split( $format ) as $value ) {
 			if ( in_array( $value, array( 'd', 'D', 'j', 'l', 'N', 'w', 'W', 'F', 'M', 'm', 'n', 't', 'L', 'o', 'Y', 'y', "c", 'r' ) ) ) {
@@ -88,7 +118,7 @@ class IntlTimeFormatter {
 	 * - a	Lowercase Ante meridiem and Post meridiem am or pm
 	 * - A	Uppercase Ante meridiem and Post meridiem
 	 */
-	private function getFormattedOutputWithTextualRepresentationReplacement( $dateTime, $format ) {
+	private function formatWithLocalizedTextReplacement( $dateTime, $format ) {
 
 		$output = $dateTime->format( $format );
 

--- a/tests/phpunit/Integration/ByJsonScript/Fixtures/p-0413.json
+++ b/tests/phpunit/Integration/ByJsonScript/Fixtures/p-0413.json
@@ -1,5 +1,5 @@
 {
-	"description": "Test in-text annotation for different `_dat` input/output (en, skip virtuoso)",
+	"description": "Test in-text annotation for different `_dat` input/output (en, skip virtuoso, `smwgDVFeatures`)",
 	"properties": [
 		{
 			"name": "Has date",
@@ -497,7 +497,7 @@
 			"subject": "Example/P0413/11a",
 			"expected-output": {
 				"to-contain": [
-					"<td data-sort-value=\"1611848.5\" class=\"Has-date smwtype_dat\">1 January 300 BC JL</td>",
+					"<td data-sort-value=\"1611848.5\" class=\"Has-date smwtype_dat\">1 January 300 BC <sup>JL</sup></td>",
 					"<td data-sort-value=\"1611848.5\" class=\"Has-date smwtype_dat\">28 December 301 BC</td>",
 					"<td data-sort-value=\"1611848.5\" class=\"Has-date smwtype_dat\">--301-12-28</td>",
 					"<td data-sort-value=\"1611848.5\" class=\"ISO-Date smwtype_dat\">--301-12-28</td>",
@@ -528,11 +528,11 @@
 			"subject": "Example/P0413/13a",
 			"expected-output": {
 				"to-contain": [
-					"<td data-sort-value=\"2451598.5\" class=\"Has-date smwtype_dat\">11 February 2000 JL</td>",
+					"<td data-sort-value=\"2451598.5\" class=\"Has-date smwtype_dat\">11 February 2000 <sup>JL</sup></td>",
 					"<td data-sort-value=\"2451598.5\" class=\"Has-date smwtype_dat\">2000-02-24</td>",
 					"<td data-sort-value=\"2451598.5\" class=\"ISO-Date smwtype_dat\">2000-02-24</td>",
 					"<td data-sort-value=\"2451598.5\" class=\"MW-Date smwtype_dat\">24 February 2000</td>",
-					"<td data-sort-value=\"2451598.5\" class=\"JL-Date smwtype_dat\">11 February 2000 JL</td>",
+					"<td data-sort-value=\"2451598.5\" class=\"JL-Date smwtype_dat\">11 February 2000 <sup>JL</sup></td>",
 					"<td data-sort-value=\"2451598.5\" class=\"GR-Date smwtype_dat\">24 February 2000</td>"
 				]
 			}
@@ -559,11 +559,11 @@
 			"subject": "Example/P0413/14a",
 			"expected-output": {
 				"to-contain": [
-					"<td data-sort-value=\"2266042.5\" class=\"Has-date smwtype_dat\">2 February 1492 JL</td>",
+					"<td data-sort-value=\"2266042.5\" class=\"Has-date smwtype_dat\">2 February 1492 <sup>JL</sup></td>",
 					"<td data-sort-value=\"2266042.5\" class=\"Has-date smwtype_dat\">1492-02-11</td>",
 					"<td data-sort-value=\"2266042.5\" class=\"ISO-Date smwtype_dat\">1492-02-11</td>",
 					"<td data-sort-value=\"2266042.5\" class=\"MW-Date smwtype_dat\">11 February 1492</td>",
-					"<td data-sort-value=\"2266042.5\" class=\"JL-Date smwtype_dat\">2 February 1492 JL</td>",
+					"<td data-sort-value=\"2266042.5\" class=\"JL-Date smwtype_dat\">2 February 1492 <sup>JL</sup></td>",
 					"<td data-sort-value=\"2266042.5\" class=\"GR-Date smwtype_dat\">11 February 1492</td>"
 				]
 			}
@@ -594,7 +594,7 @@
 					"<td data-sort-value=\"2451585.9166667\" class=\"Has-date smwtype_dat\">2000-02-11T10:00:00</td>",
 					"<td data-sort-value=\"2451585.9166667\" class=\"ISO-Date smwtype_dat\">2000-02-11T10:00:00</td>",
 					"<td data-sort-value=\"2451585.9166667\" class=\"MW-Date smwtype_dat\">10:00, 11 February 2000</td>",
-					"<td data-sort-value=\"2451585.9166667\" class=\"JL-Date smwtype_dat\">29 January 2000 10:00:00 JL</td>",
+					"<td data-sort-value=\"2451585.9166667\" class=\"JL-Date smwtype_dat\">29 January 2000 10:00:00 <sup>JL</sup></td>",
 					"<td data-sort-value=\"2451585.9166667\" class=\"GR-Date smwtype_dat\">11 February 2000 10:00:00</td>"
 				]
 			}
@@ -726,7 +726,8 @@
 	],
 	"settings": {
 		"wgContLang": "en",
-		"wgLang": "en"
+		"wgLang": "en",
+		"smwgDVFeatures": [ "SMW_DV_TIMEV_CM" ]
 	},
 	"meta": {
 

--- a/tests/phpunit/Integration/ByJsonScript/Fixtures/p-0414.json
+++ b/tests/phpunit/Integration/ByJsonScript/Fixtures/p-0414.json
@@ -1,5 +1,5 @@
 {
-	"description": "Test in-text annotation/free format for `_dat` datatype (#1389, #1401, en)",
+	"description": "Test in-text annotation/free format for `_dat` datatype (#1389, #1401, en, `smwgDVFeatures`)",
 	"properties": [
 		{
 			"name": "Has date",
@@ -104,7 +104,7 @@
 			"expected-output": {
 				"to-contain": [
 					"<td data-sort-value=\"2228431.9166782\" class=\"Has-date smwtype_dat\">10:00:01.000000</td>",
-					"<td data-sort-value=\"2228431.9166782\" class=\"Has-date smwtype_dat\">1389/02/11 10:00 JL</td>",
+					"<td data-sort-value=\"2228431.9166782\" class=\"Has-date smwtype_dat\">1389/02/11 10:00 <sup>JL</sup></td>",
 					"<td data-sort-value=\"2228431.9166782\" class=\"Has-date smwtype_dat\">1389/02/19 10:00</td>",
 					"<td data-sort-value=\"2228431.9166782\" class=\"JD smwtype_dat\">2228431.9166782</td>"
 				]
@@ -187,8 +187,8 @@
 			"subject": "Example/P0414/4a",
 			"expected-output": {
 				"to-contain": [
-					"<td data-sort-value=\"2159657.0023727\" class=\"Has-date smwtype_dat\">1200 JL</td>",
-					"<td data-sort-value=\"2159657.0023727\" class=\"Has-date smwtype_dat\">1200/10/26 JL</td>",
+					"<td data-sort-value=\"2159657.0023727\" class=\"Has-date smwtype_dat\">1200 <sup>JL</sup></td>",
+					"<td data-sort-value=\"2159657.0023727\" class=\"Has-date smwtype_dat\">1200/10/26 <sup>JL</sup></td>",
 					"<td data-sort-value=\"2159657.0023727\" class=\"JD smwtype_dat\">2159657.0023727</td>"
 				]
 			}
@@ -315,7 +315,8 @@
 	],
 	"settings": {
 		"wgContLang": "en",
-		"wgLang": "en"
+		"wgLang": "en",
+		"smwgDVFeatures": [ "SMW_DV_TIMEV_CM" ]
 	},
 	"meta": {
 

--- a/tests/phpunit/Integration/ByJsonScript/Fixtures/p-0419.json
+++ b/tests/phpunit/Integration/ByJsonScript/Fixtures/p-0419.json
@@ -1,5 +1,5 @@
 {
-	"description": "Test in-text annotation for `PRUC` to validate uniqueness",
+	"description": "Test in-text annotation for `PRUC` to validate uniqueness (`smwgDVFeatures`)",
 	"properties": [
 		{
 			"name": "Has Url",

--- a/tests/phpunit/Integration/ByJsonScript/Fixtures/p-0420.json
+++ b/tests/phpunit/Integration/ByJsonScript/Fixtures/p-0420.json
@@ -1,5 +1,5 @@
 {
-	"description": "Test in-text annotation for `_dat` using JL/GR annotated values (en)",
+	"description": "Test in-text annotation for `_dat` using JL/GR annotated values (en, `smwgDVFeatures`)",
 	"properties": [
 		{
 			"name": "Has date",
@@ -55,9 +55,9 @@
 			"subject": "Example/P0420/1a",
 			"expected-output": {
 				"to-contain": [
-					"<td data-sort-value=\"2336583.5\" class=\"Has-date smwtype_dat\">21 March 1685 JL</td>",
+					"<td data-sort-value=\"2336583.5\" class=\"Has-date smwtype_dat\">21 March 1685 <sup>JL</sup></td>",
 					"<td data-sort-value=\"2336583.5\" class=\"Has-date smwtype_dat\">31 March 1685</td>",
-					"<td data-sort-value=\"2336583.5\" class=\"Has-date smwtype_dat\">21 March 1685 JL</td>"
+					"<td data-sort-value=\"2336583.5\" class=\"Has-date smwtype_dat\">21 March 1685 <sup>JL</sup></td>"
 				]
 			}
 		},
@@ -66,9 +66,9 @@
 			"subject": "Example/P0420/2a",
 			"expected-output": {
 				"to-contain": [
-					"<td data-sort-value=\"2336583.5\" class=\"Has-date smwtype_dat\">21 March 1685 JL</td>",
+					"<td data-sort-value=\"2336583.5\" class=\"Has-date smwtype_dat\">21 March 1685 <sup>JL</sup></td>",
 					"<td data-sort-value=\"2336583.5\" class=\"Has-date smwtype_dat\">31 March 1685</td>",
-					"<td data-sort-value=\"2336583.5\" class=\"Has-date smwtype_dat\">21 March 1685 JL</td>"
+					"<td data-sort-value=\"2336583.5\" class=\"Has-date smwtype_dat\">21 March 1685 <sup>JL</sup></td>"
 				]
 			}
 		},
@@ -79,14 +79,15 @@
 				"to-contain": [
 					"<td data-sort-value=\"2336573.5\" class=\"Has-date smwtype_dat\">21 March 1685</td>",
 					"<td data-sort-value=\"2336573.5\" class=\"Has-date smwtype_dat\">21 March 1685</td>",
-					"<td data-sort-value=\"2336573.5\" class=\"Has-date smwtype_dat\">11 March 1685 JL</td>"
+					"<td data-sort-value=\"2336573.5\" class=\"Has-date smwtype_dat\">11 March 1685 <sup>JL</sup></td>"
 				]
 			}
 		}
 	],
 	"settings": {
 		"wgContLang": "en",
-		"wgLang": "en"
+		"wgLang": "en",
+		"smwgDVFeatures": [ "SMW_DV_TIMEV_CM" ]
 	},
 	"meta": {
 

--- a/tests/phpunit/Integration/ByJsonScript/Fixtures/p-0421.json
+++ b/tests/phpunit/Integration/ByJsonScript/Fixtures/p-0421.json
@@ -1,5 +1,5 @@
 {
-	"description": "Test in-text annotation with combined constraint validation",
+	"description": "Test in-text annotation with combined constraint validation (`smwgDVFeatures`)",
 	"properties": [
 		{
 			"name": "Has Url",

--- a/tests/phpunit/Unit/ExtraneousLanguageFileHandlerTest.php
+++ b/tests/phpunit/Unit/ExtraneousLanguageFileHandlerTest.php
@@ -50,7 +50,7 @@ class ExtraneousLanguageFileHandlerTest extends \PHPUnit_Framework_TestCase {
 
 		$provider[] = array(
 			'ja',
-			'\SMWLanguageEn'
+			'\SMWLanguageJa'
 		);
 
 		$provider[] = array(

--- a/tests/phpunit/Unit/ExtraneousLanguageTest.php
+++ b/tests/phpunit/Unit/ExtraneousLanguageTest.php
@@ -91,4 +91,61 @@ class ExtraneousLanguageTest extends \PHPUnit_Framework_TestCase {
 		);
 	}
 
+	public function testGetPreferredDateFormatByPrecisionOnMatchedPrecision() {
+
+		$language = $this->getMockBuilder( '\SMWLanguage' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$language->expects( $this->atLeastOnce() )
+			->method( 'getPreferredDateFormats' )
+			->will( $this->returnValue(
+				array( 'SMW_PREC_YMDT' => 'd m Y' ) ) );
+
+		$extraneousLanguageFileHandler = $this->getMockBuilder( '\SMW\ExtraneousLanguageFileHandler' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$extraneousLanguageFileHandler->expects( $this->atLeastOnce() )
+			->method( 'newByLanguageCode' )
+			->will( $this->returnValue( $language ) );
+
+		$instance = new ExtraneousLanguage(
+			$extraneousLanguageFileHandler
+		);
+
+		$this->assertEquals(
+			'd m Y',
+			$instance->getPreferredDateFormatByPrecision( SMW_PREC_YMDT )
+		);
+	}
+
+	public function testGetPreferredDateFormatOnNotMatchablePrecision() {
+
+		$language = $this->getMockBuilder( '\SMWLanguage' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$language->expects( $this->atLeastOnce() )
+			->method( 'getPreferredDateFormats' )
+			->will( $this->returnValue( array( 'Foo' => 'd m Y' ) ) );
+
+		$extraneousLanguageFileHandler = $this->getMockBuilder( '\SMW\ExtraneousLanguageFileHandler' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$extraneousLanguageFileHandler->expects( $this->atLeastOnce() )
+			->method( 'newByLanguageCode' )
+			->will( $this->returnValue( $language ) );
+
+		$instance = new ExtraneousLanguage(
+			$extraneousLanguageFileHandler
+		);
+
+		$this->assertEquals(
+			'd F Y H:i:s',
+			$instance->getPreferredDateFormatByPrecision( SMW_PREC_YMDT )
+		);
+	}
+
 }

--- a/tests/phpunit/Unit/IntlTimeFormatterTest.php
+++ b/tests/phpunit/Unit/IntlTimeFormatterTest.php
@@ -3,6 +3,7 @@
 namespace SMW\Tests;
 
 use SMW\IntlTimeFormatter;
+use Language;
 use SMWDITime as DITime;
 
 /**
@@ -48,6 +49,40 @@ class IntlTimeFormatterTest extends \PHPUnit_Framework_TestCase {
 		);
 	}
 
+	/**
+	 * @dataProvider localizedFormatProvider
+	 */
+	public function testGetLocalizedFormat( $serialization, $languageCode, $expected ) {
+
+		$instance = new IntlTimeFormatter(
+			DITime::doUnserialize( $serialization ),
+			Language::factory( $languageCode )
+		);
+
+		$this->assertEquals(
+			$expected,
+			$instance->getLocalizedFormat()
+		);
+	}
+
+	public function testContainsValidDateFormatRule() {
+
+		$formatOption = 'F Y/m/d H:i:s';
+
+		$language = $this->getMockBuilder( '\Language' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$instance = new IntlTimeFormatter(
+			DITime::doUnserialize( '1/2000/12/12/1/1/20.200' ),
+			$language
+		);
+
+		$this->assertTrue(
+			$instance->containsValidDateFormatRule( $formatOption )
+		);
+	}
+
 	public function testFormatWithLocalizedMonthReplacement() {
 
 		// F - A full textual representation of a month, such as January or March
@@ -86,7 +121,7 @@ class IntlTimeFormatterTest extends \PHPUnit_Framework_TestCase {
 		$provider[] = array(
 			'2/2000/12/12/1/1/20/200',
 			'Y/m/d H:i:s',
-			'2000/12/12 01:01:20 JL'
+			'2000/12/12 01:01:20'
 		);
 
 		#2
@@ -100,7 +135,7 @@ class IntlTimeFormatterTest extends \PHPUnit_Framework_TestCase {
 		$provider[] = array(
 			'2/1300/11/02/12/03/25.888499949',
 			'Y-m-d H:i:s.u',
-			'1300-11-02 12:03:25.888500 JL'
+			'1300-11-02 12:03:25.888500'
 		);
 
 		#4 time alone doesn't require a calendar model
@@ -113,4 +148,29 @@ class IntlTimeFormatterTest extends \PHPUnit_Framework_TestCase {
 		return $provider;
 	}
 
+	public function localizedFormatProvider() {
+
+		#0
+		$provider[] = array(
+			'1/2000/12/12/1/1/20/200',
+			'en',
+			'01:01:20, 12 December 2000'
+		);
+
+		#1
+		$provider[] = array(
+			'1/2000/12/12/1/1/20/200',
+			'ja',
+			'2000年12月12日 (月) 01:01:20'
+		);
+
+		#2
+		$provider[] = array(
+			'1/2000/12/12/1/1/20/200',
+			'es',
+			'01:01:20 12 dic 2000'
+		);
+
+		return $provider;
+	}
 }


### PR DESCRIPTION
#MEDIAWIKI has some restrictions (seconds are no displayed and is supposed to be influenced by the user selected language).

#LOCL support indiviual preferences to match SMW internal time precision while text elements are localized

- `SMW_DV_TIMEV_CM` as feature to hint the calendar model
- `TimeValueFormatter::getCaptionFromDataItem` will use the content language
which is either the default content language or if available the page content language
- `ExtraneousLanguage::getPreferredDateFormatByPrecision` determines
a PHP DateTime format string as preference for a specific language in
combination with a precision
- Each language can maintain a preference for a precision (as default)
 - 'SMW_PREC_Y'    => 'Y',
 - 'SMW_PREC_YM'   => 'F Y',
 - 'SMW_PREC_YMD'  => 'F j, Y',
 - 'SMW_PREC_YMDT' => 'H:i:s, j F Y'
- Output format `#LOCL` will use the `IntlTimeFormatter::getLocalizedFormat` and
 `ExtraneousLanguage::getPreferredDateFormatByPrecision` to dermine a
localized date/time output