### PR TITLE
Fix XmlResponseParser to correctly parse UTF-8 strings

### DIFF
--- a/src/SPARQLStore/QueryEngine/XmlResponseParser.php
+++ b/src/SPARQLStore/QueryEngine/XmlResponseParser.php
@@ -196,17 +196,29 @@ class XmlResponseParser implements HttpResponseParser {
 	private function handleCharacterData( $parser, $characterData ) {
 
 		$prevTag = end( $this->xmlOpenTags );
-		$rowcount = count( $this->data );
+		$rowcount = count( $this->data ) - 1;
+
+		// UTF-8 is being split therefore concatenate the string (use row as indicator
+		// to detect a sliced string)
+		if ( isset( $this->data[$rowcount] ) && ( $element = end( $this->data[$rowcount] ) ) !== null ) {
+			switch ( $prevTag ) {
+				case 'uri':
+					$characterData = $element->getUri() . $characterData;
+					break;
+				case 'literal':
+					$characterData = $element->getLexicalForm() . $characterData;
+			}
+		}
 
 		switch ( $prevTag ) {
 			case 'uri':
-				$this->data[$rowcount-1][$this->xmlBindIndex] = new ExpResource( $characterData );
+				$this->data[$rowcount][$this->xmlBindIndex] = new ExpResource( $characterData );
 				break;
 			case 'literal':
-				$this->data[$rowcount-1][$this->xmlBindIndex] = new ExpLiteral( $characterData, $this->currentDataType );
+				$this->data[$rowcount][$this->xmlBindIndex] = new ExpLiteral( $characterData, $this->currentDataType );
 				break;
 			case 'bnode':
-				$this->data[$rowcount-1][$this->xmlBindIndex] = new ExpResource( '_' . $characterData );
+				$this->data[$rowcount][$this->xmlBindIndex] = new ExpResource( '_' . $characterData );
 				break;
 			case 'boolean':
 				// no "results" in this case

--- a/tests/phpunit/Unit/SPARQLStore/QueryEngine/XmlResponseParserTest.php
+++ b/tests/phpunit/Unit/SPARQLStore/QueryEngine/XmlResponseParserTest.php
@@ -145,11 +145,20 @@ class XmlResponseParserTest extends \PHPUnit_Framework_TestCase {
 			new ExpLiteral( 'true', 'http://www.w3.org/2001/XMLSchema#boolean' )
 		);
 
-
 		#10
 		$provider[] = array(
 			'',
 			new ExpLiteral( 'false', 'http://www.w3.org/2001/XMLSchema#boolean' )
+		);
+
+		#11
+		$provider[] = array(
+			$rawResultProvider->getMixedRowsSparqlResultUtf8Xml(),
+			array(
+				new ExpResource( 'http://example.org/id/F安o' ),
+				new ExpResource( 'http://example.org/id/B定ar' ),
+				new ExpLiteral( 'Quux安定', 'http://www.w3.org/2001/XMLSchema#string' )
+			)
 		);
 
 		return $provider;

--- a/tests/phpunit/Utils/Fixtures/Results/FakeRawResultProvider.php
+++ b/tests/phpunit/Utils/Fixtures/Results/FakeRawResultProvider.php
@@ -55,6 +55,10 @@ class FakeRawResultProvider {
 		return $this->getFixtureContentsFor( 'invalid-sparql-result.xml' );
 	}
 
+	public function getMixedRowsSparqlResultUtf8Xml() {
+		return $this->getFixtureContentsFor( 'mixed-rows-sparql-result-utf8.xml' );
+	}
+
 	private function getFixtureContentsFor( $fixture ) {
 		if ( $file = $this->isReadableFile( $this->getFixtureLocation() . $fixture ) ) {
 			return file_get_contents( $file );

--- a/tests/phpunit/Utils/Fixtures/Results/XML/mixed-rows-sparql-result-utf8.xml
+++ b/tests/phpunit/Utils/Fixtures/Results/XML/mixed-rows-sparql-result-utf8.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0"?>
+<sparql xmlns="http://www.w3.org/2005/sparql-results#">
+	<head>
+		<variable name="result"/>
+	</head>
+	<results>
+		<result>
+			<binding name="result"><uri>http://example.org/id/F安o</uri></binding>
+		</result>
+		<result>
+			<binding name="result"><uri>http://example.org/id/B定ar</uri></binding>
+		</result>
+		<result>
+			<binding name="result"><literal datatype="http://www.w3.org/2001/XMLSchema#string">Quux安定</literal></binding>
+		</result>
+	</results>
+</sparql>


### PR DESCRIPTION
```
<?xml version="1.0"?>
<sparql xmlns="http://www.w3.org/2005/sparql-results#">
	<head>
		<variable name="result"/>
	</head>
	<results>
		<result>
			<binding name="result"><uri>http://example.org/id/F安o</uri></binding>
		</result>
		<result>
			<binding name="result"><uri>http://example.org/id/B定ar</uri></binding>
		</result>
		<result>
			<binding name="result"><literal datatype="http://www.w3.org/2001/XMLSchema#string">Quux安定</literal></binding>
		</result>
	</results>
</sparql>
```

Fixes the parser so that a SPARQL response containing UTF-8 is correctly interpret.

[0] http://stackoverflow.com/questions/9465223/php-xml-parser-utf-8-encoded-values-are-split