### PR TITLE
Cache conversion data

### DIFF
--- a/includes/datavalues/SMW_DataValue.php
+++ b/includes/datavalues/SMW_DataValue.php
@@ -321,7 +321,24 @@ abstract class SMWDataValue {
 	 * @return Options $options
 	 */
 	public function setOptions( Options $options ) {
-		$this->options = $options;
+		foreach ( $options->getOptions() as $key => $value ) {
+			$this->setOption( $key, $value );
+		}
+	}
+
+	/**
+	 * @since 2.4
+	 *
+	 * @return string $key
+	 * @param mxied $value
+	 */
+	public function setOption( $key, $value ) {
+
+		if ( $this->options === null ) {
+			$this->options = new Options();
+		}
+
+		$this->options->set( $key, $value );
 	}
 
 	/**

--- a/src/DataValues/UnitConversionFetcher.php
+++ b/src/DataValues/UnitConversionFetcher.php
@@ -1,0 +1,258 @@
+<?php
+
+namespace SMW\DataValues;
+
+use SMWNumberValue as NumberValue;
+use SMW\DIProperty;
+use SMW\ApplicationFactory;
+use SMW\CachedPropertyValuesPrefetcher;
+use SMWDIBlob as DIBlob;
+
+/**
+ * Returns conversion data from a cache instance to enable a responsive query
+ * feedback and eliminate possible repeated DB requests.
+ *
+ * The cache is evicted as soon as the property that contains "Corresponds to"
+ * is altered.
+ *
+ * @license GNU GPL v2+
+ * @since 2.4
+ *
+ * @author mwjames
+ */
+class UnitConversionFetcher {
+
+	/**
+	 * @var NumberValue
+	 */
+	private $numberValue;
+
+	/**
+	 * @var CachedPropertyValuesPrefetcher
+	 */
+	private $cachedPropertyValuesPrefetcher;
+
+	/**
+	 * @var array
+	 */
+	private $errors = array();
+
+	/**
+	 * @var array
+	 */
+	private $unitIds = array();
+
+	/**
+	 * @var array
+	 */
+	private $unitFactors = array();
+
+	/**
+	 * @var false|string
+	 */
+	private $mainUnit = false;
+
+	/**
+	 * @var array
+	 */
+	protected $prefixalUnitPreference = array();
+
+	/**
+	 * @since 2.4
+	 *
+	 * @param NumberValue $numberValue
+	 * @param CachedPropertyValuesPrefetcher|null $cachedPropertyValuesPrefetcher
+	 */
+	public function __construct( NumberValue $numberValue, CachedPropertyValuesPrefetcher $cachedPropertyValuesPrefetcher = null ) {
+		$this->numberValue = $numberValue;
+		$this->cachedPropertyValuesPrefetcher = $cachedPropertyValuesPrefetcher;
+
+		if ( $this->cachedPropertyValuesPrefetcher === null ) {
+			$this->cachedPropertyValuesPrefetcher = ApplicationFactory::getInstance()->getCachedPropertyValuesPrefetcher();
+		}
+	}
+
+	/**
+	 * @since 2.4
+	 *
+	 * @return array
+	 */
+	public function getErrors() {
+		return $this->errors;
+	}
+
+	/**
+	 * @since 2.4
+	 *
+	 * @return array
+	 */
+	public function getUnitIds() {
+		return $this->unitIds;
+	}
+
+	/**
+	 * @since 2.4
+	 *
+	 * @return array
+	 */
+	public function getUnitFactors() {
+		return $this->unitFactors;
+	}
+
+	/**
+	 * @since 2.4
+	 *
+	 * @return string
+	 */
+	public function getMainUnit() {
+		return $this->mainUnit;
+	}
+
+	/**
+	 * @since 2.4
+	 *
+	 * @return array
+	 */
+	public function getPrefixalUnitPreference() {
+		return $this->prefixalUnitPreference;
+	}
+
+	/**
+	 * @since 2.4
+	 *
+	 * @param DIProperty $property
+	 */
+	public function fetchConversionData( DIProperty $property ) {
+
+		$this->unitIds = array();
+		$this->unitFactors = array();
+		$this->mainUnit = false;
+		$this->prefixalUnitPreference = array();
+		$this->errors = array();
+
+		$factors = $this->cachedPropertyValuesPrefetcher->getPropertyValues(
+			$property->getDiWikiPage(),
+			new DIProperty( '_CONV' )
+		);
+
+		if ( $factors === null || $factors === array() ) { // no custom type
+			return $this->errors[] = 'smw_nounitsdeclared';
+		}
+
+		$number = '';
+		$unit = '';
+
+		foreach ( $factors as $di ) {
+
+			// ignore corrupted data and bogus inputs
+			if ( !( $di instanceof DIBlob ) ||
+			     ( $this->numberValue->parseNumberValue( $di->getString(), $number, $unit, $asPrefix ) != 0 ) ||
+			     ( $number == 0 ) ) {
+				continue;
+			}
+
+			$this->matchUnitAliases(
+				$number,
+				$asPrefix,
+				preg_split( '/\s*,\s*/u', $unit )
+			);
+		}
+
+		// No unit with factor 1? Make empty string the main unit.
+		if ( $this->mainUnit === false ) {
+			$this->mainUnit = '';
+		}
+
+		// Always add an extra empty unit; not as a synonym for the main unit
+		// but as a new unit with ID '' so if users do not give any unit, the
+		// conversion tooltip will still display the main unit for clarity
+		// (the empty unit is never displayed; we filter it when making
+		// conversion values)
+		$this->unitFactors = array( '' => 1 ) + $this->unitFactors;
+		$this->unitIds[''] = '';
+	}
+
+	/**
+	 * @since 2.4
+	 *
+	 * @param DIProperty|null $property
+	 */
+	public function fetchCachedConversionData( DIProperty $property = null ) {
+
+		if ( $property === null || ( $propertyDiWikiPage = $property->getDiWikiPage() ) === null ) {
+			return;
+		}
+
+		$blobStore = $this->cachedPropertyValuesPrefetcher->getBlobStore();
+
+		// Ensure that when the property page is altered the cache gets
+		// evicted
+		$hash = $this->cachedPropertyValuesPrefetcher->getRootHashFor(
+			$propertyDiWikiPage
+		);
+
+		$container = $blobStore->read(
+			$hash
+		);
+
+		$key = '--conv';
+
+		if ( $container->has( $key ) ) {
+			$data = $container->get( $key );
+			$this->unitIds = $data['ids'];
+			$this->unitFactors = $data['factors'];
+			$this->mainUnit = $data['main'];
+			$this->prefixalUnitPreference = $data['prefix'];
+			return;
+		}
+
+		$this->fetchConversionData( $property );
+
+		if ( $this->errors !== array() ) {
+			return;
+		}
+
+		$data = array(
+			'ids' => $this->unitIds,
+			'factors' => $this->unitFactors,
+			'main' => $this->mainUnit,
+			'prefix' => $this->prefixalUnitPreference
+		);
+
+		$container->set( $key, $data );
+
+		$blobStore->save(
+			$container
+		);
+	}
+
+	private function matchUnitAliases( $number, $asPrefix, array $unitAliases ) {
+		$first = true;
+
+		foreach ( $unitAliases as $unit ) {
+			$unit = $this->numberValue->normalizeUnit( $unit );
+
+			// Legacy match the preserve some behaviour where spaces where normalized
+			// no matter what
+			$normalizedUnit = $this->numberValue->normalizeUnit(
+				str_replace( array( '&nbsp;', '&#160;', '&thinsp;', ' ' ), '', $unit )
+			);
+
+			if ( $first ) {
+				$unitid = $unit;
+				if ( $number == 1 ) { // add main unit to front of array (displayed first)
+					$this->mainUnit = $unit;
+					$this->unitFactors = array( $unit => 1 ) + $this->unitFactors;
+				} else { // non-main units are not ordered (can be modified via display units)
+					$this->unitFactors[$unit] = $number;
+				}
+				$first = false;
+			}
+			// add all known units to m_unitids to simplify checking for them
+			$this->unitIds[$unit] = $unitid;
+			$this->unitIds[$normalizedUnit] = $unitid;
+			$this->prefixalUnitPreference[$unit] = $asPrefix;
+		}
+	}
+
+}

--- a/tests/phpunit/Unit/DataValues/UnitConversionFetcherTest.php
+++ b/tests/phpunit/Unit/DataValues/UnitConversionFetcherTest.php
@@ -1,0 +1,271 @@
+<?php
+
+namespace SMW\Tests\DataValues;
+
+use SMW\DataItemFactory;
+use SMW\DataValues\UnitConversionFetcher;
+use SMWNumberValue as NumberValue;
+use SMW\Tests\TestEnvironment;
+
+/**
+ * @covers \SMW\DataValues\UnitConversionFetcher
+ * @group semantic-mediawiki
+ *
+ * @license GNU GPL v2+
+ * @since 2.4
+ *
+ * @author mwjames
+ */
+class UnitConversionFetcherTest extends \PHPUnit_Framework_TestCase {
+
+	private $testEnvironment;
+	private $dataItemFactory;
+	private $propertySpecificationLookup;
+
+	protected function setUp() {
+		$this->testEnvironment = new TestEnvironment();
+		$this->dataItemFactory = new DataItemFactory();
+
+		$this->propertySpecificationLookup = $this->getMockBuilder( '\SMW\PropertySpecificationLookup' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$this->testEnvironment->registerObject( 'PropertySpecificationLookup', $this->propertySpecificationLookup );
+	}
+
+	protected function tearDown() {
+		$this->testEnvironment->tearDown();
+	}
+
+	public function testCanConstruct() {
+
+		$numberValue = $this->getMockBuilder( '\SMWNumberValue' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$this->assertInstanceOf(
+			'\SMW\DataValues\UnitConversionFetcher',
+			new UnitConversionFetcher( $numberValue )
+		);
+	}
+
+	public function testErrorOnMissingConversionData() {
+
+		$numberValue = $this->getMockBuilder( '\SMWNumberValue' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$instance = new UnitConversionFetcher(
+			$numberValue
+		);
+
+		$instance->fetchConversionData(
+			$this->dataItemFactory->newDIProperty( 'Foo' )
+		);
+
+		$this->assertNotEmpty(
+			$instance->getErrors()
+		);
+	}
+
+	/**
+	 * @dataProvider conversionDataProvider
+	 */
+	public function testFetchConversionData( $thousands, $decimal, $correspondsTo, $unitIds, $unitFactors, $mainUnit, $prefixalUnitPreference ) {
+
+		$cachedPropertyValuesPrefetcher = $this->getMockBuilder( '\SMW\CachedPropertyValuesPrefetcher' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$cachedPropertyValuesPrefetcher->expects( $this->once() )
+			->method( 'getPropertyValues' )
+			->will( $this->returnValue( array(
+				$this->dataItemFactory->newDIBlob( $correspondsTo )
+			) ) );
+
+		$numberValue = new NumberValue();
+
+		$numberValue->setOption(
+			'separator.thousands',
+			$thousands
+		);
+
+		$numberValue->setOption(
+			'separator.decimal',
+			$decimal
+		);
+
+		$instance = new UnitConversionFetcher(
+			$numberValue,
+			$cachedPropertyValuesPrefetcher
+		);
+
+		$instance->fetchConversionData(
+			$this->dataItemFactory->newDIProperty( 'Foo' )
+		);
+
+		$this->assertEmpty(
+			$instance->getErrors()
+		);
+
+		$this->assertEquals(
+			$unitIds,
+			$instance->getUnitIds()
+		);
+
+		$this->assertEquals(
+			$unitFactors,
+			$instance->getUnitFactors()
+		);
+
+		$this->assertEquals(
+			$mainUnit,
+			$instance->getMainUnit()
+		);
+
+		$this->assertEquals(
+			$prefixalUnitPreference,
+			$instance->getPrefixalUnitPreference()
+		);
+	}
+
+	public function testFetchCachedConversionData() {
+
+		$container = $this->getMockBuilder( '\Onoi\BlobStore\Container' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$container->expects( $this->any() )
+			->method( 'has' )
+			->will( $this->onConsecutiveCalls( false, true ) );
+
+		$blobStore = $this->getMockBuilder( '\Onoi\BlobStore\BlobStore' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$blobStore->expects( $this->exactly( 2 ) )
+			->method( 'read' )
+			->will( $this->returnValue( $container ) );
+
+		$blobStore->expects( $this->once() )
+			->method( 'save' );
+
+		$cachedPropertyValuesPrefetcher = $this->getMockBuilder( '\SMW\CachedPropertyValuesPrefetcher' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$cachedPropertyValuesPrefetcher->expects( $this->atLeastOnce() )
+			->method( 'getBlobStore' )
+			->will( $this->returnValue( $blobStore ) );
+
+		$cachedPropertyValuesPrefetcher->expects( $this->once() )
+			->method( 'getPropertyValues' )
+			->will( $this->returnValue( array(
+				$this->dataItemFactory->newDIBlob( 'Foo' )
+			) ) );
+
+		$numberValue = new NumberValue();
+
+		$instance = new UnitConversionFetcher(
+			$numberValue,
+			$cachedPropertyValuesPrefetcher
+		);
+
+		$property = $this->dataItemFactory->newDIProperty( 'Foo' );
+
+		$instance->fetchCachedConversionData( $property );
+
+		// Cached
+		$instance->fetchCachedConversionData( $property);
+	}
+
+	public function conversionDataProvider() {
+
+		$provider[] = array(
+			',',
+			'.',
+			'¥,JPY,Japanese Yen 1.5',
+			array(
+				'¥' => '¥',
+				'JPY' => '¥',
+				'JapaneseYen' => '¥',
+				'' => ''
+			),
+			array(
+				'' => 1,
+				'¥' => 1.5
+			),
+			'',
+			array(
+				'¥' => true,
+				'JPY' => true,
+				'JapaneseYen' => true
+			)
+		);
+
+		$provider[] = array(
+			',',
+			'.',
+			'0.5 British Pound, GBP, pounds sterling, £',
+			array(
+				'BritishPound' => 'BritishPound',
+				'GBP' => 'BritishPound',
+				'poundssterling' => 'BritishPound',
+				'£' => 'BritishPound',
+				'' => ''
+			),
+			array(
+				'' => 1,
+				'BritishPound' => 0.5
+			),
+			'',
+			array(
+				'BritishPound' => false,
+				'GBP' => false,
+				'poundssterling' => false,
+				'£' => false
+			)
+		);
+
+		$provider[] = array(
+			'.',
+			',',
+			'0,5 thousand rub., thousand ₽',
+			array(
+				'thousandrub.' => 'thousandrub.',
+				'thousand₽' => 'thousandrub.',
+				'' => ''
+			),
+			array(
+				'thousandrub.' => 0.5,
+				'' => 1
+			),
+			'',
+			array(
+				'thousandrub.' => false,
+				'thousand₽' => false
+			)
+		);
+
+		$provider[] = array(
+			'.',
+			',',
+			'€ 1',
+			array(
+				'€' => '€',
+				'' => ''
+			),
+			array(
+				'€' => 1,
+				'' => 1
+			),
+			'€',
+			array(
+				'€' => true,
+			)
+		);
+
+		return $provider;
+	}
+
+}


### PR DESCRIPTION
Isolates the DB/Store access and moves this into its own `UnitConversionFetcher`
where caching is applied using `CachedPropertyValuesPrefetcher`.

If conversion data are altered on a property page then the cache
gets evicted.