### PR TITLE
Export the canonical form for a property

### DIFF
--- a/includes/export/SMW_Exporter.php
+++ b/includes/export/SMW_Exporter.php
@@ -141,6 +141,13 @@ class SMWExporter {
 
 		$subject = $semdata->getSubject();
 
+		// Make sure to use the canonical form, a localized representation
+		// should not carry a reference to a subject (e.g invoked as incoming
+		// property caused by a different user language)
+		if ( $subject->getNamespace() === SMW_NS_PROPERTY && $subject->getSubobjectName() === '' ) {
+			$subject = DIProperty::newFromUserLabel( $subject->getDBKey() )->getCanonicalDiWikiPage();
+		}
+
 		// #649 Alwways make sure to have a least one valid sortkey
 		if ( !$semdata->getPropertyValues( new DIProperty( '_SKEY' ) ) && $subject->getSortKey() !== '' ) {
 			$semdata->addPropertyObjectValue(

--- a/src/PropertyLabelFinder.php
+++ b/src/PropertyLabelFinder.php
@@ -59,6 +59,13 @@ class PropertyLabelFinder {
 	 * @return string|boolean
 	 */
 	public function findCanonicalPropertyLabelById( $id ) {
+
+		// This is fixed otherwise the `_txt` assignment interferes with the label
+		// declaration
+		if ( $id === '_TEXT' ) {
+			return 'Text';
+		}
+
 		return array_search( $id, $this->canonicalPropertyLabels );
 	}
 

--- a/tests/phpunit/Integration/ByJsonScript/Fixtures/r-0008.json
+++ b/tests/phpunit/Integration/ByJsonScript/Fixtures/r-0008.json
@@ -1,0 +1,81 @@
+{
+	"description": "Test RDF output generation on pages that contain incoming error annotations (`wgContLang=en`, `wgLang=es`, syntax=rdf/turtle)",
+	"properties": [
+		{
+			"name": "Has area without unit",
+			"contents": "[[Has type::Quantity]]"
+		}
+	],
+	"subjects": [
+		{
+			"name": "Example/R0008/1",
+			"contents": "[[Has area without unit::1 m]]"
+		}
+	],
+	"rdf-testcases": [
+		{
+			"about": "#0 incoming (error) is exported in canonical form (especially when user language is different)",
+			"exportcontroller" : {
+				"print-pages": [ "Property:Has area without unit" ],
+				"parameters" : {
+					"backlinks" : true,
+					"recursion" : "1",
+					"revisiondate" : false
+				}
+			},
+			"expected-output": {
+				"to-contain": [
+					"<owl:DatatypeProperty rdf:about=\"http://example.org/id/Property-3AHas_area_without_unit\">",
+					"<rdfs:label>Has area without unit</rdfs:label>",
+					"<swivt:wikiPageSortKey rdf:datatype=\"http://www.w3.org/2001/XMLSchema#string\">Has area without unit</swivt:wikiPageSortKey>",
+					"<swivt:type rdf:resource=\"http://semantic-mediawiki.org/swivt/1.0#_qty\"/>"
+				],
+				"not-contain": [
+					"<owl:ObjectProperty rdf:about=\"http://example.org/id/Property-3ATiene_valor_incorrecto_para\">",
+					"<swivt:wikiPageSortKey rdf:datatype=\"http://www.w3.org/2001/XMLSchema#string\">Tiene valor incorrecto para</swivt:wikiPageSortKey>"
+				]
+			}
+		},
+		{
+			"about": "#1 (turtle)",
+			"exportcontroller" : {
+				"syntax": "turtle",
+				"print-pages": [ "Property:Has area without unit" ],
+				"parameters" : {
+					"backlinks" : true,
+					"recursion" : "1",
+					"revisiondate" : false
+				}
+			},
+			"expected-output": {
+				"to-contain": [
+					"property:Has_area_without_unit",
+					"rdf:type  owl:DatatypeProperty ;",
+					"rdfs:label  \"Has area without unit\" ;",
+					"swivt:wikiNamespace  \"102\"^^xsd:integer ;",
+					"swivt:wikiPageSortKey  \"Has area without unit\" ;",
+					"swivt:type  <http://semantic-mediawiki.org/swivt/1.0#_qty> .",
+					"<http://example.org/id/Example/R0008/1-23_ERRadfff161e75b2273a8190dbe8c78dbda>",
+					"swivt:masterPage  <http://example.org/id/Example/R0008/1> ;",
+					"property:Has_improper_value_for  property:Has_area_without_unit ;"
+				]
+			}
+		}
+	],
+	"settings": {
+		"smwgExportBCNonCanonicalFormUse": false,
+		"smwgNamespacesWithSemanticLinks": {
+			"NS_MAIN": true,
+			"NS_CATEGORY": true,
+			"SMW_NS_PROPERTY": true
+		},
+		"wgContLang": "en",
+		"wgLang": "es",
+		"smwgNamespace": "http://example.org/id/"
+	},
+	"meta": {
+		"version": "0.2",
+		"is-incomplete": false,
+		"debug": false
+	}
+}

--- a/tests/phpunit/Integration/ByJsonScript/Fixtures/r-0009.json
+++ b/tests/phpunit/Integration/ByJsonScript/Fixtures/r-0009.json
@@ -1,0 +1,81 @@
+{
+	"description": "Test RDF output generation that contain a monolingual text annotations `_PDESC` (`wgContLang=en`, `wgLang=es`, syntax=rdf/turtle)",
+	"properties": [
+		{
+			"name": "Has number",
+			"contents": "[[Has type::Number]] [[Has property description::Is a number@en]] [[Has property description::数@ja]]"
+		}
+	],
+	"subjects": [
+		{
+			"name": "Example/R0008/1",
+			"contents": "[[Has area without unit::1 m]]"
+		}
+	],
+	"rdf-testcases": [
+		{
+			"about": "#0",
+			"exportcontroller" : {
+				"print-pages": [ "Property:Has number" ],
+				"parameters" : {
+					"backlinks" : true,
+					"recursion" : "1",
+					"revisiondate" : false
+				}
+			},
+			"expected-output": {
+				"to-contain": [
+					"<owl:DatatypeProperty rdf:about=\"http://example.org/id/Property-3AHas_number\">",
+					"<property:Has_property_description rdf:resource=\"http://example.org/id/Property-3AHas_number-23_ML13b181afba7d1e489a656a75fa7917b2\"/>",
+					"<property:Has_property_description rdf:resource=\"http://example.org/id/Property-3AHas_number-23_ML4c33eabf5c7dfbb1292c817504951018\"/>",
+					"<swivt:Subject rdf:about=\"http://example.org/id/Property-3AHas_number-23_ML13b181afba7d1e489a656a75fa7917b2\">",
+					"<property:Text rdf:datatype=\"http://www.w3.org/2001/XMLSchema#string\">Is a number</property:Text>",
+					"<property:Language_code rdf:datatype=\"http://www.w3.org/2001/XMLSchema#string\">en</property:Language_code>",
+					"<swivt:Subject rdf:about=\"http://example.org/id/Property-3AHas_number-23_ML4c33eabf5c7dfbb1292c817504951018\">",
+					"<property:Text rdf:datatype=\"http://www.w3.org/2001/XMLSchema#string\">数</property:Text>",
+					"<property:Language_code rdf:datatype=\"http://www.w3.org/2001/XMLSchema#string\">ja</property:Language_code>"
+				]
+			}
+		},
+		{
+			"about": "#0",
+			"exportcontroller" : {
+				"syntax": "turtle",
+				"print-pages": [ "Property:Has number" ],
+				"parameters" : {
+					"backlinks" : true,
+					"recursion" : "1",
+					"revisiondate" : false
+				}
+			},
+			"expected-output": {
+				"to-contain": [
+					"rdfs:label  \"Has number\" ;",
+					"property:Has_property_description  property:Has_number-23_ML13b181afba7d1e489a656a75fa7917b2 ,  property:Has_number-23_ML4c33eabf5c7dfbb1292c817504951018 ;",
+					"swivt:wikiPageSortKey  \"Has number\" ;",
+					"swivt:type  <http://semantic-mediawiki.org/swivt/1.0#_num> .",
+					"property:Language_code  \"en\" ;",
+					"property:Text  \"Is a number\" .",
+					"property:Language_code  \"ja\" ;",
+					"property:Text  \"数\" ."
+				]
+			}
+		}
+	],
+	"settings": {
+		"smwgExportBCNonCanonicalFormUse": false,
+		"smwgNamespacesWithSemanticLinks": {
+			"NS_MAIN": true,
+			"NS_CATEGORY": true,
+			"SMW_NS_PROPERTY": true
+		},
+		"wgContLang": "en",
+		"wgLang": "es",
+		"smwgNamespace": "http://example.org/id/"
+	},
+	"meta": {
+		"version": "0.2",
+		"is-incomplete": false,
+		"debug": false
+	}
+}

--- a/tests/phpunit/Integration/ByJsonScript/README.md
+++ b/tests/phpunit/Integration/ByJsonScript/README.md
@@ -1,5 +1,5 @@
 ## Fixtures
-Contains 114 files:
+Contains 116 files:
 
 ### F
 * [f-0001.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/ByJsonScript/Fixtures/f-0001.json) Test format=debug output
@@ -117,6 +117,8 @@ Contains 114 files:
 * [r-0005.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/ByJsonScript/Fixtures/r-0005.json) Test RDF wiki-info output (#928, en)
 * [r-0006.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/ByJsonScript/Fixtures/r-0006.json) Test RDF output generation for pages that contain `_rec` annotations (#1285, #1275)
 * [r-0007.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/ByJsonScript/Fixtures/r-0007.json) Test RDF output for imported dc/gna vocabulary, owl:AnnotationProperty, owl:DatatypeProperty, owl:ObjectProperty, Equivalent URI (#795, `wgRestrictDisplayTitle`, en)
+* [r-0008.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/ByJsonScript/Fixtures/r-0008.json) Test RDF output generation on pages that contain incoming error annotations (`wgContLang=en`, `wgLang=es`, syntax=rdf/turtle)
+* [r-0009.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/ByJsonScript/Fixtures/r-0009.json) Test RDF output generation that contain a monolingual text annotations `_PDESC` (`wgContLang=en`, `wgLang=es`, syntax=rdf/turtle)
 
 ### S
 * [s-0001.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/ByJsonScript/Fixtures/s-0001.json) Test output of `Special:Properties` (en, skip-on sqlite, 1.19)
@@ -125,4 +127,4 @@ Contains 114 files:
 * [s-0004.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/ByJsonScript/Fixtures/s-0004.json) Test `Special:Browse` output for `_dat' (`wgContLang` = en, `wgLang` = ja)
 * [s-0005.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/ByJsonScript/Fixtures/s-0005.json) Test `Special:Browse` output for `_dat' (`wgContLang` = en, `wgLang` = en, `smwgDVFeatures`)
 
--- Last updated on 2016-05-05 by `readmeContentsBuilder.php`
+-- Last updated on 2016-05-06 by `readmeContentsBuilder.php`


### PR DESCRIPTION
- Add additional test to verify monolingual text annotation export
- Add test where user and content language are different during export