### PR TITLE
Inject User/Content language as option into DV

### DIFF
--- a/includes/articlepages/SMW_PropertyPage.php
+++ b/includes/articlepages/SMW_PropertyPage.php
@@ -176,7 +176,8 @@ class SMWPropertyPage extends SMWOrderedListPage {
 			);
 
 			// Allow the DV formatter to access a specific language code
-			$dvWikiPage->setLanguageCode(
+			$dvWikiPage->setOption(
+				'user.language',
 				Localizer::getInstance()->getUserLanguage()->getCode()
 			);
 
@@ -225,7 +226,8 @@ class SMWPropertyPage extends SMWOrderedListPage {
 			$dvWikiPage = DataValueFactory::getInstance()->newDataItemValue( $diWikiPage, null );
 
 			// Allow the DV formatter to access a specific language code
-			$dvWikiPage->setLanguageCode(
+			$dvWikiPage->setOption(
+				'user.language',
 				$languageCode
 			);
 
@@ -258,7 +260,8 @@ class SMWPropertyPage extends SMWOrderedListPage {
 				if ( $i < $smwgMaxPropertyValues + 1 ) {
 					$dv = DataValueFactory::getInstance()->newDataItemValue( $di, $this->mProperty );
 
-					$dv->setLanguageCode(
+					$dv->setOption(
+						'user.language',
 						$languageCode
 					);
 

--- a/includes/datavalues/SMW_DataValue.php
+++ b/includes/datavalues/SMW_DataValue.php
@@ -103,11 +103,6 @@ abstract class SMWDataValue {
 	protected $m_outformat = false;
 
 	/**
-	 * @var string
-	 */
-	private $languageCode = '';
-
-	/**
 	 * Used to control the addition of the standard search link.
 	 * @var boolean
 	 */
@@ -273,24 +268,6 @@ abstract class SMWDataValue {
 	 */
 	public function getProperty() {
 		return $this->m_property;
-	}
-
-	/**
-	 * @since 2.4
-	 *
-	 * @param string $languageCode
-	 */
-	public function setLanguageCode( $languageCode ) {
-		$this->languageCode = $languageCode;
-	}
-
-	/**
-	 * @since 2.4
-	 *
-	 * @return string
-	 */
-	public function getLanguageCode() {
-		return $this->languageCode;
 	}
 
 	/**

--- a/includes/specials/SMW_SpecialBrowse.php
+++ b/includes/specials/SMW_SpecialBrowse.php
@@ -5,6 +5,7 @@ use SMW\UrlEncoder;
 use SMW\Localizer;
 use SMW\SemanticData;
 use SMW\ApplicationFactory;
+use SMW\DataValueFactory;
 
 /**
  * @ingroup SMWSpecialPage
@@ -70,7 +71,7 @@ class SMWSpecialBrowse extends SpecialPage {
 			$this->articletext = UrlEncoder::decode( $query );
 		}
 
-		$this->subject = \SMW\DataValueFactory::getInstance()->newTypeIDValue( '_wpg', $this->articletext );
+		$this->subject = DataValueFactory::getInstance()->newTypeIDValue( '_wpg', $this->articletext );
 		$offsettext = $wgRequest->getVal( 'offset' );
 		$this->offset = ( is_null( $offsettext ) ) ? 0 : intval( $offsettext );
 
@@ -181,7 +182,7 @@ class SMWSpecialBrowse extends SpecialPage {
 		$diProperties = $data->getProperties();
 		$noresult = true;
 		foreach ( $diProperties as $key => $diProperty ) {
-			$dvProperty = \SMW\DataValueFactory::getInstance()->newDataItemValue( $diProperty, null );
+			$dvProperty = DataValueFactory::getInstance()->newDataItemValue( $diProperty, null );
 
 			if ( $dvProperty->isVisible() ) {
 				$dvProperty->setCaption( $this->getPropertyLabel( $dvProperty, $incoming ) );
@@ -216,9 +217,9 @@ class SMWSpecialBrowse extends SpecialPage {
 				}
 
 				if ( $incoming ) {
-					$dv = \SMW\DataValueFactory::getInstance()->newDataItemValue( $di, null );
+					$dv = DataValueFactory::getInstance()->newDataItemValue( $di, null );
 				} else {
-					$dv = \SMW\DataValueFactory::getInstance()->newDataItemValue( $di, $diProperty );
+					$dv = DataValueFactory::getInstance()->newDataItemValue( $di, $diProperty );
 				}
 
 				$body .= "<span class=\"{$ccsPrefix}value\">" .
@@ -270,8 +271,14 @@ class SMWSpecialBrowse extends SpecialPage {
 		$linker = smwfGetLinker();
 
 		// Allow the DV formatter to access a specific language code
-		$dataValue->setLanguageCode(
-			Localizer::getInstance()->getPreferredLanguageByRule( $this->subject->getDataItem() )->getCode()
+		$dataValue->setOption(
+			'content.language',
+			Localizer::getInstance()->getPreferredContentLanguage( $this->subject->getDataItem() )->getCode()
+		);
+
+		$dataValue->setOption(
+			'user.language',
+			Localizer::getInstance()->getUserLanguage()->getCode()
 		);
 
 		$dataValue->setContextPage(

--- a/includes/storage/SMW_ResultArray.php
+++ b/includes/storage/SMW_ResultArray.php
@@ -1,6 +1,9 @@
 <?php
+
 use SMW\InTextAnnotationParser;
 use SMW\Query\PrintRequest;
+use SMW\Localizer;
+use SMW\DataValueFactory;
 use SMWDIBlob as DIBlob;
 
 /**
@@ -149,7 +152,7 @@ class SMWResultArray {
 			// Not efficient, but correct: we need to find the right property for
 			// the selected index of the record here.
 			$pos = $this->mPrintRequest->getParameter( 'index' ) - 1;
-			$recordValue = \SMW\DataValueFactory::getInstance()->newDataItemValue( $di,
+			$recordValue = DataValueFactory::getInstance()->newDataItemValue( $di,
 				$this->mPrintRequest->getData()->getDataItem() );
 			$diProperties = $recordValue->getPropertyDataItems();
 
@@ -174,19 +177,26 @@ class SMWResultArray {
 			);
 		}
 
-		$dv = \SMW\DataValueFactory::getInstance()->newDataItemValue( $di, $diProperty );
-		if ( $this->mPrintRequest->getOutputFormat() ) {
-			$dv->setOutputFormat( $this->mPrintRequest->getOutputFormat() );
-		}
+		$dv = DataValueFactory::getInstance()->newDataItemValue( $di, $diProperty );
 
 		// Allow the DV formatter to access a specific language code
-		$dv->setLanguageCode(
-			\SMW\Localizer::getInstance()->getPreferredLanguageByRule( $this->mResult )->getCode()
+		$dv->setOption(
+			'content.language',
+			Localizer::getInstance()->getPreferredContentLanguage( $this->mResult )->getCode()
+		);
+
+		$dv->setOption(
+			'user.language',
+			Localizer::getInstance()->getUserLanguage()->getCode()
 		);
 
 		$dv->setContextPage(
 			$this->mResult
 		);
+
+		if ( $this->mPrintRequest->getOutputFormat() ) {
+			$dv->setOutputFormat( $this->mPrintRequest->getOutputFormat() );
+		}
 
 		return $dv;
 	}
@@ -253,7 +263,7 @@ class SMWResultArray {
 					$newcontent = array();
 
 					foreach ( $this->mContent as $diContainer ) {
-						/* SMWRecordValue */ $recordValue = \SMW\DataValueFactory::getInstance()->newDataItemValue( $diContainer, $propertyValue->getDataItem() );
+						/* SMWRecordValue */ $recordValue = DataValueFactory::getInstance()->newDataItemValue( $diContainer, $propertyValue->getDataItem() );
 						$dataItems = $recordValue->getDataItems();
 
 						if ( array_key_exists( $pos, $dataItems ) &&

--- a/src/DataValues/ValueFormatters/TimeValueFormatter.php
+++ b/src/DataValues/ValueFormatters/TimeValueFormatter.php
@@ -121,7 +121,7 @@ class TimeValueFormatter extends DataValueFormatter {
 		$precision = $dataItem->getPrecision();
 
 		$language = Localizer::getInstance()->getLanguage(
-			$this->dataValue->getLanguageCode()
+			$this->dataValue->getOptionValueFor( 'user.language' )
 		);
 
 		$year = $dataItem->getYear();
@@ -175,7 +175,7 @@ class TimeValueFormatter extends DataValueFormatter {
 
 		// If the language code is empty then the content language code is used
 		$extraneousLanguage = Localizer::getInstance()->getExtraneousLanguage(
-			Localizer::getInstance()->getContentLanguage( $this->dataValue->getContextPage() )
+			$this->dataValue->getOptionValueFor( 'content.language' )
 		);
 
 		// https://en.wikipedia.org/wiki/Anno_Domini
@@ -247,7 +247,7 @@ class TimeValueFormatter extends DataValueFormatter {
 	public function getCaptionFromFreeFormat( DITime $dataItem = null ) {
 
 		$language = Localizer::getInstance()->getLanguage(
-			$this->dataValue->getLanguageCode()
+			$this->dataValue->getOptionValueFor( 'user.language' )
 		);
 
 		// Prehistory dates are not supported when using this output format
@@ -283,7 +283,7 @@ class TimeValueFormatter extends DataValueFormatter {
 	public function getLocalizedFormat( DITime $dataItem = null ) {
 
 		$language = Localizer::getInstance()->getLanguage(
-			$this->dataValue->getLanguageCode()
+			$this->dataValue->getOptionValueFor( 'user.language' )
 		);
 
 		if ( $dataItem !== null && $dataItem->getYear() > DITime::PREHISTORY ) {

--- a/src/InTextAnnotationParser.php
+++ b/src/InTextAnnotationParser.php
@@ -75,6 +75,16 @@ class InTextAnnotationParser {
 	private $strictModeState = true;
 
 	/**
+	 * @var string
+	 */
+	private $contentLanguage = '';
+
+	/**
+	 * @var string
+	 */
+	private $userLanguage = '';
+
+	/**
 	 * @since 1.9
 	 *
 	 * @param ParserData $parserData
@@ -115,6 +125,9 @@ class InTextAnnotationParser {
 		$title = $this->parserData->getTitle();
 		$this->settings = $this->applicationFactory->getSettings();
 		$start = microtime( true );
+
+		$this->contentLanguage = Localizer::getInstance()->getPreferredContentLanguage( $title )->getCode();
+		$this->userLanguage = Localizer::getInstance()->getUserLanguage()->getCode();
 
 		// Identifies the current parser run (especially when called recursively)
 		$this->parserData->getSubject()->setContextReference( 'intp:' . uniqid() );
@@ -406,6 +419,16 @@ class InTextAnnotationParser {
 				$value,
 				$valueCaption,
 				$subject
+			);
+
+			$dataValue->setOption(
+				'content.language',
+				$this->contentLanguage
+			);
+
+			$dataValue->setOption(
+				'user.language',
+				$this->userLanguage
 			);
 
 			if (

--- a/src/IntlTimeFormatter.php
+++ b/src/IntlTimeFormatter.php
@@ -123,7 +123,7 @@ class IntlTimeFormatter {
 		$output = $dateTime->format( $format );
 
 		$monthNumber = $dateTime->format( 'n' );
-		$dayNumber = $dateTime->format( 'N' );
+		$dayNumber = $dateTime->format( 'N' ) + 1;
 
 		if ( strpos( $format, 'F' ) !== false ) {
 			$output = str_replace(

--- a/src/Localizer.php
+++ b/src/Localizer.php
@@ -83,19 +83,18 @@ class Localizer {
 	}
 
 	/**
-	 * By rule means that
+	 * @note
 	 *
-	 * 1. If the page content language is different from the content language then
-	 * use the page content language (as it is clear that the page content was
-	 * intended to be in a specific language)
-	 * 2. If the page content language and content language are indifferent then
-	 * use the user language
-	 * 3. If the page content language and user language could not be determined then
-	 * use the content language
+	 * 1. If the page content language is availabe use it as preferred language
+	 * (as it is clear that the page content was intended to be in a specific
+	 * language)
+	 * 2. If no page content language was assigned use the global content
+	 * language
 	 *
 	 * General rules:
 	 * - Special pages are in the user language
-	 * - Display of values (DV) should follow rules outlined above
+	 * - Display of values (DV) should use the user language if available otherwise
+	 * use the content language as fallback
 	 * - Storage of values (DI) should always use the content language
 	 *
 	 * Notes:
@@ -108,33 +107,22 @@ class Localizer {
 	 *
 	 * @return Language
 	 */
-	public function getPreferredLanguageByRule( $title = null ) {
+	public function getPreferredContentLanguage( $title = null ) {
 
-		$pageLanguage = '';
-		$language = $this->getUserLanguage();
+		$language = '';
 
 		if ( $title instanceof DIWikiPage ) {
 			$title = $title->getTitle();
 		}
 
-		if ( $title instanceof Title ) {
-			$pageLanguage = $title->getPageLanguage();
-		}
-
 		// If the page language is different from the global content language
 		// then we assume that an explicit language object was given otherwise
 		// the Title is using the content language as fallback
-		if (
-			$pageLanguage !== '' &&
-			$pageLanguage->getCode() !== $this->getContentLanguage()->getCode() ) {
-			$language = $pageLanguage;
+		if ( $title instanceof Title ) {
+			$language = $title->getPageLanguage();
 		}
 
-		if ( $language === '' ) {
-			$language = $this->getContentLanguage();
-		}
-
-		return $language;
+		return $language instanceof Language ? $language : $this->getContentLanguage();
 	}
 
 	/**
@@ -146,7 +134,7 @@ class Localizer {
 	 */
 	public function getLanguage( $languageCode = '' ) {
 
-		if ( $languageCode === '' ) {
+		if ( $languageCode === '' || !$languageCode || $languageCode === null ) {
 			return $this->getContentLanguage();
 		}
 
@@ -168,7 +156,7 @@ class Localizer {
 			$languageCode = $language->getCode();
 		}
 
-		if ( $languageCode === '' ) {
+		if ( $languageCode === '' || !$languageCode || $languageCode === null ) {
 			$languageCode = $this->getContentLanguage()->getCode();
 		}
 

--- a/tests/phpunit/Integration/ByJsonScript/Fixtures/p-0423.json
+++ b/tests/phpunit/Integration/ByJsonScript/Fixtures/p-0423.json
@@ -72,7 +72,7 @@
 			"subject": "Example/P0423/Q1.3",
 			"expected-output": {
 				"to-contain": [
-					"<td data-sort-value=\"2435851.0034722\" class=\"Has-date smwtype_dat\">1957年1月12日 (金) 12:05:00</td>"
+					"<td data-sort-value=\"2435851.0034722\" class=\"Has-date smwtype_dat\">1957年1月12日 (土) 12:05:00</td>"
 				]
 			}
 		},
@@ -81,7 +81,7 @@
 			"subject": "Example/P0423/Q1.4",
 			"expected-output": {
 				"to-contain": [
-					"<p>1957年1月12日 (金) 12:05:00"
+					"<p>1957年1月12日 (土) 12:05:00"
 				]
 			}
 		}

--- a/tests/phpunit/Integration/ByJsonScript/Fixtures/s-0004.json
+++ b/tests/phpunit/Integration/ByJsonScript/Fixtures/s-0004.json
@@ -22,8 +22,8 @@
 			},
 			"expected-output": {
 				"to-contain": [
-					"<span class=\"smwb-value\">1991年1月12日 (金) 08:56:00&#160;&#160;",
-					"title=\"Special:SearchByProperty/Has-20date/1991年1月12日-20(金)-2008:56:00\">+</a></span>"
+					"<span class=\"smwb-value\">1991年1月12日 (土) 08:56:00&#160;&#160;",
+					"title=\"Special:SearchByProperty/Has-20date/1991年1月12日-20(土)-2008:56:00\">+</a></span>"
 				]
 			}
 		}

--- a/tests/phpunit/Unit/DataValues/ValueFormatters/TimeValueFormatterTest.php
+++ b/tests/phpunit/Unit/DataValues/ValueFormatters/TimeValueFormatterTest.php
@@ -78,7 +78,9 @@ class TimeValueFormatterTest extends \PHPUnit_Framework_TestCase {
 		$timeValue->setUserValue( $timeUserValue );
 
 		$timeValue->setOutputFormat( $format );
-		$timeValue->setLanguageCode( $languageCode );
+
+		$timeValue->setOption( 'user.language', $languageCode );
+		$timeValue->setOption( 'content.language', $languageCode );
 
 		$instance = new TimeValueFormatter( $timeValue );
 
@@ -199,8 +201,9 @@ class TimeValueFormatterTest extends \PHPUnit_Framework_TestCase {
 	public function testMediaWikiDate_WithDifferentLanguage() {
 
 		$timeValue = new TimeValue( '_dat' );
+
 		$timeValue->setUserValue( '2015-02-28' );
-		$timeValue->setLanguageCode( 'en' );
+		$timeValue->setOption( 'user.language', 'en' );
 
 		$instance = new TimeValueFormatter( $timeValue );
 
@@ -209,7 +212,7 @@ class TimeValueFormatterTest extends \PHPUnit_Framework_TestCase {
 			$instance->getMediaWikiDate()
 		);
 
-		$timeValue->setLanguageCode( 'ja' );
+		$timeValue->setOption( 'user.language', 'ja' );
 
 		$instance = new TimeValueFormatter( $timeValue );
 
@@ -224,7 +227,7 @@ class TimeValueFormatterTest extends \PHPUnit_Framework_TestCase {
 		$timeValue = new TimeValue( '_dat' );
 		$timeValue->setUserValue( '2015-02-28' );
 
-		$timeValue->setLanguageCode( 'en' );
+		$timeValue->setOption( 'user.language', 'en' );
 		$timeValue->setOutputFormat( 'LOCL' );
 
 		$instance = new TimeValueFormatter( $timeValue );

--- a/tests/phpunit/Unit/IntlTimeFormatterTest.php
+++ b/tests/phpunit/Unit/IntlTimeFormatterTest.php
@@ -161,7 +161,7 @@ class IntlTimeFormatterTest extends \PHPUnit_Framework_TestCase {
 		$provider[] = array(
 			'1/2000/12/12/1/1/20/200',
 			'ja',
-			'2000年12月12日 (月) 01:01:20'
+			'2000年12月12日 (火) 01:01:20'
 		);
 
 		#2

--- a/tests/phpunit/Unit/LocalizerTest.php
+++ b/tests/phpunit/Unit/LocalizerTest.php
@@ -169,19 +169,11 @@ class LocalizerTest extends \PHPUnit_Framework_TestCase {
 			->disableOriginalConstructor()
 			->getMock();
 
-		$contentLanguage->expects( $this->atLeastOnce() )
-			->method( 'getCode' )
-			->will( $this->returnValue( 'en' ) );
-
 		$instance = new Localizer( $contentLanguage );
 
 		$pageLanguage = $this->getMockBuilder( '\Language' )
 			->disableOriginalConstructor()
 			->getMock();
-
-		$pageLanguage->expects( $this->once() )
-			->method( 'getCode' )
-			->will( $this->returnValue( 'foo' ) );
 
 		$title = $this->getMockBuilder( '\Title' )
 			->disableOriginalConstructor()
@@ -193,7 +185,7 @@ class LocalizerTest extends \PHPUnit_Framework_TestCase {
 
 		$this->assertEquals(
 			$pageLanguage,
-			$instance->getPreferredLanguageByRule( $title )
+			$instance->getPreferredContentLanguage( $title )
 		);
 	}
 
@@ -206,8 +198,8 @@ class LocalizerTest extends \PHPUnit_Framework_TestCase {
 		$instance = new Localizer( $contentLanguage );
 
 		$this->assertEquals(
-			$instance->getUserLanguage(),
-			$instance->getPreferredLanguageByRule( null )
+			$instance->getContentLanguage(),
+			$instance->getPreferredContentLanguage( null )
 		);
 	}
 


### PR DESCRIPTION
- Allows more freedom to handle output formatting based on options invoked
- Fixed `dayNumber` in `IntlTimeFormatter` which is +1 to match a literal