### PR TITLE
Remove/strip invalid characters/tags from property name, refs #1567

### DIFF
--- a/i18n/en.json
+++ b/i18n/en.json
@@ -341,6 +341,7 @@
 	"smw-pa-property-predefined_errp": "\"$1\" is a predefined property to track input errors for irregular value annotations that was likely caused by type or [[Property:Allows value|allowed value]] restrictions and is provided by [https://www.semantic-mediawiki.org/wiki/Help:Special_properties Semantic MediaWiki].",
 	"smw-pa-property-predefined_pval": "[https://www.semantic-mediawiki.org/wiki/Help:Special_property_Allows_value \"$1\"] is a predefined property that can define a list of permissible values to restrict value assignments for a property and is provided by [https://www.semantic-mediawiki.org/wiki/Help:Special_properties Semantic MediaWiki].",
 	"smw-datavalue-property-restricted-use": "Property \"$1\" has been marked for restricted use.",
+	"smw-datavalue-property-invalid-name": "Property name contains invalid characters (e.g. $1) .",
 	"smw-datavalue-restricted-use": "Datavalue \"$1\" has been marked for restricted use.",
 	"smw-datavalue-invalid-number": "\"$1\" can not be interpreted as a number.",
 	"smw-query-condition-circular": "A possible circular condition has been detected in \"$1\".",

--- a/tests/phpunit/Integration/ByJsonScript/Fixtures/p-0102.json
+++ b/tests/phpunit/Integration/ByJsonScript/Fixtures/p-0102.json
@@ -1,0 +1,69 @@
+{
+	"description": "Test in-text annotation on properties with invalid names/charaters (#1567, `wgContLang=en`)",
+	"properties": [
+		{
+			"name": "Has #",
+			"contents": "[[Has type::Date]]"
+		}
+	],
+	"subjects": [
+		{
+			"name": "Example/P0102/1",
+			"contents": "[[&#124; &#93;&#93;&lt;/td&gt;&lt;::123]]"
+		},
+		{
+			"name": "Example/P0102/2",
+			"contents": "[[<code>Has property a</code>::ABC]] {{#set: <code>Has property b</code>=DEF }}"
+		},
+		{
+			"name": "Example/P0102/3",
+			"contents": "[[<code>Has property e::ABC]] {{#set: <code>Has property f=DEF }}"
+		}
+	],
+	"parser-testcases": [
+		{
+			"about": "#0 do not allow #",
+			"subject": "Example/P0102/1",
+			"store": {
+				"semantic-data": {
+					"strict-mode-valuematch": false,
+					"propertyCount": 3,
+					"propertyKeys": [ "_ERRC", "_MDAT", "_SKEY" ]
+				}
+			}
+		},
+		{
+			"about": "#1 strip tags",
+			"subject": "Example/P0102/2",
+			"store": {
+				"semantic-data": {
+					"strict-mode-valuematch": false,
+					"propertyCount": 4,
+					"propertyKeys": [ "Has_property_a", "Has_property_b", "_MDAT", "_SKEY" ],
+					"propertyValues": [ "ABC", "DEF" ]
+				}
+			}
+		},
+		{
+			"about": "#2 remove broken tags",
+			"subject": "Example/P0102/3",
+			"store": {
+				"semantic-data": {
+					"strict-mode-valuematch": false,
+					"propertyCount": 4,
+					"propertyKeys": [ "Has_property_e", "Has_property_f", "_MDAT", "_SKEY" ],
+					"propertyValues": [ "ABC", "DEF" ]
+				}
+			}
+		}
+	],
+	"settings": {
+		"wgContLang": "en",
+		"smwgPageSpecialProperties": [ "_MDAT" ]
+	},
+	"meta": {
+		"version": "0.1",
+		"is-incomplete": false,
+		"debug": false
+	}
+}


### PR DESCRIPTION
- Disallow `#` in a property name as that signals a fragment and can never
be resolved in a meaningful way
- `[[<code>Property</code>::ABC]]` remove the tags from name

refs #1567