### PR TITLE
Query condition to support subtype property chaining

### DIFF
--- a/includes/query/SMW_QueryParser.php
+++ b/includes/query/SMW_QueryParser.php
@@ -7,6 +7,7 @@ use SMW\Query\Language\NamespaceDescription;
 use SMW\Query\Language\SomeProperty;
 use SMW\Query\Language\ThingDescription;
 use SMW\Query\Parser\DescriptionProcessor;
+use SMW\DataTypeRegistry;
 
 /**
  * Objects of this class are in charge of parsing a query string in order
@@ -579,7 +580,7 @@ class SMWQueryParser {
 	}
 
 	private function isPagePropertyType( $typeid ) {
-		return $typeid == '_wpg' || $typeid == '__sob';
+		return $typeid == '_wpg' || DataTypeRegistry::getInstance()->isSubDataType( $typeid );
 	}
 
 }

--- a/tests/phpunit/Integration/ByJsonScript/Fixtures/p-0409.json
+++ b/tests/phpunit/Integration/ByJsonScript/Fixtures/p-0409.json
@@ -1,5 +1,5 @@
 {
-	"description": "Test in-text annotation for `_rec`/`_mlt_rec` (+ subobject) for when record type points to another record type (en)",
+	"description": "Test in-text annotation for `_rec`/`_mlt_rec` (+ subobject) for when record type points to another record type (`wgContLang=en`, `wgLang=en`)",
 	"properties": [
 		{
 			"name": "Has text",

--- a/tests/phpunit/Integration/ByJsonScript/Fixtures/q-1105.json
+++ b/tests/phpunit/Integration/ByJsonScript/Fixtures/q-1105.json
@@ -22,6 +22,10 @@
 		{
 			"name": "Example/Q1105/2",
 			"contents": "{{#subobject: Test|Has text=Bar}} {{#subobject: Test|Has text=Foo|Has record text=abc;456}}"
+		},
+		{
+			"name": "Example/Q1105/3",
+			"contents": "{{#subobject: Test|Has text=Foo|Has record text=def;456}}"
 		}
 	],
 	"query-testcases": [
@@ -50,6 +54,24 @@
 						"property": "Has record text",
 						"value": "abc;456"
 					}
+				]
+			}
+		},
+		{
+			"about": "#1 same as #0 only to use property chain notation",
+			"store" : {
+				"clear-cache" : true
+			},
+			"condition": "[[Has record text.Has text::abc]]",
+			"printouts" : [],
+			"parameters" : {
+				"limit" : "10"
+			},
+			"queryresult": {
+				"count": 2,
+				"results": [
+					"Example/Q1105/1#0##Test",
+					"Example/Q1105/2#0##Test"
 				]
 			}
 		}

--- a/tests/phpunit/Integration/ByJsonScript/Fixtures/q-1106.json
+++ b/tests/phpunit/Integration/ByJsonScript/Fixtures/q-1106.json
@@ -8,26 +8,26 @@
 	],
 	"subjects": [
 		{
-			"name": "Example/1201/1",
-			"contents": "[[Category:E-1201]][[Has restricted status record::open]]"
+			"name": "Example/Q1106/1",
+			"contents": "[[Category:E-Q1106]][[Has restricted status record::open]]"
 		},
 		{
-			"name": "Example/1201/2",
-			"contents": "[[Category:E-1201]]{{#set:Has restricted status record=closed}}"
+			"name": "Example/Q1106/2",
+			"contents": "[[Category:E-Q1106]]{{#set:Has restricted status record=closed}}"
 		},
 		{
-			"name": "Example/1201/3",
-			"contents": "{{#subobject:Has restricted status record=in progress|@category=E-1201}}"
+			"name": "Example/Q1106/3",
+			"contents": "{{#subobject:Has restricted status record=in progress|@category=E-Q1106}}"
 		},
 		{
-			"name": "Example/1201/4",
-			"contents": "[[Category:E-1201]][[Has restricted status record::none of the above]]"
+			"name": "Example/Q1106/4",
+			"contents": "[[Category:E-Q1106]][[Has restricted status record::none of the above]]"
 		}
 	],
 	"query-testcases": [
 		{
 			"about": "#0 like *en*",
-			"condition": "[[Category:E-1201]][[Has restricted status record::~*en*]]",
+			"condition": "[[Category:E-Q1106]][[Has restricted status record::~*en*]]",
 			"printouts" : [],
 			"parameters" : {
 				"limit" : "10"
@@ -35,13 +35,13 @@
 			"queryresult": {
 				"count": 1,
 				"results": [
-					"Example/1201/1#0##"
+					"Example/Q1106/1#0##"
 				]
 			}
 		},
 		{
 			"about": "#1 like cl*",
-			"condition": "[[Category:E-1201]][[Has restricted status record::~cl*]]",
+			"condition": "[[Category:E-Q1106]][[Has restricted status record::~cl*]]",
 			"printouts" : [],
 			"parameters" : {
 				"limit" : "10"
@@ -49,13 +49,13 @@
 			"queryresult": {
 				"count": 1,
 				"results": [
-					"Example/1201/2#0##"
+					"Example/Q1106/2#0##"
 				]
 			}
 		},
 		{
 			"about": "#2 not like cl*",
-			"condition": "[[Category:E-1201]][[Has restricted status record::!~cl*]]",
+			"condition": "[[Category:E-Q1106]][[Has restricted status record::!~cl*]]",
 			"printouts" : [],
 			"parameters" : {
 				"limit" : "10"
@@ -63,14 +63,14 @@
 			"queryresult": {
 				"count": 2,
 				"results": [
-					"Example/1201/1#0##",
-					"Example/1201/3#0##_21b274980f5e103560d43a63c84cf984"
+					"Example/Q1106/1#0##",
+					"Example/Q1106/3#0##_a0cd8b51f1e768606a47a2d4ec9bd867"
 				]
 			}
 		},
 		{
 			"about": "#3 not like cl* AND *in*",
-			"condition": "[[Category:E-1201]]<q>[[Has restricted status record::!~cl*]] AND [[Has restricted status record::!~*in*]]</q>",
+			"condition": "[[Category:E-Q1106]]<q>[[Has restricted status record::!~cl*]] AND [[Has restricted status record::!~*in*]]</q>",
 			"printouts" : [],
 			"parameters" : {
 				"limit" : "10"
@@ -78,13 +78,13 @@
 			"queryresult": {
 				"count": 1,
 				"results": [
-					"Example/1201/1#0##"
+					"Example/Q1106/1#0##"
 				]
 			}
 		},
 		{
 			"about": "#4 not like cl* OR *in* (doesn't make much sense, we test it anyway)",
-			"condition": "[[Category:E-1201]]<q>[[Has restricted status record::!~cl*]] OR [[Has restricted status record::!~*in*]]</q>",
+			"condition": "[[Category:E-Q1106]]<q>[[Has restricted status record::!~cl*]] OR [[Has restricted status record::!~*in*]]</q>",
 			"printouts" : [],
 			"parameters" : {
 				"limit" : "10"
@@ -92,15 +92,17 @@
 			"queryresult": {
 				"count": 3,
 				"results": [
-					"Example/1201/1#0##",
-					"Example/1201/2#0##",
-					"Example/1201/3#0##_21b274980f5e103560d43a63c84cf984"
+					"Example/Q1106/1#0##",
+					"Example/Q1106/2#0##",
+					"Example/Q1106/3#0##_a0cd8b51f1e768606a47a2d4ec9bd867"
 				]
 			}
 		}
 	],
 	"settings": {
-		"smwStrictComparators": false
+		"smwStrictComparators": false,
+		"wgContLang": "en",
+		"wgLang": "en"
 	},
 	"meta": {
 		"version": "0.1",

--- a/tests/phpunit/Integration/ByJsonScript/Fixtures/q-1107.json
+++ b/tests/phpunit/Integration/ByJsonScript/Fixtures/q-1107.json
@@ -1,0 +1,81 @@
+{
+	"description": "Test `_rec`/`_mlt_rec`(`_PDESC`) to use property chaining (`wgContLang=en`)",
+	"properties": [
+		{
+			"name": "Has text",
+			"contents": "[[Has type::Text]] [[Has property description::Text property@en]]"
+		},
+		{
+			"name": "Has number",
+			"contents": "[[Has type::Number]] [[Has property description::Number property@en]]"
+		},
+		{
+			"name": "Has record text",
+			"contents": "[[Has type::Record]] [[Has fields::Has text;Has number]]"
+		}
+	],
+	"subjects": [
+		{
+			"name": "Example/Q1107/1",
+			"contents": "{{#subobject: Test|Has text=Foo|Has record text=abc;222}}"
+		}
+	],
+	"query-testcases": [
+		{
+			"about": "#0",
+			"store" : {
+				"clear-cache" : true
+			},
+			"condition": "[[Has property description.Language code::en]]",
+			"printouts" : [],
+			"parameters" : {
+				"limit" : "10"
+			},
+			"queryresult": {
+				"count": 2,
+				"results": [
+					"Has text#102##",
+					"Has number#102##"
+				]
+			}
+		},
+		{
+			"about": "#1",
+			"condition": "[[Has subobject.Has record text.Has number::222]]",
+			"printouts" : [],
+			"parameters" : {
+				"limit" : "10"
+			},
+			"queryresult": {
+				"count": 1,
+				"results": [
+					"Example/Q1107/1#0##"
+				]
+			}
+		},
+		{
+			"about": "#2",
+			"condition": "[[Has record text.Has number::222]]",
+			"printouts" : [],
+			"parameters" : {
+				"limit" : "10"
+			},
+			"queryresult": {
+				"count": 1,
+				"results": [
+					"Example/Q1107/1#0##Test"
+				]
+			}
+		}
+	],
+	"settings": {
+		"wgContLang": "en",
+		"wgLang": "en"
+	},
+	"meta": {
+
+		"version": "0.1",
+		"is-incomplete": false,
+		"debug": false
+	}
+}

--- a/tests/phpunit/Integration/ByJsonScript/README.md
+++ b/tests/phpunit/Integration/ByJsonScript/README.md
@@ -1,5 +1,5 @@
 ## Fixtures
-Contains 116 files:
+Contains 119 files:
 
 ### F
 * [f-0001.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/ByJsonScript/Fixtures/f-0001.json) Test format=debug output
@@ -13,6 +13,7 @@ Contains 116 files:
 * [f-0205.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/ByJsonScript/Fixtures/f-0205.json) Test `format=table` on `|+align=`/`|+limit`/`|+order` extra printout parameters (T18571, en)
 * [f-0206.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/ByJsonScript/Fixtures/f-0206.json) Test `format=table` to display extra property description `_PDESC` (en)
 * [f-0207.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/ByJsonScript/Fixtures/f-0207.json) Test `format=table` on formatted indent when using */#/: (en)
+* [f-0208.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/ByJsonScript/Fixtures/f-0208.json) Test `format=table` with further results link (`wgContLang=en`, `wgLang=es`)
 * [f-0301.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/ByJsonScript/Fixtures/f-0301.json) Test format=category with template usage (#699, en, skip postgres)
 * [f-0302.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/ByJsonScript/Fixtures/f-0302.json) Test format=category and defaultsort (#699, en)
 * [f-0303.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/ByJsonScript/Fixtures/f-0303.json) Test `format=category` sort output using a template and DEFAULTSORT (#1459, en)
@@ -21,6 +22,7 @@ Contains 116 files:
 
 ### P
 * [p-0101.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/ByJsonScript/Fixtures/p-0101.json) Test in-text annotation for use of restricted properties (#914, en)
+* [p-0102.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/ByJsonScript/Fixtures/p-0102.json) Test in-text annotation on properties with invalid names/charaters (#1567, `wgContLang=en`)
 * [p-0106.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/ByJsonScript/Fixtures/p-0106.json) Test #info parser output (#1019, en)
 * [p-0107.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/ByJsonScript/Fixtures/p-0107.json) Test #smwdoc parser output (#1019, en)
 * [p-0202.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/ByJsonScript/Fixtures/p-0202.json) Test #set parser to use template for output (#1146, en)
@@ -41,7 +43,7 @@ Contains 116 files:
 * [p-0406.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/ByJsonScript/Fixtures/p-0406.json) Test in-text annotation for unrestricted template parse using `import-annotation=true` (#1055)
 * [p-0407.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/ByJsonScript/Fixtures/p-0407.json) Test in-text annotation for a redirect that is pointing to a deleted target (#1105)
 * [p-0408.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/ByJsonScript/Fixtures/p-0408.json) Test in-text annotation for multiple property assignment using non-strict parser mode (#1252, en)
-* [p-0409.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/ByJsonScript/Fixtures/p-0409.json) Test in-text annotation for `_rec`/`_mlt_rec` (+ subobject) for when record type points to another record type (en)
+* [p-0409.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/ByJsonScript/Fixtures/p-0409.json) Test in-text annotation for `_rec`/`_mlt_rec` (+ subobject) for when record type points to another record type (`wgContLang=en`, `wgLang=en`)
 * [p-0410.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/ByJsonScript/Fixtures/p-0410.json) Test in-text annotation on `_num`/`_tem`/`_qty` type with denoted precision (`_PREC`) and/or `-p<num>` printout precision marker (#1335, en)
 * [p-0411.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/ByJsonScript/Fixtures/p-0411.json) Test in-text annotation (and #subobject) using a monolingual property (#1344, en)
 * [p-0412.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/ByJsonScript/Fixtures/p-0412.json) Test in-text annotation for `_boo` datatype (ja)
@@ -107,7 +109,8 @@ Contains 116 files:
 * [q-1103.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/ByJsonScript/Fixtures/q-1103.json) Test `_rec` using some additional search pattern (#1189, en)
 * [q-1104.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/ByJsonScript/Fixtures/q-1104.json) Test `_rec` to find correct target for redirected property (#1244, en)
 * [q-1105.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/ByJsonScript/Fixtures/q-1105.json) Test `_rec` in combination with named subobject (T49472, #1300, en, `smwStrictComparators=false`)
-* [q-1201.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/ByJsonScript/Fixtures/q-1201.json) Test `_rec` with `~/!~` comparators on allowed values (#1207, `smwStrictComparators=false`)
+* [q-1106.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/ByJsonScript/Fixtures/q-1106.json) Test `_rec` with `~/!~` comparators on allowed values (#1207, `smwStrictComparators=false`)
+* [q-1107.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/ByJsonScript/Fixtures/q-1107.json) Test `_rec`/`_mlt_rec`(`_PDESC`) to use property chaining (`wgContLang=en`)
 
 ### R
 * [r-0001.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/ByJsonScript/Fixtures/r-0001.json) Test RDF output for `_txt`/`_wpg`/`_dat` (#881)
@@ -127,4 +130,4 @@ Contains 116 files:
 * [s-0004.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/ByJsonScript/Fixtures/s-0004.json) Test `Special:Browse` output for `_dat' (`wgContLang` = en, `wgLang` = ja)
 * [s-0005.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/ByJsonScript/Fixtures/s-0005.json) Test `Special:Browse` output for `_dat' (`wgContLang` = en, `wgLang` = en, `smwgDVFeatures`)
 
--- Last updated on 2016-05-06 by `readmeContentsBuilder.php`
+-- Last updated on 2016-05-12 by `readmeContentsBuilder.php`


### PR DESCRIPTION
Queries containing things like `[[Has subobject.Foo::abc]]` does work and this PR extends this to allow record and monolingual types to use property chaining as well (e.g `[[Has property description.Language code::en]]`).