### PR TITLE
Enable to alter SQLStore::FIXED_PROPERTY_ID_UPPERBOUND

### DIFF
--- a/includes/storage/SQLStore/SMW_SQLStore3.php
+++ b/includes/storage/SQLStore/SMW_SQLStore3.php
@@ -48,6 +48,9 @@ class SMWSQLStore3 extends SMWStore {
 	/**
 	 * Specifies the border limit (upper bound) for pre-defined properties used
 	 * in the ID_TABLE
+	 *
+	 * When changing the upper bound, please make sure to copy the current upper
+	 * bound as legcy to the SMWSQLStore3SetupHandlers::checkPredefinedPropertyBorder
 	 */
 	const FIXED_PROPERTY_ID_UPPERBOUND = 50;
 


### PR DESCRIPTION
`FIXED_PROPERTY_ID_UPPERBOUND = 50` can become an issue in future, the PR  ensures that the border can be altered without running a full rebuild (by moving/re-assigning any entity that is not a fixed property within the border to a new ID).