### PR TITLE
Set context page in DescriptionProcessor

### DIFF
--- a/includes/datavalues/SMW_DataValue.php
+++ b/includes/datavalues/SMW_DataValue.php
@@ -260,9 +260,9 @@ abstract class SMWDataValue {
 	 *
 	 * @since 1.7
 	 *
-	 * @param SMWDIWikiPage $contextPage
+	 * @param SMWDIWikiPage|null $contextPage
 	 */
-	public function setContextPage( SMWDIWikiPage $contextPage ) {
+	public function setContextPage( SMWDIWikiPage $contextPage = null ) {
 		$this->m_contextPage = $contextPage;
 
 		$this->setOption(

--- a/includes/parserhooks/AskParserFunction.php
+++ b/includes/parserhooks/AskParserFunction.php
@@ -161,15 +161,18 @@ class AskParserFunction {
 		$queryDuration = 0;
 		$start = microtime( true );
 
+		$contextPage = $this->parserData->getSubject();
+
 		list( $this->query, $this->params ) = SMWQueryProcessor::getQueryAndParamsFromFunctionParams(
 			$rawParams,
 			SMW_OUTPUT_WIKI,
 			SMWQueryProcessor::INLINE_QUERY,
-			$this->showMode
+			$this->showMode,
+			$contextPage
 		);
 
-		$this->query->setSubject(
-			DIWIkiPage::newFromTitle( $this->parserData->getTitle() )
+		$this->query->setContextPage(
+			$contextPage
 		);
 
 		$queryHash = $this->query->getHash();

--- a/includes/query/SMW_Query.php
+++ b/includes/query/SMW_Query.php
@@ -55,9 +55,9 @@ class SMWQuery {
 	private $m_mainlabel = ''; // Since 1.6
 
 	/**
-	 * @var DIWikiPage
+	 * @var DIWikiPage|null
 	 */
-	private $subject;
+	private $contextPage;
 
 	/**
 	 * Describes a non-local (remote) query source
@@ -86,19 +86,19 @@ class SMWQuery {
 	/**
 	 * @since 2.3
 	 *
-	 * @param DIWikiPage $subject
+	 * @param DIWikiPage|null $contextPage
 	 */
-	public function setSubject( DIWikiPage $subject ) {
-		$this->subject = $subject;
+	public function setContextPage( DIWikiPage $contextPage = null ) {
+		$this->contextPage = $contextPage;
 	}
 
 	/**
 	 * @since 2.3
 	 *
-	 * @return DIWikiPage $subject
+	 * @return DIWikiPage|null
 	 */
-	public function getSubject() {
-		return $this->subject;
+	public function getContextPage() {
+		return $this->contextPage;
 	}
 
 	/**

--- a/includes/query/SMW_QueryProcessor.php
+++ b/includes/query/SMW_QueryProcessor.php
@@ -99,12 +99,13 @@ class SMWQueryProcessor {
 	 *
 	 * @return SMWQuery
 	 */
-	static public function createQuery( $queryString, array $params, $context = self::INLINE_QUERY, $format = '', array $extraPrintouts = array() ) {
+	static public function createQuery( $queryString, array $params, $context = self::INLINE_QUERY, $format = '', array $extraPrintouts = array(), $contextPage = null ) {
 		global $smwgQDefaultNamespaces, $smwgQFeatures, $smwgQConceptFeatures;
 
 		// parse query:
 		$queryfeatures = ( $context == self::CONCEPT_DESC ) ? $smwgQConceptFeatures : $smwgQFeatures;
 		$qp = new SMWQueryParser( $queryfeatures );
+		$qp->setContextPage( $contextPage );
 		$qp->setDefaultNamespaces( $smwgQDefaultNamespaces );
 		$desc = $qp->getQueryDescription( $queryString );
 
@@ -123,6 +124,7 @@ class SMWQueryProcessor {
 
 		$query = new SMWQuery( $desc, ( $context != self::SPECIAL_PAGE ), ( $context == self::CONCEPT_DESC ) );
 		$query->setQueryString( $queryString );
+		$query->setContextPage( $contextPage );
 		$query->setExtraPrintouts( $extraPrintouts );
 		$query->setMainLabel( $params['mainlabel']->getValue() );
 		$query->addErrors( $qp->getErrors() ); // keep parsing errors for later output
@@ -363,7 +365,7 @@ class SMWQueryProcessor {
 	 * @param boolean $showMode process like #show parser function?
 	 * @return array( SMWQuery, array of IParam )
 	 */
-	static public function getQueryAndParamsFromFunctionParams( array $rawParams, $outputMode, $context, $showMode ) {
+	static public function getQueryAndParamsFromFunctionParams( array $rawParams, $outputMode, $context, $showMode, $contextPage = null ) {
 		list( $queryString, $params, $printouts ) = self::getComponentsFromFunctionParams( $rawParams, $showMode );
 
 		if ( !$showMode ) {
@@ -372,7 +374,7 @@ class SMWQueryProcessor {
 
 		$params = self::getProcessedParams( $params, $printouts );
 
-		$query  = self::createQuery( $queryString, $params, $context, '', $printouts );
+		$query  = self::createQuery( $queryString, $params, $context, '', $printouts, $contextPage );
 		return array( $query, $params );
 	}
 

--- a/src/DataValues/ValueValidators/UniquenessConstraintValueValidator.php
+++ b/src/DataValues/ValueValidators/UniquenessConstraintValueValidator.php
@@ -183,7 +183,7 @@ class UniquenessConstraintValueValidator implements ConstraintValueValidator {
 	}
 
 	private function canValidate( $dataValue ) {
-		return $dataValue instanceof DataValue && $dataValue->getContextPage() !== null && $dataValue->isEnabledFeature( SMW_DV_PVUC );
+		return $dataValue instanceof DataValue && $dataValue->getProperty() !== null && $dataValue->getContextPage() !== null && $dataValue->isEnabledFeature( SMW_DV_PVUC );
 	}
 
 }

--- a/src/InTextAnnotationParser.php
+++ b/src/InTextAnnotationParser.php
@@ -75,16 +75,6 @@ class InTextAnnotationParser {
 	private $strictModeState = true;
 
 	/**
-	 * @var string
-	 */
-	private $contentLanguage = '';
-
-	/**
-	 * @var string
-	 */
-	private $userLanguage = '';
-
-	/**
 	 * @since 1.9
 	 *
 	 * @param ParserData $parserData
@@ -125,9 +115,6 @@ class InTextAnnotationParser {
 		$title = $this->parserData->getTitle();
 		$this->settings = $this->applicationFactory->getSettings();
 		$start = microtime( true );
-
-		$this->contentLanguage = Localizer::getInstance()->getPreferredContentLanguage( $title )->getCode();
-		$this->userLanguage = Localizer::getInstance()->getUserLanguage()->getCode();
 
 		// Identifies the current parser run (especially when called recursively)
 		$this->parserData->getSubject()->setContextReference( 'intp:' . uniqid() );
@@ -419,16 +406,6 @@ class InTextAnnotationParser {
 				$value,
 				$valueCaption,
 				$subject
-			);
-
-			$dataValue->setOption(
-				'content.language',
-				$this->contentLanguage
-			);
-
-			$dataValue->setOption(
-				'user.language',
-				$this->userLanguage
 			);
 
 			if (

--- a/src/Query/ProfileAnnotator/QueryProfileAnnotatorFactory.php
+++ b/src/Query/ProfileAnnotator/QueryProfileAnnotatorFactory.php
@@ -26,19 +26,8 @@ class QueryProfileAnnotatorFactory {
 	 */
 	public function newJointProfileAnnotator( Query $query, $format, $duration = null ) {
 
-		$subject = new DIWikiPage(
-			$query->getSubject()->getDBkey(),
-			$query->getSubject()->getNamespace(),
-			$query->getSubject()->getInterwiki(),
-			$query->getQueryId()
-		);
-
-		$container = new DIContainer(
-			new ContainerSemanticData( $subject )
-		);
-
 		$nullProfileAnnotator = new NullProfileAnnotator(
-			$container
+			$this->newDIContainer( $query )
 		);
 
 		$descriptionProfileAnnotator = new DescriptionProfileAnnotator(
@@ -57,6 +46,33 @@ class QueryProfileAnnotatorFactory {
 		);
 
 		return $durationProfileAnnotator;
+	}
+
+	/**
+	 * @param Query $query
+	 *
+	 * @return DIContainer
+	 */
+	private function newDIContainer( Query $query ) {
+
+		$subject = $query->getContextPage();
+
+		if ( $subject === null ) {
+			$containerSemanticData = ContainerSemanticData::makeAnonymousContainer();
+		} else {
+			$subject = new DIWikiPage(
+				$subject->getDBkey(),
+				$subject->getNamespace(),
+				$subject->getInterwiki(),
+				$query->getQueryId()
+			);
+
+			$containerSemanticData = new ContainerSemanticData( $subject );
+		}
+
+		return new DIContainer(
+			$containerSemanticData
+		);
 	}
 
 }

--- a/src/SQLStore/QueryDependency/QueryResultDependencyListResolver.php
+++ b/src/SQLStore/QueryDependency/QueryResultDependencyListResolver.php
@@ -91,7 +91,7 @@ class QueryResultDependencyListResolver {
 	 * @return DIWikiPage|null
 	 */
 	public function getSubject() {
-		return $this->getQuery() !== null ? $this->getQuery()->getSubject() : null;
+		return $this->getQuery() !== null ? $this->getQuery()->getContextPage() : null;
 	}
 
 	/**

--- a/tests/phpunit/Integration/QueryProfileAnnotatorToProcessorIntegrationTest.php
+++ b/tests/phpunit/Integration/QueryProfileAnnotatorToProcessorIntegrationTest.php
@@ -39,7 +39,9 @@ class QueryProfileAnnotatorToProcessorIntegrationTest extends \PHPUnit_Framework
 			false
 		);
 
-		$query->setSubject( DIWikiPage::newFromText( __METHOD__ ) );
+		$query->setContextPage(
+			DIWikiPage::newFromText( __METHOD__ )
+		);
 
 		$queryProfileAnnotatorFactory = ApplicationFactory::getInstance()->newQueryProfileAnnotatorFactory();
 

--- a/tests/phpunit/Unit/DataValues/ValueValidators/UniquenessConstraintValueValidatorTest.php
+++ b/tests/phpunit/Unit/DataValues/ValueValidators/UniquenessConstraintValueValidatorTest.php
@@ -59,6 +59,39 @@ class UniquenessConstraintValueValidatorTest extends \PHPUnit_Framework_TestCase
 		);
 	}
 
+	public function testCanNotValidateOnNullProperty() {
+
+		$cachedPropertyValuesPrefetcher = $this->getMockBuilder( '\SMW\CachedPropertyValuesPrefetcher' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$dataValue = $this->getMockBuilder( '\SMWDataValue' )
+			->disableOriginalConstructor()
+			->setMethods( array( 'getProperty', 'getDataItem', 'getContextPage' ) )
+			->getMockForAbstractClass();
+
+		$dataValue->expects( $this->atLeastOnce() )
+			->method( 'getProperty' )
+			->will( $this->returnValue( null ) );
+
+		$dataValue->expects( $this->never() )
+			->method( 'getContextPage' );
+
+		$dataValue->expects( $this->never() )
+			->method( 'getDataItem' );
+
+		$dataValue->setOption(
+			'smwgDVFeatures',
+			SMW_DV_PVUC
+		);
+
+		$instance = new UniquenessConstraintValueValidator(
+			$cachedPropertyValuesPrefetcher
+		);
+
+		$instance->validate( $dataValue );
+	}
+
 	public function testValidateUsingAMockedQueryEngine() {
 
 		$property = $this->dataItemFactory->newDIProperty( 'ValidAllowedValue' );
@@ -96,8 +129,9 @@ class UniquenessConstraintValueValidatorTest extends \PHPUnit_Framework_TestCase
 			->method( 'getDataItem' )
 			->will( $this->returnValue( $this->dataItemFactory->newDIBlob( 'Foo' ) ) );
 
-		$dataValue->setOptions(
-			new Options( array( 'smwgDVFeatures' => SMW_DV_PVUC ) )
+		$dataValue->setOption(
+			'smwgDVFeatures',
+			SMW_DV_PVUC
 		);
 
 		$instance = new UniquenessConstraintValueValidator(

--- a/tests/phpunit/Unit/Query/Parser/DescriptionProcessorTest.php
+++ b/tests/phpunit/Unit/Query/Parser/DescriptionProcessorTest.php
@@ -3,6 +3,7 @@
 namespace SMW\Tests\Query\Parser;
 
 use SMW\DIProperty;
+use SMW\DIWikiPage;
 use SMW\Query\Language\Conjunction;
 use SMW\Query\Language\Disjunction;
 use SMW\Query\Parser\DescriptionProcessor;
@@ -44,23 +45,23 @@ class DescriptionProcessorTest extends \PHPUnit_Framework_TestCase {
 		);
 	}
 
-	public function testGetDescriptionForPropertyObjectValue() {
+	public function testconstructDescriptionForPropertyObjectValue() {
 
 		$instance = new DescriptionProcessor();
 
 		$this->assertInstanceOf(
 			'SMW\Query\Language\Description',
-			$instance->getDescriptionForPropertyObjectValue( new DIProperty( 'Foo' ), 'bar' )
+			$instance->constructDescriptionForPropertyObjectValue( new DIProperty( 'Foo' ), 'bar' )
 		);
 	}
 
-	public function testGetDescriptionForWikiPageValueChunk() {
+	public function testconstructDescriptionForWikiPageValueChunk() {
 
 		$instance = new DescriptionProcessor();
 
 		$this->assertInstanceOf(
 			'SMW\Query\Language\ValueDescription',
-			$instance->getDescriptionForWikiPageValueChunk( 'bar' )
+			$instance->constructDescriptionForWikiPageValueChunk( 'bar' )
 		);
 	}
 
@@ -68,16 +69,16 @@ class DescriptionProcessorTest extends \PHPUnit_Framework_TestCase {
 
 		$instance = new DescriptionProcessor();
 
-		$currentDescription = $instance->getDescriptionForWikiPageValueChunk( 'bar' );
+		$currentDescription = $instance->constructDescriptionForWikiPageValueChunk( 'bar' );
 
-		$newDescription = $instance->getDescriptionForPropertyObjectValue(
+		$newDescription = $instance->constructDescriptionForPropertyObjectValue(
 			new DIProperty( 'Foo' ),
 			'foobar'
 		);
 
 		$this->assertInstanceOf(
 			'SMW\Query\Language\Disjunction',
-			$instance->getDisjunctiveCompoundDescriptionFrom( $currentDescription, $newDescription )
+			$instance->constructDisjunctiveCompoundDescriptionFrom( $currentDescription, $newDescription )
 		);
 	}
 
@@ -87,14 +88,14 @@ class DescriptionProcessorTest extends \PHPUnit_Framework_TestCase {
 
 		$currentDescription = new Conjunction();
 
-		$newDescription = $instance->getDescriptionForPropertyObjectValue(
+		$newDescription = $instance->constructDescriptionForPropertyObjectValue(
 			new DIProperty( 'Foo' ),
 			'foobar'
 		);
 
 		$this->assertInstanceOf(
 			'SMW\Query\Language\Disjunction',
-			$instance->getDisjunctiveCompoundDescriptionFrom( $currentDescription, $newDescription )
+			$instance->constructDisjunctiveCompoundDescriptionFrom( $currentDescription, $newDescription )
 		);
 	}
 
@@ -104,14 +105,14 @@ class DescriptionProcessorTest extends \PHPUnit_Framework_TestCase {
 
 		$currentDescription = new Disjunction();
 
-		$newDescription = $instance->getDescriptionForPropertyObjectValue(
+		$newDescription = $instance->constructDescriptionForPropertyObjectValue(
 			new DIProperty( 'Foo' ),
 			'foobar'
 		);
 
 		$this->assertInstanceOf(
 			'SMW\Query\Language\Disjunction',
-			$instance->getDisjunctiveCompoundDescriptionFrom( $currentDescription, $newDescription )
+			$instance->constructDisjunctiveCompoundDescriptionFrom( $currentDescription, $newDescription )
 		);
 	}
 
@@ -119,11 +120,11 @@ class DescriptionProcessorTest extends \PHPUnit_Framework_TestCase {
 
 		$instance = new DescriptionProcessor();
 
-		$currentDescription = $instance->getDescriptionForWikiPageValueChunk( 'bar' );
+		$currentDescription = $instance->constructDescriptionForWikiPageValueChunk( 'bar' );
 
 		$this->assertInstanceOf(
 			'SMW\Query\Language\ValueDescription',
-			$instance->getDisjunctiveCompoundDescriptionFrom( $currentDescription, null )
+			$instance->constructDisjunctiveCompoundDescriptionFrom( $currentDescription, null )
 		);
 	}
 
@@ -131,11 +132,11 @@ class DescriptionProcessorTest extends \PHPUnit_Framework_TestCase {
 
 		$instance = new DescriptionProcessor();
 
-		$newDescription = $instance->getDescriptionForWikiPageValueChunk( 'bar' );
+		$newDescription = $instance->constructDescriptionForWikiPageValueChunk( 'bar' );
 
 		$this->assertInstanceOf(
 			'SMW\Query\Language\ValueDescription',
-			$instance->getDisjunctiveCompoundDescriptionFrom( null, $newDescription )
+			$instance->constructDisjunctiveCompoundDescriptionFrom( null, $newDescription )
 		);
 	}
 
@@ -143,16 +144,16 @@ class DescriptionProcessorTest extends \PHPUnit_Framework_TestCase {
 
 		$instance = new DescriptionProcessor();
 
-		$currentDescription = $instance->getDescriptionForWikiPageValueChunk( 'bar' );
+		$currentDescription = $instance->constructDescriptionForWikiPageValueChunk( 'bar' );
 
-		$newDescription = $instance->getDescriptionForPropertyObjectValue(
+		$newDescription = $instance->constructDescriptionForPropertyObjectValue(
 			new DIProperty( 'Foo' ),
 			'foobar'
 		);
 
 		$this->assertInstanceOf(
 			'SMW\Query\Language\Conjunction',
-			$instance->getConjunctiveCompoundDescriptionFrom( $currentDescription, $newDescription )
+			$instance->constructConjunctiveCompoundDescriptionFrom( $currentDescription, $newDescription )
 		);
 	}
 
@@ -162,14 +163,14 @@ class DescriptionProcessorTest extends \PHPUnit_Framework_TestCase {
 
 		$currentDescription = new Conjunction();
 
-		$newDescription = $instance->getDescriptionForPropertyObjectValue(
+		$newDescription = $instance->constructDescriptionForPropertyObjectValue(
 			new DIProperty( 'Foo' ),
 			'foobar'
 		);
 
 		$this->assertInstanceOf(
 			'SMW\Query\Language\Conjunction',
-			$instance->getConjunctiveCompoundDescriptionFrom( $currentDescription, $newDescription )
+			$instance->constructConjunctiveCompoundDescriptionFrom( $currentDescription, $newDescription )
 		);
 	}
 
@@ -179,14 +180,14 @@ class DescriptionProcessorTest extends \PHPUnit_Framework_TestCase {
 
 		$currentDescription = new Disjunction();
 
-		$newDescription = $instance->getDescriptionForPropertyObjectValue(
+		$newDescription = $instance->constructDescriptionForPropertyObjectValue(
 			new DIProperty( 'Foo' ),
 			'foobar'
 		);
 
 		$this->assertInstanceOf(
 			'SMW\Query\Language\Conjunction',
-			$instance->getConjunctiveCompoundDescriptionFrom( $currentDescription, $newDescription )
+			$instance->constructConjunctiveCompoundDescriptionFrom( $currentDescription, $newDescription )
 		);
 	}
 
@@ -194,11 +195,11 @@ class DescriptionProcessorTest extends \PHPUnit_Framework_TestCase {
 
 		$instance = new DescriptionProcessor();
 
-		$currentDescription = $instance->getDescriptionForWikiPageValueChunk( 'bar' );
+		$currentDescription = $instance->constructDescriptionForWikiPageValueChunk( 'bar' );
 
 		$this->assertInstanceOf(
 			'SMW\Query\Language\ValueDescription',
-			$instance->getConjunctiveCompoundDescriptionFrom( $currentDescription, null )
+			$instance->constructConjunctiveCompoundDescriptionFrom( $currentDescription, null )
 		);
 	}
 
@@ -206,11 +207,32 @@ class DescriptionProcessorTest extends \PHPUnit_Framework_TestCase {
 
 		$instance = new DescriptionProcessor();
 
-		$newDescription = $instance->getDescriptionForWikiPageValueChunk( 'bar' );
+		$newDescription = $instance->constructDescriptionForWikiPageValueChunk( 'bar' );
 
 		$this->assertInstanceOf(
 			'SMW\Query\Language\ValueDescription',
-			$instance->getConjunctiveCompoundDescriptionFrom( null, $newDescription )
+			$instance->constructConjunctiveCompoundDescriptionFrom( null, $newDescription )
+		);
+	}
+
+	public function testConstuctDescriptionWithContextPage() {
+
+		$instance = new DescriptionProcessor();
+
+		$instance->setContextPage(
+			DIWikiPage::newFromText( __METHOD__ )
+		);
+
+		$currentDescription = new Disjunction();
+
+		$newDescription = $instance->constructDescriptionForPropertyObjectValue(
+			new DIProperty( 'Foo' ),
+			'foobar'
+		);
+
+		$this->assertInstanceOf(
+			'SMW\Query\Language\Conjunction',
+			$instance->constructConjunctiveCompoundDescriptionFrom( $currentDescription, $newDescription )
 		);
 	}
 

--- a/tests/phpunit/Unit/Query/ProfileAnnotator/QueryProfileAnnotatorFactoryTest.php
+++ b/tests/phpunit/Unit/Query/ProfileAnnotator/QueryProfileAnnotatorFactoryTest.php
@@ -35,8 +35,34 @@ class QueryProfileAnnotatorFactoryTest extends \PHPUnit_Framework_TestCase {
 			->getMock();
 
 		$query->expects( $this->atLeastOnce() )
-			->method( 'getSubject' )
+			->method( 'getContextPage' )
 			->will( $this->returnValue( DIWikiPage::newFromText( __METHOD__ ) ) );
+
+		$query->expects( $this->once() )
+			->method( 'getDescription' )
+			->will( $this->returnValue( $description ) );
+
+		$instance = new QueryProfileAnnotatorFactory();
+
+		$this->assertInstanceOf(
+			'\SMW\Query\ProfileAnnotator\ProfileAnnotator',
+			$instance->newJointProfileAnnotator( $query, '' )
+		);
+	}
+
+	public function testConstructJointProfileAnnotatorOnNullContextPage() {
+
+		$description = $this->getMockBuilder( '\SMW\Query\Language\Description' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$query = $this->getMockBuilder( '\SMWQuery' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$query->expects( $this->atLeastOnce() )
+			->method( 'getContextPage' )
+			->will( $this->returnValue( null ) );
 
 		$query->expects( $this->once() )
 			->method( 'getDescription' )

--- a/tests/phpunit/Unit/SQLStore/QueryDependency/QueryResultDependencyListResolverTest.php
+++ b/tests/phpunit/Unit/SQLStore/QueryDependency/QueryResultDependencyListResolverTest.php
@@ -94,7 +94,7 @@ class QueryResultDependencyListResolverTest extends \PHPUnit_Framework_TestCase 
 			->getMock();
 
 		$query = new Query( $description );
-		$query->setSubject( $subject );
+		$query->setContextPage( $subject );
 
 		$query->setUnboundLimit( 0 );
 
@@ -134,7 +134,7 @@ class QueryResultDependencyListResolverTest extends \PHPUnit_Framework_TestCase 
 		);
 
 		$query = new Query( $description );
-		$query->setSubject( $subject );
+		$query->setContextPage( $subject );
 
 		$queryResult = $this->getMockBuilder( '\SMWQueryResult' )
 			->disableOriginalConstructor()
@@ -237,7 +237,7 @@ class QueryResultDependencyListResolverTest extends \PHPUnit_Framework_TestCase 
 		);
 
 		$query = new Query( $description );
-		$query->setSubject( $subject );
+		$query->setContextPage( $subject );
 
 		$queryResult = $this->getMockBuilder( '\SMWQueryResult' )
 			->disableOriginalConstructor()
@@ -301,7 +301,7 @@ class QueryResultDependencyListResolverTest extends \PHPUnit_Framework_TestCase 
 		);
 
 		$query = new Query( $description );
-		$query->setSubject( $subject );
+		$query->setContextPage( $subject );
 
 		$queryResult = $this->getMockBuilder( '\SMWQueryResult' )
 			->disableOriginalConstructor()
@@ -366,7 +366,7 @@ class QueryResultDependencyListResolverTest extends \PHPUnit_Framework_TestCase 
 		);
 
 		$query = new Query( $description );
-		$query->setSubject( $subject );
+		$query->setContextPage( $subject );
 
 		$provider[] = array(
 			$query,
@@ -384,7 +384,7 @@ class QueryResultDependencyListResolverTest extends \PHPUnit_Framework_TestCase 
 		);
 
 		$query = new Query( $description );
-		$query->setSubject( $subject );
+		$query->setContextPage( $subject );
 
 		$provider[] = array(
 			$query,
@@ -401,7 +401,7 @@ class QueryResultDependencyListResolverTest extends \PHPUnit_Framework_TestCase 
 		);
 
 		$query = new Query( $description );
-		$query->setSubject( $subject );
+		$query->setContextPage( $subject );
 
 		$provider[] = array(
 			$query,
@@ -423,7 +423,7 @@ class QueryResultDependencyListResolverTest extends \PHPUnit_Framework_TestCase 
 			new NamespaceDescription( NS_MAIN )
 		) ) );
 
-		$query->setSubject( $subject );
+		$query->setContextPage( $subject );
 
 		$provider[] = array(
 			$query,
@@ -445,7 +445,7 @@ class QueryResultDependencyListResolverTest extends \PHPUnit_Framework_TestCase 
 			new NamespaceDescription( NS_MAIN )
 		) ) );
 
-		$query->setSubject( $subject );
+		$query->setContextPage( $subject );
 
 		$provider[] = array(
 			$query,
@@ -462,7 +462,7 @@ class QueryResultDependencyListResolverTest extends \PHPUnit_Framework_TestCase 
 		);
 
 		$query = new Query( $description );
-		$query->setSubject( $subject );
+		$query->setContextPage( $subject );
 
 		$provider[] = array(
 			$query,
@@ -478,7 +478,7 @@ class QueryResultDependencyListResolverTest extends \PHPUnit_Framework_TestCase 
 		);
 
 		$query = new Query( $description );
-		$query->setSubject( $subject );
+		$query->setContextPage( $subject );
 
 		$provider[] = array(
 			$query,
@@ -501,7 +501,7 @@ class QueryResultDependencyListResolverTest extends \PHPUnit_Framework_TestCase 
 		);
 
 		$query = new Query( $description );
-		$query->setSubject( $subject );
+		$query->setContextPage( $subject );
 
 		$provider[] = array(
 			$query,
@@ -527,7 +527,7 @@ class QueryResultDependencyListResolverTest extends \PHPUnit_Framework_TestCase 
 		);
 
 		$query = new Query( $description );
-		$query->setSubject( $subject );
+		$query->setContextPage( $subject );
 
 		$provider[] = array(
 			$query,


### PR DESCRIPTION
Ensures that when generating a query condition, the `DataValueFactory` has access to the context page.

![image](https://cloud.githubusercontent.com/assets/1245473/15275579/daa2cdf6-1acf-11e6-81a3-e443a399fe57.png)

https://www.semantic-mediawiki.org/wiki/Localization
