### PR TITLE
SearchByProperty avoid strict encoding on numbers

### DIFF
--- a/src/MediaWiki/Specials/SearchByProperty/PageRequestOptions.php
+++ b/src/MediaWiki/Specials/SearchByProperty/PageRequestOptions.php
@@ -94,7 +94,11 @@ class PageRequestOptions {
 			str_replace( array( '_' ), array( ' ' ), $property )
 		);
 
-		$value = str_replace( array( '-25', '_' ), array( '%', ' ' ), $value );
+		$value = str_replace(
+			array( '-25', '_', '-2D', '-20' ),
+			array( '%', ' ', '-', ' ' ),
+			$value
+		);
 
 		$this->property = PropertyValue::makeUserProperty( $property );
 
@@ -104,21 +108,31 @@ class PageRequestOptions {
 			$this->valueString = $value;
 		} else {
 			$this->propertyString = $this->property->getWikiValue();
-
-			$this->value = DataValueFactory::getInstance()->newPropertyObjectValue(
-				$this->property->getDataItem(),
-				$this->urlEncoder->decode( $value )
-			);
-
-			// Signals that we don't want any precision limitation
-			$this->value->setOption( 'value.description', true );
-
-			$this->valueString = $this->value->isValid() ? $this->value->getWikiValue() : $value;
+			$this->setValue( $value );
 		}
 
 		$this->setLimit();
 		$this->setOffset();
 		$this->setNearbySearch();
+	}
+
+	private function setValue( $value ) {
+
+		$this->value = DataValueFactory::getInstance()->newPropertyObjectValue(
+			$this->property->getDataItem()
+		);
+
+		if ( $this->value instanceof \SMWNumberValue ) {
+			// Do not try to decode things like 1.2e-13
+			// Signals that we don't want any precision limitation
+			$this->value->setOption( 'no.displayprecision', true );
+		} else {
+			$value = $this->urlEncoder->decode( $value );
+		}
+
+		$this->value->setUserValue( $value );
+
+		$this->valueString = $this->value->isValid() ? $this->value->getWikiValue() : $value;
 	}
 
 	private function setLimit() {

--- a/tests/phpunit/Integration/ByJsonScript/Fixtures/s-0002.json
+++ b/tests/phpunit/Integration/ByJsonScript/Fixtures/s-0002.json
@@ -22,6 +22,10 @@
 		{
 			"name": "Example/S0002/3",
 			"contents": "[[Has number::3.555567]]"
+		},
+		{
+			"name": "Example/S0002/4",
+			"contents": "[[Has number::1.2e-13]]"
 		}
 	],
 	"special-testcases": [
@@ -92,6 +96,40 @@
 				],
 				"not-contain": [
 					"value=3.56"
+				]
+			}
+		},
+		{
+			"about": "#4 do not encode e- for a number value",
+			"special-page": {
+				"page":"SearchByProperty",
+				"query-parameters": "",
+				"request-parameters":{
+					"property": "Has number",
+					"value": "1.2e-13"
+				}
+			},
+			"expected-output": {
+				"to-contain": [
+					"Example-2FS0002-2F4",
+					"<small>(1.2e-13)</small>"
+				]
+			}
+		},
+		{
+			"about": "#5 same as 1.2e-13",
+			"special-page": {
+				"page":"SearchByProperty",
+				"query-parameters": "",
+				"request-parameters":{
+					"property": "Has number",
+					"value": "0.00000000000012"
+				}
+			},
+			"expected-output": {
+				"to-contain": [
+					"Example-2FS0002-2F4",
+					"<small>(1.2e-13)</small>"
 				]
 			}
 		}

--- a/tests/phpunit/Unit/MediaWiki/Specials/SearchByProperty/PageRequestOptionsTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Specials/SearchByProperty/PageRequestOptionsTest.php
@@ -165,23 +165,25 @@ class PageRequestOptionsTest extends \PHPUnit_Framework_TestCase {
 			)
 		);
 
-		#8
+		#9
 		$provider[] = array(
 			'',
 			array(
-				'property' => '',
-				'value'    => 'Foo_bar',
+				'property' => 'Number',
+				'value'    => '2',
 				'nearbySearchForType' => array( '_wpg' )
 			),
 			array(
 				'limit'  => 20,
 				'offset' => 0,
 				'nearbySearch' => false,
-				'propertyString' => '',
-				'valueString'    => 'Foo bar',
+				'propertyString' => 'Number',
+				'valueString'    => '2.0',
 			)
 		);
 
+
+//
 		return $provider;
 	}
 

--- a/tests/phpunit/Unit/MediaWiki/Specials/SpecialSearchByPropertyTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Specials/SpecialSearchByPropertyTest.php
@@ -121,7 +121,7 @@ class SpecialSearchByPropertyTest extends \PHPUnit_Framework_TestCase {
 		#2
 		$provider[] = array(
 			'Has-20foo/http:-2F-2Fexample.org-2Fid-2FCurly-2520Brackets-257B-257D',
-			array( 'property=Has+foo', 'value=http%3A-2F-2Fexample.org-2Fid-2FCurly%2520Brackets%257B%257D' )
+			array( 'property=Has+foo', 'value=http%3A%2F%2Fexample.org%2Fid%2FCurly+Brackets%7B%7D' )
 		);
 
 		return $provider;


### PR DESCRIPTION
This avoids that values like `1.2e-13` are being split before the `NumberValue` parser has a chance to validate the input.