### PR TITLE
SearchByProperty to search for tel number, refs #1594

### DIFF
--- a/src/DataTypeRegistry.php
+++ b/src/DataTypeRegistry.php
@@ -415,7 +415,7 @@ class DataTypeRegistry {
 			'_ema'  => 'SMWURIValue', // Email type
 			'_uri'  => 'SMWURIValue', // URL/URI type
 			'_anu'  => 'SMWURIValue', // Annotation URI type
-			'_tel'  => 'SMWURIValue', // Phone number (URI) type
+			'_tel'  => 'SMW\DataValues\TelephoneUriValue', // Phone number (URI) type
 			'_wpg'  => 'SMWWikiPageValue', // Page type
 			'_wpp'  => 'SMWWikiPageValue', // Property page type TODO: make available to user space
 			'_wpc'  => 'SMWWikiPageValue', // Category page type TODO: make available to user space

--- a/src/DataValues/TelephoneUriValue.php
+++ b/src/DataValues/TelephoneUriValue.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace SMW\DataValues;
+
+use SMWURIValue as UriValue;
+
+/**
+ * @license GNU GPL v2+
+ * @since 2.4
+ *
+ * @author mwjames
+ */
+class TelephoneUriValue extends UriValue {
+
+	/**
+	 * @since 2.4
+	 *
+	 * @param string $typeid
+	 */
+	public function __construct( $typeid = '' ) {
+		parent::__construct( '_tel' );
+	}
+
+}

--- a/src/MediaWiki/Specials/SearchByProperty/PageRequestOptions.php
+++ b/src/MediaWiki/Specials/SearchByProperty/PageRequestOptions.php
@@ -5,6 +5,8 @@ namespace SMW\MediaWiki\Specials\SearchByProperty;
 use SMW\DataValueFactory;
 use SMW\UrlEncoder;
 use SMWPropertyValue as PropertyValue;
+use SMW\DataValues\TelephoneUriValue;
+use SMWNumberValue as NumberValue;
 
 /**
  * @license GNU GPL v2+
@@ -95,8 +97,8 @@ class PageRequestOptions {
 		);
 
 		$value = str_replace(
-			array( '-25', '_', '-2D', '-20' ),
-			array( '%', ' ', '-', ' ' ),
+			array( '-25', '_', '-2D' ),
+			array( '%', ' ', '-' ),
 			$value
 		);
 
@@ -122,10 +124,14 @@ class PageRequestOptions {
 			$this->property->getDataItem()
 		);
 
-		if ( $this->value instanceof \SMWNumberValue ) {
+		if ( $this->value instanceof NumberValue ) {
+			$value = str_replace( array(  '-20' ), array( ' ' ), $value);
 			// Do not try to decode things like 1.2e-13
 			// Signals that we don't want any precision limitation
 			$this->value->setOption( 'no.displayprecision', true );
+		} elseif ( $this->value instanceof TelephoneUriValue ) {
+			// No encoding to avoid turning +1-201-555-0123
+			// into +1 1U523 or further obfuscate %2B1-2D201-2D555-2D0123 ...
 		} else {
 			$value = $this->urlEncoder->decode( $value );
 		}

--- a/tests/phpunit/Integration/ByJsonScript/Fixtures/s-0002.json
+++ b/tests/phpunit/Integration/ByJsonScript/Fixtures/s-0002.json
@@ -1,5 +1,5 @@
 {
-	"description": "Test output of `Special:SearchByProperty` (`wgContLang=en`, skip-on sqlite, 1.19)",
+	"description": "Test output from `Special:SearchByProperty` for `_num`, `_txt`, `_tel` (`wgContLang=en`, skip-on sqlite, 1.19)",
 	"properties": [
 		{
 			"name": "Has text",
@@ -8,6 +8,10 @@
 		{
 			"name": "Has number",
 			"contents": "[[Has type::Number]] [[Display precision of::2]]"
+		},
+		{
+			"name": "Has telephone number",
+			"contents": "[[Has type::Telephone number]]"
 		}
 	],
 	"subjects": [
@@ -26,6 +30,10 @@
 		{
 			"name": "Example/S0002/4",
 			"contents": "[[Has number::1.2e-13]]"
+		},
+		{
+			"name": "Example/S0002/5",
+			"contents": "[[Has telephone number::+1-201-555-0123]]"
 		}
 	],
 	"special-testcases": [
@@ -130,6 +138,40 @@
 				"to-contain": [
 					"Example-2FS0002-2F4",
 					"<small>(1.2e-13)</small>"
+				]
+			}
+		},
+		{
+			"about": "#6 telephone number",
+			"special-page": {
+				"page":"SearchByProperty",
+				"query-parameters": "",
+				"request-parameters":{
+					"property": "Has telephone number",
+					"value": "+1-201-555-0123"
+				}
+			},
+			"expected-output": {
+				"to-contain": [
+					"Example-2FS0002-2F5",
+					"+1-201-555-0123"
+				]
+			}
+		},
+		{
+			"about": "#6 telephone number",
+			"special-page": {
+				"page":"SearchByProperty",
+				"query-parameters": "",
+				"request-parameters":{
+					"property": "Has telephone number",
+					"value": "+1-201-555-0123"
+				}
+			},
+			"expected-output": {
+				"to-contain": [
+					"Example-2FS0002-2F5",
+					"+1-201-555-0123"
 				]
 			}
 		}

--- a/tests/phpunit/Unit/DataValues/TelephoneUriValueTest.php
+++ b/tests/phpunit/Unit/DataValues/TelephoneUriValueTest.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace SMW\Tests\DataValues;
+
+use SMW\DataValues\TelephoneUriValue;
+
+/**
+ * @covers \SMW\DataValues\TelephoneUriValue
+ * @group semantic-mediawiki
+ *
+ * @license GNU GPL v2+
+ * @since 2.4
+ *
+ * @author mwjames
+ */
+class TelephoneUriValueTest extends \PHPUnit_Framework_TestCase {
+
+	public function testCanConstruct() {
+
+		$this->assertInstanceOf(
+			'\SMW\DataValues\TelephoneUriValue',
+			new TelephoneUriValue()
+		);
+
+		$this->assertInstanceOf(
+			'\SMWURIValue',
+			new TelephoneUriValue()
+		);
+	}
+}

--- a/tests/phpunit/Unit/MediaWiki/Specials/SearchByProperty/PageRequestOptionsTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Specials/SearchByProperty/PageRequestOptionsTest.php
@@ -182,8 +182,40 @@ class PageRequestOptionsTest extends \PHPUnit_Framework_TestCase {
 			)
 		);
 
+		#10
+		$provider[] = array(
+			'',
+			array(
+				'property' => 'Temperature',
+				'value'    => '373,15-20K',
+				'nearbySearchForType' => array( '_wpg' )
+			),
+			array(
+				'limit'  => 20,
+				'offset' => 0,
+				'nearbySearch' => false,
+				'propertyString' => 'Temperature',
+				'valueString'    => '373,15 K',
+			)
+		);
 
-//
+		#11
+		$provider[] = array(
+			'',
+			array(
+				'property' => 'Telephone number',
+				'value'    => '%2B1-2D201-2D555-2D0123',
+				'nearbySearchForType' => array( '_tel' )
+			),
+			array(
+				'limit'  => 20,
+				'offset' => 0,
+				'nearbySearch' => true,
+				'propertyString' => 'Telephone number',
+				'valueString'    => '%2B1-201-555-0123',
+			)
+		);
+
 		return $provider;
 	}
 


### PR DESCRIPTION
Avoid special encoding on a `_tel` value to prevent input like `+1-201-555-0123` to turn into `+1 1U523`.

refs #1594