### PR TITLE
Add InfoLinksProvider

### DIFF
--- a/includes/datavalues/SMW_DV_String.php
+++ b/includes/datavalues/SMW_DV_String.php
@@ -1,16 +1,21 @@
 <?php
 
 use SMW\DataValues\ValueFormatters\DataValueFormatter;
+use SMWDIBlob as DIBlob;
+use SMWDataItem as DataItem;
+use SMWDataValue as DataValue;
 
 /**
  * This datavalue implements String-Datavalues suitable for defining
  * String-types of properties.
  *
+ * @license GNU GPL v2+
+ * @since 1.6
+ *
  * @author Nikolas Iwan
  * @author Markus Krötzsch
- * @ingroup SMWDataValues
  */
-class SMWStringValue extends SMWDataValue {
+class SMWStringValue extends DataValue {
 
 	/**
 	 * @see DataValue::parseUserValue
@@ -23,43 +28,70 @@ class SMWStringValue extends SMWDataValue {
 			$this->addErrorMsg( 'smw_emptystring' );
 		}
 
-		$this->m_dataitem = new SMWDIBlob( $value );
+		$this->m_dataitem = new DIBlob( $value );
 	}
 
 	/**
-	 * @see SMWDataValue::loadDataItem()
-	 * @param $dataitem SMWDataItem
+	 * @see DataValue::loadDataItem
+	 *
+	 * @param SMWDataItem $dataitem
+	 *
 	 * @return boolean
 	 */
-	protected function loadDataItem( SMWDataItem $dataItem ) {
-		if ( $dataItem instanceof SMWDIBlob ) {
-			$this->m_caption = false;
-			$this->m_dataitem = $dataItem;
-			return true;
-		} else {
+	protected function loadDataItem( DataItem $dataItem ) {
+
+		if ( !$dataItem instanceof DIBlob ) {
 			return false;
 		}
+
+		$this->m_caption = false;
+		$this->m_dataitem = $dataItem;
+
+		return true;
 	}
 
+	/**
+	 * @see DataValue::getShortWikiText
+	 *
+	 * @return string
+	 */
 	public function getShortWikiText( $linker = null ) {
 		return $this->getDataValueFormatter()->format( DataValueFormatter::WIKI_SHORT, $linker );
 	}
 
+	/**
+	 * @see DataValue::getShortHTMLText
+	 *
+	 * @return string
+	 */
 	public function getShortHTMLText( $linker = null ) {
 		return $this->getDataValueFormatter()->format( DataValueFormatter::HTML_SHORT, $linker );
 	}
 
+	/**
+	 * @see DataValue::getLongWikiText
+	 *
+	 * @return string
+	 */
 	public function getLongWikiText( $linker = null ) {
 		return $this->getDataValueFormatter()->format( DataValueFormatter::WIKI_LONG, $linker );
 	}
 
 	/**
 	 * @todo Rather parse input to obtain properly formatted HTML.
+	 * @see DataValue::getLongHTMLText
+	 *
+	 * @return string
 	 */
 	public function getLongHTMLText( $linker = null ) {
 		return $this->getDataValueFormatter()->format( DataValueFormatter::HTML_LONG, $linker );
 	}
 
+	/**
+	 * @see DataValue::getWikiValue
+	 *
+	 * @return string
+	 */
 	public function getWikiValue() {
 		return $this->getDataValueFormatter()->format( DataValueFormatter::VALUE );
 	}
@@ -74,22 +106,24 @@ class SMWStringValue extends SMWDataValue {
 	}
 
 	public function getInfolinks() {
+
 		if ( $this->m_typeid != '_cod' ) {
 			return parent::getInfolinks();
-		} else {
-			return $this->m_infolinks;
 		}
+
+		return array();
 	}
 
 	protected function getServiceLinkParams() {
+
+		if ( !$this->isValid() ) {
+			return false;
+		}
+
 		// Create links to mapping services based on a wiki-editable message. The parameters
 		// available to the message are:
 		// $1: urlencoded string
-		if ( $this->isValid() ) {
-			return array( rawurlencode( $this->m_dataitem->getString() ) );
-		} else {
-			return false;
-		}
+		return array( rawurlencode( $this->m_dataitem->getString() ) );
 	}
 
 }

--- a/src/DataValues/InfoLinksProvider.php
+++ b/src/DataValues/InfoLinksProvider.php
@@ -1,0 +1,243 @@
+<?php
+
+namespace SMW\DataValues;
+
+use SMWInfolink as Infolink;
+use SMWDataValue  as DataValue;
+use SMW\ApplicationFactory;
+use SMW\InTextAnnotationParser;
+use SMW\DIProperty;
+use SMW\Message;
+use SMWStringValue as StringValue;
+use SMWDIBlob as DIBlob;
+
+/**
+ * @license GNU GPL v2+
+ * @since 2.4
+ *
+ * @author mwjames
+ */
+class InfoLinksProvider {
+
+	/**
+	 * @var DataValue
+	 */
+	private $dataValue;
+
+	/**
+	 * @var Infolink[]
+	 */
+	protected $infoLinks = array();
+
+	/**
+	 * Used to control the addition of the standard search link.
+	 * @var boolean
+	 */
+	private $hasSearchLink;
+
+	/**
+	 * Used to control service link creation.
+	 * @var boolean
+	 */
+	private $hasServiceLinks;
+
+	/**
+	 * @var boolean
+	 */
+	private $enabledServiceLinks = true;
+
+	/**
+	 * @var boolean|array
+	 */
+	private $serviceLinkParameters = false;
+
+	/**
+	 * @since 2.4
+	 *
+	 * @param DataValue $dataValue
+	 */
+	public function __construct( DataValue $dataValue ) {
+		$this->dataValue = $dataValue;
+	}
+
+	/**
+	 * @since 2.4
+	 */
+	public function init() {
+		$this->infoLinks = array();
+		$this->hasSearchLink = false;
+		$this->hasServiceLinks = false;
+		$this->enabledServiceLinks = true;
+		$this->serviceLinkParameters = false;
+	}
+
+	/**
+	 * @since 2.4
+	 */
+	public function disableServiceLinks() {
+		$this->enabledServiceLinks = false;
+	}
+
+	/**
+	 * Adds a single SMWInfolink object to the infoLinks array.
+	 *
+	 * @since 2.4
+	 *
+	 * @param Infolink $link
+	 */
+	public function addInfolink( Infolink $infoLink ) {
+		$this->infoLinks[] = $infoLink;
+	}
+
+	/**
+	 * @since 2.4
+	 *
+	 * @param array|false $serviceLinkParameters
+	 */
+	public function setServiceLinkParameters( $serviceLinkParameters ) {
+		$this->serviceLinkParameters = $serviceLinkParameters;
+	}
+
+	/**
+	 * Return an array of SMWLink objects that provide additional resources
+	 * for the given value. Captions can contain some HTML markup which is
+	 * admissible for wiki text, but no more. Result might have no entries
+	 * but is always an array.
+	 *
+	 * @since 2.4
+	 */
+	public function createInfoLinks() {
+
+		if ( $this->infoLinks !== array() ) {
+			return $this->infoLinks;
+		}
+
+		if ( !$this->dataValue->isValid() || $this->dataValue->getProperty() === null ) {
+			return array();
+		}
+
+		$value = $this->dataValue->getWikiValue();
+
+		// InTextAnnotationParser will detect :: therefore avoid link
+		// breakage by encoding the string
+		if ( strpos( $value, '::' ) !== false && !$this->hasInternalAnnotationMarker( $value ) ) {
+			$value = str_replace( ':', '-3A', $value );
+		}
+
+		$this->hasSearchLink = true;
+		$this->infoLinks[] = Infolink::newPropertySearchLink(
+			'+',
+			$this->dataValue->getProperty()->getLabel(),
+			$value
+		);
+
+		 // add further service links
+		if ( !$this->hasServiceLinks && $this->enabledServiceLinks ) {
+			$this->addServiceLinks();
+		}
+
+		return $this->infoLinks;
+	}
+
+	/**
+	 * Return text serialisation of info links. Ensures more uniform layout
+	 * throughout wiki (Factbox, Property pages, ...).
+	 *
+	 * @param integer $outputformat Element of the SMW_OUTPUT_ enum
+	 * @param Linker|null $linker
+	 *
+	 * @return string
+	 */
+	public function getInfolinkText( $outputformat, $linker = null ) {
+
+		$result = '';
+		$first = true;
+		$extralinks = array();
+
+		foreach ( $this->dataValue->getInfolinks() as $link ) {
+
+			if ( $outputformat === SMW_OUTPUT_WIKI ) {
+				$text = $link->getWikiText();
+			} else {
+				$text = $link->getHTML( $linker );
+			}
+
+			// the comment is needed to prevent MediaWiki from linking
+			// URL-strings together with the nbsps!
+			if ( $first ) {
+				$result .= ( $outputformat === SMW_OUTPUT_WIKI ? '<!-- -->  ' : '&#160;&#160;' ) . $text;
+				$first = false;
+			} else {
+				$extralinks[] = $text;
+			}
+		}
+
+		if ( $extralinks !== array() ) {
+			$result .= smwfEncodeMessages( $extralinks, 'service', '', false );
+		}
+
+		// #1453 SMW::on/off will break any potential link therefore just don't even try
+		return !$this->hasInternalAnnotationMarker( $result ) ? $result : '';
+	}
+
+	/**
+	 * Servicelinks are special kinds of infolinks that are created from
+	 * current parameters and in-wiki specification of URL templates. This
+	 * method adds the current property's servicelinks found in the
+	 * messages. The number and content of the parameters is depending on
+	 * the datatype, and the service link message is usually crafted with a
+	 * particular datatype in mind.
+	 */
+	public function addServiceLinks() {
+
+		if ( $this->hasServiceLinks ) {
+			return;
+		}
+
+		if ( $this->dataValue->getProperty() !== null ) {
+			$propertyDiWikiPage = $this->dataValue->getProperty()->getDiWikiPage();
+		}
+
+		if ( $propertyDiWikiPage === null ) {
+			return; // no property known, or not associated with a page
+		}
+
+		$args = $this->serviceLinkParameters;
+
+		if ( $args === false ) {
+			return; // no services supported
+		}
+
+		array_unshift( $args, '' ); // add a 0 element as placeholder
+
+		$servicelinks = ApplicationFactory::getInstance()->getCachedPropertyValuesPrefetcher()->getPropertyValues(
+			$propertyDiWikiPage,
+			new DIProperty( '_SERV' )
+		);
+
+		foreach ( $servicelinks as $dataItem ) {
+			if ( !( $dataItem instanceof DIBlob ) ) {
+				continue;
+			}
+
+			$args[0] = 'smw_service_' . str_replace( ' ', '_', $dataItem->getString() ); // messages distinguish ' ' from '_'
+			$text = Message::get( $args, Message::TEXT, Message::CONTENT_LANGUAGE );
+			$links = preg_split( "/[\n][\s]?/u", $text );
+
+			foreach ( $links as $link ) {
+				$linkdat = explode( '|', $link, 2 );
+
+				if ( count( $linkdat ) == 2 ) {
+					$this->addInfolink( Infolink::newExternalLink( $linkdat[0], trim( $linkdat[1] ) ) );
+				}
+			}
+		}
+
+		$this->hasServiceLinks = true;
+	}
+
+	private function hasInternalAnnotationMarker( $value ) {
+		return strpos( $value, 'SMW::off' ) !== false || strpos( $value, 'SMW::on' ) !== false;
+	}
+
+}

--- a/src/Factbox/Factbox.php
+++ b/src/Factbox/Factbox.php
@@ -374,7 +374,7 @@ class Factbox {
 
 				$dataValue = $this->dataValueFactory->newDataItemValue( $dataItem, $propertyDi );
 				$dataValue->setOutputFormat( 'LOCL' );
-				$dataValue->setServiceLinksRenderState( false );
+				$dataValue->disableServiceLinks();
 
 				if ( $dataValue->isValid() ) {
 					$valuesHtml[] = Sanitizer::removeHTMLtags(
@@ -404,9 +404,17 @@ class Factbox {
 			return $dataValue->getInfolinkText( SMW_OUTPUT_WIKI );
 		}
 
+		$value = $dataValue->getWikiValue();
+
+		// InTextAnnotationParser will detect :: therefore avoid link
+		// breakage by encoding the string
+		if ( strpos( $value, '::' ) !== false ) {
+			$value = str_replace( ':', '-3A', $value );
+		}
+
 		$browselink = SMWInfolink::newBrowsingLink(
 			' +',
-			$dataValue->getWikiValue(),
+			$value,
 			'smwbrowse'
 		);
 

--- a/src/Message.php
+++ b/src/Message.php
@@ -133,7 +133,16 @@ class Message {
 		return $message;
 	}
 
-	private static function getHash( $parameters, $type = null, $language = null ) {
+	/**
+	 * @since 2.4
+	 *
+	 * @param array $parameters
+	 * @param integer $type
+	 * @param integer|string|Language $language
+	 *
+	 * @return string
+	 */
+	public static function getHash( $parameters, $type = null, $language = null ) {
 
 		if ( $language instanceof Language ) {
 			$language = $language->getCode();

--- a/src/UrlEncoder.php
+++ b/src/UrlEncoder.php
@@ -72,6 +72,8 @@ class UrlEncoder {
 		// Apply decoding for SMW's own url encoding strategy (see SMWInfolink)
 		$string = str_replace( '%', '-', rawurldecode( str_replace( '-', '%', $string ) ) );
 
+		$string = str_replace( array( '-2D', '-3A' ), array( '-', ':' ), $string );
+
 		// Sanitize remaining string content
 		$string = trim( htmlspecialchars( $string, ENT_NOQUOTES ) );
 		$string = str_replace( '&nbsp;', ' ', str_replace( array( '&#160;', '&amp;' ), array( ' ', '&' ), $string ) );

--- a/tests/phpunit/Integration/ByJsonScript/Fixtures/s-0008.json
+++ b/tests/phpunit/Integration/ByJsonScript/Fixtures/s-0008.json
@@ -1,5 +1,5 @@
 {
-	"description": "Test `Special:Browse` output for `_dat', `_boo` (`wgContLang=en`, `wgLang=es`)",
+	"description": "Test `Special:Browse` output for `_dat', `_boo`, `_sobj`, `_uri` (`wgContLang=en`, `wgLang=es`)",
 	"properties": [
 		{
 			"name": "Has date",
@@ -16,6 +16,10 @@
 		{
 			"name": "Has atomic mass unit",
 			"contents": "[[Has type::Quantity]] [[Corresponds to::1 u]] [[Corresponds to::1.660539040e-27 kg]]"
+		},
+		{
+			"name": "Has url",
+			"contents": "[[Has type::URL]]"
 		}
 	],
 	"subjects": [
@@ -30,6 +34,14 @@
 		{
 			"name": "Example/S0008/3 (Hydrogen-1 atom)",
 			"contents": "[[Has atomic mass unit::1.007825 u]] [[Category:S0008]]"
+		},
+		{
+			"name": "Example/S0008/4",
+			"contents": "{{#subobject:ABC::DEF|Has number=123}}"
+		},
+		{
+			"name": "Example/S0008/5",
+			"contents": "[[Has url::http://example.org/some1::23:334/::56]]"
 		}
 	],
 	"special-testcases": [
@@ -77,6 +89,34 @@
 				"to-contain": [
 					"<span class=\"smwb-value\">1,008&#160;u (1,673533e-27&#160;kg)&#160;&#160;",
 					"Special:SearchByProperty/Has-20atomic-20mass-20unit/1.007825-20u"
+				]
+			}
+		},
+		{
+			"about": "#3 named subobject contains :: (encoded with -3A)",
+			"special-page": {
+				"page":"Browse",
+				"query-parameters": "Example-2FS0008-2F4-23ABC-2D3A-2D3ADEF",
+				"request-parameters":{}
+			},
+			"expected-output": {
+				"to-contain": [
+					"<span class=\"smwb-value\">123&#160;&#160;",
+					"Special:SearchByProperty/Has-20number/123"
+				]
+			}
+		},
+		{
+			"about": "#4 url contains :: (encoded with -3A)",
+			"special-page": {
+				"page":"Browse",
+				"query-parameters": "Example/S0008/5",
+				"request-parameters":{}
+			},
+			"expected-output": {
+				"to-contain": [
+					"href=\"http://example.org/some1::23:334/::56\">http://example.org/some1::23:334/::56</a>&#160;&#160;",
+					"Special:SearchByProperty/Has-20url/http-2D3A-2F-2Fexample.org-2Fsome1-2D3A-2D3A23-2D3A334-2F-2D3A-2D3A56"
 				]
 			}
 		}

--- a/tests/phpunit/Unit/DataValues/InfoLinksProviderTest.php
+++ b/tests/phpunit/Unit/DataValues/InfoLinksProviderTest.php
@@ -1,0 +1,158 @@
+<?php
+
+namespace SMW\Tests\DataValues;
+
+use SMW\DataItemFactory;
+use SMW\DataValues\InfoLinksProvider;
+use SMW\Tests\TestEnvironment;
+use SMW\Message;
+use SMWNumberValue as NumberValue;
+use SMWStringValue as StringValue;
+
+/**
+ * @covers \SMW\DataValues\InfoLinksProvider
+ * @group semantic-mediawiki
+ *
+ * @license GNU GPL v2+
+ * @since 2.4
+ *
+ * @author mwjames
+ */
+class InfoLinksProviderTest extends \PHPUnit_Framework_TestCase {
+
+	private $testEnvironment;
+	private $dataItemFactory;
+	private $cachedPropertyValuesPrefetcher;
+
+	protected function setUp() {
+		$this->testEnvironment = new TestEnvironment();
+		$this->dataItemFactory = new DataItemFactory();
+
+		$this->cachedPropertyValuesPrefetcher = $this->getMockBuilder( '\SMW\CachedPropertyValuesPrefetcher' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$this->testEnvironment->registerObject( 'CachedPropertyValuesPrefetcher', $this->cachedPropertyValuesPrefetcher );
+	}
+
+	protected function tearDown() {
+		$this->testEnvironment->tearDown();
+	}
+
+	public function testCanConstruct() {
+
+		$dataValue = $this->getMockBuilder( '\SMWDataValue' )
+			->disableOriginalConstructor()
+			->getMockForAbstractClass();
+
+		$this->assertInstanceOf(
+			'\SMW\DataValues\InfoLinksProvider',
+			new InfoLinksProvider( $dataValue )
+		);
+	}
+
+	public function testGetInfolinkTextOnNumberValue() {
+
+		$this->cachedPropertyValuesPrefetcher->expects( $this->atLeastOnce() )
+			->method( 'getPropertyValues' )
+			->will( $this->returnValue( array() ) );
+
+		$numberValue = new NumberValue();
+
+		$numberValue->setOption( 'user.language', 'en' );
+		$numberValue->setOption( 'content.language', 'en' );
+
+		$numberValue->setProperty(
+			$this->dataItemFactory->newDIProperty( 'Foo' )
+		);
+
+		$numberValue->setUserValue( '1000.42' );
+
+		$instance = new InfoLinksProvider( $numberValue );
+
+		$this->assertContains(
+			'/Foo/1000.42|+]]</span>',
+			$instance->getInfolinkText( SMW_OUTPUT_WIKI )
+		);
+
+		$this->assertContains(
+			'/Foo/1000.42">+</a></span>',
+			$instance->getInfolinkText( SMW_OUTPUT_HTML )
+		);
+	}
+
+	public function testGetInfolinkTextOnStringValue() {
+
+		$this->cachedPropertyValuesPrefetcher->expects( $this->atLeastOnce() )
+			->method( 'getPropertyValues' )
+			->will( $this->returnValue( array() ) );
+
+		$stringValue = new StringValue( '_txt' );
+
+		$stringValue->setOption( 'user.language', 'en' );
+		$stringValue->setOption( 'content.language', 'en' );
+
+		$stringValue->setProperty(
+			$this->dataItemFactory->newDIProperty( 'Foo' )
+		);
+
+		$stringValue->setUserValue( 'Text with :: content' );
+
+		$instance = new InfoLinksProvider( $stringValue );
+
+		$this->assertContains(
+			'/Foo/Text-20with-20-2D3A-2D3A-20content|+]]</span>',
+			$instance->getInfolinkText( SMW_OUTPUT_WIKI )
+		);
+
+		$this->assertContains(
+			'/Foo/Text-20with-20-2D3A-2D3A-20content">+</a></span>',
+			$instance->getInfolinkText( SMW_OUTPUT_HTML )
+		);
+	}
+
+	public function testGetInfolinkTextOnStringValueWithServiceLinks() {
+
+		$service = 'testGetInfolinkTextOnStringValueWithServiceLinks';
+
+		$this->cachedPropertyValuesPrefetcher->expects( $this->atLeastOnce() )
+			->method( 'getPropertyValues' )
+			->will( $this->returnValue( array(
+				$this->dataItemFactory->newDIBlob( $service ) ) ) );
+
+		// Manipulating the Message cache is a hack!!
+		$parameters = array(
+			"smw_service_" . $service,
+			'Bar'
+		);
+
+		Message::getCache()->save(
+			Message::getHash( $parameters, Message::TEXT, Message::CONTENT_LANGUAGE ),
+			'SERVICELINK-A|SERVICELINK-B'
+		);
+
+		$stringValue = new StringValue( '_txt' );
+
+		$stringValue->setOption( 'user.language', 'en' );
+		$stringValue->setOption( 'content.language', 'en' );
+
+		$stringValue->setProperty(
+			$this->dataItemFactory->newDIProperty( 'Foo' )
+		);
+
+		$stringValue->setUserValue( 'Bar' );
+
+		$instance = new InfoLinksProvider( $stringValue );
+
+		$this->assertContains(
+			'<div class="smwttcontent">[SERVICELINK-B SERVICELINK-A]</div>',
+			$instance->getInfolinkText( SMW_OUTPUT_WIKI )
+		);
+
+		$this->assertContains(
+			'<div class="smwttcontent"><a href="SERVICELINK-B">SERVICELINK-A</a></div>',
+			$instance->getInfolinkText( SMW_OUTPUT_HTML )
+		);
+	}
+
+}


### PR DESCRIPTION
It moves code responsible for info/service links generation from `DataValue` into its own `InfoLinksProvider` class. It also tackles the issue for links containing a `::`.