### PR TITLE
QueryEngine to disable DB transactions

### DIFF
--- a/src/SQLStore/QueryEngine/QueryEngine.php
+++ b/src/SQLStore/QueryEngine/QueryEngine.php
@@ -157,6 +157,11 @@ class QueryEngine {
 
 		$db = $this->store->getConnection( 'mw.db.queryengine' );
 
+		// #1605
+		// "... creating temporary tables in a transaction is not replication-safe
+		// and causes errors in MySQL 5.6. ..."
+		$db->disableTransactions();
+
 		$this->queryMode = $query->querymode;
 		$this->querySegmentList = array();
 
@@ -204,6 +209,7 @@ class QueryEngine {
 				$query->querymode != Query::MODE_DEBUG &&
 				count( $this->errors ) > 0 ) {
 			$query->addErrors( $this->errors );
+			$db->enableTransactions();
 			return new QueryResult( $query->getDescription()->getPrintrequests(), $query, array(), $this->store, false );
 		}
 
@@ -230,6 +236,8 @@ class QueryEngine {
 
 		$this->querySegmentListProcessor->cleanUp();
 		$query->addErrors( $this->errors );
+
+		$db->enableTransactions();
 
 		return $result;
 	}

--- a/tests/phpunit/Unit/MediaWiki/DatabaseTest.php
+++ b/tests/phpunit/Unit/MediaWiki/DatabaseTest.php
@@ -364,6 +364,48 @@ class DatabaseTest extends \PHPUnit_Framework_TestCase {
 		$instance->commitTransaction( __METHOD__ );
 	}
 
+	public function testDisableEnableTransactions() {
+
+		$database = $this->getMockBuilder( '\DatabaseBase' )
+			->disableOriginalConstructor()
+			->setMethods( array( 'getFlag', 'clearFlag', 'setFlag' ) )
+			->getMockForAbstractClass();
+
+		$database->expects( $this->any() )
+			->method( 'getType' )
+			->will( $this->returnValue( 'mysql' ) );
+
+		$database->expects( $this->any() )
+			->method( 'getFlag' )
+			->will( $this->returnValue( true ) );
+
+		$database->expects( $this->once() )
+			->method( 'clearFlag' );
+
+		$database->expects( $this->once() )
+			->method( 'setFlag' );
+
+		$readConnectionProvider = $this->getMockBuilder( '\SMW\DBConnectionProvider' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$writeConnectionProvider = $this->getMockBuilder( '\SMW\DBConnectionProvider' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$writeConnectionProvider->expects( $this->atLeastOnce() )
+			->method( 'getConnection' )
+			->will( $this->returnValue( $database ) );
+
+		$instance = new Database(
+			$readConnectionProvider,
+			$writeConnectionProvider
+		);
+
+		$instance->disableTransactions();
+		$instance->enableTransactions();
+	}
+
 	public function testMissingWriteConnectionThrowsException() {
 
 		$connectionProvider = $this->getMockBuilder( '\SMW\DBConnectionProvider' )


### PR DESCRIPTION
Disable transactions during `QueryEngine` request as it has been reported that "... creating temporary tables in a transaction is not replication-safe and causes errors in MySQL 5.6. ..." [0]

[0] https://github.com/Wikia/app/pull/8814