### PR TITLE
TimeValueFormatter::getCaptionFromDataItem to use correct content lan…

### DIFF
--- a/src/DataValues/ValueFormatters/TimeValueFormatter.php
+++ b/src/DataValues/ValueFormatters/TimeValueFormatter.php
@@ -175,7 +175,7 @@ class TimeValueFormatter extends DataValueFormatter {
 
 		// If the language code is empty then the content language code is used
 		$extraneousLanguage = Localizer::getInstance()->getExtraneousLanguage(
-			$this->dataValue->getOptionValueFor( 'content.language' )
+			Localizer::getInstance()->getContentLanguage()
 		);
 
 		// https://en.wikipedia.org/wiki/Anno_Domini

--- a/tests/phpunit/Integration/ByJsonScript/Fixtures/p-0423.json
+++ b/tests/phpunit/Integration/ByJsonScript/Fixtures/p-0423.json
@@ -12,6 +12,11 @@
 			"contents": "[[Has date::12 Jan 1957 12:05]]"
 		},
 		{
+			"name": "Example/P0423/2",
+			"contentlanguage": "fr",
+			"contents": "[[Has date::12 April 1957 12:05]]"
+		},
+		{
 			"name": "Example/P0423/Q1.1",
 			"contents": "{{#ask: [[Has date::12 Jan 1957 12:05]] |?Has date |?Has date#MEDIAWIKI }}"
 		},
@@ -26,6 +31,10 @@
 		{
 			"name": "Example/P0423/Q1.4",
 			"contents": "{{#show: Example/P0423/1 |?Has date#LOCL }}"
+		},
+		{
+			"name": "Example/P0423/Q2.1",
+			"contents": "{{#show: Example/P0423/2 |?Has date }}"
 		}
 	],
 	"parser-testcases": [
@@ -82,6 +91,18 @@
 			"expected-output": {
 				"to-contain": [
 					"<p>1957年1月12日 (土) 12:05:00"
+				]
+			}
+		},
+		{
+			"about": "#5 page vs global content language",
+			"subject": "Example/P0423/Q2.1",
+			"expected-output": {
+				"to-contain": [
+					"<p>12 April 1957 12:05:00"
+				],
+				"not-contain": [
+					"<p>12 avril 1957 12:05:00"
 				]
 			}
 		}


### PR DESCRIPTION
…guage

If no output format is selected (== `getCaptionFromDataItem`) then use the global content language.