### PR TITLE
removing html special char escaping from link title of wikipages

### DIFF
--- a/includes/datavalues/SMW_DV_WikiPage.php
+++ b/includes/datavalues/SMW_DV_WikiPage.php
@@ -277,7 +277,6 @@ class SMWWikiPageValue extends SMWDataValue {
 		}
 
 		$caption = $this->m_caption === false ? $this->getShortCaptionText() : $this->m_caption;
-		$caption = htmlspecialchars( $caption );
 
 		if ( $this->getNamespace() == NS_MEDIA ) { // this extra case *is* needed
 			return $linker->makeMediaLinkObj( $this->getTitle(), $caption );

--- a/includes/datavalues/SMW_DV_WikiPage.php
+++ b/includes/datavalues/SMW_DV_WikiPage.php
@@ -363,7 +363,7 @@ class SMWWikiPageValue extends SMWDataValue {
 		// all others use default linking, no embedding of images here
 		return $linker->link(
 			$this->getTitle(),
-			htmlspecialchars( $this->getLongCaptionText() ),
+			$this->getLongCaptionText(),
 			$this->linkAttributes
 		);
 	}


### PR DESCRIPTION
This fixes my Issue #1611 
I'm not quite sure that htmlspecialchar escaping is needed in this place, as the title should have been properly escaped before?

To me it looks like the title string is encoded twice.