### PR TITLE
Display title to decode html entities, refs #1611

### DIFF
--- a/src/PropertyAnnotator/DisplayTitlePropertyAnnotator.php
+++ b/src/PropertyAnnotator/DisplayTitlePropertyAnnotator.php
@@ -43,9 +43,9 @@ class DisplayTitlePropertyAnnotator extends PropertyAnnotatorDecorator {
 			return;
 		}
 
-		// #1439
+		// #1439, #1611
 		$dataItem = $this->dataItemFactory->newDIBlob(
-			strip_tags(  $this->displayTitle )
+			strip_tags( htmlspecialchars_decode( $this->displayTitle ) )
 		);
 
 		$this->getSemanticData()->addPropertyObjectValue(

--- a/tests/phpunit/Integration/ByJsonScript/Fixtures/p-0416.json
+++ b/tests/phpunit/Integration/ByJsonScript/Fixtures/p-0416.json
@@ -1,5 +1,5 @@
 {
-	"description": "Test in-text annotation with DISPLAYTITLE (#1410, `wgRestrictDisplayTitle`, en)",
+	"description": "Test in-text annotation with DISPLAYTITLE (#1410, #1611, `wgRestrictDisplayTitle`, `wgContLang=en`, `wgLang=en`)",
 	"properties": [
 		{
 			"name": "Dwc:vernacularName",
@@ -52,6 +52,10 @@
 			"contents": "{{DISPLAYTITLE:P0416}} {{#subobject:@category=P0416|@sortkey=DEF}} [[Category:P0416]]"
 		},
 		{
+			"name": "Example/P0416/7",
+			"contents": "{{DISPLAYTITLE:ABC & DEF}}, see #1611"
+		},
+		{
 			"name": "Example/P0416/Q6.1",
 			"contents": "{{#ask: [[Category:P0416]] [[~P0416]] |link=none |format=table |sort=# |order=asc}}"
 		},
@@ -62,6 +66,10 @@
 		{
 			"name": "Example/P0416/Q6.3",
 			"contents": "{{#ask: [[Category:P0416]] [[~DEF]] |link=none |format=table |sort=# |order=asc}}"
+		},
+		{
+			"name": "Example/P0416/Q7.1",
+			"contents": "{{#ask: [[Display title of::ABC & DEF]] |link=none |format=table |sort=# |order=asc}}"
 		}
 	],
 	"parser-testcases": [
@@ -179,6 +187,15 @@
 			"expected-output": {
 				"to-contain": [
 					"<tr data-row-number=\"1\" class=\"row-odd\"><td class=\"smwtype_wpg\">Example/P0416/6/3#_b6f2e00f3a822fef179c8c2ea8e0c987</td></tr>"
+				]
+			}
+		},
+		{
+			"about": "#11 Display title/query includes &",
+			"subject": "Example/P0416/Q7.1",
+			"expected-output": {
+				"to-contain": [
+					"<tr data-row-number=\"1\" class=\"row-odd\"><td class=\"smwtype_wpg\">Example/P0416/7</td></tr>"
 				]
 			}
 		}

--- a/tests/phpunit/Unit/PropertyAnnotator/DisplayTitlePropertyAnnotatorTest.php
+++ b/tests/phpunit/Unit/PropertyAnnotator/DisplayTitlePropertyAnnotatorTest.php
@@ -146,7 +146,20 @@ class DisplayTitlePropertyAnnotatorTest extends \PHPUnit_Framework_TestCase {
 			)
 		);
 
-		#4 with different sortkey
+
+		#4 Strip tags
+		$provider[] = array(
+			'Foo',
+			"A 'quote' is <b>bold</b>",
+			'',
+			array(
+				'propertyCount'  => 2,
+				'propertyKeys'   => array( '_DTITLE', '_SKEY' ),
+				'propertyValues' => array( "A 'quote' is bold" ),
+			)
+		);
+
+		#5 with different sortkey
 		$provider[] = array(
 			'Foo',
 			'Lala',
@@ -155,6 +168,30 @@ class DisplayTitlePropertyAnnotatorTest extends \PHPUnit_Framework_TestCase {
 				'propertyCount'  => 1,
 				'propertyKeys'   => array( '_DTITLE' ),
 				'propertyValues' => array( 'Lala' ),
+			)
+		);
+
+		#6 unencoded Html entity
+		$provider[] = array(
+			'Foo',
+			'ABC & DEF',
+			'',
+			array(
+				'propertyCount'  => 2,
+				'propertyKeys'   => array( '_DTITLE', '_SKEY' ),
+				'propertyValues' => array( 'ABC & DEF' ),
+			)
+		);
+
+		#7 decoded/encoded Html entity
+		$provider[] = array(
+			'Foo',
+			'ABC &amp; DEF',
+			'',
+			array(
+				'propertyCount'  => 2,
+				'propertyKeys'   => array( '_DTITLE', '_SKEY' ),
+				'propertyValues' => array( 'ABC & DEF' ),
 			)
 		);
 


### PR DESCRIPTION
The display title retrieved from the parser is encoded hence `DisplayTitlePropertyAnnotator` need to decode the string.

refs #1611