### PR TITLE
Add TestEnvironment::resetMediaWikiService

### DIFF
--- a/tests/phpunit/Integration/ByJsonScript/ByJsonScriptFixtureTestCaseRunnerTest.php
+++ b/tests/phpunit/Integration/ByJsonScript/ByJsonScriptFixtureTestCaseRunnerTest.php
@@ -88,6 +88,11 @@ class ByJsonScriptFixtureTestCaseRunnerTest extends ByJsonTestCaseProvider {
 		ApplicationFactory::getInstance()->getMediaWikiNsContentReader()->skipMessageCache();
 		DataValueFactory::getInstance()->clear();
 
+		// Reset the Title/TitleParser otherwise a singleton instance holds an outdated
+		// content language reference
+		$this->testEnvironment->resetMediaWikiService( '_MediaWikiTitleCodec' );
+		$this->testEnvironment->resetMediaWikiService( 'TitleParser' );
+
 		$this->testEnvironment->resetPoolCacheFor( \SMW\PropertySpecificationLookup::POOLCACHE_ID );
 	}
 

--- a/tests/phpunit/TestEnvironment.php
+++ b/tests/phpunit/TestEnvironment.php
@@ -89,6 +89,23 @@ class TestEnvironment {
 	/**
 	 * @since 2.4
 	 *
+	 * @param string $name
+	 */
+	public function resetMediaWikiService( $name ) {
+
+		// MW 1.27+
+		if ( !class_exists( '\MediaWiki\MediaWikiServices' ) ) {
+			return null;
+		}
+
+		\MediaWiki\MediaWikiServices::getInstance()->resetServiceForTesting( $name );
+
+		return $this;
+	}
+
+	/**
+	 * @since 2.4
+	 *
 	 * @param string $poolCache
 	 *
 	 * @return self


### PR DESCRIPTION
Some services (MW 1.28) hold a singleton instance and keep reference to an inactive content language.