### PR TITLE
Stop using DummyLinker

### DIFF
--- a/includes/GlobalFunctions.php
+++ b/includes/GlobalFunctions.php
@@ -171,18 +171,19 @@ function &smwfGetSparqlDatabase() {
  * Compatibility helper for using Linker methods.
  * MW 1.16 has a Linker with non-static methods,
  * where in MW 1.19 they are static, and a DummyLinker
- * class is introduced, which can be instantaited for
- * compat reasons.
+ * class is introduced, which can be instantiated for
+ * compat reasons. As of MW 1.28, DummyLinker is being
+ * deprecated, so always use Linker.
  *
  * @since 1.6
  *
- * @return Linker or DummyLinker
+ * @return Linker
  */
 function smwfGetLinker() {
 	static $linker = false;
 
 	if ( $linker === false ) {
-		$linker = class_exists( 'DummyLinker' ) ? new DummyLinker() : new Linker();
+		$linker = new Linker();
 	}
 
 	return $linker;

--- a/includes/SMW_Infolink.php
+++ b/includes/SMW_Infolink.php
@@ -326,7 +326,7 @@ class SMWInfolink {
 	 */
 	protected function getLinker( &$linker = null ) {
 		if ( is_null( $linker ) ) {
-			$linker = class_exists('DummyLinker') ? new DummyLinker : new Linker;
+			$linker = new Linker;
 		}
 		return $linker;
 	}

--- a/includes/queryprinters/ResultPrinter.php
+++ b/includes/queryprinters/ResultPrinter.php
@@ -2,7 +2,7 @@
 
 namespace SMW;
 
-use DummyLinker;
+use Linker;
 use ParamProcessor\ParamDefinition;
 use ParserOptions;
 use Sanitizer;
@@ -177,7 +177,7 @@ abstract class ResultPrinter extends \ContextSource implements QueryResultPrinte
 		$this->mInline = $inline;
 		$this->mLinkFirst = ( $smwgQDefaultLinking != 'none' );
 		$this->mLinkOthers = ( $smwgQDefaultLinking == 'all' );
-		$this->mLinker = class_exists( 'DummyLinker' ) ? new DummyLinker() : new \Linker(); ///TODO: how can we get the default or user skin here (depending on context)?
+		$this->mLinker = new Linker(); ///TODO: how can we get the default or user skin here (depending on context)?
 	}
 
 	/**

--- a/tests/phpunit/includes/GlobalFunctionsTest.php
+++ b/tests/phpunit/includes/GlobalFunctionsTest.php
@@ -40,8 +40,7 @@ class GlobalFunctionsTest extends SemanticMediaWikiTestCase {
 	public function testSmwfGetLinker() {
 		$instance = smwfGetLinker();
 
-		$linker = class_exists( 'DummyLinker' ) ? 'DummyLinker' : 'Linker';
-		$this->assertInstanceOf( $linker, $instance );
+		$this->assertInstanceOf( 'Linker', $instance );
 	}
 
 	/**


### PR DESCRIPTION
In MW 1.28, we are working on deprecating DummyLinker, so always use
Linker instead, since the static methods can still be called as instance
methods without any issues.