### PR TITLE
Rename smwgPropertyDependencyExemptionlist

### DIFF
--- a/SemanticMediaWiki.settings.php
+++ b/SemanticMediaWiki.settings.php
@@ -877,7 +877,7 @@ $GLOBALS['smwgEnabledQueryDependencyLinksStore'] = false;
 #
 # @since 2.3 (experimental)
 ##
-$GLOBALS['smwgPropertyDependencyExemptionlist'] = array( '_MDAT', '_SOBJ', '_ASKDU' );
+$GLOBALS['smwgQueryDependencyPropertyExemptionlist'] = array( '_MDAT', '_SOBJ', '_ASKDU' );
 ##
 
 ###

--- a/includes/Settings.php
+++ b/includes/Settings.php
@@ -130,7 +130,7 @@ class Settings extends Options {
 			'smwgEnabledDeferredUpdate' => $GLOBALS['smwgEnabledDeferredUpdate'],
 			'smwgEnabledHttpDeferredJobRequest' => $GLOBALS['smwgEnabledHttpDeferredJobRequest'],
 			'smwgEnabledQueryDependencyLinksStore' => $GLOBALS['smwgEnabledQueryDependencyLinksStore'],
-			'smwgPropertyDependencyExemptionlist' => $GLOBALS['smwgPropertyDependencyExemptionlist'],
+			'smwgQueryDependencyPropertyExemptionlist' => $GLOBALS['smwgQueryDependencyPropertyExemptionlist'],
 			'smwgExportBCNonCanonicalFormUse' => $GLOBALS['smwgExportBCNonCanonicalFormUse'],
 			'smwgExportBCAuxiliaryUse' => $GLOBALS['smwgExportBCAuxiliaryUse'],
 			'smwgEnabledInTextAnnotationParserStrictMode' => $GLOBALS['smwgEnabledInTextAnnotationParserStrictMode'],

--- a/src/MediaWiki/Hooks/HookRegistry.php
+++ b/src/MediaWiki/Hooks/HookRegistry.php
@@ -509,7 +509,7 @@ class HookRegistry {
 
 			$jobParameters = $queryDependencyLinksStore->buildParserCachePurgeJobParametersFrom(
 				$compositePropertyTableDiffIterator,
-				$applicationFactory->getSettings()->get( 'smwgPropertyDependencyExemptionlist' )
+				$applicationFactory->getSettings()->get( 'smwgQueryDependencyPropertyExemptionlist' )
 			);
 
 			$deferredRequestDispatchManager->dispatchParserCachePurgeJobFor(

--- a/src/SQLStore/QueryDependencyLinksStoreFactory.php
+++ b/src/SQLStore/QueryDependencyLinksStoreFactory.php
@@ -45,7 +45,7 @@ class QueryDependencyLinksStoreFactory {
 		);
 
 		$queryResultDependencyListResolver->setPropertyDependencyExemptionlist(
-			$this->applicationFactory->getSettings()->get( 'smwgPropertyDependencyExemptionlist' )
+			$this->applicationFactory->getSettings()->get( 'smwgQueryDependencyPropertyExemptionlist' )
 		);
 
 		return $queryResultDependencyListResolver;


### PR DESCRIPTION
`smwgPropertyDependencyExemptionlist` is an internal setting but nevertheless a bit too arbitrary.