### PR TITLE
Add EntityIdListRelevanceDetectionFilter

### DIFF
--- a/SemanticMediaWiki.settings.php
+++ b/SemanticMediaWiki.settings.php
@@ -881,6 +881,19 @@ $GLOBALS['smwgQueryDependencyPropertyExemptionlist'] = array( '_MDAT', '_SOBJ', 
 ##
 
 ###
+# Listed properties are marked as affiliate, meaning that when an alteration to
+# a property value occurs query dependencies for the related entity are recorded
+# as well. For example, _DTITLE is most likely such property where a change would
+# normally not be reflected in query results (as it not directlty linked to a
+# query) but when added as an affiliated, changes to its content will be
+# handled as if it is linked to an embedded entity.
+#
+# @since 2.4 (experimental)
+##
+$GLOBALS['smwgQueryDependencyAffiliatePropertyDetectionlist'] = array();
+##
+
+###
 # The setting is introduced the keep backwards compatibility with existing Rdf/Turtle
 # exports. The `aux` marker is epxected only used to be used for selected properties
 # to generate a helper value and not for any other predefined property.

--- a/includes/Settings.php
+++ b/includes/Settings.php
@@ -131,11 +131,12 @@ class Settings extends Options {
 			'smwgEnabledHttpDeferredJobRequest' => $GLOBALS['smwgEnabledHttpDeferredJobRequest'],
 			'smwgEnabledQueryDependencyLinksStore' => $GLOBALS['smwgEnabledQueryDependencyLinksStore'],
 			'smwgQueryDependencyPropertyExemptionlist' => $GLOBALS['smwgQueryDependencyPropertyExemptionlist'],
+			'smwgQueryDependencyAffiliatePropertyDetectionlist' => $GLOBALS['smwgQueryDependencyAffiliatePropertyDetectionlist'],
 			'smwgExportBCNonCanonicalFormUse' => $GLOBALS['smwgExportBCNonCanonicalFormUse'],
 			'smwgExportBCAuxiliaryUse' => $GLOBALS['smwgExportBCAuxiliaryUse'],
 			'smwgEnabledInTextAnnotationParserStrictMode' => $GLOBALS['smwgEnabledInTextAnnotationParserStrictMode'],
 			'smwgSparqlRepositoryConnectorForcedHttpVersion' => $GLOBALS['smwgSparqlRepositoryConnectorForcedHttpVersion'],
-			'smwgDVFeatures' => $GLOBALS['smwgDVFeatures']
+			'smwgDVFeatures' => $GLOBALS['smwgDVFeatures'],
 		);
 
 		$settings = $settings + array(

--- a/src/MediaWiki/Hooks/HookRegistry.php
+++ b/src/MediaWiki/Hooks/HookRegistry.php
@@ -507,9 +507,13 @@ class HookRegistry {
 				$compositePropertyTableDiffIterator
 			);
 
+			$entityIdListRelevanceDetectionFilter = $queryDependencyLinksStoreFactory->newEntityIdListRelevanceDetectionFilter(
+				$store,
+				$compositePropertyTableDiffIterator
+			);
+
 			$jobParameters = $queryDependencyLinksStore->buildParserCachePurgeJobParametersFrom(
-				$compositePropertyTableDiffIterator,
-				$applicationFactory->getSettings()->get( 'smwgQueryDependencyPropertyExemptionlist' )
+				$entityIdListRelevanceDetectionFilter
 			);
 
 			$deferredRequestDispatchManager->dispatchParserCachePurgeJobFor(

--- a/src/SQLStore/QueryDependency/EntityIdListRelevanceDetectionFilter.php
+++ b/src/SQLStore/QueryDependency/EntityIdListRelevanceDetectionFilter.php
@@ -1,0 +1,208 @@
+<?php
+
+namespace SMW\SQLStore\QueryDependency;
+
+use SMW\DIWikiPage;
+use SMW\DIProperty;
+use SMW\SQLStore\SQLStore;
+use SMW\SQLStore\CompositePropertyTableDiffIterator;
+use SMW\Store;
+
+/**
+ * This class filters entities recorded in CompositePropertyTableDiffIterator
+ * by applying a rule set.
+ *
+ * - Exempted properties are removed from the update list
+ * - Properties that are affiliated are checked and the related entity is added
+ *   to the update list that would eventually trigger a dependency update
+ *
+ * By affiliation implies that a property listed is no directly related to a query
+ * dependency, yet it is monitored and can, if altered trigger a dependency update
+ * that normally only reserved for dependent properties.
+ *
+ * @license GNU GPL v2+
+ * @since 2.4
+ *
+ * @author mwjames
+ */
+class EntityIdListRelevanceDetectionFilter {
+
+	/**
+	 * @var Store
+	 */
+	private $store = null;
+
+	/**
+	 * @var CompositePropertyTableDiffIterator
+	 */
+	private $compositePropertyTableDiffIterator = null;
+
+	/**
+	 * @var array
+	 */
+	private $propertyExemptionlist = array();
+
+	/**
+	 * @var array
+	 */
+	private $affiliatePropertyDetectionlist = array();
+
+	/**
+	 * @since 2.4
+	 *
+	 * @param Store $store
+	 * @param CompositePropertyTableDiffIterator $compositePropertyTableDiffIterator
+	 */
+	public function __construct( Store $store, CompositePropertyTableDiffIterator $compositePropertyTableDiffIterator ) {
+		$this->store = $store;
+		$this->compositePropertyTableDiffIterator = $compositePropertyTableDiffIterator;
+	}
+
+	/**
+	 * @since 2.4
+	 *
+	 * @param array $propertyExemptionlist
+	 */
+	public function setPropertyExemptionlist( array $propertyExemptionlist ) {
+		$this->propertyExemptionlist = array_flip(
+			str_replace( ' ', '_', $propertyExemptionlist )
+		);
+	}
+
+	/**
+	 * @since 2.4
+	 *
+	 * @param array $affiliatePropertyDetectionlist
+	 */
+	public function setAffiliatePropertyDetectionlist( array $affiliatePropertyDetectionlist ) {
+		$this->affiliatePropertyDetectionlist = array_flip(
+			str_replace( ' ', '_', $affiliatePropertyDetectionlist )
+		);
+	}
+
+	/**
+	 * @since 2.4
+	 *
+	 * @return array
+	 */
+	public function getFilteredIdList() {
+
+		$start = microtime( true );
+
+		$combinedChangedEntityList = array_flip(
+			$this->compositePropertyTableDiffIterator->getCombinedIdListOfChangedEntities()
+		);
+
+		$affiliateEntityList = array();
+
+		foreach ( $this->compositePropertyTableDiffIterator->getOrderedDiffByTable() as $tableName => $diff ) {
+			$this->applyFilterToDiffElement( $diff, $affiliateEntityList, $combinedChangedEntityList );
+		}
+
+		$listOfChangedEntitiesByRule = array_merge(
+			array_keys( $combinedChangedEntityList ),
+			array_keys( $affiliateEntityList )
+		);
+
+		wfDebugLog( 'smw', __METHOD__ . ' processing (sec): ' . round( ( microtime( true ) - $start ), 6 )  );
+
+		return $listOfChangedEntitiesByRule;
+	}
+
+	private function applyFilterToDiffElement( $diff, &$affiliateEntityList, &$combinedChangedEntityList ) {
+
+		// User-defined
+		if ( !isset( $diff['property'] ) ) {
+			if ( isset( $diff['insert'] ) ) {
+				foreach ( $diff['insert'] as $insert ) {
+					$this->addIdToAffiliateEntityList( $insert, $affiliateEntityList, $combinedChangedEntityList );
+				}
+			}
+
+			if ( isset( $diff['delete'] ) ) {
+				foreach ( $diff['delete'] as $delete ) {
+					$this->addIdToAffiliateEntityList( $delete, $affiliateEntityList, $combinedChangedEntityList );
+				}
+			}
+
+			return;
+		}
+
+		// Exemption goes for inclusion
+
+		// Fixed
+		if ( isset( $this->propertyExemptionlist[$diff['property']['key']] ) ) {
+			$this->unsetIdFromEntityList(
+				$diff['property']['p_id'],
+				$diff,
+				$combinedChangedEntityList
+			);
+
+			return;
+		}
+
+		if ( !isset( $this->affiliatePropertyDetectionlist[$diff['property']['key']]) ) {
+			return;
+		}
+
+		if ( isset( $diff['insert'] ) ) {
+			foreach ( $diff['insert'] as $insert ) {
+				$affiliateEntityList[$insert['s_id']] = true;
+			}
+		}
+
+		if ( isset( $diff['delete'] ) ) {
+			foreach ( $diff['delete'] as $delete ) {
+				$affiliateEntityList[$delete['s_id']] = true;
+			}
+		}
+	}
+
+	private function addIdToAffiliateEntityList( $diff, &$affiliateEntityList, &$combinedChangedEntityList ) {
+
+		$key = '';
+
+		if ( isset( $diff['p_id'] ) ) {
+			$dataItem = $this->store->getObjectIds()->getDataItemForId( $diff['p_id'] );
+			$key = $dataItem->getDBKey();
+
+			if ( isset( $this->propertyExemptionlist[$key]) ) {
+				$this->unsetIdFromEntityList(
+					$diff['p_id'],
+					$diff,
+					$combinedChangedEntityList
+				);
+
+				return null;
+			}
+		}
+
+		if ( isset( $this->affiliatePropertyDetectionlist[$key]) ) {
+			$affiliateEntityList[$diff['s_id']] = true;
+		}
+	}
+
+	private function unsetIdFromEntityList( $id, $diff, &$combinedChangedEntityList ) {
+
+		// Remove matched blacklisted property reference
+		unset( $combinedChangedEntityList[$id] );
+
+		if ( isset( $diff['s_id'] ) ) {
+			unset( $combinedChangedEntityList[$diff['s_id']] );
+		}
+
+		// Remove associated subject ID's
+		if ( isset( $diff['insert'] ) ) {
+			foreach ( $diff['insert'] as $insert ) {
+				unset( $combinedChangedEntityList[$insert['s_id']] );
+			}
+		}
+
+		if ( isset( $diff['delete'] ) ) {
+			foreach ( $diff['delete'] as $delete ) {
+				unset( $combinedChangedEntityList[$delete['s_id']] );
+			}
+		}
+	}
+
+}

--- a/src/SQLStore/QueryDependencyLinksStoreFactory.php
+++ b/src/SQLStore/QueryDependencyLinksStoreFactory.php
@@ -6,6 +6,7 @@ use SMW\ApplicationFactory;
 use SMW\SQLStore\QueryDependency\DependencyLinksTableUpdater;
 use SMW\SQLStore\QueryDependency\QueryDependencyLinksStore;
 use SMW\SQLStore\QueryDependency\QueryResultDependencyListResolver;
+use SMW\SQLStore\QueryDependency\EntityIdListRelevanceDetectionFilter;
 use SMW\Store;
 
 /**
@@ -69,6 +70,32 @@ class QueryDependencyLinksStoreFactory {
 		);
 
 		return $queryDependencyLinksStore;
+	}
+
+	/**
+	 * @since 2.4
+	 *
+	 * @param Store $store
+	 * @param CompositePropertyTableDiffIterator $compositePropertyTableDiffIterator
+	 *
+	 * @return EntityIdListRelevanceDetectionFilter
+	 */
+	public function newEntityIdListRelevanceDetectionFilter( Store $store, CompositePropertyTableDiffIterator $compositePropertyTableDiffIterator ) {
+
+		$entityIdListRelevanceDetectionFilter = new EntityIdListRelevanceDetectionFilter(
+			$store,
+			$compositePropertyTableDiffIterator
+		);
+
+		$entityIdListRelevanceDetectionFilter->setPropertyExemptionlist(
+			$this->applicationFactory->getSettings()->get( 'smwgQueryDependencyPropertyExemptionlist' )
+		);
+
+		$entityIdListRelevanceDetectionFilter->setAffiliatePropertyDetectionlist(
+			$this->applicationFactory->getSettings()->get( 'smwgQueryDependencyAffiliatePropertyDetectionlist' )
+		);
+
+		return $entityIdListRelevanceDetectionFilter;
 	}
 
 }

--- a/tests/phpunit/Unit/MediaWiki/Hooks/HookRegistryTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Hooks/HookRegistryTest.php
@@ -906,6 +906,10 @@ class HookRegistryTest extends \PHPUnit_Framework_TestCase {
 			->will( $this->returnValue( array() ) );
 
 		$compositePropertyTableDiffIterator->expects( $this->any() )
+			->method( 'getOrderedDiffByTable' )
+			->will( $this->returnValue( array() ) );
+
+		$compositePropertyTableDiffIterator->expects( $this->any() )
 			->method( 'getFixedPropertyRecords' )
 			->will( $this->returnValue( array() ) );
 

--- a/tests/phpunit/Unit/SQLStore/QueryDependency/EntityIdListRelevanceDetectionFilterTest.php
+++ b/tests/phpunit/Unit/SQLStore/QueryDependency/EntityIdListRelevanceDetectionFilterTest.php
@@ -1,0 +1,237 @@
+<?php
+
+namespace SMW\Tests\SQLStore\QueryDependency;
+
+use SMW\DIWikiPage;
+use SMW\SQLStore\QueryDependency\EntityIdListRelevanceDetectionFilter;
+use SMW\SQLStore\SQLStore;
+use SMW\Tests\TestEnvironment;
+
+/**
+ * @covers \SMW\SQLStore\QueryDependency\EntityIdListRelevanceDetectionFilter
+ * @group semantic-mediawiki
+ *
+ * @license GNU GPL v2+
+ * @since 2.4
+ *
+ * @author mwjames
+ */
+class EntityIdListRelevanceDetectionFilterTest extends \PHPUnit_Framework_TestCase {
+
+	private $testEnvironment;
+
+	protected function setUp() {
+		parent::setUp();
+
+		$this->testEnvironment = new TestEnvironment();
+
+		$store = $this->getMockBuilder( '\SMW\Store' )
+			->disableOriginalConstructor()
+			->getMockForAbstractClass();
+
+		$this->testEnvironment->registerObject( 'Store', $store );
+	}
+
+	protected function tearDown() {
+		$this->testEnvironment->tearDown();
+		parent::tearDown();
+	}
+
+	public function testCanConstruct() {
+
+		$store = $this->getMockBuilder( '\SMW\Store' )
+			->disableOriginalConstructor()
+			->getMockForAbstractClass();
+
+		$compositePropertyTableDiffIterator = $this->getMockBuilder( '\SMW\SQLStore\CompositePropertyTableDiffIterator' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$this->assertInstanceOf(
+			'\SMW\SQLStore\QueryDependency\EntityIdListRelevanceDetectionFilter',
+			new EntityIdListRelevanceDetectionFilter( $store, $compositePropertyTableDiffIterator )
+		);
+	}
+
+	public function testgetFilteredIdListOnExemptedPredefinedProperty() {
+
+		$orderedDiffByTable = array(
+			'fpt_mdat' => array(
+				'property' => array(
+					'key'  => '_MDAT',
+					'p_id' => 29
+				),
+				'insert' => array(
+					array(
+						's_id' => 201,
+						'o_serialized' => '1/2016/6/1/11/1/48/0',
+						'o_sortkey' => '2457540.9595833'
+					)
+				),
+				'delete' => array(
+					array(
+						's_id' => 201,
+						'o_serialized' => '1/2016/6/1/11/1/59/0',
+						'o_sortkey' => '2457540.9582292'
+					)
+				)
+			)
+		);
+
+		$store = $this->getMockBuilder( '\SMW\Store' )
+			->disableOriginalConstructor()
+			->getMockForAbstractClass();
+
+		$compositePropertyTableDiffIterator = $this->getMockBuilder( '\SMW\SQLStore\CompositePropertyTableDiffIterator' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$compositePropertyTableDiffIterator->expects( $this->once() )
+			->method( 'getCombinedIdListOfChangedEntities' )
+			->will( $this->returnValue( array( 29, 201, 1001 ) ) );
+
+		$compositePropertyTableDiffIterator->expects( $this->any() )
+			->method( 'getOrderedDiffByTable' )
+			->will( $this->returnValue( $orderedDiffByTable ) );
+
+		$instance = new EntityIdListRelevanceDetectionFilter(
+			$store,
+			$compositePropertyTableDiffIterator
+		);
+
+		$instance->setPropertyExemptionlist(
+			array( '_MDAT' )
+		);
+
+		$this->assertEquals(
+			array( 1001 ),
+			$instance->getFilteredIdList()
+		);
+	}
+
+	public function testgetFilteredIdListOnAffiliatePredefinedProperty() {
+
+		$orderedDiffByTable = array(
+			'fpt_dat' => array(
+				'property' => array(
+					'key'  => '_MDAT',
+					'p_id' => 29
+				),
+				'insert' => array(
+					array(
+						's_id' => 201,
+						'o_serialized' => '1/2016/6/1/11/1/48/0',
+						'o_sortkey' => '2457540.9595833'
+					)
+				),
+				'delete' => array(
+					array(
+						's_id' => 201,
+						'o_serialized' => '1/2016/6/1/11/1/59/0',
+						'o_sortkey' => '2457540.9582292'
+					)
+				)
+			)
+		);
+
+		$store = $this->getMockBuilder( '\SMW\Store' )
+			->disableOriginalConstructor()
+			->getMockForAbstractClass();
+
+		$compositePropertyTableDiffIterator = $this->getMockBuilder( '\SMW\SQLStore\CompositePropertyTableDiffIterator' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$compositePropertyTableDiffIterator->expects( $this->once() )
+			->method( 'getCombinedIdListOfChangedEntities' )
+			->will( $this->returnValue( array( 1001 ) ) );
+
+		$compositePropertyTableDiffIterator->expects( $this->any() )
+			->method( 'getOrderedDiffByTable' )
+			->will( $this->returnValue( $orderedDiffByTable ) );
+
+		$instance = new EntityIdListRelevanceDetectionFilter(
+			$store,
+			$compositePropertyTableDiffIterator
+		);
+
+		$instance->setAffiliatePropertyDetectionlist(
+			array( '_MDAT' )
+		);
+
+		$this->assertEquals(
+			array( 1001, 201 ),
+			$instance->getFilteredIdList()
+		);
+	}
+
+	public function testgetFilteredIdListOnExemptedUserdefinedProperty() {
+
+		$orderedDiffByTable = array(
+			'fpt_foo' => array(
+				'insert' => array(
+					array(
+						'p_id' => 100,
+						's_id' => 201,
+						'o_serialized' => '1/2016/6/1/11/1/48/0',
+						'o_sortkey' => '2457540.9595833'
+					)
+				),
+				'delete' => array(
+					array(
+						'p_id' => 100,
+						's_id' => 201,
+						'o_serialized' => '1/2016/6/1/11/1/59/0',
+						'o_sortkey' => '2457540.9582292'
+					)
+				)
+			)
+		);
+
+		$idTable = $this->getMockBuilder( '\stdClass' )
+			->setMethods( array( 'getDataItemForId' ) )
+			->getMock();
+
+		$idTable->expects( $this->any() )
+			->method( 'getDataItemForId' )
+			->with( $this->equalTo( 100 ) )
+			->will( $this->returnValue( DIWikiPage::newFromText( 'Has date', SMW_NS_PROPERTY ) ) );
+
+		$store = $this->getMockBuilder( '\SMW\SQLStore\SQLStore' )
+			->disableOriginalConstructor()
+			->setMethods( array( 'getObjectIds' ) )
+			->getMockForAbstractClass();
+
+		$store->expects( $this->any() )
+			->method( 'getObjectIds' )
+			->will( $this->returnValue( $idTable ) );
+
+		$compositePropertyTableDiffIterator = $this->getMockBuilder( '\SMW\SQLStore\CompositePropertyTableDiffIterator' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$compositePropertyTableDiffIterator->expects( $this->once() )
+			->method( 'getCombinedIdListOfChangedEntities' )
+			->will( $this->returnValue( array( 100, 201, 1001 ) ) );
+
+		$compositePropertyTableDiffIterator->expects( $this->any() )
+			->method( 'getOrderedDiffByTable' )
+			->will( $this->returnValue( $orderedDiffByTable ) );
+
+		$instance = new EntityIdListRelevanceDetectionFilter(
+			$store,
+			$compositePropertyTableDiffIterator
+		);
+
+		$instance->setPropertyExemptionlist(
+			array( 'Has date' )
+		);
+
+		$this->assertEquals(
+			array( 1001 ),
+			$instance->getFilteredIdList()
+		);
+	}
+
+
+}

--- a/tests/phpunit/Unit/SQLStore/QueryDependency/QueryDependencyLinksStoreTest.php
+++ b/tests/phpunit/Unit/SQLStore/QueryDependency/QueryDependencyLinksStoreTest.php
@@ -5,6 +5,7 @@ namespace SMW\Tests\SQLStore\QueryDependency;
 use SMW\ApplicationFactory;
 use SMW\DIWikiPage;
 use SMW\SQLStore\QueryDependency\QueryDependencyLinksStore;
+use SMW\SQLStore\QueryDependency\EntityIdListRelevanceDetectionFilter;
 use SMW\SQLStore\SQLStore;
 
 /**
@@ -131,38 +132,7 @@ class QueryDependencyLinksStoreTest extends \PHPUnit_Framework_TestCase {
 
 		$store = $this->getMockBuilder( '\SMW\SQLStore\SQLStore' )
 			->disableOriginalConstructor()
-			->getMock();
-
-		$record = array(
-			'table_foo' => array(
-				'key'  => '_FOO',
-				'p_id' => 2
-			)
-		);
-
-		$tableDiff = array(
-			'table_foo' => array(
-				'insert'  => array(
-					array( 's_id' => 1001 )
-				)
-			)
-		);
-
-		$compositePropertyTableDiffIterator = $this->getMockBuilder( '\SMW\SQLStore\CompositePropertyTableDiffIterator' )
-			->disableOriginalConstructor()
-			->getMock();
-
-		$compositePropertyTableDiffIterator->expects( $this->any() )
-			->method( 'getCombinedIdListOfChangedEntities' )
-			->will( $this->returnValue( array( 1, 2, 1001 ) ) );
-
-		$compositePropertyTableDiffIterator->expects( $this->any() )
-			->method( 'getFixedPropertyRecords' )
-			->will( $this->returnValue( $record ) );
-
-		$compositePropertyTableDiffIterator->expects( $this->any() )
-			->method( 'getOrderedDiffByTable' )
-			->will( $this->returnValue( $tableDiff ) );
+			->getMockForAbstractClass();
 
 		$dependencyLinksTableUpdater = $this->getMockBuilder( '\SMW\SQLStore\QueryDependency\DependencyLinksTableUpdater' )
 			->disableOriginalConstructor()
@@ -172,13 +142,21 @@ class QueryDependencyLinksStoreTest extends \PHPUnit_Framework_TestCase {
 			->method( 'getStore' )
 			->will( $this->returnValue( $store ) );
 
+		$entityIdListRelevanceDetectionFilter = $this->getMockBuilder( '\SMW\SQLStore\QueryDependency\EntityIdListRelevanceDetectionFilter' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$entityIdListRelevanceDetectionFilter->expects( $this->once() )
+			->method( 'getFilteredIdList' )
+			->will( $this->returnValue( array( 1 ) ) );
+
 		$instance = new QueryDependencyLinksStore(
 			$dependencyLinksTableUpdater
 		);
 
 		$this->assertEquals(
 			array( 'idlist' => array( 1 ) ),
-			$instance->buildParserCachePurgeJobParametersFrom( $compositePropertyTableDiffIterator, array( '_FOO' ) )
+			$instance->buildParserCachePurgeJobParametersFrom( $entityIdListRelevanceDetectionFilter )
 		);
 	}
 
@@ -188,10 +166,6 @@ class QueryDependencyLinksStoreTest extends \PHPUnit_Framework_TestCase {
 			->disableOriginalConstructor()
 			->getMock();
 
-		$compositePropertyTableDiffIterator = $this->getMockBuilder( '\SMW\SQLStore\CompositePropertyTableDiffIterator' )
-			->disableOriginalConstructor()
-			->getMock();
-
 		$dependencyLinksTableUpdater = $this->getMockBuilder( '\SMW\SQLStore\QueryDependency\DependencyLinksTableUpdater' )
 			->disableOriginalConstructor()
 			->getMock();
@@ -200,6 +174,10 @@ class QueryDependencyLinksStoreTest extends \PHPUnit_Framework_TestCase {
 			->method( 'getStore' )
 			->will( $this->returnValue( $store ) );
 
+		$entityIdListRelevanceDetectionFilter = $this->getMockBuilder( '\SMW\SQLStore\QueryDependency\EntityIdListRelevanceDetectionFilter' )
+			->disableOriginalConstructor()
+			->getMock();
+
 		$instance = new QueryDependencyLinksStore(
 			$dependencyLinksTableUpdater
 		);
@@ -207,7 +185,7 @@ class QueryDependencyLinksStoreTest extends \PHPUnit_Framework_TestCase {
 		$instance->setEnabledState( false );
 
 		$this->assertEmpty(
-			$instance->buildParserCachePurgeJobParametersFrom( $compositePropertyTableDiffIterator, array() )
+			$instance->buildParserCachePurgeJobParametersFrom( $entityIdListRelevanceDetectionFilter )
 		);
 	}
 

--- a/tests/phpunit/Unit/SQLStore/QueryDependencyLinksStoreFactoryTest.php
+++ b/tests/phpunit/Unit/SQLStore/QueryDependencyLinksStoreFactoryTest.php
@@ -23,7 +23,7 @@ class QueryDependencyLinksStoreFactoryTest extends \PHPUnit_Framework_TestCase {
 		);
 	}
 
-	public function canConstructQueryResultDependencyListResolver() {
+	public function testCanConstructQueryResultDependencyListResolver() {
 
 		$instance = new QueryDependencyLinksStoreFactory();
 
@@ -33,7 +33,7 @@ class QueryDependencyLinksStoreFactoryTest extends \PHPUnit_Framework_TestCase {
 		);
 	}
 
-	public function canConstructQueryDependencyLinksStore() {
+	public function testCanConstructQueryDependencyLinksStore() {
 
 		$store = $this->getMockBuilder( '\SMW\Store' )
 			->disableOriginalConstructor()
@@ -44,6 +44,24 @@ class QueryDependencyLinksStoreFactoryTest extends \PHPUnit_Framework_TestCase {
 		$this->assertInstanceOf(
 			'\SMW\SQLStore\QueryDependency\QueryDependencyLinksStore',
 			$instance->newQueryDependencyLinksStore( $store )
+		);
+	}
+
+	public function testCanConstructEntityIdListRelevanceDetectionFilter() {
+
+		$store = $this->getMockBuilder( '\SMW\Store' )
+			->disableOriginalConstructor()
+			->getMockForAbstractClass();
+
+		$compositePropertyTableDiffIterator = $this->getMockBuilder( '\SMW\SQLStore\CompositePropertyTableDiffIterator' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$instance = new QueryDependencyLinksStoreFactory();
+
+		$this->assertInstanceOf(
+			'\SMW\SQLStore\QueryDependency\EntityIdListRelevanceDetectionFilter',
+			$instance->newEntityIdListRelevanceDetectionFilter( $store, $compositePropertyTableDiffIterator )
 		);
 	}
 


### PR DESCRIPTION
`$GLOBALS['smwgQueryDependencyAffiliatePropertyDetectionlist']` allows to categorize certain properties as affiliate, with the effect that when value changes occur to those properties an update for selected entities are triggered as well.