### PR TITLE
Add TemporaryEntityListAccumulator

### DIFF
--- a/includes/storage/SMW_QueryResult.php
+++ b/includes/storage/SMW_QueryResult.php
@@ -4,6 +4,7 @@ use SMW\HashBuilder;
 use SMW\Query\PrintRequest;
 use SMW\Query\QueryLinker;
 use SMW\SerializerFactory;
+use SMW\Query\TemporaryEntityListAccumulator;
 
 /**
  * Objects of this class encapsulate the result of a query in SMW. They
@@ -70,6 +71,11 @@ class SMWQueryResult {
 	private $isFromCache = false;
 
 	/**
+	 * @var TemporaryEntityListAccumulator
+	 */
+	private $temporaryEntityListAccumulator;
+
+	/**
 	 * Initialise the object with an array of SMWPrintRequest objects, which
 	 * define the structure of the result "table" (one for each column).
 	 *
@@ -88,6 +94,16 @@ class SMWQueryResult {
 		$this->mFurtherResults = $furtherRes;
 		$this->mQuery = $query;
 		$this->mStore = $store;
+		$this->temporaryEntityListAccumulator = new TemporaryEntityListAccumulator( $query );
+	}
+
+	/**
+	 * @since  2.4
+	 *
+	 * @return TemporaryEntityListAccumulator
+	 */
+	public function getEntityListAccumulator() {
+		return $this->temporaryEntityListAccumulator;
 	}
 
 	/**
@@ -134,7 +150,9 @@ class SMWQueryResult {
 		$row = array();
 
 		foreach ( $this->mPrintRequests as $p ) {
-			$row[] = new SMWResultArray( $page, $p, $this->mStore );
+			$resultArray = new SMWResultArray( $page, $p, $this->mStore );
+			$resultArray->setEntityListAccumulator( $this->temporaryEntityListAccumulator );
+			$row[] = $resultArray;
 		}
 
 		return $row;
@@ -163,6 +181,7 @@ class SMWQueryResult {
 	 * @since 2.3
 	 */
 	public function reset() {
+		$this->temporaryEntityListAccumulator->pruneEntityList();
 		return reset( $this->mResults );
 	}
 

--- a/src/Query/TemporaryEntityListAccumulator.php
+++ b/src/Query/TemporaryEntityListAccumulator.php
@@ -1,0 +1,110 @@
+<?php
+
+namespace SMW\Query;
+
+use SMWQuery as Query;
+use SMWDataItem as DataItem;
+use SMW\DIProperty;
+use SMW\DIWikiPage;
+use SMW\Store;
+
+/**
+ * This class records selected entities used in a QueryResult by the time the
+ * ResultArray creates an object instance which avoids unnecessary work in the
+ * QueryResultDependencyListResolver (in terms of recursive processing of the
+ * QueryResult) to find related "column" entities (those related to a
+ * printrequest).
+ *
+ * @license GNU GPL v2+
+ * @since 2.4
+ *
+ * @author mwjames
+ */
+class TemporaryEntityListAccumulator {
+
+	/**
+	 * @var Query
+	 */
+	private $query;
+
+	/**
+	 * @var string|null
+	 */
+	private $queryId = null;
+
+	/**
+	 * @var array
+	 */
+	private static $entityList = array();
+
+	/**
+	 * @since 2.4
+	 *
+	 * @param Query $query
+	 */
+	public function __construct( Query $query ) {
+		$this->query = $query;
+	}
+
+	/**
+	 * @since  2.4
+	 *
+	 * @return string
+	 */
+	public function getQueryId() {
+
+		if ( $this->queryId === null ) {
+			$this->queryId = $this->query->getQueryId();
+		}
+
+		return $this->queryId;
+	}
+
+	/**
+	 * @since  2.4
+	 *
+	 * @return array
+	 */
+	public function getEntityList( $queryID = null ) {
+
+		if ( $queryID !== null ) {
+			return isset( self::$entityList[$queryID] ) ? self::$entityList[$queryID] : array();
+		}
+
+		return self::$entityList;
+	}
+
+	/**
+	 * @since  2.4
+	 *
+	 * @param string|null $queryID
+	 */
+	public function pruneEntityList( $queryID = null ) {
+
+		if ( $queryID === null ) {
+			return self::$entityList = array();
+		}
+
+		unset( self::$entityList[$queryID] );
+	}
+
+	/**
+	 * @since  2.4
+	 *
+	 * @param DIProperty|null $property
+	 * @param DataItem $dataItem
+	 */
+	public function addToEntityList( DIProperty $property = null, DataItem $dataItem ) {
+
+		$queryID = $this->getQueryId();
+
+		if ( !isset( self::$entityList[$queryID] ) ) {
+			self::$entityList[$queryID] = array();
+		}
+
+		if ( $dataItem instanceof DIWikiPage ) {
+			self::$entityList[$queryID][] = $dataItem;
+		}
+	}
+
+}

--- a/tests/phpunit/Unit/Query/TemporaryEntityListAccumulatorTest.php
+++ b/tests/phpunit/Unit/Query/TemporaryEntityListAccumulatorTest.php
@@ -1,0 +1,128 @@
+<?php
+
+namespace SMW\Tests\Query;
+
+use SMW\DIWikiPage;
+use SMW\Query\TemporaryEntityListAccumulator;
+use SMW\Tests\TestEnvironment;
+
+/**
+ * @covers \SMW\Query\TemporaryEntityListAccumulator
+ * @group semantic-mediawiki
+ *
+ * @license GNU GPL v2+
+ * @since 2.4
+ *
+ * @author mwjames
+ */
+class TemporaryEntityListAccumulatorTest extends \PHPUnit_Framework_TestCase {
+
+	private $testEnvironment;
+	private $query;
+
+	protected function setUp() {
+		parent::setUp();
+
+		$this->testEnvironment = new TestEnvironment();
+
+		$this->query = $this->getMockBuilder( '\SMWQuery' )
+			->disableOriginalConstructor()
+			->getMock();
+	}
+
+	protected function tearDown() {
+		$this->testEnvironment->tearDown();
+		parent::tearDown();
+	}
+
+	public function testCanConstruct() {
+
+		$this->assertInstanceOf(
+			'\SMW\Query\TemporaryEntityListAccumulator',
+			new TemporaryEntityListAccumulator( $this->query )
+		);
+	}
+
+	public function testAddToEntityList() {
+
+		$dataItem = DIWikiPage::newFromText( 'Foo' );
+
+		$this->query->expects( $this->any() )
+			->method( 'getQueryId' )
+			->will( $this->returnValue( 'FOO:123' ) );
+
+		$instance = new TemporaryEntityListAccumulator(
+			$this->query
+		);
+
+		$instance->pruneEntityList();
+		$instance->addToEntityList( null, $dataItem );
+
+		$this->assertEquals(
+			array( $dataItem ),
+			$instance->getEntityList( 'FOO:123' )
+		);
+	}
+
+	/**
+	 * @depends testAddToEntityList
+	 */
+	public function testAddAnotherToEntityList() {
+
+		$dataItem = DIWikiPage::newFromText( 'Bar' );
+
+		$this->query->expects( $this->any() )
+			->method( 'getQueryId' )
+			->will( $this->returnValue( 'FOO:BAR' ) );
+
+		$instance = new TemporaryEntityListAccumulator(
+			$this->query
+		);
+
+		$instance->addToEntityList( null, $dataItem );
+
+		$this->assertEquals(
+			array(
+				'FOO:BAR' => array( $dataItem ),
+				'FOO:123' => array( DIWikiPage::newFromText( 'Foo' ) ) // from previous run
+			),
+			$instance->getEntityList()
+		);
+	}
+
+	/**
+	 * @depends testAddAnotherToEntityList
+	 */
+	public function testGetAndPruneEntityList() {
+
+		$instance = new TemporaryEntityListAccumulator(
+			$this->query
+		);
+
+		$this->assertCount(
+			2,
+			$instance->getEntityList()
+		);
+
+		$this->assertNotEmpty(
+			$instance->getEntityList( 'FOO:123' )
+		);
+
+		$instance->pruneEntityList( 'FOO:123' );
+
+		$this->assertEmpty(
+			$instance->getEntityList( 'FOO:123' )
+		);
+
+		$this->assertNotEmpty(
+			$instance->getEntityList( 'FOO:BAR' )
+		);
+
+		$instance->pruneEntityList();
+
+		$this->assertEmpty(
+			$instance->getEntityList()
+		);
+	}
+
+}

--- a/tests/phpunit/Unit/SQLStore/QueryDependency/QueryResultDependencyListResolverTest.php
+++ b/tests/phpunit/Unit/SQLStore/QueryDependency/QueryResultDependencyListResolverTest.php
@@ -227,6 +227,52 @@ class QueryResultDependencyListResolverTest extends \PHPUnit_Framework_TestCase 
 		);
 	}
 
+	public function testGetDependencyListByLateRetrieval() {
+
+		$subject = DIWikiPage::newFromText( 'Bar' );
+
+		$description = new ClassDescription(
+			DIWikiPage::newFromText( 'Foocat', NS_CATEGORY )
+		);
+
+		$query = new Query( $description );
+		$query->setContextPage( DIWikiPage::newFromText( 'Foo' ) );
+
+		$temporaryEntityListAccumulator = $this->getMockBuilder( '\SMW\Query\TemporaryEntityListAccumulator' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$temporaryEntityListAccumulator->expects( $this->once() )
+			->method( 'getEntityList' )
+			->will( $this->returnValue( array( $subject ) ) );
+
+		$queryResult = $this->getMockBuilder( '\SMWQueryResult' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$queryResult->expects( $this->once() )
+			->method( 'getEntityListAccumulator' )
+			->will( $this->returnValue( $temporaryEntityListAccumulator ) );
+
+		$queryResult->expects( $this->any() )
+			->method( 'getQuery' )
+			->will( $this->returnValue( $query ) );
+
+		$propertyHierarchyLookup = $this->getMockBuilder( '\SMW\PropertyHierarchyLookup' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$instance = new QueryResultDependencyListResolver(
+			$queryResult,
+			$propertyHierarchyLookup
+		);
+
+		$this->assertEquals(
+			array( $subject ),
+			$instance->getDependencyListByLateRetrieval()
+		);
+	}
+
 	public function testResolvePropertyHierarchy() {
 
 		$subject = DIWikiPage::newFromText( 'Foo' );


### PR DESCRIPTION
Allows to track entities created by/during QueryResult/ResultArray instantiation and avoids a possible performance penalty when trying to record them independently.