### PR TITLE
Arabic enhancements

### DIFF
--- a/languages/SMW_Magic.php
+++ b/languages/SMW_Magic.php
@@ -3,6 +3,7 @@
 /**
  * Magic words
  *
+ * @author أحمد غربية <ahmad@arabdigitalexpression.org>
  * @file
  * @ingroup Extensions
  * @ingroup SMWLanguage
@@ -39,14 +40,14 @@ $magicWords['ar'] = array(
 	'ask' => array( 0, 'سؤال' ),
 	'show' => array( 0, 'عرض' ),
 	'info' => array( 0, 'معلومات' ),
-	'concept' => array( 0, 'مبدأ' ),
+	'concept' => array( 0, 'مفهوم' ),
 	'subobject' => array( 0, 'كائن_فرعي' ),
-	'smwdoc' => array( 0, 'توثيق_سمو' ),
+	'smwdoc' => array( 0, 'وثائق_سمو' ),
 	'set' => array( 0, 'مجموعة' ),
 	'set_recurring_event' => array( 0, 'ضبط_حدث_متكرر' ),
-	'declare' => array( 0, 'إعلان' ),
-	'SMW_NOFACTBOX' => array( 0, '__لا_صندوق_حقيقة__' ),
-	'SMW_SHOWFACTBOX' => array( 0, '__عرض_صندوق_الحقيقة__' ),
+	'declare' => array( 0, 'إقرار' ),
+	'SMW_NOFACTBOX' => array( 0, '__لا_صندوق_حقائق__' ),
+	'SMW_SHOWFACTBOX' => array( 0, '__عرض_صندوق_الحقائق__' ),
 );
 
 /** Egyptian Arabic (مصرى) */


### PR DESCRIPTION
Unified on "مفهوم" instead of "مبدأ" for "Concept";
"وثائق" instead of "توثيق" for "documentation" as the latter is used for "certification";
Clearer Arabic wording for factbox magic;