### PR TITLE
Add DeferredCallableUpdate::markAsPending, refs #1421, #1626, #1627

### DIFF
--- a/includes/ParserData.php
+++ b/includes/ParserData.php
@@ -263,6 +263,8 @@ class ParserData {
 	}
 
 	/**
+	 * @private This method is not for public use
+	 *
 	 * @since 1.9
 	 *
 	 * @return boolean
@@ -275,9 +277,11 @@ class ParserData {
 			$this->getUpdateJobState()
 		);
 
+		DeferredCallableUpdate::releasePendingUpdates();
+
 		if ( $deferredUpdate ) {
 			$deferredCallableUpdate = ApplicationFactory::getInstance()->newDeferredCallableUpdate( function() use( $storeUpdater ) {
-				wfDebugLog( 'smw', 'DeferredCallableUpdate on updateStore' );
+				wfDebugLog( 'smw', 'DeferredCallableUpdate on ParserData::updateStore' );
 				$storeUpdater->doUpdate();
 			} );
 

--- a/src/SQLStore/QueryDependency/QueryDependencyLinksStore.php
+++ b/src/SQLStore/QueryDependency/QueryDependencyLinksStore.php
@@ -258,6 +258,9 @@ class QueryDependencyLinksStore {
 			$dependencyLinksTableUpdater->doUpdate();
 		} );
 
+		// https://www.mediawiki.org/wiki/Manual:$wgCommandLineMode
+		// Indicates whether MW is running in command-line mode.
+		$deferredCallableUpdate->markAsPending( $GLOBALS['wgCommandLineMode'] );
 		$deferredCallableUpdate->enabledDeferredUpdate( true );
 
 		if ( $sid > 0 ) {

--- a/tests/phpunit/TestEnvironment.php
+++ b/tests/phpunit/TestEnvironment.php
@@ -4,6 +4,7 @@ namespace SMW\Tests;
 
 use SMW\ApplicationFactory;
 use SMW\DataValueFactory;
+use SMW\DeferredCallableUpdate;
 use SMW\Store;
 use SMW\Tests\Utils\UtilityFactory;
 
@@ -46,6 +47,7 @@ class TestEnvironment {
 	 * @since 2.4
 	 */
 	public static function executePendingDeferredUpdates() {
+		DeferredCallableUpdate::releasePendingUpdates();
 		\DeferredUpdates::doUpdates();
 	}
 
@@ -53,6 +55,7 @@ class TestEnvironment {
 	 * @since 2.4
 	 */
 	public static function clearPendingDeferredUpdates() {
+		DeferredCallableUpdate::releasePendingUpdates();
 		\DeferredUpdates::clearPendingUpdates();
 	}
 

--- a/tests/phpunit/Unit/DeferredCallableUpdateTest.php
+++ b/tests/phpunit/Unit/DeferredCallableUpdateTest.php
@@ -64,6 +64,34 @@ class DeferredCallableUpdateTest extends \PHPUnit_Framework_TestCase {
 		$this->testEnvironment->executePendingDeferredUpdates();
 	}
 
+	public function testWaitableUpdate() {
+
+		$this->testEnvironment->clearPendingDeferredUpdates();
+
+		$test = $this->getMockBuilder( '\stdClass' )
+			->disableOriginalConstructor()
+			->setMethods( array( 'doTest' ) )
+			->getMock();
+
+		$test->expects( $this->once() )
+			->method( 'doTest' );
+
+		$callback = function() use ( $test ) {
+			$test->doTest();
+		};
+
+		$instance = new DeferredCallableUpdate(
+			$callback
+		);
+
+		$instance->markAsPending( true );
+		$instance->pushToDeferredUpdateList();
+
+		$instance->releasePendingUpdates();
+
+		$this->testEnvironment->executePendingDeferredUpdates();
+	}
+
 	public function testUpdateWithDisabledDeferredUpdate() {
 
 		$test = $this->getMockBuilder( '\stdClass' )

--- a/tests/phpunit/Unit/SQLStore/QueryDependency/QueryDependencyLinksStoreTest.php
+++ b/tests/phpunit/Unit/SQLStore/QueryDependency/QueryDependencyLinksStoreTest.php
@@ -2,7 +2,7 @@
 
 namespace SMW\Tests\SQLStore\QueryDependency;
 
-use SMW\ApplicationFactory;
+use SMW\Tests\TestEnvironment;
 use SMW\DIWikiPage;
 use SMW\SQLStore\QueryDependency\QueryDependencyLinksStore;
 use SMW\SQLStore\QueryDependency\EntityIdListRelevanceDetectionFilter;
@@ -19,23 +19,24 @@ use SMW\SQLStore\SQLStore;
  */
 class QueryDependencyLinksStoreTest extends \PHPUnit_Framework_TestCase {
 
-	private $applicationFactory;
 	private $store;
+	private $testEnvironment;
 
 	protected function setUp() {
 		parent::setUp();
 
-		$this->applicationFactory = ApplicationFactory::getInstance();
+		$this->testEnvironment = new TestEnvironment();
 
 		$this->store = $this->getMockBuilder( '\SMW\Store' )
 			->disableOriginalConstructor()
 			->getMockForAbstractClass();
 
-		$this->applicationFactory->registerObject( 'Store', $this->store );
+		$this->testEnvironment->registerObject( 'Store', $this->store );
 	}
 
 	protected function tearDown() {
-		$this->applicationFactory->clear();
+		$this->testEnvironment->tearDown();
+		$this->testEnvironment->clearPendingDeferredUpdates();
 
 		parent::tearDown();
 	}
@@ -271,6 +272,10 @@ class QueryDependencyLinksStoreTest extends \PHPUnit_Framework_TestCase {
 			->disableOriginalConstructor()
 			->getMock();
 
+		$queryResultDependencyListResolver->expects( $this->any() )
+			->method( 'getDependencyListByLateRetrieval' )
+			->will( $this->returnValue( array() ) );
+
 		$this->assertNull(
 			$instance->doUpdateDependenciesBy( $queryResultDependencyListResolver )
 		);
@@ -312,6 +317,10 @@ class QueryDependencyLinksStoreTest extends \PHPUnit_Framework_TestCase {
 		$queryResultDependencyListResolver = $this->getMockBuilder( '\SMW\SQLStore\QueryDependency\QueryResultDependencyListResolver' )
 			->disableOriginalConstructor()
 			->getMock();
+
+		$queryResultDependencyListResolver->expects( $this->any() )
+			->method( 'getDependencyListByLateRetrieval' )
+			->will( $this->returnValue( array() ) );
 
 		$queryResultDependencyListResolver->expects( $this->once() )
 			->method( 'getDependencyList' )
@@ -356,6 +365,10 @@ class QueryDependencyLinksStoreTest extends \PHPUnit_Framework_TestCase {
 		$queryResultDependencyListResolver = $this->getMockBuilder( '\SMW\SQLStore\QueryDependency\QueryResultDependencyListResolver' )
 			->disableOriginalConstructor()
 			->getMock();
+
+		$queryResultDependencyListResolver->expects( $this->any() )
+			->method( 'getDependencyListByLateRetrieval' )
+			->will( $this->returnValue( array() ) );
 
 		$queryResultDependencyListResolver->expects( $this->any() )
 			->method( 'getSubject' )
@@ -416,6 +429,10 @@ class QueryDependencyLinksStoreTest extends \PHPUnit_Framework_TestCase {
 		$queryResultDependencyListResolver = $this->getMockBuilder( '\SMW\SQLStore\QueryDependency\QueryResultDependencyListResolver' )
 			->disableOriginalConstructor()
 			->getMock();
+
+		$queryResultDependencyListResolver->expects( $this->any() )
+			->method( 'getDependencyListByLateRetrieval' )
+			->will( $this->returnValue( array() ) );
 
 		$queryResultDependencyListResolver->expects( $this->any() )
 			->method( 'getSubject' )
@@ -498,6 +515,10 @@ class QueryDependencyLinksStoreTest extends \PHPUnit_Framework_TestCase {
 		$queryResultDependencyListResolver = $this->getMockBuilder( '\SMW\SQLStore\QueryDependency\QueryResultDependencyListResolver' )
 			->disableOriginalConstructor()
 			->getMock();
+
+		$queryResultDependencyListResolver->expects( $this->any() )
+			->method( 'getDependencyListByLateRetrieval' )
+			->will( $this->returnValue( array() ) );
 
 		$queryResultDependencyListResolver->expects( $this->any() )
 			->method( 'getSubject' )


### PR DESCRIPTION
MW's `DeferredUpdates::addUpdate` pushes updates into direct execution when `wgCommandLineMode` is enabled which can interfere with the expected update order.

 refs #1421, #1626, #1627