### PR TITLE
Enforce enableSemantics

### DIFF
--- a/SemanticMediaWiki.settings.php
+++ b/SemanticMediaWiki.settings.php
@@ -37,14 +37,20 @@ $GLOBALS['smwgExtraneousLanguageFileDir'] = __DIR__ . '/languages';
 
 ###
 # Semantic MediaWiki's operational state
+#
+# It is expected that enableSemantics() is used to enable SMW otherwise it is
+# disabled by default. disableSemantics() will also set the state to disabled.
+#
+# @since 2.4
 ##
-$GLOBALS['smwgSemanticsEnabled'] = true;
+$GLOBALS['smwgSemanticsEnabled'] = false;
 ##
 
 ###
 # CompatibilityMode is to force SMW to work with other extensions that may impact
-# performance in an unanticipated way.
+# performance in an unanticipated way or may contain potential incompatibilities.
 #
+# @since 2.4
 ##
 $GLOBALS['smwgEnabledCompatibilityMode'] = false;
 ##

--- a/includes/GlobalFunctions.php
+++ b/includes/GlobalFunctions.php
@@ -224,6 +224,8 @@ function enableSemantics( $namespace = null, $complete = false ) {
 		$smwgNamespace = $namespace;
 	}
 
+	$GLOBALS['smwgSemanticsEnabled'] = true;
+
 	return true;
 }
 

--- a/includes/Setup.php
+++ b/includes/Setup.php
@@ -90,7 +90,7 @@ final class Setup {
 			Settings::newFromGlobals( $this->globalVars )
 		);
 
-		if ( CompatibilityMode::requiresCompatibilityMode() ) {
+		if ( CompatibilityMode::requiresCompatibilityMode() || CompatibilityMode::extensionNotEnabled() ) {
 			CompatibilityMode::disableSemantics();
 		}
 	}

--- a/maintenance/rebuildConceptCache.php
+++ b/maintenance/rebuildConceptCache.php
@@ -112,8 +112,8 @@ class RebuildConceptCache extends \Maintenance {
 	 */
 	public function execute() {
 
-		if ( !defined( 'SMW_VERSION' ) ) {
-			$this->reportMessage( "You need to have SMW enabled in order to run the maintenance script!\n\n" );
+		if ( !defined( 'SMW_VERSION' ) || !$GLOBALS['smwgSemanticsEnabled'] ) {
+			$this->reportMessage( "\nYou need to have SMW enabled in order to run the maintenance script!\n" );
 			return false;
 		}
 

--- a/maintenance/rebuildData.php
+++ b/maintenance/rebuildData.php
@@ -112,8 +112,8 @@ class RebuildData extends \Maintenance {
 	 */
 	public function execute() {
 
-		if ( !defined( 'SMW_VERSION' ) ) {
-			$this->reportMessage( "You need to have SMW enabled in order to run the maintenance script!\n\n" );
+		if ( !defined( 'SMW_VERSION' ) || !$GLOBALS['smwgSemanticsEnabled'] ) {
+			$this->reportMessage( "\nYou need to have SMW enabled in order to run the maintenance script!\n" );
 			return false;
 		}
 

--- a/maintenance/rebuildPropertyStatistics.php
+++ b/maintenance/rebuildPropertyStatistics.php
@@ -30,8 +30,8 @@ class RebuildPropertyStatistics extends \Maintenance {
 	 */
 	public function execute() {
 
-		if ( !defined( 'SMW_VERSION' ) ) {
-			$this->output( "You need to have SMW enabled in order to use this maintenance script!\n\n" );
+		if ( !defined( 'SMW_VERSION' ) || !$GLOBALS['smwgSemanticsEnabled'] ) {
+			$this->output( "\nYou need to have SMW enabled in order to use this maintenance script!\n" );
 			exit;
 		}
 

--- a/maintenance/setupStore.php
+++ b/maintenance/setupStore.php
@@ -76,8 +76,8 @@ class SetupStore extends \Maintenance {
 	public function execute() {
 		// TODO It would be good if this script would work with SMW not being enable (yet).
 		// Then one could setup the store without first enabling SMW (which will break the wiki until the store is setup).
-		if ( !defined( 'SMW_VERSION' ) ) {
-			$this->output( "You need to have SMW enabled in order to use this maintenance script!\n\n" );
+		if ( !defined( 'SMW_VERSION' ) || !$GLOBALS['smwgSemanticsEnabled'] ) {
+			$this->output( "\nYou need to have SMW enabled in order to use this maintenance script!\n" );
 			exit;
 		}
 

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -59,6 +59,7 @@
         </whitelist>
     </filter>
     <php>
+       <var name="smwgSemanticsEnabled" value="true"/>
        <var name="wgUseFileCache" value="false"/>
        <var name="smwgSparqlDefaultGraph" value="http://example.org/phpunit-testrun"/>
        <var name="smwgValueLookupCacheType" value="hash"/>

--- a/src/CompatibilityMode.php
+++ b/src/CompatibilityMode.php
@@ -24,7 +24,24 @@ class CompatibilityMode {
 	 * @return boolean
 	 */
 	public static function requiresCompatibilityMode() {
-		return !$GLOBALS['smwgEnabledCompatibilityMode'] && defined( 'CARGO_VERSION' );
+		return !$GLOBALS['smwgEnabledCompatibilityMode'] && ( defined( 'CARGO_VERSION' ) ||  defined( 'WB_VERSION' ) );
+	}
+
+	/**
+	 * @since 2.4
+	 *
+	 * @return boolean
+	 */
+	public static function extensionNotEnabled() {
+
+		if ( !defined( 'MW_PHPUNIT_TEST' ) ) {
+			return !$GLOBALS['smwgSemanticsEnabled'];
+		}
+
+		$GLOBALS['smwgSemanticsEnabled'] = true;
+		ApplicationFactory::getInstance()->getSettings()->set( 'smwgSemanticsEnabled', true );
+
+		return false;
 	}
 
 	/**

--- a/tests/phpunit/Unit/CompatibilityModeTest.php
+++ b/tests/phpunit/Unit/CompatibilityModeTest.php
@@ -23,4 +23,12 @@ class CompatibilityModeTest extends \PHPUnit_Framework_TestCase {
 		);
 	}
 
+	public function testExtensionNotEnabled() {
+
+		$this->assertInternalType(
+			'boolean',
+			CompatibilityMode::extensionNotEnabled()
+		);
+	}
+
 }


### PR DESCRIPTION
`enableSemantics`[0] is required to make sure NS are correctly set and avoid issues as described in #1424.

refs #1398 

[0] https://www.semantic-mediawiki.org/wiki/Help:EnableSemantics