### PR TITLE
Add ChangeOp

### DIFF
--- a/src/SQLStore/ChangeOp/FieldChangeOp.php
+++ b/src/SQLStore/ChangeOp/FieldChangeOp.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace SMW\SQLStore\ChangeOp;
+
+use InvalidArgumentException;
+
+/**
+ * @license GNU GPL v2+
+ * @since 2.4
+ *
+ * @author mwjames
+ */
+class FieldChangeOp {
+
+	/**
+	 * @var array
+	 */
+	private $changeOp = array();
+
+	/**
+	 * @since 2.4
+	 */
+	public function __construct( array $changeOp = array() ) {
+		$this->changeOp = $changeOp;
+	}
+
+	/**
+	 * @since 2.4
+	 *
+	 * @param string $key
+	 * @param mixed $value
+	 */
+	public function set( $key, $value ) {
+		$this->changeOp[$key] = $value;
+	}
+
+	/**
+	 * @since 2.4
+	 *
+	 * @param string $key
+	 *
+	 * @return boolean
+	 */
+	public function has( $key ) {
+		return isset( $this->changeOp[$key] ) || array_key_exists( $key, $this->changeOp );
+	}
+
+	/**
+	 * @since 2.4
+	 *
+	 * @param string $key
+	 *
+	 * @return string
+	 * @throws InvalidArgumentException
+	 */
+	public function get( $key ) {
+
+		if ( $this->has( $key ) ) {
+			return $this->changeOp[$key];
+		}
+
+		throw new InvalidArgumentException( "{$key} is an unregistered field" );
+	}
+
+	/**
+	 * @since 2.4
+	 *
+	 * @return array
+	 */
+	public function getChangeOp() {
+		return $this->changeOp;
+	}
+
+}
+

--- a/src/SQLStore/ChangeOp/TableChangeOp.php
+++ b/src/SQLStore/ChangeOp/TableChangeOp.php
@@ -1,0 +1,100 @@
+<?php
+
+namespace SMW\SQLStore\ChangeOp;
+
+/**
+ * @license GNU GPL v2+
+ * @since 2.4
+ *
+ * @author mwjames
+ */
+class TableChangeOp {
+
+	const OP_INSERT = 'insert';
+	const OP_DELETE = 'delete';
+
+	/**
+	 * @var string
+	 */
+	private $tableName;
+
+	/**
+	 * @var array
+	 */
+	private $changeOps;
+
+	/**
+	 * @since 2.4
+	 *
+	 * @param string $tableName
+	 * @param array $changeOps
+	 */
+	public function __construct( $tableName, array $changeOps ) {
+		$this->tableName = $tableName;
+		$this->changeOps = $changeOps;
+	}
+
+	/**
+	 * @since 2.4
+	 *
+	 * @return string
+	 */
+	public function getTableName() {
+		return $this->tableName;
+	}
+
+	/**
+	 * @since 2.4
+	 *
+	 * @return boolean
+	 */
+	public function isFixedPropertyOp() {
+		return isset( $this->changeOps['property'] );
+	}
+
+	/**
+	 * @since 2.4
+	 *
+	 * @param string $id
+	 *
+	 * @return null|string
+	 */
+	public function getFixedPropertyValueFor( $id ) {
+		return $this->isFixedPropertyOp() && isset( $this->changeOps['property'][$id] ) ? $this->changeOps['property'][$id] : null;
+	}
+
+	/**
+	 * @since 2.4
+	 *
+	 * @param string $opType
+	 *
+	 * @return boolean
+	 */
+	public function hasChangeOp( $opType ) {
+		return isset( $this->changeOps[$opType] );
+	}
+
+	/**
+	 * @since 2.4
+	 *
+	 * @param string $opType
+	 *
+	 * @return FieldChangeOp[]|[]
+	 */
+	public function getFieldChangeOps( $opType ) {
+
+		if ( !$this->hasChangeOp( $opType ) ) {
+			return array();
+		}
+
+		$fieldOps = array();
+
+		foreach ( $this->changeOps[$opType] as $op ) {
+			$fieldOps[] = new FieldChangeOp( $op );
+		}
+
+		return $fieldOps;
+	}
+
+}
+

--- a/src/SQLStore/CompositePropertyTableDiffIterator.php
+++ b/src/SQLStore/CompositePropertyTableDiffIterator.php
@@ -2,6 +2,7 @@
 
 namespace SMW\SQLStore;
 
+use SMW\SQLStore\ChangeOp\TableChangeOp;
 use ArrayIterator;
 use IteratorAggregate;
 
@@ -70,6 +71,27 @@ class CompositePropertyTableDiffIterator implements IteratorAggregate {
 	 */
 	public function getFixedPropertyRecords() {
 		return $this->fixedPropertyRecords;
+	}
+
+	/**
+	 * ChangeOp (TableChangeOp/FieldChangeOp) representation of the composite
+	 * diff.
+	 *
+	 * @since 2.4
+	 *
+	 * @param string|null $table
+	 *
+	 * @return TableChangeOp[]|[]
+	 */
+	public function getTableChangeOps( $table = null ) {
+
+		$tableChangeOps = array();
+
+		foreach ( $this->getOrderedDiffByTable( $table ) as $tableName => $diff ) {
+			$tableChangeOps[] = new TableChangeOp( $tableName, $diff );
+		}
+
+		return $tableChangeOps;
 	}
 
 	/**

--- a/src/SQLStore/QueryDependency/QueryDependencyLinksStore.php
+++ b/src/SQLStore/QueryDependency/QueryDependencyLinksStore.php
@@ -96,18 +96,22 @@ class QueryDependencyLinksStore {
 			new DIProperty( '_ASK' )
 		);
 
-		$diff = $compositePropertyTableDiffIterator->getOrderedDiffByTable( $tableName );
+		$tableChangeOps = $compositePropertyTableDiffIterator->getTableChangeOps( $tableName );
 
 		// Remove any dependency for queries that are no longer used
-		if ( isset( $diff[$tableName]['delete'] ) ) {
+		foreach ( $tableChangeOps as $tableChangeOp ) {
+
+			if ( !$tableChangeOp->hasChangeOp( 'delete' ) ) {
+				continue;
+			}
 
 			$deleteIdList = array();
 
-			foreach ( $diff[$tableName]['delete'] as $delete ) {
-				$deleteIdList[] = $delete['o_id'];
+			foreach ( $tableChangeOp->getFieldChangeOps( 'delete' ) as $fieldChangeOp ) {
+				$deleteIdList[] = $fieldChangeOp->get( 'o_id' );
 			}
 
-			$this->dependencyLinksTableUpdater->deleteDependenciesFromList(  $deleteIdList );
+			$this->dependencyLinksTableUpdater->deleteDependenciesFromList( $deleteIdList );
 		}
 
 		// Dispatch any event registered earlier during the QueryResult processing

--- a/tests/phpunit/Unit/MediaWiki/Hooks/HookRegistryTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Hooks/HookRegistryTest.php
@@ -910,6 +910,10 @@ class HookRegistryTest extends \PHPUnit_Framework_TestCase {
 			->will( $this->returnValue( array() ) );
 
 		$compositePropertyTableDiffIterator->expects( $this->any() )
+			->method( 'getTableChangeOps' )
+			->will( $this->returnValue( array() ) );
+
+		$compositePropertyTableDiffIterator->expects( $this->any() )
 			->method( 'getFixedPropertyRecords' )
 			->will( $this->returnValue( array() ) );
 

--- a/tests/phpunit/Unit/SQLStore/ChangeOp/FieldChangeOpTest.php
+++ b/tests/phpunit/Unit/SQLStore/ChangeOp/FieldChangeOpTest.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace SMW\Tests\SQLStore\FieldChangeOp;
+
+use SMW\SQLStore\ChangeOp\FieldChangeOp;
+
+/**
+ * @covers \SMW\SQLStore\ChangeOp\FieldChangeOp
+ * @group semantic-mediawiki
+ *
+ * @license GNU GPL v2+
+ * @since 2.4
+ *
+ * @author mwjames
+ */
+class FieldChangeOpTest extends \PHPUnit_Framework_TestCase {
+
+	public function testCanConstruct() {
+
+		$this->assertInstanceOf(
+			'\SMW\SQLStore\ChangeOp\FieldChangeOp',
+			new FieldChangeOp()
+		);
+	}
+
+	public function testChangeOp() {
+
+		$changeOp = array(
+			's_id' => 462,
+			'o_serialized' => '1/2016/6/10/2/3/31/0',
+			'o_sortkey' => '2457549.5857755',
+		);
+
+		$instance = new FieldChangeOp(
+			$changeOp
+		);
+
+		$this->assertFalse(
+			$instance->has( 'foo' )
+		);
+
+		$this->assertSame(
+			'1/2016/6/10/2/3/31/0',
+			$instance->get( 'o_serialized' )
+		);
+
+		$instance->set( 'foo', 'bar' );
+
+		$this->assertSame(
+			'bar',
+			$instance->get( 'foo' )
+		);
+	}
+
+	public function testInvalidGetRequestThrowsException() {
+
+		$instance = new FieldChangeOp();
+
+		$this->setExpectedException( 'InvalidArgumentException' );
+		$instance->get( 'o_serialized' );
+	}
+
+}

--- a/tests/phpunit/Unit/SQLStore/ChangeOp/TableChangeOpTest.php
+++ b/tests/phpunit/Unit/SQLStore/ChangeOp/TableChangeOpTest.php
@@ -1,0 +1,115 @@
+<?php
+
+namespace SMW\Tests\SQLStore\TableChangeOp;
+
+use SMW\SQLStore\ChangeOp\TableChangeOp;
+
+/**
+ * @covers \SMW\SQLStore\ChangeOp\TableChangeOp
+ * @group semantic-mediawiki
+ *
+ * @license GNU GPL v2+
+ * @since 2.4
+ *
+ * @author mwjames
+ */
+class TableChangeOpTest extends \PHPUnit_Framework_TestCase {
+
+	public function testCanConstruct() {
+
+		$this->assertInstanceOf(
+			'\SMW\SQLStore\ChangeOp\TableChangeOp',
+			new TableChangeOp( 'foo', array() )
+		);
+	}
+
+	public function testEmptyOps() {
+
+		$diff = array();
+
+		$instance = new TableChangeOp(
+			'foo',
+			$diff
+		);
+
+		$this->assertSame(
+			'foo',
+			$instance->getTableName()
+		);
+
+		$this->assertFalse(
+			$instance->isFixedPropertyOp()
+		);
+
+		$this->assertFalse(
+			$instance->hasChangeOp( TableChangeOp::OP_INSERT )
+		);
+
+		$this->assertNull(
+			$instance->getFixedPropertyValueFor( 'key' )
+		);
+
+		$this->assertInternalType(
+			'array',
+			$instance->getFieldChangeOps( 'insert' )
+		);
+	}
+
+	public function testFixedPropertyOps() {
+
+		$diff = array(
+		'property' =>
+			array(
+				'key' => '_MDAT',
+				'p_id' => 29,
+			),
+		'insert' =>
+			array(
+			0 =>
+				array(
+					's_id' => 462,
+					'o_serialized' => '1/2016/6/10/2/3/31/0',
+					'o_sortkey' => '2457549.5857755',
+				),
+			),
+		'delete' =>
+			array(
+				0 =>
+				array(
+				's_id' => 462,
+				'o_serialized' => '1/2016/6/10/2/1/0/0',
+				'o_sortkey' => '2457549.5840278',
+				),
+			),
+		);
+
+		$instance = new TableChangeOp(
+			'foo',
+			$diff
+		);
+
+		$this->assertSame(
+			'foo',
+			$instance->getTableName()
+		);
+
+		$this->assertTrue(
+			$instance->isFixedPropertyOp()
+		);
+
+		$this->assertTrue(
+			$instance->hasChangeOp( TableChangeOp::OP_INSERT )
+		);
+
+		$this->assertSame(
+			'_MDAT',
+			$instance->getFixedPropertyValueFor( 'key' )
+		);
+
+		$this->assertInternalType(
+			'array',
+			$instance->getFieldChangeOps( 'insert' )
+		);
+	}
+
+}

--- a/tests/phpunit/Unit/SQLStore/CompositePropertyTableDiffIteratorTest.php
+++ b/tests/phpunit/Unit/SQLStore/CompositePropertyTableDiffIteratorTest.php
@@ -53,6 +53,68 @@ class CompositePropertyTableDiffIteratorTest extends \PHPUnit_Framework_TestCase
 		);
 	}
 
+	public function testGetTableChangeOps() {
+
+		$diff = array(
+			0 => array(
+				'insert' => array(
+					'smw_di_number' => array(
+						0 => array(
+							's_id' => 3668,
+							'p_id' => 61,
+							'o_serialized' => '123',
+							'o_sortkey' => '123',
+						),
+						1 => array(
+							's_id' => 3668,
+							'p_id' => 62,
+							'o_serialized' => '1234',
+							'o_sortkey' => '1234',
+						),
+					),
+					'smw_fpt_mdat' => array(
+						0 => array(
+							's_id' => 3668,
+							'o_serialized' => '1/2015/8/16/9/28/39',
+							'o_sortkey' => '2457250.8948958',
+						),
+					),
+				),
+				'delete' => array(
+					'smw_di_number' => array(),
+					'smw_fpt_mdat'  => array(),
+				)
+			)
+		);
+
+		$instance = new CompositePropertyTableDiffIterator(
+			$diff
+		);
+
+		$this->assertCount(
+			1,
+			$instance->getTableChangeOps( 'smw_di_number' )
+		);
+
+		$this->assertInternalType(
+			'array',
+			$instance->getTableChangeOps()
+		);
+	}
+
+	public function testTryToGetTableChangeOpForSingleTable() {
+
+		$diff = array();
+
+		$instance = new CompositePropertyTableDiffIterator(
+			$diff
+		);
+
+		$this->assertEmpty(
+			$instance->getTableChangeOps( 'smw_di_number' )
+		);
+	}
+
 	public function diffDataProvider() {
 
 		$provider[] = array(

--- a/tests/phpunit/Unit/SQLStore/QueryDependency/QueryDependencyLinksStoreTest.php
+++ b/tests/phpunit/Unit/SQLStore/QueryDependency/QueryDependencyLinksStoreTest.php
@@ -75,6 +75,10 @@ class QueryDependencyLinksStoreTest extends \PHPUnit_Framework_TestCase {
 			->disableOriginalConstructor()
 			->getMock();
 
+		$compositePropertyTableDiffIterator->expects( $this->once() )
+			->method( 'getTableChangeOps' )
+			->will( $this->returnValue( array() ) );
+
 		$dependencyLinksTableUpdater = $this->getMockBuilder( '\SMW\SQLStore\QueryDependency\DependencyLinksTableUpdater' )
 			->disableOriginalConstructor()
 			->getMock();


### PR DESCRIPTION
At least four places use/have access to `CompositePropertyTableDiffIterator` and instead of throwing around arrays, ChangeOp (TableChangeOp/FieldChangeOp) allows for a bit more control over how to analyze changeOp diffs returned from the DB.

refs #1108