### PR TITLE
Fixed ref to MonolingualTextValue

### DIFF
--- a/src/DataValues/MonolingualTextValue.php
+++ b/src/DataValues/MonolingualTextValue.php
@@ -54,7 +54,6 @@ class MonolingualTextValue extends DataValue {
 	 */
 	public function __construct( $typeid = '' ) {
 		parent::__construct( '_mlt_rec' );
-		$this->monolingualTextValueParser = ValueParserFactory::getInstance()->newMonolingualTextValueParser();
 		$this->dataValueFactory = DataValueFactory::getInstance();
 	}
 
@@ -138,7 +137,7 @@ class MonolingualTextValue extends DataValue {
 	 * @return array
 	 */
 	public function getValuesFromString( $userValue ) {
-		return $this->monolingualTextValueParser->parse( $userValue );
+		return $this->getValueParser()->parse( $userValue );
 	}
 
 	/**
@@ -312,6 +311,15 @@ class MonolingualTextValue extends DataValue {
 		$languageCodeValue->setUserValue( $languageCode );
 
 		return $languageCodeValue;
+	}
+
+	private function getValueParser() {
+
+		if ( $this->monolingualTextValueParser === null ) {
+			$this->monolingualTextValueParser = ValueParserFactory::getInstance()->newMonolingualTextValueParser();
+		}
+
+		return $this->monolingualTextValueParser;
 	}
 
 }

--- a/src/Query/DescriptionFactory.php
+++ b/src/Query/DescriptionFactory.php
@@ -2,7 +2,7 @@
 
 namespace SMW\Query;
 
-use SMW\DataValue\MonolingualTextValue;
+use SMW\DataValues\MonolingualTextValue;
 use SMW\DIProperty;
 use SMW\DIWikiPage;
 use SMW\Query\Language\ClassDescription;

--- a/tests/phpunit/Unit/Query/DescriptionFactoryTest.php
+++ b/tests/phpunit/Unit/Query/DescriptionFactoryTest.php
@@ -225,4 +225,35 @@ class DescriptionFactoryTest extends \PHPUnit_Framework_TestCase {
 		);
 	}
 
+	public function testCanConstructDescriptionFromMonolingualTextValue() {
+
+		$containerSemanticData = $this->getMockBuilder( '\SMWContainerSemanticData' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$containerSemanticData->expects( $this->atLeastOnce() )
+			->method( 'getPropertyValues' )
+			->will( $this->returnValue( array( $this->dataItemFactory->newDIBlob( 'Bar' ) ) ) );
+
+		$dataValue = $this->getMockBuilder( '\SMW\DataValues\MonolingualTextValue' )
+			->disableOriginalConstructor()
+			->setMethods( array( 'isValid', 'getProperty', 'getDataItem' ) )
+			->getMock();
+
+		$dataValue->expects( $this->atLeastOnce() )
+			->method( 'isValid' )
+			->will( $this->returnValue( true ) );
+
+		$dataValue->expects( $this->atLeastOnce() )
+			->method( 'getDataItem' )
+			->will( $this->returnValue( $this->dataItemFactory->newDIContainer( $containerSemanticData ) ) );
+
+		$instance = new DescriptionFactory();
+
+		$this->assertInstanceOf(
+			'SMW\Query\Language\Conjunction',
+			$instance->newFromDataValue( $dataValue )
+		);
+	}
+
 }


### PR DESCRIPTION
NOTE: this code is clearly not tested, as execution of the part
that refs MonolingualTextValue should result in an error before
this change.