### PR TITLE
Respect $smwgHistoricTypeNamespace (removal of the now-unused Type: n…

### DIFF
--- a/includes/NamespaceManager.php
+++ b/includes/NamespaceManager.php
@@ -64,8 +64,6 @@ class NamespaceManager {
 	 */
 	public static function getCanonicalNames() {
 
-		global $smwgHistoricTypeNamespace;
-
 		$canonicalNames = array(
 			SMW_NS_PROPERTY      => 'Property',
 			SMW_NS_PROPERTY_TALK => 'Property_talk',
@@ -75,7 +73,7 @@ class NamespaceManager {
 			SMW_NS_CONCEPT_TALK  => 'Concept_talk'
 		);
 
-		if ( !$smwgHistoricTypeNamespace ) {
+		if ( !array_key_exists( 'smwgHistoricTypeNamespace', $GLOBALS ) || !$GLOBALS['smwgHistoricTypeNamespace'] ) {
 			unset( $canonicalNames[SMW_NS_TYPE] );
 			unset( $canonicalNames[SMW_NS_TYPE_TALK] );
 		}

--- a/includes/NamespaceManager.php
+++ b/includes/NamespaceManager.php
@@ -64,6 +64,8 @@ class NamespaceManager {
 	 */
 	public static function getCanonicalNames() {
 
+		global $smwgHistoricTypeNamespace;
+
 		$canonicalNames = array(
 			SMW_NS_PROPERTY      => 'Property',
 			SMW_NS_PROPERTY_TALK => 'Property_talk',
@@ -72,6 +74,11 @@ class NamespaceManager {
 			SMW_NS_CONCEPT       => 'Concept',
 			SMW_NS_CONCEPT_TALK  => 'Concept_talk'
 		);
+
+		if ( !$smwgHistoricTypeNamespace ) {
+			unset( $canonicalNames[SMW_NS_TYPE] );
+			unset( $canonicalNames[SMW_NS_TYPE_TALK] );
+		}
 
 		return $canonicalNames;
 	}

--- a/tests/phpunit/includes/NamespaceManagerTest.php
+++ b/tests/phpunit/includes/NamespaceManagerTest.php
@@ -86,9 +86,28 @@ class NamespaceManagerTest extends \PHPUnit_Framework_TestCase {
 		);
 
 		$this->assertCount(
+			4,
+			$result
+		);
+	}
+
+	public function testGetCanonicalNamesWithTypeNamespace() {
+
+		$GLOBALS['smwgHistoricTypeNamespace'] = true;
+
+		$result = NamespaceManager::getCanonicalNames();
+
+		$this->assertInternalType(
+			'array',
+			$result
+		);
+
+		$this->assertCount(
 			6,
 			$result
 		);
+
+		unset( $GLOBALS['smwgHistoricTypeNamespace'] );
 	}
 
 	public function testBuildNamespaceIndex() {


### PR DESCRIPTION
…amespace)

This was introduced in dea5dd0d (2011-05-22), but the namespace Type: still appears,
due to the fact it is registered in the hook CanonicalNamespaces.

This commit removes the last place where this namespace is made visible for the end
user: now users can no more access to it, but content already saved is kept and they
can made it visible by adding:

    $wgExtraNamespaces[SMW_NS_TYPE] = 'Type';
    $wgExtraNamespaces[SMW_NS_TYPE_TALK] = 'Type_talk';