### PR TITLE
Pull up getQueryMode from FileExportPrinters to parent class

### DIFF
--- a/includes/queryprinters/CsvResultPrinter.php
+++ b/includes/queryprinters/CsvResultPrinter.php
@@ -3,8 +3,6 @@
 namespace SMW;
 
 use Sanitizer;
-use SMWQuery;
-use SMWQueryProcessor;
 use SMWQueryResult;
 
 /**
@@ -59,10 +57,6 @@ class CsvResultPrinter extends FileExportPrinter {
 	 */
 	public function getFileName( SMWQueryResult $queryResult ) {
 		return $this->params['filename'];
-	}
-
-	public function getQueryMode( $context ) {
-		return ( $context == SMWQueryProcessor::SPECIAL_PAGE ) ? SMWQuery::MODE_INSTANCES : SMWQuery::MODE_NONE;
 	}
 
 	protected function getResultText( SMWQueryResult $res, $outputMode ) {

--- a/includes/queryprinters/DsvResultPrinter.php
+++ b/includes/queryprinters/DsvResultPrinter.php
@@ -3,8 +3,6 @@
 namespace SMW;
 
 use Sanitizer;
-use SMWQuery;
-use SMWQueryProcessor;
 use SMWQueryResult;
 
 /**
@@ -63,10 +61,6 @@ class DsvResultPrinter extends FileExportPrinter {
 	 */
 	public function getFileName( SMWQueryResult $queryResult ) {
 		return $this->fileName;
-	}
-
-	public function getQueryMode( $context ) {
-		return $context == SMWQueryProcessor::SPECIAL_PAGE ? SMWQuery::MODE_INSTANCES : SMWQuery::MODE_NONE;
 	}
 
 	public function getName() {

--- a/includes/queryprinters/FeedResultPrinter.php
+++ b/includes/queryprinters/FeedResultPrinter.php
@@ -5,9 +5,7 @@ namespace SMW;
 use FeedItem;
 use ParserOptions;
 use Sanitizer;
-use SMWDIWikipage;
-use SMWQuery;
-use SMWQueryProcessor;
+use SMWDIWikiPage;
 use SMWQueryResult;
 use TextContent;
 use Title;
@@ -62,18 +60,6 @@ final class FeedResultPrinter extends FileExportPrinter {
 	 */
 	public function outputAsFile( SMWQueryResult $queryResult, array $params ) {
 		$this->getResult( $queryResult, $params, SMW_OUTPUT_FILE );
-	}
-
-	/**
-	 * File exports use MODE_INSTANCES on special pages (so that instances are
-	 * retrieved for the export) and MODE_NONE otherwise (displaying just a download link).
-	 *
-	 * @param $mode
-	 *
-	 * @return integer
-	 */
-	public function getQueryMode( $mode ) {
-		return $mode == SMWQueryProcessor::SPECIAL_PAGE ? SMWQuery::MODE_INSTANCES : SMWQuery::MODE_NONE;
 	}
 
 	/**

--- a/includes/queryprinters/FileExportPrinter.php
+++ b/includes/queryprinters/FileExportPrinter.php
@@ -2,6 +2,8 @@
 
 namespace SMW;
 
+use SMWQuery;
+use SMWQueryProcessor;
 use SMWQueryResult;
 
 /**
@@ -60,6 +62,18 @@ abstract class FileExportPrinter extends ResultPrinter implements ExportPrinter 
 	 */
 	public function getFileName( SMWQueryResult $queryResult ) {
 		return false;
+	}
+
+	/**
+	 * File exports use MODE_INSTANCES on special pages (so that instances are
+	 * retrieved for the export) and MODE_NONE otherwise (displaying just a download link).
+	 *
+	 * @param $mode
+	 *
+	 * @return integer
+	 */
+	public function getQueryMode( $mode ) {
+		return $mode == SMWQueryProcessor::SPECIAL_PAGE ? SMWQuery::MODE_INSTANCES : SMWQuery::MODE_NONE;
 	}
 
 }

--- a/includes/queryprinters/JsonResultPrinter.php
+++ b/includes/queryprinters/JsonResultPrinter.php
@@ -2,9 +2,7 @@
 
 namespace SMW;
 
-use FormatJSON;
-use SMWQuery;
-use SMWQueryProcessor;
+use FormatJson;
 use SMWQueryResult;
 
 /**
@@ -66,18 +64,6 @@ class JsonResultPrinter extends FileExportPrinter {
 		} else {
 			return 'result.json';
 		}
-	}
-
-	/**
-	 * File exports use MODE_INSTANCES on special pages (so that instances are
-	 * retrieved for the export) and MODE_NONE otherwise (displaying just a download link).
-	 *
-	 * @param $context
-	 *
-	 * @return integer
-	 */
-	public function getQueryMode( $context ) {
-		return ( $context == SMWQueryProcessor::SPECIAL_PAGE ) ? SMWQuery::MODE_INSTANCES : SMWQuery::MODE_NONE;
 	}
 
 	/**

--- a/includes/queryprinters/RdfResultPrinter.php
+++ b/includes/queryprinters/RdfResultPrinter.php
@@ -4,8 +4,6 @@ namespace SMW;
 
 use SMW\Query\PrintRequest;
 use SMWExporter;
-use SMWQuery;
-use SMWQueryProcessor;
 use SMWQueryResult;
 use SMWRDFXMLSerializer;
 use SMWTurtleSerializer;
@@ -62,10 +60,6 @@ class RdfResultPrinter extends FileExportPrinter {
 	 */
 	public function getFileName( SMWQueryResult $queryResult ) {
 		return $this->syntax == 'turtle' ? 'result.ttl' : 'result.rdf';
-	}
-
-	public function getQueryMode( $context ) {
-		return ( $context == SMWQueryProcessor::SPECIAL_PAGE ) ? SMWQuery::MODE_INSTANCES : SMWQuery::MODE_NONE;
 	}
 
 	public function getName() {


### PR DESCRIPTION
GetQueryMode has the exact same content for all FileExportPrinters, so I pulled
it up to the parent class.

(This also fixes a bug in the SRF\Excel result format that did not have this
method and produced empty result sets.)