### PR TITLE
Keep upper/lower case on single values for approximate search, refs #1246

### DIFF
--- a/includes/datavalues/SMW_DV_WikiPage.php
+++ b/includes/datavalues/SMW_DV_WikiPage.php
@@ -109,6 +109,13 @@ class SMWWikiPageValue extends SMWDataValue {
 			$this->m_caption = $value;
 		}
 
+		// #1701 If the DV is part of a Description and an approximate search
+		// (e.g. ~foo* / ~Foo*) then use the value as-is and avoid being
+		// transformed by the Title object
+		if ( $this->getOptionValueFor( 'approximate.comparator.context' ) ) {
+			return $this->m_dataitem = new SMWDIWikiPage( $value, NS_MAIN );
+		}
+
 		if ( $value !== '' ) {
 			if ( $value[0] == '#' ) {
 				if ( is_null( $this->m_contextPage ) ) {

--- a/src/Exporter/DataItemByExpElementMatchFinder.php
+++ b/src/Exporter/DataItemByExpElementMatchFinder.php
@@ -157,10 +157,24 @@ class DataItemByExpElementMatchFinder {
 				$namespace = NS_MAIN;
 			}
 
-			$dataItem = new DIWikiPage( $dbKey, $namespace );
+			$dataItem = new DIWikiPage(
+				$this->getFittingKeyByCapitalLinks( $dbKey, $namespace ),
+				$namespace
+			);
 		}
 
 		return $dataItem;
+	}
+
+	private function getFittingKeyByCapitalLinks( $dbKey, $namespace ) {
+
+		// https://www.mediawiki.org/wiki/Manual:$wgCapitalLinks
+		// https://www.mediawiki.org/wiki/Manual:$wgCapitalLinkOverrides
+		if ( $GLOBALS['wgCapitalLinks'] || ( isset( $GLOBALS['wgCapitalLinkOverrides'][$namespace] ) && $GLOBALS['wgCapitalLinkOverrides'][$namespace] ) ) {
+			return mb_strtoupper( mb_substr( $dbKey, 0, 1 ) ) . mb_substr( $dbKey, 1 );
+		}
+
+		return $dbKey;
 	}
 
 }

--- a/src/Query/Parser/DescriptionProcessor.php
+++ b/src/Query/Parser/DescriptionProcessor.php
@@ -144,6 +144,13 @@ class DescriptionProcessor {
 		$dataValue = $this->dataValueFactory->newTypeIDValue( '_wpg', 'QP_WPG_TITLE' );
 		$dataValue->setContextPage( $this->contextPage );
 
+		// Ensure special handling for ~foo* or !~Foo* in WikiPageDataValue
+		// to capture upper/lower case
+		$dataValue->setOption(
+			'approximate.comparator.context',
+			( $chunk{0} === '~' || $chunk{0} === '!' )
+		);
+
 		$description = null;
 
 		$description = $dataValue->getQueryDescription( $chunk );

--- a/tests/phpunit/Integration/ByJsonScript/Fixtures/p-0427.json
+++ b/tests/phpunit/Integration/ByJsonScript/Fixtures/p-0427.json
@@ -1,0 +1,134 @@
+{
+	"description": "Test in-text annotation with DISPLAYTITLE / `foaf` to check on upper vs. lower case (`wgRestrictDisplayTitle`, `wgContLang=en`, `wgLang=en`)",
+	"properties": [
+		{
+			"name": "Has text",
+			"contents": "[[Has type::Text]]"
+		}
+	],
+	"subjects": [
+		{
+			"name": "Smw import foaf",
+			"namespace": "NS_MEDIAWIKI",
+			"contents": "http://xmlns.com/foaf/0.1/|[http://www.foaf-project.org/ Friend Of A Friend]\n name|Type:Text\n homepage|Type:URL\n mbox|Type:Email\n mbox_sha1sum|Type:Text\n depiction|Type:URL\n phone|Type:Text\n Person|Category\n Organization|Category\n knows|Type:Page\n member|Type:Page\n"
+		},
+		{
+			"name": "Foaf:homepage",
+			"namespace": "SMW_NS_PROPERTY",
+			"contents": "[[Imported from::foaf:homepage]] {{DISPLAYTITLE:foaf:homepage}} [[Has property description::URL representing ... @en]] [[Category:Imported vocabulary]]"
+		},
+		{
+			"name": "Example/P0427/Q0.1",
+			"contents": "{{#show: Property:Foaf:homepage |?Has property description}}"
+		},
+		{
+			"name": "Example/P0427/Q0.2",
+			"contents": "{{#ask: [[Property:+]][[Category:Imported vocabulary]] |?Has property description=Description |link=none}}"
+		},
+		{
+			"name": "Example/P0427/1",
+			"contents": "{{#subobject: |Has text=abc |display title of=ab c123 |@category=P0427 }}{{#subobject: |Has text=ABC |display title of=AB C123 |@category=P0427 }}"
+		},
+		{
+			"name": "Example/P0427/Q1.1",
+			"contents": "{{#ask: [[Category:P0427]] [[~ab c*]] |?Has text |link=none}}"
+		},
+		{
+			"name": "Example/P0427/Q1.2",
+			"contents": "{{#ask: [[Category:P0427]] [[~AB C*]] |?Has text |link=none}}"
+		},
+		{
+			"name": "Example/P0427/Q1.3",
+			"contents": "{{#ask: [[Example/P0427/1#_46f241b02fda25aabd4d52b9b141d4e7]] |?Has text |link=none}}"
+		},
+		{
+			"name": "Example/P0427/Q1.4",
+			"contents": "{{#ask: [[Category:P0427]] [[!~ab c*]] |?Has text |link=none}}"
+		},
+		{
+			"name": "Example/P0427/Q1.5",
+			"contents": "{{#ask: [[Category:P0427]] [[!~AB C*]] |?Has text |link=none}}"
+		}
+	],
+	"parser-testcases": [
+		{
+			"about": "#0 match foaf:homepage to Property:Foaf:homepage",
+			"subject": "Example/P0427/Q0.1",
+			"expected-output": {
+				"to-contain": [
+					"URL representing ... (en)"
+				]
+			}
+		},
+		{
+			"about": "#1",
+			"subject": "Example/P0427/Q0.2",
+			"expected-output": {
+				"to-contain": [
+					"<td class=\"smwtype_wpg\">Property:Foaf:homepage</td>",
+					"<td class=\"Description smwtype_mlt_rec\">URL representing ... (en)</td>"
+				]
+			}
+		},
+		{
+			"about": "#2 only match `abc*`",
+			"subject": "Example/P0427/Q1.1",
+			"expected-output": {
+				"to-contain": [
+					"<td class=\"smwtype_wpg\">Example/P0427/1#_46f241b02fda25aabd4d52b9b141d4e7</td>",
+					"<td class=\"Has-text smwtype_txt\">abc</td>"
+				]
+			}
+		},
+		{
+			"about": "#3 only match `ABC*`",
+			"subject": "Example/P0427/Q1.2",
+			"expected-output": {
+				"to-contain": [
+					"<td class=\"smwtype_wpg\">Example/P0427/1#_d0ff6c9a1d23b69a0ba5f6d737f6180a</td>",
+					"<td class=\"Has-text smwtype_txt\">ABC</td>"
+				]
+			}
+		},
+		{
+			"about": "#4 same as #2",
+			"subject": "Example/P0427/Q1.3",
+			"expected-output": {
+				"to-contain": [
+					"<td class=\"smwtype_wpg\">Example/P0427/1#_46f241b02fda25aabd4d52b9b141d4e7</td>",
+					"<td class=\"Has-text smwtype_txt\">abc</td>"
+				]
+			}
+		},
+		{
+			"about": "#5 to be reverse to #2",
+			"subject": "Example/P0427/Q1.4",
+			"expected-output": {
+				"to-contain": [
+					"<td class=\"smwtype_wpg\">Example/P0427/1#_d0ff6c9a1d23b69a0ba5f6d737f6180a</td>",
+					"<td class=\"Has-text smwtype_txt\">ABC</td>"
+				]
+			}
+		},
+		{
+			"about": "#6 to be reverse to #3",
+			"subject": "Example/P0427/Q1.5",
+			"expected-output": {
+				"to-contain": [
+					"<td class=\"smwtype_wpg\">Example/P0427/1#_46f241b02fda25aabd4d52b9b141d4e7</td>",
+					"<td class=\"Has-text smwtype_txt\">abc</td>"
+				]
+			}
+		}
+	],
+	"settings": {
+		"wgContLang": "en",
+		"wgLang": "en",
+		"wgRestrictDisplayTitle": false
+	},
+	"meta": {
+		"version": "0.1",
+		"is-incomplete": false,
+		"debug": false
+	}
+}

--- a/tests/phpunit/Unit/Query/Parser/DescriptionProcessorTest.php
+++ b/tests/phpunit/Unit/Query/Parser/DescriptionProcessorTest.php
@@ -59,9 +59,28 @@ class DescriptionProcessorTest extends \PHPUnit_Framework_TestCase {
 
 		$instance = new DescriptionProcessor();
 
+		$valueDescription = $instance->constructDescriptionForWikiPageValueChunk( 'bar' );
+
 		$this->assertInstanceOf(
 			'SMW\Query\Language\ValueDescription',
-			$instance->constructDescriptionForWikiPageValueChunk( 'bar' )
+			$valueDescription
+		);
+
+		$this->assertEquals(
+			new DIWikiPage( 'Bar', NS_MAIN ),
+			$valueDescription->getDataItem()
+		);
+	}
+
+	public function testconstructDescriptionForWikiPageValueChunkOnApproximateValue() {
+
+		$instance = new DescriptionProcessor();
+
+		$valueDescription = $instance->constructDescriptionForWikiPageValueChunk( '~bar' );
+
+		$this->assertEquals(
+			new DIWikiPage( 'bar', NS_MAIN ),
+			$valueDescription->getDataItem()
 		);
 	}
 


### PR DESCRIPTION
`[[~foo*]]` is not the same as `[[~Foo*]]` therefore ensure that the `Title` doesn't transform the value literal in context of an approximate search.

refs #1246, #1410, #1534