### PR TITLE
QueryEngine: fix a typo in README.md

### DIFF
--- a/src/SQLStore/QueryEngine/README.md
+++ b/src/SQLStore/QueryEngine/README.md
@@ -42,11 +42,11 @@ $someProperty = new SomeProperty(
 /**
  * Equivalent to [[:+]][[Category:Foo]][[Foo::+]]
  */
-$description = new Conjunction( array(
-	$$namespaceDescription,
+$description = new Conjunction( [
+	$namespaceDescription,
 	$classDescription,
 	$someProperty
-) );
+] );
 ```
 ```php
 $query = new Query( $description );


### PR DESCRIPTION
And use short array syntax