### PR TITLE
Guard against circular reference in category/property hierarchy, refs #1713 

### DIFF
--- a/tests/phpunit/Integration/ByJsonScript/ByJsonScriptFixtureTestCaseRunnerTest.php
+++ b/tests/phpunit/Integration/ByJsonScript/ByJsonScriptFixtureTestCaseRunnerTest.php
@@ -151,7 +151,8 @@ class ByJsonScriptFixtureTestCaseRunnerTest extends ByJsonTestCaseProvider {
 			'smwgMaxNonExpNumber',
 			'wgAllowDisplayTitle',
 			'wgRestrictDisplayTitle', // Restrict {{DISPLAYTITLE}} to titles ...
-			'smwgDVFeatures'
+			'smwgDVFeatures',
+			'smwgEnabledQueryDependencyLinksStore'
 		);
 
 		foreach ( $permittedSettings as $key ) {

--- a/tests/phpunit/Integration/ByJsonScript/Fixtures/p-0906.json
+++ b/tests/phpunit/Integration/ByJsonScript/Fixtures/p-0906.json
@@ -1,0 +1,66 @@
+{
+	"description": "Test `#ask` on category/property hierarchy with circular reference (#1713, `wgContLang=en`, `wgLang=en`, 'smwgEnabledQueryDependencyLinksStore', skip virtuoso)",
+	"properties": [],
+	"subjects": [
+		{
+			"name": "CategoryWithCircularHierarchy",
+			"namespace": "NS_CATEGORY",
+			"contents": "[[Category:CategoryWithCircularHierarchy]]"
+		},
+		{
+			"name": "PropertyWithCircularHierarchy",
+			"namespace": "SMW_NS_PROPERTY",
+			"contents": "[[Subproperty of::PropertyWithCircularHierarchy]]"
+		},
+		{
+			"name": "Example/P0906/1",
+			"contents": "[[Category:CategoryWithCircularHierarchy]]"
+		},
+		{
+			"name": "Example/P0906/Q1",
+			"contents": "{{#ask: [[Category:CategoryWithCircularHierarchy]] |link=none }}"
+		},
+		{
+			"name": "Example/P0906/2",
+			"contents": "[[PropertyWithCircularHierarchy::123]]"
+		},
+		{
+			"name": "Example/P0906/Q2",
+			"contents": "{{#ask: [[PropertyWithCircularHierarchy::+]] |link=none }}"
+		}
+	],
+	"parser-testcases": [
+		{
+			"about": "#0",
+			"subject": "Example/P0906/Q1",
+			"expected-output": {
+				"to-contain": [
+					"Example/P0906/1"
+				]
+			}
+		},
+		{
+			"about": "#1",
+			"subject": "Example/P0906/Q2",
+			"expected-output": {
+				"to-contain": [
+					"Example/P0906/2"
+				]
+			}
+		}
+	],
+	"settings": {
+		"wgContLang": "en",
+		"wgLang": "en",
+		"smwgEnabledQueryDependencyLinksStore": true,
+		"smwgPageSpecialProperties": [ "_MDAT" ]
+	},
+	"meta": {
+		"skip-on": {
+			"virtuoso": "Virtuoso 6.1 rdfs / subproperty/property hierarchies are currently not implemented"
+		},
+		"version": "0.1",
+		"is-incomplete": false,
+		"debug": false
+	}
+}

--- a/tests/phpunit/Unit/SQLStore/QueryDependency/QueryResultDependencyListResolverTest.php
+++ b/tests/phpunit/Unit/SQLStore/QueryDependency/QueryResultDependencyListResolverTest.php
@@ -166,23 +166,18 @@ class QueryResultDependencyListResolverTest extends \PHPUnit_Framework_TestCase 
 			->will( $this->returnValue(
 				array( DIWikiPage::newFromText( 'Subprop', SMW_NS_PROPERTY ) ) ) );
 
-		$propertyHierarchyLookup->expects( $this->at( 3 ) )
-			->method( 'findSubpropertListFor' )
-			->with( $this->equalTo( new DIProperty( 'Subprop' ) ) )
-			->will( $this->returnValue( array() ) );
-
 		$instance = new QueryResultDependencyListResolver(
 			$queryResult,
 			$propertyHierarchyLookup
 		);
 
-		$instance->setPropertyDependencyExemptionlist( array( 'Foobar', 'Subprop' ) );
+		$instance->setPropertyDependencyExemptionlist( array( 'Subprop' ) );
 
 		$expected = array(
 			DIWikiPage::newFromText( 'Foo' ),
-			DIWikiPage::newFromText( 'Bar' )
+			DIWikiPage::newFromText( 'Bar' ),
+			'Foobar#102#' => DIWikiPage::newFromText( 'Foobar', SMW_NS_PROPERTY )
 		//	DIWikiPage::newFromText( 'Subprop', SMW_NS_PROPERTY ) removed
-		//	DIWikiPage::newFromText( 'Foobar', SMW_NS_PROPERTY ) removed
 		);
 
 		$this->assertEquals(
@@ -315,11 +310,6 @@ class QueryResultDependencyListResolverTest extends \PHPUnit_Framework_TestCase 
 			->will( $this->returnValue(
 				array( DIWikiPage::newFromText( 'Subprop', SMW_NS_PROPERTY ) ) ) );
 
-		$propertyHierarchyLookup->expects( $this->at( 3 ) )
-			->method( 'findSubpropertListFor' )
-			->with( $this->equalTo( new DIProperty( 'Subprop' ) ) )
-			->will( $this->returnValue( array() ) );
-
 		$instance = new QueryResultDependencyListResolver(
 			$queryResult,
 			$propertyHierarchyLookup
@@ -328,8 +318,8 @@ class QueryResultDependencyListResolverTest extends \PHPUnit_Framework_TestCase 
 		$expected = array(
 			DIWikiPage::newFromText( 'Foo' ),
 			DIWikiPage::newFromText( 'Bar' ),
-			DIWikiPage::newFromText( 'Subprop', SMW_NS_PROPERTY ),
-			DIWikiPage::newFromText( 'Foobar', SMW_NS_PROPERTY )
+			'Subprop#102#' => DIWikiPage::newFromText( 'Subprop', SMW_NS_PROPERTY ),
+			'Foobar#102#' => DIWikiPage::newFromText( 'Foobar', SMW_NS_PROPERTY )
 		);
 
 		$this->assertEquals(
@@ -377,12 +367,9 @@ class QueryResultDependencyListResolverTest extends \PHPUnit_Framework_TestCase 
 			->method( 'findSubcategoryListFor' )
 			->with( $this->equalTo( DIWikiPage::newFromText( 'Foocat', NS_CATEGORY ) ) )
 			->will( $this->returnValue(
-				array( DIWikiPage::newFromText( 'Subcat', NS_CATEGORY ) ) ) );
-
-		$propertyHierarchyLookup->expects( $this->at( 3 ) )
-			->method( 'findSubcategoryListFor' )
-			->with( $this->equalTo( DIWikiPage::newFromText( 'Subcat', NS_CATEGORY ) ) )
-			->will( $this->returnValue( array() ) );
+				array(
+					DIWikiPage::newFromText( 'Subcat', NS_CATEGORY ),
+					DIWikiPage::newFromText( 'Foocat', NS_CATEGORY ) ) ) );
 
 		$instance = new QueryResultDependencyListResolver(
 			$queryResult,
@@ -391,7 +378,8 @@ class QueryResultDependencyListResolverTest extends \PHPUnit_Framework_TestCase 
 
 		$expected = array(
 			DIWikiPage::newFromText( 'Foo' ),
-			DIWikiPage::newFromText( 'Subcat', NS_CATEGORY ),
+			'Subcat#14#' => DIWikiPage::newFromText( 'Subcat', NS_CATEGORY ),
+			'Foocat#14#' => DIWikiPage::newFromText( 'Foocat', NS_CATEGORY ),
 			DIWikiPage::newFromText( 'Foocat', NS_CATEGORY )
 		);
 
@@ -419,7 +407,7 @@ class QueryResultDependencyListResolverTest extends \PHPUnit_Framework_TestCase 
 			array(
 				DIWikiPage::newFromText( 'Foo' ),
 				DIWikiPage::newFromText( 'Bar' ),
-				DIWikiPage::newFromText( 'Foobar', SMW_NS_PROPERTY )
+				'Foobar#102#' => DIWikiPage::newFromText( 'Foobar', SMW_NS_PROPERTY )
 			)
 		);
 
@@ -436,7 +424,7 @@ class QueryResultDependencyListResolverTest extends \PHPUnit_Framework_TestCase 
 			$query,
 			array(
 				DIWikiPage::newFromText( 'Foo' ),
-				DIWikiPage::newFromText( 'Foobar', SMW_NS_PROPERTY )
+				'Foobar#102#' => DIWikiPage::newFromText( 'Foobar', SMW_NS_PROPERTY )
 			)
 		);
 
@@ -454,7 +442,7 @@ class QueryResultDependencyListResolverTest extends \PHPUnit_Framework_TestCase 
 			array(
 				DIWikiPage::newFromText( 'Foo' ),
 				DIWikiPage::newFromText( 'Bar' ),
-				DIWikiPage::newFromText( 'Foobar', SMW_NS_PROPERTY )
+				'Foobar#102#' => DIWikiPage::newFromText( 'Foobar', SMW_NS_PROPERTY )
 			)
 		);
 
@@ -476,7 +464,7 @@ class QueryResultDependencyListResolverTest extends \PHPUnit_Framework_TestCase 
 			array(
 				DIWikiPage::newFromText( 'Foo' ),
 				DIWikiPage::newFromText( 'Bar' ),
-				DIWikiPage::newFromText( 'Foobar', SMW_NS_PROPERTY )
+				'Foobar#102#' => DIWikiPage::newFromText( 'Foobar', SMW_NS_PROPERTY )
 			)
 		);
 
@@ -498,7 +486,7 @@ class QueryResultDependencyListResolverTest extends \PHPUnit_Framework_TestCase 
 			array(
 				DIWikiPage::newFromText( 'Foo' ),
 				DIWikiPage::newFromText( 'Bar' ),
-				DIWikiPage::newFromText( 'Foobar', SMW_NS_PROPERTY )
+				'Foobar#102#' => DIWikiPage::newFromText( 'Foobar', SMW_NS_PROPERTY )
 			)
 		);
 
@@ -554,8 +542,8 @@ class QueryResultDependencyListResolverTest extends \PHPUnit_Framework_TestCase 
 			array(
 				DIWikiPage::newFromText( 'Foo' ),
 				DIWikiPage::newFromText( 'Bar' ),
-				DIWikiPage::newFromText( 'Foobar', SMW_NS_PROPERTY ),
-				DIWikiPage::newFromText( 'Foobaz', SMW_NS_PROPERTY )
+				DIWikiPage::newFromText( 'Foobaz', SMW_NS_PROPERTY ),
+				'Foobar#102#' => DIWikiPage::newFromText( 'Foobar', SMW_NS_PROPERTY ),
 			)
 		);
 
@@ -580,8 +568,8 @@ class QueryResultDependencyListResolverTest extends \PHPUnit_Framework_TestCase 
 			array(
 				DIWikiPage::newFromText( 'Foo' ),
 				DIWikiPage::newFromText( 'Bar' ),
-				DIWikiPage::newFromText( 'Foobar', SMW_NS_PROPERTY ),
-				DIWikiPage::newFromText( 'Foobaz', SMW_NS_PROPERTY )
+				DIWikiPage::newFromText( 'Foobaz', SMW_NS_PROPERTY ),
+				'Foobar#102#' => DIWikiPage::newFromText( 'Foobar', SMW_NS_PROPERTY ),
 			)
 		);
 


### PR DESCRIPTION
refs #1713

```
...
PHP  48. SMW\MediaWiki\Hooks\HookRegistry->SMW\MediaWiki\Hooks\{closure}() /var/www/html/02310/w/includes/Hooks.php:207
PHP  49. SMW\SQLStore\QueryDependency\QueryDependencyLinksStore->doUpdateDependenciesBy() /var/www/html/02310/w/extensions/SemanticMediaWiki/src/MediaWiki/Hooks/HookRegistry.php:537
PHP  50. SMW\SQLStore\QueryDependency\QueryResultDependencyListResolver->getDependencyList() /var/www/html/02310/w/extensions/SemanticMediaWiki/src/SQLStore/QueryDependency/QueryDependencyLinksStore.php:241
PHP  51. SMW\SQLStore\QueryDependency\QueryResultDependencyListResolver->doResolveDependenciesFromDescription() /var/www/html/02310/w/extensions/SemanticMediaWiki/src/SQLStore/QueryDependency/QueryResultDependencyListResolver.php:156
PHP  52. SMW\SQLStore\QueryDependency\QueryResultDependencyListResolver->doResolveDependenciesFromDescription() /var/www/html/02310/w/extensions/SemanticMediaWiki/src/SQLStore/QueryDependency/QueryResultDependencyListResolver.php:205
PHP  53. SMW\SQLStore\QueryDependency\QueryResultDependencyListResolver->doResolveDependenciesFromDescription() /var/www/html/02310/w/extensions/SemanticMediaWiki/src/SQLStore/QueryDependency/QueryResultDependencyListResolver.php:205
PHP  54. SMW\SQLStore\QueryDependency\QueryResultDependencyListResolver->doMatchSubcategory() /var/www/html/02310/w/extensions/SemanticMediaWiki/src/SQLStore/QueryDependency/QueryResultDependencyListResolver.php:191
PHP  55. SMW\SQLStore\QueryDependency\QueryResultDependencyListResolver->doMatchSubcategory() /var/www/html/02310/w/extensions/SemanticMediaWiki/src/SQLStore/QueryDependency/QueryResultDependencyListResolver.php:234
PHP  56. SMW\SQLStore\QueryDependency\QueryResultDependencyListResolver->doMatchSubcategory() /var/www/html/02310/w/extensions/SemanticMediaWiki/src/SQLStore/QueryDependency/QueryResultDependencyListResolver.php:234
...
```