### PR TITLE
Preserve spaces in unit labels, refs #1529

### DIFF
--- a/DefaultSettings.php
+++ b/DefaultSettings.php
@@ -993,6 +993,9 @@ $GLOBALS['smwgEnabledInTextAnnotationParserStrictMode'] = true;
 # - SMW_DV_TIMEV_CM (TimeValue) to indicate the CalendarModel if is not a
 # CM_GREGORIAN
 #
+# - SMW_DV_NUMV_USPACE (Number/QuantityValue) to preserve spaces within
+# unit labels
+#
 # @since 2.4
 ##
 $GLOBALS['smwgDVFeatures'] = SMW_DV_PROV_REDI | SMW_DV_MLTV_LCODE | SMW_DV_PVAP | SMW_DV_WPV_DTITLE | SMW_DV_TIMEV_CM;

--- a/includes/datavalues/SMW_DV_Number.php
+++ b/includes/datavalues/SMW_DV_Number.php
@@ -120,9 +120,12 @@ class SMWNumberValue extends SMWDataValue {
 				'|\\' . $decseparator . '\d+' .
 				')\s*(?:[eE][-+]?\d+)?)/u';
 
+		// #1718 Whether to preserve spaces in unit labels or not (e.g. sq mi, sqmi)
+		$space = $this->isEnabledFeature( SMW_DV_NUMV_USPACE ) ? ' ' : '';
+
 		$parts = preg_split(
 			$regex,
-			trim( str_replace( array( '&nbsp;', '&#160;', '&thinsp;', ' ' ), '', $value ) ),
+			trim( str_replace( array( '&nbsp;', '&#160;', '&thinsp;', ' ' ), $space, $value ) ),
 			2,
 			PREG_SPLIT_DELIM_CAPTURE
 		);

--- a/src/Defines.php
+++ b/src/Defines.php
@@ -155,4 +155,5 @@ define( 'SMW_DV_WPV_DTITLE', 32 );  // WikiPageValue to use an explicit display 
 define( 'SMW_DV_PROV_DTITLE', 64 );  // PropertyValue allow to find a property using the display title
 define( 'SMW_DV_PVUC', 128 );  // Delcares a uniqueness constraint
 define( 'SMW_DV_TIMEV_CM', 256 );  // TimeValue to indicate calendar model
+define( 'SMW_DV_NUMV_USPACE', 512 );  // Preserve spaces in unit labels
 /**@}*/

--- a/tests/phpunit/Integration/ByJsonScript/ByJsonScriptFixtureTestCaseRunnerTest.php
+++ b/tests/phpunit/Integration/ByJsonScript/ByJsonScriptFixtureTestCaseRunnerTest.php
@@ -94,6 +94,9 @@ class ByJsonScriptFixtureTestCaseRunnerTest extends ByJsonTestCaseProvider {
 		$this->testEnvironment->resetMediaWikiService( 'TitleParser' );
 
 		$this->testEnvironment->resetPoolCacheFor( \SMW\PropertySpecificationLookup::POOLCACHE_ID );
+
+		// Make sure LocalSettings don't interfere with the default settings
+		$GLOBALS['smwgDVFeatures'] = $GLOBALS['smwgDVFeatures'] & ~SMW_DV_NUMV_USPACE;
 	}
 
 	/**

--- a/tests/phpunit/Integration/ByJsonScript/Fixtures/f-0210.json
+++ b/tests/phpunit/Integration/ByJsonScript/Fixtures/f-0210.json
@@ -1,0 +1,72 @@
+{
+	"description": "Test `format=table` on `_qty` for unit labels with spaces (#1718, `wgContLang=en`, `SMW_DV_NUMV_USPACE`)",
+	"properties": [
+		{
+			"name": "Has area with spaces",
+			"contents": "[[Has type::Quantity]], [[Corresponds to::1 km², km ²]] [[Corresponds to::0.38610 sq mi, sqmi]] [[Corresponds to::1000 m², m ²]]"
+		}
+	],
+	"subjects": [
+		{
+			"name": "Example/F0210/1",
+			"contents": "[[Has area with spaces::10 km ²]] [[Has area with spaces::3 sqmi]] [[Has area with spaces::50 m ²]] [[Category:F0210]]"
+		},
+		{
+			"name": "Example/F0210/Q1.1",
+			"contents": "{{#ask: [[Category:F0210]][[Has area with spaces::+]] |?Has area with spaces |format=table |headers=plain }}"
+		},
+		{
+			"name": "Example/F0210/Q1.2",
+			"contents": "{{#ask: [[Has area with spaces::10 km ²]] |format=table |headers=plain |link=none }}"
+		},
+		{
+			"name": "Example/F0210/Q1.3",
+			"contents": "{{#ask: [[Has area with spaces::10 km²]] |format=table |headers=plain |link=none }}"
+		}
+	],
+	"format-testcases": [
+		{
+			"about": "#0",
+			"subject": "Example/F0210/Q1.1",
+			"expected-output": {
+				"to-contain": [
+					"<span class=\"smwtext\">10&#160;km²</span><div class=\"smwttcontent\">3.861&#160;sq mi <br />10,000&#160;m² <br /></div></span>",
+					"<span class=\"smwtext\">7.77&#160;km²</span><div class=\"smwttcontent\">3&#160;sq mi <br />7,770.008&#160;m² <br /></div></span>",
+					"<span class=\"smwtext\">0.05&#160;km²</span><div class=\"smwttcontent\">0.0193&#160;sq mi <br />50&#160;m² <br /></div></span>"
+				]
+			}
+		},
+		{
+			"about": "#1",
+			"subject": "Example/F0210/Q1.2",
+			"expected-output": {
+				"to-contain": [
+					"<td class=\"smwtype_wpg\">Example/F0210/1</td>"
+				]
+			}
+		},
+		{
+			"about": "#2",
+			"subject": "Example/F0210/Q1.3",
+			"expected-output": {
+				"to-contain": [
+					"<td class=\"smwtype_wpg\">Example/F0210/1</td>"
+				]
+			}
+		}
+	],
+	"settings": {
+		"wgContLang": "en",
+		"wgLang": "en",
+		"smwgDVFeatures": [ "SMW_DV_NUMV_USPACE" ],
+		"smwgNamespacesWithSemanticLinks": {
+			"NS_MAIN": true,
+			"SMW_NS_PROPERTY": true
+		}
+	},
+	"meta": {
+		"version": "0.1",
+		"is-incomplete": false,
+		"debug": false
+	}
+}


### PR DESCRIPTION
Adds the `SMW_DV_NUMV_USPACE` flag for preserving spaces in unit labels which up to now has been squashed. For example, `sq mi` (official notation) is converted to `sqmi` without the flag.

In order to allow for different spellings a user is expected to maintain a list of permitted notations such as `[[Corresponds to::1 km², km ², k m ²]]` with the first declaration to mark the "standard" output norm.

To enable this feature `smwgDVFeatures` requires the `SMW_DV_NUMV_USPACE` flag (disabled by default to avoid BC as it would require to list all norms explicitly).