### PR TITLE
QueryDependencyLinksStore to not forgo on an empty dependency list

### DIFF
--- a/src/SQLStore/QueryDependency/DependencyLinksTableUpdater.php
+++ b/src/SQLStore/QueryDependency/DependencyLinksTableUpdater.php
@@ -61,9 +61,9 @@ class DependencyLinksTableUpdater {
 	 * @param integer $sid
 	 * @param array|null $dependencyList
 	 */
-	public function addUpdateList( $sid, array $dependencyList = null ) {
+	public function addToUpdateList( $sid, array $dependencyList = null ) {
 
-		if ( $sid == 0 || $dependencyList === null ) {
+		if ( $sid == 0 || $dependencyList === null || $dependencyList === array() ) {
 			return null;
 		}
 

--- a/src/SQLStore/QueryDependency/QueryDependencyLinksStore.php
+++ b/src/SQLStore/QueryDependency/QueryDependencyLinksStore.php
@@ -240,12 +240,8 @@ class QueryDependencyLinksStore {
 
 		$dependencyList = $queryResultDependencyListResolver->getDependencyList();
 
-		if ( $dependencyList === array() ) {
-			return null;
-		}
-
 		$dependencyLinksTableUpdater = $this->dependencyLinksTableUpdater;
-		$dependencyLinksTableUpdater->addUpdateList( $sid, $dependencyList );
+		$dependencyLinksTableUpdater->addToUpdateList( $sid, $dependencyList );
 
 		$deferredCallableUpdate = ApplicationFactory::getInstance()->newDeferredCallableUpdate( function() use( $sid, $hash, $dependencyLinksTableUpdater, $queryResultDependencyListResolver ) {
 			wfDebugLog( 'smw', 'DeferredCallableUpdate on QueryDependencyLinksStore::doUpdateDependenciesBy for ' . $hash );
@@ -254,7 +250,7 @@ class QueryDependencyLinksStore {
 			// object as been resolved by the ResultPrinter, this is done to
 			// avoid having to process the QueryResult recursively on its own
 			// (which would carry a performance penalty)
-			$dependencyLinksTableUpdater->addUpdateList(
+			$dependencyLinksTableUpdater->addToUpdateList(
 				$sid,
 				$queryResultDependencyListResolver->getDependencyListByLateRetrieval()
 			);
@@ -279,12 +275,12 @@ class QueryDependencyLinksStore {
 			wfDebugLog( 'smw', 'QueryDependencyLinksStore::doUpdateDependenciesBy as deferred.embedded.query.dep.update for ' . $hash );
 			$sid = $dependencyLinksTableUpdater->getIdForSubject( $subject, $hash );
 
-			$dependencyLinksTableUpdater->addUpdateList(
+			$dependencyLinksTableUpdater->addToUpdateList(
 				$sid,
 				$dependencyList
 			);
 
-			$dependencyLinksTableUpdater->addUpdateList(
+			$dependencyLinksTableUpdater->addToUpdateList(
 				$sid,
 				$queryResultDependencyListResolver->getDependencyListByLateRetrieval()
 			);

--- a/tests/phpunit/Unit/SQLStore/QueryDependency/DependencyLinksTableUpdaterTest.php
+++ b/tests/phpunit/Unit/SQLStore/QueryDependency/DependencyLinksTableUpdaterTest.php
@@ -46,7 +46,7 @@ class DependencyLinksTableUpdaterTest extends \PHPUnit_Framework_TestCase {
 		);
 	}
 
-	public function testAddUpdateList() {
+	public function testAddToUpdateList() {
 
 		$idTable = $this->getMockBuilder( '\stdClass' )
 			->setMethods( array( 'getIDFor' ) )
@@ -102,29 +102,40 @@ class DependencyLinksTableUpdaterTest extends \PHPUnit_Framework_TestCase {
 
 		$instance->clear();
 
-		$instance->addUpdateList( 42, array( DIWikiPage::newFromText( 'Bar' ) ) );
+		$instance->addToUpdateList( 42, array( DIWikiPage::newFromText( 'Bar' ) ) );
 		$instance->doUpdate();
 	}
 
-	public function testAddUpdateListOnNull_List() {
+	public function testAddToUpdateListOnNull_List() {
 
 		$instance = new DependencyLinksTableUpdater(
 			$this->store
 		);
 
 		$this->assertNull(
-			$instance->addUpdateList( 42, null )
+			$instance->addToUpdateList( 42, null )
 		);
 	}
 
-	public function testAddUpdateListOnZero_Id() {
+	public function testAddToUpdateListOnZero_Id() {
 
 		$instance = new DependencyLinksTableUpdater(
 			$this->store
 		);
 
 		$this->assertNull(
-			$instance->addUpdateList( 0, array() )
+			$instance->addToUpdateList( 0, array() )
+		);
+	}
+
+	public function testAddToUpdateListOnEmpty_List() {
+
+		$instance = new DependencyLinksTableUpdater(
+			$this->store
+		);
+
+		$this->assertNull(
+			$instance->addToUpdateList( 42, array() )
 		);
 	}
 
@@ -188,7 +199,7 @@ class DependencyLinksTableUpdaterTest extends \PHPUnit_Framework_TestCase {
 
 		$instance->clear();
 
-		$instance->addUpdateList( 42, array( DIWikiPage::newFromText( 'Bar', SMW_NS_PROPERTY ) ) );
+		$instance->addToUpdateList( 42, array( DIWikiPage::newFromText( 'Bar', SMW_NS_PROPERTY ) ) );
 		$instance->doUpdate();
 	}
 

--- a/tests/phpunit/Unit/SQLStore/QueryDependency/QueryDependencyLinksStoreTest.php
+++ b/tests/phpunit/Unit/SQLStore/QueryDependency/QueryDependencyLinksStoreTest.php
@@ -275,13 +275,15 @@ class QueryDependencyLinksStoreTest extends \PHPUnit_Framework_TestCase {
 			->disableOriginalConstructor()
 			->getMock();
 
-		$queryResultDependencyListResolver->expects( $this->any() )
+		$queryResultDependencyListResolver->expects( $this->never() )
 			->method( 'getDependencyListByLateRetrieval' )
 			->will( $this->returnValue( array() ) );
 
-		$this->assertNull(
-			$instance->doUpdateDependenciesBy( $queryResultDependencyListResolver )
-		);
+		$queryResultDependencyListResolver->expects( $this->never() )
+			->method( 'getDependencyList' )
+			->will( $this->returnValue( array() ) );
+
+		$instance->doUpdateDependenciesBy( $queryResultDependencyListResolver );
 	}
 
 	public function testTryDoUpdateDependenciesByForWhenDependencyListReturnsEmpty() {
@@ -333,9 +335,7 @@ class QueryDependencyLinksStoreTest extends \PHPUnit_Framework_TestCase {
 			->method( 'getSubject' )
 			->will( $this->returnValue( DIWikiPage::newFromText( __METHOD__ ) ) );
 
-		$this->assertNull(
-			$instance->doUpdateDependenciesBy( $queryResultDependencyListResolver )
-		);
+		$instance->doUpdateDependenciesBy( $queryResultDependencyListResolver );
 	}
 
 	public function testdoUpdateDependenciesByFromQueryResult() {
@@ -386,7 +386,7 @@ class QueryDependencyLinksStoreTest extends \PHPUnit_Framework_TestCase {
 			->getMock();
 
 		$dependencyLinksTableUpdater->expects( $this->once() )
-			->method( 'addUpdateList' )
+			->method( 'addToUpdateList' )
 			->with(
 				$this->equalTo( 42 ),
 				$this->anything() );
@@ -450,7 +450,7 @@ class QueryDependencyLinksStoreTest extends \PHPUnit_Framework_TestCase {
 			->getMock();
 
 		$dependencyLinksTableUpdater->expects( $this->once() )
-			->method( 'addUpdateList' )
+			->method( 'addToUpdateList' )
 			->with(
 				$this->equalTo( 42 ),
 				$this->anything() );


### PR DESCRIPTION
Ensures that `QueryResultDependencyListResolver::getDependencyListByLateRetrieval` can happen even in cases where the `dependencyList` is empty.

refs #1627