### PR TITLE
Do not yet display 2.5 requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,8 +22,8 @@ browse the [smw.org@wiki](https://www.semantic-mediawiki.org) for a more compreh
 
 ## Requirements
 
-- PHP 5.5 or later
-- MediaWiki 1.25 or later
+- PHP 5.3 or later (5.5 or later recommended)
+- MediaWiki 1.19 or later (1.25 or later recommended)
 - MySQL 5+, SQLite 3+ or PostgreSQL 9.x
 
 A list of supported PHP versions, MediaWiki versions and databases per SMW release can be found


### PR DESCRIPTION
While the code is on master, we're displaying master by default, so let's stick to the requirements of the latest release.

And when we bump, it'd be good for there to be some indication that people with PHP 5.4 can still run a slightly older version of SMW and are not completely out of luck.