### PR TITLE
Add RdbmsTableBuilder to replace SMWSQLHelpers

### DIFF
--- a/src/SQLStore/SQLStoreFactory.php
+++ b/src/SQLStore/SQLStoreFactory.php
@@ -14,6 +14,8 @@ use SMW\SQLStore\Lookup\UsageStatisticsListLookup;
 use SMW\SQLStore\QueryEngine\ConceptQueryResolver;
 use SMWRequestOptions as RequestOptions;
 use SMWSQLStore3;
+use SMW\SQLStore\TableBuilder\RdbmsTableBuilder;
+use Onoi\MessageReporter\MessageReporterFactory;
 
 /**
  * @license GNU GPL v2+
@@ -326,6 +328,24 @@ class SQLStoreFactory {
 		);
 
 		return $propertyTableIdReferenceFinder;
+	}
+
+	/**
+	 * @since 2.5
+	 *
+	 * @return RdbmsTableBuilder
+	 */
+	public function newRdbmsTableBuilder() {
+
+		$rdbmsTableBuilder = RdbmsTableBuilder::factory(
+			$this->store->getConnection( DB_MASTER )
+		);
+
+		$rdbmsTableBuilder->setMessageReporter(
+			MessageReporterFactory::getInstance()->newNullMessageReporter()
+		);
+
+		return $rdbmsTableBuilder;
 	}
 
 	private function newPropertyStatisticsStore() {

--- a/src/SQLStore/TableBuilder/MySQLRdbmsTableBuilder.php
+++ b/src/SQLStore/TableBuilder/MySQLRdbmsTableBuilder.php
@@ -1,0 +1,221 @@
+<?php
+
+namespace SMW\SQLStore\TableBuilder;
+
+/**
+ * @license GNU GPL v2+
+ * @since 2.5
+ *
+ * @author mwjames
+ */
+class MySQLRdbmsTableBuilder extends RdbmsTableBuilder {
+
+	/**
+	 * @see RdbmsTableBuilder::getStandardFieldType
+	 */
+	public function getStandardFieldType( $input ) {
+
+		switch ( $input ) {
+			case 'id':
+			return 'INT(8) UNSIGNED'; // like page_id in MW page table
+			case 'id primary':
+			return 'INT(8) UNSIGNED' . ' NOT NULL KEY AUTO_INCREMENT'; // like page_id in MW page table
+			case 'namespace':
+			return 'INT(11)'; // like page_namespace in MW page table
+			case 'title':
+			return 'VARBINARY(255)'; // like page_title in MW page table
+			case 'iw':
+			return 'VARBINARY(32)'; // like iw_prefix in MW interwiki table
+			case 'blob':
+			return 'MEDIUMBLOB'; // larger blobs of character data, usually not subject to SELECT conditions
+			case 'boolean':
+			return 'TINYINT(1)';
+			case 'double':
+			return 'DOUBLE';
+			case 'integer':
+			return 'INT(8)';
+			case 'usage count':
+			return 'INT(8) UNSIGNED';
+			case 'integer unsigned':
+			return 'INT(8) UNSIGNED';
+			case 'sort':
+			return 'VARCHAR(255)';
+		}
+
+		return false;
+	}
+
+	/**
+	 * @see RdbmsTableBuilder::getSQLFromDBName
+	 */
+	protected function getSQLFromDBName( array $tableOptions ) {
+		global $wgDBname;
+		return "`$wgDBname`.";
+	}
+
+	/**
+	 * @see RdbmsTableBuilder::getSQLFromDBTableOptions
+	 */
+	protected function getSQLFromDBTableOptions( array $tableOptions ) {
+		// This replacement is needed for compatibility, see http://bugs.mysql.com/bug.php?id=17501
+		return str_replace( 'TYPE', 'ENGINE', $GLOBALS['wgDBTableOptions'] );
+	}
+
+	/**
+	 * @see RdbmsTableBuilder::getCurrentFields
+	 */
+	protected function getCurrentFields( $tableName ) {
+
+		$sql = 'DESCRIBE ' . $tableName;
+
+		$res = $this->connection->query( $sql, __METHOD__ );
+		$currentFields = array();
+
+		foreach ( $res as $row ) {
+			$type = strtoupper( $row->Type );
+
+			if ( substr( $type, 0, 8 ) == 'VARCHAR(' ) {
+				$type .= ' binary'; // just assume this to be the case for VARCHAR, though DESCRIBE will not tell us
+			}
+
+			if ( $row->Null != 'YES' ) {
+				$type .= ' NOT NULL';
+			}
+
+			if ( $row->Key == 'PRI' ) { /// FIXME: updating "KEY" is not possible, the below query will fail in this case.
+				$type .= ' KEY';
+			}
+
+			if ( $row->Extra == 'auto_increment' ) {
+				$type .= ' AUTO_INCREMENT';
+			}
+
+			$currentFields[$row->Field] = $type;
+		}
+
+		return $currentFields;
+	}
+
+	/**
+	 * @see RdbmsTableBuilder::doDropTable
+	 */
+	protected function doDropTable( $tableName ) {
+		$this->connection->query( 'DROP TABLE ' . $this->connection->tableName( $tableName ), __METHOD__ );
+	}
+
+	/**
+	 * @see RdbmsTableBuilder::doUpdateField
+	 */
+	protected function doUpdateField( $tableName, $fieldName, $fieldType, $currentFields, $position, array $tableOptions ) {
+
+		if ( !array_key_exists( $fieldName, $currentFields ) ) {
+			$this->doCreateField( $tableName, $fieldName, $position, $fieldType );
+		} elseif ( $currentFields[$fieldName] != $fieldType ) {
+			$this->doUpdateFieldType( $tableName, $fieldName, $position, $currentFields[$fieldName], $fieldType );
+		} else {
+			$this->reportMessage( "   ... field $fieldName is fine.\n" );
+		}
+	}
+
+	protected function doCreateField( $tableName, $fieldName, $position, $fieldType ) {
+		$this->reportMessage( "   ... creating field $fieldName ... " );
+		$this->connection->query( "ALTER TABLE $tableName ADD `$fieldName` $fieldType $position", __METHOD__ );
+		$this->reportMessage( "done.\n" );
+	}
+
+	protected function doUpdateFieldType( $tableName, $fieldName, $position, $oldFieldType, $newFieldType ) {
+		$this->reportMessage( "   ... changing type of field $fieldName from '$oldFieldType' to '$newFieldType' ... " );
+
+		// To avoid Error: 1068 Multiple primary key defined when a PRIMARY is involved
+		if ( strpos( $newFieldType, 'AUTO_INCREMENT' ) !== false ) {
+			$this->connection->query( "ALTER TABLE $tableName DROP PRIMARY KEY", __METHOD__ );
+		}
+
+		$this->connection->query( "ALTER TABLE $tableName CHANGE `$fieldName` `$fieldName` $newFieldType $position", __METHOD__ );
+
+		// http://stackoverflow.com/questions/1873085/how-to-convert-from-varbinary-to-char-varchar-in-mysql
+		// http://bugs.mysql.com/bug.php?id=34564
+		if ( strpos( $oldFieldType, 'VARBINARY' ) !== false && strpos( $newFieldType, 'VARCHAR' ) !== false ) {
+		//	$this->connection->query( "SELECT CAST($fieldName AS CHAR) from $tableName", __METHOD__ );
+		}
+
+		$this->reportMessage( "done.\n" );
+	}
+
+	/**
+	 * @see RdbmsTableBuilder::doDropField
+	 */
+	protected function doDropField( $tableName, $fieldName ) {
+		$this->connection->query( "ALTER TABLE $tableName DROP COLUMN `$fieldName`", __METHOD__ );
+	}
+
+	/**
+	 * @see RdbmsTableBuilder::doDropObsoleteIndicies
+	 */
+	protected function doDropObsoleteIndicies( $tableName, array &$indicies ) {
+
+		$tableName = $this->connection->tableName( $tableName );
+		$currentIndicies = $this->getIndexInfo( $tableName );
+
+		foreach ( $currentIndicies as $indexName => $indexColumn ) {
+			$id = array_search( $indexColumn, $indicies );
+			if ( $id !== false || $indexName == 'PRIMARY' ) {
+				$this->reportMessage( "   ... index $indexColumn is fine.\n" );
+
+				if ( $id !== false ) {
+					unset( $indicies[$id] );
+				}
+
+			} else { // Duplicate or unrequired index.
+				$this->doDropIndex( $tableName, $indexName, $indexColumn );
+			}
+		}
+	}
+
+	/**
+	 * @see RdbmsTableBuilder::doCreateIndex
+	 */
+	protected function doCreateIndex( $tableName, $indexType, $indexName, $columns ) {
+
+		$tableName = $this->connection->tableName( $tableName );
+
+		$this->reportMessage( "   ... creating new index $columns ..." );
+		$this->connection->query( "ALTER TABLE $tableName ADD $indexType ($columns)", __METHOD__ );
+		$this->reportMessage( "done.\n" );
+	}
+
+	/**
+	 * Get the information about all indexes of a table. The result is an
+	 * array of format indexname => indexcolumns. The latter is a comma
+	 * separated list.
+	 *
+	 * @return array indexname => columns
+	 */
+	private function getIndexInfo( $tableName ) {
+
+		$indices = array();
+
+		$res = $this->connection->query( 'SHOW INDEX FROM ' . $tableName, __METHOD__ );
+
+		if ( !$res ) {
+			return $indices;
+		}
+
+		foreach ( $res as $row ) {
+			if ( !array_key_exists( $row->Key_name, $indices ) ) {
+				$indices[$row->Key_name] = $row->Column_name;
+			} else {
+				$indices[$row->Key_name] .= ',' . $row->Column_name;
+			}
+		}
+
+		return $indices;
+	}
+
+	private function doDropIndex( $tableName, $indexName, $columns ) {
+		$this->reportMessage( "   ... removing index $columns ..." );
+		$this->connection->query( 'DROP INDEX ' . $indexName . ' ON ' . $tableName, __METHOD__ );
+		$this->reportMessage( "done.\n" );
+	}
+
+}

--- a/src/SQLStore/TableBuilder/PostgresRdbmsTableBuilder.php
+++ b/src/SQLStore/TableBuilder/PostgresRdbmsTableBuilder.php
@@ -1,0 +1,264 @@
+<?php
+
+namespace SMW\SQLStore\TableBuilder;
+
+/**
+ * @license GNU GPL v2+
+ * @since 2.5
+ *
+ * @author mwjames
+ */
+class PostgresRdbmsTableBuilder extends RdbmsTableBuilder {
+
+	/**
+	 * @since 2.5
+	 *
+	 * {@inheritDoc}
+	 */
+	public function getStandardFieldType( $input ) {
+
+		switch ( $input ) {
+			case 'id':
+			return 'SERIAL'; // like page_id in MW page table
+			case 'id primary':
+			return 'SERIAL' . ' NOT NULL PRIMARY KEY'; // like page_id in MW page table
+			case 'namespace':
+			return 'BIGINT'; // like page_namespace in MW page table
+			case 'title':
+			return 'TEXT'; // like page_title in MW page table
+			case 'iw':
+			return 'TEXT'; // like iw_prefix in MW interwiki table
+			case 'blob':
+			return 'BYTEA'; // larger blobs of character data, usually not subject to SELECT conditions
+			case 'boolean':
+			return 'BOOLEAN';
+			case 'double':
+			return 'DOUBLE PRECISION';
+			case 'integer':
+			case 'usage count':
+			return 'bigint';
+			case 'integer unsigned':
+			return 'INTEGER';
+			case 'sort':
+			return 'TEXT';
+		}
+
+		return false;
+	}
+
+	/**
+	 * @see RdbmsTableBuilder::getSQLFromDBName
+	 */
+	protected function getSQLFromDBName( array $tableOptions ) {
+		return '';
+	}
+
+	/**
+	 * @see RdbmsTableBuilder::getSQLFromDBTableOptions
+	 */
+	protected function getSQLFromDBTableOptions( array $tableOptions ) {
+		return '';
+	}
+
+	/**
+	 * @see RdbmsTableBuilder::getCurrentFields
+	 */
+	protected function getCurrentFields( $tableName ) {
+
+		$tableName = str_replace( '"', '', $tableName );
+		// Use the data dictionary in postgresql to get an output comparable to DESCRIBE.
+/*
+		$sql = <<<EOT
+SELECT
+	a.attname as "Field",
+	upper(pg_catalog.format_type(a.atttypid, a.atttypmod)) as "Type",
+	(SELECT substring(pg_catalog.pg_get_expr(d.adbin, d.adrelid) for 128)
+	FROM pg_catalog.pg_attrdef d
+	WHERE d.adrelid = a.attrelid AND d.adnum = a.attnum AND a.atthasdef) as "Extra",
+		case when a.attnotnull THEN 'NO'::text else 'YES'::text END as "Null", a.attnum
+	FROM pg_catalog.pg_attribute a
+	WHERE a.attrelid = (
+	    SELECT c.oid
+	    FROM pg_catalog.pg_class c
+	    LEFT JOIN pg_catalog.pg_namespace n ON n.oid = c.relnamespace
+	    WHERE c.relname ~ '^($tableName)$'
+	    AND pg_catalog.pg_table_is_visible(c.oid)
+	    LIMIT 1
+	 ) AND a.attnum > 0 AND NOT a.attisdropped
+	 ORDER BY a.attnum
+EOT;
+*/
+
+		$sql = "SELECT a.attname as \"Field\","
+			. " upper(pg_catalog.format_type(a.atttypid, a.atttypmod)) as \"Type\","
+			. " (SELECT substring(pg_catalog.pg_get_expr(d.adbin, d.adrelid) for 128)"
+			. " FROM pg_catalog.pg_attrdef d"
+			. " WHERE d.adrelid = a.attrelid AND d.adnum = a.attnum AND a.atthasdef) as \"Extra\", "
+			. " case when a.attnotnull THEN 'NO'::text else 'YES'::text END as \"Null\", a.attnum"
+			. " FROM pg_catalog.pg_attribute a"
+			. " WHERE a.attrelid = (SELECT c.oid"
+			. " FROM pg_catalog.pg_class c"
+			. " LEFT JOIN pg_catalog.pg_namespace n ON n.oid = c.relnamespace"
+			. " WHERE c.relname ~ '^(" . $tableName . ")$'"
+			. " AND pg_catalog.pg_table_is_visible(c.oid)"
+			. " LIMIT 1) AND a.attnum > 0 AND NOT a.attisdropped"
+			. " ORDER BY a.attnum";
+
+		$res = $this->connection->query( $sql, __METHOD__ );
+		$currentFields = array();
+
+		foreach ( $res as $row ) {
+			$type = strtoupper( $row->Type );
+
+			if ( preg_match( '/^nextval\\(.+\\)/i', $row->Extra ) ) {
+				$type = 'SERIAL NOT NULL';
+			} elseif ( $row->Null != 'YES' ) {
+					$type .= ' NOT NULL';
+			}
+
+			$currentFields[$row->Field] = $type;
+		}
+
+		return $currentFields;
+	}
+
+	/**
+	 * @see RdbmsTableBuilder::doDropTable
+	 */
+	protected function doDropTable( $tableName ) {
+		$this->connection->query( 'DROP TABLE IF EXISTS ' . $this->connection->tableName( $tableName ), __METHOD__ );
+	}
+
+	/**
+	 * @see RdbmsTableBuilder::doUpdateField
+	 */
+	protected function doUpdateField( $tableName, $fieldName, $fieldType, $currentFields, $position, array $tableOptions ) {
+
+		$keypos = strpos( $fieldType, ' PRIMARY KEY' );
+
+		if ( $keypos > 0 ) {
+			$fieldType = substr( $fieldType, 0, $keypos );
+		}
+
+		$fieldType = strtoupper( $fieldType );
+
+		if ( !array_key_exists( $fieldName, $currentFields ) ) {
+			$this->reportMessage( "   ... creating field $fieldName ... " );
+			$this->connection->query( "ALTER TABLE $tableName ADD \"" . $fieldName . "\" $fieldType", __METHOD__ );
+			$this->reportMessage( "done.\n" );
+		} elseif ( $currentFields[$fieldName] != $fieldType ) {
+			$this->reportMessage( "   ... changing type of field $fieldName from '$currentFields[$fieldName]' to '$fieldType' ... " );
+
+			$notnullposnew = strpos( $fieldType, ' NOT NULL' );
+
+			if ( $notnullposnew > 0 ) {
+				$fieldType = substr( $fieldType, 0, $notnullposnew );
+			}
+
+			$notnullposold = strpos( $currentFields[$fieldName], ' NOT NULL' );
+			$typeold  = strtoupper( ( $notnullposold > 0 ) ? substr( $currentFields[$fieldName], 0, $notnullposold ) : $currentFields[$fieldName] );
+
+			// Added USING statement to avoid
+			// "Query: ALTER TABLE "smw_object_ids" ALTER COLUMN "smw_proptable_hash" TYPE BYTEA ...
+			// Error: 42804 ERROR:  column "smw_proptable_hash" cannot be cast automatically to type bytea
+			// HINT:  You might need to specify "USING smw_proptable_hash::bytea"."
+
+			if ( $typeold != $fieldType ) {
+				$sql = "ALTER TABLE " . $tableName . " ALTER COLUMN \"" . $fieldName . "\" TYPE " . $fieldType  . " USING \"$fieldName\"::$fieldType";
+				$this->connection->query( $sql, __METHOD__ );
+			}
+
+			if ( $notnullposold != $notnullposnew ) {
+				$sql = "ALTER TABLE " . $tableName . " ALTER COLUMN \"" . $fieldName . "\" " . ( $notnullposnew > 0 ? 'SET' : 'DROP' ) . " NOT NULL";
+				$this->connection->query( $sql, __METHOD__ );
+			}
+
+			$this->reportMessage( "done.\n" );
+		} else {
+			$this->reportMessage( "   ... field $fieldName is fine.\n" );
+		}
+	}
+
+	/**
+	 * @see RdbmsTableBuilder::doDropField
+	 */
+	protected function doDropField( $tableName, $fieldName ) {
+		$this->connection->query( 'ALTER TABLE ' . $tableName . ' DROP COLUMN "' . $fieldName . '"', __METHOD__ );
+	}
+
+	/**
+	 * @see RdbmsTableBuilder::doDropObsoleteIndicies
+	 */
+	protected function doDropObsoleteIndicies( $tableName, array &$indicies ) {
+
+		$tableName = $this->connection->tableName( $tableName, 'raw' );
+		$currentIndicies = $this->getIndexInfo( $tableName );
+
+		foreach ( $currentIndicies as $indexName => $indexColumn ) {
+			$id = array_search( $indexColumn, $indicies );
+			if ( $id !== false || $indexName == 'PRIMARY' ) {
+				$this->reportMessage( "   ... index $indexColumn is fine.\n" );
+
+				if ( $id !== false ) {
+					unset( $indicies[$id] );
+				}
+
+			} else { // Duplicate or unrequired index.
+				$this->doDropIndex( $tableName, $indexName, $indexColumn );
+			}
+		}
+	}
+
+	/**
+	 * Create an index using the suitable SQL for various RDBMS.
+	 */
+	protected function doCreateIndex( $tableName, $indexType, $indexName, $columns ) {
+
+		$tableName = $this->connection->tableName( $tableName, 'raw' );
+		$indexName = "{$tableName}_index{$indexName}";
+
+		$this->reportMessage( "   ... creating new index $columns ..." );
+
+		if ( $this->connection->indexInfo( $tableName, $indexName ) === false ) {
+			$this->connection->query( "CREATE $indexType $indexName ON $tableName ($columns)", __METHOD__ );
+		}
+
+		$this->reportMessage( "done.\n" );
+	}
+
+	private function getIndexInfo( $tableName ) {
+
+		$indices = array();
+
+		$sql = "SELECT  i.relname AS indexname,"
+			. " pg_get_indexdef(i.oid) AS indexdef, "
+			. " replace(substring(pg_get_indexdef(i.oid) from E'\\\\((.*)\\\\)'), ' ' , '') AS indexcolumns"
+			. " FROM pg_index x"
+			. " JOIN pg_class c ON c.oid = x.indrelid"
+			. " JOIN pg_class i ON i.oid = x.indexrelid"
+			. " LEFT JOIN pg_namespace n ON n.oid = c.relnamespace"
+			. " LEFT JOIN pg_tablespace t ON t.oid = i.reltablespace"
+			. " WHERE c.relkind = 'r'::\"char\" AND i.relkind = 'i'::\"char\""
+			. " AND c.relname = '" . $tableName . "'"
+			. " AND NOT pg_get_indexdef(i.oid) ~ '^CREATE UNIQUE INDEX'";
+
+		$res = $this->connection->query( $sql, __METHOD__ );
+
+		if ( !$res ) {
+			return array();
+		}
+
+		foreach ( $res as $row ) {
+			$indices[$row->indexname] = $row->indexcolumns;
+		}
+
+		return $indices;
+	}
+
+	private function doDropIndex( $tableName, $indexName, $columns ) {
+		$this->reportMessage( "   ... removing index $columns ..." );
+		$this->connection->query( 'DROP INDEX IF EXISTS ' . $indexName, __METHOD__ );
+		$this->reportMessage( "done.\n" );
+	}
+
+}

--- a/src/SQLStore/TableBuilder/RdbmsTableBuilder.php
+++ b/src/SQLStore/TableBuilder/RdbmsTableBuilder.php
@@ -1,0 +1,273 @@
+<?php
+
+namespace SMW\SQLStore\TableBuilder;
+
+use Onoi\MessageReporter\MessageReporter;
+use DatabaseBase;
+use RuntimeException;
+
+/**
+ * @license GNU GPL v2+
+ * @since 2.5
+ *
+ * @author Markus Krötzsch
+ * @author Marcel Gsteiger
+ * @author Jeroen De Dauw
+ * @author mwjames
+ */
+abstract class RdbmsTableBuilder implements TableBuilder, MessageReporter {
+
+	/**
+	 * @var DatabaseBase
+	 */
+	protected $connection;
+
+	/**
+	 * @var MessageReporter
+	 */
+	private $messageReporter;
+
+	/**
+	 * @since 2.5
+	 *
+	 * @param DatabaseBase $connection
+	 */
+	protected function __construct( DatabaseBase $connection ) {
+		$this->connection = $connection;
+	}
+
+	/**
+	 * @since 2.5
+	 *
+	 * @param DatabaseBase $connection
+	 *
+	 * @return RdbmsTableBuilder
+	 * @throws RuntimeException
+	 */
+	public static function factory( DatabaseBase $connection ) {
+
+		$instance = null;
+
+		switch ( $connection->getType() ) {
+			case 'mysql':
+				$instance = new MySQLRdbmsTableBuilder( $connection );
+				break;
+			case 'sqlite':
+				$instance = new SQLiteRdbmsTableBuilder( $connection );
+				break;
+			case 'postgres':
+				$instance = new PostgresRdbmsTableBuilder( $connection );
+				break;
+		}
+
+		if ( $instance === null ) {
+			throw new RuntimeException( "Unknown DB type " . $connection->getType() );
+		}
+
+		return $instance;
+	}
+
+	/**
+	 * @see MessageReporterAware::setMessageReporter
+	 *
+	 * @since 2.5
+	 *
+	 * @param MessageReporter $messageReporter
+	 */
+	public function setMessageReporter( MessageReporter $messageReporter ) {
+		$this->messageReporter = $messageReporter;
+	}
+
+	/**
+	 * @see MessageReporter::reportMessage
+	 *
+	 * @since 2.5
+	 *
+	 * @param string $message
+	 */
+	public function reportMessage( $message ) {
+
+		if ( $this->messageReporter === null ) {
+			return;
+		}
+
+		$this->messageReporter->reportMessage( $message );
+	}
+
+	/**
+	 * @since 2.5
+	 *
+	 * {@inheritDoc}
+	 */
+	public function getStandardFieldType( $input ) {
+		return false;
+	}
+
+	/**
+	 * @since 2.5
+	 *
+	 * {@inheritDoc}
+	 */
+	public function createTable( $tableName, array $tableOptions = null ) {
+
+		$this->reportMessage( "Checking table $tableName ...\n" );
+
+		if ( $this->connection->tableExists( $tableName ) === false ) { // create new table
+			$this->reportMessage( "   Table not found, now creating...\n" );
+			$this->doCreateTable( $tableName, $tableOptions );
+		} else {
+			$this->reportMessage( "   Table already exists, checking structure ...\n" );
+			$this->doUpdateTable( $tableName, $tableOptions );
+		}
+
+		$this->reportMessage( "   ... done.\n" );
+	}
+
+	/**
+	 * @since 2.5
+	 *
+	 * {@inheritDoc}
+	 */
+	public function dropTable( $tableName ) {
+
+		if ( $this->connection->tableExists( $tableName ) === false ) { // create new table
+			return $this->reportMessage( " ... $tableName not found, skipping removal.\n" );
+		}
+
+		$this->doDropTable( $tableName );
+		$this->reportMessage( " ... dropped table $tableName.\n" );
+	}
+
+	/**
+	 * @since 2.5
+	 *
+	 * {@inheritDoc}
+	 */
+	public function createIndex( $tableName, array $indexOptions = null ) {
+
+		$this->reportMessage( "Checking index structures for table $tableName ...\n" );
+		$indicies = $indexOptions['indicies'];
+
+		// First remove possible obsolete indicies
+		$this->doDropObsoleteIndicies( $tableName, $indicies );
+
+		// Add new indexes.
+		foreach ( $indicies as $indexName => $index ) {
+			// If the index is an array, it contains the column
+			// name as first element, and index type as second one.
+			if ( is_array( $index ) ) {
+				$columns = $index[0];
+				$indexType = count( $index ) > 1 ? $index[1] : 'INDEX';
+			} else {
+				$columns = $index;
+				$indexType = 'INDEX';
+			}
+
+			$this->doCreateIndex( $tableName, $indexType, $indexName, $columns );
+		}
+
+		$this->reportMessage( "   ... done.\n" );
+
+		return true;
+	}
+
+	/**
+	 * @param array $tableOptions
+	 */
+	abstract protected function getSQLFromDBName( array $tableOptions );
+
+	/**
+	 * @param array $tableOptions
+	 */
+	abstract protected function getSQLFromDBTableOptions( array $tableOptions );
+
+	/**
+	 * Returns an array of fields (as keys) and their types (as values).
+	 *
+	 * @param string $tableName
+	 */
+	abstract protected function getCurrentFields( $tableName );
+
+	/**
+	 * Update a single field given it's name and type and an array of
+	 * current fields.
+	 *
+	 * @param string $tableName
+	 */
+	abstract protected function doUpdateField( $tableName, $fieldName, $fieldType, $currentFields, $positon, array $tableOptions );
+
+	/**
+	 * @param string $tableName
+	 * @param string $fieldName
+	 */
+	abstract protected function doDropTable( $tableName );
+
+	/**
+	 * @param string $tableName
+	 * @param string $fieldName
+	 */
+	abstract protected function doDropField( $tableName, $fieldName );
+
+	/**
+	 * @param string $tableName
+	 * @param array &$indicies
+	 */
+	abstract protected function doDropObsoleteIndicies( $tableName, array &$indicies );
+
+	/**
+	 * Create an index using the suitable SQL for various RDBMS
+	 *
+	 * @param string $tableName
+	 * @param string $indexType
+	 * @param string $indexName
+	 * @param $columns
+	 */
+	abstract protected function doCreateIndex( $tableName, $indexType, $indexName, $columns );
+
+	private function doCreateTable( $tableName, array $tableOptions = null ) {
+
+		$tableName = $this->connection->tableName( $tableName );
+
+		$sql = 'CREATE TABLE ' . $this->getSQLFromDBName( $tableOptions ) . $tableName . ' (';
+
+		$fieldSql = array();
+		$fields = $tableOptions['fields'];
+
+		foreach ( $fields as $fieldName => $fieldType ) {
+			$fieldSql[] = "$fieldName  $fieldType";
+		}
+
+		$sql .= implode( ',', $fieldSql ) . ') ';
+		$sql .= $this->getSQLFromDBTableOptions( $tableOptions );
+
+		$this->connection->query( $sql, __METHOD__ );
+	}
+
+	private function doUpdateTable( $tableName, array $tableOptions = null ) {
+
+		$tableName = $this->connection->tableName( $tableName );
+		$currentFields = $this->getCurrentFields( $tableName );
+
+		$fields = $tableOptions['fields'];
+		$position = 'FIRST';
+
+		// Loop through all the field definitions, and handle each definition for either postgres or MySQL.
+		foreach ( $fields as $fieldName => $fieldType ) {
+			$this->doUpdateField( $tableName, $fieldName, $fieldType, $currentFields, $position, $tableOptions );
+
+			$position = "AFTER $fieldName";
+			$currentFields[$fieldName] = false;
+		}
+
+		// The updated fields have their value set to false, so if a field has a value
+		// that differs from false, it's an obsolete one that should be removed.
+		foreach ( $currentFields as $fieldName => $value ) {
+			if ( $value !== false ) {
+				$this->reportMessage( "   ... deleting obsolete field $fieldName ... " );
+				$this->doDropField( $tableName, $fieldName );
+				$this->reportMessage( "done.\n" );
+			}
+		}
+	}
+
+}

--- a/src/SQLStore/TableBuilder/SQLiteRdbmsTableBuilder.php
+++ b/src/SQLStore/TableBuilder/SQLiteRdbmsTableBuilder.php
@@ -1,0 +1,174 @@
+<?php
+
+namespace SMW\SQLStore\TableBuilder;
+
+/**
+ * @license GNU GPL v2+
+ * @since 2.5
+ *
+ * @author mwjames
+ */
+class SQLiteRdbmsTableBuilder extends MySQLRdbmsTableBuilder {
+
+	/**
+	 * @since 2.5
+	 *
+	 * {@inheritDoc}
+	 */
+	public function getStandardFieldType( $input ) {
+
+		switch ( $input ) {
+			case 'id':
+			return 'INTEGER'; // like page_id in MW page table
+			case 'id primary':
+			return 'INTEGER' . ' NOT NULL PRIMARY KEY AUTOINCREMENT'; // like page_id in MW page table
+			case 'namespace':
+			return 'INT(11)'; // like page_namespace in MW page table
+			case 'title':
+			return 'VARBINARY(255)'; // like page_title in MW page table
+			case 'iw':
+			return 'TEXT'; // like iw_prefix in MW interwiki table
+			case 'blob':
+			return 'MEDIUMBLOB'; // larger blobs of character data, usually not subject to SELECT conditions
+			case 'boolean':
+			return 'TINYINT(1)';
+			case 'double':
+			return 'DOUBLE';
+			case 'integer':
+			return 'INT(8)';
+			case 'usage count':
+			return 'INT(8)';
+			case 'integer unsigned':
+			return 'INTEGER';
+			case 'sort':
+			return 'VARCHAR(255)';
+		}
+
+		return false;
+	}
+
+	/**
+	 * @see MySQLRdbmsTableBuilder::getSQLFromDBName
+	 */
+	protected function getSQLFromDBName( array $tableOptions ) {
+		return '';
+	}
+
+	/**
+	 * @see MySQLRdbmsTableBuilder::getSQLFromDBTableOptions
+	 */
+	protected function getSQLFromDBTableOptions( array $tableOptions ) {
+		return '';
+	}
+
+	/**
+	 * @see MySQLRdbmsTableBuilder::getCurrentFields
+	 */
+	protected function getCurrentFields( $tableName ) {
+
+		$sql = 'PRAGMA table_info(' . $tableName . ')';
+
+		$res = $this->connection->query( $sql, __METHOD__ );
+		$currentFields = array();
+
+		foreach ( $res as $row ) {
+			$row->Field = $row->name;
+			$row->Type = $row->type;
+			$type = $row->type;
+
+			if ( $row->notnull == '1' ) {
+				$type .= ' NOT NULL';
+			}
+
+			if ( $row->pk == '1' ) {
+				$type .= ' PRIMARY KEY AUTOINCREMENT';
+			}
+
+			$currentFields[$row->Field] = $type;
+		}
+
+		return $currentFields;
+	}
+
+	/**
+	 * @see MySQLRdbmsTableBuilder::doCreateField
+	 */
+	protected function doCreateField( $tableName, $fieldName, $position, $fieldType ) {
+		$this->reportMessage( "   ... creating field $fieldName ... " );
+		$this->connection->query( "ALTER TABLE $tableName ADD `$fieldName` $fieldType", __METHOD__ );
+		$this->reportMessage( "done.\n" );
+	}
+
+	/**
+	 * @see MySQLRdbmsTableBuilder::doUpdateFieldType
+	 */
+	protected function doUpdateFieldType( $tableName, $fieldName, $position, $oldFieldType, $newFieldType ) {
+		$this->reportMessage( "   ... changing field type is not supported in SQLite (http://www.sqlite.org/omitted.html) \n" );
+		$this->reportMessage( "       Please delete and reinitialize the tables to remove obsolete data, or just keep it.\n" );
+	}
+
+	/**
+	 * @see MySQLRdbmsTableBuilder::doDropField
+	 */
+	protected function doDropField( $tableName, $fieldName ) {
+		$this->reportMessage( "   ... deleting obsolete field $fieldName not possible in SQLite.\n" );
+		$this->reportMessage( "       Please could delete and reinitialize the tables to remove obsolete data, or just keep it.\n" );
+	}
+
+	/**
+	 * @see GeneralTableCreator::doDropObsoleteIndicies
+	 */
+	protected function doDropObsoleteIndicies( $tableName, array &$indicies ) {
+
+		$currentIndicies = $this->getIndexInfo( $tableName );
+
+		// TODO We do not currently get the right column definitions in
+		// SQLite; hence we can only drop all indexes. Wasteful.
+		foreach ( $currentIndicies as $indexName => $indexColumn ) {
+			$this->doDropIndex( $tableName, $indexName, $indexColumn );
+		}
+	}
+
+	/**
+	 * @see GeneralTableCreator::doCreateIndex
+	 */
+	protected function doCreateIndex( $tableName, $indexType, $indexName, $columns ) {
+
+		$tableName = $this->connection->tableName( $tableName );
+		$indexName = "{$tableName}_index{$indexName}";
+
+		$this->reportMessage( "   ... creating new index $columns ..." );
+		$this->connection->query( "CREATE $indexType $indexName ON $tableName ($columns)", __METHOD__ );
+		$this->reportMessage( "done.\n" );
+	}
+
+	private function getIndexInfo( $tableName ) {
+
+		$tableName = $this->connection->tableName( $tableName );
+		$indices = array();
+
+		$res = $this->connection->query( 'PRAGMA index_list(' . $tableName . ')', __METHOD__ );
+
+		if ( !$res ) {
+			return array();
+		}
+
+		foreach ( $res as $row ) {
+			/// FIXME The value should not be $row->name below?!
+			if ( !array_key_exists( $row->name, $indices ) ) {
+				$indices[$row->name] = $row->name;
+			} else {
+				$indices[$row->name] .= ',' . $row->name;
+			}
+		}
+
+		return $indices;
+	}
+
+	private function doDropIndex( $tableName, $indexName, $columns ) {
+		$this->reportMessage( "   ... removing index $columns ..." );
+		$this->connection->query( 'DROP INDEX ' . $indexName, __METHOD__ );
+		$this->reportMessage( "done.\n" );
+	}
+
+}

--- a/src/SQLStore/TableBuilder/TableBuilder.php
+++ b/src/SQLStore/TableBuilder/TableBuilder.php
@@ -1,0 +1,90 @@
+<?php
+
+namespace SMW\SQLStore\TableBuilder;
+
+/**
+ * @license GNU GPL v2+
+ * @since 2.5
+ *
+ * @author mwjames
+ */
+interface TableBuilder {
+
+	/**
+	 * Generic creation and updating function for database tables. Ideally, it
+	 * would be able to modify a table's signature in arbitrary ways, but it will
+	 * fail for some changes. Its string-based interface is somewhat too
+	 * impoverished for a permanent solution. It would be possible to go for update
+	 * scripts (specific to each change) in the style of MediaWiki instead.
+	 *
+	 * Make sure the table of the given name has the given fields, provided
+	 * as an array with entries fieldname => typeparams. typeparams should be
+	 * in a normalised form and order to match to existing values.
+	 *
+	 * The function returns an array that includes all columns that have been
+	 * changed. For each such column, the array contains an entry
+	 * columnname => action, where action is one of 'up', 'new', or 'del'
+	 *
+	 * @note The function partly ignores the order in which fields are set up.
+	 * Only if the type of some field changes will its order be adjusted explicitly.
+	 *
+	 * ```
+	 * $tableOptions = array(
+	 * 	'fields' => array(
+	 * 	),
+	 * 	'wgDBname' => $GLOBALS['$wgDBname'],
+	 * 	'wgDBTableOptions' => $GLOBALS['wgDBTableOptions']
+	 *  ...
+	 * )
+	 *```
+	 * @since 2.5
+	 *
+	 * @param string $tableName
+	 * @param array|null $tableOptions
+	 */
+	public function createTable( $tableName, array $tableOptions = null );
+
+	/**
+	 * Removes a table from the RDBMS backend.
+	 *
+	 * @since 2.5
+	 *
+	 * @param string $tableName
+	 */
+	public function dropTable( $tableName );
+
+	/**
+	 * Generic method to create or update index information of a table
+	 *
+	 * ```
+	 * $indexOptions = array(
+	 * 	'indicies' => array(
+	 * 	)
+	 *  ...
+	 * )
+	 *```
+	 *
+	 * @since 2.5
+	 *
+	 * @param string $indexName
+	 * @param array|null $indexOptions
+	 */
+	public function createIndex( $tableName, array $indexOptions = null );
+
+	/**
+	 * Database backends often have different types that need to be used
+	 * repeatedly in (Semantic) MediaWiki. This function provides the
+	 * preferred type (as a string) for various common kinds of columns.
+	 * The input is one of the following strings: 'id' (page id numbers or
+	 * similar), 'title' (title strings or similar), 'namespace' (namespace
+	 * numbers), 'blob' (longer text blobs), 'iw' (interwiki prefixes).
+	 *
+	 * @since 2.5
+	 *
+	 * @param string $input
+	 *
+	 * @return string|false SQL type declaration
+	 */
+	public function getStandardFieldType( $input );
+
+}

--- a/tests/phpunit/Integration/SQLStore/TableBuilder/RdbmsTableBuilderIntegrationTest.php
+++ b/tests/phpunit/Integration/SQLStore/TableBuilder/RdbmsTableBuilderIntegrationTest.php
@@ -1,0 +1,252 @@
+<?php
+
+namespace SMW\Tests\Integration\SQLStore\TableBuilder;
+
+use SMW\Tests\MwDBaseUnitTestCase;
+use SMW\SQLStore\TableBuilder\RdbmsTableBuilder;
+use SMW\SQLStore\TableBuilder\PostgresRdbmsTableBuilder;
+use SMW\SQLStore\TableBuilder\SQLiteRdbmsTableBuilder;
+use Onoi\MessageReporter\MessageReporterFactory;
+
+/**
+ * @group semantic-mediawiki
+ * @group medium
+ *
+ * @license GNU GPL v2+
+ * @since 2.5
+ *
+ * @author mwjames
+ */
+class RdbmsTableBuilderIntegrationTest extends MwDBaseUnitTestCase {
+
+	private $messageReporterFactory;
+	private $rdbmsTableBuilder;
+	private $stringValidator;
+
+	protected function setUp() {
+		parent::setUp();
+
+		$this->messageReporterFactory = MessageReporterFactory::getInstance();
+
+		$this->rdbmsTableBuilder = RdbmsTableBuilder::factory(
+			$this->getStore()->getConnection( DB_MASTER )
+		);
+
+		$this->stringValidator = $this->testEnvironment->getUtilityFactory()->newValidatorFactory()->newStringValidator();
+	}
+
+	protected function tearDown() {
+		parent::tearDown();
+	}
+
+	public function testCreateTable() {
+
+		$messageReporter = $this->messageReporterFactory->newSpyMessageReporter();
+
+		$this->rdbmsTableBuilder->setMessageReporter(
+			$messageReporter
+		);
+
+		$definition = array(
+			'fields' => array(
+				'id'   => $this->rdbmsTableBuilder->getStandardFieldType( 'id primary' ),
+				't_text' => $this->rdbmsTableBuilder->getStandardFieldType( 'blob' ),
+			),
+			'wgDBname' => $GLOBALS['wgDBname'],
+			'wgDBTableOptions' => $GLOBALS['wgDBTableOptions']
+		);
+
+		$this->rdbmsTableBuilder->createTable( 'rdbms_test', $definition );
+
+		$expected = array(
+			'Checking table rdbms_test',
+			'Table not found, now creating',
+		);
+
+		$this->stringValidator->assertThatStringContains(
+			$expected,
+			$messageReporter->getMessagesAsString()
+		);
+	}
+
+	public function testUpdateTableWithNewField() {
+
+		$messageReporter = $this->messageReporterFactory->newSpyMessageReporter();
+
+		$this->rdbmsTableBuilder->setMessageReporter(
+			$messageReporter
+		);
+
+		$definition = array(
+			'fields' => array(
+				'id'   => $this->rdbmsTableBuilder->getStandardFieldType( 'id primary' ),
+				't_text' => $this->rdbmsTableBuilder->getStandardFieldType( 'blob' ),
+				't_num'  => $this->rdbmsTableBuilder->getStandardFieldType( 'integer' ),
+				't_int'  => $this->rdbmsTableBuilder->getStandardFieldType( 'integer' )
+			),
+			'wgDBname' => $GLOBALS['wgDBname'],
+			'wgDBTableOptions' => $GLOBALS['wgDBTableOptions']
+		);
+
+		$this->rdbmsTableBuilder->createTable( 'rdbms_test', $definition );
+
+		$expected = array(
+			'Checking table rdbms_test',
+			'Table already exists, checking structure',
+			'creating field t_num',
+		);
+
+		$this->stringValidator->assertThatStringContains(
+			$expected,
+			$messageReporter->getMessagesAsString()
+		);
+	}
+
+	public function testUpdateTableWithNewFieldType() {
+
+		$messageReporter = $this->messageReporterFactory->newSpyMessageReporter();
+
+		$this->rdbmsTableBuilder->setMessageReporter(
+			$messageReporter
+		);
+
+		$definition = array(
+			'fields' => array(
+				'id'   => $this->rdbmsTableBuilder->getStandardFieldType( 'id primary' ),
+				't_text' => $this->rdbmsTableBuilder->getStandardFieldType( 'blob' ),
+				't_num'  => $this->rdbmsTableBuilder->getStandardFieldType( 'double' ),
+				't_int'  => $this->rdbmsTableBuilder->getStandardFieldType( 'integer' )
+			),
+			'wgDBname' => $GLOBALS['wgDBname'],
+			'wgDBTableOptions' => $GLOBALS['wgDBTableOptions']
+		);
+
+		$this->rdbmsTableBuilder->createTable( 'rdbms_test', $definition );
+
+		$expected = array(
+			'Checking table rdbms_test',
+			'Table already exists, checking structure',
+			'changing type of field t_num',
+		);
+
+		// Not supported
+		if ( $this->rdbmsTableBuilder instanceof SQLiteRdbmsTableBuilder ) {
+			$expected = str_replace( 'changing type of field t_num', 'changing field type is not supported', $expected );
+		}
+
+		$this->stringValidator->assertThatStringContains(
+			$expected,
+			$messageReporter->getMessagesAsString()
+		);
+	}
+
+	public function testCreateIndex() {
+
+		$messageReporter = $this->messageReporterFactory->newSpyMessageReporter();
+
+		$this->rdbmsTableBuilder->setMessageReporter(
+			$messageReporter
+		);
+
+		$definition = array(
+			'indicies' => array(
+				'id',
+				't_num'
+			)
+		);
+
+		$this->rdbmsTableBuilder->createIndex( 'rdbms_test', $definition );
+
+		$expected = array(
+			'Checking index structures for table rdbms_test',
+			'index id is fine',
+			'creating new index t_num'
+		);
+
+		// ID message, Primary doesn't implicitly exists before
+		if ( $this->rdbmsTableBuilder instanceof PostgresRdbmsTableBuilder || $this->rdbmsTableBuilder instanceof SQLiteRdbmsTableBuilder ) {
+			$expected = str_replace( 'index id is fine', 'creating new index id', $expected );
+		}
+
+		$this->stringValidator->assertThatStringContains(
+			$expected,
+			$messageReporter->getMessagesAsString()
+		);
+	}
+
+	public function testUpdateExistingIndex() {
+
+		$messageReporter = $this->messageReporterFactory->newSpyMessageReporter();
+
+		$this->rdbmsTableBuilder->setMessageReporter(
+			$messageReporter
+		);
+
+		$definition = array(
+			'indicies' => array(
+				'id',
+				't_num,t_int'
+			)
+		);
+
+		$this->rdbmsTableBuilder->createIndex( 'rdbms_test', $definition );
+
+		$expected = array(
+			'Checking index structures for table rdbms_test',
+			'index id is fine',
+			'removing index t_num',
+			'creating new index t_num,t_int',
+		);
+
+		if ( $this->rdbmsTableBuilder instanceof SQLiteRdbmsTableBuilder ) {
+			$expected = str_replace( 'index id is fine', 'creating new index id', $expected );
+			$expected = 'removing index';
+		}
+
+		$this->stringValidator->assertThatStringContains(
+			$expected,
+			$messageReporter->getMessagesAsString()
+		);
+	}
+
+	public function testDropTable() {
+
+		$messageReporter = $this->messageReporterFactory->newSpyMessageReporter();
+
+		$this->rdbmsTableBuilder->setMessageReporter(
+			$messageReporter
+		);
+
+		$this->rdbmsTableBuilder->dropTable( 'rdbms_test' );
+
+		$expected = array(
+			'dropped table rdbms_test'
+		);
+
+		$this->stringValidator->assertThatStringContains(
+			$expected,
+			$messageReporter->getMessagesAsString()
+		);
+	}
+
+	public function testTryToDropTableWhichNotExists() {
+
+		$messageReporter = $this->messageReporterFactory->newSpyMessageReporter();
+
+		$this->rdbmsTableBuilder->setMessageReporter(
+			$messageReporter
+		);
+
+		$this->rdbmsTableBuilder->dropTable( 'foo_test' );
+
+		$expected = array(
+			'foo_test not found, skipping removal'
+		);
+
+		$this->stringValidator->assertThatStringContains(
+			$expected,
+			$messageReporter->getMessagesAsString()
+		);
+	}
+
+}

--- a/tests/phpunit/Unit/SQLStore/SQLStoreFactoryTest.php
+++ b/tests/phpunit/Unit/SQLStore/SQLStoreFactoryTest.php
@@ -169,4 +169,30 @@ class SQLStoreFactoryTest extends \PHPUnit_Framework_TestCase {
 		);
 	}
 
+	public function testCanConstructRdbmsTableBuilder() {
+
+		$connection = $this->getMockBuilder( '\DatabaseBase' )
+			->disableOriginalConstructor()
+			->getMockForAbstractClass();
+
+		$connection->expects( $this->any() )
+			->method( 'getType' )
+			->will( $this->returnValue( 'mysql' ) );
+
+		$store = $this->getMockBuilder( '\SMW\SQLStore\SQLStore' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$store->expects( $this->once() )
+			->method( 'getConnection' )
+			->will( $this->returnValue( $connection ) );
+
+		$instance = new SQLStoreFactory( $store );
+
+		$this->assertInstanceOf(
+			'SMW\SQLStore\TableBuilder\RdbmsTableBuilder',
+			$instance->newRdbmsTableBuilder()
+		);
+	}
+
 }

--- a/tests/phpunit/Unit/SQLStore/TableBuilder/MySQLRdbmsTableBuilderTest.php
+++ b/tests/phpunit/Unit/SQLStore/TableBuilder/MySQLRdbmsTableBuilderTest.php
@@ -1,0 +1,152 @@
+<?php
+
+namespace SMW\Tests\SQLStore\TableBuilder;
+
+use SMW\SQLStore\TableBuilder\MySQLRdbmsTableBuilder;
+
+/**
+ * @covers \SMW\SQLStore\TableBuilder\MySQLRdbmsTableBuilder
+ * @group semantic-mediawiki
+ *
+ * @license GNU GPL v2+
+ * @since 2.5
+ *
+ * @author mwjames
+ */
+class MySQLRdbmsTableBuilderTest extends \PHPUnit_Framework_TestCase {
+
+	public function testCanConstruct() {
+
+		$connection = $this->getMockBuilder( '\DatabaseBase' )
+			->disableOriginalConstructor()
+			->getMockForAbstractClass();
+
+		$connection->expects( $this->any() )
+			->method( 'getType' )
+			->will( $this->returnValue( 'mysql' ) );
+
+		$this->assertInstanceOf(
+			'\SMW\SQLStore\TableBuilder\MySQLRdbmsTableBuilder',
+			MySQLRdbmsTableBuilder::factory( $connection )
+		);
+	}
+
+	public function testCreateTableOnNewTable() {
+
+		$connection = $this->getMockBuilder( '\DatabaseBase' )
+			->disableOriginalConstructor()
+			->setMethods( array( 'tableExists', 'query' ) )
+			->getMockForAbstractClass();
+
+		$connection->expects( $this->any() )
+			->method( 'getType' )
+			->will( $this->returnValue( 'mysql' ) );
+
+		$connection->expects( $this->any() )
+			->method( 'tableExists' )
+			->will( $this->returnValue( false ) );
+
+		$connection->expects( $this->once() )
+			->method( 'query' )
+			->with( $this->stringContains( 'CREATE TABLE' ) );
+
+		$instance = MySQLRdbmsTableBuilder::factory( $connection );
+
+		$tableOptions = array(
+			'fields' => array( 'bar' => 'text' )
+		);
+
+		$instance->createTable( 'foo', $tableOptions );
+	}
+
+	public function testUpdateTableOnOldTable() {
+
+		$connection = $this->getMockBuilder( '\DatabaseBase' )
+			->disableOriginalConstructor()
+			->setMethods( array( 'tableExists', 'query' ) )
+			->getMockForAbstractClass();
+
+		$connection->expects( $this->any() )
+			->method( 'getType' )
+			->will( $this->returnValue( 'mysql' ) );
+
+		$connection->expects( $this->any() )
+			->method( 'tableExists' )
+			->will( $this->returnValue( true ) );
+
+		$connection->expects( $this->at( 2 ) )
+			->method( 'query' )
+			->with( $this->stringContains( 'DESCRIBE' ) )
+			->will( $this->returnValue( array() ) );
+
+		$connection->expects( $this->at( 3 ) )
+			->method( 'query' )
+			->with( $this->stringContains( 'ALTER TABLE "foo" ADD `bar` text FIRST' ) );
+
+		$instance = MySQLRdbmsTableBuilder::factory( $connection );
+
+		$tableOptions = array(
+			'fields' => array( 'bar' => 'text' )
+		);
+
+		$instance->createTable( 'foo', $tableOptions );
+	}
+
+	public function testCreateIndex() {
+
+		$connection = $this->getMockBuilder( '\DatabaseBase' )
+			->disableOriginalConstructor()
+			->setMethods( array( 'tableExists', 'query' ) )
+			->getMockForAbstractClass();
+
+		$connection->expects( $this->any() )
+			->method( 'getType' )
+			->will( $this->returnValue( 'mysql' ) );
+
+		$connection->expects( $this->any() )
+			->method( 'tableExists' )
+			->will( $this->returnValue( false ) );
+
+		$connection->expects( $this->at( 1 ) )
+			->method( 'query' )
+			->with( $this->stringContains( 'SHOW INDEX' ) )
+			->will( $this->returnValue( array() ) );
+
+		$connection->expects( $this->at( 2 ) )
+			->method( 'query' )
+			->with( $this->stringContains( 'ALTER TABLE "foo" ADD INDEX (bar)' ) );
+
+		$instance = MySQLRdbmsTableBuilder::factory( $connection );
+
+		$indexOptions = array(
+			'indicies' => array( 'bar' )
+		);
+
+		$instance->createIndex( 'foo', $indexOptions );
+	}
+
+	public function testDropTable() {
+
+		$connection = $this->getMockBuilder( '\DatabaseBase' )
+			->disableOriginalConstructor()
+			->setMethods( array( 'tableExists', 'query' ) )
+			->getMockForAbstractClass();
+
+		$connection->expects( $this->any() )
+			->method( 'getType' )
+			->will( $this->returnValue( 'mysql' ) );
+
+		$connection->expects( $this->once() )
+			->method( 'tableExists' )
+			->will( $this->returnValue( true ) );
+
+		$connection->expects( $this->once() )
+			->method( 'query' )
+			->with( $this->stringContains( 'DROP TABLE "foo"' ) );
+
+		$instance = MySQLRdbmsTableBuilder::factory( $connection );
+
+		$instance->dropTable( 'foo' );
+	}
+
+}

--- a/tests/phpunit/Unit/SQLStore/TableBuilder/PostgresRdbmsTableBuilderTest.php
+++ b/tests/phpunit/Unit/SQLStore/TableBuilder/PostgresRdbmsTableBuilderTest.php
@@ -1,0 +1,156 @@
+<?php
+
+namespace SMW\Tests\SQLStore\TableBuilder;
+
+use SMW\SQLStore\TableBuilder\PostgresRdbmsTableBuilder;
+
+/**
+ * @covers \SMW\SQLStore\TableBuilder\PostgresRdbmsTableBuilder
+ * @group semantic-mediawiki
+ *
+ * @license GNU GPL v2+
+ * @since 2.5
+ *
+ * @author mwjames
+ */
+class PostgresRdbmsTableBuilderTest extends \PHPUnit_Framework_TestCase {
+
+	public function testCanConstruct() {
+
+		$connection = $this->getMockBuilder( '\DatabaseBase' )
+			->disableOriginalConstructor()
+			->getMockForAbstractClass();
+
+		$connection->expects( $this->any() )
+			->method( 'getType' )
+			->will( $this->returnValue( 'postgres' ) );
+
+		$this->assertInstanceOf(
+			'\SMW\SQLStore\TableBuilder\PostgresRdbmsTableBuilder',
+			PostgresRdbmsTableBuilder::factory( $connection )
+		);
+	}
+
+	public function testCreateTableOnNewTable() {
+
+		$connection = $this->getMockBuilder( '\DatabaseBase' )
+			->disableOriginalConstructor()
+			->setMethods( array( 'tableExists', 'query' ) )
+			->getMockForAbstractClass();
+
+		$connection->expects( $this->any() )
+			->method( 'getType' )
+			->will( $this->returnValue( 'postgres' ) );
+
+		$connection->expects( $this->any() )
+			->method( 'tableExists' )
+			->will( $this->returnValue( false ) );
+
+		$connection->expects( $this->once() )
+			->method( 'query' )
+			->with( $this->stringContains( 'CREATE TABLE' ) );
+
+		$instance = PostgresRdbmsTableBuilder::factory( $connection );
+
+		$tableOptions = array(
+			'fields' => array( 'bar' => 'text' )
+		);
+
+		$instance->createTable( 'foo', $tableOptions );
+	}
+
+	public function testUpdateTableOnOldTable() {
+
+		$connection = $this->getMockBuilder( '\DatabaseBase' )
+			->disableOriginalConstructor()
+			->setMethods( array( 'tableExists', 'query' ) )
+			->getMockForAbstractClass();
+
+		$connection->expects( $this->any() )
+			->method( 'getType' )
+			->will( $this->returnValue( 'postgres' ) );
+
+		$connection->expects( $this->any() )
+			->method( 'tableExists' )
+			->will( $this->returnValue( true ) );
+
+		$connection->expects( $this->at( 2 ) )
+			->method( 'query' )
+			->with( $this->stringContains( 'SELECT a.attname as' ) )
+			->will( $this->returnValue( array() ) );
+
+		$connection->expects( $this->at( 3 ) )
+			->method( 'query' )
+			->with( $this->stringContains( 'ALTER TABLE "foo" ADD "bar" TEXT' ) );
+
+		$instance = PostgresRdbmsTableBuilder::factory( $connection );
+
+		$tableOptions = array(
+			'fields' => array( 'bar' => 'text' )
+		);
+
+		$instance->createTable( 'foo', $tableOptions );
+	}
+
+	public function testCreateIndex() {
+
+		$connection = $this->getMockBuilder( '\DatabaseBase' )
+			->disableOriginalConstructor()
+			->setMethods( array( 'tableExists', 'query', 'indexInfo' ) )
+			->getMockForAbstractClass();
+
+		$connection->expects( $this->any() )
+			->method( 'getType' )
+			->will( $this->returnValue( 'postgres' ) );
+
+		$connection->expects( $this->any() )
+			->method( 'tableExists' )
+			->will( $this->returnValue( false ) );
+
+		$connection->expects( $this->any() )
+			->method( 'indexInfo' )
+			->will( $this->returnValue( false ) );
+
+		$connection->expects( $this->at( 1 ) )
+			->method( 'query' )
+			->with( $this->stringContains( 'SELECT  i.relname AS indexname' ) )
+			->will( $this->returnValue( array() ) );
+
+		$connection->expects( $this->at( 3 ) )
+			->method( 'query' )
+			->with( $this->stringContains( 'CREATE INDEX foo_index0 ON foo (bar)' ) );
+
+		$instance = PostgresRdbmsTableBuilder::factory( $connection );
+
+		$indexOptions = array(
+			'indicies' => array( 'bar' )
+		);
+
+		$instance->createIndex( 'foo', $indexOptions );
+	}
+
+	public function testDropTable() {
+
+		$connection = $this->getMockBuilder( '\DatabaseBase' )
+			->disableOriginalConstructor()
+			->setMethods( array( 'tableExists', 'query' ) )
+			->getMockForAbstractClass();
+
+		$connection->expects( $this->any() )
+			->method( 'getType' )
+			->will( $this->returnValue( 'postgres' ) );
+
+		$connection->expects( $this->once() )
+			->method( 'tableExists' )
+			->will( $this->returnValue( true ) );
+
+		$connection->expects( $this->once() )
+			->method( 'query' )
+			->with( $this->stringContains( 'DROP TABLE IF EXISTS "foo"' ) );
+
+		$instance = PostgresRdbmsTableBuilder::factory( $connection );
+
+		$instance->dropTable( 'foo' );
+	}
+
+}

--- a/tests/phpunit/Unit/SQLStore/TableBuilder/RdbmsTableBuilderTest.php
+++ b/tests/phpunit/Unit/SQLStore/TableBuilder/RdbmsTableBuilderTest.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace SMW\Tests\SQLStore\TableBuilder;
+
+use SMW\SQLStore\TableBuilder\RdbmsTableBuilder;
+
+/**
+ * @covers \SMW\SQLStore\TableBuilder\RdbmsTableBuilder
+ * @group semantic-mediawiki
+ *
+ * @license GNU GPL v2+
+ * @since 2.5
+ *
+ * @author mwjames
+ */
+class RdbmsTableBuilderTest extends \PHPUnit_Framework_TestCase {
+
+	public function testCanConstructForMySQL() {
+
+		$connection = $this->getMockBuilder( '\DatabaseBase' )
+			->disableOriginalConstructor()
+			->getMockForAbstractClass();
+
+		$connection->expects( $this->any() )
+			->method( 'getType' )
+			->will( $this->returnValue( 'mysql' ) );
+
+		$this->assertInstanceOf(
+			'\SMW\SQLStore\TableBuilder\MySQLRdbmsTableBuilder',
+			RdbmsTableBuilder::factory( $connection )
+		);
+	}
+
+	public function testCanConstructForSQLite() {
+
+		$connection = $this->getMockBuilder( '\DatabaseBase' )
+			->disableOriginalConstructor()
+			->getMockForAbstractClass();
+
+		$connection->expects( $this->any() )
+			->method( 'getType' )
+			->will( $this->returnValue( 'sqlite' ) );
+
+		$this->assertInstanceOf(
+			'\SMW\SQLStore\TableBuilder\SQLiteRdbmsTableBuilder',
+			RdbmsTableBuilder::factory( $connection )
+		);
+	}
+
+	public function testCanConstructForPostgres() {
+
+		$connection = $this->getMockBuilder( '\DatabaseBase' )
+			->disableOriginalConstructor()
+			->getMockForAbstractClass();
+
+		$connection->expects( $this->any() )
+			->method( 'getType' )
+			->will( $this->returnValue( 'postgres' ) );
+
+		$this->assertInstanceOf(
+			'\SMW\SQLStore\TableBuilder\PostgresRdbmsTableBuilder',
+			RdbmsTableBuilder::factory( $connection )
+		);
+	}
+
+	public function testTryToConstructOnInvalidTypeThrowsException() {
+
+		$connection = $this->getMockBuilder( '\DatabaseBase' )
+			->disableOriginalConstructor()
+			->getMockForAbstractClass();
+
+		$connection->expects( $this->any() )
+			->method( 'getType' )
+			->will( $this->returnValue( 'foo' ) );
+
+		$this->setExpectedException( 'RuntimeException' );
+		RdbmsTableBuilder::factory( $connection );
+	}
+
+}

--- a/tests/phpunit/Unit/SQLStore/TableBuilder/SQLiteRdbmsTableBuilderTest.php
+++ b/tests/phpunit/Unit/SQLStore/TableBuilder/SQLiteRdbmsTableBuilderTest.php
@@ -1,0 +1,152 @@
+<?php
+
+namespace SMW\Tests\SQLStore\TableBuilder;
+
+use SMW\SQLStore\TableBuilder\SQLiteRdbmsTableBuilder;
+
+/**
+ * @covers \SMW\SQLStore\TableBuilder\SQLiteRdbmsTableBuilder
+ * @group semantic-mediawiki
+ *
+ * @license GNU GPL v2+
+ * @since 2.5
+ *
+ * @author mwjames
+ */
+class SQLiteRdbmsTableBuilderTest extends \PHPUnit_Framework_TestCase {
+
+	public function testCanConstruct() {
+
+		$connection = $this->getMockBuilder( '\DatabaseBase' )
+			->disableOriginalConstructor()
+			->getMockForAbstractClass();
+
+		$connection->expects( $this->any() )
+			->method( 'getType' )
+			->will( $this->returnValue( 'sqlite' ) );
+
+		$this->assertInstanceOf(
+			'\SMW\SQLStore\TableBuilder\SQLiteRdbmsTableBuilder',
+			SQLiteRdbmsTableBuilder::factory( $connection )
+		);
+	}
+
+	public function testCreateTableOnNewTable() {
+
+		$connection = $this->getMockBuilder( '\DatabaseBase' )
+			->disableOriginalConstructor()
+			->setMethods( array( 'tableExists', 'query' ) )
+			->getMockForAbstractClass();
+
+		$connection->expects( $this->any() )
+			->method( 'getType' )
+			->will( $this->returnValue( 'sqlite' ) );
+
+		$connection->expects( $this->any() )
+			->method( 'tableExists' )
+			->will( $this->returnValue( false ) );
+
+		$connection->expects( $this->once() )
+			->method( 'query' )
+			->with( $this->stringContains( 'CREATE TABLE' ) );
+
+		$instance = SQLiteRdbmsTableBuilder::factory( $connection );
+
+		$tableOptions = array(
+			'fields' => array( 'bar' => 'text' )
+		);
+
+		$instance->createTable( 'foo', $tableOptions );
+	}
+
+	public function testUpdateTableOnOldTable() {
+
+		$connection = $this->getMockBuilder( '\DatabaseBase' )
+			->disableOriginalConstructor()
+			->setMethods( array( 'tableExists', 'query' ) )
+			->getMockForAbstractClass();
+
+		$connection->expects( $this->any() )
+			->method( 'getType' )
+			->will( $this->returnValue( 'sqlite' ) );
+
+		$connection->expects( $this->any() )
+			->method( 'tableExists' )
+			->will( $this->returnValue( true ) );
+
+		$connection->expects( $this->at( 2 ) )
+			->method( 'query' )
+			->with( $this->stringContains( 'PRAGMA table_info("foo")' ) )
+			->will( $this->returnValue( array() ) );
+
+		$connection->expects( $this->at( 3 ) )
+			->method( 'query' )
+			->with( $this->stringContains( 'ALTER TABLE "foo" ADD `bar` text' ) );
+
+		$instance = SQLiteRdbmsTableBuilder::factory( $connection );
+
+		$tableOptions = array(
+			'fields' => array( 'bar' => 'text' )
+		);
+
+		$instance->createTable( 'foo', $tableOptions );
+	}
+
+	public function testCreateIndex() {
+
+		$connection = $this->getMockBuilder( '\DatabaseBase' )
+			->disableOriginalConstructor()
+			->setMethods( array( 'tableExists', 'query' ) )
+			->getMockForAbstractClass();
+
+		$connection->expects( $this->any() )
+			->method( 'getType' )
+			->will( $this->returnValue( 'sqlite' ) );
+
+		$connection->expects( $this->any() )
+			->method( 'tableExists' )
+			->will( $this->returnValue( false ) );
+
+		$connection->expects( $this->at( 1 ) )
+			->method( 'query' )
+			->with( $this->stringContains( 'PRAGMA index_list("foo")' ) )
+			->will( $this->returnValue( array() ) );
+
+		$connection->expects( $this->at( 2 ) )
+			->method( 'query' )
+			->with( $this->stringContains( 'CREATE INDEX "foo"_index0' ) );
+
+		$instance = SQLiteRdbmsTableBuilder::factory( $connection );
+
+		$indexOptions = array(
+			'indicies' => array( 'bar' )
+		);
+
+		$instance->createIndex( 'foo', $indexOptions );
+	}
+
+	public function testDropTable() {
+
+		$connection = $this->getMockBuilder( '\DatabaseBase' )
+			->disableOriginalConstructor()
+			->setMethods( array( 'tableExists', 'query' ) )
+			->getMockForAbstractClass();
+
+		$connection->expects( $this->any() )
+			->method( 'getType' )
+			->will( $this->returnValue( 'sqlite' ) );
+
+		$connection->expects( $this->once() )
+			->method( 'tableExists' )
+			->will( $this->returnValue( true ) );
+
+		$connection->expects( $this->once() )
+			->method( 'query' )
+			->with( $this->stringContains( 'DROP TABLE "foo"' ) );
+
+		$instance = SQLiteRdbmsTableBuilder::factory( $connection );
+
+		$instance->dropTable( 'foo' );
+	}
+
+}


### PR DESCRIPTION
- RDBMS specific code has been moved into corresponding subclasses with `RdbmsTableBuilder` itself implementing the `TableBuilder` interface
- Add unit/integration tests to verify that tables/indicies are created as specified