### PR TITLE
InTextAnnotationParser to check for possible pipe split, refs #1747

### DIFF
--- a/src/InTextAnnotationParser.php
+++ b/src/InTextAnnotationParser.php
@@ -205,6 +205,12 @@ class InTextAnnotationParser {
 				}
 
 				if ( array_key_exists( 2, $matches ) ) {
+
+					// #1747
+					if ( strpos( $matches[1], '|' ) !== false ) {
+						return $matches[0];
+					}
+
 					$parts = explode( '|', $matches[2] );
 					$value = array_key_exists( 0, $parts ) ? $parts[0] : '';
 					$caption = array_key_exists( 1, $parts ) ? $parts[1] : false;
@@ -307,7 +313,16 @@ class InTextAnnotationParser {
 		$caption = false;
 
 		if ( array_key_exists( 2, $semanticLink ) ) {
+
+			// #1747 avoid a mismatch on an annotation like [[Foo|Bar::Foobar]]
+			// where the left part of :: is split and would contain "Foo|Bar"
+			// hence this type is categorized as no value annotation
+			if ( strpos( $semanticLink[1], '|' ) !== false ) {
+				return $semanticLink[0];
+			}
+
 			$parts = explode( '|', $semanticLink[2] );
+
 			if ( array_key_exists( 0, $parts ) ) {
 				$value = $parts[0];
 			}

--- a/tests/phpunit/Integration/ByJsonScript/Fixtures/p-0433.json
+++ b/tests/phpunit/Integration/ByJsonScript/Fixtures/p-0433.json
@@ -1,0 +1,68 @@
+{
+	"description": "Test in-text annotation `::` with left pipe (#1747, `wgContLang=en`)",
+	"properties": [
+		{
+			"name": "Has text",
+			"contents": "[[Has type::Text]]"
+		}
+	],
+	"subjects": [
+		{
+			"name": "Example/P0433/1",
+			"contents": "[[Foo|Bar::Foobar]] [[File:Example.png|alt=Bar::Foobar|Caption]] [[File:Example.png|Bar::Foobar|link=Foo]]"
+		},
+		{
+			"name": "Example/P0433/2",
+			"contents": "{{#set:Has text=[[Foo|Bar::Foobar]] [[File:Example.png|alt=Bar::Foobar|Caption]] [[File:Example.png|Bar::Foobar|link=Foo]] }}"
+		},
+		{
+			"name": "Example/P0433/Q.1",
+			"contents": "{{#ask: [[Example/P0433/2]] |?Has text |link=none}}"
+		}
+	],
+	"parser-testcases": [
+		{
+			"about": "#0 no annotation due to left pipe",
+			"subject": "Example/P0433/1",
+			"store": {
+				"semantic-data": {
+					"strict-mode-valuematch": false,
+					"propertyCount": 3,
+					"propertyKeys": [ "_SKEY", "_MDAT", "_INST" ],
+					"propertyValues": []
+				}
+			}
+		},
+		{
+			"about": "#1",
+			"subject": "Example/P0433/2",
+			"store": {
+				"semantic-data": {
+					"strict-mode-valuematch": false,
+					"propertyCount": 3,
+					"propertyKeys": [ "_SKEY", "_MDAT", "Has_text" ],
+					"propertyValues": [ "[[Foo|Bar::Foobar]] [[File:Example.png|alt=Bar::Foobar|Caption]] [[File:Example.png|Bar::Foobar|link=Foo]]" ]
+				}
+			}
+		},
+		{
+			"about": "#2",
+			"subject": "Example/P0433/Q.1",
+			"expected-output": {
+				"to-contain": [
+					"title=\"File:Example.png\">Caption</a>",
+					"title=\"File:Example.png\">Bar::Foobar</a>"
+				]
+			}
+		}
+	],
+	"settings": {
+		"wgContLang": "en",
+		"smwgPageSpecialProperties": [ "_MDAT" ]
+	},
+	"meta": {
+		"version": "0.1",
+		"is-incomplete": false,
+		"debug": false
+	}
+}

--- a/tests/phpunit/Unit/InTextAnnotationParserTest.php
+++ b/tests/phpunit/Unit/InTextAnnotationParserTest.php
@@ -259,7 +259,7 @@ class InTextAnnotationParserTest extends \PHPUnit_Framework_TestCase {
 	}
 
 	/**
-	 * @dataProvider textWithAnnotationProvider
+	 * @dataProvider stripTextWithAnnotationProvider
 	 */
 	public function testStrip( $text, $expectedRemoval, $expectedObscuration ) {
 
@@ -274,7 +274,7 @@ class InTextAnnotationParserTest extends \PHPUnit_Framework_TestCase {
 		);
 	}
 
-	public function textWithAnnotationProvider() {
+	public function stripTextWithAnnotationProvider() {
 
 		$provider = array();
 
@@ -312,6 +312,13 @@ class InTextAnnotationParserTest extends \PHPUnit_Framework_TestCase {
 			'Suspendisse tincidunt semper facilisi',
 			'Suspendisse tincidunt semper facilisi',
 			'Suspendisse tincidunt semper facilisi'
+		);
+
+		// #1747
+		$provider[] = array(
+			'[[Foo|Bar::Foobar]] [[File:Example.png|alt=Bar::Foobar|Caption]] [[File:Example.png|Bar::Foobar|link=Foo]]',
+			'[[Foo|Bar::Foobar]] [[File:Example.png|alt=Bar::Foobar|Caption]] [[File:Example.png|Bar::Foobar|link=Foo]]',
+			'&#x005B;&#x005B;Foo|Bar::Foobar]] &#x005B;&#x005B;File:Example.png|alt=Bar::Foobar|Caption]] &#x005B;&#x005B;File:Example.png|Bar::Foobar|link=Foo]]'
 		);
 
 		return $provider;
@@ -543,6 +550,40 @@ class InTextAnnotationParserTest extends \PHPUnit_Framework_TestCase {
 				'propertyCount'  => 4,
 				'propertyLabels' => array( 'Foo', 'Bar:', 'Foobar', ':0049 30 12345678/' ),
 				'propertyValues' => array( 'Foobar', 'Foo', 'ABC', 'テスト' )
+			)
+		);
+
+		#11 #1747 (left pipe)
+		$provider[] = array(
+			NS_MAIN,
+			array(
+				'smwgNamespacesWithSemanticLinks' => array( NS_MAIN => true ),
+				'smwgLinksInValues' => false,
+				'smwgInlineErrors'  => true,
+				'smwgEnabledInTextAnnotationParserStrictMode' => false
+			),
+			'[[Foo|Bar::Foobar]] [[File:Example.png|alt=Bar::Foobar|Caption]] [[File:Example.png|Bar::Foobar|link=Foo]]',
+			array(
+				'resultText'     => '[[Foo|Bar::Foobar]] [[File:Example.png|alt=Bar::Foobar|Caption]] [[File:Example.png|Bar::Foobar|link=Foo]]',
+				'propertyCount'  => 0,
+			)
+		);
+
+		#12 #1747 (left pipe + including one annotation)
+		$provider[] = array(
+			NS_MAIN,
+			array(
+				'smwgNamespacesWithSemanticLinks' => array( NS_MAIN => true ),
+				'smwgLinksInValues' => false,
+				'smwgInlineErrors'  => true,
+				'smwgEnabledInTextAnnotationParserStrictMode' => true
+			),
+			'[[Foo|Bar::Foobar]] [[File:Example.png|alt=Bar::Foobar|Caption]] [[Foo::Foobar::テスト]] [[File:Example.png|Bar::Foobar|link=Foo]]',
+			array(
+				'resultText'     => '[[Foo|Bar::Foobar]] [[File:Example.png|alt=Bar::Foobar|Caption]] [[:Foobar::テスト|Foobar::テスト]] [[File:Example.png|Bar::Foobar|link=Foo]]',
+				'propertyCount'  => 1,
+				'propertyLabels' => array( 'Foo' ),
+				'propertyValues' => array( 'Foobar::テスト' )
 			)
 		);
 


### PR DESCRIPTION
This PR is made in reference to: #1747 

This PR addresses or contains:
- Changes the behaviour of `InTextAnnotationParser` in order to recognize that `[[Foo|Bar::Foobar]]` is a non-value annotation even though it contains a `::` marker.

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed