### PR TITLE
Load Special:Browse content via the API back-end

### DIFF
--- a/DefaultSettings.php
+++ b/DefaultSettings.php
@@ -281,6 +281,12 @@ $GLOBALS['smwgBrowseShowAll'] = true;
 ##
 
 ###
+# Whether the browse display is to be generated using an API request or not.
+##
+$GLOBALS['smwgBrowseByApi'] = true;
+##
+
+###
 # Should the search by property special page display nearby results when there
 # are only a few results with the exact value? Switch this off if this page has
 # performance problems.

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -223,6 +223,8 @@
 	"smw_browse_hide_incoming": "hide properties that link here",
 	"smw_browse_no_outgoing": "This page has no properties.",
 	"smw_browse_no_incoming": "No properties link to this page.",
+	"smw-browse-subject-invalid": "The subject validation returned with a \"$1\" error.",
+	"smw-browse-api-subject-serialization-invalid" : "The subject has an invalid serialization format.",
 	"smw_inverse_label_default": "$1 of",
 	"smw_inverse_label_property": "Inverse property label",
 	"pageproperty": "Page property search",

--- a/includes/Settings.php
+++ b/includes/Settings.php
@@ -62,6 +62,7 @@ class Settings extends Options {
 			'smwgMaxNumRecurringEvents' => $GLOBALS['smwgMaxNumRecurringEvents'],
 			'smwgBrowseShowInverse' => $GLOBALS['smwgBrowseShowInverse'],
 			'smwgBrowseShowAll' => $GLOBALS['smwgBrowseShowAll'],
+			'smwgBrowseByApi' => $GLOBALS['smwgBrowseByApi'],
 			'smwgSearchByPropertyFuzzy' => $GLOBALS['smwgSearchByPropertyFuzzy'],
 			'smwgTypePagingLimit' => $GLOBALS['smwgTypePagingLimit'],
 			'smwgConceptPagingLimit' => $GLOBALS['smwgConceptPagingLimit'],

--- a/includes/Setup.php
+++ b/includes/Setup.php
@@ -256,7 +256,7 @@ final class Setup {
 				'group' => 'smw_group'
 			),
 			'Browse' => array(
-				'page' =>  'SMWSpecialBrowse',
+				'page' =>  'SMW\MediaWiki\Specials\SpecialBrowse',
 				'group' => 'smw_group'
 			),
 			'PageProperty' => array(

--- a/res/Resources.php
+++ b/res/Resources.php
@@ -177,7 +177,8 @@ return array(
 	// Autocomplete resources
 	'ext.smw.autocomplete' => $moduleTemplate + array(
 		'scripts' => 'smw/util/ext.smw.util.autocomplete.js',
-		'dependencies' => 'jquery.ui.autocomplete'
+		'dependencies' => 'jquery.ui.autocomplete',
+		'targets' => array( 'mobile', 'desktop' )
 	),
 	// Special:Ask
 	'ext.smw.ask' => $moduleTemplate + array(
@@ -198,8 +199,17 @@ return array(
 	'ext.smw.browse' => $moduleTemplate + array(
 		'scripts' => 'smw/special/ext.smw.special.browse.js',
 		'dependencies' => array(
+			'mediawiki.api',
 			'ext.smw.style',
 			'ext.smw.autocomplete'
+		),
+		'position' => 'top',
+		'messages' => array(
+			'smw-browse-api-subject-serialization-invalid'
+		),
+		'targets' => array(
+			'mobile',
+			'desktop'
 		)
 	),
 

--- a/res/smw/ext.smw.css
+++ b/res/smw/ext.smw.css
@@ -749,3 +749,74 @@ a.smw-ask-action-btn-lblue:hover {
 	height: 24px;
 	line-height: 24px;
 }
+
+.is-disabled {
+	opacity: .5;
+	position: relative;
+	pointer-events: none;
+}
+
+.is-disabled::after {
+	position: absolute;
+	top: 0;
+	left: 0;
+	width: 100%;
+	height: 100%;
+	content: ' ';
+}
+
+/* http://codepen.io/anon/pen/EqdhG */
+
+.spinner.inline{
+  vertical-align: middle;
+  display: inline-block;
+  margin: 0 .2em;
+}
+
+.spinner.light{
+  border: .2em solid rgba(255,255,255,.2);
+  border-top-color: rgba(255,255,255,.8);
+}
+
+.spinner.small{
+  font-size: 20px;     /* Diameter */
+  border-width: .25em; /* Stroke */
+}
+.spinner.medium{
+  font-size: 30px;
+}
+.spinner.large{
+  font-size: 40px;
+}
+
+.spinner {
+  height:1em;
+  width:1em;
+  margin:0;
+  -webkit-animation: rotation 1.0s infinite linear;
+  -moz-animation: rotation 1.0s infinite linear;
+  animation: rotation 1.0s infinite linear;
+  border: .2em solid rgba(0,0,0,.2);
+  border-top-color: rgba(0,0,0,.8);
+  border-radius:100%;
+  position: fixed;
+  align-items: center;
+  justify-content: center;
+  left: 50%;
+  top: 30%;
+}
+
+@-webkit-keyframes rotation {
+  from {-webkit-transform: rotate(0deg);}
+  to {-webkit-transform: rotate(359deg);}
+}
+
+@-moz-keyframes rotation {
+  from {-moz-transform: rotate(0deg);}
+  to {-moz-transform: rotate(359deg);}
+}
+
+@keyframes rotation {
+  from {transform: rotate(0deg);}
+  to {transform: rotate(359deg);}
+}

--- a/res/smw/special/ext.smw.special.browse.js
+++ b/res/smw/special/ext.smw.special.browse.js
@@ -1,24 +1,133 @@
 /**
- * JavaScript for Special:Browse related functions
+ * @license GNU GPL v2+
+ * @since 2.5
  *
- * @see https://www.mediawiki.org/wiki/Extension:Semantic_MediaWiki
- * @licence: GNU GPL v2 or later
- *
- * @since: 1.7
- * @release: 0.2
- *
- * @author Jeroen De Dauw <jeroendedauw at gmail dot com>
- * @author Devayon Das
  * @author mwjames
  */
-( function( $, mw ) {
+
+/*global jQuery, mediaWiki, mw, smw */
+
+// (ES6), see https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Classes
+class Browse {
+
+	/**
+	 * @since 2.5
+	 * @constructor
+	 *
+	 * @param {Object} api
+	 */
+	constructor ( api ) {
+		this.VERSION = "2.5";
+		this.api = api;
+	}
+
+	/**
+	 * @since 2.5
+	 * @method
+	 *
+	 * @param {Object} context
+	 */
+	setContext ( context ) {
+		this.context = context;
+	}
+
+	/**
+	 * @since 2.5
+	 * @method
+	 */
+	doApiRequest () {
+
+		var self = this,
+			subject = self.context.data( 'subject' ),
+			options = JSON.stringify( self.context.data( 'options' ) );
+
+		// Expect format generated from DIWikiPage::getHash
+		if ( subject.indexOf( "#" ) == -1 ) {
+			return self.reportError( mw.msg( 'smw-browse-api-subject-serialization-invalid' ) );
+		}
+
+		subject = subject.split( "#" );
+
+		self.api.get( {
+			action: "browsebysubject",
+			subject: subject[0],
+			ns: subject[1],
+			iw: subject[2],
+			subobject: subject[3],
+			options: options,
+			type: 'html'
+		} ).done( function( data ) {
+			self.appendContent( data.query );
+		} ).fail ( function( xhr, status, error ) {
+
+			var text = 'Unknown API error';
+
+			if ( status.hasOwnProperty( 'error' ) ) {
+				text = status.error.code + ': ' + status.error.info;
+			}
+
+			self.reportError( text );
+		} );
+	}
+
+	/**
+	 * @since 2.5
+	 * @method
+	 *
+	 * @param {string} error
+	 */
+	reportError ( error ) {
+		this.context.find( '.smwb-status' ).append( error ).addClass( 'smw-callout smw-callout-error' );
+	}
+
+	/**
+	 * @since 2.5
+	 * @method
+	 *
+	 * @param {string} content
+	 */
+	appendContent ( content ) {
+
+		var self = this;
+
+		self.context.find( '.smwb-content' ).replaceWith( content );
+
+		// Re-apply JS-component instances on new content
+		mw.loader.using( 'ext.smw.tooltips' ).done( function () {
+			smw.Factory.newTooltip().initFromContext( self.context );
+		} );
+
+		mw.loader.using( 'ext.smw.browse' ).done( function () {
+			self.context.find( '#smwb-page-search' ).smwAutocomplete( { search: 'page', namespace: 0 } );
+		} );
+
+		mw.loader.load(
+			self.context.find( '.smwb-modules' ).data( 'modules' )
+		);
+
+		// Trigger an event
+		$( document ).trigger( 'SMW::Browse::ApiParseComplete' , {
+			'context': self.context
+		} );
+	}
+}
+
+( function ( $, mw ) {
+
+	'use strict';
+
+	var browse = new Browse(
+		new mw.Api()
+	);
 
 	$( document ).ready( function() {
 
-		// Used in Special:Browse
-		// Function is specified in ext.smw.autocomplete
-		$( '#page_input_box' ).smwAutocomplete( { search: 'page', namespace: 0 } );
+		$( '.smwb-container' ).each( function() {
+			browse.setContext( $( this ) );
+			browse.doApiRequest();
+		} );
 
+		$( '#smwb-page-search' ).smwAutocomplete( { search: 'page', namespace: 0 } );
 	} );
 
-} )( jQuery, mediaWiki );
+}( jQuery, mediaWiki ) );

--- a/res/smw/util/ext.smw.util.tooltip.js
+++ b/res/smw/util/ext.smw.util.tooltip.js
@@ -236,16 +236,37 @@
 	};
 
 	/**
+	 * @since 2.5
+	 * @method
+	 *
+	 * @param {Object} context
+	 */
+	smw.util.tooltip.prototype.initFromContext = function( context ) {
+		this.render( context.find( '.smw-highlighter' ) );
+	};
+
+	/**
+	 * Factory
+	 * @since 2.5
+	 */
+	var Factory = {
+		newTooltip: function() {
+			return new smw.util.tooltip();
+		}
+	}
+
+	/**
 	 * Implementation of a tooltip instance
 	 * @since 1.8
 	 * @ignore
 	 */
 	$( document ).ready( function() {
-		var tooltip = new smw.util.tooltip();
-
-		tooltip.render(
+		Factory.newTooltip().render(
 			$( '.smw-highlighter' )
 		);
 	} );
+
+	smw.Factory = smw.Factory || {};
+	smw.Factory = $.extend( smw.Factory, Factory );
 
 } )( jQuery, mediaWiki, semanticMediaWiki );

--- a/src/MediaWiki/Specials/Browse/HtmlContentBuilder.php
+++ b/src/MediaWiki/Specials/Browse/HtmlContentBuilder.php
@@ -1,111 +1,190 @@
 <?php
 
+namespace SMW\MediaWiki\Specials\Browse;
+
+use SMW\SemanticData;
 use SMW\ApplicationFactory;
 use SMW\DataValueFactory;
-use SMW\DIProperty;
 use SMW\Localizer;
-use SMW\SemanticData;
-use SMW\UrlEncoder;
+use SMW\DIProperty;
+use SMW\DIWikiPage;
+use SMW\Store;
+use Html;
+use SMWDataValue as DataValue;
+use SMW\RequestOptions;
 
 /**
- * @ingroup SMWSpecialPage
- * @ingroup SpecialPage
- *
- * A factbox like view on an article, implemented by a special page.
+ * @license GNU GPL v2+
+ * @since   2.5
  *
  * @author Denny Vrandecic
+ * @author mwjames
  */
+class HtmlContentBuilder {
 
-/**
- * A factbox view on one specific article, showing all the Semantic data about it
- *
- * @ingroup SMWSpecialPage
- * @ingroup SpecialPage
- */
-class SMWSpecialBrowse extends SpecialPage {
-	/// int How  many incoming values should be asked for
-	static public $incomingvaluescount = 8;
-	/// int  How many incoming properties should be asked for
-	static public $incomingpropertiescount = 21;
-	/// SMWDataValue  Topic of this page
-	private $subject = null;
-	/// Text to be set in the query form
-	private $articletext = "";
-	/// bool  To display outgoing values?
+	/**
+	 * @var Store
+	 */
+	private $store;
+
+	/**
+	 * @var DIWikiPage
+	 */
+	private $subject;
+
+	/**
+	 * @var boolean
+	 */
 	private $showoutgoing = true;
-	/// bool  To display incoming values?
+
+	/**
+	 * To display incoming values?
+	 *
+	 * @var boolean
+	 */
 	private $showincoming = false;
-	/// int  At which incoming property are we currently?
+
+	/**
+	 * At which incoming property are we currently?
+	 * @var integer
+	 */
 	private $offset = 0;
 
 	/**
-	 * Constructor
+	 * How many incoming values should be asked for
+	 * @var integer
 	 */
-	public function __construct() {
-		global $smwgBrowseShowAll;
-		parent::__construct( 'Browse', '', true, false, 'default', true );
-		if ( $smwgBrowseShowAll ) {
-			self::$incomingvaluescount = 21;
-			self::$incomingpropertiescount = - 1;
-		}
+	private $incomingValuesCount = 8;
+
+	/**
+	 * How many incoming properties should be asked for
+	 * @var integer
+	 */
+	private $incomingPropertiesCount = 21;
+
+	/**
+	 * @var array
+	 */
+	private $extraModules = array();
+
+	/**
+	 * @var array
+	 */
+	private $options = array();
+
+	/**
+	 * @since 2.5
+	 *
+	 * @param Store $store
+	 * @param DIWikiPage $subject
+	 */
+	public function __construct( Store $store, DIWikiPage $subject ) {
+		$this->store = $store;
+		$this->subject = DataValueFactory::getInstance()->newDataValueByItem( $subject );
 	}
 
 	/**
-	 * Main entry point for Special Pages
+	 * @since 2.5
 	 *
-	 * @param[in] $query string  Given by MediaWiki
+	 * @param string $key
+	 * @param mixed $value
 	 */
-	public function execute( $query ) {
-		global $wgRequest, $wgOut, $smwgBrowseShowAll;
-		$this->setHeaders();
-		// get the GET parameters
-		$this->articletext = $wgRequest->getVal( 'article' );
+	public function setOption( $key, $value ) {
+		$this->options[$key] = $value;
+	}
 
-		// @see SMWInfolink::encodeParameters
-		if ( $query === null && $this->getRequest()->getCheck( 'x' ) ) {
-			$query = $this->getRequest()->getVal( 'x' );
+	/**
+	 * @since 2.5
+	 *
+	 * @param string $key
+	 *
+	 * @return mixed
+	 */
+	public function getOption( $key ) {
+
+		if ( isset( $this->options[$key] ) ) {
+			return $this->options[$key];
 		}
 
-		// no GET parameters? Then try the URL
-		if ( is_null( $this->articletext ) ) {
-			$this->articletext = UrlEncoder::decode( $query );
+		return null;
+	}
+
+	/**
+	 * @since 2.5
+	 *
+	 * @param string $json
+	 */
+	public function setOptionsFromJsonFormat( $json ) {
+		$this->options = json_decode( $json, true );
+	}
+
+	/**
+	 * @since 2.5
+	 *
+	 * @return string
+	 */
+	public function getHtml() {
+
+		if ( ( $offset = $this->getOption( 'offset' ) ) ) {
+			$this->offset = $offset;
 		}
 
-		$this->subject = DataValueFactory::getInstance()->newTypeIDValue( '_wpg', $this->articletext );
-		$offsettext = $wgRequest->getVal( 'offset' );
-		$this->offset = ( is_null( $offsettext ) ) ? 0 : intval( $offsettext );
-
-		$dir = $wgRequest->getVal( 'dir' );
-
-		if ( $smwgBrowseShowAll ) {
+		if ( $this->getOption( 'showAll' ) ) {
+			$this->incomingValuesCount = 21;
+			$this->incomingPropertiesCount = - 1;
 			$this->showoutgoing = true;
 			$this->showincoming = true;
 		}
 
-		if ( $dir === 'both' || $dir === 'in' ) {
+		if ( $this->getOption( 'dir' ) === 'both' || $this->getOption( 'dir' ) === 'in' ) {
 			$this->showincoming = true;
 		}
 
-		if ( $dir === 'in' ) {
+		if ( $this->getOption( 'dir' ) === 'in' ) {
 			$this->showoutgoing = false;
 		}
 
-		if ( $dir === 'out' ) {
+		if ( $this->getOption( 'dir' ) === 'out' ) {
 			$this->showincoming = false;
 		}
 
-		$out = $this->getOutput();
+		return $this->doGenerateHtml();
+	}
 
-		$out->addModuleStyles( array(
-			'mediawiki.ui',
-			'mediawiki.ui.button',
-			'mediawiki.ui.input',
-		) );
+	/**
+	 * @since 2.5
+	 *
+	 * @return string
+	 */
+	public function getEmptyHtml() {
+		global $wgContLang;
 
-		$out->addHTML( $this->displayBrowse() );
-		$this->addExternalHelpLinks();
+		$leftside = !( $wgContLang->isRTL() );
+		$html = "\n";
 
-		SMWOutputs::commitToOutputPage( $out ); // make sure locally collected output data is pushed to the output!
+		$semanticData = new SemanticData( $this->subject->getDataItem() );
+		$this->articletext = $this->subject->getWikiValue();
+
+		$html .= $this->displayHead();
+		$html .= $this->displayData( $semanticData, $leftside );
+		$html .= $this->displayCenter();
+		$html .= $this->displayData( $semanticData, $leftside, true );
+		$html .= $this->displayBottom( false );
+
+		if ( $this->getOption( 'printable' ) !== 'yes' ) {
+			$html .= $this->queryForm( $this->articletext );
+		}
+
+		return $html;
+	}
+
+	/**
+	 * @since 2.5
+	 *
+	 * @return string
+	 */
+	public static function getPageSearchQuickForm( $articletext = '' ) {
+		return "\n" . self::queryForm( $articletext );
 	}
 
 	/**
@@ -114,7 +193,7 @@ class SMWSpecialBrowse extends SpecialPage {
 	 *
 	 * @return string  A HTML string with the factbox
 	 */
-	private function displayBrowse() {
+	private function doGenerateHtml() {
 		global $wgContLang;
 		$html = "\n";
 		$leftside = !( $wgContLang->isRTL() ); // For right to left languages, all is mirrored
@@ -123,21 +202,18 @@ class SMWSpecialBrowse extends SpecialPage {
 		if ( $this->subject->isValid() ) {
 
 			$semanticData = new SemanticData( $this->subject->getDataItem() );
-			$store = ApplicationFactory::getInstance()->getStore();
-
 			$html .= $this->displayHead();
 
 			if ( $this->showoutgoing ) {
-				$semanticData = $store->getSemanticData( $this->subject->getDataItem() );
+				$semanticData = $this->store->getSemanticData( $this->subject->getDataItem() );
 				$html .= $this->displayData( $semanticData, $leftside );
 				$html .= $this->displayCenter();
 			}
 
 			if ( $this->showincoming ) {
 				list( $indata, $more ) = $this->getInData();
-				global $smwgBrowseShowInverse;
 
-				if ( !$smwgBrowseShowInverse ) {
+				if ( !$this->getOption( 'showInverse' ) ) {
 					$leftside = !$leftside;
 				}
 
@@ -147,20 +223,22 @@ class SMWSpecialBrowse extends SpecialPage {
 
 			$this->articletext = $this->subject->getWikiValue();
 
-			\Hooks::run( 'SMW::Browse::AfterDataLookupComplete', array( $store, $semanticData, &$html, &$modules ) );
-			$this->getOutput()->addModules( $modules );
-
-			// Add a bit space between the factbox and the query form
-			if ( !$this->including() ) {
-				$html .= '<div style="margin-top:15px;"></div>' ."\n";
-			}
+			\Hooks::run( 'SMW::Browse::AfterDataLookupComplete', array( $this->store, $semanticData, &$html, &$this->extraModules ) );
 		}
 
-		if ( !$this->including() ) {
-			$html .= $this->queryForm();
+		if ( $this->getOption( 'printable' ) !== 'yes' ) {
+			$html .= $this->queryForm( $this->articletext );
 		}
 
-		$this->getOutput()->addHTML( $html );
+		$html .= Html::element(
+			'div',
+			array(
+				'class' => 'smwb-modules',
+				'data-modules' => json_encode( $this->extraModules )
+			)
+		);
+
+		return $html;
 	}
 
 	/**
@@ -172,7 +250,7 @@ class SMWSpecialBrowse extends SpecialPage {
 	 *
 	 * @return string A string containing the HTML with the factbox
 	 */
-	private function displayData( SMWSemanticData $data, $left = true, $incoming = false ) {
+	private function displayData( SemanticData $data, $left = true, $incoming = false ) {
 		// Some of the CSS classes are different for the left or the right side.
 		// In this case, there is an "i" after the "smwb-". This is set here.
 		$ccsPrefix = $left ? 'smwb-' : 'smwb-i';
@@ -201,7 +279,7 @@ class SMWSpecialBrowse extends SpecialPage {
 
 			$values = $data->getPropertyValues( $diProperty );
 
-			if ( $incoming && ( count( $values ) >= self::$incomingvaluescount ) ) {
+			if ( $incoming && ( count( $values ) >= $this->incomingValuesCount ) ) {
 				$moreIncoming = true;
 				array_pop( $values );
 			} else {
@@ -229,10 +307,10 @@ class SMWSpecialBrowse extends SpecialPage {
 			// Added in 2.3
 			// link to the remaining incoming pages
 			if ( $moreIncoming && \Hooks::run( 'SMW::Browse::BeforeIncomingPropertyValuesFurtherLinkCreate', array( $diProperty, $this->subject->getDataItem(), &$body ) ) ) {
-				$body .= Html::element(
+				$body .= \Html::element(
 					'a',
 					array(
-						'href' => SpecialPage::getSafeTitleFor( 'SearchByProperty' )->getLocalURL( array(
+						'href' => \SpecialPage::getSafeTitleFor( 'SearchByProperty' )->getLocalURL( array(
 							 'property' => $dvProperty->getWikiValue(),
 							 'value' => $this->subject->getWikiValue()
 						) )
@@ -262,22 +340,22 @@ class SMWSpecialBrowse extends SpecialPage {
 	 * Displays a value, including all relevant links (browse and search by property)
 	 *
 	 * @param[in] $property SMWPropertyValue  The property this value is linked to the subject with
-	 * @param[in] $value SMWDataValue  The actual value
+	 * @param[in] $value DataValue  The actual value
 	 * @param[in] $incoming bool  If this is an incoming or outgoing link
 	 *
 	 * @return string  HTML with the link to the article, browse, and search pages
 	 */
-	private function displayValue( SMWPropertyValue $property, SMWDataValue $dataValue, $incoming ) {
+	private function displayValue( \SMWPropertyValue $property, DataValue $dataValue, $incoming ) {
 		$linker = smwfGetLinker();
 
 		// Allow the DV formatter to access a specific language code
 		$dataValue->setOption(
-			'content.language',
+			DataValue::OPT_CONTENT_LANGUAGE,
 			Localizer::getInstance()->getPreferredContentLanguage( $this->subject->getDataItem() )->getCode()
 		);
 
 		$dataValue->setOption(
-			'user.language',
+			DataValue::OPT_USER_LANGUAGE,
 			Localizer::getInstance()->getUserLanguage()->getCode()
 		);
 
@@ -291,9 +369,9 @@ class SMWSpecialBrowse extends SpecialPage {
 		$html = $dataValue->getLongHTMLText( $linker );
 
 		if ( $dataValue->getTypeID() === '_wpg' || $dataValue->getTypeID() === '__sob' ) {
-			$html .= "&#160;" . SMWInfolink::newBrowsingLink( '+', $dataValue->getLongWikiText() )->getHTML( $linker );
+			$html .= "&#160;" . \SMWInfolink::newBrowsingLink( '+', $dataValue->getLongWikiText() )->getHTML( $linker );
 		} elseif ( $incoming && $property->isVisible() ) {
-			$html .= "&#160;" . SMWInfolink::newInversePropertySearchLink( '+', $dataValue->getTitle(), $property->getDataItem()->getLabel(), 'smwsearch' )->getHTML( $linker );
+			$html .= "&#160;" . \SMWInfolink::newInversePropertySearchLink( '+', $dataValue->getTitle(), $property->getDataItem()->getLabel(), 'smwsearch' )->getHTML( $linker );
 		} elseif ( $dataValue->getProperty() instanceof DIProperty && $dataValue->getProperty()->getKey() !== '_INST' ) {
 			$html .= $dataValue->getInfolinkText( SMW_OUTPUT_HTML, $linker );
 		}
@@ -307,9 +385,7 @@ class SMWSpecialBrowse extends SpecialPage {
 	 * @return string A string containing the HTML with the subject line
 	 */
 	private function displayHead() {
-		global $wgOut;
 
-		$wgOut->setHTMLTitle( $this->subject->getTitle() );
 		$html = "<table class=\"smwb-factbox\" cellpadding=\"0\" cellspacing=\"0\">\n" .
 			"<tr class=\"smwb-title\"><td colspan=\"2\">\n" .
 			$this->subject->getLongHTMLText( smwfGetLinker() ) . "\n" .
@@ -342,19 +418,20 @@ class SMWSpecialBrowse extends SpecialPage {
 	private function displayBottom( $more ) {
 		$html  = "<table class=\"smwb-factbox\" cellpadding=\"0\" cellspacing=\"0\">\n" .
 		         "<tr class=\"smwb-center\"><td colspan=\"2\">\n";
-		global $smwgBrowseShowAll;
-		if ( !$smwgBrowseShowAll ) {
+
+		if ( !$this->getOption( 'showAll' ) ) {
 			if ( ( $this->offset > 0 ) || $more ) {
-				$offset = max( $this->offset - self::$incomingpropertiescount + 1, 0 );
+				$offset = max( $this->offset - $this->incomingPropertiesCount + 1, 0 );
 				$html .= ( $this->offset == 0 ) ? wfMessage( 'smw_result_prev' )->text():
 					     $this->linkHere( wfMessage( 'smw_result_prev' )->text(), $this->showoutgoing, true, $offset );
-				$offset = $this->offset + self::$incomingpropertiescount - 1;
+				$offset = $this->offset + $this->incomingPropertiesCount - 1;
 				// @todo FIXME: i18n patchwork.
 				$html .= " &#160;&#160;&#160;  <strong>" . wfMessage( 'smw_result_results' )->text() . " " . ( $this->offset + 1 ) .
 						 " – " . ( $offset ) . "</strong>  &#160;&#160;&#160; ";
 				$html .= $more ? $this->linkHere( wfMessage( 'smw_result_next' )->text(), $this->showoutgoing, true, $offset ):wfMessage( 'smw_result_next' )->text();
 			}
 		}
+
 		$html .= "&#160;\n" . "</td></tr>\n" . "</table>\n";
 		return $html;
 	}
@@ -375,7 +452,7 @@ class SMWSpecialBrowse extends SpecialPage {
 		return Html::element(
 			'a',
 			array(
-				'href' => SpecialPage::getSafeTitleFor( 'Browse' )->getLocalURL( array(
+				'href' => \SpecialPage::getSafeTitleFor( 'Browse' )->getLocalURL( array(
 					'offset' => $offset,
 					'dir' => $out ? ( $in ? 'both' : 'out' ) : 'in',
 					'article' => $this->subject->getLongWikiText()
@@ -392,37 +469,39 @@ class SMWSpecialBrowse extends SpecialPage {
 	 * @return array(SMWSemanticData, bool)  The semantic data including all inproperties, and if there are more inproperties left
 	 */
 	private function getInData() {
-		$indata = new SMWSemanticData( $this->subject->getDataItem() );
-		$options = new SMWRequestOptions();
-		$options->sort = true;
-		$options->limit = self::$incomingpropertiescount;
+		$indata = new SemanticData( $this->subject->getDataItem() );
+
+		$propRequestOptions = new RequestOptions();
+		$propRequestOptions->sort = true;
+		$propRequestOptions->limit = $this->incomingPropertiesCount;
+
 		if ( $this->offset > 0 ) {
-			$options->offset = $this->offset;
+			$propRequestOptions->offset = $this->offset;
 		}
 
-		$store = ApplicationFactory::getInstance()->getStore();
-		$inproperties = $store->getInProperties( $this->subject->getDataItem(), $options );
+		$incomingProperties = $this->store->getInProperties( $this->subject->getDataItem(), $propRequestOptions );
+		$more = false;
 
-		if ( count( $inproperties ) == self::$incomingpropertiescount ) {
+		if ( count( $incomingProperties ) == $this->incomingPropertiesCount ) {
 			$more = true;
-			array_pop( $inproperties ); // drop the last one
-		} else {
-			$more = false;
+			array_pop( $incomingProperties ); // drop the last one
 		}
 
-		$valoptions = new SMWRequestOptions();
-		$valoptions->sort = true;
-		$valoptions->limit = self::$incomingvaluescount;
+		$valRequestOptions = new RequestOptions();
+		$valRequestOptions->sort = true;
+		$valRequestOptions->limit = $this->incomingValuesCount;
 
-		foreach ( $inproperties as $property ) {
-			$values = $store->getPropertySubjects( $property, $this->subject->getDataItem(), $valoptions );
+		foreach ( $incomingProperties as $property ) {
+			$values = $this->store->getPropertySubjects( $property, $this->subject->getDataItem(), $valRequestOptions );
 			foreach ( $values as $value ) {
 				$indata->addPropertyObjectValue( $property, $value );
 			}
 		}
 
 		// Added in 2.3
-		\Hooks::run( 'SMW::Browse::AfterIncomingPropertiesLookupComplete', array( $store, $indata, $valoptions ) );
+		// Whether to show a more link or not can be set via
+		// SMW::Browse::BeforeIncomingPropertyValuesFurtherLinkCreate
+		\Hooks::run( 'SMW::Browse::AfterIncomingPropertiesLookupComplete', array( $this->store, $indata, $valRequestOptions ) );
 
 		return array( $indata, $more );
 	}
@@ -437,12 +516,11 @@ class SMWSpecialBrowse extends SpecialPage {
 	 *
 	 * @return string  The label of the property
 	 */
-	private function getPropertyLabel( SMWPropertyValue $property, $incoming = false ) {
-		global $smwgBrowseShowInverse;
+	private function getPropertyLabel( \SMWPropertyValue $property, $incoming = false ) {
 
-		if ( $incoming && $smwgBrowseShowInverse ) {
-			$oppositeprop = SMWPropertyValue::makeUserProperty( wfMessage( 'smw_inverse_label_property' )->text() );
-			$labelarray = ApplicationFactory::getInstance()->getStore()->getPropertyValues( $property->getDataItem()->getDiWikiPage(), $oppositeprop->getDataItem() );
+		if ( $incoming && $this->getOption( 'showInverse' ) ) {
+			$oppositeprop = \SMWPropertyValue::makeUserProperty( wfMessage( 'smw_inverse_label_property' )->text() );
+			$labelarray = $this->store->getPropertyValues( $property->getDataItem()->getDiWikiPage(), $oppositeprop->getDataItem() );
 			$rv = ( count( $labelarray ) > 0 ) ? $labelarray[0]->getLongWikiText():
 				wfMessage( 'smw_inverse_label_default', $property->getWikiValue() )->text();
 		} else {
@@ -457,20 +535,21 @@ class SMWSpecialBrowse extends SpecialPage {
 	 *
 	 * @return string A string containing the HTML for the form
 	 */
-	private function queryForm() {
+	private static function queryForm( $articletext ) {
 
-		if ( $this->getRequest()->getVal( 'printable' ) === 'yes' ) {
-			return '';
-		}
+		$title = \SpecialPage::getTitleFor( 'Browse' );
 
-		SMWOutputs::requireResource( 'ext.smw.browse' );
-		$title = SpecialPage::getTitleFor( 'Browse' );
-		return '  <form name="smwbrowse" action="' . htmlspecialchars( $title->getLocalURL() ) . '" method="get">' . "\n" .
+		$html = '<div style="margin-top:15px;"></div>' ."\n";
+		$dir = $title->getPageLanguage()->isRTL() ? 'rtl' : 'ltr';
+
+		$html .= '  <form name="smwbrowse" action="' . htmlspecialchars( $title->getLocalURL() ) . '" method="get">' . "\n" .
 			'    <input type="hidden" name="title" value="' . $title->getPrefixedText() . '"/>' .
 			wfMessage( 'smw_browse_article' )->text() . "<br />\n" .
-		    ' <div class="browse-input-resp"> <div class="input-field"><input type="text" name="article" size="40" id="page_input_box" class="input mw-ui-input" value="' . htmlspecialchars( $this->articletext ) . '" /></div>' .
+		    ' <div class="browse-input-resp"> <div class="input-field"><input type="text"  dir="' . $dir . '" name="article" size="40" id="smwb-page-search" class="input mw-ui-input" value="' . htmlspecialchars( $articletext ) . '" /></div>' .
 		    ' <div class="button-field"><input type="submit" class="input-button mw-ui-button" value="' . wfMessage( 'smw_browse_go' )->text() . "\"/></div></div>\n" .
 		    "  </form>\n";
+
+		return $html;
 	}
 
 	/**
@@ -485,37 +564,4 @@ class SMWSpecialBrowse extends SpecialPage {
 		return $count > 2 ? preg_replace( '/($nonBreakingSpace)/u', ' ', $text, max( 0, $count - 2 ) ):$text;
 	}
 
-	/**
-	 * FIXME MW 1.25
-	 */
-	private function addExternalHelpLinks() {
-
-		if ( !method_exists( $this, 'addHelpLink' ) || ( $this->getRequest()->getVal( 'printable' ) === 'yes' ) ) {
-			return null;
-		}
-
-		if ( $this->subject->isValid() ) {
-			$link = SpecialPage::getTitleFor( 'ExportRDF', $this->subject->getTitle()->getPrefixedText() )->getLocalUrl( 'syntax=rdf' );
-
-			$this->getOutput()->setIndicators( array(
-				Html::rawElement(
-					'div',
-					array(
-						'class' => 'mw-indicator smw-page-indicator-rdflink'
-					),
-					Html::rawElement(
-						'a',
-						array(
-							'href' => $link
-					), 'RDF' )
-				)
-			) );
-		}
-
-		$this->addHelpLink( wfMessage( 'smw-specials-browse-helplink' )->escaped(), true );
-	}
-
-	protected function getGroupName() {
-		return 'smw_group';
-	}
 }

--- a/src/MediaWiki/Specials/SpecialBrowse.php
+++ b/src/MediaWiki/Specials/SpecialBrowse.php
@@ -1,0 +1,222 @@
+<?php
+
+namespace SMW\MediaWiki\Specials;
+
+use SMW\ApplicationFactory;
+use SMW\DataValueFactory;
+use SMW\DIProperty;
+use SMW\Localizer;
+use SMW\SemanticData;
+use SMW\UrlEncoder;
+use SMW\MediaWiki\Specials\Browse\HtmlContentBuilder;
+use SMW\Message;
+use SpecialPage;
+use Html;
+
+/**
+ * A factbox view on one specific article, showing all the Semantic data about it
+ *
+ * @license GNU GPL v2+
+ * @since 1.6
+ *
+ * @author mwjames
+ */
+class SpecialBrowse extends SpecialPage {
+
+	/**
+	 * @var DataValue
+	 */
+	private $subjectDV = null;
+
+	/**
+	 * @var ApplicationFactory
+	 */
+	private $applicationFactory = null;
+
+	/**
+	 * @see SpecialPage::__construct
+	 */
+	public function __construct() {
+		parent::__construct( 'Browse', '', true, false, 'default', true );
+		$this->applicationFactory = ApplicationFactory::getInstance();
+	}
+
+	/**
+	 * @see SpecialPage::execute
+	 *
+	 * @param string $query string
+	 */
+	public function execute( $query ) {
+
+		$this->setHeaders();
+		$webRequest = $this->getRequest();
+
+		// get the GET parameters
+		$articletext = $webRequest->getVal( 'article' );
+
+		// @see SMWInfolink::encodeParameters
+		if ( $query === null && $this->getRequest()->getCheck( 'x' ) ) {
+			$query = $this->getRequest()->getVal( 'x' );
+		}
+
+		// no GET parameters? Then try the URL
+		if ( $articletext === null ) {
+			$articletext = UrlEncoder::decode( $query );
+		}
+
+		$this->subjectDV = DataValueFactory::getInstance()->newTypeIDValue(
+			'_wpg',
+			$articletext
+		);
+
+		$out = $this->getOutput();
+		$out->setHTMLTitle( $this->subjectDV->getTitle() );
+
+		$out->addModuleStyles( array(
+			'mediawiki.ui',
+			'mediawiki.ui.button',
+			'mediawiki.ui.input'
+		) );
+
+		$out->addModules( array(
+			'ext.smw.browse',
+			'ext.smw.tooltip'
+		) );
+
+		$out->addHTML(
+			$this->getHtml( $webRequest )
+		);
+
+		$this->addExternalHelpLinks();
+	}
+
+	private function getHtml( $webRequest ) {
+
+		if ( !$this->subjectDV->isValid() ) {
+			return Html::rawElement(
+					'div',
+					array(
+						'class' => 'smw-callout smw-callout-error'
+					),
+					Message::get( array( 'smw-browse-subject-invalid', $this->subjectDV->getErrors() ) )
+				) . HtmlContentBuilder::getPageSearchQuickForm();
+		}
+
+		$htmlContentBuilder = $this->newHtmlContentBuilder( $webRequest );
+
+		if ( $webRequest->getVal( 'output' ) === 'legacy' || !$htmlContentBuilder->getOption( 'byApi' ) ) {
+			return $htmlContentBuilder->getHtml();
+		}
+
+		$options = array(
+			'dir'         => $htmlContentBuilder->getOption( 'dir' ),
+			'offset'      => $htmlContentBuilder->getOption( 'offset' ),
+			'printable'   => $htmlContentBuilder->getOption( 'printable' ),
+			'showInverse' => $htmlContentBuilder->getOption( 'showInverse' ),
+			'showAll'     => $htmlContentBuilder->getOption( 'showAll' )
+		);
+
+		// Ajax/API is doing the data fetch
+		$html = Html::rawElement(
+			'div',
+			array(
+				'class' => 'smwb-container',
+				'data-subject' => $this->subjectDV->getDataItem()->getHash(),
+				'data-options' => json_encode( $options )
+			),
+			Html::rawElement(
+				'div',
+				array(
+					'class' => 'smwb-status'
+				)
+			) . Html::rawElement(
+				'div',
+				array(
+					'class' => 'smwb-content is-disabled'
+				),
+				Html::rawElement(
+					'span',
+					array(
+						'class' => 'spinner large inline'
+					)
+				) . $htmlContentBuilder->getEmptyHtml()
+			)
+		);
+
+		return $html;
+	}
+
+	private function newHtmlContentBuilder( $webRequest ) {
+
+		$htmlContentBuilder = new HtmlContentBuilder(
+			$this->applicationFactory->getStore(),
+			$this->subjectDV->getDataItem()
+		);
+
+		$htmlContentBuilder->setOption(
+			'dir',
+			$webRequest->getVal( 'dir' )
+		);
+
+		$htmlContentBuilder->setOption(
+			'printable',
+			$webRequest->getVal( 'printable' )
+		);
+
+		$htmlContentBuilder->setOption(
+			'offset',
+			$webRequest->getVal( 'offset' )
+		);
+
+		$htmlContentBuilder->setOption(
+			'showInverse',
+			$this->applicationFactory->getSettings()->get( 'smwgBrowseShowInverse' )
+		);
+
+		$htmlContentBuilder->setOption(
+			'showAll',
+			$this->applicationFactory->getSettings()->get( 'smwgBrowseShowAll' )
+		);
+
+		$htmlContentBuilder->setOption(
+			'byApi',
+			$this->applicationFactory->getSettings()->get( 'smwgBrowseByApi' )
+		);
+
+		return $htmlContentBuilder;
+	}
+
+	private function addExternalHelpLinks() {
+
+		if ( $this->getRequest()->getVal( 'printable' ) === 'yes' ) {
+			return null;
+		}
+
+		if ( $this->subjectDV->isValid() ) {
+			$link = SpecialPage::getTitleFor( 'ExportRDF', $this->subjectDV->getTitle()->getPrefixedText() );
+
+			$this->getOutput()->setIndicators( array(
+				Html::rawElement(
+					'div',
+					array(
+						'class' => 'mw-indicator smw-page-indicator-rdflink'
+					),
+					Html::rawElement(
+						'a',
+						array(
+							'href' => $link->getLocalUrl( 'syntax=rdf' )
+						),
+						'RDF'
+					)
+				)
+			) );
+		}
+
+		$this->addHelpLink( wfMessage( 'smw-specials-browse-helplink' )->escaped(), true );
+	}
+
+	protected function getGroupName() {
+		return 'smw_group';
+	}
+
+}

--- a/tests/phpunit/Integration/ByJsonScript/Fixtures/s-0004.json
+++ b/tests/phpunit/Integration/ByJsonScript/Fixtures/s-0004.json
@@ -1,5 +1,5 @@
 {
-	"description": "Test `Special:Browse` output for `_dat' (`wgContLang=en`, `wgLang=ja`)",
+	"description": "Test `Special:Browse` output for `_dat` (`wgContLang=en`, `wgLang=ja`)",
 	"properties": [
 		{
 			"name": "Has date",
@@ -18,7 +18,9 @@
 			"special-page": {
 				"page":"Browse",
 				"query-parameters": "Example/S0004/1",
-				"request-parameters":{}
+				"request-parameters":{
+					"output": "legacy"
+				}
 			},
 			"expected-output": {
 				"to-contain": [

--- a/tests/phpunit/Integration/ByJsonScript/Fixtures/s-0005.json
+++ b/tests/phpunit/Integration/ByJsonScript/Fixtures/s-0005.json
@@ -1,5 +1,5 @@
 {
-	"description": "Test `Special:Browse` output for `_dat' (`wgContLang` = en, `wgLang` = en, `smwgDVFeatures`)",
+	"description": "Test `Special:Browse` output for `_dat` (`wgContLang=en`, `wgLang=en`, `smwgDVFeatures=SMW_DV_TIMEV_CM`)",
 	"properties": [
 		{
 			"name": "Has date",
@@ -18,7 +18,9 @@
 			"special-page": {
 				"page":"Browse",
 				"query-parameters": "Example/S0005/1",
-				"request-parameters":{}
+				"request-parameters":{
+					"output": "legacy"
+				}
 			},
 			"expected-output": {
 				"to-contain": [

--- a/tests/phpunit/Integration/ByJsonScript/Fixtures/s-0008.json
+++ b/tests/phpunit/Integration/ByJsonScript/Fixtures/s-0008.json
@@ -1,5 +1,5 @@
 {
-	"description": "Test `Special:Browse` output for `_dat', `_boo`, `_sobj`, `_uri` (`wgContLang=en`, `wgLang=es`, skip-on 1.25.6)",
+	"description": "Test `Special:Browse` output for `_dat`, `_boo`, `_sobj`, `_uri` (`wgContLang=en`, `wgLang=es`, skip-on 1.25.6)",
 	"properties": [
 		{
 			"name": "Has date",
@@ -50,7 +50,9 @@
 			"special-page": {
 				"page":"Browse",
 				"query-parameters": "Example/S0008/1",
-				"request-parameters":{}
+				"request-parameters":{
+					"output": "legacy"
+				}
 			},
 			"expected-output": {
 				"to-contain": [
@@ -65,7 +67,9 @@
 			"special-page": {
 				"page":"Browse",
 				"query-parameters": "Example/S0008/2",
-				"request-parameters":{}
+				"request-parameters":{
+					"output": "legacy"
+				}
 			},
 			"expected-output": {
 				"to-contain": [
@@ -83,7 +87,9 @@
 			"special-page": {
 				"page":"Browse",
 				"query-parameters": "Example/S0008/3 (Hydrogen-1 atom)",
-				"request-parameters":{}
+				"request-parameters":{
+					"output": "legacy"
+				}
 			},
 			"expected-output": {
 				"to-contain": [
@@ -97,7 +103,9 @@
 			"special-page": {
 				"page":"Browse",
 				"query-parameters": "Example-2FS0008-2F4-23ABC-2D3A-2D3ADEF",
-				"request-parameters":{}
+				"request-parameters":{
+					"output": "legacy"
+				}
 			},
 			"expected-output": {
 				"to-contain": [
@@ -111,7 +119,9 @@
 			"special-page": {
 				"page":"Browse",
 				"query-parameters": "Example/S0008/5",
-				"request-parameters":{}
+				"request-parameters":{
+					"output": "legacy"
+				}
 			},
 			"expected-output": {
 				"to-contain": [

--- a/tests/phpunit/Unit/MediaWiki/Specials/Browse/HtmlContentBuilderTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Specials/Browse/HtmlContentBuilderTest.php
@@ -1,0 +1,162 @@
+<?php
+
+namespace SMW\Tests\MediaWiki\Specials\Browse;
+
+use SMW\MediaWiki\Specials\Browse\HtmlContentBuilder;
+use SMW\Tests\TestEnvironment;
+use SMW\DIWikiPage;
+use SMW\SemanticData;
+
+/**
+ * @covers \SMW\MediaWiki\Specials\Browse\HtmlContentBuilder
+ * @group semantic-mediawiki
+ *
+ * @license GNU GPL v2+
+ * @since 2.5
+ *
+ * @author mwjames
+ */
+class HtmlContentBuilderTest extends \PHPUnit_Framework_TestCase {
+
+	private $testEnvironment;
+	private $store;
+
+	protected function setUp() {
+		parent::setUp();
+
+		$this->testEnvironment = new TestEnvironment();
+
+		$this->store = $this->getMockBuilder( '\SMW\Store' )
+			->disableOriginalConstructor()
+			->getMockForAbstractClass();
+
+		$this->testEnvironment->registerObject( 'Store', $this->store );
+	}
+
+	protected function tearDown() {
+		$this->testEnvironment->tearDown();
+		parent::tearDown();
+	}
+
+	public function testCanConstruct() {
+
+		$instance = new HtmlContentBuilder(
+			$this->store,
+			DIWikiPage::newFromText( 'Foo' )
+		);
+
+		$this->assertInstanceOf(
+			HtmlContentBuilder::class,
+			$instance
+		);
+	}
+
+	public function testGetEmptyHtml() {
+
+		$instance = new HtmlContentBuilder(
+			$this->store,
+			DIWikiPage::newFromText( 'Foo' )
+		);
+
+		$this->assertInternalType(
+			'string',
+			$instance->getEmptyHtml()
+		);
+	}
+
+	public function testGetPageSearchQuickForm() {
+
+		$this->assertInternalType(
+			'string',
+			HtmlContentBuilder::getPageSearchQuickForm()
+		);
+	}
+
+	public function testGetHtml() {
+
+		$subject = DIWikiPage::newFromText( 'Foo' );
+
+		$this->store->expects( $this->any() )
+			->method( 'getSemanticData' )
+			->will( $this->returnValue( new SemanticData( $subject ) ) );
+
+		$instance = new HtmlContentBuilder(
+			$this->store,
+			$subject
+		);
+
+		$this->assertInternalType(
+			'string',
+			$instance->getHtml()
+		);
+	}
+
+	public function testGetHtmlWithOptions() {
+
+		$subject = DIWikiPage::newFromText( 'Foo' );
+
+		$this->store->expects( $this->any() )
+			->method( 'getSemanticData' )
+			->will( $this->returnValue( new SemanticData( $subject ) ) );
+
+		$this->store->expects( $this->any() )
+			->method( 'getInProperties' )
+			->will( $this->returnValue( array() ) );
+
+		$instance = new HtmlContentBuilder(
+			$this->store,
+			$subject
+		);
+
+		$options = array(
+			'offset' => 0,
+			'showAll' => true,
+			'showInverse' => false,
+			'dir' => 'both',
+			'printable' => ''
+		);
+
+		$instance->setOptionsFromJsonFormat(
+			json_encode( $options )
+		);
+
+		$this->assertInternalType(
+			'string',
+			$instance->getHtml()
+		);
+	}
+
+	public function testOptions() {
+
+		$subject = DIWikiPage::newFromText( 'Foo' );
+
+		$instance = new HtmlContentBuilder(
+			$this->store,
+			$subject
+		);
+
+		$options = array(
+			'Foo' => 42
+		);
+
+		$instance->setOptionsFromJsonFormat(
+			json_encode( $options )
+		);
+
+		$instance->setOption(
+			'Bar',
+			1001
+		);
+
+		$this->assertEquals(
+			42,
+			$instance->getOption( 'Foo' )
+		);
+
+		$this->assertEquals(
+			1001,
+			$instance->getOption( 'Bar' )
+		);
+	}
+
+}

--- a/tests/phpunit/Unit/MediaWiki/Specials/SpecialBrowseTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Specials/SpecialBrowseTest.php
@@ -1,0 +1,98 @@
+<?php
+
+namespace SMW\Tests\MediaWiki\Specials;
+
+use SMW\MediaWiki\Specials\SpecialBrowse;
+use SMW\Tests\TestEnvironment;
+use Title;
+
+/**
+ * @covers \SMW\MediaWiki\Specials\SpecialBrowse
+ * @group semantic-mediawiki
+ *
+ * @license GNU GPL v2+
+ * @since 2.1
+ *
+ * @author mwjames
+ */
+class SpecialBrowseTest extends \PHPUnit_Framework_TestCase {
+
+	private $testEnvironment;
+	private $stringValidator;
+
+	protected function setUp() {
+		parent::setUp();
+
+		$this->testEnvironment = new TestEnvironment( array(
+			'smwgBrowseShowInverse' => false,
+			'smwgBrowseShowAll'     => true
+		) );
+
+		$store = $this->getMockBuilder( '\SMW\Store' )
+			->disableOriginalConstructor()
+			->getMockForAbstractClass();
+
+		$this->testEnvironment->registerObject( 'Store', $store );
+		$this->stringValidator = $this->testEnvironment->getUtilityFactory()->newValidatorFactory()->newStringValidator();
+	}
+
+	protected function tearDown() {
+		$this->testEnvironment->tearDown();
+		parent::tearDown();
+	}
+
+	/**
+	 * @dataProvider queryParameterProvider
+	 */
+	public function testQueryParameter( $query, $expected ) {
+
+		$instance = new SpecialBrowse();
+
+		$instance->getContext()->setTitle(
+			Title::newFromText( 'SpecialBrowse' )
+		);
+
+		$instance->execute( $query );
+
+		$this->stringValidator->assertThatStringContains(
+			$expected,
+			$instance->getOutput()->getHtml()
+		);
+	}
+
+	public function queryParameterProvider() {
+
+		#0
+		$provider[] = array(
+			'',
+			array( 'smw-callout smw-callout-error' )
+		);
+
+		#1
+		$provider[] = array(
+			'Has-20foo/http:-2F-2Fexample.org-2Fid-2FCurly-2520Brackets-257B-257D',
+			array( 'smw-callout smw-callout-error' )
+		);
+
+		#2
+		$provider[] = array(
+			'Foo/Bar',
+			array(
+				'data-subject="Foo/Bar#0#"',
+				'data-options="{&quot;dir&quot;:null,&quot;offset&quot;:null,&quot;printable&quot;:null,&quot;showInverse&quot;:false,&quot;showAll&quot;:true}"'
+			)
+		);
+
+		#3
+		$provider[] = array(
+			'Main-20Page-23_QUERY140d50d705e9566904fc4a877c755964',
+			array(
+				'data-subject="Main_Page#0##_QUERY140d50d705e9566904fc4a877c755964"',
+				'data-options="{&quot;dir&quot;:null,&quot;offset&quot;:null,&quot;printable&quot;:null,&quot;showInverse&quot;:false,&quot;showAll&quot;:true}"'
+			)
+		);
+
+		return $provider;
+	}
+
+}

--- a/tests/phpunit/includes/specials/SpecialsTest.php
+++ b/tests/phpunit/includes/specials/SpecialsTest.php
@@ -28,8 +28,8 @@ use SpecialPageFactory;
  * @covers \SMW\SpecialConcepts
  * @covers \SMW\SpecialPage
  * @covers SMWAskPage
- * @covers SMWSpecialBrowse
  * @covers SMWAdmin
+ * @covers \SMW\MediaWiki\Specials\SpecialBrowse
  * @covers \SMW\MediaWiki\Specials\SpecialSearchByProperty
  *
  * @note Test base was borrowed from the EducationProgram extension


### PR DESCRIPTION
This PR is made in reference to: N/A

This PR addresses or contains:

- Display is served from an API request/response in order to increase responsiveness for pages with large fact sets
- `Special:Browse` synchronous display characteristics is still available using `output=legacy` or `$GLOBALS['smwgBrowseByApi'] = false`
- Design issues (html construction etc.) that are prominent in `Special:Browse` (and have moved to the `HtmlContentBuilder`) class has not been addressed as part of this PR and requires a follow-up

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed
