### PR TITLE
Improve handling of MonolingualTextValue in SearchByProperty

### DIFF
--- a/DefaultSettings.php
+++ b/DefaultSettings.php
@@ -288,7 +288,7 @@ $GLOBALS['smwgBrowseShowAll'] = true;
 # @since 2.1 enabled default types, to disable the functionality either set the
 # variable to array() or false
 ##
-$GLOBALS['smwgSearchByPropertyFuzzy'] = array( '_num', '_txt', '_dat' );
+$GLOBALS['smwgSearchByPropertyFuzzy'] = array( '_num', '_txt', '_dat', '_mlt_rec' );
 ##
 
 ###

--- a/src/DataValues/MonolingualTextValue.php
+++ b/src/DataValues/MonolingualTextValue.php
@@ -46,16 +46,10 @@ class MonolingualTextValue extends DataValue {
 	private $monolingualTextValueParser = null;
 
 	/**
-	 * @var DataValueFactory
-	 */
-	private $dataValueFactory = null;
-
-	/**
 	 * @param string $typeid
 	 */
 	public function __construct( $typeid = '' ) {
 		parent::__construct( '_mlt_rec' );
-		$this->dataValueFactory = DataValueFactory::getInstance();
 	}
 
 	/**
@@ -103,7 +97,7 @@ class MonolingualTextValue extends DataValue {
 				$value = $languageCode;
 			}
 
-			$dataValue = $this->dataValueFactory->newDataValueByProperty(
+			$dataValue = DataValueFactory::getInstance()->newDataValueByProperty(
 				$property,
 				$value,
 				false,
@@ -272,7 +266,7 @@ class MonolingualTextValue extends DataValue {
 			return null;
 		}
 
-		$dataValue = $this->dataValueFactory->newDataValueByItem(
+		$dataValue = DataValueFactory::getInstance()->newDataValueByItem(
 			$dataItem,
 			new DIProperty( '_TEXT' )
 		);

--- a/src/DataValues/ValueFormatters/MonolingualTextValueFormatter.php
+++ b/src/DataValues/ValueFormatters/MonolingualTextValueFormatter.php
@@ -112,8 +112,10 @@ class MonolingualTextValueFormatter extends DataValueFormatter {
 				$linker
 			);
 
-			if ( $property->getKey() === '_LCODE' ) {
+			if ( $property->getKey() === '_LCODE' && $type !== self::VALUE ) {
 				$languagecode = ' ' . Message::get( array( 'smw-datavalue-monolingual-lcode-parenthesis', $result ) );
+			} elseif ( $property->getKey() === '_LCODE' && $type === self::VALUE ) {
+				$languagecode = '@' . $result;
 			} else {
 				$text = $result;
 			}

--- a/src/MediaWiki/Specials/SearchByProperty/QueryResultLookup.php
+++ b/src/MediaWiki/Specials/SearchByProperty/QueryResultLookup.php
@@ -10,6 +10,7 @@ use SMW\Query\PrintRequest as PrintRequest;
 use SMW\Store;
 use SMWQuery as Query;
 use SMWRequestOptions as RequestOptions;
+use SMW\Query\DescriptionFactory;
 
 /**
  * @license GNU GPL v2+
@@ -90,22 +91,22 @@ class QueryResultLookup {
 			$comparator = SMW_CMP_LIKE;
 		}
 
+		$descriptionFactory = new DescriptionFactory();
+
 		if ( $pageRequestOptions->valueString === '' || $pageRequestOptions->valueString === null ) {
-			$description = new ThingDescription();
+			$description = $descriptionFactory->newThingDescription();
 		} else {
-			$description = new ValueDescription(
-				$pageRequestOptions->value->getDataItem(),
-				$pageRequestOptions->property->getDataItem(),
-				$comparator
+
+			$pageRequestOptions->value->setProperty(
+				$pageRequestOptions->property->getDataItem()
+			);
+
+			$description = $descriptionFactory->newFromDataValue(
+				$pageRequestOptions->value
 			);
 		}
 
-		$someProperty = new SomeProperty(
-			$pageRequestOptions->property->getDataItem(),
-			$description
-		);
-
-		$query = new Query( $someProperty );
+		$query = new Query( $description );
 
 		$query->setLimit( $pageRequestOptions->limit );
 		$query->setOffset( $pageRequestOptions->offset );

--- a/src/Query/DescriptionFactory.php
+++ b/src/Query/DescriptionFactory.php
@@ -141,12 +141,18 @@ class DescriptionFactory {
 				}
 			}
 
-			return $dataValue->getQueryDescription( $value );
+			$description = $dataValue->getQueryDescription( $value );
+		} else {
+			$description = $this->newValueDescription( $dataValue->getDataItem() );
+		}
+
+		if ( $dataValue->getProperty() === null ) {
+			return $description;
 		}
 
 		return $this->newSomeProperty(
 			$dataValue->getProperty(),
-			$this->newValueDescription( $dataValue->getDataItem() )
+			$description
 		);
 	}
 

--- a/tests/phpunit/Integration/ByJsonScript/Fixtures/p-0409.json
+++ b/tests/phpunit/Integration/ByJsonScript/Fixtures/p-0409.json
@@ -97,7 +97,7 @@
 					"strict-mode-valuematch": false,
 					"propertyCount": 3,
 					"propertyKeys": [ "Has_record_one_mlt", "_SKEY", "_MDAT" ],
-					"propertyValues": [ "test (en); 42" ]
+					"propertyValues": [ "test@en; 42" ]
 				}
 			}
 		},
@@ -109,7 +109,7 @@
 					"strict-mode-valuematch": false,
 					"propertyCount": 2,
 					"propertyKeys": [ "Has_record_one_mlt", "_SKEY" ],
-					"propertyValues": [ "test (en); 42" ]
+					"propertyValues": [ "test@en; 42" ]
 				}
 			}
 		},
@@ -121,7 +121,7 @@
 					"strict-mode-valuematch": false,
 					"propertyCount": 3,
 					"propertyKeys": [ "Has_record_two_mlt", "_SKEY", "_MDAT" ],
-					"propertyValues": [ "one (en); two (fr)\\; 123" ]
+					"propertyValues": [ "one@en; two@fr\\; 123" ]
 				}
 			}
 		},
@@ -133,7 +133,7 @@
 					"strict-mode-valuematch": false,
 					"propertyCount": 2,
 					"propertyKeys": [ "Has_record_two_mlt", "_SKEY" ],
-					"propertyValues": [ "one (en); two (fr)\\; 123" ]
+					"propertyValues": [ "one@en; two@fr\\; 123" ]
 				}
 			}
 		},

--- a/tests/phpunit/Unit/DataValues/MonolingualTextValueTest.php
+++ b/tests/phpunit/Unit/DataValues/MonolingualTextValueTest.php
@@ -111,7 +111,7 @@ class MonolingualTextValueTest extends \PHPUnit_Framework_TestCase {
 		$instance->setUserValue( 'Foo@en' );
 
 		$this->assertEquals(
-			'Foo (en)',
+			'Foo@en',
 			$instance->getWikiValue()
 		);
 	}

--- a/tests/phpunit/Unit/DataValues/ValueFormatters/MonolingualTextValueFormatterTest.php
+++ b/tests/phpunit/Unit/DataValues/ValueFormatters/MonolingualTextValueFormatterTest.php
@@ -85,7 +85,7 @@ class MonolingualTextValueFormatterTest extends \PHPUnit_Framework_TestCase {
 			'foo@en',
 			MonolingualTextValueFormatter::VALUE,
 			null,
-			'foo (en)'
+			'foo@en'
 		);
 
 		$provider[] = array(

--- a/tests/phpunit/Unit/Query/DescriptionFactoryTest.php
+++ b/tests/phpunit/Unit/Query/DescriptionFactoryTest.php
@@ -256,4 +256,39 @@ class DescriptionFactoryTest extends \PHPUnit_Framework_TestCase {
 		);
 	}
 
+	public function testCanConstructDescriptionFromMonolingualTextValueWithProperty() {
+
+		$containerSemanticData = $this->getMockBuilder( '\SMWContainerSemanticData' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$containerSemanticData->expects( $this->atLeastOnce() )
+			->method( 'getPropertyValues' )
+			->will( $this->returnValue( array( $this->dataItemFactory->newDIBlob( 'Bar' ) ) ) );
+
+		$dataValue = $this->getMockBuilder( '\SMW\DataValues\MonolingualTextValue' )
+			->disableOriginalConstructor()
+			->setMethods( array( 'isValid', 'getProperty', 'getDataItem' ) )
+			->getMock();
+
+		$dataValue->expects( $this->atLeastOnce() )
+			->method( 'isValid' )
+			->will( $this->returnValue( true ) );
+
+		$dataValue->expects( $this->atLeastOnce() )
+			->method( 'getProperty' )
+			->will( $this->returnValue( $this->dataItemFactory->newDIProperty( 'Foo' ) ) );
+
+		$dataValue->expects( $this->atLeastOnce() )
+			->method( 'getDataItem' )
+			->will( $this->returnValue( $this->dataItemFactory->newDIContainer( $containerSemanticData ) ) );
+
+		$instance = new DescriptionFactory();
+
+		$this->assertInstanceOf(
+			'SMW\Query\Language\SomeProperty',
+			$instance->newFromDataValue( $dataValue )
+		);
+	}
+
 }


### PR DESCRIPTION
This PR is made in reference to: # N/A

This PR addresses or contains:

- Value output (`DataValueFormatter::VALUE`) will return `foo@en` instead of the formatted `foo (en)` allowing `SearchByProperty` to apply appropriate serialization on behalf of the string value 
- `DescriptionFactory` now returns a `SomeProperty` description in case `MonolingualTextValue` contains a property reference

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed

