### PR TITLE
Add context to newPropertyValueByLabel

### DIFF
--- a/includes/dataitems/SMW_DI_Property.php
+++ b/includes/dataitems/SMW_DI_Property.php
@@ -388,7 +388,7 @@ class DIProperty extends SMWDataItem {
 	 *
 	 * @return DIProperty object
 	 */
-	public static function newFromUserLabel( $label, $inverse = false ) {
+	public static function newFromUserLabel( $label, $inverse = false, $languageCode = false ) {
 
 		if ( $label !== '' && $label{0} == '-' ) {
 			$label = substr( $label, 1 );
@@ -398,10 +398,14 @@ class DIProperty extends SMWDataItem {
 		$id = false;
 
 		// Special handling for when the user value contains a @LCODE marker
-		if ( ( $langCode = Localizer::getLanguageCodeFrom( $label ) ) !== false ) {
+		if ( ( $annotatedLanguageCode = Localizer::getAnnotatedLanguageCodeFrom( $label ) ) !== false ) {
+			$languageCode = $annotatedLanguageCode;
+		}
+
+		if ( $languageCode ) {
 			$id = PropertyRegistry::getInstance()->findPropertyIdByLanguageCode(
 				$label,
-				$langCode
+				$languageCode
 			);
 		}
 

--- a/src/DataTypeRegistry.php
+++ b/src/DataTypeRegistry.php
@@ -280,6 +280,37 @@ class DataTypeRegistry {
 	}
 
 	/**
+	 * @since 2.5
+	 *
+	 * @param string $label
+	 * @param string|false $languageCode
+	 *
+	 * @return string
+	 */
+	public function findTypeIdByLanguage( $label, $languageCode = false ) {
+
+		$label = mb_strtolower( $label );
+
+		if ( !$languageCode ) {
+			return $this->findTypeId( $label );
+		}
+
+		$extraneousLanguage = Localizer::getInstance()->getExtraneousLanguage( $languageCode );
+
+		$datatypeLabels = $extraneousLanguage->getDatatypeLabels();
+		$datatypeLabels = array_flip( $datatypeLabels );
+		$datatypeLabels += $extraneousLanguage->getDatatypeAliases();
+
+		foreach ( $datatypeLabels as $key => $id ) {
+			if ( mb_strtolower( $key ) === $label ) {
+				return $id;
+			}
+		}
+
+		return '';
+	}
+
+	/**
 	 * Get the translated user label for a given internal ID. If the ID does
 	 * not have a label associated with it in the current language, the
 	 * empty string is returned. This is the case both for internal type ids

--- a/src/DataValueFactory.php
+++ b/src/DataValueFactory.php
@@ -106,6 +106,16 @@ class DataValueFactory {
 			$dataTypeRegistry->getOptions()
 		);
 
+		$dataValue->setOption(
+			DataValue::OPT_USER_LANGUAGE,
+			Localizer::getInstance()->getUserLanguage()->getCode()
+		);
+
+		$dataValue->setOption(
+			DataValue::OPT_CONTENT_LANGUAGE,
+			Localizer::getInstance()->getPreferredContentLanguage()->getCode()
+		);
+
 		if ( $property !== null ) {
 			$dataValue->setProperty( $property );
 		}
@@ -113,11 +123,6 @@ class DataValueFactory {
 		if ( !is_null( $contextPage ) ) {
 			$dataValue->setContextPage( $contextPage );
 		}
-
-		$dataValue->setOption(
-			DataValue::OPT_USER_LANGUAGE,
-			Localizer::getInstance()->getUserLanguage()->getCode()
-		);
 
 		if ( $valueString !== false ) {
 			$dataValue->setUserValue( $valueString, $caption );
@@ -188,14 +193,7 @@ class DataValueFactory {
 	 */
 	public function newDataValueByText( $propertyName, $valueString, $caption = false, DIWikiPage $contextPage = null ) {
 
-		// Enforce upper case for the first character on annotations that are used
-		// within the property namespace in order to avoid confusion when
-		// $wgCapitalLinks setting is disabled
-		if ( $contextPage !== null && $contextPage->getNamespace() === SMW_NS_PROPERTY ) {
-			$propertyName = ucfirst( $propertyName );
-		}
-
-		$propertyDV = $this->newPropertyValueByLabel( $propertyName );
+		$propertyDV = $this->newPropertyValueByLabel( $propertyName, $contextPage );
 
 		if ( !$propertyDV->isValid() ) {
 			return $propertyDV;
@@ -267,11 +265,12 @@ class DataValueFactory {
 	 * @since 2.4
 	 *
 	 * @param string $propertyLabel
+	 * @param DIWikiPage|null $contextPage
 	 *
 	 * @return DataValue
 	 */
-	public function newPropertyValueByLabel( $propertyLabel ) {
-		return $this->newDataValueByType( '__pro', $propertyLabel );
+	public function newPropertyValueByLabel( $propertyLabel, DIWikiPage $contextPage = null ) {
+		return $this->newDataValueByType( '__pro', $propertyLabel, false, null, $contextPage );
 	}
 
 /// Deprecated methods

--- a/src/Localizer.php
+++ b/src/Localizer.php
@@ -207,6 +207,7 @@ class Localizer {
 	}
 
 	/**
+	 * @deprecated 2.5, use Localizer::getAnnotatedLanguageCodeFrom instead
 	 * @since 2.4
 	 *
 	 * @param string &$value
@@ -214,6 +215,17 @@ class Localizer {
 	 * @return string|false
 	 */
 	public static function getLanguageCodeFrom( &$value ) {
+		return self::getAnnotatedLanguageCodeFrom( $value );
+	}
+
+	/**
+	 * @since 2.4
+	 *
+	 * @param string &$value
+	 *
+	 * @return string|false
+	 */
+	public static function getAnnotatedLanguageCodeFrom( &$value ) {
 
 		if ( strpos( $value, '@' ) === false ) {
 			return false;

--- a/tests/phpunit/Integration/ByJsonScript/Fixtures/p-0428.json
+++ b/tests/phpunit/Integration/ByJsonScript/Fixtures/p-0428.json
@@ -1,0 +1,39 @@
+{
+	"description": "Test `_TYPE` annotations on different content language (`wgContLang=fr`, `wgLang=en`)",
+	"properties": [
+		{
+			"name": "Has text",
+			"contents": "[[A le type::Texte]]"
+		}
+	],
+	"subjects": [
+		{
+			"name": "Example/P0428/1",
+			"contents": "[[Has text::#-Foo]]"
+		}
+	],
+	"parser-testcases": [
+		{
+			"about": "#0",
+			"subject": "Example/P0428/1",
+			"store": {
+				"semantic-data": {
+					"strict-mode-valuematch": false,
+					"propertyCount": 3,
+					"propertyKeys": [ "_SKEY", "_MDAT", "Has_text" ],
+					"propertyValues": [ "#-Foo" ]
+				}
+			}
+		}
+	],
+	"settings": {
+		"wgContLang": "fr",
+		"wgLang": "en",
+		"smwgPageSpecialProperties": [ "_MDAT" ]
+	},
+	"meta": {
+		"version": "0.1",
+		"is-incomplete": false,
+		"debug": false
+	}
+}

--- a/tests/phpunit/Unit/DataTypeRegistryTest.php
+++ b/tests/phpunit/Unit/DataTypeRegistryTest.php
@@ -221,6 +221,21 @@ class DataTypeRegistryTest extends \PHPUnit_Framework_TestCase {
 		}
 	}
 
+	public function testFindTypeIdByLanguage() {
+
+		$instance = new DataTypeRegistry();
+
+		$this->assertSame(
+			'_num',
+			$instance->findTypeIdByLanguage( 'Número' , 'es' )
+		);
+
+		$this->assertSame(
+			'_num',
+			$instance->findTypeIdByLanguage( '数值型' , 'zh-Hans' )
+		);
+	}
+
 	protected function assertRegistryFindsIdForLabels( $inputLabel, array $equivalentLabels ) {
 		$id = '_wpg';
 

--- a/tests/phpunit/Unit/LocalizerTest.php
+++ b/tests/phpunit/Unit/LocalizerTest.php
@@ -105,13 +105,13 @@ class LocalizerTest extends \PHPUnit_Framework_TestCase {
 		);
 	}
 
-	public function testCanGetLanguageCodeOnValidMarkedValue() {
+	public function testCanGetAnnotatedLanguageCodeOnValidMarkedValue() {
 
 		$value = 'Foo@en';
 
 		$this->assertEquals(
 			'en',
-			Localizer::getLanguageCodeFrom( $value )
+			Localizer::getAnnotatedLanguageCodeFrom( $value )
 		);
 
 		$this->assertEquals(
@@ -120,13 +120,13 @@ class LocalizerTest extends \PHPUnit_Framework_TestCase {
 		);
 	}
 
-	public function testCanGetLanguageCodeOnDoubledMarker() {
+	public function testCanGetAnnotatedLanguageCodeOnDoubledMarker() {
 
 		$value = 'Foo@@en';
 
 		$this->assertEquals(
 			'en',
-			Localizer::getLanguageCodeFrom( $value )
+			Localizer::getAnnotatedLanguageCodeFrom( $value )
 		);
 
 		$this->assertEquals(

--- a/tests/phpunit/includes/dataitems/DIPropertyTest.php
+++ b/tests/phpunit/includes/dataitems/DIPropertyTest.php
@@ -133,6 +133,26 @@ class DIPropertyTest extends DataItemTest {
 		);
 	}
 
+	public function testCreatePropertyFromLabelWithExplicitLanguageCode() {
+
+		$property = DIProperty::newFromUserLabel( 'Fecha de modificación', '', 'es' );
+
+		$this->assertEquals(
+			'_MDAT',
+			$property->getKey()
+		);
+	}
+
+	public function testCreatePropertyFromLabelWithAnnotatedLangCodeToTakePrecedence() {
+
+		$property = DIProperty::newFromUserLabel( 'A le type@fr', '', 'es' );
+
+		$this->assertEquals(
+			'_TYPE',
+			$property->getKey()
+		);
+	}
+
 	public function testCanonicalRepresentation() {
 
 		$property = new DIProperty( '_MDAT' );


### PR DESCRIPTION
This PR is made in reference to: # N/A

This PR addresses or contains:

- If the property page defines a specific page context then localized annotations (e.g `[[具有类型::文本型]]`) can be correctly identified.
- A page content language defined by `SIL` can directly make use of this

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed

