### PR TITLE
FTS to retain spaces on +/- operators, refs #1481

### DIFF
--- a/src/SQLStore/QueryEngine/Fulltext/TextSanitizer.php
+++ b/src/SQLStore/QueryEngine/Fulltext/TextSanitizer.php
@@ -152,7 +152,7 @@ class TextSanitizer {
 		// Remove possible spaces added by the tokenizer
 		$text = str_replace(
 			array( ' *', '* ', ' "', '" ', '+ ', '- ', '@ ' ),
-			array( '*', '*', '"', '"', '+', '-', '@' ),
+			array( '*', '*', '"', '"', ' +', ' -', '@' ),
 			$text
 		) . $affix;
 

--- a/tests/phpunit/Integration/ByJsonScript/Fixtures/q-0104.json
+++ b/tests/phpunit/Integration/ByJsonScript/Fixtures/q-0104.json
@@ -150,7 +150,7 @@
 			}
 		},
 		{
-			"about": "#8 free search",
+			"about": "#8 free search (wide proximity)",
 			"condition": "[[~~with a category]]",
 			"printouts" : [],
 			"parameters" : {
@@ -165,7 +165,7 @@
 			}
 		},
 		{
-			"about": "#9 free search",
+			"about": "#9 free search (wide proximity)",
 			"condition": "[[~~with a category]] [[Category:Q0104]]",
 			"printouts" : [],
 			"parameters" : {
@@ -175,6 +175,22 @@
 				"count": 1,
 				"results": [
 					"Example/Q0104/4#0##_d4fe48d7241e6530c628f32168815beb"
+				]
+			}
+		},
+		{
+			"about": "#10 retain spaces on +/- operators",
+			"condition": "[[Has text::~+*maria* -postgres*]]",
+			"printouts" : [],
+			"parameters" : {
+				"limit" : "10"
+			},
+			"queryresult": {
+				"count": 3,
+				"results": [
+					"Example/Q0104/1#0##_7980f674d00e51fbc91cc663a43054c5",
+					"Example/Q0104/1#0##_507a001e2e9e0e7659aa33e8c4b2d471",
+					"Example/Q0104/1#0##_55b020117d21e4b7967cf5bf78cf6b32"
 				]
 			}
 		}

--- a/tests/phpunit/Unit/SQLStore/QueryEngine/Fulltext/TextSanitizerTest.php
+++ b/tests/phpunit/Unit/SQLStore/QueryEngine/Fulltext/TextSanitizerTest.php
@@ -32,11 +32,18 @@ class TextSanitizerTest extends \PHPUnit_Framework_TestCase {
 		);
 	}
 
-	public function testSanitize() {
+	/**
+	 * @dataProvider textOnMockProvider
+	 */
+	public function testSanitizs( $text, $expected ) {
 
 		$sanitizer = $this->getMockBuilder( '\Onoi\Tesa\Sanitizer' )
 			->disableOriginalConstructor()
 			->getMock();
+
+		$sanitizer->expects( $this->atLeastOnce() )
+			->method( 'sanitizeWith' )
+			->will( $this->returnValue( $text ) );
 
 		$stopwordAnalyzer = $this->getMockBuilder( '\Onoi\Tesa\StopwordAnalyzer\StopwordAnalyzer' )
 			->disableOriginalConstructor()
@@ -70,7 +77,41 @@ class TextSanitizerTest extends \PHPUnit_Framework_TestCase {
 			$this->sanitizerFactory
 		);
 
-		$instance->sanitize( 'foo' );
+		$this->assertEquals(
+			$expected,
+			$instance->sanitize( $text )
+		);
 	}
+
+	public function textOnMockProvider() {
+
+		$provider[] = array(
+			'foo',
+			'foo'
+		);
+
+		$provider[] = array(
+			'foo* - bar',
+			'foo* -bar'
+		);
+
+		$provider[] = array(
+			'foo* + bar',
+			'foo* +bar'
+		);
+
+		$provider[] = array(
+			'foo *',
+			'foo*'
+		);
+
+		$provider[] = array(
+			'* foo *',
+			'*foo*'
+		);
+
+		return $provider;
+	}
+
 
 }


### PR DESCRIPTION
This PR is made in reference to: #1481

This PR addresses or contains:

- Ensures that after the sanitzer/tokenizer process, +/- operators retain spaces to be correctly identified as Boolean operators in the full-text search context.

This PR includes:
- [x] Tests (unit/integration)
- [ ] CI build passed

