### PR TITLE
FTS rebuilder to add --v/--quick option, refs #1481, #1763

### DIFF
--- a/tests/phpunit/Unit/SQLStore/QueryEngine/Fulltext/SearchTableRebuilderTest.php
+++ b/tests/phpunit/Unit/SQLStore/QueryEngine/Fulltext/SearchTableRebuilderTest.php
@@ -4,6 +4,7 @@ namespace SMW\Tests\SQLStore\QueryEngine\Fulltext;
 
 use SMW\SQLStore\QueryEngine\Fulltext\SearchTableRebuilder;
 use SMWDataItem as DataItem;
+use SMW\Tests\Utils\Mock\IteratorMockBuilder;
 
 /**
  * @covers \SMW\SQLStore\QueryEngine\Fulltext\SearchTableRebuilder
@@ -18,6 +19,7 @@ class SearchTableRebuilderTest extends \PHPUnit_Framework_TestCase {
 
 	private $searchTableUpdater;
 	private $connection;
+	private $iteratorMockBuilder;
 
 	protected function setUp() {
 
@@ -28,6 +30,8 @@ class SearchTableRebuilderTest extends \PHPUnit_Framework_TestCase {
 		$this->connection = $this->getMockBuilder( '\SMW\MediaWiki\Database' )
 			->disableOriginalConstructor()
 			->getMock();
+
+		$this->iteratorMockBuilder = new IteratorMockBuilder();
 	}
 
 	public function testCanConstruct() {
@@ -61,6 +65,62 @@ class SearchTableRebuilderTest extends \PHPUnit_Framework_TestCase {
 			$this->connection
 		);
 
+		$instance->run();
+	}
+
+	public function testRunWithUpdateOnBlob() {
+
+		$row = new \stdClass;
+		$row->o_serialized = 'Foo';
+		$row->s_id = 42;
+
+		$resultWrapper = $this->iteratorMockBuilder->setClass( '\ResultWrapper' )
+			->with( array( $row ) )
+			->incrementInvokedCounterBy( 1 )
+			->getMockForIterator();
+
+		$resultWrapper->expects( $this->atLeastOnce() )
+			->method( 'numRows' )
+			->will( $this->returnValue( 1 ) );
+
+		$this->connection->expects( $this->atLeastOnce() )
+			->method( 'select' )
+			->will( $this->returnValue( $resultWrapper ) );
+
+		$tableDefinition = $this->getMockBuilder( '\SMW\SQLStore\TableDefinition' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$tableDefinition->expects( $this->atLeastOnce() )
+			->method( 'getDiType' )
+			->will( $this->returnValue( DataItem::TYPE_BLOB ) );
+
+		$searchTable = $this->getMockBuilder( '\SMW\SQLStore\QueryEngine\Fulltext\SearchTable' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$this->searchTableUpdater->expects( $this->atLeastOnce() )
+			->method( 'getSearchTable' )
+			->will( $this->returnValue( $searchTable ) );
+
+		$this->searchTableUpdater->expects( $this->once() )
+			->method( 'isEnabled' )
+			->will( $this->returnValue( true ) );
+
+		$this->searchTableUpdater->expects( $this->atLeastOnce() )
+			->method( 'getPropertyTables' )
+			->will( $this->returnValue( array( $tableDefinition ) ) );
+
+		$this->searchTableUpdater->expects( $this->atLeastOnce() )
+			->method( 'update' )
+			->with( $this->equalTo( $row->s_id ) );
+
+		$instance = new SearchTableRebuilder(
+			$this->searchTableUpdater,
+			$this->connection
+		);
+
+		$instance->reportWithVerbosity( true );
 		$instance->run();
 	}
 

--- a/tests/phpunit/Utils/Mock/IteratorMockBuilder.php
+++ b/tests/phpunit/Utils/Mock/IteratorMockBuilder.php
@@ -6,10 +6,7 @@ use RuntimeException;
 
 /**
  * Convenience mock builder for Iterator classes
- *
- *
- * @group SMW
- * @group SMWExtension
+ * @group semantic-mediawiki
  *
  * @license GNU GPL v2+
  * @since 2.0
@@ -20,6 +17,7 @@ class IteratorMockBuilder extends \PHPUnit_Framework_TestCase {
 
 	private $iteratorClass;
 	private $items = array();
+	private $methods = array();
 	private $counter = 0;
 
 	/**
@@ -47,6 +45,34 @@ class IteratorMockBuilder extends \PHPUnit_Framework_TestCase {
 	}
 
 	/**
+	 * @since  2.5
+	 *
+	 * @param array $methods
+	 *
+	 * @return IteratorMockBuilder
+	 */
+	public function setMethods( array $methods ) {
+		$this->methods = $methods;
+		return $this;
+	}
+
+	/**
+	 * @note When other methods called before the actual current/next then
+	 * set the counter to ensure the starting point matches the expected
+	 * InvokeCount.
+	 *
+	 * @since  2.5
+	 *
+	 * @param integer $num
+	 *
+	 * @return IteratorMockBuilder
+	 */
+	public function incrementInvokedCounterBy( $num ) {
+		$this->counter += $num;
+		return $this;
+	}
+
+	/**
 	 * @since  2.0
 	 *
 	 * @return PHPUnit_Framework_MockObject_MockObject
@@ -56,13 +82,12 @@ class IteratorMockBuilder extends \PHPUnit_Framework_TestCase {
 
 		$instance = $this->getMockBuilder( $this->iteratorClass )
 			->disableOriginalConstructor()
+			->setMethods( $this->methods )
 			->getMock();
 
 		if ( !$instance instanceof \Iterator ) {
 			throw new RuntimeException( "Instance is not an Iterator" );
 		}
-
-		$this->counter = 0;
 
 		$instance->expects( $this->at( $this->counter++ ) )
 			->method( 'rewind' );


### PR DESCRIPTION
This PR is made in reference to: #1481, #1763

This PR addresses or contains:

- Adds `--v`/`--quick` to `rebuildFulltextSearchTable.php`

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed

