### PR TITLE
Use ul/li element in Ask error output, refs #1759, #1768

### DIFF
--- a/i18n/en.json
+++ b/i18n/en.json
@@ -120,7 +120,7 @@
 	"smw_noqueryfeature": "Some query feature was not supported in this wiki and part of the query was dropped ($1).",
 	"smw_noconjunctions": "Conjunctions in queries are not supported in this wiki and part of the query was dropped ($1).",
 	"smw_nodisjunctions": "Disjunctions in queries are not supported in this wiki and part of the query was dropped ($1).",
-	"smw_querytoolarge": "The following query conditions could not be considered due to the wikis restrictions in query size or depth: $1.",
+	"smw_querytoolarge": "The following query conditions <code>$1</code> could not be considered due to the wikis restrictions in query size or depth.",
 	"smw_notemplategiven": "Provide a value for the parameter \"template\" for this query format to work.",
 	"smw_db_sparqlqueryproblem": "The query result could not be obtained from the SPARQL database. This error might be temporary or indicate a bug in the database software.",
 	"smw_db_sparqlqueryincomplete": "Answering the query turned out to be too difficult and was aborted. Some results could be missing. If possible, try using a simpler query instead.",

--- a/includes/query/SMW_Query.php
+++ b/includes/query/SMW_Query.php
@@ -3,6 +3,7 @@
 use SMW\DIWikiPage;
 use SMW\HashBuilder;
 use SMW\Query\PrintRequest;
+use SMW\Message;
 
 /**
  * This file contains the class for representing queries in SMW, each
@@ -299,10 +300,10 @@ class SMWQuery {
 			$this->description = $this->description->prune( $maxsize, $maxdepth, $log );
 
 			if ( count( $log ) > 0 ) {
-				$this->errors[] = array(
+				$this->errors[] = Message::encode( array(
 					'smw_querytoolarge',
 					str_replace( '[', '&#x005B;', implode( ', ', $log ) )
-				);
+				) );
 			}
 		}
 	}

--- a/includes/specials/SMW_SpecialAsk.php
+++ b/includes/specials/SMW_SpecialAsk.php
@@ -311,6 +311,7 @@ class SMWAskPage extends SMWQuerySpecialPage {
 			}
 
 			$printer = SMWQueryProcessor::getResultPrinter( $this->m_params['format'], SMWQueryProcessor::SPECIAL_PAGE );
+			$printer->setShowErrors( false );
 
 			global $wgRequest;
 
@@ -372,9 +373,7 @@ class SMWAskPage extends SMWQuerySpecialPage {
 				$navigation,
 				$duration,
 				$isFromCache
-			) . $result;
-
-			$result .= $htmlContentBuilder->getFormattedErrorString( $queryobj );
+			) . $htmlContentBuilder->getFormattedErrorString( $queryobj ) . $result;
 
 			$this->getOutput()->addHTML( $result );
 		}

--- a/src/MediaWiki/Specials/Ask/HtmlContentBuilder.php
+++ b/src/MediaWiki/Specials/Ask/HtmlContentBuilder.php
@@ -2,6 +2,8 @@
 
 namespace SMW\MediaWiki\Specials\Ask;
 
+use SMW\ProcessingErrorMsgHandler;
+use SMW\Message;
 use SMWQuery as Query;
 use Html;
 
@@ -26,22 +28,25 @@ class HtmlContentBuilder {
 			return '';
 		}
 
-		if ( count( $query->getErrors() ) == 1 ) {
-			$error = implode( ' ', $query->getErrors() );
-		} else {
+		$errors = array();
 
-			// Filter any duplicate messages
-			$errors = array();
-			foreach ( $query->getErrors() as $key => $value ) {
+		foreach ( ProcessingErrorMsgHandler::normalizeMessages( $query->getErrors() ) as $value ) {
 
-				if ( is_array( $value ) ) {
-					$value = implode( ' ', $value );
-				}
-
-				$errors[md5( $value )] = $value;
+			if ( $value === '' ) {
+				continue;
 			}
 
-			$error = '<li>' . implode( '</li><li>', $errors ) . '</li>';
+			if ( is_array( $value ) ) {
+				$value = implode( " ", $value );
+			}
+
+			$errors[] = $value;
+		}
+
+		if ( count( $errors ) > 1 ) {
+			$error = '<ul><li>' . implode( '</li><li>', $errors ) . '</li></ul>';
+		} else {
+			$error =  implode( ' ', $errors ) ;
 		}
 
 		return Html::rawElement( 'div', array( 'class' => 'smw-callout smw-callout-error' ), $error );

--- a/tests/phpunit/Unit/MediaWiki/Specials/Ask/HtmlContentBuilderTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Specials/Ask/HtmlContentBuilderTest.php
@@ -58,18 +58,18 @@ class HtmlContentBuilderTest extends \PHPUnit_Framework_TestCase {
 
 		$provider[] = array(
 			array( 'Foo', 'Bar' ),
-			'<div class="smw-callout smw-callout-error"><li>Foo</li><li>Bar</li></div>'
+			'<div class="smw-callout smw-callout-error"><ul><li>Foo</li><li>Bar</li></ul></div>'
 		);
 
 		$provider[] = array(
 			array( 'Foo', array( 'Bar' ) ),
-			'<div class="smw-callout smw-callout-error"><li>Foo</li><li>Bar</li></div>'
+			'<div class="smw-callout smw-callout-error"><ul><li>Foo</li><li>Bar</li></ul></div>'
 		);
 
 		// Filter duplicate
 		$provider[] = array(
 			array( 'Foo', array( 'Bar' ), 'Bar' ),
-			'<div class="smw-callout smw-callout-error"><li>Foo</li><li>Bar</li></div>'
+			'<div class="smw-callout smw-callout-error"><ul><li>Foo</li><li>Bar</li></ul></div>'
 		);
 
 		return $provider;


### PR DESCRIPTION
This PR is made in reference to: #1759, #1768

This PR addresses or contains:

- Firefox need a proper ul/li element otherwise a list of error msgs looks out of place
- With  #1768 ensure to use `ProcessingErrorMsgHandler` to retrieve encoded msgs
- Place a possible error msg before the actual result display

![image](https://cloud.githubusercontent.com/assets/1245473/17615523/1b2e2a98-606f-11e6-8fd0-f42a58b5850f.png)

![image](https://cloud.githubusercontent.com/assets/1245473/17615751/83370be0-6070-11e6-87b1-10c96157cb9f.png)

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed

