### PR TITLE
Avoid double error recording, refs #1768

### DIFF
--- a/includes/ParserData.php
+++ b/includes/ParserData.php
@@ -271,7 +271,6 @@ class ParserData {
 	 */
 	public function addDataValue( DataValue $dataValue ) {
 		$this->semanticData->addDataValue( $dataValue );
-		$this->addError( $this->semanticData->getErrors() );
 	}
 
 	/**

--- a/tests/phpunit/includes/ParserDataTest.php
+++ b/tests/phpunit/includes/ParserDataTest.php
@@ -214,7 +214,7 @@ class ParserDataTest extends \PHPUnit_Framework_TestCase {
 		);
 
 		if ( $errorCount > 0 ) {
-			return $this->assertCount( $errorCount, $instance->getErrors() );
+			return $this->assertCount( $errorCount, $instance->getSemanticData()->getErrors() );
 		}
 
 		$expected = array(


### PR DESCRIPTION
This PR is made in reference to: #1768

This PR addresses or contains:

- Recording of `DV` relate errors already happened in `SemanticData` therefore avoid recording it twice 

This PR includes:
- [ ] Tests (unit/integration)
- [x] CI build passed

