### PR TITLE
Remove wfMessage usage from DV's, refs #1768

### DIFF
--- a/includes/datavalues/SMW_DV_PropertyList.php
+++ b/includes/datavalues/SMW_DV_PropertyList.php
@@ -33,7 +33,7 @@ class SMWPropertyListValue extends SMWDataValue {
 				$propertyName = $propertyNameParts[1];
 				$propertyNamespace = $wgContLang->getNsText( SMW_NS_PROPERTY );
 				if ( $namespace != $propertyNamespace ) {
-					$this->addError( wfMessage( 'smw_wrong_namespace', $propertyNamespace )->inContentLanguage()->text() );
+					$this->addErrorMsg( array( 'smw_wrong_namespace', $propertyNamespace ) );
 				}
 			}
 
@@ -43,7 +43,7 @@ class SMWPropertyListValue extends SMWDataValue {
 				$diProperty = SMW\DIProperty::newFromUserLabel( $propertyName );
 			} catch ( SMWDataItemException $e ) {
 				$diProperty = new SMW\DIProperty( 'Error' );
-				$this->addError( wfMessage( 'smw_noproperty', $propertyName )->inContentLanguage()->text() );
+				$this->addErrorMsg( array( 'smw_noproperty', $propertyName ) );
 			}
 
 			$this->m_diProperties[] = $diProperty;
@@ -76,7 +76,7 @@ class SMWPropertyListValue extends SMWDataValue {
 				$property = new SMW\DIProperty( $propertyKey );
 			} catch ( SMWDataItemException $e ) {
 				$property = new SMW\DIProperty( 'Error' );
-				$this->addError( wfMessage( 'smw_parseerror' )->inContentLanguage()->text() );
+				$this->addErrorMsg( array( 'smw_parseerror' ) );
 			}
 
 			if ( $property instanceof SMWDIProperty ) {

--- a/includes/datavalues/SMW_DV_Record.php
+++ b/includes/datavalues/SMW_DV_Record.php
@@ -60,7 +60,7 @@ class SMWRecordValue extends SMWDataValue {
 	protected function parseUserValue( $value ) {
 
 		if ( $value === '' ) {
-			$this->addError( wfMessage( 'smw_novalues' )->text() );
+			$this->addErrorMsg( array( 'smw_novalues' ) );
 			return;
 		}
 
@@ -114,7 +114,7 @@ class SMWRecordValue extends SMWDataValue {
 		}
 
 		if ( $empty && $this->getErrors() === array()  ) {
-			$this->addError( wfMessage( 'smw_novalues' )->text() );
+			$this->addErrorMsg( array( 'smw_novalues' ) );
 		}
 
 		$this->m_dataitem = new SMWDIContainer( $semanticData );

--- a/includes/datavalues/SMW_DV_URI.php
+++ b/includes/datavalues/SMW_DV_URI.php
@@ -1,6 +1,7 @@
 <?php
 
 use SMW\UrlEncoder;
+use SMW\Message;
 
 /**
  * @ingroup SMWDataValues
@@ -69,7 +70,7 @@ class SMWURIValue extends SMWDataValue {
 
 		$scheme = $hierpart = $query = $fragment = '';
 		if ( $value === '' ) { // do not accept empty strings
-			$this->addError( wfMessage( 'smw_emptystring' )->inContentLanguage()->text() );
+			$this->addErrorMsg( array( 'smw_emptystring' ) );
 			return;
 		}
 
@@ -92,7 +93,7 @@ class SMWURIValue extends SMWDataValue {
 					$parts[0] = 'http';
 				}
 				// check against blacklist
-				$uri_blacklist = explode( "\n", wfMessage( 'smw_uri_blacklist' )->inContentLanguage()->text() );
+				$uri_blacklist = explode( "\n", Message::get( 'smw_uri_blacklist', Message::TEXT, Message::CONTENT_LANGUAGE ) );
 				foreach ( $uri_blacklist as $uri ) {
 					$uri = trim( $uri );
 					if ( $uri !== '' && $uri == mb_substr( $value, 0, mb_strlen( $uri ) ) ) { // disallowed URI!

--- a/includes/datavalues/SMW_DV_WikiPage.php
+++ b/includes/datavalues/SMW_DV_WikiPage.php
@@ -2,6 +2,7 @@
 
 use SMW\ApplicationFactory;
 use SMW\DIProperty;
+use SMW\Localizer;
 
 /**
  * @ingroup SMWDataValues
@@ -173,9 +174,12 @@ class SMWWikiPageValue extends SMWDataValue {
 
 		if ( ( $this->m_fixNamespace != NS_MAIN ) &&
 			( $this->m_fixNamespace != $dataItem->getNamespace() ) ) {
-				global $wgContLang;
-				$this->addError( wfMessage( 'smw_wrong_namespace',
-					$wgContLang->getNsText( $this->m_fixNamespace ) )->inContentLanguage()->text() );
+				$this->addErrorMsg(
+					array(
+						'smw_wrong_namespace',
+						Localizer::getInstance()->getNamespaceTextById( $this->m_fixNamespace )
+					)
+				);
 		}
 
 		return true;
@@ -420,11 +424,12 @@ class SMWWikiPageValue extends SMWDataValue {
 			$this->m_title = $this->m_dataitem->getTitle();
 
 			if ( is_null( $this->m_title ) ) { // should not normally happen, but anyway ...
-				global $wgContLang;
-				$this->addError( wfMessage(
-					'smw_notitle',
-					$wgContLang->getNsText( $this->m_dataitem->getNamespace() ) . ':' . $this->m_dataitem->getDBkey()
-				)->inContentLanguage()->text() );
+				$this->addErrorMsg(
+					array(
+						'smw_notitle',
+						Localizer::getInstance()->getNamespaceTextById( $this->m_dataitem->getNamespace() ) . ':' . $this->m_dataitem->getDBkey()
+					)
+				);
 			}
 		}
 


### PR DESCRIPTION
This PR is made in reference to: #1768

This PR addresses or contains:

- Removes most `wfMessage` usage from DV's to avoid generating a text representation

This PR includes:
- [ ] Tests (unit/integration)
- [x] CI build passed

