### PR TITLE
Fix time offset recognition

### DIFF
--- a/i18n/en.json
+++ b/i18n/en.json
@@ -407,5 +407,12 @@
 	"smw-pa-property-predefined_num": "\"$1\" is a [[Special:Types/Number|type]] and predefined property provided by [https://www.semantic-mediawiki.org/wiki/Help:Special_properties Semantic MediaWiki] to represent numeric values.",
 	"smw-pa-property-predefined_dat": "\"$1\" is a [[Special:Types/Date|type]] and predefined property provided by [https://www.semantic-mediawiki.org/wiki/Help:Special_properties Semantic MediaWiki] to represent date values.",
 	"smw-pa-property-predefined_uri": "\"$1\" is a [[Special:Types/URL|type]] and predefined property provided by [https://www.semantic-mediawiki.org/wiki/Help:Special_properties Semantic MediaWiki] to represent URI/URL values.",
-	"smw-pa-property-predefined_qty": "\"$1\" is a [[Special:Types/Quantity|type]] and predefined property provided by [https://www.semantic-mediawiki.org/wiki/Help:Special_properties Semantic MediaWiki] to represent quantity values."
+	"smw-pa-property-predefined_qty": "\"$1\" is a [[Special:Types/Quantity|type]] and predefined property provided by [https://www.semantic-mediawiki.org/wiki/Help:Special_properties Semantic MediaWiki] to represent quantity values.",
+	"smw-datavalue-time-invalid-offset-zone-usage": "\"$1\" contains an offset and zone identifier which is not supported.",
+	"smw-datavalue-time-invalid-values": "The \"$1\" value contains uninterpretable information in form of \"$2\".",
+	"smw-datavalue-time-invalid-date-components-common": "\"$1\" contains some uninterpretable information.",
+	"smw-datavalue-time-invalid-date-components-dash": "\"$1\" contains an uninterpretable dash.",
+	"smw-datavalue-time-invalid-date-components-empty": "\"$1\" contains some empty components.",
+	"smw-datavalue-time-invalid-date-components-three": "\"$1\" contains more than three components.",
+	"smw-datavalue-time-invalid-ampm": "\"$1\" contains \"$2\" as hour element that is invalid for a 12-hour convention."
 }

--- a/tests/phpunit/Integration/ByJsonScript/Fixtures/p-0402.json
+++ b/tests/phpunit/Integration/ByJsonScript/Fixtures/p-0402.json
@@ -169,7 +169,7 @@
 			},
 			"expected-output": {
 				"to-contain": [
-					"The date &quot;-901 AD&quot; was not understood."
+					"&quot;-901 AD&quot; contains an uninterpretable dash."
 				]
 			}
 		}

--- a/tests/phpunit/Integration/ByJsonScript/Fixtures/p-0429.json
+++ b/tests/phpunit/Integration/ByJsonScript/Fixtures/p-0429.json
@@ -1,0 +1,118 @@
+{
+	"description": "Test in-text `_dat` annotation with time offset, time zone, am/pm (`wgContLang=en`, `wgLang=en`)",
+	"properties": [
+		{
+			"name": "Has date",
+			"contents": "[[Has type::Date]]"
+		}
+	],
+	"subjects": [
+		{
+			"name": "Example/P0429/1",
+			"contents": "[[Has date::1 Jan 1971 13:45:23-3:30]]"
+		},
+		{
+			"name": "Example/P0429/Q.1",
+			"contents": "{{#show: Example/P0429/1 |?Has date }}"
+		},
+		{
+			"name": "Example/P0429/2",
+			"contents": "[[Has date::1 Jan 1971 13:45:23 EST]]"
+		},
+		{
+			"name": "Example/P0429/Q.2",
+			"contents": "{{#show: Example/P0429/2 |?Has date }}"
+		},
+		{
+			"name": "Example/P0429/3",
+			"contents": "[[Has date::1 Jan 1971 13:45:23 am]]"
+		},
+		{
+			"name": "Example/P0429/4",
+			"contents": "[[Has date::1 Jan 1971 5:05:23 pm]]"
+		}
+	],
+	"parser-testcases": [
+		{
+			"about": "#0 timeoffset",
+			"subject": "Example/P0429/1",
+			"store": {
+				"semantic-data": {
+					"strict-mode-valuematch": false,
+					"propertyCount": 3,
+					"propertyKeys": [ "_SKEY", "_MDAT", "Has_date" ],
+					"propertyValues": [ "1971-01-01T16:15:23" ]
+				}
+			}
+		},
+		{
+			"about": "#1",
+			"subject": "Example/P0429/Q.1",
+			"expected-output": {
+				"to-contain": [
+					"1 January 1971 16:15:23"
+				]
+			}
+		},
+		{
+			"about": "#2 timezone",
+			"subject": "Example/P0429/2",
+			"store": {
+				"semantic-data": {
+					"strict-mode-valuematch": false,
+					"propertyCount": 3,
+					"propertyKeys": [ "_SKEY", "_MDAT", "Has_date" ],
+					"propertyValues": [ "1971-01-01T18:45:23" ]
+				}
+			}
+		},
+		{
+			"about": "#3",
+			"subject": "Example/P0429/Q.2",
+			"expected-output": {
+				"to-contain": [
+					"1 January 1971 18:45:23"
+				]
+			}
+		},
+		{
+			"about": "#4 invalid am/pm",
+			"subject": "Example/P0429/3",
+			"expected-output": {
+				"to-contain": [
+					"&quot;1 Jan 1971 13:45:23 am&quot; contains &quot;13&quot; as hour element that is invalid for a 12-hour convention."
+				]
+			}
+		},
+		{
+			"about": "#5 valid am/pm",
+			"subject": "Example/P0429/4",
+			"store": {
+				"semantic-data": {
+					"strict-mode-valuematch": false,
+					"propertyCount": 3,
+					"propertyKeys": [ "_SKEY", "_MDAT", "Has_date" ],
+					"propertyValues": [ "1971-01-01T17:05:23" ]
+				}
+			}
+		},
+		{
+			"about": "#6 valid am/pm",
+			"subject": "Example/P0429/4",
+			"expected-output": {
+				"to-contain": [
+					"1 Jan 1971 5:05:23 pm"
+				]
+			}
+		}
+	],
+	"settings": {
+		"wgContLang": "en",
+		"wgLang": "en"
+	},
+	"meta": {
+		"version": "0.1",
+		"is-incomplete": false,
+		"debug": false
+	}
+}


### PR DESCRIPTION
This PR is made in reference to: # N/A

This PR addresses or contains:

- Fix time offset recognition where something like `[[Has date::1 Jan 1971 13:45:23-3:30]]` should return
`1971-01-01T16:15:23`. This is/was at least broken since 1.9.2 (where it returns `1 January 1971 13:45:23`).
- Adds additional error msgs to clarify situations where values are unclear, incomprehensible,  or insufficient

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed

