### PR TITLE
Add QueryEngine and StoreAware interface

### DIFF
--- a/includes/query/SMW_QueryProcessor.php
+++ b/includes/query/SMW_QueryProcessor.php
@@ -6,6 +6,7 @@ use ParamProcessor\ParamDefinition;
 use ParamProcessor\Processor;
 use SMW\Query\PrintRequest;
 use SMW\Query\PrintRequestFactory;
+use SMW\ApplicationFactory;
 
 /**
  * This file contains a static class for accessing functions to generate and execute
@@ -488,15 +489,7 @@ class SMWQueryProcessor {
 	}
 
 	private static function getStoreFromParams( array $params ) {
-
-		$storeId = null;
-		$source  = $params['source']->getValue();
-
-		if ( $source !== '' ) {
-			$storeId = $GLOBALS['smwgQuerySources'][$source];
-		}
-
-		return \SMW\StoreFactory::getStore( $storeId );
+		return ApplicationFactory::getInstance()->getQuerySource( $params['source']->getValue() );
 	}
 
 	/**

--- a/includes/specials/SMW_SpecialAsk.php
+++ b/includes/specials/SMW_SpecialAsk.php
@@ -4,6 +4,7 @@ use ParamProcessor\Param;
 use SMW\Query\PrintRequest;
 use SMW\Query\QueryLinker;
 use SMW\MediaWiki\Specials\Ask\HtmlContentBuilder;
+use SMW\ApplicationFactory;
 
 /**
  * This special page for MediaWiki implements a customisable form for
@@ -200,15 +201,7 @@ class SMWAskPage extends SMWQuerySpecialPage {
 	}
 
 	private function getStoreFromParams( array $params ) {
-
-		$storeId = null;
-		$source  = $params['source']->getValue();
-
-		if ( $source !== '' ) {
-			$storeId = $GLOBALS['smwgQuerySources'][$source];
-		}
-
-		return \SMW\StoreFactory::getStore( $storeId );
+		return ApplicationFactory::getInstance()->getQuerySource( $params['source']->getValue() );
 	}
 
 	/**

--- a/includes/storage/SMW_Store.php
+++ b/includes/storage/SMW_Store.php
@@ -8,6 +8,7 @@ use SMWQueryResult;
 use SMWRequestOptions;
 use SMWSemanticData;
 use Title;
+use SMW\QueryEngine;
 
 /**
  * This group contains all parts of SMW that relate to storing and retrieving
@@ -28,7 +29,7 @@ use Title;
  *
  * @author Markus Krötzsch
  */
-abstract class Store {
+abstract class Store implements QueryEngine {
 
 	/**
 	 * @var boolean

--- a/src/ApplicationFactory.php
+++ b/src/ApplicationFactory.php
@@ -175,6 +175,17 @@ class ApplicationFactory {
 	}
 
 	/**
+	 * @since 2.5
+	 *
+	 * @param string|null $source
+	 *
+	 * @return QueryEngine
+	 */
+	public function getQuerySource( $source = null ) {
+		return $this->callbackLoader->singleton( 'QuerySourceFactory' )->getWithLocalFallback( $source );
+	}
+
+	/**
 	 * @since 2.0
 	 *
 	 * @return Store
@@ -364,12 +375,12 @@ class ApplicationFactory {
 	}
 
 	/**
-	 * @since 2.4
+	 * @since 2.5
 	 *
 	 * @return QueryFactory
 	 */
-	public function newQueryFactory() {
-		return new QueryFactory();
+	public function getQueryFactory() {
+		return $this->callbackLoader->singleton( 'QueryFactory' );
 	}
 
 	private static function registerBuilder( CallbackLoader $callbackLoader = null ) {

--- a/src/DataValues/ValueValidators/UniquenessConstraintValueValidator.php
+++ b/src/DataValues/ValueValidators/UniquenessConstraintValueValidator.php
@@ -58,7 +58,7 @@ class UniquenessConstraintValueValidator implements ConstraintValueValidator {
 			$this->cachedPropertyValuesPrefetcher = ApplicationFactory::getInstance()->getCachedPropertyValuesPrefetcher();
 		}
 
-		$this->queryFactory = ApplicationFactory::getInstance()->newQueryFactory();
+		$this->queryFactory = ApplicationFactory::getInstance()->getQueryFactory();
 	}
 
 	/**

--- a/src/Query/QuerySourceFactory.php
+++ b/src/Query/QuerySourceFactory.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace SMW\Query;
+
+use SMW\Store;
+use SMW\QueryEngine;
+use SMW\StoreAware;
+use RuntimeException;
+
+/**
+ * @private
+ *
+ * @license GNU GPL v2+
+ * @since 2.5
+ *
+ * @author mwjames
+ */
+class QuerySourceFactory {
+
+	/**
+	 * @var Store
+	 */
+	private $store;
+
+	/**
+	 * @var array
+	 */
+	private $querySources = array();
+
+	/**
+	 * @since 2.5
+	 *
+	 * @param Store $store
+	 * @param array $querySources
+	 */
+	public function __construct( Store $store, $querySources = array() ) {
+		$this->store = $store;
+		$this->querySources = $querySources;
+	}
+
+	/**
+	 * @see DefaultSettings::$smwgQuerySources
+	 *
+	 * @since 2.5
+	 *
+	 * @param string|null $source
+	 *
+	 * @return QueryEngine|Store
+	 * @throws RuntimeException
+	 */
+	public function getWithLocalFallback( $source = null ) {
+
+		if ( $source !== '' && isset( $this->querySources[$source] ) ) {
+			$source = $this->querySources[$source];
+		}
+
+		if ( $source !== '' && class_exists( $source ) ) {
+			$source = new $source;
+		} else {
+			$source = $this->store;
+		}
+
+		if ( !$source instanceof QueryEngine && !$source instanceof Store ) {
+			throw new RuntimeException(  get_class( $source ) . " does not match the expected QueryEngine interface." );
+		}
+
+		if ( $source instanceof StoreAware ) {
+			$source->setStore( $this->store );
+		}
+
+		return $source;
+	}
+
+}

--- a/src/QueryEngine.php
+++ b/src/QueryEngine.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace SMW;
+
+use SMWQuery as Query;
+use SMWQueryResult as QueryResult;
+
+/**
+ * Interface for query answering that depend on concrete implementations to
+ * provide the filtering and matching process for specific conditions against a
+ * select back-end.
+ *
+ * @license GNU GPL v2
+ * @since 2.5
+ *
+ * @author mwjames
+ */
+interface QueryEngine {
+
+	/**
+	 * Returns a QueryResult object that matches the condition described by a
+	 * query.
+	 *
+	 * @note If the request was made for a debug (querymode MODE_DEBUG) query
+	 * then a simple HTML-compatible string is returned.
+	 *
+	 * @since 2.5
+	 *
+	 * @param Query $query
+	 *
+	 * @return QueryResult|string
+	 */
+	public function getQueryResult( Query $query );
+
+}

--- a/src/SPARQLStore/QueryEngine/QueryEngine.php
+++ b/src/SPARQLStore/QueryEngine/QueryEngine.php
@@ -12,6 +12,7 @@ use SMW\SPARQLStore\QueryEngine\Condition\SingletonCondition;
 use SMW\SPARQLStore\RepositoryConnection;
 use SMWQuery as Query;
 use SMWQueryResult as QueryResult;
+use SMW\QueryEngine as QueryEngineInterface;
 
 /**
  * Class mapping SMWQuery objects to SPARQL, and for controlling the execution
@@ -23,7 +24,7 @@ use SMWQueryResult as QueryResult;
  * @author Markus Krötzsch
  * @author mwjames
  */
-class QueryEngine {
+class QueryEngine implements QueryEngineInterface {
 
 	/// The name of the SPARQL variable that represents the query result.
 	const RESULT_VARIABLE = 'result';

--- a/src/SQLStore/QueryEngine/QueryEngine.php
+++ b/src/SQLStore/QueryEngine/QueryEngine.php
@@ -15,6 +15,7 @@ use SMWQuery as Query;
 use SMWQueryResult as QueryResult;
 use SMWSql3SmwIds;
 use SMWSQLStore3 as SQLStore;
+use SMW\QueryEngine as QueryEngineInterface;
 
 /**
  * Class that implements query answering for SQLStore.
@@ -26,7 +27,7 @@ use SMWSQLStore3 as SQLStore;
  * @author Jeroen De Dauw
  * @author mwjames
  */
-class QueryEngine {
+class QueryEngine implements QueryEngineInterface {
 
 	/**
 	 * @var SQLStore

--- a/src/SharedCallbackContainer.php
+++ b/src/SharedCallbackContainer.php
@@ -10,6 +10,7 @@ use SMW\MediaWiki\Jobs\JobFactory;
 use SMW\MediaWiki\MediaWikiNsContentReader;
 use SMW\MediaWiki\PageCreator;
 use SMW\MediaWiki\TitleCreator;
+use SMW\Query\QuerySourceFactory;
 
 /**
  * @license GNU GPL v2+
@@ -108,6 +109,26 @@ class SharedCallbackContainer implements CallbackContainer {
 
 		$callbackLoader->registerCallback( 'FactboxFactory', function() {
 			return new FactboxFactory();
+		} );
+
+		/**
+		 * @var QuerySourceFactory
+		 */
+		$callbackLoader->registerCallback( 'QuerySourceFactory', function() use ( $callbackLoader ) {
+			$callbackLoader->registerExpectedReturnType( 'QuerySourceFactory', '\SMW\Query\QuerySourceFactory' );
+
+			return new QuerySourceFactory(
+				$callbackLoader->load( 'Store' ),
+				$callbackLoader->load( 'Settings' )->get( 'smwgQuerySources' )
+			);
+		} );
+
+		/**
+		 * @var QueryFactory
+		 */
+		$callbackLoader->registerCallback( 'QueryFactory', function() use ( $callbackLoader ) {
+			$callbackLoader->registerExpectedReturnType( 'QueryFactory', '\SMW\QueryFactory' );
+			return new QueryFactory();
 		} );
 
 		$callbackLoader->registerExpectedReturnType( 'DeferredCallableUpdate', '\SMW\DeferredCallableUpdate' );

--- a/src/StoreAware.php
+++ b/src/StoreAware.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace SMW;
+
+/**
+ * Describes an instance that is aware of a Store object.
+ *
+ * @license GNU GPL v2
+ * @since 2.5
+ *
+ * @author mwjames
+ */
+interface StoreAware {
+
+	/**
+	 * @since 2.5
+	 *
+	 * @param Store $store
+	 */
+	public function setStore( Store $store );
+
+}

--- a/tests/phpunit/Integration/ByJsonScript/ByJsonScriptFixtureTestCaseRunnerTest.php
+++ b/tests/phpunit/Integration/ByJsonScript/ByJsonScriptFixtureTestCaseRunnerTest.php
@@ -259,7 +259,7 @@ class ByJsonScriptFixtureTestCaseRunnerTest extends ByJsonTestCaseProvider {
 		// Set query parser late to ensure that expected settings are adjusted
 		// (language etc.) because the __construct relies on the context language
 		$this->queryTestCaseProcessor->setQueryParser(
-			ApplicationFactory::getInstance()->newQueryFactory()->newQueryParser()
+			ApplicationFactory::getInstance()->getQueryFactory()->newQueryParser()
 		);
 
 		$this->queryTestCaseProcessor->setDebugMode(

--- a/tests/phpunit/Unit/ApplicationFactoryTest.php
+++ b/tests/phpunit/Unit/ApplicationFactoryTest.php
@@ -73,6 +73,14 @@ class ApplicationFactoryTest extends \PHPUnit_Framework_TestCase {
 		);
 	}
 
+	public function testCanConstructQuerySource() {
+
+		$this->assertInstanceOf(
+			'\SMW\QueryEngine',
+			$this->applicationFactory->getQuerySource()
+		);
+	}
+
 	public function testGetStore() {
 
 		$this->assertInstanceOf(
@@ -225,7 +233,7 @@ class ApplicationFactoryTest extends \PHPUnit_Framework_TestCase {
 
 		$this->assertInstanceOf(
 			'\SMW\QueryFactory',
-			$this->applicationFactory->newQueryFactory()
+			$this->applicationFactory->getQueryFactory()
 		);
 	}
 

--- a/tests/phpunit/Unit/Query/QuerySourceFactoryTest.php
+++ b/tests/phpunit/Unit/Query/QuerySourceFactoryTest.php
@@ -1,0 +1,102 @@
+<?php
+
+namespace SMW\Tests\Query;
+
+use SMW\Query\QuerySourceFactory;
+use SMW\QueryEngine;
+use SMW\StoreAware;
+use SMW\Store;
+use SMWQuery as Query;
+use SMW\Tests\TestEnvironment;
+
+/**
+ * @covers SMW\Query\QuerySourceFactory
+ * @group semantic-mediawiki
+ *
+ * @license GNU GPL v2+
+ * @since 2.5
+ *
+ * @author mwjames
+ */
+class QuerySourceFactoryTest extends \PHPUnit_Framework_TestCase {
+
+	private $testEnvironment;
+
+	protected function setUp() {
+		$this->testEnvironment = new TestEnvironment();
+
+		$this->store = $this->getMockBuilder( '\SMW\Store' )
+			->disableOriginalConstructor()
+			->getMockForAbstractClass();
+
+		$this->testEnvironment->registerObject( 'Store', $this->store );
+	}
+
+	protected function tearDown() {
+		$this->testEnvironment->tearDown();
+		parent::tearDown();
+	}
+
+	public function testCanConstruct() {
+
+		$this->assertInstanceOf(
+			QuerySourceFactory::class,
+			new QuerySourceFactory( $this->store )
+		);
+	}
+
+	public function testGetFromFakeSource() {
+
+		$instance = new QuerySourceFactory(
+			$this->store,
+			array(
+				'foo' => FakeQueryEngine::class
+			)
+		);
+
+		$this->assertInstanceOf(
+			'\SMW\QueryEngine',
+			$instance->getWithLocalFallback( 'foo' )
+		);
+	}
+
+	public function testGetFromAnotherFakeSourceThatImplementsStoreAware() {
+
+		$store = $this->getMockBuilder( '\SMW\Store' )
+			->disableOriginalConstructor()
+			->setMethods( array( 'getConnection' ) )
+			->getMockForAbstractClass();
+
+		$store->expects( $this->once() )
+			->method( 'getConnection' )
+			->with( $this->stringContains( 'foo' ) );
+
+		$instance = new QuerySourceFactory(
+			$store,
+			array(
+				'bar' => AnotherFakeQueryEngine::class
+			)
+		);
+
+		$this->assertInstanceOf(
+			'\SMW\QueryEngine',
+			$instance->getWithLocalFallback( 'bar' )
+		);
+	}
+}
+
+class FakeQueryEngine implements QueryEngine {
+
+	public function getQueryResult( Query $query ) {
+		return '';
+	}
+
+}
+
+class AnotherFakeQueryEngine extends FakeQueryEngine implements StoreAware {
+
+	public function setStore( Store $store ) {
+		return $store->getConnection( 'foo' );
+	}
+
+}

--- a/tests/phpunit/Utils/Mock/FakeQueryStore.php
+++ b/tests/phpunit/Utils/Mock/FakeQueryStore.php
@@ -4,7 +4,9 @@ namespace SMW\Tests\Utils\Mock;
 
 use SMWQuery;
 use SMWQueryResult;
-use SMWSQLStore3;
+use SMW\QueryEngine;
+use SMW\StoreAware;
+use SMW\Store;
 
 /**
  * FIXME One would wish to have a FakeStore but instead SMWSQLStore3 is used in
@@ -21,15 +23,20 @@ use SMWSQLStore3;
  *
  * @author mwjames
  */
-class FakeQueryStore extends SMWSQLStore3 {
+class FakeQueryStore implements QueryEngine, StoreAware {
 
-	protected $queryResult;
+	protected $store;
 
 	public function setQueryResult( SMWQueryResult $queryResult ) {
 		$this->queryResult = $queryResult;
 	}
+
+	public function setStore( Store $store ) {
+		$this->store = $store;
+	}
+
 	// @codingStandardsIgnoreStart phpcs, ignore --sniffs=Generic.CodeAnalysis.UnusedFunctionParameter
 	public function getQueryResult( SMWQuery $query ) { // @codingStandardsIgnoreEnd
-		return $this->queryResult;
+		return $this->store->getQueryResult( $query );
 	}
 }


### PR DESCRIPTION
This PR is made in reference to: # N/A

This PR addresses or contains:

- Adds `QueryEngine` and `StoreAware` interface to allow external services to implement those interfaces instead of forcing an inheritance from `SQLStore`  or similar concrete implementations
- `QuerySourceInstantiator` is consolidating code responsible for handling query sources

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed

