### PR TITLE
Adds `--with-maintenance-log` option to "rebuildFulltextSearchTable.php"

### DIFF
--- a/docs/RELEASE-NOTES.md
+++ b/docs/RELEASE-NOTES.md
@@ -19,6 +19,7 @@ THIS IS NOT A RELEASE YET
 * #1758 Added the [`$smwgQTemporaryTablesAutoCommitMode`](https://www.semantic-mediawiki.org/wiki/Help:$smwgQTemporaryTablesAutoCommitMode) setting to mitigate possible issues with temporary tables in `MySQL` for when `enforce_gtid_consistency=true` is set
 * #1756 Extended the display characteristics of `Special:Browse` to load content via the API back-end (legacy display can be retained by setting [`$smwgBrowseByApi`](https://www.semantic-mediawiki.org/wiki/Help:$smwgBrowseByApi) to `false`) 
 * #1761 Added content language context to recognize localized property type `[[Has type ...]]` annotations
+* #1764 Added `--with-maintenance-log` option to the "rebuildFulltextSearchTable.php" maintenance script
 * #1768 Improved general error display to be more user context friendly
 * #1779 Added [`Special:ProcessingErrorList`](https://www.semantic-mediawiki.org/wiki/Help:Special:ProcessingErrorList) 
 

--- a/maintenance/rebuildFulltextSearchTable.php
+++ b/maintenance/rebuildFulltextSearchTable.php
@@ -21,6 +21,7 @@ class RebuildFulltextSearchTable extends \Maintenance {
 	public function __construct() {
 		$this->mDescription = 'Rebuild the fulltext search index (only works with SQLStore)';
 		$this->addOption( 'report-runtime', 'Report execution time and memory usage', false );
+		$this->addOption( 'with-maintenance-log', 'Add log entry to `Special:Log` about the maintenance run.', false );
 		$this->addOption( 'v', 'Show additional (verbose) information about the progress', false );
 		$this->addOption( 'quick', 'Suppress abort operation', false );
 
@@ -108,6 +109,11 @@ class RebuildFulltextSearchTable extends \Maintenance {
 			$this->reportMessage(
 				"\n" . $maintenanceHelper->transformRuntimeValuesForOutput() . "\n"
 			);
+		}
+
+		if ( $this->hasOption( 'with-maintenance-log' ) ) {
+			$maintenanceLogger = $maintenanceFactory->newMaintenanceLogger( 'RebuildFulltextSearchTableLogger' );
+			$maintenanceLogger->log( $maintenanceHelper->transformRuntimeValuesForOutput() );
 		}
 
 		$maintenanceHelper->reset();


### PR DESCRIPTION
This PR is made in reference to issue https://github.com/SemanticMediaWiki/SemanticMediaWiki/issues/1764

This PR addresses or contains:
- Adds `--with-maintenance-log` option to "rebuildFulltextSearchTable.php"

This PR includes:
- [ ] Tests (unit/integration)
- [x] CI build passed