### PR TITLE
Predefined properties can show context unrelated help, refs #1381, #1787

### DIFF
--- a/includes/datavalues/SMW_DV_Property.php
+++ b/includes/datavalues/SMW_DV_Property.php
@@ -358,7 +358,7 @@ class SMWPropertyValue extends SMWDataValue {
 
 		$propertySpecificationLookup = ApplicationFactory::getInstance()->getPropertySpecificationLookup();
 
-		if ( ( $content = $propertySpecificationLookup->getPropertyDescriptionFor( $this->m_dataitem, $linker ) ) !== '' ) {
+		if ( ( $content = $propertySpecificationLookup->getPropertyDescriptionFor( $this->m_dataitem, $linker ) ) !== '' || !$this->m_dataitem->isUserDefined() ) {
 
 			$highlighter = Highlighter::factory( Highlighter::TYPE_PROPERTY );
 			$highlighter->setContent( array (


### PR DESCRIPTION
This PR is made in reference to: #1381, #1787

This PR addresses or contains:

- Allowing predefined properties to show context unrelated help

This PR includes:
- [ ] Tests (unit/integration)
- [x] CI build passed