### PR TITLE
Add PropertyRegistry::registerPropertyDescriptionByMsgKey, refs #1789

### DIFF
--- a/includes/articlepages/SMW_PropertyPage.php
+++ b/includes/articlepages/SMW_PropertyPage.php
@@ -5,6 +5,7 @@ use SMW\DataValueFactory;
 use SMW\Localizer;
 use SMW\RequestOptions;
 use SMW\StringCondition;
+use SMW\PropertyRegistry;
 
 /**
  * Implementation of MediaWiki's Article that shows additional information on
@@ -61,13 +62,22 @@ class SMWPropertyPage extends SMWOrderedListPage {
 		$propertyName = htmlspecialchars( $this->mTitle->getText() );
 		$message = '';
 
-		if ( !$this->mProperty->isUserDefined() ) {
-			$propertyKey  = 'smw-pa-property-predefined' . strtolower( $this->mProperty->getKey() );
-			$messageKey   = wfMessage( $propertyKey )->exists() ? $propertyKey : 'smw-pa-property-predefined-default';
-			$message .= wfMessage( $messageKey, $propertyName )->parse();
-			$message .= wfMessage( 'smw-pa-property-predefined-long' . strtolower( $this->mProperty->getKey() ) )->exists() ? ' ' . wfMessage( 'smw-pa-property-predefined-long' . strtolower( $this->mProperty->getKey() ) )->parse() : '';
-			$message .= ' ' . wfMessage( 'smw-pa-property-predefined-common' )->parse();
+		if ( $this->mProperty->isUserDefined() ) {
+			return $message;
 		}
+
+		$key = $this->mProperty->getKey();
+
+		if ( ( $messageKey = PropertyRegistry::getInstance()->findPropertyDescriptionMsgKeyById( $key ) ) !== '' ) {
+			$messageKeyLong = $messageKey . '-long';
+		} else {
+			$messageKey = 'smw-pa-property-predefined' . strtolower( $key );
+			$messageKeyLong = 'smw-pa-property-predefined-long' . strtolower( $key );
+		}
+
+		$message .= wfMessage( $messageKey )->exists() ? wfMessage( $messageKey, $propertyName )->parse() : wfMessage( 'smw-pa-property-predefined-default' )->parse();
+		$message .= wfMessage( $messageKeyLong )->exists() ? ' ' . wfMessage( $messageKeyLong )->parse() : '';
+		$message .= ' ' . wfMessage( 'smw-pa-property-predefined-common' )->parse();
 
 		return Html::rawElement( 'div', array( 'class' => 'smw-property-predefined-intro' ), $message );
 	}

--- a/src/CachedPropertyValuesPrefetcher.php
+++ b/src/CachedPropertyValuesPrefetcher.php
@@ -28,7 +28,7 @@ class CachedPropertyValuesPrefetcher {
 	/**
 	 * @var string
 	 */
-	const VERSION = '0.3';
+	const VERSION = '0.4';
 
 	/**
 	 * @var Store

--- a/src/PropertyRegistry.php
+++ b/src/PropertyRegistry.php
@@ -43,6 +43,11 @@ class PropertyRegistry {
 	private $datatypeLabels = array();
 
 	/**
+	 * @var string[]
+	 */
+	private $propertyDescriptionMsgKeys = array();
+
+	/**
 	 * @var PropertyAliasFinder
 	 */
 	private $propertyAliasFinder;
@@ -179,6 +184,30 @@ class PropertyRegistry {
 	 */
 	public function registerPropertyAliasByMsgKey( $id, $msgKey ) {
 		$this->propertyAliasFinder->registerAliasByMsgKey( $id, $msgKey );
+	}
+
+	/**
+	 * Register a description message key for allowing it to be displayed in a
+	 * localized context.
+	 *
+	 * @since 2.5
+	 *
+	 * @param string $id
+	 * @param string $msgKey
+	 */
+	public function registerPropertyDescriptionMsgKeyById( $id, $msgKey ) {
+		$this->propertyDescriptionMsgKeys[$id] = $msgKey;
+	}
+
+	/**
+	 * @since 2.5
+	 *
+	 * @param string $id
+	 *
+	 * @return string
+	 */
+	public function findPropertyDescriptionMsgKeyById( $id ) {
+		return isset( $this->propertyDescriptionMsgKeys[$id] ) ? $this->propertyDescriptionMsgKeys[$id] : '';
 	}
 
 	/**

--- a/src/PropertySpecificationLookup.php
+++ b/src/PropertySpecificationLookup.php
@@ -319,7 +319,11 @@ class PropertySpecificationLookup {
 	private function getPredefinedPropertyDescription( $property, $linker ) {
 
 		$description = '';
-		$msgKey = 'smw-pa-property-predefined' . strtolower( $property->getKey() );
+		$key = $property->getKey();
+
+		if ( ( $msgKey = PropertyRegistry::getInstance()->findPropertyDescriptionMsgKeyById( $key ) ) === '' ) {
+			$msgKey = 'smw-pa-property-predefined' . strtolower( $key );
+		}
 
 		if ( !wfMessage( $msgKey )->exists() ) {
 			return $description;

--- a/tests/phpunit/Unit/PropertyRegistryTest.php
+++ b/tests/phpunit/Unit/PropertyRegistryTest.php
@@ -424,4 +424,44 @@ class PropertyRegistryTest extends \PHPUnit_Framework_TestCase {
 		);
 	}
 
+	public function testPropertyDescriptionMsgKey() {
+
+		$datatypeRegistry = $this->getMockBuilder( '\SMW\DataTypeRegistry' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$datatypeRegistry->expects( $this->once() )
+			->method( 'getKnownTypeLabels' )
+			->will( $this->returnValue( array() ) );
+
+		$datatypeRegistry->expects( $this->once() )
+			->method( 'getKnownTypeAliases' )
+			->will( $this->returnValue( array() ) );
+
+		$store = $this->getMockBuilder( '\SMW\Store' )
+			->disableOriginalConstructor()
+			->getMockForAbstractClass();
+
+		$propertyLabelFinder = new PropertyLabelFinder( $store, array() );
+
+		$propertyAliases = new PropertyAliasFinder();
+
+		$instance = new PropertyRegistry(
+			$datatypeRegistry,
+			$propertyLabelFinder,
+			$propertyAliases
+		);
+
+		$instance->registerPropertyDescriptionMsgKeyById( '_foo', 'bar' );
+
+		$this->assertEquals(
+			'bar',
+			$instance->findPropertyDescriptionMsgKeyById( '_foo' )
+		);
+
+		$this->assertEmpty(
+			$instance->findPropertyDescriptionMsgKeyById( 'unknown' )
+		);
+	}
+
 }


### PR DESCRIPTION
This PR is made in reference to: #1789

This PR addresses or contains:

- Allows to register description msg keys without the need of the `smw-pa-property-predefined` prefix in extensions.

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed

