### PR TITLE
Add TextByChangeUpdater::isCommandLineMode

### DIFF
--- a/src/MediaWiki/Hooks/HookRegistry.php
+++ b/src/MediaWiki/Hooks/HookRegistry.php
@@ -497,7 +497,7 @@ class HookRegistry {
 		/**
 		 * @see https://www.semantic-mediawiki.org/wiki/Hooks#SMW::SQLStore::AfterDataUpdateComplete
 		 */
-		$this->handlers['SMW::SQLStore::AfterDataUpdateComplete'] = function ( $store, $semanticData, $compositePropertyTableDiffIterator ) use ( $applicationFactory, $queryDependencyLinksStoreFactory, $deferredRequestDispatchManager ) {
+		$this->handlers['SMW::SQLStore::AfterDataUpdateComplete'] = function ( $store, $semanticData, $compositePropertyTableDiffIterator ) use ( $queryDependencyLinksStoreFactory, $deferredRequestDispatchManager ) {
 
 			$queryDependencyLinksStore = $queryDependencyLinksStoreFactory->newQueryDependencyLinksStore(
 				$store

--- a/src/SQLStore/QueryEngine/FulltextSearchTableFactory.php
+++ b/src/SQLStore/QueryEngine/FulltextSearchTableFactory.php
@@ -132,6 +132,11 @@ class FulltextSearchTableFactory {
 			$settings->get( 'smwgFulltextDeferredUpdate' )
 		);
 
+		// https://www.mediawiki.org/wiki/Manual:$wgCommandLineMode
+		$textByChangeUpdater->isCommandLineMode(
+			$GLOBALS['wgCommandLineMode']
+		);
+
 		return $textByChangeUpdater;
 	}
 

--- a/tests/phpunit/Unit/SQLStore/QueryEngine/Fulltext/TextByChangeUpdaterTest.php
+++ b/tests/phpunit/Unit/SQLStore/QueryEngine/Fulltext/TextByChangeUpdaterTest.php
@@ -43,7 +43,7 @@ class TextByChangeUpdaterTest extends \PHPUnit_Framework_TestCase {
 
 	public function testPushUpdatesOnDisabledDeferredUpdateAndNullChange() {
 
-		$this->searchTableUpdater->expects( $this->once() )
+		$this->searchTableUpdater->expects( $this->atLeastOnce() )
 			->method( 'isEnabled' )
 			->will( $this->returnValue( true ) );
 
@@ -77,6 +77,10 @@ class TextByChangeUpdaterTest extends \PHPUnit_Framework_TestCase {
 
 	public function testPushUpdatesAsDeferredUpdate() {
 
+		$this->searchTableUpdater->expects( $this->atLeastOnce() )
+			->method( 'isEnabled' )
+			->will( $this->returnValue( true ) );
+
 		$compositePropertyTableDiffIterator = $this->getMockBuilder( '\SMW\SQLStore\CompositePropertyTableDiffIterator' )
 			->disableOriginalConstructor()
 			->getMock();
@@ -99,6 +103,41 @@ class TextByChangeUpdaterTest extends \PHPUnit_Framework_TestCase {
 		$subject = $this->dataItemFactory->newDIWikiPage( 'Foo', NS_MAIN );
 
 		$instance->asDeferredUpdate( true );
+
+		$instance->pushUpdates(
+			$subject,
+			$compositePropertyTableDiffIterator,
+			$deferredRequestDispatchManager
+		);
+	}
+
+	public function testPushUpdatesDirectlyWhenExecutedFromCommandLine() {
+
+		$this->searchTableUpdater->expects( $this->atLeastOnce() )
+			->method( 'isEnabled' )
+			->will( $this->returnValue( true ) );
+
+		$compositePropertyTableDiffIterator = $this->getMockBuilder( '\SMW\SQLStore\CompositePropertyTableDiffIterator' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$compositePropertyTableDiffIterator->expects( $this->once() )
+			->method( 'getTableChangeOps' )
+			->will( $this->returnValue( array() ) );
+
+		$deferredRequestDispatchManager = $this->getMockBuilder( '\SMW\DeferredRequestDispatchManager' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$instance = new TextByChangeUpdater(
+			$this->searchTableUpdater,
+			$this->connection
+		);
+
+		$subject = $this->dataItemFactory->newDIWikiPage( 'Foo', NS_MAIN );
+
+		$instance->asDeferredUpdate( true );
+		$instance->isCommandLineMode( true );
 
 		$instance->pushUpdates(
 			$subject,


### PR DESCRIPTION
This PR is made in reference to: #1481

This PR addresses or contains:

- If `isCommandLineMode` is enabled then push updates directly without being deferred.

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed

