### PR TITLE
TimeValue to support #LOCL@... as output format, refs #1545

### DIFF
--- a/src/DataValues/ValueFormatters/TimeValueFormatter.php
+++ b/src/DataValues/ValueFormatters/TimeValueFormatter.php
@@ -282,23 +282,29 @@ class TimeValueFormatter extends DataValueFormatter {
 	 */
 	public function getLocalizedFormat( DITime $dataItem = null ) {
 
-		$language = Localizer::getInstance()->getLanguage(
-			$this->dataValue->getOptionValueFor( 'user.language' )
-		);
-
-		if ( $dataItem !== null && $dataItem->getYear() > DITime::PREHISTORY ) {
-
-			$intlTimeFormatter = new IntlTimeFormatter(
-				$dataItem,
-				$language
-			);
-
-			return $intlTimeFormatter->getLocalizedFormat() . $this->hintCalendarModel( $dataItem );
+		if ( $dataItem === null ) {
+			return '';
 		}
 
-		return $this->getISO8601Date();
-	}
+		if ( $dataItem->getYear() < DITime::PREHISTORY ) {
+			return $this->getISO8601Date();
+		}
 
+		$outputFormat = $this->dataValue->getOutputFormat();
+
+		if ( ( $language = Localizer::getInstance()->getAnnotatedLanguageCodeFrom( $outputFormat ) ) === false ) {
+			$language = $this->dataValue->getOptionValueFor( DataValue::OPT_USER_LANGUAGE );
+		}
+
+		$language = Localizer::getInstance()->getLanguage( $language );
+
+		$intlTimeFormatter = new IntlTimeFormatter(
+			$dataItem,
+			$language
+		);
+
+		return $intlTimeFormatter->getLocalizedFormat() . $this->hintCalendarModel( $dataItem );
+	}
 
 	/**
 	 * Compute a suitable string to display this date, taking into account the
@@ -337,7 +343,7 @@ class TimeValueFormatter extends DataValueFormatter {
 
 		if ( strpos( $format, '-F[' ) !== false ) {
 			return $this->getCaptionFromFreeFormat( $this->dataValue->getDataItemForCalendarModel( $model ) );
-		} elseif ( $format == 'LOCL' ) {
+		} elseif ( strpos( $format, 'LOCL' ) !== false ) {
 			return $this->getLocalizedFormat( $this->dataValue->getDataItemForCalendarModel( $model ) );
 		} elseif ( $dataItem->getYear() > TimeValue::PREHISTORY && $dataItem->getPrecision() >= DITime::PREC_YM ) {
 			// Do not convert between Gregorian and Julian if only

--- a/tests/phpunit/Integration/ByJsonScript/Fixtures/p-0423.json
+++ b/tests/phpunit/Integration/ByJsonScript/Fixtures/p-0423.json
@@ -1,5 +1,5 @@
 {
-	"description": "Test in-text annotation / `#ask` (#MEDIAWIKI, #LOCL) output for `_dat` datatype (`wgContLang` = en, `wgLang` = ja)",
+	"description": "Test in-text annotation / `#ask` (#MEDIAWIKI, #LOCL) output for `_dat` datatype (#1545, `wgContLang=en`, `wgLang=ja`)",
 	"properties": [
 		{
 			"name": "Has date",
@@ -31,6 +31,10 @@
 		{
 			"name": "Example/P0423/Q1.4",
 			"contents": "{{#show: Example/P0423/1 |?Has date#LOCL }}"
+		},
+		{
+			"name": "Example/P0423/Q1.5",
+			"contents": "{{#show: Example/P0423/1 |?Has date#LOCL@fr }}"
 		},
 		{
 			"name": "Example/P0423/Q2.1",
@@ -86,7 +90,7 @@
 			}
 		},
 		{
-			"about": "#4 (#show LOCL)",
+			"about": "#4 (#show LOCL for user lang)",
 			"subject": "Example/P0423/Q1.4",
 			"expected-output": {
 				"to-contain": [
@@ -95,7 +99,16 @@
 			}
 		},
 		{
-			"about": "#5 page vs global content language",
+			"about": "#5 (#show LOCL@fr for annotated fr lang and not for user lang)",
+			"subject": "Example/P0423/Q1.5",
+			"expected-output": {
+				"to-contain": [
+					"<p>12:05:00, 12 janvier 1957"
+				]
+			}
+		},
+		{
+			"about": "#6 page vs global content language",
 			"subject": "Example/P0423/Q2.1",
 			"expected-output": {
 				"to-contain": [

--- a/tests/phpunit/Unit/DataValues/ValueFormatters/TimeValueFormatterTest.php
+++ b/tests/phpunit/Unit/DataValues/ValueFormatters/TimeValueFormatterTest.php
@@ -227,7 +227,7 @@ class TimeValueFormatterTest extends \PHPUnit_Framework_TestCase {
 		$timeValue = new TimeValue( '_dat' );
 		$timeValue->setUserValue( '2015-02-28' );
 
-		$timeValue->setOption( 'user.language', 'en' );
+		$timeValue->setOption( TimeValue::OPT_USER_LANGUAGE, 'en' );
 		$timeValue->setOutputFormat( 'LOCL' );
 
 		$instance = new TimeValueFormatter( $timeValue );
@@ -239,6 +239,22 @@ class TimeValueFormatterTest extends \PHPUnit_Framework_TestCase {
 
 		$this->assertEquals(
 			$instance->format( TimeValueFormatter::HTML_LONG ),
+			$instance->getLocalizedFormat( $timeValue->getDataItem() )
+		);
+	}
+
+	public function testLOCLOutputFormatWithSpecificAnnotatedLanguage() {
+
+		$timeValue = new TimeValue( '_dat' );
+		$timeValue->setUserValue( '2015-02-28' );
+
+		$timeValue->setOption( TimeValue::OPT_USER_LANGUAGE, 'en' );
+		$timeValue->setOutputFormat( 'LOCL@ja' );
+
+		$instance = new TimeValueFormatter( $timeValue );
+
+		$this->assertEquals(
+			'2015年2月28日 (土)',
 			$instance->getLocalizedFormat( $timeValue->getDataItem() )
 		);
 	}


### PR DESCRIPTION
This PR is made in reference to: #1545

This PR addresses or contains:

- Support language specific output allowing something like `#LOCL@es` to output a localized date for the annotated language instead of the user language.

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed
