### PR TITLE
Localizer::getAnnotatedLanguageCodeFrom to check for ctype_alpha

### DIFF
--- a/src/Localizer.php
+++ b/src/Localizer.php
@@ -236,8 +236,11 @@ class Localizer {
 		}
 
 		// Do we want to check here whether isSupportedLanguage or not?
+		if ( $langCode !== '' && ctype_alpha( str_replace( array( '-' ), '', $langCode ) ) ) {
+			return $langCode;
+		}
 
-		return $langCode !== '' ? $langCode : false;
+		return false;
 	}
 
 	/**

--- a/tests/phpunit/Unit/LocalizerTest.php
+++ b/tests/phpunit/Unit/LocalizerTest.php
@@ -120,7 +120,7 @@ class LocalizerTest extends \PHPUnit_Framework_TestCase {
 		);
 	}
 
-	public function testCanGetAnnotatedLanguageCodeOnDoubledMarker() {
+	public function testCanGetAnnotatedLanguageCodeOnDoubledMarkedValue() {
 
 		$value = 'Foo@@en';
 
@@ -132,6 +132,30 @@ class LocalizerTest extends \PHPUnit_Framework_TestCase {
 		$this->assertEquals(
 			'Foo@',
 			$value
+		);
+	}
+
+	public function testCanGetAnnotatedLanguageCodeOnValueWithDash() {
+
+		$value = 'Foo@zh-Hans';
+
+		$this->assertEquals(
+			'zh-Hans',
+			Localizer::getAnnotatedLanguageCodeFrom( $value )
+		);
+
+		$this->assertEquals(
+			'Foo',
+			$value
+		);
+	}
+
+	public function testCanNotGetAnnotatedLanguageCodeThatContainsInvalidCharacter() {
+
+		$value = 'Foo@en#bar';
+
+		$this->assertFalse(
+			Localizer::getAnnotatedLanguageCodeFrom( $value )
 		);
 	}
 


### PR DESCRIPTION
This PR is made in reference to: # N/A

This PR addresses or contains:

- Catch invalid language annotations early by checking against `ctype_alpha`

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed

