### PR TITLE
Fix "Call to undefined method SMW\DIWikiPage::getKey() in SMW_QueryProcessor.php"

### DIFF
--- a/includes/storage/SMW_Store.php
+++ b/includes/storage/SMW_Store.php
@@ -174,8 +174,9 @@ abstract class Store {
 		$hash = $wikipage->getHash();
 		$poolCache = InMemoryPoolCache::getInstance()->getPoolCacheFor( 'store.redirectTarget.lookup' );
 
-		if ( $poolCache->contains( $hash ) ) {
-			return $poolCache->fetch( $hash );
+		// Ensure that the same type context is used
+		if ( ( $di = $poolCache->fetch( $hash ) ) !== false && $di->getDIType() === $dataItem->getDIType() ) {
+			return $di;
 		}
 
 		$redirectDataItems = $this->getPropertyValues( $wikipage, new DIProperty( '_REDI' ) );


### PR DESCRIPTION
This PR is made in reference to: # N/A

This PR addresses or contains:

- When generating a hash for the cache ensure to distinguish the context as to which object requested a redirect and avoid a target with a different context being returned from cache (caused the `getKey` on a `DIWikiPage` object while `DIProperty` was expected).

This PR includes:
- [ ] Tests (unit/integration)
- [x] CI build passed

