### PR TITLE
Allow Special:Import to have early access to property specifications

### DIFF
--- a/src/MediaWiki/Hooks/LinksUpdateConstructed.php
+++ b/src/MediaWiki/Hooks/LinksUpdateConstructed.php
@@ -71,6 +71,11 @@ class LinksUpdateConstructed {
 			$this->updateEmptySemanticData( $parserData, $title );
 		}
 
+		// Push updates on properties directly without delay
+		if ( $title->getNamespace() === SMW_NS_PROPERTY ) {
+			$this->enabledDeferredUpdate = false;
+		}
+
 		$parserData->updateStore(
 			$this->enabledDeferredUpdate
 		);


### PR DESCRIPTION
This PR is made in reference to: # N/A

This PR addresses or contains:

- Allow `Special:Import` to have early access to property specifications

This PR includes:
- [ ] Tests (unit/integration)
- [x] CI build passed

