### PR TITLE
Add DeferredCallableUpdate::getOrigin

### DIFF
--- a/includes/storage/SQLStore/SMW_SQLStore3.php
+++ b/includes/storage/SQLStore/SMW_SQLStore3.php
@@ -375,7 +375,9 @@ class SMWSQLStore3 extends SMWStore {
 			return null;
 		}
 
-		$this->factory->newDeferredCallableCachedListLookupUpdate()->pushToDeferredUpdateList();
+		$deferredCallableUpdate = $this->factory->newDeferredCallableCachedListLookupUpdate();
+		$deferredCallableUpdate->setOrigin( __METHOD__ );
+		$deferredCallableUpdate->pushUpdate();
 	}
 
 ///// Query answering /////

--- a/includes/storage/SQLStore/SMW_SQLStore3_Writers.php
+++ b/includes/storage/SQLStore/SMW_SQLStore3_Writers.php
@@ -993,24 +993,20 @@ class SMWSQLStore3Writers {
 		if ( $redirectId != 0 ) {
 			$title = $oldTitle;
 			$deferredCallableUpdate = ApplicationFactory::getInstance()->newDeferredCallableUpdate( function() use( $title, $jobFactory ) {
-
-				wfDebugLog( 'smw', 'DeferredCallableUpdate on changeTitle for ' . $title->getPrefixedDBKey() );
-
 				$jobFactory->newUpdateJob( $title )->run();
 			} );
 
-			$deferredCallableUpdate->pushToDeferredUpdateList();
+			$deferredCallableUpdate->setOrigin( __METHOD__ . ' for ' . $title->getPrefixedDBKey() );
+			$deferredCallableUpdate->pushUpdate();
 		}
 
 		$title = $newTitle;
 		$deferredCallableUpdate = ApplicationFactory::getInstance()->newDeferredCallableUpdate( function() use( $title, $jobFactory ) {
-
-			wfDebugLog( 'smw', 'DeferredCallableUpdate on changeTitle for ' . $title->getPrefixedDBKey() );
-
 			$jobFactory->newUpdateJob( $title )->run();
 		} );
 
-		$deferredCallableUpdate->pushToDeferredUpdateList();
+		$deferredCallableUpdate->setOrigin( __METHOD__ . ' for ' . $title->getPrefixedDBKey() );
+		$deferredCallableUpdate->pushUpdate();
 	}
 
 }

--- a/src/DeferredCallableUpdate.php
+++ b/src/DeferredCallableUpdate.php
@@ -31,6 +31,11 @@ class DeferredCallableUpdate implements DeferrableUpdate {
 	private $isPending = false;
 
 	/**
+	 * @var string
+	 */
+	private $origin = '';
+
+	/**
 	 * @var array
 	 */
 	private static $pendingUpdates = array();
@@ -74,6 +79,26 @@ class DeferredCallableUpdate implements DeferrableUpdate {
 	}
 
 	/**
+	 * @since 2.5
+	 *
+	 * @param string $origin
+	 */
+	public function setOrigin( $origin ) {
+		$this->origin = $origin;
+	}
+
+	/**
+	 * @see DeferrableCallback::getOrigin
+	 *
+	 * @since 2.5
+	 *
+	 * @return string
+	 */
+	public function getOrigin() {
+		return $this->origin;
+	}
+
+	/**
 	 * @since 2.4
 	 */
 	public static function releasePendingUpdates() {
@@ -90,19 +115,30 @@ class DeferredCallableUpdate implements DeferrableUpdate {
 	 * @since 2.4
 	 */
 	public function doUpdate() {
+		wfDebugLog( 'smw', $this->origin . ' doUpdate' );
 		call_user_func( $this->callback );
 	}
 
 	/**
 	 * @since 2.4
+	 * @deprecated since 2.5, use DeferredCallableUpdate::pushUpdate
 	 */
 	public function pushToDeferredUpdateList() {
+		$this->pushUpdate();
+	}
+
+	/**
+	 * @since 2.5
+	 */
+	public function pushUpdate() {
 
 		if ( $this->isPending && $this->enabledDeferredUpdate ) {
+			wfDebugLog( 'smw', $this->origin . ' (as pending DeferredCallableUpdate)' );
 			return self::$pendingUpdates[] = $this;
 		}
 
 		if ( $this->enabledDeferredUpdate ) {
+			wfDebugLog( 'smw', $this->origin . ' (as DeferredCallableUpdate)' );
 			return DeferredUpdates::addUpdate( $this );
 		}
 

--- a/src/EventListenerRegistry.php
+++ b/src/EventListenerRegistry.php
@@ -151,7 +151,8 @@ class EventListenerRegistry implements EventListenerCollection {
 						$pageUpdater->doPurgeHtmlCache();
 					} );
 
-					$deferredCallableUpdate->pushToDeferredUpdateList();
+					$deferredCallableUpdate->setOrigin( 'Event on.after.semanticdata.update.complete doPurgeParserCache for ' . $subject->getHash() );
+					$deferredCallableUpdate->pushUpdate();
 				}
 
 				$dispatchContext->set( 'propagationstop', true );

--- a/src/MediaWiki/Hooks/ArticleDelete.php
+++ b/src/MediaWiki/Hooks/ArticleDelete.php
@@ -84,7 +84,8 @@ class ArticleDelete {
 			);
 		} );
 
-		$deferredCallableUpdate->pushToDeferredUpdateList();
+		$deferredCallableUpdate->setOrigin( __METHOD__ );
+		$deferredCallableUpdate->pushUpdate();
 
 		return true;
 	}

--- a/tests/phpunit/Unit/DeferredCallableUpdateTest.php
+++ b/tests/phpunit/Unit/DeferredCallableUpdateTest.php
@@ -111,7 +111,23 @@ class DeferredCallableUpdateTest extends \PHPUnit_Framework_TestCase {
 		);
 
 		$instance->enabledDeferredUpdate( false );
-		$instance->pushToDeferredUpdateList();
+		$instance->pushUpdate();
+	}
+
+	public function testOrigin() {
+
+		$callback = function() {};
+
+		$instance = new DeferredCallableUpdate(
+			$callback
+		);
+
+		$instance->setOrigin( 'Foo' );
+
+		$this->assertEquals(
+			'Foo',
+			$instance->getOrigin()
+		);
 	}
 
 }


### PR DESCRIPTION
This PR is made in reference to: # N/A

This PR addresses or contains:

- Extends the interface to allow for a better logging as to when updates are carried out and follows the MW 1.28 introduced `DeferrableCallback::getOrigin`

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed

