### PR TITLE
#set_recurring_event to avoid 00:00:00 time display

### DIFF
--- a/includes/RecurringEvents.php
+++ b/includes/RecurringEvents.php
@@ -341,7 +341,7 @@ class RecurringEvents {
 		$all_date_strings = array_filter( array_merge( $all_date_strings, $included_dates ) );
 
 		// Set dates
-		$this->dates = $all_date_strings;
+		$this->dates = str_replace( ' 00:00:00', '', $all_date_strings );
 	}
 
 	/**

--- a/includes/datavalues/SMW_DV_Time.php
+++ b/includes/datavalues/SMW_DV_Time.php
@@ -166,10 +166,11 @@ class SMWTimeValue extends SMWDataValue {
 						}
 						$this->m_dataitem = SMWDITime::newFromJD( $jd, SMWDITime::CM_GREGORIAN, SMWDITime::PREC_YMDT );
 					} catch ( SMWDataItemException $e ) {
-						$this->addError( wfMessage( 'smw_nodatetime', $this->m_wikivalue )->inContentLanguage()->text() );
+						$this->addErrorMsg( array( 'smw_nodatetime', $this->m_wikivalue ) );
 					}
 				} else {
-					$this->addError( wfMessage( 'smw_nodatetime', $this->m_wikivalue )->inContentLanguage()->text() );
+					var_dump( $this->m_wikivalue );
+					$this->addErrorMsg( array( 'smw_nodatetime', $this->m_wikivalue ) );
 				}
 			} else {
 				$this->setDateFromParsedValues( $datecomponents, $calendarmodel, $era, $hours, $minutes, $seconds, $microseconds, $timeoffset, $timezone );
@@ -476,7 +477,7 @@ class SMWTimeValue extends SMWDataValue {
 			}
 		}
 		if ( $date['y'] === false ) { // no band matches the entered date
-			$this->addError( wfMessage( 'smw_nodatetime', $this->m_wikivalue )->inContentLanguage()->text() );
+			$this->addErrorMsg( array( 'smw_nodatetime', $this->m_wikivalue ) );
 			return false;
 		}
 		return true;
@@ -522,7 +523,7 @@ class SMWTimeValue extends SMWDataValue {
 		try {
 			$this->m_dataitem = new SMWDITime( $calmod, $date['y'], $date['m'], $date['d'], $hours, $minutes, $seconds . '.' . $microseconds );
 		} catch ( SMWDataItemException $e ) {
-			$this->addError( wfMessage( 'smw_nodatetime', $this->m_wikivalue )->inContentLanguage()->text() );
+			$this->addErrorMsg( array( 'smw_nodatetime', $this->m_wikivalue ) );
 			return false;
 		}
 
@@ -531,7 +532,7 @@ class SMWTimeValue extends SMWDataValue {
 		// conversion would not be reliable if JD numbers get too huge:
 		if ( ( $date['y'] <= self::PREHISTORY ) &&
 		     ( ( $this->m_dataitem->getPrecision() > SMWDITime::PREC_Y ) || ( $calendarmodel !== false ) ) ) {
-			$this->addError( wfMessage( 'smw_nodatetime', $this->m_wikivalue )->inContentLanguage()->text() );
+			$this->addErrorMsg( array( 'smw_nodatetime', $this->m_wikivalue ) );
 			return false;
 		}
 		if ( $timeoffset != 0 ) {
@@ -539,7 +540,7 @@ class SMWTimeValue extends SMWDataValue {
 			try {
 				$this->m_dataitem = SMWDITime::newFromJD( $newjd, $calmod, $this->m_dataitem->getPrecision() );
 			} catch ( SMWDataItemException $e ) {
-				$this->addError( wfMessage( 'smw_nodatetime', $this->m_wikivalue )->inContentLanguage()->text() );
+				$this->addErrorMsg( array( 'smw_nodatetime', $this->m_wikivalue ) );
 				return false;
 			}
 		}

--- a/tests/phpunit/Integration/ByJsonScript/Fixtures/p-0210.json
+++ b/tests/phpunit/Integration/ByJsonScript/Fixtures/p-0210.json
@@ -1,0 +1,43 @@
+{
+	"description": "Test `#set_recurring_event` (`wgContLang=en`, `wgLang=en`)",
+	"properties": [
+		{
+			"name": "Has date",
+			"contents": "[[Has type::Date]]"
+		}
+	],
+	"subjects": [
+		{
+			"name": "Example/P0210/1",
+			"contents": "{{#set_recurring_event:property=Has date |start=01 Feb 1970 |Has title=Recurring event |unit=year |period=12 |limit=3 }}"
+		},
+		{
+			"name": "Example/P0210/Q1",
+			"contents": "{{#ask: [[Has title::Recurring event]] |?Has date |format=table |link=none }}"
+		}
+	],
+	"parser-testcases": [
+		{
+			"about": "#0",
+			"subject": "Example/P0210/Q1",
+			"expected-output": {
+				"to-contain": [
+					"<td class=\"smwtype_wpg\">Example/P0210/1#_de6907a285b0c316fd3caa77a932d0ae</td><td data-sort-value=\"2453767.5\" class=\"Has-date smwtype_dat\">1 February 2006</td>",
+					"<td class=\"smwtype_wpg\">Example/P0210/1#_5c90cef15e8ecbb3662fe10e6cb50bb7</td><td data-sort-value=\"2440618.5\" class=\"Has-date smwtype_dat\">1 February 1970</td>",
+					"<td class=\"smwtype_wpg\">Example/P0210/1#_7582eb6443d1bd2f35114842dc700673</td><td data-sort-value=\"2445001.5\" class=\"Has-date smwtype_dat\">1 February 1982</td>",
+					"<td class=\"smwtype_wpg\">Example/P0210/1#_d9e81e6ceed8bc0ec8a92feeea25ca1a</td><td data-sort-value=\"2449384.5\" class=\"Has-date smwtype_dat\">1 February 1994</td>"
+				]
+			}
+		}
+	],
+	"settings": {
+		"wgContLang": "en",
+		"wgLang": "en",
+		"smwgPageSpecialProperties": [ "_MDAT" ]
+	},
+	"meta": {
+		"version": "0.1",
+		"is-incomplete": false,
+		"debug": false
+	}
+}

--- a/tests/phpunit/Unit/IntlTimeFormatterTest.php
+++ b/tests/phpunit/Unit/IntlTimeFormatterTest.php
@@ -206,6 +206,27 @@ class IntlTimeFormatterTest extends \PHPUnit_Framework_TestCase {
 			'2016年5月8日 (日) 01:01:20'
 		);
 
+		#5
+		$provider['midnight-ja'] = array(
+			'1/2016/05/08/00/00/00/00',
+			'ja',
+			'2016年5月8日 (日) 00:00:00'
+		);
+
+		#6
+		$provider['midnight-en'] = array(
+			'1/2016/05/08/0/0/0/0',
+			'en',
+			'00:00:00, 8 May 2016'
+		);
+
+		#6
+		$provider['after-midnight'] = array(
+			'1/2016/05/08/0/0/01/0',
+			'en',
+			'00:00:01, 8 May 2016'
+		);
+
 		return $provider;
 	}
 }

--- a/tests/phpunit/includes/RecurringEventsTest.php
+++ b/tests/phpunit/includes/RecurringEventsTest.php
@@ -164,7 +164,7 @@ class RecurringEventsTest extends SemanticMediaWikiTestCase {
 				),
 				array(
 					'errors' => 0,
-					'dates' => array( '1 February 1970', '1 February 1971 00:00:00', '1 February 1972 00:00:00', '1 February 1973 00:00:00' ),
+					'dates' => array( '1 February 1970', '1 February 1971', '1 February 1972', '1 February 1973' ),
 					'property' => 'Has birthday',
 					'parameters' => array( 'has title' => array( 'Birthday' ) )
 				)
@@ -190,7 +190,7 @@ class RecurringEventsTest extends SemanticMediaWikiTestCase {
 				),
 				array(
 					'errors' => 0,
-					'dates' => array( '1 February 1970', '1 February 1971 00:00:00', '1 February 1972 00:00:00' ),
+					'dates' => array( '1 February 1970', '1 February 1971', '1 February 1972' ),
 					'property' => 'Has birthday',
 					'parameters' => array( 'has title' => array( 'Birthday' ) )
 				)
@@ -218,7 +218,7 @@ class RecurringEventsTest extends SemanticMediaWikiTestCase {
 				),
 				array(
 					'errors' => 0,
-					'dates' => array( '1 February 1970', '14 February 1971 00:00:00' ),
+					'dates' => array( '1 February 1970', '14 February 1971' ),
 					'property' => 'Has birthday',
 					'parameters' => array( 'has title' => array( 'Birthday' ) )
 				)
@@ -268,7 +268,7 @@ class RecurringEventsTest extends SemanticMediaWikiTestCase {
 				),
 				array(
 					'errors' => 0,
-					'dates' => array( '4 January 2010', '11 January 2010 00:00:00', '1 February 2010 00:00:00', 'March 16, 2010', 'March 23, 2010' ),
+					'dates' => array( '4 January 2010', '11 January 2010', '1 February 2010', 'March 16, 2010', 'March 23, 2010' ),
 					'property' => 'Has date',
 					'parameters' => array()
 				)
@@ -296,7 +296,7 @@ class RecurringEventsTest extends SemanticMediaWikiTestCase {
 				),
 				array(
 					'errors' => 0,
-					'dates' => array( '4 January 2010', '11 January 2010 00:00:00', '1 February 2010 00:00:00', 'March 16, 2010', 'March 23, 2010' ),
+					'dates' => array( '4 January 2010', '11 January 2010', '1 February 2010', 'March 16, 2010', 'March 23, 2010' ),
 					'property' => 'Has date',
 					'parameters' => array()
 				)

--- a/tests/phpunit/includes/parserhooks/RecurringEventsParserFunctionTest.php
+++ b/tests/phpunit/includes/parserhooks/RecurringEventsParserFunctionTest.php
@@ -102,9 +102,9 @@ class RecurringEventsParserFunctionTest extends \PHPUnit_Framework_TestCase {
 				'errors' => false,
 				'dates' => array(
 					'1 February 1970',
-					'1 February 1971 00:00:00',
-					'1 February 1972 00:00:00',
-					'1 February 1973 00:00:00'
+					'1 February 1971',
+					'1 February 1972',
+					'1 February 1973'
 				),
 				'property' => array(
 					'Has birthday',
@@ -174,8 +174,8 @@ class RecurringEventsParserFunctionTest extends \PHPUnit_Framework_TestCase {
 				'errors' => false,
 				'dates' => array(
 					'4 January 2010',
-					'11 January 2010 00:00:00',
-					'1 February 2010 00:00:00',
+					'11 January 2010',
+					'1 February 2010',
 					'March 16, 2010',
 					'March 23, 2010'
 				),
@@ -209,8 +209,8 @@ class RecurringEventsParserFunctionTest extends \PHPUnit_Framework_TestCase {
 				'errors' => false,
 				'dates' => array(
 					'4 January 2010',
-					'11 January 2010 00:00:00',
-					'1 February 2010 00:00:00',
+					'11 January 2010',
+					'1 February 2010',
 					'March 16, 2010',
 					'March 23, 2010'
 				),
@@ -245,8 +245,8 @@ class RecurringEventsParserFunctionTest extends \PHPUnit_Framework_TestCase {
 				'errors' => false,
 				'dates' => array(
 					'4 January 2010',
-					'11 January 2010 00:00:00',
-					'1 February 2010 00:00:00',
+					'11 January 2010',
+					'1 February 2010',
 					'March 16, 2010',
 					'March 23, 2010'
 				),


### PR DESCRIPTION
This PR is made in reference to: # N/A

This PR addresses or contains:

- `#set_recurring_event` to avoid displaying 00:00:00 as time

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed

