### PR TITLE
Update SMW_LanguageDe.php

### DIFF
--- a/languages/SMW_LanguageDe.php
+++ b/languages/SMW_LanguageDe.php
@@ -141,7 +141,7 @@ class SMWLanguageDe extends SMWLanguage {
 		'SMW_PREC_Y' => 'Y',
 		'SMW_PREC_YM' => 'F Y',
 		'SMW_PREC_YMD' => 'j. F Y',
-		'SMW_PREC_YMDT' => 'j. F Y, H:i Uhr'
+		'SMW_PREC_YMDT' => 'j. F Y, H:i:s Uhr'
 	);
 
 }


### PR DESCRIPTION
This PR is made in reference to: #1783 

This PR addresses or contains:
Amend German default date time precision for #LOCL (YMDT) by also adding "s"

This PR includes:
- [ ] Tests (unit/integration) - Already available
- [ ] CI build passed