### PR TITLE
Update SMW_LanguageDe.php

### DIFF
--- a/languages/SMW_LanguageDe.php
+++ b/languages/SMW_LanguageDe.php
@@ -136,12 +136,12 @@ class SMWLanguageDe extends SMWLanguage {
 	protected $m_months = array( 'Januar', 'Februar', 'März', 'April', 'Mai', 'Juni', 'Juli', 'August', 'September', 'Oktober', 'November', 'Dezember' );
 
 	protected $m_monthsshort = array( 'Jan', 'Feb', 'Mär', 'Apr', 'Mai', 'Jun', 'Jul', 'Aug', 'Sep', 'Okt', 'Nov', 'Dez' );
-	
+
 	protected $preferredDateFormatsByPrecision = array(
 		'SMW_PREC_Y' => 'Y',
 		'SMW_PREC_YM' => 'F Y',
 		'SMW_PREC_YMD' => 'j. F Y',
-		'SMW_PREC_YMDT' => 'j. F Y, H:i Uhr'
+		'SMW_PREC_YMDT' => 'j. F Y, H:i:s'
 	);
 
 }


### PR DESCRIPTION
This PR is made in reference to: #1783 

This PR addresses or contains:
Amend German default date time precision for #LOCL (YMDT) by also adding "s"

This PR includes:
- [ ] Tests (unit/integration) - Already available
- [x] CI build passed