### PR TITLE
MonolingualTextValue to transfer errors, refs #1344, #1774

### DIFF
--- a/i18n/en.json
+++ b/i18n/en.json
@@ -99,7 +99,7 @@
 	"smw_wrong_namespace": "Only pages in namespace \"$1\" are allowed here.",
 	"smw_manytypes": "More than one type defined for property.",
 	"smw_emptystring": "Empty strings are not accepted.",
-	"smw_notinenum": "\"$1\" is not in the list of possible values ($2) for this property.",
+	"smw_notinenum": "\"$1\" is not in the list ($2) of [[Property:Allows value|allowed values]] for the \"$3\" property.",
 	"smw_noboolean": "\"$1\" is not recognized as a Boolean (true/false) value.",
 	"smw_true_words": "true,t,yes,y",
 	"smw_false_words": "false,f,no,n",

--- a/src/DataValues/MonolingualTextValue.php
+++ b/src/DataValues/MonolingualTextValue.php
@@ -104,6 +104,8 @@ class MonolingualTextValue extends DataValue {
 				$this->m_contextPage
 			);
 
+			$this->addError( $dataValue->getErrors() );
+
 			$dataValues[] = $dataValue;
 		}
 

--- a/src/DataValues/ValueValidators/ListConstraintValueValidator.php
+++ b/src/DataValues/ValueValidators/ListConstraintValueValidator.php
@@ -5,6 +5,7 @@ namespace SMW\DataValues\ValueValidators;
 use SMW\DataValueFactory;
 use SMWDataValue as DataValue;
 use SMWDIBlob as DIBlob;
+use SMW\Message;
 
 /**
  * @private
@@ -60,8 +61,10 @@ class ListConstraintValueValidator implements ConstraintValueValidator {
 				array(
 					'smw_notinenum',
 					$dataValue->getWikiValue(),
-					$valuestring
-				)
+					$valuestring,
+					$property->getLabel()
+				),
+				Message::PARSE
 			);
 
 			$this->hasConstraintViolation = true;

--- a/src/Message.php
+++ b/src/Message.php
@@ -156,7 +156,7 @@ class Message {
 			return $message[0];
 		}
 
-		return self::get( $message, $type !== null ? $type : $asType, $language );
+		return self::get( $message, ( $asType !== null ? $asType: $type ), $language );
 	}
 
 	/**


### PR DESCRIPTION
This PR is made in reference to: #1344, #1774 

This PR addresses or contains:

- Ensures that errors are transferred and can be recorded by the `ProcessingErrorMsgHandler`

This PR includes:
- [ ] Tests (unit/integration)
- [x] CI build passed

