### PR TITLE
Record type to support property name as index, refs #1808

### DIFF
--- a/includes/storage/SMW_ResultArray.php
+++ b/includes/storage/SMW_ResultArray.php
@@ -173,24 +173,16 @@ class SMWResultArray {
 
 		if ( $this->mPrintRequest->getMode() == PrintRequest::PRINT_PROP &&
 		    strpos( $this->mPrintRequest->getTypeID(), '_rec' ) !== false &&
-		     $this->mPrintRequest->getParameter( 'index' ) !== false ) {
-			// Not efficient, but correct: we need to find the right property for
-			// the selected index of the record here.
-			$pos = $this->mPrintRequest->getParameter( 'index' ) - 1;
+		    $this->mPrintRequest->getParameter( 'index' ) !== false ) {
 
 			$recordValue = DataValueFactory::getInstance()->newDataValueByItem(
 				$dataItem,
 				$this->mPrintRequest->getData()->getDataItem()
 			);
 
-			$diProperties = $recordValue->getPropertyDataItems();
-
-			if ( array_key_exists( $pos, $diProperties ) &&
-				!is_null( $diProperties[$pos] ) ) {
-				$diProperty = $diProperties[$pos];
-			} else {
-				$diProperty = null;
-			}
+			$diProperty = $recordValue->getPropertyDataItemByIndex(
+				$this->mPrintRequest->getParameter( 'index' )
+			);
 		} elseif ( $this->mPrintRequest->getMode() == PrintRequest::PRINT_PROP ) {
 			$diProperty = $this->mPrintRequest->getData()->getDataItem();
 		} else {
@@ -284,16 +276,14 @@ class SMWResultArray {
 				// for this then they will not recognize that it returns some more concrete type.
 				if ( strpos( $this->mPrintRequest->getTypeID(), '_rec' ) !== false &&
 				     ( $this->mPrintRequest->getParameter( 'index' ) !== false ) ) {
-					$pos = $this->mPrintRequest->getParameter( 'index' ) - 1;
+					$index = $this->mPrintRequest->getParameter( 'index' );
 					$newcontent = array();
 
 					foreach ( $this->mContent as $diContainer ) {
 						/* SMWRecordValue */ $recordValue = DataValueFactory::getInstance()->newDataValueByItem( $diContainer, $propertyValue->getDataItem() );
-						$dataItems = $recordValue->getDataItems();
 
-						if ( array_key_exists( $pos, $dataItems ) &&
-							( !is_null( $dataItems[$pos] ) ) ) {
-							$newcontent[] = $dataItems[$pos];
+						if ( ( $dataItem = $recordValue->getDataItemByIndex( $index ) ) !== null ) {
+							$newcontent[] = $dataItem;
 						}
 					}
 

--- a/src/DataValues/AbstractMultiValue.php
+++ b/src/DataValues/AbstractMultiValue.php
@@ -1,0 +1,120 @@
+<?php
+
+namespace SMW\DataValues;
+
+use SMWDataValue as DataValue;
+
+/**
+ * @private
+ *
+ * @license GNU GPL v2+
+ * @since 2.5
+ *
+ * @author mwjames
+ */
+abstract class AbstractMultiValue extends DataValue {
+
+	/**
+	 * @since 2.5
+	 *
+	 * @param string $userValue
+	 *
+	 * @return array
+	 */
+	abstract public function getValuesFromString( $userValue );
+
+	/**
+	 * @since 2.5
+	 *
+	 * @param DIProperty[] $properties
+	 *
+	 * @return DIProperty[]|null
+	 */
+	abstract public function setFieldProperties( array $properties );
+
+	/**
+	 * @since 2.5
+	 *
+	 * @return DIProperty[]|null
+	 */
+	abstract public function getProperties();
+
+	/**
+	 * Create a list (array with numeric keys) containing the datavalue
+	 * objects that this SMWRecordValue object holds. Values that are not
+	 * present are set to null. Note that the first index in the array is
+	 * 0, not 1.
+	 *
+	 * @since 2.5
+	 *
+	 * @return DataItem[]|null
+	 */
+	abstract public function getDataItems();
+
+	/**
+	 * Return the array (list) of properties that the individual entries of
+	 * this datatype consist of.
+	 *
+	 * @since 2.5
+	 *
+	 * @return DIProperty[]|null
+	 */
+	abstract public function getPropertyDataItems();
+
+	/**
+	 * @note called by SMWResultArray::loadContent for matching an index as denoted
+	 * in |?Foo=Bar|+index=1 OR |?Foo=Bar|+index=Bar
+	 *
+	 * @see https://www.semantic-mediawiki.org/wiki/Help:Type_Record#Semantic_search
+	 *
+	 * @since 2.5
+	 *
+	 * @param string|integer $index
+	 *
+	 * @return DataItem[]|null
+	 */
+	public function getDataItemByIndex( $index ) {
+
+		if ( is_numeric( $index ) ) {
+			$pos = $index - 1;
+			$dataItems = $this->getDataItems();
+			return isset( $dataItems[$pos] ) ? $dataItems[$pos] : null;
+		}
+
+		if ( ( $property = $this->getPropertyDataItemByIndex( $index ) ) !== null ) {
+			$values = $this->getDataItem()->getSemanticData()->getPropertyValues( $property );
+			return reset( $values );
+		}
+
+		return null;
+	}
+
+	/**
+	 * @note called by SMWResultArray::getNextDataValue to match an index
+	 * that has been denoted using |?Foo=Bar|+index=1 OR |?Foo=Bar|+index=Bar
+	 *
+	 * @since 2.5
+	 *
+	 * @param string|integer $index
+	 *
+	 * @return DIProperty|null
+	 */
+	public function getPropertyDataItemByIndex( $index ) {
+
+		$properties = $this->getPropertyDataItems();
+
+		if ( is_numeric( $index ) ) {
+			$pos = $index - 1;
+			return isset( $properties[$pos] ) ? $properties[$pos] : null;
+		}
+
+		foreach ( $properties as $property ) {
+			if ( $property->getLabel() === $index ) {
+				return $property;
+			}
+		}
+
+		return null;
+	}
+
+}

--- a/src/DataValues/MonolingualTextValue.php
+++ b/src/DataValues/MonolingualTextValue.php
@@ -33,7 +33,7 @@ use SMWDIContainer as DIContainer;
  *
  * @author mwjames
  */
-class MonolingualTextValue extends DataValue {
+class MonolingualTextValue extends AbstractMultiValue {
 
 	/**
 	 * @var DIProperty[]|null
@@ -53,13 +53,22 @@ class MonolingualTextValue extends DataValue {
 	}
 
 	/**
-	 * @see RecordValue::setFieldProperties
+	 * @see AbstractMultiValue::setFieldProperties
 	 *
 	 * @param DIProperty[] $properties
 	 */
 	public function setFieldProperties( array $properties ) {
 		// Keep the interface while the properties for this type
 		// are fixed.
+	}
+
+	/**
+	 * @see AbstractMultiValue::getProperties
+	 *
+	 * @param DIProperty[] $properties
+	 */
+	public function getProperties() {
+		self::$properties;
 	}
 
 	/**
@@ -194,11 +203,11 @@ class MonolingualTextValue extends DataValue {
 
 	/**
 	 * @since 2.4
-	 * @note called by SMWResultArray::getNextDataValue
+	 * @note called by AbstractRecordValue::getPropertyDataItems
 	 *
 	 * @return DIProperty[]
 	 */
-	public static function getPropertyDataItems() {
+	public function getPropertyDataItems() {
 
 		if ( self::$properties !== null && self::$properties !== array() ) {
 			return self::$properties;
@@ -213,7 +222,7 @@ class MonolingualTextValue extends DataValue {
 
 	/**
 	 * @since 2.4
-	 * @note called by SMWResultArray::loadContent
+	 * @note called by AbstractRecordValue::getDataItems
 	 *
 	 * @return DataItem[]
 	 */

--- a/tests/phpunit/Integration/ByJsonScript/Fixtures/p-0431.json
+++ b/tests/phpunit/Integration/ByJsonScript/Fixtures/p-0431.json
@@ -1,0 +1,81 @@
+{
+	"description": "Test in-text annotation `_rec` and `|+index` (`wgContLang=en`, `wgLang=en`)",
+	"properties": [
+		{
+			"name": "Has text",
+			"contents": "[[Has type::Text]]"
+		},
+		{
+			"name": "Has number",
+			"contents": "[[Has type::Number]]"
+		},
+		{
+			"name": "Has record",
+			"contents": "[[Has type::Record]] [[Has fields::Has text;Has number]] [[Has property description::Test@en]]"
+		}
+	],
+	"subjects": [
+		{
+			"name": "Example/P0431/1",
+			"contents": "[[Has record::Foo;123]]"
+		},
+		{
+			"name": "Example/P0431/Q1.1",
+			"contents": "{{#ask: [[Has record::+]] |?Has record|+index=Has text}}"
+		},
+		{
+			"name": "Example/P0431/Q1.2",
+			"contents": "{{#ask: [[Has record::+]] |?Has record|+index=Has number|?Has record|+index=Has text}}"
+		},
+		{
+			"name": "Example/P0431/Q2.1",
+			"contents": "{{#ask: [[Has property description::Test@en]] |?Has property description|+index=Language code}}"
+		}
+	],
+	"parser-testcases": [
+		{
+			"about": "#0",
+			"subject": "Example/P0431/Q1.1",
+			"expected-output": {
+				"to-contain": [
+					"Example/P0431/1",
+					"<td class=\"Has-record smwtype_txt\">Foo</td>"
+				],
+				"not-contain": [
+					"<td data-sort-value=\"123\" class=\"Has-record smwtype_num\">123</td>"
+				]
+			}
+		},
+		{
+			"about": "#1",
+			"subject": "Example/P0431/Q1.2",
+			"expected-output": {
+				"to-contain": [
+					"Example/P0431/1",
+					"<td class=\"Has-record smwtype_txt\">Foo</td>",
+					"<td data-sort-value=\"123\" class=\"Has-record smwtype_num\">123</td>"
+				]
+			}
+		},
+		{
+			"about": "#2",
+			"subject": "Example/P0431/Q2.1",
+			"expected-output": {
+				"to-contain": [
+					"Property:Has record",
+					"<td class=\"Has-property-description smwtype&#95;_lcode\">en</td>"
+				]
+			}
+		}
+	],
+	"settings": {
+		"wgContLang": "en",
+		"wgLang": "en"
+	},
+	"meta": {
+
+		"version": "0.1",
+		"is-incomplete": false,
+		"debug": false
+	}
+}


### PR DESCRIPTION
This PR is made in reference to: #1808

This PR addresses or contains:

- Besides supporting an index number as in `|?Foo=Bar|+index=1`, enable to use the property name `|?Foo=Bar|+index=Bar` as well.

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed

