### PR TITLE
Special:Browse to show redirect by source without displaytitle, refs #1410

### DIFF
--- a/src/MediaWiki/Specials/Browse/HtmlContentBuilder.php
+++ b/src/MediaWiki/Specials/Browse/HtmlContentBuilder.php
@@ -300,6 +300,11 @@ class HtmlContentBuilder {
 					$dv = DataValueFactory::getInstance()->newDataValueByItem( $di, $diProperty );
 				}
 
+				// For a redirect, disable the DisplayTitle to show the original (aka source) page
+				if ( $diProperty->getKey() == '_REDI' ) {
+					$dv->setOption( 'smwgDVFeatures', ( $dv->getOptionValueFor( 'smwgDVFeatures' ) & ~SMW_DV_WPV_DTITLE ) );
+				}
+
 				$body .= "<span class=\"{$ccsPrefix}value\">" .
 				         $this->displayValue( $dvProperty, $dv, $incoming ) . "</span>\n";
 			}

--- a/tests/phpunit/Integration/ByJsonScript/Fixtures/s-0005.json
+++ b/tests/phpunit/Integration/ByJsonScript/Fixtures/s-0005.json
@@ -1,5 +1,5 @@
 {
-	"description": "Test `Special:Browse` output for `_dat` (`wgContLang=en`, `wgLang=en`, `smwgDVFeatures=SMW_DV_TIMEV_CM`)",
+	"description": "Test `Special:Browse` output for `_dat`, '_REDI' (`wgContLang=en`, `wgLang=en`, `smwgDVFeatures=SMW_DV_TIMEV_CM | SMW_DV_WPV_DTITLE`, `wgRestrictDisplayTitle=false`)",
 	"properties": [
 		{
 			"name": "Has date",
@@ -9,7 +9,15 @@
 	"subjects": [
 		{
 			"name": "Example/S0005/1",
-			"contents": "[[Has date::12 Jan 1991 8:56]] [[Has date::12 Jan 1345]] [[Category:S0004]"
+			"contents": "[[Has date::12 Jan 1991 8:56]] [[Has date::12 Jan 1345]] [[Category:S0004]]"
+		},
+		{
+			"name": "Example/S0005/2",
+			"contents": "#REDIRECT [[Example/S0005/3]]"
+		},
+		{
+			"name": "Example/S0005/3",
+			"contents": "{{DISPLAYTITLE:ABC}}"
 		}
 	],
 	"special-testcases": [
@@ -29,6 +37,24 @@
 					"<span class=\"smwb-value\">January 12, 1345 <sup>JL</sup>&#160;&#160;"
 				]
 			}
+		},
+		{
+			"about": "#1 (redirect to show source page instead of DISPLAYTITLE)",
+			"special-page": {
+				"page":"Browse",
+				"query-parameters": "Example/S0005/3",
+				"request-parameters":{
+					"output": "legacy"
+				}
+			},
+			"expected-output": {
+				"to-contain": [
+					"class=\"mw-redirect\" title=\"Example/S0005/2\">Example/S0005/2"
+				],
+				"not-contain": [
+					"class=\"mw-redirect\" title=\"Example/S0005/2\">ABC"
+				]
+			}
 		}
 	],
 	"settings": {
@@ -39,7 +65,11 @@
 			"NS_MAIN": true,
 			"SMW_NS_PROPERTY": true
 		},
-		"smwgDVFeatures": [ "SMW_DV_TIMEV_CM" ]
+		"wgRestrictDisplayTitle": false,
+		"smwgDVFeatures": [
+			"SMW_DV_TIMEV_CM",
+			"SMW_DV_WPV_DTITLE"
+		]
 	},
 	"meta": {
 		"version": "0.1",


### PR DESCRIPTION
This PR is made in reference to: #1410

This PR addresses or contains:

- Ensures that redirects show as source and not with the displaytitle otherwise they can appear with the same title as the target in case `DISPLAYTITLE` is used

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed