### PR TITLE
Track queries even in case of an error, refs #1768

### DIFF
--- a/includes/parserhooks/AskParserFunction.php
+++ b/includes/parserhooks/AskParserFunction.php
@@ -220,10 +220,11 @@ class AskParserFunction {
 
 	private function createQueryProfile( $query, $format, $duration ) {
 
-		// In case of an query error add a marker to the subject for
-		// discoverability of a failed query
+		// In case of an query error add a marker to the subject for discoverability
+		// of a failed query, don't bail-out as we can have results and errors
+		// at the same time
 		if ( $query->getErrors() !== array() ) {
-			return $this->addProcessingError( $query->getErrors() );
+			$this->addProcessingError( $query->getErrors() );
 		}
 
 		$queryProfileAnnotatorFactory = $this->applicationFactory->newQueryProfileAnnotatorFactory();

--- a/tests/phpunit/Integration/ByJsonScript/Fixtures/p-0902.json
+++ b/tests/phpunit/Integration/ByJsonScript/Fixtures/p-0902.json
@@ -19,8 +19,8 @@
 			"store": {
 				"semantic-data": {
 					"strict-mode-valuematch": false,
-					"propertyCount": 3,
-					"propertyKeys": [ "_MDAT", "_SKEY", "_ERRC" ]
+					"propertyCount": 4,
+					"propertyKeys": [ "_MDAT", "_SKEY", "_ASK", "_ERRC" ]
 				}
 			},
 			"expected-output": {

--- a/tests/phpunit/includes/parserhooks/AskParserFunctionTest.php
+++ b/tests/phpunit/includes/parserhooks/AskParserFunctionTest.php
@@ -293,8 +293,8 @@ class AskParserFunctionTest extends \PHPUnit_Framework_TestCase {
 		);
 
 		$expected = array(
-			'propertyCount'  => 1,
-			'propertyKeys'   => array( '_ERRC' ),
+			'propertyCount'  => 2,
+			'propertyKeys'   => array( '_ASK', '_ERRC' ),
 		);
 
 		$parserData = $this->applicationFactory->newParserData(

--- a/tests/phpunit/includes/parserhooks/ShowParserFunctionTest.php
+++ b/tests/phpunit/includes/parserhooks/ShowParserFunctionTest.php
@@ -193,7 +193,7 @@ class ShowParserFunctionTest extends \PHPUnit_Framework_TestCase {
 		);
 
 		$instance->parse( $params );
-/*
+
 		$expected = array(
 			'output' => 'class="smwtticon warning"', // lazy content check for the error
 			'propertyCount'  => 4,
@@ -205,7 +205,7 @@ class ShowParserFunctionTest extends \PHPUnit_Framework_TestCase {
 			$expected,
 			$parserData->getSemanticData()->findSubSemanticData( '_QUERYc685f41368e6d9c59dfc9d8d69ef557f' )
 		);
-*/
+
 		$expected = array(
 			'propertyCount'  => 2,
 			'propertyKeys'   => array( '_ERRP', '_ERRT' ),


### PR DESCRIPTION
This PR is made in reference to: #1768

This PR addresses or contains:

- Don't exit on an error and track queries even in case of an error

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed

