### PR TITLE
Add ReferenceValue, refs #1808

### DIFF
--- a/DefaultSettings.php
+++ b/DefaultSettings.php
@@ -535,6 +535,20 @@ $GLOBALS['smwgPageSpecialProperties'] = array( '_MDAT' );
 $GLOBALS['smwgDeclarationProperties'] = array( '_PVAL', '_LIST', '_PVAP', '_PVUC' );
 ##
 
+###
+# By default, DataTypes (Date, URL etc.) are registered with a corresponding
+# property of the same name to match the expected semantics. Yet, users can
+# decide to change the behaviour by exempting listed DataTypes from the property
+# registration process.
+#
+# @since 2.5
+##
+$GLOBALS['smwgDataTypePropertyExemptionList'] = array(
+	'Record',
+	'Reference'
+);
+##
+
 // some default settings which usually need no modification
 
 ###

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -293,6 +293,7 @@
 	"smw-ui-tooltip-title-event": "Event",
 	"smw-ui-tooltip-title-note": "Note",
 	"smw-ui-tooltip-title-legend": "Legend",
+	"smw-ui-tooltip-title-reference": "Reference",
 	"smw_unknowntype": "The type of this property is invalid",
 	"smw-concept-cache-text": "The concept has a total of $1 {{PLURAL:$1|page|pages}}, and was last updated $3, $2.",
 	"smw_concept_header": "Pages of concept \"$1\"",
@@ -438,6 +439,8 @@
 	"smw-datavalue-type-invalid-typeuri": "The \"$1\" type could not be transformed into a valid URI representation.",
 	"smw-datavalue-wikipage-missing-fragment-context": "The wikipage input value \"$1\" cannot be used without a context page.",
 	"smw-datavalue-wikipage-invalid-title": "The wikipage input value \"$1\" contains invalid characters or is incomplete and can therefore cause unexpected results during a query or annotation process.",
-	"smw-datavalue-wikipage-empty": "The wikipage input value is empty (e.g. <code>[[SomeProperty::]], [[]]</code>) and can therefore not be used as name or as part of a query condition."
+	"smw-datavalue-wikipage-empty": "The wikipage input value is empty (e.g. <code>[[SomeProperty::]], [[]]</code>) and can therefore not be used as name or as part of a query condition.",
+	"smw-sp-types_ref_rec": "\"$1\" is a [https://www.semantic-mediawiki.org/wiki/Container container] type that allows to record additional information (e.g. provenance data) about a value assignment.",
+	"smw-datavalue-reference-outputformat": "$1: $2",
+	"smw-datavalue-reference-invalid-fields-definition": "The [[Special:Types/Reference|Reference]] type expects a list of properties to be declared using the [https://www.semantic-mediawiki.org/wiki/Help:Special_property_Has_fields Has fields] property."
 }
-

--- a/includes/Highlighter.php
+++ b/includes/Highlighter.php
@@ -33,6 +33,7 @@ class Highlighter {
 	const TYPE_NOTE      = 7;
 	//  Highlighter ID for service links
 	const TYPE_SERVICE   = 8;
+	const TYPE_REFERENCE = 9;
 
 	/**
 	 * @var array $options
@@ -137,6 +138,8 @@ class Highlighter {
 			return self::TYPE_NOTE;
 			case 'service':
 			return self::TYPE_SERVICE;
+			case 'reference':
+			return self::TYPE_REFERENCE;
 			default:
 			return self::TYPE_NOTYPE;
 		}
@@ -168,10 +171,11 @@ class Highlighter {
 		return Html::rawElement(
 			'span',
 			array(
-				'class'      => 'smw-highlighter',
-				'data-type'  => $this->options['type'],
-				'data-state' => $this->options['state'],
-				'data-title' => Message::get( $this->options['title'], Message::TEXT, $language ),
+				'class'        => 'smw-highlighter',
+				'data-type'    => $this->options['type'],
+				'data-content' => isset( $this->options['data-content'] ) ? $this->options['data-content'] : null,
+				'data-state'   => $this->options['state'],
+				'data-title'   => Message::get( $this->options['title'], Message::TEXT, $language ),
 			), Html::rawElement(
 					'span',
 					array(
@@ -234,6 +238,11 @@ class Highlighter {
 				$settings['state'] = 'persistent';
 				$settings['title'] = 'smw-ui-tooltip-title-service';
 				$settings['captionclass'] = 'smwtticon service';
+				break;
+			case self::TYPE_REFERENCE:
+				$settings['state'] = 'persistent';
+				$settings['title'] = 'smw-ui-tooltip-title-reference';
+				$settings['captionclass'] = 'smwtext';
 				break;
 			case self::TYPE_HELP:
 			case self::TYPE_INFO:

--- a/includes/Settings.php
+++ b/includes/Settings.php
@@ -101,6 +101,7 @@ class Settings extends Options {
 			'smwgNamespacesWithSemanticLinks' => $GLOBALS['smwgNamespacesWithSemanticLinks'],
 			'smwgPageSpecialProperties' => $GLOBALS['smwgPageSpecialProperties'],
 			'smwgDeclarationProperties' => $GLOBALS['smwgDeclarationProperties'],
+			'smwgDataTypePropertyExemptionList' => $GLOBALS['smwgDataTypePropertyExemptionList'],
 			'smwgTranslate' => $GLOBALS['smwgTranslate'],
 			'smwgAdminRefreshStore' => $GLOBALS['smwgAdminRefreshStore'],
 			'smwgAutocompleteInSpecialAsk' => $GLOBALS['smwgAutocompleteInSpecialAsk'],

--- a/includes/datavalues/SMW_DV_URI.php
+++ b/includes/datavalues/SMW_DV_URI.php
@@ -229,7 +229,7 @@ class SMWURIValue extends SMWDataValue {
 
 		if ( is_null( $linker ) || ( !$this->isValid() ) || ( $url === '' ) ||
 			( $this->m_outformat == '-' ) || ( $this->m_outformat == 'nowiki' ) ||
-			( $this->m_caption === '' ) ) {
+			( $this->m_caption === '' ) ||  is_bool( $linker ) ) {
 			return $caption;
 		} else {
 			return $linker->makeExternalLink( $url, $caption );
@@ -245,7 +245,7 @@ class SMWURIValue extends SMWDataValue {
 		list( $url, $wikitext ) = $this->decodeUriContext( $this->m_wikitext );
 
 		if ( is_null( $linked ) || ( $linked === false ) || ( $url === '' ) ||
-			( $this->m_outformat == '-' ) ) {
+			( $this->m_outformat == '-' ) || is_bool( $linked ) ) {
 			return $wikitext;
 		} elseif ( $this->m_outformat == 'nowiki' ) {
 			return $this->makeNonlinkedWikiText( $wikitext );
@@ -263,7 +263,7 @@ class SMWURIValue extends SMWDataValue {
 		list( $url, $wikitext ) = $this->decodeUriContext( $this->m_wikitext );
 
 		if ( is_null( $linker ) || ( !$this->isValid() ) || ( $url === '' ) ||
-			( $this->m_outformat == '-' ) || ( $this->m_outformat == 'nowiki' ) ) {
+			( $this->m_outformat == '-' ) || ( $this->m_outformat == 'nowiki' ) ||  is_bool( $linker ) ) {
 			return $wikitext;
 		} else {
 			return $linker->makeExternalLink( $url, $wikitext );

--- a/languages/SMW_Language.php
+++ b/languages/SMW_Language.php
@@ -77,7 +77,9 @@ abstract class SMWLanguage {
 		'Record'                => '_rec',
 		'External identifier'   => '_eid',
 		'Monolingual text'      => '_mlt_rec', // need the _rec to allow for special treatment
+		'Reference'             => '_ref_rec', // need the _rec to allow for special treatment
 	);
+
 	/// Default English aliases for special property names (typically used in all languages)
 	static protected $enPropertyAliases = array(
 		'Has type'          => '_TYPE',

--- a/languages/SMW_LanguageEn.php
+++ b/languages/SMW_LanguageEn.php
@@ -44,6 +44,7 @@ class SMWLanguageEn extends SMWLanguage {
 		'_qty' => 'Quantity', // name of the number type with units of measurement
 		'_mlt_rec' => 'Monolingual text',
 		'_eid' => 'External identifier',
+		'_ref_rec' => 'Reference',
 	);
 
 	protected $m_DatatypeAliases = array(

--- a/res/smw/ext.smw.css
+++ b/res/smw/ext.smw.css
@@ -762,6 +762,20 @@ a.smw-ask-action-btn-lblue:hover {
 	line-height: 24px;
 }
 
+.smw-reference-indicator {
+	vertical-align: super;
+	margin-left:2px;
+	font-size: 10px;
+}
+
+.smw-reference-indicator::before {
+	content: "";
+}
+
+.smw-reference-indicator::after {
+	content: "≡";
+}
+
 .is-disabled {
 	opacity: .5;
 	position: relative;

--- a/src/DataTypeRegistry.php
+++ b/src/DataTypeRegistry.php
@@ -457,6 +457,7 @@ class DataTypeRegistry {
 			'_boo'  => 'SMW\DataValues\BooleanValue', // Boolean type
 			'_rec'  => 'SMWRecordValue', // Value list type (replacing former nary properties)
 			'_mlt_rec'  => 'SMW\DataValues\MonolingualTextValue',
+			'_ref_rec'  => 'SMW\DataValues\ReferenceValue',
 			'_qty'  => 'SMWQuantityValue', // Type for numbers with units of measurement
 			// Special types are not avaialble directly for users (and have no local language name):
 			'__typ' => 'SMWTypesValue', // Special type page type
@@ -501,6 +502,7 @@ class DataTypeRegistry {
 			'_boo'  => DataItem::TYPE_BOOLEAN, // Boolean type
 			'_rec'  => DataItem::TYPE_WIKIPAGE, // Value list type (replacing former nary properties)
 			'_mlt_rec' => DataItem::TYPE_WIKIPAGE, // Monolingual text container
+			'_ref_rec' => DataItem::TYPE_WIKIPAGE, // Reference container
 			'_geo'  => DataItem::TYPE_GEO, // Geographical coordinates
 			'_gpo'  => DataItem::TYPE_BLOB, // Geographical polygon
 			'_qty'  => DataItem::TYPE_NUMBER, // Type for numbers with units of measurement
@@ -532,7 +534,8 @@ class DataTypeRegistry {
 		$this->subDataTypes = array(
 			'__sob' => true,
 			'_rec'  => true,
-			'_mlt_rec' => true
+			'_mlt_rec' => true,
+			'_ref_rec' => true
 		);
 
 		// Deprecated since 1.9

--- a/src/DataValues/ReferenceValue.php
+++ b/src/DataValues/ReferenceValue.php
@@ -1,0 +1,316 @@
+<?php
+
+namespace SMW\DataValues;
+
+use SMW\ApplicationFactory;
+use SMW\DataValueFactory;
+use SMW\DataValues\ValueFormatters\DataValueFormatter;
+use SMW\DIProperty;
+use SMW\DIWikiPage;
+use SMWContainerSemanticData as ContainerSemanticData;
+use SMWDataItem as DataItem;
+use SMWDataValue as DataValue;
+use SMWDIContainer as DIContainer;
+use SMWPropertyListValue as PropertyListValue;
+
+/**
+ * ReferenceValue allows to define additional DV to describe the state of a
+ * SourceValue in terms of provenance or referential evidence. ReferenceValue is
+ * stored as separate entity to the original subject in order to encapsulate the
+ * SourceValue from the remaining annotations kept in reference to a subject.
+ *
+ * Defining which fields are required can vary and therefore is left to the user
+ * to specify such requirements using the `'Has fields' property.
+ *
+ * For example, declaring `[[Has fields::SomeValue;Date;SomeUrl;...]]` on a
+ * `SomeProperty` property page is to define:
+ *
+ * - a property called `SomeValue` with its own specification
+ * - a date property with the Date type
+ * - a property called `SomeUrl` with its own specification
+ * - ... any other property the users expects to require when making a value
+ *   annotation of this type
+ *
+ * An annotation `[[SomeProperty::Foo;12-12-1212;http://example.org]]` is expected
+ * to be a concatenated string and be separated by ';' to indicate the next value
+ * string which will corespondent to the index of the `Has fields` declaration.
+ *
+ * @license GNU GPL v2+
+ * @since 2.5
+ *
+ * @author mwjames
+ */
+class ReferenceValue extends AbstractMultiValue {
+
+	/**
+	 * @var DIProperty[]|null
+	 */
+	private $properties = null;
+
+	/**
+	 * @param string $typeid
+	 */
+	public function __construct( $typeid = '' ) {
+		parent::__construct( '_ref_rec' );
+	}
+
+	/**
+	 * @since 2.5
+	 *
+	 * {@inheritDoc}
+	 */
+	public function setFieldProperties( array $properties ) {
+		foreach ( $properties as $property ) {
+			if ( $property instanceof DIProperty ) {
+				$this->properties[] = $property;
+			}
+		}
+	}
+
+	/**
+	 * @since 2.5
+	 *
+	 * {@inheritDoc}
+	 */
+	public function getProperties() {
+		return $this->properties;
+	}
+
+	/**
+	 * @since 2.5
+	 *
+	 * {@inheritDoc}
+	 */
+	public function getValuesFromString( $value ) {
+		// #664 / T17732
+		$value = str_replace( "\;", "-3B", $value );
+
+		// Bug 21926 / T23926
+		// Values that use html entities are encoded with a semicolon
+		$value = htmlspecialchars_decode( $value, ENT_QUOTES );
+		$values = preg_split( '/[\s]*;[\s]*/u', trim( $value ) );
+
+		return str_replace( "-3B", ";", $values );
+	}
+
+	/**
+	 * @see DataValue::getShortWikiText
+	 * @since 2.5
+	 *
+	 * {@inheritDoc}
+	 */
+	public function getShortWikiText( $linker = null ) {
+		return $this->getDataValueFormatter()->format( DataValueFormatter::WIKI_SHORT, $linker );
+	}
+
+	/**
+	 * @see DataValue::getShortHTMLText
+	 * @since 2.5
+	 *
+	 * {@inheritDoc}
+	 */
+	public function getShortHTMLText( $linker = null ) {
+		return $this->getDataValueFormatter()->format( DataValueFormatter::HTML_SHORT, $linker );
+	}
+
+	/**
+	 * @see DataValue::getLongWikiText
+	 * @since 2.5
+	 *
+	 * {@inheritDoc}
+	 */
+	public function getLongWikiText( $linker = null ) {
+		return $this->getDataValueFormatter()->format( DataValueFormatter::WIKI_LONG, $linker );
+	}
+
+	/**
+	 * @see DataValue::getLongHTMLText
+	 * @since 2.5
+	 *
+	 * {@inheritDoc}
+	 */
+	public function getLongHTMLText( $linker = null ) {
+		return $this->getDataValueFormatter()->format( DataValueFormatter::HTML_LONG, $linker );
+	}
+
+	/**
+	 * @see DataValue::getWikiValue
+	 * @since 2.5
+	 *
+	 * {@inheritDoc}
+	 */
+	public function getWikiValue() {
+		return $this->getDataValueFormatter()->format( DataValueFormatter::VALUE );
+	}
+
+	/**
+	 * @since 2.5
+	 *
+	 * {@inheritDoc}
+	 */
+	public function getPropertyDataItems() {
+
+		if ( $this->properties === null ) {
+			$this->properties = $this->findPropertyDataItems( $this->getProperty() );
+
+			if ( count( $this->properties ) == 0 ) {
+				$this->addErrorMsg( 'smw-datavalue-reference-invalid-fields-definition' );
+			}
+		}
+
+		return $this->properties;
+	}
+
+	/**
+	 * @since 2.5
+	 *
+	 * {@inheritDoc}
+	 */
+	public function getDataItems() {
+
+		if ( !$this->isValid() ) {
+			return array();
+		}
+
+		$result = array();
+		$index = 0;
+
+		foreach ( $this->getPropertyDataItems() as $diProperty ) {
+			$values = $this->getDataItem()->getSemanticData()->getPropertyValues( $diProperty );
+			if ( count( $values ) > 0 ) {
+				$result[$index] = reset( $values );
+			} else {
+				$result[$index] = null;
+			}
+			$index += 1;
+		}
+
+		return $result;
+	}
+
+	/**
+	 * @note called by DataValue::setUserValue
+	 * @see DataValue::parseUserValue
+	 *
+	 * {@inheritDoc}
+	 */
+	protected function parseUserValue( $value ) {
+
+		if ( $value === '' ) {
+			$this->addErrorMsg( array( 'smw_novalues' ) );
+			return;
+		}
+
+		$containerSemanticData = $this->newContainerSemanticData( $value );
+
+		$values = $this->getValuesFromString( $value );
+		$index = 0; // index in value array
+
+		$propertyIndex = 0; // index in property list
+		$empty = true;
+
+		foreach ( $this->getPropertyDataItems() as $property ) {
+
+			if ( !array_key_exists( $index, $values ) || $this->getErrors() !== array() ) {
+				break; // stop if there are no values left
+			}
+
+			// generating the DVs:
+			if ( ( $values[$index] === '' ) || ( $values[$index] == '?' ) ) { // explicit omission
+				$index++;
+			} else {
+				$dataValue = DataValueFactory::getInstance()->newDataValueByProperty(
+					$property,
+					$values[$index],
+					false,
+					$this->getContextPage()
+				);
+
+				if ( $dataValue->isValid() ) { // valid DV: keep
+					$containerSemanticData->addPropertyObjectValue( $property, $dataValue->getDataItem() );
+
+					$index++;
+					$empty = false;
+				} elseif ( ( count( $values ) - $index ) == ( count( $this->properties ) - $propertyIndex ) ) {
+					$containerSemanticData->addPropertyObjectValue( $property, $dataValue->getDataItem() );
+					$this->addError( $dataValue->getErrors() );
+					++$index;
+				}
+			}
+			++$propertyIndex;
+		}
+
+		if ( $empty && $this->getErrors() === array()  ) {
+			$this->addErrorMsg( array( 'smw_novalues' ) );
+		}
+
+		$this->m_dataitem = new DIContainer( $containerSemanticData );
+	}
+
+	/**
+	 * @see DataValue::loadDataItem
+	 */
+	protected function loadDataItem( DataItem $dataItem ) {
+
+		if ( $dataItem->getDIType() === DataItem::TYPE_CONTAINER ) {
+			$this->m_dataitem = $dataItem;
+			return true;
+		} elseif ( $dataItem->getDIType() === DataItem::TYPE_WIKIPAGE ) {
+			$semanticData = new ContainerSemanticData( $dataItem );
+			$semanticData->copyDataFrom( ApplicationFactory::getInstance()->getStore()->getSemanticData( $dataItem ) );
+			$this->m_dataitem = new DIContainer( $semanticData );
+			return true;
+		}
+
+		return false;
+	}
+
+	private function findPropertyDataItems( DIProperty $property = null ) {
+
+		if ( $property === null ) {
+			return array();
+		}
+
+		$propertyDiWikiPage = $property->getDiWikiPage();
+
+		if ( $propertyDiWikiPage === null ) {
+			return array();
+		}
+
+		$listDiProperty = new DIProperty( '_LIST' );
+		$dataItems = ApplicationFactory::getInstance()->getStore()->getPropertyValues( $propertyDiWikiPage, $listDiProperty );
+
+		if ( count( $dataItems ) == 1 ) {
+			$propertyListValue = new PropertyListValue( '__pls' );
+			$propertyListValue->setDataItem( reset( $dataItems ) );
+
+			if ( $propertyListValue->isValid() ) {
+				return $propertyListValue->getPropertyDataItems();
+			}
+		}
+
+		return array();
+	}
+
+	private function newContainerSemanticData( $value ) {
+
+		if ( $this->m_contextPage === null ) {
+			$containerSemanticData = ContainerSemanticData::makeAnonymousContainer();
+			$containerSemanticData->skipAnonymousCheck();
+		} else {
+			$subobjectName = '_REF' . md5( $value );
+
+			$subject = new DIWikiPage(
+				$this->m_contextPage->getDBkey(),
+				$this->m_contextPage->getNamespace(),
+				$this->m_contextPage->getInterwiki(),
+				$subobjectName
+			);
+
+			$containerSemanticData = new ContainerSemanticData( $subject );
+		}
+
+		return $containerSemanticData;
+	}
+
+}

--- a/src/DataValues/ValueFormatterRegistry.php
+++ b/src/DataValues/ValueFormatterRegistry.php
@@ -6,6 +6,7 @@ use SMW\DataValues\ValueFormatters\CodeStringValueFormatter;
 use SMW\DataValues\ValueFormatters\DataValueFormatter;
 use SMW\DataValues\ValueFormatters\DispatchingDataValueFormatter;
 use SMW\DataValues\ValueFormatters\MonolingualTextValueFormatter;
+use SMW\DataValues\ValueFormatters\ReferenceValueFormatter;
 use SMW\DataValues\ValueFormatters\NoValueFormatter;
 use SMW\DataValues\ValueFormatters\NumberValueFormatter;
 use SMW\DataValues\ValueFormatters\StringValueFormatter;
@@ -96,6 +97,8 @@ class ValueFormatterRegistry {
 	private function newDispatchingDataValueFormatter() {
 
 		$dispatchingDataValueFormatter = new DispatchingDataValueFormatter();
+
+		$dispatchingDataValueFormatter->addDataValueFormatter( new ReferenceValueFormatter() );
 		$dispatchingDataValueFormatter->addDataValueFormatter( new MonolingualTextValueFormatter() );
 		$dispatchingDataValueFormatter->addDataValueFormatter( new CodeStringValueFormatter() );
 

--- a/src/Deserializers/DVDescriptionDeserializer/RecordValueDescriptionDeserializer.php
+++ b/src/Deserializers/DVDescriptionDeserializer/RecordValueDescriptionDeserializer.php
@@ -8,6 +8,7 @@ use SMW\Query\Language\Conjunction;
 use SMW\Query\Language\SomeProperty;
 use SMW\Query\Language\ThingDescription;
 use SMWRecordValue as RecordValue;
+use SMW\DataValues\ReferenceValue;
 
 /**
  * @private
@@ -25,7 +26,7 @@ class RecordValueDescriptionDeserializer extends DescriptionDeserializer {
 	 * {@inheritDoc}
 	 */
 	public function isDeserializerFor( $serialization ) {
-		return $serialization instanceof RecordValue;
+		return $serialization instanceof RecordValue || $serialization instanceof ReferenceValue;
 	}
 
 	/**

--- a/src/PropertyRegistry.php
+++ b/src/PropertyRegistry.php
@@ -78,7 +78,8 @@ class PropertyRegistry {
 			self::$instance = new self(
 				$dataTypeRegistry,
 				$propertyLabelFinder,
-				$propertyAliasFinder
+				$propertyAliasFinder,
+				$GLOBALS['smwgDataTypePropertyExemptionList']
 			);
 
 			self::$instance->registerPredefinedProperties( $GLOBALS['smwgUseCategoryHierarchy'] );
@@ -93,18 +94,32 @@ class PropertyRegistry {
 	 * @param DataTypeRegistry $datatypeRegistry
 	 * @param PropertyLabelFinder $propertyLabelFinder
 	 * @param PropertyAliasFinder $propertyAliasFinder
+	 * @param array $dataTypePropertyExemptionList
 	 */
-	public function __construct( DataTypeRegistry $datatypeRegistry, PropertyLabelFinder $propertyLabelFinder, PropertyAliasFinder $propertyAliasFinder ) {
+	public function __construct( DataTypeRegistry $datatypeRegistry, PropertyLabelFinder $propertyLabelFinder, PropertyAliasFinder $propertyAliasFinder, array $dataTypePropertyExemptionList = array() ) {
 
 		$this->datatypeLabels = $datatypeRegistry->getKnownTypeLabels();
 		$this->propertyLabelFinder = $propertyLabelFinder;
 		$this->propertyAliasFinder = $propertyAliasFinder;
 
+		// To get an index access
+		$dataTypePropertyExemptionList = array_flip( $dataTypePropertyExemptionList );
+
 		foreach ( $this->datatypeLabels as $id => $label ) {
+
+			if ( isset( $dataTypePropertyExemptionList[$label] ) ) {
+				continue;
+			}
+
 			$this->registerPropertyLabel( $id, $label );
 		}
 
 		foreach ( $datatypeRegistry->getKnownTypeAliases() as $alias => $id ) {
+
+			if ( isset( $dataTypePropertyExemptionList[$alias] ) ) {
+				continue;
+			}
+
 			$this->registerPropertyAlias( $id, $alias );
 		}
 	}

--- a/tests/phpunit/Integration/ByJsonScript/Fixtures/p-0432.json
+++ b/tests/phpunit/Integration/ByJsonScript/Fixtures/p-0432.json
@@ -1,0 +1,102 @@
+{
+	"description": "Test in-text annotation for '_ref_rec' type (`wgContLang=en`, `wgLang=en`)",
+	"properties": [
+		{
+			"name": "Has number with ref",
+			"contents": "[[Has type::Reference]] [[Has fields::Number;Date;URL]]"
+		},
+		{
+			"name": "Has mlt with ref",
+			"contents": "[[Has type::Reference]] [[Has fields::Monolingual text;Date;Number]]"
+		}
+	],
+	"subjects": [
+		{
+			"name": "Example/P0431/1",
+			"contents": "[[Has number with ref::123;1.1.2000;http://example.org]]"
+		},
+		{
+			"name": "Example/P0431/Q1.1",
+			"contents": "{{#ask: [[Has number with ref::123]] |?Has number with ref|+index=Date|?Has number with ref|+index=URL |link=none}}"
+		},
+		{
+			"name": "Example/P0431/2",
+			"contents": "{{#subobject: |Has number with ref=456;12-04-1637;http://example.org }}"
+		},
+		{
+			"name": "Example/P0431/Q2.1",
+			"contents": "{{#ask: [[Has number with ref::456]] |?Has number with ref|+index=Date|?Has number with ref|+index=URL |link=none}}"
+		},
+		{
+			"name": "Example/P0431/3",
+			"contents": "[[Has mlt with ref::Test@en;01.01.1800;123]] {{#subobject: |Has mlt with ref::テスト@ja;01.01.1800;456 }}"
+		},
+		{
+			"name": "Example/P0431/Q3.1",
+			"contents": "{{#ask: [[Has mlt with ref::?@en]] |?Has mlt with ref|+index=Monolingual text|?Has mlt with ref|+index=Number |link=none}}"
+		}
+	],
+	"parser-testcases": [
+		{
+			"about": "#0",
+			"subject": "Example/P0431/1",
+			"store": {
+				"clear-cache": true,
+				"semantic-data": {
+					"strict-mode-valuematch": false,
+					"propertyCount": 3,
+					"propertyKeys": [ "Has_number_with_ref", "_SKEY", "_MDAT" ],
+					"propertyValues": [ "123;1 January 2000;http://example.org" ]
+				}
+			},
+			"expected-output": {
+				"to-contain": [
+					"123<span class=\"smw-reference smw-reference-indicator smw-highlighter smwttinline\" data-title=\"Reference\"",
+					"data-content=\"&lt;ul&gt;&lt;li&gt;Date: 1 January 2000&lt;/li&gt;&lt;li&gt;URL: &lt;a class=&quot;external&quot; rel=&quot;nofollow&quot; href=&quot;http://example.org&quot;&gt;http://example.org&lt;/a&gt;&lt;/li&gt;&lt;/ul&gt;\""
+				]
+			}
+		},
+		{
+			"about": "#1",
+			"subject": "Example/P0431/Q1.1",
+			"expected-output": {
+				"to-contain": [
+					"<tr data-row-number=\"1\" class=\"row-odd\"><td class=\"smwtype_wpg\">Example/P0431/1</td>",
+					"<td data-sort-value=\"2451544.5\" class=\"Has-number-with-ref smwtype_dat\">1 January 2000</td>",
+					"<td class=\"Has-number-with-ref smwtype_uri\"><a rel=\"nofollow\" class=\"external free\" href=\"http://example.org\">http://example.org</a></td>"
+				]
+			}
+		},
+		{
+			"about": "#2",
+			"subject": "Example/P0431/Q2.1",
+			"expected-output": {
+				"to-contain": [
+					"<tr data-row-number=\"1\" class=\"row-odd\"><td class=\"smwtype_wpg\">Example/P0431/2#_7b5db4a4195b1843f9a25639c0d7ff5c</td>",
+					"<td data-sort-value=\"2319299.5\" class=\"Has-number-with-ref smwtype_dat\">4 December 1637</td>",
+					"<td class=\"Has-number-with-ref smwtype_uri\"><a rel=\"nofollow\" class=\"external free\" href=\"http://example.org\">http://example.org</a></td>"
+				]
+			}
+		},
+		{
+			"about": "#3 (Monolingual text, number index output)",
+			"subject": "Example/P0431/Q3.1",
+			"expected-output": {
+				"to-contain": [
+					"<tr data-row-number=\"1\" class=\"row-odd\"><td class=\"smwtype_wpg\">Example/P0431/3</td>",
+					"<td class=\"Has-mlt-with-ref smwtype_mlt_rec\">Test (en)</td>",
+					"<td data-sort-value=\"123\" class=\"Has-mlt-with-ref smwtype_num\">123</td>"
+				]
+			}
+		}
+	],
+	"settings": {
+		"wgContLang": "en",
+		"wgLang": "en"
+	},
+	"meta": {
+		"version": "0.1",
+		"is-incomplete": false,
+		"debug": false
+	}
+}

--- a/tests/phpunit/Unit/DataValues/ReferenceValueTest.php
+++ b/tests/phpunit/Unit/DataValues/ReferenceValueTest.php
@@ -1,0 +1,184 @@
+<?php
+
+namespace SMW\Tests\DataValues;
+
+use SMW\DataValues\ReferenceValue;
+use SMW\DataItemFactory;
+use SMW\Tests\TestEnvironment;
+
+/**
+ * @covers \SMW\DataValues\ReferenceValue
+ * @group semantic-mediawiki
+ *
+ * @license GNU GPL v2+
+ * @since 2.5
+ *
+ * @author mwjames
+ */
+class ReferenceValueTest extends \PHPUnit_Framework_TestCase {
+
+	private $testEnvironment;
+	private $dataItemFactory;
+
+	protected function setUp() {
+		parent::setUp();
+
+		$this->testEnvironment = new TestEnvironment();
+		$this->dataItemFactory = new DataItemFactory();
+
+		$this->propertySpecificationLookup = $this->getMockBuilder( '\SMW\PropertySpecificationLookup' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$this->testEnvironment->registerObject( 'PropertySpecificationLookup', $this->propertySpecificationLookup );
+	}
+
+	protected function tearDown() {
+		$this->testEnvironment->tearDown();
+		parent::tearDown();
+	}
+
+	public function testCanConstruct() {
+
+		$this->assertInstanceOf(
+			'\SMW\DataValues\ReferenceValue',
+			new ReferenceValue()
+		);
+	}
+
+	public function testGetPropertyDataItems() {
+
+		$expected = array(
+			$this->dataItemFactory->newDIProperty( 'Bar' ),
+			$this->dataItemFactory->newDIProperty( 'Foobar' )
+		);
+
+		$store = $this->getMockBuilder( '\SMW\Store' )
+			->disableOriginalConstructor()
+			->setMethods( array( 'getRedirectTarget' ) )
+			->getMockForAbstractClass();
+
+		$store->expects( $this->atLeastOnce() )
+			->method( 'getPropertyValues' )
+			->will( $this->returnValue( array( $this->dataItemFactory->newDIBlob( 'Bar;Foobar' ) ) ) );
+
+		$store->expects( $this->any() )
+			->method( 'getRedirectTarget' )
+			->will( $this->returnArgument( 0 ) );
+
+		$this->testEnvironment->registerObject( 'Store', $store );
+
+		$instance = new ReferenceValue();
+		$instance->setProperty(
+			$this->dataItemFactory->newDIProperty( 'Foo' )
+		);
+
+		$this->assertEquals(
+			$expected,
+			$instance->getPropertyDataItems()
+		);
+
+		$this->assertEquals(
+			$this->dataItemFactory->newDIProperty( 'Foobar' ),
+			$instance->getPropertyDataItemByIndex( 'Foobar' )
+		);
+	}
+
+	public function testParseValue() {
+
+		$store = $this->getMockBuilder( '\SMW\Store' )
+			->disableOriginalConstructor()
+			->setMethods( array( 'getRedirectTarget' ) )
+			->getMockForAbstractClass();
+
+		$store->expects( $this->atLeastOnce() )
+			->method( 'getPropertyValues' )
+			->will( $this->returnValue( array( $this->dataItemFactory->newDIBlob( 'Bar;Foobar' ) ) ) );
+
+		$store->expects( $this->any() )
+			->method( 'getRedirectTarget' )
+			->will( $this->returnArgument( 0 ) );
+
+		$this->testEnvironment->registerObject( 'Store', $store );
+
+		$instance = new ReferenceValue();
+		$instance->setProperty(
+			$this->dataItemFactory->newDIProperty( 'Foo' )
+		);
+
+		$instance->setUserValue( '123;abc' );
+		$container = $instance->getDataItem();
+
+		$this->assertInstanceOf(
+			'\SMWDIContainer',
+			$container
+		);
+
+		$semanticData = $container->getSemanticData();
+
+		$this->assertTrue(
+			$semanticData->hasProperty( $this->dataItemFactory->newDIProperty( 'Foobar' ) )
+		);
+	}
+
+	public function testParseValueOnMissingValues() {
+
+		$instance = new ReferenceValue();
+		$instance->setProperty(
+			$this->dataItemFactory->newDIProperty( 'Foo' )
+		);
+
+		$instance->setUserValue( '' );
+
+		$this->assertInstanceOf(
+			'\SMWDIError',
+			$instance->getDataItem()
+		);
+	}
+
+	public function testParseValueWithErroredDv() {
+
+		$store = $this->getMockBuilder( '\SMW\Store' )
+			->disableOriginalConstructor()
+			->setMethods( array( 'getRedirectTarget' ) )
+			->getMockForAbstractClass();
+
+		$store->expects( $this->atLeastOnce() )
+			->method( 'getPropertyValues' )
+			->will( $this->returnValue( array( $this->dataItemFactory->newDIBlob( 'Bar;Foobar' ) ) ) );
+
+		$store->expects( $this->any() )
+			->method( 'getRedirectTarget' )
+			->will( $this->returnArgument( 0 ) );
+
+		$this->testEnvironment->registerObject( 'Store', $store );
+
+		$instance = new ReferenceValue();
+		$instance->setProperty(
+			$this->dataItemFactory->newDIProperty( 'Foo' )
+		);
+
+		$instance->setUserValue( 'Foo;<>Foo' );
+
+		$this->assertInstanceOf(
+			'\SMWDIError',
+			$instance->getDataItem()
+		);
+
+		$this->assertEquals(
+			array( '[2,"smw-datavalue-wikipage-invalid-title","<>Foo"]' ),
+			$instance->getErrors()
+		);
+	}
+
+	public function testGetValuesFromStringWithEncodedSemicolon() {
+
+		$instance = new ReferenceValue();
+
+		$this->assertEquals(
+			array( 'abc', '1;2', 3 ),
+			$instance->getValuesFromString( 'abc;1\;2;3' )
+		);
+	}
+
+}

--- a/tests/phpunit/Unit/DataValues/ValueFormatters/ReferenceValueFormatterTest.php
+++ b/tests/phpunit/Unit/DataValues/ValueFormatters/ReferenceValueFormatterTest.php
@@ -1,0 +1,152 @@
+<?php
+
+namespace SMW\Tests\DataValues\ValueFormatters;
+
+use SMW\DataValues\ReferenceValue;
+use SMW\DataValues\ValueFormatters\ReferenceValueFormatter;
+use SMW\DataItemFactory;
+use SMW\Tests\TestEnvironment;
+
+/**
+ * @covers \SMW\DataValues\ValueFormatters\ReferenceValueFormatter
+ * @group semantic-mediawiki
+ *
+ * @license GNU GPL v2+
+ * @since 2.5
+ *
+ * @author mwjames
+ */
+class ReferenceValueFormatterTest extends \PHPUnit_Framework_TestCase {
+
+	private $testEnvironment;
+	private $dataItemFactory;
+
+	protected function setUp() {
+		parent::setUp();
+
+		$this->testEnvironment = new TestEnvironment();
+		$this->dataItemFactory = new DataItemFactory();
+
+		$this->propertySpecificationLookup = $this->getMockBuilder( '\SMW\PropertySpecificationLookup' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$this->testEnvironment->registerObject( 'PropertySpecificationLookup', $this->propertySpecificationLookup );
+	}
+
+	protected function tearDown() {
+		$this->testEnvironment->tearDown();
+		parent::tearDown();
+	}
+
+	public function testCanConstruct() {
+
+		$this->assertInstanceOf(
+			'\SMW\DataValues\ValueFormatters\ReferenceValueFormatter',
+			new ReferenceValueFormatter()
+		);
+	}
+
+	public function testIsFormatterForValidation() {
+
+		$referenceValue = $this->getMockBuilder( '\SMW\DataValues\ReferenceValue' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$instance = new ReferenceValueFormatter();
+
+		$this->assertTrue(
+			$instance->isFormatterFor( $referenceValue )
+		);
+	}
+
+	public function testToUseCaptionOutput() {
+
+		$referenceValue = new ReferenceValue();
+		$referenceValue->setCaption( 'ABC' );
+
+		$instance = new ReferenceValueFormatter( $referenceValue );
+
+		$this->assertEquals(
+			'ABC',
+			$instance->format( ReferenceValueFormatter::WIKI_SHORT )
+		);
+
+		$this->assertEquals(
+			'ABC',
+			$instance->format( ReferenceValueFormatter::HTML_SHORT )
+		);
+	}
+
+	/**
+	 * @dataProvider stringValueProvider
+	 */
+	public function testFormat( $suserValue, $type, $linker, $expected ) {
+
+		$referenceValue = new ReferenceValue();
+
+		$referenceValue->setFieldProperties( array(
+			$this->dataItemFactory->newDIProperty( 'Foo' ),
+			$this->dataItemFactory->newDIProperty( 'Bar' ),
+			$this->dataItemFactory->newDIProperty( 'Foobar' )
+		) );
+
+		$referenceValue->setUserValue( $suserValue );
+
+		$instance = new ReferenceValueFormatter( $referenceValue );
+
+		$this->assertEquals(
+			$expected,
+			$instance->format( $type, $linker )
+		);
+	}
+
+	public function testTryToFormatOnMissingDataValueThrowsException() {
+
+		$instance = new ReferenceValueFormatter();
+
+		$this->setExpectedException( 'RuntimeException' );
+		$instance->format( ReferenceValueFormatter::VALUE );
+	}
+
+	public function stringValueProvider() {
+
+		$provider[] = array(
+			'abc;12;3',
+			ReferenceValueFormatter::VALUE,
+			null,
+			'Abc;12;3'
+		);
+
+		$provider[] = array(
+			'abc',
+			ReferenceValueFormatter::WIKI_SHORT,
+			null,
+			'Abc<span class="smw-reference smw-reference-indicator smw-highlighter smwttinline" data-title="Reference" data-content="&lt;ul&gt;&lt;li&gt;Bar: ?&lt;/li&gt;&lt;li&gt;Foobar: ?&lt;/li&gt;&lt;/ul&gt;" title="Bar: ?, Foobar: ?"></span>'
+		);
+
+		$provider[] = array(
+			'abc',
+			ReferenceValueFormatter::HTML_SHORT,
+			null,
+			'Abc<span class="smw-reference smw-reference-indicator smw-highlighter smwttinline" data-title="Reference" data-content="&lt;ul&gt;&lt;li&gt;Bar: ?&lt;/li&gt;&lt;li&gt;Foobar: ?&lt;/li&gt;&lt;/ul&gt;" title="Bar: ?, Foobar: ?"></span>'
+		);
+
+		$provider[] = array(
+			'abc',
+			ReferenceValueFormatter::WIKI_LONG,
+			null,
+			'Abc<span class="smw-reference smw-reference-indicator smw-highlighter smwttinline" data-title="Reference" data-content="&lt;ul&gt;&lt;li&gt;Bar: ?&lt;/li&gt;&lt;li&gt;Foobar: ?&lt;/li&gt;&lt;/ul&gt;" title="Bar: ?, Foobar: ?"></span>'
+		);
+
+		$provider[] = array(
+			'abc',
+			ReferenceValueFormatter::HTML_LONG,
+			null,
+			'Abc<span class="smw-reference smw-reference-indicator smw-highlighter smwttinline" data-title="Reference" data-content="&lt;ul&gt;&lt;li&gt;Bar: ?&lt;/li&gt;&lt;li&gt;Foobar: ?&lt;/li&gt;&lt;/ul&gt;" title="Bar: ?, Foobar: ?"></span>'
+		);
+
+		return $provider;
+	}
+
+}

--- a/tests/phpunit/Unit/PropertyRegistryTest.php
+++ b/tests/phpunit/Unit/PropertyRegistryTest.php
@@ -464,4 +464,49 @@ class PropertyRegistryTest extends \PHPUnit_Framework_TestCase {
 		);
 	}
 
+	public function testDataTypePropertyExemptionList() {
+
+		$datatypeRegistry = $this->getMockBuilder( '\SMW\DataTypeRegistry' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$datatypeRegistry->expects( $this->once() )
+			->method( 'getKnownTypeLabels' )
+			->will( $this->returnValue( array( '_foo' => 'Foo', '_foobar' => 'Foobar' ) ) );
+
+		$datatypeRegistry->expects( $this->once() )
+			->method( 'getKnownTypeAliases' )
+			->will( $this->returnValue( array( 'Bar' => '_bar' ) ) );
+
+		$store = $this->getMockBuilder( '\SMW\Store' )
+			->disableOriginalConstructor()
+			->getMockForAbstractClass();
+
+		$propertyLabelFinder = new PropertyLabelFinder( $store, array() );
+
+		$propertyAliases = new PropertyAliasFinder();
+
+		$dataTypePropertyExemptionList = array( 'Foo', 'Bar' );
+
+		$instance = new PropertyRegistry(
+			$datatypeRegistry,
+			$propertyLabelFinder,
+			$propertyAliases,
+			$dataTypePropertyExemptionList
+		);
+
+		$this->assertEquals(
+			'_foobar',
+			$instance->findPropertyIdByLabel( 'Foobar' )
+		);
+
+		$this->assertFalse(
+			$instance->findPropertyIdByLabel( 'Foo' )
+		);
+
+		$this->assertFalse(
+			$instance->findPropertyIdByLabel( 'Bar' )
+		);
+	}
+
 }


### PR DESCRIPTION
This PR is made in reference to: #1808

This PR addresses or contains:

- `ReferenceValue` and `ReferenceValueFormatter`
- `smwgDataTypePropertyExemptionList` to exclude listed `DataType`'s from being registered as property. In case of `Reference` the use as property to match the `DataType` semantics is of no help since the definition requires `Has fields` and it is expected that the `Reference` name to be a common property name hence we refrain from using it unless in a `DataType` context.

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed

