### PR TITLE
Add Localizer::getCanonicalizedUrlByNamespace, refs #1778

### DIFF
--- a/includes/export/SMW_Exporter.php
+++ b/includes/export/SMW_Exporter.php
@@ -4,6 +4,7 @@ use SMW\ApplicationFactory;
 use SMW\DataTypeRegistry;
 use SMW\DataValueFactory;
 use SMW\DIProperty;
+use SMW\Localizer;
 use SMW\NamespaceUriFinder;
 use SMW\Exporter\DataItemByExpElementMatchFinder;
 use SMW\Exporter\DataItemToElementEncoder;
@@ -148,10 +149,12 @@ class SMWExporter {
 		// Canonical form, the title object always contains a wgContLang reference
 		// therefore replace it
 		if ( !$GLOBALS['smwgExportBCNonCanonicalFormUse'] ) {
-			$special = wfUrlencode( '/' . $wgContLang->getNsText( NS_SPECIAL ) .':' );
+			$localizer = Localizer::getInstance();
 
-			self::$m_ent_wiki = str_replace( $special , '/Special:', self::$m_ent_wiki );
-			self::$m_exporturl = str_replace( $special , '/Special:', self::$m_exporturl );
+			self::$m_ent_property = $localizer->getCanonicalizedUrlByNamespace( NS_SPECIAL, self::$m_ent_property );
+			self::$m_ent_category = $localizer->getCanonicalizedUrlByNamespace( NS_SPECIAL, self::$m_ent_category );
+			self::$m_ent_wiki = $localizer->getCanonicalizedUrlByNamespace( NS_SPECIAL, self::$m_ent_wiki );
+			self::$m_exporturl = $localizer->getCanonicalizedUrlByNamespace( NS_SPECIAL, self::$m_exporturl );
 		}
 	}
 

--- a/src/Localizer.php
+++ b/src/Localizer.php
@@ -219,6 +219,28 @@ class Localizer {
 	}
 
 	/**
+	 * @since 2.5
+	 *
+	 * @param integer $ns
+	 * @param string $url
+	 *
+	 * @return string
+	 */
+	public function getCanonicalizedUrlByNamespace( $ns, $url ) {
+
+		$namespace = $this->getNamespaceTextById( $ns );
+
+		return str_replace(
+			array(
+				wfUrlencode( '/' . $namespace .':' ),
+				'/' . $namespace .':'
+			),
+			'/' . \MWNamespace::getCanonicalName( $ns ) . ':',
+			$url
+		);
+	}
+
+	/**
 	 * @since 2.4
 	 *
 	 * @param string &$value

--- a/tests/phpunit/Unit/LocalizerTest.php
+++ b/tests/phpunit/Unit/LocalizerTest.php
@@ -268,4 +268,27 @@ class LocalizerTest extends \PHPUnit_Framework_TestCase {
 		);
 	}
 
+	public function testGetCanonicalizedUrlByNamespace() {
+
+		$language = $this->getMockBuilder( '\Language' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$language->expects( $this->exactly( 2 ) )
+			->method( 'getNsText' )
+			->will( $this->returnValue( 'Spécial' ) );
+
+		$instance = new Localizer( $language );
+
+		$this->assertEquals(
+			'http://example.org/wiki/Special:URIResolver/Property-3AHas_query',
+			$instance->getCanonicalizedUrlByNamespace( NS_SPECIAL, 'http://example.org/wiki/Sp%C3%A9cial:URIResolver/Property-3AHas_query' )
+		);
+
+		$this->assertEquals(
+			'http://example.org/wiki/Special:URIResolver/Property-3AHas_query',
+			$instance->getCanonicalizedUrlByNamespace( NS_SPECIAL, 'http://example.org/wiki/Spécial:URIResolver/Property-3AHas_query' )
+		);
+	}
+
 }


### PR DESCRIPTION
This PR is made in reference to: #1778

This PR addresses or contains:

- Provides a method to output a canonicalized url which is required by the `RDF` export.

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed

