### PR TITLE
Add MonolingualTextPropertyValueResourceBuilder, refs #1344, #1780

### DIFF
--- a/includes/export/SMW_Exporter.php
+++ b/includes/export/SMW_Exporter.php
@@ -13,7 +13,7 @@ use SMW\Exporter\Element\ExpElement;
 use SMW\Exporter\Element\ExpLiteral;
 use SMW\Exporter\Element\ExpNsResource;
 use SMW\Exporter\Escaper;
-use SMW\Exporter\DispatchingResourceBuilder;
+use SMW\Exporter\ResourceBuilders\DispatchingResourceBuilder;
 
 /**
  * SMWExporter is a class for converting internal page-based data (SMWSemanticData) into

--- a/includes/export/SMW_Serializer_RDFXML.php
+++ b/includes/export/SMW_Serializer_RDFXML.php
@@ -180,11 +180,20 @@ class SMWRDFXMLSerializer extends SMWSerializer{
 	 */
 	protected function serializeExpLiteral( SMWExpNsResource $expResourceProperty, SMWExpLiteral $expLiteral, $indent ) {
 		$this->post_ns_buffer .= $indent . '<' . $expResourceProperty->getQName();
-		if ( $expLiteral->getDatatype() !== '' ) {
+
+		// https://www.w3.org/TR/rdf-syntax-grammar/#section-Syntax-languages
+		// "... to indicate that the included content is in the given language.
+		// Typed literals which includes XML literals are not affected by this
+		// attribute. The most specific in-scope language present (if any) is
+		// applied to property element string literal ..."
+		if ( $expLiteral->getDatatype() !== '' && $expLiteral->getLang() !== '' ) {
+			$this->post_ns_buffer .= ' xml:lang="' . $expLiteral->getLang() . '"';
+		} elseif ( $expLiteral->getDatatype() !== '' ) {
 			$this->post_ns_buffer .= ' rdf:datatype="' . $expLiteral->getDatatype() . '"';
 		}
-		$this->post_ns_buffer .= '>' . $this->makeAttributeValueString( $expLiteral->getLexicalForm() ) .
-			'</' . $expResourceProperty->getQName() . ">\n";
+
+		$this->post_ns_buffer .= '>' . $this->makeAttributeValueString( $expLiteral->getLexicalForm() );
+		$this->post_ns_buffer .= '</' . $expResourceProperty->getQName() . ">\n";
 	}
 
 	/**

--- a/includes/export/SMW_Serializer_Turtle.php
+++ b/includes/export/SMW_Serializer_Turtle.php
@@ -261,18 +261,34 @@ class SMWTurtleSerializer extends SMWSerializer{
 				return '<' . str_replace( '>', '\>', SMWExporter::getInstance()->expandURI( $expElement->getUri() ) ) . '>';
 			}
 		} elseif ( $expElement instanceof SMWExpLiteral ) {
-			$lexicalForm = '"' . str_replace( array( '\\', "\n", '"' ), array( '\\\\', "\\n", '\"' ), $expElement->getLexicalForm() ) . '"';
-			$dt = $expElement->getDatatype();
-			if ( ( $dt !== '' ) && ( $dt != 'http://www.w3.org/2001/XMLSchema#string' ) ) {
+			$dataType = $expElement->getDatatype();
+			$lexicalForm = self::getCorrectLexicalForm( $expElement );
+
+			if ( ( $dataType !== '' ) && ( $dataType != 'http://www.w3.org/2001/XMLSchema#string' ) ) {
 				$count = 0;
-				$newdt = str_replace( 'http://www.w3.org/2001/XMLSchema#', 'xsd:', $dt, $count );
-				return ( $count == 1 ) ? "$lexicalForm^^$newdt" : "$lexicalForm^^<$dt>";
+				$newdt = str_replace( 'http://www.w3.org/2001/XMLSchema#', 'xsd:', $dataType, $count );
+				return ( $count == 1 ) ? "$lexicalForm^^$newdt" : "$lexicalForm^^<$dataType>";
 			} else {
 				return $lexicalForm;
 			}
 		} else {
 			throw new InvalidArgumentException( 'The method can only serialize atomic elements of type SMWExpResource or SMWExpLiteral.' );
 		}
+	}
+
+	private static function getCorrectLexicalForm( $expElement ) {
+
+		$lexicalForm = str_replace( array( '\\', "\n", '"' ), array( '\\\\', "\\n", '\"' ), $expElement->getLexicalForm() );
+
+		if ( $expElement->getLang() !== '' && ( $expElement->getDatatype() === 'http://www.w3.org/1999/02/22-rdf-syntax-ns#langString' ) ) {
+			$lexicalForm = '"' . $lexicalForm . '@' . $expElement->getLang() . '"';
+		} elseif ( $expElement->getLang() !== '' ) {
+			$lexicalForm = '"' . $lexicalForm . '"'. '@' . $expElement->getLang();
+		} else {
+			$lexicalForm = '"' . $lexicalForm . '"';
+		}
+
+		return $lexicalForm;
 	}
 
 }

--- a/src/Exporter/Element/ExpLiteral.php
+++ b/src/Exporter/Element/ExpLiteral.php
@@ -59,8 +59,7 @@ class ExpLiteral extends ExpElement {
 			throw new InvalidArgumentException( '$datatype needs to be a string' );
 		}
 
-		// http://www.w3.org/TR/rdf11-concepts/#section-Graph-Literal
-		if ( !is_string( $lang ) || ( $lang !== '' && $datatype !== 'http://www.w3.org/1999/02/22-rdf-syntax-ns#langString' ) ) {
+		if ( !is_string( $lang )  ) {
 			throw new InvalidArgumentException( '$lang needs to be a string and $datatype has to be of langString type' );
 		}
 
@@ -68,7 +67,17 @@ class ExpLiteral extends ExpElement {
 
 		$this->lexicalForm = $lexicalForm;
 		$this->datatype = $datatype;
-		$this->lang = $lang;
+
+		// 'http://www.w3.org/1999/02/22-rdf-syntax-ns#langString'
+		// can also be used instead of the simple Foo@lang-tag convention
+
+		// https://www.w3.org/TR/2004/REC-rdf-concepts-20040210/#dfn-language-identifier
+		// "...Plain literals have a lexical form and optionally a language tag as
+		// defined by [RFC-3066], normalized to lowercase..."
+		// https://www.w3.org/TR/rdf11-concepts/#section-Graph-Literal
+		// "...Lexical representations of language tags may be converted to
+		// lower case. The value space of language tags is always in lower case..."
+		$this->lang = strtolower( $lang );
 	}
 
 	/**

--- a/src/Exporter/ResourceBuilders/DispatchingResourceBuilder.php
+++ b/src/Exporter/ResourceBuilders/DispatchingResourceBuilder.php
@@ -1,15 +1,9 @@
 <?php
 
-namespace SMW\Exporter;
+namespace SMW\Exporter\ResourceBuilders;
 
-use SMW\Exporter\ResourceBuilders\PropertyValueResourceBuilder;
-use SMW\Exporter\ResourceBuilders\ConceptPropertyValueResourceBuilder;
-use SMW\Exporter\ResourceBuilders\ImportFromPropertyValueResourceBuilder;
-use SMW\Exporter\ResourceBuilders\PredefinedPropertyValueResourceBuilder;
-use SMW\Exporter\ResourceBuilders\RedirectPropertyValueResourceBuilder;
-use SMW\Exporter\ResourceBuilders\AuxiliaryPropertyValueResourceBuilder;
-use SMW\Exporter\ResourceBuilders\ExternalIdentifierPropertyValueResourceBuilder;
 use SMW\DIProperty;
+use SMW\Exporter\ResourceBuilder;
 use SMWDataItem as DataItem;
 use SMWExpData as ExpData;
 
@@ -107,6 +101,7 @@ class DispatchingResourceBuilder implements ResourceBuilder {
 	private function initResourceBuilders() {
 
 		$this->addResourceBuilder( new ExternalIdentifierPropertyValueResourceBuilder() );
+		$this->addResourceBuilder( new MonolingualTextPropertyValueResourceBuilder() );
 
 		$this->addResourceBuilder( new ConceptPropertyValueResourceBuilder() );
 		$this->addResourceBuilder( new ImportFromPropertyValueResourceBuilder() );

--- a/src/Exporter/ResourceBuilders/MonolingualTextPropertyValueResourceBuilder.php
+++ b/src/Exporter/ResourceBuilders/MonolingualTextPropertyValueResourceBuilder.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace SMW\Exporter\ResourceBuilders;
+
+use SMW\DIProperty;
+use SMW\DataValueFactory;
+use SMWDataItem as DataItem;
+use SMWExpData as ExpData;
+use SMWExpLiteral as ExpLiteral;
+
+/**
+ * @private
+ *
+ * @license GNU GPL v2+
+ * @since 2.5
+ *
+ * @author mwjames
+ */
+class MonolingualTextPropertyValueResourceBuilder extends PropertyValueResourceBuilder {
+
+	/**
+	 * @since 2.5
+	 *
+	 * {@inheritDoc}
+	 */
+	public function isResourceBuilderFor( DIProperty $property ) {
+		return $property->findPropertyTypeID() === '_mlt_rec';
+	}
+
+	/**
+	 * @since 2.5
+	 *
+	 * {@inheritDoc}
+	 */
+	public function addResourceValue( ExpData $expData, DIProperty $property, DataItem $dataItem ) {
+
+		parent::addResourceValue( $expData, $property, $dataItem );
+
+		$dataValue = DataValueFactory::getInstance()->newDataValueByItem(
+			$dataItem,
+			$property
+		);
+
+		$list = $dataValue->toArray();
+
+		if ( !isset( $list['_TEXT'] ) || !isset( $list['_LCODE'] ) ) {
+			return;
+		}
+
+		$expData->addPropertyObjectValue(
+			$this->exporter->getResourceElementForWikiPage( $property->getCanonicalDiWikiPage(), true ),
+			new ExpLiteral(
+				(string)$list['_TEXT'],
+				'http://www.w3.org/2001/XMLSchema#string',
+				(string)$list['_LCODE'],
+				$dataItem
+			)
+		);
+	}
+
+}

--- a/tests/phpunit/Integration/ByJsonScript/Fixtures/r-0009.json
+++ b/tests/phpunit/Integration/ByJsonScript/Fixtures/r-0009.json
@@ -21,6 +21,8 @@
 			"expected-output": {
 				"to-contain": [
 					"<owl:DatatypeProperty rdf:about=\"http://example.org/id/Property-3AHas_number\">",
+					"<property:Has_property_description-23aux xml:lang=\"en\">Is a number</property:Has_property_description-23aux>",
+					"<property:Has_property_description-23aux xml:lang=\"ja\">数</property:Has_property_description-23aux>",
 					"<property:Has_property_description rdf:resource=\"http://example.org/id/Property-3AHas_number-23_ML13b181afba7d1e489a656a75fa7917b2\"/>",
 					"<property:Has_property_description rdf:resource=\"http://example.org/id/Property-3AHas_number-23_ML4c33eabf5c7dfbb1292c817504951018\"/>",
 					"<swivt:Subject rdf:about=\"http://example.org/id/Property-3AHas_number-23_ML13b181afba7d1e489a656a75fa7917b2\">",
@@ -46,6 +48,7 @@
 			"expected-output": {
 				"to-contain": [
 					"rdfs:label  \"Has number\" ;",
+					"property:Has_property_description-23aux  \"Is a number\"@en ,  \"数\"@ja ;",
 					"property:Has_property_description  property:Has_number-23_ML13b181afba7d1e489a656a75fa7917b2 ,  property:Has_number-23_ML4c33eabf5c7dfbb1292c817504951018 ;",
 					"swivt:wikiPageSortKey  \"Has number\" ;",
 					"swivt:type  <http://semantic-mediawiki.org/swivt/1.0#_num> .",

--- a/tests/phpunit/Unit/DataValues/MonolingualTextValueTest.php
+++ b/tests/phpunit/Unit/DataValues/MonolingualTextValueTest.php
@@ -147,4 +147,18 @@ class MonolingualTextValueTest extends \PHPUnit_Framework_TestCase {
 		);
 	}
 
+	public function testToArray() {
+
+		$instance = new MonolingualTextValue();
+		$instance->setUserValue( 'Foo@en' );
+
+		$this->assertEquals(
+			array(
+				'_TEXT'  => 'Foo',
+				'_LCODE' => 'en'
+			),
+			$instance->toArray()
+		);
+	}
+
 }

--- a/tests/phpunit/Unit/Exporter/ResourceBuilders/DispatchingResourceBuilderTest.php
+++ b/tests/phpunit/Unit/Exporter/ResourceBuilders/DispatchingResourceBuilderTest.php
@@ -1,13 +1,13 @@
 <?php
 
-namespace SMW\Tests\Exporter;
+namespace SMW\Tests\Exporter\ResourceBuilders;
 
-use SMW\Exporter\DispatchingResourceBuilder;
+use SMW\Exporter\ResourceBuilders\DispatchingResourceBuilder;
 use SMW\Exporter\ResourceBuilder;
 use SMW\DataItemFactory;
 
 /**
- * @covers \SMW\Exporter\DispatchingResourceBuilder
+ * @covers \SMW\Exporter\ResourceBuilders\DispatchingResourceBuilder
  * @group semantic-mediawiki
  *
  * @license GNU GPL v2+

--- a/tests/phpunit/Unit/Exporter/ResourceBuilders/MonolingualTextPropertyValueResourceBuilderTest.php
+++ b/tests/phpunit/Unit/Exporter/ResourceBuilders/MonolingualTextPropertyValueResourceBuilderTest.php
@@ -1,0 +1,87 @@
+<?php
+
+namespace SMW\Tests\Exporter\ResourceBuilders;
+
+use SMW\Exporter\ResourceBuilders\MonolingualTextPropertyValueResourceBuilder;
+use SMW\DataItemFactory;
+use SMW\DataValueFactory;
+use SMW\Tests\TestEnvironment;
+use SMWExpData as ExpData;
+use SMW\Exporter\Element\ExpNsResource;
+
+/**
+ * @covers \SMW\Exporter\ResourceBuilders\MonolingualTextPropertyValueResourceBuilder
+ * @group semantic-mediawiki
+ *
+ * @license GNU GPL v2+
+ * @since 2.5
+ *
+ * @author mwjames
+ */
+class MonolingualTextPropertyValueResourceBuilderTest extends \PHPUnit_Framework_TestCase {
+
+	private $dataItemFactory;
+	private $dataValueFactory;
+	private $testEnvironment;
+
+	protected function setUp() {
+		parent::setUp();
+		$this->dataItemFactory = new DataItemFactory();
+		$this->dataValueFactory = DataValueFactory::getInstance();
+
+		$this->testEnvironment = new TestEnvironment();
+		$this->testEnvironment->resetPoolCacheFor( \SMWExporter::POOLCACHE_ID );
+	}
+
+	protected function tearDown() {
+		$this->testEnvironment->tearDown();
+		parent::tearDown();
+	}
+
+	public function testCanConstruct() {
+
+		$this->assertInstanceof(
+			MonolingualTextPropertyValueResourceBuilder::class,
+			new MonolingualTextPropertyValueResourceBuilder()
+		);
+	}
+
+	public function testIsNotResourceBuilderForNonExternalIdentifierTypedProperty() {
+
+		$property = $this->dataItemFactory->newDIProperty( 'Foo' );
+
+		$instance = new MonolingualTextPropertyValueResourceBuilder();
+
+		$this->assertFalse(
+			$instance->isResourceBuilderFor( $property )
+		);
+	}
+
+	public function testAddResourceValueForValidProperty() {
+
+		$property = $this->dataItemFactory->newDIProperty( 'Foo' );
+		$property->setPropertyTypeId( '_mlt_rec' );
+
+		$monolingualTextValue = $this->dataValueFactory->newDataValueByProperty(
+			$property,
+			'Bar@en'
+		);
+
+		$expData = new ExpData(
+			new ExpNsResource( 'Foobar', 'Bar', 'Mo', null )
+		);
+
+		$instance = new MonolingualTextPropertyValueResourceBuilder();
+
+		$instance->addResourceValue(
+			$expData,
+			$property,
+			$monolingualTextValue->getDataItem()
+		);
+
+		$this->assertTrue(
+			$instance->isResourceBuilderFor( $property )
+		);
+	}
+
+}


### PR DESCRIPTION
This PR is made in reference to: #1344, #1780

This PR addresses or contains:

- Enables a `Monolingual text` value to be exported as `aux` statement in form of `<property:Has_property_description-23aux xml:lang="en">Used for ... </property:Has_property_description-23aux>`

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed

