### PR TITLE
Mark a query context to avoid constraint validation

### DIFF
--- a/includes/datavalues/SMW_DV_URI.php
+++ b/includes/datavalues/SMW_DV_URI.php
@@ -143,7 +143,7 @@ class SMWURIValue extends SMWDataValue {
 					$hierpart = '+' . substr( $hierpart, 2 );
 				}
 
-				if ( !$this->getOptionValueFor( 'description.processor' ) && ( ( strlen( preg_replace( '/[^0-9]/', '', $hierpart ) ) < 6 ) ||
+				if ( !$this->getOptionValueFor( self::OPT_QUERY_CONTEXT ) && ( ( strlen( preg_replace( '/[^0-9]/', '', $hierpart ) ) < 6 ) ||
 					( preg_match( '<[-+./][-./]>', $hierpart ) ) ||
 					( !self::isValidTelURI( 'tel:' . $hierpart ) ) ) ) { /// TODO: introduce error-message for "bad" phone number
 					$this->addErrorMsg( array( 'smw_baduri', $this->m_wikitext ) );
@@ -157,7 +157,7 @@ class SMWURIValue extends SMWDataValue {
 					$this->m_wikitext = $value;
 				}
 
-				if ( !$this->getOptionValueFor( 'description.processor' ) && !Sanitizer::validateEmail( $value ) ) {
+				if ( !$this->getOptionValueFor( self::OPT_QUERY_CONTEXT ) && !Sanitizer::validateEmail( $value ) ) {
 					/// TODO: introduce error-message for "bad" email
 					$this->addErrorMsg( array( 'smw_baduri', $value ) );
 					return;

--- a/includes/datavalues/SMW_DataValue.php
+++ b/includes/datavalues/SMW_DataValue.php
@@ -47,8 +47,22 @@ use SMW\Query\QueryComparator;
  */
 abstract class SMWDataValue {
 
+	/**
+	 * Contains the user language a user operates in.
+	 */
 	const OPT_USER_LANGUAGE = 'user.language';
+
+	/**
+	 * Contains either the global "site" content language or a specified page
+	 * content language invoked by the context page.
+	 */
 	const OPT_CONTENT_LANGUAGE = 'content.language';
+
+	/**
+	 * Describes a state where a DataValue is part of a query condition and may
+	 * (or not) require a different treatment.
+	 */
+	const OPT_QUERY_CONTEXT = 'query.context';
 
 	/**
 	 * Associated data item. This is the reference to the immutable object
@@ -181,7 +195,7 @@ abstract class SMWDataValue {
 			$this->addErrorMsg( array( 'smw-datavalue-stripmarker-parse-error', $value ) );
 		}
 
-		if ( $this->isValid() && !$approximateValue ) {
+		if ( $this->isValid() && !$approximateValue && !$this->getOptionValueFor( self::OPT_QUERY_CONTEXT ) ) {
 			$this->checkAllowedValues();
 		}
 

--- a/src/Query/Parser/DescriptionProcessor.php
+++ b/src/Query/Parser/DescriptionProcessor.php
@@ -3,6 +3,7 @@
 namespace SMW\Query\Parser;
 
 use SMW\DataValueFactory;
+use SMWDataValue as DataValue;
 use SMW\DIProperty;
 use SMW\DIWikiPage;
 use SMW\Message;
@@ -114,7 +115,7 @@ class DescriptionProcessor {
 
 		// Indicates whether a value is being used by a query condition or not which
 		// can lead to a modified validation of a value.
-		$dataValue->setOption( 'description.processor', true );
+		$dataValue->setOption( DataValue::OPT_QUERY_CONTEXT, true );
 
 		$description = $dataValue->getQueryDescription( $chunk );
 		$this->addError( $dataValue->getErrors() );

--- a/tests/phpunit/Integration/ByJsonScript/Fixtures/p-0419.json
+++ b/tests/phpunit/Integration/ByJsonScript/Fixtures/p-0419.json
@@ -1,5 +1,5 @@
 {
-	"description": "Test in-text annotation for `PRUC` to validate uniqueness (`smwgDVFeatures`)",
+	"description": "Test in-text annotation for `_PVUC` to validate uniqueness (`smwgDVFeatures`)",
 	"properties": [
 		{
 			"name": "Has Url",

--- a/tests/phpunit/Integration/ByJsonScript/Fixtures/q-1108.json
+++ b/tests/phpunit/Integration/ByJsonScript/Fixtures/q-1108.json
@@ -1,0 +1,102 @@
+{
+	"description": "Test conditions and constraint validations for allowed values `_LIST` and uniqueness `_PVUC` (#1207, `wgContLang=en`, `wgLang=en`)",
+	"properties": [
+		{
+			"name": "Has text",
+			"contents": "[[Has type::Text]] [[Allows value::open]], [[Allows value::closed]]"
+		},
+		{
+			"name": "Has uniqueness",
+			"contents": "[[Has type::Text]] [[Has uniqueness constraint::true]]"
+		}
+	],
+	"subjects": [
+		{
+			"name": "Example/Q1108/1",
+			"contents": "[[Category:Q1108]][[Has text::open]]"
+		},
+		{
+			"name": "Example/Q1108/2",
+			"contents": "[[Category:Q1108]][[Has text::close]]"
+		},
+		{
+			"name": "Example/Q1108/3",
+			"contents": "[[Category:Q1108]][[Has text::invalid]]"
+		},
+		{
+			"name": "Example/Q1108/4",
+			"contents": "[[Category:Q1108]] [[Has uniqueness::Foo]]"
+		},
+		{
+			"name": "Example/Q1108/5",
+			"contents": "[[Category:Q1108]] [[Has uniqueness::Foo]]"
+		},
+		{
+			"name": "Example/Q1108/Q1",
+			"contents": "{{#ask: [[Category:Q1108]] [[Has uniqueness::Foo]] |link=none}}"
+		}
+	],
+	"query-testcases": [
+		{
+			"about": "#0 matches one with open",
+			"condition": "[[Category:Q1108]][[Has text::open]]",
+			"printouts" : [],
+			"parameters" : {
+				"limit" : 10
+			},
+			"queryresult": {
+				"count": 1,
+				"results": [
+					"Example/Q1108/1#0##"
+				]
+			}
+		},
+		{
+			"about": "#1 matches none",
+			"condition": "[[Category:Q1108]][[Has text::invalid]]",
+			"printouts" : [],
+			"parameters" : {
+				"limit" : 10
+			},
+			"queryresult": {
+				"count": 0,
+				"results": []
+			}
+		},
+		{
+			"about": "#2",
+			"condition": "[[Category:Q1108]] [[Has uniqueness::Foo]]",
+			"printouts" : [],
+			"parameters" : {
+				"limit" : 10
+			},
+			"queryresult": {
+				"count": 1,
+				"results": [
+					"Example/Q1108/4#0##"
+				]
+			}
+		}
+	],
+	"parser-testcases": [
+		{
+			"about": "#3 embedded query with uniqueness condition works without raising an issue due to different context page",
+			"subject": "Example/Q1108/Q1",
+			"expected-output": {
+				"to-contain": [
+					"Example/Q1108/4"
+				]
+			}
+		}
+	],
+	"settings": {
+		"smwgDVFeatures": [ "SMW_DV_PVUC" ],
+		"wgContLang": "en",
+		"wgLang": "en"
+	},
+	"meta": {
+		"version": "0.1",
+		"is-incomplete": false,
+		"debug": false
+	}
+}


### PR DESCRIPTION
This PR is made in reference to: # N/A

This PR addresses or contains:

- Indicate a query context to avoid constraint validation in those cases
- In response to http://wikimedia.7.x6.nabble.com/Is-this-a-feature-or-a-bug-td5066080.html

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed

