### PR TITLE
ResultArray clean-up

### DIFF
--- a/includes/storage/SMW_QueryResult.php
+++ b/includes/storage/SMW_QueryResult.php
@@ -3,7 +3,7 @@
 use SMW\HashBuilder;
 use SMW\Query\PrintRequest;
 use SMW\Query\QueryLinker;
-use SMW\Query\TemporaryEntityListAccumulator;
+use SMW\Query\Result\EntityListAccumulator;
 use SMW\SerializerFactory;
 
 /**
@@ -71,9 +71,9 @@ class SMWQueryResult {
 	private $isFromCache = false;
 
 	/**
-	 * @var TemporaryEntityListAccumulator
+	 * @var EntityListAccumulator
 	 */
-	private $temporaryEntityListAccumulator;
+	private $entityListAccumulator;
 
 	/**
 	 * Initialise the object with an array of SMWPrintRequest objects, which
@@ -94,16 +94,16 @@ class SMWQueryResult {
 		$this->mFurtherResults = $furtherRes;
 		$this->mQuery = $query;
 		$this->mStore = $store;
-		$this->temporaryEntityListAccumulator = new TemporaryEntityListAccumulator( $query );
+		$this->entityListAccumulator = new EntityListAccumulator( $query );
 	}
 
 	/**
 	 * @since  2.4
 	 *
-	 * @return TemporaryEntityListAccumulator
+	 * @return EntityListAccumulator
 	 */
 	public function getEntityListAccumulator() {
-		return $this->temporaryEntityListAccumulator;
+		return $this->entityListAccumulator;
 	}
 
 	/**
@@ -151,7 +151,7 @@ class SMWQueryResult {
 
 		foreach ( $this->mPrintRequests as $p ) {
 			$resultArray = new SMWResultArray( $page, $p, $this->mStore );
-			$resultArray->setEntityListAccumulator( $this->temporaryEntityListAccumulator );
+			$resultArray->setEntityListAccumulator( $this->entityListAccumulator );
 			$row[] = $resultArray;
 		}
 

--- a/src/Query/PrintRequest/Deserializer.php
+++ b/src/Query/PrintRequest/Deserializer.php
@@ -1,0 +1,117 @@
+<?php
+
+namespace SMW\Query\PrintRequest;
+
+use SMW\Query\PrintRequest;
+use SMWPropertyValue as PropertyValue;
+use SMW\Localizer;
+use Title;
+use InvalidArgumentException;
+
+/**
+ * @license GNU GPL v2+
+ * @since 2.5
+ *
+ * @author Markus Krötzsch
+ * @author mwjames
+ */
+class Deserializer {
+
+	/**
+	 * Create an PrintRequest object from a string description as one
+	 * would normally use in #ask and related inputs. The string must start
+	 * with a "?" and may contain label and formatting parameters after "="
+	 * or "#", respectively. However, further parameters, given in #ask by
+	 * "|+param=value" are not allowed here; they must be added
+	 * individually.
+	 *
+	 * @since 2.5
+	 *
+	 * @param string $text
+	 * @param boolean $showMode = false
+	 *
+	 * @return PrintRequest|null
+	 */
+	public static function deserialize( $text, $showMode = false ) {
+
+		list( $parts, $outputFormat, $printRequestLabel ) = self::getPartsFromText(
+			$text
+		);
+
+		$data = null;
+
+		if ( $printRequestLabel === '' ) { // print "this"
+			$printmode = PrintRequest::PRINT_THIS;
+			$label = ''; // default
+		} elseif ( self::isCategory( $printRequestLabel ) ) { // print categories
+			$printmode = PrintRequest::PRINT_CATS;
+			$label = $showMode ? '' : Localizer::getInstance()->getNamespaceTextById( NS_CATEGORY ); // default
+		} else { // print property or check category
+			$title = Title::newFromText( $printRequestLabel, SMW_NS_PROPERTY ); // trim needed for \n
+
+			// not a legal property/category name; give up
+			if ( $title === null ) {
+				return null;
+			}
+
+			if ( $title->getNamespace() == NS_CATEGORY ) {
+				$printmode = PrintRequest::PRINT_CCAT;
+				$data = $title;
+				$label = $showMode ? '' : $title->getText();  // default
+			} else { // enforce interpretation as property (even if it starts with something that looks like another namespace)
+				$printmode = PrintRequest::PRINT_PROP;
+				$data = PropertyValue::makeUserProperty( $printRequestLabel );
+				if ( !$data->isValid() ) { // not a property; give up
+					return null;
+				}
+				$label = $showMode ? '' : $data->getWikiValue();  // default
+			}
+		}
+
+		// "plain printout", avoid empty string to avoid confusions with "false"
+		if ( $outputFormat === '' ) {
+			$outputFormat = '-';
+		}
+
+		// label found, use this instead of default
+		if ( count( $parts ) > 1 ) {
+			$label = trim( $parts[1] );
+		}
+
+		try {
+			$printRequest = new PrintRequest( $printmode, $label, $data, trim( $outputFormat ) );
+		} catch ( InvalidArgumentException $e ) { // something still went wrong; give up
+			$printRequest = null;
+		}
+
+		return $printRequest;
+	}
+
+	private static function isCategory( $text ) {
+		return Localizer::getInstance()->getNamespaceTextById( NS_CATEGORY ) == mb_convert_case( $text, MB_CASE_TITLE ) ||
+		$text == 'Category';
+	}
+
+	private static function getPartsFromText( $text ) {
+
+		// 1464
+		// Temporary encode "=" within a <> entity (<span>...</span>)
+		$text = preg_replace_callback( "/(<(.*?)>(.*?)>)/u", function( $matches ) {
+			foreach ( $matches as $match ) {
+				return str_replace( array( '=' ), array( '-3D' ), $match );
+			}
+		}, $text );
+
+		$parts = explode( '=', $text, 2 );
+
+		// Restore temporary encoding
+		$parts[0] = str_replace( array( '-3D' ), array( '=' ), $parts[0] );
+
+		$propparts = explode( '#', $parts[0], 2 );
+		$printRequestLabel = trim( $propparts[0] );
+		$outputFormat = isset( $propparts[1] ) ? trim( $propparts[1] ) : false;
+
+		return array( $parts, $outputFormat, $printRequestLabel );
+	}
+
+}

--- a/src/Query/Result/EntityListAccumulator.php
+++ b/src/Query/Result/EntityListAccumulator.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace SMW\Query;
+namespace SMW\Query\Result;
 
 use SMW\DIProperty;
 use SMW\DIWikiPage;
@@ -20,7 +20,7 @@ use SMWQuery as Query;
  *
  * @author mwjames
  */
-class TemporaryEntityListAccumulator {
+class EntityListAccumulator {
 
 	/**
 	 * @var Query
@@ -91,10 +91,10 @@ class TemporaryEntityListAccumulator {
 	/**
 	 * @since  2.4
 	 *
-	 * @param DIProperty|null $property
 	 * @param DataItem $dataItem
+	 * @param DIProperty|null $property
 	 */
-	public function addToEntityList( DIProperty $property = null, DataItem $dataItem ) {
+	public function addToEntityList( DataItem $dataItem, DIProperty $property = null ) {
 
 		$queryID = $this->getQueryId();
 

--- a/src/Query/Result/ResultFieldMatchFinder.php
+++ b/src/Query/Result/ResultFieldMatchFinder.php
@@ -1,0 +1,230 @@
+<?php
+
+namespace SMW\Query\Result;
+
+use SMW\Query\PrintRequest;
+use SMW\DataValueFactory;
+use SMW\RequestOptions;
+use SMW\DIProperty;
+use SMW\DIWikiPage;
+use SMW\Store;
+use SMWDataItem as DataItem;
+use SMWDIBoolean as DIBoolean;
+
+/**
+ * Returns the result content (DI objects) for a single PrintRequest represented
+ * as cell of the intersection between a subject row and a print column.
+ *
+ * @license GNU GPL v2+
+ * @since 2.5
+ *
+ * @author Markus Krötzsch
+ * @author Jeroen De Dauw < jeroendedauw@gmail.com >
+ * @author mwjames
+ */
+class ResultFieldMatchFinder {
+
+	/**
+	 * @var Store
+	 */
+	private $store;
+
+	/**
+	 * @var PrintRequest
+	 */
+	private $printRequest;
+
+	/**
+	 * @var boolean|array
+	 */
+	private static $catCacheObj = false;
+
+	/**
+	 * @var boolean|array
+	 */
+	private static $catCache = false;
+
+	/**
+	 * @since 2.5
+	 *
+	 * @param Store $store
+	 * @param PrintRequest $printRequest
+	 */
+	public function __construct( Store $store, PrintRequest $printRequest ) {
+		$this->printRequest = $printRequest;
+		$this->store = $store;
+	}
+
+	/**
+	 * @since 2.5
+	 *
+	 * @param DataItem $dataItem
+	 *
+	 * @param DataItem[]|[]
+	 */
+	public function getResultsBy( DataItem $dataItem ) {
+
+		$content = array();
+
+		// Request the current element (page in result set).
+		// The limit is ignored here.
+		if ( $this->printRequest->isMode( PrintRequest::PRINT_THIS ) ) {
+			return array( $dataItem );
+		}
+
+		// Request all direct categories of the current element
+		// Always recompute cache here to ensure output format is respected.
+		if ( $this->printRequest->isMode( PrintRequest::PRINT_CATS ) ) {
+			self::$catCache = $this->store->getPropertyValues(
+				$dataItem,
+				new DIProperty( '_INST' ),
+				$this->getRequestOptions( false )
+			);
+
+			self::$catCacheObj = $dataItem->getHash();
+
+			$limit = $this->printRequest->getParameter( 'limit' );
+
+			return ( $limit === false ) ? ( self::$catCache ) : array_slice( self::$catCache, 0, $limit );
+		}
+
+		// Request to whether current element is in given category (Boolean printout).
+		// The limit is ignored here.
+		if ( $this->printRequest->isMode( PrintRequest::PRINT_CCAT ) ) {
+			if ( self::$catCacheObj !== $dataItem->getHash() ) {
+				self::$catCache = $this->store->getPropertyValues(
+					$dataItem,
+					new DIProperty( '_INST' )
+				);
+				self::$catCacheObj = $dataItem->getHash();
+			}
+
+			$found = false;
+			$prkey = $this->printRequest->getData()->getDBkey();
+
+			foreach ( self::$catCache as $cat ) {
+				if ( $cat->getDBkey() == $prkey ) {
+					$found = true;
+					break;
+				}
+			}
+
+			return array( new DIBoolean( $found ) );
+		}
+
+		// Request all property values of a certain attribute of the current element.
+		if ( $this->printRequest->isMode( PrintRequest::PRINT_PROP ) ) {
+
+			$content = $this->getResultContent(
+				$dataItem
+			);
+
+			if ( !$this->isMultiValueWithIndex() ) {
+				return $content;
+			}
+
+			// Print one component of a multi-valued string.
+			// Known limitation: the printrequest still is of type _rec, so if printers check
+			// for this then they will not recognize that it returns some more concrete type.
+
+			$propertyValue = $this->printRequest->getData();
+
+			$index = $this->printRequest->getParameter( 'index' );
+			$newcontent = array();
+
+			foreach ( $content as $diContainer ) {
+
+				/* SMWRecordValue */
+				$recordValue = DataValueFactory::getInstance()->newDataValueByItem(
+					$diContainer,
+					$propertyValue->getDataItem()
+				);
+
+				if ( ( $dataItemByRecord = $recordValue->getDataItemByIndex( $index ) ) !== null ) {
+					$newcontent[] = $dataItemByRecord;
+				}
+			}
+
+			$content = $newcontent;
+			unset( $newcontent );
+		}
+
+		return $content;
+	}
+
+	/**
+	 * Make a request option object based on the given parameters, and
+	 * return NULL if no such object is required. The parameter defines
+	 * if the limit should be taken into account, which is not always desired
+	 * (especially if results are to be cached for future use).
+	 *
+	 * @param boolean $useLimit
+	 *
+	 * @return RequestOptions|null
+	 */
+	public function getRequestOptions( $useLimit = true ) {
+		$limit = $useLimit ? $this->printRequest->getParameter( 'limit' ) : false;
+		$order = trim( $this->printRequest->getParameter( 'order' ) );
+
+		// Important: use "!=" for order, since trim() above does never return "false", use "!==" for limit since "0" is meaningful here.
+		if ( ( $limit !== false ) || ( $order != false ) ) {
+			$options = new RequestOptions();
+
+			if ( $limit !== false ) {
+				$options->limit = trim( $limit );
+			}
+
+			if ( ( $order == 'descending' ) || ( $order == 'reverse' ) || ( $order == 'desc' ) ) {
+				$options->sort = true;
+				$options->ascending = false;
+			} elseif ( ( $order == 'ascending' ) || ( $order == 'asc' ) ) {
+				$options->sort = true;
+				$options->ascending = true;
+			}
+		} else {
+			$options = null;
+		}
+
+		return $options;
+	}
+
+	private function isMultiValueWithIndex() {
+		return strpos( $this->printRequest->getTypeID(), '_rec' ) !== false && $this->printRequest->getParameter( 'index' ) !== false;
+	}
+
+	private function getResultContent( DataItem $dataItem ) {
+
+		$dataValue = $this->printRequest->getData();
+		$dataItems = array( $dataItem );
+
+		if ( !$dataValue->isValid() ) {
+			return array();
+		}
+
+		return $this->doFetchPropertyValues( $dataItems, $dataValue );
+	}
+
+	private function doFetchPropertyValues( $dataItems, $dataValue ) {
+
+		$propertyValues = array();
+
+		foreach ( $dataItems as $dataItem ) {
+
+			if ( !$dataItem instanceof DIWikiPage ) {
+				continue;
+			}
+
+			$pv = $this->store->getPropertyValues(
+				$dataItem,
+				$dataValue->getDataItem(),
+				$this->getRequestOptions()
+			);
+
+			$propertyValues = array_merge( $propertyValues, $pv );
+			unset( $pv );
+		}
+
+		return $propertyValues;
+	}
+
+}

--- a/src/SQLStore/QueryDependency/QueryResultDependencyListResolver.php
+++ b/src/SQLStore/QueryDependency/QueryResultDependencyListResolver.php
@@ -96,7 +96,7 @@ class QueryResultDependencyListResolver {
 
 	/**
 	 * At the point where the QueryResult instantiates results by means of the
-	 * ResultArray, record the objects with the help of the TemporaryEntityListAccumulator.
+	 * ResultArray, record the objects with the help of the EntityListAccumulator.
 	 * Processing is depending and various factors which could be to early with
 	 * the row instance is not yet being resolved.
 	 *

--- a/tests/phpunit/Integration/ByJsonScript/Fixtures/f-0208.json
+++ b/tests/phpunit/Integration/ByJsonScript/Fixtures/f-0208.json
@@ -1,5 +1,5 @@
 {
-	"description": "Test `format=table` further results link for user/predefined property (`wgContLang=en`, `wgLang=es`)",
+	"description": "Test `format=table` with `limit=0` (further result links) for user/predefined properties, `mainlabel=-`, `#show` (`wgContLang=en`, `wgLang=es`)",
 	"properties": [
 		{
 			"name": "Has text",
@@ -22,6 +22,30 @@
 		{
 			"name": "Example/F0208/Q2.2",
 			"contents": "{{#ask: [[Fecha de modificación@es::+]] |?Fecha de modificación@es |limit=0 }}"
+		},
+		{
+			"name": "Example/F0208/3",
+			"contents": "[[Has page::F0208]]"
+		},
+		{
+			"name": "Example/F0208/Q3.1",
+			"contents": "{{#ask: [[Has page::F0208]] |mainlabel |?Has page |format=table |headers=plain |link=none |limit=0 }}"
+		},
+		{
+			"name": "Example/F0208/Q3.2",
+			"contents": "{{#ask: [[Has page::F0208]] |mainlabel |?Has page#Foo |format=table |headers=plain |link=none |limit=0 }}"
+		},
+		{
+			"name": "Example/F0208/Q3.3",
+			"contents": "{{#ask: [[Has page::F0208]] |mainlabel |?Has page# |format=table |headers=plain |link=none |limit=0 }}"
+		},
+		{
+			"name": "Example/F0208/Q3.4",
+			"contents": "{{#ask: [[Has page::F0208]] |mainlabel=- |?Has page |format=table |headers=plain |link=none |limit=0 }}"
+		},
+		{
+			"name": "Example/F0208/Q3.5",
+			"contents": "{{#show: Example/F0208/3 |mainlabel=- |?Has page |format=table |headers=plain |link=none |limit=0 }}"
 		}
 	],
 	"format-testcases": [
@@ -31,6 +55,9 @@
 			"expected-output": {
 				"to-contain": [
 					"Special:Ask/-5B-5BHas-20text::F0208-5D-5D/-3FHas-20text/-3FModification-20date%3DFecha-20de-20modificaci%C3%B3n/mainlabel%3D/offset%3D0/format%3Dtable"
+				],
+				"not-contain": [
+					"Special:Ask/-5B-5BHas-20text::F0208-5D-5D/-3FHas-20text-23/-3FModification-20date-23=Fecha-20de-20modificación/mainlabel=/offset=0/format=table"
 				]
 			}
 		},
@@ -49,6 +76,51 @@
 			"expected-output": {
 				"to-contain": [
 					"Special:Ask/-5B-5BModification-20date::%2B-5D-5D/-3FModification-20date%3DFecha-20de-20modificaci%C3%B3n/mainlabel%3D/offset%3D0/format%3Dtable"
+				]
+			}
+		},
+		{
+			"about": "#3",
+			"subject": "Example/F0208/Q3.1",
+			"expected-output": {
+				"to-contain": [
+					"Special:Ask/-5B-5BHas-20page::F0208-5D-5D/-3FHas-20page/mainlabel=/offset=0/format=table/link=none/headers=plain"
+				]
+			}
+		},
+		{
+			"about": "#4",
+			"subject": "Example/F0208/Q3.2",
+			"expected-output": {
+				"to-contain": [
+					"Special:Ask/-5B-5BHas-20page::F0208-5D-5D/-3FHas-20page-23Foo/mainlabel=/offset=0/format=table/link=none/headers=plain"
+				]
+			}
+		},
+		{
+			"about": "#5",
+			"subject": "Example/F0208/Q3.3",
+			"expected-output": {
+				"to-contain": [
+					"Special:Ask/-5B-5BHas-20page::F0208-5D-5D/-3FHas-20page-23-2D/mainlabel=/offset=0/format=table/link=none/headers=plain"
+				]
+			}
+		},
+		{
+			"about": "#6",
+			"subject": "Example/F0208/Q3.4",
+			"expected-output": {
+				"to-contain": [
+					"Special:Ask/-5B-5BHas-20page::F0208-5D-5D/-3FHas-20page/mainlabel=-2D/offset=0/format=table/link=none/headers=plain"
+				]
+			}
+		},
+		{
+			"about": "#7 (#show)",
+			"subject": "Example/F0208/Q3.5",
+			"expected-output": {
+				"to-contain": [
+					"Special:Ask/-5B-5B:Example-2FF0208-2F3-5D-5D/-3FHas-20page=/mainlabel=-2D/offset=0/format=table/link=none/headers=plain"
 				]
 			}
 		}

--- a/tests/phpunit/Unit/Query/PrintRequest/DeserializerTest.php
+++ b/tests/phpunit/Unit/Query/PrintRequest/DeserializerTest.php
@@ -1,0 +1,128 @@
+<?php
+
+namespace SMW\Tests\Query\PrintRequest;
+
+use SMW\Query\PrintRequest\Deserializer;
+use SMWPropertyValue as PropertyValue;
+use SMW\Query\PrintRequest;
+use SMW\Localizer;
+
+/**
+ * @covers SMW\Query\PrintRequest\Deserializer
+ * @group semantic-mediawiki
+ *
+ * @license GNU GPL v2+
+ * @since 2.5
+ *
+ * @author mwjames
+ */
+class DeserializerTest extends \PHPUnit_Framework_TestCase {
+
+	/**
+	 * @dataProvider textProvider
+	 */
+	public function testDeserialize( $text, $showMode, $expectedLabel, $expectedMode, $expectedDataInstance, $expectedOutputFormat ) {
+
+		$instance = Deserializer::deserialize( $text, $showMode );
+
+		$this->assertEquals(
+			$expectedLabel,
+			$instance->getLabel()
+		);
+
+		$this->assertEquals(
+			$expectedMode,
+			$instance->getMode()
+		);
+
+		if ( $expectedDataInstance !== null ) {
+			$this->assertInstanceOf(
+				$expectedDataInstance,
+				$instance->getData()
+			);
+		}
+
+		$this->assertSame(
+			$expectedOutputFormat,
+			$instance->getOutputFormat()
+		);
+	}
+
+	public function textProvider() {
+
+		#0
+		$provider[] = array(
+			'Foo',
+			false,
+			'Foo',
+			PrintRequest::PRINT_PROP,
+			PropertyValue::class,
+			''
+		);
+
+		#1
+		$provider[] = array(
+			'-Foo',
+			false,
+			'-Foo',
+			PrintRequest::PRINT_PROP,
+			PropertyValue::class,
+			''
+		);
+
+		#2
+		$provider[] = array(
+			'-Foo=Bar',
+			false,
+			'Bar',
+			PrintRequest::PRINT_PROP,
+			PropertyValue::class,
+			''
+		);
+
+		#3
+		 // Category
+		$categoryName = Localizer::getInstance()->getNamespaceTextById( NS_CATEGORY );
+		$provider[] = array(
+			'Category',
+			false,
+			$categoryName,
+			PrintRequest::PRINT_CATS,
+			null,
+			''
+		);
+
+		#4
+		$provider[] = array(
+			'Bar#foobar',
+			false,
+			'Bar',
+			PrintRequest::PRINT_PROP,
+			PropertyValue::class,
+			'foobar'
+		);
+
+		#5
+		$provider[] = array(
+			'Foo#',
+			false,
+			'Foo',
+			PrintRequest::PRINT_PROP,
+			PropertyValue::class,
+			'-'
+		);
+
+		#6, 1464
+		$provider[] = array(
+			'Has boolean#<span style="color: green; font-size: 120%;">&#10003;</span>,<span style="color: #AA0000; font-size: 120%;">&#10005;</span>=Label on (&#10003;,&#10005;)',
+			false,
+			'Label on (&#10003;,&#10005;)',
+			PrintRequest::PRINT_PROP,
+			PropertyValue::class,
+			'<span style="color: green; font-size: 120%;">&#10003;</span>,<span style="color: #AA0000; font-size: 120%;">&#10005;</span>'
+		);
+
+		return $provider;
+	}
+
+}

--- a/tests/phpunit/Unit/Query/Result/EntityListAccumulatorTest.php
+++ b/tests/phpunit/Unit/Query/Result/EntityListAccumulatorTest.php
@@ -1,13 +1,13 @@
 <?php
 
-namespace SMW\Tests\Query;
+namespace SMW\Tests\Query\Result;
 
 use SMW\DIWikiPage;
-use SMW\Query\TemporaryEntityListAccumulator;
+use SMW\Query\Result\EntityListAccumulator;
 use SMW\Tests\TestEnvironment;
 
 /**
- * @covers \SMW\Query\TemporaryEntityListAccumulator
+ * @covers \SMW\Query\Result\EntityListAccumulator
  * @group semantic-mediawiki
  *
  * @license GNU GPL v2+
@@ -15,7 +15,7 @@ use SMW\Tests\TestEnvironment;
  *
  * @author mwjames
  */
-class TemporaryEntityListAccumulatorTest extends \PHPUnit_Framework_TestCase {
+class EntityListAccumulatorTest extends \PHPUnit_Framework_TestCase {
 
 	private $testEnvironment;
 	private $query;
@@ -38,8 +38,8 @@ class TemporaryEntityListAccumulatorTest extends \PHPUnit_Framework_TestCase {
 	public function testCanConstruct() {
 
 		$this->assertInstanceOf(
-			'\SMW\Query\TemporaryEntityListAccumulator',
-			new TemporaryEntityListAccumulator( $this->query )
+			EntityListAccumulator::class,
+			new EntityListAccumulator( $this->query )
 		);
 	}
 
@@ -51,12 +51,12 @@ class TemporaryEntityListAccumulatorTest extends \PHPUnit_Framework_TestCase {
 			->method( 'getQueryId' )
 			->will( $this->returnValue( 'FOO:123' ) );
 
-		$instance = new TemporaryEntityListAccumulator(
+		$instance = new EntityListAccumulator(
 			$this->query
 		);
 
 		$instance->pruneEntityList();
-		$instance->addToEntityList( null, $dataItem );
+		$instance->addToEntityList( $dataItem );
 
 		$this->assertEquals(
 			array( 'Foo#0#' => $dataItem ),
@@ -81,11 +81,11 @@ class TemporaryEntityListAccumulatorTest extends \PHPUnit_Framework_TestCase {
 			->method( 'getQueryId' )
 			->will( $this->returnValue( 'FOO:BAR' ) );
 
-		$instance = new TemporaryEntityListAccumulator(
+		$instance = new EntityListAccumulator(
 			$this->query
 		);
 
-		$instance->addToEntityList( null, $dataItem );
+		$instance->addToEntityList( $dataItem );
 
 		$this->assertEquals(
 			array(

--- a/tests/phpunit/Unit/Query/Result/ResultFieldMatchFinderTest.php
+++ b/tests/phpunit/Unit/Query/Result/ResultFieldMatchFinderTest.php
@@ -1,0 +1,215 @@
+<?php
+
+namespace SMW\Tests\Query\Result;
+
+use SMW\Query\Result\ResultFieldMatchFinder;
+use SMW\DataItemFactory;
+use SMW\DataValueFactory;
+use SMW\Query\PrintRequest;
+
+/**
+ * @covers SMW\Query\Result\ResultFieldMatchFinder
+ * @group semantic-mediawiki
+ *
+ * @license GNU GPL v2+
+ * @since 2.5
+ *
+ * @author mwjames
+ */
+class ResultFieldMatchFinderTest extends \PHPUnit_Framework_TestCase {
+
+	private $dataItemFactory;
+	private $dataValueFactory;
+
+	protected function setUp() {
+		parent::setUp();
+		$this->dataItemFactory = new DataItemFactory();
+		$this->dataValueFactory = DataValueFactory::getInstance();
+	}
+
+	public function testCanConstruct() {
+
+		$store = $this->getMockBuilder( '\SMW\Store' )
+			->disableOriginalConstructor()
+			->getMockForAbstractClass();
+
+		$printRequest = $this->getMockBuilder( '\SMW\Query\PrintRequest' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$this->assertInstanceOf(
+			'SMW\Query\Result\ResultFieldMatchFinder',
+			new ResultFieldMatchFinder( $store, $printRequest )
+		);
+	}
+
+	public function testGetRequestOptions() {
+
+		$store = $this->getMockBuilder( '\SMW\Store' )
+			->disableOriginalConstructor()
+			->getMockForAbstractClass();
+
+		$printRequest = $this->getMockBuilder( '\SMW\Query\PrintRequest' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$printRequest->expects( $this->any() )
+			->method( 'getParameter' )
+			->will( $this->returnValue( 42 ) );
+
+		$instance = new ResultFieldMatchFinder(
+			$store,
+			$printRequest
+		);
+
+		$this->assertInstanceOf(
+			'SMW\RequestOptions',
+			$instance->getRequestOptions()
+		);
+	}
+
+	public function testGetResultsBy_THIS() {
+
+		$dataItem = $this->dataItemFactory->newDIWikiPage( 'Foo' );
+
+		$store = $this->getMockBuilder( '\SMW\Store' )
+			->disableOriginalConstructor()
+			->getMockForAbstractClass();
+
+		$printRequest = $this->getMockBuilder( '\SMW\Query\PrintRequest' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$printRequest->expects( $this->any() )
+			->method( 'isMode' )
+			->with($this->equalTo( PrintRequest::PRINT_THIS ) )
+			->will( $this->returnValue( true ) );
+
+		$instance = new ResultFieldMatchFinder(
+			$store,
+			$printRequest
+		);
+
+		$this->assertEquals(
+			array( $dataItem ),
+			$instance->getResultsBy( $dataItem )
+		);
+	}
+
+	public function testGetResultsBy_CATS() {
+
+		$dataItem = $this->dataItemFactory->newDIWikiPage( 'Foo' );
+		$expected = $this->dataItemFactory->newDIWikiPage( __METHOD__ );
+
+		$store = $this->getMockBuilder( '\SMW\Store' )
+			->disableOriginalConstructor()
+			->getMockForAbstractClass();
+
+		$store->expects( $this->once() )
+			->method( 'getPropertyValues' )
+			->with(
+				$this->equalTo( $dataItem ),
+				$this->equalTo( $this->dataItemFactory->newDIProperty( '_INST' ) ) )
+			->will( $this->returnValue( array( $expected ) ) );
+
+		$printRequest = $this->getMockBuilder( '\SMW\Query\PrintRequest' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$printRequest->expects( $this->at( 1 ) )
+			->method( 'isMode' )
+			->with($this->equalTo( PrintRequest::PRINT_CATS ) )
+			->will( $this->returnValue( true ) );
+
+		$instance = new ResultFieldMatchFinder(
+			$store,
+			$printRequest
+		);
+
+		$this->assertEquals(
+			array( $expected ),
+			$instance->getResultsBy( $dataItem )
+		);
+	}
+
+	public function testGetResultsBy_CCAT() {
+
+		$dataItem = $this->dataItemFactory->newDIWikiPage( 'Bar' );
+		$expected = $this->dataItemFactory->newDIWikiPage( __METHOD__ );
+
+		$store = $this->getMockBuilder( '\SMW\Store' )
+			->disableOriginalConstructor()
+			->getMockForAbstractClass();
+
+		$store->expects( $this->once() )
+			->method( 'getPropertyValues' )
+			->with(
+				$this->equalTo( $dataItem ),
+				$this->equalTo( $this->dataItemFactory->newDIProperty( '_INST' ) ) )
+			->will( $this->returnValue( array( $expected ) ) );
+
+		$printRequest = $this->getMockBuilder( '\SMW\Query\PrintRequest' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$printRequest->expects( $this->at( 2 ) )
+			->method( 'isMode' )
+			->with($this->equalTo( PrintRequest::PRINT_CCAT ) )
+			->will( $this->returnValue( true ) );
+
+		$printRequest->expects( $this->once() )
+			->method( 'getData' )
+			->will( $this->returnValue( $expected ) );
+
+		$instance = new ResultFieldMatchFinder(
+			$store,
+			$printRequest
+		);
+
+		$this->assertEquals(
+			array( $this->dataItemFactory->newDIBoolean( true ) ),
+			$instance->getResultsBy( $dataItem )
+		);
+	}
+
+	public function testGetResultsBy_PROP() {
+
+		$dataItem = $this->dataItemFactory->newDIWikiPage( 'Bar' );
+		$expected = $this->dataItemFactory->newDIWikiPage( __METHOD__ );
+
+		$store = $this->getMockBuilder( '\SMW\Store' )
+			->disableOriginalConstructor()
+			->getMockForAbstractClass();
+
+		$store->expects( $this->once() )
+			->method( 'getPropertyValues' )
+			->with(
+				$this->equalTo( $dataItem ),
+				$this->equalTo( $this->dataItemFactory->newDIProperty( 'Prop' ) ) )
+			->will( $this->returnValue( array( $expected ) ) );
+
+		$printRequest = $this->getMockBuilder( '\SMW\Query\PrintRequest' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$printRequest->expects( $this->at( 3 ) )
+			->method( 'isMode' )
+			->with($this->equalTo( PrintRequest::PRINT_PROP ) )
+			->will( $this->returnValue( true ) );
+
+		$printRequest->expects( $this->once() )
+			->method( 'getData' )
+			->will( $this->returnValue( $this->dataValueFactory->newPropertyValueByLabel( 'Prop' ) ) );
+
+		$instance = new ResultFieldMatchFinder(
+			$store,
+			$printRequest
+		);
+
+		$this->assertEquals(
+			array( $expected ),
+			$instance->getResultsBy( $dataItem )
+		);
+	}
+
+}

--- a/tests/phpunit/Unit/SQLStore/QueryDependency/QueryResultDependencyListResolverTest.php
+++ b/tests/phpunit/Unit/SQLStore/QueryDependency/QueryResultDependencyListResolverTest.php
@@ -233,11 +233,11 @@ class QueryResultDependencyListResolverTest extends \PHPUnit_Framework_TestCase 
 		$query = new Query( $description );
 		$query->setContextPage( DIWikiPage::newFromText( 'Foo' ) );
 
-		$temporaryEntityListAccumulator = $this->getMockBuilder( '\SMW\Query\TemporaryEntityListAccumulator' )
+		$entityListAccumulator = $this->getMockBuilder( '\SMW\Query\Result\EntityListAccumulator' )
 			->disableOriginalConstructor()
 			->getMock();
 
-		$temporaryEntityListAccumulator->expects( $this->once() )
+		$entityListAccumulator->expects( $this->once() )
 			->method( 'getEntityList' )
 			->will( $this->returnValue( array( $subject ) ) );
 
@@ -247,7 +247,7 @@ class QueryResultDependencyListResolverTest extends \PHPUnit_Framework_TestCase 
 
 		$queryResult->expects( $this->once() )
 			->method( 'getEntityListAccumulator' )
-			->will( $this->returnValue( $temporaryEntityListAccumulator ) );
+			->will( $this->returnValue( $entityListAccumulator ) );
 
 		$queryResult->expects( $this->any() )
 			->method( 'getQuery' )


### PR DESCRIPTION
This PR is made in reference to: # N/A

This PR addresses or contains:

- Isolate code responsible for the `Store` connection and move from `ResultArray` to `ResultFieldMatchFinder`
- Code responsible for creating a `PrintRequest` instance from a string is moved to `SMW\Query\PrintRequest\Deserializer`
- Changes are made in preparation to support property.chain printrequests (`|?Foo.Bar`) in a subsequent PR

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed

