### PR TITLE
Don't give the 'autocomplete-suggestions' class to the input field

### DIFF
--- a/res/smw/special/ext.smw.special.property.js
+++ b/res/smw/special/ext.smw.special.property.js
@@ -12,8 +12,6 @@
 
 	$( document ).ready( function() {
 
-		$( '#smw-property-input' ).addClass( 'autocomplete-suggestions' );
-
 		$( '#smw-property-input, .smw-property-input' ).autocomplete({
 			serviceUrl: mw.util.wikiScript( 'api' ),
 			dataType: 'json',


### PR DESCRIPTION
The CSS of the 'autocomplete-suggestions' class is intended for the suggestion box, not the input field. Giving it to the input field overrides the default styling and makes it look weird and ugly.