### PR TITLE
Add PropertyChainValue

### DIFF
--- a/includes/datavalues/SMW_DV_Property.php
+++ b/includes/datavalues/SMW_DV_Property.php
@@ -235,6 +235,7 @@ class SMWPropertyValue extends SMWDataValue {
 			$this->m_wikipage = \SMW\DataValueFactory::getInstance()->newDataValueByItem( $diWikiPage, null, $this->m_caption );
 			$this->m_wikipage->setOutputFormat( $this->m_outformat );
 			$this->m_wikipage->setLinkAttributes( $this->linkAttributes );
+			$this->m_wikipage->setOptions( $this->getOptions() );
 			$this->addError( $this->m_wikipage->getErrors() );
 		} else { // should rarely happen ($value is only changed if the input $value really was a label for a predefined prop)
 			$this->m_wikipage = null;

--- a/includes/datavalues/SMW_DataValue.php
+++ b/includes/datavalues/SMW_DataValue.php
@@ -272,9 +272,14 @@ abstract class SMWDataValue {
 	/**
 	 * @since 2.4
 	 *
-	 * @return Options $options
+	 * @return Options|null $options
 	 */
-	public function setOptions( Options $options ) {
+	public function setOptions( Options $options = null ) {
+
+		if ( $options === null ) {
+			return;
+		}
+
 		foreach ( $options->getOptions() as $key => $value ) {
 			$this->setOption( $key, $value );
 		}
@@ -826,6 +831,10 @@ abstract class SMWDataValue {
 	 */
 	protected function convertDoubleWidth( $value ) {
 		return Localizer::convertDoubleWidth( $value );
+	}
+
+	protected function getOptions() {
+		return $this->options;
 	}
 
 	private function getInfoLinksProvider() {

--- a/includes/storage/SMW_ResultArray.php
+++ b/includes/storage/SMW_ResultArray.php
@@ -189,8 +189,10 @@ class SMWResultArray {
 			$diProperty = $recordValue->getPropertyDataItemByIndex(
 				$this->mPrintRequest->getParameter( 'index' )
 			);
-		} elseif ( $this->mPrintRequest->getMode() == PrintRequest::PRINT_PROP ) {
+		} elseif ( $this->mPrintRequest->isMode( PrintRequest::PRINT_PROP ) ) {
 			$diProperty = $this->mPrintRequest->getData()->getDataItem();
+		} elseif ( $this->mPrintRequest->isMode( PrintRequest::PRINT_CHAIN ) ) {
+			$diProperty = $this->mPrintRequest->getData()->getLastPropertyChainValue()->getDataItem();
 		} else {
 			$diProperty = null;
 		}

--- a/src/DataTypeRegistry.php
+++ b/src/DataTypeRegistry.php
@@ -482,6 +482,7 @@ class DataTypeRegistry {
 			'__pvuc' => 'SMW\DataValues\UniquenessConstraintValue',
 			'_eid' => 'SMW\DataValues\ExternalIdentifierValue',
 			'__pefu' => 'SMW\DataValues\ExternalFormatterUriValue',
+			'__pchn' => 'SMW\DataValues\PropertyChainValue',
 		);
 
 		$this->typeDataItemIds = array(
@@ -529,6 +530,7 @@ class DataTypeRegistry {
 			'__pvap' => DataItem::TYPE_BLOB, // Allows pattern
 			'__pvuc' => DataItem::TYPE_BOOLEAN, // Uniqueness constraint
 			'__pefu' => DataItem::TYPE_URI, // External formatter uri
+			'__pchn' => DataItem::TYPE_BLOB, // Property chain
 		);
 
 		$this->subDataTypes = array(

--- a/src/DataValues/PropertyChainValue.php
+++ b/src/DataValues/PropertyChainValue.php
@@ -1,0 +1,209 @@
+<?php
+
+namespace SMW\DataValues;
+
+use SMWStringValue as StringValue;
+use SMWPropertyValue as PropertyValue;
+use SMWDIBlob as DIBlob;
+use SMWDataItem as DataItem;
+
+/**
+ * @private
+ *
+ * @license GNU GPL v2+
+ * @since 2.5
+ *
+ * @author mwjames
+ */
+class PropertyChainValue extends StringValue {
+
+	/**
+	 * @var PropertyValue[]
+	 */
+	private $propertyValues = array();
+
+	/**
+	 * @var PropertyValue
+	 */
+	private $lastPropertyChainValue;
+
+	/**
+	 * @param string $typeid
+	 */
+	public function __construct( $typeid = '' ) {
+		parent::__construct( '__pchn' );
+	}
+
+	/**
+	 * @since 2.5
+	 *
+	 * @param string $value
+	 *
+	 * @return boolean
+	 */
+	public static function isChained( $value ) {
+		return strpos( $value, '.' ) !== false;
+	}
+
+	/**
+	 * @since 2.5
+	 *
+	 * @return PropertyValue
+	 */
+	public function getLastPropertyChainValue() {
+		return $this->lastPropertyChainValue;
+	}
+
+	/**
+	 * @since 2.5
+	 *
+	 * @return PropertyValue[]
+	 */
+	public function getPropertyChainValues() {
+		return $this->propertyValues;
+	}
+
+	/**
+	 * @see DataValue::getShortWikiText
+	 */
+	public function setCaption( $caption ) {
+		$this->m_caption = $caption;
+
+		if ( $this->lastPropertyChainValue !== null ) {
+			$this->lastPropertyChainValue->setCaption( $caption );
+		}
+	}
+
+	/**
+	 * @see DataValue::getShortWikiText
+	 */
+	public function getShortWikiText( $linker = null ) {
+
+		if ( $this->lastPropertyChainValue !== null ) {
+			return $this->lastPropertyChainValue->getShortWikiText( $linker ) . $this->doHintPropertyChainMembers();
+		}
+
+		return '';
+	}
+
+	/**
+	 * @see DataValue::getLongWikiText
+	 */
+	public function getLongWikiText( $linker = null ) {
+
+		if ( $this->lastPropertyChainValue !== null ) {
+			return $this->lastPropertyChainValue->getLongWikiText( $linker ) . $this->doHintPropertyChainMembers();
+		}
+
+		return '';
+	}
+
+	/**
+	 * @see DataValue::getShortHTMLText
+	 */
+	public function getShortHTMLText( $linker = null ) {
+
+		if ( $this->lastPropertyChainValue !== null ) {
+			return $this->lastPropertyChainValue->getShortHTMLText( $linker ) . $this->doHintPropertyChainMembers();
+		}
+
+		return '';
+	}
+
+	/**
+	 * @see DataValue::getLongHTMLText
+	 */
+	public function getLongHTMLText( $linker = null ) {
+
+		if ( $this->lastPropertyChainValue !== null ) {
+			return $this->lastPropertyChainValue->getLongHTMLText( $linker ) . $this->doHintPropertyChainMembers();
+		}
+
+		return '';
+	}
+
+	/**
+	 * @see DataValue::getWikiValue
+	 */
+	public function getWikiValue() {
+		return $this->lastPropertyChainValue !== null ? $this->lastPropertyChainValue->getWikiValue() : '';
+	}
+
+	/**
+	 * @see SMWDataValue::loadDataItem()
+	 *
+	 * @param $dataitem SMWDataItem
+	 *
+	 * @return boolean
+	 */
+	protected function loadDataItem( DataItem $dataItem ) {
+
+		if ( !$dataItem instanceof DIBlob ) {
+			return false;
+		}
+
+		$this->m_caption = false;
+		$this->m_dataitem = $dataItem;
+
+		$this->initPropertyChain( $dataItem->getString() );
+
+		return true;
+	}
+
+	/**
+	 * @see DataValue::parseUserValue
+	 * @note called by DataValue::setUserValue
+	 *
+	 * @param string $userValue
+	 */
+	protected function parseUserValue( $value ) {
+
+		if ( $value === '' ) {
+			$this->addErrorMsg( 'smw_emptystring' );
+		}
+
+		if ( !$this->isChained( $value ) ) {
+			$this->addErrorMsg( 'smw-datavalue-propertychain-missing-chain-indicator' );
+		}
+
+		$this->initPropertyChain( $value );
+
+		$this->m_dataitem = new DIBlob( $value );
+	}
+
+	private function initPropertyChain( $value ) {
+
+		$chain = explode( '.', $value );
+
+		// Get the last which represents the final output
+		// Foo.Bar.Foobar.Baz
+		$last = array_pop( $chain );
+
+		$this->lastPropertyChainValue = PropertyValue::makeUserProperty( $last );
+
+		if ( !$this->lastPropertyChainValue->isValid() ) {
+			return $this->addError( $this->lastPropertyChainValue->getErrors() );
+		}
+
+		$this->lastPropertyChainValue->setOptions( $this->getOptions() );
+
+		// Generate a forward list from the remaining property labels
+		// Foo.Bar.Foobar
+		foreach ( $chain as $value ) {
+			$propertyValue = PropertyValue::makeUserProperty( $value );
+
+			if ( !$propertyValue->isValid() ) {
+				continue;
+			}
+
+			$propertyValue->setOptions( $this->getOptions() );
+
+			$this->propertyValues[] = $propertyValue;
+		}
+	}
+
+	private function doHintPropertyChainMembers() {
+		return '&nbsp;' . \Html::rawElement( 'span', array( 'title' => $this->m_dataitem ), '⠉' );
+	}
+
+}

--- a/src/DataValues/ValueFormatters/ReferenceValueFormatter.php
+++ b/src/DataValues/ValueFormatters/ReferenceValueFormatter.php
@@ -10,6 +10,7 @@ use SMW\DIWikiPage;
 use SMW\Message;
 use SMWDataValue as DataValue;
 use SMWDIUri as DIUri;
+use SMWDITime as DITime;
 
 /**
  * @license GNU GPL v2+
@@ -39,8 +40,7 @@ class ReferenceValueFormatter extends DataValueFormatter {
 			throw new RuntimeException( "The formatter is missing a valid ReferenceValue object" );
 		}
 
-		if (
-			$this->dataValue->getCaption() !== false &&
+		if ( $this->dataValue->getCaption() !== false &&
 			( $type === self::WIKI_SHORT || $type === self::HTML_SHORT ) ) {
 			return $this->dataValue->getCaption();
 		}
@@ -101,6 +101,9 @@ class ReferenceValueFormatter extends DataValueFormatter {
 
 			$propertyValues = $this->dataValue->getDataItem()->getSemanticData()->getPropertyValues( $propertyDataItem );
 			$dataItem = reset( $propertyValues );
+
+			// By definition the first element in the list is the VALUE other
+			// members are referencing to
 			$isValue = $results === array();
 
 			if ( $dataItem !== false ) {
@@ -122,13 +125,18 @@ class ReferenceValueFormatter extends DataValueFormatter {
 
 	private function findValueOutputFor( $isValue, $type, $dataValue, $linker ) {
 
+		$dataItem = $dataValue->getDataItem();
+
 		// Turn Uri/Page links into a href representation when not used as value
 		if ( !$isValue &&
-			(
-				$dataValue->getDataItem() instanceof DIUri ||
-				$dataValue->getDataItem() instanceof DIWikiPage
+			( $dataItem instanceof DIUri || $dataItem instanceof DIWikiPage
 			) && $type !== self::VALUE ) {
 			return $dataValue->getShortHTMLText( smwfGetLinker() );
+		}
+
+		// Dates and times are to be displayed in a localized format
+		if ( !$isValue && $dataItem instanceof DITime && $type !== self::VALUE ) {
+			$dataValue->setOutputFormat( 'LOCL' );
 		}
 
 		switch ( $type ) {

--- a/src/Query/PrintRequest/Deserializer.php
+++ b/src/Query/PrintRequest/Deserializer.php
@@ -4,6 +4,7 @@ namespace SMW\Query\PrintRequest;
 
 use SMW\Query\PrintRequest;
 use SMWPropertyValue as PropertyValue;
+use SMW\DataValues\PropertyChainValue;
 use SMW\Localizer;
 use Title;
 use InvalidArgumentException;
@@ -46,6 +47,14 @@ class Deserializer {
 		} elseif ( self::isCategory( $printRequestLabel ) ) { // print categories
 			$printmode = PrintRequest::PRINT_CATS;
 			$label = $showMode ? '' : Localizer::getInstance()->getNamespaceTextById( NS_CATEGORY ); // default
+		} elseif ( PropertyChainValue::isChained( $printRequestLabel ) ) {
+
+			$data = new PropertyChainValue();
+			$data->setUserValue( $printRequestLabel );
+
+			$printmode = PrintRequest::PRINT_CHAIN;
+			$label = $showMode ? '' : $data->getLastPropertyChainValue()->getWikiValue();  // default
+
 		} else { // print property or check category
 			$title = Title::newFromText( $printRequestLabel, SMW_NS_PROPERTY ); // trim needed for \n
 

--- a/src/Serializers/QueryResultSerializer.php
+++ b/src/Serializers/QueryResultSerializer.php
@@ -210,11 +210,16 @@ class QueryResultSerializer implements DispatchableSerializer {
 			'format' => $printRequest->getOutputFormat()
 		);
 
-		if ( $printRequest->getMode() !== PrintRequest::PRINT_PROP ) {
-			return $serialized;
+		$data = $printRequest->getData();
+
+		if ( $printRequest->isMode( PrintRequest::PRINT_CHAIN ) ) {
+			$serialized['chain'] = $data->getDataItem()->getString();
+			$serialized['key'] = $data->getLastPropertyChainValue()->getDataItem()->getKey();
 		}
 
-		$data = $printRequest->getData();
+		if ( !$printRequest->isMode( PrintRequest::PRINT_PROP ) ) {
+			return $serialized;
+		}
 
 		if ( $data === null ) {
 			return $serialized;

--- a/tests/phpunit/Integration/ByJsonScript/Fixtures/f-0208.json
+++ b/tests/phpunit/Integration/ByJsonScript/Fixtures/f-0208.json
@@ -25,7 +25,11 @@
 		},
 		{
 			"name": "Example/F0208/3",
-			"contents": "[[Has page::F0208]]"
+			"contents": "[[Has page::F0208]] {{#subobject:Has text=ABC}}"
+		},
+		{
+			"name": "Example/F0208/4",
+			"contents": "[[Has page::Example/F0208/3]]"
 		},
 		{
 			"name": "Example/F0208/Q3.1",
@@ -46,6 +50,14 @@
 		{
 			"name": "Example/F0208/Q3.5",
 			"contents": "{{#show: Example/F0208/3 |mainlabel=- |?Has page |format=table |headers=plain |link=none |limit=0 }}"
+		},
+		{
+			"name": "Example/F0208/Q4.1",
+			"contents": "{{#ask:[[Has page::Example/F0208/3]] |mainlabel=- |?Has page.Has subobject.Has text |format=table |headers=plain |link=none |limit=0 }}"
+		},
+		{
+			"name": "Example/F0208/Q4.2",
+			"contents": "{{#ask:[[Has page::Example/F0208/3]] |mainlabel=- |?Has page.Has subobject.Has text=SomeOtherText |format=table |headers=plain |link=none |limit=0 }}"
 		}
 	],
 	"format-testcases": [
@@ -121,6 +133,24 @@
 			"expected-output": {
 				"to-contain": [
 					"Special:Ask/-5B-5B:Example-2FF0208-2F3-5D-5D/-3FHas-20page=/mainlabel=-2D/offset=0/format=table/link=none/headers=plain"
+				]
+			}
+		},
+		{
+			"about": "#8 (property chain on printrequest)",
+			"subject": "Example/F0208/Q4.1",
+			"expected-output": {
+				"to-contain": [
+					"Special:Ask/-5B-5BHas-20page::Example-2FF0208-2F3-5D-5D/-3FHas-20page.Has-20subobject.Has-20text=Has-20text/mainlabel=-2D/offset=0/format=table/link=none/headers=plain"
+				]
+			}
+		},
+		{
+			"about": "#9 (property chain on printrequest)",
+			"subject": "Example/F0208/Q4.2",
+			"expected-output": {
+				"to-contain": [
+					"Special:Ask/-5B-5BHas-20page::Example-2FF0208-2F3-5D-5D/-3FHas-20page.Has-20subobject.Has-20text=SomeOtherText/mainlabel=-2D/offset=0/format=table/link=none/headers=plain"
 				]
 			}
 		}

--- a/tests/phpunit/Integration/ByJsonScript/Fixtures/p-0432.json
+++ b/tests/phpunit/Integration/ByJsonScript/Fixtures/p-0432.json
@@ -1,5 +1,5 @@
 {
-	"description": "Test in-text annotation for '_ref_rec' type (`wgContLang=en`, `wgLang=en`)",
+	"description": "Test in-text annotation for '_ref_rec' type (#1808, `wgContLang=en`, `wgLang=en`)",
 	"properties": [
 		{
 			"name": "Has number with ref",
@@ -52,7 +52,7 @@
 			"expected-output": {
 				"to-contain": [
 					"123<span class=\"smw-reference smw-reference-indicator smw-highlighter smwttinline\" data-title=\"Reference\"",
-					"data-content=\"&lt;ul&gt;&lt;li&gt;Date: 1 January 2000&lt;/li&gt;&lt;li&gt;URL: &lt;a class=&quot;external&quot; rel=&quot;nofollow&quot; href=&quot;http://example.org&quot;&gt;http://example.org&lt;/a&gt;&lt;/li&gt;&lt;/ul&gt;\""
+					"data-content=\"&lt;ul&gt;&lt;li&gt;Date: January 1, 2000&lt;/li&gt;&lt;li&gt;URL: &lt;a class=&quot;external&quot; rel=&quot;nofollow&quot; href=&quot;http://example.org&quot;&gt;http://example.org&lt;/a&gt;&lt;/li&gt;&lt;/ul&gt;\""
 				]
 			}
 		},

--- a/tests/phpunit/Integration/ByJsonScript/Fixtures/p-0434.json
+++ b/tests/phpunit/Integration/ByJsonScript/Fixtures/p-0434.json
@@ -1,0 +1,122 @@
+{
+	"description": "Test printrequest property chaining `|?Foo.Bar` (#1824, `wgContLang=en`, `wgLang=en`)",
+	"properties": [
+		{
+			"name": "Has population",
+			"contents": "[[Has type::Reference]] [[Has fields::Number;Date;URL]]"
+		},
+		{
+			"name": "Capital of",
+			"contents": "[[Has type::Page]]"
+		}
+	],
+	"subjects": [
+		{
+			"name": "Example/P0434/1",
+			"contents": "[[Has population::123;1 Jan 1970;http://example.org/SomeSource]] {{#subobject:Has population=456;1 Jan 2000;http://example.org/SomeSource }} [[Category:P0434]]"
+		},
+		{
+			"name": "Example/P0434/Q1.1",
+			"contents": "{{#ask: [[Has population::+]] [[Category:P0434]] |?Has population.Number |link=none}}"
+		},
+		{
+			"name": "Example/P0434/Q1.2",
+			"contents": "{{#ask: [[Has population::+]] [[Category:P0434]] |?Has population.Date |link=none}}"
+		},
+		{
+			"name": "Example/P0434/2",
+			"contents": "[[Capital of::Example/P0434/1]] [[Located in::Example/P0434/3]] [[Category:City]] [[Category:P0434]]"
+		},
+		{
+			"name": "Example/P0434/Q2.1",
+			"contents": "{{#ask: [[Category:City]] [[Category:P0434]] |?Capital of.Has population.Number |link=none}}"
+		},
+		{
+			"name": "Example/P0434/3",
+			"contents": "[[Located in::Example/P0434/4]] [[Category:Country]] [[Category:P0434]]"
+		},
+		{
+			"name": "Example/P0434/Q3.1",
+			"contents": "{{#ask: [[Category:Country]] [[Category:P0434]] |?Located in.-Located in.-Located in.Capital of |link=subject }}"
+		},
+		{
+			"name": "Example/P0434/Q3.2",
+			"contents": "{{#ask: [[Category:Country]] [[Category:P0434]] |?Located in.-Located in.-Located in.Capital of=SomeOtherText |link=none }}"
+		},
+		{
+			"name": "Example/P0434/Q3.3",
+			"contents": "{{#ask: [[Category:Country]] [[Category:P0434]] |?Located in.-Located in.-Located in.Capital of.Has subobject.Has population.Number |link=none }}"
+		}
+	],
+	"parser-testcases": [
+		{
+			"about": "#0",
+			"subject": "Example/P0434/Q1.1",
+			"expected-output": {
+				"to-contain": [
+					"<td class=\"smwtype_wpg\">Example/P0434/1</td><td data-sort-value=\"123\" class=\"Number smwtype_num\">123</td>"
+				]
+			}
+		},
+		{
+			"about": "#1",
+			"subject": "Example/P0434/Q1.2",
+			"expected-output": {
+				"to-contain": [
+					"<td class=\"smwtype_wpg\">Example/P0434/1</td><td data-sort-value=\"2440587.5\" class=\"Date smwtype_dat\">1 January 1970</td></tr></table>"
+				]
+			}
+		},
+		{
+			"about": "#2 on (?Capital of.Has population.Number)",
+			"subject": "Example/P0434/Q2.1",
+			"expected-output": {
+				"to-contain": [
+					"<td class=\"smwtype_wpg\">Example/P0434/2</td><td data-sort-value=\"123\" class=\"Number smwtype_num\">123</td>"
+				],
+				"not-contain": [
+					"<td class=\"smwtype_wpg\">Example/P0434/1</td><td data-sort-value=\"123\" class=\"Number smwtype_num\">123</td>"
+				]
+			}
+		},
+		{
+			"about": "#3 on (?Located in.-Located in.-Located in.Capital of)",
+			"subject": "Example/P0434/Q3.1",
+			"expected-output": {
+				"to-contain": [
+					"<td class=\"Capital-of smwtype_wpg\">Example/P0434/1</td>"
+				]
+			}
+		},
+		{
+			"about": "#4 on (?Located in.-Located in.-Located in.Capital of=SomeOtherText)",
+			"subject": "Example/P0434/Q3.2",
+			"expected-output": {
+				"to-contain": [
+					"SomeOtherText</a>&#160;<span title=\"Located in.-Located in.-Located in.Capital of\">⠉</span>",
+					"<td class=\"SomeOtherText smwtype_wpg\">Example/P0434/1</td>"
+				]
+			}
+		},
+		{
+			"about": "#5 on (?Located in.-Located in.-Located in.Capital of.Has subobject.Has population.Number)",
+			"subject": "Example/P0434/Q3.3",
+			"expected-output": {
+				"to-contain": [
+					"<span title=\"Located in.-Located in.-Located in.Capital of.Has subobject.Has population.Number\">⠉</span>",
+					"<td class=\"smwtype_wpg\">Example/P0434/3</td><td data-sort-value=\"456\" class=\"Number smwtype_num\">456</td>"
+				]
+			}
+		}
+	],
+	"settings": {
+		"wgContLang": "en",
+		"wgLang": "en",
+		"smwgPageSpecialProperties": [ "_MDAT" ]
+	},
+	"meta": {
+		"version": "0.1",
+		"is-incomplete": false,
+		"debug": false
+	}
+}

--- a/tests/phpunit/TestEnvironment.php
+++ b/tests/phpunit/TestEnvironment.php
@@ -6,6 +6,7 @@ use SMW\ApplicationFactory;
 use SMW\DataValueFactory;
 use SMW\DeferredCallableUpdate;
 use SMW\Store;
+use SMW\Localizer;
 use SMW\Tests\Utils\UtilityFactory;
 use SMW\Tests\Utils\Mock\ConfigurableStub;
 use RuntimeException;
@@ -202,6 +203,25 @@ class TestEnvironment {
 	 */
 	public function getUtilityFactory() {
 		return UtilityFactory::getInstance();
+	}
+
+	/**
+	 * @since 2.5
+	 *
+	 * @param integer $ns
+	 * @param string $url
+	 *
+	 * @return string
+	 */
+	public function getLocalizedTextByNamespace( $ns, $text ) {
+
+		$namespace = Localizer::getInstance()->getNamespaceTextById( $ns );
+
+		return str_replace(
+			\MWNamespace::getCanonicalName( $ns ) . ':',
+			$namespace . ':',
+			$text
+		);
 	}
 
 	/**

--- a/tests/phpunit/Unit/DataValues/PropertyChainValueTest.php
+++ b/tests/phpunit/Unit/DataValues/PropertyChainValueTest.php
@@ -1,0 +1,155 @@
+<?php
+
+namespace SMW\Tests\DataValues;
+
+use SMW\DataValues\PropertyChainValue;
+use SMW\DIProperty;
+use SMW\Tests\TestEnvironment;
+
+/**
+ * @covers \SMW\DataValues\PropertyChainValue
+ * @group semantic-mediawiki
+ *
+ * @license GNU GPL v2+
+ * @since 2.5
+ *
+ * @author mwjames
+ */
+class PropertyChainValueTest extends \PHPUnit_Framework_TestCase {
+
+	private $testEnvironment;
+
+	protected function setUp() {
+		$this->testEnvironment = new TestEnvironment();
+	}
+
+	public function testCanConstruct() {
+
+		$this->assertInstanceOf(
+			'\SMW\DataValues\PropertyChainValue',
+			new PropertyChainValue()
+		);
+	}
+
+	public function testIsChained() {
+
+		$this->assertFalse(
+			PropertyChainValue::isChained( 'Foo' )
+		);
+
+		$this->assertTrue(
+			PropertyChainValue::isChained( 'Foo.Bar' )
+		);
+	}
+
+	public function testErrorOnUnchainedValue() {
+
+		$instance = new PropertyChainValue();
+
+		$instance->setUserValue( 'Foo' );
+
+		$this->assertNotEmpty(
+			$instance->getErrors()
+		);
+	}
+
+	public function testGetLastPropertyChainValue() {
+
+		$instance = new PropertyChainValue();
+
+		$instance->setUserValue( 'Foo.Bar' );
+
+		$this->assertEquals(
+			new DIProperty( 'Bar' ),
+			$instance->getLastPropertyChainValue()->getDataItem()
+		);
+
+		$this->assertInstanceOf(
+			'\SMWDIBlob',
+			$instance->getDataItem()
+		);
+	}
+
+	public function testGetPropertyChainValues() {
+
+		$instance = new PropertyChainValue();
+
+		$instance->setUserValue( 'Foo.Bar' );
+
+		$this->assertCount(
+			1,
+			$instance->getPropertyChainValues()
+		);
+	}
+
+	public function testGetWikiValue() {
+
+		$instance = new PropertyChainValue();
+
+		$instance->setUserValue( 'Foo.Bar' );
+
+		$this->assertEquals(
+			'Bar',
+			$instance->getWikiValue()
+		);
+	}
+
+	public function testGetShortWikiText() {
+
+		$instance = new PropertyChainValue();
+
+		$instance->setUserValue( 'Foo.Bar' );
+
+		$this->assertEquals(
+			'Bar&nbsp;<span title="Foo.Bar">⠉</span>',
+			$instance->getShortWikiText()
+		);
+
+		$this->assertEquals(
+			$this->testEnvironment->getLocalizedTextByNamespace( SMW_NS_PROPERTY, '[[:Property:Bar|Bar]]&nbsp;<span title="Foo.Bar">⠉</span>' ),
+			$instance->getShortWikiText( 'linker' )
+		);
+	}
+
+	public function testGetLongWikiText() {
+
+		$instance = new PropertyChainValue();
+
+		$instance->setUserValue( 'Foo.Bar' );
+
+		$this->assertEquals(
+			$this->testEnvironment->getLocalizedTextByNamespace( SMW_NS_PROPERTY, 'Property:Bar&nbsp;<span title="Foo.Bar">⠉</span>' ),
+			$instance->getLongWikiText()
+		);
+
+		$this->assertEquals(
+			$this->testEnvironment->getLocalizedTextByNamespace( SMW_NS_PROPERTY, '[[:Property:Bar|Property:Bar]]&nbsp;<span title="Foo.Bar">⠉</span>' ),
+			$instance->getLongWikiText( 'linker' )
+		);
+	}
+
+	public function testGetShortHTMLText() {
+
+		$instance = new PropertyChainValue();
+
+		$instance->setUserValue( 'Foo.Bar' );
+
+		$this->assertEquals(
+			'Bar&nbsp;<span title="Foo.Bar">⠉</span>',
+			$instance->getShortHTMLText()
+		);
+	}
+
+	public function testGetLongHTMLText() {
+
+		$instance = new PropertyChainValue();
+
+		$instance->setUserValue( 'Foo.Bar' );
+
+		$this->assertEquals(
+			$this->testEnvironment->getLocalizedTextByNamespace( SMW_NS_PROPERTY, 'Property:Bar&nbsp;<span title="Foo.Bar">⠉</span>' ),
+			$instance->getLongHTMLText()
+		);
+	}
+
+}

--- a/tests/phpunit/Unit/Query/PrintRequest/DeserializerTest.php
+++ b/tests/phpunit/Unit/Query/PrintRequest/DeserializerTest.php
@@ -4,8 +4,9 @@ namespace SMW\Tests\Query\PrintRequest;
 
 use SMW\Query\PrintRequest\Deserializer;
 use SMWPropertyValue as PropertyValue;
-use SMW\Query\PrintRequest;
 use SMW\Localizer;
+use SMW\DataValues\PropertyChainValue;
+use SMW\Query\PrintRequest;
 
 /**
  * @covers SMW\Query\PrintRequest\Deserializer
@@ -120,6 +121,26 @@ class DeserializerTest extends \PHPUnit_Framework_TestCase {
 			PrintRequest::PRINT_PROP,
 			PropertyValue::class,
 			'<span style="color: green; font-size: 120%;">&#10003;</span>,<span style="color: #AA0000; font-size: 120%;">&#10005;</span>'
+		);
+
+		#7
+		$provider[] = array(
+			'Foo.Bar',
+			false,
+			'Bar',
+			PrintRequest::PRINT_CHAIN,
+			PropertyChainValue::class,
+			''
+		);
+
+		#8
+		$provider[] = array(
+			'Foo.Bar#foobar',
+			false,
+			'Bar',
+			PrintRequest::PRINT_CHAIN,
+			PropertyChainValue::class,
+			'foobar'
 		);
 
 		return $provider;


### PR DESCRIPTION
This PR is made in reference to: # N/A (orthogonal refs #1812, #1819)

This PR addresses or contains:

- Support for the property chain notation in printrequests to provide the means to request page nodes of the next chain member (if the returned data type is not a page type then no further iterations are executed as the match process only takes into account `_wpg` edges)
- Elevated by the introduction of #1812 to allow for a more convenient access to provenance values using the `SomeProperty.AnotherProperty` notation in printouts

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed

