### PR TITLE
Allow to disable the QueryProfiler

### DIFF
--- a/DefaultSettings.php
+++ b/DefaultSettings.php
@@ -812,10 +812,15 @@ $GLOBALS['smwgShowHiddenCategories'] = true;
 # QueryProfiler related setting to enable/disable specific monitorable profile
 # data
 #
-# @note If these settings are changed, please ensure to run update.php
+# @note If these settings are changed, please ensure to run update.php/rebuildData.php
+#
+# - smwgQueryProfiler can be set false itself allowing it to disable its
+# functionality but it may impact secondary processes that rely on profile
+# information to be available (Notification system etc.)
 #
 # - smwgQueryDurationEnabled to record query duration (the time
 # between the query result selection and output its)
+#
 #
 # @since 1.9
 ##

--- a/includes/parserhooks/ConceptParserFunction.php
+++ b/includes/parserhooks/ConceptParserFunction.php
@@ -138,6 +138,11 @@ class ConceptParserFunction {
 
 	private function addQueryProfile( $query ) {
 
+		// If the smwgQueryProfiler is marked with FALSE then just don't create a profile.
+		if ( ApplicationFactory::getInstance()->getSettings()->get( 'smwgQueryProfiler' ) === false ) {
+			return;
+		}
+
 		$query->setContextPage(
 			$this->parserData->getSemanticData()->getSubject()
 		);

--- a/includes/query/SMW_Query.php
+++ b/includes/query/SMW_Query.php
@@ -37,6 +37,17 @@ class SMWQuery {
 	const MODE_DEBUG = 3; // prepare query, but show debug data instead of executing it
 	const MODE_NONE = 4;  // do nothing with the query
 
+	/**
+	 * The time the QueryEngine required to answer a query condition
+	 */
+	const PROC_QUERY_TIME = 'query.time';
+
+	/**
+	 * The time a ResultPrinter required to build the final result including all
+	 * PrintRequests
+	 */
+	const PROC_PRINT_TIME = 'print.time';
+
 	public $sort = false;
 	public $sortkeys = array(); // format: "Property key" => "ASC" / "DESC" (note: order of entries also matters)
 	public $querymode = self::MODE_INSTANCES;
@@ -66,6 +77,11 @@ class SMWQuery {
 	 * @var string|null
 	 */
 	private $querySource = null;
+
+	/**
+	 * @var array
+	 */
+	private $options = array();
 
 	/**
 	 * Constructor.
@@ -183,6 +199,27 @@ class SMWQuery {
 
 	public function setQueryString( $querystring ) {
 		$this->queryString = $querystring;
+	}
+
+	/**
+	 * @since 2.5
+	 *
+	 * @param string|integer $key
+	 * @param mixed $value
+	 */
+	public function setOption( $key, $value ) {
+		$this->options[$key] = $value;
+	}
+
+	/**
+	 * @since 2.5
+	 *
+	 * @param string|integer $key
+	 *
+	 * @return mixed
+	 */
+	public function getOptionBy( $key ) {
+		return isset( $this->options[$key] ) ? $this->options[$key] : false;
 	}
 
 	/**

--- a/includes/query/SMW_QueryProcessor.php
+++ b/includes/query/SMW_QueryProcessor.php
@@ -454,6 +454,7 @@ class SMWQueryProcessor {
 	public static function getResultFromQuery( SMWQuery $query, array $params, $outputMode, $context ) {
 
 		$res = self::getStoreFromParams( $params )->getQueryResult( $query );
+		$start = microtime( true );
 
 		if ( ( $query->querymode == SMWQuery::MODE_INSTANCES ) ||
 			( $query->querymode == SMWQuery::MODE_NONE ) ) {
@@ -461,7 +462,7 @@ class SMWQueryProcessor {
 			$printer = self::getResultPrinter( $params['format']->getValue(), $context );
 			$result = $printer->getResult( $res, $params, $outputMode );
 
-
+			$query->setOption( SMWQuery::PROC_PRINT_TIME, microtime( true ) - $start );
 			return $result;
 		} else { // result for counting or debugging is just a string or number
 
@@ -483,6 +484,7 @@ class SMWQueryProcessor {
 				$result = smwfEncodeMessages( $query->getErrors() );
 			}
 
+			$query->setOption( SMWQuery::PROC_PRINT_TIME, microtime( true ) - $start );
 
 			return $result;
 		}

--- a/includes/storage/SQLStore/SMW_SQLStore3.php
+++ b/includes/storage/SQLStore/SMW_SQLStore3.php
@@ -394,6 +394,7 @@ class SMWSQLStore3 extends SMWStore {
 	public function getQueryResult( SMWQuery $query ) {
 
 		$result = null;
+		$start = microtime( true );
 
 		if ( \Hooks::run( 'SMW::Store::BeforeQueryResultLookupComplete', array( $this, $query, &$result ) ) ) {
 			$result = $this->fetchQueryResult( $query );
@@ -401,6 +402,8 @@ class SMWSQLStore3 extends SMWStore {
 
 		\Hooks::run( 'SMW::SQLStore::AfterQueryResultLookupComplete', array( $this, &$result ) );
 		\Hooks::run( 'SMW::Store::AfterQueryResultLookupComplete', array( $this, &$result ) );
+
+		$query->setOption( SMWQuery::PROC_QUERY_TIME, microtime( true ) - $start );
 
 		return $result;
 	}

--- a/src/SPARQLStore/SPARQLStore.php
+++ b/src/SPARQLStore/SPARQLStore.php
@@ -272,12 +272,15 @@ class SPARQLStore extends Store {
 	public function getQueryResult( Query $query ) {
 
 		$result = null;
+		$start = microtime( true );
 
 		if ( \Hooks::run( 'SMW::Store::BeforeQueryResultLookupComplete', array( $this, $query, &$result ) ) ) {
 			$result = $this->fetchQueryResult( $query );
 		}
 
 		\Hooks::run( 'SMW::Store::AfterQueryResultLookupComplete', array( $this, &$result ) );
+
+		$query->setOption( Query::PROC_QUERY_TIME, microtime( true ) - $start );
 
 		return $result;
 	}

--- a/tests/phpunit/includes/parserhooks/AskParserFunctionTest.php
+++ b/tests/phpunit/includes/parserhooks/AskParserFunctionTest.php
@@ -324,6 +324,46 @@ class AskParserFunctionTest extends \PHPUnit_Framework_TestCase {
 		);
 	}
 
+	public function testWithDisabledQueryProfiler() {
+
+		$params = array(
+			'[[Modification date::+]]',
+			'format=table'
+		);
+
+		$expected = array(
+			'propertyCount'  => 0
+		);
+
+		$this->applicationFactory->getSettings()->set( 'smwgQueryProfiler', false );
+
+		$parserData = $this->applicationFactory->newParserData(
+			Title::newFromText( __METHOD__ ),
+			new ParserOutput()
+		);
+
+		$messageFormatter = $this->getMockBuilder( '\SMW\MessageFormatter' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$circularReferenceGuard = $this->getMockBuilder( '\SMW\CircularReferenceGuard' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$instance = new AskParserFunction(
+			$parserData,
+			$messageFormatter,
+			$circularReferenceGuard
+		);
+
+		$instance->parse( $params );
+
+		$this->semanticDataValidator->assertThatPropertiesAreSet(
+			$expected,
+			$parserData->getSemanticData()
+		);
+	}
+
 	public function queryDataProvider() {
 
 		$categoryNS = Localizer::getInstance()->getNamespaceTextById( NS_CATEGORY );


### PR DESCRIPTION
This PR is made in reference to: #N/A

This PR addresses or contains:

- Some users may want to disable the `QueryProfiler` (which is not recommended) by setting `$GLOBALS['smwgQueryProfiler'] = false`
- PR is made in response to an inquiry (http://wikimedia.7.x6.nabble.com/Has-query-question-td5067316.html)

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed

