### PR TITLE
Check SMW_DV_WPV_DTITLE for DisplayTitlePropertyAnnotator, refs #1823

### DIFF
--- a/src/PropertyAnnotator/DisplayTitlePropertyAnnotator.php
+++ b/src/PropertyAnnotator/DisplayTitlePropertyAnnotator.php
@@ -23,6 +23,11 @@ class DisplayTitlePropertyAnnotator extends PropertyAnnotatorDecorator {
 	private $defaultSort;
 
 	/**
+	 * @var boolean
+	 */
+	private $canCreateAnnotation = true;
+
+	/**
 	 * @since 2.4
 	 *
 	 * @param PropertyAnnotator $propertyAnnotator
@@ -35,9 +40,20 @@ class DisplayTitlePropertyAnnotator extends PropertyAnnotatorDecorator {
 		$this->defaultSort = $defaultSort;
 	}
 
+	/**
+	 * @see SMW_DV_WPV_DTITLE in $GLOBALS['smwgDVFeatures']
+	 *
+	 * @since 2.5
+	 *
+	 * @param boolean $canCreateAnnotation
+	 */
+	public function canCreateAnnotation( $canCreateAnnotation ) {
+		$this->canCreateAnnotation = (bool)$canCreateAnnotation;
+	}
+
 	protected function addPropertyValues() {
 
-		if ( !$this->displayTitle || $this->displayTitle === '' ) {
+		if ( !$this->canCreateAnnotation || !$this->displayTitle || $this->displayTitle === '' ) {
 			return;
 		}
 

--- a/src/PropertyAnnotatorFactory.php
+++ b/src/PropertyAnnotatorFactory.php
@@ -93,11 +93,18 @@ class PropertyAnnotatorFactory {
 	 * @return DisplayTitlePropertyAnnotator
 	 */
 	public function newDisplayTitlePropertyAnnotator( SemanticData $semanticData, $displayTitle, $defaultSort ) {
-		return new DisplayTitlePropertyAnnotator(
+
+		$displayTitlePropertyAnnotator = new DisplayTitlePropertyAnnotator(
 			$this->newNullPropertyAnnotator( $semanticData ),
 			$displayTitle,
 			$defaultSort
 		);
+
+		$displayTitlePropertyAnnotator->canCreateAnnotation(
+			( ApplicationFactory::getInstance()->getSettings()->get( 'smwgDVFeatures' ) & SMW_DV_WPV_DTITLE ) != 0
+		);
+
+		return $displayTitlePropertyAnnotator;
 	}
 
 	/**

--- a/tests/phpunit/Unit/PropertyAnnotator/DisplayTitlePropertyAnnotatorTest.php
+++ b/tests/phpunit/Unit/PropertyAnnotator/DisplayTitlePropertyAnnotatorTest.php
@@ -94,6 +94,29 @@ class DisplayTitlePropertyAnnotatorTest extends \PHPUnit_Framework_TestCase {
 		);
 	}
 
+	public function testNoAnnotationWhenDisabled() {
+
+		$semanticData = $this->semanticDataFactory->newEmptySemanticData(
+			DIWikiPage::newFromText( 'Foo' )
+		);
+
+		$instance = new DisplayTitlePropertyAnnotator(
+			new NullPropertyAnnotator( $semanticData ),
+			'Bar'
+		);
+		$instance->canCreateAnnotation( false );
+		$instance->addAnnotation();
+
+		$expected = array(
+			'propertyCount'  => 0
+		);
+
+		$this->semanticDataValidator->assertThatPropertiesAreSet(
+			$expected,
+			$instance->getSemanticData()
+		);
+	}
+
 	public function displayTitleProvider() {
 
 		$provider = array();


### PR DESCRIPTION
This PR is made in reference to: #1823 (#1410, #1534)

This PR addresses or contains:

- Only have the `DisplayTitlePropertyAnnotator` create an annotation in case `SMW_DV_WPV_DTITLE` is enabled

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed

