### PR TITLE
Use MappingIterator in IdToDataItemMatchFinder

### DIFF
--- a/includes/storage/SQLStore/SMW_SQLStore3.php
+++ b/includes/storage/SQLStore/SMW_SQLStore3.php
@@ -178,9 +178,8 @@ class SMWSQLStore3 extends SMWStore {
 	 * @since 1.8
 	 */
 	public function __construct() {
-		$this->smwIds = new SMWSql3SmwIds( $this );
 		$this->factory = new SQLStoreFactory( $this );
-
+		$this->smwIds = $this->factory->newIdTableManager();
 		$this->cachedValueLookupStore = $this->factory->newCachedValueLookupStore();
 	}
 

--- a/includes/storage/SQLStore/SMW_Sql3SmwIds.php
+++ b/includes/storage/SQLStore/SMW_Sql3SmwIds.php
@@ -220,14 +220,12 @@ class SMWSql3SmwIds {
 	 * @since 1.8
 	 * @param SMWSQLStore3 $store
 	 */
-	public function __construct( SMWSQLStore3 $store ) {
+	public function __construct( SMWSQLStore3 $store, IdToDataItemMatchFinder $idToDataItemMatchFinder ) {
 		$this->store = $store;
 		// Yes, this is a hack, but we only use it for convenient debugging:
 		self::$singleton_debug = $this;
 
-		$this->idToDataItemMatchFinder = new IdToDataItemMatchFinder(
-			$this->store->getConnection( 'mw.db' )
-		);
+		$this->idToDataItemMatchFinder = $idToDataItemMatchFinder;
 
 		$this->redirectInfoStore = new RedirectInfoStore(
 			$this->store->getConnection( 'mw.db' )

--- a/src/ApplicationFactory.php
+++ b/src/ApplicationFactory.php
@@ -213,6 +213,15 @@ class ApplicationFactory {
 	}
 
 	/**
+	 * @since 2.5
+	 *
+	 * @return IteratorFactory
+	 */
+	public function getIteratorFactory() {
+		return $this->callbackLoader->singleton( 'IteratorFactory' );
+	}
+
+	/**
 	 * @since 2.0
 	 *
 	 * @return Cache

--- a/src/IteratorFactory.php
+++ b/src/IteratorFactory.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace SMW;
+
+use SMW\Iterators\ResultIterator;
+use SMW\Iterators\MappingIterator;
+
+/**
+ * @license GNU GPL v2+
+ * @since 2.5
+ *
+ * @author mwjames
+ */
+class IteratorFactory {
+
+	/**
+	 * @since 2.5
+	 *
+	 * @param ResultWrapper|array $res
+	 *
+	 * @return ResultIterator
+	 */
+	public function newResultIterator( $res ) {
+		return new ResultIterator( $res );
+	}
+
+	/**
+	 * @since 2.5
+	 *
+	 * @param Iterator/array $$iterable
+	 * @param callable $callback
+	 *
+	 * @return MappingIterator
+	 */
+	public function newMappingIterator( $iterable, callable $callback ) {
+		return new MappingIterator( $iterable, $callback );
+	}
+
+}

--- a/src/Iterators/MappingIterator.php
+++ b/src/Iterators/MappingIterator.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace SMW\Iterators;
+
+use IteratorIterator;
+use Iterator;
+use ArrayIterator;
+use RuntimeException;
+use Countable;
+
+/**
+ * This iterator is expected to be called in combination with another iterator
+ * (or traversable/array) in order to apply a mapping on the returned current element
+ * during an iterative (foreach etc.) process.
+ *
+ * @license GNU GPL v2+
+ * @since 2.5
+ *
+ * @author mwjames
+ */
+class MappingIterator extends IteratorIterator implements Countable  {
+
+	/**
+	 * @var callable
+	 */
+	private $callback;
+
+	/**
+	 * @var integer
+	 */
+	private $count = 1;
+
+	/**
+	 * @since 2.5
+	 *
+	 * @param Iterator|array $iterable
+	 * @param callable  $callback
+	 */
+	public function __construct( $iterable, callable $callback ) {
+
+		if ( is_array( $iterable ) ) {
+			$iterable = new ArrayIterator( $iterable );
+		}
+
+		if ( !$iterable instanceof Iterator ) {
+			throw new RuntimeException( "MappingIterator expected an Iterator" );
+		}
+
+		if ( $iterable instanceof Countable ) {
+			$this->count = $iterable->count();
+		}
+
+		parent::__construct( $iterable );
+		$this->callback = $callback;
+	}
+
+	/**
+	 * @see Countable::count
+	 * @since 2.5
+	 *
+	 * {@inheritDoc}
+	 */
+	public function count() {
+		return $this->count;
+	}
+
+	/**
+	 * @since 2.5
+	 *
+	 * {@inheritDoc}
+	 */
+	public function current() {
+		return call_user_func( $this->callback, parent::current() );
+	}
+
+}

--- a/src/Iterators/ResultIterator.php
+++ b/src/Iterators/ResultIterator.php
@@ -1,0 +1,143 @@
+<?php
+
+namespace SMW\Iterators;
+
+use Iterator;
+use Countable;
+use ResultWrapper;
+use ArrayIterator;
+use SeekableIterator;
+use RuntimeException;
+
+/**
+ * @license GNU GPL v2+
+ * @since 2.5
+ *
+ * @author mwjames
+ */
+class ResultIterator implements Iterator, Countable, SeekableIterator {
+
+	/**
+	 * @var ResultWrapper
+	 */
+	public $res;
+
+	/**
+	 * @var integer
+	 */
+	public $position;
+
+	/**
+	 * @var mixed
+	 */
+	public $current;
+
+	/**
+	 * @var boolean
+	 */
+	public $isResultWrapper = false;
+
+	/**
+	 * @since 2.5
+	 *
+	 * @param ResultWrapper|array $res
+	 */
+	public function __construct( $res ) {
+
+		if ( $res instanceof ResultWrapper ) {
+			$this->isResultWrapper = true;
+		}
+
+		if ( !$this->isResultWrapper && is_array( $res ) ) {
+			$res = new ArrayIterator( $res );
+		}
+
+		if ( !$res instanceof Iterator && !$this->isResultWrapper ) {
+			throw new RuntimeException( "ResultIterator expected an ResultWrapper or array" );
+		}
+
+		$this->res = $res;
+		$this->position = 0;
+		$this->setCurrent( $this->res->current() );
+	}
+
+	/**
+	 * @see Countable::count
+	 * @since 2.5
+	 *
+	 * {@inheritDoc}
+	 */
+	public function count() {
+		return $this->isResultWrapper ? $this->res->numRows() : $this->res->count();
+	}
+
+	/**
+	 * @see SeekableIterator::seek
+	 * @since 2.5
+	 *
+	 * {@inheritDoc}
+	 */
+	public function seek( $position ) {
+		$this->res->seek( $position );
+		$this->setCurrent( $this->res->current() );
+		$this->position = $position;
+	}
+
+	/**
+	 * @since 2.5
+	 *
+	 * {@inheritDoc}
+	 */
+	public function current() {
+		return $this->current;
+	}
+
+	/**
+	 * @since 2.5
+	 *
+	 * {@inheritDoc}
+	 */
+	public function key() {
+		return $this->position;
+	}
+
+	/**
+	 * @since 2.5
+	 *
+	 * {@inheritDoc}
+	 */
+	public function next() {
+		$row = $this->res->next();
+		$this->setCurrent( $row );
+		$this->position++;
+	}
+
+	/**
+	 * @since 2.5
+	 *
+	 * {@inheritDoc}
+	 */
+	public function rewind() {
+		$this->res->rewind();
+		$this->position = 0;
+		$this->setCurrent( $this->res->current() );
+	}
+
+	/**
+	 * @since 2.5
+	 *
+	 * {@inheritDoc}
+	 */
+	public function valid() {
+		return $this->current !== false;
+	}
+
+	protected function setCurrent( $row ) {
+		if ( $row === false || $row === null ) {
+			$this->current = false;
+		} else {
+			$this->current = $row;
+		}
+	}
+
+}

--- a/src/MediaWiki/Jobs/ParserCachePurgeJob.php
+++ b/src/MediaWiki/Jobs/ParserCachePurgeJob.php
@@ -138,7 +138,7 @@ class ParserCachePurgeJob extends JobBase {
 		$this->addPagesToUpdater( $hashList );
 	}
 
-	private function doBuildUniqueTargetLinksHashList( array $targetLinksHashList ) {
+	private function doBuildUniqueTargetLinksHashList( $targetLinksHashList ) {
 
 		$uniqueTargetLinksHashList = array();
 

--- a/src/SharedCallbackContainer.php
+++ b/src/SharedCallbackContainer.php
@@ -28,6 +28,7 @@ class SharedCallbackContainer implements CallbackContainer {
 	public function register( CallbackLoader $callbackLoader ) {
 		$this->registerCallbackHandlers( $callbackLoader );
 		$this->registerCallbackHandlersByFactory( $callbackLoader );
+		$this->registerCallbackHandlersByConstructedInstance( $callbackLoader );
 	}
 
 	private function registerCallbackHandlers( $callbackLoader ) {
@@ -42,12 +43,6 @@ class SharedCallbackContainer implements CallbackContainer {
 
 		$callbackLoader->registerCallback( 'Store', function( $store = null ) use ( $callbackLoader ) {
 			return StoreFactory::getStore( $store !== null ? $store : $callbackLoader->singleton( 'Settings' )->get( 'smwgDefaultStore' ) );
-		} );
-
-		$callbackLoader->registerExpectedReturnType( 'CacheFactory', '\SMW\CacheFactory' );
-
-		$callbackLoader->registerCallback( 'CacheFactory', function( $mainCacheType = null ) {
-			return new CacheFactory( $mainCacheType );
 		} );
 
 		$callbackLoader->registerExpectedReturnType( 'Cache', '\Onoi\Cache\Cache' );
@@ -99,12 +94,45 @@ class SharedCallbackContainer implements CallbackContainer {
 			return new ContentParser( $title );
 		} );
 
+		$callbackLoader->registerExpectedReturnType( 'DeferredCallableUpdate', '\SMW\DeferredCallableUpdate' );
+
+		$callbackLoader->registerCallback( 'DeferredCallableUpdate', function( \Closure $callback ) {
+			return new DeferredCallableUpdate( $callback );
+		} );
+	}
+
+	private function registerCallbackHandlersByFactory( $callbackLoader ) {
+
+		/**
+		 * @var CacheFactory
+		 */
+		$callbackLoader->registerExpectedReturnType( 'CacheFactory', '\SMW\CacheFactory' );
+
+		$callbackLoader->registerCallback( 'CacheFactory', function( $mainCacheType = null ) {
+			return new CacheFactory( $mainCacheType );
+		} );
+
+		/**
+		 * @var IteratorFactory
+		 */
+		$callbackLoader->registerExpectedReturnType( 'IteratorFactory', '\SMW\IteratorFactory' );
+
+		$callbackLoader->registerCallback( 'IteratorFactory', function() {
+			return new IteratorFactory();
+		} );
+
+		/**
+		 * @var JobFactory
+		 */
 		$callbackLoader->registerExpectedReturnType( 'JobFactory', '\SMW\MediaWiki\Jobs\JobFactory' );
 
 		$callbackLoader->registerCallback( 'JobFactory', function() {
 			return new JobFactory();
 		} );
 
+		/**
+		 * @var FactboxFactory
+		 */
 		$callbackLoader->registerExpectedReturnType( 'FactboxFactory', '\SMW\Factbox\FactboxFactory' );
 
 		$callbackLoader->registerCallback( 'FactboxFactory', function() {
@@ -130,16 +158,13 @@ class SharedCallbackContainer implements CallbackContainer {
 			$callbackLoader->registerExpectedReturnType( 'QueryFactory', '\SMW\QueryFactory' );
 			return new QueryFactory();
 		} );
-
-		$callbackLoader->registerExpectedReturnType( 'DeferredCallableUpdate', '\SMW\DeferredCallableUpdate' );
-
-		$callbackLoader->registerCallback( 'DeferredCallableUpdate', function( \Closure $callback ) {
-			return new DeferredCallableUpdate( $callback );
-		} );
 	}
 
-	private function registerCallbackHandlersByFactory( $callbackLoader ) {
+	private function registerCallbackHandlersByConstructedInstance( $callbackLoader ) {
 
+		/**
+		 * @var BlobStore
+		 */
 		$callbackLoader->registerCallback( 'BlobStore', function( $namespace, $cacheType = null, $ttl = 0 ) use ( $callbackLoader ) {
 			$callbackLoader->registerExpectedReturnType( 'BlobStore', '\Onoi\BlobStore\BlobStore' );
 
@@ -161,6 +186,9 @@ class SharedCallbackContainer implements CallbackContainer {
 			return $blobStore;
 		} );
 
+		/**
+		 * @var CachedPropertyValuesPrefetcher
+		 */
 		$callbackLoader->registerCallback( 'CachedPropertyValuesPrefetcher', function( $cacheType = null, $ttl = 604800 ) use ( $callbackLoader ) {
 			$callbackLoader->registerExpectedReturnType( 'CachedPropertyValuesPrefetcher', '\SMW\CachedPropertyValuesPrefetcher' );
 
@@ -172,6 +200,9 @@ class SharedCallbackContainer implements CallbackContainer {
 			return $cachedPropertyValuesPrefetcher;
 		} );
 
+		/**
+		 * @var PropertySpecificationLookup
+		 */
 		$callbackLoader->registerCallback( 'PropertySpecificationLookup', function() use ( $callbackLoader ) {
 			$callbackLoader->registerExpectedReturnType( 'PropertySpecificationLookup', '\SMW\PropertySpecificationLookup' );
 
@@ -188,7 +219,9 @@ class SharedCallbackContainer implements CallbackContainer {
 			return $propertySpecificationLookup;
 		} );
 
-
+		/**
+		 * @var PropertyHierarchyLookup
+		 */
 		$callbackLoader->registerCallback( 'PropertyHierarchyLookup', function() use ( $callbackLoader ) {
 			$callbackLoader->registerExpectedReturnType( 'PropertyHierarchyLookup', '\SMW\PropertyHierarchyLookup' );
 

--- a/tests/phpunit/Unit/ApplicationFactoryTest.php
+++ b/tests/phpunit/Unit/ApplicationFactoryTest.php
@@ -197,6 +197,14 @@ class ApplicationFactoryTest extends \PHPUnit_Framework_TestCase {
 		);
 	}
 
+	public function testCanConstructIteratorFactory() {
+
+		$this->assertInstanceOf(
+			'\SMW\IteratorFactory',
+			$this->applicationFactory->getIteratorFactory()
+		);
+	}
+
 	public function testCanConstructPropertySpecificationLookup() {
 
 		$this->assertInstanceOf(

--- a/tests/phpunit/Unit/IteratorFactoryTest.php
+++ b/tests/phpunit/Unit/IteratorFactoryTest.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace SMW\Tests;
+
+use SMW\IteratorFactory;
+
+/**
+ * @covers \SMW\IteratorFactory
+ * @group semantic-mediawiki
+ *
+ * @license GNU GPL v2+
+ * @since 2.5
+ *
+ * @author mwjames
+ */
+class IteratorFactoryTest extends \PHPUnit_Framework_TestCase {
+
+	public function testCanConstructResultIterator() {
+
+		$instance = new IteratorFactory();
+
+		$result = $this->getMockBuilder( '\ResultWrapper' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$this->assertInstanceOf(
+			'\SMW\Iterators\ResultIterator',
+			$instance->newResultIterator( $result )
+		);
+	}
+
+	public function testCanConstructMappingIterator() {
+
+		$instance = new IteratorFactory();
+
+		$iterator = $this->getMockBuilder( '\Iterator' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$this->assertInstanceOf(
+			'\SMW\Iterators\MappingIterator',
+			$instance->newMappingIterator( $iterator, function(){} )
+		);
+	}
+
+}

--- a/tests/phpunit/Unit/Iterators/MappingIteratorTest.php
+++ b/tests/phpunit/Unit/Iterators/MappingIteratorTest.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace SMW\Iterators\Tests;
+
+use SMW\Iterators\MappingIterator;
+use ArrayIterator;
+
+/**
+ * @covers \SMW\Iterators\MappingIterator
+ * @group semantic-mediawiki
+ *
+ * @license GNU GPL v2+
+ * @since 2.5
+ *
+ * @author mwjames
+ */
+class MappingIteratorTest extends \PHPUnit_Framework_TestCase {
+
+	public function testCanConstruct() {
+
+		$this->assertInstanceOf(
+			MappingIterator::class,
+			new MappingIterator( array(), function() {} )
+		);
+	}
+
+	public function testInvalidConstructorArgumentThrowsException() {
+
+		$this->setExpectedException( 'RuntimeException' );
+		$instance = new MappingIterator( 2, function() {} );
+	}
+
+	public function testdoIterateOnArray() {
+
+		$expected = array(
+			1 , 42
+		);
+
+		$mappingIterator = new MappingIterator( $expected, function( $counter ) {
+			return $counter;
+		} );
+
+		foreach ( $mappingIterator as $key => $value ) {
+			$this->assertEquals(
+				$expected[$key],
+				$value
+			);
+		}
+	}
+
+	public function testdoIterateOnArrayIterator() {
+
+		$expected = array(
+			1001 , 42
+		);
+
+		$mappingIterator = new MappingIterator( new ArrayIterator( $expected ), function( $counter ) {
+			return $counter;
+		} );
+
+		$this->assertCount(
+			2,
+			$mappingIterator
+		);
+
+		foreach ( $mappingIterator as $key => $value ) {
+			$this->assertEquals(
+				$expected[$key],
+				$value
+			);
+		}
+	}
+
+}

--- a/tests/phpunit/Unit/Iterators/ResultIteratorTest.php
+++ b/tests/phpunit/Unit/Iterators/ResultIteratorTest.php
@@ -1,0 +1,98 @@
+<?php
+
+namespace SMW\Iterators\Tests;
+
+use SMW\Iterators\ResultIterator;
+use ArrayIterator;
+
+/**
+ * @covers \SMW\Iterators\ResultIterator
+ * @group semantic-mediawiki
+ *
+ * @license GNU GPL v2+
+ * @since 2.5
+ *
+ * @author mwjames
+ */
+class ResultIteratorTest extends \PHPUnit_Framework_TestCase {
+
+	public function testCanConstruct() {
+
+		$this->assertInstanceOf(
+			ResultIterator::class,
+			new ResultIterator( array() )
+		);
+	}
+
+	public function testInvalidConstructorArgumentThrowsException() {
+
+		$this->setExpectedException( 'RuntimeException' );
+		$instance = new ResultIterator( 2 );
+	}
+
+	public function testdoIterateOnArray() {
+
+		$result = array(
+			1, 42
+		);
+
+		$instance = new ResultIterator( $result );
+
+		$this->assertCount(
+			2,
+			$instance
+		);
+
+		foreach ( $instance as $key => $value ) {
+			$this->assertEquals(
+				$result[$key],
+				$value
+			);
+		}
+	}
+
+	public function testdoSeekOnArray() {
+
+		$result = array(
+			1, 42, 1001
+		);
+
+		$instance = new ResultIterator( $result );
+		$instance->seek( 1 );
+
+		$this->assertEquals(
+			42,
+			$instance->current()
+		);
+	}
+
+	public function testdoIterateOnResultWrapper() {
+
+		$resultWrapper = $this->getMockBuilder( '\ResultWrapper' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$resultWrapper->expects( $this->once() )
+			->method( 'numRows' )
+			->will( $this->returnValue( 1 ) );
+
+		$resultWrapper->expects( $this->atLeastOnce() )
+			->method( 'current' )
+			->will( $this->returnValue( 42 ) );
+
+		$instance = new ResultIterator( $resultWrapper );
+
+		$this->assertCount(
+			1,
+			$instance
+		);
+
+		foreach ( $instance as $key => $value ) {
+			$this->assertEquals(
+				42,
+				$value
+			);
+		}
+	}
+
+}

--- a/tests/phpunit/Unit/SQLStore/IdToDataItemMatchFinderTest.php
+++ b/tests/phpunit/Unit/SQLStore/IdToDataItemMatchFinderTest.php
@@ -4,6 +4,7 @@ namespace SMW\Tests\SQLStore;
 
 use SMW\InMemoryPoolCache;
 use SMW\SQLStore\IdToDataItemMatchFinder;
+use SMW\IteratorFactory;
 use SMW\Tests\TestEnvironment;
 
 /**
@@ -18,9 +19,14 @@ use SMW\Tests\TestEnvironment;
 class IdToDataItemMatchFinderTest extends \PHPUnit_Framework_TestCase {
 
 	private $testEnvironment;
+	private $iteratorFactory;
 
 	protected function setUp() {
 		$this->testEnvironment = new TestEnvironment();
+
+		$this->iteratorFactory = $this->getMockBuilder( '\SMW\IteratorFactory' )
+			->disableOriginalConstructor()
+			->getMock();
 	}
 
 	protected function tearDown() {
@@ -35,7 +41,7 @@ class IdToDataItemMatchFinderTest extends \PHPUnit_Framework_TestCase {
 
 		$this->assertInstanceOf(
 			'\SMW\SQLStore\IdToDataItemMatchFinder',
-			new IdToDataItemMatchFinder( $connection )
+			new IdToDataItemMatchFinder( $connection, $this->iteratorFactory )
 		);
 	}
 
@@ -60,7 +66,8 @@ class IdToDataItemMatchFinderTest extends \PHPUnit_Framework_TestCase {
 			->will( $this->returnValue( $row ) );
 
 		$instance = new IdToDataItemMatchFinder(
-			$connection
+			$connection,
+			$this->iteratorFactory
 		);
 
 		$this->assertInstanceOf(
@@ -88,7 +95,8 @@ class IdToDataItemMatchFinderTest extends \PHPUnit_Framework_TestCase {
 		InMemoryPoolCache::getInstance()->getPoolCacheFor( IdToDataItemMatchFinder::POOLCACHE_ID )->save( 42, 'Foo#0##' );
 
 		$instance = new IdToDataItemMatchFinder(
-			$connection
+			$connection,
+			$this->iteratorFactory
 		);
 
 		$this->assertInstanceOf(
@@ -119,7 +127,8 @@ class IdToDataItemMatchFinderTest extends \PHPUnit_Framework_TestCase {
 			->method( 'selectRow' );
 
 		$instance = new IdToDataItemMatchFinder(
-			$connection
+			$connection,
+			$this->iteratorFactory
 		);
 
 		$instance->saveToCache( 42, '_MDAT#102##' );
@@ -141,7 +150,8 @@ class IdToDataItemMatchFinderTest extends \PHPUnit_Framework_TestCase {
 			->will( $this->returnValue( false ) );
 
 		$instance = new IdToDataItemMatchFinder(
-			$connection
+			$connection,
+			$this->iteratorFactory
 		);
 
 		$instance->saveToCache( 42, 'Foo#14##' );
@@ -162,7 +172,8 @@ class IdToDataItemMatchFinderTest extends \PHPUnit_Framework_TestCase {
 			->will( $this->returnValue( false ) );
 
 		$instance = new IdToDataItemMatchFinder(
-			$connection
+			$connection,
+			$this->iteratorFactory
 		);
 
 		$instance->saveToCache( 42, 'Foo#0##' );
@@ -182,7 +193,10 @@ class IdToDataItemMatchFinderTest extends \PHPUnit_Framework_TestCase {
 			->method( 'selectRow' )
 			->will( $this->returnValue( false ) );
 
-		$instance = new IdToDataItemMatchFinder( $connection );
+		$instance = new IdToDataItemMatchFinder(
+			$connection,
+			$this->iteratorFactory
+		);
 
 		$this->assertNull(
 			$instance->getDataItemForId( 42 )
@@ -210,13 +224,16 @@ class IdToDataItemMatchFinderTest extends \PHPUnit_Framework_TestCase {
 			->will( $this->returnValue( array( $row ) ) );
 
 		$instance = new IdToDataItemMatchFinder(
-			$connection
+			$connection,
+			new IteratorFactory()
 		);
 
-		$this->assertEquals(
-			array( 'Foo#0##' ),
-			$instance->getDataItemPoolHashListFor( array( 42 ) )
-		);
+		foreach ( $instance->getDataItemPoolHashListFor( array( 42 ) ) as $value ) {
+			$this->assertEquals(
+				'Foo#0##',
+				$value
+			);
+		}
 	}
 
 }

--- a/tests/phpunit/Unit/SQLStore/SQLStoreFactoryTest.php
+++ b/tests/phpunit/Unit/SQLStore/SQLStoreFactoryTest.php
@@ -75,6 +75,16 @@ class SQLStoreFactoryTest extends \PHPUnit_Framework_TestCase {
 		);
 	}
 
+	public function testCanConstractIdTableManager() {
+
+		$instance = new SQLStoreFactory( new SMWSQLStore3() );
+
+		$this->assertInstanceOf(
+			'SMWSql3SmwIds',
+			$instance->newIdTableManager()
+		);
+	}
+
 	public function testCanConstructUsageStatisticsCachedListLookup() {
 
 		$instance = new SQLStoreFactory( new SMWSQLStore3() );

--- a/tests/phpunit/includes/storage/sqlstore/SQLStoreSmwIdsTest.php
+++ b/tests/phpunit/includes/storage/sqlstore/SQLStoreSmwIdsTest.php
@@ -8,11 +8,7 @@ use SMWSql3SmwIds;
 
 /**
  * @covers \SMWSql3SmwIds
- *
- * @group SMW
- * @group SMWExtension
- *
- * @group semantic-mediawiki-sqlstore
+ * @group semantic-mediawiki
  *
  * @license GNU GPL v2+
  * @since 1.9.1
@@ -20,6 +16,20 @@ use SMWSql3SmwIds;
  * @author mwjames
  */
 class SQLStoreSmwIdsTest extends \PHPUnit_Framework_TestCase {
+
+	private $store;
+	private $idToDataItemMatchFinder;
+
+	protected function setUp() {
+
+		$this->store = $this->getMockBuilder( '\SMW\SQLStore\SQLStore' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$this->idToDataItemMatchFinder = $this->getMockBuilder( '\SMW\SQLStore\IdToDataItemMatchFinder' )
+			->disableOriginalConstructor()
+			->getMock();
+	}
 
 	public function testCanConstruct() {
 
@@ -37,7 +47,7 @@ class SQLStoreSmwIdsTest extends \PHPUnit_Framework_TestCase {
 
 		$this->assertInstanceOf(
 			'\SMWSql3SmwIds',
-			new SMWSql3SmwIds( $store )
+			new SMWSql3SmwIds( $store, $this->idToDataItemMatchFinder )
 		);
 	}
 
@@ -57,7 +67,10 @@ class SQLStoreSmwIdsTest extends \PHPUnit_Framework_TestCase {
 			->method( 'getConnection' )
 			->will( $this->returnValue( $connection ) );
 
-		$instance = new SMWSql3SmwIds( $store );
+		$instance = new SMWSql3SmwIds(
+			$store,
+			$this->idToDataItemMatchFinder
+		);
 
 		$this->assertFalse(
 			$instance->checkIsRedirect( $subject )
@@ -108,7 +121,10 @@ class SQLStoreSmwIdsTest extends \PHPUnit_Framework_TestCase {
 			->method( 'getConnection' )
 			->will( $this->returnValue( $connection ) );
 
-		$instance = new SMWSql3SmwIds( $store );
+		$instance = new SMWSql3SmwIds(
+			$store,
+			$this->idToDataItemMatchFinder
+		);
 
 		$result = $instance->getSMWPropertyID( new DIProperty( 'Foo' ) );
 
@@ -141,7 +157,10 @@ class SQLStoreSmwIdsTest extends \PHPUnit_Framework_TestCase {
 			->method( 'getConnection' )
 			->will( $this->returnValue( $connection ) );
 
-		$instance = new SMWSql3SmwIds( $store );
+		$instance = new SMWSql3SmwIds(
+			$store,
+			$this->idToDataItemMatchFinder
+		);
 
 		$sortkey = $parameters['sortkey'];
 
@@ -189,7 +208,10 @@ class SQLStoreSmwIdsTest extends \PHPUnit_Framework_TestCase {
 			->method( 'getConnection' )
 			->will( $this->returnValue( $connection ) );
 
-		$instance = new SMWSql3SmwIds( $store );
+		$instance = new SMWSql3SmwIds(
+			$store,
+			$this->idToDataItemMatchFinder
+		);
 
 		$sortkey = $parameters['sortkey'];
 
@@ -208,33 +230,23 @@ class SQLStoreSmwIdsTest extends \PHPUnit_Framework_TestCase {
 
 	public function testGetDataItemForId() {
 
-		$row = new \stdClass;
-		$row->smw_title = 'Foo';
-		$row->smw_namespace = 0;
-		$row->smw_iw = '';
-		$row->smw_subobject ='';
-
 		$connection = $this->getMockBuilder( '\SMW\MediaWiki\Database' )
 			->disableOriginalConstructor()
 			->getMock();
 
-		$connection->expects( $this->once() )
-			->method( 'selectRow' )
-			->with(
-				$this->anything(),
-				$this->anything(),
-				$this->equalTo( array( 'smw_id' => 42 ) ) )
-			->will( $this->returnValue( $row ) );
-
-		$store = $this->getMockBuilder( 'SMWSQLStore3' )
-			->disableOriginalConstructor()
-			->getMock();
-
-		$store->expects( $this->atLeastOnce() )
+		$this->store->expects( $this->atLeastOnce() )
 			->method( 'getConnection' )
 			->will( $this->returnValue( $connection ) );
 
-		$instance = new SMWSql3SmwIds( $store );
+		$this->idToDataItemMatchFinder->expects( $this->once() )
+			->method( 'getDataItemForId' )
+			->with( $this->equalTo( 42 ) )
+			->will( $this->returnValue( new DIWikiPage( 'Foo', NS_MAIN ) ) );
+
+		$instance = new SMWSql3SmwIds(
+			$this->store,
+			$this->idToDataItemMatchFinder
+		);
 
 		$this->assertInstanceOf(
 			'\SMW\DIWikiPage',
@@ -263,7 +275,10 @@ class SQLStoreSmwIdsTest extends \PHPUnit_Framework_TestCase {
 			->method( 'getConnection' )
 			->will( $this->returnValue( $connection ) );
 
-		$instance = new SMWSql3SmwIds( $store );
+		$instance = new SMWSql3SmwIds(
+			$store,
+			$this->idToDataItemMatchFinder
+		);
 
 		$instance->updateInterwikiField(
 			42,


### PR DESCRIPTION
This PR is made in reference to: # N/A

This PR addresses or contains:

- Adds `ResultIterator` and `MappingIterator`
- Support for a lazy mapping during an iteration (instead of resolving a ResultWrapper in its entirety) and avoid a possible memory exhaustion on large lists.

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed

