### PR TITLE
Add Timezone handling

### DIFF
--- a/i18n/en.json
+++ b/i18n/en.json
@@ -425,6 +425,7 @@
 	"smw-datavalue-time-invalid-jd": "Unable to interpret the \"$1\" input value as valid JD (Julian day) number. \"$2\" was reported.",
 	"smw-datavalue-time-invalid-prehistoric": "Unable to interpret a prehistoric \"$1\" input value. For example, having specified more than years or a calendar model may return unexpected results in a prehistoric context.",
 	"smw-datavalue-time-invalid": "Unable to interpret the \"$1\" input value as valid date or time component. \"$2\" was reported.",
+	"smw-datavalue-time-invalid-offset-zone-usage": "\"$1\" contains an offset and zone identifier which is not supported.",
 	"smw-datavalue-external-formatter-uri-missing-placeholder": "Formatter uri is missing the ''$1'' placeholder.",
 	"smw-datavalue-external-formatter-invalid-uri": " \"$1\" is an invalid URL.",
 	"smw-datavalue-external-identifier-formatter-missing": "The property is missing an [[Property:External formatter uri|\"External formatter uri\"]] assignment.",

--- a/includes/dataitems/SMW_DI_Time.php
+++ b/includes/dataitems/SMW_DI_Time.php
@@ -139,10 +139,9 @@ class SMWDITime extends SMWDataItem implements CalendarModel {
 		$this->m_minutes = $minute !== false ? intval( $minute ) : 0;
 		$this->m_seconds = $second !== false ? floatval( $second ) : 0;
 
-		$this->timezone = $timezone !== false ? intval( $timezone ) : 0;
+		$this->timezone = $timezone !== false ? $timezone : 0;
 		$year = strval( $year );
 		$this->era      = $year{0} === '+' ? 1 : ( $year{0} === '-' ? -1 : 0 );
-
 
 		if ( $this->isOutOfBoundsBySome() ) {
 			throw new DataItemException( "Part of the date is out of bounds." );
@@ -171,6 +170,15 @@ class SMWDITime extends SMWDataItem implements CalendarModel {
 	 */
 	public function getCalendarModel() {
 		return $this->m_model;
+	}
+
+	/**
+	 * @since 2.5
+	 *
+	 * @return integer
+	 */
+	public function getTimezone() {
+		return $this->timezone;
 	}
 
 	/**
@@ -470,6 +478,12 @@ class SMWDITime extends SMWDataItem implements CalendarModel {
 
 			$values[$i] = false;
 
+			// Can contain something like '1/1970/1/12/11/43/0/Asia/Tokyo'
+			if ( $i == 7 && isset( $parts[$i] ) ) {
+				$values[$i] = strval( $parts[$i] );
+				continue;
+			}
+
 			if ( $i < count( $parts ) ) {
 
 				if ( $parts[$i] !== '' && !is_numeric( $parts[$i] ) ) {
@@ -499,7 +513,7 @@ class SMWDITime extends SMWDataItem implements CalendarModel {
 	 *
 	 * @return DITime object
 	 */
-	public static function newFromJD( $jdValue, $calendarModel = null, $precision = null ) {
+	public static function newFromJD( $jdValue, $calendarModel = null, $precision = null, $timezone = false ) {
 
 		$hour = $minute = $second = false;
 		$year = $month = $day = false;
@@ -521,7 +535,7 @@ class SMWDITime extends SMWDataItem implements CalendarModel {
 			list( $hour, $minute, $second ) = JulianDay::JD2Time( $jdValue );
 		}
 
-		return new self( $calendarModel, $year, $month, $day, $hour, $minute, $second );
+		return new self( $calendarModel, $year, $month, $day, $hour, $minute, $second, $timezone );
 	}
 
 	/**

--- a/languages/SMW_Language.php
+++ b/languages/SMW_Language.php
@@ -39,10 +39,11 @@ abstract class SMWLanguage {
 	protected $m_dateformats = array( array( SMW_Y ), array( SMW_MY, SMW_YM ), array( SMW_DMY, SMW_MDY, SMW_YMD, SMW_YDM ) );
 
 	protected $preferredDateFormatsByPrecision = array(
-		'SMW_PREC_Y'    => 'Y',
-		'SMW_PREC_YM'   => 'F Y',
-		'SMW_PREC_YMD'  => 'F j, Y',
-		'SMW_PREC_YMDT' => 'H:i:s, j F Y'
+		'SMW_PREC_Y'     => 'Y',
+		'SMW_PREC_YM'    => 'F Y',
+		'SMW_PREC_YMD'   => 'F j, Y',
+		'SMW_PREC_YMDT'  => 'H:i:s, j F Y',
+		'SMW_PREC_YMDTZ' => 'H:i:s T, j F Y'
 	);
 
 	/// Should English default aliases be used in this language?

--- a/languages/SMW_LanguageEn.php
+++ b/languages/SMW_LanguageEn.php
@@ -122,10 +122,11 @@ class SMWLanguageEn extends SMWLanguage {
 	protected $m_monthsshort = array( "Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec" );
 
 	protected $preferredDateFormatsByPrecision = array(
-		'SMW_PREC_Y'    => 'Y',
-		'SMW_PREC_YM'   => 'F Y',
-		'SMW_PREC_YMD'  => 'F j, Y',
-		'SMW_PREC_YMDT' => 'H:i:s, j F Y'
+		'SMW_PREC_Y'     => 'Y',
+		'SMW_PREC_YM'    => 'F Y',
+		'SMW_PREC_YMD'   => 'F j, Y',
+		'SMW_PREC_YMDT'  => 'H:i:s, j F Y',
+		'SMW_PREC_YMDTZ' => 'H:i:s T, j F Y'
 	);
 }
 

--- a/languages/SMW_LanguageJa.php
+++ b/languages/SMW_LanguageJa.php
@@ -117,10 +117,11 @@ class SMWLanguageJa extends SMWLanguage {
 	protected $m_monthsshort = array( "Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec" );
 
 	protected $preferredDateFormatsByPrecision = array(
-		'SMW_PREC_Y'    => 'Y年',
-		'SMW_PREC_YM'   => 'Y年n月',
-		'SMW_PREC_YMD'  => 'Y年n月j日 (D)',
-		'SMW_PREC_YMDT' => 'Y年n月j日 (D) H:i:s'
+		'SMW_PREC_Y'     => 'Y年',
+		'SMW_PREC_YM'    => 'Y年n月',
+		'SMW_PREC_YMD'   => 'Y年n月j日 (D)',
+		'SMW_PREC_YMDT'  => 'Y年n月j日 (D) H:i:s',
+		'SMW_PREC_YMDTZ' => 'Y年n月j日 (D) H:i:s T'
 	);
 }
 

--- a/src/DataValues/ValueFormatters/TimeValueFormatter.php
+++ b/src/DataValues/ValueFormatters/TimeValueFormatter.php
@@ -121,7 +121,7 @@ class TimeValueFormatter extends DataValueFormatter {
 		$precision = $dataItem->getPrecision();
 
 		$language = Localizer::getInstance()->getLanguage(
-			$this->dataValue->getOptionBy( 'user.language' )
+			$this->dataValue->getOptionBy( DataValue::OPT_USER_LANGUAGE )
 		);
 
 		$year = $dataItem->getYear();
@@ -247,7 +247,7 @@ class TimeValueFormatter extends DataValueFormatter {
 	public function getCaptionFromFreeFormat( DITime $dataItem = null ) {
 
 		$language = Localizer::getInstance()->getLanguage(
-			$this->dataValue->getOptionBy( 'user.language' )
+			$this->dataValue->getOptionBy( DataValue::OPT_USER_LANGUAGE )
 		);
 
 		// Prehistory dates are not supported when using this output format
@@ -291,8 +291,14 @@ class TimeValueFormatter extends DataValueFormatter {
 		}
 
 		$outputFormat = $this->dataValue->getOutputFormat();
+		$formatFlag = IntlTimeFormatter::LOCL_DEFAULT;
 
-		if ( ( $language = Localizer::getInstance()->getAnnotatedLanguageCodeFrom( $outputFormat ) ) === false ) {
+		if ( strpos( $outputFormat, 'TZ' ) !== false ) {
+			$formatFlag = IntlTimeFormatter::LOCL_TIMEZONE;
+			$outputFormat = str_replace( '#TZ', '', $outputFormat );
+		}
+
+		if ( ( $language = Localizer::getInstance()->getLanguageCodeFrom( $outputFormat ) ) === false ) {
 			$language = $this->dataValue->getOptionBy( DataValue::OPT_USER_LANGUAGE );
 		}
 
@@ -307,7 +313,7 @@ class TimeValueFormatter extends DataValueFormatter {
 		// string (2147483647-01-01 00:00:0.0000000) at position 17 (0): Double
 		// time specification" for an annotation like [[Date::Jan 10000000000]]
 		try {
-			$localizedFormat = $intlTimeFormatter->getLocalizedFormat() . $this->hintCalendarModel( $dataItem );
+			$localizedFormat = $intlTimeFormatter->getLocalizedFormat( $formatFlag ) . $this->hintCalendarModel( $dataItem );
 		} catch ( \Exception $e ) {
 			$localizedFormat = $this->getISO8601Date();
 		}

--- a/src/Defines.php
+++ b/src/Defines.php
@@ -116,6 +116,7 @@ define( 'SMW_PREC_Y', 0 );
 define( 'SMW_PREC_YM', 1 );
 define( 'SMW_PREC_YMD', 2 );
 define( 'SMW_PREC_YMDT', 3 );
+define( 'SMW_PREC_YMDTZ', 4 ); // with time zone
 /**@}*/
 
 /**@{

--- a/src/Libs/Time/Timezone.php
+++ b/src/Libs/Time/Timezone.php
@@ -1,0 +1,385 @@
+<?php
+
+namespace SMW\Libs\Time;
+
+use DateTimeZone;
+use DateInterval;
+use DateTime;
+
+/**
+ * @private
+ *
+ * @license GNU GPL v2+
+ * @since 2.5
+ *
+ * @author mwjames
+ */
+class Timezone {
+
+	/**
+	 * A new TZ is expected to be added at the end of the list without changing
+	 * existing ID's (those are used as internal serialization identifier).
+	 *
+	 * The associated offsets are in hours or fractions of hours.
+	 *
+	 * 'FOO' => array( ID, OffsetInSeconds, isMilitary )
+	 *
+	 * @var array
+	 */
+	private static $shortList = array(
+		"UTC" => array( 0, 0, false ),
+		"Z" => array( 1, 0, true ),
+		"A" => array( 2, 3600, true ),
+		"ACDT" => array( 3, 37800, false ),
+		"ACST" => array( 4, 34200, false ),
+		"ADT" => array( 5, -10800, false ),
+		"AEDT" => array( 6, 39600, false ),
+		"AEST" => array( 7, 36000, false ),
+		"AKDT" => array( 8, -28800, false ),
+		"AKST" => array( 9, -32400, false ),
+		"AST" => array( 10, -14400, false ),
+		"AWDT" => array( 11, 32400, false ),
+		"AWST" => array( 12, 28800, false ),
+		"B" => array( 13, 7200, true ),
+		"BST" => array( 14, 3600, false ),
+		"C" => array( 15, 10800, true ),
+		"CDT" => array( 16, -18000, false ),
+		"CEDT" => array( 17, 7200, false ),
+		"CEST" => array( 18, 7200, false ),
+		"CET" => array( 19, 3600, false ),
+		"CST" => array( 20, -21600, false ),
+		"CXT" => array( 21, 25200, false ),
+		"D" => array( 22, 14400, true ),
+		"E" => array( 23, 18000, true ),
+		"EDT" => array( 24, -14400, false ),
+		"EEDT" => array( 25, 10800, false ),
+		"EEST" => array( 26, 10800, false ),
+		"EET" => array( 27, 7200, false ),
+		"EST" => array( 28, -18000, false ),
+		"F" => array( 29, 21600, true ),
+		"G" => array( 30, 25200, true ),
+		"GMT" => array( 31, 0, false ),
+		"H" => array( 32, 28800, true ),
+		"HAA" => array( 33, -10800, false ),
+		"HAC" => array( 34, -18000, false ),
+		"HADT" => array( 35, -32400, false ),
+		"HAE" => array( 36, -14400, false ),
+		"HAP" => array( 37, -25200, false ),
+		"HAR" => array( 38, -21600, false ),
+		"HAST" => array( 39, -36000, false ),
+		"HAT" => array( 40, -9000, false ),
+		"HAY" => array( 41, -28800, false ),
+		"HNA" => array( 42, -14400, false ),
+		"HNC" => array( 43, -21600, false ),
+		"HNE" => array( 44, -18000, false ),
+		"HNP" => array( 45, -28800, false ),
+		"HNR" => array( 46, -25200, false ),
+		"HNT" => array( 47, -12600, false ),
+		"HNY" => array( 48, -32400, false ),
+		"I" => array( 49, 32400, true ),
+		"IST" => array( 50, 3600, false ),
+		"K" => array( 51, 36000, true ),
+		"L" => array( 52, 39600, true ),
+		"M" => array( 53, 43200, true ),
+		"MDT" => array( 54, -21600, false ),
+		"MESZ" => array( 55, 7200, false ),
+		"MEZ" => array( 56, 3600, false ),
+		"MSD" => array( 57, 14400, false ),
+		"MSK" => array( 58, 10800, false ),
+		"MST" => array( 59, -25200, false ),
+		"N" => array( 60, -3600, true ),
+		"NDT" => array( 61, -9000, false ),
+		"NFT" => array( 62, 41400, false ),
+		"NST" => array( 63, -12600, false ),
+		"O" => array( 64, -7200, true ),
+		"P" => array( 65, -10800, true ),
+		"PDT" => array( 66, -25200, false ),
+		"PST" => array( 67, -28800, false ),
+		"Q" => array( 68, -14400, true ),
+		"R" => array( 69, -18000, true ),
+		"S" => array( 70, -21600, true ),
+		"T" => array( 71, -25200, true ),
+		"U" => array( 72, -28800, true ),
+		"V" => array( 73, -32400, true ),
+		"W" => array( 74, -36000, true ),
+		"WDT" => array( 75, 32400, false ),
+		"WEDT" => array( 76, 3600, false ),
+		"WEST" => array( 77, 3600, false ),
+		"WET" => array( 78, 0, false ),
+		"WST" => array( 79, 28800, false ),
+		"X" => array( 80, -39600, true ),
+		"Y" => array( 81, -43200, true ),
+	);
+
+	/**
+	 * Generated from the DateTimeZone::listAbbreviations and contains "Area/Location",
+	 * e.g. "America/New_York".
+	 *
+	 * Citing https://en.wikipedia.org/wiki/Tz_database which describes that " ...
+	 * The underscore character is used in place of spaces. Hyphens are used
+	 * where they appear in the name of a location ...  names have a maximum
+	 * length of 14 characters ..."
+	 *
+	 * @var array
+	 */
+	private static $dateTimeZoneList = array();
+
+	/**
+	 * @var array
+	 */
+	private static $offsetCache = array();
+
+	/**
+	 * @since 2.5
+	 *
+	 * @return array
+	 */
+	public static function listShortAbbreviations() {
+		return array_keys( self::$shortList );
+	}
+
+	/**
+	 * @since 2.5
+	 *
+	 * @param string $identifer
+	 *
+	 * @return boolean
+	 */
+	public static function isValid( $identifer ) {
+
+		$identifer = str_replace( ' ', '_', $identifer );
+
+		if ( isset( self::$shortList[strtoupper( $identifer )] ) ) {
+			return true;
+		}
+
+		$dateTimeZoneList = self::getDateTimeZoneList();
+
+		if ( isset( $dateTimeZoneList[$identifer] ) ) {
+			return true;
+		}
+
+		return false;
+	}
+
+	/**
+	 * @since 2.5
+	 *
+	 * @param string $abbreviation
+	 *
+	 * @return boolean
+	 */
+	public static function isMilitary( $abbreviation ) {
+
+		$abbreviation = strtoupper( $abbreviation );
+
+		if ( isset( self::$shortList[$abbreviation] ) ) {
+			return self::$shortList[$abbreviation][2];
+		}
+
+		return false;
+	}
+
+	/**
+	 * @since 2.5
+	 *
+	 * @param string $identifer
+	 *
+	 * @return false|integer
+	 */
+	public static function getIdByAbbreviation( $identifer ) {
+
+		if ( isset( self::$shortList[strtoupper( $identifer )] ) ) {
+			return self::$shortList[strtoupper( $identifer )][0];
+		}
+
+		$identifer = str_replace( ' ', '_', $identifer );
+		$dateTimeZoneList = self::getDateTimeZoneList();
+
+		if ( isset( $dateTimeZoneList[$identifer] ) ) {
+			return $dateTimeZoneList[$identifer];
+		}
+
+		return false;
+	}
+
+	/**
+	 * @since 2.5
+	 *
+	 * @param integer $identifer
+	 *
+	 * @return false|string
+	 */
+	public static function getTimezoneLiteralById( $identifer ) {
+
+		foreach ( self::$shortList as $abbreviation => $value ) {
+			if ( is_numeric( $identifer ) && $value[0] == $identifer ) {
+				return $abbreviation;
+			}
+		}
+
+		$dateTimeZoneList = self::getDateTimeZoneList();
+
+		if ( ( $abbreviation = array_search( $identifer, $dateTimeZoneList ) ) !== false ) {
+			return $abbreviation;
+		}
+
+		return false;
+	}
+
+	/**
+	 * @since 2.5
+	 *
+	 * @param string $abbreviation
+	 *
+	 * @return false|string
+	 */
+	public static function getOffsetByAbbreviation( $abbreviation ) {
+
+		if ( isset( self::$shortList[strtoupper( $abbreviation )] ) ) {
+			return self::$shortList[strtoupper( $abbreviation )][1];
+		}
+
+		$abbreviation = str_replace( ' ', '_', $abbreviation );
+
+		if ( isset( self::$offsetCache[$abbreviation] ) ) {
+			return self::$offsetCache[$abbreviation];
+		}
+
+		$offset = false;
+
+		try {
+			$dateTimeZone = new DateTimeZone( $abbreviation );
+			$offset = $dateTimeZone->getOffset( new DateTime() );
+		} catch( \Exception $e ) {
+			//
+		}
+
+		return self::$offsetCache[$abbreviation] = $offset;
+	}
+
+	/**
+	 * @since 2.5
+	 *
+	 * @param string $abbreviation
+	 *
+	 * @return string
+	 */
+	public static function getNameByAbbreviation( $abbreviation ) {
+
+		$abbreviation = strtoupper( $abbreviation );
+
+		if ( isset( self::$shortList[$abbreviation] ) ) {
+			$name = timezone_name_from_abbr( $abbreviation );
+		}
+
+		// If the abbrevation couldn't be matched use the offset instead
+		if ( !$name ) {
+			$name = timezone_name_from_abbr(
+				"",
+				self::getOffsetByAbbreviation( $abbreviation ) * 3600,
+				0
+			);
+		}
+
+		return $name;
+	}
+
+	/**
+	 * @since 2.5
+	 *
+	 * @param string $abbreviation
+	 *
+	 * @return DateInterval
+	 */
+	public static function newDateIntervalWithOffsetBy( $abbreviation ) {
+
+		$minutes = 0;
+		$hour = 0;
+
+		// Here we don't care for +/-, the caller of the function
+		// has to care for it
+		$offsetInSeconds = abs( self::getOffsetByAbbreviation( $abbreviation ) );
+
+		return new DateInterval( "PT{$offsetInSeconds}S" );
+	}
+
+	/**
+	 * @since 2.5
+	 *
+	 * @param string $abbreviation
+	 *
+	 * @return false|DateTimeZone
+	 */
+	public static function newDateTimeZone( $abbreviation ) {
+
+		try {
+			$dateTimeZone = new DateTimeZone( $abbreviation );
+		} catch( \Exception $e ) {
+			if ( ( $name = self::getNameByAbbreviation( $abbreviation ) ) !== false ) {
+				return new DateTimeZone( $name );
+			}
+		}
+
+		return false;
+	}
+
+	/**
+	 * Generated from the DateTimeZone::listAbbreviations
+	 *
+	 * @since 2.5
+	 *
+	 * @return array
+	 */
+	public static function getDateTimeZoneList() {
+
+		if ( self::$dateTimeZoneList !== array() ) {
+			return self::$dateTimeZoneList;
+		}
+
+		$list = DateTimeZone::listIdentifiers();
+
+		foreach ( $list as $identifier ) {
+			self::$dateTimeZoneList[$identifier] = $identifier;
+		}
+
+		return self::$dateTimeZoneList;
+	}
+
+	/**
+	 * @since 2.5
+	 *
+	 * @param DateTime &$dateTime
+	 * @param string|integer $identifer
+	 *
+	 * @return string
+	 */
+	public static function getTimezoneLiteralWithModifiedDateTime( DateTime &$dateTime, $identifer = 0 ) {
+
+		if ( ( $timezoneLiteral = Timezone::getTimezoneLiteralById( $identifer ) ) === false ) {
+			return '';
+		}
+
+		$dateTimeZone = null;
+
+		if ( !Timezone::isMilitary( $timezoneLiteral ) && Timezone::getOffsetByAbbreviation( $timezoneLiteral ) != 0 ) {
+			$dateTimeZone = Timezone::newDateTimeZone( $timezoneLiteral );
+		}
+
+		// DI is stored in UTC time therefore find and add the offset
+		if ( !$dateTimeZone instanceof DateTimeZone ) {
+			$dateInterval = Timezone::newDateIntervalWithOffsetBy( $timezoneLiteral );
+
+			if ( Timezone::getOffsetByAbbreviation( $timezoneLiteral ) > 0 ) {
+				$dateTime->add( $dateInterval );
+			} else {
+				$dateTime->sub( $dateInterval );
+			}
+		} else {
+			$dateTime->setTimezone( $dateTimeZone );
+		}
+
+		return $timezoneLiteral;
+	}
+
+}

--- a/tests/phpunit/Integration/ByJsonScript/Fixtures/p-0429.json
+++ b/tests/phpunit/Integration/ByJsonScript/Fixtures/p-0429.json
@@ -21,7 +21,7 @@
 		},
 		{
 			"name": "Example/P0429/Q.2",
-			"contents": "{{#show: Example/P0429/2 |?Has date }}"
+			"contents": "{{#show: Example/P0429/2 |?Has date }} {{#show: Example/P0429/2 |?Has date#LOCL#TZ }}"
 		},
 		{
 			"name": "Example/P0429/3",
@@ -30,6 +30,22 @@
 		{
 			"name": "Example/P0429/4",
 			"contents": "[[Has date::1 Jan 1971 5:05:23 pm]]"
+		},
+		{
+			"name": "Example/P0429/5",
+			"contents": "[[Has date::1 Jan 1971 13:45:23 America/New_York]]"
+		},
+		{
+			"name": "Example/P0429/Q.5.1",
+			"contents": "{{#show: Example/P0429/5 |?Has date#LOCL#TZ }}"
+		},
+		{
+			"name": "Example/P0429/Q.5.2",
+			"contents": "{{#show: Example/P0429/5 |?Has date#LOCL#TZ@ja }}"
+		},
+		{
+			"name": "Example/P0429/Q.5.3",
+			"contents": "{{#show: Example/P0429/5 |?Has date#LOCL@ja#TZ }}"
 		}
 	],
 	"parser-testcases": [
@@ -71,7 +87,8 @@
 			"subject": "Example/P0429/Q.2",
 			"expected-output": {
 				"to-contain": [
-					"1 January 1971 18:45:23"
+					"1 January 1971 18:45:23",
+					"13:45:23 EST, 1 January 1971"
 				]
 			}
 		},
@@ -102,6 +119,33 @@
 			"expected-output": {
 				"to-contain": [
 					"1 Jan 1971 5:05:23 pm"
+				]
+			}
+		},
+		{
+			"about": "#7 long timezone name",
+			"subject": "Example/P0429/Q.5.1",
+			"expected-output": {
+				"to-contain": [
+					"13:45:23 America/New_York, 1 January 1971"
+				]
+			}
+		},
+		{
+			"about": "#8 long timezone name",
+			"subject": "Example/P0429/Q.5.2",
+			"expected-output": {
+				"to-contain": [
+					"1971年1月1日 (金) 13:45:23 America/New_York"
+				]
+			}
+		},
+		{
+			"about": "#9 long timezone name",
+			"subject": "Example/P0429/Q.5.3",
+			"expected-output": {
+				"to-contain": [
+					"1971年1月1日 (金) 13:45:23 America/New_York"
 				]
 			}
 		}

--- a/tests/phpunit/Unit/DataValues/ValueFormatters/TimeValueFormatterTest.php
+++ b/tests/phpunit/Unit/DataValues/ValueFormatters/TimeValueFormatterTest.php
@@ -259,6 +259,48 @@ class TimeValueFormatterTest extends \PHPUnit_Framework_TestCase {
 		);
 	}
 
+	public function testLOCLOutputFormatWithTimeZone() {
+
+		$timeValue = new TimeValue( '_dat' );
+		$timeValue->setUserValue( '2015-02-28 12:12:00 A' );
+
+		$timeValue->setOption( TimeValue::OPT_USER_LANGUAGE, 'en' );
+		$timeValue->setOutputFormat( 'LOCL#TZ' );
+
+		$instance = new TimeValueFormatter( $timeValue );
+
+		$this->assertEquals(
+			'12:12:00 A, 28 February 2015',
+			$instance->format( TimeValueFormatter::HTML_LONG )
+		);
+
+		$this->assertEquals(
+			'2015-02-28 12:12:00 A',
+			$instance->format( TimeValueFormatter::WIKI_SHORT )
+		);
+	}
+
+	public function testLOCLOutputFormatWithTimeZoneOnSpecificAnnotatedLanguage() {
+
+		$timeValue = new TimeValue( '_dat' );
+		$timeValue->setUserValue( '2015-02-28 12:12:00 A' );
+
+		$timeValue->setOption( TimeValue::OPT_USER_LANGUAGE, 'en' );
+		$timeValue->setOutputFormat( 'LOCL@ja#TZ' );
+
+		$instance = new TimeValueFormatter( $timeValue );
+
+		$this->assertEquals(
+			'2015年2月28日 (土) 12:12:00 A',
+			$instance->format( TimeValueFormatter::HTML_LONG )
+		);
+
+		$this->assertEquals(
+			'2015-02-28 12:12:00 A',
+			$instance->format( TimeValueFormatter::WIKI_SHORT )
+		);
+	}
+
 	public function timeInputProvider() {
 
 		#0

--- a/tests/phpunit/Unit/IntlTimeFormatterTest.php
+++ b/tests/phpunit/Unit/IntlTimeFormatterTest.php
@@ -52,7 +52,7 @@ class IntlTimeFormatterTest extends \PHPUnit_Framework_TestCase {
 	/**
 	 * @dataProvider localizedFormatProvider
 	 */
-	public function testGetLocalizedFormat( $serialization, $languageCode, $expected ) {
+	public function testGetLocalizedFormat( $serialization, $languageCode, $flag, $expected ) {
 
 		$instance = new IntlTimeFormatter(
 			DITime::doUnserialize( $serialization ),
@@ -61,7 +61,7 @@ class IntlTimeFormatterTest extends \PHPUnit_Framework_TestCase {
 
 		$this->assertEquals(
 			$expected,
-			$instance->getLocalizedFormat()
+			$instance->getLocalizedFormat( $flag )
 		);
 	}
 
@@ -158,12 +158,20 @@ class IntlTimeFormatterTest extends \PHPUnit_Framework_TestCase {
 			'2000-12-12 Dec'
 		);
 
-		#4
+		#6
 		$provider['on daynumber 7'] = array(
 			'1/2016/05/08/1/1/20/200',
 			'en',
 			'Y-m-d D',
 			'2016-05-08 Sun'
+		);
+
+		#7
+		$provider['on timezone 1'] = array(
+			'1/1970/1/12/11/43/0/14',
+			'en',
+			'Y-m-d H:i:s T',
+			'1970-01-12 11:43:00 UTC'
 		);
 
 		return $provider;
@@ -175,6 +183,7 @@ class IntlTimeFormatterTest extends \PHPUnit_Framework_TestCase {
 		$provider[] = array(
 			'1/2000/12/12/1/1/20/200',
 			'en',
+			IntlTimeFormatter::LOCL_DEFAULT,
 			'01:01:20, 12 December 2000'
 		);
 
@@ -182,6 +191,7 @@ class IntlTimeFormatterTest extends \PHPUnit_Framework_TestCase {
 		$provider[] = array(
 			'1/2000/12/12/1/1/20/200',
 			'ja',
+			IntlTimeFormatter::LOCL_DEFAULT,
 			'2000年12月12日 (火) 01:01:20'
 		);
 
@@ -189,6 +199,7 @@ class IntlTimeFormatterTest extends \PHPUnit_Framework_TestCase {
 		$provider[] = array(
 			'1/2000/12/12/1/1/20/200',
 			'es',
+			IntlTimeFormatter::LOCL_DEFAULT,
 			'01:01:20 12 dic 2000'
 		);
 
@@ -196,6 +207,7 @@ class IntlTimeFormatterTest extends \PHPUnit_Framework_TestCase {
 		$provider['on daynumber 1'] = array(
 			'1/2016/05/02/1/1/20/200',
 			'ja',
+			IntlTimeFormatter::LOCL_DEFAULT,
 			'2016年5月2日 (月) 01:01:20'
 		);
 
@@ -203,6 +215,7 @@ class IntlTimeFormatterTest extends \PHPUnit_Framework_TestCase {
 		$provider['on daynumber 7'] = array(
 			'1/2016/05/08/1/1/20/200',
 			'ja',
+			IntlTimeFormatter::LOCL_DEFAULT,
 			'2016年5月8日 (日) 01:01:20'
 		);
 
@@ -210,6 +223,7 @@ class IntlTimeFormatterTest extends \PHPUnit_Framework_TestCase {
 		$provider['midnight-ja'] = array(
 			'1/2016/05/08/00/00/00/00',
 			'ja',
+			IntlTimeFormatter::LOCL_DEFAULT,
 			'2016年5月8日 (日) 00:00:00'
 		);
 
@@ -217,16 +231,35 @@ class IntlTimeFormatterTest extends \PHPUnit_Framework_TestCase {
 		$provider['midnight-en'] = array(
 			'1/2016/05/08/0/0/0/0',
 			'en',
+			IntlTimeFormatter::LOCL_DEFAULT,
 			'00:00:00, 8 May 2016'
 		);
 
-		#6
+		#7
 		$provider['after-midnight'] = array(
 			'1/2016/05/08/0/0/01/0',
 			'en',
+			IntlTimeFormatter::LOCL_DEFAULT,
 			'00:00:01, 8 May 2016'
+		);
+
+		#8
+		$provider['timezone-short'] = array(
+			'1/1970/1/12/11/43/0/14',
+			'en',
+			IntlTimeFormatter::LOCL_TIMEZONE,
+			'12:43:00 BST, 12 January 1970'
+		);
+
+		#9
+		$provider['timezone-long'] = array(
+			'1/1970/1/12/11/43/0/America/Cuiaba',
+			'en',
+			IntlTimeFormatter::LOCL_TIMEZONE,
+			'07:43:00 America/Cuiaba, 12 January 1970'
 		);
 
 		return $provider;
 	}
+
 }

--- a/tests/phpunit/Unit/Libs/Time/TimezoneTest.php
+++ b/tests/phpunit/Unit/Libs/Time/TimezoneTest.php
@@ -1,0 +1,155 @@
+<?php
+
+namespace SMW\Tests\Libs\Time;
+
+use SMW\DataItemFactory;
+use SMW\Libs\Time\Timezone;
+
+/**
+ * @covers \SMW\Libs\Time\Timezone
+ * @group semantic-mediawiki
+ *
+ * @license GNU GPL v2+
+ * @since 2.5
+ *
+ * @author mwjames
+ */
+class TimezoneTest extends \PHPUnit_Framework_TestCase {
+
+	public function testCanConstruct() {
+
+		$this->assertInstanceOf(
+			Timezone::class,
+			new Timezone()
+		);
+	}
+
+	public function testListShortAbbreviations() {
+
+		$this->assertInternalType(
+			'array',
+			Timezone::listShortAbbreviations()
+		);
+	}
+
+	/**
+	 * @dataProvider timezoneProvider
+	 */
+	public function testIsValidAndIsMilitary( $abbrevation, $isValid, $isMilitary ) {
+
+		$this->assertEquals(
+			$isValid,
+			Timezone::isValid( $abbrevation )
+		);
+
+		$this->assertEquals(
+			$isMilitary,
+			Timezone::isMilitary( $abbrevation )
+		);
+	}
+
+	/**
+	 * @dataProvider timezoneProvider
+	 */
+	public function testGetIdByAbbreviation( $abbrevation, $isValid, $isMilitary, $expectedId ) {
+
+		$this->assertEquals(
+			$expectedId,
+			Timezone::getIdByAbbreviation( $abbrevation )
+		);
+	}
+
+	/**
+	 * @dataProvider offsetProvider
+	 */
+	public function testGetOffsetByAbbreviation( $abbrevation, $expected ) {
+
+		$this->assertEquals(
+			$expected,
+			Timezone::getOffsetByAbbreviation( $abbrevation )
+		);
+	}
+
+	public function timezoneProvider() {
+
+		$provider[] = array(
+			'UTC',
+			true,
+			false,
+			0
+		);
+
+		$provider[] = array(
+			'Z',
+			true,
+			true,
+			1
+		);
+
+		$provider[] = array(
+			'Unknown',
+			false,
+			false,
+			false
+		);
+
+		$provider[] = array(
+			'Asia/Tokyo',
+			true,
+			false,
+			'Asia/Tokyo'
+		);
+
+		$provider[] = array(
+			'America/Los Angeles',
+			true,
+			false,
+			'America/Los_Angeles'
+		);
+
+		$provider[] = array(
+			'America/Los_Angeles',
+			true,
+			false,
+			'America/Los_Angeles'
+		);
+
+		return $provider;
+	}
+
+	public function offsetProvider() {
+
+		$provider[] = array(
+			'UTC',
+			0
+		);
+
+		$provider[] = array(
+			'Z',
+			0
+		);
+
+		$provider[] = array(
+			'Unknown',
+			false
+		);
+
+		$provider[] = array(
+			'Asia/Tokyo',
+			32400
+		);
+
+		$provider[] = array(
+			'America/Los Angeles',
+			-25200
+		);
+
+		$provider[] = array(
+			'America/Los_Angeles',
+			-25200
+		);
+
+		return $provider;
+	}
+
+}


### PR DESCRIPTION
This PR is made in reference to: # N/A

This PR addresses or contains:

- Annotating `12 Jan 1970 20:43 EST` with the output format of `#LOCL#TZ` will display the annotated value as `20:43:00 EST, 12 January 1970` instead of the UTC based date.

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed

