### PR TITLE
Revert "QueryPrinterFactory cleanup"

### DIFF
--- a/includes/FormatFactory.php
+++ b/includes/FormatFactory.php
@@ -7,21 +7,21 @@ use MWException;
 /**
  * Factory for "result formats", ie classes implementing QueryResultPrinter.
  *
- * @since 2.5 (since 1.9, renamed in 2.5)
+ * @since 1.9
  *
  * @ingroup SMW
  *
  * @licence GNU GPL v2+
  * @author Jeroen De Dauw < jeroendedauw@gmail.com >
  */
-final class QueryPrinterFactory {
+final class FormatFactory {
 
 	/**
 	 * Returns the global instance of the factory.
 	 *
-	 * @since 2.5
+	 * @since 1.9
 	 *
-	 * @return QueryPrinterFactory
+	 * @return self
 	 */
 	public static function singleton() {
 		static $instance = null;
@@ -66,7 +66,7 @@ final class QueryPrinterFactory {
 	 * If there is a format already with the provided name,
 	 * it will be overridden with the newly provided data.
 	 *
-	 * @since 2.5
+	 * @since 1.9
 	 *
 	 * @param string $formatName
 	 * @param string $class
@@ -90,7 +90,7 @@ final class QueryPrinterFactory {
 	 * If an aliases is already registered, it will
 	 * be overridden with the newly provided data.
 	 *
-	 * @since 2.5
+	 * @since 1.9
 	 *
 	 * @param string $formatName
 	 * @param array $aliases
@@ -114,7 +114,7 @@ final class QueryPrinterFactory {
 	/**
 	 * Returns the canonical format names.
 	 *
-	 * @since 2.5
+	 * @since 1.9
 	 *
 	 * @return string[]
 	 */
@@ -125,7 +125,7 @@ final class QueryPrinterFactory {
 	/**
 	 * Returns if there is a format or format alias with the provided name.
 	 *
-	 * @since 2.5
+	 * @since 1.9
 	 *
 	 * @param string $formatName Format name or alias
 	 *
@@ -139,7 +139,7 @@ final class QueryPrinterFactory {
 	/**
 	 * Returns a new instance of the handling result printer for the provided format.
 	 *
-	 * @since 2.5
+	 * @since 1.9
 	 *
 	 * @param string $formatName
 	 *
@@ -153,6 +153,8 @@ final class QueryPrinterFactory {
 
 	/**
 	 * Returns the QueryResultPrinter implementing class that is the printer for the provided format.
+	 *
+	 * @since 1.9
 	 *
 	 * @param string $formatName Format name or alias
 	 *
@@ -172,7 +174,7 @@ final class QueryPrinterFactory {
 	/**
 	 * Resolves format aliases into their associated canonical format name.
 	 *
-	 * @since 2.5
+	 * @since 1.9
 	 *
 	 * @param string $formatName Format name or alias
 	 *

--- a/src/Aliases.php
+++ b/src/Aliases.php
@@ -71,6 +71,3 @@ class_alias( 'SMW\RequestOptions', 'SMWRequestOptions' );
 class_alias( 'SMW\StringCondition', 'SMWStringCondition' );
 class_alias( 'SMW\HashBuilder', 'SMW\Hash' );
 class_alias( 'SMW\DataValues\BooleanValue', 'SMWBoolValue' );
-
-// 2.5
-class_alias( 'SMW\QueryPrinterFactory', 'SMW\FormatFactory' );

--- a/tests/phpunit/includes/FormatFactoryTest.php
+++ b/tests/phpunit/includes/FormatFactoryTest.php
@@ -2,13 +2,13 @@
 
 namespace SMW\Tests;
 
-use SMW\QueryPrinterFactory;
+use SMW\FormatFactory;
 use SMW\QueryResultPrinter;
 use SMW\TableResultPrinter;
 use SMWListResultPrinter;
 
 /**
- * @covers \SMW\QueryPrinterFactory
+ * @covers \SMW\FormatFactory
  *
  * @group SMW
  * @group SMWExtension
@@ -17,13 +17,13 @@ use SMWListResultPrinter;
  * @license GNU GPL v2+
  * @author Jeroen De Dauw < jeroendedauw@gmail.com >
  */
-class QueryPrinterFactoryTest extends \PHPUnit_Framework_TestCase {
+class FormatFactoryTest extends \PHPUnit_Framework_TestCase {
 
 	public function testSingleton() {
-		$instance = QueryPrinterFactory::singleton();
+		$instance = FormatFactory::singleton();
 
-		$this->assertInstanceOf( QueryPrinterFactory::class, $instance );
-		$this->assertTrue( QueryPrinterFactory::singleton() === $instance );
+		$this->assertInstanceOf( FormatFactory::class, $instance );
+		$this->assertTrue( FormatFactory::singleton() === $instance );
 
 		global $smwgResultFormats, $smwgResultAliases;
 
@@ -43,7 +43,7 @@ class QueryPrinterFactoryTest extends \PHPUnit_Framework_TestCase {
 	}
 
 	public function testRegisterFormat() {
-		$factory = new QueryPrinterFactory();
+		$factory = new FormatFactory();
 
 		$factory->registerFormat( 'table', TableResultPrinter::class );
 		$factory->registerFormat( 'list', SMWListResultPrinter::class );
@@ -60,7 +60,7 @@ class QueryPrinterFactoryTest extends \PHPUnit_Framework_TestCase {
 	}
 
 	public function testRegisterAliases() {
-		$factory = new QueryPrinterFactory();
+		$factory = new FormatFactory();
 
 		$this->assertEquals( 'foo', $factory->getCanonicalName( 'foo' ) );
 
@@ -83,7 +83,7 @@ class QueryPrinterFactoryTest extends \PHPUnit_Framework_TestCase {
 	}
 
 	public function testGetPrinter() {
-		$factory = QueryPrinterFactory::singleton();
+		$factory = FormatFactory::singleton();
 
 		foreach ( $factory->getFormats() as $format ) {
 			$printer = $factory->getPrinter( $format );
@@ -95,7 +95,7 @@ class QueryPrinterFactoryTest extends \PHPUnit_Framework_TestCase {
 	}
 
 	public function testGetFormats() {
-		$factory = new QueryPrinterFactory();
+		$factory = new FormatFactory();
 
 		$this->assertInternalType( 'array', $factory->getFormats() );
 
@@ -115,7 +115,7 @@ class QueryPrinterFactoryTest extends \PHPUnit_Framework_TestCase {
 	}
 
 	public function testHasFormat() {
-		$factory = new QueryPrinterFactory();
+		$factory = new FormatFactory();
 
 		$this->assertFalse( $factory->hasFormat( 'ohi' ) );
 
@@ -126,7 +126,7 @@ class QueryPrinterFactoryTest extends \PHPUnit_Framework_TestCase {
 		$this->assertTrue( $factory->hasFormat( 'there' ) );
 		$this->assertTrue( $factory->hasFormat( 'o_O' ) );
 
-		$factory = QueryPrinterFactory::singleton();
+		$factory = FormatFactory::singleton();
 
 		foreach ( $factory->getFormats() as $format ) {
 			$this->assertTrue( $factory->hasFormat( $format ) );
@@ -137,9 +137,9 @@ class QueryPrinterFactoryTest extends \PHPUnit_Framework_TestCase {
 	 * @test FormatFactory::getPrinter
 	 */
 	public function testGetPrinterException() {
-		$this->setExpectedException( 'MWException' );
+		$this->SetExpectedException( 'MWException' );
 
-		$factory = new QueryPrinterFactory();
+		$factory = new FormatFactory();
 		$factory->getPrinter( 'lula' );
 
 		$this->assertTrue( true );
@@ -149,9 +149,9 @@ class QueryPrinterFactoryTest extends \PHPUnit_Framework_TestCase {
 	 * @test FormatFactory::getCanonicalName
 	 */
 	public function testGetCanonicalNameException() {
-		$this->setExpectedException( 'MWException' );
+		$this->SetExpectedException( 'MWException' );
 
-		$factory = new QueryPrinterFactory();
+		$factory = new FormatFactory();
 		$factory->getCanonicalName( 9001 );
 
 		$this->assertTrue( true );
@@ -159,13 +159,25 @@ class QueryPrinterFactoryTest extends \PHPUnit_Framework_TestCase {
 
 	/**
 	 * @test FormatFactory::registerFormat
-	 * @dataProvider registerFormatExceptioProvider
+	 * @dataProvider getRegisterFormatExceptioDataProvider
 	 */
 	public function testRegisterFormatException( $formatName, $class ) {
-		$this->setExpectedException( 'MWException' );
+		$this->SetExpectedException( 'MWException' );
 
-		$factory = new QueryPrinterFactory();
+		$factory = new FormatFactory();
 		$factory->registerFormat( $formatName, $class );
+		$this->assertTrue( true );
+	}
+
+	/**
+	 * @test FormatFactory::registerAliases
+	 * @dataProvider getRegisterAliasesExceptioDataProvider
+	 */
+	public function testRegisterAliasesException( $formatName, array $aliases ) {
+		$this->SetExpectedException( 'MWException' );
+
+		$factory = new FormatFactory();
+		$factory->registerAliases( $formatName, $aliases );
 		$this->assertTrue( true );
 	}
 
@@ -174,7 +186,7 @@ class QueryPrinterFactoryTest extends \PHPUnit_Framework_TestCase {
 	 *
 	 * @return array
 	 */
-	public function registerFormatExceptioProvider() {
+	public function getRegisterFormatExceptioDataProvider() {
 		return array(
 			array( 1001, 'Foo' ),
 			array( 'Foo', 9001 ),
@@ -182,23 +194,11 @@ class QueryPrinterFactoryTest extends \PHPUnit_Framework_TestCase {
 	}
 
 	/**
-	 * @test FormatFactory::registerAliases
-	 * @dataProvider registerAliasesExceptionProvider
-	 */
-	public function testRegisterAliasesException( $formatName, array $aliases ) {
-		$this->setExpectedException( 'MWException' );
-
-		$factory = new QueryPrinterFactory();
-		$factory->registerAliases( $formatName, $aliases );
-		$this->assertTrue( true );
-	}
-
-	/**
 	 * Register aliases exception data provider
 	 *
 	 * @return array
 	 */
-	public function registerAliasesExceptionProvider() {
+	public function getRegisterAliasesExceptioDataProvider() {
 		return array(
 			array( 1001, array( 'Foo' => 'Bar' ) ),
 			array( 'Foo', array( 'Foo' => 9001 ) ),


### PR DESCRIPTION
@JeroenDeDauw FYI

Reverts SemanticMediaWiki/SemanticMediaWiki#1836 as it causes a local "Warning</b>:  Class 'SMW\QueryPrinterFactory' not found in <b>...\SemanticMediaWiki\src\Aliases.php</b> on line <b>76</b>"