### PR TITLE
PropertyList via API to support matching capitalized labels

### DIFF
--- a/res/smw/special/ext.smw.special.property.js
+++ b/res/smw/special/ext.smw.special.property.js
@@ -12,7 +12,7 @@
 
 	$( document ).ready( function() {
 
-		$( '#smw-property-input, .smw-property-input' ).autocomplete({
+		$( '#smw-property-input, .smw-property-input' ).autocomplete( {
 			serviceUrl: mw.util.wikiScript( 'api' ),
 			dataType: 'json',
 			minChars: 3,
@@ -21,7 +21,9 @@
 			delimiter: "\n",
 			params: {
 				'action': 'browsebyproperty',
-				'format': 'json'
+				'format': 'json',
+				'listonly': true,
+				'limit': 100
 			},
 			onSearchStart: function( query ) {
 				query.property = query.property.replace( "?", '' );

--- a/src/MediaWiki/Api/BrowseByProperty.php
+++ b/src/MediaWiki/Api/BrowseByProperty.php
@@ -31,11 +31,15 @@ class BrowseByProperty extends ApiBase {
 			$params['limit']
 		);
 
+		$propertyListByApiRequest->setListOnly(
+			$params['listonly']
+		);
+
 		$propertyListByApiRequest->setLanguageCode(
 			$params['lang']
 		);
 
-		$propertyListByApiRequest->findPropertyListFor(
+		$propertyListByApiRequest->findPropertyListBy(
 			$params['property']
 		);
 
@@ -77,7 +81,7 @@ class BrowseByProperty extends ApiBase {
 		$this->getResult()->addValue(
 			null,
 			'version',
-			0.2
+			2
 		);
 
 		$this->getResult()->addValue(
@@ -116,6 +120,12 @@ class BrowseByProperty extends ApiBase {
 				ApiBase::PARAM_TYPE => 'string',
 				ApiBase::PARAM_ISMULTI => false,
 				ApiBase::PARAM_REQUIRED => false,
+			),
+			'listonly' => array(
+				ApiBase::PARAM_TYPE => 'string',
+				ApiBase::PARAM_DFLT => false,
+				ApiBase::PARAM_ISMULTI => false,
+				ApiBase::PARAM_REQUIRED => false,
 			)
 		);
 	}
@@ -128,8 +138,10 @@ class BrowseByProperty extends ApiBase {
 	 */
 	public function getParamDescription() {
 		return array(
-			'property' => 'To select a specific property',
-			'limit' => 'To specify the size of the list request'
+			'property' => 'To match a specific property',
+			'limit'    => 'To specify the size of the list request',
+			'lang'     => 'To specify a specific language used for some attributes (description etc.)',
+			'listonly' => 'To specify that only a property list is returned without further details'
 		);
 	}
 
@@ -155,6 +167,7 @@ class BrowseByProperty extends ApiBase {
 		return array(
 			'api.php?action=browsebyproperty&property=Modification_date',
 			'api.php?action=browsebyproperty&limit=50',
+			'api.php?action=browsebyproperty&limit=5&listonly=true',
 		);
 	}
 

--- a/tests/phpunit/Unit/MediaWiki/Api/PropertyListByApiRequestTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Api/PropertyListByApiRequestTest.php
@@ -110,7 +110,7 @@ class PropertyListByApiRequestTest extends \PHPUnit_Framework_TestCase {
 		$instance->setLimit( 3 );
 
 		$this->assertTrue(
-			$instance->findPropertyListFor( 'Foo' )
+			$instance->findPropertyListBy( 'Foo' )
 		);
 
 		$this->assertEquals(


### PR DESCRIPTION
This PR is made in reference to: # N/A

This PR addresses or contains:

- Auto-complete now returns `FOO` for searches on `foo`
- Adds `listonly` to only retrieve a list of properties that match the search without making a request for additional information

This PR includes:
- [ ] Tests (unit/integration)
- [x] CI build passed

