### PR TITLE
Support conjunctive query in connection with a NS, refs #1652

### DIFF
--- a/src/ApplicationFactory.php
+++ b/src/ApplicationFactory.php
@@ -375,12 +375,22 @@ class ApplicationFactory {
 	}
 
 	/**
+	 * @deprecated since 2.5, use QueryFactory::newQueryParser
 	 * @since 2.1
 	 *
 	 * @return QueryParser
 	 */
 	public function newQueryParser() {
-		return new QueryParser();
+		return $this->getQueryFactory()->newQueryParser();
+	}
+
+	/**
+	 * @since 2.5
+	 *
+	 * @return DataItemFactory
+	 */
+	public function getDataItemFactory() {
+		return $this->callbackLoader->singleton( 'DataItemFactory' );
 	}
 
 	/**

--- a/src/DataItemFactory.php
+++ b/src/DataItemFactory.php
@@ -9,6 +9,7 @@ use SMWDIContainer as DIContainer;
 use SMWDIError as DIError;
 use SMWDINumber as DINumber;
 use SMWDIUri as DIUri;
+use SMWDITime  as DITime;
 
 /**
  * @private
@@ -128,6 +129,24 @@ class DataItemFactory {
 	 */
 	public function newDIUri( $scheme, $hierpart, $query = '', $fragment = '' ) {
 		return new DIUri( $scheme, $hierpart, $query, $fragment );
+	}
+
+	/**
+	 * @since 2.5
+	 *
+	 * @param integer $calendarmodel
+	 * @param integer $year
+	 * @param integer|false $month
+	 * @param integer|false $day
+	 * @param integer|false $hour
+	 * @param integer|false $minute
+	 * @param integer|false $second
+	 * @param integer|false $timezone
+	 *
+	 * @return DITime
+	 */
+	public function newDITime( $calendarmodel, $year, $month = false, $day = false, $hour = false, $minute = false, $second = false, $timezone = false ) {
+		return new DITime( $calendarmodel, $year, $month, $day, $hour, $minute, $second, $timezone );
 	}
 
 }

--- a/src/Deserializers/DVDescriptionDeserializer/DescriptionDeserializer.php
+++ b/src/Deserializers/DVDescriptionDeserializer/DescriptionDeserializer.php
@@ -4,7 +4,10 @@ namespace SMW\Deserializers\DVDescriptionDeserializer;
 
 use Deserializers\DispatchableDeserializer;
 use SMW\Query\QueryComparator;
+use SMW\Query\DescriptionFactory;
 use SMWDataValue as DataValue;
+use SMW\ApplicationFactory;
+use SMW\DataItemFactory;
 
 /**
  * @private
@@ -34,6 +37,16 @@ use SMWDataValue as DataValue;
 abstract class DescriptionDeserializer implements DispatchableDeserializer {
 
 	/**
+	 * @var DescriptionFactory
+	 */
+	protected $descriptionFactory;
+
+	/**
+	 * @var DataItemFactory
+	 */
+	protected $dataItemFactory;
+
+	/**
 	 * @var array
 	 */
 	protected $errors = array();
@@ -42,6 +55,25 @@ abstract class DescriptionDeserializer implements DispatchableDeserializer {
 	 * @var DataValue
 	 */
 	protected $dataValue;
+
+	/**
+	 * @since 2.5
+	 *
+	 * @param DescriptionFactory|null $descriptionFactory
+	 * @param DataItemFactory|null $dataItemFactory
+	 */
+	public function __construct( DescriptionFactory $descriptionFactory = null, DescriptionFactory $dataItemFactory = null ) {
+		$this->descriptionFactory = $descriptionFactory;
+		$this->dataItemFactory = $dataItemFactory;
+
+		if ( $this->descriptionFactory === null ) {
+			$this->descriptionFactory = ApplicationFactory::getInstance()->getQueryFactory()->newDescriptionFactory();
+		}
+
+		if ( $this->dataItemFactory === null ) {
+			$this->dataItemFactory = ApplicationFactory::getInstance()->getDataItemFactory();
+		}
+	}
 
 	/**
 	 * @since 2.3

--- a/src/Deserializers/DVDescriptionDeserializer/TimeValueDescriptionDeserializer.php
+++ b/src/Deserializers/DVDescriptionDeserializer/TimeValueDescriptionDeserializer.php
@@ -4,10 +4,6 @@ namespace SMW\Deserializers\DVDescriptionDeserializer;
 
 use DateInterval;
 use InvalidArgumentException;
-use SMW\Query\Language\Conjunction;
-use SMW\Query\Language\Disjunction;
-use SMW\Query\Language\ThingDescription;
-use SMW\Query\Language\ValueDescription;
 use SMWDITime as DITime;
 use SMWTimeValue as TimeValue;
 
@@ -28,15 +24,6 @@ class TimeValueDescriptionDeserializer extends DescriptionDeserializer {
 	 */
 	public function isDeserializerFor( $serialization ) {
 		return $serialization instanceof TimeValue;
-	}
-
-	/**
-	 * @since 2.5
-	 *
-	 * {@inheritDoc}
-	 */
-	public function getPrimitiveValue() {
-		return $this->dataValue->getMediaWikiDate();
 	}
 
 	/**
@@ -61,9 +48,9 @@ class TimeValueDescriptionDeserializer extends DescriptionDeserializer {
 			$this->dataValue->setUserValue( $value );
 
 			if ( $this->dataValue->isValid() ) {
-				return new ValueDescription( $this->dataValue->getDataItem(), $this->dataValue->getProperty(), $comparator );
+				return $this->descriptionFactory->newValueDescription( $this->dataValue->getDataItem(), $this->dataValue->getProperty(), $comparator );
 			} else {
-				return new ThingDescription();
+				return $this->descriptionFactory->newThingDescription();
 			}
 		}
 
@@ -72,7 +59,7 @@ class TimeValueDescriptionDeserializer extends DescriptionDeserializer {
 		$this->dataValue->setUserValue( $value );
 
 		if ( !$this->dataValue->isValid() ) {
-			return new ThingDescription();
+			return $this->descriptionFactory->newThingDescription();
 		}
 
 		$dataItem = $this->dataValue->getDataItem();
@@ -81,20 +68,20 @@ class TimeValueDescriptionDeserializer extends DescriptionDeserializer {
 		$upperLimitDataItem = $this->getUpperLimit( $dataItem );
 
 		if ( $this->getErrors() !== array() ) {
-			return new ThingDescription();
+			return $this->descriptionFactory->newThingDescription();
 		}
 
 		if( $comparator === SMW_CMP_LIKE ) {
-			$description = new Conjunction( array(
-				new ValueDescription( $dataItem, $property, SMW_CMP_GEQ ),
-				new ValueDescription( $upperLimitDataItem, $property, SMW_CMP_LESS )
+			$description = $this->descriptionFactory->newConjunction( array(
+				$this->descriptionFactory->newValueDescription( $dataItem, $property, SMW_CMP_GEQ ),
+				$this->descriptionFactory->newValueDescription( $upperLimitDataItem, $property, SMW_CMP_LESS )
 			) );
 		}
 
 		if( $comparator === SMW_CMP_NLKE ) {
-			$description = new Disjunction( array(
-				new ValueDescription( $dataItem, $property, SMW_CMP_LESS ),
-				new ValueDescription( $upperLimitDataItem, $property, SMW_CMP_GEQ )
+			$description = $this->descriptionFactory->newDisjunction( array(
+				$this->descriptionFactory->newValueDescription( $dataItem, $property, SMW_CMP_LESS ),
+				$this->descriptionFactory->newValueDescription( $upperLimitDataItem, $property, SMW_CMP_GEQ )
 			) );
 		}
 

--- a/src/SharedCallbackContainer.php
+++ b/src/SharedCallbackContainer.php
@@ -167,6 +167,14 @@ class SharedCallbackContainer implements CallbackContainer {
 			$callbackLoader->registerExpectedReturnType( 'QueryFactory', '\SMW\QueryFactory' );
 			return new QueryFactory();
 		} );
+
+		/**
+		 * @var DataItemFactory
+		 */
+		$callbackLoader->registerCallback( 'DataItemFactory', function() use ( $callbackLoader ) {
+			$callbackLoader->registerExpectedReturnType( 'DataItemFactory', '\SMW\DataItemFactory' );
+			return new DataItemFactory();
+		} );
 	}
 
 	private function registerCallbackHandlersByConstructedInstance( $callbackLoader ) {

--- a/tests/phpunit/Integration/ByJsonScript/Fixtures/q-0613.json
+++ b/tests/phpunit/Integration/ByJsonScript/Fixtures/q-0613.json
@@ -1,0 +1,175 @@
+{
+	"description": "Test single value (`~/!~`/`<`/`>`) queries on namespaced entity (#1652, `NS_HELP`, `smwStrictComparators=false`, skip-on virtuoso)",
+	"properties": [
+	],
+	"subjects": [
+		{
+			"name": "ABC",
+			"contents": "[[Category:0613]] (control group)"
+		},
+		{
+			"name": "ABB",
+			"contents": "[[Category:0613]] (control group)"
+		},
+		{
+			"name": "ABC",
+			"namespace": "NS_HELP",
+			"contents": "[[Category:0613]]"
+		},
+		{
+			"name": "ABB",
+			"namespace": "NS_HELP",
+			"contents": "[[Category:0613]]"
+		},
+		{
+			"name": "AAB",
+			"namespace": "NS_HELP",
+			"contents": "[[Category:0613]]"
+		}
+	],
+	"query-testcases": [
+		{
+			"about": "#0",
+			"condition": "[[Help:~A*B]] [[Category:0613]]",
+			"printouts" : [],
+			"parameters" : {
+				"limit" : "10"
+			},
+			"queryresult": {
+				"count": 2,
+				"results": [
+					"AAB#12##",
+					"ABB#12##"
+				]
+			}
+		},
+		{
+			"about": "#1",
+			"condition": "[[~Help:A*B]] [[Category:0613]]",
+			"printouts" : [],
+			"parameters" : {
+				"limit" : "10"
+			},
+			"queryresult": {
+				"count": 2,
+				"results": [
+					"AAB#12##",
+					"ABB#12##"
+				]
+			}
+		},
+		{
+			"about": "#2",
+			"condition": "[[Help:!~A*B]] [[Category:0613]]",
+			"printouts" : [],
+			"parameters" : {
+				"limit" : "10"
+			},
+			"queryresult": {
+				"count": 1,
+				"results": [
+					"ABC#12##"
+				]
+			}
+		},
+		{
+			"about": "#3",
+			"condition": "[[!~Help:A*B]] [[Category:0613]]",
+			"printouts" : [],
+			"parameters" : {
+				"limit" : "10"
+			},
+			"queryresult": {
+				"count": 1,
+				"results": [
+					"ABC#12##"
+				]
+			}
+		},
+		{
+			"about": "#4",
+			"condition": "[[Help:>AB]] [[Category:0613]]",
+			"printouts" : [],
+			"parameters" : {
+				"limit" : "10"
+			},
+			"queryresult": {
+				"count": 2,
+				"results": [
+					"ABC#12##",
+					"ABB#12##"
+				]
+			}
+		},
+		{
+			"about": "#5",
+			"condition": "[[>Help:AB]] [[Category:0613]]",
+			"printouts" : [],
+			"parameters" : {
+				"limit" : "10"
+			},
+			"queryresult": {
+				"count": 2,
+				"results": [
+					"ABC#12##",
+					"ABB#12##"
+				]
+			}
+		},
+		{
+			"about": "#6",
+			"condition": "[[Help:<AB]] [[Category:0613]]",
+			"printouts" : [],
+			"parameters" : {
+				"limit" : "10"
+			},
+			"queryresult": {
+				"count": 1,
+				"results": [
+					"AAB#12##"
+				]
+			}
+		},
+		{
+			"about": "#7",
+			"condition": "[[<Help:AB]] [[Category:0613]]",
+			"printouts" : [],
+			"parameters" : {
+				"limit" : "10"
+			},
+			"queryresult": {
+				"count": 1,
+				"results": [
+					"AAB#12##"
+				]
+			}
+		},
+		{
+			"about": "#8",
+			"condition": "[[<Help:<AB]] [[Category:0613]]",
+			"printouts" : [],
+			"parameters" : {
+				"limit" : "10"
+			},
+			"queryresult": {
+				"count": 0
+			}
+		}
+	],
+	"settings": {
+		"smwStrictComparators" : false,
+		"smwgNamespacesWithSemanticLinks": {
+			"NS_MAIN": true,
+			"SMW_NS_PROPERTY": true,
+			"NS_HELP": true
+		}
+	},
+	"meta": {
+		"skip-on": {
+			"virtuoso": "Virtuoso 6.1 does not like this test"
+		},
+		"version": "0.1",
+		"is-incomplete": false,
+		"debug": false
+	}
+}

--- a/tests/phpunit/Unit/ApplicationFactoryTest.php
+++ b/tests/phpunit/Unit/ApplicationFactoryTest.php
@@ -173,11 +173,11 @@ class ApplicationFactoryTest extends \PHPUnit_Framework_TestCase {
 		);
 	}
 
-	public function testCanConstructQueryParser() {
+	public function testCanConstructDataItemFactory() {
 
 		$this->assertInstanceOf(
-			'\SMWQueryParser',
-			$this->applicationFactory->newQueryParser()
+			'\SMW\DataItemFactory',
+			$this->applicationFactory->getDataItemFactory()
 		);
 	}
 

--- a/tests/phpunit/Unit/DataItemFactoryTest.php
+++ b/tests/phpunit/Unit/DataItemFactoryTest.php
@@ -4,6 +4,7 @@ namespace SMW\Tests;
 
 use SMW\DataItemFactory;
 use SMWDIUri as DIUri;
+use SMWDITime as DITime;
 
 /**
  * @covers \SMW\DataItemFactory
@@ -115,6 +116,16 @@ class DataItemFactoryTest extends \PHPUnit_Framework_TestCase {
 		$this->assertInstanceOf(
 			DIUri::class,
 			$instance->newDIUri( 'http', 'example.org' )
+		);
+	}
+
+	public function testCanConstructDITime() {
+
+		$instance = new DataItemFactory();
+
+		$this->assertInstanceOf(
+			DITime::class,
+			$instance->newDITime( 1, '1900' )
 		);
 	}
 


### PR DESCRIPTION
This PR is made in reference to: #1652

This PR addresses or contains:

- A query like `[[Help:~A*B]]` or `[[Help:>AB]]` is split into into `[[Help:]] [[~A*B]]` to ensure to match the namespace.

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed

