### PR TITLE
JsonResultPrinter add option for unescaped output

### DIFF
--- a/i18n/en.json
+++ b/i18n/en.json
@@ -80,6 +80,7 @@
 	"smw-paramdesc-import-annotation": "Additional annotated data are to be copied during the parsing of a subject",
 	"smw-paramdesc-export": "Export option",
 	"smw-paramdesc-prettyprint": "A pretty-print output that displays additional indents and newlines",
+	"smw-paramdesc-json-unescape": "Output to contain unescaped slashes and multibyte Unicode characters.",
 	"smw-paramdesc-source": "Alternative query source",
 	"smw-paramdesc-jsonsyntax": "JSON syntax to be used",
 	"smw-printername-feed": "RSS and Atom feed",

--- a/includes/queryprinters/JsonResultPrinter.php
+++ b/includes/queryprinters/JsonResultPrinter.php
@@ -59,11 +59,12 @@ class JsonResultPrinter extends FileExportPrinter {
 	 * @return string|boolean
 	 */
 	public function getFileName( SMWQueryResult $queryResult ) {
+
 		if ( $this->getSearchLabel( SMW_OUTPUT_WIKI ) !== '' ) {
 			return str_replace( ' ', '_', $this->getSearchLabel( SMW_OUTPUT_WIKI ) ) . '.json';
-		} else {
-			return 'result.json';
 		}
+
+		return 'result.json';
 	}
 
 	/**
@@ -83,13 +84,16 @@ class JsonResultPrinter extends FileExportPrinter {
 				return $this->params['default'] !== '' ? $this->params['default'] : '';
 			}
 
+			$flags = $this->params['prettyprint'] ? JSON_PRETTY_PRINT : 0;
+			$flags = $flags | ( $this->params['unescape'] ? JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES : 0 );
+
 			// Serialize queryResult
-			$result = FormatJSON::encode(
+			$result = json_encode(
 				array_merge(
 					$res->serializeToArray(),
 					array ( 'rows' => $res->getCount() )
 				),
-				$this->params['prettyprint']
+				$flags
 			);
 
 		} else {
@@ -124,6 +128,12 @@ class JsonResultPrinter extends FileExportPrinter {
 			'type' => 'boolean',
 			'default' => '',
 			'message' => 'smw-paramdesc-prettyprint',
+		);
+
+		$params['unescape'] = array(
+			'type' => 'boolean',
+			'default' => '',
+			'message' => 'smw-paramdesc-json-unescape',
 		);
 
 		return $params;

--- a/includes/specials/SMW_SpecialAsk.php
+++ b/includes/specials/SMW_SpecialAsk.php
@@ -737,6 +737,7 @@ class SMWAskPage extends SMWQuerySpecialPage {
 
 		$link = QueryLinker::get( $query );
 		$link->setParameter( 'true', 'prettyprint' );
+		$link->setParameter( 'true', 'unescape' );
 		$link->setParameter( 'json', 'format' );
 		$link->setCaption( 'JSON' );
 

--- a/tests/phpunit/Integration/ByJsonScript/Fixtures/s-0003.json
+++ b/tests/phpunit/Integration/ByJsonScript/Fixtures/s-0003.json
@@ -63,7 +63,7 @@
 			},
 			"special-page": {
 				"page":"Ask",
-				"query-parameters": "-5B-5BCategory:S0003-5D-5D/-3FCategory/-3FHas-20boolean=Text/mainlabel=/limit=100/offset=0/format=json/link=none",
+				"query-parameters": "-5B-5BCategory:S0003-5D-5D/-3FCategory/-3FHas-20boolean=Text/mainlabel=/limit=100/offset=0/format=json/unescape=true/prettyprint=true/link=none",
 				"request-parameters":{}
 			},
 			"expected-output": {

--- a/tests/phpunit/includes/queryprinters/JsonResultPrinterTest.php
+++ b/tests/phpunit/includes/queryprinters/JsonResultPrinterTest.php
@@ -107,7 +107,7 @@ class JsonResultPrinterTest extends QueryPrinterTestCase {
 
 		$expected = array_merge( $result, array( 'rows' => count( $result ) ) );
 
-		$instance = $this->newInstance( array( 'prettyprint' => false ) );
+		$instance = $this->newInstance( array( 'prettyprint' => false, 'unescape' => false ) );
 
 		$reflector = new ReflectionClass( '\SMW\JsonResultPrinter' );
 		$getResultText = $reflector->getMethod( 'getResultText' );


### PR DESCRIPTION
This PR is made in reference to: #

This PR addresses or contains:

- Add option to support `JSON_UNESCAPED_SLASHES` | `JSON_UNESCAPED_UNICODE`

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed

