### PR TITLE
Add InTextAnnotationSanitizer

### DIFF
--- a/src/InTextAnnotationSanitizer.php
+++ b/src/InTextAnnotationSanitizer.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace SMW;
+
+/**
+ * @license GNU GPL v2+
+ * @since 2.5
+ *
+ * @author mwjames
+ */
+class InTextAnnotationSanitizer {
+
+	/**
+	 * @since 2.5
+	 *
+	 * @param string $text
+	 *
+	 * @return text
+	 */
+	public static function decodeSquareBracket( $text ) {
+		return str_replace( array( '%5B', '%5D' ), array( '[', ']' ), $text );
+	}
+
+	/**
+	 * @since 2.5
+	 *
+	 * @param string $text
+	 *
+	 * @return text
+	 */
+	public static function obscureAnnotation( $text ) {
+		return preg_replace_callback(
+			InTextAnnotationParser::getRegexpPattern( false ),
+			function( array $matches ) {
+				return str_replace( '[', '&#x005B;', $matches[0] );
+			},
+			self::decodeSquareBracket( $text )
+		);
+	}
+
+	/**
+	 * @since 2.5
+	 *
+	 * @param string $text
+	 *
+	 * @return text
+	 */
+	public static function removeAnnotation( $text ) {
+		return preg_replace_callback(
+			InTextAnnotationParser::getRegexpPattern( false ),
+			'self::doRemoveAnnotation',
+			self::decodeSquareBracket( $text )
+		);
+	}
+
+	private static function doRemoveAnnotation( array $matches ) {
+
+		$caption = false;
+		$value = '';
+
+		// #1453
+		if ( $matches[0] === InTextAnnotationParser::OFF || $matches[0] === InTextAnnotationParser::ON ) {
+			return false;
+		}
+
+		// Strict mode matching
+		if ( array_key_exists( 1, $matches ) ) {
+			if ( strpos( $matches[1], ':' ) !== false && isset( $matches[2] ) ) {
+				list( $matches[1], $matches[2] ) = explode( '::', $matches[1] . '::' . $matches[2], 2 );
+			}
+		}
+
+		if ( array_key_exists( 2, $matches ) ) {
+
+			// #1747
+			if ( strpos( $matches[1], '|' ) !== false ) {
+				return $matches[0];
+			}
+
+			$parts = explode( '|', $matches[2] );
+			$value = array_key_exists( 0, $parts ) ? $parts[0] : '';
+			$caption = array_key_exists( 1, $parts ) ? $parts[1] : false;
+		}
+
+		// #...
+		if ( $value === '@@@' ) {
+			$value = '';
+		}
+
+		return $caption !== false ? $caption : $value;
+	}
+
+}

--- a/tests/phpunit/Unit/InTextAnnotationParserTest.php
+++ b/tests/phpunit/Unit/InTextAnnotationParserTest.php
@@ -282,43 +282,6 @@ class InTextAnnotationParserTest extends \PHPUnit_Framework_TestCase {
 			'Suspendisse &#x005B;&#x005B;Bar::tincidunt semper|abc]] facilisi'
 		);
 
-		$provider[] = array(
-			'Suspendisse [[Bar::tincidunt semper]] facilisi',
-			'Suspendisse tincidunt semper facilisi',
-			'Suspendisse &#x005B;&#x005B;Bar::tincidunt semper]] facilisi'
-		);
-
-		$provider[] = array(
-			'Suspendisse [[:Tincidunt semper|tincidunt semper]]',
-			'Suspendisse [[:Tincidunt semper|tincidunt semper]]',
-			'Suspendisse [[:Tincidunt semper|tincidunt semper]]'
-		);
-
-		$provider[] = array(
-			'[[Foo::Foobar::テスト]] [[Bar:::ABC|DEF]] [[Foo:::0049 30 12345678/::Foo]]',
-			'Foobar::テスト DEF :0049 30 12345678/::Foo',
-			'&#x005B;&#x005B;Foo::Foobar::テスト]] &#x005B;&#x005B;Bar:::ABC|DEF]] &#x005B;&#x005B;Foo:::0049 30 12345678/::Foo]]'
-		);
-
-		$provider[] = array(
-			'%5B%5BFoo%20Bar::foobaz%5D%5D',
-			'foobaz',
-			'&#x005B;&#x005B;Foo%20Bar::foobaz]]'
-		);
-
-		$provider[] = array(
-			'Suspendisse tincidunt semper facilisi',
-			'Suspendisse tincidunt semper facilisi',
-			'Suspendisse tincidunt semper facilisi'
-		);
-
-		// #1747
-		$provider[] = array(
-			'[[Foo|Bar::Foobar]] [[File:Example.png|alt=Bar::Foobar|Caption]] [[File:Example.png|Bar::Foobar|link=Foo]]',
-			'[[Foo|Bar::Foobar]] [[File:Example.png|alt=Bar::Foobar|Caption]] [[File:Example.png|Bar::Foobar|link=Foo]]',
-			'&#x005B;&#x005B;Foo|Bar::Foobar]] &#x005B;&#x005B;File:Example.png|alt=Bar::Foobar|Caption]] &#x005B;&#x005B;File:Example.png|Bar::Foobar|link=Foo]]'
-		);
-
 		return $provider;
 	}
 

--- a/tests/phpunit/Unit/InTextAnnotationSanitizerTest.php
+++ b/tests/phpunit/Unit/InTextAnnotationSanitizerTest.php
@@ -1,0 +1,96 @@
+<?php
+
+namespace SMW\Tests;
+
+use SMW\InTextAnnotationSanitizer;
+
+/**
+ * @covers \SMW\InTextAnnotationSanitizer
+ * @group semantic-mediawiki
+ *
+ * @license GNU GPL v2+
+ * @since 2.5
+ *
+ * @author mwjames
+ */
+class InTextAnnotationSanitizerTest extends \PHPUnit_Framework_TestCase {
+
+	/**
+	 * @dataProvider stripTextWithAnnotationProvider
+	 */
+	public function testStrip( $text, $expectedRemoval, $expectedObscuration ) {
+
+		$this->assertEquals(
+			$expectedRemoval,
+			InTextAnnotationSanitizer::removeAnnotation( $text )
+		);
+
+		$this->assertEquals(
+			$expectedObscuration,
+			InTextAnnotationSanitizer::obscureAnnotation( $text )
+		);
+	}
+
+	public function stripTextWithAnnotationProvider() {
+
+		$provider = array();
+
+		$provider[] = array(
+			'Suspendisse [[Bar::tincidunt semper|abc]] facilisi',
+			'Suspendisse abc facilisi',
+			'Suspendisse &#x005B;&#x005B;Bar::tincidunt semper|abc]] facilisi'
+		);
+
+		$provider[] = array(
+			'Suspendisse [[Bar::tincidunt semper]] facilisi',
+			'Suspendisse tincidunt semper facilisi',
+			'Suspendisse &#x005B;&#x005B;Bar::tincidunt semper]] facilisi'
+		);
+
+		$provider[] = array(
+			'Suspendisse [[:Tincidunt semper|tincidunt semper]]',
+			'Suspendisse [[:Tincidunt semper|tincidunt semper]]',
+			'Suspendisse [[:Tincidunt semper|tincidunt semper]]'
+		);
+
+		$provider[] = array(
+			'[[Foo::Foobar::テスト]] [[Bar:::ABC|DEF]] [[Foo:::0049 30 12345678/::Foo]]',
+			'Foobar::テスト DEF :0049 30 12345678/::Foo',
+			'&#x005B;&#x005B;Foo::Foobar::テスト]] &#x005B;&#x005B;Bar:::ABC|DEF]] &#x005B;&#x005B;Foo:::0049 30 12345678/::Foo]]'
+		);
+
+		$provider[] = array(
+			'%5B%5BFoo%20Bar::foobaz%5D%5D',
+			'foobaz',
+			'&#x005B;&#x005B;Foo%20Bar::foobaz]]'
+		);
+
+		$provider[] = array(
+			'Suspendisse tincidunt semper facilisi',
+			'Suspendisse tincidunt semper facilisi',
+			'Suspendisse tincidunt semper facilisi'
+		);
+
+		// #1747
+		$provider[] = array(
+			'[[Foo|Bar::Foobar]] [[File:Example.png|alt=Bar::Foobar|Caption]] [[File:Example.png|Bar::Foobar|link=Foo]]',
+			'[[Foo|Bar::Foobar]] [[File:Example.png|alt=Bar::Foobar|Caption]] [[File:Example.png|Bar::Foobar|link=Foo]]',
+			'&#x005B;&#x005B;Foo|Bar::Foobar]] &#x005B;&#x005B;File:Example.png|alt=Bar::Foobar|Caption]] &#x005B;&#x005B;File:Example.png|Bar::Foobar|link=Foo]]'
+		);
+
+		$provider[] = array(
+			'[[Foo::@@@]] [[Bar::@@@|123]]',
+			' 123',
+			'&#x005B;&#x005B;Foo::@@@]] &#x005B;&#x005B;Bar::@@@|123]]'
+		);
+
+		$provider[] = array(
+			'Suspendisse [[SMW::off]][[Bar::tincidunt semper|abc]] facilisi[[SMW::on]] [[Bar:::ABC|DEF]]',
+			'Suspendisse abc facilisi DEF',
+			'Suspendisse &#x005B;&#x005B;SMW::off]]&#x005B;&#x005B;Bar::tincidunt semper|abc]] facilisi&#x005B;&#x005B;SMW::on]] &#x005B;&#x005B;Bar:::ABC|DEF]]'
+		);
+
+		return $provider;
+	}
+
+}


### PR DESCRIPTION
This PR is made in reference to: # N/A

This PR addresses or contains:

- Moving dedicated sanitation methods from `InTextAnnotationParser` to `InTextAnnotationSanitizer`

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed

