### PR TITLE
DataValue::getQueryDescription

### DIFF
--- a/docs/technical/code-snippets/match.property.values.md
+++ b/docs/technical/code-snippets/match.property.values.md
@@ -52,9 +52,8 @@ $queryResult = $applicationFactory->getStore()->getQueryResult( $query );
 $descriptionFactory = $queryFactory->newDescriptionFactory();
 
 // [[Foo::Bar]] with a limit of 42 matches
-$description = $descriptionFactory->newSomeProperty(
-	$dataValue->getProperty(),
-	$dataValue->getQueryDescription()
+$description = $descriptionFactory->newFromDataValue(
+	$dataValue
 );
 
 $query = $queryFactory->newQuery( $description );

--- a/includes/datavalues/SMW_DataValue.php
+++ b/includes/datavalues/SMW_DataValue.php
@@ -476,25 +476,22 @@ abstract class SMWDataValue {
 ///// Query support /////
 
 	/**
+	 * FIXME 3.0, allow NULL as value
+	 *
 	 * @see DataValueDescriptionDeserializer::deserialize
 	 *
 	 * @note Descriptions of values need to know their property to be able to
 	 * create a parsable wikitext version of a query condition again. Thus it
 	 * might be necessary to call setProperty() before using this method.
 	 *
-	 * @param string|null $value
+	 * @param string $value
 	 *
 	 * @return Description
 	 * @throws InvalidArgumentException
 	 */
-	public function getQueryDescription( $value = null ) {
+	public function getQueryDescription( $value ) {
 
 		$descriptionDeserializer = DVDescriptionDeserializerRegistry::getInstance()->getDescriptionDeserializerBy( $this );
-
-		if ( $value === null ) {
-			$value = $this->getWikiValue();
-		}
-
 		$description = $descriptionDeserializer->deserialize( $value );
 
 		foreach ( $descriptionDeserializer->getErrors() as $error ) {

--- a/src/Query/DescriptionFactory.php
+++ b/src/Query/DescriptionFactory.php
@@ -127,13 +127,10 @@ class DescriptionFactory {
 			return $this->newThingDescription();
 		}
 
-		// RecordValue is missing
+		// Avoid circular reference when called from outside of the DV context
+		$dataValue->setOption( DataValue::OPT_QUERY_CONTEXT, true );
 
-		if ( $dataValue instanceof MonolingualTextValue ) {
-			$description = $dataValue->getQueryDescription( $dataValue->toString() );
-		} else {
-			$description = $this->newValueDescription( $dataValue->getDataItem() );
-		}
+		$description = $dataValue->getQueryDescription( $dataValue->getWikiValue() );
 
 		if ( $dataValue->getProperty() === null ) {
 			return $description;

--- a/tests/phpunit/Unit/Query/DescriptionFactoryTest.php
+++ b/tests/phpunit/Unit/Query/DescriptionFactoryTest.php
@@ -202,7 +202,7 @@ class DescriptionFactoryTest extends \PHPUnit_Framework_TestCase {
 
 		$dataValue = $this->getMockBuilder( '\SMWDataValue' )
 			->disableOriginalConstructor()
-			->setMethods( array( 'isValid', 'getProperty', 'getDataItem' ) )
+			->setMethods( array( 'isValid', 'getProperty', 'getDataItem', 'getWikiValue' ) )
 			->getMockForAbstractClass();
 
 		$dataValue->expects( $this->atLeastOnce() )
@@ -216,6 +216,10 @@ class DescriptionFactoryTest extends \PHPUnit_Framework_TestCase {
 		$dataValue->expects( $this->atLeastOnce() )
 			->method( 'getDataItem' )
 			->will( $this->returnValue( $this->dataItemFactory->newDIBlob( 'Bar' ) ) );
+
+		$dataValue->expects( $this->atLeastOnce() )
+			->method( 'getWikiValue' )
+			->will( $this->returnValue( 'Bar' ) );
 
 		$instance = new DescriptionFactory();
 


### PR DESCRIPTION
This PR is made in reference to: #1845

This PR addresses or contains:

- Avoid BC by introducing `NULL` with 3+.

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed