### PR TITLE
Normalize namespace text output

### DIFF
--- a/includes/datavalues/SMW_DV_WikiPage.php
+++ b/includes/datavalues/SMW_DV_WikiPage.php
@@ -493,18 +493,20 @@ class SMWWikiPageValue extends SMWDataValue {
 	 * @return string
 	 */
 	public function getPrefixedText() {
-		global $wgContLang;
-		if ( $this->m_prefixedtext === '' ) {
-			if ( $this->isValid() ) {
-				$nstext = $wgContLang->getNSText( $this->m_dataitem->getNamespace() );
-				$this->m_prefixedtext =
-					( $this->m_dataitem->getInterwiki() !== '' ?
-						$this->m_dataitem->getInterwiki() . ':' : '' ) .
-					( $nstext !== '' ? "$nstext:" : '' ) . $this->getText();
-			} else {
-				$this->m_prefixedtext = 'NO_VALID_VALUE';
-			}
+
+		if ( $this->m_prefixedtext !== '' ) {
+			return $this->m_prefixedtext;
 		}
+
+		$this->m_prefixedtext = 'NO_VALID_VALUE';
+
+		if ( $this->isValid() ) {
+			$nstext = Localizer::getInstance()->getNamespaceTextById( $this->m_dataitem->getNamespace() );
+			$this->m_prefixedtext =
+				( $this->m_dataitem->getInterwiki() !== '' ? $this->m_dataitem->getInterwiki() . ':' : '' ) .
+				( $nstext !== '' ? "$nstext:" : '' ) . $this->getText();
+		}
+
 		return $this->m_prefixedtext;
 	}
 

--- a/src/Localizer.php
+++ b/src/Localizer.php
@@ -160,7 +160,7 @@ class Localizer {
 	 * @return string
 	 */
 	public function getNamespaceTextById( $namespaceId ) {
-		return $this->contentLanguage->getNsText( $namespaceId );
+		return str_replace( '_', ' ', $this->contentLanguage->getNsText( $namespaceId ) );
 	}
 
 	/**


### PR DESCRIPTION
This PR is made in reference to: # N/A

This PR addresses or contains:

- To avoid namespaces being displayed with a `_` and instead use the normalized form

This PR includes:
- [ ] Tests (unit/integration)
- [x] CI build passed

