### PR TITLE
Add PropertyDescriptionValueResourceBuilder

### DIFF
--- a/src/Exporter/ResourceBuilders/DispatchingResourceBuilder.php
+++ b/src/Exporter/ResourceBuilders/DispatchingResourceBuilder.php
@@ -100,6 +100,8 @@ class DispatchingResourceBuilder implements ResourceBuilder {
 
 	private function initResourceBuilders() {
 
+		$this->addResourceBuilder( new PropertyDescriptionValueResourceBuilder() );
+
 		$this->addResourceBuilder( new ExternalIdentifierPropertyValueResourceBuilder() );
 		$this->addResourceBuilder( new MonolingualTextPropertyValueResourceBuilder() );
 

--- a/src/Exporter/ResourceBuilders/PropertyDescriptionValueResourceBuilder.php
+++ b/src/Exporter/ResourceBuilders/PropertyDescriptionValueResourceBuilder.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace SMW\Exporter\ResourceBuilders;
+
+use SMW\Exporter\ResourceBuilder;
+use SMW\DIProperty;
+use SMWExporter as Exporter;
+use SMW\DataValueFactory;
+use SMWDataItem as DataItem;
+use SMWExpData as ExpData;
+use SMWExpLiteral as ExpLiteral;
+
+/**
+ * @private
+ *
+ * @license GNU GPL v2+
+ * @since 2.5
+ *
+ * @author mwjames
+ */
+class PropertyDescriptionValueResourceBuilder extends PropertyValueResourceBuilder {
+
+	/**
+	 * @since 2.5
+	 *
+	 * {@inheritDoc}
+	 */
+	public function isResourceBuilderFor( DIProperty $property ) {
+		return $property->getKey() === '_PDESC';
+	}
+
+	/**
+	 * @since 2.5
+	 *
+	 * {@inheritDoc}
+	 */
+	public function addResourceValue( ExpData $expData, DIProperty $property, DataItem $dataItem ) {
+
+		parent::addResourceValue( $expData, $property, $dataItem );
+
+		$dataValue = DataValueFactory::getInstance()->newDataValueByItem(
+			$dataItem,
+			$property
+		);
+
+		$list = $dataValue->toArray();
+
+		if ( !isset( $list['_TEXT'] ) || !isset( $list['_LCODE'] ) ) {
+			return;
+		}
+
+		// Ussing `skos:scopeNote` instead of `skos:definition` since we can not
+		// ensure that the description given by a user is complete.
+		//
+		// "skos:scopeNote supplies some, possibly partial, information about the
+		// intended meaning of a concept ..."
+		//
+		// "skos:definition supplies a complete explanation of the intended
+		// meaning of a concept."
+		//
+		// According to https://www.w3.org/TR/2009/NOTE-skos-primer-20090818/#secdocumentation
+
+		$expData->addPropertyObjectValue(
+			$this->exporter->getSpecialNsResource( 'skos', 'scopeNote' ),
+			new ExpLiteral(
+				(string)$list['_TEXT'],
+				'http://www.w3.org/2001/XMLSchema#string',
+				(string)$list['_LCODE'],
+				$dataItem
+			)
+		);
+	}
+
+}

--- a/tests/phpunit/Integration/ByJsonScript/Fixtures/r-0009.json
+++ b/tests/phpunit/Integration/ByJsonScript/Fixtures/r-0009.json
@@ -21,8 +21,8 @@
 			"expected-output": {
 				"to-contain": [
 					"<owl:DatatypeProperty rdf:about=\"http://example.org/id/Property-3AHas_number\">",
-					"<property:Has_property_description-23aux xml:lang=\"en\">Is a number</property:Has_property_description-23aux>",
-					"<property:Has_property_description-23aux xml:lang=\"ja\">数</property:Has_property_description-23aux>",
+					"<skos:scopeNote xml:lang=\"en\">Is a number</skos:scopeNote>",
+					"<skos:scopeNote xml:lang=\"ja\">数</skos:scopeNote>",
 					"<property:Has_property_description rdf:resource=\"http://example.org/id/Property-3AHas_number-23_ML13b181afba7d1e489a656a75fa7917b2\"/>",
 					"<property:Has_property_description rdf:resource=\"http://example.org/id/Property-3AHas_number-23_ML4c33eabf5c7dfbb1292c817504951018\"/>",
 					"<swivt:Subject rdf:about=\"http://example.org/id/Property-3AHas_number-23_ML13b181afba7d1e489a656a75fa7917b2\">",
@@ -48,7 +48,7 @@
 			"expected-output": {
 				"to-contain": [
 					"rdfs:label  \"Has number\" ;",
-					"property:Has_property_description-23aux  \"Is a number\"@en ,  \"数\"@ja ;",
+					"skos:scopeNote  \"Is a number\"@en ,  \"数\"@ja ;",
 					"property:Has_property_description  property:Has_number-23_ML13b181afba7d1e489a656a75fa7917b2 ,  property:Has_number-23_ML4c33eabf5c7dfbb1292c817504951018 ;",
 					"swivt:wikiPageSortKey  \"Has number\" ;",
 					"swivt:type  <http://semantic-mediawiki.org/swivt/1.0#_num> .",

--- a/tests/phpunit/Unit/Exporter/ResourceBuilders/PropertyDescriptionValueResourceBuilderTest.php
+++ b/tests/phpunit/Unit/Exporter/ResourceBuilders/PropertyDescriptionValueResourceBuilderTest.php
@@ -1,0 +1,86 @@
+<?php
+
+namespace SMW\Tests\Exporter\ResourceBuilders;
+
+use SMW\Exporter\ResourceBuilders\PropertyDescriptionValueResourceBuilder;
+use SMW\DataItemFactory;
+use SMW\DataValueFactory;
+use SMW\Tests\TestEnvironment;
+use SMWExpData as ExpData;
+use SMW\Exporter\Element\ExpNsResource;
+
+/**
+ * @covers \SMW\Exporter\ResourceBuilders\PropertyDescriptionValueResourceBuilder
+ * @group semantic-mediawiki
+ *
+ * @license GNU GPL v2+
+ * @since 2.5
+ *
+ * @author mwjames
+ */
+class PropertyDescriptionValueResourceBuilderTest extends \PHPUnit_Framework_TestCase {
+
+	private $dataItemFactory;
+	private $dataValueFactory;
+	private $testEnvironment;
+
+	protected function setUp() {
+		parent::setUp();
+		$this->dataItemFactory = new DataItemFactory();
+		$this->dataValueFactory = DataValueFactory::getInstance();
+
+		$this->testEnvironment = new TestEnvironment();
+		$this->testEnvironment->resetPoolCacheFor( \SMWExporter::POOLCACHE_ID );
+	}
+
+	protected function tearDown() {
+		$this->testEnvironment->tearDown();
+		parent::tearDown();
+	}
+
+	public function testCanConstruct() {
+
+		$this->assertInstanceof(
+			PropertyDescriptionValueResourceBuilder::class,
+			new PropertyDescriptionValueResourceBuilder()
+		);
+	}
+
+	public function testIsNotResourceBuilderForPropertyDescription() {
+
+		$property = $this->dataItemFactory->newDIProperty( 'Foo' );
+
+		$instance = new PropertyDescriptionValueResourceBuilder();
+
+		$this->assertFalse(
+			$instance->isResourceBuilderFor( $property )
+		);
+	}
+
+	public function testAddResourceValueForPropertyDescription() {
+
+		$property = $this->dataItemFactory->newDIProperty( '_PDESC' );
+
+		$monolingualTextValue = $this->dataValueFactory->newDataValueByProperty(
+			$property,
+			'Some description@en'
+		);
+
+		$expData = new ExpData(
+			new ExpNsResource( 'Foobar', 'Bar', 'Mo', null )
+		);
+
+		$instance = new PropertyDescriptionValueResourceBuilder();
+
+		$instance->addResourceValue(
+			$expData,
+			$property,
+			$monolingualTextValue->getDataItem()
+		);
+
+		$this->assertTrue(
+			$instance->isResourceBuilderFor( $property )
+		);
+	}
+
+}


### PR DESCRIPTION
This PR is made in reference to: #1381, #1814

This PR addresses or contains:

- Add `skos:scopeNote` as an extra statement for a `Has property description` assignment.

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed
