### PR TITLE
Highlighter to use title element for no-js environments, refs 1806

### DIFF
--- a/includes/Highlighter.php
+++ b/includes/Highlighter.php
@@ -176,6 +176,7 @@ class Highlighter {
 				'data-content' => isset( $this->options['data-content'] ) ? $this->options['data-content'] : null,
 				'data-state'   => $this->options['state'],
 				'data-title'   => Message::get( $this->options['title'], Message::TEXT, $language ),
+				'title'        => strip_tags( htmlspecialchars_decode( $this->options['content'] ) )
 			), Html::rawElement(
 					'span',
 					array(

--- a/tests/phpunit/Integration/ByJsonScript/Fixtures/p-0106.json
+++ b/tests/phpunit/Integration/ByJsonScript/Fixtures/p-0106.json
@@ -17,7 +17,7 @@
 			"subject": "Info-warning",
 			"expected-output": {
 				"to-contain": [
-					"<span class=\"smw-highlighter\" data-type=\"4\" data-state=\"inline\" data-title=\"Error\">",
+					"<span class=\"smw-highlighter\" data-type=\"4\" data-state=\"inline\" data-title=\"Error\" title=\"an error text\">",
 					"<span class=\"smwtticon warning\">",
 					"<div class=\"smwttcontent\">an error text</div>"
 				]
@@ -28,7 +28,7 @@
 			"subject": "Info-note",
 			"expected-output": {
 				"to-contain": [
-					"<span class=\"smw-highlighter\" data-type=\"7\" data-state=\"inline\" data-title=\"Note\">",
+					"<span class=\"smw-highlighter\" data-type=\"7\" data-state=\"inline\" data-title=\"Note\" title=\"an info note\">",
 					"<span class=\"smwtticon note\">",
 					"<div class=\"smwttcontent\">an info note</div>"
 				]

--- a/tests/phpunit/Unit/DataValues/ValueFormatters/NumberValueFormatterTest.php
+++ b/tests/phpunit/Unit/DataValues/ValueFormatters/NumberValueFormatterTest.php
@@ -186,7 +186,7 @@ class NumberValueFormatterTest extends \PHPUnit_Framework_TestCase {
 			'100 K',
 			NumberValueFormatter::WIKI_SHORT,
 			'notNull',
-			'<span class="smw-highlighter" data-type="3" data-state="inline" data-title="Unit conversion"><span class="smwtext">100 K</span><div class="smwttcontent">-173.15&#160;°C <br />-279.67&#160;°F <br />180&#160;°R <br /></div></span>'
+			'<span class="smw-highlighter" data-type="3" data-state="inline" data-title="Unit conversion" title="-173.15&amp;#160;°C -279.67&amp;#160;°F 180&amp;#160;°R "><span class="smwtext">100 K</span><div class="smwttcontent">-173.15&#160;°C <br />-279.67&#160;°F <br />180&#160;°R <br /></div></span>'
 		);
 
 		$provider['wl.1'] = array(


### PR DESCRIPTION
This PR is made in reference to: # N/A

This PR addresses or contains:

- If JavaScript cannot be loaded then the title will remain and allows to display information in a minimalistic form for no-js environments.

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed
