### PR TITLE
Store URI's longer than 255 chars in blob field, refs #1872

### DIFF
--- a/src/SQLStore/QueryEngine/Fulltext/SearchTableRebuilder.php
+++ b/src/SQLStore/QueryEngine/Fulltext/SearchTableRebuilder.php
@@ -124,7 +124,7 @@ class SearchTableRebuilder {
 		$searchTable = $this->getSearchTable();
 
 		if ( $proptable->getDiType() === DataItem::TYPE_URI ) {
-			$fetchFields = array( 's_id', 'p_id', 'o_serialized' );
+			$fetchFields = array( 's_id', 'p_id', 'o_blob', 'o_serialized' );
 		} else {
 			$fetchFields = array( 's_id', 'p_id', 'o_blob', 'o_hash' );
 		}
@@ -177,7 +177,7 @@ class SearchTableRebuilder {
 
 			// Uri or blob?
 			if ( isset( $row->o_serialized ) ) {
-				$indexableText = $row->o_serialized;
+				$indexableText = $row->o_blob === null ? $row->o_serialized : $row->o_blob;
 			} else {
 				$indexableText = $row->o_blob === null ? $row->o_hash : $row->o_blob;
 			}

--- a/tests/phpunit/Integration/ByJsonScript/Fixtures/q-0704.json
+++ b/tests/phpunit/Integration/ByJsonScript/Fixtures/q-0704.json
@@ -1,0 +1,52 @@
+{
+	"description": "Test `_uri` long URL (255+) (#1872)",
+	"setup": [
+		{
+			"namespace": "SMW_NS_PROPERTY",
+			"page": "Has url",
+			"contents": "[[Has type::URL]]"
+		},
+		{
+			"page": "Example/Q0704/1",
+			"contents": "[[Has url::http://example.org/TBgcHiQBTvpV3XkFiRpMcV1KQoZvQXFyiQUQMM2RoYUyJaRoSyKnsQTWwia3HATd4YVmd8BZgkL2LfL0Q6rP5E90A4IuV6uKdYjL3nxZvx0pbc3tbxwa6jMW1JDNxusaKQ52ftRS7DCEY1IPTRZnuRMLPgWYwLOsEAebOsxD7BBL9IK3Z2Osfh9s0FC1SUwCVdKcLkBgurXKGi99s61qnAU2zWFXBUCEzID6533LeaHCBKW8\\/\\i2BgTK2tv65LHO6zB-larger%&`^Than255ö/ä/ü/è/é]]"
+		},
+		{
+			"page": "Example/Q0704/Q.1",
+			"contents": "{{#ask: [[Has url::~*Than255]] |?Has url}}"
+		}
+	],
+	"tests": [
+		{
+			"type": "query",
+			"about": "#0 URL 255+ chars",
+			"condition": "[[Has url::~*Than255*]]",
+			"printouts": [
+				"Has url"
+			],
+			"parameters": {
+				"limit": "10"
+			},
+			"queryresult": {
+				"count": 1,
+				"results": [
+					"Example/Q0704/1#0##"
+				],
+				"datavalues": [
+					{
+						"property": "Has url",
+						"value": "http://example.org/TBgcHiQBTvpV3XkFiRpMcV1KQoZvQXFyiQUQMM2RoYUyJaRoSyKnsQTWwia3HATd4YVmd8BZgkL2LfL0Q6rP5E90A4IuV6uKdYjL3nxZvx0pbc3tbxwa6jMW1JDNxusaKQ52ftRS7DCEY1IPTRZnuRMLPgWYwLOsEAebOsxD7BBL9IK3Z2Osfh9s0FC1SUwCVdKcLkBgurXKGi99s61qnAU2zWFXBUCEzID6533LeaHCBKW8%5C/%5Ci2BgTK2tv65LHO6zB-larger%&%60%5EThan255%C3%B6/%C3%A4/%C3%BC/%C3%A8/%C3%A9"
+					}
+				]
+			}
+		}
+	],
+	"settings": {
+		"smwgEnabledFulltextSearch": true,
+		"smwgFulltextDeferredUpdate": false
+	},
+	"meta": {
+		"version": "2",
+		"is-incomplete": false,
+		"debug": false
+	}
+}

--- a/tests/phpunit/Unit/SQLStore/QueryEngine/Fulltext/SearchTableRebuilderTest.php
+++ b/tests/phpunit/Unit/SQLStore/QueryEngine/Fulltext/SearchTableRebuilderTest.php
@@ -72,6 +72,7 @@ class SearchTableRebuilderTest extends \PHPUnit_Framework_TestCase {
 
 		$row = new \stdClass;
 		$row->o_serialized = 'Foo';
+		$row->o_blob = null;
 		$row->s_id = 42;
 
 		$resultWrapper = $this->iteratorMockBuilder->setClass( '\ResultWrapper' )


### PR DESCRIPTION
This PR is made in reference to: #1872

This PR addresses or contains:
- Add a `o_blob` field to store URI's > 255 chars and allow retrieving them as intended by a user. The `o_serialized` is left unchanged to ensure that standard searches against this field is continuing to work. The full-text index (if enabled) will allow to search on the complete length.

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed
