### PR TITLE
Preferred property label, refs #1865

### DIFF
--- a/DefaultSettings.php
+++ b/DefaultSettings.php
@@ -524,7 +524,7 @@ $GLOBALS['smwgPageSpecialProperties'] = array( '_MDAT' );
 # setting is not normally changed by users but by extensions that add new
 # types that have their own additional declaration properties.
 ##
-$GLOBALS['smwgDeclarationProperties'] = array( '_PVAL', '_LIST', '_PVAP', '_PVUC' );
+$GLOBALS['smwgDeclarationProperties'] = array( '_PVAL', '_LIST', '_PVAP', '_PVUC', '_PDESC', '_PPLB' );
 ##
 
 ###
@@ -1007,9 +1007,14 @@ $GLOBALS['smwgEnabledInTextAnnotationParserStrictMode'] = true;
 # - SMW_DV_NUMV_USPACE (Number/QuantityValue) to preserve spaces within
 # unit labels
 #
+# - SMW_DV_PPLB to support the use of preferred property labels
+#
+# - SMW_DV_PROV_LHNT (PropertyValue) to output a <sup>p</sup> hint marker on
+# properties that use a preferred label
+#
 # @since 2.4
 ##
-$GLOBALS['smwgDVFeatures'] = SMW_DV_PROV_REDI | SMW_DV_MLTV_LCODE | SMW_DV_PVAP | SMW_DV_WPV_DTITLE | SMW_DV_TIMEV_CM;
+$GLOBALS['smwgDVFeatures'] = SMW_DV_PROV_REDI | SMW_DV_MLTV_LCODE | SMW_DV_PVAP | SMW_DV_WPV_DTITLE | SMW_DV_TIMEV_CM | SMW_DV_PPLB | SMW_DV_PROV_LHNT;
 
 ##
 # Fulltext search support

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -446,5 +446,7 @@
 	"smw-sp-types_ref_rec": "\"$1\" is a [https://www.semantic-mediawiki.org/wiki/Container container] type that allows to record additional information (e.g. provenance data) about a value assignment.",
 	"smw-datavalue-reference-outputformat": "$1: $2",
 	"smw-datavalue-reference-invalid-fields-definition": "The [[Special:Types/Reference|Reference]] type expects a list of properties to be declared using the [https://www.semantic-mediawiki.org/wiki/Help:Special_property_Has_fields Has fields] property.",
-	"smw-parser-invalid-json-format": "The JSON parser returned with a \"$1\"."
+	"smw-parser-invalid-json-format": "The JSON parser returned with a \"$1\".",
+	"smw-property-preferred-title-format":"$1 ($2)",
+	"smw-property-preferred-label-language-combination-exists": "\"$1\" cannot be used as preferred label because the language \"$2\" is already assigned to the \"$3\" label."
 }

--- a/i18n/extra/en.json
+++ b/i18n/extra/en.json
@@ -87,7 +87,8 @@
 		"_DTITLE": "Display title of",
 		"_PVUC": "Has uniqueness constraint",
 		"_PEID": "External identifier",
-		"_PEFU": "External formatter uri"
+		"_PEFU": "External formatter uri",
+		"_PPLB": "Has preferred property label"
 	},
 	"propertyAliases": {
 		"Display unit": "_UNIT",
@@ -126,7 +127,8 @@
 		"Has display title of": "_DTITLE",
 		"Has uniqueness constraint": "_PVUC",
 		"External identifier": "_PEID",
-		"External formatter uri": "_PEFU"
+		"External formatter uri": "_PEFU",
+		"Preferred property label": "_PPLB"
 	},
 	"namespaces":{
 		"SMW_NS_PROPERTY": "Property",

--- a/includes/articlepages/SMW_PropertyPage.php
+++ b/includes/articlepages/SMW_PropertyPage.php
@@ -29,6 +29,7 @@ class SMWPropertyPage extends SMWOrderedListPage {
 		$this->limit = $smwgPropertyPagingLimit;
 		$this->mProperty = DIProperty::newFromUserLabel( $this->mTitle->getText() );
 		$this->store = ApplicationFactory::getInstance()->getStore();
+		$this->propertyValue = DataValueFactory::getInstance()->newDataItemValue( $this->mProperty );
 		return true;
 	}
 
@@ -41,6 +42,12 @@ class SMWPropertyPage extends SMWOrderedListPage {
 
 		if ( !$this->store->getRedirectTarget( $this->mProperty )->equals( $this->mProperty ) ) {
 			return '';
+		}
+
+		if ( $this->propertyValue->getDataItem()->getPreferredLabel() !== '' && $this->mTitle->getText() !== $this->propertyValue->getDataItem()->getPreferredLabel() ) {
+			$this->getContext()->getOutput()->setPageTitle(
+				wfMessage( 'smw-property-preferred-title-format', $this->mTitle->getPrefixedText(), $this->propertyValue->getWikiValue() )->text()
+			);
 		}
 
 		$list = $this->getSubpropertyList() . $this->getPropertyValueList();

--- a/includes/dataitems/SMW_DI_Property.php
+++ b/includes/dataitems/SMW_DI_Property.php
@@ -209,6 +209,31 @@ class DIProperty extends SMWDataItem {
 	}
 
 	/**
+	 * Borrowing the skos:prefLabel definition where a preferred label is expected
+	 * to have only one label per given language (skos:altLabel can have many
+	 * alternative labels)
+	 *
+	 * An empty string signals that no preferred label is available in the current
+	 * user language.
+	 *
+	 * @since 2.5
+	 *
+	 * @param string $languageCode
+	 *
+	 * @return string
+	 */
+	public function getPreferredLabel( $languageCode = '' ) {
+
+		$label = PropertyRegistry::getInstance()->findPreferredPropertyLabelById( $this->m_key, $languageCode );
+
+		if ( $label !== '' ) {
+			return ( $this->m_inverse ? '-' : '' ) . $label;
+		}
+
+		return '';
+	}
+
+	/**
 	 * @since 2.4
 	 *
 	 * @param string $interwiki

--- a/includes/export/SMW_ExportController.php
+++ b/includes/export/SMW_ExportController.php
@@ -191,7 +191,7 @@ class SMWExportController {
 				$inprops = \SMW\StoreFactory::getStore()->getInProperties( $diWikiPage );
 
 				foreach ( $inprops as $inprop ) {
-					$propWikiPage = $inprop->getDiWikiPage();
+					$propWikiPage = $inprop->getCanonicalDiWikiPage();
 
 					if ( !is_null( $propWikiPage ) ) {
 						$this->queuePage( $propWikiPage, 0 ); // no real recursion along properties

--- a/includes/storage/SQLStore/SMW_Sql3SmwIds.php
+++ b/includes/storage/SQLStore/SMW_Sql3SmwIds.php
@@ -179,6 +179,7 @@ class SMWSql3SmwIds {
 		'_INST' => 4,
 		'_UNIT' => 7,
 		'_IMPO' => 8,
+		'_PPLB' => 9,
 		'_PDESC' => 10,
 		'_PREC' => 11,
 		'_CONV' => 12,

--- a/src/ApplicationFactory.php
+++ b/src/ApplicationFactory.php
@@ -327,6 +327,15 @@ class ApplicationFactory {
 	}
 
 	/**
+	 * @since 2.5
+	 *
+	 * @return PropertyLabelFinder
+	 */
+	public function newPropertyLabelFinder() {
+		return $this->callbackLoader->create( 'PropertyLabelFinder' );
+	}
+
+	/**
 	 * @since 2.4
 	 *
 	 * @return CachedPropertyValuesPrefetcher

--- a/src/DataTypeRegistry.php
+++ b/src/DataTypeRegistry.php
@@ -119,13 +119,6 @@ class DataTypeRegistry {
 
 		if ( self::$instance === null ) {
 
-			// This is the earliest point we can reset the language in accordance with
-			// the user setting because any access to Language::getCode during the
-			// setup violates MW's internal state
-			NamespaceManager::getNamespacesByLanguageCode(
-				Localizer::getInstance()->getUserLanguage()->getCode()
-			);
-
 			self::$instance = new self(
 				$GLOBALS['smwgContLang']->getDatatypeLabels(),
 				$GLOBALS['smwgContLang']->getDatatypeAliases(),

--- a/src/DataValues/MonolingualTextValue.php
+++ b/src/DataValues/MonolingualTextValue.php
@@ -9,6 +9,7 @@ use SMW\DataValues\ValueParsers\MonolingualTextValueParser;
 use SMW\DIProperty;
 use SMW\DIWikiPage;
 use SMW\Localizer;
+use SMW\StringCondition;
 use SMWContainerSemanticData as ContainerSemanticData;
 use SMWDataItem as DataItem;
 use SMWDataValue as DataValue;
@@ -70,6 +71,18 @@ class MonolingualTextValue extends AbstractMultiValue {
 	 */
 	public function getProperties() {
 		self::$properties;
+	}
+
+	/**
+	 * @since 2.5
+	 *
+	 * @param $userValue
+	 * @param string $languageCode
+	 *
+	 * @return string
+	 */
+	public function getTextWithLanguageTag( $text, $languageCode ) {
+		return $text . '@' . Localizer::asBCP47FormattedLanguageCode( $languageCode );
 	}
 
 	/**

--- a/src/DataValues/ValueFormatterRegistry.php
+++ b/src/DataValues/ValueFormatterRegistry.php
@@ -11,6 +11,7 @@ use SMW\DataValues\ValueFormatters\NoValueFormatter;
 use SMW\DataValues\ValueFormatters\NumberValueFormatter;
 use SMW\DataValues\ValueFormatters\StringValueFormatter;
 use SMW\DataValues\ValueFormatters\TimeValueFormatter;
+use SMW\DataValues\ValueFormatters\PropertyValueFormatter;
 use SMWDataValue as DataValue;
 
 /**
@@ -104,6 +105,7 @@ class ValueFormatterRegistry {
 
 		// To be checked only after DispatchingDataValueFormatter::addDataValueFormatter did
 		// not match any previous registered DataValueFormatters
+		$dispatchingDataValueFormatter->addDefaultDataValueFormatter( new PropertyValueFormatter() );
 		$dispatchingDataValueFormatter->addDefaultDataValueFormatter( new StringValueFormatter() );
 		$dispatchingDataValueFormatter->addDefaultDataValueFormatter( new NumberValueFormatter() );
 		$dispatchingDataValueFormatter->addDefaultDataValueFormatter( new TimeValueFormatter() );

--- a/src/DataValues/ValueFormatters/PropertyValueFormatter.php
+++ b/src/DataValues/ValueFormatters/PropertyValueFormatter.php
@@ -1,0 +1,168 @@
+<?php
+
+namespace SMW\DataValues\ValueFormatters;
+
+use SMW\ApplicationFactory;
+use SMW\Highlighter;
+use SMW\Message;
+use SMWDataValue as DataValue;
+use SMWPropertyValue as PropertyValue;
+use RuntimeException;
+
+/**
+ * @license GNU GPL v2+
+ * @since 2.5
+ *
+ * @author mwjames
+ */
+class PropertyValueFormatter extends DataValueFormatter {
+
+	/**
+	 * @since 2.5
+	 *
+	 * {@inheritDoc}
+	 */
+	public function isFormatterFor( DataValue $dataValue ) {
+		return $dataValue instanceof PropertyValue;
+	}
+
+	/**
+	 * @since 2.5
+	 *
+	 * {@inheritDoc}
+	 */
+	public function format( $type, $linker = null ) {
+
+		if ( !$this->dataValue instanceof PropertyValue ) {
+			throw new RuntimeException( "The formatter is missing a valid PropertyValue object" );
+		}
+
+		if ( !$this->dataValue->isVisible() ) {
+			return '';
+		}
+
+		if ( $type === self::VALUE ) {
+			return $this->getWikiValue();
+		}
+
+		$wikiPageValue = $this->prepareWikiPageValue( $linker );
+
+		if ( $wikiPageValue === null ) {
+			return '';
+		}
+
+		if ( $type === self::WIKI_SHORT ) {
+			$text = $this->doHighlightText( $wikiPageValue->getShortWikiText( $linker ) );
+		}
+
+		if ( $type === self::HTML_SHORT ) {
+			$text = $this->doHighlightText( $wikiPageValue->getShortHTMLText( $linker ), $linker );
+		}
+
+		if ( $type === self::WIKI_LONG ) {
+			$text = $wikiPageValue->getLongWikiText( $linker );
+		}
+
+		if ( $type === self::HTML_LONG ) {
+			$text = $this->doHighlightText( $wikiPageValue->getLongHTMLText( $linker ), $linker );
+		}
+
+		return $text . $this->hintPreferredLabelUse();
+	}
+
+	private function getWikiValue() {
+
+		if ( $this->dataValue->getPreferredLabel() !== '' ) {
+			return $this->dataValue->getPreferredLabel();
+		}
+
+		if ( $this->dataValue->getWikiPageValue() !== null && $this->dataValue->getWikiPageValue()->getDisplayTitle() !== '' ) {
+			return $this->dataValue->getWikiPageValue()->getDisplayTitle();
+		}
+
+		return $this->dataValue->getDataItem()->getLabel();
+	}
+
+	private function prepareWikiPageValue( $linker = null ) {
+
+		$wikiPageValue = $this->dataValue->getWikiPageValue();
+
+		if ( $wikiPageValue === null ) {
+			return null;
+		}
+
+		$label = $this->dataValue->getDataItem()->getLabel();
+		$preferredLabel = $this->dataValue->getPreferredLabel();
+		$caption = $this->dataValue->getCaption();
+
+		if ( $caption !== false && $caption !== '' ) {
+			$wikiPageValue->setCaption( $caption );
+		} elseif ( $preferredLabel !== '' ) {
+			$wikiPageValue->setCaption( $preferredLabel );
+		} else {
+			$wikiPageValue->setCaption( $label );
+		}
+
+		return $wikiPageValue;
+	}
+
+	private function doHighlightText( $text, $linker = null ) {
+
+		$content = '';
+
+		if ( !$this->canHighlight( $content, $linker ) ) {
+			return $text;
+		}
+
+		$highlighter = Highlighter::factory(
+			Highlighter::TYPE_PROPERTY,
+			$this->dataValue->getOptionBy( PropertyValue::OPT_USER_LANGUAGE )
+		);
+
+		$highlighter->setContent( array (
+			'userDefined' => $this->dataValue->getDataItem()->isUserDefined(),
+			'caption' => $text,
+			'content' => $content !== '' ? $content : Message::get( 'smw_isspecprop' )
+		) );
+
+		return $highlighter->getHtml();
+	}
+
+	private function canHighlight( &$propertyDescription, $linker ) {
+
+		if ( $this->dataValue->getOptionBy( PropertyValue::OPT_NO_HIGHLIGHT ) === true ) {
+			return false;
+		}
+
+		$dataItem = $this->dataValue->getDataItem();
+		$propertySpecificationLookup = ApplicationFactory::getInstance()->getPropertySpecificationLookup();
+
+		$propertyDescription = $propertySpecificationLookup->getPropertyDescriptionBy(
+			$dataItem,
+			$linker
+		);
+
+		return !$dataItem->isUserDefined() || $propertyDescription !== '';
+	}
+
+	private function hintPreferredLabelUse() {
+
+		$preferredLabel = $this->dataValue->getPreferredLabel();
+		$label = $this->dataValue->getDataItem()->getLabel();
+
+		if ( !$this->dataValue->isEnabledFeature( SMW_DV_PROV_LHNT ) ||
+			$preferredLabel === $this->dataValue->getDataItem()->getCanonicalLabel() ||
+			$preferredLabel === '' ) {
+			return '';
+		}
+
+		$preferredLabelMarker = '';
+
+		if ( $preferredLabel !== $label ) {
+			$preferredLabelMarker = '&nbsp;' . \Html::rawElement( 'span', array( 'title' => $label ), '<sup>ᵖ</sup>' );
+		}
+
+		return $preferredLabelMarker;
+	}
+
+}

--- a/src/DataValues/ValueValidators/CompoundConstraintValueValidator.php
+++ b/src/DataValues/ValueValidators/CompoundConstraintValueValidator.php
@@ -73,6 +73,7 @@ class CompoundConstraintValueValidator implements ConstraintValueValidator {
 		$this->registerConstraintValueValidator( new UniquenessConstraintValueValidator() );
 		$this->registerConstraintValueValidator( new PatternConstraintValueValidator() );
 		$this->registerConstraintValueValidator( new ListConstraintValueValidator() );
+		$this->registerConstraintValueValidator( new PropertySpecificationConstraintValueValidator() );
 	}
 
 }

--- a/src/DataValues/ValueValidators/PropertySpecificationConstraintValueValidator.php
+++ b/src/DataValues/ValueValidators/PropertySpecificationConstraintValueValidator.php
@@ -1,0 +1,107 @@
+<?php
+
+namespace SMW\DataValues\ValueValidators;
+
+use SMWDataValue as DataValue;
+use SMW\ApplicationFactory;
+use SMW\DIProperty;
+
+/**
+ * @private
+ *
+ * @license GNU GPL v2+
+ * @since 2.5
+ *
+ * @author mwjames
+ */
+class PropertySpecificationConstraintValueValidator implements ConstraintValueValidator {
+
+	/**
+	 * @var boolean
+	 */
+	private $hasConstraintViolation = false;
+
+	/**
+	 * @var array
+	 */
+	private static $inMemoryLabelToLanguageTracer = array();
+
+	/**
+	 * @since 2.5
+	 *
+	 * {@inheritDoc}
+	 */
+	public function hasConstraintViolation() {
+		return $this->hasConstraintViolation;
+	}
+
+	/**
+	 * @since 2.5
+	 *
+	 * {@inheritDoc}
+	 */
+	public function validate( $dataValue ) {
+
+		$this->hasConstraintViolation = false;
+
+		if (
+			!$dataValue instanceof DataValue ||
+			$dataValue->getProperty() === null ||
+			$dataValue->getContextPage() === null ||
+			$dataValue->getContextPage()->getNamespace() !== SMW_NS_PROPERTY ) {
+			return $this->hasConstraintViolation;
+		}
+
+		if ( $dataValue->getProperty()->getKey() === '_PPLB' ) {
+			return $this->doValidateCodifiedPreferredPropertyLabelConstraints( $dataValue );
+		}
+	}
+
+	private function doValidateCodifiedPreferredPropertyLabelConstraints( $dataValue ) {
+
+		// Annotated but not enabled
+		if ( !$dataValue->isEnabledFeature( SMW_DV_PPLB ) ) {
+			return $dataValue->addErrorMsg(
+				array(
+					'smw-datavalue-feature-not-supported',
+					'SMW_DV_PPLB'
+				)
+			);
+		}
+
+		$value = $dataValue->toArray();
+		$dbKey = $dataValue->getContextPage()->getDBKey();
+
+		// Language has been already assigned!
+		if ( ( $isKnownBy = $this->isKnownByLabelAndLanguage( $value, $dbKey ) ) !== false ) {
+			$dataValue->addErrorMsg(
+				array(
+					'smw-property-preferred-label-language-combination-exists',
+					$value['_TEXT'],
+					$value['_LCODE'],
+					$isKnownBy
+				)
+			);
+		}
+	}
+
+	private function isKnownByLabelAndLanguage( $value, $dbkey ) {
+
+		$lang = isset( $value['_LCODE'] ) ? $value['_LCODE'] : false;
+
+		if ( !isset( self::$inMemoryLabelToLanguageTracer[$dbkey] ) ) {
+			self::$inMemoryLabelToLanguageTracer[$dbkey] = array();
+		}
+
+		if ( $lang && !isset( self::$inMemoryLabelToLanguageTracer[$dbkey][$lang] ) ) {
+			self::$inMemoryLabelToLanguageTracer[$dbkey][$lang] = $value['_TEXT'];
+		}
+
+		if ( $lang && self::$inMemoryLabelToLanguageTracer[$dbkey][$lang] !== $value['_TEXT'] ) {
+			return self::$inMemoryLabelToLanguageTracer[$dbkey][$lang];
+		}
+
+		return false;
+	}
+
+}

--- a/src/Defines.php
+++ b/src/Defines.php
@@ -151,10 +151,12 @@ define( 'SMW_UJ_PM_CLASTMDATE', 4 ); // compare last modified
 define( 'SMW_DV_NONE', 0 );
 define( 'SMW_DV_PROV_REDI', 2 );  // PropertyValue to follow a property redirect target
 define( 'SMW_DV_MLTV_LCODE', 4 );  // MonolingualTextValue requires language code
+define( 'SMW_DV_NUMV_USPACE', 8 );  // Preserve spaces in unit labels
 define( 'SMW_DV_PVAP', 16 );  // Allows pattern
 define( 'SMW_DV_WPV_DTITLE', 32 );  // WikiPageValue to use an explicit display title
 define( 'SMW_DV_PROV_DTITLE', 64 );  // PropertyValue allow to find a property using the display title
 define( 'SMW_DV_PVUC', 128 );  // Delcares a uniqueness constraint
 define( 'SMW_DV_TIMEV_CM', 256 );  // TimeValue to indicate calendar model
-define( 'SMW_DV_NUMV_USPACE', 512 );  // Preserve spaces in unit labels
+define( 'SMW_DV_PPLB', 512 );  // Preferred property label
+define( 'SMW_DV_PROV_LHNT', 1024 );  // PropertyValue to output a hint in case of a preferred label usage
 /**@}*/

--- a/src/Exporter/ResourceBuilders/DispatchingResourceBuilder.php
+++ b/src/Exporter/ResourceBuilders/DispatchingResourceBuilder.php
@@ -101,6 +101,7 @@ class DispatchingResourceBuilder implements ResourceBuilder {
 	private function initResourceBuilders() {
 
 		$this->addResourceBuilder( new PropertyDescriptionValueResourceBuilder() );
+		$this->addResourceBuilder( new PreferredPropertyLabelResourceBuilder() );
 
 		$this->addResourceBuilder( new ExternalIdentifierPropertyValueResourceBuilder() );
 		$this->addResourceBuilder( new MonolingualTextPropertyValueResourceBuilder() );

--- a/src/Exporter/ResourceBuilders/PreferredPropertyLabelResourceBuilder.php
+++ b/src/Exporter/ResourceBuilders/PreferredPropertyLabelResourceBuilder.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace SMW\Exporter\ResourceBuilders;
+
+use SMW\Exporter\ResourceBuilder;
+use SMW\DIProperty;
+use SMWExporter as Exporter;
+use SMW\DataValueFactory;
+use SMWDataItem as DataItem;
+use SMWExpData as ExpData;
+use SMWExpLiteral as ExpLiteral;
+
+/**
+ * @private
+ *
+ * @license GNU GPL v2+
+ * @since 2.5
+ *
+ * @author mwjames
+ */
+class PreferredPropertyLabelResourceBuilder extends PropertyValueResourceBuilder {
+
+	/**
+	 * @since 2.5
+	 *
+	 * {@inheritDoc}
+	 */
+	public function isResourceBuilderFor( DIProperty $property ) {
+		return $property->getKey() === '_PPLB';
+	}
+
+	/**
+	 * @since 2.5
+	 *
+	 * {@inheritDoc}
+	 */
+	public function addResourceValue( ExpData $expData, DIProperty $property, DataItem $dataItem ) {
+
+		parent::addResourceValue( $expData, $property, $dataItem );
+
+		$dataValue = DataValueFactory::getInstance()->newDataValueByItem(
+			$dataItem,
+			$property
+		);
+
+		$list = $dataValue->toArray();
+
+		if ( !isset( $list['_TEXT'] ) || !isset( $list['_LCODE'] ) ) {
+			return;
+		}
+
+		// https://www.w3.org/TR/2009/NOTE-skos-primer-20090818/#secpref
+		//
+		// "skos:prefLabel ... implies that a resource can only have one such
+		// label per language tag ... it is recommended that no two concepts in
+		// the same KOS be given the same preferred lexical label for any given
+		// language tag ..."
+
+		$expData->addPropertyObjectValue(
+			$this->exporter->getSpecialNsResource( 'skos', 'prefLabel' ),
+			new ExpLiteral(
+				(string)$list['_TEXT'],
+				'http://www.w3.org/2001/XMLSchema#string',
+				(string)$list['_LCODE'],
+				$dataItem
+			)
+		);
+	}
+
+}

--- a/src/Factbox/Factbox.php
+++ b/src/Factbox/Factbox.php
@@ -358,7 +358,6 @@ class Factbox {
 				$attributes['property'] = array( 'class' => 'smwpropname' );
 				$attributes['values'] = array( 'class' => 'smwprops' );
 			} elseif ( $propertyDv->isVisible() ) {
-				$propertyDv->setCaption( $propertyDi->getLabel() );
 				// Predefined property
 				$attributes['property'] = array( 'class' => 'smwspecname' );
 				$attributes['values'] = array( 'class' => 'smwspecs' );

--- a/src/MediaWiki/Api/PropertyListByApiRequest.php
+++ b/src/MediaWiki/Api/PropertyListByApiRequest.php
@@ -7,6 +7,8 @@ use SMW\PropertySpecificationLookup;
 use SMW\RequestOptions;
 use SMW\Store;
 use SMW\StringCondition;
+use SMW\Localizer;
+use SMW\ApplicationFactory;
 
 /**
  * @license GNU GPL v2+
@@ -155,6 +157,9 @@ class PropertyListByApiRequest {
 
 		$isFromCache = false;
 
+		//
+		$this->matchPropertiesToPreferredLabelBy( $property );
+
 		// Increase by one to look ahead
 		$requestOptions->limit++;
 
@@ -275,6 +280,23 @@ class PropertyListByApiRequest {
 		return array(
 			$this->propertySpecificationLookup->getLanguageCode() => $description
 		);
+	}
+
+	private function matchPropertiesToPreferredLabelBy( $label ) {
+
+		$propertyLabelFinder = ApplicationFactory::getInstance()->newPropertyLabelFinder();
+
+		// Use the proximity search on a text field
+		$label = '~*' . $label . '*';
+
+		$results = $propertyLabelFinder->findPropertyListFromLabelByLanguageCode(
+			$label,
+			Localizer::getInstance()->getUserLanguage()->getCode()
+		);
+
+		foreach ( $results as $result ) {
+			$this->addPropertyToList( array( $result, 0 ) );
+		}
 	}
 
 }

--- a/src/MediaWiki/Specials/Browse/HtmlContentBuilder.php
+++ b/src/MediaWiki/Specials/Browse/HtmlContentBuilder.php
@@ -391,6 +391,19 @@ class HtmlContentBuilder {
 	 */
 	private function displayHead() {
 
+		if ( $this->subject->getDataItem()->getNamespace() === SMW_NS_PROPERTY ) {
+			$property = \SMWDIProperty::newFromUserLabel( $this->subject->getDataItem()->getDBKey() );
+			$caption = '';
+
+			$title = $property->getCanonicalDiWikiPage()->getTitle();
+
+			if ( ( $preferredLabel = $property->getPreferredLabel() ) !== '' && $title->getText() !== $preferredLabel ) {
+				$caption = wfMessage( 'smw-property-preferred-title-format', $title->getPrefixedText(), $preferredLabel )->text();
+			}
+
+			$this->subject->setCaption( $caption );
+		}
+
 		$html = "<table class=\"smwb-factbox\" cellpadding=\"0\" cellspacing=\"0\">\n" .
 			"<tr class=\"smwb-title\"><td colspan=\"2\">\n" .
 			$this->subject->getLongHTMLText( smwfGetLinker() ) . "\n" .

--- a/src/MediaWiki/Specials/SearchByProperty/PageRequestOptions.php
+++ b/src/MediaWiki/Specials/SearchByProperty/PageRequestOptions.php
@@ -109,7 +109,7 @@ class PageRequestOptions {
 			$this->value = null;
 			$this->valueString = $value;
 		} else {
-			$this->propertyString = $this->property->getWikiValue();
+			$this->propertyString = $this->property->getDataItem()->getLabel();
 			$this->setValue( $value );
 		}
 

--- a/src/NamespaceManager.php
+++ b/src/NamespaceManager.php
@@ -54,18 +54,6 @@ class NamespaceManager {
 	}
 
 	/**
-	 * @since 2.4
-	 *
-	 * @param string $languageCode
-	 *
-	 * @return array
-	 */
-	public static function getNamespacesByLanguageCode( $languageCode ) {
-		$GLOBALS['smwgContLang'] = ExtraneousLanguage::getInstance()->fetchByLanguageCode( $languageCode );
-		return $GLOBALS['smwgContLang']->getNamespaces();
-	}
-
-	/**
 	 * @see Hooks:CanonicalNamespaces
 	 * CanonicalNamespaces initialization
 	 *
@@ -221,6 +209,11 @@ class NamespaceManager {
 
 	protected function isDefinedConstant( $constant ) {
 		return defined( $constant );
+	}
+
+	protected function getNamespacesByLanguageCode( $languageCode ) {
+		$GLOBALS['smwgContLang'] = $this->extraneousLanguage->fetchByLanguageCode( $languageCode );
+		return $GLOBALS['smwgContLang']->getNamespaces();
 	}
 
 }

--- a/src/Query/PrintRequest/Serializer.php
+++ b/src/Query/PrintRequest/Serializer.php
@@ -81,15 +81,29 @@ class Serializer {
 
 		$printname = '';
 
-		if ( $printRequest->getData()->isVisible() ) {
+		$label = $printRequest->getLabel();
+		$data = $printRequest->getData();
+
+		if ( $data->isVisible() ) {
 			// #1564
 			// Use the canonical form for predefined properties to ensure
 			// that local representations are for display but points to
 			// the correct property
 			if ( $printRequest->isMode( PrintRequest::PRINT_CHAIN ) ) {
-				$printname = $printRequest->getData()->getDataItem()->getString();
+				$printname = $data->getDataItem()->getString();
+				// If the preferred label and invoked label are the same
+				// then no additional label is required as the label is
+				// recognized as being available by the system
+				if ( $label === $data->getLastPropertyChainValue()->getDataItem()->getPreferredLabel() ) {
+					$label = $printname;
+				}
 			} else {
+
 				$printname = $printRequest->getData()->getDataItem()->getCanonicalLabel();
+
+				if ( $label === $data->getDataItem()->getPreferredLabel() ) {
+					$label = $printname;
+				}
 			}
 		}
 
@@ -99,8 +113,8 @@ class Serializer {
 			$result .= '#' . $printRequest->getOutputFormat();
 		}
 
-		if ( $printname != $printRequest->getLabel() ) {
-			$result .= '=' . $printRequest->getLabel();
+		if ( $printname != $label ) {
+			$result .= '=' . $label;
 		}
 
 		return $result . $parameters;

--- a/src/SQLStore/PropertyTableInfoFetcher.php
+++ b/src/SQLStore/PropertyTableInfoFetcher.php
@@ -51,7 +51,7 @@ class PropertyTableInfoFetcher {
 	 */
 	private $fixedSpecialProperties = array(
 		// property declarations
-		'_TYPE', '_UNIT', '_CONV', '_PVAL', '_LIST', '_SERV', '_PREC',
+		'_TYPE', '_UNIT', '_CONV', '_PVAL', '_LIST', '_SERV', '_PREC', '_PPLB',
 		// query statistics (very frequently used)
 		'_ASK', '_ASKDE', '_ASKSI', '_ASKFO', '_ASKST', '_ASKDU',
 		// subproperties, classes, and instances

--- a/src/SharedCallbackContainer.php
+++ b/src/SharedCallbackContainer.php
@@ -265,6 +265,23 @@ class SharedCallbackContainer implements CallbackContainer {
 
 			return $propertyHierarchyLookup;
 		} );
+
+		/**
+		 * @var PropertyLabelFinder
+		 */
+		$callbackLoader->registerCallback( 'PropertyLabelFinder', function() use ( $callbackLoader ) {
+			$callbackLoader->registerExpectedReturnType( 'PropertyLabelFinder', '\SMW\PropertyLabelFinder' );
+
+			$extraneousLanguage = Localizer::getInstance()->getExtraneousLanguage();
+
+			$propertyLabelFinder = new PropertyLabelFinder(
+				$callbackLoader->load( 'Store' ),
+				$extraneousLanguage->getPropertyLabels(),
+				$extraneousLanguage->getCanonicalPropertyLabels()
+			);
+
+			return $propertyLabelFinder;
+		} );
 	}
 
 }

--- a/tests/phpunit/Integration/ByJsonScript/Contents/p-0436.json
+++ b/tests/phpunit/Integration/ByJsonScript/Contents/p-0436.json
@@ -1,0 +1,24 @@
+* Has type: [[Has type::Text]]
+
+== Preferred property labels ==
+* [[Has preferred property label::occupation@en]]
+* [[Has preferred property label::Tätigkeit@de]]
+* [[Has preferred property label::occupation@fr]]
+* [[Has preferred property label::ocupación@es]]
+* [[Has preferred property label::род занятий@ru]]
+* [[Has preferred property label::occupazione@it]]
+* [[Has preferred property label::职业@zh-hans]]
+* [[Has preferred property label::職業@ja]]
+
+<!-- Causes error as it is already defined above -->
+* [[Has preferred property label::職種@ja]]
+
+== Property descriptions ==
+* [[Has property description::occupation of a person; see also field of work (Property:P101)@en]]
+* [[Has property description::Beruf oder andere Tätigkeit einer Person (ergänzt durch Arbeitsgebiet: Property:P101)@de]]
+* [[Has property description::actividad laboral u otra ocupación de la persona; véase también campo de trabajo (propiedad 101)@es]]
+* [[Has property description::qualité d'une personne (métier, hobby...), voir aussi domaine d'activité (Property:P101) et fonction (Property:P39)@fr]]
+* [[Has property description::attività lavorativa svolta, vedi anche campo di lavoro (Property: P101)@it]]
+* [[Has property description::профессия персоны; см. также свойство область деятельности (Property:P101)@ru]]
+* [[Has property description::职业即职场上的专门行业，是对劳动的分类。@zh-hans]]
+* [[Has property description::人物の職業。「専門分野」(Property:P101) も参照@ja]]

--- a/tests/phpunit/Integration/ByJsonScript/Fixtures/f-0208.json
+++ b/tests/phpunit/Integration/ByJsonScript/Fixtures/f-0208.json
@@ -66,7 +66,7 @@
 			"subject": "Example/F0208/Q1.1",
 			"expected-output": {
 				"to-contain": [
-					"Special:Ask/-5B-5BHas-20text::F0208-5D-5D/-3FHas-20text/-3FModification-20date%3DFecha-20de-20modificaci%C3%B3n/mainlabel%3D/offset%3D0/format%3Dtable"
+					"Special:Ask/-5B-5BHas-20text::F0208-5D-5D/-3FHas-20text/-3FModification-20date/mainlabel%3D/offset%3D0/format%3Dtable"
 				],
 				"not-contain": [
 					"Special:Ask/-5B-5BHas-20text::F0208-5D-5D/-3FHas-20text-23/-3FModification-20date-23=Fecha-20de-20modificación/mainlabel=/offset=0/format=table"
@@ -79,7 +79,7 @@
 			"subject": "Example/F0208/Q2.1",
 			"expected-output": {
 				"to-contain": [
-					"Special:Ask/-5B-5BModification-20date::%2B-5D-5D/-3FModification-20date%3DFecha-20de-20modificaci%C3%B3n/mainlabel%3D/offset%3D0/format%3Dtable"
+					"Special:Ask/-5B-5BModification-20date::%2B-5D-5D/-3FModification-20date/mainlabel%3D/offset%3D0/format%3Dtable"
 				]
 			}
 		},
@@ -89,7 +89,7 @@
 			"subject": "Example/F0208/Q2.2",
 			"expected-output": {
 				"to-contain": [
-					"Special:Ask/-5B-5BModification-20date::%2B-5D-5D/-3FModification-20date%3DFecha-20de-20modificaci%C3%B3n/mainlabel%3D/offset%3D0/format%3Dtable"
+					"Special:Ask/-5B-5BModification-20date::%2B-5D-5D/-3FModification-20date/mainlabel%3D/offset%3D0/format%3Dtable"
 				]
 			}
 		},
@@ -139,7 +139,7 @@
 			"subject": "Example/F0208/Q3.5",
 			"expected-output": {
 				"to-contain": [
-					"Special:Ask/-5B-5B:Example-2FF0208-2F3-5D-5D/-3FHas-20page=/mainlabel=-2D/offset=0/format=table/link=none/headers=plain"
+					"Special:Ask/-5B-5B:Example-2FF0208-2F3-5D-5D/-3FHas-20page/mainlabel=-2D/offset=0/format=table/link=none/headers=plain"
 				]
 			}
 		},

--- a/tests/phpunit/Integration/ByJsonScript/Fixtures/p-0436.json
+++ b/tests/phpunit/Integration/ByJsonScript/Fixtures/p-0436.json
@@ -1,0 +1,113 @@
+{
+	"description": "Test in-text annotation with preferred property label (`wgContLang=en`, `wgLang=en`)",
+	"setup": [
+		{
+			"namespace": "SMW_NS_PROPERTY",
+			"name": "P106",
+			"contents": {
+				"import-from": "/../Contents/p-0436.json"
+			}
+		},
+		{
+			"name": "Example/P0436/1",
+			"contents": "{{#subobject: |P106=Teacher }}{{#subobject: |P106=Actor }}"
+		},
+		{
+			"name": "Example/P0436/Q.1",
+			"contents": "{{#ask: [[P106::+]] |?P106 }}"
+		},
+		{
+			"name": "Example/P0436/Q.2",
+			"contents": "{{#ask: [[P106::+]] |?P106 |headers=plain }}"
+		},
+		{
+			"name": "Example/P0436/Q.3",
+			"contents": "{{#ask: [[P106::+]] |?P106=with a different Label |headers=plain }}"
+		},
+		{
+			"name": "Example/P0436/Q.4",
+			"contents": "{{#ask: [[P106::+]] |?P106=with a different Label }}"
+		}
+	],
+	"tests": [
+		{
+			"type": "parser",
+			"about": "#0",
+			"namespace": "SMW_NS_PROPERTY",
+			"subject": "P106",
+			"store": {
+				"semantic-data": {
+					"strictPropertyValueMatch": false,
+					"propertyCount": 6,
+					"propertyKeys": [
+						"_PPLB",
+						"_PDESC",
+						"_TYPE",
+						"_SKEY",
+						"_MDAT",
+						"_ERRC"
+					]
+				}
+			}
+		},
+		{
+			"type": "parser",
+			"about": "#0 (en)",
+			"subject": "Example/P0436/Q.1",
+			"expected-output": {
+				"to-contain": [
+					"data-title=\"Property\" title=\"occupation of a person; see also field of work (Property:P101)\">",
+					"title=\"Property:P106\">occupation</a>",
+					"<div class=\"smwttcontent\">occupation of a person; see also field of work (Property:P101)</div></span>&#160;<span title=\"P106\"><sup>ᵖ</sup></span>"
+				]
+			}
+		},
+		{
+			"type": "parser",
+			"about": "#1 (en, headers=plain)",
+			"subject": "Example/P0436/Q.2",
+			"expected-output": {
+				"to-contain": [
+					"<th class=\"occupation\">occupation</th>"
+				]
+			}
+		},
+		{
+			"type": "parser",
+			"about": "#2 (en, headers=plain, different label)",
+			"subject": "Example/P0436/Q.3",
+			"expected-output": {
+				"to-contain": [
+					"<th class=\"with-a-different-Label\">with a different Label</th>"
+				],
+				"not-contain": [
+					"<th class=\"occupation\">occupation</th>"
+				]
+			}
+		},
+		{
+			"type": "parser",
+			"about": "#3 (en, different label)",
+			"subject": "Example/P0436/Q.4",
+			"expected-output": {
+				"to-contain": [
+					"<th class=\"with-a-different-Label\">",
+					"title=\"Property:P106\">with a different Label</a>",
+					"<div class=\"smwttcontent\">occupation of a person; see also field of work (Property:P101)</div></span>&#160;<span title=\"P106\"><sup>ᵖ</sup></span>"
+				],
+				"not-contain": [
+					"<th class=\"occupation\">occupation</th>"
+				]
+			}
+		}
+	],
+	"settings": {
+		"wgContLang": "en",
+		"wgLang": "en"
+	},
+	"meta": {
+		"version": "2",
+		"is-incomplete": false,
+		"debug": false
+	}
+}

--- a/tests/phpunit/Integration/ByJsonScript/Fixtures/p-0437.json
+++ b/tests/phpunit/Integration/ByJsonScript/Fixtures/p-0437.json
@@ -1,0 +1,42 @@
+{
+	"description": "Test in-text annotation with preferred property label (`wgContLang=en`, `wgLang=ja`)",
+	"setup": [
+		{
+			"namespace": "SMW_NS_PROPERTY",
+			"name": "P106",
+			"contents": {
+				"import-from": "/../Contents/p-0436.json"
+			}
+		},
+		{
+			"name": "Example/P0437/1",
+			"contents": "{{#subobject: |P106=Teacher }}{{#subobject: |P106=Actor }}"
+		},
+		{
+			"name": "Example/P0437/Q.1",
+			"contents": "{{#ask: [[P106::+]] |?P106 }}"
+		}
+	],
+	"tests": [
+		{
+			"type": "parser",
+			"about": "#0 (ja)",
+			"subject": "Example/P0437/Q.1",
+			"expected-output": {
+				"to-contain": [
+					"data-title=\"プロパティ\" title=\"人物の職業。「専門分野」(Property:P101) も参照\">",
+					"title=\"Property:P106\">職業</a>"
+				]
+			}
+		}
+	],
+	"settings": {
+		"wgContLang": "en",
+		"wgLang": "ja"
+	},
+	"meta": {
+		"version": "2",
+		"is-incomplete": false,
+		"debug": false
+	}
+}

--- a/tests/phpunit/Unit/ApplicationFactoryTest.php
+++ b/tests/phpunit/Unit/ApplicationFactoryTest.php
@@ -245,6 +245,14 @@ class ApplicationFactoryTest extends \PHPUnit_Framework_TestCase {
 		);
 	}
 
+	public function testCanConstructPropertyLabelFinder() {
+
+		$this->assertInstanceOf(
+			'\SMW\PropertyLabelFinder',
+			$this->applicationFactory->newPropertyLabelFinder()
+		);
+	}
+
 	public function testCanConstructDeferredCallableUpdate() {
 
 		$callback = function() {

--- a/tests/phpunit/Unit/DataValues/MonolingualTextValueTest.php
+++ b/tests/phpunit/Unit/DataValues/MonolingualTextValueTest.php
@@ -172,4 +172,14 @@ class MonolingualTextValueTest extends \PHPUnit_Framework_TestCase {
 		);
 	}
 
+	public function testGetTextWithLanguageTag() {
+
+		$instance = new MonolingualTextValue();
+
+		$this->assertSame(
+			'foo@zh-Hans',
+			$instance->getTextWithLanguageTag( 'foo', 'zh-hans' )
+		);
+	}
+
 }

--- a/tests/phpunit/Unit/DataValues/ValueFormatters/PropertyValueFormatterTest.php
+++ b/tests/phpunit/Unit/DataValues/ValueFormatters/PropertyValueFormatterTest.php
@@ -1,0 +1,229 @@
+<?php
+
+namespace SMW\Tests\DataValues\ValueFormatters;
+
+use SMW\DataValues\ValueFormatters\PropertyValueFormatter;
+use SMWPropertyValue as PropertyValue;
+use SMW\DataItemFactory;
+use SMW\Tests\TestEnvironment;
+
+/**
+ * @covers \SMW\DataValues\ValueFormatters\PropertyValueFormatter
+ * @group semantic-mediawiki
+ *
+ * @license GNU GPL v2+
+ * @since 2.5
+ *
+ * @author mwjames
+ */
+class PropertyValueFormatterTest extends \PHPUnit_Framework_TestCase {
+
+	private $dataItemFactory;
+	private $propertyLabelFinder;
+
+	protected function setUp() {
+		parent::setUp();
+
+		$this->testEnvironment = new TestEnvironment();
+		$this->dataItemFactory = new DataItemFactory();
+
+		$this->propertyLabelFinder = $this->getMockBuilder( '\SMW\PropertyLabelFinder' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$this->testEnvironment->registerObject( 'PropertyLabelFinder', $this->propertyLabelFinder );
+	}
+
+	public function testCanConstruct() {
+
+		$this->assertInstanceOf(
+			'\SMW\DataValues\ValueFormatters\PropertyValueFormatter',
+			new PropertyValueFormatter()
+		);
+	}
+
+	public function testIsFormatterForValidation() {
+
+		$propertyValue = $this->getMockBuilder( '\SMWPropertyValue' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$instance = new PropertyValueFormatter();
+
+		$this->assertTrue(
+			$instance->isFormatterFor( $propertyValue )
+		);
+	}
+
+	public function testWithCaptionOutput() {
+
+		$propertyValue = new PropertyValue();
+		$propertyValue->setDataItem( $this->dataItemFactory->newDIProperty( 'Foo' ) );
+		$propertyValue->setCaption( 'ABC[<>]' );
+
+		$instance = new PropertyValueFormatter( $propertyValue );
+
+		$this->assertEquals(
+			'ABC[<>]',
+			$instance->format( PropertyValueFormatter::WIKI_SHORT )
+		);
+
+		$this->assertEquals(
+			'ABC[&lt;&gt;]',
+			$instance->format( PropertyValueFormatter::HTML_SHORT )
+		);
+	}
+
+	/**
+	 * @dataProvider propertyValueProvider
+	 */
+	public function testFormat( $property, $type, $linker, $expected ) {
+
+		$propertyValue = new PropertyValue();
+		$propertyValue->setDataItem( $property );
+
+		$propertyValue->setOption( PropertyValue::OPT_CONTENT_LANGUAGE, 'en' );
+		$propertyValue->setOption( PropertyValue::OPT_USER_LANGUAGE, 'en' );
+
+		$instance = new PropertyValueFormatter( $propertyValue );
+
+		$this->assertEquals(
+			$expected,
+			$instance->format( $type, $linker )
+		);
+	}
+
+	/**
+	 * @dataProvider preferredLabelValueProvider
+	 */
+	public function testFormatWithPreferredLabel( $property, $preferredLabel, $type, $linker, $expected ) {
+
+		// Ensures the mocked instance is injected and registered with the
+		// PropertyRegistry instance
+		\SMW\PropertyRegistry::clear();
+
+		$this->propertyLabelFinder->expects( $this->any() )
+			->method( 'findPreferredPropertyLabelByLanguageCode' )
+			->will( $this->returnValue( $preferredLabel ) );
+
+		$this->propertyLabelFinder->expects( $this->any() )
+			->method( 'searchPropertyIdByLabel' )
+			->will( $this->returnValue( false ) );
+
+		$propertyValue = new PropertyValue();
+
+		$propertyValue->setOption( 'smwgDVFeatures', SMW_DV_PROV_LHNT );
+		$propertyValue->setOption( PropertyValue::OPT_CONTENT_LANGUAGE, 'en' );
+		$propertyValue->setOption( PropertyValue::OPT_USER_LANGUAGE, 'en' );
+
+		$propertyValue->setUserValue( $property );
+
+		$instance = new PropertyValueFormatter( $propertyValue );
+
+		$this->assertEquals(
+			$expected,
+			$instance->format( $type, $linker )
+		);
+
+		\SMW\PropertyRegistry::clear();
+	}
+
+	public function testTryToFormatOnMissingDataValueThrowsException() {
+
+		$instance = new PropertyValueFormatter();
+
+		$this->setExpectedException( 'RuntimeException' );
+		$instance->format( PropertyValueFormatter::VALUE );
+	}
+
+	public function propertyValueProvider() {
+
+		$dataItemFactory = new DataItemFactory();
+
+		$provider[] = array(
+			$dataItemFactory->newDIProperty( 'Foo' ),
+			PropertyValueFormatter::VALUE,
+			null,
+			'Foo'
+		);
+
+		$provider[] = array(
+			$dataItemFactory->newDIProperty( 'Foo' ),
+			PropertyValueFormatter::WIKI_SHORT,
+			null,
+			'Foo'
+		);
+
+		$provider[] = array(
+			$dataItemFactory->newDIProperty( 'Foo' ),
+			PropertyValueFormatter::HTML_SHORT,
+			null,
+			'Foo'
+		);
+
+		$provider[] = array(
+			$dataItemFactory->newDIProperty( 'Foo' ),
+			PropertyValueFormatter::WIKI_LONG,
+			null,
+			'Property:Foo'
+		);
+
+		$provider[] = array(
+			$dataItemFactory->newDIProperty( 'Foo' ),
+			PropertyValueFormatter::HTML_LONG,
+			null,
+			'Property:Foo'
+		);
+
+		return $provider;
+	}
+
+	public function preferredLabelValueProvider() {
+
+		$dataItemFactory = new DataItemFactory();
+		$linker = 'some';
+
+		$provider[] = array(
+			'Foo',
+			'Bar',
+			PropertyValueFormatter::VALUE,
+			null,
+			'Bar'
+		);
+
+		$provider[] = array(
+			'Foo',
+			'Bar',
+			PropertyValueFormatter::WIKI_SHORT,
+			null,
+			'Bar&nbsp;<span title="Foo"><sup>ᵖ</sup></span>'
+		);
+
+		$provider[] = array(
+			'Foo',
+			'Bar',
+			PropertyValueFormatter::HTML_SHORT,
+			null,
+			'Bar&nbsp;<span title="Foo"><sup>ᵖ</sup></span>'
+		);
+
+		$provider[] = array(
+			'Foo',
+			'Bar',
+			PropertyValueFormatter::WIKI_LONG,
+			$linker,
+			'[[:Property:Foo|Bar]]&nbsp;<span title="Foo"><sup>ᵖ</sup></span>'
+		);
+
+		$provider[] = array(
+			'Foo',
+			'Bar',
+			PropertyValueFormatter::HTML_LONG,
+			null,
+			'Property:Foo&nbsp;<span title="Foo"><sup>ᵖ</sup></span>'
+		);
+
+		return $provider;
+	}
+
+}

--- a/tests/phpunit/Unit/DataValues/ValueValidators/PropertySpecificationConstraintValueValidatorTest.php
+++ b/tests/phpunit/Unit/DataValues/ValueValidators/PropertySpecificationConstraintValueValidatorTest.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace SMW\Tests\DataValues\ValueValidators;
+
+use SMW\DataValues\ValueValidators\PropertySpecificationConstraintValueValidator;
+use SMW\DataItemFactory;
+use SMW\DataValueFactory;
+
+/**
+ * @covers \SMW\DataValues\ValueValidators\PropertySpecificationConstraintValueValidator
+ * @group semantic-mediawiki
+ *
+ * @license GNU GPL v2+
+ * @since 2.5
+ *
+ * @author mwjames
+ */
+class PropertySpecificationConstraintValueValidatorTest extends \PHPUnit_Framework_TestCase {
+
+	private $dataItemFactory;
+	private $dataValueFactory;
+
+	protected function setUp() {
+		parent::setUp();
+		$this->dataItemFactory = new DataItemFactory();
+		$this->dataValueFactory = DataValueFactory::getInstance();
+	}
+
+	public function testCanConstruct() {
+
+		$this->assertInstanceOf(
+			'\SMW\DataValues\ValueValidators\PropertySpecificationConstraintValueValidator',
+			new PropertySpecificationConstraintValueValidator()
+		);
+	}
+
+	public function testHasNoConstraintViolationOnNonRelatedValue() {
+
+		$instance = new PropertySpecificationConstraintValueValidator();
+		$instance->validate( 'Foo' );
+
+		$this->assertFalse(
+			$instance->hasConstraintViolation()
+		);
+	}
+
+	public function testHasNoConstraintViolationOnDisabledPreferredLabelPropertyButWithError() {
+
+		$dataValue = $this->dataValueFactory->newDataValueByProperty(
+			$this->dataItemFactory->newDIProperty( '_PPLB' )
+		);
+
+		$dataValue->setContextPage(
+			$this->dataItemFactory->newDIWikiPage( 'Foo', SMW_NS_PROPERTY )
+		);
+
+		$dataValue->setOption( 'smwgDVFeatures', ~SMW_DV_PPLB );
+
+		$instance = new PropertySpecificationConstraintValueValidator();
+		$instance->validate( $dataValue );
+
+		$this->assertFalse(
+			$instance->hasConstraintViolation()
+		);
+
+		$this->assertNotEmpty(
+			$dataValue->getErrors()
+		);
+	}
+
+}

--- a/tests/phpunit/Unit/Exporter/ResourceBuilders/PreferredPropertyLabelResourceBuilderTest.php
+++ b/tests/phpunit/Unit/Exporter/ResourceBuilders/PreferredPropertyLabelResourceBuilderTest.php
@@ -1,0 +1,86 @@
+<?php
+
+namespace SMW\Tests\Exporter\ResourceBuilders;
+
+use SMW\Exporter\ResourceBuilders\PreferredPropertyLabelResourceBuilder;
+use SMW\DataItemFactory;
+use SMW\DataValueFactory;
+use SMW\Tests\TestEnvironment;
+use SMWExpData as ExpData;
+use SMW\Exporter\Element\ExpNsResource;
+
+/**
+ * @covers \SMW\Exporter\ResourceBuilders\PreferredPropertyLabelResourceBuilder
+ * @group semantic-mediawiki
+ *
+ * @license GNU GPL v2+
+ * @since 2.5
+ *
+ * @author mwjames
+ */
+class PreferredPropertyLabelResourceBuilderTest extends \PHPUnit_Framework_TestCase {
+
+	private $dataItemFactory;
+	private $dataValueFactory;
+	private $testEnvironment;
+
+	protected function setUp() {
+		parent::setUp();
+		$this->dataItemFactory = new DataItemFactory();
+		$this->dataValueFactory = DataValueFactory::getInstance();
+
+		$this->testEnvironment = new TestEnvironment();
+		$this->testEnvironment->resetPoolCacheFor( \SMWExporter::POOLCACHE_ID );
+	}
+
+	protected function tearDown() {
+		$this->testEnvironment->tearDown();
+		parent::tearDown();
+	}
+
+	public function testCanConstruct() {
+
+		$this->assertInstanceof(
+			PreferredPropertyLabelResourceBuilder::class,
+			new PreferredPropertyLabelResourceBuilder()
+		);
+	}
+
+	public function testIsNotResourceBuilderForNonExternalIdentifierTypedProperty() {
+
+		$property = $this->dataItemFactory->newDIProperty( 'Foo' );
+
+		$instance = new PreferredPropertyLabelResourceBuilder();
+
+		$this->assertFalse(
+			$instance->isResourceBuilderFor( $property )
+		);
+	}
+
+	public function testAddResourceValueForValidProperty() {
+
+		$property = $this->dataItemFactory->newDIProperty( '_PPLB' );
+
+		$monolingualTextValue = $this->dataValueFactory->newDataValueByProperty(
+			$property,
+			'Bar@en'
+		);
+
+		$expData = new ExpData(
+			new ExpNsResource( 'Foobar', 'Bar', 'Mo', null )
+		);
+
+		$instance = new PreferredPropertyLabelResourceBuilder();
+
+		$instance->addResourceValue(
+			$expData,
+			$property,
+			$monolingualTextValue->getDataItem()
+		);
+
+		$this->assertTrue(
+			$instance->isResourceBuilderFor( $property )
+		);
+	}
+
+}

--- a/tests/phpunit/Unit/MediaWiki/Hooks/FileUploadTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Hooks/FileUploadTest.php
@@ -44,6 +44,12 @@ class FileUploadTest extends \PHPUnit_Framework_TestCase {
 			->will( $this->returnValue( $idTable ) );
 
 		$this->testEnvironment->registerObject( 'Store', $store );
+
+		$this->propertySpecificationLookup = $this->getMockBuilder( '\SMW\PropertySpecificationLookup' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$this->testEnvironment->registerObject( 'PropertySpecificationLookup', $this->propertySpecificationLookup );
 	}
 
 	protected function tearDown() {

--- a/tests/phpunit/Unit/PropertySpecificationLookupTest.php
+++ b/tests/phpunit/Unit/PropertySpecificationLookupTest.php
@@ -284,6 +284,9 @@ class PropertySpecificationLookupTest extends \PHPUnit_Framework_TestCase {
 
 		$property = $this->dataItemFactory->newDIProperty( 'Foo' );
 
+		$pdesc = $this->dataItemFactory->newDIProperty( '_PDESC' );
+		$pdesc->setPropertyTypeId( '_mlt_rec' );
+
 		$container = $this->getMockBuilder( '\Onoi\BlobStore\Container' )
 			->disableOriginalConstructor()
 			->getMock();
@@ -296,10 +299,10 @@ class PropertySpecificationLookupTest extends \PHPUnit_Framework_TestCase {
 			->method( 'getPropertyValues' )
 			->with(
 				$this->equalTo( $property->getDiWikiPage() ),
-				$this->equalTo( $this->dataItemFactory->newDIProperty( '_PDESC' ) ),
+				$this->anything(),
 				$this->anything() )
 			->will( $this->returnValue( array(
-				 $this->dataItemFactory->newDIContainer( ContainerSemanticData::makeAnonymousContainer() ) ) ) );
+				$this->dataItemFactory->newDIContainer( ContainerSemanticData::makeAnonymousContainer() ) ) ) );
 
 		$this->cachedPropertyValuesPrefetcher->expects( $this->once() )
 			->method( 'getBlobStore' )


### PR DESCRIPTION
This PR is made in reference to: #1865

This PR addresses or contains:

- Adds support for localized preferred property labels
- `$GLOBALS['smwgDVFeatures']` adds `SMW_DV_PPLB` to support the use of preferred property labels and `SMW_DV_PROV_LHNT` to output a <sup>p</sup> hint marker on properties that use a preferred label

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed

