### PR TITLE
PostgresTableBuilder support DROP ... CASCADE

### DIFF
--- a/src/SQLStore/TableBuilder/PostgresTableBuilder.php
+++ b/src/SQLStore/TableBuilder/PostgresTableBuilder.php
@@ -322,7 +322,11 @@ EOT;
 	 * {@inheritDoc}
 	 */
 	protected function doDropTable( $tableName ) {
-		$this->connection->query( 'DROP TABLE IF EXISTS ' . $this->connection->tableName( $tableName ), __METHOD__ );
+		// Function: SMW\SQLStore\TableBuilder\PostgresTableBuilder::doDropTable
+		// Error: 2BP01 ERROR:  cannot drop table smw_object_ids because other objects depend on it
+		// DETAIL:  default for table sunittest_smw_object_ids column smw_id depends on sequence smw_object_ids_smw_id_seq
+		// HINT:  Use DROP ... CASCADE to drop the dependent objects too.
+		$this->connection->query( 'DROP TABLE IF EXISTS ' . $this->connection->tableName( $tableName ) . ' CASCADE', __METHOD__ );
 	}
 
 }


### PR DESCRIPTION
This PR is made in reference to: # N/A

This PR addresses or contains:

- Postgres reported "Error: 2BP01 ERROR:  cannot drop table smw_object_ids because other objects depend on it DETAIL:  default for table sunittest_smw_object_ids column smw_id depends on sequence smw_object_ids_smw_id_seq HINT:  Use DROP ... CASCADE to drop the dependent objects too."

This PR includes:
- [ ] Tests (unit/integration)
- [x] CI build passed

