### PR TITLE
Fix postgres bytea escape/unescape on blob fields, refs #1880

### DIFF
--- a/src/MediaWiki/Database.php
+++ b/src/MediaWiki/Database.php
@@ -399,19 +399,6 @@ class Database {
 	 * @since 1.9.1
 	 */
 	public function insert( $table, $rows, $fname = __METHOD__, $options = array() ) {
-
-		// Postgres can complain because of:
-		// Error: 22P02 ERROR:  invalid input syntax for type bytea LINE 1: ...ob" (s_id,p_id,o_blob,o_hash)
-		// when it contains something like "Has Url","http:\/\/example.org\/Foo","Example\/P0419\/1"]
-
-		if ( $this->isType( 'postgres' ) ) {
-			foreach ( $rows as &$row ) {
-				if ( isset( $row['o_blob'] ) ) {
-					$row['o_blob'] = str_replace( '\/', '/', $row['o_blob'] );
-				}
-			}
-		}
-
 		return $this->writeConnection()->insert( $table, $rows, $fname, $options );
 	}
 

--- a/tests/phpunit/Integration/ByJsonScript/Fixtures/p-0435.json
+++ b/tests/phpunit/Integration/ByJsonScript/Fixtures/p-0435.json
@@ -1,0 +1,44 @@
+{
+	"description": "Test in-text annotation using '_txt' type with 255+ char (`wgContLang=en`, `wgLang=en`)",
+	"properties": [
+		{
+			"name": "Has text",
+			"contents": "[[Has type::Text]]"
+		}
+	],
+	"subjects": [
+		{
+			"name": "Example/P0435/1",
+			"contents": "[[Has text::TBgcHiQBTvpV3XkFiRpMcV1KQoZvQXFyiQUQMM2RoYUyJaRoSyKnsQTWwia3HATd4YVmd8BZgkL2LfL0Q6rP5E90A\\4IuV6u\/KdYjL3nxZvx0pbc3tbxwa6jMW1JDNxusaKQ52ftRS7DCEY1IPTRZnuRMLPgWYwLOsEAebOsxD7BBL9IK3Z2Osfh9s0FC1SUwCVdKcLkBgurXKGi99s61qnAU2zWFXBUCEzID6533LeaHCBKW8i2BgTK2tv65LHO6zB:;%&`^WithTextLongerThan255]]"
+		}
+	],
+	"parser-testcases": [
+		{
+			"about": "#0",
+			"subject": "Example/P0435/1",
+			"store": {
+				"clear-cache": true,
+				"semantic-data": {
+					"strict-mode-valuematch": false,
+					"propertyCount": 3,
+					"propertyKeys": [ "Has_text", "_SKEY", "_MDAT" ],
+					"propertyValues": [ "TBgcHiQBTvpV3XkFiRpMcV1KQoZvQXFyiQUQMM2RoYUyJaRoSyKnsQTWwia3HATd4YVmd8BZgkL2LfL0Q6rP5E90A\\4IuV6u\/KdYjL3nxZvx0pbc3tbxwa6jMW1JDNxusaKQ52ftRS7DCEY1IPTRZnuRMLPgWYwLOsEAebOsxD7BBL9IK3Z2Osfh9s0FC1SUwCVdKcLkBgurXKGi99s61qnAU2zWFXBUCEzID6533LeaHCBKW8i2BgTK2tv65LHO6zB:;%&`^WithTextLongerThan255" ]
+				}
+			},
+			"expected-output": {
+				"to-contain": [
+					"TBgcHiQBTvpV3XkFiRpMcV1KQoZvQXFyiQUQMM2RoYUyJaRoSyKnsQTWwia3HATd4YVmd8BZgkL2LfL0Q6rP5E90A\\4IuV6u\/KdYjL3nxZvx0pbc3tbxwa6jMW1JDNxusaKQ52ftRS7DCEY1IPTRZnuRMLPgWYwLOsEAebOsxD7BBL9IK3Z2Osfh9s0FC1SUwCVdKcLkBgurXKGi99s61qnAU2zWFXBUCEzID6533LeaHCBKW8i2BgTK2tv65LHO6zB:;%&amp;`^WithTextLongerThan255"
+				]
+			}
+		}
+	],
+	"settings": {
+		"wgContLang": "en",
+		"wgLang": "en"
+	},
+	"meta": {
+		"version": "0.1",
+		"is-incomplete": false,
+		"debug": false
+	}
+}

--- a/tests/phpunit/Integration/ByJsonScript/Fixtures/q-0103.json
+++ b/tests/phpunit/Integration/ByJsonScript/Fixtures/q-0103.json
@@ -194,7 +194,6 @@
 	"settings": {},
 	"meta": {
 		"skip-on": {
-			"postgres": "Requires special \\ escape sequence on postgres",
 			"sqlite": "Requires special \\ escape sequence on sqlite"
 		},
 		"version": "0.1",


### PR DESCRIPTION
This PR is made in reference to: #1880

This PR addresses or contains:

- "Error: 22P02 ERROR:  invalid input syntax for type bytea"

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed

