### PR TITLE
Add QueryCreator, refs #1516

### DIFF
--- a/includes/queryprinters/FeedResultPrinter.php
+++ b/includes/queryprinters/FeedResultPrinter.php
@@ -341,4 +341,14 @@ final class FeedResultPrinter extends FileExportPrinter {
 
 		return $params;
 	}
+
+	/**
+	 * @since 2.5
+	 *
+	 * @return string
+	 */
+	public function getDefaultSort() {
+		return 'DESC';
+	}
+
 }

--- a/includes/queryprinters/ResultPrinter.php
+++ b/includes/queryprinters/ResultPrinter.php
@@ -660,4 +660,13 @@ abstract class ResultPrinter extends \ContextSource implements QueryResultPrinte
 		return false;
 	}
 
+	/**
+	 * @since 2.5
+	 *
+	 * @return string
+	 */
+	public function getDefaultSort() {
+		return 'ASC';
+	}
+
 }

--- a/src/Query/QueryContext.php
+++ b/src/Query/QueryContext.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace SMW\Query;
+
+/**
+ * "Query contexts" define restrictions during query parsing and
+ * are used to preconfigure query (e.g. special pages show no further
+ * results link)
+ *
+ * @license GNU GPL v2+
+ * @since 2.5
+ *
+ * @author Markus Krötzsch
+ */
+interface QueryContext {
+
+	/**
+	 * Query for special page
+	 */
+	const SPECIAL_PAGE = 1000;
+
+	/**
+	 * Query for inline use
+	 */
+	const INLINE_QUERY = 1001;
+
+	/**
+	 * Query for concept definition
+	 */
+	const CONCEPT_DESC = 1002;
+
+	/**
+	 * normal instance retrieval
+	 */
+	const MODE_INSTANCES = 1;
+
+	/**
+	 * find result count only
+	 */
+	const MODE_COUNT = 2;
+
+	/**
+	 * prepare query, but show debug data instead of executing it
+	 */
+	const MODE_DEBUG = 3;
+
+	/**
+	 * do nothing with the query
+	 */
+	const MODE_NONE = 4;
+
+}

--- a/src/Query/QueryCreator.php
+++ b/src/Query/QueryCreator.php
@@ -1,0 +1,249 @@
+<?php
+
+namespace SMW\Query;
+
+use SMW\QueryFactory;
+use SMW\DIWikiPage;
+use SMW\Localizer;
+use SMW\DataValueFactory;
+
+/**
+ * @private
+ *
+ * @license GNU GPL v2+
+ * @since 2.5
+ *
+ * @author mwjames
+ */
+class QueryCreator implements QueryContext {
+
+	/**
+	 * @var QueryFactory
+	 */
+	private $queryFactory;
+
+	/**
+	 * @var array
+	 */
+	private $configuration = array();
+
+	/**
+	 * @see smwgQDefaultNamespaces
+	 * @var null|array
+	 */
+	private $defaultNamespaces = null;
+
+	/**
+	 * @see smwgQDefaultLimit
+	 * @var integer
+	 */
+	private $defaultLimit = 0;
+
+	/**
+	 * @see smwgQFeatures
+	 * @var integer
+	 */
+	private $queryFeatures = 0;
+
+	/**
+	 * @see smwgQConceptFeatures
+	 * @var integer
+	 */
+	private $conceptFeatures = 0;
+
+	/**
+	 * @since 2.5
+	 *
+	 * @param QueryFactory $queryFactory
+	 * @param array|null $defaultNamespaces
+	 * @param integer $defaultLimit
+	 */
+	public function __construct( QueryFactory $queryFactory, $defaultNamespaces = null, $defaultLimit = 50 ) {
+		$this->queryFactory = $queryFactory;
+		$this->defaultNamespaces = $defaultNamespaces;
+		$this->defaultLimit = $defaultLimit;
+	}
+
+	/**
+	 * @since 2.5
+	 *
+	 * @param array $configuration
+	 */
+	public function withConfiguration( array $configuration ) {
+		$this->configuration = $configuration;
+	}
+
+	/**
+	 * @since 2.5
+	 *
+	 * @param integer $queryFeatures
+	 */
+	public function setQFeatures( $queryFeatures ) {
+		$this->queryFeatures = $queryFeatures;
+	}
+
+	/**
+	 * @since 2.5
+	 *
+	 * @param integer $conceptFeatures
+	 */
+	public function setQConceptFeatures( $conceptFeatures ) {
+		$this->conceptFeatures = $conceptFeatures;
+	}
+
+	/**
+	 * Parse a query string given in SMW's query language to create an Query.
+	 * Parameters are given as key-value-pairs in the given array. The parameter
+	 * $context defines in what context the query is used, which affects certaim
+	 * general settings.
+	 *
+	 * @since 2.5
+	 *
+	 * @param string $queryString
+	 *
+	 * @return Query
+	 */
+	public function createFromString( $queryString ) {
+
+		$context = $this->getFromConfigurationWith( 'context', self::INLINE_QUERY );
+
+		$queryParser = $this->queryFactory->newQueryParser(
+			$context == self::CONCEPT_DESC ? $this->conceptFeatures : $this->queryFeatures
+		);
+
+		$contextPage = $this->getFromConfigurationWith( 'contextPage', null );
+		$queryMode = $this->getFromConfigurationWith( 'queryMode', self::MODE_INSTANCES );
+
+		$queryParser->setContextPage( $contextPage );
+		$queryParser->setDefaultNamespaces( $this->defaultNamespaces );
+
+		$query = $this->queryFactory->newQuery(
+			$queryParser->getQueryDescription( $queryString ),
+			$context
+		);
+
+		$query->setQueryString( $queryString );
+		$query->setContextPage( $contextPage );
+		$query->setQuerymode( $queryMode );
+
+		$query->setExtraPrintouts(
+			$this->getFromConfigurationWith( 'extraPrintouts', array() )
+		);
+
+		$query->setMainLabel(
+			$this->getFromConfigurationWith( 'mainLabel', '' )
+		);
+
+		$query->setQuerySource(
+			$this->getFromConfigurationWith( 'querySource', null )
+		);
+
+		// keep parsing or other errors for later output
+		$query->addErrors(
+			$queryParser->getErrors()
+		);
+
+		// set sortkeys, limit, and offset
+		$query->setOffset(
+			max( 0, trim( $this->getFromConfigurationWith( 'offset', 0 ) ) + 0 )
+		);
+
+		$query->setLimit(
+			max( 0, trim( $this->getFromConfigurationWith( 'limit', $this->defaultLimit ) ) + 0 ),
+			$queryMode != self::MODE_COUNT
+		);
+
+		$sortKeys = $this->getSortKeys(
+			$this->getFromConfigurationWith( 'sort', array() ),
+			$this->getFromConfigurationWith( 'order', array() ),
+			$this->getFromConfigurationWith( 'defaultSort', 'ASC' )
+		);
+
+		$query->addErrors(
+			$sortKeys['errors']
+		);
+
+		$query->setSortKeys(
+			$sortKeys['keys']
+		);
+
+		return $query;
+	}
+
+	/**
+	 * @since 2.5
+	 *
+	 * @param array $sortParameters
+	 * @param array $orderParameters
+	 * @param string $defaultSort
+	 *
+	 * @return array ( keys => array(), errors => array() )
+	 */
+	public function getSortKeys( array $sortParameters, array $orderParameters, $defaultSort ) {
+
+		$sortKeys = array();
+		$sortErros = array();
+
+		$orders = $this->getNormalizedOrderParameters( $orderParameters );
+
+		foreach ( $sortParameters as $sort ) {
+			$sortKey = false;
+
+			// An empty string indicates we mean the page, such as element 0 on the next line.
+			// sort=,Some property
+			if ( trim( $sort ) === '' ) {
+				$sortKey = '';
+			} else {
+
+				$propertyValue = DataValueFactory::getInstance()->newPropertyValueByLabel(
+					$this->getNormalizedSortLabel( trim( $sort ) )
+				);
+
+				if ( $propertyValue->isValid() ) {
+					$sortKey = $propertyValue->getDataItem()->getKey();
+				} else {
+					$sortErros = array_merge( $sortErros, $propertyValue->getErrors() );
+				}
+			}
+
+			if ( $sortKey !== false ) {
+				$order = empty( $orders ) ? $defaultSort : array_shift( $orders );
+				$sortKeys[$sortKey] = $order;
+			}
+		}
+
+		// If more sort arguments are provided then properties, assume the first one is for the page.
+		// TODO: we might want to add errors if there is more then one.
+		if ( !array_key_exists( '', $sortKeys ) && !empty( $orders ) ) {
+			$sortKeys[''] = array_shift( $orders );
+		}
+
+		return array( 'keys' => $sortKeys, 'errors' => $sortErros );
+	}
+
+	private function getNormalizedOrderParameters( $orderParameters ) {
+		$orders = array();
+
+		foreach ( $orderParameters as $key => $order ) {
+			$order = strtolower( trim( $order ) );
+			if ( ( $order == 'descending' ) || ( $order == 'reverse' ) || ( $order == 'desc' ) ) {
+				$orders[$key] = 'DESC';
+			} elseif ( ( $order == 'random' ) || ( $order == 'rand' ) ) {
+				$orders[$key] = 'RANDOM';
+			} else {
+				$orders[$key] = 'ASC';
+			}
+		}
+
+		return $orders;
+	}
+
+	private function getNormalizedSortLabel( $sort ) {
+		return Localizer::getInstance()->getNamespaceTextById( NS_CATEGORY ) == mb_convert_case( $sort, MB_CASE_TITLE ) ? '_INST' : $sort;
+	}
+
+	private function getFromConfigurationWith( $key, $default ) {
+		return isset( $this->configuration[$key] ) ? $this->configuration[$key] : $default;
+	}
+
+}

--- a/src/QueryFactory.php
+++ b/src/QueryFactory.php
@@ -6,6 +6,7 @@ use SMW\Query\DescriptionFactory;
 use SMW\Query\Language\Description;
 use SMW\Query\PrintRequestFactory;
 use SMW\Query\ProfileAnnotatorFactory;
+use SMW\Query\QueryCreator;
 use SMWQuery as Query;
 use SMWQueryParser as QueryParser;
 
@@ -30,11 +31,12 @@ class QueryFactory {
 	 * @since 2.4
 	 *
 	 * @param Description $description
+	 * @param integer|false $context
 	 *
 	 * @return Query
 	 */
-	public function newQuery( Description $description ) {
-		return new Query( $description );
+	public function newQuery( Description $description, $context = false ) {
+		return new Query( $description, $context );
 	}
 
 	/**
@@ -80,10 +82,36 @@ class QueryFactory {
 	/**
 	 * @since 2.4
 	 *
+	 * @param integer|boolean $queryFeatures
+	 *
 	 * @return QueryParser
 	 */
-	public function newQueryParser() {
-		return new QueryParser();
+	public function newQueryParser( $queryFeatures = false ) {
+		return new QueryParser( $queryFeatures );
+	}
+
+	/**
+	 * @since 2.5
+	 *
+	 * @return QueryCreator
+	 */
+	public function newQueryCreator() {
+
+		$queryCreator = new QueryCreator(
+			$this,
+			$GLOBALS['smwgQDefaultNamespaces'],
+			$GLOBALS['smwgQDefaultLimit']
+		);
+
+		$queryCreator->setQFeatures(
+			$GLOBALS['smwgQFeatures']
+		);
+
+		$queryCreator->setQConceptFeatures(
+			$GLOBALS['smwgQConceptFeatures']
+		);
+
+		return $queryCreator;
 	}
 
 }

--- a/tests/phpunit/Unit/Query/QueryCreatorTest.php
+++ b/tests/phpunit/Unit/Query/QueryCreatorTest.php
@@ -1,0 +1,95 @@
+<?php
+
+namespace SMW\Tests\Query;
+
+use SMW\Query\QueryCreator;
+use SMW\ApplicationFactory;
+
+/**
+ * @covers SMW\Query\QueryCreator
+ * @group semantic-mediawiki
+ *
+ * @license GNU GPL v2+
+ * @since 2.5
+ *
+ * @author mwjames
+ */
+class QueryCreatorTest extends \PHPUnit_Framework_TestCase {
+
+	public function testCanConstruct() {
+
+		$queryFactory = $this->getMockBuilder( '\SMW\QueryFactory' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$this->assertInstanceOf(
+			'SMW\Query\QueryCreator',
+			new QueryCreator( $queryFactory )
+		);
+	}
+
+	/**
+	 * @dataProvider queryStringProvider
+	 */
+	public function testCreateFromString( $queryString, $configuration, $expected ) {
+
+		$instance = new QueryCreator(
+			ApplicationFactory::getInstance()->getQueryFactory()
+		);
+
+		$instance->withConfiguration( $configuration );
+
+		$query = $instance->createFromString( $queryString );
+
+		$this->assertInstanceOf(
+			'\SMWQuery',
+			$query
+		);
+
+		$this->assertSame(
+			$expected,
+			$query->getAsString()
+		);
+	}
+
+	public function queryStringProvider() {
+
+		$provider[] = array(
+			'[[Foo::Bar]]',
+			array(
+				'limit'  => 42,
+				'offset' => 12
+			),
+			'[[Foo::Bar]]|limit=42|offset=12|mainlabel='
+		);
+
+		$provider[] = array(
+			'[[Foo::Bar]]',
+			array(
+				'querySource' => 'foobar',
+				'mainLabel'   => 'Some'
+			),
+			'[[Foo::Bar]]|limit=50|offset=0|mainlabel=Some|source=foobar'
+		);
+
+		$provider[] = array(
+			'[[Foo::Bar]]',
+			array(
+				'sort'  => array( '', 'SomeA', 'SomeB' ),
+				'order' => array( 'desc', 'random', 'asc' )
+			),
+			'[[Foo::Bar]]|limit=50|offset=0|mainlabel=|sort=SomeA,SomeB|order=random,asc'
+		);
+
+		$provider[] = array(
+			'[[Foo::Bar]]',
+			array(
+				'sort'  => array( ',' )
+			),
+			'[[Foo::Bar]]|limit=50|offset=0|mainlabel=|sort=,|order=asc'
+		);
+
+		return $provider;
+	}
+
+}

--- a/tests/phpunit/Unit/Query/QueryTest.php
+++ b/tests/phpunit/Unit/Query/QueryTest.php
@@ -39,7 +39,7 @@ class QueryTest extends \PHPUnit_Framework_TestCase {
 
 		$description = $this->getMockForAbstractClass( '\SMW\Query\Language\Description' );
 
-		$instance = new Query( $description, true, false );
+		$instance = new Query( $description, Query::INLINE_QUERY );
 
 		$lowerboundLimit = 1;
 
@@ -72,7 +72,7 @@ class QueryTest extends \PHPUnit_Framework_TestCase {
 
 		$description = $this->getMockForAbstractClass( '\SMW\Query\Language\Description' );
 
-		$instance = new Query( $description, true, false );
+		$instance = new Query( $description, Query::INLINE_QUERY );
 
 		$upperboundLimit = 999999999;
 
@@ -105,7 +105,7 @@ class QueryTest extends \PHPUnit_Framework_TestCase {
 
 		$description = $this->getMockForAbstractClass( '\SMW\Query\Language\Description' );
 
-		$instance = new Query( $description, true, false );
+		$instance = new Query( $description, Query::INLINE_QUERY );
 
 		$upperboundLimit = 999999999;
 
@@ -135,7 +135,7 @@ class QueryTest extends \PHPUnit_Framework_TestCase {
 			->disableOriginalConstructor()
 			->getMock();
 
-		$instance = new Query( $description, true, false );
+		$instance = new Query( $description, Query::INLINE_QUERY );
 		$instance->setExtraPrintouts( array( $printRequest ) );
 
 		$serialized = $instance->toArray();
@@ -172,7 +172,7 @@ class QueryTest extends \PHPUnit_Framework_TestCase {
 
 		$description = $this->getMockForAbstractClass( '\SMW\Query\Language\Description' );
 
-		$instance = new Query( $description, true, false );
+		$instance = new Query( $description, Query::INLINE_QUERY );
 		$instance->setLimit( 50 );
 
 		$hash = $instance->getHash();

--- a/tests/phpunit/Unit/QueryFactoryTest.php
+++ b/tests/phpunit/Unit/QueryFactoryTest.php
@@ -98,4 +98,14 @@ class QueryFactoryTest extends \PHPUnit_Framework_TestCase {
 		);
 	}
 
+	public function testCanConstructQueryCreator() {
+
+		$instance = new QueryFactory();
+
+		$this->assertInstanceOf(
+			'\SMW\Query\QueryCreator',
+			$instance->newQueryCreator()
+		);
+	}
+
 }


### PR DESCRIPTION
This PR is made in reference to: #1516

This PR addresses or contains:

- Removes query creation from `SMWQueryProcessor ` to a separate configurable component 

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed

