### PR TITLE
ParserParameterProcessor to support JSON typed annotation

### DIFF
--- a/i18n/en.json
+++ b/i18n/en.json
@@ -444,5 +444,6 @@
 	"smw-datavalue-wikipage-empty": "The wikipage input value is empty (e.g. <code>[[SomeProperty::]], [[]]</code>) and therefore it cannot be used as a name or as part of a query condition.",
 	"smw-sp-types_ref_rec": "\"$1\" is a [https://www.semantic-mediawiki.org/wiki/Container container] type that allows to record additional information (e.g. provenance data) about a value assignment.",
 	"smw-datavalue-reference-outputformat": "$1: $2",
-	"smw-datavalue-reference-invalid-fields-definition": "The [[Special:Types/Reference|Reference]] type expects a list of properties to be declared using the [https://www.semantic-mediawiki.org/wiki/Help:Special_property_Has_fields Has fields] property."
+	"smw-datavalue-reference-invalid-fields-definition": "The [[Special:Types/Reference|Reference]] type expects a list of properties to be declared using the [https://www.semantic-mediawiki.org/wiki/Help:Special_property_Has_fields Has fields] property.",
+	"smw-parser-invalid-json-format": "The JSON parser returned with a \"$1\"."
 }

--- a/src/ExtraneousLanguage/LanguageFileContentsReader.php
+++ b/src/ExtraneousLanguage/LanguageFileContentsReader.php
@@ -5,6 +5,7 @@ namespace SMW\ExtraneousLanguage;
 use RuntimeException;
 use Onoi\Cache\Cache;
 use Onoi\Cache\NullCache;
+use SMW\Libs\ErrorCode;
 
 /**
  * @license GNU GPL v2+
@@ -174,7 +175,7 @@ class LanguageFileContentsReader {
 			return $contents;
 		}
 
-		throw new RuntimeException( $this->getMessageForJsonErrorCode( json_last_error() ) );
+		throw new RuntimeException( ErrorCode::getMessageFromJsonErrorCode( json_last_error() ) );
 	}
 
 	private function getFileForLanguageCode( $languageCode ) {
@@ -186,22 +187,6 @@ class LanguageFileContentsReader {
 		}
 
 		throw new RuntimeException( "Expected a {$file} file" );
-	}
-
-	private function getMessageForJsonErrorCode( $errorCode ) {
-
-		$errorMessages = array(
-			JSON_ERROR_STATE_MISMATCH => 'Underflow or the modes mismatch, malformed JSON',
-			JSON_ERROR_CTRL_CHAR => 'Unexpected control character found, possibly incorrectly encoded',
-			JSON_ERROR_SYNTAX => 'Syntax error, malformed JSON',
-			JSON_ERROR_UTF8   => 'Malformed UTF-8 characters, possibly incorrectly encoded',
-			JSON_ERROR_DEPTH  => 'The maximum stack depth has been exceeded'
-		);
-
-		return sprintf(
-			"Expected a JSON compatible format but failed with '%s'",
-			$errorMessages[$errorCode]
-		);
 	}
 
 	private function getCacheKeyFrom( $languageCode ) {

--- a/src/Libs/ErrorCode.php
+++ b/src/Libs/ErrorCode.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace SMW\Libs;
+
+/**
+ * Convenience method to retrieved stringified error codes.
+ *
+ * @license GNU GPL v2+
+ * @since 2.5
+ *
+ * @author mwjames
+ */
+class ErrorCode {
+
+	/**
+	 * @var array
+	 */
+	private static $constants = array();
+
+	/**
+	 * @var array
+	 */
+	private static $jsonErrors = array();
+
+	/**
+	 * @see http://php.net/manual/en/function.json-decode.php
+	 * @since 2.5
+	 *
+	 * @param integer $errorCode
+	 *
+	 * @return string
+	 */
+	public static function getStringFromJsonErrorCode( $errorCode ) {
+
+		if ( self::$constants === array() ) {
+			self::$constants = get_defined_constants( true );
+		}
+
+		if ( self::$jsonErrors === array() ) {
+			foreach ( self::$constants["json"] as $name => $value ) {
+				if ( !strncmp( $name, "JSON_ERROR_", 11 ) ) {
+					self::$jsonErrors[$value] = $name;
+				}
+			}
+		}
+
+		return isset( self::$jsonErrors[$errorCode] ) ? self::$jsonErrors[$errorCode] : 'UNKNOWN';
+	}
+
+	/**
+	 * @since 2.5
+	 *
+	 * @param integer $errorCode
+	 *
+	 * @return string
+	 */
+	public static function getMessageFromJsonErrorCode( $errorCode ) {
+
+		$errorMessages = array(
+			JSON_ERROR_STATE_MISMATCH => 'Underflow or the modes mismatch, malformed JSON',
+			JSON_ERROR_CTRL_CHAR => 'Unexpected control character found, possibly incorrectly encoded',
+			JSON_ERROR_SYNTAX => 'Syntax error, malformed JSON',
+			JSON_ERROR_UTF8   => 'Malformed UTF-8 characters, possibly incorrectly encoded',
+			JSON_ERROR_DEPTH  => 'The maximum stack depth has been exceeded'
+		);
+
+		if ( !isset( $errorMessages[$errorCode] ) ) {
+			return self::getStringFromJsonErrorCode( $errorCode );
+		}
+
+		return sprintf(
+			"Expected a JSON compatible format but failed with '%s'",
+			$errorMessages[$errorCode]
+		);
+	}
+
+}

--- a/tests/phpunit/Integration/ByJsonScript/Contents/p-0211.1.json
+++ b/tests/phpunit/Integration/ByJsonScript/Contents/p-0211.1.json
@@ -1,0 +1,20 @@
+@source: http://www.simile-widgets.org/exhibit3/examples/other-versions/HEAD/icd/icd10-infectious.json
+
+{{#subobject:
+    |@category=P0211
+    |@json={
+    "kind": "chapter",
+    "code": "I",
+    "exclusion": "carrier or suspected carrier of infectious diseaseZ22.-",
+    "icdId": "http://id.who.int/icd/icd10/I",
+    "inclusion": "diseases generally recognized as communicable or transmissible",
+    "label": "Certain infectious and parasitic diseases",
+    "link": "http://apps.who.int/classifications/icd10/browse/2010/en#/I",
+    "subclasses": [
+        "http://id.who.int/icd/icd10/A00-A09",
+        "http://id.who.int/icd/icd10/A15-A19",
+        "http://id.who.int/icd/icd10/A20-A28"
+    ],
+    "id": "http://id.who.int/icd/icd10/I"
+}
+}}

--- a/tests/phpunit/Integration/ByJsonScript/Contents/p-0211.2.json
+++ b/tests/phpunit/Integration/ByJsonScript/Contents/p-0211.2.json
@@ -1,0 +1,27 @@
+@source: http://www.simile-widgets.org/exhibit3/examples/other-versions/HEAD/icd/icd10-infectious.json
+
+{{#set:
+    |@json={
+    "kind": "block",
+    "code": "A00-A09",
+    "icdId": "http://id.who.int/icd/icd10/A00-A09",
+    "label": "Intestinal infectious diseases",
+    "link": "http://apps.who.int/classifications/icd10/browse/2010/en#/A00-A09",
+    "superclasses": [
+        "http://id.who.int/icd/icd10/I"
+    ],
+    "subclasses": [
+        "http://id.who.int/icd/icd10/A00",
+        "http://id.who.int/icd/icd10/A01",
+        "http://id.who.int/icd/icd10/A02",
+        "http://id.who.int/icd/icd10/A03",
+        "http://id.who.int/icd/icd10/A04",
+        "http://id.who.int/icd/icd10/A05",
+        "http://id.who.int/icd/icd10/A06",
+        "http://id.who.int/icd/icd10/A07",
+        "http://id.who.int/icd/icd10/A08",
+        "http://id.who.int/icd/icd10/A09"
+    ],
+    "id": "http://id.who.int/icd/icd10/A00-A09"
+}
+}}

--- a/tests/phpunit/Integration/ByJsonScript/Contents/p-0211.3.json
+++ b/tests/phpunit/Integration/ByJsonScript/Contents/p-0211.3.json
@@ -1,0 +1,11 @@
+3+ depth is not permitted
+
+{{#set:
+    |@json={
+    "foo": {
+        "kind": {
+               "kind": "bar"
+           }
+    }
+}
+}}

--- a/tests/phpunit/Integration/ByJsonScript/Fixtures/p-0211.json
+++ b/tests/phpunit/Integration/ByJsonScript/Fixtures/p-0211.json
@@ -1,0 +1,74 @@
+{
+	"description": "Test `#set`/`#subobject` to import annotation via `@json` syntax (`wgContLang=en`, `wgLang=en`)",
+	"properties": [
+		{
+			"name": "Has date",
+			"contents": "[[Has type::Date]]"
+		}
+	],
+	"subjects": [
+		{
+			"name": "Example/P0211/1",
+			"contents": {
+				"import-from": "/../Contents/p-0211.1.json"
+			}
+		},
+		{
+			"name": "Example/P0211/2",
+			"contents": {
+				"import-from": "/../Contents/p-0211.2.json"
+			}
+		},
+		{
+			"name": "Example/P0211/3",
+			"contents": {
+				"import-from": "/../Contents/p-0211.3.json"
+			}
+		}
+	],
+	"parser-testcases": [
+		{
+			"about": "#0 #subobject",
+			"subject": "Example/P0211/1",
+			"store": {
+				"semantic-data": {
+					"strict-mode-valuematch": false,
+					"propertyCount": 3,
+					"propertyKeys": [ "_SOBJ", "_SKEY", "_MDAT" ]
+				}
+			}
+		},
+		{
+			"about": "#1 #set",
+			"subject": "Example/P0211/2",
+			"store": {
+				"semantic-data": {
+					"strict-mode-valuematch": false,
+					"propertyCount": 10,
+					"propertyKeys": [ "Kind", "_cod", "IcdId", "Label", "Link", "Superclasses", "Subclasses", "Id", "_SKEY", "_MDAT" ]
+				}
+			}
+		},
+		{
+			"about": "#3 #set depth issue",
+			"subject": "Example/P0211/3",
+			"store": {
+				"semantic-data": {
+					"strict-mode-valuematch": false,
+					"propertyCount": 3,
+					"propertyKeys": [ "_ERRC", "_SKEY", "_MDAT" ]
+				}
+			}
+		}
+	],
+	"settings": {
+		"wgContLang": "en",
+		"wgLang": "en",
+		"smwgPageSpecialProperties": [ "_MDAT" ]
+	},
+	"meta": {
+		"version": "0.1",
+		"is-incomplete": false,
+		"debug": false
+	}
+}

--- a/tests/phpunit/Unit/ExtraneousLanguage/LanguageFileContentsReaderTest.php
+++ b/tests/phpunit/Unit/ExtraneousLanguage/LanguageFileContentsReaderTest.php
@@ -106,6 +106,14 @@ class LanguageFileContentsReaderTest extends \PHPUnit_Framework_TestCase {
 		$instance->readByLanguageCode( 'bar', true );
 	}
 
+	public function testTryToReadInaccessibleFileByLanguageThrowsException() {
+
+		$instance = new LanguageFileContentsReader();
+
+		$this->setExpectedException( 'RuntimeException' );
+		$instance->readByLanguageCode( 'foo', true );
+	}
+
 	/**
 	 * This method is just for convenience so that one can quickly add contents to files
 	 * without requiring an extra class when extending the language content. Normally the

--- a/tests/phpunit/Unit/Libs/ErrorCodeTest.php
+++ b/tests/phpunit/Unit/Libs/ErrorCodeTest.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace SMW\Tests\Libs;
+
+use SMW\Libs\ErrorCode;
+
+/**
+ * @covers \SMW\Libs\ErrorCode
+ * @group semantic-mediawiki
+ *
+ * @license GNU GPL v2+
+ * @since 2.5
+ *
+ * @author mwjames
+ */
+class ErrorCodeTest extends \PHPUnit_Framework_TestCase {
+
+	public function testGetStringFromJsonErrorCode() {
+
+		$this->assertInternalType(
+			'string',
+			ErrorCode::getStringFromJsonErrorCode( 'Foo' )
+		);
+
+		$contents = json_decode( '{ Foo: Bar }' );
+
+		$this->assertInternalType(
+			'string',
+			ErrorCode::getStringFromJsonErrorCode( json_last_error() )
+		);
+	}
+
+	public function testGetMessageFromJsonErrorCode() {
+
+		$this->assertInternalType(
+			'string',
+			ErrorCode::getMessageFromJsonErrorCode( 'Foo' )
+		);
+
+		$contents = json_decode( '{ Foo: Bar }' );
+
+		$this->assertInternalType(
+			'string',
+			ErrorCode::getMessageFromJsonErrorCode( json_last_error() )
+		);
+	}
+
+}

--- a/tests/phpunit/Unit/ParserParameterProcessorTest.php
+++ b/tests/phpunit/Unit/ParserParameterProcessorTest.php
@@ -280,6 +280,43 @@ class ParserParameterProcessorTest extends \PHPUnit_Framework_TestCase {
 			)
 		);
 
+		// {{#...:
+		// |@json={ "Foo": 123}
+		// }}
+		$provider[] = array(
+			array(
+				'@json={ "Foo": 123}'
+			),
+			array(
+				'Foo' => array( '123' )
+			)
+		);
+
+		// {{#...:
+		// |@json={ "Foo": [123, 456] }
+		// }}
+		$provider[] = array(
+			array(
+				'@json={ "Foo": [123, 456] }'
+			),
+			array(
+				'Foo' => array( '123', '456' )
+			)
+		);
+
+		// Error
+		// {{#...:
+		// |@json={ "Foo": [123, 456] }
+		// }}
+		$provider[] = array(
+			array(
+				'@json={ Foo: [123, 456] }'
+			),
+			array(
+				'@json' => array( '{ Foo: [123, 456] }' )
+			)
+		);
+
 		return $provider;
 	}
 


### PR DESCRIPTION
This PR is made in reference to: #N/A

This PR addresses or contains:

- This allows to add JSON typed annotation in the `#set` and `#subobject` parser function using the `@json` marker.
- Using the JSON format allows for creating structured annotation by means of electronic generators
- A depth of 3+ is not supported (for details see test cases)

```
{{#set:
    |@json={
    "foo": [
         "bar",
         "foobar"
    ]
}
}}
```

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed
