### PR TITLE
enableSemantics to call NamespaceManager

### DIFF
--- a/src/GlobalFunctions.php
+++ b/src/GlobalFunctions.php
@@ -220,6 +220,11 @@ function smwfGetLinker() {
 function enableSemantics( $namespace = null, $complete = false ) {
 	global $smwgNamespace;
 
+	// Apparently this is required (1.28+) as the earliest possible execution
+	// point in order for settings that refer to the SMW_NS_PROPERTY namespace
+	// to be available in LocalSettings
+	NamespaceManager::initCustomNamespace( $GLOBALS );
+
 	if ( !$complete && ( $smwgNamespace !== '' ) ) {
 		// The dot tells that the domain is not complete. It will be completed
 		// in the Export since we do not want to create a title object here when


### PR DESCRIPTION
This PR is made in reference to: #1886

This PR addresses or contains:

- I did hope to avoid the `NamespaceManager` call in `enableSemantics` but apparently something changed again in 1.28 and this ensures that `SMW_NS_PROPERTY` can be referred in `LocalSettings` without encountering a "Use of undefined constant SMW_NS_PROPERTY - assumed 'SMW_NS_PROPERTY' in ..."

This PR includes:
- [ ] Tests (unit/integration)
- [x] CI build passed

