### PR TITLE
Highligher to obfuscate `[` in the title element, refs #1875

### DIFF
--- a/includes/Highlighter.php
+++ b/includes/Highlighter.php
@@ -176,7 +176,7 @@ class Highlighter {
 				'data-content' => isset( $this->options['data-content'] ) ? $this->options['data-content'] : null,
 				'data-state'   => $this->options['state'],
 				'data-title'   => Message::get( $this->options['title'], Message::TEXT, $language ),
-				'title'        => strip_tags( htmlspecialchars_decode( $this->options['content'] ) )
+				'title'        => strip_tags( htmlspecialchars_decode( str_replace( "[", "&#x005B;", $this->options['content'] ) ) )
 			), Html::rawElement(
 					'span',
 					array(

--- a/includes/datavalues/SMW_DV_Property.php
+++ b/includes/datavalues/SMW_DV_Property.php
@@ -370,7 +370,7 @@ class SMWPropertyValue extends SMWDataValue {
 
 		if ( ( $content = $propertySpecificationLookup->getPropertyDescriptionBy( $this->m_dataitem, $linker ) ) !== '' || !$this->m_dataitem->isUserDefined() ) {
 
-			$highlighter = Highlighter::factory( Highlighter::TYPE_PROPERTY );
+			$highlighter = Highlighter::factory( Highlighter::TYPE_PROPERTY, $this->getOptionBy( self::OPT_USER_LANGUAGE ) );
 			$highlighter->setContent( array (
 				'userDefined' => $this->m_dataitem->isUserDefined(),
 				'caption' => $text,

--- a/tests/phpunit/Integration/ByJsonScript/Fixtures/p-0212.json
+++ b/tests/phpunit/Integration/ByJsonScript/Fixtures/p-0212.json
@@ -1,0 +1,53 @@
+{
+	"description": "Test `@@@` in-text annotation syntax (#1855, #1875 `wgContLang=en`, `wgLang=en`)",
+	"setup": [
+		{
+			"namespace": "SMW_NS_PROPERTY",
+			"name": "Has date",
+			"contents": "[[Has type::Date]] {{#set: Has property description=Some text with a link to [http://example.org/ foo] and <li>stripped `li` in title element</li>@en}}"
+		},
+		{
+			"name": "Example/P0212/1",
+			"contents": "[[Has date::@@@]]"
+		},
+		{
+			"name": "Example/P0212/2",
+			"contents": "[[Has date::@@@|With extra caption]]"
+		}
+	],
+	"tests": [
+		{
+			"type": "parser",
+			"about": "#0",
+			"subject": "Example/P0212/1",
+			"expected-output": {
+				"to-contain": [
+					"<span class=\"smw-highlighter\" data-type=\"1\" data-state=\"inline\" data-title=\"Property\" title=\"Some text with a link to &amp;#x005B;http://example.org/ foo] and stripped `li` in title element\">",
+					"<div class=\"smwttcontent\">Some text with a link to <a rel=\"nofollow\" class=\"external text\" href=\"http://example.org/\">foo</a> and <li>stripped `li` in title element</li></div>",
+					"title=\"Property:Has date\">Has date</a>"
+				]
+			}
+		},
+		{
+			"type": "parser",
+			"about": "#1",
+			"subject": "Example/P0212/2",
+			"expected-output": {
+				"to-contain": [
+					"<span class=\"smw-highlighter\" data-type=\"1\" data-state=\"inline\" data-title=\"Property\" title=\"Some text with a link to &amp;#x005B;http://example.org/ foo] and stripped `li` in title element\">",
+					"<div class=\"smwttcontent\">Some text with a link to <a rel=\"nofollow\" class=\"external text\" href=\"http://example.org/\">foo</a> and <li>stripped `li` in title element</li></div>",
+					"title=\"Property:Has date\">With extra caption</a>"
+				]
+			}
+		}
+	],
+	"settings": {
+		"wgContLang": "en",
+		"wgLang": "en"
+	},
+	"meta": {
+		"version": "2",
+		"is-incomplete": false,
+		"debug": false
+	}
+}


### PR DESCRIPTION
This PR is made in reference to: #1875

This PR addresses or contains:

- This avoids broken links in case a title element contains `[ ... ]`.

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed