### PR TITLE
PropertyTableIdReferenceDisposer trigger cache reset

### DIFF
--- a/src/EventListenerRegistry.php
+++ b/src/EventListenerRegistry.php
@@ -42,7 +42,12 @@ class EventListenerRegistry implements EventListenerCollection {
 		$this->eventListenerCollection->registerCallback(
 			'factbox.cache.delete', function( $dispatchContext ) {
 
-				$title = $dispatchContext->get( 'title' );
+				if ( $dispatchContext->has( 'subject' ) ) {
+					$title = $dispatchContext->get( 'subject' )->getTitle();
+				} else{
+					$title = $dispatchContext->get( 'title' );
+				}
+
 				$applicationFactory = ApplicationFactory::getInstance();
 
 				$applicationFactory->getCache()->delete(
@@ -69,7 +74,12 @@ class EventListenerRegistry implements EventListenerCollection {
 		$this->eventListenerCollection->registerCallback(
 			'cached.propertyvalues.prefetcher.reset', function( $dispatchContext ) {
 
-				$subject = DIWikiPage::newFromTitle( $dispatchContext->get( 'title' ) );
+				if ( $dispatchContext->has( 'title' ) ) {
+					$subject = DIWikiPage::newFromTitle( $dispatchContext->get( 'title' ) );
+				} else{
+					$subject = $dispatchContext->get( 'subject' );
+				}
+
 				wfDebugLog( 'smw', 'Clear CachedPropertyValuesPrefetcher for ' . $subject->getHash() );
 
 				$applicationFactory = ApplicationFactory::getInstance();
@@ -93,7 +103,7 @@ class EventListenerRegistry implements EventListenerCollection {
 		 * Emitted during PropertySpecificationChangeNotifier::notifyDispatcher
 		 */
 		$this->eventListenerCollection->registerCallback(
-			'property.spec.change', function( $dispatchContext ) {
+			'property.specification.change', function( $dispatchContext ) {
 
 				$applicationFactory = ApplicationFactory::getInstance();
 				$subject = $dispatchContext->get( 'subject' );

--- a/src/PropertySpecificationChangeNotifier.php
+++ b/src/PropertySpecificationChangeNotifier.php
@@ -117,7 +117,7 @@ class PropertySpecificationChangeNotifier {
 			$dispatchContext->set( 'subject', $this->semanticData->getSubject() );
 
 			EventHandler::getInstance()->getEventDispatcher()->dispatch(
-				'property.spec.change',
+				'property.specification.change',
 				$dispatchContext
 			);
 

--- a/src/PropertySpecificationLookup.php
+++ b/src/PropertySpecificationLookup.php
@@ -275,7 +275,7 @@ class PropertySpecificationLookup {
 	/**
 	 * We try to cache anything to avoid unnecessary store connections or DB
 	 * lookups. For cases where a property was changed, the EventDipatcher will
-	 * receive a 'property.spec.change' event (emitted as soon as the content of
+	 * receive a 'property.specification.change' event (emitted as soon as the content of
 	 * a property page was altered) with PropertySpecificationLookup::resetCacheBy
 	 * being invoked to remove the cache entry for that specific property.
 	 *

--- a/src/SQLStore/ByIdDataRebuildDispatcher.php
+++ b/src/SQLStore/ByIdDataRebuildDispatcher.php
@@ -263,7 +263,7 @@ class ByIdDataRebuildDispatcher {
 				// leave subobjects alone; they ought to be changed with their pages
 				$this->dispatchedEntities[] = array( 's' => $row->smw_title . '#' . $row->smw_namespace . '#' .$row->smw_subobject );
 			} elseif ( $this->isPlainObjectValue( $row ) ) {
-				$this->propertyTableIdReferenceDisposer->tryToRemoveOutdatedIDFromEntityTables( $row->smw_id );
+				$this->propertyTableIdReferenceDisposer->removeOutdatedEntityReferencesById( $row->smw_id );
 			} elseif ( $row->smw_iw === '' && $titleKey != '' ) {
 				// objects representing pages
 				$title = Title::makeTitleSafe( $row->smw_namespace, $titleKey );
@@ -283,7 +283,7 @@ class ByIdDataRebuildDispatcher {
 					$updateJobs[] = $this->newUpdateJob( $title );
 				}
 			} elseif ( $row->smw_iw == SMW_SQL3_SMWIW_OUTDATED || $row->smw_iw == SMW_SQL3_SMWDELETEIW ) { // remove outdated internal object references
-				$this->propertyTableIdReferenceDisposer->cleanUpTableEntriesFor( $row->smw_id );
+				$this->propertyTableIdReferenceDisposer->cleanUpTableEntriesById( $row->smw_id );
 			} elseif ( $titleKey != '' ) { // "normal" interwiki pages or outdated internal objects -- delete
 				$diWikiPage = new DIWikiPage( $titleKey, $row->smw_namespace, $row->smw_iw );
 				$emptySemanticData = new SemanticData( $diWikiPage );

--- a/src/SQLStore/PropertyTableIdReferenceFinder.php
+++ b/src/SQLStore/PropertyTableIdReferenceFinder.php
@@ -89,7 +89,7 @@ class PropertyTableIdReferenceFinder {
 	 *
 	 * @return boolean
 	 */
-	public function hasResidualReferenceFor( $id ) {
+	public function hasResidualReferenceForId( $id ) {
 
 		if ( $id == SQLStore::FIXED_PROPERTY_ID_UPPERBOUND ) {
 			return true;

--- a/tests/phpunit/Unit/EventListenerRegistryTest.php
+++ b/tests/phpunit/Unit/EventListenerRegistryTest.php
@@ -64,7 +64,7 @@ class EventListenerRegistryTest extends \PHPUnit_Framework_TestCase {
 			EventDispatcherFactory::getInstance()->newGenericEventListenerCollection()
 		);
 
-		$this->verifyPropertyTypeChangeEvent( $instance );
+		$this->verifyPropertySpecificationeChangeEvent( $instance );
 		$this->verifyExporterResetEvent( $instance );
 		$this->verifyFactboxCacheDeleteEvent( $instance );
 		$this->verifyCachedPropertyValuesPrefetcherResetEvent( $instance );
@@ -80,7 +80,7 @@ class EventListenerRegistryTest extends \PHPUnit_Framework_TestCase {
 		$this->assertListenerExecuteFor( 'query.comparator.reset', $instance, null );
 	}
 
-	public function verifyPropertyTypeChangeEvent( EventListenerCollection $instance ) {
+	public function verifyPropertySpecificationeChangeEvent( EventListenerCollection $instance ) {
 
 		$store = $this->getMockBuilder( '\SMW\Store' )
 			->disableOriginalConstructor()
@@ -99,7 +99,7 @@ class EventListenerRegistryTest extends \PHPUnit_Framework_TestCase {
 		$dispatchContext = EventDispatcherFactory::getInstance()->newDispatchContext();
 		$dispatchContext->set( 'subject', new DIWikiPage( 'Foo', NS_MAIN ) );
 
-		$this->assertListenerExecuteFor( 'property.spec.change', $instance, $dispatchContext );
+		$this->assertListenerExecuteFor( 'property.specification.change', $instance, $dispatchContext );
 	}
 
 	public function verifyFactboxCacheDeleteEvent( EventListenerCollection $instance ) {

--- a/tests/phpunit/Unit/SQLStore/PropertyTableIdReferenceDisposerTest.php
+++ b/tests/phpunit/Unit/SQLStore/PropertyTableIdReferenceDisposerTest.php
@@ -3,7 +3,7 @@
 namespace SMW\Tests\SQLStore;
 
 use SMW\SQLStore\PropertyTableIdReferenceDisposer;
-use Title;
+use SMW\DIWikiPage;
 
 /**
  * @covers \SMW\SQLStore\PropertyTableIdReferenceDisposer
@@ -21,9 +21,22 @@ class PropertyTableIdReferenceDisposerTest extends \PHPUnit_Framework_TestCase {
 	protected function setUp() {
 		parent::setUp();
 
+		$idTable = $this->getMockBuilder( '\stdClass' )
+			->setMethods( array( 'getDataItemById' ) )
+			->getMock();
+
+		$idTable->expects( $this->any() )
+			->method( 'getDataItemById' )
+			->will( $this->returnValue( DIWikiPage::newFromText( 'Foo' ) ) );
+
 		$this->store = $this->getMockBuilder( '\SMW\SQLStore\SQLStore' )
 			->disableOriginalConstructor()
 			->getMock();
+
+		$this->store->expects( $this->any() )
+			->method( 'getObjectIds' )
+			->will( $this->returnValue( $idTable ) );
+
 	}
 
 	public function testCanConstruct() {
@@ -72,7 +85,7 @@ class PropertyTableIdReferenceDisposerTest extends \PHPUnit_Framework_TestCase {
 			$this->store
 		);
 
-		$instance->tryToRemoveOutdatedIDFromEntityTables( 42 );
+		$instance->removeOutdatedEntityReferencesById( 42 );
 	}
 
 	public function testCleanUpTableEntriesFor() {
@@ -109,7 +122,7 @@ class PropertyTableIdReferenceDisposerTest extends \PHPUnit_Framework_TestCase {
 			$this->store
 		);
 
-		$instance->cleanUpTableEntriesFor( 42 );
+		$instance->cleanUpTableEntriesById( 42 );
 	}
 
 }

--- a/tests/phpunit/Unit/SQLStore/PropertyTableIdReferenceFinderTest.php
+++ b/tests/phpunit/Unit/SQLStore/PropertyTableIdReferenceFinderTest.php
@@ -125,7 +125,7 @@ class PropertyTableIdReferenceFinderTest extends \PHPUnit_Framework_TestCase {
 
 		$this->assertInternalType(
 			'boolean',
-			$instance->hasResidualReferenceFor( 42 )
+			$instance->hasResidualReferenceForId( 42 )
 		);
 	}
 
@@ -136,7 +136,7 @@ class PropertyTableIdReferenceFinderTest extends \PHPUnit_Framework_TestCase {
 		);
 
 		$this->assertTrue(
-			$instance->hasResidualReferenceFor( SQLStore::FIXED_PROPERTY_ID_UPPERBOUND )
+			$instance->hasResidualReferenceForId( SQLStore::FIXED_PROPERTY_ID_UPPERBOUND )
 		);
 	}
 


### PR DESCRIPTION
This PR is made in reference to: #

This PR addresses or contains:

- Ensures that any remaining cache items are purged for a matchable id that is going to be disposed.

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed
