### PR TITLE
SMWSearch: Fix unit test; Move access to MediaWikiServices to ApplicationFactory

### DIFF
--- a/src/ApplicationFactory.php
+++ b/src/ApplicationFactory.php
@@ -354,6 +354,26 @@ class ApplicationFactory {
 	}
 
 	/**
+	 * @since 2.5
+	 *
+	 * @return \LoadBalancer
+	 */
+	public function getLoadBalancer() {
+		return $this->callbackLoader->singleton( 'DBLoadBalancer' );
+	}
+
+	/**
+	 * @since 2.5
+	 *
+	 * @param \IDatabase $db
+	 * @return string
+	 */
+	public function getDefaultSearchEngineTypeForDB( \IDatabase $db ) {
+		return $this->callbackLoader->create( 'DefaultSearchEngineTypeForDB', $db );
+
+	}
+
+	/**
 	 * @since 2.4
 	 *
 	 * @param Closure $callback

--- a/src/MediaWiki/Search/Search.php
+++ b/src/MediaWiki/Search/Search.php
@@ -52,7 +52,11 @@ class Search extends SearchEngine {
 			throw new RuntimeException( "$type does not exist." );
 		}
 
-		if ( !is_subclass_of( $type, 'SearchEngine' ) || $type === 'SMWSearch' ) {
+		if ( $type === 'SMWSearch' ) {
+			throw new RuntimeException( 'SMWSearch is not a valid fallback search engine type.' );
+		}
+
+		if ( $type !== 'SearchEngine' && !is_subclass_of( $type, 'SearchEngine' ) ) {
 			throw new RuntimeException( "$type is not a valid fallback search engine type." );
 		}
 	}

--- a/src/MediaWiki/Search/Search.php
+++ b/src/MediaWiki/Search/Search.php
@@ -4,7 +4,6 @@ namespace SMW\MediaWiki\Search;
 
 use Content;
 use DatabaseBase;
-use MediaWiki\MediaWikiServices;
 use RuntimeException;
 use SearchEngine;
 use SMW\ApplicationFactory;
@@ -49,33 +48,12 @@ class Search extends SearchEngine {
 	 */
 	private function assertValidFallbackSearchEngineType( $type ) {
 
-		if ( $type === null ) {
-			return;
-		}
-
 		if ( !class_exists( $type ) ) {
 			throw new RuntimeException( "$type does not exist." );
 		}
 
 		if ( !is_subclass_of( $type, 'SearchEngine' ) || $type === 'SMWSearch' ) {
 			throw new RuntimeException( "$type is not a valid fallback search engine type." );
-		}
-	}
-
-	/**
-	 * @param $db
-	 * @return string
-	 */
-	private function getDefaultSearchEngineTypeForDB( $db ) {
-
-		if ( method_exists( 'SearchEngineFactory', 'getSearchEngineClass' ) ) { // MW > 1.27
-
-			return \SearchEngineFactory::getSearchEngineClass( $db );
-
-		} else { // MW <= 1.27
-
-			return $db->getSearchEngine();
-
 		}
 	}
 
@@ -88,13 +66,13 @@ class Search extends SearchEngine {
 
 			$type = ApplicationFactory::getInstance()->getSettings()->get( 'smwgFallbackSearchType' );
 
-			$this->assertValidFallbackSearchEngineType( $type );
-
 			$dbr = $this->getDB();
 
 			if ( $type === null ) {
-				$type = $this->getDefaultSearchEngineTypeForDB( $dbr );
+				$type = ApplicationFactory::getInstance()->getDefaultSearchEngineTypeForDB( $dbr );
 			}
+
+			$this->assertValidFallbackSearchEngineType( $type );
 
 			$this->fallbackSearch = new $type( $dbr );
 		}
@@ -111,12 +89,14 @@ class Search extends SearchEngine {
 	}
 
 	/**
-	 * @return DatabaseBase
+	 * @return \IDatabase
 	 */
 	public function getDB() {
 
 		if ( $this->database === null ) {
-			$this->database = wfGetDB( defined( 'DB_REPLICA' ) ? DB_REPLICA : DB_SLAVE );
+
+			$this->database = ApplicationFactory::getInstance()->getLoadBalancer()->getConnection( defined( 'DB_REPLICA' ) ? DB_REPLICA : DB_SLAVE );
+
 		}
 
 		return $this->database;

--- a/tests/phpunit/Unit/MediaWiki/Search/SearchTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Search/SearchTest.php
@@ -55,15 +55,23 @@ class SearchTest extends \PHPUnit_Framework_TestCase {
 
 	public function testGetDefaultFallbackSearchEngineForNullFallbackSearchType() {
 
-		// #1531
-		$searchEngine = class_exists( 'SearchDatabase' ) ? 'SearchDatabase' : 'SearchEngine';
+		$searchEngine = 'SearchDatabase';
+
+		if ( class_exists( 'SearchEngine' ) ) {
+
+			$reflection = new \ReflectionClass( 'SearchEngine' );
+
+			if ( $reflection->isInstantiable() ) {
+				$searchEngine = 'SearchEngine';
+			}
+		}
 
 		$databaseBase = $this->getMockBuilder( '\DatabaseBase' )
 			->disableOriginalConstructor()
 			->setMethods( array( 'getSearchEngine' ) )
 			->getMockForAbstractClass();
 
-		$databaseBase->expects( $this->once() )
+		$databaseBase->expects( $this->any() )
 			->method( 'getSearchEngine' )
 			->will( $this->returnValue( $searchEngine ) );
 
@@ -73,7 +81,7 @@ class SearchTest extends \PHPUnit_Framework_TestCase {
 		$search->setDB( $databaseBase );
 
 		$this->assertInstanceOf(
-			$searchEngine,
+			'SearchEngine',
 			$search->getFallbackSearchEngine()
 		);
 	}


### PR DESCRIPTION
This PR is made in reference to:
- https://github.com/SemanticMediaWiki/SemanticMediaWiki/pull/1897#issuecomment-252457927
- https://github.com/SemanticMediaWiki/SemanticMediaWiki/pull/1897#pullrequestreview-3417583

This PR addresses or contains:
- fix SearchTest::testGetDefaultFallbackSearchEngineForNullFallbackSearchType
- remove direct accesses to MediaWikiServices from Search.php
- add ApplicationFactory::getMediaWikiServices
- add $callbackLoader->registerCallback( 'MediaWikiServices', ...) to SharedCallbackContainer
  (not sure if that is the correct thing to do)

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed

