### PR TITLE
QueryDependencyLinksStore avoid event trigger on a possible Request abort

### DIFF
--- a/src/DeferredRequestDispatchManager.php
+++ b/src/DeferredRequestDispatchManager.php
@@ -224,12 +224,17 @@ class DeferredRequestDispatchManager {
 		$this->httpRequest->setOption( ONOI_HTTP_REQUEST_CONTENT, 'parameters=' . json_encode( $parameters ) );
 		$this->httpRequest->setOption( ONOI_HTTP_REQUEST_CONNECTION_FAILURE_REPEAT, 2 );
 
-		$this->httpRequest->setOption( ONOI_HTTP_REQUEST_ON_COMPLETED_CALLBACK, function( $requestResponse ) {
-			wfDebugLog( 'smw', 'SMW\DeferredRequestDispatchManager: ' . json_encode( $requestResponse->getList() ) . "\n" );
+		$this->httpRequest->setOption( ONOI_HTTP_REQUEST_ON_COMPLETED_CALLBACK, function( $requestResponse ) use ( $parameters ) {
+			$requestResponse->set( 'type', $parameters['async-job']['type'] );
+			$requestResponse->set( 'title', $parameters['async-job']['title'] );
+			wfDebugLog( 'smw', 'SMW\DeferredRequestDispatchManager: ' . json_encode( $requestResponse->getList(), JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES ) . "\n" );
 		} );
 
 		$this->httpRequest->setOption( ONOI_HTTP_REQUEST_ON_FAILED_CALLBACK, function( $requestResponse ) use ( $dispatchableCallbackJob, $title, $type, $parameters ) {
-			wfDebugLog( 'smw', "SMW\DeferredRequestDispatchManager: Connection to SpecialDeferredRequestDispatcher failed on {$type} with " . json_encode( $requestResponse->getList() ). " " . $title->getPrefixedDBkey() . "\n" );
+			$requestResponse->set( 'type', $parameters['async-job']['type'] );
+			$requestResponse->set( 'title', $parameters['async-job']['title'] );
+
+			wfDebugLog( 'smw', "SMW\DeferredRequestDispatchManager: Connection to SpecialDeferredRequestDispatcher failed on {$type} with " . json_encode( $requestResponse->getList(), JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES ). " " . $title->getPrefixedDBkey() . "\n" );
 			call_user_func_array( $dispatchableCallbackJob, array( $title, $parameters ) );
 		} );
 

--- a/src/MediaWiki/Hooks/HookRegistry.php
+++ b/src/MediaWiki/Hooks/HookRegistry.php
@@ -499,7 +499,10 @@ class HookRegistry {
 				$store
 			);
 
+			$subject = $semanticData->getSubject();
+
 			$queryDependencyLinksStore->pruneOutdatedTargetLinks(
+				$subject,
 				$compositePropertyTableDiffIterator
 			);
 
@@ -513,7 +516,7 @@ class HookRegistry {
 			);
 
 			$deferredRequestDispatchManager->dispatchParserCachePurgeJobFor(
-				$semanticData->getSubject()->getTitle(),
+				$subject->getTitle(),
 				$jobParameters
 			);
 
@@ -524,13 +527,14 @@ class HookRegistry {
 			);
 
 			$textByChangeUpdater->pushUpdates(
-				$semanticData->getSubject(),
+				$subject,
 				$compositePropertyTableDiffIterator,
 				$deferredRequestDispatchManager
 			);
 
 			return true;
 		};
+
 
 		/**
 		 * @see https://www.semantic-mediawiki.org/wiki/Hooks#SMW::Store::AfterQueryResultLookupComplete

--- a/src/MediaWiki/Jobs/ParserCachePurgeJob.php
+++ b/src/MediaWiki/Jobs/ParserCachePurgeJob.php
@@ -6,6 +6,7 @@ use Hooks;
 use SMW\ApplicationFactory;
 use SMW\HashBuilder;
 use SMW\SQLStore\QueryDependencyLinksStoreFactory;
+use SMW\RequestOptions;
 use Title;
 
 /**
@@ -103,11 +104,15 @@ class ParserCachePurgeJob extends JobBase {
 			$this->store
 		);
 
+		$requestOptions = new RequestOptions();
+
 		// +1 to look ahead
-		$hashList = $queryDependencyLinksStore->findPartialEmbeddedQueryTargetLinksHashListFor(
+		$requestOptions->setLimit( $this->limit + 1 );
+		$requestOptions->setOffset( $this->offset );
+
+		$hashList = $queryDependencyLinksStore->findEmbeddedQueryTargetLinksHashListFor(
 			$idList,
-			$this->limit + 1,
-			$this->offset
+			$requestOptions
 		);
 
 		if ( $hashList === array() ) {

--- a/src/MediaWiki/Specials/SpecialDeferredRequestDispatcher.php
+++ b/src/MediaWiki/Specials/SpecialDeferredRequestDispatcher.php
@@ -84,6 +84,10 @@ class SpecialDeferredRequestDispatcher extends SpecialPage {
 
 		$this->getOutput()->disable();
 
+		if ( wfReadOnly() ) {
+			return $this->modifyHttpHeader( "HTTP/1.0 423 Locked", 'Wiki is in read-only mode.' );
+		}
+
 		if ( !$this->isHttpRequestMethod( 'HEAD' ) && !$this->isHttpRequestMethod( 'POST' ) ) {
 			return $this->modifyHttpHeader( "HTTP/1.0 400 Bad Request", 'The special page requires a POST/HEAD request.' );
 		}

--- a/src/RequestOptions.php
+++ b/src/RequestOptions.php
@@ -63,6 +63,11 @@ class RequestOptions {
 	private $stringConditions = array();
 
 	/**
+	 * An array extra conditions
+	 */
+	private $extraConditions = array();
+
+	/**
 	 * @since 1.0
 	 *
 	 * @param string $string to match
@@ -82,6 +87,24 @@ class RequestOptions {
 	 */
 	public function getStringConditions() {
 		return $this->stringConditions;
+	}
+
+	/**
+	 * @since 2.5
+	 *
+	 * @param mixed $extraCondition
+	 */
+	public function addExtraCondition( $extraCondition ) {
+		$this->extraConditions[] = $extraCondition;
+	}
+
+	/**
+	 * @since 2.5
+	 *
+	 * @param array
+	 */
+	public function getExtraConditions() {
+		return $this->extraConditions;
 	}
 
 	/**
@@ -140,6 +163,7 @@ class RequestOptions {
 			$this->boundary . '#' .
 			$this->include_boundary . '#' .
 			( $stringConditions !== '' ? '|' . $stringConditions : '' );
+			( $this->extraConditions !== array() ? implode( '#', $this->extraConditions ): '' );
 	}
 
 }

--- a/src/SQLStore/QueryDependency/EntityIdListRelevanceDetectionFilter.php
+++ b/src/SQLStore/QueryDependency/EntityIdListRelevanceDetectionFilter.php
@@ -106,7 +106,7 @@ class EntityIdListRelevanceDetectionFilter {
 			array_keys( $affiliateEntityList )
 		);
 
-		wfDebugLog( 'smw', __METHOD__ . ' processing (sec): ' . round( ( microtime( true ) - $start ), 6 )  );
+		wfDebugLog( 'smw', __METHOD__ . ' procTime (sec): ' . round( ( microtime( true ) - $start ), 6 )  );
 
 		return $filteredIdList;
 	}

--- a/src/SQLStore/QueryDependencyLinksStoreFactory.php
+++ b/src/SQLStore/QueryDependencyLinksStoreFactory.php
@@ -65,7 +65,7 @@ class QueryDependencyLinksStoreFactory {
 			new DependencyLinksTableUpdater( $store )
 		);
 
-		$queryDependencyLinksStore->setEnabledState(
+		$queryDependencyLinksStore->setEnabled(
 			$this->applicationFactory->getSettings()->get( 'smwgEnabledQueryDependencyLinksStore' )
 		);
 


### PR DESCRIPTION
This PR is made in reference to: #

This PR addresses or contains:

- MW can abort a Request on/in certain circumstances which can lead to unresolved updates before the task could finish.

This PR includes:
- [ ] Tests (unit/integration)
- [x] CI build passed

