### PR TITLE
Add EntityIdDisposerJob, refs 1931, 1216

### DIFF
--- a/includes/Setup.php
+++ b/includes/Setup.php
@@ -163,7 +163,7 @@ final class Setup {
 			if ( $language === Message::USER_LANGUAGE ) {
 				$language = Localizer::getInstance()->getUserLanguage();
 			}
-			
+
 			// 1.27+
 			// [GlobalTitleFail] MessageCache::parse called by ... Message::parseText/MessageCache::parse with no title set.
 			return call_user_func_array( 'wfMessage', $arguments )->inLanguage( $language )->title( $GLOBALS['wgTitle'] )->parse();
@@ -203,15 +203,23 @@ final class Setup {
 	 * @see https://www.mediawiki.org/wiki/Manual:$wgJobClasses
 	 */
 	private function registerJobClasses() {
-		$this->globalVars['wgJobClasses']['SMW\UpdateJob']  = 'SMW\MediaWiki\Jobs\UpdateJob';
-		$this->globalVars['wgJobClasses']['SMW\RefreshJob'] = 'SMW\MediaWiki\Jobs\RefreshJob';
-		$this->globalVars['wgJobClasses']['SMW\UpdateDispatcherJob'] = 'SMW\MediaWiki\Jobs\UpdateDispatcherJob';
-		$this->globalVars['wgJobClasses']['SMW\ParserCachePurgeJob'] = 'SMW\MediaWiki\Jobs\ParserCachePurgeJob';
-		$this->globalVars['wgJobClasses']['SMW\SearchTableUpdateJob'] = 'SMW\MediaWiki\Jobs\SearchTableUpdateJob';
 
-		// Legacy definition to be removed with 1.10
-		$this->globalVars['wgJobClasses']['SMWUpdateJob']  = 'SMW\MediaWiki\Jobs\UpdateJob';
-		$this->globalVars['wgJobClasses']['SMWRefreshJob'] = 'SMW\MediaWiki\Jobs\RefreshJob';
+		$jobClasses = array(
+			'SMW\UpdateJob' => 'SMW\MediaWiki\Jobs\UpdateJob',
+			'SMW\RefreshJob' => 'SMW\MediaWiki\Jobs\RefreshJob',
+			'SMW\UpdateDispatcherJob' => 'SMW\MediaWiki\Jobs\UpdateDispatcherJob',
+			'SMW\ParserCachePurgeJob' => 'SMW\MediaWiki\Jobs\ParserCachePurgeJob',
+			'SMW\SearchTableUpdateJob' => 'SMW\MediaWiki\Jobs\SearchTableUpdateJob',
+			'SMW\EntityIdDisposerJob' => 'SMW\MediaWiki\Jobs\EntityIdDisposerJob',
+
+			// Legacy definition to be removed with 1.10
+			'SMWUpdateJob'  => 'SMW\MediaWiki\Jobs\UpdateJob',
+			'SMWRefreshJob' => 'SMW\MediaWiki\Jobs\RefreshJob'
+		);
+
+		foreach ( $jobClasses as $job => $class ) {
+			$this->globalVars['wgJobClasses'][$job] = $class;
+		}
 	}
 
 	/**

--- a/includes/specials/SMW_SpecialSMWAdmin.php
+++ b/includes/specials/SMW_SpecialSMWAdmin.php
@@ -4,7 +4,6 @@ use SMW\ApplicationFactory;
 use SMW\MediaWiki\Jobs\RefreshJob;
 use SMW\MediaWiki\ManualEntryLogger;
 use SMW\Settings;
-use SMW\SQLStore\PropertyTableIdReferenceDisposer;
 use SMW\Store;
 use SMW\StoreFactory;
 
@@ -150,7 +149,7 @@ class SMWAdmin extends SpecialPage {
 		}
 
 		if ( $this->getRequest()->getText( 'action' ) === 'iddispose' ) {
-			$this->doIdDispose( (int)$this->getRequest()->getVal( 'id' ) );
+			$this->doDisposeById( (int)$this->getRequest()->getVal( 'id' ) );
 		}
 
 		$id = (int)$this->getRequest()->getText( 'id' );
@@ -342,17 +341,17 @@ class SMWAdmin extends SpecialPage {
 		} );
 	}
 
-	protected function doIdDispose( $id ) {
+	protected function doDisposeById( $id ) {
 
 		if ( $GLOBALS['wgRequest']->getText( 'dispose' ) !== 'yes' || $id < 1 ) {
 			return $id;
 		}
 
-		$propertyTableIdReferenceDisposer = new PropertyTableIdReferenceDisposer(
-			ApplicationFactory::getInstance()->getStore( '\SMW\SQLStore\SQLStore' )
+		$entityIdDisposerJob = ApplicationFactory::getInstance()->newJobFactory()->newEntityIdDisposerJob(
+			Title::newFromText( __METHOD__ )
 		);
 
-		$propertyTableIdReferenceDisposer->cleanupTableEntriesFor( $id );
+		$entityIdDisposerJob->executeWith( $id );
 
 		$manualEntryLogger = new ManualEntryLogger();
 		$manualEntryLogger->registerLoggableEventType( 'admin' );

--- a/maintenance/setupStore.php
+++ b/maintenance/setupStore.php
@@ -130,9 +130,6 @@ class SetupStore extends \Maintenance {
 
 		$store->drop( !$this->isQuiet() );
 
-		// TODO: this hook should be run on all calls to SMWStore::drop
-		\Hooks::run( 'smwDropTables' );
-
 		// be sure to have some buffer, otherwise some PHPs complain
 		while ( ob_get_level() > 0 ) {
 			ob_end_flush();

--- a/src/MediaWiki/Jobs/EntityIdDisposerJob.php
+++ b/src/MediaWiki/Jobs/EntityIdDisposerJob.php
@@ -1,0 +1,85 @@
+<?php
+
+namespace SMW\MediaWiki\Jobs;
+
+use Hooks;
+use SMW\ApplicationFactory;
+use SMW\SQLStore\PropertyTableIdReferenceDisposer;
+use Title;
+
+/**
+ * @license GNU GPL v2+
+ * @since 2.5
+ *
+ * @author mwjames
+ */
+class EntityIdDisposerJob extends JobBase {
+
+	/**
+	 * @var PropertyTableIdReferenceDisposer
+	 */
+	private $propertyTableIdReferenceDisposer;
+
+	/**
+	 * @since 2.5
+	 *
+	 * @param Title $title
+	 * @param array $params job parameters
+	 */
+	public function __construct( Title $title, $params = array() ) {
+		parent::__construct( 'SMW\EntityIdDisposerJob', $title, $params );
+
+		$this->propertyTableIdReferenceDisposer = new PropertyTableIdReferenceDisposer(
+			ApplicationFactory::getInstance()->getStore( '\SMW\SQLStore\SQLStore' )
+		);
+	}
+
+	/**
+	 * @since  2.5
+	 *
+	 * @return ResultIterator
+	 */
+	public function newOutdatedEntitiesResultIterator() {
+		return $this->propertyTableIdReferenceDisposer->newOutdatedEntitiesResultIterator();
+	}
+
+	/**
+	 * @since  2.5
+	 *
+	 * @param integer|stdClass $id
+	 */
+	public function executeWith( $id ) {
+
+		if ( is_int( $id ) ) {
+			return $this->propertyTableIdReferenceDisposer->cleanUpTableEntriesById( $id );
+		}
+
+		$this->propertyTableIdReferenceDisposer->cleanUpTableEntriesByRow( $id );
+	}
+
+	/**
+	 * @see Job::run
+	 *
+	 * @since  2.5
+	 */
+	public function run() {
+
+		if ( $this->hasParameter( 'id' ) ) {
+			$this->executeWith( $this->getParameter( 'id' ) );
+		} else {
+			$this->doDisposeMarkedEnitites();
+		}
+
+		return true;
+	}
+
+	private function doDisposeMarkedEnitites() {
+
+		$outdatedEntitiesResultIterator = $this->newOutdatedEntitiesResultIterator();
+
+		foreach ( $outdatedEntitiesResultIterator as $row ) {
+			$this->executeWith( $row );
+		}
+	}
+
+}

--- a/src/MediaWiki/Jobs/JobFactory.php
+++ b/src/MediaWiki/Jobs/JobFactory.php
@@ -60,4 +60,16 @@ class JobFactory {
 		return new SearchTableUpdateJob( $title, $parameters );
 	}
 
+	/**
+	 * @since 2.5
+	 *
+	 * @param Title $title
+	 * @param array $parameters
+	 *
+	 * @return EntityIdDisposerJob
+	 */
+	public function newEntityIdDisposerJob( Title $title, array $parameters = array() ) {
+		return new EntityIdDisposerJob( $title, $parameters );
+	}
+
 }

--- a/src/SQLStore/QueryEngine/Fulltext/TextByChangeUpdater.php
+++ b/src/SQLStore/QueryEngine/Fulltext/TextByChangeUpdater.php
@@ -113,11 +113,14 @@ class TextByChangeUpdater {
 	/**
 	 * @see SearchTableUpdateJob::run
 	 *
+	 * Parameters can be boolean in case of "Notice: unserialize(): Error at offset
+	 * 65504 of 65535 bytes in ... JobQueueDB.php on line 817"
+	 *
 	 * @since 2.5
 	 *
-	 * @param array $parameters
+	 * @param array|boolan $parameters
 	 */
-	public function pushUpdatesFromJobParameters( array $parameters ) {
+	public function pushUpdatesFromJobParameters( $parameters ) {
 
 		if ( !$this->searchTableUpdater->isEnabled() || !isset( $parameters['diff'] ) || $parameters['diff'] === false ) {
 			return;

--- a/tests/phpunit/Unit/MediaWiki/Jobs/EntityIdDisposerJobTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Jobs/EntityIdDisposerJobTest.php
@@ -1,0 +1,98 @@
+<?php
+
+namespace SMW\Tests\MediaWiki\Jobs;
+
+use SMW\Tests\TestEnvironment;
+use SMW\DIWikiPage;
+use SMW\MediaWiki\Jobs\EntityIdDisposerJob;
+
+/**
+ * @covers \SMW\MediaWiki\Jobs\EntityIdDisposerJob
+ * @group semantic-mediawiki
+ *
+ * @license GNU GPL v2+
+ * @since 2.5
+ *
+ * @author mwjames
+ */
+class EntityIdDisposerJobTest extends \PHPUnit_Framework_TestCase {
+
+	private $testEnvironment;
+
+	protected function setUp() {
+		parent::setUp();
+
+		$this->testEnvironment = new TestEnvironment();
+
+		$connection = $this->getMockBuilder( '\SMW\MediaWiki\Database' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$connection->expects( $this->any() )
+			->method( 'select' )
+			->will( $this->returnValue( array( 'Foo' ) ) );
+
+		$store = $this->getMockBuilder( '\SMW\SQLStore\SQLStore' )
+			->getMockForAbstractClass();
+
+		$connectionManager = $this->getMockBuilder( '\SMW\ConnectionManager' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$connectionManager->expects( $this->any() )
+			->method( 'getConnection' )
+			->will( $this->returnValue( $connection ) );
+
+		$store->setConnectionManager( $connectionManager );
+
+		$this->testEnvironment->registerObject( 'Store', $store );
+	}
+
+	protected function tearDown() {
+		$this->testEnvironment->tearDown();
+		parent::tearDown();
+	}
+
+	public function testCanConstruct() {
+
+		$title = $this->getMockBuilder( 'Title' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$this->assertInstanceOf(
+			'SMW\MediaWiki\Jobs\EntityIdDisposerJob',
+			new EntityIdDisposerJob( $title )
+		);
+	}
+
+	/**
+	 * @dataProvider parametersProvider
+	 */
+	public function testJobRun( $parameters ) {
+
+		$subject = DIWikiPage::newFromText( __METHOD__ );
+
+		$instance = new EntityIdDisposerJob(
+			$subject->getTitle(),
+			$parameters
+		);
+
+		$this->assertTrue(
+			$instance->run()
+		);
+	}
+
+	public function parametersProvider() {
+
+		$provider[] = array(
+			array()
+		);
+
+		$provider[] = array(
+			array( 'id' => 42 )
+		);
+
+		return $provider;
+	}
+
+}

--- a/tests/phpunit/Unit/MediaWiki/Jobs/JobFactoryTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Jobs/JobFactoryTest.php
@@ -64,4 +64,14 @@ class JobFactoryTest extends \PHPUnit_Framework_TestCase {
 		);
 	}
 
+	public function testCanConstructEntityIdDisposerJob() {
+
+		$instance = new JobFactory();
+
+		$this->assertInstanceOf(
+			'\SMW\MediaWiki\Jobs\EntityIdDisposerJob',
+			$instance->newEntityIdDisposerJob( Title::newFromText( __METHOD__ ) )
+		);
+	}
+
 }

--- a/tests/phpunit/Unit/SQLStore/PropertyTableIdReferenceDisposerTest.php
+++ b/tests/phpunit/Unit/SQLStore/PropertyTableIdReferenceDisposerTest.php
@@ -36,7 +36,6 @@ class PropertyTableIdReferenceDisposerTest extends \PHPUnit_Framework_TestCase {
 		$this->store->expects( $this->any() )
 			->method( 'getObjectIds' )
 			->will( $this->returnValue( $idTable ) );
-
 	}
 
 	public function testCanConstruct() {
@@ -106,7 +105,7 @@ class PropertyTableIdReferenceDisposerTest extends \PHPUnit_Framework_TestCase {
 			->method( 'selectRow' )
 			->will( $this->returnValue( false ) );
 
-		$connection->expects( $this->at( 2 ) )
+		$connection->expects( $this->at( 3 ) )
 			->method( 'delete' )
 			->with( $this->equalTo( \SMW\SQLStore\SQLStore::ID_TABLE ) );
 
@@ -123,6 +122,57 @@ class PropertyTableIdReferenceDisposerTest extends \PHPUnit_Framework_TestCase {
 		);
 
 		$instance->cleanUpTableEntriesById( 42 );
+	}
+
+	public function testCanConstructOutdatedEntitiesResultIterator() {
+
+		$connection = $this->getMockBuilder( '\SMW\MediaWiki\Database' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$connection->expects( $this->atLeastOnce() )
+			->method( 'select' )
+			->will( $this->returnValue( array() ) );
+
+		$this->store->expects( $this->any() )
+			->method( 'getConnection' )
+			->will( $this->returnValue( $connection ) );
+
+		$instance = new PropertyTableIdReferenceDisposer(
+			$this->store
+		);
+
+		$this->assertInstanceOf(
+			'\SMW\Iterators\ResultIterator',
+			$instance->newOutdatedEntitiesResultIterator()
+		);
+	}
+
+	public function testcCleanUpTableEntriesByRow() {
+
+		$row = new \stdClass;
+		$row->smw_id = 42;
+
+		$connection = $this->getMockBuilder( '\SMW\MediaWiki\Database' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$connection->expects( $this->atLeastOnce() )
+			->method( 'delete' );
+
+		$this->store->expects( $this->any() )
+			->method( 'getConnection' )
+			->will( $this->returnValue( $connection ) );
+
+		$this->store->expects( $this->any() )
+			->method( 'getPropertyTables' )
+			->will( $this->returnValue( array() ) );
+
+		$instance = new PropertyTableIdReferenceDisposer(
+			$this->store
+		);
+
+		$instance->cleanUpTableEntriesByRow( $row );
 	}
 
 }

--- a/tests/phpunit/Utils/Runners/MaintenanceRunner.php
+++ b/tests/phpunit/Utils/Runners/MaintenanceRunner.php
@@ -4,6 +4,7 @@ namespace SMW\Tests\Utils\Runners;
 
 use DomainException;
 use RuntimeException;
+use SMW\ApplicationFactory;
 
 /**
  * Running maintenance scripts via phpunit is not really possible but instead
@@ -71,6 +72,8 @@ class MaintenanceRunner {
 			throw new RuntimeException( "Expected a valid {$this->maintenanceClass} class" );
 		}
 
+		// Avoid outdated reference to invoked store instance
+		ApplicationFactory::getInstance()->clear();
 		$maintenance = new $this->maintenanceClass;
 
 		if ( !( $maintenance instanceof \Maintenance ) ) {

--- a/tests/phpunit/includes/SetupTest.php
+++ b/tests/phpunit/includes/SetupTest.php
@@ -244,6 +244,8 @@ class SetupTest extends \PHPUnit_Framework_TestCase {
 			'SMW\RefreshJob',
 			'SMW\UpdateDispatcherJob',
 			'SMW\ParserCachePurgeJob',
+			'SMW\SearchTableUpdateJob',
+			'SMW\EntityIdDisposerJob',
 
 			// Legacy
 			'SMWUpdateJob',


### PR DESCRIPTION
This PR is made in reference to: #1931, #1216

This PR addresses or contains:

- During ID disposal operations, avoid any `Title` object interaction that may cause #1931.

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed

