### PR TITLE
PropertyValueFormatter improve label output

### DIFF
--- a/includes/articlepages/SMW_PropertyPage.php
+++ b/includes/articlepages/SMW_PropertyPage.php
@@ -7,6 +7,7 @@ use SMW\RequestOptions;
 use SMW\StringCondition;
 use SMW\PropertyRegistry;
 use SMWDataValue as DataValue;
+use SMW\DataValues\ValueFormatters\DataValueFormatter;
 use SMW\DIProperty;
 
 /**
@@ -44,15 +45,12 @@ class SMWPropertyPage extends SMWOrderedListPage {
 			return '';
 		}
 
-		$label = ApplicationFactory::getInstance()->getPropertySpecificationLookup()->getFormattedPropertyLabelFrom(
-			$this->propertyValue->getDataItem()
+		$dv = DataValueFactory::getInstance()->newDataValueByItem(
+			$this->mProperty
 		);
 
-		if ( $this->mTitle->getText() !== $label ) {
-			$this->getContext()->getOutput()->setPageTitle(
-				Localizer::getInstance()->createTextWithNamespacePrefix( SMW_NS_PROPERTY, $label )
-			);
-		}
+		$title = $dv->getFormattedLabel( DataValueFormatter::WIKI_LONG );
+		$this->getContext()->getOutput()->setPageTitle( $title );
 
 		$list = $this->getSubpropertyList() . $this->getPropertyValueList();
 		$result = ( $list !== '' ? Html::element( 'div', array( 'id' => 'smwfootbr' ) ) . $list : '' );
@@ -73,10 +71,11 @@ class SMWPropertyPage extends SMWOrderedListPage {
 	 */
 	protected function getIntroductoryText() {
 
-		$propertyName = ApplicationFactory::getInstance()->getPropertySpecificationLookup()->getFormattedPropertyLabelFrom(
-			$this->propertyValue->getDataItem()
+		$dv = DataValueFactory::getInstance()->newDataValueByItem(
+			$this->mProperty
 		);
 
+		$propertyName = $dv->getFormattedLabel();
 		$message = '';
 
 		if ( $this->mProperty->isUserDefined() ) {

--- a/includes/articlepages/SMW_PropertyPage.php
+++ b/includes/articlepages/SMW_PropertyPage.php
@@ -44,9 +44,13 @@ class SMWPropertyPage extends SMWOrderedListPage {
 			return '';
 		}
 
-		if ( $this->propertyValue->getDataItem()->getPreferredLabel() !== '' && $this->mTitle->getText() !== $this->propertyValue->getDataItem()->getPreferredLabel() ) {
+		$label = ApplicationFactory::getInstance()->getPropertySpecificationLookup()->getFormattedPropertyLabelFrom(
+			$this->propertyValue->getDataItem()
+		);
+
+		if ( $this->mTitle->getText() !== $label ) {
 			$this->getContext()->getOutput()->setPageTitle(
-				wfMessage( 'smw-property-preferred-title-format', $this->mTitle->getPrefixedText(), $this->propertyValue->getWikiValue() )->text()
+				Localizer::getInstance()->createTextWithNamespacePrefix( SMW_NS_PROPERTY, $label )
 			);
 		}
 
@@ -68,7 +72,11 @@ class SMWPropertyPage extends SMWOrderedListPage {
 	 * @return string
 	 */
 	protected function getIntroductoryText() {
-		$propertyName = htmlspecialchars( $this->mTitle->getText() );
+
+		$propertyName = ApplicationFactory::getInstance()->getPropertySpecificationLookup()->getFormattedPropertyLabelFrom(
+			$this->propertyValue->getDataItem()
+		);
+
 		$message = '';
 
 		if ( $this->mProperty->isUserDefined() ) {

--- a/includes/datavalues/SMW_DV_Property.php
+++ b/includes/datavalues/SMW_DV_Property.php
@@ -39,6 +39,11 @@ class SMWPropertyValue extends SMWDataValue {
 	const OPT_NO_HIGHLIGHT = 'no.highlight';
 
 	/**
+	 * Avoid the display of a preferred label marker
+	 */
+	const OPT_NO_PREF_LHNT = 'no.preflabel.marker';
+
+	/**
 	 * Cache for wiki page value object associated to this property, or
 	 * null if no such page exists. Use getWikiPageValue() to get the data.
 	 * @var SMWWikiPageValue

--- a/includes/datavalues/SMW_DV_Property.php
+++ b/includes/datavalues/SMW_DV_Property.php
@@ -44,6 +44,11 @@ class SMWPropertyValue extends SMWDataValue {
 	const OPT_NO_PREF_LHNT = 'no.preflabel.marker';
 
 	/**
+	 * Special formatting of the label/preferred label
+	 */
+	const FORMAT_LABEL = 'format.label';
+
+	/**
 	 * Cache for wiki page value object associated to this property, or
 	 * null if no such page exists. Use getWikiPageValue() to get the data.
 	 * @var SMWWikiPageValue
@@ -344,6 +349,27 @@ class SMWPropertyValue extends SMWDataValue {
 	 */
 	public function getWikiValue() {
 		return $this->getDataValueFormatter()->format( DataValueFormatter::VALUE );
+	}
+
+	/**
+	 * Outputs a formatted property label that takes into account preferred/
+	 * canonical label characteristics
+	 *
+	 * @param integer|string $format
+	 * @param Linker|null $linker
+	 *
+	 * @return string
+	 */
+	public function getFormattedLabel( $format = DataValueFormatter::VALUE, $linker = null ) {
+
+		$dataValueFormatter = $this->getDataValueFormatter();
+
+		$dataValueFormatter->setOption(
+			self::FORMAT_LABEL,
+			$format
+		);
+
+		return $dataValueFormatter->format( self::FORMAT_LABEL, $linker );
 	}
 
 	/**

--- a/src/ApplicationFactory.php
+++ b/src/ApplicationFactory.php
@@ -331,8 +331,8 @@ class ApplicationFactory {
 	 *
 	 * @return PropertyLabelFinder
 	 */
-	public function newPropertyLabelFinder() {
-		return $this->callbackLoader->create( 'PropertyLabelFinder' );
+	public function getPropertyLabelFinder() {
+		return $this->callbackLoader->singleton( 'PropertyLabelFinder' );
 	}
 
 	/**

--- a/src/CachedPropertyValuesPrefetcher.php
+++ b/src/CachedPropertyValuesPrefetcher.php
@@ -28,7 +28,7 @@ class CachedPropertyValuesPrefetcher {
 	/**
 	 * @var string
 	 */
-	const VERSION = '0.4';
+	const VERSION = '0.4.1';
 
 	/**
 	 * @var Store

--- a/src/Localizer.php
+++ b/src/Localizer.php
@@ -241,6 +241,18 @@ class Localizer {
 	 * @since 2.5
 	 *
 	 * @param integer $index
+	 * @param string $text
+	 *
+	 * @return string
+	 */
+	public function createTextWithNamespacePrefix( $index, $text ) {
+		return $this->getNamespaceTextById( $index ) . ':' . $text;
+	}
+
+	/**
+	 * @since 2.5
+	 *
+	 * @param integer $ns
 	 * @param string $url
 	 *
 	 * @return string

--- a/src/MediaWiki/Api/PropertyListByApiRequest.php
+++ b/src/MediaWiki/Api/PropertyListByApiRequest.php
@@ -284,7 +284,7 @@ class PropertyListByApiRequest {
 
 	private function matchPropertiesToPreferredLabelBy( $label ) {
 
-		$propertyLabelFinder = ApplicationFactory::getInstance()->newPropertyLabelFinder();
+		$propertyLabelFinder = ApplicationFactory::getInstance()->getPropertyLabelFinder();
 
 		// Use the proximity search on a text field
 		$label = '~*' . $label . '*';

--- a/src/MediaWiki/Specials/Browse/HtmlContentBuilder.php
+++ b/src/MediaWiki/Specials/Browse/HtmlContentBuilder.php
@@ -11,6 +11,7 @@ use SMW\DIWikiPage;
 use SMW\Store;
 use Html;
 use SMWDataValue as DataValue;
+use SMW\DataValues\ValueFormatters\DataValueFormatter;
 use SMW\RequestOptions;
 
 /**
@@ -394,13 +395,11 @@ class HtmlContentBuilder {
 		if ( $this->subject->getDataItem()->getNamespace() === SMW_NS_PROPERTY ) {
 			$caption = '';
 
-			$label = ApplicationFactory::getInstance()->getPropertySpecificationLookup()->getFormattedPropertyLabelFrom(
+			$dv = DataValueFactory::getInstance()->newDataValueByItem(
 				DIProperty::newFromUserLabel( $this->subject->getDataItem()->getDBKey() )
 			);
 
-			$this->subject->setCaption(
-				Localizer::getInstance()->createTextWithNamespacePrefix( SMW_NS_PROPERTY, $label )
-			);
+			$this->subject->setCaption( $dv->getFormattedLabel( DataValueFormatter::WIKI_LONG ) );
 		}
 
 		$html = "<table class=\"smwb-factbox\" cellpadding=\"0\" cellspacing=\"0\">\n" .

--- a/src/MediaWiki/Specials/Browse/HtmlContentBuilder.php
+++ b/src/MediaWiki/Specials/Browse/HtmlContentBuilder.php
@@ -392,16 +392,15 @@ class HtmlContentBuilder {
 	private function displayHead() {
 
 		if ( $this->subject->getDataItem()->getNamespace() === SMW_NS_PROPERTY ) {
-			$property = \SMWDIProperty::newFromUserLabel( $this->subject->getDataItem()->getDBKey() );
 			$caption = '';
 
-			$title = $property->getCanonicalDiWikiPage()->getTitle();
+			$label = ApplicationFactory::getInstance()->getPropertySpecificationLookup()->getFormattedPropertyLabelFrom(
+				DIProperty::newFromUserLabel( $this->subject->getDataItem()->getDBKey() )
+			);
 
-			if ( ( $preferredLabel = $property->getPreferredLabel() ) !== '' && $title->getText() !== $preferredLabel ) {
-				$caption = wfMessage( 'smw-property-preferred-title-format', $title->getPrefixedText(), $preferredLabel )->text();
-			}
-
-			$this->subject->setCaption( $caption );
+			$this->subject->setCaption(
+				Localizer::getInstance()->createTextWithNamespacePrefix( SMW_NS_PROPERTY, $label )
+			);
 		}
 
 		$html = "<table class=\"smwb-factbox\" cellpadding=\"0\" cellspacing=\"0\">\n" .

--- a/src/PropertyLabelFinder.php
+++ b/src/PropertyLabelFinder.php
@@ -134,16 +134,11 @@ class PropertyLabelFinder {
 
 		// Lookup is cached in PropertySpecificationLookup
 		$propertySpecificationLookup = ApplicationFactory::getInstance()->getPropertySpecificationLookup();
-		$propertySpecificationLookup->setLanguageCode( $languageCode );
 
-		$preferredPropertyLabel = $propertySpecificationLookup->getPreferredPropertyLabelBy( $id );
-
-		// In case someone tried a preferred label on a predefined property like
-		// _MDAT => '[[Has preferred property label::Foo@en]]' but ensure to find
-		// a "standard" via extraneousLanguage
-		if ( $id{0} === '_' && $preferredPropertyLabel === '' ) {
-			$preferredPropertyLabel = $this->findPropertyLabelByLanguageCode( $id, $languageCode );
-		}
+		$preferredPropertyLabel = $propertySpecificationLookup->getPreferredPropertyLabelBy(
+			$id,
+			$languageCode
+		);
 
 		return $preferredPropertyLabel;
 	}

--- a/src/PropertyRegistry.php
+++ b/src/PropertyRegistry.php
@@ -63,7 +63,7 @@ class PropertyRegistry {
 			return self::$instance;
 		}
 
-		$propertyLabelFinder = ApplicationFactory::getInstance()->newPropertyLabelFinder();
+		$propertyLabelFinder = ApplicationFactory::getInstance()->getPropertyLabelFinder();
 		$extraneousLanguage = Localizer::getInstance()->getExtraneousLanguage();
 
 		$propertyAliasFinder = new PropertyAliasFinder(

--- a/src/PropertySpecificationLookup.php
+++ b/src/PropertySpecificationLookup.php
@@ -75,27 +75,6 @@ class PropertySpecificationLookup {
 	/**
 	 * @since 2.5
 	 *
-	 * @param DIProperty $property
-	 * @param string $languageCode
-	 *
-	 * @return string
-	 */
-	public function getFormattedPropertyLabelFrom( DIProperty $property, $languageCode = '' ) {
-
-		if ( ( $label = $property->getPreferredLabel( $languageCode ) ) === '' ) {
-			$label = $property->getLabel();
-		}
-
-		if ( $property->getCanonicalLabel() !== $label ) {
-			$label = Message::get( array( 'smw-property-preferred-title-format', $label, $property->getCanonicalLabel() ) );
-		}
-
-		return $label;
-	}
-
-	/**
-	 * @since 2.5
-	 *
 	 * @param string $id
 	 * @param string $languageCode
 	 *
@@ -386,8 +365,14 @@ class PropertySpecificationLookup {
 			return $description;
 		}
 
+		$dataValue = DataValueFactory::getInstance()->newDataValueByItem(
+			$property
+		);
+
+		$label = $dataValue->getFormattedLabel();
+
 		$message = Message::get(
-			array( $msgKey, $this->getFormattedPropertyLabelFrom( $property ) ),
+			array( $msgKey, $label ),
 			$linker === null ? Message::ESCAPED : Message::PARSE,
 			$languageCode
 		);

--- a/src/Query/PrintRequest/Serializer.php
+++ b/src/Query/PrintRequest/Serializer.php
@@ -99,10 +99,16 @@ class Serializer {
 				}
 			} else {
 
-				$printname = $printRequest->getData()->getDataItem()->getCanonicalLabel();
+				$printname = $data->getDataItem()->getCanonicalLabel();
 
 				if ( $label === $data->getDataItem()->getPreferredLabel() ) {
 					$label = $printname;
+				}
+
+				// Don't carry a localized label for a predefined property
+				// (fetched via the wikiValue)
+				if ( !$data->getDataItem()->isUserDefined() && $label === $data->getWikiValue() ) {
+					$label = $data->getDataItem()->getCanonicalLabel();
 				}
 			}
 		}
@@ -113,7 +119,7 @@ class Serializer {
 			$result .= '#' . $printRequest->getOutputFormat();
 		}
 
-		if ( $printname != $label ) {
+		if ( $printname != $label && $label !== '' ) {
 			$result .= '=' . $label;
 		}
 

--- a/tests/phpunit/Integration/ByJsonScript/Fixtures/p-0436.json
+++ b/tests/phpunit/Integration/ByJsonScript/Fixtures/p-0436.json
@@ -87,16 +87,17 @@
 		},
 		{
 			"type": "parser",
-			"about": "#3 (en, different label)",
+			"about": "#3 (en, different label, does't contain a prefLabel marker)",
 			"subject": "Example/P0436/Q.4",
 			"expected-output": {
 				"to-contain": [
 					"<th class=\"with-a-different-Label\">",
 					"title=\"Property:P106\">with a different Label</a>",
-					"<div class=\"smwttcontent\">occupation of a person; see also field of work (Property:P101)</div></span>&#160;<span title=\"P106\"><sup>ᵖ</sup></span>"
+					"<div class=\"smwttcontent\">occupation of a person; see also field of work (Property:P101)</div></span>"
 				],
 				"not-contain": [
-					"<th class=\"occupation\">occupation</th>"
+					"<th class=\"occupation\">occupation</th>",
+					"&#160;<span title=\"P106\"><sup>ᵖ</sup></span>"
 				]
 			}
 		}

--- a/tests/phpunit/Integration/ByJsonScript/Fixtures/p-0438.json
+++ b/tests/phpunit/Integration/ByJsonScript/Fixtures/p-0438.json
@@ -1,0 +1,61 @@
+{
+	"description": "Test in-text annotation with preferred property label/DISPLAYTITLE on user/predefined properties (`wgContLang=es`, `wgLang=de`, `wgRestrictDisplayTitle=false`)",
+	"setup": [
+		{
+			"namespace": "SMW_NS_PROPERTY",
+			"name": "Modification date",
+			"contents": "[[Has preferred property label::prefLabel-123@de]]"
+		},
+		{
+			"namespace": "SMW_NS_PROPERTY",
+			"name": "Has query",
+			"contents": "{{DISPLAYTITLE:query-displaytitle}}"
+		},
+		{
+			"namespace": "SMW_NS_PROPERTY",
+			"name": "Has keyword",
+			"contents": "[[Has preferred property label::prefLabel-456@de]]"
+		},
+		{
+			"name": "Example/P0438/1",
+			"contents": "[[Category:P0438]] [[Has keyword::some keyword]]"
+		},
+		{
+			"name": "Example/P0438/2",
+			"contents": "[[Category:P0438]] [[Has keyword::another keyword]]"
+		},
+		{
+			"name": "Example/P0438/Q.1",
+			"contents": "{{#ask: [[Category:P0438]] |?Modification date |?Modification date=ModificationSomeLabel |?Has keyword |?Has keyword=KeywordCaption |?Has query |?Has query=QueryCaption |limit=1 }}"
+		}
+	],
+	"tests": [
+		{
+			"type": "parser",
+			"about": "#0 (combination of prefLabel, DISPLAYTITLE, local caption)",
+			"subject": "Example/P0438/Q.1",
+			"expected-output": {
+				"to-contain": [
+					"title=\"Property:Modification date\">prefLabel-123</a></span><div class=\"smwttcontent\">„prefLabel-123 (Modification date)“",
+					"title=\"Property:Modification date\">ModificationSomeLabel</a></span><div class=\"smwttcontent\">„prefLabel-123 (Modification date)“",
+					"&#160;<span title=\"Modification date\"><sup>ᵖ</sup></span>",
+					"title=\"Property:Has keyword\">prefLabel-456</a>&#160;<span title=\"Has keyword\"><sup>ᵖ</sup>",
+					"title=\"Property:Has keyword\">KeywordCaption</a>",
+					"title=\"Property:Has query\">query-displaytitle</a></span><div class=\"smwttcontent\">„query-displaytitle“",
+					"title=\"Property:Has query\">QueryCaption</a></span><div class=\"smwttcontent\">„query-displaytitle“",
+					"title=\"Especial:Ask/-5B-5BCategoría:P0438-5D-5D/-3FModification-20date/-3FModification-20date=ModificationSomeLabel/-3FHas-20keyword/-3FHas-20keyword=KeywordCaption/-3FHas-20query/-3FHas-20query=QueryCaption/mainlabel=/limit=1/offset=1/format=table\">"
+				]
+			}
+		}
+	],
+	"settings": {
+		"wgContLang": "es",
+		"wgLang": "de",
+		"wgRestrictDisplayTitle": false
+	},
+	"meta": {
+		"version": "2",
+		"is-incomplete": false,
+		"debug": false
+	}
+}

--- a/tests/phpunit/Unit/ApplicationFactoryTest.php
+++ b/tests/phpunit/Unit/ApplicationFactoryTest.php
@@ -249,7 +249,7 @@ class ApplicationFactoryTest extends \PHPUnit_Framework_TestCase {
 
 		$this->assertInstanceOf(
 			'\SMW\PropertyLabelFinder',
-			$this->applicationFactory->newPropertyLabelFinder()
+			$this->applicationFactory->getPropertyLabelFinder()
 		);
 	}
 

--- a/tests/phpunit/Unit/DataValues/ValueFormatters/PropertyValueFormatterTest.php
+++ b/tests/phpunit/Unit/DataValues/ValueFormatters/PropertyValueFormatterTest.php
@@ -55,7 +55,20 @@ class PropertyValueFormatterTest extends \PHPUnit_Framework_TestCase {
 		);
 	}
 
-	public function testWithCaptionOutput() {
+	public function testFormatWithInvalidFormat() {
+
+		$propertyValue = new PropertyValue();
+		$propertyValue->setDataItem( $this->dataItemFactory->newDIProperty( 'Foo' ) );
+
+		$instance = new PropertyValueFormatter( $propertyValue );
+
+		$this->assertEquals(
+			'',
+			$instance->format( 'Foo' )
+		);
+	}
+
+	public function testFormatWithCaptionOutput() {
 
 		$propertyValue = new PropertyValue();
 		$propertyValue->setDataItem( $this->dataItemFactory->newDIProperty( 'Foo' ) );
@@ -86,6 +99,7 @@ class PropertyValueFormatterTest extends \PHPUnit_Framework_TestCase {
 		$propertyValue->setOption( PropertyValue::OPT_USER_LANGUAGE, 'en' );
 
 		$instance = new PropertyValueFormatter( $propertyValue );
+		$expected = $this->testEnvironment->getLocalizedTextByNamespace( SMW_NS_PROPERTY, $expected );
 
 		$this->assertEquals(
 			$expected,
@@ -102,6 +116,14 @@ class PropertyValueFormatterTest extends \PHPUnit_Framework_TestCase {
 		// PropertyRegistry instance
 		\SMW\PropertyRegistry::clear();
 
+		$this->propertyLabelFinder = $this->getMockBuilder( '\SMW\PropertyLabelFinder' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$this->propertyLabelFinder->expects( $this->any() )
+			->method( 'findPropertyListByLabelAndLanguageCode' )
+			->will( $this->returnValue( array() ) );
+
 		$this->propertyLabelFinder->expects( $this->any() )
 			->method( 'findPreferredPropertyLabelByLanguageCode' )
 			->will( $this->returnValue( $preferredLabel ) );
@@ -109,6 +131,8 @@ class PropertyValueFormatterTest extends \PHPUnit_Framework_TestCase {
 		$this->propertyLabelFinder->expects( $this->any() )
 			->method( 'searchPropertyIdByLabel' )
 			->will( $this->returnValue( false ) );
+
+		$this->testEnvironment->registerObject( 'PropertyLabelFinder', $this->propertyLabelFinder );
 
 		$propertyValue = new PropertyValue();
 
@@ -119,6 +143,7 @@ class PropertyValueFormatterTest extends \PHPUnit_Framework_TestCase {
 		$propertyValue->setUserValue( $property );
 
 		$instance = new PropertyValueFormatter( $propertyValue );
+		$expected = $this->testEnvironment->getLocalizedTextByNamespace( SMW_NS_PROPERTY, $expected );
 
 		$this->assertEquals(
 			$expected,

--- a/tests/phpunit/Unit/DataValues/ValueFormatters/PropertyValueFormatterTest.php
+++ b/tests/phpunit/Unit/DataValues/ValueFormatters/PropertyValueFormatterTest.php
@@ -153,6 +153,27 @@ class PropertyValueFormatterTest extends \PHPUnit_Framework_TestCase {
 		\SMW\PropertyRegistry::clear();
 	}
 
+	/**
+	 * @dataProvider formattedLabelProvider
+	 */
+	public function testFormattedLabelLabel( $property, $linker, $expected ) {
+
+		$propertyValue = new PropertyValue();
+
+		$propertyValue->setOption( PropertyValue::OPT_CONTENT_LANGUAGE, 'en' );
+		$propertyValue->setOption( PropertyValue::OPT_USER_LANGUAGE, 'en' );
+
+		$propertyValue->setDataItem( $property );
+
+		$instance = new PropertyValueFormatter( $propertyValue );
+		$expected = $this->testEnvironment->getLocalizedTextByNamespace( SMW_NS_PROPERTY, $expected );
+
+		$this->assertEquals(
+			$expected,
+			$instance->format( PropertyValue::FORMAT_LABEL, $linker )
+		);
+	}
+
 	public function testTryToFormatOnMissingDataValueThrowsException() {
 
 		$instance = new PropertyValueFormatter();
@@ -246,6 +267,37 @@ class PropertyValueFormatterTest extends \PHPUnit_Framework_TestCase {
 			PropertyValueFormatter::HTML_LONG,
 			null,
 			'Property:Foo&nbsp;<span title="Foo"><sup>ᵖ</sup></span>'
+		);
+
+		return $provider;
+	}
+
+	public function formattedLabelProvider() {
+
+		$property = $this->getMockBuilder( '\SMW\DIProperty' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$property->expects( $this->any() )
+			->method( 'getDIType' )
+			->will( $this->returnValue( \SMWDataItem::TYPE_PROPERTY ) );
+
+		$property->expects( $this->any() )
+			->method( 'getPreferredLabel' )
+			->will( $this->returnValue( 'Bar' ) );
+
+		$property->expects( $this->any() )
+			->method( 'getLabel' )
+			->will( $this->returnValue( 'Foo' ) );
+
+		$property->expects( $this->any() )
+			->method( 'getCanonicalLabel' )
+			->will( $this->returnValue( 'Foo' ) );
+
+		$provider[] = array(
+			$property,
+			null,
+			' (Foo)'
 		);
 
 		return $provider;

--- a/tests/phpunit/Unit/LocalizerTest.php
+++ b/tests/phpunit/Unit/LocalizerTest.php
@@ -268,6 +268,16 @@ class LocalizerTest extends \PHPUnit_Framework_TestCase {
 		);
 	}
 
+	public function testCreateTextWithNamespacePrefix() {
+
+		$instance = new Localizer( Language::factory( 'en') );
+
+		$this->assertEquals(
+			'Property:foo bar',
+			$instance->createTextWithNamespacePrefix( SMW_NS_PROPERTY, 'foo bar' )
+		);
+	}
+
 	public function testGetCanonicalizedUrlByNamespace() {
 
 		$language = $this->getMockBuilder( '\Language' )

--- a/tests/phpunit/Unit/PropertyLabelFinderTest.php
+++ b/tests/phpunit/Unit/PropertyLabelFinderTest.php
@@ -168,10 +168,6 @@ class PropertyLabelFinderTest extends \PHPUnit_Framework_TestCase {
 			->with( $this->equalTo( 'Foo' ) )
 			->will( $this->returnValue( 'ABC' ) );
 
-		$this->propertySpecificationLookup->expects( $this->once() )
-			->method( 'setLanguageCode' )
-			->with( $this->equalTo( 'fr' ) );
-
 		$instance = new PropertyLabelFinder(
 			$this->store
 		);

--- a/tests/phpunit/Unit/PropertySpecificationLookupTest.php
+++ b/tests/phpunit/Unit/PropertySpecificationLookupTest.php
@@ -319,4 +319,19 @@ class PropertySpecificationLookupTest extends \PHPUnit_Framework_TestCase {
 		);
 	}
 
+	public function testGetFormattedPropertyLabelFrom() {
+
+		$property = $this->dataItemFactory->newDIProperty( 'Foo' );
+
+		$instance = new PropertySpecificationLookup(
+			$this->cachedPropertyValuesPrefetcher,
+			$this->intermediaryMemoryCache
+		);
+
+		$this->assertInternalType(
+			'string',
+			$instance->getFormattedPropertyLabelFrom( $property )
+		);
+	}
+
 }

--- a/tests/phpunit/Unit/PropertySpecificationLookupTest.php
+++ b/tests/phpunit/Unit/PropertySpecificationLookupTest.php
@@ -319,19 +319,4 @@ class PropertySpecificationLookupTest extends \PHPUnit_Framework_TestCase {
 		);
 	}
 
-	public function testGetFormattedPropertyLabelFrom() {
-
-		$property = $this->dataItemFactory->newDIProperty( 'Foo' );
-
-		$instance = new PropertySpecificationLookup(
-			$this->cachedPropertyValuesPrefetcher,
-			$this->intermediaryMemoryCache
-		);
-
-		$this->assertInternalType(
-			'string',
-			$instance->getFormattedPropertyLabelFrom( $property )
-		);
-	}
-
 }

--- a/tests/phpunit/Unit/Query/PrintRequest/SerializerTest.php
+++ b/tests/phpunit/Unit/Query/PrintRequest/SerializerTest.php
@@ -84,6 +84,14 @@ class SerializerTest extends \PHPUnit_Framework_TestCase {
 			'?Bar#foobar=Foo|+index=2'
 		);
 
+		$data = DataValueFactory::getInstance()->newPropertyValueByLabel( 'Modification date' );
+
+		$provider['predefined-property'] = array(
+			new PrintRequest( PrintRequest::PRINT_PROP, '', $data ),
+			false,
+			'?Modification date#'
+		);
+
 		return $provider;
 	}
 

--- a/tests/phpunit/includes/parserhooks/ShowParserFunctionTest.php
+++ b/tests/phpunit/includes/parserhooks/ShowParserFunctionTest.php
@@ -203,7 +203,7 @@ class ShowParserFunctionTest extends \PHPUnit_Framework_TestCase {
 
 		$this->semanticDataValidator->assertThatPropertiesAreSet(
 			$expected,
-			$parserData->getSemanticData()->findSubSemanticData( '_QUERYc685f41368e6d9c59dfc9d8d69ef557f' )
+			$parserData->getSemanticData()->findSubSemanticData( '_QUERYda9bddddc9907eafb60792ca4bed3008' )
 		);
 
 		$expected = array(


### PR DESCRIPTION
This PR is made in reference to: #1865, #1879

This PR addresses or contains:

- Consolidate the label output formatting in `PropertyValueFormatter::getFormattedLabel` to provide consistency among all output anchors that require a `prefLabel`.

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed
