### PR TITLE
Add long text test containing ö/ä/ü/è/é

### DIFF
--- a/tests/phpunit/ByJsonTestCaseProvider.php
+++ b/tests/phpunit/ByJsonTestCaseProvider.php
@@ -219,7 +219,7 @@ abstract class ByJsonTestCaseProvider extends MwDBaseUnitTestCase {
 		);
 
 		if ( is_array( $page['contents'] ) && isset( $page['contents']['import-from'] ) ) {
-			$contents = file_get_contents( $this->getTestCaseLocation() . $page['contents']['import-from'] );
+			$contents = $this->getFileContentsWithEncodingDetection( $this->getTestCaseLocation() . $page['contents']['import-from'] );
 		} else {
 			$contents = $page['contents'];
 		}
@@ -253,6 +253,12 @@ abstract class ByJsonTestCaseProvider extends MwDBaseUnitTestCase {
 		);
 
 		$this->itemsMarkedForDeletion[] = $target;
+	}
+
+	// http://php.net/manual/en/function.file-get-contents.php
+	private function getFileContentsWithEncodingDetection( $file ) {
+		$content = file_get_contents( $file );
+		return mb_convert_encoding( $content, 'UTF-8', mb_detect_encoding( $content, 'UTF-8, ISO-8859-1, ISO-8859-2', true ) );
 	}
 
 }

--- a/tests/phpunit/Integration/ByJsonScript/Contents/p-0439.de.txt
+++ b/tests/phpunit/Integration/ByJsonScript/Contents/p-0439.de.txt
@@ -1,0 +1,11 @@
+@source http://www.gutenberg.org/files/34811/34811-h/34811-h.htm
+
+Title: Buddenbrooks - Verfall einer Familie
+
+Author: Thomas Mann
+
+Release Date: January 1, 2011 [EBook #34811]
+
+Language: German
+
+[[Has text::Und die kleine Antonie, achtjährig und zartgebaut, in einem Kleidchen aus ganz leichter changierender Seide, den hübschen Blondkopf ein wenig vom Gesichte des Großvaters abgewandt, blickte aus ihren graublauen Augen angestrengt nachdenkend und ohne etwas zu sehen ins Zimmer hinein, wiederholte noch einmal: »Was ist das«, sprach darauf langsam: »Ich glaube, daß mich Gott«, fügte, während ihr Gesicht sich aufklärte, rasch hinzu: »– geschaffen hat samt allen Kreaturen« ...]]

--- a/tests/phpunit/Integration/ByJsonScript/Contents/p-0439.fr.txt
+++ b/tests/phpunit/Integration/ByJsonScript/Contents/p-0439.fr.txt
@@ -1,0 +1,13 @@
+@source http://www.gutenberg.org/cache/epub/22768/pg22768-images.html
+
+Title: L'enfer (1 of 2) La Divine Comédie - Traduit par Rivarol
+
+Author: Dante Alighieri
+
+Translator: Antoine Rivarol (de)
+
+Release Date: September 26, 2007 [EBook #22768]
+
+Language: French
+
+[[Has text::Dès les premières heures de notre publication, nous avons annoncé le chef-d'oeuvre du poëte florentin comme devant figurer en première ligne parmi les joyaux de notre modeste écrin. Nous avons voulu, au début, donner accès à tous les ouvrages consacrés par le temps et par l'admiration universelle. Un succès constant pendant quatre longues et parfois difficiles années, nous a prouvé que nous nous étions très rarement trompé sur ...]]

--- a/tests/phpunit/Integration/ByJsonScript/Fixtures/p-0435.json
+++ b/tests/phpunit/Integration/ByJsonScript/Fixtures/p-0435.json
@@ -1,5 +1,5 @@
 {
-	"description": "Test in-text annotation using '_txt' type with 255+ char (`wgContLang=en`, `wgLang=en`)",
+	"description": "Test in-text annotation using '_txt' type with 255+ char (#1878, `wgContLang=en`, `wgLang=en`)",
 	"setup": [
 		{
 			"namespace": "SMW_NS_PROPERTY",

--- a/tests/phpunit/Integration/ByJsonScript/Fixtures/p-0436.json
+++ b/tests/phpunit/Integration/ByJsonScript/Fixtures/p-0436.json
@@ -1,5 +1,5 @@
 {
-	"description": "Test in-text annotation with preferred property label (`wgContLang=en`, `wgLang=en`)",
+	"description": "Test in-text annotation with preferred property label (#1879, `wgContLang=en`, `wgLang=en`)",
 	"setup": [
 		{
 			"namespace": "SMW_NS_PROPERTY",

--- a/tests/phpunit/Integration/ByJsonScript/Fixtures/p-0437.json
+++ b/tests/phpunit/Integration/ByJsonScript/Fixtures/p-0437.json
@@ -1,5 +1,5 @@
 {
-	"description": "Test in-text annotation with preferred property label (`wgContLang=en`, `wgLang=ja`)",
+	"description": "Test in-text annotation with preferred property label (#1879, `wgContLang=en`, `wgLang=ja`)",
 	"setup": [
 		{
 			"namespace": "SMW_NS_PROPERTY",

--- a/tests/phpunit/Integration/ByJsonScript/Fixtures/p-0439.json
+++ b/tests/phpunit/Integration/ByJsonScript/Fixtures/p-0439.json
@@ -1,0 +1,122 @@
+{
+	"description": "Test in-text annotation using '_txt'/'_wpg' type / UTF encoding (`wgContLang=en`, `wgLang=en`)",
+	"setup": [
+		{
+			"namespace": "SMW_NS_PROPERTY",
+			"name": "Has text",
+			"contents": "[[Has type::Text]]"
+		},
+		{
+			"namespace": "SMW_NS_PROPERTY",
+			"name": "Has page",
+			"contents": "[[Has type::Page]]"
+		},
+		{
+			"name": "Example/P0439/1",
+			"contents": "[[Has text::ö/ä/ü]]"
+		},
+		{
+			"name": "Example/P0439/2",
+			"contents": {
+				"import-from": "/../Contents/p-0439.de.txt"
+			}
+		},
+		{
+			"name": "Example/P0439/3",
+			"contents": {
+				"import-from": "/../Contents/p-0439.fr.txt"
+			}
+		},
+		{
+			"name": "Example/P0439/ö/ä/ü",
+			"contents": "[[Has page::Some ö/ä/ü]]"
+		},
+		{
+			"name": "Example/P0439/Q.1",
+			"contents": "{{#ask: [[Has text::ö/ä/ü]] |?Has text }}"
+		},
+		{
+			"name": "Example/P0439/Q.2",
+			"contents": "{{#ask: [[Example/P0439/2]] |?Has text }}"
+		},
+		{
+			"name": "Example/P0439/Q.3",
+			"contents": "{{#ask: [[Example/P0439/3]] |?Has text }}"
+		},
+		{
+			"name": "Example/P0439/Q.4",
+			"contents": "{{#ask: [[Has page::Some ö/ä/ü]] |?Has page }}"
+		}
+	],
+	"tests": [
+		{
+			"type": "parser",
+			"about": "#0",
+			"subject": "Example/P0439/1",
+			"store": {
+				"semantic-data": {
+					"strictPropertyValueMatch": false,
+					"propertyCount": 3,
+					"propertyKeys": [
+						"Has_text",
+						"_SKEY",
+						"_MDAT"
+					],
+					"propertyValues": [
+						"ö/ä/ü"
+					]
+				}
+			}
+		},
+		{
+			"type": "parser",
+			"about": "#1",
+			"subject": "Example/P0439/Q.1",
+			"expected-output": {
+				"to-contain": [
+					"<td class=\"Has-text smwtype_txt\">ö/ä/ü</td>"
+				]
+			}
+		},
+		{
+			"type": "parser",
+			"about": "#2 (long text, de)",
+			"subject": "Example/P0439/Q.2",
+			"expected-output": {
+				"to-contain": [
+					"fügte, während ihr Gesicht sich aufklärte"
+				]
+			}
+		},
+		{
+			"type": "parser",
+			"about": "#3 (long text, fr)",
+			"subject": "Example/P0439/Q.3",
+			"expected-output": {
+				"to-contain": [
+					"nous avons annoncé le chef-d'oeuvre du poëte"
+				]
+			}
+		},
+		{
+			"type": "parser",
+			"about": "#4",
+			"subject": "Example/P0439/Q.4",
+			"expected-output": {
+				"to-contain": [
+					"title=\"Example/P0439/ö/ä/ü\">Example/P0439/ö/ä/ü</a>",
+					"Some ö/ä/ü"
+				]
+			}
+		}
+	],
+	"settings": {
+		"wgContLang": "en",
+		"wgLang": "en"
+	},
+	"meta": {
+		"version": "2",
+		"is-incomplete": false,
+		"debug": false
+	}
+}


### PR DESCRIPTION
This PR is made in reference to: #1880

This PR addresses or contains:

- Tests long text with `ö/ä/ü/è/é` and made in response to [0].

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed

[0]http://wikimedia.7.x6.nabble.com/utf-encoding-problem-after-update-td5068366.html