### PR TITLE
Fix subobject selection for predefined properties, refs 1957

### DIFF
--- a/includes/dataitems/SMW_DI_WikiPage.php
+++ b/includes/dataitems/SMW_DI_WikiPage.php
@@ -56,6 +56,11 @@ class DIWikiPage extends SMWDataItem {
 	private $pageLanguage = null;
 
 	/**
+	 * @var integer
+	 */
+	private $id = 0;
+
+	/**
 	 * Contructor. We do not bother with too much detailed validation here,
 	 * regarding the known namespaces, canonicity of the dbkey (namespace
 	 * exrtacted?), validity of interwiki prefix (known?), and general use
@@ -168,6 +173,24 @@ class DIWikiPage extends SMWDataItem {
 		}
 
 		return $this->pageLanguage;
+	}
+
+	/**
+	 * @since  2.5
+	 *
+	 * @param integer $id
+	 */
+	public function setId( $id ) {
+		$this->id = (int)$id;
+	}
+
+	/**
+	 * @since 2.5
+	 *
+	 * @return string
+	 */
+	public function getId() {
+		return $this->id;
 	}
 
 	/**

--- a/src/SQLStore/EntityStore/EntitySubobjectListIterator.php
+++ b/src/SQLStore/EntityStore/EntitySubobjectListIterator.php
@@ -1,0 +1,126 @@
+<?php
+
+namespace SMW\SQLStore\EntityStore;
+
+use SMW\IteratorFactory;
+use SMW\DIProperty;
+use SMW\DIWikiPage;
+use SMWDataItem as DataItem;
+use SMW\SQLStore\SQLStore;
+use IteratorAggregate;
+use RuntimeException;
+
+/**
+ * @private
+ *
+ * @license GNU GPL v2+
+ * @since 2.5
+ *
+ * @author mwjames
+ */
+class EntitySubobjectListIterator implements IteratorAggregate {
+
+	/**
+	 * @var SQLStore
+	 */
+	private $store;
+
+	/**
+	 * @var IteratorFactory
+	 */
+	private $iteratorFactory;
+
+	/**
+	 * @var MappingIterator
+	 */
+	private $mappingIterator;
+
+	/**
+	 * @since 2.5
+	 *
+	 * @param SQLStore $store
+	 * @param IteratorFactory $iteratorFactory
+	 */
+	public function __construct( SQLStore $store, IteratorFactory $iteratorFactory ) {
+		$this->store = $store;
+		$this->iteratorFactory = $iteratorFactory;
+	}
+
+	/**
+	 * @see IteratorAggregate::getIterator
+	 *
+	 * @since 2.5
+	 *
+	 * @return Iterator
+	 */
+	public function getIterator() {
+
+		if ( $this->mappingIterator === null ) {
+			throw new RuntimeException( "MappingIterator is not initialized" );
+		}
+
+		return $this->mappingIterator;
+	}
+
+	/**
+	 * Fetch all subobjects for a given subject using a lazy-mapping iterator
+	 * in order to only resolve one subobject per iteration step.
+	 *
+	 * @since 2.5
+	 *
+	 * @param DIWikiPage $subject
+	 *
+	 * @return MappingIterator
+	 */
+	public function newMappingIterator( DIWikiPage $subject ) {
+
+		$diHandler = $this->store->getDataItemHandlerForDIType(
+			DataItem::TYPE_WIKIPAGE
+		);
+
+		$callback = function( $row ) use ( $subject, $diHandler ) {
+
+			$subobject = $diHandler->dataItemFromDBKeys( array(
+				$subject->getDBkey(),
+				$subject->getNamespace(),
+				$subject->getInterwiki(),
+				$row->smw_sortkey,
+				$row->smw_subobject
+			) );
+
+			$subobject->setId( $row->smw_id );
+
+			return $subobject;
+		};
+
+		return $this->mappingIterator = $this->iteratorFactory->newMappingIterator(
+			$this->newResultIterator( $subject ),
+			$callback
+		);
+	}
+
+	private function newResultIterator( DIWikiPage $subject ) {
+
+		$connection = $this->store->getConnection();
+		$dbKey = $subject->getDBkey();
+
+		// #1955 Ensure to match a possible predefined property
+		// (Modification date -> _MDAT)
+		if ( $subject->getNamespace() === SMW_NS_PROPERTY ) {
+			$dbKey = DIProperty::newFromUserLabel( $subject->getDBkey() )->getKey();
+		}
+
+		$res = $connection->select(
+			$connection->tablename( SQLStore::ID_TABLE ),
+			array( 'smw_id' , 'smw_subobject' , 'smw_sortkey' ),
+			'smw_title = ' . $connection->addQuotes( $dbKey ) . ' AND ' .
+			'smw_namespace = ' . $connection->addQuotes( $subject->getNamespace() ) . ' AND ' .
+			'smw_iw = ' . $connection->addQuotes( $subject->getInterwiki() ) . ' AND ' .
+			'smw_subobject != ' . $connection->addQuotes( '' ), // The "!=" is why we cannot use MW array syntax here
+			__METHOD__
+		);
+
+		return $this->iteratorFactory->newResultIterator( $res );
+	}
+
+}

--- a/tests/phpunit/Unit/SQLStore/EntityStore/EntitySubobjectListIteratorTest.php
+++ b/tests/phpunit/Unit/SQLStore/EntityStore/EntitySubobjectListIteratorTest.php
@@ -1,0 +1,168 @@
+<?php
+
+namespace SMW\Tests\SQLStore\EntityStore;
+
+use SMW\SQLStore\EntityStore\EntitySubobjectListIterator;
+use SMW\ApplicationFactory;
+use SMW\DIWikiPage;
+
+/**
+ * @covers \SMW\SQLStore\EntityStore\EntitySubobjectListIterator
+ * @group semantic-mediawiki
+ *
+ * @license GNU GPL v2+
+ * @since 2.5
+ *
+ * @author mwjames
+ */
+class EntitySubobjectListIteratorTest extends \PHPUnit_Framework_TestCase {
+
+	public function testCanConstruct() {
+
+		$store = $this->getMockBuilder( '\SMW\SQLStore\SQLStore' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$iteratorFactory = $this->getMockBuilder( '\SMW\IteratorFactory' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$this->assertInstanceOf(
+			'\SMW\SQLStore\EntityStore\EntitySubobjectListIterator',
+			new EntitySubobjectListIterator( $store, $iteratorFactory )
+		);
+	}
+
+	/**
+	 * @dataProvider subjectProvider
+	 */
+	public function testNewMappingIterator( $subject ) {
+
+		$dataItemHandler = $this->getMockBuilder( '\SMW\SQLStore\EntityStore\DataItemHandler' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$connection = $this->getMockBuilder( '\SMW\MediaWiki\Database' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$connection->expects( $this->atLeastOnce() )
+			->method( 'select' )
+			->will( $this->returnValue( array() ) );
+
+		$store = $this->getMockBuilder( '\SMW\SQLStore\SQLStore' )
+			->disableOriginalConstructor()
+			->setMethods( array( 'getConnection', 'getDataItemHandlerForDIType' ) )
+			->getMock();
+
+		$store->expects( $this->atLeastOnce() )
+			->method( 'getConnection' )
+			->will( $this->returnValue( $connection ) );
+
+		$store->expects( $this->atLeastOnce() )
+			->method( 'getDataItemHandlerForDIType' )
+			->will( $this->returnValue( $dataItemHandler ) );
+
+		$instance = new EntitySubobjectListIterator(
+			$store,
+			ApplicationFactory::getInstance()->getIteratorFactory()
+		);
+
+		$this->assertInstanceOf(
+			'\SMW\Iterators\MappingIterator',
+			$instance->newMappingIterator( $subject )
+		);
+	}
+
+	public function testIterateOn() {
+
+		$row = new \stdClass;
+		$row->smw_id = 42;
+		$row->smw_sortkey = 'sort';
+		$row->smw_subobject = '10000000001';
+
+		$expected = array(
+			'Foo', 0, '', 'sort', '10000000001'
+		);
+
+		$dataItemHandler = $this->getMockBuilder( '\SMW\SQLStore\EntityStore\DataItemHandler' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$dataItemHandler->expects( $this->atLeastOnce() )
+			->method( 'dataItemFromDBKeys' )
+			->with( $this->equalTo( $expected ) )
+			->will( $this->returnValue( DIWikiPage::newFromText( 'Foo' ) ) );
+
+		$connection = $this->getMockBuilder( '\SMW\MediaWiki\Database' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$connection->expects( $this->atLeastOnce() )
+			->method( 'select' )
+			->will( $this->returnValue( array( $row ) ) );
+
+		$store = $this->getMockBuilder( '\SMW\SQLStore\SQLStore' )
+			->disableOriginalConstructor()
+			->setMethods( array( 'getConnection', 'getDataItemHandlerForDIType' ) )
+			->getMock();
+
+		$store->expects( $this->atLeastOnce() )
+			->method( 'getConnection' )
+			->will( $this->returnValue( $connection ) );
+
+		$store->expects( $this->atLeastOnce() )
+			->method( 'getDataItemHandlerForDIType' )
+			->will( $this->returnValue( $dataItemHandler ) );
+
+		$instance = new EntitySubobjectListIterator(
+			$store,
+			ApplicationFactory::getInstance()->getIteratorFactory()
+		);
+
+		$instance->newMappingIterator(
+			DIWikiPage::newFromText( 'Foo' )
+		);
+
+		foreach ( $instance as $v ) {
+			$this->assertEquals( 42, $v->getId() );
+		}
+	}
+
+	public function testMissingIteratorInstanceThrowsExcetion() {
+
+		$store = $this->getMockBuilder( '\SMW\SQLStore\SQLStore' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$iteratorFactory = $this->getMockBuilder( '\SMW\IteratorFactory' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$instance = new EntitySubobjectListIterator(
+			$store,
+			$iteratorFactory
+		);
+
+		$this->setExpectedException( 'RuntimeException' );
+		foreach ( $instance as $v ) {}
+	}
+
+	public function subjectProvider() {
+
+		$provider[] = array(
+			DIWikiPage::newFromText( 'Foo' )
+		);
+
+		$provider[] = array(
+			DIWikiPage::newFromText( 'Bar', SMW_NS_PROPERTY )
+		);
+
+		$provider[] = array(
+			DIWikiPage::newFromText( 'Modification date', SMW_NS_PROPERTY )
+		);
+
+		return $provider;
+	}
+
+}


### PR DESCRIPTION
This PR is made in reference to: #1957

This PR addresses or contains:

- `EntitySubobjectListIterator` to isolate the selection process and return an iterator

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed

