### PR TITLE
ExtraneousLanguage / Extend the CanonicalPropertyLabels members, refs 1848

### DIFF
--- a/src/ExtraneousLanguage/ExtraneousLanguage.php
+++ b/src/ExtraneousLanguage/ExtraneousLanguage.php
@@ -286,6 +286,11 @@ class ExtraneousLanguage {
 			'propertyAliases'
 		);
 
+		$canonicalPropertyLabels += $this->languageContents->getFromLanguageWithIndex(
+			$this->languageContents->getCanonicalFallbackLanguageCode(),
+			'dataTypeAliases'
+		);
+
 		return $canonicalPropertyLabels;
 	}
 

--- a/tests/phpunit/Integration/ExtraneousLanguage/LanguageContentTest.php
+++ b/tests/phpunit/Integration/ExtraneousLanguage/LanguageContentTest.php
@@ -54,6 +54,23 @@ class LanguageContent extends \PHPUnit_Framework_TestCase {
 		);
 	}
 
+	/**
+	 * @dataProvider canonicalPropertyLabelsProvider
+	 */
+	public function testGetCanonicalPropertyLabels( $languageCode, $aliasMatch, $expected ) {
+
+		$extraneousLanguage = ExtraneousLanguage::getInstance()->fetchByLanguageCode(
+			$languageCode
+		);
+
+		$propertyLabels = $extraneousLanguage->getCanonicalPropertyLabels();
+
+		$this->assertEquals(
+			$expected,
+			$propertyLabels[$aliasMatch]
+		);
+	}
+
 	public function canonicalPropertyAliasesProvider() {
 
 		$provider[] = array(
@@ -61,6 +78,17 @@ class LanguageContent extends \PHPUnit_Framework_TestCase {
 			'Query size',
 			'Taille de la requête',
 			'_ASKSI'
+		);
+
+		return $provider;
+	}
+
+	public function canonicalPropertyLabelsProvider() {
+
+		$provider[] = array(
+			'fr',
+			'Boolean',
+			'_boo'
 		);
 
 		return $provider;


### PR DESCRIPTION
This PR is made in reference to: #1848

This PR addresses or contains:

This PR includes:
- [x] Tests (unit/integration)
- [ ] CI build passed
