### PR TITLE
QueryDependencyLinksStore / Improve resource usage in AfterQueryResultLookupComplete hook

### DIFF
--- a/src/CachedQueryResultPrefetcher.php
+++ b/src/CachedQueryResultPrefetcher.php
@@ -167,6 +167,9 @@ class CachedQueryResultPrefetcher implements QueryEngine, LoggerAwareInterface {
 
 		$queryResult = $this->queryEngine->getQueryResult( $query );
 
+		$time = round( ( microtime( true ) - $this->start ), 5 );
+		$this->log( __METHOD__ . ' from backend in (sec): ' . $time . " ($queryId)" );
+
 		if ( $this->isEnabled( $query ) && $queryResult instanceof QueryResult ) {
 			$this->addQueryResultToCache( $queryResult, $queryId, $container, $query );
 		}
@@ -214,7 +217,7 @@ class CachedQueryResultPrefetcher implements QueryEngine, LoggerAwareInterface {
 
 		$time = round( ( microtime( true ) - $this->start ), 5 );
 
-		$this->log( 'QueryResult from cache in (sec): ' . $time . " ($queryId) " );
+		$this->log( __METHOD__ . ' (sec): ' . $time . " ($queryId)" );
 
 		return $queryResult;
 	}
@@ -264,7 +267,7 @@ class CachedQueryResultPrefetcher implements QueryEngine, LoggerAwareInterface {
 			$container
 		);
 
-		$this->log( 'QueryResult from backend in (sec): ' . $time . " ($queryId) " . $hash );
+		$this->log( __METHOD__ . ' cache storage (sec): ' . $time . " ($queryId)" );
 
 		return $queryResult;
 	}

--- a/src/SQLStore/QueryDependencyLinksStoreFactory.php
+++ b/src/SQLStore/QueryDependencyLinksStoreFactory.php
@@ -20,33 +20,18 @@ use SMW\Store;
 class QueryDependencyLinksStoreFactory {
 
 	/**
-	 * @var $applicationFactory
-	 */
-	private $applicationFactory;
-
-	/**
 	 * @since 2.4
-	 */
-	public function __construct() {
-		$this->applicationFactory = ApplicationFactory::getInstance();
-	}
-
-	/**
-	 * @since 2.4
-	 *
-	 * @param QueryResult|string $queryResult
 	 *
 	 * @return QueryResultDependencyListResolver
 	 */
-	public function newQueryResultDependencyListResolver( $queryResult ) {
+	public function newQueryResultDependencyListResolver() {
 
 		$queryResultDependencyListResolver = new QueryResultDependencyListResolver(
-			$queryResult,
-			$this->applicationFactory->newPropertyHierarchyLookup()
+			ApplicationFactory::getInstance()->newPropertyHierarchyLookup()
 		);
 
 		$queryResultDependencyListResolver->setPropertyDependencyExemptionlist(
-			$this->applicationFactory->getSettings()->get( 'smwgQueryDependencyPropertyExemptionlist' )
+			ApplicationFactory::getInstance()->getSettings()->get( 'smwgQueryDependencyPropertyExemptionlist' )
 		);
 
 		return $queryResultDependencyListResolver;
@@ -62,12 +47,15 @@ class QueryDependencyLinksStoreFactory {
 	public function newQueryDependencyLinksStore( $store ) {
 
 		$queryDependencyLinksStore = new QueryDependencyLinksStore(
+			$this->newQueryResultDependencyListResolver(),
 			new DependencyLinksTableUpdater( $store )
 		);
 
 		$queryDependencyLinksStore->setEnabled(
-			$this->applicationFactory->getSettings()->get( 'smwgEnabledQueryDependencyLinksStore' )
+			ApplicationFactory::getInstance()->getSettings()->get( 'smwgEnabledQueryDependencyLinksStore' )
 		);
+
+		$queryDependencyLinksStore->isCommandLineMode( $GLOBALS['wgCommandLineMode'] );
 
 		return $queryDependencyLinksStore;
 	}
@@ -88,11 +76,11 @@ class QueryDependencyLinksStoreFactory {
 		);
 
 		$entityIdListRelevanceDetectionFilter->setPropertyExemptionlist(
-			$this->applicationFactory->getSettings()->get( 'smwgQueryDependencyPropertyExemptionlist' )
+			ApplicationFactory::getInstance()->getSettings()->get( 'smwgQueryDependencyPropertyExemptionlist' )
 		);
 
 		$entityIdListRelevanceDetectionFilter->setAffiliatePropertyDetectionlist(
-			$this->applicationFactory->getSettings()->get( 'smwgQueryDependencyAffiliatePropertyDetectionlist' )
+			ApplicationFactory::getInstance()->getSettings()->get( 'smwgQueryDependencyAffiliatePropertyDetectionlist' )
 		);
 
 		return $entityIdListRelevanceDetectionFilter;

--- a/tests/phpunit/Unit/SQLStore/QueryDependency/QueryDependencyLinksStoreTest.php
+++ b/tests/phpunit/Unit/SQLStore/QueryDependency/QueryDependencyLinksStoreTest.php
@@ -51,9 +51,13 @@ class QueryDependencyLinksStoreTest extends \PHPUnit_Framework_TestCase {
 			->method( 'getStore' )
 			->will( $this->returnValue( $this->store ) );
 
+		$queryResultDependencyListResolver = $this->getMockBuilder( '\SMW\SQLStore\QueryDependency\QueryResultDependencyListResolver' )
+			->disableOriginalConstructor()
+			->getMock();
+
 		$this->assertInstanceOf(
 			'\SMW\SQLStore\QueryDependency\QueryDependencyLinksStore',
-			new QueryDependencyLinksStore( $dependencyLinksTableUpdater )
+			new QueryDependencyLinksStore( $queryResultDependencyListResolver, $dependencyLinksTableUpdater )
 		);
 	}
 
@@ -89,7 +93,12 @@ class QueryDependencyLinksStoreTest extends \PHPUnit_Framework_TestCase {
 			->method( 'getStore' )
 			->will( $this->returnValue( $store ) );
 
+		$queryResultDependencyListResolver = $this->getMockBuilder( '\SMW\SQLStore\QueryDependency\QueryResultDependencyListResolver' )
+			->disableOriginalConstructor()
+			->getMock();
+
 		$instance = new QueryDependencyLinksStore(
+			$queryResultDependencyListResolver,
 			$dependencyLinksTableUpdater
 		);
 
@@ -126,7 +135,12 @@ class QueryDependencyLinksStoreTest extends \PHPUnit_Framework_TestCase {
 			->method( 'getStore' )
 			->will( $this->returnValue( $store ) );
 
+		$queryResultDependencyListResolver = $this->getMockBuilder( '\SMW\SQLStore\QueryDependency\QueryResultDependencyListResolver' )
+			->disableOriginalConstructor()
+			->getMock();
+
 		$instance = new QueryDependencyLinksStore(
+			$queryResultDependencyListResolver,
 			$dependencyLinksTableUpdater
 		);
 
@@ -159,7 +173,12 @@ class QueryDependencyLinksStoreTest extends \PHPUnit_Framework_TestCase {
 			->method( 'getFilteredIdList' )
 			->will( $this->returnValue( array( 1 ) ) );
 
+		$queryResultDependencyListResolver = $this->getMockBuilder( '\SMW\SQLStore\QueryDependency\QueryResultDependencyListResolver' )
+			->disableOriginalConstructor()
+			->getMock();
+
 		$instance = new QueryDependencyLinksStore(
+			$queryResultDependencyListResolver,
 			$dependencyLinksTableUpdater
 		);
 
@@ -187,7 +206,12 @@ class QueryDependencyLinksStoreTest extends \PHPUnit_Framework_TestCase {
 			->disableOriginalConstructor()
 			->getMock();
 
+		$queryResultDependencyListResolver = $this->getMockBuilder( '\SMW\SQLStore\QueryDependency\QueryResultDependencyListResolver' )
+			->disableOriginalConstructor()
+			->getMock();
+
 		$instance = new QueryDependencyLinksStore(
+			$queryResultDependencyListResolver,
 			$dependencyLinksTableUpdater
 		);
 
@@ -249,7 +273,12 @@ class QueryDependencyLinksStoreTest extends \PHPUnit_Framework_TestCase {
 			->method( 'getStore' )
 			->will( $this->returnValue( $store ) );
 
+		$queryResultDependencyListResolver = $this->getMockBuilder( '\SMW\SQLStore\QueryDependency\QueryResultDependencyListResolver' )
+			->disableOriginalConstructor()
+			->getMock();
+
 		$instance = new QueryDependencyLinksStore(
+			$queryResultDependencyListResolver,
 			$dependencyLinksTableUpdater
 		);
 
@@ -274,12 +303,6 @@ class QueryDependencyLinksStoreTest extends \PHPUnit_Framework_TestCase {
 			->method( 'getStore' )
 			->will( $this->returnValue( $store ) );
 
-		$instance = new QueryDependencyLinksStore(
-			$dependencyLinksTableUpdater
-		);
-
-		$instance->setEnabled( false );
-
 		$queryResultDependencyListResolver = $this->getMockBuilder( '\SMW\SQLStore\QueryDependency\QueryResultDependencyListResolver' )
 			->disableOriginalConstructor()
 			->getMock();
@@ -292,7 +315,15 @@ class QueryDependencyLinksStoreTest extends \PHPUnit_Framework_TestCase {
 			->method( 'getDependencyList' )
 			->will( $this->returnValue( array() ) );
 
-		$instance->doUpdateDependenciesBy( $queryResultDependencyListResolver );
+		$instance = new QueryDependencyLinksStore(
+			$queryResultDependencyListResolver,
+			$dependencyLinksTableUpdater
+		);
+
+		$instance->setEnabled( false );
+		$queryResult = '';
+
+		$instance->doUpdateDependenciesFrom( $queryResult );
 	}
 
 	public function testTryDoUpdateDependenciesByForWhenDependencyListReturnsEmpty() {
@@ -322,29 +353,46 @@ class QueryDependencyLinksStoreTest extends \PHPUnit_Framework_TestCase {
 			->method( 'getStore' )
 			->will( $this->returnValue( $store ) );
 
-		$instance = new QueryDependencyLinksStore(
-			$dependencyLinksTableUpdater
-		);
-
-		$instance->setEnabled( true );
-
 		$queryResultDependencyListResolver = $this->getMockBuilder( '\SMW\SQLStore\QueryDependency\QueryResultDependencyListResolver' )
 			->disableOriginalConstructor()
 			->getMock();
 
 		$queryResultDependencyListResolver->expects( $this->any() )
-			->method( 'getDependencyListByLateRetrieval' )
+			->method( 'getDependencyListByLateRetrievalFrom' )
 			->will( $this->returnValue( array() ) );
 
 		$queryResultDependencyListResolver->expects( $this->once() )
-			->method( 'getDependencyList' )
+			->method( 'getDependencyListFrom' )
 			->will( $this->returnValue( array() ) );
 
-		$queryResultDependencyListResolver->expects( $this->any() )
-			->method( 'getSubject' )
+		$instance = new QueryDependencyLinksStore(
+			$queryResultDependencyListResolver,
+			$dependencyLinksTableUpdater
+		);
+
+		$instance->setEnabled( true );
+
+		$query = $this->getMockBuilder( '\SMWQuery' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$query->expects( $this->any() )
+			->method( 'getContextPage' )
 			->will( $this->returnValue( DIWikiPage::newFromText( __METHOD__ ) ) );
 
-		$instance->doUpdateDependenciesBy( $queryResultDependencyListResolver );
+		$query->expects( $this->any() )
+			->method( 'getLimit' )
+			->will( $this->returnValue( 1 ) );
+
+		$queryResult = $this->getMockBuilder( '\SMWQueryResult' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$queryResult->expects( $this->any() )
+			->method( 'getQuery' )
+			->will( $this->returnValue( $query ) );
+
+		$instance->doUpdateDependenciesFrom( $queryResult );
 
 		$this->testEnvironment->executePendingDeferredUpdates();
 	}
@@ -379,15 +427,11 @@ class QueryDependencyLinksStoreTest extends \PHPUnit_Framework_TestCase {
 			->getMock();
 
 		$queryResultDependencyListResolver->expects( $this->any() )
-			->method( 'getDependencyListByLateRetrieval' )
+			->method( 'getDependencyListByLateRetrievalFrom' )
 			->will( $this->returnValue( array() ) );
 
 		$queryResultDependencyListResolver->expects( $this->any() )
-			->method( 'getSubject' )
-			->will( $this->returnValue( DIWikiPage::newFromText( __METHOD__ )  ) );
-
-		$queryResultDependencyListResolver->expects( $this->any() )
-			->method( 'getDependencyList' )
+			->method( 'getDependencyListFrom' )
 			->will( $this->returnValue( array( null, DIWikiPage::newFromText( 'Foo' ) ) ) );
 
 		$dependencyLinksTableUpdater = $this->getMockBuilder( '\SMW\SQLStore\QueryDependency\DependencyLinksTableUpdater' )
@@ -409,10 +453,31 @@ class QueryDependencyLinksStoreTest extends \PHPUnit_Framework_TestCase {
 			->will( $this->returnValue( $store ) );
 
 		$instance = new QueryDependencyLinksStore(
+			$queryResultDependencyListResolver,
 			$dependencyLinksTableUpdater
 		);
 
-		$instance->doUpdateDependenciesBy( $queryResultDependencyListResolver );
+		$query = $this->getMockBuilder( '\SMWQuery' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$query->expects( $this->any() )
+			->method( 'getContextPage' )
+			->will( $this->returnValue( DIWikiPage::newFromText( __METHOD__ ) ) );
+
+		$query->expects( $this->any() )
+			->method( 'getLimit' )
+			->will( $this->returnValue( 1 ) );
+
+		$queryResult = $this->getMockBuilder( '\SMWQueryResult' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$queryResult->expects( $this->any() )
+			->method( 'getQuery' )
+			->will( $this->returnValue( $query ) );
+
+		$instance->doUpdateDependenciesFrom( $queryResult );
 
 		$this->testEnvironment->executePendingDeferredUpdates();
 	}
@@ -432,15 +497,11 @@ class QueryDependencyLinksStoreTest extends \PHPUnit_Framework_TestCase {
 			->getMock();
 
 		$queryResultDependencyListResolver->expects( $this->any() )
-			->method( 'getDependencyListByLateRetrieval' )
+			->method( 'getDependencyListByLateRetrievalFrom' )
 			->will( $this->returnValue( array() ) );
 
 		$queryResultDependencyListResolver->expects( $this->any() )
-			->method( 'getSubject' )
-			->will( $this->returnValue( DIWikiPage::newFromText( __METHOD__ )  ) );
-
-		$queryResultDependencyListResolver->expects( $this->any() )
-			->method( 'getDependencyList' )
+			->method( 'getDependencyListFrom' )
 			->will( $this->returnValue( array( DIWikiPage::newFromText( 'Foo', NS_CATEGORY ) ) ) );
 
 		$dependencyLinksTableUpdater = $this->getMockBuilder( '\SMW\SQLStore\QueryDependency\DependencyLinksTableUpdater' )
@@ -466,10 +527,31 @@ class QueryDependencyLinksStoreTest extends \PHPUnit_Framework_TestCase {
 			->will( $this->returnValue( $store ) );
 
 		$instance = new QueryDependencyLinksStore(
+			$queryResultDependencyListResolver,
 			$dependencyLinksTableUpdater
 		);
 
-		$instance->doUpdateDependenciesBy( $queryResultDependencyListResolver );
+		$query = $this->getMockBuilder( '\SMWQuery' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$query->expects( $this->any() )
+			->method( 'getContextPage' )
+			->will( $this->returnValue( DIWikiPage::newFromText( __METHOD__ ) ) );
+
+		$query->expects( $this->any() )
+			->method( 'getLimit' )
+			->will( $this->returnValue( 1 ) );
+
+		$queryResult = $this->getMockBuilder( '\SMWQueryResult' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$queryResult->expects( $this->any() )
+			->method( 'getQuery' )
+			->will( $this->returnValue( $query ) );
+
+		$instance->doUpdateDependenciesFrom( $queryResult );
 
 		$this->testEnvironment->executePendingDeferredUpdates();
 	}
@@ -519,12 +601,8 @@ class QueryDependencyLinksStoreTest extends \PHPUnit_Framework_TestCase {
 			->getMock();
 
 		$queryResultDependencyListResolver->expects( $this->any() )
-			->method( 'getDependencyListByLateRetrieval' )
+			->method( 'getDependencyListByLateRetrievalFrom' )
 			->will( $this->returnValue( array() ) );
-
-		$queryResultDependencyListResolver->expects( $this->any() )
-			->method( 'getSubject' )
-			->will( $this->returnValue( $subject ) );
 
 		$dependencyLinksTableUpdater = $this->getMockBuilder( '\SMW\SQLStore\QueryDependency\DependencyLinksTableUpdater' )
 			->disableOriginalConstructor()
@@ -539,10 +617,31 @@ class QueryDependencyLinksStoreTest extends \PHPUnit_Framework_TestCase {
 			->will( $this->returnValue( $store ) );
 
 		$instance = new QueryDependencyLinksStore(
+			$queryResultDependencyListResolver,
 			$dependencyLinksTableUpdater
 		);
 
-		$instance->doUpdateDependenciesBy( $queryResultDependencyListResolver );
+		$query = $this->getMockBuilder( '\SMWQuery' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$query->expects( $this->any() )
+			->method( 'getContextPage' )
+			->will( $this->returnValue( $subject ) );
+
+		$query->expects( $this->any() )
+			->method( 'getLimit' )
+			->will( $this->returnValue( 1 ) );
+
+		$queryResult = $this->getMockBuilder( '\SMWQueryResult' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$queryResult->expects( $this->any() )
+			->method( 'getQuery' )
+			->will( $this->returnValue( $query ) );
+
+		$instance->doUpdateDependenciesFrom( $queryResult );
 	}
 
 }

--- a/tests/phpunit/Unit/SQLStore/QueryDependency/QueryResultDependencyListResolverTest.php
+++ b/tests/phpunit/Unit/SQLStore/QueryDependency/QueryResultDependencyListResolverTest.php
@@ -2,7 +2,6 @@
 
 namespace SMW\Tests\SQLStore\QueryDependency;
 
-use SMW\ApplicationFactory;
 use SMW\DIProperty;
 use SMW\DIWikiPage;
 use SMW\Query\Language\ClassDescription;
@@ -16,6 +15,7 @@ use SMW\Query\PrintRequest;
 use SMW\SQLStore\QueryDependency\QueryResultDependencyListResolver;
 use SMWDIBlob as DIBlob;
 use SMWQuery as Query;
+use SMW\Tests\TestEnvironment;
 
 /**
  * @covers \SMW\SQLStore\QueryDependency\QueryResultDependencyListResolver
@@ -28,23 +28,23 @@ use SMWQuery as Query;
  */
 class QueryResultDependencyListResolverTest extends \PHPUnit_Framework_TestCase {
 
-	private $applicationFactory;
+	private $testEnvironment;
 	private $store;
 
 	protected function setUp() {
 		parent::setUp();
 
-		$this->applicationFactory = ApplicationFactory::getInstance();
+		$this->testEnvironment = new TestEnvironment();
 
 		$this->store = $this->getMockBuilder( '\SMW\Store' )
 			->disableOriginalConstructor()
 			->getMockForAbstractClass();
 
-		$this->applicationFactory->registerObject( 'Store', $this->store );
+		$this->testEnvironment->registerObject( 'Store', $this->store );
 	}
 
 	protected function tearDown() {
-		$this->applicationFactory->clear();
+		$this->testEnvironment->tearDown();
 
 		parent::tearDown();
 	}
@@ -57,35 +57,26 @@ class QueryResultDependencyListResolverTest extends \PHPUnit_Framework_TestCase 
 
 		$this->assertInstanceOf(
 			'\SMW\SQLStore\QueryDependency\QueryResultDependencyListResolver',
-			new QueryResultDependencyListResolver( null, $propertyHierarchyLookup )
+			new QueryResultDependencyListResolver( $propertyHierarchyLookup )
 		);
 	}
 
-	public function testTryToGetDependencyListForNonSetQueryResult() {
+	public function testTryTogetDependencyListFromForNonSetQueryResult() {
 
 		$propertyHierarchyLookup = $this->getMockBuilder( '\SMW\PropertyHierarchyLookup' )
 			->disableOriginalConstructor()
 			->getMock();
 
 		$instance = new QueryResultDependencyListResolver(
-			null,
 			$propertyHierarchyLookup
 		);
 
-		$this->assertNull(
-			$instance->getQueryId()
-		);
-
-		$this->assertNull(
-			$instance->getSubject()
-		);
-
 		$this->assertEmpty(
-			$instance->getDependencyList()
+			$instance->getDependencyListFrom( '' )
 		);
 	}
 
-	public function testTryToGetDependencyListForLimitZeroQuery() {
+	public function testTryTogetDependencyListFromForLimitZeroQuery() {
 
 		$subject = DIWikiPage::newFromText( 'Foo' );
 
@@ -106,7 +97,7 @@ class QueryResultDependencyListResolverTest extends \PHPUnit_Framework_TestCase 
 			->method( 'getQuery' )
 			->will( $this->returnValue( $query ) );
 
-		$queryResult->expects( $this->any() )
+		$queryResult->expects( $this->never() )
 			->method( 'getStore' )
 			->will( $this->returnValue( $this->store ) );
 
@@ -115,12 +106,11 @@ class QueryResultDependencyListResolverTest extends \PHPUnit_Framework_TestCase 
 			->getMock();
 
 		$instance = new QueryResultDependencyListResolver(
-			$queryResult,
 			$propertyHierarchyLookup
 		);
 
 		$this->assertEmpty(
-			$instance->getDependencyList()
+			$instance->getDependencyListFrom( $queryResult )
 		);
 	}
 
@@ -167,7 +157,6 @@ class QueryResultDependencyListResolverTest extends \PHPUnit_Framework_TestCase 
 				array( DIWikiPage::newFromText( 'Subprop', SMW_NS_PROPERTY ) ) ) );
 
 		$instance = new QueryResultDependencyListResolver(
-			$queryResult,
 			$propertyHierarchyLookup
 		);
 
@@ -182,14 +171,15 @@ class QueryResultDependencyListResolverTest extends \PHPUnit_Framework_TestCase 
 
 		$this->assertEquals(
 			$expected,
-			$instance->getDependencyList()
+			$instance->getDependencyListFrom( $queryResult )
 		);
 	}
+
 
 	/**
 	 * @dataProvider queryProvider
 	 */
-	public function testgetDependencyList( $query, $expected ) {
+	public function testgetDependencyListFrom( $query, $expected ) {
 
 		$queryResult = $this->getMockBuilder( '\SMWQueryResult' )
 			->disableOriginalConstructor()
@@ -212,17 +202,16 @@ class QueryResultDependencyListResolverTest extends \PHPUnit_Framework_TestCase 
 			->getMock();
 
 		$instance = new QueryResultDependencyListResolver(
-			$queryResult,
 			$propertyHierarchyLookup
 		);
 
 		$this->assertEquals(
 			$expected,
-			$instance->getDependencyList()
+			$instance->getDependencyListFrom( $queryResult )
 		);
 	}
 
-	public function testGetDependencyListByLateRetrieval() {
+	public function testgetDependencyListByLateRetrievalFrom() {
 
 		$subject = DIWikiPage::newFromText( 'Bar' );
 
@@ -258,13 +247,12 @@ class QueryResultDependencyListResolverTest extends \PHPUnit_Framework_TestCase 
 			->getMock();
 
 		$instance = new QueryResultDependencyListResolver(
-			$queryResult,
 			$propertyHierarchyLookup
 		);
 
 		$this->assertEquals(
 			array( $subject ),
-			$instance->getDependencyListByLateRetrieval()
+			$instance->getDependencyListByLateRetrievalFrom( $queryResult )
 		);
 	}
 
@@ -311,7 +299,6 @@ class QueryResultDependencyListResolverTest extends \PHPUnit_Framework_TestCase 
 				array( DIWikiPage::newFromText( 'Subprop', SMW_NS_PROPERTY ) ) ) );
 
 		$instance = new QueryResultDependencyListResolver(
-			$queryResult,
 			$propertyHierarchyLookup
 		);
 
@@ -324,7 +311,7 @@ class QueryResultDependencyListResolverTest extends \PHPUnit_Framework_TestCase 
 
 		$this->assertEquals(
 			$expected,
-			$instance->getDependencyList()
+			$instance->getDependencyListFrom( $queryResult )
 		);
 	}
 
@@ -372,7 +359,6 @@ class QueryResultDependencyListResolverTest extends \PHPUnit_Framework_TestCase 
 					DIWikiPage::newFromText( 'Foocat', NS_CATEGORY ) ) ) );
 
 		$instance = new QueryResultDependencyListResolver(
-			$queryResult,
 			$propertyHierarchyLookup
 		);
 
@@ -385,7 +371,7 @@ class QueryResultDependencyListResolverTest extends \PHPUnit_Framework_TestCase 
 
 		$this->assertEquals(
 			$expected,
-			$instance->getDependencyList()
+			$instance->getDependencyListFrom( $queryResult )
 		);
 	}
 

--- a/tests/phpunit/Unit/SQLStore/QueryDependencyLinksStoreFactoryTest.php
+++ b/tests/phpunit/Unit/SQLStore/QueryDependencyLinksStoreFactoryTest.php
@@ -29,7 +29,7 @@ class QueryDependencyLinksStoreFactoryTest extends \PHPUnit_Framework_TestCase {
 
 		$this->assertInstanceOf(
 			'\SMW\SQLStore\QueryDependency\QueryResultDependencyListResolver',
-			$instance->newQueryResultDependencyListResolver( '' )
+			$instance->newQueryResultDependencyListResolver()
 		);
 	}
 


### PR DESCRIPTION
This PR is made in reference to: #

This PR addresses or contains:

- Avoid `QueryDependencyLinksStoreFactory::newQueryDependencyLinksStore` on each query executing during `SMW::Store::AfterQueryResultLookupComplete`.

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed

