### PR TITLE
WikiPageValue to use Sanitizer on caption/label output / Test XSS injection

### DIFF
--- a/includes/datavalues/SMW_DV_WikiPage.php
+++ b/includes/datavalues/SMW_DV_WikiPage.php
@@ -235,7 +235,8 @@ class SMWWikiPageValue extends SMWDataValue {
 
 		if ( $this->m_dataitem->getNamespace() == NS_FILE && $this->m_dataitem->getInterwiki() === '' ) {
 			$linkEscape = '';
-			$defaultCaption = '|' . $this->getShortCaptionText() . '|frameless|border|text-top';
+			$options = $this->m_outformat !== '' ? str_replace( ';', '|', \Sanitizer::removeHTMLtags( $this->m_outformat ) ) : 'frameless|border|text-top|';
+			$defaultCaption = '|' . $this->getShortCaptionText() . '|' . $options;
 		} else {
 			$linkEscape = ':';
 			$defaultCaption = '|' . $this->getShortCaptionText();
@@ -285,11 +286,11 @@ class SMWWikiPageValue extends SMWDataValue {
 				$this->m_outformat == '-' || $this->m_caption === '' ) {
 
 			$caption = $this->m_caption === false ? $this->getWikiValue() : $this->m_caption;
-			return htmlspecialchars( $caption );
+			return \Sanitizer::removeHTMLtags( $caption );
 		}
 
 		$caption = $this->m_caption === false ? $this->getShortCaptionText() : $this->m_caption;
-		$caption = htmlspecialchars( $caption );
+		$caption =  \Sanitizer::removeHTMLtags( $caption );
 
 		if ( $this->getNamespace() == NS_MEDIA ) { // this extra case *is* needed
 			return $linker->makeMediaLinkObj( $this->getTitle(), $caption );
@@ -366,16 +367,16 @@ class SMWWikiPageValue extends SMWDataValue {
 		}
 
 		if ( is_null( $linker ) || $this->m_outformat == '-' ) {
-			return htmlspecialchars( $this->getWikiValue() );
+			return  \Sanitizer::removeHTMLtags( $this->getWikiValue() );
 		} elseif ( $this->getNamespace() == NS_MEDIA ) { // this extra case is really needed
 			return $linker->makeMediaLinkObj( $this->getTitle(),
-				htmlspecialchars( $this->getLongCaptionText() ) );
+				 \Sanitizer::removeHTMLtags( $this->getLongCaptionText() ) );
 		}
 
 		// all others use default linking, no embedding of images here
 		return $linker->link(
 			$this->getTitle(),
-			htmlspecialchars( $this->getLongCaptionText() ),
+			 \Sanitizer::removeHTMLtags( $this->getLongCaptionText() ),
 			$this->linkAttributes
 		);
 	}

--- a/src/DataValues/BooleanValue.php
+++ b/src/DataValues/BooleanValue.php
@@ -96,8 +96,8 @@ class BooleanValue extends DataValue {
 		} else { // format "truelabel, falselabel" (hopefully)
 			$captions = explode( ',', $formatstring, 2 );
 			if ( count( $captions ) == 2 ) { // note: escaping needed to be safe; MW-sanitising would be an alternative
-				$this->trueCaption = htmlspecialchars_decode( htmlspecialchars( trim( $captions[0] ) ) );
-				$this->falseCaption = htmlspecialchars_decode( htmlspecialchars( trim( $captions[1] ) ) );
+				$this->trueCaption = \Sanitizer::removeHTMLtags( trim( $captions[0] ) );
+				$this->falseCaption = \Sanitizer::removeHTMLtags( trim( $captions[1] ) );
 			} // else: no format that is recognised, ignore
 		}
 

--- a/tests/phpunit/Integration/ByJsonScript/Fixtures/p-0703.json
+++ b/tests/phpunit/Integration/ByJsonScript/Fixtures/p-0703.json
@@ -11,13 +11,17 @@
 			"contents": "[[Has text::P0703]]"
 		},
 		{
-			"page": "Example/P0703/Q.1",
-			"contents": "{{#ask: [[Has text::P0703]] |?Has text=<span style=\"color: green; font-size: 120%;\">Label</span> |format=table }}"
+			"page": "Example/P0703/2",
+			"contents": "[[Has text::P0703]]"
 		},
 		{
-			"message-cache": "clear",
+			"page": "Example/P0703/Q.1",
+			"contents": "{{#ask: [[Has text::P0703]] |?Has text=<span style=\"color: green; font-size: 120%;\">Label</span> |format=table |limit=1 }}"
+		},
+		{
 			"page": "Example/P0703/Q.2",
-			"contents": "{{#ask: [[Has text::P0703]] |?Has text=Label {{#info:Text info.}} |format=table }}"
+			"contents": "{{#ask: [[Has text::P0703]] |?Has text=Label {{#info:Text info.}} |format=table |limit=1 }}",
+			"message-cache": "clear"
 		}
 	],
 	"tests": [
@@ -27,7 +31,8 @@
 			"subject": "Example/P0703/Q.1",
 			"assert-output": {
 				"to-contain": [
-					"title=\"Property:Has text\"><span style=\"color: green; font-size: 120%;\">Label</span>"
+					"title=\"Property:Has text\"><span style=\"color: green; font-size: 120%;\">Label</span>",
+					"Special:Ask/-5B-5BHas-20text::P0703-5D-5D/-3FHas-20text=-3Cspan-20style=&quot;color:-20green-3B-20font-2Dsize:-20120-25-3B&quot;-3ELabel-3C-2Fspan-3E/mainlabel=/limit=1/offset=1/format=table"
 				]
 			}
 		},
@@ -38,7 +43,8 @@
 			"assert-output": {
 				"to-contain": [
 					"title=\"Property:Has text\">Label <span class=\"smw-highlighter\" data-type=\"5\" data-state=\"persistent\" data-title=\"Information\" title=\"Text info.\">",
-					"<span class=\"smwtticon info\"></span><div class=\"smwttcontent\">Text info.</div></span>"
+					"<span class=\"smwtticon info\"></span><div class=\"smwttcontent\">Text info.</div></span>",
+					"Special:Ask/-5B-5BHas-20text::P0703-5D-5D/-3FHas-20text=Label-20-3Cspan-20class=&quot;smw-2Dhighlighter&quot;-20data-2Dtype=&quot;5&quot;-20data-2Dstate=&quot;persistent&quot;-20data-2Dtitle=&quot;Information&quot;-20title=&quot;Text-20info.&quot;-3E-3Cspan-20class=&quot;smwtticon-20info&quot;-3E-3C-2Fspan-3E-3Cdiv-20class=&quot;smwttcontent&quot;-3EText-20info.-3C-2Fdiv-3E-3C-2Fspan-3E/mainlabel=/limit=1/offset=1/format=table"
 				]
 			}
 		}

--- a/tests/phpunit/Integration/ByJsonScript/Fixtures/p-0704.json
+++ b/tests/phpunit/Integration/ByJsonScript/Fixtures/p-0704.json
@@ -1,0 +1,56 @@
+{
+	"description": "Test `#ask` sanitization of printrequest labels to avoid XSS injection (`wgContLang=en`, `wgLang=en`)",
+	"setup": [
+		{
+			"namespace": "SMW_NS_PROPERTY",
+			"page": "Has text",
+			"contents": "[[Has type::Text]]"
+		},
+		{
+			"page": "Example/P0704/1",
+			"contents": "[[Has text::P0704]]"
+		},
+		{
+			"page": "Example/P0704/Q.1",
+			"contents": "{{#ask: [[Has text::P0704]] |?Has text=Some <div onmouseover=\"alert('<?php echo htmlspecialchars($xss) ?>')\"> |format=table |limit=1 }}"
+		},
+		{
+			"page": "Example/P0704/Q.2",
+			"contents": "{{#ask: [[Has text::P0704]] |?Has text=Some <a href=\"javascript:alert('<?php echo htmlspecialchars($xss) ?>')\"> |format=table |limit=1 }}"
+		}
+	],
+	"tests": [
+		{
+			"type": "parser",
+			"about": "#0 (avoid XSS through sanitization)",
+			"subject": "Example/P0704/Q.1",
+			"assert-output": {
+				"to-contain": [
+					"title=\"Property:Has text\">Some &lt;div onmouseover=\"alert('&lt;?php echo htmlspecialchars($xss) ?&gt;')\"&gt;"
+				]
+			}
+		},
+		{
+			"type": "parser",
+			"about": "#1 (avoid XSS through sanitization)",
+			"subject": "Example/P0704/Q.2",
+			"assert-output": {
+				"to-contain": [
+					"title=\"Property:Has text\">Some &lt;a href=\"javascript:alert('&lt;?php echo htmlspecialchars($xss) ?&gt;')\"&gt;"
+				]
+			}
+		}
+	],
+	"settings": {
+		"wgContLang": "en",
+		"wgLang": "en",
+		"smwgPageSpecialProperties": [
+			"_MDAT"
+		]
+	},
+	"meta": {
+		"version": "2",
+		"is-incomplete": false,
+		"debug": false
+	}
+}


### PR DESCRIPTION
This PR is made in reference to: # [0]

This PR addresses or contains:

- Use Sanitizer::removeHTMLtags instead of htmlspecialchars_decode

This PR includes:
- [ ] Tests (unit/integration)
- [x] CI build passed

[0] http://wikimedia.7.x6.nabble.com/Modify-table-header-in-quot-further-results-quot-td5068597.html