### PR TITLE
Add TransitionalDiffStore

### DIFF
--- a/docs/technical/hooks.md
+++ b/docs/technical/hooks.md
@@ -41,6 +41,8 @@ Implementing a hook should be made in consideration of the expected performance 
 
 ### 2.5
 
+- `SMW::Job::AfterUpdateDispatcherJobComplete`
+
 `SMW\SQLStore\Installer` defines:
 
 - `SMW::SQLStore::AfterCreateTablesComplete` to add extra tables after the create process as been finalized

--- a/includes/Setup.php
+++ b/includes/Setup.php
@@ -210,6 +210,7 @@ final class Setup {
 			'SMW\ParserCachePurgeJob' => 'SMW\MediaWiki\Jobs\ParserCachePurgeJob',
 			'SMW\SearchTableUpdateJob' => 'SMW\MediaWiki\Jobs\SearchTableUpdateJob',
 			'SMW\EntityIdDisposerJob' => 'SMW\MediaWiki\Jobs\EntityIdDisposerJob',
+			'SMW\SequentialCachePurgeJob' => 'SMW\MediaWiki\Jobs\SequentialCachePurgeJob',
 
 			// Legacy definition to be removed with 1.10
 			'SMWUpdateJob'  => 'SMW\MediaWiki\Jobs\UpdateJob',

--- a/src/ApplicationFactory.php
+++ b/src/ApplicationFactory.php
@@ -90,14 +90,17 @@ class ApplicationFactory {
 	}
 
 	/**
-	 * @private
-	 *
-	 * @since 2.4
-	 *
-	 * @return CallbackLoader
+	 * @since 2.5
 	 */
-	public function getCallbackInstantiator() {
-		return $this->callbackLoader;
+	public function singleton( $serviceName ) {
+		return call_user_func_array( array( $this->callbackLoader, 'singleton' ), func_get_args() );
+	}
+
+	/**
+	 * @since 2.5
+	 */
+	public function create( $serviceName ) {
+		return call_user_func_array( array( $this->callbackLoader, 'create' ), func_get_args() );
 	}
 
 	/**

--- a/src/CacheFactory.php
+++ b/src/CacheFactory.php
@@ -20,17 +20,11 @@ class CacheFactory {
 	private $mainCacheType;
 
 	/**
-	 * @var CallbackInstantiator
-	 */
-	private $callbackInstantiator;
-
-	/**
 	 * @since 2.2
 	 *
 	 * @param string|integer|null $mainCacheType
 	 */
 	public function __construct( $mainCacheType = null ) {
-		$this->callbackInstantiator = ApplicationFactory::getInstance()->getCallbackInstantiator();
 		$this->mainCacheType = $mainCacheType;
 
 		if ( $this->mainCacheType === null ) {
@@ -146,7 +140,7 @@ class CacheFactory {
 	 * @return BlobStore
 	 */
 	public function newBlobStore( $namespace, $cacheType = null, $cacheLifetime = 0 ) {
-		return $this->callbackInstantiator->load( 'BlobStore', $namespace, $cacheType, $cacheLifetime );
+		return ApplicationFactory::getInstance()->create( 'BlobStore', $namespace, $cacheType, $cacheLifetime );
 	}
 
 }

--- a/src/DeferredRequestDispatchManager.php
+++ b/src/DeferredRequestDispatchManager.php
@@ -196,7 +196,8 @@ class DeferredRequestDispatchManager {
 		$allowedJobs = array(
 			'SMW\ParserCachePurgeJob',
 			'SMW\UpdateJob',
-			'SMW\SearchTableUpdateJob'
+			'SMW\SearchTableUpdateJob',
+			'SMW\SequentialCachePurgeJob'
 		);
 
 		return in_array( $type, $allowedJobs );

--- a/src/MediaWiki/Jobs/JobFactory.php
+++ b/src/MediaWiki/Jobs/JobFactory.php
@@ -47,9 +47,11 @@ class JobFactory {
 				return $this->newSearchTableUpdateJob( $title, $parameters );
 			case 'SMW\EntityIdDisposerJob':
 				return $this->newEntityIdDisposerJob( $title, $parameters );
+			case 'SMW\SequentialCachePurgeJob':
+				return $this->newSequentialCachePurgeJob( $title, $parameters );
 		}
 
-		throw new RuntimeException( "Cannot match $type to a valid Job type" );
+		throw new RuntimeException( "Unable to match $type to a valid Job type" );
 	}
 
 	/**
@@ -122,6 +124,18 @@ class JobFactory {
 	 */
 	public function newEntityIdDisposerJob( Title $title, array $parameters = array() ) {
 		return new EntityIdDisposerJob( $title, $parameters );
+	}
+
+	/**
+	 * @since 2.5
+	 *
+	 * @param Title $title
+	 * @param array $parameters
+	 *
+	 * @return SequentialCachePurgeJob
+	 */
+	public function newSequentialCachePurgeJob( Title $title, array $parameters = array() ) {
+		return new SequentialCachePurgeJob( $title, $parameters );
 	}
 
 }

--- a/src/MediaWiki/Jobs/SequentialCachePurgeJob.php
+++ b/src/MediaWiki/Jobs/SequentialCachePurgeJob.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace SMW\MediaWiki\Jobs;
+
+use SMW\ApplicationFactory;
+use SMW\SQLStore\TransitionalTableDiffStore;
+use Title;
+
+/**
+ * @license GNU GPL v2+
+ * @since 2.5
+ *
+ * @author mwjames
+ */
+class SequentialCachePurgeJob extends JobBase {
+
+	/**
+	 * @since 2.5
+	 *
+	 * @param Title $title
+	 * @param array $params job parameters
+	 */
+	public function __construct( Title $title, $params = array() ) {
+		parent::__construct( 'SMW\SequentialCachePurgeJob', $title, $params );
+	}
+
+	/**
+	 * @see Job::run
+	 *
+	 * @since  2.5
+	 */
+	public function run() {
+
+		if ( $this->hasParameter( 'slot:id' ) ) {
+			$this->doPurgeTransitionalDiffStore( $this->getParameter( 'slot:id' ) );
+		}
+
+		return true;
+	}
+
+	private function doPurgeTransitionalDiffStore( $slot ) {
+		ApplicationFactory::getInstance()->singleton( 'TransitionalDiffStore' )->delete( $slot );
+		wfDebugLog( 'smw', __METHOD__ . ' :: '. $slot );
+	}
+
+}

--- a/src/SQLStore/CompositePropertyTableDiffIterator.php
+++ b/src/SQLStore/CompositePropertyTableDiffIterator.php
@@ -4,6 +4,7 @@ namespace SMW\SQLStore;
 
 use ArrayIterator;
 use IteratorAggregate;
+use SMW\DIWikiPage;
 use SMW\SQLStore\ChangeOp\TableChangeOp;
 
 /**
@@ -20,6 +21,16 @@ class CompositePropertyTableDiffIterator implements IteratorAggregate {
 	private $diff = array();
 
 	/**
+	 * @var DIWikiPage
+	 */
+	private $subject;
+
+	/**
+	 * @var string
+	 */
+	private $hash = '';
+
+	/**
 	 * @var array
 	 */
 	private $fixedPropertyRecords = array();
@@ -34,6 +45,24 @@ class CompositePropertyTableDiffIterator implements IteratorAggregate {
 	}
 
 	/**
+	 * @since 2.5
+	 *
+	 * @return DIWikiPage $subject
+	 */
+	public function setSubject( DIWikiPage $subject ) {
+		$this->subject = $subject;
+	}
+
+	/**
+	 * @since 2.5
+	 *
+	 * @return DIWikiPage
+	 */
+	public function getSubject() {
+		return $this->subject;
+	}
+
+	/**
 	 * @since 2.3
 	 *
 	 * @return ArrayIterator
@@ -43,16 +72,30 @@ class CompositePropertyTableDiffIterator implements IteratorAggregate {
 	}
 
 	/**
+	 * @since 2.5
+	 *
+	 * @return string
+	 */
+	public function getHash() {
+		return md5( $this->hash . ( $this->subject !== null ? $this->subject->getHash() : '' ) );
+	}
+
+	/**
 	 * @since 2.3
 	 *
 	 * @param array $insertRecord
 	 * @param array $deleteRecord
 	 */
 	public function addTableRowsToCompositeDiff( array $insertRecord, array $deleteRecord ) {
-		$this->diff[] = array(
+
+		$diff = array(
 			'insert' => $insertRecord,
 			'delete' => $deleteRecord
 		);
+
+		$this->diff[] = $diff;
+
+		$this->hash .= json_encode( $diff );
 	}
 
 	/**

--- a/src/SQLStore/PropertyTableRowDiffer.php
+++ b/src/SQLStore/PropertyTableRowDiffer.php
@@ -70,6 +70,10 @@ class PropertyTableRowDiffer {
 
 		$newHashes = array();
 
+		$this->getCompositePropertyTableDiff()->setSubject(
+			$semanticData->getSubject()
+		);
+
 		$newData = $this->mapToInsertValueFormat(
 			$sid,
 			$semanticData

--- a/src/SQLStore/QueryEngine/FulltextSearchTableFactory.php
+++ b/src/SQLStore/QueryEngine/FulltextSearchTableFactory.php
@@ -13,6 +13,7 @@ use SMW\SQLStore\QueryEngine\Fulltext\SearchTable;
 use SMW\SQLStore\QueryEngine\Fulltext\SearchTableUpdater;
 use SMW\SQLStore\QueryEngine\Fulltext\SearchTableRebuilder;
 use Onoi\Tesa\SanitizerFactory;
+use SMW\SQLStore\TransitionalTableDiffStore;
 
 /**
  * @license GNU GPL v2+
@@ -136,7 +137,8 @@ class FulltextSearchTableFactory {
 		$textByChangeUpdater = new TextByChangeUpdater(
 			$store->getConnection( 'mw.db' ),
 			$this->newSearchTableUpdater( $store ),
-			$this->newTextSanitizer()
+			$this->newTextSanitizer(),
+			ApplicationFactory::getInstance()->singleton( 'TransitionalDiffStore' )
 		);
 
 		$textByChangeUpdater->asDeferredUpdate(

--- a/src/SQLStore/TransitionalDiffStore.php
+++ b/src/SQLStore/TransitionalDiffStore.php
@@ -1,0 +1,159 @@
+<?php
+
+namespace SMW\SQLStore;
+
+use Onoi\Cache\Cache;
+use SMW\DIWikiPage;
+use SMW\SQLStore\ChangeOp\TableChangeOp;
+use Psr\Log\LoggerInterface;
+use Psr\Log\LoggerAwareInterface;
+
+/**
+ * Pending the size of a diff, transferring it with the job parameter maybe too
+ * large and can eventually fail during unserialization forcing a job and hereby
+ * the update transaction to fail with:
+ *
+ * "Notice: unserialize(): Error at offset 65504 of 65535 bytes in ...
+ * JobQueueDB.php on line 817"
+ *
+ * This class will store the diff object temporarily in Cache with the possibility
+ * to retrieve it at a later point without relying on the JobQueueDB as storage
+ * medium.
+ *
+ * The slot can be removed using a reference and the SequentialCachePurgeJob.
+ *
+ * @license GNU GPL v2+
+ * @since 2.5
+ *
+ * @author mwjames
+ */
+class TransitionalDiffStore implements LoggerAwareInterface {
+
+	const CACHE_NAMESPACE = ':smw:diff:';
+
+	/**
+	 * @var Cache
+	 */
+	private $cache;
+
+	/**
+	 * @var string
+	 */
+	private $prefix = '';
+
+	/**
+	 * loggerInterface
+	 */
+	private $logger;
+
+	/**
+	 * @since 2.5
+	 *
+	 * @param Cache $cache
+	 * @param string $prefix
+	 */
+	public function __construct( Cache $cache, $prefix = '' ) {
+		$this->cache = $cache;
+		$this->prefix = $prefix;
+	}
+
+	/**
+	 * @see LoggerAwareInterface::setLogger
+	 *
+	 * @since 2.5
+	 *
+	 * @param LoggerInterface $logger
+	 */
+	public function setLogger( LoggerInterface $logger ) {
+		$this->logger = $logger;
+	}
+
+	/**
+	 * @since 2.5
+	 *
+	 * @param CompositePropertyTableDiffIterator $compositePropertyTableDiffIterator
+	 *
+	 * @return string
+	 */
+	public function getSlot( CompositePropertyTableDiffIterator $compositePropertyTableDiffIterator ) {
+		return $this->prefix . self::CACHE_NAMESPACE . $compositePropertyTableDiffIterator->getHash();
+	}
+
+	/**
+	 * @since 2.5
+	 *
+	 * @param CompositePropertyTableDiffIterator $compositePropertyTableDiffIterator
+	 *
+	 * @return null|string
+	 */
+	public function createSlotFrom( CompositePropertyTableDiffIterator $compositePropertyTableDiffIterator ) {
+
+		$orderedDiffByTable = $compositePropertyTableDiffIterator->getOrderedDiffByTable();
+
+		if ( $orderedDiffByTable === array() ) {
+			return null;
+		}
+
+		$slot = $this->getSlot( $compositePropertyTableDiffIterator );
+
+		$this->cache->save(
+			$slot,
+			$orderedDiffByTable
+		);
+
+		return $slot;
+	}
+
+	/**
+	 * @since 2.5
+	 *
+	 * @param string $slot
+	 */
+	public function delete( $slot ) {
+		$this->cache->delete( $slot );
+	}
+
+	/**
+	 * @since 2.5
+	 *
+	 * @param string $slot
+	 * @param string|null $tableName
+	 *
+	 * @return TableChange[]
+	 */
+	public function newTableChangeOpsFrom( $slot, $tableName = null ) {
+
+		$start = microtime( true );
+
+		$diffByTable = $this->cache->fetch( $slot );
+		$tableChangeOps = array();
+
+		if ( $diffByTable === false || $diffByTable === null ) {
+			$this->log( __METHOD__ . ' unknown slot :: '. $slot );
+			return array();
+		}
+
+		foreach ( $diffByTable as $tblName => $diff ) {
+
+			if ( $tableName !== null && $tableName !== $tblName ) {
+				continue;
+			}
+
+			$tableChangeOps[] = new TableChangeOp( $tblName, $diff );
+		}
+
+		$this->log( __METHOD__ . ' procTime (sec): '. round( ( microtime( true ) - $start ), 5 ) );
+
+		return $tableChangeOps;
+	}
+
+	private function log( $message, $context = array() ) {
+
+		if ( $this->logger === null ) {
+			return;
+		}
+
+		$this->logger->info( $message, $context );
+	}
+
+}

--- a/src/SharedCallbackContainer.php
+++ b/src/SharedCallbackContainer.php
@@ -15,6 +15,7 @@ use SMW\MediaWiki\TitleCreator;
 use SMW\Query\QuerySourceFactory;
 use MediaWiki\Logger\LoggerFactory;
 use Psr\Log\NullLogger;
+use SMW\SQLStore\TransitionalDiffStore;
 
 /**
  * @license GNU GPL v2+
@@ -346,6 +347,27 @@ class SharedCallbackContainer implements CallbackContainer {
 			);
 
 			return $propertyLabelFinder;
+		} );
+
+		/**
+		 * @var TransitionalDiffStore
+		 */
+		$callbackLoader->registerCallback( 'TransitionalDiffStore', function() use ( $callbackLoader ) {
+			$callbackLoader->registerExpectedReturnType( 'TransitionalDiffStore', '\SMW\SQLStore\TransitionalDiffStore' );
+
+			$cacheFactory = $callbackLoader->load( 'CacheFactory' );
+			$cacheType = null;
+
+			$transitionalDiffStore = new TransitionalDiffStore(
+				$cacheFactory->newMediaWikiCompositeCache( $cacheType ),
+				$cacheFactory->getCachePrefix()
+			);
+
+			$transitionalDiffStore->setLogger(
+				$callbackLoader->singleton( 'MediaWikiLogger' )
+			);
+
+			return $transitionalDiffStore;
 		} );
 	}
 

--- a/tests/phpunit/Unit/DeferredRequestDispatchManagerTest.php
+++ b/tests/phpunit/Unit/DeferredRequestDispatchManagerTest.php
@@ -106,6 +106,11 @@ class DeferredRequestDispatchManagerTest extends \PHPUnit_Framework_TestCase {
 		);
 
 		$provider[] = array(
+			'SMW\SequentialCachePurgeJob',
+			true
+		);
+
+		$provider[] = array(
 			'SMW\ParserCachePurgeJob',
 			false,
 			array( 'idlist' => '1|2' )

--- a/tests/phpunit/Unit/MediaWiki/Jobs/JobFactoryTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Jobs/JobFactoryTest.php
@@ -77,6 +77,11 @@ class JobFactoryTest extends \PHPUnit_Framework_TestCase {
 			'\SMW\MediaWiki\Jobs\EntityIdDisposerJob'
 		);
 
+		$provider[] = array(
+			'SMW\SequentialCachePurgeJob',
+			'\SMW\MediaWiki\Jobs\SequentialCachePurgeJob'
+		);
+
 		return $provider;
 	}
 

--- a/tests/phpunit/Unit/MediaWiki/Jobs/SequentialCachePurgeJobTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Jobs/SequentialCachePurgeJobTest.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace SMW\Tests\MediaWiki\Jobs;
+
+use SMW\DIWikiPage;
+use SMW\MediaWiki\Jobs\SequentialCachePurgeJob;
+use SMW\Tests\TestEnvironment;
+
+/**
+ * @covers \SMW\MediaWiki\Jobs\SequentialCachePurgeJob
+ * @group semantic-mediawiki
+ *
+ * @license GNU GPL v2+
+ * @since 2.5
+ *
+ * @author mwjames
+ */
+class SequentialCachePurgeJobTest extends \PHPUnit_Framework_TestCase {
+
+	private $testEnvironment;
+	private $transitionalDiffStore;
+
+	protected function setUp() {
+		parent::setUp();
+
+		$this->testEnvironment = new TestEnvironment();
+
+		$this->transitionalDiffStore = $this->getMockBuilder( '\SMW\SQLStore\TransitionalDiffStore' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$this->testEnvironment->registerObject( 'TransitionalDiffStore', $this->transitionalDiffStore );
+	}
+
+	protected function tearDown() {
+		$this->testEnvironment->tearDown();
+		parent::tearDown();
+	}
+
+	public function testCanConstruct() {
+
+		$title = $this->getMockBuilder( 'Title' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$this->assertInstanceOf(
+			'SMW\MediaWiki\Jobs\SequentialCachePurgeJob',
+			new SequentialCachePurgeJob( $title )
+		);
+	}
+
+	public function testRun() {
+
+		$parameters = array(
+			'slot:id' => 42
+		);
+
+		$this->transitionalDiffStore->expects( $this->once() )
+			->method( 'delete' );
+
+		$subject = DIWikiPage::newFromText( __METHOD__ );
+
+		$instance = new SequentialCachePurgeJob(
+			$subject->getTitle(),
+			$parameters
+		);
+
+		$this->assertTrue(
+			$instance->run()
+		);
+	}
+
+}

--- a/tests/phpunit/Unit/SQLStore/CompositePropertyTableDiffIteratorTest.php
+++ b/tests/phpunit/Unit/SQLStore/CompositePropertyTableDiffIteratorTest.php
@@ -3,6 +3,7 @@
 namespace SMW\Tests\SQLStore;
 
 use SMW\SQLStore\CompositePropertyTableDiffIterator;
+use SMW\DIWikiPage;
 
 /**
  * @covers \SMW\SQLStore\CompositePropertyTableDiffIterator
@@ -112,6 +113,24 @@ class CompositePropertyTableDiffIteratorTest extends \PHPUnit_Framework_TestCase
 
 		$this->assertEmpty(
 			$instance->getTableChangeOps( 'smw_di_number' )
+		);
+	}
+
+	public function testGetHash() {
+
+		$diff = array();
+
+		$instance = new CompositePropertyTableDiffIterator(
+			$diff
+		);
+
+		$instance->setSubject(
+			DIWikiPage::newFromText( __METHOD__ )
+		);
+
+		$this->assertInternalType(
+			'string',
+			$instance->getHash()
 		);
 	}
 

--- a/tests/phpunit/Unit/SQLStore/TransitionalDiffStoreTest.php
+++ b/tests/phpunit/Unit/SQLStore/TransitionalDiffStoreTest.php
@@ -1,0 +1,139 @@
+<?php
+
+namespace SMW\Tests\SQLStore;
+
+use SMW\SQLStore\TransitionalDiffStore;
+use Onoi\MessageReporter\MessageReporterFactory;
+
+/**
+ * @covers \SMW\SQLStore\TransitionalDiffStore
+ * @group semantic-mediawiki
+ *
+ * @license GNU GPL v2+
+ * @since 2.5
+ *
+ * @author mwjames
+ */
+class TransitionalDiffStoreTest extends \PHPUnit_Framework_TestCase {
+
+	private $cache;
+	private $compositePropertyTableDiffIterator;
+
+	protected function setUp() {
+
+		$this->cache = $this->getMockBuilder( '\Onoi\Cache\Cache' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$this->compositePropertyTableDiffIterator = $this->getMockBuilder( '\SMW\SQLStore\CompositePropertyTableDiffIterator' )
+			->disableOriginalConstructor()
+			->getMock();
+	}
+
+	public function testCanConstruct() {
+
+		$this->assertInstanceOf(
+			'\SMW\SQLStore\TransitionalDiffStore',
+			new TransitionalDiffStore( $this->cache )
+		);
+	}
+
+	public function testGetSlot() {
+
+		$instance = new TransitionalDiffStore(
+			$this->cache
+		);
+
+		$this->assertContains(
+			'smw:diff',
+			$instance->getSlot( $this->compositePropertyTableDiffIterator )
+		);
+	}
+
+	public function testCreateSlotWithDiff() {
+
+		$this->cache->expects( $this->once() )
+			->method( 'save' )
+			->will( $this->returnValue( array() ) );
+
+		$this->compositePropertyTableDiffIterator->expects( $this->once() )
+			->method( 'getOrderedDiffByTable' )
+			->will( $this->returnValue( array( 'Foo' => 'Bar' ) ) );
+
+		$instance = new TransitionalDiffStore(
+			$this->cache
+		);
+
+		$this->assertContains(
+			'smw:diff',
+			$instance->createSlotFrom( $this->compositePropertyTableDiffIterator )
+		);
+	}
+
+	public function testCreateSlotWithEmptyDiff() {
+
+		$this->cache->expects( $this->never() )
+			->method( 'save' );
+
+		$this->compositePropertyTableDiffIterator->expects( $this->once() )
+			->method( 'getOrderedDiffByTable' )
+			->will( $this->returnValue( array() ) );
+
+		$instance = new TransitionalDiffStore(
+			$this->cache
+		);
+
+		$this->assertNull(
+			$instance->createSlotFrom( $this->compositePropertyTableDiffIterator )
+		);
+	}
+
+	public function testDelete() {
+
+		$this->cache->expects( $this->once() )
+			->method( 'delete' );
+
+		$instance = new TransitionalDiffStore(
+			$this->cache
+		);
+
+		$instance->delete( 'foo' );
+	}
+
+	public function testNewTableChangeOpsFrom() {
+
+		$res = array(
+			'Foo' => array( 'Bar' ),
+			'Foobar' => array( 'baz' )
+		);
+
+		$this->cache->expects( $this->once() )
+			->method( 'fetch' )
+			->with( $this->equalTo( 'Foo:bar' ) )
+			->will( $this->returnValue( $res ) );
+
+		$instance = new TransitionalDiffStore(
+			$this->cache
+		);
+
+		$this->assertContainsOnlyInstancesOf(
+			'\SMW\SQLStore\ChangeOp\TableChangeOp',
+			$instance->newTableChangeOpsFrom( 'Foo:bar' )
+		);
+	}
+
+	public function testNewTableChangeOpsFromUnknownSlot() {
+
+		$this->cache->expects( $this->once() )
+			->method( 'fetch' );
+
+		$instance = new TransitionalDiffStore(
+			$this->cache
+		);
+
+		$this->assertEmpty(
+			$instance->newTableChangeOpsFrom( 'Foo:bar' )
+		);
+	}
+
+}


### PR DESCRIPTION
This PR is made in reference to: #N/A

This PR addresses or contains:

- Pending the size of a diff, transferring it with the job parameter maybe too large and can eventually fail during unserialization forcing a job and hereby the update transaction to fail with "Notice: unserialize(): Error at offset 65504 of 65535 bytes in ..."
- This class will store the diff object temporarily in Cache with the possibility to retrieve it at a later point without relying on the `JobQueueDB` as storage medium.

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed

