### PR TITLE
ListResultPrinter / Fix usage of sep in format=template

### DIFF
--- a/includes/queryprinters/ListResultPrinter.php
+++ b/includes/queryprinters/ListResultPrinter.php
@@ -224,7 +224,7 @@ class ListResultPrinter extends ResultPrinter {
 		}
 
 		// Define separators for list items
-		if ( $this->params['format'] !== 'template' ){
+		if ( $this->params['sep'] !== '' ){
 			if ( $this->params['format'] === 'list' && $this->params['sep'] === ',' ){
 				// Make default list ", , , and "
 				$this->listsep = ', ';

--- a/tests/phpunit/Integration/ByJsonScript/Fixtures/f-0803.json
+++ b/tests/phpunit/Integration/ByJsonScript/Fixtures/f-0803.json
@@ -1,0 +1,47 @@
+{
+	"description": "Test `format=template` and `sep`/`named args` (...)",
+	"setup": [
+		{
+			"namespace": "SMW_NS_PROPERTY",
+			"page": "Has text",
+			"contents": "[[Has type::Text]]"
+		},
+		{
+			"namespace": "NS_TEMPLATE",
+			"page": "Example/F0803/Sep",
+			"contents": "<includeonly>{{{?Has text}}}</includeonly>"
+		},
+		{
+			"page": "Example/F0803/1",
+			"contents": "{{#subobject: |@category=F0803 |Has text=123 |Has text=456 }} {{#subobject: |@category=F0803 |Has text=abc }}"
+		},
+		{
+			"page": "Example/F0803/Q.1",
+			"contents": "{{#ask: [[Category:F0803]] |?Has text |format=template |template=Example/F0803/Sep |mainlabel=main |named args=yes |link=none |sep= &#32;&bull;&#32; |sort=Has text |order=asc }}"
+		}
+	],
+	"tests": [
+		{
+			"type": "parser",
+			"about": "#0",
+			"subject": "Example/F0803/Q.1",
+			"assert-output": {
+				"to-contain": [
+					"123&#32;&#8226;&#32; 456&#32;&#8226;&#32;abc"
+				]
+			}
+		}
+	],
+	"settings": {
+		"smwgPageSpecialProperties": [ "_MDAT" ],
+		"smwgNamespacesWithSemanticLinks": {
+			"NS_MAIN": true,
+			"SMW_NS_PROPERTY": true
+		}
+	},
+	"meta": {
+		"version": "2",
+		"is-incomplete": false,
+		"debug": false
+	}
+}


### PR DESCRIPTION
This PR is made in reference to: # [0, 1]

This PR addresses or contains:

- Most likely introduced with https://github.com/SemanticMediaWiki/SemanticMediaWiki/commit/66b776138b9c9607566cdc2f7ada8ffc77804bac

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed

[0] [Issues with the "sep" function in mode Query template.](https://www.semantic-mediawiki.org/wiki/Thread:Semantic-mediawiki.org:Community_portal/Issues_with_the_%22sep%22_function_in_mode_Query_template.)
[1] http://naruto.wikia.com/wiki/Thread:217742#29
