### PR TITLE
ListResultPrinter / Add `template arguments` parameter, refs 972

### DIFF
--- a/includes/queryprinters/ListResultPrinter.php
+++ b/includes/queryprinters/ListResultPrinter.php
@@ -403,11 +403,18 @@ class ListResultPrinter extends ResultPrinter {
 			$value = '';
 			$fieldName = '';
 
-			if ( $this->mNamedArgs ) {
+			// {{{?Foo}}}
+			if ( $this->mNamedArgs || $this->params['template arguments'] === 'legacy' ) {
 				$fieldName = '?' . $field->getPrintRequest()->getLabel();
 			}
 
-			if ( $fieldName === '' || $fieldName === '?' ) {
+			// {{{Foo}}}
+			if ( $fieldName === '' && $this->params['template arguments'] === 'named' ) {
+				$fieldName = $field->getPrintRequest()->getLabel();
+			}
+
+			// {{{1}}}
+			if ( $fieldName === '' || $fieldName === '?' || $this->params['template arguments'] === 'numbered' ) {
 				$fieldName = $fieldName . $i + 1;
 			}
 
@@ -473,6 +480,12 @@ class ListResultPrinter extends ResultPrinter {
 		$params['template'] = array(
 			'message' => 'smw-paramdesc-template',
 			'default' => '',
+		);
+
+		$params['template arguments'] = array(
+			'message' => 'smw-paramdesc-template-arguments',
+			'default' => '',
+			'values' => array( 'numbered', 'named', 'legacy' ),
 		);
 
 		$params['named args'] = array(

--- a/tests/phpunit/Integration/ByJsonScript/Fixtures/f-0803.json
+++ b/tests/phpunit/Integration/ByJsonScript/Fixtures/f-0803.json
@@ -1,5 +1,5 @@
 {
-	"description": "Test `format=template` and `sep`/`named args` (...)",
+	"description": "Test `format=template` with `sep`/`named args`/`template arguments` (#972, #2022)",
 	"setup": [
 		{
 			"namespace": "SMW_NS_PROPERTY",
@@ -12,12 +12,56 @@
 			"contents": "<includeonly>{{{?Has text}}}</includeonly>"
 		},
 		{
+			"namespace": "NS_TEMPLATE",
+			"page": "Example/F0803/Numbered",
+			"contents": "<includeonly>{{{1}}}</includeonly>"
+		},
+		{
+			"namespace": "NS_TEMPLATE",
+			"page": "Example/F0803/Named",
+			"contents": "<includeonly>{{{Has text}}}</includeonly>"
+		},
+		{
+			"namespace": "NS_TEMPLATE",
+			"page": "Example/F0803/NamedWithMainlabel",
+			"contents": "<includeonly>{{{main}}}{{{Has text}}}</includeonly>"
+		},
+		{
+			"namespace": "NS_TEMPLATE",
+			"page": "Example/F0803/Legacy",
+			"contents": "<includeonly>{{{?Has text}}}</includeonly>"
+		},
+		{
 			"page": "Example/F0803/1",
 			"contents": "{{#subobject: |@category=F0803 |Has text=123 |Has text=456 }} {{#subobject: |@category=F0803 |Has text=abc }}"
 		},
 		{
 			"page": "Example/F0803/Q.1",
 			"contents": "{{#ask: [[Category:F0803]] |?Has text |format=template |template=Example/F0803/Sep |mainlabel=main |named args=yes |link=none |sep= &#32;&bull;&#32; |sort=Has text |order=asc }}"
+		},
+		{
+			"page": "Example/F0803/Q.2",
+			"contents": "{{#ask: [[Category:F0803]] |?Has text |format=template |template=Example/F0803/Sep |mainlabel=main |template arguments=named |named args=yes |link=none |sep= &#32;&bull;&#32; |sort=Has text |order=asc }}"
+		},
+		{
+			"page": "Example/F0803/Q.3",
+			"contents": "{{#ask: [[Category:F0803]] |?Has text |format=template |template=Example/F0803/Legacy |mainlabel=main |template arguments=named |link=none |sep= &#32;&bull;&#32; |sort=Has text |order=asc }}"
+		},
+		{
+			"page": "Example/F0803/Q.4",
+			"contents": "{{#ask: [[Category:F0803]] |?Has text |format=template |template=Example/F0803/Named |mainlabel=main |template arguments=named |link=none |sep= &#32;&bull;&#32; |sort=Has text |order=asc }}"
+		},
+		{
+			"page": "Example/F0803/Q.5",
+			"contents": "{{#ask: [[Category:F0803]] |?Has text |format=template |template=Example/F0803/NamedWithMainlabel |mainlabel=main |template arguments=named |link=none |sep= &#32;&bull;&#32; |sort=Has text |order=asc }}"
+		},
+		{
+			"page": "Example/F0803/Q.6",
+			"contents": "{{#ask: [[Category:F0803]] |?Has text |format=template |template=Example/F0803/Numbered |mainlabel=main |template arguments=numbered |link=none |sep= &#32;&bull;&#32; |sort=Has text |order=asc }}"
+		},
+		{
+			"page": "Example/F0803/Q.7",
+			"contents": "{{#ask: [[Category:F0803]] |?Has text |format=template |template=Example/F0803/Numbered |mainlabel=- |template arguments=numbered |link=none |sep= &#32;&bull;&#32; |sort=Has text |order=asc }}"
 		}
 	],
 	"tests": [
@@ -25,6 +69,66 @@
 			"type": "parser",
 			"about": "#0",
 			"subject": "Example/F0803/Q.1",
+			"assert-output": {
+				"to-contain": [
+					"123&#32;&#8226;&#32; 456&#32;&#8226;&#32;abc"
+				]
+			}
+		},
+		{
+			"type": "parser",
+			"about": "#1 (named args wins over template arguments)",
+			"subject": "Example/F0803/Q.2",
+			"assert-output": {
+				"to-contain": [
+					"123&#32;&#8226;&#32; 456&#32;&#8226;&#32;abc"
+				]
+			}
+		},
+		{
+			"type": "parser",
+			"about": "#2 (`named` selected but template contains ?... )",
+			"subject": "Example/F0803/Q.3",
+			"assert-output": {
+				"to-contain": [
+					"{{{?Has text}}}&#32;&#8226;&#32;{{{?Has text}}}"
+				]
+			}
+		},
+		{
+			"type": "parser",
+			"about": "#3 (`named` selected)",
+			"subject": "Example/F0803/Q.4",
+			"assert-output": {
+				"to-contain": [
+					"123&#32;&#8226;&#32; 456&#32;&#8226;&#32;abc"
+				]
+			}
+		},
+		{
+			"type": "parser",
+			"about": "#4 (`named` selected with mainlabel)",
+			"subject": "Example/F0803/Q.5",
+			"assert-output": {
+				"to-contain": [
+					"Example/F0803/1#_a8833df1372ac8f410272cb680410853123&#32;&#8226;&#32; 456&#32;&#8226;&#32;Example/F0803/1#_41e021fb1955f0af8aa8b9dcb8313425abc"
+				]
+			}
+		},
+		{
+			"type": "parser",
+			"about": "#5 (`numbered` selected)",
+			"subject": "Example/F0803/Q.6",
+			"assert-output": {
+				"to-contain": [
+					"Example/F0803/1#_a8833df1372ac8f410272cb680410853&#32;&#8226;&#32;Example/F0803/1#_41e021fb1955f0af8aa8b9dcb8313425"
+				]
+			}
+		},
+		{
+			"type": "parser",
+			"about": "#6 (`numbered` selected, without mainlabel)",
+			"subject": "Example/F0803/Q.7",
 			"assert-output": {
 				"to-contain": [
 					"123&#32;&#8226;&#32; 456&#32;&#8226;&#32;abc"


### PR DESCRIPTION
This PR is made in reference to: #972, [0]

This PR addresses or contains:

- Adds the `template arguments` parameter with `'numbered', 'named', 'legacy'` where numbered being `{{{1}}}`, named is interpret as `{{{Has test}}}`, and legacy to require the `?` `{{{?Has text}}}` which is equal to `named args`
- `named args` is used with priority (to avoid any incompatibilities with existing output) even in cases where `|template arguments=named` is denoted

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed

[0] https://semantic-mediawiki.org/wiki/Thread:Help_talk:Template_format/Clarifying_something_with_named_args