### PR TITLE
Add StringCondition::COND_EQ

### DIFF
--- a/includes/articlepages/SMW_PropertyPage.php
+++ b/includes/articlepages/SMW_PropertyPage.php
@@ -101,11 +101,12 @@ class SMWPropertyPage extends SMWOrderedListPage {
 	protected function getTopIndicator() {
 
 		$propertyName = htmlspecialchars( $this->mTitle->getText() );
-
 		$usageCountHtml = '';
+
 		$requestOptions = new RequestOptions();
-		$requestOptions->limit = 1;
-		$requestOptions->addStringCondition( $propertyName, StringCondition::STRCOND_PRE );
+		$requestOptions->setLimit( 1 );
+		$requestOptions->addStringCondition( $propertyName, StringCondition::COND_EQ );
+
 		$cachedLookupList = $this->store->getPropertiesSpecial( $requestOptions );
 		$usageList = $cachedLookupList->fetchList();
 

--- a/src/SQLStore/RequestOptionsProcessor.php
+++ b/src/SQLStore/RequestOptionsProcessor.php
@@ -103,19 +103,22 @@ class RequestOptionsProcessor {
 		if ( $labelCol !== '' ) {
 			foreach ( $requestOptions->getStringConditions() as $strcond ) {
 				$string = str_replace( '_', '\_', $strcond->string );
+				$condition = 'LIKE';
 
 				switch ( $strcond->condition ) {
-					case StringCondition::STRCOND_PRE:  $string .= '%';
+					case StringCondition::COND_PRE:  $string .= '%';
 					break;
-					case StringCondition::STRCOND_POST: $string = '%' . $string;
+					case StringCondition::COND_POST: $string = '%' . $string;
 					break;
-					case StringCondition::STRCOND_MID:  $string = '%' . $string . '%';
+					case StringCondition::COND_MID:  $string = '%' . $string . '%';
+					break;
+					case StringCondition::COND_EQ:  $condition = '=';
 					break;
 				}
 
 				$conditionOperator = $strcond->isDisjunctiveCondition ? ' OR ' : ' AND ';
 
-				$sqlConds .= ( ( $addAnd || ( $sqlConds !== '' ) ) ? $conditionOperator : '' ) . $labelCol . ' LIKE ' . $connection->addQuotes( $string );
+				$sqlConds .= ( ( $addAnd || ( $sqlConds !== '' ) ) ? $conditionOperator : '' ) . "$labelCol $condition " . $connection->addQuotes( $string );
 			}
 		}
 

--- a/src/StringCondition.php
+++ b/src/StringCondition.php
@@ -14,9 +14,28 @@ namespace SMW;
  */
 class StringCondition {
 
-	const STRCOND_PRE = 0;
-	const STRCOND_POST = 1;
-	const STRCOND_MID = 2;
+	/**
+	 * String matches prefix
+	 */
+	const COND_PRE = 0;
+	const STRCOND_PRE = self::COND_PRE; // Deprecated
+
+	/**
+	 * String matches postfix
+	 */
+	const COND_POST = 1;
+	const STRCOND_POST = self::COND_POST; // Deprecated
+
+	/**
+	 * String matches to some inner part
+	 */
+	const COND_MID = 2;
+	const STRCOND_MID = self::COND_MID; // Deprecated
+
+	/**
+	 * String matches as equal
+	 */
+	const COND_EQ = 3;
 
 	/**
 	 * String to match.
@@ -34,10 +53,6 @@ class StringCondition {
 	public $isDisjunctiveCondition;
 
 	/**
-	 * Condition. One of STRCOND_PRE (string matches prefix),
-	 * STRCOND_POST (string matches postfix), STRCOND_MID
-	 * (string matches to some inner part).
-	 *
 	 * @var integer
 	 */
 	public $condition;

--- a/tests/phpunit/Unit/SQLStore/RequestOptionsProcessorTest.php
+++ b/tests/phpunit/Unit/SQLStore/RequestOptionsProcessorTest.php
@@ -135,6 +135,19 @@ class RequestOptionsProcessorTest extends \PHPUnit_Framework_TestCase {
 			' AND Foo >= 1 OR Bar LIKE foobar% OR Bar LIKE %foobaz'
 		);
 
+		# 3
+		$requestOptions = new RequestOptions();
+		$requestOptions->boundary = true;
+
+		$requestOptions->addStringCondition( 'foo_bar', StringCondition::COND_EQ );
+
+		$provider[] = array(
+			$requestOptions,
+			'Foo',
+			'Bar',
+			' AND Foo >= 1 AND Bar = foo\_bar'
+		);
+
 		return $provider;
 	}
 

--- a/tests/phpunit/Unit/StringConditionTest.php
+++ b/tests/phpunit/Unit/StringConditionTest.php
@@ -35,7 +35,7 @@ class StringConditionTest extends \PHPUnit_Framework_TestCase {
 		);
 
 		$this->assertEquals(
-			StringCondition::STRCOND_PRE,
+			StringCondition::COND_PRE,
 			$instance->condition
 		);
 


### PR DESCRIPTION
This PR is made in reference to: #

This PR addresses or contains:

- Avoids a `LIKE` match and instead uses `=` when selecting properties that are known (as in case of the property page) with the property label expected to be equal (`COND_EQ`)

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed

