### PR TITLE
Handle imported vocab in MonolingualTextPropertyValueResourceBuilder 

### DIFF
--- a/includes/export/SMW_Exporter.php
+++ b/includes/export/SMW_Exporter.php
@@ -367,8 +367,8 @@ class SMWExporter {
 	/**
 	 * @see DataItemToExpResourceEncoder::mapPropertyToResourceElement
 	 */
-	static public function getResourceElementForProperty( SMWDIProperty $diProperty, $helperProperty = false ) {
-		return self::$dataItemToExpResourceEncoder->mapPropertyToResourceElement( $diProperty, $helperProperty );
+	static public function getResourceElementForProperty( SMWDIProperty $diProperty, $helperProperty = false, $seekImportVocabulary = true ) {
+		return self::$dataItemToExpResourceEncoder->mapPropertyToResourceElement( $diProperty, $helperProperty, $seekImportVocabulary );
 	}
 
 	/**

--- a/src/Exporter/Element/ExpResource.php
+++ b/src/Exporter/Element/ExpResource.php
@@ -28,6 +28,11 @@ class ExpResource extends ExpElement {
 	private $uri;
 
 	/**
+	 * @var boolean
+	 */
+	public $isImported = false;
+
+	/**
 	 * @note The given URI must not contain serialization-specific
 	 * abbreviations or escapings, such as XML entities.
 	 *
@@ -54,6 +59,15 @@ class ExpResource extends ExpElement {
 	 */
 	public function isBlankNode() {
 		return $this->uri === '' || $this->uri{0} == '_';
+	}
+
+	/**
+	 * @since 2.5
+	 *
+	 * @return boolean
+	 */
+	public function isImported() {
+		return $this->isImported;
 	}
 
 	/**

--- a/src/Exporter/ResourceBuilders/MonolingualTextPropertyValueResourceBuilder.php
+++ b/src/Exporter/ResourceBuilders/MonolingualTextPropertyValueResourceBuilder.php
@@ -34,7 +34,28 @@ class MonolingualTextPropertyValueResourceBuilder extends PropertyValueResourceB
 	 */
 	public function addResourceValue( ExpData $expData, DIProperty $property, DataItem $dataItem ) {
 
-		parent::addResourceValue( $expData, $property, $dataItem );
+		$expResourceElement = $this->exporter->getResourceElementForWikiPage(
+			$property->getCanonicalDiWikiPage(),
+			true
+		);
+
+		// Avoid that an imported vocabulary is pointing to an internal resource.
+		//
+		// For example: <Has_alternative_label> imported from <skos:altLabel>
+		// with "Monolingual text" type is expected to produce:
+		//
+		// - <property:Has_alternative_label rdf:resource="http://example.org/id/Foo_MLa9c103f4379a94bfab97819dacd3c182"/>
+		// - <skos:altLabel xml:lang="en">Foo</skos:altLabel>
+		if ( $expResourceElement->isImported() ) {
+			$seekImportVocabulary = false;
+
+			$expData->addPropertyObjectValue(
+				$this->exporter->getResourceElementForProperty( $property, false, $seekImportVocabulary ),
+				$this->exporter->getDataItemExpElement( $dataItem )
+			);
+		} else {
+			parent::addResourceValue( $expData, $property, $dataItem );
+		}
 
 		$dataValue = DataValueFactory::getInstance()->newDataValueByItem(
 			$dataItem,
@@ -48,7 +69,7 @@ class MonolingualTextPropertyValueResourceBuilder extends PropertyValueResourceB
 		}
 
 		$expData->addPropertyObjectValue(
-			$this->exporter->getResourceElementForWikiPage( $property->getCanonicalDiWikiPage(), true ),
+			$expResourceElement,
 			new ExpLiteral(
 				(string)$list['_TEXT'],
 				'http://www.w3.org/2001/XMLSchema#string',

--- a/src/SPARQLStore/QueryEngine/CompoundConditionBuilder.php
+++ b/src/SPARQLStore/QueryEngine/CompoundConditionBuilder.php
@@ -365,7 +365,7 @@ class CompoundConditionBuilder {
 		$redirectExpElement = Exporter::getInstance()->getResourceElementForWikiPage( $dataItem );
 
 		// If the resource was matched to an imported vocab then no redirect is required
-		if ( isset( $redirectExpElement->wasMatchedToImportVocab ) && $redirectExpElement->wasMatchedToImportVocab ) {
+		if ( $redirectExpElement->isImported() ) {
 			return null;
 		}
 

--- a/tests/phpunit/Integration/ByJsonScript/Contents/skos-import.txt
+++ b/tests/phpunit/Integration/ByJsonScript/Contents/skos-import.txt
@@ -1,0 +1,33 @@
+http://www.w3.org/2004/02/skos/core#|[http://www.w3.org/TR/skos-reference/skos.rdf Simple Knowledge Organization System (SKOS)]
+ altLabel|Type:Monolingual text
+ broader|Type:Annotation URI
+ broaderTransitive|Type:Annotation URI
+ broadMatch|Type:Annotation URI
+ changeNote|Type:Text
+ closeMatch|Type:Annotation URI
+ Collection|Class
+ Concept|Class
+ ConceptScheme|Class
+ definition|Type:Text
+ editorialNote|Type:Text
+ exactMatch|Type:Annotation URI
+ example|Type:Text
+ hasTopConcept|Type:Page
+ hiddenLabel|Type:String
+ historyNote|Type:Text
+ inScheme|Type:Page
+ mappingRelation|Type:Page
+ member|Type:Page
+ memberList|Type:Page
+ narrower|Type:Annotation URI
+ narrowerTransitive|Type:Annotation URI
+ narrowMatch|Type:Annotation URI
+ notation|Type:Text
+ note|Type:Text
+ OrderedCollection|Class
+ prefLabel|Type:String
+ related|Type:Annotation URI
+ relatedMatch|Type:Annotation URI
+ scopeNote|Type:Text
+ semanticRelation|Type:Page
+ topConceptOf|Type:Page

--- a/tests/phpunit/Integration/ByJsonScript/Fixtures/r-0011.json
+++ b/tests/phpunit/Integration/ByJsonScript/Fixtures/r-0011.json
@@ -1,0 +1,112 @@
+{
+	"description": "Test RDF output generation `skos` import/`skos:altLabel` as Monolingual text (`wgContLang=en`, `wgLang=en`)",
+	"setup": [
+		{
+			"namespace": "NS_MEDIAWIKI",
+			"page": "Smw import skos",
+			"contents": {
+				"import-from": "/../Contents/skos-import.txt"
+			}
+		},
+		{
+			"namespace": "SMW_NS_PROPERTY",
+			"page": "Has alternative label",
+			"contents": "[[Imported from::skos:altLabel]]"
+		},
+		{
+			"page": "Example/P0440/Triacylglycerol lipase",
+			"contents": "[[Has alternative label::Lipase@en]], [[Has alternative label::Tributyrase@en]], [[Has alternative label::Triglyceride lipase@en]], [[Has alternative label::トリアシルグリセロールリパーゼ@ja]]"
+		}
+	],
+	"tests": [
+		{
+			"type": "rdf",
+			"about": "#0",
+			"exportcontroller": {
+				"print-pages": [
+					"Example/P0440/Triacylglycerol lipase"
+				],
+				"parameters": {
+					"backlinks": true,
+					"recursion": "1",
+					"revisiondate": false
+				}
+			},
+			"assert-output": {
+				"to-contain": [
+					"<property:Has_alternative_label rdf:resource=\"&wiki;Example/P0440/Triacylglycerol_lipase-23_MLb850763abfc7ff93b2753834b000b7dc\"/>",
+					"<property:Has_alternative_label rdf:resource=\"&wiki;Example/P0440/Triacylglycerol_lipase-23_MLa9c103f4379a94bfab97819dacd3c182\"/>",
+					"<property:Has_alternative_label rdf:resource=\"&wiki;Example/P0440/Triacylglycerol_lipase-23_MLcbdbdd5279ca447e5dc7f78465f45256\"/>",
+					"<property:Has_alternative_label rdf:resource=\"&wiki;Example/P0440/Triacylglycerol_lipase-23_MLca7a57d40b775013e7fcc714ec4da30d\"/>",
+					"<skos:altLabel xml:lang=\"en\">Lipase</skos:altLabel>",
+					"<skos:altLabel xml:lang=\"en\">Tributyrase</skos:altLabel>",
+					"<skos:altLabel xml:lang=\"en\">Triglyceride lipase</skos:altLabel>",
+					"<skos:altLabel xml:lang=\"ja\">トリアシルグリセロールリパーゼ</skos:altLabel>",
+					"<swivt:Subject rdf:about=\"http://example.org/id/Example/P0440/Triacylglycerol_lipase-23_MLb850763abfc7ff93b2753834b000b7dc\">",
+					"<property:Language_code rdf:datatype=\"http://www.w3.org/2001/XMLSchema#string\">en</property:Language_code>",
+					"<property:Text rdf:datatype=\"http://www.w3.org/2001/XMLSchema#string\">Lipase</property:Text>",
+					"<owl:ObjectProperty rdf:about=\"http://example.org/id/Property-3AHas_alternative_label\" />",
+					"<owl:DatatypeProperty rdf:about=\"http://www.w3.org/2004/02/skos/core#altLabel\" />"
+				]
+			}
+		},
+		{
+			"type": "rdf",
+			"about": "#1",
+			"exportcontroller": {
+				"syntax": "turtle",
+				"print-pages": [
+					"Example/P0440/Triacylglycerol lipase"
+				],
+				"parameters": {
+					"backlinks": true,
+					"recursion": "1",
+					"revisiondate": false
+				}
+			},
+			"assert-output": {
+				"to-contain": [
+					"property:Has_alternative_label  <http://example.org/id/Example/P0440/Triacylglycerol_lipase-23_MLb850763abfc7ff93b2753834b000b7dc> ,  <http://example.org/id/Example/P0440/Triacylglycerol_lipase-23_MLa9c103f4379a94bfab97819dacd3c182> ,  <http://example.org/id/Example/P0440/Triacylglycerol_lipase-23_MLcbdbdd5279ca447e5dc7f78465f45256> ,  <http://example.org/id/Example/P0440/Triacylglycerol_lipase-23_MLca7a57d40b775013e7fcc714ec4da30d> ;",
+					"skos:altLabel  \"Lipase\"@en ,  \"Tributyrase\"@en ,  \"Triglyceride lipase\"@en ,  \"トリアシルグリセロールリパーゼ\"@ja ;"
+				]
+			}
+		},
+		{
+			"type": "rdf",
+			"about": "#2",
+			"exportcontroller": {
+				"print-pages": [
+					"Property:Has alternative label"
+				],
+				"parameters": {
+					"backlinks": true,
+					"recursion": "1",
+					"revisiondate": false
+				}
+			},
+			"assert-output": {
+				"to-contain": [
+					"<owl:DatatypeProperty rdf:about=\"http://www.w3.org/2004/02/skos/core#altLabel\">",
+					"<rdfs:label>Has alternative label</rdfs:label>",
+					"<swivt:specialImportedFrom rdf:datatype=\"http://www.w3.org/2001/XMLSchema#string\">skos altLabel http://www.w3.org/2004/02/skos/core#</swivt:specialImportedFrom>",
+					"<swivt:type rdf:resource=\"http://semantic-mediawiki.org/swivt/1.0#_mlt_rec\"/>"
+				]
+			}
+		}
+	],
+	"settings": {
+		"wgContLang": "en",
+		"wgLang": "en",
+		"smwgExportBCNonCanonicalFormUse": false,
+		"smwgNamespacesWithSemanticLinks": {
+			"NS_MAIN": true,
+			"SMW_NS_PROPERTY": true
+		},
+		"smwgNamespace": "http://example.org/id/"
+	},
+	"meta": {
+		"version": "2",
+		"is-incomplete": false,
+		"debug": false
+	}
+}

--- a/tests/phpunit/Unit/Exporter/DataItemToExpResourceEncoderTest.php
+++ b/tests/phpunit/Unit/Exporter/DataItemToExpResourceEncoderTest.php
@@ -123,7 +123,7 @@ class DataItemToExpResourceEncoderTest extends \PHPUnit_Framework_TestCase {
 		);
 
 		$this->assertTrue(
-			$resource->wasMatchedToImportVocab
+			$resource->isImported()
 		);
 
 		$this->assertSame(


### PR DESCRIPTION
This PR is made in reference to: #1814

This PR addresses or contains:

- Import `skos:altLabel|Type:Monolingual text`
- Property that imports a vocabulary  (and is of type Monolingual text) is pointing to the internal resource `<property:Has_alternative_label rdf:resource="http://example.org/id/Foo_MLa9c103f4379a94bfab97819dacd3c182"/>` while the imported vocabulary contains the expected declaration `<skos:altLabel xml:lang="en">Foo</skos:altLabel>`

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed
