### PR TITLE
StringValueFormatter / Allow to reduce the text output length

### DIFF
--- a/tests/phpunit/Integration/ByJsonScript/Fixtures/p-0435.json
+++ b/tests/phpunit/Integration/ByJsonScript/Fixtures/p-0435.json
@@ -1,5 +1,5 @@
 {
-	"description": "Test in-text annotation using `_txt` type with 255+ char (#1878, `wgContLang=en`, `wgLang=en`)",
+	"description": "Test in-text annotation using `_txt` type with 255+ char, `#ask` to produce reduced length (#1878, `wgContLang=en`, `wgLang=en`)",
 	"setup": [
 		{
 			"namespace": "SMW_NS_PROPERTY",
@@ -9,6 +9,10 @@
 		{
 			"page": "Example/P0435/1",
 			"contents": "[[Has text::TBgcHiQBTvpV3XkFiRpMcV1KQoZvQXFyiQUQMM2RoYUyJaRoSyKnsQTWwia3HATd4YVmd8BZgkL2LfL0Q6rP5E90A\\4IuV6u/KdYjL3nxZvx0pbc3tbxwa6jMW1JDNxusaKQ52ftRS7DCEY1IPTRZnuRMLPgWYwLOsEAebOsxD7BBL9IK3Z2Osfh9s0FC1SUwCVdKcLkBgurXKGi99s61qnAU2zWFXBUCEzID6533LeaHCBKW8i2BgTK2tv65LHO6zB:;%&`^WithTextLongerThan255]]"
+		},
+		{
+			"page": "Example/P0435/Q.1",
+			"contents": "{{#ask: [[Example/P0435/1]] |?Has text#20 }}"
 		}
 	],
 	"tests": [
@@ -36,6 +40,16 @@
 			"assert-output": {
 				"to-contain": [
 					"TBgcHiQBTvpV3XkFiRpMcV1KQoZvQXFyiQUQMM2RoYUyJaRoSyKnsQTWwia3HATd4YVmd8BZgkL2LfL0Q6rP5E90A\\4IuV6u/KdYjL3nxZvx0pbc3tbxwa6jMW1JDNxusaKQ52ftRS7DCEY1IPTRZnuRMLPgWYwLOsEAebOsxD7BBL9IK3Z2Osfh9s0FC1SUwCVdKcLkBgurXKGi99s61qnAU2zWFXBUCEzID6533LeaHCBKW8i2BgTK2tv65LHO6zB:;%&amp;`^WithTextLongerThan255"
+				]
+			}
+		},
+		{
+			"type": "parser",
+			"about": "#1",
+			"subject": "Example/P0435/Q.1",
+			"assert-output": {
+				"to-contain": [
+					"<td class=\"Has-text smwtype_txt\">TBgcHiQBTvpV3XkFiRpM …</td>"
 				]
 			}
 		}

--- a/tests/phpunit/Unit/DataValues/ValueFormatters/StringValueFormatterTest.php
+++ b/tests/phpunit/Unit/DataValues/ValueFormatters/StringValueFormatterTest.php
@@ -71,6 +71,32 @@ class StringValueFormatterTest extends \PHPUnit_Framework_TestCase {
 		);
 	}
 
+	public function testFormatWithReducedLength() {
+
+		// > 255 / Reduced length
+		$text = 'Lorem ipsum dolor sit amet consectetuer justo Nam quis lobortis vel. Sapien nulla enim Lorem enim pede ' .
+		'lorem nulla justo diam wisi. Libero Nam turpis neque leo scelerisque nec habitasse a lacus mattis. Accumsan ' .
+		'tincidunt Sed adipiscing nec facilisis tortor Nunc Sed ipsum tellus';
+
+		$expected = 'Lorem ipsum dolor sit amet consectetuer …';
+
+		$stringValue = new StringValue( '_txt' );
+		$stringValue->setUserValue( $text );
+		$stringValue->setOutputFormat( 40 );
+
+		$instance = new StringValueFormatter( $stringValue );
+
+		$this->assertEquals(
+			$expected,
+			$instance->format( StringValueFormatter::HTML_LONG )
+		);
+
+		$this->assertEquals(
+			$expected,
+			$instance->format( StringValueFormatter::WIKI_SHORT )
+		);
+	}
+
 	public function testTryToFormatOnMissingDataValueThrowsException() {
 
 		$instance = new StringValueFormatter();


### PR DESCRIPTION
This PR is made in reference to: # N/A

This PR addresses or contains:

- A simple numeric value added to the output modifier `|?Has text#20` is interpret as requested length and hereby reduces the output text (if the overall string length is larger than the requested length then an additional `…` is displayed)
- Pending the last word to the requested length, the length may vary given that a whole word is returned as to the requested length (this does not apply for languages that use a different/no word separation)

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed

