### PR TITLE
ResultFieldMatchFinder / Support |+lang= filter in PrintRequests

### DIFF
--- a/includes/dataitems/SMW_DI_Container.php
+++ b/includes/dataitems/SMW_DI_Container.php
@@ -4,6 +4,8 @@
  */
 
 use SMW\DataItemException;
+use SMW\DIProperty;
+use SMWDIBlob as DIBlob;
 
 /**
  * Subclass of SMWSemanticData that is used to store the data in SMWDIContainer
@@ -178,6 +180,18 @@ class SMWDIContainer extends SMWDataItem {
 
 	public function getSortKey() {
 		return '';
+	}
+
+	/**
+	 * @since 2.5
+	 *
+	 * @param string $sortKey
+	 */
+	public function addCompositeSortKey( $sortKey ) {
+		$this->m_semanticData->addPropertyObjectValue(
+			new DIProperty( '_SKEY' ),
+			new DIBlob( $this->m_semanticData->getSubject()->getSortKey() . '#' . $sortKey )
+		);
 	}
 
 	public function getSerialization() {

--- a/includes/datavalues/SMW_DV_Record.php
+++ b/includes/datavalues/SMW_DV_Record.php
@@ -81,6 +81,7 @@ class SMWRecordValue extends AbstractMultiValue {
 		}
 
 		$containerSemanticData = $this->newContainerSemanticData( $value );
+		$sortKeys = array();
 
 		$values = $this->getValuesFromString( $value );
 		$valueIndex = 0; // index in value array
@@ -106,6 +107,7 @@ class SMWRecordValue extends AbstractMultiValue {
 
 				if ( $dataValue->isValid() ) { // valid DV: keep
 					$containerSemanticData->addPropertyObjectValue( $diProperty, $dataValue->getDataItem() );
+					$sortKeys[] = $dataValue->getDataItem()->getSortKey();
 
 					$valueIndex++;
 					$empty = false;
@@ -123,6 +125,10 @@ class SMWRecordValue extends AbstractMultiValue {
 		}
 
 		$this->m_dataitem = new DIContainer( $containerSemanticData );
+
+		// Composite sortkey is to ensure that Store::getPropertyValues can
+		// apply sorting during value selection
+		$this->m_dataitem->addCompositeSortKey( implode( ';', $sortKeys ) );
 	}
 
 	/**

--- a/src/DataValues/MonolingualTextValue.php
+++ b/src/DataValues/MonolingualTextValue.php
@@ -141,6 +141,10 @@ class MonolingualTextValue extends AbstractMultiValue {
 		}
 
 		$this->m_dataitem = new DIContainer( $containerSemanticData );
+
+		// Composite sortkey is to ensure that Store::getPropertyValues can
+		// apply sorting during value selection
+		$this->m_dataitem->addCompositeSortKey( implode( ';', array( $text, $languageCode ) ) );
 	}
 
 	/**

--- a/src/DataValues/ReferenceValue.php
+++ b/src/DataValues/ReferenceValue.php
@@ -185,6 +185,7 @@ class ReferenceValue extends AbstractMultiValue {
 		}
 
 		$containerSemanticData = $this->newContainerSemanticData( $value );
+		$sortKeys = array();
 
 		$values = $this->getValuesFromString( $value );
 		$index = 0; // index in value array
@@ -211,6 +212,7 @@ class ReferenceValue extends AbstractMultiValue {
 
 				if ( $dataValue->isValid() ) { // valid DV: keep
 					$containerSemanticData->addPropertyObjectValue( $property, $dataValue->getDataItem() );
+					$sortKeys[] = $dataValue->getDataItem()->getSortKey();
 
 					$index++;
 					$empty = false;
@@ -228,6 +230,10 @@ class ReferenceValue extends AbstractMultiValue {
 		}
 
 		$this->m_dataitem = new DIContainer( $containerSemanticData );
+
+		// Composite sortkey is to ensure that Store::getPropertyValues can
+		// apply sorting during value selection
+		$this->m_dataitem->addCompositeSortKey( implode( ';', $sortKeys ) );
 	}
 
 	/**

--- a/tests/phpunit/Integration/ByJsonScript/Fixtures/p-0440.json
+++ b/tests/phpunit/Integration/ByJsonScript/Fixtures/p-0440.json
@@ -1,0 +1,142 @@
+{
+	"description": "Test in-text annotation `_mlt_rec` (Monolingual text) with `|+lang`/`|+order` parameter (`wgContLang=en`, `wgLang=en`)",
+	"setup": [
+		{
+			"namespace": "SMW_NS_PROPERTY",
+			"page": "Has alternative label",
+			"contents": "[[Has type::Monolingual text]]"
+		},
+		{
+			"namespace": "SMW_NS_PROPERTY",
+			"page": "Has alternative record",
+			"contents": "[[Has type::Record]] [[Has fields::Text;Number]]"
+		},
+		{
+			"page": "Example/P0440/Triacylglycerol lipase",
+			"contents": "[[Has page::{{FULLPAGENAME}}]] [[Has alternative record::ABC;123]] [[Has alternative label::Lipase@en]], [[Has alternative label::Tributyrase@en]], [[Has alternative label::Triglyceride lipase@en]], [[Has alternative label::トリアシルグリセロールリパーゼ@ja]], [[Has alternative label::ليباز ثلاثي اسيل الغليسيرول@ar]], [[Has alternative label::Triacylglycérol lipase@fr]], [[Has alternative label::Triacilglicerol lipaza@sh]], [[Has alternative label::Triacilglicerol lipaza@sr]]"
+		},
+		{
+			"page": "Example/P0440/Q.0",
+			"contents": "{{#ask: [[Has alternative label::+]] |?Has alternative label|+order=desc }}"
+		},
+		{
+			"page": "Example/P0440/Q.1",
+			"contents": "{{#ask: [[Has alternative label::+]] |?Has alternative label|+order=asc }}"
+		},
+		{
+			"page": "Example/P0440/Q.2",
+			"contents": "{{#ask: [[Has alternative label::+]] |?Has alternative label|+lang=en }}"
+		},
+		{
+			"page": "Example/P0440/Q.3",
+			"contents": "{{#ask: [[Has alternative label::+]] |?Has alternative label|+lang=en|+limit=1 }}"
+		},
+		{
+			"page": "Example/P0440/Q.4",
+			"contents": "{{#ask: [[Has alternative label::+]] |?Has alternative label|+lang=en|+limit=1 |limit=0 }}"
+		},
+		{
+			"page": "Example/P0440/Q.5",
+			"contents": "{{#ask: [[Has alternative label::+]] |?Has alternative label|+lang=foo }}"
+		},
+		{
+			"page": "Example/P0440/Q.6",
+			"contents": "{{#ask: [[Has alternative label::+]] |?Has page|+lang=en }}"
+		},
+		{
+			"page": "Example/P0440/Q.7",
+			"contents": "{{#ask: [[Has alternative record::+]] |?Has alternative record|+lang=en }}"
+		}
+	],
+	"tests": [
+		{
+			"type": "parser",
+			"about": "#0 (no filter, lang tag, desc)",
+			"subject": "Example/P0440/Q.0",
+			"assert-output": {
+				"to-contain": [
+					"<td class=\"Has-alternative-label smwtype_mlt_rec\">トリアシルグリセロールリパーゼ (ja)<br />ليباز ثلاثي اسيل الغليسيرول (ar)<br />Triglyceride lipase (en)<br />Tributyrase (en)<br />Triacylglycérol lipase (fr)<br />Triacilglicerol lipaza (sr)<br />Triacilglicerol lipaza (sh)<br />Lipase (en)</td>"
+				]
+			}
+		},
+		{
+			"type": "parser",
+			"about": "#1 (no filter, lang tag, asc)",
+			"subject": "Example/P0440/Q.1",
+			"assert-output": {
+				"to-contain": [
+					"<td class=\"Has-alternative-label smwtype_mlt_rec\">Lipase (en)<br />Triacilglicerol lipaza (sh)<br />Triacilglicerol lipaza (sr)<br />Triacylglycérol lipase (fr)<br />Tributyrase (en)<br />Triglyceride lipase (en)<br />ليباز ثلاثي اسيل الغليسيرول (ar)<br />トリアシルグリセロールリパーゼ (ja)</td>"
+				]
+			}
+		},
+		{
+			"type": "parser",
+			"about": "#2 (filtered by language, no lang tag)",
+			"subject": "Example/P0440/Q.2",
+			"assert-output": {
+				"to-contain": [
+					"<td class=\"Has-alternative-label smwtype_txt\">Lipase<br />Tributyrase<br />Triglyceride lipase</td>"
+				]
+			}
+		},
+		{
+			"type": "parser",
+			"about": "#3 (column value list limited to 1)",
+			"subject": "Example/P0440/Q.3",
+			"assert-output": {
+				"to-contain": [
+					"<td class=\"Has-alternative-label smwtype_txt\">Lipase</td>"
+				]
+			}
+		},
+		{
+			"type": "parser",
+			"about": "#4 (no result, Special:Ask link)",
+			"subject": "Example/P0440/Q.4",
+			"assert-output": {
+				"to-contain": [
+					"-5B-5BHas-20alternative-20label::+-5D-5D/-3FHas-20alternative-20label-7C+lang=en-7C+limit=1/mainlabel=/offset=0/format=table"
+				]
+			}
+		},
+		{
+			"type": "parser",
+			"about": "#5 (invalid/unknown/unmatchable language)",
+			"subject": "Example/P0440/Q.5",
+			"assert-output": {
+				"not-contain": [
+					"<td class=\"Has-alternative-label smwtype_txt\">Lipase<br />Tributyrase<br />Triglyceride lipase</td>"
+				]
+			}
+		},
+		{
+			"type": "parser",
+			"about": "#6 (+lang not applied on non-Monolingual type)",
+			"subject": "Example/P0440/Q.6",
+			"assert-output": {
+				"to-contain": [
+					"title=\"Example/P0440/Triacylglycerol lipase\">Example/P0440/Triacylglycerol lipase</a>"
+				]
+			}
+		},
+		{
+			"type": "parser",
+			"about": "#7 (+lang not applied on non-Monolingual type)",
+			"subject": "Example/P0440/Q.7",
+			"assert-output": {
+				"to-contain": [
+					"title=\"Example/P0440/Triacylglycerol lipase\">Example/P0440/Triacylglycerol lipase</a>"
+				]
+			}
+		}
+	],
+	"settings": {
+		"wgContLang": "en",
+		"wgLang": "en"
+	},
+	"meta": {
+		"version": "2",
+		"is-incomplete": false,
+		"debug": false
+	}
+}

--- a/tests/phpunit/Integration/ByJsonScript/Fixtures/r-0006.json
+++ b/tests/phpunit/Integration/ByJsonScript/Fixtures/r-0006.json
@@ -102,7 +102,7 @@
 					"<property:HasTextNumberRecord rdf:resource=\"&wiki;Example/R0006/3-23_e594fde0f37d237549009d2ecebce80e\"/>",
 					"<property:Has_subobject rdf:resource=\"&wiki;Example/R0006/3-23A1\"/>",
 					"<property:Has_subobject rdf:resource=\"&wiki;Example/R0006/3-23A2\"/>",
-					"<property:Has_number rdf:datatype=\"http://www.w3.org/2001/XMLSchema#double\">123</property:Has_number>\n\t\t<property:Has_text rdf:datatype=\"http://www.w3.org/2001/XMLSchema#string\">Foo</property:Has_text>\n\t\t<swivt:wikiPageSortKey rdf:datatype=\"http://www.w3.org/2001/XMLSchema#string\">Example/R0006/3</swivt:wikiPageSortKey>",
+					"<property:Has_number rdf:datatype=\"http://www.w3.org/2001/XMLSchema#double\">123</property:Has_number>\n\t\t<property:Has_text rdf:datatype=\"http://www.w3.org/2001/XMLSchema#string\">Foo</property:Has_text>\n\t\t<swivt:wikiPageSortKey rdf:datatype=\"http://www.w3.org/2001/XMLSchema#string\">Example/R0006/3#Foo;123</swivt:wikiPageSortKey>",
 					"<property:HasTextNumberRecord rdf:resource=\"&wiki;Example/R0006/3-23_e594fde0f37d237549009d2ecebce80e\"/>\n\t\t<property:Has_number rdf:datatype=\"http://www.w3.org/2001/XMLSchema#double\">123</property:Has_number>",
 					"<property:HasTextNumberRecord rdf:resource=\"&wiki;Example/R0006/3-23_e594fde0f37d237549009d2ecebce80e\"/>\n\t\t<property:Has_number rdf:datatype=\"http://www.w3.org/2001/XMLSchema#double\">456</property:Has_number>"
 				]

--- a/tests/phpunit/Unit/Query/Result/ResultFieldMatchFinderTest.php
+++ b/tests/phpunit/Unit/Query/Result/ResultFieldMatchFinderTest.php
@@ -197,6 +197,10 @@ class ResultFieldMatchFinderTest extends \PHPUnit_Framework_TestCase {
 			->with($this->equalTo( PrintRequest::PRINT_PROP ) )
 			->will( $this->returnValue( true ) );
 
+		$printRequest->expects( $this->any() )
+			->method( 'getParameter' )
+			->will( $this->returnValue( false ) );
+
 		$printRequest->expects( $this->once() )
 			->method( 'getData' )
 			->will( $this->returnValue( $this->dataValueFactory->newPropertyValueByLabel( 'Prop' ) ) );


### PR DESCRIPTION
This PR is made in reference to: #1344

This PR addresses or contains:

- `|+lang=` is to support filtering of results that match a specific language and is applied during query post-processing after the condition has retrieved matchable entities. (The `PrintRequest` and hereby the DV may match text in different languages and unless the query condition was designed in a way that would made them reducible, it would display them all)
- Using the post-filtering mechanism allows that a query condition can be indifferent towards possible language matches, yet enables to only select the one that match the denoted `lang` value
- `|+lang=` filtering is only applied to instances of type `Monolingual text`

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed

