### PR TITLE
Recognize annotated language in @@@ syntax, refs 1855

### DIFF
--- a/src/InTextAnnotationParser.php
+++ b/src/InTextAnnotationParser.php
@@ -456,8 +456,8 @@ class InTextAnnotationParser {
 
 	private function getPropertyLink( $subject, $properties, $value, $valueCaption ) {
 
-		// #...
-		if ( strlen( $value ) == 3 && $value === '@@@' ) {
+		// #1855
+		if ( substr( $value, 0, 3 ) === '@@@' ) {
 			$property = end( $properties );
 
 			$dataValue = $this->dataValueFactory->newPropertyValueByLabel(
@@ -466,7 +466,14 @@ class InTextAnnotationParser {
 				$subject
 			);
 
-			return $dataValue->getShortWikitext( true );
+			if ( ( $lang = Localizer::getAnnotatedLanguageCodeFrom( $value ) ) !== false ) {
+				$dataValue->setOption( $dataValue::OPT_USER_LANGUAGE, $lang );
+				$dataValue->setCaption(
+					$valueCaption === false ? $dataValue->getWikiValue() : $valueCaption
+				);
+			}
+
+			return $dataValue->getShortWikitext( smwfGetLinker() );
 		}
 
 		return '';

--- a/tests/phpunit/Integration/ByJsonScript/Fixtures/p-0212.json
+++ b/tests/phpunit/Integration/ByJsonScript/Fixtures/p-0212.json
@@ -7,12 +7,25 @@
 			"contents": "[[Has type::Date]] {{#set: Has property description=Some text with a link to [http://example.org/ foo] and <li>stripped `li` in title element</li>@en}}"
 		},
 		{
+			"namespace": "SMW_NS_PROPERTY",
+			"page": "P106",
+			"contents": "[[Has type::Text]] [[Has preferred property label::occupation@en]] [[Has preferred property label::직업@ko]] [[Has preferred property label::職業@ja]] [[Has property description::人物の職業。「専門分野」@ja]] [[Has property description::대상 인물의 직업@ko]]"
+		},
+		{
 			"page": "Example/P0212/1",
 			"contents": "[[Has date::@@@]]"
 		},
 		{
 			"page": "Example/P0212/2",
 			"contents": "[[Has date::@@@|With extra caption]]"
+		},
+		{
+			"page": "Example/P0212/3",
+			"contents": "[[P106::@@@ja]]"
+		},
+		{
+			"page": "Example/P0212/4",
+			"contents": "[[P106::@@@ko|WithCaption]]"
 		}
 	],
 	"tests": [
@@ -37,6 +50,26 @@
 					"<span class=\"smw-highlighter\" data-type=\"1\" data-state=\"inline\" data-title=\"Property\" title=\"Some text with a link to &amp;#x005B;http://example.org/ foo] and stripped `li` in title element\">",
 					"<div class=\"smwttcontent\">Some text with a link to <a rel=\"nofollow\" class=\"external text\" href=\"http://example.org/\">foo</a> and <li>stripped `li` in title element</li></div>",
 					"title=\"Property:Has date\">With extra caption</a>"
+				]
+			}
+		},
+		{
+			"type": "parser",
+			"about": "#2",
+			"subject": "Example/P0212/3",
+			"assert-output": {
+				"to-contain": [
+					"title=\"Property:P106\">職業</a></span><div class=\"smwttcontent\">人物の職業。「専門分野」</div></span>&#160;<span title=\"P106\"><sup>ᵖ</sup>"
+				]
+			}
+		},
+		{
+			"type": "parser",
+			"about": "#3",
+			"subject": "Example/P0212/4",
+			"assert-output": {
+				"to-contain": [
+					"title=\"Property:P106\">WithCaption</a></span><div class=\"smwttcontent\">대상 인물의 직업</div></span>"
 				]
 			}
 		}

--- a/tests/phpunit/Unit/InTextAnnotationParserTest.php
+++ b/tests/phpunit/Unit/InTextAnnotationParserTest.php
@@ -558,7 +558,7 @@ class InTextAnnotationParserTest extends \PHPUnit_Framework_TestCase {
 				'smwgInlineErrors'  => true,
 				'smwgEnabledInTextAnnotationParserStrictMode' => true
 			),
-			'[[Foo::@@@]] [[Bar::@@@|Foobar]]',
+			'[[Foo::@@@]] [[Bar::@@@en|Foobar]]',
 			array(
 				'resultText'     => $testEnvironment->getLocalizedTextByNamespace( SMW_NS_PROPERTY, '[[:Property:Foo|Foo]] [[:Property:Bar|Foobar]]' ),
 				'propertyCount'  => 0


### PR DESCRIPTION
This PR is made in reference to: #1855

This PR addresses or contains:

- `[[SomeProperty::@@@]]` will use the user language to match a preferred label, and/or property description
- `[[SomeProperty::@@@en]]` will use the annotated `@en` language

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed

