### PR TITLE
TransientStatsdCollector / Use DeferredCallableUpdate, refs 2046

### DIFF
--- a/src/MediaWiki/Hooks/HookRegistry.php
+++ b/src/MediaWiki/Hooks/HookRegistry.php
@@ -558,10 +558,12 @@ class HookRegistry {
 		/**
 		 * @see https://www.semantic-mediawiki.org/wiki/Hooks#SMW::Store::AfterQueryResultLookupComplete
 		 */
-		$this->handlers['SMW::Store::AfterQueryResultLookupComplete'] = function ( $store, &$result ) use ( $queryDependencyLinksStore ) {
+		$this->handlers['SMW::Store::AfterQueryResultLookupComplete'] = function ( $store, &$result ) use ( $queryDependencyLinksStore, $applicationFactory ) {
 
 			$queryDependencyLinksStore->setStore( $store );
 			$queryDependencyLinksStore->doUpdateDependenciesFrom( $result );
+
+			$applicationFactory->singleton( 'CachedQueryResultPrefetcher' )->recordStats();
 
 			return true;
 		};

--- a/src/SharedCallbackContainer.php
+++ b/src/SharedCallbackContainer.php
@@ -280,7 +280,7 @@ class SharedCallbackContainer implements CallbackContainer {
 					CachedQueryResultPrefetcher::CACHE_NAMESPACE, $cacheType,
 					$settings->get( 'smwgQueryResultCacheLifetime' )
 				),
-				$callbackLoader->create(
+				$callbackLoader->singleton(
 					'TransientStatsdCollector',
 					CachedQueryResultPrefetcher::STATSD_ID
 				)
@@ -322,7 +322,7 @@ class SharedCallbackContainer implements CallbackContainer {
 			$ttl = 0;
 
 			$transientStatsdCollector = new TransientStatsdCollector(
-				$callbackLoader->load( 'BlobStore', TransientStatsdCollector::CACHE_NAMESPACE, $cacheType, $ttl ),
+				$callbackLoader->create( 'BlobStore', TransientStatsdCollector::CACHE_NAMESPACE, $cacheType, $ttl ),
 				$id
 			);
 

--- a/tests/phpunit/Unit/CachedQueryResultPrefetcherTest.php
+++ b/tests/phpunit/Unit/CachedQueryResultPrefetcherTest.php
@@ -79,6 +79,10 @@ class CachedQueryResultPrefetcherTest extends \PHPUnit_Framework_TestCase {
 	public function testPurgeCacheByQueryList() {
 
 		$this->blobStore->expects( $this->atLeastOnce() )
+			->method( 'exists' )
+			->will( $this->returnValue( true ) );
+
+		$this->blobStore->expects( $this->atLeastOnce() )
 			->method( 'delete' );
 
 		$instance = new CachedQueryResultPrefetcher(
@@ -154,8 +158,15 @@ class CachedQueryResultPrefetcherTest extends \PHPUnit_Framework_TestCase {
 		$subject = new DIWikiPage( 'Foo', NS_MAIN );
 
 		$this->blobStore->expects( $this->atLeastOnce() )
+			->method( 'exists' )
+			->will( $this->returnValue( true ) );
+
+		$this->blobStore->expects( $this->atLeastOnce() )
 			->method( 'delete' )
 			->with( $this->equalTo( '39e2606942246606c5daa2ddfec4ace8' ) );
+
+		$this->transientStatsdCollector->expects( $this->once() )
+			->method( 'recordStats' );
 
 		$instance = new CachedQueryResultPrefetcher(
 			$this->store,

--- a/tests/phpunit/Unit/TransientStatsdCollectorTest.php
+++ b/tests/phpunit/Unit/TransientStatsdCollectorTest.php
@@ -30,7 +30,7 @@ class TransientStatsdCollectorTest extends \PHPUnit_Framework_TestCase {
 			->disableOriginalConstructor()
 			->getMock();
 
-		$this->blobStore->expects( $this->atLeastOnce() )
+		$this->blobStore->expects( $this->any() )
 			->method( 'read' )
 			->will( $this->returnValue( $this->container ) );
 	}
@@ -40,17 +40,6 @@ class TransientStatsdCollectorTest extends \PHPUnit_Framework_TestCase {
 		$this->assertInstanceOf(
 			TransientStatsdCollector::class,
 			new TransientStatsdCollector( $this->blobStore, 42 )
-		);
-	}
-
-	public function testSaveOnDestruct() {
-
-		$this->blobStore->expects( $this->once() )
-			->method( 'save' );
-
-		$instance = new TransientStatsdCollector(
-			$this->blobStore,
-			42
 		);
 	}
 
@@ -79,6 +68,7 @@ class TransientStatsdCollectorTest extends \PHPUnit_Framework_TestCase {
 		);
 
 		$instance->incr( 'Foo.bar' );
+		$instance->saveStats();
 	}
 
 	public function testSet() {
@@ -104,7 +94,9 @@ class TransientStatsdCollectorTest extends \PHPUnit_Framework_TestCase {
 			$this->blobStore,
 			42
 		);
+
 		$instance->set( 'Foo.bar', 10 );
+		$instance->saveStats();
 	}
 
 	public function testCalcMedian() {
@@ -132,6 +124,7 @@ class TransientStatsdCollectorTest extends \PHPUnit_Framework_TestCase {
 		);
 
 		$instance->calcMedian( 'Foo.bar', 5 );
+		$instance->saveStats();
 	}
 
 	public function testStats_Simple() {


### PR DESCRIPTION
This PR is made in reference to: #2046

This PR addresses or contains:

- Using `__destruct` as event trigger didn't work well and most likely caused some seg faults due to reliance on the MediaWiki object and their state (`PHP Fatal error:  Access to undeclared static property: MediaWiki\\Logger\\LegacyLogger::$levelMapping` ...)
- Trigger the `TransientStatsdCollector::recordStats` manually and post updates as `DeferredCallableUpdate` (the update queue will filter updates with the same fingerprint during a request avoiding possible duplicate updates)

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed

