### PR TITLE
Add AbstractMultiValue::getFieldProperties

### DIFF
--- a/includes/datavalues/SMW_DV_Record.php
+++ b/includes/datavalues/SMW_DV_Record.php
@@ -234,47 +234,18 @@ class SMWRecordValue extends AbstractMultiValue {
 	 * @return array of DIProperty
 	 */
 	public function getPropertyDataItems() {
-		if ( is_null( $this->m_diProperties ) ) {
-			$this->m_diProperties = $this->findPropertyDataItems( $this->m_property );
 
-			if ( count( $this->m_diProperties ) == 0 ) { // TODO internalionalize
-				$this->addError( 'The list of properties to be used for the data fields has not been specified properly.' );
-			}
+		if ( $this->m_diProperties !== null ) {
+			return $this->m_diProperties;
+		}
+
+		$this->m_diProperties = $this->getFieldProperties( $this->m_property );
+
+		if ( $this->m_diProperties  === array() ) { // TODO internalionalize
+			$this->addError( 'The list of properties to be used for the data fields has not been specified properly.' );
 		}
 
 		return $this->m_diProperties;
-	}
-
-	/**
-	 * Return the array (list) of properties that the individual entries of
-	 * this datatype consist of.
-	 *
-	 * @since 1.6
-	 *
-	 * @param $diProperty mixed null or DIProperty object for which to retrieve the types
-	 *
-	 * @return array of DIProperty
-	 */
-	protected function findPropertyDataItems( $diProperty ) {
-		if ( !is_null( $diProperty ) ) {
-			$propertyDiWikiPage = $diProperty->getDiWikiPage();
-
-			if ( !is_null( $propertyDiWikiPage ) ) {
-				$listDiProperty = new DIProperty( '_LIST' );
-				$dataItems = ApplicationFactory::getInstance()->getStore()->getPropertyValues( $propertyDiWikiPage, $listDiProperty );
-
-				if ( count( $dataItems ) == 1 ) {
-					$propertyListValue = new PropertyListValue( '__pls' );
-					$propertyListValue->setDataItem( reset( $dataItems ) );
-
-					if ( $propertyListValue->isValid() ) {
-						return $propertyListValue->getPropertyDataItems();
-					}
-				}
-			}
-		}
-
-		return array();
 	}
 
 ////// Internal helper functions

--- a/src/DataValues/AbstractMultiValue.php
+++ b/src/DataValues/AbstractMultiValue.php
@@ -3,6 +3,9 @@
 namespace SMW\DataValues;
 
 use SMWDataValue as DataValue;
+use SMWPropertyListValue as PropertyListValue;
+use SMW\DIProperty;
+use SMW\ApplicationFactory;
 
 /**
  * @private
@@ -131,6 +134,38 @@ abstract class AbstractMultiValue extends DataValue {
 		}
 
 		return null;
+	}
+
+	/**
+	 * Return the array (list) of properties that the individual entries of
+	 * this datatype consist of.
+	 *
+	 * @since 2.5
+	 *
+	 * @param DIProperty|null $property
+	 *
+	 * @return DIProperty[]|[]
+	 */
+	protected function getFieldProperties( DIProperty $property = null ) {
+
+		if ( $property === null || $property->getDiWikiPage() === null ) {
+			return array();
+		}
+
+		$dataItem = ApplicationFactory::getInstance()->getPropertySpecificationLookup()->getFieldListBy( $property );
+
+		if ( !$dataItem ) {
+			return array();
+		}
+
+		$propertyListValue = new PropertyListValue( '__pls' );
+		$propertyListValue->setDataItem( $dataItem );
+
+		if ( !$propertyListValue->isValid() ) {
+			return array();
+		}
+
+		return $propertyListValue->getPropertyDataItems();
 	}
 
 }

--- a/src/DataValues/ReferenceValue.php
+++ b/src/DataValues/ReferenceValue.php
@@ -152,7 +152,7 @@ class ReferenceValue extends AbstractMultiValue {
 	public function getPropertyDataItems() {
 
 		if ( $this->properties === null ) {
-			$this->properties = $this->findPropertyDataItems( $this->getProperty() );
+			$this->properties = $this->getFieldProperties( $this->getProperty() );
 
 			if ( count( $this->properties ) == 0 ) {
 				$this->addErrorMsg( array( 'smw-datavalue-reference-invalid-fields-definition' ), Message::PARSE );
@@ -252,33 +252,6 @@ class ReferenceValue extends AbstractMultiValue {
 		}
 
 		return false;
-	}
-
-	private function findPropertyDataItems( DIProperty $property = null ) {
-
-		if ( $property === null ) {
-			return array();
-		}
-
-		$propertyDiWikiPage = $property->getDiWikiPage();
-
-		if ( $propertyDiWikiPage === null ) {
-			return array();
-		}
-
-		$listDiProperty = new DIProperty( '_LIST' );
-		$dataItems = ApplicationFactory::getInstance()->getStore()->getPropertyValues( $propertyDiWikiPage, $listDiProperty );
-
-		if ( count( $dataItems ) == 1 ) {
-			$propertyListValue = new PropertyListValue( '__pls' );
-			$propertyListValue->setDataItem( reset( $dataItems ) );
-
-			if ( $propertyListValue->isValid() ) {
-				return $propertyListValue->getPropertyDataItems();
-			}
-		}
-
-		return array();
 	}
 
 	private function newContainerSemanticData( $value ) {

--- a/src/PropertySpecificationLookup.php
+++ b/src/PropertySpecificationLookup.php
@@ -75,6 +75,37 @@ class PropertySpecificationLookup {
 	/**
 	 * @since 2.5
 	 *
+	 * @param DIProperty $property
+	 *
+	 * @return false|DataItem
+	 */
+	public function getFieldListBy( DIProperty $property ) {
+
+		$fieldList = false;
+		$key = 'list:'. $property->getKey();
+
+		// Guard against high frequency lookup
+		if ( $this->intermediaryMemoryCache->contains( $key ) ) {
+			return $this->intermediaryMemoryCache->fetch( $key );
+		}
+
+		$dataItems = $this->cachedPropertyValuesPrefetcher->getPropertyValues(
+			$property->getCanonicalDiWikiPage(),
+			new DIProperty( '_LIST' )
+		);
+
+		if ( is_array( $dataItems ) && $dataItems !== array() ) {
+			$fieldList = end( $dataItems );
+		}
+
+		$this->intermediaryMemoryCache->save( $key, $fieldList );
+
+		return $fieldList;
+	}
+
+	/**
+	 * @since 2.5
+	 *
 	 * @param string $id
 	 * @param string $languageCode
 	 *
@@ -331,7 +362,7 @@ class PropertySpecificationLookup {
 			return $container->get( $key );
 		}
 
-		$localPropertyDescription = $this->tryToFindLocalPropertyDescription(
+		$localPropertyDescription = $this->findLocalPropertyDescription(
 			$property,
 			$linker,
 			$languageCode
@@ -380,7 +411,7 @@ class PropertySpecificationLookup {
 		return $message;
 	}
 
-	private function tryToFindLocalPropertyDescription( $property, $linker, $languageCode ) {
+	private function findLocalPropertyDescription( $property, $linker, $languageCode ) {
 
 		$text = '';
 		$descriptionProperty = new DIProperty( '_PDESC' );

--- a/tests/phpunit/Integration/ByJsonScript/Fixtures/p-0440.json
+++ b/tests/phpunit/Integration/ByJsonScript/Fixtures/p-0440.json
@@ -39,7 +39,7 @@
 		},
 		{
 			"page": "Example/P0440/Q.3",
-			"contents": "{{#ask: [[Has alternative label::+]] |?Has alternative label|+lang=en|+limit=1 }}"
+			"contents": "{{#ask: [[Has alternative label::+]] |?Has alternative label|+lang=en|+limit=1|+order=asc }}"
 		},
 		{
 			"page": "Example/P0440/Q.4",
@@ -47,7 +47,7 @@
 		},
 		{
 			"page": "Example/P0440/Q.5",
-			"contents": "{{#ask: [[Has alternative label::+]] |?Has alternative label|+lang=foo }}"
+			"contents": "{{#ask: [[Has alternative label::+]] |?Has alternative label|+lang=foo|+order=asc }}"
 		},
 		{
 			"page": "Example/P0440/Q.6",

--- a/tests/phpunit/Unit/DataValues/ReferenceValueTest.php
+++ b/tests/phpunit/Unit/DataValues/ReferenceValueTest.php
@@ -58,9 +58,9 @@ class ReferenceValueTest extends \PHPUnit_Framework_TestCase {
 			->setMethods( array( 'getRedirectTarget' ) )
 			->getMockForAbstractClass();
 
-		$store->expects( $this->atLeastOnce() )
-			->method( 'getPropertyValues' )
-			->will( $this->returnValue( array( $this->dataItemFactory->newDIBlob( 'Bar;Foobar' ) ) ) );
+		$this->propertySpecificationLookup->expects( $this->atLeastOnce() )
+			->method( 'getFieldListBy' )
+			->will( $this->returnValue( $this->dataItemFactory->newDIBlob( 'Bar;Foobar' ) ) );
 
 		$store->expects( $this->any() )
 			->method( 'getRedirectTarget' )
@@ -91,9 +91,9 @@ class ReferenceValueTest extends \PHPUnit_Framework_TestCase {
 			->setMethods( array( 'getRedirectTarget' ) )
 			->getMockForAbstractClass();
 
-		$store->expects( $this->atLeastOnce() )
-			->method( 'getPropertyValues' )
-			->will( $this->returnValue( array( $this->dataItemFactory->newDIBlob( 'Bar;Foobar' ) ) ) );
+		$this->propertySpecificationLookup->expects( $this->atLeastOnce() )
+			->method( 'getFieldListBy' )
+			->will( $this->returnValue( $this->dataItemFactory->newDIBlob( 'Bar;Foobar' ) ) );
 
 		$store->expects( $this->any() )
 			->method( 'getRedirectTarget' )
@@ -143,9 +143,9 @@ class ReferenceValueTest extends \PHPUnit_Framework_TestCase {
 			->setMethods( array( 'getRedirectTarget' ) )
 			->getMockForAbstractClass();
 
-		$store->expects( $this->atLeastOnce() )
-			->method( 'getPropertyValues' )
-			->will( $this->returnValue( array( $this->dataItemFactory->newDIBlob( 'Bar;Foobar' ) ) ) );
+		$this->propertySpecificationLookup->expects( $this->atLeastOnce() )
+			->method( 'getFieldListBy' )
+			->will( $this->returnValue( $this->dataItemFactory->newDIBlob( 'Bar;Foobar' ) ) );
 
 		$store->expects( $this->any() )
 			->method( 'getRedirectTarget' )

--- a/tests/phpunit/Unit/PropertySpecificationLookupTest.php
+++ b/tests/phpunit/Unit/PropertySpecificationLookupTest.php
@@ -51,6 +51,59 @@ class PropertySpecificationLookupTest extends \PHPUnit_Framework_TestCase {
 		);
 	}
 
+	public function testGetFieldList() {
+
+		$property = $this->dataItemFactory->newDIProperty( 'RecordProperty' );
+
+		$this->cachedPropertyValuesPrefetcher->expects( $this->once() )
+			->method( 'getPropertyValues' )
+			->with(
+				$this->equalTo( $property->getDiWikiPage() ),
+				$this->equalTo( $this->dataItemFactory->newDIProperty( '_LIST' ) ),
+				$this->anything() )
+			->will(
+				$this->returnValue( array(
+					$this->dataItemFactory->newDIBlob( 'Foo' ),
+					$this->dataItemFactory->newDIBlob( 'abc;123' ) ) ) );
+
+		$instance = new PropertySpecificationLookup(
+			$this->cachedPropertyValuesPrefetcher,
+			$this->intermediaryMemoryCache
+		);
+
+		$this->assertEquals(
+			'abc;123',
+			$instance->getFieldListBy( $property )
+		);
+	}
+
+	public function testGetPreferredPropertyLabel() {
+
+		$property = $this->dataItemFactory->newDIProperty( 'SomeProperty' );
+		$property->setPropertyTypeId( '_mlt_rec' );
+
+		$this->cachedPropertyValuesPrefetcher->expects( $this->once() )
+			->method( 'getPropertyValues' )
+			->with(
+				$this->equalTo( $property->getDiWikiPage() ),
+				$this->equalTo( $this->dataItemFactory->newDIProperty( '_PPLB' ) ),
+				$this->anything() );
+
+		$this->intermediaryMemoryCache->expects( $this->once() )
+			->method( 'fetch' )
+			->will( $this->returnValue( false ) );
+
+		$instance = new PropertySpecificationLookup(
+			$this->cachedPropertyValuesPrefetcher,
+			$this->intermediaryMemoryCache
+		);
+
+		$this->assertEquals(
+			'',
+			$instance->getPreferredPropertyLabelBy( $property )
+		);
+	}
+
 	public function testGetPropertyFromDisplayTitle() {
 
 		$property = $this->dataItemFactory->newDIProperty( 'Foo' );

--- a/tests/phpunit/Unit/Serializers/QueryResultSerializerTest.php
+++ b/tests/phpunit/Unit/Serializers/QueryResultSerializerTest.php
@@ -29,6 +29,12 @@ class QueryResultSerializerTest extends \PHPUnit_Framework_TestCase {
 
 		$this->testEnvironment = new TestEnvironment();
 		$this->dataItemFactory = new DataItemFactory();
+
+		$this->propertySpecificationLookup = $this->getMockBuilder( '\SMW\PropertySpecificationLookup' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$this->testEnvironment->registerObject( 'PropertySpecificationLookup', $this->propertySpecificationLookup );
 	}
 
 	protected function tearDown() {
@@ -93,9 +99,9 @@ class QueryResultSerializerTest extends \PHPUnit_Framework_TestCase {
 			->method( 'getSemanticData' )
 			->will( $this->returnValue( $semanticData ) );
 
-		$store->expects( $this->at( 1 ) )
-			->method( 'getPropertyValues' )
-			->will( $this->returnValue( array( $this->dataItemFactory->newDIBlob( 'BarList1;BarList2' ) ) ) );
+		$this->propertySpecificationLookup->expects( $this->atLeastOnce() )
+			->method( 'getFieldListBy' )
+			->will( $this->returnValue( $this->dataItemFactory->newDIBlob( 'BarList1;BarList2' ) ) );
 
 		$this->testEnvironment->registerObject( 'Store', $store );
 

--- a/tests/phpunit/includes/DataValues/RecordValueTest.php
+++ b/tests/phpunit/includes/DataValues/RecordValueTest.php
@@ -58,9 +58,9 @@ class RecordValueTest extends \PHPUnit_Framework_TestCase {
 			->setMethods( array( 'getRedirectTarget' ) )
 			->getMockForAbstractClass();
 
-		$store->expects( $this->atLeastOnce() )
-			->method( 'getPropertyValues' )
-			->will( $this->returnValue( array( $this->dataItemFactory->newDIBlob( 'Bar;Foobar' ) ) ) );
+		$this->propertySpecificationLookup->expects( $this->atLeastOnce() )
+			->method( 'getFieldListBy' )
+			->will( $this->returnValue( $this->dataItemFactory->newDIBlob( 'Bar;Foobar' ) ) );
 
 		$store->expects( $this->any() )
 			->method( 'getRedirectTarget' )
@@ -91,9 +91,9 @@ class RecordValueTest extends \PHPUnit_Framework_TestCase {
 			->setMethods( array( 'getRedirectTarget' ) )
 			->getMockForAbstractClass();
 
-		$store->expects( $this->atLeastOnce() )
-			->method( 'getPropertyValues' )
-			->will( $this->returnValue( array( $this->dataItemFactory->newDIBlob( 'Bar;Foobar' ) ) ) );
+		$this->propertySpecificationLookup->expects( $this->atLeastOnce() )
+			->method( 'getFieldListBy' )
+			->will( $this->returnValue( $this->dataItemFactory->newDIBlob( 'Bar;Foobar' ) ) );
 
 		$store->expects( $this->any() )
 			->method( 'getRedirectTarget' )
@@ -143,9 +143,9 @@ class RecordValueTest extends \PHPUnit_Framework_TestCase {
 			->setMethods( array( 'getRedirectTarget' ) )
 			->getMockForAbstractClass();
 
-		$store->expects( $this->atLeastOnce() )
-			->method( 'getPropertyValues' )
-			->will( $this->returnValue( array( $this->dataItemFactory->newDIBlob( 'Bar;Foobar' ) ) ) );
+		$this->propertySpecificationLookup->expects( $this->atLeastOnce() )
+			->method( 'getFieldListBy' )
+			->will( $this->returnValue( $this->dataItemFactory->newDIBlob( 'Bar;Foobar' ) ) );
 
 		$store->expects( $this->any() )
 			->method( 'getRedirectTarget' )


### PR DESCRIPTION
This PR is made in reference to: #

This PR addresses or contains:

- Consolidate the use of `getFieldProperties` in `SMW_DV_Record` and `ReferenceValue` 
- Cache the `_LIST` lookup using `PropertySpecificationLookup::getFieldListBy` to avoid an active `Store::getPropertyValues` request

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed

