### PR TITLE
Tooltip to fetch pf.addTemplateInstance/sf.addTemplateInstance event

### DIFF
--- a/res/smw/util/ext.smw.util.tooltip.js
+++ b/res/smw/util/ext.smw.util.tooltip.js
@@ -263,6 +263,15 @@
 			 self.initFromContext( opts.context );
 		} );
 
+		// SemanticForms/PageForms instance trigger
+		mw.hook( 'sf.addTemplateInstance' ).add( function( context ) {
+			self.initFromContext( context );
+		} );
+
+		mw.hook( 'pf.addTemplateInstance' ).add( function( context ) {
+			self.initFromContext( context );
+		} );
+
 		return self;
 	};
 


### PR DESCRIPTION
This PR is made in reference to: #N/A

This PR addresses or contains:

- Should allow `{{#info: ... }}` to be displayed on/in multi-instances

This PR includes:
- [ ] Tests (unit/integration)
- [ ] CI build passed

