### PR TITLE
PropertyValueFormatter normalize &#160; when comparing a caption

### DIFF
--- a/src/DataValues/ValueFormatters/PropertyValueFormatter.php
+++ b/src/DataValues/ValueFormatters/PropertyValueFormatter.php
@@ -240,7 +240,15 @@ class PropertyValueFormatter extends DataValueFormatter {
 			$this->dataValue->getOptionBy( PropertyValue::OPT_USER_LANGUAGE )
 		);
 
-		if ( $preferredLabel === '' || $this->dataValue->getCaption() !== $preferredLabel ) {
+		// When comparing with a caption set from the "outside", normalize
+		// the string to avoid a false negative in case of a non-breaking space
+		$caption = str_replace(
+			array( "&#160;", "&nbsp;", html_entity_decode( '&#160;', ENT_NOQUOTES, 'UTF-8' ) ),
+			" ",
+			$this->dataValue->getCaption()
+		);
+
+		if ( $preferredLabel === '' || $caption !== $preferredLabel ) {
 			return '';
 		}
 

--- a/tests/phpunit/Integration/JSONScript/TestCases/s-0013.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/s-0013.json
@@ -1,0 +1,48 @@
+{
+	"description": "Test `Special:Browse` output preferred label (`wgContLang=en`, `wgLang=es`)",
+	"setup": [
+		{
+			"namespace": "SMW_NS_PROPERTY",
+			"page": "SomeProperty",
+			"contents": "[[Has type::Text]] [[Has preferred property label::Label with spaces@es]]"
+		},
+		{
+			"page": "Example/S0013/1",
+			"contents": "[[SomeProperty::abc]]"
+		}
+	],
+	"tests": [
+		{
+			"type": "special",
+			"about": "#0 verify preferred label display",
+			"special-page": {
+				"page": "Browse",
+				"query-parameters": "Example/S0013/1",
+				"request-parameters": {
+					"output": "legacy"
+				}
+			},
+			"assert-output": {
+				"to-contain": [
+					">Label with spaces</a>&nbsp;<span title=\"SomeProperty\"><sup>ᵖ</sup>"
+				]
+			}
+		}
+	],
+	"settings": {
+		"wgContLang": "en",
+		"wgLang": "es",
+		"smwgPageSpecialProperties": [
+			"_MDAT"
+		],
+		"smwgNamespacesWithSemanticLinks": {
+			"NS_MAIN": true,
+			"SMW_NS_PROPERTY": true
+		}
+	},
+	"meta": {
+		"version": "2",
+		"is-incomplete": false,
+		"debug": false
+	}
+}


### PR DESCRIPTION
This PR is made in reference to: #1865

This PR addresses or contains:

- Normalize and compare otherwise `" "` isn't the same as `"&#160;"` and would avoid the display of <sup>ᵖ</sup> for labels with spaces

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed

