### PR TITLE
Fix "Data too long for column" (MySQL 5.7), refs 2089

### DIFF
--- a/includes/storage/SQLStore/SMW_Sql3SmwIds.php
+++ b/includes/storage/SQLStore/SMW_Sql3SmwIds.php
@@ -650,6 +650,9 @@ class SMWSql3SmwIds {
 			$sortkey = $sortkey ? $sortkey : ( str_replace( '_', ' ', $title ) );
 			$sequenceValue = $db->nextSequenceValue( $this->getIdTable() . '_smw_id_seq' ); // Bug 42659
 
+			// #2089 (MySQL 5.7 complained with "Data too long for column")
+			$sortkey = substr( $sortkey, 0, 254 );
+
 			$db->insert(
 				self::TABLE_NAME,
 				array(
@@ -683,6 +686,10 @@ class SMWSql3SmwIds {
 			}
 
 		} elseif ( $sortkey !== '' && $sortkey != $oldsort ) {
+
+			// #2089 (MySQL 5.7 complained with "Data too long for column")
+			$sortkey = substr( $sortkey, 0, 254 );
+
 			$db->update(
 				self::TABLE_NAME,
 				array( 'smw_sortkey' => $sortkey ),


### PR DESCRIPTION
This PR is made in reference to: #2089

This PR addresses or contains:

This PR includes:
- [ ] Tests (unit/integration)
- [x] CI build passed

