### PR TITLE
Avoid removal of existing data by #REDIRECT in target

### DIFF
--- a/includes/storage/SQLStore/SMW_SQLStore3_Writers.php
+++ b/includes/storage/SQLStore/SMW_SQLStore3_Writers.php
@@ -614,9 +614,8 @@ class SMWSQLStore3Writers {
 		} else { // General move method: should always be correct
 			// (equality support respected when updating redirects)
 
-			// Delete any existing data (including redirects) from new title
-			// ($newtitle should not have data, but let's be sure)
-			$emptyNewSemanticData = new SMWSemanticData( SMWDIWikiPage::newFromTitle( $newTitle ) );
+			// Delete any existing data (including redirects) from old title
+			$emptyNewSemanticData = new SMWSemanticData( SMWDIWikiPage::newFromTitle( $oldTitle ) );
 			$this->doDataUpdate( $emptyNewSemanticData );
 
 			// Move all data of old title to new position:

--- a/tests/phpunit/Integration/JSONScript/TestCases/p-0442.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/p-0442.json
@@ -1,0 +1,50 @@
+{
+	"description": "Test in-text `#REDIRECT` to verify target subobject isn't removed (#, `wgContLang=en`, `wgLang=en`)",
+	"setup": [
+		{
+			"namespace": "SMW_NS_PROPERTY",
+			"page": "Has text",
+			"contents": "[[Has type::Text]] [[Has property description::Some text that should remain@en]]"
+		},
+		{
+			"namespace": "SMW_NS_PROPERTY",
+			"page": "Has another text",
+			"contents": "#REDIRECT [[Property:Has text]]"
+		}
+	],
+	"tests": [
+		{
+			"type": "parser",
+			"about": "#0 (verify redirect doesn't delete the subobjects of a target; if it fails then propertyValues will be empty and cause an error in this test)",
+			"namespace": "SMW_NS_PROPERTY",
+			"subject": "Has text",
+			"store": {
+				"clear-cache": true
+			},
+			"assert-store": {
+				"semantic-data": {
+					"strictPropertyValueMatch": false,
+					"propertyCount": 4,
+					"propertyKeys": [
+						"_MDAT",
+						"_SKEY",
+						"_PDESC",
+						"_TYPE"
+					],
+					"propertyValues": [
+						"Some text that should remain@en"
+					]
+				}
+			}
+		}
+	],
+	"settings": {
+		"wgContLang": "en",
+		"wgLang": "en"
+	},
+	"meta": {
+		"version": "2",
+		"is-incomplete": false,
+		"debug": false
+	}
+}

--- a/tests/phpunit/Integration/MediaWiki/RedirectTargetFinderIntegrationTest.php
+++ b/tests/phpunit/Integration/MediaWiki/RedirectTargetFinderIntegrationTest.php
@@ -228,7 +228,7 @@ class RedirectTargetFinderIntegrationTest extends MwDBaseUnitTestCase {
 
 		// Store will point towards the correct target
 		$expectedRedirect = DIWikiPage::newFromTitle(
-			Title::newFromText( 'DeepRedirectTargetResolverToDetectCircularTarget/2' )
+			Title::newFromText( 'DeepRedirectTargetResolverToDetectCircularTarget/1' )
 		);
 
 		$this->assertEquals(


### PR DESCRIPTION
This PR is made in reference to: # N/A

This PR addresses or contains:

- A reproducible scenario where a `#REDIRECT` would force a removal of subobjects in the target
- This also solves a weird copy issue (objects are copied back and forth with the result of additional ID's that get marked for deleted after the process) of entity objects during a move/redirect action

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed

