### PR TITLE
CachedQueryResultPrefetcher to add removal context

### DIFF
--- a/src/EventListenerRegistry.php
+++ b/src/EventListenerRegistry.php
@@ -107,6 +107,8 @@ class EventListenerRegistry implements EventListenerCollection {
 					$subject = $dispatchContext->get( 'subject' );
 				}
 
+				$context = $dispatchContext->has( 'context' ) ? $dispatchContext->get( 'context' ) : '';
+
 				$applicationFactory = ApplicationFactory::getInstance();
 				$applicationFactory->getMediaWikiLogger()->info( 'Event: cached.prefetcher.reset :: ' . $subject->getHash() );
 
@@ -115,7 +117,8 @@ class EventListenerRegistry implements EventListenerCollection {
 				);
 
 				$applicationFactory->singleton( 'CachedQueryResultPrefetcher' )->resetCacheBy(
-					$subject
+					$subject,
+					$context
 				);
 
 				$dispatchContext->set( 'propagationstop', true );

--- a/src/MediaWiki/Hooks/ArticleDelete.php
+++ b/src/MediaWiki/Hooks/ArticleDelete.php
@@ -77,6 +77,7 @@ class ArticleDelete {
 
 			$dispatchContext = $eventHandler->newDispatchContext();
 			$dispatchContext->set( 'title', $title );
+			$dispatchContext->set( 'context', 'ArticleDelete' );
 
 			$eventHandler->getEventDispatcher()->dispatch(
 				'cached.prefetcher.reset',

--- a/src/MediaWiki/Hooks/ArticlePurge.php
+++ b/src/MediaWiki/Hooks/ArticlePurge.php
@@ -46,6 +46,7 @@ class ArticlePurge {
 
 		$dispatchContext = EventHandler::getInstance()->newDispatchContext();
 		$dispatchContext->set( 'title', $wikiPage->getTitle() );
+		$dispatchContext->set( 'context', 'ArticlePurge' );
 
 		if ( $settings->get( 'smwgFactboxCacheRefreshOnPurge' ) ) {
 			EventHandler::getInstance()->getEventDispatcher()->dispatch(

--- a/src/MediaWiki/Hooks/TitleMoveComplete.php
+++ b/src/MediaWiki/Hooks/TitleMoveComplete.php
@@ -106,6 +106,7 @@ class TitleMoveComplete {
 
 		$dispatchContext = $eventHandler->newDispatchContext();
 		$dispatchContext->set( 'title', $this->newTitle );
+		$dispatchContext->set( 'context', 'ArticleMove' );
 
 		$eventHandler->getEventDispatcher()->dispatch(
 			'cached.prefetcher.reset',

--- a/src/MediaWiki/Jobs/ParserCachePurgeJob.php
+++ b/src/MediaWiki/Jobs/ParserCachePurgeJob.php
@@ -148,7 +148,8 @@ class ParserCachePurgeJob extends JobBase {
 		);
 
 		$this->applicationFactory->singleton( 'CachedQueryResultPrefetcher' )->resetCacheBy(
-			$queryList
+			$queryList,
+			'ParserCachePurgeJob'
 		);
 
 		$this->addPagesToUpdater( $hashList );

--- a/src/TransientStatsdCollector.php
+++ b/src/TransientStatsdCollector.php
@@ -163,6 +163,10 @@ class TransientStatsdCollector {
 	 */
 	public function saveStats() {
 
+		if ( $this->stats === array() ) {
+			return;
+		}
+
 		$container = $this->blobStore->read(
 			md5( $this->statsdId . self::VERSION )
 		);

--- a/tests/phpunit/Unit/CachedQueryResultPrefetcherTest.php
+++ b/tests/phpunit/Unit/CachedQueryResultPrefetcherTest.php
@@ -163,7 +163,7 @@ class CachedQueryResultPrefetcherTest extends \PHPUnit_Framework_TestCase {
 
 		$this->blobStore->expects( $this->atLeastOnce() )
 			->method( 'delete' )
-			->with( $this->equalTo( '39e2606942246606c5daa2ddfec4ace8' ) );
+			->with( $this->equalTo( '063682d55f277990d70fa8213e5eccd8' ) );
 
 		$this->transientStatsdCollector->expects( $this->once() )
 			->method( 'recordStats' );


### PR DESCRIPTION
This PR is made in reference to: #1251, #2074

This PR addresses or contains:

- Adds a context to the removal stats in order to better understand as to why the query cache was purged/evicted

This PR includes:
- [ ] Tests (unit/integration)
- [x] CI build passed

