### PR TITLE
Improve computation of query signature (Description::getHash)

### DIFF
--- a/includes/query/SMW_Query.php
+++ b/includes/query/SMW_Query.php
@@ -445,21 +445,25 @@ class SMWQuery implements QueryContext {
 		// elements that directly influence the result list
 		$serialized = array();
 
-		$serialized['conditions'] = $this->getQueryString();
+		// Don't use the QueryString, use the canonized hash to ensure that
+		// [[Foo::123]][[Bar::abc]] returns the same ID as [[Bar::abc]][[Foo::123]]
+		// given that limit, offset, and sort/order are the same
+		$serialized['hash'] = $this->description->getHash();
 		$serialized['parameters'] = array(
 			'limit'     => $this->limit,
 			'offset'    => $this->offset,
 			'sortkeys'  => $this->sortkeys,
-			'querymode' => $this->querymode
+			'querymode' => $this->querymode // COUNT, DEBUG ...
 		);
 
+		// Make to sure to distinguish queries and results from a foreign repository
 		if ( $this->querySource !== null && $this->querySource !== '' ) {
 			$serialized['parameters']['source'] = $this->querySource;
 		}
 
-		// printouts are avoided as part of the hash as they not influence the
-		// match process and are only resolved after the query result has been
-		// retrieved
+		// Printouts are avoided as part of the hash as they not influence the
+		// result match process and are only resolved after the query result has
+		// been retrieved
 
 		return HashBuilder::createFromArray( $serialized );
 	}

--- a/src/Query/Language/ClassDescription.php
+++ b/src/Query/Language/ClassDescription.php
@@ -48,6 +48,24 @@ class ClassDescription extends Description {
 	}
 
 	/**
+	 * @since 2.5
+	 *
+	 * @return string
+	 */
+	public function getHash() {
+
+		$hash = array();
+
+		foreach ( $this->m_diWikiPages as $subject ) {
+			$hash[$subject->getHash()] = true;
+		}
+
+		ksort( $hash );
+
+		return 'Cl:' . md5( implode( '|', array_keys( $hash ) ) );
+	}
+
+	/**
 	 * @return array of DIWikiPage
 	 */
 	public function getCategories() {

--- a/src/Query/Language/ConceptDescription.php
+++ b/src/Query/Language/ConceptDescription.php
@@ -30,6 +30,15 @@ class ConceptDescription extends Description {
 	}
 
 	/**
+	 * @since 2.5
+	 *
+	 * @return string
+	 */
+	public function getHash() {
+		return 'Co:' . md5( $this->concept->getHash() );
+	}
+
+	/**
 	 * @return DIWikiPage
 	 */
 	public function getConcept() {

--- a/src/Query/Language/Description.php
+++ b/src/Query/Language/Description.php
@@ -2,7 +2,7 @@
 
 namespace SMW\Query\Language;
 
-use SMW\Query\PrintRequest as PrintRequest;
+use SMW\Query\PrintRequest;
 
 /**
  * Abstract base class for all descriptions
@@ -15,7 +15,7 @@ use SMW\Query\PrintRequest as PrintRequest;
 abstract class Description {
 
 	/**
-	 * @var \SMW\Query\PrintRequest[]
+	 * @var PrintRequest[]
 	 */
 	protected $m_printreqs = array();
 
@@ -23,7 +23,7 @@ abstract class Description {
 	 * Get the (possibly empty) array of all print requests that
 	 * exist for the entities that fit this description.
 	 *
-	 * @return array of SMW\Query\PrintRequest
+	 * @return PrintRequest[]
 	 */
 	public function getPrintRequests() {
 		return $this->m_printreqs;
@@ -41,7 +41,7 @@ abstract class Description {
 	/**
 	 * Add a single SMW\Query\PrintRequest.
 	 *
-	 * @param \SMW\Query\PrintRequest $printRequest
+	 * @param PrintRequest $printRequest
 	 */
 	public function addPrintRequest( PrintRequest $printRequest ) {
 		$this->m_printreqs[] = $printRequest;
@@ -56,6 +56,20 @@ abstract class Description {
 	public function prependPrintRequest( PrintRequest $printRequest ) {
 		array_unshift( $this->m_printreqs, $printRequest );
 	}
+
+	/**
+	 * Returns a compound hash that represents the canonized description with
+	 * the order being normalized as well so that [[Foo::123]][[Bar::abc]]
+	 * returns the same ID as for [[Bar::abc]][[Foo::123]].
+	 *
+	 * One can not rely on the query string to filter equal descriptions when
+	 * only comparing the string representation.
+	 *
+	 * @since 2.5
+	 *
+	 * @return string
+	 */
+	abstract public function getHash();
 
 	/**
 	 * Return a string expressing this query.

--- a/src/Query/Language/Disjunction.php
+++ b/src/Query/Language/Disjunction.php
@@ -21,6 +21,11 @@ class Disjunction extends Description {
 	private $descriptions;
 
 	/**
+	 * @var string|null
+	 */
+	private $hash = null;
+
+	/**
 	 * contains a single class description if any such disjunct was given;
 	 * disjunctive classes are aggregated therei
 	 * n
@@ -41,11 +46,37 @@ class Disjunction extends Description {
 		}
 	}
 
+	/**
+	 * @since 2.5
+	 *
+	 * @return string
+	 */
+	public function getHash() {
+
+		// Avoid a recursive tree
+		if ( $this->hash !== null ) {
+			return $this->hash;
+		}
+
+		$hash = array();
+
+		foreach ( $this->descriptions as $description ) {
+			$hash[$description->getHash()] = true;
+		}
+
+		ksort( $hash );
+
+		return $this->hash = 'D:' . md5( implode( '|', array_keys( $hash ) ) );
+	}
+
 	public function getDescriptions() {
 		return $this->descriptions;
 	}
 
 	public function addDescription( Description $description ) {
+
+		$this->hash = null;
+
 		if ( $description instanceof ThingDescription ) {
 			$this->isTrue = true;
 			$this->descriptions = array(); // no conditions any more

--- a/src/Query/Language/NamespaceDescription.php
+++ b/src/Query/Language/NamespaceDescription.php
@@ -30,6 +30,17 @@ class NamespaceDescription extends Description {
 	}
 
 	/**
+	 * @since 2.5
+	 *
+	 * @return string
+	 */
+	public function getHash() {
+		// Avoid a simple `int` which may interfere with an associative array
+		// when compounding hash strings from different descriptions
+		return 'N:' . md5( $this->namespace );
+	}
+
+	/**
 	 * @return integer
 	 */
 	public function getNamespace() {

--- a/src/Query/Language/SomeProperty.php
+++ b/src/Query/Language/SomeProperty.php
@@ -35,6 +35,15 @@ class SomeProperty extends Description {
 	}
 
 	/**
+	 * @since 2.5
+	 *
+	 * @return string
+	 */
+	public function getHash() {
+		return 'S:' . md5( $this->property->getKey() . '|' . $this->description->getHash() );
+	}
+
+	/**
 	 * @return DIProperty
 	 */
 	public function getProperty() {

--- a/src/Query/Language/ThingDescription.php
+++ b/src/Query/Language/ThingDescription.php
@@ -32,4 +32,15 @@ class ThingDescription extends Description {
 		return $this;
 	}
 
+	/**
+	 * @since 2.5
+	 *
+	 * @return string
+	 */
+	public function getHash() {
+		// Avoid a simple 0 which may interfere with an associative array
+		// when compounding hash strings from different descriptions
+		return 'T:' . md5( 0 );
+	}
+
 }

--- a/src/Query/Language/ValueDescription.php
+++ b/src/Query/Language/ValueDescription.php
@@ -50,6 +50,19 @@ class ValueDescription extends Description {
 	}
 
 	/**
+	 * @since 2.5
+	 *
+	 * @return string
+	 */
+	public function getHash() {
+		return 'V:' . md5(
+			$this->comparator . '|' .
+			$this->dataItem->getHash() . '|' .
+			( $this->property !== null ? $this->property->getKey() : null )
+		);
+	}
+
+	/**
 	 * @deprecated Use getDataItem() and \SMW\DataValueFactory::getInstance()->newDataValueByItem() if needed. Vanishes before SMW 1.7
 	 * @return DataItem
 	 */

--- a/tests/phpunit/Unit/Query/DescriptionFactoryTest.php
+++ b/tests/phpunit/Unit/Query/DescriptionFactoryTest.php
@@ -125,11 +125,19 @@ class DescriptionFactoryTest extends \PHPUnit_Framework_TestCase {
 			->disableOriginalConstructor()
 			->getMock();
 
+		$description->expects( $this->once() )
+			->method( 'getPrintRequests' )
+			->will( $this->returnValue( array() ) );
+
 		$descriptions[] = $description;
 
 		$description = $this->getMockBuilder( '\SMW\Query\Language\ValueDescription' )
 			->disableOriginalConstructor()
 			->getMock();
+
+		$description->expects( $this->once() )
+			->method( 'getPrintRequests' )
+			->will( $this->returnValue( array() ) );
 
 		$descriptions[] = $description;
 

--- a/tests/phpunit/Unit/Query/Language/ClassDescriptionTest.php
+++ b/tests/phpunit/Unit/Query/Language/ClassDescriptionTest.php
@@ -81,6 +81,45 @@ class ClassDescriptionTest extends \PHPUnit_Framework_TestCase {
 		);
 	}
 
+	public function testGetHash() {
+
+		$ns = Localizer::getInstance()->getNamespaceTextById( NS_CATEGORY );
+
+		$instance = new ClassDescription(
+			new DIWikiPage( 'Foo', NS_CATEGORY )
+		);
+
+		$instance->addDescription(
+			new ClassDescription( new DIWikiPage( 'Bar', NS_CATEGORY ) )
+		);
+
+		$expected = $instance->getHash();
+
+		// Different position, same hash
+		$instance = new ClassDescription(
+			new DIWikiPage( 'Bar', NS_CATEGORY )
+		);
+
+		$instance->addDescription(
+			new ClassDescription( new DIWikiPage( 'Foo', NS_CATEGORY ) )
+		);
+
+		$this->assertSame(
+			$expected,
+			$instance->getHash()
+		);
+
+		// Adds extra description, changes hash
+		$instance->addDescription(
+			new ClassDescription( new DIWikiPage( 'Foobar', NS_CATEGORY ) )
+		);
+
+		$this->assertNotSame(
+			$expected,
+			$instance->getHash()
+		);
+	}
+
 	public function testPrune() {
 
 		$instance = new ClassDescription( new DIWikiPage( 'Foo', NS_CATEGORY ) );

--- a/tests/phpunit/Unit/Query/Language/ConceptDescriptionTest.php
+++ b/tests/phpunit/Unit/Query/Language/ConceptDescriptionTest.php
@@ -56,6 +56,24 @@ class ConceptDescriptionTest extends \PHPUnit_Framework_TestCase {
 		$this->assertEquals( 4, $instance->getQueryFeatures() );
 	}
 
+	public function testGetHash() {
+
+		$instance = new ConceptDescription(
+			new DIWikiPage( 'Foo', SMW_NS_CONCEPT )
+		);
+
+		$expected = $instance->getHash();
+
+		$instance = new ConceptDescription(
+			new DIWikiPage( 'Bar', SMW_NS_CONCEPT )
+		);
+
+		$this->assertNotSame(
+			$expected,
+			$instance->getHash()
+		);
+	}
+
 	public function testPrune() {
 
 		$instance = new ConceptDescription( new DIWikiPage( 'Foo', SMW_NS_CONCEPT ) );

--- a/tests/phpunit/Unit/Query/Language/ConjunctionTest.php
+++ b/tests/phpunit/Unit/Query/Language/ConjunctionTest.php
@@ -41,17 +41,94 @@ class ConjunctionTest extends \PHPUnit_Framework_TestCase {
 
 		$instance = new Conjunction( $descriptions );
 
-		$this->assertEquals( $expected['descriptions'], $instance->getDescriptions() );
+		$this->assertEquals(
+			$expected['descriptions'],
+			$instance->getDescriptions()
+		);
 
-		$this->assertEquals( $expected['queryString'], $instance->getQueryString() );
-		$this->assertEquals( $expected['queryStringAsValue'], $instance->getQueryString( true ) );
+		$this->assertEquals(
+			$expected['queryString'],
+			$instance->getQueryString()
+		);
 
-		$this->assertEquals( $expected['isSingleton'], $instance->isSingleton() );
-		$this->assertEquals( array(), $instance->getPrintRequests() );
+		$this->assertEquals(
+			$expected['queryStringAsValue'],
+			$instance->getQueryString( true )
+		);
 
-		$this->assertEquals( $expected['size'], $instance->getSize() );
-		$this->assertEquals( $expected['depth'], $instance->getDepth() );
-		$this->assertEquals( $expected['queryFeatures'], $instance->getQueryFeatures() );
+		$this->assertEquals(
+			$expected['isSingleton'],
+			$instance->isSingleton()
+		);
+
+		$this->assertEquals(
+			array(),
+			$instance->getPrintRequests()
+		);
+
+		$this->assertEquals(
+			$expected['size'],
+			$instance->getSize()
+		);
+
+		$this->assertEquals(
+			$expected['depth'],
+			$instance->getDepth()
+		);
+
+		$this->assertEquals(
+			$expected['queryFeatures'],
+			$instance->getQueryFeatures()
+		);
+	}
+
+	public function testGetHash() {
+
+		$descriptions = array(
+			new NamespaceDescription( NS_MAIN ),
+			new NamespaceDescription( NS_HELP )
+		);
+
+		$instance = new Conjunction(
+			$descriptions
+		);
+
+		$expected = $instance->getHash();
+
+		// Different order, same hash
+		$descriptions = array(
+			new NamespaceDescription( NS_HELP ),
+			new NamespaceDescription( NS_MAIN ) // Changed position
+		);
+
+		$instance = new Conjunction(
+			$descriptions
+		);
+
+		$this->assertSame(
+			$expected,
+			$instance->getHash()
+		);
+
+		// ThingDescription is neglected
+		$instance->addDescription(
+			new ThingDescription()
+		);
+
+		$this->assertSame(
+			$expected,
+			$instance->getHash()
+		);
+
+		// Adds description === different signature === different hash
+		$instance->addDescription(
+			new ValueDescription( new DIWikiPage( 'Foo', NS_MAIN ) )
+		);
+
+		$this->assertNotSame(
+			$expected,
+			$instance->getHash()
+		);
 	}
 
 	public function conjunctionProvider() {
@@ -84,10 +161,16 @@ class ConjunctionTest extends \PHPUnit_Framework_TestCase {
 			) )
 		);
 
+		$description = array(
+			new ValueDescription( new DIWikiPage( 'Foo', NS_MAIN ) ),
+			new ValueDescription( new DIWikiPage( 'Bar', NS_MAIN ) ),
+			new ValueDescription( new DIWikiPage( 'Yim', NS_MAIN ) )
+		);
+
 		$provider[] = array(
 			$descriptions,
 			array(
-				'descriptions'  => $descriptions,
+				'descriptions'  => $description,
 				'queryString' => '[[:Foo]] [[:Bar]] [[:Yim]]',
 				'queryStringAsValue' => ' <q>[[:Foo]] [[:Bar]] [[:Yim]]</q> ',
 				'isSingleton' => true,

--- a/tests/phpunit/Unit/Query/Language/DisjunctionTest.php
+++ b/tests/phpunit/Unit/Query/Language/DisjunctionTest.php
@@ -42,17 +42,90 @@ class DisjunctionTest extends \PHPUnit_Framework_TestCase {
 
 		$instance = new Disjunction( $descriptions );
 
-		$this->assertEquals( $expected['descriptions'], $instance->getDescriptions() );
+		$this->assertEquals(
+			$expected['descriptions'],
+			$instance->getDescriptions()
+		);
 
-		$this->assertEquals( $expected['queryString'], $instance->getQueryString() );
-		$this->assertEquals( $expected['queryStringAsValue'], $instance->getQueryString( true ) );
+		$this->assertEquals(
+			$expected['queryString'],
+			$instance->getQueryString()
+		);
 
-		$this->assertEquals( $expected['isSingleton'], $instance->isSingleton() );
-		$this->assertEquals( array(), $instance->getPrintRequests() );
+		$this->assertEquals(
+			$expected['queryStringAsValue'],
+			$instance->getQueryString( true )
+		);
 
-		$this->assertEquals( $expected['size'], $instance->getSize() );
-		$this->assertEquals( $expected['depth'], $instance->getDepth() );
-		$this->assertEquals( $expected['queryFeatures'], $instance->getQueryFeatures() );
+		$this->assertEquals(
+			$expected['isSingleton'],
+			$instance->isSingleton()
+		);
+
+		$this->assertEquals(
+			array(),
+			$instance->getPrintRequests()
+		);
+
+		$this->assertEquals(
+			$expected['size'],
+			$instance->getSize()
+		);
+
+		$this->assertEquals(
+			$expected['depth'],
+			$instance->getDepth()
+		);
+
+		$this->assertEquals(
+			$expected['queryFeatures'],
+			$instance->getQueryFeatures()
+		);
+	}
+
+	public function testGetHash() {
+
+		$descriptions = array(
+			new NamespaceDescription( NS_MAIN ),
+			new NamespaceDescription( NS_HELP )
+		);
+
+		$instance = new Disjunction(
+			$descriptions
+		);
+
+		$expected = $instance->getHash();
+
+		// Different order, same hash
+		$descriptions = array(
+			new NamespaceDescription( NS_HELP ),
+			new NamespaceDescription( NS_MAIN )
+		);
+
+		$instance = new Disjunction(
+			$descriptions
+		);
+
+		$this->assertSame(
+			$expected,
+			$instance->getHash()
+		);
+
+		// Different signature, different hash
+		$descriptions = array(
+			new NamespaceDescription( NS_HELP ),
+			new NamespaceDescription( NS_MAIN ),
+			new ThingDescription()
+		);
+
+		$instance = new Disjunction(
+			$descriptions
+		);
+
+		$this->assertNotSame(
+			$expected,
+			$instance->getHash()
+		);
 	}
 
 	public function disjunctionProvider() {

--- a/tests/phpunit/Unit/Query/Language/SomePropertyTest.php
+++ b/tests/phpunit/Unit/Query/Language/SomePropertyTest.php
@@ -8,6 +8,7 @@ use SMW\Query\Language\NamespaceDescription;
 use SMW\Query\Language\SomeProperty;
 use SMW\Query\Language\ThingDescription;
 use SMW\Query\Language\ValueDescription;
+use SMW\Query\Language\Conjunction;
 
 /**
  * @covers \SMW\Query\Language\SomeProperty
@@ -49,18 +50,71 @@ class SomePropertyTest extends \PHPUnit_Framework_TestCase {
 
 		$instance = new SomeProperty( $property, $description );
 
-		$this->assertEquals( $expected['property'], $instance->getProperty() );
-		$this->assertEquals( $expected['description'], $instance->getDescription() );
+		$this->assertEquals(
+			$expected['property'],
+			$instance->getProperty()
+		);
 
-		$this->assertEquals( $expected['queryString'], $instance->getQueryString() );
-		$this->assertEquals( $expected['queryStringAsValue'], $instance->getQueryString( true ) );
+		$this->assertEquals(
+			$expected['description'],
+			$instance->getDescription()
+		);
 
-		$this->assertEquals( $expected['isSingleton'], $instance->isSingleton() );
-		$this->assertEquals( array(), $instance->getPrintRequests() );
+		$this->assertEquals(
+			$expected['queryString'],
+			$instance->getQueryString()
+		);
 
-		$this->assertEquals( $expected['size'], $instance->getSize() );
-		$this->assertEquals( $expected['depth'], $instance->getDepth() );
-		$this->assertEquals( $expected['queryFeatures'], $instance->getQueryFeatures() );
+		$this->assertEquals(
+			$expected['queryStringAsValue'],
+			$instance->getQueryString( true )
+		);
+
+		$this->assertEquals(
+			$expected['isSingleton'],
+			$instance->isSingleton()
+		);
+
+		$this->assertEquals(
+			array(),
+			$instance->getPrintRequests()
+		);
+
+		$this->assertEquals(
+			$expected['size'],
+			$instance->getSize()
+		);
+
+		$this->assertEquals(
+			$expected['depth'],
+			$instance->getDepth()
+		);
+
+		$this->assertEquals(
+			$expected['queryFeatures'],
+			$instance->getQueryFeatures()
+		);
+	}
+
+	public function testGetHash() {
+
+		$instance = new SomeProperty(
+			new DIProperty( 'Foo' ),
+			new NamespaceDescription( NS_HELP )
+		);
+
+		$expected = $instance->getHash();
+
+		// Same property, different description === different hash
+		$instance = new SomeProperty(
+			new DIProperty( 'Foo' ),
+			new NamespaceDescription( NS_MAIN )
+		);
+
+		$this->assertNotSame(
+			$expected,
+			$instance->getHash()
+		);
 	}
 
 	public function somePropertyProvider() {

--- a/tests/phpunit/Unit/Query/Language/ValueDescriptionTest.php
+++ b/tests/phpunit/Unit/Query/Language/ValueDescriptionTest.php
@@ -43,20 +43,82 @@ class ValueDescriptionTest extends \PHPUnit_Framework_TestCase {
 
 		$instance = new ValueDescription( $dataItem, $property, $comparator );
 
-		$this->assertEquals( $expected['comparator'], $instance->getComparator() );
-		$this->assertEquals( $expected['dataItem'], $instance->getDataItem() );
+		$this->assertEquals(
+			$expected['comparator'],
+			$instance->getComparator()
+		);
 
-		$this->assertEquals( $expected['property'], $instance->getProperty() );
+		$this->assertEquals(
+			$expected['dataItem'],
+			$instance->getDataItem()
+		);
 
-		$this->assertEquals( $expected['queryString'], $instance->getQueryString() );
-		$this->assertEquals( $expected['queryStringAsValue'], $instance->getQueryString( true ) );
+		$this->assertEquals(
+			$expected['property'],
+			$instance->getProperty()
+		);
 
-		$this->assertEquals( $expected['isSingleton'], $instance->isSingleton() );
-		$this->assertEquals( array(), $instance->getPrintRequests() );
+		$this->assertEquals(
+			$expected['queryString'],
+			$instance->getQueryString()
+		);
 
-		$this->assertEquals( 1, $instance->getSize() );
-		$this->assertEquals( 0, $instance->getDepth() );
-		$this->assertEquals( 0, $instance->getQueryFeatures() );
+		$this->assertEquals(
+			$expected['queryStringAsValue'],
+			$instance->getQueryString( true )
+		);
+
+		$this->assertEquals(
+			$expected['isSingleton'],
+			$instance->isSingleton()
+		);
+
+		$this->assertEquals(
+			array(),
+			$instance->getPrintRequests()
+		);
+
+		$this->assertEquals(
+			1,
+			$instance->getSize()
+		);
+
+		$this->assertEquals(
+			0,
+			$instance->getDepth()
+		);
+
+		$this->assertEquals(
+			0,
+			$instance->getQueryFeatures()
+		);
+	}
+
+	public function testGetHash() {
+
+		$instance = new ValueDescription(
+			new DIWikiPage( 'Foo', NS_MAIN ), null, SMW_CMP_EQ
+		);
+
+		$expected = $instance->getHash();
+
+		$instance = new ValueDescription(
+			new DIWikiPage( 'Foo', NS_MAIN ), null, SMW_CMP_LEQ
+		);
+
+		$this->assertNotSame(
+			$expected,
+			$instance->getHash()
+		);
+
+		$instance = new ValueDescription(
+			new DIWikiPage( 'Foo', NS_MAIN ), new DIProperty( 'Bar' ), SMW_CMP_EQ
+		);
+
+		$this->assertNotSame(
+			$expected,
+			$instance->getHash()
+		);
 	}
 
 	public function valueDescriptionProvider() {


### PR DESCRIPTION
This PR is made in reference to:  #1251

This PR addresses or contains:

- Using the plain query string `[[Foo::123]][[Bar::abc]]` as part of the signature (among limit, offset, sort/order) is not good enough to filter queries with the same conditional expression because `[[Foo::123]][[Bar::abc]]` would yield a different hash compared to `[[Bar::abc]][[Foo::123]]`
- `[[Foo::123]][[Bar::abc]]` and `[[Bar::abc]][[Foo::123]]` are equal expressions in terms of the conditional match process therefore a signature should account for that as well to ensure that queries can sufficiently be cached or compared
- `Description::getHash` will take into account the canonization and uses a sorted compound to represent a signature

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed

