### PR TITLE
NamespaceManager::init to set SMW_NS* default settings, refs 1887, 2105

### DIFF
--- a/src/NamespaceManager.php
+++ b/src/NamespaceManager.php
@@ -51,6 +51,8 @@ class NamespaceManager {
 		if ( empty( $this->globalVars['smwgContLang'] ) ) {
 			$this->globalVars['smwgContLang'] = $this->extraneousLanguage->fetchByLanguageCode( $this->globalVars['wgLanguageCode'] );
 		}
+
+		$this->addNamespaceSettings();
 	}
 
 	/**
@@ -198,6 +200,12 @@ class NamespaceManager {
 			SMW_NS_CONCEPT => true,
 			SMW_NS_CONCEPT_TALK => false,
 		);
+
+		if ( !array_key_exists( 'smwgHistoricTypeNamespace', $GLOBALS ) || !$GLOBALS['smwgHistoricTypeNamespace'] ) {
+			unset( $smwNamespacesSettings[SMW_NS_TYPE] );
+			unset( $smwNamespacesSettings[SMW_NS_TYPE_TALK] );
+			unset( $this->globalVars['wgNamespacesWithSubpages'][SMW_NS_TYPE_TALK] );
+		}
 
 		// Combine default values with values specified in other places
 		// (LocalSettings etc.)

--- a/tests/phpunit/Unit/NamespaceManagerTest.php
+++ b/tests/phpunit/Unit/NamespaceManagerTest.php
@@ -61,7 +61,6 @@ class NamespaceManagerTest extends \PHPUnit_Framework_TestCase {
 		);
 	}
 
-
 	public function testExecutionWithIncompleteConfiguration() {
 
 		$test = $this->default + array(
@@ -136,6 +135,66 @@ class NamespaceManagerTest extends \PHPUnit_Framework_TestCase {
 		$this->assertEquals(
 			100,
 			$test['smwgNamespaceIndex']
+		);
+	}
+
+	public function testNamespacesInitWithEmptySettings() {
+
+		$this->testEnvironment->addConfiguration(
+			'smwgHistoricTypeNamespace',
+			false
+		);
+
+		$test = $this->default + array(
+			'wgExtraNamespaces'  => '',
+			'wgNamespaceAliases' => ''
+		);
+
+		$instance = new NamespaceManager( $test, $this->extraneousLanguage );
+		$instance->init();
+
+		$this->assertTrue(
+			$test['smwgNamespacesWithSemanticLinks'][SMW_NS_PROPERTY]
+		);
+
+		$this->assertTrue(
+			$test['smwgNamespacesWithSemanticLinks'][SMW_NS_CONCEPT]
+		);
+
+		$this->assertFalse(
+			isset( $test['smwgNamespacesWithSemanticLinks'][SMW_NS_TYPE] )
+		);
+	}
+
+	public function testNamespacesInitToKeepPreInitSettings() {
+
+		$this->testEnvironment->addConfiguration(
+			'smwgHistoricTypeNamespace',
+			true
+		);
+
+		$test = $this->default + array(
+			'wgExtraNamespaces'  => '',
+			'wgNamespaceAliases' => '',
+		);
+
+		$test['smwgNamespacesWithSemanticLinks'] = array(
+			SMW_NS_PROPERTY => false
+		);
+
+		$instance = new NamespaceManager( $test, $this->extraneousLanguage );
+		$instance->init();
+
+		$this->assertFalse(
+			$test['smwgNamespacesWithSemanticLinks'][SMW_NS_PROPERTY]
+		);
+
+		$this->assertTrue(
+			$test['smwgNamespacesWithSemanticLinks'][SMW_NS_CONCEPT]
+		);
+
+		$this->assertTrue(
+			$test['smwgNamespacesWithSemanticLinks'][SMW_NS_TYPE]
 		);
 	}
 


### PR DESCRIPTION
This PR is made in reference to: #1887, #2105

This PR addresses or contains:

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed
