### PR TITLE
Stricter interpretation of the "UniquenessConstraint", refs 1463

### DIFF
--- a/i18n/en.json
+++ b/i18n/en.json
@@ -435,6 +435,7 @@
 	"smw-pa-property-predefined_pvuc": "\"$1\" is a predefined property indicating that value assignments to a property are expected to be unique and is provided by [https://www.semantic-mediawiki.org/wiki/Help:Special_properties Semantic MediaWiki].",
 	"smw-pa-property-predefined-long_pvuc": "Uniqueness is established when two values are not equal in their literal representation and any violation of this constraint will be categorized as error.",
 	"smw-datavalue-uniqueness-constraint-error": "Property \"$1\" only permits unique value assignments and ''$2'' was already annotated in subject \"$3\".",
+	"smw-datavalue-uniqueness-constraint-isknown": "Property \"$1\" only permits unique value annotations, ''$2'' has already been assigned to \"$3\".",
 	"smw-pa-property-predefined_boo": "\"$1\" is a [[Special:Types/Boolean|type]] and predefined property provided by [https://www.semantic-mediawiki.org/wiki/Help:Special_properties Semantic MediaWiki] to represent boolean values.",
 	"smw-pa-property-predefined_num": "\"$1\" is a [[Special:Types/Number|type]] and predefined property provided by [https://www.semantic-mediawiki.org/wiki/Help:Special_properties Semantic MediaWiki] to represent numeric values.",
 	"smw-pa-property-predefined_dat": "\"$1\" is a [[Special:Types/Date|type]] and predefined property provided by [https://www.semantic-mediawiki.org/wiki/Help:Special_properties Semantic MediaWiki] to represent date values.",

--- a/tests/phpunit/Integration/JSONScript/TestCases/p-0443.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/p-0443.json
@@ -1,0 +1,72 @@
+{
+	"description": "Test conditions and strict constraint validations for uniqueness `_PVUC` (#1463, `wgContLang=en`, `wgLang=en`, `smwgDVFeatures`)",
+	"setup": [
+		{
+			"namespace": "SMW_NS_PROPERTY",
+			"page": "Has uniqueness one",
+			"contents": "[[Has type::Text]] [[Has uniqueness constraint::true]]"
+		},
+		{
+			"namespace": "SMW_NS_PROPERTY",
+			"page": "Has uniqueness two",
+			"contents": "[[Has type::Text]] [[Has uniqueness constraint::true]]"
+		},
+		{
+			"page": "Example/P0443/1",
+			"contents": "[[Has uniqueness one::Allowed one]] [[Has uniqueness one::Not permitted]] [[Has uniqueness two::Allowed two]] [[Has uniqueness two::Not permitted]]"
+		},
+		{
+			"page": "Example/P0443/2",
+			"contents": "[[Has uniqueness one::1111]] {{#ask: [[Has uniqueness one::1111]] |link=none }}"
+		}
+	],
+	"tests": [
+		{
+			"type": "parser",
+			"about": "#0 (verify uniqueness for only one assignment per property)",
+			"subject": "Example/P0443/1",
+			"store": {
+				"clear-cache": true
+			},
+			"assert-store": {
+				"semantic-data": {
+					"strictPropertyValueMatch": false,
+					"propertyCount": 5,
+					"propertyKeys": [
+						"_MDAT",
+						"_SKEY",
+						"_ERRC",
+						"Has uniqueness one",
+						"Has uniqueness two"
+					],
+					"propertyValues": [
+						"Allowed one",
+						"Allowed two"
+					]
+				}
+			}
+		},
+		{
+			"type": "parser",
+			"about": "#1 (verify declared unique value doesn't interfere with #ask within the same page)",
+			"subject": "Example/P0443/2",
+			"assert-output": {
+				"to-contain": [
+					"<p>1111 Example/P0443/2"
+				]
+			}
+		}
+	],
+	"settings": {
+		"smwgDVFeatures": [
+			"SMW_DV_PVUC"
+		],
+		"wgContLang": "en",
+		"wgLang": "en"
+	},
+	"meta": {
+		"version": "2",
+		"is-incomplete": false,
+		"debug": false
+	}
+}

--- a/tests/phpunit/Utils/Validators/SemanticDataValidator.php
+++ b/tests/phpunit/Utils/Validators/SemanticDataValidator.php
@@ -311,6 +311,9 @@ class SemanticDataValidator extends \PHPUnit_Framework_Assert {
 	}
 
 	private function assertContainsPropertyKeys( $keys, DIProperty $property ) {
+
+		$keys = str_replace( " " , "_", $keys );
+
 		$this->assertContains(
 			$property->getKey(),
 			$keys,


### PR DESCRIPTION
This PR is made in reference to: #1463

This PR addresses or contains:

- Checks that no competing values on the same subject/property are declared for when the property is specified as `[[Has uniqueness constraint::true]]`

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed
