### PR TITLE
RebuildFulltextSearchTable to add `--optimize`, refs 1481

### DIFF
--- a/maintenance/rebuildFulltextSearchTable.php
+++ b/maintenance/rebuildFulltextSearchTable.php
@@ -22,6 +22,7 @@ class RebuildFulltextSearchTable extends \Maintenance {
 		$this->mDescription = 'Rebuild the fulltext search index (only works with SQLStore)';
 		$this->addOption( 'report-runtime', 'Report execution time and memory usage', false );
 		$this->addOption( 'with-maintenance-log', 'Add log entry to `Special:Log` about the maintenance run.', false );
+		$this->addOption( 'optimize', 'Run possible table optimization (support depends on the SQL back-end) ', false );
 		$this->addOption( 'v', 'Show additional (verbose) information about the progress', false );
 		$this->addOption( 'quick', 'Suppress abort operation', false );
 
@@ -50,6 +51,10 @@ class RebuildFulltextSearchTable extends \Maintenance {
 
 		$searchTableRebuilder->reportVerbose(
 			$this->hasOption( 'v' )
+		);
+
+		$searchTableRebuilder->requestOptimization(
+			$this->hasOption( 'optimize' )
 		);
 
 		$this->reportMessage(

--- a/src/SQLStore/QueryEngine/Fulltext/SearchTableUpdater.php
+++ b/src/SQLStore/QueryEngine/Fulltext/SearchTableUpdater.php
@@ -68,6 +68,32 @@ class SearchTableUpdater {
 	}
 
 	/**
+	 * @see http://dev.mysql.com/doc/refman/5.7/en/fulltext-fine-tuning.html
+	 * @see http://dev.mysql.com/doc/refman/5.7/en/optimize-table.html
+	 *
+	 * "Running OPTIMIZE TABLE on a table with a full-text index rebuilds the
+	 * full-text index, removing deleted Document IDs and consolidating multiple
+	 * entries for the same word, where possible."
+	 *
+	 * @since 2.5
+	 *
+	 * @return boolean
+	 */
+	public function optimize() {
+
+		if ( !$this->connection->isType( 'mysql' ) ) {
+			return false;
+		}
+
+		$this->connection->query(
+			"OPTIMIZE TABLE " . $this->searchTable->getTableName(),
+			__METHOD__
+		);
+
+		return true;
+	}
+
+	/**
 	 * @since 2.5
 	 *
 	 * @param integer $sid

--- a/tests/phpunit/Unit/SQLStore/QueryEngine/Fulltext/SearchTableRebuilderTest.php
+++ b/tests/phpunit/Unit/SQLStore/QueryEngine/Fulltext/SearchTableRebuilderTest.php
@@ -68,6 +68,32 @@ class SearchTableRebuilderTest extends \PHPUnit_Framework_TestCase {
 		$instance->run();
 	}
 
+	public function testNeverRebuildOnOptimization() {
+
+		$tableDefinition = $this->getMockBuilder( '\SMW\SQLStore\TableDefinition' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$this->searchTableUpdater->expects( $this->once() )
+			->method( 'isEnabled' )
+			->will( $this->returnValue( true ) );
+
+		$this->searchTableUpdater->expects( $this->never() )
+			->method( 'getPropertyTables' );
+
+		$this->searchTableUpdater->expects( $this->once() )
+			->method( 'optimize' );
+
+		$instance = new SearchTableRebuilder(
+			$this->connection,
+			$this->searchTableUpdater
+		);
+
+		$instance->requestOptimization( true );
+
+		$instance->run();
+	}
+
 	public function testRunWithUpdateOnBlob() {
 
 		$row = new \stdClass;

--- a/tests/phpunit/Unit/SQLStore/QueryEngine/Fulltext/SearchTableUpdaterTest.php
+++ b/tests/phpunit/Unit/SQLStore/QueryEngine/Fulltext/SearchTableUpdaterTest.php
@@ -64,6 +64,47 @@ class SearchTableUpdaterTest extends \PHPUnit_Framework_TestCase {
 		$instance->read( 12, 42 );
 	}
 
+	public function testOptimizeOnEnabledType() {
+
+		$this->connection->expects( $this->once() )
+			->method( 'isType' )
+			->with( $this->equalTo( 'mysql' ) )
+			->will( $this->returnValue( true ) );
+
+		$this->connection->expects( $this->once() )
+			->method( 'query' );
+
+		$instance = new SearchTableUpdater(
+			$this->connection,
+			$this->searchTable,
+			$this->textSanitizer
+		);
+
+		$this->assertTrue(
+			$instance->optimize()
+		);
+	}
+
+	public function testOptimizeOnDisabledType() {
+
+		$this->connection->expects( $this->once() )
+			->method( 'isType' )
+			->will( $this->returnValue( false ) );
+
+		$this->connection->expects( $this->never() )
+			->method( 'query' );
+
+		$instance = new SearchTableUpdater(
+			$this->connection,
+			$this->searchTable,
+			$this->textSanitizer
+		);
+
+		$this->assertFalse(
+			$instance->optimize()
+		);
+	}
+
 	public function testUpdateWithText() {
 
 		$this->connection->expects( $this->once() )


### PR DESCRIPTION
This PR is made in reference to: #1481

This PR addresses or contains:

- Add maintenance option for the full-text table (only supported by `mysql` [0, 1])

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed

[0] http://dev.mysql.com/doc/refman/5.7/en/fulltext-fine-tuning.html
[1] http://dev.mysql.com/doc/refman/5.7/en/optimize-table.html