### PR TITLE
Fulltext to add support for TYPE_WIKIPAGE, refs 1481, 1801, 1912

### DIFF
--- a/includes/Settings.php
+++ b/includes/Settings.php
@@ -150,6 +150,7 @@ class Settings extends Options {
 			'smwgFulltextSearchPropertyExemptionList' => $GLOBALS['smwgFulltextSearchPropertyExemptionList'],
 			'smwgFulltextSearchMinTokenSize' => $GLOBALS['smwgFulltextSearchMinTokenSize'],
 			'smwgFulltextLanguageDetection' => $GLOBALS['smwgFulltextLanguageDetection'],
+			'smwgFulltextSearchIndexableDataTypes' => $GLOBALS['smwgFulltextSearchIndexableDataTypes'],
 			'smwgQTemporaryTablesAutoCommitMode' => $GLOBALS['smwgQTemporaryTablesAutoCommitMode'],
 			'smwgQueryResultCacheType' => $GLOBALS['smwgQueryResultCacheType'],
 			'smwgQueryResultCacheLifetime' => $GLOBALS['smwgQueryResultCacheLifetime'],

--- a/src/Defines.php
+++ b/src/Defines.php
@@ -160,3 +160,12 @@ define( 'SMW_DV_TIMEV_CM', 256 );  // TimeValue to indicate calendar model
 define( 'SMW_DV_PPLB', 512 );  // Preferred property label
 define( 'SMW_DV_PROV_LHNT', 1024 );  // PropertyValue to output a hint in case of a preferred label usage
 /**@}*/
+
+/**@{
+  * Constants for Fulltext types
+  */
+define( 'SMW_FT_NONE', 0 );
+define( 'SMW_FT_BLOB', 2 ); // DataItem::TYPE_BLOB
+define( 'SMW_FT_URI', 4 ); // DataItem::TYPE_URI
+define( 'SMW_FT_WIKIPAGE', 8 ); // DataItem::TYPE_WIKIPAGE
+/**@}*/

--- a/src/SQLStore/QueryEngine/DescriptionInterpreters/SomePropertyInterpreter.php
+++ b/src/SQLStore/QueryEngine/DescriptionInterpreters/SomePropertyInterpreter.php
@@ -178,6 +178,11 @@ class SomePropertyInterpreter implements DescriptionInterpreter {
 			);
 
 			if ( $sub >= 0 ) {
+				$subQuery = $this->querySegmentListBuilder->findQuerySegment(
+					$sub
+				);
+
+				$o_id = $subQuery->indexField !== '' ? $subQuery->indexField : $o_id;
 				$query->components[$sub] = "{$query->alias}.{$o_id}";
 			}
 
@@ -191,7 +196,7 @@ class SomePropertyInterpreter implements DescriptionInterpreter {
 			}
 		} else { // non-page value description
 			$query->joinfield = "{$query->alias}.s_id";
-			$this->interpretInnerValueDescription( $query, $description->getDescription(), $proptable, $diHandler, 'AND' );
+			$this->compilePropertyValueDescription( $query, $description->getDescription(), $proptable, $diHandler, 'AND' );
 			if ( array_key_exists( $sortkey, $this->querySegmentListBuilder->getSortKeys() ) ) {
 				$query->sortfields[$sortkey] = isset( $query->sortIndexField ) ? $query->sortIndexField : "{$query->alias}.{$indexField}";
 			}
@@ -209,7 +214,7 @@ class SomePropertyInterpreter implements DescriptionInterpreter {
 	 * @param DataItemHandler $diHandler for that table
 	 * @param string $operator SQL operator "AND" or "OR"
 	 */
-	private function interpretInnerValueDescription(
+	private function compilePropertyValueDescription(
 			$query, Description $description, SMWSQLStore3Table $proptable, DataItemHandler $diHandler, $operator ) {
 
 		if ( $description instanceof ValueDescription ) {
@@ -227,7 +232,7 @@ class SomePropertyInterpreter implements DescriptionInterpreter {
 			$query->where .= "(";
 
 			foreach ( $description->getDescriptions() as $subdesc ) {
-				$this->interpretInnerValueDescription( $query, $subdesc, $proptable, $diHandler, $op );
+				$this->compilePropertyValueDescription( $query, $subdesc, $proptable, $diHandler, $op );
 			}
 
 			$query->where .= ")";

--- a/src/SQLStore/QueryEngine/Fulltext/MySQLValueMatchConditionBuilder.php
+++ b/src/SQLStore/QueryEngine/Fulltext/MySQLValueMatchConditionBuilder.php
@@ -3,6 +3,7 @@
 namespace SMW\SQLStore\QueryEngine\Fulltext;
 
 use SMW\Query\Language\ValueDescription;
+use SMW\DIProperty;
 
 /**
  * @license GNU GPL v2+
@@ -54,7 +55,18 @@ class MySQLValueMatchConditionBuilder extends ValueMatchConditionBuilder {
 	 * @return boolean
 	 */
 	public function hasMinTokenLength( $value ) {
-		return mb_strlen( $value ) >= $this->searchTable->getMinTokenSize();
+		return $this->searchTable->hasMinTokenLength( $value );
+	}
+
+	/**
+	 * @since 2.5
+	 *
+	 * @param string $property
+	 *
+	 * @return boolean
+	 */
+	public function isExemptedProperty( DIProperty $property ) {
+		return $this->searchTable->isExemptedProperty( $property );
 	}
 
 	/**
@@ -77,11 +89,15 @@ class MySQLValueMatchConditionBuilder extends ValueMatchConditionBuilder {
 	 */
 	public function canApplyFulltextSearchMatchCondition( ValueDescription $description ) {
 
-		if ( !$this->isEnabled() || $description->getProperty() === null ) {
+		if ( !$this->isEnabled() ) {
 			return false;
 		}
 
-		if ( $this->searchTable->isExemptedProperty( $description->getProperty() ) ) {
+		if ( $description->getProperty() !== null && $this->isExemptedProperty( $description->getProperty() ) ) {
+			return false;
+		}
+
+		if ( !$this->searchTable->isValidByType( $description->getDataItem()->getDiType() ) ) {
 			return false;
 		}
 

--- a/src/SQLStore/QueryEngine/Fulltext/SQLiteValueMatchConditionBuilder.php
+++ b/src/SQLStore/QueryEngine/Fulltext/SQLiteValueMatchConditionBuilder.php
@@ -3,6 +3,7 @@
 namespace SMW\SQLStore\QueryEngine\Fulltext;
 
 use SMW\Query\Language\ValueDescription;
+use SMW\DIProperty;
 
 /**
  * @license GNU GPL v2+
@@ -54,7 +55,18 @@ class SQLiteValueMatchConditionBuilder extends ValueMatchConditionBuilder {
 	 * @return boolean
 	 */
 	public function hasMinTokenLength( $value ) {
-		return mb_strlen( $value ) >= $this->searchTable->getMinTokenSize();
+		return $this->searchTable->hasMinTokenLength( $value );
+	}
+
+	/**
+	 * @since 2.5
+	 *
+	 * @param string $property
+	 *
+	 * @return boolean
+	 */
+	public function isExemptedProperty( DIProperty $property ) {
+		return $this->searchTable->isExemptedProperty( $property );
 	}
 
 	/**
@@ -77,11 +89,15 @@ class SQLiteValueMatchConditionBuilder extends ValueMatchConditionBuilder {
 	 */
 	public function canApplyFulltextSearchMatchCondition( ValueDescription $description ) {
 
-		if ( !$this->isEnabled() || $description->getProperty() === null ) {
+		if ( !$this->isEnabled() ) {
 			return false;
 		}
 
-		if ( $this->searchTable->isExemptedProperty( $description->getProperty() ) ) {
+		if ( $description->getProperty() !== null && $this->isExemptedProperty( $description->getProperty() ) ) {
+			return false;
+		}
+
+		if ( !$this->searchTable->isValidByType( $description->getDataItem()->getDiType() ) ) {
 			return false;
 		}
 

--- a/src/SQLStore/QueryEngine/Fulltext/SearchTableUpdater.php
+++ b/src/SQLStore/QueryEngine/Fulltext/SearchTableUpdater.php
@@ -128,14 +128,14 @@ class SearchTableUpdater {
 	 */
 	public function update( $sid, $pid, $text ) {
 
-		if ( trim( $text ) === '' ) {
+		if ( trim( $text ) === '' || ( $indexableText = $this->textSanitizer->sanitize( $text ) ) === '' ) {
 			return $this->delete( $sid, $pid );
 		}
 
 		$this->connection->update(
 			$this->searchTable->getTableName(),
 			array(
-				'o_text' => $this->textSanitizer->sanitize( $text ),
+				'o_text' => $indexableText,
 				'o_sort' => mb_substr( $text, 0, 32 )
 			),
 			array(

--- a/src/SQLStore/QueryEngine/Fulltext/TextByChangeUpdater.php
+++ b/src/SQLStore/QueryEngine/Fulltext/TextByChangeUpdater.php
@@ -198,14 +198,19 @@ class TextByChangeUpdater {
 			return;
 		}
 
-		// Only text components
-		if ( !$fieldChangeOp->has( 'o_blob' ) && !$fieldChangeOp->has( 'o_hash' ) && !$fieldChangeOp->has( 'o_serialized' ) ) {
+		if ( !$fieldChangeOp->has( 'o_blob' ) && !$fieldChangeOp->has( 'o_hash' ) && !$fieldChangeOp->has( 'o_serialized' ) && !$fieldChangeOp->has( 'o_id' ) ) {
 			return;
 		}
 
 		// Re-map (url type)
 		if ( $fieldChangeOp->has( 'o_serialized' ) ) {
 			$fieldChangeOp->set( 'o_blob', $fieldChangeOp->get( 'o_serialized' ) );
+		}
+
+		// Re-map (wpg type)
+		if ( $fieldChangeOp->has( 'o_id' ) ) {
+			$dataItem = $searchTable->getDataItemById( $fieldChangeOp->get( 'o_id' ) );
+			$fieldChangeOp->set( 'o_blob', $dataItem !== null ? $dataItem->getSortKey() : 'NO_TEXT' );
 		}
 
 		// Build a temporary stable key for the diff match

--- a/src/SQLStore/QueryEngine/Fulltext/TextSanitizer.php
+++ b/src/SQLStore/QueryEngine/Fulltext/TextSanitizer.php
@@ -47,14 +47,14 @@ class TextSanitizer {
 	 */
 	public function getVersions() {
 
-		$languageDetector = '(disabled)';
+		$languageDetector = '(Disabled)';
 
 		if ( isset( $this->languageDetection['TextCatLanguageDetector'] ) ) {
 			$languageDetector = 'TextCatLanguageDetector (' . implode(', ', $this->languageDetection['TextCatLanguageDetector'] ) . ')';
 		}
 
 		return array(
-			'ICU (Intl) PHP-extension' => ( extension_loaded( 'intl' ) ? INTL_ICU_VERSION : '(disabled)' ),
+			'ICU (Intl) PHP-extension' => ( extension_loaded( 'intl' ) ? INTL_ICU_VERSION : '(Disabled)' ),
 			'Tesa::Sanitizer'  => Sanitizer::VERSION,
 			'Tesa::Transliterator' => Transliterator::VERSION,
 			'Tesa::LanguageDetector' => $languageDetector

--- a/src/SQLStore/QueryEngine/Fulltext/ValueMatchConditionBuilder.php
+++ b/src/SQLStore/QueryEngine/Fulltext/ValueMatchConditionBuilder.php
@@ -5,6 +5,7 @@ namespace SMW\SQLStore\QueryEngine\Fulltext;
 use SMW\Query\Language\ValueDescription;
 use SMWDIBlob as DIBlob;
 use SMWDIUri as DIUri;
+use SMW\DIWikiPage;
 
 /**
  * @license GNU GPL v2+
@@ -99,7 +100,7 @@ class ValueMatchConditionBuilder {
 			$matchableText = $description->getDataItem()->getString();
 		}
 
-		if ( $description->getDataItem() instanceof DIUri ) {
+		if ( $description->getDataItem() instanceof DIUri || $description->getDataItem() instanceof DIWikiPage ) {
 			$matchableText = $description->getDataItem()->getSortKey();
 		}
 

--- a/src/SQLStore/QueryEngine/FulltextSearchTableFactory.php
+++ b/src/SQLStore/QueryEngine/FulltextSearchTableFactory.php
@@ -105,6 +105,10 @@ class FulltextSearchTableFactory {
 			$settings->get( 'smwgFulltextSearchMinTokenSize' )
 		);
 
+		$searchTable->setIndexableDataTypes(
+			$settings->get( 'smwgFulltextSearchIndexableDataTypes' )
+		);
+
 		return $searchTable;
 	}
 

--- a/src/SQLStore/QueryEngine/QuerySegment.php
+++ b/src/SQLStore/QueryEngine/QuerySegment.php
@@ -82,6 +82,14 @@ class QuerySegment {
 	public $joinfield = '';
 
 	/**
+	 * Allows to define an index field, for example in case when a sub-query rewires
+	 * a match condition.
+	 *
+	 * @var string
+	 */
+	public $indexField = '';
+
+	/**
 	 * @var string
 	 */
 	public $from = '';

--- a/src/SharedCallbackContainer.php
+++ b/src/SharedCallbackContainer.php
@@ -277,13 +277,18 @@ class SharedCallbackContainer implements CallbackContainer {
 				$callbackLoader->singleton( 'QueryFactory' ),
 				$callbackLoader->create(
 					'BlobStore',
-					CachedQueryResultPrefetcher::CACHE_NAMESPACE, $cacheType,
+					CachedQueryResultPrefetcher::CACHE_NAMESPACE,
+					$cacheType,
 					$settings->get( 'smwgQueryResultCacheLifetime' )
 				),
 				$callbackLoader->singleton(
 					'TransientStatsdCollector',
 					CachedQueryResultPrefetcher::STATSD_ID
 				)
+			);
+
+			$cachedQueryResultPrefetcher->setHashModifier(
+				$settings->get( 'smwgFulltextSearchIndexableDataTypes' )
 			);
 
 			$cachedQueryResultPrefetcher->setLogger(

--- a/tests/phpunit/Integration/JSONScript/JsonTestCaseScriptRunnerTest.php
+++ b/tests/phpunit/Integration/JSONScript/JsonTestCaseScriptRunnerTest.php
@@ -163,6 +163,7 @@ class JsonTestCaseScriptRunnerTest extends JsonTestCaseScriptRunner {
 			'smwgEnabledQueryDependencyLinksStore',
 			'smwgEnabledFulltextSearch',
 			'smwgFulltextDeferredUpdate',
+			'smwgFulltextSearchIndexableDataTypes',
 			'smwgPropertyZeroCountDisplay',
 			'smwgQueryResultCacheType',
 			'smwgLinksInValues',

--- a/tests/phpunit/Integration/JSONScript/TestCases/q-0104.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/q-0104.json
@@ -234,7 +234,11 @@
 	],
 	"settings": {
 		"smwgEnabledFulltextSearch": true,
-		"smwgFulltextDeferredUpdate": false
+		"smwgFulltextDeferredUpdate": false,
+		"smwgFulltextSearchIndexableDataTypes": [
+			"SMW_FT_BLOB",
+			"SMW_FT_URI"
+		]
 	},
 	"meta": {
 		"skip-on": {

--- a/tests/phpunit/Integration/JSONScript/TestCases/q-0105.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/q-0105.json
@@ -1,0 +1,273 @@
+{
+	"description": "Test `_wpg`/`~` with enabled full-text search support (only enabled for MySQL, SQLite, `SMW_FT_WIKIPAGE`)",
+	"setup": [
+		{
+			"namespace": "SMW_NS_PROPERTY",
+			"page": "Has page",
+			"contents": "[[Has type::Page]]"
+		},
+		{
+			"page": "Example/Q0105/1",
+			"contents": "{{#subobject: |Has page=MySQL vs MariaDB database}} {{#subobject: |Has page=Oracle vs MariaDB database}} {{#subobject: |Has page=PostgreSQL vs MariaDB database and more of}} {{#subobject: |Has page=MariaDB overview}}"
+		},
+		{
+			"page": "Example/Q0105/2",
+			"contents": "{{#subobject: |Has page=Elastic search}} {{#subobject: |Has page=Sphinx search}}"
+		},
+		{
+			"page": "Example/Q0105/3",
+			"contents": "{{#subobject: |Has page=...a hyphenated phrase that has special significance when it appears at the beginning of text...}} {{#subobject: |Has page=...a hyphenated phrase that has NOT any special significance when it appears at the beginning of text...}}"
+		},
+		{
+			"page": "Example/Q0105/4",
+			"contents": "{{#subobject: |Has page=Text with a category|@category=Q0105}} {{#subobject: |Has page=Text without a category}}"
+		}
+	],
+	"beforeTest": {
+		"job-run": [
+			"SMW\\SearchTableUpdateJob"
+		]
+	},
+	"tests": [
+		{
+			"type": "query",
+			"about": "#0 with boolean include/not include",
+			"condition": "[[Has page::~+MariaDB -database]]",
+			"printouts": [],
+			"parameters": {
+				"limit": "10"
+			},
+			"queryresult": {
+				"count": 1,
+				"results": [
+					"Example/Q0105/1#0##_13bfd7da17ee73035f210b926e671c83"
+				]
+			}
+		},
+		{
+			"type": "query",
+			"about": "#1",
+			"condition": "[[Has page::~+database]]",
+			"printouts": [],
+			"parameters": {
+				"limit": "10"
+			},
+			"queryresult": {
+				"count": 3,
+				"results": [
+					"Example/Q0105/1#0##_d1e52a56041afb2795ebc6683f9a5229",
+					"Example/Q0105/1#0##_e64ad35fdcd8d9e99f2db9a815e36be3",
+					"Example/Q0105/1#0##_4b9aef2f903c80012ed4000b519a039d"
+				]
+			}
+		},
+		{
+			"type": "query",
+			"about": "#2 (plus sorting)",
+			"condition": "[[Has page::~DATA*]]",
+			"printouts": [],
+			"parameters": {
+				"limit": "10",
+				"sort": {
+					"Has_page": "DESC"
+				}
+			},
+			"queryresult": {
+				"count": 3,
+				"results": [
+					"Example/Q0105/1#0##_d1e52a56041afb2795ebc6683f9a5229",
+					"Example/Q0105/1#0##_e64ad35fdcd8d9e99f2db9a815e36be3",
+					"Example/Q0105/1#0##_4b9aef2f903c80012ed4000b519a039d"
+				]
+			}
+		},
+		{
+			"type": "query",
+			"about": "#3 (plus sorting)",
+			"condition": "[[Has page::~sear*]]",
+			"printouts": [],
+			"parameters": {
+				"limit": "10",
+				"sort": {
+					"Has_page": "ASC"
+				}
+			},
+			"queryresult": {
+				"count": 2,
+				"results": [
+					"Example/Q0105/2#0##_4e8a7e81b361d0e14670809d9a1ff614",
+					"Example/Q0105/2#0##_7927dc49ee111e0929a91a1f357d9906"
+				]
+			}
+		},
+		{
+			"type": "query",
+			"about": "#4 include/not include",
+			"condition": "[[Has page::~sear*, -elas*]]",
+			"printouts": [],
+			"parameters": {
+				"limit": "10",
+				"sort": {
+					"Has_page": "DESC"
+				}
+			},
+			"queryresult": {
+				"count": 1,
+				"results": [
+					"Example/Q0105/2#0##_7927dc49ee111e0929a91a1f357d9906"
+				]
+			}
+		},
+		{
+			"type": "query",
+			"about": "#5 same as #4",
+			"condition": "[[Has page::!~elastic*, +sear*]]",
+			"printouts": [],
+			"parameters": {
+				"limit": "10"
+			},
+			"queryresult": {
+				"count": 1,
+				"results": [
+					"Example/Q0105/2#0##_7927dc49ee111e0929a91a1f357d9906"
+				]
+			}
+		},
+		{
+			"type": "query",
+			"about": "#6 phrase matching",
+			"condition": "[[Has page::~\"phrase that has special\"]]",
+			"printouts": [],
+			"parameters": {
+				"limit": "10"
+			},
+			"queryresult": {
+				"count": 1,
+				"results": [
+					"Example/Q0105/3#0##_6b717d3124b3d294797a43ed5064374c"
+				]
+			}
+		},
+		{
+			"type": "query",
+			"about": "#7 similar to #5 but not used in phrase matching mode",
+			"condition": "[[Has page::~phrase that has special]]",
+			"printouts": [],
+			"parameters": {
+				"limit": "10"
+			},
+			"queryresult": {
+				"count": 2,
+				"results": [
+					"Example/Q0105/3#0##_6b717d3124b3d294797a43ed5064374c",
+					"Example/Q0105/3#0##_1dd972ef96528fe09e971c88ed933a7a"
+				]
+			}
+		},
+		{
+			"type": "query",
+			"about": "#8 free search (wide proximity)",
+			"skip-on": {
+				"sqlite": "works different in comparison to MySQL, see #9"
+			},
+			"condition": "[[~~with a category]]",
+			"printouts": [],
+			"parameters": {
+				"limit": "10"
+			},
+			"queryresult": {
+				"count": 2,
+				"results": [
+					"Example/Q0105/4#0##_c77b6e54b1b4d59500b7d4232b30a0fb",
+					"Example/Q0105/4#0##_b827401b701c08c3c3d610a3a43d18c3"
+				]
+			}
+		},
+		{
+			"type": "query",
+			"about": "#9 free search (wide proximity)",
+			"condition": "[[~~with* a category]] [[~Example/Q0105/*]]",
+			"printouts": [],
+			"parameters": {
+				"limit": "10"
+			},
+			"queryresult": {
+				"count": 2,
+				"results": [
+					"Example/Q0105/4#0##_c77b6e54b1b4d59500b7d4232b30a0fb",
+					"Example/Q0105/4#0##_b827401b701c08c3c3d610a3a43d18c3"
+				]
+			}
+		},
+		{
+			"type": "query",
+			"about": "#10 free search (wide proximity)",
+			"condition": "[[~~with a category]] [[Category:Q0105]]",
+			"printouts": [],
+			"parameters": {
+				"limit": "10"
+			},
+			"queryresult": {
+				"count": 1,
+				"results": [
+					"Example/Q0105/4#0##_c77b6e54b1b4d59500b7d4232b30a0fb"
+				]
+			}
+		},
+		{
+			"type": "query",
+			"about": "#11 retain spaces on +/- operators",
+			"condition": "[[Has page::~+*maria* -postgres*]]",
+			"printouts": [],
+			"parameters": {
+				"limit": "10"
+			},
+			"queryresult": {
+				"count": 3,
+				"results": [
+					"Example/Q0105/1#0##_d1e52a56041afb2795ebc6683f9a5229",
+					"Example/Q0105/1#0##_e64ad35fdcd8d9e99f2db9a815e36be3",
+					"Example/Q0105/1#0##_13bfd7da17ee73035f210b926e671c83"
+				]
+			}
+		},
+		{
+			"type": "query",
+			"about": "#12 same as #11 only with `,` (required by MySQL 5.7/MariaDB 10.1)",
+			"condition": "[[Has page::~+*maria*, -postgres*]]",
+			"printouts": [],
+			"parameters": {
+				"limit": "10"
+			},
+			"queryresult": {
+				"count": 3,
+				"results": [
+					"Example/Q0105/1#0##_d1e52a56041afb2795ebc6683f9a5229",
+					"Example/Q0105/1#0##_e64ad35fdcd8d9e99f2db9a815e36be3",
+					"Example/Q0105/1#0##_13bfd7da17ee73035f210b926e671c83"
+				]
+			}
+		}
+	],
+	"settings": {
+		"smwgEnabledFulltextSearch": true,
+		"smwgFulltextDeferredUpdate": false,
+		"smwgFulltextSearchIndexableDataTypes": [
+			"SMW_FT_BLOB",
+			"SMW_FT_URI",
+			"SMW_FT_WIKIPAGE"
+		]
+	},
+	"meta": {
+		"skip-on": {
+			"postgres": "Not supported by PostgreSQL.",
+			"sesame": "Not supported by SPARQLStore (Sesame).",
+			"virtuoso": "Not supported by SPARQLStore (Virtuoso).",
+			"fuseki": "Not supported by SPARQLStore (Fuskei).",
+			"blazegraph": "Not supported by SPARQLStore (Blazegraph)."
+		},
+		"version": "2",
+		"is-incomplete": false,
+		"debug": false
+	}
+}

--- a/tests/phpunit/JsonTestCaseFileHandler.php
+++ b/tests/phpunit/JsonTestCaseFileHandler.php
@@ -206,6 +206,16 @@ class JsonTestCaseFileHandler {
 			return $smwgDVFeatures;
 		}
 
+		if ( $key === 'smwgFulltextSearchIndexableDataTypes' && isset( $settings[$key] ) ) {
+			$smwgFulltextSearchIndexableDataTypes = '';
+
+			foreach ( $settings[$key] as $value ) {
+				$smwgFulltextSearchIndexableDataTypes = constant( $value ) | $smwgFulltextSearchIndexableDataTypes;
+			}
+
+			return $smwgFulltextSearchIndexableDataTypes;
+		}
+
 		if ( $key === 'wgDefaultUserOptions' && isset( $settings[$key] ) ) {
 			return array_merge( $GLOBALS['wgDefaultUserOptions'], $settings[$key] );
 		}

--- a/tests/phpunit/Unit/SQLStore/QueryEngine/Fulltext/MySQLValueMatchConditionBuilderTest.php
+++ b/tests/phpunit/Unit/SQLStore/QueryEngine/Fulltext/MySQLValueMatchConditionBuilderTest.php
@@ -74,30 +74,6 @@ class MySQLValueMatchConditionBuilderTest extends \PHPUnit_Framework_TestCase {
 		);
 	}
 
-	public function testHasMinTokenLength() {
-
-		$this->searchTable->expects( $this->any() )
-			->method( 'getMinTokenSize' )
-			->will( $this->returnValue( 4 ) );
-
-		$instance = new MySQLValueMatchConditionBuilder(
-			$this->textSanitizer,
-			$this->searchTable
-		);
-
-		$this->assertFalse(
-			$instance->hasMinTokenLength( 'bar' )
-		);
-
-		$this->assertFalse(
-			$instance->hasMinTokenLength( 'テスト' )
-		);
-
-		$this->assertTrue(
-			$instance->hasMinTokenLength( 'test' )
-		);
-	}
-
 	public function testGetSortIndexField() {
 
 		$this->searchTable->expects( $this->any() )
@@ -119,6 +95,14 @@ class MySQLValueMatchConditionBuilderTest extends \PHPUnit_Framework_TestCase {
 
 		$this->searchTable->expects( $this->once() )
 			->method( 'isEnabled' )
+			->will( $this->returnValue( true ) );
+
+		$this->searchTable->expects( $this->once() )
+			->method( 'isValidByType' )
+			->will( $this->returnValue( true ) );
+
+		$this->searchTable->expects( $this->once() )
+			->method( 'hasMinTokenLength' )
 			->will( $this->returnValue( true ) );
 
 		$this->searchTable->expects( $this->once() )

--- a/tests/phpunit/Unit/SQLStore/QueryEngine/Fulltext/SQLiteValueMatchConditionBuilderTest.php
+++ b/tests/phpunit/Unit/SQLStore/QueryEngine/Fulltext/SQLiteValueMatchConditionBuilderTest.php
@@ -74,30 +74,6 @@ class SQLiteValueMatchConditionBuilderTest extends \PHPUnit_Framework_TestCase {
 		);
 	}
 
-	public function testHasMinTokenLength() {
-
-		$this->searchTable->expects( $this->any() )
-			->method( 'getMinTokenSize' )
-			->will( $this->returnValue( 4 ) );
-
-		$instance = new SQLiteValueMatchConditionBuilder(
-			$this->textSanitizer,
-			$this->searchTable
-		);
-
-		$this->assertFalse(
-			$instance->hasMinTokenLength( 'bar' )
-		);
-
-		$this->assertFalse(
-			$instance->hasMinTokenLength( 'テスト' )
-		);
-
-		$this->assertTrue(
-			$instance->hasMinTokenLength( 'test' )
-		);
-	}
-
 	public function testGetSortIndexField() {
 
 		$this->searchTable->expects( $this->any() )
@@ -119,6 +95,14 @@ class SQLiteValueMatchConditionBuilderTest extends \PHPUnit_Framework_TestCase {
 
 		$this->searchTable->expects( $this->once() )
 			->method( 'isEnabled' )
+			->will( $this->returnValue( true ) );
+
+		$this->searchTable->expects( $this->once() )
+			->method( 'isValidByType' )
+			->will( $this->returnValue( true ) );
+
+		$this->searchTable->expects( $this->once() )
+			->method( 'hasMinTokenLength' )
 			->will( $this->returnValue( true ) );
 
 		$this->searchTable->expects( $this->once() )

--- a/tests/phpunit/Unit/SQLStore/QueryEngine/Fulltext/SearchTableRebuilderTest.php
+++ b/tests/phpunit/Unit/SQLStore/QueryEngine/Fulltext/SearchTableRebuilderTest.php
@@ -18,6 +18,7 @@ use SMW\Tests\Utils\Mock\IteratorMockBuilder;
 class SearchTableRebuilderTest extends \PHPUnit_Framework_TestCase {
 
 	private $searchTableUpdater;
+	private $searchTable;
 	private $connection;
 	private $iteratorMockBuilder;
 
@@ -27,9 +28,17 @@ class SearchTableRebuilderTest extends \PHPUnit_Framework_TestCase {
 			->disableOriginalConstructor()
 			->getMock();
 
+		$this->searchTable = $this->getMockBuilder( '\SMW\SQLStore\QueryEngine\Fulltext\SearchTable' )
+			->disableOriginalConstructor()
+			->getMock();
+
 		$this->searchTableUpdater = $this->getMockBuilder( '\SMW\SQLStore\QueryEngine\Fulltext\SearchTableUpdater' )
 			->disableOriginalConstructor()
 			->getMock();
+
+		$this->searchTableUpdater->expects( $this->any() )
+			->method( 'getSearchTable' )
+			->will( $this->returnValue( $this->searchTable ) );
 
 		$this->iteratorMockBuilder = new IteratorMockBuilder();
 	}
@@ -122,13 +131,13 @@ class SearchTableRebuilderTest extends \PHPUnit_Framework_TestCase {
 			->method( 'getDiType' )
 			->will( $this->returnValue( DataItem::TYPE_BLOB ) );
 
-		$searchTable = $this->getMockBuilder( '\SMW\SQLStore\QueryEngine\Fulltext\SearchTable' )
-			->disableOriginalConstructor()
-			->getMock();
+		$this->searchTable->expects( $this->any() )
+			->method( 'isValidByType' )
+			->will( $this->returnValue( true ) );
 
-		$this->searchTableUpdater->expects( $this->atLeastOnce() )
-			->method( 'getSearchTable' )
-			->will( $this->returnValue( $searchTable ) );
+		$this->searchTable->expects( $this->any() )
+			->method( 'hasMinTokenLength' )
+			->will( $this->returnValue( true ) );
 
 		$this->searchTableUpdater->expects( $this->once() )
 			->method( 'isEnabled' )

--- a/tests/phpunit/Unit/SQLStore/QueryEngine/Fulltext/SearchTableTest.php
+++ b/tests/phpunit/Unit/SQLStore/QueryEngine/Fulltext/SearchTableTest.php
@@ -4,6 +4,7 @@ namespace SMW\Tests\SQLStore\QueryEngine\Fulltext;
 
 use SMW\SQLStore\QueryEngine\Fulltext\SearchTable;
 use SMW\DataItemFactory;
+use SMWDataItem as DataItem;
 
 /**
  * @covers \SMW\SQLStore\QueryEngine\Fulltext\SearchTable
@@ -71,6 +72,10 @@ class SearchTableTest extends \PHPUnit_Framework_TestCase {
 			$this->store
 		);
 
+		$instance->setIndexableDataTypes(
+			SMW_FT_BLOB | SMW_FT_URI
+		);
+
 		$instance->setPropertyExemptionList(
 			array( '_TEXT' )
 		);
@@ -86,6 +91,46 @@ class SearchTableTest extends \PHPUnit_Framework_TestCase {
 
 		$this->assertFalse(
 			$instance->isExemptedProperty( $property )
+		);
+	}
+
+	public function testIsValidType() {
+
+		$instance = new SearchTable(
+			$this->store
+		);
+
+		$instance->setIndexableDataTypes(
+			SMW_FT_BLOB | SMW_FT_URI
+		);
+
+		$this->assertTrue(
+			$instance->isValidByType( DataItem::TYPE_BLOB )
+		);
+
+		$this->assertFalse(
+			$instance->isValidByType( DataItem::TYPE_WIKIPAGE )
+		);
+	}
+
+	public function testHasMinTokenLength() {
+
+		$instance = new SearchTable(
+			$this->store
+		);
+
+		$instance->setMinTokenSize( 4 );
+
+		$this->assertFalse(
+			$instance->hasMinTokenLength( 'bar' )
+		);
+
+		$this->assertFalse(
+			$instance->hasMinTokenLength( 'テスト' )
+		);
+
+		$this->assertTrue(
+			$instance->hasMinTokenLength( 'test' )
 		);
 	}
 


### PR DESCRIPTION
This PR is made in reference to: #1481, #1801, #1912 

This PR addresses or contains:

- Adds `smwgFulltextSearchIndexableDataTypes` which can be extended to what datatype are allowed to be index using the full-text index with the default being `BLOB` and `URI`
- Adds support for page type properties to use the same `~` matching operation (incl. case insensitivity) as text or uri property types

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed
