### PR TITLE
TableIntegrityExaminer to extend checks

### DIFF
--- a/maintenance/setupStore.php
+++ b/maintenance/setupStore.php
@@ -133,8 +133,8 @@ class SetupStore extends \Maintenance {
 			ob_end_flush();
 		}
 
-		$this->output( "\nAll storage structures for $storeName have been deleted." );
-		$this->output( "You can recreate them with this script followed by the use of the rebuildData.php script to rebuild their contents.\n\n");
+		$this->output( "\nYou can recreate them with this script followed by the use\n");
+		$this->output( "of the rebuildData.php script to rebuild their contents.\n");
 	}
 
 	/**

--- a/src/SQLStore/Installer.php
+++ b/src/SQLStore/Installer.php
@@ -143,9 +143,12 @@ class Installer implements MessageReporter, MessageReporterAware {
 			$this->tableBuilder->drop( $table );
 		}
 
+		$this->tableIntegrityExaminer->checkOnPostDestruction( $this->tableBuilder );
+
 		Hooks::run( 'SMW::SQLStore::AfterDropTablesComplete', array( $this->tableBuilder ) );
 
-		$messageReporter->reportMessage( "\nStandard and auxiliary tables with corresponding data have been removed successfully.\n" );
+		$messageReporter->reportMessage( "\nStandard and auxiliary tables with all corresponding data\n" );
+		$messageReporter->reportMessage( "have been removed successfully.\n" );
 
 		return true;
 	}

--- a/src/SQLStore/TableBuilder.php
+++ b/src/SQLStore/TableBuilder.php
@@ -10,7 +10,7 @@ use Onoi\MessageReporter\MessageReporterAware;
  *
  * Provides generic creation and updating function for database tables. A builder
  * that implements this interface is expected to define Database specific
- * operations and allowing it to be executed on specific RDBMS backend.
+ * operations and allowing it to be executed on a specific RDBMS back-end.
  *
  * @license GNU GPL v2+
  * @since 2.5
@@ -20,14 +20,24 @@ use Onoi\MessageReporter\MessageReporterAware;
 interface TableBuilder extends MessageReporterAware {
 
 	/**
-	 * On after the creation of tables and indicies
+	 * Common prefix used by all Semantic MediaWiki tables
+	 */
+	const TABLE_PREFIX = 'smw_';
+
+	/**
+	 * On before the creation of tables and indicies
 	 */
 	const PRE_CREATION = 'pre.creation';
 
 	/**
-	 * On after dropping all tables
+	 * On after creation of all tables
 	 */
 	const POST_CREATION = 'post.creation';
+
+	/**
+	 * On after dropping all tables
+	 */
+	const POST_DESTRUCTION = 'post.destruction';
 
 	/**
 	 * Generic creation and updating function for database tables. Ideally, it

--- a/src/SQLStore/TableIntegrityExaminer.php
+++ b/src/SQLStore/TableIntegrityExaminer.php
@@ -5,16 +5,17 @@ namespace SMW\SQLStore;
 use Onoi\MessageReporter\NullMessageReporter;
 use Onoi\MessageReporter\MessageReporter;
 use Onoi\MessageReporter\MessageReporterAware;
+use SMW\SQLStore\TableBuilder\Table;
 use SMWDataItem as DataItem;
 use SMW\DIProperty;
 use SMWSql3SmwIds;
+use SMW\InvalidPredefinedPropertyException;
 
 /**
  * @private
  *
- *
- * Allows to execute SQLStore or table specific tasks that are expected to be part
- * of the installation or removal routine.
+ * Allows to execute SQLStore or table specific examination tasks that are
+ * expected to be part of the installation or removal routine.
  *
  * @license GNU GPL v2+
  * @since 2.5
@@ -34,6 +35,11 @@ class TableIntegrityExaminer implements MessageReporterAware {
 	private $messageReporter;
 
 	/**
+	 * @var array
+	 */
+	private $predefinedProperties = array();
+
+	/**
 	 * @since 2.5
 	 *
 	 * @param SQLStore $store
@@ -41,6 +47,7 @@ class TableIntegrityExaminer implements MessageReporterAware {
 	public function __construct( SQLStore $store ) {
 		$this->store = $store;
 		$this->messageReporter = new NullMessageReporter();
+		$this->predefinedProperties = SMWSql3SmwIds::$special_ids;
 	}
 
 	/**
@@ -57,32 +64,81 @@ class TableIntegrityExaminer implements MessageReporterAware {
 	/**
 	 * @since 2.5
 	 *
+	 * @param array $predefinedProperties
+	 */
+	public function setPredefinedProperties( array $predefinedProperties ) {
+		$this->predefinedProperties = $predefinedProperties;
+	}
+
+	/**
+	 * @since 2.5
+	 *
 	 * @param TableBuilder $tableBuilder
 	 */
 	public function checkOnPostCreation( TableBuilder $tableBuilder ) {
 
-		$this->doCheckInternalPropertyIndices(
-			$this->store->getConnection( DB_MASTER )
+		$connection = $this->store->getConnection( DB_MASTER );
+
+		$this->doCheckPredefinedPropertyIndices(
+			$connection
 		);
 
+		// Call out for RDBMS specific implementations
 		$tableBuilder->checkOn( TableBuilder::POST_CREATION );
 	}
 
 	/**
-	 * Create some initial DB entries for important built-in properties. Having the DB contents predefined
-	 * allows us to safe DB calls when certain data is needed. At the same time, the entries in the DB
-	 * make sure that DB-based functions work as with all other properties.
+	 * @since 2.5
+	 *
+	 * @param TableBuilder $tableBuilder
 	 */
-	private function doCheckInternalPropertyIndices( $connection ) {
+	public function checkOnPostDestruction( TableBuilder $tableBuilder ) {
 
-		$this->messageReporter->reportMessage( "\nSetting up internal property indices ...\n" );
+		$connection = $this->store->getConnection( DB_MASTER );
+
+		// Find orphaned tables that have not been removed but were produced and
+		// handled by SMW
+		foreach ( $connection->listTables() as $table ) {
+			if ( strpos( $table, TableBuilder::TABLE_PREFIX ) !== false ) {
+
+				// Remove any MW specific prefix at this point which will be
+				// handled by the DB class (abcsmw_foo -> smw_foo)
+				$tableBuilder->drop( new Table( strstr( $table, TableBuilder::TABLE_PREFIX ) ) );
+			}
+		}
+
+		// Call out for RDBMS specific implementations
+		$tableBuilder->checkOn( TableBuilder::POST_DESTRUCTION );
+	}
+
+	/**
+	 * Create some initial DB entries for important built-in properties. Having
+	 * the DB contents predefined allows us to safe DB calls when certain data
+	 * is needed. At the same time, the entries in the DB make sure that DB-based
+	 * functions work as with all other properties.
+	 */
+	private function doCheckPredefinedPropertyIndices( $connection ) {
+
+		$this->messageReporter->reportMessage( "Checking predefined properties ...\n" );
 		$this->doCheckPredefinedPropertyBorder( $connection );
 
-		// now write actual properties; do that each time, it is cheap enough and we can update sortkeys by current language
-		$this->messageReporter->reportMessage( "   ... writing entries for internal properties ...\n" );
+		// now write actual properties; do that each time, it is cheap enough
+		// and we can update sortkeys by current language
+		$this->messageReporter->reportMessage( "   ... writing properties ...\n" );
 
-		foreach ( SMWSql3SmwIds::$special_ids as $prop => $id ) {
-			$property = new DIProperty( $prop );
+		foreach ( $this->predefinedProperties as $prop => $id ) {
+
+			try{
+				$property = new DIProperty( $prop );
+			} catch ( InvalidPredefinedPropertyException $e ) {
+				$property = null;
+				$this->messageReporter->reportMessage( "   ... skipping {$prop} due to invalid registration ...\n" );
+			}
+
+			if ( $property === null ) {
+				continue;
+			}
+
 			$connection->replace(
 				SQLStore::ID_TABLE,
 				array( 'smw_id' ),
@@ -96,6 +152,29 @@ class TableIntegrityExaminer implements MessageReporterAware {
 				),
 				__METHOD__
 			);
+
+			$row = $connection->selectRow(
+				SQLStore::PROPERTY_STATISTICS_TABLE,
+				array(
+					'p_id'
+				),
+				array( 'p_id' => $id ),
+				__METHOD__
+			);
+
+			// Entry is available therefore don't try to override the count value
+			if ( $row !== false ) {
+				continue;
+			}
+
+			$connection->insert(
+				SQLStore::PROPERTY_STATISTICS_TABLE,
+				array(
+					'p_id' => $id,
+					'usage_count' => 0
+				),
+				__METHOD__
+			);
 		}
 
 		$this->messageReporter->reportMessage( "   ... done.\n" );
@@ -104,28 +183,28 @@ class TableIntegrityExaminer implements MessageReporterAware {
 	private function doCheckPredefinedPropertyBorder( $connection ) {
 
 		// Check if we already have this structure
-		$expectedID = SQLStore::FIXED_PROPERTY_ID_UPPERBOUND;
+		$expectedIdUpperbound = SQLStore::FIXED_PROPERTY_ID_UPPERBOUND;
 
-		$currentID = $connection->selectRow(
+		$currentIdUpperbound = $connection->selectRow(
 			SQLStore::ID_TABLE,
 			'smw_id',
 			'smw_iw=' . $connection->addQuotes( SMW_SQL3_SMWBORDERIW )
 		);
 
-		if ( $currentID !== false && $currentID->smw_id == $expectedID ) {
+		if ( $currentIdUpperbound !== false && $currentIdUpperbound->smw_id == $expectedIdUpperbound ) {
 			return $this->messageReporter->reportMessage( "   ... space for internal properties already allocated.\n" );
 		}
 
 		// Legacy bound
-		$currentID = $currentID === false ? 50 : $currentID->smw_id;
+		$currentIdUpperbound = $currentIdUpperbound === false ? 50 : $currentIdUpperbound->smw_id;
 
 		$this->messageReporter->reportMessage( "   ... allocating space for internal properties ...\n" );
-		$this->store->getObjectIds()->moveSMWPageID( $expectedID );
+		$this->store->getObjectIds()->moveSMWPageID( $expectedIdUpperbound );
 
 		$connection->insert(
 			SQLStore::ID_TABLE,
 			array(
-				'smw_id' => $expectedID,
+				'smw_id' => $expectedIdUpperbound,
 				'smw_title' => '',
 				'smw_namespace' => 0,
 				'smw_iw' => SMW_SQL3_SMWBORDERIW,
@@ -135,12 +214,15 @@ class TableIntegrityExaminer implements MessageReporterAware {
 			__METHOD__
 		);
 
-		$this->messageReporter->reportMessage( "   ... moving from $currentID to $expectedID " );
+		if ( $currentIdUpperbound == $expectedIdUpperbound ) {
+			return $this->messageReporter->reportMessage( "   ... done.\n" );
+		}
+
+		$this->messageReporter->reportMessage( "   ... moving from $currentIdUpperbound to $expectedIdUpperbound" );
 
 		// make way for built-in ids
-		for ( $i = $currentID; $i < $expectedID; $i++ ) {
+		for ( $i = $currentIdUpperbound; $i < $expectedIdUpperbound; $i++ ) {
 			$this->store->getObjectIds()->moveSMWPageID( $i );
-			$this->messageReporter->reportMessage( '.' );
 		}
 
 		$this->messageReporter->reportMessage( "\n   ... done.\n" );


### PR DESCRIPTION
This PR is made in reference to: # N/A

This PR addresses or contains:

- Check for `InvalidPredefinedPropertyException`
- Add `TableIntegrityExaminer::checkOnPostDestruction` to find orphaned SMW tables that have not been removed

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed
