### PR TITLE
Add PropertyTypeFinder (smwgFixedProperties)

### DIFF
--- a/DefaultSettings.php
+++ b/DefaultSettings.php
@@ -731,39 +731,26 @@ return array(
 	##
 
 	##
-	# These are fixed properties, i.e. user defined properties having a
-	# dedicated table for them. Entries in this array have the following format:
+	# List of user-defined fixed properties
 	#
-	# 		property_key => property_type.
+	# Listed properties are managed by its own fixed table (instad of a
+	# shared one) to allow for sharding large datasets with value assignments.
 	#
-	# The 'property_key' is the title of the property (with underscores instead
-	# of _ and capital first letter).
-	# The 'property_type' denotes the type of the property and has to be one of the following:
-	#		SMWDataItem::TYPE_BLOB
-	#		SMWDataItem::TYPE_URI
-	#		SMWDataItem::TYPE_WIKIPAGE
-	#		SMWDataItem::TYPE_NUMBER
-	#		SMWDataItem::TYPE_TIME
-	#		SMWDataItem::TYPE_BOOLEAN
-	#		SMWDataItem::TYPE_CONTAINER
-	#		SMWDataItem::TYPE_GEO
-	#		SMWDataItem::TYPE_CONCEPT
-	#		SMWDataItem::TYPE_PROPERTY
+	# The type definition is talen from the property page `[[Has type::...]]` and
+	# by default (if no type is defined) then the `smwgPDefaultType` is returned.
 	#
-	# A run of setup using SMWAdmin is needed to create these tables. If an already used property is assigned a new table all old data for this property will
-	# become inaccessible for SMW. This can be repaired by either migrating it to the new table (repair data) or will eventually be updated on page edits.
+	# Any change to the property type requires to run the `setupStore.php` script
+	# or `Special:SMWAdmin` table update.
 	#
-	# Example: If you have a property named 'Age' which is of type 'Number' then add in LocalSettings:
+	# 'smwgFixedProperties' => array(
+	#		'Age',
+	#		'Has population'
+	# ),
 	#
-	# 		'smwgFixedProperties' => array(
-	#		'Age' => SMWDataItem::TYPE_NUMBER
-	#  	),
-	#
-	# @see http://semantic-mediawiki.org/wiki/Fixed_properties
-	#
+	# @see https://semantic-mediawiki.org/wiki/Fixed_properties
 	# @since 1.9
 	#
-	# @var array
+	# @default array()
 	##
 	'smwgFixedProperties' => array(),
 

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -475,5 +475,6 @@
 	"smw-property-preferred-title-format":"$1 ($2)",
 	"smw-property-preferred-label-language-combination-exists": "\"$1\" cannot be used as preferred label because the language \"$2\" is already assigned to the \"$3\" label.",
 	"smw-parse": "$1",
-	"smw-clipboard-copy-link": "Copy link to clipboard"
+	"smw-clipboard-copy-link": "Copy link to clipboard",
+	"smw-property-userdefined-fixedtable": "\"$1\" was configured as [https://semantic-mediawiki.org/wiki/Fixed_properties fixed property] and any modification to its [https://semantic-mediawiki.org/wiki/Type_declaration type declaration] requires to either run <code>setupStore.php</code> or to complete the special [[Special:SemanticMediaWiki|\"Database installation and upgrade\"]] task."
 }

--- a/includes/articlepages/SMW_PropertyPage.php
+++ b/includes/articlepages/SMW_PropertyPage.php
@@ -79,6 +79,11 @@ class SMWPropertyPage extends SMWOrderedListPage {
 		$message = '';
 
 		if ( $this->mProperty->isUserDefined() ) {
+
+			if ( $this->store->getPropertyTableInfoFetcher()->isFixedTableProperty( $this->mProperty ) ) {
+				$message = Html::rawElement( 'div', array( 'class' => 'plainlinks' ), wfMessage( 'smw-property-userdefined-fixedtable', $propertyName )->parse() );
+			}
+
 			return $message;
 		}
 

--- a/src/SPARQLStore/SPARQLStore.php
+++ b/src/SPARQLStore/SPARQLStore.php
@@ -371,6 +371,15 @@ class SPARQLStore extends Store {
 	}
 
 	/**
+	 * @since 2.5
+	 *
+	 * @return PropertyTableInfoFetcher
+	 */
+	public function getPropertyTableInfoFetcher() {
+		return $this->baseStore->getPropertyTableInfoFetcher();
+	}
+
+	/**
 	 * @since 2.0
 	 */
 	public function getPropertyTables() {

--- a/src/SQLStore/PropertyTableInfoFetcher.php
+++ b/src/SQLStore/PropertyTableInfoFetcher.php
@@ -15,6 +15,11 @@ use SMWDataItem as DataItem;
 class PropertyTableInfoFetcher {
 
 	/**
+	 * @var PropertyTypeFinder
+	 */
+	private $propertyTypeFinder;
+
+	/**
 	 * Array for keeping property table table data, indexed by table id.
 	 * Access this only by calling getPropertyTables().
 	 *
@@ -92,6 +97,15 @@ class PropertyTableInfoFetcher {
 	);
 
 	/**
+	 * @since 2.5
+	 *
+	 * @param PropertyTypeFinder $propertyTypeFinder
+	 */
+	public function __construct( PropertyTypeFinder $propertyTypeFinder ) {
+		$this->propertyTypeFinder = $propertyTypeFinder;
+	}
+
+	/**
 	 * @since 2.2
 	 *
 	 * @param array $customFixedProperties
@@ -144,6 +158,22 @@ class PropertyTableInfoFetcher {
 		}
 
 		return '';
+	}
+
+	/**
+	 * @since 2.5
+	 *
+	 * @param DIProperty $property
+	 *
+	 * @return boolean
+	 */
+	public function isFixedTableProperty( DIProperty $property ) {
+
+		if ( $this->fixedPropertyTableIds === null ) {
+			$this->buildDefinitionsForPropertyTables();
+		}
+
+		return array_key_exists( $property->getKey(), $this->fixedPropertyTableIds );
 	}
 
 	/**
@@ -212,12 +242,14 @@ class PropertyTableInfoFetcher {
 		}
 
 		$definitionBuilder = new PropertyTableDefinitionBuilder(
+			$this->propertyTypeFinder
+		);
+
+		$definitionBuilder->doBuild(
 			$this->defaultDiTypeTableIdMap,
 			$enabledSpecialProperties,
 			$this->customFixedPropertyList
 		);
-
-		$definitionBuilder->doBuild();
 
 		$this->propertyTableDefinitions = $definitionBuilder->getTableDefinitions();
 		$this->fixedPropertyTableIds = $definitionBuilder->getFixedPropertyTableIds();

--- a/src/SQLStore/PropertyTypeFinder.php
+++ b/src/SQLStore/PropertyTypeFinder.php
@@ -1,0 +1,112 @@
+<?php
+
+namespace SMW\SQLStore;
+
+use SMW\MediaWiki\Database;
+use SMW\DIProperty;
+use SMWTypesValue as TypesValue;
+use RuntimeException;
+
+/**
+ * @private
+ *
+ * @license GNU GPL v2+
+ * @since 2.5
+ *
+ * @author mwjames
+ */
+class PropertyTypeFinder {
+
+	/**
+	 * @var Database
+	 */
+	private $connection;
+
+	/**
+	 * @var string
+	 */
+	private $typeTableName = '';
+
+	/**
+	* @since 2.5
+	*
+	* @param Database $connection
+	*/
+	public function __construct( Database $connection ) {
+		$this->connection = $connection;
+	}
+
+	/**
+	* @since 2.5
+	*
+	* @param string $typeTableName
+	*/
+	public function setTypeTableName( $typeTableName ) {
+		$this->typeTableName = $typeTableName;
+	}
+
+	/**
+	* @since 2.5
+	*
+	* @param DIProperty $property
+	*
+	* @return string
+	* @throws RuntimeException
+	*/
+	public function findTypeID( DIProperty $property ) {
+
+		try {
+			$row = $this->connection->selectRow(
+				SQLStore::ID_TABLE,
+				array(
+					'smw_id'
+				),
+				array(
+					'smw_namespace' => SMW_NS_PROPERTY,
+					'smw_title' => $property->getKey(),
+					'smw_iw' => '',
+					'smw_subobject' => ''
+				),
+				__METHOD__
+			);
+		} catch ( \Exception $e ) {
+			$row = false;
+		}
+
+		if ( !isset( $row->smw_id ) ) {
+			return $GLOBALS['smwgPDefaultType'];
+		}
+
+		if ( $this->typeTableName === '' ) {
+			throw new RuntimeException( "Missing a table name" );
+		}
+
+		// The Finder is executed before tables are initialized with a corresponding
+		// and matchable DIHandler therefore using Store::getPropertyValue cannot
+		// be used at this point as it would create a circular reference during
+		// the table initialization.
+		//
+		// We expect it to be a URI table with `o_serialized` containing the
+		// type string
+		$row = $this->connection->selectRow(
+			$this->typeTableName,
+			array(
+				'o_serialized'
+			),
+			array(
+				's_id' => $row->smw_id
+			),
+			__METHOD__
+		);
+
+		if ( $row === false ) {
+			return $GLOBALS['smwgPDefaultType'];
+		}
+
+		// e.g. http://semantic-mediawiki.org/swivt/1.0#_num
+		list( $url, $fragment ) = explode( "#", $row->o_serialized );
+
+		return $fragment;
+	}
+
+}

--- a/src/SQLStore/SQLStoreFactory.php
+++ b/src/SQLStore/SQLStoreFactory.php
@@ -342,7 +342,9 @@ class SQLStoreFactory {
 
 		$settings = $this->applicationFactory->getSettings();
 
-		$propertyTableInfoFetcher = new PropertyTableInfoFetcher();
+		$propertyTableInfoFetcher = new PropertyTableInfoFetcher(
+			new PropertyTypeFinder( $this->store->getConnection( 'mw.db' ) )
+		);
 
 		$propertyTableInfoFetcher->setCustomFixedPropertyList(
 			$settings->get( 'smwgFixedProperties' )

--- a/tests/phpunit/Unit/SQLStore/PropertyTableDefinitionBuilderTest.php
+++ b/tests/phpunit/Unit/SQLStore/PropertyTableDefinitionBuilderTest.php
@@ -17,13 +17,18 @@ use SMWDataItem as DataItem;
  */
 class PropertyTableDefinitionBuilderTest extends \PHPUnit_Framework_TestCase {
 
-	protected $mwHooksHandler;
+	private $propertyTypeFinder;
+	private $mwHooksHandler;
 
 	protected function setUp() {
 		parent::setUp();
 
 		$this->mwHooksHandler = new MwHooksHandler();
 		$this->mwHooksHandler->deregisterListedHooks();
+
+		$this->propertyTypeFinder = $this->getMockBuilder( '\SMW\SQLStore\PropertyTypeFinder' )
+			->disableOriginalConstructor()
+			->getMock();
 	}
 
 	protected function tearDown() {
@@ -41,7 +46,7 @@ class PropertyTableDefinitionBuilderTest extends \PHPUnit_Framework_TestCase {
 
 		$this->assertInstanceOf(
 			'\SMW\SQLStore\PropertyTableDefinitionBuilder',
-			new PropertyTableDefinitionBuilder( $dataItems, $specials, $fixed )
+			new PropertyTableDefinitionBuilder( $this->propertyTypeFinder )
 		);
 	}
 
@@ -51,8 +56,15 @@ class PropertyTableDefinitionBuilderTest extends \PHPUnit_Framework_TestCase {
 		$specials = array();
 		$fixed = array();
 
-		$instance = new PropertyTableDefinitionBuilder( $dataItems, $specials, $fixed );
-		$instance->doBuild();
+		$instance = new PropertyTableDefinitionBuilder(
+			$this->propertyTypeFinder
+		);
+
+		$instance->doBuild(
+			$dataItems,
+			$specials,
+			$fixed
+		);
 
 		$definition = $instance->newTableDefinition(
 			DataItem::TYPE_NUMBER, 'smw_di_number'
@@ -75,12 +87,23 @@ class PropertyTableDefinitionBuilderTest extends \PHPUnit_Framework_TestCase {
 
 		$dataItems = array();
 		$specials = array();
-		$fixed = array( $propertyKey => DataItem::TYPE_NUMBER );
+		$fixed = array( $propertyKey );
 
-		$instance = new PropertyTableDefinitionBuilder( $dataItems, $specials, $fixed );
-		$instance->doBuild();
+		$this->propertyTypeFinder->expects( $this->any() )
+			->method( 'findTypeID' )
+			->will( $this->returnValue( '_num' ) );
 
-		$tableName = $instance->getTablePrefix() . '_' . md5( $expectedKey );
+		$instance = new PropertyTableDefinitionBuilder(
+			$this->propertyTypeFinder
+		);
+
+		$instance->doBuild(
+			$dataItems,
+			$specials,
+			$fixed
+		);
+
+		$tableName = $instance->createHashedTableNameFrom( $expectedKey );
 		$definition = $instance->newTableDefinition( DataItem::TYPE_NUMBER, $tableName, $expectedKey );
 
 		$expected = array(
@@ -107,8 +130,15 @@ class PropertyTableDefinitionBuilderTest extends \PHPUnit_Framework_TestCase {
 		$specials = array( $propertyKey );
 		$fixed = array();
 
-		$instance = new PropertyTableDefinitionBuilder( $dataItems, $specials, $fixed );
-		$instance->doBuild();
+		$instance = new PropertyTableDefinitionBuilder(
+			$this->propertyTypeFinder
+		);
+
+		$instance->doBuild(
+			$dataItems,
+			$specials,
+			$fixed
+		);
 
 		$tableName = $instance->getTablePrefix() . strtolower( $propertyKey );
 		$definition = $instance->newTableDefinition( DataItem::TYPE_TIME, $tableName, $propertyKey );
@@ -128,8 +158,15 @@ class PropertyTableDefinitionBuilderTest extends \PHPUnit_Framework_TestCase {
 		$specials = array( $propertyKey );
 		$fixed = array();
 
-		$instance = new PropertyTableDefinitionBuilder( $dataItems, $specials, $fixed );
-		$instance->doBuild();
+		$instance = new PropertyTableDefinitionBuilder(
+			$this->propertyTypeFinder
+		);
+
+		$instance->doBuild(
+			$dataItems,
+			$specials,
+			$fixed
+		);
 
 		$tableName = $instance->getTablePrefix() . strtolower( $propertyKey );
 		$definition = $instance->newTableDefinition( DataItem::TYPE_WIKIPAGE, $tableName, $propertyKey );

--- a/tests/phpunit/Unit/SQLStore/PropertyTableInfoFetcherTest.php
+++ b/tests/phpunit/Unit/SQLStore/PropertyTableInfoFetcherTest.php
@@ -17,17 +17,29 @@ use SMWDataItem as DataItem;
  */
 class PropertyTableInfoFetcherTest extends \PHPUnit_Framework_TestCase {
 
+	private $propertyTypeFinder;
+
+	protected function setUp() {
+		parent::setUp();
+
+		$this->propertyTypeFinder = $this->getMockBuilder( '\SMW\SQLStore\PropertyTypeFinder' )
+			->disableOriginalConstructor()
+			->getMock();
+	}
+
 	public function testCanConstruct() {
 
 		$this->assertInstanceOf(
 			'\SMW\SQLStore\PropertyTableInfoFetcher',
-			new PropertyTableInfoFetcher()
+			new PropertyTableInfoFetcher( $this->propertyTypeFinder )
 		);
 	}
 
 	public function testGetPropertyTableDefinitions() {
 
-		$instance = new PropertyTableInfoFetcher();
+		$instance = new PropertyTableInfoFetcher(
+			$this->propertyTypeFinder
+		);
 
 		$this->assertInternalType(
 			'array',
@@ -44,7 +56,9 @@ class PropertyTableInfoFetcherTest extends \PHPUnit_Framework_TestCase {
 
 		$property = DIProperty::newFromUserLabel( $property );
 
-		$instance = new PropertyTableInfoFetcher();
+		$instance = new PropertyTableInfoFetcher(
+			$this->propertyTypeFinder
+		);
 
 		$instance->setCustomSpecialPropertyList(
 			array( '_MDAT', '_MEDIA', '_MIME' )
@@ -61,7 +75,9 @@ class PropertyTableInfoFetcherTest extends \PHPUnit_Framework_TestCase {
 	 */
 	public function testFindTableIdForDataItemTypeId( $diType, $expected ) {
 
-		$instance = new PropertyTableInfoFetcher();
+		$instance = new PropertyTableInfoFetcher(
+			$this->propertyTypeFinder
+		);
 
 		$instance->setCustomSpecialPropertyList(
 			array( '_MDAT', '_MEDIA', '_MIME' )
@@ -78,7 +94,9 @@ class PropertyTableInfoFetcherTest extends \PHPUnit_Framework_TestCase {
 	 */
 	public function testFindTableIdForDataTypeTypeId( $dataType, $expected ) {
 
-		$instance = new PropertyTableInfoFetcher();
+		$instance = new PropertyTableInfoFetcher(
+			$this->propertyTypeFinder
+		);
 
 		$instance->setCustomSpecialPropertyList(
 			array( '_MDAT', '_MEDIA', '_MIME' )


### PR DESCRIPTION
This PR is made in reference to: #

This PR addresses or contains:

- Simplify `$smwgFixedProperties` customizing where the type is now read from the property instead of having it declared as customizing which would create issues when the type on the property page and the `$smwgFixedProperties` setting are different from each other
- Table name is no longer the complete md5 hash instead `substr( base_convert( md5( $tableName ), 16, 32 ), 0, 12 )` is used to get a shorter ID 
- Property page now displays a message that any change to its type requires some admin activity

```
$GLOBALS['smwgFixedProperties'] = array(
	'Has fixed test'
);
```

![image](https://cloud.githubusercontent.com/assets/1245473/21577491/d8a94b00-cf5c-11e6-80f7-a633b0a93233.png)

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed
