### PR TITLE
Avoid OOM in Subobject, use hash to store multiple errors

### DIFF
--- a/includes/Subobject.php
+++ b/includes/Subobject.php
@@ -86,7 +86,14 @@ class Subobject {
 	 * @param array|string $error
 	 */
 	public function addError( $error ) {
-		$this->errors = array_merge( $this->errors, (array)$error );
+
+		if ( is_string( $error ) ) {
+			$error = array( md5( $error ) => $error );
+		}
+
+		// Preserve the keys, avoid using array_merge to avert a possible
+		// Fatal error: Allowed memory size of ... bytes exhausted ... Subobject.php on line 89
+		$this->errors += $error;
 	}
 
 	/**

--- a/includes/datavalues/SMW_DataValue.php
+++ b/includes/datavalues/SMW_DataValue.php
@@ -430,7 +430,7 @@ abstract class SMWDataValue {
 	 * @param integer|null $language
 	 */
 	public function addErrorMsg( $parameters, $type = null ) {
-		$this->mErrors[] = Message::encode( $parameters, $type );
+		$this->mErrors[Message::getHash( $parameters, $type )] = Message::encode( $parameters, $type );
 		$this->mHasErrors = true;
 	}
 

--- a/tests/phpunit/Unit/DataValues/ReferenceValueTest.php
+++ b/tests/phpunit/Unit/DataValues/ReferenceValueTest.php
@@ -165,9 +165,9 @@ class ReferenceValueTest extends \PHPUnit_Framework_TestCase {
 			$instance->getDataItem()
 		);
 
-		$this->assertEquals(
-			array( '[2,"smw-datavalue-wikipage-invalid-title","<>Foo"]' ),
-			$instance->getErrors()
+		$this->assertContains(
+			"smw-datavalue-wikipage-invalid-title",
+			implode( ' ', $instance->getErrors() )
 		);
 	}
 

--- a/tests/phpunit/includes/DataValues/RecordValueTest.php
+++ b/tests/phpunit/includes/DataValues/RecordValueTest.php
@@ -165,9 +165,9 @@ class RecordValueTest extends \PHPUnit_Framework_TestCase {
 			$instance->getDataItem()
 		);
 
-		$this->assertEquals(
-			array( '[2,"smw-datavalue-wikipage-invalid-title","<>Foo"]' ),
-			$instance->getErrors()
+		$this->assertContains(
+			"smw-datavalue-wikipage-invalid-title",
+			implode( ' ', $instance->getErrors() )
 		);
 	}
 

--- a/tests/phpunit/includes/SubobjectTest.php
+++ b/tests/phpunit/includes/SubobjectTest.php
@@ -199,6 +199,23 @@ class SubobjectTest extends \PHPUnit_Framework_TestCase {
 	}
 
 	/**
+	 * @dataProvider errorProvider
+	 */
+	public function testErrorHandlingOnErrors( $errors, $expected ) {
+
+		$instance = new Subobject( Title::newFromText( __METHOD__ ) );
+
+		foreach ( $errors as $error ) {
+			$instance->addError( $error );
+		}
+
+		$this->assertCount(
+			$expected,
+			$instance->getErrors()
+		);
+	}
+
+	/**
 	 * @dataProvider getDataProvider
 	 */
 	public function testGetContainer( array $parameters ) {
@@ -213,9 +230,6 @@ class SubobjectTest extends \PHPUnit_Framework_TestCase {
 		);
 	}
 
-	/**
-	 * @return array
-	 */
 	public function getDataProvider() {
 
 		$provider = array();
@@ -372,6 +386,49 @@ class SubobjectTest extends \PHPUnit_Framework_TestCase {
 		$instance->setEmptyContainerForId( $id );
 
 		return $instance;
+	}
+
+	public function errorProvider() {
+
+		$provider = array();
+
+		#0
+		$provider[] = array(
+			array(
+				'Foo',
+				'Foo'
+			),
+			1
+		);
+
+		#1
+		$provider[] = array(
+			array(
+				'Foo',
+				'Bar'
+			),
+			2
+		);
+
+		#2
+		$provider[] = array(
+			array(
+				array( 'Foo' => 'Bar' ),
+				array( 'Foo' => 'Bar' ),
+			),
+			1
+		);
+
+		#3
+		$provider[] = array(
+			array(
+				array( 'Foo' => 'Bar' ),
+				array( 'Bar' => 'Foo' ),
+			),
+			2
+		);
+
+		return $provider;
 	}
 
 }


### PR DESCRIPTION
This PR is made in reference to: #

This PR addresses or contains:

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed
