### PR TITLE
FTS to retain second `~` operator

### DIFF
--- a/src/SQLStore/QueryEngine/DescriptionInterpreters/ValueDescriptionInterpreter.php
+++ b/src/SQLStore/QueryEngine/DescriptionInterpreters/ValueDescriptionInterpreter.php
@@ -131,7 +131,7 @@ class ValueDescriptionInterpreter implements DescriptionInterpreter {
 		// If a remaining ~ is present then the user searched with a ~~ string
 		// where the Comparator already matched/removed the first one
 		if ( substr( $value, 0, 1 ) === '~' ) {
-			$value = str_replace( '~', '', $value );
+			$value = substr( $value, 1 );
 			$usesWidePromixity = true;
 		}
 

--- a/src/SQLStore/QueryEngine/Fulltext/TextSanitizer.php
+++ b/src/SQLStore/QueryEngine/Fulltext/TextSanitizer.php
@@ -96,7 +96,7 @@ class TextSanitizer {
 		// Those have special meaning when running a match search against
 		// the fulltext index (wildcard, phrase matching markers etc.)
 		if ( $isSearchTerm ) {
-			$exemptionList = array( '*', '"', '+', '-', '&', ',', '@' );
+			$exemptionList = array( '*', '"', '+', '-', '&', ',', '@', '~' );
 		}
 
 		$sanitizer = $this->sanitizerFactory->newSanitizer( $text );
@@ -139,8 +139,8 @@ class TextSanitizer {
 
 		// Remove possible spaces added by the tokenizer
 		$text = str_replace(
-			array( ' *', '* ', ' "', '" ', '+ ', '- ', '@ ' ),
-			array( '*', '*', '"', '"', ' +', ' -', '@' ),
+			array( ' *', '* ', ' "', '" ', '+ ', '- ', '@ ', '~ ', '*+', '*-', '*~' ),
+			array( '*', '*', '"', '"', '+', '-', '@', '~' ,'* +', '* -', '* ~' ),
 			$text
 		);
 

--- a/tests/phpunit/Unit/SQLStore/QueryEngine/Fulltext/TextSanitizerTest.php
+++ b/tests/phpunit/Unit/SQLStore/QueryEngine/Fulltext/TextSanitizerTest.php
@@ -110,8 +110,27 @@ class TextSanitizerTest extends \PHPUnit_Framework_TestCase {
 			'*foo*'
 		);
 
+		$provider[] = array(
+			'*foo* bar',
+			'*foo*bar'
+		);
+
+		$provider[] = array(
+			'+foo*, *bar',
+			'+foo*,*bar'
+		);
+
+		$provider[] = array(
+			'+foo* -bar',
+			'+foo* -bar'
+		);
+
+		$provider[] = array(
+			'+foo* ~ bar',
+			'+foo* ~bar'
+		);
+
 		return $provider;
 	}
-
 
 }


### PR DESCRIPTION
This PR is made in reference to: #1481, #1762

This PR addresses or contains:

- Retain `~` as possible second operator as it has extra meaning in MySQL [0] "... causing the word's contribution to the row's relevance to be negative ... "

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed

[0] http://dev.mysql.com/doc/refman/5.7/en/fulltext-boolean.html
