### PR TITLE
RepositoryConnection to expose RepositoryClient, refs 1620

### DIFF
--- a/src/SPARQLStore/RepositoryClient.php
+++ b/src/SPARQLStore/RepositoryClient.php
@@ -72,7 +72,7 @@ class RepositoryClient {
 	/**
 	 * @since 2.2
 	 *
-	 * @return string
+	 * @return string|false
 	 */
 	public function getQueryEndpoint() {
 		return $this->queryEndpoint;

--- a/src/SPARQLStore/RepositoryConnection.php
+++ b/src/SPARQLStore/RepositoryConnection.php
@@ -12,6 +12,16 @@ namespace SMW\SPARQLStore;
 interface RepositoryConnection {
 
 	/**
+	 * The function returns connection details required for establishing an active
+	 * repository connection.
+	 *
+	 * @since 2.5
+	 *
+	 * @return RepositoryClient
+	 */
+	public function getRepositoryClient();
+
+	/**
 	 * The function declares the standard namespaces wiki, swivt, rdf, owl,
 	 * rdfs, property, xsd, so these do not have to be included in
 	 * $extraNamespaces.

--- a/src/SPARQLStore/RepositoryConnectors/GenericHttpRepositoryConnector.php
+++ b/src/SPARQLStore/RepositoryConnectors/GenericHttpRepositoryConnector.php
@@ -76,6 +76,15 @@ class GenericHttpRepositoryConnector implements RepositoryConnection {
 	}
 
 	/**
+	 * @since 2.5
+	 *
+	 * @return RepositoryClient
+	 */
+	public function getRepositoryClient() {
+		return $this->repositoryClient;
+	}
+
+	/**
 	 * Get the URI of the default graph that this database connector is
 	 * using, or the empty string if none is used (no graph related
 	 * statements in queries/updates).

--- a/src/SPARQLStore/SPARQLStore.php
+++ b/src/SPARQLStore/SPARQLStore.php
@@ -61,7 +61,7 @@ class SPARQLStore extends Store {
 		$this->baseStore = $baseStore;
 
 		if ( $this->baseStore === null ) {
-			$this->baseStore = $this->factory->newBaseStore( self::$baseStoreClass );
+			$this->baseStore = $this->factory->getBaseStore( self::$baseStoreClass );
 		}
 	}
 
@@ -273,6 +273,11 @@ class SPARQLStore extends Store {
 	 */
 	public function getQueryResult( Query $query ) {
 
+		// Use a fallback QueryEngine in case the QueryEndpoint is inaccessible
+		if ( !$this->isEnabledQueryEndpoint() ) {
+			return $this->baseStore->getQueryResult( $query );
+		}
+
 		$result = null;
 		$start = microtime( true );
 
@@ -432,6 +437,10 @@ class SPARQLStore extends Store {
 		}
 
 		return parent::getConnection( $connectionTypeId );
+	}
+
+	private function isEnabledQueryEndpoint() {
+		return $this->getConnection( 'sparql' )->getRepositoryClient()->getQueryEndpoint() !== false;
 	}
 
 }

--- a/src/SPARQLStore/SPARQLStoreFactory.php
+++ b/src/SPARQLStore/SPARQLStoreFactory.php
@@ -44,10 +44,12 @@ class SPARQLStoreFactory {
 	/**
 	 * @since 2.2
 	 *
+	 * @param string $storeClass
+	 *
 	 * @return Store
 	 */
-	public function newBaseStore( $storeId ) {
-		return StoreFactory::getStore( $storeId );
+	public function getBaseStore( $storeClass ) {
+		return StoreFactory::getStore( $storeClass );
 	}
 
 	/**

--- a/tests/phpunit/Unit/SPARQLStore/SPARQLStoreFactoryTest.php
+++ b/tests/phpunit/Unit/SPARQLStore/SPARQLStoreFactoryTest.php
@@ -47,7 +47,7 @@ class SPARQLStoreFactoryTest extends \PHPUnit_Framework_TestCase {
 
 		$this->assertInstanceOf(
 			'\SMWSQLStore3',
-			$instance->newBaseStore( 'SMWSQLStore3' )
+			$instance->getBaseStore( 'SMWSQLStore3' )
 		);
 	}
 


### PR DESCRIPTION
This PR is made in reference to: #1620 

This PR addresses or contains:

- Allows the `smwgSparqlQueryEndpoint` to be `false` and in those cases will the query request redirected to the `SQLStore` query engine

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed
