### PR TITLE
Add UniquenessConstraintPropertyValueResourceBuilder, refs 1463, 1780

### DIFF
--- a/i18n/extra/en.json
+++ b/i18n/extra/en.json
@@ -86,7 +86,7 @@
 		"_DTITLE": "Display title of",
 		"_PVUC": "Has uniqueness constraint",
 		"_PEID": "External identifier",
-		"_PEFU": "External formatter uri",
+		"_PEFU": "External formatter URI",
 		"_PPLB": "Has preferred property label"
 	},
 	"propertyAliases": {
@@ -126,8 +126,12 @@
 		"Has allows pattern": "_PVAP",
 		"Has display title of": "_DTITLE",
 		"Has uniqueness constraint": "_PVUC",
+		"Uniqueness constraint": "_PVUC",
+		"IsFunctionalProperty": "_PVUC",
 		"External identifier": "_PEID",
+		"External formatter URI": "_PEFU",
 		"External formatter uri": "_PEFU",
+		"External formatter URL": "_PEFU",
 		"Preferred property label": "_PPLB"
 	},
 	"namespaces":{

--- a/src/Exporter/ResourceBuilders/DispatchingResourceBuilder.php
+++ b/src/Exporter/ResourceBuilders/DispatchingResourceBuilder.php
@@ -100,6 +100,8 @@ class DispatchingResourceBuilder implements ResourceBuilder {
 
 	private function initResourceBuilders() {
 
+		$this->addResourceBuilder( new UniquenessConstraintPropertyValueResourceBuilder() );
+
 		$this->addResourceBuilder( new PropertyDescriptionValueResourceBuilder() );
 		$this->addResourceBuilder( new PreferredPropertyLabelResourceBuilder() );
 

--- a/src/Exporter/ResourceBuilders/UniquenessConstraintPropertyValueResourceBuilder.php
+++ b/src/Exporter/ResourceBuilders/UniquenessConstraintPropertyValueResourceBuilder.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace SMW\Exporter\ResourceBuilders;
+
+use SMW\Exporter\ResourceBuilder;
+use SMW\DIProperty;
+use SMWExporter as Exporter;
+use SMW\DataValueFactory;
+use SMWDataItem as DataItem;
+use SMWExpData as ExpData;
+use SMWExpLiteral as ExpLiteral;
+
+/**
+ * @private
+ *
+ * @license GNU GPL v2+
+ * @since 2.5
+ *
+ * @author mwjames
+ */
+class UniquenessConstraintPropertyValueResourceBuilder extends PropertyValueResourceBuilder {
+
+	/**
+	 * @since 2.5
+	 *
+	 * {@inheritDoc}
+	 */
+	public function isResourceBuilderFor( DIProperty $property ) {
+		return $property->getKey() === '_PVUC';
+	}
+
+	/**
+	 * @since 2.5
+	 *
+	 * {@inheritDoc}
+	 */
+	public function addResourceValue( ExpData $expData, DIProperty $property, DataItem $dataItem ) {
+
+		parent::addResourceValue( $expData, $property, $dataItem );
+
+		// https://www.w3.org/TR/2004/REC-owl-ref-20040210/#FunctionalProperty-def
+		//
+		// "A functional property is a property that can have only one (unique)
+		// value y for each instance x ..."
+
+		$expData->addPropertyObjectValue(
+			$this->exporter->getSpecialNsResource( 'rdf', 'type' ),
+			$this->exporter->getSpecialNsResource( 'owl', 'FunctionalProperty' )
+		);
+	}
+
+}

--- a/tests/phpunit/Unit/Exporter/ResourceBuilders/UniquenessConstraintPropertyValueResourceBuilderTest.php
+++ b/tests/phpunit/Unit/Exporter/ResourceBuilders/UniquenessConstraintPropertyValueResourceBuilderTest.php
@@ -2,7 +2,7 @@
 
 namespace SMW\Tests\Exporter\ResourceBuilders;
 
-use SMW\Exporter\ResourceBuilders\PreferredPropertyLabelResourceBuilder;
+use SMW\Exporter\ResourceBuilders\UniquenessConstraintPropertyValueResourceBuilder;
 use SMW\DataItemFactory;
 use SMW\DataValueFactory;
 use SMW\Tests\TestEnvironment;
@@ -10,7 +10,7 @@ use SMWExpData as ExpData;
 use SMW\Exporter\Element\ExpNsResource;
 
 /**
- * @covers \SMW\Exporter\ResourceBuilders\PreferredPropertyLabelResourceBuilder
+ * @covers \SMW\Exporter\ResourceBuilders\UniquenessConstraintPropertyValueResourceBuilder
  * @group semantic-mediawiki
  *
  * @license GNU GPL v2+
@@ -18,7 +18,7 @@ use SMW\Exporter\Element\ExpNsResource;
  *
  * @author mwjames
  */
-class PreferredPropertyLabelResourceBuilderTest extends \PHPUnit_Framework_TestCase {
+class UniquenessConstraintPropertyValueResourceBuilderTest extends \PHPUnit_Framework_TestCase {
 
 	private $dataItemFactory;
 	private $dataValueFactory;
@@ -41,16 +41,16 @@ class PreferredPropertyLabelResourceBuilderTest extends \PHPUnit_Framework_TestC
 	public function testCanConstruct() {
 
 		$this->assertInstanceof(
-			PreferredPropertyLabelResourceBuilder::class,
-			new PreferredPropertyLabelResourceBuilder()
+			UniquenessConstraintPropertyValueResourceBuilder::class,
+			new UniquenessConstraintPropertyValueResourceBuilder()
 		);
 	}
 
-	public function testIsNotResourceBuilderForNonPreferredPropertyLabelProperty() {
+	public function testIsNotResourceBuilderForNonUniquenessConstraintProperty() {
 
 		$property = $this->dataItemFactory->newDIProperty( 'Foo' );
 
-		$instance = new PreferredPropertyLabelResourceBuilder();
+		$instance = new UniquenessConstraintPropertyValueResourceBuilder();
 
 		$this->assertFalse(
 			$instance->isResourceBuilderFor( $property )
@@ -59,23 +59,18 @@ class PreferredPropertyLabelResourceBuilderTest extends \PHPUnit_Framework_TestC
 
 	public function testAddResourceValueForValidProperty() {
 
-		$property = $this->dataItemFactory->newDIProperty( '_PPLB' );
-
-		$monolingualTextValue = $this->dataValueFactory->newDataValueByProperty(
-			$property,
-			'Bar@en'
-		);
+		$property = $this->dataItemFactory->newDIProperty( '_PVUC' );
 
 		$expData = new ExpData(
 			new ExpNsResource( 'Foobar', 'Bar', 'Mo', null )
 		);
 
-		$instance = new PreferredPropertyLabelResourceBuilder();
+		$instance = new UniquenessConstraintPropertyValueResourceBuilder();
 
 		$instance->addResourceValue(
 			$expData,
 			$property,
-			$monolingualTextValue->getDataItem()
+			$this->dataItemFactory->newDIBoolean( true )
 		);
 
 		$this->assertTrue(


### PR DESCRIPTION
This PR is made in reference to: #1463, #1780

This PR addresses or contains:

- Adds an extra RDF statement `owl:FunctionalProperty` [0] to the property in case the uniqueness constraint is maintained

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed

[0] https://www.w3.org/TR/2004/REC-owl-ref-20040210/#FunctionalProperty-def