### PR TITLE
Fix "Call to a member function getSubSemanticData() on array", refs 2177

### DIFF
--- a/includes/SemanticData.php
+++ b/includes/SemanticData.php
@@ -273,12 +273,24 @@ class SemanticData {
 	}
 
 	/**
-	 * Return the array of subSemanticData objects for this SemanticData
+	 * @see SubSemanticData::getSubSemanticData
 	 *
 	 * @since 1.8
-	 * @return SMWContainerSemanticData[] subobject => SMWContainerSemanticData
+	 *
+	 * @return ContainerSemanticData[]
 	 */
 	public function getSubSemanticData() {
+
+		// Remove the check in 3.0
+		$subSemanticData = $this->subSemanticData;
+
+		// Avoids an issue where the serialized array from a previous usage is
+		// returned from a __wakeup, where now a SubSemanticData (#2177) is expected.
+		if ( !$subSemanticData instanceof SubSemanticData ) {
+			$this->subSemanticData = new SubSemanticData( $this->mSubject, $this->mNoDuplicates );
+			$this->subSemanticData->copyDataFrom( $subSemanticData );
+		}
+
 		return $this->subSemanticData->getSubSemanticData();
 	}
 

--- a/src/DataModel/SubSemanticData.php
+++ b/src/DataModel/SubSemanticData.php
@@ -116,6 +116,18 @@ class SubSemanticData {
 	}
 
 	/**
+	 * This is used as contingency where the serialized SementicData still
+	 * has an array object reference.
+	 *
+	 * @since 2.5
+	 *
+	 * @return ContainerSemanticData[]
+	 */
+	public function copyDataFrom( array $subSemanticData ) {
+		$this->subSemanticData = $subSemanticData;
+	}
+
+	/**
 	 * Return the array of subSemanticData objects in form of
 	 * subobjectName => ContainerSemanticData
 	 *


### PR DESCRIPTION
This PR is made in reference to: #2177

This PR addresses or contains:

- Adds a contingency where an "old" serialized array would cause a "Fatal error: Call to a member function getSubSemanticData() on array in /var/www/htdocs/mw/02100/w/extensions/SemanticMediaWiki/includes/SemanticData.php on line 282"

This PR includes:
- [ ] Tests (unit/integration)
- [x] CI build passed
