### PR TITLE
Obfuscator to use &#x005B; instead of &#91;, refs 2153

### DIFF
--- a/includes/Highlighter.php
+++ b/includes/Highlighter.php
@@ -176,7 +176,7 @@ class Highlighter {
 				'data-content' => isset( $this->options['data-content'] ) ? $this->options['data-content'] : null,
 				'data-state'   => $this->options['state'],
 				'data-title'   => Message::get( $this->options['title'], Message::TEXT, $language ),
-				'title'        => strip_tags( htmlspecialchars_decode( str_replace( "[", "&#x005B;", $this->options['content'] ) ) )
+				'title'        => strip_tags( htmlspecialchars_decode( str_replace( "[", "&#91;", $this->options['content'] ) ) )
 			), Html::rawElement(
 					'span',
 					array(

--- a/includes/query/SMW_Query.php
+++ b/includes/query/SMW_Query.php
@@ -370,7 +370,7 @@ class SMWQuery implements QueryContext {
 			if ( count( $log ) > 0 ) {
 				$this->errors[] = Message::encode( array(
 					'smw_querytoolarge',
-					str_replace( '[', '&#x005B;', implode( ', ', $log ) ),
+					str_replace( '[', '&#91;', implode( ', ', $log ) ),
 					count( $log )
 				) );
 			}

--- a/src/DataValues/ValueFormatters/CodeStringValueFormatter.php
+++ b/src/DataValues/ValueFormatters/CodeStringValueFormatter.php
@@ -42,7 +42,7 @@ class CodeStringValueFormatter extends StringValueFormatter {
 			// This disables all active wiki and HTML markup:
 			$result = str_replace(
 				array( '<', '>', ' ', '[', '{', '=', "'", ':', "\n" ),
-				array( '&lt;', '&gt;', '&#160;', '&#x005B;', '&#x007B;', '&#x003D;', '&#x0027;', '&#58;', "<br />" ),
+				array( '&lt;', '&gt;', '&#160;', '&#91;', '&#x007B;', '&#x003D;', '&#x0027;', '&#58;', "<br />" ),
 				$text
 			);
 		}

--- a/src/Parser/Obfuscator.php
+++ b/src/Parser/Obfuscator.php
@@ -22,12 +22,16 @@ class Obfuscator {
 	 */
 	public static function obfuscateLinks( $text, InTextAnnotationParser $parser ) {
 
+		// Use &#x005B; instead of &#91; to distinguish it from the MW's Sanitizer
+		// who uses the same decode sequence and avoid issues when removing links
+		// obfuscation
+
 		// Filter simple [ ... ] from [[ ... ]] links
 		// Ensure to find the correct start and end in case of
 		// [[Foo::[[Bar]]]] or [[Foo::[http://example.org/foo]]]
 		$text = str_replace(
-			array( '[', ']', '&#91;&#91;', '&#93;&#93;&#93;&#93;', '&#93;&#93;&#93;', '&#93;&#93;' ),
-			array( '&#91;', '&#93;', '[[', ']]]]', '&#93;]]', ']]' ),
+			array( '[', ']', '&#x005B;&#x005B;', '&#93;&#93;&#93;&#93;', '&#93;&#93;&#93;', '&#93;&#93;' ),
+			array( '&#x005B;', '&#93;', '[[', ']]]]', '&#93;]]', ']]' ),
 			$text
 		);
 
@@ -43,7 +47,7 @@ class Obfuscator {
 	 */
 	public static function removeLinkObfuscation( $text ) {
 		return str_replace(
-			array( '&#91;', '&#93;', '&#124;' ),
+			array( '&#x005B;', '&#93;', '&#124;' ),
 			array( '[', ']', '|' ),
 			$text
 		);
@@ -59,7 +63,7 @@ class Obfuscator {
 	public static function encodeLinks( $text ) {
 		return str_replace(
 			array( '[', ']', '|' ),
-			array( '&#91;', '&#93;', '&#124;' ),
+			array( '&#x005B;', '&#93;', '&#124;' ),
 			$text
 		);
 	}
@@ -86,7 +90,7 @@ class Obfuscator {
 		return preg_replace_callback(
 			InTextAnnotationParser::getRegexpPattern( false ),
 			function( array $matches ) {
-				return str_replace( '[', '&#x005B;', $matches[0] );
+				return str_replace( '[', '&#91;', $matches[0] );
 			},
 			self::decodeSquareBracket( $text )
 		);
@@ -176,7 +180,7 @@ class Obfuscator {
 				// [[Text::Some [[abc]]
 				// Forget about about the first position
 				$replace = str_replace( $match, self::encodeLinks( $match ), $match );
-				$replace = substr_replace( $replace, '[[', 0, 10 );
+				$replace = substr_replace( $replace, '[[', 0, 16 );
 				$text = str_replace( $match, $replace, $text );
 			} elseif ( $openNum === $closeNum && $markerNum == 1 ) {
 				// [[Foo::Bar]] annotation therefore run a pattern match and

--- a/src/ParserFunctions/ConceptParserFunction.php
+++ b/src/ParserFunctions/ConceptParserFunction.php
@@ -116,7 +116,7 @@ class ConceptParserFunction {
 			Html::rawElement( 'span', array( 'class' => 'smwrdflink' ), $this->getRdfLink( $title )->getWikiText() ) .
 			Html::element( 'br', array() ) .
 			Html::element( 'p', array( 'class' => 'concept-documenation' ), $documentation ? $documentation : '' ) .
-			Html::rawElement( 'pre', array(), str_replace( '[', '&#x005B;', $queryString ) ) .
+			Html::rawElement( 'pre', array(), str_replace( '[', '&#91;', $queryString ) ) .
 			Html::element( 'br', array() )
 		);
 	}

--- a/src/Query/DebugOutputFormatter.php
+++ b/src/Query/DebugOutputFormatter.php
@@ -31,7 +31,7 @@ class DebugOutputFormatter {
 
 		if ( $query instanceof Query ) {
 			$preEntries = array();
-			$preEntries['ASK Query'] = '<div class="smwpre">' . str_replace( '[', '&#x005B;', $query->getDescription()->getQueryString() ) . '</div>';
+			$preEntries['ASK Query'] = '<div class="smwpre">' . str_replace( '[', '&#91;', $query->getDescription()->getQueryString() ) . '</div>';
 			$entries = array_merge( $preEntries, $entries );
 			$entries['Query Metrics'] = 'Query-Size:' . $query->getDescription()->getSize() . '<br />' .
 						'Query-Depth:' . $query->getDescription()->getDepth();
@@ -147,7 +147,7 @@ class DebugOutputFormatter {
 				' '
 			),
 			array(
-				'&#x005B;',
+				'&#91;',
 				'&#x003A;',
 				'&#x0020;'
 			),

--- a/src/SQLStore/QueryEngine/Fulltext/TextSanitizer.php
+++ b/src/SQLStore/QueryEngine/Fulltext/TextSanitizer.php
@@ -105,8 +105,8 @@ class TextSanitizer {
 		$sanitizer->convertDoubleWidth();
 
 		$sanitizer->replace(
-			array( 'http://', 'https://', 'mailto:', '%2A', '_', '&#x005B;', "\n", "\t" ),
-			array( '', '', '', '*', ' ', '[', "", "" )
+			array( 'http://', 'https://', 'mailto:', '%2A', '_', '&#x005B;', '&#91;', "\n", "\t" ),
+			array( '', '', '', '*', ' ', '[', '[', "", "" )
 		);
 
 		$language = $this->predictLanguage( $text );

--- a/tests/phpunit/Integration/JSONScript/TestCases/f-0001.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/f-0001.json
@@ -40,7 +40,7 @@
 			"subject": "Example/0001/1",
 			"assert-output": {
 				"to-contain": [
-					"&#x5b;&#x5b;Has page::Foo]] &#x5b;&#x5b;Has page::42]]",
+					"&#91;&#91;Has page::Foo]] &#91;&#91;Has page::42]]",
 					"Query-Size:4",
 					"Query-Depth:1",
 					"None"
@@ -53,7 +53,7 @@
 			"subject": "Example/F0001/Q.1",
 			"assert-output": {
 				"to-contain": [
-					"<div class=\"smwpre\">&#x5b;&#x5b;Has number::3.555567]]</div>"
+					"<div class=\"smwpre\">&#91;&#91;Has number::3.555567]]</div>"
 				]
 			}
 		}

--- a/tests/phpunit/Integration/JSONScript/TestCases/p-0212.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/p-0212.json
@@ -35,7 +35,7 @@
 			"subject": "Example/P0212/1",
 			"assert-output": {
 				"to-contain": [
-					"<span class=\"smw-highlighter\" data-type=\"1\" data-state=\"inline\" data-title=\"Property\" title=\"Some text with a link to &amp;#x005B;http://example.org/ foo] and stripped `li` in title element\">",
+					"<span class=\"smw-highlighter\" data-type=\"1\" data-state=\"inline\" data-title=\"Property\" title=\"Some text with a link to &amp;#91;http://example.org/ foo] and stripped `li` in title element\">",
 					"<div class=\"smwttcontent\">Some text with a link to <a rel=\"nofollow\" class=\"external text\" href=\"http://example.org/\">foo</a> and <li>stripped `li` in title element</li></div>",
 					"title=\"Property:Has date\">Has date</a>"
 				]
@@ -47,7 +47,7 @@
 			"subject": "Example/P0212/2",
 			"assert-output": {
 				"to-contain": [
-					"<span class=\"smw-highlighter\" data-type=\"1\" data-state=\"inline\" data-title=\"Property\" title=\"Some text with a link to &amp;#x005B;http://example.org/ foo] and stripped `li` in title element\">",
+					"<span class=\"smw-highlighter\" data-type=\"1\" data-state=\"inline\" data-title=\"Property\" title=\"Some text with a link to &amp;#91;http://example.org/ foo] and stripped `li` in title element\">",
 					"<div class=\"smwttcontent\">Some text with a link to <a rel=\"nofollow\" class=\"external text\" href=\"http://example.org/\">foo</a> and <li>stripped `li` in title element</li></div>",
 					"title=\"Property:Has date\">With extra caption</a>"
 				]

--- a/tests/phpunit/Integration/JSONScript/TestCases/p-0501.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/p-0501.json
@@ -15,10 +15,10 @@
 			"namespace": "SMW_NS_CONCEPT",
 			"assert-output": {
 				"to-contain": [
-					"<p class=\"concept-documenation\">Modification date</p><pre>&#x5b;&#x5b;Modification date::+]]</pre>"
+					"<p class=\"concept-documenation\">Modification date</p><pre>&#91;&#91;Modification date::+]]</pre>"
 				],
 				"not-contain": [
-					"<p class=\"concept-documenation\">Modification date</p><pre>&#x5b;&#x5b;Fecha de modificación::+]]</pre>"
+					"<p class=\"concept-documenation\">Modification date</p><pre>&#91;&#91;Fecha de modificación::+]]</pre>"
 				]
 			}
 		}

--- a/tests/phpunit/Unit/InTextAnnotationParserTest.php
+++ b/tests/phpunit/Unit/InTextAnnotationParserTest.php
@@ -283,7 +283,7 @@ class InTextAnnotationParserTest extends \PHPUnit_Framework_TestCase {
 		$provider[] = array(
 			'Suspendisse [[Bar::tincidunt semper|abc]] facilisi',
 			'Suspendisse abc facilisi',
-			'Suspendisse &#x005B;&#x005B;Bar::tincidunt semper|abc]] facilisi'
+			'Suspendisse &#91;&#91;Bar::tincidunt semper|abc]] facilisi'
 		);
 
 		return $provider;
@@ -578,12 +578,12 @@ class InTextAnnotationParserTest extends \PHPUnit_Framework_TestCase {
 				'smwgInlineErrors'  => true,
 				'smwgEnabledInTextAnnotationParserStrictMode' => true
 			),
-			'[[Text::Bar [http:://example.org/Foo]]] [[Code::Foo[1] Foobar]]',
+			'[[Text::Bar [http://example.org/Foo Foo]]] [[Code::Foo[1] Foobar]]',
 			array(
-				'resultText'     => 'Bar [http:://example.org/Foo] <div class="smwpre">Foo&#x005B;1]&#160;Foobar</div>',
+				'resultText'     => 'Bar [http://example.org/Foo Foo] <div class="smwpre">Foo&#91;1]&#160;Foobar</div>',
 				'propertyCount'  => 2,
 				'propertyLabels' => array( 'Text', 'Code' ),
-				'propertyValues' => array( 'Bar [http:://example.org/Foo]', 'Foo[1] Foobar' )
+				'propertyValues' => array( 'Bar [http://example.org/Foo Foo]', 'Foo[1] Foobar' )
 			)
 		);
 

--- a/tests/phpunit/Unit/Parser/ObfuscatorTest.php
+++ b/tests/phpunit/Unit/Parser/ObfuscatorTest.php
@@ -66,13 +66,13 @@ class ObfuscatorTest extends \PHPUnit_Framework_TestCase {
 		$provider[] = array(
 			'Suspendisse [[Bar::tincidunt semper|abc]] facilisi',
 			'Suspendisse abc facilisi',
-			'Suspendisse &#x005B;&#x005B;Bar::tincidunt semper|abc]] facilisi'
+			'Suspendisse &#91;&#91;Bar::tincidunt semper|abc]] facilisi'
 		);
 
 		$provider[] = array(
 			'Suspendisse [[Bar::tincidunt semper]] facilisi',
 			'Suspendisse tincidunt semper facilisi',
-			'Suspendisse &#x005B;&#x005B;Bar::tincidunt semper]] facilisi'
+			'Suspendisse &#91;&#91;Bar::tincidunt semper]] facilisi'
 		);
 
 		$provider[] = array(
@@ -84,13 +84,13 @@ class ObfuscatorTest extends \PHPUnit_Framework_TestCase {
 		$provider[] = array(
 			'[[Foo::Foobar::テスト]] [[Bar:::ABC|DEF]] [[Foo:::0049 30 12345678/::Foo]]',
 			'Foobar::テスト DEF :0049 30 12345678/::Foo',
-			'&#x005B;&#x005B;Foo::Foobar::テスト]] &#x005B;&#x005B;Bar:::ABC|DEF]] &#x005B;&#x005B;Foo:::0049 30 12345678/::Foo]]'
+			'&#91;&#91;Foo::Foobar::テスト]] &#91;&#91;Bar:::ABC|DEF]] &#91;&#91;Foo:::0049 30 12345678/::Foo]]'
 		);
 
 		$provider[] = array(
 			'%5B%5BFoo%20Bar::foobaz%5D%5D',
 			'foobaz',
-			'&#x005B;&#x005B;Foo%20Bar::foobaz]]'
+			'&#91;&#91;Foo%20Bar::foobaz]]'
 		);
 
 		$provider[] = array(
@@ -103,19 +103,19 @@ class ObfuscatorTest extends \PHPUnit_Framework_TestCase {
 		$provider[] = array(
 			'[[Foo|Bar::Foobar]] [[File:Example.png|alt=Bar::Foobar|Caption]] [[File:Example.png|Bar::Foobar|link=Foo]]',
 			'[[Foo|Bar::Foobar]] [[File:Example.png|alt=Bar::Foobar|Caption]] [[File:Example.png|Bar::Foobar|link=Foo]]',
-			'&#x005B;&#x005B;Foo|Bar::Foobar]] &#x005B;&#x005B;File:Example.png|alt=Bar::Foobar|Caption]] &#x005B;&#x005B;File:Example.png|Bar::Foobar|link=Foo]]'
+			'&#91;&#91;Foo|Bar::Foobar]] &#91;&#91;File:Example.png|alt=Bar::Foobar|Caption]] &#91;&#91;File:Example.png|Bar::Foobar|link=Foo]]'
 		);
 
 		$provider[] = array(
 			'[[Foo::@@@]] [[Bar::@@@|123]]',
 			' 123',
-			'&#x005B;&#x005B;Foo::@@@]] &#x005B;&#x005B;Bar::@@@|123]]'
+			'&#91;&#91;Foo::@@@]] &#91;&#91;Bar::@@@|123]]'
 		);
 
 		$provider[] = array(
 			'Suspendisse [[SMW::off]][[Bar::tincidunt semper|abc]] facilisi[[SMW::on]] [[Bar:::ABC|DEF]]',
 			'Suspendisse abc facilisi DEF',
-			'Suspendisse &#x005B;&#x005B;SMW::off]]&#x005B;&#x005B;Bar::tincidunt semper|abc]] facilisi&#x005B;&#x005B;SMW::on]] &#x005B;&#x005B;Bar:::ABC|DEF]]'
+			'Suspendisse &#91;&#91;SMW::off]]&#91;&#91;Bar::tincidunt semper|abc]] facilisi&#91;&#91;SMW::on]] &#91;&#91;Bar:::ABC|DEF]]'
 		);
 
 		return $provider;
@@ -132,17 +132,17 @@ class ObfuscatorTest extends \PHPUnit_Framework_TestCase {
 
 		$provider[] = array(
 			'[[Foo]]',
-			'&#91;&#91;Foo&#93;&#93;'
+			'&#x005B;&#x005B;Foo&#93;&#93;'
 		);
 
 		$provider[] = array(
 			'[[Foo|Bar]]',
-			'&#91;&#91;Foo&#124;Bar&#93;&#93;'
+			'&#x005B;&#x005B;Foo&#124;Bar&#93;&#93;'
 		);
 
 		$provider[] = array(
 			'[[Foo::[[Bar]]]]',
-			'[[Foo::&#91;&#91;Bar&#93;&#93;]]'
+			'[[Foo::&#x005B;&#x005B;Bar&#93;&#93;]]'
 		);
 
 		return $provider;


### PR DESCRIPTION
This PR is made in reference to: #2153 


This PR addresses or contains:
- MW's `Sanitizer` uses `&#91` as internal decoding for `[` therefore use `&#x005B;` to distinguish between what was added by the `Sanitizer` and what comes from the internal `Obfuscator`

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed
