### PR TITLE
Run secondary updates onTransactionIdle (MW 1.29+)

### DIFF
--- a/includes/storage/SMW_Store.php
+++ b/includes/storage/SMW_Store.php
@@ -229,6 +229,7 @@ abstract class Store implements QueryEngine {
 		}
 
 		$pageUpdater->addPage( $subject->getTitle() );
+		$pageUpdater->waitOnTransactionIdle();
 
 		$pageUpdater->doPurgeParserCache();
 		$pageUpdater->doPurgeHtmlCache();

--- a/includes/storage/SQLStore/SMW_SQLStore3.php
+++ b/includes/storage/SQLStore/SMW_SQLStore3.php
@@ -294,6 +294,7 @@ class SMWSQLStore3 extends SMWStore {
 
 		$deferredCallableUpdate = $this->factory->newDeferredCallableCachedListLookupUpdate();
 		$deferredCallableUpdate->setOrigin( __METHOD__ );
+		$deferredCallableUpdate->waitOnTransactionIdle();
 		$deferredCallableUpdate->pushUpdate();
 	}
 

--- a/src/ApplicationFactory.php
+++ b/src/ApplicationFactory.php
@@ -231,7 +231,8 @@ class ApplicationFactory {
 	public function newPageUpdater() {
 
 		$pageUpdater = $this->callbackLoader->create(
-			'PageUpdater'
+			'PageUpdater',
+			$this->getStore()->getConnection( 'mw.db' )
 		);
 
 		$pageUpdater->setLogger(
@@ -416,9 +417,12 @@ class ApplicationFactory {
 	 */
 	public function newDeferredCallableUpdate( Closure $callback ) {
 
+		$store = $this->getStore();
+
 		$deferredCallableUpdate = $this->callbackLoader->create(
 			'DeferredCallableUpdate',
-			$callback
+			$callback,
+			$store->getConnection( 'mw.db' )
 		);
 
 		$deferredCallableUpdate->enabledDeferredUpdate(
@@ -427,6 +431,10 @@ class ApplicationFactory {
 
 		$deferredCallableUpdate->setLogger(
 			$this->getMediaWikiLogger()
+		);
+
+		$deferredCallableUpdate->isCommandLineMode(
+			$store->getOptions()->has( 'isCommandLineMode' ) ? $store->getOptions()->get( 'isCommandLineMode' ) : $GLOBALS['wgCommandLineMode']
 		);
 
 		return $deferredCallableUpdate;

--- a/src/MediaWiki/Jobs/EntityIdDisposerJob.php
+++ b/src/MediaWiki/Jobs/EntityIdDisposerJob.php
@@ -64,6 +64,9 @@ class EntityIdDisposerJob extends JobBase {
 	 */
 	public function run() {
 
+		// MW 1.29+ Avoid transaction collisions during Job execution
+		$this->propertyTableIdReferenceDisposer->waitOnTransactionIdle();
+
 		if ( $this->hasParameter( 'id' ) ) {
 			$this->dispose( $this->getParameter( 'id' ) );
 		} else {

--- a/src/MediaWiki/Jobs/ParserCachePurgeJob.php
+++ b/src/MediaWiki/Jobs/ParserCachePurgeJob.php
@@ -78,6 +78,7 @@ class ParserCachePurgeJob extends JobBase {
 		}
 
 		$this->pageUpdater->addPage( $this->getTitle() );
+		$this->pageUpdater->waitOnTransactionIdle();
 		$this->pageUpdater->doPurgeParserCache();
 
 		Hooks::run( 'SMW::Job::AfterParserCachePurgeComplete', array( $this ) );

--- a/src/MediaWiki/Jobs/UpdateJob.php
+++ b/src/MediaWiki/Jobs/UpdateJob.php
@@ -95,6 +95,7 @@ class UpdateJob extends JobBase {
 		if ( $lastModified === \WikiPage::factory( $title )->getTimestamp() ) {
 			$pageUpdater = $this->applicationFactory->newPageUpdater();
 			$pageUpdater->addPage( $title );
+			$pageUpdater->waitOnTransactionIdle();
 			$pageUpdater->doPurgeParserCache();
 			return true;
 		}

--- a/src/SQLStore/EntityRebuildDispatcher.php
+++ b/src/SQLStore/EntityRebuildDispatcher.php
@@ -240,6 +240,10 @@ class EntityRebuildDispatcher {
 		// update by internal SMW id --> make sure we get all objects in SMW
 		$db = $this->store->getConnection( 'mw.db' );
 
+		// MW 1.29+ "Exception thrown with an uncommited database transaction ...
+		// MWCallableUpdate::doUpdate: transaction round 'SMW\MediaWiki\Jobs\RefreshJob::run' already started"
+		$this->propertyTableIdReferenceDisposer->waitOnTransactionIdle();
+
 		$res = $db->select(
 			\SMWSql3SmwIds::TABLE_NAME,
 			array( 'smw_id', 'smw_title', 'smw_namespace', 'smw_iw', 'smw_subobject', 'smw_sortkey', 'smw_proptable_hash' ),

--- a/src/SQLStore/SQLStoreFactory.php
+++ b/src/SQLStore/SQLStoreFactory.php
@@ -258,8 +258,6 @@ class SQLStoreFactory {
 		$factory = $this;
 
 		$deferredCallableUpdate = ApplicationFactory::getInstance()->newDeferredCallableUpdate( function() use( $factory ) {
-			wfDebugLog( 'smw', 'DeferredCachedListLookupUpdate' );
-
 			$factory->newPropertyUsageCachedListLookup()->deleteCache();
 			$factory->newUnusedPropertyCachedListLookup()->deleteCache();
 			$factory->newUndeclaredPropertyCachedListLookup()->deleteCache();

--- a/src/SharedCallbackContainer.php
+++ b/src/SharedCallbackContainer.php
@@ -99,9 +99,9 @@ class SharedCallbackContainer implements CallbackContainer {
 			return new PageCreator();
 		} );
 
-		$callbackLoader->registerCallback( 'PageUpdater', function() use ( $callbackLoader ) {
+		$callbackLoader->registerCallback( 'PageUpdater', function( Database $connection = null ) use ( $callbackLoader ) {
 			$callbackLoader->registerExpectedReturnType( 'PageUpdater', '\SMW\MediaWiki\PageUpdater' );
-			return new PageUpdater();
+			return new PageUpdater( $connection );
 		} );
 
 		$callbackLoader->registerCallback( 'JobQueueLookup', function( Database $connection ) use ( $callbackLoader ) {
@@ -128,8 +128,8 @@ class SharedCallbackContainer implements CallbackContainer {
 
 		$callbackLoader->registerExpectedReturnType( 'DeferredCallableUpdate', '\SMW\DeferredCallableUpdate' );
 
-		$callbackLoader->registerCallback( 'DeferredCallableUpdate', function( \Closure $callback ) {
-			return new DeferredCallableUpdate( $callback );
+		$callbackLoader->registerCallback( 'DeferredCallableUpdate', function( \Closure $callback, Database $connection = null ) {
+			return new DeferredCallableUpdate( $callback, $connection );
 		} );
 
 		/**

--- a/tests/phpunit/Integration/MediaWiki/Import/TimeDataTypeTest.php
+++ b/tests/phpunit/Integration/MediaWiki/Import/TimeDataTypeTest.php
@@ -32,9 +32,7 @@ class TimeDataTypeTest extends MwDBaseUnitTestCase {
 	protected function setUp() {
 		parent::setUp();
 
-		if ( is_a( $this->getStore(), '\SMW\SPARQLStore\SPARQLStore' )
-			&& is_a( $this->getStore()->getConnection( 'sparql' ), '\SMW\SPARQLStore\RepositoryConnector\VirtuosoHttpRepositoryConnector' ) ) {
-
+		if ( strpos( strtolower( $GLOBALS['smwgSparqlDatabaseConnector'] ), 'virtuoso' ) !== false ) {
 			$this->markTestIncomplete(
 				"Virtuoso will fail for '1 January 300 BC' with 'Virtuoso 22007 Error DT006: Cannot convert -0302-12-28Z to datetime : Incorrect month field length'"
 			);


### PR DESCRIPTION
This PR is made in reference to: #

This PR addresses or contains:

- Allow secondary updates to run on MW's `onTransactionIdle` to avoid collisions with unfinished transactions that appeared with MW 1.29+ such as "MWCallableUpdate::doUpdate: transaction round 'SMW\MediaWiki\Jobs\RefreshJob::run' already started", or with `Title::invalidateCache` that runs in `AutoCommitUpdate` since  MW 1.29 etc.
- Adds `PageUpdater::waitOnTransactionIdle`, `DeferredCallableUpdate::waitOnTransactionIdle`, and `PropertyTableIdReferenceDisposer::waitOnTransactionIdle`

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed
