### PR TITLE
PropertyStatisticsRebuilder only select non-subobject entities

### DIFF
--- a/src/Maintenance/PropertyStatisticsRebuilder.php
+++ b/src/Maintenance/PropertyStatisticsRebuilder.php
@@ -65,7 +65,10 @@ class PropertyStatisticsRebuilder {
 		$res = $this->store->getConnection( 'mw.db' )->select(
 			\SMWSql3SmwIds::TABLE_NAME,
 			array( 'smw_id', 'smw_title' ),
-			array( 'smw_namespace' => SMW_NS_PROPERTY  ),
+			array(
+				'smw_namespace' => SMW_NS_PROPERTY,
+				'smw_subobject' => ''
+			),
 			__METHOD__
 		);
 


### PR DESCRIPTION
This PR is made in reference to: #

This PR addresses or contains:

- Avoids that property descriptions or labels are selected during the rebuild (those entities also carry the `SMW_NS_PROPERTY` namespace)

This PR includes:
- [ ] Tests (unit/integration)
- [x] CI build passed
