### PR TITLE
Track wgCommandLineMode, refs 2198, 2203

### DIFF
--- a/src/ApplicationFactory.php
+++ b/src/ApplicationFactory.php
@@ -239,6 +239,10 @@ class ApplicationFactory {
 			$this->getMediaWikiLogger()
 		);
 
+		$pageUpdater->isCommandLineMode(
+			$GLOBALS['wgCommandLineMode']
+		);
+
 		return $pageUpdater;
 	}
 

--- a/src/MediaWiki/PageUpdater.php
+++ b/src/MediaWiki/PageUpdater.php
@@ -32,6 +32,11 @@ class PageUpdater implements LoggerAwareInterface {
 	/**
 	 * @var boolean
 	 */
+	private $isCommandLineMode = false;
+
+	/**
+	 * @var boolean
+	 */
 	private $onTransactionIdle = false;
 
 	/**
@@ -52,6 +57,18 @@ class PageUpdater implements LoggerAwareInterface {
 	 */
 	public function setLogger( LoggerInterface $logger ) {
 		$this->logger = $logger;
+	}
+
+	/**
+	 * @see https://www.mediawiki.org/wiki/Manual:$wgCommandLineMode
+	 * Indicates whether MW is running in command-line mode or not.
+	 *
+	 * @since 2.5
+	 *
+	 * @param boolean $isCommandLineMode
+	 */
+	public function isCommandLineMode( $isCommandLineMode ) {
+		$this->isCommandLineMode = $isCommandLineMode;
 	}
 
 	/**
@@ -83,7 +100,7 @@ class PageUpdater implements LoggerAwareInterface {
 			return $this->onTransactionIdle = false;
 		}
 
-		$this->onTransactionIdle = true;
+		$this->onTransactionIdle = !$this->isCommandLineMode;
 	}
 
 	/**

--- a/src/SQLStore/PropertyStatisticsTable.php
+++ b/src/SQLStore/PropertyStatisticsTable.php
@@ -39,6 +39,11 @@ class PropertyStatisticsTable implements PropertyStatisticsStore, LoggerAwareInt
 	/**
 	 * @var boolean
 	 */
+	private $isCommandLineMode = false;
+
+	/**
+	 * @var boolean
+	 */
 	private $onTransactionIdle = false;
 
 	/**
@@ -66,10 +71,22 @@ class PropertyStatisticsTable implements PropertyStatisticsStore, LoggerAwareInt
 	}
 
 	/**
+	 * @see https://www.mediawiki.org/wiki/Manual:$wgCommandLineMode
+	 * Indicates whether MW is running in command-line mode or not.
+	 *
+	 * @since 2.5
+	 *
+	 * @param boolean $isCommandLineMode
+	 */
+	public function isCommandLineMode( $isCommandLineMode ) {
+		$this->isCommandLineMode = $isCommandLineMode;
+	}
+
+	/**
 	 * @since 2.5
 	 */
 	public function waitOnTransactionIdle() {
-		$this->onTransactionIdle = true;
+		$this->onTransactionIdle = !$this->isCommandLineMode;
 	}
 
 	/**

--- a/src/SQLStore/SQLStoreFactory.php
+++ b/src/SQLStore/SQLStoreFactory.php
@@ -434,6 +434,10 @@ class SQLStoreFactory {
 			ApplicationFactory::getInstance()->getMediaWikiLogger()
 		);
 
+		$propertyStatisticsTable->isCommandLineMode(
+			$GLOBALS['wgCommandLineMode']
+		);
+
 		return $propertyStatisticsTable;
 	}
 

--- a/tests/phpunit/includes/storage/sqlstore/PropertyStatisticsTableTest.php
+++ b/tests/phpunit/includes/storage/sqlstore/PropertyStatisticsTableTest.php
@@ -228,4 +228,33 @@ class PropertyStatisticsTableTest extends MwDBaseUnitTestCase {
 		);
 	}
 
+	public function testAddToUsageCountsWillNotWaitOnTransactionIdleWhenCommandLineModeIsActive() {
+
+		$connection = $this->getMockBuilder( '\SMW\MediaWiki\Database' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$connection->expects( $this->never() )
+			->method( 'onTransactionIdle' );
+
+		$connection->expects( $this->atLeastOnce() )
+			->method( 'update' );
+
+		$instance = new PropertyStatisticsTable(
+			$connection,
+			\SMWSQLStore3::PROPERTY_STATISTICS_TABLE
+		);
+
+		$additions = array(
+			2 => 42,
+			9001 => -9000,
+			9003 => 0,
+		);
+
+		$instance->isCommandLineMode( true );
+		$instance->waitOnTransactionIdle();
+
+		$instance->addToUsageCounts( $additions );
+	}
+
 }


### PR DESCRIPTION
This PR is made in reference to: #2198, #2203

This PR addresses or contains:

- Benchmark tests showed a significant change [0, 1] (Time: 4.54 minutes, Memory: 457.08MB vs. Time: 3.72 minutes, Memory: 456.91MB) in the runtime due to a different execution model when initiated from the `commandLine` therefore avoid `onTransactionIdle` for transactions that are executed from the `commandLine`

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed

[0] https://travis-ci.org/SemanticMediaWiki/SemanticMediaWiki/jobs/194133463
[1] https://travis-ci.org/SemanticMediaWiki/SemanticMediaWiki/jobs/194036649
