### PR TITLE
Allow InterfaceMessage parsing on enabled special pages, ref 2209

### DIFF
--- a/src/MediaWiki/Hooks/InternalParseBeforeLinks.php
+++ b/src/MediaWiki/Hooks/InternalParseBeforeLinks.php
@@ -59,10 +59,10 @@ class InternalParseBeforeLinks {
 	 * @return true
 	 */
 	public function process() {
-		return $this->canPerformUpdate() ? $this->performUpdate() : true;
+		return $this->canPerformUpdate( $this->parser->getTitle() ) ? $this->performUpdate() : true;
 	}
 
-	private function canPerformUpdate() {
+	private function canPerformUpdate( $title ) {
 
 		if ( $this->getRedirectTarget() !== null ) {
 			return true;
@@ -70,18 +70,21 @@ class InternalParseBeforeLinks {
 
 		// ParserOptions::getInterfaceMessage is being used to identify whether a
 		// parse was initiated by `Message::parse`
-		if ( $this->text === '' || $this->parser->getOptions()->getInterfaceMessage() ) {
+		//
+		// #2209 If the text was an `InterfaceMessage` send from a SpecialPage such as
+		// Special:Booksources we allow to proceed
+		if ( $this->text === '' || ( $this->parser->getOptions()->getInterfaceMessage() && !$title->isSpecialPage() ) ) {
 			return false;
 		}
 
-		if ( !$this->parser->getTitle()->isSpecialPage() ) {
+		if ( !$title->isSpecialPage() ) {
 			return true;
 		}
 
 		$isEnabledSpecialPage = $this->applicationFactory->getSettings()->get( 'smwgEnabledSpecialPage' );
 
 		foreach ( $isEnabledSpecialPage as $specialPage ) {
-			if ( $this->parser->getTitle()->isSpecial( $specialPage ) ) {
+			if ( $title->isSpecial( $specialPage ) ) {
 				return true;
 			}
 		}

--- a/tests/phpunit/Unit/MediaWiki/Hooks/InternalParseBeforeLinksTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Hooks/InternalParseBeforeLinksTest.php
@@ -77,9 +77,15 @@ class InternalParseBeforeLinksTest extends \PHPUnit_Framework_TestCase {
 		$this->assertTrue( $instance->process() );
 	}
 
-	public function testNonProcessForInterfaceMessage() {
+	public function testNonProcessForInterfaceMessageOnNonSpecialPage() {
 
 		$text = 'Foo';
+
+		$title = MockTitle::buildMockForMainNamespace();
+
+		$title->expects( $this->atLeastOnce() )
+			->method( 'isSpecialPage' )
+			->will( $this->returnValue( false ) );
 
 		$parserOptions = $this->getMockBuilder( '\ParserOptions' )
 			->disableOriginalConstructor()
@@ -97,8 +103,9 @@ class InternalParseBeforeLinksTest extends \PHPUnit_Framework_TestCase {
 			->method( 'getOptions' )
 			->will( $this->returnValue( $parserOptions ) );
 
-		$parser->expects( $this->never() )
-			->method( 'getTitle' );
+		$parser->expects( $this->once() )
+			->method( 'getTitle' )
+			->will( $this->returnValue( $title ) );
 
 		$instance = new InternalParseBeforeLinks(
 			$parser,


### PR DESCRIPTION
This PR is made in reference to: #2209

This PR addresses or contains:

This PR includes:
- [ ] Tests (unit/integration)
- [x] CI build passed
