### PR TITLE
Add LinksProcessor and SemanticLinksParser

### DIFF
--- a/src/ApplicationFactory.php
+++ b/src/ApplicationFactory.php
@@ -282,14 +282,17 @@ class ApplicationFactory {
 
 		$mwCollaboratorFactory = $this->newMwCollaboratorFactory();
 
-		$inTextAnnotationParser = new InTextAnnotationParser(
-			$parserData,
-			$mwCollaboratorFactory->newMagicWordsFinder(),
-			$mwCollaboratorFactory->newRedirectTargetFinder()
+		$linksProcessor = $this->callbackLoader->create( 'LinksProcessor' );
+
+		$linksProcessor->isStrictMode(
+			$this->getSettings()->get( 'smwgEnabledInTextAnnotationParserStrictMode' )
 		);
 
-		$inTextAnnotationParser->isStrictMode(
-			$this->getSettings()->get( 'smwgEnabledInTextAnnotationParserStrictMode' )
+		$inTextAnnotationParser = new InTextAnnotationParser(
+			$parserData,
+			$linksProcessor,
+			$mwCollaboratorFactory->newMagicWordsFinder(),
+			$mwCollaboratorFactory->newRedirectTargetFinder()
 		);
 
 		// 2.5+ Changed modus operandi

--- a/src/InTextAnnotationParser.php
+++ b/src/InTextAnnotationParser.php
@@ -4,8 +4,10 @@ namespace SMW;
 
 use Hooks;
 use SMW\Parser\Obfuscator;
+use SMW\Parser\linksProcessor;
 use SMW\MediaWiki\MagicWordsFinder;
 use SMW\MediaWiki\RedirectTargetFinder;
+use SMW\Utils\Timer;
 use SMWOutputs;
 use Title;
 
@@ -39,6 +41,11 @@ class InTextAnnotationParser {
 	 * @var ParserData
 	 */
 	private $parserData;
+
+	/**
+	 * @var LinksProcessor
+	 */
+	private $linksProcessor;
 
 	/**
 	 * @var MagicWordsFinder
@@ -78,11 +85,6 @@ class InTextAnnotationParser {
 	protected $isAnnotation = true;
 
 	/**
-	 * @var boolean
-	 */
-	private $isStrictMode = true;
-
-	/**
 	 * @var boolean|integer
 	 */
 	private $enabledLinksInValues = false;
@@ -91,28 +93,17 @@ class InTextAnnotationParser {
 	 * @since 1.9
 	 *
 	 * @param ParserData $parserData
+	 * @param LinksProcessor $linksProcessor
 	 * @param MagicWordsFinder $magicWordsFinder
 	 * @param RedirectTargetFinder $redirectTargetFinder
 	 */
-	public function __construct( ParserData $parserData, MagicWordsFinder $magicWordsFinder, RedirectTargetFinder $redirectTargetFinder ) {
+	public function __construct( ParserData $parserData, LinksProcessor $linksProcessor, MagicWordsFinder $magicWordsFinder, RedirectTargetFinder $redirectTargetFinder ) {
 		$this->parserData = $parserData;
+		$this->linksProcessor = $linksProcessor;
 		$this->magicWordsFinder = $magicWordsFinder;
 		$this->redirectTargetFinder = $redirectTargetFinder;
 		$this->dataValueFactory = DataValueFactory::getInstance();
 		$this->applicationFactory = ApplicationFactory::getInstance();
-	}
-
-	/**
-	 * Whether a strict interpretation (e.g [[property::value:partOfTheValue::alsoPartOfTheValue]])
-	 * or a more loose interpretation (e.g. [[property1::property2::value]]) for
-	 * annotations is to be applied.
-	 *
-	 * @since 2.3
-	 *
-	 * @param boolean $isStrictMode
-	 */
-	public function isStrictMode( $isStrictMode ) {
-		$this->isStrictMode = (bool)$isStrictMode;
 	}
 
 	/**
@@ -136,7 +127,7 @@ class InTextAnnotationParser {
 
 		$title = $this->parserData->getTitle();
 		$this->settings = $this->applicationFactory->getSettings();
-		$start = microtime( true );
+		Timer::start( __CLASS__ );
 
 		// Identifies the current parser run (especially when called recursively)
 		$this->parserData->getSubject()->setContextReference( 'intp:' . uniqid() );
@@ -179,7 +170,7 @@ class InTextAnnotationParser {
 
 		$this->parserData->addLimitReport(
 			'intext-parsertime',
-			number_format( ( microtime( true ) - $start ), 3 )
+			Timer::getElapsedTime( __CLASS__, 3 )
 		);
 
 		SMWOutputs::commitToParserOutput( $this->parserData->getOutput() );
@@ -264,47 +255,19 @@ class InTextAnnotationParser {
 	}
 
 	/**
-	 * $smwgLinksInValues (default = false) determines which regexp pattern
-	 * is returned, either a more complex (lib PCRE may cause segfaults if text
-	 * is long) or a simpler (no segfaults found for those, but no links
-	 * in values) pattern.
-	 *
-	 * If enabled (SMW accepts inputs like [[property::Some [[link]] in value]]),
-	 * this may lead to PHP crashes (!) when very long texts are
-	 * used as values. This is due to limitations in the library PCRE that
-	 * PHP uses for pattern matching.
-	 *
+	 * @see LinksProcessor::getRegexpPattern
 	 * @since 1.9
 	 *
 	 * @param boolean $linksInValues
 	 *
 	 * @return string
 	 */
-	public static function getRegexpPattern( $linksInValues ) {
-		if ( $linksInValues ) {
-			return '/\[\[             # Beginning of the link
-				(?:([^:][^]]*):[=:])+ # Property name (or a list of those)
-				(                     # After that:
-				  (?:[^|\[\]]         #   either normal text (without |, [ or ])
-				  |\[\[[^]]*\]\]      #   or a [[link]]
-				  |\[[^]]*\]          #   or an [external link]
-				)*)                   # all this zero or more times
-				(?:\|([^]]*))?        # Display text (like "text" in [[link|text]]), optional
-				\]\]                  # End of link
-				/xu';
-		} else {
-			return '/\[\[             # Beginning of the link
-				(?:([^:][^]]*):[=:])+ # Property name (or a list of those)
-				([^\[\]]*)            # content: anything but [, |, ]
-				\]\]                  # End of link
-				/xu';
-		}
+	public static function getRegexpPattern( $linksInValues = false ) {
+		return LinksProcessor::getRegexpPattern( $linksInValues );
 	}
 
 	/**
-	 * A method that precedes the process() callback, it takes care of separating
-	 * value and caption (instead of leaving this to a more complex regexp).
-	 *
+	 * @see linksProcessor::preprocess
 	 * @since 1.9
 	 *
 	 * @param array $semanticLink expects (linktext, properties, value|caption)
@@ -312,39 +275,18 @@ class InTextAnnotationParser {
 	 * @return string
 	 */
 	public function preprocess( array $semanticLink ) {
-		$value = '';
-		$caption = false;
 
-		if ( array_key_exists( 2, $semanticLink ) ) {
+		$semanticLinks = $this->linksProcessor->preprocess( $semanticLink );
 
-			// #1747 avoid a mismatch on an annotation like [[Foo|Bar::Foobar]]
-			// where the left part of :: is split and would contain "Foo|Bar"
-			// hence this type is categorized as no value annotation
-			if ( strpos( $semanticLink[1], '|' ) !== false ) {
-				return $semanticLink[0];
-			}
-
-			$parts = explode( '|', $semanticLink[2] );
-
-			if ( array_key_exists( 0, $parts ) ) {
-				$value = $parts[0];
-			}
-			if ( array_key_exists( 1, $parts ) ) {
-				$caption = $parts[1];
-			}
+		if ( is_string( $semanticLinks ) ) {
+			return $semanticLinks;
 		}
 
-		if ( $caption !== false ) {
-			return $this->process( array( $semanticLink[0], $semanticLink[1], $value, $caption ) );
-		}
-
-		return $this->process( array( $semanticLink[0], $semanticLink[1], $value ) );
+		return $this->process( $semanticLinks );
 	}
 
 	/**
-	 * This callback function strips out the semantic attributes from a wiki
-	 * link.
-	 *
+	 * @see linksProcessor::process
 	 * @since 1.9
 	 *
 	 * @param array $semanticLink expects (linktext, properties, value|caption)
@@ -357,53 +299,25 @@ class InTextAnnotationParser {
 		$property = '';
 		$value = '';
 
-		if ( array_key_exists( 1, $semanticLink ) ) {
+		$semanticLinks = $this->linksProcessor->process(
+			$semanticLink
+		);
 
-			// #1252 Strict mode being disabled for support of multi property
-			// assignments (e.g. [[property1::property2::value]])
+		$this->isAnnotation = $this->linksProcessor->isAnnotation();
 
-			// #1066 Strict mode is to check for colon(s) produced by something
-			// like [[Foo::Bar::Foobar]], [[Foo:::0049 30 12345678]]
-			// In case a colon appears (in what is expected to be a string without a colon)
-			// then concatenate the string again and split for the first :: occurrence
-			// only
-			if ( $this->isStrictMode && strpos( $semanticLink[1], ':' ) !== false && isset( $semanticLink[2] ) ) {
-				list( $semanticLink[1], $semanticLink[2] ) = explode( '::', $semanticLink[1] . '::' . $semanticLink[2], 2 );
-			}
-
-			$property = $semanticLink[1];
+		if ( is_string( $semanticLinks ) ) {
+			return $semanticLinks;
 		}
 
-		if ( array_key_exists( 2, $semanticLink ) ) {
-			$value = $semanticLink[2];
+		list( $properties, $value, $valueCaption ) = $semanticLinks;
+
+		$subject = $this->parserData->getSubject();
+
+		if ( ( $propertyLink = $this->getPropertyLink( $subject, $properties, $value, $valueCaption ) ) !== '' ) {
+			return $propertyLink;
 		}
 
-		$value = Obfuscator::removeLinkObfuscation( $value );
-
-		if ( $value === '' ) { // silently ignore empty values
-			return '';
-		}
-
-		if ( $property == 'SMW' ) {
-			switch ( $value ) {
-				case 'on':
-					$this->isAnnotation = true;
-					break;
-				case 'off':
-					$this->isAnnotation = false;
-					break;
-			}
-			return '';
-		}
-
-		if ( array_key_exists( 3, $semanticLink ) ) {
-			$valueCaption = $semanticLink[3];
-		}
-
-		// Extract annotations and create tooltip.
-		$properties = preg_split( '/:[=:]/u', $property );
-
-		return $this->addPropertyValue( $properties, $value, $valueCaption );
+		return $this->addPropertyValue( $subject, $properties, $value, $valueCaption );
 	}
 
 	/**
@@ -415,13 +329,7 @@ class InTextAnnotationParser {
 	 *
 	 * @return string
 	 */
-	protected function addPropertyValue( array $properties, $value, $valueCaption ) {
-
-		$subject = $this->parserData->getSubject();
-
-		if ( ( $propertyLink = $this->getPropertyLink( $subject, $properties, $value, $valueCaption ) ) !== '' ) {
-			return $propertyLink;
-		}
+	protected function addPropertyValue( $subject, array $properties, $value, $valueCaption ) {
 
 		// Add properties to the semantic container
 		foreach ( $properties as $property ) {

--- a/src/Parser/LinksProcessor.php
+++ b/src/Parser/LinksProcessor.php
@@ -1,0 +1,198 @@
+<?php
+
+namespace SMW\Parser;
+
+/**
+ * @license GNU GPL v2+
+ * @since 2.5
+ *
+ * @author mwjames
+ */
+class LinksProcessor {
+
+	/**
+	 * Internal state for switching SMW link annotations off/on during parsing
+	 * ([[SMW::on]] and [[SMW:off]])
+	 *
+	 * @var boolean
+	 */
+	private $isAnnotation = true;
+
+	/**
+	 * @var boolean
+	 */
+	private $isStrictMode = true;
+
+	/**
+	 * Whether a strict interpretation (e.g [[property::value:partOfTheValue::alsoPartOfTheValue]])
+	 * or a more loose interpretation (e.g. [[property1::property2::value]]) for
+	 * annotations is expected.
+	 *
+	 * @since 2.3
+	 *
+	 * @param boolean $isStrictMode
+	 */
+	public function isStrictMode( $isStrictMode ) {
+		$this->isStrictMode = (bool)$isStrictMode;
+	}
+
+	/**
+	 * @since 2.5
+	 *
+	 * @return boolean
+	 */
+	public function isAnnotation() {
+		return $this->isAnnotation;
+	}
+
+	/**
+	 * $smwgLinksInValues (default = false) determines which regexp pattern
+	 * is returned, either a more complex (lib PCRE may cause segfaults if text
+	 * is long) or a simpler (no segfaults found for those, but no links
+	 * in values) pattern.
+	 *
+	 * If enabled (SMW accepts inputs like [[property::Some [[link]] in value]]),
+	 * this may lead to PHP crashes (!) when very long texts are
+	 * used as values. This is due to limitations in the library PCRE that
+	 * PHP uses for pattern matching.
+	 *
+	 * @since 1.9
+	 *
+	 * @param boolean $linksInValues
+	 *
+	 * @return string
+	 */
+	public static function getRegexpPattern( $linksInValues = false ) {
+
+		if ( $linksInValues ) {
+			return '/\[\[             # Beginning of the link
+				(?:([^:][^]]*):[=:])+ # Property name (or a list of those)
+				(                     # After that:
+				  (?:[^|\[\]]         #   either normal text (without |, [ or ])
+				  |\[\[[^]]*\]\]      #   or a [[link]]
+				  |\[[^]]*\]          #   or an [external link]
+				)*)                   # all this zero or more times
+				(?:\|([^]]*))?        # Display text (like "text" in [[link|text]]), optional
+				\]\]                  # End of link
+				/xu';
+		}
+
+		return '/\[\[             # Beginning of the link
+			(?:([^:][^]]*):[=:])+ # Property name (or a list of those)
+			([^\[\]]*)            # content: anything but [, |, ]
+			\]\]                  # End of link
+			/xu';
+	}
+
+	/**
+	 * A method that precedes the process method, it takes care of separating
+	 * value and caption (instead of leaving this to a more complex regexp).
+	 *
+	 * @since 1.9
+	 *
+	 * @param array $semanticLink expects (linktext, properties, value|caption)
+	 *
+	 * @return string
+	 */
+	public function preprocess( array $semanticLink ) {
+
+		$value = '';
+		$caption = false;
+
+		if ( array_key_exists( 2, $semanticLink ) ) {
+
+			// #1747 avoid a mismatch on an annotation like [[Foo|Bar::Foobar]]
+			// where the left part of :: is split and would contain "Foo|Bar"
+			// hence this type is categorized as no value annotation
+			if ( strpos( $semanticLink[1], '|' ) !== false ) {
+				return $semanticLink[0];
+			}
+
+			$parts = explode( '|', $semanticLink[2] );
+
+			if ( array_key_exists( 0, $parts ) ) {
+				$value = $parts[0];
+			}
+			if ( array_key_exists( 1, $parts ) ) {
+				$caption = $parts[1];
+			}
+		}
+
+		if ( $caption !== false ) {
+			return array( $semanticLink[0], $semanticLink[1], $value, $caption );
+		}
+
+		return array( $semanticLink[0], $semanticLink[1], $value );
+	}
+
+	/**
+	 * Function strips out the semantic attributes from a wiki link.
+	 *
+	 * @since 1.9
+	 *
+	 * @param array $semanticLink expects (linktext, properties, value|caption)
+	 *
+	 * @return string
+	 */
+	public function process( array $semanticLink ) {
+
+		$valueCaption = false;
+		$property = '';
+		$value = '';
+
+		if ( array_key_exists( 1, $semanticLink ) ) {
+
+			// #1252 Strict mode being disabled for support of multi property
+			// assignments (e.g. [[property1::property2::value]])
+
+			// #1066 Strict mode is to check for colon(s) produced by something
+			// like [[Foo::Bar::Foobar]], [[Foo:::0049 30 12345678]]
+			// In case a colon appears (in what is expected to be a string without a colon)
+			// then concatenate the string again and split for the first :: occurrence
+			// only
+			if ( $this->isStrictMode && strpos( $semanticLink[1], ':' ) !== false && isset( $semanticLink[2] ) ) {
+				list( $semanticLink[1], $semanticLink[2] ) = explode( '::', $semanticLink[1] . '::' . $semanticLink[2], 2 );
+			}
+
+			$property = $semanticLink[1];
+		}
+
+		if ( array_key_exists( 2, $semanticLink ) ) {
+			$value = $semanticLink[2];
+		}
+
+		$value = Obfuscator::removeLinkObfuscation( $value );
+
+		if ( $value === '' ) { // silently ignore empty values
+			return '';
+		}
+
+		if ( $property == 'SMW' ) {
+			return $this->setAnnotation( $value );
+		}
+
+		if ( array_key_exists( 3, $semanticLink ) ) {
+			$valueCaption = $semanticLink[3];
+		}
+
+		// Extract annotations and create tooltip.
+		$properties = preg_split( '/:[=:]/u', $property );
+
+		return array( $properties, $value, $valueCaption );
+	}
+
+	private function setAnnotation( $value ) {
+
+		switch ( $value ) {
+			case 'on':
+				$this->isAnnotation = true;
+				break;
+			case 'off':
+				$this->isAnnotation = false;
+				break;
+		}
+
+		return '';
+	}
+
+}

--- a/src/Parser/SemanticLinksParser.php
+++ b/src/Parser/SemanticLinksParser.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace SMW\Parser;
+
+use SMW\Parser\Obfuscator;
+use SMW\InTextAnnotationParser;
+
+/**
+ * @license GNU GPL v2+
+ * @since 2.5
+ *
+ * @author mwjames
+ */
+class SemanticLinksParser {
+
+	/**
+	 * @var LinksProcessor
+	 */
+	private $linksProcessor;
+
+	/**
+	 * @since 2.5
+	 *
+	 * @param LinksProcessor $linksProcessor
+	 */
+	public function __construct( LinksProcessor $linksProcessor ) {
+		$this->linksProcessor = $linksProcessor;
+	}
+
+	/**
+	 * @since 2.5
+	 *
+	 * @param $text
+	 *
+	 * @return array
+	 */
+	public function parse( $text ) {
+
+		$matches = array();
+
+		preg_match(
+			$this->linksProcessor->getRegexpPattern(),
+			$text,
+			$matches
+		);
+
+		if ( $matches === array() ) {
+			return array();
+		}
+
+		$semanticLinks = $this->linksProcessor->preprocess( $matches );
+
+		if ( is_string( $semanticLinks ) ) {
+			return array();
+		}
+
+		$semanticLinks = $this->linksProcessor->process( $semanticLinks );
+
+		if ( is_string( $semanticLinks ) ) {
+			return array();
+		}
+
+		return $semanticLinks;
+	}
+
+}

--- a/src/SharedCallbackContainer.php
+++ b/src/SharedCallbackContainer.php
@@ -22,6 +22,7 @@ use Psr\Log\NullLogger;
 use SMW\SQLStore\ChangeOp\TempChangeOpStore;
 use SMW\Query\Result\CachedQueryResultPrefetcher;
 use SMW\Utils\BufferedStatsdCollector;
+use SMW\Parser\LinksProcessor;
 
 /**
  * @license GNU GPL v2+
@@ -82,6 +83,11 @@ class SharedCallbackContainer implements CallbackContainer {
 
 		$callbackLoader->registerCallback( 'ParserData', function( \Title $title, \ParserOutput $parserOutput ) {
 			return new ParserData( $title, $parserOutput );
+		} );
+
+		$callbackLoader->registerCallback( 'LinksProcessor', function() use ( $callbackLoader ) {
+			$callbackLoader->registerExpectedReturnType( 'LinksProcessor', '\SMW\Parser\LinksProcessor' );
+			return new LinksProcessor();
 		} );
 
 		$callbackLoader->registerCallback( 'MessageFormatter', function( \Language $language ) {

--- a/tests/phpunit/Integration/SemanticMediaWikiProvidedHookInterfaceIntegrationTest.php
+++ b/tests/phpunit/Integration/SemanticMediaWikiProvidedHookInterfaceIntegrationTest.php
@@ -372,12 +372,16 @@ class SemanticMediaWikiProvidedHookInterfaceIntegrationTest extends \PHPUnit_Fra
 				$this->anything() )
 			->will( $this->returnValue( array() ) );
 
+		$linksProcessor = $this->getMockBuilder( '\SMW\Parser\LinksProcessor' )
+			->disableOriginalConstructor()
+			->getMock();
+
 		$redirectTargetFinder = $this->getMockBuilder( '\SMW\MediaWiki\RedirectTargetFinder' )
 			->disableOriginalConstructor()
 			->getMock();
 
 		$inTextAnnotationParser = $this->getMockBuilder( '\SMW\InTextAnnotationParser' )
-			->setConstructorArgs( array( $parserData, $magicWordsFinder, $redirectTargetFinder ) )
+			->setConstructorArgs( array( $parserData, $linksProcessor, $magicWordsFinder, $redirectTargetFinder ) )
 			->setMethods( null )
 			->getMock();
 

--- a/tests/phpunit/Unit/InTextAnnotationParserTemplateTransclusionTest.php
+++ b/tests/phpunit/Unit/InTextAnnotationParserTemplateTransclusionTest.php
@@ -4,9 +4,7 @@ namespace SMW\Tests;
 
 use ParserOutput;
 use SMW\InTextAnnotationParser;
-use SMW\MediaWiki\MagicWordsFinder;
-use SMW\MediaWiki\RedirectTargetFinder;
-use SMW\ParserData;
+use SMW\ApplicationFactory;
 use Title;
 
 /**
@@ -22,6 +20,7 @@ class InTextAnnotationParserTemplateTransclusionTest extends \PHPUnit_Framework_
 
 	private $semanticDataValidator;
 	private $testEnvironment;
+	private $applicationFactory;
 
 	protected function setUp() {
 		parent::setUp();
@@ -34,6 +33,8 @@ class InTextAnnotationParserTemplateTransclusionTest extends \PHPUnit_Framework_
 			->getMockForAbstractClass();
 
 		$this->testEnvironment->registerObject( 'Store', $store );
+
+		$this->applicationFactory = ApplicationFactory::getInstance();
 	}
 
 	protected function tearDown() {
@@ -82,15 +83,13 @@ class InTextAnnotationParserTemplateTransclusionTest extends \PHPUnit_Framework_
 
 		$this->testEnvironment->withConfiguration( $settings );
 
-		$parserData = new ParserData(
+		$parserData = $this->applicationFactory->newParserData(
 			$title,
 			$parserOutput
 		);
 
-		$instance = new InTextAnnotationParser(
-			$parserData,
-			new MagicWordsFinder(),
-			new RedirectTargetFinder()
+		$instance = $this->applicationFactory->newInTextAnnotationParser(
+			$parserData
 		);
 
 		$instance->parse( $outputText );
@@ -100,7 +99,10 @@ class InTextAnnotationParserTemplateTransclusionTest extends \PHPUnit_Framework_
 			$outputText
 		);
 
-		$parserData = new ParserData( $title, $parserOutput );
+		$parserData = $this->applicationFactory->newParserData(
+			$title,
+			$parserOutput
+		);
 
 		$this->assertInstanceOf(
 			'\SMW\SemanticData',

--- a/tests/phpunit/Unit/InTextAnnotationParserTest.php
+++ b/tests/phpunit/Unit/InTextAnnotationParserTest.php
@@ -6,6 +6,7 @@ use ParserOutput;
 use ReflectionClass;
 use SMW\DIProperty;
 use SMW\InTextAnnotationParser;
+use SMW\Parser\LinksProcessor;
 use SMW\MediaWiki\MagicWordsFinder;
 use SMW\MediaWiki\RedirectTargetFinder;
 use SMW\ParserData;
@@ -26,6 +27,7 @@ class InTextAnnotationParserTest extends \PHPUnit_Framework_TestCase {
 
 	private $semanticDataValidator;
 	private $testEnvironment;
+	private $linksProcessor;
 
 	protected function setUp() {
 		parent::setUp();
@@ -38,6 +40,8 @@ class InTextAnnotationParserTest extends \PHPUnit_Framework_TestCase {
 			->getMockForAbstractClass();
 
 		$this->testEnvironment->registerObject( 'Store', $store );
+
+		$this->LinksProcessor = new LinksProcessor();
 	}
 
 	protected function tearDown() {
@@ -62,6 +66,7 @@ class InTextAnnotationParserTest extends \PHPUnit_Framework_TestCase {
 
 		$instance =	new InTextAnnotationParser(
 			new ParserData( $title, $parserOutput ),
+			$this->LinksProcessor,
 			new MagicWordsFinder(),
 			$redirectTargetFinder
 		);
@@ -86,6 +91,7 @@ class InTextAnnotationParserTest extends \PHPUnit_Framework_TestCase {
 
 		$instance = new InTextAnnotationParser(
 			$parserData,
+			$this->LinksProcessor,
 			$magicWordsFinder,
 			new RedirectTargetFinder()
 		);
@@ -108,14 +114,15 @@ class InTextAnnotationParserTest extends \PHPUnit_Framework_TestCase {
 			new ParserOutput()
 		);
 
-		$instance = new InTextAnnotationParser(
-			$parserData,
-			new MagicWordsFinder(),
-			new RedirectTargetFinder()
+		$this->LinksProcessor->isStrictMode(
+			isset( $settings['smwgEnabledInTextAnnotationParserStrictMode'] ) ? $settings['smwgEnabledInTextAnnotationParserStrictMode'] : true
 		);
 
-		$instance->isStrictMode(
-			isset( $settings['smwgEnabledInTextAnnotationParserStrictMode'] ) ? $settings['smwgEnabledInTextAnnotationParserStrictMode'] : true
+		$instance = new InTextAnnotationParser(
+			$parserData,
+			$this->LinksProcessor,
+			new MagicWordsFinder(),
+			new RedirectTargetFinder()
 		);
 
 		$instance->enabledLinksInValues(
@@ -172,6 +179,7 @@ class InTextAnnotationParserTest extends \PHPUnit_Framework_TestCase {
 
 		$instance = new InTextAnnotationParser(
 			$parserData,
+			$this->LinksProcessor,
 			new MagicWordsFinder(),
 			$redirectTargetFinder
 		);
@@ -216,6 +224,7 @@ class InTextAnnotationParserTest extends \PHPUnit_Framework_TestCase {
 
 		$instance = new InTextAnnotationParser(
 			$parserData,
+			$this->LinksProcessor,
 			new MagicWordsFinder(),
 			$redirectTargetFinder
 		);
@@ -238,6 +247,7 @@ class InTextAnnotationParserTest extends \PHPUnit_Framework_TestCase {
 
 		$instance = new InTextAnnotationParser(
 			$parserData,
+			$this->LinksProcessor,
 			new MagicWordsFinder(),
 			new RedirectTargetFinder()
 		);

--- a/tests/phpunit/Unit/Parser/LinksProcessorTest.php
+++ b/tests/phpunit/Unit/Parser/LinksProcessorTest.php
@@ -1,0 +1,124 @@
+<?php
+
+namespace SMW\Tests\Parser;
+
+use SMW\Parser\LinksProcessor;
+
+/**
+ * @covers \SMW\Parser\LinksProcessor
+ * @group semantic-mediawiki
+ *
+ * @license GNU GPL v2+
+ * @since 2.5
+ *
+ * @author mwjames
+ */
+class LinksProcessorTest extends \PHPUnit_Framework_TestCase {
+
+	public function testCanConstruct() {
+
+		$instance = new LinksProcessor();
+
+		$this->assertInstanceOf(
+			'SMW\Parser\LinksProcessor',
+			$instance
+		);
+	}
+
+	/**
+	 * @dataProvider semanticPreLinkProvider
+	 */
+	public function testPreprocess( $semanticLink, $expected ) {
+
+		$instance = new LinksProcessor();
+
+		$this->assertEquals(
+			$expected,
+			$instance->preprocess( $semanticLink )
+		);
+	}
+
+	/**
+	 * @dataProvider semanticLinkProvider
+	 */
+	public function testProcess( $semanticLink, $expected ) {
+
+		$instance = new LinksProcessor();
+
+		$this->assertEquals(
+			$expected,
+			$instance->process( $semanticLink )
+		);
+	}
+
+	public function semanticPreLinkProvider() {
+
+		$provider = array();
+
+		$provider[] = array(
+			array(
+				'[[Foo::Bar]]',
+				'Foo',
+				'Bar'
+			),
+			array(
+				'[[Foo::Bar]]',
+				'Foo',
+				'Bar'
+			)
+		);
+
+		$provider[] = array(
+			array(
+				'[[Foo::Bar|Foobar]]',
+				'Foo',
+				'Bar'
+			),
+			array(
+				'[[Foo::Bar|Foobar]]',
+				'Foo',
+				'Bar'
+			)
+		);
+
+		return $provider;
+	}
+
+	public function semanticLinkProvider() {
+
+		$provider = array();
+
+		$provider[] = array(
+			array(
+				'[[Foo::Bar]]',
+				'Foo',
+				'Bar'
+			),
+			array(
+				array(
+					'Foo'
+				),
+				'Bar',
+				false
+			)
+		);
+
+		$provider[] = array(
+			array(
+				'[[Foo::Bar|Foobar]]',
+				'Foo',
+				'Bar'
+			),
+			array(
+				array(
+					'Foo'
+				),
+				'Bar',
+				false
+			)
+		);
+
+		return $provider;
+	}
+
+}

--- a/tests/phpunit/Unit/Parser/SemanticLinksParserTest.php
+++ b/tests/phpunit/Unit/Parser/SemanticLinksParserTest.php
@@ -1,0 +1,97 @@
+<?php
+
+namespace SMW\Tests\Parser;
+
+use SMW\Parser\SemanticLinksParser;
+use SMW\Parser\LinksProcessor;
+
+/**
+ * @covers \SMW\Parser\SemanticLinksParser
+ * @group semantic-mediawiki
+ *
+ * @license GNU GPL v2+
+ * @since 2.5
+ *
+ * @author mwjames
+ */
+class SemanticLinksParserTest extends \PHPUnit_Framework_TestCase {
+
+	public function testCanConstruct() {
+
+		$linksProcessor = $this->getMockBuilder( 'SMW\Parser\LinksProcessor' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$instance = new SemanticLinksParser( $linksProcessor );
+
+		$this->assertInstanceOf(
+			'SMW\Parser\SemanticLinksParser',
+			$instance
+		);
+	}
+
+	/**
+	 * @dataProvider textProvider
+	 */
+	public function testParse( $text, $expected ) {
+
+		$instance = new SemanticLinksParser(
+			new LinksProcessor()
+		);
+
+		$this->assertEquals(
+			$expected,
+			$instance->parse( $text )
+		);
+	}
+
+	public function textProvider() {
+
+		$provider = array();
+
+		$provider[] = array(
+			'Foo',
+			array()
+		);
+
+		$provider[] = array(
+			'[[Foo]]',
+			array()
+		);
+
+		$provider[] = array(
+			'[[Foo|Bar]]',
+			array()
+		);
+
+		$provider[] = array(
+			'[[Foo::[[Bar]]]]',
+			array()
+		);
+
+		$provider[] = array(
+			'[[Foo::Bar]]',
+			array(
+				array(
+					'Foo'
+				),
+				'Bar',
+				false
+			)
+		);
+
+		$provider[] = array(
+			'[[Foo::Bar|Foobar]]',
+			array(
+				array(
+					'Foo'
+				),
+				'Bar',
+				'Foobar'
+			)
+		);
+
+		return $provider;
+	}
+
+}


### PR DESCRIPTION
This PR is made in reference to: #

This PR addresses or contains:

- `InTextAnnotationParser` does a lot of things and to ease maintenance, processing of links have been moved to its own class `LinksProcessor`
- `SemanticLinksParser` allows to return all semantic links from a text.

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed
