### PR TITLE
Add possibility to display introductory-message on property, concept page

### DIFF
--- a/includes/articlepages/SMW_PropertyPage.php
+++ b/includes/articlepages/SMW_PropertyPage.php
@@ -102,10 +102,26 @@ class SMWPropertyPage extends SMWOrderedListPage {
 		$propertyName = $dv->getFormattedLabel();
 		$message = '';
 
+		if ( wfMessage( 'smw-property-introductory-message' )->exists() ) {
+			$message = Html::rawElement(
+				'div',
+				array(
+					'class' => 'plainlinks smw-callout smw-callout-info'
+				),
+				wfMessage( 'smw-property-introductory-message', $propertyName )->parse()
+			);
+		}
+
 		if ( $this->mProperty->isUserDefined() ) {
 
 			if ( $this->store->getPropertyTableInfoFetcher()->isFixedTableProperty( $this->mProperty ) ) {
-				$message = Html::rawElement( 'div', array( 'class' => 'plainlinks' ), wfMessage( 'smw-property-userdefined-fixedtable', $propertyName )->parse() );
+				$message .= Html::rawElement(
+					'div',
+					array(
+						'class' => 'plainlinks smw-callout smw-callout-info'
+					),
+					wfMessage( 'smw-property-userdefined-fixedtable', $propertyName )->parse()
+				);
 			}
 
 			return $message;

--- a/src/ParserFunctions/ConceptParserFunction.php
+++ b/src/ParserFunctions/ConceptParserFunction.php
@@ -106,11 +106,24 @@ class ConceptParserFunction {
 			return $this->messageFormatter->getHtml();
 		}
 
-		return $this->buildConceptInfoBox( $title, $conceptQueryString, $conceptDocu );
+		return $this->createHtml( $title, $conceptQueryString, $conceptDocu );
 	}
 
-	private function buildConceptInfoBox( Title $title, $queryString, $documentation ) {
-		return Html::rawElement( 'div', array( 'class' => 'smwfact' ),
+	private function createHtml( Title $title, $queryString, $documentation ) {
+
+		$message = '';
+
+		if ( wfMessage( 'smw-concept-introductory-message' )->exists() ) {
+			$message = Html::rawElement(
+				'div',
+				array(
+					'class' => 'plainlinks smw-callout smw-callout-info'
+				),
+				wfMessage( 'smw-concept-introductory-message', $title->getText() )->text()
+			);
+		}
+
+		return $message . Html::rawElement( 'div', array( 'class' => 'smwfact' ),
 			Html::rawElement( 'span', array( 'class' => 'smwfactboxhead' ),
 				wfMessage( 'smw_concept_description', $title->getText() )->text() ) .
 			Html::rawElement( 'span', array( 'class' => 'smwrdflink' ), $this->getRdfLink( $title )->getWikiText() ) .


### PR DESCRIPTION
This PR is made in reference to: #

This PR addresses or contains:

- Adds possibility to maintain `smw-property-introductory-message`, `smw-concept-introductory-message` and if available will be displayed at the top on either the property or concept page

This PR includes:
- [ ] Tests (unit/integration)
- [x] CI build passed
