### PR TITLE
Check codified property specification requirements, refs 2221

### DIFF
--- a/i18n/en.json
+++ b/i18n/en.json
@@ -491,5 +491,8 @@
 	"smw-clipboard-copy-link": "Copy link to clipboard",
 	"smw-property-userdefined-fixedtable": "\"$1\" was configured as [https://www.semantic-mediawiki.org/wiki/Fixed_properties fixed property] and any modification to its [https://www.semantic-mediawiki.org/wiki/Type_declaration type declaration] requires to either run <code>setupStore.php</code> or to complete the special [[Special:SemanticMediaWiki|\"Database installation and upgrade\"]] task.",
 	"smw-data-lookup": "Fetching data ...",
-	"smw-no-data-available": "No data available."
+	"smw-no-data-available": "No data available.",
+	"smw-property-req-violation-missing-fields": "Property \"$1\" is missing declaration details for the annotated \"$2\" type by failing to define the <code>Has fields</code> property.",
+	"smw-property-req-violation-missing-formatter-uri": "Property \"$1\" is missing declaration details for the annotated type by failing to define the <code>External formatter URI</code> property.",
+	"smw-property-req-violation-predefined-type": "Property \"$1\" as predefined property contains a \"$2\" type declaration that is incompatible with the default type of this property."
 }

--- a/src/PropertySpecificationReqExaminer.php
+++ b/src/PropertySpecificationReqExaminer.php
@@ -1,0 +1,150 @@
+<?php
+
+namespace SMW;
+
+use SMW\SemanticData;
+use SMW\Store;
+use SMW\DIProperty;
+use SMW\DataItemFactory;
+
+/**
+ * Examines codified requirements for listed types of property specifications which
+ * in case of a violation returns a message with the details of that violation.
+ *
+ * @license GNU GPL v2+
+ * @since 2.5
+ *
+ * @author mwjames
+ */
+class PropertySpecificationReqExaminer {
+
+	/**
+	 * @var Store
+	 */
+	private $store;
+
+	/**
+	 * @var SemanticData
+	 */
+	private $semanticData;
+
+	/**
+	 * @var DataItemFactory
+	 */
+	private $dataItemFactory;
+
+	/**
+	 * @since 2.5
+	 *
+	 * @param Store $store
+	 * @param DIProperty $property
+	 */
+	public function __construct( Store $store ) {
+		$this->store = $store;
+	}
+
+	/**
+	 * @since 2.5
+	 *
+	 * @param SemanticData $semanticData
+	 */
+	public function setSemanticData( SemanticData $semanticData ) {
+		$this->semanticData = $semanticData;
+	}
+
+	/**
+	 * @since 2.5
+	 *
+	 * @param DIProperty $property
+	 *
+	 * @return array|null
+	 */
+	public function checkOn( DIProperty $property ) {
+
+		if ( $this->semanticData === null ) {
+			$this->semanticData = $this->store->getSemanticData( $property->getCanonicalDiWikiPage() );
+		}
+
+		$type = $property->findPropertyTypeID();
+		$this->dataItemFactory = new DataItemFactory();
+
+		if ( !$property->isUserDefined() ) {
+			return $this->checkOnTypeForPredefinedProperty( $property );
+		}
+
+		if ( $type === '_ref_rec' || $type === '_rec' ) {
+			return $this->checkOnFieldList( $property );
+		}
+
+		if ( $type === '_eid' ) {
+			return $this->checkOnExternalFormatterUri( $property );
+		}
+	}
+
+	/**
+	 * A violation occurs when a predefined property contains a `Has type` annotation
+	 * that is incompatible with the default type.
+	 */
+	private function checkOnTypeForPredefinedProperty( $property ) {
+
+		if ( !$this->semanticData->hasProperty( $this->dataItemFactory->newDIProperty( '_TYPE' ) ) ) {
+			return;
+		}
+
+		$typeValues = $this->semanticData->getPropertyValues(
+			$this->dataItemFactory->newDIProperty( '_TYPE' )
+		);
+
+		if ( $typeValues !== array() ) {
+			list( $url, $type ) = explode( "#", end( $typeValues )->getSerialization() );
+		}
+
+		if ( $type === $property->findPropertyTypeID() ) {
+			return;
+		}
+
+		$prop = $this->dataItemFactory->newDIProperty( $type );
+
+		return array(
+			'smw-property-req-violation-predefined-type',
+			$property->getCanonicalLabel(),
+			$prop->getCanonicalLabel()
+		);
+	}
+
+	/**
+	 * A violation occurs when a Reference or Record typed property does not denote
+	 * a `Has fields` declaration.
+	 */
+	private function checkOnFieldList( $property ) {
+
+		if ( $this->semanticData->hasProperty( $this->dataItemFactory->newDIProperty( '_LIST' ) ) ) {
+			return;
+		}
+
+		$prop = $this->dataItemFactory->newDIProperty( $property->findPropertyTypeID() );
+
+		return array(
+			'smw-property-req-violation-missing-fields',
+			$property->getLabel(),
+			$prop->getCanonicalLabel()
+		);
+	}
+
+	/**
+	 * A violation occurs when the External Identifier typed property does not declare
+	 * a `External formatter URI` declaration.
+	 */
+	private function checkOnExternalFormatterUri( $property ) {
+
+		if ( $this->semanticData->hasProperty( $this->dataItemFactory->newDIProperty( '_PEFU' ) ) ) {
+			return;
+		}
+
+		return array(
+			'smw-property-req-violation-missing-formatter-uri',
+			$property->getLabel()
+		);
+	}
+
+}

--- a/tests/phpunit/Unit/Content/PropertyPageMessageHtmlBuilderTest.php
+++ b/tests/phpunit/Unit/Content/PropertyPageMessageHtmlBuilderTest.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace SMW\Tests\Content;
+
+use SMW\Content\PropertyPageMessageHtmlBuilder;
+use SMW\DataItemFactory;
+
+/**
+ * @covers \SMW\Content\PropertyPageMessageHtmlBuilder
+ * @group semantic-mediawiki
+ *
+ * @license GNU GPL v2+
+ * @since 2.5
+ *
+ * @author mwjames
+ */
+class PropertyPageMessageHtmlBuilderTest extends \PHPUnit_Framework_TestCase {
+
+	private $store;
+	private $propertySpecificationReqExaminer;
+
+	protected function setUp() {
+		parent::setUp();
+
+		$propertyTableInfoFetcher = $this->getMockBuilder( '\SMW\SQLStore\PropertyTableInfoFetcher' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$this->store = $this->getMockBuilder( '\SMW\SQLStore\SQLStore' )
+			->disableOriginalConstructor()
+			->setMethods( array( 'getPropertyTableInfoFetcher' ) )
+			->getMockForAbstractClass();
+
+		$this->store->expects( $this->any() )
+			->method( 'getPropertyTableInfoFetcher' )
+			->will( $this->returnValue( $propertyTableInfoFetcher ) );
+
+		$this->propertySpecificationReqExaminer = $this->getMockBuilder( '\SMW\PropertySpecificationReqExaminer' )
+			->disableOriginalConstructor()
+			->getMock();
+	}
+
+	public function testCanConstruct() {
+
+		$this->assertInstanceOf(
+			PropertyPageMessageHtmlBuilder::class,
+			new PropertyPageMessageHtmlBuilder( $this->store, $this->propertySpecificationReqExaminer )
+		);
+	}
+
+	/**
+	 * @dataProvider propertyProvider
+	 */
+	public function testCreateMessageBody( $property ) {
+
+		$instance = new PropertyPageMessageHtmlBuilder(
+			$this->store,
+			$this->propertySpecificationReqExaminer
+		);
+
+		$this->assertInternalType(
+			'string',
+			$instance->createMessageBody( $property )
+		);
+	}
+
+	public function propertyProvider() {
+
+		$dataItemFactory = new DataItemFactory();
+
+		$provider[] = array(
+			$dataItemFactory->newDIProperty( 'Foo' )
+		);
+
+		$provider[] = array(
+			$dataItemFactory->newDIProperty( '_MDAT' )
+		);
+
+		return $provider;
+	}
+
+}

--- a/tests/phpunit/Unit/PropertySpecificationReqExaminerTest.php
+++ b/tests/phpunit/Unit/PropertySpecificationReqExaminerTest.php
@@ -1,0 +1,123 @@
+<?php
+
+namespace SMW\Tests;
+
+use SMW\PropertySpecificationReqExaminer;
+use SMW\DataItemFactory;
+
+/**
+ * @covers \SMW\PropertySpecificationReqExaminer
+ * @group semantic-mediawiki
+ *
+ * @license GNU GPL v2+
+ * @since 2.5
+ *
+ * @author mwjames
+ */
+class PropertySpecificationReqExaminerTest extends \PHPUnit_Framework_TestCase {
+
+	private $store;
+
+	protected function setUp() {
+		parent::setUp();
+
+		$this->store = $this->getMockBuilder( '\SMW\Store' )
+			->disableOriginalConstructor()
+			->getMockForAbstractClass();
+	}
+
+	public function testCanConstruct() {
+
+		$this->assertInstanceOf(
+			PropertySpecificationReqExaminer::class,
+			new PropertySpecificationReqExaminer( $this->store )
+		);
+	}
+
+	/**
+	 * @dataProvider propertyProvider
+	 */
+	public function testCheckOn( $property, $semanticData, $expected ) {
+
+		$instance = new PropertySpecificationReqExaminer(
+			$this->store
+		);
+
+		$instance->setSemanticData( $semanticData );
+
+		$this->assertEquals(
+			$expected,
+			$instance->checkOn( $property )
+		);
+	}
+
+	public function propertyProvider() {
+
+		$dataItemFactory = new DataItemFactory();
+
+		$semanticData = $this->getMockBuilder( '\SMW\SemanticData' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$provider[] = array(
+			$dataItemFactory->newDIProperty( 'Foo' ),
+			$semanticData,
+			''
+		);
+
+		$provider[] = array(
+			$dataItemFactory->newDIProperty( '_MDAT' ),
+			$semanticData,
+			''
+		);
+
+		$semanticData = $this->getMockBuilder( '\SMW\SemanticData' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$semanticData->expects( $this->any() )
+			->method( 'hasProperty' )
+			->will( $this->returnValue( false ) );
+
+		$property = $dataItemFactory->newDIProperty( 'Foo' );
+		$property->setPropertyTypeId( '_ref_rec' );
+
+		$provider[] = array(
+			$property,
+			$semanticData,
+			array(
+				'smw-property-req-violation-missing-fields',
+				'Foo',
+				'Reference'
+			)
+		);
+
+		$property = $dataItemFactory->newDIProperty( 'Foo' );
+		$property->setPropertyTypeId( '_rec' );
+
+		$provider[] = array(
+			$property,
+			$semanticData,
+			array(
+				'smw-property-req-violation-missing-fields',
+				'Foo',
+				'Record'
+			)
+		);
+
+		$property = $dataItemFactory->newDIProperty( 'Foo' );
+		$property->setPropertyTypeId( '_eid' );
+
+		$provider[] = array(
+			$property,
+			$semanticData,
+			array(
+				'smw-property-req-violation-missing-formatter-uri',
+				'Foo'
+			)
+		);
+
+		return $provider;
+	}
+
+}


### PR DESCRIPTION
This PR is made in reference to: #2221 

This PR addresses or contains:

- Show users clear messages on the property page in case some codified requirements (in `PropertySpecificationReqExaminer`) are missing from the property specification
- Move code for the HTML generation to `PropertyPageMessageHtmlBuilder`

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed
