### PR TITLE
Different way to generate the hash in RequestOptions::getHash

### DIFF
--- a/src/CachedPropertyValuesPrefetcher.php
+++ b/src/CachedPropertyValuesPrefetcher.php
@@ -74,9 +74,17 @@ class CachedPropertyValuesPrefetcher {
 	 */
 	public function getPropertyValues( DIWikiPage $subject, DIProperty $property, RequestOptions $requestOptions = null ) {
 
-		$key = $property->getKey() . ':' . $subject->getSubobjectName() . ':' . (
-			$requestOptions !== null ? $requestOptions->getHash() : null
-		);
+		// Items are collected as part of the subject hash so that any request is
+		// stored with that entity identifier allowing it to be evicted entirely
+		// when the subject is changed.
+		//
+		// The key on the other hand represent an individual request identifier
+		// that is stored as part of the overall cache item but making distinct
+		// requests possible, yet is fetched as part of the overall subject to
+		// minimize cache fragmentation and a better eviction strategy.
+		$key = $property->getKey() .
+			':' . $subject->getSubobjectName() .
+			':' . ( $requestOptions !== null ? md5( $requestOptions->getHash() ) : null );
 
 		$container = $this->blobStore->read(
 			$this->getRootHashFrom( $subject )

--- a/src/PropertyHierarchyLookup.php
+++ b/src/PropertyHierarchyLookup.php
@@ -162,7 +162,7 @@ class PropertyHierarchyLookup implements LoggerAwareInterface {
 
 	private function doFind( $id, $key, DIWikiPage $subject, $requestOptions ) {
 
-		$key = $id . '#' . $key . '#' . $requestOptions->getHash();
+		$key = $id . '#' . $key . '#' . md5( $requestOptions->getHash() );
 
 		if ( $this->cache->contains( $key ) ) {
 			return $this->cache->fetch( $key );

--- a/src/RequestOptions.php
+++ b/src/RequestOptions.php
@@ -59,11 +59,16 @@ class RequestOptions {
 	/**
 	 * An array of string conditions that are applied if the result has a
 	 * string label that can be subject to those patterns.
+	 *
+	 * @var StringCondition[]
 	 */
 	private $stringConditions = array();
 
 	/**
-	 * An array extra conditions
+	 * Contains extra conditions which a consumer is being allowed to interpret
+	 * freely to modify a search condition.
+	 *
+	 * @var array
 	 */
 	private $extraConditions = array();
 
@@ -156,14 +161,16 @@ class RequestOptions {
 			$stringConditions .= $stringCondition->getHash();
 		}
 
-		return $this->limit . '#' .
-			$this->offset . '#' .
-			$this->sort . '#' .
-			$this->ascending . '#' .
-			$this->boundary . '#' .
-			$this->include_boundary . '#' .
-			( $stringConditions !== '' ? '|' . $stringConditions : '' );
-			( $this->extraConditions !== array() ? implode( '#', $this->extraConditions ): '' );
+		return json_encode( array(
+			$this->limit,
+			$this->offset,
+			$this->sort,
+			$this->ascending,
+			$this->boundary,
+			$this->include_boundary,
+			$stringConditions,
+			$this->extraConditions
+		) );
 	}
 
 }

--- a/tests/phpunit/Unit/PropertyHierarchyLookupTest.php
+++ b/tests/phpunit/Unit/PropertyHierarchyLookupTest.php
@@ -54,7 +54,7 @@ class PropertyHierarchyLookupTest extends \PHPUnit_Framework_TestCase {
 		$cache->expects( $this->once() )
 			->method( 'save' )
 			->with(
-				$this->equalTo( '_SUBP#Foo#1#0##1##1#' ),
+				$this->equalTo( '_SUBP#Foo#5230d9b41a617ba30fa77223b431507c' ),
 				$this->equalTo( array() ) );
 
 		$instance = new PropertyHierarchyLookup( $store, $cache );
@@ -92,7 +92,7 @@ class PropertyHierarchyLookupTest extends \PHPUnit_Framework_TestCase {
 		$cache->expects( $this->once() )
 			->method( 'save' )
 			->with(
-				$this->equalTo( '_SUBP#Foo#-1#0##1##1#' ),
+				$this->equalTo( '_SUBP#Foo#b3ed5707ed115aa0ef22f567c08c35df' ),
 				$this->anything() );
 
 		$instance = new PropertyHierarchyLookup( $store, $cache );
@@ -134,7 +134,7 @@ class PropertyHierarchyLookupTest extends \PHPUnit_Framework_TestCase {
 		$cache->expects( $this->once() )
 			->method( 'save' )
 			->with(
-				$this->equalTo( '_SUBC#Foo#-1#0##1##1#' ),
+				$this->equalTo( '_SUBC#Foo#b3ed5707ed115aa0ef22f567c08c35df' ),
 				$this->anything() );
 
 		$instance = new PropertyHierarchyLookup( $store, $cache );

--- a/tests/phpunit/Unit/RequestOptionsTest.php
+++ b/tests/phpunit/Unit/RequestOptionsTest.php
@@ -41,7 +41,27 @@ class RequestOptionsTest extends \PHPUnit_Framework_TestCase {
 		}
 
 		$this->assertEquals(
-			'-1#0##1##1#|Foo#0#',
+			'[-1,0,false,true,null,true,"Foo#0#",[]]',
+			$instance->getHash()
+		);
+	}
+
+	public function testEddExtraCondition() {
+
+		$instance = new RequestOptions();
+		$instance->addExtraCondition( 'Foo' );
+		$instance->addExtraCondition( array( 'Bar' => 'Foobar' ) );
+
+		$this->assertEquals(
+			array(
+				'Foo',
+				array( 'Bar' => 'Foobar' )
+			),
+			$instance->getExtraConditions()
+		);
+
+		$this->assertEquals(
+			'[-1,0,false,true,null,true,"",["Foo",{"Bar":"Foobar"}]]',
 			$instance->getHash()
 		);
 	}


### PR DESCRIPTION
This PR is made in reference to: #

This PR addresses or contains:

- Requires a different method to ensure `extraConditions` field is appropriately recognized and accounted for

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed
