### PR TITLE
Support for "Is edit protected", refs 2227

### DIFF
--- a/DefaultSettings.php
+++ b/DefaultSettings.php
@@ -1371,4 +1371,27 @@ return array(
 	'smwgQueryResultCacheRefreshOnPurge' => true,
 	##
 
+	###
+	# Protect page edits
+	#
+	# To prevent accidental changes of content especially to those of property
+	# definitions, this setting allows with the help of the `Is edit protected`
+	# property to prevent editing on pages that have annotate the property with
+	# `true`.
+	#
+	# Once the property is set, only users with the listed user right are able
+	# to edit and/or revoke the restriction on the selected page.
+	#
+	# `smw-pageedit` has been deployed as extra right to be distinct from existing
+	# edit protections
+	#
+	# To enable this functionality either assign `smw-pageedit` or any other
+	# right to the variable to activate an edit protection.
+	#
+	# @since 2.5
+	# @default false
+	##
+	'smwgEditProtectionRight' => false,
+	##
+
 );

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -338,6 +338,7 @@
 	"smw-qp-empty-data": "Requested data could not be displayed due to some insufficient selection criteria.",
 	"right-smw-admin": "Access administration tasks (Semantic MediaWiki)",
 	"right-smw-patternedit": "Edit access to maintain allowed regular expressions and patterns (Semantic MediaWiki)",
+	"right-smw-pageedit": "Edit access for <code>Is edit protected</code> annotated pages (Semantic MediaWiki)",
 	"action-smw-patternedit": "edit regular expressions used by Semantic MediaWiki",
 	"group-smwadministrator": "Administrators (Semantic MediaWiki)",
 	"group-smwadministrator-member": "{{GENDER:$1|administrator (Semantic MediaWiki)}}",
@@ -494,5 +495,10 @@
 	"smw-no-data-available": "No data available.",
 	"smw-property-req-violation-missing-fields": "Property \"$1\" is missing declaration details for the annotated \"$2\" type by failing to define the <code>Has fields</code> property.",
 	"smw-property-req-violation-missing-formatter-uri": "Property \"$1\" is missing declaration details for the annotated type by failing to define the <code>External formatter URI</code> property.",
-	"smw-property-req-violation-predefined-type": "Property \"$1\" as predefined property contains a \"$2\" type declaration that is incompatible with the default type of this property."
+	"smw-property-req-violation-predefined-type": "Property \"$1\" as predefined property contains a \"$2\" type declaration that is incompatible with the default type of this property.",
+	"smw-pageedit-protection": "This page is [[Property:Is edit protected|protected]] to prevent accidental data modification and therefore can only be edited by users with the appropriate \"$1\" [https://www.semantic-mediawiki.org/wiki/Help:User_rights_and_user_groups right].",
+	"smw-pageedit-protection-disabled": "The edit protection has been disbled therefore \"$1\" cannot be used to protect entity pages from unauthorized editing.",
+	"smw-patternedit-protection": "This page is protected and can only be edited by users with the appropriate <code>smw-patternedit</code> [https://www.semantic-mediawiki.org/wiki/Help:Permissions permission].",
+	"smw-pa-property-predefined_edip": "\"$1\" is a predefined property provided by [https://www.semantic-mediawiki.org/wiki/Help:Special_properties Semantic MediaWiki] to indicate whether editing is protected or not.",
+	"smw-pa-property-predefined-long_edip": "While any user is qualified to add this property to a subject, only a user with a dedicated permission can edit or revoke the protection to an entity after it has been added."
 }

--- a/i18n/extra/en.json
+++ b/i18n/extra/en.json
@@ -87,7 +87,8 @@
 		"_PVUC": "Has uniqueness constraint",
 		"_PEID": "External identifier",
 		"_PEFU": "External formatter URI",
-		"_PPLB": "Has preferred property label"
+		"_PPLB": "Has preferred property label",
+		"_EDIP": "Is edit protected"
 	},
 	"propertyAliases": {
 		"Display unit": "_UNIT",
@@ -132,7 +133,9 @@
 		"External formatter URI": "_PEFU",
 		"External formatter uri": "_PEFU",
 		"External formatter URL": "_PEFU",
-		"Preferred property label": "_PPLB"
+		"Preferred property label": "_PPLB",
+		"Is edit protected": "_EDIP",
+		"IsEditProtected": "_EDIP"
 	},
 	"namespaces":{
 		"SMW_NS_PROPERTY": "Property",

--- a/includes/Settings.php
+++ b/includes/Settings.php
@@ -161,6 +161,7 @@ class Settings extends Options {
 			'smwgQueryResultCacheLifetime' => $GLOBALS['smwgQueryResultCacheLifetime'],
 			'smwgQueryResultNonEmbeddedCacheLifetime' => $GLOBALS['smwgQueryResultNonEmbeddedCacheLifetime'],
 			'smwgQueryResultCacheRefreshOnPurge' => $GLOBALS['smwgQueryResultCacheRefreshOnPurge'],
+			'smwgEditProtectionRight' => $GLOBALS['smwgEditProtectionRight'],
 		);
 
 		\Hooks::run( 'SMW::Config::BeforeCompletion', array( &$configuration ) );

--- a/includes/Setup.php
+++ b/includes/Setup.php
@@ -237,6 +237,7 @@ final class Setup {
 		// Rights
 		$this->globalVars['wgAvailableRights'][] = 'smw-admin';
 		$this->globalVars['wgAvailableRights'][] = 'smw-patternedit';
+		$this->globalVars['wgAvailableRights'][] = 'smw-pageedit';
 
 		// User group rights
 		if ( !isset( $this->globalVars['wgGroupPermissions']['sysop']['smw-admin'] ) ) {
@@ -245,6 +246,10 @@ final class Setup {
 
 		if ( !isset( $this->globalVars['wgGroupPermissions']['smwcurator']['smw-patternedit'] ) ) {
 			$this->globalVars['wgGroupPermissions']['smwcurator']['smw-patternedit'] = true;
+		}
+
+		if ( !isset( $this->globalVars['wgGroupPermissions']['smwcurator']['smw-pageedit'] ) ) {
+			$this->globalVars['wgGroupPermissions']['smwcurator']['smw-pageedit'] = true;
 		}
 
 		if ( !isset( $this->globalVars['wgGroupPermissions']['smwadministrator']['smw-admin'] ) ) {

--- a/includes/articlepages/SMW_PropertyPage.php
+++ b/includes/articlepages/SMW_PropertyPage.php
@@ -91,9 +91,21 @@ class SMWPropertyPage extends SMWOrderedListPage {
 	 */
 	protected function getIntroductoryText() {
 
+		$propertySpecificationReqExaminer = new PropertySpecificationReqExaminer(
+			$this->store
+		);
+
+		$propertySpecificationReqExaminer->setEditProtectionRight(
+			ApplicationFactory::getInstance()->getSettings()->get( 'smwgEditProtectionRight' )
+		);
+
 		$propertyPageMessageHtmlBuilder = new PropertyPageMessageHtmlBuilder(
 			$this->store,
-			new PropertySpecificationReqExaminer( $this->store )
+			$propertySpecificationReqExaminer
+		);
+
+		$propertyPageMessageHtmlBuilder->hasEditProtection(
+			ApplicationFactory::getInstance()->singleton( 'EditProtectionValidator' )->hasEditProtection( $this->mTitle )
 		);
 
 		return $propertyPageMessageHtmlBuilder->createMessageBody( $this->mProperty );

--- a/src/Content/PropertyPageMessageHtmlBuilder.php
+++ b/src/Content/PropertyPageMessageHtmlBuilder.php
@@ -28,6 +28,11 @@ class PropertyPageMessageHtmlBuilder {
 	private $propertySpecificationReqExaminer;
 
 	/**
+	 * @var boolean
+	 */
+	private $hasEditProtection = false;
+
+	/**
 	 * @since 2.5
 	 *
 	 * @param Store $store
@@ -36,6 +41,15 @@ class PropertyPageMessageHtmlBuilder {
 	public function __construct( Store $store, PropertySpecificationReqExaminer $propertySpecificationReqExaminer ) {
 		$this->store = $store;
 		$this->propertySpecificationReqExaminer = $propertySpecificationReqExaminer;
+	}
+
+	/**
+	 * @since 2.5
+	 *
+	 * @param boolean $hasEditLock
+	 */
+	public function hasEditProtection( $hasEditProtection ) {
+		$this->hasEditProtection = $hasEditProtection;
 	}
 
 	/**
@@ -54,6 +68,10 @@ class PropertyPageMessageHtmlBuilder {
 		$message = $this->createReqViolationMessage(
 			$this->propertySpecificationReqExaminer->checkOn( $property )
 		);
+
+		if ( $this->hasEditProtection ) {
+			$message .= $this->createEditProtectionMessage( $propertyName );
+		}
 
 		if ( wfMessage( 'smw-property-introductory-message' )->exists() ) {
 			$message .= $this->createIntroductoryMessage( $propertyName );
@@ -74,12 +92,27 @@ class PropertyPageMessageHtmlBuilder {
 			return '';
 		}
 
+		$type = array_shift( $violationMessage );
+
 		return Html::rawElement(
 			'div',
 			array(
-				'class' => 'plainlinks smw-callout smw-callout-error'
+				'id' => 'smw-property-content-violation-message',
+				'class' => 'plainlinks ' . ( $type !== '' ? 'smw-callout smw-callout-'. $type : '' )
 			),
 			call_user_func_array( 'wfMessage', $violationMessage )->parse()
+		);
+	}
+
+	private function createEditProtectionMessage( $propertyName ) {
+
+		return Html::rawElement(
+			'div',
+			array(
+				'id' => 'smw-property-content-editprotection-message',
+				'class' => 'plainlinks smw-callout smw-callout-warning'
+			),
+			wfMessage( 'smw-pageedit-protection', $GLOBALS['smwgEditProtectionRight'] )->parse()
 		);
 	}
 
@@ -87,6 +120,7 @@ class PropertyPageMessageHtmlBuilder {
 		return Html::rawElement(
 			'div',
 			array(
+				'id' => 'smw-property-content-intro-message',
 				'class' => 'plainlinks smw-callout smw-callout-info'
 			),
 			wfMessage( 'smw-property-introductory-message', $propertyName )->parse()
@@ -97,6 +131,7 @@ class PropertyPageMessageHtmlBuilder {
 		return Html::rawElement(
 			'div',
 			array(
+				'id' => 'smw-property-content-fixedtable-message',
 				'class' => 'plainlinks smw-callout smw-callout-info'
 			),
 			wfMessage( 'smw-property-userdefined-fixedtable', $propertyName )->parse()
@@ -141,6 +176,7 @@ class PropertyPageMessageHtmlBuilder {
 		return Html::rawElement(
 			'div',
 			array(
+				'id' => 'smw-property-content-predefined-message',
 				'class' => 'smw-property-predefined-intro plainlinks'
 			),
 			$message

--- a/src/EditProtectionValidator.php
+++ b/src/EditProtectionValidator.php
@@ -1,0 +1,138 @@
+<?php
+
+namespace SMW;
+
+use Onoi\Cache\Cache;
+use Title;
+
+/**
+ * Handles edit protection validation on the basis of an annotated `Is edit protected`
+ * property value assignment.
+ *
+ * The lookup is cached using the `CachedPropertyValuesPrefetcher` to avoid a
+ * continued access to the Store or DB layer.
+ *
+ * @license GNU GPL v2+
+ * @since 2.5
+ *
+ * @author mwjames
+ */
+class EditProtectionValidator {
+
+	/**
+	 * Reference used in InMemoryPoolCache
+	 */
+	const POOLCACHE_ID = 'edit.protection.manager';
+
+	/**
+	 * @var CachedPropertyValuesPrefetcher
+	 */
+	private $cachedPropertyValuesPrefetcher;
+
+	/**
+	 * @var Cache
+	 */
+	private $intermediaryMemoryCache;
+
+	/**
+	 * @var boolean
+	 */
+	private $editProtectionRight = false;
+
+	/**
+	 * @since 2.5
+	 *
+	 * @param CachedPropertyValuesPrefetcher $cachedPropertyValuesPrefetcher
+	 * @param Cache $intermediaryMemoryCache
+	 */
+	public function __construct( CachedPropertyValuesPrefetcher $cachedPropertyValuesPrefetcher, Cache $intermediaryMemoryCache ) {
+		$this->cachedPropertyValuesPrefetcher = $cachedPropertyValuesPrefetcher;
+		$this->intermediaryMemoryCache = $intermediaryMemoryCache;
+	}
+
+	/**
+	 * @since 2.5
+	 *
+	 * @param string|boolean $editProtectionRight
+	 */
+	public function setEditProtectionRight( $editProtectionRight ) {
+		$this->editProtectionRight = $editProtectionRight;
+	}
+
+	/**
+	 * @since 2.5
+	 *
+	 * @param DIWikiPage $subject
+	 */
+	public function resetCacheBy( DIWikiPage $subject ) {
+		$this->cachedPropertyValuesPrefetcher->resetCacheBy( $subject );
+	}
+
+	/**
+	 * @since 2.5
+	 *
+	 * @param Title $title
+	 *
+	 * @return boolean
+	 */
+	public function hasProtectionOnNamespace( Title $title ) {
+		return $this->checkProtection( DIWikiPage::newFromTitle( $title )->asBase() );
+	}
+
+	/**
+	 * @since 2.5
+	 *
+	 * @param Title $title
+	 *
+	 * @return boolean
+	 */
+	public function hasProtection( Title $title ) {
+		return $this->checkProtection( DIWikiPage::newFromTitle( $title )->asBase() );
+	}
+
+	/**
+	 * @note There is not direct validation of the permission in this methods,
+	 * it is done by the Title::userCan when probing against the User and hooks
+	 * that carry our the permission check including the validation provided by
+	 * SMW's `PermissionPthValidator`.
+	 *
+	 * @since 2.5
+	 *
+	 * @param Title $title
+	 *
+	 * @return boolean
+	 */
+	public function hasEditProtection( Title $title ) {
+		return !$title->userCan( 'edit' ) && $this->checkProtection( DIWikiPage::newFromTitle( $title )->asBase() );
+	}
+
+	private function checkProtection( $subject ) {
+
+		$key = $subject->getHash();
+		$hasProtection = false;
+
+		if ( $this->intermediaryMemoryCache->contains( $key ) ) {
+			return $this->intermediaryMemoryCache->fetch( $key );
+		}
+
+		// Set editProtectionRight to influence the key to detect changes
+		// before the cache is evicted
+		$requestOptions = new RequestOptions();
+		$requestOptions->addExtraCondition( $this->editProtectionRight );
+
+		$dataItems = $this->cachedPropertyValuesPrefetcher->getPropertyValues(
+			$subject,
+			new DIProperty( '_EDIP' ),
+			$requestOptions
+		);
+
+		if ( $dataItems !== null && $dataItems !== array() ) {
+			$hasProtection = end( $dataItems )->getBoolean();
+		}
+
+		$this->intermediaryMemoryCache->save( $key, $hasProtection );
+
+		return $hasProtection;
+	}
+
+}

--- a/src/MediaWiki/Hooks/HookRegistry.php
+++ b/src/MediaWiki/Hooks/HookRegistry.php
@@ -121,7 +121,13 @@ class HookRegistry {
 			$GLOBALS['wgDBtype'] === 'sqlite'
 		);
 
-		$permissionPthValidator = new PermissionPthValidator();
+		$permissionPthValidator = new PermissionPthValidator(
+			$applicationFactory->singleton( 'EditProtectionValidator' )
+		);
+
+		$permissionPthValidator->setEditProtectionRight(
+			$applicationFactory->getSettings()->get( 'smwgEditProtectionRight' )
+		);
 
 		/**
 		 * Hook: ParserAfterTidy to add some final processing to the fully-rendered page output
@@ -483,10 +489,14 @@ class HookRegistry {
 		};
 
 		/**
-		 * @see https://www.mediawiki.org/wiki/Manual:Hooks/userCan
+		 * @see https://www.mediawiki.org/wiki/Manual:Hooks/TitleQuickPermissions
+		 *
+		 * "...Quick permissions are checked first in the Title::checkQuickPermissions
+		 * function. Quick permissions are the most basic of permissions needed
+		 * to perform an action ..."
 		 */
-		$this->handlers['userCan'] = function ( &$title, &$user, $action, &$result ) use ( $permissionPthValidator ) {
-			return $permissionPthValidator->checkUserCanPermissionFor( $title, $user, $action, $result );
+		$this->handlers['TitleQuickPermissions'] = function ( $title, $user, $action, &$errors, $rigor, $short ) use ( $permissionPthValidator ) {
+			return $permissionPthValidator->checkQuickPermissionOn( $title, $user, $action, $errors );
 		};
 
 		$this->registerHooksForInternalUse( $applicationFactory, $deferredRequestDispatchManager );

--- a/src/PermissionPthValidator.php
+++ b/src/PermissionPthValidator.php
@@ -4,6 +4,7 @@ namespace SMW;
 
 use Title;
 use User;
+use SMW\MediaWiki\PageProtectionManager;
 
 /**
  * @license GNU GPL v2+
@@ -14,40 +15,100 @@ use User;
 class PermissionPthValidator {
 
 	/**
+	 * @var EditProtectionValidator
+	 */
+	private $editProtectionValidator;
+
+	/**
+	 * @var string|false
+	 */
+	private $editProtectionRight = false;
+
+	/**
+	 * @since 2.5
+	 *
+	 * @param EditProtectionValidator $editProtectionValidator
+	 */
+	public function __construct( EditProtectionValidator $editProtectionValidator ) {
+		$this->editProtectionValidator = $editProtectionValidator;
+	}
+
+	/**
+	 * @since 2.5
+	 *
+	 * @param string|false $editProtectionRight
+	 */
+	public function setEditProtectionRight( $editProtectionRight ) {
+		$this->editProtectionRight = $editProtectionRight;
+	}
+
+	/**
+	 * @since 2.5
+	 *
+	 * @param Title &$title
+	 * @param User $user
+	 * @param string $action
+	 * @param array &$errors
+	 *
+	 * @return boolean
+	 */
+	public function checkQuickPermissionOn( Title &$title, User $user, $action, &$errors ) {
+		return $this->checkUserPermissionOn( $title, $user, $action, $errors );
+	}
+
+	/**
 	 * @since 2.4
 	 *
 	 * @param Title &$title
 	 * @param User $user
 	 * @param string $action
-	 * @param boolean &$result
+	 * @param array &$errors
 	 *
 	 * @return boolean
 	 */
-	public function checkUserCanPermissionFor( Title &$title, User $user, $action, &$result ) {
+	public function checkUserPermissionOn( Title &$title, User $user, $action, &$errors ) {
 
-		if ( $title->getNamespace() === NS_MEDIAWIKI &&
-			 !$this->checkMwNamespaceEditPermission( $title, $user, $action, $result ) ) {
-			return false;
+		if ( $action !== 'edit' && $action !== 'delete' && $action !== 'move' ) {
+			return true;
+		}
+
+		if ( $title->getNamespace() === NS_MEDIAWIKI ) {
+			return $this->checkMwNamespaceEditPermission( $title, $user, $action, $errors );
+		}
+
+		if ( !$title->exists() ) {
+			return true;
+		}
+
+		if ( $this->editProtectionRight && $this->editProtectionValidator->hasProtectionOnNamespace( $title ) ) {
+			return $this->checkPermissionOn( $title, $user, $action, $errors );
 		}
 
 		return true;
 	}
 
-	private function checkMwNamespaceEditPermission( Title &$title, User $user, $action, &$result ) {
+	private function checkMwNamespaceEditPermission( Title &$title, User $user, $action, &$errors ) {
 
-		if ( $action !== 'edit' ) {
+		// @see https://www.semantic-mediawiki.org/wiki/Help:Special_property_Allows_pattern
+		if ( $title->getDBKey() !== 'Smw_allows_pattern' || $user->isAllowed( 'smw-patternedit' ) ) {
 			return true;
 		}
 
-		// @see https://www.semantic-mediawiki.org/wiki/Help:Special_property_Allows_pattern
-		// User should not be allowed to proceed and later functions (chain hook
-		// execution) are not consulted
-		if ( $title->getDBKey() === 'Smw_allows_pattern' ) {
-			$result = false;
-			return $user->isAllowed( 'smw-patternedit' );
+		$errors[] = array( 'smw-patternedit-protection', 'smw-patternedit' );
+
+		return false;
+	}
+
+	private function checkPermissionOn( Title &$title, User $user, $action, &$errors ) {
+
+		// @see https://www.semantic-mediawiki.org/wiki/Help:Special_property_Is_edit_protected
+		if ( !$this->editProtectionValidator->hasProtection( $title ) || $user->isAllowed( $this->editProtectionRight ) ) {
+			return true;
 		}
 
-		return true;
+		$errors[] = array( 'smw-pageedit-protection', $this->editProtectionRight );
+
+		return false;
 	}
 
 }

--- a/src/PropertyRegistry.php
+++ b/src/PropertyRegistry.php
@@ -456,6 +456,7 @@ class PropertyRegistry {
 			'_MDAT'  => array( '_dat', false, false ), // "modification date"
 			'_CDAT'  => array( '_dat', false, false ), // "creation date"
 			'_NEWP'  => array( '_boo', false, false ), // "is a new page"
+			'_EDIP'  => array( '_boo', true, true ), // "is edit protected"
 			'_LEDT'  => array( '_wpg', false, false ), // "last editor is"
 			'_ERRC'  => array( '__sob', false, false ), // "has error"
 			'_ERRT'  => array( '__errt', false, false ), // "has error text"

--- a/src/PropertySpecificationReqExaminer.php
+++ b/src/PropertySpecificationReqExaminer.php
@@ -34,6 +34,11 @@ class PropertySpecificationReqExaminer {
 	private $dataItemFactory;
 
 	/**
+	 * @var boolean
+	 */
+	private $editProtectionRight = false;
+
+	/**
 	 * @since 2.5
 	 *
 	 * @param Store $store
@@ -50,6 +55,15 @@ class PropertySpecificationReqExaminer {
 	 */
 	public function setSemanticData( SemanticData $semanticData ) {
 		$this->semanticData = $semanticData;
+	}
+
+	/**
+	 * @since 2.5
+	 *
+	 * @param string|boolean $editProtectionRight
+	 */
+	public function setEditProtectionRight( $editProtectionRight ) {
+		$this->editProtectionRight = $editProtectionRight;
 	}
 
 	/**
@@ -87,6 +101,10 @@ class PropertySpecificationReqExaminer {
 	 */
 	private function checkOnTypeForPredefinedProperty( $property ) {
 
+		if ( $property->getKey() === '_EDIP' ) {
+			return $this->checkOnEditProtectionRight( $property );
+		}
+
 		if ( !$this->semanticData->hasProperty( $this->dataItemFactory->newDIProperty( '_TYPE' ) ) ) {
 			return;
 		}
@@ -106,9 +124,27 @@ class PropertySpecificationReqExaminer {
 		$prop = $this->dataItemFactory->newDIProperty( $type );
 
 		return array(
+			'error',
 			'smw-property-req-violation-predefined-type',
 			$property->getCanonicalLabel(),
 			$prop->getCanonicalLabel()
+		);
+	}
+
+	/**
+	 * Examines whether the setting `smwgEditProtectionRight` contains an appropriate
+	 * value or is disabled in order for the `Is edit protected` property to function.
+	 */
+	private function checkOnEditProtectionRight( $property ) {
+
+		if ( $this->editProtectionRight !== false ) {
+			return;
+		}
+
+		return array(
+			'warning',
+			'smw-pageedit-protection-disabled',
+			$property->getCanonicalLabel()
 		);
 	}
 
@@ -125,6 +161,7 @@ class PropertySpecificationReqExaminer {
 		$prop = $this->dataItemFactory->newDIProperty( $property->findPropertyTypeID() );
 
 		return array(
+			'error',
 			'smw-property-req-violation-missing-fields',
 			$property->getLabel(),
 			$prop->getCanonicalLabel()
@@ -142,6 +179,7 @@ class PropertySpecificationReqExaminer {
 		}
 
 		return array(
+			'error',
 			'smw-property-req-violation-missing-formatter-uri',
 			$property->getLabel()
 		);

--- a/src/SharedCallbackContainer.php
+++ b/src/SharedCallbackContainer.php
@@ -375,6 +375,24 @@ class SharedCallbackContainer implements CallbackContainer {
 		} );
 
 		/**
+		 * @var EditProtectionValidator
+		 */
+		$callbackLoader->registerCallback( 'EditProtectionValidator', function() use ( $callbackLoader ) {
+			$callbackLoader->registerExpectedReturnType( 'EditProtectionValidator', '\SMW\EditProtectionValidator' );
+
+			$editProtectionValidator = new EditProtectionValidator(
+				$callbackLoader->singleton( 'CachedPropertyValuesPrefetcher' ),
+				$callbackLoader->singleton( 'InMemoryPoolCache' )->getPoolCacheById( EditProtectionValidator::POOLCACHE_ID )
+			);
+
+			$editProtectionValidator->setEditProtectionRight(
+				$callbackLoader->singleton( 'Settings' )->get( 'smwgEditProtectionRight' )
+			);
+
+			return $editProtectionValidator;
+		} );
+
+		/**
 		 * @var PropertyHierarchyLookup
 		 */
 		$callbackLoader->registerCallback( 'PropertyHierarchyLookup', function() use ( $callbackLoader ) {

--- a/tests/phpunit/Unit/EditProtectionValidatorTest.php
+++ b/tests/phpunit/Unit/EditProtectionValidatorTest.php
@@ -1,0 +1,119 @@
+<?php
+
+namespace SMW\Tests;
+
+use SMW\EditProtectionValidator;
+use SMW\DataItemFactory;
+
+/**
+ * @covers \SMW\EditProtectionValidator
+ * @group semantic-mediawiki
+ *
+ * @license GNU GPL v2+
+ * @since  2.5
+ *
+ * @author mwjames
+ */
+class EditProtectionValidatorTest extends \PHPUnit_Framework_TestCase {
+
+	private $dataItemFactory;
+	private $cachedPropertyValuesPrefetcher;
+	private $cache;
+
+	protected function setUp() {
+		parent::setUp();
+
+		$this->dataItemFactory = new DataItemFactory();
+
+		$this->cachedPropertyValuesPrefetcher = $this->getMockBuilder( '\SMW\CachedPropertyValuesPrefetcher' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$this->cache = $this->getMockBuilder( '\Onoi\Cache\Cache' )
+			->disableOriginalConstructor()
+			->getMock();
+	}
+
+	public function testCanConstruct() {
+
+		$this->assertInstanceOf(
+			'\SMW\EditProtectionValidator',
+			new EditProtectionValidator( $this->cachedPropertyValuesPrefetcher, $this->cache )
+		);
+	}
+
+	public function testHasProtectionOnNamespace() {
+
+		$subject = $this->dataItemFactory->newDIWikiPage( 'Foo', NS_MAIN, '', 'Bar' );
+		$property = $this->dataItemFactory->newDIProperty( '_EDIP' );
+
+		$this->cache->expects( $this->once() )
+			->method( 'contains' )
+			->will( $this->returnValue( false ) );
+
+		$this->cachedPropertyValuesPrefetcher->expects( $this->once() )
+			->method( 'getPropertyValues' )
+			->with(
+				$this->equalTo( $subject->asBase() ),
+				$this->equalTo( $property ) )
+			->will( $this->returnValue( array( $this->dataItemFactory->newDIBoolean( true ) ) ) );
+
+		$instance = new EditProtectionValidator(
+			$this->cachedPropertyValuesPrefetcher,
+			$this->cache
+		);
+
+		$this->assertTrue(
+			$instance->hasProtectionOnNamespace( $subject->getTitle() )
+		);
+	}
+
+	public function testHasProtection() {
+
+		$subject = $this->dataItemFactory->newDIWikiPage( 'Foo', NS_MAIN, '', 'Bar' );
+		$property = $this->dataItemFactory->newDIProperty( '_EDIP' );
+
+		$this->cache->expects( $this->once() )
+			->method( 'contains' )
+			->will( $this->returnValue( false ) );
+
+		$this->cachedPropertyValuesPrefetcher->expects( $this->once() )
+			->method( 'getPropertyValues' )
+			->with(
+				$this->equalTo( $subject->asBase() ),
+				$this->equalTo( $property ) )
+			->will( $this->returnValue( array( $this->dataItemFactory->newDIBoolean( true ) ) ) );
+
+		$instance = new EditProtectionValidator(
+			$this->cachedPropertyValuesPrefetcher,
+			$this->cache
+		);
+
+		$this->assertTrue(
+			$instance->hasProtection( $subject->getTitle() )
+		);
+	}
+
+	public function testHasProtectionFromCache() {
+
+		$subject = $this->dataItemFactory->newDIWikiPage( 'Foo', NS_MAIN, '', 'Bar' );
+
+		$this->cache->expects( $this->once() )
+			->method( 'contains' )
+			->will( $this->returnValue( true ) );
+
+		$this->cache->expects( $this->once() )
+			->method( 'fetch' )
+			->will( $this->returnValue( false ) );
+
+		$instance = new EditProtectionValidator(
+			$this->cachedPropertyValuesPrefetcher,
+			$this->cache
+		);
+
+		$this->assertFalse(
+			$instance->hasProtection( $subject->getTitle() )
+		);
+	}
+
+}

--- a/tests/phpunit/Unit/MediaWiki/Hooks/HookRegistryTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Hooks/HookRegistryTest.php
@@ -155,7 +155,7 @@ class HookRegistryTest extends \PHPUnit_Framework_TestCase {
 		$this->doTestExecutionForTitleIsMovable( $instance );
 		$this->doTestExecutionForEditPageForm( $instance );
 		$this->doTestExecutionForParserFirstCallInit( $instance );
-		$this->doTestExecutionForUserCan( $instance );
+		$this->doTestExecutionForTitleQuickPermissions( $instance );
 
 		// Usage of registered hooks in/by smw-core
 		//$this->doTestExecutionForSMWStoreDropTables( $instance );
@@ -823,20 +823,20 @@ class HookRegistryTest extends \PHPUnit_Framework_TestCase {
 		);
 	}
 
-	public function doTestExecutionForUserCan( $instance ) {
+	public function doTestExecutionForTitleQuickPermissions( $instance ) {
 
-		$handler = 'userCan';
+		$handler = 'TitleQuickPermissions';
 
-		$title = $this->getMockBuilder( '\Title' )
-			->disableOriginalConstructor()
-			->getMock();
+		$title = $this->title;
 
 		$user = $this->getMockBuilder( '\User' )
 			->disableOriginalConstructor()
 			->getMock();
 
 		$action = '';
-		$result = '';
+		$errors = array();
+		$rigor = '';
+		$short = '';
 
 		$this->assertTrue(
 			$instance->isRegistered( $handler )
@@ -844,7 +844,7 @@ class HookRegistryTest extends \PHPUnit_Framework_TestCase {
 
 		$this->assertThatHookIsExcutable(
 			$instance->getHandlerFor( $handler ),
-			array( &$title, &$user, $action, &$result )
+			array( $title, $user, $action, &$errors, $rigor, $short )
 		);
 	}
 

--- a/tests/phpunit/Unit/PropertySpecificationReqExaminerTest.php
+++ b/tests/phpunit/Unit/PropertySpecificationReqExaminerTest.php
@@ -17,9 +17,12 @@ use SMW\DataItemFactory;
 class PropertySpecificationReqExaminerTest extends \PHPUnit_Framework_TestCase {
 
 	private $store;
+	private $dataItemFactory;
 
 	protected function setUp() {
 		parent::setUp();
+
+		$this->dataItemFactory = new DataItemFactory();
 
 		$this->store = $this->getMockBuilder( '\SMW\Store' )
 			->disableOriginalConstructor()
@@ -47,6 +50,28 @@ class PropertySpecificationReqExaminerTest extends \PHPUnit_Framework_TestCase {
 
 		$this->assertEquals(
 			$expected,
+			$instance->checkOn( $property )
+		);
+	}
+
+	public function testCheckOnEditProtectionRight() {
+
+		$property = $this->dataItemFactory->newDIProperty( '_EDIP' );
+
+		$instance = new PropertySpecificationReqExaminer(
+			$this->store
+		);
+
+		$instance->setEditProtectionRight(
+			false
+		);
+
+		$this->assertEquals(
+			array(
+				'warning',
+				'smw-pageedit-protection-disabled',
+				'Is edit protected'
+			),
 			$instance->checkOn( $property )
 		);
 	}
@@ -86,6 +111,7 @@ class PropertySpecificationReqExaminerTest extends \PHPUnit_Framework_TestCase {
 			$property,
 			$semanticData,
 			array(
+				'error',
 				'smw-property-req-violation-missing-fields',
 				'Foo',
 				'Reference'
@@ -99,6 +125,7 @@ class PropertySpecificationReqExaminerTest extends \PHPUnit_Framework_TestCase {
 			$property,
 			$semanticData,
 			array(
+				'error',
 				'smw-property-req-violation-missing-fields',
 				'Foo',
 				'Record'
@@ -112,6 +139,7 @@ class PropertySpecificationReqExaminerTest extends \PHPUnit_Framework_TestCase {
 			$property,
 			$semanticData,
 			array(
+				'error',
 				'smw-property-req-violation-missing-formatter-uri',
 				'Foo'
 			)

--- a/tests/phpunit/includes/SetupTest.php
+++ b/tests/phpunit/includes/SetupTest.php
@@ -149,6 +149,10 @@ class SetupTest extends \PHPUnit_Framework_TestCase {
 		);
 
 		$this->assertTrue(
+			$config['wgGroupPermissions']['smwcurator']['smw-pageedit']
+		);
+
+		$this->assertTrue(
 			$config['wgGroupPermissions']['smwadministrator']['smw-admin']
 		);
 	}


### PR DESCRIPTION
This PR is made in reference to: #2227

This PR addresses or contains:

- Adds `Is edit protected` as an administrative property to restrict edit access to an annotated entity (page) to avoid accidental data modification

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed
