### PR TITLE
properly set headers in SpecialSearchByProperty.php

### DIFF
--- a/src/MediaWiki/Specials/SpecialSearchByProperty.php
+++ b/src/MediaWiki/Specials/SpecialSearchByProperty.php
@@ -35,6 +35,7 @@ class SpecialSearchByProperty extends SpecialPage {
 	 */
 	public function execute( $query ) {
 
+		$this->setHeaders();
 		$output = $this->getOutput();
 
 		$output->setPageTitle( $this->msg( 'searchbyproperty' )->text() );


### PR DESCRIPTION
This makes the SpecialPage adhere to stuff like `$wgDefaultRobotPolicy`