### PR TITLE
Add Property/Concept NS to $wgContentNamespaces/$wgNamespacesToBeSearchedDefault

### DIFF
--- a/src/NamespaceManager.php
+++ b/src/NamespaceManager.php
@@ -213,6 +213,24 @@ class NamespaceManager {
 			$smwNamespacesSettings,
 			$this->globalVars['smwgNamespacesWithSemanticLinks']
 		);
+
+		/**
+		 * Allow custom namespaces to be acknowledged as containing useful content
+		 *
+		 * @see https://www.mediawiki.org/wiki/Manual:$wgContentNamespaces
+		 */
+		$this->globalVars['wgContentNamespaces'] = $this->globalVars['wgContentNamespaces'] + array(
+			SMW_NS_PROPERTY,
+			SMW_NS_CONCEPT
+		);
+
+		/**
+		 * To indicate which namespaces are enabled for searching by default
+		 *
+		 * @see https://www.mediawiki.org/wiki/Manual:$wgNamespacesToBeSearchedDefault
+		 */
+		$this->globalVars['wgNamespacesToBeSearchedDefault'][SMW_NS_PROPERTY] = true;
+		$this->globalVars['wgNamespacesToBeSearchedDefault'][SMW_NS_CONCEPT] = true;
 	}
 
 	protected function isDefinedConstant( $constant ) {

--- a/tests/phpunit/Integration/MediaWiki/MWNamespaceCanonicalNameMatchTest.php
+++ b/tests/phpunit/Integration/MediaWiki/MWNamespaceCanonicalNameMatchTest.php
@@ -38,9 +38,10 @@ class MWNamespaceCanonicalNameMatchTest extends \PHPUnit_Framework_TestCase {
 		$default = array(
 			'smwgNamespacesWithSemanticLinks' => array(),
 			'wgNamespacesWithSubpages' => array(),
-			'wgExtraNamespaces'  => array(),
-			'wgNamespaceAliases' => array(),
-			'wgLanguageCode'     => 'en'
+			'wgExtraNamespaces'   => array(),
+			'wgNamespaceAliases'  => array(),
+			'wgContentNamespaces' => array(),
+			'wgLanguageCode'      => 'en'
 		);
 
 		$instance = $this->getMock( '\SMW\NamespaceManager',

--- a/tests/phpunit/Unit/NamespaceManagerTest.php
+++ b/tests/phpunit/Unit/NamespaceManagerTest.php
@@ -45,6 +45,8 @@ class NamespaceManagerTest extends \PHPUnit_Framework_TestCase {
 			'wgNamespacesWithSubpages' => array(),
 			'wgExtraNamespaces'  => array(),
 			'wgNamespaceAliases' => array(),
+			'wgContentNamespaces' => array(),
+			'wgNamespacesToBeSearchedDefault' => array(),
 			'wgLanguageCode'     => 'en'
 		);
 	}
@@ -126,7 +128,8 @@ class NamespaceManagerTest extends \PHPUnit_Framework_TestCase {
 	public function testInitCustomNamespace() {
 
 		$test = array(
-			'wgLanguageCode' => 'en'
+			'wgLanguageCode' => 'en',
+			'wgContentNamespaces' => array()
 		);
 
 		NamespaceManager::initCustomNamespace( $test );


### PR DESCRIPTION
This PR is made in reference to: #

This PR addresses or contains:

- `$wgContentNamespaces` to allow custom namespaces to be acknowledged as containing useful content
- `$wgNamespacesToBeSearchedDefault` to indicate which namespaces are enabled for searching by default

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed
