### PR TITLE
Add `smw-pageedit` to wgRestrictionLevels, refs 2232

### DIFF
--- a/i18n/en.json
+++ b/i18n/en.json
@@ -505,8 +505,11 @@
 	"smw-property-req-violation-missing-fields": "Property \"$1\" is missing declaration details for the annotated \"$2\" type by failing to define the <code>Has fields</code> property.",
 	"smw-property-req-violation-missing-formatter-uri": "Property \"$1\" is missing declaration details for the annotated type by failing to define the <code>External formatter URI</code> property.",
 	"smw-property-req-violation-predefined-type": "Property \"$1\" as predefined property contains a \"$2\" type declaration that is incompatible with the default type of this property.",
+	"protect-level-smw-pageedit":"Allow only users with page edit permission (Semantic MediaWiki)",
 	"smw-edit-protection": "This page is [[Property:Is edit protected|protected]] to prevent accidental data modification and therefore can only be edited by users with the appropriate \"$1\" [https://www.semantic-mediawiki.org/wiki/Help:User_rights_and_user_groups right].",
 	"smw-edit-protection-disabled": "The edit protection has been disabled therefore \"$1\" cannot be used to protect entity pages from unauthorized editing.",
+	"smw-edit-protection-auto-update":"Semantic MediaWiki has updated the protection status according to the `Is edit protected` property.",
+	"smw-edit-protection-enabled":"Edit protection (Semantic MediaWiki)",
 	"smw-patternedit-protection": "This page is protected and can only be edited by users with the appropriate <code>smw-patternedit</code> [https://www.semantic-mediawiki.org/wiki/Help:Permissions permission].",
 	"smw-pa-property-predefined_edip": "\"$1\" is a predefined property provided by [https://www.semantic-mediawiki.org/wiki/Help:Special_properties Semantic MediaWiki] to indicate whether editing is protected or not.",
 	"smw-pa-property-predefined-long_edip": "While any user is qualified to add this property to a subject, only a user with a dedicated permission can edit or revoke the protection to an entity after it has been added."

--- a/includes/Setup.php
+++ b/includes/Setup.php
@@ -255,6 +255,11 @@ final class Setup {
 		if ( !isset( $this->globalVars['wgGroupPermissions']['smwadministrator']['smw-admin'] ) ) {
 			$this->globalVars['wgGroupPermissions']['smwadministrator']['smw-admin'] = true;
 		}
+
+		// Add an additional protection level restricting edit/move/etc
+		if ( ( $editProtectionRight = $this->applicationFactory->getSettings()->get( 'smwgEditProtectionRight' ) ) !== false ) {
+			$this->globalVars['wgRestrictionLevels'][] = $editProtectionRight;
+		}
 	}
 
 	/**

--- a/includes/StoreUpdater.php
+++ b/includes/StoreUpdater.php
@@ -131,6 +131,13 @@ class StoreUpdater {
 
 		$this->addFinalAnnotations( $title, $wikiPage, $revision, $user );
 
+		// In case of a restricted update, only the protection update is required
+		// hence the process bails-out early to avoid unnecessary DB connections
+		// or updates
+		if ( $this->doUpdateEditProtection( $wikiPage, $user ) === true ) {
+			return true;
+		}
+
 		$this->inspectPropertySpecification();
 		$this->doRealUpdate();
 	}
@@ -161,6 +168,18 @@ class StoreUpdater {
 		);
 
 		$propertyAnnotator->addAnnotation();
+	}
+
+	private function doUpdateEditProtection( $wikiPage, $user ) {
+
+		$editProtectionUpdater = $this->applicationFactory->create( 'EditProtectionUpdater',
+			$wikiPage,
+			$user
+		);
+
+		$editProtectionUpdater->doUpdateFrom( $this->semanticData );
+
+		return $editProtectionUpdater->isRestrictedUpdate();
 	}
 
 	/**

--- a/src/MediaWiki/Hooks/ArticleProtectComplete.php
+++ b/src/MediaWiki/Hooks/ArticleProtectComplete.php
@@ -1,0 +1,145 @@
+<?php
+
+namespace SMW\MediaWiki\Hooks;
+
+use SMW\MediaWiki\EditInfoProvider;
+use SMW\Message;
+use Title;
+use SMW\ApplicationFactory;
+use SMW\PropertyAnnotators\EditProtectedPropertyAnnotator;
+
+/**
+ * Occurs after the protect article request has been processed
+ *
+ * @see https://www.mediawiki.org/wiki/Manual:Hooks/ArticleProtectComplete
+ *
+ * @license GNU GPL v2+
+ * @since 2.5
+ *
+ * @author mwjames
+ */
+class ArticleProtectComplete extends HookHandler {
+
+	/**
+	 * Whether the update should be restricted or not. Which means that when
+	 * no other change is required then categorize the update as restricted
+	 * to avoid unnecessary cascading updates.
+	 */
+	const RESTRICTED_UPDATE = 'articleprotectcomplete.restricted.update';
+
+	/**
+	 * @var Title
+	 */
+	private $title;
+
+	/**
+	 * @var EditInfoProvider
+	 */
+	private $editInfoProvider;
+
+	/**
+	 * @var boolean|string
+	 */
+	private $editProtectionRight = false;
+
+	/**
+	 * @since  2.5
+	 *
+	 * @param Title $title
+	 * @param EditInfoProvider $editInfoProvider
+	 */
+	public function __construct( Title $title, EditInfoProvider $editInfoProvider ) {
+		parent::__construct();
+		$this->title = $title;
+		$this->editInfoProvider = $editInfoProvider;
+	}
+
+	/**
+	 * @since 2.5
+	 *
+	 * @param string|boolean $editProtectionRight
+	 */
+	public function setEditProtectionRight( $editProtectionRight ) {
+		$this->editProtectionRight = $editProtectionRight;
+	}
+
+	/**
+	 * @since 2.5
+	 *
+	 * @param array $protections
+	 * @param string $reason
+	 */
+	public function process( $protections, $reason ) {
+
+		if ( Message::get( 'smw-edit-protection-auto-update' ) === $reason ) {
+			return $this->log( __METHOD__ . ' No changes required, invoked by own process!' );
+		}
+
+		$this->editInfoProvider->fetchEditInfo();
+
+		$output = $this->editInfoProvider->getOutput();
+
+		if ( $output === null ) {
+			return $this->log( __METHOD__ . ' Missing ParserOutput!' );
+		}
+
+		$parserData = ApplicationFactory::getInstance()->newParserData(
+			$this->title,
+			$output
+		);
+
+		$this->doPrepareData( $protections, $parserData );
+		$parserData->setOrigin( 'ArticleProtectComplete' );
+
+		$parserData->updateStore(
+			true
+		);
+	}
+
+	private function doPrepareData( $protections, $parserData ) {
+
+		$isRestrictedUpdate = true;
+		$isAnnotationBySystem = false;
+
+		$property = $this->dataItemFactory->newDIProperty( '_EDIP' );
+
+		$dataItems = $parserData->getSemanticData()->getPropertyValues( $property );
+		$dataItem = end( $dataItems );
+
+		if ( $dataItem ) {
+			$isAnnotationBySystem = $dataItem->getOption( EditProtectedPropertyAnnotator::SYSTEM_ANNOTATION );
+		}
+
+		// No _EDIP annotation but a selected protection matches the
+		// `EditProtectionRight` setting
+		if ( !$dataItem && isset( $protections['edit'] ) && $protections['edit'] === $this->editProtectionRight ) {
+			$this->log( 'ArticleProtectComplete addProperty `Is edit protected`' );
+
+			$isRestrictedUpdate = false;
+			$parserData->getSemanticData()->addPropertyObjectValue(
+				$property,
+				$this->dataItemFactory->newDIBoolean( true )
+			);
+		}
+
+		// _EDIP exists and was set by the EditProtectedPropertyAnnotator (which
+		// means that is has been set by the system and is not a "human" added
+		// annotation) but since the selected protection doesn't match the
+		// `EditProtectionRight` setting, remove the annotation
+		if ( $dataItem && $isAnnotationBySystem && isset( $protections['edit'] ) && $protections['edit'] !== $this->editProtectionRight ) {
+			$this->log( 'ArticleProtectComplete removeProperty `Is edit protected`' );
+
+			$isRestrictedUpdate = false;
+			$parserData->getSemanticData()->removePropertyObjectValue(
+				$property,
+				$this->dataItemFactory->newDIBoolean( true )
+			);
+		}
+
+		$parserData->getSemanticData()->setOption(
+			self::RESTRICTED_UPDATE,
+			$isRestrictedUpdate
+		);
+	}
+
+}

--- a/src/MediaWiki/Hooks/HookRegistry.php
+++ b/src/MediaWiki/Hooks/HookRegistry.php
@@ -243,6 +243,37 @@ class HookRegistry {
 		};
 
 		/**
+		 * Hook: Occurs after the protect article request has been processed
+		 *
+		 * @see https://www.mediawiki.org/wiki/Manual:Hooks/ArticleProtectComplete
+		 */
+		$this->handlers['ArticleProtectComplete'] = function ( &$wikiPage, &$user, $protections, $reason ) use ( $applicationFactory ) {
+
+			$editInfoProvider = new \SMW\MediaWiki\EditInfoProvider(
+				$wikiPage,
+				$wikiPage->getRevision(),
+				$user
+			);
+
+			$articleProtectComplete = new ArticleProtectComplete(
+				$wikiPage->getTitle(),
+				$editInfoProvider
+			);
+
+			$articleProtectComplete->setEditProtectionRight(
+				$applicationFactory->getSettings()->get( 'smwgEditProtectionRight' )
+			);
+
+			$articleProtectComplete->setLogger(
+				$applicationFactory->getMediaWikiLogger()
+			);
+
+			$articleProtectComplete->process( $protections, $reason );
+
+			return true;
+		};
+
+		/**
 		 * Hook: TitleMoveComplete occurs whenever a request to move an article
 		 * is completed
 		 *

--- a/src/MediaWiki/Hooks/ParserAfterTidy.php
+++ b/src/MediaWiki/Hooks/ParserAfterTidy.php
@@ -60,6 +60,7 @@ class ParserAfterTidy {
 		// @see ParserData::setSemanticDataStateToParserOutputProperty
 		if ( $this->parser->getOutput()->getProperty( 'smw-semanticdata-status' ) ||
 			$this->parser->getOutput()->getProperty( 'displaytitle' ) ||
+			$this->parser->getTitle()->isProtected( 'edit' ) ||
 			$this->parser->getOutput()->getCategoryLinks() ||
 			$this->parser->getDefaultSort() ) {
 			return true;
@@ -102,6 +103,16 @@ class ParserAfterTidy {
 
 		$propertyAnnotator = $propertyAnnotatorFactory->newMandatoryTypePropertyAnnotator(
 			$propertyAnnotator
+		);
+
+		$propertyAnnotator = $propertyAnnotatorFactory->newEditProtectedPropertyAnnotator(
+			$propertyAnnotator,
+			$this->parser->getTitle()
+		);
+
+		// Special case! belongs to the EditProtectedPropertyAnnotator instance
+		$propertyAnnotator->addTopIndicatorTo(
+			$this->parser->getOutput()
 		);
 
 		$propertyAnnotator = $propertyAnnotatorFactory->newDisplayTitlePropertyAnnotator(

--- a/src/PermissionPthValidator.php
+++ b/src/PermissionPthValidator.php
@@ -4,7 +4,7 @@ namespace SMW;
 
 use Title;
 use User;
-use SMW\MediaWiki\PageProtectionManager;
+use SMW\Protection\EditProtectionValidator;
 
 /**
  * @license GNU GPL v2+
@@ -68,7 +68,7 @@ class PermissionPthValidator {
 	 */
 	public function checkUserPermissionOn( Title &$title, User $user, $action, &$errors ) {
 
-		if ( $action !== 'edit' && $action !== 'delete' && $action !== 'move' ) {
+		if ( $action !== 'edit' && $action !== 'delete' && $action !== 'move' && $action !== 'upload' ) {
 			return true;
 		}
 

--- a/src/PropertyAnnotatorFactory.php
+++ b/src/PropertyAnnotatorFactory.php
@@ -10,7 +10,9 @@ use SMW\PropertyAnnotators\NullPropertyAnnotator;
 use SMW\PropertyAnnotators\PredefinedPropertyAnnotator;
 use SMW\PropertyAnnotators\RedirectPropertyAnnotator;
 use SMW\PropertyAnnotators\SortKeyPropertyAnnotator;
+use SMW\PropertyAnnotators\EditProtectedPropertyAnnotator;
 use SMW\Store;
+use Title;
 
 /**
  * @license GNU GPL v2+
@@ -66,6 +68,28 @@ class PropertyAnnotatorFactory {
 		);
 
 		return $predefinedPropertyAnnotator;
+	}
+
+	/**
+	 * @since 2.5
+	 *
+	 * @param SemanticData $semanticData
+	 * @param Title $title
+	 *
+	 * @return EditProtectedPropertyAnnotator
+	 */
+	public function newEditProtectedPropertyAnnotator( PropertyAnnotator $propertyAnnotator, Title $title ) {
+
+		$editProtectedPropertyAnnotator = new EditProtectedPropertyAnnotator(
+			$propertyAnnotator,
+			$title
+		);
+
+		$editProtectedPropertyAnnotator->setEditProtectionRight(
+			ApplicationFactory::getInstance()->getSettings()->get( 'smwgEditProtectionRight' )
+		);
+
+		return $editProtectedPropertyAnnotator;
 	}
 
 	/**

--- a/src/PropertyAnnotators/EditProtectedPropertyAnnotator.php
+++ b/src/PropertyAnnotators/EditProtectedPropertyAnnotator.php
@@ -1,0 +1,159 @@
+<?php
+
+namespace SMW\PropertyAnnotators;
+
+use SMW\PropertyAnnotator;
+use ParserOutput;
+use SMW\Message;
+use Title;
+use Html;
+
+/**
+ * @license GNU GPL v2+
+ * @since 2.5
+ *
+ * @author mwjames
+ */
+class EditProtectedPropertyAnnotator extends PropertyAnnotatorDecorator {
+
+	/**
+	 * Indicates whether the annotation was maintained by
+	 * the system or not.
+	 */
+	const SYSTEM_ANNOTATION = 'editprotectedpropertyannotator.system.annotation';
+
+	/**
+	 * @var Title
+	 */
+	private $title;
+
+	/**
+	 * @var boolean
+	 */
+	private $editProtectionRight = false;
+
+	/**
+	 * @since 1.9
+	 *
+	 * @param PropertyAnnotator $propertyAnnotator
+	 * @param Title $title
+	 */
+	public function __construct( PropertyAnnotator $propertyAnnotator, Title $title ) {
+		parent::__construct( $propertyAnnotator );
+		$this->title = $title;
+	}
+
+	/**
+	 * @since 2.5
+	 *
+	 * @param string|boolean $editProtectionRight
+	 */
+	public function setEditProtectionRight( $editProtectionRight ) {
+		$this->editProtectionRight = $editProtectionRight;
+	}
+
+	/**
+	 * @since 2.5
+	 *
+	 * @param ParserOutput
+	 */
+	public function addTopIndicatorTo( ParserOutput $parserOutput ) {
+
+		if ( $this->editProtectionRight === false ) {
+			return false;
+		}
+
+		// FIXME 3.0; Only MW 1.25+ (ParserOutput::setIndicator)
+		if ( !method_exists( $parserOutput, 'setIndicator' ) ) {
+			return false;
+		}
+
+		$property = $this->dataItemFactory->newDIProperty( '_EDIP' );
+
+		if ( !$this->isEnabledProtection( $property ) && !$this->hasEditProtection() ) {
+			return;
+		}
+
+		$html = Html::rawElement(
+			'div',
+			array(
+				'class' => 'smw-edit-protection',
+				'title' => Message::get( 'smw-edit-protection-enabled' )
+			), ''
+		);
+
+		$parserOutput->setIndicator(
+			'smw-protection-indicator',
+			Html::rawElement( 'div', array( 'class' => 'smw-protection-indicator' ), $html )
+		);
+	}
+
+	/**
+	 * @see PropertyAnnotatorDecorator::addPropertyValues
+	 */
+	protected function addPropertyValues() {
+
+		if ( $this->editProtectionRight === false ) {
+			return false;
+		}
+
+		$property = $this->dataItemFactory->newDIProperty( '_EDIP' );
+
+		if ( $this->getSemanticData()->hasProperty( $property ) || !$this->hasEditProtection() ) {
+			return;
+		}
+
+		// Notify preceding processes that this property is set as part of the
+		// protection restriction detection in order to decide whether this
+		// property was added manually or by the system
+		$dataItem = $this->dataItemFactory->newDIBoolean( true );
+		$dataItem->setOption( self::SYSTEM_ANNOTATION, true );
+
+		// Since edit protection is active, add the property as indicator this is
+		// especially to retain the status when purging a page
+		$this->getSemanticData()->addPropertyObjectValue(
+			$property,
+			$dataItem
+		);
+	}
+
+	private function hasEditProtection() {
+
+		//$this->title->flushRestrictions();
+
+		if ( !$this->title->isProtected( 'edit' ) ) {
+			return false;
+		}
+
+		$restrictions = array_flip( $this->title->getRestrictions( 'edit' ) );
+
+		// There could by any edit protections but the `Is edit protected` is
+		// bound to the `smwgEditProtectionRight` setting
+		return isset( $restrictions[$this->editProtectionRight] );
+	}
+
+	private function isEnabledProtection( $property ) {
+
+		if ( !$this->getSemanticData()->hasProperty( $property ) ) {
+			return false;
+		}
+
+		$semanticData = $this->getSemanticData();
+
+		$dataItems = $semanticData->getPropertyValues( $property );
+		$isEnabledProtection = false;
+
+		// In case of two competing values, true always wins
+		foreach ( $dataItems as $dataItem ) {
+
+			$isEnabledProtection = $dataItem->getBoolean();
+
+			if ( $isEnabledProtection ) {
+				break;
+			}
+		}
+
+		return $isEnabledProtection;
+	}
+
+}

--- a/src/Protection/EditProtectionUpdater.php
+++ b/src/Protection/EditProtectionUpdater.php
@@ -1,0 +1,207 @@
+<?php
+
+namespace SMW\Protection;
+
+use SMW\Message;
+use SMW\SemanticData;
+use SMW\DIProperty;
+use SMW\PropertyAnnotators\EditProtectedPropertyAnnotator;
+use SMW\MediaWiki\Hooks\ArticleProtectComplete;
+use Psr\Log\LoggerInterface;
+use Psr\Log\LoggerAwareInterface;
+use WikiPage;
+use User;
+
+/**
+ * @license GNU GPL v2+
+ * @since 2.5
+ *
+ * @author mwjames
+ */
+class EditProtectionUpdater implements LoggerAwareInterface {
+
+	/**
+	 * @var WikiPage
+	 */
+	private $wikiPage;
+
+	/**
+	 * @var User
+	 */
+	private $user;
+
+	/**
+	 * @var boolean
+	 */
+	private $isRestrictedUpdate = false;
+
+	/**
+	 * @var boolean|string
+	 */
+	private $editProtectionRight = false;
+
+	/**
+	 * LoggerInterface
+	 */
+	private $logger;
+
+	/**
+	 * @since 2.5
+	 *
+	 * @param WikiPage $wikiPage
+	 * @param User|null $user
+	 */
+	public function __construct( WikiPage $wikiPage, User $user = null ) {
+		$this->wikiPage = $wikiPage;
+		$this->user = $user;
+
+		if ( $this->user === null ) {
+			$this->user = $GLOBALS['wgUser'];
+		}
+	}
+
+	/**
+	 * @see LoggerAwareInterface::setLogger
+	 *
+	 * @since 2.5
+	 *
+	 * @param LoggerInterface $logger
+	 */
+	public function setLogger( LoggerInterface $logger ) {
+		$this->logger = $logger;
+	}
+
+	/**
+	 * @since 2.5
+	 *
+	 * @param string|boolean $editProtectionRight
+	 */
+	public function setEditProtectionRight( $editProtectionRight ) {
+		$this->editProtectionRight = $editProtectionRight;
+	}
+
+	/**
+	 * @since 2.5
+	 *
+	 * @return boolean
+	 */
+	public function isRestrictedUpdate() {
+		return $this->isRestrictedUpdate;
+	}
+
+	/**
+	 * @since 2.5
+	 *
+	 * @param SemanticData $semanticData
+	 */
+	public function doUpdateFrom( SemanticData $semanticData ) {
+
+		// Do nothing
+		if ( $this->editProtectionRight === false ) {
+			return;
+		}
+
+		list( $isEditProtected, $isAnnotationBySystem ) = $this->fetchEditProtectedInfo( $semanticData );
+
+		$title = $this->wikiPage->getTitle();
+
+		if ( $title === null ) {
+			return;
+		}
+
+		$restrictions = array_flip( $title->getRestrictions( 'edit' ) );
+
+		// No `Is edit protected` was found and the restriction doesn't contain
+		// a matchable `editProtectionRight`
+		if ( $isEditProtected === null && !isset( $restrictions[$this->editProtectionRight] ) ) {
+			return $this->log( __METHOD__ . ' no update required' );
+		}
+
+		if ( $isEditProtected && !isset( $restrictions[$this->editProtectionRight] ) && !$isAnnotationBySystem ) {
+			return $this->doUpdateRestrictions( $isEditProtected );
+		}
+
+		if ( $isEditProtected && $title->isProtected( 'edit' ) || !$isEditProtected && !$title->isProtected( 'edit' ) ) {
+			return $this->log( __METHOD__ . ' Status already set, no update required' );
+		}
+
+		$this->doUpdateRestrictions( $isEditProtected );
+	}
+
+	private function fetchEditProtectedInfo( $semanticData ) {
+
+		// Whether or not the update was invoked by the ArticleProtectComplete hook
+		$this->isRestrictedUpdate = $semanticData->getOption( ArticleProtectComplete::RESTRICTED_UPDATE ) === true;
+		$property = new DIProperty( '_EDIP' );
+
+		$isEditProtected = null;
+		$isAnnotationBySystem = false;
+
+		$dataItems = $semanticData->getPropertyValues(
+			$property
+		);
+
+		if ( $dataItems !== array() ) {
+			$isEditProtected = false;
+
+			// In case of two competing values, true always wins
+			foreach ( $dataItems as $dataItem ) {
+
+				$isEditProtected = $dataItem->getBoolean();
+
+				if ( $isEditProtected ) {
+					break;
+				}
+			}
+
+			$isAnnotationBySystem = $dataItem->getOption( EditProtectedPropertyAnnotator::SYSTEM_ANNOTATION );
+		}
+
+		return array( $isEditProtected, $isAnnotationBySystem );
+	}
+
+	private function doUpdateRestrictions( $isEditProtected ) {
+
+		$protections = array();
+		$expiry = array();
+
+		if ( $isEditProtected ) {
+			$this->log( __METHOD__ . ' add protection on edit, move' );
+
+			$protections = array(
+				'edit' => $this->editProtectionRight,
+				'move' => $this->editProtectionRight
+			);
+
+			$expiry = array(
+				'edit' => 'infinity',
+				'move' => 'infinity'
+			);
+		} else {
+			$this->log( __METHOD__ . ' remove protection on edit, move' );
+			$protections = array();
+			$expiry = array();
+		}
+
+		$reason = Message::get( 'smw-edit-protection-auto-update' );
+		$cascade = false;
+
+		$status = $this->wikiPage->doUpdateRestrictions(
+			$protections,
+			$expiry,
+			$cascade,
+			$reason,
+			$this->user
+		);
+	}
+
+	private function log( $message, $context = array() ) {
+
+		if ( $this->logger === null ) {
+			return;
+		}
+
+		$this->logger->info( $message, $context );
+	}
+
+}

--- a/src/Protection/EditProtectionValidator.php
+++ b/src/Protection/EditProtectionValidator.php
@@ -1,8 +1,12 @@
 <?php
 
-namespace SMW;
+namespace SMW\Protection;
 
 use Onoi\Cache\Cache;
+use SMW\CachedPropertyValuesPrefetcher;
+use SMW\DIWikiPage;
+use SMW\RequestOptions;
+use SMW\DIProperty;
 use Title;
 
 /**
@@ -22,7 +26,7 @@ class EditProtectionValidator {
 	/**
 	 * Reference used in InMemoryPoolCache
 	 */
-	const POOLCACHE_ID = 'edit.protection.manager';
+	const POOLCACHE_ID = 'edit.protection.validator';
 
 	/**
 	 * @var CachedPropertyValuesPrefetcher
@@ -35,7 +39,7 @@ class EditProtectionValidator {
 	private $intermediaryMemoryCache;
 
 	/**
-	 * @var boolean
+	 * @var boolean|string
 	 */
 	private $editProtectionRight = false;
 

--- a/src/SharedCallbackContainer.php
+++ b/src/SharedCallbackContainer.php
@@ -23,6 +23,8 @@ use SMW\SQLStore\ChangeOp\TempChangeOpStore;
 use SMW\Query\Result\CachedQueryResultPrefetcher;
 use SMW\Utils\BufferedStatsdCollector;
 use SMW\Parser\LinksProcessor;
+use SMW\Protection\EditProtectionValidator;
+use SMW\Protection\EditProtectionUpdater;
 
 /**
  * @license GNU GPL v2+
@@ -378,7 +380,7 @@ class SharedCallbackContainer implements CallbackContainer {
 		 * @var EditProtectionValidator
 		 */
 		$callbackLoader->registerCallback( 'EditProtectionValidator', function() use ( $callbackLoader ) {
-			$callbackLoader->registerExpectedReturnType( 'EditProtectionValidator', '\SMW\EditProtectionValidator' );
+			$callbackLoader->registerExpectedReturnType( 'EditProtectionValidator', '\SMW\Protection\EditProtectionValidator' );
 
 			$editProtectionValidator = new EditProtectionValidator(
 				$callbackLoader->singleton( 'CachedPropertyValuesPrefetcher' ),
@@ -390,6 +392,28 @@ class SharedCallbackContainer implements CallbackContainer {
 			);
 
 			return $editProtectionValidator;
+		} );
+
+		/**
+		 * @var EditProtectionUpdater
+		 */
+		$callbackLoader->registerCallback( 'EditProtectionUpdater', function( \WikiPage $wikiPage, \User $user = null ) use ( $callbackLoader ) {
+			$callbackLoader->registerExpectedReturnType( 'EditProtectionUpdater', '\SMW\Protection\EditProtectionUpdater' );
+
+			$editProtectionUpdater = new EditProtectionUpdater(
+				$wikiPage,
+				$user
+			);
+
+			$editProtectionUpdater->setEditProtectionRight(
+				$callbackLoader->singleton( 'Settings' )->get( 'smwgEditProtectionRight' )
+			);
+
+			$editProtectionUpdater->setLogger(
+				$callbackLoader->singleton( 'MediaWikiLogger' )
+			);
+
+			return $editProtectionUpdater;
 		} );
 
 		/**

--- a/tests/phpunit/Unit/MediaWiki/Hooks/ArticleProtectCompleteTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Hooks/ArticleProtectCompleteTest.php
@@ -1,0 +1,197 @@
+<?php
+
+namespace SMW\Tests\MediaWiki\Hooks;
+
+use SMW\MediaWiki\Hooks\ArticleProtectComplete;
+use SMW\PropertyAnnotators\EditProtectedPropertyAnnotator;
+use SMW\Tests\TestEnvironment;
+use SMW\DataItemFactory;
+
+/**
+ * @covers \SMW\MediaWiki\Hooks\ArticleProtectComplete
+ * @group semantic-mediawiki
+ *
+ * @license GNU GPL v2+
+ * @since 2.5
+ *
+ * @author mwjames
+ */
+class ArticleProtectCompleteTest extends \PHPUnit_Framework_TestCase {
+
+	private $spyLogger;
+	private $testEnvironment;
+	private $semanticDataFactory;
+	private $dataItemFactory;
+
+	protected function setUp() {
+		parent::setUp();
+
+		$this->testEnvironment = new TestEnvironment();
+		$this->dataItemFactory = new DataItemFactory();
+
+		$this->spyLogger = $this->testEnvironment->getUtilityFactory()->newSpyLogger();
+		$this->semanticDataFactory = $this->testEnvironment->getUtilityFactory()->newSemanticDataFactory();
+
+		$store = $this->getMockBuilder( '\SMW\Store' )
+			->disableOriginalConstructor()
+			->getMockForAbstractClass();
+
+		$this->testEnvironment->registerObject( 'Store', $store );
+	}
+
+	protected function tearDown() {
+		$this->testEnvironment->tearDown();
+		parent::tearDown();
+	}
+
+	public function testCanConstruct() {
+
+		$title = $this->getMockBuilder( '\Title' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$editInfoProvider = $this->getMockBuilder( '\SMW\MediaWiki\EditInfoProvider' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$this->assertInstanceOf(
+			ArticleProtectComplete::class,
+			new ArticleProtectComplete( $title, $editInfoProvider )
+		);
+	}
+
+	public function testProcessOnSelfInvokedReason() {
+
+		$title = $this->getMockBuilder( '\Title' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$editInfoProvider = $this->getMockBuilder( '\SMW\MediaWiki\EditInfoProvider' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$instance = new ArticleProtectComplete(
+			$title,
+			$editInfoProvider
+		);
+
+		$instance->setLogger( $this->spyLogger );
+
+		$protections = array();
+		$reason = \SMW\Message::get( 'smw-edit-protection-auto-update' );
+
+		$instance->process( $protections, $reason );
+
+		$this->assertContains(
+			'No changes required, invoked by own process',
+			$this->spyLogger->getMessagesAsString()
+		);
+	}
+
+	public function testProcessOnMatchableEditProtectionToAddAnnotation() {
+
+		$parserOutput = $this->getMockBuilder( '\ParserOutput' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$title = $this->getMockBuilder( '\Title' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$title->expects( $this->any() )
+			->method( 'getDBKey' )
+			->will( $this->returnValue( 'Foo' ) );
+
+		$title->expects( $this->any() )
+			->method( 'getNamespace' )
+			->will( $this->returnValue( NS_SPECIAL ) );
+
+		$editInfoProvider = $this->getMockBuilder( '\SMW\MediaWiki\EditInfoProvider' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$editInfoProvider->expects( $this->once() )
+			->method( 'getOutput' )
+			->will( $this->returnValue( $parserOutput ) );
+
+		$instance = new ArticleProtectComplete(
+			$title,
+			$editInfoProvider
+		);
+
+		$instance->setLogger( $this->spyLogger );
+		$instance->setEditProtectionRight( 'Foo' );
+
+		$protections = array( 'edit' => 'Foo' );
+		$reason = '';
+
+		$instance->process( $protections, $reason );
+
+		$this->assertContains(
+			'ArticleProtectComplete addProperty `Is edit protected`',
+			$this->spyLogger->getMessagesAsString()
+		);
+	}
+
+	public function testProcessOnUnmatchableEditProtectionToRemoveAnnotation() {
+
+		$semanticData = $this->semanticDataFactory->newEmptySemanticData(
+			$this->dataItemFactory->newDIWikiPage( __METHOD__, NS_SPECIAL )
+		);
+
+		$dataItem = $this->dataItemFactory->newDIBoolean( true );
+		$dataItem->setOption( EditProtectedPropertyAnnotator::SYSTEM_ANNOTATION, true );
+
+		$semanticData->addPropertyObjectValue(
+			$this->dataItemFactory->newDIProperty( '_EDIP' ),
+			$dataItem
+		);
+
+		$parserOutput = $this->getMockBuilder( '\ParserOutput' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$parserOutput->expects( $this->once() )
+			->method( 'getExtensionData' )
+			->will( $this->returnValue( $semanticData ) );
+
+		$title = $this->getMockBuilder( '\Title' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$title->expects( $this->any() )
+			->method( 'getDBKey' )
+			->will( $this->returnValue( 'Foo' ) );
+
+		$title->expects( $this->any() )
+			->method( 'getNamespace' )
+			->will( $this->returnValue( NS_SPECIAL ) );
+
+		$editInfoProvider = $this->getMockBuilder( '\SMW\MediaWiki\EditInfoProvider' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$editInfoProvider->expects( $this->once() )
+			->method( 'getOutput' )
+			->will( $this->returnValue( $parserOutput ) );
+
+		$instance = new ArticleProtectComplete(
+			$title,
+			$editInfoProvider
+		);
+
+		$instance->setLogger( $this->spyLogger );
+		$instance->setEditProtectionRight( 'Foo2' );
+
+		$protections = array( 'edit' => 'Foo' );
+		$reason = '';
+
+		$instance->process( $protections, $reason );
+
+		$this->assertContains(
+			'ArticleProtectComplete removeProperty `Is edit protected`',
+			$this->spyLogger->getMessagesAsString()
+		);
+	}
+
+}

--- a/tests/phpunit/Unit/MediaWiki/Hooks/HookRegistryTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Hooks/HookRegistryTest.php
@@ -138,6 +138,7 @@ class HookRegistryTest extends \PHPUnit_Framework_TestCase {
 		$this->doTestExecutionForInternalParseBeforeLinks( $instance );
 		$this->doTestExecutionForNewRevisionFromEditComplete( $instance );
 		$this->doTestExecutionForTitleMoveComplete( $instance );
+		$this->doTestExecutionForArticleProtectComplete( $instance );
 		$this->doTestExecutionForArticlePurge( $instance );
 		$this->doTestExecutionForArticleDelete( $instance );
 		$this->doTestExecutionForLinksUpdateConstructed( $instance );
@@ -411,6 +412,59 @@ class HookRegistryTest extends \PHPUnit_Framework_TestCase {
 		);
 
 		$this->testEnvironment->registerObject( 'Store', $this->store );
+	}
+
+	public function doTestExecutionForArticleProtectComplete( $instance ) {
+
+		$handler = 'ArticleProtectComplete';
+
+		$contentHandler = $this->getMockBuilder( '\ContentHandler' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$content = $this->getMockBuilder( '\Content' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$content->expects( $this->any() )
+			->method( 'getContentHandler' )
+			->will( $this->returnValue( $contentHandler ) );
+
+		$revision = $this->getMockBuilder( '\Revision' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$revision->expects( $this->any() )
+			->method( 'getContent' )
+			->will( $this->returnValue( $content ) );
+
+		$wikiPage = $this->getMockBuilder( '\WikiPage' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$wikiPage->expects( $this->any() )
+			->method( 'getRevision' )
+			->will( $this->returnValue( $revision ) );
+
+		$wikiPage->expects( $this->any() )
+			->method( 'getTitle' )
+			->will( $this->returnValue( $this->title ) );
+
+		$user = $this->getMockBuilder( '\User' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$protections = array();
+		$reason = '';
+
+		$this->assertTrue(
+			$instance->isRegistered( $handler )
+		);
+
+		$this->assertThatHookIsExcutable(
+			$instance->getHandlerFor( $handler ),
+			array( &$wikiPage, &$user, $protections, $reason )
+		);
 	}
 
 	public function doTestExecutionForArticlePurge( $instance ) {

--- a/tests/phpunit/Unit/MediaWiki/MwCollaboratorFactoryTest.php
+++ b/tests/phpunit/Unit/MediaWiki/MwCollaboratorFactoryTest.php
@@ -184,11 +184,19 @@ class MwCollaboratorFactoryTest extends \PHPUnit_Framework_TestCase {
 
 	public function testCanConstructPageInfoProvider() {
 
+		$settings = $this->getMockBuilder( '\SMW\Settings' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$applicationFactory = $this->getMockBuilder( '\SMW\ApplicationFactory' )
+			->disableOriginalConstructor()
+			->getMock();
+
 		$wikiPage = $this->getMockBuilder( '\WikiPage' )
 			->disableOriginalConstructor()
 			->getMock();
 
-		$instance = new MwCollaboratorFactory( new ApplicationFactory() );
+		$instance = new MwCollaboratorFactory( $applicationFactory );
 
 		$this->assertInstanceOf(
 			'\SMW\MediaWiki\PageInfoProvider',

--- a/tests/phpunit/Unit/PermissionPthValidatorTest.php
+++ b/tests/phpunit/Unit/PermissionPthValidatorTest.php
@@ -16,23 +16,25 @@ use Title;
  */
 class PermissionPthValidatorTest extends \PHPUnit_Framework_TestCase {
 
-	public function testCanConstruct() {
+	private $editProtectionValidator;
 
-		$editProtectionValidator = $this->getMockBuilder( '\SMW\EditProtectionValidator' )
+	protected function setUp() {
+		parent::setUp();
+
+		$this->editProtectionValidator = $this->getMockBuilder( '\SMW\Protection\EditProtectionValidator' )
 			->disableOriginalConstructor()
 			->getMock();
+	}
+
+	public function testCanConstruct() {
 
 		$this->assertInstanceOf(
 			'\SMW\PermissionPthValidator',
-			new PermissionPthValidator( $editProtectionValidator )
+			new PermissionPthValidator( $this->editProtectionValidator  )
 		);
 	}
 
 	public function testGrantPermissionToMainNamespace() {
-
-		$editProtectionValidator = $this->getMockBuilder( '\SMW\EditProtectionValidator' )
-			->disableOriginalConstructor()
-			->getMock();
 
 		$title = Title::newFromText( 'Foo', NS_MAIN );
 
@@ -43,7 +45,7 @@ class PermissionPthValidatorTest extends \PHPUnit_Framework_TestCase {
 		$result = '';
 
 		$instance = new PermissionPthValidator(
-			$editProtectionValidator
+			$this->editProtectionValidator
 		);
 
 		$this->assertTrue(
@@ -60,15 +62,11 @@ class PermissionPthValidatorTest extends \PHPUnit_Framework_TestCase {
 	 */
 	public function testToReturnFalseOnMwNamespacePermissionCheck( $title, $permission, $action, $expected ) {
 
-		$editProtectionValidator = $this->getMockBuilder( '\SMW\EditProtectionValidator' )
-			->disableOriginalConstructor()
-			->getMock();
-
-		$editProtectionValidator->expects( $this->any() )
+		$this->editProtectionValidator ->expects( $this->any() )
 			->method( 'hasEditProtection' )
 			->will( $this->returnValue( true ) );
 
-		$editProtectionValidator->expects( $this->any() )
+		$this->editProtectionValidator ->expects( $this->any() )
 			->method( 'hasProtectionOnNamespace' )
 			->will( $this->returnValue( true ) );
 
@@ -84,7 +82,7 @@ class PermissionPthValidatorTest extends \PHPUnit_Framework_TestCase {
 		$result = '';
 
 		$instance = new PermissionPthValidator(
-			$editProtectionValidator
+			$this->editProtectionValidator
 		);
 
 		$this->assertFalse(
@@ -117,15 +115,11 @@ class PermissionPthValidatorTest extends \PHPUnit_Framework_TestCase {
 			->method( 'getNamespace' )
 			->will( $this->returnValue( SMW_NS_PROPERTY ) );
 
-		$editProtectionValidator = $this->getMockBuilder( '\SMW\EditProtectionValidator' )
-			->disableOriginalConstructor()
-			->getMock();
-
-		$editProtectionValidator->expects( $this->any() )
+		$this->editProtectionValidator->expects( $this->any() )
 			->method( 'hasProtection' )
 			->will( $this->returnValue( true ) );
 
-		$editProtectionValidator->expects( $this->any() )
+		$this->editProtectionValidator->expects( $this->any() )
 			->method( 'hasProtectionOnNamespace' )
 			->will( $this->returnValue( true ) );
 
@@ -141,7 +135,7 @@ class PermissionPthValidatorTest extends \PHPUnit_Framework_TestCase {
 		$result = '';
 
 		$instance = new PermissionPthValidator(
-			$editProtectionValidator
+			$this->editProtectionValidator
 		);
 
 		$instance->setEditProtectionRight(
@@ -178,11 +172,7 @@ class PermissionPthValidatorTest extends \PHPUnit_Framework_TestCase {
 			->method( 'getNamespace' )
 			->will( $this->returnValue( SMW_NS_PROPERTY ) );
 
-		$editProtectionValidator = $this->getMockBuilder( '\SMW\EditProtectionValidator' )
-			->disableOriginalConstructor()
-			->getMock();
-
-		$editProtectionValidator->expects( $this->never() )
+		$this->editProtectionValidator->expects( $this->never() )
 			->method( 'hasProtectionOnNamespace' )
 			->will( $this->returnValue( true ) );
 
@@ -193,7 +183,7 @@ class PermissionPthValidatorTest extends \PHPUnit_Framework_TestCase {
 		$result = '';
 
 		$instance = new PermissionPthValidator(
-			$editProtectionValidator
+			$this->editProtectionValidator
 		);
 
 		$instance->setEditProtectionRight(

--- a/tests/phpunit/Unit/PropertyAnnotators/EditProtectedPropertyAnnotatorTest.php
+++ b/tests/phpunit/Unit/PropertyAnnotators/EditProtectedPropertyAnnotatorTest.php
@@ -1,0 +1,228 @@
+<?php
+
+namespace SMW\Tests\PropertyAnnotators;
+
+use SMW\DIWikiPage;
+use SMW\PropertyAnnotators\EditProtectedPropertyAnnotator;
+use SMW\PropertyAnnotators\NullPropertyAnnotator;
+use SMW\Tests\TestEnvironment;
+use SMW\DataItemFactory;
+
+/**
+ * @covers \SMW\PropertyAnnotators\EditProtectedPropertyAnnotator
+ * @group semantic-mediawiki
+ *
+ * @license GNU GPL v2+
+ * @since 2.5
+ *
+ * @author mwjames
+ */
+class EditProtectedPropertyAnnotatorTest extends \PHPUnit_Framework_TestCase {
+
+	private $semanticDataFactory;
+	private $semanticDataValidator;
+	private $dataItemFactory;
+
+	protected function setUp() {
+		parent::setUp();
+
+		$testEnvironment = new TestEnvironment();
+		$this->dataItemFactory = new DataItemFactory();
+
+		$this->semanticDataFactory = $testEnvironment->getUtilityFactory()->newSemanticDataFactory();
+		$this->semanticDataValidator = $testEnvironment->getUtilityFactory()->newValidatorFactory()->newSemanticDataValidator();
+	}
+
+	public function testCanConstruct() {
+
+		$semanticData = $this->getMockBuilder( '\SMW\SemanticData' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$title = $this->getMockBuilder( '\Title' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$instance = new EditProtectedPropertyAnnotator(
+			new NullPropertyAnnotator( $semanticData ),
+			$title
+		);
+
+		$this->assertInstanceOf(
+			'\SMW\PropertyAnnotators\EditProtectedPropertyAnnotator',
+			$instance
+		);
+	}
+
+	/**
+	 * @dataProvider titleProvider
+	 */
+	public function testAddAnnotationForDisplayTitle( $title, $editProtectionRight, array $expected ) {
+
+		$semanticData = $this->semanticDataFactory->newEmptySemanticData(
+			$title
+		);
+
+		$instance = new EditProtectedPropertyAnnotator(
+			new NullPropertyAnnotator( $semanticData ),
+			$title
+		);
+
+		$instance->setEditProtectionRight( $editProtectionRight );
+		$instance->addAnnotation();
+
+		$this->semanticDataValidator->assertThatPropertiesAreSet(
+			$expected,
+			$instance->getSemanticData()
+		);
+	}
+
+	public function testAddTopIndicatorToFromMatchableRestriction() {
+
+		$parserOutput = $this->getMockBuilder( '\ParserOutput' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$parserOutput->expects( $this->once() )
+			->method( 'setIndicator' );
+
+		$semanticData = $this->getMockBuilder( '\SMW\SemanticData' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$title = $this->getMockBuilder( '\Title' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$title->expects( $this->once() )
+			->method( 'isProtected' )
+			->with( $this->equalTo( 'edit' ) )
+			->will( $this->returnValue( true ) );
+
+		$title->expects( $this->once() )
+			->method( 'getRestrictions' )
+			->will( $this->returnValue( array( 'Foo' ) ) );
+
+		$instance = new EditProtectedPropertyAnnotator(
+			new NullPropertyAnnotator( $semanticData ),
+			$title
+		);
+
+		$instance->setEditProtectionRight( 'Foo' );
+		$instance->addTopIndicatorTo( $parserOutput );
+	}
+
+	public function titleProvider() {
+
+		$title = $this->getMockBuilder( '\Title' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$title->expects( $this->any() )
+			->method( 'getDBKey' )
+			->will( $this->returnValue( 'Foo' ) );
+
+		$title->expects( $this->any() )
+			->method( 'getNamespace' )
+			->will( $this->returnValue( 0 ) );
+
+		$title->expects( $this->any() )
+			->method( 'isProtected' )
+			->with( $this->equalTo( 'edit' ) )
+			->will( $this->returnValue( true ) );
+
+		$title->expects( $this->any() )
+			->method( 'getRestrictions' )
+			->will( $this->returnValue( array() ) );
+
+		$provider = array();
+
+		#0 no EditProtectionRight
+		$provider[] = array(
+			$title,
+			false,
+			array(
+				'propertyCount'  => 0,
+				'propertyKeys'   => array(),
+				'propertyValues' => array(),
+			)
+		);
+
+		#1
+		$provider[] = array(
+			$title,
+			'Foo',
+			array(
+				'propertyCount'  => 0,
+				'propertyKeys'   => array(),
+				'propertyValues' => array(),
+			)
+		);
+
+		$title = $this->getMockBuilder( '\Title' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$title->expects( $this->any() )
+			->method( 'getDBKey' )
+			->will( $this->returnValue( 'Foo' ) );
+
+		$title->expects( $this->any() )
+			->method( 'getNamespace' )
+			->will( $this->returnValue( 0 ) );
+
+		$title->expects( $this->any() )
+			->method( 'isProtected' )
+			->with( $this->equalTo( 'edit' ) )
+			->will( $this->returnValue( true ) );
+
+		$title->expects( $this->any() )
+			->method( 'getRestrictions' )
+			->will( $this->returnValue( array( 'Foo' ) ) );
+
+		#2
+		$provider[] = array(
+			$title,
+			'Foo',
+			array(
+				'propertyCount'  => 1,
+				'propertyKeys'   => array( '_EDIP' ),
+				'propertyValues' => array( true ),
+			)
+		);
+
+		$title = $this->getMockBuilder( '\Title' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$title->expects( $this->any() )
+			->method( 'getDBKey' )
+			->will( $this->returnValue( 'Foo' ) );
+
+		$title->expects( $this->any() )
+			->method( 'getNamespace' )
+			->will( $this->returnValue( 0 ) );
+
+		$title->expects( $this->any() )
+			->method( 'isProtected' )
+			->with( $this->equalTo( 'edit' ) )
+			->will( $this->returnValue( false ) );
+
+		$title->expects( $this->never() )
+			->method( 'getRestrictions' );
+
+		#3
+		$provider[] = array(
+			$title,
+			'Foo',
+			array(
+				'propertyCount'  => 0,
+				'propertyKeys'   => array(),
+				'propertyValues' => array(),
+			)
+		);
+
+		return $provider;
+	}
+
+}

--- a/tests/phpunit/Unit/Protection/EditProtectionUpdaterTest.php
+++ b/tests/phpunit/Unit/Protection/EditProtectionUpdaterTest.php
@@ -1,0 +1,233 @@
+<?php
+
+namespace SMW\Tests\Protection;
+
+use SMW\Protection\EditProtectionUpdater;
+use SMW\DataItemFactory;
+use SMW\Tests\TestEnvironment;
+
+/**
+ * @covers \SMW\Protection\EditProtectionUpdater
+ * @group semantic-mediawiki
+ *
+ * @license GNU GPL v2+
+ * @since  2.5
+ *
+ * @author mwjames
+ */
+class EditProtectionUpdaterTest extends \PHPUnit_Framework_TestCase {
+
+	private $dataItemFactory;
+	private $wikiPage;
+	private $user;
+	private $spyLogger;
+
+	protected function setUp() {
+		parent::setUp();
+
+		$testEnvironment = new TestEnvironment();
+
+		$this->spyLogger = $testEnvironment->getUtilityFactory()->newSpyLogger();
+		$this->dataItemFactory = new DataItemFactory();
+
+		$this->wikiPage = $this->getMockBuilder( '\WikiPage' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$this->user = $this->getMockBuilder( '\User' )
+			->disableOriginalConstructor()
+			->getMock();
+	}
+
+	public function testCanConstruct() {
+
+		$this->assertInstanceOf(
+			EditProtectionUpdater::class,
+			new EditProtectionUpdater( $this->wikiPage, $this->user )
+		);
+	}
+
+	public function testDoUpdateFromWithNoRestrictionsNoEditProtection() {
+
+		$subject = $this->dataItemFactory->newDIWikiPage( 'Foo', NS_MAIN );
+
+		$this->wikiPage->expects( $this->once() )
+			->method( 'getTitle' )
+			->will( $this->returnValue( $subject->getTitle() ) );
+
+		$this->wikiPage->expects( $this->never() )
+			->method( 'doUpdateRestrictions' );
+
+		$semanticData = $this->getMockBuilder( '\SMW\SemanticData' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$semanticData->expects( $this->once() )
+			->method( 'getPropertyValues' )
+			->will( $this->returnValue( array() ) );
+
+		$instance = new EditProtectionUpdater(
+			$this->wikiPage,
+			$this->user
+		);
+
+		$instance->setEditProtectionRight( 'Foo' );
+		$instance->doUpdateFrom( $semanticData );
+
+		$this->assertFalse(
+			$instance->isRestrictedUpdate()
+		);
+	}
+
+	public function testDoUpdateFromWithNoRestrictionsAnActiveEditProtection() {
+
+		$subject = $this->dataItemFactory->newDIWikiPage( 'Foo', NS_MAIN );
+
+		$this->wikiPage->expects( $this->once() )
+			->method( 'getTitle' )
+			->will( $this->returnValue( $subject->getTitle() ) );
+
+		$this->wikiPage->expects( $this->once() )
+			->method( 'doUpdateRestrictions' );
+
+		$semanticData = $this->getMockBuilder( '\SMW\SemanticData' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$semanticData->expects( $this->once() )
+			->method( 'getPropertyValues' )
+			->will( $this->returnValue( array( $this->dataItemFactory->newDIBoolean( true ) ) ) );
+
+		$instance = new EditProtectionUpdater(
+			$this->wikiPage,
+			$this->user
+		);
+
+		$instance->setEditProtectionRight( 'Foo' );
+
+		$instance->setLogger(
+			$this->spyLogger
+		);
+
+		$instance->doUpdateFrom( $semanticData );
+
+		$this->assertFalse(
+			$instance->isRestrictedUpdate()
+		);
+
+		$this->assertContains(
+			'add protection on edit, move',
+			$this->spyLogger->getMessagesAsString()
+		);
+	}
+
+	public function testDoUpdateFromWithRestrictionsButNoTrueEditProtection() {
+
+		$title = $this->getMockBuilder( '\Title' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$title->expects( $this->once() )
+			->method( 'isProtected' )
+			->with( $this->equalTo( 'edit' ) )
+			->will( $this->returnValue( true ) );
+
+		$title->expects( $this->once() )
+			->method( 'getRestrictions' )
+			->will( $this->returnValue( array( 'Foo' ) ) );
+
+		$this->wikiPage->expects( $this->once() )
+			->method( 'getTitle' )
+			->will( $this->returnValue( $title ) );
+
+		$this->wikiPage->expects( $this->once() )
+			->method( 'doUpdateRestrictions' );
+
+		$semanticData = $this->getMockBuilder( '\SMW\SemanticData' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$semanticData->expects( $this->once() )
+			->method( 'getPropertyValues' )
+			->will( $this->returnValue( array( $this->dataItemFactory->newDIBoolean( false ) ) ) );
+
+		$instance = new EditProtectionUpdater(
+			$this->wikiPage,
+			$this->user
+		);
+
+		$instance->setEditProtectionRight( 'Foo' );
+
+		$instance->setLogger(
+			$this->spyLogger
+		);
+
+		$instance->doUpdateFrom( $semanticData );
+
+		$this->assertFalse(
+			$instance->isRestrictedUpdate()
+		);
+
+		$this->assertContains(
+			'remove protection on edit, move',
+			$this->spyLogger->getMessagesAsString()
+		);
+	}
+
+	public function testDoUpdateFromWithRestrictionsAnActiveEditProtection() {
+
+		$property = $this->dataItemFactory->newDIProperty( '_EDIP' );
+
+		$title = $this->getMockBuilder( '\Title' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$title->expects( $this->once() )
+			->method( 'isProtected' )
+			->with( $this->equalTo( 'edit' ) )
+			->will( $this->returnValue( true ) );
+
+		$title->expects( $this->once() )
+			->method( 'getRestrictions' )
+			->will( $this->returnValue( array( 'Foo' ) ) );
+
+		$this->wikiPage->expects( $this->once() )
+			->method( 'getTitle' )
+			->will( $this->returnValue( $title ) );
+
+		$this->wikiPage->expects( $this->never() )
+			->method( 'doUpdateRestrictions' );
+
+		$semanticData = $this->getMockBuilder( '\SMW\SemanticData' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$semanticData->expects( $this->once() )
+			->method( 'getPropertyValues' )
+			->with( $this->equalTo( $property ) )
+			->will( $this->returnValue( array( $this->dataItemFactory->newDIBoolean( true ) ) ) );
+
+		$instance = new EditProtectionUpdater(
+			$this->wikiPage,
+			$this->user
+		);
+
+		$instance->setEditProtectionRight( 'Foo' );
+
+		$instance->setLogger(
+			$this->spyLogger
+		);
+
+		$instance->doUpdateFrom( $semanticData );
+
+		$this->assertFalse(
+			$instance->isRestrictedUpdate()
+		);
+
+		$this->assertContains(
+			'Status already set, no update required',
+			$this->spyLogger->getMessagesAsString()
+		);
+	}
+
+}

--- a/tests/phpunit/Unit/Protection/EditProtectionValidatorTest.php
+++ b/tests/phpunit/Unit/Protection/EditProtectionValidatorTest.php
@@ -1,12 +1,12 @@
 <?php
 
-namespace SMW\Tests;
+namespace SMW\Tests\Protection;
 
-use SMW\EditProtectionValidator;
+use SMW\Protection\EditProtectionValidator;
 use SMW\DataItemFactory;
 
 /**
- * @covers \SMW\EditProtectionValidator
+ * @covers \SMW\Protection\EditProtectionValidator
  * @group semantic-mediawiki
  *
  * @license GNU GPL v2+
@@ -37,7 +37,7 @@ class EditProtectionValidatorTest extends \PHPUnit_Framework_TestCase {
 	public function testCanConstruct() {
 
 		$this->assertInstanceOf(
-			'\SMW\EditProtectionValidator',
+			EditProtectionValidator::class,
 			new EditProtectionValidator( $this->cachedPropertyValuesPrefetcher, $this->cache )
 		);
 	}

--- a/tests/phpunit/Utils/SpyLogger.php
+++ b/tests/phpunit/Utils/SpyLogger.php
@@ -37,4 +37,19 @@ class SpyLogger extends AbstractLogger {
 		return $this->logs;
 	}
 
+	/**
+	 * @since 2.5
+	 *
+	 * @return string
+	 */
+	public function getMessagesAsString() {
+		$message = '';
+
+		foreach ( $this->logs as $log ) {
+			$message .= ' ' . $log[1];
+		}
+
+		return $message;
+	}
+
 }


### PR DESCRIPTION
This PR is made in reference to: #2232

This PR addresses or contains:

- Adds `wgRestrictionLevels` in case `$smwgEditProtectionRight` is maintained, allowing to support edit protection via the protect menu
- Follow-up on https://github.com/SemanticMediaWiki/SemanticMediaWiki/pull/2232#issuecomment-277520142

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed
