### PR TITLE
Output option to highlight search tokens in result set

### DIFF
--- a/includes/query/SMW_Query.php
+++ b/includes/query/SMW_Query.php
@@ -6,6 +6,7 @@ use SMW\Query\PrintRequest;
 use SMW\Query\Language\Description;
 use SMW\Query\QueryContext;
 use SMW\Query\QueryStringifier;
+use SMW\Query\QueryToken;
 use SMW\Message;
 
 /**
@@ -87,6 +88,11 @@ class SMWQuery implements QueryContext {
 	 * @var string|null
 	 */
 	private $querySource = null;
+
+	/**
+	 * @var QueryToken|null
+	 */
+	private $queryToken;
 
 	/**
 	 * @var array
@@ -176,6 +182,24 @@ class SMWQuery implements QueryContext {
 	 */
 	public function getQuerySource() {
 		return $this->querySource;
+	}
+
+	/**
+	 * @since 2.5
+	 *
+	 * @param QueryToken|null $queryToken
+	 */
+	public function setQueryToken( QueryToken $queryToken = null ) {
+		$this->queryToken = $queryToken;
+	}
+
+	/**
+	 * @since 2.5
+	 *
+	 * @return QueryToken|null
+	 */
+	public function getQueryToken() {
+		return $this->queryToken;
 	}
 
 	/**

--- a/includes/storage/SMW_QueryResult.php
+++ b/includes/storage/SMW_QueryResult.php
@@ -152,6 +152,7 @@ class SMWQueryResult {
 		foreach ( $this->mPrintRequests as $p ) {
 			$resultArray = new SMWResultArray( $page, $p, $this->mStore );
 			$resultArray->setEntityListAccumulator( $this->entityListAccumulator );
+			$resultArray->setQueryToken( $this->mQuery->getQueryToken() );
 			$row[] = $resultArray;
 		}
 

--- a/includes/storage/SMW_ResultArray.php
+++ b/includes/storage/SMW_ResultArray.php
@@ -7,6 +7,7 @@ use SMW\Query\Result\EntityListAccumulator;
 use SMWDataItem as DataItem;
 use SMWDIBlob as DIBlob;
 use SMW\Query\Result\ResultFieldMatchFinder;
+use SMW\Query\QueryToken;
 
 /**
  * Container for the contents of a single result field of a query result,
@@ -49,6 +50,11 @@ class SMWResultArray {
 	 * @var ResultFieldMatchFinder
 	 */
 	private $resultFieldMatchFinder;
+
+	/**
+	 * @var QueryToken
+	 */
+	private $queryToken;
 
 	/**
 	 * Constructor.
@@ -98,6 +104,15 @@ class SMWResultArray {
 	 */
 	public function setEntityListAccumulator( EntityListAccumulator $entityListAccumulator ) {
 		$this->entityListAccumulator = $entityListAccumulator;
+	}
+
+	/**
+	 * @since 2.5
+	 *
+	 * @param QueryToken|null $queryToken
+	 */
+	public function setQueryToken( QueryToken $queryToken = null ) {
+		$this->queryToken = $queryToken;
 	}
 
 	/**
@@ -197,15 +212,6 @@ class SMWResultArray {
 			$diProperty = null;
 		}
 
-		// refs #1314
-		if ( $this->mPrintRequest->getMode() == PrintRequest::PRINT_PROP &&
-			strpos( $this->mPrintRequest->getTypeID(), '_txt' ) !== false &&
-			$dataItem instanceof DIBlob ) {
-			$dataItem = new DIBlob(
-				InTextAnnotationParser::removeAnnotation( $dataItem->getString() )
-			);
-		}
-
 		$dataValue = DataValueFactory::getInstance()->newDataValueByItem(
 			$dataItem,
 			$diProperty
@@ -257,7 +263,14 @@ class SMWResultArray {
 			return;
 		}
 
-		$this->mContent = $this->resultFieldMatchFinder->getResultsBy( $this->mResult );
+		$this->resultFieldMatchFinder->setQueryToken(
+			$this->queryToken
+		);
+
+		$this->mContent = $this->resultFieldMatchFinder->findAndMatch(
+			$this->mResult
+		);
+
 		return reset( $this->mContent );
 	}
 

--- a/src/Query/QueryCreator.php
+++ b/src/Query/QueryCreator.php
@@ -125,6 +125,7 @@ class QueryCreator implements QueryContext {
 			$context
 		);
 
+		$query->setQueryToken( $queryParser->getQueryToken() );
 		$query->setQueryString( $queryString );
 		$query->setContextPage( $contextPage );
 		$query->setQueryMode( $queryMode );

--- a/src/Utils/Tokenizer.php
+++ b/src/Utils/Tokenizer.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace SMW\Utils;
+
+/**
+ * @license GNU GPL v2+
+ * @since 2.5
+ *
+ * @author mwjames
+ */
+class Tokenizer {
+
+	/**
+	 * @since 2.5
+	 *
+	 * @param string $text
+	 *
+	 * @return array
+	 */
+	public static function tokenize( $text ) {
+
+		if ( !class_exists( '\IntlRuleBasedBreakIterator' ) ) {
+			return explode( ' ', $text );
+		}
+
+		// As for CJK, this returns better results as trying to split tokens
+		// by a single character
+		$intlRuleBasedBreakIterator = \IntlRuleBasedBreakIterator::createWordInstance( 'en' );
+		$intlRuleBasedBreakIterator->setText( $text );
+
+		$prev = 0;
+		$tokens = array();
+
+		foreach ( $intlRuleBasedBreakIterator as $token ) {
+
+			if ( $token == 0 ) {
+				continue;
+			}
+
+			$res = substr( $text, $prev, $token - $prev );
+
+			if ( $res !== '' && $res !== ' ' ) {
+				$tokens[] = $res;
+			}
+
+			$prev = $token;
+		}
+
+		return $tokens;
+	}
+
+}

--- a/tests/phpunit/Integration/JSONScript/TestCases/p-0910.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/p-0910.json
@@ -1,0 +1,134 @@
+{
+	"description": "Test `#ask` to highlight (`#-hl`) search token in result set (#..., `wgContLang=en`, `wgLang=en`)",
+	"setup": [
+		{
+			"namespace": "SMW_NS_PROPERTY",
+			"page": "Has text",
+			"contents": "[[Has type::text]]"
+		},
+		{
+			"namespace": "SMW_NS_PROPERTY",
+			"page": "Has mono text",
+			"contents": "[[Has type::Monolingual text]]"
+		},
+		{
+			"namespace": "SMW_NS_PROPERTY",
+			"page": "Has record with text",
+			"contents": "[[Has type::Record]] [[Has fields::Text;Number]]"
+		},
+		{
+			"page": "Example/P0910/1",
+			"contents": "[[Category:P0910]] [[Has text::Lorem ipsum dolor sit amet consectetuer justo Nam quis lobortis vel. Sapien nulla enim Lorem enim pede lorem nulla justo diam wisi. Libero Nam turpis ...]]"
+		},
+		{
+			"page": "Example/P0910/Q.1",
+			"contents": "{{#ask: [[Has text::~*dolor sit amet consectetuer*]] |?Has text#-hl |link=none }} "
+		},
+		{
+			"page": "Example/P0910/2",
+			"contents": "[[Category:P0910]] [[Has mono text::Lorem ipsum dolor sit amet consectetuer justo Nam quis lobortis vel. Sapien nulla enim Lorem enim pede lorem nulla justo diam wisi. Libero Nam turpis ...@la]]"
+		},
+		{
+			"page": "Example/P0910/Q.2.1",
+			"contents": "{{#ask: [[Has mono text::~*dolor sit amet consectetuer*]] |?Has mono text#-hl |link=none }} "
+		},
+		{
+			"page": "Example/P0910/Q.2.2",
+			"contents": "{{#ask: [[Has mono text::~*dolor sit amet consectetuer*]] |?Has mono text#-hl|+lang=la |link=none }} "
+		},
+		{
+			"page": "Example/P0910/Q.2.3",
+			"contents": "{{#ask: [[Has mono text::~*dolor sit amet consectetuer*]] |?Has mono text#-hl|+index=1 |link=none }} "
+		},
+		{
+			"page": "Example/P0910/3",
+			"contents": "[[Category:P0910]] [[Has record with text::Lorem ipsum dolor sit amet consectetuer justo Nam quis lobortis vel. Sapien nulla enim Lorem enim pede lorem nulla justo diam wisi. Libero Nam turpis ...;123]]"
+		},
+		{
+			"page": "Example/P0910/Q.3.1",
+			"contents": "{{#ask: [[Has record with text::~*dolor sit amet consectetuer*]] |?Has record with text#-hl |link=none }} "
+		},
+		{
+			"page": "Example/P0910/Q.3.2",
+			"contents": "{{#ask: [[Has record with text::~*dolor sit amet consectetuer*]] |?Has record with text#-hl|+index=1 |link=none }} "
+		}
+	],
+	"tests": [
+		{
+			"type": "parser",
+			"about": "#0 (...)",
+			"subject": "Example/P0910/Q.1",
+			"assert-output": {
+				"to-contain": [
+					"smwtype_txt\">Lorem ipsum <b>dolor</b> <b>sit</b> <b>amet</b> <b>consectetuer</b> justo Nam quis lobortis vel. Sapien nulla enim Lorem enim pede lorem nulla justo diam wisi. Libero Nam turpis ..."
+				]
+			}
+		},
+		{
+			"type": "parser",
+			"about": "#1 (simple record/mono text doens't display a highlight)",
+			"subject": "Example/P0910/Q.2.1",
+			"assert-output": {
+				"to-contain": [
+					"smwtype_mlt_rec\">Lorem ipsum dolor sit amet consectetuer justo Nam quis lobortis vel. Sapien nulla enim Lorem enim pede lorem nulla justo diam wisi. Libero Nam turpis ... (la)"
+				]
+			}
+		},
+		{
+			"type": "parser",
+			"about": "#2 (on selected language |+lang, tokens are displayed)",
+			"subject": "Example/P0910/Q.2.2",
+			"assert-output": {
+				"to-contain": [
+					"smwtype_txt\">Lorem ipsum <b>dolor</b> <b>sit</b> <b>amet</b> <b>consectetuer</b> justo Nam quis lobortis vel. Sapien nulla enim Lorem enim pede lorem nulla justo diam wisi. Libero Nam turpis ..."
+				]
+			}
+		},
+		{
+			"type": "parser",
+			"about": "#3 (on selected index |+index, tokens are displayed)",
+			"subject": "Example/P0910/Q.2.3",
+			"assert-output": {
+				"to-contain": [
+					"smwtype_txt\">Lorem ipsum <b>dolor</b> <b>sit</b> <b>amet</b> <b>consectetuer</b> justo Nam quis lobortis vel. Sapien nulla enim Lorem enim pede lorem nulla justo diam wisi. Libero Nam turpis ..."
+				]
+			}
+		},
+		{
+			"type": "parser",
+			"about": "#4 (simple record/mono text doens't display a highlight)",
+			"subject": "Example/P0910/Q.3.1",
+			"assert-output": {
+				"to-contain": [
+					"smwtype_rec\">Lorem ipsum dolor sit amet consectetuer justo Nam quis lobortis vel. Sapien nulla enim Lorem enim pede lorem nulla justo diam wisi. Libero Nam turpis ... (123)"
+				]
+			}
+		},
+		{
+			"type": "parser",
+			"about": "#5 (on selected index |+index, tokens are displayed)",
+			"subject": "Example/P0910/Q.3.2",
+			"assert-output": {
+				"to-contain": [
+					"smwtype_txt\">Lorem ipsum <b>dolor</b> <b>sit</b> <b>amet</b> <b>consectetuer</b> justo Nam quis lobortis vel. Sapien nulla enim Lorem enim pede lorem nulla justo diam wisi. Libero Nam turpis ..."
+				]
+			}
+		}
+	],
+	"settings": {
+		"wgContLang": "en",
+		"wgLang": "en",
+		"smwgPageSpecialProperties": [
+			"_MDAT"
+		],
+		"smwgNamespacesWithSemanticLinks": {
+			"NS_MAIN": true,
+			"SMW_NS_PROPERTY": true
+		}
+	},
+	"meta": {
+		"version": "2",
+		"is-incomplete": false,
+		"debug": false
+	}
+}

--- a/tests/phpunit/Unit/Query/QueryTokenTest.php
+++ b/tests/phpunit/Unit/Query/QueryTokenTest.php
@@ -1,0 +1,200 @@
+<?php
+
+namespace SMW\Tests\Query;
+
+use SMW\Query\QueryToken;
+use SMW\DataItemFactory;
+
+/**
+ * @covers \SMW\Query\QueryToken
+ * @group semantic-mediawiki
+ *
+ * @license GNU GPL v2+
+ * @since 2.5
+ *
+ * @author mwjames
+ */
+class QueryTokenTest extends \PHPUnit_Framework_TestCase {
+
+	private $dataItemFactory;
+
+	protected function setUp() {
+		parent::setUp();
+
+		$this->dataItemFactory = new DataItemFactory();
+	}
+
+	public function testCanConstruct() {
+
+		$this->assertInstanceOf(
+			QueryToken::class,
+			new QueryToken()
+		);
+	}
+
+	/**
+	 * @dataProvider descriptionProvider
+	 */
+	public function testAddFromDesciption( $description, $expected ) {
+
+		$instance = new QueryToken();
+
+		$instance->addFromDesciption( $description );
+
+		$this->assertEquals(
+			$expected,
+			$instance->getTokens()
+		);
+	}
+
+	public function testMulitpleAddFromDesciption() {
+
+		$instance = new QueryToken();
+
+		$description = $this->getMockBuilder( '\SMW\Query\Language\ValueDescription' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$description->expects( $this->once() )
+			->method( 'getComparator' )
+			->will( $this->returnValue( SMW_CMP_LIKE ) );
+
+		$description->expects( $this->atLeastOnce() )
+			->method( 'getDataItem' )
+			->will( $this->returnValue( $this->dataItemFactory->newDIBlob( 'abc Foo 123' ) ) );
+
+		$instance->addFromDesciption( $description );
+
+		$description = $this->getMockBuilder( '\SMW\Query\Language\ValueDescription' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$description->expects( $this->atLeastOnce() )
+			->method( 'getDataItem' )
+			->will( $this->returnValue( $this->dataItemFactory->newDIWikiPage( '~*123 bar 456' ) ) );
+
+		$instance->addFromDesciption( $description );
+
+		$this->assertEquals(
+			array(
+				'abc' => 0,
+				'Foo' => 1,
+				123 => 2,
+				'bar' => 1,
+				456 => 2
+			),
+			$instance->getTokens()
+		);
+	}
+
+	/**
+	 * @dataProvider highlightProvider
+	 */
+	public function testHighlight( $description, $text, $type, $expected ) {
+
+		$instance = new QueryToken();
+
+		$instance->addFromDesciption( $description );
+		$instance->canHighlight( '-hL' );
+
+		$this->assertEquals(
+			$expected,
+			$instance->highlight( $text, $type )
+		);
+	}
+
+	public function descriptionProvider() {
+
+		$dataItemFactory = new DataItemFactory();
+
+		$description = $this->getMockBuilder( '\SMW\Query\Language\ValueDescription' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$description->expects( $this->once() )
+			->method( 'getComparator' )
+			->will( $this->returnValue( SMW_CMP_LIKE ) );
+
+		$description->expects( $this->atLeastOnce() )
+			->method( 'getDataItem' )
+			->will( $this->returnValue( $dataItemFactory->newDIBlob( 'abc Foo 123' ) ) );
+
+		$provider[] = array(
+			$description,
+			array(
+				'abc' => 0,
+				'Foo' => 1,
+				123 => 2
+			)
+		);
+
+		return $provider;
+	}
+
+	public function highlightProvider() {
+
+		$dataItemFactory = new DataItemFactory();
+
+		$description = $this->getMockBuilder( '\SMW\Query\Language\ValueDescription' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$description->expects( $this->any() )
+			->method( 'getComparator' )
+			->will( $this->returnValue( SMW_CMP_LIKE ) );
+
+		$description->expects( $this->any() )
+			->method( 'getDataItem' )
+			->will( $this->returnValue( $dataItemFactory->newDIBlob( 'abc Foo 123 foobar' ) ) );
+
+		$provider[] = array(
+			$description,
+			'Lorem abc foobar',
+			QueryToken::HL_BOLD,
+			"Lorem <b>abc</b> <b>foo</b>bar"
+		);
+
+		$provider[] = array(
+			$description,
+			'Lorem abc foobar',
+			QueryToken::HL_WIKI,
+			"Lorem '''abc''' '''foo'''bar"
+		);
+
+		$provider[] = array(
+			$description,
+			'Lorem abc foobar',
+			QueryToken::HL_UNDERLINE,
+			"Lorem <u>abc</u> <u>foo</u>bar"
+		);
+
+		$description = $this->getMockBuilder( '\SMW\Query\Language\ValueDescription' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$description->expects( $this->any() )
+			->method( 'getComparator' )
+			->will( $this->returnValue( SMW_CMP_LIKE ) );
+
+		$description->expects( $this->any() )
+			->method( 'getDataItem' )
+			->will( $this->returnValue( $dataItemFactory->newDIBlob( 'integer porttitor portt' ) ) );
+
+		$provider[] = array(
+			$description,
+			'Integer porttitor mi id ante consequat consequat <b>porttitor</b>',
+			QueryToken::HL_BOLD,
+			"<b>Integer</b> <b>porttitor</b> mi id ante consequat consequat <b><b>porttitor</b></b>"
+		);
+
+		$provider[] = array(
+			$description,
+			'Integer porttitor mi id ante consequat consequat <b>porttitor</b>',
+			QueryToken::HL_SPAN,
+			"<span class='smw-query-token'>Integer</span> <span class='smw-query-token'>porttitor</span> mi id ante consequat consequat <b><span class='smw-query-token'>porttitor</span></b>"
+		);
+
+		return $provider;
+	}
+
+}

--- a/tests/phpunit/Unit/Query/Result/ResultFieldMatchFinderTest.php
+++ b/tests/phpunit/Unit/Query/Result/ResultFieldMatchFinderTest.php
@@ -68,7 +68,7 @@ class ResultFieldMatchFinderTest extends \PHPUnit_Framework_TestCase {
 		);
 	}
 
-	public function testGetResultsBy_THIS() {
+	public function testFindAndMatch_THIS() {
 
 		$dataItem = $this->dataItemFactory->newDIWikiPage( 'Foo' );
 
@@ -92,11 +92,11 @@ class ResultFieldMatchFinderTest extends \PHPUnit_Framework_TestCase {
 
 		$this->assertEquals(
 			array( $dataItem ),
-			$instance->getResultsBy( $dataItem )
+			$instance->findAndMatch( $dataItem )
 		);
 	}
 
-	public function testGetResultsBy_CATS() {
+	public function testFindAndMatch_CATS() {
 
 		$dataItem = $this->dataItemFactory->newDIWikiPage( 'Foo' );
 		$expected = $this->dataItemFactory->newDIWikiPage( __METHOD__ );
@@ -128,11 +128,11 @@ class ResultFieldMatchFinderTest extends \PHPUnit_Framework_TestCase {
 
 		$this->assertEquals(
 			array( $expected ),
-			$instance->getResultsBy( $dataItem )
+			$instance->findAndMatch( $dataItem )
 		);
 	}
 
-	public function testGetResultsBy_CCAT() {
+	public function testFindAndMatch_CCAT() {
 
 		$dataItem = $this->dataItemFactory->newDIWikiPage( 'Bar' );
 		$expected = $this->dataItemFactory->newDIWikiPage( __METHOD__ );
@@ -168,11 +168,11 @@ class ResultFieldMatchFinderTest extends \PHPUnit_Framework_TestCase {
 
 		$this->assertEquals(
 			array( $this->dataItemFactory->newDIBoolean( true ) ),
-			$instance->getResultsBy( $dataItem )
+			$instance->findAndMatch( $dataItem )
 		);
 	}
 
-	public function testGetResultsBy_PROP() {
+	public function testFindAndMatch_PROP() {
 
 		$dataItem = $this->dataItemFactory->newDIWikiPage( 'Bar' );
 		$expected = $this->dataItemFactory->newDIWikiPage( __METHOD__ );
@@ -212,7 +212,7 @@ class ResultFieldMatchFinderTest extends \PHPUnit_Framework_TestCase {
 
 		$this->assertEquals(
 			array( $expected ),
-			$instance->getResultsBy( $dataItem )
+			$instance->findAndMatch( $dataItem )
 		);
 	}
 

--- a/tests/phpunit/Unit/Utils/TokenizerTest.php
+++ b/tests/phpunit/Unit/Utils/TokenizerTest.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace SMW\Tests\Utils;
+
+use SMW\Utils\Tokenizer;
+
+/**
+ * @covers \SMW\Utils\Tokenizer
+ * @group semantic-mediawiki
+ *
+ * @license GNU GPL v2+
+ * @since 2.5
+ *
+ * @author mwjames
+ */
+class TokenizerTest extends \PHPUnit_Framework_TestCase {
+
+	/**
+	 * @dataProvider textProvider
+	 */
+	public function testTokenize( $text, $expected ) {
+
+		$this->assertEquals(
+			$expected,
+			Tokenizer::tokenize( $text )
+		);
+	}
+
+	public function textProvider() {
+
+		$provider[] = array(
+			'foo',
+			array( 'foo' )
+		);
+
+		$provider[] = array(
+			'foo bar',
+			array( 'foo', 'bar' )
+		);
+
+		return $provider;
+	}
+
+}


### PR DESCRIPTION
This PR is made in reference to: #

This PR addresses or contains:

- Adds the `-hl`output formatter, allowing it to highlight search tokens in a result set

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed
