### PR TITLE
Allow multiple edit protection rights, refs 2232, 2249

### DIFF
--- a/DefaultSettings.php
+++ b/DefaultSettings.php
@@ -1388,10 +1388,31 @@ return array(
 	# To enable this functionality either assign `smw-pageedit` or any other
 	# right to the variable to activate an edit protection.
 	#
+	# NOTICE: The program will NOT validate or check whether listed rights
+	# exists or not, it is the responsibility of the administrator to make sure
+	# that changes to rights and its members are done carefully and with the
+	# necessary precautions to avoid disruptions.
+	#
+	# @since 2.5
+	# @default false|array
+	##
+	'smwgEditProtectionRights' => false,
+	##
+
+	###
+	# Enforced protection right
+	#
+	# If the `Is edit protected` property is used to enforce a protection from
+	# within the content of a page (instead of using the protection menu) then
+	# the enabled protection (== TRUE value) will force a specific right that is
+	# maintained by this setting.
+	#
+	# The selected right should be listed in the `smwgEditProtectionRights`.
+	#
 	# @since 2.5
 	# @default false
 	##
-	'smwgEditProtectionRight' => false,
+	'smwgEditProtectionEnforcedRight' => false,
 	##
 
 	##

--- a/includes/Settings.php
+++ b/includes/Settings.php
@@ -161,7 +161,8 @@ class Settings extends Options {
 			'smwgQueryResultCacheLifetime' => $GLOBALS['smwgQueryResultCacheLifetime'],
 			'smwgQueryResultNonEmbeddedCacheLifetime' => $GLOBALS['smwgQueryResultNonEmbeddedCacheLifetime'],
 			'smwgQueryResultCacheRefreshOnPurge' => $GLOBALS['smwgQueryResultCacheRefreshOnPurge'],
-			'smwgEditProtectionRight' => $GLOBALS['smwgEditProtectionRight'],
+			'smwgEditProtectionRights' => $GLOBALS['smwgEditProtectionRights'],
+			'smwgEditProtectionEnforcedRight' => $GLOBALS['smwgEditProtectionEnforcedRight'],
 			'smwgSimilarityLookupExemptionProperty' => $GLOBALS['smwgSimilarityLookupExemptionProperty']
 		);
 

--- a/includes/Setup.php
+++ b/includes/Setup.php
@@ -257,8 +257,8 @@ final class Setup {
 		}
 
 		// Add an additional protection level restricting edit/move/etc
-		if ( ( $editProtectionRight = $this->applicationFactory->getSettings()->get( 'smwgEditProtectionRight' ) ) !== false ) {
-			$this->globalVars['wgRestrictionLevels'][] = $editProtectionRight;
+		if ( ( $editProtectionRights = $this->applicationFactory->getSettings()->get( 'smwgEditProtectionRights' ) ) !== false ) {
+			$this->globalVars['wgRestrictionLevels'] = array_merge( $this->globalVars['wgRestrictionLevels'], (array)$editProtectionRights );
 		}
 	}
 

--- a/includes/articlepages/SMW_PropertyPage.php
+++ b/includes/articlepages/SMW_PropertyPage.php
@@ -95,8 +95,8 @@ class SMWPropertyPage extends SMWOrderedListPage {
 			$this->store
 		);
 
-		$propertySpecificationReqExaminer->setEditProtectionRight(
-			ApplicationFactory::getInstance()->getSettings()->get( 'smwgEditProtectionRight' )
+		$propertySpecificationReqExaminer->setEditProtectionRights(
+			ApplicationFactory::getInstance()->getSettings()->get( 'smwgEditProtectionRights' )
 		);
 
 		$propertyPageMessageHtmlBuilder = new PropertyPageMessageHtmlBuilder(

--- a/src/Content/PropertyPageMessageHtmlBuilder.php
+++ b/src/Content/PropertyPageMessageHtmlBuilder.php
@@ -112,7 +112,7 @@ class PropertyPageMessageHtmlBuilder {
 				'id' => 'smw-property-content-editprotection-message',
 				'class' => 'plainlinks smw-callout smw-callout-warning'
 			),
-			wfMessage( 'smw-edit-protection', $GLOBALS['smwgEditProtectionRight'] )->parse()
+			wfMessage( 'smw-edit-protection', implode(', ', $GLOBALS['smwgEditProtectionRights'] ) )->parse()
 		);
 	}
 

--- a/src/MediaWiki/Hooks/ArticleProtectComplete.php
+++ b/src/MediaWiki/Hooks/ArticleProtectComplete.php
@@ -40,7 +40,7 @@ class ArticleProtectComplete extends HookHandler {
 	/**
 	 * @var boolean|string
 	 */
-	private $editProtectionRight = false;
+	private $editProtectionRights = false;
 
 	/**
 	 * @since  2.5
@@ -57,10 +57,10 @@ class ArticleProtectComplete extends HookHandler {
 	/**
 	 * @since 2.5
 	 *
-	 * @param string|boolean $editProtectionRight
+	 * @param array|boolean $editProtectionRights
 	 */
-	public function setEditProtectionRight( $editProtectionRight ) {
-		$this->editProtectionRight = $editProtectionRight;
+	public function setEditProtectionRights( $editProtectionRights ) {
+		$this->editProtectionRights = is_bool( $editProtectionRights ) ? $editProtectionRights : array_flip( (array)$editProtectionRights );
 	}
 
 	/**
@@ -70,6 +70,10 @@ class ArticleProtectComplete extends HookHandler {
 	 * @param string $reason
 	 */
 	public function process( $protections, $reason ) {
+
+		if ( $this->editProtectionRights === false ) {
+			return $this->log( __METHOD__ . ' EditProtectionRights not enabled' );
+		}
 
 		if ( Message::get( 'smw-edit-protection-auto-update' ) === $reason ) {
 			return $this->log( __METHOD__ . ' No changes required, invoked by own process!' );
@@ -112,7 +116,7 @@ class ArticleProtectComplete extends HookHandler {
 
 		// No _EDIP annotation but a selected protection matches the
 		// `EditProtectionRight` setting
-		if ( !$dataItem && isset( $protections['edit'] ) && $protections['edit'] === $this->editProtectionRight ) {
+		if ( !$dataItem && isset( $protections['edit'] ) && isset( $this->editProtectionRights[$protections['edit']] ) ) {
 			$this->log( 'ArticleProtectComplete addProperty `Is edit protected`' );
 
 			$isRestrictedUpdate = false;
@@ -126,7 +130,7 @@ class ArticleProtectComplete extends HookHandler {
 		// means that is has been set by the system and is not a "human" added
 		// annotation) but since the selected protection doesn't match the
 		// `EditProtectionRight` setting, remove the annotation
-		if ( $dataItem && $isAnnotationBySystem && isset( $protections['edit'] ) && $protections['edit'] !== $this->editProtectionRight ) {
+		if ( $dataItem && $isAnnotationBySystem && isset( $protections['edit'] ) && !isset( $this->editProtectionRights[$protections['edit']] ) ) {
 			$this->log( 'ArticleProtectComplete removeProperty `Is edit protected`' );
 
 			$isRestrictedUpdate = false;

--- a/src/MediaWiki/Hooks/HookRegistry.php
+++ b/src/MediaWiki/Hooks/HookRegistry.php
@@ -125,8 +125,8 @@ class HookRegistry {
 			$applicationFactory->singleton( 'EditProtectionValidator' )
 		);
 
-		$permissionPthValidator->setEditProtectionRight(
-			$applicationFactory->getSettings()->get( 'smwgEditProtectionRight' )
+		$permissionPthValidator->setEditProtectionRights(
+			$applicationFactory->getSettings()->get( 'smwgEditProtectionRights' )
 		);
 
 		/**
@@ -260,8 +260,8 @@ class HookRegistry {
 				$editInfoProvider
 			);
 
-			$articleProtectComplete->setEditProtectionRight(
-				$applicationFactory->getSettings()->get( 'smwgEditProtectionRight' )
+			$articleProtectComplete->setEditProtectionRights(
+				$applicationFactory->getSettings()->get( 'smwgEditProtectionRights' )
 			);
 
 			$articleProtectComplete->setLogger(

--- a/src/PermissionPthValidator.php
+++ b/src/PermissionPthValidator.php
@@ -22,7 +22,7 @@ class PermissionPthValidator {
 	/**
 	 * @var string|false
 	 */
-	private $editProtectionRight = false;
+	private $editProtectionRights = false;
 
 	/**
 	 * @since 2.5
@@ -36,10 +36,10 @@ class PermissionPthValidator {
 	/**
 	 * @since 2.5
 	 *
-	 * @param string|false $editProtectionRight
+	 * @param string|false $editProtectionRights
 	 */
-	public function setEditProtectionRight( $editProtectionRight ) {
-		$this->editProtectionRight = $editProtectionRight;
+	public function setEditProtectionRights( $editProtectionRights ) {
+		$this->editProtectionRights = is_bool( $editProtectionRights ) ? $editProtectionRights : (array)$editProtectionRights;
 	}
 
 	/**
@@ -80,7 +80,7 @@ class PermissionPthValidator {
 			return true;
 		}
 
-		if ( $this->editProtectionRight && $this->editProtectionValidator->hasProtectionOnNamespace( $title ) ) {
+		if ( $this->editProtectionRights && $this->editProtectionValidator->hasProtectionOnNamespace( $title ) ) {
 			return $this->checkPermissionOn( $title, $user, $action, $errors );
 		}
 
@@ -101,12 +101,18 @@ class PermissionPthValidator {
 
 	private function checkPermissionOn( Title &$title, User $user, $action, &$errors ) {
 
-		// @see https://www.semantic-mediawiki.org/wiki/Help:Special_property_Is_edit_protected
-		if ( !$this->editProtectionValidator->hasProtection( $title ) || $user->isAllowed( $this->editProtectionRight ) ) {
+		if ( !$this->editProtectionValidator->hasProtection( $title ) ) {
 			return true;
 		}
 
-		$errors[] = array( 'smw-edit-protection', $this->editProtectionRight );
+		// @see https://www.semantic-mediawiki.org/wiki/Help:Special_property_Is_edit_protected
+		foreach ( $this->editProtectionRights as $editProtectionRight ) {
+			if ( $user->isAllowed( $editProtectionRight ) ) {
+				return true;
+			}
+		}
+
+		$errors[] = array( 'smw-edit-protection', implode( ', ', $this->editProtectionRights ) );
 
 		return false;
 	}

--- a/src/PropertyAnnotatorFactory.php
+++ b/src/PropertyAnnotatorFactory.php
@@ -85,8 +85,8 @@ class PropertyAnnotatorFactory {
 			$title
 		);
 
-		$editProtectedPropertyAnnotator->setEditProtectionRight(
-			ApplicationFactory::getInstance()->getSettings()->get( 'smwgEditProtectionRight' )
+		$editProtectedPropertyAnnotator->setEditProtectionRights(
+			ApplicationFactory::getInstance()->getSettings()->get( 'smwgEditProtectionRights' )
 		);
 
 		return $editProtectedPropertyAnnotator;

--- a/src/PropertyAnnotators/EditProtectedPropertyAnnotator.php
+++ b/src/PropertyAnnotators/EditProtectedPropertyAnnotator.php
@@ -30,7 +30,7 @@ class EditProtectedPropertyAnnotator extends PropertyAnnotatorDecorator {
 	/**
 	 * @var boolean
 	 */
-	private $editProtectionRight = false;
+	private $editProtectionRights = false;
 
 	/**
 	 * @since 1.9
@@ -46,10 +46,10 @@ class EditProtectedPropertyAnnotator extends PropertyAnnotatorDecorator {
 	/**
 	 * @since 2.5
 	 *
-	 * @param string|boolean $editProtectionRight
+	 * @param array|boolean $editProtectionRights
 	 */
-	public function setEditProtectionRight( $editProtectionRight ) {
-		$this->editProtectionRight = $editProtectionRight;
+	public function setEditProtectionRights( $editProtectionRights ) {
+		$this->editProtectionRights = is_bool( $editProtectionRights ) ? $editProtectionRights : (array)$editProtectionRights;
 	}
 
 	/**
@@ -59,7 +59,7 @@ class EditProtectedPropertyAnnotator extends PropertyAnnotatorDecorator {
 	 */
 	public function addTopIndicatorTo( ParserOutput $parserOutput ) {
 
-		if ( $this->editProtectionRight === false ) {
+		if ( $this->editProtectionRights === false ) {
 			return false;
 		}
 
@@ -93,7 +93,7 @@ class EditProtectedPropertyAnnotator extends PropertyAnnotatorDecorator {
 	 */
 	protected function addPropertyValues() {
 
-		if ( $this->editProtectionRight === false ) {
+		if ( $this->editProtectionRights === false ) {
 			return false;
 		}
 
@@ -128,8 +128,14 @@ class EditProtectedPropertyAnnotator extends PropertyAnnotatorDecorator {
 		$restrictions = array_flip( $this->title->getRestrictions( 'edit' ) );
 
 		// There could by any edit protections but the `Is edit protected` is
-		// bound to the `smwgEditProtectionRight` setting
-		return isset( $restrictions[$this->editProtectionRight] );
+		// bound to the `smwgEditProtectionRights` setting
+		foreach ( $this->editProtectionRights as $editProtectionRight ) {
+			if ( isset( $restrictions[$editProtectionRight] ) ) {
+				return true;
+			}
+		}
+
+		return false;
 	}
 
 	private function isEnabledProtection( $property ) {

--- a/src/PropertySpecificationReqExaminer.php
+++ b/src/PropertySpecificationReqExaminer.php
@@ -36,7 +36,7 @@ class PropertySpecificationReqExaminer {
 	/**
 	 * @var boolean
 	 */
-	private $editProtectionRight = false;
+	private $editProtectionRights = false;
 
 	/**
 	 * @since 2.5
@@ -60,10 +60,10 @@ class PropertySpecificationReqExaminer {
 	/**
 	 * @since 2.5
 	 *
-	 * @param string|boolean $editProtectionRight
+	 * @param string|boolean $editProtectionRights
 	 */
-	public function setEditProtectionRight( $editProtectionRight ) {
-		$this->editProtectionRight = $editProtectionRight;
+	public function setEditProtectionRights( $editProtectionRights ) {
+		$this->editProtectionRights = $editProtectionRights;
 	}
 
 	/**
@@ -132,12 +132,12 @@ class PropertySpecificationReqExaminer {
 	}
 
 	/**
-	 * Examines whether the setting `smwgEditProtectionRight` contains an appropriate
+	 * Examines whether the setting `smwgEditProtectionRights` contains an appropriate
 	 * value or is disabled in order for the `Is edit protected` property to function.
 	 */
 	private function checkOnEditProtectionRight( $property ) {
 
-		if ( $this->editProtectionRight !== false ) {
+		if ( $this->editProtectionRights !== false ) {
 			return;
 		}
 

--- a/src/Protection/EditProtectionValidator.php
+++ b/src/Protection/EditProtectionValidator.php
@@ -41,7 +41,7 @@ class EditProtectionValidator {
 	/**
 	 * @var boolean|string
 	 */
-	private $editProtectionRight = false;
+	private $editProtectionRights = false;
 
 	/**
 	 * @since 2.5
@@ -57,10 +57,10 @@ class EditProtectionValidator {
 	/**
 	 * @since 2.5
 	 *
-	 * @param string|boolean $editProtectionRight
+	 * @param array|boolean $editProtectionRights
 	 */
-	public function setEditProtectionRight( $editProtectionRight ) {
-		$this->editProtectionRight = $editProtectionRight;
+	public function setEditProtectionRights( $editProtectionRights ) {
+		$this->editProtectionRights = implode( '|', (array)$editProtectionRights );
 	}
 
 	/**
@@ -119,10 +119,10 @@ class EditProtectionValidator {
 			return $this->intermediaryMemoryCache->fetch( $key );
 		}
 
-		// Set editProtectionRight to influence the key to detect changes
+		// Set editProtectionRights to influence the key to detect changes
 		// before the cache is evicted
 		$requestOptions = new RequestOptions();
-		$requestOptions->addExtraCondition( $this->editProtectionRight );
+		$requestOptions->addExtraCondition( $this->editProtectionRights );
 
 		$dataItems = $this->cachedPropertyValuesPrefetcher->getPropertyValues(
 			$subject,

--- a/src/SharedCallbackContainer.php
+++ b/src/SharedCallbackContainer.php
@@ -387,8 +387,8 @@ class SharedCallbackContainer implements CallbackContainer {
 				$callbackLoader->singleton( 'InMemoryPoolCache' )->getPoolCacheById( EditProtectionValidator::POOLCACHE_ID )
 			);
 
-			$editProtectionValidator->setEditProtectionRight(
-				$callbackLoader->singleton( 'Settings' )->get( 'smwgEditProtectionRight' )
+			$editProtectionValidator->setEditProtectionRights(
+				$callbackLoader->singleton( 'Settings' )->get( 'smwgEditProtectionRights' )
 			);
 
 			return $editProtectionValidator;
@@ -405,8 +405,12 @@ class SharedCallbackContainer implements CallbackContainer {
 				$user
 			);
 
-			$editProtectionUpdater->setEditProtectionRight(
-				$callbackLoader->singleton( 'Settings' )->get( 'smwgEditProtectionRight' )
+			$editProtectionUpdater->setEditProtectionRights(
+				$callbackLoader->singleton( 'Settings' )->get( 'smwgEditProtectionRights' )
+			);
+
+			$editProtectionUpdater->setEditProtectionEnforcedRight(
+				$callbackLoader->singleton( 'Settings' )->get( 'smwgEditProtectionEnforcedRight' )
 			);
 
 			$editProtectionUpdater->setLogger(

--- a/tests/phpunit/Unit/MediaWiki/Hooks/ArticleProtectCompleteTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Hooks/ArticleProtectCompleteTest.php
@@ -76,6 +76,7 @@ class ArticleProtectCompleteTest extends \PHPUnit_Framework_TestCase {
 		);
 
 		$instance->setLogger( $this->spyLogger );
+		$instance->setEditProtectionRights( 'Foo' );
 
 		$protections = array();
 		$reason = \SMW\Message::get( 'smw-edit-protection-auto-update' );
@@ -120,7 +121,7 @@ class ArticleProtectCompleteTest extends \PHPUnit_Framework_TestCase {
 		);
 
 		$instance->setLogger( $this->spyLogger );
-		$instance->setEditProtectionRight( 'Foo' );
+		$instance->setEditProtectionRights( 'Foo' );
 
 		$protections = array( 'edit' => 'Foo' );
 		$reason = '';
@@ -181,7 +182,7 @@ class ArticleProtectCompleteTest extends \PHPUnit_Framework_TestCase {
 		);
 
 		$instance->setLogger( $this->spyLogger );
-		$instance->setEditProtectionRight( 'Foo2' );
+		$instance->setEditProtectionRights( 'Foo2' );
 
 		$protections = array( 'edit' => 'Foo' );
 		$reason = '';

--- a/tests/phpunit/Unit/PermissionPthValidatorTest.php
+++ b/tests/phpunit/Unit/PermissionPthValidatorTest.php
@@ -97,7 +97,7 @@ class PermissionPthValidatorTest extends \PHPUnit_Framework_TestCase {
 
 	public function testToReturnFalseOnNamespaceWithEditPermissionCheck() {
 
-		$editProtectionRight = 'Foo';
+		$editProtectionRights = 'Foo';
 
 		$title = $this->getMockBuilder( '\Title' )
 			->disableOriginalConstructor()
@@ -129,7 +129,7 @@ class PermissionPthValidatorTest extends \PHPUnit_Framework_TestCase {
 
 		$user->expects( $this->once() )
 			->method( 'isAllowed' )
-			->with( $this->equalTo( $editProtectionRight ) )
+			->with( $this->equalTo( $editProtectionRights ) )
 			->will( $this->returnValue( false ) );
 
 		$result = '';
@@ -138,8 +138,8 @@ class PermissionPthValidatorTest extends \PHPUnit_Framework_TestCase {
 			$this->editProtectionValidator
 		);
 
-		$instance->setEditProtectionRight(
-			$editProtectionRight
+		$instance->setEditProtectionRights(
+			$editProtectionRights
 		);
 
 		$this->assertFalse(
@@ -147,14 +147,14 @@ class PermissionPthValidatorTest extends \PHPUnit_Framework_TestCase {
 		);
 
 		$this->assertEquals(
-			array( array( 'smw-edit-protection', $editProtectionRight ) ),
+			array( array( 'smw-edit-protection', $editProtectionRights ) ),
 			$result
 		);
 	}
 
 	public function testFalseEditProtectionRightToNeverCheckPermissionOnNonMwNamespace() {
 
-		$editProtectionRight = false;
+		$editProtectionRights = false;
 
 		$title = $this->getMockBuilder( '\Title' )
 			->disableOriginalConstructor()
@@ -186,8 +186,8 @@ class PermissionPthValidatorTest extends \PHPUnit_Framework_TestCase {
 			$this->editProtectionValidator
 		);
 
-		$instance->setEditProtectionRight(
-			$editProtectionRight
+		$instance->setEditProtectionRights(
+			$editProtectionRights
 		);
 
 		$this->assertTrue(

--- a/tests/phpunit/Unit/PropertyAnnotators/EditProtectedPropertyAnnotatorTest.php
+++ b/tests/phpunit/Unit/PropertyAnnotators/EditProtectedPropertyAnnotatorTest.php
@@ -57,7 +57,7 @@ class EditProtectedPropertyAnnotatorTest extends \PHPUnit_Framework_TestCase {
 	/**
 	 * @dataProvider titleProvider
 	 */
-	public function testAddAnnotationForDisplayTitle( $title, $editProtectionRight, array $expected ) {
+	public function testAddAnnotationForDisplayTitle( $title, $editProtectionRights, array $expected ) {
 
 		$semanticData = $this->semanticDataFactory->newEmptySemanticData(
 			$title
@@ -68,7 +68,7 @@ class EditProtectedPropertyAnnotatorTest extends \PHPUnit_Framework_TestCase {
 			$title
 		);
 
-		$instance->setEditProtectionRight( $editProtectionRight );
+		$instance->setEditProtectionRights( $editProtectionRights );
 		$instance->addAnnotation();
 
 		$this->semanticDataValidator->assertThatPropertiesAreSet(
@@ -113,7 +113,7 @@ class EditProtectedPropertyAnnotatorTest extends \PHPUnit_Framework_TestCase {
 			$title
 		);
 
-		$instance->setEditProtectionRight( 'Foo' );
+		$instance->setEditProtectionRights( 'Foo' );
 		$instance->addTopIndicatorTo( $parserOutput );
 	}
 

--- a/tests/phpunit/Unit/PropertySpecificationReqExaminerTest.php
+++ b/tests/phpunit/Unit/PropertySpecificationReqExaminerTest.php
@@ -62,7 +62,7 @@ class PropertySpecificationReqExaminerTest extends \PHPUnit_Framework_TestCase {
 			$this->store
 		);
 
-		$instance->setEditProtectionRight(
+		$instance->setEditProtectionRights(
 			false
 		);
 

--- a/tests/phpunit/Unit/Protection/EditProtectionUpdaterTest.php
+++ b/tests/phpunit/Unit/Protection/EditProtectionUpdaterTest.php
@@ -71,7 +71,7 @@ class EditProtectionUpdaterTest extends \PHPUnit_Framework_TestCase {
 			$this->user
 		);
 
-		$instance->setEditProtectionRight( 'Foo' );
+		$instance->setEditProtectionRights( 'Foo' );
 		$instance->doUpdateFrom( $semanticData );
 
 		$this->assertFalse(
@@ -79,7 +79,7 @@ class EditProtectionUpdaterTest extends \PHPUnit_Framework_TestCase {
 		);
 	}
 
-	public function testDoUpdateFromWithNoRestrictionsAnActiveEditProtection() {
+	public function testDoUpdateFromWithNoRestrictionsOnAnActiveEditProtection() {
 
 		$subject = $this->dataItemFactory->newDIWikiPage( 'Foo', NS_MAIN );
 
@@ -103,7 +103,7 @@ class EditProtectionUpdaterTest extends \PHPUnit_Framework_TestCase {
 			$this->user
 		);
 
-		$instance->setEditProtectionRight( 'Foo' );
+		$instance->setEditProtectionRights( 'Foo' );
 
 		$instance->setLogger(
 			$this->spyLogger
@@ -116,7 +116,50 @@ class EditProtectionUpdaterTest extends \PHPUnit_Framework_TestCase {
 		);
 
 		$this->assertContains(
-			'add protection on edit, move',
+			'add `Foo` protection on edit, move',
+			$this->spyLogger->getMessagesAsString()
+		);
+	}
+
+	public function testDoUpdateFromWithNoRestrictionsOnAnActiveEditProtectionWhileEnforcingSelectedRight() {
+
+		$subject = $this->dataItemFactory->newDIWikiPage( 'Foo', NS_MAIN );
+
+		$this->wikiPage->expects( $this->once() )
+			->method( 'getTitle' )
+			->will( $this->returnValue( $subject->getTitle() ) );
+
+		$this->wikiPage->expects( $this->once() )
+			->method( 'doUpdateRestrictions' );
+
+		$semanticData = $this->getMockBuilder( '\SMW\SemanticData' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$semanticData->expects( $this->once() )
+			->method( 'getPropertyValues' )
+			->will( $this->returnValue( array( $this->dataItemFactory->newDIBoolean( true ) ) ) );
+
+		$instance = new EditProtectionUpdater(
+			$this->wikiPage,
+			$this->user
+		);
+
+		$instance->setEditProtectionRights( array( 'Foo', 'Bar' ) );
+		$instance->setEditProtectionEnforcedRight( 'Bar' );
+
+		$instance->setLogger(
+			$this->spyLogger
+		);
+
+		$instance->doUpdateFrom( $semanticData );
+
+		$this->assertFalse(
+			$instance->isRestrictedUpdate()
+		);
+
+		$this->assertContains(
+			'add `Bar` protection on edit, move',
 			$this->spyLogger->getMessagesAsString()
 		);
 	}
@@ -156,7 +199,7 @@ class EditProtectionUpdaterTest extends \PHPUnit_Framework_TestCase {
 			$this->user
 		);
 
-		$instance->setEditProtectionRight( 'Foo' );
+		$instance->setEditProtectionRights( 'Foo' );
 
 		$instance->setLogger(
 			$this->spyLogger
@@ -212,7 +255,7 @@ class EditProtectionUpdaterTest extends \PHPUnit_Framework_TestCase {
 			$this->user
 		);
 
-		$instance->setEditProtectionRight( 'Foo' );
+		$instance->setEditProtectionRights( 'Foo' );
 
 		$instance->setLogger(
 			$this->spyLogger

--- a/tests/phpunit/includes/SetupTest.php
+++ b/tests/phpunit/includes/SetupTest.php
@@ -51,6 +51,7 @@ class SetupTest extends \PHPUnit_Framework_TestCase {
 			'smwgNamespacesWithSemanticLinks' => array(),
 			'smwgEnableUpdateJobs' => false,
 			'wgNamespacesWithSubpages' => array(),
+			'wgRestrictionLevels' => array(),
 			'wgExtensionAssetsPath'    => false,
 			'wgResourceModules' => array(),
 			'wgScriptPath'      => '/Foo',


### PR DESCRIPTION
This PR is made in reference to: #2232, #2249

This PR addresses or contains:

- Allows to use multiple edit protection rights as in `$GLOBALS['smwgEditProtectionRights'] = array( 'smw-pageedit', 'editsemiprotected' );`
- In response to https://github.com/SemanticMediaWiki/SemanticMediaWiki/pull/2232#issuecomment-279215493

This PR includes:
- [ ] Tests (unit/integration)
- [x] CI build passed
