### PR TITLE
Fixed a number of special pages to properly set headers

### DIFF
--- a/includes/specials/SMW_SpecialOWLExport.php
+++ b/includes/specials/SMW_SpecialOWLExport.php
@@ -21,6 +21,7 @@ class SMWSpecialOWLExport extends SpecialPage {
 	}
 
 	public function execute( $page ) {
+		$this->setHeaders();
 		global $wgOut, $wgRequest;
 
 		$wgOut->setPageTitle( wfMessage( 'exportrdf' )->text() );

--- a/includes/specials/SMW_SpecialTypes.php
+++ b/includes/specials/SMW_SpecialTypes.php
@@ -22,6 +22,7 @@ class SMWSpecialTypes extends SpecialPage {
 	}
 
 	public function execute( $param ) {
+		$this->setHeaders();
 		global $wgOut;
 
 		$params = SMWInfolink::decodeParameters( $param, false );

--- a/includes/specials/SpecialConcepts.php
+++ b/includes/specials/SpecialConcepts.php
@@ -116,6 +116,7 @@ class SpecialConcepts extends SpecialPage {
 	 * @param array $param
 	 */
 	public function execute( $param ) {
+		$this->setHeaders();
 
 		$this->getOutput()->setPageTitle( $this->msg( 'concepts' )->text() );
 

--- a/includes/specials/SpecialProperties.php
+++ b/includes/specials/SpecialProperties.php
@@ -36,6 +36,7 @@ class SpecialProperties extends SpecialPage {
 	 * @see SpecialPage::execute
 	 */
 	public function execute( $param ) {
+		$this->setHeaders();
 		$out = $this->getOutput();
 
 		$out->setPageTitle( $this->msg( 'properties' )->text() );

--- a/includes/specials/SpecialSemanticStatistics.php
+++ b/includes/specials/SpecialSemanticStatistics.php
@@ -32,6 +32,7 @@ class SpecialSemanticStatistics extends SpecialPage {
 	 * @see SpecialPage::execute
 	 */
 	public function execute( $param ) {
+		$this->setHeaders();
 
 		$semanticStatistics = $this->getStore()->getStatistics();
 		$context = $this->getContext();

--- a/includes/specials/SpecialUnusedProperties.php
+++ b/includes/specials/SpecialUnusedProperties.php
@@ -37,6 +37,7 @@ class SpecialUnusedProperties extends SpecialPage {
 	 * @see SpecialPage::execute
 	 */
 	public function execute( $param ) {
+		$this->setHeaders();
 
 		$out = $this->getOutput();
 

--- a/includes/specials/SpecialWantedProperties.php
+++ b/includes/specials/SpecialWantedProperties.php
@@ -37,6 +37,7 @@ class SpecialWantedProperties extends SpecialPage {
 	 * @see SpecialPage::execute
 	 */
 	public function execute( $param ) {
+		$this->setHeaders();
 
 		$out = $this->getOutput();
 


### PR DESCRIPTION
I fixed one of these recently, but realized that there are more of these in the codebase. This makes the SpecialPages adhere to stuff like `$wgDefaultRobotPolicy`