### PR TITLE
Use onoi/callback-container 2.x

### DIFF
--- a/DefaultSettings.php
+++ b/DefaultSettings.php
@@ -26,6 +26,7 @@ return array(
 	##
 	'smwgIP' => dirname( __FILE__ ) . '/',
 	'smwgExtraneousLanguageFileDir' => __DIR__ . '/i18n/extra',
+	'smwgServicesFileDir' => __DIR__ . '/src/Services',
 	##
 
 	###

--- a/composer.json
+++ b/composer.json
@@ -49,7 +49,7 @@
 		"onoi/event-dispatcher": "~1.0",
 		"onoi/blob-store": "~1.2",
 		"onoi/http-request": "~1.1",
-		"onoi/callback-container": "~1.0",
+		"onoi/callback-container": "~2.0",
 		"onoi/tesa": "~0.1",
 		"onoi/shared-resources": "~0.3"
 	},

--- a/includes/Settings.php
+++ b/includes/Settings.php
@@ -42,6 +42,7 @@ class Settings extends Options {
 			'smwgScriptPath' => isset( $GLOBALS['smwgScriptPath'] ) ? $GLOBALS['smwgScriptPath'] : '',
 			'smwgIP' => $GLOBALS['smwgIP'],
 			'smwgExtraneousLanguageFileDir' => $GLOBALS['smwgExtraneousLanguageFileDir'],
+			'smwgServicesFileDir' => $GLOBALS['smwgServicesFileDir'],
 			'smwgSemanticsEnabled' => $GLOBALS['smwgSemanticsEnabled'],
 			'smwgEnabledCompatibilityMode' => $GLOBALS['smwgEnabledCompatibilityMode'],
 			'smwgDefaultStore' => $GLOBALS['smwgDefaultStore'],

--- a/src/Services/MediaWikiServices.php
+++ b/src/Services/MediaWikiServices.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace SMW\Services;
+
+use MediaWiki\Logger\LoggerFactory;
+use MediaWiki\MediaWikiServices;
+use LBFactory;
+use Psr\Log\NullLogger;
+
+/**
+ * @codeCoverageIgnore
+ *
+ * Services defined in this file SHOULD only be accessed either via the
+ * ApplicationFactory or a different factory instance.
+ *
+ * @license GNU GPL v2
+ * @since 2.5
+ *
+ * @author mwjames
+ */
+return array(
+
+	/**
+	 * WikiPage
+	 *
+	 * @return callable
+	 */
+	'WikiPage' => function( $containerBuilder, \Title $title  ) {
+		$containerBuilder->registerExpectedReturnType( 'WikiPage', '\WikiPage' );
+		return \WikiPage::factory( $title );
+	},
+
+	/**
+	 * DBLoadBalancer
+	 *
+	 * @return callable
+	 */
+	'DBLoadBalancer' => function( $containerBuilder ) {
+		$containerBuilder->registerExpectedReturnType( 'DBLoadBalancer', '\LoadBalancer' );
+
+		 // > MW 1.27
+		if ( class_exists( '\MediaWiki\MediaWikiServices' ) && method_exists( '\MediaWiki\MediaWikiServices', 'getDBLoadBalancer' ) ) {
+			return MediaWikiServices::getInstance()->getDBLoadBalancer();
+		}
+
+		return LBFactory::singleton()->getMainLB();
+	},
+
+	/**
+	 * DBLoadBalancer
+	 *
+	 * @return callable
+	 */
+	'DefaultSearchEngineTypeForDB' => function( $containerBuilder, \IDatabase $db ) {
+
+		// MW > 1.27
+		if ( class_exists( '\MediaWiki\MediaWikiServices' ) && method_exists( 'SearchEngineFactory', 'getSearchEngineClass' ) ) {
+			return MediaWikiServices::getInstance()->getSearchEngineFactory()->getSearchEngineClass( $db );
+		}
+
+		return $db->getSearchEngine();
+	},
+
+	/**
+	 * MediaWikiLogger
+	 *
+	 * @return callable
+	 */
+	'MediaWikiLogger' => function( $containerBuilder ) {
+
+		$containerBuilder->registerExpectedReturnType( 'MediaWikiLogger', '\Psr\Log\LoggerInterface' );
+
+		if ( class_exists( '\MediaWiki\Logger\LoggerFactory' ) ) {
+			return LoggerFactory::getInstance( 'smw' );
+		}
+
+		return new NullLogger();
+	},
+
+);

--- a/tests/phpunit/Unit/Services/MediaWikiServicesContainerBuildTest.php
+++ b/tests/phpunit/Unit/Services/MediaWikiServicesContainerBuildTest.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace SMW\Tests\Services;
+
+use Onoi\CallbackContainer\CallbackContainerFactory;
+
+/**
+ * @group semantic-mediawiki
+ *
+ * @license GNU GPL v2+
+ * @since 2.5
+ *
+ * @author mwjames
+ */
+class MediaWikiServicesContainerBuildTest extends \PHPUnit_Framework_TestCase {
+
+	private $callbackContainerFactory;
+	private $servicesFileDir;
+
+	protected function setUp() {
+		parent::setUp();
+
+		$this->callbackContainerFactory = new CallbackContainerFactory();
+		$this->servicesFileDir = $GLOBALS['smwgServicesFileDir'];
+	}
+
+	/**
+	 * @dataProvider servicesProvider
+	 */
+	public function testCanConstruct( $service, $parameters, $expected ) {
+
+		array_unshift( $parameters, $service );
+
+		$containerBuilder = $this->callbackContainerFactory->newCallbackContainerBuilder();
+		$containerBuilder->registerFromFile( $this->servicesFileDir . '/' . 'MediaWikiServices.php' );
+
+		$this->assertInstanceOf(
+			$expected,
+			call_user_func_array( array( $containerBuilder, 'create' ), $parameters )
+		);
+	}
+
+	public function servicesProvider() {
+
+		$title = $this->getMockBuilder( '\Title' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$provider[] = array(
+			'WikiPage',
+			array( $title ),
+			'\WikiPage'
+		);
+
+		$provider[] = array(
+			'DBLoadBalancer',
+			array(),
+			'\LoadBalancer'
+		);
+
+/*
+		$database = $this->getMockBuilder( '\DatabaeBase' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$provider[] = array(
+			'DefaultSearchEngineTypeForDB',
+			array( $database ),
+			'\SearchEngine'
+		);
+*/
+
+		$provider[] = array(
+			'MediaWikiLogger',
+			array(),
+			'\Psr\Log\LoggerInterface'
+		);
+
+		return $provider;
+	}
+}

--- a/tests/phpunit/Unit/SharedCallbackContainerTest.php
+++ b/tests/phpunit/Unit/SharedCallbackContainerTest.php
@@ -30,15 +30,15 @@ class SharedCallbackContainerTest extends \PHPUnit_Framework_TestCase {
 
 	public function testRegister() {
 
-		$callbackLoader = $this->getMockBuilder( '\Onoi\CallbackContainer\CallbackLoader' )
+		$containerBuilder = $this->getMockBuilder( '\Onoi\CallbackContainer\ContainerBuilder' )
 			->disableOriginalConstructor()
 			->getMock();
 
-		$callbackLoader->expects( $this->atLeastOnce() )
+		$containerBuilder->expects( $this->atLeastOnce() )
 			->method( 'registerCallback' );
 
 		$instance = new SharedCallbackContainer();
-		$instance->register( $callbackLoader );
+		$instance->register( $containerBuilder );
 	}
 
 }


### PR DESCRIPTION
This PR is made in reference to: #

This PR addresses or contains:

- Requires `onoi/callback-container:~2.0`

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed
