### PR TITLE
Add SMW_HTTP_DEFERRED_SYNC_JOB, refs 2283

### DIFF
--- a/src/Defines.php
+++ b/src/Defines.php
@@ -146,6 +146,13 @@ define( 'SMW_UJ_PM_CLASTMDATE', 4 ); // compare last modified
 /**@}*/
 
 /**@{
+  * Constants for DeferredRequestDispatchManager update modes
+  */
+define( 'SMW_HTTP_DEFERRED_ASYNC', true );
+define( 'SMW_HTTP_DEFERRED_SYNC_JOB', 4 );
+/**@}*/
+
+/**@{
   * Constants DV features
   */
 define( 'SMW_DV_NONE', 0 );

--- a/src/MediaWiki/Hooks/HookRegistry.php
+++ b/src/MediaWiki/Hooks/HookRegistry.php
@@ -103,7 +103,8 @@ class HookRegistry {
 		$httpRequestFactory = new HttpRequestFactory();
 
 		$deferredRequestDispatchManager = new DeferredRequestDispatchManager(
-			$httpRequestFactory->newSocketRequest()
+			$httpRequestFactory->newSocketRequest(),
+			$applicationFactory->newJobFactory()
 		);
 
 		$deferredRequestDispatchManager->setLogger(


### PR DESCRIPTION
This PR is made in reference to: #2283 

This PR addresses or contains:

- Adds option `SMW_HTTP_DEFERRED_SYNC_JOB` to `smwgEnabledHttpDeferredJobRequest` so that updates are synchronously executed with an update transaction using the job runner

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed
