### PR TITLE
Add QueryReferenceBacklinks, refs 1117

### DIFF
--- a/i18n/en.json
+++ b/i18n/en.json
@@ -516,5 +516,6 @@
 	"smw-edit-protection-enabled":"Edit protected (Semantic MediaWiki)",
 	"smw-patternedit-protection": "This page is protected and can only be edited by users with the appropriate <code>smw-patternedit</code> [https://www.semantic-mediawiki.org/wiki/Help:Permissions permission].",
 	"smw-pa-property-predefined_edip": "\"$1\" is a predefined property provided by [https://www.semantic-mediawiki.org/wiki/Help:Special_properties Semantic MediaWiki] to indicate whether editing is protected or not.",
-	"smw-pa-property-predefined-long_edip": "While any user is qualified to add this property to a subject, only a user with a dedicated permission can edit or revoke the protection to an entity after it has been added."
+	"smw-pa-property-predefined-long_edip": "While any user is qualified to add this property to a subject, only a user with a dedicated permission can edit or revoke the protection to an entity after it has been added.",
+	"smw-query-reference-link-label" : "Query reference"
 }

--- a/includes/storage/SQLStore/SMW_Sql3SmwIds.php
+++ b/includes/storage/SQLStore/SMW_Sql3SmwIds.php
@@ -4,6 +4,7 @@ use SMW\ApplicationFactory;
 use SMW\DIProperty;
 use SMW\DIWikiPage;
 use SMW\HashBuilder;
+use SMW\RequestOptions;
 use SMW\SQLStore\IdToDataItemMatchFinder;
 use SMW\SQLStore\PropertyStatisticsTable;
 use SMW\SQLStore\RedirectInfoStore;
@@ -989,11 +990,12 @@ class SMWSql3SmwIds {
 	 * @since 2.3
 	 *
 	 * @param integer $id
+	 * @param RequestOptions|null $requestOptions
 	 *
 	 * @return string[]
 	 */
-	public function getDataItemPoolHashListFor( array $idlist ) {
-		return $this->idToDataItemMatchFinder->getDataItemPoolHashListFor( $idlist );
+	public function getDataItemPoolHashListFor( array $idlist, RequestOptions $requestOptions = null ) {
+		return $this->idToDataItemMatchFinder->getDataItemsFromList( $idlist, $requestOptions );
 	}
 
 	/**

--- a/src/MediaWiki/Hooks/HookRegistry.php
+++ b/src/MediaWiki/Hooks/HookRegistry.php
@@ -616,6 +616,43 @@ class HookRegistry {
 
 			return true;
 		};
+
+		/**
+		 * @see https://www.semantic-mediawiki.org/wiki/Hooks/Browse::AfterIncomingPropertiesLookupComplete
+		 */
+		$this->handlers['SMW::Browse::AfterIncomingPropertiesLookupComplete'] = function ( $store, $semanticData, $requestOptions ) use ( $queryDependencyLinksStoreFactory ) {
+
+			$queryReferenceBacklinks = $queryDependencyLinksStoreFactory->newQueryReferenceBacklinks(
+				$store
+			);
+
+			$queryReferenceBacklinks->addReferenceLinksTo(
+				$semanticData,
+				$requestOptions
+			);
+
+			return true;
+		};
+
+		/**
+		 * @see https://www.semantic-mediawiki.org/wiki/Hooks/Browse::BeforeIncomingPropertyValuesFurtherLinkCreate
+		 */
+		$this->handlers['SMW::Browse::BeforeIncomingPropertyValuesFurtherLinkCreate'] = function ( $property, $subject, &$html ) use ( $queryDependencyLinksStoreFactory, $applicationFactory ) {
+
+			$queryReferenceBacklinks = $queryDependencyLinksStoreFactory->newQueryReferenceBacklinks(
+				$applicationFactory->getStore()
+			);
+
+			$doesRequireFurtherLink = $queryReferenceBacklinks->doesRequireFurtherLink(
+				$property,
+				$subject,
+				$html
+			);
+
+			// Return false in order to stop the link creation process to replace the
+			// standard link
+			return $doesRequireFurtherLink;
+		};
 	}
 
 	private function registerParserFunctionHooks( ApplicationFactory $applicationFactory ) {

--- a/src/MediaWiki/Jobs/ParserCachePurgeJob.php
+++ b/src/MediaWiki/Jobs/ParserCachePurgeJob.php
@@ -121,7 +121,7 @@ class ParserCachePurgeJob extends JobBase {
 		$requestOptions->setLimit( $this->limit + 1 );
 		$requestOptions->setOffset( $this->offset );
 
-		$hashList = $queryDependencyLinksStore->findEmbeddedQueryTargetLinksHashListFor(
+		$hashList = $queryDependencyLinksStore->findEmbeddedQueryTargetLinksHashListFrom(
 			$idList,
 			$requestOptions
 		);

--- a/src/MediaWiki/Specials/Browse/ContentsBuilder.php
+++ b/src/MediaWiki/Specials/Browse/ContentsBuilder.php
@@ -252,6 +252,7 @@ class ContentsBuilder {
 		$html = "<table class=\"{$ccsPrefix}factbox\" cellpadding=\"0\" cellspacing=\"0\">\n";
 		$noresult = true;
 
+		$contextPage = $data->getSubject();
 		$diProperties = $data->getProperties();
 		$showInverse = $this->getOption( 'showInverse' );
 
@@ -260,6 +261,10 @@ class ContentsBuilder {
 			$dvProperty = DataValueFactory::getInstance()->newDataValueByItem(
 				$diProperty,
 				null
+			);
+
+			$dvProperty->setContextPage(
+				$contextPage
 			);
 
 			$propertyLabel = ValueFormatter::getPropertyLabel(

--- a/src/MediaWiki/Specials/Browse/ValueFormatter.php
+++ b/src/MediaWiki/Specials/Browse/ValueFormatter.php
@@ -103,12 +103,19 @@ class ValueFormatter {
 
 	private static function findPropertyLabel( PropertyValue $propertyValue, $incoming = false, $showInverse = false ) {
 
+		$property = $propertyValue->getDataItem();
+		$contextPage = $propertyValue->getContextPage();
+
+		// Change caption for the incoming, Has query instance
+		if ( $incoming && $property->getKey() === '_ASK' && strpos( $contextPage->getSubobjectName(), '_QUERY' ) === false ) {
+			return self::addNonBreakingSpace( wfMessage( 'smw-query-reference-link-label' )->text() );
+		}
+
 		if ( !$incoming || !$showInverse ) {
 			return self::addNonBreakingSpace( $propertyValue->getWikiValue() );
 		}
 
 		$inverseProperty = PropertyValue::makeUserProperty( wfMessage( 'smw_inverse_label_property' )->text() );
-		$property = $propertyValue->getDataItem();
 
 		$dataItems = ApplicationFactory::getInstance()->getStore()->getPropertyValues(
 			$property->getDiWikiPage(),

--- a/src/SQLStore/IdToDataItemMatchFinder.php
+++ b/src/SQLStore/IdToDataItemMatchFinder.php
@@ -7,6 +7,7 @@ use SMW\HashBuilder;
 use SMW\ApplicationFactory;
 use SMW\MediaWiki\Database;
 use SMW\IteratorFactory;
+use SMW\RequestOptions;
 
 /**
  * @license GNU GPL v2+
@@ -75,10 +76,21 @@ class IdToDataItemMatchFinder {
 	 * @since 2.3
 	 *
 	 * @param array $idList
+	 * @param RequestOptions|null $requestOptions
 	 *
 	 * @return DIWikiPage[]
 	 */
-	public function getDataItemPoolHashListFor( array $idList ) {
+	public function getDataItemsFromList( array $idList, RequestOptions $requestOptions = null ) {
+
+		$conditions = array(
+			'smw_id' => $idList,
+		);
+
+		if ( $requestOptions !== null ) {
+			foreach ( $requestOptions->getExtraConditions() as $extraCondition ) {
+				$conditions[] = $extraCondition;
+			}
+		}
 
 		$rows = $this->connection->select(
 			\SMWSQLStore3::ID_TABLE,
@@ -88,7 +100,7 @@ class IdToDataItemMatchFinder {
 				'smw_iw',
 				'smw_subobject'
 			),
-			array( 'smw_id' => $idList ),
+			$conditions,
 			__METHOD__
 		);
 

--- a/src/SQLStore/QueryDependency/QueryDependencyLinksStore.php
+++ b/src/SQLStore/QueryDependency/QueryDependencyLinksStore.php
@@ -228,6 +228,21 @@ class QueryDependencyLinksStore implements LoggerAwareInterface {
 	}
 
 	/**
+	 * @since 2.5
+	 *
+	 * @param DIWikiPage $subject
+	 * @param RequestOptions $requestOptions
+	 *
+	 * @return array
+	 */
+	public function findEmbeddedQueryTargetLinksHashListBySubject( DIWikiPage $subject, RequestOptions $requestOptions ) {
+		return $this->findEmbeddedQueryTargetLinksHashListFrom(
+			array( $this->dependencyLinksTableUpdater->getId( $subject ) ),
+			$requestOptions
+		);
+	}
+
+	/**
 	 * Finds a partial list (given limit and offset) of registered subjects that
 	 * that represent a dependency on something like a subject in a query list,
 	 * a property, or a printrequest.
@@ -250,7 +265,7 @@ class QueryDependencyLinksStore implements LoggerAwareInterface {
 	 *
 	 * @return array
 	 */
-	public function findEmbeddedQueryTargetLinksHashListFor( array $idlist, RequestOptions $requestOptions ) {
+	public function findEmbeddedQueryTargetLinksHashListFrom( array $idlist, RequestOptions $requestOptions ) {
 
 		if ( $idlist === array() || !$this->isEnabled() ) {
 			return array();
@@ -269,7 +284,7 @@ class QueryDependencyLinksStore implements LoggerAwareInterface {
 		);
 
 		foreach ( $requestOptions->getExtraConditions() as $extraCondition ) {
-			$conditions += $extraCondition;
+			$conditions[] = $extraCondition;
 		}
 
 		$rows = $this->connection->select(
@@ -290,8 +305,16 @@ class QueryDependencyLinksStore implements LoggerAwareInterface {
 			return array();
 		}
 
+		$requestOptions = new RequestOptions();
+
+		$requestOptions->addExtraCondition(
+			'smw_iw !=' . $this->connection->addQuotes( SMW_SQL3_SMWREDIIW ) . ' AND '.
+			'smw_iw !=' . $this->connection->addQuotes( SMW_SQL3_SMWDELETEIW )
+		);
+
 		return $this->store->getObjectIds()->getDataItemPoolHashListFor(
-			$targetLinksIdList
+			$targetLinksIdList,
+			$requestOptions
 		);
 	}
 

--- a/src/SQLStore/QueryDependency/QueryReferenceBacklinks.php
+++ b/src/SQLStore/QueryDependency/QueryReferenceBacklinks.php
@@ -1,0 +1,118 @@
+<?php
+
+namespace SMW\SQLStore\QueryDependency;
+
+use SMW\SQLStore\QueryDependency\QueryDependencyLinksStore;
+use SMW\DIWikiPage;
+use SMW\DIProperty;
+use SMW\Message;
+use SMW\SemanticData;
+use SMW\RequestOptions;
+
+/**
+ * @license GNU GPL v2+
+ * @since 2.5
+ *
+ * @author mwjames
+ */
+class QueryReferenceBacklinks {
+
+	/**
+	 * @var QueryDependencyLinksStore
+	 */
+	private $queryDependencyLinksStore = null;
+
+	/**
+	 * @since 2.5
+	 *
+	 * @param QueryDependencyLinksStore $queryDependencyLinksStore
+	 */
+	public function __construct( QueryDependencyLinksStore $queryDependencyLinksStore ) {
+		$this->queryDependencyLinksStore = $queryDependencyLinksStore;
+	}
+
+	/**
+	 * @since 2.5
+	 *
+	 * @param SemanticData $semanticData
+	 * @param RequestOptions|null $requestOptions
+	 *
+	 * @return boolean
+	 */
+	public function addReferenceLinksTo( SemanticData $semanticData, RequestOptions $requestOptions = null ) {
+
+		if ( $semanticData->getSubject()->getSubobjectName() !== '' || !$this->queryDependencyLinksStore->isEnabled() ) {
+			return false;
+		}
+
+		// Don't display a reference where the requesting page is
+		// part of the list that contains queries (suppress self-embedded queries)
+		foreach ( $this->queryDependencyLinksStore->findEmbeddedQueryIdListBySubject( $semanticData->getSubject() ) as $key => $qid ) {
+			$requestOptions->addExtraCondition( 's_id!=' . $qid );
+		}
+
+		$referenceLinks = $this->findReferenceLinks( $semanticData->getSubject(), $requestOptions );
+
+		$property = new DIProperty(
+			'_ASK'
+		);
+
+		foreach ( $referenceLinks as $subject ) {
+			$semanticData->addPropertyObjectValue( $property, DIWikiPage::doUnserialize( $subject ) );
+		}
+
+		return true;
+	}
+
+	/**
+	 * @since 2.5
+	 *
+	 * @param DIWikiPage $subject
+	 * @param integer $limit
+	 * @param integer $offset
+	 *
+	 * @return array
+	 */
+	public function findReferenceLinks( DIWikiPage $subject, RequestOptions $requestOptions = null ) {
+
+		$queryTargetLinksHashList = $this->queryDependencyLinksStore->findEmbeddedQueryTargetLinksHashListBySubject(
+			$subject,
+			$requestOptions
+		);
+
+		return $queryTargetLinksHashList;
+	}
+
+	/**
+	 * @since 2.5
+	 *
+	 * @param DIProperty $property
+	 * @param DIWikiPage $subject
+	 *
+	 * @return boolean
+	 */
+	public function doesRequireFurtherLink( DIProperty $property, DIWikiPage $subject, &$html ) {
+
+		if ( $property->getKey() !== '_ASK' ) {
+			return true;
+		}
+
+		$localURL = \SpecialPage::getSafeTitleFor( 'SearchByProperty' )->getLocalURL(
+			array(
+				 'property' => $property->getLabel(),
+				 'value'    => $subject->getTitle()->getPrefixedText()
+			)
+		);
+
+		$html .= \Html::element(
+			'a',
+			array( 'href' => $localURL ),
+			Message::get( 'smw_browse_more' )
+		);
+
+		// Return false in order to stop the link creation process the replace the
+		// generate link
+		return false;
+	}
+
+}

--- a/src/SQLStore/QueryDependencyLinksStoreFactory.php
+++ b/src/SQLStore/QueryDependencyLinksStoreFactory.php
@@ -7,6 +7,7 @@ use SMW\SQLStore\QueryDependency\DependencyLinksTableUpdater;
 use SMW\SQLStore\QueryDependency\EntityIdListRelevanceDetectionFilter;
 use SMW\SQLStore\QueryDependency\QueryDependencyLinksStore;
 use SMW\SQLStore\QueryDependency\QueryResultDependencyListResolver;
+use SMW\SQLStore\QueryDependency\QueryReferenceBacklinks;
 use SMW\Store;
 
 /**
@@ -44,7 +45,7 @@ class QueryDependencyLinksStoreFactory {
 	 *
 	 * @return QueryDependencyLinksStore
 	 */
-	public function newQueryDependencyLinksStore( $store ) {
+	public function newQueryDependencyLinksStore( Store $store ) {
 
 		$logger = ApplicationFactory::getInstance()->getMediaWikiLogger();
 		$dependencyLinksTableUpdater = new DependencyLinksTableUpdater( $store );
@@ -81,6 +82,8 @@ class QueryDependencyLinksStoreFactory {
 	 */
 	public function newEntityIdListRelevanceDetectionFilter( Store $store, CompositePropertyTableDiffIterator $compositePropertyTableDiffIterator ) {
 
+		$settings = ApplicationFactory::getInstance()->getSettings();
+
 		$entityIdListRelevanceDetectionFilter = new EntityIdListRelevanceDetectionFilter(
 			$store,
 			$compositePropertyTableDiffIterator
@@ -91,14 +94,25 @@ class QueryDependencyLinksStoreFactory {
 		);
 
 		$entityIdListRelevanceDetectionFilter->setPropertyExemptionlist(
-			ApplicationFactory::getInstance()->getSettings()->get( 'smwgQueryDependencyPropertyExemptionlist' )
+			$settings->get( 'smwgQueryDependencyPropertyExemptionlist' )
 		);
 
 		$entityIdListRelevanceDetectionFilter->setAffiliatePropertyDetectionlist(
-			ApplicationFactory::getInstance()->getSettings()->get( 'smwgQueryDependencyAffiliatePropertyDetectionlist' )
+			$settings->get( 'smwgQueryDependencyAffiliatePropertyDetectionlist' )
 		);
 
 		return $entityIdListRelevanceDetectionFilter;
+	}
+
+	/**
+	 * @since 2.5
+	 *
+	 * @param Store $store
+	 *
+	 * @return QueryReferenceBacklinks
+	 */
+	public function newQueryReferenceBacklinks( Store $store ) {
+		return new QueryReferenceBacklinks( $this->newQueryDependencyLinksStore( $store ) );
 	}
 
 }

--- a/tests/phpunit/Unit/MediaWiki/Specials/Browse/ContentsBuilderTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Specials/Browse/ContentsBuilderTest.php
@@ -24,7 +24,10 @@ class ContentsBuilderTest extends \PHPUnit_Framework_TestCase {
 	protected function setUp() {
 		parent::setUp();
 
-		$this->testEnvironment = new TestEnvironment();
+		// Disable a possible active hook execution
+		$this->testEnvironment = new TestEnvironment( array(
+			'smwgEnabledQueryDependencyLinksStore' => false
+		) );
 
 		$this->store = $this->getMockBuilder( '\SMW\Store' )
 			->disableOriginalConstructor()

--- a/tests/phpunit/Unit/MediaWiki/Specials/SearchByProperty/QueryResultLookupTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Specials/SearchByProperty/QueryResultLookupTest.php
@@ -108,4 +108,34 @@ class QueryResultLookupTest extends \PHPUnit_Framework_TestCase {
 		);
 	}
 
+	public function testDoQueryLinksReferences() {
+
+		$idTable = $this->getMockBuilder( '\stdClass' )
+			->setMethods( array( 'getIDFor' ) )
+			->getMock();
+
+		$idTable->expects( $this->atLeastOnce() )
+			->method( 'getIDFor' )
+			->will( $this->onConsecutiveCalls( 42 ) );
+
+		$store = $this->getMockBuilder( '\SMW\SQLStore\SQLStore' )
+			->disableOriginalConstructor()
+			->setMethods( array( 'getObjectIds' ) )
+			->getMockForAbstractClass();
+
+		$store->expects( $this->any() )
+			->method( 'getObjectIds' )
+			->will( $this->returnValue( $idTable ) );
+
+		$pageRequestOptions = new PageRequestOptions( 'Foo/Bar', array() );
+		$pageRequestOptions->initialize();
+
+		$instance = new QueryResultLookup( $store );
+
+		$this->assertInternaltype(
+			'array',
+			$instance->doQueryLinksReferences( $pageRequestOptions, 1 )
+		);
+	}
+
 }

--- a/tests/phpunit/Unit/SQLStore/IdToDataItemMatchFinderTest.php
+++ b/tests/phpunit/Unit/SQLStore/IdToDataItemMatchFinderTest.php
@@ -203,7 +203,7 @@ class IdToDataItemMatchFinderTest extends \PHPUnit_Framework_TestCase {
 		);
 	}
 
-	public function testGetDataItemPoolHashListFor() {
+	public function testGetDataItemsFromList() {
 
 		$row = new \stdClass;
 		$row->smw_title = 'Foo';
@@ -228,7 +228,7 @@ class IdToDataItemMatchFinderTest extends \PHPUnit_Framework_TestCase {
 			new IteratorFactory()
 		);
 
-		foreach ( $instance->getDataItemPoolHashListFor( array( 42 ) ) as $value ) {
+		foreach ( $instance->getDataItemsFromList( array( 42 ) ) as $value ) {
 			$this->assertEquals(
 				'Foo#0##',
 				$value

--- a/tests/phpunit/Unit/SQLStore/QueryDependency/QueryReferenceBacklinksTest.php
+++ b/tests/phpunit/Unit/SQLStore/QueryDependency/QueryReferenceBacklinksTest.php
@@ -1,0 +1,143 @@
+<?php
+
+namespace SMW\Tests\SQLStore\QueryDependency;
+
+use SMW\SQLStore\QueryDependency\QueryReferenceBacklinks;
+use SMW\Tests\TestEnvironment;
+use SMW\DataItemFactory;
+use SMW\RequestOptions;
+
+/**
+ * @covers \SMW\SQLStore\QueryDependency\QueryReferenceBacklinks
+ * @group semantic-mediawiki
+ *
+ * @license GNU GPL v2+
+ * @since 2.5
+ *
+ * @author mwjames
+ */
+class QueryReferenceBacklinksTest extends \PHPUnit_Framework_TestCase {
+
+	private $dataItemFactory;
+
+	protected function setUp() {
+		parent::setUp();
+
+		$this->dataItemFactory = new DataItemFactory();
+	}
+
+	protected function tearDown() {
+		parent::tearDown();
+	}
+
+	public function testCanConstruct() {
+
+		$queryDependencyLinksStore = $this->getMockBuilder( '\SMW\SQLStore\QueryDependency\QueryDependencyLinksStore' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$this->assertInstanceOf(
+			'\SMW\SQLStore\QueryDependency\QueryReferenceBacklinks',
+			new QueryReferenceBacklinks( $queryDependencyLinksStore )
+		);
+	}
+
+	public function testAddQueryReferenceBacklinksTo() {
+
+		$subject = $this->dataItemFactory->newDIWikiPage( 'Bar', NS_MAIN, '', '' );
+
+		$semanticData = $this->getMockBuilder( '\SMW\SemanticData' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$semanticData->expects( $this->atLeastOnce() )
+			->method( 'getSubject' )
+			->will( $this->returnValue( $subject ) );
+
+		$semanticData->expects( $this->any() )
+			->method( 'addPropertyObjectValue' )
+			->with(
+				$this->equalTo( $this->dataItemFactory->newDIProperty( '_ASK' ) ),
+				$this->equalTo( $this->dataItemFactory->newDIWikiPage( 'Foo', NS_MAIN ) ) );
+
+		$queryDependencyLinksStore = $this->getMockBuilder( '\SMW\SQLStore\QueryDependency\QueryDependencyLinksStore' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$queryDependencyLinksStore->expects( $this->once() )
+			->method( 'isEnabled' )
+			->will( $this->returnValue( true ) );
+
+		$queryDependencyLinksStore->expects( $this->any() )
+			->method( 'getIdBySubject' )
+			->with( $this->equalTo( $subject ) );
+
+		$queryDependencyLinksStore->expects( $this->any() )
+			->method( 'findEmbeddedQueryIdListBySubject' )
+			->with( $this->equalTo( $subject ) )
+			->will( $this->returnValue( array( 'Foo#0##' => 42 ) ) );
+
+		$queryDependencyLinksStore->expects( $this->once() )
+			->method( 'findEmbeddedQueryTargetLinksHashListBySubject' )
+			->will( $this->returnValue( array( 'Foo#0##' ) ) );
+
+		$instance = new QueryReferenceBacklinks(
+			$queryDependencyLinksStore
+		);
+
+		$requestOptions = new RequestOptions();
+
+		$this->assertTrue(
+			$instance->addReferenceLinksTo( $semanticData, $requestOptions )
+		);
+	}
+
+	public function testFindQueryReferenceBacklinks() {
+
+		$subject = $this->dataItemFactory->newDIWikiPage( 'Bar', NS_MAIN, '', '' );
+
+		$queryDependencyLinksStore = $this->getMockBuilder( '\SMW\SQLStore\QueryDependency\QueryDependencyLinksStore' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$queryDependencyLinksStore->expects( $this->any() )
+			->method( 'getIdBySubject' )
+			->with( $this->equalTo( $subject ) );
+
+		$queryDependencyLinksStore->expects( $this->any() )
+			->method( 'findEmbeddedQueryTargetLinksHashListBySubject' )
+			->will( $this->returnValue( array( 'Foo#0##' ) ) );
+
+		$instance = new QueryReferenceBacklinks(
+			$queryDependencyLinksStore
+		);
+
+		$requestOptions = new RequestOptions();
+
+		$this->assertEquals(
+			 array( 'Foo#0##' ),
+			$instance->findReferenceLinks( $subject, $requestOptions )
+		);
+	}
+
+	public function testInspectFurtherLinkRequirement() {
+
+		$property = $this->dataItemFactory->newDIProperty( '_ASK' );
+		$subject = $this->dataItemFactory->newDIWikiPage( 'Bar', NS_MAIN, '', '' );
+
+		$queryDependencyLinksStore = $this->getMockBuilder( '\SMW\SQLStore\QueryDependency\QueryDependencyLinksStore' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$instance = new QueryReferenceBacklinks(
+			$queryDependencyLinksStore
+		);
+
+		$html = '';
+
+		$this->assertFalse(
+			$instance->doesRequireFurtherLink( $property, $subject, $html )
+		);
+	}
+
+}

--- a/tests/phpunit/Unit/SQLStore/QueryDependencyLinksStoreFactoryTest.php
+++ b/tests/phpunit/Unit/SQLStore/QueryDependencyLinksStoreFactoryTest.php
@@ -65,4 +65,18 @@ class QueryDependencyLinksStoreFactoryTest extends \PHPUnit_Framework_TestCase {
 		);
 	}
 
+	public function testCanConstructQueryReferenceBacklinks() {
+
+		$store = $this->getMockBuilder( '\SMW\Store' )
+			->disableOriginalConstructor()
+			->getMockForAbstractClass();
+
+		$instance = new QueryDependencyLinksStoreFactory();
+
+		$this->assertInstanceOf(
+			'\SMW\SQLStore\QueryDependency\QueryReferenceBacklinks',
+			$instance->newQueryReferenceBacklinks( $store )
+		);
+	}
+
 }


### PR DESCRIPTION
This PR is made in reference to: #1117

This PR addresses or contains:

- If `smwgEnabledQueryDependencyLinksStore` is enabled then `Special:Browse` will list query references that have an active link to the browsed subject aka "Which queries link to this subject?"

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed
