### PR TITLE
ParserAfterTidy avoid Parser::lock (Parser state cleared while parsing)

### DIFF
--- a/src/MediaWiki/Hooks/HookRegistry.php
+++ b/src/MediaWiki/Hooks/HookRegistry.php
@@ -138,11 +138,14 @@ class HookRegistry {
 		$this->handlers['ParserAfterTidy'] = function ( &$parser, &$text ) {
 
 			$parserAfterTidy = new ParserAfterTidy(
-				$parser,
-				$text
+				$parser
 			);
 
-			return $parserAfterTidy->process();
+			$parserAfterTidy->isCommandLineMode(
+				$GLOBALS['wgCommandLineMode']
+			);
+
+			return $parserAfterTidy->process( $text );
 		};
 
 		/**


### PR DESCRIPTION
This PR is made in reference to: #

This PR addresses or contains:

- Edge case for when a purge request on a redirect remained active during a `UpdateJob`

This PR includes:
- [ ] Tests (unit/integration)
- [x] CI build passed
