### PR TITLE
Add Query::NO_DEP_TRACE option

### DIFF
--- a/includes/ParserData.php
+++ b/includes/ParserData.php
@@ -26,6 +26,11 @@ class ParserData {
 	const DATA_ID = 'smwdata';
 
 	/**
+	 * Indicates that no #ask dependency tracking should occur
+	 */
+	const NO_QUERY_DEP_TRACE = 'no.query.dep.trace';
+
+	/**
 	 * @var Title
 	 */
 	private $title;
@@ -58,6 +63,11 @@ class ParserData {
 	private $origin = '';
 
 	/**
+	 * @var Options
+	 */
+	private $options = null;
+
+	/**
 	 * @since 1.9
 	 *
 	 * @param Title $title
@@ -68,6 +78,37 @@ class ParserData {
 		$this->parserOutput = $parserOutput;
 
 		$this->initSemanticData();
+	}
+
+	/**
+	 * @since 2.5
+	 *
+	 * @param string $key
+	 *
+	 * @return mixed
+	 */
+	public function getOption( $key ) {
+
+		if ( !$this->options instanceof Options ) {
+			$this->options = new Options();
+		}
+
+		return $this->options->has( $key ) ? $this->options->get( $key ) : null;
+	}
+
+	/**
+	 * @since 2.5
+	 *
+	 * @param string $key
+	 * @param string $value
+	 */
+	public function setOption( $key, $value ) {
+
+		if ( !$this->options instanceof Options ) {
+			$this->options = new Options();
+		}
+
+		return $this->options->set( $key, $value );
 	}
 
 	/**

--- a/includes/query/SMW_Query.php
+++ b/includes/query/SMW_Query.php
@@ -64,6 +64,11 @@ class SMWQuery implements QueryContext {
 	 */
 	const NO_CACHE = 'no.cache';
 
+	/**
+	 * Indicates no dependency trace
+	 */
+	const NO_DEP_TRACE = 'no.dep.trace';
+
 	public $sort = false;
 	public $sortkeys = array(); // format: "Property key" => "ASC" / "DESC" (note: order of entries also matters)
 	public $querymode = self::MODE_INSTANCES;

--- a/src/ParserFunctionFactory.php
+++ b/src/ParserFunctionFactory.php
@@ -31,9 +31,9 @@ class ParserFunctionFactory {
 	/**
 	 * @since 1.9
 	 *
-	 * @param Parser $parser
+	 * @param Parser|null $parser
 	 */
-	public function __construct( Parser $parser ) {
+	public function __construct( Parser $parser = null ) {
 		$this->parser = $parser;
 	}
 
@@ -81,6 +81,10 @@ class ParserFunctionFactory {
 			$parser->getOutput()
 		);
 
+		if ( isset( $parser->getOptions()->smwAskNoDependencyTracking ) ) {
+			$parserData->setOption( $parserData::NO_QUERY_DEP_TRACE, $parser->getOptions()->smwAskNoDependencyTracking );
+		}
+
 		$messageFormatter = new MessageFormatter(
 			$parser->getTargetLanguage()
 		);
@@ -110,6 +114,10 @@ class ParserFunctionFactory {
 			$parser->getTitle(),
 			$parser->getOutput()
 		);
+
+		if ( isset( $parser->getOptions()->smwAskNoDependencyTracking ) ) {
+			$parserData->setOption( $parserData::NO_QUERY_DEP_TRACE, $parser->getOptions()->smwAskNoDependencyTracking );
+		}
 
 		$messageFormatter = new MessageFormatter(
 			$parser->getTargetLanguage()

--- a/src/ParserFunctions/AskParserFunction.php
+++ b/src/ParserFunctions/AskParserFunction.php
@@ -175,6 +175,10 @@ class AskParserFunction {
 			$contextPage
 		);
 
+		if ( $this->parserData->getOption( ParserData::NO_QUERY_DEP_TRACE ) ) {
+			$query->setOption( $query::NO_DEP_TRACE, true );
+		}
+
 		$queryHash = $query->getHash();
 
 		$this->circularReferenceGuard->mark( $queryHash );

--- a/src/SQLStore/QueryDependency/QueryDependencyLinksStore.php
+++ b/src/SQLStore/QueryDependency/QueryDependencyLinksStore.php
@@ -10,6 +10,7 @@ use SMW\SQLStore\CompositePropertyTableDiffIterator;
 use SMW\Store;
 use SMW\RequestOptions;
 use SMW\SQLStore\SQLStore;
+use SMWQuery as Query;
 use SMWQueryResult as QueryResult;
 use Psr\Log\LoggerInterface;
 use Psr\Log\LoggerAwareInterface;
@@ -395,7 +396,14 @@ class QueryDependencyLinksStore implements LoggerAwareInterface {
 	}
 
 	private function canUpdateDependencies( $queryResult ) {
-		return $this->isEnabled() && $queryResult instanceof QueryResult && $queryResult->getQuery() !== null && $queryResult->getQuery()->getContextPage() !== null && $queryResult->getQuery()->getLimit() > 0;
+
+		if ( !$this->isEnabled() || !$queryResult instanceof QueryResult ) {
+			return false;
+		}
+
+		$query = $queryResult->getQuery();
+
+		return $query !== null && $query->getContextPage() !== null && $query->getLimit() > 0 && $query->getOption( Query::NO_DEP_TRACE ) !== true;
 	}
 
 	private function canSuppressUpdateOnSkewFactorFor( $sid, $subject ) {

--- a/tests/phpunit/Unit/ParserFunctionFactoryTest.php
+++ b/tests/phpunit/Unit/ParserFunctionFactoryTest.php
@@ -4,7 +4,7 @@ namespace SMW\Tests;
 
 use SMW\DIWikiPage;
 use SMW\ParserFunctionFactory;
-use SMW\Tests\Utils\UtilityFactory;
+use SMW\Tests\TestEnvironment;
 
 /**
  * @covers \SMW\ParserFunctionFactory
@@ -22,7 +22,20 @@ class ParserFunctionFactoryTest extends \PHPUnit_Framework_TestCase {
 	protected function setUp() {
 		parent::setUp();
 
-		$this->parserFactory = UtilityFactory::getInstance()->newParserFactory();
+		$this->testEnvironment = new TestEnvironment();
+
+		$this->parserData = $this->getMockBuilder( '\SMW\ParserData' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$this->testEnvironment->registerObject( 'ParserData', $this->parserData );
+
+		$this->parserFactory = $this->testEnvironment->getUtilityFactory()->newParserFactory();
+	}
+
+	protected function tearDown() {
+		$this->testEnvironment->tearDown();
+		parent::tearDown();
 	}
 
 	public function testCanConstruct() {
@@ -47,9 +60,7 @@ class ParserFunctionFactoryTest extends \PHPUnit_Framework_TestCase {
 	 */
 	public function testParserFunctionInstance( $instance, $method ) {
 
-		$parser = $this->parserFactory->newFromTitle(
-			DIWikiPage::newFromText( __METHOD__ )->getTitle()
-		);
+		$parser = $this->parserFactory->create( __METHOD__ );
 
 		$parserFunctionFactory = new ParserFunctionFactory( $parser );
 
@@ -64,9 +75,7 @@ class ParserFunctionFactoryTest extends \PHPUnit_Framework_TestCase {
 	 */
 	public function testParserFunctionDefinition( $method, $expected ) {
 
-		$parser = $this->parserFactory->newFromTitle(
-			DIWikiPage::newFromText( __METHOD__ )->getTitle()
-		);
+		$parser = $this->parserFactory->create( __METHOD__ );
 
 		$parserFunctionFactory = new ParserFunctionFactory( $parser );
 
@@ -88,6 +97,25 @@ class ParserFunctionFactoryTest extends \PHPUnit_Framework_TestCase {
 		$this->assertInternalType(
 			'integer',
 			$definition[2]
+		);
+	}
+
+	public function testAskParserFunctionWithParserOption() {
+
+		$this->parserData->expects( $this->once() )
+			->method( 'setOption' )
+			->with(
+				$this->equalTo( \SMW\ParserData::NO_QUERY_DEP_TRACE ),
+				$this->anything() );
+
+		$parser = $this->parserFactory->create( __METHOD__ );
+		$parser->getOptions()->smwAskNoDependencyTracking = true;
+
+		$parserFunctionFactory = new ParserFunctionFactory();
+
+		$this->assertInstanceOf(
+			'\SMW\ParserFunctions\AskParserFunction',
+			$parserFunctionFactory->newAskParserFunction( $parser )
 		);
 	}
 

--- a/tests/phpunit/Utils/ParserFactory.php
+++ b/tests/phpunit/Utils/ParserFactory.php
@@ -5,6 +5,7 @@ namespace SMW\Tests\Utils;
 use Parser;
 use ParserOptions;
 use SMW\Tests\Utils\Mock\MockSuperUser;
+use SMW\DIWikiPage;
 use Title;
 use User;
 
@@ -17,6 +18,19 @@ use User;
  * @since 2.0
  */
 class ParserFactory {
+
+	public static function create( $title, User $user = null ) {
+
+		if ( is_string( $title ) ) {
+			$title = Title::newFromText( $title );
+		}
+
+		if ( $title instanceof DIWikiPage ) {
+			$title = $title->getTitle();
+		}
+
+		return self::newFromTitle( $title, $user );
+	}
 
 	public static function newFromTitle( Title $title, User $user = null ) {
 

--- a/tests/phpunit/includes/ParserDataTest.php
+++ b/tests/phpunit/includes/ParserDataTest.php
@@ -411,4 +411,28 @@ class ParserDataTest extends \PHPUnit_Framework_TestCase {
 		);
 	}
 
+	public function testSetGetOption() {
+
+		$title = $this->getMockBuilder( 'Title' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$title->expects( $this->once() )
+			->method( 'getNamespace' )
+			->will( $this->returnValue( -1 ) );
+
+		$parserOutput = new ParserOutput();
+
+		$instance = new ParserData(
+			$title,
+			$parserOutput
+		);
+
+		$instance->setOption( $instance::NO_QUERY_DEP_TRACE, true );
+
+		$this->assertTrue(
+			$instance->getOption( $instance::NO_QUERY_DEP_TRACE )
+		);
+	}
+
 }


### PR DESCRIPTION
This PR is made in reference to: #

This PR addresses or contains:

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed
