### PR TITLE
Add replication property exemption list (SPARQLStore)

### DIFF
--- a/DefaultSettings.php
+++ b/DefaultSettings.php
@@ -165,6 +165,18 @@ return array(
 	'smwgSparqlRepositoryConnectorForcedHttpVersion' => false,
 	##
 
+	##
+	# Property replication exemption list
+	#
+	# Listed properties will be exempted from the replication process for a
+	# registered SPARQL repository.
+	#
+	# @since 2.5
+	# @default array
+	##
+	'smwgSparqlReplicationPropertyExemptionList' => array(),
+	##
+
 	###
 	# Setting this option to true before including this file to enable the old
 	# Type: namespace that SMW used up to version 1.5.*. This should only be

--- a/includes/SemanticData.php
+++ b/includes/SemanticData.php
@@ -549,6 +549,40 @@ class SemanticData {
 	}
 
 	/**
+	 * Removes a property and all the values associated with this property.
+	 *
+	 * @since 2.5
+	 *
+	 * @param $property DIProperty
+	 */
+	public function removeProperty( DIProperty $property ) {
+
+		$this->hash = null;
+		$key = $property->getKey();
+
+		 // Inverse properties cannot be used for an annotation
+		if ( $property->isInverse() || !isset( $this->mProperties[$key] ) ) {
+			return;
+		}
+
+		// Find and remove associated assignments (e.g. _ASK as subobject
+		// contains _ASKSI ...)
+		foreach ( $this->mPropVals[$key] as $dataItem ) {
+
+			if ( !$dataItem instanceof DIWikiPage || $dataItem->getSubobjectName() === '' ) {
+				continue;
+			}
+
+			if ( ( $subSemanticData = $this->findSubSemanticData( $dataItem->getSubobjectName() ) ) !== null ) {
+				$this->removeSubSemanticData( $subSemanticData );
+			}
+		}
+
+		unset( $this->mPropVals[$key] );
+		unset( $this->mProperties[$key] );
+	}
+
+	/**
 	 * Delete all data other than the subject.
 	 */
 	public function clear() {
@@ -668,7 +702,7 @@ class SemanticData {
 	 *
 	 * @param string $subobjectName
 	 *
-	 * @return SMWContainerSemanticData|[]
+	 * @return SMWContainerSemanticData|null
 	 */
 	public function findSubSemanticData( $subobjectName ) {
 		return $this->subSemanticData->findSubSemanticData( $subobjectName );

--- a/includes/Settings.php
+++ b/includes/Settings.php
@@ -55,6 +55,7 @@ class Settings extends Options {
 			'smwgSparqlDataEndpoint' => $GLOBALS['smwgSparqlDataEndpoint'],
 			'smwgSparqlDefaultGraph' => $GLOBALS['smwgSparqlDefaultGraph'],
 			'smwgSparqlRepositoryConnectorForcedHttpVersion' => $GLOBALS['smwgSparqlRepositoryConnectorForcedHttpVersion'],
+			'smwgSparqlReplicationPropertyExemptionList' => $GLOBALS['smwgSparqlReplicationPropertyExemptionList'],
 			'smwgSparqlQFeatures' => $GLOBALS['smwgSparqlQFeatures'],
 			'smwgHistoricTypeNamespace' => $GLOBALS['smwgHistoricTypeNamespace'],
 			'smwgNamespaceIndex' => $GLOBALS['smwgNamespaceIndex'],

--- a/src/DataModel/SubSemanticData.php
+++ b/src/DataModel/SubSemanticData.php
@@ -5,6 +5,7 @@ namespace SMW\DataModel;
 use SMW\Exception\SubSemanticDataException;
 use SMW\SemanticData;
 use SMW\DIWikiPage;
+use SMW\DIProperty;
 
 /**
  * @private
@@ -164,7 +165,7 @@ class SubSemanticData {
 	 *
 	 * @param string $subobjectName
 	 *
-	 * @return ContainerSemanticData|[]
+	 * @return ContainerSemanticData|null
 	 */
 	public function findSubSemanticData( $subobjectName ) {
 
@@ -172,7 +173,7 @@ class SubSemanticData {
 			return $this->subSemanticData[$subobjectName];
 		}
 
-		return array();
+		return null;
 	}
 
 	/**
@@ -233,6 +234,25 @@ class SubSemanticData {
 			if ( $this->subSemanticData[$subobjectName]->isEmpty() ) {
 				unset( $this->subSemanticData[$subobjectName] );
 			}
+		}
+	}
+
+	/**
+	 * Remove property and all values associated with this property.
+	 *
+	 * @since 2.5
+	 *
+	 * @param $property DIProperty
+	 */
+	public function removeProperty( DIProperty $property ) {
+
+		 // Inverse properties cannot be used for an annotation
+		if ( $property->isInverse() ) {
+			return;
+		}
+
+		foreach ( $this->subSemanticData as $containerSemanticData ) {
+			$containerSemanticData->removeProperty( $property );
 		}
 	}
 

--- a/src/SPARQLStore/ReplicationDataTruncator.php
+++ b/src/SPARQLStore/ReplicationDataTruncator.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace SMW\SPARQLStore;
+
+use SMW\SemanticData;
+use SMW\DIProperty;
+use SMW\DataTypeRegistry;
+
+/**
+ * Truncate a SemanticData instance for the replication process
+ *
+ * @license GNU GPL v2+
+ * @since 2.5
+ *
+ * @author mwjames
+ */
+class ReplicationDataTruncator {
+
+	/**
+	 * @var array
+	 */
+	private $propertyExemptionList = array();
+
+	/**
+	 * @since 2.5
+	 *
+	 * @param array $propertyExemptionList
+	 */
+	public function setPropertyExemptionList( array $propertyExemptionList ) {
+		$this->propertyExemptionList = str_replace( ' ', '_', $propertyExemptionList );
+	}
+
+	/**
+	 * @since 2.5
+	 *
+	 * @param SemanticData $semanticDat
+	 *
+	 * @return SemanticData
+	 */
+	public function doTruncate( SemanticData $semanticData ) {
+
+		if ( $this->propertyExemptionList === array() ) {
+			return $semanticData;
+		}
+
+		foreach ( $this->propertyExemptionList as $property ) {
+			$semanticData->removeProperty( DIProperty::newFromUserLabel( $property ) );
+		}
+
+		return $semanticData;
+	}
+
+}

--- a/src/SPARQLStore/SPARQLStore.php
+++ b/src/SPARQLStore/SPARQLStore.php
@@ -179,11 +179,15 @@ class SPARQLStore extends Store {
 	 */
 	public function doSparqlDataUpdate( SemanticData $semanticData ) {
 
+		$replicationDataTruncator = $this->factory->newReplicationDataTruncator();
+		$semanticData = $replicationDataTruncator->doTruncate( $semanticData );
+
 		$repositoryRedirectLookup = $this->factory->newRepositoryRedirectLookup();
 		$this->doSparqlFlatDataUpdate( $semanticData, $repositoryRedirectLookup );
 
 		foreach( $semanticData->getSubSemanticData() as $subSemanticData ) {
-			 $this->doSparqlFlatDataUpdate( $subSemanticData, $repositoryRedirectLookup );
+			$subSemanticData = $replicationDataTruncator->doTruncate( $subSemanticData );
+			$this->doSparqlFlatDataUpdate( $subSemanticData, $repositoryRedirectLookup );
 		}
 
 		//wfDebugLog( 'smw', ' InMemoryPoolCache: ' . json_encode( \SMW\InMemoryPoolCache::getInstance()->getStats() ) );

--- a/src/SPARQLStore/SPARQLStoreFactory.php
+++ b/src/SPARQLStore/SPARQLStoreFactory.php
@@ -27,18 +27,12 @@ class SPARQLStoreFactory {
 	private $store;
 
 	/**
-	 * @var ApplicationFactory
-	 */
-	private $applicationFactory;
-
-	/**
 	 * @since 2.2
 	 *
 	 * @param SPARQLStore $store
 	 */
 	public function __construct( SPARQLStore $store ) {
 		$this->store = $store;
-		$this->applicationFactory = ApplicationFactory::getInstance();
 	}
 
 	/**
@@ -74,7 +68,7 @@ class SPARQLStoreFactory {
 		);
 
 		$compoundConditionBuilder->setPropertyHierarchyLookup(
-			$this->applicationFactory->newPropertyHierarchyLookup()
+			ApplicationFactory::getInstance()->newPropertyHierarchyLookup()
 		);
 
 		$queryEngine = new QueryEngine(
@@ -97,6 +91,22 @@ class SPARQLStoreFactory {
 	}
 
 	/**
+	 * @since 2.5
+	 *
+	 * @return ReplicationDataTruncator
+	 */
+	public function newReplicationDataTruncator() {
+
+		$replicationDataTruncator = new ReplicationDataTruncator();
+
+		$replicationDataTruncator->setPropertyExemptionList(
+			ApplicationFactory::getInstance()->getSettings()->get( 'smwgSparqlReplicationPropertyExemptionList' )
+		);
+
+		return $replicationDataTruncator;
+	}
+
+	/**
 	 * @since 2.2
 	 *
 	 * @return ConnectionManager
@@ -107,7 +117,7 @@ class SPARQLStoreFactory {
 
 		$repositoryConnectionProvider = new RepositoryConnectionProvider();
 		$repositoryConnectionProvider->setHttpVersionTo(
-			$this->applicationFactory->getSettings()->get( 'smwgSparqlRepositoryConnectorForcedHttpVersion' )
+			ApplicationFactory::getInstance()->getSettings()->get( 'smwgSparqlRepositoryConnectorForcedHttpVersion' )
 		);
 
 		$connectionManager->registerConnectionProvider(

--- a/tests/phpunit/Integration/JSONScript/JsonTestCaseScriptRunnerTest.php
+++ b/tests/phpunit/Integration/JSONScript/JsonTestCaseScriptRunnerTest.php
@@ -108,6 +108,7 @@ class JsonTestCaseScriptRunnerTest extends JsonTestCaseScriptRunner {
 		$this->testEnvironment->addConfiguration( 'smwgQueryResultCacheType', false );
 		$this->testEnvironment->addConfiguration( 'smwgQFilterDuplicates', false );
 		$this->testEnvironment->addConfiguration( 'smwgExportResourcesAsIri', false );
+		$this->testEnvironment->addConfiguration( 'smwgSparqlReplicationPropertyExemptionList', array() );
 	}
 
 	/**

--- a/tests/phpunit/Unit/DataModel/SubSemanticDataTest.php
+++ b/tests/phpunit/Unit/DataModel/SubSemanticDataTest.php
@@ -97,4 +97,40 @@ class SubSemanticDataTest extends \PHPUnit_Framework_TestCase {
 		);
 	}
 
+	public function testRemoveProperty() {
+
+		$property = $this->dataItemFactory->newDIProperty( 'Foo' );
+
+		$instance = new SubSemanticData(
+			$this->dataItemFactory->newDIWikiPage( __METHOD__, NS_MAIN )
+		);
+
+		$containerSemanticData = new ContainerSemanticData(
+			$this->dataItemFactory->newDIWikiPage( __METHOD__, NS_MAIN, '', 'Foo' )
+		);
+
+		$containerSemanticData->addPropertyObjectValue(
+			$property,
+			$this->dataItemFactory->newDIBlob( 'Bar' )
+		);
+
+		$instance->addSubSemanticData(
+			$containerSemanticData
+		);
+
+		$subSemanticData = $instance->findSubSemanticData( 'Foo' );
+
+		$this->assertTrue(
+			$subSemanticData->hasProperty( $property )
+		);
+
+		$instance->removeProperty(
+			$property
+		);
+
+		$this->assertFalse(
+			$subSemanticData->hasProperty( $property )
+		);
+	}
+
 }

--- a/tests/phpunit/Unit/SPARQLStore/ReplicationDataTruncatorTest.php
+++ b/tests/phpunit/Unit/SPARQLStore/ReplicationDataTruncatorTest.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace SMW\Tests\SPARQLStore;
+
+use SMW\SPARQLStore\ReplicationDataTruncator;
+use SMW\DIProperty;
+
+/**
+ * @covers \SMW\SPARQLStore\ReplicationDataTruncator
+ * @group semantic-mediawiki
+ *
+ * @license GNU GPL v2+
+ * @since 2.5
+ *
+ * @author mwjames
+ */
+class ReplicationDataTruncatorTest extends \PHPUnit_Framework_TestCase {
+
+	private $semanticData;
+
+	public function setUp() {
+
+		$this->semanticData = $this->getMockBuilder( '\SMW\semanticData' )
+			->disableOriginalConstructor()
+			->getMock();
+	}
+
+	public function testCanConstruct() {
+
+		$this->assertInstanceOf(
+			'\SMW\SPARQLStore\ReplicationDataTruncator',
+			new ReplicationDataTruncator()
+		);
+	}
+
+	public function testOnEmptyList() {
+
+		$instance = new ReplicationDataTruncator();
+		$semanticData = $instance->doTruncate( $this->semanticData );
+
+		$this->assertSame(
+			$this->semanticData,
+			$semanticData
+		);
+	}
+
+	public function testOnExemptedList() {
+
+		$property = new DIProperty( 'Foo_bar' );
+
+		$this->semanticData->expects( $this->once() )
+			->method( 'removeProperty' )
+			->with( $this->equalTo( $property ) );
+
+		$instance = new ReplicationDataTruncator();
+		$instance->setPropertyExemptionList( array( 'Foo bar' ) );
+
+		$instance->doTruncate( $this->semanticData );
+	}
+
+	public function testOnExemptedListWithPredefinedProperty() {
+
+		$property = new DIProperty( '_ASK' );
+
+		$this->semanticData->expects( $this->once() )
+			->method( 'removeProperty' )
+			->with($this->equalTo( $property ) );
+
+		$instance = new ReplicationDataTruncator();
+		$instance->setPropertyExemptionList( array( 'Has query' ) );
+
+		$instance->doTruncate( $this->semanticData );
+	}
+
+}

--- a/tests/phpunit/Unit/SPARQLStore/SPARQLStoreFactoryTest.php
+++ b/tests/phpunit/Unit/SPARQLStore/SPARQLStoreFactoryTest.php
@@ -81,4 +81,14 @@ class SPARQLStoreFactoryTest extends \PHPUnit_Framework_TestCase {
 		);
 	}
 
+	public function testCanConstructReplicationDataTruncator() {
+
+		$instance = new SPARQLStoreFactory( $this->store );
+
+		$this->assertInstanceOf(
+			'\SMW\SPARQLStore\ReplicationDataTruncator',
+			$instance->newReplicationDataTruncator()
+		);
+	}
+
 }

--- a/tests/phpunit/includes/SemanticDataTest.php
+++ b/tests/phpunit/includes/SemanticDataTest.php
@@ -465,6 +465,27 @@ class SemanticDataTest extends \PHPUnit_Framework_TestCase {
 		$this->assertTrue( $instance->isEmpty() );
 	}
 
+	public function testRemoveProperty() {
+
+		$property = new DIProperty( 'Foo' );
+		$instance = new SemanticData( DIWikiPage::newFromText( __METHOD__ ) );
+
+		$instance->addPropertyObjectValue(
+			$property,
+			new DIWikiPage( 'Bar', NS_MAIN, '', 'Foobar' )
+		);
+
+		$this->assertTrue(
+			$instance->hasProperty( $property )
+		);
+
+		$instance->removeProperty( $property );
+
+		$this->assertFalse(
+			$instance->hasProperty( $property )
+		);
+	}
+
 	public function testClear() {
 
 		$title = Title::newFromText( __METHOD__ );


### PR DESCRIPTION
This PR is made in reference to: #

This PR addresses or contains:

- Allows for listed properties in `smwgSparqlReplicationPropertyExemptionList` to be exempted from the replication process
- For users that " ... properties like 'Has query' for example tend to clutter sparql queries with results that have little to do with the content of the wiki. ..." (`#1987`) can maintain `$GLOBALS['smwgSparqlReplicationPropertyExemptionList'] = array( '_ASK' )`
- By default no properties are exempted

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed
