### PR TITLE
Check item type in ...ReqExaminer, refs 2227

### DIFF
--- a/src/DataTypeRegistry.php
+++ b/src/DataTypeRegistry.php
@@ -174,6 +174,13 @@ class DataTypeRegistry {
 	}
 
 	/**
+	 * @deprecated since 2.5, use DataTypeRegistry::getDataItemByTypeId
+	 */
+	public function getDataItemId( $typeId ) {
+		return $this->getDataItemByTypeId( $typeId );
+	}
+
+	/**
 	 * Get the preferred data item ID for a given type. The ID defines the
 	 * appropriate data item class for processing data of this type. See
 	 * DataItem for possible values.
@@ -185,7 +192,8 @@ class DataTypeRegistry {
 	 * @param $typeId string id string for the given type
 	 * @return integer data item ID
 	 */
-	public function getDataItemId( $typeId ) {
+	public function getDataItemByTypeId( $typeId ) {
+
 		if ( isset( $this->typeDataItemIds[$typeId] ) ) {
 			return $this->typeDataItemIds[$typeId];
 		}
@@ -206,11 +214,24 @@ class DataTypeRegistry {
 	/**
 	 * @since 2.4
 	 *
-	 * @param string
+	 * @param string $typeId
+	 *
 	 * @return boolean
 	 */
 	public function isSubDataType( $typeId ) {
 		return isset( $this->subDataTypes[$typeId] ) && $this->subDataTypes[$typeId];
+	}
+
+	/**
+	 * @since 2.5
+	 *
+	 * @param string $srcType
+	 * @param string $tagType
+	 *
+	 * @return boolean
+	 */
+	public function isEqualByType( $srcType, $tagType ) {
+		return $this->getDataItemByTypeId( $srcType ) === $this->getDataItemByTypeId( $tagType );
 	}
 
 	/**

--- a/src/PropertySpecificationReqExaminer.php
+++ b/src/PropertySpecificationReqExaminer.php
@@ -123,7 +123,7 @@ class PropertySpecificationReqExaminer {
 			list( $url, $type ) = explode( "#", end( $typeValues )->getSerialization() );
 		}
 
-		if ( $type === $property->findPropertyTypeID() ) {
+		if ( DataTypeRegistry::getInstance()->isEqualByType( $type, $property->findPropertyTypeID() ) ) {
 			return;
 		}
 

--- a/tests/phpunit/Unit/DataTypeRegistryTest.php
+++ b/tests/phpunit/Unit/DataTypeRegistryTest.php
@@ -50,6 +50,17 @@ class DataTypeRegistryTest extends \PHPUnit_Framework_TestCase {
 		);
 	}
 
+	public function testIsEqualItemType() {
+
+		$this->assertTrue(
+			$this->dataTypeRegistry->isEqualByType( '_wpg', '__sob' )
+		);
+
+		$this->assertFalse(
+			$this->dataTypeRegistry->isEqualByType( '_wpg', '_txt' )
+		);
+	}
+
 	public function testRegisterDatatype() {
 
 		$this->assertNull(


### PR DESCRIPTION
This PR is made in reference to: #2227

This PR addresses or contains:

- Comparing types by applying `===` string comparison allows for false positive therefore use a different method to compare item types

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed
