### PR TITLE
Fix Feed result printer on empty query result, refs 1419

### DIFF
--- a/includes/queryprinters/FeedResultPrinter.php
+++ b/includes/queryprinters/FeedResultPrinter.php
@@ -75,8 +75,8 @@ final class FeedResultPrinter extends FileExportPrinter {
 		if ( $outputMode == SMW_OUTPUT_FILE ) {
 			if ( $res->getCount() == 0 ){
 				$res->addErrors( array( $this->getContext()->msg( 'smw_result_noresults' )->inContentLanguage()->text() ) );
-				return '';
 			}
+
 			$result = $this->getFeed( $res, $this->params['type'] );
 		} else {
 			// Points to the Feed link


### PR DESCRIPTION
This PR is made in reference to: #1419

This PR addresses or contains:


This PR includes:
- [ ] Tests (unit/integration)
- [x] CI build passed
