### PR TITLE
Add `#-ia` output option filter for text results

### DIFF
--- a/includes/queryprinters/ListResultPrinter.php
+++ b/includes/queryprinters/ListResultPrinter.php
@@ -335,9 +335,12 @@ class ListResultPrinter extends ResultPrinter {
 	 * @return string
 	 */
 	protected function getRowListContent( array $row ) {
+
 		$firstField = true; // is this the first entry in this row?
 		$extraFields = false; // has anything but the first field been printed?
+
 		$result = '';
+		$excluded = array( 'table', 'tr', 'th', 'td', 'dl', 'dd', 'ul', 'li', 'ol' );
 
 		foreach ( $row as $field ) {
 			$firstValue = true; // is this the first value in this field?
@@ -368,17 +371,9 @@ class ListResultPrinter extends ResultPrinter {
 					}
 				}
 
-				// Display the text with tags for all non-list type outputs and
-				// where the property is of type _qty (to ensure the highlighter
-				// is displayed) but for others remove tags so that lists are
-				// not distorted by unresolved in-text tags
-				// FIXME This is a hack that limits extendibility of SMW datatypes
-				// by giving _qty a special status that no other type can have.
-				if ( $dataValue->getTypeID() === '_qty' || $this->isPlainlist() ) {
-					$result .=  $text;
-				} else {
-					$result .= Sanitizer::stripAllTags( $text );
-				}
+				// Remove seleted tags to avoid lists are distorted by unresolved
+				// in-text tags
+				$result .= $this->isPlainlist() ? $text : Sanitizer::removeHTMLtags( $text, null, array(), array(), $excluded );
 			}
 
 			$firstField = false;

--- a/src/Query/Result/ResultFieldMatchFinder.php
+++ b/src/Query/Result/ResultFieldMatchFinder.php
@@ -319,6 +319,12 @@ class ResultFieldMatchFinder {
 			return $dataItem;
 		}
 
+		// Outputs marked with -ia (import annotation) are allowed to retain a
+		// possible [[ :: ]] annotation
+		if ( strpos( $this->printRequest->getOutputFormat(), '-ia' ) !== false ) {
+			return $dataItem;
+		}
+
 		// #1314
 		$string = InTextAnnotationParser::removeAnnotation(
 			$dataItem->getString()

--- a/tests/phpunit/Integration/JSONScript/TestCases/f-0105.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/f-0105.json
@@ -1,0 +1,125 @@
+{
+	"description": "Test `format=list, ul, ol` on `_qty` property (`wgContLang=en`, `SMW_DV_NUMV_USPACE`)",
+	"setup": [
+		{
+			"namespace": "SMW_NS_PROPERTY",
+			"page": "Has area",
+			"contents": "[[Has type::Quantity]], [[Corresponds to::1 km², km ²]] [[Corresponds to::0.38610 sq mi, sqmi]] [[Corresponds to::1000 m², m ²]]"
+		},
+		{
+			"namespace": "SMW_NS_PROPERTY",
+			"page": "Has text",
+			"contents": "[[Has type::Text]]"
+		},
+		{
+			"page": "Example/F0105/1",
+			"contents": "[[Has area::10 km ²]] [[Category:F0105]]"
+		},
+		{
+			"page": "Example/F0105/2",
+			"contents": "[[Has text::Test <li>Item</li>]] [[Category:F0105]]"
+		},
+		{
+			"page": "Example/F0105/Q.1.1",
+			"contents": "{{#ask: [[Category:F0105]] [[Has area::+]] |?Has area |format=list |headers=plain }}"
+		},
+		{
+			"page": "Example/F0105/Q.1.2",
+			"contents": "{{#ask: [[Category:F0105]] [[Has area::+]] |?Has area |format=ul |headers=plain }}"
+		},
+		{
+			"page": "Example/F0105/Q.1.3",
+			"contents": "{{#ask: [[Category:F0105]] [[Has area::+]] |?Has area |format=ol |headers=plain }}"
+		},
+		{
+			"page": "Example/F0105/Q.2.1",
+			"contents": "{{#ask: [[Category:F0105]] [[Has text::+]] |?Has text |format=list |headers=plain }}"
+		},
+		{
+			"page": "Example/F0105/Q.2.2",
+			"contents": "{{#ask: [[Category:F0105]] [[Has text::+]] |?Has text |format=ul |headers=plain }}"
+		},
+		{
+			"page": "Example/F0105/Q.2.3",
+			"contents": "{{#ask: [[Category:F0105]] [[Has text::+]] |?Has text |format=ol |headers=plain }}"
+		}
+	],
+	"tests": [
+		{
+			"type": "format",
+			"about": "#0 (format=list)",
+			"subject": "Example/F0105/Q.1.1",
+			"assert-output": {
+				"to-contain": [
+					"title=\"3.861&amp;#160;sq mi 10,000&amp;#160;m²\"><span class=\"smwtext\">10&#160;km²</span><div class=\"smwttcontent\">3.861&#160;sq mi <br />10,000&#160;m² <br /></div>"
+				]
+			}
+		},
+		{
+			"type": "format",
+			"about": "#1 (format=ul)",
+			"subject": "Example/F0105/Q.1.2",
+			"assert-output": {
+				"to-contain": [
+					"title=\"3.861&amp;#160;sq mi 10,000&amp;#160;m²\"><span class=\"smwtext\">10&#160;km²</span><div class=\"smwttcontent\">3.861&#160;sq mi <br />10,000&#160;m² <br /></div>"
+				]
+			}
+		},
+		{
+			"type": "format",
+			"about": "#2 (format=ol)",
+			"subject": "Example/F0105/Q.1.3",
+			"assert-output": {
+				"to-contain": [
+					"title=\"3.861&amp;#160;sq mi 10,000&amp;#160;m²\"><span class=\"smwtext\">10&#160;km²</span><div class=\"smwttcontent\">3.861&#160;sq mi <br />10,000&#160;m² <br /></div>"
+				]
+			}
+		},
+		{
+			"type": "format",
+			"about": "#3 (format=list) with <li> element",
+			"subject": "Example/F0105/Q.2.1",
+			"assert-output": {
+				"to-contain": [
+					"title=\"Example/F0105/2\">Example/F0105/2</a> (Has text Test <li>Item</li>)"
+				]
+			}
+		},
+		{
+			"type": "format",
+			"about": "#4 (format=ul) with sanitized <li> element",
+			"subject": "Example/F0105/Q.2.2",
+			"assert-output": {
+				"to-contain": [
+					"title=\"Example/F0105/2\">Example/F0105/2</a> (Has text Test &lt;li&gt;Item&lt;/li&gt;)</li>"
+				]
+			}
+		},
+		{
+			"type": "format",
+			"about": "#5 (format=ol) with sanitized <li> element",
+			"subject": "Example/F0105/Q.2.3",
+			"assert-output": {
+				"to-contain": [
+					"title=\"Example/F0105/2\">Example/F0105/2</a> (Has text Test &lt;li&gt;Item&lt;/li&gt;)</li>"
+				]
+			}
+		}
+	],
+	"settings": {
+		"wgContLang": "en",
+		"wgLang": "en",
+		"smwgDVFeatures": [
+			"SMW_DV_NUMV_USPACE"
+		],
+		"smwgNamespacesWithSemanticLinks": {
+			"NS_MAIN": true,
+			"SMW_NS_PROPERTY": true
+		}
+	},
+	"meta": {
+		"version": "2",
+		"is-incomplete": false,
+		"debug": false
+	}
+}

--- a/tests/phpunit/Integration/JSONScript/TestCases/p-0912.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/p-0912.json
@@ -1,0 +1,112 @@
+{
+	"description": "Test `#ask` with (`#-ia`) formatter using `#set` (#..., `wgContLang=en`, `wgLang=en`)",
+	"setup": [
+		{
+			"namespace": "SMW_NS_PROPERTY",
+			"page": "Has text",
+			"contents": "[[Has type::text]]"
+		},
+		{
+			"namespace": "SMW_NS_PROPERTY",
+			"page": "Has mono text",
+			"contents": "[[Has type::Monolingual text]]"
+		},
+		{
+			"page": "Example/P0912/1",
+			"contents": "[[Category:P0912]] {{#set: Has text=Some text with annotation [[Foo::Example/P0912/1]] }}"
+		},
+		{
+			"page": "Example/P0912/Q.1",
+			"contents": "{{#ask: [[Category:P0912]] [[Has text::+]] |?Has text |link=none }}"
+		},
+		{
+			"page": "Example/P0912/Q.2",
+			"contents": "{{#ask: [[Category:P0912]] [[Has text::+]] |?Has text#-ia |link=none }}"
+		}
+	],
+	"tests": [
+		{
+			"type": "parser",
+			"about": "#0",
+			"subject": "Example/P0912/1",
+			"assert-store": {
+				"semantic-data": {
+					"strict-mode-valuematch": false,
+					"propertyCount": 4,
+					"propertyKeys": [
+						"_MDAT",
+						"_INST",
+						"_SKEY",
+						"Has text"
+					],
+					"propertyValues": [
+						"Some text with annotation [[Foo::Example/P0912/1]]"
+					]
+				}
+			}
+		},
+		{
+			"type": "parser",
+			"about": "#1 (without `-ia`)",
+			"subject": "Example/P0912/Q.1",
+			"assert-store": {
+				"semantic-data": {
+					"strict-mode-valuematch": false,
+					"propertyCount": 3,
+					"propertyKeys": [
+						"_MDAT",
+						"_ASK",
+						"_SKEY"
+					]
+				}
+			},
+			"assert-output": {
+				"to-contain": [
+					"<td class=\"Has-text smwtype_txt\">Some text with annotation Example/P0912/1</td></tr></table>"
+				]
+			}
+		},
+		{
+			"type": "parser",
+			"about": "#2 (with `-ia`)",
+			"subject": "Example/P0912/Q.2",
+			"assert-store": {
+				"semantic-data": {
+					"strict-mode-valuematch": false,
+					"propertyCount": 4,
+					"propertyKeys": [
+						"_MDAT",
+						"_ASK",
+						"_SKEY",
+						"Foo"
+					],
+					"propertyValues": [
+						"Example/P0912/1"
+					]
+				}
+			},
+			"assert-output": {
+				"to-contain": [
+					"<td class=\"Has-text smwtype_txt\">Some text with annotation",
+					"title=\"Example/P0912/1\">Example/P0912/1</a></td></tr></table>"
+				]
+			}
+		}
+	],
+	"settings": {
+		"wgContLang": "en",
+		"wgLang": "en",
+		"smwgPageSpecialProperties": [
+			"_MDAT"
+		],
+		"smwgNamespacesWithSemanticLinks": {
+			"NS_MAIN": true,
+			"SMW_NS_PROPERTY": true
+		}
+	},
+	"meta": {
+		"version": "2",
+		"is-incomplete": false,
+		"debug": false
+	}
+}

--- a/tests/phpunit/Integration/JSONScript/TestCases/p-0913.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/p-0913.json
@@ -1,0 +1,106 @@
+{
+	"description": "Test `#ask` with (`#-ia`) formatter using `smwgLinksInValues` (#..., `wgContLang=en`, `wgLang=en`, `smwgLinksInValues=SMW_LINV_OBFU`)",
+	"setup": [
+		{
+			"namespace": "SMW_NS_PROPERTY",
+			"page": "Has text",
+			"contents": "[[Has type::text]]"
+		},
+		{
+			"page": "Example/P0913/1",
+			"contents": "[[Category:P0913]] [[Has text::Some text with annotation [[Foo::Example/P0913/1]]]]"
+		},
+		{
+			"page": "Example/P0913/Q.1",
+			"contents": "{{#ask: [[Category:P0913]] [[Has text::+]] |?Has text |link=none }}"
+		},
+		{
+			"page": "Example/P0913/Q.2",
+			"contents": "{{#ask: [[Category:P0913]] [[Has text::+]] |?Has text#-ia |link=none }}"
+		}
+	],
+	"tests": [
+		{
+			"type": "parser",
+			"about": "#0",
+			"subject": "Example/P0913/1",
+			"assert-store": {
+				"semantic-data": {
+					"strict-mode-valuematch": false,
+					"propertyCount": 5,
+					"propertyKeys": [
+						"_MDAT",
+						"_INST",
+						"_SKEY",
+						"Has text",
+						"Foo"
+					],
+					"propertyValues": [
+						"Some text with annotation Example/P0913/1"
+					]
+				}
+			}
+		},
+		{
+			"type": "parser",
+			"about": "#1 (without `-ia`)",
+			"subject": "Example/P0913/Q.1",
+			"assert-store": {
+				"semantic-data": {
+					"strict-mode-valuematch": false,
+					"propertyCount": 3,
+					"propertyKeys": [
+						"_MDAT",
+						"_ASK",
+						"_SKEY"
+					]
+				}
+			},
+			"assert-output": {
+				"to-contain": [
+					"<td class=\"Has-text smwtype_txt\">Some text with annotation <a href=",
+					"title=\"Example/P0913/1\">Example/P0913/1</a></td></tr></table>"
+				]
+			}
+		},
+		{
+			"type": "parser",
+			"about": "#2 (with `-ia`)",
+			"subject": "Example/P0913/Q.2",
+			"assert-store": {
+				"semantic-data": {
+					"strict-mode-valuematch": false,
+					"propertyCount": 3,
+					"propertyKeys": [
+						"_MDAT",
+						"_ASK",
+						"_SKEY"
+					]
+				}
+			},
+			"assert-output": {
+				"to-contain": [
+					"<td class=\"Has-text smwtype_txt\">Some text with annotation <a href=",
+					"title=\"Example/P0913/1\">Example/P0913/1</a></td></tr></table>"
+				]
+			}
+		}
+	],
+	"settings": {
+		"wgContLang": "en",
+		"wgLang": "en",
+		"smwgLinksInValues": "SMW_LINV_OBFU",
+		"smwgPageSpecialProperties": [
+			"_MDAT"
+		],
+		"smwgNamespacesWithSemanticLinks": {
+			"NS_MAIN": true,
+			"SMW_NS_PROPERTY": true
+		}
+	},
+	"meta": {
+		"version": "2",
+		"is-incomplete": false,
+		"debug": false
+	}
+}


### PR DESCRIPTION
This PR is made in reference to: #1314, https://github.com/SemanticMediaWiki/SemanticCite/issues/40

This PR addresses or contains:

- If for some use cases a text that contains an in-text annotation wishes to retain that content in its raw form then `#-ia` can be used to direct that action otherwise it is filter as described in #1314
- Adds some extra `format=list` integration tests

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed
