### PR TITLE
Use `--skip-external-dependencies` with TravisCI, refs #2323

### DIFF
--- a/tests/travis/update-configuration-settings.sh
+++ b/tests/travis/update-configuration-settings.sh
@@ -76,4 +76,4 @@ echo '$wgDebugDumpSql = false;' >> LocalSettings.php
 echo '$wgShowDBErrorBacktrace = true;' >> LocalSettings.php
 echo "putenv( 'MW_INSTALL_PATH=$(pwd)' );" >> LocalSettings.php
 
-php maintenance/update.php --quick
+php maintenance/update.php --skip-external-dependencies --quick


### PR DESCRIPTION
This PR is made in reference to: #2323

This PR addresses or contains:

This PR includes:
- [ ] Tests (unit/integration)
- [x] CI build passed
