### PR TITLE
Add smwgResultFormatsFeatures, refs 2022, 2329

### DIFF
--- a/DefaultSettings.php
+++ b/DefaultSettings.php
@@ -553,6 +553,17 @@ return array(
 	'smwgResultAliases' => array( 'feed' => array( 'rss' ) ),
 	##
 
+	##
+	# Result printer features
+	#
+	# - SMW_RF_NONE
+	# - SMW_RF_TEMPLATE_OUTSEP, #2022 (use the sep parameter as outer separator)
+	#
+	# @since 2.3
+	##
+	'smwgResultFormatsFeatures' => SMW_RF_TEMPLATE_OUTSEP,
+	##
+
 	### Predefined sources for queries
 	# Array of available sources for answering queries. Can be redefined in
 	# the settings to register new sources (usually an extension will do so

--- a/includes/Settings.php
+++ b/includes/Settings.php
@@ -111,6 +111,7 @@ class Settings extends Options {
 			'smwgQuerySources' => $GLOBALS['smwgQuerySources'],
 			'smwgQTemporaryTablesAutoCommitMode' => $GLOBALS['smwgQTemporaryTablesAutoCommitMode'],
 			'smwgResultFormats' => $GLOBALS['smwgResultFormats'],
+			'smwgResultFormatsFeatures' => $GLOBALS['smwgResultFormatsFeatures'],
 			'smwgResultAliases' => $GLOBALS['smwgResultAliases'],
 			'smwgPDefaultType' => $GLOBALS['smwgPDefaultType'],
 			'smwgAllowRecursiveExport' => $GLOBALS['smwgAllowRecursiveExport'],

--- a/includes/queryprinters/ListResultPrinter.php
+++ b/includes/queryprinters/ListResultPrinter.php
@@ -242,6 +242,12 @@ class ListResultPrinter extends ResultPrinter {
 			$this->listsep = '';
 			$this->finallistsep = '';
 		}
+
+		// #2329
+		if ( $this->params['format'] === 'template' && !$this->isEnabledFeature( SMW_RF_TEMPLATE_OUTSEP ) ) {
+			$this->listsep = '';
+			$this->finallistsep = '';
+		}
 	}
 
 	/**
@@ -396,6 +402,9 @@ class ListResultPrinter extends ResultPrinter {
 	 */
 	protected function addTemplateContentFields( $row ) {
 
+		// In case the sep is used as outer sep, switch to the valuesep
+		$sep = $this->isEnabledFeature( SMW_RF_TEMPLATE_OUTSEP ) && $this->mFormat === 'template' ? $this->params['valuesep'] : $this->params['sep'];
+
 		foreach ( $row as $i => $field ) {
 
 			$value = '';
@@ -417,7 +426,7 @@ class ListResultPrinter extends ResultPrinter {
 			}
 
 			while ( ( $text = $field->getNextText( SMW_OUTPUT_WIKI, $this->getLinker( $i == 0 ) ) ) !== false ) {
-				$value .= $value === '' ? $text : $this->params['sep'] . ' ' . $text;
+				$value .= $value === '' ? $text : $sep . ' ' . $text;
 			}
 
 			$this->templateRenderer->addField( $fieldName, $value );
@@ -474,6 +483,13 @@ class ListResultPrinter extends ResultPrinter {
 			'message' => 'smw-paramdesc-sep',
 			'default' => '',
 		);
+
+		if ( $this->mFormat === 'template' && $this->isEnabledFeature( SMW_RF_TEMPLATE_OUTSEP ) ) {
+			$params['valuesep'] = array(
+				'message' => 'smw-paramdesc-sep',
+				'default' => '',
+			);
+		}
 
 		$params['template'] = array(
 			'message' => 'smw-paramdesc-template',

--- a/includes/queryprinters/ResultPrinter.php
+++ b/includes/queryprinters/ResultPrinter.php
@@ -181,6 +181,17 @@ abstract class ResultPrinter extends \ContextSource implements QueryResultPrinte
 	}
 
 	/**
+	 * @since 2.5
+	 *
+	 * @param integer $feature
+	 *
+	 * @return boolean
+	 */
+	public function isEnabledFeature( $feature ) {
+		return ( (int)$GLOBALS['smwgResultFormatsFeatures'] & $feature ) != 0;
+	}
+
+	/**
 	 * @see SMWIResultPrinter::getResult
 	 *
 	 * @note: since 1.8 this method is final, since it's the entry point.

--- a/src/Defines.php
+++ b/src/Defines.php
@@ -194,3 +194,10 @@ define( 'SMW_ADM_FULLT', 32 ); // Fulltext update
 define( 'SMW_LINV_PCRE', 2 ); // Using the PCRE approach
 define( 'SMW_LINV_OBFU', 4 ); // Using the Obfuscator approach
 /**@}*/
+
+/**@{
+  * Constants for ResultPrinter
+  */
+define( 'SMW_RF_NONE', 0 );
+define( 'SMW_RF_TEMPLATE_OUTSEP', 2 ); // #2022 Enable 2.5 behaviour for template handling
+/**@}*/

--- a/tests/phpunit/Integration/JSONScript/TestCases/f-0101.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/f-0101.json
@@ -34,11 +34,11 @@
 		},
 		{
 			"page": "template-001-asc-order-unnamed-args",
-			"contents": "{{#ask:[[Category:template-001]][[Has page property::ABC]] |?Has page property |sep=, |format=template |order=asc |link=none |limit=3 |searchlabel=furtherresults |userparam=[$%&*==42] |template=TemplateOutputUsingUnnamedArgumentsForNonUnicode |introtemplate=TemplateOutputUsingUnnamedArgumentsForNonUnicodeExtra |outrotemplate=TemplateOutputUsingUnnamedArgumentsForNonUnicodeExtra}}"
+			"contents": "{{#ask:[[Category:template-001]][[Has page property::ABC]] |?Has page property |sep=, |valuesep=, |format=template |order=asc |link=none |limit=3 |searchlabel=furtherresults |userparam=[$%&*==42] |template=TemplateOutputUsingUnnamedArgumentsForNonUnicode |introtemplate=TemplateOutputUsingUnnamedArgumentsForNonUnicodeExtra |outrotemplate=TemplateOutputUsingUnnamedArgumentsForNonUnicodeExtra}}"
 		},
 		{
 			"page": "template-001-desc-order-unnamed-args",
-			"contents": "{{#ask:[[Category:template-001]][[Has page property::ABC]] |?Has page property |sep=, |format=template |order=desc |link=none |limit=3 |searchlabel=furtherresults |userparam=[$%&*==42] |template=TemplateOutputUsingUnnamedArgumentsForNonUnicode |introtemplate=TemplateOutputUsingUnnamedArgumentsForNonUnicodeExtra |outrotemplate=TemplateOutputUsingUnnamedArgumentsForNonUnicodeExtra}}"
+			"contents": "{{#ask:[[Category:template-001]][[Has page property::ABC]] |?Has page property |sep=, |valuesep=, |format=template |order=desc |link=none |limit=3 |searchlabel=furtherresults |userparam=[$%&*==42] |template=TemplateOutputUsingUnnamedArgumentsForNonUnicode |introtemplate=TemplateOutputUsingUnnamedArgumentsForNonUnicodeExtra |outrotemplate=TemplateOutputUsingUnnamedArgumentsForNonUnicodeExtra}}"
 		}
 	],
 	"tests": [

--- a/tests/phpunit/Integration/JSONScript/TestCases/f-0102.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/f-0102.json
@@ -29,11 +29,11 @@
 		},
 		{
 			"page": "template-002-asc-order-named-args",
-			"contents": "{{#ask:[[Category:template-002]]<q>[[Has page property:一二三]] OR [[Has page property::456]]</q> |?Has page property |format=template |order=asc |sep=; |link=none |limit=10 |userparam=[$%&*==42] |template=TemplateOutputUsingNamedArgumentsForUnicodeIncludedSubject ||named args=yes}}"
+			"contents": "{{#ask:[[Category:template-002]]<q>[[Has page property:一二三]] OR [[Has page property::456]]</q> |?Has page property |format=template |order=asc |sep=; |valuesep=; |link=none |limit=10 |userparam=[$%&*==42] |template=TemplateOutputUsingNamedArgumentsForUnicodeIncludedSubject ||named args=yes}}"
 		},
 		{
 			"page": "template-002-desc-order-named-args",
-			"contents": "{{#ask:[[Category:template-002]]<q>[[Has page property:一二三]] OR [[Has page property::456]]</q> |?Has page property |format=template |order=desc |sep=; |link=none |limit=10 |userparam=[$%&*==42] |template=TemplateOutputUsingNamedArgumentsForUnicodeIncludedSubject ||named args=yes}}"
+			"contents": "{{#ask:[[Category:template-002]]<q>[[Has page property:一二三]] OR [[Has page property::456]]</q> |?Has page property |format=template |order=desc |sep=; |valuesep=; |link=none |limit=10 |userparam=[$%&*==42] |template=TemplateOutputUsingNamedArgumentsForUnicodeIncludedSubject ||named args=yes}}"
 		}
 	],
 	"tests": [

--- a/tests/phpunit/Integration/JSONScript/TestCases/f-0104.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/f-0104.json
@@ -64,7 +64,7 @@
 		},
 		{
 			"page": "Example/F0104/Q.7",
-			"contents": "{{#ask: [[Category:F0104]] |?Has page |?Has text |sep=; |format=template |template arguments=named |introtemplate=TemplateOutputUsingNamedArguments-intro |template=TemplateOutputUsingNamedArguments |outrotemplate=TemplateOutputUsingNamedArguments-outro |link=none |headers=plain }}"
+			"contents": "{{#ask: [[Category:F0104]] |?Has page |?Has text |sep=; |valuesep=; |format=template |template arguments=named |introtemplate=TemplateOutputUsingNamedArguments-intro |template=TemplateOutputUsingNamedArguments |outrotemplate=TemplateOutputUsingNamedArguments-outro |link=none |headers=plain }}"
 		}
 	],
 	"tests": [

--- a/tests/phpunit/Integration/JSONScript/TestCases/f-0803.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/f-0803.json
@@ -37,31 +37,31 @@
 		},
 		{
 			"page": "Example/F0803/Q.1",
-			"contents": "{{#ask: [[Category:F0803]] |?Has text |format=template |template=Example/F0803/Sep |mainlabel=main |named args=yes |link=none |sep= &#32;&bull;&#32; |sort=Has text |order=asc }}"
+			"contents": "{{#ask: [[Category:F0803]] |?Has text |format=template |template=Example/F0803/Sep |mainlabel=main |named args=yes |link=none |sep= &#32;&bull;&#32; |valuesep= &#32;&bull;&#32; |sort=Has text |order=asc }}"
 		},
 		{
 			"page": "Example/F0803/Q.2",
-			"contents": "{{#ask: [[Category:F0803]] |?Has text |format=template |template=Example/F0803/Sep |mainlabel=main |template arguments=named |named args=yes |link=none |sep= &#32;&bull;&#32; |sort=Has text |order=asc }}"
+			"contents": "{{#ask: [[Category:F0803]] |?Has text |format=template |template=Example/F0803/Sep |mainlabel=main |template arguments=named |named args=yes |link=none |sep= &#32;&bull;&#32; |valuesep= &#32;&bull;&#32; |sort=Has text |order=asc }}"
 		},
 		{
 			"page": "Example/F0803/Q.3",
-			"contents": "{{#ask: [[Category:F0803]] |?Has text |format=template |template=Example/F0803/Legacy |mainlabel=main |template arguments=named |link=none |sep= &#32;&bull;&#32; |sort=Has text |order=asc }}"
+			"contents": "{{#ask: [[Category:F0803]] |?Has text |format=template |template=Example/F0803/Legacy |mainlabel=main |template arguments=named |link=none |sep= &#32;&bull;&#32; |valuesep= &#32;&bull;&#32; |sort=Has text |order=asc }}"
 		},
 		{
 			"page": "Example/F0803/Q.4",
-			"contents": "{{#ask: [[Category:F0803]] |?Has text |format=template |template=Example/F0803/Named |mainlabel=main |template arguments=named |link=none |sep= &#32;&bull;&#32; |sort=Has text |order=asc }}"
+			"contents": "{{#ask: [[Category:F0803]] |?Has text |format=template |template=Example/F0803/Named |mainlabel=main |template arguments=named |link=none |sep= &#32;&bull;&#32; |valuesep= &#32;&bull;&#32; |sort=Has text |order=asc }}"
 		},
 		{
 			"page": "Example/F0803/Q.5",
-			"contents": "{{#ask: [[Category:F0803]] |?Has text |format=template |template=Example/F0803/NamedWithMainlabel |mainlabel=main |template arguments=named |link=none |sep= &#32;&bull;&#32; |sort=Has text |order=asc }}"
+			"contents": "{{#ask: [[Category:F0803]] |?Has text |format=template |template=Example/F0803/NamedWithMainlabel |mainlabel=main |template arguments=named |link=none |sep= &#32;&bull;&#32; |valuesep= &#32;&bull;&#32; |sort=Has text |order=asc }}"
 		},
 		{
 			"page": "Example/F0803/Q.6",
-			"contents": "{{#ask: [[Category:F0803]] |?Has text |format=template |template=Example/F0803/Numbered |mainlabel=main |template arguments=numbered |link=none |sep= &#32;&bull;&#32; |sort=Has text |order=asc }}"
+			"contents": "{{#ask: [[Category:F0803]] |?Has text |format=template |template=Example/F0803/Numbered |mainlabel=main |template arguments=numbered |link=none |sep= &#32;&bull;&#32; |valuesep= &#32;&bull;&#32; |sort=Has text |order=asc }}"
 		},
 		{
 			"page": "Example/F0803/Q.7",
-			"contents": "{{#ask: [[Category:F0803]] |?Has text |format=template |template=Example/F0803/Numbered |mainlabel=- |template arguments=numbered |link=none |sep= &#32;&bull;&#32; |sort=Has text |order=asc }}"
+			"contents": "{{#ask: [[Category:F0803]] |?Has text |format=template |template=Example/F0803/Numbered |mainlabel=- |template arguments=numbered |link=none |sep= &#32;&bull;&#32; |valuesep= &#32;&bull;&#32; |sort=Has text |order=asc }}"
 		}
 	],
 	"tests": [


### PR DESCRIPTION
This PR is made in reference to: #2022, #2329

This PR addresses or contains:

- Adds `$smwgResultFormatsFeatures` setting with enabled `SMW_RF_TEMPLATE_OUTSEP` flag (#2022)
- Adds `valuesep` for the `format=template` when `SMW_RF_TEMPLATE_OUTSEP` is enabled to avoid ambiguity of the `sep` parameter semantics

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed
