### PR TITLE
Allow showing annotations even if they are improper

### DIFF
--- a/includes/dataitems/SMW_DI_Error.php
+++ b/includes/dataitems/SMW_DI_Error.php
@@ -21,8 +21,14 @@ class SMWDIError extends SMWDataItem {
 	 */
 	protected $m_errors;
 
-	public function __construct( $errors ) {
+	/**
+	 * @var string
+	 */
+	private $userValue;
+
+	public function __construct( $errors, $userValue = '' ) {
 		$this->m_errors = $errors;
+		$this->userValue = $userValue;
 	}
 
 	public function getDIType() {
@@ -31,6 +37,15 @@ class SMWDIError extends SMWDataItem {
 
 	public function getErrors() {
 		return $this->m_errors;
+	}
+
+	/**
+	 * @since 3.0
+	 *
+	 * @return string
+	 */
+	public function getUserValue() {
+		return $this->userValue;
 	}
 
 	public function getSortKey() {

--- a/includes/datavalues/SMW_DataValue.php
+++ b/includes/datavalues/SMW_DataValue.php
@@ -149,6 +149,11 @@ abstract class SMWDataValue {
 	private $infoLinksProvider = null;
 
 	/**
+	 * @var string
+	 */
+	private $userValue = '';
+
+	/**
 	 * @var DataValueServiceFactory
 	 */
 	protected $dataValueServiceFactory;
@@ -178,6 +183,7 @@ abstract class SMWDataValue {
 		$this->mErrors = array(); // clear errors
 		$this->mHasErrors = false;
 		$this->m_caption = is_string( $caption ) ? trim( $caption ) : false;
+		$this->userValue = $value;
 
 		$value = CharArmor::removeControlChars(
 			CharArmor::removeSpecialChars( $value )
@@ -540,7 +546,7 @@ abstract class SMWDataValue {
 			return $this->m_dataitem;
 		}
 
-		return new SMWDIError( $this->mErrors );
+		return new SMWDIError( $this->mErrors, $this->userValue );
 	}
 
 	/**

--- a/src/DataValues/ValueFormatters/StringValueFormatter.php
+++ b/src/DataValues/ValueFormatters/StringValueFormatter.php
@@ -49,7 +49,7 @@ class StringValueFormatter extends DataValueFormatter {
 		}
 
 		if ( !$this->dataValue->isValid() ) {
-			return '';
+			return $this->dataValue->getDataItem()->getUserValue();
 		}
 
 		return $this->doFormatFinalOutputFor( $type, $linker );

--- a/tests/phpunit/Integration/JSONScript/TestCases/p-0452.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/p-0452.json
@@ -34,7 +34,7 @@
 			"subject": "Example/P0452/2",
 			"assert-output": {
 				"to-contain": [
-					"<span class=\"smw-highlighter smwttinline\" data-type=\"4\" data-state=\"inline\" data-title=\"Error\" title=\"&quot;Do&quot; is not in the list (Doe, Doe) of allowed values for the &quot;Has text&quot; property.\">"
+					"Do<span class=\"smw-highlighter\" data-type=\"4\" data-state=\"inline\" data-title=\"Error\" title=\"&quot;Do&quot; is not in the list (Doe) of allowed values for the &quot;Has text&quot; property.\">"
 				]
 			}
 		}

--- a/tests/phpunit/Integration/JSONScript/TestCases/p-0452.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/p-0452.json
@@ -34,10 +34,7 @@
 			"subject": "Example/P0452/2",
 			"assert-output": {
 				"to-contain": [
-					"<span class=\"smw-highlighter smwttinline\" data-type=\"4\" data-state=\"inline\" data-title=\"Error\" data-hasqtip=\"0\" aria-describedby=\"qtip-0\">"
-				],
-				"not-contain": [
-					"Do"
+					"<span class=\"smw-highlighter smwttinline\" data-type=\"4\" data-state=\"inline\" data-title=\"Error\" title=\"&quot;Do&quot; is not in the list (Doe, Doe) of allowed values for the &quot;Has text&quot; property.\">"
 				]
 			}
 		}

--- a/tests/phpunit/Integration/JSONScript/TestCases/p-0452.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/p-0452.json
@@ -1,0 +1,58 @@
+{
+	"description": "Test in-text `_txt` datatype in combination with an \"Allows value\" output (#2342, `wgContLang=en`, `wgLang=en`)",
+	"setup": [
+		{
+			"page": "Has text",
+			"namespace":"SMW_NS_PROPERTY",
+			"contents": "[[Has type::Text]], [[Allows value::Doe]]"
+		},
+		{
+			"page": "Example/P0452/1",
+			"namespace":"NS_MAIN",
+			"contents": "[[Has text::Doe]]"
+		},
+		{
+			"page": "Example/P0452/2",
+			"namespace":"NS_MAIN",
+			"contents": "[[Has text::Do]]"
+		}
+	],
+	"tests": [
+		{
+			"type": "parser",
+			"about": "#0 test output of the valid [[Has text::Doe]] annotation",
+			"subject": "Example/P0452/1",
+			"assert-output": {
+				"to-contain": [
+					"Doe"
+				]
+			}
+		},
+		{
+			"type": "parser",
+			"about": "#1 test output of the invalid [[Has text::Do]] annotation",
+			"subject": "Example/P0452/2",
+			"assert-output": {
+				"to-contain": [
+					"<span class=\"smw-highlighter smwttinline\" data-type=\"4\" data-state=\"inline\" data-title=\"Error\" data-hasqtip=\"0\" aria-describedby=\"qtip-0\">"
+				],
+				"not-contain": [
+					"Do"
+				]
+			}
+		}
+	],
+	"settings": {
+		"wgContLang": "en",
+		"wgLang": "en",
+		"smwgNamespacesWithSemanticLinks": {
+			"NS_MAIN": true,
+			"SMW_NS_PROPERTY": true
+		}
+	},
+	"meta": {
+		"version": "2",
+		"is-incomplete": false,
+		"debug": false
+	}
+}

--- a/tests/phpunit/Unit/DataValues/LanguageCodeValueTest.php
+++ b/tests/phpunit/Unit/DataValues/LanguageCodeValueTest.php
@@ -56,8 +56,8 @@ class LanguageCodeValueTest extends \PHPUnit_Framework_TestCase {
 		$upperCase->setUserValue( 'EN' );
 
 		$this->assertEquals(
-			$mixedCase,
-			$upperCase
+			$mixedCase->getDataItem(),
+			$upperCase->getDataItem()
 		);
 
 		$this->assertEquals(


### PR DESCRIPTION
This PR is made in reference to: #2342 

This PR addresses or contains:
- Datatype "Text" - Allow showing annotations even if they are improper

Coding by @mwjames via https://github.com/SemanticMediaWiki/SemanticMediaWiki/issues/2342#issuecomment-287533327

This PR includes:
- [ ] Tests (unit/integration)
- [x] CI build passed
