### PR TITLE
Add Highlighter::decode, refs 1768, 2347

### DIFF
--- a/includes/Highlighter.php
+++ b/includes/Highlighter.php
@@ -78,6 +78,22 @@ class Highlighter {
 	}
 
 	/**
+	 * @since 3.0
+	 *
+	 * @param string $text
+	 *
+	 * @return string
+	 */
+	public static function decode( $text ) {
+		// #2347, '[' is handled by the MediaWiki parser/sanitizer itself
+		return str_replace(
+			array( '&amp;', '&lt;', '&gt;', '&#160;', '<nowiki>', '</nowiki>' ),
+			array( '&', '<', '>', ' ', '', '' ),
+			$text
+		);
+	}
+
+	/**
 	 * Returns html output
 	 *
 	 * @since 1.9

--- a/src/GlobalFunctions.php
+++ b/src/GlobalFunctions.php
@@ -5,6 +5,7 @@ use SMW\NamespaceManager;
 use SMW\IntlNumberFormatter;
 use SMW\SPARQLStore\SparqlDBConnectionProvider;
 use SMW\ProcessingErrorMsgHandler;
+use SMW\Highlighter;
 
 /**
  * Global functions specified and used by Semantic MediaWiki. In general, it is
@@ -124,17 +125,11 @@ function smwfEncodeMessages( array $messages, $type = 'warning', $seperator = ' 
 			$errorList = '<ul>' . implode( $seperator, $messages ) . '</ul>';
 		}
 
-		$errorList = str_replace(
-			array( '&amp;', '&lt;', '&gt;', '&#160;', '<nowiki>', '</nowiki>', '[',  ),
-			array( '&', '<', '>', ' ', '', '', '&#x005B;' ),
-			$errorList
-		);
-
 		// Type will be converted internally
-		$highlighter = SMW\Highlighter::factory( $type );
+		$highlighter = Highlighter::factory( $type );
 		$highlighter->setContent( array (
 			'caption'   => null,
-			'content'   => $errorList
+			'content'   => Highlighter::decode( $errorList )
 		) );
 
 		return $highlighter->getHtml();

--- a/tests/phpunit/Integration/JSONScript/TestCases/p-0108.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/p-0108.json
@@ -1,0 +1,113 @@
+{
+	"description": "Test `#info`, `#ask` template output (#2347, `wgContLang=en`, `wgLang=en`)",
+	"setup": [
+		{
+			"namespace": "SMW_NS_PROPERTY",
+			"page": "Has page",
+			"contents": "[[Has type::Page]]"
+		},
+		{
+			"namespace": "SMW_NS_PROPERTY",
+			"page": "Has text",
+			"contents": "[[Has type::Text]]"
+		},
+		{
+			"namespace": "NS_TEMPLATE",
+			"page": "P0108.Ask.Output",
+			"contents": "<includeonly>{{{1}}} {{{2}}}</includeonly>"
+		},
+		{
+			"namespace": "NS_TEMPLATE",
+			"page": "P0108.Ask",
+			"contents": "<includeonly>{{#ask: [[Has page::P0108]] |?Has page |limit=1 |format=template |link=none |template=P0108.Ask.Output }}</includeonly>"
+		},
+		{
+			"namespace": "NS_TEMPLATE",
+			"page": "P0108",
+			"contents": "{{#info: message={{P0108.Ask}} }}"
+		},
+		{
+			"page": "Test/P0108/1",
+			"contents": "[[Has page::P0108]]"
+		},
+		{
+			"page": "Test/P0108/2",
+			"contents": "{{P0108}}"
+		},
+		{
+			"page": "Test/P0108/3",
+			"contents": "{{#set: Has text=Text with an [[Has page::annotation]] }}"
+		},
+		{
+			"page": "Test/P0108/4",
+			"contents": "{{#info: message={{#show: Test/P0108/3 |?Has text }} }}"
+		},
+		{
+			"page": "Test/P0108/5",
+			"contents": "{{#info: {{#show: Test/P0108/3 |?Has text }} }}"
+		}
+	],
+	"tests": [
+		{
+			"type": "parser",
+			"about": "#0 #info with template generate output including encoded (&#91;) on/off marker",
+			"subject": "Test/P0108/2",
+			"assert-output": {
+				"to-contain": [
+					"title=\"&amp;#91;&amp;#91;SMW::off]]Test/P0108/1 P0108&amp;#91;&amp;#91;SMW::on]]\">"
+				]
+			}
+		},
+		{
+			"type": "parser",
+			"about": "#1 $info + #show (no annotation is leaked via a text element)",
+			"subject": "Test/P0108/4",
+			"assert-store": {
+				"semantic-data": {
+					"strictPropertyValueMatch": false,
+					"propertyCount": 3,
+					"propertyKeys": [
+						"_ASK",
+						"_MDAT",
+						"_SKEY"
+					]
+				}
+			},
+			"assert-output": {
+				"to-contain": [
+					"title=\"Text with an annotation\">"
+				]
+			}
+		},
+		{
+			"type": "parser",
+			"about": "#2 $info + #show (no annotation is leaked via a text element)",
+			"subject": "Test/P0108/5",
+			"assert-store": {
+				"semantic-data": {
+					"strictPropertyValueMatch": false,
+					"propertyCount": 3,
+					"propertyKeys": [
+						"_ASK",
+						"_MDAT",
+						"_SKEY"
+					]
+				}
+			},
+			"assert-output": {
+				"to-contain": [
+					"title=\"Text with an annotation\">"
+				]
+			}
+		}
+	],
+	"settings": {
+		"wgContLang": "en",
+		"wgLang": "en"
+	},
+	"meta": {
+		"version": "2",
+		"is-incomplete": false,
+		"debug": false
+	}
+}

--- a/tests/phpunit/Unit/DataValues/InfoLinksProviderTest.php
+++ b/tests/phpunit/Unit/DataValues/InfoLinksProviderTest.php
@@ -215,7 +215,7 @@ class InfoLinksProviderTest extends \PHPUnit_Framework_TestCase {
 			->will( $this->returnValue( $instance ) );
 
 		$this->assertContains(
-			'<div class="smwttcontent">&#x005B;SERVICELINK-B SERVICELINK-A]</div>',
+			'<div class="smwttcontent">[SERVICELINK-B SERVICELINK-A]</div>',
 			$instance->getInfolinkText( SMW_OUTPUT_WIKI )
 		);
 

--- a/tests/phpunit/includes/HighlighterTest.php
+++ b/tests/phpunit/includes/HighlighterTest.php
@@ -43,6 +43,14 @@ class HighlighterTest extends \PHPUnit_Framework_TestCase {
 		);
 	}
 
+	public function testDecode() {
+
+		$this->assertEquals(
+			'&<> ',
+			Highlighter::decode( '&amp;&lt;&gt;&#160;<nowiki></nowiki>' )
+		);
+	}
+
 	/**
 	 * @dataProvider getTypeDataProvider
 	 */


### PR DESCRIPTION
This PR is made in reference to: #1768, #2347

This PR addresses or contains:

- Removes the `[` encoding introduced in #1768 to allow some post-processing to detect the necessary links

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed
