### PR TITLE
Add Job::lazyPush, and SMW_HTTP_DEFERRED_LAZY_JOB, refs 2285

### DIFF
--- a/src/DeferredRequestDispatchManager.php
+++ b/src/DeferredRequestDispatchManager.php
@@ -253,7 +253,14 @@ class DeferredRequestDispatchManager implements LoggerAwareInterface {
 			// defying the idea of a deferred process therefore only directly
 			// have the job run when initiate from the commandLine as transactions
 			// are expected without delay and are separated
-			$this->isCommandLineMode || $this->isEnabledHttpDeferredRequest === SMW_HTTP_DEFERRED_SYNC_JOB ? $job->run() : $job->insert();
+			if ( $this->isCommandLineMode || $this->isEnabledHttpDeferredRequest === SMW_HTTP_DEFERRED_SYNC_JOB ) {
+				$job->run();
+			} elseif ( $this->isEnabledHttpDeferredRequest === SMW_HTTP_DEFERRED_LAZY_JOB ) {
+				// Buffers the job and is added at the end of MediaWiki::restInPeace
+				$job->lazyPush();
+			} else {
+				$job->insert();
+			}
 		};
 
 		return $callback;

--- a/src/Defines.php
+++ b/src/Defines.php
@@ -150,6 +150,7 @@ define( 'SMW_UJ_PM_CLASTMDATE', 4 ); // compare last modified
   */
 define( 'SMW_HTTP_DEFERRED_ASYNC', true );
 define( 'SMW_HTTP_DEFERRED_SYNC_JOB', 4 );
+define( 'SMW_HTTP_DEFERRED_LAZY_JOB', 8 );
 /**@}*/
 
 /**@{

--- a/src/MediaWiki/Jobs/JobBase.php
+++ b/src/MediaWiki/Jobs/JobBase.php
@@ -149,6 +149,24 @@ abstract class JobBase extends Job {
 	}
 
 	/**
+	 * @see JobQueueGroup::lazyPush
+	 *
+	 * @note Registered jobs are pushed using JobQueueGroup::pushLazyJobs at the
+	 * end of MediaWiki::restInPeace
+	 *
+	 * @since 3.0
+	 */
+	public function lazyPush() {
+
+		// MW 1.26+
+		if ( $this->isEnabledJobQueue && method_exists( 'JobQueueGroup', 'lazyPush' ) ) {
+			return JobQueueGroup::singleton()->lazyPush( $this );
+		}
+
+		$this->insert();
+	}
+
+	/**
 	 * @since 2.5
 	 *
 	 * @return array


### PR DESCRIPTION
This PR is made in reference to: #2285

This PR addresses or contains:

- `Job::lazyPush` makes use of `JobQueueGroup::lazyPush` to push buffered jobs at the end of `MediaWiki::restInPeace` according to the documentation
- Add option `SMW_HTTP_DEFERRED_LAZY_JOB` in connection with `smwgEnabledHttpDeferredJobRequest `

This PR includes:
- [ ] Tests (unit/integration)
- [x] CI build passed
