### PR TITLE
Remove foreign Property, Concept named canonical namespaces

### DIFF
--- a/src/NamespaceManager.php
+++ b/src/NamespaceManager.php
@@ -69,7 +69,20 @@ class NamespaceManager {
 	 * @since 2.5
 	 */
 	public static function initCanonicalNamespaces( array &$namespaces ) {
-		$namespaces += self::initCustomNamespace( $GLOBALS )->getCanonicalNames();
+
+		$canonicalNames = self::initCustomNamespace( $GLOBALS )->getCanonicalNames();
+		$namespacesByName = array_flip( $namespaces );
+
+		// https://phabricator.wikimedia.org/T160665
+		// Find any namespace that uses the same canonical name and remove it
+		foreach ( $canonicalNames as $id => $name ) {
+			if ( isset( $namespacesByName[$name] ) ) {
+				unset( $namespaces[$namespacesByName[$name]] );
+			}
+		}
+
+		$namespaces += $canonicalNames;
+
 		return true;
 	}
 

--- a/tests/phpunit/Unit/NamespaceManagerTest.php
+++ b/tests/phpunit/Unit/NamespaceManagerTest.php
@@ -201,4 +201,26 @@ class NamespaceManagerTest extends \PHPUnit_Framework_TestCase {
 		);
 	}
 
+	public function testInitCanonicalNamespacesWithForcedNsReset() {
+
+		$namespaces = array(
+			10001 => 'Property',
+			10002 => 'Property_talk'
+		);
+
+		$this->assertTrue(
+			NamespaceManager::initCanonicalNamespaces( $namespaces )
+		);
+
+		$this->assertEquals(
+			'Property',
+			$namespaces[SMW_NS_PROPERTY]
+		);
+
+		$this->assertEquals(
+			'Property_talk',
+			$namespaces[SMW_NS_PROPERTY_TALK]
+		);
+	}
+
 }


### PR DESCRIPTION
This PR is made in reference to: https://phabricator.wikimedia.org/T160665

This PR addresses or contains:

- Ensures and enforces consistency of the Property, Concept canonical namespace when Semantic MediaWiki is installed 

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed
