### PR TITLE
Fix "SubSemanticData::copyDataFrom ... null given"

### DIFF
--- a/src/DataModel/ContainerSemanticData.php
+++ b/src/DataModel/ContainerSemanticData.php
@@ -69,7 +69,8 @@ class ContainerSemanticData extends SemanticData {
 			'mHasVisibleProps',
 			'mHasVisibleSpecs',
 			'mNoDuplicates',
-			'skipAnonymousCheck'
+			'skipAnonymousCheck',
+			'subSemanticData'
 		);
 	}
 

--- a/tests/phpunit/Unit/HashBuilderTest.php
+++ b/tests/phpunit/Unit/HashBuilderTest.php
@@ -6,6 +6,7 @@ use SMW\DIProperty;
 use SMW\DIWikiPage;
 use SMW\HashBuilder;
 use SMW\SemanticData;
+use SMW\DataModel\ContainerSemanticData;
 use Title;
 
 /**
@@ -100,6 +101,36 @@ class HashBuilderTest extends \PHPUnit_Framework_TestCase {
 		$this->assertInternalType(
 			'string',
 			HashBuilder::createFromSemanticData( $semanticData )
+		);
+	}
+
+	public function testCreateFromSemanticDataWithSubSemanticDataAndPHPSerialization() {
+
+		$semanticData = new SemanticData(
+			DIWikiPage::newFromText( __METHOD__ )
+		);
+
+		$containerSemanticData = new ContainerSemanticData(
+			new DIWikiPage( __METHOD__, NS_MAIN, '', 'Foo' )
+		);
+
+		$containerSemanticData->addSubSemanticData(
+			new ContainerSemanticData( new DIWikiPage( __METHOD__, NS_MAIN, '', 'Foo2' ) )
+		);
+
+		$semanticData->addSubSemanticData(
+			$containerSemanticData
+		);
+
+		$semanticData->addSubSemanticData(
+			new ContainerSemanticData( new DIWikiPage( __METHOD__, NS_MAIN, '', 'Bar' ) )
+		);
+
+		$sem = serialize( $semanticData );
+
+		$this->assertInternalType(
+			'string',
+			HashBuilder::createFromSemanticData( unserialize( $sem ) )
 		);
 	}
 


### PR DESCRIPTION
This PR is made in reference to: #2177

This PR addresses or contains:

- Ensures that a serialized `ContainerSemanticData` (as done so by ApiStashEdit) includes a `_sleep` ref to a stored `SubSemanticData` object

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed
