### PR TITLE
Highlighter to pre-process title content, refs 1905

### DIFF
--- a/includes/Highlighter.php
+++ b/includes/Highlighter.php
@@ -205,6 +205,11 @@ class Highlighter {
 
 		$language = is_string( $this->language ) ? $this->language : Message::USER_LANGUAGE;
 
+		// #1875
+		// title attribute contains stripped content to allow for a display in
+		// no-js environments, the tooltip will remove the element once it is
+		// loaded
+
 		return Html::rawElement(
 			'span',
 			array(
@@ -213,7 +218,7 @@ class Highlighter {
 				'data-content' => isset( $this->options['data-content'] ) ? $this->options['data-content'] : null,
 				'data-state'   => $this->options['state'],
 				'data-title'   => Message::get( $this->options['title'], Message::TEXT, $language ),
-				'title'        => strip_tags( htmlspecialchars_decode( str_replace( "[", "&#91;", $this->options['content'] ) ) )
+				'title'        => $this->createStrippedContentFrom( $this->options['content'], $language )
 			), Html::rawElement(
 					'span',
 					array(
@@ -297,4 +302,16 @@ class Highlighter {
 
 		return $settings;
 	}
+
+	private function createStrippedContentFrom( $content, $language ) {
+
+		// Pre-process the content when used as title to avoid breaking elements
+		// (URLs etc.)
+		if ( strpos( $content, '[' ) !== false || strpos( $content, '//' ) !== false ) {
+			$content = Message::get( array( 'smw-parse', $content ), Message::PARSE, $language );
+		}
+
+		return strip_tags( htmlspecialchars_decode( str_replace( "[", "&#91;", $content ) ) );
+	}
+
 }

--- a/tests/phpunit/Integration/JSONScript/TestCases/p-0108.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/p-0108.json
@@ -54,7 +54,8 @@
 			"subject": "Test/P0108/2",
 			"assert-output": {
 				"to-contain": [
-					"title=\"&amp;#91;&amp;#91;SMW::off]]Test/P0108/1 P0108&amp;#91;&amp;#91;SMW::on]]\">"
+					"title=\"SMW::offTest/P0108/1 P0108SMW::on\">",
+					"<div class=\"smwttcontent\">Test/P0108/1 P0108</div>"
 				]
 			}
 		},

--- a/tests/phpunit/Integration/JSONScript/TestCases/p-0110.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/p-0110.json
@@ -1,0 +1,43 @@
+{
+	"description": "Test tooltip with error output on `_PVUC` (`smwgDVFeatures`, `wgContLang=en`, `wgLang=en`)",
+	"setup": [
+		{
+			"namespace": "SMW_NS_PROPERTY",
+			"page": "Has Url",
+			"contents": "[[Has type::URL]] [[Has uniqueness constraint::true]]"
+		},
+		{
+			"page": "Test/P0110/1",
+			"contents": "[[Has Url::http://example.org/Foo]]"
+		},
+		{
+			"page": "Test/P0110/2",
+			"contents": "[[Has Url::http://example.org/Foo]]"
+		}
+	],
+	"tests": [
+		{
+			"type": "parser",
+			"about": "#0 error tooltip, title does not include <a> elements",
+			"subject": "Test/P0110/2",
+			"assert-output": {
+				"to-contain": [
+					"title=\"Property &quot;Has Url&quot; only permits unique value assignments and http://example.org/Foo",
+					"<div class=\"smwttcontent\">Property \"Has Url\" only permits unique value assignments and <i><a rel=\"nofollow\" class=\"external free\" href=\"http://example.org/Foo\">http://example.org/Foo</a></i>"
+				]
+			}
+		}
+	],
+	"settings": {
+		"smwgDVFeatures": [
+			"SMW_DV_PVUC"
+		],
+		"wgContLang": "en",
+		"wgLang": "en"
+	},
+	"meta": {
+		"version": "2",
+		"is-incomplete": false,
+		"debug": false
+	}
+}

--- a/tests/phpunit/Integration/JSONScript/TestCases/p-0212.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/p-0212.json
@@ -35,7 +35,7 @@
 			"subject": "Example/P0212/1",
 			"assert-output": {
 				"to-contain": [
-					"<span class=\"smw-highlighter\" data-type=\"1\" data-state=\"inline\" data-title=\"Property\" title=\"Some text with a link to &amp;#91;http://example.org/ foo] and stripped `li` in title element\">",
+					"<span class=\"smw-highlighter\" data-type=\"1\" data-state=\"inline\" data-title=\"Property\" title=\"Some text with a link to foo and stripped `li` in title element&#10;\">",
 					"<div class=\"smwttcontent\">Some text with a link to <a rel=\"nofollow\" class=\"external text\" href=\"http://example.org/\">foo</a> and <li>stripped `li` in title element</li></div>",
 					"title=\"Property:Has date\">Has date</a>"
 				]
@@ -47,7 +47,7 @@
 			"subject": "Example/P0212/2",
 			"assert-output": {
 				"to-contain": [
-					"<span class=\"smw-highlighter\" data-type=\"1\" data-state=\"inline\" data-title=\"Property\" title=\"Some text with a link to &amp;#91;http://example.org/ foo] and stripped `li` in title element\">",
+					"<span class=\"smw-highlighter\" data-type=\"1\" data-state=\"inline\" data-title=\"Property\" title=\"Some text with a link to foo and stripped `li` in title element&#10;\">",
 					"<div class=\"smwttcontent\">Some text with a link to <a rel=\"nofollow\" class=\"external text\" href=\"http://example.org/\">foo</a> and <li>stripped `li` in title element</li></div>",
 					"title=\"Property:Has date\">With extra caption</a>"
 				]


### PR DESCRIPTION
This PR is made in reference to: #1905 

This PR addresses or contains:

- Ensures that content in the `title` element is pre-processed and avoids breaking the tooltip

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed
