### PR TITLE
Track persistent update marker (MW 1.29+)

### DIFF
--- a/src/GlobalFunctions.php
+++ b/src/GlobalFunctions.php
@@ -153,6 +153,25 @@ function &smwfGetStore() {
 }
 
 /**
+ * @since 3.0
+ *
+ * @param string $namespace
+ * @param string $key
+ *
+ * @return string
+ */
+function smwfCacheKey( $namespace, $key ) {
+
+	$cachePrefix = $GLOBALS['wgCachePrefix'] === false ? wfWikiID() : $GLOBALS['wgCachePrefix'];
+
+	if ( $namespace{0} !== ':' ) {
+		$namespace = ':' . $namespace;
+	}
+
+	return $cachePrefix . $namespace . ':' . md5( $key );
+}
+
+/**
  * @codeCoverageIgnore
  *
  * Get the SMWSparqlDatabase object to use for connecting to a SPARQL store,

--- a/src/MediaWiki/Hooks/ParserAfterTidy.php
+++ b/src/MediaWiki/Hooks/ParserAfterTidy.php
@@ -187,6 +187,11 @@ class ParserAfterTidy extends HookHandler {
 				wfTimestamp( TS_UNIX )
 			);
 
+			$parserData->setOption(
+				$parserData::OPT_FORCED_UPDATE,
+				true
+			);
+
 			$parserData->updateStore( true );
 
 			$parserData->addLimitReport(

--- a/tests/phpunit/Integration/MediaWiki/LinksUpdateSQLStoreDBIntegrationTest.php
+++ b/tests/phpunit/Integration/MediaWiki/LinksUpdateSQLStoreDBIntegrationTest.php
@@ -188,6 +188,7 @@ class LinksUpdateSQLStoreDBIntegrationTest extends MwDBaseUnitTestCase {
 
 		$contentParser = new ContentParser( $this->title );
 		$parserOutput =	$contentParser->setRevision( $revision )->parse()->getOutput();
+		$parserOutput->setExtensionData( ParserData::OPT_FORCED_UPDATE, true );
 
 		if ( $parserOutput instanceof ParserOutput ) {
 			return new ParserData( $this->title, $parserOutput );

--- a/tests/phpunit/Unit/GlobalFunctionsTest.php
+++ b/tests/phpunit/Unit/GlobalFunctionsTest.php
@@ -89,6 +89,14 @@ class GlobalFunctionsTest extends \PHPUnit_Framework_TestCase {
 		$this->assertTrue( is_string( $results ) );
 	}
 
+	public function testSmwfCacheKeyOnPrefixedNamespace() {
+
+		$this->assertEquals(
+			smwfCacheKey( 'foo', 'bar' ),
+			smwfCacheKey( ':foo', 'bar' )
+		);
+	}
+
 	/**
 	 * Provides available global functions
 	 *

--- a/tests/phpunit/Unit/MediaWiki/Hooks/LinksUpdateConstructedTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Hooks/LinksUpdateConstructedTest.php
@@ -144,7 +144,7 @@ class LinksUpdateConstructedTest extends \PHPUnit_Framework_TestCase {
 			->method( 'getTitle' )
 			->will( $this->returnValue( $title ) );
 
-		$linksUpdate->expects( $this->once() )
+		$linksUpdate->expects( $this->atLeastOnce() )
 			->method( 'getParserOutput' )
 			->will( $this->returnValue( $parserOutput ) );
 

--- a/tests/phpunit/includes/ParserDataTest.php
+++ b/tests/phpunit/includes/ParserDataTest.php
@@ -285,6 +285,46 @@ class ParserDataTest extends \PHPUnit_Framework_TestCase {
 		);
 	}
 
+	public function testSkipUpdateOnMatchedMarker() {
+
+		$title = $this->getMockBuilder( '\Title' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$title->expects( $this->once() )
+			->method( 'getNamespace' )
+			->will( $this->returnValue( NS_MAIN ) );
+
+		$title->expects( $this->any() )
+			->method( 'getLatestRevID' )
+			->will( $this->returnValue( 42 ) );
+
+		$cache = $this->getMockBuilder( '\Onoi\Cache\Cache' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$cache->expects( $this->once() )
+			->method( 'fetch' )
+			->with( $this->stringContains( ':smw:update:55fd50809b6221a77f8f3dbd49e0d5bc' ) )
+			->will( $this->returnValue( 42 ) );
+
+		$cache->expects( $this->once() )
+			->method( 'save' )
+			->with( $this->stringContains( ':smw:update:55fd50809b6221a77f8f3dbd49e0d5bc' ) );
+
+		$instance = new ParserData(
+			$title,
+			new ParserOutput(),
+			$cache
+		);
+
+		$instance->markUpdate( 42 );
+
+		$this->assertNull(
+			$instance->updateStore()
+		);
+	}
+
 	public function testSemanticDataStateToParserOutput() {
 
 		$parserOutput = new ParserOutput();


### PR DESCRIPTION
This PR is made in reference to: #

This PR addresses or contains:

- MW 1.29 made the `LinksUpdate` a `EnqueueableDataUpdate` which creates updates as `JobSpecification` (refreshLinksPrioritized) and depending on the scheduler creates a possibility of running an update more than once on the same RevID
- Track the RevID and skip any reoccurring updates for the same RevID (persistent update marker is stored for an hour)

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed
