### PR TITLE
InternalParseBeforeLinks detect SMW off/on, refs 2209, 2370

### DIFF
--- a/src/DataValues/InfoLinksProvider.php
+++ b/src/DataValues/InfoLinksProvider.php
@@ -8,6 +8,7 @@ use SMW\Message;
 use SMWDataValue as DataValue;
 use SMWDIBlob as DIBlob;
 use SMWInfolink as Infolink;
+use SMW\InTextAnnotationParser;
 
 /**
  * @license GNU GPL v2+
@@ -121,7 +122,7 @@ class InfoLinksProvider {
 
 		// InTextAnnotationParser will detect :: therefore avoid link
 		// breakage by encoding the string
-		if ( strpos( $value, '::' ) !== false && !$this->hasInternalAnnotationMarker( $value ) ) {
+		if ( strpos( $value, '::' ) !== false && !InTextAnnotationParser::hasMarker( $value ) ) {
 			$value = str_replace( ':', '-3A', $value );
 		}
 
@@ -178,7 +179,7 @@ class InfoLinksProvider {
 		}
 
 		// #1453 SMW::on/off will break any potential link therefore just don't even try
-		return !$this->hasInternalAnnotationMarker( $result ) ? $result : '';
+		return !InTextAnnotationParser::hasMarker( $result ) ? $result : '';
 	}
 
 	/**
@@ -235,10 +236,6 @@ class InfoLinksProvider {
 		}
 
 		$this->hasServiceLinks = true;
-	}
-
-	private function hasInternalAnnotationMarker( $value ) {
-		return strpos( $value, 'SMW::off' ) !== false || strpos( $value, 'SMW::on' ) !== false;
 	}
 
 }

--- a/src/InTextAnnotationParser.php
+++ b/src/InTextAnnotationParser.php
@@ -177,6 +177,17 @@ class InTextAnnotationParser {
 	}
 
 	/**
+	 * @since 3.0
+	 *
+	 * @param string $text
+	 *
+	 * @return boolean
+	 */
+	public static function hasMarker( $text ) {
+		return strpos( $text, self::OFF ) !== false || strpos( $text, self::ON ) !== false;
+	}
+
+	/**
 	 * @since 2.4
 	 *
 	 * @param string $text

--- a/src/MediaWiki/Hooks/InternalParseBeforeLinks.php
+++ b/src/MediaWiki/Hooks/InternalParseBeforeLinks.php
@@ -4,6 +4,7 @@ namespace SMW\MediaWiki\Hooks;
 
 use Parser;
 use SMW\ApplicationFactory;
+use SMW\InTextAnnotationParser;
 
 /**
  * Hook: InternalParseBeforeLinks is used to process the expanded wiki
@@ -76,12 +77,15 @@ class InternalParseBeforeLinks {
 			return true;
 		}
 
+		// #2209, #2370 Allow content to be parsed that contain [[SMW::off]]/[[SMW::on]]
+		// even in case of MediaWiki messages
+		if ( InTextAnnotationParser::hasMarker( $text ) ) {
+			return true;
+		}
+
 		// ParserOptions::getInterfaceMessage is being used to identify whether a
 		// parse was initiated by `Message::parse`
-		//
-		// #2209 If the text was a `InterfaceMessage` send from a SpecialPage such as
-		// Special:Booksources we allow to proceed
-		if ( $text === '' || ( $this->parser->getOptions()->getInterfaceMessage() && !$title->isSpecialPage() ) ) {
+		if ( $text === '' || $this->parser->getOptions()->getInterfaceMessage() ) {
 			return false;
 		}
 

--- a/tests/phpunit/Integration/JSONScript/ParserTestCaseProcessor.php
+++ b/tests/phpunit/Integration/JSONScript/ParserTestCaseProcessor.php
@@ -4,6 +4,7 @@ namespace SMW\Tests\Integration\JSONScript;
 
 use SMW\DIWikiPage;
 use SMW\Tests\Utils\UtilityFactory;
+use SMW\MediaWiki\MediaWikiNsContentReader;
 
 /**
  * @group semantic-mediawiki
@@ -69,6 +70,7 @@ class ParserTestCaseProcessor extends \PHPUnit_Framework_TestCase {
 
 		$this->assertSemanticDataForCase( $case );
 		$this->assertParserOutputForCase( $case );
+		$this->assertParserMsgForCase( $case );
 	}
 
 	private function assertSemanticDataForCase( $case ) {
@@ -142,6 +144,35 @@ class ParserTestCaseProcessor extends \PHPUnit_Framework_TestCase {
 			$this->stringValidator->assertThatStringNotContains(
 				$case['assert-output']['not-contain'],
 				$parserOutput->getText(),
+				$case['about']
+			);
+		}
+	}
+
+	private function assertParserMsgForCase( $case ) {
+
+		if ( !isset( $case['assert-msgoutput'] ) ) {
+			return;
+		}
+
+		$mediaWikiNsContentReader = new MediaWikiNsContentReader();
+		$mediaWikiNsContentReader->skipMessageCache();
+
+		$text = $mediaWikiNsContentReader->read( $case['subject'] );
+		$text = wfMessage( 'smw-parse', $text )->parse();
+
+		if ( isset( $case['assert-msgoutput']['to-contain'] ) ) {
+			$this->stringValidator->assertThatStringContains(
+				$case['assert-msgoutput']['to-contain'],
+				$text,
+				$case['about']
+			);
+		}
+
+		if ( isset( $case['assert-msgoutput']['not-contain'] ) ) {
+			$this->stringValidator->assertThatStringNotContains(
+				$case['assert-msgoutput']['not-contain'],
+				$text,
 				$case['about']
 			);
 		}

--- a/tests/phpunit/Integration/JSONScript/TestCases/p-0108.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/p-0108.json
@@ -57,7 +57,7 @@
 			},
 			"assert-output": {
 				"to-contain": [
-					"title=\"SMW::offTest/P0108/1 P0108SMW::on\">",
+					"title=\"Test/P0108/1 P0108\">",
 					"<div class=\"smwttcontent\">Test/P0108/1 P0108</div>"
 				]
 			}

--- a/tests/phpunit/Integration/JSONScript/TestCases/p-0706.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/p-0706.json
@@ -1,0 +1,183 @@
+{
+	"description": "Test `#ask` on `format=template` with message parse (`wgContLang=en`, `wgLang=en`)",
+	"setup": [
+		{
+			"page": "Example/P0706/1",
+			"contents": "[[P0706::P0706]]"
+		},
+		{
+			"namespace": "NS_TEMPLATE",
+			"page": "Example/Tmpl0706",
+			"contents": "{{{1}}}"
+		},
+		{
+			"namespace": "NS_TEMPLATE",
+			"page": "Example/Tmpl0706withAnnotationDeep",
+			"contents": "<includeonly>[[Tmpl0706withAnnotationDeep::789]]</includeonly>"
+		},
+		{
+			"namespace": "NS_TEMPLATE",
+			"page": "Example/Tmpl0706withAnnotation",
+			"contents": "<includeonly>{{#set:|Tmpl0706withAnnotation=123}} [[Tmpl0706withAnnotation::456]] {{Example/Tmpl0706withAnnotationDeep}}</includeonly>"
+		},
+		{
+			"namespace": "NS_TEMPLATE",
+			"page": "Example/Tmpl0706ResultOutput",
+			"contents": "<includeonly>{{{1}}} {{Example/Tmpl0706withAnnotation}}</includeonly>"
+		},
+		{
+			"namespace": "NS_MEDIAWIKI",
+			"page": "Test/Msg0706/1",
+			"contents": "{{#ask: [[P0706::P0706]] |?P0706 |link=none |template=Example/Tmpl0706 |format=template }}"
+		},
+		{
+			"namespace": "NS_MEDIAWIKI",
+			"page": "Test/Msg0706/2",
+			"contents": "{{#ask: [[P0706::P0706]] |?P0706 |link=none |template=Example/Tmpl0706 |format=template }}"
+		},
+		{
+			"namespace": "NS_MEDIAWIKI",
+			"page": "Test/Msg0706/3",
+			"contents": "{{#ask: [[P0706::P0706]] |?P0706 |link=none |template=Example/Tmpl0706 |format=list }}"
+		},
+		{
+			"page": "Test/P0706/4",
+			"contents": "{{#ask: [[P0706::P0706]] |?P0706 |link=none |template=Example/Tmpl0706ResultOutput |format=template }}"
+		},
+		{
+			"page": "Test/P0706/5",
+			"contents": "{{#ask: [[P0706::P0706]] |?P0706 |link=none |template=Example/Tmpl0706ResultOutput |format=template |import-annotation=true }}"
+		},
+		{
+			"page": "Test/P0706/6",
+			"contents": "{{#ask: [[P0706::P0706]] |?P0706 |link=none |template=Example/Tmpl0706ResultOutput |format=template }}"
+		}
+	],
+	"tests": [
+		{
+			"type": "parser",
+			"about": "#0 template format, msg parse outputs [[SMW::off]]/[[SMW::on]]",
+			"subject": "Test/Msg0706/1",
+			"assert-msgoutput": {
+				"to-contain": [
+					"Example/P0706/1"
+				],
+				"not-contain": [
+					">SMW::off</a>",
+					">SMW::on</a>"
+				]
+			}
+		},
+		{
+			"type": "parser",
+			"about": "#1 template format, msg parse to avoid [[SMW::off]]/[[SMW::on]]",
+			"subject": "Test/Msg0706/2",
+			"assert-msgoutput": {
+				"to-contain": [
+					"Example/P0706/1"
+				],
+				"not-contain": [
+					">SMW::off</a>",
+					">SMW::on</a>"
+				]
+			}
+		},
+		{
+			"type": "parser",
+			"about": "#2 list format, msg parse to avoid [[SMW::off]]/[[SMW::on]]",
+			"subject": "Test/Msg0706/3",
+			"assert-msgoutput": {
+				"to-contain": [
+					"Example/P0706/1"
+				],
+				"not-contain": [
+					">SMW::off</a>",
+					">SMW::on</a>"
+				]
+			}
+		},
+		{
+			"type": "parser",
+			"about": "#3 (no foreign annotation import)",
+			"subject": "Test/P0706/4",
+			"assert-store": {
+				"semantic-data": {
+					"strictPropertyValueMatch": false,
+					"propertyCount": 3,
+					"propertyKeys": [
+						"_ASK",
+						"_MDAT",
+						"_SKEY"
+					]
+				}
+			},
+			"assert-output": {
+				"to-contain": [
+					"Example/P0706/1",
+					"456",
+					"789"
+				]
+			}
+		},
+		{
+			"type": "parser",
+			"about": "#4 (import foreign annotation)",
+			"subject": "Test/P0706/5",
+			"assert-store": {
+				"semantic-data": {
+					"strictPropertyValueMatch": false,
+					"propertyCount": 5,
+					"propertyKeys": [
+						"_ASK",
+						"_MDAT",
+						"_SKEY",
+						"Tmpl0706withAnnotation",
+						"Tmpl0706withAnnotationDeep"
+					]
+				}
+			},
+			"assert-output": {
+				"to-contain": [
+					"Example/P0706/1",
+					"456",
+					"789"
+				]
+			}
+		},
+		{
+			"type": "parser",
+			"about": "#5 (no foreign annotation import)",
+			"subject": "Test/P0706/6",
+			"assert-store": {
+				"semantic-data": {
+					"strictPropertyValueMatch": false,
+					"propertyCount": 3,
+					"propertyKeys": [
+						"_ASK",
+						"_MDAT",
+						"_SKEY"
+					]
+				}
+			},
+			"assert-output": {
+				"to-contain": [
+					"Example/P0706/1",
+					"456",
+					"789"
+				]
+			}
+		}
+	],
+	"settings": {
+		"wgContLang": "en",
+		"wgLang": "en",
+		"smwgPageSpecialProperties": [
+			"_MDAT"
+		]
+	},
+	"meta": {
+		"version": "2",
+		"is-incomplete": false,
+		"debug": false
+	}
+}

--- a/tests/phpunit/Unit/InTextAnnotationParserTest.php
+++ b/tests/phpunit/Unit/InTextAnnotationParserTest.php
@@ -76,6 +76,21 @@ class InTextAnnotationParserTest extends \PHPUnit_Framework_TestCase {
 		);
 	}
 
+	public function testHasMarker() {
+
+		$this->assertTrue(
+			InTextAnnotationParser::hasMarker( '[[SMW::off]]' )
+		);
+
+		$this->assertTrue(
+			InTextAnnotationParser::hasMarker( '[[SMW::on]]' )
+		);
+
+		$this->assertFalse(
+			InTextAnnotationParser::hasMarker( 'Foo' )
+		);
+	}
+
 	/**
 	 * @dataProvider magicWordDataProvider
 	 */

--- a/tests/phpunit/Unit/MediaWiki/Hooks/InternalParseBeforeLinksTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Hooks/InternalParseBeforeLinksTest.php
@@ -153,6 +153,47 @@ class InternalParseBeforeLinksTest extends \PHPUnit_Framework_TestCase {
 			->method( 'getOptions' )
 			->will( $this->returnValue( $parserOptions ) );
 
+		$instance = new InternalParseBeforeLinks(
+			$parser
+		);
+
+		$instance->setEnabledSpecialPage(
+			array( 'Bar' )
+		);
+
+		$instance->process( $text );
+	}
+
+	public function testProcessOfInterfaceMessageOnSpecialPageWithOnOffMarker() {
+
+		$text = '[[SMW::off]]Foo[[SMW::on]]';
+
+		$title = $this->testEnvironment->createConfiguredStub(
+			'\Title',
+			array(
+				'getDBKey'      => __METHOD__,
+				'getNamespace'  => NS_MAIN,
+				'isSpecialPage' => true
+			)
+		);
+
+		$title->expects( $this->atLeastOnce() )
+			->method( 'isSpecial' )
+			->with( $this->equalTo( 'Bar' ) )
+			->will( $this->returnValue( true ) );
+
+		$parserOptions = $this->getMockBuilder( '\ParserOptions' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$parserOutput = $this->getMockBuilder( '\ParserOutput' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$parser = $this->getMockBuilder( 'Parser' )
+			->disableOriginalConstructor()
+			->getMock();
+
 		$parser->expects( $this->atLeastOnce() )
 			->method( 'getOutput' )
 			->will( $this->returnValue( $parserOutput ) );
@@ -163,10 +204,6 @@ class InternalParseBeforeLinksTest extends \PHPUnit_Framework_TestCase {
 
 		$instance = new InternalParseBeforeLinks(
 			$parser
-		);
-
-		$instance->setEnabledSpecialPage(
-			array( 'Bar' )
 		);
 
 		$instance->process( $text );


### PR DESCRIPTION
This PR is made in reference to: #2209, #2370

This PR addresses or contains:

- Detect a marker an allow a parse even in cases of a message

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed
