### PR TITLE
Add PropertyLabelSimilarityLookup::getPropertyMaxCount, refs 2244

### DIFF
--- a/src/MediaWiki/Specials/PropertyLabelSimilarity/ContentsBuilder.php
+++ b/src/MediaWiki/Specials/PropertyLabelSimilarity/ContentsBuilder.php
@@ -65,12 +65,9 @@ class ContentsBuilder {
 			$requestOptions
 		);
 
-		$count = $this->propertyLabelSimilarityLookup->getLookupCount();
-
 		$html = $this->getForm(
 			$requestOptions->getLimit(),
 			$requestOptions->getOffset(),
-			$count,
 			count( $result ),
 			$threshold,
 			$type
@@ -85,9 +82,16 @@ class ContentsBuilder {
 		return $html;
 	}
 
-	private function getForm( $limit, $offset, $count, $resultCount, $threshold, $type ) {
+	private function getForm( $limit, $offset, $resultCount, $threshold, $type ) {
 
 		$exemptionProperty = $this->propertyLabelSimilarityLookup->getExemptionProperty();
+		$lookupCount = $this->propertyLabelSimilarityLookup->getLookupCount();
+
+		// Allow for an extra range since the property pool may be larger than
+		// the reductive comparison matches, +1 is to request additional paging
+		if ( $limit + $offset < $this->propertyLabelSimilarityLookup->getPropertyMaxCount() ) {
+			$lookupCount = $limit + $offset + 1;
+		}
 
 		$html = $this->getMessageAsString(
 			array( 'smw-property-label-similarity-docu', $exemptionProperty ),
@@ -101,7 +105,7 @@ class ContentsBuilder {
 			->addPaging(
 				$limit,
 				$offset,
-				$count,
+				$lookupCount,
 				$resultCount )
 			->addHiddenField( 'limit', $limit )
 			->addHiddenField( 'offset', $offset )

--- a/src/SQLStore/Lookup/PropertyLabelSimilarityLookup.php
+++ b/src/SQLStore/Lookup/PropertyLabelSimilarityLookup.php
@@ -107,6 +107,21 @@ class PropertyLabelSimilarityLookup {
 	}
 
 	/**
+	 * @since 3.0
+	 *
+	 * @return integer
+	 */
+	public function getPropertyMaxCount() {
+		$statistics = $this->store->getStatistics();
+
+		if ( isset( $statistics['TOTALPROPS'] ) ) {
+			return $statistics['TOTALPROPS'];
+		}
+
+		return 0;
+	}
+
+	/**
 	 * @since 2.5
 	 *
 	 * @param RequestOptions|null $requestOptions

--- a/tests/phpunit/Unit/SQLStore/Lookup/PropertyLabelSimilarityLookupTest.php
+++ b/tests/phpunit/Unit/SQLStore/Lookup/PropertyLabelSimilarityLookupTest.php
@@ -44,6 +44,27 @@ class PropertyLabelSimilarityLookupTest extends \PHPUnit_Framework_TestCase {
 		);
 	}
 
+	public function testGetPropertyMaxCount() {
+
+		$this->store->expects( $this->any() )
+			->method( 'getStatistics' )
+			->will( $this->returnValue( array( 'TOTALPROPS' => 42 ) ) );
+
+		$propertySpecificationLookup = $this->getMockBuilder( '\SMW\PropertySpecificationLookup' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$instance = new PropertyLabelSimilarityLookup(
+			$this->store,
+			$propertySpecificationLookup
+		);
+
+		$this->assertEquals(
+			42,
+			$instance->getPropertyMaxCount()
+		);
+	}
+
 	public function testCompareAndFindLabels() {
 
 		$row = new \stdClass;


### PR DESCRIPTION
This PR is made in reference to: #2244

This PR addresses or contains:

- Ensures that the max range for legitimate properties is detected and used as orientation for the navigation paging.

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed
