### PR TITLE
Special:Browse avoid "Uncaught Error: Unknown dependency: jquery.ui.autocomplete" by MobileFrontend

### DIFF
--- a/res/Resources.php
+++ b/res/Resources.php
@@ -206,12 +206,22 @@ return array(
 		'scripts' => 'smw/special/ext.smw.special.browse.js',
 		'dependencies' => array(
 			'mediawiki.api',
-			'ext.smw.style',
-			'ext.smw.autocomplete'
+			'ext.smw.style'
 		),
 		'position' => 'top',
 		'messages' => array(
 			'smw-browse-api-subject-serialization-invalid'
+		),
+		'targets' => array(
+			'mobile',
+			'desktop'
+		)
+	),
+
+	'ext.smw.browse.page.autocomplete' => $moduleTemplate + array(
+		'dependencies' => array(
+			'ext.smw.browse',
+			'ext.smw.autocomplete'
 		),
 		'targets' => array(
 			'mobile',

--- a/res/smw/special/ext.smw.special.browse.js
+++ b/res/smw/special/ext.smw.special.browse.js
@@ -23,6 +23,7 @@
 
 		this.VERSION = "2.5.0";
 		this.api = mwApi;
+		this.isMobileFrontend = false;
 
 		return this;
 	};
@@ -54,7 +55,7 @@
 
 		subject = subject.split( "#" );
 
-		self.api.get( {
+		self.api.post( {
 			action: "browsebysubject",
 			subject: subject[0],
 			ns: subject[1],
@@ -102,9 +103,11 @@
 
 		self.context.find( '.smwb-content' ).replaceWith( content );
 
-		mw.loader.using( 'ext.smw.browse' ).done( function () {
-			self.context.find( '#smwb-page-search' ).smwAutocomplete( { search: 'page', namespace: 0 } );
-		} );
+		if ( !instance.isMobileFrontend ) {
+			mw.loader.using( [ 'ext.smw.browse', 'ext.smw.browse.page.autocomplete' ] ).done( function () {
+				self.context.find( '#smwb-page-search' ).smwAutocomplete( { search: 'page', namespace: 0 } );
+			} );
+		};
 
 		mw.loader.load(
 			self.context.find( '.smwb-modules' ).data( 'modules' )
@@ -130,7 +133,17 @@
 			instance.doApiRequest();
 		} );
 
-		$( '#smwb-page-search' ).smwAutocomplete( { search: 'page', namespace: 0 } );
+		// Detect whether this uses the MF skin
+		instance.isMobileFrontend = $( "body" ).hasClass( "skin-minerva" );
+
+		// Avoid "Uncaught Error: Unknown dependency: jquery.ui.autocomplete" in
+		// mobile context as the module is not defined with target mobile
+		if ( !instance.isMobileFrontend ) {
+			mw.loader.using( [ 'ext.smw.browse.page.autocomplete' ] ).done( function () {
+				$( '#smwb-page-search' ).smwAutocomplete( { search: 'page', namespace: 0 } );
+			} );
+		};
+
 	} );
 
 }( jQuery, mediaWiki ) );


### PR DESCRIPTION
This PR is made in reference to: #

This PR addresses or contains:

- MW core hasn't defined `jquery.ui.autocomplete` as module with a mobile target but since the autocomplete requires that module, `MobileFrontend`  fails with a "Uncaught Error: Unknown dependency: jquery.ui.autocomplete"
- Autocomplete and the required modules are not loaded when `MobileFrontend` is detected

This PR includes:
- [ ] Tests (unit/integration)
- [x] CI build passed
