### PR TITLE
Remove ContentParser::forceToUseParser from tests

### DIFF
--- a/tests/phpunit/Integration/MediaWiki/LinksUpdateTest.php
+++ b/tests/phpunit/Integration/MediaWiki/LinksUpdateTest.php
@@ -185,7 +185,6 @@ class LinksUpdateTest extends MwDBaseUnitTestCase {
 	public function testReparseFirstRevision( $firstRunRevision ) {
 
 		$contentParser = $this->applicationFactory->newContentParser( $this->title );
-		$contentParser->forceToUseParser();
 		$contentParser->setRevision( $firstRunRevision );
 		$contentParser->parse();
 

--- a/tests/phpunit/Utils/PageRefresher.php
+++ b/tests/phpunit/Utils/PageRefresher.php
@@ -39,7 +39,6 @@ class PageRefresher {
 		}
 
 		$contentParser = new ContentParser( $title );
-		$contentParser->forceToUseParser();
 
 		$parserData = ApplicationFactory::getInstance()->newParserData(
 			$title,


### PR DESCRIPTION
This PR is made in reference to: #2038

This PR addresses or contains:

- Avoids "Fatal error: Call to undefined method Revision::getText() in ...\SemanticMediaWiki\includes\ContentParser.php on line 196" on MW master during tests

This PR includes:
- [ ] Tests (unit/integration)
- [ ] CI build passed
