### PR TITLE
Special:Browse improve mobile display (replace <table> with <div>)

### DIFF
--- a/res/Resources.php
+++ b/res/Resources.php
@@ -202,6 +202,18 @@ return array(
 	),
 
 	// Facts and browse
+	'ext.smw.browse.styles' => $moduleTemplate + array(
+		'styles' => array(
+			'smw/ext.smw.table.css',
+			'smw/special/ext.smw.special.browse.css',
+		),
+		'position' => 'top',
+		'targets' => array(
+			'mobile',
+			'desktop'
+		)
+	),
+
 	'ext.smw.browse' => $moduleTemplate + array(
 		'scripts' => 'smw/special/ext.smw.special.browse.js',
 		'dependencies' => array(

--- a/res/smw/ext.smw.css
+++ b/res/smw/ext.smw.css
@@ -319,109 +319,6 @@ span.smwsearchicon {
 	/* @embed */ background: url(../images/rdf_flyer.12.png) center right no-repeat;
 }
 
-/* @TODO Browse and Factbox should be split into seperated CSS file, CSS style file for Semantic MediaWiki Special Browse. */
-table.smwb-factbox {
-	border-left: 8px solid #DDDDDD;
-	width: 100%
-}
-
-.smwb-factbox .smwb-propvalue th, .smwb-ifactbox .smwb-ipropvalue th, .smwb-ifactbox .smwb-propvalue th {
-	width: 25%
-}
-
-/* Only apply when less then 350*/
-@media (max-width: 400px) {
-	.smwb-factbox .smwb-propvalue th, .smwb-ifactbox .smwb-ipropvalue th, .smwb-ifactbox .smwb-propvalue th {
-		width: 50%
-	}
-}
-
-tr.smwb-title {
-	font-size: 200%;
-	background-color: #DDDDDD;
-	line-height: 1.5;
-}
-
-tr.smwb-title td {
-	padding-left: 5px;
-	border-bottom: 2px solid white;
-}
-
-tr.smwb-propvalue {
-	background-color: #EEEEEE;
-}
-
-tr.smwb-propvalue th {
-	text-align: right;
-	vertical-align: top;
-	font-weight: bold;
-	font-size: 120%;
-	background-color: #DDDDDD;
-	padding: 0.2em 0.6em;
-	border-bottom: 2px solid white;
-	border-top: 2px solid white;
-}
-
-tr.smwb-propvalue td {
-	padding-left:0.4em;
-	background-color: #EEEEEE;
-	border: 0px solid white;
-	border-bottom: 2px solid white;
-	border-top: 2px solid white;
-}
-
-tr.smwb-center {
-	background-color: #DDDDDD;
-}
-
-span.smwb-value {
-}
-
-/**
- * Inverse factbox
- * @ignore
- */
-table.smwb-ifactbox {
-	border-right: 8px solid #DDDDDD;
-	width: 100%
-}
-
-tr.smwb-ititle {
-	font-size: 200%;
-	background-color: #DDDDDD;
-	line-height: 1.5;
-}
-
-tr.smwb-ititle td {
-	padding-left: 5px;
-	border-bottom: 2px solid white;
-}
-
-tr.smwb-ipropvalue {
-	background-color: #EEEEEE;
-	text-align: right;
-}
-
-tr.smwb-ipropvalue th {
-	text-align: left;
-	font-weight: bold;
-	font-size: 120%;
-	background-color: #DDDDDD;
-	padding: 0.2em 0.6em;
-	border-bottom: 3px solid white;
-	border-top: 3px solid white;
-}
-
-tr.smwb-ipropvalue td {
-	background-color: #EEEEEE;
-	border-bottom: 3px solid white;
-	border-top: 3px solid white;
-	padding-right: 1em;
-}
-
-span.smwb-ivalue {
-}
-
 /* @since 1.9; Spinner */
 .smw-spinner .text {
 	padding-left: 2.1em;
@@ -821,22 +718,8 @@ a.smw-ask-action-btn-lblue:hover {
 	margin-top: 5px;
 }
 
-.browse-input-resp { display: flex; }
-.browse-input-resp .input-field { flex: 1; margin: 0 0 0 0; }
-.browse-input-resp .button-field { flex: 0; margin: 0 0 0 1rem; }
-
-.skin-chameleon .browse-input-resp .mw-ui-button {
-	padding: .3em 1em;
-}
-
 .skin-chameleon .smwfact td {
 	padding: 5px;
-}
-
-.browse-input-resp .mw-ui-input:focus {
-	box-shadow: inset 0 0 0 1px #ddd;
-	border-color: #ddd;
-	outline: 0;
 }
 
 .smw-page-indicator-rdflink {

--- a/res/smw/ext.smw.table.css
+++ b/res/smw/ext.smw.table.css
@@ -1,0 +1,63 @@
+/*!
+ * This file is part of the Semantic MediaWiki Extension
+ * @see https://semantic-mediawiki.org/
+ *
+ * @section LICENSE
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA
+ *
+ * @since 3.0
+ *
+ * @file
+ * @ingroup SMW
+ *
+ * @licence GNU GPL v2+
+ * @author mwjames
+ */
+
+.smw-table {
+	display: table;
+	width: 100%;
+}
+
+.smw-table-row {
+	display: table-row;
+}
+
+.smw-table-header {
+	background-color: #EEE;
+	display: table-header-group;
+}
+
+.smw-table-cell, .smw-table-head {
+	border: 1px solid #999999;
+	display: table-cell;
+	padding: 3px 10px;
+}
+
+.smw-table-header {
+	background-color: #EEE;
+	display: table-header-group;
+	font-weight: bold;
+}
+
+.smw-table-footer {
+	background-color: #EEE;
+	display: table-footer-group;
+	font-weight: bold;
+}
+
+.smw-table-body {
+	display: table-row-group;
+}

--- a/res/smw/special/ext.smw.special.browse.css
+++ b/res/smw/special/ext.smw.special.browse.css
@@ -1,0 +1,160 @@
+/*!
+ * This file is part of the Semantic MediaWiki Extension
+ * @see https://semantic-mediawiki.org/
+ *
+ * @section LICENSE
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA
+ *
+ * @since 3.0
+ *
+ * @file
+ * @ingroup SMW
+ *
+ * @licence GNU GPL v2+
+ * @author mwjames
+ */
+
+.smwb-datasheet, .smwb-content {
+	margin-right: 0.5em;
+}
+
+.smwb-factbox {
+	border-left: 0.5em solid #DDDDDD;
+	width: 100%
+}
+
+.smwb-factbox .smwb-propvalue .smwb-prophead, .smwb-ifactbox .smwb-ipropvalue .smwb-prophead, .smwb-ifactbox .smwb-propvalue .smwb-prophead {
+	width: 25%
+}
+
+/* Only apply when less then 350*/
+@media (max-width: 400px) {
+	.smwb-factbox .smwb-propvalue .smwb-prophead, .smwb-ifactbox .smwb-ipropvalue .smwb-prophead, .smwb-ifactbox .smwb-propvalue .smwb-prophead {
+		width: 50%
+	}
+}
+
+.smwb-cell {
+	border: 0px solid #999999;
+	border-top: 2px solid #fff;
+/*	border-bottom: 2px solid #fff; */
+}
+
+.smwb-cell-empty {
+	border-left: 0.5em solid #DDDDDD;
+}
+
+.smwb-prophead {
+	min-width: 5em;
+	background-color: #ddd;
+}
+
+.smwb-title {
+	font-size: 200%;
+	background-color: #DDDDDD;
+	line-height: 1.5;
+	font-weight: normal;
+}
+
+.smwb-title td {
+	padding-left: 5px;
+	border-bottom: 2px solid white;
+}
+
+.smwb-propvalue {
+	background-color: #EEEEEE;
+}
+
+.smwb-propvalue .smwb-prophead {
+	text-align: right;
+	vertical-align: top;
+	font-weight: bold;
+	font-size: 120%;
+	background-color: #DDDDDD;
+	padding: 0.2em 0.6em;
+}
+
+.smwb-propvalue .smwb-propval {
+	padding: 0.4em 0.6em;
+	background-color: #EEEEEE;
+	vertical-align: top;
+}
+
+.smwb-center {
+	background-color: #DDDDDD;
+	padding: 0px;
+}
+
+span.smwb-value {
+}
+
+.smwb-bottom {
+	border-bottom: 2px solid #fff;
+}
+
+/**
+ * Inverse factbox
+ * @ignore
+ */
+.smwb-ifactbox {
+	border-right: 0.5em solid #DDDDDD;
+	width: 100%
+}
+
+.smwb-ititle {
+	font-size: 200%;
+	background-color: #DDDDDD;
+	line-height: 1.5;
+}
+
+.smwb-ititle td {
+	padding-left: 5px;
+	border-bottom: 2px solid white;
+}
+
+.smwb-ipropvalue {
+	background-color: #EEEEEE;
+	text-align: right;
+}
+
+.smwb-ipropvalue .smwb-prophead {
+	text-align: left;
+	font-weight: bold;
+	font-size: 120%;
+	background-color: #DDDDDD;
+	padding: 0.2em 0.6em;
+}
+
+.smwb-ipropvalue .smwb-propval {
+	background-color: #EEEEEE;
+	padding-right: 1em;
+}
+
+span.smwb-ivalue {
+}
+
+.browse-input-resp { display: flex; }
+.browse-input-resp .input-field { flex: 1; margin: 0 0 0 0; }
+.browse-input-resp .button-field { flex: 0; margin: 0 0 0 1rem; }
+
+.skin-chameleon .smwb-datasheet, .skin-chameleon .smwb-content {
+	margin-right: 0em;
+}
+
+.browse-input-resp .mw-ui-input:focus {
+	box-shadow: inset 0 0 0 1px #ddd;
+	border-color: #ddd;
+	outline: 0;
+}

--- a/res/smw/special/ext.smw.special.browse.js
+++ b/res/smw/special/ext.smw.special.browse.js
@@ -101,7 +101,7 @@
 
 		var self = this;
 
-		self.context.find( '.smwb-content' ).replaceWith( content );
+		self.context.find( '.smwb-emptysheet' ).replaceWith( content );
 
 		if ( !instance.isMobileFrontend ) {
 			mw.loader.using( [ 'ext.smw.browse', 'ext.smw.browse.page.autocomplete' ] ).done( function () {

--- a/src/MediaWiki/Specials/Browse/FormHelper.php
+++ b/src/MediaWiki/Specials/Browse/FormHelper.php
@@ -32,7 +32,7 @@ class FormHelper {
 		$title = SpecialPage::getTitleFor( 'Browse' );
 		$dir = $title->getPageLanguage()->isRTL() ? 'rtl' : 'ltr';
 
-		$html = Html::rawElement(
+		$html = "<div class=\"smwb-form\">". Html::rawElement(
 			'div',
 			array( 'style' => 'margin-top:15px;' ),
 			''
@@ -94,7 +94,7 @@ class FormHelper {
 			)
 		);
 
-		return $html;
+		return $html . "</div>";
 	}
 
 	/**

--- a/src/MediaWiki/Specials/SpecialBrowse.php
+++ b/src/MediaWiki/Specials/SpecialBrowse.php
@@ -83,7 +83,8 @@ class SpecialBrowse extends SpecialPage {
 		$out->addModuleStyles( array(
 			'mediawiki.ui',
 			'mediawiki.ui.button',
-			'mediawiki.ui.input'
+			'mediawiki.ui.input',
+			'ext.smw.browse.styles'
 		) );
 
 		$out->addModules( array(
@@ -130,10 +131,6 @@ class SpecialBrowse extends SpecialPage {
 			$this->applicationFactory->getSettings()
 		);
 
-		if ( $webRequest->getVal( 'output' ) === 'legacy' || !$contentsBuilder->getOption( 'byApi' ) ) {
-			return $contentsBuilder->getHtml();
-		}
-
 		$options = array(
 			'dir'         => $contentsBuilder->getOption( 'dir' ),
 			'offset'      => $contentsBuilder->getOption( 'offset' ),
@@ -142,6 +139,18 @@ class SpecialBrowse extends SpecialPage {
 			'showAll'     => $contentsBuilder->getOption( 'showAll' ),
 			'including'   => $contentsBuilder->getOption( 'including' )
 		);
+
+		if ( $webRequest->getVal( 'output' ) === 'legacy' || !$contentsBuilder->getOption( 'byApi' ) ) {
+			return Html::rawElement(
+				'div',
+				array(
+					'class' => 'smwb-container',
+					'data-subject' => $this->subjectDV->getDataItem()->getHash(),
+					'data-options' => json_encode( $options )
+				),
+				$contentsBuilder->getHtml()
+			);
+		}
 
 		// Ajax/API is doing the data fetch
 		$html = Html::rawElement(
@@ -170,7 +179,7 @@ class SpecialBrowse extends SpecialPage {
 			) . Html::rawElement(
 				'div',
 				array(
-					'class' => 'smwb-content is-disabled'
+					'class' => 'smwb-emptysheet is-disabled'
 				),
 				Html::rawElement(
 					'span',

--- a/tests/phpunit/Unit/MediaWiki/Api/BrowseBySubjectTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Api/BrowseBySubjectTest.php
@@ -194,7 +194,7 @@ class BrowseBySubjectTest extends \PHPUnit_Framework_TestCase {
 		$out = ob_get_clean();
 
 		$this->stringValidator->assertThatStringContains(
-			'"query":"\n<table class=\"smwb-factbox\" ',
+			'"query":"<div class=\"smwb-datasheet\"><div class=\"smw-table smwb-factbox\">',
 			$out
 		);
 	}


### PR DESCRIPTION
This PR is made in reference to: #

This PR addresses or contains:

- Replaces the use of `<table>` with `<div>` (together with `display: table;`)
- Provides better responsiveness towards smaller screens 
- Avoids `MobileFrontend` display  issues (uneven table columns) as seen in 

![image](https://cloud.githubusercontent.com/assets/1245473/24586477/d1ba1400-17dc-11e7-9faf-7bb49f79b1fd.png)



This PR includes:
- [ ] Tests (unit/integration)
- [ ] CI build passed
