### PR TITLE
TextByChangeUpdater change update approach, refs 1481

### DIFF
--- a/DefaultSettings.php
+++ b/DefaultSettings.php
@@ -1268,7 +1268,8 @@ return array(
 	##
 	'smwgFulltextSearchPropertyExemptionList' => array(
 		'_ASKFO', '_ASKST', '_ASKPA','_IMPO', '_LCODE', '_UNIT', '_CONV',
-		'_TYPE', '_ERRT', '_INST', '_ASK', '_INST', '_SOBJ', '_PVAL', '_PVALI'
+		'_TYPE', '_ERRT', '_INST', '_ASK', '_INST', '_SOBJ', '_PVAL', '_PVALI',
+		'_REDI'
 	),
 	##
 

--- a/src/SQLStore/ChangeOp/TableChangeOp.php
+++ b/src/SQLStore/ChangeOp/TableChangeOp.php
@@ -77,19 +77,24 @@ class TableChangeOp {
 	/**
 	 * @since 2.4
 	 *
-	 * @param string $opType
+	 * @param string|null $opType
 	 *
 	 * @return FieldChangeOp[]|[]
 	 */
-	public function getFieldChangeOps( $opType ) {
+	public function getFieldChangeOps( $opType = null ) {
 
-		if ( !$this->hasChangeOp( $opType ) ) {
+		if ( $opType !== null && !$this->hasChangeOp( $opType ) ) {
 			return array();
 		}
 
 		$fieldOps = array();
+		$changeOps = $this->changeOps;
 
-		foreach ( $this->changeOps[$opType] as $op ) {
+		if ( $opType !== null ) {
+			$changeOps = $this->changeOps[$opType];
+		}
+
+		foreach ( $changeOps as $op ) {
 			$fieldOps[] = new FieldChangeOp( $op );
 		}
 

--- a/src/SQLStore/ChangeOp/TempChangeOpStore.php
+++ b/src/SQLStore/ChangeOp/TempChangeOpStore.php
@@ -99,7 +99,7 @@ class TempChangeOpStore implements LoggerAwareInterface {
 
 		$this->cache->save(
 			$slot,
-			$orderedDiffByTable
+			serialize( $compositePropertyTableDiffIterator )
 		);
 
 		return $slot;
@@ -115,37 +115,23 @@ class TempChangeOpStore implements LoggerAwareInterface {
 	}
 
 	/**
-	 * @since 2.5
+	 * @since 3.0
 	 *
 	 * @param string $slot
-	 * @param string|null $tableName
 	 *
-	 * @return TableChange[]
+	 * @return CompositePropertyTableDiffIterator|null
 	 */
-	public function newTableChangeOpsFrom( $slot, $tableName = null ) {
+	public function newCompositePropertyTableDiffIterator( $slot ) {
 
-		$start = microtime( true );
+		$compositePropertyTableDiffIterator = unserialize(
+			$this->cache->fetch( $slot )
+		);
 
-		$diffByTable = $this->cache->fetch( $slot );
-		$tableChangeOps = array();
-
-		if ( $diffByTable === false || $diffByTable === null ) {
-			$this->log( __METHOD__ . ' unknown slot :: '. $slot );
-			return array();
+		if ( $compositePropertyTableDiffIterator === false || $compositePropertyTableDiffIterator === null ) {
+			return null;
 		}
 
-		foreach ( $diffByTable as $tblName => $diff ) {
-
-			if ( $tableName !== null && $tableName !== $tblName ) {
-				continue;
-			}
-
-			$tableChangeOps[] = new TableChangeOp( $tblName, $diff );
-		}
-
-		$this->log( __METHOD__ . ' procTime (sec): '. round( ( microtime( true ) - $start ), 5 ) );
-
-		return $tableChangeOps;
+		return $compositePropertyTableDiffIterator;
 	}
 
 	private function log( $message, $context = array() ) {

--- a/src/SQLStore/PropertyTableRowDiffer.php
+++ b/src/SQLStore/PropertyTableRowDiffer.php
@@ -146,7 +146,12 @@ class PropertyTableRowDiffer {
 			}
 		}
 
-		$this->getCompositePropertyTableDiff()->addTableRowsToCompositeDiff(
+		$this->getCompositePropertyTableDiff()->addDataRecord(
+			$semanticData->getSubject()->getHash(),
+			$newData
+		);
+
+		$this->getCompositePropertyTableDiff()->addTableDiffChangeOp(
 			$tablesInsertRows,
 			$tablesDeleteRows
 		);

--- a/src/SQLStore/QueryEngine/Fulltext/SearchTableUpdater.php
+++ b/src/SQLStore/QueryEngine/Fulltext/SearchTableUpdater.php
@@ -99,6 +99,29 @@ class SearchTableUpdater {
 	 * @param integer $sid
 	 * @param integer $pid
 	 *
+	 * @return boolean
+	 */
+	public function exists( $sid, $pid ) {
+
+		$row = $this->connection->selectRow(
+			$this->searchTable->getTableName(),
+			array( 's_id' ),
+			array(
+				's_id' => (int)$sid,
+				'p_id' => (int)$pid
+			),
+			__METHOD__
+		);
+
+		return $row !== false;
+	}
+
+	/**
+	 * @since 2.5
+	 *
+	 * @param integer $sid
+	 * @param integer $pid
+	 *
 	 * @return false|string
 	 */
 	public function read( $sid, $pid ) {

--- a/tests/phpunit/Unit/SQLStore/ChangeOp/TableChangeOpTest.php
+++ b/tests/phpunit/Unit/SQLStore/ChangeOp/TableChangeOpTest.php
@@ -105,10 +105,49 @@ class TableChangeOpTest extends \PHPUnit_Framework_TestCase {
 			'_MDAT',
 			$instance->getFixedPropertyValueBy( 'key' )
 		);
+	}
 
-		$this->assertInternalType(
-			'array',
-			$instance->getFieldChangeOps( 'insert' )
+	public function testGetFieldChangeOpsNoType() {
+
+		$diff = array(
+		'property' =>
+			array(
+				'key' => '_MDAT',
+				'p_id' => 29,
+			),
+		'insert' =>
+			array(
+			0 =>
+				array(
+					's_id' => 462,
+					'o_serialized' => '1/2016/6/10/2/3/31/0',
+					'o_sortkey' => '2457549.5857755',
+				),
+			),
+		'delete' =>
+			array(
+				0 =>
+				array(
+				's_id' => 462,
+				'o_serialized' => '1/2016/6/10/2/1/0/0',
+				'o_sortkey' => '2457549.5840278',
+				),
+			),
+		);
+
+		$instance = new TableChangeOp(
+			'foo',
+			$diff
+		);
+
+		$this->assertCount(
+			1,
+			$instance->getFieldChangeOps( TableChangeOp::OP_INSERT )
+		);
+
+		$this->assertCount(
+			3,
+			$instance->getFieldChangeOps()
 		);
 	}
 

--- a/tests/phpunit/Unit/SQLStore/ChangeOp/TempChangeOpStoreTest.php
+++ b/tests/phpunit/Unit/SQLStore/ChangeOp/TempChangeOpStoreTest.php
@@ -88,6 +88,37 @@ class TempChangeOpStoreTest extends \PHPUnit_Framework_TestCase {
 		);
 	}
 
+	public function testNewCompositePropertyTableDiffIterator() {
+
+		$this->cache->expects( $this->once() )
+			->method( 'fetch' )
+			->will( $this->returnValue( serialize( $this->compositePropertyTableDiffIterator ) ) );
+
+		$instance = new TempChangeOpStore(
+			$this->cache
+		);
+
+		$this->assertInstanceOf(
+			'\SMW\SQLStore\CompositePropertyTableDiffIterator',
+			$instance->newCompositePropertyTableDiffIterator( 'foo' )
+		);
+	}
+
+	public function testNewCompositePropertyTableDiffIteratorOnInvalidSlot() {
+
+		$this->cache->expects( $this->once() )
+			->method( 'fetch' )
+			->will( $this->returnValue( false ) );
+
+		$instance = new TempChangeOpStore(
+			$this->cache
+		);
+
+		$this->assertNull(
+			$instance->newCompositePropertyTableDiffIterator( 'foo' )
+		);
+	}
+
 	public function testDelete() {
 
 		$this->cache->expects( $this->once() )
@@ -98,42 +129,6 @@ class TempChangeOpStoreTest extends \PHPUnit_Framework_TestCase {
 		);
 
 		$instance->delete( 'foo' );
-	}
-
-	public function testNewTableChangeOpsFrom() {
-
-		$res = array(
-			'Foo' => array( 'Bar' ),
-			'Foobar' => array( 'baz' )
-		);
-
-		$this->cache->expects( $this->once() )
-			->method( 'fetch' )
-			->with( $this->equalTo( 'Foo:bar' ) )
-			->will( $this->returnValue( $res ) );
-
-		$instance = new TempChangeOpStore(
-			$this->cache
-		);
-
-		$this->assertContainsOnlyInstancesOf(
-			'\SMW\SQLStore\ChangeOp\TableChangeOp',
-			$instance->newTableChangeOpsFrom( 'Foo:bar' )
-		);
-	}
-
-	public function testNewTableChangeOpsFromUnknownSlot() {
-
-		$this->cache->expects( $this->once() )
-			->method( 'fetch' );
-
-		$instance = new TempChangeOpStore(
-			$this->cache
-		);
-
-		$this->assertEmpty(
-			$instance->newTableChangeOpsFrom( 'Foo:bar' )
-		);
 	}
 
 }

--- a/tests/phpunit/Unit/SQLStore/CompositePropertyTableDiffIteratorTest.php
+++ b/tests/phpunit/Unit/SQLStore/CompositePropertyTableDiffIteratorTest.php
@@ -103,6 +103,67 @@ class CompositePropertyTableDiffIteratorTest extends \PHPUnit_Framework_TestCase
 		);
 	}
 
+	public function testGetListOfChangedEntitiesByType() {
+
+		$diff = array(
+			0 => array(
+				'insert' => array(
+					'smw_di_number' => array(
+						0 => array(
+							's_id' => 3668,
+							'p_id' => 61,
+							'o_serialized' => '123',
+							'o_sortkey' => '123',
+						),
+						1 => array(
+							's_id' => 3668,
+							'p_id' => 62,
+							'o_serialized' => '1234',
+							'o_sortkey' => '1234',
+						),
+					),
+					'smw_fpt_mdat' => array(
+						0 => array(
+							's_id' => 3668,
+							'o_serialized' => '1/2015/8/16/9/28/39',
+							'o_sortkey' => '2457250.8948958',
+						),
+					),
+				),
+				'delete' => array(
+					'smw_di_number' => array(),
+					'smw_fpt_mdat'  => array(
+						0 => array(
+							's_id' => 3667,
+							'o_serialized' => '1/2015/8/16/9/28/39',
+							'o_sortkey' => '2457250.8948958',
+						)
+					),
+				)
+			)
+		);
+
+		$instance = new CompositePropertyTableDiffIterator(
+			$diff
+		);
+
+		$this->assertEquals(
+			array(
+				3667 => true
+			),
+			$instance->getListOfChangedEntityIdsByType( $instance::TYPE_DELETE )
+		);
+
+		$this->assertEquals(
+			array(
+				61 => true,
+				3668 => true,
+				62 => true
+			),
+			$instance->getListOfChangedEntityIdsByType( $instance::TYPE_INSERT )
+		);
+	}
+
 	public function testTryToGetTableChangeOpForSingleTable() {
 
 		$diff = array();

--- a/tests/phpunit/Unit/SQLStore/QueryEngine/Fulltext/SearchTableUpdaterTest.php
+++ b/tests/phpunit/Unit/SQLStore/QueryEngine/Fulltext/SearchTableUpdaterTest.php
@@ -192,4 +192,24 @@ class SearchTableUpdaterTest extends \PHPUnit_Framework_TestCase {
 		$instance->flushTable();
 	}
 
+	public function testExists() {
+
+		$this->connection->expects( $this->once() )
+			->method( 'selectRow' )
+			->with(
+				$this->anything(),
+				$this->anything(),
+				$this->equalTo( array(
+					's_id' => 12,
+					'p_id' => 42 ) ) );
+
+		$instance = new SearchTableUpdater(
+			$this->connection,
+			$this->searchTable,
+			$this->textSanitizer
+		);
+
+		$instance->exists( 12, 42 );
+	}
+
 }

--- a/tests/phpunit/Unit/SQLStore/QueryEngine/Fulltext/TextByChangeUpdaterTest.php
+++ b/tests/phpunit/Unit/SQLStore/QueryEngine/Fulltext/TextByChangeUpdaterTest.php
@@ -68,6 +68,10 @@ class TextByChangeUpdaterTest extends \PHPUnit_Framework_TestCase {
 			->method( 'getTableChangeOps' )
 			->will( $this->returnValue( array() ) );
 
+		$compositePropertyTableDiffIterator->expects( $this->once() )
+			->method( 'getDataChangeOps' )
+			->will( $this->returnValue( array() ) );
+
 		$compositePropertyTableDiffIterator->expects( $this->never() )
 			->method( 'getSubject' );
 
@@ -163,6 +167,10 @@ class TextByChangeUpdaterTest extends \PHPUnit_Framework_TestCase {
 
 		$compositePropertyTableDiffIterator->expects( $this->once() )
 			->method( 'getTableChangeOps' )
+			->will( $this->returnValue( array() ) );
+
+		$compositePropertyTableDiffIterator->expects( $this->once() )
+			->method( 'getDataChangeOps' )
 			->will( $this->returnValue( array() ) );
 
 		$compositePropertyTableDiffIterator->expects( $this->never() )


### PR DESCRIPTION
This PR is made in reference to: #1481

This PR addresses or contains:

A certain update sequence could allow for a text element to remain in the
index due to the missing information in the diff record about a removed
element.

Instead of using the insert-diff to replace text elements, use the delete-diff
to remove all items from the index and after that insert related data from
the primary data container. This approach ensures the content is in sync with
the `SemanticData` primary data update.

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed
