### PR TITLE
ParserCachePurgeJob count links from the source

### DIFF
--- a/src/SQLStore/QueryDependency/QueryDependencyLinksStore.php
+++ b/src/SQLStore/QueryDependency/QueryDependencyLinksStore.php
@@ -306,16 +306,19 @@ class QueryDependencyLinksStore implements LoggerAwareInterface {
 			return array();
 		}
 
-		$requestOptions = new RequestOptions();
+		// Return the expected count of targets
+		$requestOptions->targetLinksCount = count( $targetLinksIdList );
 
-		$requestOptions->addExtraCondition(
+		$poolRequestOptions = new RequestOptions();
+
+		$poolRequestOptions->addExtraCondition(
 			'smw_iw !=' . $this->connection->addQuotes( SMW_SQL3_SMWREDIIW ) . ' AND '.
 			'smw_iw !=' . $this->connection->addQuotes( SMW_SQL3_SMWDELETEIW )
 		);
 
 		return $this->store->getObjectIds()->getDataItemPoolHashListFor(
 			$targetLinksIdList,
-			$requestOptions
+			$poolRequestOptions
 		);
 	}
 


### PR DESCRIPTION
This PR is made in reference to: #1421

This PR addresses or contains:

- Use the count of the original source list instead of the composite list to ensure that all chunks can be fetched

This PR includes:
- [ ] Tests (unit/integration)
- [x] CI build passed
