### PR TITLE
PageUpdater::isHtmlCacheUpdate, DeferrableUpdate

### DIFF
--- a/includes/storage/SMW_Store.php
+++ b/includes/storage/SMW_Store.php
@@ -232,9 +232,12 @@ abstract class Store implements QueryEngine {
 
 		$pageUpdater->addPage( $subject->getTitle() );
 		$pageUpdater->waitOnTransactionIdle();
+		$pageUpdater->markAsPending();
+		$pageUpdater->setOrigin( __METHOD__ );
 
 		$pageUpdater->doPurgeParserCache();
 		$pageUpdater->doPurgeHtmlCache();
+		$pageUpdater->pushUpdate();
 
 		$applicationFactory->getMediaWikiLogger()->info(
 			__METHOD__ . ' (procTime in sec: '. Timer::getElapsedTime( __METHOD__, 5 ) . ')'

--- a/src/ApplicationFactory.php
+++ b/src/ApplicationFactory.php
@@ -268,6 +268,15 @@ class ApplicationFactory {
 			$GLOBALS['wgCommandLineMode']
 		);
 
+		// https://phabricator.wikimedia.org/T154427
+		// It is unclear what changed in MW 1.29 but it has been observed that
+		// executing a HTMLCacheUpdate from within an transaction can lead to a
+		// "ErrorException ... 1 buffered job ... HTMLCacheUpdateJob never
+		// inserted" hence disable the update functionality
+		$pageUpdater->isHtmlCacheUpdate(
+			false
+		);
+
 		return $pageUpdater;
 	}
 

--- a/src/DeferredCallableUpdate.php
+++ b/src/DeferredCallableUpdate.php
@@ -206,8 +206,6 @@ class DeferredCallableUpdate implements DeferrableUpdate, LoggerAwareInterface {
 	 */
 	public function doUpdate() {
 
-		$this->log( $this->origin . ' doUpdate' . ( $this->fingerprint ? ' (' . $this->fingerprint . ')' : '' ) );
-
 		if ( $this->onTransactionIdle ) {
 			return $this->connection->onTransactionIdle( function() {
 				$this->log( $this->origin . ' doUpdate (onTransactionIdle)' );
@@ -215,6 +213,8 @@ class DeferredCallableUpdate implements DeferrableUpdate, LoggerAwareInterface {
 				$this->doUpdate();
 			} );
 		}
+
+		$this->log( $this->origin . ' doUpdate' . ( $this->fingerprint ? ' (' . $this->fingerprint . ')' : '' ) );
 
 		call_user_func( $this->callback );
 		unset( self::$queueList[$this->fingerprint] );

--- a/src/MediaWiki/Database.php
+++ b/src/MediaWiki/Database.php
@@ -122,6 +122,19 @@ class Database {
 	}
 
 	/**
+	 * @see DatabaseBase::timestamp
+	 *
+	 * @since 3.0
+	 *
+	 * @param integer $ts
+	 *
+	 * @return string
+	 */
+	public function timestamp( $ts = 0 ) {
+		return $this->readConnection()->timestamp( $ts );
+	}
+
+	/**
 	 * @see DatabaseBase::addQuotes
 	 *
 	 * @since 1.9.0.2

--- a/src/MediaWiki/Jobs/ParserCachePurgeJob.php
+++ b/src/MediaWiki/Jobs/ParserCachePurgeJob.php
@@ -85,7 +85,7 @@ class ParserCachePurgeJob extends JobBase {
 		}
 
 		$this->pageUpdater->addPage( $this->getTitle() );
-		$this->pageUpdater->waitOnTransactionIdle();
+		$this->pageUpdater->asPoolPurge();
 		$this->pageUpdater->doPurgeParserCache();
 
 		Hooks::run( 'SMW::Job::AfterParserCachePurgeComplete', array( $this ) );

--- a/src/MediaWiki/PageUpdater.php
+++ b/src/MediaWiki/PageUpdater.php
@@ -5,6 +5,9 @@ namespace SMW\MediaWiki;
 use Title;
 use Psr\Log\LoggerInterface;
 use Psr\Log\LoggerAwareInterface;
+use SMW\Utils\Timer;
+use DeferrableUpdate;
+use DeferredUpdates;
 
 /**
  * @license GNU GPL v2+
@@ -12,7 +15,7 @@ use Psr\Log\LoggerAwareInterface;
  *
  * @author mwjames
  */
-class PageUpdater implements LoggerAwareInterface {
+class PageUpdater implements LoggerAwareInterface, DeferrableUpdate {
 
 	/**
 	 * @var Database
@@ -30,6 +33,11 @@ class PageUpdater implements LoggerAwareInterface {
 	private $logger;
 
 	/**
+	 * @var string
+	 */
+	private $origin = '';
+
+	/**
 	 * @var boolean
 	 */
 	private $isCommandLineMode = false;
@@ -37,7 +45,27 @@ class PageUpdater implements LoggerAwareInterface {
 	/**
 	 * @var boolean
 	 */
+	private $isHtmlCacheUpdate = true;
+
+	/**
+	 * @var boolean
+	 */
 	private $onTransactionIdle = false;
+
+	/**
+	 * @var boolean
+	 */
+	private $asPoolPurge = false;
+
+	/**
+	 * @var boolean
+	 */
+	private $isPending = false;
+
+	/**
+	 * @var array
+	 */
+	private $pendingUpdates = array();
 
 	/**
 	 * @since 2.5
@@ -60,6 +88,15 @@ class PageUpdater implements LoggerAwareInterface {
 	}
 
 	/**
+	 * @since 3.0
+	 *
+	 * @param string $origin
+	 */
+	public function setOrigin( $origin ) {
+		$this->origin = $origin;
+	}
+
+	/**
 	 * @see https://www.mediawiki.org/wiki/Manual:$wgCommandLineMode
 	 * Indicates whether MW is running in command-line mode or not.
 	 *
@@ -69,6 +106,24 @@ class PageUpdater implements LoggerAwareInterface {
 	 */
 	public function isCommandLineMode( $isCommandLineMode ) {
 		$this->isCommandLineMode = $isCommandLineMode;
+	}
+
+	/**
+	 * @since 3.0
+	 *
+	 * @param boolean $isHtmlCacheUpdate
+	 */
+	public function isHtmlCacheUpdate( $isHtmlCacheUpdate ) {
+		$this->isHtmlCacheUpdate = $isHtmlCacheUpdate;
+	}
+
+	/**
+	 * @since 3.0
+	 *
+	 * @param booloan $isPending
+	 */
+	public function markAsPending() {
+		$this->isPending = true;
 	}
 
 	/**
@@ -82,7 +137,7 @@ class PageUpdater implements LoggerAwareInterface {
 			return;
 		}
 
-		$this->titles[$title->getPrefixedDBKey()] = $title;
+		$this->titles[$title->getDBKey()] = $title;
 	}
 
 	/**
@@ -104,6 +159,22 @@ class PageUpdater implements LoggerAwareInterface {
 	}
 
 	/**
+	 * Controls the purge to use a direct DB access to make changes to avoid
+	 * racing conditions for a large number of title entities.
+	 *
+	 * @since 3.0
+	 */
+	public function asPoolPurge() {
+
+		if ( $this->connection === null ) {
+			return;
+		}
+
+		$this->onTransactionIdle = true;
+		$this->asPoolPurge = true;
+	}
+
+	/**
 	 * @since 2.1
 	 */
 	public function clear() {
@@ -120,11 +191,53 @@ class PageUpdater implements LoggerAwareInterface {
 	}
 
 	/**
+	 * Push updates to be either deferred or direct pending the setting invoked
+	 * by PageUPdater::markAsPending.
+	 *
+	 * @since 3.0
+	 */
+	public function pushUpdate() {
+
+		if ( !$this->isPending || $this->isCommandLineMode === true ) {
+			return $this->doUpdate();
+		}
+
+		$this->log( __METHOD__ . " $this->origin (as DeferrableUpdate)" );
+
+		if ( $this->onTransactionIdle ) {
+			$this->connection->onTransactionIdle( function () {
+				DeferredUpdates::addUpdate( $this );
+			} );
+		} else{
+			DeferredUpdates::addUpdate( $this );
+		}
+	}
+
+	/**
+	 * @see DeferrableUpdate::doUpdate
+	 *
+	 * @since 3.0
+	 */
+	public function doUpdate() {
+		$this->isPending = false;
+
+		foreach ( array_keys( $this->pendingUpdates ) as $update ) {
+			call_user_func( [ $this, $update ] );
+		}
+
+		$this->pendingUpdates = array();
+	}
+
+	/**
 	 * @since 2.1
 	 */
 	public function doPurgeParserCache() {
 
 		$method = __METHOD__;
+
+		if ( $this->isPending ) {
+			return $this->pendingUpdates['doPurgeParserCache'] = true;
+		}
 
 		if ( $this->onTransactionIdle ) {
 			return $this->connection->onTransactionIdle( function () use( $method ) {
@@ -133,6 +246,10 @@ class PageUpdater implements LoggerAwareInterface {
 				$this->doPurgeParserCache();
 				$this->onTransactionIdle = true;
 			} );
+		}
+
+		if ( $this->asPoolPurge ) {
+			return $this->doPoolPurge();
 		}
 
 		foreach ( $this->titles as $title ) {
@@ -145,6 +262,14 @@ class PageUpdater implements LoggerAwareInterface {
 	 */
 	public function doPurgeHtmlCache() {
 
+		if ( $this->isHtmlCacheUpdate === false ) {
+			return;
+		}
+
+		if ( $this->isPending ) {
+			return $this->pendingUpdates['doPurgeHtmlCache'] = true;
+		}
+
 		$method = __METHOD__;
 
 		if ( $this->onTransactionIdle ) {
@@ -156,11 +281,10 @@ class PageUpdater implements LoggerAwareInterface {
 			} );
 		}
 
+		// Calls HTMLCacheUpdate, HTMLCacheUpdateJob including HTMLFileCache,
+		// CdnCacheUpdate
 		foreach ( $this->titles as $title ) {
 			$title->touchLinks();
-
-			// @see MW 1.19 Title::invalidateCache
-			\HTMLFileCache::clearFileCache( $title );
 		}
 	}
 
@@ -170,6 +294,10 @@ class PageUpdater implements LoggerAwareInterface {
 	public function doPurgeWebCache() {
 
 		$method = __METHOD__;
+
+		if ( $this->isPending ) {
+			return $this->pendingUpdates['doPurgeWebCache'] = true;
+		}
 
 		if ( $this->onTransactionIdle ) {
 			return $this->connection->onTransactionIdle( function () use ( $method ) {
@@ -183,6 +311,54 @@ class PageUpdater implements LoggerAwareInterface {
 		foreach ( $this->titles as $title ) {
 			$title->purgeSquid();
 		}
+	}
+
+	/**
+	 * Copied from PurgeJobUtils to avoid the AutoCommitUpdate from
+	 * Title::invalidateCache introduced with MW 1.28/1.29 on a large update pool
+	 */
+	private function doPoolPurge() {
+
+		Timer::start( __METHOD__ );
+
+		// Required due to postgres and "Error: 22007 ERROR:  invalid input
+		// syntax for type timestamp with time zone: "20170408113703""
+		$now = $this->connection->timestamp();
+		$res = $this->connection->select(
+			'page',
+			'page_id',
+			[
+				'page_title' => array_keys( $this->titles ),
+				'page_touched < ' . $this->connection->addQuotes( $now )
+			],
+			__METHOD__
+		);
+
+		if ( $res === false ) {
+			return;
+		}
+
+		$ids = [];
+
+		foreach ( $res as $row ) {
+			$ids[] = $row->page_id;
+		}
+
+		if ( $ids === array() ) {
+			return;
+		}
+
+		$this->connection->update(
+			'page',
+			[ 'page_touched' => $now ],
+			[
+				'page_id' => $ids,
+				'page_touched < ' . $this->connection->addQuotes( $now )
+			],
+			__METHOD__
+		);
+
+		$this->log( __METHOD__ . ' (procTime in sec: ' . Timer::getElapsedTime( __METHOD__, 7 ) . ')' );
 	}
 
 	private function log( $message, $context = array() ) {

--- a/src/Utils/BufferedStatsdCollector.php
+++ b/src/Utils/BufferedStatsdCollector.php
@@ -223,6 +223,7 @@ class BufferedStatsdCollector {
 		);
 
 		$deferredCallableUpdate->setOrigin( __METHOD__ );
+		$deferredCallableUpdate->waitOnTransactionIdle();
 
 		$deferredCallableUpdate->setFingerprint(
 			__METHOD__ . $this->fingerprint

--- a/src/Utils/Timer.php
+++ b/src/Utils/Timer.php
@@ -16,6 +16,18 @@ class Timer {
 	private static $start = array();
 
 	/**
+	 * @since 3.0
+	 *
+	 * @param integer $outputType
+	 * @param integer $ts
+	 *
+	 * @return string|bool
+	 */
+	public static function getTimestamp( $outputType = TS_UNIX, $ts = 0 ) {
+		return wfTimestamp( $outputType, $ts );
+	}
+
+	/**
 	 * @since 2.5
 	 */
 	public static function start( $name ) {


### PR DESCRIPTION
This PR is made in reference to: #

This PR addresses or contains:

- Avoid HtmlCacheUpdate due to observed https://phabricator.wikimedia.org/T154427 (MW 1.29)
- Allow `PageUpdater::asPoolPurge` to avoid having the `ParserCachePurgeJob` collide with the `AutoCommitUpdate` of the `Title::invalidateCache` (https://phabricator.wikimedia.org/T15443, MW 1.29)
- `BufferedStatsdCollector::saveStats` to `waitOnTransactionIdle` to avoid collision with an open transaction (nondeterministic observed on MW 1.29)

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed
