### PR TITLE
Skip 1.23 tests on unknown ImportSource interface, refs 2386

### DIFF
--- a/tests/phpunit/Integration/Importer/ImporterIntegrationTest.php
+++ b/tests/phpunit/Integration/Importer/ImporterIntegrationTest.php
@@ -54,6 +54,8 @@ class ImporterIntegrationTest extends MwDBaseUnitTestCase {
 
 	public function testValidXmlContent() {
 
+		$this->skipTestForMediaWikiVersionLowerThan( '1.25', "ImportSource interface is unknown (MW 1.25-)" );
+
 		$importFileDir = $this->testEnvironment->getFixturesLocation( 'Importer/ValidXmlContent' );
 
 		$importer = $this->importServicesFactory->newImporter(

--- a/tests/phpunit/Unit/Importer/ContentCreators/DispatchingContentCreatorTest.php
+++ b/tests/phpunit/Unit/Importer/ContentCreators/DispatchingContentCreatorTest.php
@@ -16,7 +16,6 @@ use SMW\Importer\ImportContents;
  */
 class DispatchingContentCreatorTest extends \PHPUnit_Framework_TestCase {
 
-	private $importServicesFactory;
 	private $wikiImporter;
 	private $messageReporter;
 
@@ -30,18 +29,6 @@ class DispatchingContentCreatorTest extends \PHPUnit_Framework_TestCase {
 		$this->wikiImporter = $this->getMockBuilder( '\WikiImporter' )
 			->disableOriginalConstructor()
 			->getMock();
-
-		$this->importServicesFactory = $this->getMockBuilder( '\SMW\Services\ImportServicesFactory' )
-			->disableOriginalConstructor()
-			->getMock();
-
-		$this->importServicesFactory->expects( $this->any() )
-			->method( 'newImportStreamSource' )
-			->will( $this->returnValue( $importStreamSource ) );
-
-		$this->importServicesFactory->expects( $this->any() )
-			->method( 'newWikiImporter' )
-			->will( $this->returnValue( $this->wikiImporter ) );
 
 		$this->messageReporter = $this->getMockBuilder( '\Onoi\MessageReporter\MessageReporter' )
 			->disableOriginalConstructor()

--- a/tests/phpunit/Unit/Importer/ContentCreators/XmlContentCreatorTest.php
+++ b/tests/phpunit/Unit/Importer/ContentCreators/XmlContentCreatorTest.php
@@ -23,6 +23,10 @@ class XmlContentCreatorTest extends \PHPUnit_Framework_TestCase {
 	protected function setUp() {
 		parent::setUp();
 
+		if ( !class_exists( '\ImportSource' ) ) {
+			$this->markTestSkipped( "ImportSource interface is unknown (MW 1.25-)" );
+		}
+
 		$importStreamSource = $this->getMockBuilder( '\ImportStreamSource' )
 			->disableOriginalConstructor()
 			->getMock();


### PR DESCRIPTION
This PR is made in reference to: #2386

This PR addresses or contains:

This PR includes:
- [ ] Tests (unit/integration)
- [x] CI build passed
