### PR TITLE
SemanticData::getPropertyValues to return always an indexed array

### DIFF
--- a/includes/SemanticData.php
+++ b/includes/SemanticData.php
@@ -227,7 +227,7 @@ class SemanticData {
 		}
 
 		if ( array_key_exists( $property->getKey(), $this->mPropVals ) ) {
-			return $this->mPropVals[$property->getKey()];
+			return array_values( $this->mPropVals[$property->getKey()] );
 		}
 
 		return array();

--- a/tests/phpunit/includes/SemanticDataTest.php
+++ b/tests/phpunit/includes/SemanticDataTest.php
@@ -486,6 +486,22 @@ class SemanticDataTest extends \PHPUnit_Framework_TestCase {
 		);
 	}
 
+	public function testGetPropertyValuesToReturnAnUnmappedArray() {
+
+		$property = new DIProperty( 'Foo' );
+		$instance = new SemanticData( DIWikiPage::newFromText( __METHOD__ ) );
+
+		$instance->addPropertyObjectValue(
+			$property,
+			new DIWikiPage( 'Bar', NS_MAIN )
+		);
+
+		$this->assertArrayHasKey(
+			0,
+			$instance->getPropertyValues( $property )
+		);
+	}
+
 	public function testClear() {
 
 		$title = Title::newFromText( __METHOD__ );


### PR DESCRIPTION
This PR is made in reference to: #

This PR addresses or contains:

- Ensures `SemanticData::getPropertyValues` always returns an index array independent of https://github.com/SemanticMediaWiki/SemanticMediaWiki/blob/2.5.x/includes/SemanticData.php#L405-L409

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed
