### PR TITLE
AskParserFunction to support @deferred mode

### DIFF
--- a/includes/query/SMW_Query.php
+++ b/includes/query/SMW_Query.php
@@ -121,7 +121,7 @@ class SMWQuery implements QueryContext {
 
 		// stating whether this query runs in an inline context; used to
 		// determine proper default parameters (e.g. the default limit)
-		if ( $context === self::INLINE_QUERY ) {
+		if ( $context === self::INLINE_QUERY || $context === self::DEFERRED_QUERY ) {
 			$inline = true;
 		}
 

--- a/includes/query/SMW_QueryProcessor.php
+++ b/includes/query/SMW_QueryProcessor.php
@@ -10,6 +10,7 @@ use SMW\ApplicationFactory;
 use SMW\Message;
 use SMW\Query\QueryContext;
 use SMW\Query\ResultFormatNotFoundException;
+use SMW\Query\DeferredQuery;
 
 /**
  * This file contains a static class for accessing functions to generate and execute
@@ -43,8 +44,8 @@ class SMWQueryProcessor implements QueryContext {
 	 *
 	 * @return Param[]
 	 */
-	public static function getProcessedParams( array $params, array $printRequests = array(), $unknownInvalid = true ) {
-		$validator = self::getValidatorForParams( $params, $printRequests, $unknownInvalid );
+	public static function getProcessedParams( array $params, array $printRequests = array(), $unknownInvalid = true, $context = null ) {
+		$validator = self::getValidatorForParams( $params, $printRequests, $unknownInvalid, $context );
 		$validator->processParameters();
 		return $validator->getParameters();
 	}
@@ -62,8 +63,8 @@ class SMWQueryProcessor implements QueryContext {
 	 *
 	 * @return Processor
 	 */
-	public static function getValidatorForParams( array $params, array $printRequests = array(), $unknownInvalid = true ) {
-		$paramDefinitions = self::getParameters();
+	public static function getValidatorForParams( array $params, array $printRequests = array(), $unknownInvalid = true, $context = null ) {
+		$paramDefinitions = self::getParameters( $context );
 
 		$paramDefinitions['format']->setPrintRequests( $printRequests );
 
@@ -325,9 +326,18 @@ class SMWQueryProcessor implements QueryContext {
 			self::addThisPrintout( $printouts, $params );
 		}
 
-		$params = self::getProcessedParams( $params, $printouts );
+		$params = self::getProcessedParams( $params, $printouts, true, $context );
 
 		$query  = self::createQuery( $queryString, $params, $context, '', $printouts, $contextPage );
+
+		// For convenience keep parameters and options to available for immediate
+		// processing
+		if ( $context === self::DEFERRED_QUERY ) {
+			$query->setOption( DeferredQuery::QUERY_PARAMETERS, implode( '|', $rawParams ) );
+			$query->setOption( DeferredQuery::SHOW_MODE, $showMode );
+			$query->setOption( DeferredQuery::CONTROL_ELEMENT, isset( $params['@control'] ) ? $params['@control']->getValue() : '' );
+		}
+
 		return array( $query, $params );
 	}
 
@@ -403,13 +413,18 @@ class SMWQueryProcessor implements QueryContext {
 	 */
 	public static function getResultFromQuery( SMWQuery $query, array $params, $outputMode, $context ) {
 
+		$printer = self::getResultPrinter( $params['format']->getValue(), $context );
+
+		if ( $printer->isDeferrable() && $context === self::DEFERRED_QUERY && $query->getLimit() > 0 ) {
+			return DeferredQuery::getHtml( $query );
+		}
+
 		$res = self::getStoreFromParams( $params )->getQueryResult( $query );
 		$start = microtime( true );
 
 		if ( ( $query->querymode == SMWQuery::MODE_INSTANCES ) ||
 			( $query->querymode == SMWQuery::MODE_NONE ) ) {
 
-			$printer = self::getResultPrinter( $params['format']->getValue(), $context );
 			$result = $printer->getResult( $res, $params, $outputMode );
 
 			$query->setOption( SMWQuery::PROC_PRINT_TIME, microtime( true ) - $start );
@@ -478,7 +493,7 @@ class SMWQueryProcessor implements QueryContext {
 	 *
 	 * @return IParamDefinition[]
 	 */
-	public static function getParameters() {
+	public static function getParameters( $context = null ) {
 		$params = array();
 
 		$allowedFormats = $GLOBALS['smwgResultFormats'];
@@ -552,6 +567,13 @@ class SMWQueryProcessor implements QueryContext {
 		$params['default'] = array(
 			'default' => '',
 		);
+
+		if ( $context === self::DEFERRED_QUERY ) {
+			$params['@control'] = array(
+				'default' => '',
+				'values' => array( 'slider' ),
+			);
+		}
 
 		// Give grep a chance to find the usages:
 		// smw-paramdesc-format, smw-paramdesc-source, smw-paramdesc-limit, smw-paramdesc-offset,

--- a/includes/queryprinters/CategoryResultPrinter.php
+++ b/includes/queryprinters/CategoryResultPrinter.php
@@ -45,6 +45,15 @@ class CategoryResultPrinter extends ResultPrinter {
 		return wfMessage( 'smw_printername_' . $this->mFormat )->text();
 	}
 
+	/**
+	 * @see ResultPrinter::isDeferrable
+	 *
+	 * {@inheritDoc}
+	 */
+	public function isDeferrable() {
+		return true;
+	}
+
 	protected function getResultText( SMWQueryResult $res, $outputMode ) {
 		$contentsByIndex = array();
 

--- a/includes/queryprinters/EmbeddedResultPrinter.php
+++ b/includes/queryprinters/EmbeddedResultPrinter.php
@@ -44,6 +44,15 @@ class EmbeddedResultPrinter extends ResultPrinter {
 		return wfMessage( 'smw_printername_embedded' )->text();
 	}
 
+	/**
+	 * @see ResultPrinter::isDeferrable
+	 *
+	 * {@inheritDoc}
+	 */
+	public function isDeferrable() {
+		return true;
+	}
+
 	protected function getResultText( SMWQueryResult $res, $outputMode ) {
 		global $wgParser;
 		// No page should embed itself, find out who we are:

--- a/includes/queryprinters/ListResultPrinter.php
+++ b/includes/queryprinters/ListResultPrinter.php
@@ -131,6 +131,15 @@ class ListResultPrinter extends ResultPrinter {
 	}
 
 	/**
+	 * @see ResultPrinter::isDeferrable
+	 *
+	 * {@inheritDoc}
+	 */
+	public function isDeferrable() {
+		return true;
+	}
+
+	/**
 	 * @see SMW\ResultPrinter::getResultText
 	 *
 	 * @param SMWQueryResult $queryResult

--- a/includes/queryprinters/ResultPrinter.php
+++ b/includes/queryprinters/ResultPrinter.php
@@ -671,6 +671,15 @@ abstract class ResultPrinter extends \ContextSource implements QueryResultPrinte
 	}
 
 	/**
+	 * @since 3.0
+	 *
+	 * @return boolean
+	 */
+	public function isDeferrable() {
+		return false;
+	}
+
+	/**
 	 * @since 2.5
 	 *
 	 * @return string

--- a/includes/queryprinters/TableResultPrinter.php
+++ b/includes/queryprinters/TableResultPrinter.php
@@ -38,6 +38,15 @@ class TableResultPrinter extends ResultPrinter {
 	}
 
 	/**
+	 * @see ResultPrinter::isDeferrable
+	 *
+	 * {@inheritDoc}
+	 */
+	public function isDeferrable() {
+		return true;
+	}
+
+	/**
 	 * Returns a table
 	 *
 	 * @param SMWQueryResult $res
@@ -116,7 +125,7 @@ class TableResultPrinter extends ResultPrinter {
 
 		$html = $this->htmlTableRenderer->getHtml( $tableAttrs );
 
-		return $this->isDataTable ? Html::rawElement( 'div', array( 'class' => 'smw-datatable smw-loading-image-dots' ), $html ) : $html;
+		return $this->isDataTable ? Html::rawElement( 'span', array( 'class' => 'smw-datatable smw-loading-image-dots' ), $html ) : $html;
 	}
 
 	/**

--- a/res/Resources.php
+++ b/res/Resources.php
@@ -299,6 +299,31 @@ return array(
 			"smw-format-datatable-sortdescending"
 		),
 		'targets' => array( 'mobile', 'desktop' )
+	),
+
+	// Deferred
+	'ext.smw.deferred.styles'  => $moduleTemplate + array(
+		'position' => 'top',
+		'styles'   => array( 'smw/deferred/ext.smw.deferred.css' ),
+		'targets' => array(
+			'mobile',
+			'desktop'
+		)
+	),
+
+	'ext.smw.deferred'  => $moduleTemplate + array(
+		'position' => 'top',
+		'styles'   => array( 'smw/deferred/ext.smw.deferred.css' ),
+		'scripts'  => array( 'smw/deferred/ext.smw.deferred.js' ),
+		'dependencies'  => array(
+			'mediawiki.api',
+			'mediawiki.api.parse',
+			'onoi.rangeslider'
+		),
+		'targets' => array(
+			'mobile',
+			'desktop'
+		)
 	)
 
 );

--- a/res/smw/deferred/ext.smw.deferred.css
+++ b/res/smw/deferred/ext.smw.deferred.css
@@ -1,0 +1,78 @@
+
+.smw-deferred-query-loading {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+.smw-deferred-query .loading-image {
+    text-align: center;
+}
+
+.smw-deferred-query .overlay {
+    filter:alpha(opacity=50);
+    -moz-opacity:0.5;
+    -khtml-opacity: 0.5;
+    opacity: 0.5;
+    z-index: 10000;
+    cursor: wait;
+}
+
+.smw-deferred-query #controls {
+   margin-bottom:10px;
+}
+
+.smw-deferred-query .ui-slider-horizontal .ui-state-default {
+    margin-left: -1.5em;
+}
+
+.smw-deferred-query .ui-slider .ui-slider-handle {
+    width:3em;
+    left:-1.5em;
+    text-decoration:none;
+    text-align:center;
+}
+
+.smw-deferred-query .irs-from, .smw-deferred-query .irs-to, .smw-deferred-query .irs-single {
+    background: rgba(0,0,0,0.3);
+}
+
+.smw-deferred-query .irs-from:after, .smw-deferred-query .irs-to:after, .smw-deferred-query .irs-single:after {
+    border-top-color: rgba(0,0,0,0.3);
+}
+
+.smw-deferred-query .irs {
+   margin-bottom: 10px;
+}
+
+.is-disabled {
+    opacity: .5;
+    position: relative;
+    pointer-events: none;
+}
+
+.is-disabled::after {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    content: ' ';
+}
+
+.skin-vector .smw-overlay-spinner {
+    left: 43%;
+    top: 40%;
+}
+
+@media (min-width: 400px) {
+    .skin-vector .smw-overlay-spinner {
+        left: 46%;
+    }
+}
+
+@media (max-width: 399px) {
+    .skin-vector .smw-overlay-spinner {
+        left: 47%;
+    }
+}

--- a/res/smw/deferred/ext.smw.deferred.js
+++ b/res/smw/deferred/ext.smw.deferred.js
@@ -1,0 +1,220 @@
+/**
+ * Responsible for executing a deferred request to the MediaWiki back-end to
+ * retrieve the representation for a #ask query.
+ */
+
+/*global jQuery, mediaWiki, smw */
+/*jslint white: true */
+
+( function( $, mw, onoi ) {
+
+	'use strict';
+
+	/**
+	 * @since 3.0
+	 * @constructor
+	 *
+	 * @param container {Object}
+	 * @param api {Object}
+	 */
+	var Query = function ( container, api ) {
+
+		this.VERSION = "3.0";
+
+		this.container = container;
+		this.mwApi = api;
+
+		this.title = mw.config.get( 'wgPageName' );
+		this.query = container.data( 'query' );
+
+		this.cmd = container.data( 'cmd' );
+		this.control = container.find( '#deferred-control' ).data( 'control' );
+
+		this.limit = container.data( 'limit' );
+		this.offset = container.data( 'offset' );
+
+		this.rangeLimit = this.limit;
+		this.init = true;
+
+		this.max = container.data( 'max' );
+		this.step = 1;
+		this.postfix = '';
+
+		// Ensure to have a limit parameter for queries that use
+		// the default setting
+		if ( this.query.indexOf( "|limit=" ) == -1 ) {
+			this.query = this.query + '|limit=' + this.limit;
+		}
+	};
+
+	/**
+	 * Request and parse a #ask/#show query using the MediaWiki API back-end
+	 *
+	 * @since 3.0
+	 */
+	Query.prototype.doApiRequest = function() {
+
+		var self = this,
+			noTrace = '';
+
+		// Replace limit with that of the range
+		var query = self.query.replace(
+			'limit=' + self.limit,
+			'limit=' + self.rangeLimit
+		);
+
+		// In case the query was altered from its original request, signal
+		// to the QueryDependencyLinksStore to disable any tracking
+		if ( self.query !== query ) {
+			noTrace = '|@notrace';
+		};
+
+		// API notes "modules: Gives the ResourceLoader modules used on the page.
+		// Either jsconfigvars or encodedjsconfigvars must be requested jointly
+		// with modules. 1.24+"
+		self.mwApi.post( {
+			action: "parse",
+			title: self.title,
+			contentmodel: 'wikitext',
+			prop: 'text|modules|jsconfigvars',
+			text: '{{#' + self.cmd + ':' +  query + noTrace + '}}'
+		} ).done( function( data ) {
+
+			if ( self.init === true ) {
+				self.replaceOutput( '' );
+			};
+
+			// Remove any comments retrieved from the API parse
+			// Remove any remaining placeholder loading classes
+			var text = data.parse.text['*']
+				.replace(/<!--[\S\s]*?-->/gm, '' )
+				.replace( 'smw-loading-image-dots', '' );
+
+			// Remove any <p> element to avoid line breakages
+			if ( self.cmd === 'show' ) {
+				text = text.replace( /(?:^<p[^>]*>)|(?:<\/p>$)/g, "");
+			}
+
+			self.replaceOutput( text, '', data.parse.modules );
+
+		} ).fail ( function( code, details ) {
+			var error =  code + ': ' + details.textStatus;
+
+			if ( details.error.hasOwnProperty( 'info' ) ) {
+				error = details.error.info;
+			}
+
+			self.container.find( '#deferred-control' ).replaceWith( "<div id='deferred-control'></div>" );
+			self.container.find( '.irs' ).hide();
+			self.replaceOutput( error, "smw-callout smw-callout-error" );
+		} );
+	};
+
+	/**
+	 * Replace output with generated content
+	 *
+	 * @since 3.0
+	 *
+	 * @param text {String}
+	 * @param oClass {String}
+	 * @param modules {Array}
+	 *
+	 * @return {this}
+	 */
+	Query.prototype.replaceOutput = function( text, oClass, modules ) {
+
+		var self = this,
+			element = this.cmd === 'ask' ? 'div' : 'span';
+
+		oClass = oClass !== undefined ? "class='" + oClass + "'" : '';
+
+		self.container.find( '#deferred-output' ).replaceWith(
+			"<" + element + " id='deferred-output'" + oClass + ">" + text + "</" + element + ">"
+		);
+
+		self.reload( modules );
+	};
+
+	/**
+	 * Reload module objects that rely on JavaScript to be executed after a
+	 * fresh parse.
+	 *
+	 * @since 3.0
+	 *
+	 * @param modules {Array}
+	 */
+	Query.prototype.reload = function( modules ) {
+
+		var self = this;
+
+		self.initControls();
+
+		// Trigger an event to re-apply JS instances initialization on new
+		// content
+		if ( modules !== undefined ) {
+			mw.loader.using( modules ).done( function () {
+				mw.hook( 'smw.deferred.query' ).fire( self.container );
+			} );
+		} else {
+			mw.hook( 'smw.deferred.query' ).fire( self.container );
+		}
+
+		var table = self.container.find( '#deferred-output table' );
+
+		// MW's table sorter isn't listed as page module therefore make an exception
+		// and reload it manually
+		if ( table.length > 0 && table.hasClass( 'sortable' ) ) {
+			mw.loader.using( 'jquery.tablesorter' ).done( function () {
+				table.tablesorter();
+				mw.hook( 'smw.deferred.query.tablesorter' ).fire( table );
+			} );
+		}
+	};
+
+	/**
+	 * Executes and manages the initialization of control elements
+	 *
+	 * @since 3.0
+	 */
+	Query.prototype.initControls = function() {
+
+		var self = this;
+		var loading = '<span class="smw-overlay-spinner large inline" alt="Loading..."></span>';
+
+		if ( self.init === true && self.control === 'slider' ) {
+			self.container.find( '#deferred-control' ).ionRangeSlider( {
+				min: self.limit + self.offset,
+				max: self.max,
+				step: self.step,
+				from: self.limit,
+				force_edges: true,
+				postfix: self.postfix,
+				onChange: function ( data ) {
+					self.container.find( '#deferred-output' ).addClass( 'is-disabled' ).append( loading );
+				},
+				onFinish: function ( data ) {
+					self.rangeLimit = data.from - self.offset;
+					self.doApiRequest();
+				}
+			} );
+		};
+
+		// Once called turn off the init flag
+		self.init = self.init === true ? false : self.init;
+	};
+
+	/**
+	 * @since 3.0
+	 */
+	$( document ).ready( function() {
+		$( '.smw-deferred-query' ).each( function() {
+			var q = new Query(
+				$( this ),
+				new mw.Api()
+			);
+
+			q.doApiRequest();
+		} );
+	} );
+
+}( jQuery, mediaWiki ) );

--- a/res/smw/ext.smw.css
+++ b/res/smw/ext.smw.css
@@ -821,7 +821,7 @@ a.smw-ask-action-btn-lblue:hover {
 }
 
 .skin-vector .smw-overlay-spinner {
-	left: 45%;
+	left: 43%;
 	top: 30%;
 }
 

--- a/res/smw/util/ext.smw.util.tooltip.js
+++ b/res/smw/util/ext.smw.util.tooltip.js
@@ -268,6 +268,11 @@
 			self.initFromContext( context );
 		} );
 
+		// Listen to the smw.deferred.query event
+		mw.hook( 'smw.deferred.query' ).add( function( context ) {
+			self.initFromContext( context );
+		} );
+
 		// SemanticForms/PageForms instance trigger
 		mw.hook( 'sf.addTemplateInstance' ).add( function( context ) {
 			self.initFromContext( context );

--- a/src/Query/DeferredQuery.php
+++ b/src/Query/DeferredQuery.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace SMW\Query;
+
+use SMWQuery as Query;
+use Html;
+use ParserOutput;
+
+/**
+ * @license GNU GPL v2+
+ * @since 3.0
+ *
+ * @author mwjames
+ */
+class DeferredQuery {
+
+	/**
+	 * Identifies the showMode
+	 */
+	const SHOW_MODE = 'dq.showmode';
+
+	/**
+	 * Identifies unparsed parameters
+	 */
+	const QUERY_PARAMETERS = 'dq.parameters';
+
+	/**
+	 * Identifies the @control element
+	 */
+	const CONTROL_ELEMENT = 'dq.control';
+
+	/**
+	 * @since 3.0
+	 *
+	 * @param ParserOutput $parserOutput
+	 */
+	public static function registerResourceModules( ParserOutput $parserOutput ) {
+		$parserOutput->addModuleStyles( 'ext.smw.deferred.styles' );
+		$parserOutput->addModules( 'ext.smw.deferred' );
+	}
+
+	/**
+	 * @since 3.0
+	 *
+	 * @param Query $query
+	 *
+	 * @return string
+	 */
+	public static function getHtml( Query $query ) {
+
+		$isShowMode = $query->getOption( self::SHOW_MODE );
+
+		// Ensures that a generated string can appear next to another text
+		$element = 'span';
+
+		$result = \Html::rawElement(
+			$element,
+			array(
+				'class' => 'smw-deferred-query',
+				'data-query'  => trim( $query->getOption( self::QUERY_PARAMETERS ) ),
+				'data-limit'  => $query->getLimit(),
+				'data-offset' => $query->getOffset(),
+				'data-max'    => $GLOBALS['smwgQMaxInlineLimit'],
+				'data-cmd'    => $isShowMode ? 'show' : 'ask'
+			),
+			\Html::rawElement( $element, array(
+				'id' => 'deferred-control',
+				'data-control' => $isShowMode ? '' : $query->getOption( self::CONTROL_ELEMENT )
+			), '' ) .
+			\Html::rawElement( $element, array(
+				'id' => 'deferred-output',
+				'class' => 'smw-loading-image-dots'
+			), '' )
+		);
+
+		return $result;
+	}
+
+}

--- a/src/Query/QueryContext.php
+++ b/src/Query/QueryContext.php
@@ -25,9 +25,14 @@ interface QueryContext {
 	const INLINE_QUERY = 1001;
 
 	/**
+	 * Deferred query definition
+	 */
+	const DEFERRED_QUERY = 1002;
+
+	/**
 	 * Query for concept definition
 	 */
-	const CONCEPT_DESC = 1002;
+	const CONCEPT_DESC = 1003;
 
 	/**
 	 * normal instance retrieval

--- a/tests/phpunit/Unit/Query/DeferredQueryTest.php
+++ b/tests/phpunit/Unit/Query/DeferredQueryTest.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace SMW\Tests\Query;
+
+use SMW\Query\DeferredQuery;
+
+/**
+ * @covers \SMW\Query\DeferredQuery
+ * @group semantic-mediawiki
+ *
+ * @license GNU GPL v2+
+ * @since 3.0
+ *
+ * @author mwjames
+ */
+class DeferredQueryTest extends \PHPUnit_Framework_TestCase {
+
+	public function testRegisterResourceModules() {
+
+		$parserOutput = $this->getMockBuilder( '\ParserOutput' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$parserOutput->expects( $this->once() )
+			->method( 'addModuleStyles' );
+
+		$parserOutput->expects( $this->once() )
+			->method( 'addModules' );
+
+		DeferredQuery::registerResourceModules( $parserOutput );
+	}
+
+	public function testGetHtml() {
+
+		$query = $this->getMockBuilder( '\SMWQuery' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$this->assertContains(
+			'smw-deferred-query',
+			DeferredQuery::getHtml( $query )
+		);
+	}
+
+}


### PR DESCRIPTION
Some `#ask` result formats are able to defer the result display with the help of JavaScript but those formats still require the initial `#ask` query to be executed while the page content is build making it possible that the page display is delayed due to some complex or long running queries being executed synchronously with the build process.

The overcome the issue of a `#ask` to require an in-process execution (means during the page content build process), this PR introduces some minor modification to decouple query execution and display from a page build process. 

## Synopsis

The enemy of any up-to-date query is the `ParserCache` as it prevents most embedded queries to contain updated results. `@deferred` as option is yet another method (besides `QueryDependencyLinksStore` and the `ParserCachePurgeJob`) that can circumvent the  `ParserCache` (without disabling it) by providing an inception point for queries (those marked with `@deferred`) to be updated via the MediaWiki API after MediaWiki has processed the page and generated the static HTML content.

## Query examples

Non-deferred query, requires the result to be available during the page build process.

```
{{#ask: [[Category:Lorem ipsum]]
 |?Has property description=Description 
 |limit=3
}}
```

Deferred query
```
{{#ask: [[Category:Lorem ipsum]]
 |?Has property description=Description 
 |limit=3
 |@deferred
}}
```

![deferred-query-2](https://cloud.githubusercontent.com/assets/1245473/24831363/22ed48f6-1cd3-11e7-8aaf-00b93173f4d8.gif)


## Technical notes

![image](https://cloud.githubusercontent.com/assets/1245473/25302095/0e346b30-2771-11e7-8618-a613afea1bdc.png)

As the `@deferred` name suggests, the query request is postponed until a page is build and send to the browser and only then a request (initiated by the `smw.deferred.query`) is made to the MediaWiki API to generate the result and place it within the marked area.

There is no modification of the result format itself with `smw.deferred.query` being only responsible to request a `api.post` for `action=parse`.

- Added `@deferred` as fixed identifier to a `#ask` query that will signal the parser function to defer any activities for those printers that support `ResultPrinter::isDeferrable`
- `#ask` and `#show` are both supported given that a result format supports `isDeferrable`
- The `smw.deferred.query` script will execute the query request on behalf of the embedded `#ask` query
- The `smw.deferred.query` script will trigger a `smw.deferred.query` event to inform result context related objects that the result has been generated and is loaded
- Out-of-the box support is added for `CategoryResultPrinter`, `EmbeddedResultPrinter`, `ListResultPrinter`, and `TableResultPrinter`
- `ResultFormat::isExportFormat` and `limit=0` are excluded from the deferred request as those queries don't create any DB/Store connection while building a reference link 
- `@control=slider` was added to allow generating a slider which can be used to dynamically alter a result display without the need to reload a page
- If the `QueryDependencyLinksStore` is enabled then the initial query (the one that contains the embedded definition) will be tracked but any modified query via the `@control` will not.
- If the `QueryCache` is enabled then the initial query will be stored with the embedded settings, yet any modified query  via the `@control` will only be cached for the time of the non-embedded cache duration.
- ![image](https://cloud.githubusercontent.com/assets/1245473/24831440/5214f9b6-1cd4-11e7-93a2-8133bc166f3f.png) indicates a queued request

### JS event hook

The tooltip uses the event to ensure that after a deferred parse content that requires a tooltip display is correctly initialized for the context.

```
// Listen to the smw.deferred.query event
mw.hook( 'smw.deferred.query' ).add( function( context ) {
	 self.initFromContext( context );
} );
```

### How to make a result format deferrable?

Example for the SRF gallery format:

- Add `SRF\Gallery::isDeferrable` and return `true`
- Modify `ext.srf.gallary.slideshow.js` with 

```
 	$( document ).ready( function() {
 
+		var gallery = new srf.formats.gallery();
+
 		$( '.srf-gallery-slideshow' ).each(function() {
-			var gallery = new srf.formats.gallery();
 			gallery.slideshow( $( this ) );
 		} );
+
+		// Listen to the smw.deferred.query event
+		mw.hook( 'smw.deferred.query' ).add( function( context ) {
+			gallery.slideshow( context );
+		} );
+
 	} );
```

This PR includes:
- [ ] Tests (unit/integration)
- [x] CI build passed
