### PR TITLE
Fix tests due changes on "Selflinks <a> tags vs. <strong> tags" (1.29+)

### DIFF
--- a/tests/phpunit/Integration/JSONScript/TestCases/f-0801.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/f-0801.json
@@ -66,7 +66,7 @@
 			},
 			"assert-output": {
 				"to-contain": [
-					"<h1><span class=\"mw-headline\" id=\"Format.2FEmbedded.2FA\"><strong class=\"selflink\">Format/Embedded/A</strong></span></h1>",
+					"<h1><span class=\"mw-headline\" id=\"Format.2FEmbedded.2FA\">.*selflink\">Format/Embedded/A.*</h1>",
 					"<h1><span class=\"mw-headline\" id=\"Format.2FEmbedded.2FA.2F1\">",
 					"<h1><span class=\"mw-headline\" id=\"Format.2FEmbedded.2FA.2F2\">",
 					"ABC",
@@ -95,7 +95,7 @@
 			},
 			"assert-output": {
 				"to-contain": [
-					"<h1><span class=\"mw-headline\" id=\"Format.2FEmbedded.2FB\"><strong class=\"selflink\">Format/Embedded/B</strong></span></h1>",
+					"<h1><span class=\"mw-headline\" id=\"Format.2FEmbedded.2FB\">.*selflink\">Format/Embedded/B.*</h1>",
 					"<h1><span class=\"mw-headline\" id=\"Format.2FEmbedded.2FB.2F1\">",
 					"<h1><span class=\"mw-headline\" id=\"Format.2FEmbedded.2FB.2F2\">",
 					"ABC",
@@ -149,7 +149,7 @@
 			},
 			"assert-output": {
 				"to-contain": [
-					"<h1><span class=\"mw-headline\" id=\"Format.2FEmbedded.2FD\"><strong class=\"selflink\">Format/Embedded/D</strong></span></h1>",
+					"<h1><span class=\"mw-headline\" id=\"Format.2FEmbedded.2FD\">.*selflink\">Format/Embedded/D.*</h1>",
 					"<h1><span class=\"mw-headline\" id=\"Format.2FEmbedded.2FB.2F1\">",
 					"<h1><span class=\"mw-headline\" id=\"Format.2FEmbedded.2FB.2F2\">",
 					"A123",

--- a/tests/phpunit/Integration/JSONScript/TestCases/p-0206.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/p-0206.json
@@ -65,7 +65,7 @@
 			},
 			"assert-output": {
 				"to-contain": [
-					">Example/0206/2</strong> + Example/0206/2 + Example/0206/2"
+					">Example/0206/2.* + Example/0206/2 + Example/0206/2"
 				]
 			}
 		},

--- a/tests/phpunit/Utils/Validators/StringValidator.php
+++ b/tests/phpunit/Utils/Validators/StringValidator.php
@@ -19,8 +19,8 @@ class StringValidator extends \PHPUnit_Framework_Assert {
 	public function assertThatStringContains( $expected, $actual, $message = '' ) {
 
 		$callback = function( &$expected, $actual, &$actualCounted ) {
-			foreach ( $expected as $key => $string ) {
-				if ( strpos( $actual, $string ) !== false ) {
+			foreach ( $expected as $key => $pattern ) {
+				if ( $this->isMatch( $pattern, $actual ) ) {
 					$actualCounted++;
 					unset( $expected[$key] );
 				}
@@ -80,6 +80,20 @@ class StringValidator extends \PHPUnit_Framework_Assert {
 			$actualCounted,
 			"Failed on `{$message}` for $actual with ($method) " . $this->toString( $expected )
 		);
+	}
+
+	private function isMatch( $pattern, $source ) {
+
+		// .* indicator to use the preg_match/wildcard search match otherwise
+		// use a simple strpos (as it is faster)
+		if ( strpos( $pattern, '.*' ) === false ) {
+			return strpos( $source, $pattern ) !== false;
+		}
+
+		$pattern = preg_quote( $pattern, '/' );
+		$pattern = str_replace( '\.\*' , '.*?', $pattern );
+
+		return (bool)preg_match( '/' . $pattern . '/' , $source );
 	}
 
 	private function toString( $expected ) {


### PR DESCRIPTION
This PR is made in reference to: https://phabricator.wikimedia.org/T160480

This PR addresses or contains:

- Use `.*` as wilcard to avoid dependence on MW specific version

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed
