### PR TITLE
UniquenessConstraintValueValidator to enforce NO_DEPENDENCY_TRACE

### DIFF
--- a/includes/ParserData.php
+++ b/includes/ParserData.php
@@ -40,7 +40,7 @@ class ParserData {
 	/**
 	 * Indicates that no #ask dependency tracking should occur
 	 */
-	const NO_QUERY_DEP_TRACE = 'no.query.dep.trace';
+	const NO_QUERY_DEPENDENCY_TRACE = 'no.query.dependency.trace';
 
 	/**
 	 * @var Title

--- a/includes/query/SMW_Query.php
+++ b/includes/query/SMW_Query.php
@@ -67,7 +67,7 @@ class SMWQuery implements QueryContext {
 	/**
 	 * Indicates no dependency trace
 	 */
-	const NO_DEP_TRACE = 'no.dep.trace';
+	const NO_DEPENDENCY_TRACE = 'no.dependency.trace';
 
 	public $sort = false;
 	public $sortkeys = array(); // format: "Property key" => "ASC" / "DESC" (note: order of entries also matters)

--- a/src/DataValues/ValueValidators/UniquenessConstraintValueValidator.php
+++ b/src/DataValues/ValueValidators/UniquenessConstraintValueValidator.php
@@ -177,7 +177,9 @@ class UniquenessConstraintValueValidator implements ConstraintValueValidator {
 		$query = $this->queryFactory->newQuery( $description );
 		$query->setLimit( 1 );
 		$query->setContextPage( $contextPage );
+
 		$query->setOption( $query::PROC_CONTEXT, 'UniquenessConstraintValueValidator' );
+		$query->setOption( $query::NO_DEPENDENCY_TRACE, true );
 
 		$dataItems = $this->cachedPropertyValuesPrefetcher->queryPropertyValuesFor(
 			$query

--- a/src/ParserFunctionFactory.php
+++ b/src/ParserFunctionFactory.php
@@ -82,7 +82,7 @@ class ParserFunctionFactory {
 		);
 
 		if ( isset( $parser->getOptions()->smwAskNoDependencyTracking ) ) {
-			$parserData->setOption( $parserData::NO_QUERY_DEP_TRACE, $parser->getOptions()->smwAskNoDependencyTracking );
+			$parserData->setOption( $parserData::NO_QUERY_DEPENDENCY_TRACE, $parser->getOptions()->smwAskNoDependencyTracking );
 		}
 
 		$messageFormatter = new MessageFormatter(
@@ -116,7 +116,7 @@ class ParserFunctionFactory {
 		);
 
 		if ( isset( $parser->getOptions()->smwAskNoDependencyTracking ) ) {
-			$parserData->setOption( $parserData::NO_QUERY_DEP_TRACE, $parser->getOptions()->smwAskNoDependencyTracking );
+			$parserData->setOption( $parserData::NO_QUERY_DEPENDENCY_TRACE, $parser->getOptions()->smwAskNoDependencyTracking );
 		}
 
 		$messageFormatter = new MessageFormatter(

--- a/src/ParserFunctions/AskParserFunction.php
+++ b/src/ParserFunctions/AskParserFunction.php
@@ -177,8 +177,8 @@ class AskParserFunction {
 
 		$query->setOption( Query::PROC_CONTEXT, 'AskParserFunction' );
 
-		if ( $this->parserData->getOption( ParserData::NO_QUERY_DEP_TRACE ) ) {
-			$query->setOption( $query::NO_DEP_TRACE, true );
+		if ( $this->parserData->getOption( ParserData::NO_QUERY_DEPENDENCY_TRACE ) ) {
+			$query->setOption( $query::NO_DEPENDENCY_TRACE, true );
 		}
 
 		$queryHash = $query->getHash();

--- a/src/SQLStore/QueryDependency/QueryDependencyLinksStore.php
+++ b/src/SQLStore/QueryDependency/QueryDependencyLinksStore.php
@@ -406,7 +406,7 @@ class QueryDependencyLinksStore implements LoggerAwareInterface {
 
 		$query = $queryResult->getQuery();
 
-		return $query !== null && $query->getContextPage() !== null && $query->getLimit() > 0 && $query->getOption( Query::NO_DEP_TRACE ) !== true;
+		return $query !== null && $query->getContextPage() !== null && $query->getLimit() > 0 && $query->getOption( Query::NO_DEPENDENCY_TRACE ) !== true;
 	}
 
 	private function canSuppressUpdateOnSkewFactorFor( $sid, $subject ) {

--- a/tests/phpunit/Unit/ParserFunctionFactoryTest.php
+++ b/tests/phpunit/Unit/ParserFunctionFactoryTest.php
@@ -105,7 +105,7 @@ class ParserFunctionFactoryTest extends \PHPUnit_Framework_TestCase {
 		$this->parserData->expects( $this->once() )
 			->method( 'setOption' )
 			->with(
-				$this->equalTo( \SMW\ParserData::NO_QUERY_DEP_TRACE ),
+				$this->equalTo( \SMW\ParserData::NO_QUERY_DEPENDENCY_TRACE ),
 				$this->anything() );
 
 		$parser = $this->parserFactory->create( __METHOD__ );

--- a/tests/phpunit/includes/ParserDataTest.php
+++ b/tests/phpunit/includes/ParserDataTest.php
@@ -468,10 +468,10 @@ class ParserDataTest extends \PHPUnit_Framework_TestCase {
 			$parserOutput
 		);
 
-		$instance->setOption( $instance::NO_QUERY_DEP_TRACE, true );
+		$instance->setOption( $instance::NO_QUERY_DEPENDENCY_TRACE, true );
 
 		$this->assertTrue(
-			$instance->getOption( $instance::NO_QUERY_DEP_TRACE )
+			$instance->getOption( $instance::NO_QUERY_DEPENDENCY_TRACE )
 		);
 	}
 


### PR DESCRIPTION
This PR is made in reference to: #

This PR addresses or contains:

- Avoids unnecessary ID creation for a temporary query when a uniqueness constraint isn't cached and requires an active DB connection

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed
