### PR TITLE
ExternalFormatterUriValue avoid already encoded values, refs 1708

### DIFF
--- a/src/DataValues/ExternalFormatterUriValue.php
+++ b/src/DataValues/ExternalFormatterUriValue.php
@@ -64,8 +64,12 @@ class ExternalFormatterUriValue extends UriValue {
 			return '';
 		}
 
+		// Avoid already encoded values like `W%D6LLEKLA01` to be
+		// doubled encoded
+		$value = rawurlencode( rawurldecode( $value ) );
+
 		// %241 == encoded $1
-		return str_replace( array( '%241', '$1' ), array( '$1', rawurlencode( $value ) ), $this->getDataItem()->getUri() );
+		return str_replace( array( '%241', '$1' ), array( '$1', $value ), $this->getDataItem()->getUri() );
 	}
 
 }

--- a/tests/phpunit/Integration/JSONScript/TestCases/p-0430.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/p-0430.json
@@ -1,10 +1,15 @@
 {
-	"description": "Test in-text annotation for '_eid' type (`wgContLang=en`, `wgLang=en`)",
+	"description": "Test in-text annotation for `_eid` type (`wgContLang=en`, `wgLang=en`)",
 	"setup": [
 		{
 			"namespace": "SMW_NS_PROPERTY",
 			"page": "NDL ID",
 			"contents": "[[Has type::External identifier]] [[External formatter uri::https://id.ndl.go.jp/auth/ndlna/$1]]"
+		},
+		{
+			"namespace": "SMW_NS_PROPERTY",
+			"page": "Some ID",
+			"contents": "[[Has type::External identifier]] [[External formatter uri::https://example.org/$1]]"
 		},
 		{
 			"page": "Example/P0430/1",
@@ -17,6 +22,10 @@
 		{
 			"page": "Example/P0430/Q1.2",
 			"contents": "{{#ask: [[NDL ID::00564222]] |?NDL ID }}"
+		},
+		{
+			"page": "Example/P0430/2",
+			"contents": "[[Some ID::W%D6LLEKLA01]]"
 		}
 	],
 	"tests": [
@@ -64,6 +73,19 @@
 			"assert-output": {
 				"to-contain": [
 					"<td data-sort-value=\"00564222\" class=\"NDL-ID smwtype_eid\"><span class=\"plainlinks smw-eid\"><a rel=\"nofollow\" class=\"external text\" href=\"https://id.ndl.go.jp/auth/ndlna/00564222\">00564222</a></span></td>"
+				]
+			}
+		},
+		{
+			"type": "parser",
+			"about": "#3 (decode,encode)",
+			"subject": "Example/P0430/2",
+			"assert-output": {
+				"to-contain": [
+					"<a rel=\"nofollow\" class=\"external text\" href=\"https://example.org/W%D6LLEKLA01\">W%D6LLEKLA01</a>"
+				],
+				"not-contain": [
+					"<a rel=\"nofollow\" class=\"external text\" href=\"https://example.org/W%25D6LLEKLA01\">W%D6LLEKLA01</a>"
 				]
 			}
 		}

--- a/tests/phpunit/Unit/DataValues/ExternalFormatterUriValueTest.php
+++ b/tests/phpunit/Unit/DataValues/ExternalFormatterUriValueTest.php
@@ -149,6 +149,13 @@ class ExternalFormatterUriValueTest extends \PHPUnit_Framework_TestCase {
 			'urn:oasis:names:specification:docbook:dtd:xml:foo'
 		);
 
+		// https://phabricator.wikimedia.org/T160281
+		$provider[] = array(
+			'http://foo/bar/$1',
+			'W%D6LLEKLA01',
+			'http://foo/bar/W%D6LLEKLA01'
+		);
+
 		return $provider;
 	}
 


### PR DESCRIPTION
This PR is made in reference to: #1708

This PR addresses or contains:

- https://phabricator.wikimedia.org/T160281 contains an example of an encoded ID

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed
