### PR TITLE
ParserAfterTidy to check readOnly mode, refs 2432

### DIFF
--- a/src/MediaWiki/Hooks/HookRegistry.php
+++ b/src/MediaWiki/Hooks/HookRegistry.php
@@ -137,12 +137,24 @@ class HookRegistry {
 		 */
 		$this->handlers['ParserAfterTidy'] = function ( &$parser, &$text ) {
 
+			// MediaWiki\Services\ServiceDisabledException from line 340 of
+			// ...\ServiceContainer.php: Service disabled: DBLoadBalancer
+			try {
+				$isReadOnly = wfReadOnly();
+			} catch( \MediaWiki\Services\ServiceDisabledException $e ) {
+				$isReadOnly = true;
+			}
+
 			$parserAfterTidy = new ParserAfterTidy(
 				$parser
 			);
 
 			$parserAfterTidy->isCommandLineMode(
 				$GLOBALS['wgCommandLineMode']
+			);
+
+			$parserAfterTidy->isReadOnly(
+				$isReadOnly
 			);
 
 			return $parserAfterTidy->process( $text );

--- a/src/MediaWiki/Hooks/ParserAfterTidy.php
+++ b/src/MediaWiki/Hooks/ParserAfterTidy.php
@@ -5,6 +5,7 @@ namespace SMW\MediaWiki\Hooks;
 use Parser;
 use SMW\ApplicationFactory;
 use SMW\SemanticData;
+use SMW\MediaWiki\MediaWiki;
 
 /**
  * Hook: ParserAfterTidy to add some final processing to the
@@ -30,6 +31,11 @@ class ParserAfterTidy extends HookHandler {
 	private $isCommandLineMode = false;
 
 	/**
+	 * @var boolean
+	 */
+	private $isReadOnly = false;
+
+	/**
 	 * @since  1.9
 	 *
 	 * @param Parser $parser
@@ -50,6 +56,15 @@ class ParserAfterTidy extends HookHandler {
 	}
 
 	/**
+	 * @since 3.0
+	 *
+	 * @param boolean $isReadOnly
+	 */
+	public function isReadOnly( $isReadOnly ) {
+		$this->isReadOnly = (bool)$isReadOnly;
+	}
+
+	/**
 	 * @since 1.9
 	 *
 	 * @param string $text
@@ -66,6 +81,12 @@ class ParserAfterTidy extends HookHandler {
 	}
 
 	private function canPerformUpdate() {
+
+		// #2432 avoid access to the DBLoadBalancer while being in readOnly mode
+		// when for example Title::isProtected is accessed
+		if ( $this->isReadOnly ) {
+			return false;
+		}
 
 		// ParserOptions::getInterfaceMessage is being used to identify whether a
 		// parse was initiated by `Message::parse`

--- a/tests/phpunit/Unit/MediaWiki/Hooks/ParserAfterTidyTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Hooks/ParserAfterTidyTest.php
@@ -68,6 +68,22 @@ class ParserAfterTidyTest extends \PHPUnit_Framework_TestCase {
 		);
 	}
 
+	public function testIsReadOnly() {
+
+		$parser = $this->getMockBuilder( 'Parser' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$parser->expects( $this->never() )
+			->method( 'getTitle' );
+
+		$instance = new ParserAfterTidy( $parser );
+		$instance->isReadOnly( true );
+
+		$text = '';
+		$instance->process( $text );
+	}
+
 	private function newMockCache( $id, $containsStatus, $fetchStatus ) {
 
 		$key = $this->applicationFactory->newCacheFactory()->getPurgeCacheKey( $id );


### PR DESCRIPTION
This PR is made in reference to: #2432

This PR addresses or contains:

- Checks `wfReadOnly` to avoid an active DB connection in cases where the wiki is not yet ready

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed
