### PR TITLE
Filter and armor against invisible chars

### DIFF
--- a/includes/datavalues/SMW_DataValue.php
+++ b/includes/datavalues/SMW_DataValue.php
@@ -14,6 +14,7 @@ use SMW\Localizer;
 use SMW\Message;
 use SMW\Options;
 use SMW\Query\QueryComparator;
+use SMW\Utils\CharArmor;
 
 /**
  * Objects of this type represent all that is known about a certain user-provided
@@ -177,6 +178,10 @@ abstract class SMWDataValue {
 		$this->mErrors = array(); // clear errors
 		$this->mHasErrors = false;
 		$this->m_caption = is_string( $caption ) ? trim( $caption ) : false;
+
+		$value = CharArmor::removeControlChars(
+			CharArmor::removeSpecialChars( $value )
+		);
 
 		$this->parseUserValue( $value ); // may set caption if not set yet, depending on datavalue
 

--- a/src/Utils/CharArmor.php
+++ b/src/Utils/CharArmor.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace SMW\Utils;
+
+/**
+ * @license GNU GPL v2+
+ * @since 3.0
+ *
+ * @author mwjames
+ */
+class CharArmor {
+
+	/**
+	 * Remove invisible control characters and unused code points (using a
+	 * negated character class to avoid removing spaces)
+	 *
+	 * @see http://www.regular-expressions.info/unicode.html#category
+	 * @since 3.0
+	 *
+	 * @param string $text
+	 *
+	 * @return text
+	 */
+	public static function removeControlChars( $text ) {
+		return preg_replace('/[^\PC\s]/u', '', $text );
+	}
+
+	/**
+	 * @since 3.0
+	 *
+	 * @param string $text
+	 *
+	 * @return text
+	 */
+	public static function removeSpecialChars( $text ) {
+		return str_replace(
+			array( '&shy;', '&lrm;', " ", " ", " " ),
+			array( '', '', ' ', ' ', ' ' ),
+			$text
+		);
+	}
+
+}

--- a/tests/phpunit/Integration/JSONScript/TestCases/p-0450.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/p-0450.json
@@ -1,0 +1,94 @@
+{
+	"description": "Test in-text annotation with invisible chars (`wgContLang=en`)",
+	"setup": [
+		{
+			"namespace": "SMW_NS_PROPERTY",
+			"page": "Has text",
+			"contents": "[[Has type::Text]]"
+		},
+		{
+			"page": "Example/P0450/1",
+			"contents": "[[Left-To-Right ‎‎Mark::C++‎]] [[Left-To-Right Mark::C++]]"
+		},
+		{
+			"page": "Example/P0450/2",
+			"contents": "[[Right-To-Left ‏Mark::באמת! -]] [[Right-To-Left Mark::באמת!‏ -]]"
+		},
+		{
+			"page": "Example/P0450/3",
+			"contents": "[[Has text::no shyness]] [[Has text::visible shy&shy;ness]] [[Has text::invisible shy­ness]]"
+		}
+	],
+	"tests": [
+		{
+			"type": "parser",
+			"about": "#0 Left-To-Right Mark chars",
+			"subject": "Example/P0450/1",
+			"assert-store": {
+				"semantic-data": {
+					"strictPropertyValueMatch": false,
+					"propertyCount": 3,
+					"propertyKeys": [
+						"_SKEY",
+						"_MDAT",
+						"Left-To-Right Mark"
+					],
+					"propertyValues": [
+						"C++"
+					]
+				}
+			}
+		},
+		{
+			"type": "parser",
+			"about": "#1 Right-To-Left Mark chars",
+			"subject": "Example/P0450/2",
+			"assert-store": {
+				"semantic-data": {
+					"strictPropertyValueMatch": false,
+					"propertyCount": 3,
+					"propertyKeys": [
+						"_SKEY",
+						"_MDAT",
+						"Right-To-Left Mark"
+					],
+					"propertyValues": [
+						"באמת! -"
+					]
+				}
+			}
+		},
+		{
+			"type": "parser",
+			"about": "#2 shy char",
+			"subject": "Example/P0450/3",
+			"assert-store": {
+				"semantic-data": {
+					"strictPropertyValueMatch": false,
+					"propertyCount": 3,
+					"propertyKeys": [
+						"_SKEY",
+						"_MDAT",
+						"Has text"
+					],
+					"propertyValues": [
+						"no shyness",
+						"visible shyness",
+						"invisible shyness"
+					]
+				}
+			}
+		}
+	],
+	"settings": {
+		"wgContLang": "en",
+		"smwgPageSpecialProperties": [
+			"_MDAT"
+		]
+	},
+	"meta": {
+		"version": "2",
+		"is-incomplete": false,
+		"debug": false
+	}
+}

--- a/tests/phpunit/Unit/Utils/CharArmorTest.php
+++ b/tests/phpunit/Unit/Utils/CharArmorTest.php
@@ -1,0 +1,104 @@
+<?php
+
+namespace SMW\Tests\Utils;
+
+use SMW\Utils\CharArmor;
+
+/**
+ * @covers \SMW\Utils\CharArmor
+ * @group semantic-mediawiki
+ *
+ * @license GNU GPL v2+
+ * @since 3.0
+ *
+ * @author mwjames
+ */
+class CharArmorTest extends \PHPUnit_Framework_TestCase {
+
+	/**
+	 * @dataProvider invisibleControlCharactersProvider
+	 */
+	public function testRemoveControlChars( $withControlChar, $expected ) {
+
+		$this->assertFalse(
+			$expected === $withControlChar
+		);
+
+		$this->assertEquals(
+			$expected,
+			CharArmor::removeControlChars( $withControlChar )
+		);
+	}
+
+	/**
+	 * @dataProvider specialCharactersProvider
+	 */
+	public function testRemoveSpecialChars( $withSpecialChar, $expected ) {
+
+		$this->assertEquals(
+			$expected,
+			CharArmor::removeSpecialChars( $withSpecialChar )
+		);
+	}
+
+	public function invisibleControlCharactersProvider() {
+
+		$provider[] = array(
+			'[[Left-To-Right Mark::"‎"]]',
+			'[[Left-To-Right Mark::""]]'
+		);
+
+		$provider[] = array(
+			'[[Right-To-Left Mark::"‏"]]',
+			'[[Right-To-Left Mark::""]]'
+		);
+
+		$provider[] = array(
+			'[[Zero-Width​Space::"​"]]',
+			'[[Zero-WidthSpace::""]]'
+		);
+
+		$provider[] = array(
+			'[[Zero Width Non-Joiner::"‌"]]',
+			'[[Zero Width Non-Joiner::""]]'
+		);
+
+		$provider[] = array(
+			'[[Zero Width Joiner::"‍"]]',
+			'[[Zero Width Joiner::""]]'
+		);
+
+		return $provider;
+	}
+
+	public function specialCharactersProvider() {
+
+		$provider[] = array(
+			'visible shy&shy;ness',
+			'visible shyness'
+		);
+
+		$provider[] = array(
+			'leftToRight&lrm;Mark',
+			'leftToRightMark'
+		);
+
+		$provider[] = array(
+			'[[Figure Space::" "]]',
+			'[[Figure Space::" "]]'
+		);
+
+		$provider[] = array(
+			'[[En Quad::" "]]',
+			'[[En Quad::" "]]'
+		);
+
+		$provider[] = array(
+			'[[Hair Space::" "]]',
+			'[[Hair Space::" "]]'
+		);
+
+		return $provider;
+	}
+
+}


### PR DESCRIPTION
This PR is made in reference to: http://wikimedia.7.x6.nabble.com/I-really-can-t-understand-what-s-happening-with-my-form-template-tp5073264p5074223.html

This PR addresses or contains:

- Armor against so called non-printing characters [0, 1] to avoid facts and properties appearing as equal when in fact there are not due to some hidden characters
- Remove visible and invisible shyness character  

[0] https://en.wikipedia.org/wiki/Right-to-left_mark
[1] https://en.wikipedia.org/wiki/Left-to-right_mark

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed
