### PR TITLE
ArticlePurge add safeguard to flush query result cache

### DIFF
--- a/src/EventListenerRegistry.php
+++ b/src/EventListenerRegistry.php
@@ -121,6 +121,13 @@ class EventListenerRegistry implements EventListenerCollection {
 					$context
 				);
 
+				if ( $dispatchContext->has( 'ask' ) ) {
+					$applicationFactory->singleton( 'CachedQueryResultPrefetcher' )->resetCacheBy(
+						$dispatchContext->get( 'ask' ),
+						$context
+					);
+				}
+
 				$dispatchContext->set( 'propagationstop', true );
 			}
 		);

--- a/src/MediaWiki/Hooks/ArticlePurge.php
+++ b/src/MediaWiki/Hooks/ArticlePurge.php
@@ -5,6 +5,7 @@ namespace SMW\MediaWiki\Hooks;
 use SMW\ApplicationFactory;
 use SMW\EventHandler;
 use SMW\DIWikiPage;
+use SMW\DIProperty;
 use WikiPage;
 
 /**
@@ -56,6 +57,12 @@ class ArticlePurge {
 		}
 
 		if ( $settings->get( 'smwgQueryResultCacheRefreshOnPurge' ) ) {
+
+			$dispatchContext->set( 'ask', $applicationFactory->getStore()->getPropertyValues(
+				DIWikiPage::newFromTitle( $wikiPage->getTitle() ),
+				new DIProperty( '_ASK') )
+			);
+
 			EventHandler::getInstance()->getEventDispatcher()->dispatch(
 				'cached.prefetcher.reset',
 				$dispatchContext


### PR DESCRIPTION
This PR is made in reference to: #2074, #1251

This PR addresses or contains:

- Finds all queries to a purged article and triggers a cache reset for all matchable cache entities

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed
