### PR TITLE
NamespaceManager avoid reset of user settings, refs 2439

### DIFF
--- a/src/NamespaceManager.php
+++ b/src/NamespaceManager.php
@@ -53,6 +53,7 @@ class NamespaceManager {
 		}
 
 		$this->addNamespaceSettings();
+		$this->addExtraNamespaceSettings();
 	}
 
 	/**
@@ -188,19 +189,6 @@ class NamespaceManager {
 
 	protected function addNamespaceSettings() {
 
-		// Support subpages only for talk pages by default
-		$this->globalVars['wgNamespacesWithSubpages'] = $this->globalVars['wgNamespacesWithSubpages'] + array(
-			SMW_NS_PROPERTY_TALK => true,
-			SMW_NS_TYPE_TALK => true,
-			SMW_NS_CONCEPT_TALK => true,
-		);
-
-		// not modified for Semantic MediaWiki
-		/* $this->globalVars['wgNamespacesToBeSearchedDefault'] = array(
-			NS_MAIN           => true,
-			);
-		*/
-
 		/**
 		 * Default settings for the SMW specific NS which can only
 		 * be defined after SMW_NS_PROPERTY is declared
@@ -226,6 +214,19 @@ class NamespaceManager {
 			$smwNamespacesSettings,
 			$this->globalVars['smwgNamespacesWithSemanticLinks']
 		);
+	}
+
+	private function addExtraNamespaceSettings() {
+
+		/**
+		 * Indicating which namespaces allow sub-pages
+		 *
+		 * @see https://www.mediawiki.org/wiki/Manual:$wgNamespacesWithSubpages
+		 */
+		$this->globalVars['wgNamespacesWithSubpages'] = $this->globalVars['wgNamespacesWithSubpages'] + array(
+			SMW_NS_PROPERTY_TALK => true,
+			SMW_NS_CONCEPT_TALK => true,
+		);
 
 		/**
 		 * Allow custom namespaces to be acknowledged as containing useful content
@@ -242,8 +243,10 @@ class NamespaceManager {
 		 *
 		 * @see https://www.mediawiki.org/wiki/Manual:$wgNamespacesToBeSearchedDefault
 		 */
-		$this->globalVars['wgNamespacesToBeSearchedDefault'][SMW_NS_PROPERTY] = true;
-		$this->globalVars['wgNamespacesToBeSearchedDefault'][SMW_NS_CONCEPT] = true;
+		$this->globalVars['wgNamespacesToBeSearchedDefault'] = $this->globalVars['wgNamespacesToBeSearchedDefault'] + array(
+			SMW_NS_PROPERTY => true,
+			SMW_NS_CONCEPT => true
+		);
 	}
 
 	protected function isDefinedConstant( $constant ) {

--- a/tests/phpunit/Integration/MediaWiki/MWNamespaceCanonicalNameMatchTest.php
+++ b/tests/phpunit/Integration/MediaWiki/MWNamespaceCanonicalNameMatchTest.php
@@ -41,6 +41,7 @@ class MWNamespaceCanonicalNameMatchTest extends \PHPUnit_Framework_TestCase {
 			'wgExtraNamespaces'   => array(),
 			'wgNamespaceAliases'  => array(),
 			'wgContentNamespaces' => array(),
+			'wgNamespacesToBeSearchedDefault' => array(),
 			'wgLanguageCode'      => 'en'
 		);
 

--- a/tests/phpunit/Unit/NamespaceManagerTest.php
+++ b/tests/phpunit/Unit/NamespaceManagerTest.php
@@ -63,7 +63,7 @@ class NamespaceManagerTest extends \PHPUnit_Framework_TestCase {
 		);
 	}
 
-	public function testExecutionWithIncompleteConfiguration() {
+	public function testInitOnIncompleteConfiguration() {
 
 		$test = $this->default + array(
 			'wgExtraNamespaces'  => '',
@@ -169,7 +169,7 @@ class NamespaceManagerTest extends \PHPUnit_Framework_TestCase {
 		);
 	}
 
-	public function testNamespacesInitToKeepPreInitSettings() {
+	public function testInitToKeepPreInitSettings() {
 
 		$this->testEnvironment->addConfiguration(
 			'smwgHistoricTypeNamespace',
@@ -198,6 +198,36 @@ class NamespaceManagerTest extends \PHPUnit_Framework_TestCase {
 
 		$this->assertTrue(
 			$test['smwgNamespacesWithSemanticLinks'][SMW_NS_TYPE]
+		);
+	}
+
+	public function testInitWithoutOverridingUserSettingsOnExtraNamespaceSettings() {
+
+		$test = array(
+			'wgNamespacesWithSubpages' => array(
+				SMW_NS_PROPERTY => false
+			),
+			'wgNamespacesToBeSearchedDefault' => array(
+				SMW_NS_PROPERTY => false
+			),
+			'wgContentNamespaces' => array(
+				SMW_NS_PROPERTY => false
+			)
+		) + $this->default;
+
+		$instance = new NamespaceManager( $test, $this->extraneousLanguage );
+		$instance->init();
+
+		$this->assertFalse(
+			$test['wgNamespacesWithSubpages'][SMW_NS_PROPERTY]
+		);
+
+		$this->assertFalse(
+			$test['wgNamespacesToBeSearchedDefault'][SMW_NS_PROPERTY]
+		);
+
+		$this->assertFalse(
+			$test['wgContentNamespaces'][SMW_NS_PROPERTY]
 		);
 	}
 


### PR DESCRIPTION
This PR is made in reference to: #2439

This PR addresses or contains:

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed
