### PR TITLE
Enforce NO_DEPENDENCY_TRACE on queries with NS_SPECIAL, refs #2413

### DIFF
--- a/src/ParserFunctions/AskParserFunction.php
+++ b/src/ParserFunctions/AskParserFunction.php
@@ -138,6 +138,15 @@ class AskParserFunction {
 			$functionParams
 		);
 
+		if ( !$this->noTrace ) {
+			$this->noTrace = $this->parserData->getOption( ParserData::NO_QUERY_DEPENDENCY_TRACE );
+		}
+
+		// No trace on queries invoked by special pages
+		if ( $this->parserData->getTitle()->getNamespace() === NS_SPECIAL ) {
+			$this->noTrace = true;
+		}
+
 		$result = $this->doFetchResultsFromFunctionParameters(
 			$functionParams
 		);
@@ -200,7 +209,7 @@ class AskParserFunction {
 
 		$contextPage = $this->parserData->getSubject();
 
-		if ( $this->noTrace ) {
+		if ( $this->noTrace === true ) {
 			$contextPage = null;
 		}
 
@@ -213,10 +222,7 @@ class AskParserFunction {
 		);
 
 		$query->setOption( Query::PROC_CONTEXT, 'AskParserFunction' );
-
-		if ( $this->noTrace || $this->parserData->getOption( ParserData::NO_QUERY_DEPENDENCY_TRACE ) ) {
-			$query->setOption( $query::NO_DEPENDENCY_TRACE, true );
-		}
+		$query->setOption( Query::NO_DEPENDENCY_TRACE, $this->noTrace );
 
 		$queryHash = $query->getHash();
 
@@ -266,7 +272,7 @@ class AskParserFunction {
 		$settings = $this->applicationFactory->getSettings();
 
 		// If the smwgQueryProfiler is marked with FALSE then just don't create a profile.
-		if ( ( $queryProfiler = $settings->get( 'smwgQueryProfiler' ) ) === false || $this->noTrace ) {
+		if ( ( $queryProfiler = $settings->get( 'smwgQueryProfiler' ) ) === false || $this->noTrace === true ) {
 			return;
 		}
 

--- a/tests/phpunit/Unit/ParserFunctions/AskParserFunctionTest.php
+++ b/tests/phpunit/Unit/ParserFunctions/AskParserFunctionTest.php
@@ -416,6 +416,46 @@ class AskParserFunctionTest extends \PHPUnit_Framework_TestCase {
 		);
 	}
 
+	public function testNoQueryProfileOnSpecialPages() {
+
+		$params = array(
+			'[[Modification date::+]]',
+			'format=table'
+		);
+
+		$expected = array(
+			'propertyCount'  => 0
+		);
+
+		$this->testEnvironment->addConfiguration( 'smwgQueryProfiler', true );
+
+		$parserData = ApplicationFactory::getInstance()->newParserData(
+			Title::newFromText( __METHOD__, NS_SPECIAL ),
+			new ParserOutput()
+		);
+
+		$messageFormatter = $this->getMockBuilder( '\SMW\MessageFormatter' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$circularReferenceGuard = $this->getMockBuilder( '\SMW\Utils\CircularReferenceGuard' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$instance = new AskParserFunction(
+			$parserData,
+			$messageFormatter,
+			$circularReferenceGuard
+		);
+
+		$instance->parse( $params );
+
+		$this->semanticDataValidator->assertThatPropertiesAreSet(
+			$expected,
+			$parserData->getSemanticData()
+		);
+	}
+
 	public function queryDataProvider() {
 
 		$categoryNS = Localizer::getInstance()->getNamespaceTextById( NS_CATEGORY );


### PR DESCRIPTION
This PR is made in reference to: #2413

This PR addresses or contains:

- Queries executed from a special page (`Special:RunQuery` etc.) are not going to be tracked or traced

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed
