### PR TITLE
Use 'forcedUpdate' on redirect jobs, refs 2365

### DIFF
--- a/includes/storage/SQLStore/SMW_SQLStore3_Writers.php
+++ b/includes/storage/SQLStore/SMW_SQLStore3_Writers.php
@@ -958,11 +958,14 @@ class SMWSQLStore3Writers {
 	private function addToDeferredUpdate( $oldTitle, $newTitle, $redirectId ) {
 
 		$jobFactory = ApplicationFactory::getInstance()->newJobFactory();
+		$parameters = array(
+			'forcedUpdate' => true
+		);
 
 		if ( $redirectId != 0 ) {
 			$title = $oldTitle;
-			$deferredCallableUpdate = ApplicationFactory::getInstance()->newDeferredCallableUpdate( function() use( $title, $jobFactory ) {
-				$jobFactory->newUpdateJob( $title )->run();
+			$deferredCallableUpdate = ApplicationFactory::getInstance()->newDeferredCallableUpdate( function() use( $title, $jobFactory, $parameters ) {
+				$jobFactory->newUpdateJob( $title, $parameters )->run();
 			} );
 
 			$deferredCallableUpdate->setOrigin( __METHOD__ . ' for ' . $title->getPrefixedDBKey() );
@@ -970,8 +973,8 @@ class SMWSQLStore3Writers {
 		}
 
 		$title = $newTitle;
-		$deferredCallableUpdate = ApplicationFactory::getInstance()->newDeferredCallableUpdate( function() use( $title, $jobFactory ) {
-			$jobFactory->newUpdateJob( $title )->run();
+		$deferredCallableUpdate = ApplicationFactory::getInstance()->newDeferredCallableUpdate( function() use( $title, $jobFactory, $parameters ) {
+			$jobFactory->newUpdateJob( $title, $parameters )->run();
 		} );
 
 		$deferredCallableUpdate->setOrigin( __METHOD__ . ' for ' . $title->getPrefixedDBKey() );

--- a/src/MediaWiki/Hooks/HookRegistry.php
+++ b/src/MediaWiki/Hooks/HookRegistry.php
@@ -122,6 +122,12 @@ class HookRegistry {
 			$GLOBALS['wgDBtype'] === 'sqlite'
 		);
 
+		// When in commandLine mode avoid deferred execution and run a process
+		// within the same transaction
+		$deferredRequestDispatchManager->isCommandLineMode(
+			$GLOBALS['wgCommandLineMode']
+		);
+
 		$permissionPthValidator = new PermissionPthValidator(
 			$applicationFactory->singleton( 'EditProtectionValidator' )
 		);
@@ -544,12 +550,6 @@ class HookRegistry {
 		 * @see https://www.semantic-mediawiki.org/wiki/Hooks#SMW::SQLStore::AfterDataUpdateComplete
 		 */
 		$this->handlers['SMW::SQLStore::AfterDataUpdateComplete'] = function ( $store, $semanticData, $compositePropertyTableDiffIterator ) use ( $queryDependencyLinksStoreFactory, $queryDependencyLinksStore, $deferredRequestDispatchManager, $tempChangeOpStore ) {
-
-			// When in commandLine mode avoid deferred execution and run a process
-			// within the same transaction
-			$deferredRequestDispatchManager->isCommandLineMode(
-				$store->getOptions()->has( 'isCommandLineMode' ) ? $store->getOptions()->get( 'isCommandLineMode' ) : $GLOBALS['wgCommandLineMode']
-			);
 
 			$queryDependencyLinksStore->setStore( $store );
 			$subject = $semanticData->getSubject();

--- a/src/MediaWiki/Jobs/UpdateJob.php
+++ b/src/MediaWiki/Jobs/UpdateJob.php
@@ -160,19 +160,12 @@ class UpdateJob extends JobBase {
 		// TODO
 		// Rebuild the factbox
 
-		// Signal to succeeding processes that the update was
-		// run from the CommandLine/JobQueue
-		$this->applicationFactory->getStore()->getOptions()->set(
-			'isCommandLineMode',
-			true
-		);
-
-		$this->applicationFactory->getStore()->getOptions()->set(
-			'isFromJob',
-			true
-		);
-
 		$parserData->setOrigin( 'UpdateJob' );
+
+		$parserData->setOption(
+			$parserData::OPT_FORCED_UPDATE,
+			$this->getParameter( 'forcedUpdate' )
+		);
 
 		$parserData->disableBackgroundUpdateJobs();
 		$parserData->updateStore();

--- a/tests/phpunit/Integration/JSONScript/TestCases/p-1000.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/p-1000.json
@@ -1,0 +1,109 @@
+{
+	"description": "Test property page with redirect(synonym)/displayTitle (`wgContLang=en`, `wgLang=en`, `wgAllowDisplayTitle`)",
+	"setup": [
+		{
+			"namespace": "SMW_NS_PROPERTY",
+			"page": "Has synonym",
+			"contents": "[[Has type::Page]] {{DISPLAYTITLE:SomeTest}}"
+		},
+		{
+			"namespace": "SMW_NS_PROPERTY",
+			"page": "Some redirect",
+			"contents": "[[Has type::Page]] {{DISPLAYTITLE:SomePropertyRedirectTest}}"
+		},
+		{
+			"namespace": "SMW_NS_PROPERTY",
+			"page": "Some redirect",
+			"contents": "#REDIRECT [[Property:Has synonym]]"
+		},
+		{
+			"namespace": "SMW_NS_PROPERTY",
+			"page": "Some redirect2",
+			"contents": "[[Has type::Page]] {{DISPLAYTITLE:IsRedirectTarget}}"
+		},
+		{
+			"namespace": "SMW_NS_PROPERTY",
+			"page": "Some redirect2",
+			"contents": "[[Has type::Page]] {{DISPLAYTITLE:SomeTest2}}",
+			"move-to":{
+				"target": "Has synonym2",
+				"is-redirect": true
+			}
+		}
+	],
+	"tests": [
+		{
+			"type": "parser",
+			"about": "#0 (manual redirect)",
+			"namespace": "SMW_NS_PROPERTY",
+			"subject": "Has synonym",
+			"assert-store": {
+				"semantic-data": {
+					"strictPropertyValueMatch": false,
+					"propertyCount": 4,
+					"propertyKeys": [
+						"_TYPE",
+						"_MDAT",
+						"_DTITLE",
+						"_SKEY"
+					],
+					"incoming": {
+						"propertyKeys": [
+							"_REDI"
+						],
+						"propertyValues": [
+							"Some_redirect#102#"
+						]
+					}
+				}
+			}
+		},
+		{
+			"type": "parser",
+			"about": "#1",
+			"namespace": "SMW_NS_PROPERTY",
+			"subject": "Has synonym2",
+			"store": {
+				"clear-cache": true
+			},
+			"assert-store": {
+				"semantic-data": {
+					"strictPropertyValueMatch": false,
+					"propertyCount": 4,
+					"propertyKeys": [
+						"_TYPE",
+						"_MDAT",
+						"_DTITLE",
+						"_SKEY"
+					],
+					"incoming": {
+						"propertyKeys": [
+							"_REDI"
+						],
+						"propertyValues": [
+							"Some_redirect2#102#"
+						]
+					}
+				}
+			}
+		}
+	],
+	"settings": {
+		"wgContLang": "en",
+		"wgLang": "en",
+		"wgAllowDisplayTitle": true,
+		"wgRestrictDisplayTitle": false,
+		"smwgPageSpecialProperties": [
+			"_MDAT"
+		],
+		"smwgNamespacesWithSemanticLinks": {
+			"NS_MAIN": true,
+			"SMW_NS_PROPERTY": true
+		}
+	},
+	"meta": {
+		"version": "2",
+		"is-incomplete": false,
+		"debug": false
+	}
+}

--- a/tests/phpunit/Utils/PageCreator.php
+++ b/tests/phpunit/Utils/PageCreator.php
@@ -4,6 +4,7 @@ namespace SMW\Tests\Utils;
 
 use Revision;
 use SMW\Tests\TestEnvironment;
+use SMW\Tests\Utils\Mock\MockSuperUser;
 use Title;
 use UnexpectedValueException;
 
@@ -110,12 +111,16 @@ class PageCreator {
 	 */
 	public function doMoveTo( Title $target, $isRedirect = true ) {
 
-		$this->getPage()->getTitle()->moveTo(
-			$target,
-			false,
-			"integration test",
-			$isRedirect
-		);
+		$reason = "integration test";
+		$source = $this->getPage()->getTitle();
+
+		if ( class_exists( '\MovePage' ) ) {
+			$mp = new \MovePage( $source, $target );
+			$status = $mp->move( new MockSuperUser(), $reason, $isRedirect );
+		} else {
+			// deprecated since 1.25, use the MovePage class instead
+			$status = $source->moveTo( $target, false, $reason, $isRedirect );
+		}
 
 		TestEnvironment::executePendingDeferredUpdates();
 


### PR DESCRIPTION
This PR is made in reference to: #2365

This PR addresses or contains:

- Necessary for MW 1.28/1.29+ to ensure that any redirect `UpdateJob` forces an update even though the revision hasn't changed (normally would result in a discarded update attempt due to `refreshLinksPrioritized` jobs running in parallel and arefiltered by #2365)

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed
