### PR TITLE
PropertyPage to show source name of redirect (synonym), refs 2157, 1810

### DIFF
--- a/includes/SMW_PageLister.php
+++ b/includes/SMW_PageLister.php
@@ -279,6 +279,12 @@ class SMWPageLister {
 	public static function getShortList( $start, $end, array $diWikiPages, $diProperty ) {
 
 		$startDv = \SMW\DataValueFactory::getInstance()->newDataValueByItem( $diWikiPages[$start], $diProperty );
+
+		// For a redirect, disable the DisplayTitle to show the original (aka source) page
+		if ( $diProperty !== null && $diProperty->getKey() == '_REDI' ) {
+			$startDv->setOption( 'smwgDVFeatures', ( $startDv->getOption( 'smwgDVFeatures' ) & ~SMW_DV_WPV_DTITLE ) );
+		}
+
 		$startChar = self::getFirstChar( $diWikiPages[$start] );
 
 		$r = '<h3>' . htmlspecialchars( $startChar ) . "</h3>\n" .
@@ -287,6 +293,12 @@ class SMWPageLister {
 		$prevStartChar = $startChar;
 		for ( $index = $start + 1; $index < $end; $index++ ) {
 			$dataValue = \SMW\DataValueFactory::getInstance()->newDataValueByItem( $diWikiPages[$index], $diProperty );
+
+			// For a redirect, disable the DisplayTitle to show the original (aka source) page
+			if ( $diProperty !== null && $diProperty->getKey() == '_REDI' ) {
+				$dataValue->setOption( 'smwgDVFeatures', ( $dataValue->getOption( 'smwgDVFeatures' ) & ~SMW_DV_WPV_DTITLE ) );
+			}
+
 			$startChar = self::getFirstChar( $diWikiPages[$index] );
 
 			if ( $startChar != $prevStartChar ) {

--- a/includes/articlepages/SMW_OrderedListPage.php
+++ b/includes/articlepages/SMW_OrderedListPage.php
@@ -175,15 +175,16 @@ abstract class SMWOrderedListPage extends Article {
 	 * Main method for adding all additional HTML to the output stream.
 	 */
 	protected function showList() {
-		global $wgOut, $wgRequest;
+		global $wgRequest;
 
+		$outputPage = $this->getContext()->getOutput();
 
 		$this->from = $wgRequest->getVal( 'from', '' );
 		$this->until = $wgRequest->getVal( 'until', '' );
 
 		if ( $this->initParameters() ) {
-			$wgOut->addHTML( $this->getHtml() );
-			SMWOutputs::commitToOutputPage( $wgOut );
+			$outputPage->addHTML( $this->getHtml() );
+			SMWOutputs::commitToOutputPage( $outputPage );
 		}
 
 	}

--- a/includes/articlepages/SMW_PropertyPage.php
+++ b/includes/articlepages/SMW_PropertyPage.php
@@ -209,9 +209,9 @@ class SMWPropertyPage extends SMWOrderedListPage {
 			$result .= $message . "</p>";
 
 			if ( $resultCount < 6 ) {
-				$result .= SMWPageLister::getShortList( 0, $resultCount, $propertyList, null );
+				$result .= SMWPageLister::getShortList( 0, $resultCount, $propertyList, $property );
 			} else {
-				$result .= SMWPageLister::getColumnList( 0, $resultCount, $propertyList, null );
+				$result .= SMWPageLister::getColumnList( 0, $resultCount, $propertyList, $property );
 			}
 
 			$result .= "\n</div>";

--- a/tests/phpunit/Integration/JSONScript/TestCases/p-1000.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/p-1000.json
@@ -56,6 +56,15 @@
 						]
 					}
 				}
+			},
+			"assert-output": {
+				"onPageView": true,
+				"to-contain": [
+					"class=\"mw-redirect\" title=\"Property:Some redirect\">Property:Some redirect</a>"
+				],
+				"not-contain": [
+					"class=\"mw-redirect\" title=\"Property:Some redirect\">SomeTest</a>"
+				]
 			}
 		},
 		{
@@ -85,6 +94,15 @@
 						]
 					}
 				}
+			},
+			"assert-output": {
+				"onPageView": true,
+				"to-contain": [
+					"class=\"mw-redirect\" title=\"Property:Some redirect2\">Property:Some redirect2</a>"
+				],
+				"not-contain": [
+					"class=\"mw-redirect\" title=\"Property:Some redirect2\">SomeTest2</a>"
+				]
 			}
 		}
 	],


### PR DESCRIPTION
This PR is made in reference to: #2157, #1810

This PR addresses or contains:

- Property page to display the redirect (synonym) without a `DisplayTitle` formatter

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed
