### PR TITLE
JD values to use a consitent format, refs #2454

### DIFF
--- a/includes/dataitems/SMW_DI_Time.php
+++ b/includes/dataitems/SMW_DI_Time.php
@@ -517,6 +517,7 @@ class SMWDITime extends SMWDataItem implements CalendarModel {
 
 		$hour = $minute = $second = false;
 		$year = $month = $day = false;
+		$jdValue = JulianDay::format( $jdValue );
 
 		if ( $precision === null ) {
 			$precision = strpos( strval( $jdValue ), '.5' ) !== false ? self::PREC_YMD : self::PREC_YMDT;

--- a/src/DataValues/Time/JulianDay.php
+++ b/src/DataValues/Time/JulianDay.php
@@ -45,8 +45,25 @@ class JulianDay implements CalendarModel {
 	 * @return float
 	 */
 	public static function getJD( $calendarModel = self::CM_GREGORIAN, $year, $month, $day, $hour, $minute, $second ) {
+		return self::format( self::date2JD( $calendarModel, $year, $month, $day ) + self::time2JDoffset( $hour, $minute, $second ) );
+	}
+
+	/**
+	 * Return a formatted value
+	 *
+	 * @note April 25, 2017 20:00-4:00 is expected to be 2457869.5 and not
+	 * 2457869.4999999665 hence apply the same formatting on all values to avoid
+	 * some unexpected behaviour as observed in #2454
+	 *
+	 * @since 3.0
+	 *
+	 * @param $value
+	 *
+	 * @return float
+	 */
+	public static function format( $value ) {
 		// Keep microseconds to a certain degree distinguishable
-		return floatval( number_format( self::date2JD( $calendarModel, $year, $month, $day ) + self::time2JDoffset( $hour, $minute, $second ), 7, '.', '' ) );
+		return floatval( number_format( $value, 7, '.', '' ) );
 	}
 
 	/**

--- a/tests/phpunit/Integration/JSONScript/TestCases/p-0451.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/p-0451.json
@@ -1,0 +1,77 @@
+{
+	"description": "Test in-text `_dat` datatype, time zone, and JD output (#2454, `wgContLang=en`, `wgLang=en`, `smwgDVFeatures=SMW_DV_TIMEV_CM`)",
+	"setup": [
+		{
+			"namespace": "SMW_NS_PROPERTY",
+			"page": "Has date",
+			"contents": "[[Has type::Date]]"
+		},
+		{
+			"page": "Example/P0451/1",
+			"contents": "{{#set:Has date=April 25, 2017 20:00-4:00}} [[Category:P0451]]"
+		},
+		{
+			"page": "Example/P0451/2",
+			"contents": "{{#set:Has date=April 25, 2017 20:00 EDT}} [[Category:P0451]]"
+		},
+		{
+			"page": "Example/P0451/3",
+			"contents": "{{#set:Has date=April 25, 2017 20:00-5:00}} [[Category:P0451]]"
+		},
+		{
+			"page": "Example/P0451/4",
+			"contents": "{{#set:Has date=April 25, 2017 21:00 EDT}} [[Category:P0451]]"
+		},
+		{
+			"page": "Example/P0451/5",
+			"contents": "{{#set:Has date=April 25, 2017 20:00-3:00}} [[Category:P0451]]"
+		},
+		{
+			"page": "Example/P0451/6",
+			"contents": "{{#set:Has date=April 25, 2017 19:00 EDT}} [[Category:P0451]]"
+		},
+		{
+			"page": "Example/P0451/7",
+			"contents": "{{#set:Has date=April 25, 2017 17:00-7:00}} [[Category:P0451]]"
+		},
+		{
+			"page": "Example/P0451/8",
+			"contents": "{{#set:Has date=April 25, 2017 14:00-10:00}} [[Category:P0451]]"
+		},
+		{
+			"page": "Example/P0451/Q.1",
+			"contents": "{{#ask: [[Category:P0451]] |?Has date  |?Has date#LOCL#TZ |?Has date#JD=JD |format=list }}"
+		}
+	],
+	"tests": [
+		{
+			"type": "parser",
+			"about": "#0 standard, TZ, and JD output",
+			"subject": "Example/P0451/Q.1",
+			"assert-output": {
+				"to-contain": [
+					"Example/P0451/1.* 26 April 2017 00:00:00.* 00:00:00 UTC, 26 April 2017.* 2457869.5",
+					"Example/P0451/2.* 26 April 2017 00:00:00.* 20:00:00 EDT, 25 April 2017.* 2457869.5",
+					"Example/P0451/3.* 26 April 2017 01:00:00.* 01:00:00 UTC, 26 April 2017.* 2457869.5416667",
+					"Example/P0451/4.* 26 April 2017 01:00:00.* 21:00:00 EDT, 25 April 2017.* 2457869.5416667",
+					"Example/P0451/5.* 25 April 2017 23:00:00.* 23:00:00 UTC, 25 April 2017.* 2457869.4583333",
+					"Example/P0451/6.* 25 April 2017 23:00:00.* 19:00:00 EDT, 25 April 2017.* 2457869.4583333",
+					"Example/P0451/7.* 26 April 2017 00:00:00.* 00:00:00 UTC, 26 April 2017.* 2457869.5",
+					"Example/P0451/8.* 26 April 2017 00:00:00.* 00:00:00 UTC, 26 April 2017.* 2457869.5"
+				]
+			}
+		}
+	],
+	"settings": {
+		"wgContLang": "en",
+		"wgLang": "en",
+		"smwgDVFeatures": [
+			"SMW_DV_TIMEV_CM"
+		]
+	},
+	"meta": {
+		"version": "2",
+		"is-incomplete": false,
+		"debug": false
+	}
+}

--- a/tests/phpunit/Unit/DataValues/Time/JulianDayTest.php
+++ b/tests/phpunit/Unit/DataValues/Time/JulianDayTest.php
@@ -28,6 +28,26 @@ class JulianDayTest extends \PHPUnit_Framework_TestCase {
 		);
 	}
 
+	public function testGetJD_Issue2454() {
+
+		$offset = -4 / 24;
+
+		$this->assertSame(
+			2457869.3333333,
+			JulianDay::getJD( 1, 2017, 4, 25, 20, 0, 0 )
+		);
+
+		$this->assertNotSame(
+			2457869.5,
+			JulianDay::getJD( 1, 2017, 4, 25, 20, 0, 0 ) - $offset // returns 2457869.4999999665
+		);
+
+		$this->assertSame(
+			2457869.5,
+			JulianDay::format( JulianDay::getJD( 1, 2017, 4, 25, 20, 0, 0 ) - $offset )
+		);
+	}
+
 	public function valueProvider() {
 
 		$provider[] = array(


### PR DESCRIPTION
This PR is made in reference to: #2454

This PR addresses or contains:

- Apply formatting consistently to avoid a mismatch on 2457869.5 vs. 2457869.4999999665

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed
