### PR TITLE
Travis switch to trusty environment

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,14 @@
+# https://docs.travis-ci.com/user/languages/php
 language: php
+sudo: required
+
+# https://docs.travis-ci.com/user/trusty-ci-environment/
+dist: trusty
 
 matrix:
   fast_finish: true
   include:
-    - env: DB=mysql; MW=REL1_27; TYPE=coverage; PHPUNIT=4.8.*
+    - env: DB=mysql; MW=REL1_27; PHPUNIT=4.8.*
       php: 7.0
     - env: DB=mysql; MW=REL1_28; FUSEKI=2.4.0
       php: 5.5
@@ -17,10 +22,10 @@ matrix:
       php: 5.5
     - env: DB=mysql; MW=REL1_26; BLAZEGRAPH=1.5.2; PHPUNIT=4.8.*
       php: 5.6
-    - env: DB=mysql; MW=REL1_25; TYPE=benchmark; PHPUNIT=4.8.*
-      php: hhvm
-    - env: DB=sqlite; MW=master; PHPUNIT=4.8.*
-      php: hhvm
+    - env: DB=mysql; MW=REL1_25; TYPE=benchmark; PHPUNIT=5.7.*
+      php: hhvm-3.12
+    - env: DB=sqlite; MW=master; PHPUNIT=5.7.*
+      php: hhvm-3.12
     - env: DB=sqlite; MW=REL1_27; TYPE=composer; PHPUNIT=4.8.*
       php: 5.6
     - env: DB=mysql; MW=REL1_25; TYPE=relbuild
@@ -28,15 +33,15 @@ matrix:
   allow_failures:
     # Takes at least ~35 min to complete therefore allow it run without delaying
     # the status update
-    - env: DB=mysql; MW=REL1_27; TYPE=coverage; PHPUNIT=4.8.*
+    - env: DB=mysql; MW=REL1_27; PHPUNIT=4.8.*
     # Can fail when pushed/used with newly Composer dependencies
     - env: DB=mysql; MW=REL1_25; TYPE=relbuild
     # Can fail when pushed/used with newly Composer dependencies
     - env: DB=sqlite; MW=REL1_27; TYPE=composer; PHPUNIT=4.8.*
     # This is MW master, you never know what WMF developers have put in for easter eggs
-    - env: DB=sqlite; MW=master; PHPUNIT=4.8.*
+    - env: DB=sqlite; MW=master; PHPUNIT=5.7.*
     # May take a moment and is non-critical therefore allow it to run without delaying the status
-    - env: DB=mysql; MW=REL1_25; TYPE=benchmark; PHPUNIT=4.8.*
+    - env: DB=mysql; MW=REL1_25; TYPE=benchmark; PHPUNIT=5.7.*
     - env: DB=mysql; MW=REL1_23; SESAME=2.8.7
 
 # Dec 16, 2015 (GCE switch): Travis support wrote (Tomcat + Java):
@@ -66,6 +71,10 @@ before_script:
 
 script:
   - bash ./tests/travis/run-tests.sh
+
+after_script:
+  - if [ ls /tmp/stacktrace* 1> /dev/null 2>&1 ] ; then cat /tmp/stacktrace*.log ; fi
+  - if [ -f php.log ] ; then cat php.log ; fi
 
 after_success:
   - bash ./tests/travis/upload-coverage-report.sh

--- a/tests/phpunit/Integration/JSONScript/TestCases/f-0001.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/f-0001.json
@@ -59,6 +59,8 @@
 		}
 	],
 	"settings": {
+		"wgContLang": "en",
+		"wgLang": "en",
 		"smwgNamespacesWithSemanticLinks": {
 			"NS_MAIN": true,
 			"SMW_NS_PROPERTY": true

--- a/tests/phpunit/Integration/JSONScript/TestCases/p-0414.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/p-0414.json
@@ -323,6 +323,9 @@
 			"type": "parser",
 			"about": "#13 `.888499949` is being rounded to `.888500`",
 			"subject": "Example/P0414/7a",
+			"skip-on": {
+				"hhvm-*": "Avoid .888500 vs. .888499 msec issue due to hhvm#6899"
+			},
 			"assert-output": {
 				"to-contain": [
 					"<td data-sort-value=\"2456116.9682395\" class=\"Has-date smwtype_dat\">8 July 2012 11:14:15</td>",

--- a/tests/phpunit/JsonTestCaseFileHandler.php
+++ b/tests/phpunit/JsonTestCaseFileHandler.php
@@ -83,6 +83,11 @@ class JsonTestCaseFileHandler {
 				return true;
 			}
 
+			if ( strpos( $id, 'hhvm-' ) !== false && defined( 'HHVM_VERSION' ) ) {
+				$this->reasonToSkip = "HHVM " . HHVM_VERSION . " version is not supported ({$reason})";
+				return true;
+			}
+
 			if ( strpos( $id, 'mw-' ) === false ) {
 				continue;
 			}

--- a/tests/phpunit/MwDBaseUnitTestCase.php
+++ b/tests/phpunit/MwDBaseUnitTestCase.php
@@ -80,6 +80,12 @@ abstract class MwDBaseUnitTestCase extends \PHPUnit_Framework_TestCase {
 			ApplicationFactory::getInstance()->newCacheFactory()->newFixedInMemoryCache()
 		);
 
+		// Avoid surprise on revisions etc.
+		// @see MediaWikiTestCase::doLightweightServiceReset
+		$this->testEnvironment->resetMediaWikiService( 'MainObjectStash' );
+		$this->testEnvironment->resetMediaWikiService( 'LocalServerObjectCache' );
+		$this->testEnvironment->resetMediaWikiService( 'MainWANObjectCache' );
+
 		$this->testEnvironment->clearPendingDeferredUpdates();
 	}
 

--- a/tests/phpunit/TestEnvironment.php
+++ b/tests/phpunit/TestEnvironment.php
@@ -115,6 +115,10 @@ class TestEnvironment {
 			// MediaWiki\Services\NoSuchServiceException: No such service ...
 		}
 
+		if ( $name === 'MainWANObjectCache' ) {
+			\MediaWiki\MediaWikiServices::getInstance()->getMainWANObjectCache()->clearProcessCache();
+		}
+
 		return $this;
 	}
 

--- a/tests/phpunit/Unit/IntlTimeFormatterTest.php
+++ b/tests/phpunit/Unit/IntlTimeFormatterTest.php
@@ -134,21 +134,24 @@ class IntlTimeFormatterTest extends \PHPUnit_Framework_TestCase {
 			'2000/12/12 01:01:20.200000'
 		);
 
-		#3
-		$provider[] = array(
-			'2/1300/11/02/12/03/25.888499949',
-			'en',
-			'Y-m-d H:i:s.u',
-			'1300-11-02 12:03:25.888500'
-		);
+		// Skip on HHVM to avoid .888500 vs. .888499 msec @see hhvm#6899
+		if ( !defined( 'HHVM_VERSION' ) ) {
+			#3
+			$provider[] = array(
+				'2/1300/11/02/12/03/25.888499949',
+				'en',
+				'Y-m-d H:i:s.u',
+				'1300-11-02 12:03:25.888500'
+			);
 
-		#4 time alone doesn't require a calendar model
-		$provider[] = array(
-			'2/1300/11/02/12/03/25.888499949',
-			'en',
-			'H:i:s.u',
-			'12:03:25.888500'
-		);
+			#4 time alone doesn't require a calendar model
+			$provider[] = array(
+				'2/1300/11/02/12/03/25.888499949',
+				'en',
+				'H:i:s.u',
+				'12:03:25.888500'
+			);
+		}
 
 		#5
 		$provider['on monthnumber 12'] = array(

--- a/tests/phpunit/Utils/File/BulkFileProvider.php
+++ b/tests/phpunit/Utils/File/BulkFileProvider.php
@@ -78,6 +78,8 @@ class BulkFileProvider {
 			}
 		}
 
+		asort( $files );
+
 		return $files;
 	}
 


### PR DESCRIPTION
This PR is made in reference to: https://blog.travis-ci.com/2017-05-04-precise-image-updates

This PR addresses or contains:

- Travis support wrote "Thanks for writing in. HHVM was unfortunately excluded from our last round of Ubuntu Precise 12.04 updates. Could you try using `dist: trusty` in your travis.yml and running the build again? "

This PR includes:
- [ ] Tests (unit/integration)
- [ ] CI build passed
