### PR TITLE
ArticleDelete to restrict pool of properties in update dispatcher, refs 2453

### DIFF
--- a/src/MediaWiki/Hooks/ArticleDelete.php
+++ b/src/MediaWiki/Hooks/ArticleDelete.php
@@ -4,7 +4,11 @@ namespace SMW\MediaWiki\Hooks;
 
 use SMW\ApplicationFactory;
 use SMW\DIWikiPage;
+use SMW\SemanticData;
 use SMW\EventHandler;
+use Wikipage;
+use Title;
+use SMW\MediaWiki\Jobs\UpdateDispatcherJob;
 use Psr\Log\LoggerInterface;
 use Psr\Log\LoggerAwareInterface;
 
@@ -16,23 +20,7 @@ use Psr\Log\LoggerAwareInterface;
  *
  * @author mwjames
  */
-class ArticleDelete implements LoggerAwareInterface {
-
-	/**
-	 * @var LoggerInterface
-	 */
-	private $logger;
-
-	/**
-	 * @see LoggerAwareInterface::setLogger
-	 *
-	 * @since 2.5
-	 *
-	 * @param LoggerInterface $logger
-	 */
-	public function setLogger( LoggerInterface $logger ) {
-		$this->logger = $logger;
-	}
+class ArticleDelete extends HookHandler {
 
 	/**
 	 * @since 2.0
@@ -41,52 +29,10 @@ class ArticleDelete implements LoggerAwareInterface {
 	 *
 	 * @return true
 	 */
-	public function process( $wikiPage ) {
+	public function process( Wikipage $wikiPage ) {
 
-		$applicationFactory = ApplicationFactory::getInstance();
-		$eventHandler = EventHandler::getInstance();
-
-		$title = $wikiPage->getTitle();
-		$store = $applicationFactory->getStore();
-
-		$semanticDataSerializer = $applicationFactory->newSerializerFactory()->newSemanticDataSerializer();
-		$jobFactory = $applicationFactory->newJobFactory();
-
-		$deferredCallableUpdate = $applicationFactory->newDeferredCallableUpdate( function() use( $store, $title, $semanticDataSerializer, $jobFactory, $eventHandler ) {
-
-			$subject = DIWikiPage::newFromTitle( $title );
-			$this->log( 'DeferredCallableUpdate on delete for ' . $subject->getHash() );
-
-			$parameters['semanticData'] = $semanticDataSerializer->serialize(
-				$store->getSemanticData( $subject )
-			);
-
-			$jobFactory->newUpdateDispatcherJob( $title, $parameters )->insert();
-
-			// Do we want this?
-			/*
-			$properties = $store->getInProperties( $subject );
-			$jobList = array();
-
-			foreach ( $properties as $property ) {
-				$propertySubjects = $store->getPropertySubjects( $property, $subject );
-				foreach ( $propertySubjects as $sub ) {
-					$jobList[$sub->getHash()] = true;
-				}
-			}
-
-			$jobFactory->newUpdateDispatcherJob( $title, array( 'job-list' => $jobList ) )->insert();
-			*/
-			$store->deleteSubject( $title );
-
-			$dispatchContext = $eventHandler->newDispatchContext();
-			$dispatchContext->set( 'title', $title );
-			$dispatchContext->set( 'context', 'ArticleDelete' );
-
-			$eventHandler->getEventDispatcher()->dispatch(
-				'cached.prefetcher.reset',
-				$dispatchContext
-			);
+		$deferredCallableUpdate = ApplicationFactory::getInstance()->newDeferredCallableUpdate( function() use( $wikiPage ) {
+			$this->doDelete( $wikiPage->getTitle() );
 		} );
 
 		$deferredCallableUpdate->setOrigin( __METHOD__ );
@@ -95,13 +41,60 @@ class ArticleDelete implements LoggerAwareInterface {
 		return true;
 	}
 
-	private function log( $message, $context = array() ) {
+	/**
+	 * @since 3.0
+	 *
+	 * @param Title $title
+	 */
+	public function doDelete( Title $title ) {
 
-		if ( $this->logger === null ) {
-			return;
+		$applicationFactory = ApplicationFactory::getInstance();
+
+		$store = $applicationFactory->getStore();
+		$subject = DIWikiPage::newFromTitle( $title );
+
+		$semanticDataSerializer = $applicationFactory->newSerializerFactory()->newSemanticDataSerializer();
+		$jobFactory = $applicationFactory->newJobFactory();
+
+		// Instead of Store::getSemanticData, construct the SemanticData by
+		// attaching only the incoming properties indicating which entities
+		// carry an actual reference to this subject
+		$semanticData = new SemanticData(
+			$subject
+		);
+
+		$properties = $store->getInProperties( $subject );
+
+		foreach ( $properties as $property ) {
+			// Avoid doing $propertySubjects = $store->getPropertySubjects( $property, $subject );
+			// as it may produce a too large pool of entities and ultimately
+			// block the delete transaction
+			// Use the subject as dataItem with the UpdateDispatcherJob because
+			// Store::getAllPropertySubjects is only scanning the property
+			$semanticData->addPropertyObjectValue( $property, $subject );
 		}
 
-		$this->logger->info( $message, $context );
+		$parameters['semanticData'] = $semanticDataSerializer->serialize(
+			$semanticData
+		);
+
+		// Restricted to the available SemanticData
+		$parameters[UpdateDispatcherJob::RESTRICTED_DISPATCH_POOL] = true;
+
+		$jobFactory->newUpdateDispatcherJob( $title, $parameters )->insert();
+
+		$store->deleteSubject( $title );
+
+		$eventHandler = EventHandler::getInstance();
+		$dispatchContext = $eventHandler->newDispatchContext();
+
+		$dispatchContext->set( 'title', $title );
+		$dispatchContext->set( 'context', 'ArticleDelete' );
+
+		$eventHandler->getEventDispatcher()->dispatch(
+			'cached.prefetcher.reset',
+			$dispatchContext
+		);
 	}
 
 }

--- a/src/MediaWiki/Jobs/UpdateDispatcherJob.php
+++ b/src/MediaWiki/Jobs/UpdateDispatcherJob.php
@@ -20,6 +20,11 @@ use Hooks;
 class UpdateDispatcherJob extends JobBase {
 
 	/**
+	 * Restict disptach process on available pool of data
+	 */
+	const RESTRICTED_DISPATCH_POOL = 'restricted.disp.pool';
+
+	/**
 	 * Size of chunks used when invoking the secondary dispatch run
 	 */
 	const CHUNK_SIZE = 500;
@@ -95,13 +100,15 @@ class UpdateDispatcherJob extends JobBase {
 
 	private function dispatchUpdateForSubject( DIWikiPage $subject ) {
 
-		$this->addUpdateJobsForProperties(
-			$this->store->getProperties( $subject )
-		);
+		if ( $this->getParameter( self::RESTRICTED_DISPATCH_POOL ) !== true ) {
+			$this->addUpdateJobsForProperties(
+				$this->store->getProperties( $subject )
+			);
 
-		$this->addUpdateJobsForProperties(
-			$this->store->getInProperties( $subject )
-		);
+			$this->addUpdateJobsForProperties(
+				$this->store->getInProperties( $subject )
+			);
+		}
 
 		$this->addUpdateJobsFromDeserializedSemanticData();
 	}

--- a/tests/phpunit/Unit/MediaWiki/Hooks/ArticleDeleteTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Hooks/ArticleDeleteTest.php
@@ -5,6 +5,7 @@ namespace SMW\Tests\MediaWiki\Hooks;
 use SMW\DIWikiPage;
 use SMW\MediaWiki\Hooks\ArticleDelete;
 use SMW\Tests\TestEnvironment;
+use SMW\DIProperty;
 
 /**
  * @covers \SMW\MediaWiki\Hooks\ArticleDelete
@@ -50,25 +51,9 @@ class ArticleDeleteTest extends \PHPUnit_Framework_TestCase {
 		);
 	}
 
-	public function testProcess() {
+	public function testActOn() {
 
 		$subject = DIWikiPage::newFromText( __METHOD__ );
-
-		$semanticData = $this->getMockBuilder( '\SMWSemanticData' )
-			->disableOriginalConstructor()
-			->getMock();
-
-		$semanticData->expects( $this->atLeastOnce() )
-			->method( 'getSubject' )
-			->will( $this->returnValue( $subject ) );
-
-		$semanticData->expects( $this->atLeastOnce() )
-			->method( 'getProperties' )
-			->will( $this->returnValue( array() ) );
-
-		$semanticData->expects( $this->atLeastOnce() )
-			->method( 'getSubSemanticData' )
-			->will( $this->returnValue( array() ) );
 
 		$store = $this->getMockBuilder( '\SMW\Store' )
 			->disableOriginalConstructor()
@@ -78,8 +63,8 @@ class ArticleDeleteTest extends \PHPUnit_Framework_TestCase {
 			->method( 'deleteSubject' );
 
 		$store->expects( $this->atLeastOnce() )
-			->method( 'getSemanticData' )
-			->will( $this->returnValue( $semanticData ) );
+			->method( 'getInProperties' )
+			->will( $this->returnValue( array( new DIProperty( 'Foo' ) ) ) );
 
 		$wikiPage = $this->getMockBuilder( '\WikiPage' )
 			->disableOriginalConstructor()


### PR DESCRIPTION
This PR is made in reference to: #2453

This PR addresses or contains:

- Only use the incoming properties to restrict the list of potential referenced entities that require an update after a subject has been deleted.

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed
