### PR TITLE
Improve Store::getInProperty performance, refs 1234

### DIFF
--- a/DefaultSettings.php
+++ b/DefaultSettings.php
@@ -1495,4 +1495,18 @@ return array(
 	'smwgEntityCollation' => 'identity',
 	##
 
+	##
+	# Entity lookup specific features
+	#
+	# - SMW_EL_NONE applies no query or schema changes
+	#
+	# - SMW_EL_INPROP enables a new query form for selecting incoming properties
+	#   (#1234)
+	#
+	# @since 3.0
+	# @default false
+	##
+	'smwgEntityLookupFeatures' => SMW_EL_INPROP,
+	##
+
 );

--- a/includes/Settings.php
+++ b/includes/Settings.php
@@ -174,6 +174,7 @@ class Settings extends Options {
 			'smwgSimilarityLookupExemptionProperty' => $GLOBALS['smwgSimilarityLookupExemptionProperty'],
 			'smwgPropertyInvalidCharacterList' => $GLOBALS['smwgPropertyInvalidCharacterList'],
 			'smwgEntityCollation' => $GLOBALS['smwgEntityCollation'],
+			'smwgEntityLookupFeatures' => $GLOBALS['smwgEntityLookupFeatures'],
 		);
 
 		self::initLegacyMapping( $configuration );

--- a/src/Defines.php
+++ b/src/Defines.php
@@ -203,3 +203,10 @@ define( 'SMW_LINV_OBFU', 4 ); // Using the Obfuscator approach
 define( 'SMW_RF_NONE', 0 );
 define( 'SMW_RF_TEMPLATE_OUTSEP', 2 ); // #2022 Enable 2.5 behaviour for template handling
 /**@}*/
+
+/**@{
+  * Constants for $smwgEntityLookupFeatures
+  */
+define( 'SMW_EL_NONE', 0 );
+define( 'SMW_EL_INPROP', 2 ); // New query for EntityLookup::getInProperties
+/**@}*/

--- a/src/MediaWiki/DatabaseHelper.php
+++ b/src/MediaWiki/DatabaseHelper.php
@@ -16,6 +16,32 @@ namespace SMW\MediaWiki;
 class DatabaseHelper {
 
 	/**
+	 * @since 3.0
+	 *
+	 * @return string
+	 */
+	public static function toString( array $options ) {
+
+		$string = '';
+
+		if ( isset( $options['GROUP BY'] ) ) {
+			$string .= ' GROUP BY ' . ( is_array( $options['GROUP BY'] ) ? implode( ',', $options['GROUP BY'] ) : $options['GROUP BY'] );
+		}
+
+		$string .= self::makeOrderBy( $options );
+
+		if ( isset( $options['LIMIT'] ) ) {
+			$string .= ' LIMIT ' . $options['LIMIT'];
+		}
+
+		if ( isset( $options['OFFSET'] ) ) {
+			$string .= ' OFFSET ' . $options['OFFSET'];
+		}
+
+		return $string;
+	}
+
+	/**
 	 * @see Database::makeSelectOptions
 	 */
 	public static function makeSelectOptions( Database $connection, $options ) {

--- a/src/Options.php
+++ b/src/Options.php
@@ -63,6 +63,18 @@ class Options {
 	}
 
 	/**
+	 * @since 3.0
+	 *
+	 * @param string $key
+	 * @param mixed $default
+	 *
+	 * @return mixed
+	 */
+	public function safeGet( $key, $default = false ) {
+		return $this->has( $key ) ? $this->options[$key] : $default;
+	}
+
+	/**
 	 * @since 2.4
 	 *
 	 * @return array

--- a/src/SQLStore/EntityStore/DIHandlers/DINumberHandler.php
+++ b/src/SQLStore/EntityStore/DIHandlers/DINumberHandler.php
@@ -47,6 +47,18 @@ class DINumberHandler extends DataItemHandler {
 	 *
 	 * {@inheritDoc}
 	 */
+	public function getTableIndexes() {
+		return array(
+			// QueryEngine::getInstanceQueryResult
+			's_id,p_id,o_sortkey',
+		);
+	}
+
+	/**
+	 * @since 1.8
+	 *
+	 * {@inheritDoc}
+	 */
 	public function getWhereConds( DataItem $dataItem ) {
 		return array(
 			'o_sortkey' => floatval( $dataItem->getNumber() )

--- a/src/SQLStore/EntityStore/DIHandlers/DITimeHandler.php
+++ b/src/SQLStore/EntityStore/DIHandlers/DITimeHandler.php
@@ -47,6 +47,24 @@ class DITimeHandler extends DataItemHandler {
 	 *
 	 * {@inheritDoc}
 	 */
+	public function getTableIndexes() {
+		return array(
+
+			// SMWSQLStore3Readers::fetchSemanticData
+			// SELECT p.smw_title as prop,o_serialized AS v0, o_sortkey AS v2
+			// FROM `smw_di_time` INNER JOIN `smw_object_ids` AS p ON
+			// p_id=p.smw_id WHERE s_id='104822'	7.9291ms
+			// ... FROM `smw_fpt_sobj` INNER JOIN `smw_object_ids` AS o0 ON
+			// o_id=o0.smw_id WHERE s_id='104322'
+			's_id,p_id,o_sortkey,o_serialized',
+		);
+	}
+
+	/**
+	 * @since 1.8
+	 *
+	 * {@inheritDoc}
+	 */
 	public function getWhereConds( DataItem $dataItem ) {
 		return array( 'o_sortkey' => $dataItem->getSortKey() );
 	}

--- a/src/SQLStore/EntityStore/DIHandlers/DIWikiPageHandler.php
+++ b/src/SQLStore/EntityStore/DIHandlers/DIWikiPageHandler.php
@@ -52,7 +52,46 @@ class DIWikiPageHandler extends DataItemHandler {
 	 * {@inheritDoc}
 	 */
 	public function getTableIndexes() {
-		return array( 'o_id' );
+		return array(
+			'o_id',
+
+			// SMWSQLStore3Readers::fetchSemanticData
+			// ... FROM `smw_fpt_sobj` INNER JOIN `smw_object_ids` AS o0 ON
+			// o_id=o0.smw_id WHERE s_id='104322'
+			's_id,o_id',
+
+			// SMWSQLStore3Readers::fetchSemanticData
+			// ... FROM `smw_di_wikipage` INNER JOIN `smw_object_ids` AS p ON
+			// p_id=p.smw_id INNER JOIN `smw_object_ids` AS o0 ON o_id=o0.smw_id
+			// WHERE s_id='104815'
+			's_id,p_id,o_id',
+
+			// QueryEngine::getInstanceQueryResult
+			// ... INNER JOIN `smw_fpt_inst` AS t3 ON t2.smw_id=t3.s_id WHERE
+			// (t2.smw_namespace='0' AND (t3.o_id='56')
+			'o_id,s_id',
+
+			// QueryEngine::getInstanceQueryResult
+			//'p_id,o_id,s_sort',
+
+			// SMWSQLStore3Readers::getPropertySubjects
+			//'p_id,s_sort,s_id',
+
+			// SMWSQLStore3Readers::getPropertySubjects
+			// SELECT DISTINCT s_id FROM `smw_fpt_sobj` ORDER BY s_sort
+			//'s_sort,s_id',
+
+			// SELECT DISTINCT s_id FROM `smw_fpt_subp` WHERE o_id='96' ORDER BY s_sort
+			//'o_id,s_sort,s_id',
+
+			// In-property lookup
+			'o_id,p_id',
+			//'o_id,p_id,s_sort',
+
+			// SMWSQLStore3Readers::getPropertySubjects
+			// SELECT DISTINCT s_id FROM `smw_di_wikipage` WHERE (p_id='64' AND o_id='104') ORDER BY s_sort ASC
+			//'o_id,p_id,s_id,s_sort'
+		);
 	}
 
 	/**

--- a/src/SQLStore/EntityStore/SqlEntityLookupResultFetcher.php
+++ b/src/SQLStore/EntityStore/SqlEntityLookupResultFetcher.php
@@ -1,0 +1,164 @@
+<?php
+
+namespace SMW\SQLStore\EntityStore;
+
+use SMW\SQLStore\SQLStore;
+use SMW\SQLStore\PropertyTableDefinition as PropertyTableDef;
+use SMWDataItem as DataItem;
+use SMW\DIContainer;
+use SMW\RequestOptions;
+use SMW\Options;
+use SMW\MediaWiki\DatabaseHelper;
+use RuntimeException;
+
+/**
+ * @license GNU GPL v2
+ * @since 3.0
+ *
+ * @author mwjames
+ */
+class SqlEntityLookupResultFetcher {
+
+	/**
+	 * @var SQLStore
+	 */
+	private $store;
+
+	/**
+	 * @var Options
+	 */
+	private $options;
+
+	/**
+	 * @since 3.0
+	 *
+	 * @param SQLStore $store
+	 * @param Options|null $options
+	 */
+	public function __construct( SQLStore $store, Options $options = null ) {
+		$this->store = $store;
+		$this->options = $options;
+
+		if ( $this->options === null ) {
+			$this->options = new Options();
+		}
+	}
+
+	/**
+	 * @since 3.0
+	 *
+	 * @param integer $feature
+	 *
+	 * @return boolean
+	 */
+	public function isEnabledFeature( $feature ) {
+		return ( (int)$this->options->safeGet( 'smwgEntityLookupFeatures' ) & $feature ) != 0;
+	}
+
+	/**
+	 * @see Store::getInProperties
+	 *
+	 * @since 3.0
+	 *
+	 * {@inheritDoc}
+	 */
+	public function fetchIncomingProperties( PropertyTableDef $propertyTableDef, DataItem $dataItem, RequestOptions $requestOptions = null ) {
+
+		$connection = $this->store->getConnection( 'mw.db' );
+
+		if ( $dataItem instanceof DIContainer ) {
+			throw new RuntimeException( "DIContainer: " . $dataItem->getSerialization() );
+		}
+
+		// Potentially need to get more results, since options apply to union.
+		if ( $requestOptions !== null ) {
+			$subOptions = clone $requestOptions;
+			$subOptions->limit = $requestOptions->limit + $requestOptions->offset;
+			$subOptions->offset = 0;
+		} else {
+			$subOptions = null;
+		}
+
+		if ( !$propertyTableDef->isFixedPropertyTable() ) {
+
+			$cond = $this->getWhereConds( $dataItem );
+			$conditions = '';
+
+			// No sorting
+			$options = $this->store->getSQLOptions( $subOptions, '' );
+
+			// Avoid any limit or offset for the sub-query in order to find all
+			// incoming properties
+			unset( $options['LIMIT'] );
+			unset( $options['OFFSET'] );
+
+			// Ensure to group same IDs to reduce the amount of data transferred
+			// from the inner join
+			$options['GROUP BY'] = 'p_id';
+
+			$opt = DatabaseHelper::toString( $options );
+
+			$cond = ( $cond !== '' ? ' WHERE ' : '' ) . $cond;
+
+			// Use a subquery to match all possible IDs, no ORDER BY or DISTINCT to avoid
+			// a filesort
+			$from = $connection->tableName( SQLStore::ID_TABLE ) .
+				" INNER JOIN (" .
+				" SELECT p_id FROM " . $connection->tableName( $propertyTableDef->getName() ) .
+				" $cond $opt ) AS t1 ON t1.p_id=smw_id";
+
+			$conditions .= ( $conditions ? ' AND ' : ' ' ) .
+				" smw_iw!=" . $connection->addQuotes( SMW_SQL3_SMWIW_OUTDATED ) .
+				" AND smw_iw!=" . $connection->addQuotes( SMW_SQL3_SMWDELETEIW );
+
+			$conditions .= $this->store->getSQLConditions( $subOptions, 'smw_sortkey', 'smw_sortkey', $conditions !== '' );
+
+			$options = $this->store->getSQLOptions( $subOptions, '' ) + array( 'DISTINCT' );
+
+			$result = $connection->select(
+				$from,
+				' smw_title,smw_sortkey,smw_iw',
+				$conditions,
+				__METHOD__,
+				$options
+			);
+
+		} else {
+			$from = $connection->tableName( $propertyTableDef->getName() ) . " AS t1";
+			$where = $this->getWhereConds( $dataItem );
+			$fields = $propertyTableDef->usesIdSubject() ? 's_id' : '*';
+
+			$result = $connection->select(
+				$from,
+				$fields,
+				$where,
+				__METHOD__,
+				array( 'LIMIT' => 1 )
+			);
+
+			if ( $result->numRows() > 0 ) {
+				$res = new \stdClass;
+				$res->smw_title = $propertyTableDef->getFixedProperty();
+				$result = array( $res );
+			}
+		}
+
+		return $result;
+	}
+
+	private function getWhereConds( $dataItem ) {
+
+		$where = '';
+		$connection = $this->store->getConnection( 'mw.db' );
+
+		if ( $dataItem !== null ) {
+			$dataItemHandler = $this->store->getDataItemHandlerForDIType( $dataItem->getDIType() );
+			foreach ( $dataItemHandler->getWhereConds( $dataItem ) as $fieldname => $value ) {
+				$where .= ( $where ? ' AND ' : '' ) . "$fieldname=" . $connection->addQuotes( $value );
+			}
+		}
+
+		return $where;
+	}
+
+}

--- a/src/SQLStore/RequestOptionsProcessor.php
+++ b/src/SQLStore/RequestOptionsProcessor.php
@@ -61,6 +61,12 @@ class RequestOptionsProcessor {
 			$sqlConds['ORDER BY'] = $requestOptions->ascending ? $valueCol : $valueCol . ' DESC';
 		}
 
+		// Avoid a possible filesort (likely caused by ORDER BY) when limit is
+		// less than 2
+		if ( $requestOptions->limit < 2 ) {
+			unset( $sqlConds['ORDER BY'] );
+		}
+
 		return $sqlConds;
 	}
 

--- a/src/SQLStore/SQLStoreFactory.php
+++ b/src/SQLStore/SQLStoreFactory.php
@@ -12,6 +12,7 @@ use SMW\SQLStore\Lookup\UnusedPropertyListLookup;
 use SMW\SQLStore\Lookup\UsageStatisticsListLookup;
 use SMW\SQLStore\Lookup\RedirectTargetLookup;
 use SMWRequestOptions as RequestOptions;
+use SMW\Options;
 use SMWSQLStore3;
 use SMW\SQLStore\TableBuilder\TableBuilder;
 use Onoi\MessageReporter\MessageReporterFactory;
@@ -19,6 +20,7 @@ use SMWSql3SmwIds as IdTableManager;
 use SMW\SQLStore\EntityStore\DataItemHandlerDispatcher;
 use SMW\SQLStore\EntityStore\CachedEntityLookup;
 use SMW\SQLStore\EntityStore\DirectEntityLookup;
+use SMW\SQLStore\EntityStore\SqlEntityLookupResultFetcher;
 
 /**
  * @license GNU GPL v2+
@@ -416,6 +418,24 @@ class SQLStoreFactory {
 	 */
 	public function getLogger() {
 		return ApplicationFactory::getInstance()->getMediaWikiLogger();
+	}
+
+	/**
+	 * @since 3.0
+	 *
+	 * @return SqlEntityLookupResultFetcher
+	 */
+	public function newSqlEntityLookupResultFetcher() {
+
+		$settings = ApplicationFactory::getInstance()->getSettings();
+
+		$options = new Options(
+			array(
+				'smwgEntityLookupFeatures' => $settings->get( 'smwgEntityLookupFeatures' )
+			)
+		);
+
+		return new SqlEntityLookupResultFetcher( $this->store, $options );
 	}
 
 	/**

--- a/src/SQLStore/TableBuilder/PostgresTableBuilder.php
+++ b/src/SQLStore/TableBuilder/PostgresTableBuilder.php
@@ -286,7 +286,7 @@ EOT;
 		}
 
 		$tableName = $this->connection->tableName( $tableName, 'raw' );
-		$indexName = "{$tableName}_index{$indexName}";
+		$indexName = $this->getCumulatedIndexName( $tableName, $columns );
 
 		$this->reportMessage( "   ... creating new index $columns ..." );
 
@@ -295,6 +295,12 @@ EOT;
 		}
 
 		$this->reportMessage( "done.\n" );
+	}
+
+	private function getCumulatedIndexName( $tableName, $columns ) {
+		// Identifiers -- table names, column names, constraint names,
+		// etc. -- are limited to a maximum length of 63 bytes
+		return str_replace( '__' , '_', "{$tableName}_idx_" . str_replace( array( '_', 'smw', ',' ), array( '', '_', '_' ), $columns ) );
 	}
 
 	private function getIndexInfo( $tableName ) {

--- a/src/SQLStore/TableSchemaManager.php
+++ b/src/SQLStore/TableSchemaManager.php
@@ -113,15 +113,23 @@ class TableSchemaManager {
 		$table->addIndex( 'smw_id,smw_sortkey' );
 		// IW match lookup
 		$table->addIndex( 'smw_iw' );
+		$table->addIndex( 'smw_iw,smw_id' );
+
 		// ID lookup
 		$table->addIndex( 'smw_title,smw_namespace,smw_iw,smw_subobject' );
+
+		// InProperty lookup
+		// $table->addIndex( 'smw_iw,smw_id,smw_title,smw_sortkey,smw_sort' );
+
 		// Select by sortkey (range queries)
 		$table->addIndex( 'smw_sortkey' );
 
 		// Sort related indices
-		$table->addIndex( 'smw_sort' );
+		// $table->addIndex( 'smw_sort' );
 		$table->addIndex( 'smw_id,smw_sort' );
-		$table->addIndex( 'smw_sort,smw_id' );
+		//$table->addIndex( 'smw_sort,smw_id' );
+
+		$table->addIndex( 'smw_sort,smw_id,smw_iw' );
 
 		return $table;
 	}
@@ -239,6 +247,10 @@ class TableSchemaManager {
 			}
 
 			if ( strpos( $value, 'o_id' ) !== false && !$propertyTable->usesIdSubject() ) {
+				continue;
+			}
+
+			if ( strpos( $value, 's_id' ) !== false && !$propertyTable->usesIdSubject() ) {
 				continue;
 			}
 

--- a/tests/phpunit/Unit/MediaWiki/DatabaseHelperTest.php
+++ b/tests/phpunit/Unit/MediaWiki/DatabaseHelperTest.php
@@ -37,6 +37,21 @@ class DatabaseHelperTest extends \PHPUnit_Framework_TestCase {
 		);
 	}
 
+	/**
+	 * @dataProvider optionsProvider
+	 */
+	public function testToString( $options ) {
+
+		$connection = $this->getMockBuilder( '\SMW\MediaWiki\Database' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$this->assertInternalType(
+			'string',
+			DatabaseHelper::toString( $options )
+		);
+	}
+
 	public function optionsProvider() {
 
 		$provider[] = array(

--- a/tests/phpunit/Unit/OptionsTest.php
+++ b/tests/phpunit/Unit/OptionsTest.php
@@ -59,4 +59,14 @@ class OptionsTest extends \PHPUnit_Framework_TestCase {
 		$instance->get( 'Foo' );
 	}
 
+	public function testSafeGetOnUnregisteredKey() {
+
+		$instance = new Options();
+
+		$this->assertEquals(
+			'Default',
+			$instance->safeGet( 'Foo', 'Default' )
+		);
+	}
+
 }

--- a/tests/phpunit/Unit/SQLStore/EntityStore/SqlEntityLookupResultFetcherTest.php
+++ b/tests/phpunit/Unit/SQLStore/EntityStore/SqlEntityLookupResultFetcherTest.php
@@ -1,0 +1,143 @@
+<?php
+
+namespace SMW\Tests\SQLStore\EntityStore;
+
+use SMW\SQLStore\EntityStore\SqlEntityLookupResultFetcher;
+use SMW\ApplicationFactory;
+use SMW\DIWikiPage;
+use SMW\Options;
+
+/**
+ * @covers \SMW\SQLStore\EntityStore\SqlEntityLookupResultFetcher
+ * @group semantic-mediawiki
+ *
+ * @license GNU GPL v2+
+ * @since 3.0
+ *
+ * @author mwjames
+ */
+class SqlEntityLookupResultFetcherTest extends \PHPUnit_Framework_TestCase {
+
+	public function testCanConstruct() {
+
+		$store = $this->getMockBuilder( '\SMW\SQLStore\SQLStore' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$this->assertInstanceOf(
+			SqlEntityLookupResultFetcher::class,
+			new SqlEntityLookupResultFetcher( $store )
+		);
+	}
+
+	public function testFetchIncomingPropertiesForNonFixedPropertyTable() {
+
+		$dataItem = DIWikiPage::newFromText( __METHOD__ );
+
+		$dataItemHandler = $this->getMockBuilder( '\SMW\SQLStore\EntityStore\DataItemHandler' )
+			->disableOriginalConstructor()
+			->getMockForAbstractClass();
+
+		$dataItemHandler->expects( $this->atLeastOnce() )
+			->method( 'getWhereConds' )
+			->will( $this->returnValue( array( 'o_id' => 42 ) ) );
+
+		$propertyTableDef = $this->getMockBuilder( '\SMW\SQLStore\PropertyTableDefinition' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$propertyTableDef->expects( $this->atLeastOnce() )
+			->method( 'isFixedPropertyTable' )
+			->will( $this->returnValue( false ) );
+
+		$connection = $this->getMockBuilder( '\SMW\MediaWiki\Database' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$connection->expects( $this->atLeastOnce() )
+			->method( 'select' )
+			->will( $this->returnValue( array() ) );
+
+		$store = $this->getMockBuilder( '\SMW\SQLStore\SQLStore' )
+			->disableOriginalConstructor()
+			->setMethods( array( 'getConnection', 'getDataItemHandlerForDIType', 'getSQLOptions', 'getSQLConditions' ) )
+			->getMock();
+
+		$store->expects( $this->atLeastOnce() )
+			->method( 'getSQLOptions' )
+			->will( $this->returnValue( array() ) );
+
+		$store->expects( $this->atLeastOnce() )
+			->method( 'getSQLConditions' )
+			->will( $this->returnValue( '' ) );
+
+		$store->expects( $this->atLeastOnce() )
+			->method( 'getConnection' )
+			->will( $this->returnValue( $connection ) );
+
+		$store->expects( $this->atLeastOnce() )
+			->method( 'getDataItemHandlerForDIType' )
+			->will( $this->returnValue( $dataItemHandler ) );
+
+		$instance = new SqlEntityLookupResultFetcher(
+			$store,
+			new Options( array( 'smwgEntityLookupFeatures' => SMW_EL_INPROP ) )
+		);
+
+		$instance->fetchIncomingProperties( $propertyTableDef, $dataItem );
+	}
+
+	public function testFetchIncomingPropertiesForFixedPropertyTable() {
+
+		$dataItem = DIWikiPage::newFromText( __METHOD__ );
+
+		$resultWrapper = $this->getMockBuilder( '\FakeResultWrapper' )
+			->disableOriginalConstructor()
+			->getMockForAbstractClass();
+
+		$dataItemHandler = $this->getMockBuilder( '\SMW\SQLStore\EntityStore\DataItemHandler' )
+			->disableOriginalConstructor()
+			->getMockForAbstractClass();
+
+		$dataItemHandler->expects( $this->atLeastOnce() )
+			->method( 'getWhereConds' )
+			->will( $this->returnValue( array( 'o_id' => 42 ) ) );
+
+		$propertyTableDef = $this->getMockBuilder( '\SMW\SQLStore\PropertyTableDefinition' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$propertyTableDef->expects( $this->atLeastOnce() )
+			->method( 'isFixedPropertyTable' )
+			->will( $this->returnValue( true ) );
+
+		$connection = $this->getMockBuilder( '\SMW\MediaWiki\Database' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$connection->expects( $this->atLeastOnce() )
+			->method( 'select' )
+			->will( $this->returnValue( $resultWrapper ) );
+
+		$store = $this->getMockBuilder( '\SMW\SQLStore\SQLStore' )
+			->disableOriginalConstructor()
+			->setMethods( array( 'getConnection', 'getDataItemHandlerForDIType' ) )
+			->getMock();
+
+		$store->expects( $this->atLeastOnce() )
+			->method( 'getConnection' )
+			->will( $this->returnValue( $connection ) );
+
+		$store->expects( $this->atLeastOnce() )
+			->method( 'getDataItemHandlerForDIType' )
+			->will( $this->returnValue( $dataItemHandler ) );
+
+		$instance = new SqlEntityLookupResultFetcher(
+			$store,
+			new Options( array( 'smwgEntityLookupFeatures' => SMW_EL_INPROP ) )
+		);
+
+		$instance->fetchIncomingProperties( $propertyTableDef, $dataItem );
+	}
+
+}

--- a/tests/phpunit/Unit/SQLStore/RequestOptionsProcessorTest.php
+++ b/tests/phpunit/Unit/SQLStore/RequestOptionsProcessorTest.php
@@ -34,7 +34,7 @@ class RequestOptionsProcessorTest extends \PHPUnit_Framework_TestCase {
 		);
 	}
 
-	public function testTransformToSQLOptions() {
+	public function testTransformToSQLOptionsWithoutOrderBy() {
 
 		$instance = new RequestOptionsProcessor( $this->store );
 
@@ -45,6 +45,26 @@ class RequestOptionsProcessorTest extends \PHPUnit_Framework_TestCase {
 
 		$expected = array(
 			'LIMIT'    => 1,
+			'OFFSET'   => 2
+		);
+
+		$this->assertEquals(
+			$expected,
+			$instance->getSQLOptionsFrom( $requestOptions, 'Foo' )
+		);
+	}
+
+	public function testTransformToSQLOptionsWithOrderBy() {
+
+		$instance = new RequestOptionsProcessor( $this->store );
+
+		$requestOptions = new RequestOptions();
+		$requestOptions->limit = 2;
+		$requestOptions->offset = 2;
+		$requestOptions->sort = true;
+
+		$expected = array(
+			'LIMIT'    => 2,
 			'OFFSET'   => 2,
 			'ORDER BY' => 'Foo'
 		);

--- a/tests/phpunit/Unit/SQLStore/SQLStoreFactoryTest.php
+++ b/tests/phpunit/Unit/SQLStore/SQLStoreFactoryTest.php
@@ -243,6 +243,16 @@ class SQLStoreFactoryTest extends \PHPUnit_Framework_TestCase {
 		);
 	}
 
+	public function testCanConstrucSqlEntityLookupResultFetcher() {
+
+		$instance = new SQLStoreFactory( $this->store );
+
+		$this->assertInstanceOf(
+			'\SMW\SQLStore\EntityStore\SqlEntityLookupResultFetcher',
+			$instance->newSqlEntityLookupResultFetcher()
+		);
+	}
+
 	public function testCanConstrucPropertyStatisticsTable() {
 
 		$connection = $this->getMockBuilder( '\SMW\MediaWiki\Database' )

--- a/tests/phpunit/Unit/SQLStore/TableBuilder/PostgresTableBuilderTest.php
+++ b/tests/phpunit/Unit/SQLStore/TableBuilder/PostgresTableBuilderTest.php
@@ -117,7 +117,7 @@ class PostgresTableBuilderTest extends \PHPUnit_Framework_TestCase {
 
 		$connection->expects( $this->at( 5 ) )
 			->method( 'query' )
-			->with( $this->stringContains( 'CREATE INDEX foo_index0 ON foo (bar)' ) );
+			->with( $this->stringContains( 'CREATE INDEX foo_idx_bar ON foo (bar)' ) );
 
 		$instance = PostgresTableBuilder::factory( $connection );
 


### PR DESCRIPTION
This PR is made in reference to: #1234

This PR addresses or contains:

- The following [content](https://gist.github.com/mwjames/103afa6ecd53b666de075e69cc1970ca) was used to simulate some high data load
- Changes on pre/post to the query plan can be found [here](https://gist.github.com/mwjames/0bbe876b11ec4e134cddd0c46345b7d5)
- The PR in particular addresses the `Store::getInProperties` performance with a __significant improvement__ in query execution time by extending the `INNER JOIN` with a subquery to pre-select and filter possible matches before being materialized. One example entity with > 100 incoming properties and an overall table size that covers ~1M triples demonstrated the following changes pre/post this PR.
  - MySQL ( `841.3639ms` ↘ `39.1431ms`)
  - Postgres (`1282.6319ms` ↘ `59.8922ms`) 
- The suggestion from #1234 on using something like  ` ... WHERE smw_id IN (SELECT p_id FROM mediawiki."smw_di_wikipage" WHERE o_id='19683’);` did not create the expected improvement on MySQL hence a different query was selected that showed favorable query plans on both MySQL and Postgres.

To eliminate filesort and other expensive operations we needed to:

* Create additional composite indexes to ensure the query planner choose the right one with the objective of using an index
* Eliminate `ORDER BY` as it is expected to returns all matches and sort the results during a post processing
*  Filter possible matches before being materialized

```sql
SELECT DISTINCT smw_title,smw_sortkey,smw_iw FROM "smw_object_ids"
INNER JOIN (
  SELECT p_id FROM "smw_di_wikipage" WHERE o_id='266' GROUP BY p_id
 ) AS t1 ON t1.p_id=smw_id
WHERE smw_iw!=':smw' AND smw_iw!=':smw-delete'
```

Tested on:

```
MediaWiki	1.30.0-alpha (3d26a96)
PHP	7.1.1 (apache2handler)
MariaDB	10.1.21-MariaDB
ICU	57.1
```
```
MediaWiki	1.26.2
PHP	5.6.8 (apache2handler)
PostgreSQL	9.3.12
ICU	54.1
```

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed
