### PR TITLE
SMWSql3SmwIds set legacy cache only on success, refs 2446

### DIFF
--- a/includes/storage/SQLStore/SMW_Sql3SmwIds.php
+++ b/includes/storage/SQLStore/SMW_Sql3SmwIds.php
@@ -570,17 +570,17 @@ class SMWSql3SmwIds {
 
 		if ( $row !== false ) {
 			$id = $row->smw_id;
-		}
 
-		// Legacy
-		$this->setCache(
-			$subject->getDBKey(),
-			$subject->getNamespace(),
-			$subject->getInterWiki(),
-			$subject->getSubobjectName(),
-			$id,
-			$subject->getSortKey()
-		);
+			// Legacy
+			$this->setCache(
+				$subject->getDBKey(),
+				$subject->getNamespace(),
+				$subject->getInterWiki(),
+				$subject->getSubobjectName(),
+				$id,
+				$subject->getSortKey()
+			);
+		}
 
 		return $id;
 	}


### PR DESCRIPTION
This PR is made in reference to: #2446

This PR addresses or contains:

- This had the effect that under certain circumstances during a transaction the cache reset itself to 0 which forced to create a duplicate ID.

This PR includes:
- [ ] Tests (unit/integration)
- [x] CI build passed
