### PR TITLE
Add $smwgUseCategoryRedirect to handle redirects/errors on categories

### DIFF
--- a/DefaultSettings.php
+++ b/DefaultSettings.php
@@ -294,6 +294,15 @@ return array(
 	##
 
 	###
+	# Resolves redirects and errors in connection with categories
+	#
+	# @since 3.0
+	# @default true
+	##
+	'smwgUseCategoryRedirect' => true,
+	##
+
+	###
 	# InText annotation to support "links in value"
 	#
 	# SMW_LINV_OBFU (2.5+)

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -548,5 +548,6 @@
 	"smw-format-datatable-next": "Next",
 	"smw-format-datatable-previous": "Previous",
 	"smw-format-datatable-sortascending": ": activate to sort column ascending",
-	"smw-format-datatable-sortdescending": ": activate to sort column descending"
+	"smw-format-datatable-sortdescending": ": activate to sort column descending",
+	"smw-category-invalid-redirect-target": "Category \"$1\" contains an invalid redirect target to a non-category namespace."
 }

--- a/includes/Settings.php
+++ b/includes/Settings.php
@@ -70,6 +70,7 @@ class Settings extends Options {
 			'smwgInlineErrors' => $GLOBALS['smwgInlineErrors'],
 			'smwgUseCategoryHierarchy' => $GLOBALS['smwgUseCategoryHierarchy'],
 			'smwgCategoriesAsInstances' => $GLOBALS['smwgCategoriesAsInstances'],
+			'smwgUseCategoryRedirect' => $GLOBALS['smwgUseCategoryRedirect'],
 			'smwgLinksInValues' => $GLOBALS['smwgLinksInValues'],
 			'smwgDefaultNumRecurringEvents' => $GLOBALS['smwgDefaultNumRecurringEvents'],
 			'smwgMaxNumRecurringEvents' => $GLOBALS['smwgMaxNumRecurringEvents'],

--- a/src/PropertyAnnotatorFactory.php
+++ b/src/PropertyAnnotatorFactory.php
@@ -141,21 +141,27 @@ class PropertyAnnotatorFactory {
 	 */
 	public function newCategoryPropertyAnnotator( PropertyAnnotator $propertyAnnotator, array $categories ) {
 
+		$settings = ApplicationFactory::getInstance()->getSettings();
+
 		$categoryPropertyAnnotator = new CategoryPropertyAnnotator(
 			$propertyAnnotator,
 			$categories
 		);
 
-		$categoryPropertyAnnotator->setShowHiddenCategoriesState(
-			ApplicationFactory::getInstance()->getSettings()->get( 'smwgShowHiddenCategories' )
+		$categoryPropertyAnnotator->showHiddenCategories(
+			$settings->get( 'smwgShowHiddenCategories' )
 		);
 
-		$categoryPropertyAnnotator->setCategoryInstanceUsageState(
-			ApplicationFactory::getInstance()->getSettings()->get( 'smwgCategoriesAsInstances' )
+		$categoryPropertyAnnotator->useCategoryInstance(
+			$settings->get( 'smwgCategoriesAsInstances' )
 		);
 
-		$categoryPropertyAnnotator->setCategoryHierarchyUsageState(
-			ApplicationFactory::getInstance()->getSettings()->get( 'smwgUseCategoryHierarchy' )
+		$categoryPropertyAnnotator->useCategoryHierarchy(
+			$settings->get( 'smwgUseCategoryHierarchy' )
+		);
+
+		$categoryPropertyAnnotator->useCategoryRedirect(
+			$settings->get( 'smwgUseCategoryRedirect' )
 		);
 
 		return $categoryPropertyAnnotator;

--- a/tests/phpunit/Integration/JSONScript/JsonTestCaseScriptRunnerTest.php
+++ b/tests/phpunit/Integration/JSONScript/JsonTestCaseScriptRunnerTest.php
@@ -184,6 +184,7 @@ class JsonTestCaseScriptRunnerTest extends JsonTestCaseScriptRunner {
 			'smwgQueryProfiler',
 			'smwgEntityCollation',
 			'smwgSparqlQFeatures',
+			'smwgUseCategoryRedirect',
 
 			// MW related
 			'wgLanguageCode',

--- a/tests/phpunit/Integration/JSONScript/TestCases/p-0915.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/p-0915.json
@@ -1,0 +1,108 @@
+{
+	"description": "Test category redirect (`smwgUseCategoryRedirect`)",
+	"setup": [
+		{
+			"namespace": "NS_CATEGORY",
+			"page": "Example/P0915",
+			"contents": "#REDIRECT [[Example/P0915/1]]"
+		},
+		{
+			"namespace": "NS_CATEGORY",
+			"page": "Example/P0915/SubCat",
+			"contents": "[[Category:Example/P0915]]"
+		},
+		{
+			"namespace": "NS_CATEGORY",
+			"page": "Example/P0915/ValidCat",
+			"contents": "#REDIRECT [[:Category:Example/P0915/ValidCat2]]"
+		},
+		{
+			"page": "Example/P0915/1",
+			"contents": "[[Category:Example/P0915]]"
+		},
+		{
+			"page": "Example/P0915/2",
+			"contents": "[[Category:Example/P0915/ValidCat]]"
+		}
+	],
+	"tests": [
+		{
+			"type": "parser",
+			"about": "#0 track category with invalid (NS_MAIN) redirect target",
+			"subject": "Example/P0915/1",
+			"store": {
+				"clear-cache": true
+			},
+			"assert-store": {
+				"semantic-data": {
+					"strictPropertyValueMatch": false,
+					"propertyCount": 3,
+					"propertyKeys": [
+						"_SKEY",
+						"_MDAT",
+						"_ERRC"
+					],
+					"incoming": {
+						"propertyKeys": [
+							"_REDI"
+						]
+					}
+				}
+			}
+		},
+		{
+			"type": "parser",
+			"about": "#1 track sub-category",
+			"namespace": "NS_CATEGORY",
+			"subject": "Example/P0915/SubCat",
+			"assert-store": {
+				"semantic-data": {
+					"strictPropertyValueMatch": false,
+					"propertyCount": 3,
+					"propertyKeys": [
+						"_SKEY",
+						"_MDAT",
+						"_ERRC"
+					]
+				}
+			}
+		},
+		{
+			"type": "parser",
+			"about": "#2 valid cat redirect, dsiplay the redirect target",
+			"subject": "Example/P0915/2",
+			"assert-store": {
+				"semantic-data": {
+					"strictPropertyValueMatch": false,
+					"propertyCount": 3,
+					"propertyKeys": [
+						"_SKEY",
+						"_MDAT",
+						"_INST"
+					],
+					"propertyValues": [
+						"Example/P0915/ValidCat2#14#"
+					]
+				}
+			}
+		}
+	],
+	"settings": {
+		"wgContLang": "en",
+		"wgLang": "en",
+		"smwgUseCategoryRedirect": true,
+		"smwgPageSpecialProperties": [
+			"_MDAT"
+		],
+		"smwgNamespacesWithSemanticLinks": {
+			"NS_MAIN": true,
+			"NS_CATEGORY": true,
+			"SMW_NS_PROPERTY": true
+		}
+	},
+	"meta": {
+		"version": "2",
+		"is-incomplete": false,
+		"debug": false
+	}
+}

--- a/tests/phpunit/Unit/PropertyAnnotators/CategoryPropertyAnnotatorTest.php
+++ b/tests/phpunit/Unit/PropertyAnnotators/CategoryPropertyAnnotatorTest.php
@@ -32,6 +32,12 @@ class CategoryPropertyAnnotatorTest extends \PHPUnit_Framework_TestCase {
 
 		$this->semanticDataFactory = $this->testEnvironment->getUtilityFactory()->newSemanticDataFactory();
 		$this->semanticDataValidator = $this->testEnvironment->getUtilityFactory()->newValidatorFactory()->newSemanticDataValidator();
+
+		$store = $this->getMockBuilder( '\SMW\Store' )
+			->disableOriginalConstructor()
+			->getMockForAbstractClass();
+
+		$this->testEnvironment->registerObject( 'Store', $store );
 	}
 
 	protected function tearDown() {
@@ -70,16 +76,20 @@ class CategoryPropertyAnnotatorTest extends \PHPUnit_Framework_TestCase {
 			$parameters['categories']
 		);
 
-		$instance->setShowHiddenCategoriesState(
+		$instance->showHiddenCategories(
 			$parameters['settings']['smwgShowHiddenCategories']
 		);
 
-		$instance->setCategoryInstanceUsageState(
+		$instance->useCategoryInstance(
 			$parameters['settings']['smwgCategoriesAsInstances']
 		);
 
-		$instance->setCategoryHierarchyUsageState(
+		$instance->useCategoryHierarchy(
 			$parameters['settings']['smwgUseCategoryHierarchy']
+		);
+
+		$instance->useCategoryRedirect(
+			false
 		);
 
 		$instance->addAnnotation();
@@ -108,16 +118,20 @@ class CategoryPropertyAnnotatorTest extends \PHPUnit_Framework_TestCase {
 			$parameters['categories']
 		);
 
-		$instance->setShowHiddenCategoriesState(
+		$instance->showHiddenCategories(
 			$parameters['settings']['smwgShowHiddenCategories']
 		);
 
-		$instance->setCategoryInstanceUsageState(
+		$instance->useCategoryInstance(
 			$parameters['settings']['smwgCategoriesAsInstances']
 		);
 
-		$instance->setCategoryHierarchyUsageState(
+		$instance->useCategoryHierarchy(
 			$parameters['settings']['smwgUseCategoryHierarchy']
+		);
+
+		$instance->useCategoryRedirect(
+			false
 		);
 
 		$instance->addAnnotation();
@@ -168,16 +182,20 @@ class CategoryPropertyAnnotatorTest extends \PHPUnit_Framework_TestCase {
 			$parameters['categories']
 		);
 
-		$instance->setShowHiddenCategoriesState(
+		$instance->showHiddenCategories(
 			$parameters['settings']['smwgShowHiddenCategories']
 		);
 
-		$instance->setCategoryInstanceUsageState(
+		$instance->useCategoryInstance(
 			$parameters['settings']['smwgCategoriesAsInstances']
 		);
 
-		$instance->setCategoryHierarchyUsageState(
+		$instance->useCategoryHierarchy(
 			$parameters['settings']['smwgUseCategoryHierarchy']
+		);
+
+		$instance->useCategoryRedirect(
+			false
 		);
 
 		$instance->addAnnotation();
@@ -185,6 +203,45 @@ class CategoryPropertyAnnotatorTest extends \PHPUnit_Framework_TestCase {
 		$this->semanticDataValidator->assertThatPropertiesAreSet(
 			$expected,
 			$semanticData
+		);
+	}
+
+	public function testAddCategoryOnInvalidRedirect() {
+
+		$store = $this->getMockBuilder( '\SMW\Store' )
+			->disableOriginalConstructor()
+			->setMethods( array( 'getRedirectTarget' ) )
+			->getMockForAbstractClass();
+
+		$store->expects( $this->atLeastOnce() )
+			->method( 'getRedirectTarget' )
+			->will( $this->returnValue( new DIWikiPage( 'Foo', NS_MAIN ) ) );
+
+		$this->testEnvironment->registerObject( 'Store', $store );
+
+		$semanticData = $this->semanticDataFactory
+			->setSubject( new DIWikiPage( __METHOD__, NS_MAIN ) )
+			->newEmptySemanticData();
+
+		$instance = new CategoryPropertyAnnotator(
+			new NullPropertyAnnotator( $semanticData ),
+			array( 'Bar' )
+		);
+
+		$instance->useCategoryRedirect(
+			true
+		);
+
+		$instance->addAnnotation();
+
+		$expected = array(
+			'propertyCount'  => 1,
+			'propertyKeys'   => '_ERRC'
+		);
+
+		$this->semanticDataValidator->assertThatPropertiesAreSet(
+			$expected,
+			$instance->getSemanticData()
 		);
 	}
 

--- a/tests/phpunit/Unit/PropertyAnnotators/ChainablePropertyAnnotatorTest.php
+++ b/tests/phpunit/Unit/PropertyAnnotators/ChainablePropertyAnnotatorTest.php
@@ -49,16 +49,20 @@ class ChainablePropertyAnnotatorTest extends \PHPUnit_Framework_TestCase {
 			$parameters['categories']
 		);
 
-		$categoryPropertyAnnotator->setShowHiddenCategoriesState(
+		$categoryPropertyAnnotator->showHiddenCategories(
 			$parameters['settings']['smwgShowHiddenCategories']
 		);
 
-		$categoryPropertyAnnotator->setCategoryInstanceUsageState(
+		$categoryPropertyAnnotator->useCategoryInstance(
 			$parameters['settings']['smwgCategoriesAsInstances']
 		);
 
-		$categoryPropertyAnnotator->setCategoryHierarchyUsageState(
+		$categoryPropertyAnnotator->useCategoryHierarchy(
 			$parameters['settings']['smwgUseCategoryHierarchy']
+		);
+
+		$categoryPropertyAnnotator->useCategoryRedirect(
+			false
 		);
 
 		$sortKeyPropertyAnnotator = new SortKeyPropertyAnnotator(


### PR DESCRIPTION
This PR is made in reference to: http://wikimedia.7.x6.nabble.com/Query-doesn-t-show-all-rows-tp5074992p5075018.html

This PR addresses or contains:

- Introduces`$smwgUseCategoryRedirect` (enabled by default) to allow finding redirects on categories, use them as annotation value, and if necessary track errors on invalid redirects to make them discoverable beyond `Special:Browse`

![image](https://cloud.githubusercontent.com/assets/1245473/26273815/950eaa2c-3d73-11e7-9eba-d2acb44d20a1.png)

vs.

![image](https://cloud.githubusercontent.com/assets/1245473/26273846/c1c50ac4-3d74-11e7-9f91-f97517891983.png)

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed
