### PR TITLE
QueryProcessor::getProcessedParams fix limit param

### DIFF
--- a/includes/query/SMW_QueryProcessor.php
+++ b/includes/query/SMW_QueryProcessor.php
@@ -47,7 +47,17 @@ class SMWQueryProcessor implements QueryContext {
 	public static function getProcessedParams( array $params, array $printRequests = array(), $unknownInvalid = true, $context = null ) {
 		$validator = self::getValidatorForParams( $params, $printRequests, $unknownInvalid, $context );
 		$validator->processParameters();
-		return $validator->getParameters();
+		$parameters =  $validator->getParameters();
+
+		// Negates some weird behaviour of ParamDefinition::setDefault used in
+		// an individual printer.
+		// Applying $smwgQMaxLimit, $smwgQMaxInlineLimit will happen at a later
+		// stage.
+		if ( isset( $params['limit'] ) && isset( $parameters['limit'] ) ) {
+			$parameters['limit']->setValue( (int)$params['limit'] );
+		}
+
+		return $parameters;
 	}
 
 	/**


### PR DESCRIPTION
This PR is made in reference to: #

This PR addresses or contains:

- Fix `limit` when the value is greater as the `$smwgQMaxLimit`, `$smwgQMaxInlineLimit` where it is reset to the default value despite the global limitation

```
{{#ask: [[Modification date::+]]
 |?Modification date
 |format=csv
 |limit=5000 --> resets to default 100 but should reset to $smwgQMaxInlineLimit
}}

{{#ask: [[Modification date::+]]
 |?Modification date
 |format=csv
 |limit=222 --> is within the $smwgQMaxInlineLimit
}}
```

This PR includes:
- [ ] Tests (unit/integration)
- [x] CI build passed
