### PR TITLE
Capitalize predefined property only, refs 673, 2282

### DIFF
--- a/includes/datavalues/SMW_DV_Property.php
+++ b/includes/datavalues/SMW_DV_Property.php
@@ -175,21 +175,25 @@ class SMWPropertyValue extends SMWDataValue {
 			$this->getOption( self::OPT_QUERY_CONTEXT )
 		);
 
-		$propertyValueParser->requireUpperCase(
-			$this->getContextPage() !== null &&
-			$this->getContextPage()->getNamespace() === SMW_NS_PROPERTY
+		$reqCapitalizedFirstChar = $this->getContextPage() !== null && $this->getContextPage()->getNamespace() === SMW_NS_PROPERTY;
+
+		$propertyValueParser->reqCapitalizedFirstChar(
+			$reqCapitalizedFirstChar
 		);
 
-		list( $propertyName, $inverse ) = $propertyValueParser->parse( $value );
+		list( $propertyName, $capitalizedName, $inverse ) = $propertyValueParser->parse( $value );
 
 		foreach ( $propertyValueParser->getErrors() as $error ) {
 			return $this->addErrorMsg( $error, Message::PARSE );
 		}
 
-		$contentLanguage = $this->getOption( self::OPT_CONTENT_LANGUAGE );
-
 		try {
-			$this->m_dataitem = DIProperty::newFromUserLabel( $propertyName, $inverse, $contentLanguage );
+			$this->m_dataitem = $this->createDataItemFrom(
+				$reqCapitalizedFirstChar,
+				$propertyName,
+				$capitalizedName,
+				$inverse
+			);
 		} catch ( SMWDataItemException $e ) { // happens, e.g., when trying to sort queries by property "-"
 			$this->addErrorMsg( array( 'smw_noproperty', $value ) );
 			$this->m_dataitem = new DIProperty( 'ERROR', false ); // just to have something
@@ -520,6 +524,21 @@ class SMWPropertyValue extends SMWDataValue {
 	 */
 	public function getText() {
 		return $this->m_dataitem->getLabel();
+	}
+
+	private function createDataItemFrom( $reqCapitalizedFirstChar, $propertyName, $capitalizedName, $inverse ) {
+
+		$contentLanguage = $this->getOption( self::OPT_CONTENT_LANGUAGE );
+
+		// Probe on capitalizedFirstChar because we only want predefined
+		// properties (e.g. Has type vs. has type etc.) to adhere the rule while
+		// custom (user) defined properties can appear in any form
+		if ( $reqCapitalizedFirstChar ) {
+			$dataItem = DIProperty::newFromUserLabel( $capitalizedName, $inverse, $contentLanguage );
+			$propertyName = $dataItem->isUserDefined() ? $propertyName : $capitalizedName;
+		}
+
+		return DIProperty::newFromUserLabel( $propertyName, $inverse, $contentLanguage );
 	}
 
 }

--- a/src/DataValues/ValueParsers/PropertyValueParser.php
+++ b/src/DataValues/ValueParsers/PropertyValueParser.php
@@ -4,6 +4,7 @@ namespace SMW\DataValues\ValueParsers;
 
 use SMWPropertyValue as PropertyValue;
 use SMWDataValue as DataValue;
+use SMW\Localizer;
 
 /**
  * @private
@@ -28,7 +29,12 @@ class PropertyValueParser implements ValueParser {
 	/**
 	 * @var boolean
 	 */
-	private $requireUpperCase = false;
+	private $isCapitalLinks = true;
+
+	/**
+	 * @var boolean
+	 */
+	private $reqCapitalizedFirstChar = false;
 
 	/**
 	 * @var boolean
@@ -54,16 +60,26 @@ class PropertyValueParser implements ValueParser {
 	}
 
 	/**
-	 * Enforce upper case for the first character that are used within the
-	 * property namespace in order to avoid invalid types when the $wgCapitalLinks
-	 * setting is disabled.
+	 * Corresponds to the $wgCapitalLinks setting
+	 *
+	 * @since 3.0
+	 *
+	 * @param boolean $isCapitalLinks
+	 */
+	public function isCapitalLinks( $isCapitalLinks ) {
+		$this->isCapitalLinks = (bool)$isCapitalLinks;
+	}
+
+	/**
+	 * Whether upper case for the first character is required or not in case of
+	 * $wgCapitalLinks = false.
 	 *
 	 * @since 2.5
 	 *
-	 * @param boolean $requireUpperCase
+	 * @param boolean $reqCapitalizedFirstChar
 	 */
-	public function requireUpperCase( $requireUpperCase ) {
-		$this->requireUpperCase = (bool)$requireUpperCase;
+	public function reqCapitalizedFirstChar( $reqCapitalizedFirstChar ) {
+		$this->reqCapitalizedFirstChar = (bool)$reqCapitalizedFirstChar;
 	}
 
 	/**
@@ -96,7 +112,7 @@ class PropertyValueParser implements ValueParser {
 		);
 
 		if ( !$this->doCheckValidCharacters( $userValue ) ) {
-			return array( null, null );
+			return array( null, null, null );
 		}
 
 		return $this->getNormalizedValueFrom( $userValue );
@@ -140,27 +156,38 @@ class PropertyValueParser implements ValueParser {
 	private function getNormalizedValueFrom( $value ) {
 
 		$inverse = false;
-
-		if ( $this->requireUpperCase ) {
-			$value = $this->applyUpperCaseToLeadingCharacter( $value );
-		}
+		$capitalizedName = '';
 
 		// slightly normalise label
-		$propertyName = smwfNormalTitleText( ltrim( rtrim( $value, ' ]' ), ' [' ) );
+		$propertyName = $this->doNormalize(
+			ltrim( rtrim( $value, ' ]' ), ' [' ),
+			$this->isCapitalLinks
+		);
 
-		if ( ( $propertyName !== '' ) && ( $propertyName { 0 } == '-' ) ) { // property refers to an inverse
-			$propertyName = smwfNormalTitleText( (string)substr( $value, 1 ) );
+		if ( $this->reqCapitalizedFirstChar ) {
+			$capitalizedName = $this->doNormalize( $propertyName, true );
+		}
+
+		// property refers to an inverse
+		if ( ( $propertyName !== '' ) && ( $propertyName { 0 } == '-' ) ) {
+			$propertyName = $this->doNormalize( (string)substr( $value, 1 ), $this->isCapitalLinks );
 			/// NOTE The cast is necessary at least in PHP 5.3.3 to get string '' instead of boolean false.
 			/// NOTE It is necessary to normalize again here, since normalization may uppercase the first letter.
 			$inverse = true;
 		}
 
-		return array( $propertyName, $inverse );
+		return array( $propertyName, $capitalizedName, $inverse );
 	}
 
-	private function applyUpperCaseToLeadingCharacter( $value ) {
-		// ucfirst is not utf-8 safe hence the reliance on mb_strtoupper
-		return mb_strtoupper( mb_substr( $value, 0, 1 ) ) . mb_substr( $value, 1 );
+	private function doNormalize( $text, $isCapitalLinks ) {
+
+		$text = trim( $text );
+
+		if ( $isCapitalLinks ) {
+			$text = Localizer::getInstance()->getContentLanguage()->ucfirst( $text );
+		}
+
+		return str_replace( '_', ' ', $text );
 	}
 
 }

--- a/src/Services/DataValueServices.php
+++ b/src/Services/DataValueServices.php
@@ -62,6 +62,10 @@ return array(
 			$containerBuilder->singleton( 'Settings' )->get( 'smwgPropertyInvalidCharacterList' )
 		);
 
+		$propertyValueParser->isCapitalLinks(
+			$GLOBALS['wgCapitalLinks']
+		);
+
 		return $propertyValueParser;
 	},
 

--- a/tests/phpunit/Integration/JSONScript/TestCases/p-0401.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/p-0401.json
@@ -8,6 +8,16 @@
 		},
 		{
 			"namespace": "SMW_NS_PROPERTY",
+			"page": "wikidata id",
+			"contents": "[[has type::string]]"
+		},
+		{
+			"namespace": "SMW_NS_PROPERTY",
+			"page": "founded",
+			"contents": "[[has type::date]] [[wikidata id::P571]]"
+		},
+		{
+			"namespace": "SMW_NS_PROPERTY",
 			"page": "set-non-capital-property",
 			"contents": "{{#set:|has type=boolean}} [[Category:Foo]]"
 		},
@@ -101,6 +111,27 @@
 					"propertyValues": [
 						"Boolean",
 						"Foo"
+					]
+				}
+			}
+		},
+		{
+			"type": "parser",
+			"about": "#4 check has type despite wgCapitalLinks setting, user-defined property is kept lower case",
+			"subject": "founded",
+			"namespace": "SMW_NS_PROPERTY",
+			"assert-store": {
+				"semantic-data": {
+					"strictPropertyValueMatch": false,
+					"propertyCount": 4,
+					"propertyKeys": [
+						"_SKEY",
+						"_MDAT",
+						"_TYPE",
+						"wikidata id"
+					],
+					"propertyValues": [
+						"P571"
 					]
 				}
 			}

--- a/tests/phpunit/Unit/DataValues/ValueParsers/PropertyValueParserTest.php
+++ b/tests/phpunit/Unit/DataValues/ValueParsers/PropertyValueParserTest.php
@@ -33,7 +33,7 @@ class PropertyValueParserTest extends \PHPUnit_Framework_TestCase {
 			$invalidCharacterList
 		);
 
-		list( $propertyName, $inverse ) = $instance->parse( $value );
+		list( $propertyName, $capitalizedName, $inverse ) = $instance->parse( $value );
 
 		$this->assertSame(
 			$expectedPropertyName,
@@ -46,16 +46,22 @@ class PropertyValueParserTest extends \PHPUnit_Framework_TestCase {
 		);
 	}
 
-	public function testEnforceUpperCase() {
+	public function testEnforceFirstCharUpperCase() {
 
 		$instance = new PropertyValueParser();
-		$instance->requireUpperCase( true );
+		$instance->isCapitalLinks( false );
+		$instance->reqCapitalizedFirstChar( true );
 
-		list( $propertyName, $inverse ) = $instance->parse( 'foo' );
+		list( $propertyName, $capitalizedName, $inverse ) = $instance->parse( 'foo' );
+
+		$this->assertSame(
+			'foo',
+			$propertyName
+		);
 
 		$this->assertSame(
 			'Foo',
-			$propertyName
+			$capitalizedName
 		);
 	}
 
@@ -63,6 +69,34 @@ class PropertyValueParserTest extends \PHPUnit_Framework_TestCase {
 
 		$provider[] = array(
 			'Foo',
+			array(),
+			'Foo',
+			false
+		);
+
+		$provider[] = array(
+			'[ Foo',
+			array(),
+			'Foo',
+			false
+		);
+
+		$provider[] = array(
+			'[Foo',
+			array(),
+			'Foo',
+			false
+		);
+
+		$provider[] = array(
+			'Foo ]',
+			array(),
+			'Foo',
+			false
+		);
+
+		$provider[] = array(
+			'Foo]',
 			array(),
 			'Foo',
 			false


### PR DESCRIPTION
This PR is made in reference to: #673, #2282, 
http://wikimedia.7.x6.nabble.com/various-semantic-properties-related-isssues-tp5074872p5074873.html

This PR addresses or contains:

- In case of `$wgCapitalLinks=false`, restrict property name uppercase conversion on special properties only 

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed
