### PR TITLE
Count and limit expensive #ask/#show functions, refs 2469

### DIFF
--- a/DefaultSettings.php
+++ b/DefaultSettings.php
@@ -472,6 +472,31 @@ return array(
 	##
 
 	###
+	# Expensive threshold
+	#
+	# The threshold defined in seconds denotes the ceiling as to when a #ask or
+	# #show call is classified as expensive and will count towards the
+	# $smwgQExpensiveExecutionLimit setting.
+	#
+	# @since 3.0
+	# @default 10
+	##
+	'smwgQExpensiveThreshold' => 10,
+	##
+
+	###
+	# Limit of expensive #ask/#show functions
+	#
+	# The limit will count all classified #ask/#show parser functions and restricts
+	# further use on pages that exceed that limit.
+	#
+	# @since 3.0
+	# @default false (== no limit)
+	##
+	'smwgQExpensiveExecutionLimit' => false,
+	##
+
+	###
 	# The below setting defines which query features should be available by
 	# default.
 	#

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -549,5 +549,6 @@
 	"smw-format-datatable-previous": "Previous",
 	"smw-format-datatable-sortascending": ": activate to sort column ascending",
 	"smw-format-datatable-sortdescending": ": activate to sort column descending",
-	"smw-category-invalid-redirect-target": "Category \"$1\" contains an invalid redirect target to a non-category namespace."
+	"smw-category-invalid-redirect-target": "Category \"$1\" contains an invalid redirect target to a non-category namespace.",
+	"smw-parser-function-expensive-execution-limit": "The parser function has reached the limit for expensive executions (see [https://www.semantic-mediawiki.org/wiki/Help:$smwgQExpensiveExecutionLimit $smwgQExpensiveExecutionLimit])."
 }

--- a/includes/Settings.php
+++ b/includes/Settings.php
@@ -109,6 +109,8 @@ class Settings extends Options {
 			'smwgQConceptMaxDepth' => $GLOBALS['smwgQConceptMaxDepth'],
 			'smwgQConceptFeatures' => $GLOBALS['smwgQConceptFeatures'],
 			'smwgQConceptCacheLifetime' => $GLOBALS['smwgQConceptCacheLifetime'],
+			'smwgQExpensiveThreshold' => $GLOBALS['smwgQExpensiveThreshold'],
+			'smwgQExpensiveExecutionLimit' => $GLOBALS['smwgQExpensiveExecutionLimit'],
 			'smwgQuerySources' => $GLOBALS['smwgQuerySources'],
 			'smwgQTemporaryTablesAutoCommitMode' => $GLOBALS['smwgQTemporaryTablesAutoCommitMode'],
 			'smwgResultFormats' => $GLOBALS['smwgResultFormats'],

--- a/src/ParserFunctions/ExpensiveFuncExecutionWatcher.php
+++ b/src/ParserFunctions/ExpensiveFuncExecutionWatcher.php
@@ -1,0 +1,113 @@
+<?php
+
+namespace SMW\ParserFunctions;
+
+use SMW\ParserData;
+use SMWQuery as Query;
+
+/**
+ * @private
+ *
+ * @license GNU GPL v2+
+ * @since 3.0
+ *
+ * @author mwjames
+ */
+class ExpensiveFuncExecutionWatcher {
+
+	/**
+	 * Idenitifer
+	 */
+	const EXPENSIVE_COUNTER = 'smw-expensiveparsercount';
+
+	/**
+	 * @var ParserData
+	 */
+	private $parserData;
+
+	/**
+	 * @var integer
+	 */
+	private $expensiveThreshold = 10;
+
+	/**
+	 * @var integer|boolean
+	 */
+	private $expensiveExecutionLimit = false;
+
+	/**
+	 * @since 3.0
+	 *
+	 * @param ParserData $parserData
+	 */
+	public function __construct( ParserData $parserData ) {
+		$this->parserData = $parserData;
+	}
+
+	/**
+	 * @since 3.0
+	 *
+	 * @param integer $expensiveThreshold
+	 */
+	public function setExpensiveThreshold( $expensiveThreshold ) {
+		$this->expensiveThreshold = $expensiveThreshold;
+	}
+
+	/**
+	 * @since 3.0
+	 *
+	 * @param integer|boolean $expensiveExecutionLimit
+	 */
+	public function setExpensiveExecutionLimit( $expensiveExecutionLimit ) {
+		$this->expensiveExecutionLimit = $expensiveExecutionLimit;
+	}
+
+	/**
+	 * @since 3.0
+	 *
+	 * @param Query $query
+	 *
+	 * @return boolean
+	 */
+	public function hasReachedExpensiveLimit( Query $query ) {
+
+		if ( $this->expensiveExecutionLimit === false ) {
+			return false;
+		}
+
+		if ( $query->getLimit() == 0 ) {
+			return false;
+		}
+
+		if ( $this->parserData->getOutput()->getExtensionData( self::EXPENSIVE_COUNTER ) < $this->expensiveExecutionLimit ) {
+			return false;
+		}
+
+		return true;
+	}
+
+	/**
+	 * @since 3.0
+	 *
+	 * @param Query $query
+	 *
+	 * @return boolean
+	 */
+	public function incrementExpensiveCount( Query $query ) {
+
+		if ( $this->expensiveExecutionLimit === false || $query->getLimit() == 0 || $query->getOption( Query::PROC_QUERY_TIME ) < $this->expensiveThreshold  ) {
+			return;
+		}
+
+		$output = $this->parserData->getOutput();
+		$expensiveCount = $output->getExtensionData( self::EXPENSIVE_COUNTER );
+
+		if ( !is_int( $expensiveCount ) ) {
+			$expensiveCount = 0;
+		}
+
+		$expensiveCount++;
+		$output->setExtensionData( self::EXPENSIVE_COUNTER, $expensiveCount );
+	}
+
+}

--- a/src/ParserFunctions/ShowParserFunction.php
+++ b/src/ParserFunctions/ShowParserFunction.php
@@ -2,10 +2,6 @@
 
 namespace SMW\ParserFunctions;
 
-use SMW\ParserData;
-use SMW\MessageFormatter;
-use SMW\Utils\CircularReferenceGuard;
-
 /**
  * Class that provides the {{#show}} parser function
  *
@@ -17,31 +13,17 @@ use SMW\Utils\CircularReferenceGuard;
 class ShowParserFunction {
 
 	/**
-	 * @var ParserData
+	 * @var AskParserFunction
 	 */
-	private $parserData;
-
-	/**
-	 * @var MessageFormatter
-	 */
-	private $messageFormatter;
-
-	/**
-	 * @var CircularReferenceGuard
-	 */
-	private $circularReferenceGuard;
+	private $askParserFunction;
 
 	/**
 	 * @since 1.9
 	 *
-	 * @param ParserData $parserData
-	 * @param MessageFormatter $messageFormatter
-	 * @param CircularReferenceGuard $circularReferenceGuard
+	 * @param AskParserFunction $askParserFunction
 	 */
-	public function __construct( ParserData $parserData, MessageFormatter $messageFormatter, CircularReferenceGuard $circularReferenceGuard ) {
-		$this->parserData = $parserData;
-		$this->messageFormatter = $messageFormatter;
-		$this->circularReferenceGuard = $circularReferenceGuard;
+	public function __construct( AskParserFunction $askParserFunction ) {
+		$this->askParserFunction = $askParserFunction;
 	}
 
 	/**
@@ -59,16 +41,8 @@ class ShowParserFunction {
 	 * @return string|null
 	 */
 	public function parse( array $rawParams ) {
-
-		$instance = new AskParserFunction(
-			$this->parserData,
-			$this->messageFormatter,
-			$this->circularReferenceGuard
-		);
-
-		$instance->setShowMode( true );
-
-		return $instance->parse( $rawParams );
+		$this->askParserFunction->setShowMode( true );
+		return $this->askParserFunction->parse( $rawParams );
 	}
 
 	/**
@@ -80,7 +54,7 @@ class ShowParserFunction {
 	 * @return string|null
 	 */
 	public function isQueryDisabled() {
-		return $this->messageFormatter->addFromKey( 'smw_iq_disabled' )->getHtml();
+		return $this->askParserFunction->isQueryDisabled();
 	}
 
 }

--- a/tests/phpunit/Integration/JSONScript/JsonTestCaseScriptRunnerTest.php
+++ b/tests/phpunit/Integration/JSONScript/JsonTestCaseScriptRunnerTest.php
@@ -186,6 +186,8 @@ class JsonTestCaseScriptRunnerTest extends JsonTestCaseScriptRunner {
 			'smwgEntityCollation',
 			'smwgSparqlQFeatures',
 			'smwgUseCategoryRedirect',
+			'smwgQExpensiveThreshold',
+			'smwgQExpensiveExecutionLimit',
 
 			// MW related
 			'wgLanguageCode',

--- a/tests/phpunit/Integration/JSONScript/TestCases/p-0707.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/p-0707.json
@@ -1,0 +1,45 @@
+{
+	"description": "Test `#ask` with enabled execution limit (`wgContLang=en`, `wgLang=en`, `smwgQExpensiveThreshold`, `smwgQExpensiveExecutionLimit`)",
+	"setup": [
+		{
+			"namespace": "SMW_NS_PROPERTY",
+			"page": "Has text",
+			"contents": "[[Has type::Text]]"
+		},
+		{
+			"page": "Example/P0707/1",
+			"contents": "[[Has text::123]]"
+		},
+		{
+			"page": "Example/P0707/Q.1",
+			"contents": "{{#ask: [[Has text::+]] |?Has text }} {{#ask: [[Has text::123]] |?Has text }}"
+		}
+	],
+	"tests": [
+		{
+			"type": "parser",
+			"about": "#0",
+			"subject": "Example/P0707/Q.1",
+			"assert-output": {
+				"to-contain": [
+					"title=\"Example/P0707/1\">Example/P0707/1",
+					"title=\"The parser function has reached the limit for expensive executions"
+				]
+			}
+		}
+	],
+	"settings": {
+		"wgContLang": "en",
+		"wgLang": "en",
+		"smwgQExpensiveExecutionLimit": 1,
+		"smwgQExpensiveThreshold": 0,
+		"smwgNamespacesWithSemanticLinks": {
+			"NS_MAIN": true
+		}
+	},
+	"meta": {
+		"version": "2",
+		"is-incomplete": false,
+		"debug": false
+	}
+}

--- a/tests/phpunit/Unit/ParserFunctions/ExpensiveFuncExecutionWatcherTest.php
+++ b/tests/phpunit/Unit/ParserFunctions/ExpensiveFuncExecutionWatcherTest.php
@@ -1,0 +1,149 @@
+<?php
+
+namespace SMW\Tests\ParserFunctions;
+
+use SMW\ParserFunctions\ExpensiveFuncExecutionWatcher;
+
+/**
+ * @covers \SMW\ParserFunctions\ExpensiveFuncExecutionWatcher
+ * @group semantic-mediawiki
+ *
+ * @license GNU GPL v2+
+ * @since  3.0
+ *
+ * @author mwjames
+ */
+class ExpensiveFuncExecutionWatcherTest extends \PHPUnit_Framework_TestCase {
+
+	private $parserData;
+
+	protected function setUp() {
+		parent::setUp();
+
+		$this->parserData = $this->getMockBuilder( '\SMW\ParserData' )
+			->disableOriginalConstructor()
+			->getMock();
+	}
+
+	public function testCanConstruct() {
+
+		$this->assertInstanceOf(
+			'\SMW\ParserFunctions\ExpensiveFuncExecutionWatcher',
+			new ExpensiveFuncExecutionWatcher( $this->parserData )
+		);
+	}
+
+	public function testHasReachedExpensiveLimit() {
+
+		$parserOutput = $this->getMockBuilder( '\ParserOutput' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$parserOutput->expects( $this->once() )
+			->method( 'getExtensionData' )
+			->will( $this->returnValue( 42 ) );
+
+		$query = $this->getMockBuilder( '\SMWQuery' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$query->expects( $this->once() )
+			->method( 'getLimit' )
+			->will( $this->returnValue( 100 ) );
+
+		$this->parserData->expects( $this->once() )
+			->method( 'getOutput' )
+			->will( $this->returnValue( $parserOutput ) );
+
+		$instance = new ExpensiveFuncExecutionWatcher(
+			$this->parserData
+		);
+
+		$instance->setExpensiveExecutionLimit( 1 );
+
+		$this->assertTrue(
+			$instance->hasReachedExpensiveLimit( $query )
+		);
+	}
+
+	public function testIncrementExpensiveCountOnExsitingCounter() {
+
+		$parserOutput = $this->getMockBuilder( '\ParserOutput' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$parserOutput->expects( $this->once() )
+			->method( 'getExtensionData' )
+			->will( $this->returnValue( 42 ) );
+
+		$parserOutput->expects( $this->once() )
+			->method( 'setExtensionData' )
+			->with(
+				$this->equalTo( ExpensiveFuncExecutionWatcher::EXPENSIVE_COUNTER ),
+				$this->equalTo( 43 ) );
+
+		$query = $this->getMockBuilder( '\SMWQuery' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$query->expects( $this->once() )
+			->method( 'getLimit' )
+			->will( $this->returnValue( 100 ) );
+
+		$query->expects( $this->once() )
+			->method( 'getOption' )
+			->will( $this->returnValue( 100 ) );
+
+		$this->parserData->expects( $this->any() )
+			->method( 'getOutput' )
+			->will( $this->returnValue( $parserOutput ) );
+
+		$instance = new ExpensiveFuncExecutionWatcher(
+			$this->parserData
+		);
+
+		$instance->setExpensiveThreshold( 1 );
+		$instance->setExpensiveExecutionLimit( 1 );
+
+		$instance->incrementExpensiveCount( $query );
+	}
+
+	public function testIncrementExpensiveCountOnNull() {
+
+		$parserOutput = $this->getMockBuilder( '\ParserOutput' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$parserOutput->expects( $this->once() )
+			->method( 'setExtensionData' )
+			->with(
+				$this->equalTo( ExpensiveFuncExecutionWatcher::EXPENSIVE_COUNTER ),
+				$this->equalTo( 1 ) );
+
+		$query = $this->getMockBuilder( '\SMWQuery' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$query->expects( $this->once() )
+			->method( 'getLimit' )
+			->will( $this->returnValue( 100 ) );
+
+		$query->expects( $this->once() )
+			->method( 'getOption' )
+			->will( $this->returnValue( 100 ) );
+
+		$this->parserData->expects( $this->any() )
+			->method( 'getOutput' )
+			->will( $this->returnValue( $parserOutput ) );
+
+		$instance = new ExpensiveFuncExecutionWatcher(
+			$this->parserData
+		);
+
+		$instance->setExpensiveThreshold( 1 );
+		$instance->setExpensiveExecutionLimit( 1 );
+
+		$instance->incrementExpensiveCount( $query );
+	}
+
+}

--- a/tests/phpunit/Unit/ParserFunctions/ShowParserFunctionTest.php
+++ b/tests/phpunit/Unit/ParserFunctions/ShowParserFunctionTest.php
@@ -5,6 +5,7 @@ namespace SMW\Tests\ParserFunctions;
 use ParserOutput;
 use SMW\ApplicationFactory;
 use SMW\ParserFunctions\ShowParserFunction;
+use SMW\ParserFunctions\AskParserFunction;
 use SMW\Tests\TestEnvironment;
 use Title;
 
@@ -21,6 +22,9 @@ class ShowParserFunctionTest extends \PHPUnit_Framework_TestCase {
 
 	private $testEnvironment;
 	private $semanticDataValidator;
+	private $messageFormatter;
+	private $circularReferenceGuard;
+	private $expensiveFuncExecutionWatcher;
 
 	protected function setUp() {
 		parent::setUp();
@@ -31,6 +35,22 @@ class ShowParserFunctionTest extends \PHPUnit_Framework_TestCase {
 		$this->testEnvironment->addConfiguration( 'smwgQueryDurationEnabled', false );
 		$this->testEnvironment->addConfiguration( 'smwgQueryResultCacheType', false );
 		$this->testEnvironment->addConfiguration( 'smwgQFilterDuplicates', false );
+
+		$this->messageFormatter = $this->getMockBuilder( '\SMW\MessageFormatter' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$this->circularReferenceGuard = $this->getMockBuilder( '\SMW\Utils\CircularReferenceGuard' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$this->expensiveFuncExecutionWatcher = $this->getMockBuilder( '\SMW\ParserFunctions\ExpensiveFuncExecutionWatcher' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$this->expensiveFuncExecutionWatcher->expects( $this->any() )
+			->method( 'hasReachedExpensiveLimit' )
+			->will( $this->returnValue( false ) );
 	}
 
 	protected function tearDown() {
@@ -44,17 +64,16 @@ class ShowParserFunctionTest extends \PHPUnit_Framework_TestCase {
 			->disableOriginalConstructor()
 			->getMock();
 
-		$messageFormatter = $this->getMockBuilder( '\SMW\MessageFormatter' )
-			->disableOriginalConstructor()
-			->getMock();
-
-		$circularReferenceGuard = $this->getMockBuilder( '\SMW\Utils\CircularReferenceGuard' )
-			->disableOriginalConstructor()
-			->getMock();
+		$askParserFunction = new AskParserFunction(
+			$parserData,
+			$this->messageFormatter,
+			$this->circularReferenceGuard,
+			$this->expensiveFuncExecutionWatcher
+		);
 
 		$this->assertInstanceOf(
 			'\SMW\ParserFunctions\ShowParserFunction',
-			new ShowParserFunction( $parserData, $messageFormatter, $circularReferenceGuard )
+			new ShowParserFunction( $askParserFunction )
 		);
 	}
 
@@ -68,18 +87,13 @@ class ShowParserFunctionTest extends \PHPUnit_Framework_TestCase {
 			new ParserOutput()
 		);
 
-		$messageFormatter = $this->getMockBuilder( '\SMW\MessageFormatter' )
-			->disableOriginalConstructor()
-			->getMock();
-
-		$circularReferenceGuard = $this->getMockBuilder( '\SMW\Utils\CircularReferenceGuard' )
-			->disableOriginalConstructor()
-			->getMock();
-
 		$instance = new ShowParserFunction(
-			$parserData,
-			$messageFormatter,
-			$circularReferenceGuard
+			new AskParserFunction(
+				$parserData,
+				$this->messageFormatter,
+				$this->circularReferenceGuard,
+				$this->expensiveFuncExecutionWatcher
+			)
 		);
 
 		$result = $instance->parse( $params );
@@ -97,25 +111,20 @@ class ShowParserFunctionTest extends \PHPUnit_Framework_TestCase {
 			->disableOriginalConstructor()
 			->getMock();
 
-		$messageFormatter = $this->getMockBuilder( '\SMW\MessageFormatter' )
-			->disableOriginalConstructor()
-			->getMock();
-
-		$messageFormatter->expects( $this->any() )
+		$this->messageFormatter->expects( $this->any() )
 			->method( 'addFromKey' )
 			->will( $this->returnSelf() );
 
-		$messageFormatter->expects( $this->once() )
+		$this->messageFormatter->expects( $this->once() )
 			->method( 'getHtml' );
 
-		$circularReferenceGuard = $this->getMockBuilder( '\SMW\Utils\CircularReferenceGuard' )
-			->disableOriginalConstructor()
-			->getMock();
-
 		$instance = new ShowParserFunction(
-			$parserData,
-			$messageFormatter,
-			$circularReferenceGuard
+			new AskParserFunction(
+				$parserData,
+				$this->messageFormatter,
+				$this->circularReferenceGuard,
+				$this->expensiveFuncExecutionWatcher
+			)
 		);
 
 		$instance->isQueryDisabled();
@@ -131,18 +140,13 @@ class ShowParserFunctionTest extends \PHPUnit_Framework_TestCase {
 			new ParserOutput()
 		);
 
-		$messageFormatter = $this->getMockBuilder( '\SMW\MessageFormatter' )
-			->disableOriginalConstructor()
-			->getMock();
-
-		$circularReferenceGuard = $this->getMockBuilder( '\SMW\Utils\CircularReferenceGuard' )
-			->disableOriginalConstructor()
-			->getMock();
-
 		$instance = new ShowParserFunction(
-			$parserData,
-			$messageFormatter,
-			$circularReferenceGuard
+			new AskParserFunction(
+				$parserData,
+				$this->messageFormatter,
+				$this->circularReferenceGuard,
+				$this->expensiveFuncExecutionWatcher
+			)
 		);
 
 		$instance->parse( $params );
@@ -164,18 +168,13 @@ class ShowParserFunctionTest extends \PHPUnit_Framework_TestCase {
 			new ParserOutput()
 		);
 
-		$messageFormatter = $this->getMockBuilder( '\SMW\MessageFormatter' )
-			->disableOriginalConstructor()
-			->getMock();
-
-		$circularReferenceGuard = $this->getMockBuilder( '\SMW\Utils\CircularReferenceGuard' )
-			->disableOriginalConstructor()
-			->getMock();
-
 		$instance = new ShowParserFunction(
-			$parserData,
-			$messageFormatter,
-			$circularReferenceGuard
+			new AskParserFunction(
+				$parserData,
+				$this->messageFormatter,
+				$this->circularReferenceGuard,
+				$this->expensiveFuncExecutionWatcher
+			)
 		);
 
 		// #2 [[..]] is not acknowledged therefore displays an error message


### PR DESCRIPTION
This PR is made in reference to: #2469 

This PR addresses or contains:

- `$smwgQExpensiveThreshold` (Threshold in seconds that define an expensive #ask/#show function) and
- `$smwgQExpensiveExecutionLimit` (Limit of expensive #ask/#show functions)
-  It counts all expensive functions (as per definition) and cut-off any #ask/#show that follows the reached limit in a semi sequential process with the exception that a #ask/#show (limit=0) can still be executed even though the counter has reached the limit. In case of `$smwgQExpensiveThreshold=0` any #ask/#show will be counted towards the limit.
- The limit is disabled by default.

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed
