### PR TITLE
RequestOptions to cast int on limit/offset, refs 2479

### DIFF
--- a/includes/articlepages/SMW_OrderedListPage.php
+++ b/includes/articlepages/SMW_OrderedListPage.php
@@ -59,9 +59,10 @@ abstract class SMWOrderedListPage extends Article {
 	 * output.
 	 */
 	public function view() {
-		global $wgRequest, $wgUser;
+		global $wgUser;
 
 		$outputPage = $this->getContext()->getOutput();
+		$request = $this->getContext()->getRequest();
 
 		if ( !ApplicationFactory::getInstance()->getSettings()->get( 'smwgSemanticsEnabled' ) ) {
 			$outputPage->setPageTitle( $this->getTitle()->getPrefixedText() );
@@ -88,8 +89,8 @@ abstract class SMWOrderedListPage extends Article {
 		parent::view();
 
 		// Copied from CategoryPage
-		$diff = $wgRequest->getVal( 'diff' );
-		$diffOnly = $wgRequest->getBool( 'diffonly', $wgUser->getOption( 'diffonly' ) );
+		$diff = $request->getVal( 'diff' );
+		$diffOnly = $request->getBool( 'diffonly', $wgUser->getOption( 'diffonly' ) );
 		if ( !isset( $diff ) || !$diffOnly ) {
 			$this->showList();
 		}
@@ -133,8 +134,8 @@ abstract class SMWOrderedListPage extends Article {
 	 * @since 2.4
 	 */
 	protected function getNavigationLinks( $msgKey, array $diWikiPages, $default = 50 ) {
-		global $wgRequest;
 
+		$request = $this->getContext()->getRequest();
 		$mwCollaboratorFactory = ApplicationFactory::getInstance()->newMwCollaboratorFactory();
 
 		$messageBuilder = $mwCollaboratorFactory->newMessageBuilder(
@@ -150,14 +151,14 @@ abstract class SMWOrderedListPage extends Article {
 		if ( $resultCount > 0 ) {
 			$navigation = $messageBuilder->prevNextToText(
 				$title,
-				$wgRequest->getVal( 'limit', $default ),
-				$wgRequest->getVal( 'offset', '0' ),
+				intval( $request->getVal( 'limit', $default ) ),
+				intval( $request->getVal( 'offset', '0' ) ),
 				array(
-					'value'  => $wgRequest->getVal( 'value', '' ),
-					'from'   => $wgRequest->getVal( 'from', '' ),
-					'until'  => $wgRequest->getVal( 'until', '' )
+					'value'  => $request->getVal( 'value', '' ),
+					'from'   => $request->getVal( 'from', '' ),
+					'until'  => $request->getVal( 'until', '' )
 				),
-				$resultCount < $wgRequest->getVal( 'limit', $default )
+				$resultCount < $request->getVal( 'limit', $default )
 			);
 
 			$navigation = Html::rawElement('div', array(), $navigation );
@@ -175,12 +176,12 @@ abstract class SMWOrderedListPage extends Article {
 	 * Main method for adding all additional HTML to the output stream.
 	 */
 	protected function showList() {
-		global $wgRequest;
 
 		$outputPage = $this->getContext()->getOutput();
+		$request = $this->getContext()->getRequest();
 
-		$this->from = $wgRequest->getVal( 'from', '' );
-		$this->until = $wgRequest->getVal( 'until', '' );
+		$this->from = $request->getVal( 'from', '' );
+		$this->until = $request->getVal( 'until', '' );
 
 		if ( $this->initParameters() ) {
 			$outputPage->addHTML( $this->getHtml() );

--- a/includes/articlepages/SMW_PropertyPage.php
+++ b/includes/articlepages/SMW_PropertyPage.php
@@ -228,20 +228,22 @@ class SMWPropertyPage extends SMWOrderedListPage {
 	 * @return string
 	 */
 	protected function getPropertyValueList() {
-		global $smwgPropertyPagingLimit, $wgRequest;
+		global $smwgPropertyPagingLimit;
 
 		 // limit==0: configuration setting to disable this completely
 		if ( $this->limit < 1 ) {
 			return '';
 		}
 
+		$request = $this->getContext()->getRequest();
+
 		$diWikiPages = array();
 		$options = SMWPageLister::getRequestOptions( $this->limit, $this->from, $this->until );
 
-		$options->limit = $wgRequest->getVal( 'limit', $smwgPropertyPagingLimit );
-		$options->offset = $wgRequest->getVal( 'offset', '0' );
+		$options->limit = intval( $request->getVal( 'limit', $smwgPropertyPagingLimit ) );
+		$options->offset = intval( $request->getVal( 'offset', '0' ) );
 
-		if ( ( $value = $wgRequest->getVal( 'value', '' ) ) !== '' ) {
+		if ( ( $value = $request->getVal( 'value', '' ) ) !== '' ) {
 			$diWikiPages = $this->doQuerySubjectListWithValue( $value, $options );
 		} else {
 			$diWikiPages = $this->store->getAllPropertySubjects( $this->mProperty, $options );

--- a/src/RequestOptions.php
+++ b/src/RequestOptions.php
@@ -118,7 +118,7 @@ class RequestOptions {
 	 * @param integer $limit
 	 */
 	public function setLimit( $limit ) {
-		$this->limit = $limit;
+		$this->limit = (int)$limit;
 	}
 
 	/**
@@ -127,7 +127,7 @@ class RequestOptions {
 	 * @return integer
 	 */
 	public function getLimit() {
-		return $this->limit;
+		return (int)$this->limit;
 	}
 
 	/**
@@ -136,7 +136,7 @@ class RequestOptions {
 	 * @param integer $offset
 	 */
 	public function setOffset( $offset ) {
-		$this->offset = $offset;
+		$this->offset = (int)$offset;
 	}
 
 	/**
@@ -145,7 +145,7 @@ class RequestOptions {
 	 * @return integer
 	 */
 	public function getOffset() {
-		return $this->offset;
+		return (int)$this->offset;
 	}
 
 	/**

--- a/src/SQLStore/RequestOptionsProcessor.php
+++ b/src/SQLStore/RequestOptionsProcessor.php
@@ -49,12 +49,12 @@ class RequestOptionsProcessor {
 			return $sqlConds;
 		}
 
-		if ( $requestOptions->limit > 0 ) {
-			$sqlConds['LIMIT'] = $requestOptions->limit;
+		if ( $requestOptions->getLimit() > 0 ) {
+			$sqlConds['LIMIT'] = $requestOptions->getLimit();
 		}
 
-		if ( $requestOptions->offset > 0 ) {
-			$sqlConds['OFFSET'] = $requestOptions->offset;
+		if ( $requestOptions->getOffset() > 0 ) {
+			$sqlConds['OFFSET'] = $requestOptions->getOffset();
 		}
 
 		if ( ( $valueCol !== '' ) && ( $requestOptions->sort ) ) {

--- a/tests/phpunit/Integration/JSONScript/ParserTestCaseProcessor.php
+++ b/tests/phpunit/Integration/JSONScript/ParserTestCaseProcessor.php
@@ -132,15 +132,18 @@ class ParserTestCaseProcessor extends \PHPUnit_Framework_TestCase {
 
 		$parserOutput = UtilityFactory::getInstance()->newPageReader()->getEditInfo( $subject->getTitle() )->output;
 
-		if ( isset( $case['assert-output']['withOutputPageContext'] ) && $case['assert-output']['withOutputPageContext'] ) {
+		if ( isset( $case['assert-output']['onOutputPage'] ) && $case['assert-output']['onOutputPage'] ) {
 			$context = new \RequestContext();
 			$context->setTitle( $subject->getTitle() );
 			// Ensures the OutputPageBeforeHTML hook is run
 			$context->getOutput()->addParserOutput( $parserOutput );
 			$output = $context->getOutput()->getHtml();
-		} elseif ( isset( $case['assert-output']['onPageView'] ) && $case['assert-output']['onPageView'] ) {
-			$context = new \RequestContext();
-			$context->setTitle( $subject->getTitle() );
+		} elseif ( isset( $case['assert-output']['onPageView'] ) ) {
+			$parameters = isset( $case['assert-output']['onPageView']['parameters'] ) ? $case['assert-output']['onPageView']['parameters'] : array();
+			$context = \RequestContext::newExtraneousContext(
+				$subject->getTitle(),
+				$parameters
+			);
 			\Article::newFromTitle( $subject->getTitle(), $context )->view();
 			$output = $context->getOutput()->getHtml();
 		} else {

--- a/tests/phpunit/Integration/JSONScript/TestCases/p-1001.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/p-1001.json
@@ -1,0 +1,72 @@
+{
+	"description": "Test property page with parameters (#2479, `wgContLang=en`, `wgLang=en`)",
+	"setup": [
+		{
+			"namespace": "SMW_NS_PROPERTY",
+			"page": "Has page test",
+			"contents": "[[Has type::Page]]"
+		},
+		{
+			"page": "Example/P1001/1",
+			"contents": "[[Has page test::One]]"
+		},
+		{
+			"page": "Example/P1001/2",
+			"contents": "[[Has page test::Two]]"
+		}
+	],
+	"tests": [
+		{
+			"type": "parser",
+			"about": "#0",
+			"namespace": "SMW_NS_PROPERTY",
+			"subject": "Has page test",
+			"assert-output": {
+				"onPageView": {
+					"parameters": {
+						"limit": "1",
+						"offset": "1"
+					}
+				},
+				"to-contain": [
+					"Has_page_test&amp;limit=1&amp;offset=0",
+					"title=\"Example/P1001/2\""
+				]
+			}
+		},
+		{
+			"type": "parser",
+			"about": "#1 (see issue #2479)",
+			"namespace": "SMW_NS_PROPERTY",
+			"subject": "Has page test",
+			"assert-output": {
+				"onPageView": {
+					"parameters": {
+						"limit": "1foo",
+						"offset": "1"
+					}
+				},
+				"to-contain": [
+					"Has_page_test&amp;limit=1&amp;offset=0",
+					"title=\"Example/P1001/2\""
+				]
+			}
+		}
+	],
+	"settings": {
+		"wgContLang": "en",
+		"wgLang": "en",
+		"smwgPageSpecialProperties": [
+			"_MDAT"
+		],
+		"smwgNamespacesWithSemanticLinks": {
+			"NS_MAIN": true,
+			"SMW_NS_PROPERTY": true
+		}
+	},
+	"meta": {
+		"version": "2",
+		"is-incomplete": false,
+		"debug": false
+	}
+}

--- a/tests/phpunit/Unit/RequestOptionsTest.php
+++ b/tests/phpunit/Unit/RequestOptionsTest.php
@@ -66,26 +66,61 @@ class RequestOptionsTest extends \PHPUnit_Framework_TestCase {
 		);
 	}
 
-	public function testLimit() {
+	/**
+	 * @dataProvider numberProvider
+	 */
+	public function testLimit( $limit, $expected ) {
 
 		$instance = new RequestOptions();
-		$instance->setLimit( 42 );
+		$instance->setLimit( $limit );
 
 		$this->assertEquals(
-			42,
+			$expected,
+			$instance->getLimit()
+		);
+
+		$instance->limit = $limit;
+
+		$this->assertEquals(
+			$expected,
 			$instance->getLimit()
 		);
 	}
 
-	public function testOffset() {
+	/**
+	 * @dataProvider numberProvider
+	 */
+	public function testOffset( $offset, $expected ) {
 
 		$instance = new RequestOptions();
-		$instance->setOffset( 42 );
+		$instance->setOffset( $offset );
 
 		$this->assertEquals(
-			42,
+			$expected,
 			$instance->getOffset()
 		);
+
+		$instance->offset = $offset;
+
+		$this->assertEquals(
+			$expected,
+			$instance->getOffset()
+		);
+	}
+
+	public function numberProvider() {
+
+		$provider[] = array(
+			42,
+			42
+		);
+
+		$provider[] = array(
+			'42foo',
+			42
+		);
+
+		return $provider;
 	}
 
 }


### PR DESCRIPTION
This PR is made in reference to: #2479

This PR addresses or contains:

- Cast int on limit and offset
- Adds an integration test (p-1001.json) to verify that an input like `1foo` on a property page doesn't cause an exception

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed
