### PR TITLE
Add TransactionalDeferredCallableUpdate

### DIFF
--- a/includes/storage/SMW_Store.php
+++ b/includes/storage/SMW_Store.php
@@ -224,11 +224,11 @@ abstract class Store implements QueryEngine {
 		 */
 		\Hooks::run( 'SMWStore::updateDataAfter', array( $this, $semanticData ) );
 
-		$pageUpdater = $applicationFactory->newPageUpdater();
-
-		if ( !$this->getOptions()->get( 'smwgAutoRefreshSubject' ) || !$pageUpdater->canUpdate() ) {
+		if ( !$this->getOptions()->get( 'smwgAutoRefreshSubject' ) || $semanticData->getOption( Enum::OPT_SUSPEND_PURGE ) ) {
 			return;
 		}
+
+		$pageUpdater = $applicationFactory->newPageUpdater();
 
 		$pageUpdater->addPage( $subject->getTitle() );
 		$pageUpdater->waitOnTransactionIdle();

--- a/src/Aliases.php
+++ b/src/Aliases.php
@@ -78,3 +78,6 @@ class_alias( 'SMW\ParserFunctions\SubobjectParserFunction', 'SMW\SubobjectParser
 class_alias( 'SMW\ParserFunctions\RecurringEventsParserFunction', 'SMW\RecurringEventsParserFunction' );
 class_alias( 'SMW\SQLStore\PropertyTableDefinition', 'SMW\SQLStore\TableDefinition' );
 class_alias( 'SMW\DataModel\ContainerSemanticData', 'SMWContainerSemanticData' );
+
+// 3.0
+class_alias( 'SMW\Updater\DeferredCallableUpdate', 'SMW\DeferredCallableUpdate' );

--- a/src/Enum.php
+++ b/src/Enum.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace SMW;
+
+/**
+ * @license GNU GPL v2+
+ * @since 3.0
+ *
+ * @author mwjames
+ */
+class Enum {
+
+	/**
+	 * Option that allows to suspend the page purge
+	 */
+	const OPT_SUSPEND_PURGE = 'smw.opt.suspend.purge';
+
+}

--- a/src/MediaWiki/Jobs/ParserCachePurgeJob.php
+++ b/src/MediaWiki/Jobs/ParserCachePurgeJob.php
@@ -85,8 +85,8 @@ class ParserCachePurgeJob extends JobBase {
 		}
 
 		$this->pageUpdater->addPage( $this->getTitle() );
-		$this->pageUpdater->asPoolPurge();
-		$this->pageUpdater->doPurgeParserCache();
+		$this->pageUpdater->setOrigin( __METHOD__ );
+		$this->pageUpdater->doPurgeParserCacheAsPool();
 
 		Hooks::run( 'SMW::Job::AfterParserCachePurgeComplete', array( $this ) );
 

--- a/src/MediaWiki/Jobs/UpdateJob.php
+++ b/src/MediaWiki/Jobs/UpdateJob.php
@@ -8,6 +8,7 @@ use SMW\ApplicationFactory;
 use SMW\DIWikiPage;
 use SMW\DIProperty;
 use SMW\EventHandler;
+use SMW\Enum;
 use Title;
 
 /**
@@ -170,6 +171,13 @@ class UpdateJob extends JobBase {
 		$parserData->setOption(
 			$parserData::OPT_FORCED_UPDATE,
 			$this->getParameter( self::FORCED_UPDATE )
+		);
+
+		// Suspend the purge as any preceding parse process most likely has
+		// invalidated the cache for a selected subject
+		$parserData->setOption(
+			Enum::OPT_SUSPEND_PURGE,
+			true
 		);
 
 		$parserData->disableBackgroundUpdateJobs();

--- a/src/SQLStore/SQLStoreFactory.php
+++ b/src/SQLStore/SQLStoreFactory.php
@@ -247,18 +247,14 @@ class SQLStoreFactory {
 	 */
 	public function newDeferredCallableCachedListLookupUpdate() {
 
-		// PHP 5.3
-		$factory = $this;
-
-		$deferredCallableUpdate = ApplicationFactory::getInstance()->newDeferredCallableUpdate( function() use( $factory ) {
-			$factory->newPropertyUsageCachedListLookup()->deleteCache();
-			$factory->newUnusedPropertyCachedListLookup()->deleteCache();
-			$factory->newUndeclaredPropertyCachedListLookup()->deleteCache();
-			$factory->newUsageStatisticsCachedListLookup()->deleteCache();
-
+		$transactionalDeferredCallableUpdate = ApplicationFactory::getInstance()->newTransactionalDeferredCallableUpdate( function() {
+			$this->newPropertyUsageCachedListLookup()->deleteCache();
+			$this->newUnusedPropertyCachedListLookup()->deleteCache();
+			$this->newUndeclaredPropertyCachedListLookup()->deleteCache();
+			$this->newUsageStatisticsCachedListLookup()->deleteCache();
 		} );
 
-		return $deferredCallableUpdate;
+		return $transactionalDeferredCallableUpdate;
 	}
 
 	/**

--- a/src/Services/MediaWikiServices.php
+++ b/src/Services/MediaWikiServices.php
@@ -79,6 +79,23 @@ return array(
 	},
 
 	/**
+	 * LBFactory
+	 *
+	 * @return callable
+	 */
+	'DBLoadBalancerFactory' => function( $containerBuilder ) {
+
+		 $containerBuilder->registerExpectedReturnType( 'DBLoadBalancerFactory', '\LBFactory' );
+
+		// > MW 1.28
+		if ( class_exists( '\MediaWiki\MediaWikiServices' ) && method_exists( '\MediaWiki\MediaWikiServices', 'getDBLoadBalancerFactory' ) ) {
+			return MediaWikiServices::getInstance()->getDBLoadBalancerFactory();
+		}
+
+		return LBFactory::singleton();
+	},
+
+	/**
 	 * DBLoadBalancer
 	 *
 	 * @return callable

--- a/src/Services/SharedServicesContainer.php
+++ b/src/Services/SharedServicesContainer.php
@@ -28,7 +28,8 @@ use SMW\MessageFormatter;
 use SMW\NamespaceExaminer;
 use SMW\ParserData;
 use SMW\ContentParser;
-use SMW\DeferredCallableUpdate;
+use SMW\Updater\DeferredCallableUpdate;
+use SMW\Updater\TransactionalDeferredCallableUpdate;
 use SMW\InMemoryPoolCache;
 use SMW\PropertyAnnotatorFactory;
 use SMW\CacheFactory;
@@ -119,9 +120,9 @@ class SharedServicesContainer implements CallbackContainer {
 			return new PageCreator();
 		} );
 
-		$containerBuilder->registerCallback( 'PageUpdater', function( $containerBuilder, Database $connection = null ) {
+		$containerBuilder->registerCallback( 'PageUpdater', function( $containerBuilder, $connection, TransactionalDeferredCallableUpdate $transactionalDeferredCallableUpdate = null ) {
 			$containerBuilder->registerExpectedReturnType( 'PageUpdater', '\SMW\MediaWiki\PageUpdater' );
-			return new PageUpdater( $connection );
+			return new PageUpdater( $connection, $transactionalDeferredCallableUpdate );
 		} );
 
 		$containerBuilder->registerCallback( 'JobQueueLookup', function( $containerBuilder, Database $connection ) {
@@ -144,9 +145,14 @@ class SharedServicesContainer implements CallbackContainer {
 			return new ContentParser( $title );
 		} );
 
-		$containerBuilder->registerCallback( 'DeferredCallableUpdate', function( $containerBuilder, \Closure $callback, Database $connection = null ) {
-			$containerBuilder->registerExpectedReturnType( 'DeferredCallableUpdate', '\SMW\DeferredCallableUpdate' );
-			return new DeferredCallableUpdate( $callback, $connection );
+		$containerBuilder->registerCallback( 'DeferredCallableUpdate', function( $containerBuilder, \Closure $callback = null ) {
+			$containerBuilder->registerExpectedReturnType( 'DeferredCallableUpdate', '\SMW\Updater\DeferredCallableUpdate' );
+			return new DeferredCallableUpdate( $callback );
+		} );
+
+		$containerBuilder->registerCallback( 'TransactionalDeferredCallableUpdate', function( $containerBuilder, \Closure $callback = null, Database $connection = null ) {
+			$containerBuilder->registerExpectedReturnType( 'TransactionalDeferredCallableUpdate', '\SMW\Updater\TransactionalDeferredCallableUpdate' );
+			return new TransactionalDeferredCallableUpdate( $callback, $connection );
 		} );
 
 		/**

--- a/src/Updater/TransactionalDeferredCallableUpdate.php
+++ b/src/Updater/TransactionalDeferredCallableUpdate.php
@@ -1,0 +1,163 @@
+<?php
+
+namespace SMW\Updater;
+
+use Closure;
+use SMW\MediaWiki\Database;
+
+/**
+ * Extends DeferredCallableUpdate to allow handling of transaction related tasks
+ * or isolations to ensure an undisturbed update process before and after
+ * MediaWiki::preOutputCommit.
+ *
+ * @license GNU GPL v2+
+ * @since 3.0
+ *
+ * @author mwjames
+ */
+class TransactionalDeferredCallableUpdate extends DeferredCallableUpdate {
+
+	/**
+	 * @var Database|null
+	 */
+	private $connection;
+
+	/**
+	 * @var boolean
+	 */
+	private $onTransactionIdle = false;
+
+	/**
+	 * @var int|null
+	 */
+	private $transactionTicket = null;
+
+	/**
+	 * @var array
+	 */
+	private $preCommitableCallbacks = array();
+
+	/**
+	 * @var array
+	 */
+	private $postCommitableCallbacks = array();
+
+	/**
+	 * @since 3.0
+	 *
+	 * @param Closure $callback|null
+	 * @param Database|null $connection
+	 */
+	public function __construct( Closure $callback = null, Database $connection ) {
+		parent::__construct( $callback );
+		$this->connection = $connection;
+	}
+
+	/**
+	 * @note MW 1.29+ showed transaction collisions (Exception thrown with
+	 * an uncommited database transaction), use 'onTransactionIdle' to isolate
+	 * the update execution.
+	 *
+	 * @since 2.5
+	 */
+	public function waitOnTransactionIdle() {
+		$this->onTransactionIdle = !$this->isCommandLineMode;
+	}
+
+ 	/**
+	 * It tries to fetch a transactionTicket to assert whether transaction writes
+	 * are active or not and if available will process Database::commitAndWaitForReplication
+	 * during DeferredCallableUpdate::doUpdate to safely post commits to the
+	 * master.
+	 *
+	 * @note If the commandLine is active then continue an update without a ticket
+	 * to avoid any update lag or possible transaction lock.
+	 *
+	 * @since 3.0
+	 */
+	public function commitWithTransactionTicket() {
+		if ( $this->isCommandLineMode === false ) {
+			$this->transactionTicket = $this->connection->getEmptyTransactionTicket( $this->getOrigin() );
+		}
+	}
+
+	/**
+	 * Attaches a callback pre-execution of the source callback and is scheduled
+	 * to be executed before the source callback.
+	 *
+	 * @since 3.0
+	 *
+	 * @param string $fname
+	 * @param Closure $callback
+	 */
+	public function addPreCommitableCallback( $fname, $callback ) {
+		if ( is_callable( $callback ) ) {
+			$this->preCommitableCallbacks[$fname] = $callback;
+		}
+	}
+
+	/**
+	 * Attaches a callback post execution of the source callback and is scheduled
+	 * to be executed after the source callback.
+	 *
+	 * @since 3.0
+	 *
+	 * @param string $fname
+	 * @param Closure $callback
+	 */
+	public function addPostCommitableCallback( $fname, $callback ) {
+		if ( is_callable( $callback ) ) {
+			$this->postCommitableCallbacks[$fname] = $callback;
+		}
+	}
+
+	/**
+	 * @see DeferrableUpdate::doUpdate
+	 *
+	 * @since 3.0
+	 */
+	public function doUpdate() {
+
+		if ( $this->onTransactionIdle ) {
+			return $this->connection->onTransactionIdle( function() {
+				$this->log( $this->getOrigin() . ' doUpdate (onTransactionIdle)' );
+				$this->onTransactionIdle = false;
+				$this->doUpdate();
+			} );
+		}
+
+		foreach ( $this->preCommitableCallbacks as $fname => $preCallback ) {
+			$this->log( $this->getOrigin() . " (pre-commitable callback: $fname)" );
+			call_user_func( $preCallback, $this->transactionTicket );
+		}
+
+		parent::doUpdate();
+
+		foreach ( $this->postCommitableCallbacks as $fname => $postCallback ) {
+			$this->log( $this->getOrigin() . " (post-commitable callback: $fname)" );
+			call_user_func( $postCallback, $this->transactionTicket );
+		}
+
+		$this->connection->commitAndWaitForReplication( $this->getOrigin(), $this->transactionTicket );
+	}
+
+	protected function addUpdate( $update ) {
+
+		if ( $this->onTransactionIdle ) {
+			$this->log( $this->getOrigin() . ' (as waitable DeferrableUpdate)' );
+			return $this->connection->onTransactionIdle( function() use( $update ) {
+				$update->onTransactionIdle = false;
+				parent::addUpdate( $update );
+			} );
+		}
+
+		parent::addUpdate( $update );
+	}
+
+	protected function getLoggableContext() {
+		return parent::getLoggableContext() + array(
+			'transactionTicket' => $this->transactionTicket
+		);
+	}
+
+}

--- a/src/Utils/BufferedStatsdCollector.php
+++ b/src/Utils/BufferedStatsdCollector.php
@@ -217,20 +217,20 @@ class BufferedStatsdCollector {
 		// environment therefore rely on the deferred update and any caller
 		// that invokes the recordStats method
 
-		$deferredCallableUpdate = ApplicationFactory::getInstance()->newDeferredCallableUpdate(
+		$transactionalDeferredCallableUpdate = ApplicationFactory::getInstance()->newTransactionalDeferredCallableUpdate(
 			function() { $this->saveStats();
 			}
 		);
 
-		$deferredCallableUpdate->setOrigin( __METHOD__ );
-		$deferredCallableUpdate->waitOnTransactionIdle();
+		$transactionalDeferredCallableUpdate->setOrigin( __METHOD__ );
+		$transactionalDeferredCallableUpdate->waitOnTransactionIdle();
 
-		$deferredCallableUpdate->setFingerprint(
+		$transactionalDeferredCallableUpdate->setFingerprint(
 			__METHOD__ . $this->fingerprint
 		);
 
-		$deferredCallableUpdate->markAsPending( $asPending );
-		$deferredCallableUpdate->pushUpdate();
+		$transactionalDeferredCallableUpdate->markAsPending( $asPending );
+		$transactionalDeferredCallableUpdate->pushUpdate();
 	}
 
 }

--- a/tests/phpunit/Unit/ApplicationFactoryTest.php
+++ b/tests/phpunit/Unit/ApplicationFactoryTest.php
@@ -252,8 +252,16 @@ class ApplicationFactoryTest extends \PHPUnit_Framework_TestCase {
 		};
 
 		$this->assertInstanceOf(
-			'\SMW\DeferredCallableUpdate',
+			'\SMW\Updater\DeferredCallableUpdate',
 			$this->applicationFactory->newDeferredCallableUpdate( $callback )
+		);
+	}
+
+	public function testCanConstructTransactionalDeferredCallableUpdate() {
+
+		$this->assertInstanceOf(
+			'\SMW\Updater\TransactionalDeferredCallableUpdate',
+			$this->applicationFactory->newTransactionalDeferredCallableUpdate( null )
 		);
 	}
 

--- a/tests/phpunit/Unit/EnumTest.php
+++ b/tests/phpunit/Unit/EnumTest.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace SMW\Tests;
+
+use SMW\Enum;
+
+/**
+ * @covers \SMW\Enum
+ * @group semantic-mediawiki
+ *
+ * @license GNU GPL v2+
+ * @since 3.0
+ *
+ * @author mwjames
+ */
+class EnumTest extends \PHPUnit_Framework_TestCase {
+
+	/**
+	 *@dataProvider constProvider
+	 */
+	public function testValidate( $const ) {
+
+		$this->assertInternalType(
+			'string',
+			$const
+		);
+	}
+
+	public function constProvider() {
+
+		$provider[] = array(
+			Enum::OPT_SUSPEND_PURGE
+		);
+
+		return $provider;
+	}
+
+}

--- a/tests/phpunit/Unit/Updater/TransactionalDeferredCallableUpdateTest.php
+++ b/tests/phpunit/Unit/Updater/TransactionalDeferredCallableUpdateTest.php
@@ -1,0 +1,268 @@
+<?php
+
+namespace SMW\Tests\Updater;
+
+use SMW\Updater\TransactionalDeferredCallableUpdate;
+use SMW\Tests\TestEnvironment;
+
+/**
+ * @covers \SMW\Updater\TransactionalDeferredCallableUpdate
+ * @group semantic-mediawiki
+ *
+ * @license GNU GPL v2+
+ * @since 3.0
+ *
+ * @author mwjames
+ */
+class TransactionalDeferredCallableUpdateTest extends \PHPUnit_Framework_TestCase {
+
+	private $testEnvironment;
+	private $spyLogger;
+	private $connection;
+
+	protected function setUp() {
+		parent::setUp();
+		$this->testEnvironment = new TestEnvironment();
+		$this->spyLogger = $this->testEnvironment->getUtilityFactory()->newSpyLogger();
+
+		$this->connection = $this->getMockBuilder( '\SMW\MediaWiki\Database' )
+			->disableOriginalConstructor()
+			->getMock();
+	}
+
+	protected function tearDown() {
+		$this->testEnvironment->clearPendingDeferredUpdates();
+		$this->testEnvironment->tearDown();
+		parent::tearDown();
+	}
+
+	public function testCanConstruct() {
+
+		$callback = function() {
+			return null;
+		};
+
+		$this->assertInstanceOf(
+			TransactionalDeferredCallableUpdate::class,
+			new TransactionalDeferredCallableUpdate( $callback, $this->connection )
+		);
+	}
+
+	public function testUpdate() {
+
+		$test = $this->getMockBuilder( '\stdClass' )
+			->disableOriginalConstructor()
+			->setMethods( array( 'doTest' ) )
+			->getMock();
+
+		$test->expects( $this->once() )
+			->method( 'doTest' );
+
+		$callback = function() use ( $test ) {
+			$test->doTest();
+		};
+
+		$instance = new TransactionalDeferredCallableUpdate(
+			$callback,
+			$this->connection
+		);
+
+		$instance->setLogger( $this->spyLogger );
+		$instance->pushUpdate();
+
+		$this->testEnvironment->executePendingDeferredUpdates();
+	}
+
+	public function testUpdateOnEmptyCallback() {
+
+		$instance = new TransactionalDeferredCallableUpdate(
+			null,
+			$this->connection
+		);
+
+		$instance->setLogger( $this->spyLogger );
+		$instance->pushUpdate();
+
+		$this->testEnvironment->executePendingDeferredUpdates();
+
+		$this->assertContains(
+			'DeferredCallableUpdate::emptyCallback',
+			$this->spyLogger->getMessagesAsString()
+		);
+	}
+
+	public function testUpdateOnLateCallback() {
+
+		$instance = new TransactionalDeferredCallableUpdate(
+			null,
+			$this->connection
+		);
+
+		$test = $this->getMockBuilder( '\stdClass' )
+			->disableOriginalConstructor()
+			->setMethods( array( 'doTest' ) )
+			->getMock();
+
+		$test->expects( $this->once() )
+			->method( 'doTest' );
+
+		$callback = function() use ( $test ) {
+			$test->doTest();
+		};
+
+		$instance->setCallback( $callback );
+
+		$instance->setLogger( $this->spyLogger );
+		$instance->pushUpdate();
+
+		$this->testEnvironment->executePendingDeferredUpdates();
+
+		$this->assertContains(
+			'DeferredCallableUpdate::addUpdate',
+			$this->spyLogger->getMessagesAsString()
+		);
+	}
+
+	public function testWaitableUpdate() {
+
+		$test = $this->getMockBuilder( '\stdClass' )
+			->disableOriginalConstructor()
+			->setMethods( array( 'doTest' ) )
+			->getMock();
+
+		$test->expects( $this->once() )
+			->method( 'doTest' );
+
+		$callback = function() use ( $test ) {
+			$test->doTest();
+		};
+
+		$instance = new TransactionalDeferredCallableUpdate(
+			$callback,
+			$this->connection
+		);
+
+		$instance->markAsPending( true );
+		$instance->pushUpdate();
+
+		$instance->releasePendingUpdates();
+
+		$this->testEnvironment->executePendingDeferredUpdates();
+	}
+
+	public function testUpdateWithDisabledDeferredUpdate() {
+
+		$test = $this->getMockBuilder( '\stdClass' )
+			->disableOriginalConstructor()
+			->setMethods( array( 'doTest' ) )
+			->getMock();
+
+		$test->expects( $this->once() )
+			->method( 'doTest' );
+
+		$callback = function() use ( $test ) {
+			$test->doTest();
+		};
+
+		$instance = new TransactionalDeferredCallableUpdate(
+			$callback,
+			$this->connection
+		);
+
+		$instance->enabledDeferredUpdate( false );
+		$instance->pushUpdate();
+	}
+
+	public function testOrigin() {
+
+		$callback = function() {
+		};
+
+		$instance = new TransactionalDeferredCallableUpdate(
+			$callback,
+			$this->connection
+		);
+
+		$instance->setOrigin( 'Foo' );
+
+		$this->assertEquals(
+			'Foo',
+			$instance->getOrigin()
+		);
+	}
+
+	public function testFilterDuplicateQueueEntryByFingerprint() {
+
+		$test = $this->getMockBuilder( '\stdClass' )
+			->disableOriginalConstructor()
+			->setMethods( array( 'doTest' ) )
+			->getMock();
+
+		$test->expects( $this->once() )
+			->method( 'doTest' );
+
+		$callback = function() use ( $test ) {
+			$test->doTest();
+		};
+
+		$instance = new TransactionalDeferredCallableUpdate(
+			$callback,
+			$this->connection
+		);
+
+		$instance->setFingerprint( __METHOD__ );
+		$instance->markAsPending( true );
+		$instance->pushUpdate();
+
+		$instance = new TransactionalDeferredCallableUpdate(
+			$callback,
+			$this->connection
+		);
+
+		$instance->setFingerprint( __METHOD__ );
+		$instance->markAsPending( true );
+		$instance->pushUpdate();
+
+		$this->testEnvironment->executePendingDeferredUpdates();
+	}
+
+	public function testUpdateOnTransactionIdle() {
+
+		$callback = function( $callback ) {
+			return call_user_func( $callback );
+		};
+
+		$connection = $this->getMockBuilder( '\SMW\MediaWiki\Database' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$connection->expects( $this->once() )
+			->method( 'onTransactionIdle' )
+			->will( $this->returnCallback( $callback ) );
+
+		$this->testEnvironment->clearPendingDeferredUpdates();
+
+		$test = $this->getMockBuilder( '\stdClass' )
+			->disableOriginalConstructor()
+			->setMethods( array( 'doTest' ) )
+			->getMock();
+
+		$test->expects( $this->once() )
+			->method( 'doTest' );
+
+		$callback = function() use ( $test ) {
+			$test->doTest();
+		};
+
+		$instance = new TransactionalDeferredCallableUpdate(
+			$callback,
+			$connection
+		);
+
+		$instance->waitOnTransactionIdle();
+		$instance->pushUpdate();
+
+		$this->testEnvironment->executePendingDeferredUpdates();
+	}
+
+}


### PR DESCRIPTION
This PR is made in reference to: #2198, https://phabricator.wikimedia.org/T152583#3292654, https://phabricator.wikimedia.org/T165714 

This PR addresses or contains:

- Moves transaction specific handling from `DeferredCallableUpdate` to `TransactionalDeferredCallableUpdate`
- Add `TransactionalDeferredCallableUpdate::commitWithTransactionTicket` to reduce a possible transaction lag where a `TransactionTicket` is available
- `PageUpdater` is to make use of `TransactionalDeferredCallableUpdate` instead of trying to manage `DeferredUpdates` on its own

#2198 tried to cover most use case where a `SMW\DeferredCallableUpdate::doUpdate: Cannot flush snapshot because writes are pending` could appear but when a transaction is started as job but not through the commandLine (cronJob) then under certain circumstance the following can be observed where `MediaWiki::doPostOutputShutdown` triggers a pending job.

```
[smw] SMW\Utils\BufferedStatsdCollector::recordStats (as DeferredCallableUpdate a4663009fe01e8c985f3dda0fe6a173b)
[exception] [bf15bc4350f627484425b01b] /mw-master/index.php/Special:Ask/format%3Drss/link%3Dall/headers%3Dshow/searchlabel%3DRSS/class%3Dsortable-20wikitable-20smwtable/offset%3D/limit%3D50/-5B-5BFeedWithDisplayTitle::%2B-5D-5D/mainlabel%3D/prettyprint%3Dtrue/unescape%3Dtrue   Wikimedia\Rdbms\DBUnexpectedError from line 2947 of ...\mw-master\includes\libs\rdbms\database\Database.php: SMW\DeferredCallableUpdate::doUpdate: Cannot flush snapshot because writes are pending (SMW\SQLStore\TableFieldUpdater::updateCollationField, SMW\SQLStore\TableFieldUpdater::updateCollationField, SMW\SQLStore\TableFieldUpdater::updateCollationField, SMW\SQLStore\TableFieldUpdater::updateCollationField, SMW::writePropertyTableRowUpdates-insert-smw_di_wikipage, SMWSql3SmwIds::setPropertyTableHashes, SMW::writePropertyTableRowUpdates-insert-smw_di_wikipage, SMWSql3SmwIds::setPropertyTableHashes, SMW::writePropertyTableRowUpdates-insert-smw_di_wikipage, SMWSql3SmwIds::setPropertyTableHashes, SMW::writePropertyTableRowUpdates-insert-smw_di_wikipage, SMWSql3SmwIds::setPropertyTableHashes, SMW::writePropertyTableRowUpdates-insert-smw_di_wikipage, SMWSql3SmwIds::setPropertyTableHashes, SMW::writePropertyTableRowUpdates-insert-smw_di_wikipage, SMWSql3SmwIds::setPropertyTableHashes, SMW::writePropertyTableRowUpdates-insert-smw_di_wikipage, SMWSql3SmwIds::setPropertyTableHashes, SMW::writePropertyTableRowUpdates-insert-smw_di_wikipage, SMWSql3SmwIds::setPropertyTableHashes, SMW::writePropertyTableRowUpdates-insert-smw_di_wikipage, SMWSql3SmwIds::setPropertyTableHashes, SMW::writePropertyTableRowUpdates-insert-smw_di_wikipage, SMWSql3SmwIds::setPropertyTableHashes, SMW::writePropertyTableRowUpdates-insert-smw_di_wikipage, SMWSql3SmwIds::setPropertyTableHashes, SMW::writePropertyTableRowUpdates-insert-smw_di_wikipage, SMWSql3SmwIds::setPropertyTableHashes, SMW::writePropertyTableRowUpdates-insert-smw_di_wikipage, SMWSql3SmwIds::setPropertyTableHashes, SMW::writePropertyTableRowUpdates-insert-smw_di_wikipage, SMWSql3SmwIds::setPropertyTableHashes, SMW::writePropertyTableRowUpdates-insert-smw_di_wikipage, SMWSql3SmwIds::setPropertyTableHashes, SMW::writePropertyTableRowUpdates-insert-smw_di_wikipage, SMWSql3SmwIds::setPropertyTableHashes, SMW::writePropertyTableRowUpdates-insert-smw_di_wikipage, SMWSql3SmwIds::setPropertyTableHashes, SMW::writePropertyTableRowUpdates-insert-smw_di_wikipage, SMWSql3SmwIds::setPropertyTableHashes, SMW::writePropertyTableRowUpdates-insert-smw_di_wikipage, SMWSql3SmwIds::setPropertyTableHashes, Wikimedia\Rdbms\Database::onTransactionIdle, Wikimedia\Rdbms\Database::onTransactionIdle, Wikimedia\Rdbms\Database::onTransactionIdle, Wikimedia\Rdbms\Database::onTransactionIdle, Wikimedia\Rdbms\Database::onTransactionIdle, Wikimedia\Rdbms\Database::onTransactionIdle, Wikimedia\Rdbms\Database::onTransactionIdle, Wikimedia\Rdbms\Database::onTransactionIdle, Wikimedia\Rdbms\Database::onTransactionIdle, Wikimedia\Rdbms\Database::onTransactionIdle, Wikimedia\Rdbms\Database::onTransactionIdle, Wikimedia\Rdbms\Database::onTransactionIdle, Wikimedia\Rdbms\Database::onTransactionIdle, Wikimedia\Rdbms\Database::onTransactionIdle, Wikimedia\Rdbms\Database::onTransactionIdle, Wikimedia\Rdbms\Database::onTransactionIdle, Wikimedia\Rdbms\Database::onTransactionIdle, Wikimedia\Rdbms\Database::onTransactionIdle, Wikimedia\Rdbms\Database::onTransactionIdle).
#0 ...\mw-master\includes\libs\rdbms\loadbalancer\LoadBalancer.php(1200): Wikimedia\Rdbms\Database->flushSnapshot(string)
#1 [internal function]: Wikimedia\Rdbms\LoadBalancer->Wikimedia\Rdbms\{closure}(Wikimedia\Rdbms\DatabaseMysqli)
#2 ...\mw-master\includes\libs\rdbms\loadbalancer\LoadBalancer.php(1498): call_user_func_array(Closure, array)
#3 ...\mw-master\includes\libs\rdbms\loadbalancer\LoadBalancer.php(1207): Wikimedia\Rdbms\LoadBalancer->forEachOpenMasterConnection(Closure)
#4 [internal function]: Wikimedia\Rdbms\LoadBalancer->beginMasterChanges(string)
#5 ...\mw-master\includes\libs\rdbms\lbfactory\LBFactory.php(183): call_user_func_array(array, array)
#6 [internal function]: Wikimedia\Rdbms\LBFactory->Wikimedia\Rdbms\{closure}(Wikimedia\Rdbms\LoadBalancer, string, array)
#7 ...\mw-master\includes\libs\rdbms\lbfactory\LBFactorySimple.php(149): call_user_func_array(Closure, array)
#8 ...\mw-master\includes\libs\rdbms\lbfactory\LBFactory.php(185): Wikimedia\Rdbms\LBFactorySimple->forEachLB(Closure, array)
#9 ...\mw-master\includes\libs\rdbms\lbfactory\LBFactory.php(207): Wikimedia\Rdbms\LBFactory->forEachLBCallMethod(string, array)
#10 ...\mw-master\includes\deferred\DeferredUpdates.php(265): Wikimedia\Rdbms\LBFactory->beginMasterChanges(string)
#11 ...\mw-master\includes\deferred\DeferredUpdates.php(228): DeferredUpdates::runUpdate(SMW\DeferredCallableUpdate, Wikimedia\Rdbms\LBFactorySimple, integer)
#12 ...\mw-master\includes\deferred\DeferredUpdates.php(136): DeferredUpdates::execute(array, string, integer)
#13 ...\mw-master\includes\deferred\DeferredUpdates.php(95): DeferredUpdates::doUpdates(string)
#14 ...\mw-master\extensions\SemanticMediaWiki\src\DeferredCallableUpdate.php(242): DeferredUpdates::addUpdate(SMW\DeferredCallableUpdate)
#15 ...\mw-master\extensions\SemanticMediaWiki\src\Utils\BufferedStatsdCollector.php(233): SMW\DeferredCallableUpdate->pushUpdate()
#16 ...\mw-master\extensions\SemanticMediaWiki\src\Query\Result\CachedQueryResultPrefetcher.php(314): SMW\Utils\BufferedStatsdCollector->recordStats()
#17 ...\mw-master\extensions\SemanticMediaWiki\src\MediaWiki\Jobs\ParserCachePurgeJob.php(165): SMW\Query\Result\CachedQueryResultPrefetcher->resetCacheBy(array, string)
#18 ...\mw-master\extensions\SemanticMediaWiki\src\MediaWiki\Jobs\ParserCachePurgeJob.php(82): SMW\MediaWiki\Jobs\ParserCachePurgeJob->findEmbeddedQueryTargetLinksBatches(array, MediaWiki\Logger\LegacyLogger)
#19 ...\mw-master\extensions\SemanticMediaWiki\src\MediaWiki\Jobs\ParserCachePurgeJob.php(145): SMW\MediaWiki\Jobs\ParserCachePurgeJob->run()
#20 ...\mw-master\extensions\SemanticMediaWiki\src\MediaWiki\Jobs\ParserCachePurgeJob.php(82): SMW\MediaWiki\Jobs\ParserCachePurgeJob->findEmbeddedQueryTargetLinksBatches(array, MediaWiki\Logger\LegacyLogger)
#21 ...\mw-master\extensions\SemanticMediaWiki\src\MediaWiki\Jobs\ParserCachePurgeJob.php(145): SMW\MediaWiki\Jobs\ParserCachePurgeJob->run()
#22 ...\mw-master\extensions\SemanticMediaWiki\src\MediaWiki\Jobs\ParserCachePurgeJob.php(82): SMW\MediaWiki\Jobs\ParserCachePurgeJob->findEmbeddedQueryTargetLinksBatches(array, MediaWiki\Logger\LegacyLogger)
#23 ...\mw-master\extensions\SemanticMediaWiki\src\MediaWiki\Jobs\ParserCachePurgeJob.php(145): SMW\MediaWiki\Jobs\ParserCachePurgeJob->run()
#24 ...\mw-master\extensions\SemanticMediaWiki\src\MediaWiki\Jobs\ParserCachePurgeJob.php(82): SMW\MediaWiki\Jobs\ParserCachePurgeJob->findEmbeddedQueryTargetLinksBatches(array, MediaWiki\Logger\LegacyLogger)
#25 ...\mw-master\extensions\SemanticMediaWiki\src\MediaWiki\Jobs\ParserCachePurgeJob.php(145): SMW\MediaWiki\Jobs\ParserCachePurgeJob->run()
#26 ...\mw-master\extensions\SemanticMediaWiki\src\MediaWiki\Jobs\ParserCachePurgeJob.php(82): SMW\MediaWiki\Jobs\ParserCachePurgeJob->findEmbeddedQueryTargetLinksBatches(array, MediaWiki\Logger\LegacyLogger)
#27 ...\mw-master\extensions\SemanticMediaWiki\src\MediaWiki\Jobs\ParserCachePurgeJob.php(145): SMW\MediaWiki\Jobs\ParserCachePurgeJob->run()
#28 ...\mw-master\extensions\SemanticMediaWiki\src\MediaWiki\Jobs\ParserCachePurgeJob.php(82): SMW\MediaWiki\Jobs\ParserCachePurgeJob->findEmbeddedQueryTargetLinksBatches(array, MediaWiki\Logger\LegacyLogger)
#29 ...\mw-master\extensions\SemanticMediaWiki\src\DeferredRequestDispatchManager.php(257): SMW\MediaWiki\Jobs\ParserCachePurgeJob->run()
#30 [internal function]: SMW\DeferredRequestDispatchManager->SMW\{closure}(Title, array)
#31 ...\mw-master\extensions\SemanticMediaWiki\src\DeferredRequestDispatchManager.php(229): call_user_func_array(Closure, array)
#32 ...\mw-master\extensions\SemanticMediaWiki\src\DeferredRequestDispatchManager.php(163): SMW\DeferredRequestDispatchManager->dispatchJobRequestWith(string, Title, array)
#33 ...\mw-master\extensions\SemanticMediaWiki\src\MediaWiki\Hooks\HookRegistry.php(584): SMW\DeferredRequestDispatchManager->dispatchParserCachePurgeJobWith(Title, array)
#34 ...\mw-master\includes\Hooks.php(186): SMW\MediaWiki\Hooks\HookRegistry->SMW\MediaWiki\Hooks\{closure}(SMWSQLStore3, SMW\SemanticData, SMW\SQLStore\CompositePropertyTableDiffIterator)
#35 ...\mw-master\extensions\SemanticMediaWiki\includes\storage\SQLStore\SMW_SQLStore3_Writers.php(188): Hooks::run(string, array)
#36 ...\mw-master\extensions\SemanticMediaWiki\includes\storage\SQLStore\SMW_SQLStore3.php(265): SMWSQLStore3Writers->doDataUpdate(SMW\SemanticData)
#37 ...\mw-master\extensions\SemanticMediaWiki\includes\storage\SMW_Store.php(220): SMWSQLStore3->doDataUpdate(SMW\SemanticData)
#38 ...\mw-master\extensions\SemanticMediaWiki\includes\StoreUpdater.php(218): SMW\Store->updateData(SMW\SemanticData)
#39 ...\mw-master\extensions\SemanticMediaWiki\includes\StoreUpdater.php(142): SMW\StoreUpdater->doRealUpdate()
#40 ...\mw-master\extensions\SemanticMediaWiki\includes\StoreUpdater.php(96): SMW\StoreUpdater->doPerformUpdate()
#41 ...\mw-master\extensions\SemanticMediaWiki\includes\ParserData.php(401): SMW\StoreUpdater->doUpdate()
#42 [internal function]: SMW\ParserData->SMW\{closure}()
#43 ...\mw-master\extensions\SemanticMediaWiki\src\DeferredCallableUpdate.php(219): call_user_func(Closure)
#44 ...\mw-master\extensions\SemanticMediaWiki\src\DeferredCallableUpdate.php(245): SMW\DeferredCallableUpdate->doUpdate()
#45 ...\mw-master\extensions\SemanticMediaWiki\includes\ParserData.php(412): SMW\DeferredCallableUpdate->pushUpdate()
#46 ...\mw-master\extensions\SemanticMediaWiki\src\MediaWiki\Jobs\UpdateJob.php(176): SMW\ParserData->updateStore()
#47 ...\mw-master\extensions\SemanticMediaWiki\src\MediaWiki\Jobs\UpdateJob.php(145): SMW\MediaWiki\Jobs\UpdateJob->updateStore(SMW\ParserData)
#48 ...\mw-master\extensions\SemanticMediaWiki\src\MediaWiki\Jobs\UpdateJob.php(117): SMW\MediaWiki\Jobs\UpdateJob->needToParsePageContentBeforeUpdate()
#49 ...\mw-master\extensions\SemanticMediaWiki\src\MediaWiki\Jobs\UpdateJob.php(85): SMW\MediaWiki\Jobs\UpdateJob->doPrepareForUpdate()
#50 ...\mw-master\extensions\SemanticMediaWiki\src\MediaWiki\Jobs\UpdateJob.php(66): SMW\MediaWiki\Jobs\UpdateJob->doUpdate()
#51 ...\mw-master\includes\jobqueue\JobRunner.php(289): SMW\MediaWiki\Jobs\UpdateJob->run()
#52 ...\mw-master\includes\jobqueue\JobRunner.php(189): JobRunner->executeJob(SMW\MediaWiki\Jobs\UpdateJob, Wikimedia\Rdbms\LBFactorySimple, BufferingStatsdDataFactory, integer)
#53 ...\mw-master\includes\MediaWiki.php(973): JobRunner->run(array)
#54 ...\mw-master\includes\MediaWiki.php(959): MediaWiki->triggerSyncJobs(integer, MediaWiki\Logger\LegacyLogger)
#55 ...\mw-master\includes\MediaWiki.php(911): MediaWiki->triggerJobs()
#56 ...\mw-master\includes\MediaWiki.php(731): MediaWiki->restInPeace(string)
#57 ...\mw-master\includes\MediaWiki.php(750): MediaWiki->{closure}()
#58 ...\mw-master\includes\MediaWiki.php(554): MediaWiki->doPostOutputShutdown(string)
#59 ...\mw-master\index.php(43): MediaWiki->run()
```





This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed
