### PR TITLE
TableChangeOp to record fixed property, refs 2135, 2388

### DIFF
--- a/src/Maintenance/DistinctEntityDataRebuilder.php
+++ b/src/Maintenance/DistinctEntityDataRebuilder.php
@@ -155,6 +155,7 @@ class DistinctEntityDataRebuilder {
 	private function doExecuteUpdateJobFor( $page ) {
 
 		$updatejob = new UpdateJob( $page, array(
+			UpdateJob::FORCED_UPDATE => true,
 			'pm' => $this->options->has( 'shallow-update' ) ? SMW_UJ_PM_CLASTMDATE : false
 		) );
 

--- a/src/SQLStore/ChangeOp/TableChangeOp.php
+++ b/src/SQLStore/ChangeOp/TableChangeOp.php
@@ -94,6 +94,8 @@ class TableChangeOp {
 			$changeOps = $this->changeOps[$opType];
 		}
 
+		unset( $changeOps['property'] );
+
 		foreach ( $changeOps as $op ) {
 			$fieldOps[] = new FieldChangeOp( $op );
 		}

--- a/src/SQLStore/CompositePropertyTableDiffIterator.php
+++ b/src/SQLStore/CompositePropertyTableDiffIterator.php
@@ -116,6 +116,11 @@ class CompositePropertyTableDiffIterator implements IteratorAggregate {
 
 		foreach ( $this->data as $hash => $data ) {
 			foreach ( $data as $tableName => $d ) {
+
+				if ( isset( $this->fixedPropertyRecords[$tableName] ) ) {
+					$d['property'] = $this->fixedPropertyRecords[$tableName];
+				}
+
 				$dataChangeOps[] = new TableChangeOp( $tableName, $d );
 			}
 		}

--- a/src/SQLStore/PropertyTableRowDiffer.php
+++ b/src/SQLStore/PropertyTableRowDiffer.php
@@ -109,6 +109,10 @@ class PropertyTableRowDiffer {
 				}
 			}
 
+			if ( $fixedProperty ) {
+				$this->getCompositePropertyTableDiff()->addFixedPropertyRecord( $tableName, $fixedProperty );
+			}
+
 			if ( array_key_exists( $tableName, $newData ) ) {
 				// Note: the order within arrays should remain the same while page is not updated.
 				// Hence we do not sort before serializing. It is hoped that this assumption is valid.
@@ -139,10 +143,6 @@ class PropertyTableRowDiffer {
 					$sid,
 					$propertyTable
 				);
-
-				if ( $fixedProperty ) {
-					$this->getCompositePropertyTableDiff()->addFixedPropertyRecord( $tableName, $fixedProperty );
-				}
 			}
 		}
 

--- a/src/SQLStore/QueryEngine/Fulltext/TextByChangeUpdater.php
+++ b/src/SQLStore/QueryEngine/Fulltext/TextByChangeUpdater.php
@@ -239,6 +239,10 @@ class TextByChangeUpdater implements LoggerAwareInterface {
 
 		foreach ( $dataChangeOp->getFieldChangeOps() as $fieldChangeOp ) {
 
+			if ( $dataChangeOp->isFixedPropertyOp() ) {
+				$fieldChangeOp->set( 'p_id', $dataChangeOp->getFixedPropertyValueBy( 'p_id' ) );
+			}
+
 			// Exempted property -> out
 			if ( !$fieldChangeOp->has( 'p_id' ) || $searchTable->isExemptedPropertyById( $fieldChangeOp->get( 'p_id' ) ) ) {
 				continue;

--- a/src/SQLStore/SQLStoreFactory.php
+++ b/src/SQLStore/SQLStoreFactory.php
@@ -324,7 +324,7 @@ class SQLStoreFactory {
 	 */
 	public function newPropertyTableInfoFetcher() {
 
-		$settings = $this->applicationFactory->getSettings();
+		$settings = ApplicationFactory::getInstance()->getSettings();
 
 		$propertyTableInfoFetcher = new PropertyTableInfoFetcher(
 			new PropertyTypeFinder( $this->store->getConnection( 'mw.db' ) )

--- a/tests/phpunit/Integration/JSONScript/TestCases/q-0106.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/q-0106.json
@@ -1,0 +1,94 @@
+{
+	"description": "Test `_txt`/`~` with enabled full-text search support on fixed user property (only enabled for MySQL, SQLite, `smwgFixedProperties`)",
+	"setup": [
+		{
+			"namespace": "SMW_NS_PROPERTY",
+			"page": "Has fixed text",
+			"contents": "[[Has type::Text]]"
+		},
+		{
+			"namespace": "SMW_NS_PROPERTY",
+			"page": "Has fixed page",
+			"contents": "[[Has type::Page]]"
+		},
+		{
+			"page": "Example/Q0106/1",
+			"contents": "{{#subobject: |Has fixed text=MySQL vs MariaDB database}} {{#subobject: |Has fixed text=Oracle vs MariaDB database}} {{#subobject: |Has fixed text=PostgreSQL vs MariaDB database and more of}} {{#subobject: |Has fixed text=MariaDB overview}}"
+		},
+		{
+			"page": "Example/Q0106/2",
+			"contents": "{{#subobject: |Has fixed page=Elastic search}} {{#subobject: |Has fixed page=Sphinx search}}"
+		}
+	],
+	"beforeTest": {
+		"maintenance-run": {
+			"rebuildData": {
+				"page": "Property:Has fixed text|Property:Has fixed page|Example/Q0106/1|Example/Q0106/2"
+			}
+		}
+	},
+	"tests": [
+		{
+			"type": "query",
+			"store": {
+				"clear-cache": true
+			},
+			"about": "#0 on fixed blob user property",
+			"condition": "[[Has fixed text::~+MariaDB -database]]",
+			"printouts": [],
+			"parameters": {
+				"limit": "10"
+			},
+			"assert-queryresult": {
+				"count": 1,
+				"results": [
+					"Example/Q0106/1#0##_29f6aa337d1dc1e2f79376c7940aeab3"
+				]
+			}
+		},
+		{
+			"type": "query",
+			"store": {
+				"clear-cache": true
+			},
+			"about": "#1 on fixed page user property",
+			"condition": "[[Has fixed page::~*search*]]",
+			"printouts": [],
+			"parameters": {
+				"limit": "10"
+			},
+			"assert-queryresult": {
+				"count": 2,
+				"results": [
+					"Example/Q0106/2#0##_39c07b506d692088c97dc0d1cbfd67e6",
+					"Example/Q0106/2#0##_89e5e037d244e08b050101bb8ddb7768"
+				]
+			}
+		}
+	],
+	"settings": {
+		"smwgEnabledFulltextSearch": true,
+		"smwgFulltextDeferredUpdate": false,
+		"smwgFulltextSearchIndexableDataTypes": [
+			"SMW_FT_BLOB",
+			"SMW_FT_URI",
+			"SMW_FT_WIKIPAGE"
+		],
+		"smwgFixedProperties": [
+			"Has_fixed_text",
+			"Has fixed page"
+		]
+	},
+	"meta": {
+		"skip-on": {
+			"postgres": "Not supported by PostgreSQL.",
+			"sesame": "Not supported by SPARQLStore (Sesame).",
+			"virtuoso": "Not supported by SPARQLStore (Virtuoso).",
+			"fuseki": "Not supported by SPARQLStore (Fuskei).",
+			"blazegraph": "Not supported by SPARQLStore (Blazegraph)."
+		},
+		"version": "2",
+		"is-incomplete": false,
+		"debug": false
+	}
+}

--- a/tests/phpunit/Integration/MediaWiki/Hooks/FileUploadIntegrationTest.php
+++ b/tests/phpunit/Integration/MediaWiki/Hooks/FileUploadIntegrationTest.php
@@ -68,6 +68,8 @@ class FileUploadIntegrationTest extends MwDBaseUnitTestCase {
 			'LinksUpdateConstructed',
 			$this->mwHooksHandler->getHookRegistry()->getHandlerFor( 'LinksUpdateConstructed' )
 		);
+
+		$this->getStore()->setup( false );
 	}
 
 	protected function tearDown() {

--- a/tests/phpunit/Unit/SQLStore/ChangeOp/TableChangeOpTest.php
+++ b/tests/phpunit/Unit/SQLStore/ChangeOp/TableChangeOpTest.php
@@ -146,7 +146,7 @@ class TableChangeOpTest extends \PHPUnit_Framework_TestCase {
 		);
 
 		$this->assertCount(
-			3,
+			2,
 			$instance->getFieldChangeOps()
 		);
 	}

--- a/tests/phpunit/Utils/Runners/MaintenanceRunner.php
+++ b/tests/phpunit/Utils/Runners/MaintenanceRunner.php
@@ -55,7 +55,7 @@ class MaintenanceRunner {
 	 * @return MaintenanceRunner
 	 */
 	public function setQuiet() {
-		$this->quiet = true;
+		$this->options['quiet'] = true;
 		return $this;
 	}
 
@@ -80,9 +80,14 @@ class MaintenanceRunner {
 			throw new DomainException( "Expected a Maintenance instance" );
 		}
 
+		// isset/ null
+		if ( isset( $this->options['quiet'] ) && $this->options['quiet'] === false ) {
+			unset( $this->options['quiet'] );
+		}
+
 		$maintenance->loadParamsAndArgs(
 			$this->maintenanceClass,
-			array_merge( $this->options, array( 'quiet' => $this->quiet ) )
+			$this->options
 		);
 
 		ob_start();

--- a/tests/phpunit/Utils/Runners/RunnerFactory.php
+++ b/tests/phpunit/Utils/Runners/RunnerFactory.php
@@ -48,6 +48,9 @@ class RunnerFactory {
 			case 'rebuildConceptCache';
 				$maintenanceClass = 'SMW\Maintenance\RebuildConceptCache';
 				break;
+			case 'setupStore';
+				$maintenanceClass = 'SMW\Maintenance\SetupStore';
+				break;
 		}
 
 		return new MaintenanceRunner( $maintenanceClass );


### PR DESCRIPTION
This PR is made in reference to: #2135, #2388

This PR addresses or contains:

- Ensures all fixed properties are recorded and available in `TableChangeOp`
- Adds a fixed user property integration test to test the fixed user properties in connection with `TableChangeOp` and `TextByChangeUpdater`

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed
