### PR TITLE
QueryDependencyLinksStore to avoid activities during 'stashedit', refs 2484

### DIFF
--- a/src/ParserFunctionFactory.php
+++ b/src/ParserFunctionFactory.php
@@ -85,6 +85,9 @@ class ParserFunctionFactory {
 			$parserData->setOption( $parserData::NO_QUERY_DEPENDENCY_TRACE, $parser->getOptions()->smwAskNoDependencyTracking );
 		}
 
+		// Avoid possible actions during for example stashedit etc.
+		$parserData->setOption( 'request.action', $GLOBALS['wgRequest']->getVal( 'action' ) );
+
 		$messageFormatter = new MessageFormatter(
 			$parser->getTargetLanguage()
 		);
@@ -118,6 +121,9 @@ class ParserFunctionFactory {
 		if ( isset( $parser->getOptions()->smwAskNoDependencyTracking ) ) {
 			$parserData->setOption( $parserData::NO_QUERY_DEPENDENCY_TRACE, $parser->getOptions()->smwAskNoDependencyTracking );
 		}
+
+		// Avoid possible actions during for example stashedit etc.
+		$parserData->setOption( 'request.action', $GLOBALS['wgRequest']->getVal( 'action' ) );
 
 		$messageFormatter = new MessageFormatter(
 			$parser->getTargetLanguage()

--- a/src/ParserFunctions/AskParserFunction.php
+++ b/src/ParserFunctions/AskParserFunction.php
@@ -223,6 +223,7 @@ class AskParserFunction {
 
 		$query->setOption( Query::PROC_CONTEXT, 'AskParserFunction' );
 		$query->setOption( Query::NO_DEPENDENCY_TRACE, $this->noTrace );
+		$query->setOption( 'request.action', $this->parserData->getOption( 'request.action' ) );
 
 		$queryHash = $query->getHash();
 

--- a/src/SQLStore/QueryDependency/QueryDependencyLinksStore.php
+++ b/src/SQLStore/QueryDependency/QueryDependencyLinksStore.php
@@ -403,6 +403,11 @@ class QueryDependencyLinksStore implements LoggerAwareInterface {
 
 		$query = $queryResult->getQuery();
 
+		// #2484 Avoid any update activities during a stashedit API access
+		if ( $query->getOption( 'request.action' ) === 'stashedit' ) {
+			return false;
+		}
+
 		return $query !== null && $query->getContextPage() !== null && $query->getLimit() > 0 && $query->getOption( Query::NO_DEPENDENCY_TRACE ) !== true;
 	}
 

--- a/tests/phpunit/Unit/ParserFunctionFactoryTest.php
+++ b/tests/phpunit/Unit/ParserFunctionFactoryTest.php
@@ -102,7 +102,7 @@ class ParserFunctionFactoryTest extends \PHPUnit_Framework_TestCase {
 
 	public function testAskParserFunctionWithParserOption() {
 
-		$this->parserData->expects( $this->once() )
+		$this->parserData->expects( $this->at( 0 ) )
 			->method( 'setOption' )
 			->with(
 				$this->equalTo( \SMW\ParserData::NO_QUERY_DEPENDENCY_TRACE ),


### PR DESCRIPTION
This PR is made in reference to: #1117, #2484

This PR addresses or contains:

- Allows for the `QueryDependencyLinksStore` to suspend any DB activities during a `stashedit` request, the deferred execution will ensure that active changes will be stored on a save event

This PR includes:
- [ ] Tests (unit/integration)
- [x] CI build passed
