### PR TITLE
Fix for finallistsep not showing up

### DIFF
--- a/includes/queryprinters/ListResultPrinter.php
+++ b/includes/queryprinters/ListResultPrinter.php
@@ -325,7 +325,7 @@ class ListResultPrinter extends ResultPrinter {
 
 		if ( $this->numRows > 0 && $this->isPlainlist() )  {
 			// Use comma between "rows" other than the last one:
-			return ( $this->numRows <= $res->getCount() ) ? $this->listsep : $this->finallistsep;
+			return ( $this->numRows + 1 < $res->getCount() ) ? $this->listsep : $this->finallistsep;
 		}
 
 		if ( $this->rowSortkey !== '' ) {


### PR DESCRIPTION
When using the list format `$this->numRows` contains the current row number starting from 0, so when comparing it to the number of rows in the result you need to add 1.
Then you need to make sure that the normal listsep is returned only for rows strictly less than the row count. For row number == row count the finallistsep needs to be returned.

(Generally `$this->numrows` should probably start from 1, but I don't  want to dig in right now and fix all the usages.)

This PR includes:
- [ ] Tests (unit/integration)
- [ ] CI build passed
