### PR TITLE
Provide a ChunkedIterator, refs 1938

### DIFF
--- a/src/IteratorFactory.php
+++ b/src/IteratorFactory.php
@@ -4,6 +4,7 @@ namespace SMW;
 
 use SMW\Iterators\ResultIterator;
 use SMW\Iterators\MappingIterator;
+use SMW\Iterators\ChunkedIterator;
 
 /**
  * @license GNU GPL v2+
@@ -34,6 +35,18 @@ class IteratorFactory {
 	 */
 	public function newMappingIterator( $iterable, callable $callback ) {
 		return new MappingIterator( $iterable, $callback );
+	}
+
+	/**
+	 * @since 3.0
+	 *
+	 * @param Iterator/array $$iterable
+	 * @param integer $chunkSize
+	 *
+	 * @return ChunkedIterator
+	 */
+	public function newChunkedIterator( $iterable, $chunkSize = 500 ) {
+		return new ChunkedIterator( $iterable, $chunkSize );
 	}
 
 }

--- a/src/Iterators/ChunkedIterator.php
+++ b/src/Iterators/ChunkedIterator.php
@@ -1,0 +1,97 @@
+<?php
+
+namespace SMW\Iterators;
+
+use IteratorIterator;
+use Traversable;
+use ArrayIterator;
+use InvalidArgumentException;
+use RuntimeException;
+
+/**
+ * @see Guzzle::ChunkedIterator
+ *
+ * @license GNU GPL v2+
+ * @since 3.0
+ */
+class ChunkedIterator extends IteratorIterator {
+
+	/**
+	 * @var integer
+	 */
+	private $chunkSize = 0;
+
+	/**
+	 * @var array
+	 */
+	private $chunk;
+
+	/**
+	 * @since 3.0
+	 *
+	 * @param Traversable|array $iterator
+	 * @param integer $chunkSize
+	 */
+	public function __construct( $iterable, $chunkSize = 500 ) {
+
+		$chunkSize = (int)$chunkSize;
+
+		if ( is_array( $iterable ) ) {
+			$iterable = new ArrayIterator( $iterable );
+		}
+
+		if ( !$iterable instanceof Traversable ) {
+			throw new RuntimeException( "ChunkedIterator expected an Traversable" );
+		}
+
+		if ( $chunkSize < 0 ) {
+			throw new InvalidArgumentException( "$chunkSize is lower than 0" );
+		}
+
+		parent::__construct( $iterable );
+		$this->chunkSize = $chunkSize;
+	}
+
+	/**
+	 * @since 3.0
+	 *
+	 * {@inheritDoc}
+	 */
+   public function rewind() {
+		parent::rewind();
+		$this->next();
+	}
+
+	/**
+	 * @since 3.0
+	 *
+	 * {@inheritDoc}
+	 */
+	public function next() {
+		$this->chunk = array();
+
+		for ( $i = 0; $i < $this->chunkSize && parent::valid(); $i++ ) {
+			$this->chunk[] = parent::current();
+			parent::next();
+		}
+	}
+
+	/**
+	 * @since 3.0
+	 *
+	 * {@inheritDoc}
+	 */
+	public function current() {
+		return $this->chunk;
+	}
+
+	/**
+	 * @since 3.0
+	 *
+	 * {@inheritDoc}
+	 */
+	public function valid() {
+		return (bool) $this->chunk;
+	}
+
+}

--- a/src/MediaWiki/Jobs/EntityIdDisposerJob.php
+++ b/src/MediaWiki/Jobs/EntityIdDisposerJob.php
@@ -5,6 +5,7 @@ namespace SMW\MediaWiki\Jobs;
 use Hooks;
 use SMW\ApplicationFactory;
 use SMW\SQLStore\PropertyTableIdReferenceDisposer;
+use SMW\Iterators\ChunkedIterator;
 use Title;
 
 /**
@@ -14,6 +15,11 @@ use Title;
  * @author mwjames
  */
 class EntityIdDisposerJob extends JobBase {
+
+	/**
+	 * Commit chunk size
+	 */
+	const CHUNK_SIZE = 200;
 
 	/**
 	 * @var PropertyTableIdReferenceDisposer
@@ -77,8 +83,24 @@ class EntityIdDisposerJob extends JobBase {
 	}
 
 	private function doDisposeAll( $outdatedEntitiesResultIterator ) {
-		foreach ( $outdatedEntitiesResultIterator as $row ) {
-			$this->dispose( $row );
+
+		$applicationFactory = ApplicationFactory::getInstance();
+		$connection = $applicationFactory->getStore()->getConnection( 'mw.db' );
+
+		$chunkedIterator = $applicationFactory->getIteratorFactory()->newChunkedIterator(
+			$outdatedEntitiesResultIterator,
+			self::CHUNK_SIZE
+		);
+
+		foreach ( $chunkedIterator as $chunk ) {
+
+			$transactionTicket = $connection->getEmptyTransactionTicket( __METHOD__ );
+
+			foreach ( $chunk as $row ) {
+				$this->dispose( $row );
+			}
+
+			$connection->commitAndWaitForReplication( __METHOD__, $transactionTicket );
 		}
 	}
 

--- a/src/SQLStore/PropertyTableIdReferenceDisposer.php
+++ b/src/SQLStore/PropertyTableIdReferenceDisposer.php
@@ -224,7 +224,7 @@ class PropertyTableIdReferenceDisposer {
 		$eventHandler = EventHandler::getInstance();
 
 		$dispatchContext = $eventHandler->newDispatchContext();
-		$dispatchContext->set( 'subject', $subject );
+		$dispatchContext->set( 'subject', $subject->asBase() );
 		$dispatchContext->set( 'context', 'PropertyTableIdReferenceDisposal' );
 
 		$eventHandler->getEventDispatcher()->dispatch(

--- a/tests/phpunit/Unit/IteratorFactoryTest.php
+++ b/tests/phpunit/Unit/IteratorFactoryTest.php
@@ -44,4 +44,18 @@ class IteratorFactoryTest extends \PHPUnit_Framework_TestCase {
 		);
 	}
 
+	public function testCanConstructChunkedIterator() {
+
+		$instance = new IteratorFactory();
+
+		$iterator = $this->getMockBuilder( '\Iterator' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$this->assertInstanceOf(
+			'\SMW\Iterators\ChunkedIterator',
+			$instance->newChunkedIterator( $iterator )
+		);
+	}
+
 }

--- a/tests/phpunit/Unit/Iterators/ChunkedIteratorTest.php
+++ b/tests/phpunit/Unit/Iterators/ChunkedIteratorTest.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace SMW\Iterators\Tests;
+
+use SMW\Iterators\ChunkedIterator;
+
+/**
+ * @covers \SMW\Iterators\ChunkedIterator
+ * @group semantic-mediawiki
+ *
+ * @license GNU GPL v2+
+ * @since 3.0
+ *
+ * @author mwjames
+ */
+class ChunkedIteratorTest extends \PHPUnit_Framework_TestCase {
+
+	public function testCanConstruct() {
+
+		$this->assertInstanceOf(
+			ChunkedIterator::class,
+			new ChunkedIterator( array() )
+		);
+	}
+
+	public function testChunkedOnArray() {
+
+		$result = array(
+			1, 42, 1001, 9999
+		);
+
+		$instance = new ChunkedIterator( $result, 2 );
+
+		foreach ( $instance as $chunk ) {
+			$this->assertCount(
+				2,
+				$chunk
+			);
+		}
+
+		$chunks = iterator_to_array( $instance, false );
+
+		$this->assertEquals(
+			[1, 42],
+			$chunks[0]
+		);
+
+		$this->assertEquals(
+			[1001, 9999],
+			$chunks[1]
+		);
+	}
+
+	public function testInvalidConstructorArgumentThrowsException() {
+
+		$this->setExpectedException( 'RuntimeException' );
+		$instance = new ChunkedIterator( 2 );
+	}
+
+	public function testInvalidChunkSizeArgumentThrowsException() {
+
+		$this->setExpectedException( 'InvalidArgumentException' );
+		$instance = new ChunkedIterator( array(), -1 );
+	}
+
+}


### PR DESCRIPTION
This PR is made in reference to: #1938

This PR addresses or contains:

- Adds a `ChunkedIterator` to avoid a possible OOM in cases where outdated entities reach a level of insanity 
- `EntityIdDisposerJob` to post a `Databae::commitAndWaitForReplication` where available (1.28+) after each chunk to release the transaction queue

http://wiki.teamliquid.net/dota2/Special:Statistics

![image](https://cloud.githubusercontent.com/assets/1245473/26750493/1fc3286e-485f-11e7-9f8b-0c2964fc9651.png)


This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed
