### PR TITLE
Normalize message value arguments

### DIFF
--- a/src/Message.php
+++ b/src/Message.php
@@ -111,7 +111,16 @@ class Message {
 			$type = self::TEXT;
 		}
 
-		return json_encode( array_merge( (array)$type, (array)$message ) );
+		$message = (array)$message;
+		$encode = array();
+		$encode[] = $type;
+
+		// Normalize arguments like "<strong>Expression error: Unrecognized word "yyyy".</strong>"
+		foreach ( $message as $value ) {
+			$encode[] = strip_tags( htmlspecialchars_decode( $value, ENT_QUOTES ) );
+		}
+
+		return json_encode( $encode );
 	}
 
 	/**

--- a/tests/phpunit/Unit/DataValues/ValueValidators/AllowsListConstraintValueValidatorTest.php
+++ b/tests/phpunit/Unit/DataValues/ValueValidators/AllowsListConstraintValueValidatorTest.php
@@ -179,7 +179,7 @@ class AllowsListConstraintValueValidatorTest extends \PHPUnit_Framework_TestCase
 
 		$this->assertEquals(
 			array(
-				'2da6400856e4455038d21793670ff9f7' => '[8,"smw_notinenum",null,"VAL1, VAL2, VAL3, VAL4, VAL5, VAL6, VAL7, VAL8, VAL9, VAL0, ...","InvalidAllowedValue"]'
+				'2da6400856e4455038d21793670ff9f7' => '[8,"smw_notinenum","","VAL1, VAL2, VAL3, VAL4, VAL5, VAL6, VAL7, VAL8, VAL9, VAL0, ...","InvalidAllowedValue"]'
 			),
 			$dataValue->getErrors()
 		);

--- a/tests/phpunit/Unit/MessageTest.php
+++ b/tests/phpunit/Unit/MessageTest.php
@@ -154,21 +154,14 @@ class MessageTest extends \PHPUnit_Framework_TestCase {
 		$instance->deregisterHandlerFor( 'SimpleText' );
 	}
 
-	public function testEncode() {
+	/**
+	 * @dataProvider encodeProvider
+	 */
+	public function testEncode( $string, $expected ) {
 
 		$this->assertEquals(
-			'[2,"Foo"]',
-			Message::encode( 'Foo' )
-		);
-
-		$this->assertEquals(
-			'[2,"Foo"]',
-			Message::encode( array( 'Foo' ) )
-		);
-
-		$this->assertEquals(
-			'[2,"Foo"]',
-			Message::encode( '[2,"Foo"]' )
+			$expected,
+			Message::encode( $string )
 		);
 	}
 
@@ -183,6 +176,31 @@ class MessageTest extends \PHPUnit_Framework_TestCase {
 			'Foo',
 			Message::decode( '[2,"Foo"]' )
 		);
+	}
+
+	public function encodeProvider() {
+
+		$provider[] = array(
+			'Foo',
+			'[2,"Foo"]'
+		);
+
+		$provider[] = array(
+			array( 'Foo' ),
+			'[2,"Foo"]'
+		);
+
+		$provider[] = array(
+			'[2,"Foo"]',
+			'[2,"Foo"]'
+		);
+
+		$provider[] = array(
+			array( 'Foo', '<strong>Expression error: Unrecognized word "yyyy".</strong>' ),
+			'[2,"Foo","Expression error: Unrecognized word \"yyyy\"."]'
+		);
+
+		return $provider;
 	}
 
 }


### PR DESCRIPTION
This PR is made in reference to: #

This PR addresses or contains:

- Avoid to break JSON encoding for arguments that contain things like `"Expression error: Unexpected < operator." is not recognized as a Boolean (true/false) value.`

![image](https://cloud.githubusercontent.com/assets/1245473/26753678/8930ffbe-48a6-11e7-803f-edc12e18ea28.png)

http://wiki.teamliquid.net/dota2/index.php?title=Special:Ask&q=[[Has+processing+error+text%3A%3A%2B]]&po=%3FHas+improper+value+for|%3FHas+processing+error+text&p=class%3Dsortable-20wikitable-20smwtable-2Dstriped&eq=no&limit=100&bTitle=processingerrorlist&bMsg=smw-processingerrorlist-intro

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed
