### PR TITLE
Add `smwgFieldTypeFeatures` (SMW_FIELDT_CHAR_NOCASE), refs 1912

### DIFF
--- a/DefaultSettings.php
+++ b/DefaultSettings.php
@@ -152,6 +152,8 @@ return array(
 	#   as in case of for example "Ennis, Ennis Hill, Ennis Jones, Ennis-Hill,
 	#   Ennis-London"
 	#
+	# - SMW_SPARQL_QF_NOCASE to support case insensitive pattern matches
+	#
 	# Please check with your repository provider whether SPARQL 1.1 is fully
 	# supported or not, and if not SMW_SPARQL_QF_NONE should be set.
 	#
@@ -1541,6 +1543,38 @@ return array(
 	# @default false
 	##
 	'smwgEntityLookupFeatures' => SMW_EL_INPROP,
+	##
+
+	##
+	# SQLStore specific field type features
+	#
+	# SMW_FIELDT_NONE
+	#
+	# SMW_FIELDT_CHAR_NOCASE - Modifies selected search fields to use a case
+	# insensitive collation and may require additional extension (e.g. Postgres
+	# requires `citext`) on non MySQL related systems therefore it is disabled
+	# by default.
+	#
+	# Furthermore, no extensive analysis has been performed on how the switch
+	# from VARBINARY to a collated VARCHAR field type affects the search
+	# performance.
+	#
+	# If enabled, the setting will replace selected `FieldType::FIELD_TITLE`
+	# types with `FieldType::TYPE_CHAR_NOCASE`.
+	#
+	# `FieldType::TYPE_CHAR_NOCASE` has been defined as:
+	#
+	# - MySQL: VARCHAR(255) CHARSET utf8 COLLATE utf8_general_ci
+	# - Postgres: citext NOT NULL
+	# - SQLite: VARCHAR(255) NOT NULL COLLATE NOCASE but according to [0] this may
+	#   not work and need a special solution as hinted in [0]
+	#
+	# [0] https://techblog.dorogin.com/case-insensitive-like-in-sqlite-504f594dcdc3
+	#
+	# @since 3.0
+	# @default false
+	##
+	'smwgFieldTypeFeatures' => false,
 	##
 
 );

--- a/includes/Settings.php
+++ b/includes/Settings.php
@@ -178,6 +178,7 @@ class Settings extends Options {
 			'smwgPropertyInvalidCharacterList' => $GLOBALS['smwgPropertyInvalidCharacterList'],
 			'smwgEntityCollation' => $GLOBALS['smwgEntityCollation'],
 			'smwgEntityLookupFeatures' => $GLOBALS['smwgEntityLookupFeatures'],
+			'smwgFieldTypeFeatures' => $GLOBALS['smwgFieldTypeFeatures'],
 		);
 
 		self::initLegacyMapping( $configuration );

--- a/maintenance/setupStore.php
+++ b/maintenance/setupStore.php
@@ -87,7 +87,7 @@ class SetupStore extends \Maintenance {
 		$this->loadGlobalFunctions();
 
 		$store = $this->getStore();
-		$store->clear();
+		StoreFactory::clear();
 
 		if ( $this->getOption( 'quiet' ) ) {
 			$messageReporter = MessageReporterFactory::getInstance()->newNullMessageReporter();
@@ -100,10 +100,6 @@ class SetupStore extends \Maintenance {
 			Installer::OPT_MESSAGEREPORTER,
 			$messageReporter
 		);
-
-		if ( method_exists( $store, 'getPropertyTableInfoFetcher' ) ) {
-			$store->getPropertyTableInfoFetcher()->clearCache();
-		}
 
 		if ( $this->hasOption( 'delete' ) ) {
 			$this->dropStore( $store );

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -57,6 +57,7 @@
        <var name="smwgSemanticsEnabled" value="true"/>
        <var name="wgUseFileCache" value="false"/>
        <var name="smwgEntityCollation" value="identity"/>
+       <var name="smwgFieldTypeFeatures" value="false"/>
        <var name="smwgSparqlDefaultGraph" value="http://example.org/phpunit-testrun"/>
        <var name="smwgValueLookupCacheType" value="hash"/>
        <var name="smwgEnabledDeferredUpdate" value="false"/>

--- a/src/Defines.php
+++ b/src/Defines.php
@@ -128,6 +128,7 @@ define( 'SMW_SPARQL_QF_REDI', 2 ); // support for inverse property paths to find
 define( 'SMW_SPARQL_QF_SUBP', 4 ); // support for rdfs:subPropertyOf*
 define( 'SMW_SPARQL_QF_SUBC', 8 ); // support for rdfs:subClassOf*
 define( 'SMW_SPARQL_QF_COLLATION', 16 ); // support for use of $smwgEntityCollation
+define( 'SMW_SPARQL_QF_NOCASE', 32 ); // support case insensitive pattern matches
 /**@}*/
 
 /**@{
@@ -209,4 +210,11 @@ define( 'SMW_RF_TEMPLATE_OUTSEP', 2 ); // #2022 Enable 2.5 behaviour for templat
   */
 define( 'SMW_EL_NONE', 0 );
 define( 'SMW_EL_INPROP', 2 ); // New query for EntityLookup::getInProperties
+/**@}*/
+
+/**@{
+  * Constants for $smwgFieldTypeFeatures
+  */
+define( 'SMW_FIELDT_NONE', 0 );
+define( 'SMW_FIELDT_CHAR_NOCASE', 2 ); // Using FieldType::TYPE_CHAR_NOCASE
 /**@}*/

--- a/src/SPARQLStore/QueryEngine/DescriptionInterpreters/ValueDescriptionInterpreter.php
+++ b/src/SPARQLStore/QueryEngine/DescriptionInterpreters/ValueDescriptionInterpreter.php
@@ -230,8 +230,10 @@ class ValueDescriptionInterpreter implements DescriptionInterpreter {
 
 	private function createFilterConditionToMatchRegexPattern( $dataItem, &$joinVariable, $comparator, $pattern ) {
 
+		$flag = $this->compoundConditionBuilder->canUseQFeature( SMW_SPARQL_QF_NOCASE ) ? 'i' : 's';
+
 		if ( $dataItem instanceof DIBlob ) {
-			return new FilterCondition( "$comparator( ?$joinVariable, \"$pattern\", \"s\")", array() );
+			return new FilterCondition( "$comparator( ?$joinVariable, \"$pattern\", \"$flag\")", array() );
 		}
 
 		if ( $dataItem instanceof DIUri ) {
@@ -250,7 +252,7 @@ class ValueDescriptionInterpreter implements DescriptionInterpreter {
 		$condition->condition = "?$joinVariable " . $skeyExpElement->getQName(). " ?$filterVariable .\n";
 		$condition->matchElement = "?$joinVariable";
 
-		$filterCondition = new FilterCondition( "$comparator( ?$filterVariable, \"$pattern\", \"s\")", array() );
+		$filterCondition = new FilterCondition( "$comparator( ?$filterVariable, \"$pattern\", \"$flag\")", array() );
 
 		$condition->weakConditions = array( $filterVariable => $filterCondition->getCondition() );
 

--- a/src/SQLStore/EntityStore/DIHandlers/DIBlobHandler.php
+++ b/src/SQLStore/EntityStore/DIHandlers/DIBlobHandler.php
@@ -20,26 +20,6 @@ use SMW\SQLStore\TableBuilder\FieldType;
 class DIBlobHandler extends DataItemHandler {
 
 	/**
-	 * Maximal number of bytes (chars) to be stored in the hash field of
-	 * the table. Must not be bigger than 255 (the length of our VARCHAR
-	 * field in the DB). Strings that are longer than this will be stored
-	 * as a blob, and the hash will only start with the original string
-	 * but the last 32 bytes are used for a hash. So the minimal portion
-	 * of the string that is stored literally in the hash is 32 chars
-	 * less.
-	 *
-	 * The value of 72 was chosen since it leads to a smaller index size
-	 * at the cost of needing more blobs in cases where many strings are
-	 * of length 73 to 255. But keeping the index small seems more
-	 * important than saving disk space. Also, with 72 bytes there are at
-	 * least 40 bytes of content available for sorting and prefix matching,
-	 * which should be more than enough in most contexts.
-	 *
-	 * @since 1.8
-	 */
-	const MAX_HASH_LENGTH = 72;
-
-	/**
 	 * @since 1.8
 	 *
 	 * {@inheritDoc}
@@ -47,7 +27,7 @@ class DIBlobHandler extends DataItemHandler {
 	public function getTableFields() {
 		return array(
 			'o_blob' => FieldType::TYPE_BLOB,
-			'o_hash' => FieldType::FIELD_TITLE
+			'o_hash' => $this->getCharFieldType()
 		);
 	}
 
@@ -59,7 +39,7 @@ class DIBlobHandler extends DataItemHandler {
 	public function getFetchFields() {
 		return array(
 			'o_blob' => FieldType::TYPE_BLOB,
-			'o_hash' => FieldType::FIELD_TITLE
+			'o_hash' => $this->getCharFieldType()
 		);
 	}
 
@@ -78,7 +58,7 @@ class DIBlobHandler extends DataItemHandler {
 	 * {@inheritDoc}
 	 */
 	public function getWhereConds( DataItem $dataItem ) {
-		return array( 'o_hash' => self::makeHash( $dataItem->getString() ) );
+		return array( 'o_hash' => $this->makeHash( $dataItem->getString() ) );
 	}
 
 	/**
@@ -87,11 +67,21 @@ class DIBlobHandler extends DataItemHandler {
 	 * {@inheritDoc}
 	 */
 	public function getInsertValues( DataItem $dataItem ) {
+
 		$text = htmlspecialchars_decode( trim( $dataItem->getString() ), ENT_QUOTES );
+		$hash = $this->makeHash( $text );
+
+		if ( $this->isDbType( 'postgres' ) ) {
+			$text = pg_escape_bytea( $text );
+		}
+
+		if ( mb_strlen( $text ) <= $this->getMaxLength() ) {
+			$text = null;
+		}
 
 		return array(
-			'o_blob' => strlen( $text ) <= self::MAX_HASH_LENGTH ? null : ( $GLOBALS['wgDBtype'] === 'postgres' ? pg_escape_bytea( $text ) : $text ),
-			'o_hash' => self::makeHash( $text ),
+			'o_blob' => $text,
+			'o_hash' => $hash,
 		);
 	}
 
@@ -119,35 +109,77 @@ class DIBlobHandler extends DataItemHandler {
 	 * {@inheritDoc}
 	 */
 	public function dataItemFromDBKeys( $dbkeys ) {
+
 		if ( !is_array( $dbkeys ) || count( $dbkeys ) != 2 ) {
 			throw new DataItemHandlerException( 'Failed to create data item from DB keys.' );
 		}
 
-		if ( $GLOBALS['wgDBtype'] === 'postgres' ) {
+		if ( $this->isDbType( 'postgres' ) ) {
 			$dbkeys[0] = pg_unescape_bytea( $dbkeys[0] );
 		}
 
-		if ( $dbkeys[0] == '' ) { // empty blob: use "hash" string
+		// empty blob: use "hash" string
+		if ( $dbkeys[0] == '' ) {
 			return new DIBlob( $dbkeys[1] );
-		} else {
-			return new DIBlob( $dbkeys[0] );
 		}
+
+		return new DIBlob( $dbkeys[0] );
 	}
 
 	/**
 	* Method to make a hashed representation for strings of length greater
-	* than self::MAX_HASH_LENGTH to be used for selecting and sorting.
+	* than DIBlobHandler::getMaxLength to be used for selecting and sorting.
 	*
 	* @since 1.8
 	* @param $string string
 	*
 	* @return string
 	*/
-	static protected function makeHash( $string ) {
-		if( strlen( $string ) <= self::MAX_HASH_LENGTH ) {
+	private function makeHash( $string ) {
+
+		$length = $this->getMaxLength();
+
+		if( mb_strlen( $string ) <= $length ) {
 			return $string;
-		} else {
-			return substr( $string, 0, self::MAX_HASH_LENGTH - 32 ) . md5( $string );
 		}
+
+		return mb_substr( $string, 0, $length - 32 ) . md5( $string );
 	}
+
+	/**
+	 * Maximal number of bytes (chars) to be stored in the hash field of
+	 * the table. Must not be bigger than 255 (the length of our VARCHAR
+	 * field in the DB). Strings that are longer than this will be stored
+	 * as a blob, and the hash will only start with the original string
+	 * but the last 32 bytes are used for a hash. So the minimal portion
+	 * of the string that is stored literally in the hash is 32 chars
+	 * less.
+	 *
+	 * The value of 72 was chosen since it leads to a smaller index size
+	 * at the cost of needing more blobs in cases where many strings are
+	 * of length 73 to 255. But keeping the index small seems more
+	 * important than saving disk space. Also, with 72 bytes there are at
+	 * least 40 bytes of content available for sorting and prefix matching,
+	 * which should be more than enough in most contexts.
+	 *
+	 * @since 1.8
+	 */
+	private function getMaxLength() {
+
+		$length = 72;
+
+		return $length;
+	}
+
+	private function getCharFieldType() {
+
+		$fieldType = FieldType::FIELD_TITLE;
+
+		if ( $this->isEnabledFeature( SMW_FIELDT_CHAR_NOCASE ) ) {
+			$fieldType = FieldType::TYPE_CHAR_NOCASE;
+		}
+
+		return $fieldType;
+	}
+
 }

--- a/src/SQLStore/EntityStore/DataItemHandler.php
+++ b/src/SQLStore/EntityStore/DataItemHandler.php
@@ -21,12 +21,56 @@ abstract class DataItemHandler {
 	protected $store;
 
 	/**
+	 * @var integer
+	*/
+	private $fieldTypeFeatures = false;
+
+	/**
+	 * @var null|string
+	*/
+	private $dbType;
+
+	/**
 	 * @since 1.8
 	 *
 	 * @param SQLStore $store
 	 */
 	public function __construct( SQLStore $store ) {
 		$this->store = $store;
+	}
+
+	/**
+	 * @since 3.0
+	 *
+	 * @param integer $fieldTypeFeatures
+	 */
+	public function setFieldTypeFeatures( $fieldTypeFeatures ) {
+		$this->fieldTypeFeatures = $fieldTypeFeatures;
+	}
+
+	/**
+	 * @since 3.0
+	 *
+	 * @param integer $feature
+	 *
+	 * @return boolean
+	 */
+	public function isEnabledFeature( $feature ) {
+		return ( (int)$this->fieldTypeFeatures & $feature ) != 0;
+	}
+
+	/**
+	 * @since 3.0
+	 *
+	 * @param boolean
+	 */
+	public function isDbType( $dbType ) {
+
+		if ( $this->dbType === null ) {
+			$this->dbType = $this->store->getConnection( 'mw.db' )->getType();
+		}
+
+		return $this->dbType === $dbType;
 	}
 
 	/**

--- a/src/SQLStore/EntityStore/DataItemHandlerDispatcher.php
+++ b/src/SQLStore/EntityStore/DataItemHandlerDispatcher.php
@@ -33,12 +33,26 @@ class DataItemHandlerDispatcher {
 	private $handlers = array();
 
 	/**
+	 * @var integer
+	*/
+	private $fieldTypeFeatures = false;
+
+	/**
 	 * @since 2.5
 	 *
 	 * @param SQLStore $store
 	 */
 	public function __construct( SQLStore $store ) {
 		$this->store = $store;
+	}
+
+	/**
+	 * @since 3.0
+	 *
+	 * @param integer $fieldTypeFeatures
+	 */
+	public function setFieldTypeFeatures( $fieldTypeFeatures ) {
+		$this->fieldTypeFeatures = $fieldTypeFeatures;
 	}
 
 	/**
@@ -51,11 +65,15 @@ class DataItemHandlerDispatcher {
 	 */
 	public function getHandlerByType( $type ) {
 
-		if ( isset( $this->handlers[$type] ) ) {
-			return $this->handlers[$type];
+		if ( !isset( $this->handlers[$type] ) ) {
+			$this->handlers[$type] = $this->newHandlerByType( $type );
 		}
 
-		return $this->handlers[$type] = $this->newHandlerByType( $type );
+	//	$this->handlers[$type]->setFieldTypeFeatures(
+	//		$this->fieldTypeFeatures
+	//	);
+
+		return $this->handlers[$type];
 	}
 
 	private function newHandlerByType( $type ) {
@@ -94,6 +112,10 @@ class DataItemHandlerDispatcher {
 			default:
 				throw new DataItemHandlerException( "The value \"$type\" is not a valid dataitem ID." );
 		}
+
+		$handler->setFieldTypeFeatures(
+			$this->fieldTypeFeatures
+		);
 
 		return $handler;
 	}

--- a/src/SQLStore/SQLStoreFactory.php
+++ b/src/SQLStore/SQLStoreFactory.php
@@ -362,6 +362,8 @@ class SQLStoreFactory {
 	 */
 	public function newInstaller() {
 
+		$settings = ApplicationFactory::getInstance()->getSettings();
+
 		$messageReporter = MessageReporterFactory::getInstance()->newNullMessageReporter();
 		$options = $this->store->getOptions();
 
@@ -379,6 +381,10 @@ class SQLStoreFactory {
 
 		$tableSchemaManager = new TableSchemaManager(
 			$this->store
+		);
+
+		$tableSchemaManager->setFieldTypeFeatures(
+			$settings->get( 'smwgFieldTypeFeatures' )
 		);
 
 		$installer = new Installer(
@@ -404,7 +410,18 @@ class SQLStoreFactory {
 	 * @return DataItemHandlerDispatcher
 	 */
 	public function newDataItemHandlerDispatcher() {
-		return new DataItemHandlerDispatcher( $this->store );
+
+		$settings = ApplicationFactory::getInstance()->getSettings();
+
+		$dataItemHandlerDispatcher = new DataItemHandlerDispatcher(
+			$this->store
+		);
+
+		$dataItemHandlerDispatcher->setFieldTypeFeatures(
+			$settings->get( 'smwgFieldTypeFeatures' )
+		);
+
+		return $dataItemHandlerDispatcher;
 	}
 
 	/**

--- a/src/SQLStore/TableBuilder/FieldType.php
+++ b/src/SQLStore/TableBuilder/FieldType.php
@@ -50,6 +50,16 @@ class FieldType {
 	/**
 	 * @var string
 	 */
+	const TYPE_CHAR_LONG = 'char long';
+
+	/**
+	 * @var string
+	 */
+	const TYPE_CHAR_LONG_NOCASE = 'char long nocase';
+
+	/**
+	 * @var string
+	 */
 	const TYPE_BOOL = 'boolean';
 
 	/**

--- a/src/SQLStore/TableBuilder/MySQLTableBuilder.php
+++ b/src/SQLStore/TableBuilder/MySQLTableBuilder.php
@@ -38,7 +38,9 @@ class MySQLTableBuilder extends TableBuilder {
 			'boolean'    => 'TINYINT(1)',
 			'double'     => 'DOUBLE',
 			'integer'    => 'INT(8)',
+			'char long'  => 'VARBINARY(300)',
 			'char nocase'      => 'VARCHAR(255) CHARSET utf8 COLLATE utf8_general_ci',
+			'char long nocase' => 'VARCHAR(300) CHARSET utf8 COLLATE utf8_general_ci',
 			'usage count'      => 'INT(8) UNSIGNED',
 			'integer unsigned' => 'INT(8) UNSIGNED'
 		);

--- a/src/SQLStore/TableBuilder/PostgresTableBuilder.php
+++ b/src/SQLStore/TableBuilder/PostgresTableBuilder.php
@@ -40,8 +40,10 @@ class PostgresTableBuilder extends TableBuilder {
 			'boolean'    => 'BOOLEAN',
 			'double'     => 'DOUBLE PRECISION',
 			'integer'    => 'bigint',
+			'char long'  => 'TEXT',
 			// Requires citext extension
-			'char nocase'      => 'citext NOT NULL',
+			'char nocase' => 'citext NOT NULL',
+			'char long nocase' => 'citext NOT NULL',
 			'usage count'      => 'bigint',
 			'integer unsigned' => 'INTEGER'
 		);

--- a/src/SQLStore/TableBuilder/SQLiteTableBuilder.php
+++ b/src/SQLStore/TableBuilder/SQLiteTableBuilder.php
@@ -37,8 +37,10 @@ class SQLiteTableBuilder extends TableBuilder {
 			'boolean'    => 'TINYINT(1)',
 			'double'     => 'DOUBLE',
 			'integer'    => 'INT(8)',
+			'char long'  => 'VARBINARY(300)',
 			'char nocase'      => 'VARCHAR(255) NOT NULL COLLATE NOCASE',
-			'usage count'      =>'INT(8)',
+			'char long nocase' => 'VARCHAR(300) NOT NULL COLLATE NOCASE',
+			'usage count'      => 'INT(8)',
 			'integer unsigned' => 'INTEGER'
 		);
 

--- a/tests/phpunit/Integration/JSONScript/JsonTestCaseScriptRunnerTest.php
+++ b/tests/phpunit/Integration/JSONScript/JsonTestCaseScriptRunnerTest.php
@@ -107,6 +107,8 @@ class JsonTestCaseScriptRunnerTest extends JsonTestCaseScriptRunner {
 
 		// Make sure LocalSettings don't interfere with the default settings
 		$GLOBALS['smwgDVFeatures'] = $GLOBALS['smwgDVFeatures'] & ~SMW_DV_NUMV_USPACE;
+		$GLOBALS['smwgFieldTypeFeatures'] = SMW_FIELDT_NONE;
+
 		$this->testEnvironment->addConfiguration( 'smwgQueryResultCacheType', false );
 		$this->testEnvironment->addConfiguration( 'smwgQFilterDuplicates', false );
 		$this->testEnvironment->addConfiguration( 'smwgExportResourcesAsIri', false );
@@ -188,6 +190,7 @@ class JsonTestCaseScriptRunnerTest extends JsonTestCaseScriptRunner {
 			'smwgUseCategoryRedirect',
 			'smwgQExpensiveThreshold',
 			'smwgQExpensiveExecutionLimit',
+			'smwgFieldTypeFeatures',
 
 			// MW related
 			'wgLanguageCode',
@@ -211,12 +214,12 @@ class JsonTestCaseScriptRunnerTest extends JsonTestCaseScriptRunner {
 
 		$pageList = $jsonTestCaseFileHandler->getPageCreationSetupList();
 
-		// Special handling for fixed properties to fetch the correct type
-		// before being used as annotation
-		if ( $jsonTestCaseFileHandler->getSettingsFor( 'smwgFixedProperties' ) !== array() ) {
+		// On some occasions ( e.g. fixed properties) to setup the correct
+		// table schema, run the creation once before the content is created
+		if ( $jsonTestCaseFileHandler->hasSetting( 'smwgFixedProperties' ) || $jsonTestCaseFileHandler->hasSetting( 'smwgFieldTypeFeatures' ) ) {
 			foreach ( $pageList as $page ) {
 				if ( isset( $page['namespace'] ) && $page['namespace'] === 'SMW_NS_PROPERTY' ) {
-					$this->doRunFixedPropertyTableCreation( $page );
+					$this->doRunTableSetupBeforeContentCreation( $page );
 				}
 			}
 		}
@@ -227,11 +230,11 @@ class JsonTestCaseScriptRunnerTest extends JsonTestCaseScriptRunner {
 		);
 	}
 
-	private function doRunFixedPropertyTableCreation( $page ) {
+	private function doRunTableSetupBeforeContentCreation( $page ) {
+
 		// Create property to ...
 		$this->createPagesFrom( array( $page ) );
 
-		// Create table
 		$maintenanceRunner = $this->runnerFactory->newMaintenanceRunner( 'setupStore' );
 		$maintenanceRunner->setQuiet();
 		$maintenanceRunner->run();

--- a/tests/phpunit/Integration/JSONScript/TestCases/q-0906.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/q-0906.json
@@ -1,0 +1,155 @@
+{
+	"description": "Test `_wpg`/`_txt` with enabled `SMW_FIELDT_CHAR_NOCASE` (#1912, `smwgFieldTypeFeatures`)",
+	"setup": [
+		{
+			"namespace": "SMW_NS_PROPERTY",
+			"page": "Has page",
+			"contents": "[[Has type::Page]]"
+		},
+		{
+			"namespace": "SMW_NS_PROPERTY",
+			"page": "Has text",
+			"contents": "[[Has type::Text]]"
+		},
+		{
+			"page": "Example/Q0906/1",
+			"contents": "[[Category:Q0906]] [[Has page::noCASE]] [[Has text::noCASE]]"
+		},
+		{
+			"page": "Example/Q0906/2",
+			"contents": "[[Category:Q0906]] [[Has page::NOcase]] [[Has text::NOcase]]"
+		},
+		{
+			"page": "Example/Q0906/3",
+			"contents": "[[Category:Q0906]] [[Has page::NOoNcase]] [[Has text::NOoNcase]]"
+		}
+	],
+	"tests": [
+		{
+			"type": "query",
+			"about": "#0 (on _wpg type ~ match)",
+			"condition": "[[Category:Q0906]] [[Has page::~*noCa*]]",
+			"printouts": [],
+			"parameters": {
+				"limit": "10"
+			},
+			"assert-queryresult": {
+				"count": 2,
+				"results": [
+					"Example/Q0906/1#0##",
+					"Example/Q0906/2#0##"
+				]
+			}
+		},
+		{
+			"type": "query",
+			"about": "#1 (on _txt type as ~ match)",
+			"condition": "[[Category:Q0906]] [[Has text::~*NOcA*]]",
+			"printouts": [],
+			"parameters": {
+				"limit": "10"
+			},
+			"assert-queryresult": {
+				"count": 2,
+				"results": [
+					"Example/Q0906/1#0##",
+					"Example/Q0906/2#0##"
+				]
+			}
+		},
+		{
+			"type": "query",
+			"about": "#2 (on _wpg type !~ match)",
+			"condition": "[[Category:Q0906]] [[Has page::!~*noCa*]]",
+			"printouts": [],
+			"parameters": {
+				"limit": "10"
+			},
+			"assert-queryresult": {
+				"count": 1,
+				"results": [
+					"Example/Q0906/3#0##"
+				]
+			}
+		},
+		{
+			"type": "query",
+			"about": "#3 (on _txt type as !~ match)",
+			"condition": "[[Category:Q0906]] [[Has text::!~*NOcA*]]",
+			"printouts": [],
+			"parameters": {
+				"limit": "10"
+			},
+			"assert-queryresult": {
+				"count": 1,
+				"results": [
+					"Example/Q0906/3#0##"
+				]
+			}
+		},
+		{
+			"type": "query",
+			"skip-on": {
+				"virtuoso": "Not suported",
+				"sesame": "Not suported",
+				"fuseki": "Not suported",
+				"blazegraph": "Not suported"
+			},
+			"about": "#4 (on _txt type as object match)",
+			"condition": "[[Category:Q0906]] [[Has text::nocase]]",
+			"printouts": [],
+			"parameters": {
+				"limit": "10"
+			},
+			"assert-queryresult": {
+				"count": 2,
+				"results": [
+					"Example/Q0906/1#0##",
+					"Example/Q0906/2#0##"
+				]
+			}
+		},
+		{
+			"type": "query",
+			"skip-on": {
+				"virtuoso": "Not suported",
+				"sesame": "Not suported",
+				"fuseki": "Not suported",
+				"blazegraph": "Not suported"
+			},
+			"about": "#5 (on _txt type as !object match)",
+			"condition": "[[Category:Q0906]] [[Has text::!nocase]]",
+			"printouts": [],
+			"parameters": {
+				"limit": "10"
+			},
+			"assert-queryresult": {
+				"count": 1,
+				"results": [
+					"Example/Q0906/3#0##"
+				]
+			}
+		}
+	],
+	"settings": {
+		"smwgNamespacesWithSemanticLinks": {
+			"NS_MAIN": true,
+			"SMW_NS_PROPERTY": true
+		},
+		"smwgSparqlQFeatures": [
+			"SMW_SPARQL_QF_NOCASE"
+		],
+		"smwgFieldTypeFeatures": [
+			"SMW_FIELDT_CHAR_NOCASE"
+		]
+	},
+	"meta": {
+		"skip-on": {
+			"postgres": "Error: 42704 ERROR:  type \"citext\" does not exist",
+			"sqlite": "NOCASE is not supported"
+		},
+		"version": "2",
+		"is-incomplete": false,
+		"debug": false
+	}
+}

--- a/tests/phpunit/JsonTestCaseFileHandler.php
+++ b/tests/phpunit/JsonTestCaseFileHandler.php
@@ -197,6 +197,20 @@ class JsonTestCaseFileHandler {
 	}
 
 	/**
+	 * @since 3.0
+	 *
+	 * @param string $key
+	 *
+	 * @return booleam
+	 */
+	public function hasSetting( $key ) {
+
+		$settings = $this->getFileContentsFor( 'settings' );
+
+		return isset( $settings[$key] );
+	}
+
+	/**
 	 * @since 2.2
 	 *
 	 * @return array|integer|string|boolean
@@ -226,7 +240,8 @@ class JsonTestCaseFileHandler {
 		$constantFeaturesList = array(
 			'smwgSparqlQFeatures',
 			'smwgDVFeatures',
-			'smwgFulltextSearchIndexableDataTypes'
+			'smwgFulltextSearchIndexableDataTypes',
+			'smwgFieldTypeFeatures'
 		);
 
 		foreach ( $constantFeaturesList as $constantFeatures ) {

--- a/tests/phpunit/Unit/SQLStore/EntityStore/DIHandlers/DIBlobHandlerTest.php
+++ b/tests/phpunit/Unit/SQLStore/EntityStore/DIHandlers/DIBlobHandlerTest.php
@@ -1,0 +1,223 @@
+<?php
+
+namespace SMW\Tests\SQLStore\EntityStore\DIHandlers;
+
+use SMW\SQLStore\EntityStore\DIHandlers\DIBlobHandler;
+use SMW\SQLStore\TableBuilder\FieldType;
+use SMWDIBlob as DIBlob;
+
+/**
+ * @covers \SMW\SQLStore\EntityStore\DIHandlers\DIBlobHandler
+ * @group semantic-mediawiki
+ *
+ * @license GNU GPL v2+
+ * @since   3.0
+ *
+ * @author mwjames
+ */
+class DIBlobHandlerTest extends \PHPUnit_Framework_TestCase {
+
+	private $store;
+
+	protected function setUp() {
+		parent::setUp();
+
+		$connection = $this->getMockBuilder( '\SMW\MediaWiki\Database' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$this->store = $this->getMockBuilder( '\SMW\SQLStore\SQLStore' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$this->store->expects( $this->any() )
+			->method( 'getConnection' )
+			->will( $this->returnValue( $connection ) );
+	}
+
+	public function testCanConstruct() {
+
+		$this->assertInstanceOf(
+			DIBlobHandler::class,
+			new DIBlobHandler( $this->store )
+		);
+	}
+
+	public function testImmutableMethodAccess() {
+
+		$instance = new DIBlobHandler(
+			$this->store
+		);
+
+		$this->assertInternalType(
+			'array',
+			$instance->getTableFields()
+		);
+
+		$this->assertInternalType(
+			'array',
+			$instance->getFetchFields()
+		);
+
+		$this->assertInternalType(
+			'array',
+			$instance->getTableIndexes()
+		);
+
+		$this->assertInternalType(
+			'string',
+			$instance->getIndexField()
+		);
+
+		$this->assertInternalType(
+			'string',
+			$instance->getLabelField()
+		);
+	}
+
+	public function testMutableMethodAccess() {
+
+		$blob = new DIBlob( 'Foo' );
+
+		$instance = new DIBlobHandler(
+			$this->store
+		);
+
+		$this->assertInternalType(
+			'array',
+			$instance->getWhereConds( $blob )
+		);
+
+		$this->assertInternalType(
+			'array',
+			$instance->getInsertValues( $blob )
+		);
+	}
+
+	public function testMutableOnNoCaseFieldFeature() {
+
+		$instance = new DIBlobHandler(
+			$this->store
+		);
+
+		$expected = [
+			'o_blob' => FieldType::TYPE_BLOB,
+			'o_hash' => FieldType::FIELD_TITLE
+		];
+
+		$this->assertEquals(
+			$expected,
+			$instance->getTableFields()
+		);
+
+		$this->assertEquals(
+			$expected,
+			$instance->getFetchFields()
+		);
+
+		$instance->setFieldTypeFeatures(
+			SMW_FIELDT_CHAR_NOCASE
+		);
+
+		$expected = [
+			'o_blob' => FieldType::TYPE_BLOB,
+			'o_hash' => FieldType::TYPE_CHAR_NOCASE
+		];
+
+		$this->assertEquals(
+			$expected,
+			$instance->getTableFields()
+		);
+
+		$this->assertEquals(
+			$expected,
+			$instance->getFetchFields()
+		);
+	}
+
+	public function testMutableInsertValuesOnVariableLength() {
+
+		$instance = new DIBlobHandler( $this->store );
+
+		$s72  = 'zcqaBHr1jV7mINGovktU8bD6zYjgKMqfaCxQlPcT4J6h4197dQpSW5PK5f8HigRk0yEsLC2F';
+		$blob = new DIBlob( $s72 );
+
+		$expected = [
+			'o_blob' => '',
+			'o_hash' => $blob->getString()
+		];
+
+		$this->assertEquals(
+			$expected,
+			$instance->getInsertValues( $blob )
+		);
+
+		$s73  = 'zcqaBHr1jV7mINGovktU8bD6zYjgKMqfaCxQlPcT4J6h4197dQpSW5PK5f8HigRk0yEsLC2Fs';
+		$blob = new DIBlob( $s73 );
+
+		$expected = [
+			'o_blob' => $blob->getString(),
+			'o_hash' => 'zcqaBHr1jV7mINGovktU8bD6zYjgKMqfaCxQlPcTcf085df3633862a2d74e393fa84944e2'
+		];
+
+		$this->assertEquals(
+			$expected,
+			$instance->getInsertValues( $blob )
+		);
+	}
+
+	/**
+	 * @dataProvider dbKeysProvider
+	 */
+	public function testDataItemFromDBKeys( $dbKeys ) {
+
+		$instance = new DIBlobHandler(
+			$this->store
+		);
+
+		$this->assertInstanceOf(
+			'\SMWDIBlob',
+			$instance->dataItemFromDBKeys( $dbKeys )
+		);
+	}
+
+	/**
+	 * @dataProvider dbKeysExceptionProvider
+	 */
+	public function testDataItemFromDBKeysThrowsException( $dbKeys ) {
+
+		$instance = new DIBlobHandler(
+			$this->store
+		);
+
+		$this->setExpectedException( '\SMW\SQLStore\EntityStore\Exception\DataItemHandlerException' );
+		$instance->dataItemFromDBKeys( $dbKeys );
+	}
+
+	public function dbKeysProvider() {
+
+		$provider[] = array(
+			array( 'Foo', '' )
+		);
+
+		$provider[] = array(
+			array( '', 'Foo' )
+		);
+
+		return $provider;
+	}
+
+	public function dbKeysExceptionProvider() {
+
+		$provider[] = array(
+			array( '' )
+		);
+
+		return $provider;
+	}
+
+	private function createRandomString( $length = 10 ) {
+		return substr(str_shuffle(str_repeat($x='0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ', ceil($length/strlen($x)) )),1,$length);
+	}
+
+}

--- a/tests/phpunit/Unit/SQLStore/EntityStore/DIHandlers/DIUriHandlerTest.php
+++ b/tests/phpunit/Unit/SQLStore/EntityStore/DIHandlers/DIUriHandlerTest.php
@@ -1,0 +1,192 @@
+<?php
+
+namespace SMW\Tests\SQLStore\EntityStore\DIHandlers;
+
+use SMW\SQLStore\EntityStore\DIHandlers\DIUriHandler;
+use SMW\SQLStore\TableBuilder\FieldType;
+use SMWDIUri as DIUri;
+
+/**
+ * @covers \SMW\SQLStore\EntityStore\DIHandlers\DIUriHandler
+ * @group semantic-mediawiki
+ *
+ * @license GNU GPL v2+
+ * @since   3.0
+ *
+ * @author mwjames
+ */
+class DIUriHandlerTest extends \PHPUnit_Framework_TestCase {
+
+	private $store;
+
+	protected function setUp() {
+		parent::setUp();
+
+		$connection = $this->getMockBuilder( '\SMW\MediaWiki\Database' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$this->store = $this->getMockBuilder( '\SMW\SQLStore\SQLStore' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$this->store->expects( $this->any() )
+			->method( 'getConnection' )
+			->will( $this->returnValue( $connection ) );
+	}
+
+	public function testCanConstruct() {
+
+		$store = $this->getMockBuilder( '\SMW\SQLStore\SQLStore' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$this->assertInstanceOf(
+			DIUriHandler::class,
+			new DIUriHandler( $this->store )
+		);
+	}
+
+	public function testImmutableMethodAccess() {
+
+		$instance = new DIUriHandler(
+			$this->store
+		);
+
+		$this->assertInternalType(
+			'array',
+			$instance->getTableFields()
+		);
+
+		$this->assertInternalType(
+			'array',
+			$instance->getFetchFields()
+		);
+
+		$this->assertInternalType(
+			'array',
+			$instance->getTableIndexes()
+		);
+
+		$this->assertInternalType(
+			'string',
+			$instance->getIndexField()
+		);
+
+		$this->assertInternalType(
+			'string',
+			$instance->getLabelField()
+		);
+	}
+
+	public function testMutableMethodAccess() {
+
+		$uri = new DIUri( 'http', 'example.org', '', '' );
+
+		$instance = new DIUriHandler(
+			$this->store
+		);
+
+		$this->assertInternalType(
+			'array',
+			$instance->getWhereConds( $uri )
+		);
+
+		$this->assertInternalType(
+			'array',
+			$instance->getInsertValues( $uri )
+		);
+	}
+
+	public function testtMutableOnNoCaseFieldFeature() {
+
+		$instance = new DIUriHandler(
+			$this->store
+		);
+
+		$expected = [
+			'o_blob' => FieldType::TYPE_BLOB,
+			'o_serialized' => FieldType::FIELD_TITLE
+		];
+
+		$this->assertEquals(
+			$expected,
+			$instance->getTableFields()
+		);
+
+		$this->assertEquals(
+			$expected,
+			$instance->getFetchFields()
+		);
+
+		$instance->setFieldTypeFeatures(
+			SMW_FIELDT_CHAR_NOCASE
+		);
+
+		$expected = [
+			'o_blob' => FieldType::TYPE_BLOB,
+			'o_serialized' => FieldType::TYPE_CHAR_NOCASE
+		];
+
+		$this->assertEquals(
+			$expected,
+			$instance->getTableFields()
+		);
+
+		$this->assertEquals(
+			$expected,
+			$instance->getFetchFields()
+		);
+	}
+
+	/**
+	 * @dataProvider dbKeysProvider
+	 */
+	public function testDataItemFromDBKeys( $dbKeys ) {
+
+		$instance = new DIUriHandler(
+			$this->store
+		);
+
+		$this->assertInstanceOf(
+			'\SMWDIUri',
+			$instance->dataItemFromDBKeys( $dbKeys )
+		);
+	}
+
+	/**
+	 * @dataProvider dbKeysExceptionProvider
+	 */
+	public function testDataItemFromDBKeysThrowsException( $dbKeys ) {
+
+		$instance = new DIUriHandler(
+			$this->store
+		);
+
+		$this->setExpectedException( '\SMW\SQLStore\EntityStore\Exception\DataItemHandlerException' );
+		$instance->dataItemFromDBKeys( $dbKeys );
+	}
+
+	public function dbKeysProvider() {
+
+		$provider[] = array(
+			array( 'http://example.org', '' )
+		);
+
+		$provider[] = array(
+			array( '', 'http://example.org' )
+		);
+
+		return $provider;
+	}
+
+	public function dbKeysExceptionProvider() {
+
+		$provider[] = array(
+			array( '' )
+		);
+
+		return $provider;
+	}
+
+}

--- a/tests/phpunit/Unit/SQLStore/TableSchemaManagerTest.php
+++ b/tests/phpunit/Unit/SQLStore/TableSchemaManagerTest.php
@@ -3,6 +3,7 @@
 namespace SMW\Tests\SQLStore;
 
 use SMW\SQLStore\TableSchemaManager;
+use SMW\SQLStore\TableBuilder\FieldType;
 use Onoi\MessageReporter\MessageReporterFactory;
 
 /**
@@ -66,6 +67,49 @@ class TableSchemaManagerTest extends \PHPUnit_Framework_TestCase {
 		$this->assertInternalType(
 			'string',
 			$instance->getHash()
+		);
+	}
+
+	public function testFindTableDefinitionWithNoCaseFeature() {
+
+		$propertyTableDefinition = $this->getMockBuilder( '\SMW\SQLStore\PropertyTableDefinition' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$dataItemHandler = $this->getMockBuilder( '\SMW\SQLStore\EntityStore\DataItemHandler' )
+			->disableOriginalConstructor()
+			->getMockForAbstractClass();
+
+		$dataItemHandler->expects( $this->once() )
+			->method( 'getTableFields' )
+			->will( $this->returnValue( array() ) );
+
+		$store = $this->getMockBuilder( '\SMW\SQLStore\SQLStore' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$store->expects( $this->once() )
+			->method( 'getPropertyTables' )
+			->will( $this->returnValue( array( $propertyTableDefinition ) ) );
+
+		$store->expects( $this->once() )
+			->method( 'getDataItemHandlerForDIType' )
+			->will( $this->returnValue( $dataItemHandler ) );
+
+		$instance = new TableSchemaManager(
+			$store
+		);
+
+		$instance->setFieldTypeFeatures(
+			SMW_FIELDT_CHAR_NOCASE
+		);
+
+		$table = $instance->findTable( \SMW\SQLStore\SQLStore::ID_TABLE );
+		$fields = $table->getConfiguration( 'fields' );
+
+		$this->assertContains(
+			FieldType::TYPE_CHAR_NOCASE,
+			$fields['smw_sortkey']
 		);
 	}
 


### PR DESCRIPTION
This PR is made in reference to: #1912, http://wikimedia.7.x6.nabble.com/Non-case-sensitive-search-possible-tp5075393p5075402.html

This PR addresses or contains: 

- Adds a new `smwgFieldTypeFeatures` setting with flag `SMW_FIELDT_CHAR_NOCASE` that can alter the field type to make a field search case insensitive after the #1912 model
- The setting and flag `SMW_FIELDT_CHAR_NOCASE` are disabled by default as " ... no extensive analysis has been performed on how the switch from VARBINARY to a collated VARCHAR field type affects the search performance"
- Extends `smwgSparqlQFeatures` to support `SMW_SPARQL_QF_NOCASE` (`SPARQLStore`)
- Changing the setting requires to run `setupStore.php` or `update.php`

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed
