### PR TITLE
Provide POST purge link, to avoid confirmation

### DIFF
--- a/i18n/en.json
+++ b/i18n/en.json
@@ -166,6 +166,7 @@
 	"smw-wantedproperties-docu": "This page lists [https://www.semantic-mediawiki.org/wiki/Wanted_properties wanted properties] that are used in the wiki but do not have a page describing them. For a differentiated view, see the [[Special:Properties|entire]] or  [[Special:UnusedProperties|unused properties]] special pages.",
 	"smw-wantedproperty-template": "$1 ($2 {{PLURAL:$2|use|uses}})",
 	"smw_purge": "Refresh",
+	"smw-purge-failed": "Refreshing failed",
 	"types": "Types",
 	"smw_types_docu": "List of [https://www.semantic-mediawiki.org/wiki/Help:List_of_datatypes available datatypes] with each [https://www.semantic-mediawiki.org/wiki/Help:Datatype type] representing a unique set of attributes to describe a value in terms of storage and display characteristics that are hereditary to an assigned property.",
 	"smw-special-types-no-such-type": "The specified data type does not exist",

--- a/i18n/qqq.json
+++ b/i18n/qqq.json
@@ -176,6 +176,7 @@
 	"smw-wantedproperties-docu": "This is the introductory message at the top of [[Special:WantedProperties]].",
 	"smw-wantedproperty-template": "This is the message on [[Special:WantedProperties]] showing the name of the property without an assigned data type and how often it is used in the wiki. $1 holds the name of the wanted property. $2 holds the number of values annotated with the wanted property.",
 	"smw_purge": "{{doc-actionlink}}\nThis is the label of a tab of an action item for the content area.\n{{Identical|Refresh}}",
+	"smw-purge-failed": "This is an error/warning message.",
 	"types": "{{doc-special|Types}}\n{{Identical|Type}}",
 	"smw_types_docu": "This is the introductory message at the top of [[Special:Types]].",
 	"smw-special-types-no-such-type": "Error message shown on [[Special:Types]] when specifying an invalid data type.",

--- a/res/Resources.php
+++ b/res/Resources.php
@@ -192,6 +192,11 @@ return array(
 		'scripts' => 'smw/util/ext.smw.util.purge.js',
 		'messages' => array(
 			'smw-purge-failed'
+		),
+		'position' => 'top',
+		'targets' => array(
+			'mobile',
+			'desktop'
 		)
 	),
 	

--- a/res/Resources.php
+++ b/res/Resources.php
@@ -186,6 +186,15 @@ return array(
 		'dependencies' => 'jquery.ui.autocomplete',
 		'targets' => array( 'mobile', 'desktop' )
 	),
+	
+	// Purge resources
+	'ext.smw.purge' => $moduleTemplate + array(
+		'scripts' => 'smw/util/ext.smw.util.purge.js',
+		'messages' => array(
+			'smw-purge-failed'
+		)
+	),
+	
 	// Special:Ask
 	'ext.smw.ask' => $moduleTemplate + array(
 		'scripts' => 'smw/special/ext.smw.special.ask.js',

--- a/res/smw/util/ext.smw.util.purge.js
+++ b/res/smw/util/ext.smw.util.purge.js
@@ -9,20 +9,28 @@
  * @ingroup SMW
  *
  * @licence GNU GPL v2+
- * @author samwilson
+ * @author samwilson, mwjames
  */
 
+/*global jQuery, mediaWiki, smw */
+/*jslint white: true */
 
-mw.loader.using( [ 'mediawiki.api', 'mediawiki.notify' ] ).then( function () {
+( function( $, mw ) {
 
-	$( "#ca-purge a" ).on( 'click', function ( e ) {
-		var postArgs = { action: 'purge', titles: mw.config.get( 'wgPageName' ) };
-		new mw.Api().post( postArgs ).then( function () {
-			location.reload();
-		}, function () {
-			mw.notify( mw.msg( 'smw-purge-failed' ), { type: 'error' } );
+	'use strict';
+
+	mw.loader.using( [ 'mediawiki.api', 'mediawiki.notify' ] ).then( function () {
+
+		$( "#ca-purge a" ).on( 'click', function ( e ) {
+			var postArgs = { action: 'purge', titles: mw.config.get( 'wgPageName' ) };
+			new mw.Api().post( postArgs ).then( function () {
+				location.reload();
+			}, function () {
+				mw.notify( mw.msg( 'smw-purge-failed' ), { type: 'error' } );
+			} );
+			e.preventDefault();
 		} );
-		e.preventDefault();
+
 	} );
 
-} );
+}( jQuery, mediaWiki ) );

--- a/res/smw/util/ext.smw.util.purge.js
+++ b/res/smw/util/ext.smw.util.purge.js
@@ -1,0 +1,28 @@
+/*!
+ * This file is part of the Semantic MediaWiki Purge module
+ * @see https://www.semantic-mediawiki.org/wiki/Help:Purge
+ *
+ * @since 2.5
+ * @revision 0.0.1
+ *
+ * @file
+ * @ingroup SMW
+ *
+ * @licence GNU GPL v2+
+ * @author samwilson
+ */
+
+
+mw.loader.using( [ 'mediawiki.api', 'mediawiki.notify' ] ).then( function () {
+
+	$( "#ca-purge a" ).on( 'click', function ( e ) {
+		var postArgs = { action: 'purge', titles: mw.config.get( 'wgPageName' ) };
+		new mw.Api().post( postArgs ).then( function () {
+			location.reload();
+		}, function () {
+			mw.notify( mw.msg( 'purge-failed' ), { type: 'error' } );
+		} );
+		e.preventDefault();
+	} );
+
+} );

--- a/res/smw/util/ext.smw.util.purge.js
+++ b/res/smw/util/ext.smw.util.purge.js
@@ -20,7 +20,7 @@ mw.loader.using( [ 'mediawiki.api', 'mediawiki.notify' ] ).then( function () {
 		new mw.Api().post( postArgs ).then( function () {
 			location.reload();
 		}, function () {
-			mw.notify( mw.msg( 'purge-failed' ), { type: 'error' } );
+			mw.notify( mw.msg( 'smw-purge-failed' ), { type: 'error' } );
 		} );
 		e.preventDefault();
 	} );

--- a/src/MediaWiki/Hooks/SkinTemplateNavigation.php
+++ b/src/MediaWiki/Hooks/SkinTemplateNavigation.php
@@ -45,6 +45,7 @@ class SkinTemplateNavigation {
 	public function process() {
 
 		if ( $this->skinTemplate->getUser()->isAllowed( 'purge' ) ) {
+			$skin->getOutput()->addModules( 'ext.smw.purge' );
 			$this->links['actions']['purge'] = array(
 				'class' => false,
 				'text' => $this->skinTemplate->msg( 'smw_purge' )->text(),

--- a/src/MediaWiki/Hooks/SkinTemplateNavigation.php
+++ b/src/MediaWiki/Hooks/SkinTemplateNavigation.php
@@ -45,7 +45,7 @@ class SkinTemplateNavigation {
 	public function process() {
 
 		if ( $this->skinTemplate->getUser()->isAllowed( 'purge' ) ) {
-			$skin->getOutput()->addModules( 'ext.smw.purge' );
+			$this->skinTemplate->getOutput()->addModules( 'ext.smw.purge' );
 			$this->links['actions']['purge'] = array(
 				'class' => false,
 				'text' => $this->skinTemplate->msg( 'smw_purge' )->text(),

--- a/tests/phpunit/Unit/MediaWiki/Hooks/SkinTemplateNavigationTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Hooks/SkinTemplateNavigationTest.php
@@ -46,11 +46,19 @@ class SkinTemplateNavigationTest extends \PHPUnit_Framework_TestCase {
 		$user->expects( $this->atLeastOnce() )
 			->method( 'isAllowed' )
 			->will( $this->returnValue( true ) );
+		
+		$output = $this->getMockBuilder( '\OutputPage' )
+			->disableOriginalConstructor()
+			->getMock();
 
 		$skinTemplate = $this->getMockBuilder( '\SkinTemplate' )
 			->disableOriginalConstructor()
 			->getMock();
 
+		$skinTemplate->expects( $this->atLeastOnce() )
+			->method( 'getOutput' )
+			->will( $this->returnValue( $output ) );
+			
 		$skinTemplate->expects( $this->atLeastOnce() )
 			->method( 'getUser' )
 			->will( $this->returnValue( $user ) );


### PR DESCRIPTION
This PR is made in reference to: #1585 

This PR addresses or contains:
- Resource module to make a POST purge action possible avoiding confirmation

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed
