### PR TITLE
PropertyTableIdReferenceDisposer avoid unnecessary cache reset on subobject, refs 1907

### DIFF
--- a/src/SQLStore/PropertyTableIdReferenceDisposer.php
+++ b/src/SQLStore/PropertyTableIdReferenceDisposer.php
@@ -215,6 +215,12 @@ class PropertyTableIdReferenceDisposer {
 			return;
 		}
 
+		// Skip any reset for subobjects where it is expected that the base
+		// subject is cleaning up all related cache entries
+		if ( $subject->getSubobjectName() !== '' ) {
+			return;
+		}
+
 		if ( $onTransactionIdle ) {
 			return $this->connection->onTransactionIdle( function() use( $subject ) {
 				$this->triggerCleanUpEvents( $subject, false );
@@ -224,7 +230,7 @@ class PropertyTableIdReferenceDisposer {
 		$eventHandler = EventHandler::getInstance();
 
 		$dispatchContext = $eventHandler->newDispatchContext();
-		$dispatchContext->set( 'subject', $subject->asBase() );
+		$dispatchContext->set( 'subject', $subject );
 		$dispatchContext->set( 'context', 'PropertyTableIdReferenceDisposal' );
 
 		$eventHandler->getEventDispatcher()->dispatch(


### PR DESCRIPTION
This PR is made in reference to: #1907

This PR addresses or contains:

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed
