### PR TITLE
Add TableBuilder::optimize, refs 1940

### DIFF
--- a/src/SQLStore/Installer.php
+++ b/src/SQLStore/Installer.php
@@ -115,6 +115,13 @@ class Installer implements MessageReporter, MessageReporterAware {
 		$this->tableIntegrityExaminer->checkOnPostCreation( $this->tableBuilder );
 
 		$messageReporter->reportMessage( "\nDatabase initialized completed.\n" );
+		$messageReporter->reportMessage( "\nRunning table optimization.\n" );
+
+		foreach ( $this->tableSchemaManager->getTables() as $table ) {
+			$this->tableBuilder->optimize( $table );
+		}
+
+		$messageReporter->reportMessage( "\nOptimization completed.\n" );
 
 		Hooks::run( 'SMW::SQLStore::Installer::AfterCreateTablesComplete', array( $this->tableBuilder, $messageReporter ) );
 

--- a/src/SQLStore/TableBuilder.php
+++ b/src/SQLStore/TableBuilder.php
@@ -83,6 +83,17 @@ interface TableBuilder extends MessageReporterAware {
 	public function drop( Table $table );
 
 	/**
+	 * Performs analysis on a key distribution and stores the distribution so
+	 * that the query planner can use these statistics to help determine the
+	 * most efficient execution plans for queries.
+	 *
+	 * @since 3.0
+	 *
+	 * @param Table $table
+	 */
+	public function optimize( Table $table );
+
+	/**
 	 * Database backends often have different types that need to be used
 	 * repeatedly in (Semantic) MediaWiki. This function provides the
 	 * preferred type (as a string) for various common kinds of columns.

--- a/src/SQLStore/TableBuilder/MySQLTableBuilder.php
+++ b/src/SQLStore/TableBuilder/MySQLTableBuilder.php
@@ -338,4 +338,28 @@ class MySQLTableBuilder extends TableBuilder {
 		$this->connection->query( 'DROP TABLE ' . $this->connection->tableName( $tableName ), __METHOD__ );
 	}
 
+	/**
+	 * @since 3.0
+	 *
+	 * {@inheritDoc}
+	 */
+	protected function doOptimize( $tableName ) {
+
+		$this->reportMessage( "   Table $tableName ...\n" );
+
+		// https://dev.mysql.com/doc/refman/5.7/en/analyze-table.html
+		// Performs a key distribution analysis and stores the distribution for
+		// the named table or tables
+		$this->reportMessage( "   ... analyze" );
+		$this->connection->query( 'ANALYZE TABLE ' . $this->connection->tableName( $tableName ), __METHOD__ );
+
+		// https://dev.mysql.com/doc/refman/5.7/en/optimize-table.html
+		// Reorganizes the physical storage of table data and associated index data,
+		// to reduce storage space and improve I/O efficiency
+		$this->reportMessage( ", optimize " );
+		$this->connection->query( 'OPTIMIZE TABLE ' . $this->connection->tableName( $tableName ), __METHOD__ );
+
+		$this->reportMessage( "done.\n" );
+	}
+
 }

--- a/src/SQLStore/TableBuilder/PostgresTableBuilder.php
+++ b/src/SQLStore/TableBuilder/PostgresTableBuilder.php
@@ -356,6 +356,22 @@ EOT;
 	}
 
 	/**
+	 * @since 3.0
+	 *
+	 * {@inheritDoc}
+	 */
+	protected function doOptimize( $tableName ) {
+
+		$this->reportMessage( "   Table $tableName ...\n" );
+
+		// https://www.postgresql.org/docs/9.0/static/sql-analyze.html
+		$this->reportMessage( "   ... analyze " );
+		$this->connection->query( 'ANALYZE ' . $this->connection->tableName( $tableName ), __METHOD__ );
+
+		$this->reportMessage( "done.\n" );
+	}
+
+	/**
 	 * @since 2.5
 	 *
 	 * {@inheritDoc}

--- a/src/SQLStore/TableBuilder/SQLiteTableBuilder.php
+++ b/src/SQLStore/TableBuilder/SQLiteTableBuilder.php
@@ -305,4 +305,20 @@ class SQLiteTableBuilder extends TableBuilder {
 		$this->connection->query( 'DROP TABLE ' . $this->connection->tableName( $tableName ), __METHOD__ );
 	}
 
+	/**
+	 * @since 3.0
+	 *
+	 * {@inheritDoc}
+	 */
+	protected function doOptimize( $tableName ) {
+
+		$this->reportMessage( "   Table $tableName ...\n" );
+
+		// https://sqlite.org/lang_analyze.html
+		$this->reportMessage( "   ... analyze " );
+		$this->connection->query( 'ANALYZE ' . $this->connection->tableName( $tableName ), __METHOD__ );
+
+		$this->reportMessage( "done.\n" );
+	}
+
 }

--- a/src/SQLStore/TableBuilder/TableBuilder.php
+++ b/src/SQLStore/TableBuilder/TableBuilder.php
@@ -175,6 +175,15 @@ abstract class TableBuilder implements TableBuilderInterface, MessageReporter {
 	}
 
 	/**
+	 * @since 3.0
+	 *
+	 * {@inheritDoc}
+	 */
+	public function optimize( Table $table ) {
+		$this->doOptimize( $table->getName() );
+	}
+
+	/**
 	 * @since 2.5
 	 *
 	 * @param string $event
@@ -214,6 +223,11 @@ abstract class TableBuilder implements TableBuilderInterface, MessageReporter {
 	 * @param string $tableName
 	 */
 	abstract protected function doDropTable( $tableName );
+
+	/**
+	 * @param string $tableName
+	 */
+	abstract protected function doOptimize( $tableName );
 
 	// #1978
 	// http://php.net/manual/en/function.array-search.php

--- a/tests/phpunit/Unit/SQLStore/InstallerTest.php
+++ b/tests/phpunit/Unit/SQLStore/InstallerTest.php
@@ -56,7 +56,7 @@ class InstallerTest extends \PHPUnit_Framework_TestCase {
 			->disableOriginalConstructor()
 			->getMock();
 
-		$tableSchemaManager->expects( $this->once() )
+		$tableSchemaManager->expects( $this->atLeastOnce() )
 			->method( 'getTables' )
 			->will( $this->returnValue( array( $table ) ) );
 
@@ -98,7 +98,7 @@ class InstallerTest extends \PHPUnit_Framework_TestCase {
 			->disableOriginalConstructor()
 			->getMock();
 
-		$tableSchemaManager->expects( $this->once() )
+		$tableSchemaManager->expects( $this->atLeastOnce() )
 			->method( 'getTables' )
 			->will( $this->returnValue( array( $table ) ) );
 

--- a/tests/phpunit/Unit/SQLStore/TableBuilder/MySQLTableBuilderTest.php
+++ b/tests/phpunit/Unit/SQLStore/TableBuilder/MySQLTableBuilderTest.php
@@ -150,4 +150,29 @@ class MySQLTableBuilderTest extends \PHPUnit_Framework_TestCase {
 		$instance->drop( $table );
 	}
 
+	public function testOptimizeTable() {
+
+		$connection = $this->getMockBuilder( '\DatabaseBase' )
+			->disableOriginalConstructor()
+			->setMethods( array( 'query' ) )
+			->getMockForAbstractClass();
+
+		$connection->expects( $this->any() )
+			->method( 'getType' )
+			->will( $this->returnValue( 'mysql' ) );
+
+		$connection->expects( $this->at( 1 ) )
+			->method( 'query' )
+			->with( $this->stringContains( 'ANALYZE TABLE "foo"' ) );
+
+		$connection->expects( $this->at( 2 ) )
+			->method( 'query' )
+			->with( $this->stringContains( 'OPTIMIZE TABLE "foo"' ) );
+
+		$instance = MySQLTableBuilder::factory( $connection );
+
+		$table = new Table( 'foo' );
+		$instance->optimize( $table );
+	}
+
 }

--- a/tests/phpunit/Unit/SQLStore/TableBuilder/PostgresTableBuilderTest.php
+++ b/tests/phpunit/Unit/SQLStore/TableBuilder/PostgresTableBuilderTest.php
@@ -173,4 +173,25 @@ class PostgresTableBuilderTest extends \PHPUnit_Framework_TestCase {
 		$instance->checkOn( $instance::POST_CREATION );
 	}
 
+	public function testOptimizeTable() {
+
+		$connection = $this->getMockBuilder( '\DatabaseBase' )
+			->disableOriginalConstructor()
+			->setMethods( array( 'query' ) )
+			->getMockForAbstractClass();
+
+		$connection->expects( $this->any() )
+			->method( 'getType' )
+			->will( $this->returnValue( 'postgres' ) );
+
+		$connection->expects( $this->at( 1 ) )
+			->method( 'query' )
+			->with( $this->stringContains( 'ANALYZE "foo"' ) );
+
+		$instance = PostgresTableBuilder::factory( $connection );
+
+		$table = new Table( 'foo' );
+		$instance->optimize( $table );
+	}
+
 }

--- a/tests/phpunit/Unit/SQLStore/TableBuilder/SQLiteTableBuilderTest.php
+++ b/tests/phpunit/Unit/SQLStore/TableBuilder/SQLiteTableBuilderTest.php
@@ -149,4 +149,25 @@ class SQLiteTableBuilderTest extends \PHPUnit_Framework_TestCase {
 		$instance->drop( $table );
 	}
 
+	public function testOptimizeTable() {
+
+		$connection = $this->getMockBuilder( '\DatabaseBase' )
+			->disableOriginalConstructor()
+			->setMethods( array( 'query' ) )
+			->getMockForAbstractClass();
+
+		$connection->expects( $this->any() )
+			->method( 'getType' )
+			->will( $this->returnValue( 'sqlite' ) );
+
+		$connection->expects( $this->at( 1 ) )
+			->method( 'query' )
+			->with( $this->stringContains( 'ANALYZE "foo"' ) );
+
+		$instance = SQLiteTableBuilder::factory( $connection );
+
+		$table = new Table( 'foo' );
+		$instance->optimize( $table );
+	}
+
 }


### PR DESCRIPTION
This PR is made in reference to: #1940

This PR addresses or contains:

- Runs the `ANALYZE` (and `OPTIMIZE` where available) command during the setup to ensure that "...key distribution and stores the distribution so that the query planner can use these statistics to help determine the most efficient execution plans for queries."

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed
