### PR TITLE
SQLStore performance (avoid DISTINCT, filesort, add index), refs 2461

### DIFF
--- a/includes/storage/SQLStore/SMW_SQLStore3_Readers.php
+++ b/includes/storage/SQLStore/SMW_SQLStore3_Readers.php
@@ -507,7 +507,7 @@ class SMWSQLStore3Readers {
 
 		$res = $db->select(
 			$from,
-			'DISTINCT ' . $select,
+			' ' . $select,
 			$where . $this->store->getSQLConditions( $requestOptions, 'smw_sortkey', 'smw_sortkey', $where !== '' ),
 			__METHOD__,
 			$this->store->getSQLOptions( $requestOptions, 'smw_sort' )

--- a/src/SQLStore/EntityStore/DIHandlers/DIBlobHandler.php
+++ b/src/SQLStore/EntityStore/DIHandlers/DIBlobHandler.php
@@ -49,7 +49,16 @@ class DIBlobHandler extends DataItemHandler {
 	 * {@inheritDoc}
 	 */
 	public function getTableIndexes() {
-		return array( 's_id,o_hash' );
+		return array(
+
+			's_id,o_hash',
+
+			//SMW\SQLStore\QueryEngine\QueryEngine::getInstanceQueryResult
+			'o_hash,p_id',
+
+			// SMWSQLStore3Readers::getPropertySubjects
+			'p_id,s_id'
+		);
 	}
 
 	/**

--- a/src/SQLStore/EntityStore/DIHandlers/DIBooleanHandler.php
+++ b/src/SQLStore/EntityStore/DIHandlers/DIBooleanHandler.php
@@ -45,6 +45,21 @@ class DIBooleanHandler extends DataItemHandler {
 	 *
 	 * {@inheritDoc}
 	 */
+	public function getTableIndexes() {
+		return array(
+			// SMWSQLStore3Readers::getPropertySubjects
+			'p_id,s_id',
+
+			// SMWSQLStore3Readers::getPropertySubjects
+			'p_id,o_value,s_id'
+		);
+	}
+
+	/**
+	 * @since 1.8
+	 *
+	 * {@inheritDoc}
+	 */
 	public function getWhereConds( DataItem $dataItem ) {
 		return array(
 			'o_value' => $dataItem->getBoolean() ? 1 : 0,

--- a/src/SQLStore/EntityStore/DIHandlers/DINumberHandler.php
+++ b/src/SQLStore/EntityStore/DIHandlers/DINumberHandler.php
@@ -51,6 +51,13 @@ class DINumberHandler extends DataItemHandler {
 		return array(
 			// QueryEngine::getInstanceQueryResult
 			's_id,p_id,o_sortkey',
+
+			// QueryEngine::getInstanceQueryResult
+			// `smw_di_number` AS t5 ON t2.s_id=t5.s_id WHERE ... ((t5.o_sortkey>='700') AND t5.p_id='120') ORDER BY ... t5.o_sortkey
+			'o_sortkey,p_id,s_id',
+
+			// SMWSQLStore3Readers::getPropertySubjects
+			'p_id,s_id'
 		);
 	}
 

--- a/src/SQLStore/EntityStore/DIHandlers/DIUriHandler.php
+++ b/src/SQLStore/EntityStore/DIHandlers/DIUriHandler.php
@@ -48,6 +48,18 @@ class DIUriHandler extends DataItemHandler {
 	 *
 	 * {@inheritDoc}
 	 */
+	public function getTableIndexes() {
+		return array(
+			// SMWSQLStore3Readers::getPropertySubjects
+			'p_id,s_id'
+		);
+	}
+
+	/**
+	 * @since 1.8
+	 *
+	 * {@inheritDoc}
+	 */
 	public function getWhereConds( DataItem $dataItem ) {
 		return array( 'o_serialized' => rawurldecode( $dataItem->getSerialization() ) );
 	}

--- a/src/SQLStore/EntityStore/DIHandlers/DIWikiPageHandler.php
+++ b/src/SQLStore/EntityStore/DIHandlers/DIWikiPageHandler.php
@@ -53,7 +53,7 @@ class DIWikiPageHandler extends DataItemHandler {
 	 */
 	public function getTableIndexes() {
 		return array(
-			'o_id',
+			//'o_id',
 
 			// SMWSQLStore3Readers::fetchSemanticData
 			// ... FROM `smw_fpt_sobj` INNER JOIN `smw_object_ids` AS o0 ON
@@ -90,7 +90,7 @@ class DIWikiPageHandler extends DataItemHandler {
 
 			// SMWSQLStore3Readers::getPropertySubjects
 			// SELECT DISTINCT s_id FROM `smw_di_wikipage` WHERE (p_id='64' AND o_id='104') ORDER BY s_sort ASC
-			//'o_id,p_id,s_id,s_sort'
+			'o_id,p_id,s_id'
 		);
 	}
 

--- a/src/SQLStore/QueryEngine/QueryEngine.php
+++ b/src/SQLStore/QueryEngine/QueryEngine.php
@@ -283,7 +283,7 @@ class QueryEngine implements QueryEngineInterface, LoggerAwareInterface {
 		$sortfields = implode( $qobj->sortfields, ',' );
 		$sortfields = $sortfields ? ', ' . $sortfields : '';
 
-		$sql = "SELECT DISTINCT ".
+		$sql = "SELECT ".
 			"$qobj->alias.smw_id AS id," .
 			"$qobj->alias.smw_title AS t," .
 			"$qobj->alias.smw_namespace AS ns," .
@@ -401,7 +401,7 @@ class QueryEngine implements QueryEngineInterface, LoggerAwareInterface {
 
 		$res = $connection->select(
 			$connection->tableName( $qobj->joinTable ) . " AS $qobj->alias" . $qobj->from,
-			"DISTINCT ".
+			" ".
 			"$qobj->alias.smw_id AS id," .
 			"$qobj->alias.smw_title AS t," .
 			"$qobj->alias.smw_namespace AS ns," .

--- a/src/SQLStore/TableSchemaManager.php
+++ b/src/SQLStore/TableSchemaManager.php
@@ -166,6 +166,10 @@ class TableSchemaManager {
 		// ID lookup
 		$table->addIndex( 'smw_title,smw_namespace,smw_iw,smw_subobject' );
 
+		// SMW\SQLStore\QueryEngine\QueryEngine::getInstanceQueryResult
+		// ... ORDER BY t0.smw_sort ASC,t0.smw_title ASC,t0.smw_subobject
+		$table->addIndex( 'smw_sort,smw_title,smw_subobject,smw_iw' );
+
 		// InProperty lookup
 		// $table->addIndex( 'smw_iw,smw_id,smw_title,smw_sortkey,smw_sort' );
 


### PR DESCRIPTION
This PR is made in reference to: #2461, #2516, #2040

This PR addresses or contains:

- Avoid `SELECT DISTINCT ... ORDER BY ...` as it will most certainly cause a filesort and in worst case scenarios forces a full table scan [0]  which will __not__ be O(N) for large tables
- Add additional indices in order for the query planner to pick the best available option
- Not all queries will select the best query plan due to missing indices but current changes show a significant improvement over the existing setup
- `$GLOBALS['smwgQueryResultCacheType'] = 'redis';` was disabled during the test
- Some preliminary results include (`12802.0909ms` ↘ `10.7570ms`), (`22218.1082ms` ↘ `12.7010ms`) for ([content](https://gist.github.com/mwjames/103afa6ecd53b666de075e69cc1970ca) was used to simulate some high data load):

```
smw_object_ids: 169975 rows
smw_di_wikipage: 1404815 rows
smw_di_time: 140828 rows
smw_ft_search: 516884 rows
...
```

[0] https://dev.mysql.com/doc/refman/5.7/en/table-scan-avoidance.html

This PR includes:
- [ ] Tests (unit/integration)
- [ ] CI build passed
