### PR TITLE
Comma as default valuesep with template format

### DIFF
--- a/includes/queryprinters/ListResultPrinter.php
+++ b/includes/queryprinters/ListResultPrinter.php
@@ -490,7 +490,7 @@ class ListResultPrinter extends ResultPrinter {
 
 		$params['sep'] = array(
 			'message' => 'smw-paramdesc-sep',
-			'default' => '',
+			'default' => $this->isEnabledFeature( SMW_RF_TEMPLATE_OUTSEP ) ? '' : ',',
 		);
 
 		if ( $this->mFormat === 'template' && $this->isEnabledFeature( SMW_RF_TEMPLATE_OUTSEP ) ) {

--- a/includes/queryprinters/ListResultPrinter.php
+++ b/includes/queryprinters/ListResultPrinter.php
@@ -496,7 +496,7 @@ class ListResultPrinter extends ResultPrinter {
 		if ( $this->mFormat === 'template' && $this->isEnabledFeature( SMW_RF_TEMPLATE_OUTSEP ) ) {
 			$params['valuesep'] = array(
 				'message' => 'smw-paramdesc-sep',
-				'default' => '',
+				'default' => ',',
 			);
 		}
 

--- a/tests/phpunit/Integration/JSONScript/TestCases/f-0101.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/f-0101.json
@@ -34,11 +34,11 @@
 		},
 		{
 			"page": "template-001-asc-order-unnamed-args",
-			"contents": "{{#ask:[[Category:template-001]][[Has page property::ABC]] |?Has page property |sep=, |valuesep=, |format=template |order=asc |link=none |limit=3 |searchlabel=furtherresults |userparam=[$%&*==42] |template=TemplateOutputUsingUnnamedArgumentsForNonUnicode |introtemplate=TemplateOutputUsingUnnamedArgumentsForNonUnicodeExtra |outrotemplate=TemplateOutputUsingUnnamedArgumentsForNonUnicodeExtra}}"
+			"contents": "{{#ask:[[Category:template-001]][[Has page property::ABC]] |?Has page property |sep=, |format=template |order=asc |link=none |limit=3 |searchlabel=furtherresults |userparam=[$%&*==42] |template=TemplateOutputUsingUnnamedArgumentsForNonUnicode |introtemplate=TemplateOutputUsingUnnamedArgumentsForNonUnicodeExtra |outrotemplate=TemplateOutputUsingUnnamedArgumentsForNonUnicodeExtra}}"
 		},
 		{
 			"page": "template-001-desc-order-unnamed-args",
-			"contents": "{{#ask:[[Category:template-001]][[Has page property::ABC]] |?Has page property |sep=, |valuesep=, |format=template |order=desc |link=none |limit=3 |searchlabel=furtherresults |userparam=[$%&*==42] |template=TemplateOutputUsingUnnamedArgumentsForNonUnicode |introtemplate=TemplateOutputUsingUnnamedArgumentsForNonUnicodeExtra |outrotemplate=TemplateOutputUsingUnnamedArgumentsForNonUnicodeExtra}}"
+			"contents": "{{#ask:[[Category:template-001]][[Has page property::ABC]] |?Has page property |sep=, |format=template |order=desc |link=none |limit=3 |searchlabel=furtherresults |userparam=[$%&*==42] |template=TemplateOutputUsingUnnamedArgumentsForNonUnicode |introtemplate=TemplateOutputUsingUnnamedArgumentsForNonUnicodeExtra |outrotemplate=TemplateOutputUsingUnnamedArgumentsForNonUnicodeExtra}}"
 		}
 	],
 	"tests": [

--- a/tests/phpunit/Integration/JSONScript/TestCases/f-0104.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/f-0104.json
@@ -128,7 +128,7 @@
 			"subject": "Example/F0104/Q.6",
 			"assert-output": {
 				"to-contain": [
-					"(I)Example/F0104/1:123 456Example/F0104/2:abc defExample/F0104/3:001 0011(O)"
+					"(I)Example/F0104/1:123, 456Example/F0104/2:abc, defExample/F0104/3:001, 0011(O)"
 				]
 			}
 		},

--- a/tests/phpunit/Integration/JSONScript/TestCases/f-0803.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/f-0803.json
@@ -62,6 +62,10 @@
 		{
 			"page": "Example/F0803/Q.7",
 			"contents": "{{#ask: [[Category:F0803]] |?Has text |format=template |template=Example/F0803/Numbered |mainlabel=- |template arguments=numbered |link=none |sep= &#32;&bull;&#32; |valuesep= &#32;&bull;&#32; |sort=Has text |order=asc }}"
+		},
+		{
+			"page": "Example/F0803/Q.8",
+			"contents": "{{#ask: [[Category:F0803]] |?Has text |format=template |template=Example/F0803/Sep |mainlabel=main |named args=yes |link=none |sep= &#32;&bull;&#32; |sort=Has text |order=asc }}"
 		}
 	],
 	"tests": [
@@ -132,6 +136,16 @@
 			"assert-output": {
 				"to-contain": [
 					"123&#32;&#8226;&#32; 456&#32;&#8226;&#32;abc"
+				]
+			}
+		},
+		{
+			"type": "parser",
+			"about": "#7 (`valuesep` parameter omitted)",
+			"subject": "Example/F0803/Q.8",
+			"assert-output": {
+				"to-contain": [
+					"123, 456&#32;&#8226;&#32;abc"
 				]
 			}
 		}


### PR DESCRIPTION
See comment from @cicalese in #2331 regarding need for valuesep to default to comma when this parameter is offered by the template output format.