### PR TITLE
Revert "LinksUpdateConstructed add additional log output (#2520)"

### DIFF
--- a/src/MediaWiki/Hooks/LinksUpdateConstructed.php
+++ b/src/MediaWiki/Hooks/LinksUpdateConstructed.php
@@ -74,14 +74,7 @@ class LinksUpdateConstructed implements LoggerAwareInterface {
 			$linksUpdate->getParserOutput()
 		);
 
-		$isEmpty = $parserData->getSemanticData()->isEmpty();
-
-		$this->log( 'LinksUpdateConstructed' . ' on ' . $title->getPrefixedDBkey() );
-
-		$this->log( 'LinksUpdateConstructed' . ' isEmpty: ' . (int)$isEmpty );
-		$this->log( 'LinksUpdateConstructed' . ' properties: ' . serialize( $parserData->getSemanticData()->getProperties() ) );
-
-		if ( $this->isSemanticEnabledNamespace( $title ) && $isEmpty ) {
+		if ( $this->isSemanticEnabledNamespace( $title ) && $parserData->getSemanticData()->isEmpty() ) {
 			$this->updateEmptySemanticData( $parserData, $title );
 		}
 
@@ -105,11 +98,9 @@ class LinksUpdateConstructed implements LoggerAwareInterface {
 		// EnqueueableDataUpdate which creates updates as JobSpecification
 		// (refreshLinksPrioritized) and posses a possibility of running an
 		// update more than once for the same RevID
-		if ( !$isEmpty ) {
-			$revId = $title->getLatestRevID( Title::GAID_FOR_UPDATE );
-			$this->log( 'LinksUpdateConstructed' . ' markUpdate: ' . $revId );
-			$parserData->markUpdate( $revId );
-		}
+		$parserData->markUpdate(
+			$title->getLatestRevID( Title::GAID_FOR_UPDATE )
+		);
 
 		return true;
 	}

--- a/tests/phpunit/Unit/MediaWiki/Hooks/LinksUpdateConstructedTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Hooks/LinksUpdateConstructedTest.php
@@ -124,17 +124,12 @@ class LinksUpdateConstructedTest extends \PHPUnit_Framework_TestCase {
 		$title = Title::newFromText( __METHOD__, NS_HELP );
 		$parserOutput = new ParserOutput();
 
-		$semanticData = $this->getMockBuilder( '\SMW\SemanticData' )
-			->disableOriginalConstructor()
-			->getMock();
-
 		$parserData = $this->getMockBuilder( '\SMW\ParserData' )
 			->disableOriginalConstructor()
 			->getMock();
 
-		$parserData->expects( $this->any() )
-			->method( 'getSemanticData' )
-			->will( $this->returnValue( $semanticData ) );
+		$parserData->expects( $this->never() )
+			->method( 'getSemanticData' );
 
 		$parserData->expects( $this->once() )
 			->method( 'updateStore' );


### PR DESCRIPTION
This reverts commit b5a21f931d8975dd28c3eba6123bf13286b2cdad.

This PR is made in reference to: #2520, https://phabricator.wikimedia.org/T168347

This PR addresses or contains:

- No longer required as the cause of an issue has been identified

This PR includes:
- [ ] Tests (unit/integration)
- [x] CI build passed
