### PR TITLE
CommitWithTransactionTicket only on DeferrableUpdate, refs 1796, 2482, 2523

### DIFF
--- a/src/Updater/DeferredCallableUpdate.php
+++ b/src/Updater/DeferredCallableUpdate.php
@@ -41,7 +41,12 @@ class DeferredCallableUpdate implements DeferrableUpdate, LoggerAwareInterface {
 	/**
 	 * @var boolean
 	 */
-	private $isDeferrableUpdate = true;
+	protected $isDeferrableUpdate = true;
+
+	/**
+	 * @var boolean
+	 */
+	protected $isCommandLineMode = false;
 
 	/**
 	 * @var boolean
@@ -62,11 +67,6 @@ class DeferredCallableUpdate implements DeferrableUpdate, LoggerAwareInterface {
 	 * @var string|null
 	 */
 	private $fingerprint = null;
-
-	/**
-	 * @var boolean
-	 */
-	protected $isCommandLineMode = false;
 
 	/**
 	 * @var array

--- a/src/Updater/TransactionalDeferredCallableUpdate.php
+++ b/src/Updater/TransactionalDeferredCallableUpdate.php
@@ -76,7 +76,7 @@ class TransactionalDeferredCallableUpdate extends DeferredCallableUpdate {
 	 * @since 3.0
 	 */
 	public function commitWithTransactionTicket() {
-		if ( $this->isCommandLineMode === false ) {
+		if ( $this->isCommandLineMode === false && $this->isDeferrableUpdate === true ) {
 			$this->transactionTicket = $this->connection->getEmptyTransactionTicket( $this->getOrigin() );
 		}
 	}

--- a/tests/phpunit/Unit/Updater/TransactionalDeferredCallableUpdateTest.php
+++ b/tests/phpunit/Unit/Updater/TransactionalDeferredCallableUpdateTest.php
@@ -265,4 +265,74 @@ class TransactionalDeferredCallableUpdateTest extends \PHPUnit_Framework_TestCas
 		$this->testEnvironment->executePendingDeferredUpdates();
 	}
 
+	public function testCommitWithTransactionTicketOnDeferrableUpdate() {
+
+		$connection = $this->getMockBuilder( '\SMW\MediaWiki\Database' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$connection->expects( $this->once() )
+			->method( 'getEmptyTransactionTicket' );
+
+		$this->testEnvironment->clearPendingDeferredUpdates();
+
+		$test = $this->getMockBuilder( '\stdClass' )
+			->disableOriginalConstructor()
+			->setMethods( array( 'doTest' ) )
+			->getMock();
+
+		$test->expects( $this->once() )
+			->method( 'doTest' );
+
+		$callback = function() use ( $test ) {
+			$test->doTest();
+		};
+
+		$instance = new TransactionalDeferredCallableUpdate(
+			$callback,
+			$connection
+		);
+
+		$instance->isDeferrableUpdate( true );
+		$instance->commitWithTransactionTicket();
+		$instance->pushUpdate();
+
+		$this->testEnvironment->executePendingDeferredUpdates();
+	}
+
+	public function testCommitWithTransactionTicketOnNonDeferrableUpdate() {
+
+		$connection = $this->getMockBuilder( '\SMW\MediaWiki\Database' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$connection->expects( $this->never() )
+			->method( 'getEmptyTransactionTicket' );
+
+		$this->testEnvironment->clearPendingDeferredUpdates();
+
+		$test = $this->getMockBuilder( '\stdClass' )
+			->disableOriginalConstructor()
+			->setMethods( array( 'doTest' ) )
+			->getMock();
+
+		$test->expects( $this->once() )
+			->method( 'doTest' );
+
+		$callback = function() use ( $test ) {
+			$test->doTest();
+		};
+
+		$instance = new TransactionalDeferredCallableUpdate(
+			$callback,
+			$connection
+		);
+
+		$instance->isDeferrableUpdate( false );
+		$instance->commitWithTransactionTicket();
+		$instance->pushUpdate();
+
+		$this->testEnvironment->executePendingDeferredUpdates();
+	}
+
 }


### PR DESCRIPTION
This PR is made in reference to: #1796, #2482, #2523

This PR addresses or contains:

- Due to https://phabricator.wikimedia.org/T168347 somewhere an exception is thrown when a `transactionTicket` is used while not being a separate transaction and causes the property update (which is not made deferred due to #1796) to be silently fail without a DB update or log entry
- Ensure that only marked `isDeferrableUpdate` can use a `transactionTicket`

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed
