### PR TITLE
InternalParseBeforeLinks cast smwgEnabledSpecialPage setting late, refs 2529

### DIFF
--- a/src/MediaWiki/Hooks/InternalParseBeforeLinks.php
+++ b/src/MediaWiki/Hooks/InternalParseBeforeLinks.php
@@ -49,10 +49,10 @@ class InternalParseBeforeLinks {
 	/**
 	 * @since 2.5
 	 *
-	 * @param array $enabledSpecialPage
+	 * @param array|boolean $enabledSpecialPage
 	 */
-	public function setEnabledSpecialPage( array $enabledSpecialPage ) {
-		$this->enabledSpecialPage = $enabledSpecialPage;
+	public function setEnabledSpecialPage( $enabledSpecialPage ) {
+		$this->enabledSpecialPage = (array)$enabledSpecialPage;
 	}
 
 	/**
@@ -93,8 +93,9 @@ class InternalParseBeforeLinks {
 			return true;
 		}
 
+		// #2529
 		foreach ( $this->enabledSpecialPage as $specialPage ) {
-			if ( $title->isSpecial( $specialPage ) ) {
+			if ( is_string( $specialPage ) && $title->isSpecial( $specialPage ) ) {
 				return true;
 			}
 		}

--- a/tests/phpunit/Unit/MediaWiki/Hooks/InternalParseBeforeLinksTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Hooks/InternalParseBeforeLinksTest.php
@@ -337,6 +337,7 @@ class InternalParseBeforeLinksTest extends \PHPUnit_Framework_TestCase {
 				)
 		);
 
+		// #1
 		$provider[] = array(
 			array(
 				'title'    => $title,
@@ -356,7 +357,7 @@ class InternalParseBeforeLinksTest extends \PHPUnit_Framework_TestCase {
 				)
 		);
 
-		// #1 NS_SPECIAL, processed but no annotations
+		// #2 NS_SPECIAL, processed but no annotations
 		$title = Title::newFromText( 'Ask', NS_SPECIAL );
 
 		$provider[] = array(
@@ -381,7 +382,7 @@ class InternalParseBeforeLinksTest extends \PHPUnit_Framework_TestCase {
 				)
 		);
 
-		// #2 NS_SPECIAL, not processed
+		// #3 NS_SPECIAL, not processed, Title::isSpecial returns false
 		$title = Title::newFromText( 'Foo', NS_SPECIAL );
 
 		$provider[] = array(
@@ -393,6 +394,31 @@ class InternalParseBeforeLinksTest extends \PHPUnit_Framework_TestCase {
 					'smwgLinksInValues' => false,
 					'smwgInlineErrors'  => true,
 					'smwgEnabledSpecialPage' => array( 'Ask', 'Foo' )
+				),
+				'text'  => 'Lorem ipsum dolor sit &$% [[FooBar::dictumst|寒い]]' .
+					' [[Bar::tincidunt semper]] facilisi {{volutpat}} Ut quis' .
+					' [[foo::9001]] et Donec.',
+				),
+				array(
+					'resultText' => 'Lorem ipsum dolor sit &$% [[FooBar::dictumst|寒い]]' .
+						' [[Bar::tincidunt semper]] facilisi {{volutpat}} Ut quis' .
+						' [[foo::9001]] et Donec.',
+					'propertyCount' => 0
+				)
+		);
+
+		// #4 NS_SPECIAL, not processed, invalid smwgEnabledSpecialPage setting
+		$title = Title::newFromText( 'Foobar', NS_SPECIAL );
+
+		$provider[] = array(
+			array(
+				'title'    => $title,
+				'settings' => array(
+					'smwgNamespacesWithSemanticLinks' => array( NS_MAIN => true ),
+					'smwgEnabledInTextAnnotationParserStrictMode' => true,
+					'smwgLinksInValues' => false,
+					'smwgInlineErrors'  => true,
+					'smwgEnabledSpecialPage' => false
 				),
 				'text'  => 'Lorem ipsum dolor sit &$% [[FooBar::dictumst|寒い]]' .
 					' [[Bar::tincidunt semper]] facilisi {{volutpat}} Ut quis' .


### PR DESCRIPTION
This PR is made in reference to: #2529

This PR addresses or contains:

- Cause for #2529 is a not anticipated value in `smwgEnabledSpecialPage` when set via `InternalParseBeforeLinks::setEnabledSpecialPage`
- Validate the value later instead of relying on an early type check which avoids punishment of a user during normal operations or as seen in #2529 during the setup

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed
