### PR TITLE
Add newQueryEngineDatabaseConnectionProvider for temporary table queries on DB_REPLICA

### DIFF
--- a/includes/Setup.php
+++ b/includes/Setup.php
@@ -109,7 +109,9 @@ final class Setup {
 		);
 
 		// Connection can be used to redirect queries to another DB cluster
+		// Wikia Change - Start
 		$queryengineConnectionProvider = $mwCollaboratorFactory->newQueryEngineDatabaseConnectionProvider();
+		// Wikia Change - End
 
 		$connectionManager->registerConnectionProvider(
 			'mw.db.queryengine',

--- a/includes/Setup.php
+++ b/includes/Setup.php
@@ -109,8 +109,7 @@ final class Setup {
 		);
 
 		// Connection can be used to redirect queries to another DB cluster
-		$queryengineConnectionProvider = $mwCollaboratorFactory->newMediaWikiDatabaseConnectionProvider();
-		$queryengineConnectionProvider->resetTransactionProfiler();
+		$queryengineConnectionProvider = $mwCollaboratorFactory->newQueryEngineDatabaseConnectionProvider();
 
 		$connectionManager->registerConnectionProvider(
 			'mw.db.queryengine',

--- a/includes/Setup.php
+++ b/includes/Setup.php
@@ -109,9 +109,7 @@ final class Setup {
 		);
 
 		// Connection can be used to redirect queries to another DB cluster
-		// Wikia Change - Start
 		$queryengineConnectionProvider = $mwCollaboratorFactory->newQueryEngineDatabaseConnectionProvider();
-		// Wikia Change - End
 
 		$connectionManager->registerConnectionProvider(
 			'mw.db.queryengine',

--- a/src/MediaWiki/MwCollaboratorFactory.php
+++ b/src/MediaWiki/MwCollaboratorFactory.php
@@ -142,6 +142,20 @@ class MwCollaboratorFactory {
 	}
 
 	/**
+	 * Wikia Change
+	 * QueryEngineDatabase use slave for read and write operation.
+	 * There is no write in QueryEngine but ->query() use writeConnection.
+	 * Query needs to create temporary tables and insert data to it.
+	 *
+	 *
+	 * @return QueryEngineDatabaseConnectionProvider
+	 */
+	public function newQueryEngineDatabaseConnectionProvider(){
+		return new QueryEngineDatabaseConnectionProvider();
+	}
+
+
+	/**
 	 * @since 2.0
 	 *
 	 * @param WikiPage $wkiPage

--- a/src/MediaWiki/MwCollaboratorFactory.php
+++ b/src/MediaWiki/MwCollaboratorFactory.php
@@ -142,11 +142,9 @@ class MwCollaboratorFactory {
 	}
 
 	/**
-	 * Wikia Change
 	 * QueryEngineDatabase use slave for read and write operation.
 	 * There is no write in QueryEngine but ->query() use writeConnection.
 	 * Query needs to create temporary tables and insert data to it.
-	 *
 	 *
 	 * @return QueryEngineDatabaseConnectionProvider
 	 */

--- a/src/MediaWiki/QueryEngineDatabaseConnectionProvider.php
+++ b/src/MediaWiki/QueryEngineDatabaseConnectionProvider.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace SMW\MediaWiki;
+
+
+use SMW\DBConnectionProvider;
+
+/**
+ * QueryEngineDatabase use slave for read and write operation.
+ * There is no write in QueryEngine but ->query() use writeConnection.
+ * Query needs to create temporary tables and insert data to it.
+ * @package SMW\MediaWiki
+ */
+class QueryEngineDatabaseConnectionProvider implements DBConnectionProvider {
+
+	private $connection = null;
+
+	/**
+	 * Returns the database connection.
+	 * Initialization of this connection is done if it was not already initialized.
+	 *
+	 * @since 0.1
+	 */
+	public function getConnection() {
+		if ($this->connection === null) {
+			$this->connection = $this->createConnection();
+		}
+
+		return $this->connection;
+	}
+
+	/**
+	 * Releases the connection if doing so makes any sense resource wise.
+	 *
+	 * @since 0.1
+	 */
+	public function releaseConnection() {
+		$this->connection = null;
+	}
+
+	private function createConnection() {
+
+
+		$connection = new Database(
+			new LazyDBConnectionProvider( DB_SLAVE ),
+			new LazyDBConnectionProvider( DB_SLAVE )
+		);
+
+		$connection->setDBPrefix( $GLOBALS['wgDBprefix'] );
+
+		$connection->resetTransactionProfiler();
+
+		return $connection;
+	}
+}

--- a/src/MediaWiki/QueryEngineDatabaseConnectionProvider.php
+++ b/src/MediaWiki/QueryEngineDatabaseConnectionProvider.php
@@ -41,10 +41,9 @@ class QueryEngineDatabaseConnectionProvider implements DBConnectionProvider {
 
 	private function createConnection() {
 
-		$connection = new Database(
-			new LazyDBConnectionProvider( DB_SLAVE ),
-			new LazyDBConnectionProvider( DB_SLAVE )
-		);
+		$connectionProvider = new LazyDBConnectionProvider( DB_SLAVE );
+		// use same connection to read/write see explanation in this class doc
+		$connection = new Database( $connectionProvider, $connectionProvider );
 
 		global $wgDBprefix;
 		$connection->setDBPrefix( $wgDBprefix );

--- a/src/MediaWiki/QueryEngineDatabaseConnectionProvider.php
+++ b/src/MediaWiki/QueryEngineDatabaseConnectionProvider.php
@@ -6,6 +6,7 @@ namespace SMW\MediaWiki;
 use SMW\DBConnectionProvider;
 
 /**
+ * Wikia Change -> whole file
  * QueryEngineDatabase use slave for read and write operation.
  * There is no write in QueryEngine but ->query() use writeConnection.
  * Query needs to create temporary tables and insert data to it.
@@ -40,13 +41,13 @@ class QueryEngineDatabaseConnectionProvider implements DBConnectionProvider {
 
 	private function createConnection() {
 
-
 		$connection = new Database(
 			new LazyDBConnectionProvider( DB_SLAVE ),
 			new LazyDBConnectionProvider( DB_SLAVE )
 		);
 
-		$connection->setDBPrefix( $GLOBALS['wgDBprefix'] );
+		global $wgDBprefix;
+		$connection->setDBPrefix( $wgDBprefix );
 
 		$connection->resetTransactionProfiler();
 

--- a/src/MediaWiki/QueryEngineDatabaseConnectionProvider.php
+++ b/src/MediaWiki/QueryEngineDatabaseConnectionProvider.php
@@ -6,7 +6,6 @@ namespace SMW\MediaWiki;
 use SMW\DBConnectionProvider;
 
 /**
- * Wikia Change -> whole file
  * QueryEngineDatabase use slave for read and write operation.
  * There is no write in QueryEngine but ->query() use writeConnection.
  * Query needs to create temporary tables and insert data to it.
@@ -19,8 +18,6 @@ class QueryEngineDatabaseConnectionProvider implements DBConnectionProvider {
 	/**
 	 * Returns the database connection.
 	 * Initialization of this connection is done if it was not already initialized.
-	 *
-	 * @since 0.1
 	 */
 	public function getConnection() {
 		if ($this->connection === null) {
@@ -32,8 +29,6 @@ class QueryEngineDatabaseConnectionProvider implements DBConnectionProvider {
 
 	/**
 	 * Releases the connection if doing so makes any sense resource wise.
-	 *
-	 * @since 0.1
 	 */
 	public function releaseConnection() {
 		$this->connection = null;

--- a/src/MediaWiki/QueryEngineDatabaseConnectionProvider.php
+++ b/src/MediaWiki/QueryEngineDatabaseConnectionProvider.php
@@ -43,7 +43,7 @@ class QueryEngineDatabaseConnectionProvider implements DBConnectionProvider {
 		global $wgDBprefix;
 		$connection->setDBPrefix( $wgDBprefix );
 
-		$connection->resetTransactionProfiler();
+		$connection->resetTransactionProfiler( $this->resetTransactionProfiler );
 
 		return $connection;
 	}

--- a/src/MediaWiki/QueryEngineDatabaseConnectionProvider.php
+++ b/src/MediaWiki/QueryEngineDatabaseConnectionProvider.php
@@ -2,22 +2,39 @@
 
 namespace SMW\MediaWiki;
 
-
 use SMW\DBConnectionProvider;
 
 /**
  * QueryEngineDatabase use slave for read and write operation.
  * There is no write in QueryEngine but ->query() use writeConnection.
  * Query needs to create temporary tables and insert data to it.
- * @package SMW\MediaWiki
+ *
+ * @license GNU GPL v2+
+ * @since 2.5
+ *
+ * @author Sqreek
  */
 class QueryEngineDatabaseConnectionProvider implements DBConnectionProvider {
 
+	/**
+	 * @var Database
+	 */
 	private $connection = null;
 
 	/**
+	 * @var boolean
+	 */
+	private $resetTransactionProfiler = false;
+
+	/**
+	 * @see DBConnectionProvider::getConnection
+	 *
 	 * Returns the database connection.
 	 * Initialization of this connection is done if it was not already initialized.
+	 *
+	 * @since 2.5
+	 *
+	 * @return Database
 	 */
 	public function getConnection() {
 		if ($this->connection === null) {
@@ -29,6 +46,10 @@ class QueryEngineDatabaseConnectionProvider implements DBConnectionProvider {
 
 	/**
 	 * Releases the connection if doing so makes any sense resource wise.
+	 *
+	 * @see DBConnectionProvider::releaseConnection
+	 *
+	 * @since 2.5
 	 */
 	public function releaseConnection() {
 		$this->connection = null;


### PR DESCRIPTION
This PR removes the runtime exception found in #2532 when using a DB_MASTER + DB_SLAVE setup. At present I'm seeing more lag then I like, so I'll do some profiling before being ready for this to merge.

This PR includes:
- [ ] Tests (unit/integration)
- [ ] CI build passed
