### PR TITLE
Add $smwgLocalConnectionConf, refs 2532, 2533

### DIFF
--- a/DefaultSettings.php
+++ b/DefaultSettings.php
@@ -75,6 +75,34 @@ return array(
 	##
 
 	###
+	# Local connection configurations
+	#
+	# Allows to modify connection characteristics for providers that are used by
+	# Semantic MediaWiki.
+	#
+	# Changes to these settings should ONLY be made by trained professionals to
+	# avoid unexpected or unanticipated results when using connection handlers.
+	#
+	# Available DB index as provided by MediaWiki:
+	#
+	# - DB_SLAVE or DB_REPLICA (1.28+)
+	# - DB_MASTER
+	#
+	# @since 3.0
+	##
+	'smwgLocalConnectionConf' => array(
+		'mw.db' => array(
+			'read'  => DB_SLAVE,
+			'write' => DB_MASTER
+		),
+		'mw.db.queryengine' => array(
+			'read'  => DB_SLAVE,
+			'write' => DB_MASTER
+		)
+	),
+	##
+
+	###
 	# Configure SPARQL database connection for Semantic MediaWiki. This is used
 	# when SPARQL-based features are enabled, e.g. when using SMWSparqlStore as
 	# the $smwgDefaultStore.

--- a/includes/Settings.php
+++ b/includes/Settings.php
@@ -53,6 +53,7 @@ class Settings extends Options {
 			'smwgSemanticsEnabled' => $GLOBALS['smwgSemanticsEnabled'],
 			'smwgEnabledCompatibilityMode' => $GLOBALS['smwgEnabledCompatibilityMode'],
 			'smwgDefaultStore' => $GLOBALS['smwgDefaultStore'],
+			'smwgLocalConnectionConf' => $GLOBALS['smwgLocalConnectionConf'],
 			'smwgSparqlDatabaseConnector' => $GLOBALS['smwgSparqlDatabaseConnector'],
 			'smwgSparqlDatabase' => $GLOBALS['smwgSparqlDatabase'],
 			'smwgSparqlQueryEndpoint' => $GLOBALS['smwgSparqlQueryEndpoint'],

--- a/includes/Setup.php
+++ b/includes/Setup.php
@@ -105,11 +105,11 @@ final class Setup {
 
 		$connectionManager->registerConnectionProvider(
 			'mw.db',
-			$mwCollaboratorFactory->newMediaWikiDatabaseConnectionProvider()
+			$mwCollaboratorFactory->newMediaWikiDatabaseConnectionProvider( 'mw.db' )
 		);
 
 		// Connection can be used to redirect queries to another DB cluster
-		$queryengineConnectionProvider = $mwCollaboratorFactory->newMediaWikiDatabaseConnectionProvider();
+		$queryengineConnectionProvider = $mwCollaboratorFactory->newMediaWikiDatabaseConnectionProvider( 'mw.db.queryengine' );
 		$queryengineConnectionProvider->resetTransactionProfiler();
 
 		$connectionManager->registerConnectionProvider(

--- a/src/MediaWiki/MwCollaboratorFactory.php
+++ b/src/MediaWiki/MwCollaboratorFactory.php
@@ -135,10 +135,25 @@ class MwCollaboratorFactory {
 	/**
 	 * @since 2.1
 	 *
+	 * @param string|null $provider
+	 *
 	 * @return DatabaseConnectionProvider
 	 */
-	public function newMediaWikiDatabaseConnectionProvider() {
-		return new DatabaseConnectionProvider();
+	public function newMediaWikiDatabaseConnectionProvider( $provider = null ) {
+
+		$databaseConnectionProvider = new DatabaseConnectionProvider(
+			$provider
+		);
+
+		$databaseConnectionProvider->setLocalConnectionConf(
+			$this->applicationFactory->getSettings()->get( 'smwgLocalConnectionConf' )
+		);
+
+		$databaseConnectionProvider->setLogger(
+			$this->applicationFactory->getMediaWikiLogger()
+		);
+
+		return $databaseConnectionProvider;
 	}
 
 	/**

--- a/tests/phpunit/Unit/MediaWiki/MwCollaboratorFactoryTest.php
+++ b/tests/phpunit/Unit/MediaWiki/MwCollaboratorFactoryTest.php
@@ -170,7 +170,29 @@ class MwCollaboratorFactoryTest extends \PHPUnit_Framework_TestCase {
 
 	public function testCanConstructDatabaseConnectionProvider() {
 
-		$instance = new MwCollaboratorFactory( new ApplicationFactory() );
+		$settings = $this->getMockBuilder( '\SMW\Settings' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$logger = $this->getMockBuilder( '\Psr\Log\LoggerInterface' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$settings->expects( $this->atLeastOnce() )
+			->method( 'get' )
+			->will( $this->returnValue( array() ) );
+
+		$this->applicationFactory->expects( $this->atLeastOnce() )
+			->method( 'getSettings' )
+			->will( $this->returnValue( $settings ) );
+
+		$this->applicationFactory->expects( $this->atLeastOnce() )
+			->method( 'getMediaWikiLogger' )
+			->will( $this->returnValue( $logger ) );
+
+		$instance = new MwCollaboratorFactory(
+			$this->applicationFactory
+		);
 
 		$this->assertInstanceOf(
 			'\SMW\MediaWiki\DatabaseConnectionProvider',


### PR DESCRIPTION
This PR is made in reference to: #2532, #2533

This PR addresses or contains:

- `$smwgLocalConnectionConf` to allow for modifications on connection providers
- As noted "Changes to these settings should ONLY be made by trained professionals to avoid unexpected or unanticipated results ..."
- In certain environments a setting like `$smwgLocalConnectionConf['mw.db.queryengine'] = [ 'read' => DB_SLAVE, 'write' => DB_SLAVE ]`  can be more favourable 
- Setting `[ 'read' => DB_SLAVE, 'write' => DB_MASTER ]` will be logged as `[smw] [mw.db.queryengine] connection provider with {"read":-1,"write":-2}`

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed
