### PR TITLE
Add SMW_FIELDT_CHAR_LONG, refs 2499

### DIFF
--- a/DefaultSettings.php
+++ b/DefaultSettings.php
@@ -1599,6 +1599,22 @@ return array(
 	#
 	# [0] https://techblog.dorogin.com/case-insensitive-like-in-sqlite-504f594dcdc3
 	#
+	# SMW_FIELDT_CHAR_LONG - Extends the size to 300 chars for text pattern
+	# match (DIBlob and DIUri) fields.
+	#
+	# By default, those fields are limited to 72 chars that limits search depth
+	# in exchange for index size and performance. Extending fields to 300 allows
+	# to run LIKE/NLIKE matching on a larger text body without relying on a
+	# full-text index but an increased index size could potentially carry a
+	# performance penalty when the index cannot be kept in memory.
+	#
+	# No analysis has been performed on how performance is impacted. Selecting
+	# this option requires to run `rebuildData.php` to adjust the field content
+	# to the new length.
+	#
+	# SMW_FIELDT_CHAR_NOCASE | SMW_FIELDT_CHAR_LONG can be combined to build a
+	# case insensitive long field type.
+	#
 	# @since 3.0
 	# @default false
 	##

--- a/maintenance/setupStore.php
+++ b/maintenance/setupStore.php
@@ -84,10 +84,10 @@ class SetupStore extends \Maintenance {
 			exit;
 		}
 
+		StoreFactory::clear();
 		$this->loadGlobalFunctions();
 
 		$store = $this->getStore();
-		StoreFactory::clear();
 
 		if ( $this->getOption( 'quiet' ) ) {
 			$messageReporter = MessageReporterFactory::getInstance()->newNullMessageReporter();

--- a/src/Defines.php
+++ b/src/Defines.php
@@ -217,4 +217,5 @@ define( 'SMW_EL_INPROP', 2 ); // New query for EntityLookup::getInProperties
   */
 define( 'SMW_FIELDT_NONE', 0 );
 define( 'SMW_FIELDT_CHAR_NOCASE', 2 ); // Using FieldType::TYPE_CHAR_NOCASE
+define( 'SMW_FIELDT_CHAR_LONG', 4 ); // Using FieldType::TYPE_CHAR_LONG
 /**@}*/

--- a/src/SQLStore/EntityStore/DIHandlers/DIBlobHandler.php
+++ b/src/SQLStore/EntityStore/DIHandlers/DIBlobHandler.php
@@ -163,10 +163,20 @@ class DIBlobHandler extends DataItemHandler {
 	 * which should be more than enough in most contexts.
 	 *
 	 * @since 1.8
+	 *
+	 * Using `SMW_FIELDT_CHAR_LONG` as option in `smwgFieldTypeFeatures`
+	 * will extend the field size to 300 and expands the maximum matchable
+	 * string length to 300-32 for LIKE/NLIKE queries.
+	 *
+	 * @since 3.0
 	 */
 	private function getMaxLength() {
 
 		$length = 72;
+
+		if ( $this->isEnabledFeature( SMW_FIELDT_CHAR_LONG ) ) {
+			$length = FieldType::CHAR_LONG_LENGTH;
+		}
 
 		return $length;
 	}
@@ -177,6 +187,14 @@ class DIBlobHandler extends DataItemHandler {
 
 		if ( $this->isEnabledFeature( SMW_FIELDT_CHAR_NOCASE ) ) {
 			$fieldType = FieldType::TYPE_CHAR_NOCASE;
+		}
+
+		if ( $this->isEnabledFeature( SMW_FIELDT_CHAR_LONG ) ) {
+			$fieldType = FieldType::TYPE_CHAR_LONG;
+		}
+
+		if ( $this->isEnabledFeature( SMW_FIELDT_CHAR_LONG ) && $this->isEnabledFeature( SMW_FIELDT_CHAR_NOCASE ) ) {
+			$fieldType = FieldType::TYPE_CHAR_LONG_NOCASE;
 		}
 
 		return $fieldType;

--- a/src/SQLStore/EntityStore/DIHandlers/DIUriHandler.php
+++ b/src/SQLStore/EntityStore/DIHandlers/DIUriHandler.php
@@ -113,6 +113,10 @@ class DIUriHandler extends DataItemHandler {
 
 		$length = 255;
 
+		if ( $this->isEnabledFeature( SMW_FIELDT_CHAR_LONG ) ) {
+			$length = FieldType::CHAR_LONG_LENGTH;
+		}
+
 		return $length;
 	}
 
@@ -122,6 +126,14 @@ class DIUriHandler extends DataItemHandler {
 
 		if ( $this->isEnabledFeature( SMW_FIELDT_CHAR_NOCASE ) ) {
 			$fieldType = FieldType::TYPE_CHAR_NOCASE;
+		}
+
+		if ( $this->isEnabledFeature( SMW_FIELDT_CHAR_LONG ) ) {
+			$fieldType = FieldType::TYPE_CHAR_LONG;
+		}
+
+		if ( $this->isEnabledFeature( SMW_FIELDT_CHAR_LONG ) && $this->isEnabledFeature( SMW_FIELDT_CHAR_NOCASE ) ) {
+			$fieldType = FieldType::TYPE_CHAR_LONG_NOCASE;
 		}
 
 		return $fieldType;

--- a/src/SQLStore/EntityStore/DataItemHandler.php
+++ b/src/SQLStore/EntityStore/DataItemHandler.php
@@ -23,7 +23,7 @@ abstract class DataItemHandler {
 	/**
 	 * @var integer
 	*/
-	private $fieldTypeFeatures = false;
+	protected $fieldTypeFeatures = false;
 
 	/**
 	 * @var null|string

--- a/src/SQLStore/QueryEngine/DescriptionInterpreters/ComparatorMapper.php
+++ b/src/SQLStore/QueryEngine/DescriptionInterpreters/ComparatorMapper.php
@@ -48,6 +48,10 @@ class ComparatorMapper {
 				$value = str_replace( array( 'http://', 'https://', '%2A' ), array( '', '', '*' ), $value );
 			}
 
+			if ( $value !== '' && $value{0} === '=' ) {
+				$value = substr( $value, 1 );
+			}
+
 			// Escape to prepare string matching:
 			$value = str_replace(
 				array( '\\', '%', '_', '*', '?' ),

--- a/src/SQLStore/QueryEngine/Fulltext/MySQLValueMatchConditionBuilder.php
+++ b/src/SQLStore/QueryEngine/Fulltext/MySQLValueMatchConditionBuilder.php
@@ -41,6 +41,11 @@ class MySQLValueMatchConditionBuilder extends ValueMatchConditionBuilder {
 		$comparator = $description->getComparator();
 
 		if ( $matchableText && ( $comparator === SMW_CMP_LIKE || $comparator === SMW_CMP_NLKE ) ) {
+
+			if ( $matchableText !== '' && $matchableText{0} === '=' ) {
+				return false;
+			}
+
 			// http://dev.mysql.com/doc/refman/5.7/en/fulltext-boolean.html
 			// innodb_ft_min_token_size and innodb_ft_max_token_size are used
 			// for InnoDB search indexes. ft_min_word_len and ft_max_word_len

--- a/src/SQLStore/TableBuilder/FieldType.php
+++ b/src/SQLStore/TableBuilder/FieldType.php
@@ -58,6 +58,11 @@ class FieldType {
 	const TYPE_CHAR_LONG_NOCASE = 'char long nocase';
 
 	/**
+	 * @var integer
+	 */
+	const CHAR_LONG_LENGTH = 300;
+
+	/**
 	 * @var string
 	 */
 	const TYPE_BOOL = 'boolean';

--- a/src/SQLStore/TableBuilder/MySQLTableBuilder.php
+++ b/src/SQLStore/TableBuilder/MySQLTableBuilder.php
@@ -20,6 +20,8 @@ class MySQLTableBuilder extends TableBuilder {
 	 */
 	public function getStandardFieldType( $fieldType ) {
 
+		$charLongLength = FieldType::CHAR_LONG_LENGTH;
+
 		$fieldTypes = array(
 			 // like page_id in MW page table
 			'id'         => 'INT(8) UNSIGNED',
@@ -38,9 +40,9 @@ class MySQLTableBuilder extends TableBuilder {
 			'boolean'    => 'TINYINT(1)',
 			'double'     => 'DOUBLE',
 			'integer'    => 'INT(8)',
-			'char long'  => 'VARBINARY(300)',
+			'char long'  => "VARBINARY($charLongLength)",
 			'char nocase'      => 'VARCHAR(255) CHARSET utf8 COLLATE utf8_general_ci',
-			'char long nocase' => 'VARCHAR(300) CHARSET utf8 COLLATE utf8_general_ci',
+			'char long nocase' => "VARCHAR($charLongLength) CHARSET utf8 COLLATE utf8_general_ci",
 			'usage count'      => 'INT(8) UNSIGNED',
 			'integer unsigned' => 'INT(8) UNSIGNED'
 		);

--- a/src/SQLStore/TableBuilder/SQLiteTableBuilder.php
+++ b/src/SQLStore/TableBuilder/SQLiteTableBuilder.php
@@ -20,6 +20,8 @@ class SQLiteTableBuilder extends TableBuilder {
 	 */
 	public function getStandardFieldType( $fieldType ) {
 
+		$charLongLength = FieldType::CHAR_LONG_LENGTH;
+
 		$fieldTypes = array(
 			 // like page_id in MW page table
 			'id'         => 'INTEGER',
@@ -37,9 +39,9 @@ class SQLiteTableBuilder extends TableBuilder {
 			'boolean'    => 'TINYINT(1)',
 			'double'     => 'DOUBLE',
 			'integer'    => 'INT(8)',
-			'char long'  => 'VARBINARY(300)',
+			'char long'  => "VARBINARY($charLongLength)",
 			'char nocase'      => 'VARCHAR(255) NOT NULL COLLATE NOCASE',
-			'char long nocase' => 'VARCHAR(300) NOT NULL COLLATE NOCASE',
+			'char long nocase' => "VARCHAR($charLongLength) NOT NULL COLLATE NOCASE",
 			'usage count'      => 'INT(8)',
 			'integer unsigned' => 'INTEGER'
 		);

--- a/tests/phpunit/Integration/JSONScript/Fixtures/q-0907-1.txt
+++ b/tests/phpunit/Integration/JSONScript/Fixtures/q-0907-1.txt
@@ -1,0 +1,3 @@
+[[Has text::Lorem ipsum dolor sit amet, consectetur adipiscing elit. Cras vulputate tortor nec magna volutpat suscipit. Aliquam erat volutpat. Nulla aliquam, lectus ut dictum sollicitudin, justo magna dapibus turpis, eget tincidunt justo tellus id libero. Aliquam tortor leo, aliquam eu feugiat in, efficitur ac nisl. Ut elit ante, rutrum ac varius vel, faucibus in magna. Mauris euismod erat sit amet vulputate placerat. Maecenas vitae urna eleifend, scelerisque metus vitae, rhoncus metus. Vestibulum luctus, tellus et blandit laoreet, mauris odio commodo mauris, at porttitor libero orci sit amet quam. Fusce at laoreet tortor.]]
+
+[[Category:Q0907]]

--- a/tests/phpunit/Integration/JSONScript/Fixtures/q-0907-2.txt
+++ b/tests/phpunit/Integration/JSONScript/Fixtures/q-0907-2.txt
@@ -1,0 +1,3 @@
+[[Has url::http://example.com/chart?chs=500x500&chma=0,0,100,100&cht=p&chco=FF0000%2CFFFF00%7CFF8000%2C00FF00%7C00FF00%2C0000FF&chd=t%3A122%2C42%2C17%2C10%2C8%2C7%2C7%2C7%2C7%2C6%2C6%2C6%2C6%2C5%2C5&chl=122%7C42%7C17%7C10%7C8%7C7%7C7%7C7%7C7%7C6%7C6%7C6%7C6%7C5%7C5&chdl=android%7Cjava%7Cstack-trace%7Cbroadcastreceiver%7Candroid-ndk%7Cuser-agent%7Candroid-webview%7Cwebview%7Cbackground%7Cmultithreading%7Candroid-source%7Csms%7Cadb%7Csollections%7Cactivity]]
+
+[[Category:Q0907]]

--- a/tests/phpunit/Integration/JSONScript/JsonTestCaseScriptRunnerTest.php
+++ b/tests/phpunit/Integration/JSONScript/JsonTestCaseScriptRunnerTest.php
@@ -212,14 +212,18 @@ class JsonTestCaseScriptRunnerTest extends JsonTestCaseScriptRunner {
 			);
 		}
 
-		$pageList = $jsonTestCaseFileHandler->getPageCreationSetupList();
+		if ( $jsonTestCaseFileHandler->hasSetting( 'smwgFieldTypeFeatures' ) ) {
+			$this->doRunTableSetupBeforeContentCreation();
+		}
 
 		// On some occasions ( e.g. fixed properties) to setup the correct
 		// table schema, run the creation once before the content is created
-		if ( $jsonTestCaseFileHandler->hasSetting( 'smwgFixedProperties' ) || $jsonTestCaseFileHandler->hasSetting( 'smwgFieldTypeFeatures' ) ) {
+		$pageList = $jsonTestCaseFileHandler->getPageCreationSetupList();
+
+		if ( $jsonTestCaseFileHandler->hasSetting( 'smwgFixedProperties' ) ) {
 			foreach ( $pageList as $page ) {
 				if ( isset( $page['namespace'] ) && $page['namespace'] === 'SMW_NS_PROPERTY' ) {
-					$this->doRunTableSetupBeforeContentCreation( $page );
+					$this->doRunTableSetupBeforeContentCreation( array( $page ) );
 				}
 			}
 		}
@@ -230,10 +234,11 @@ class JsonTestCaseScriptRunnerTest extends JsonTestCaseScriptRunner {
 		);
 	}
 
-	private function doRunTableSetupBeforeContentCreation( $page ) {
+	private function doRunTableSetupBeforeContentCreation( $pageList = null ) {
 
-		// Create property to ...
-		$this->createPagesFrom( array( $page ) );
+		if ( $pageList !== null ) {
+			$this->createPagesFrom( $pageList );
+		}
 
 		$maintenanceRunner = $this->runnerFactory->newMaintenanceRunner( 'setupStore' );
 		$maintenanceRunner->setQuiet();

--- a/tests/phpunit/Integration/JSONScript/TestCases/q-0907.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/q-0907.json
@@ -1,0 +1,111 @@
+{
+	"description": "Test `_txt` with enabled `SMW_FIELDT_CHAR_LONG` (#1912, `smwgFieldTypeFeatures`)",
+	"setup": [
+		{
+			"namespace": "SMW_NS_PROPERTY",
+			"page": "Has text",
+			"contents": "[[Has type::Text]]"
+		},
+		{
+			"namespace": "SMW_NS_PROPERTY",
+			"page": "Has url",
+			"contents": "[[Has type::URL]]"
+		},
+		{
+			"page": "Example/Q0907/1",
+			"contents": {
+				"import-from": "/../Fixtures/q-0907-1.txt"
+			}
+		},
+		{
+			"page": "Example/Q0907/2",
+			"contents": {
+				"import-from": "/../Fixtures/q-0907-2.txt"
+			}
+		}
+	],
+	"tests": [
+		{
+			"type": "query",
+			"about": "#0 (on _txt within 300 char range)",
+			"condition": "[[Category:Q0907]] [[Has text::~*libero*]]",
+			"printouts": [],
+			"parameters": {
+				"limit": "10"
+			},
+			"assert-queryresult": {
+				"count": 1,
+				"results": [
+					"Example/Q0907/1#0##"
+				]
+			}
+		},
+		{
+			"type": "query",
+			"about": "#1 (on _txt within 300 char range, case insensitive)",
+			"condition": "[[Category:Q0907]] [[Has text::~*LIbero*]]",
+			"printouts": [],
+			"parameters": {
+				"limit": "10"
+			},
+			"assert-queryresult": {
+				"count": 1,
+				"results": [
+					"Example/Q0907/1#0##"
+				]
+			}
+		},
+		{
+			"type": "query",
+			"about": "#2 (on _uri within 300 char range)",
+			"condition": "[[Category:Q0907]] [[Has url::~*stack*]]",
+			"printouts": [],
+			"parameters": {
+				"limit": "10"
+			},
+			"assert-queryresult": {
+				"count": 1,
+				"results": [
+					"Example/Q0907/2#0##"
+				]
+			}
+		},
+		{
+			"type": "query",
+			"about": "#3 (on _uri within 300 char range)",
+			"condition": "[[Category:Q0907]] [[Has url::~*STACK*]]",
+			"printouts": [],
+			"parameters": {
+				"limit": "10"
+			},
+			"assert-queryresult": {
+				"count": 1,
+				"results": [
+					"Example/Q0907/2#0##"
+				]
+			}
+		}
+	],
+	"settings": {
+		"smwgNamespacesWithSemanticLinks": {
+			"NS_MAIN": true,
+			"SMW_NS_PROPERTY": true
+		},
+		"smwgSparqlQFeatures": [
+			"SMW_SPARQL_QF_NOCASE"
+		],
+		"smwgFieldTypeFeatures": [
+			"SMW_FIELDT_CHAR_NOCASE",
+			"SMW_FIELDT_CHAR_LONG"
+		]
+	},
+	"meta": {
+		"skip-on": {
+			"postgres": "Error: 42704 ERROR:  type \"citext\" does not exist",
+			"sqlite": "NOCASE is not supported"
+		},
+		"version": "2",
+		"is-incomplete": false,
+		"debug": false
+	}
+}

--- a/tests/phpunit/Unit/SQLStore/EntityStore/DIHandlers/DIBlobHandlerTest.php
+++ b/tests/phpunit/Unit/SQLStore/EntityStore/DIHandlers/DIBlobHandlerTest.php
@@ -94,35 +94,18 @@ class DIBlobHandlerTest extends \PHPUnit_Framework_TestCase {
 		);
 	}
 
-	public function testMutableOnNoCaseFieldFeature() {
+	/**
+	 * @dataProvider fieldTypeProvider
+	 */
+	public function testMutableOnFieldTypeFeature( $fieldTypeFeatures, $expected ) {
 
 		$instance = new DIBlobHandler(
 			$this->store
 		);
 
-		$expected = [
-			'o_blob' => FieldType::TYPE_BLOB,
-			'o_hash' => FieldType::FIELD_TITLE
-		];
-
-		$this->assertEquals(
-			$expected,
-			$instance->getTableFields()
-		);
-
-		$this->assertEquals(
-			$expected,
-			$instance->getFetchFields()
-		);
-
 		$instance->setFieldTypeFeatures(
-			SMW_FIELDT_CHAR_NOCASE
+			$fieldTypeFeatures
 		);
-
-		$expected = [
-			'o_blob' => FieldType::TYPE_BLOB,
-			'o_hash' => FieldType::TYPE_CHAR_NOCASE
-		];
 
 		$this->assertEquals(
 			$expected,
@@ -218,6 +201,43 @@ class DIBlobHandlerTest extends \PHPUnit_Framework_TestCase {
 
 	private function createRandomString( $length = 10 ) {
 		return substr(str_shuffle(str_repeat($x='0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ', ceil($length/strlen($x)) )),1,$length);
+	}
+
+	public function fieldTypeProvider() {
+
+		$provider[] = array(
+			SMW_FIELDT_NONE,
+			[
+				'o_blob' => FieldType::TYPE_BLOB,
+				'o_hash' => FieldType::FIELD_TITLE
+			]
+		);
+
+		$provider[] = array(
+			SMW_FIELDT_CHAR_NOCASE,
+			[
+				'o_blob' => FieldType::TYPE_BLOB,
+				'o_hash' => FieldType::TYPE_CHAR_NOCASE
+			]
+		);
+
+		$provider[] = array(
+			SMW_FIELDT_CHAR_LONG,
+			[
+				'o_blob' => FieldType::TYPE_BLOB,
+				'o_hash' => FieldType::TYPE_CHAR_LONG
+			]
+		);
+
+		$provider[] = array(
+			SMW_FIELDT_CHAR_NOCASE | SMW_FIELDT_CHAR_LONG,
+			[
+				'o_blob' => FieldType::TYPE_BLOB,
+				'o_hash' => FieldType::TYPE_CHAR_LONG_NOCASE
+			]
+		);
+
+		return $provider;
 	}
 
 }

--- a/tests/phpunit/Unit/SQLStore/EntityStore/DIHandlers/DIUriHandlerTest.php
+++ b/tests/phpunit/Unit/SQLStore/EntityStore/DIHandlers/DIUriHandlerTest.php
@@ -98,35 +98,18 @@ class DIUriHandlerTest extends \PHPUnit_Framework_TestCase {
 		);
 	}
 
-	public function testtMutableOnNoCaseFieldFeature() {
+	/**
+	 * @dataProvider fieldTypeProvider
+	 */
+	public function testMutableOnFieldTypeFeature( $fieldTypeFeatures, $expected ) {
 
 		$instance = new DIUriHandler(
 			$this->store
 		);
 
-		$expected = [
-			'o_blob' => FieldType::TYPE_BLOB,
-			'o_serialized' => FieldType::FIELD_TITLE
-		];
-
-		$this->assertEquals(
-			$expected,
-			$instance->getTableFields()
-		);
-
-		$this->assertEquals(
-			$expected,
-			$instance->getFetchFields()
-		);
-
 		$instance->setFieldTypeFeatures(
-			SMW_FIELDT_CHAR_NOCASE
+			$fieldTypeFeatures
 		);
-
-		$expected = [
-			'o_blob' => FieldType::TYPE_BLOB,
-			'o_serialized' => FieldType::TYPE_CHAR_NOCASE
-		];
 
 		$this->assertEquals(
 			$expected,
@@ -184,6 +167,43 @@ class DIUriHandlerTest extends \PHPUnit_Framework_TestCase {
 
 		$provider[] = array(
 			array( '' )
+		);
+
+		return $provider;
+	}
+
+	public function fieldTypeProvider() {
+
+		$provider[] = array(
+			SMW_FIELDT_NONE,
+			[
+				'o_blob' => FieldType::TYPE_BLOB,
+				'o_serialized' => FieldType::FIELD_TITLE
+			]
+		);
+
+		$provider[] = array(
+			SMW_FIELDT_CHAR_NOCASE,
+			[
+				'o_blob' => FieldType::TYPE_BLOB,
+				'o_serialized' => FieldType::TYPE_CHAR_NOCASE
+			]
+		);
+
+		$provider[] = array(
+			SMW_FIELDT_CHAR_LONG,
+			[
+				'o_blob' => FieldType::TYPE_BLOB,
+				'o_serialized' => FieldType::TYPE_CHAR_LONG
+			]
+		);
+
+		$provider[] = array(
+			SMW_FIELDT_CHAR_NOCASE | SMW_FIELDT_CHAR_LONG,
+			[
+				'o_blob' => FieldType::TYPE_BLOB,
+				'o_serialized' => FieldType::TYPE_CHAR_LONG_NOCASE
+			]
 		);
 
 		return $provider;

--- a/tests/phpunit/Utils/Runners/MaintenanceRunner.php
+++ b/tests/phpunit/Utils/Runners/MaintenanceRunner.php
@@ -72,6 +72,8 @@ class MaintenanceRunner {
 			throw new RuntimeException( "Expected a valid {$this->maintenanceClass} class" );
 		}
 
+		$obLevel = ob_get_level();
+
 		// Avoid outdated reference to invoked store instance
 		ApplicationFactory::getInstance()->clear();
 		$maintenance = new $this->maintenanceClass;
@@ -93,7 +95,10 @@ class MaintenanceRunner {
 		ob_start();
 		$result = $maintenance->execute();
 		$this->output = ob_get_contents();
-		ob_end_clean();
+
+		while ( ob_get_level() > $obLevel ) {
+			ob_end_clean();
+		}
 
 		return $result;
 	}


### PR DESCRIPTION
This PR is made in reference to: #2499

This PR addresses or contains:

- `$smwgFieldTypeFeatures` setting add flag `SMW_FIELDT_CHAR_LONG` to allow for a 300 char long field (blob and uri datatype) to store indexable (== querable) text content without relying on a full-text index
- 300 char (-32 char) which is longer than the default 72 char (-32 char) and short enough to be indexable without further technical modifications
- `SMW_FIELDT_CHAR_NOCASE | SMW_FIELDT_CHAR_LONG` can be combined to make the long field type also case insensitive (limitation as outlined in #2499 applies)
- No analysis has been performed on how performance is impacted by the length extension in regards to index and update performance
- Requires to run `rebuildData.php` to adjust the field content length

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed
