### PR TITLE
Add type parser-html to JSONScript to allow assertions on HTML structure

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -51,7 +51,8 @@
 		"onoi/http-request": "~1.1",
 		"onoi/callback-container": "~2.0",
 		"onoi/tesa": "~0.1",
-		"onoi/shared-resources": "~0.3"
+		"onoi/shared-resources": "~0.3",
+		"symfony/css-selector": "^3.3"
 	},
 	"require-dev": {
 		"squizlabs/php_codesniffer": "~2.1",

--- a/docs/RELEASE-NOTES.md
+++ b/docs/RELEASE-NOTES.md
@@ -26,6 +26,7 @@ This release requires to run the `setupStore.php` or `update.php` script. (#2065
 * [#2499](https://github.com/SemanticMediaWiki/SemanticMediaWiki/pull/2499) Added [`$smwgFieldTypeFeatures`](https://www.semantic-mediawiki.org/wiki/Help:$smwgFieldTypeFeatures) with `SMW_FIELDT_CHAR_NOCASE` to enable case insensitive search queries
 * [#2516](https://github.com/SemanticMediaWiki/SemanticMediaWiki/pull/2516) Added an optimization run for Semantic MediaWiki managed tables during the installation process (`setupStore.php`)
 * [#2536](https://github.com/SemanticMediaWiki/SemanticMediaWiki/pull/2536) Added `SMW_FIELDT_CHAR_LONG` as flag for  `$smwgFieldTypeFeatures` to extend the indexable length of blob and uri fields to max of 300 chars
+* [#2540](https://github.com/SemanticMediaWiki/SemanticMediaWiki/pull/2540) Add type `parser-html` to `JSONScript` testing to allow assertions on HTML structure
 
 ## Bug fixes
 

--- a/tests/phpunit/Integration/JSONScript/JsonTestCaseScriptRunnerTest.php
+++ b/tests/phpunit/Integration/JSONScript/JsonTestCaseScriptRunnerTest.php
@@ -43,6 +43,11 @@ class JsonTestCaseScriptRunnerTest extends JsonTestCaseScriptRunner {
 	private $specialPageTestCaseProcessor;
 
 	/**
+	 * @var ParserHtmlTestCaseProcessor
+	 */
+	private $parserHtmlTestCaseProcessor;
+
+	/**
 	 * @var RunnerFactory
 	 */
 	private $runnerFactory;
@@ -88,6 +93,10 @@ class JsonTestCaseScriptRunnerTest extends JsonTestCaseScriptRunner {
 		$this->specialPageTestCaseProcessor = new SpecialPageTestCaseProcessor(
 			$this->getStore(),
 			$stringValidator
+		);
+
+		$this->parserHtmlTestCaseProcessor = new ParserHtmlTestCaseProcessor(
+			$validatorFactory->newHtmlValidator()
 		);
 
 		$this->eventDispatcher = EventHandler::getInstance()->getEventDispatcher();
@@ -156,6 +165,7 @@ class JsonTestCaseScriptRunnerTest extends JsonTestCaseScriptRunner {
 		$this->doRunSpecialTests( $jsonTestCaseFileHandler );
 		$this->doRunRdfTests( $jsonTestCaseFileHandler );
 		$this->doRunQueryTests( $jsonTestCaseFileHandler );
+		$this->doRunParserHtmlTests( $jsonTestCaseFileHandler );
 	}
 
 	private function prepareTest( $jsonTestCaseFileHandler ) {
@@ -355,6 +365,21 @@ class JsonTestCaseScriptRunnerTest extends JsonTestCaseScriptRunner {
 			}
 
 			$this->queryTestCaseProcessor->processFormatCase( new QueryTestCaseInterpreter( $case ) );
+		}
+	}
+
+	/**
+	 * @param JsonTestCaseFileHandler $jsonTestCaseFileHandler
+	 */
+	private function doRunParserHtmlTests( JsonTestCaseFileHandler $jsonTestCaseFileHandler ) {
+
+		foreach ( $jsonTestCaseFileHandler->findTestCasesByType( 'parser-html' ) as $case ) {
+
+			if ( $jsonTestCaseFileHandler->requiredToSkipFor( $case, $this->connectorId ) ) {
+				continue;
+			}
+
+			$this->parserHtmlTestCaseProcessor->process( $case );
 		}
 	}
 

--- a/tests/phpunit/Integration/JSONScript/ParserHtmlTestCaseProcessor.php
+++ b/tests/phpunit/Integration/JSONScript/ParserHtmlTestCaseProcessor.php
@@ -1,0 +1,130 @@
+<?php
+
+namespace SMW\Tests\Integration\JSONScript;
+
+use SMW\DIWikiPage;
+use SMW\Tests\Utils\UtilityFactory;
+use SMW\Tests\Utils\Validators\HtmlValidator;
+
+/**
+ * @group semantic-mediawiki
+ * @group medium
+ *
+ * @license GNU GPL v2+
+ * @since 3.0
+ *
+ * @author Stephan Gambke
+ */
+class ParserHtmlTestCaseProcessor extends \PHPUnit_Framework_TestCase {
+
+	/**
+	 * @var HtmlValidator
+	 */
+	private $htmlValidator;
+
+	/**
+	 * ParserHtmlTestCaseProcessor constructor.
+	 *
+	 * @param HtmlValidator $htmlValidator
+	 */
+	public function __construct( HtmlValidator $htmlValidator ) {
+
+		parent::__construct();
+
+		$this->htmlValidator = $htmlValidator;
+
+	}
+
+	/**
+	 * @param array $case
+	 */
+	public function process( array $case ) {
+
+		if ( !isset( $case[ 'subject' ] ) ) {
+			return;
+		}
+
+		if ( isset( $case[ 'about' ] ) ) {
+			$this->setName( $case[ 'about' ] );
+		}
+
+		$this->assertParserHtmlOutputForCase( $case );
+	}
+
+	/**
+	 * @param array $case
+	 */
+	private function assertParserHtmlOutputForCase( array $case ) {
+
+		if ( !isset( $case[ 'assert-output' ] ) ) {
+			return;
+		}
+
+		$outputText = $this->getOutputText( $case );
+
+		if ( $this->isSetAndTrueish( $case[ 'assert-output' ], 'to-be-valid-html' ) ) {
+			$this->htmlValidator->assertThatHtmlIsValid(
+				$outputText,
+				$case[ 'about' ]
+			);
+		}
+
+		if ( $this->isSetAndTrueish( $case[ 'assert-output' ], 'to-contain' ) ) {
+			$this->htmlValidator->assertThatHtmlContains(
+				$case[ 'assert-output' ][ 'to-contain' ],
+				$outputText,
+				$case[ 'about' ]
+			);
+		}
+	}
+
+	/**
+	 * @param array $case
+	 * @return string
+	 */
+	private function getOutputText( array $case ) {
+
+		$subject = DIWikiPage::newFromText(
+			$case[ 'subject' ],
+			isset( $case[ 'namespace' ] ) ? constant( $case[ 'namespace' ] ) : NS_MAIN
+		);
+
+		$parserOutput = UtilityFactory::getInstance()->newPageReader()->getEditInfo( $subject->getTitle() )->output;
+
+		if ( !$this->isSetAndTrueish( $case[ 'assert-output' ], [ 'withOutputPageContext', 'onPageView' ] ) ) {
+			return $parserOutput->getText();
+		}
+
+		$context = new \RequestContext();
+		$context->setTitle( $subject->getTitle() );
+
+		if ( $this->isSetAndTrueish( $case[ 'assert-output' ], 'withOutputPageContext' ) ) {
+			// Ensures the OutputPageBeforeHTML hook is run
+			$context->getOutput()->addParserOutput( $parserOutput );
+		} else {
+			\Article::newFromTitle( $subject->getTitle(), $context )->view();
+		}
+
+		return $context->getOutput()->getHTML();
+
+	}
+
+	/**
+	 * @param $array
+	 * @param string | string[] $keys
+	 * @return bool True if any of the $keys is defined in $array and true-ish
+	 */
+	private function isSetAndTrueish( $array, $keys ) {
+
+		$keys = (array)$keys;
+
+		foreach ( $keys as $key ) {
+			if ( isset( $array[ $key ] ) && $array[ $key ] ) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+}

--- a/tests/phpunit/Integration/JSONScript/README.md
+++ b/tests/phpunit/Integration/JSONScript/README.md
@@ -17,7 +17,7 @@ objects work.
 
 ## TestCases
 
-Contains 208 files with a total of 906 tests:
+Contains 209 files with a total of 906 tests:
 
 ### B
 * [bootstrap.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/JSONScript/TestCases/bootstrap.json) Example bootstrap test case (see https://youtu.be/7fDKjPFaTaY)
@@ -45,6 +45,7 @@ Contains 208 files with a total of 906 tests:
 * [f-0304.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/JSONScript/TestCases/f-0304.json) Test `format=category` with identity collation sort (#2065, `smwgEntityCollation=identity`, `smwgSparqlQFeatures=SMW_SPARQL_QF_COLLATION`)
 * [f-0305.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/JSONScript/TestCases/f-0305.json) Test `format=category` with uppercase collation sort (#2065, `smwgEntityCollation=uppercase`, `smwgSparqlQFeatures=SMW_SPARQL_QF_COLLATION`)
 * [f-0306.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/JSONScript/TestCases/f-0306.json) Test `format=category` with numeric collation sort (same as uppercase, but with numeric sorting) (#2065, `smwgEntityCollation=numeric`, `smwgSparqlQFeatures=SMW_SPARQL_QF_COLLATION`)
+* [f-0401.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/JSONScript/TestCases/f-0401.json) Test `format=list` output
 * [f-0801.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/JSONScript/TestCases/f-0801.json) Test `format=embedded` output (skip 1.19)
 * [f-0802.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/JSONScript/TestCases/f-0802.json) Test `format=template` [[SMW::on/off]] regression using `named args=yes` (#1453, skip-on 1.19)
 * [f-0803.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/JSONScript/TestCases/f-0803.json) Test `format=template` with `sep`/`named args`/`template arguments` (#972, #2022)
@@ -326,6 +327,7 @@ should suffice to create test assertions for common test scenarios. Available ty
 are:
   * `query`, `concept`, and `format`
   * `parser`
+  * `parser-html`
   * `rdf`
   * `special`
 * The `about` describes what the test is expected to test which may help during

--- a/tests/phpunit/Integration/JSONScript/README.md
+++ b/tests/phpunit/Integration/JSONScript/README.md
@@ -259,7 +259,7 @@ tests will not interfer with the expected results. It may also be of advantage t
 the setup of data (e.g. `Example/Test/1`) from the actual test subject (e.g. `Example/Test/Q.1`)
 to avoid conflicating comparisons or false positive results during the assertion process.
 
-<pre>
+``` json
 "setup": [
 	{
 		"page": "Has text",
@@ -281,16 +281,38 @@ to avoid conflicating comparisons or false positive results during the assertion
 		"contents": "{{#ask: [[Has text::~Some text*]] |?Has text }}"
 	}
 ],
-</pre>
+```
 
 ### Test assertions
 
+* The `type` provides specialized assertion methods with some of them requiring
+an extra setup to yield a comparable output but in most cases the `parser` type
+should suffice to create test assertions for common test scenarios. Available types
+are:
+  * `query`, `concept`, and `format`
+  * `parser`
+  * `parser-html`
+  * `rdf`
+  * `special`
+* The `about` describes what the test is expected to test which may help during
+  a failure to identify potential conflicts or hints on how to resolve an issue.
+* The `subject` refers to the page that was defined in the `setup` section.
+
+For example, as of version 2 the `parser` type (`ParserTestCaseProcessor`) knows
+two assertions methods:
+
+- `assert-store` is to validate data against `Store::getSemanticData`
+- `assert-output` is to validate string comparison against the `ParserOutput`
+  generated text
+
+
+#### Type `parser`
 The test result assertion provides simplified string comparison methods (mostly for
 output related assertion but expressive enough for users to understand the test
-objective and its expected results). For example, verifying that a the parser
+objective and its expected results). For example, verifying that the parser
 does output a certain string, one has to the define an expected output.
 
-<pre>
+``` json
 "tests": [
 	{
 		"type": "parser",
@@ -318,28 +340,60 @@ does output a certain string, one has to the define an expected output.
 			]
 		}
 	}
-}
-</pre>
+]
+```
 
-* The `type` provides specialized assertion methods with some of them requiring
-an extra setup to yield a comparable output but in most cases the `parser` type
-should suffice to create test assertions for common test scenarios. Available types
-are:
-  * `query`, `concept`, and `format`
-  * `parser`
-  * `parser-html`
-  * `rdf`
-  * `special`
-* The `about` describes what the test is expected to test which may help during
-  a failure to identify potential conflicts or hints on how to resolve an issue.
-* The `subject` refers to the page that was defined in the `setup` section.
+#### Type `parser-html`
 
-For example, as of version 2 the `parser` type (`ParserTestCaseProcessor`) knows
-two assertions methods:
+To verify that the HTML code produced by the parser conforms to a certain
+structure the test type `parser-html` may be used. With this type the expected
+output structure may be specified as a CSS selector. The test will succeed if at
+least one element according to that selector is found in the output.
 
-- `assert-store` is to validate data against `Store::getSemanticData`
-- `assert-output` is to validate string comparison against the `ParserOutput`
-  generated text
+Example:
+``` json
+"tests": [
+	{
+		"type": "parser-html",
+		"about": "#0 Basic List format",
+		"subject": "Example/0401",
+		"assert-output": {
+			"to-contain": [
+				"p > a[ title='Bar' ] + a[ title='Baz' ] + a[ title='Foo' ] + a[ title='Quok' ]"
+			]
+		}
+	}
+]
+```
+
+For further details and limitations on the CSS selectors see the [description of
+the Symfony CssSelector
+Component](https://symfony.com/doc/current/components/css_selector.html) that is
+used for this test type.
+
+It is also possible to require an exact number of occurences of HTML elements by
+providing an array instead of just a CSS selector string.
+
+Example:
+``` json
+		"assert-output": {
+			"to-contain": [
+				[ "p > a", 4 ]
+			]
+		}
+```
+
+Finally the general well-formedness of the HTML can be tested, although this
+will not fail for recoverable errors (see the [documentation on PHP's
+DOMDocument::loadHTML](http://php.net/manual/en/domdocument.loadhtml.php#refsect1-domdocument.loadhtml-errors)).
+
+Example:
+``` json
+		"assert-output": {
+			"to-be-valid-html": true,
+		}
+```
+
 
 ### Preparing the test environment
 
@@ -347,7 +401,7 @@ It can happen that an output is mixed with language dependent content (site vs.
 page content vs. user language) and therefore it is recommended to fix those
 settings for a test by adding something like:
 
-<pre>
+``` json
 "settings": {
 	"wgContLang": "en",
 	"wgLang": "en",
@@ -356,7 +410,7 @@ settings for a test by adding something like:
 		"SMW_NS_PROPERTY": true
 	}
 }
-</pre>
+```
 
 By default not all settings parameter are enabled in `JsonTestCaseScriptRunner::prepareTest`
 and may require an extension in case a specific test case depends on additional
@@ -371,20 +425,20 @@ Each `json` file expects a `meta` section with:
 - `debug` as flag for support of intermediary debugging that may output internal
   object state information.
 
-<pre>
+``` json
 "meta": {
 	"version": "2",
 	"is-incomplete": false,
 	"debug": false
 }
-</pre>
+```
 
 ### Skipping a test or mark as incomplete
 
 Sometimes certain data can cause inconsistencies with an environment hence it is
 possible to skip those cases by adding:
 
-<pre>
+``` json
 {
 	"skip-on": {
 		"virtuoso": "Virtuoso 6.1 does not support BC/BCE dates"
@@ -392,16 +446,16 @@ possible to skip those cases by adding:
 	"page": "Example/P0413/11",
 	"contents": "[[Has date::Jan 1 300 BC]]"
 },
-</pre>
+```
 
-<pre>
+``` json
 {
 	"skip-on": {
 		"hhvm-*": "HHVM (or SQLite) shows opposite B1000, B9",
 		"mw-1.28<": "`numeric` collation only available with 1.28+"
 	}
 }
-</pre>
+```
 
 Constraints that include `hhvm-*` will indicate to exclude all HHVM versions while
 `mw-1.28<` defines that any MW version lower than 1.28 is to be ignored.
@@ -409,7 +463,7 @@ Constraints that include `hhvm-*` will indicate to exclude all HHVM versions whi
 It is also possible that an entire test scenario cannot be completed in a particular
 environment therefore it can be marked and skipped with:
 
-<pre>
+``` json
 "meta": {
 	"skip-on": {
 		"virtuoso": "Some info as to why it is skipped.",
@@ -420,7 +474,7 @@ environment therefore it can be marked and skipped with:
 	"is-incomplete": false,
 	"debug": false
 }
-</pre>
+```
 
 If a test is incomplete for some reason, use the `is-incomplete` field to indicate
 the status which henceforth avoids a test execution.
@@ -447,7 +501,7 @@ is mostly done when running from an IDE editor
 * The command line allows to invoke a filter argument to specify a case such as
 `composer integration -- --filter 's-0014.json'`
 
-<pre>
+```
 $  composer integration -- --filter 's-0014.json'
 Using PHP 5.6.8
 
@@ -469,7 +523,7 @@ Configuration:  ...\extensions\SemanticMediaWiki\phpunit.xml.dist
 Time: 13.02 seconds, Memory: 34.00Mb
 
 OK (1 test, 16 assertions)
-</pre>
+```
 
 The following [video](https://youtu.be/7fDKjPFaTaY) contains a very brief introduction on how
 to run and debug a JSONScript test case. For a general introduction to the test environment,

--- a/tests/phpunit/Integration/JSONScript/TestCases/f-0401.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/f-0401.json
@@ -1,0 +1,54 @@
+{
+	"description": "Test `format=list` output",
+	"setup": [
+		{
+			"namespace": "SMW_NS_PROPERTY",
+			"page": "Has page property",
+			"contents": "[[Has type::Page]]"
+		},
+		{
+			"page": "Foo",
+			"contents": "[[Has page property::ABC]]"
+		},
+		{
+			"page": "Bar",
+			"contents": "[[Has page property::ABC]]"
+		},
+		{
+			"page": "Baz",
+			"contents": "[[Has page property::ABC]]"
+		},
+		{
+			"page": "Quok",
+			"contents": "[[Has page property::ABC]]"
+		},
+		{
+			"page": "Example/0401",
+			"contents": "{{#ask:[[Has page property::ABC]] |format=list}}"
+		}
+	],
+	"tests": [
+		{
+			"type": "parser-html",
+			"about": "#0 Basic List format",
+			"subject": "Example/0401",
+			"assert-output": {
+				"to-be-valid-html": 1,
+				"to-contain": [
+					"p > a[ title='Bar' ] + a[ title='Baz' ] + a[ title='Foo' ] + a[ title='Quok' ]"
+				]
+			}
+		}
+	],
+	"settings": {
+		"smwgNamespacesWithSemanticLinks": {
+			"NS_MAIN": true,
+			"SMW_NS_PROPERTY": true
+		}
+	},
+	"meta": {
+		"version": "2",
+		"is-incomplete": false,
+		"debug": false
+	}
+}

--- a/tests/phpunit/Integration/JSONScript/TestCases/f-0401.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/f-0401.json
@@ -33,9 +33,10 @@
 			"about": "#0 Basic List format",
 			"subject": "Example/0401",
 			"assert-output": {
-				"to-be-valid-html": 1,
+				"to-be-valid-html": true,
 				"to-contain": [
-					"p > a[ title='Bar' ] + a[ title='Baz' ] + a[ title='Foo' ] + a[ title='Quok' ]"
+					"p > a[ title='Bar' ] + a[ title='Baz' ] + a[ title='Foo' ] + a[ title='Quok' ]",
+					[ "p > a", 4 ]
 				]
 			}
 		}

--- a/tests/phpunit/Utils/Validators/HtmlValidator.php
+++ b/tests/phpunit/Utils/Validators/HtmlValidator.php
@@ -1,0 +1,102 @@
+<?php
+
+namespace SMW\Tests\Utils\Validators;
+
+use DOMDocument;
+use Symfony\Component\CssSelector\CssSelectorConverter;
+
+/**
+ * @license GNU GPL v2+
+ * @since   3.0
+ *
+ * @author Stephan Gambke
+ */
+class HtmlValidator extends \PHPUnit_Framework_Assert {
+
+	private $documentCache = [];
+
+	/**
+	 * @param string $actual
+	 * @param string $message
+	 */
+	public function assertThatHtmlIsValid( $actual, $message = '' ) {
+
+		$document = $this->getDomDocumentFromHtmlFragment( $actual );
+
+		self::assertTrue( $document !== false, "Failed test `{$message}` (assertion HtmlIsValid) for $actual" );
+	}
+
+	/**
+	 * @param string $fragment
+	 * @return bool|DOMDocument
+	 */
+	private function getDomDocumentFromHtmlFragment( $fragment ) {
+
+		$cacheKey = md5( $fragment );
+
+		if ( !isset( $this->documentCache[ $cacheKey ] ) ) {
+			$this->addHtmlFragmentToCache( $fragment, $cacheKey );
+		}
+
+		return $this->documentCache[ $cacheKey ];
+	}
+
+	/**
+	 * @param $fragment
+	 * @param $cacheKey
+	 */
+	private function addHtmlFragmentToCache( $fragment, $cacheKey ) {
+
+		$fragment = self::wrapHtmlFragment( $fragment );
+
+		$document = new DOMDocument();
+		$document->preserveWhiteSpace = false;
+
+		libxml_use_internal_errors( true );
+		$result = $document->loadHTML( $fragment );
+		libxml_use_internal_errors( false );
+
+		$this->documentCache[ $cacheKey ] = ( $result === true ) ? $document : false;
+
+	}
+
+	/**
+	 * @param string $fragment
+	 * @return string
+	 */
+	private static function wrapHtmlFragment( $fragment ) {
+		return "<!DOCTYPE html><html><head><meta charset='utf-8'/><title>SomeTitle</title></head><body>$fragment</body></html>";
+	}
+
+	/**
+	 * @param string | string[] $cssSelectors
+	 * @param string $htmlFragment
+	 * @param string $message
+	 */
+	public function assertThatHtmlContains( $cssSelectors, $htmlFragment, $message = '' ) {
+
+		$document = $this->getDomDocumentFromHtmlFragment( $htmlFragment );
+		$xpath = new \DOMXPath( $document );
+		$converter = new CssSelectorConverter();
+
+		foreach ( $cssSelectors as $selector ) {
+
+			if ( is_array( $selector ) ) {
+				$expectedCount = array_pop( $selector );
+				$expectedCountText = $expectedCount . 'x ';
+				$selector = array_shift( $selector );
+			} else {
+				$expectedCount = false;
+				$expectedCountText = '';
+			}
+
+			$entries = $xpath->evaluate( $converter->toXPath( $selector ) );
+			$actualCount = $entries->length;
+
+			$message = "Failed test `{$message}` for assertion HtmlContains: $expectedCountText`$selector` for \n=====\n$htmlFragment\n=====";
+
+			self::assertTrue( ( $expectedCount === false && $actualCount > 0 ) || ( $actualCount === $expectedCount ), $message );
+		}
+	}
+
+}

--- a/tests/phpunit/Utils/Validators/ValidatorFactory.php
+++ b/tests/phpunit/Utils/Validators/ValidatorFactory.php
@@ -86,4 +86,13 @@ class ValidatorFactory {
 		return new QuerySegmentValidator();
 	}
 
+	/**
+	 * @since 3.0
+	 *
+	 * @return HtmlValidator
+	 */
+	public function newHtmlValidator() {
+		return new HtmlValidator();
+	}
+
 }

--- a/tests/travis/install-semantic-mediawiki.sh
+++ b/tests/travis/install-semantic-mediawiki.sh
@@ -24,6 +24,10 @@ function installSmwIntoMwWithComposer {
 	installPHPUnitWithComposer
 	composer require mediawiki/semantic-media-wiki "dev-master" --dev
 
+	# Explicitly load symfony/css-selector
+	# FIXME: Remove once composer.json with symfony/css-selector arrived at packagist
+	composer require  "symfony/css-selector" "^3.3"
+
 	cd extensions
 	cd SemanticMediaWiki
 


### PR DESCRIPTION
This PR is made in reference to: #2531

This PR allows JSONScript test scripts to make assertions on the HTML structure of the parser output.

Rules are described as CSS selectors, e.g.

``` json
{
	"type": "parser-html",
	"about": "#0 Basic List format",
	"subject": "Example/0401",
	"assert-output": {
		"to-contain": [
			"p > a[ title='Bar' ] + a[ title='Baz' ] + a[ title='Foo' ] + a[ title='Quok' ]"
		]
	}
}
```

A requirement on the number of occurrences can be descriped as well, e.g.
``` json
{
        "type": "parser-html",
        "about": "#0 Basic List format",
        "subject": "Example/0401",
        "assert-output": {
                "to-contain": [
                        [ "p > a", 4 ]
                ]
        }
}
```

Finally the general well-formedness of the HTML can be asserted, although this will not fail for recoverable errors (see http://php.net/manual/en/domdocument.loadhtml.php#refsect1-domdocument.loadhtml-errors).
Example:
``` json
{
	"type": "parser-html",
	"about": "#0 Basic List format",
	"subject": "Example/0401",
	"assert-output": {
		"to-be-valid-html": 1
	}
}
```


This PR includes:
- [X] Tests (unit/integration)
- [x] CI build passed
