### PR TITLE
Remove explicit installation of symfony/css-selector from Travis build script

### DIFF
--- a/tests/travis/install-semantic-mediawiki.sh
+++ b/tests/travis/install-semantic-mediawiki.sh
@@ -24,10 +24,6 @@ function installSmwIntoMwWithComposer {
 	installPHPUnitWithComposer
 	composer require mediawiki/semantic-media-wiki "dev-master" --dev
 
-	# Explicitly load symfony/css-selector
-	# FIXME: Remove once composer.json with symfony/css-selector arrived at packagist
-	composer require  "symfony/css-selector" "^3.3"
-
 	cd extensions
 	cd SemanticMediaWiki
 


### PR DESCRIPTION
This PR is made in reference to: #2540

This PR removes the explicit installation of symfony/css-selector from Travis build script. The updated `composer.json` arrived at Packagist now, so the package should be loaded automatically as a dependency.

This PR includes:
- [ ] Tests (unit/integration)
- [ ] CI build passed
