### PR TITLE
Add type parser-html to JSONScript to allow assertions on HTML structure (Backport #2540)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -51,7 +51,8 @@
 		"onoi/http-request": "~1.1",
 		"onoi/callback-container": "~2.0",
 		"onoi/tesa": "~0.1",
-		"onoi/shared-resources": "~0.3"
+		"onoi/shared-resources": "~0.3",
+		"symfony/css-selector": "^3.3"
 	},
 	"require-dev": {
 		"squizlabs/php_codesniffer": "~2.1",

--- a/docs/RELEASE-NOTES.md
+++ b/docs/RELEASE-NOTES.md
@@ -1,35 +1,12 @@
-# Semantic MediaWiki 2.5.3
+# Semantic MediaWiki 2.5.4
 
-Released on July 8, 2017.
+This is not a release yet.
 
 ## Enhancements
 
-* [#2534](https://github.com/SemanticMediaWiki/SemanticMediaWiki/pull/2534) as `d7077b8` Added [`$smwgLocalConnectionConf`](https://www.semantic-mediawiki.org/wiki/Help:$smwgLocalConnectionConf) configuration parameter together with respective functionality allowing for modifications on connection providers in environments with multiple relational databases
+* [#2547](https://github.com/SemanticMediaWiki/SemanticMediaWiki/pull/2547) Add type `parser-html` to `JSONScript` testing to allow assertions on HTML structure
 * Many new translations for numerous languages by the communtity of [translatewiki.net](https://translatewiki.net/w/i.php?title=Special%3AMessageGroupStats&x=D&group=mwgithub-semanticmediawiki&suppressempty=1)
 
 ## Bug fixes and internal code changes
 
-* [#2379](https://github.com/SemanticMediaWiki/SemanticMediaWiki/pull/2379) as `7c98b4a` Removed `ContentParser::forceToUseParser` from tests
-* [#2459](https://github.com/SemanticMediaWiki/SemanticMediaWiki/pull/2459) as `a7b3f00` Switched Travis CI integration test to use Ubuntu Trusty operating system environment
-* [#2460](https://github.com/SemanticMediaWiki/SemanticMediaWiki/pull/2460) as `3b6e30d` Made `ArticleDelete` restrict the pool of properties in update dispatcher
-* [#2472](https://github.com/SemanticMediaWiki/SemanticMediaWiki/pull/2472) as `03e0b8c` Added debug output to Travis CI integration tests
-* [#2473](https://github.com/SemanticMediaWiki/SemanticMediaWiki/pull/2473) as `9f78042` Replaced `isSupportedLanguage` with `isKnownLanguageTag` to allow for any known language usage
-* [#2474](https://github.com/SemanticMediaWiki/SemanticMediaWiki/pull/2474) as `d1ba666` Fixed limit when the number of results is greater as the `$smwgQMaxLimit` or in `$smwgQMaxInlineLimit` where it is reset to the default value despite the global limitation
-* [#2475](https://github.com/SemanticMediaWiki/SemanticMediaWiki/pull/2475) as `a3499b6` Fixed behavior in case of `$wgCapitalLinks = false;` by restricting property name uppercase conversion to special properties only
-* [#2477](https://github.com/SemanticMediaWiki/SemanticMediaWiki/pull/2477) as `c12fec7` Fixed `UpdateDispatcherJob` to check for null title
-* [#2478](https://github.com/SemanticMediaWiki/SemanticMediaWiki/pull/2478) as `681b0fc` Tidyed `QueryToken`
-* [#2481](https://github.com/SemanticMediaWiki/SemanticMediaWiki/pull/2481) as `7c3900f` Made `RequestOptions` cast "int" on `limit` and `offset`
-* [#2482](https://github.com/SemanticMediaWiki/SemanticMediaWiki/pull/2482) as `2ff92bd` Added TransactionalDeferredCallableUpdate
-* [#2491](https://github.com/SemanticMediaWiki/SemanticMediaWiki/pull/2491) as `ca36069` Provided `ChunkedIterator` to avoid possible out of memory situations in cases where outdated entities reach a unhandable level
-* [#2493](https://github.com/SemanticMediaWiki/SemanticMediaWiki/pull/2493) as `409025d` Prevended unintended override of `PropertyTablePrefix` in hook
-* [#2496](https://github.com/SemanticMediaWiki/SemanticMediaWiki/pull/2496) as `fb3d604` Normalized message value arguments
-* [#2500](https://github.com/SemanticMediaWiki/SemanticMediaWiki/pull/2500) as `3edb303` Made "Special:Browse" avoid API request on legacy setting
-* [#2502](https://github.com/SemanticMediaWiki/SemanticMediaWiki/pull/2502) as `a527bbe` Provided POST purge link to avoid confirmation by users using action "purge"
-* [#2512](https://github.com/SemanticMediaWiki/SemanticMediaWiki/pull/2512) as `86f9733` Made `DataRebuilder` to report progress on disposed entities
-* [#2518](https://github.com/SemanticMediaWiki/SemanticMediaWiki/pull/2518) as `a851f8d` Prevended "PHP Notice: A non well formed numeric value encountered" on `Title::touched`
-* [#2522](https://github.com/SemanticMediaWiki/SemanticMediaWiki/pull/2522) as `36cec82` Set a comma as default for `valuesep` with the "template" format
-* [#2524](https://github.com/SemanticMediaWiki/SemanticMediaWiki/pull/2524) as `36cec82` Ensured that only marked `isDeferrableUpdate` can use a `transactionTicket`
-* [#2526](https://github.com/SemanticMediaWiki/SemanticMediaWiki/pull/2526) as `9d3e0f2` Prevented failing test in `QueryDependencyLinksStoreTest`
-* [#2527](https://github.com/SemanticMediaWiki/SemanticMediaWiki/pull/2527) as `f72df04` Made `BooleanValue` always recognize canonical boolean string
-* [#2530](https://github.com/SemanticMediaWiki/SemanticMediaWiki/pull/2530) as `ad32a26` Made `InternalParseBeforeLinks` cast `$smwgEnabledSpecialPage` setting late
-* `2bf07c3` Removed update marker on delete event
+* 

--- a/tests/phpunit/Integration/JSONScript/JsonTestCaseScriptRunnerTest.php
+++ b/tests/phpunit/Integration/JSONScript/JsonTestCaseScriptRunnerTest.php
@@ -42,6 +42,11 @@ class JsonTestCaseScriptRunnerTest extends JsonTestCaseScriptRunner {
 	private $specialPageTestCaseProcessor;
 
 	/**
+	 * @var ParserHtmlTestCaseProcessor
+	 */
+	private $parserHtmlTestCaseProcessor;
+
+	/**
 	 * @var RunnerFactory
 	 */
 	private $runnerFactory;
@@ -87,6 +92,10 @@ class JsonTestCaseScriptRunnerTest extends JsonTestCaseScriptRunner {
 		$this->specialPageTestCaseProcessor = new SpecialPageTestCaseProcessor(
 			$this->getStore(),
 			$stringValidator
+		);
+
+		$this->parserHtmlTestCaseProcessor = new ParserHtmlTestCaseProcessor(
+			$validatorFactory->newHtmlValidator()
 		);
 
 		$this->eventDispatcher = EventHandler::getInstance()->getEventDispatcher();
@@ -152,6 +161,7 @@ class JsonTestCaseScriptRunnerTest extends JsonTestCaseScriptRunner {
 		$this->doRunSpecialTests( $jsonTestCaseFileHandler );
 		$this->doRunRdfTests( $jsonTestCaseFileHandler );
 		$this->doRunQueryTests( $jsonTestCaseFileHandler );
+		$this->doRunParserHtmlTests( $jsonTestCaseFileHandler );
 	}
 
 	private function prepareTest( $jsonTestCaseFileHandler ) {
@@ -304,6 +314,21 @@ class JsonTestCaseScriptRunnerTest extends JsonTestCaseScriptRunner {
 
 		foreach ( $jsonTestCaseFileHandler->findTestCasesByType( 'format' ) as $formatCase ) {
 			$this->queryTestCaseProcessor->processFormatCase( new QueryTestCaseInterpreter( $formatCase ) );
+		}
+	}
+
+	/**
+	 * @param JsonTestCaseFileHandler $jsonTestCaseFileHandler
+	 */
+	private function doRunParserHtmlTests( JsonTestCaseFileHandler $jsonTestCaseFileHandler ) {
+
+		foreach ( $jsonTestCaseFileHandler->findTestCasesByType( 'parser-html' ) as $case ) {
+
+			if ( $jsonTestCaseFileHandler->requiredToSkipFor( $case, $this->connectorId ) ) {
+				continue;
+			}
+
+			$this->parserHtmlTestCaseProcessor->process( $case );
 		}
 	}
 

--- a/tests/phpunit/Integration/JSONScript/ParserHtmlTestCaseProcessor.php
+++ b/tests/phpunit/Integration/JSONScript/ParserHtmlTestCaseProcessor.php
@@ -1,0 +1,130 @@
+<?php
+
+namespace SMW\Tests\Integration\JSONScript;
+
+use SMW\DIWikiPage;
+use SMW\Tests\Utils\UtilityFactory;
+use SMW\Tests\Utils\Validators\HtmlValidator;
+
+/**
+ * @group semantic-mediawiki
+ * @group medium
+ *
+ * @license GNU GPL v2+
+ * @since 3.0
+ *
+ * @author Stephan Gambke
+ */
+class ParserHtmlTestCaseProcessor extends \PHPUnit_Framework_TestCase {
+
+	/**
+	 * @var HtmlValidator
+	 */
+	private $htmlValidator;
+
+	/**
+	 * ParserHtmlTestCaseProcessor constructor.
+	 *
+	 * @param HtmlValidator $htmlValidator
+	 */
+	public function __construct( HtmlValidator $htmlValidator ) {
+
+		parent::__construct();
+
+		$this->htmlValidator = $htmlValidator;
+
+	}
+
+	/**
+	 * @param array $case
+	 */
+	public function process( array $case ) {
+
+		if ( !isset( $case[ 'subject' ] ) ) {
+			return;
+		}
+
+		if ( isset( $case[ 'about' ] ) ) {
+			$this->setName( $case[ 'about' ] );
+		}
+
+		$this->assertParserHtmlOutputForCase( $case );
+	}
+
+	/**
+	 * @param array $case
+	 */
+	private function assertParserHtmlOutputForCase( array $case ) {
+
+		if ( !isset( $case[ 'assert-output' ] ) ) {
+			return;
+		}
+
+		$outputText = $this->getOutputText( $case );
+
+		if ( $this->isSetAndTrueish( $case[ 'assert-output' ], 'to-be-valid-html' ) ) {
+			$this->htmlValidator->assertThatHtmlIsValid(
+				$outputText,
+				$case[ 'about' ]
+			);
+		}
+
+		if ( $this->isSetAndTrueish( $case[ 'assert-output' ], 'to-contain' ) ) {
+			$this->htmlValidator->assertThatHtmlContains(
+				$case[ 'assert-output' ][ 'to-contain' ],
+				$outputText,
+				$case[ 'about' ]
+			);
+		}
+	}
+
+	/**
+	 * @param array $case
+	 * @return string
+	 */
+	private function getOutputText( array $case ) {
+
+		$subject = DIWikiPage::newFromText(
+			$case[ 'subject' ],
+			isset( $case[ 'namespace' ] ) ? constant( $case[ 'namespace' ] ) : NS_MAIN
+		);
+
+		$parserOutput = UtilityFactory::getInstance()->newPageReader()->getEditInfo( $subject->getTitle() )->output;
+
+		if ( !$this->isSetAndTrueish( $case[ 'assert-output' ], [ 'withOutputPageContext', 'onPageView' ] ) ) {
+			return $parserOutput->getText();
+		}
+
+		$context = new \RequestContext();
+		$context->setTitle( $subject->getTitle() );
+
+		if ( $this->isSetAndTrueish( $case[ 'assert-output' ], 'withOutputPageContext' ) ) {
+			// Ensures the OutputPageBeforeHTML hook is run
+			$context->getOutput()->addParserOutput( $parserOutput );
+		} else {
+			\Article::newFromTitle( $subject->getTitle(), $context )->view();
+		}
+
+		return $context->getOutput()->getHTML();
+
+	}
+
+	/**
+	 * @param $array
+	 * @param string | string[] $keys
+	 * @return bool True if any of the $keys is defined in $array and true-ish
+	 */
+	private function isSetAndTrueish( $array, $keys ) {
+
+		$keys = (array)$keys;
+
+		foreach ( $keys as $key ) {
+			if ( isset( $array[ $key ] ) && $array[ $key ] ) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+}

--- a/tests/phpunit/Integration/JSONScript/README.md
+++ b/tests/phpunit/Integration/JSONScript/README.md
@@ -17,212 +17,221 @@ objects work.
 
 ## TestCases
 
-Contains 193 files with a total of 850 tests:
+Contains 202 files with a total of 877 tests:
 
 ### F
-* [f-0001.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/JSONScript/TestCases/f-0001.json) Test `format=debug` output
-* [f-0101.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/JSONScript/TestCases/f-0101.json) Test `format=template` output using unnamed arguments (#885)
-* [f-0102.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/JSONScript/TestCases/f-0102.json) Test `format=template` output + unicode characters (#988, skip postgres)
-* [f-0103.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/JSONScript/TestCases/f-0103.json) Test `format=template` with self reference (#988, guard against template self-reference in ask/show query)
-* [f-0104.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/JSONScript/TestCases/f-0104.json) Test `format=list, ul, ol, template` (#2022,`wgContLang=en`, `wgLang=en`)
-* [f-0105.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/JSONScript/TestCases/f-0105.json) Test `format=list, ul, ol` on `_qty` property (`wgContLang=en`, `SMW_DV_NUMV_USPACE`)
-* [f-0201.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/JSONScript/TestCases/f-0201.json) Test `format=table` on boolean table output formatting (#896, #1464)
-* [f-0202.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/JSONScript/TestCases/f-0202.json) Test `format=table` with sep cell formatting, #495 (`wgContLang=en`,`wgLang=en`)
-* [f-0203.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/JSONScript/TestCases/f-0203.json) Test `format=table` to sort by category (#1286)
-* [f-0204.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/JSONScript/TestCases/f-0204.json) Test `format=table` on `_qty` for different positional unit preference (#1329, en)
-* [f-0205.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/JSONScript/TestCases/f-0205.json) Test `format=table` on `|+align=`/`|+limit`/`|+order` extra printout parameters (T18571, en)
-* [f-0206.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/JSONScript/TestCases/f-0206.json) Test `format=table` to display extra property description `_PDESC` (en)
-* [f-0207.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/JSONScript/TestCases/f-0207.json) Test `format=table` on formatted indent when using */#/: (en)
-* [f-0208.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/JSONScript/TestCases/f-0208.json) Test `format=table` with `limit=0` (further result links) for user/predefined properties, `mainlabel=-`, `#show` (`wgContLang=en`, `wgLang=es`)
-* [f-0209.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/JSONScript/TestCases/f-0209.json) Test `format=table` on `_tem`/ `_num` with `LOCAL@...` output (#1591, `wgContLang=es`, `wgLang=en`)
-* [f-0210.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/JSONScript/TestCases/f-0210.json) Test `format=table` on `_qty` for unit labels with spaces (#1718, `wgContLang=en`, `SMW_DV_NUMV_USPACE`)
-* [f-0301.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/JSONScript/TestCases/f-0301.json) Test `format=category` with template usage (#699, en, skip postgres)
-* [f-0302.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/JSONScript/TestCases/f-0302.json) Test `format=category` and defaultsort (#699, en)
-* [f-0303.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/JSONScript/TestCases/f-0303.json) Test `format=category` sort output using a template and DEFAULTSORT (#1459, en)
-* [f-0801.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/JSONScript/TestCases/f-0801.json) Test `format=embedded` output (skip 1.19)
-* [f-0802.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/JSONScript/TestCases/f-0802.json) Test `format=template` [[SMW::on/off]] regression using `named args=yes` (#1453, skip-on 1.19)
-* [f-0803.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/JSONScript/TestCases/f-0803.json) Test `format=template` with `sep`/`named args`/`template arguments` (#972, #2022)
+* [f-0001.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/2.5.x/tests/phpunit/Integration/JSONScript/TestCases/f-0001.json) Test `format=debug` output
+* [f-0101.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/2.5.x/tests/phpunit/Integration/JSONScript/TestCases/f-0101.json) Test `format=template` output using unnamed arguments (#885)
+* [f-0102.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/2.5.x/tests/phpunit/Integration/JSONScript/TestCases/f-0102.json) Test `format=template` output + unicode characters (#988, skip postgres)
+* [f-0103.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/2.5.x/tests/phpunit/Integration/JSONScript/TestCases/f-0103.json) Test `format=template` with self reference (#988, guard against template self-reference in ask/show query)
+* [f-0104.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/2.5.x/tests/phpunit/Integration/JSONScript/TestCases/f-0104.json) Test `format=list, ul, ol, template` (#2022,`wgContLang=en`, `wgLang=en`)
+* [f-0105.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/2.5.x/tests/phpunit/Integration/JSONScript/TestCases/f-0105.json) Test `format=list, ul, ol` on `_qty` property (`wgContLang=en`, `SMW_DV_NUMV_USPACE`)
+* [f-0201.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/2.5.x/tests/phpunit/Integration/JSONScript/TestCases/f-0201.json) Test `format=table` on boolean table output formatting (#896, #1464)
+* [f-0202.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/2.5.x/tests/phpunit/Integration/JSONScript/TestCases/f-0202.json) Test `format=table` with sep cell formatting, #495 (`wgContLang=en`,`wgLang=en`)
+* [f-0203.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/2.5.x/tests/phpunit/Integration/JSONScript/TestCases/f-0203.json) Test `format=table` to sort by category (#1286)
+* [f-0204.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/2.5.x/tests/phpunit/Integration/JSONScript/TestCases/f-0204.json) Test `format=table` on `_qty` for different positional unit preference (#1329, en)
+* [f-0205.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/2.5.x/tests/phpunit/Integration/JSONScript/TestCases/f-0205.json) Test `format=table` on `|+align=`/`|+limit`/`|+order` extra printout parameters (T18571, en)
+* [f-0206.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/2.5.x/tests/phpunit/Integration/JSONScript/TestCases/f-0206.json) Test `format=table` to display extra property description `_PDESC` (en)
+* [f-0207.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/2.5.x/tests/phpunit/Integration/JSONScript/TestCases/f-0207.json) Test `format=table` on formatted indent when using */#/: (en)
+* [f-0208.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/2.5.x/tests/phpunit/Integration/JSONScript/TestCases/f-0208.json) Test `format=table` with `limit=0` (further result links) for user/predefined properties, `mainlabel=-`, `#show` (`wgContLang=en`, `wgLang=es`)
+* [f-0209.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/2.5.x/tests/phpunit/Integration/JSONScript/TestCases/f-0209.json) Test `format=table` on `_tem`/ `_num` with `LOCAL@...` output (#1591, `wgContLang=es`, `wgLang=en`)
+* [f-0210.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/2.5.x/tests/phpunit/Integration/JSONScript/TestCases/f-0210.json) Test `format=table` on `_qty` for unit labels with spaces (#1718, `wgContLang=en`, `SMW_DV_NUMV_USPACE`)
+* [f-0301.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/2.5.x/tests/phpunit/Integration/JSONScript/TestCases/f-0301.json) Test `format=category` with template usage (#699, en, skip postgres)
+* [f-0302.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/2.5.x/tests/phpunit/Integration/JSONScript/TestCases/f-0302.json) Test `format=category` and defaultsort (#699, en)
+* [f-0303.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/2.5.x/tests/phpunit/Integration/JSONScript/TestCases/f-0303.json) Test `format=category` sort output using a template and DEFAULTSORT (#1459, en)
+* [f-0401.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/2.5.x/tests/phpunit/Integration/JSONScript/TestCases/f-0401.json) Test `format=list` output
+* [f-0801.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/2.5.x/tests/phpunit/Integration/JSONScript/TestCases/f-0801.json) Test `format=embedded` output (skip 1.19)
+* [f-0802.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/2.5.x/tests/phpunit/Integration/JSONScript/TestCases/f-0802.json) Test `format=template` [[SMW::on/off]] regression using `named args=yes` (#1453, skip-on 1.19)
+* [f-0803.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/2.5.x/tests/phpunit/Integration/JSONScript/TestCases/f-0803.json) Test `format=template` with `sep`/`named args`/`template arguments` (#972, #2022)
 
 ### P
-* [p-0101.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/JSONScript/TestCases/p-0101.json) Test in-text annotation for use of restricted properties (#914, `wgContLang=en`, `wgLang=en`)
-* [p-0102.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/JSONScript/TestCases/p-0102.json) Test in-text annotation on properties with invalid names/charaters (#1567, #1638, #1727 `wgContLang=en`)
-* [p-0106.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/JSONScript/TestCases/p-0106.json) Test #info parser output (#1019, `wgContLang=en`, `wgLang=en`)
-* [p-0107.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/JSONScript/TestCases/p-0107.json) Test #smwdoc parser output (#1019, en)
-* [p-0202.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/JSONScript/TestCases/p-0202.json) Test #set parser to use template for output (#1146, en)
-* [p-0203.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/JSONScript/TestCases/p-0203.json) Test #set parser in combination with #subobject and template output (#1067, regression check)
-* [p-0204.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/JSONScript/TestCases/p-0204.json) Test #set parser to produce error output (#870, en, verify that #set calls do not affect each other with previous errors)
-* [p-0205.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/JSONScript/TestCases/p-0205.json) Test #set/#ask recursive annotation support (#711, #1055, recursive annotation using import-annotation=true via template)
-* [p-0206.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/JSONScript/TestCases/p-0206.json) Test #show parser on inverse printrequest (#1222, #1223)
-* [p-0207.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/JSONScript/TestCases/p-0207.json) Test that undeclared properties with references remain after a `rebuildData` run (#1216, en)
-* [p-0208.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/JSONScript/TestCases/p-0208.json) Test `#set` for various `_num` values without explicit precision (3 digit implicit), with/without leading zero, different printouts, negative numbers (#753, en, `smwgMaxNonExpNumber`)
-* [p-0209.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/JSONScript/TestCases/p-0209.json) Test `#set` for various `_qty` values without explicit precision (3 digit implicit), with/without leading zero, and different printouts (#753, en, `smwgMaxNonExpNumber`)
-* [p-0210.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/JSONScript/TestCases/p-0210.json) Test `#set_recurring_event` (`wgContLang=en`, `wgLang=en`)
-* [p-0211.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/JSONScript/TestCases/p-0211.json) Test `#set`/`#subobject` to import annotation via `@json` syntax (`wgContLang=en`, `wgLang=en`)
-* [p-0212.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/JSONScript/TestCases/p-0212.json) Test `@@@` in-text annotation syntax (#1855, #1875 `wgContLang=en`, `wgLang=en`)
-* [p-0301.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/JSONScript/TestCases/p-0301.json) Test #subobject category annotation (#1172)
-* [p-0302.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/JSONScript/TestCases/p-0302.json) Test #subobject parser to use invalid assignments and create `_ERRC` (#1299, en)
-* [p-0303.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/JSONScript/TestCases/p-0303.json) Test `#subobject` and `#set` parser on values with spaces (`wgContLang=en`, `wgLang=en`)
-* [p-0401.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/JSONScript/TestCases/p-0401.json) Test annotations with disabled capital links (#673, `wgCapitalLinks=false`)
-* [p-0402.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/JSONScript/TestCases/p-0402.json) Test in-text parsing for double colon annotation such as `::::` or `:::` (#1066, #1075, en)
-* [p-0403.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/JSONScript/TestCases/p-0403.json) Test in-text annotations being disabled for when Factbox contains extra `[[ ... ]]` (#1126)
-* [p-0404.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/JSONScript/TestCases/p-0404.json) Test in-text annonation on different category colon identifier
-* [p-0405.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/JSONScript/TestCases/p-0405.json) Test in-text annotation via template and manual redirect (#895)
-* [p-0406.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/JSONScript/TestCases/p-0406.json) Test in-text annotation for unrestricted template parse using `import-annotation=true` (#1055)
-* [p-0407.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/JSONScript/TestCases/p-0407.json) Test in-text annotation for a redirect that is pointing to a deleted target (#1105)
-* [p-0408.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/JSONScript/TestCases/p-0408.json) Test in-text annotation for multiple property assignment using non-strict parser mode (#1252, en)
-* [p-0409.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/JSONScript/TestCases/p-0409.json) Test in-text annotation for `_rec`/`_mlt_rec` (+ subobject) for when record type points to another record type (`wgContLang=en`, `wgLang=en`)
-* [p-0410.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/JSONScript/TestCases/p-0410.json) Test in-text annotation on `_num`/`_tem`/`_qty` type with denoted precision (`_PREC`) and/or `-p<num>` printout precision marker (#1335, en)
-* [p-0411.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/JSONScript/TestCases/p-0411.json) Test in-text annotation (and #subobject) using a monolingual property (#1344, en)
-* [p-0412.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/JSONScript/TestCases/p-0412.json) Test in-text annotation for `_boo` datatype (`wgContLang=ja`, `wgLang=ja`)
-* [p-0413.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/JSONScript/TestCases/p-0413.json) Test in-text annotation for different `_dat` input/output (en, skip virtuoso, `smwgDVFeatures`)
-* [p-0414.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/JSONScript/TestCases/p-0414.json) Test in-text annotation/free format for `_dat` datatype (#1389, #1401, en, `smwgDVFeatures`)
-* [p-0415.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/JSONScript/TestCases/p-0415.json) Test in-text annotation on `_tem` with display unit preference (en)
-* [p-0416.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/JSONScript/TestCases/p-0416.json) Test in-text annotation with DISPLAYTITLE (#1410, #1611, `wgRestrictDisplayTitle`, `wgContLang=en`, `wgLang=en`)
-* [p-0417.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/JSONScript/TestCases/p-0417.json) Test in-text annotation for `Allows pattern` to match regular expressions (en)
-* [p-0418.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/JSONScript/TestCases/p-0418.json) Test in-text annotation using `_SERV` as provide service links (en)
-* [p-0419.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/JSONScript/TestCases/p-0419.json) Test in-text annotation for `_PVUC` to validate uniqueness (`smwgDVFeatures`)
-* [p-0420.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/JSONScript/TestCases/p-0420.json) Test in-text annotation for `_dat` using JL/GR annotated values (en, `smwgDVFeatures`)
-* [p-0421.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/JSONScript/TestCases/p-0421.json) Test in-text annotation with combined constraint validation (`smwgDVFeatures`)
-* [p-0422.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/JSONScript/TestCases/p-0422.json) Test in-text annotation `_dat` on partial dates (#2076, `wgContLang=en`, `wgLang=en`)
-* [p-0423.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/JSONScript/TestCases/p-0423.json) Test in-text annotation / `#ask` (#MEDIAWIKI, #LOCL) output for `_dat` datatype (#1545, `wgContLang=en`, `wgLang=ja`)
-* [p-0424.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/JSONScript/TestCases/p-0424.json) Test in-text annotation for `_boo` datatype using `LOCL` (`wgContLang=en`, `wgLang=fr`, skip-on 1.25.6)
-* [p-0425.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/JSONScript/TestCases/p-0425.json) Test in-text annotation on `_tem`/ `_num` with different page content language (#1591, `wgContLang=es`, `wgLang=en`)
-* [p-0426.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/JSONScript/TestCases/p-0426.json) Test in-text annotation for `_num` on big/small numbers/scientific notation (`wgContLang=fr`, `wgLang=en`)
-* [p-0427.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/JSONScript/TestCases/p-0427.json) Test in-text annotation with DISPLAYTITLE / `foaf` to check on upper vs. lower case (`wgRestrictDisplayTitle`, `wgContLang=en`, `wgLang=en`)
-* [p-0428.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/JSONScript/TestCases/p-0428.json) Test `_TYPE` annotations on different content language (`wgContLang=fr`, `wgLang=en`)
-* [p-0429.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/JSONScript/TestCases/p-0429.json) Test in-text `_dat` annotation with time offset, time zone, am/pm (`wgContLang=en`, `wgLang=en`)
-* [p-0430.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/JSONScript/TestCases/p-0430.json) Test in-text annotation for '_eid' type (`wgContLang=en`, `wgLang=en`)
-* [p-0431.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/JSONScript/TestCases/p-0431.json) Test in-text annotation `_rec` and `|+index` (`wgContLang=en`, `wgLang=en`)
-* [p-0432.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/JSONScript/TestCases/p-0432.json) Test in-text annotation for `_ref_rec` type (#1808, `wgContLang=en`, `wgLang=en`)
-* [p-0433.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/JSONScript/TestCases/p-0433.json) Test in-text annotation `::` with left pipe (#1747, `wgContLang=en`, `smwgLinksInValues=false`)
-* [p-0434.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/JSONScript/TestCases/p-0434.json) Test printrequest property chaining `|?Foo.Bar` (#1824, `wgContLang=en`, `wgLang=en`)
-* [p-0435.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/JSONScript/TestCases/p-0435.json) Test in-text annotation using `_txt` type with 255+ char, `#ask` to produce reduced length (#1878, `wgContLang=en`, `wgLang=en`)
-* [p-0436.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/JSONScript/TestCases/p-0436.json) Test in-text annotation with `_PPLB` [preferred property label] (#1879, `wgContLang=en`, `wgLang=en`)
-* [p-0437.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/JSONScript/TestCases/p-0437.json) Test in-text annotation with preferred property label/`_PPLB` (#1879, `wgContLang=en`, `wgLang=ja`)
-* [p-0438.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/JSONScript/TestCases/p-0438.json) Test in-text annotation with preferred property label/DISPLAYTITLE on user/predefined properties (`wgContLang=es`, `wgLang=de`, `wgRestrictDisplayTitle=false`)
-* [p-0439.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/JSONScript/TestCases/p-0439.json) Test in-text annotation using '_txt'/'_wpg' type / UTF encoding (`wgContLang=en`, `wgLang=en`)
-* [p-0440.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/JSONScript/TestCases/p-0440.json) Test in-text annotation `_mlt_rec` (Monolingual text) with `|+lang`/`|+order` parameter (`wgContLang=en`, `wgLang=en`)
-* [p-0441.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/JSONScript/TestCases/p-0441.json) Test in-text `_txt` 00 string/loose comparison (#2061)
-* [p-0442.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/JSONScript/TestCases/p-0442.json) Test in-text `#REDIRECT` to verify target subobject isn't removed (#, `wgContLang=en`, `wgLang=en`)
-* [p-0443.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/JSONScript/TestCases/p-0443.json) Test conditions and strict constraint validations for uniqueness `_PVUC` (#1463, `wgContLang=en`, `wgLang=en`, `smwgDVFeatures`)
-* [p-0444.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/JSONScript/TestCases/p-0444.json) Test in-text annotation LinksInValue `SMW_LINV_OBFU` (#2153, `wgContLang=en`, `smwgLinksInValues=SMW_LINV_OBFU`)
-* [p-0445.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/JSONScript/TestCases/p-0445.json) Test in-text annotation for `_ref_rec` type with errors (#..., `wgContLang=en`)
-* [p-0446.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/JSONScript/TestCases/p-0446.json) Test in-text annotation `_uri`/`_ema`/`_tel` with spaces/underscore (`wgContLang=en`)
-* [p-0447.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/JSONScript/TestCases/p-0447.json) Test in-text annotation with IRI export (#2188, `smwgExportResourcesAsIri=true`, `wgContLang=ru`, `wgLang=en`)
-* [p-0448.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/JSONScript/TestCases/p-0448.json) Test in-text legacy `:=` annotation style (#2153, `wgContLang=en`, `smwgLinksInValues=false`)
-* [p-0449.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/JSONScript/TestCases/p-0449.json) Test in-text legacy `:=` and `::` annotation style with enabled LinksInValue (#2153, `wgContLang=en`, `smwgLinksInValues=SMW_LINV_OBFU`)
-* [p-0501.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/JSONScript/TestCases/p-0501.json) Test `#concept` on predefined property (`wgContLang=en`, `wgLang=es`)
-* [p-0502.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/JSONScript/TestCases/p-0502.json) Test in-text annotation allows value list (`wgContLang=en`)
-* [p-0701.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/JSONScript/TestCases/p-0701.json) Test to create inverted annotation using a #ask/template combination (#711, `import-annotation=true`)
-* [p-0702.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/JSONScript/TestCases/p-0702.json) Test #ask with `format=table` on inverse property/printrquest (#1270, en)
-* [p-0703.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/JSONScript/TestCases/p-0703.json) Test `#ask` on `format=table` using different printrequest label output (#1270, `wgContLang=en`, `wgLang=en`)
-* [p-0704.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/JSONScript/TestCases/p-0704.json) Test `#ask` sanitization of printrequest labels to avoid XSS injection (`wgContLang=en`, `wgLang=en`)
-* [p-0705.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/JSONScript/TestCases/p-0705.json) Test `#ask`/ NS_FILE option (`wgContLang=en`, `wgLang=en`, `wgEnableUploads`, `wgFileExtensions`, 'wgDefaultUserOptions')
-* [p-0901.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/JSONScript/TestCases/p-0901.json) Test #ask on moved redirected subject (#1086)
-* [p-0902.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/JSONScript/TestCases/p-0902.json) Test #ask on failed queries to produce a `_ERRC` (#1297, en)
-* [p-0903.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/JSONScript/TestCases/p-0903.json) Test #ask on redirected printrequest (#1290, en)
-* [p-0904.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/JSONScript/TestCases/p-0904.json) Test #ask with subject redirected to different NS (en)
-* [p-0905.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/JSONScript/TestCases/p-0905.json) Test `#ask` query-in-query construct (`_sobj`/`_dat`/`_num`) (`wgContLang=en`, `wgLang=en`)
-* [p-0906.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/JSONScript/TestCases/p-0906.json) Test `#ask` on category/property hierarchy with circular reference (#1713, `wgContLang=en`, `wgLang=en`, 'smwgEnabledQueryDependencyLinksStore', skip virtuoso)
-* [p-0907.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/JSONScript/TestCases/p-0907.json) Test the QueryResult cache feature (#1251, `wgContLang=en`, `wgLang=en`, `smwgQueryResultCacheType=true`)
-* [p-0908.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/JSONScript/TestCases/p-0908.json) Test the QueryResult cache feature with different `|+lang`/`|+order` prinrequest parameters (#1251, `wgContLang=en`, `wgLang=en`, `smwgQueryResultCacheType=true`)
-* [p-0909.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/JSONScript/TestCases/p-0909.json) Test the description optimization (`wgContLang=en`, `wgLang=en`, `smwgQueryResultCacheType=true`, `smwgQFilterDuplicates=true`, `smwgQueryProfiler`)
-* [p-0910.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/JSONScript/TestCases/p-0910.json) Test `#ask` to highlight (`#-hl`) search token in result set (#..., `wgContLang=en`, `wgLang=en`)
-* [p-0911.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/JSONScript/TestCases/p-0911.json) Test the `_ASK` profile (#2270, `smwgQueryProfiler`, `smwgQueryResultCacheType`)
-* [p-0912.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/JSONScript/TestCases/p-0912.json) Test `#ask` with (`#-ia`) formatter using `#set` (#..., `wgContLang=en`, `wgLang=en`)
-* [p-0913.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/JSONScript/TestCases/p-0913.json) Test `#ask` with (`#-ia`) formatter using `smwgLinksInValues` (#..., `wgContLang=en`, `wgLang=en`, `smwgLinksInValues=SMW_LINV_OBFU`)
+* [p-0101.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/2.5.x/tests/phpunit/Integration/JSONScript/TestCases/p-0101.json) Test in-text annotation for use of restricted properties (#914, `wgContLang=en`, `wgLang=en`)
+* [p-0102.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/2.5.x/tests/phpunit/Integration/JSONScript/TestCases/p-0102.json) Test in-text annotation on properties with invalid names/charaters (#1567, #1638, #1727 `wgContLang=en`)
+* [p-0106.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/2.5.x/tests/phpunit/Integration/JSONScript/TestCases/p-0106.json) Test #info parser output (#1019, `wgContLang=en`, `wgLang=en`)
+* [p-0107.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/2.5.x/tests/phpunit/Integration/JSONScript/TestCases/p-0107.json) Test #smwdoc parser output (#1019, en)
+* [p-0108.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/2.5.x/tests/phpunit/Integration/JSONScript/TestCases/p-0108.json) Test `#info`, `#ask` template output (#2347, `wgContLang=en`, `wgLang=en`)
+* [p-0110.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/2.5.x/tests/phpunit/Integration/JSONScript/TestCases/p-0110.json) Test tooltip with error output on `_PVUC` (`smwgDVFeatures`, `wgContLang=en`, `wgLang=en`)
+* [p-0202.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/2.5.x/tests/phpunit/Integration/JSONScript/TestCases/p-0202.json) Test #set parser to use template for output (#1146, en)
+* [p-0203.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/2.5.x/tests/phpunit/Integration/JSONScript/TestCases/p-0203.json) Test #set parser in combination with #subobject and template output (#1067, regression check)
+* [p-0204.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/2.5.x/tests/phpunit/Integration/JSONScript/TestCases/p-0204.json) Test #set parser to produce error output (#870, en, verify that #set calls do not affect each other with previous errors)
+* [p-0205.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/2.5.x/tests/phpunit/Integration/JSONScript/TestCases/p-0205.json) Test #set/#ask recursive annotation support (#711, #1055, recursive annotation using import-annotation=true via template)
+* [p-0206.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/2.5.x/tests/phpunit/Integration/JSONScript/TestCases/p-0206.json) Test #show parser on inverse printrequest (#1222, #1223)
+* [p-0207.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/2.5.x/tests/phpunit/Integration/JSONScript/TestCases/p-0207.json) Test that undeclared properties with references remain after a `rebuildData` run (#1216, en)
+* [p-0208.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/2.5.x/tests/phpunit/Integration/JSONScript/TestCases/p-0208.json) Test `#set` for various `_num` values without explicit precision (3 digit implicit), with/without leading zero, different printouts, negative numbers (#753, en, `smwgMaxNonExpNumber`)
+* [p-0209.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/2.5.x/tests/phpunit/Integration/JSONScript/TestCases/p-0209.json) Test `#set` for various `_qty` values without explicit precision (3 digit implicit), with/without leading zero, and different printouts (#753, en, `smwgMaxNonExpNumber`)
+* [p-0210.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/2.5.x/tests/phpunit/Integration/JSONScript/TestCases/p-0210.json) Test `#set_recurring_event` (`wgContLang=en`, `wgLang=en`)
+* [p-0211.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/2.5.x/tests/phpunit/Integration/JSONScript/TestCases/p-0211.json) Test `#set`/`#subobject` to import annotation via `@json` syntax (`wgContLang=en`, `wgLang=en`)
+* [p-0212.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/2.5.x/tests/phpunit/Integration/JSONScript/TestCases/p-0212.json) Test `@@@` in-text annotation syntax (#1855, #1875 `wgContLang=en`, `wgLang=en`)
+* [p-0301.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/2.5.x/tests/phpunit/Integration/JSONScript/TestCases/p-0301.json) Test #subobject category annotation (#1172)
+* [p-0302.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/2.5.x/tests/phpunit/Integration/JSONScript/TestCases/p-0302.json) Test #subobject parser to use invalid assignments and create `_ERRC` (#1299, en)
+* [p-0303.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/2.5.x/tests/phpunit/Integration/JSONScript/TestCases/p-0303.json) Test `#subobject` and `#set` parser on values with spaces (`wgContLang=en`, `wgLang=en`)
+* [p-0401.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/2.5.x/tests/phpunit/Integration/JSONScript/TestCases/p-0401.json) Test annotations with disabled capital links (#673, `wgCapitalLinks=false`)
+* [p-0402.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/2.5.x/tests/phpunit/Integration/JSONScript/TestCases/p-0402.json) Test in-text parsing for double colon annotation such as `::::` or `:::` (#1066, #1075, en)
+* [p-0403.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/2.5.x/tests/phpunit/Integration/JSONScript/TestCases/p-0403.json) Test in-text annotations being disabled for when Factbox contains extra `[[ ... ]]` (#1126)
+* [p-0404.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/2.5.x/tests/phpunit/Integration/JSONScript/TestCases/p-0404.json) Test in-text annonation on different category colon identifier
+* [p-0405.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/2.5.x/tests/phpunit/Integration/JSONScript/TestCases/p-0405.json) Test in-text annotation via template and manual redirect (#895)
+* [p-0406.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/2.5.x/tests/phpunit/Integration/JSONScript/TestCases/p-0406.json) Test in-text annotation for unrestricted template parse using `import-annotation=true` (#1055)
+* [p-0407.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/2.5.x/tests/phpunit/Integration/JSONScript/TestCases/p-0407.json) Test in-text annotation for a redirect that is pointing to a deleted target (#1105)
+* [p-0408.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/2.5.x/tests/phpunit/Integration/JSONScript/TestCases/p-0408.json) Test in-text annotation for multiple property assignment using non-strict parser mode (#1252, en)
+* [p-0409.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/2.5.x/tests/phpunit/Integration/JSONScript/TestCases/p-0409.json) Test in-text annotation for `_rec`/`_mlt_rec` (+ subobject) for when record type points to another record type (`wgContLang=en`, `wgLang=en`)
+* [p-0410.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/2.5.x/tests/phpunit/Integration/JSONScript/TestCases/p-0410.json) Test in-text annotation on `_num`/`_tem`/`_qty` type with denoted precision (`_PREC`) and/or `-p<num>` printout precision marker (#1335, en)
+* [p-0411.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/2.5.x/tests/phpunit/Integration/JSONScript/TestCases/p-0411.json) Test in-text annotation (and #subobject) using a monolingual property (#1344, en)
+* [p-0412.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/2.5.x/tests/phpunit/Integration/JSONScript/TestCases/p-0412.json) Test in-text annotation for `_boo` datatype (`wgContLang=ja`, `wgLang=ja`)
+* [p-0413.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/2.5.x/tests/phpunit/Integration/JSONScript/TestCases/p-0413.json) Test in-text annotation for different `_dat` input/output (en, skip virtuoso, `smwgDVFeatures`)
+* [p-0414.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/2.5.x/tests/phpunit/Integration/JSONScript/TestCases/p-0414.json) Test in-text annotation/free format for `_dat` datatype (#1389, #1401, en, `smwgDVFeatures`)
+* [p-0415.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/2.5.x/tests/phpunit/Integration/JSONScript/TestCases/p-0415.json) Test in-text annotation on `_tem` with display unit preference (en)
+* [p-0416.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/2.5.x/tests/phpunit/Integration/JSONScript/TestCases/p-0416.json) Test in-text annotation with DISPLAYTITLE (#1410, #1611, `wgRestrictDisplayTitle`, `wgContLang=en`, `wgLang=en`)
+* [p-0417.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/2.5.x/tests/phpunit/Integration/JSONScript/TestCases/p-0417.json) Test in-text annotation for `Allows pattern` to match regular expressions (en)
+* [p-0418.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/2.5.x/tests/phpunit/Integration/JSONScript/TestCases/p-0418.json) Test in-text annotation using `_SERV` as provide service links (en)
+* [p-0419.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/2.5.x/tests/phpunit/Integration/JSONScript/TestCases/p-0419.json) Test in-text annotation for `_PVUC` to validate uniqueness (`smwgDVFeatures`)
+* [p-0420.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/2.5.x/tests/phpunit/Integration/JSONScript/TestCases/p-0420.json) Test in-text annotation for `_dat` using JL/GR annotated values (en, `smwgDVFeatures`)
+* [p-0421.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/2.5.x/tests/phpunit/Integration/JSONScript/TestCases/p-0421.json) Test in-text annotation with combined constraint validation (`smwgDVFeatures`)
+* [p-0422.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/2.5.x/tests/phpunit/Integration/JSONScript/TestCases/p-0422.json) Test in-text annotation `_dat` on partial dates (#2076, `wgContLang=en`, `wgLang=en`)
+* [p-0423.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/2.5.x/tests/phpunit/Integration/JSONScript/TestCases/p-0423.json) Test in-text annotation / `#ask` (#MEDIAWIKI, #LOCL) output for `_dat` datatype (#1545, `wgContLang=en`, `wgLang=ja`)
+* [p-0424.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/2.5.x/tests/phpunit/Integration/JSONScript/TestCases/p-0424.json) Test in-text annotation for `_boo` datatype using `LOCL` (`wgContLang=en`, `wgLang=fr`, skip-on 1.25.6)
+* [p-0425.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/2.5.x/tests/phpunit/Integration/JSONScript/TestCases/p-0425.json) Test in-text annotation on `_tem`/ `_num` with different page content language (#1591, `wgContLang=es`, `wgLang=en`)
+* [p-0426.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/2.5.x/tests/phpunit/Integration/JSONScript/TestCases/p-0426.json) Test in-text annotation for `_num` on big/small numbers/scientific notation (`wgContLang=fr`, `wgLang=en`)
+* [p-0427.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/2.5.x/tests/phpunit/Integration/JSONScript/TestCases/p-0427.json) Test in-text annotation with DISPLAYTITLE / `foaf` to check on upper vs. lower case (`wgRestrictDisplayTitle`, `wgContLang=en`, `wgLang=en`)
+* [p-0428.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/2.5.x/tests/phpunit/Integration/JSONScript/TestCases/p-0428.json) Test `_TYPE` annotations on different content language (`wgContLang=fr`, `wgLang=en`)
+* [p-0429.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/2.5.x/tests/phpunit/Integration/JSONScript/TestCases/p-0429.json) Test in-text `_dat` annotation with time offset, time zone, am/pm (`wgContLang=en`, `wgLang=en`)
+* [p-0430.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/2.5.x/tests/phpunit/Integration/JSONScript/TestCases/p-0430.json) Test in-text annotation for `_eid` type (`wgContLang=en`, `wgLang=en`)
+* [p-0431.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/2.5.x/tests/phpunit/Integration/JSONScript/TestCases/p-0431.json) Test in-text annotation `_rec` and `|+index` (`wgContLang=en`, `wgLang=en`)
+* [p-0432.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/2.5.x/tests/phpunit/Integration/JSONScript/TestCases/p-0432.json) Test in-text annotation for `_ref_rec` type (#1808, `wgContLang=en`, `wgLang=en`)
+* [p-0433.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/2.5.x/tests/phpunit/Integration/JSONScript/TestCases/p-0433.json) Test in-text annotation `::` with left pipe (#1747, `wgContLang=en`, `smwgLinksInValues=false`)
+* [p-0434.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/2.5.x/tests/phpunit/Integration/JSONScript/TestCases/p-0434.json) Test printrequest property chaining `|?Foo.Bar` (#1824, `wgContLang=en`, `wgLang=en`)
+* [p-0435.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/2.5.x/tests/phpunit/Integration/JSONScript/TestCases/p-0435.json) Test in-text annotation using `_txt` type with 255+ char, `#ask` to produce reduced length (#1878, `wgContLang=en`, `wgLang=en`)
+* [p-0436.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/2.5.x/tests/phpunit/Integration/JSONScript/TestCases/p-0436.json) Test in-text annotation with `_PPLB` [preferred property label] (#1879, `wgContLang=en`, `wgLang=en`)
+* [p-0437.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/2.5.x/tests/phpunit/Integration/JSONScript/TestCases/p-0437.json) Test in-text annotation with preferred property label/`_PPLB` (#1879, `wgContLang=en`, `wgLang=ja`)
+* [p-0438.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/2.5.x/tests/phpunit/Integration/JSONScript/TestCases/p-0438.json) Test in-text annotation with preferred property label/DISPLAYTITLE on user/predefined properties (`wgContLang=es`, `wgLang=de`, `wgRestrictDisplayTitle=false`)
+* [p-0439.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/2.5.x/tests/phpunit/Integration/JSONScript/TestCases/p-0439.json) Test in-text annotation using '_txt'/'_wpg' type / UTF encoding (`wgContLang=en`, `wgLang=en`)
+* [p-0440.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/2.5.x/tests/phpunit/Integration/JSONScript/TestCases/p-0440.json) Test in-text annotation `_mlt_rec` (Monolingual text) with `|+lang`/`|+order` parameter (`wgContLang=en`, `wgLang=en`)
+* [p-0441.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/2.5.x/tests/phpunit/Integration/JSONScript/TestCases/p-0441.json) Test in-text `_txt` 00 string/loose comparison (#2061)
+* [p-0442.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/2.5.x/tests/phpunit/Integration/JSONScript/TestCases/p-0442.json) Test in-text `#REDIRECT` to verify target subobject isn't removed (#, `wgContLang=en`, `wgLang=en`)
+* [p-0443.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/2.5.x/tests/phpunit/Integration/JSONScript/TestCases/p-0443.json) Test conditions and strict constraint validations for uniqueness `_PVUC` (#1463, `wgContLang=en`, `wgLang=en`, `smwgDVFeatures`)
+* [p-0444.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/2.5.x/tests/phpunit/Integration/JSONScript/TestCases/p-0444.json) Test in-text annotation LinksInValue `SMW_LINV_OBFU` (#2153, `wgContLang=en`, `smwgLinksInValues=SMW_LINV_OBFU`)
+* [p-0445.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/2.5.x/tests/phpunit/Integration/JSONScript/TestCases/p-0445.json) Test in-text annotation for `_ref_rec` type with errors (#..., `wgContLang=en`)
+* [p-0446.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/2.5.x/tests/phpunit/Integration/JSONScript/TestCases/p-0446.json) Test in-text annotation `_uri`/`_ema`/`_tel` with spaces/underscore (`wgContLang=en`)
+* [p-0447.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/2.5.x/tests/phpunit/Integration/JSONScript/TestCases/p-0447.json) Test in-text annotation with IRI export (#2188, `smwgExportResourcesAsIri=true`, `wgContLang=ru`, `wgLang=en`)
+* [p-0448.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/2.5.x/tests/phpunit/Integration/JSONScript/TestCases/p-0448.json) Test in-text legacy `:=` annotation style (#2153, `wgContLang=en`, `smwgLinksInValues=false`)
+* [p-0449.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/2.5.x/tests/phpunit/Integration/JSONScript/TestCases/p-0449.json) Test in-text legacy `:=` and `::` annotation style with enabled LinksInValue (#2153, `wgContLang=en`, `smwgLinksInValues=SMW_LINV_OBFU`)
+* [p-0451.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/2.5.x/tests/phpunit/Integration/JSONScript/TestCases/p-0451.json) Test in-text `_dat` datatype, time zone, and JD output (#2454, `wgContLang=en`, `wgLang=en`, `smwgDVFeatures=SMW_DV_TIMEV_CM`)
+* [p-0501.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/2.5.x/tests/phpunit/Integration/JSONScript/TestCases/p-0501.json) Test `#concept` on predefined property (`wgContLang=en`, `wgLang=es`)
+* [p-0502.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/2.5.x/tests/phpunit/Integration/JSONScript/TestCases/p-0502.json) Test in-text annotation allows value list (#2295, `wgContLang=en`, `wgLang=en`)
+* [p-0701.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/2.5.x/tests/phpunit/Integration/JSONScript/TestCases/p-0701.json) Test to create inverted annotation using a #ask/template combination (#711, `import-annotation=true`)
+* [p-0702.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/2.5.x/tests/phpunit/Integration/JSONScript/TestCases/p-0702.json) Test #ask with `format=table` on inverse property/printrquest (#1270, en)
+* [p-0703.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/2.5.x/tests/phpunit/Integration/JSONScript/TestCases/p-0703.json) Test `#ask` on `format=table` using different printrequest label output (#1270, `wgContLang=en`, `wgLang=en`)
+* [p-0704.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/2.5.x/tests/phpunit/Integration/JSONScript/TestCases/p-0704.json) Test `#ask` sanitization of printrequest labels to avoid XSS injection (`wgContLang=en`, `wgLang=en`)
+* [p-0705.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/2.5.x/tests/phpunit/Integration/JSONScript/TestCases/p-0705.json) Test `#ask`/ NS_FILE option (`wgContLang=en`, `wgLang=en`, `wgEnableUploads`, `wgFileExtensions`, 'wgDefaultUserOptions')
+* [p-0706.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/2.5.x/tests/phpunit/Integration/JSONScript/TestCases/p-0706.json) Test `#ask` on `format=template` with message parse (`wgContLang=en`, `wgLang=en`)
+* [p-0901.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/2.5.x/tests/phpunit/Integration/JSONScript/TestCases/p-0901.json) Test #ask on moved redirected subject (#1086)
+* [p-0902.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/2.5.x/tests/phpunit/Integration/JSONScript/TestCases/p-0902.json) Test #ask on failed queries to produce a `_ERRC` (#1297, en)
+* [p-0903.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/2.5.x/tests/phpunit/Integration/JSONScript/TestCases/p-0903.json) Test #ask on redirected printrequest (#1290, en)
+* [p-0904.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/2.5.x/tests/phpunit/Integration/JSONScript/TestCases/p-0904.json) Test #ask with subject redirected to different NS (en)
+* [p-0905.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/2.5.x/tests/phpunit/Integration/JSONScript/TestCases/p-0905.json) Test `#ask` query-in-query construct (`_sobj`/`_dat`/`_num`) (`wgContLang=en`, `wgLang=en`)
+* [p-0906.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/2.5.x/tests/phpunit/Integration/JSONScript/TestCases/p-0906.json) Test `#ask` on category/property hierarchy with circular reference (#1713, `wgContLang=en`, `wgLang=en`, 'smwgEnabledQueryDependencyLinksStore', skip virtuoso)
+* [p-0907.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/2.5.x/tests/phpunit/Integration/JSONScript/TestCases/p-0907.json) Test the QueryResult cache feature (#1251, `wgContLang=en`, `wgLang=en`, `smwgQueryResultCacheType=true`)
+* [p-0908.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/2.5.x/tests/phpunit/Integration/JSONScript/TestCases/p-0908.json) Test the QueryResult cache feature with different `|+lang`/`|+order` prinrequest parameters (#1251, `wgContLang=en`, `wgLang=en`, `smwgQueryResultCacheType=true`)
+* [p-0909.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/2.5.x/tests/phpunit/Integration/JSONScript/TestCases/p-0909.json) Test the description optimization (`wgContLang=en`, `wgLang=en`, `smwgQueryResultCacheType=true`, `smwgQFilterDuplicates=true`, `smwgQueryProfiler`)
+* [p-0910.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/2.5.x/tests/phpunit/Integration/JSONScript/TestCases/p-0910.json) Test `#ask` to highlight (`#-hl`) search token in result set (#..., `wgContLang=en`, `wgLang=en`)
+* [p-0911.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/2.5.x/tests/phpunit/Integration/JSONScript/TestCases/p-0911.json) Test the `_ASK` profile (#2270, `smwgQueryProfiler`, `smwgQueryResultCacheType`)
+* [p-0912.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/2.5.x/tests/phpunit/Integration/JSONScript/TestCases/p-0912.json) Test `#ask` with (`#-ia`) formatter using `#set` (#..., `wgContLang=en`, `wgLang=en`)
+* [p-0913.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/2.5.x/tests/phpunit/Integration/JSONScript/TestCases/p-0913.json) Test `#ask` with (`#-ia`) formatter using `smwgLinksInValues` (#..., `wgContLang=en`, `wgLang=en`, `smwgLinksInValues=SMW_LINV_OBFU`)
+* [p-0914.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/2.5.x/tests/phpunit/Integration/JSONScript/TestCases/p-0914.json) Test the description optimization on `_ref_rec` type with property chain query/sort (`wgContLang=en`, `wgLang=en`, `smwgQueryResultCacheType=true`, `smwgQFilterDuplicates=true`, `smwgQueryProfiler`)
+* [p-1000.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/2.5.x/tests/phpunit/Integration/JSONScript/TestCases/p-1000.json) Test property page with redirect(synonym)/displayTitle (`wgContLang=en`, `wgLang=en`, `wgAllowDisplayTitle`)
+* [p-1001.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/2.5.x/tests/phpunit/Integration/JSONScript/TestCases/p-1001.json) Test property page with parameters (#2479, `wgContLang=en`, `wgLang=en`)
 
 ### Q
-* [q-0101.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/JSONScript/TestCases/q-0101.json) Test `_txt` query for simple assignments, NS_HELP, and special chars
-* [q-0102.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/JSONScript/TestCases/q-0102.json) Test `_txt` for `~*` regex queries to validate correct escape pattern as applied in the `QueryEngine`
-* [q-0103.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/JSONScript/TestCases/q-0103.json) Test `_txt` for `~*` regex query with the condition to include the `\` escape character (skip sqlite, postgres)
-* [q-0104.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/JSONScript/TestCases/q-0104.json) Test `_txt`/`~` with enabled full-text search support (only enabled for MySQL, SQLite)
-* [q-0105.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/JSONScript/TestCases/q-0105.json) Test `_wpg`/`~` with enabled full-text search support (only enabled for MySQL, SQLite, `SMW_FT_WIKIPAGE`)
-* [q-0201.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/JSONScript/TestCases/q-0201.json) Test `_CONC` queries (skip postgres, skip virtuoso)
-* [q-0202.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/JSONScript/TestCases/q-0202.json) Test `_CONC` for guarding against circular/self-reference which otherwise would fail with 'Maximum function nesting level ... reached, aborting' (#945, skip virtuoso)
-* [q-0203.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/JSONScript/TestCases/q-0203.json) Test `_CONC` to use `CONCEPT_CACHE_ALL` (#1050, skip postgres + all SPARQL repository)
-* [q-0204.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/JSONScript/TestCases/q-0204.json) Test `_CONC` on predefined inverse query and subobject inverse query (#1096, skip virtuoso)
-* [q-0301.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/JSONScript/TestCases/q-0301.json) Test `_IMPO` queries for imported foaf vocabulary (#891, en)
-* [q-0401.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/JSONScript/TestCases/q-0401.json) Test `_SUBP` on a simple 'family' subproperty hierarchy example query (#1003, skip virtuoso)
-* [q-0402.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/JSONScript/TestCases/q-0402.json) Test `_SUBP` to map DC imported vocabulary with MARC 21 bibliographic terms (#1003, http://www.loc.gov/marc/bibliographic/bd20x24x.html)
-* [q-0501.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/JSONScript/TestCases/q-0501.json) Test `_qty` queries for custom unit (km²/°C) property value assignments
-* [q-0502.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/JSONScript/TestCases/q-0502.json) Test `_qty` range queries using non strict comparators (`smwStrictComparators=false`)
-* [q-0503.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/JSONScript/TestCases/q-0503.json) Test `_qty` on positional unit preference in query condition (#1329, `smwStrictComparators=false`)
-* [q-0601.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/JSONScript/TestCases/q-0601.json) Test `_wpg` for property chain query queries
-* [q-0602.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/JSONScript/TestCases/q-0602.json) Test `_wpg` sort query with #subobject annotated @sortkey content
-* [q-0603.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/JSONScript/TestCases/q-0603.json) Test `_wpg` queries for various conditions using #set annotated content
-* [q-0604.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/JSONScript/TestCases/q-0604.json) Test `_wpg` queries to resolve property/values redirects (#467, skip virtuoso)
-* [q-0605.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/JSONScript/TestCases/q-0605.json) Test `_wpg` regex search (`!~/~*/~?`) queries (#679)
-* [q-0606.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/JSONScript/TestCases/q-0606.json) Test `_wpg`/`_num`/`_txt` using subqueries (#466, #627, #625)
-* [q-0607.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/JSONScript/TestCases/q-0607.json) Test `_wpg`/`_dat`/`_num`/`_txt` subquery example
-* [q-0608.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/JSONScript/TestCases/q-0608.json) Test `_wpg` for single value approximate (`~/!~`) queries (#1246)
-* [q-0609.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/JSONScript/TestCases/q-0609.json) Test `_wpg` for single value approximate (`~/!~`) queries with conjunctive category hierarchy (#1246, en, skip virtuoso)
-* [q-0610.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/JSONScript/TestCases/q-0610.json) Test `_wpg` range queries (#1291, `smwStrictComparators=false`, skip virtuoso)
-* [q-0611.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/JSONScript/TestCases/q-0611.json) Test `_wpg` namespace any value queries (#1301, en)
-* [q-0612.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/JSONScript/TestCases/q-0612.json) Test `_wpg` object value that contains `=` (equals sign) (#640, #710, #1542, #1645, `wgContLang=en`, `wgLang=en`)
-* [q-0613.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/JSONScript/TestCases/q-0613.json) Test single value (`~/!~`/`<`/`>`) queries on namespaced entity (#1652, `NS_HELP`, `smwStrictComparators=false`, skip-on virtuoso)
-* [q-0701.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/JSONScript/TestCases/q-0701.json) Test `_uri` with some annotation/search pattern (T45264, #679)
-* [q-0702.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/JSONScript/TestCases/q-0702.json) Test `_uri` with additional annotation/search (#1129)
-* [q-0703.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/JSONScript/TestCases/q-0703.json) Test to map `Foaf` property from back-end / using a localized predefined property `A le type@fr` (en)
-* [q-0704.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/JSONScript/TestCases/q-0704.json) Test `_uri` long URL (255+) (#1872)
-* [q-0801.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/JSONScript/TestCases/q-0801.json) Test `_INST` query (#1004, en)
-* [q-0802.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/JSONScript/TestCases/q-0802.json) Test `_INST`/`_SUBC` queries (#1005, en, skip virtuoso)
-* [q-0803.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/JSONScript/TestCases/q-0803.json) Test `_INST`/ Nested category annotation (#1012, en, skip virtuoso) category hierarchy queries
-* [q-0901.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/JSONScript/TestCases/q-0901.json) Test `_wpg`/`_txt` on various disjunction, conjunction queries (#19, #1060, #1056, #1057)
-* [q-0902.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/JSONScript/TestCases/q-0902.json) Test `_txt` to correctly apply parentheses for somehting like (a OR b OR c) AND d (#556)
-* [q-0903.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/JSONScript/TestCases/q-0903.json) Test `_wpg`/`_num`/`_txt` for disjunction OR || (T31866, #1059, en)
-* [q-0904.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/JSONScript/TestCases/q-0904.json) Test `_wpg`/`_txt` disjunction in connection with property hierarchies (#1060, en, skip virtuoso)
-* [q-0905.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/JSONScript/TestCases/q-0905.json) Test `_wpg`/`_txt` conjunction queries (#1362, #1060)
-* [q-1002.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/JSONScript/TestCases/q-1002.json) Test `_dat` range for non strict comparators (#285, `smwStrictComparators=false`, skip virtuoso)
-* [q-1003.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/JSONScript/TestCases/q-1003.json) Test `_dat` range for strict comparators (#285, `smwStrictComparators=true`, skip virtuoso)
-* [q-1004.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/JSONScript/TestCases/q-1004.json) Test `_dat` range for `~`/`!~` comparators (#1178, `smwStrictComparators=false`, skip virtuoso)
-* [q-1101.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/JSONScript/TestCases/q-1101.json) Test _rec for non strict comparators queries (`smwStrictComparators=false`)
-* [q-1102.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/JSONScript/TestCases/q-1102.json) Test `_rec` queries in combination with `_dat` `~/!~` search pattern (#1178, `smwStrictComparators=false`, skip virtuoso)
-* [q-1103.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/JSONScript/TestCases/q-1103.json) Test `_rec` using some additional search pattern (#1189, en)
-* [q-1104.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/JSONScript/TestCases/q-1104.json) Test `_rec` to find correct target for redirected property (#1244, en)
-* [q-1105.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/JSONScript/TestCases/q-1105.json) Test `_rec` in combination with named subobject (T49472, #1300, en, `smwStrictComparators=false`)
-* [q-1106.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/JSONScript/TestCases/q-1106.json) Test `_rec` with `~/!~` comparators on allowed values (#1207, `smwStrictComparators=false`)
-* [q-1107.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/JSONScript/TestCases/q-1107.json) Test `_rec`/`_mlt_rec`(`_PDESC`) to use property chaining (`wgContLang=en`)
-* [q-1108.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/JSONScript/TestCases/q-1108.json) Test conditions and constraint validations for allowed values `_LIST` and uniqueness `_PVUC` (#1207, `wgContLang=en`, `wgLang=en`)
+* [q-0101.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/2.5.x/tests/phpunit/Integration/JSONScript/TestCases/q-0101.json) Test `_txt` query for simple assignments, NS_HELP, and special chars
+* [q-0102.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/2.5.x/tests/phpunit/Integration/JSONScript/TestCases/q-0102.json) Test `_txt` for `~*` regex queries to validate correct escape pattern as applied in the `QueryEngine`
+* [q-0103.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/2.5.x/tests/phpunit/Integration/JSONScript/TestCases/q-0103.json) Test `_txt` for `~*` regex query with the condition to include the `\` escape character (skip sqlite, postgres)
+* [q-0104.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/2.5.x/tests/phpunit/Integration/JSONScript/TestCases/q-0104.json) Test `_txt`/`~` with enabled full-text search support (only enabled for MySQL, SQLite)
+* [q-0105.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/2.5.x/tests/phpunit/Integration/JSONScript/TestCases/q-0105.json) Test `_wpg`/`~` with enabled full-text search support (only enabled for MySQL, SQLite, `SMW_FT_WIKIPAGE`)
+* [q-0201.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/2.5.x/tests/phpunit/Integration/JSONScript/TestCases/q-0201.json) Test `_CONC` queries (skip postgres, skip virtuoso)
+* [q-0202.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/2.5.x/tests/phpunit/Integration/JSONScript/TestCases/q-0202.json) Test `_CONC` for guarding against circular/self-reference which otherwise would fail with 'Maximum function nesting level ... reached, aborting' (#945, skip virtuoso)
+* [q-0203.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/2.5.x/tests/phpunit/Integration/JSONScript/TestCases/q-0203.json) Test `_CONC` to use `CONCEPT_CACHE_ALL` (#1050, skip postgres + all SPARQL repository)
+* [q-0204.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/2.5.x/tests/phpunit/Integration/JSONScript/TestCases/q-0204.json) Test `_CONC` on predefined inverse query and subobject inverse query (#1096, skip virtuoso)
+* [q-0301.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/2.5.x/tests/phpunit/Integration/JSONScript/TestCases/q-0301.json) Test `_IMPO` queries for imported foaf vocabulary (#891, en)
+* [q-0401.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/2.5.x/tests/phpunit/Integration/JSONScript/TestCases/q-0401.json) Test `_SUBP` on a simple 'family' subproperty hierarchy example query (#1003, skip virtuoso)
+* [q-0402.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/2.5.x/tests/phpunit/Integration/JSONScript/TestCases/q-0402.json) Test `_SUBP` to map DC imported vocabulary with MARC 21 bibliographic terms (#1003, http://www.loc.gov/marc/bibliographic/bd20x24x.html)
+* [q-0501.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/2.5.x/tests/phpunit/Integration/JSONScript/TestCases/q-0501.json) Test `_qty` queries for custom unit (km²/°C) property value assignments
+* [q-0502.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/2.5.x/tests/phpunit/Integration/JSONScript/TestCases/q-0502.json) Test `_qty` range queries using non strict comparators (`smwStrictComparators=false`)
+* [q-0503.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/2.5.x/tests/phpunit/Integration/JSONScript/TestCases/q-0503.json) Test `_qty` on positional unit preference in query condition (#1329, `smwStrictComparators=false`)
+* [q-0601.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/2.5.x/tests/phpunit/Integration/JSONScript/TestCases/q-0601.json) Test `_wpg` for property chain query queries
+* [q-0602.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/2.5.x/tests/phpunit/Integration/JSONScript/TestCases/q-0602.json) Test `_wpg` sort query with #subobject annotated @sortkey content
+* [q-0603.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/2.5.x/tests/phpunit/Integration/JSONScript/TestCases/q-0603.json) Test `_wpg` queries for various conditions using #set annotated content
+* [q-0604.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/2.5.x/tests/phpunit/Integration/JSONScript/TestCases/q-0604.json) Test `_wpg` queries to resolve property/values redirects (#467, skip virtuoso)
+* [q-0605.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/2.5.x/tests/phpunit/Integration/JSONScript/TestCases/q-0605.json) Test `_wpg` regex search (`!~/~*/~?`) queries (#679)
+* [q-0606.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/2.5.x/tests/phpunit/Integration/JSONScript/TestCases/q-0606.json) Test `_wpg`/`_num`/`_txt` using subqueries (#466, #627, #625)
+* [q-0607.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/2.5.x/tests/phpunit/Integration/JSONScript/TestCases/q-0607.json) Test `_wpg`/`_dat`/`_num`/`_txt` subquery example
+* [q-0608.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/2.5.x/tests/phpunit/Integration/JSONScript/TestCases/q-0608.json) Test `_wpg` for single value approximate (`~/!~`) queries (#1246)
+* [q-0609.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/2.5.x/tests/phpunit/Integration/JSONScript/TestCases/q-0609.json) Test `_wpg` for single value approximate (`~/!~`) queries with conjunctive category hierarchy (#1246, en, skip virtuoso)
+* [q-0610.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/2.5.x/tests/phpunit/Integration/JSONScript/TestCases/q-0610.json) Test `_wpg` range queries (#1291, `smwStrictComparators=false`, skip virtuoso)
+* [q-0611.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/2.5.x/tests/phpunit/Integration/JSONScript/TestCases/q-0611.json) Test `_wpg` namespace any value queries (#1301, en)
+* [q-0612.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/2.5.x/tests/phpunit/Integration/JSONScript/TestCases/q-0612.json) Test `_wpg` object value that contains `=` (equals sign) (#640, #710, #1542, #1645, `wgContLang=en`, `wgLang=en`)
+* [q-0613.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/2.5.x/tests/phpunit/Integration/JSONScript/TestCases/q-0613.json) Test single value (`~/!~`/`<`/`>`) queries on namespaced entity (#1652, `NS_HELP`, `smwStrictComparators=false`, skip-on virtuoso)
+* [q-0701.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/2.5.x/tests/phpunit/Integration/JSONScript/TestCases/q-0701.json) Test `_uri` with some annotation/search pattern (T45264, #679)
+* [q-0702.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/2.5.x/tests/phpunit/Integration/JSONScript/TestCases/q-0702.json) Test `_uri` with additional annotation/search (#1129)
+* [q-0703.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/2.5.x/tests/phpunit/Integration/JSONScript/TestCases/q-0703.json) Test to map `Foaf` property from back-end / using a localized predefined property `A le type@fr` (en)
+* [q-0704.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/2.5.x/tests/phpunit/Integration/JSONScript/TestCases/q-0704.json) Test `_uri` long URL (255+) (#1872)
+* [q-0801.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/2.5.x/tests/phpunit/Integration/JSONScript/TestCases/q-0801.json) Test `_INST` query (#1004, en)
+* [q-0802.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/2.5.x/tests/phpunit/Integration/JSONScript/TestCases/q-0802.json) Test `_INST`/`_SUBC` queries (#1005, en, skip virtuoso)
+* [q-0803.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/2.5.x/tests/phpunit/Integration/JSONScript/TestCases/q-0803.json) Test `_INST`/ Nested category annotation (#1012, en, skip virtuoso) category hierarchy queries
+* [q-0901.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/2.5.x/tests/phpunit/Integration/JSONScript/TestCases/q-0901.json) Test `_wpg`/`_txt` on various disjunction, conjunction queries (#19, #1060, #1056, #1057)
+* [q-0902.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/2.5.x/tests/phpunit/Integration/JSONScript/TestCases/q-0902.json) Test `_txt` to correctly apply parentheses for somehting like (a OR b OR c) AND d (#556)
+* [q-0903.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/2.5.x/tests/phpunit/Integration/JSONScript/TestCases/q-0903.json) Test `_wpg`/`_num`/`_txt` for disjunction OR || (T31866, #1059, en)
+* [q-0904.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/2.5.x/tests/phpunit/Integration/JSONScript/TestCases/q-0904.json) Test `_wpg`/`_txt` disjunction in connection with property hierarchies (#1060, en, skip virtuoso)
+* [q-0905.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/2.5.x/tests/phpunit/Integration/JSONScript/TestCases/q-0905.json) Test `_wpg`/`_txt` conjunction queries (#1362, #1060)
+* [q-1002.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/2.5.x/tests/phpunit/Integration/JSONScript/TestCases/q-1002.json) Test `_dat` range for non strict comparators (#285, `smwStrictComparators=false`, skip virtuoso)
+* [q-1003.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/2.5.x/tests/phpunit/Integration/JSONScript/TestCases/q-1003.json) Test `_dat` range for strict comparators (#285, `smwStrictComparators=true`, skip virtuoso)
+* [q-1004.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/2.5.x/tests/phpunit/Integration/JSONScript/TestCases/q-1004.json) Test `_dat` range for `~`/`!~` comparators (#1178, `smwStrictComparators=false`, skip virtuoso)
+* [q-1101.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/2.5.x/tests/phpunit/Integration/JSONScript/TestCases/q-1101.json) Test _rec for non strict comparators queries (`smwStrictComparators=false`)
+* [q-1102.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/2.5.x/tests/phpunit/Integration/JSONScript/TestCases/q-1102.json) Test `_rec` queries in combination with `_dat` `~/!~` search pattern (#1178, `smwStrictComparators=false`, skip virtuoso)
+* [q-1103.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/2.5.x/tests/phpunit/Integration/JSONScript/TestCases/q-1103.json) Test `_rec` using some additional search pattern (#1189, en)
+* [q-1104.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/2.5.x/tests/phpunit/Integration/JSONScript/TestCases/q-1104.json) Test `_rec` to find correct target for redirected property (#1244, en)
+* [q-1105.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/2.5.x/tests/phpunit/Integration/JSONScript/TestCases/q-1105.json) Test `_rec` in combination with named subobject (T49472, #1300, en, `smwStrictComparators=false`)
+* [q-1106.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/2.5.x/tests/phpunit/Integration/JSONScript/TestCases/q-1106.json) Test `_rec` with `~/!~` comparators on allowed values (#1207, `smwStrictComparators=false`)
+* [q-1107.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/2.5.x/tests/phpunit/Integration/JSONScript/TestCases/q-1107.json) Test `_rec`/`_mlt_rec`(`_PDESC`) to use property chaining (`wgContLang=en`)
+* [q-1108.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/2.5.x/tests/phpunit/Integration/JSONScript/TestCases/q-1108.json) Test conditions and constraint validations for allowed values `_LIST` and uniqueness `_PVUC` (#1207, `wgContLang=en`, `wgLang=en`)
 
 ### R
-* [r-0001.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/JSONScript/TestCases/r-0001.json) Test RDF output for `_txt`/`_wpg`/`_dat` (#881)
-* [r-0002.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/JSONScript/TestCases/r-0002.json) Test RDF output for redirected pages (#882)
-* [r-0003.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/JSONScript/TestCases/r-0003.json) Test RDF output for imported foaf vocabulary (#884, en)
-* [r-0004.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/JSONScript/TestCases/r-0004.json) Test RDF output generation for `_INST`/`_SUBC` pages (#922, en)
-* [r-0005.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/JSONScript/TestCases/r-0005.json) Test RDF wiki-info output (#928, en)
-* [r-0006.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/JSONScript/TestCases/r-0006.json) Test RDF output generation for pages that contain `_rec` annotations (#1285, #1275)
-* [r-0007.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/JSONScript/TestCases/r-0007.json) Test RDF output for imported dc/gna vocabulary, owl:AnnotationProperty, owl:DatatypeProperty, owl:ObjectProperty, Equivalent URI (#795, `wgRestrictDisplayTitle`, en)
-* [r-0008.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/JSONScript/TestCases/r-0008.json) Test RDF output generation on pages that contain incoming error annotations (`wgContLang=en`, `wgLang=es`, syntax=rdf/turtle)
-* [r-0009.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/JSONScript/TestCases/r-0009.json) Test RDF output generation that contain a monolingual text annotations `_PDESC` (`wgContLang=en`, `wgLang=es`, syntax=rdf/turtle)
-* [r-0010.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/JSONScript/TestCases/r-0010.json) Test RDF output on canonical entities (`wgContLang=fr`, `wgLang=es`, syntax=rdf/turtle)
-* [r-0011.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/JSONScript/TestCases/r-0011.json) Test RDF output generation `skos` import/`skos:altLabel` as Monolingual text (`wgContLang=en`, `wgLang=en`)
-* [r-0012.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/JSONScript/TestCases/r-0012.json) Test RDF output generation on SubSemanticData traversal (#2177, `wgContLang=en`, `wgLang=en`)
-* [r-0013.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/JSONScript/TestCases/r-0013.json) Test RDF output generation `_uri`/`_ema`/`_tel` with spaces/underscore (`wgContLang=en`, `wgLang=en`)
-* [r-0014.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/JSONScript/TestCases/r-0014.json) Test RDF output generation on non-latin URI/IRI export (#2188, `smwgExportResourcesAsIri=false`, `wgContLang=ru`, `wgLang=en`)
-* [r-0015.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/JSONScript/TestCases/r-0015.json) Test RDF output generation on non-latin URI/IRI export (#2188, `smwgExportResourcesAsIri=true`, `wgContLang=ru`, `wgLang=en`)
-* [r-0016.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/JSONScript/TestCases/r-0016.json) Test RDF output generation with special characters (#2188, `smwgExportResourcesAsIri=false`, `wgContLang=en`, `wgLang=en`)
-* [r-0017.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/JSONScript/TestCases/r-0017.json) Test RDF output generation with special characters (#2188, `smwgExportResourcesAsIri=true`, `wgContLang=en`, `wgLang=en`)
-* [r-0018.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/JSONScript/TestCases/r-0018.json) Test RDF output generation with special characters (`smwgExportResourcesAsIri=true`, `wgContLang=en`, `wgLang=en`)
+* [r-0001.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/2.5.x/tests/phpunit/Integration/JSONScript/TestCases/r-0001.json) Test RDF output for `_txt`/`_wpg`/`_dat` (#881)
+* [r-0002.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/2.5.x/tests/phpunit/Integration/JSONScript/TestCases/r-0002.json) Test RDF output for redirected pages (#882)
+* [r-0003.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/2.5.x/tests/phpunit/Integration/JSONScript/TestCases/r-0003.json) Test RDF output for imported foaf vocabulary (#884, en)
+* [r-0004.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/2.5.x/tests/phpunit/Integration/JSONScript/TestCases/r-0004.json) Test RDF output generation for `_INST`/`_SUBC` pages (#922, en)
+* [r-0005.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/2.5.x/tests/phpunit/Integration/JSONScript/TestCases/r-0005.json) Test RDF wiki-info output (#928, en)
+* [r-0006.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/2.5.x/tests/phpunit/Integration/JSONScript/TestCases/r-0006.json) Test RDF output generation for pages that contain `_rec` annotations (#1285, #1275)
+* [r-0007.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/2.5.x/tests/phpunit/Integration/JSONScript/TestCases/r-0007.json) Test RDF output for imported dc/gna vocabulary, owl:AnnotationProperty, owl:DatatypeProperty, owl:ObjectProperty, Equivalent URI (#795, `wgRestrictDisplayTitle`, en)
+* [r-0008.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/2.5.x/tests/phpunit/Integration/JSONScript/TestCases/r-0008.json) Test RDF output generation on pages that contain incoming error annotations (`wgContLang=en`, `wgLang=es`, syntax=rdf/turtle)
+* [r-0009.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/2.5.x/tests/phpunit/Integration/JSONScript/TestCases/r-0009.json) Test RDF output generation that contain a monolingual text annotations `_PDESC` (`wgContLang=en`, `wgLang=es`, syntax=rdf/turtle)
+* [r-0010.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/2.5.x/tests/phpunit/Integration/JSONScript/TestCases/r-0010.json) Test RDF output on canonical entities (`wgContLang=fr`, `wgLang=es`, syntax=rdf/turtle)
+* [r-0011.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/2.5.x/tests/phpunit/Integration/JSONScript/TestCases/r-0011.json) Test RDF output generation `skos` import/`skos:altLabel` as Monolingual text (`wgContLang=en`, `wgLang=en`)
+* [r-0012.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/2.5.x/tests/phpunit/Integration/JSONScript/TestCases/r-0012.json) Test RDF output generation on SubSemanticData traversal (#2177, `wgContLang=en`, `wgLang=en`)
+* [r-0013.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/2.5.x/tests/phpunit/Integration/JSONScript/TestCases/r-0013.json) Test RDF output generation `_uri`/`_ema`/`_tel` with spaces/underscore (`wgContLang=en`, `wgLang=en`)
+* [r-0014.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/2.5.x/tests/phpunit/Integration/JSONScript/TestCases/r-0014.json) Test RDF output generation on non-latin URI/IRI export (#2188, `smwgExportResourcesAsIri=false`, `wgContLang=ru`, `wgLang=en`)
+* [r-0015.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/2.5.x/tests/phpunit/Integration/JSONScript/TestCases/r-0015.json) Test RDF output generation on non-latin URI/IRI export (#2188, `smwgExportResourcesAsIri=true`, `wgContLang=ru`, `wgLang=en`)
+* [r-0016.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/2.5.x/tests/phpunit/Integration/JSONScript/TestCases/r-0016.json) Test RDF output generation with special characters (#2188, `smwgExportResourcesAsIri=false`, `wgContLang=en`, `wgLang=en`)
+* [r-0017.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/2.5.x/tests/phpunit/Integration/JSONScript/TestCases/r-0017.json) Test RDF output generation with special characters (#2188, `smwgExportResourcesAsIri=true`, `wgContLang=en`, `wgLang=en`)
+* [r-0018.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/2.5.x/tests/phpunit/Integration/JSONScript/TestCases/r-0018.json) Test RDF output generation with special characters (`smwgExportResourcesAsIri=true`, `wgContLang=en`, `wgLang=en`)
 
 ### S
-* [s-0001.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/JSONScript/TestCases/s-0001.json) Test output of `Special:Properties` (`wgContLang=en`, skip-on sqlite)
-* [s-0002.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/JSONScript/TestCases/s-0002.json) Test output from `Special:SearchByProperty` for `_num`, `_txt`, `_tel` (#1728, #2009, `wgContLang=en`, `wgLang=en`, skip-on sqlite, postgres)
-* [s-0003.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/JSONScript/TestCases/s-0003.json) Test `Special:Ask` output for `format=rdf`/`format=json`/DISPLAYTITLE (#1453, #1619, `wgRestrictDisplayTitle`, `wgContLang=en`)
-* [s-0004.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/JSONScript/TestCases/s-0004.json) Test `Special:Browse` output for `_dat` (`wgContLang=en`, `wgLang=ja`)
-* [s-0005.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/JSONScript/TestCases/s-0005.json) Test `Special:Browse` output for `_dat`, '_REDI' (`wgContLang=en`, `wgLang=en`, `smwgDVFeatures=SMW_DV_TIMEV_CM | SMW_DV_WPV_DTITLE`, `wgRestrictDisplayTitle=false`)
-* [s-0006.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/JSONScript/TestCases/s-0006.json) Test output of `Special:WantedProperties` (`wgContLang=en`, `wgLang=en`, skip-on sqlite, 1.19)
-* [s-0007.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/JSONScript/TestCases/s-0007.json) Test output of `Special:UnusedProperties` (`wgContLang=en`, `wgLang=en`, skip-on sqlite, 1.19)
-* [s-0008.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/JSONScript/TestCases/s-0008.json) Test `Special:Browse` output for `_dat`, `_boo`, `_sobj`, `_uri` (`wgContLang=en`, `wgLang=es`, skip-on 1.25.6)
-* [s-0009.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/JSONScript/TestCases/s-0009.json) Test output in `Special:Search` for SMWSearch (`wgLanguageCode=en`, `wgContLang=en`, `wgSearchType=SMWSearch`)
-* [s-0010.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/JSONScript/TestCases/s-0010.json) Test output from `Special:SearchByProperty` / `_dat` (#1922, `wgContLang=en`, `wgLang=es`, skip-on sqlite)
-* [s-0011.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/JSONScript/TestCases/s-0011.json) Test `Special:Ask` output `#ask` intro/outro link/template parse (`wgContLang=en`, `wgLang=en`)
-* [s-0012.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/JSONScript/TestCases/s-0012.json) Test `Special:Ask` output `#ask` image/upload (#2009, `wgContLang=en`, `wgLang=en`, `wgEnableUploads`, `wgFileExtensions`)
-* [s-0013.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/JSONScript/TestCases/s-0013.json) Test `Special:Browse` output preferred label (`wgContLang=en`, `wgLang=es`)
-* [s-0014.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/JSONScript/TestCases/s-0014.json) Test `Special:Browse` with special characters `%'"&` (`wgContLang=en`, `wgLang=es` )
-* [s-0015.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/JSONScript/TestCases/s-0015.json) Test `Special:Ask` output for `_txt` with formatted text (#..., `wgContLang=en`, `wgLang=en`)
+* [s-0001.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/2.5.x/tests/phpunit/Integration/JSONScript/TestCases/s-0001.json) Test output of `Special:Properties` (`wgContLang=en`, skip-on sqlite)
+* [s-0002.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/2.5.x/tests/phpunit/Integration/JSONScript/TestCases/s-0002.json) Test output from `Special:SearchByProperty` for `_num`, `_txt`, `_tel` (#1728, #2009, `wgContLang=en`, `wgLang=en`, skip-on sqlite, postgres)
+* [s-0003.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/2.5.x/tests/phpunit/Integration/JSONScript/TestCases/s-0003.json) Test `Special:Ask` output for `format=rdf`/`format=json`/DISPLAYTITLE (#1453, #1619, `wgRestrictDisplayTitle`, `wgContLang=en`)
+* [s-0004.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/2.5.x/tests/phpunit/Integration/JSONScript/TestCases/s-0004.json) Test `Special:Browse` output for `_dat` (`wgContLang=en`, `wgLang=ja`)
+* [s-0005.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/2.5.x/tests/phpunit/Integration/JSONScript/TestCases/s-0005.json) Test `Special:Browse` output for `_dat`, '_REDI' (`wgContLang=en`, `wgLang=en`, `smwgDVFeatures=SMW_DV_TIMEV_CM | SMW_DV_WPV_DTITLE`, `wgRestrictDisplayTitle=false`)
+* [s-0006.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/2.5.x/tests/phpunit/Integration/JSONScript/TestCases/s-0006.json) Test output of `Special:WantedProperties` (`wgContLang=en`, `wgLang=en`, skip-on sqlite, 1.19)
+* [s-0007.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/2.5.x/tests/phpunit/Integration/JSONScript/TestCases/s-0007.json) Test output of `Special:UnusedProperties` (`wgContLang=en`, `wgLang=en`, skip-on sqlite, 1.19)
+* [s-0008.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/2.5.x/tests/phpunit/Integration/JSONScript/TestCases/s-0008.json) Test `Special:Browse` output for `_dat`, `_boo`, `_sobj`, `_uri` (`wgContLang=en`, `wgLang=es`, skip-on 1.25.6)
+* [s-0009.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/2.5.x/tests/phpunit/Integration/JSONScript/TestCases/s-0009.json) Test output in `Special:Search` for SMWSearch (`wgLanguageCode=en`, `wgContLang=en`, `wgSearchType=SMWSearch`)
+* [s-0010.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/2.5.x/tests/phpunit/Integration/JSONScript/TestCases/s-0010.json) Test output from `Special:SearchByProperty` / `_dat` (#1922, `wgContLang=en`, `wgLang=es`, skip-on sqlite)
+* [s-0011.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/2.5.x/tests/phpunit/Integration/JSONScript/TestCases/s-0011.json) Test `Special:Ask` output `#ask` intro/outro link/template parse (`wgContLang=en`, `wgLang=en`)
+* [s-0012.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/2.5.x/tests/phpunit/Integration/JSONScript/TestCases/s-0012.json) Test `Special:Ask` output `#ask` image/upload (#2009, `wgContLang=en`, `wgLang=en`, `wgEnableUploads`, `wgFileExtensions`)
+* [s-0013.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/2.5.x/tests/phpunit/Integration/JSONScript/TestCases/s-0013.json) Test `Special:Browse` output preferred label (`wgContLang=en`, `wgLang=es`)
+* [s-0014.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/2.5.x/tests/phpunit/Integration/JSONScript/TestCases/s-0014.json) Test `Special:Browse` with special characters `%'"&` (`wgContLang=en`, `wgLang=es` )
+* [s-0015.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/2.5.x/tests/phpunit/Integration/JSONScript/TestCases/s-0015.json) Test `Special:Ask` output for `_txt` with formatted text (#..., `wgContLang=en`, `wgLang=en`)
+* [s-0016.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/2.5.x/tests/phpunit/Integration/JSONScript/TestCases/s-0016.json) Test `Special:Ask` to produce correct printout position for `+|...` parameters (`wgContLang=en`, `wgLang=en`)
 
--- Last updated on 2017-03-11 by `readmeContentsBuilder.php`
+-- Last updated on 2017-07-11 by `readmeContentsBuilder.php`
 
 <!-- End of generated contents by readmeContentsBuilder.php -->
 
@@ -235,6 +244,11 @@ annotations etc.) to follow a predefined structure.
 
 It is also possible to [import](https://github.com/SemanticMediaWiki/SemanticMediaWiki/blob/master/tests/phpunit/Integration/JSONScript/TestCases/p-0211.json) larger text passages or [upload files](https://github.com/SemanticMediaWiki/SemanticMediaWiki/blob/master/tests/phpunit/Integration/JSONScript/TestCases/p-0705.json)
 for a test scenario.
+
+When creating test scenarios, use disinct names and subjects to ensure that other
+tests will not interfer with the expected results. It may also be of advantage to split
+the setup of data (e.g. `Example/Test/1`) from the actual test subject (e.g. `Example/Test/Q.1`)
+to avoid conflicating comparisons or false positive results during the assertion process.
 
 <pre>
 "setup": [
@@ -262,9 +276,31 @@ for a test scenario.
 
 ### Test assertions
 
+* The `type` provides specialized assertion methods with some of them requiring
+an extra setup to yield a comparable output but in most cases the `parser` type
+should suffice to create test assertions for common test scenarios. Available types
+are:
+  * `query`, `concept`, and `format`
+  * `parser`
+  * `parser-html`
+  * `rdf`
+  * `special`
+* The `about` describes what the test is expected to test which may help during
+  a failure to identify potential conflicts or hints on how to resolve an issue.
+* The `subject` refers to the page that was defined in the `setup` section.
+
+For example, as of version 2 the `parser` type (`ParserTestCaseProcessor`) knows
+two assertions methods:
+
+- `assert-store` is to validate data against `Store::getSemanticData`
+- `assert-output` is to validate string comparison against the `ParserOutput`
+  generated text
+
+
+#### Type `parser`
 The test result assertion provides simplified string comparison methods (mostly for
 output related assertion but expressive enough for users to understand the test
-objective and its expected results). For example, verifying that a the parser
+objective and its expected results). For example, verifying that the parser
 does output a certain string, one has to the define an expected output.
 
 <pre>
@@ -295,21 +331,60 @@ does output a certain string, one has to the define an expected output.
 			]
 		}
 	}
-}
+]
 </pre>
 
-* The `subject` refers to the page that was defined in the `setup` section.
-* The `about` describes what the test is expected to test which
-may help during a failure to identify potential conflicts or hints on how to
-resolve an issue.
-* The `type` provides specialized assertion methods with some of them requiring
-an extra setup to yield a comparable output but in most cases the `parser` type
-should suffice to create test assertions for scenarios under test. Available types
-are:
-  * `query`, `concept`, and `format`
-  * `parser`
-  * `rdf`
-  * `special`
+#### Type `parser-html`
+
+To verify that the HTML code produced by the parser conforms to a certain
+structure the test type `parser-html` may be used. With this type the expected
+output structure may be specified as a CSS selector. The test will succeed if at
+least one element according to that selector is found in the output.
+
+Example:
+<pre>
+"tests": [
+	{
+		"type": "parser-html",
+		"about": "#0 Basic List format",
+		"subject": "Example/0401",
+		"assert-output": {
+			"to-contain": [
+				"p > a[ title='Bar' ] + a[ title='Baz' ] + a[ title='Foo' ] + a[ title='Quok' ]"
+			]
+		}
+	}
+]
+</pre>
+
+For further details and limitations on the CSS selectors see the [description of
+the Symfony CssSelector
+Component](https://symfony.com/doc/current/components/css_selector.html) that is
+used for this test type.
+
+It is also possible to require an exact number of occurences of HTML elements by
+providing an array instead of just a CSS selector string.
+
+Example:
+<pre>
+		"assert-output": {
+			"to-contain": [
+				[ "p > a", 4 ]
+			]
+		}
+</pre>
+
+Finally the general well-formedness of the HTML can be tested, although this
+will not fail for recoverable errors (see the [documentation on PHP's
+DOMDocument::loadHTML](http://php.net/manual/en/domdocument.loadhtml.php#refsect1-domdocument.loadhtml-errors)).
+
+Example:
+<pre>
+		"assert-output": {
+			"to-be-valid-html": true,
+		}
+</pre>
+
 
 ### Preparing the test environment
 
@@ -362,7 +437,19 @@ possible to skip those cases by adding:
 },
 </pre>
 
-It is also possible that an entire test scenario is unable to be completed in a particular
+<pre>
+{
+	"skip-on": {
+		"hhvm-*": "HHVM (or SQLite) shows opposite B1000, B9",
+		"mw-1.28<": "`numeric` collation only available with 1.28+"
+	}
+}
+</pre>
+
+Constraints that include `hhvm-*` will indicate to exclude all HHVM versions while
+`mw-1.28<` defines that any MW version lower than 1.28 is to be ignored.
+
+It is also possible that an entire test scenario cannot be completed in a particular
 environment therefore it can be marked and skipped with:
 
 <pre>
@@ -403,7 +490,7 @@ is mostly done when running from an IDE editor
 `composer phpunit tests/phpunit/Integration/JSONScript/JsonTestCaseScriptRunnerTest -- --filter 's-0014.json'`
 
 <pre>
-$  composer phpunit tests/phpunit/Integration/JSONScript/JsonTestCaseScriptRunnerTest -- --filter 's-0014.json'
+$  composer integration -- --filter 's-0014.json'
 Using PHP 5.6.8
 
 Semantic MediaWiki: 2.5.0-alpha (SMWSQLStore3, mysql)

--- a/tests/phpunit/Integration/JSONScript/TestCases/f-0401.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/f-0401.json
@@ -1,0 +1,55 @@
+{
+	"description": "Test `format=list` output",
+	"setup": [
+		{
+			"namespace": "SMW_NS_PROPERTY",
+			"page": "Has page property",
+			"contents": "[[Has type::Page]]"
+		},
+		{
+			"page": "Foo",
+			"contents": "[[Has page property::ABC]]"
+		},
+		{
+			"page": "Bar",
+			"contents": "[[Has page property::ABC]]"
+		},
+		{
+			"page": "Baz",
+			"contents": "[[Has page property::ABC]]"
+		},
+		{
+			"page": "Quok",
+			"contents": "[[Has page property::ABC]]"
+		},
+		{
+			"page": "Example/0401",
+			"contents": "{{#ask:[[Has page property::ABC]] |format=list}}"
+		}
+	],
+	"tests": [
+		{
+			"type": "parser-html",
+			"about": "#0 Basic List format",
+			"subject": "Example/0401",
+			"assert-output": {
+				"to-be-valid-html": true,
+				"to-contain": [
+					"p > a[ title='Bar' ] + a[ title='Baz' ] + a[ title='Foo' ] + a[ title='Quok' ]",
+					[ "p > a", 4 ]
+				]
+			}
+		}
+	],
+	"settings": {
+		"smwgNamespacesWithSemanticLinks": {
+			"NS_MAIN": true,
+			"SMW_NS_PROPERTY": true
+		}
+	},
+	"meta": {
+		"version": "2",
+		"is-incomplete": false,
+		"debug": false
+	}
+}

--- a/tests/phpunit/Utils/Validators/HtmlValidator.php
+++ b/tests/phpunit/Utils/Validators/HtmlValidator.php
@@ -1,0 +1,102 @@
+<?php
+
+namespace SMW\Tests\Utils\Validators;
+
+use DOMDocument;
+use Symfony\Component\CssSelector\CssSelectorConverter;
+
+/**
+ * @license GNU GPL v2+
+ * @since   3.0
+ *
+ * @author Stephan Gambke
+ */
+class HtmlValidator extends \PHPUnit_Framework_Assert {
+
+	private $documentCache = [];
+
+	/**
+	 * @param string $actual
+	 * @param string $message
+	 */
+	public function assertThatHtmlIsValid( $actual, $message = '' ) {
+
+		$document = $this->getDomDocumentFromHtmlFragment( $actual );
+
+		self::assertTrue( $document !== false, "Failed test `{$message}` (assertion HtmlIsValid) for $actual" );
+	}
+
+	/**
+	 * @param string $fragment
+	 * @return bool|DOMDocument
+	 */
+	private function getDomDocumentFromHtmlFragment( $fragment ) {
+
+		$cacheKey = md5( $fragment );
+
+		if ( !isset( $this->documentCache[ $cacheKey ] ) ) {
+			$this->addHtmlFragmentToCache( $fragment, $cacheKey );
+		}
+
+		return $this->documentCache[ $cacheKey ];
+	}
+
+	/**
+	 * @param $fragment
+	 * @param $cacheKey
+	 */
+	private function addHtmlFragmentToCache( $fragment, $cacheKey ) {
+
+		$fragment = self::wrapHtmlFragment( $fragment );
+
+		$document = new DOMDocument();
+		$document->preserveWhiteSpace = false;
+
+		libxml_use_internal_errors( true );
+		$result = $document->loadHTML( $fragment );
+		libxml_use_internal_errors( false );
+
+		$this->documentCache[ $cacheKey ] = ( $result === true ) ? $document : false;
+
+	}
+
+	/**
+	 * @param string $fragment
+	 * @return string
+	 */
+	private static function wrapHtmlFragment( $fragment ) {
+		return "<!DOCTYPE html><html><head><meta charset='utf-8'/><title>SomeTitle</title></head><body>$fragment</body></html>";
+	}
+
+	/**
+	 * @param string | string[] $cssSelectors
+	 * @param string $htmlFragment
+	 * @param string $message
+	 */
+	public function assertThatHtmlContains( $cssSelectors, $htmlFragment, $message = '' ) {
+
+		$document = $this->getDomDocumentFromHtmlFragment( $htmlFragment );
+		$xpath = new \DOMXPath( $document );
+		$converter = new CssSelectorConverter();
+
+		foreach ( $cssSelectors as $selector ) {
+
+			if ( is_array( $selector ) ) {
+				$expectedCount = array_pop( $selector );
+				$expectedCountText = $expectedCount . 'x ';
+				$selector = array_shift( $selector );
+			} else {
+				$expectedCount = false;
+				$expectedCountText = '';
+			}
+
+			$entries = $xpath->evaluate( $converter->toXPath( $selector ) );
+			$actualCount = $entries->length;
+
+			$message = "Failed test `{$message}` for assertion HtmlContains: $expectedCountText`$selector` for \n=====\n$htmlFragment\n=====";
+
+			self::assertTrue( ( $expectedCount === false && $actualCount > 0 ) || ( $actualCount === $expectedCount ), $message );
+		}
+	}
+
+}

--- a/tests/phpunit/Utils/Validators/ValidatorFactory.php
+++ b/tests/phpunit/Utils/Validators/ValidatorFactory.php
@@ -86,4 +86,13 @@ class ValidatorFactory {
 		return new QuerySegmentValidator();
 	}
 
+	/**
+	 * @since 3.0
+	 *
+	 * @return HtmlValidator
+	 */
+	public function newHtmlValidator() {
+		return new HtmlValidator();
+	}
+
 }

--- a/tests/travis/install-semantic-mediawiki.sh
+++ b/tests/travis/install-semantic-mediawiki.sh
@@ -24,6 +24,10 @@ function installSmwIntoMwWithComposer {
 	installPHPUnitWithComposer
 	composer require mediawiki/semantic-media-wiki "dev-master" --dev
 
+	# Explicitly load symfony/css-selector
+	# FIXME: Remove once composer.json with symfony/css-selector arrived at packagist
+	composer require  "symfony/css-selector" "^3.3"
+
 	cd extensions
 	cd SemanticMediaWiki
 


### PR DESCRIPTION
This PR is made in reference to: #2540

Allows `JSONScript` test scripts to make assertions on the HTML structure of the parser output.

Rules are described as CSS selectors, e.g.

``` json
{
	"type": "parser-html",
	"about": "#0 Basic List format",
	"subject": "Example/0401",
	"assert-output": {
		"to-contain": [
			"p > a[ title='Bar' ] + a[ title='Baz' ] + a[ title='Foo' ] + a[ title='Quok' ]"
		]
	}
}
```

A requirement on the number of occurrences can be described as well, e.g.
``` json
{
        "type": "parser-html",
        "about": "#0 Basic List format",
        "subject": "Example/0401",
        "assert-output": {
                "to-contain": [
                        [ "p > a", 4 ]
                ]
        }
}
```

Finally the general wellformedness of the HTML can be asserted, although this will not fail for recoverable errors (see http://php.net/manual/en/domdocument.loadhtml.php#refsect1-domdocument.loadhtml-errors).
Example:
``` json
{
	"type": "parser-html",
	"about": "#0 Basic List format",
	"subject": "Example/0401",
	"assert-output": {
		"to-be-valid-html": 1
	}
}
```

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed
