### PR TITLE
Allow adding globals in TestEnvironment; allow extending permitted settings in JsonScripts

### DIFF
--- a/src/Options.php
+++ b/src/Options.php
@@ -35,6 +35,15 @@ class Options {
 	}
 
 	/**
+	 * @since 3.0
+	 *
+	 * @param string $key
+	 */
+	public function delete( $key ) {
+		unset( $this->options[ $key ] );
+	}
+
+	/**
 	 * @since 2.3
 	 *
 	 * @param string $key

--- a/tests/phpunit/Integration/JSONScript/JsonTestCaseScriptRunnerTest.php
+++ b/tests/phpunit/Integration/JSONScript/JsonTestCaseScriptRunnerTest.php
@@ -170,56 +170,15 @@ class JsonTestCaseScriptRunnerTest extends JsonTestCaseScriptRunner {
 
 	private function prepareTest( $jsonTestCaseFileHandler ) {
 
-		$permittedSettings = array(
-			'smwgNamespacesWithSemanticLinks',
-			'smwgPageSpecialProperties',
-			'smwgNamespace',
-			'smwgExportBCNonCanonicalFormUse',
-			'smwgExportBCAuxiliaryUse',
-			'smwgExportResourcesAsIri',
-			'smwgQMaxSize',
-			'smwStrictComparators',
-			'smwgQSubpropertyDepth',
-			'smwgQSubcategoryDepth',
-			'smwgQConceptCaching',
-			'smwgEnabledInTextAnnotationParserStrictMode',
-			'smwgMaxNonExpNumber',
-			'smwgDVFeatures',
-			'smwgEnabledQueryDependencyLinksStore',
-			'smwgEnabledFulltextSearch',
-			'smwgFulltextDeferredUpdate',
-			'smwgFulltextSearchIndexableDataTypes',
-			'smwgFixedProperties',
-			'smwgPropertyZeroCountDisplay',
-			'smwgQueryResultCacheType',
-			'smwgLinksInValues',
-			'smwgQFilterDuplicates',
-			'smwgQueryProfiler',
-			'smwgEntityCollation',
-			'smwgSparqlQFeatures',
-			'smwgUseCategoryRedirect',
-			'smwgQExpensiveThreshold',
-			'smwgQExpensiveExecutionLimit',
-			'smwgFieldTypeFeatures',
+		foreach ( $this->getPermittedSettings() as $key ) {
 
-			// MW related
-			'wgLanguageCode',
-			'wgContLang',
-			'wgLang',
-			'wgCapitalLinks',
-			'wgAllowDisplayTitle',
-			'wgRestrictDisplayTitle',
-			'wgSearchType',
-			'wgEnableUploads',
-			'wgFileExtensions',
-			'wgDefaultUserOptions'
-		);
+			try {
+				$value = $jsonTestCaseFileHandler->getSettingsFor( $key );
+			} catch (\RuntimeException $e ) {
+				continue;
+			}
 
-		foreach ( $permittedSettings as $key ) {
-			$this->changeGlobalSettingTo(
-				$key,
-				$jsonTestCaseFileHandler->getSettingsFor( $key )
-			);
+			$this->changeGlobalSettingTo( $key, $value );
 		}
 
 		if ( $jsonTestCaseFileHandler->hasSetting( 'smwgFieldTypeFeatures' ) ) {
@@ -381,6 +340,57 @@ class JsonTestCaseScriptRunnerTest extends JsonTestCaseScriptRunner {
 
 			$this->parserHtmlTestCaseProcessor->process( $case );
 		}
+	}
+
+	/**
+	 * @return string[]
+	 * @since 3.0
+	 */
+	protected function getPermittedSettings() {
+		return [
+			'smwgNamespacesWithSemanticLinks',
+			'smwgPageSpecialProperties',
+			'smwgNamespace',
+			'smwgExportBCNonCanonicalFormUse',
+			'smwgExportBCAuxiliaryUse',
+			'smwgExportResourcesAsIri',
+			'smwgQMaxSize',
+			'smwStrictComparators',
+			'smwgQSubpropertyDepth',
+			'smwgQSubcategoryDepth',
+			'smwgQConceptCaching',
+			'smwgEnabledInTextAnnotationParserStrictMode',
+			'smwgMaxNonExpNumber',
+			'smwgDVFeatures',
+			'smwgEnabledQueryDependencyLinksStore',
+			'smwgEnabledFulltextSearch',
+			'smwgFulltextDeferredUpdate',
+			'smwgFulltextSearchIndexableDataTypes',
+			'smwgFixedProperties',
+			'smwgPropertyZeroCountDisplay',
+			'smwgQueryResultCacheType',
+			'smwgLinksInValues',
+			'smwgQFilterDuplicates',
+			'smwgQueryProfiler',
+			'smwgEntityCollation',
+			'smwgSparqlQFeatures',
+			'smwgUseCategoryRedirect',
+			'smwgQExpensiveThreshold',
+			'smwgQExpensiveExecutionLimit',
+			'smwgFieldTypeFeatures',
+
+			// MW related
+			'wgLanguageCode',
+			'wgContLang',
+			'wgLang',
+			'wgCapitalLinks',
+			'wgAllowDisplayTitle',
+			'wgRestrictDisplayTitle',
+			'wgSearchType',
+			'wgEnableUploads',
+			'wgFileExtensions',
+			'wgDefaultUserOptions'
+		];
 	}
 
 }

--- a/tests/phpunit/TestEnvironment.php
+++ b/tests/phpunit/TestEnvironment.php
@@ -32,7 +32,8 @@ class TestEnvironment {
 	/**
 	 * @var array
 	 */
-	private $configuration = array();
+	private $configuration = [];
+	private $newKeys = [];
 
 	/**
 	 * @since 2.4
@@ -85,11 +86,13 @@ class TestEnvironment {
 
 		foreach ( $configuration as $key => $value ) {
 
-			if ( isset( $GLOBALS[$key] ) || array_key_exists( $key, $GLOBALS ) ) {
+			if ( array_key_exists( $key, $GLOBALS ) ) {
 				$this->configuration[$key] = $GLOBALS[$key];
-				$GLOBALS[$key] = $value;
+			} else {
+				$this->newKeys[] = $key;
 			}
 
+			$GLOBALS[$key] = $value;
 			$this->applicationFactory->getSettings()->set( $key, $value );
 		}
 
@@ -163,6 +166,11 @@ class TestEnvironment {
 		foreach ( $this->configuration as $key => $value ) {
 			$GLOBALS[$key] = $value;
 			$this->applicationFactory->getSettings()->set( $key, $value );
+		}
+
+		foreach ( $this->newKeys as $newKey ) {
+			unset( $GLOBALS[ $newKey ] );
+			$this->applicationFactory->getSettings()->delete( $newKey );
 		}
 
 		$this->applicationFactory->clear();


### PR DESCRIPTION
In sum this patch will allow to define additional allowed globals for JsonScript tests in sub-classes of JsonTestCaseScriptRunnerTest.
It will also allow adding globals that are not already defined in the TestEnvironment.

Use case: SRF's "filtered" format will support $srfgMapProvider, that is unset by default. See https://github.com/SemanticMediaWiki/SemanticResultFormats/pull/272

* add getPermittedSettings() to JsonTestCaseScriptRunnerTest
* allow undefined global settings in JsonTestCaseScriptRunnerTest::prepareTest
* track new globals in a dedicated array in TestEnvironment and unset them on tearDown
* add delete($key) method to Options

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed
