### PR TITLE
Remove Settings::add

### DIFF
--- a/includes/Settings.php
+++ b/includes/Settings.php
@@ -213,12 +213,9 @@ class Settings extends Options {
 	}
 
 	/**
-	 * @since 2.5
-	 *
-	 * @param string $key
-	 * @param mixed $value
+	 * @deprecated 3.0
 	 */
-	public function add( $key, $value ) {
+	private function add( $key, $value ) {
 
 		if ( !$this->has( $key ) ) {
 			return $this->set( $key, $value );

--- a/tests/phpunit/includes/SettingsTest.php
+++ b/tests/phpunit/includes/SettingsTest.php
@@ -76,27 +76,6 @@ class SettingsTest extends \PHPUnit_Framework_TestCase {
 		$this->assertTrue( true );
 	}
 
-	public function testAdd() {
-
-		$instance = Settings::newFromArray( array() );
-
-		$instance->set( 'foo', 123 );
-		$instance->add( 'foo', 456 );
-
-		$this->assertEquals(
-			456,
-			$instance->get( 'foo' )
-		);
-
-		$instance->set( 'bar', array( 123 ) );
-		$instance->add( 'bar', array( 456 ) );
-
-		$this->assertEquals(
-			array( 123, 456 ),
-			$instance->get( 'bar' )
-		);
-	}
-
 	/**
 	 * @dataProvider globalsSettingsProvider
 	 */


### PR DESCRIPTION
This PR is made in reference to: https://github.com/SemanticMediaWiki/SemanticMediaWiki/commit/a212e3054cac3d137d5247776d5b7c5bdc762fed

This PR addresses or contains:

- Use the `SMW::Config::BeforeCompletion` hook to alter settings during an initialization as done in https://github.com/SemanticMediaWiki/SemanticCite/blob/master/src/HookRegistry.php#L104-L115

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed
