### PR TITLE
Move config handling to TestConfig, refs 2551

### DIFF
--- a/tests/phpunit/JsonTestCaseFileHandler.php
+++ b/tests/phpunit/JsonTestCaseFileHandler.php
@@ -216,14 +216,12 @@ class JsonTestCaseFileHandler {
 	 * @return array|integer|string|boolean
 	 * @throws RuntimeException
 	 */
-	public function getSettingsFor( $key ) {
+	public function getSettingsFor( $key, $callback = null ) {
 
 		$settings = $this->getFileContentsFor( 'settings' );
 
-		if ( ( $key === 'wgContLang' || $key === 'wgLang' ) && isset( $settings[$key] ) ) {
-			\RequestContext::getMain()->setLanguage( $settings[$key] );
-			Localizer::getInstance()->clear();
-			return \Language::factory( $settings[$key] );
+		if ( isset( $settings[$key] ) && is_callable( $callback ) ) {
+			return call_user_func_array( $callback, array( $settings[$key] ) );
 		}
 
 		// Needs special attention due to NS constant usage
@@ -279,12 +277,13 @@ class JsonTestCaseFileHandler {
 			return $settings[$key];
 		}
 
-		// Set default values
+		// Return values from the global settings as default
 		if ( isset( $GLOBALS[$key] ) || array_key_exists( $key, $GLOBALS ) ) {
 			return $GLOBALS[$key];
 		}
 
-		throw new RuntimeException( "{$key} is unknown" );
+		// Key is unknown, TestConfig will remove any remains during tearDown
+		return null;
 	}
 
 	/**

--- a/tests/phpunit/JsonTestCaseScriptRunner.php
+++ b/tests/phpunit/JsonTestCaseScriptRunner.php
@@ -61,6 +61,11 @@ abstract class JsonTestCaseScriptRunner extends MwDBaseUnitTestCase {
 	 */
 	protected $connectorId = '';
 
+	/**
+	 * @var array
+	 */
+	protected $settingsValueCallbacks = array();
+
 	protected function setUp() {
 		parent::setUp();
 
@@ -114,6 +119,20 @@ abstract class JsonTestCaseScriptRunner extends MwDBaseUnitTestCase {
 	 * @return array
 	 */
 	protected function getAllowedTestCaseFiles() {
+		return array();
+	}
+
+	/**
+	 * Selected list of settings (internal or MediaWiki related) that are
+	 * permissible for the time of the test run to be manipulated.
+	 *
+	 * For a configuration that requires special treatment (i.e. where a simple
+	 * assignment isn't sufficient), a callback can be assigned to a settings
+	 * key in order to sort out required manipulation (constants etc.).
+	 *
+	 * @return array
+	 */
+	protected function getPermittedSettings() {
 		return array();
 	}
 

--- a/tests/phpunit/TestConfig.php
+++ b/tests/phpunit/TestConfig.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace SMW\Tests;
+
+use SMW\ApplicationFactory;
+use RuntimeException;
+
+/**
+ * @license GNU GPL v2+
+ * @since 3.0
+ *
+ * @author mwjames
+ */
+class TestConfig {
+
+	/**
+	 * @var Settings
+	 */
+	private $settings;
+
+	/**
+	 * @var array
+	 */
+	private $configurations = array();
+
+	/**
+	 * @var array
+	 */
+	private $newKeys = array();
+
+	/**
+	 * @since 3.0
+	 */
+	public function __construct() {
+		$this->settings = ApplicationFactory::getInstance()->getSettings();
+	}
+
+	/**
+	 * @since 3.0
+	 *
+	 * @param array $configurations
+	 */
+	public function set( array $configurations = array() ) {
+
+		foreach ( $configurations as $key => $value ) {
+
+			if ( array_key_exists( $key, $GLOBALS ) ) {
+				$this->configurations[$key] = $GLOBALS[$key];
+			} else {
+				$this->newKeys[] = $key;
+			}
+
+			$GLOBALS[$key] = $value;
+			$this->settings->set( $key, $value );
+		}
+	}
+
+	/**
+	 * @since 3.0
+	 */
+	public function reset() {
+
+		foreach ( $this->configurations as $key => $value ) {
+			$GLOBALS[$key] = $value;
+			$this->settings->set( $key, $value );
+		}
+
+		foreach ( $this->newKeys as $key ) {
+			unset( $GLOBALS[$key] );
+			$this->settings->delete( $key );
+		}
+	}
+
+}

--- a/tests/phpunit/TestEnvironment.php
+++ b/tests/phpunit/TestEnvironment.php
@@ -22,18 +22,17 @@ class TestEnvironment {
 	/**
 	 * @var ApplicationFactory
 	 */
-	private $applicationFactory = null;
+	private $applicationFactory;
 
 	/**
 	 * @var DataValueFactory
 	 */
-	private $dataValueFactory = null;
+	private $dataValueFactory;
 
 	/**
-	 * @var array
+	 * @var TestConfig
 	 */
-	private $configuration = [];
-	private $newKeys = [];
+	private $testConfig;
 
 	/**
 	 * @since 2.4
@@ -43,6 +42,7 @@ class TestEnvironment {
 	public function __construct( array $configuration = array() ) {
 		$this->applicationFactory = ApplicationFactory::getInstance();
 		$this->dataValueFactory = DataValueFactory::getInstance();
+		$this->testConfig = new TestConfig();
 
 		$this->withConfiguration( $configuration );
 	}
@@ -83,19 +83,7 @@ class TestEnvironment {
 	 * @return self
 	 */
 	public function withConfiguration( array $configuration = array() ) {
-
-		foreach ( $configuration as $key => $value ) {
-
-			if ( array_key_exists( $key, $GLOBALS ) ) {
-				$this->configuration[$key] = $GLOBALS[$key];
-			} else {
-				$this->newKeys[] = $key;
-			}
-
-			$GLOBALS[$key] = $value;
-			$this->applicationFactory->getSettings()->set( $key, $value );
-		}
-
+		$this->testConfig->set( $configuration );
 		return $this;
 	}
 
@@ -162,17 +150,7 @@ class TestEnvironment {
 	 * @since 2.4
 	 */
 	public function tearDown() {
-
-		foreach ( $this->configuration as $key => $value ) {
-			$GLOBALS[$key] = $value;
-			$this->applicationFactory->getSettings()->set( $key, $value );
-		}
-
-		foreach ( $this->newKeys as $newKey ) {
-			unset( $GLOBALS[ $newKey ] );
-			$this->applicationFactory->getSettings()->delete( $newKey );
-		}
-
+		$this->testConfig->reset();
 		$this->applicationFactory->clear();
 		$this->dataValueFactory->clear();
 	}


### PR DESCRIPTION
This PR is made in reference to: #2551 

This PR addresses or contains:

- Moves the config manipulation to `TestConfig`
- Allows for extended permitted settings (#2551) to define a callback so that string values can be interpret accordingly

This PR includes:
- [ ] Tests (unit/integration)
- [x] CI build passed