### PR TITLE
Add like:/nlike: comparator, refs 1481, 2489, 2536

### DIFF
--- a/DefaultSettings.php
+++ b/DefaultSettings.php
@@ -464,21 +464,33 @@ return array(
 										// Example with namespaces: 	'smwgQDefaultNamespaces' => array(NS_MAIN, NS_FILE),
 
 	###
-	# List of comparator characters supported by queries, separated by '|', for use in a regex.
+	# List of comparator characters
 	#
-	# Available entries:
-	#  	< (smaller than) if $smwStrictComparators is false, it's actually smaller than or equal to
-	#  	> (greater than) if $smwStrictComparators is false, it's actually bigger than or equal to
-	#  	! (unequal to)
-	#  	~ (pattern with '*' as wildcard, only for Type:String)
-	#  	!~ (not a pattern with '*' as wildcard, only for Type:String, need to be placed before ! and ~ to work correctly)
-	#  	≤ (smaller than or equal to)
-	#  	≥ (greater than or equal to)
+	# Comparators supported by queries with available entries being:
 	#
-	# If unsupported comparators are used, they are treated as part of the queried value
+	#  < (smaller than) if $smwStrictComparators is false, it's actually smaller
+	#    than or equal to
+	#  > (greater than) if $smwStrictComparators is false, it's actually bigger
+	#    than or equal to
+	#  ! (unequal to)
+	#  ~ (pattern with '*' as wildcard)
+	#  !~ (not a pattern with '*' as wildcard, only for Type:String, need to be
+	#    placed before ! and ~ to work correctly)
+	#  ≤ (smaller than or equal to)
+	#  ≥ (greater than or equal to)
 	#
+	# Extra compartors that in case of an enabled full-text index uses the primary
+	# LIKE/NLIKE match operation with operators being:
+	#
+	#  like: to express LIKE use
+	#  nlike: to express NLIKE use
+	#
+	# If unsupported comparators are used, they are treated as part of the
+	# queried value.
+	#
+	# @since 1.0
 	##
-	'smwgQComparators' => '<|>|!~|!|~|≤|≥|<<|>>',
+	'smwgQComparators' => '<|>|!~|!|~|≤|≥|<<|>>|~=|like:|nlike:',
 	##
 
 	###

--- a/includes/dataitems/SMW_DI_URI.php
+++ b/includes/dataitems/SMW_DI_URI.php
@@ -46,11 +46,11 @@ class SMWDIUri extends SMWDataItem {
 	 *
 	 * @todo Implement more validation here.
 	 */
-	public function __construct( $scheme, $hierpart, $query, $fragment ) {
-		if ( ( $scheme === '' ) || ( preg_match( '/[^a-zA-Z]/u', $scheme ) ) ) {
+	public function __construct( $scheme, $hierpart, $query, $fragment, $strict = true ) {
+		if ( $strict && ( ( $scheme === '' ) || ( preg_match( '/[^a-zA-Z]/u', $scheme ) ) ) ) {
 			throw new DataItemException( "Illegal URI scheme \"$scheme\"." );
 		}
-		if ( $hierpart === '' ) {
+		if ( $strict && $hierpart === '' ) {
 			throw new DataItemException( "Illegal URI hierpart \"$hierpart\"." );
 		}
 		$this->m_scheme   = $scheme;

--- a/includes/datavalues/SMW_DV_URI.php
+++ b/includes/datavalues/SMW_DV_URI.php
@@ -172,7 +172,7 @@ class SMWURIValue extends SMWDataValue {
 
 		// Now create the URI data item:
 		try {
-			$this->m_dataitem = new SMWDIUri( $scheme, $hierpart, $query, $fragment, $this->m_typeid );
+			$this->m_dataitem = new SMWDIUri( $scheme, $hierpart, $query, $fragment, !$this->getOption( self::OPT_QUERY_CONTEXT ) );
 		} catch ( SMWDataItemException $e ) {
 			$this->addErrorMsg( array( 'smw_baduri', $this->m_wikitext ) );
 		}

--- a/src/Defines.php
+++ b/src/Defines.php
@@ -89,6 +89,8 @@ define( 'SMW_CMP_LIKE', 5 ); // Matches only datavalues that are LIKE the given 
 define( 'SMW_CMP_NLKE', 6 ); // Matches only datavalues that are not LIKE the given value.
 define( 'SMW_CMP_LESS', 7 ); // Matches only datavalues that are less than the given value.
 define( 'SMW_CMP_GRTR', 8 ); // Matches only datavalues that are greater than the given value.
+define( 'SMW_CMP_PRIM_LIKE', 20 ); // Native LIKE matches (in disregards of an existing full-text index)
+define( 'SMW_CMP_PRIM_NLKE', 21 ); // Native NLIKE matches (in disregards of an existing full-text index)
 /**@}*/
 
 /**@{

--- a/src/Query/QueryComparator.php
+++ b/src/Query/QueryComparator.php
@@ -155,8 +155,11 @@ class QueryComparator {
 
 	private function getEnabledComparators( $comparatorList, $strictComparators ) {
 
-		// Note: Comparators that contain other comparators at the beginning of the string need to be at beginning of the array.
+		// Note: Comparators that contain other comparators at the beginning of
+		// the string need to be at beginning of the array.
 		$comparators = array(
+			'like:' => SMW_CMP_PRIM_LIKE,
+			'nlike:' => SMW_CMP_PRIM_NLKE,
 			'!~' => SMW_CMP_NLKE,
 			'<<' => SMW_CMP_LESS,
 			'>>' => SMW_CMP_GRTR,

--- a/src/SQLStore/QueryEngine/DescriptionInterpreters/ComparatorMapper.php
+++ b/src/SQLStore/QueryEngine/DescriptionInterpreters/ComparatorMapper.php
@@ -33,23 +33,21 @@ class ComparatorMapper {
 			SMW_CMP_GEQ  => '>=',
 			SMW_CMP_NEQ  => '!=',
 			SMW_CMP_LIKE => ' LIKE ',
-			SMW_CMP_NLKE => ' NOT LIKE '
+			SMW_CMP_PRIM_LIKE => ' LIKE ',
+			SMW_CMP_NLKE => ' NOT LIKE ',
+			SMW_CMP_PRIM_NLKE => ' NOT LIKE '
 		);
 
 		$comparator = $description->getComparator();
 
 		if ( !isset( $comparatorMap[$comparator] ) ) {
-			throw new RuntimeException( "Unsupported comparator '" . $comparator . "' in value description." );
+			throw new RuntimeException( "Unsupported comparator $comparator in value description." );
 		}
 
-		if ( $comparator === SMW_CMP_LIKE || $comparator === SMW_CMP_NLKE ) {
+		if ( $comparator === SMW_CMP_LIKE || $comparator === SMW_CMP_NLKE || $comparator === SMW_CMP_PRIM_LIKE || $comparator === SMW_CMP_PRIM_NLKE ) {
 
 			if ( $description->getDataItem() instanceof DIUri ) {
-				$value = str_replace( array( 'http://', 'https://', '%2A' ), array( '', '', '*' ), $value );
-			}
-
-			if ( $value !== '' && $value{0} === '=' ) {
-				$value = substr( $value, 1 );
+				$value = str_replace( array( 'http://', 'https://', '%2A' ), array( '*', '*', '*' ), $value );
 			}
 
 			// Escape to prepare string matching:

--- a/src/SQLStore/QueryEngine/Fulltext/MySQLValueMatchConditionBuilder.php
+++ b/src/SQLStore/QueryEngine/Fulltext/MySQLValueMatchConditionBuilder.php
@@ -42,10 +42,6 @@ class MySQLValueMatchConditionBuilder extends ValueMatchConditionBuilder {
 
 		if ( $matchableText && ( $comparator === SMW_CMP_LIKE || $comparator === SMW_CMP_NLKE ) ) {
 
-			if ( $matchableText !== '' && $matchableText{0} === '=' ) {
-				return false;
-			}
-
 			// http://dev.mysql.com/doc/refman/5.7/en/fulltext-boolean.html
 			// innodb_ft_min_token_size and innodb_ft_max_token_size are used
 			// for InnoDB search indexes. ft_min_word_len and ft_max_word_len

--- a/tests/phpunit/Integration/JSONScript/TestCases/q-0907.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/q-0907.json
@@ -1,5 +1,5 @@
 {
-	"description": "Test `_txt` with enabled `SMW_FIELDT_CHAR_LONG` (#1912, `smwgFieldTypeFeatures`)",
+	"description": "Test `_txt`/`_uri` with enabled `SMW_FIELDT_CHAR_LONG | SMW_FIELDT_CHAR_NOCASE` (#1912, #2499, `smwgFieldTypeFeatures`)",
 	"setup": [
 		{
 			"namespace": "SMW_NS_PROPERTY",

--- a/tests/phpunit/Integration/JSONScript/TestCases/q-0908.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/q-0908.json
@@ -1,0 +1,194 @@
+{
+	"description": "Test `_wpg`/`_txt`/`_uri` on enabled `SMW_FIELDT_CHAR_LONG | SMW_FIELDT_CHAR_NOCASE` with `like:/nlike:` (#1912, #2499, `smwgFieldTypeFeatures`, `smwgSparqlQFeatures`)",
+	"setup": [
+		{
+			"namespace": "SMW_NS_PROPERTY",
+			"page": "Has page",
+			"contents": "[[Has type::page]]"
+		},
+		{
+			"namespace": "SMW_NS_PROPERTY",
+			"page": "Has text",
+			"contents": "[[Has type::Text]]"
+		},
+		{
+			"namespace": "SMW_NS_PROPERTY",
+			"page": "Has url",
+			"contents": "[[Has type::URL]]"
+		},
+		{
+			"page": "Example/Q0908/0",
+			"contents": "[[Category:Q0908]] [[Has page::Some title]] [[Has text::Some title]] [[Has url::http://example.org/some title]] {{#subobject: |Has page=SOME title |Has text=SOME title |Has url=http://example.org/SOME title |@category=Q0908 }}"
+		},
+		{
+			"page": "Example/Q0908/1",
+			"contents": "[[Category:Q0908]] [[Has page::Some title WiTH a VaLUE]] {{#subobject: |Has page=SOME title WITH A value |@category=Q0908 }}"
+		},
+		{
+			"page": "Example/Q0908/2",
+			"contents": "[[Category:Q0908]] [[Has text::Some title WiTH a VaLUE]] {{#subobject: |Has text=SOME title WITH A value |@category=Q0908 }}"
+		},
+		{
+			"page": "Example/Q0908/3",
+			"contents": "[[Category:Q0908]] [[Has url::http://example.org/Some title WiTH a VaLUE]] {{#subobject: |Has url=http://example.org/SOME title WITH A value |@category=Q0908 }}"
+		}
+	],
+	"tests": [
+		{
+			"type": "query",
+			"about": "#0 (on _wpg, like:)",
+			"condition": "[[Category:Q0908]] [[Has page::like:some title with a value]]",
+			"printouts": [],
+			"parameters": {
+				"limit": "10"
+			},
+			"assert-queryresult": {
+				"count": 2,
+				"results": [
+					"Example/Q0908/1#0##",
+					"Example/Q0908/1#0##_7a94494466265fb10b60311ce51a94c4"
+				]
+			}
+		},
+		{
+			"type": "query",
+			"about": "#1 (on _wpg, nlike:)",
+			"condition": "[[Category:Q0908]] [[Has page::nlike:some title with a value]]",
+			"printouts": [],
+			"parameters": {
+				"limit": "10"
+			},
+			"assert-queryresult": {
+				"count": 2,
+				"results": [
+					"Example/Q0908/0#0##",
+					"Example/Q0908/0#0##_c9c37230f08043b1f7244ac8255daeea"
+				]
+			}
+		},
+		{
+			"type": "query",
+			"about": "#2 (on _txt, equal)",
+			"condition": "[[Category:Q0908]] [[Has text::some title with a value]]",
+			"printouts": [],
+			"parameters": {
+				"limit": "10"
+			},
+			"assert-queryresult": {
+				"count": 2,
+				"results": [
+					"Example/Q0908/2#0##",
+					"Example/Q0908/2#0##_1a3b9a0c0f0ab867f34b3ff0ff5c306d"
+				]
+			}
+		},
+		{
+			"type": "query",
+			"about": "#3 (on _txt, like:)",
+			"condition": "[[Category:Q0908]] [[Has text::like:some title with a value]]",
+			"printouts": [],
+			"parameters": {
+				"limit": "10"
+			},
+			"assert-queryresult": {
+				"count": 2,
+				"results": [
+					"Example/Q0908/2#0##",
+					"Example/Q0908/2#0##_1a3b9a0c0f0ab867f34b3ff0ff5c306d"
+				]
+			}
+		},
+		{
+			"type": "query",
+			"about": "#4 (on _txt, nlike:)",
+			"condition": "[[Category:Q0908]] [[Has text::nlike:some title with a value]]",
+			"printouts": [],
+			"parameters": {
+				"limit": "10"
+			},
+			"assert-queryresult": {
+				"count": 2,
+				"results": [
+					"Example/Q0908/0#0##",
+					"Example/Q0908/0#0##_c9c37230f08043b1f7244ac8255daeea"
+				]
+			}
+		},
+		{
+			"type": "query",
+			"about": "#5 (on _uri, equal)",
+			"skip-on": {
+				"fuseki": "Using lcase on _uri/equal is not supported",
+				"sesame": "Using lcase on _uri/equal is not supported",
+				"blazegraph": "Using lcase on _uri/equal is not supported",
+				"virtuoso": "Using lcase on _uri/equal is not supported"
+			},
+			"condition": "[[Category:Q0908]] [[Has url::http://example.org/some title with a value]]",
+			"printouts": [],
+			"parameters": {
+				"limit": "10"
+			},
+			"assert-queryresult": {
+				"count": 2,
+				"results": [
+					"Example/Q0908/3#0#",
+					"Example/Q0908/3#0##_e129319fa43ae1aa35ef6ffd91d323ed"
+				]
+			}
+		},
+		{
+			"type": "query",
+			"about": "#6 (on _uri, like:)",
+			"condition": "[[Category:Q0908]] [[Has url::like:http://example.org/some title with a value]]",
+			"printouts": [],
+			"parameters": {
+				"limit": "10"
+			},
+			"assert-queryresult": {
+				"count": 2,
+				"results": [
+					"Example/Q0908/3#0#",
+					"Example/Q0908/3#0##_e129319fa43ae1aa35ef6ffd91d323ed"
+				]
+			}
+		},
+		{
+			"type": "query",
+			"about": "#7 (on _uri, nlike:)",
+			"condition": "[[Category:Q0908]] [[Has url::nlike:http://example.org/some title with a value]]",
+			"printouts": [],
+			"parameters": {
+				"limit": "10"
+			},
+			"assert-queryresult": {
+				"count": 2,
+				"results": [
+					"Example/Q0908/0#0##",
+					"Example/Q0908/0#0##_c9c37230f08043b1f7244ac8255daeea"
+				]
+			}
+		}
+	],
+	"settings": {
+		"smwgNamespacesWithSemanticLinks": {
+			"NS_MAIN": true,
+			"SMW_NS_PROPERTY": true
+		},
+		"smwgSparqlQFeatures": [
+			"SMW_SPARQL_QF_NOCASE"
+		],
+		"smwgFieldTypeFeatures": [
+			"SMW_FIELDT_CHAR_NOCASE",
+			"SMW_FIELDT_CHAR_LONG"
+		]
+	},
+	"meta": {
+		"skip-on": {
+			"postgres": "Postgres requires \"citext\" otherwise it returns with \"Error: 42704 ERROR:  type \"citext\" does not exist\"",
+			"sqlite": "NOCASE is not supported"
+		},
+		"version": "2",
+		"is-incomplete": false,
+		"debug": false
+	}
+}

--- a/tests/phpunit/Unit/Query/QueryComparatorTest.php
+++ b/tests/phpunit/Unit/Query/QueryComparatorTest.php
@@ -119,6 +119,18 @@ class QueryComparatorTest extends \PHPUnit_Framework_TestCase {
 			SMW_CMP_LESS
 		);
 
+		$provider[] = array(
+			'like:Foo',
+			'Foo',
+			SMW_CMP_PRIM_LIKE
+		);
+
+		$provider[] = array(
+			'nlike:Foo',
+			'Foo',
+			SMW_CMP_PRIM_NLKE
+		);
+
 		return $provider;
 	}
 
@@ -157,6 +169,19 @@ class QueryComparatorTest extends \PHPUnit_Framework_TestCase {
 		$provider[] = array(
 			'<<someThing',
 			SMW_CMP_LESS,
+			true
+		);
+
+
+		$provider[] = array(
+			'like:someThing',
+			SMW_CMP_PRIM_LIKE,
+			true
+		);
+
+		$provider[] = array(
+			'nlike:someThing',
+			SMW_CMP_PRIM_NLKE,
 			true
 		);
 

--- a/tests/phpunit/Unit/SPARQLStore/QueryEngine/CompoundConditionBuilderTest.php
+++ b/tests/phpunit/Unit/SPARQLStore/QueryEngine/CompoundConditionBuilderTest.php
@@ -804,6 +804,11 @@ class CompoundConditionBuilderTest extends \PHPUnit_Framework_TestCase {
 
 		$instance->expects( $this->at( 0 ) )
 			->method( 'canUseQFeature' )
+			->with( $this->equalTo( SMW_SPARQL_QF_NOCASE ) )
+			->will( $this->returnValue( false ) );
+
+		$instance->expects( $this->at( 1 ) )
+			->method( 'canUseQFeature' )
 			->with( $this->equalTo( SMW_SPARQL_QF_REDI ) )
 			->will( $this->returnValue( true ) );
 
@@ -854,6 +859,11 @@ class CompoundConditionBuilderTest extends \PHPUnit_Framework_TestCase {
 			->getMock();
 
 		$instance->expects( $this->at( 0 ) )
+			->method( 'canUseQFeature' )
+			->with( $this->equalTo( SMW_SPARQL_QF_NOCASE ) )
+			->will( $this->returnValue( false ) );
+
+		$instance->expects( $this->at( 1 ) )
 			->method( 'canUseQFeature' )
 			->with( $this->equalTo( SMW_SPARQL_QF_REDI ) )
 			->will( $this->returnValue( true ) );

--- a/tests/phpunit/Unit/SQLStore/QueryEngine/DescriptionInterpreters/ComparatorMapperTest.php
+++ b/tests/phpunit/Unit/SQLStore/QueryEngine/DescriptionInterpreters/ComparatorMapperTest.php
@@ -73,7 +73,9 @@ class ComparatorMapperTest extends \PHPUnit_Framework_TestCase {
 		$provider[] = array( SMW_CMP_NEQ,  'Foo%_*?', array( 'comparator' => '!=', 'value' => 'Foo%_*?' ) );
 
 		$provider[] = array( SMW_CMP_LIKE, 'Foo%_*?\\', array( 'comparator' => ' LIKE ',     'value' => 'Foo\%\_%_\\\\' ) );
+		$provider[] = array( SMW_CMP_PRIM_LIKE, 'Foo%_*?\\', array( 'comparator' => ' LIKE ',     'value' => 'Foo\%\_%_\\\\' ) );
 		$provider[] = array( SMW_CMP_NLKE, 'Foo%_*?\\', array( 'comparator' => ' NOT LIKE ', 'value' => 'Foo\%\_%_\\\\' ) );
+		$provider[] = array( SMW_CMP_PRIM_NLKE, 'Foo%_*?\\', array( 'comparator' => ' NOT LIKE ', 'value' => 'Foo\%\_%_\\\\' ) );
 
 		return $provider;
 	}


### PR DESCRIPTION
This PR is made in reference to: #1481, #2489, #2536

This PR addresses or contains:

- `~/!~` uses a preferred matching approach depending on the environment (available and for an enabled full-text index with  a "MATCH ..." operation)
- `like:/nlike:` is introduced to always use the standard `LIKE` / `NOT LIKE` SQL syntax for a pattern match

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed
