### PR TITLE
SMWSql3SmwIds to use ProcessLruCache

### DIFF
--- a/includes/storage/SQLStore/SMW_SQLStore3.php
+++ b/includes/storage/SQLStore/SMW_SQLStore3.php
@@ -167,7 +167,7 @@ class SMWSQLStore3 extends SMWStore {
 	 */
 	public function __construct() {
 		$this->factory = new SQLStoreFactory( $this );
-		$this->smwIds = $this->factory->newIdTableManager();
+		$this->smwIds = $this->factory->newEntityIdManager();
 	}
 
 	/**

--- a/maintenance/rebuildData.php
+++ b/maintenance/rebuildData.php
@@ -102,6 +102,7 @@ class RebuildData extends \Maintenance {
 		$this->addOption( 'query', "<query> Will refresh only pages returned by a given query. Example: --query='[[Category:SomeCategory]]'", false, true );
 
 		$this->addOption( 'report-runtime', 'Report execution time and memory usage', false );
+		$this->addOption( 'report-poolcache', 'Report internal poolcache memory usage', false );
 		$this->addOption( 'no-cache', 'Sets the `wgMainCacheType` to none while running the script', false );
 		$this->addOption( 'debug', 'Sets global variables to support debug ouput while running the script', false );
 		$this->addOption( 'quiet', 'Do not give any output', false );
@@ -170,8 +171,9 @@ class RebuildData extends \Maintenance {
 
 		$maintenanceHelper->reset();
 
-		// Only for internal use
-		// $this->reportMessage( "\n" . ApplicationFactory::getInstance()->getInMemoryPoolCache()->getFormattedStats() . "\n" );
+		if ( $this->hasOption( 'report-poolcache' ) ) {
+			$this->reportMessage( "\n" . ApplicationFactory::getInstance()->getInMemoryPoolCache()->getStats( \SMW\Utils\StatsFormatter::FORMAT_JSON ) . "\n" );
+		}
 
 		return $result;
 	}

--- a/src/ProcessLruCache.php
+++ b/src/ProcessLruCache.php
@@ -1,0 +1,85 @@
+<?php
+
+namespace SMW;
+
+use RuntimeException;
+
+/**
+ * @license GNU GPL v2+
+ * @since 3.0
+ *
+ * @author mwjames
+ */
+class ProcessLruCache {
+
+	const POOLCACHE_ID = 'smw.process.cache';
+
+	/**
+	 * @var Cache[]
+	 */
+	private $caches = array();
+
+	/**
+	 * @since 3.0
+	 *
+	 * @param array $cache
+	 */
+	public function __construct( array $caches ) {
+		$this->caches = $caches;
+	}
+
+	/**
+	 * @since 3.0
+	 *
+	 * @param array $config
+	 *
+	 * @return self
+	 */
+	public static function newFromConfig( array $config ) {
+
+		$inMemoryPoolCache = ApplicationFactory::getInstance()->getInMemoryPoolCache();
+		$caches = array();
+
+		foreach ( $config as $id => $cacheSize ) {
+			$caches[$id] = $inMemoryPoolCache->getPoolCacheById( self::POOLCACHE_ID . '.' . $id, $cacheSize );
+		}
+
+		return new self( $caches );
+	}
+
+	/**
+	 * @since 3.0
+	 *
+	 * @param string $id
+	 *
+	 * @return Cache
+	 * @throws RuntimeException
+	 */
+	public function get( $id ) {
+
+		if ( isset( $this->caches[$id] ) ) {
+			return $this->caches[$id];
+		}
+
+		throw new RuntimeException( "$id is not registered" );
+	}
+
+	/**
+	 * @since 3.0
+	 */
+	public function reset() {
+
+		$inMemoryPoolCache = ApplicationFactory::getInstance()->getInMemoryPoolCache();
+		$caches = array();
+
+		foreach ( $this->caches as $id => $cache ) {
+			$stats = $cache->getStats();
+			$inMemoryPoolCache->resetPoolCacheById( self::POOLCACHE_ID . '.' . $id );
+			$caches[$id] = $inMemoryPoolCache->getPoolCacheById( self::POOLCACHE_ID . '.' . $id, $stats['max'] );
+		}
+
+		$this->caches = $caches;
+		unset( $caches );
+	}
+
+}

--- a/tests/phpunit/Unit/ProcessLruCacheTest.php
+++ b/tests/phpunit/Unit/ProcessLruCacheTest.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace SMW\Tests;
+
+use SMW\ProcessLruCache;
+use SMW\StringCondition;
+
+/**
+ * @covers \SMW\ProcessLruCache
+ * @group semantic-mediawiki
+ *
+ * @license GNU GPL v2+
+ * @since 3.0
+ *
+ * @author mwjames
+ */
+class ProcessLruCacheTest extends \PHPUnit_Framework_TestCase {
+
+	public function testCanConstruct() {
+
+		$this->assertInstanceOf(
+			ProcessLruCache::class,
+			new ProcessLruCache( [] )
+		);
+	}
+
+	public function testConstructWithConfig() {
+
+		$instance = ProcessLruCache::newFromConfig(
+			[
+				'Foo' => 100
+			]
+		);
+
+		$this->assertInstanceOf(
+			'Onoi\Cache\Cache',
+			$instance->get( 'Foo' )
+		);
+
+		$instance->reset();
+	}
+
+	public function testGetOnUnknownCacheThrowsException() {
+
+		$instance = new ProcessLruCache( [] );
+
+		$this->setExpectedException( '\RuntimeException' );
+		$instance->get( 'Foo' );
+	}
+
+}

--- a/tests/phpunit/Unit/SQLStore/SQLStoreFactoryTest.php
+++ b/tests/phpunit/Unit/SQLStore/SQLStoreFactoryTest.php
@@ -80,13 +80,13 @@ class SQLStoreFactoryTest extends \PHPUnit_Framework_TestCase {
 		);
 	}
 
-	public function testCanConstractIdTableManager() {
+	public function testCanConstractEntityIdManager() {
 
 		$instance = new SQLStoreFactory( new SMWSQLStore3() );
 
 		$this->assertInstanceOf(
 			'SMWSql3SmwIds',
-			$instance->newIdTableManager()
+			$instance->newEntityIdManager()
 		);
 	}
 
@@ -243,7 +243,7 @@ class SQLStoreFactoryTest extends \PHPUnit_Framework_TestCase {
 		);
 	}
 
-	public function testCanConstrucSqlEntityLookupResultFetcher() {
+	public function testCanConstructSqlEntityLookupResultFetcher() {
 
 		$instance = new SQLStoreFactory( $this->store );
 
@@ -253,7 +253,7 @@ class SQLStoreFactoryTest extends \PHPUnit_Framework_TestCase {
 		);
 	}
 
-	public function testCanConstrucPropertyStatisticsTable() {
+	public function testCanConstructPropertyStatisticsTable() {
 
 		$connection = $this->getMockBuilder( '\SMW\MediaWiki\Database' )
 			->disableOriginalConstructor()
@@ -268,6 +268,38 @@ class SQLStoreFactoryTest extends \PHPUnit_Framework_TestCase {
 		$this->assertInstanceOf(
 			'\SMW\SQLStore\PropertyStatisticsTable',
 			$instance->newPropertyStatisticsTable()
+		);
+	}
+
+	public function testCanConstructProcessLruCache() {
+
+		$instance = new SQLStoreFactory( $this->store );
+
+		$this->assertInstanceOf(
+			'\SMW\ProcessLruCache',
+			$instance->newProcessLruCache( array() )
+		);
+	}
+
+	public function testCanConstructIdMatchFinder() {
+
+		$cache = $this->getMockBuilder( '\Onoi\Cache\Cache' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$connection = $this->getMockBuilder( '\SMW\MediaWiki\Database' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$this->store->expects( $this->once() )
+			->method( 'getConnection' )
+			->will( $this->returnValue( $connection ) );
+
+		$instance = new SQLStoreFactory( $this->store );
+
+		$this->assertInstanceOf(
+			'\SMW\SQLStore\EntityStore\IdMatchFinder',
+			$instance->newIdMatchFinder( $cache )
 		);
 	}
 


### PR DESCRIPTION
This PR is made in reference to: #

This PR addresses or contains:

- Replace use of array caches with `ProcessLruCache` which uses a LRU approach instead of an arbitrary random size limit on behalf of an array

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed
