### PR TITLE
HtmlValidator check for CssSelectorConverter

### DIFF
--- a/tests/phpunit/Integration/JSONScript/JsonTestCaseScriptRunnerTest.php
+++ b/tests/phpunit/Integration/JSONScript/JsonTestCaseScriptRunnerTest.php
@@ -404,6 +404,10 @@ class JsonTestCaseScriptRunnerTest extends JsonTestCaseScriptRunner {
 				continue;
 			}
 
+			if ( !$this->parserHtmlTestCaseProcessor->canUse() ) {
+				$this->markTestIncomplete( 'The required resource for the ParserHtmlTestCaseProcessor/HtmlValidator is not available.' );
+			}
+
 			$this->parserHtmlTestCaseProcessor->process( $case );
 		}
 	}

--- a/tests/phpunit/Integration/JSONScript/ParserHtmlTestCaseProcessor.php
+++ b/tests/phpunit/Integration/JSONScript/ParserHtmlTestCaseProcessor.php
@@ -23,16 +23,18 @@ class ParserHtmlTestCaseProcessor extends \PHPUnit_Framework_TestCase {
 	private $htmlValidator;
 
 	/**
-	 * ParserHtmlTestCaseProcessor constructor.
-	 *
 	 * @param HtmlValidator $htmlValidator
 	 */
 	public function __construct( HtmlValidator $htmlValidator ) {
-
 		parent::__construct();
-
 		$this->htmlValidator = $htmlValidator;
+	}
 
+	/**
+	 * @return boolean
+	 */
+	public function canUse() {
+		return $this->htmlValidator->canUse();
 	}
 
 	/**

--- a/tests/phpunit/Utils/Validators/HtmlValidator.php
+++ b/tests/phpunit/Utils/Validators/HtmlValidator.php
@@ -13,7 +13,15 @@ use Symfony\Component\CssSelector\CssSelectorConverter;
  */
 class HtmlValidator extends \PHPUnit_Framework_Assert {
 
+	/**
+	 * @var array
+	 */
 	private $documentCache = [];
+
+	/**
+	 * @var null|boolean
+	 */
+	private $canUse;
 
 	/**
 	 * @param string $actual
@@ -24,6 +32,18 @@ class HtmlValidator extends \PHPUnit_Framework_Assert {
 		$document = $this->getDomDocumentFromHtmlFragment( $actual );
 
 		self::assertTrue( $document !== false, "Failed test `{$message}` (assertion HtmlIsValid) for $actual" );
+	}
+
+	/**
+	 * @return boolean
+	 */
+	public function canUse() {
+
+		if ( $this->canUse === null ) {
+			$this->canUse = class_exists( '\Symfony\Component\CssSelector\CssSelectorConverter' );
+		}
+
+		return $this->canUse;
 	}
 
 	/**


### PR DESCRIPTION
This PR is made in reference to: #2540

This PR addresses or contains:

Avoids things like "Error: Class 'Symfony\Component\CssSelector\CssSelectorConverter' not found" where the dependency isn't available.

```
1) SMW\Tests\Integration\JSONScript\JsonTestCaseScriptRunnerTest::executeTestCases with data set "f-0401.json" ('...\exte...1.json')
Error: Class 'Symfony\Component\CssSelector\CssSelectorConverter' not found

...\extensions\SemanticMediaWiki\tests\phpunit\Utils\Validators\HtmlValidator.php:80
...\extensions\SemanticMediaWiki\tests\phpunit\Integration\JSONScript\ParserHtmlTestCaseProcessor.php:76
...\extensions\SemanticMediaWiki\tests\phpunit\Integration\JSONScript\ParserHtmlTestCaseProcessor.php:51
...\extensions\SemanticMediaWiki\tests\phpunit\Integration\JSONScript\JsonTestCaseScriptRunnerTest.php:407
...\extensions\SemanticMediaWiki\tests\phpunit\Integration\JSONScript\JsonTestCaseScriptRunnerTest.php:171
...\extensions\SemanticMediaWiki\tests\phpunit\JsonTestCaseScriptRunner.php:179
...\extensions\SemanticMediaWiki\tests\phpunit\MwDBaseUnitTestCase.php:131
...\maintenance\doMaintenance.php:111
```

This PR includes:
- [ ] Tests (unit/integration)
- [x] CI build passed
