### PR TITLE
Fix #2567: Start template parameters on new line

### DIFF
--- a/src/MediaWiki/Renderer/WikitextTemplateRenderer.php
+++ b/src/MediaWiki/Renderer/WikitextTemplateRenderer.php
@@ -40,7 +40,7 @@ class WikitextTemplateRenderer {
 		$this->template .= '{{'. $templateName;
 
 		foreach ( $this->fields as $key => $value ) {
-			$this->template .= "|$key=$value";
+			$this->template .= "\n|$key=$value";
 		}
 
 		$this->template .= '}}';

--- a/tests/phpunit/Integration/JSONScript/TestCases/f-0803.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/f-0803.json
@@ -1,5 +1,5 @@
 {
-	"description": "Test `format=template` with `sep`/`named args`/`template arguments` (#972, #2022)",
+	"description": "Test `format=template` with `sep`/`named args`/`template arguments` (#972, #2022, #2567)",
 	"setup": [
 		{
 			"namespace": "SMW_NS_PROPERTY",
@@ -36,6 +36,10 @@
 			"contents": "{{#subobject: |@category=F0803 |Has text=123 |Has text=456 }} {{#subobject: |@category=F0803 |Has text=abc }}"
 		},
 		{
+			"page": "Example/F0803/2",
+			"contents": "[[Category:F0803]][[Has text::foo\n=bar]]"
+		},
+		{
 			"page": "Example/F0803/Q.1",
 			"contents": "{{#ask: [[Category:F0803]] |?Has text |format=template |template=Example/F0803/Sep |mainlabel=main |named args=yes |link=none |sep= &#32;&bull;&#32; |valuesep= &#32;&bull;&#32; |sort=Has text |order=asc }}"
 		},
@@ -66,6 +70,10 @@
 		{
 			"page": "Example/F0803/Q.8",
 			"contents": "{{#ask: [[Category:F0803]] |?Has text |format=template |template=Example/F0803/Sep |mainlabel=main |named args=yes |link=none |sep= &#32;&bull;&#32; |sort=Has text |order=asc }}"
+		},
+		{
+			"page": "Example/F0803/Q.9",
+			"contents": "{{#ask: [[Category:F0803]] |?Has text |format=template |template=Example/F0803/Sep |named args=yes |sort=Has text |order=asc }}"
 		}
 	],
 	"tests": [
@@ -146,6 +154,16 @@
 			"assert-output": {
 				"to-contain": [
 					"123, 456&#32;&#8226;&#32;abc"
+				]
+			}
+		},
+		{
+			"type": "parser",
+			"about": "#8 (#2567)",
+			"subject": "Example/F0803/Q.9",
+			"assert-output": {
+				"to-contain": [
+					"123, 456abcfoo\n=bar"
 				]
 			}
 		}

--- a/tests/phpunit/Unit/MediaWiki/Renderer/HtmlTemplateRendererTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Renderer/HtmlTemplateRendererTest.php
@@ -41,7 +41,7 @@ class HtmlTemplateRendererTest extends \PHPUnit_Framework_TestCase {
 		$parser->expects( $this->once() )
 			->method( 'recursiveTagParse' )
 			->with(
-				$this->stringContains( '{{Bar|property=Foo|value=42}}{{Foobaz|property=Bar|value=Foo}}' ) );
+				$this->stringContains( "{{Bar\n|property=Foo\n|value=42}}{{Foobaz\n|property=Bar\n|value=Foo}}" ) );
 
 		$instance = new HtmlTemplateRenderer(
 			new WikitextTemplateRenderer(),

--- a/tests/phpunit/Unit/MediaWiki/Renderer/WikitextTemplateRendererTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Renderer/WikitextTemplateRendererTest.php
@@ -42,7 +42,7 @@ class WikitextTemplateRendererTest extends \PHPUnit_Framework_TestCase {
 		$instance->packFieldsForTemplate( 'Foobaz' );
 
 		$this->assertEquals(
-			'{{Bar|property=Foo|value=42}}{{Foobaz|property=Bar|value=Foo}}',
+			"{{Bar\n|property=Foo\n|value=42}}{{Foobaz\n|property=Bar\n|value=Foo}}",
 			$instance->render()
 		);
 


### PR DESCRIPTION
This PR is made in reference to: #2567 

This PR addresses or contains:
- Start each parameter of the template calls created by the `template` format  on a new line

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed

Fixes #2567