### PR TITLE
Tidy (ParserData)

### DIFF
--- a/src/InTextAnnotationParser.php
+++ b/src/InTextAnnotationParser.php
@@ -160,10 +160,7 @@ class InTextAnnotationParser {
 
 		if ( $this->isEnabledNamespace ) {
 			$this->parserData->getOutput()->addModules( $this->getModules() );
-
-			if ( method_exists( $this->parserData->getOutput(), 'recordOption' ) ) {
-				$this->parserData->getOutput()->recordOption( 'userlang' );
-			}
+			$this->parserData->addExtraParserKey( 'userlang' );
 		}
 
 		$this->parserData->pushSemanticDataToParserOutput();
@@ -354,7 +351,7 @@ class InTextAnnotationParser {
 			if (
 				$this->isEnabledNamespace &&
 				$this->isAnnotation &&
-				$this->parserData->canModifySemanticData() ) {
+				$this->parserData->canUse() ) {
 				$this->parserData->addDataValue( $dataValue );
 			}
 		}

--- a/src/ParserFunctions/SetParserFunction.php
+++ b/src/ParserFunctions/SetParserFunction.php
@@ -85,7 +85,7 @@ class SetParserFunction {
 						$subject
 					);
 
-				if ( $this->parserData->canModifySemanticData() ) {
+				if ( $this->parserData->canUse() ) {
 					$this->parserData->addDataValue( $dataValue );
 				}
 

--- a/src/ParserFunctions/SubobjectParserFunction.php
+++ b/src/ParserFunctions/SubobjectParserFunction.php
@@ -136,9 +136,9 @@ class SubobjectParserFunction {
 	public function parse( ParserParameterProcessor $parameters ) {
 
 		if (
-			$this->parserData->canModifySemanticData() &&
+			$this->parserData->canUse() &&
 			$this->addDataValuesToSubobject( $parameters ) &&
-			!$this->subobject->getSemanticData()->isEmpty()  ) {
+			$this->subobject->getSemanticData()->isEmpty() === false ) {
 			$this->parserData->getSemanticData()->addSubobject( $this->subobject );
 		}
 

--- a/tests/phpunit/Unit/ParserDataTest.php
+++ b/tests/phpunit/Unit/ParserDataTest.php
@@ -229,28 +229,6 @@ class ParserDataTest extends \PHPUnit_Framework_TestCase {
 		);
 	}
 
-	public function testSetGetForNonExtensionDataLegacyAccess() {
-
-		$title = Title::newFromText( __METHOD__ );
-		$parserOutput = new ParserOutput();
-
-		$instance = $this->getMockBuilder( '\SMW\ParserData' )
-			->setConstructorArgs( array( $title, $parserOutput ) )
-			->setMethods( array( 'hasExtensionData' ) )
-			->getMock();
-
-		$instance->expects( $this->any() )
-			->method( 'hasExtensionData' )
-			->will( $this->returnValue( false ) );
-
-		$instance->pushSemanticDataToParserOutput();
-
-		$this->assertInstanceOf(
-			'\SMW\SemanticData',
-			$instance->getSemanticData()
-		);
-	}
-
 	public function testUpdateStore() {
 
 		$idTable = $this->getMockBuilder( '\stdClass' )
@@ -418,7 +396,7 @@ class ParserDataTest extends \PHPUnit_Framework_TestCase {
 		$instance->addLimitReport( 'Foo', 'Bar' );
 	}
 
-	public function testCanModifySemanticData() {
+	public function testIsBlocked() {
 
 		$title = $this->getMockBuilder( 'Title' )
 			->disableOriginalConstructor()
@@ -430,24 +408,19 @@ class ParserDataTest extends \PHPUnit_Framework_TestCase {
 
 		$parserOutput = new ParserOutput();
 
-		// FIXME 1.21+
-		if ( !method_exists( $parserOutput, 'getExtensionData' ) ) {
-			$this->markTestSkipped( 'getExtensionData is not available.' );
-		}
-
 		$instance = new ParserData(
 			$title,
 			$parserOutput
 		);
 
-		$this->assertTrue(
-			$instance->canModifySemanticData()
+		$this->assertFalse(
+			$instance->isBlocked()
 		);
 
-		$parserOutput->setExtensionData( 'smw-blockannotation', true );
+		$parserOutput->setExtensionData( ParserData::ANNOTATION_BLOCK, true );
 
-		$this->assertFalse(
-			$instance->canModifySemanticData()
+		$this->assertTrue(
+			$instance->isBlocked()
 		);
 	}
 
@@ -497,6 +470,10 @@ class ParserDataTest extends \PHPUnit_Framework_TestCase {
 			->disableOriginalConstructor()
 			->getMock();
 
+		$parserOutput->expects( $this->once() )
+			->method( 'recordOption' )
+			->with( $this->stringContains( 'userlang' ) );
+
 		$instance = new ParserData(
 			$title,
 			$parserOutput
@@ -504,6 +481,7 @@ class ParserDataTest extends \PHPUnit_Framework_TestCase {
 
 		$instance->setParserOptions( $parserOptions );
 		$instance->addExtraParserKey( 'Foo' );
+		$instance->addExtraParserKey( 'userlang' );
 	}
 
 }


### PR DESCRIPTION
This PR is made in reference to: #2515

This PR addresses or contains:

- For parser keys 'userlang', 'dateformat' use `ParserOutput::recordOption` to avoid things like `idhash:19989-0!canonical!userlang!dateformat!userlang!dateformat!userlang!dateformat!userlang!dateformat`
- Remove legacy check on `ParserOutput::getExtensionData`

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed
