### PR TITLE
Add PostProcHandler and `queryref` update task, refs 1696

### DIFF
--- a/i18n/en.json
+++ b/i18n/en.json
@@ -558,5 +558,6 @@
 	"smw-format-datatable-sortascending": ": activate to sort column ascending",
 	"smw-format-datatable-sortdescending": ": activate to sort column descending",
 	"smw-category-invalid-redirect-target": "Category \"$1\" contains an invalid redirect target to a non-category namespace.",
-	"smw-parser-function-expensive-execution-limit": "The parser function has reached the limit for expensive executions (see [https://www.semantic-mediawiki.org/wiki/Help:$smwgQExpensiveExecutionLimit $smwgQExpensiveExecutionLimit])."
+	"smw-parser-function-expensive-execution-limit": "The parser function has reached the limit for expensive executions (see [https://www.semantic-mediawiki.org/wiki/Help:$smwgQExpensiveExecutionLimit $smwgQExpensiveExecutionLimit]).",
+	"smw-postproc-queryref": "The page was marked as to be refreshed due to some required post processing."
 }

--- a/includes/Setup.php
+++ b/includes/Setup.php
@@ -190,6 +190,7 @@ final class Setup {
 		}
 
 		$this->globalVars['wgAPIModules']['smwinfo'] = '\SMW\MediaWiki\Api\Info';
+		$this->globalVars['wgAPIModules']['smwtask'] = '\SMW\MediaWiki\Api\Task';
 		$this->globalVars['wgAPIModules']['ask']     = '\SMW\MediaWiki\Api\Ask';
 		$this->globalVars['wgAPIModules']['askargs'] = '\SMW\MediaWiki\Api\AskArgs';
 		$this->globalVars['wgAPIModules']['browsebysubject'] = '\SMW\MediaWiki\Api\BrowseBySubject';

--- a/res/Resources.php
+++ b/res/Resources.php
@@ -186,7 +186,7 @@ return array(
 		'dependencies' => 'jquery.ui.autocomplete',
 		'targets' => array( 'mobile', 'desktop' )
 	),
-	
+
 	// Purge resources
 	'ext.smw.purge' => $moduleTemplate + array(
 		'scripts' => 'smw/util/ext.smw.util.purge.js',
@@ -199,7 +199,20 @@ return array(
 			'desktop'
 		)
 	),
-	
+
+	// Postproc resources
+	'ext.smw.postproc' => $moduleTemplate + array(
+		'scripts' => 'smw/util/ext.smw.util.postproc.js',
+		'position' => 'top',
+		'messages' => array(
+			'smw-postproc-queryref'
+		),
+		'targets' => array(
+			'mobile',
+			'desktop'
+		)
+	),
+
 	// Special:Ask
 	'ext.smw.ask' => $moduleTemplate + array(
 		'scripts' => 'smw/special/ext.smw.special.ask.js',

--- a/res/smw/util/ext.smw.util.postproc.js
+++ b/res/smw/util/ext.smw.util.postproc.js
@@ -1,0 +1,51 @@
+/*!
+ * This file is part of the Semantic MediaWiki Reload module
+ * @see https://www.semantic-mediawiki.org/wiki/Help:Purge
+ *
+ * @since 3.0
+ *
+ * @file
+ * @ingroup SMW
+ *
+ * @licence GNU GPL v2+
+ * @author mwjames
+ */
+
+/*global jQuery, mediaWiki, smw */
+/*jslint white: true */
+
+( function( $, mw ) {
+
+	'use strict';
+
+	/**
+	 * @since 3.0
+	 */
+	mw.loader.using( [ 'mediawiki.api', 'mediawiki.notify' ] ).then( function () {
+
+		$( '.smw-postproc' ).each( function() {
+
+			var queryRef = $( this ).data( 'queryref' );
+
+			if ( queryRef !== '' ) {
+				mw.notify( mw.msg( 'smw-postproc-queryref' ), { type: 'info', autoHide: false } );
+
+				var postArgs = {
+					'action': 'smwtask',
+					'subject': $( this ).data( 'subject' ),
+					'taskType': 'queryref',
+					'taskParams': JSON.stringify( queryRef )
+				};
+
+				new mw.Api().postWithToken( 'csrf', postArgs ).then( function ( data ) {
+					location.reload( true );
+				}, function () {
+					// Do nothing
+				} );
+			};
+
+		} );
+
+	} );
+
+}( jQuery, mediaWiki ) );

--- a/src/MediaWiki/Api/Task.php
+++ b/src/MediaWiki/Api/Task.php
@@ -1,0 +1,171 @@
+<?php
+
+namespace SMW\MediaWiki\Api;
+
+use ApiBase;
+use SMW\MediaWiki\Jobs\UpdateJob;
+use SMW\ApplicationFactory;
+use SMW\DIWikiPage;
+
+/**
+ * Module to support various tasks initiate using the API interface
+ *
+ * @license GNU GPL v2+
+ * @since 3.0
+ *
+ * @author mwjames
+ */
+class Task extends ApiBase {
+
+	/**
+	 * @see ApiBase::execute
+	 */
+	public function execute() {
+
+		$params = $this->extractRequestParams();
+		$results = array();
+
+		if ( $params['taskType'] === 'queryref' ) {
+			$results = $this->handleQueryRefTask( $params );
+		}
+
+		$this->getResult()->addValue(
+			null,
+			'task',
+			$results
+		);
+	}
+
+	private function handleQueryRefTask( $params ) {
+
+		if ( $params['taskParams'] === '' ) {
+			return ['done' => false ];
+		}
+
+		$title = DIWikiPage::doUnserialize( $params['subject'] )->getTitle();
+
+		if ( $title === null ) {
+			return ['done' => false ];
+		}
+
+		if ( ( $qrefs = json_decode( $params['taskParams'] ) ) === array() ) {
+			return ['done' => false ];
+		}
+
+		$jobFactory = ApplicationFactory::getInstance()->newJobFactory();
+
+		// Each single update is required to allow for a cascading computation
+		// where one query follows another to ensure that results are updated
+		// according to the value dependency amon the referenced annotations that
+		// rely on a computed (#ask) value
+		foreach ( $qrefs as $qref ) {
+			$updateJob = $jobFactory->newUpdateJob(
+				$title,
+				[
+					UpdateJob::FORCED_UPDATE => true,
+					'qref' => $qref
+				]
+			);
+
+			$updateJob->run();
+		}
+
+		return ['done' => true ];
+	}
+
+	/**
+	 * @codeCoverageIgnore
+	 * @see ApiBase::getAllowedParams
+	 *
+	 * @return array
+	 */
+	public function getAllowedParams() {
+		return array(
+			'taskType' => array(
+				ApiBase::PARAM_REQUIRED => true,
+				ApiBase::PARAM_TYPE => array(
+					'queryref'
+				)
+			),
+			'subject' => array(
+				ApiBase::PARAM_TYPE => 'string',
+				ApiBase::PARAM_REQUIRED => true,
+			),
+			'taskParams' => array(
+				ApiBase::PARAM_TYPE => 'string',
+				ApiBase::PARAM_REQUIRED => true,
+			),
+		);
+	}
+
+	/**
+	 * @codeCoverageIgnore
+	 * @see ApiBase::getParamDescription
+	 *
+	 * @return array
+	 */
+	public function getParamDescription() {
+		return array(
+			'taskType' => 'task type'
+		);
+	}
+
+	/**
+	 * @codeCoverageIgnore
+	 * @see ApiBase::getDescription
+	 *
+	 * @return array
+	 */
+	public function getDescription() {
+		return array(
+			'API module ...'
+		);
+	}
+
+	/**
+	 * @codeCoverageIgnore
+	 * @see ApiBase::needsToken
+	 */
+	public function needsToken() {
+		return 'csrf';
+	}
+
+	/**
+	 * @codeCoverageIgnore
+	 * @see ApiBase::mustBePosted
+	 */
+	public function mustBePosted() {
+		return true;
+	}
+
+	/**
+	 * @codeCoverageIgnore
+	 * @see ApiBase::isWriteMode
+	 */
+	public function isWriteMode() {
+		return true;
+	}
+
+	/**
+	 * @codeCoverageIgnore
+	 * @see ApiBase::getExamples
+	 *
+	 * @return array
+	 */
+	protected function getExamples() {
+		return array(
+			'api.php?action=smwtask&taskType=queryref',
+		);
+	}
+
+	/**
+	 * @codeCoverageIgnore
+	 * @see ApiBase::getVersion
+	 *
+	 * @return string
+	 */
+	public function getVersion() {
+		return __CLASS__ . ': $Id$';
+	}
+
+}

--- a/src/MediaWiki/Hooks/OutputPageParserOutput.php
+++ b/src/MediaWiki/Hooks/OutputPageParserOutput.php
@@ -5,7 +5,10 @@ namespace SMW\MediaWiki\Hooks;
 use OutputPage;
 use ParserOutput;
 use SMW\ApplicationFactory;
+use SMW\DIWikiPage;
 use Title;
+use SMW\Query\QueryRefFinder;
+use SMW\Message;
 
 /**
  * OutputPageParserOutput hook is called after parse, before the HTML is
@@ -77,7 +80,21 @@ class OutputPageParserOutput {
 
 	protected function performUpdate() {
 
-		$cachedFactbox = ApplicationFactory::getInstance()->singleton( 'FactboxFactory' )->newCachedFactbox();
+		$applicationFactory = ApplicationFactory::getInstance();
+
+		$postProcHandler = $applicationFactory->create( 'PostProcHandler', $this->parserOutput );
+
+		$html = $postProcHandler->getHtml(
+			$this->outputPage->getTitle(),
+			$this->outputPage->getContext()->getRequest()
+		);
+
+		if ( $html !== '' ) {
+			$this->outputPage->addModules( $postProcHandler->getResModules() );
+			$this->outputPage->addHtml( $html );
+		}
+
+		$cachedFactbox = $applicationFactory->singleton( 'FactboxFactory' )->newCachedFactbox();
 
 		$cachedFactbox->prepareFactboxContent(
 			$this->outputPage,

--- a/src/ParserFunctionFactory.php
+++ b/src/ParserFunctionFactory.php
@@ -118,6 +118,10 @@ class ParserFunctionFactory {
 			$expensiveFuncExecutionWatcher
 		);
 
+		$askParserFunction->setPostProcHandler(
+			$applicationFactory->create( 'PostProcHandler', $parser->getOutput() )
+		);
+
 		return $askParserFunction;
 	}
 

--- a/src/PostProcHandler.php
+++ b/src/PostProcHandler.php
@@ -1,0 +1,130 @@
+<?php
+
+namespace SMW;
+
+use SMWQuery as Query;
+use SMW\Query\QueryRefFinder;
+use ParserOutput;
+use Title;
+use WebRequest;
+
+/**
+ * Some updates require to be handled in a "post" process meaning after an update
+ * has already taken place to iterate over those results as input for a value
+ * dependency.
+ *
+ * The post process can only happen after the Store and hereby related processes
+ * have been updated. A simple null edit is in most cases inappropriate and
+ * therefore it is necessary to a complete a re-parse (triggered by the UpdateJob)
+ * to ensure consistency among the stored and displayed data.
+ *
+ * The PostProc relies on an API request to initiate related updates and once
+ * finished will handle the reload of the page.
+ *
+ * @license GNU GPL v2+
+ * @since 3.0
+ *
+ * @author mwjames
+ */
+class PostProcHandler {
+
+	const PROC_POST_QUERYREF = 'smw-postproc-queryref';
+
+	/**
+	 * @var ParserOutput
+	 */
+	private $parserOutput;
+
+	/**
+	 * @var boolean
+	 */
+	private $isEnabled = true;
+
+	/**
+	 * @since 3.0
+	 */
+	public function __construct( ParserOutput $parserOutput ) {
+		$this->parserOutput = $parserOutput;
+	}
+
+	/**
+	 * @since 3.0
+	 *
+	 * @param boolean $isEnabled
+	 */
+	public function isEnabled( $isEnabled ) {
+		$this->isEnabled = (bool)$isEnabled;
+	}
+
+	/**
+	 * @since 3.0
+	 *
+	 * @return array|string
+	 */
+	public function getResModules() {
+		return 'ext.smw.postproc';
+	}
+
+	/**
+	 * @since 3.0
+	 *
+	 * @param Title $title
+	 * @param WebRequest $webRequest
+	 *
+	 * @return string
+	 */
+	public function getHtml( Title $title, WebRequest $webRequest ) {
+
+		if ( $this->isEnabled === false ) {
+			return '';
+		}
+
+		// @see Article::view
+		$key = \EditPage::POST_EDIT_COOKIE_KEY_PREFIX . $title->getLatestRevID();
+		$postEdit = $webRequest->getCookie( $key );
+
+		// Ensure to detect the post edit process to distinguish between an edit
+		// event and any other post, get request in order to only sent a html
+		// fragment once on the edit request and avoid an infinite loop when the
+		// page is reloaded using an API request
+
+		// The element is only added temporary in the event of a postEdit, a
+		// reload of the page will not have the cookie being set and is therefore
+		// neglected
+		if ( $postEdit !== null && ( $refs = $this->parserOutput->getExtensionData( self::PROC_POST_QUERYREF ) ) !== null ) {
+			return \Html::rawElement(
+				'div',
+				array(
+					'class' => 'smw-postproc',
+					'data-subject' => DIWikiPage::newFromTitle( $title )->getHash(),
+					'data-queryref' => json_encode( array_keys( $refs ) )
+				),
+				'' // Message::get( 'smw-postproc-queryref', Message::PARSE )
+			);
+		}
+
+		return '';
+	}
+
+	/**
+	 * @since 3.0
+	 *
+	 * @param string $queryRef
+	 */
+	public function addQueryRef( $queryRef ) {
+
+		$data = $this->parserOutput->getExtensionData( self::PROC_POST_QUERYREF );
+
+		if ( $data === null ) {
+			$data = array();
+		}
+
+		$data[$queryRef] = true;
+
+		$this->parserOutput->setExtensionData(
+			self::PROC_POST_QUERYREF,
+			$data
+		);
+	}
+
+}

--- a/src/Services/SharedServicesContainer.php
+++ b/src/Services/SharedServicesContainer.php
@@ -43,6 +43,7 @@ use SMW\CachedPropertyValuesPrefetcher;
 use SMW\Localizer;
 use SMW\MediaWiki\DatabaseConnectionProvider;
 use SMW\Utils\TempFile;
+use SMW\PostProcHandler;
 
 /**
  * @license GNU GPL v2+
@@ -186,6 +187,19 @@ class SharedServicesContainer implements CallbackContainer {
 		$containerBuilder->registerCallback( 'TempFile', function( $containerBuilder ) {
 			$containerBuilder->registerExpectedReturnType( 'TempFile', '\SMW\Utils\TempFile' );
 			return new TempFile();
+		} );
+
+		/**
+		 * @var PostProcHandler
+		 */
+		$containerBuilder->registerCallback( 'PostProcHandler', function( $containerBuilder, \ParserOutput $parserOutput ) {
+			$containerBuilder->registerExpectedReturnType( 'PostProcHandler', PostProcHandler::class );
+
+			$postProcHandler = new PostProcHandler(
+				$parserOutput
+			);
+
+			return $postProcHandler;
 		} );
 	}
 

--- a/tests/phpunit/Unit/MediaWiki/Api/TaskTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Api/TaskTest.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace SMW\Tests\MediaWiki\Api;
+
+use SMW\MediaWiki\Api\Task;
+use SMW\Tests\TestEnvironment;
+
+/**
+ * @covers \SMW\MediaWiki\Api\Task
+ * @group semantic-mediawiki
+ *
+ * @license GNU GPL v2+
+ * @since 3.0
+ *
+ * @author mwjames
+ */
+class TaskTest extends \PHPUnit_Framework_TestCase {
+
+	private $apiFactory;
+	private $testEnvironment;
+
+	protected function setUp() {
+		parent::setUp();
+
+		$this->testEnvironment = new TestEnvironment();
+		$this->apiFactory = $this->testEnvironment->getUtilityFactory()->newMwApiFactory();
+	}
+
+	protected function tearDown() {
+		$this->testEnvironment->tearDown();
+		parent::tearDown();
+	}
+
+	public function testCanConstruct() {
+
+		$instance = new Task(
+			$this->apiFactory->newApiMain( array() ),
+			'smwtask'
+		);
+
+		$this->assertInstanceOf(
+			Task::class,
+			$instance
+		);
+	}
+
+	public function testHandleQueryRefTask() {
+
+		$updateJob = $this->getMockBuilder( '\SMW\MediaWiki\Jobs\UpdateJob' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$updateJob->expects( $this->atLeastOnce() )
+			->method( 'run' );
+
+		$jobFactory = $this->getMockBuilder( '\SMW\MediaWiki\Jobs\JobFactory' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$jobFactory->expects( $this->atLeastOnce() )
+			->method( 'newUpdateJob' )
+			->will( $this->returnValue( $updateJob ) );
+
+		$this->testEnvironment->registerObject( 'JobFactory', $jobFactory );
+
+		$instance = new Task(
+			$this->apiFactory->newApiMain( array(
+					'action'     => 'smwtask',
+					'subject'    => 'Foo#0##',
+					'taskType'   => 'queryref',
+					'taskParams' => json_encode( [ 'Bar' ] ),
+					'token'      => 'foo'
+				)
+			),
+			'smwtask'
+		);
+
+		$instance->execute();
+	}
+
+}

--- a/tests/phpunit/Unit/ParserFunctions/AskParserFunctionTest.php
+++ b/tests/phpunit/Unit/ParserFunctions/AskParserFunctionTest.php
@@ -435,6 +435,37 @@ class AskParserFunctionTest extends \PHPUnit_Framework_TestCase {
 		);
 	}
 
+	public function testQueryWithAnnotationMarker() {
+
+		$params = array(
+			'[[Modification date::+]]',
+			'format=table',
+			'@annotation'
+		);
+
+		$postProcHandler = $this->getMockBuilder( '\SMW\PostProcHandler' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$postProcHandler->expects( $this->once() )
+			->method( 'addQueryRef' );
+
+		$parserData = ApplicationFactory::getInstance()->newParserData(
+			Title::newFromText( __METHOD__ ),
+			new ParserOutput()
+		);
+
+		$instance = new AskParserFunction(
+			$parserData,
+			$this->messageFormatter,
+			$this->circularReferenceGuard,
+			$this->expensiveFuncExecutionWatcher
+		);
+
+		$instance->setPostProcHandler( $postProcHandler );
+		$instance->parse( $params );
+	}
+
 	public function queryDataProvider() {
 
 		$categoryNS = Localizer::getInstance()->getNamespaceTextById( NS_CATEGORY );

--- a/tests/phpunit/Unit/PostProcHandlerTest.php
+++ b/tests/phpunit/Unit/PostProcHandlerTest.php
@@ -1,0 +1,112 @@
+<?php
+
+namespace SMW\Tests;
+
+use SMW\PostProcHandler;
+
+/**
+ * @covers \SMW\PostProcHandler
+ * @group semantic-mediawiki
+ *
+ * @license GNU GPL v2+
+ * @since 3.0
+ *
+ * @author mwjames
+ */
+class PostProcHandlerTest extends \PHPUnit_Framework_TestCase {
+
+	private $parserOutput;
+
+	protected function setUp() {
+		parent::setUp();
+
+		$this->parserOutput = $this->getMockBuilder( '\ParserOutput' )
+			->disableOriginalConstructor()
+			->getMock();
+	}
+
+	public function testCanConstruct() {
+
+		$this->assertInstanceOf(
+			PostProcHandler::class,
+			new PostProcHandler( $this->parserOutput )
+		);
+	}
+
+	public function testGetHtml() {
+
+		$this->parserOutput->expects( $this->once() )
+			->method( 'getExtensionData' )
+			->with( $this->equalTo( PostProcHandler::PROC_POST_QUERYREF ) )
+			->will( $this->returnValue( [ 'Bar' => true ] ) );
+
+		$instance = new PostProcHandler( $this->parserOutput );
+
+		$title = $this->getMockBuilder( '\Title' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$title->expects( $this->once() )
+			->method( 'getDBKey' )
+			->will( $this->returnValue( 'Foo' ) );
+
+		$title->expects( $this->once() )
+			->method( 'getNamespace' )
+			->will( $this->returnValue( NS_MAIN ) );
+
+		$title->expects( $this->once() )
+			->method( 'getLatestRevID' )
+			->will( $this->returnValue( 42 ) );
+
+		$webRequest = $this->getMockBuilder( '\WebRequest' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$webRequest->expects( $this->once() )
+			->method( 'getCookie' )
+			->will( $this->returnValue( 'FakeCokie' ) );
+
+		$this->assertContains(
+			'<div class="smw-postproc" data-subject="Foo#0#" data-queryref="[&quot;Bar&quot;]"></div>',
+			$instance->getHtml( $title,  $webRequest )
+		);
+	}
+
+	/**
+	 * @dataProvider queryRefProvider
+	 */
+	public function testAddQueryRef( $gExtensionData, $sExtensionData, $ref ) {
+
+		$this->parserOutput->expects( $this->once() )
+			->method( 'getExtensionData' )
+			->with( $this->equalTo( PostProcHandler::PROC_POST_QUERYREF ) )
+			->will( $this->returnValue( $gExtensionData ) );
+
+		$this->parserOutput->expects( $this->once() )
+			->method( 'setExtensionData' )
+			->with( $this->equalTo( PostProcHandler::PROC_POST_QUERYREF ) )
+			->will( $this->returnValue( $sExtensionData ) );
+
+		$instance = new PostProcHandler( $this->parserOutput );
+
+		$instance->addQueryRef( $ref );
+	}
+
+	public function queryRefProvider() {
+
+		$provider[] =[
+			null,
+			[ 'Foo' => true ],
+			'Foo'
+		];
+
+		$provider[] =[
+			[ 'Bar' => true ],
+			[ 'Bar' => true, 'Foo' => true ],
+			'Foo'
+		];
+
+		return $provider;
+	}
+
+}


### PR DESCRIPTION
This PR is made in reference to: #1696

This PR addresses or contains:

This implements a different approach from what has been outlined in #1696 due to some limitations on the part of:

One cannot reliably detect (while parsing a #ask from within the `Parser` instance) whether a #ask query is part of an embedded parsing process (i.e. part of a [[ ... ]] annotation or #set annotation) and trying to only use an entity name `{{FULLPAGENAME}}` as decision parameter is insufficient. It could cause a query like `{{#show: {{FULLPAGENAME}} |?Some property |link=none|mainlabel=-}}` to always being identified as to contain a self-reference even though it is not embedded in an annotation, yet it would be marked as to require a post processing update.

To clearly identify which `#ask`/`#show` is used as input for an annotation process, it is proposed to mark those queries with a `@annotation` parameter as in `[[Another property:: {{#show: {{FULLPAGENAME}} |?Some property |link=none|mainlabel=-|@annotation}}]]` to distinguish them from a simple `{{#show: {{FULLPAGENAME}} |?Some property |link=none|mainlabel=-}}` query.

### Technical notes 

* `AskParserFunction` will use `PostProcHandler::addQueryRef` on queries marked with a `@annotation` parameter and store references with `ParserOutput::setExtensionData` in order for succeeding processes to access that information without relying on a `Cache` or `DB` connection
* `OutputPageParserOutput` hook will inspect the `ParserOutput` and in case of a matching result, adds a `HTML` element at the top of a page together with a resource module (`ext.smw.postproc`)
* Once the page has been loaded client-side, the earlier invoked resource module will initiate an API request using the `smwtask` module to run the required `UpdateJob` and when finished forces a reload of the page to display the newly computed and annotated values
* This approach requires that the API is available and writable, see also:
  * https://www.mediawiki.org/wiki/Manual:$wgEnableAPI 
  * https://www.mediawiki.org/wiki/Manual:$wgEnableWriteAPI
  * https://www.mediawiki.org/wiki/API:Restricting_API_usage

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed

Fixes #1696