### PR TITLE
Special:Admin to check editToken

### DIFF
--- a/src/MediaWiki/Specials/Admin/IdTaskHandler.php
+++ b/src/MediaWiki/Specials/Admin/IdTaskHandler.php
@@ -97,6 +97,11 @@ class IdTaskHandler extends TaskHandler {
 		$this->outputFormatter->setPageTitle( $this->getMessageAsString( 'smw-admin-supplementary-idlookup-title' ) );
 		$this->outputFormatter->addParentLink();
 
+		// https://phabricator.wikimedia.org/T109652#1562641
+		if ( !$this->user->matchEditToken( $webRequest->getVal( 'wpEditToken' ) ) ) {
+			return $this->outputFormatter->addHtml( $this->getMessageAsString( 'sessionfailure' ) );
+		}
+
 		$id = $webRequest->getText( 'id' );
 
 		if ( $this->isEnabledFeature( SMW_ADM_DISPOSAL ) && $id > 0 && $webRequest->getText( 'dispose' ) === 'yes' ) {

--- a/src/MediaWiki/Specials/SpecialAdmin.php
+++ b/src/MediaWiki/Specials/SpecialAdmin.php
@@ -48,6 +48,12 @@ class SpecialAdmin extends SpecialPage {
 			throw new ExtendedPermissionsError( 'smw-admin', array( 'smw-admin-permission-missing' ) );
 		}
 
+		// https://phabricator.wikimedia.org/T109652#1562641
+		$this->getRequest()->setVal(
+			'wpEditToken',
+			$this->getUser()->getEditToken()
+		);
+
 		$this->setHeaders();
 		$output = $this->getOutput();
 		$output->setPageTitle( $this->getMessageAsString( 'smwadmin' ) );

--- a/tests/phpunit/Unit/MediaWiki/Specials/Admin/IdTaskHandlerTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Specials/Admin/IdTaskHandlerTest.php
@@ -105,6 +105,18 @@ class IdTaskHandlerTest extends \PHPUnit_Framework_TestCase {
 			$this->outputFormatter
 		);
 
+		$user = $this->getMockBuilder( '\User' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$user->expects( $this->atLeastOnce() )
+			->method( 'matchEditToken' )
+			->will( $this->returnValue( true ) );
+
+		$instance->setUser(
+			$user
+		);
+
 		$webRequest = $this->getMockBuilder( '\WebRequest' )
 			->disableOriginalConstructor()
 			->getMock();
@@ -166,21 +178,25 @@ class IdTaskHandlerTest extends \PHPUnit_Framework_TestCase {
 			->disableOriginalConstructor()
 			->getMock();
 
+		$user->expects( $this->atLeastOnce() )
+			->method( 'matchEditToken' )
+			->will( $this->returnValue( true ) );
+
 		$webRequest = $this->getMockBuilder( '\WebRequest' )
 			->disableOriginalConstructor()
 			->getMock();
 
-		$webRequest->expects( $this->at( 0 ) )
+		$webRequest->expects( $this->at( 1 ) )
 			->method( 'getText' )
 			->with( $this->equalTo( 'id' ) )
 			->will( $this->returnValue( 42 ) );
 
-		$webRequest->expects( $this->at( 1 ) )
+		$webRequest->expects( $this->at( 2 ) )
 			->method( 'getText' )
 			->with( $this->equalTo( 'dispose' ) )
 			->will( $this->returnValue( 'yes' ) );
 
-		$webRequest->expects( $this->at( 2 ) )
+		$webRequest->expects( $this->at( 3 ) )
 			->method( 'getText' )
 			->with( $this->equalTo( 'action' ) )
 			->will( $this->returnValue( 'idlookup' ) );


### PR DESCRIPTION
This PR is made in reference to: https://phabricator.wikimedia.org/T109652#1562641

This PR addresses or contains:

Quoting from the phab ticket:
 
- " ... page to run commands there, potentially causing a minor DoS ... "
- " ... a hidden input adding $user->getEditToken() to the form, then checking it with $user->matchEditToken() is the simplest fix ..."

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed

Fixes #