### PR TITLE
Avoid reading MW job table directly, use JobQueue

### DIFF
--- a/src/ApplicationFactory.php
+++ b/src/ApplicationFactory.php
@@ -565,6 +565,15 @@ class ApplicationFactory {
 		return $this->containerBuilder->singleton( 'JobQueueGroup' );
 	}
 
+	/**
+	 * @since 3.0
+	 *
+	 * @return JobQueue
+	 */
+	public function getJobQueue() {
+		return $this->containerBuilder->singleton( 'JobQueue' );
+	}
+
 	private static function newContainerBuilder( CallbackContainerFactory $callbackContainerFactory, $servicesFileDir ) {
 
 		$containerBuilder = $callbackContainerFactory->newCallbackContainerBuilder();

--- a/src/MediaWiki/JobQueue.php
+++ b/src/MediaWiki/JobQueue.php
@@ -1,0 +1,146 @@
+<?php
+
+namespace SMW\MediaWiki;
+
+use JobQueueGroup;
+use Job;
+
+/**
+ * MediaWiki's JobQueue contains mostly final methods making it difficult to use
+ * an instance during tests hence this class provides a reduced interface with
+ * mockable methods.
+ *
+ * @license GNU GPL v2+
+ * @since 3.0
+ *
+ * @author mwjames
+ */
+class JobQueue {
+
+	/**
+	 * @var JobQueueGroup
+	 */
+	private $jobQueueGroup;
+
+	/**
+	 * @var boolean
+	 */
+	private $disableCache = false;
+
+	/**
+	 * @since 3.0
+	 *
+	 * @param JobQueueGroup $jobQueueGroup
+	 */
+	public function __construct( JobQueueGroup $jobQueueGroup ) {
+		$this->jobQueueGroup = $jobQueueGroup;
+	}
+
+	/**
+	 * @since 3.0
+	 *
+	 * @param boolean $disableCache
+	 */
+	public function disableCache( $disableCache = true ) {
+		$this->disableCache = (bool)$disableCache;
+	}
+
+	/**
+	 * @since 3.0
+	 *
+	 * @param string $type
+	 *
+	 * @return Job|boolean
+	 */
+	public function pop( $type ) {
+		return $this->jobQueueGroup->get( $type )->pop();
+	}
+
+	/**
+	 * Acknowledge that a job was completed
+	 *
+	 * @since 3.0
+	 *
+	 * @param Job $job
+	 */
+	public function ack( Job $job ) {
+		$this->jobQueueGroup->get( $job->getType() )->ack( $job );
+	}
+
+	/**
+	 * @since 3.0
+	 *
+	 * @param string $type
+	 */
+	public function delete( $type ) {
+
+		$jobQueue = $this->jobQueueGroup->get( $type );
+		$jobQueue->delete();
+
+		if ( $this->disableCache ) {
+			$jobQueue->flushCaches();
+		}
+	}
+
+	/**
+	 * @since 3.0
+	 *
+	 * @param Job|Job[] $jobs
+	 */
+	public function push( $jobs ) {
+		$this->jobQueueGroup->push( $jobs );
+	}
+
+	/**
+	 * @since 3.0
+	 *
+	 * @param Job|Job[] $jobs
+	 */
+	public function lazyPush( $jobs ) {
+
+		if ( !method_exists( $this->jobQueueGroup, 'lazyPush' ) ) {
+			return $this->push( $jobs );
+		}
+
+		$this->jobQueueGroup->lazyPush( $jobs );
+	}
+
+	/**
+	 * @since 3.0
+	 *
+	 * @return array
+	 */
+	public function getQueueSizes() {
+		return $this->jobQueueGroup->getQueueSizes();
+	}
+
+	/**
+	 * @since 3.0
+	 *
+	 * @param string $type
+	 *
+	 * @return integer
+	 */
+	public function getQueueSize( $type ) {
+
+		$jobQueue = $this->jobQueueGroup->get( $type );
+
+		if ( $this->disableCache ) {
+			$jobQueue->flushCaches();
+		}
+
+		return $jobQueue->getSize();
+	}
+
+	/**
+	 * @since 3.0
+	 *
+	 * @param string $type
+	 *
+	 * @return boolean
+	 */
+	public function hasPendingJob( $type ) {
+		return $this->getQueueSize( $type ) > 0;
+	}
+
+}

--- a/src/MediaWiki/Specials/Admin/PropertyStatsRebuildJobTaskHandler.php
+++ b/src/MediaWiki/Specials/Admin/PropertyStatsRebuildJobTaskHandler.php
@@ -9,7 +9,6 @@ use SMW\Store;
 use Html;
 use WebRequest;
 use Title;
-use Job;
 
 /**
  * @license GNU GPL v2+
@@ -18,11 +17,6 @@ use Job;
  * @author mwjames
  */
 class PropertyStatsRebuildJobTaskHandler extends TaskHandler {
-
-	/**
-	 * @var Store
-	 */
-	private $store;
 
 	/**
 	 * @var HtmlFormRenderer
@@ -37,12 +31,10 @@ class PropertyStatsRebuildJobTaskHandler extends TaskHandler {
 	/**
 	 * @since 2.5
 	 *
-	 * @param Store $store
 	 * @param HtmlFormRenderer $htmlFormRenderer
 	 * @param OutputFormatter $outputFormatter
 	 */
-	public function __construct( Store $store, HtmlFormRenderer $htmlFormRenderer, OutputFormatter $outputFormatter ) {
-		$this->store = $store;
+	public function __construct( HtmlFormRenderer $htmlFormRenderer, OutputFormatter $outputFormatter ) {
 		$this->htmlFormRenderer = $htmlFormRenderer;
 		$this->outputFormatter = $outputFormatter;
 	}
@@ -68,7 +60,7 @@ class PropertyStatsRebuildJobTaskHandler extends TaskHandler {
 				->addHeader( 'h3', $this->getMessageAsString( 'smw-admin-propertystatistics-title' ) )
 				->addParagraph( $this->getMessageAsString( 'smw-admin-propertystatistics-intro', Message::PARSE ) );
 
-		if ( $this->isEnabledFeature( SMW_ADM_PSTATS ) && !$this->hasPropertyStatisticsRebuildJob() ) {
+		if ( $this->isEnabledFeature( SMW_ADM_PSTATS ) && !$this->hasPendingPropertyStatisticsRebuildJob() ) {
 			$this->htmlFormRenderer
 				->setMethod( 'post' )
 				->addHiddenField( 'action', 'pstatsrebuild' )
@@ -99,34 +91,22 @@ class PropertyStatsRebuildJobTaskHandler extends TaskHandler {
 	 */
 	public function handleRequest( WebRequest $webRequest ) {
 
-		if ( $this->isEnabledFeature( SMW_ADM_PSTATS ) && !$this->hasPropertyStatisticsRebuildJob() ) {
-			$propertyStatisticsRebuildJob = ApplicationFactory::getInstance()->newJobFactory()->newByType(
-				'SMW\PropertyStatisticsRebuildJob',
-				\SpecialPage::getTitleFor( 'SMWAdmin' )
-			);
-
-			$propertyStatisticsRebuildJob->insert();
+		if ( !$this->isEnabledFeature( SMW_ADM_PSTATS ) || $this->hasPendingPropertyStatisticsRebuildJob() ) {
+			return false;
 		}
+
+		$propertyStatisticsRebuildJob = ApplicationFactory::getInstance()->newJobFactory()->newByType(
+			'SMW\PropertyStatisticsRebuildJob',
+			\SpecialPage::getTitleFor( 'SMWAdmin' )
+		);
+
+		$propertyStatisticsRebuildJob->insert();
 
 		$this->outputFormatter->redirectToRootPage( $this->getMessageAsString( 'smw-admin-propertystatistics-title' ) );
 	}
 
-	private function hasPropertyStatisticsRebuildJob() {
-
-		if ( !$this->isEnabledFeature( SMW_ADM_PSTATS ) ) {
-			return false;
-		}
-
-		$jobQueueLookup = ApplicationFactory::getInstance()->create(
-			'JobQueueLookup',
-			$this->store->getConnection( 'mw.db' )
-		);
-
-		$row = $jobQueueLookup->selectJobRowBy(
-			'SMW\PropertyStatisticsRebuildJob'
-		);
-
-		return $row !== null && $row !== false;
+	private function hasPendingPropertyStatisticsRebuildJob() {
+		return ApplicationFactory::getInstance()->getJobQueue()->hasPendingJob( 'SMW\PropertyStatisticsRebuildJob' );
 	}
 
 }

--- a/src/MediaWiki/Specials/Admin/TaskHandlerFactory.php
+++ b/src/MediaWiki/Specials/Admin/TaskHandlerFactory.php
@@ -92,7 +92,7 @@ class TaskHandlerFactory {
 	 * @return DataRefreshJobTaskHandler
 	 */
 	public function newDataRefreshJobTaskHandler() {
-		return new DataRefreshJobTaskHandler( $this->store, $this->htmlFormRenderer, $this->outputFormatter );
+		return new DataRefreshJobTaskHandler( $this->htmlFormRenderer, $this->outputFormatter );
 	}
 
 	/**
@@ -101,7 +101,7 @@ class TaskHandlerFactory {
 	 * @return DisposeJobTaskHandler
 	 */
 	public function newDisposeJobTaskHandler() {
-		return new DisposeJobTaskHandler( $this->store, $this->htmlFormRenderer, $this->outputFormatter );
+		return new DisposeJobTaskHandler( $this->htmlFormRenderer, $this->outputFormatter );
 	}
 
 	/**
@@ -110,7 +110,7 @@ class TaskHandlerFactory {
 	 * @return PropertyStatsRebuildJobTaskHandler
 	 */
 	public function newPropertyStatsRebuildJobTaskHandler() {
-		return new PropertyStatsRebuildJobTaskHandler( $this->store, $this->htmlFormRenderer, $this->outputFormatter );
+		return new PropertyStatsRebuildJobTaskHandler( $this->htmlFormRenderer, $this->outputFormatter );
 	}
 
 	/**
@@ -119,7 +119,7 @@ class TaskHandlerFactory {
 	 * @return FulltextSearchTableRebuildJobTaskHandler
 	 */
 	public function newFulltextSearchTableRebuildJobTaskHandler() {
-		return new FulltextSearchTableRebuildJobTaskHandler( $this->store, $this->htmlFormRenderer, $this->outputFormatter );
+		return new FulltextSearchTableRebuildJobTaskHandler( $this->htmlFormRenderer, $this->outputFormatter );
 	}
 
 	/**

--- a/src/Services/SharedServicesContainer.php
+++ b/src/Services/SharedServicesContainer.php
@@ -14,6 +14,7 @@ use SMW\MediaWiki\PageCreator;
 use SMW\MediaWiki\PageUpdater;
 use SMW\MediaWiki\TitleCreator;
 use SMW\MediaWiki\JobQueueLookup;
+use SMW\MediaWiki\JobQueue;
 use SMW\Query\QuerySourceFactory;
 use SMW\SQLStore\ChangeOp\TempChangeOpStore;
 use SMW\Query\Result\CachedQueryResultPrefetcher;
@@ -130,6 +131,23 @@ class SharedServicesContainer implements CallbackContainer {
 		$containerBuilder->registerCallback( 'JobQueueLookup', function( $containerBuilder, Database $connection ) {
 			$containerBuilder->registerExpectedReturnType( 'JobQueueLookup', '\SMW\MediaWiki\JobQueueLookup' );
 			return new JobQueueLookup( $connection );
+		} );
+
+		/**
+		 * JobQueue
+		 *
+		 * @return callable
+		 */
+		$containerBuilder->registerCallback( 'JobQueue', function( $containerBuilder ) {
+
+			$containerBuilder->registerExpectedReturnType(
+				'JobQueue',
+				'\SMW\MediaWiki\JobQueue'
+			);
+
+			return new JobQueue(
+				$containerBuilder->create( 'JobQueueGroup' )
+			);
 		} );
 
 		$containerBuilder->registerCallback( 'ManualEntryLogger', function( $containerBuilder ) {

--- a/tests/phpunit/Unit/MediaWiki/JobQueueTest.php
+++ b/tests/phpunit/Unit/MediaWiki/JobQueueTest.php
@@ -1,0 +1,200 @@
+<?php
+
+namespace SMW\Tests\MediaWiki;
+
+use SMW\MediaWiki\JobQueue;
+
+/**
+ * @covers \SMW\MediaWiki\JobQueue
+ * @group semantic-mediawiki
+ *
+ * @license GNU GPL v2+
+ * @since 3.0
+ *
+ * @author mwjames
+ */
+class JobQueueTest extends \PHPUnit_Framework_TestCase {
+
+	private $jobQueueGroup;
+
+	protected function setup() {
+
+		$this->jobQueueGroup = $this->getMockBuilder( '\JobQueueGroup' )
+			->disableOriginalConstructor()
+			->getMock();
+	}
+
+	public function testCanConstruct() {
+
+		$this->assertInstanceOf(
+			JobQueue::class,
+			new JobQueue( $this->jobQueueGroup )
+		);
+	}
+
+	public function testPop() {
+
+		$jobQueue = $this->getMockBuilder( '\JobQueue' )
+			->disableOriginalConstructor()
+			->getMockForAbstractClass();
+
+		$this->jobQueueGroup->expects( $this->once() )
+			->method( 'get' )
+			->with( $this->stringContains( 'FakeJob' ) )
+			->will( $this->returnValue( $jobQueue ) );
+
+		$instance = new JobQueue( $this->jobQueueGroup );
+
+		// MediaWiki's JobQueue::pop !!!
+		try {
+			$instance->pop( 'FakeJob' );
+		} catch ( \Exception $e ) {
+			// Do nothing
+		}
+	}
+
+	public function testAck() {
+
+		$job = $this->getMockBuilder( '\Job' )
+			->disableOriginalConstructor()
+			->setMethods( array( 'getType', 'run' ) )
+			->getMock();
+
+		$job->expects( $this->atLeastOnce() )
+			->method( 'getType' )
+			->will( $this->returnValue( 'FakeJob' ) );
+
+		$jobQueue = $this->getMockBuilder( '\JobQueue' )
+			->disableOriginalConstructor()
+			->getMockForAbstractClass();
+
+		$this->jobQueueGroup->expects( $this->once() )
+			->method( 'get' )
+			->with( $this->stringContains( 'FakeJob' ) )
+			->will( $this->returnValue( $jobQueue ) );
+
+		$instance = new JobQueue( $this->jobQueueGroup );
+
+		// MediaWiki's JobQueue::ack !!!
+		try {
+			$instance->ack( $job );
+		} catch ( \Exception $e ) {
+			// Do nothing
+		}
+	}
+
+	public function testDeleteWithDisabledCache() {
+
+		$jobQueue = $this->getMockBuilder( '\JobQueue' )
+			->disableOriginalConstructor()
+			->setMethods( array( 'assertNotReadOnly', 'doDelete', 'doFlushCaches' ) )
+			->getMockForAbstractClass();
+
+		$jobQueue->expects( $this->any() )
+			->method( 'assertNotReadOnly' )
+			->will( $this->returnValue( false ) );
+
+		$jobQueue->expects( $this->once() )
+			->method( 'doDelete' );
+
+		$jobQueue->expects( $this->once() )
+			->method( 'doFlushCaches' );
+
+		$this->jobQueueGroup->expects( $this->once() )
+			->method( 'get' )
+			->with( $this->stringContains( 'FakeJob' ) )
+			->will( $this->returnValue( $jobQueue ) );
+
+		$instance = new JobQueue( $this->jobQueueGroup );
+		$instance->disableCache( true );
+
+		$instance->delete( 'FakeJob' );
+	}
+
+	public function testPush() {
+
+		$fakeJob = $this->getMockBuilder( '\Job' )
+			->disableOriginalConstructor()
+			->getMockForAbstractClass();
+
+		$this->jobQueueGroup->expects( $this->once() )
+			->method( 'push' );
+
+		$instance = new JobQueue( $this->jobQueueGroup );
+		$instance->push( $fakeJob );
+	}
+
+	public function testLazyPush() {
+
+		if ( !method_exists( $this->jobQueueGroup, 'lazyPush' ) ) {
+			$this->markTestSkipped( 'JobQueueGroup::lazyPush is not supported.' );
+		}
+
+		$fakeJob = $this->getMockBuilder( '\Job' )
+			->disableOriginalConstructor()
+			->getMockForAbstractClass();
+
+		$this->jobQueueGroup->expects( $this->once() )
+			->method( 'lazyPush' );
+
+		$instance = new JobQueue( $this->jobQueueGroup );
+		$instance->lazyPush( $fakeJob );
+	}
+
+	public function testGetQueueSizes() {
+
+		$this->jobQueueGroup->expects( $this->once() )
+			->method( 'getQueueSizes' );
+
+		$instance = new JobQueue( $this->jobQueueGroup );
+		$instance->getQueueSizes();
+	}
+
+	public function testGetQueueSize() {
+
+		$jobQueue = $this->getMockBuilder( '\JobQueue' )
+			->disableOriginalConstructor()
+			->setMethods( array( 'doGetSize', 'doFlushCaches' ) )
+			->getMockForAbstractClass();
+
+		$jobQueue->expects( $this->once() )
+			->method( 'doGetSize' );
+
+		$jobQueue->expects( $this->once() )
+			->method( 'doFlushCaches' );
+
+		$this->jobQueueGroup->expects( $this->once() )
+			->method( 'get' )
+			->with( $this->stringContains( 'FakeJob' ) )
+			->will( $this->returnValue( $jobQueue ) );
+
+		$instance = new JobQueue( $this->jobQueueGroup );
+		$instance->disableCache( true );
+
+		$instance->getQueueSize( 'FakeJob' );
+	}
+
+	public function testHasPendingJob() {
+
+		$jobQueue = $this->getMockBuilder( '\JobQueue' )
+			->disableOriginalConstructor()
+			->setMethods( array( 'doGetSize' ) )
+			->getMockForAbstractClass();
+
+		$jobQueue->expects( $this->once() )
+			->method( 'doGetSize' )
+			->will( $this->returnValue( 1 ) );
+
+		$this->jobQueueGroup->expects( $this->once() )
+			->method( 'get' )
+			->with( $this->stringContains( 'FakeJob' ) )
+			->will( $this->returnValue( $jobQueue ) );
+
+		$instance = new JobQueue( $this->jobQueueGroup );
+
+		$this->assertTrue(
+			$instance->hasPendingJob( 'FakeJob' )
+		);
+	}
+
+}

--- a/tests/phpunit/Unit/MediaWiki/Specials/Admin/DisposeJobTaskHandlerTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Specials/Admin/DisposeJobTaskHandlerTest.php
@@ -17,27 +17,14 @@ use SMW\MediaWiki\Specials\Admin\DisposeJobTaskHandler;
 class DisposeJobTaskHandlerTest extends \PHPUnit_Framework_TestCase {
 
 	private $testEnvironment;
-	private $connection;
 	private $htmlFormRenderer;
 	private $outputFormatter;
+	private $jobQueue;
 
 	protected function setUp() {
 		parent::setUp();
 
 		$this->testEnvironment = new TestEnvironment();
-
-		$this->connection = $this->getMockBuilder( '\SMW\MediaWiki\Database' )
-			->disableOriginalConstructor()
-			->getMock();
-
-		$this->store = $this->getMockBuilder( '\SMW\Store' )
-			->disableOriginalConstructor()
-			->setMethods( array( 'getConnection' ) )
-			->getMockForAbstractClass();
-
-		$this->store->expects( $this->any() )
-			->method( 'getConnection' )
-			->will( $this->returnValue( $this->connection ) );
 
 		$this->htmlFormRenderer = $this->getMockBuilder( '\SMW\MediaWiki\Renderer\HtmlFormRenderer' )
 			->disableOriginalConstructor()
@@ -47,7 +34,11 @@ class DisposeJobTaskHandlerTest extends \PHPUnit_Framework_TestCase {
 			->disableOriginalConstructor()
 			->getMock();
 
-		$this->testEnvironment->registerObject( 'Store', $this->store );
+		$this->jobQueue = $this->getMockBuilder( '\SMW\MediaWiki\JobQueue' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$this->testEnvironment->registerObject( 'JobQueue', $this->jobQueue );
 	}
 
 	protected function tearDown() {
@@ -59,7 +50,7 @@ class DisposeJobTaskHandlerTest extends \PHPUnit_Framework_TestCase {
 
 		$this->assertInstanceOf(
 			'\SMW\MediaWiki\Specials\Admin\DisposeJobTaskHandler',
-			new DisposeJobTaskHandler( $this->store, $this->htmlFormRenderer, $this->outputFormatter )
+			new DisposeJobTaskHandler( $this->htmlFormRenderer, $this->outputFormatter )
 		);
 	}
 
@@ -84,7 +75,6 @@ class DisposeJobTaskHandlerTest extends \PHPUnit_Framework_TestCase {
 			->method( 'getForm' );
 
 		$instance = new DisposeJobTaskHandler(
-			$this->store,
 			$this->htmlFormRenderer,
 			$this->outputFormatter
 		);
@@ -92,7 +82,12 @@ class DisposeJobTaskHandlerTest extends \PHPUnit_Framework_TestCase {
 		$instance->getHtml();
 	}
 
-	public function testHandleRequest() {
+	public function testHandleRequestOnNonPendingJob() {
+
+		$this->jobQueue->expects( $this->once() )
+			->method( 'hasPendingJob' )
+			->with( $this->equalTo( 'SMW\EntityIdDisposerJob' ) )
+			->will( $this->returnValue( false ) );
 
 		$entityIdDisposerJob = $this->getMockBuilder( '\SMW\MediaWiki\Jobs\EntityIdDisposerJob' )
 			->disableOriginalConstructor()
@@ -116,7 +111,35 @@ class DisposeJobTaskHandlerTest extends \PHPUnit_Framework_TestCase {
 			->getMock();
 
 		$instance = new DisposeJobTaskHandler(
-			$this->store,
+			$this->htmlFormRenderer,
+			$this->outputFormatter
+		);
+
+		$instance->setEnabledFeatures( SMW_ADM_DISPOSAL );
+		$instance->handleRequest( $webRequest );
+	}
+
+	public function testHandleRequestOnPendingJob() {
+
+		$this->jobQueue->expects( $this->once() )
+			->method( 'hasPendingJob' )
+			->with( $this->equalTo( 'SMW\EntityIdDisposerJob' ) )
+			->will( $this->returnValue( true ) );
+
+		$jobFactory = $this->getMockBuilder( '\SMW\MediaWiki\Jobs\JobFactory' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$jobFactory->expects( $this->never() )
+			->method( 'newByType' );
+
+		$this->testEnvironment->registerObject( 'JobFactory', $jobFactory );
+
+		$webRequest = $this->getMockBuilder( '\WebRequest' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$instance = new DisposeJobTaskHandler(
 			$this->htmlFormRenderer,
 			$this->outputFormatter
 		);


### PR DESCRIPTION
This PR is made in reference to: https://phabricator.wikimedia.org/T157088

This PR addresses or contains:

- MW might use the `JobQueueDB`, `JobQueueRedis`, or `JobQueueFederated` to mange the job queue, reading the `job` table may not provide correct results therefore rely on a reduced `JobQueue` interface to fetch require information 

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed
