### PR TITLE
Fix null return from Iterator in Store::getPropertySubjects, refs 2495

### DIFF
--- a/includes/storage/SQLStore/SMW_SQLStore3_Readers.php
+++ b/includes/storage/SQLStore/SMW_SQLStore3_Readers.php
@@ -536,6 +536,9 @@ class SMWSQLStore3Readers {
 			} catch ( DataItemHandlerException $e ) {
 				// silently drop data, should be extremely rare and will usually fix itself at next edit
 			}
+
+			// Avoid null return in Iterator
+			return $diHandler->dataItemFromDBKeys( [ 'PROP_SUBJECT_READ', 0, ':smw-error', '', '' ] );
 		};
 
 		$iteratorFactory = ApplicationFactory::getInstance()->getIteratorFactory();


### PR DESCRIPTION
This PR is made in reference to: #2495

This PR addresses or contains:

- "Catchable fatal error: Argument 1 passed to SMW\DataValueFactory::newDataValueByItem() must be an instance of SMWDataItem, null given, called in /var/www/htdocs/mw/02100/w/extensions/SemanticMediaWiki/includes/articlepages/SMW_PropertyPage.php on line 348 and defined in /var/www/htdocs/mw/02100/w/extensions/SemanticMediaWiki/src/DataValueFactory.php on line 162" on https://sandbox.semantic-mediawiki.org/wiki/Attribut:Has_preferred_property_label

This PR includes:
- [ ] Tests (unit/integration)
- [x] CI build passed
