### PR TITLE
Filter :smw-redi from Store::getPropertySubjects, refs 2598, 2599

### DIFF
--- a/includes/storage/SQLStore/SMW_SQLStore3_Readers.php
+++ b/includes/storage/SQLStore/SMW_SQLStore3_Readers.php
@@ -503,11 +503,9 @@ class SMWSQLStore3Readers {
 		$result = array();
 
 		if ( !$proptable->isFixedPropertyTable() ) {
-			if ( $where !== '' && strpos( SMW_SQL3_SMWIW_OUTDATED, $where ) === false ) {
-				$where .= " AND smw_iw!=" . $db->addQuotes( SMW_SQL3_SMWIW_OUTDATED ) . " AND smw_iw!=" . $db->addQuotes( SMW_SQL3_SMWDELETEIW );
-			} else {
-				$where .= " smw_iw!=" . $db->addQuotes( SMW_SQL3_SMWIW_OUTDATED ) . " AND smw_iw!=" . $db->addQuotes( SMW_SQL3_SMWDELETEIW );
-			}
+			$where .= ( $where !== '' ? ' AND ' : ' ' ) . "smw_iw!=" . $db->addQuotes( SMW_SQL3_SMWIW_OUTDATED ) .
+			" AND smw_iw!=" . $db->addQuotes( SMW_SQL3_SMWDELETEIW ) .
+			" AND smw_iw!=" . $db->addQuotes( SMW_SQL3_SMWREDIIW );
 		}
 
 		$res = $db->select(
@@ -537,7 +535,7 @@ class SMWSQLStore3Readers {
 				// silently drop data, should be extremely rare and will usually fix itself at next edit
 			}
 
-			$title = $row->smw_title !== '' ? $row->smw_title : 'Empty';
+			$title = ( $row->smw_title !== '' ? $row->smw_title : 'Empty' ) . '/' . $row->smw_namespace;
 
 			// Avoid null return in Iterator
 			return $diHandler->dataItemFromDBKeys( [ 'Blankpage/' . $title, NS_SPECIAL, '', '', '' ] );


### PR DESCRIPTION
This PR is made in reference to: #2598, #2599

This PR addresses or contains:

- Rows returned from a `SELECT` with a `:smw..` (as interwiki) are filtered but when used in a callback it returns a null and caused the issue in #2598 therefore filter `:smw-redi` early on in the SQL `SELECT` before it reaches the iterator callback

This PR includes:
- [ ] Tests (unit/integration)
- [x] CI build passed

Fixes #