### PR TITLE
Special:Ask prevent debug mode on federated source, refs 2616

### DIFF
--- a/includes/specials/SMW_SpecialAsk.php
+++ b/includes/specials/SMW_SpecialAsk.php
@@ -402,7 +402,7 @@ class SMWAskPage extends SpecialPage {
 			$debug = '';
 
 			// Allow to generate a debug output
-			if ( $this->getRequest()->getVal( 'debug' ) ) {
+			if ( $this->getRequest()->getVal( 'debug' ) && ( !isset( $this->m_params['source'] ) || $this->m_params['source'] === '' ) ) {
 
 				$queryobj = SMWQueryProcessor::createQuery(
 					$this->m_querystring,
@@ -583,9 +583,13 @@ class SMWAskPage extends SpecialPage {
 
 			$this->inputFormWidget->createFindResultLinkElement( $hideForm ) .
 			$this->inputFormWidget->createShowHideLinkElement( $title, $urltail, $hideForm, $isEmpty ) .
-			$this->inputFormWidget->createClipboardLinkElement( $this->queryLinker ) .
-			$this->inputFormWidget->createDebugLinkElement( $title, $urltail, $isEmpty ) .
-			$this->inputFormWidget->createEmbeddedCodeLinkElement( $isEmpty ) .
+			$this->inputFormWidget->createClipboardLinkElement( $this->queryLinker );
+
+			if ( !isset( $this->m_params['source'] ) || $this->m_params['source'] === '' ) {
+				$result .= $this->inputFormWidget->createDebugLinkElement( $title, $urltail, $isEmpty );
+			}
+
+			$result .= $this->inputFormWidget->createEmbeddedCodeLinkElement( $isEmpty ) .
 			$this->inputFormWidget->createEmbeddedCodeElement( $this->getQueryAsCodeString() );
 
 		$result .= '<p></p>';


### PR DESCRIPTION
This PR is made in reference to: #2616 

This PR addresses or contains:

- Prevents "Catchable fatal error: Object of class SMWQueryResult could not be converted to string in /var/www/htdocs/mw/02100/w/extensions/SemanticMediaWiki/includes/specials/SMW_SpecialAsk.php on line 433" since we cannot use the debug query mode on a federate query (`source=...`)

This PR includes:
- [ ] Tests (unit/integration)
- [x] CI build passed

Fixes #