### PR TITLE
Special:Ask move condition/printout textarea, refs 839

### DIFF
--- a/includes/specials/SMW_SpecialAsk.php
+++ b/includes/specials/SMW_SpecialAsk.php
@@ -11,6 +11,7 @@ use SMW\MediaWiki\Specials\Ask\NavigationWidget;
 use SMW\MediaWiki\Specials\Ask\DownloadLinksWidget;
 use SMW\MediaWiki\Specials\Ask\SortWidget;
 use SMW\MediaWiki\Specials\Ask\FormatSelectionWidget;
+use SMW\MediaWiki\Specials\Ask\QueryInputWidget;
 use SMW\ApplicationFactory;
 
 /**
@@ -80,6 +81,7 @@ class SMWAskPage extends SpecialPage {
 
 		$out->addModuleStyles( 'ext.smw.style' );
 		$out->addModuleStyles( 'ext.smw.ask.styles' );
+		$out->addModuleStyles( 'ext.smw.table.styles' );
 
 		$out->addModules( 'ext.smw.ask' );
 		$out->addModules( 'ext.smw.property' );
@@ -111,6 +113,15 @@ class SMWAskPage extends SpecialPage {
 
 		ParametersFormWidget::setDefaultLimit(
 			$GLOBALS['smwgQDefaultLimit']
+		);
+
+		SortWidget::setSortingSupport(
+			$GLOBALS['smwgQSortingSupport']
+		);
+
+		// @see #835
+		SortWidget::setRandSortingSupport(
+			$GLOBALS['smwgQRandSortingSupport']
 		);
 
 		if ( $request->getCheck( 'bTitle' ) ) {
@@ -531,17 +542,6 @@ class SMWAskPage extends SpecialPage {
 		$hideForm = false;
 		$title = SpecialPage::getSafeTitleFor( 'Ask' );
 
-		$sorting = '';
-
-		SortWidget::setSortingSupport(
-			$GLOBALS['smwgQSortingSupport']
-		);
-
-		// @see #835
-		SortWidget::setRandSortingSupport(
-			$GLOBALS['smwgQRandSortingSupport']
-		);
-
 		$sorting = SortWidget::sortSection( $this->m_params );
 
 		$result .= Html::openElement( 'form',
@@ -551,10 +551,7 @@ class SMWAskPage extends SpecialPage {
 			$result .= Html::hidden( 'title', $title->getPrefixedDBKey() );
 
 			// Table for main query and printouts.
-			$result .= '<div id="query" class="smw-ask-query"><table style="width: 100%;"><tr><th>' . wfMessage( 'smw_ask_queryhead' )->escaped() . "</th>\n<th>" . wfMessage( 'smw_ask_printhead' )->escaped() . "<br />\n" .
-				'<span style="font-weight: normal;"></span>' . "</th></tr>\n" .
-				'<tr><td style="padding-left: 0px; width: 50%;"><textarea class="smw-ask-query-condition" name="q" cols="20" rows="6">' . htmlspecialchars( $this->m_querystring ) . "</textarea></td>\n" .
-				'<td style="padding-left: 7px; width: 50%;"><textarea id="smw-property-input" class="smw-ask-query-printout" name="po" cols="20" rows="6">' . htmlspecialchars( $printoutstring ) . '</textarea></td></tr></table></div>' . "\n";
+			$result .= QueryInputWidget::input( $this->m_querystring , $printoutstring );
 
 			// Format selection
 			$result .= FormatSelectionWidget::selection( $title, $this->m_params );

--- a/res/Resources.php
+++ b/res/Resources.php
@@ -269,6 +269,18 @@ return array(
 		)
 	),
 
+	// Table styles
+	'ext.smw.table.styles' => $moduleTemplate + array(
+		'styles' => array(
+			'smw/ext.smw.table.css'
+		),
+		'position' => 'top',
+		'targets' => array(
+			'mobile',
+			'desktop'
+		)
+	),
+
 	// Facts and browse
 	'ext.smw.browse.styles' => $moduleTemplate + array(
 		'styles' => array(

--- a/res/smw/special/ext.smw.special.ask.css
+++ b/res/smw/special/ext.smw.special.ask.css
@@ -75,6 +75,26 @@
 	padding: 5px;
 }
 
+.smw-ask-query .smw-table-header {
+	background-color: transparent;
+	text-align: center;
+	padding-bottom: 5px;
+}
+
+.smw-ask-query .smw-table-header .smw-table-cell {
+	border: 0px;
+	padding: 0px 0px 5px 0px;
+}
+
+.smw-ask-query .smw-table-row .smw-table-cell {
+	border: 1px solid #a2a9b1;
+    padding: 0px;
+}
+
+.smw-ask-query textarea{
+	border: 0px;
+}
+
 .smw-ask-options-row-odd {
 	background: #eee;
 }

--- a/src/MediaWiki/Specials/Ask/QueryInputWidget.php
+++ b/src/MediaWiki/Specials/Ask/QueryInputWidget.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace SMW\MediaWiki\Specials\Ask;
+
+use SMW\Message;
+use SMW\Utils\HtmlTable;
+use Html;
+
+/**
+ * @license GNU GPL v2+
+ * @since   3.0
+ *
+ * @author mwjames
+ */
+class QueryInputWidget {
+
+	/**
+	 * @since 3.0
+	 *
+	 * @param string $queryString
+	 * @param string $printoutString
+	 *
+	 * @return string
+	 */
+	public static function input( $queryString , $printoutString ) {
+
+		$table = HtmlTable::open( [ 'style' => "width: 100%;" ] );
+
+		$table .= HtmlTable::header(
+			HtmlTable::cell(
+				Message::get( 'smw_ask_queryhead', Message::TEXT, Message::USER_LANGUAGE ),
+				[]
+			) .	HtmlTable::cell(
+				'',
+				[]
+			) .	HtmlTable::cell(
+				Message::get( 'smw_ask_printhead', Message::TEXT, Message::USER_LANGUAGE ),
+				[]
+			)
+		);
+
+		$table .= HtmlTable::row(
+			HtmlTable::cell(
+				'<textarea class="smw-ask-query-condition" name="q" rows="6">' . htmlspecialchars( $queryString ) . '</textarea>',
+				[]
+			) . HtmlTable::cell(
+				'',
+				[
+					'style' => 'width:10px; border:0px; padding: 0px;'
+				]
+			) . HtmlTable::cell(
+				'<textarea id="smw-property-input" class="smw-ask-query-printout" name="po" rows="6">' . htmlspecialchars( $printoutString ) . '</textarea>',
+				[]
+			)
+		);
+
+		$table .= HtmlTable::close();
+
+		return Html::rawElement(
+			'div',
+			[
+				'id' => 'query',
+				'class' => 'smw-ask-query',
+				'style' => 'margin-bottom:10px; margin-top:10px;'
+			],
+			$table
+		);
+	}
+
+}

--- a/tests/phpunit/Unit/MediaWiki/Specials/Ask/QueryInputWidgetTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Specials/Ask/QueryInputWidgetTest.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace SMW\Tests\MediaWiki\Specials\Ask;
+
+use SMW\MediaWiki\Specials\Ask\QueryInputWidget;
+use SMW\Tests\TestEnvironment;
+
+/**
+ * @covers \SMW\MediaWiki\Specials\Ask\QueryInputWidget
+ * @group semantic-mediawiki
+ *
+ * @license GNU GPL v2+
+ * @since 3.0
+ *
+ * @author mwjames
+ */
+class QueryInputWidgetTest extends \PHPUnit_Framework_TestCase {
+
+	private $stringValidator;
+
+	protected function setUp() {
+		$testEnvironment = new TestEnvironment();
+
+		$this->stringValidator = $testEnvironment->getUtilityFactory()->newValidatorFactory()->newStringValidator();
+	}
+
+	public function testInput() {
+
+		$this->stringValidator->assertThatStringContains(
+			[
+				'<div id="query" class="smw-ask-query" style="margin-bottom:10px; margin-top:10px;">',
+				'<div style="width: 100%;" class="smw-table">',
+				'<div class="smw-table-header"><div class="smw-table-cell">.*</div><div class="smw-table-cell"></div><div class="smw-table-cell">.*</div></div>',
+				'<div class="smw-table-row"><div class="smw-table-cell"><textarea class="smw-ask-query-condition" name="q" rows="6">Foo</textarea></div>',
+				'<div class="smw-table-cell"><textarea id="smw-property-input" class="smw-ask-query-printout" name="po" rows="6">Bar</textarea>'
+			],
+			QueryInputWidget::input( 'Foo', 'Bar' )
+		);
+	}
+
+}


### PR DESCRIPTION
This PR is made in reference to: #839

This PR addresses or contains:

- Moves condition/printout textarea to its own widget in order to be testable
- Replaces `table` with div-table

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed
