### PR TITLE
Disable purge button while JS isn't ready, refs 2502

### DIFF
--- a/res/smw/util/ext.smw.util.purge.js
+++ b/res/smw/util/ext.smw.util.purge.js
@@ -21,6 +21,9 @@
 
 	mw.loader.using( [ 'mediawiki.api', 'mediawiki.notify' ] ).then( function () {
 
+		// JS is loaded, now remove the "soft" disabled functionality
+		$( "#ca-purge" ).removeClass( 'is-disabled' );
+
 		$( "#ca-purge a" ).on( 'click', function ( e ) {
 			var postArgs = { action: 'purge', titles: mw.config.get( 'wgPageName' ) };
 			new mw.Api().post( postArgs ).then( function () {

--- a/src/MediaWiki/Hooks/SkinTemplateNavigation.php
+++ b/src/MediaWiki/Hooks/SkinTemplateNavigation.php
@@ -47,7 +47,7 @@ class SkinTemplateNavigation {
 		if ( $this->skinTemplate->getUser()->isAllowed( 'purge' ) ) {
 			$this->skinTemplate->getOutput()->addModules( 'ext.smw.purge' );
 			$this->links['actions']['purge'] = array(
-				'class' => false,
+				'class' => 'is-disabled',
 				'text' => $this->skinTemplate->msg( 'smw_purge' )->text(),
 				'href' => $this->skinTemplate->getTitle()->getLocalUrl( array( 'action' => 'purge' ) )
 			);


### PR DESCRIPTION
This PR is made in reference to: #2502

This PR addresses or contains:

- Disables the "refresh" button for as long as the JS resource isn't loaded

This PR includes:
- [ ] Tests (unit/integration)
- [X] CI build passed
