### PR TITLE
Special:Ask use user lang

### DIFF
--- a/includes/specials/SMW_SpecialAsk.php
+++ b/includes/specials/SMW_SpecialAsk.php
@@ -117,10 +117,10 @@ class SMWAskPage extends SpecialPage {
 
 		if ( $request->getCheck( 'bTitle' ) ) {
 			$visibleLinks = [];
-		} elseif( $request->getVal( 'eq' ) === 'no' ) {
+		} elseif( $request->getVal( 'eq' ) === 'no' || $p !== null || $request->getVal( 'x' ) ) {
 			$visibleLinks = [ 'empty' ];
 		} else {
-			$visibleLinks = [ 'options', 'search', 'result', 'empty' ];
+			$visibleLinks = [ 'options', 'search', 'empty' ];
 		}
 
 		$out->addHTML(

--- a/res/smw/special/ext.smw.special.ask.css
+++ b/res/smw/special/ext.smw.special.ask.css
@@ -65,7 +65,7 @@
 	padding: 5px;
 }
 
-.smw-ask-cond-info{
+.smw-ask-cond-info {
 	margin-top: 15px;
 	margin-bottom: 10px;
 }
@@ -93,6 +93,7 @@
 
 .smw-ask-query textarea{
 	border: 0px;
+	resize: none;
 }
 
 .smw-ask-options-row-odd {
@@ -277,4 +278,8 @@ fieldset.smw-ask-actions, fieldset.smw-ask-format, fieldset.smw-ask-options {
 
 .smw-ask-sort-add a::after, .smw-ask-sort-delete a::after {
 	content:"]";
+}
+
+.smw-ask-sort-delete, .smw-ask-sort-add {
+	cursor: pointer;
 }

--- a/res/smw/special/ext.smw.special.property.js
+++ b/res/smw/special/ext.smw.special.property.js
@@ -26,7 +26,17 @@
 				'limit': 100
 			},
 			onSearchStart: function( query ) {
+
+				// Avoid a search request on options or invalid characters
+				if ( query.property.indexOf( '#' ) > 0 || query.property.indexOf( '|' ) > 0 ) {
+					return false;
+				};
+
+				context.addClass( 'is-disabled' );
 				query.property = query.property.replace( "?", '' );
+			},
+			onSearchComplete: function( query ) {
+				context.removeClass( 'is-disabled' );
 			},
 			transformResult: function( response ) {
 				return {

--- a/src/MediaWiki/Specials/Ask/NavigationLinksWidget.php
+++ b/src/MediaWiki/Specials/Ask/NavigationLinksWidget.php
@@ -93,12 +93,20 @@ class NavigationLinksWidget {
 			}
 		}
 
+		$sep = Html::rawElement(
+			'span',
+			[
+				'style' => 'color:#aaa;'
+			],
+			'|'
+		);
+
 		return Html::rawElement(
 			'div',
 			[
 				'class' => 'smw-ask-toplinks'
 			],
-			implode( ' | ', $lLinks ) . '&#160;' .  implode( ' | ', $rLinks )
+			implode( "&#160;$sep&#160;", $lLinks ) . '&#160;' .  implode( "&#160;$sep&#160;", $rLinks )
 		) . Html::rawElement(
 			'div',
 			[
@@ -127,10 +135,22 @@ class NavigationLinksWidget {
 		// @todo FIXME: i18n: Patchwork text.
 		$navigation .=
 			'<b>' .
-				Message::get( 'smw_result_results' ) . ' ' . $userLanguage->formatNum( $offset + 1 ) .
+				Message::get( 'smw_result_results', Message::TEXT, Message::USER_LANGUAGE ) . ' ' . $userLanguage->formatNum( $offset + 1 ) .
 			' &#150; ' .
 				$userLanguage->formatNum( $offset + $count ) .
 			'</b>&#160;&#160;&#160;&#160;';
+
+		$prev = Message::get(
+			'smw_result_prev',
+			Message::TEXT,
+			Message::USER_LANGUAGE
+		);
+
+		$next = Message::get(
+			'smw_result_next',
+			Message::TEXT,
+			Message::USER_LANGUAGE
+		);
 
 		// Prepare navigation bar.
 		if ( $offset > 0 ) {
@@ -147,10 +167,10 @@ class NavigationLinksWidget {
 					'href' => $href,
 					'rel' => 'nofollow'
 				),
-				Message::get( 'smw_result_prev' ) . ' ' . $limit
+				$prev . ' ' . $limit
 			) . ' | ';
 		} else {
-			$navigation .= '(' . Html::rawElement( 'span', [ 'class' => 'smw-ask-nav-prev' ], Message::get( 'smw_result_prev' ) . '&#160;' . $limit ) . ' | ';
+			$navigation .= '(' . Html::rawElement( 'span', [ 'class' => 'smw-ask-nav-prev' ], $prev . '&#160;' . $limit ) . ' | ';
 		}
 
 		if ( $hasFurtherResults ) {
@@ -167,10 +187,10 @@ class NavigationLinksWidget {
 					'href' => $href,
 					'rel' => 'nofollow'
 				),
-				Message::get( 'smw_result_next' ) . ' ' . $limit
+				$next . ' ' . $limit
 			) . ')';
 		} else {
-			$navigation .= Html::rawElement( 'span', [ 'class' => 'smw-ask-nav-prev' ], Message::get( 'smw_result_next' ) . '&#160;' . $limit ) . ')';
+			$navigation .= Html::rawElement( 'span', [ 'class' => 'smw-ask-nav-prev' ], $next . '&#160;' . $limit ) . ')';
 		}
 
 		$first = true;
@@ -210,7 +230,13 @@ class NavigationLinksWidget {
 
 		$navigation .= ')';
 
-		return Html::rawElement( 'span', [ 'class' => 'smw-ask-result-navigation' ], $navigation );
+		return Html::rawElement(
+			'span',
+			[
+				'class' => 'smw-ask-result-navigation'
+			],
+			$navigation
+		);
 	}
 
 }


### PR DESCRIPTION
This PR is made in reference to: #

This PR addresses or contains:

- User language and avoid log messages like `...Message->parse/Message->toString/Message->parseText/MessageCache->parse with no title set...`
- Avoid property autocomplete (and hereby server request) on invalid characters like `#`, `|`
- Indicate an active autocomplete process

![image](https://user-images.githubusercontent.com/1245473/29485581-1b65d234-850f-11e7-83a5-afab950b9f55.png)

This PR includes:
- [ ] Tests (unit/integration)
- [x] CI build passed

Fixes #