### PR TITLE
Special:Ask hide buttons on export format

### DIFF
--- a/i18n/en.json
+++ b/i18n/en.json
@@ -233,6 +233,7 @@
 	"smw-ask-empty": "Empty",
 	"smw-ask-format": "Format",
 	"smw-ask-format-selection-help": "For a detailed description, please visit the $1 help page.",
+	"smw-ask-format-export-info": "You have selected an export format with no visual representation. Be aware that results are provided as download.",
 	"smw-ask-query-search-info": "The query <code><nowiki>$1</nowiki></code> was answered by the {{PLURAL:$3|1=<code>$2</code> (from cache)|<code>$2</code> (from cache)|<code>$2</code>}} in $4 {{PLURAL:$4|second|seconds}}.",
 	"searchbyproperty": "Search by property",
 	"processingerrorlist": "Processing error list",

--- a/includes/specials/SMW_SpecialAsk.php
+++ b/includes/specials/SMW_SpecialAsk.php
@@ -495,7 +495,7 @@ class SMWAskPage extends SpecialPage {
 			$searchInfoText
 		);
 
-		$result .= ( $navigation !== '' ? '<div class="smw-ask-cond-info">'. $searchInfoText . '</div>' . '<hr class="smw-form-horizontalrule"><div class="smw-ask-actions-nav">' .  $navigation . '&#160;&#160;&#160;' . $downloadLink : '' ) . '</div>' .
+		$result .= ( $navigation !== '' ? '<div id="ask-navinfo"><div class="smw-ask-cond-info">'. $searchInfoText . '</div>' . '<hr class="smw-form-horizontalrule"><div class="smw-ask-actions-nav">' .  $navigation . '&#160;&#160;&#160;' . $downloadLink : '' ) . '</div></div>' .
 			"\n</fieldset></div>\n</form>\n";
 
 		return $result;

--- a/res/Resources.php
+++ b/res/Resources.php
@@ -260,7 +260,8 @@ return array(
 		),
 		'messages' => array(
 			'smw-ask-delete',
-			'smw-ask-format-selection-help'
+			'smw-ask-format-selection-help',
+			'smw-ask-format-export-info'
 		),
 		'position' => 'top',
 		'targets' => array(

--- a/res/smw/special/ext.smw.special.ask.js
+++ b/res/smw/special/ext.smw.special.ask.js
@@ -67,7 +67,9 @@
 		formatHelp: function( options ){
 			// Make sure we don't have a pre existing element, using id as selector
 			// as it is faster compared to the class selector
-			$( '#formatHelp' ).replaceWith( '<span id="formatHelp" class="smw-ask-format-selection-help">' + mw.msg( 'smw-ask-format-selection-help', addFormatHelpLink( options ) ) + '</span>' );
+			$( '#formatHelp' ).replaceWith(
+				'<span id="formatHelp" class="smw-ask-format-selection-help">' + mw.msg( 'smw-ask-format-selection-help', addFormatHelpLink( options ) ) + '</span>'
+			);
 		}
 	};
 
@@ -91,13 +93,10 @@
 
 	/**
 	 * Multiple sorting
-	 * Code for handling adding and removing the "sort" inputs
-	 *
-	 * @TODO Something don't quite work here but it is broken from the beginning therefore ...
 	 */
 	var num_elements = $( '#sorting_main > div' ).length;
 
-	function addInstance(starter_div_id, main_div_id) {
+	function addSortInstance(starter_div_id, main_div_id) {
 		num_elements++;
 
 		var starter_div = $( '#' + starter_div_id),
@@ -117,8 +116,9 @@
 			'data-target': 'sort_div_' + num_elements
 		} ).text( mw.msg( 'smw-ask-delete' ) );
 
+		// Register event on the added instance
 		button.click( function( event ) {
-			removeInstance( $(this).data( 'target' ) );
+			removeInstance( $( this ).data( 'target' ) );
 		} );
 
 		new_div.append(
@@ -126,12 +126,12 @@
 		);
 
 		// Trigger an event to ensure that the input field has an autocomplete
-		// instance attach
+		// instance attached
 		main_div.trigger( 'SMW::Property::Autocomplete' , {
 			'context': new_div
 		} );
 
-		//Add the new instance
+		// Add the new instance
 		main_div.append( new_div );
 	}
 
@@ -145,6 +145,8 @@
 	 * @ignore
 	 */
 	$( document ).ready( function() {
+
+		var h = mw.html;
 
 		// Field input is kept disabled until JS is fully loaded to signal
 		// "ready for input"
@@ -169,12 +171,39 @@
 		} );
 
 		$( '.smw-ask-sort-add-action' ).click( function() {
-			addInstance( 'sorting_starter', 'sorting_main' );
+			addSortInstance( 'sorting_starter', 'sorting_main' );
 		} );
 
 		// Change format parameter form via ajax
-		$( '#formatSelector' ).change( function() {
-			var $this = $( this );
+		$( '#formatSelector' ).change( function( event, $opts ) {
+
+			var $this = $( this ),
+				exportHideList = '#ask-embed, #inlinequeryembed, #ask-showhide, #ask-debug, #ask-clipboard, #ask-navinfo, #result';
+
+			// Display the options list for the time the list is being generated
+			// via an ajax request
+			$( '#options-list' ).addClass( 'is-disabled');
+
+			// Hide buttons/elements that cannot be used on an export format
+			if ( $this.find( 'option:selected' ).data( 'isexport' ) == 1 ) {
+				$( exportHideList ).hide();
+
+				if ( !$( "#export-info" ).length ) {
+					var html = h.element(
+						'div',
+						{
+							id: 'export-info',
+							class: 'smw-callout smw-callout-info'
+						},
+						mw.msg( 'smw-ask-format-export-info' )
+					);
+
+					$( '#result' ).after( html );
+				};
+			} else {
+				$( exportHideList ).show();
+				$( '#export-info' ).remove();
+			}
 
 			$.ajax( {
 				// Evil hack to get more evil Spcial:Ask stuff to work with less evil JS.
@@ -183,7 +212,8 @@
 				'success': function( data ) {
 					$( '#options-list' ).html( data );
 
-					// Disabled state was set during the onChange in FormatSelectionWidget
+					// Remove disable state that was set at the beginning of the
+					// onChange event
 					$( '#options-list' ).removeClass( 'is-disabled' );
 
 					// Reinitialize functions after each ajax request

--- a/src/MediaWiki/Specials/Ask/ErrorWidget.php
+++ b/src/MediaWiki/Specials/Ask/ErrorWidget.php
@@ -39,6 +39,7 @@ class ErrorWidget {
 		return Html::rawElement(
 			'div',
 			array(
+				'id'    => 'ask-status',
 				'class' => 'smw-ask-status plainlinks'
 			),
 			Html::rawElement(

--- a/src/MediaWiki/Specials/Ask/LinksWidget.php
+++ b/src/MediaWiki/Specials/Ask/LinksWidget.php
@@ -45,32 +45,39 @@ class LinksWidget {
 			"document.getElementById('embed_show').style.display='inline';" .
 			"document.getElementById('embed_hide').style.display='none';";
 
-		return Html::rawElement( 'span', [ 'class' => 'smw-ask-button smw-ask-button-lblue' ], Html::rawElement(
+		return Html::rawElement(
 			'span',
-			array(
-				'id'  => 'embed_show'
-			), Html::rawElement(
-				'a',
+			[
+				'id' => 'ask-embed',
+				'class' => 'smw-ask-button smw-ask-button-lblue'
+			],
+			Html::rawElement(
+				'span',
 				array(
-					'href'  => '#embed_show',
-					'rel'   => 'nofollow',
-					'onclick' => $embedShow
-				), wfMessage( 'smw_ask_show_embed' )->escaped()
-			)
-		) . Html::rawElement(
-			'span',
-			array(
-				'id'  => 'embed_hide',
-				'style'  => 'display: none;'
-			), Html::rawElement(
-				'a',
+					'id'  => 'embed_show'
+				), Html::rawElement(
+					'a',
+					array(
+						'href'  => '#embed_show',
+						'rel'   => 'nofollow',
+						'onclick' => $embedShow
+					), wfMessage( 'smw_ask_show_embed' )->escaped()
+				)
+			) . Html::rawElement(
+				'span',
 				array(
-					'href'  => '#embed_hide',
-					'rel'   => 'nofollow',
-					'onclick' => $embedHide
-				), wfMessage( 'smw_ask_hide_embed' )->escaped()
+					'id'  => 'embed_hide',
+					'style'  => 'display: none;'
+				), Html::rawElement(
+					'a',
+					array(
+						'href'  => '#embed_hide',
+						'rel'   => 'nofollow',
+						'onclick' => $embedHide
+					), wfMessage( 'smw_ask_hide_embed' )->escaped()
+				)
 			)
-		) );
+		);
 	}
 
 	/**
@@ -154,6 +161,7 @@ class LinksWidget {
 		return Html::rawElement(
 			'span',
 			[
+				'id' => 'ask-showhide',
 				'class' => 'smw-ask-button smw-ask-button-lblue'
 			], Html::element(
 				'a',
@@ -188,6 +196,7 @@ class LinksWidget {
 		return Html::rawElement(
 			'span',
 			[
+				'id' => 'ask-debug',
 				'class' => 'smw-ask-button smw-ask-button-right'
 			],
 			Html::element(
@@ -218,6 +227,7 @@ class LinksWidget {
 		return Html::rawElement(
 			'span',
 			[
+				'id' => 'ask-clipboard',
 				'class' => 'smw-ask-button smw-ask-button-right smw-ask-button-lgrey'
 			],
 			Html::element(

--- a/tests/phpunit/Integration/JSONScript/TestCases/s-0018.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/s-0018.json
@@ -23,7 +23,7 @@
 			},
 			"assert-output": {
 				"to-contain": [
-					"<div class=\"smw-ask-status plainlinks\"><noscript><div class=\"smw-callout smw-callout-error\">"
+					"<div id=\"ask-status\" class=\"smw-ask-status plainlinks\"><noscript><div class=\"smw-callout smw-callout-error\">"
 				]
 			}
 		}

--- a/tests/phpunit/Unit/MediaWiki/Specials/Ask/FormatSelectionWidgetTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Specials/Ask/FormatSelectionWidgetTest.php
@@ -16,31 +16,27 @@ use SMW\Tests\TestEnvironment;
  */
 class FormatSelectionWidgetTest extends \PHPUnit_Framework_TestCase {
 
-	private $stringValidator;
-
-	protected function setUp() {
-		$testEnvironment = new TestEnvironment();
-
-		$this->stringValidator = $testEnvironment->getUtilityFactory()->newValidatorFactory()->newStringValidator();
-	}
-
 	public function testEmptyParameters() {
+
+		$stringValidator = TestEnvironment::newValidatorFactory()->newStringValidator();
 
 		$title = $this->getMockBuilder( '\Title' )
 			->disableOriginalConstructor()
 			->getMock();
 
-		$this->stringValidator->assertThatStringContains(
+		$stringValidator->assertThatStringContains(
 			[
 				'<fieldset id="format" class="smw-ask-format" style="margin-top:0px;"><legend>.*</legend>',
 				'<span class="smw-ask-format-list"><input type="hidden" value="yes" name="eq"',
-				'<option value="broadtable" selected="selected">.*</option>'
+				'<option value="broadtable" selected="">.*</option>'
 			],
 			FormatSelectionWidget::selection( $title, [] )
 		);
 	}
 
 	public function testSetResultFormats() {
+
+		$stringValidator = TestEnvironment::newValidatorFactory()->newStringValidator();
 
 		$title = $this->getMockBuilder( '\Title' )
 			->disableOriginalConstructor()
@@ -52,10 +48,10 @@ class FormatSelectionWidgetTest extends \PHPUnit_Framework_TestCase {
 			]
 		);
 
-		$this->stringValidator->assertThatStringContains(
+		$stringValidator->assertThatStringContains(
 			[
 				'<option value="broadtable">.*</option>',
-				'<option value="rdf" selected="selected">.*</option>'
+				'<option data-isexport="1" value="rdf" selected="">.*</option>'
 			],
 			FormatSelectionWidget::selection( $title, [ 'format' => 'rdf' ] )
 		);


### PR DESCRIPTION
This PR is made in reference to: #

This PR addresses or contains:

- Hide buttons that cannot be used in combination with an export format and show a message about the selected state.

![image](https://user-images.githubusercontent.com/1245473/29489160-21daf6c6-8555-11e7-9958-9229d20c2336.png)


This PR includes:
- [ ] Tests (unit/integration)
- [x] CI build passed

Fixes #