### PR TITLE
Add JSON explain format option in query debug mode

### DIFF
--- a/src/Query/DebugOutputFormatter.php
+++ b/src/Query/DebugOutputFormatter.php
@@ -14,6 +14,45 @@ use SMW\ProcessingErrorMsgHandler;
  */
 class DebugOutputFormatter {
 
+	const JSON_FORMAT = 'json';
+
+	/**
+	 * @var boolean
+	 */
+	private static $explainFormat = '';
+
+	/**
+	 * @since 3.0
+	 *
+	 * @param string $explainFormat
+	 */
+	public static function setExplainFormat( $explainFormat ) {
+		if ( $explainFormat === self::JSON_FORMAT ) {
+			self::$explainFormat = $explainFormat;
+		}
+	}
+
+	/**
+	 * @since 3.0
+	 *
+	 * @param string $type
+	 *
+	 * @return string
+	 */
+	public static function getFormat( $type ) {
+
+		$format = '';
+
+		// Use a more expressive explain output
+		// https://dev.mysql.com/doc/refman/5.6/en/explain.html
+		// https://mariadb.com/kb/en/mariadb/explain-formatjson-in-mysql/
+		if ( $type === 'mysql' && self::$explainFormat === self::JSON_FORMAT ) {
+			$format = 'FORMAT=json';
+		}
+
+		return $format;
+	}
+
 	/**
 	 * Generate textual debug output that shows an arbitrary list of informative
 	 * fields. Used for formatting query debug output.
@@ -96,6 +135,11 @@ class DebugOutputFormatter {
 			'<th style="text-align: left;">Extra</th></tr>';
 
 			foreach ( $res as $row ) {
+
+				if ( isset( $row->EXPLAIN ) ) {
+					return '<div class="smwpre">' . $row->EXPLAIN . '</div>';
+				}
+
 				$output .= "<tr><td>" . $row->id .
 				"</td><td>" . $row->select_type .
 				"</td><td>" . $row->table .

--- a/src/SQLStore/QueryEngine/QueryEngine.php
+++ b/src/SQLStore/QueryEngine/QueryEngine.php
@@ -283,6 +283,10 @@ class QueryEngine implements QueryEngineInterface, LoggerAwareInterface {
 		$sortfields = implode( $qobj->sortfields, ',' );
 		$sortfields = $sortfields ? ', ' . $sortfields : '';
 
+		$format = QueryDebugOutputFormatter::getFormat(
+			$connection->getType()
+		);
+
 		$sql = "SELECT DISTINCT ".
 			"$qobj->alias.smw_id AS id," .
 			"$qobj->alias.smw_title AS t," .
@@ -298,7 +302,7 @@ class QueryEngine implements QueryEngineInterface, LoggerAwareInterface {
 			"OFFSET " . $sqlOptions['OFFSET'];
 
 		$res = $connection->query(
-			'EXPLAIN '. $sql,
+			"EXPLAIN $format $sql",
 			__METHOD__
 		);
 

--- a/tests/phpunit/Unit/Query/DebugOutputFormatterTest.php
+++ b/tests/phpunit/Unit/Query/DebugOutputFormatterTest.php
@@ -25,6 +25,16 @@ class DebugOutputFormatterTest extends \PHPUnit_Framework_TestCase {
 		);
 	}
 
+	public function testExplainFormat() {
+
+		DebugOutputFormatter::setExplainFormat( DebugOutputFormatter::JSON_FORMAT );
+
+		$this->assertEquals(
+			'FORMAT=json',
+			DebugOutputFormatter::getFormat( 'mysql' )
+		);
+	}
+
 	public function testFormatDebugOutputWithQuery() {
 
 		$description = $this->getMockBuilder( '\SMW\Query\Language\Description' )
@@ -52,7 +62,7 @@ class DebugOutputFormatterTest extends \PHPUnit_Framework_TestCase {
 	}
 
 	/**
-	 * @dataProvider sqlFormatProvider
+	 * @dataProvider sqlExplainFormatProvider
 	 */
 	public function testFormatSQLExplainOutput( $type, $res ) {
 
@@ -89,9 +99,9 @@ class DebugOutputFormatterTest extends \PHPUnit_Framework_TestCase {
 		);
 	}
 
-	public function sqlFormatProvider() {
+	public function sqlExplainFormatProvider() {
 
-		$mysqlFormat = array(
+		$row = array(
 			'id' => '',
 			'select_type' => '',
 			'table' => '',
@@ -106,7 +116,7 @@ class DebugOutputFormatterTest extends \PHPUnit_Framework_TestCase {
 
 		$provider[] = array(
 			'mysql',
-			array( (object)$mysqlFormat )
+			array( (object)$row )
 		);
 
 		$provider[] = array(
@@ -117,6 +127,15 @@ class DebugOutputFormatterTest extends \PHPUnit_Framework_TestCase {
 		$provider[] = array(
 			'sqlite',
 			''
+		);
+
+		$row = [
+			'EXPLAIN' => 'Foooooooo'
+		];
+
+		$provider[] = array(
+			'mysql',
+			array( (object)$row )
 		);
 
 		return $provider;


### PR DESCRIPTION
This PR is made in reference to: #

This PR addresses or contains:

- https://mariadb.com/kb/en/mariadb/explain-formatjson-in-mysql/

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed
