### PR TITLE
Special:Ask fix checkbox parameter input

### DIFF
--- a/src/MediaWiki/Specials/Ask/ParameterInput.php
+++ b/src/MediaWiki/Specials/Ask/ParameterInput.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace SMW;
+namespace SMW\MediaWiki\Specials\Ask;
 
 use Html;
 use ParamProcessor\ParamDefinition;
@@ -118,8 +118,7 @@ class ParameterInput {
 					$html = $this->getStrInput();
 					break;
 			}
-		}
-		else {
+		} else {
 			$html = $this->param->isList() ? $this->getCheckboxListInput( $valueList ) : $this->getSelectInput( $valueList );
 		}
 
@@ -245,23 +244,37 @@ class ParameterInput {
 	 */
 	protected function getCheckboxListInput( array $valueList ) {
 		$boxes = array();
+		$currentValues = array();
 
-		$currentValues = (array)$this->getValueToUse();
-		if ( is_null( $currentValues ) ) {
-			$currentValues = array();
+		$values = $this->getValueToUse();
+
+		// List of comma separated values, see ParametersProcessor::getParameterList
+		if ( strpos( $values, ',' ) !== false ) {
+			$currentValues = array_flip(
+				array_map( 'trim', explode( ',', $values ) )
+			);
+		} elseif ( $values !== '' ) {
+			$currentValues[$values] = true;
 		}
 
 		foreach ( $valueList as $value ) {
+
+			// Use a value not a simple "true"
+			$attr = [
+				'type' => 'checkbox',
+				'name' => $this->inputName . '[]',
+				'value' => $value
+			];
+
 			$boxes[] = Html::rawElement(
 				'span',
 				array(
 					'style' => 'white-space: nowrap; padding-right: 5px;'
 				),
-				Xml::check(
-					$this->inputName . '[' . htmlspecialchars( $value ). ']',
-					in_array( $value, $currentValues )
-				) .
-				Html::element( 'tt', array(), $value )
+				Html::rawElement(
+					'input',
+					$attr + ( isset( $currentValues[$value] ) ? [ 'checked' ] : [] )
+				) . Html::element( 'tt', array(), $value )
 			);
 		}
 

--- a/src/MediaWiki/Specials/Ask/ParametersProcessor.php
+++ b/src/MediaWiki/Specials/Ask/ParametersProcessor.php
@@ -169,6 +169,13 @@ class ParametersProcessor {
 			$parameterList = Infolink::decodeParameters( $query_values, false );
 		}
 
+		foreach ( $parameterList as $key => $value ) {
+			// Concatenate checkbox values into a simple comma separated list
+			if ( is_array( $value ) ) {
+				$parameterList[$key] = implode( ',', $value );
+			}
+		}
+
 		return $parameterList;
 	}
 

--- a/src/MediaWiki/Specials/Ask/ParametersWidget.php
+++ b/src/MediaWiki/Specials/Ask/ParametersWidget.php
@@ -3,7 +3,6 @@
 namespace SMW\MediaWiki\Specials\Ask;
 
 use ParamProcessor\ParamDefinition;
-use SMW\ParameterInput;
 use SMW\Message;
 use SMWQueryProcessor as QueryProcessor;
 use Html;

--- a/tests/phpunit/Unit/MediaWiki/Specials/Ask/ParameterInputTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Specials/Ask/ParameterInputTest.php
@@ -1,0 +1,106 @@
+<?php
+
+namespace SMW\Tests\MediaWiki\Specials\Ask;
+
+use SMW\MediaWiki\Specials\Ask\ParameterInput;
+use SMW\Tests\TestEnvironment;
+
+/**
+ * @covers \SMW\MediaWiki\Specials\Ask\ParameterInput
+ * @group semantic-mediawiki
+ *
+ * @license GNU GPL v2+
+ * @since 3.0
+ *
+ * @author mwjames
+ */
+class ParameterInputTest extends \PHPUnit_Framework_TestCase {
+
+	public function testCanConstruct() {
+
+		$paramDefinition = $this->getMockBuilder( '\ParamProcessor\ParamDefinition' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$this->assertInstanceOf(
+			ParameterInput::class,
+			new ParameterInput( $paramDefinition, '' )
+		);
+	}
+
+	/**
+	 * @dataProvider listValueProvider
+	 */
+	public function testGetHtmlOnCheckboxList( $currentValue, $allowedValues, $expected ) {
+
+		$stringValidator = TestEnvironment::newValidatorFactory()->newStringValidator();
+
+		$paramDefinition = $this->getMockBuilder( '\ParamProcessor\ParamDefinition' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$paramDefinition->expects( $this->atLeastOnce() )
+			->method( 'getAllowedValues' )
+			->will( $this->returnValue( $allowedValues ) );
+
+		$paramDefinition->expects( $this->any() )
+			->method( 'isList' )
+			->will( $this->returnValue( true ) );
+
+		$instance = new ParameterInput(
+			$paramDefinition,
+			$currentValue
+		);
+
+		$stringValidator->assertThatStringContains(
+			$expected,
+			$instance->getHtml()
+		);
+	}
+
+	public function listValueProvider() {
+
+		$provider[] = [
+			'Foo',
+			[ 'Foo', 'Bar' ],
+			[
+				'<span style="white-space: nowrap; padding-right: 5px;"><input type="checkbox" name="[]" value="Foo" checked="".*><tt>Foo</tt></span>',
+				'<span style="white-space: nowrap; padding-right: 5px;"><input type="checkbox" name="[]" value="Bar".*><tt>Bar</tt></span>'
+			],
+
+		];
+
+		$provider[] = [
+			[ 'Foo' ],
+			[ 'Foo', 'Bar' ],
+			[
+				'<span style="white-space: nowrap; padding-right: 5px;"><input type="checkbox" name="[]" value="Foo" checked="".*><tt>Foo</tt></span>',
+				'<span style="white-space: nowrap; padding-right: 5px;"><input type="checkbox" name="[]" value="Bar".*><tt>Bar</tt></span>'
+			],
+
+		];
+
+		$provider[] = [
+			[ 'Foo, Bar' ],
+			[ 'Foo', 'Bar' ],
+			[
+				'<span style="white-space: nowrap; padding-right: 5px;"><input type="checkbox" name="[]" value="Foo" checked="".*><tt>Foo</tt></span>',
+				'<span style="white-space: nowrap; padding-right: 5px;"><input type="checkbox" name="[]" value="Bar" checked="".*><tt>Bar</tt></span>'
+			],
+
+		];
+
+		$provider[] = [
+			[ 'Foo,foo bar' ],
+			[ 'Foo', 'foo bar' ],
+			[
+				'<span style="white-space: nowrap; padding-right: 5px;"><input type="checkbox" name="[]" value="Foo" checked="".*><tt>Foo</tt></span>',
+				'<span style="white-space: nowrap; padding-right: 5px;"><input type="checkbox" name="[]" value="foo bar" checked="".*><tt>foo bar</tt></span>'
+			],
+
+		];
+
+		return $provider;
+	}
+
+}

--- a/tests/phpunit/Unit/MediaWiki/Specials/Ask/ParametersProcessorTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Specials/Ask/ParametersProcessorTest.php
@@ -74,4 +74,40 @@ class ParametersProcessorTest extends \PHPUnit_Framework_TestCase {
 		ParametersProcessor::process( $request, $parameters );
 	}
 
+	public function testParametersOn_p_Array_Request() {
+
+		$request = $this->getMockBuilder( '\WebRequest' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$request->expects( $this->at( 0 ) )
+			->method( 'getCheck' )
+			->with( $this->equalTo( 'q' ) )
+			->will( $this->returnValue( true ) );
+
+		$request->expects( $this->at( 1 ) )
+			->method( 'getVal' )
+			->with( $this->equalTo( 'p' ) )
+			->will( $this->returnValue( '' ) );
+
+		$request->expects( $this->at( 2 ) )
+			->method( 'getArray' )
+			->with( $this->equalTo( 'p' ) )
+			->will( $this->returnValue( [ 'foo' => [ 'Bar', 'foobar' ] ] ) );
+
+		$parameters = [];
+
+		$res = ParametersProcessor::process( $request, $parameters );
+
+		$this->assertEquals(
+			[
+				'foo'    => 'Bar,foobar',
+				'format' => 'broadtable',
+				'offset' => null,
+				'limit'  => null
+			],
+			$res[1]
+		);
+	}
+
 }


### PR DESCRIPTION
This PR is made in reference to: #

This PR addresses or contains:

- I don't now since when (probably from the start and wasn't tested) but using multiple checkboxes in `Special:Ask` didn't work because you need an `array` as request type and require the checkbox value to be a "value" not just a `true` to ensure to build a comma separate list from selected values during processing

![image](https://user-images.githubusercontent.com/1245473/29741172-0df2a29c-8aa2-11e7-9853-f4f83162fd67.png)


This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed

Fixes #