### PR TITLE
Fix broadtable 100% width on MobileFrontend

### DIFF
--- a/includes/queryprinters/TableResultPrinter.php
+++ b/includes/queryprinters/TableResultPrinter.php
@@ -109,6 +109,7 @@ class TableResultPrinter extends ResultPrinter {
 
 		if ( $this->mFormat == 'broadtable' ) {
 			$tableAttrs['width'] = '100%';
+			$tableAttrs['class'] .= ' broadtable';
 		}
 
 		if ( $this->isDataTable ) {

--- a/res/smw/ext.smw.css
+++ b/res/smw/ext.smw.css
@@ -848,3 +848,8 @@ a.smw-ask-action-btn-lblue:hover {
 	from {transform: rotate(0deg);}
 	to {transform: rotate(359deg);}
 }
+
+/* MobileFrontend overrides some desktop rules */
+.content table.broadtable, .smw-ask-result table.broadtable {
+	width: 100% !important;
+}

--- a/tests/phpunit/Integration/JSONScript/TestCases/f-0202.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/f-0202.json
@@ -67,7 +67,7 @@
 			"subject": "Broadtable-with-sep-parameter",
 			"assert-output": {
 				"to-contain": [
-					"<table class=\"sortable wikitable smwtable\" width=\"100%\">",
+					"<table class=\"sortable wikitable smwtable broadtable\" width=\"100%\">",
 					"<th>&#160;</th><th class=\"Has-page\">Has page</th>",
 					"<th class=\"Has-text\">Has text</th>",
 					"<tr data-row-number=\"1\" class=\"row-odd\"><td class=\"smwtype_wpg\">Table-page</td>",


### PR DESCRIPTION
This PR is made in reference to: #

This PR addresses or contains:

- One should not use `!important` [0] but MobileFrontend does so on the table element and in order to remain true to the intended use of `broadtable` we need to counter the rule

![image](https://user-images.githubusercontent.com/1245473/29742434-233b55a0-8aba-11e7-96c2-4a7daa030f8d.png)

[0] https://css-tricks.com/when-using-important-is-the-right-choice/

This PR includes:
- [ ] Tests (unit/integration)
- [x] CI build passed

Fixes #