### PR TITLE
Specify hierarchy depth restriction in query condition, refs 2662

### DIFF
--- a/src/Query/Language/ClassDescription.php
+++ b/src/Query/Language/ClassDescription.php
@@ -24,6 +24,11 @@ class ClassDescription extends Description {
 	protected $m_diWikiPages;
 
 	/**
+	 * @var integer|null
+	 */
+	protected $hierarchyDepth;
+
+	/**
 	 * Constructor.
 	 *
 	 * @param mixed $content DIWikiPage or array of DIWikiPage
@@ -38,6 +43,29 @@ class ClassDescription extends Description {
 		} else {
 			throw new Exception( "ClassDescription::__construct(): parameter must be an DIWikiPage object or an array of such objects." );
 		}
+	}
+
+	/**
+	 * @since 3.0
+	 *
+	 * @param integer $hierarchyDepth
+	 */
+	public function setHierarchyDepth( $hierarchyDepth ) {
+
+		if ( $hierarchyDepth > $GLOBALS['smwgQSubcategoryDepth'] ) {
+			$hierarchyDepth = $GLOBALS['smwgQSubcategoryDepth'];
+		}
+
+		$this->hierarchyDepth = $hierarchyDepth;
+	}
+
+	/**
+	 * @since 3.0
+	 *
+	 * @return integer|null
+	 */
+	public function getHierarchyDepth() {
+		return $this->hierarchyDepth;
 	}
 
 	/**
@@ -63,7 +91,7 @@ class ClassDescription extends Description {
 
 		ksort( $hash );
 
-		return 'Cl:' . md5( implode( '|', array_keys( $hash ) ) );
+		return 'Cl:' . md5( implode( '|', array_keys( $hash ) ) . $this->hierarchyDepth );
 	}
 
 	/**
@@ -85,6 +113,10 @@ class ClassDescription extends Description {
 			} else {
 				$result .= '||' . $wikiValue->getText();
 			}
+		}
+
+		if ( $this->hierarchyDepth !== null ) {
+			$result .= '|+depth=' . $this->hierarchyDepth;
 		}
 
 		$result .= ']]';
@@ -130,11 +162,16 @@ class ClassDescription extends Description {
 			$result = new ClassDescription( array_slice( $this->m_diWikiPages, 0, $maxsize ) );
 			$rest = new ClassDescription( array_slice( $this->m_diWikiPages, $maxsize ) );
 
+			$result->setHierarchyDepth(
+				$this->getHierarchyDepth()
+			);
+
 			$log[] = $rest->getQueryString();
 			$maxsize = 0;
 		}
 
 		$result->setPrintRequests( $this->getPrintRequests() );
+
 		return $result;
 	}
 

--- a/src/Query/Language/Disjunction.php
+++ b/src/Query/Language/Disjunction.php
@@ -65,6 +65,26 @@ class Disjunction extends Description {
 		return $this->fingerprint = 'D:' . md5( implode( '|', array_keys( $fingerprint ) ) );
 	}
 
+	/**
+	 * @since 3.0
+	 *
+	 * @param integer $hierarchyDepth
+	 */
+	public function setHierarchyDepth( $hierarchyDepth ) {
+
+		$this->fingerprint = null;
+
+		if ( $this->classDescription !== null ) {
+			$this->classDescription->setHierarchyDepth( $hierarchyDepth );
+		}
+
+		foreach ( $this->descriptions as $key => $description ) {
+			if ( $description instanceof SomeProperty ) {
+				$description->setHierarchyDepth( $hierarchyDepth );
+			}
+		}
+	}
+
 	public function getDescriptions() {
 		return $this->descriptions;
 	}

--- a/src/SQLStore/QueryEngine/DescriptionInterpreters/ClassDescriptionInterpreter.php
+++ b/src/SQLStore/QueryEngine/DescriptionInterpreters/ClassDescriptionInterpreter.php
@@ -57,6 +57,7 @@ class ClassDescriptionInterpreter implements DescriptionInterpreter {
 		$cquery = new QuerySegment();
 		$cquery->type = QuerySegment::Q_CLASS_HIERARCHY;
 		$cquery->joinfield = array();
+		$cquery->depth = $description->getHierarchyDepth();
 
 		foreach ( $description->getCategories() as $category ) {
 

--- a/src/SQLStore/QueryEngine/DescriptionInterpreters/SomePropertyInterpreter.php
+++ b/src/SQLStore/QueryEngine/DescriptionInterpreters/SomePropertyInterpreter.php
@@ -143,6 +143,7 @@ class SomePropertyInterpreter implements DescriptionInterpreter {
 
 		// *** Now construct the query ... ***//
 		$query->joinTable = $proptable->getName();
+		$query->depth = $description->getHierarchyDepth();
 
 		// *** Add conditions for selecting rows for this property ***//
 		if ( !$proptable->isFixedPropertyTable() ) {
@@ -153,6 +154,7 @@ class SomePropertyInterpreter implements DescriptionInterpreter {
 			$pquery = new QuerySegment();
 			$pquery->type = QuerySegment::Q_PROP_HIERARCHY;
 			$pquery->joinfield = array( $pid );
+			$pquery->depth = $description->getHierarchyDepth();
 			$query->components[$pqid] = "{$query->alias}.p_id";
 
 			$this->querySegmentListBuilder->addQuerySegment( $pquery );

--- a/src/SQLStore/QueryEngine/HierarchyTempTableBuilder.php
+++ b/src/SQLStore/QueryEngine/HierarchyTempTableBuilder.php
@@ -108,14 +108,19 @@ class HierarchyTempTableBuilder {
 	 * @param string $type
 	 * @param string $tablename
 	 * @param string $valueComposite
+	 * @param integer|null $depth
 	 *
 	 * @throws RuntimeException
 	 */
-	public function createHierarchyTempTableFor( $type, $tablename, $valueComposite ) {
+	public function createHierarchyTempTableFor( $type, $tablename, $valueComposite, $depth = null ) {
 
 		$this->temporaryTableBuilder->create( $tablename );
 
-		list( $smwtable, $depth ) = $this->getHierarchyTableDefinitionForType( $type );
+		list( $smwtable, $d ) = $this->getHierarchyTableDefinitionForType( $type );
+
+		if ( $depth === null ) {
+			$depth = $d;
+		}
 
 		if ( array_key_exists( $valueComposite, $this->hierarchyCache ) ) { // Just copy known result.
 

--- a/src/SQLStore/QueryEngine/QuerySegment.php
+++ b/src/SQLStore/QueryEngine/QuerySegment.php
@@ -67,6 +67,11 @@ class QuerySegment {
 	public $type = self::Q_TABLE;
 
 	/**
+	 * @var integer|null
+	 */
+	public $depth;
+
+	/**
 	 * @var string
 	 */
 	public $fingerprint = '';

--- a/src/SQLStore/QueryEngine/QuerySegmentListProcessor.php
+++ b/src/SQLStore/QueryEngine/QuerySegmentListProcessor.php
@@ -264,6 +264,11 @@ class QuerySegmentListProcessor {
 			$type
 		);
 
+		// An individual depth was annotated as part of the query
+		if ( $query->depth !== null ) {
+			$depth = $query->depth;
+		}
+
 		if ( $depth <= 0 ) { // treat as value, no recursion
 			$query->type = QuerySegment::Q_VALUE;
 			return;
@@ -297,7 +302,8 @@ class QuerySegmentListProcessor {
 		$this->hierarchyTempTableBuilder->createHierarchyTempTableFor(
 			$type,
 			$tablename,
-			$values
+			$values,
+			$depth
 		);
 	}
 

--- a/tests/phpunit/Integration/JSONScript/TestCases/q-0614.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/q-0614.json
@@ -1,0 +1,109 @@
+{
+	"description": "Test query with category hierarchy depth (#2662, `wgContLang=en`, `smwgQSubpropertyDepth`, `smwgQSubcategoryDepth`, skip virtuoso)",
+	"setup": [
+		{
+			"namespace": "NS_CATEGORY",
+			"page": "Q0614",
+			"contents": "Super class"
+		},
+		{
+			"namespace": "NS_CATEGORY",
+			"page": "Q0614/1",
+			"contents": "[[Category:Q0614]]"
+		},
+		{
+			"namespace": "NS_CATEGORY",
+			"page": "Q0614/1/2",
+			"contents": "[[Category:Q0614/1]]"
+		},
+		{
+			"namespace": "NS_CATEGORY",
+			"page": "Q0614/1/2/3",
+			"contents": "[[Category:Q0614/1/2]]"
+		},
+		{
+			"page": "Example/Q0614/1",
+			"contents": "[[Category:Q0614]]"
+		},
+		{
+			"page": "Example/Q0614/1/2",
+			"contents": "[[Category:Q0614/1]]"
+		},
+		{
+			"page": "Example/Q0614/1/2/3",
+			"contents": "[[Category:Q0614/1/2]]"
+		}
+	],
+	"tests": [
+		{
+			"type": "query",
+			"about": "#0 select all members",
+			"condition": "[[Category:Q0614]]",
+			"printouts": [],
+			"parameters": {
+				"limit": "10"
+			},
+			"assert-queryresult": {
+				"count": 3,
+				"results": [
+					"Example/Q0614/1#0##",
+					"Example/Q0614/1/2#0##",
+					"Example/Q0614/1/2/3#0##"
+				]
+			}
+		},
+		{
+			"type": "query",
+			"about": "#1 depth=0",
+			"condition": "[[Category:Q0614|+depth=0]]",
+			"printouts": [],
+			"parameters": {
+				"limit": "10"
+			},
+			"assert-queryresult": {
+				"count": 1,
+				"results": [
+					"Example/Q0614/1#0##"
+				]
+			}
+		},
+		{
+			"type": "query",
+			"about": "#2 depth=1",
+			"condition": "[[Category:Q0614|+depth=1]]",
+			"printouts": [],
+			"parameters": {
+				"limit": "10"
+			},
+			"assert-queryresult": {
+				"count": 2,
+				"results": [
+					"Example/Q0614/1#0##",
+					"Example/Q0614/1/2#0##"
+				]
+			}
+		}
+	],
+	"settings": {
+		"smwgNamespacesWithSemanticLinks": {
+			"NS_MAIN": true,
+			"NS_CATEGORY": true,
+			"SMW_NS_PROPERTY": true
+		},
+		"wgContLang": "en",
+		"smwgQSubpropertyDepth": 10,
+		"smwgQSubcategoryDepth": 10,
+		"smwgSparqlQFeatures": [
+			"SMW_SPARQL_QF_SUBP",
+			"SMW_SPARQL_QF_SUBC"
+		]
+	},
+	"meta": {
+		"skip-on": {
+			"virtuoso": "Virtuoso 6.1 rdfs / subproperty/subcategory hierarchies are not supported"
+		},
+		"version": "2",
+		"is-incomplete": false,
+		"debug": false
+	}
+}

--- a/tests/phpunit/Integration/JSONScript/TestCases/q-0615.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/q-0615.json
@@ -1,0 +1,148 @@
+{
+	"description": "Test query with property hierarchy depth (#2662, `wgContLang=en`, `smwgQSubpropertyDepth`, `smwgQSubcategoryDepth`, skip virtuoso)",
+	"setup": [
+		{
+			"namespace": "SMW_NS_PROPERTY",
+			"page": "Q0615",
+			"contents": "Super property"
+		},
+		{
+			"namespace": "SMW_NS_PROPERTY",
+			"page": "Q0615/1",
+			"contents": "[[Subproperty of::Q0615]]"
+		},
+		{
+			"namespace": "SMW_NS_PROPERTY",
+			"page": "Q0615/1/2",
+			"contents": "[[Subproperty of::Q0615/1]]"
+		},
+		{
+			"namespace": "SMW_NS_PROPERTY",
+			"page": "Q0615/1/2/3",
+			"contents": "[[Subproperty of::Q0615/1/2]]"
+		},
+		{
+			"page": "Example/Q0615/1",
+			"contents": "[[Q0615::123]]"
+		},
+		{
+			"page": "Example/Q0615/1/2.1",
+			"contents": "[[Q0615/1::123]]"
+		},
+		{
+			"page": "Example/Q0615/1/2.2",
+			"contents": "[[Q0615/1::456]]"
+		},
+		{
+			"page": "Example/Q0615/1/2/3",
+			"contents": "[[Q0615/1/2::123]]"
+		}
+	],
+	"tests": [
+		{
+			"type": "query",
+			"about": "#0 select all members on discrete value",
+			"condition": "[[Q0615::123]]",
+			"printouts": [],
+			"parameters": {
+				"limit": "10"
+			},
+			"assert-queryresult": {
+				"count": 3,
+				"results": [
+					"Example/Q0615/1#0##",
+					"Example/Q0615/1/2.1#0##",
+					"Example/Q0615/1/2/3#0##"
+				]
+			}
+		},
+		{
+			"type": "query",
+			"about": "#1 select all members on any value",
+			"condition": "[[Q0615::+]]",
+			"printouts": [],
+			"parameters": {
+				"limit": "10"
+			},
+			"assert-queryresult": {
+				"count": 4,
+				"results": [
+					"Example/Q0615/1#0##",
+					"Example/Q0615/1/2.1#0##",
+					"Example/Q0615/1/2.2#0##",
+					"Example/Q0615/1/2/3#0##"
+				]
+			}
+		},
+		{
+			"type": "query",
+			"about": "#2 depth=0",
+			"condition": "[[Q0615::123|+depth=0]]",
+			"printouts": [],
+			"parameters": {
+				"limit": "10"
+			},
+			"assert-queryresult": {
+				"count": 1,
+				"results": [
+					"Example/Q0615/1#0##"
+				]
+			}
+		},
+		{
+			"type": "query",
+			"about": "#3 depth=1 on discrete value",
+			"condition": "[[Q0615::123|+depth=1]]",
+			"printouts": [],
+			"parameters": {
+				"limit": "10"
+			},
+			"assert-queryresult": {
+				"count": 2,
+				"results": [
+					"Example/Q0615/1#0##",
+					"Example/Q0615/1/2.1#0##"
+				]
+			}
+		},
+		{
+			"type": "query",
+			"about": "#4 depth=1 on any value",
+			"condition": "[[Q0615::+|+depth=1]]",
+			"printouts": [],
+			"parameters": {
+				"limit": "10"
+			},
+			"assert-queryresult": {
+				"count": 3,
+				"results": [
+					"Example/Q0615/1#0##",
+					"Example/Q0615/1/2.1#0##",
+					"Example/Q0615/1/2.2#0##"
+				]
+			}
+		}
+	],
+	"settings": {
+		"smwgNamespacesWithSemanticLinks": {
+			"NS_MAIN": true,
+			"SMW_NS_PROPERTY": true,
+			"SMW_NS_PROPERTY": true
+		},
+		"wgContLang": "en",
+		"smwgQSubpropertyDepth": 10,
+		"smwgQSubcategoryDepth": 10,
+		"smwgSparqlQFeatures": [
+			"SMW_SPARQL_QF_SUBP",
+			"SMW_SPARQL_QF_SUBC"
+		]
+	},
+	"meta": {
+		"skip-on": {
+			"virtuoso": "Virtuoso 6.1 rdfs / subproperty/subcategory hierarchies are not supported"
+		},
+		"version": "2",
+		"is-incomplete": false,
+		"debug": false
+	}
+}

--- a/tests/phpunit/Unit/Query/Language/ClassDescriptionTest.php
+++ b/tests/phpunit/Unit/Query/Language/ClassDescriptionTest.php
@@ -83,8 +83,6 @@ class ClassDescriptionTest extends \PHPUnit_Framework_TestCase {
 
 	public function testGetFingerprint() {
 
-		$ns = Localizer::getInstance()->getNamespaceTextById( NS_CATEGORY );
-
 		$instance = new ClassDescription(
 			new DIWikiPage( 'Foo', NS_CATEGORY )
 		);
@@ -140,6 +138,67 @@ class ClassDescriptionTest extends \PHPUnit_Framework_TestCase {
 		$this->assertEquals(
 			new ThingDescription(),
 			$instance->prune( $maxsize, $maxDepth, $log )
+		);
+	}
+
+	public function testStableFingerprint() {
+
+		$instance = new ClassDescription(
+			new DIWikiPage( 'Foo', NS_CATEGORY )
+		);
+
+		$this->assertSame(
+			'Cl:f35b531270067b4772aa3a1a907b8c81',
+			$instance->getFingerprint()
+		);
+	}
+
+	public function testHierarchyDepthToBeCeiledOnMaxQSubcategoryDepthSetting() {
+
+		$instance = new ClassDescription(
+			new DIWikiPage( 'Foo', NS_CATEGORY )
+		);
+
+		$instance->setHierarchyDepth( 9999999 );
+
+		$this->assertSame(
+			$GLOBALS['smwgQSubcategoryDepth'],
+			$instance->getHierarchyDepth()
+		);
+	}
+
+	public function testGetQueryStringWithHierarchyDepth() {
+
+		$ns = Localizer::getInstance()->getNamespaceTextById( NS_CATEGORY );
+
+		$instance = new ClassDescription(
+			new DIWikiPage( 'Foo', NS_CATEGORY )
+		);
+
+		$instance->setHierarchyDepth( 1 );
+
+		$this->assertSame(
+			"[[$ns:Foo|+depth=1]]",
+			$instance->getQueryString()
+		);
+	}
+
+	public function testVaryingHierarchyDepthCausesDifferentFingerprint() {
+
+		$instance = new ClassDescription(
+			new DIWikiPage( 'Foo', NS_CATEGORY )
+		);
+
+		$instance->setHierarchyDepth( 9999 );
+		$expected = $instance->getFingerprint();
+
+		$instance = new ClassDescription(
+			new DIWikiPage( 'Foo', NS_CATEGORY )
+		);
+
+		$this->assertNotSame(
+			$expected,
+			$instance->getFingerprint()
 		);
 	}
 

--- a/tests/phpunit/Unit/Query/Language/DisjunctionTest.php
+++ b/tests/phpunit/Unit/Query/Language/DisjunctionTest.php
@@ -7,6 +7,7 @@ use SMW\Localizer;
 use SMW\Query\Language\Conjunction;
 use SMW\Query\Language\Disjunction;
 use SMW\Query\Language\NamespaceDescription;
+use SMW\Query\Language\ClassDescription;
 use SMW\Query\Language\ThingDescription;
 use SMW\Query\Language\ValueDescription;
 
@@ -263,6 +264,34 @@ class DisjunctionTest extends \PHPUnit_Framework_TestCase {
 		);
 
 		return $provider;
+	}
+
+	public function testVaryingHierarchyDepthCausesClassDescriptionToYieldDifferentFingerprint() {
+
+		$descriptions = [
+			new ClassDescription( new DIWikiPage( 'Foo', NS_CATEGORY ) )
+		];
+
+		$instance = new Disjunction(
+			$descriptions
+		);
+
+		$expected = $instance->getFingerprint();
+
+		$descriptions = [
+			new ClassDescription( new DIWikiPage( 'Foo', NS_CATEGORY ) )
+		];
+
+		$instance = new Disjunction(
+			$descriptions
+		);
+
+		$instance->setHierarchyDepth( 1 );
+
+		$this->assertNotSame(
+			$expected,
+			$instance->getFingerprint()
+		);
 	}
 
 }

--- a/tests/phpunit/Unit/Query/Language/SomePropertyTest.php
+++ b/tests/phpunit/Unit/Query/Language/SomePropertyTest.php
@@ -266,6 +266,98 @@ class SomePropertyTest extends \PHPUnit_Framework_TestCase {
 		);
 	}
 
+	public function testStableFingerprint() {
+
+		$property = new DIProperty( 'Foo' );
+
+		$description = new ValueDescription(
+			new DIWikiPage( 'Bar', NS_MAIN ),
+			$property
+		);
+
+		$instance = new SomeProperty(
+			$property,
+			$description
+		);
+
+		$this->assertSame(
+			'S:17184798751fd76ae86d1c18bbce6954',
+			$instance->getFingerprint()
+		);
+	}
+
+	public function testHierarchyDepthToBeCeiledOnMaxQSubpropertyDepthSetting() {
+
+		$property = new DIProperty( 'Foo' );
+
+		$description = new ValueDescription(
+			new DIWikiPage( 'Bar', NS_MAIN ),
+			$property
+		);
+
+		$instance = new SomeProperty(
+			$property,
+			$description
+		);
+
+		$instance->setHierarchyDepth( 9999999 );
+
+		$this->assertSame(
+			$GLOBALS['smwgQSubpropertyDepth'],
+			$instance->getHierarchyDepth()
+		);
+	}
+
+	public function testGetQueryStringWithHierarchyDepth() {
+
+		$property = new DIProperty( 'Foo' );
+
+		$description = new ValueDescription(
+			new DIWikiPage( 'Bar', NS_MAIN ),
+			$property
+		);
+
+		$instance = new SomeProperty(
+			$property,
+			$description
+		);
+
+		$instance->setHierarchyDepth( 1 );
+
+		$this->assertSame(
+			"[[Foo::Bar|+depth=1]]",
+			$instance->getQueryString()
+		);
+	}
+
+	public function testVaryingHierarchyDepthCausesDifferentFingerprint() {
+
+		$property = new DIProperty( 'Foo' );
+
+		$description = new ValueDescription(
+			new DIWikiPage( 'Bar', NS_MAIN ),
+			$property
+		);
+
+		$instance = new SomeProperty(
+			$property,
+			$description
+		);
+
+		$instance->setHierarchyDepth( 9999 );
+		$expected = $instance->getFingerprint();
+
+		$instance = new SomeProperty(
+			$property,
+			$description
+		);
+
+		$this->assertNotSame(
+			$expected,
+			$instance->getFingerprint()
+		);
+	}
+
 	public function comparativeHashProvider() {
 
 		// Same property, different description === different hash


### PR DESCRIPTION
This PR is made in reference to: #2662 (#1003, #1012)

This PR addresses or contains:

- Introduces the syntax of `+depth=`  in connection with resolving hierarchies for conditions like `[[Category:Foo|+depth=0]]` and `[[SomeProperty:SomeValue|+depth=0]]`
- Limitations for the `SPARQLStore` as described in #2662 by supporting only `0, 1, or any`

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed

Fixes #2662