### PR TITLE
Add support for mandatory properties, refs 2669

### DIFF
--- a/DefaultSettings.php
+++ b/DefaultSettings.php
@@ -500,7 +500,7 @@ return array(
 	#
 	# @since 1.0
 	##
-	'smwgQComparators' => '<|>|!~|!|~|≤|≥|<<|>>|~=|like:|nlike:',
+	'smwgQComparators' => '<|>|!~|!|~|≤|≥|<<|>>|~=|like:|nlike:|!+',
 	##
 
 	###
@@ -734,7 +734,7 @@ return array(
 	# @since 1.6
 	##
 	'smwgDeclarationProperties' => array(
-		'_PVAL', '_LIST', '_PVAP', '_PVUC', '_PDESC', '_PPLB', '_PREC', '_PDESC'
+		'_PVAL', '_LIST', '_PVAP', '_PVUC', '_PDESC', '_PPLB', '_PREC', '_PDESC', '_MREI'
 	),
 	##
 
@@ -1670,5 +1670,29 @@ return array(
 	##
 	'smwgChangePropagationProtection' => true,
 	##
+
+	##
+	# Supported mandatory requiremnts in namespaces
+	#
+	# Mandatory properties will be checked for each entity on those enabled
+	# namespaces. Changes to the content of the list requires to run
+	# the `rebuildData.php` script.
+	#
+	# $GLOBALS['smwgMandatoryRequirementsNamespaceList'] = [
+	#		NS_MAIN => true,
+	#		NS_HELP => true
+	# ];
+	#
+	# An empty assignment will disable any checks even though `Is mandatory`
+	# or `{{#mandatory: ...}}` are maintained.
+	#
+	# $GLOBALS['smwgMandatoryRequirementsNamespaceList'] = [];
+	#
+	# @since 3.0
+	# @default []
+	##
+	'smwgMandatoryRequirementsNamespaceList' => [
+		NS_MAIN => true
+	],
 
 );

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -603,5 +603,6 @@
 	"apihelp-askargs-summary": "API module to query Semantic MediaWiki using the ask language as list of conditions, printouts and parameters.",
 	"apihelp-browsebyproperty-summary": "API module to retrieve information about a property or list of properties.",
 	"apihelp-browsebysubject-summary": "API module to retrieve information about a subject.",
-	"apihelp-smwtask-summary": "API module to execute Semantic MediaWiki related tasks."
+	"apihelp-smwtask-summary": "API module to execute Semantic MediaWiki related tasks.",
+	"smw-pa-property-predefined_mand": "\"$1\" is a predefined property provided by [https://www.semantic-mediawiki.org/wiki/Help:Special_properties Semantic MediaWiki] to declare a property instance to be mandatory to an entity (subject, subobject etc.)."
 }

--- a/i18n/extra/SemanticMediaWiki.magic.php
+++ b/i18n/extra/SemanticMediaWiki.magic.php
@@ -13,6 +13,7 @@ $magicWords = array();
 
 /** English (English) */
 $magicWords['en'] = array(
+	'mandatory' => array( 0, 'mandatory' ),
 	'ask' => array( 0, 'ask' ),
 	'show' => array( 0, 'show' ),
 	'info' => array( 0, 'info' ),

--- a/i18n/extra/en.json
+++ b/i18n/extra/en.json
@@ -92,7 +92,11 @@
 		"_PEFU": "External formatter URI",
 		"_PPLB": "Has preferred property label",
 		"_EDIP": "Is edit protected",
-		"_CHGPRO": "Change propagation"
+		"_CHGPRO": "Change propagation",
+		"_MREI": "Is mandatory",
+		"_MREP": "Mandatory property",
+		"_MREQ": "Mandatory requirement"
+
 	},
 	"propertyAliases": {
 		"Display unit": "_UNIT",
@@ -144,7 +148,11 @@
 		"Preferred property label": "_PPLB",
 		"Is edit protected": "_EDIP",
 		"IsEditProtected": "_EDIP",
-		"Change propagation" : "_CHGPRO"
+		"Change propagation" : "_CHGPRO",
+		"Is mandatory": "_MREI",
+		"Mandatory property": "_MREP",
+		"Mandatory requirement": "_MREQ",
+		"Has mandatory requirement": "_MREQ"
 	},
 	"namespaces":{
 		"SMW_NS_PROPERTY": "Property",

--- a/includes/SemanticData.php
+++ b/includes/SemanticData.php
@@ -10,6 +10,7 @@ use SMWDIContainer;
 use SMWPropertyValue;
 use SMW\Exception\SemanticDataImportException;
 use SMW\DataModel\SubSemanticData;
+use SMW\DataModel\MandatoryRequirements;
 
 /**
  * Class for representing chunks of semantic data for one given
@@ -36,6 +37,11 @@ class SemanticData {
 	 * have been fetched from cache.
 	 */
 	const OPT_LAST_MODIFIED = 'opt.last.modified';
+
+	/**
+	 * Identifies that a data block was created by a user.
+	 */
+	const USER_ANNOTATION = 'user.annotation';
 
 	/**
 	 * Cache for the localized version of the namespace prefix "Property:".
@@ -68,6 +74,11 @@ class SemanticData {
 	 * @var DIProperty[]
 	 */
 	protected $mProperties = array();
+
+	/**
+	 * @var MandatoryRequirements|null
+	 */
+	protected $mandatoryRequirements;
 
 	/**
 	 * States whether the container holds any normal properties.
@@ -145,7 +156,7 @@ class SemanticData {
 	/**
 	 * @var Options
 	 */
-	private $options = null;
+	protected $options = null;
 
 	/**
 	 * This is kept public to keep track of the depth during a recursive processing
@@ -182,7 +193,7 @@ class SemanticData {
 	 * @return array
 	 */
 	public function __sleep() {
-		return array( 'mSubject', 'mPropVals', 'mProperties', 'subSemanticData', 'mHasVisibleProps', 'mHasVisibleSpecs', 'options' );
+		return array( 'mSubject', 'mPropVals', 'mProperties', 'subSemanticData', 'mHasVisibleProps', 'mHasVisibleSpecs', 'options', 'mandatoryRequirements' );
 	}
 
 	/**
@@ -213,6 +224,24 @@ class SemanticData {
 	 */
 	public function hasProperty( DIProperty $property ) {
 		return isset( $this->mProperties[$property->getKey()] ) || array_key_exists( $property->getKey(), $this->mProperties );
+	}
+
+	/**
+	 * @since 3.0
+	 *
+	 * @param MandatoryRequirements $mandatoryRequirements
+	 */
+	public function setMandatoryRequirements( MandatoryRequirements $mandatoryRequirements ) {
+		$this->mandatoryRequirements = $mandatoryRequirements;
+	}
+
+	/**
+	 * @since 3.0
+	 *
+	 * @return MandatoryRequirements|null
+	 */
+	public function getMandatoryRequirements() {
+		return $this->mandatoryRequirements;
 	}
 
 	/**
@@ -633,6 +662,7 @@ class SemanticData {
 		if ( count( $this->mProperties ) == 0 &&
 		     ( $semanticData->mNoDuplicates >= $this->mNoDuplicates ) ) {
 			$this->mProperties = $semanticData->getProperties();
+			$this->mandatoryRequirements = $semanticData->getMandatoryRequirements();
 			$this->mPropVals = array();
 
 			foreach ( $this->mProperties as $property ) {

--- a/includes/Settings.php
+++ b/includes/Settings.php
@@ -180,6 +180,7 @@ class Settings extends Options {
 			'smwgEntityLookupFeatures' => $GLOBALS['smwgEntityLookupFeatures'],
 			'smwgFieldTypeFeatures' => $GLOBALS['smwgFieldTypeFeatures'],
 			'smwgChangePropagationProtection' => $GLOBALS['smwgChangePropagationProtection'],
+			'smwgMandatoryRequirementsNamespaceList' => $GLOBALS['smwgMandatoryRequirementsNamespaceList']
 		);
 
 		self::initLegacyMapping( $configuration );

--- a/includes/dataitems/SMW_DI_Bool.php
+++ b/includes/dataitems/SMW_DI_Bool.php
@@ -21,7 +21,7 @@ class SMWDIBoolean extends SMWDataItem {
 	protected $m_boolean;
 
 	public function __construct( $boolean ) {
-		if ( !is_bool( $boolean ) ) {
+		if ( !is_bool( $boolean ) && $boolean !== null ) {
 			throw new DataItemException( "Initialization value '$boolean' is not a boolean." );
 		}
 

--- a/includes/dataitems/SMW_DI_Number.php
+++ b/includes/dataitems/SMW_DI_Number.php
@@ -22,7 +22,7 @@ class SMWDINumber extends SMWDataItem {
 	protected $m_number;
 
 	public function __construct( $number ) {
-		if ( !is_numeric( $number ) ) {
+		if ( !is_numeric( $number ) && $number !== null ) {
 			throw new DataItemException( "Initialization value '$number' is not a number." );
 		}
 		$this->m_number = $number;

--- a/includes/dataitems/SMW_DI_Time.php
+++ b/includes/dataitems/SMW_DI_Time.php
@@ -127,7 +127,7 @@ class SMWDITime extends SMWDataItem implements CalendarModel {
 			throw new DataItemException( "Unsupported calendar model constant \"$calendarmodel\"." );
 		}
 
-		if ( $year == 0 ) {
+		if ( $year == 0 && $year !== null ) {
 			throw new DataItemException( "There is no year 0 in Gregorian and Julian calendars." );
 		}
 
@@ -140,8 +140,14 @@ class SMWDITime extends SMWDataItem implements CalendarModel {
 		$this->m_seconds = $second !== false ? floatval( $second ) : 0;
 
 		$this->timezone = $timezone !== false ? $timezone : 0;
-		$year = strval( $year );
-		$this->era      = $year{0} === '+' ? 1 : ( $year{0} === '-' ? -1 : 0 );
+
+		if ( $year !== null ) {
+			$year = strval( $year );
+		}
+
+		if ( $year !== null ) {
+			$this->era = $year{0} === '+' ? 1 : ( $year{0} === '-' ? -1 : 0 );
+		}
 
 		if ( $this->isOutOfBoundsBySome() ) {
 			throw new DataItemException( "Part of the date is out of bounds." );

--- a/includes/datavalues/SMW_DV_Number.php
+++ b/includes/datavalues/SMW_DV_Number.php
@@ -181,6 +181,12 @@ class SMWNumberValue extends SMWDataValue {
 		$number = $unit = '';
 		$error = $this->parseNumberValue( $value, $number, $unit );
 
+		// #2669
+		// Allow the transient state of `!+` in a query context
+		if ( $this->getOption( self::OPT_QUERY_CONTEXT ) && $value === SMW_IS_NULL ) {
+			return $this->convertToMainUnit( null, $unit );
+		}
+
 		if ( $error == 1 ) { // no number found
 			$this->addErrorMsg( array( 'smw_nofloat', $value ) );
 		} elseif ( $error == 2 ) { // number is too large for this platform

--- a/includes/datavalues/SMW_DV_Time.php
+++ b/includes/datavalues/SMW_DV_Time.php
@@ -124,6 +124,12 @@ class SMWTimeValue extends SMWDataValue {
 
 	protected function parseUserValue( $value ) {
 
+		// #2669
+		// Allow the transient state of `!+` in a query context
+		if ( $this->getOption( self::OPT_QUERY_CONTEXT ) && $value === SMW_IS_NULL ) {
+			return $this->m_dataitem = new SMWDITime( SMWDITime::CM_GREGORIAN, null );
+		}
+
 		$value = Localizer::convertDoubleWidth( $value );
 		$this->m_wikivalue = $value;
 

--- a/includes/storage/SQLStore/SMW_Sql3SmwIds.php
+++ b/includes/storage/SQLStore/SMW_Sql3SmwIds.php
@@ -697,7 +697,7 @@ class SMWSql3SmwIds {
 					SMWSQLStore3::PROPERTY_STATISTICS_TABLE
 				);
 
-				$statsStore->insertUsageCount( $id, 0 );
+				$statsStore->insertUsageCount( $id, [ 0, 0 ] );
 			}
 
 			$this->setCache( $title, $namespace, $iw, $subobjectName, $id, $sortkey );

--- a/includes/storage/SQLStore/SMW_Sql3StubSemanticData.php
+++ b/includes/storage/SQLStore/SMW_Sql3StubSemanticData.php
@@ -79,7 +79,7 @@ class SMWSql3StubSemanticData extends SMWSemanticData {
 	 * @return array
 	 */
 	public function __sleep() {
-		return array( 'mSubject', 'mPropVals', 'mProperties', 'subSemanticData', 'mStubPropVals' );
+		return array( 'mSubject', 'mPropVals', 'mProperties', 'subSemanticData', 'mStubPropVals', 'options', 'mandatoryRequirements' );
 	}
 
 	/**

--- a/src/DataModel/ContainerSemanticData.php
+++ b/src/DataModel/ContainerSemanticData.php
@@ -70,7 +70,9 @@ class ContainerSemanticData extends SemanticData {
 			'mHasVisibleSpecs',
 			'mNoDuplicates',
 			'skipAnonymousCheck',
-			'subSemanticData'
+			'subSemanticData',
+			'options',
+			'mandatoryRequirements'
 		);
 	}
 
@@ -145,6 +147,7 @@ class ContainerSemanticData extends SemanticData {
 		$this->mHasVisibleProps = $semanticData->hasVisibleProperties();
 		$this->mHasVisibleSpecs = $semanticData->hasVisibleSpecialProperties();
 		$this->mNoDuplicates = $semanticData->mNoDuplicates;
+		$this->mandatoryRequirements = $semanticData->getMandatoryRequirements();
 	}
 
 }

--- a/src/DataModel/DataItems/DINull.php
+++ b/src/DataModel/DataItems/DINull.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace SMW\DataModel\DataItems;
+
+use SMWDataItem as DataItem;
+use SMW\Exception\DataItemException;
+
+/**
+ * @license GNU GPL v2
+ * @since 3.0
+ *
+ * @author mwjames
+ */
+class DINull extends DataItem {
+
+	/**
+	 * @see DataItem::getDIType
+	 */
+	public function getDIType() {
+		return DataItem::TYPE_NOTYPE;
+	}
+
+	/**
+	 * @see DataItem::getDIType
+	 */
+	public function getSortKey() {
+		return '';
+	}
+
+	/**
+	 * @see DataItem::getSerialization
+	 */
+	public function getSerialization() {
+		return '';
+	}
+
+	/**
+	 * @see DataItem::equals
+	 */
+	public function equals( DataItem $di ) {
+		return $di instanceof Null;
+	}
+
+}

--- a/src/DataModel/MandatoryRequirements.php
+++ b/src/DataModel/MandatoryRequirements.php
@@ -1,0 +1,276 @@
+<?php
+
+namespace SMW\DataModel;
+
+use SMW\SemanticData;
+use SMW\ApplicationFactory;
+use SMW\DIWikiPage;
+use SMW\DIProperty;
+use SMWDIContainer as DIContainer;
+use SMW\Store;
+use SMW\RequestOptions;
+use Onoi\Cache\Cache;
+use SMW\ChangePropListener;
+use InvalidArgumentException;
+
+/**
+ * Class to represent and process mandatory requirements.
+ *
+ * Global requirements are cached to avoid excessive DB requests with the cache
+ * being evicted as soon as some changes that involves the `Is mandatory` property
+ * is detected in the attached ChangePropListener.
+ *
+ * @license GNU GPL v2+
+ * @since 3.0
+ *
+ * @author mwjames
+ */
+class MandatoryRequirements {
+
+	const CACHE_NAMESPACE = 'smw:mreq';
+
+	/**
+	 * @var Cache
+	 */
+	private $cache;
+
+	/**
+	 * @var integer
+	 */
+	private $cacheTTL;
+
+	/**
+	 * @var DIProperty[]|[]
+	 */
+	private $mandatoryProperties = [];
+
+	/**
+	 * @var []
+	 */
+	private $namespaceList = [];
+
+	/**
+	 * @since 3.0
+	 *
+	 * @param Cache|null $cache
+	 */
+	public function __construct( Cache $cache = null ) {
+
+		if ( $cache === null ) {
+			$cache = ApplicationFactory::getInstance()->getCache();
+		}
+
+		$this->cache = $cache;
+		$this->cacheTTL = 60 * 60 * 24;
+	}
+
+	/**
+	 * @since 3.0
+	 *
+	 * @param array|false $namespaceList
+	 */
+	public function setNamespaceList( $namespaceList ) {
+
+		if ( !is_array( $namespaceList ) ) {
+			$namespaceList = [];
+		}
+
+		$this->namespaceList = $namespaceList;
+	}
+
+	/**
+	 * Any change that involves the Is mandatory (_MREI) property will trigger
+	 * a cache eviction.
+	 *
+	 * @since 3.0
+	 */
+	public function setChangePropListener( ChangePropListener $changePropListener ) {
+
+		$callback = function( $record ) {
+			$this->cache->delete(
+				smwfCacheKey( self::CACHE_NAMESPACE, 'GlobalRequirements' )
+			);
+
+			wfDebugLog( 'smw-mreq', 'MandatoryRequirements: GlobalRequirements cache invalidated due to a ChangePropListener event' );
+		};
+
+		$changePropListener->addListenerCallback( '_MREI', $callback );
+	}
+
+	/**
+	 * @since 3.0
+	 *
+	 * @param SemanticData $semanticData
+	 *
+	 * @return boolean
+	 */
+	public function canCheckRequirements( SemanticData $semanticData ) {
+
+		$subject = $semanticData->getSubject();
+
+		// Skip on any non-user subobject (_QUERY..., _ERR... etc.)
+		if ( $subject->getSubobjectName() !== '' && $semanticData->getOption( SemanticData::USER_ANNOTATION ) !== true ) {
+			return false;
+		}
+
+		$ns = $subject->getNamespace();
+
+		return isset( $this->namespaceList[$ns] ) && $this->namespaceList[$ns];
+	}
+
+	/**
+	 * @since 3.0
+	 *
+	 * @return DIProperty[]|[]
+	 */
+	public function getMandatoryProperties() {
+		return array_values( $this->mandatoryProperties );
+	}
+
+	/**
+	 * @since 3.0
+	 *
+	 * @param SemanticData $semanticData
+	 * @param DIProperty[] $propertyList
+	 */
+	public function copyRequirements( SemanticData $semanticData, array $propertyList ) {
+
+		if ( $propertyList === [] ) {
+			return;
+		}
+
+		ksort( $propertyList );
+
+		$subject = $semanticData->getSubject();
+		$identifier = '_MREQ' . md5( json_encode( array_keys( $propertyList ) ) );
+
+		$subWikiPage = new DIWikiPage(
+			$subject->getDBkey(),
+			$subject->getNamespace(),
+			$subject->getInterwiki(),
+			$identifier
+		);
+
+		$containerSemanticData = new ContainerSemanticData(
+			$subWikiPage
+		);
+
+		foreach ( $propertyList as $key => $prop ) {
+			$containerSemanticData->addPropertyObjectValue(
+				new DIProperty( '_MREP' ),
+				$prop->getDiWikiPage()
+			);
+		}
+
+		$semanticData->addPropertyObjectValue(
+			new DIProperty( '_MREQ' ),
+			new DIContainer( $containerSemanticData )
+		);
+
+		wfDebugLog( 'smw-mreq', 'MandatoryRequirements: Adding LocalRequirements on ' . $subject->getHash() . ' with ' . count( $propertyList ) . ' member(s)' );
+	}
+
+	/**
+	 * @since 3.0
+	 *
+	 * @param Store $store
+	 * @param SemanticData $semanticData
+	 */
+	public function findRequirements( Store $store, SemanticData $semanticData ) {
+
+		if ( !$this->canCheckRequirements( $semanticData ) ) {
+			return;
+		}
+
+		$this->mandatoryProperties = $this->findLocalRequirements(
+			$semanticData
+		);
+
+		if ( $this->mandatoryProperties !== [] ) {
+			return;
+		}
+
+		$this->mandatoryProperties = $this->findGlobalRequirements(
+			$store
+		);
+	}
+
+	private function findLocalRequirements( SemanticData $semanticData ) {
+
+		$property = new DIProperty( '_MREQ' );
+
+		if ( !$semanticData->hasProperty( $property ) ) {
+			return [];
+		}
+
+		$pv = $semanticData->getPropertyValues( $property );
+		$requirements = [];
+
+		foreach ( $pv as $dataItem ) {
+
+			$subSemanticData = $semanticData->findSubSemanticData(
+				$dataItem->getSubobjectName()
+			);
+
+			$spv = $subSemanticData->getPropertyValues(
+				new DIProperty( '_MREP' )
+			);
+
+			foreach ( $spv as $v ) {
+				$requirements[$v->getDBKey()] = new DIProperty( $v->getDBkey() );
+			}
+		}
+
+		return $requirements;
+	}
+
+	private function findGlobalRequirements( $store ) {
+
+		$hash = smwfCacheKey( self::CACHE_NAMESPACE, 'GlobalRequirements' );
+
+		if ( ( $requirements = $this->cache->fetch( $hash ) ) !== false ) {
+			wfDebugLog( 'smw-mreq', 'MandatoryRequirements: Using GlobalRequirements cache' );
+			return $requirements;
+		}
+
+		$requirements = [];
+		$connection = $store->getConnection( 'mw.db' );
+
+		// Only match property subjects
+		$requestOptions = new RequestOptions();
+
+		$requestOptions->addExtraCondition(
+			'smw_namespace=' . $connection->addQuotes( SMW_NS_PROPERTY )
+		);
+
+		$property = new DIProperty( '_MREI' );
+
+		$dataItems = $store->getAllPropertySubjects(
+			$property,
+			$requestOptions
+		);
+
+		if ( $dataItems === null ) {
+			return $requirements;
+		}
+
+		foreach ( $dataItems as $dataItem ) {
+
+			$pv = $store->getPropertyValues( $dataItem, $property );
+
+			// Is mandatory === true?
+			foreach ( $pv as $di ) {
+				if ( $di->getBoolean() ) {
+					$requirements[$dataItem->getDBkey()] = new DIProperty( $dataItem->getDBkey() );
+				}
+			}
+		}
+
+		wfDebugLog( 'smw-mreq', 'MandatoryRequirements: Created new GlobalRequirements list with ' . count( $requirements ) . ' member(s)' );
+
+		$this->cache->save( $hash, $requirements, $this->cacheTTL );
+
+		return $requirements;
+	}
+
+}

--- a/src/DataValues/BooleanValue.php
+++ b/src/DataValues/BooleanValue.php
@@ -181,6 +181,12 @@ class BooleanValue extends DataValue {
 
 	private function doParseBoolValue( $value ) {
 
+		// #2669
+		// Allow the transient state of `!+` in a query context
+		if ( $this->getOption( self::OPT_QUERY_CONTEXT ) && $value === SMW_IS_NULL ) {
+			return null;
+		}
+
 		// Use either the global or page related content language
 		$contentLanguage = $this->getOption( 'content.language' );
 

--- a/src/Defines.php
+++ b/src/Defines.php
@@ -91,7 +91,10 @@ define( 'SMW_CMP_LESS', 7 ); // Matches only datavalues that are less than the g
 define( 'SMW_CMP_GRTR', 8 ); // Matches only datavalues that are greater than the given value.
 define( 'SMW_CMP_PRIM_LIKE', 20 ); // Native LIKE matches (in disregards of an existing full-text index)
 define( 'SMW_CMP_PRIM_NLKE', 21 ); // Native NLIKE matches (in disregards of an existing full-text index)
+define( 'SMW_CMP_NULL', 23 ); // Null support
 /**@}*/
+
+define( 'SMW_IS_NULL', 'IS NULL' ); // Null support
 
 /**@{
  * Constants for date formats (using binary encoding of nine bits:

--- a/src/Deserializers/DVDescriptionDeserializer/SomeValueDescriptionDeserializer.php
+++ b/src/Deserializers/DVDescriptionDeserializer/SomeValueDescriptionDeserializer.php
@@ -55,6 +55,12 @@ class SomeValueDescriptionDeserializer extends DescriptionDeserializer {
 			( $comparator !== SMW_CMP_EQ && $comparator !== SMW_CMP_NEQ )
 		);
 
+		// To avoid the DataValue::parse to return with an invalid as we
+		// require a matchable DI to the property
+		if ( $comparator === SMW_CMP_NULL ) {
+			$value = SMW_IS_NULL;
+		}
+
 		$this->dataValue->setUserValue( $value );
 
 		if ( !$this->dataValue->isValid() ) {

--- a/src/Deserializers/DVDescriptionDeserializer/TimeValueDescriptionDeserializer.php
+++ b/src/Deserializers/DVDescriptionDeserializer/TimeValueDescriptionDeserializer.php
@@ -43,6 +43,12 @@ class TimeValueDescriptionDeserializer extends DescriptionDeserializer {
 		$comparator = SMW_CMP_EQ;
 		$this->prepareValue( $value, $comparator );
 
+		// To avoid the DataValue::parse to return with an invalid as we
+		// require a matchable DI to the property
+		if ( $comparator === SMW_CMP_NULL ) {
+			$value = SMW_IS_NULL;
+		}
+
 		if( $comparator !== SMW_CMP_LIKE && $comparator !== SMW_CMP_NLKE ) {
 
 			$this->dataValue->setUserValue( $value );

--- a/src/MediaWiki/Hooks/HookRegistry.php
+++ b/src/MediaWiki/Hooks/HookRegistry.php
@@ -716,6 +716,10 @@ class HookRegistry {
 
 			$parserFunctionFactory = $applicationFactory->newParserFunctionFactory( $parser );
 
+			list( $name, $definition, $flag ) = $parserFunctionFactory->newMandatoryParserFunctionDefinition();
+
+			$parser->setFunctionHook( $name, $definition, $flag );
+
 			list( $name, $definition, $flag ) = $parserFunctionFactory->newAskParserFunctionDefinition();
 
 			$parser->setFunctionHook( $name, $definition, $flag );

--- a/src/ParserFunctionFactory.php
+++ b/src/ParserFunctionFactory.php
@@ -11,6 +11,7 @@ use SMW\ParserFunctions\SetParserFunction;
 use SMW\ParserFunctions\ConceptParserFunction;
 use SMW\ParserFunctions\DeclareParserFunction;
 use SMW\ParserFunctions\ExpensiveFuncExecutionWatcher;
+use SMW\ParserFunctions\MandatoryParserFunction;
 use SMW\Utils\CircularReferenceGuard;
 use Parser;
 
@@ -63,6 +64,29 @@ class ParserFunctionFactory {
 	 */
 	public function getRecurringEventsParser() {
 		return $this->newRecurringEventsParserFunction( $this->parser );
+	}
+
+	/**
+	 * @since 3.0
+	 *
+	 * @param Parser $parser
+	 *
+	 * @return MandatoryParserFunction
+	 */
+	public function newMandatoryParserFunction( Parser $parser ) {
+
+		$applicationFactory = ApplicationFactory::getInstance();
+
+		$parserData = $applicationFactory->newParserData(
+			$parser->getTitle(),
+			$parser->getOutput()
+		);
+
+		$mandatoryParserFunction = new MandatoryParserFunction(
+			$parserData
+		);
+
+		return $mandatoryParserFunction;
 	}
 
 	/**
@@ -280,6 +304,25 @@ class ParserFunctionFactory {
 		);
 
 		return $declareParserFunction;
+	}
+
+	/**
+	 * @since 3.0
+	 *
+	 * @return array
+	 */
+	public function newMandatoryParserFunctionDefinition() {
+
+		$mandatoryParserFunctionDefinition = function( $parser ) {
+
+			$mandatoryParserFunction = $this->newMandatoryParserFunction(
+				$parser
+			);
+
+			return $mandatoryParserFunction->parse( func_get_args() );
+		};
+
+		return array( 'mandatory', $mandatoryParserFunctionDefinition, 0 );
 	}
 
 	/**

--- a/src/ParserFunctions/MandatoryParserFunction.php
+++ b/src/ParserFunctions/MandatoryParserFunction.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace SMW\ParserFunctions;
+
+use SMW\ParserData;
+use Parser;
+use SMW\DIProperty;
+use SMW\DIWikiPage;
+use SMWDIContainer as DIContainer;
+use SMW\DataModel\MandatoryRequirements;
+
+/**
+ * Define individual mandatory requirements {{#mandatory: ... }} per entity.
+ *
+ * @license GNU GPL v2+
+ * @since 3.0
+ *
+ * @author mwjames
+ */
+class MandatoryParserFunction {
+
+	/**
+	 * @var ParserData
+	 */
+	private $parserData;
+
+	/**
+	 * @since 3.0
+	 *
+	 * @param ParserData $parserData
+	 */
+	public function __construct( ParserData $parserData ) {
+		$this->parserData = $parserData;
+	}
+
+	/**
+	 * @since 3.0
+	 *
+	 * @param array $parameters
+	 *
+	 * @return string|null
+	 */
+	public function parse( array $parameters ) {
+
+		// Remove parser object from parameters array
+		if( isset( $parameters[0] ) && $parameters[0] instanceof Parser ) {
+			array_shift( $parameters );
+		}
+
+		$semanticData = $this->parserData->getSemanticData();
+		$propertyList = [];
+
+		foreach ( $parameters as $val ) {
+			if ( strpos( $val, '=' ) !== false ) {
+				list( $k, $v ) = explode( '=', $val, 2 );
+
+				if ( $k === 'property' ) {
+					$properties = explode( ',' , $v );
+					foreach ( $properties as $prop ) {
+						$prop = trim( $prop );
+						$propertyList[$prop] = DIProperty::newFromUserLabel( $prop );
+					}
+				}
+			}
+		}
+
+		$mandatoryRequirements = new MandatoryRequirements();
+
+		$mandatoryRequirements->copyRequirements(
+			$semanticData,
+			$propertyList
+		);
+
+		$this->parserData->pushSemanticDataToParserOutput();
+	}
+
+}

--- a/src/ParserFunctions/SubobjectParserFunction.php
+++ b/src/ParserFunctions/SubobjectParserFunction.php
@@ -10,6 +10,7 @@ use SMW\Message;
 use SMW\HashBuilder;
 use SMW\DataValueFactory;
 use SMW\DIProperty;
+use SMW\SemanticData;
 use Parser;
 
 /**
@@ -204,6 +205,13 @@ class SubobjectParserFunction {
 
 		$this->doAugmentSortKeyOnAccessibleDisplayTitle(
 			$this->subobject->getSemanticData()
+		);
+
+		// @see MandatoryRequirements::canCheckRequirements, indentify the instance
+		// as being created by a user
+		$this->subobject->getSemanticData()->setOption(
+			SemanticData::USER_ANNOTATION,
+			true
 		);
 
 		return true;

--- a/src/PropertyRegistry.php
+++ b/src/PropertyRegistry.php
@@ -463,6 +463,9 @@ class PropertyRegistry {
 			'_ERRP'  => array( '_wpp', false, false ), // "has improper value for"
 			'_LIST'  => array( '__pls', true, true ), // "has fields"
 			'_SKEY'  => array( '__key', false, true ), // sort key of a page
+			'_MREI'  => array( '_boo', true, true ), // "Is mandatory"
+			'_MREP'  => array( '_wpp', true, false ), // "Mandatory property"
+			'_MREQ'  => array( '__sob', true, false ), // "Mandatory requirement"
 
 			// FIXME SF related properties to be removed with 3.0
 			'_SF_DF' => array( '__spf', true, true ), // Semantic Form's default form property
@@ -491,7 +494,7 @@ class PropertyRegistry {
 			'_PEID'  => array( '_eid', true, true ), // External identifier
 			'_PEFU'  => array( '__pefu', true, true ), // External formatter uri
 			'_PPLB'  => array( '_mlt_rec', true, true ), // Preferred property label
-			'_CHGPRO' => array( '_cod', true, false ), // "Change propagation"
+			'_CHGPRO' => array( '_cod', true, false ), // "Change propagation",
 		);
 
 		foreach ( $this->datatypeLabels as $id => $label ) {

--- a/src/Query/Language/ClassDescription.php
+++ b/src/Query/Language/ClassDescription.php
@@ -5,6 +5,7 @@ namespace SMW\Query\Language;
 use Exception;
 use SMW\DataValueFactory;
 use SMW\DIWikiPage;
+use SMW\Localizer;
 
 /**
  * Description of a single class as given by a wiki category, or of a
@@ -29,8 +30,6 @@ class ClassDescription extends Description {
 	protected $hierarchyDepth;
 
 	/**
-	 * Constructor.
-	 *
 	 * @param mixed $content DIWikiPage or array of DIWikiPage
 	 *
 	 * @throws Exception
@@ -104,11 +103,12 @@ class ClassDescription extends Description {
 	public function getQueryString( $asValue = false ) {
 
 		$first = true;
+		$ns = Localizer::getInstance()->getNamespaceTextById( NS_CATEGORY );
 
 		foreach ( $this->m_diWikiPages as $wikiPage ) {
 			$wikiValue = DataValueFactory::getInstance()->newDataValueByItem( $wikiPage, null );
 			if ( $first ) {
-				$result = '[[' . $wikiValue->getPrefixedText();
+				$result = '[[' . $ns . ':' . $wikiValue->getText();
 				$first = false;
 			} else {
 				$result .= '||' . $wikiValue->getText();

--- a/src/Query/Language/ValueDescription.php
+++ b/src/Query/Language/ValueDescription.php
@@ -123,16 +123,22 @@ class ValueDescription extends Description {
 		$dataValue->setOption( UriValue::VALUE_RAW, true );
 		$dataValue->setOption( NumberValue::NO_DISP_PRECISION_LIMIT, true );
 
+		$value = $dataValue->getWikiValue();
+
+		if ( $this->comparator === SMW_CMP_NULL ) {
+			$value = '';
+		}
+
 		if ( $asValue ) {
-			return $comparator . $dataValue->getWikiValue();
+			return $comparator . $value;
 		}
 
 		// this only is possible for values of Type:Page
 		if ( $comparator === '' ) { // some extra care for Category: pages
-			return '[[:' . $dataValue->getWikiValue() . ']]';
+			return '[[:' . $value . ']]';
 		}
 
-		return '[[' . $comparator . $dataValue->getWikiValue() . ']]';
+		return '[[' . $comparator . $value . ']]';
 	}
 
 	public function isSingleton() {

--- a/src/Query/QueryComparator.php
+++ b/src/Query/QueryComparator.php
@@ -161,6 +161,7 @@ class QueryComparator {
 			'like:' => SMW_CMP_PRIM_LIKE,
 			'nlike:' => SMW_CMP_PRIM_NLKE,
 			'!~' => SMW_CMP_NLKE,
+			'!+' => SMW_CMP_NULL,
 			'<<' => SMW_CMP_LESS,
 			'>>' => SMW_CMP_GRTR,
 			'<' => $strictComparators ? SMW_CMP_LESS : SMW_CMP_LEQ,

--- a/src/SQLStore/ChangePropagationEntityFinder.php
+++ b/src/SQLStore/ChangePropagationEntityFinder.php
@@ -68,8 +68,13 @@ class ChangePropagationEntityFinder {
 		$dataItems = array();
 		$appendIterator = $this->iteratorFactory->newAppendIterator();
 
+		// Allow entities with NULL to be listed since we want them to be cleaned
+		$requestOptions = new RequestOptions();
+		$requestOptions->reqNullExpr = false;
+
 		$res = $this->store->getAllPropertySubjects(
-			$property
+			$property,
+			$requestOptions
 		);
 
 		$appendIterator->add(

--- a/src/SQLStore/EntityStore/DIHandlers/DIBlobHandler.php
+++ b/src/SQLStore/EntityStore/DIHandlers/DIBlobHandler.php
@@ -8,6 +8,7 @@ use SMW\SQLStore\EntityStore\DataItemHandler;
 use SMW\SQLStore\EntityStore\Exception\DataItemHandlerException;
 use SMWDIBlob as DIBlob;
 use SMW\SQLStore\TableBuilder\FieldType;
+use SMW\DataModel\DataItems\DINull;
 
 /**
  * This class implements Store access to blob (string) data items.
@@ -68,8 +69,13 @@ class DIBlobHandler extends DataItemHandler {
 	 */
 	public function getInsertValues( DataItem $dataItem ) {
 
-		$text = htmlspecialchars_decode( trim( $dataItem->getString() ), ENT_QUOTES );
-		$hash = $this->makeHash( $text );
+		if ( $dataItem instanceof DINull ) {
+			$text = null;
+			$hash = null;
+		} else {
+			$text = htmlspecialchars_decode( trim( $dataItem->getString() ), ENT_QUOTES );
+			$hash = $this->makeHash( $text );
+		}
 
 		if ( $this->isDbType( 'postgres' ) ) {
 			$text = pg_escape_bytea( $text );

--- a/src/SQLStore/EntityStore/DIHandlers/DIBooleanHandler.php
+++ b/src/SQLStore/EntityStore/DIHandlers/DIBooleanHandler.php
@@ -7,6 +7,7 @@ use SMWDataItem as DataItem;
 use SMW\SQLStore\EntityStore\DataItemHandler;
 use SMWDIBoolean as DIBoolean;
 use SMW\SQLStore\TableBuilder\FieldType;
+use SMW\DataModel\DataItems\DINull;
 
 /**
  * This class implements Store access to Boolean data items.
@@ -57,6 +58,11 @@ class DIBooleanHandler extends DataItemHandler {
 	 * {@inheritDoc}
 	 */
 	public function getInsertValues( DataItem $dataItem ) {
+
+		if ( $dataItem instanceof DINull ) {
+			return [ 'o_value' => NULL ];
+		}
+
 		return array(
 			'o_value' => $dataItem->getBoolean() ? 1 : 0,
 		);

--- a/src/SQLStore/EntityStore/DIHandlers/DIGeoCoordinateHandler.php
+++ b/src/SQLStore/EntityStore/DIHandlers/DIGeoCoordinateHandler.php
@@ -8,6 +8,7 @@ use SMW\SQLStore\EntityStore\DataItemHandler;
 use SMW\SQLStore\EntityStore\Exception\DataItemHandlerException;
 use SMWDIGeoCoord  as DIGeoCoord;
 use SMW\SQLStore\TableBuilder\FieldType;
+use SMW\DataModel\DataItems\DINull;
 
 /**
  * This class implements store access to DIGeoCoord data items.
@@ -80,11 +81,22 @@ class DIGeoCoordinateHandler extends DataItemHandler {
 	 * {@inheritDoc}
 	 */
 	public function getInsertValues( DataItem $dataItem ) {
-		return array(
-			'o_serialized' => $dataItem->getSerialization(),
-			'o_lat' => (string)$dataItem->getLatitude(),
-			'o_lon' => (string)$dataItem->getLongitude()
-		);
+
+		if ( $dataItem instanceof DINull ) {
+			$serialized = null;
+			$lat = null;
+			$lon = null;
+		} else {
+			$serialized = $dataItem->getSerialization();
+			$lat = (string)$dataItem->getLatitude();
+			$lon = (string)$dataItem->getLongitude();
+		}
+
+		return [
+			'o_serialized' => $serialized,
+			'o_lat' => $lat,
+			'o_lon' => $lon
+		];
 	}
 
 	/**

--- a/src/SQLStore/EntityStore/DIHandlers/DINumberHandler.php
+++ b/src/SQLStore/EntityStore/DIHandlers/DINumberHandler.php
@@ -8,6 +8,7 @@ use SMW\SQLStore\EntityStore\DataItemHandler;
 use SMW\SQLStore\EntityStore\Exception\DataItemHandlerException;
 use SMWDINumber as DINumber;
 use SMW\SQLStore\TableBuilder\FieldType;
+use SMW\DataModel\DataItems\DINull;
 
 /**
  * This class implements Store access to Number data items.
@@ -71,10 +72,19 @@ class DINumberHandler extends DataItemHandler {
 	 * {@inheritDoc}
 	 */
 	public function getInsertValues( DataItem $dataItem ) {
-		return array(
-			'o_serialized' => $dataItem->getSerialization(),
-			'o_sortkey' => floatval( $dataItem->getNumber() )
-			);
+
+		if ( $dataItem instanceof DINull ) {
+			$serialized = null;
+			$number = null;
+		} else {
+			$serialized = $dataItem->getSerialization();
+			$number = floatval( $dataItem->getNumber() );
+		}
+
+		return [
+			'o_serialized' => $serialized,
+			'o_sortkey' => $number
+		];
 	}
 
 	/**

--- a/src/SQLStore/EntityStore/DIHandlers/DITimeHandler.php
+++ b/src/SQLStore/EntityStore/DIHandlers/DITimeHandler.php
@@ -8,6 +8,7 @@ use SMW\SQLStore\EntityStore\DataItemHandler;
 use SMW\SQLStore\EntityStore\Exception\DataItemHandlerException;
 use SMWDITime as DITime;
 use SMW\SQLStore\TableBuilder\FieldType;
+use SMW\DataModel\DataItems\DINull;
 
 /**
  * This class implements Store access to Time data items.
@@ -75,10 +76,19 @@ class DITimeHandler extends DataItemHandler {
 	 * {@inheritDoc}
 	 */
 	public function getInsertValues( DataItem $dataItem ) {
-		return array(
-			'o_serialized' => $dataItem->getSerialization(),
-			'o_sortkey' => $dataItem->getSortKey()
-		);
+
+		if ( $dataItem instanceof DINull ) {
+			$serialized = null;
+			$time = null;
+		} else {
+			$serialized = $dataItem->getSerialization();
+			$time = $dataItem->getSortKey();
+		}
+
+		return [
+			'o_serialized' => $serialized,
+			'o_sortkey' => $time
+		];
 	}
 
 	/**

--- a/src/SQLStore/EntityStore/DIHandlers/DIUriHandler.php
+++ b/src/SQLStore/EntityStore/DIHandlers/DIUriHandler.php
@@ -8,6 +8,7 @@ use SMW\SQLStore\EntityStore\DataItemHandler;
 use SMW\SQLStore\EntityStore\Exception\DataItemHandlerException;
 use SMWDIUri as DIUri;
 use SMW\SQLStore\TableBuilder\FieldType;
+use SMW\DataModel\DataItems\DINull;
 
 /**
  * This class implements Store access to Uri data items.
@@ -59,8 +60,13 @@ class DIUriHandler extends DataItemHandler {
 	 */
 	public function getInsertValues( DataItem $dataItem ) {
 
-		$serialization = rawurldecode( $dataItem->getSerialization() );
-		$text = mb_strlen( $serialization ) <= $this->getMaxLength() ? null : $serialization;
+		if ( $dataItem instanceof DINull ) {
+			$serialization = null;
+			$text = null;
+		} else {
+			$serialization = rawurldecode( $dataItem->getSerialization() );
+			$text = mb_strlen( $serialization ) <= $this->getMaxLength() ? null : $serialization;
+		}
 
 		// bytea type handling
 		if ( $text !== null && $this->isDbType( 'postgres' ) ) {

--- a/src/SQLStore/EntityStore/DIHandlers/DIWikiPageHandler.php
+++ b/src/SQLStore/EntityStore/DIHandlers/DIWikiPageHandler.php
@@ -9,6 +9,7 @@ use SMW\SQLStore\EntityStore\Exception\DataItemHandlerException;
 use SMW\DIWikiPage;
 use SMW\DIProperty;
 use SMW\SQLStore\TableBuilder\FieldType;
+use SMW\DataModel\DataItems\DINull;
 
 /**
  * DataItemHandler for dataitems of type DIWikiPage.
@@ -117,6 +118,10 @@ class DIWikiPageHandler extends DataItemHandler {
 	 * {@inheritDoc}
 	 */
 	public function getInsertValues( DataItem $dataItem ) {
+
+		if ( $dataItem instanceof DINull ) {
+			return [ 'o_id' => NULL ];
+		}
 
 		$oid = $this->store->getObjectIds()->makeSMWPageID(
 			$dataItem->getDBkey(),

--- a/src/SQLStore/QueryEngine/DescriptionInterpreters/ComparatorMapper.php
+++ b/src/SQLStore/QueryEngine/DescriptionInterpreters/ComparatorMapper.php
@@ -32,6 +32,7 @@ class ComparatorMapper {
 			SMW_CMP_LEQ  => '<=',
 			SMW_CMP_GEQ  => '>=',
 			SMW_CMP_NEQ  => '!=',
+			SMW_CMP_NULL => '!+',
 			SMW_CMP_LIKE => ' LIKE ',
 			SMW_CMP_PRIM_LIKE => ' LIKE ',
 			SMW_CMP_NLKE => ' NOT LIKE ',

--- a/src/SQLStore/QueryEngine/DescriptionInterpreters/SomePropertyInterpreter.php
+++ b/src/SQLStore/QueryEngine/DescriptionInterpreters/SomePropertyInterpreter.php
@@ -163,6 +163,11 @@ class SomePropertyInterpreter implements DescriptionInterpreter {
 			// $query->where = "{$query->alias}.p_id=" . $this->m_dbs->addQuotes( $pid );
 		} // else: no property column, no hierarchy queries
 
+		// #2669
+		if ( $description->getDescription() instanceof ThingDescription ) {
+			$query->where = "{$query->alias}.$indexField IS NOT NULL";
+		}
+
 		// *** Add conditions on the value of the property ***//
 		if ( $diType === DataItem::TYPE_WIKIPAGE ) {
 			$o_id = $indexField;
@@ -303,7 +308,12 @@ class SomePropertyInterpreter implements DescriptionInterpreter {
 				$value
 			);
 
-			$where = "$query->alias.{$indexField}{$comparator}" . $db->addQuotes( $value );
+			// #2669
+			if ( $description->getComparator() === SMW_CMP_NULL ) {
+				$where = "$query->alias.{$indexField} IS NULL";
+			} else{
+				$where = "$query->alias.{$indexField}{$comparator}" . $db->addQuotes( $value );
+			}
 		}
 
 		if ( $where !== '' ) {

--- a/src/SQLStore/QueryEngine/DescriptionInterpreters/ThingDescriptionInterpreter.php
+++ b/src/SQLStore/QueryEngine/DescriptionInterpreters/ThingDescriptionInterpreter.php
@@ -51,6 +51,9 @@ class ThingDescriptionInterpreter implements DescriptionInterpreter {
 		$query = new QuerySegment();
 		$query->type = QuerySegment::Q_NOQUERY;
 
+		// #2669
+		$query->isNull = false;
+
 		return $query;
 	}
 

--- a/src/SQLStore/QueryEngine/DescriptionInterpreters/ValueDescriptionInterpreter.php
+++ b/src/SQLStore/QueryEngine/DescriptionInterpreters/ValueDescriptionInterpreter.php
@@ -106,6 +106,11 @@ class ValueDescriptionInterpreter implements DescriptionInterpreter {
 			);
 
 			$query->joinfield = array( $oid );
+		} elseif( $comparator === SMW_CMP_NULL ) {
+			// #2669, treat NULL as discrete value of a state
+			$query->type = QuerySegment::Q_VALUE;
+			$query->joinfield = [];
+			$query->isNull = true;
 		} else { // Join with SMW IDs table needed for other comparators (apply to title string).
 			$query->joinTable = SMWSql3SmwIds::TABLE_NAME;
 			$query->joinfield = "{$query->alias}.smw_id";

--- a/src/SQLStore/QueryEngine/Fulltext/TextByChangeUpdater.php
+++ b/src/SQLStore/QueryEngine/Fulltext/TextByChangeUpdater.php
@@ -278,6 +278,12 @@ class TextByChangeUpdater implements LoggerAwareInterface {
 			$key = $sid . ':' . $pid;
 
 			if ( $text === null || $text === '' ) {
+
+				// #2669
+				if ( !$fieldChangeOp->has( 'o_hash' ) ) {
+					continue;
+				}
+
 				$text = $fieldChangeOp->get( 'o_hash' );
 			}
 

--- a/src/SQLStore/QueryEngine/QuerySegment.php
+++ b/src/SQLStore/QueryEngine/QuerySegment.php
@@ -77,6 +77,16 @@ class QuerySegment {
 	public $fingerprint = '';
 
 	/**
+	 * @var boolean
+	 */
+	public $isNull = false;
+
+	/**
+	 * @var boolean
+	 */
+	public $isNot = false;
+
+	/**
 	 * @var string
 	 */
 	public $joinType = '';

--- a/tests/phpunit/includes/SQLStore/Writer/DeleteSubjectTest.php
+++ b/tests/phpunit/includes/SQLStore/Writer/DeleteSubjectTest.php
@@ -78,7 +78,7 @@ class DeleteSubjectTest extends \PHPUnit_Framework_TestCase {
 			->method( 'select' )
 			->will( $this->returnValue( array() ) );
 
-		$this->store->expects( $this->exactly( 7 ) )
+		$this->store->expects( $this->exactly( 8 ) )
 			->method( 'getObjectIds' )
 			->will( $this->returnValue( $objectIdGenerator ) );
 
@@ -139,7 +139,7 @@ class DeleteSubjectTest extends \PHPUnit_Framework_TestCase {
 			->method( 'getConnection' )
 			->will( $this->returnValue( $database ) );
 
-		$this->store->expects( $this->exactly( 7 ) )
+		$this->store->expects( $this->exactly( 8 ) )
 			->method( 'getObjectIds' )
 			->will( $this->returnValue( $objectIdGenerator ) );
 


### PR DESCRIPTION
This PR is made in reference to: #2669

This PR addresses or contains:

- Implements requirements as outlined in #2669
- Adds `#mandatory` parser function and `$smwgMandatoryProperties` setting
- Does NOT add support in `SPARQLStore` for the newly added `!+` syntax
- Missing unit and integration tests, for now changes at least pass the existing test suite which means that the PR does not introduce any testable regression

This PR includes:
- [ ] Tests (unit/integration)
- [ ] CI build passed

Fixes #2669