### PR TITLE
Obfuscator to use &#x005D; instead of &#93;, refs 2153, 2671

### DIFF
--- a/src/Parser/Obfuscator.php
+++ b/src/Parser/Obfuscator.php
@@ -20,15 +20,20 @@ class Obfuscator {
 	 */
 	public static function obfuscateLinks( $text, InTextAnnotationParser $parser ) {
 
+		// #2193
 		// Use &#x005B; instead of &#91; to distinguish it from the MW's Sanitizer
 		// who uses the same decode sequence and avoid issues when removing links
 		// after obfuscation
 
+		// #2671
+		// Use &#x005D; instead of &#93; (]) since CiteExtension use the later as
+		// encoding for the ref brackets
+
 		// Filter simple [ ... ] from [[ ... ]] links and ensure to find the correct
 		// start and end in case of [[Foo::[[Bar]]]] or [[Foo::[http://example.org/foo]]]
 		$text = str_replace(
-			array( '[', ']', '&#x005B;&#x005B;', '&#93;&#93;&#93;&#93;', '&#93;&#93;&#93;', '&#93;&#93;' ),
-			array( '&#x005B;', '&#93;', '[[', ']]]]', '&#93;]]', ']]' ),
+			array( '[', ']', '&#x005B;&#x005B;', '&#x005D;&#x005D;&#x005D;&#x005D;', '&#x005D;&#x005D;&#x005D;', '&#x005D;&#x005D;' ),
+			array( '&#x005B;', '&#x005D;', '[[', ']]]]', '&#x005D;]]', ']]' ),
 			$text
 		);
 
@@ -44,11 +49,11 @@ class Obfuscator {
 	 * @return text
 	 */
 	public static function removeLinkObfuscation( $text ) {
-		return str_replace(
-			array( '&#x005B;', '&#93;', '&#124;' ),
-			array( '[', ']', '|' ),
-			$text
-		);
+
+		$from = [ '&#x005B;', '&#x005D;', '&#124;' ];
+		$to = [ '[', ']', '|' ];
+
+		return str_replace( $from, $to,	$text );
 	}
 
 	/**
@@ -61,7 +66,7 @@ class Obfuscator {
 	public static function encodeLinks( $text ) {
 		return str_replace(
 			array( '[', ']', '|' ),
-			array( '&#x005B;', '&#93;', '&#124;' ),
+			array( '&#x005B;', '&#x005D;', '&#124;' ),
 			$text
 		);
 	}

--- a/tests/phpunit/Unit/Parser/InTextAnnotationParserTest.php
+++ b/tests/phpunit/Unit/Parser/InTextAnnotationParserTest.php
@@ -607,6 +607,21 @@ class InTextAnnotationParserTest extends \PHPUnit_Framework_TestCase {
 			)
 		);
 
+		#15 (#2671) external [] decode use
+		$provider[] = array(
+			NS_MAIN,
+			array(
+				'smwgNamespacesWithSemanticLinks' => array( NS_MAIN => true ),
+				'smwgLinksInValues' => SMW_LINV_OBFU,
+				'smwgInlineErrors'  => true,
+				'smwgEnabledInTextAnnotationParserStrictMode' => true
+			),
+			'<sup id="cite_ref-1" class="reference">[[#cite_note-1|&#91;1&#93;]]</sup>',
+			array(
+				'resultText' => '<sup id="cite_ref-1" class="reference">[[#cite_note-1|&#91;1&#93;]]</sup>'
+			)
+		);
+
 		return $provider;
 	}
 

--- a/tests/phpunit/Unit/Parser/ObfuscatorTest.php
+++ b/tests/phpunit/Unit/Parser/ObfuscatorTest.php
@@ -142,12 +142,12 @@ class ObfuscatorTest extends \PHPUnit_Framework_TestCase {
 
 		$provider[] = array(
 			'[[Foo::[[Bar]]]]',
-			'[[Foo::&#x005B;&#x005B;Bar&#93;&#93;]]'
+			'[[Foo::&#x005B;&#x005B;Bar&#x005D;&#x005D;]]'
 		);
 
 		$provider[] = array(
 			'[[Foo::[[Foo|Bar]]]]',
-			'[[Foo::&#x005B;&#x005B;Foo&#124;Bar&#93;&#93;]]'
+			'[[Foo::&#x005B;&#x005B;Foo&#124;Bar&#x005D;&#x005D;]]'
 		);
 
 		return $provider;


### PR DESCRIPTION
This PR is made in reference to: #2153, #2193, #2671

This PR addresses or contains:

- Switching internal encoding strategy from `&#93;` to `&#x005D;` (see #2193)

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed

Fixes #2671