### PR TITLE
TableResultPrinter to support +width parameter

### DIFF
--- a/includes/queryprinters/TableResultPrinter.php
+++ b/includes/queryprinters/TableResultPrinter.php
@@ -184,6 +184,7 @@ class TableResultPrinter extends ResultPrinter {
 		if ( count( $dataValues ) > 0 ) {
 			$sortKey = $dataValues[0]->getDataItem()->getSortKey();
 			$dataValueType = $dataValues[0]->getTypeID();
+			$printRequest = $resultArray->getPrintRequest();
 
 			if ( is_numeric( $sortKey ) ) {
 				$attributes['data-sort-value'] = $sortKey;
@@ -193,17 +194,26 @@ class TableResultPrinter extends ResultPrinter {
 				$attributes['data-order'] = $sortKey;
 			}
 
-			$alignment = trim( $resultArray->getPrintRequest()->getParameter( 'align' ) );
+			$alignment = trim( $printRequest->getParameter( 'align' ) );
 
 			if ( in_array( $alignment, array( 'right', 'left', 'center' ) ) ) {
 				$attributes['style'] = "text-align:$alignment;";
 			}
+
+			$width = htmlspecialchars(
+				trim( $printRequest->getParameter( 'width' ) )
+			);
+
+			if ( $width ) {
+				$attributes['style'] = isset( $attributes['style'] ) ?  $attributes['style'] . " width:$width;" . $width : "width:$width;";
+			}
+
 			$attributes['class'] = $columnClass . ( $dataValueType !== '' ? ' smwtype' . $dataValueType : '' );
 
 			$content = $this->getCellContent(
 				$dataValues,
 				$outputMode,
-				$resultArray->getPrintRequest()->getMode() == PrintRequest::PRINT_THIS
+				$printRequest->getMode() == PrintRequest::PRINT_THIS
 			);
 		}
 

--- a/tests/phpunit/Integration/JSONScript/TestCases/f-0205.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/f-0205.json
@@ -1,5 +1,5 @@
 {
-	"description": "Test `format=table` on `|+align=`/`|+limit`/`|+order` extra printout parameters (T18571, en)",
+	"description": "Test `format=table` on `|+align=`/`|+limit`/`|+order`/`|+width=` extra printout parameters (T18571, en)",
 	"setup": [
 		{
 			"namespace": "SMW_NS_PROPERTY",
@@ -21,6 +21,10 @@
 		{
 			"page": "Example/F0205/1b",
 			"contents": "{{#ask: [[~Example/F0205/1/*]] |?Has number |+align=left |+limit=2 |+order=desc |format=table |headers=plain }}"
+		},
+		{
+			"page": "Example/F0205/Q.2",
+			"contents": "{{#ask: [[~Example/F0205/1/*]] |?Has number |+width=50% |+limit=2 |+order=desc |format=table |headers=plain }}"
 		}
 	],
 	"tests": [
@@ -37,12 +41,23 @@
 		},
 		{
 			"type": "format",
-			"about": "#1",
+			"about": "#1 (align, left)",
 			"subject": "Example/F0205/1b",
 			"assert-output": {
 				"to-contain": [
 					"data-sort-value=\"42\" style=\"text-align:left;\" class=\"Has-number smwtype_num\">42<br />1",
 					"data-sort-value=\"1001\" style=\"text-align:left;\" class=\"Has-number smwtype_num\">1,001<br />21"
+				]
+			}
+		},
+		{
+			"type": "format",
+			"about": "#2 (+width)",
+			"subject": "Example/F0205/Q.2",
+			"assert-output": {
+				"to-contain": [
+					"<td data-sort-value=\"42\" style=\"width:50%;\" class=\"Has-number smwtype_num\">42<br />1</td>",
+					"<td data-sort-value=\"1001\" style=\"width:50%;\" class=\"Has-number smwtype_num\">1,001<br />21</td>"
 				]
 			}
 		}


### PR DESCRIPTION
This PR is made in reference to: #

This PR addresses or contains:

- Allows to define ` |+width=...` as in `|?Has number |+width=50%` to format the width of a table column and hereby easily enables different tables on the same page to be formatted with the same width without relying on a template format.

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed
