### PR TITLE
PropertyStatisticsTable to add null_count column, refs 2676

### DIFF
--- a/maintenance/rebuildPropertyStatistics.php
+++ b/maintenance/rebuildPropertyStatistics.php
@@ -42,7 +42,7 @@ class RebuildPropertyStatistics extends \Maintenance {
 		$maintenanceHelper->initRuntimeValues();
 
 		$statisticsRebuilder = $maintenanceFactory->newPropertyStatisticsRebuilder(
-			$applicationFactory->getStore(),
+			$applicationFactory->getStore( 'SMW\SQLStore\SQLStore' ),
 			array( $this, 'reportMessage' )
 		);
 

--- a/src/Maintenance/PropertyStatisticsRebuilder.php
+++ b/src/Maintenance/PropertyStatisticsRebuilder.php
@@ -31,7 +31,7 @@ class PropertyStatisticsRebuilder {
 	/**
 	 * @var MessageReporter
 	 */
-	private $reporter;
+	private $messageReporter;
 
 	/**
 	 * @since 1.9
@@ -42,7 +42,7 @@ class PropertyStatisticsRebuilder {
 	public function __construct( Store $store, PropertyStatisticsStore $propertyStatisticsStore ) {
 		$this->store = $store;
 		$this->propertyStatisticsStore = $propertyStatisticsStore;
-		$this->reporter = MessageReporterFactory::getInstance()->newNullMessageReporter();
+		$this->messageReporter = MessageReporterFactory::getInstance()->newNullMessageReporter();
 	}
 
 	/**
@@ -51,18 +51,25 @@ class PropertyStatisticsRebuilder {
 	 * @param MessageReporter $messageReporter
 	 */
 	public function setMessageReporter( MessageReporter $messageReporter ) {
-		$this->reporter = $messageReporter;
+		$this->messageReporter = $messageReporter;
 	}
 
 	/**
 	 * @since 1.9
 	 */
 	public function rebuild() {
-		$this->reportMessage( "Updating property statistics. This may take a while.\n" );
+		$this->reportMessage( "\nProperty statistics update\n" );
 
+
+		$this->reportMessage( "\nDeleting table content ..." );
 		$this->propertyStatisticsStore->deleteAll();
+		$this->reportMessage( "\n   ... done.\n" );
 
-		$res = $this->store->getConnection( 'mw.db' )->select(
+		$connection = $this->store->getConnection( 'mw.db' );
+
+		$this->reportMessage( "\nSelecting properties ..." );
+
+		$res = $connection->select(
 			\SMWSql3SmwIds::TABLE_NAME,
 			array( 'smw_id', 'smw_title' ),
 			array(
@@ -72,46 +79,117 @@ class PropertyStatisticsRebuilder {
 			__METHOD__
 		);
 
+		$propCount = $res->numRows();
+		$this->reportMessage( "\n   ... $propCount properties selected ..." );
+		$this->reportMessage( "\n   ... done.\n" );
+
+		$this->reportMessage( "\nProcessing (this may take a while) ...\n" );
 		$i = 0;
 
 		foreach ( $res as $row ) {
-			$this->reportMessage( ( $i++ % 60 === 0 ? "\n" : ''  ) . '.' );
+			$this->reportMessage( $this->progress( $propCount, $i++ ) );
 
-			$usageCount = 0;
-			foreach ( $this->store->getPropertyTables() as $propertyTable ) {
-
-				if ( $propertyTable->isFixedPropertyTable() && $propertyTable->getFixedProperty() !== $row->smw_title ) {
-					// This table cannot store values for this property
-					continue;
-				}
-
-				$usageCount += $this->getPropertyTableRowCount( $propertyTable, $row->smw_id );
-			}
-
-			$this->propertyStatisticsStore->insertUsageCount( (int)$row->smw_id, $usageCount );
+			$this->propertyStatisticsStore->insertUsageCount(
+				(int)$row->smw_id,
+				$this->getCountFormRow( $row )
+			);
 		}
 
-		$propCount = $res->numRows();
-		$this->store->getConnection( 'mw.db' )->freeResult( $res );
-		$this->reportMessage( "\n\nUpdated statistics for $propCount Properties.\n" );
+		$connection->freeResult( $res );
+
+		$this->reportMessage( "\n\nCompleted.\n" );
 	}
 
-	protected function getPropertyTableRowCount( $propertyTable, $id ) {
+	private function getCountFormRow( $row ) {
 
-		$condition = $propertyTable->isFixedPropertyTable() ? array() : array( 'p_id' => $id );
+		$usageCount = 0;
+		$nullCount = 0;
 
-		$row = $this->store->getConnection( 'mw.db' )->selectRow(
-			$propertyTable->getName(),
+		foreach ( $this->store->getPropertyTables() as $propertyTable ) {
+
+			if ( $propertyTable->isFixedPropertyTable() && $propertyTable->getFixedProperty() !== $row->smw_title ) {
+				// This table cannot store values for this property
+				continue;
+			}
+
+			list( $uCount, $nCount ) = $this->getPropertyTableRowCount(
+				$propertyTable,
+				$row->smw_id
+			);
+
+			$usageCount += $uCount;
+			$nullCount += $nCount;
+		}
+
+		return [ $usageCount, $nullCount ];
+	}
+
+	private function getPropertyTableRowCount( $propertyTable, $pid ) {
+
+		$condition = [];
+		$connection = $this->store->getConnection( 'mw.db' );
+
+		if ( !$propertyTable->isFixedPropertyTable() ) {
+			$condition = [ 'p_id' => $pid ];
+		}
+
+		$tableFields = $this->store->getDataItemHandlerForDIType( $propertyTable->getDiType() )->getTableFields();
+		$tableName = $propertyTable->getName();
+
+		$usageCount = 0;
+		$nullCount = 0;
+
+		// Select all (incl. NULL since for example blob table can have a null
+		// for when only the hash field is used, substract NULL in a second step)
+		$row = $connection->selectRow(
+			$tableName,
 			'Count(*) as count',
 			$condition,
 			__METHOD__
 		);
 
-		return $row->count;
+		if ( $row !== false ) {
+			$usageCount = $row->count;
+		}
+
+		// Select only those that match NULL for all fields
+		foreach ( $tableFields as $field => $type ) {
+			$condition[] = "$field IS NULL";
+		}
+
+		$nRow = $connection->selectRow(
+			$tableName,
+			'Count(*) as count',
+			$condition,
+			__METHOD__
+		);
+
+		if ( $nRow !== false ) {
+			$nullCount = $nRow->count;
+		}
+
+		if ( $usageCount > 0 ) {
+			$usageCount = $usageCount - $nullCount;
+		}
+
+		return [ $usageCount, $nullCount ];
+	}
+
+	private function progress( $propCount, $i ) {
+
+		if ( $i % 60 === 0 ) {
+			if ( $i < 1 ) {
+				return "\n";
+			}
+
+			return ' ' . round( ( $i / $propCount ) * 100 ) . ' %' . "\n";
+		}
+
+		return '.';
 	}
 
 	protected function reportMessage( $message ) {
-		$this->reporter->reportMessage( $message );
+		$this->messageReporter->reportMessage( $message );
 	}
 
 }

--- a/src/SQLStore/TableIntegrityExaminer.php
+++ b/src/SQLStore/TableIntegrityExaminer.php
@@ -180,7 +180,8 @@ class TableIntegrityExaminer implements MessageReporterAware {
 				SQLStore::PROPERTY_STATISTICS_TABLE,
 				array(
 					'p_id' => $id,
-					'usage_count' => 0
+					'usage_count' => 0,
+					'null_count' => 0
 				),
 				__METHOD__
 			);

--- a/src/SQLStore/TableSchemaManager.php
+++ b/src/SQLStore/TableSchemaManager.php
@@ -242,9 +242,14 @@ class TableSchemaManager {
 
 		$table->addColumn( 'p_id', FieldType::FIELD_ID );
 		$table->addColumn( 'usage_count', FieldType::FIELD_USAGE_COUNT );
+		$table->addColumn( 'null_count', FieldType::FIELD_USAGE_COUNT );
+
+		$table->addDefault( 'usage_count', 0 );
+		$table->addDefault( 'null_count', 0 );
 
 		$table->addIndex( array( 'p_id', 'UNIQUE INDEX' ) );
 		$table->addIndex( 'usage_count' );
+		$table->addIndex( 'null_count' );
 
 		return $table;
 	}

--- a/tests/phpunit/Unit/Maintenance/PropertyStatisticsRebuilderTest.php
+++ b/tests/phpunit/Unit/Maintenance/PropertyStatisticsRebuilderTest.php
@@ -27,24 +27,37 @@ class PropertyStatisticsRebuilderTest extends \PHPUnit_Framework_TestCase {
 			->getMockForAbstractClass();
 
 		$this->assertInstanceOf(
-			'\SMW\Maintenance\PropertyStatisticsRebuilder',
+			PropertyStatisticsRebuilder::class,
 			new PropertyStatisticsRebuilder( $store, $propertyStatisticsStore )
 		);
 	}
 
-	public function testRebuildWithValidPropertyStatisticsStoreInsertUsageCount() {
+	public function testRebuildStatisticsStoreAndInsertCountRows() {
 
-		$arbitraryPropertyTableName = 'allornothing';
+		$tableName = 'Foobar';
 
-		$propertySelectRow = new \stdClass;
-		$propertySelectRow->count = 1111;
+		$uRow = new \stdClass;
+		$uRow->count = 1111;
 
-		$selectResult = array(
-			'smw_title'   => 'Foo',
-			'smw_id'      => 9999
+		$nRow = new \stdClass;
+		$nRow->count = 1;
+
+		$res = [
+			'smw_title' => 'Foo',
+			'smw_id' => 9999
+		];
+
+		$resultWrapper = new FakeResultWrapper(
+			array( (object)$res )
 		);
 
-		$selectResultWrapper = new FakeResultWrapper( array( (object)$selectResult ) );
+		$dataItemHandler = $this->getMockBuilder( '\SMW\SQLStore\EntityStore\DataItemHandler' )
+			->disableOriginalConstructor()
+			->getMockForAbstractClass();
+
+		$dataItemHandler->expects( $this->atLeastOnce() )
+			->method( 'getTableFields' )
+			->will( $this->returnValue( [] ) );
 
 		$database = $this->getMockBuilder( '\SMW\MediaWiki\Database' )
 			->disableOriginalConstructor()
@@ -52,15 +65,16 @@ class PropertyStatisticsRebuilderTest extends \PHPUnit_Framework_TestCase {
 
 		$database->expects( $this->atLeastOnce() )
 			->method( 'select' )
-			->will( $this->returnValue( $selectResultWrapper ) );
+			->will( $this->returnValue( $resultWrapper ) );
 
-		$database->expects( $this->once() )
+		$database->expects( $this->atLeastOnce() )
 			->method( 'selectRow' )
-			->with( $this->stringContains( $arbitraryPropertyTableName ),
+			->with(
+				$this->stringContains( $tableName ),
 				$this->anything(),
 				$this->equalTo( array( 'p_id' => 9999 ) ),
 				$this->anything() )
-			->will( $this->returnValue( $propertySelectRow ) );
+			->will( $this->onConsecutiveCalls( $uRow, $nRow ) );
 
 		$store = $this->getMockBuilder( '\SMWSQLStore3' )
 			->disableOriginalConstructor()
@@ -71,17 +85,22 @@ class PropertyStatisticsRebuilderTest extends \PHPUnit_Framework_TestCase {
 			->will( $this->returnValue( $database ) );
 
 		$store->expects( $this->atLeastOnce() )
+			->method( 'getDataItemHandlerForDIType' )
+			->will( $this->returnValue( $dataItemHandler ) );
+
+		$store->expects( $this->atLeastOnce() )
 			->method( 'getPropertyTables' )
-			->will( $this->returnValue( array(
-				$this->getNonFixedPropertyTable( $arbitraryPropertyTableName ) )
-			) );
+			->will( $this->returnValue( [ $this->newPropertyTable( $tableName ) ] ) );
 
 		$propertyStatisticsStore = $this->getMockBuilder( '\SMW\Store\PropertyStatisticsStore' )
 			->disableOriginalConstructor()
 			->getMock();
 
 		$propertyStatisticsStore->expects( $this->atLeastOnce() )
-			->method( 'insertUsageCount' );
+			->method( 'insertUsageCount' )
+			->with(
+				$this->equalTo( 9999 ),
+				$this->equalTo( [ 1110, 1 ] ) );
 
 		$instance = new PropertyStatisticsRebuilder(
 			$store,
@@ -91,17 +110,16 @@ class PropertyStatisticsRebuilderTest extends \PHPUnit_Framework_TestCase {
 		$instance->rebuild();
 	}
 
-	protected function getNonFixedPropertyTable( $propertyTableName ) {
+	protected function newPropertyTable( $propertyTableName, $fixedPropertyTable = false ) {
 
-		$propertyTable = $this->getMockBuilder( '\stdClass' )
-			->setMethods( array(
-				'isFixedPropertyTable',
-				'getName' ) )
+		$propertyTable = $this->getMockBuilder( '\SMW\SQLStore\PropertyTableDefinition' )
+			->disableOriginalConstructor()
+			->setMethods( array( 'isFixedPropertyTable', 'getName' ) )
 			->getMock();
 
 		$propertyTable->expects( $this->atLeastOnce() )
 			->method( 'isFixedPropertyTable' )
-			->will( $this->returnValue( false ) );
+			->will( $this->returnValue( $fixedPropertyTable ) );
 
 		$propertyTable->expects( $this->atLeastOnce() )
 			->method( 'getName' )

--- a/tests/phpunit/includes/storage/sqlstore/PropertyStatisticsTableTest.php
+++ b/tests/phpunit/includes/storage/sqlstore/PropertyStatisticsTableTest.php
@@ -258,4 +258,99 @@ class PropertyStatisticsTableTest extends MwDBaseUnitTestCase {
 		$instance->addToUsageCounts( $additions );
 	}
 
+	public function testInsertUsageCountWithArrayValue() {
+
+		$tableName = 'Foo';
+
+		$connection = $this->getMockBuilder( '\SMW\MediaWiki\Database' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$connection->expects( $this->once() )
+			->method( 'insert' )
+			->with(
+				$this->stringContains( $tableName ),
+				$this->equalTo(
+					[
+						'usage_count' => 1,
+						'null_count'  => 9999,
+						'p_id' => 42
+					] ),
+				$this->anything() );
+
+
+		$instance = new PropertyStatisticsTable(
+			$connection,
+			$tableName
+		);
+
+		$instance->insertUsageCount( 42, [ 1, 9999 ] );
+	}
+
+	public function testAddToUsageCountsWithArrayValue() {
+
+		$tableName = 'Foo';
+
+		$connection = $this->getMockBuilder( '\SMW\MediaWiki\Database' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$connection->expects( $this->any() )
+			->method( 'addQuotes' )
+			->will( $this->returnArgument( 0 ) );
+
+		$connection->expects( $this->once() )
+			->method( 'update' )
+			->with(
+				$this->stringContains( $tableName ),
+				$this->equalTo(
+					[
+						'usage_count = usage_count + 1',
+						'null_count = null_count + 9999'
+					] ),
+				$this->equalTo(
+					[
+						'p_id' => 42
+					] ),
+				$this->anything() );
+
+		$instance = new PropertyStatisticsTable(
+			$connection,
+			$tableName
+		);
+
+		$instance->addToUsageCounts( [ 42 => [ 'usage' => 1, 'null' => 9999 ] ] );
+	}
+
+	public function testSetUsageCountWithArrayValue() {
+
+		$tableName = 'Foo';
+
+		$connection = $this->getMockBuilder( '\SMW\MediaWiki\Database' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$connection->expects( $this->once() )
+			->method( 'update' )
+			->with(
+				$this->stringContains( $tableName ),
+				$this->equalTo(
+					[
+						'usage_count' => 1,
+						'null_count' => 9999
+					] ),
+				$this->equalTo(
+					[
+						'p_id' => 42
+					] ),
+				$this->anything() );
+
+		$instance = new PropertyStatisticsTable(
+			$connection,
+			$tableName
+		);
+
+		$instance->setUsageCount( 42, [ 1, 9999 ] );
+	}
+
 }


### PR DESCRIPTION
This PR is made in reference to: #2676

This PR addresses or contains:

- Prerequisite for #2670
- Adds a `null_count` column to record entities independent from `usage_count` 

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed
