### PR TITLE
Fix "EventListenerRegistry.php: Call to a member function getArticleID() on null"

### DIFF
--- a/src/CacheFactory.php
+++ b/src/CacheFactory.php
@@ -3,6 +3,7 @@
 namespace SMW;
 
 use ObjectCache;
+use Title;
 use Onoi\Cache\CacheFactory as OnoiCacheFactory;
 use RuntimeException;
 
@@ -46,30 +47,40 @@ class CacheFactory {
 	 *
 	 * @return string
 	 */
-	public function getCachePrefix() {
+	public static function getCachePrefix() {
 		return $GLOBALS['wgCachePrefix'] === false ? wfWikiID() : $GLOBALS['wgCachePrefix'];
 	}
 
 	/**
 	 * @since 2.2
 	 *
-	 * @param string $key
+	 * @param Title|integer|string $key
 	 *
 	 * @return string
 	 */
-	public function getFactboxCacheKey( $key ) {
-		return $this->getCachePrefix() . ':smw:fc:' . md5( $key );
+	public static function getFactboxCacheKey( $key ) {
+
+		if ( $key instanceof Title ) {
+			$key = $key->getArticleID();
+		}
+
+		return self::getCachePrefix() . ':smw:fc:' . md5( $key );
 	}
 
 	/**
 	 * @since 2.2
 	 *
-	 * @param string $key
+	 * @param Title|integer|string $key
 	 *
 	 * @return string
 	 */
-	public function getPurgeCacheKey( $key ) {
-		return $this->getCachePrefix() . ':smw:arc:' . md5( $key );
+	public static function getPurgeCacheKey( $key ) {
+
+		if ( $key instanceof Title ) {
+			$key = $key->getArticleID();
+		}
+
+		return self::getCachePrefix() . ':smw:arc:' . md5( $key );
 	}
 
 	/**

--- a/src/EventListenerRegistry.php
+++ b/src/EventListenerRegistry.php
@@ -47,14 +47,14 @@ class EventListenerRegistry implements EventListenerCollection {
 
 				if ( $dispatchContext->has( 'subject' ) ) {
 					$title = $dispatchContext->get( 'subject' )->getTitle();
-				} else{
+				} else {
 					$title = $dispatchContext->get( 'title' );
 				}
 
 				$applicationFactory = ApplicationFactory::getInstance();
 
 				$applicationFactory->getCache()->delete(
-					$applicationFactory->newCacheFactory()->getFactboxCacheKey( $title->getArticleID() )
+					$applicationFactory->newCacheFactory()->getFactboxCacheKey( $title )
 				);
 			}
 		);

--- a/tests/phpunit/Unit/CacheFactoryTest.php
+++ b/tests/phpunit/Unit/CacheFactoryTest.php
@@ -52,6 +52,42 @@ class CacheFactoryTest extends \PHPUnit_Framework_TestCase {
 		);
 	}
 
+	public function testGetFactboxCacheKey() {
+
+		$title = $this->getMockBuilder( '\Title' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$title->expects( $this->once() )
+			->method( 'getArticleID' )
+			->will( $this->returnValue( 42 ) );
+
+		$instance = new CacheFactory( 'hash' );
+
+		$this->assertInternalType(
+			'string',
+			$instance->getFactboxCacheKey( $title )
+		);
+	}
+
+	public function testGetPurgeCacheKey() {
+
+		$title = $this->getMockBuilder( '\Title' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$title->expects( $this->once() )
+			->method( 'getArticleID' )
+			->will( $this->returnValue( 42 ) );
+
+		$instance = new CacheFactory( 'hash' );
+
+		$this->assertInternalType(
+			'string',
+			$instance->getPurgeCacheKey( $title )
+		);
+	}
+
 	public function testCanConstructCacheOptions() {
 
 		$instance = new CacheFactory( 'hash' );

--- a/tests/phpunit/Unit/EventListenerRegistryTest.php
+++ b/tests/phpunit/Unit/EventListenerRegistryTest.php
@@ -19,9 +19,11 @@ use SMW\EventListenerRegistry;
 class EventListenerRegistryTest extends \PHPUnit_Framework_TestCase {
 
 	private $testEnvironment;
+	private $eventDispatcherFactory;
 
 	protected function setUp() {
 		$this->testEnvironment = new TestEnvironment();
+		$this->eventDispatcherFactory = EventDispatcherFactory::getInstance();
 	}
 
 	protected function tearDown() {
@@ -35,7 +37,7 @@ class EventListenerRegistryTest extends \PHPUnit_Framework_TestCase {
 			->getMock();
 
 		$this->assertInstanceOf(
-			'\SMW\EventListenerRegistry',
+			EventListenerRegistry::class,
 			new EventListenerRegistry( $eventListenerCollection )
 		);
 	}
@@ -61,11 +63,12 @@ class EventListenerRegistryTest extends \PHPUnit_Framework_TestCase {
 	public function testCanExecuteRegisteredListeners() {
 
 		$instance = new EventListenerRegistry(
-			EventDispatcherFactory::getInstance()->newGenericEventListenerCollection()
+			$this->eventDispatcherFactory->newGenericEventListenerCollection()
 		);
 
 		$this->verifyExporterResetEvent( $instance );
 		$this->verifyFactboxCacheDeleteEvent( $instance );
+		$this->verifyFactboxCacheDeleteEventOnEmpty( $instance );
 		$this->verifyCachedPropertyValuesPrefetcherResetEvent( $instance );
 		$this->verifyCachedPrefetcherResetEvent( $instance );
 		$this->verifyCachedUpdateMarkerDeleteEvent( $instance );
@@ -95,7 +98,7 @@ class EventListenerRegistryTest extends \PHPUnit_Framework_TestCase {
 
 		$this->testEnvironment->registerObject( 'Cache', $cache );
 
-		$dispatchContext = EventDispatcherFactory::getInstance()->newDispatchContext();
+		$dispatchContext = $this->eventDispatcherFactory->newDispatchContext();
 
 		$dispatchContext->set(
 			'title',
@@ -109,9 +112,31 @@ class EventListenerRegistryTest extends \PHPUnit_Framework_TestCase {
 		);
 	}
 
+	public function verifyFactboxCacheDeleteEventOnEmpty( EventListenerCollection $instance ) {
+
+		$cache = $this->getMockBuilder( '\Onoi\Cache\Cache' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$this->testEnvironment->registerObject( 'Cache', $cache );
+
+		$dispatchContext = $this->eventDispatcherFactory->newDispatchContext();
+
+		$dispatchContext->set(
+			'title',
+			''
+		);
+
+		$this->assertListenerExecuteFor(
+			'factbox.cache.delete',
+			$instance,
+			$dispatchContext
+		);
+	}
+
 	public function verifyCachedPropertyValuesPrefetcherResetEvent( EventListenerCollection $instance ) {
 
-		$dispatchContext = EventDispatcherFactory::getInstance()->newDispatchContext();
+		$dispatchContext = $this->eventDispatcherFactory->newDispatchContext();
 
 		$title = $this->getMockBuilder( '\Title' )
 			->disableOriginalConstructor()
@@ -135,7 +160,7 @@ class EventListenerRegistryTest extends \PHPUnit_Framework_TestCase {
 
 	public function verifyCachedPrefetcherResetEvent( EventListenerCollection $instance ) {
 
-		$dispatchContext = EventDispatcherFactory::getInstance()->newDispatchContext();
+		$dispatchContext = $this->eventDispatcherFactory->newDispatchContext();
 
 		$title = $this->getMockBuilder( '\Title' )
 			->disableOriginalConstructor()
@@ -159,7 +184,7 @@ class EventListenerRegistryTest extends \PHPUnit_Framework_TestCase {
 
 	public function verifyCachedUpdateMarkerDeleteEvent( EventListenerCollection $instance ) {
 
-		$dispatchContext = EventDispatcherFactory::getInstance()->newDispatchContext();
+		$dispatchContext = $this->eventDispatcherFactory->newDispatchContext();
 
 		$subject = $this->getMockBuilder( '\SMW\DIWikiPage' )
 			->disableOriginalConstructor()


### PR DESCRIPTION
This PR is made in reference to: #

This PR addresses or contains:

```
[4bda863a79a1e4504be4a2c5] /mw-master/index.php?title=Special%3ASemanticMediaWiki&action=lookup&id=122776&dispose=yes Error from line 57 of ...\mw-master\extensions\SemanticMediaWiki\src\EventListenerRegistry.php: Call to a member function getArticleID() on null

Backtrace:

#0 [internal function]: SMW\EventListenerRegistry->SMW\{closure}(Onoi\EventDispatcher\DispatchContext)
#1 ...\mw-master\vendor\onoi\event-dispatcher\src\Listener\GenericCallbackEventListener.php(62): call_user_func_array(Closure, array)
#2 ...\mw-master\vendor\onoi\event-dispatcher\src\Dispatcher\GenericEventDispatcher.php(122): Onoi\EventDispatcher\Listener\GenericCallbackEventListener->execute(Onoi\EventDispatcher\DispatchContext)
#3 ...\mw-master\extensions\SemanticMediaWiki\src\SQLStore\PropertyTableIdReferenceDisposer.php(243): Onoi\EventDispatcher\Dispatcher\GenericEventDispatcher->dispatch(string, Onoi\EventDispatcher\DispatchContext)
#4 ...\mw-master\extensions\SemanticMediaWiki\src\SQLStore\PropertyTableIdReferenceDisposer.php(137): SMW\SQLStore\PropertyTableIdReferenceDisposer->triggerCleanUpEvents(SMW\DIWikiPage, boolean)
#5 ...\mw-master\extensions\SemanticMediaWiki\src\MediaWiki\Jobs\EntityIdDisposerJob.php(60): SMW\SQLStore\PropertyTableIdReferenceDisposer->cleanUpTableEntriesById(integer)
#6 ...\mw-master\extensions\SemanticMediaWiki\src\MediaWiki\Specials\Admin\EntityLookupTaskHandler.php(126): SMW\MediaWiki\Jobs\EntityIdDisposerJob->dispose(integer)
#7 ...\mw-master\extensions\SemanticMediaWiki\src\MediaWiki\Specials\Admin\EntityLookupTaskHandler.php(108): SMW\MediaWiki\Specials\Admin\EntityLookupTaskHandler->doDispose(string)
#8 ...\mw-master\extensions\SemanticMediaWiki\src\MediaWiki\Specials\SpecialAdmin.php(173): SMW\MediaWiki\Specials\Admin\EntityLookupTaskHandler->handleRequest(WebRequest)
#9 ...\mw-master\includes\specialpage\SpecialPage.php(522): SMW\MediaWiki\Specials\SpecialAdmin->execute(NULL)
#10 ...\mw-master\includes\specialpage\SpecialPageFactory.php(578): SpecialPage->run(NULL)
#11 ...\mw-master\includes\MediaWiki.php(287): SpecialPageFactory::executePath(Title, RequestContext)
#12 ...\mw-master\includes\MediaWiki.php(851): MediaWiki->performRequest()
#13 ...\mw-master\includes\MediaWiki.php(523): MediaWiki->main()
#14 ...\mw-master\index.php(43): MediaWiki->run()
#15 {main}
```

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed
