### PR TITLE
Add API smwbrowse module

### DIFF
--- a/i18n/en.json
+++ b/i18n/en.json
@@ -603,5 +603,8 @@
 	"apihelp-askargs-summary": "API module to query Semantic MediaWiki using the ask language as list of conditions, printouts and parameters.",
 	"apihelp-browsebyproperty-summary": "API module to retrieve information about a property or list of properties.",
 	"apihelp-browsebysubject-summary": "API module to retrieve information about a subject.",
-	"apihelp-smwtask-summary": "API module to execute Semantic MediaWiki related tasks."
+	"apihelp-smwtask-summary": "API module to execute Semantic MediaWiki related tasks.",
+	"apihelp-smwbrowse-summary": "Semantic MediaWiki API module to support selected browse activties.",
+	"smw-api-smwbrowse-invalid-parameters": "Parameters format is invalid, expected a valid JSON format."
+
 }

--- a/includes/Setup.php
+++ b/includes/Setup.php
@@ -191,8 +191,10 @@ final class Setup {
 
 		$this->globalVars['wgAPIModules']['smwinfo'] = '\SMW\MediaWiki\Api\Info';
 		$this->globalVars['wgAPIModules']['smwtask'] = '\SMW\MediaWiki\Api\Task';
+		$this->globalVars['wgAPIModules']['smwbrowse'] = '\SMW\MediaWiki\Api\Browse';
 		$this->globalVars['wgAPIModules']['ask']     = '\SMW\MediaWiki\Api\Ask';
 		$this->globalVars['wgAPIModules']['askargs'] = '\SMW\MediaWiki\Api\AskArgs';
+
 		$this->globalVars['wgAPIModules']['browsebysubject'] = '\SMW\MediaWiki\Api\BrowseBySubject';
 		$this->globalVars['wgAPIModules']['browsebyproperty'] = '\SMW\MediaWiki\Api\BrowseByProperty';
 	}

--- a/src/MediaWiki/Api/Browse.php
+++ b/src/MediaWiki/Api/Browse.php
@@ -1,0 +1,187 @@
+<?php
+
+namespace SMW\MediaWiki\Api;
+
+use ApiBase;
+use SMW\ApplicationFactory;
+use SMW\MediaWiki\Api\Browse\ListLookup;
+use SMW\MediaWiki\Api\Browse\ListAugmentor;
+use SMW\MediaWiki\Api\Browse\LookupCache;
+
+/**
+ * Module to support selected browse activties including:
+ *
+ * - Search a list of available
+ *   - categories
+ *   - properties
+ *   - concepts
+ *
+ * @license GNU GPL v2+
+ * @since 3.0
+ *
+ * @author mwjames
+ */
+class Browse extends ApiBase {
+
+	/**
+	 * @see ApiBase::execute
+	 */
+	public function execute() {
+
+		$params = $this->extractRequestParams();
+		$parameters = json_decode( $params['params'], true );
+		$res = [];
+
+		if ( json_last_error() !== JSON_ERROR_NONE || !is_array( $parameters ) ) {
+
+			// 1.29+
+			if ( method_exists($this, 'dieWithError' ) ) {
+				$this->dieWithError( [ 'smw-api-smwbrowse-invalid-parameters' ] );
+			} else {
+				$this->dieUsageMsg( 'smw-api-smwbrowse-invalid-parameters' );
+			}
+		}
+
+		if ( $params['browse'] === 'category' ) {
+			$res = $this->callListLookup( NS_CATEGORY, $parameters );
+		}
+
+		if ( $params['browse'] === 'property' ) {
+			$res = $this->callListLookup( SMW_NS_PROPERTY, $parameters );
+		}
+
+		if ( $params['browse'] === 'concept' ) {
+			$res = $this->callListLookup( SMW_NS_CONCEPT, $parameters );
+		}
+
+		$result = $this->getResult();
+
+		foreach ( $res as $key => $value ) {
+
+			if ( $key === 'query' ) {
+
+				// For those items that start with _xyz as in _MDAT
+				// https://www.mediawiki.org/wiki/API:JSON_version_2
+				// " ... can indicate that a property beginning with an underscore ..."
+				foreach ( $value as $k => $v ) {
+					if ( $k{0} === '_' ) {
+						$result->addPreserveKeysList( 'query', $k );
+					}
+				}
+			}
+
+			$result->addValue( null, $key, $value );
+		}
+	}
+
+	private function callListLookup( $ns, $parameters ) {
+
+		$applicationFactory = ApplicationFactory::getInstance();
+		$store = $applicationFactory->getStore();
+
+		$listAugmentor = new ListAugmentor(
+			$store
+		);
+
+		$listLookup = new ListLookup(
+			$store,
+			$listAugmentor
+		);
+
+		$lookupCache = new LookupCache(
+			$applicationFactory->getCache(),
+			$listLookup
+		);
+
+		return $lookupCache->lookup(
+			$ns,
+			$parameters
+		);
+	}
+
+	/**
+	 * @codeCoverageIgnore
+	 * @see ApiBase::getAllowedParams
+	 *
+	 * @return array
+	 */
+	public function getAllowedParams() {
+		return array(
+			'browse' => array(
+				ApiBase::PARAM_REQUIRED => true,
+				ApiBase::PARAM_TYPE => array(
+					'category',
+					'property',
+					'concept'
+				)
+			),
+			'params' => array(
+				ApiBase::PARAM_TYPE => 'string',
+				ApiBase::PARAM_REQUIRED => true,
+			),
+		);
+	}
+
+	/**
+	 * @codeCoverageIgnore
+	 * @see ApiBase::getParamDescription
+	 *
+	 * @return array
+	 */
+	public function getParamDescription() {
+		return array(
+			'browse' => 'Specifies type of browse activty',
+			'params' => 'JSON encoded parameters that matches the selected type requirment'
+		);
+	}
+
+	/**
+	 * @codeCoverageIgnore
+	 * @see ApiBase::getDescription
+	 *
+	 * @return array
+	 */
+	public function getDescription() {
+		return array(
+			'Semantic MediaWiki API module to support browse activties.'
+		);
+	}
+
+	/**
+	 * @codeCoverageIgnore
+	 * @see ApiBase::getExamples
+	 *
+	 * @return array
+	 */
+	protected function getExamples() {
+		return array(
+			'api.php?action=smwbrowse&browse=property&params={ "limit": 10, "offset": 0, "search": "Date" }',
+			'api.php?action=smwbrowse&browse=property&params={ "limit": 10, "offset": 0, "search": "Date", "description": true }',
+			'api.php?action=smwbrowse&browse=property&params={ "limit": 10, "offset": 0, "search": "Date", "description": true, "prefLabel": true }',
+			'api.php?action=smwbrowse&browse=property&params={ "limit": 10, "offset": 0, "search": "Date", "description": true, "prefLabel": true, "usageCount": true }',
+			'api.php?action=smwbrowse&browse=category&params={ "limit": 10, "offset": 0 }',
+			'api.php?action=smwbrowse&browse=concept&params={ "limit": 10, "offset": 0 }'
+		);
+	}
+
+	/**
+	 * @codeCoverageIgnore
+	 * @see ApiBase::getVersion
+	 *
+	 * @return string
+	 */
+	public function getVersion() {
+		return __CLASS__ . ':' . SMW_VERSION;
+	}
+
+	/**
+	 * @codeCoverageIgnore
+	 * @see ApiBase::getVersion
+	 *
+	 * @return string
+	 */
+	public function getHelpUrls() {
+		return 'https://www.semantic-mediawiki.org/wiki/Help:API';
+	}
+
+}

--- a/src/MediaWiki/Api/Browse/ListAugmentor.php
+++ b/src/MediaWiki/Api/Browse/ListAugmentor.php
@@ -1,0 +1,147 @@
+<?php
+
+namespace SMW\MediaWiki\Api\Browse;
+
+use SMW\DIProperty;
+use SMW\Store;
+use SMW\SQLStore\SQLStore;
+use SMW\ApplicationFactory;
+
+/**
+ * @license GNU GPL v2+
+ * @since 3.0
+ *
+ * @author mwjames
+ */
+class ListAugmentor {
+
+	/**
+	 * @var Store
+	 */
+	private $store;
+
+	/**
+	 * @since 3.0
+	 *
+	 * @param Store $store
+	 */
+	public function __construct( Store $store ) {
+		$this->store = $store;
+	}
+
+	/**
+	 * @since 3.0
+	 *
+	 * @param integer $ns
+	 * @param array $parameters
+	 *
+	 * @return array
+	 */
+	public function augment( array &$res, array $parameters ) {
+
+		if ( !isset( $res['query'] ) && $res['query'] === [] ) {
+			return;
+		}
+
+		$type = null;
+		$lang = 'en';
+
+		if ( isset( $res['meta']['type'] ) ) {
+			$type = $res['meta']['type'];
+		}
+
+		if ( isset( $parameters['lang'] ) ) {
+			$lang = $parameters['lang'];
+		}
+
+		if ( is_string( $lang ) ) {
+			$lang = [ $lang ];
+		}
+
+		if ( $type === 'property' && isset( $parameters['description' ] ) ) {
+			$this->addPropertyDescription( $res, $lang );
+		}
+
+		if ( $type === 'property' && isset( $parameters['prefLabel' ] ) ) {
+			$this->addPreferredPropertyLabel( $res, $lang );
+		}
+
+		if ( $type === 'property' && isset( $parameters['usageCount' ] ) ) {
+			$this->addUsageCount( $res );
+		}
+
+		// Remove the internal ID, no external consumer should rely on it
+		foreach ( $res['query'] as $key => &$value ) {
+			unset( $value['id'] );
+		}
+
+		return $res;
+	}
+
+	private function addUsageCount( &$res ) {
+
+		$list = $res['query'];
+
+		$db = $this->store->getConnection( 'mw.db' );
+
+		foreach ( $list as $key => $value ) {
+
+			$row = $db->selectRow(
+				SQLStore::PROPERTY_STATISTICS_TABLE,
+				[ 'usage_count' ],
+				[
+					'p_id' => $value['id']
+				],
+				__METHOD__
+			);
+
+			$list[$key] = $value + [
+				'usageCount' => $row->usage_count
+			];
+		}
+
+		$res['query'] = $list;
+	}
+
+	private function addPreferredPropertyLabel( &$res, array $languageCodes ) {
+
+		$list = $res['query'];
+
+		foreach ( $list as $key => $value ) {
+			$property = new DIProperty( $key );
+			$prefLabel = [];
+
+			foreach ( $languageCodes as $code ) {
+				$prefLabel[$code] = $property->getPreferredLabel( $code );
+			}
+
+			$list[$key] = $value + [
+				'prefLabel' => $prefLabel
+			];
+		}
+
+		$res['query'] = $list;
+	}
+
+	private function addPropertyDescription( &$res, array $languageCodes ) {
+
+		$list = $res['query'];
+		$propertySpecificationLookup = ApplicationFactory::getInstance()->getPropertySpecificationLookup();
+
+		foreach ( $list as $key => $value ) {
+			$property = new DIProperty( $key );
+			$description = [];
+
+			foreach ( $languageCodes as $code ) {
+				$description[$code] = $propertySpecificationLookup->getPropertyDescriptionBy( $property, $code );
+			}
+
+			$list[$key] = $value + [
+				'description' => $description
+			];
+		}
+
+		$res['query'] = $list;
+	}
+
+}

--- a/src/MediaWiki/Api/Browse/ListLookup.php
+++ b/src/MediaWiki/Api/Browse/ListLookup.php
@@ -1,0 +1,229 @@
+<?php
+
+namespace SMW\MediaWiki\Api\Browse;
+
+use SMW\DIProperty;
+use Exception;
+use SMW\RequestOptions;
+use SMW\Store;
+use SMW\StringCondition;
+use SMW\ApplicationFactory;
+use SMW\SQLStore\SQLStore;
+
+/**
+ * @license GNU GPL v2+
+ * @since 3.0
+ *
+ * @author mwjames
+ */
+class ListLookup {
+
+	const VERSION = 1;
+
+	/**
+	 * @var Store
+	 */
+	private $store;
+
+	/**
+	 * @var ListAugmentor
+	 */
+	private $listAugmentor;
+
+	/**
+	 * @since 3.0
+	 *
+	 * @param Store $store
+	 */
+	public function __construct( Store $store, ListAugmentor $listAugmentor ) {
+		$this->store = $store;
+		$this->listAugmentor = $listAugmentor;
+	}
+
+	/**
+	 * @since 3.0
+	 *
+	 * @param integer $ns
+	 * @param array $parameters
+	 *
+	 * @return array
+	 */
+	public function lookup( $ns, array $parameters ) {
+
+		$requestOptions = $this->newRequestOptions(
+			$parameters
+		);
+
+		$limit = $requestOptions->getLimit();
+		$list = [];
+		$continueOffset = 0;
+
+		// Increase by one to look ahead
+		$requestOptions->setLimit( $limit + 1 );
+
+		switch ( $ns ) {
+			case NS_CATEGORY:
+				$type = 'category';
+				break;
+			case SMW_NS_PROPERTY:
+				$type = 'property';
+				break;
+			case SMW_NS_CONCEPT:
+				$type = 'concept';
+				break;
+			default:
+				$type = 'unlisted';
+				break;
+		}
+
+		if ( isset( $parameters['search'] ) ) {
+			list( $list, $continueOffset ) = $this->search( $ns, $requestOptions );
+		}
+
+		// Changing this output format requires to set a new version
+		$res = [
+			'query' => $list,
+			'query-continue-offset' => $continueOffset,
+			'version' => self::VERSION,
+			'meta' => [
+				'type'  => $type,
+				'limit' => $limit,
+				'count' => count( $list )
+			]
+		];
+
+		$this->listAugmentor->augment(
+			$res,
+			$parameters
+		);
+
+		return $res;
+	}
+
+	private function newRequestOptions( $parameters ) {
+
+		$limit = 50;
+		$offset = 0;
+		$search = '';
+
+		if ( isset( $parameters['limit'] ) ) {
+			$limit = (int)$parameters['limit'];
+		}
+
+		if ( isset( $parameters['offset'] ) ) {
+			$offset = (int)$parameters['offset'];
+		}
+
+		$requestOptions = new RequestOptions();
+		$requestOptions->sort = true;
+		$requestOptions->setLimit( $limit );
+		$requestOptions->setOffset( $offset );
+
+		if ( isset( $parameters['search'] ) ) {
+			$search = $parameters['search'];
+
+			if ( $search !== '' && $search{0} !== '_' ) {
+				$search = str_replace( "_", " ", $search );
+			}
+
+			$requestOptions->addStringCondition(
+				$search,
+				StringCondition::STRCOND_MID
+			);
+
+			// Disjunctive condition to allow for auto searches to match foaf OR Foaf
+			$requestOptions->addStringCondition(
+				ucfirst( $search ),
+				StringCondition::STRCOND_MID,
+				true
+			);
+
+			// Allow something like FOO to match the search string `foo`
+			$requestOptions->addStringCondition(
+				strtoupper( $search ),
+				StringCondition::STRCOND_MID,
+				true
+			);
+
+			$requestOptions->addStringCondition(
+				strtolower( $search ),
+				StringCondition::STRCOND_MID,
+				true
+			);
+		}
+
+		return $requestOptions;
+	}
+
+	private function search( $ns, $requestOptions ) {
+
+		$limit = $requestOptions->getLimit() - 1;
+		$list = [];
+
+		$fields = [
+			'smw_id',
+			'smw_title'
+		];
+
+		// the query needs to do the filtering of internal properties, else LIMIT is wrong
+		$options = $this->store->getSQLOptions( $requestOptions, 'smw_sort' );
+		$fields[] = 'smw_sort';
+
+		$conditions = [
+			'smw_namespace' => $ns,
+			'smw_iw' => '',
+			'smw_subobject' => ''
+		];
+
+		if ( ( $cond = $this->store->getSQLConditions( $requestOptions, '', 'smw_sortkey', false ) ) !== '' ) {
+			$conditions[] = $cond;
+			$fields[] = 'smw_sortkey';
+		}
+
+		$connection = $this->store->getConnection( 'mw.db' );
+
+		$res = $connection->select(
+			$connection->tableName( SQLStore::ID_TABLE ),
+			$fields,
+			$conditions,
+			__METHOD__,
+			$options
+		);
+
+		$count = 0;
+		$continueOffset = 0;
+
+		foreach ( $res as $row ) {
+
+			$key = $row->smw_title;
+			$count++;
+
+			if ( $count > $limit ) {
+				$continueOffset = $requestOptions->getOffset() + $limit;
+				break;
+			}
+
+			if ( $ns === SMW_NS_PROPERTY ) {
+				try {
+					$label = DIProperty::newFromUserLabel( $row->smw_title )->getLabel();
+				} catch( Exception $e ) {
+					continue;
+				}
+
+			} else {
+				$label = str_replace( '_', ' ', $row->smw_title );
+			}
+
+			$list[$key] = [
+				 // Only keep the ID as internal field which is
+				 // removed by the Augmentor
+				'id'    => $row->smw_id,
+				'label' => $label,
+				'key'   => $key
+			];
+		}
+
+		return [ $list, $continueOffset ];
+	}
+
+}

--- a/src/MediaWiki/Api/Browse/LookupCache.php
+++ b/src/MediaWiki/Api/Browse/LookupCache.php
@@ -1,0 +1,84 @@
+<?php
+
+namespace SMW\MediaWiki\Api\Browse;
+
+use SMW\Utils\Timer;
+use Onoi\Cache\Cache;
+
+/**
+ * @license GNU GPL v2+
+ * @since 3.0
+ *
+ * @author mwjames
+ */
+class LookupCache {
+
+	const CACHE_NAMESPACE = 'smw:api:browse';
+	const CACHE_TTL = 1800;
+
+	/**
+	 * @var Store
+	 */
+	private $store;
+
+	/**
+	 * @var ListLookup
+	 */
+	private $listLookup;
+
+	/**
+	 * @since 3.0
+	 *
+	 * @param Cache $cache
+	 * @param ListLookup $listLookup
+	 */
+	public function __construct( Cache $cache, ListLookup $listLookup ) {
+		$this->cache = $cache;
+		$this->listLookup = $listLookup;
+	}
+
+	/**
+	 * @since 3.0
+	 *
+	 * @param integer $ns
+	 * @param array $parameters
+	 *
+	 * @return array
+	 */
+	public function lookup( $ns, array $parameters ) {
+
+		Timer::start( __METHOD__ );
+
+		$hash = smwfCacheKey(
+			self::CACHE_NAMESPACE,
+			[
+				$ns,
+				$parameters,
+				ListLookup::VERSION
+			]
+		);
+
+		if ( ( $res = $this->cache->fetch( $hash ) ) !== false ) {
+			$res['meta']['isFromCache'] = true;
+			$res['meta']['queryTime'] = Timer::getElapsedTime( __METHOD__, 5 );
+			return $res;
+		}
+
+		$res = $this->listLookup->lookup(
+			$ns,
+			$parameters
+		);
+
+		$res['meta']['isFromCache'] = false;
+		$res['meta']['queryTime'] = Timer::getElapsedTime( __METHOD__, 5 );
+
+		$this->cache->save(
+			$hash,
+			$res,
+			self::CACHE_TTL
+		);
+
+		return $res;
+	}
+
+}

--- a/src/MediaWiki/Api/BrowseBySubject.php
+++ b/src/MediaWiki/Api/BrowseBySubject.php
@@ -69,7 +69,8 @@ class BrowseBySubject extends ApiBase {
 		$applicationFactory = ApplicationFactory::getInstance();
 
 		$title = $applicationFactory->newTitleCreator()->createFromText(
-			$params['subject']
+			$params['subject'],
+			$params['ns']
 		);
 
 		$deepRedirectTargetResolver = $applicationFactory->newMwCollaboratorFactory()->newDeepRedirectTargetResolver();
@@ -142,7 +143,7 @@ class BrowseBySubject extends ApiBase {
 			'ns' => array(
 				ApiBase::PARAM_TYPE => 'integer',
 				ApiBase::PARAM_ISMULTI => false,
-				ApiBase::PARAM_DFLT => '',
+				ApiBase::PARAM_DFLT => 0,
 				ApiBase::PARAM_REQUIRED => false,
 			),
 			'iw' => array(

--- a/tests/phpunit/Unit/MediaWiki/Api/Browse/ListAugmentorTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Api/Browse/ListAugmentorTest.php
@@ -1,0 +1,194 @@
+<?php
+
+namespace SMW\Tests\MediaWiki\Api\ListAugmentor;
+
+use SMW\MediaWiki\Api\Browse\ListAugmentor;
+
+/**
+ * @covers \SMW\MediaWiki\Api\Browse\ListAugmentor
+ * @group semantic-mediawiki
+ *
+ * @license GNU GPL v2+
+ * @since 3.0
+ *
+ * @author mwjames
+ */
+class ListAugmentorTest extends \PHPUnit_Framework_TestCase {
+
+	public function testCanConstruct() {
+
+		$store = $this->getMockBuilder( '\SMW\SQLStore\SQLStore' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$this->assertInstanceOf(
+			ListAugmentor::class,
+			new ListAugmentor( $store )
+		);
+	}
+
+	public function testAugmentOnDescription() {
+
+		$res = [
+			'query' => [
+				'Foo' => [
+					'id' => 42,
+					'label' => 'Foo',
+					'key' => 'Foo'
+				]
+			],
+			'query-continue-offset' => 0,
+			'version' => 1,
+			'meta' => [
+				'type'  => 'property',
+				'limit' => 50,
+				'count' => 1
+			]
+		];
+
+		$parameters = [
+			'description' => true,
+			'lang' => [ 'en', 'ja' ]
+		];
+
+		$expected = [
+			'Foo' => [
+				'label' => 'Foo',
+				'key' => 'Foo',
+				'description' => [
+					'en' => '',
+					'ja' => ''
+				]
+			]
+		];
+
+		$store = $this->getMockBuilder( '\SMW\SQLStore\SQLStore' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$instance = new ListAugmentor(
+			$store
+		);
+
+		$instance->augment( $res, $parameters );
+
+		$this->assertEquals(
+			$res['query'],
+			$expected
+		);
+	}
+
+	public function testAugmentOnPrefLabel() {
+
+		$res = [
+			'query' => [
+				'Foo' => [
+					'id' => 42,
+					'label' => 'Foo',
+					'key' => 'Foo'
+				]
+			],
+			'query-continue-offset' => 0,
+			'version' => 1,
+			'meta' => [
+				'type'  => 'property',
+				'limit' => 50,
+				'count' => 1
+			]
+		];
+
+		$parameters = [
+			'prefLabel' => true,
+			'lang' => [ 'en', 'ja' ]
+		];
+
+		$expected = [
+			'Foo' => [
+				'label' => 'Foo',
+				'key' => 'Foo',
+				'prefLabel' => [
+					'en' => '',
+					'ja' => ''
+				]
+			]
+		];
+
+		$store = $this->getMockBuilder( '\SMW\SQLStore\SQLStore' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$instance = new ListAugmentor(
+			$store
+		);
+
+		$instance->augment( $res, $parameters );
+
+		$this->assertEquals(
+			$res['query'],
+			$expected
+		);
+	}
+
+	public function testAugmentOnUsageCount() {
+
+		$res = [
+			'query' => [
+				'Foo' => [
+					'id' => 42,
+					'label' => 'Foo',
+					'key' => 'Foo'
+				]
+			],
+			'query-continue-offset' => 0,
+			'version' => 1,
+			'meta' => [
+				'type'  => 'property',
+				'limit' => 50,
+				'count' => 1
+			]
+		];
+
+		$parameters = [
+			'usageCount' => true
+		];
+
+		$expected = [
+			'Foo' => [
+				'label' => 'Foo',
+				'key' => 'Foo',
+				'usageCount' => 1111
+			]
+		];
+
+		$row = new \stdClass;
+		$row->usage_count = 1111;
+
+		$connection = $this->getMockBuilder( '\SMW\MediaWiki\Database' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$connection->expects( $this->any() )
+			->method( 'selectRow' )
+			->will( $this->returnValue( $row ) );
+
+		$store = $this->getMockBuilder( '\SMW\SQLStore\SQLStore' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$store->expects( $this->any() )
+			->method( 'getConnection' )
+			->will( $this->returnValue( $connection ) );
+
+		$instance = new ListAugmentor(
+			$store
+		);
+
+		$instance->augment( $res, $parameters );
+
+		$this->assertEquals(
+			$res['query'],
+			$expected
+		);
+	}
+
+}

--- a/tests/phpunit/Unit/MediaWiki/Api/Browse/ListLookupTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Api/Browse/ListLookupTest.php
@@ -1,0 +1,123 @@
+<?php
+
+namespace SMW\Tests\MediaWiki\Api\ListLookup;
+
+use SMW\MediaWiki\Api\Browse\ListLookup;
+
+/**
+ * @covers \SMW\MediaWiki\Api\Browse\ListLookup
+ * @group semantic-mediawiki
+ *
+ * @license GNU GPL v2+
+ * @since 3.0
+ *
+ * @author mwjames
+ */
+class ListLookupTest extends \PHPUnit_Framework_TestCase {
+
+	public function testCanConstruct() {
+
+		$store = $this->getMockBuilder( '\SMW\SQLStore\SQLStore' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$listAugmentor = $this->getMockBuilder( '\SMW\MediaWiki\Api\Browse\ListAugmentor' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$this->assertInstanceOf(
+			ListLookup::class,
+			new ListLookup( $store, $listAugmentor )
+		);
+	}
+
+	/**
+	 * @dataProvider namespaceProvider
+	 */
+	public function testLookup( $ns, $title, $expected ) {
+
+		$row = new \stdClass;
+		$row->smw_title = $title;
+		$row->smw_id = 42;
+
+		$listAugmentor = $this->getMockBuilder( '\SMW\MediaWiki\Api\Browse\ListAugmentor' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$connection = $this->getMockBuilder( '\SMW\MediaWiki\Database' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$connection->expects( $this->atLeastOnce() )
+			->method( 'select' )
+			->will( $this->returnValue( [ $row ] ) );
+
+		$store = $this->getMockBuilder( '\SMW\SQLStore\SQLStore' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$store->expects( $this->atLeastOnce() )
+			->method( 'getSQLOptions' )
+			->will( $this->returnValue( [] ) );
+
+		$store->expects( $this->atLeastOnce() )
+			->method( 'getConnection' )
+			->will( $this->returnValue( $connection ) );
+
+		$instance = new ListLookup(
+			$store,
+			$listAugmentor
+		);
+
+		$parameters = [ 'search' => 'Foo' ];
+
+		$res = $instance->lookup( $ns, $parameters );
+
+		$this->assertEquals(
+			$res['query'],
+			$expected
+		);
+	}
+
+	public function namespaceProvider() {
+
+		$provider[] = [
+			SMW_NS_PROPERTY,
+			'Foo',
+			[
+				'Foo' => [
+					'id' => 42,
+					'label' => 'Foo',
+					'key' => 'Foo'
+				]
+			]
+		];
+
+		$provider[] = [
+			NS_CATEGORY,
+			'Foo',
+			[
+				'Foo' => [
+					'id' => 42,
+					'label' => 'Foo',
+					'key' => 'Foo'
+				]
+			]
+		];
+
+		$provider[] = [
+			SMW_NS_CONCEPT,
+			'Foo',
+			[
+				'Foo' => [
+					'id' => 42,
+					'label' => 'Foo',
+					'key' => 'Foo'
+				]
+			]
+		];
+
+		return $provider;
+	}
+
+}

--- a/tests/phpunit/Unit/MediaWiki/Api/Browse/LookupCacheTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Api/Browse/LookupCacheTest.php
@@ -1,0 +1,95 @@
+<?php
+
+namespace SMW\Tests\MediaWiki\Api\LookupCache;
+
+use SMW\MediaWiki\Api\Browse\LookupCache;
+
+/**
+ * @covers \SMW\MediaWiki\Api\Browse\LookupCache
+ * @group semantic-mediawiki
+ *
+ * @license GNU GPL v2+
+ * @since 3.0
+ *
+ * @author mwjames
+ */
+class LookupCacheTest extends \PHPUnit_Framework_TestCase {
+
+	public function testCanConstruct() {
+
+		$cache = $this->getMockBuilder( '\Onoi\Cache\Cache' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$listLookup = $this->getMockBuilder( '\SMW\MediaWiki\Api\Browse\ListLookup' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$this->assertInstanceOf(
+			LookupCache::class,
+			new LookupCache( $cache, $listLookup )
+		);
+	}
+
+	public function testLookupWithoutCache() {
+
+		$cache = $this->getMockBuilder( '\Onoi\Cache\Cache' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$cache->expects( $this->atLeastOnce() )
+			->method( 'fetch' )
+			->will( $this->returnValue( false ) );
+
+		$cache->expects( $this->atLeastOnce() )
+			->method( 'save' );
+
+		$listLookup = $this->getMockBuilder( '\SMW\MediaWiki\Api\Browse\ListLookup' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$listLookup->expects( $this->atLeastOnce() )
+			->method( 'lookup' )
+			->will( $this->returnValue( [] ) );
+
+		$instance = new LookupCache(
+			$cache,
+			$listLookup
+		);
+
+		$parameters = [];
+
+		$instance->lookup( 'Foo', $parameters );
+	}
+
+	public function testLookupWithCache() {
+
+		$cache = $this->getMockBuilder( '\Onoi\Cache\Cache' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$cache->expects( $this->atLeastOnce() )
+			->method( 'fetch' )
+			->will( $this->returnValue( [] ) );
+
+		$cache->expects( $this->never() )
+			->method( 'save' );
+
+		$listLookup = $this->getMockBuilder( '\SMW\MediaWiki\Api\Browse\ListLookup' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$listLookup->expects( $this->never() )
+			->method( 'lookup' );
+
+		$instance = new LookupCache(
+			$cache,
+			$listLookup
+		);
+
+		$parameters = [];
+
+		$instance->lookup( 'Foo', $parameters );
+	}
+
+}

--- a/tests/phpunit/Unit/MediaWiki/Api/BrowseTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Api/BrowseTest.php
@@ -1,0 +1,114 @@
+<?php
+
+namespace SMW\Tests\MediaWiki\Api;
+
+use SMW\MediaWiki\Api\Browse;
+use SMW\Tests\TestEnvironment;
+
+/**
+ * @covers \SMW\MediaWiki\Api\Browse
+ * @group semantic-mediawiki
+ *
+ * @license GNU GPL v2+
+ * @since 3.0
+ *
+ * @author mwjames
+ */
+class BrowseTest extends \PHPUnit_Framework_TestCase {
+
+	private $apiFactory;
+	private $testEnvironment;
+
+	protected function setUp() {
+		parent::setUp();
+
+		$this->testEnvironment = new TestEnvironment();
+		$this->apiFactory = $this->testEnvironment->getUtilityFactory()->newMwApiFactory();
+	}
+
+	protected function tearDown() {
+		$this->testEnvironment->tearDown();
+		parent::tearDown();
+	}
+
+	public function testCanConstruct() {
+
+		$instance = new Browse(
+			$this->apiFactory->newApiMain( array() ),
+			'smwbrowse'
+		);
+
+		$this->assertInstanceOf(
+			Browse::class,
+			$instance
+		);
+	}
+
+	/**
+	 * @dataProvider browseIdProvider
+	 */
+	public function testExecute( $id ) {
+
+		$cache = $this->getMockBuilder( '\Onoi\Cache\Cache' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$cache->expects( $this->atLeastOnce() )
+			->method( 'fetch' )
+			->will( $this->returnValue( false ) );
+
+		$connection = $this->getMockBuilder( '\SMW\MediaWiki\Database' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$connection->expects( $this->atLeastOnce() )
+			->method( 'select' )
+			->will( $this->returnValue( [] ) );
+
+		$store = $this->getMockBuilder( '\SMW\SQLStore\SQLStore' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$store->expects( $this->atLeastOnce() )
+			->method( 'getSQLOptions' )
+			->will( $this->returnValue( [] ) );
+
+		$store->expects( $this->atLeastOnce() )
+			->method( 'getConnection' )
+			->will( $this->returnValue( $connection ) );
+
+		$this->testEnvironment->registerObject( 'Cache', $cache );
+		$this->testEnvironment->registerObject( 'Store', $store );
+
+		$instance = new Browse(
+			$this->apiFactory->newApiMain(
+				[
+					'action'   => 'smwbrowse',
+					'browse'   => $id,
+					'params'   => json_encode( [ 'search' => 'Foo' ] )
+				]
+			),
+			'smwbrowse'
+		);
+
+		$instance->execute();
+	}
+
+	public function browseIdProvider() {
+
+		$provider[] = [
+			'property'
+		];
+
+		$provider[] = [
+			'category'
+		];
+
+		$provider[] = [
+			'concept'
+		];
+
+		return $provider;
+	}
+
+}


### PR DESCRIPTION
This PR is made in reference to: #

This PR addresses or contains:

- Adds `smwbrowse` as API module (required for an upcoming feature) and currently supports the search for
  - properties
  - categories
  - concepts
- Does a similar thing like `browsebyproperty`  but that module was not easily extendable therefore rewrote it from scratch, eventually it will be deprecated and removed
- It is expected to incorporated `browsebysubject` at a later state so that this module can be scrapped as well
- Classes and responsibilities are split into:
  - `Browse` (API, MediaWiki)
  - `ListLookup` (primary selector),
  - `ListAugmentor` (adding additional field components) with
    - `property` to support:
      - `description` to pull the `Has property description` in a selected language
      - `prefLabal` to fetch the `Has preferred property label` in a selected language
      - `usageCount` retrieve the usage count of the property
  - `LookupCache` caches each request for 30 min and by this avoids to introduce some complex invalidation strategy, yet keeping requests close to up-to-date information

## Example

```
'api.php?action=smwbrowse&browse=property&params={ "limit": 10, "offset": 0, "search": "Date" }',
'api.php?action=smwbrowse&browse=property&params={ "limit": 10, "offset": 0, "search": "Date", "description": true }',
'api.php?action=smwbrowse&browse=property&params={ "limit": 10, "offset": 0, "search": "Date", "description": true, "prefLabel": true }',
'api.php?action=smwbrowse&browse=property&params={ "limit": 10, "offset": 0, "search": "Date", "description": true, "prefLabel": true, "usageCount": true }',
'api.php?action=smwbrowse&browse=category&params={ "limit": 10, "offset": 0 }',
'api.php?action=smwbrowse&browse=category&params={ "limit": 10, "offset": 0, "search": "Date" }',
'api.php?action=smwbrowse&browse=concept&params={ "limit": 10, "offset": 0 }'
'api.php?action=smwbrowse&browse=concept&params={ "limit": 10, "offset": 0, "search": "Date" }'

```

## Output
```json
{
    "query": {
        "Has_description": {
            "label": "Has description",
            "key": "Has_description",
            "description": {
                "en": "Simple descriptive explanatory text property."
            },
            "prefLabel": {
                "en": ""
            }
        },
        "_PDESC": {
            "label": "Has property description",
            "key": "_PDESC",
            "description": {
                "en": "&quot;Has property description&quot; is a predefined prop..."
            },
            "prefLabel": {
                "en": ""
            }
        }
    },
    "query-continue-offset": 0,
    "version": 1,
    "meta": {
        "type": "property",
        "limit": 10,
        "count": 2,
        "isFromCache": "",
        "queryTime": 0.00051
    }
}
```

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed

Fixes #