### PR TITLE
Ren PropertyHierarchyLookup

### DIFF
--- a/src/ApplicationFactory.php
+++ b/src/ApplicationFactory.php
@@ -409,10 +409,10 @@ class ApplicationFactory {
 	/**
 	 * @since 2.4
 	 *
-	 * @return PropertyHierarchyLookup
+	 * @return HierarchyLookup
 	 */
-	public function newPropertyHierarchyLookup() {
-		return $this->containerBuilder->create( 'PropertyHierarchyLookup' );
+	public function newHierarchyLookup() {
+		return $this->containerBuilder->create( 'HierarchyLookup' );
 	}
 
 	/**

--- a/src/HierarchyLookup.php
+++ b/src/HierarchyLookup.php
@@ -13,9 +13,9 @@ use Psr\Log\LoggerAwareInterface;
  *
  * @author mwjames
  */
-class PropertyHierarchyLookup implements LoggerAwareInterface {
+class HierarchyLookup implements LoggerAwareInterface {
 
-	const POOLCACHE_ID = 'property.hierarchy.lookup';
+	const POOLCACHE_ID = 'hierarchy.lookup';
 
 	/**
 	 * @var Store

--- a/src/SPARQLStore/QueryEngine/CompoundConditionBuilder.php
+++ b/src/SPARQLStore/QueryEngine/CompoundConditionBuilder.php
@@ -8,7 +8,7 @@ use SMW\DataTypeRegistry;
 use SMW\DIProperty;
 use SMW\DIWikiPage;
 use SMW\Message;
-use SMW\PropertyHierarchyLookup;
+use SMW\HierarchyLookup;
 use SMW\Query\Language\Description;
 use SMW\Query\Language\SomeProperty;
 use SMW\Query\Language\ThingDescription;
@@ -52,9 +52,9 @@ class CompoundConditionBuilder {
 	private $circularReferenceGuard;
 
 	/**
-	 * @var PropertyHierarchyLookup
+	 * @var HierarchyLookup
 	 */
-	private $propertyHierarchyLookup;
+	private $hierarchyLookup;
 
 	/**
 	 * @var DescriptionFactory
@@ -193,19 +193,19 @@ class CompoundConditionBuilder {
 	/**
 	 * @since 2.3
 	 *
-	 * @param PropertyHierarchyLookup $propertyHierarchyLookup
+	 * @param HierarchyLookup $hierarchyLookup
 	 */
-	public function setPropertyHierarchyLookup( PropertyHierarchyLookup $propertyHierarchyLookup ) {
-		$this->propertyHierarchyLookup = $propertyHierarchyLookup;
+	public function setHierarchyLookup( HierarchyLookup $hierarchyLookup ) {
+		$this->hierarchyLookup = $hierarchyLookup;
 	}
 
 	/**
 	 * @since 2.3
 	 *
-	 * @return PropertyHierarchyLookup
+	 * @return HierarchyLookup
 	 */
-	public function getPropertyHierarchyLookup() {
-		return $this->propertyHierarchyLookup;
+	public function getHierarchyLookup() {
+		return $this->hierarchyLookup;
 	}
 
 	/**

--- a/src/SPARQLStore/QueryEngine/DescriptionInterpreters/ClassDescriptionInterpreter.php
+++ b/src/SPARQLStore/QueryEngine/DescriptionInterpreters/ClassDescriptionInterpreter.php
@@ -121,7 +121,7 @@ class ClassDescriptionInterpreter implements DescriptionInterpreter {
 			return '';
 		}
 
-		if ( $this->compoundConditionBuilder->getPropertyHierarchyLookup() === null || !$this->compoundConditionBuilder->getPropertyHierarchyLookup()->hasSubcategory( $category ) ) {
+		if ( $this->compoundConditionBuilder->getHierarchyLookup() === null || !$this->compoundConditionBuilder->getHierarchyLookup()->hasSubcategory( $category ) ) {
 			return '';
 		}
 

--- a/src/SPARQLStore/QueryEngine/DescriptionInterpreters/SomePropertyInterpreter.php
+++ b/src/SPARQLStore/QueryEngine/DescriptionInterpreters/SomePropertyInterpreter.php
@@ -247,7 +247,7 @@ class SomePropertyInterpreter implements DescriptionInterpreter {
 			return null;
 		}
 
-		if ( $this->compoundConditionBuilder->getPropertyHierarchyLookup() == null || !$this->compoundConditionBuilder->getPropertyHierarchyLookup()->hasSubproperty( $property ) ) {
+		if ( $this->compoundConditionBuilder->getHierarchyLookup() == null || !$this->compoundConditionBuilder->getHierarchyLookup()->hasSubproperty( $property ) ) {
 			return null;
 		}
 

--- a/src/SPARQLStore/SPARQLStoreFactory.php
+++ b/src/SPARQLStore/SPARQLStoreFactory.php
@@ -67,8 +67,8 @@ class SPARQLStoreFactory {
 			$circularReferenceGuard
 		);
 
-		$compoundConditionBuilder->setPropertyHierarchyLookup(
-			ApplicationFactory::getInstance()->newPropertyHierarchyLookup()
+		$compoundConditionBuilder->setHierarchyLookup(
+			ApplicationFactory::getInstance()->newHierarchyLookup()
 		);
 
 		$queryEngine = new QueryEngine(

--- a/src/SQLStore/QueryDependency/QueryResultDependencyListResolver.php
+++ b/src/SQLStore/QueryDependency/QueryResultDependencyListResolver.php
@@ -5,7 +5,7 @@ namespace SMW\SQLStore\QueryDependency;
 use SMW\ApplicationFactory;
 use SMW\DIProperty;
 use SMW\DIWikiPage;
-use SMW\PropertyHierarchyLookup;
+use SMW\HierarchyLookup;
 use SMW\Query\Language\ClassDescription;
 use SMW\Query\Language\ConceptDescription;
 use SMW\Query\Language\Conjunction;
@@ -26,9 +26,9 @@ use SMWQueryResult as QueryResult;
 class QueryResultDependencyListResolver {
 
 	/**
-	 * @var PropertyHierarchyLookup
+	 * @var HierarchyLookup
 	 */
-	private $propertyHierarchyLookup;
+	private $hierarchyLookup;
 
 	/**
 	 * Specifies a list of property keys to be excluded from the detection
@@ -42,10 +42,10 @@ class QueryResultDependencyListResolver {
 	 * @since 2.3
 	 *
 	 * @param $queryResult Can be a string for when format=Debug
-	 * @param PropertyHierarchyLookup $propertyHierarchyLookup
+	 * @param HierarchyLookup $hierarchyLookup
 	 */
-	public function __construct( PropertyHierarchyLookup $propertyHierarchyLookup ) {
-		$this->propertyHierarchyLookup = $propertyHierarchyLookup;
+	public function __construct( HierarchyLookup $hierarchyLookup ) {
+		$this->hierarchyLookup = $hierarchyLookup;
 	}
 
 	/**
@@ -165,7 +165,7 @@ class QueryResultDependencyListResolver {
 		if ( $description instanceof ClassDescription ) {
 			foreach ( $description->getCategories() as $category ) {
 
-				if ( $this->propertyHierarchyLookup->hasSubcategory( $category ) ) {
+				if ( $this->hierarchyLookup->hasSubcategory( $category ) ) {
 					$this->doMatchSubcategory( $subjects, $category );
 				}
 
@@ -193,7 +193,7 @@ class QueryResultDependencyListResolver {
 
 		$subject = $property->getCanonicalDiWikiPage();
 
-		if ( $this->propertyHierarchyLookup->hasSubproperty( $property ) ) {
+		if ( $this->hierarchyLookup->hasSubproperty( $property ) ) {
 			$this->doMatchSubproperty( $subjects, $subject, $property );
 		}
 
@@ -214,14 +214,14 @@ class QueryResultDependencyListResolver {
 		// Safeguard against a possible category (or redirect thereof) to point
 		// to itself by relying on tracking the hash of already inserted objects
 		if ( !isset( $subjects[$hash] ) ) {
-			$subcategories = $this->propertyHierarchyLookup->findSubcategoryList( $category );
+			$subcategories = $this->hierarchyLookup->findSubcategoryList( $category );
 		}
 
 		foreach ( $subcategories as $subcategory ) {
 
 			$subjects[$subcategory->getHash()] = $subcategory;
 
-			if ( $this->propertyHierarchyLookup->hasSubcategory( $subcategory ) ) {
+			if ( $this->hierarchyLookup->hasSubcategory( $subcategory ) ) {
 				$this->doMatchSubcategory( $subjects, $subcategory );
 			}
 		}
@@ -237,7 +237,7 @@ class QueryResultDependencyListResolver {
 		if (
 			!isset( $subjects[$subject->getHash()] ) &&
 			!isset( $this->propertyDependencyExemptionlist[$subject->getDBKey()] ) ) {
-			$subproperties = $this->propertyHierarchyLookup->findSubpropertyList( $property );
+			$subproperties = $this->hierarchyLookup->findSubpropertyList( $property );
 		}
 
 		foreach ( $subproperties as $subproperty ) {

--- a/src/SQLStore/QueryDependencyLinksStoreFactory.php
+++ b/src/SQLStore/QueryDependencyLinksStoreFactory.php
@@ -28,7 +28,7 @@ class QueryDependencyLinksStoreFactory {
 	public function newQueryResultDependencyListResolver() {
 
 		$queryResultDependencyListResolver = new QueryResultDependencyListResolver(
-			ApplicationFactory::getInstance()->newPropertyHierarchyLookup()
+			ApplicationFactory::getInstance()->newHierarchyLookup()
 		);
 
 		$queryResultDependencyListResolver->setPropertyDependencyExemptionlist(

--- a/src/Services/SharedServicesContainer.php
+++ b/src/Services/SharedServicesContainer.php
@@ -38,7 +38,7 @@ use SMW\IteratorFactory;
 use SMW\QueryFactory;
 use SMW\DataItemFactory;
 use SMW\PropertySpecificationLookup;
-use SMW\PropertyHierarchyLookup;
+use SMW\HierarchyLookup;
 use SMW\PropertyLabelFinder;
 use SMW\CachedPropertyValuesPrefetcher;
 use SMW\Localizer;
@@ -480,29 +480,29 @@ class SharedServicesContainer implements CallbackContainer {
 		} );
 
 		/**
-		 * @var PropertyHierarchyLookup
+		 * @var HierarchyLookup
 		 */
-		$containerBuilder->registerCallback( 'PropertyHierarchyLookup', function( $containerBuilder ) {
-			$containerBuilder->registerExpectedReturnType( 'PropertyHierarchyLookup', '\SMW\PropertyHierarchyLookup' );
+		$containerBuilder->registerCallback( 'HierarchyLookup', function( $containerBuilder ) {
+			$containerBuilder->registerExpectedReturnType( 'HierarchyLookup', '\SMW\HierarchyLookup' );
 
-			$propertyHierarchyLookup = new PropertyHierarchyLookup(
+			$hierarchyLookup = new HierarchyLookup(
 				$containerBuilder->create( 'Store' ),
-				$containerBuilder->singleton( 'InMemoryPoolCache' )->getPoolCacheById( PropertyHierarchyLookup::POOLCACHE_ID )
+				$containerBuilder->singleton( 'InMemoryPoolCache' )->getPoolCacheById( HierarchyLookup::POOLCACHE_ID )
 			);
 
-			$propertyHierarchyLookup->setLogger(
+			$hierarchyLookup->setLogger(
 				$containerBuilder->singleton( 'MediaWikiLogger' )
 			);
 
-			$propertyHierarchyLookup->setSubcategoryDepth(
+			$hierarchyLookup->setSubcategoryDepth(
 				$containerBuilder->create( 'Settings' )->get( 'smwgQSubcategoryDepth' )
 			);
 
-			$propertyHierarchyLookup->setSubpropertyDepth(
+			$hierarchyLookup->setSubpropertyDepth(
 				$containerBuilder->create( 'Settings' )->get( 'smwgQSubpropertyDepth' )
 			);
 
-			return $propertyHierarchyLookup;
+			return $hierarchyLookup;
 		} );
 
 		/**

--- a/tests/phpunit/Unit/ApplicationFactoryTest.php
+++ b/tests/phpunit/Unit/ApplicationFactoryTest.php
@@ -213,11 +213,11 @@ class ApplicationFactoryTest extends \PHPUnit_Framework_TestCase {
 		);
 	}
 
-	public function testCanConstructPropertyHierarchyLookup() {
+	public function testCanConstructHierarchyLookup() {
 
 		$this->assertInstanceOf(
-			'\SMW\PropertyHierarchyLookup',
-			$this->applicationFactory->newPropertyHierarchyLookup()
+			'\SMW\HierarchyLookup',
+			$this->applicationFactory->newHierarchyLookup()
 		);
 	}
 

--- a/tests/phpunit/Unit/HierarchyLookupTest.php
+++ b/tests/phpunit/Unit/HierarchyLookupTest.php
@@ -4,10 +4,10 @@ namespace SMW\Tests;
 
 use SMW\DIProperty;
 use SMW\DIWikiPage;
-use SMW\PropertyHierarchyLookup;
+use SMW\HierarchyLookup;
 
 /**
- * @covers \SMW\PropertyHierarchyLookup
+ * @covers \SMW\HierarchyLookup
  * @group semantic-mediawiki
  *
  * @license GNU GPL v2+
@@ -15,7 +15,7 @@ use SMW\PropertyHierarchyLookup;
  *
  * @author mwjames
  */
-class PropertyHierarchyLookupTest extends \PHPUnit_Framework_TestCase {
+class HierarchyLookupTest extends \PHPUnit_Framework_TestCase {
 
 	public function testCanConstruct() {
 
@@ -28,8 +28,8 @@ class PropertyHierarchyLookupTest extends \PHPUnit_Framework_TestCase {
 			->getMock();
 
 		$this->assertInstanceOf(
-			PropertyHierarchyLookup::class,
-			new PropertyHierarchyLookup( $store, $cache )
+			HierarchyLookup::class,
+			new HierarchyLookup( $store, $cache )
 		);
 	}
 
@@ -57,7 +57,7 @@ class PropertyHierarchyLookupTest extends \PHPUnit_Framework_TestCase {
 				$this->equalTo( '_SUBP#Foo#5230d9b41a617ba30fa77223b431507c' ),
 				$this->equalTo( array() ) );
 
-		$instance = new PropertyHierarchyLookup( $store, $cache );
+		$instance = new HierarchyLookup( $store, $cache );
 
 		$this->assertInternalType(
 			'boolean',
@@ -95,7 +95,7 @@ class PropertyHierarchyLookupTest extends \PHPUnit_Framework_TestCase {
 				$this->equalTo( '_SUBP#Foo#b3ed5707ed115aa0ef22f567c08c35df' ),
 				$this->anything() );
 
-		$instance = new PropertyHierarchyLookup( $store, $cache );
+		$instance = new HierarchyLookup( $store, $cache );
 
 		$expected = array(
 			DIWikiPage::newFromText( 'Bar', SMW_NS_PROPERTY )
@@ -137,7 +137,7 @@ class PropertyHierarchyLookupTest extends \PHPUnit_Framework_TestCase {
 				$this->equalTo( '_SUBC#Foo#b3ed5707ed115aa0ef22f567c08c35df' ),
 				$this->anything() );
 
-		$instance = new PropertyHierarchyLookup( $store, $cache );
+		$instance = new HierarchyLookup( $store, $cache );
 
 		$expected = array(
 			DIWikiPage::newFromText( 'Bar', NS_CATEGORY )
@@ -163,7 +163,7 @@ class PropertyHierarchyLookupTest extends \PHPUnit_Framework_TestCase {
 			->method( 'contains' )
 			->will( $this->returnValue( false ) );
 
-		$instance = new PropertyHierarchyLookup( $store, $cache );
+		$instance = new HierarchyLookup( $store, $cache );
 		$instance->setSubpropertyDepth( 0 );
 
 		$property = new DIProperty( 'Foo' );
@@ -191,7 +191,7 @@ class PropertyHierarchyLookupTest extends \PHPUnit_Framework_TestCase {
 			->method( 'contains' )
 			->will( $this->returnValue( false ) );
 
-		$instance = new PropertyHierarchyLookup( $store, $cache );
+		$instance = new HierarchyLookup( $store, $cache );
 		$instance->setSubcategoryDepth( 0 );
 
 		$category = DIWikiPage::newFromText( 'Foo', NS_CATEGORY );

--- a/tests/phpunit/Unit/SPARQLStore/QueryEngine/DescriptionInterpreters/ClassDescriptionInterpreterTest.php
+++ b/tests/phpunit/Unit/SPARQLStore/QueryEngine/DescriptionInterpreters/ClassDescriptionInterpreterTest.php
@@ -97,11 +97,11 @@ class ClassDescriptionInterpreterTest extends \PHPUnit_Framework_TestCase {
 			\SMWExporter::getInstance()->getResourceElementForWikiPage( $category )
 		);
 
-		$propertyHierarchyLookup = $this->getMockBuilder( '\SMW\PropertyHierarchyLookup' )
+		$hierarchyLookup = $this->getMockBuilder( '\SMW\HierarchyLookup' )
 			->disableOriginalConstructor()
 			->getMock();
 
-		$propertyHierarchyLookup->expects( $this->once() )
+		$hierarchyLookup->expects( $this->once() )
 			->method( 'hasSubcategory' )
 			->with( $this->equalTo( $category ) )
 			->will( $this->returnValue( true ) );
@@ -109,7 +109,7 @@ class ClassDescriptionInterpreterTest extends \PHPUnit_Framework_TestCase {
 		$resultVariable = 'result';
 
 		$compoundConditionBuilder = new CompoundConditionBuilder( $this->descriptionInterpreterFactory, $engineOptions );
-		$compoundConditionBuilder->setPropertyHierarchyLookup( $propertyHierarchyLookup );
+		$compoundConditionBuilder->setHierarchyLookup( $hierarchyLookup );
 		$compoundConditionBuilder->setResultVariable( $resultVariable );
 		$compoundConditionBuilder->setJoinVariable( $resultVariable );
 

--- a/tests/phpunit/Unit/SPARQLStore/QueryEngine/DescriptionInterpreters/SomePropertyInterpreterTest.php
+++ b/tests/phpunit/Unit/SPARQLStore/QueryEngine/DescriptionInterpreters/SomePropertyInterpreterTest.php
@@ -69,14 +69,14 @@ class SomePropertyInterpreterTest extends \PHPUnit_Framework_TestCase {
 	 */
 	public function testSomeProperty( $description, $orderByProperty, $sortkeys, $expectedConditionType, $expectedConditionString ) {
 
-		$propertyHierarchyLookup = $this->getMockBuilder( '\SMW\PropertyHierarchyLookup' )
+		$hierarchyLookup = $this->getMockBuilder( '\SMW\HierarchyLookup' )
 			->disableOriginalConstructor()
 			->getMock();
 
 		$resultVariable = 'result';
 
 		$compoundConditionBuilder = new CompoundConditionBuilder( $this->descriptionInterpreterFactory );
-		$compoundConditionBuilder->setPropertyHierarchyLookup( $propertyHierarchyLookup );
+		$compoundConditionBuilder->setHierarchyLookup( $hierarchyLookup );
 		$compoundConditionBuilder->setResultVariable( $resultVariable );
 		$compoundConditionBuilder->setSortKeys( $sortkeys );
 		$compoundConditionBuilder->setJoinVariable( $resultVariable );
@@ -104,11 +104,11 @@ class SomePropertyInterpreterTest extends \PHPUnit_Framework_TestCase {
 
 		$property = new DIProperty( 'Foo' );
 
-		$propertyHierarchyLookup = $this->getMockBuilder( '\SMW\PropertyHierarchyLookup' )
+		$hierarchyLookup = $this->getMockBuilder( '\SMW\HierarchyLookup' )
 			->disableOriginalConstructor()
 			->getMock();
 
-		$propertyHierarchyLookup->expects( $this->once() )
+		$hierarchyLookup->expects( $this->once() )
 			->method( 'hasSubproperty' )
 			->with( $this->equalTo( $property ) )
 			->will( $this->returnValue( true ) );
@@ -116,7 +116,7 @@ class SomePropertyInterpreterTest extends \PHPUnit_Framework_TestCase {
 		$resultVariable = 'result';
 
 		$compoundConditionBuilder = new CompoundConditionBuilder( $this->descriptionInterpreterFactory, $engineOptions );
-		$compoundConditionBuilder->setPropertyHierarchyLookup( $propertyHierarchyLookup );
+		$compoundConditionBuilder->setHierarchyLookup( $hierarchyLookup );
 		$compoundConditionBuilder->setResultVariable( $resultVariable );
 		$compoundConditionBuilder->setJoinVariable( $resultVariable );
 

--- a/tests/phpunit/Unit/SQLStore/QueryDependency/QueryResultDependencyListResolverTest.php
+++ b/tests/phpunit/Unit/SQLStore/QueryDependency/QueryResultDependencyListResolverTest.php
@@ -51,24 +51,24 @@ class QueryResultDependencyListResolverTest extends \PHPUnit_Framework_TestCase 
 
 	public function testCanConstruct() {
 
-		$propertyHierarchyLookup = $this->getMockBuilder( '\SMW\PropertyHierarchyLookup' )
+		$hierarchyLookup = $this->getMockBuilder( '\SMW\HierarchyLookup' )
 			->disableOriginalConstructor()
 			->getMock();
 
 		$this->assertInstanceOf(
 			'\SMW\SQLStore\QueryDependency\QueryResultDependencyListResolver',
-			new QueryResultDependencyListResolver( $propertyHierarchyLookup )
+			new QueryResultDependencyListResolver( $hierarchyLookup )
 		);
 	}
 
 	public function testTryTogetDependencyListFromForNonSetQueryResult() {
 
-		$propertyHierarchyLookup = $this->getMockBuilder( '\SMW\PropertyHierarchyLookup' )
+		$hierarchyLookup = $this->getMockBuilder( '\SMW\HierarchyLookup' )
 			->disableOriginalConstructor()
 			->getMock();
 
 		$instance = new QueryResultDependencyListResolver(
-			$propertyHierarchyLookup
+			$hierarchyLookup
 		);
 
 		$this->assertEmpty(
@@ -101,12 +101,12 @@ class QueryResultDependencyListResolverTest extends \PHPUnit_Framework_TestCase 
 			->method( 'getStore' )
 			->will( $this->returnValue( $this->store ) );
 
-		$propertyHierarchyLookup = $this->getMockBuilder( '\SMW\PropertyHierarchyLookup' )
+		$hierarchyLookup = $this->getMockBuilder( '\SMW\HierarchyLookup' )
 			->disableOriginalConstructor()
 			->getMock();
 
 		$instance = new QueryResultDependencyListResolver(
-			$propertyHierarchyLookup
+			$hierarchyLookup
 		);
 
 		$this->assertEmpty(
@@ -142,22 +142,22 @@ class QueryResultDependencyListResolverTest extends \PHPUnit_Framework_TestCase 
 			->method( 'getStore' )
 			->will( $this->returnValue( $this->store ) );
 
-		$propertyHierarchyLookup = $this->getMockBuilder( '\SMW\PropertyHierarchyLookup' )
+		$hierarchyLookup = $this->getMockBuilder( '\SMW\HierarchyLookup' )
 			->disableOriginalConstructor()
 			->getMock();
 
-		$propertyHierarchyLookup->expects( $this->any() )
+		$hierarchyLookup->expects( $this->any() )
 			->method( 'hasSubproperty' )
 			->will( $this->returnValue( true ) );
 
-		$propertyHierarchyLookup->expects( $this->at( 1 ) )
+		$hierarchyLookup->expects( $this->at( 1 ) )
 			->method( 'findSubpropertyList' )
 			->with( $this->equalTo( new DIProperty( 'Foobar' ) ) )
 			->will( $this->returnValue(
 				array( DIWikiPage::newFromText( 'Subprop', SMW_NS_PROPERTY ) ) ) );
 
 		$instance = new QueryResultDependencyListResolver(
-			$propertyHierarchyLookup
+			$hierarchyLookup
 		);
 
 		$instance->setPropertyDependencyExemptionlist( array( 'Subprop' ) );
@@ -197,12 +197,12 @@ class QueryResultDependencyListResolverTest extends \PHPUnit_Framework_TestCase 
 			->method( 'getStore' )
 			->will( $this->returnValue( $this->store ) );
 
-		$propertyHierarchyLookup = $this->getMockBuilder( '\SMW\PropertyHierarchyLookup' )
+		$hierarchyLookup = $this->getMockBuilder( '\SMW\HierarchyLookup' )
 			->disableOriginalConstructor()
 			->getMock();
 
 		$instance = new QueryResultDependencyListResolver(
-			$propertyHierarchyLookup
+			$hierarchyLookup
 		);
 
 		$this->assertEquals(
@@ -242,12 +242,12 @@ class QueryResultDependencyListResolverTest extends \PHPUnit_Framework_TestCase 
 			->method( 'getQuery' )
 			->will( $this->returnValue( $query ) );
 
-		$propertyHierarchyLookup = $this->getMockBuilder( '\SMW\PropertyHierarchyLookup' )
+		$hierarchyLookup = $this->getMockBuilder( '\SMW\HierarchyLookup' )
 			->disableOriginalConstructor()
 			->getMock();
 
 		$instance = new QueryResultDependencyListResolver(
-			$propertyHierarchyLookup
+			$hierarchyLookup
 		);
 
 		$this->assertEquals(
@@ -284,22 +284,22 @@ class QueryResultDependencyListResolverTest extends \PHPUnit_Framework_TestCase 
 			->method( 'getStore' )
 			->will( $this->returnValue( $this->store ) );
 
-		$propertyHierarchyLookup = $this->getMockBuilder( '\SMW\PropertyHierarchyLookup' )
+		$hierarchyLookup = $this->getMockBuilder( '\SMW\HierarchyLookup' )
 			->disableOriginalConstructor()
 			->getMock();
 
-		$propertyHierarchyLookup->expects( $this->any() )
+		$hierarchyLookup->expects( $this->any() )
 			->method( 'hasSubproperty' )
 			->will( $this->returnValue( true ) );
 
-		$propertyHierarchyLookup->expects( $this->at( 1 ) )
+		$hierarchyLookup->expects( $this->at( 1 ) )
 			->method( 'findSubpropertyList' )
 			->with( $this->equalTo( new DIProperty( 'Foobar' ) ) )
 			->will( $this->returnValue(
 				array( DIWikiPage::newFromText( 'Subprop', SMW_NS_PROPERTY ) ) ) );
 
 		$instance = new QueryResultDependencyListResolver(
-			$propertyHierarchyLookup
+			$hierarchyLookup
 		);
 
 		$expected = array(
@@ -342,15 +342,15 @@ class QueryResultDependencyListResolverTest extends \PHPUnit_Framework_TestCase 
 			->method( 'getStore' )
 			->will( $this->returnValue( $this->store ) );
 
-		$propertyHierarchyLookup = $this->getMockBuilder( '\SMW\PropertyHierarchyLookup' )
+		$hierarchyLookup = $this->getMockBuilder( '\SMW\HierarchyLookup' )
 			->disableOriginalConstructor()
 			->getMock();
 
-		$propertyHierarchyLookup->expects( $this->any() )
+		$hierarchyLookup->expects( $this->any() )
 			->method( 'hasSubcategory' )
 			->will( $this->returnValue( true ) );
 
-		$propertyHierarchyLookup->expects( $this->at( 1 ) )
+		$hierarchyLookup->expects( $this->at( 1 ) )
 			->method( 'findSubcategoryList' )
 			->with( $this->equalTo( DIWikiPage::newFromText( 'Foocat', NS_CATEGORY ) ) )
 			->will( $this->returnValue(
@@ -359,7 +359,7 @@ class QueryResultDependencyListResolverTest extends \PHPUnit_Framework_TestCase 
 					DIWikiPage::newFromText( 'Foocat', NS_CATEGORY ) ) ) );
 
 		$instance = new QueryResultDependencyListResolver(
-			$propertyHierarchyLookup
+			$hierarchyLookup
 		);
 
 		$expected = array(


### PR DESCRIPTION
This PR is made in reference to: #

This PR addresses or contains:

- Rename `PropertyHierarchyLookup` to `HierarchyLookup` since it not only covers properties but also categories

This PR includes:
- [ ] Tests (unit/integration)
- [x] CI build passed
