### PR TITLE
HierarchyLookup add persistent cache, refs 2670

### DIFF
--- a/includes/storage/SQLStore/SMW_SQLStore3_Writers.php
+++ b/includes/storage/SQLStore/SMW_SQLStore3_Writers.php
@@ -2,6 +2,7 @@
 
 use SMW\ApplicationFactory;
 use SMW\DIWikiPage;
+use SMW\HierarchyLookup;
 use SMW\MediaWiki\Jobs\JobBase;
 use SMW\MediaWiki\Jobs\UpdateJob;
 use SMW\SemanticData;
@@ -158,6 +159,10 @@ class SMWSQLStore3Writers {
 		$this->propertyTableRowDiffer->resetCompositePropertyTableDiff();
 
 		$changePropListener = new ChangePropListener();
+
+		$this->factory->newHierarchyLookup()->addListenersTo(
+			$changePropListener
+		);
 
 		$changePropListener->enabledListeners(
 			$this->store

--- a/src/ChangePropListener.php
+++ b/src/ChangePropListener.php
@@ -37,7 +37,7 @@ class ChangePropListener {
 	 * @param string $key
 	 * @param Closure $callback
 	 */
-	public static function addListenerCallback( $key, Closure $callback ) {
+	public function addListenerCallback( $key, Closure $callback ) {
 
 		if ( $key === '' ) {
 			return;

--- a/src/HierarchyLookup.php
+++ b/src/HierarchyLookup.php
@@ -6,6 +6,7 @@ use Onoi\Cache\Cache;
 use SMW\Store;
 use Psr\Log\LoggerInterface;
 use Psr\Log\LoggerAwareInterface;
+use InvalidArgumentException;
 
 /**
  * @license GNU GPL v2+
@@ -15,17 +16,36 @@ use Psr\Log\LoggerAwareInterface;
  */
 class HierarchyLookup implements LoggerAwareInterface {
 
-	const POOLCACHE_ID = 'hierarchy.lookup';
+	/**
+	 * Persistent cache namespace
+	 */
+	const CACHE_NAMESPACE = 'smw:hlkp';
+
+	/**
+	 * Consecutive hierarchy types
+	 */
+	const TYPE_PROPERTY = 'type.property';
+	const TYPE_CATEGORY = 'type.category';
 
 	/**
 	 * @var Store
 	 */
-	private $store = null;
+	private $store;
 
 	/**
 	 * @var Cache|null
 	 */
-	private $cache = null;
+	private $cache;
+
+	/**
+	 * @var []
+	 */
+	private $inMemoryCache = [];
+
+	/**
+	 * @var integer
+	 */
+	private $cacheTTL;
 
 	/**
 	 * @var LoggerInterface
@@ -55,6 +75,40 @@ class HierarchyLookup implements LoggerAwareInterface {
 	public function __construct( Store $store, Cache $cache ) {
 		$this->store = $store;
 		$this->cache = $cache;
+
+		$this->cacheTTL = 60 * 60 * 24 * 7;
+	}
+
+	/**
+	 * @since 3.0
+	 *
+	 * @param ChangePropListener $changePropListener
+	 */
+	public function addListenersTo( ChangePropListener $changePropListener ) {
+
+		// @see HierarchyLookup::getConsecutiveHierarchyList
+		//
+		// Remove the global hierarchy cache in the event that some entity was
+		// annotated (or removed) with the `Subproperty of`/ `Subcategory of`
+		// property, and while this purges the entire cache we ensure that the
+		// hierarchy lookup is always correct without loosing too much sleep
+		// over a more fine-grained caching strategy.
+
+		$callback = function( $context ) {
+			$this->cache->delete(
+				smwfCacheKey( self::CACHE_NAMESPACE, self::TYPE_PROPERTY )
+			);
+		};
+
+		$changePropListener->addListenerCallback( '_SUBP', $callback );
+
+		$callback = function( $context ) {
+			$this->cache->delete(
+				smwfCacheKey( self::CACHE_NAMESPACE, self::TYPE_CATEGORY )
+			);
+		};
+
+		$changePropListener->addListenerCallback( '_SUBC', $callback );
 	}
 
 	/**
@@ -170,28 +224,150 @@ class HierarchyLookup implements LoggerAwareInterface {
 		return $this->lookup( '_SUBC', $category->getDBKey(), $category, new RequestOptions() );
 	}
 
+	/**
+	 * @since 3.0
+	 *
+	 * @param DIProperty|DIWikiPage $id
+	 *
+	 * @return DIProperty[]|DIWikiPage[]|[]
+	 */
+	public function getConsecutiveHierarchyList( $id ) {
+
+		$hierarchyType = null;
+
+		if ( $id instanceof DIProperty ) {
+			$hierarchyType = self::TYPE_PROPERTY;
+		} elseif ( $id instanceof DIWikiPage && $id->getNamespace() === NS_CATEGORY ) {
+			$hierarchyType = self::TYPE_CATEGORY;
+		}
+
+		if ( $hierarchyType === null ) {
+			throw new InvalidArgumentException( 'No matchable hierarchy type.' );
+		}
+
+		// Store elements of the hierarchy tree in one large cache slot
+		// since we are unable to detect if or when a leaf is removed from within
+		// a cached tree unless one stores child and parent in a secondary cache.
+		//
+		// On the assumption that hierarchy data are less frequently changed, using
+		// a "global" cache should be sufficient to avoid constant DB lookups.
+		//
+		// Invalidation of the cache will occur on each _SUBP/_SUBC change event (see
+		// above).
+		$hash = smwfCacheKey(
+			self::CACHE_NAMESPACE,
+			$hierarchyType
+		);
+
+		$hierarchyCache = $this->cache->fetch( $hash );
+		$reqCacheUpdate = false;
+
+		if ( $hierarchyCache === false ) {
+			$hierarchyCache = [];
+		}
+
+		$hierarchyMembers = [];
+		$key = $hierarchyType === self::TYPE_PROPERTY ? $id->getKey() : $id->getDBKey();
+
+		if ( !isset( $hierarchyCache[$key] ) ) {
+			$hierarchyCache[$key] = [];
+
+			if ( $hierarchyType === self::TYPE_PROPERTY ) {
+				$this->findSubproperties( $hierarchyMembers, $id, 1 );
+			} else {
+				$this->findSubcategories( $hierarchyMembers, $id, 1 );
+			}
+
+			$hierarchyList[$key] = $hierarchyMembers;
+
+			// Store only the key to keep the cache size low
+			foreach ( $hierarchyList[$key] as $k ) {
+				if ( $hierarchyType === self::TYPE_PROPERTY ) {
+					$hierarchyCache[$key][] = $k->getKey();
+				} else {
+					$hierarchyCache[$key][] = $k->getDBKey();
+				}
+			}
+
+			$reqCacheUpdate = true;
+		} else {
+			$hierarchyList[$key] = [];
+
+			foreach ( $hierarchyCache[$key] as $k ) {
+				if ( $hierarchyType === self::TYPE_PROPERTY ) {
+					$hierarchyList[$key][] = new DIProperty( $k );
+				} else {
+					$hierarchyList[$key][] = new DIWikiPage( $k, NS_CATEGORY );
+				}
+			}
+		}
+
+		if ( $reqCacheUpdate ) {
+			$this->cache->save( $hash, $hierarchyCache, $this->cacheTTL );
+		}
+
+		return $hierarchyList[$key];
+	}
+
+	private function findSubproperties( &$hierarchyMembers, DIProperty $property, $depth ) {
+
+		if ( $depth++ > $this->subpropertyDepth ) {
+			return;
+		}
+
+		$propertyList = $this->findSubpropertyList(
+			$property
+		);
+
+		if ( $propertyList === null || $propertyList === [] ) {
+			return;
+		}
+
+		foreach ( $propertyList as $property ) {
+			$property = DIProperty::newFromUserLabel(
+				$property->getDBKey()
+			);
+
+			$hierarchyMembers[] = $property;
+			$this->findSubproperties( $hierarchyMembers, $property, $depth );
+		}
+	}
+
+	private function findSubcategories( &$hierarchyMembers, DIWikiPage $category, $depth ) {
+
+		if ( $depth++ > $this->subcategoryDepth ) {
+			return;
+		}
+
+		$categoryList = $this->findSubcategoryList(
+			$category
+		);
+
+		foreach ( $categoryList as $category ) {
+			$hierarchyMembers[] = $category;
+			$this->findSubcategories( $hierarchyMembers, $category, $depth );
+		}
+	}
+
 	private function lookup( $id, $key, DIWikiPage $subject, $requestOptions ) {
 
 		$key = $id . '#' . $key . '#' . md5( $requestOptions->getHash() );
 
-		if ( $this->cache->contains( $key ) ) {
-			return $this->cache->fetch( $key );
+		if ( isset( $this->inMemoryCache[$key] ) ) {
+			return $this->inMemoryCache[$key];
 		}
 
-		$result = $this->store->getPropertySubjects(
+		$res = $this->store->getPropertySubjects(
 			new DIProperty( $id ),
 			$subject,
 			$requestOptions
 		);
 
-		$this->cache->save(
-			$key,
-			$result
-		);
+		$this->inMemoryCache[$key] = $res;
 
 		$this->log( __METHOD__ . " {$id} and " . $subject->getDBKey() );
 
-		return $result;
+		return $res;
 	}
 
 	private function log( $message, $context = array() ) {

--- a/src/SQLStore/SQLStoreFactory.php
+++ b/src/SQLStore/SQLStoreFactory.php
@@ -502,4 +502,14 @@ class SQLStoreFactory {
 		return $idMatchFinder;
 	}
 
+	/**
+	 * @since 3.0
+	 *
+	 * @return HierarchyLookup
+	 */
+	public function newHierarchyLookup() {
+		return $this->applicationFactory->newHierarchyLookup();
+	}
+
+
 }

--- a/src/Services/SharedServicesContainer.php
+++ b/src/Services/SharedServicesContainer.php
@@ -482,12 +482,12 @@ class SharedServicesContainer implements CallbackContainer {
 		/**
 		 * @var HierarchyLookup
 		 */
-		$containerBuilder->registerCallback( 'HierarchyLookup', function( $containerBuilder ) {
+		$containerBuilder->registerCallback( 'HierarchyLookup', function( $containerBuilder, $cacheType = null ) {
 			$containerBuilder->registerExpectedReturnType( 'HierarchyLookup', '\SMW\HierarchyLookup' );
 
 			$hierarchyLookup = new HierarchyLookup(
 				$containerBuilder->create( 'Store' ),
-				$containerBuilder->singleton( 'InMemoryPoolCache' )->getPoolCacheById( HierarchyLookup::POOLCACHE_ID )
+				$containerBuilder->singleton( 'Cache', $cacheType )
 			);
 
 			$hierarchyLookup->setLogger(

--- a/tests/phpunit/Unit/SQLStore/SQLStoreFactoryTest.php
+++ b/tests/phpunit/Unit/SQLStore/SQLStoreFactoryTest.php
@@ -303,4 +303,14 @@ class SQLStoreFactoryTest extends \PHPUnit_Framework_TestCase {
 		);
 	}
 
+	public function testCanConstructHierarchyLookup() {
+
+		$instance = new SQLStoreFactory( $this->store );
+
+		$this->assertInstanceOf(
+			'\SMW\HierarchyLookup',
+			$instance->newHierarchyLookup()
+		);
+	}
+
 }

--- a/tests/phpunit/includes/SQLStore/Writer/ChangeTitleTest.php
+++ b/tests/phpunit/includes/SQLStore/Writer/ChangeTitleTest.php
@@ -29,6 +29,10 @@ class ChangeTitleTest extends \PHPUnit_Framework_TestCase {
 			->disableOriginalConstructor()
 			->getMock();
 
+		$hierarchyLookup = $this->getMockBuilder( '\SMW\HierarchyLookup' )
+			->disableOriginalConstructor()
+			->getMock();
+
 		$this->factory = $this->getMockBuilder( '\SMW\SQLStore\SQLStoreFactory' )
 			->disableOriginalConstructor()
 			->getMock();
@@ -36,6 +40,10 @@ class ChangeTitleTest extends \PHPUnit_Framework_TestCase {
 		$this->factory->expects( $this->any() )
 			->method( 'newPropertyStatisticsTable' )
 			->will( $this->returnValue( $propertyStatisticsTable ) );
+
+		$this->factory->expects( $this->any() )
+			->method( 'newHierarchyLookup' )
+			->will( $this->returnValue( $hierarchyLookup ) );
 	}
 
 	public function testCanConstruct() {

--- a/tests/phpunit/includes/SQLStore/Writer/DataUpdateTest.php
+++ b/tests/phpunit/includes/SQLStore/Writer/DataUpdateTest.php
@@ -30,6 +30,10 @@ class DataUpdateTest extends \PHPUnit_Framework_TestCase {
 			->disableOriginalConstructor()
 			->getMock();
 
+		$hierarchyLookup = $this->getMockBuilder( '\SMW\HierarchyLookup' )
+			->disableOriginalConstructor()
+			->getMock();
+
 		$this->factory = $this->getMockBuilder( '\SMW\SQLStore\SQLStoreFactory' )
 			->disableOriginalConstructor()
 			->getMock();
@@ -37,6 +41,10 @@ class DataUpdateTest extends \PHPUnit_Framework_TestCase {
 		$this->factory->expects( $this->any() )
 			->method( 'newPropertyStatisticsTable' )
 			->will( $this->returnValue( $propertyStatisticsTable ) );
+
+		$this->factory->expects( $this->any() )
+			->method( 'newHierarchyLookup' )
+			->will( $this->returnValue( $hierarchyLookup ) );
 	}
 
 	public function testCanConstruct() {

--- a/tests/phpunit/includes/SQLStore/Writer/DeleteSubjectTest.php
+++ b/tests/phpunit/includes/SQLStore/Writer/DeleteSubjectTest.php
@@ -25,6 +25,10 @@ class DeleteSubjectTest extends \PHPUnit_Framework_TestCase {
 			->disableOriginalConstructor()
 			->getMock();
 
+		$hierarchyLookup = $this->getMockBuilder( '\SMW\HierarchyLookup' )
+			->disableOriginalConstructor()
+			->getMock();
+
 		$this->factory = $this->getMockBuilder( '\SMW\SQLStore\SQLStoreFactory' )
 			->disableOriginalConstructor()
 			->getMock();
@@ -32,6 +36,10 @@ class DeleteSubjectTest extends \PHPUnit_Framework_TestCase {
 		$this->factory->expects( $this->any() )
 			->method( 'newPropertyStatisticsTable' )
 			->will( $this->returnValue( $propertyStatisticsTable ) );
+
+		$this->factory->expects( $this->any() )
+			->method( 'newHierarchyLookup' )
+			->will( $this->returnValue( $hierarchyLookup ) );
 
 		$propertyTableInfoFetcher = $this->getMockBuilder( '\SMW\SQLStore\PropertyTableInfoFetcher' )
 			->disableOriginalConstructor()


### PR DESCRIPTION
This PR is made in reference to: #2670 

This PR addresses or contains:

- Prerequisite for #2670 to support hierarchy traversal in mandatory requirements 
- Adds a persistent cache layer to minimize the impact during the lookup of hierarchy references, invalidation will take place on each change that involves the `_SUBC` and `_SUBP` meta property  using the `ChangePropListener`

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed

Fixes #