### PR TITLE
API smwbrowse integration test, refs 2696

### DIFF
--- a/src/MediaWiki/Api/Browse.php
+++ b/src/MediaWiki/Api/Browse.php
@@ -77,7 +77,11 @@ class Browse extends ApiBase {
 	private function callListLookup( $ns, $parameters ) {
 
 		$applicationFactory = ApplicationFactory::getInstance();
-		$store = $applicationFactory->getStore();
+
+		// We explicitly want the SQLStore here to avoid
+		// "Call to undefined method SMW\SPARQLStore\SPARQLStore::getSQLOptions() ..."
+		// since we don't use those methods anywher else other than the SQLStore
+		$store = $applicationFactory->getStore( '\SMW\SQLStore\SQLStore' );
 
 		$listAugmentor = new ListAugmentor(
 			$store

--- a/tests/phpunit/Integration/JSONScript/ApiTestCaseProcessor.php
+++ b/tests/phpunit/Integration/JSONScript/ApiTestCaseProcessor.php
@@ -1,0 +1,123 @@
+<?php
+
+namespace SMW\Tests\Integration\JSONScript;
+
+/**
+ * @group semantic-mediawiki
+ * @group medium
+ *
+ * @license GNU GPL v2+
+ * @since 3.0
+ *
+ * @author mwjames
+ */
+class ApiTestCaseProcessor extends \PHPUnit_Framework_TestCase {
+
+	/**
+	 * @var MwApiFactory
+	 */
+	private $mwApiFactory;
+
+	/**
+	 * @var StringValidator
+	 */
+	private $stringValidator;
+
+	/**
+	 * @var boolean
+	 */
+	private $debug = false;
+
+	/**
+	 * @param MwApiFactory mwApiFactory
+	 * @param StringValidator
+	 */
+	public function __construct( $mwApiFactory, $stringValidator ) {
+		$this->mwApiFactory = $mwApiFactory;
+		$this->stringValidator = $stringValidator;
+	}
+
+	/**
+	 * @since 3.0
+	 */
+	public function setDebugMode( $debugMode ) {
+		$this->debug = $debugMode;
+	}
+
+	/**
+	 * @since 3.0
+	 *
+	 * @param string $testCaseLocation
+	 */
+	public function setTestCaseLocation( $testCaseLocation ) {
+		$this->testCaseLocation = $testCaseLocation;
+	}
+
+	/**
+	 * @since 3.0
+	 *
+	 * @param array $case
+	 */
+	public function process( array $case ) {
+
+		if ( !isset( $case['api'] ) ) {
+			return;
+		}
+
+		$parameters = [];
+
+		if ( isset( $case['api']['parameters'] ) ) {
+			$parameters = $case['api']['parameters'];
+		}
+
+		$res = $this->mwApiFactory->doApiRequest(
+			$parameters
+		);
+
+		$this->assertOutputForCase( $case, json_encode( $res ) );
+	}
+
+	private function assertOutputForCase( $case, $text ) {
+
+		if ( isset( $case['assert-output']['to-contain'] ) ) {
+
+			if ( isset( $case['assert-output']['to-contain']['contents-file'] ) ) {
+				$contents = $this->getFileContentsWithEncodingDetection(
+					$this->testCaseLocation . $case['assert-output']['to-contain']['contents-file']
+				);
+			} else {
+				$contents = $case['assert-output']['to-contain'];
+			}
+
+			$this->stringValidator->assertThatStringContains(
+				$contents,
+				$text,
+				$case['about']
+			);
+		}
+
+		if ( isset( $case['assert-output']['not-contain'] ) ) {
+
+			if ( isset( $case['assert-output']['not-contain']['contents-file'] ) ) {
+				$contents = $this->getFileContentsWithEncodingDetection(
+					$this->testCaseLocation . $case['assert-output']['not-contain']['contents-file']
+				);
+			} else {
+				$contents = $case['assert-output']['not-contain'];
+			}
+
+			$this->stringValidator->assertThatStringNotContains(
+				$contents,
+				$text,
+				$case['about']
+			);
+		}
+	}
+
+	// http://php.net/manual/en/function.file-get-contents.php
+	private function getFileContentsWithEncodingDetection( $file ) {
+		$content = file_get_contents( $file );
+		return mb_convert_encoding( $content, 'UTF-8', mb_detect_encoding( $content, 'UTF-8, ISO-8859-1, ISO-8859-2', true ) );
+	}
+
+}

--- a/tests/phpunit/Integration/JSONScript/Fixtures/a-0001.0.txt
+++ b/tests/phpunit/Integration/JSONScript/Fixtures/a-0001.0.txt
@@ -1,0 +1,1 @@
+{"query":{"API_test_property":{"label":"API test property","key":"API_test_property","description":{"en":""},"prefLabel":{"en":""}}},"query-continue-offset":0,"version":1,"meta":{"type":"property","limit":10,"count":1,"isFromCache":false,"queryTime":.*}

--- a/tests/phpunit/Integration/JSONScript/Fixtures/a-0001.1.txt
+++ b/tests/phpunit/Integration/JSONScript/Fixtures/a-0001.1.txt
@@ -1,0 +1,1 @@
+{"query":{"API_test_concept":{"label":"API test concept","key":"API_test_concept"}},"query-continue-offset":0,"version":1,"meta":{"type":"concept","limit":10,"count":1,"isFromCache":false,"queryTime":.*}

--- a/tests/phpunit/Integration/JSONScript/Fixtures/a-0001.2.txt
+++ b/tests/phpunit/Integration/JSONScript/Fixtures/a-0001.2.txt
@@ -1,0 +1,1 @@
+{"query":{"API_test_category":{"label":"API test category","key":"API_test_category"}},"query-continue-offset":0,"version":1,"meta":{"type":"category","limit":10,"count":1,"isFromCache":false,"queryTime":.*}

--- a/tests/phpunit/Integration/JSONScript/TestCases/a-0001.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/a-0001.json
@@ -1,0 +1,88 @@
+{
+	"description": "Test API `action=smwbrowse`",
+	"setup": [
+		{
+			"namespace": "SMW_NS_PROPERTY",
+			"page": "API test property",
+			"contents": "[[Has type::Page]]"
+		},
+		{
+			"namespace": "SMW_NS_CONCEPT",
+			"page": "API test concept",
+			"contents": "..."
+		},
+		{
+			"namespace": "NS_CATEGORY",
+			"page": "API test category",
+			"contents": "..."
+		}
+	],
+	"tests": [
+		{
+			"type": "api",
+			"about": "#0 `smwbrowse` property search",
+			"api": {
+				"parameters": {
+					"action": "smwbrowse",
+					"format": "json",
+					"browse": "property",
+					"params": "{ \"limit\": 10, \"offset\": 0, \"search\": \"API test\", \"description\": true, \"prefLabel\": true }"
+				}
+			},
+			"assert-output": {
+				"to-contain": {
+					"contents-file" : "/../Fixtures/a-0001.0.txt"
+				}
+			}
+		},
+		{
+			"type": "api",
+			"about": "#1 `smwbrowse` concept search",
+			"api": {
+				"parameters": {
+					"action": "smwbrowse",
+					"format": "json",
+					"browse": "concept",
+					"params": "{ \"limit\": 10, \"offset\": 0, \"search\": \"API test\", \"description\": true, \"prefLabel\": true }"
+				}
+			},
+			"assert-output": {
+				"to-contain": {
+					"contents-file" : "/../Fixtures/a-0001.1.txt"
+				}
+			}
+		},
+		{
+			"type": "api",
+			"about": "#2 `smwbrowse` category search",
+			"api": {
+				"parameters": {
+					"action": "smwbrowse",
+					"format": "json",
+					"browse": "category",
+					"params": "{ \"limit\": 10, \"offset\": 0, \"search\": \"API test\", \"description\": true, \"prefLabel\": true }"
+				}
+			},
+			"assert-output": {
+				"to-contain": {
+					"contents-file" : "/../Fixtures/a-0001.2.txt"
+				}
+			}
+		}
+	],
+	"settings": {
+		"wgContLang": "en",
+		"wgLang": "en",
+		"smwgNamespacesWithSemanticLinks": {
+			"NS_MAIN": true,
+			"SMW_NS_PROPERTY": true,
+			"SMW_NS_CONCEPT": true,
+			"NS_CATEGORY": true
+		}
+	},
+	"meta": {
+		"version": "2",
+		"is-incomplete": false,
+		"debug": false
+	}
+}


### PR DESCRIPTION
This PR is made in reference to: #2696

This PR addresses or contains:

- Adds `ApiTestCaseProcessor` to test an API output
- Adds `smwbrowse` test for a `property`, `category`, and `concept` search

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed
