### PR TITLE
Update en.json

### DIFF
--- a/i18n/en.json
+++ b/i18n/en.json
@@ -395,7 +395,7 @@
 	"right-smw-admin": "Access administration tasks (Semantic MediaWiki)",
 	"right-smw-patternedit": "Edit access to maintain allowed regular expressions and patterns (Semantic MediaWiki)",
 	"right-smw-pageedit": "Edit access for <code>Is edit protected</code> annotated pages (Semantic MediaWiki)",
-	"restriction-level-smw-pageedit": "protected (only {{PLURAL:$1|eligible user|eligible users}})",
+	"restriction-level-smw-pageedit": "protected (only eligible users)",
 	"action-smw-patternedit": "edit regular expressions used by Semantic MediaWiki",
 	"action-smw-pageedit": "edit pages annotated with <code>Is edit protected</code> (Semantic MediaWiki)",
 	"group-smwadministrator": "Administrators (Semantic MediaWiki)",

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -395,6 +395,7 @@
 	"right-smw-admin": "Access administration tasks (Semantic MediaWiki)",
 	"right-smw-patternedit": "Edit access to maintain allowed regular expressions and patterns (Semantic MediaWiki)",
 	"right-smw-pageedit": "Edit access for <code>Is edit protected</code> annotated pages (Semantic MediaWiki)",
+	"restriction-level-smw-pageedit": "protected (only {{PLURAL:$1|eligible user|eligible users}})",
 	"action-smw-patternedit": "edit regular expressions used by Semantic MediaWiki",
 	"action-smw-pageedit": "edit pages annotated with <code>Is edit protected</code> (Semantic MediaWiki)",
 	"group-smwadministrator": "Administrators (Semantic MediaWiki)",


### PR DESCRIPTION
This PR is made in reference to: #2232 

This PR addresses or contains:
- Add missing system message used on "Special:ProtectedPages".

Note that the part within the brackets is usually added automatically by MediaWiki. The SMW implementation works a bit different thus adding this part here too since I do not think that it is worth automatizing the display of the allowed user groups. `{{PLURAL}}` was added for the sake of avoiding complaints though always the plural version is used.

This PR includes:
- [ ] Tests (unit/integration)
- [x] CI build passed