### PR TITLE
Remove usages of deprecated ResultPrinter::getParameters, refs 1654

### DIFF
--- a/includes/queryprinters/CategoryResultPrinter.php
+++ b/includes/queryprinters/CategoryResultPrinter.php
@@ -181,44 +181,52 @@ class CategoryResultPrinter extends ResultPrinter {
 		return $htmlColumnListRenderer->getHtml();
 	}
 
-	public function getParameters() {
-		return array_merge( parent::getParameters(), array(
-			array(
-				'name' => 'columns',
-				'type' => 'integer',
-				'message' => 'smw-paramdesc-columns',
-				'default' => 3,
-			),
-			array(
-				'name' => 'delim',
-				'message' => 'smw-paramdesc-category-delim',
-				'default' => '',
-			),
-			array(
-				'name' => 'template',
-				'message' => 'smw-paramdesc-category-template',
-				'default' => '',
-			),
-			array(
-				'name' => 'userparam',
-				'message' => 'smw-paramdesc-category-userparam',
-				'default' => '',
-			),
+	/**
+	 * @inheritdoc
+	 */
+	public function getParamDefinitions( array $definitions ) {
+		$definitions = parent::getParamDefinitions( $definitions );
 
-			array(
-				'name' => 'named args',
-				'type' => 'boolean',
-				'message' => 'smw-paramdesc-named_args',
-				'default' => false,
-			),
+		$definitions[] = [
+			'name' => 'columns',
+			'type' => 'integer',
+			'message' => 'smw-paramdesc-columns',
+			'default' => 3,
+		];
 
-			array(
-				'name' => 'import-annotation',
-				'type' => 'boolean',
-				'message' => 'smw-paramdesc-import-annotation',
-				'default' => false,
-			)
-		) );
+		$definitions[] = [
+			'name' => 'delim',
+			'message' => 'smw-paramdesc-category-delim',
+			'default' => '',
+		];
+
+		$definitions[] = [
+			'name' => 'template',
+			'message' => 'smw-paramdesc-category-template',
+			'default' => '',
+		];
+
+		$definitions[] = [
+			'name' => 'userparam',
+			'message' => 'smw-paramdesc-category-userparam',
+			'default' => '',
+		];
+
+		$definitions[] = [
+			'name' => 'named args',
+			'type' => 'boolean',
+			'message' => 'smw-paramdesc-named_args',
+			'default' => false,
+		];
+
+		$definitions[] = [
+			'name' => 'import-annotation',
+			'type' => 'boolean',
+			'message' => 'smw-paramdesc-import-annotation',
+			'default' => false,
+		];
+
+		return $definitions;
 	}
 
 	private function getFirstLetterForCategory( SMWQueryResult $res, SMWDataItem $dataItem ) {

--- a/includes/queryprinters/EmbeddedResultPrinter.php
+++ b/includes/queryprinters/EmbeddedResultPrinter.php
@@ -122,24 +122,27 @@ class EmbeddedResultPrinter extends ResultPrinter {
 		return $result;
 	}
 
-	public function getParameters() {
-		$params = parent::getParameters();
+	/**
+	 * @inheritdoc
+	 */
+	public function getParamDefinitions( array $definitions ) {
+		$definitions = parent::getParamDefinitions( $definitions );
 
-		$params[] = array(
+		$definitions[] = [
 			'name' => 'embedformat',
 			'message' => 'smw-paramdesc-embedformat',
 			'default' => 'h1',
-			'values' => array( 'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'ol', 'ul' ),
-		);
+			'values' => [ 'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'ol', 'ul' ],
+		];
 
-		$params[] = array(
+		$definitions[] = [
 			'name' => 'embedonly',
 			'type' => 'boolean',
 			'message' => 'smw-paramdesc-embedonly',
 			'default' => false,
-		);
+		];
 
-		return $params;
+
+		return $definitions;
 	}
-
 }

--- a/includes/queryprinters/ListResultPrinter.php
+++ b/includes/queryprinters/ListResultPrinter.php
@@ -485,68 +485,71 @@ class ListResultPrinter extends ResultPrinter {
 		return $this->mFormat != 'ul' && $this->mFormat != 'ol';
 	}
 
-	public function getParameters() {
-		$params = parent::getParameters();
+	/**
+	 * @inheritdoc
+	 */
+	public function getParamDefinitions( array $definitions ) {
+		$definitions = parent::getParamDefinitions( $definitions );
 
-		$params['sep'] = array(
+		$definitions['sep'] = [
 			'message' => 'smw-paramdesc-sep',
 			'default' => $this->isEnabledFeature( SMW_RF_TEMPLATE_OUTSEP ) ? '' : ',',
-		);
+		];
 
 		if ( $this->mFormat === 'template' && $this->isEnabledFeature( SMW_RF_TEMPLATE_OUTSEP ) ) {
-			$params['valuesep'] = array(
+			$definitions['valuesep'] = [
 				'message' => 'smw-paramdesc-sep',
 				'default' => ',',
-			);
+			];
 		}
 
-		$params['template'] = array(
+		$definitions['template'] = [
 			'message' => 'smw-paramdesc-template',
 			'default' => '',
-		);
+		];
 
-		$params['template arguments'] = array(
+		$definitions['template arguments'] = [
 			'message' => 'smw-paramdesc-template-arguments',
 			'default' => '',
-			'values' => array( 'numbered', 'named', 'legacy' ),
-		);
+			'values' => [ 'numbered', 'named', 'legacy' ],
+		];
 
-		$params['named args'] = array(
+		$definitions['named args'] = [
 			'type' => 'boolean',
 			'message' => 'smw-paramdesc-named_args',
 			'default' => false,
-		);
+		];
 
 		if ( !$this->isPlainlist() ) {
-			$params['columns'] = array(
+			$definitions['columns'] = [
 				'type' => 'integer',
 				'message' => 'smw-paramdesc-columns',
 				'default' => 1,
-				'range' => array( 1, 10 ),
-			);
+				'range' => [ 1, 10 ],
+			];
 		}
 
-		$params['userparam'] = array(
+		$definitions['userparam'] = [
 			'message' => 'smw-paramdesc-userparam',
 			'default' => '',
-		);
+		];
 
-		$params['introtemplate'] = array(
+		$definitions['introtemplate'] = [
 			'message' => 'smw-paramdesc-introtemplate',
 			'default' => '',
-		);
+		];
 
-		$params['outrotemplate'] = array(
+		$definitions['outrotemplate'] = [
 			'message' => 'smw-paramdesc-outrotemplate',
 			'default' => '',
-		);
+		];
 
-		$params['import-annotation'] = array(
+		$definitions['import-annotation'] = [
 			'message' => 'smw-paramdesc-import-annotation',
 			'type' => 'boolean',
-			'default' => false
-		);
+			'default' => false,
+		];
 
-		return $params;
+		return $definitions;
 	}
 }

--- a/tests/phpunit/includes/queryprinters/ListResultPrinterTest.php
+++ b/tests/phpunit/includes/queryprinters/ListResultPrinterTest.php
@@ -1,0 +1,64 @@
+<?php
+namespace SMW\Test;
+
+use SMW\ListResultPrinter;
+
+/**
+ * @covers \SMW\ListResultPrinter
+ *
+ * @group SMW
+ * @group SMWExtension
+ *
+ * @license GNU GPL v2+
+ * @since 3.0
+ */
+class ListResultPrinterTest extends QueryPrinterTestCase {
+	/**
+	 * @dataProvider allFormatsProvider
+	 * @param string $format
+	 */
+	public function testCanConstruct( $format ) {
+		$listResultPrinter = new ListResultPrinter( $format );
+
+		$this->assertInstanceOf( '\SMW\ListResultPrinter', $listResultPrinter );
+	}
+
+	/**
+	 * @dataProvider listFormatProvider
+	 * @param string $format
+	 */
+	public function whenFormatIsNotPlainThenColumnsParameterExists( $format ) {
+		$listResultPrinter = new ListResultPrinter( $format );
+
+		$definitions = $listResultPrinter->getParamDefinitions( [] );
+
+		$this->assertArrayHasKey( 'columns', $definitions );
+	}
+
+	/**
+	 * @dataProvider plainFormatProvider
+	 * @param string $format
+	 */
+	public function whenFormatIsPlainThenColumnsParameterDoesNotExist( $format ) {
+		$listResultPrinter = new ListResultPrinter( $format );
+
+		$definitions = $listResultPrinter->getParamDefinitions( [] );
+
+		$this->assertArrayNotHasKey( 'columns', $definitions );
+	}
+
+	public function listFormatProvider() {
+		yield [ 'ul' ];
+		yield [ 'ol' ];
+	}
+
+	public function plainFormatProvider() {
+		yield [ 'template' ];
+	}
+
+	public function allFormatsProvider() {
+		yield [ 'ul' ];
+		yield [ 'ol' ];
+		yield [ 'template' ];
+	}
+}


### PR DESCRIPTION
This PR is made in reference to: #1654 

This PR addresses or contains:
- Remove usages of `ResultPrinter::getParameters` method that was deprecated since SMW 1.8, as per #1654 

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed

Fixes #1654 