### PR TITLE
Always define cell datatype class for query printouts, refs 2586

### DIFF
--- a/includes/queryprinters/TableResultPrinter.php
+++ b/includes/queryprinters/TableResultPrinter.php
@@ -178,13 +178,20 @@ class TableResultPrinter extends ResultPrinter {
 			$dataValues[] = $dv;
 		}
 
-		$attributes = array();
+		$printRequest = $resultArray->getPrintRequest();
+		$dataValueType = $printRequest->getTypeID();
+
+		$cellTypeClass = $dataValueType !== '' ? ' smwtype' . $dataValueType : '';
+
+		// We would like the cell class to always be defined, even if the cell itself is empty
+		$attributes = [
+			'class' => $columnClass . $cellTypeClass
+		];
+
 		$content = null;
 
 		if ( count( $dataValues ) > 0 ) {
 			$sortKey = $dataValues[0]->getDataItem()->getSortKey();
-			$dataValueType = $dataValues[0]->getTypeID();
-			$printRequest = $resultArray->getPrintRequest();
 
 			if ( is_numeric( $sortKey ) ) {
 				$attributes['data-sort-value'] = $sortKey;
@@ -201,14 +208,13 @@ class TableResultPrinter extends ResultPrinter {
 			}
 
 			$width = htmlspecialchars(
-				trim( $printRequest->getParameter( 'width' ) )
+				trim( $printRequest->getParameter( 'width' ) ),
+				ENT_QUOTES
 			);
 
 			if ( $width ) {
 				$attributes['style'] = isset( $attributes['style'] ) ?  $attributes['style'] . " width:$width;" . $width : "width:$width;";
 			}
-
-			$attributes['class'] = $columnClass . ( $dataValueType !== '' ? ' smwtype' . $dataValueType : '' );
 
 			$content = $this->getCellContent(
 				$dataValues,

--- a/includes/queryprinters/TableResultPrinter.php
+++ b/includes/queryprinters/TableResultPrinter.php
@@ -172,16 +172,17 @@ class TableResultPrinter extends ResultPrinter {
 	 * @return string
 	 */
 	protected function getCellForPropVals( SMWResultArray $resultArray, $outputMode, $columnClass ) {
-		$dataValues = array();
+		/** @var SMWDataValue[] $dataValues */
+		$dataValues = [];
 
 		while ( ( $dv = $resultArray->getNextDataValue() ) !== false ) {
 			$dataValues[] = $dv;
 		}
 
 		$printRequest = $resultArray->getPrintRequest();
-		$dataValueType = $printRequest->getTypeID();
+		$printRequestType = $printRequest->getTypeID();
 
-		$cellTypeClass = $dataValueType !== '' ? ' smwtype' . $dataValueType : '';
+		$cellTypeClass = " smwtype$printRequestType";
 
 		// We would like the cell class to always be defined, even if the cell itself is empty
 		$attributes = [
@@ -192,6 +193,12 @@ class TableResultPrinter extends ResultPrinter {
 
 		if ( count( $dataValues ) > 0 ) {
 			$sortKey = $dataValues[0]->getDataItem()->getSortKey();
+			$dataValueType = $dataValues[0]->getTypeID();
+
+			// The data value type might differ from the print request type - override in this case
+			if ( $dataValueType !== '' && $dataValueType !== $printRequestType ) {
+				$attributes['class'] = "$columnClass smwtype$dataValueType";
+			}
 
 			if ( is_numeric( $sortKey ) ) {
 				$attributes['data-sort-value'] = $sortKey;
@@ -222,6 +229,9 @@ class TableResultPrinter extends ResultPrinter {
 				$printRequest->getMode() == PrintRequest::PRINT_THIS
 			);
 		}
+
+		// Sort the cell HTML attributes, to make test behavior more deterministic
+		ksort( $attributes );
 
 		$this->htmlTableRenderer->addCell( $content, $attributes );
 	}

--- a/tests/phpunit/Integration/JSONScript/TestCases/f-0201.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/f-0201.json
@@ -61,8 +61,8 @@
 			"assert-output": {
 				"to-contain": [
 					"<table class=\"sortable wikitable smwtable\">",
-					"<tr data-row-number=\"1\" class=\"row-odd\"><td class=\"smwtype_wpg\">Project one</td><td data-sort-value=\"1\" class=\"Has-success-state smwtype_boo\"><span style=\"font-family: sans-serif;\">X</span></td><td class=\"Has-project-name smwtype_txt\">One</td></tr>",
-					"<tr data-row-number=\"2\" class=\"row-even\"><td class=\"smwtype_wpg\">Project two</td><td data-sort-value=\"0\" class=\"Has-success-state smwtype_boo\">&#160;</td><td class=\"Has-project-name smwtype_txt\">Two</td></tr>",
+					"<tr data-row-number=\"1\" class=\"row-odd\"><td class=\"smwtype_wpg\">Project one</td><td class=\"Has-success-state smwtype_boo\" data-sort-value=\"1\"><span style=\"font-family: sans-serif;\">X</span></td><td class=\"Has-project-name smwtype_txt\">One</td></tr>",
+					"<tr data-row-number=\"2\" class=\"row-even\"><td class=\"smwtype_wpg\">Project two</td><td class=\"Has-success-state smwtype_boo\" data-sort-value=\"0\">&#160;</td><td class=\"Has-project-name smwtype_txt\">Two</td></tr>",
 					"</table>"
 				]
 			}
@@ -75,8 +75,8 @@
 				"to-contain": [
 					"<table class=\"sortable wikitable smwtable\">",
 					"title=\"Property:Has success state\">Has success state</a></th><tr data-row-number=\"1\" class=\"row-odd\"><td class=\"smwtype_wpg\">",
-					"title=\"Project one\">Project one</a></td><td data-sort-value=\"1\" class=\"Has-success-state smwtype_boo\">success</td>",
-					"title=\"Project two\">Project two</a></td><td data-sort-value=\"0\" class=\"Has-success-state smwtype_boo\">failure</td>",
+					"title=\"Project one\">Project one</a></td><td class=\"Has-success-state smwtype_boo\" data-sort-value=\"1\">success</td>",
+					"title=\"Project two\">Project two</a></td><td class=\"Has-success-state smwtype_boo\" data-sort-value=\"0\">failure</td>",
 					"</table>"
 				]
 			}
@@ -89,8 +89,8 @@
 				"to-contain": [
 					"<table class=\"sortable wikitable smwtable\">",
 					"title=\"Property:Has success state\">Status</a></th><tr data-row-number=\"1\" class=\"row-odd\"><td class=\"smwtype_wpg\">",
-					"title=\"Project one\">Project one</a></td><td data-sort-value=\"1\" class=\"Status smwtype_boo\">success</td>",
-					"title=\"Project two\">Project two</a></td><td data-sort-value=\"0\" class=\"Status smwtype_boo\">failure</td>",
+					"title=\"Project one\">Project one</a></td><td class=\"Status smwtype_boo\" data-sort-value=\"1\">success</td>",
+					"title=\"Project two\">Project two</a></td><td class=\"Status smwtype_boo\" data-sort-value=\"0\">failure</td>",
 					"</table>"
 				]
 			}
@@ -101,8 +101,8 @@
 			"subject": "Example/F0201/3a",
 			"assert-output": {
 				"to-contain": [
-					"<td data-sort-value=\"1\" class=\"Has-boolean smwtype_boo\">✓</td>",
-					"<td data-sort-value=\"0\" class=\"Has-boolean smwtype_boo\">✕</td>"
+					"<td class=\"Has-boolean smwtype_boo\" data-sort-value=\"1\">✓</td>",
+					"<td class=\"Has-boolean smwtype_boo\" data-sort-value=\"0\">✕</td>"
 				]
 			}
 		},
@@ -112,8 +112,8 @@
 			"subject": "Example/F0201/3b",
 			"assert-output": {
 				"to-contain": [
-					"<td data-sort-value=\"1\" class=\"Has-boolean smwtype_boo\">○</td>",
-					"<td data-sort-value=\"0\" class=\"Has-boolean smwtype_boo\">×</td>"
+					"<td class=\"Has-boolean smwtype_boo\" data-sort-value=\"1\">○</td>",
+					"<td class=\"Has-boolean smwtype_boo\" data-sort-value=\"0\">×</td>"
 				]
 			}
 		},
@@ -123,8 +123,8 @@
 			"subject": "Example/F0201/3c",
 			"assert-output": {
 				"to-contain": [
-					"<td data-sort-value=\"1\" class=\"Label-on-(&amp;#10003;,&amp;#10005;) smwtype_boo\"><span style=\"color: green; font-size: 120%;\">&#10003;</span></td>",
-					"<td data-sort-value=\"0\" class=\"Label-on-(&amp;#10003;,&amp;#10005;) smwtype_boo\"><span style=\"color: #AA0000; font-size: 120%;\">&#10005;</span></td>"
+					"<td class=\"Label-on-(&amp;#10003;,&amp;#10005;) smwtype_boo\" data-sort-value=\"1\"><span style=\"color: green; font-size: 120%;\">&#10003;</span></td>",
+					"<td class=\"Label-on-(&amp;#10003;,&amp;#10005;) smwtype_boo\" data-sort-value=\"0\"><span style=\"color: #AA0000; font-size: 120%;\">&#10005;</span></td>"
 				]
 			}
 		}

--- a/tests/phpunit/Integration/JSONScript/TestCases/f-0205.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/f-0205.json
@@ -34,8 +34,8 @@
 			"subject": "Example/F0205/1a",
 			"assert-output": {
 				"to-contain": [
-					"data-sort-value=\"0.02\" style=\"text-align:right;\" class=\"Has-number smwtype_num\">0.02<br />1",
-					"data-sort-value=\"2.02\" style=\"text-align:right;\" class=\"Has-number smwtype_num\">2.02<br />21"
+					"class=\"Has-number smwtype_num\" data-sort-value=\"0.02\" style=\"text-align:right;\">0.02<br />1",
+					"class=\"Has-number smwtype_num\" data-sort-value=\"2.02\" style=\"text-align:right;\">2.02<br />21"
 				]
 			}
 		},
@@ -45,8 +45,8 @@
 			"subject": "Example/F0205/1b",
 			"assert-output": {
 				"to-contain": [
-					"data-sort-value=\"42\" style=\"text-align:left;\" class=\"Has-number smwtype_num\">42<br />1",
-					"data-sort-value=\"1001\" style=\"text-align:left;\" class=\"Has-number smwtype_num\">1,001<br />21"
+					"class=\"Has-number smwtype_num\" data-sort-value=\"42\" style=\"text-align:left;\">42<br />1",
+					"class=\"Has-number smwtype_num\" data-sort-value=\"1001\" style=\"text-align:left;\">1,001<br />21"
 				]
 			}
 		},
@@ -56,8 +56,8 @@
 			"subject": "Example/F0205/Q.2",
 			"assert-output": {
 				"to-contain": [
-					"<td data-sort-value=\"42\" style=\"width:50%;\" class=\"Has-number smwtype_num\">42<br />1</td>",
-					"<td data-sort-value=\"1001\" style=\"width:50%;\" class=\"Has-number smwtype_num\">1,001<br />21</td>"
+					"<td class=\"Has-number smwtype_num\" data-sort-value=\"42\" style=\"width:50%;\">42<br />1</td>",
+					"<td class=\"Has-number smwtype_num\" data-sort-value=\"1001\" style=\"width:50%;\">1,001<br />21</td>"
 				]
 			}
 		}

--- a/tests/phpunit/Integration/JSONScript/TestCases/f-0206.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/f-0206.json
@@ -23,7 +23,7 @@
 			"assert-output": {
 				"to-contain": [
 					"<div class=\"smwttcontent\">A number to display ....</div>",
-					"<td data-sort-value=\"1001\" class=\"Has-number smwtype_num\">1,001</td>"
+					"<td class=\"Has-number smwtype_num\" data-sort-value=\"1001\">1,001</td>"
 				]
 			}
 		}

--- a/tests/phpunit/Integration/JSONScript/TestCases/p-0210.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/p-0210.json
@@ -22,10 +22,10 @@
 			"subject": "Example/P0210/Q1",
 			"assert-output": {
 				"to-contain": [
-					"<td class=\"smwtype_wpg\">Example/P0210/1#_de6907a285b0c316fd3caa77a932d0ae</td><td data-sort-value=\"2453767.5\" class=\"Has-date smwtype_dat\">1 February 2006</td>",
-					"<td class=\"smwtype_wpg\">Example/P0210/1#_5c90cef15e8ecbb3662fe10e6cb50bb7</td><td data-sort-value=\"2440618.5\" class=\"Has-date smwtype_dat\">1 February 1970</td>",
-					"<td class=\"smwtype_wpg\">Example/P0210/1#_7582eb6443d1bd2f35114842dc700673</td><td data-sort-value=\"2445001.5\" class=\"Has-date smwtype_dat\">1 February 1982</td>",
-					"<td class=\"smwtype_wpg\">Example/P0210/1#_d9e81e6ceed8bc0ec8a92feeea25ca1a</td><td data-sort-value=\"2449384.5\" class=\"Has-date smwtype_dat\">1 February 1994</td>"
+					"<td class=\"smwtype_wpg\">Example/P0210/1#_de6907a285b0c316fd3caa77a932d0ae</td><td class=\"Has-date smwtype_dat\" data-sort-value=\"2453767.5\">1 February 2006</td>",
+					"<td class=\"smwtype_wpg\">Example/P0210/1#_5c90cef15e8ecbb3662fe10e6cb50bb7</td><td class=\"Has-date smwtype_dat\" data-sort-value=\"2440618.5\">1 February 1970</td>",
+					"<td class=\"smwtype_wpg\">Example/P0210/1#_7582eb6443d1bd2f35114842dc700673</td><td class=\"Has-date smwtype_dat\" data-sort-value=\"2445001.5\">1 February 1982</td>",
+					"<td class=\"smwtype_wpg\">Example/P0210/1#_d9e81e6ceed8bc0ec8a92feeea25ca1a</td><td class=\"Has-date smwtype_dat\" data-sort-value=\"2449384.5\">1 February 1994</td>"
 				]
 			}
 		}

--- a/tests/phpunit/Integration/JSONScript/TestCases/p-0410.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/p-0410.json
@@ -298,7 +298,7 @@
 					"class=\"Has-currency-with-prec4 smwtype_qty\" data-sort-value=\"0.0043778198632194\"",
 					"€&#160;0.0044",
 					"¥&#160;0.5000",
-					"class=\"Has-currency-with-prec4 smwtype_qty\" data-sort-value=\"5000\"",
+					"class=\"Has-currency-with-prec2 smwtype_qty\" data-sort-value=\"5000\"",
 					"€&#160;5,000.00",
 					"¥&#160;571,060.50"
 				]

--- a/tests/phpunit/Integration/JSONScript/TestCases/p-0410.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/p-0410.json
@@ -249,16 +249,16 @@
 			"subject": "Example/P0410/3",
 			"assert-output": {
 				"to-contain": [
-					"data-sort-value=\"0.001\" class=\"Has-number-with-prec4 smwtype_num\">0.0010",
-					"data-sort-value=\"0.001\" class=\"Has-number-with-prec2 smwtype_num\">0.00",
-					"data-sort-value=\"0.003\" class=\"Has-number smwtype_num\">0.003",
-					"data-sort-value=\"0.005\" class=\"Has-number-with-prec4 smwtype_num\">0.0050",
-					"data-sort-value=\"0.005\" class=\"Has-number-with-prec2 smwtype_num\">0.01",
-					"data-sort-value=\"0.008\" class=\"Has-number smwtype_num\">0.008",
-					"data-sort-value=\"42\" class=\"Has-number-with-prec2 smwtype_num\">42.00",
-					"data-sort-value=\"42\" class=\"Has-number smwtype_num\">42",
-					"data-sort-value=\"10000\" class=\"Has-number-with-prec2 smwtype_num\">10,000.00",
-					"data-sort-value=\"10000\" class=\"Has-number smwtype_num\">10,000"
+					"class=\"Has-number-with-prec4 smwtype_num\" data-sort-value=\"0.001\">0.0010",
+					"class=\"Has-number-with-prec2 smwtype_num\" data-sort-value=\"0.001\">0.00",
+					"class=\"Has-number smwtype_num\" data-sort-value=\"0.003\">0.003",
+					"class=\"Has-number-with-prec4 smwtype_num\" data-sort-value=\"0.005\">0.0050",
+					"class=\"Has-number-with-prec2 smwtype_num\" data-sort-value=\"0.005\">0.01",
+					"class=\"Has-number smwtype_num\" data-sort-value=\"0.008\">0.008",
+					"class=\"Has-number-with-prec2 smwtype_num\" data-sort-value=\"42\">42.00",
+					"class=\"Has-number smwtype_num\" data-sort-value=\"42\">42",
+					"class=\"Has-number-with-prec2 smwtype_num\" data-sort-value=\"10000\">10,000.00",
+					"class=\"Has-number smwtype_num\" data-sort-value=\"10000\">10,000"
 				]
 			}
 		},
@@ -268,15 +268,15 @@
 			"subject": "Example/P0410/4",
 			"assert-output": {
 				"to-contain": [
-					"data-sort-value=\"0.02\" class=\"Has-area-with-prec4 smwtype_qty\"",
+					"class=\"Has-area-with-prec4 smwtype_qty\" data-sort-value=\"0.02\"",
 					"0.0200&#160;km²",
 					"0.0077&#160;sqmi",
 					"20.0000&#160;m²",
-					"data-sort-value=\"10\" class=\"Has-area-with-prec2 smwtype_qty\"",
+					"class=\"Has-area-with-prec2 smwtype_qty\" data-sort-value=\"10\"",
 					"10.00&#160;km²",
 					"3.86&#160;sqmi",
 					"10,000.00&#160;m²",
-					"data-sort-value=\"3.33\" class=\"Has-area-with-prec0 smwtype_qty\"",
+					"class=\"Has-area-with-prec0 smwtype_qty\" data-sort-value=\"3.33\"",
 					"3&#160;km²",
 					"1&#160;sqmi",
 					"3,330&#160;m²"
@@ -289,16 +289,16 @@
 			"subject": "Example/P0410/5",
 			"assert-output": {
 				"to-contain": [
-					"data-sort-value=\"0.87556397264388\" class=\"Has-currency-with-prec4 smwtype_qty\"",
+					"class=\"Has-currency-with-prec4 smwtype_qty\" data-sort-value=\"0.87556397264388\"",
 					"€&#160;0.8756",
 					"¥&#160;100.0000",
-					"data-sort-value=\"5\" class=\"Has-currency-with-prec2 smwtype_qty\"",
+					"class=\"Has-currency-with-prec2 smwtype_qty\" data-sort-value=\"5\"",
 					"€&#160;5.00",
 					"¥&#160;571.06",
-					"data-sort-value=\"0.0043778198632194\" class=\"Has-currency-with-prec4 smwtype_qty\"",
+					"class=\"Has-currency-with-prec4 smwtype_qty\" data-sort-value=\"0.0043778198632194\"",
 					"€&#160;0.0044",
 					"¥&#160;0.5000",
-					"data-sort-value=\"5000\" class=\"Has-currency-with-prec2 smwtype_qty\"",
+					"class=\"Has-currency-with-prec4 smwtype_qty\" data-sort-value=\"5000\"",
 					"€&#160;5,000.00",
 					"¥&#160;571,060.50"
 				]
@@ -310,7 +310,7 @@
 			"subject": "Example/P0410/6a",
 			"assert-output": {
 				"to-contain": [
-					"data-sort-value=\"10000\" class=\"Has-number smwtype_num\"",
+					"class=\"Has-number smwtype_num\" data-sort-value=\"10000\"",
 					"10,000.00",
 					"0.01",
 					"42.01",
@@ -324,7 +324,7 @@
 			"subject": "Example/P0410/6b",
 			"assert-output": {
 				"to-contain": [
-					"data-sort-value=\"10000\" class=\"Has-number smwtype_num\"",
+					"class=\"Has-number smwtype_num\" data-sort-value=\"10000\"",
 					"10,000.0000",
 					"0.0050",
 					"42.0050",
@@ -338,7 +338,7 @@
 			"subject": "Example/P0410/6c",
 			"assert-output": {
 				"to-contain": [
-					"data-sort-value=\"10000\" class=\"Has-number smwtype_num\"",
+					"class=\"Has-number smwtype_num\" data-sort-value=\"10000\"",
 					"10000.000",
 					"0.005",
 					"42.005",
@@ -352,7 +352,7 @@
 			"subject": "Example/P0410/7a",
 			"assert-output": {
 				"to-contain": [
-					"data-sort-value=\"10\" class=\"Has-area smwtype_qty\"",
+					"class=\"Has-area smwtype_qty\" data-sort-value=\"10\"",
 					"10.00&#160;km²",
 					"3.86&#160;sqmi",
 					"10,000.00&#160;m²",
@@ -371,7 +371,7 @@
 			"subject": "Example/P0410/7b",
 			"assert-output": {
 				"to-contain": [
-					"data-sort-value=\"10\" class=\"Has-area smwtype_qty\"",
+					"class=\"Has-area smwtype_qty\" data-sort-value=\"10\"",
 					"10,000.000&#160;m²",
 					"10.000&#160;km²",
 					"3.861&#160;sqmi",
@@ -390,7 +390,7 @@
 			"subject": "Example/P0410/7c",
 			"assert-output": {
 				"to-contain": [
-					"data-sort-value=\"10\" class=\"Has-area smwtype_qty\"",
+					"class=\"Has-area smwtype_qty\" data-sort-value=\"10\"",
 					"10.00",
 					"0.02",
 					"3.33"
@@ -403,7 +403,7 @@
 			"subject": "Example/P0410/8a",
 			"assert-output": {
 				"to-contain": [
-					"data-sort-value=\"273.15\" class=\"Has-temperature smwtype_tem\"",
+					"class=\"Has-temperature smwtype_tem\" data-sort-value=\"273.15\"",
 					"class=\"smwtext\">273.15&#160;K",
 					"0.00&#160;°C",
 					"32.00&#160;°F",
@@ -421,7 +421,7 @@
 			"subject": "Example/P0410/8b",
 			"assert-output": {
 				"to-contain": [
-					"data-sort-value=\"273.15\" class=\"Has-temperature smwtype_tem\"",
+					"class=\"Has-temperature smwtype_tem\" data-sort-value=\"273.15\"",
 					"class=\"smwtext\">0.000&#160;°C",
 					"273.150&#160;K",
 					"32.000&#160;°F",
@@ -439,7 +439,7 @@
 			"subject": "Example/P0410/8c",
 			"assert-output": {
 				"to-contain": [
-					"data-sort-value=\"273.15\" class=\"Has-temperature smwtype_tem\"",
+					"class=\"Has-temperature smwtype_tem\" data-sort-value=\"273.15\"",
 					"273.15",
 					"373.15"
 				]

--- a/tests/phpunit/Integration/JSONScript/TestCases/p-0413.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/p-0413.json
@@ -208,10 +208,10 @@
 			"subject": "Example/P0413/1a",
 			"assert-output": {
 				"to-contain": [
-					"<td data-sort-value=\"2451585.9166782\" class=\"Has-date smwtype_dat\">11 February 2000 10:00:01</td>",
-					"<td data-sort-value=\"2451585.9166782\" class=\"Has-date smwtype_dat\">2000-02-11T10:00:01</td>",
-					"<td data-sort-value=\"2451585.9166782\" class=\"ISO-Date smwtype_dat\">2000-02-11T10:00:01</td>",
-					"<td data-sort-value=\"2451585.9166782\" class=\"MW-Date smwtype_dat\">10:00, 11 February 2000</td>"
+					"<td class=\"Has-date smwtype_dat\" data-sort-value=\"2451585.9166782\">11 February 2000 10:00:01</td>",
+					"<td class=\"Has-date smwtype_dat\" data-sort-value=\"2451585.9166782\">2000-02-11T10:00:01</td>",
+					"<td class=\"ISO-Date smwtype_dat\" data-sort-value=\"2451585.9166782\">2000-02-11T10:00:01</td>",
+					"<td class=\"MW-Date smwtype_dat\" data-sort-value=\"2451585.9166782\">10:00, 11 February 2000</td>"
 				]
 			}
 		},
@@ -245,10 +245,10 @@
 			"subject": "Example/P0413/2a",
 			"assert-output": {
 				"to-contain": [
-					"<td data-sort-value=\"2451585.5\" class=\"Has-date smwtype_dat\">11 February 2000</td>",
-					"<td data-sort-value=\"2451585.5\" class=\"Has-date smwtype_dat\">2000-02-11</td>",
-					"<td data-sort-value=\"2451585.5\" class=\"ISO-Date smwtype_dat\">2000-02-11</td>",
-					"<td data-sort-value=\"2451585.5\" class=\"MW-Date smwtype_dat\">11 February 2000</td>"
+					"<td class=\"Has-date smwtype_dat\" data-sort-value=\"2451585.5\">11 February 2000</td>",
+					"<td class=\"Has-date smwtype_dat\" data-sort-value=\"2451585.5\">2000-02-11</td>",
+					"<td class=\"ISO-Date smwtype_dat\" data-sort-value=\"2451585.5\">2000-02-11</td>",
+					"<td class=\"MW-Date smwtype_dat\" data-sort-value=\"2451585.5\">11 February 2000</td>"
 				]
 			}
 		},
@@ -282,10 +282,10 @@
 			"subject": "Example/P0413/3a",
 			"assert-output": {
 				"to-contain": [
-					"<td data-sort-value=\"2451544.5\" class=\"Has-date smwtype_dat\">2000</td>",
-					"<td data-sort-value=\"2451544.5\" class=\"Has-date smwtype_dat\">2000-01-01</td>",
-					"<td data-sort-value=\"2451544.5\" class=\"ISO-Date smwtype_dat\">2000-01-01</td>",
-					"<td data-sort-value=\"2451544.5\" class=\"MW-Date smwtype_dat\">2000</td>"
+					"<td class=\"Has-date smwtype_dat\" data-sort-value=\"2451544.5\">2000</td>",
+					"<td class=\"Has-date smwtype_dat\" data-sort-value=\"2451544.5\">2000-01-01</td>",
+					"<td class=\"ISO-Date smwtype_dat\" data-sort-value=\"2451544.5\">2000-01-01</td>",
+					"<td class=\"MW-Date smwtype_dat\" data-sort-value=\"2451544.5\">2000</td>"
 				]
 			}
 		},
@@ -319,10 +319,10 @@
 			"subject": "Example/P0413/4a",
 			"assert-output": {
 				"to-contain": [
-					"<td data-sort-value=\"2451586.4166782\" class=\"Has-date smwtype_dat\">11 February 2000 22:00:01</td>",
-					"<td data-sort-value=\"2451586.4166782\" class=\"Has-date smwtype_dat\">2000-02-11T22:00:01</td>",
-					"<td data-sort-value=\"2451586.4166782\" class=\"ISO-Date smwtype_dat\">2000-02-11T22:00:01</td>",
-					"<td data-sort-value=\"2451586.4166782\" class=\"MW-Date smwtype_dat\">22:00, 11 February 2000</td>"
+					"<td class=\"Has-date smwtype_dat\" data-sort-value=\"2451586.4166782\">11 February 2000 22:00:01</td>",
+					"<td class=\"Has-date smwtype_dat\" data-sort-value=\"2451586.4166782\" >2000-02-11T22:00:01</td>",
+					"<td class=\"ISO-Date smwtype_dat\" data-sort-value=\"2451586.4166782\">2000-02-11T22:00:01</td>",
+					"<td class=\"MW-Date smwtype_dat\" data-sort-value=\"2451586.4166782\">22:00, 11 February 2000</td>"
 				]
 			}
 		},
@@ -356,10 +356,10 @@
 			"subject": "Example/P0413/5a",
 			"assert-output": {
 				"to-contain": [
-					"<td data-sort-value=\"2451586.4166782\" class=\"Has-date smwtype_dat\">11 February 2000 22:00:01</td>",
-					"<td data-sort-value=\"2451586.4166782\" class=\"Has-date smwtype_dat\">2000-02-11T22:00:01</td>",
-					"<td data-sort-value=\"2451586.4166782\" class=\"ISO-Date smwtype_dat\">2000-02-11T22:00:01</td>",
-					"<td data-sort-value=\"2451586.4166782\" class=\"MW-Date smwtype_dat\">22:00, 11 February 2000</td>"
+					"<td class=\"Has-date smwtype_dat\" data-sort-value=\"2451586.4166782\">11 February 2000 22:00:01</td>",
+					"<td class=\"Has-date smwtype_dat\" data-sort-value=\"2451586.4166782\">2000-02-11T22:00:01</td>",
+					"<td class=\"ISO-Date smwtype_dat\" data-sort-value=\"2451586.4166782\">2000-02-11T22:00:01</td>",
+					"<td class=\"MW-Date smwtype_dat\" data-sort-value=\"2451586.4166782\">22:00, 11 February 2000</td>"
 				]
 			}
 		},
@@ -393,10 +393,10 @@
 			"subject": "Example/P0413/6a",
 			"assert-output": {
 				"to-contain": [
-					"<td data-sort-value=\"2451586.4166782\" class=\"Has-date smwtype_dat\">11 February 2000 22:00:01</td>",
-					"<td data-sort-value=\"2451586.4166782\" class=\"Has-date smwtype_dat\">2000-02-11T22:00:01</td>",
-					"<td data-sort-value=\"2451586.4166782\" class=\"ISO-Date smwtype_dat\">2000-02-11T22:00:01</td>",
-					"<td data-sort-value=\"2451586.4166782\" class=\"MW-Date smwtype_dat\">22:00, 11 February 2000</td>"
+					"<td class=\"Has-date smwtype_dat\" data-sort-value=\"2451586.4166782\">11 February 2000 22:00:01</td>",
+					"<td class=\"Has-date smwtype_dat\" data-sort-value=\"2451586.4166782\">2000-02-11T22:00:01</td>",
+					"<td class=\"ISO-Date smwtype_dat\" data-sort-value=\"2451586.4166782\">2000-02-11T22:00:01</td>",
+					"<td class=\"MW-Date smwtype_dat\" data-sort-value=\"2451586.4166782\">22:00, 11 February 2000</td>"
 				]
 			}
 		},
@@ -430,10 +430,10 @@
 			"subject": "Example/P0413/7a",
 			"assert-output": {
 				"to-contain": [
-					"<td data-sort-value=\"2451586.3333449\" class=\"Has-date smwtype_dat\">11 February 2000 20:00:01</td>",
-					"<td data-sort-value=\"2451586.3333449\" class=\"Has-date smwtype_dat\">2000-02-11T20:00:01</td>",
-					"<td data-sort-value=\"2451586.3333449\" class=\"ISO-Date smwtype_dat\">2000-02-11T20:00:01</td>",
-					"<td data-sort-value=\"2451586.3333449\" class=\"MW-Date smwtype_dat\">20:00, 11 February 2000</td>"
+					"<td class=\"Has-date smwtype_dat\" data-sort-value=\"2451586.3333449\">11 February 2000 20:00:01</td>",
+					"<td class=\"Has-date smwtype_dat\" data-sort-value=\"2451586.3333449\">2000-02-11T20:00:01</td>",
+					"<td class=\"ISO-Date smwtype_dat\" data-sort-value=\"2451586.3333449\">2000-02-11T20:00:01</td>",
+					"<td class=\"MW-Date smwtype_dat\" data-sort-value=\"2451586.3333449\">20:00, 11 February 2000</td>"
 				]
 			}
 		},
@@ -467,10 +467,10 @@
 			"subject": "Example/P0413/8a",
 			"assert-output": {
 				"to-contain": [
-					"<td data-sort-value=\"2451576.5\" class=\"Has-date smwtype_dat\">2 February 2000</td>",
-					"<td data-sort-value=\"2451576.5\" class=\"Has-date smwtype_dat\">2000-02-02</td>",
-					"<td data-sort-value=\"2451576.5\" class=\"ISO-Date smwtype_dat\">2000-02-02</td>",
-					"<td data-sort-value=\"2451576.5\" class=\"MW-Date smwtype_dat\">2 February 2000</td>"
+					"<td class=\"Has-date smwtype_dat\" data-sort-value=\"2451576.5\">2 February 2000</td>",
+					"<td class=\"Has-date smwtype_dat\" data-sort-value=\"2451576.5\">2000-02-02</td>",
+					"<td class=\"ISO-Date smwtype_dat\" data-sort-value=\"2451576.5\">2000-02-02</td>",
+					"<td class=\"MW-Date smwtype_dat\" data-sort-value=\"2451576.5\">2 February 2000</td>"
 				]
 			}
 		},
@@ -504,10 +504,10 @@
 			"subject": "Example/P0413/9a",
 			"assert-output": {
 				"to-contain": [
-					"<td data-sort-value=\"2451577.5\" class=\"Has-date smwtype_dat\">3 February 2000</td>",
-					"<td data-sort-value=\"2451577.5\" class=\"Has-date smwtype_dat\">2000-02-03</td>",
-					"<td data-sort-value=\"2451577.5\" class=\"ISO-Date smwtype_dat\">2000-02-03</td>",
-					"<td data-sort-value=\"2451577.5\" class=\"MW-Date smwtype_dat\">3 February 2000</td>"
+					"<td class=\"Has-date smwtype_dat\" data-sort-value=\"2451577.5\">3 February 2000</td>",
+					"<td class=\"Has-date smwtype_dat\" data-sort-value=\"2451577.5\">2000-02-03</td>",
+					"<td class=\"ISO-Date smwtype_dat\" data-sort-value=\"2451577.5\">2000-02-03</td>",
+					"<td class=\"MW-Date smwtype_dat\" data-sort-value=\"2451577.5\">3 February 2000</td>"
 				]
 			}
 		},
@@ -541,10 +541,10 @@
 			"subject": "Example/P0413/10a",
 			"assert-output": {
 				"to-contain": [
-					"<td data-sort-value=\"2451577.5\" class=\"Has-date smwtype_dat\">3 February 2000</td>",
-					"<td data-sort-value=\"2451577.5\" class=\"Has-date smwtype_dat\">2000-02-03</td>",
-					"<td data-sort-value=\"2451577.5\" class=\"ISO-Date smwtype_dat\">2000-02-03</td>",
-					"<td data-sort-value=\"2451577.5\" class=\"MW-Date smwtype_dat\">3 February 2000</td>"
+					"<td class=\"Has-date smwtype_dat\" data-sort-value=\"2451577.5\">3 February 2000</td>",
+					"<td class=\"Has-date smwtype_dat\" data-sort-value=\"2451577.5\">2000-02-03</td>",
+					"<td class=\"ISO-Date smwtype_dat\" data-sort-value=\"2451577.5\">2000-02-03</td>",
+					"<td class=\"MW-Date smwtype_dat\" data-sort-value=\"2451577.5\">3 February 2000</td>"
 				]
 			}
 		},
@@ -584,12 +584,12 @@
 			"subject": "Example/P0413/11a",
 			"assert-output": {
 				"to-contain": [
-					"<td data-sort-value=\"1611848.5\" class=\"Has-date smwtype_dat\">1 January 300 BC <sup>JL</sup></td>",
-					"<td data-sort-value=\"1611848.5\" class=\"Has-date smwtype_dat\">28 December 301 BC</td>",
-					"<td data-sort-value=\"1611848.5\" class=\"Has-date smwtype_dat\">--301-12-28</td>",
-					"<td data-sort-value=\"1611848.5\" class=\"ISO-Date smwtype_dat\">--301-12-28</td>",
-					"<td data-sort-value=\"1611848.5\" class=\"MW-Date smwtype_dat\">28 December 0000</td>",
-					"<td data-sort-value=\"1611848.5\" class=\"JD smwtype_dat\">1611848.5</td>"
+					"<td class=\"Has-date smwtype_dat\" data-sort-value=\"1611848.5\">1 January 300 BC <sup>JL</sup></td>",
+					"<td class=\"Has-date smwtype_dat\" data-sort-value=\"1611848.5\">28 December 301 BC</td>",
+					"<td class=\"Has-date smwtype_dat\" data-sort-value=\"1611848.5\">--301-12-28</td>",
+					"<td class=\"ISO-Date smwtype_dat\" data-sort-value=\"1611848.5\">--301-12-28</td>",
+					"<td class=\"MW-Date smwtype_dat\" data-sort-value=\"1611848.5\">28 December 0000</td>",
+					"<td class=\"JD smwtype_dat\" data-sort-value=\"1611848.5\">1611848.5</td>"
 				]
 			}
 		},
@@ -623,12 +623,12 @@
 			"subject": "Example/P0413/13a",
 			"assert-output": {
 				"to-contain": [
-					"<td data-sort-value=\"2451598.5\" class=\"Has-date smwtype_dat\">11 February 2000 <sup>JL</sup></td>",
-					"<td data-sort-value=\"2451598.5\" class=\"Has-date smwtype_dat\">2000-02-24</td>",
-					"<td data-sort-value=\"2451598.5\" class=\"ISO-Date smwtype_dat\">2000-02-24</td>",
-					"<td data-sort-value=\"2451598.5\" class=\"MW-Date smwtype_dat\">24 February 2000</td>",
-					"<td data-sort-value=\"2451598.5\" class=\"JL-Date smwtype_dat\">11 February 2000 <sup>JL</sup></td>",
-					"<td data-sort-value=\"2451598.5\" class=\"GR-Date smwtype_dat\">24 February 2000</td>"
+					"<td class=\"Has-date smwtype_dat\" data-sort-value=\"2451598.5\">11 February 2000 <sup>JL</sup></td>",
+					"<td class=\"Has-date smwtype_dat\" data-sort-value=\"2451598.5\">2000-02-24</td>",
+					"<td class=\"ISO-Date smwtype_dat\" data-sort-value=\"2451598.5\">2000-02-24</td>",
+					"<td class=\"MW-Date smwtype_dat\" data-sort-value=\"2451598.5\">24 February 2000</td>",
+					"<td class=\"JL-Date smwtype_dat\" data-sort-value=\"2451598.5\">11 February 2000 <sup>JL</sup></td>",
+					"<td class=\"GR-Date smwtype_dat\" data-sort-value=\"2451598.5\">24 February 2000</td>"
 				]
 			}
 		},
@@ -662,12 +662,12 @@
 			"subject": "Example/P0413/14a",
 			"assert-output": {
 				"to-contain": [
-					"<td data-sort-value=\"2266042.5\" class=\"Has-date smwtype_dat\">2 February 1492 <sup>JL</sup></td>",
-					"<td data-sort-value=\"2266042.5\" class=\"Has-date smwtype_dat\">1492-02-11</td>",
-					"<td data-sort-value=\"2266042.5\" class=\"ISO-Date smwtype_dat\">1492-02-11</td>",
-					"<td data-sort-value=\"2266042.5\" class=\"MW-Date smwtype_dat\">11 February 1492</td>",
-					"<td data-sort-value=\"2266042.5\" class=\"JL-Date smwtype_dat\">2 February 1492 <sup>JL</sup></td>",
-					"<td data-sort-value=\"2266042.5\" class=\"GR-Date smwtype_dat\">11 February 1492</td>"
+					"<td class=\"Has-date smwtype_dat\" data-sort-value=\"2266042.5\">2 February 1492 <sup>JL</sup></td>",
+					"<td class=\"Has-date smwtype_dat\" data-sort-value=\"2266042.5\">1492-02-11</td>",
+					"<td class=\"ISO-Date smwtype_dat\" data-sort-value=\"2266042.5\">1492-02-11</td>",
+					"<td class=\"MW-Date smwtype_dat\" data-sort-value=\"2266042.5\">11 February 1492</td>",
+					"<td class=\"JL-Date smwtype_dat\" data-sort-value=\"2266042.5\">2 February 1492 <sup>JL</sup></td>",
+					"<td class=\"GR-Date smwtype_dat\" data-sort-value=\"2266042.5\">11 February 1492</td>"
 				]
 			}
 		},
@@ -701,12 +701,12 @@
 			"subject": "Example/P0413/15a",
 			"assert-output": {
 				"to-contain": [
-					"<td data-sort-value=\"2451585.9166667\" class=\"Has-date smwtype_dat\">11 February 2000 10:00:00</td>",
-					"<td data-sort-value=\"2451585.9166667\" class=\"Has-date smwtype_dat\">2000-02-11T10:00:00</td>",
-					"<td data-sort-value=\"2451585.9166667\" class=\"ISO-Date smwtype_dat\">2000-02-11T10:00:00</td>",
-					"<td data-sort-value=\"2451585.9166667\" class=\"MW-Date smwtype_dat\">10:00, 11 February 2000</td>",
-					"<td data-sort-value=\"2451585.9166667\" class=\"JL-Date smwtype_dat\">29 January 2000 10:00:00 <sup>JL</sup></td>",
-					"<td data-sort-value=\"2451585.9166667\" class=\"GR-Date smwtype_dat\">11 February 2000 10:00:00</td>"
+					"<td class=\"Has-date smwtype_dat\" data-sort-value=\"2451585.9166667\">11 February 2000 10:00:00</td>",
+					"<td class=\"Has-date smwtype_dat\" data-sort-value=\"2451585.9166667\">2000-02-11T10:00:00</td>",
+					"<td class=\"ISO-Date smwtype_dat\" data-sort-value=\"2451585.9166667\">2000-02-11T10:00:00</td>",
+					"<td class=\"MW-Date smwtype_dat\" data-sort-value=\"2451585.9166667\">10:00, 11 February 2000</td>",
+					"<td class=\"JL-Date smwtype_dat\" data-sort-value=\"2451585.9166667\">29 January 2000 10:00:00 <sup>JL</sup></td>",
+					"<td class=\"GR-Date smwtype_dat\" data-sort-value=\"2451585.9166667\">11 February 2000 10:00:00</td>"
 				]
 			}
 		},
@@ -740,10 +740,10 @@
 			"subject": "Example/P0413/16a",
 			"assert-output": {
 				"to-contain": [
-					"<td data-sort-value=\"2451596.5\" class=\"Has-date smwtype_dat\">22 February 2000</td>",
-					"<td data-sort-value=\"2451596.5\" class=\"Has-date smwtype_dat\">2000-02-22</td>",
-					"<td data-sort-value=\"2451596.5\" class=\"ISO-Date smwtype_dat\">2000-02-22</td>",
-					"<td data-sort-value=\"2451596.5\" class=\"MW-Date smwtype_dat\">22 February 2000</td>"
+					"<td class=\"Has-date smwtype_dat\" data-sort-value=\"2451596.5\">22 February 2000</td>",
+					"<td class=\"Has-date smwtype_dat\" data-sort-value=\"2451596.5\">2000-02-22</td>",
+					"<td class=\"ISO-Date smwtype_dat\" data-sort-value=\"2451596.5\">2000-02-22</td>",
+					"<td class=\"MW-Date smwtype_dat\" data-sort-value=\"2451596.5\">22 February 2000</td>"
 				]
 			}
 		},
@@ -783,10 +783,10 @@
 			"subject": "Example/P0413/17a",
 			"assert-output": {
 				"to-contain": [
-					"<td data-sort-value=\"-11001\" class=\"Has-date smwtype_dat\">11000 BC</td>",
-					"<td data-sort-value=\"-11001\" class=\"Has-date smwtype_dat\">--11000-01-01</td>",
-					"<td data-sort-value=\"-11001\" class=\"ISO-Date smwtype_dat\">--11000-01-01</td>",
-					"<td data-sort-value=\"-11001\" class=\"MW-Date smwtype_dat\">0000</td>"
+					"<td class=\"Has-date smwtype_dat\" data-sort-value=\"-11001\">11000 BC</td>",
+					"<td class=\"Has-date smwtype_dat\" data-sort-value=\"-11001\">--11000-01-01</td>",
+					"<td class=\"ISO-Date smwtype_dat\" data-sort-value=\"-11001\">--11000-01-01</td>",
+					"<td class=\"MW-Date smwtype_dat\" data-sort-value=\"-11001\">0000</td>"
 				]
 			}
 		},
@@ -820,11 +820,11 @@
 			"subject": "Example/P0413/18a",
 			"assert-output": {
 				"to-contain": [
-					"<td data-sort-value=\"2488346.0804977\" class=\"Has-date smwtype_dat\">4 October 2100 13:55:55</td>",
-					"<td data-sort-value=\"2488346.0804977\" class=\"Has-date smwtype_dat\">2100-10-04T13:55:55</td>",
-					"<td data-sort-value=\"2488346.0804977\" class=\"ISO-Date smwtype_dat\">2100-10-04T13:55:55</td>",
-					"<td data-sort-value=\"2488346.0804977\" class=\"MW-Date smwtype_dat\">13:55, 4 October 2100</td>",
-					"<td data-sort-value=\"2488346.0804977\" class=\"JD smwtype_dat\">2488346.0804977</td>"
+					"<td class=\"Has-date smwtype_dat\" data-sort-value=\"2488346.0804977\">4 October 2100 13:55:55</td>",
+					"<td class=\"Has-date smwtype_dat\" data-sort-value=\"2488346.0804977\">2100-10-04T13:55:55</td>",
+					"<td class=\"ISO-Date smwtype_dat\" data-sort-value=\"2488346.0804977\">2100-10-04T13:55:55</td>",
+					"<td class=\"MW-Date smwtype_dat\" data-sort-value=\"2488346.0804977\">13:55, 4 October 2100</td>",
+					"<td class=\"JD smwtype_dat\" data-sort-value=\"2488346.0804977\">2488346.0804977</td>"
 				]
 			}
 		},
@@ -858,11 +858,11 @@
 			"subject": "Example/P0413/19a",
 			"assert-output": {
 				"to-contain": [
-					"<td data-sort-value=\"4888346.5804977\" class=\"Has-date smwtype_dat\">27 September 8671 01:55:55</td>",
-					"<td data-sort-value=\"4888346.5804977\" class=\"Has-date smwtype_dat\">8671-09-27T01:55:55</td>",
-					"<td data-sort-value=\"4888346.5804977\" class=\"ISO-Date smwtype_dat\">8671-09-27T01:55:55</td>",
-					"<td data-sort-value=\"4888346.5804977\" class=\"MW-Date smwtype_dat\">01:55, 27 September 8671</td>",
-					"<td data-sort-value=\"4888346.5804977\" class=\"JD smwtype_dat\">4888346.5804977</td>"
+					"<td class=\"Has-date smwtype_dat\" data-sort-value=\"4888346.5804977\">27 September 8671 01:55:55</td>",
+					"<td class=\"Has-date smwtype_dat\" data-sort-value=\"4888346.5804977\">8671-09-27T01:55:55</td>",
+					"<td class=\"ISO-Date smwtype_dat\" data-sort-value=\"4888346.5804977\">8671-09-27T01:55:55</td>",
+					"<td class=\"MW-Date smwtype_dat\" data-sort-value=\"4888346.5804977\">01:55, 27 September 8671</td>",
+					"<td class=\"JD smwtype_dat\" data-sort-value=\"4888346.5804977\">4888346.5804977</td>"
 				]
 			}
 		}

--- a/tests/phpunit/Integration/JSONScript/TestCases/p-0413.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/p-0413.json
@@ -320,7 +320,7 @@
 			"assert-output": {
 				"to-contain": [
 					"<td class=\"Has-date smwtype_dat\" data-sort-value=\"2451586.4166782\">11 February 2000 22:00:01</td>",
-					"<td class=\"Has-date smwtype_dat\" data-sort-value=\"2451586.4166782\" >2000-02-11T22:00:01</td>",
+					"<td class=\"Has-date smwtype_dat\" data-sort-value=\"2451586.4166782\">2000-02-11T22:00:01</td>",
 					"<td class=\"ISO-Date smwtype_dat\" data-sort-value=\"2451586.4166782\">2000-02-11T22:00:01</td>",
 					"<td class=\"MW-Date smwtype_dat\" data-sort-value=\"2451586.4166782\">22:00, 11 February 2000</td>"
 				]

--- a/tests/phpunit/Integration/JSONScript/TestCases/p-0414.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/p-0414.json
@@ -110,10 +110,10 @@
 			"subject": "Example/P0414/1a",
 			"assert-output": {
 				"to-contain": [
-					"<td data-sort-value=\"2228431.9166782\" class=\"Has-date smwtype_dat\">10:00:01.000000</td>",
-					"<td data-sort-value=\"2228431.9166782\" class=\"Has-date smwtype_dat\">1389/02/11 10:00 <sup>JL</sup></td>",
-					"<td data-sort-value=\"2228431.9166782\" class=\"Has-date smwtype_dat\">1389/02/19 10:00</td>",
-					"<td data-sort-value=\"2228431.9166782\" class=\"JD smwtype_dat\">2228431.9166782</td>"
+					"<td class=\"Has-date smwtype_dat\" data-sort-value=\"2228431.9166782\">10:00:01.000000</td>",
+					"<td class=\"Has-date smwtype_dat\" data-sort-value=\"2228431.9166782\">1389/02/11 10:00 <sup>JL</sup></td>",
+					"<td class=\"Has-date smwtype_dat\" data-sort-value=\"2228431.9166782\">1389/02/19 10:00</td>",
+					"<td class=\"JD smwtype_dat\" data-sort-value=\"2228431.9166782\">2228431.9166782</td>"
 				]
 			}
 		},
@@ -147,8 +147,8 @@
 			"subject": "Example/P0414/2a",
 			"assert-output": {
 				"to-contain": [
-					"<td data-sort-value=\"-100001\" class=\"Has-date smwtype_dat\">--100000-01-01</td>",
-					"<td data-sort-value=\"-100001\" class=\"JD smwtype_dat\">-34802824.5</td>"
+					"<td class=\"Has-date smwtype_dat\" data-sort-value=\"-100001\">--100000-01-01</td>",
+					"<td class=\"JD smwtype_dat\" data-sort-value=\"-100001\">-34802824.5</td>"
 				]
 			}
 		},
@@ -182,9 +182,9 @@
 			"subject": "Example/P0414/3a",
 			"assert-output": {
 				"to-contain": [
-					"<td data-sort-value=\"2415750.5\" class=\"Has-date smwtype_dat\">1902</td>",
-					"<td data-sort-value=\"2415750.5\" class=\"Has-date smwtype_dat\">1902/01/01</td>",
-					"<td data-sort-value=\"2415750.5\" class=\"JD smwtype_dat\">2415750.5</td>"
+					"<td class=\"Has-date smwtype_dat\" data-sort-value=\"2415750.5\">1902</td>",
+					"<td class=\"Has-date smwtype_dat\" data-sort-value=\"2415750.5\">1902/01/01</td>",
+					"<td class=\"JD smwtype_dat\" data-sort-value=\"2415750.5\">2415750.5</td>"
 				]
 			}
 		},
@@ -218,9 +218,9 @@
 			"subject": "Example/P0414/4a",
 			"assert-output": {
 				"to-contain": [
-					"<td data-sort-value=\"2159657.0023727\" class=\"Has-date smwtype_dat\">1200 <sup>JL</sup></td>",
-					"<td data-sort-value=\"2159657.0023727\" class=\"Has-date smwtype_dat\">1200/10/26 <sup>JL</sup></td>",
-					"<td data-sort-value=\"2159657.0023727\" class=\"JD smwtype_dat\">2159657.0023727</td>"
+					"<td class=\"Has-date smwtype_dat\" data-sort-value=\"2159657.0023727\">1200 <sup>JL</sup></td>",
+					"<td class=\"Has-date smwtype_dat\" data-sort-value=\"2159657.0023727\">1200/10/26 <sup>JL</sup></td>",
+					"<td class=\"JD smwtype_dat\" data-sort-value=\"2159657.0023727\">2159657.0023727</td>"
 				]
 			}
 		},
@@ -254,8 +254,8 @@
 			"subject": "Example/P0414/5a",
 			"assert-output": {
 				"to-contain": [
-					"<td data-sort-value=\"-100001\" class=\"Has-date smwtype_dat\">--100000-01-01</td>",
-					"<td data-sort-value=\"-100001\" class=\"JD smwtype_dat\">-34802824.5</td>"
+					"<td class=\"Has-date smwtype_dat\" data-sort-value=\"-100001\">--100000-01-01</td>",
+					"<td class=\"JD smwtype_dat\" data-sort-value=\"-100001\">-34802824.5</td>"
 				]
 			}
 		},
@@ -289,9 +289,9 @@
 			"subject": "Example/P0414/6a",
 			"assert-output": {
 				"to-contain": [
-					"<td data-sort-value=\"2415750.5\" class=\"Has-date smwtype_dat\">AD 1902</td>",
-					"<td data-sort-value=\"2415750.5\" class=\"Has-date smwtype_dat\">1902</td>",
-					"<td data-sort-value=\"2415750.5\" class=\"Has-date smwtype_dat\">1902/01/01</td>"
+					"<td class=\"Has-date smwtype_dat\" data-sort-value=\"2415750.5\">AD 1902</td>",
+					"<td class=\"Has-date smwtype_dat\" data-sort-value=\"2415750.5\">1902</td>",
+					"<td class=\"Has-date smwtype_dat\" data-sort-value=\"2415750.5\">1902/01/01</td>"
 				]
 			}
 		},
@@ -328,8 +328,8 @@
 			},
 			"assert-output": {
 				"to-contain": [
-					"<td data-sort-value=\"2456116.9682395\" class=\"Has-date smwtype_dat\">8 July 2012 11:14:15</td>",
-					"<td data-sort-value=\"2456116.9682395\" class=\"Has-date smwtype_dat\">11:14:15.888500</td>"
+					"<td class=\"Has-date smwtype_dat\" data-sort-value=\"2456116.9682395\">8 July 2012 11:14:15</td>",
+					"<td class=\"Has-date smwtype_dat\" data-sort-value=\"2456116.9682395\">11:14:15.888500</td>"
 				]
 			}
 		},
@@ -363,8 +363,8 @@
 			"subject": "Example/P0414/8a",
 			"assert-output": {
 				"to-contain": [
-					"<td data-sort-value=\"2455203.20625\" class=\"Has-date smwtype_dat\">6 January 2010 16:57:00</td>",
-					"<td data-sort-value=\"2455203.20625\" class=\"Has-date smwtype_dat\">2010年01月06日 16:57</td>"
+					"<td class=\"Has-date smwtype_dat\" data-sort-value=\"2455203.20625\">6 January 2010 16:57:00</td>",
+					"<td class=\"Has-date smwtype_dat\" data-sort-value=\"2455203.20625\">2010年01月06日 16:57</td>"
 				]
 			}
 		},
@@ -374,8 +374,8 @@
 			"subject": "Example/P0414/9a",
 			"assert-output": {
 				"to-contain": [
-					"<td data-sort-value=\"2455203.20625\" class=\"Has-date smwtype_dat\">6 January 2010 16:57:00</td>",
-					"<td data-sort-value=\"2455203.20625\" class=\"Has-date smwtype_dat\">2010年01月06日 16:57</td>"
+					"<td class=\"Has-date smwtype_dat\" data-sort-value=\"2455203.20625\">6 January 2010 16:57:00</td>",
+					"<td class=\"Has-date smwtype_dat\" data-sort-value=\"2455203.20625\">2010年01月06日 16:57</td>"
 				]
 			}
 		}

--- a/tests/phpunit/Integration/JSONScript/TestCases/p-0415.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/p-0415.json
@@ -44,9 +44,9 @@
 				"to-contain": [
 					"<span class=\"smwtext\">0&#160;°C</span><div class=\"smwttcontent\">273.15&#160;K <br />32&#160;°F <br />491.67&#160;°R <br /></div></span>",
 					"<span class=\"smwtext\">100&#160;°C</span><div class=\"smwttcontent\">373.15&#160;K <br />212&#160;°F <br />671.67&#160;°R <br /></div></span>",
-					"<td data-sort-value=\"273.15\" class=\"- smwtype_tem\">0 °C<br />100 °C</td>",
-					"<td data-sort-value=\"273.15\" class=\"-u smwtype_tem\">°C<br />°C</td>",
-					"<td data-sort-value=\"273.15\" class=\"-n smwtype_tem\">0 <br />100 </td>",
+					"<td class=\"- smwtype_tem\" data-sort-value=\"273.15\">0 °C<br />100 °C</td>",
+					"<td class=\"-u smwtype_tem\" data-sort-value=\"273.15\">°C<br />°C</td>",
+					"<td class=\"-n smwtype_tem\" data-sort-value=\"273.15\">0 <br />100 </td>",
 					"<span class=\"smwtext\">491.67&#160;°R</span><div class=\"smwttcontent\">0&#160;°C <br />273.15&#160;K <br />32&#160;°F <br /></div></span>",
 					"<span class=\"smwtext\">671.67&#160;°R</span><div class=\"smwttcontent\">100&#160;°C <br />373.15&#160;K <br />212&#160;°F <br /></div></span>"
 				]

--- a/tests/phpunit/Integration/JSONScript/TestCases/p-0416.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/p-0416.json
@@ -127,7 +127,7 @@
 			"assert-output": {
 				"to-contain": [
 					"title=\"Example/P0416/1\">Foo</a></td><td class=\"Display-title-of smwtype_txt\">Foo</td>",
-					"title=\"Example/P0416/1\">123#Bar</a></span></td><td data-sort-value=\"123\" class=\"Display-title-of smwtype_txt\">123</td>"
+					"title=\"Example/P0416/1\">123#Bar</a></span></td><td class=\"Display-title-of smwtype_txt\" data-sort-value=\"123\">123</td>"
 				]
 			}
 		},

--- a/tests/phpunit/Integration/JSONScript/TestCases/p-0420.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/p-0420.json
@@ -62,9 +62,9 @@
 			"subject": "Example/P0420/1a",
 			"assert-output": {
 				"to-contain": [
-					"<td data-sort-value=\"2336583.5\" class=\"Has-date smwtype_dat\">21 March 1685 <sup>JL</sup></td>",
-					"<td data-sort-value=\"2336583.5\" class=\"Has-date smwtype_dat\">31 March 1685</td>",
-					"<td data-sort-value=\"2336583.5\" class=\"Has-date smwtype_dat\">21 March 1685 <sup>JL</sup></td>"
+					"<td class=\"Has-date smwtype_dat\" data-sort-value=\"2336583.5\">21 March 1685 <sup>JL</sup></td>",
+					"<td class=\"Has-date smwtype_dat\" data-sort-value=\"2336583.5\">31 March 1685</td>",
+					"<td class=\"Has-date smwtype_dat\" data-sort-value=\"2336583.5\">21 March 1685 <sup>JL</sup></td>"
 				]
 			}
 		},
@@ -74,9 +74,9 @@
 			"subject": "Example/P0420/2a",
 			"assert-output": {
 				"to-contain": [
-					"<td data-sort-value=\"2336583.5\" class=\"Has-date smwtype_dat\">21 March 1685 <sup>JL</sup></td>",
-					"<td data-sort-value=\"2336583.5\" class=\"Has-date smwtype_dat\">31 March 1685</td>",
-					"<td data-sort-value=\"2336583.5\" class=\"Has-date smwtype_dat\">21 March 1685 <sup>JL</sup></td>"
+					"<td class=\"Has-date smwtype_dat\" data-sort-value=\"2336583.5\">21 March 1685 <sup>JL</sup></td>",
+					"<td class=\"Has-date smwtype_dat\" data-sort-value=\"2336583.5\">31 March 1685</td>",
+					"<td class=\"Has-date smwtype_dat\" data-sort-value=\"2336583.5\">21 March 1685 <sup>JL</sup></td>"
 				]
 			}
 		},
@@ -86,9 +86,9 @@
 			"subject": "Example/P0420/3a",
 			"assert-output": {
 				"to-contain": [
-					"<td data-sort-value=\"2336573.5\" class=\"Has-date smwtype_dat\">21 March 1685</td>",
-					"<td data-sort-value=\"2336573.5\" class=\"Has-date smwtype_dat\">21 March 1685</td>",
-					"<td data-sort-value=\"2336573.5\" class=\"Has-date smwtype_dat\">11 March 1685 <sup>JL</sup></td>"
+					"<td class=\"Has-date smwtype_dat\" data-sort-value=\"2336573.5\">21 March 1685</td>",
+					"<td class=\"Has-date smwtype_dat\" data-sort-value=\"2336573.5\">21 March 1685</td>",
+					"<td class=\"Has-date smwtype_dat\" data-sort-value=\"2336573.5\">11 March 1685 <sup>JL</sup></td>"
 				]
 			}
 		}

--- a/tests/phpunit/Integration/JSONScript/TestCases/p-0422.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/p-0422.json
@@ -77,9 +77,9 @@
 			"subject": "Example/P0422/Q/2/1",
 			"assert-output": {
 				"to-contain": [
-					"<tr data-row-number=\"1\" class=\"row-odd\"><td class=\"smwtype_wpg\">Example/P0422/2#_519df0ee370ade5d506e5dd769a14b26</td><td data-sort-value=\"2321884.5\" class=\"Has-date smwtype_dat\">1645</td></tr>",
-					"<tr data-row-number=\"2\" class=\"row-even\"><td class=\"smwtype_wpg\">Example/P0422/2#_a9167ae46aa815bb052650683c4719d6</td><td data-sort-value=\"2423420.5\" class=\"Has-date smwtype_dat\">January 1923</td></tr>",
-					"<tr data-row-number=\"3\" class=\"row-odd\"><td class=\"smwtype_wpg\">Example/P0422/2#_803b6de7d53ad0173871f4e4210ce477</td><td data-sort-value=\"2436965.5\" class=\"Has-date smwtype_dat\">February 1960</td></tr>"
+					"<tr data-row-number=\"1\" class=\"row-odd\"><td class=\"smwtype_wpg\">Example/P0422/2#_519df0ee370ade5d506e5dd769a14b26</td><td class=\"Has-date smwtype_dat\" data-sort-value=\"2321884.5\">1645</td></tr>",
+					"<tr data-row-number=\"2\" class=\"row-even\"><td class=\"smwtype_wpg\">Example/P0422/2#_a9167ae46aa815bb052650683c4719d6</td><td class=\"Has-date smwtype_dat\" data-sort-value=\"2423420.5\">January 1923</td></tr>",
+					"<tr data-row-number=\"3\" class=\"row-odd\"><td class=\"smwtype_wpg\">Example/P0422/2#_803b6de7d53ad0173871f4e4210ce477</td><td class=\"Has-date smwtype_dat\" data-sort-value=\"2436965.5\">February 1960</td></tr>"
 				]
 			}
 		},
@@ -89,9 +89,9 @@
 			"subject": "Example/P0422/Q/2/2",
 			"assert-output": {
 				"to-contain": [
-					"<tr data-row-number=\"1\" class=\"row-odd\"><td class=\"smwtype_wpg\">Example/P0422/2#_803b6de7d53ad0173871f4e4210ce477</td><td data-sort-value=\"2436965.5\" class=\"Has-date smwtype_dat\">February 1960</td></tr>",
-					"<tr data-row-number=\"2\" class=\"row-even\"><td class=\"smwtype_wpg\">Example/P0422/2#_a9167ae46aa815bb052650683c4719d6</td><td data-sort-value=\"2423420.5\" class=\"Has-date smwtype_dat\">January 1923</td></tr>",
-					"<tr data-row-number=\"3\" class=\"row-odd\"><td class=\"smwtype_wpg\">Example/P0422/2#_519df0ee370ade5d506e5dd769a14b26</td><td data-sort-value=\"2321884.5\" class=\"Has-date smwtype_dat\">1645</td></tr>"
+					"<tr data-row-number=\"1\" class=\"row-odd\"><td class=\"smwtype_wpg\">Example/P0422/2#_803b6de7d53ad0173871f4e4210ce477</td><td class=\"Has-date smwtype_dat\" data-sort-value=\"2436965.5\">February 1960</td></tr>",
+					"<tr data-row-number=\"2\" class=\"row-even\"><td class=\"smwtype_wpg\">Example/P0422/2#_a9167ae46aa815bb052650683c4719d6</td><td class=\"Has-date smwtype_dat\" data-sort-value=\"2423420.5\">January 1923</td></tr>",
+					"<tr data-row-number=\"3\" class=\"row-odd\"><td class=\"smwtype_wpg\">Example/P0422/2#_519df0ee370ade5d506e5dd769a14b26</td><td class=\"Has-date smwtype_dat\" data-sort-value=\"2321884.5\">1645</td></tr>"
 				]
 			}
 		},

--- a/tests/phpunit/Integration/JSONScript/TestCases/p-0423.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/p-0423.json
@@ -93,8 +93,8 @@
 			"subject": "Example/P0423/Q1.2",
 			"assert-output": {
 				"to-contain": [
-					"<td class=\"Has-date smwtype_dat\" data-sort-value=\"2435851.0034722\">12 January 1957 12:05:00</td>",
-					"<td class=\"Has-date smwtype_dat\" data-sort-value=\"2435851.0034722\">1957年1月12日 (土) 12:05</td>"
+					"<td class=\"smwtype_dat\" data-sort-value=\"2435851.0034722\">12 January 1957 12:05:00</td>",
+					"<td class=\"smwtype_dat\" data-sort-value=\"2435851.0034722\">1957年1月12日 (土) 12:05</td>"
 				]
 			}
 		},

--- a/tests/phpunit/Integration/JSONScript/TestCases/p-0423.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/p-0423.json
@@ -147,7 +147,7 @@
 			"subject": "Example/P0423/Q3.1",
 			"assert-output": {
 				"to-contain": [
-					"class=\"Has-date smwtype_dat\">"
+					"class=\"Has-date smwtype_dat\" "
 				]
 			}
 		}

--- a/tests/phpunit/Integration/JSONScript/TestCases/p-0423.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/p-0423.json
@@ -82,8 +82,8 @@
 			"subject": "Example/P0423/Q1.1",
 			"assert-output": {
 				"to-contain": [
-					"<td data-sort-value=\"2435851.0034722\" class=\"Has-date smwtype_dat\">12 January 1957 12:05:00</td>",
-					"<td data-sort-value=\"2435851.0034722\" class=\"Has-date smwtype_dat\">1957年1月12日 (土) 12:05</td>"
+					"<td class=\"Has-date smwtype_dat\" data-sort-value=\"2435851.0034722\">12 January 1957 12:05:00</td>",
+					"<td class=\"Has-date smwtype_dat\" data-sort-value=\"2435851.0034722\">1957年1月12日 (土) 12:05</td>"
 				]
 			}
 		},
@@ -93,8 +93,8 @@
 			"subject": "Example/P0423/Q1.2",
 			"assert-output": {
 				"to-contain": [
-					"<td data-sort-value=\"2435851.0034722\" class=\"smwtype_dat\">12 January 1957 12:05:00</td>",
-					"<td data-sort-value=\"2435851.0034722\" class=\"smwtype_dat\">1957年1月12日 (土) 12:05</td>"
+					"<td class=\"Has-date smwtype_dat\" data-sort-value=\"2435851.0034722\">12 January 1957 12:05:00</td>",
+					"<td class=\"Has-date smwtype_dat\" data-sort-value=\"2435851.0034722\">1957年1月12日 (土) 12:05</td>"
 				]
 			}
 		},
@@ -104,7 +104,7 @@
 			"subject": "Example/P0423/Q1.3",
 			"assert-output": {
 				"to-contain": [
-					"<td data-sort-value=\"2435851.0034722\" class=\"Has-date smwtype_dat\">1957年1月12日 (土) 12:05:00</td>"
+					"<td class=\"Has-date smwtype_dat\" data-sort-value=\"2435851.0034722\">1957年1月12日 (土) 12:05:00</td>"
 				]
 			}
 		},

--- a/tests/phpunit/Integration/JSONScript/TestCases/p-0424.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/p-0424.json
@@ -79,7 +79,7 @@
 					"<td class=\"Has-boolean smwtype_boo\" data-sort-value=\"1\">true</td>",
 					"<td class=\"Has-boolean smwtype_boo\" data-sort-value=\"1\">vrai</td>",
 					"<td class=\"Has-boolean smwtype_boo\" data-sort-value=\"0\">false</td>",
-					"<tdclass=\"Has-boolean smwtype_boo\"  data-sort-value=\"0\">faux</td>"
+					"<td class=\"Has-boolean smwtype_boo\" data-sort-value=\"0\">faux</td>"
 				]
 			}
 		},

--- a/tests/phpunit/Integration/JSONScript/TestCases/p-0424.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/p-0424.json
@@ -76,10 +76,10 @@
 			"subject": "Example/P0424/Q1.1",
 			"assert-output": {
 				"to-contain": [
-					"<td data-sort-value=\"1\" class=\"Has-boolean smwtype_boo\">true</td>",
-					"<td data-sort-value=\"1\" class=\"Has-boolean smwtype_boo\">vrai</td>",
-					"<td data-sort-value=\"0\" class=\"Has-boolean smwtype_boo\">false</td>",
-					"<td data-sort-value=\"0\" class=\"Has-boolean smwtype_boo\">faux</td>"
+					"<td class=\"Has-boolean smwtype_boo\" data-sort-value=\"1\">true</td>",
+					"<td class=\"Has-boolean smwtype_boo\" data-sort-value=\"1\">vrai</td>",
+					"<td class=\"Has-boolean smwtype_boo\" data-sort-value=\"0\">false</td>",
+					"<tdclass=\"Has-boolean smwtype_boo\"  data-sort-value=\"0\">faux</td>"
 				]
 			}
 		},
@@ -89,10 +89,10 @@
 			"subject": "Example/P0424/Q1.2",
 			"assert-output": {
 				"to-contain": [
-					"<td data-sort-value=\"1\" class=\"Has-boolean smwtype_boo\">true</td>",
-					"<td data-sort-value=\"1\" class=\"Has-boolean smwtype_boo\">真</td>",
-					"<td data-sort-value=\"0\" class=\"Has-boolean smwtype_boo\">false</td>",
-					"<td data-sort-value=\"0\" class=\"Has-boolean smwtype_boo\">偽</td>"
+					"<td class=\"Has-boolean smwtype_boo\" data-sort-value=\"1\">true</td>",
+					"<td class=\"Has-boolean smwtype_boo\" data-sort-value=\"1\">真</td>",
+					"<td class=\"Has-boolean smwtype_boo\" data-sort-value=\"0\">false</td>",
+					"<td class=\"Has-boolean smwtype_boo\" data-sort-value=\"0\">偽</td>"
 				]
 			}
 		}

--- a/tests/phpunit/Integration/JSONScript/TestCases/p-0430.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/p-0430.json
@@ -62,7 +62,7 @@
 			"subject": "Example/P0430/Q1.1",
 			"assert-output": {
 				"to-contain": [
-					"<td data-sort-value=\"00564222\" class=\"NDL-ID smwtype_eid\">00564222</td>"
+					"<td class=\"NDL-ID smwtype_eid\" data-sort-value=\"00564222\">00564222</td>"
 				]
 			}
 		},
@@ -72,7 +72,7 @@
 			"subject": "Example/P0430/Q1.2",
 			"assert-output": {
 				"to-contain": [
-					"<td data-sort-value=\"00564222\" class=\"NDL-ID smwtype_eid\"><span class=\"plainlinks smw-eid\"><a rel=\"nofollow\" class=\"external text\" href=\"https://id.ndl.go.jp/auth/ndlna/00564222\">00564222</a></span></td>"
+					"<td class=\"NDL-ID smwtype_eid\" data-sort-value=\"00564222\"><span class=\"plainlinks smw-eid\"><a rel=\"nofollow\" class=\"external text\" href=\"https://id.ndl.go.jp/auth/ndlna/00564222\">00564222</a></span></td>"
 				]
 			}
 		},

--- a/tests/phpunit/Integration/JSONScript/TestCases/p-0431.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/p-0431.json
@@ -44,7 +44,7 @@
 					"<td class=\"Has-record smwtype_txt\">Foo</td>"
 				],
 				"not-contain": [
-					"<td data-sort-value=\"123\" class=\"Has-record smwtype_num\">123</td>"
+					"<td class=\"Has-record smwtype_num\" data-sort-value=\"123\">123</td>"
 				]
 			}
 		},
@@ -56,7 +56,7 @@
 				"to-contain": [
 					"Example/P0431/1",
 					"<td class=\"Has-record smwtype_txt\">Foo</td>",
-					"<td data-sort-value=\"123\" class=\"Has-record smwtype_num\">123</td>"
+					"<td class=\"Has-record smwtype_num\" data-sort-value=\"123\">123</td>"
 				]
 			}
 		},

--- a/tests/phpunit/Integration/JSONScript/TestCases/p-0432.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/p-0432.json
@@ -78,7 +78,7 @@
 			"assert-output": {
 				"to-contain": [
 					"<tr data-row-number=\"1\" class=\"row-odd\"><td class=\"smwtype_wpg\">Example/P0432/1</td>",
-					"<td data-sort-value=\"2451544.5\" class=\"Has-number-with-ref smwtype_dat\">1 January 2000</td>",
+					"<td class=\"Has-number-with-ref smwtype_dat\" data-sort-value=\"2451544.5\">1 January 2000</td>",
 					"<td class=\"Has-number-with-ref smwtype_uri\"><a rel=\"nofollow\" class=\"external free\" href=\"http://example.org\">http://example.org</a></td>"
 				]
 			}
@@ -90,7 +90,7 @@
 			"assert-output": {
 				"to-contain": [
 					"<tr data-row-number=\"1\" class=\"row-odd\"><td class=\"smwtype_wpg\">Example/P0432/2#_7b5db4a4195b1843f9a25639c0d7ff5c</td>",
-					"<td data-sort-value=\"2319299.5\" class=\"Has-number-with-ref smwtype_dat\">4 December 1637</td>",
+					"<td class=\"Has-number-with-ref smwtype_dat\" data-sort-value=\"2319299.5\">4 December 1637</td>",
 					"<td class=\"Has-number-with-ref smwtype_uri\"><a rel=\"nofollow\" class=\"external free\" href=\"http://example.org\">http://example.org</a></td>"
 				]
 			}
@@ -103,7 +103,7 @@
 				"to-contain": [
 					"<tr data-row-number=\"1\" class=\"row-odd\"><td class=\"smwtype_wpg\">Example/P0432/3</td>",
 					"<td class=\"Has-mlt-with-ref smwtype_mlt_rec\">Test (en)</td>",
-					"<td data-sort-value=\"123\" class=\"Has-mlt-with-ref smwtype_num\">123</td>"
+					"<td class=\"Has-mlt-with-ref smwtype_num\" data-sort-value=\"123\">123</td>"
 				]
 			}
 		},

--- a/tests/phpunit/Integration/JSONScript/TestCases/p-0434.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/p-0434.json
@@ -76,7 +76,7 @@
 			"subject": "Example/P0434/Q1.1",
 			"assert-output": {
 				"to-contain": [
-					"<td class=\"smwtype_wpg\">Example/P0434/1</td><td data-sort-value=\"123\" class=\"Number smwtype_num\">123</td>"
+					"<td class=\"smwtype_wpg\">Example/P0434/1</td><td class=\"Number smwtype_num\" data-sort-value=\"123\">123</td>"
 				]
 			}
 		},
@@ -86,7 +86,7 @@
 			"subject": "Example/P0434/Q1.2",
 			"assert-output": {
 				"to-contain": [
-					"<td class=\"smwtype_wpg\">Example/P0434/1</td><td data-sort-value=\"2440587.5\" class=\"Date smwtype_dat\">1 January 1970</td></tr></table>"
+					"<td class=\"smwtype_wpg\">Example/P0434/1</td><td class=\"Date smwtype_dat\" data-sort-value=\"2440587.5\">1 January 1970</td></tr></table>"
 				]
 			}
 		},
@@ -96,10 +96,10 @@
 			"subject": "Example/P0434/Q2.1",
 			"assert-output": {
 				"to-contain": [
-					"<td class=\"smwtype_wpg\">Example/P0434/2</td><td data-sort-value=\"123\" class=\"Number smwtype_num\">123</td>"
+					"<td class=\"smwtype_wpg\">Example/P0434/2</td><td class=\"Number smwtype_num\" data-sort-value=\"123\">123</td>"
 				],
 				"not-contain": [
-					"<td class=\"smwtype_wpg\">Example/P0434/1</td><td data-sort-value=\"123\" class=\"Number smwtype_num\">123</td>"
+					"<td class=\"smwtype_wpg\">Example/P0434/1</td><td class=\"Number smwtype_num\" data-sort-value=\"123\">123</td>"
 				]
 			}
 		},
@@ -131,7 +131,7 @@
 			"assert-output": {
 				"to-contain": [
 					"<span title=\"Located in.-Located in.-Located in.Capital of.Has subobject.Has population.Number\">⠉</span>",
-					"<td class=\"smwtype_wpg\">Example/P0434/3</td><td data-sort-value=\"456\" class=\"Number smwtype_num\">456</td>"
+					"<td class=\"smwtype_wpg\">Example/P0434/3</td><td class=\"Number smwtype_num\" data-sort-value=\"456\">456</td>"
 				]
 			}
 		},
@@ -141,8 +141,8 @@
 			"subject": "Example/P0434/Q4.1",
 			"assert-output": {
 				"to-contain": [
-					"<tr data-row-number=\"1\" class=\"row-odd\"><td class=\"smwtype_wpg\">Example/P0434/4#_fb1dd749d7117fe311c13da0f5088d88</td><td data-sort-value=\"2415020.5\" class=\"Date smwtype_dat\">1 January 1900</td>",
-					"<tr data-row-number=\"2\" class=\"row-even\"><td class=\"smwtype_wpg\">Example/P0434/4#_c7fd595ef59775763dd517dc39dc27a1</td><td data-sort-value=\"2451179.5\" class=\"Date smwtype_dat\">1 January 1999</td>"
+					"<tr data-row-number=\"1\" class=\"row-odd\"><td class=\"smwtype_wpg\">Example/P0434/4#_fb1dd749d7117fe311c13da0f5088d88</td><td class=\"Date smwtype_dat\" data-sort-value=\"2415020.5\">1 January 1900</td>",
+					"<tr data-row-number=\"2\" class=\"row-even\"><td class=\"smwtype_wpg\">Example/P0434/4#_c7fd595ef59775763dd517dc39dc27a1</td><td class=\"Date smwtype_dat\" data-sort-value=\"2451179.5\">1 January 1999</td>"
 				]
 			}
 		},
@@ -152,8 +152,8 @@
 			"subject": "Example/P0434/Q4.2",
 			"assert-output": {
 				"to-contain": [
-					"<tr data-row-number=\"1\" class=\"row-odd\"><td class=\"smwtype_wpg\">Example/P0434/4#_b839bc3327e104d1aad75903fbc5a278</td><td data-sort-value=\"2451544.5\" class=\"Date smwtype_dat\">1 January 2000</td>",
-					"<tr data-row-number=\"2\" class=\"row-even\"><td class=\"smwtype_wpg\">Example/P0434/4#_c7fd595ef59775763dd517dc39dc27a1</td><td data-sort-value=\"2451179.5\" class=\"Date smwtype_dat\">1 January 1999</td>"
+					"<tr data-row-number=\"1\" class=\"row-odd\"><td class=\"smwtype_wpg\">Example/P0434/4#_b839bc3327e104d1aad75903fbc5a278</td><td class=\"Date smwtype_dat\" data-sort-value=\"2451544.5\">1 January 2000</td>",
+					"<tr data-row-number=\"2\" class=\"row-even\"><td class=\"smwtype_wpg\">Example/P0434/4#_c7fd595ef59775763dd517dc39dc27a1</td><td class=\"Date smwtype_dat\" data-sort-value=\"2451179.5\">1 January 1999</td>"
 				]
 			}
 		},
@@ -163,8 +163,8 @@
 			"subject": "Example/P0434/Q4.3",
 			"assert-output": {
 				"to-contain": [
-					"<tr data-row-number=\"1\" class=\"row-odd\"><td class=\"smwtype_wpg\">Example/P0434/4#_fb1dd749d7117fe311c13da0f5088d88</td><td data-sort-value=\"2415020.5\" class=\"Date smwtype_dat\">1 January 1900</td></tr>",
-					"<tr data-row-number=\"2\" class=\"row-even\"><td class=\"smwtype_wpg\">Example/P0434/4#_c7fd595ef59775763dd517dc39dc27a1</td><td data-sort-value=\"2451179.5\" class=\"Date smwtype_dat\">1 January 1999</td></tr>"
+					"<tr data-row-number=\"1\" class=\"row-odd\"><td class=\"smwtype_wpg\">Example/P0434/4#_fb1dd749d7117fe311c13da0f5088d88</td><td class=\"Date smwtype_dat\" data-sort-value=\"2415020.5\">1 January 1900</td></tr>",
+					"<tr data-row-number=\"2\" class=\"row-even\"><td class=\"smwtype_wpg\">Example/P0434/4#_c7fd595ef59775763dd517dc39dc27a1</td><td class=\"Date smwtype_dat\" data-sort-value=\"2451179.5\">1 January 1999</td></tr>"
 				]
 			}
 		},
@@ -174,8 +174,8 @@
 			"subject": "Example/P0434/Q4.4",
 			"assert-output": {
 				"to-contain": [
-					"<tr data-row-number=\"1\" class=\"row-odd\"><td class=\"smwtype_wpg\">Example/P0434/4#_b839bc3327e104d1aad75903fbc5a278</td><td data-sort-value=\"2451544.5\" class=\"Date smwtype_dat\">1 January 2000</td>",
-					"<tr data-row-number=\"2\" class=\"row-even\"><td class=\"smwtype_wpg\">Example/P0434/4#_c7fd595ef59775763dd517dc39dc27a1</td><td data-sort-value=\"2451179.5\" class=\"Date smwtype_dat\">1 January 1999</td>"
+					"<tr data-row-number=\"1\" class=\"row-odd\"><td class=\"smwtype_wpg\">Example/P0434/4#_b839bc3327e104d1aad75903fbc5a278</td><td class=\"Date smwtype_dat\" data-sort-value=\"2451544.5\">1 January 2000</td>",
+					"<tr data-row-number=\"2\" class=\"row-even\"><td class=\"smwtype_wpg\">Example/P0434/4#_c7fd595ef59775763dd517dc39dc27a1</td><td class=\"Date smwtype_dat\" data-sort-value=\"2451179.5\">1 January 1999</td>"
 				]
 			}
 		}

--- a/tests/phpunit/Integration/JSONScript/TestCases/p-0441.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/p-0441.json
@@ -27,10 +27,10 @@
 			"subject": "Example/P0441/2",
 			"assert-output": {
 				"to-contain": [
-					"<td data-sort-value=\"011\" class=\"Has-text smwtype_txt\">011<br />00011</td>"
+					"<td class=\"Has-text smwtype_txt\" data-sort-value=\"011\">011<br />00011</td>"
 				],
 				"no-contain": [
-					"<td data-sort-value=\"011\" class=\"Has-text smwtype_txt\">011</td>"
+					"<td class=\"Has-text smwtype_txt\" data-sort-value=\"011\">011</td>"
 				]
 			}
 		}

--- a/tests/phpunit/Integration/JSONScript/TestCases/p-0453.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/p-0453.json
@@ -22,8 +22,8 @@
 			"subject": "Example/P0453/Q.1",
 			"assert-output": {
 				"to-contain": [
-					"<td data-sort-value=\"2440953.0416667\" class=\"smwtype_dat\">1 January 1971 13:00:00</td>",
-					"<td data-sort-value=\"2440953.0416667\" class=\"smwtype_dat\">15:00:00, 1 January 1971&#160;<sup title=\"ISO: 1971-01-01T13:00:00\">ᴸ</sup></td>"
+					"<td class=\"smwtype_dat\" data-sort-value=\"2440953.0416667\">1 January 1971 13:00:00</td>",
+					"<td class=\"smwtype_dat\" data-sort-value=\"2440953.0416667\">15:00:00, 1 January 1971&#160;<sup title=\"ISO: 1971-01-01T13:00:00\">ᴸ</sup></td>"
 				]
 			}
 		}

--- a/tests/phpunit/Integration/JSONScript/TestCases/p-0905.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/p-0905.json
@@ -39,9 +39,9 @@
 			"subject": "Example/P0905/Q1",
 			"assert-output": {
 				"to-contain": [
-					"Assessment 1a</a></td><td class=\"Assessment-year smwtype_dat\" data-sort-value=\"2453371.5\">2005</td><td data-sort-value=\"13\"",
-					"Assessment 1b</a></td><td class=\"Assessment-year smwtype_dat\" data-sort-value=\"2453736.5\">2006</td><td data-sort-value=\"2\"",
-					"Assessment 1c</a></td><td class=\"Assessment-year smwtype_dat\" data-sort-value=\"2453371.5\">2005</td><td data-sort-value=\"14\""
+					"Assessment 1a</a></td><td class=\"Assessment-year smwtype_dat\" data-sort-value=\"2453371.5\">2005</td><td class=\"Assessment-value smwtype_num\" data-sort-value=\"13\"",
+					"Assessment 1b</a></td><td class=\"Assessment-year smwtype_dat\" data-sort-value=\"2453736.5\">2006</td><td class=\"Assessment-value smwtype_num\" data-sort-value=\"2\"",
+					"Assessment 1c</a></td><td class=\"Assessment-year smwtype_dat\" data-sort-value=\"2453371.5\">2005</td><td class=\"Assessment-value smwtype_num\" data-sort-value=\"14\""
 				]
 			}
 		},
@@ -51,11 +51,11 @@
 			"subject": "Example/P0905/Q2",
 			"assert-output": {
 				"to-contain": [
-					"Assessment 1c</a></td><td class=\"Assessment-year smwtype_dat\" data-sort-value=\"2453371.5\">2005</td><td data-sort-value=\"14\""
+					"Assessment 1c</a></td><td class=\"Assessment-year smwtype_dat\" data-sort-value=\"2453371.5\">2005</td><td class=\"Assessment-value smwtype_num\" data-sort-value=\"14\""
 				],
 				"not-contain": [
-					"Assessment 1a</a></td><td class=\"Assessment-year smwtype_dat\" data-sort-value=\"2453371.5\">2005</td><td data-sort-value=\"13\"",
-					"Assessment 1b</a></td><td class=\"Assessment-year smwtype_dat\" data-sort-value=\"2453736.5\">2006</td><td data-sort-value=\"2\""
+					"Assessment 1a</a></td><td class=\"Assessment-year smwtype_dat\" data-sort-value=\"2453371.5\">2005</td><td class=\"Assessment-value smwtype_num\" data-sort-value=\"13\"",
+					"Assessment 1b</a></td><td class=\"Assessment-year smwtype_dat\" data-sort-value=\"2453736.5\">2006</td><td class=\"Assessment-value smwtype_num\" data-sort-value=\"2\""
 				]
 			}
 		},
@@ -65,11 +65,11 @@
 			"subject": "Example/P0905/Q3",
 			"assert-output": {
 				"to-contain": [
-					"Assessment 1c</a></td><td class=\"Assessment-year smwtype_dat\" data-sort-value=\"2453371.5\">2005</td><td data-sort-value=\"14\""
+					"Assessment 1c</a></td><td class=\"Assessment-year smwtype_dat\" data-sort-value=\"2453371.5\">2005</td><td class=\"Assessment-value smwtype_num\" data-sort-value=\"14\""
 				],
 				"not-contain": [
-					"Assessment 1a</a></td><td class=\"Assessment-year smwtype_dat\" data-sort-value=\"2453371.5\">2005</td><td data-sort-value=\"13\"",
-					"Assessment 1b</a></td><td class=\"Assessment-year smwtype_dat\" data-sort-value=\"2453736.5\">2006</td><td data-sort-value=\"2\""
+					"Assessment 1a</a></td><td class=\"Assessment-year smwtype_dat\" data-sort-value=\"2453371.5\">2005</td><td class=\"Assessment-value smwtype_num\" data-sort-value=\"13\"",
+					"Assessment 1b</a></td><td class=\"Assessment-year smwtype_dat\" data-sort-value=\"2453736.5\">2006</td><td class=\"Assessment-value smwtype_num\" data-sort-value=\"2\""
 				]
 			}
 		},
@@ -79,11 +79,11 @@
 			"subject": "Example/P0905/Q4",
 			"assert-output": {
 				"to-contain": [
-					"Assessment 1b</a></td><td class=\"Assessment-year smwtype_dat\" data-sort-value=\"2453736.5\">2006</td><td data-sort-value=\"2\""
+					"Assessment 1b</a></td><td class=\"Assessment-year smwtype_dat\" data-sort-value=\"2453736.5\">2006</td><td class=\"Assessment-value smwtype_num\" data-sort-value=\"2\""
 				],
 				"not-contain": [
-					"Assessment 1a</a></td><td class=\"Assessment-year smwtype_dat\" data-sort-value=\"2453371.5\">2005</td><td data-sort-value=\"13\"",
-					"Assessment 1c</a></td><td class=\"Assessment-year smwtype_dat\" data-sort-value=\"2453371.5\">2005</td><td data-sort-value=\"14\""
+					"Assessment 1a</a></td><td class=\"Assessment-year smwtype_dat\" data-sort-value=\"2453371.5\">2005</td><td class=\"Assessment-value smwtype_num\" data-sort-value=\"13\"",
+					"Assessment 1c</a></td><td class=\"Assessment-year smwtype_dat\" data-sort-value=\"2453371.5\">2005</td><td class=\"Assessment-value smwtype_num\" data-sort-value=\"14\""
 				]
 			}
 		}

--- a/tests/phpunit/Integration/JSONScript/TestCases/p-0905.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/p-0905.json
@@ -39,9 +39,9 @@
 			"subject": "Example/P0905/Q1",
 			"assert-output": {
 				"to-contain": [
-					"Assessment 1a</a></td><td data-sort-value=\"2453371.5\" class=\"Assessment-year smwtype_dat\">2005</td><td data-sort-value=\"13\"",
-					"Assessment 1b</a></td><td data-sort-value=\"2453736.5\" class=\"Assessment-year smwtype_dat\">2006</td><td data-sort-value=\"2\"",
-					"Assessment 1c</a></td><td data-sort-value=\"2453371.5\" class=\"Assessment-year smwtype_dat\">2005</td><td data-sort-value=\"14\""
+					"Assessment 1a</a></td><td class=\"Assessment-year smwtype_dat\" data-sort-value=\"2453371.5\">2005</td><td data-sort-value=\"13\"",
+					"Assessment 1b</a></td><td class=\"Assessment-year smwtype_dat\" data-sort-value=\"2453736.5\">2006</td><td data-sort-value=\"2\"",
+					"Assessment 1c</a></td><td class=\"Assessment-year smwtype_dat\" data-sort-value=\"2453371.5\">2005</td><td data-sort-value=\"14\""
 				]
 			}
 		},
@@ -51,11 +51,11 @@
 			"subject": "Example/P0905/Q2",
 			"assert-output": {
 				"to-contain": [
-					"Assessment 1c</a></td><td data-sort-value=\"2453371.5\" class=\"Assessment-year smwtype_dat\">2005</td><td data-sort-value=\"14\""
+					"Assessment 1c</a></td><td class=\"Assessment-year smwtype_dat\" data-sort-value=\"2453371.5\">2005</td><td data-sort-value=\"14\""
 				],
 				"not-contain": [
-					"Assessment 1a</a></td><td data-sort-value=\"2453371.5\" class=\"Assessment-year smwtype_dat\">2005</td><td data-sort-value=\"13\"",
-					"Assessment 1b</a></td><td data-sort-value=\"2453736.5\" class=\"Assessment-year smwtype_dat\">2006</td><td data-sort-value=\"2\""
+					"Assessment 1a</a></td><td class=\"Assessment-year smwtype_dat\" data-sort-value=\"2453371.5\">2005</td><td data-sort-value=\"13\"",
+					"Assessment 1b</a></td><td class=\"Assessment-year smwtype_dat\" data-sort-value=\"2453736.5\">2006</td><td data-sort-value=\"2\""
 				]
 			}
 		},
@@ -65,11 +65,11 @@
 			"subject": "Example/P0905/Q3",
 			"assert-output": {
 				"to-contain": [
-					"Assessment 1c</a></td><td data-sort-value=\"2453371.5\" class=\"Assessment-year smwtype_dat\">2005</td><td data-sort-value=\"14\""
+					"Assessment 1c</a></td><td class=\"Assessment-year smwtype_dat\" data-sort-value=\"2453371.5\">2005</td><td data-sort-value=\"14\""
 				],
 				"not-contain": [
-					"Assessment 1a</a></td><td data-sort-value=\"2453371.5\" class=\"Assessment-year smwtype_dat\">2005</td><td data-sort-value=\"13\"",
-					"Assessment 1b</a></td><td data-sort-value=\"2453736.5\" class=\"Assessment-year smwtype_dat\">2006</td><td data-sort-value=\"2\""
+					"Assessment 1a</a></td><td class=\"Assessment-year smwtype_dat\" data-sort-value=\"2453371.5\">2005</td><td data-sort-value=\"13\"",
+					"Assessment 1b</a></td><td class=\"Assessment-year smwtype_dat\" data-sort-value=\"2453736.5\">2006</td><td data-sort-value=\"2\""
 				]
 			}
 		},
@@ -79,11 +79,11 @@
 			"subject": "Example/P0905/Q4",
 			"assert-output": {
 				"to-contain": [
-					"Assessment 1b</a></td><td data-sort-value=\"2453736.5\" class=\"Assessment-year smwtype_dat\">2006</td><td data-sort-value=\"2\""
+					"Assessment 1b</a></td><td class=\"Assessment-year smwtype_dat\" data-sort-value=\"2453736.5\">2006</td><td data-sort-value=\"2\""
 				],
 				"not-contain": [
-					"Assessment 1a</a></td><td data-sort-value=\"2453371.5\" class=\"Assessment-year smwtype_dat\">2005</td><td data-sort-value=\"13\"",
-					"Assessment 1c</a></td><td data-sort-value=\"2453371.5\" class=\"Assessment-year smwtype_dat\">2005</td><td data-sort-value=\"14\""
+					"Assessment 1a</a></td><td class=\"Assessment-year smwtype_dat\" data-sort-value=\"2453371.5\">2005</td><td data-sort-value=\"13\"",
+					"Assessment 1c</a></td><td class=\"Assessment-year smwtype_dat\" data-sort-value=\"2453371.5\">2005</td><td data-sort-value=\"14\""
 				]
 			}
 		}

--- a/tests/phpunit/Integration/JSONScript/TestCases/p-0914.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/p-0914.json
@@ -52,7 +52,7 @@
 			},
 			"assert-output": {
 				"to-contain": [
-					"<td class=\"Runtime-benchmark smwtype_ref_rec\">27 November 2016</td><td data-sort-value=\"16690400\" class=\"Memory-used smwtype_num\">16690400</td><td data-sort-value=\"200\" class=\"ID smwtype_num\">200</td><td data-sort-value=\"48.35\" class=\"Runtime smwtype_num\">48.35</td><td class=\"Benchmark-notes smwtype_wpg\">N/a</td>"
+					"<td class=\"Runtime-benchmark smwtype_ref_rec\">27 November 2016</td><td class=\"Memory-used smwtype_num\" data-sort-value=\"16690400\">16690400</td><td class=\"ID smwtype_num\" data-sort-value=\"200\">200</td><td class=\"Runtime smwtype_num\" data-sort-value=\"48.35\">48.35</td><td class=\"Benchmark-notes smwtype_wpg\">N/a</td>"
 				]
 			}
 		},
@@ -62,7 +62,7 @@
 			"subject": "Example/P0914/Q.2",
 			"assert-output": {
 				"to-contain": [
-					"<td class=\"Runtime-benchmark smwtype_ref_rec\">27 November 2016</td><td data-sort-value=\"16690400\" class=\"Memory-used smwtype_num\">16690400</td><td data-sort-value=\"200\" class=\"ID smwtype_num\">200</td><td data-sort-value=\"48.35\" class=\"Runtime smwtype_num\">48.35</td><td class=\"Benchmark-notes smwtype_wpg\">N/a</td>"
+					"<td class=\"Runtime-benchmark smwtype_ref_rec\">27 November 2016</td><td class=\"Memory-used smwtype_num\" data-sort-value=\"16690400\">16690400</td><td class=\"ID smwtype_num\" data-sort-value=\"200\">200</td><td class=\"Runtime smwtype_num\" data-sort-value=\"48.35\">48.35</td><td class=\"Benchmark-notes smwtype_wpg\">N/a</td>"
 				]
 			}
 		}


### PR DESCRIPTION
This PR is made in reference to: #2586 

This PR addresses or contains:
For certain inline queries which contain empty printouts, the generated HTML table cell does not contain proper `class` attribute. We must ensure that the `class` attribute is always defined, even if the cell is empty.

This PR includes:
- [ ] Tests (unit/integration)
- [x] CI build passed

Fixes #2586 