### PR TITLE
Property autocomplete to use smwbrowse API, refs 2696

### DIFF
--- a/includes/querypages/QueryPage.php
+++ b/includes/querypages/QueryPage.php
@@ -130,7 +130,7 @@ abstract class QueryPage extends \QueryPage {
 	public function getSearchForm( $property = '', $cacheDate = '', $propertySearch = true, $filter = '' ) {
 
 		$this->useSerchForm = true;
-		$this->getOutput()->addModules( 'ext.smw.property' );
+		$this->getOutput()->addModules( 'ext.smw.autocomplete.property' );
 
 		// No need to verify $this->selectOptions because its values are set
 		// during doQuery() which is processed before this form is generated

--- a/res/Resources.php
+++ b/res/Resources.php
@@ -380,8 +380,8 @@ return array(
 	),
 
 	// Special:SearchByProperty
-	'ext.smw.property' => $moduleTemplate + array(
-		'scripts' => 'smw/special/ext.smw.special.property.js',
+	'ext.smw.autocomplete.property' => $moduleTemplate + array(
+		'scripts' => 'smw/util/ext.smw.util.autocomplete.property.js',
 		'dependencies' => array(
 			'mediawiki.util',
 			'ext.jquery.autocomplete'

--- a/res/smw/special/ext.smw.special.ask.css
+++ b/res/smw/special/ext.smw.special.ask.css
@@ -111,6 +111,11 @@ div#ask legend {
 .smw-ask-query textarea {
 	border: 0px;
 	resize: none;
+	padding: 2px 0 0 2px;
+	outline: none;
+	line-height: normal !important;
+	box-shadow: none !important;
+	margin:0 !important;
 }
 
 .smw-ask-query .condition {

--- a/res/smw/util/ext.smw.util.autocomplete.property.js
+++ b/res/smw/util/ext.smw.util.autocomplete.property.js
@@ -12,20 +12,26 @@
 
 	var autocomplete = function( context ) {
 
+		var limit = 20;
+
+		// https://github.com/devbridge/jQuery-Autocomplete
 		context.autocomplete( {
 			serviceUrl: mw.util.wikiScript( 'api' ),
 			dataType: 'json',
 			minChars: 3,
 			maxHeight: 150,
-			paramName: 'property',
+			paramName: 'search',
 			delimiter: "\n",
 			noCache: false,
 			triggerSelectOnValidInput: false,
 			params: {
-				'action': 'browsebyproperty',
+				'action': 'smwbrowse',
 				'format': 'json',
-				'listonly': true,
-				'limit': 100
+				'browse': 'property',
+				'params': {
+					"search": '',
+					"limit": limit
+				}
 			},
 			onSelect: function( suggestion ) {
 				// #611
@@ -34,12 +40,19 @@
 			onSearchStart: function( query ) {
 
 				// Avoid a search request on options or invalid characters
-				if ( query.property.indexOf( '#' ) > 0 || query.property.indexOf( '|' ) > 0 ) {
+				if ( query.search.indexOf( '#' ) > 0 || query.search.indexOf( '|' ) > 0 ) {
 					return false;
 				};
 
 				context.addClass( 'is-disabled' );
-				query.property = query.property.replace( "?", '' );
+
+				query.params = JSON.stringify( {
+					'search': query.search.replace( "?", '' ),
+					'limit': limit
+				} );
+
+				// Avoids {"warnings":{"main":{"*":"Unrecognized parameter: search."}
+				delete query.search;
 			},
 			onSearchComplete: function( query ) {
 				context.removeClass( 'is-disabled' );

--- a/src/MediaWiki/Specials/SpecialAsk.php
+++ b/src/MediaWiki/Specials/SpecialAsk.php
@@ -102,7 +102,7 @@ class SpecialAsk extends SpecialPage {
 		$out->addModuleStyles( 'ext.smw.table.styles' );
 
 		$out->addModules( 'ext.smw.ask' );
-		$out->addModules( 'ext.smw.property' );
+		$out->addModules( 'ext.smw.autocomplete.property' );
 
 		$out->addModules(
 			LinksWidget::getModules()

--- a/src/MediaWiki/Specials/SpecialSearchByProperty.php
+++ b/src/MediaWiki/Specials/SpecialSearchByProperty.php
@@ -40,7 +40,7 @@ class SpecialSearchByProperty extends SpecialPage {
 
 		$output->setPageTitle( $this->msg( 'searchbyproperty' )->text() );
 		$output->addModules( 'ext.smw.tooltip' );
-		$output->addModules( 'ext.smw.property' );
+		$output->addModules( 'ext.smw.autocomplete.property' );
 
 		list( $limit, $offset ) = $this->getLimitOffset();
 


### PR DESCRIPTION
This PR is made in reference to: #2696

This PR addresses or contains:

- Use the `smwbrowse` API to leverage and reuse cache entries that were created by other requests that use the same API

This PR includes:
- [ ] Tests (unit/integration)
- [x] CI build passed
