### PR TITLE
Subobject to use a comparable content hash

### DIFF
--- a/DefaultSettings.php
+++ b/DefaultSettings.php
@@ -1677,4 +1677,30 @@ return array(
 	'smwgChangePropagationProtection' => true,
 	##
 
+	##
+	# Subobject content hash !! BC setting ONLY !!
+	#
+	# Normalized content hash is enabled by default to ensure that a content
+	# declaration like:
+	#
+	# {{#subobject:
+	# |Has text=Foo,Bar|+sep=,
+	# }}
+	#
+	# yields the same hash as:
+	#
+	# {{#subobject:
+	# |Has text=Bar,Foo|+sep=,
+	# }}
+	#
+	# The setting is only provided to allow for a temporary backwards compatibility
+	# and will be removed with 3.1 at which point the functionality is enabled
+	# without any constraint.
+	#
+	# @since 3.0
+	# @default true
+	##
+	'smwgUseComparableContentHash' => true,
+	##
+
 );

--- a/includes/Settings.php
+++ b/includes/Settings.php
@@ -180,6 +180,7 @@ class Settings extends Options {
 			'smwgEntityLookupFeatures' => $GLOBALS['smwgEntityLookupFeatures'],
 			'smwgFieldTypeFeatures' => $GLOBALS['smwgFieldTypeFeatures'],
 			'smwgChangePropagationProtection' => $GLOBALS['smwgChangePropagationProtection'],
+			'smwgUseComparableContentHash' => $GLOBALS['smwgUseComparableContentHash'],
 		);
 
 		self::initLegacyMapping( $configuration );

--- a/src/ParserFunctionFactory.php
+++ b/src/ParserFunctionFactory.php
@@ -207,7 +207,9 @@ class ParserFunctionFactory {
 	 */
 	public function newSubobjectParserFunction( Parser $parser ) {
 
-		$parserData = ApplicationFactory::getInstance()->newParserData(
+		$applicationFactory = ApplicationFactory::getInstance();
+
+		$parserData = $applicationFactory->newParserData(
 			$parser->getTitle(),
 			$parser->getOutput()
 		);
@@ -225,7 +227,11 @@ class ParserFunctionFactory {
 		);
 
 		$subobjectParserFunction->isCapitalLinks(
-			$GLOBALS['wgCapitalLinks']
+			Site::isCapitalLinks()
+		);
+
+		$subobjectParserFunction->isComparableContent(
+			$applicationFactory->getSettings()->get( 'smwgUseComparableContentHash' )
 		);
 
 		return $subobjectParserFunction;
@@ -240,7 +246,9 @@ class ParserFunctionFactory {
 	 */
 	public function newRecurringEventsParserFunction( Parser $parser ) {
 
-		$parserData = ApplicationFactory::getInstance()->newParserData(
+		$applicationFactory = ApplicationFactory::getInstance();
+
+		$parserData = $applicationFactory->newParserData(
 			$parser->getTitle(),
 			$parser->getOutput()
 		);
@@ -254,8 +262,23 @@ class ParserFunctionFactory {
 		$recurringEventsParserFunction = new RecurringEventsParserFunc(
 			$parserData,
 			$subobject,
-			$messageFormatter,
-			ApplicationFactory::getInstance()->getSettings()
+			$messageFormatter
+		);
+
+		$recurringEventsParserFunction->isCapitalLinks(
+			Site::isCapitalLinks()
+		);
+
+		$recurringEventsParserFunction->setDefaultNumRecurringEvents(
+			$applicationFactory->getSettings()->get( 'smwgDefaultNumRecurringEvents' )
+		);
+
+		$recurringEventsParserFunction->setMaxNumRecurringEvents(
+			$applicationFactory->getSettings()->get( 'smwgMaxNumRecurringEvents' )
+		);
+
+		$recurringEventsParserFunction->isComparableContent(
+			$applicationFactory->getSettings()->get( 'smwgUseComparableContentHash' )
 		);
 
 		return $recurringEventsParserFunction;

--- a/src/ParserParameterProcessor.php
+++ b/src/ParserParameterProcessor.php
@@ -187,6 +187,28 @@ class ParserParameterProcessor {
 	}
 
 	/**
+	 * @since 3.0
+	 *
+	 * @param array $parameters
+	 * @param boolean $associative
+	 */
+	public static function sort( array &$parameters, $associative = true ) {
+
+		// Associative vs. simple index array sort
+		if ( $associative ) {
+			ksort( $parameters );
+		} else {
+			sort( $parameters );
+		}
+
+		foreach ( $parameters as $key => &$value ) {
+			if ( is_array( $value ) ) {
+				self::sort( $value, is_int( $key ) );
+			}
+		}
+	}
+
+	/**
 	 * Map raw parameters array into an 2n-array for simplified
 	 * via [key] => [value1, value2]
 	 */

--- a/src/Services/SharedServicesContainer.php
+++ b/src/Services/SharedServicesContainer.php
@@ -354,9 +354,14 @@ class SharedServicesContainer implements CallbackContainer {
 			$cachedQueryResultPrefetcher->setDependantHashIdExtension(
 				// If the mix of dataTypes changes then modify the hash
 				$settings->get( 'smwgFulltextSearchIndexableDataTypes' ) .
+
 				// If the collation is altered then modify the hash as it
 				// is likely that the sort order of results change
-				$settings->get( 'smwgEntityCollation' )
+				$settings->get( 'smwgEntityCollation' ) .
+
+				// Changing the sobj has computation should invalidate
+				// existing caches to avoid oudated references SOBJ IDs
+				$settings->get( 'smwgUseComparableContentHash' )
 			);
 
 			$cachedQueryResultPrefetcher->setLogger(

--- a/src/Site.php
+++ b/src/Site.php
@@ -42,6 +42,15 @@ class Site {
 	/**
 	 * @since 3.0
 	 *
+	 * @return boolean
+	 */
+	public static function isCapitalLinks() {
+		return $GLOBALS['wgCapitalLinks'];
+	}
+
+	/**
+	 * @since 3.0
+	 *
 	 * @param string $typeFilter
 	 *
 	 * @return array

--- a/tests/phpunit/Integration/JSONScript/TestCases/f-0207.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/f-0207.json
@@ -61,7 +61,7 @@
 					"<td class=\"smwtype_wpg\">Example/F0207/1/1</td><td class=\"Has-text smwtype_txt\">",
 					"<li> 123",
 					"<li> 345",
-					"<td class=\"smwtype_wpg\">Example/F0207/1/2#_57e4949f2a9a569755412c784489402a</td><td class=\"Has-text smwtype_txt\">",
+					"<td class=\"smwtype_wpg\">Example/F0207/1/2#_f3c65172820fbf16a271da866298e82b</td><td class=\"Has-text smwtype_txt\">",
 					"<li> 一二三",
 					"<li> 四五六",
 					"<p>some text without indent",

--- a/tests/phpunit/Integration/JSONScript/TestCases/p-0203.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/p-0203.json
@@ -52,7 +52,7 @@
 					],
 					"propertyValues": [
 						"Test",
-						"Transclude-Template#_49c8abd563e00e4dcf6debf1d61b5408"
+						"Transclude-Template#_2d7f2b93bd6e9816ff85f022cddc62eb"
 					]
 				}
 			}
@@ -60,7 +60,7 @@
 		{
 			"type": "parser",
 			"about": "#1 subobject check",
-			"subject": "Transclude-Template#_49c8abd563e00e4dcf6debf1d61b5408",
+			"subject": "Transclude-Template#_2d7f2b93bd6e9816ff85f022cddc62eb",
 			"assert-store": {
 				"semantic-data": {
 					"strictPropertyValueMatch": false,

--- a/tests/phpunit/Integration/JSONScript/TestCases/p-0210.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/p-0210.json
@@ -22,10 +22,10 @@
 			"subject": "Example/P0210/Q1",
 			"assert-output": {
 				"to-contain": [
-					"<td class=\"smwtype_wpg\">Example/P0210/1#_de6907a285b0c316fd3caa77a932d0ae</td><td class=\"Has-date smwtype_dat\" data-sort-value=\"2453767.5\">1 February 2006</td>",
-					"<td class=\"smwtype_wpg\">Example/P0210/1#_5c90cef15e8ecbb3662fe10e6cb50bb7</td><td class=\"Has-date smwtype_dat\" data-sort-value=\"2440618.5\">1 February 1970</td>",
-					"<td class=\"smwtype_wpg\">Example/P0210/1#_7582eb6443d1bd2f35114842dc700673</td><td class=\"Has-date smwtype_dat\" data-sort-value=\"2445001.5\">1 February 1982</td>",
-					"<td class=\"smwtype_wpg\">Example/P0210/1#_d9e81e6ceed8bc0ec8a92feeea25ca1a</td><td class=\"Has-date smwtype_dat\" data-sort-value=\"2449384.5\">1 February 1994</td>"
+					"<td class=\"smwtype_wpg\">Example/P0210/1#_6c0c58959b4717205b4c1b2c3b0e3e84</td><td class=\"Has-date smwtype_dat\" data-sort-value=\"2440618.5\">1 February 1970</td>",
+					"<td class=\"smwtype_wpg\">Example/P0210/1#_999d559e938eeaee07f5f52de53638e9</td><td class=\"Has-date smwtype_dat\" data-sort-value=\"2445001.5\">1 February 1982</td>",
+					"<td class=\"smwtype_wpg\">Example/P0210/1#_f42111f2b6af198c265ef2d8330b6a13</td><td class=\"Has-date smwtype_dat\" data-sort-value=\"2449384.5\">1 February 1994</td>",
+					"<td class=\"smwtype_wpg\">Example/P0210/1#_bdfba16fe62b82d1eadcb21054d8452b</td><td class=\"Has-date smwtype_dat\" data-sort-value=\"2453767.5\">1 February 2006</td>"
 				]
 			}
 		}

--- a/tests/phpunit/Integration/JSONScript/TestCases/p-0301.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/p-0301.json
@@ -15,7 +15,7 @@
 		{
 			"type": "parser",
 			"about": "#0 #subobject with category annotation",
-			"subject": "Example/0301/1#_033037fca2311e746bf1871d3be6984c",
+			"subject": "Example/0301/1#_04284bb237a62f6648c369d713da3996",
 			"assert-store": {
 				"semantic-data": {
 					"strictPropertyValueMatch": false,
@@ -43,7 +43,7 @@
 			},
 			"assert-queryresult": {
 				"results": [
-					"Example/0301/1#0##_033037fca2311e746bf1871d3be6984c"
+					"Example/0301/1#0##_04284bb237a62f6648c369d713da3996"
 				],
 				"count": "1"
 			}

--- a/tests/phpunit/Integration/JSONScript/TestCases/p-0303.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/p-0303.json
@@ -38,7 +38,7 @@
 		{
 			"type": "parser",
 			"about": "#1 values are trimmed (no leading spaces)",
-			"subject": "Example/P0303/1#_552ae60fadcc2e5dd609d118abcdbbbc",
+			"subject": "Example/P0303/1#_4cf77c0a97795d2717d53fa6165a0bf5",
 			"assert-store": {
 				"semantic-data": {
 					"strictPropertyValueMatch": false,

--- a/tests/phpunit/Integration/JSONScript/TestCases/p-0422.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/p-0422.json
@@ -77,9 +77,9 @@
 			"subject": "Example/P0422/Q/2/1",
 			"assert-output": {
 				"to-contain": [
-					"<tr data-row-number=\"1\" class=\"row-odd\"><td class=\"smwtype_wpg\">Example/P0422/2#_519df0ee370ade5d506e5dd769a14b26</td><td class=\"Has-date smwtype_dat\" data-sort-value=\"2321884.5\">1645</td></tr>",
-					"<tr data-row-number=\"2\" class=\"row-even\"><td class=\"smwtype_wpg\">Example/P0422/2#_a9167ae46aa815bb052650683c4719d6</td><td class=\"Has-date smwtype_dat\" data-sort-value=\"2423420.5\">January 1923</td></tr>",
-					"<tr data-row-number=\"3\" class=\"row-odd\"><td class=\"smwtype_wpg\">Example/P0422/2#_803b6de7d53ad0173871f4e4210ce477</td><td class=\"Has-date smwtype_dat\" data-sort-value=\"2436965.5\">February 1960</td></tr>"
+					"<tr data-row-number=\"1\" class=\"row-odd\"><td class=\"smwtype_wpg\">Example/P0422/2#_eda78f1641edf981597b59b79f9a8c1f</td><td class=\"Has-date smwtype_dat\" data-sort-value=\"2321884.5\">1645</td></tr>",
+					"<tr data-row-number=\"2\" class=\"row-even\"><td class=\"smwtype_wpg\">Example/P0422/2#_23b1a59a99dd05132dabb6cf45cb40b3</td><td class=\"Has-date smwtype_dat\" data-sort-value=\"2423420.5\">January 1923</td></tr>",
+					"<tr data-row-number=\"3\" class=\"row-odd\"><td class=\"smwtype_wpg\">Example/P0422/2#_f9a370d40ebd98e67c2b884fc09c7f9d</td><td class=\"Has-date smwtype_dat\" data-sort-value=\"2436965.5\">February 1960</td></tr>"
 				]
 			}
 		},
@@ -89,9 +89,9 @@
 			"subject": "Example/P0422/Q/2/2",
 			"assert-output": {
 				"to-contain": [
-					"<tr data-row-number=\"1\" class=\"row-odd\"><td class=\"smwtype_wpg\">Example/P0422/2#_803b6de7d53ad0173871f4e4210ce477</td><td class=\"Has-date smwtype_dat\" data-sort-value=\"2436965.5\">February 1960</td></tr>",
-					"<tr data-row-number=\"2\" class=\"row-even\"><td class=\"smwtype_wpg\">Example/P0422/2#_a9167ae46aa815bb052650683c4719d6</td><td class=\"Has-date smwtype_dat\" data-sort-value=\"2423420.5\">January 1923</td></tr>",
-					"<tr data-row-number=\"3\" class=\"row-odd\"><td class=\"smwtype_wpg\">Example/P0422/2#_519df0ee370ade5d506e5dd769a14b26</td><td class=\"Has-date smwtype_dat\" data-sort-value=\"2321884.5\">1645</td></tr>"
+					"<tr data-row-number=\"1\" class=\"row-odd\"><td class=\"smwtype_wpg\">Example/P0422/2#_f9a370d40ebd98e67c2b884fc09c7f9d</td><td class=\"Has-date smwtype_dat\" data-sort-value=\"2436965.5\">February 1960</td></tr>",
+					"<tr data-row-number=\"2\" class=\"row-even\"><td class=\"smwtype_wpg\">Example/P0422/2#_23b1a59a99dd05132dabb6cf45cb40b3</td><td class=\"Has-date smwtype_dat\" data-sort-value=\"2423420.5\">January 1923</td></tr>",
+					"<tr data-row-number=\"3\" class=\"row-odd\"><td class=\"smwtype_wpg\">Example/P0422/2#_eda78f1641edf981597b59b79f9a8c1f</td><td class=\"Has-date smwtype_dat\" data-sort-value=\"2321884.5\">1645</td></tr>"
 				]
 			}
 		},

--- a/tests/phpunit/Integration/JSONScript/TestCases/p-0427.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/p-0427.json
@@ -38,7 +38,7 @@
 		},
 		{
 			"page": "Example/P0427/Q1.3",
-			"contents": "{{#ask: [[Example/P0427/1#_46f241b02fda25aabd4d52b9b141d4e7]] |?Has text |link=none}}"
+			"contents": "{{#ask: [[Example/P0427/1#_7cae05fedd48fa820a0ea915518cc3fd]] |?Has text |link=none}}"
 		},
 		{
 			"page": "Example/P0427/Q1.4",
@@ -77,7 +77,7 @@
 			"subject": "Example/P0427/Q1.1",
 			"assert-output": {
 				"to-contain": [
-					"<td class=\"smwtype_wpg\">Example/P0427/1#_46f241b02fda25aabd4d52b9b141d4e7</td>",
+					"<td class=\"smwtype_wpg\">Example/P0427/1#_7cae05fedd48fa820a0ea915518cc3fd</td>",
 					"<td class=\"Has-text smwtype_txt\">abc</td>"
 				]
 			}
@@ -88,7 +88,7 @@
 			"subject": "Example/P0427/Q1.2",
 			"assert-output": {
 				"to-contain": [
-					"<td class=\"smwtype_wpg\">Example/P0427/1#_d0ff6c9a1d23b69a0ba5f6d737f6180a</td>",
+					"<td class=\"smwtype_wpg\">Example/P0427/1#_6840005f556d165faf53ecf39be9ee97</td>",
 					"<td class=\"Has-text smwtype_txt\">ABC</td>"
 				]
 			}
@@ -99,7 +99,7 @@
 			"subject": "Example/P0427/Q1.3",
 			"assert-output": {
 				"to-contain": [
-					"<td class=\"smwtype_wpg\">Example/P0427/1#_46f241b02fda25aabd4d52b9b141d4e7</td>",
+					"<td class=\"smwtype_wpg\">Example/P0427/1#_7cae05fedd48fa820a0ea915518cc3fd</td>",
 					"<td class=\"Has-text smwtype_txt\">abc</td>"
 				]
 			}
@@ -110,7 +110,7 @@
 			"subject": "Example/P0427/Q1.4",
 			"assert-output": {
 				"to-contain": [
-					"<td class=\"smwtype_wpg\">Example/P0427/1#_d0ff6c9a1d23b69a0ba5f6d737f6180a</td>",
+					"<td class=\"smwtype_wpg\">Example/P0427/1#_6840005f556d165faf53ecf39be9ee97</td>",
 					"<td class=\"Has-text smwtype_txt\">ABC</td>"
 				]
 			}
@@ -121,7 +121,7 @@
 			"subject": "Example/P0427/Q1.5",
 			"assert-output": {
 				"to-contain": [
-					"<td class=\"smwtype_wpg\">Example/P0427/1#_46f241b02fda25aabd4d52b9b141d4e7</td>",
+					"<td class=\"smwtype_wpg\">Example/P0427/1#_7cae05fedd48fa820a0ea915518cc3fd</td>",
 					"<td class=\"Has-text smwtype_txt\">abc</td>"
 				]
 			}

--- a/tests/phpunit/Integration/JSONScript/TestCases/p-0434.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/p-0434.json
@@ -141,8 +141,9 @@
 			"subject": "Example/P0434/Q4.1",
 			"assert-output": {
 				"to-contain": [
-					"<tr data-row-number=\"1\" class=\"row-odd\"><td class=\"smwtype_wpg\">Example/P0434/4#_fb1dd749d7117fe311c13da0f5088d88</td><td class=\"Date smwtype_dat\" data-sort-value=\"2415020.5\">1 January 1900</td>",
-					"<tr data-row-number=\"2\" class=\"row-even\"><td class=\"smwtype_wpg\">Example/P0434/4#_c7fd595ef59775763dd517dc39dc27a1</td><td class=\"Date smwtype_dat\" data-sort-value=\"2451179.5\">1 January 1999</td>"
+					"<tr data-row-number=\"1\" class=\"row-odd\"><td class=\"smwtype_wpg\">Example/P0434/4#_357f4a06073b86afc07cb0c6237b9f36</td><td class=\"Date smwtype_dat\" data-sort-value=\"2415020.5\">1 January 1900</td></tr>",
+					"<tr data-row-number=\"2\" class=\"row-even\"><td class=\"smwtype_wpg\">Example/P0434/4#_eb1c9a9f3a8ad677d7424e8d842b10dd</td><td class=\"Date smwtype_dat\" data-sort-value=\"2451179.5\">1 January 1999</td></tr>",
+					"<tr data-row-number=\"3\" class=\"row-odd\"><td class=\"smwtype_wpg\">Example/P0434/4#_4bae31c0cd5bda46c3cf0245523a954a</td><td class=\"Date smwtype_dat\" data-sort-value=\"2451544.5\">1 January 2000</td></tr>"
 				]
 			}
 		},
@@ -152,8 +153,9 @@
 			"subject": "Example/P0434/Q4.2",
 			"assert-output": {
 				"to-contain": [
-					"<tr data-row-number=\"1\" class=\"row-odd\"><td class=\"smwtype_wpg\">Example/P0434/4#_b839bc3327e104d1aad75903fbc5a278</td><td class=\"Date smwtype_dat\" data-sort-value=\"2451544.5\">1 January 2000</td>",
-					"<tr data-row-number=\"2\" class=\"row-even\"><td class=\"smwtype_wpg\">Example/P0434/4#_c7fd595ef59775763dd517dc39dc27a1</td><td class=\"Date smwtype_dat\" data-sort-value=\"2451179.5\">1 January 1999</td>"
+					"<tr data-row-number=\"1\" class=\"row-odd\"><td class=\"smwtype_wpg\">Example/P0434/4#_4bae31c0cd5bda46c3cf0245523a954a</td><td class=\"Date smwtype_dat\" data-sort-value=\"2451544.5\">1 January 2000</td></tr>",
+					"<tr data-row-number=\"2\" class=\"row-even\"><td class=\"smwtype_wpg\">Example/P0434/4#_eb1c9a9f3a8ad677d7424e8d842b10dd</td><td class=\"Date smwtype_dat\" data-sort-value=\"2451179.5\">1 January 1999</td></tr>",
+					"<tr data-row-number=\"3\" class=\"row-odd\"><td class=\"smwtype_wpg\">Example/P0434/4#_357f4a06073b86afc07cb0c6237b9f36</td><td class=\"Date smwtype_dat\" data-sort-value=\"2415020.5\">1 January 1900</td></tr>"
 				]
 			}
 		},
@@ -163,8 +165,9 @@
 			"subject": "Example/P0434/Q4.3",
 			"assert-output": {
 				"to-contain": [
-					"<tr data-row-number=\"1\" class=\"row-odd\"><td class=\"smwtype_wpg\">Example/P0434/4#_fb1dd749d7117fe311c13da0f5088d88</td><td class=\"Date smwtype_dat\" data-sort-value=\"2415020.5\">1 January 1900</td></tr>",
-					"<tr data-row-number=\"2\" class=\"row-even\"><td class=\"smwtype_wpg\">Example/P0434/4#_c7fd595ef59775763dd517dc39dc27a1</td><td class=\"Date smwtype_dat\" data-sort-value=\"2451179.5\">1 January 1999</td></tr>"
+					"<tr data-row-number=\"1\" class=\"row-odd\"><td class=\"smwtype_wpg\">Example/P0434/4#_357f4a06073b86afc07cb0c6237b9f36</td><td class=\"Date smwtype_dat\" data-sort-value=\"2415020.5\">1 January 1900</td></tr>",
+					"<tr data-row-number=\"2\" class=\"row-even\"><td class=\"smwtype_wpg\">Example/P0434/4#_eb1c9a9f3a8ad677d7424e8d842b10dd</td><td class=\"Date smwtype_dat\" data-sort-value=\"2451179.5\">1 January 1999</td></tr>",
+					"<tr data-row-number=\"3\" class=\"row-odd\"><td class=\"smwtype_wpg\">Example/P0434/4#_4bae31c0cd5bda46c3cf0245523a954a</td><td class=\"Date smwtype_dat\" data-sort-value=\"2451544.5\">1 January 2000</td></tr>"
 				]
 			}
 		},
@@ -174,8 +177,9 @@
 			"subject": "Example/P0434/Q4.4",
 			"assert-output": {
 				"to-contain": [
-					"<tr data-row-number=\"1\" class=\"row-odd\"><td class=\"smwtype_wpg\">Example/P0434/4#_b839bc3327e104d1aad75903fbc5a278</td><td class=\"Date smwtype_dat\" data-sort-value=\"2451544.5\">1 January 2000</td>",
-					"<tr data-row-number=\"2\" class=\"row-even\"><td class=\"smwtype_wpg\">Example/P0434/4#_c7fd595ef59775763dd517dc39dc27a1</td><td class=\"Date smwtype_dat\" data-sort-value=\"2451179.5\">1 January 1999</td>"
+					"<tr data-row-number=\"1\" class=\"row-odd\"><td class=\"smwtype_wpg\">Example/P0434/4#_4bae31c0cd5bda46c3cf0245523a954a</td><td class=\"Date smwtype_dat\" data-sort-value=\"2451544.5\">1 January 2000</td></tr>",
+					"<tr data-row-number=\"2\" class=\"row-even\"><td class=\"smwtype_wpg\">Example/P0434/4#_eb1c9a9f3a8ad677d7424e8d842b10dd</td><td class=\"Date smwtype_dat\" data-sort-value=\"2451179.5\">1 January 1999</td></tr>",
+					"<tr data-row-number=\"3\" class=\"row-odd\"><td class=\"smwtype_wpg\">Example/P0434/4#_357f4a06073b86afc07cb0c6237b9f36</td><td class=\"Date smwtype_dat\" data-sort-value=\"2415020.5\">1 January 1900</td></tr>"
 				]
 			}
 		}

--- a/tests/phpunit/Integration/JSONScript/TestCases/q-0104.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/q-0104.json
@@ -179,7 +179,7 @@
 				"count": 2,
 				"results": [
 					"Example/Q0104/4#0##_5a524a435267f6e6d2d45d64a419c1da",
-					"Example/Q0104/4#0##_d4fe48d7241e6530c628f32168815beb"
+					"Example/Q0104/4#0##_9f7e6f010523ae7a6d1639d40773e379"
 				]
 			}
 		},
@@ -195,7 +195,7 @@
 				"count": 2,
 				"results": [
 					"Example/Q0104/4#0##_5a524a435267f6e6d2d45d64a419c1da",
-					"Example/Q0104/4#0##_d4fe48d7241e6530c628f32168815beb"
+					"Example/Q0104/4#0##_9f7e6f010523ae7a6d1639d40773e379"
 				]
 			}
 		},
@@ -210,7 +210,7 @@
 			"assert-queryresult": {
 				"count": 1,
 				"results": [
-					"Example/Q0104/4#0##_d4fe48d7241e6530c628f32168815beb"
+					"Example/Q0104/4#0##_9f7e6f010523ae7a6d1639d40773e379"
 				]
 			}
 		},

--- a/tests/phpunit/Integration/JSONScript/TestCases/q-0105.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/q-0105.json
@@ -178,7 +178,7 @@
 			"assert-queryresult": {
 				"count": 2,
 				"results": [
-					"Example/Q0105/4#0##_c77b6e54b1b4d59500b7d4232b30a0fb",
+					"Example/Q0105/4#0##_9f1222a5f6669be2c5f76dd5af08a4dc",
 					"Example/Q0105/4#0##_b827401b701c08c3c3d610a3a43d18c3"
 				]
 			}
@@ -194,7 +194,7 @@
 			"assert-queryresult": {
 				"count": 2,
 				"results": [
-					"Example/Q0105/4#0##_c77b6e54b1b4d59500b7d4232b30a0fb",
+					"Example/Q0105/4#0##_9f1222a5f6669be2c5f76dd5af08a4dc",
 					"Example/Q0105/4#0##_b827401b701c08c3c3d610a3a43d18c3"
 				]
 			}
@@ -210,7 +210,7 @@
 			"assert-queryresult": {
 				"count": 1,
 				"results": [
-					"Example/Q0105/4#0##_c77b6e54b1b4d59500b7d4232b30a0fb"
+					"Example/Q0105/4#0##_9f1222a5f6669be2c5f76dd5af08a4dc"
 				]
 			}
 		},

--- a/tests/phpunit/Integration/JSONScript/TestCases/q-0602.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/q-0602.json
@@ -28,9 +28,9 @@
 			"assert-queryresult": {
 				"count": "3",
 				"results": [
-					"Page-with-subobject#0##_5ca349b39ebfdc3ca49b0eda4c934a45",
-					"Page-with-subobject#0##_f4469f99af0cf02670841cd93634f947",
-					"Page-with-subobject#0##_2d984853884c90ed45d980772e1d2163"
+					"Page-with-subobject#0##_7aa07758037723bb0d3522a1a151771f",
+					"Page-with-subobject#0##_cd630d70e4e469611f361bcda9cf919a",
+					"Page-with-subobject#0##_38a501d710af2a3167121d6282e64fe6"
 				]
 			}
 		}

--- a/tests/phpunit/Integration/JSONScript/TestCases/q-0908.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/q-0908.json
@@ -46,7 +46,7 @@
 				"count": 2,
 				"results": [
 					"Example/Q0908/1#0##",
-					"Example/Q0908/1#0##_7a94494466265fb10b60311ce51a94c4"
+					"Example/Q0908/1#0##_fddfd44d1be8e8a7f3ea5f4893df9963"
 				]
 			}
 		},
@@ -62,7 +62,7 @@
 				"count": 2,
 				"results": [
 					"Example/Q0908/0#0##",
-					"Example/Q0908/0#0##_c9c37230f08043b1f7244ac8255daeea"
+					"Example/Q0908/0#0##_34013e9e1a62a2138034ac5287a7cf0e"
 				]
 			}
 		},
@@ -78,7 +78,7 @@
 				"count": 2,
 				"results": [
 					"Example/Q0908/2#0##",
-					"Example/Q0908/2#0##_1a3b9a0c0f0ab867f34b3ff0ff5c306d"
+					"Example/Q0908/2#0##_52d6bd41c1e8946f754f9687b88ded4c"
 				]
 			}
 		},
@@ -94,7 +94,7 @@
 				"count": 2,
 				"results": [
 					"Example/Q0908/2#0##",
-					"Example/Q0908/2#0##_1a3b9a0c0f0ab867f34b3ff0ff5c306d"
+					"Example/Q0908/2#0##_52d6bd41c1e8946f754f9687b88ded4c"
 				]
 			}
 		},
@@ -110,7 +110,7 @@
 				"count": 2,
 				"results": [
 					"Example/Q0908/0#0##",
-					"Example/Q0908/0#0##_c9c37230f08043b1f7244ac8255daeea"
+					"Example/Q0908/0#0##_34013e9e1a62a2138034ac5287a7cf0e"
 				]
 			}
 		},
@@ -132,7 +132,7 @@
 				"count": 2,
 				"results": [
 					"Example/Q0908/3#0#",
-					"Example/Q0908/3#0##_e129319fa43ae1aa35ef6ffd91d323ed"
+					"Example/Q0908/3#0##_bc98426861e347260e7aa56265803598"
 				]
 			}
 		},
@@ -148,7 +148,7 @@
 				"count": 2,
 				"results": [
 					"Example/Q0908/3#0#",
-					"Example/Q0908/3#0##_e129319fa43ae1aa35ef6ffd91d323ed"
+					"Example/Q0908/3#0##_bc98426861e347260e7aa56265803598"
 				]
 			}
 		},
@@ -164,7 +164,7 @@
 				"count": 2,
 				"results": [
 					"Example/Q0908/0#0##",
-					"Example/Q0908/0#0##_c9c37230f08043b1f7244ac8255daeea"
+					"Example/Q0908/0#0##_34013e9e1a62a2138034ac5287a7cf0e"
 				]
 			}
 		}

--- a/tests/phpunit/Integration/JSONScript/TestCases/q-1106.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/q-1106.json
@@ -66,7 +66,7 @@
 				"count": 2,
 				"results": [
 					"Example/Q1106/1#0##",
-					"Example/Q1106/3#0##_a0cd8b51f1e768606a47a2d4ec9bd867"
+					"Example/Q1106/3#0##_5005bc588cbc65273b9c8d9b96bf5c01"
 				]
 			}
 		},
@@ -98,7 +98,7 @@
 				"results": [
 					"Example/Q1106/1#0##",
 					"Example/Q1106/2#0##",
-					"Example/Q1106/3#0##_a0cd8b51f1e768606a47a2d4ec9bd867"
+					"Example/Q1106/3#0##_5005bc588cbc65273b9c8d9b96bf5c01"
 				]
 			}
 		}

--- a/tests/phpunit/Integration/JSONScript/TestCases/r-0001.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/r-0001.json
@@ -100,9 +100,9 @@
 			"assert-output": {
 				"to-contain": [
 					"<swivt:Subject rdf:about=\"http://example.org/id/Rdf-2D3\">",
-					"<property:Has_subobject-23aux rdf:resource=\"&wiki;Rdf-2D3-23_352994736fdd9b50f3506c054ce554ab\"/>",
+					"<property:Has_subobject-23aux rdf:resource=\"&wiki;Rdf-2D3-23_c14ce3099ebd07ab500052b8c661832f\"/>",
 					"<property:Has_subobject-23aux rdf:resource=\"&wiki;Rdf-2D3-23Caract-C3-A8res_sp-C3-A9ciaux\"/>",
-					"<swivt:Subject rdf:about=\"http://example.org/id/Rdf-2D3-23_352994736fdd9b50f3506c054ce554ab\">",
+					"<swivt:Subject rdf:about=\"http://example.org/id/Rdf-2D3-23_c14ce3099ebd07ab500052b8c661832f\">",
 					"<property:Has_page_property_for_rdf rdf:resource=\"&wiki;I-2D-2D11-2D-2DO\"/>",
 					"<swivt:Subject rdf:about=\"http://example.org/id/Rdf-2D3-23Caract-C3-A8res_sp-C3-A9ciaux\">",
 					"<property:Has_text_property_for_rdf rdf:datatype=\"http://www.w3.org/2001/XMLSchema#string\">{({[[&amp;,,;-]]})}</property:Has_text_property_for_rdf>",

--- a/tests/phpunit/Integration/MediaWiki/Import/Maintenance/DumpRdfMaintenanceTest.php
+++ b/tests/phpunit/Integration/MediaWiki/Import/Maintenance/DumpRdfMaintenanceTest.php
@@ -121,7 +121,7 @@ class DumpRdfMaintenanceTest extends MwDBaseUnitTestCase {
 		$expectedOutputContent = array(
 			'<rdfs:label>Lorem ipsum</rdfs:label>',
 			'<swivt:masterPage rdf:resource="&wiki;Lorem_ipsum"/>',
-			'<property:Has_subobject-23aux rdf:resource="&wiki;Lorem_ipsum-23_017ced50ca5208f4cc77f90c43a0d4a9"/>',
+			'<property:Has_subobject-23aux rdf:resource="&wiki;Lorem_ipsum-23_b704f46f7acbb89982564cc97d8e9019"/>',
 			'<swivt:wikiPageSortKey rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Lorem ipsum</swivt:wikiPageSortKey>'
 		);
 

--- a/tests/phpunit/Unit/ParserFunctions/SubobjectParserFunctionTest.php
+++ b/tests/phpunit/Unit/ParserFunctions/SubobjectParserFunctionTest.php
@@ -157,6 +157,82 @@ class SubobjectParserFunctionTest extends \PHPUnit_Framework_TestCase {
 		);
 	}
 
+	public function testParametersOnBeingSorted() {
+
+		$parameters = [
+			'Foo=Foobar, Bar',
+			'+sep=,'
+		];
+
+		$subobject = new Subobject( Title::newFromText( __METHOD__ ) );
+
+		$instance = $this->acquireInstance( $subobject );
+
+		$instance->isComparableContent(
+			true
+		);
+
+		$instance->parse(
+			new ParserParameterFormatter( $parameters )
+		);
+
+		$this->assertEquals(
+			'_c0bea380739b21578cdcf28ed5d4cfd3',
+			$subobject->getSubobjectId()
+		);
+	}
+
+	public function testParametersOnBeingSortedWithRevertedValueOrderProducesSameHash() {
+
+		$parameters = [
+			'Foo=Bar, Foobar',
+			'+sep=,'
+		];
+
+		$subobject = new Subobject( Title::newFromText( __METHOD__ ) );
+
+		$instance = $this->acquireInstance( $subobject );
+
+		$instance->isComparableContent(
+			true
+		);
+
+		$instance->parse(
+			new ParserParameterFormatter( $parameters )
+		);
+
+		$this->assertEquals(
+			'_c0bea380739b21578cdcf28ed5d4cfd3',
+			$subobject->getSubobjectId()
+		);
+	}
+
+	public function testParametersIsNotSorted() {
+
+		$parameters = [
+			'Foo=Foobar, Bar',
+			'+sep=,'
+		];
+
+		$subobject = new Subobject( Title::newFromText( __METHOD__ ) );
+
+		$instance = $this->acquireInstance( $subobject );
+
+		$instance->isComparableContent(
+			false
+		);
+
+		$instance->parse(
+			new ParserParameterFormatter( $parameters )
+		);
+
+		// Expected to be stable for PHP and HHVM as well
+		$this->assertEquals(
+			'_ec7323184d89fe1409b5cfaf09950a95',
+			$subobject->getSubobjectId()
+		);
+	}
+
 	public function testCreateSameIdForNormalizedParametersWithEnabledCapitalLinks() {
 
 		$title = Title::newFromText( __METHOD__ );
@@ -177,7 +253,7 @@ class SubobjectParserFunctionTest extends \PHPUnit_Framework_TestCase {
 
 		$instance = $this->acquireInstance( $subobject );
 
-		$instance->enabledNormalization();
+		$instance->isComparableContent( true );
 		$instance->isCapitalLinks( true );
 
 		$instance->parse(

--- a/tests/phpunit/Unit/ParserParameterProcessorTest.php
+++ b/tests/phpunit/Unit/ParserParameterProcessorTest.php
@@ -97,6 +97,41 @@ class ParserParameterProcessorTest extends \PHPUnit_Framework_TestCase {
 		);
 	}
 
+	public function testSort() {
+
+		$a = [
+			'Has test 3=One,Two,Three',
+			'+sep',
+			'Has test 4=Four'
+		];
+
+		$instance = new ParserParameterProcessor(
+			$a
+		);
+
+		$paramsA = $instance->toArray();
+		$instance->sort( $paramsA );
+
+		$b = [
+			'Has test 4=Four',
+			'Has test 3=Two,Three,One',
+			'+sep',
+		];
+
+		$instance = new ParserParameterProcessor(
+			$b
+		);
+
+		$paramsB = $instance->toArray();
+
+		$instance->sort( $paramsB );
+
+		$this->assertEquals(
+			$paramsA,
+			$paramsB
+		);
+	}
+
 	/**
 	 * @dataProvider parametersDataProvider
 	 */

--- a/tests/phpunit/Unit/SiteTest.php
+++ b/tests/phpunit/Unit/SiteTest.php
@@ -31,6 +31,14 @@ class SiteTest extends \PHPUnit_Framework_TestCase {
 		);
 	}
 
+	public function testIsCapitalLinks() {
+
+		$this->assertInternalType(
+			'boolean',
+			Site::isCapitalLinks()
+		);
+	}
+
 	public function testGetJobClasses() {
 
 		$this->assertInternalType(


### PR DESCRIPTION
This PR is made in reference to: #2723 

This PR addresses or contains:

- Adds `$smwgUseComparableContentHash` as setting to help those who need more time for a migration but the default is `true` which means that it uses an internal sorting to ensure a comparable  hash when creating the subobject ID
-  `$smwgUseComparableContentHash` will be removed with 3.1, the setting is only introduced to ease migration
- This ticket is only related to anonymous subobjects 
- Content arguments are only internally sorted that are used for the hash, the content itself remains in the order of the input

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed

Fixes #2723 