### PR TITLE
Add text input assistance, refs 2725

### DIFF
--- a/i18n/en.json
+++ b/i18n/en.json
@@ -377,6 +377,7 @@
 	"smw-prefs-ask-options-collapsed-default": "Enable option box to be collapsed by default",
 	"smw-prefs-general-options-time-correction": "Enable time correction for special pages using the local [[Special:Preferences#mw-prefsection-rendering|time offset]] preference",
 	"smw-prefs-general-options-disable-editpage-info": "Disable the introductory text on the edit page",
+	"smw-prefs-general-options-suggester-textinput": "Enable input assistance for semantic entity suggestions",
 	"smw-ui-tooltip-title-property": "Property",
 	"smw-ui-tooltip-title-quantity": "Unit conversion",
 	"smw-ui-tooltip-title-info": "Information",

--- a/res/Resources.php
+++ b/res/Resources.php
@@ -266,11 +266,24 @@ return array(
 	),
 
 	'ext.smw.suggester' => $moduleTemplate + array(
-		'scripts' => 'smw/util/ext.smw.util.suggester.js',
+		'scripts' => 'smw/suggester/ext.smw.suggester.js',
 		'position' => 'top',
 		'dependencies' => array(
 			'ext.smw',
 			'ext.jquery.atwho'
+		),
+		'targets' => array(
+			'mobile',
+			'desktop'
+		)
+	),
+
+	'ext.smw.suggester.textInput' => $moduleTemplate + array(
+		'scripts' => 'smw/suggester/ext.smw.suggester.textInput.js',
+		'position' => 'top',
+		'dependencies' => array(
+			'ext.smw',
+			'ext.smw.suggester'
 		),
 		'targets' => array(
 			'mobile',

--- a/res/smw/suggester/ext.smw.suggester.js
+++ b/res/smw/suggester/ext.smw.suggester.js
@@ -27,13 +27,10 @@
 	'use strict';
 
 	/**
-	 * Inheritance class for the smw.util constructor
-	 *
 	 * @since 3.0
 	 * @class
 	 */
-	smw.util = smw.util || {};
-	smw.util.suggester = smw.util.suggester || {};
+	smw.suggester = smw.suggester || {};
 
 	/**
 	 * Class constructor
@@ -43,7 +40,7 @@
 	 * @class
 	 * @constructor
 	 */
-	smw.util.suggester = function ( context ) {
+	smw.suggester = function ( context ) {
 
 		var localizedName = mw.config.get( 'smw-config' ).namespaces.localizedName;
 		this.context = context;
@@ -234,11 +231,11 @@
 	 */
 	var Factory = {
 		newSearchSuggester: function( $context ) {
-			return new smw.util.suggester( $context );
+			return new smw.suggester( $context );
 		}
 	};
 
-	smw.util.suggester.prototype = fn;
+	smw.suggester.prototype = fn;
 
 	smw.Factory = smw.Factory || {};
 	smw.Factory = $.extend( smw.Factory, Factory );

--- a/res/smw/suggester/ext.smw.suggester.textInput.js
+++ b/res/smw/suggester/ext.smw.suggester.textInput.js
@@ -1,0 +1,159 @@
+/*!
+ * This file is part of the Semantic MediaWiki
+ *
+ * @section LICENSE
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ * http://www.gnu.org/copyleft/gpl.html
+ *
+ * @license GNU GPL v2+
+ * @since  3.0
+ *
+ * @author mwjames
+ */
+( function( $, mw, smw ) {
+	'use strict';
+
+	/**
+	 * Simple semantic links autocompleter.
+	 *
+	 * Only when the registered marker are used will the search be activated
+	 * to avoid arbitrary matches for non-semantic content.
+	 */
+	mw.loader.using( [ 'ext.smw.suggester' ], function() {
+
+		/**
+		 * Support text input on Special:Search
+		 *
+		 * @since 3.0
+		 */
+		var search = function() {
+
+			var context = $( '#searchText > input' );
+
+			if ( context.length ) {
+				smw.log( 'autocomplete.Input: search field registration' );
+
+				// This features is only enabled for SMWSearch hence when the input
+				// field contains [[ ... ]] we assume a search via the QueryEngine
+				// therefore disable the highlighlter as no meaningfull input help
+				// will be shown
+				context.on( 'keyup keypres focus', function( e ) {
+					var highlighter = context.parent().find( '.oo-ui-widget' );
+
+					if ( context.val().indexOf( '[' ) > -1 ) {
+						highlighter.hide();
+					} else {
+						highlighter.show();
+					};
+				} );
+
+				var searchSuggester = smw.Factory.newSearchSuggester(
+					context
+				);
+
+				// Register autocomplete default tokens
+				searchSuggester.registerDefaultTokenList(
+					[
+						'property',
+						'concept',
+						'category'
+					]
+				);
+			};
+		};
+
+		/**
+		 * Support text input on the wikiEditor textbox
+		 *
+		 * @since 3.0
+		 */
+		var wikiEditor = function() {
+
+			var wpTextbox1 = $( '#wpTextbox1' );
+
+			// Attach to the textarea
+			if ( wpTextbox1.length ) {
+				smw.log( 'autocomplete.Input: textbox1 field registration' );
+
+				var searchSuggester = smw.Factory.newSearchSuggester(
+					wpTextbox1
+				);
+
+				// Register autocomplete default tokens
+				searchSuggester.registerDefaultTokenList(
+					[
+						'property',
+						'concept',
+						'category'
+					]
+				);
+
+				// Register additional definition since the editing can involve
+				// different patterns
+
+				// Used in combination with printouts as in:
+				//
+				// {{#ask: ..
+				//  |?p: ...
+				// }}
+				searchSuggester.registerTokenDefinition(
+					'property',
+					{
+						token: '?p:',
+						beforeInsert: function( token, value ) {
+							return value.replace( 'p:', '' );
+						}
+					}
+				);
+
+				// Used in combination with #set and #subobject as in:
+				//
+				// {{#set:
+				//  |p: ...
+				// }}
+				searchSuggester.registerTokenDefinition(
+					'property',
+					{
+						token: '|p:',
+						beforeInsert: function( token, value ) {
+							return value.replace( 'p:', '' ) + '=';
+						}
+					}
+				);
+			};
+		};
+
+		function load( callback ) {
+			if ( document.readyState == 'complete' ) {
+				callback();
+			} else {
+				window.addEventListener( 'load', callback );
+			}
+		}
+
+		// Only load when it is Special:Search and the search type supports
+		// https://www.semantic-mediawiki.org/wiki/Help:SMWSearch
+		if ( mw.config.get( 'wgCanonicalSpecialPageName' ) == 'Search' && mw.config.get( 'wgSearchType' ) == 'SMWSearch' ) {
+			load( search );
+		};
+
+		var wgAction = mw.config.get( 'wgAction' );
+
+		if ( ( wgAction == 'edit' || wgAction == 'submit' ) && mw.config.get( 'wgPageContentModel' ) == 'wikitext'  ) {
+			load( wikiEditor );
+		};
+	} );
+
+} )( jQuery, mediaWiki, semanticMediaWiki );

--- a/src/MediaWiki/Hooks/BeforePageDisplay.php
+++ b/src/MediaWiki/Hooks/BeforePageDisplay.php
@@ -44,6 +44,19 @@ class BeforePageDisplay {
 	}
 
 	/**
+	 * @since 3.0
+	 *
+	 * @param array $modules
+	 */
+	public function registerModules( $modules ) {
+		foreach ( $modules as $name => $enabled ) {
+			if ( $enabled ) {
+				$this->outputPage->addModules( $name );
+			};
+		}
+	}
+
+	/**
 	 * @since 1.9
 	 *
 	 * @return boolean
@@ -53,9 +66,11 @@ class BeforePageDisplay {
 		$title = $this->outputPage->getTitle();
 
 		// MW 1.26 / T107399 / Async RL causes style delay
-		$this->outputPage->addModuleStyles( array(
-			'ext.smw.style',
-			'ext.smw.tooltip.styles' )
+		$this->outputPage->addModuleStyles(
+			[
+				'ext.smw.style',
+				'ext.smw.tooltip.styles'
+			]
 		);
 
 		// Add style resources to avoid unstyled content

--- a/src/MediaWiki/Hooks/GetPreferences.php
+++ b/src/MediaWiki/Hooks/GetPreferences.php
@@ -82,6 +82,13 @@ class GetPreferences extends HookHandler {
 			'disabled' => !$this->enabledEditPageHelp
 		);
 
+		// Option to enable input assistance
+		$preferences['smw-prefs-general-options-suggester-textinput'] = array(
+			'type' => 'toggle',
+			'label-message' => 'smw-prefs-general-options-suggester-textinput',
+			'section' => 'smw/general-options',
+		);
+
 		// Option to enable tooltip info
 		$preferences['smw-prefs-ask-options-tooltip-display'] = array(
 			'type' => 'toggle',

--- a/src/MediaWiki/Hooks/HookRegistry.php
+++ b/src/MediaWiki/Hooks/HookRegistry.php
@@ -213,6 +213,12 @@ class HookRegistry {
 				$skin
 			);
 
+			$beforePageDisplay->registerModules(
+				[
+					'ext.smw.suggester.textInput' => $outputPage->getUser()->getOption( 'smw-prefs-general-options-suggester-textinput' )
+				]
+			);
+
 			return $beforePageDisplay->process();
 		};
 

--- a/tests/phpunit/Unit/MediaWiki/Hooks/BeforePageDisplayTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Hooks/BeforePageDisplayTest.php
@@ -34,6 +34,32 @@ class BeforePageDisplayTest extends \PHPUnit_Framework_TestCase {
 		);
 	}
 
+	public function testRegisterModules() {
+
+		$outputPage = $this->getMockBuilder( '\OutputPage' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$outputPage->expects( $this->once() )
+			->method( 'addModules' );
+
+		$skin = $this->getMockBuilder( '\Skin' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$instance = new BeforePageDisplay(
+			$outputPage,
+			$skin
+		);
+
+		$instance->registerModules(
+			[
+				'Foo' => true,
+				'Bar' => false
+			]
+		);
+	}
+
 	/**
 	 * @dataProvider titleDataProvider
 	 */

--- a/tests/phpunit/Unit/MediaWiki/Hooks/HookRegistryTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Hooks/HookRegistryTest.php
@@ -31,6 +31,10 @@ class HookRegistryTest extends \PHPUnit_Framework_TestCase {
 
 		$this->testEnvironment = new TestEnvironment();
 
+		$user = $this->getMockBuilder( '\User' )
+			->disableOriginalConstructor()
+			->getMock();
+
 		$this->parser = $this->getMockBuilder( '\Parser' )
 			->disableOriginalConstructor()
 			->getMock();
@@ -46,6 +50,10 @@ class HookRegistryTest extends \PHPUnit_Framework_TestCase {
 		$this->outputPage = $this->getMockBuilder( '\OutputPage' )
 			->disableOriginalConstructor()
 			->getMock();
+
+		$this->outputPage->expects( $this->any() )
+			->method( 'getUser' )
+			->will( $this->returnValue( $user ) );
 
 		$webRequest = $this->getMockBuilder( '\WebRequest' )
 			->disableOriginalConstructor()


### PR DESCRIPTION
This PR is made in reference to: #2725

This PR addresses or contains:

- Building on the works of #2699, we are able to offer a very simple input assistance where entities can be searched and suggested using one of the predefined tokens (`[[p:`, `[[c:`, and `[[con:`) to support the editing process (using the standard wikiEditor)
- If <code>$wgSearchType = 'SMWSearch';</code> is enabled, input assistance is available as well
- The function is __not__ enabled by default and each user has to set the appropriate user preference 

![textwithinputassistance](https://user-images.githubusercontent.com/1245473/31049862-bfb28876-a677-11e7-941a-b25d84c70f7e.gif)

![image](https://user-images.githubusercontent.com/1245473/31049914-dfc93136-a678-11e7-8e7c-6897c39d7078.png)

![image](https://user-images.githubusercontent.com/1245473/31049953-d1a80338-a679-11e7-9f7a-71813bddda91.png)

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed

Fixes #