### PR TITLE
Move param processing from QueryProcessor to ParamListProcessor

### DIFF
--- a/src/Query/PrintRequestFactory.php
+++ b/src/Query/PrintRequestFactory.php
@@ -50,4 +50,16 @@ class PrintRequestFactory {
 		return PrintRequest::newFromText( $text, $showMode );
 	}
 
+	/**
+	 * @since 3.0
+	 *
+	 * @param string $label
+	 * @param array $parameters
+	 *
+	 * @return PrintRequest
+	 */
+	public function newThisPrintRequest( $label = '', array $parameters = [] ) {
+		return new PrintRequest( PrintRequest::PRINT_THIS, $label, null, false, $parameters );
+	}
+
 }

--- a/src/Query/Processor/ParamListProcessor.php
+++ b/src/Query/Processor/ParamListProcessor.php
@@ -1,0 +1,227 @@
+<?php
+
+namespace SMW\Query\Processor;
+
+use SMW\Query\PrintRequestFactory;
+
+/**
+ * @private
+ *
+ * @license GNU GPL v2+
+ * @since 3.0
+ *
+ * @author mwjames
+ */
+class ParamListProcessor {
+
+	/**
+	 * Identify the PrintThis instance
+	 */
+	const PRINT_THIS = 'print.this';
+
+	/**
+	 * @var PrintRequestFactory
+	 */
+	private $printRequestFactory;
+
+	/**
+	 * @since 3.0
+	 *
+	 * @param PrintRequestFactory|null $printRequestFactory
+	 */
+	public function __construct( PrintRequestFactory $printRequestFactory = null ) {
+		$this->printRequestFactory = $printRequestFactory;
+
+		if ( $this->printRequestFactory === null ) {
+			$this->printRequestFactory = new PrintRequestFactory();
+		}
+	}
+
+	/**
+	 * @since 3.0
+	 *
+	 * @param array $paramList
+	 *
+	 * @return array
+	 */
+	public function getLegacyArray( array $paramList ) {
+
+		$printouts = [];
+
+		foreach ( $paramList['printouts'] as $k => $request ) {
+
+			if ( !isset( $request['label'] ) ) {
+				continue;
+			}
+
+			$printRequest = $this->printRequestFactory->newPrintRequestFromText(
+				$request['label'],
+				$paramList['showMode']
+			);
+
+			if ( $printRequest === null ) {
+				continue;
+			}
+
+			foreach ( $request['params'] as $key => $value ) {
+				$printRequest->setParameter( $key, $value );
+			}
+
+			$printouts[] = $printRequest;
+		}
+
+		return [
+			$paramList['query'],
+			$paramList['parameters'],
+			$printouts
+		];
+	}
+
+	/**
+	 * @since 3.0
+	 *
+	 * @param array $parameters
+	 * @param boolean $showMode
+	 *
+	 * @return array
+	 */
+	public function preprocess( array $parameters, $showMode = false ) {
+
+		$previousPrintout = null;
+
+		$serialization = [
+			'showMode'   => $showMode,
+			'query'      => '',
+			'this'       => [],
+			'printouts'  => [],
+			'parameters' => []
+		];
+
+		foreach ( $parameters as $name => $param ) {
+
+			// special handling for arrays - this can happen if the
+			// parameter came from a checkboxes input in Special:Ask:
+			if ( is_array( $param ) ) {
+				$param = implode( ',', array_keys( $param ) );
+			}
+
+			$param = $this->encodeEq( $param );
+
+			// #1258 (named_args -> named args)
+			// accept 'name' => 'value' just as '' => 'name=value':
+			if ( is_string( $name ) && ( $name !== '' ) ) {
+				$param = str_replace( "_", " ", $name ) . '=' . $param;
+			}
+
+			// Find out whether this is a mainlabel, and if so store related
+			// parameters separate since QueryProcessor::addThisPrintout is
+			// added in isolation !!??!!
+			// $isMainlabel = strpos( $param, 'mainlabel=' ) !== false;
+
+			// mainlable=Foo |+with=200 ... is currently not support
+			// use
+			// |?=Foo |+width=200 ...
+			// |mainlabel=-
+			$isMainlabel = false;
+
+			if ( $param === '' ) {
+			} elseif ( $isMainlabel ) {
+				$this->addThisPrintRequest( $name, $param, $previousPrintout, $serialization );
+			} elseif ( $param[0] == '?' ) {
+				$this->addPrintRequest( $name, $param, $previousPrintout, $serialization );
+			} elseif ( $param[0] == '+' ) {
+				$this->addPrintRequestParameter( $name, $param, $previousPrintout, $serialization );
+			} else {
+				$this->addOtherParameters( $name, $param, $serialization, $showMode );
+			}
+		}
+
+		$serialization['query'] = str_replace(
+			[ '&lt;', '&gt;', '-3D' ],
+			['<', '>', '=' ],
+			$serialization['query']
+		);
+
+		if ( $showMode ) {
+			$serialization['query'] = '[[:' . $serialization['query'] . ']]';
+		}
+
+		return $serialization;
+	}
+
+	private function encodeEq ( $param ) {
+		// Bug 32955 / #640
+		// Modify (e.g. replace `=`) a condition string only if enclosed by [[ ... ]]
+		return preg_replace_callback(
+			'/\[\[([^\[\]]*)\]\]/xu',
+			function( array $matches ) {
+				return str_replace( array( '=' ), array( '-3D' ), $matches[0] );
+			},
+			$param
+		);
+	}
+
+	private function addPrintRequest( $name, $param, &$previousPrintout, array &$serialization ) {
+
+		$param = substr( $param, 1 );
+
+		// Currently we don't filter any duplicates hence the additional
+		// $name is added to distinguish printouts with the same configuration
+		$hash = md5( json_encode( $param ) . $name );
+		$previousPrintout = $hash;
+
+		$serialization['printouts'][$hash] = [
+			'label' => $param,
+			'params'  => []
+		];
+	}
+
+	private function addThisPrintRequest( $name, $param, &$previousPrintout, array &$serialization ) {
+
+		$param = substr( $param, 1 );
+
+		$parts = explode( '=', $param, 2 );
+		$serialization['parameters']['mainlabel'] = count( $parts ) >= 2 ? $parts[1] : null;
+		$previousPrintout = self::PRINT_THIS;
+	}
+
+	private function addPrintRequestParameter( $name, $param, $previousPrintout, array &$serialization ) {
+
+		if ( $previousPrintout === null ) {
+			return;
+		}
+
+		$param = substr( $param, 1 );
+		$parts = explode( '=', $param, 2 );
+
+		if ( $previousPrintout === self::PRINT_THIS ) {
+			if ( count( $parts ) == 2 ) {
+				$serialization['this'] = [ trim( $parts[0] ) => $parts[1] ];
+			} else {
+				$serialization['this'] = [ trim( $parts[0] ) => null ];
+			}
+		} else {
+			if ( count( $parts ) == 2 ) {
+				$serialization['printouts'][$previousPrintout]['params'][trim( $parts[0] )] = $parts[1];
+			} else {
+				$serialization['printouts'][$previousPrintout]['params'][trim( $parts[0] )] = null;
+			}
+		}
+	}
+
+	private function addOtherParameters( $name, $param, array &$serialization, $showMode ) {
+
+		// #1645
+		$parts = $showMode && $name == 0 ? $param : explode( '=', $param, 2 );
+
+		if ( count( $parts ) >= 2 ) {
+			$p = strtolower( trim( $parts[0] ) );
+
+			// don't trim here, some parameters care for " "
+			$serialization['parameters'][$p] = $parts[1];
+		} else {
+			$serialization['query'] .= $param;
+		}
+	}
+
+}

--- a/tests/phpunit/Unit/Query/PrintRequestFactoryTest.php
+++ b/tests/phpunit/Unit/Query/PrintRequestFactoryTest.php
@@ -4,6 +4,7 @@ namespace SMW\Tests\Query;
 
 use SMW\DIProperty;
 use SMW\Query\PrintRequestFactory;
+use SMW\Query\PrintRequest;
 
 /**
  * @covers \SMW\Query\PrintRequestFactory
@@ -68,6 +69,19 @@ class PrintRequestFactoryTest extends \PHPUnit_Framework_TestCase {
 
 		$this->assertNull(
 			$printRequest
+		);
+	}
+
+	public function testCanConstructThisPrintRequest() {
+
+		$instance = new PrintRequestFactory();
+
+		$printRequest = $instance->newThisPrintRequest(
+			'Foo'
+		);
+
+		$this->assertTrue(
+			$printRequest->isMode( PrintRequest::PRINT_THIS )
 		);
 	}
 

--- a/tests/phpunit/Unit/Query/Processor/ParamListProcessorTest.php
+++ b/tests/phpunit/Unit/Query/Processor/ParamListProcessorTest.php
@@ -1,0 +1,293 @@
+<?php
+
+namespace SMW\Tests\Query\Processor;
+
+use SMW\Query\Processor\ParamListProcessor;
+use SMW\DataItemFactory;
+
+/**
+ * @covers \SMW\Query\Processor\ParamListProcessor
+ * @group semantic-mediawiki
+ *
+ * @license GNU GPL v2+
+ * @since 3.0
+ *
+ * @author mwjames
+ */
+class ParamListProcessorTest extends \PHPUnit_Framework_TestCase {
+
+	public function testCanConstruct() {
+
+		$printRequestFactory = $this->getMockBuilder( '\SMW\Query\PrintRequestFactory' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$this->assertInstanceOf(
+			ParamListProcessor::class,
+			new ParamListProcessor( $printRequestFactory )
+		);
+	}
+
+	/**
+	 * @dataProvider parametersProvider
+	 */
+	public function testPreprocess( $parameters, $showMode, $expected ) {
+
+		$printRequestFactory = $this->getMockBuilder( '\SMW\Query\PrintRequestFactory' )
+			->disableOriginalConstructor()
+			->getMock();
+
+			$instance = new ParamListProcessor(
+				$printRequestFactory
+			);
+
+		$this->assertEquals(
+			$expected,
+			$instance->preprocess( $parameters, $showMode )
+		);
+	}
+
+	/**
+	 * @dataProvider legacyParametersProvider
+	 */
+	public function testLegacyArray( $parameters ) {
+
+		$printRequestFactory = $this->getMockBuilder( '\SMW\Query\PrintRequestFactory' )
+			->disableOriginalConstructor()
+			->getMock();
+
+			$instance = new ParamListProcessor(
+				$printRequestFactory
+			);
+
+		$a = $instance->getLegacyArray(
+			$parameters
+		);
+
+		$this->assertInternalType(
+			'string',
+			$a[0]
+		);
+
+		$this->assertInternalType(
+			'array',
+			$a[1]
+		);
+
+		$this->assertInternalType(
+			'array',
+			$a[2]
+		);
+	}
+
+	public function parametersProvider() {
+
+		yield [
+			[ '[[Foo::Bar]]' ],
+			false,
+			[
+				'showMode'   => false,
+				'query'      => '[[Foo::Bar]]',
+				'printouts'  => [],
+				'parameters' => [],
+				'this'       => []
+			]
+		];
+
+		// #640
+		yield [
+			[ '[[Foo::Bar=Foobar]]' ],
+			false,
+			[
+				'showMode'   => false,
+				'query'      => '[[Foo::Bar=Foobar]]',
+				'printouts'  => [],
+				'parameters' => [],
+				'this'       => []
+			]
+		];
+
+		yield [
+			[ '[[Foo::&lt;Bar=Foobar&gt;]]' ],
+			false,
+			[
+				'showMode'   => false,
+				'query'      => '[[Foo::<Bar=Foobar>]]',
+				'printouts'  => [],
+				'parameters' => [],
+				'this'       => []
+			]
+		];
+
+		yield [
+			[ '[[Foo::Bar]]', 'mainlabel=-' ],
+			false,
+			[
+				'showMode'   => false,
+				'query'      => '[[Foo::Bar]]',
+				'printouts'  => [],
+				'parameters' => [
+					'mainlabel' => '-'
+				],
+				'this'       => []
+			]
+		];
+
+		yield [
+			[ '[[Foo::Bar]]', '?Foobar' ],
+			false,
+			[
+				'showMode'   => false,
+				'query'      => '[[Foo::Bar]]',
+				'printouts'  => [
+					'0bfab051cd82c364058617af13e9874a' => [
+						'label'   => 'Foobar',
+						'params'  => []
+					]
+				],
+				'parameters' => [],
+				'this'       => []
+			]
+		];
+
+		yield [
+			[ '[[Foo::Bar]]', '?Foobar', '+abc=123' ],
+			false,
+			[
+				'showMode'   => false,
+				'query'      => '[[Foo::Bar]]',
+				'printouts'  => [
+					'0bfab051cd82c364058617af13e9874a' => [
+						'label'   => 'Foobar',
+						'params'  => [
+							'abc' => '123'
+						]
+					]
+				],
+				'parameters' => [],
+				'this'       => []
+			]
+		];
+
+		yield [
+			[ '[[Foo::Bar]]', '?Foobar', '+abc=123', '+abc=123' ],
+			false,
+			[
+				'showMode'   => false,
+				'query'      => '[[Foo::Bar]]',
+				'printouts'  => [
+					'0bfab051cd82c364058617af13e9874a' => [
+						'label'   => 'Foobar',
+						'params'  => [
+							'abc' => '123'
+						]
+					]
+				],
+				'parameters' => [],
+				'this'       => []
+			]
+		];
+
+		yield [
+			[ '[[Foo::Bar]]', '?Foobar', '+abc=123', '?ABC', '+abc=456', '+abc=+FOO', 'limit=10' ],
+			false,
+			[
+				'showMode'   => false,
+				'query'      => '[[Foo::Bar]]',
+				'printouts'  => [
+					'0bfab051cd82c364058617af13e9874a' => [
+						'label'   => 'Foobar',
+						'params'  => [
+							'abc' => '123'
+						]
+					],
+					'2a30f08efdf827f7e76b895fde0fe670' => [
+						'label'   => 'ABC',
+						'params'  => [
+							'abc' => '456',
+							'abc' => '+FOO'
+						]
+					]
+				],
+				'parameters' => [
+					'limit' => '10'
+				],
+				'this'       => []
+			]
+		];
+
+		// mainlabel=Foo|+abc=123 is currently NOT supported
+		yield [
+			[ '[[Foo::Bar]]', 'mainlabel=Foo', '+abc=123' ],
+			false,
+			[
+				'showMode'   => false,
+				'query'      => '[[Foo::Bar]]',
+				'printouts'  => [],
+				'parameters' => [
+					'mainlabel' => 'Foo'
+				],
+				'this'       => []
+			]
+		];
+
+		// #1645
+		yield [
+			[ 'Foo=Bar', 'link=none' ],
+			true,
+			[
+				'showMode'   => true,
+				'query'      => '[[:Foo=Bar]]',
+				'printouts'  => [],
+				'parameters' => [
+					'link' => 'none'
+				],
+				'this'       => []
+			]
+		];
+
+	}
+
+	public function legacyParametersProvider() {
+
+		yield [
+			[
+				'showMode'   => false,
+				'query'      => '[[Foo::Bar]]',
+				'printouts'  => [
+					'0bfab051cd82c364058617af13e9874a' => [
+						'label'   => 'Foobar',
+						'params'  => [
+							'abc' => '123'
+						]
+					],
+					'2a30f08efdf827f7e76b895fde0fe670' => [
+						'label'   => 'ABC',
+						'params'  => [
+							'abc' => '456',
+							'abc' => '+FOO'
+						]
+					]
+				],
+				'parameters' => [
+					'limit' => '10'
+				],
+				'this'       => []
+			]
+		];
+
+		yield [
+			[
+				'showMode'   => true,
+				'query'      => '[[:Foo=Bar]]',
+				'printouts'  => [],
+				'parameters' => [
+					'link' => 'none'
+				],
+				'this'       => []
+			]
+		];
+
+	}
+
+}


### PR DESCRIPTION
This PR is made in reference to: https://github.com/SemanticMediaWiki/SemanticMediaWiki/pull/2677#issuecomment-332131358

This PR addresses or contains:

- Issues with interpreting the code came to light while trying to answer https://github.com/SemanticMediaWiki/SemanticMediaWiki/pull/2677#issuecomment-332131358
- Move the processing part to `ParamListProcessor` in order to make it more testable
- Behaviour for `mainlabel=Foo|+abc=123`  is being tested, and declared as currently NOT supported

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed
