### PR TITLE
Replace $smwgCacheUsage settings

### DIFF
--- a/DefaultSettings.php
+++ b/DefaultSettings.php
@@ -864,31 +864,27 @@ return array(
 	# requires $smwgCacheType to be set otherwise related settings will have
 	# no effect.
 	#
-	# - smwgWantedPropertiesCache Enable to serve wanted properties from cache
-	# - smwgWantedPropertiesCacheExpiry Number of seconds before the cache expires
+	# - special.wantedproperties TTL (in sec, or false to disable it) for caching
+	#   the lookup on wanted property usage
 	#
-	# - smwgUnusedPropertiesCache Enable to serve unused properties from cache
-	# - smwgUnusedPropertiesCacheExpiry Number of seconds before the cache expires
+	# - special.unusedproperties TTL (in sec, or false to disable it) for caching
+	#   the lookup on unused property usage
 	#
-	# - smwgPropertiesCache Enable to serve properties from cache
-	# - smwgPropertiesCacheExpiry Number of seconds before the cache expires
+	# - special.properties TTL (in sec, or false to disable it) for caching the
+	#   lookup on property usage
 	#
-	# - smwgStatisticsCache Enable to serve statistics from cache
-	# - smwgStatisticsCacheExpiry Number of seconds before the cache expires
+	# - special.statistics TTL (in sec, or false to disable it) for caching the
+	#   lookup on statistics
 	#
 	# - api.browse TTL (in sec, or false to disable it) for the API browse module
 	#
 	# @since 1.9
 	##
 	'smwgCacheUsage' => array(
-		'smwgWantedPropertiesCache' => true,
-		'smwgWantedPropertiesCacheExpiry' => 3600,
-		'smwgUnusedPropertiesCache' => true,
-		'smwgUnusedPropertiesCacheExpiry' => 3600,
-		'smwgPropertiesCache' => true,
-		'smwgPropertiesCacheExpiry' => 3600,
-		'smwgStatisticsCache' => true,
-		'smwgStatisticsCacheExpiry' => 3600,
+		'special.wantedproperties' => 3600,
+		'special.unusedproperties' => 3600,
+		'special.properties' => 3600,
+		'special.statistics' => 3600,
 		'api.browse' => 3600
 	),
 	##

--- a/includes/Settings.php
+++ b/includes/Settings.php
@@ -265,6 +265,25 @@ class Settings extends Options {
 	}
 
 	/**
+	 * @since 3.0
+	 *
+	 * @param string $key
+	 * @param mixed $default
+	 *
+	 * @return mixed
+	 */
+	public function safeGet( $key, $default = false ) {
+
+		try {
+			$r = $this->get( $key );
+		} catch ( SettingNotFoundException $e ) {
+			return $default;
+		}
+
+		return $r;
+	}
+
+	/**
 	 * @since 1.9
 	 */
 	public static function clear() {
@@ -316,6 +335,38 @@ class Settings extends Options {
 			$configuration['smwgPropertyListLimit']['redirect'] = $GLOBALS['smwgRedirectPropertyListLimit'];
 		}
 
+		if ( isset( $GLOBALS['smwgCacheUsage']['smwgStatisticsCacheExpiry'] ) ) {
+			$configuration['smwgCacheUsage']['special.statistics'] = $GLOBALS['smwgCacheUsage']['smwgStatisticsCacheExpiry'];
+		}
+
+		if ( isset( $GLOBALS['smwgCacheUsage']['smwgStatisticsCache'] ) && $GLOBALS['smwgCacheUsage']['smwgStatisticsCache'] === false ) {
+			$configuration['smwgCacheUsage']['special.statistics'] = false;
+		}
+
+		if ( isset( $GLOBALS['smwgCacheUsage']['smwgPropertiesCacheExpiry'] ) ) {
+			$configuration['smwgCacheUsage']['special.properties'] = $GLOBALS['smwgCacheUsage']['smwgPropertiesCacheExpiry'];
+		}
+
+		if ( isset( $GLOBALS['smwgCacheUsage']['smwgPropertiesCache'] ) && $GLOBALS['smwgCacheUsage']['smwgPropertiesCache'] === false ) {
+			$configuration['smwgCacheUsage']['special.properties'] = false;
+		}
+
+		if ( isset( $GLOBALS['smwgCacheUsage']['smwgUnusedPropertiesCacheExpiry'] ) ) {
+			$configuration['smwgCacheUsage']['special.unusedproperties'] = $GLOBALS['smwgCacheUsage']['smwgUnusedPropertiesCacheExpiry'];
+		}
+
+		if ( isset( $GLOBALS['smwgCacheUsage']['smwgUnusedPropertiesCache'] ) && $GLOBALS['smwgCacheUsage']['smwgUnusedPropertiesCache'] === false ) {
+			$configuration['smwgCacheUsage']['special.unusedproperties'] = false;
+		}
+
+		if ( isset( $GLOBALS['smwgCacheUsage']['smwgWantedPropertiesCacheExpiry'] ) ) {
+			$configuration['smwgCacheUsage']['special.wantedproperties'] = $GLOBALS['smwgCacheUsage']['smwgWantedPropertiesCacheExpiry'];
+		}
+
+		if ( isset( $GLOBALS['smwgCacheUsage']['smwgWantedPropertiesCache'] ) && $GLOBALS['smwgCacheUsage']['smwgWantedPropertiesCache'] === false ) {
+			$configuration['smwgCacheUsage']['special.wantedproperties'] = false;
+		}
+
 		// Deprecated mapping used in DeprecationNoticeTaskHandler to detect and
 		// output notices
 		$GLOBALS['smwgDeprecationNotices'] = array(
@@ -324,14 +375,34 @@ class Settings extends Options {
 				'smwgQueryDependencyPropertyExemptionlist' => '3.1.0',
 				'smwgQueryDependencyAffiliatePropertyDetectionlist' => '3.1.0',
 				'smwgSubPropertyListLimit' => '3.1.0',
-				'smwgRedirectPropertyListLimit' => '3.1.0'
+				'smwgRedirectPropertyListLimit' => '3.1.0',
+				'options' => [
+					'smwgCacheUsage' =>  [
+						'smwgStatisticsCache' => '3.1.0',
+						'smwgStatisticsCacheExpiry' => '3.1.0',
+						'smwgPropertiesCache' => '3.1.0',
+						'smwgPropertiesCacheExpiry' => '3.1.0',
+						'smwgUnusedPropertiesCache' => '3.1.0',
+						'smwgUnusedPropertiesCacheExpiry' => '3.1.0',
+						'smwgWantedPropertiesCache' => '3.1.0',
+						'smwgWantedPropertiesCacheExpiry' => '3.1.0',
+					]
+				],
 			),
 			'replacement' => array(
 				'smwgAdminRefreshStore' => 'smwgAdminFeatures',
 				'smwgQueryDependencyPropertyExemptionlist' => 'smwgQueryDependencyPropertyExemptionList',
 				'smwgQueryDependencyAffiliatePropertyDetectionlist' => 'smwgQueryDependencyAffiliatePropertyDetectionList',
 				'smwgSubPropertyListLimit' => 'smwgPropertyListLimit',
-				'smwgRedirectPropertyListLimit' => 'smwgPropertyListLimit'
+				'smwgRedirectPropertyListLimit' => 'smwgPropertyListLimit',
+				'options' => [
+					'smwgCacheUsage' => [
+						'smwgStatisticsCacheExpiry' => 'special.statistics',
+						'smwgPropertiesCacheExpiry' => 'special.properties',
+						'smwgUnusedPropertiesCacheExpiry' => 'special.unusedproperties',
+						'smwgWantedPropertiesCacheExpiry' => 'special.wantedproperties',
+					]
+				]
 			),
 			'removal' => array(
 				'smwgOnDeleteAction' => '2.4.0',

--- a/src/SQLStore/Lookup/CachedListLookup.php
+++ b/src/SQLStore/Lookup/CachedListLookup.php
@@ -42,7 +42,7 @@ class CachedListLookup implements ListLookup {
 	/**
 	 * @var string
 	 */
-	private $cachePrefix = 'smw:llc:';
+	private $cachePrefix = 'smw:store:lookup:';
 
 	/**
 	 * @since 2.2

--- a/src/SQLStore/SQLStoreFactory.php
+++ b/src/SQLStore/SQLStoreFactory.php
@@ -131,8 +131,8 @@ class SQLStoreFactory {
 
 		return $this->newCachedListLookup(
 			$usageStatisticsListLookup,
-			$settings->get( 'smwgStatisticsCache' ),
-			$settings->get( 'smwgStatisticsCacheExpiry' )
+			$settings->safeGet( 'special.statistics' ),
+			$settings->safeGet( 'special.statistics' )
 		);
 	}
 
@@ -155,8 +155,8 @@ class SQLStoreFactory {
 
 		return $this->newCachedListLookup(
 			$propertyUsageListLookup,
-			$settings->get( 'smwgPropertiesCache' ),
-			$settings->get( 'smwgPropertiesCacheExpiry' )
+			$settings->safeGet( 'special.properties' ),
+			$settings->safeGet( 'special.properties' )
 		);
 	}
 
@@ -179,8 +179,8 @@ class SQLStoreFactory {
 
 		return $this->newCachedListLookup(
 			$unusedPropertyListLookup,
-			$settings->get( 'smwgUnusedPropertiesCache' ),
-			$settings->get( 'smwgUnusedPropertiesCacheExpiry' )
+			$settings->safeGet( 'special.unusedproperties' ),
+			$settings->safeGet( 'special.unusedproperties' )
 		);
 	}
 
@@ -203,8 +203,8 @@ class SQLStoreFactory {
 
 		return $this->newCachedListLookup(
 			$undeclaredPropertyListLookup,
-			$settings->get( 'smwgWantedPropertiesCache' ),
-			$settings->get( 'smwgWantedPropertiesCacheExpiry' )
+			$settings->safeGet( 'special.wantedproperties' ),
+			$settings->safeGet( 'special.wantedproperties' )
 		);
 	}
 
@@ -220,6 +220,10 @@ class SQLStoreFactory {
 	public function newCachedListLookup( ListLookup $listLookup, $useCache, $cacheExpiry ) {
 
 		$cacheFactory = $this->applicationFactory->newCacheFactory();
+
+		if ( is_int( $useCache ) ) {
+			$useCache = true;
+		}
 
 		$cacheOptions = $cacheFactory->newCacheOptions( array(
 			'useCache' => $useCache,

--- a/tests/phpunit/Unit/SQLStore/Lookup/CachedListLookupTest.php
+++ b/tests/phpunit/Unit/SQLStore/Lookup/CachedListLookupTest.php
@@ -52,7 +52,7 @@ class CachedListLookupTest extends \PHPUnit_Framework_TestCase {
 
 		$cache->expects( $this->once() )
 			->method( 'contains' )
-			->with(	$this->stringContains( 'cacheprefix-foobar:smw:llc:' ) )
+			->with(	$this->stringContains( 'cacheprefix-foobar:smw:store:lookup:' ) )
 			->will( $this->returnValue( true ) );
 
 		$cache->expects( $this->once() )
@@ -111,7 +111,7 @@ class CachedListLookupTest extends \PHPUnit_Framework_TestCase {
 		$cache->expects( $this->at( 1 ) )
 			->method( 'save' )
 			->with(
-				$this->stringContains( 'llc' ),
+				$this->stringContains( 'smw:store:lookup' ),
 				$this->anything( serialize( $expectedCacheItem ) ),
 				$this->equalTo( 1001 ) );
 
@@ -152,12 +152,12 @@ class CachedListLookupTest extends \PHPUnit_Framework_TestCase {
 
 		$cache->expects( $this->once() )
 			->method( 'fetch' )
-			->will( $this->returnValue( serialize( array( 'smw:llc:6283479db90b04ad3a6db333a3c89766' => true ) ) ) );
+			->will( $this->returnValue( serialize( array( 'smw:store:lookup:6283479db90b04ad3a6db333a3c89766' => true ) ) ) );
 
 		$cache->expects( $this->atLeastOnce() )
 			->method( 'delete' )
 			->with(
-				$this->stringContains( 'llc' ) );
+				$this->stringContains( 'smw:store:lookup' ) );
 
 		$cacheOptions = new \stdClass;
 

--- a/tests/phpunit/includes/SettingsTest.php
+++ b/tests/phpunit/includes/SettingsTest.php
@@ -61,6 +61,15 @@ class SettingsTest extends \PHPUnit_Framework_TestCase {
 		$instance->get( 'foo' );
 	}
 
+	public function testSafeGetOnUnknownSetting() {
+
+		$instance = Settings::newFromArray( array( 'Foo' => 'bar' ) );
+
+		$this->assertFalse(
+			$instance->safeGet( 'foo', false )
+		);
+	}
+
 	/**
 	 * @dataProvider settingsProvider
 	 */


### PR DESCRIPTION
This PR is made in reference to: #

This PR addresses or contains:

- `smwgStatisticsCacheExpiry` => `special.statistics`, `smwgStatisticsCache` removed
- `smwgPropertiesCacheExpiry` => `special.properties`, `smwgPropertiesCache` removed
- `smwgUnusedPropertiesCacheExpiry` => `special.unusedproperties`, `smwgUnusedPropertiesCache` removed
- `smwgWantedPropertiesCacheExpiry` => `special.wantedproperties`, `smwgWantedPropertiesCache` removed

This PR includes:
- [ ] Tests (unit/integration)
- [x] CI build passed
