### PR TITLE
Replace $smwgQueryProfiler settings

### DIFF
--- a/DefaultSettings.php
+++ b/DefaultSettings.php
@@ -1006,29 +1006,26 @@ return array(
 	##
 
 	###
-	# QueryProfiler related setting to enable/disable specific monitorable profile
-	# data
+	# QueryProfiler related settings
 	#
 	# @note If these settings are changed, please ensure to run update.php/rebuildData.php
 	#
-	# - smwgQueryProfiler can be set false itself allowing it to disable its
-	# functionality but it may impact secondary processes that rely on profile
-	# information to be available (Notification system etc.)
+	# - smwgQueryProfiler can be set false to disable its functionality but it
+	# may impact secondary processes that rely on profile information to be
+	# available (Notification system etc.)
 	#
-	# - smwgQueryDurationEnabled to record query duration (the time
+	# - SMW_QPRFL_DUR to record query duration (the time
 	# between the query result selection and output its)
 	#
-	# - smwgQueryParametersEnabled to record query parameters that are necessary
+	# - SMW_QPRFL_PARAMS to record query parameters that are necessary
 	# for allowing to generate a query result using a background job
 	#
-	# False will disabled the query profiler (not recommended)
+	# $smwgQueryProfiler = SMW_QPRFL_DUR | SMW_QPRFL_PARAMS;
 	#
 	# @since 1.9
+	# @default true
 	##
-	'smwgQueryProfiler' => array(
-		'smwgQueryDurationEnabled' => false,
-		'smwgQueryParametersEnabled' => false
-	),
+	'smwgQueryProfiler' => true,
 	##
 
 	###

--- a/includes/Settings.php
+++ b/includes/Settings.php
@@ -367,6 +367,14 @@ class Settings extends Options {
 			$configuration['smwgCacheUsage']['special.wantedproperties'] = false;
 		}
 
+		if ( isset( $GLOBALS['smwgQueryProfiler']['smwgQueryDurationEnabled'] ) && $GLOBALS['smwgQueryProfiler']['smwgQueryDurationEnabled'] === true ) {
+			$configuration['smwgQueryProfiler'] = $configuration['smwgQueryProfiler'] | SMW_QPRFL_DUR;
+		}
+
+		if ( isset( $GLOBALS['smwgQueryProfiler']['smwgQueryParametersEnabled'] ) && $GLOBALS['smwgQueryProfiler']['smwgQueryParametersEnabled'] === true ) {
+			$configuration['smwgQueryProfiler'] = $configuration['smwgQueryProfiler'] | SMW_QPRFL_PARAMS;
+		}
+
 		// Deprecated mapping used in DeprecationNoticeTaskHandler to detect and
 		// output notices
 		$GLOBALS['smwgDeprecationNotices'] = array(
@@ -386,8 +394,12 @@ class Settings extends Options {
 						'smwgUnusedPropertiesCacheExpiry' => '3.1.0',
 						'smwgWantedPropertiesCache' => '3.1.0',
 						'smwgWantedPropertiesCacheExpiry' => '3.1.0',
+					],
+					'smwgQueryProfiler' =>  [
+						'smwgQueryDurationEnabled' => '3.1.0',
+						'smwgQueryParametersEnabled' => '3.1.0'
 					]
-				],
+				]
 			),
 			'replacement' => array(
 				'smwgAdminRefreshStore' => 'smwgAdminFeatures',
@@ -401,6 +413,10 @@ class Settings extends Options {
 						'smwgPropertiesCacheExpiry' => 'special.properties',
 						'smwgUnusedPropertiesCacheExpiry' => 'special.unusedproperties',
 						'smwgWantedPropertiesCacheExpiry' => 'special.wantedproperties',
+					],
+					'smwgQueryProfiler' => [
+						'smwgQueryDurationEnabled' => 'SMW_QPRFL_DUR',
+						'smwgQueryParametersEnabled' => 'SMW_QPRFL_PARAMS'
 					]
 				]
 			),

--- a/src/Defines.php
+++ b/src/Defines.php
@@ -221,3 +221,11 @@ define( 'SMW_FIELDT_NONE', 0 );
 define( 'SMW_FIELDT_CHAR_NOCASE', 2 ); // Using FieldType::TYPE_CHAR_NOCASE
 define( 'SMW_FIELDT_CHAR_LONG', 4 ); // Using FieldType::TYPE_CHAR_LONG
 /**@}*/
+
+/**@{
+  * Constants for $smwgQueryProfiler
+  */
+define( 'SMW_QPRFL_NONE', 0 );
+define( 'SMW_QPRFL_PARAMS', 2 ); // Support for Query parameters
+define( 'SMW_QPRFL_DUR', 4 ); // Support for Query duration
+/**@}*/

--- a/src/Options.php
+++ b/src/Options.php
@@ -96,18 +96,6 @@ class Options {
 	}
 
 	/**
-	 * @since 3.0
-	 *
-	 * @param string $key
-	 * @param mixed $value
-	 *
-	 * @return boolean
-	 */
-	public function isValueSet( $key, $value ) {
-		return $this->safeGet( $key ) === $value;
-	}
-
-	/**
 	 * @since 2.4
 	 *
 	 * @return array

--- a/src/ParserFunctions/AskParserFunction.php
+++ b/src/ParserFunctions/AskParserFunction.php
@@ -332,16 +332,16 @@ class AskParserFunction {
 		$settings = $applicationFactory->getSettings();
 
 		// If the smwgQueryProfiler is marked with FALSE then just don't create a profile.
-		if ( ( $queryProfiler = $settings->get( 'smwgQueryProfiler' ) ) === false || $extraKeys[self::NO_TRACE] === true ) {
+		if ( $settings->get( 'smwgQueryProfiler' ) === false || $extraKeys[self::NO_TRACE] === true ) {
 			return;
 		}
 
-		if ( !isset( $queryProfiler['smwgQueryDurationEnabled'] ) || $queryProfiler['smwgQueryDurationEnabled'] === false ) {
+		if ( !$settings->isFlagSet( 'smwgQueryProfiler', SMW_QPRFL_DUR ) ) {
 			$query->setOption( Query::PROC_QUERY_TIME, 0 );
 		}
 
-		if ( isset( $queryProfiler['smwgQueryParametersEnabled'] ) ) {
-			$query->setOption( Query::OPT_PARAMETERS, $queryProfiler['smwgQueryParametersEnabled'] );
+		if ( $settings->isFlagSet( 'smwgQueryProfiler', SMW_QPRFL_PARAMS ) ) {
+			$query->setOption( Query::OPT_PARAMETERS, true );
 		}
 
 		$query->setContextPage(

--- a/tests/phpunit/Integration/JSONScript/TestCases/p-0909.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/p-0909.json
@@ -247,9 +247,6 @@
 		"wgContLang": "en",
 		"wgLang": "en",
 		"smwgQFilterDuplicates": true,
-		"smwgQueryProfiler" : {
-			"smwgQueryDurationEnabled": false
-		},
 		"smwgQueryResultCacheType": "hash",
 		"smwgPageSpecialProperties": [
 			"_MDAT"

--- a/tests/phpunit/Integration/JSONScript/TestCases/p-0911.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/p-0911.json
@@ -44,10 +44,10 @@
 		"wgContLang": "en",
 		"wgLang": "en",
 		"smwgQueryResultCacheType": "hash",
-		"smwgQueryProfiler" : {
-			"smwgQueryDurationEnabled": true,
-			"smwgQueryParametersEnabled": true
-		},
+		"smwgQueryProfiler" : [
+			"SMW_QPRFL_DUR",
+			"SMW_QPRFL_PARAMS"
+		],
 		"smwgPageSpecialProperties": [
 			"_MDAT"
 		],

--- a/tests/phpunit/Integration/JSONScript/TestCases/p-0914.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/p-0914.json
@@ -71,9 +71,6 @@
 		"wgContLang": "en",
 		"wgLang": "en",
 		"smwgQFilterDuplicates": true,
-		"smwgQueryProfiler" : {
-			"smwgQueryDurationEnabled": false
-		},
 		"smwgQueryResultCacheType": "hash",
 		"smwgPageSpecialProperties": [
 			"_MDAT"

--- a/tests/phpunit/JsonTestCaseFileHandler.php
+++ b/tests/phpunit/JsonTestCaseFileHandler.php
@@ -239,7 +239,8 @@ class JsonTestCaseFileHandler {
 			'smwgSparqlQFeatures',
 			'smwgDVFeatures',
 			'smwgFulltextSearchIndexableDataTypes',
-			'smwgFieldTypeFeatures'
+			'smwgFieldTypeFeatures',
+			'smwgQueryProfiler'
 		);
 
 		foreach ( $constantFeaturesList as $constantFeatures ) {

--- a/tests/phpunit/Unit/OptionsTest.php
+++ b/tests/phpunit/Unit/OptionsTest.php
@@ -70,20 +70,6 @@ class OptionsTest extends \PHPUnit_Framework_TestCase {
 	}
 
 	/**
-	 * @dataProvider isSetProvider
-	 */
-	public function testIsValueSet( $value, $is, $expected ) {
-
-		$instance = new Options();
-		$instance->set( 'Foo', $value );
-
-		$this->assertEquals(
-			$expected,
-			$instance->isValueSet( 'Foo', $is )
-		);
-	}
-
-	/**
 	 * @dataProvider isFlagSetProvider
 	 */
 	public function testIsFlagSet( $value, $flag, $expected ) {

--- a/tests/phpunit/Unit/ParserFunctions/AskParserFunctionTest.php
+++ b/tests/phpunit/Unit/ParserFunctions/AskParserFunctionTest.php
@@ -33,11 +33,7 @@ class AskParserFunctionTest extends \PHPUnit_Framework_TestCase {
 		$this->testEnvironment = new TestEnvironment();
 		$this->semanticDataValidator = $this->testEnvironment->getUtilityFactory()->newValidatorFactory()->newSemanticDataValidator();
 
-		$this->testEnvironment->addConfiguration( 'smwgQueryProfiler', array(
-			'smwgQueryDurationEnabled' => false,
-			'smwgQueryParametersEnabled' => false
-		) );
-
+		$this->testEnvironment->addConfiguration( 'smwgQueryProfiler', true );
 		$this->testEnvironment->addConfiguration( 'smwgQMaxLimit', 1000 );
 
 		$this->messageFormatter = $this->getMockBuilder( '\SMW\MessageFormatter' )
@@ -490,10 +486,7 @@ class AskParserFunctionTest extends \PHPUnit_Framework_TestCase {
 				'propertyValues' => array( 'list', 1, 1, '[[Modification date::+]]' )
 			),
 			array(
-				'smwgQueryProfiler' => array(
-					'smwgQueryDurationEnabled' => false,
-					'smwgQueryParametersEnabled' => false
-				)
+				'smwgQueryProfiler' => true
 			)
 		);
 
@@ -517,10 +510,7 @@ class AskParserFunctionTest extends \PHPUnit_Framework_TestCase {
 			),
 			array(
 				'smwgCreateProtectionRight' => false,
-				'smwgQueryProfiler' => array(
-					'smwgQueryDurationEnabled' => false,
-					'smwgQueryParametersEnabled' => false
-				)
+				'smwgQueryProfiler' => true
 			)
 		);
 
@@ -543,10 +533,7 @@ class AskParserFunctionTest extends \PHPUnit_Framework_TestCase {
 				'propertyValues' => array( 'list', 2, 1, "[[Modification date::+]] [[$categoryNS:Foo]]" )
 			),
 			array(
-				'smwgQueryProfiler' => array(
-					'smwgQueryDurationEnabled' => false,
-					'smwgQueryParametersEnabled' => false
-				)
+				'smwgQueryProfiler' => true
 			)
 		);
 
@@ -569,10 +556,7 @@ class AskParserFunctionTest extends \PHPUnit_Framework_TestCase {
 				'propertyValues' => array( 'feed', 1, 1, "[[:$fileNS:Fooo]]" )
 			),
 			array(
-				'smwgQueryProfiler' => array(
-					'smwgQueryDurationEnabled' => false,
-					'smwgQueryParametersEnabled' => false
-				)
+				'smwgQueryProfiler' => true
 			)
 		);
 
@@ -595,10 +579,7 @@ class AskParserFunctionTest extends \PHPUnit_Framework_TestCase {
 				'propertyValues' => array( 'table', 2, 1, "[[Modification date::+]] [[$categoryNS:Foo]]" )
 			),
 			array(
-				'smwgQueryProfiler' => array(
-					'smwgQueryDurationEnabled' => false,
-					'smwgQueryParametersEnabled' => false
-				)
+				'smwgQueryProfiler' => true
 			)
 		);
 
@@ -615,10 +596,7 @@ class AskParserFunctionTest extends \PHPUnit_Framework_TestCase {
 				'propertyKeys'   => array( '_ASKST', '_ASKSI', '_ASKDE', '_ASKFO', '_ASKDU' ),
 			),
 			array(
-				'smwgQueryProfiler' => array(
-					'smwgQueryDurationEnabled' => true,
-					'smwgQueryParametersEnabled' => false
-				)
+				'smwgQueryProfiler' => SMW_QPRFL_DUR
 			)
 		);
 
@@ -645,10 +623,7 @@ class AskParserFunctionTest extends \PHPUnit_Framework_TestCase {
 				'propertyValues' => array( 'list', 1, 1, '[[Modification date::+]]', '{"limit":50,"offset":0,"sort":[""],"order":["asc"],"mode":1}' )
 			),
 			array(
-				'smwgQueryProfiler' => array(
-					'smwgQueryDurationEnabled' => false,
-					'smwgQueryParametersEnabled' => true
-				)
+				'smwgQueryProfiler' => SMW_QPRFL_PARAMS
 			)
 		);
 

--- a/tests/phpunit/Unit/ParserFunctions/ShowParserFunctionTest.php
+++ b/tests/phpunit/Unit/ParserFunctions/ShowParserFunctionTest.php
@@ -32,7 +32,7 @@ class ShowParserFunctionTest extends \PHPUnit_Framework_TestCase {
 		$this->testEnvironment = new TestEnvironment();
 		$this->semanticDataValidator = $this->testEnvironment->getUtilityFactory()->newValidatorFactory()->newSemanticDataValidator();
 
-		$this->testEnvironment->addConfiguration( 'smwgQueryDurationEnabled', false );
+		$this->testEnvironment->addConfiguration( 'smwgQueryProfiler', true );
 		$this->testEnvironment->addConfiguration( 'smwgQueryResultCacheType', false );
 		$this->testEnvironment->addConfiguration( 'smwgQFilterDuplicates', false );
 


### PR DESCRIPTION
This PR is made in reference to: #

This PR addresses or contains:

- Replaces `smwgQueryDurationEnabled` with `SMW_QPRFL_DUR`
- Replaces `smwgQueryParametersEnabled` with `SMW_QPRFL_PARAMS`
- To enable both the assignment looks like `$smwgQueryProfiler = SMW_QPRFL_DUR | SMW_QPRFL_PARAMS;`

This PR includes:
- [ ] Tests (unit/integration)
- [x] CI build passed
