### PR TITLE
Move definition of ask param `import-annotation` to `SMWQueryProcessor`

### DIFF
--- a/includes/query/SMW_QueryProcessor.php
+++ b/includes/query/SMW_QueryProcessor.php
@@ -75,7 +75,7 @@ class SMWQueryProcessor implements QueryContext {
 	 * @return Processor
 	 */
 	public static function getValidatorForParams( array $params, array $printRequests = array(), $unknownInvalid = true, $context = null ) {
-		$paramDefinitions = self::getParameters( $context );
+		$paramDefinitions = self::getParameters( null, $context );
 
 		$paramDefinitions['format']->setPrintRequests( $printRequests );
 
@@ -442,7 +442,7 @@ class SMWQueryProcessor implements QueryContext {
 	 *
 	 * @return IParamDefinition[]
 	 */
-	public static function getParameters( $context = null ) {
+	public static function getParameters( $resultPrinter = null, $context = null ) {
 		$params = array();
 
 		$allowedFormats = $GLOBALS['smwgResultFormats'];
@@ -524,6 +524,14 @@ class SMWQueryProcessor implements QueryContext {
 			);
 		}
 
+		if ( !( $resultPrinter instanceof \SMW\ResultPrinter ) || $resultPrinter->supportsRecursiveAnnotation() ) {
+			$params['import-annotation'] = array(
+				'message' => 'smw-paramdesc-import-annotation',
+				'type' => 'boolean',
+				'default' => false
+			);
+		}
+
 		// Give grep a chance to find the usages:
 		// smw-paramdesc-format, smw-paramdesc-source, smw-paramdesc-limit, smw-paramdesc-offset,
 		// smw-paramdesc-link, smw-paramdesc-sort, smw-paramdesc-order, smw-paramdesc-headers,
@@ -560,8 +568,10 @@ class SMWQueryProcessor implements QueryContext {
 		SMWParamFormat::resolveFormatAliases( $format );
 
 		if ( array_key_exists( $format, $GLOBALS['smwgResultFormats'] ) ) {
+			$resultPrinter = self::getResultPrinter( $format );
+
 			return ParamDefinition::getCleanDefinitions(
-				self::getResultPrinter( $format )->getParamDefinitions( self::getParameters() )
+				$resultPrinter->getParamDefinitions( self::getParameters( $resultPrinter ) )
 			);
 		} else {
 			return array();

--- a/includes/query/SMW_QueryProcessor.php
+++ b/includes/query/SMW_QueryProcessor.php
@@ -75,7 +75,7 @@ class SMWQueryProcessor implements QueryContext {
 	 * @return Processor
 	 */
 	public static function getValidatorForParams( array $params, array $printRequests = array(), $unknownInvalid = true, $context = null ) {
-		$paramDefinitions = self::getParameters( null, $context );
+		$paramDefinitions = self::getParameters( $context );
 
 		$paramDefinitions['format']->setPrintRequests( $printRequests );
 
@@ -442,7 +442,7 @@ class SMWQueryProcessor implements QueryContext {
 	 *
 	 * @return IParamDefinition[]
 	 */
-	public static function getParameters( $resultPrinter = null, $context = null ) {
+	public static function getParameters( $context = null, $resultPrinter = null ) {
 		$params = array();
 
 		$allowedFormats = $GLOBALS['smwgResultFormats'];
@@ -571,7 +571,7 @@ class SMWQueryProcessor implements QueryContext {
 			$resultPrinter = self::getResultPrinter( $format );
 
 			return ParamDefinition::getCleanDefinitions(
-				$resultPrinter->getParamDefinitions( self::getParameters( $resultPrinter ) )
+				$resultPrinter->getParamDefinitions( self::getParameters( null, $resultPrinter ) )
 			);
 		} else {
 			return array();

--- a/includes/queryprinters/ListResultPrinter.php
+++ b/includes/queryprinters/ListResultPrinter.php
@@ -486,6 +486,16 @@ class ListResultPrinter extends ResultPrinter {
 	}
 
 	/**
+	 * @since 3.0
+	 *
+	 * @return boolean
+	 */
+	public function supportsRecursiveAnnotation() {
+		return true;
+	}
+
+
+	/**
 	 * @inheritdoc
 	 */
 	public function getParamDefinitions( array $definitions ) {
@@ -542,12 +552,6 @@ class ListResultPrinter extends ResultPrinter {
 		$definitions['outrotemplate'] = [
 			'message' => 'smw-paramdesc-outrotemplate',
 			'default' => '',
-		];
-
-		$definitions['import-annotation'] = [
-			'message' => 'smw-paramdesc-import-annotation',
-			'type' => 'boolean',
-			'default' => false,
 		];
 
 		return $definitions;

--- a/includes/queryprinters/ResultPrinter.php
+++ b/includes/queryprinters/ResultPrinter.php
@@ -680,6 +680,18 @@ abstract class ResultPrinter extends \ContextSource implements QueryResultPrinte
 	}
 
 	/**
+	 * Returns if the result printer supports using a "full parse" instead of a
+	 * '[[SMW::off]]' . $wgParser->replaceVariables( $result ) . '[[SMW::on]]'
+	 *
+	 * @since 3.0
+	 *
+	 * @return boolean
+	 */
+	public function supportsRecursiveAnnotation() {
+		return false;
+	}
+
+	/**
 	 * @since 2.5
 	 *
 	 * @return string

--- a/src/ParserFunctions/DocumentationParserFunction.php
+++ b/src/ParserFunctions/DocumentationParserFunction.php
@@ -83,7 +83,7 @@ class DocumentationParserFunction implements HookHandler {
 		$resultPrinter = SMWQueryProcessor::getResultPrinter( $format );
 
 		return ParamDefinition::getCleanDefinitions(
-			$resultPrinter->getParamDefinitions( SMWQueryProcessor::getParameters( $resultPrinter ) )
+			$resultPrinter->getParamDefinitions( SMWQueryProcessor::getParameters( null, $resultPrinter ) )
 		);
 	}
 

--- a/src/ParserFunctions/DocumentationParserFunction.php
+++ b/src/ParserFunctions/DocumentationParserFunction.php
@@ -80,8 +80,10 @@ class DocumentationParserFunction implements HookHandler {
 			return array();
 		}
 
+		$resultPrinter = SMWQueryProcessor::getResultPrinter( $format );
+
 		return ParamDefinition::getCleanDefinitions(
-			SMWQueryProcessor::getResultPrinter( $format )->getParamDefinitions( SMWQueryProcessor::getParameters() )
+			$resultPrinter->getParamDefinitions( SMWQueryProcessor::getParameters( $resultPrinter ) )
 		);
 	}
 

--- a/tests/phpunit/includes/queryprinters/ResultPrintersTest.php
+++ b/tests/phpunit/includes/queryprinters/ResultPrintersTest.php
@@ -78,7 +78,7 @@ class ResultPrintersTest extends QueryPrinterTestCase {
 	 * @param \SMWResultPrinter $printer
 	 */
 	public function testGetParamDefinitions( ResultPrinter $printer ) {
-		$params = $printer->getParamDefinitions( SMWQueryProcessor::getParameters() );
+		$params = $printer->getParamDefinitions( SMWQueryProcessor::getParameters( $printer ) );
 
 		$params = ParamDefinition::getCleanDefinitions( $params );
 

--- a/tests/phpunit/includes/queryprinters/ResultPrintersTest.php
+++ b/tests/phpunit/includes/queryprinters/ResultPrintersTest.php
@@ -78,7 +78,7 @@ class ResultPrintersTest extends QueryPrinterTestCase {
 	 * @param \SMWResultPrinter $printer
 	 */
 	public function testGetParamDefinitions( ResultPrinter $printer ) {
-		$params = $printer->getParamDefinitions( SMWQueryProcessor::getParameters( $printer ) );
+		$params = $printer->getParamDefinitions( SMWQueryProcessor::getParameters( null, $printer ) );
 
 		$params = ParamDefinition::getCleanDefinitions( $params );
 


### PR DESCRIPTION
This PR is made in reference to: #1257

This PR addresses or contains:
* Add ResultPrinter::supportsRecursiveAnnotation()
* Remove definition of ask param `import-annotation` from `ResultPrinter::getParamDefinitions()`
* Add definition of ask param `import-annotation` to `SMWQueryProcessor::getParameters()`
* Fix calls to `SMWQueryProcessor::getParameters()`

This PR includes:
- [ ] Tests (unit/integration)
- [x] CI build passed
