### PR TITLE
Move ResultPrinter, refs 2740

### DIFF
--- a/includes/storage/SMW_QueryResult.php
+++ b/includes/storage/SMW_QueryResult.php
@@ -279,8 +279,6 @@ class SMWQueryResult {
 	 * can also be changed afterwards with SMWInfolink::setCaption()). If empty, the
 	 * message 'smw_iq_moreresults' is used as a caption.
 	 *
-	 * @deprecated since SMW 1.8
-	 *
 	 * @param string|false $caption
 	 *
 	 * @return SMWInfolink

--- a/src/Aliases.php
+++ b/src/Aliases.php
@@ -4,6 +4,15 @@
  * SemanticMediaWiki compatibility aliases for classes that got moved into the SMW namespace
  */
 
+// 3.0
+class_alias( 'SMW\Updater\DeferredCallableUpdate', 'SMW\DeferredCallableUpdate' );
+class_alias( 'SMW\Parser\InTextAnnotationParser', 'SMW\InTextAnnotationParser' );
+class_alias( 'SMW\Encoder', 'SMW\UrlEncoder' );
+class_alias( 'SMW\Query\ResultPrinter', 'SMW\QueryResultPrinter' );
+class_alias( 'SMW\Query\ExportPrinter', 'SMW\ExportPrinter' );
+class_alias( 'SMW\Query\ResultPrinters\ResultPrinter', 'SMW\ResultPrinter' );
+class_alias( 'SMW\Query\ResultPrinters\FileExportPrinter', 'SMW\FileExportPrinter' );
+
 // 1.9.
 class_alias( 'SMW\Store', 'SMWStore' );
 class_alias( 'SMW\MediaWiki\Jobs\UpdateJob', 'SMWUpdateJob' );
@@ -79,7 +88,3 @@ class_alias( 'SMW\ParserFunctions\RecurringEventsParserFunction', 'SMW\Recurring
 class_alias( 'SMW\SQLStore\PropertyTableDefinition', 'SMW\SQLStore\TableDefinition' );
 class_alias( 'SMW\DataModel\ContainerSemanticData', 'SMWContainerSemanticData' );
 
-// 3.0
-class_alias( 'SMW\Updater\DeferredCallableUpdate', 'SMW\DeferredCallableUpdate' );
-class_alias( 'SMW\Parser\InTextAnnotationParser', 'SMW\InTextAnnotationParser' );
-class_alias( 'SMW\Encoder', 'SMW\UrlEncoder' );

--- a/src/Query/ExportPrinter.php
+++ b/src/Query/ExportPrinter.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace SMW;
+namespace SMW\Query;
 
-use SMWQueryResult;
+use SMWQueryResult as QueryResult;
 
 /**
  * Interface for SMW export related result printers
@@ -12,17 +12,17 @@ use SMWQueryResult;
  *
  * @author Jeroen De Dauw < jeroendedauw@gmail.com >
  */
-interface ExportPrinter extends QueryResultPrinter {
+interface ExportPrinter extends ResultPrinter {
 
 	/**
 	 * Outputs the result as file.
 	 *
 	 * @since 1.8
 	 *
-	 * @param SMWQueryResult $queryResult
+	 * @param QueryResult $queryResult
 	 * @param array $params
 	 */
-	public function outputAsFile( SMWQueryResult $queryResult, array $params );
+	public function outputAsFile( QueryResult $queryResult, array $params );
 
 	/**
 	 * Some printers do not mainly produce embeddable HTML or Wikitext, but
@@ -36,11 +36,11 @@ interface ExportPrinter extends QueryResultPrinter {
 	 *
 	 * @since 1.8
 	 *
-	 * @param SMWQueryResult $queryResult
+	 * @param QueryResult $queryResult
 	 *
 	 * @return string
 	 */
-	public function getMimeType( SMWQueryResult $queryResult );
+	public function getMimeType( QueryResult $queryResult );
 
 	/**
 	 * Some printers can produce not only embeddable HTML or Wikitext, but
@@ -49,10 +49,10 @@ interface ExportPrinter extends QueryResultPrinter {
 	 * in such a case (the default filename is created by browsers from the
 	 * URL, and it is often not pretty).
 	 *
-	 * @param SMWQueryResult $queryResult
+	 * @param QueryResult $queryResult
 	 *
 	 * @return string|boolean
 	 */
-	public function getFileName( SMWQueryResult $queryResult );
+	public function getFileName( QueryResult $queryResult );
 
 }

--- a/src/Query/ResultPrinter.php
+++ b/src/Query/ResultPrinter.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace SMW;
+namespace SMW\Query;
 
 use SMWQueryResult as QueryResult;
 
@@ -13,7 +13,7 @@ use SMWQueryResult as QueryResult;
  * @author Jeroen De Dauw < jeroendedauw@gmail.com >
  * @author Markus Krötzsch
  */
-interface QueryResultPrinter {
+interface ResultPrinter {
 
 	// Constructor restriction:
 	// Needs to have exactly one required argument $formatName.

--- a/src/Query/ResultPrinters/FileExportPrinter.php
+++ b/src/Query/ResultPrinters/FileExportPrinter.php
@@ -1,7 +1,8 @@
 <?php
 
-namespace SMW;
+namespace SMW\Query\ResultPrinters;
 
+use SMW\Query\ExportPrinter;
 use SMWQuery;
 use SMWQueryProcessor;
 use SMWQueryResult;

--- a/src/Query/ResultPrinters/ResultPrinter.php
+++ b/src/Query/ResultPrinters/ResultPrinter.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace SMW;
+namespace SMW\Query\ResultPrinters;
 
 use Linker;
 use ParamProcessor\ParamDefinition;
@@ -9,7 +9,9 @@ use Sanitizer;
 use SMWInfolink;
 use SMWQuery;
 use SMWQueryResult;
+use SMW\Message;
 use Title;
+use SMW\Query\ResultPrinter as IResultPrinter;
 
 /**
  * Abstract base class for printing query results.
@@ -40,7 +42,7 @@ use Title;
  *
  * @ingroup SMWQuery
  */
-abstract class ResultPrinter extends \ContextSource implements QueryResultPrinter {
+abstract class ResultPrinter extends \ContextSource implements IResultPrinter {
 
 	/**
 	 * @deprecated Use $params instead. Will be removed in 1.10.


### PR DESCRIPTION
This PR is made in reference to: #2740

This PR addresses or contains:

- Moves interface `SMW\ExportPrinter` to `SMW\Query\ExportPrinter`
- Moves interface `SMW\QueryResultPrinter` to `SMW\Query\ResultPrinter`

This PR includes:
- [ ] Tests (unit/integration)
- [x] CI build passed
