### PR TITLE
Move TableResultPrinter, refs 2740

### DIFF
--- a/DefaultSettings.php
+++ b/DefaultSettings.php
@@ -623,11 +623,11 @@ return array(
 	# 'broadtable' should not be disabled either in order not to break Special:ask.
 	##
 	'smwgResultFormats' => array(
-		'table'      => 'SMW\TableResultPrinter',
+		'table'      => 'SMW\Query\ResultPrinters\TableResultPrinter',
+		'broadtable' => 'SMW\Query\ResultPrinters\TableResultPrinter',
 		'list'       => 'SMW\ListResultPrinter',
 		'ol'         => 'SMW\ListResultPrinter',
 		'ul'         => 'SMW\ListResultPrinter',
-		'broadtable' => 'SMW\TableResultPrinter',
 		'category'   => 'SMW\CategoryResultPrinter',
 		'embedded'   => 'SMW\EmbeddedResultPrinter',
 		'template'   => 'SMW\ListResultPrinter',

--- a/src/Aliases.php
+++ b/src/Aliases.php
@@ -9,8 +9,10 @@ class_alias( 'SMW\Updater\DeferredCallableUpdate', 'SMW\DeferredCallableUpdate' 
 class_alias( 'SMW\Parser\InTextAnnotationParser', 'SMW\InTextAnnotationParser' );
 class_alias( 'SMW\Encoder', 'SMW\UrlEncoder' );
 class_alias( 'SMW\Query\ResultPrinter', 'SMW\QueryResultPrinter' );
+class_alias( 'SMW\Query\ResultPrinter', 'SMWIResultPrinter' );
 class_alias( 'SMW\Query\ExportPrinter', 'SMW\ExportPrinter' );
 class_alias( 'SMW\Query\ResultPrinters\ResultPrinter', 'SMW\ResultPrinter' );
+class_alias( 'SMW\Query\ResultPrinters\ResultPrinter', 'SMWResultPrinter' );
 class_alias( 'SMW\Query\ResultPrinters\FileExportPrinter', 'SMW\FileExportPrinter' );
 
 // 1.9.
@@ -25,18 +27,16 @@ class_alias( 'SMW\DataValueFactory', 'SMWDataValueFactory' );
 class_alias( 'SMW\Exception\DataItemException', 'SMWDataItemException' );
 class_alias( 'SMW\SQLStore\PropertyTableDefinition', 'SMWSQLStore3Table' );
 class_alias( 'SMW\DIConcept', 'SMWDIConcept' );
-class_alias( 'SMW\TableResultPrinter', 'SMWTableResultPrinter' );
+class_alias( 'SMW\Query\ResultPrinters\TableResultPrinter', 'SMWTableResultPrinter' );
 
 // 2.0
 class_alias( 'SMW\FileExportPrinter', 'SMWExportPrinter' );
-class_alias( 'SMW\ResultPrinter', 'SMWResultPrinter' );
 class_alias( 'SMW\AggregatablePrinter', 'SMWAggregatablePrinter' );
 class_alias( 'SMW\CategoryResultPrinter', 'SMWCategoryResultPrinter' );
 class_alias( 'SMW\DsvResultPrinter', 'SMWDSVResultPrinter' );
 class_alias( 'SMW\EmbeddedResultPrinter', 'SMWEmbeddedResultPrinter' );
 class_alias( 'SMW\RdfResultPrinter', 'SMWRDFResultPrinter' );
 class_alias( 'SMW\ListResultPrinter', 'SMWListResultPrinter' );
-class_alias( 'SMW\QueryResultPrinter', 'SMWIResultPrinter' );
 class_alias( 'SMW\RawResultPrinter', 'SMW\ApiResultPrinter' );
 
 // 2.0

--- a/src/Query/ResultPrinters/ResultPrinter.php
+++ b/src/Query/ResultPrinters/ResultPrinter.php
@@ -10,6 +10,7 @@ use SMWInfolink;
 use SMWQuery;
 use SMWQueryResult;
 use SMW\Message;
+use SMWOutputs as ResourceManager;
 use Title;
 use SMW\Query\ResultPrinter as IResultPrinter;
 
@@ -191,6 +192,23 @@ abstract class ResultPrinter extends \ContextSource implements IResultPrinter {
 	 */
 	public function isEnabledFeature( $feature ) {
 		return ( (int)$GLOBALS['smwgResultFormatsFeatures'] & $feature ) != 0;
+	}
+
+	/**
+	 * @since 3.0
+	 *
+	 * @param array $modules
+	 * @param array $styleModules
+	 */
+	public function registerResources( array $modules = [], array $styleModules = [] ) {
+
+		foreach ( $modules as $module ) {
+			ResourceManager::requireResource( $module );
+		}
+
+		foreach ( $styleModules as $styleModule ) {
+			ResourceManager::requireStyle( $styleModule );
+		}
 	}
 
 	/**

--- a/tests/phpunit/Unit/Query/ResultPrinters/TableResultPrinterTest.php
+++ b/tests/phpunit/Unit/Query/ResultPrinters/TableResultPrinterTest.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace SMW\Tests\Query\ResultPrinters;
+
+use SMW\Query\ResultPrinters\TableResultPrinter;
+
+/**
+ * @covers SMW\Query\ResultPrinters\TableResultPrinter
+ * @group semantic-mediawiki
+ *
+ * @license GNU GPL v2+
+ * @since 3.0
+ *
+ * @author mwjames
+ */
+class TableResultPrinterTest extends \PHPUnit_Framework_TestCase {
+
+	public function testCanConstruct() {
+
+		$this->assertInstanceOf(
+			TableResultPrinter::class,
+			new TableResultPrinter( 'table' )
+		);
+	}
+
+	public function testGetResult_Empty() {
+
+		$queryResult = $this->getMockBuilder( '\SMWQueryResult' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$queryResult->expects( $this->any() )
+			->method( 'getErrors' )
+			->will( $this->returnValue( [] ) );
+
+		$instance = new TableResultPrinter( 'table' );
+
+		$this->assertInternalType(
+			'string',
+			$instance->getResult( $queryResult, [], SMW_OUTPUT_WIKI )
+		);
+	}
+
+}


### PR DESCRIPTION
This PR is made in reference to: #2740

This PR addresses or contains:

- Moves  `SMW\TableResultPrinter` to  `SMW\Query\ResultPrinters\TableResultPrinter`

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed
