### PR TITLE
Remove ContextSource from ResultPrinter, refs 842

### DIFF
--- a/includes/queryprinters/FeedResultPrinter.php
+++ b/includes/queryprinters/FeedResultPrinter.php
@@ -34,7 +34,7 @@ final class FeedResultPrinter extends FileExportPrinter {
 	 * @return string
 	 */
 	public function getName() {
-		return $this->getContext()->msg( 'smw-printername-feed' )->text();
+		return $this->msg( 'smw-printername-feed' )->text();
 	}
 
 	/**
@@ -74,7 +74,7 @@ final class FeedResultPrinter extends FileExportPrinter {
 
 		if ( $outputMode == SMW_OUTPUT_FILE ) {
 			if ( $res->getCount() == 0 ){
-				$res->addErrors( array( $this->getContext()->msg( 'smw_result_noresults' )->inContentLanguage()->text() ) );
+				$res->addErrors( array( $this->msg( 'smw_result_noresults' )->inContentLanguage()->text() ) );
 			}
 
 			$result = $this->getFeed( $res, $this->params['type'] );
@@ -101,7 +101,7 @@ final class FeedResultPrinter extends FileExportPrinter {
 		global $wgFeedClasses;
 
 		if( !isset( $wgFeedClasses[$type] ) ) {
-			$results->addErrors( array( $this->getContext()->msg( 'feed-invalid' )->inContentLanguage()->text() ) );
+			$results->addErrors( array( $this->msg( 'feed-invalid' )->inContentLanguage()->text() ) );
 			return '';
 		}
 
@@ -149,7 +149,7 @@ final class FeedResultPrinter extends FileExportPrinter {
 	 * @return string
 	 */
 	protected function feedDescription() {
-		return $this->params['description'] !== '' ? $this->getContext()->msg( 'smw-label-feed-description', $this->params['description'], $this->params['type'] )->text() : $this->getContext()->msg( 'tagline' )->text();
+		return $this->params['description'] !== '' ? $this->msg( 'smw-label-feed-description', $this->params['description'], $this->params['type'] )->text() : $this->msg( 'tagline' )->text();
 	}
 
 	/**
@@ -312,7 +312,7 @@ final class FeedResultPrinter extends FileExportPrinter {
 	public function getParamDefinitions( array $definitions ) {
 		$params = parent::getParamDefinitions( $definitions );
 
-		$params['searchlabel']->setDefault( $this->getContext()->msg( 'smw-label-feed-link' )->inContentLanguage()->text() );
+		$params['searchlabel']->setDefault( $this->msg( 'smw-label-feed-link' )->inContentLanguage()->text() );
 
 		$params['type'] = array(
 			'type' => 'string',

--- a/includes/queryprinters/ListResultPrinter.php
+++ b/includes/queryprinters/ListResultPrinter.php
@@ -127,7 +127,7 @@ class ListResultPrinter extends ResultPrinter {
 	public function getName() {
 		// Give grep a chance to find the usages:
 		// smw_printername_list, smw_printername_ol,smw_printername_ul, smw_printername_template
-		return $this->getContext()->msg( 'smw_printername_' . $this->mFormat )->text();
+		return $this->msg( 'smw_printername_' . $this->mFormat )->text();
 	}
 
 	/**
@@ -150,7 +150,7 @@ class ListResultPrinter extends ResultPrinter {
 	protected function getResultText( SMWQueryResult $queryResult, $outputMode ) {
 		if ( $this->mFormat == 'template' && !$this->mTemplate ) {
 			$queryResult->addErrors( array(
-				$this->getContext()->msg( 'smw_notemplategiven' )->inContentLanguage()->text()
+				$this->msg( 'smw_notemplategiven' )->inContentLanguage()->text()
 			) );
 			return '';
 		}
@@ -239,7 +239,7 @@ class ListResultPrinter extends ResultPrinter {
 		if ( $this->params['format'] === 'list' && $this->params['sep'] === ',' ) {
 			// Make default list ", , , and "
 			$this->listsep = ', ';
-			$this->finallistsep = $this->getContext()->msg( 'smw_finallistconjunct' )->inContentLanguage()->text() . ' ';
+			$this->finallistsep = $this->msg( 'smw_finallistconjunct' )->inContentLanguage()->text() . ' ';
 		} elseif ( $this->params['format'] !== 'template' && $this->params['sep'] === '' ) {
 			$this->listsep = ', ';
 			$this->finallistsep = $this->listsep;


### PR DESCRIPTION
This PR is made in reference to: #2748, cb6c6ad

This PR addresses or contains:

- Removes the use of `ContextSource` (`RequestContext`) from the `ResultPrinter` instance
- There is no particular need for the project to carry around a kitchen sink object like the `ContextSource` which has (and only would) increase dependency on a very specific MediaWiki concept.
- For now, `ResultPrinter` provides `ResultPrinter::msg` as interim's method in case some callers relied upon this method to fetch `Message` objects 

This PR includes:
- [ ] Tests (unit/integration)
- [x] CI build passed

Fixes: #842