### PR TITLE
Remove smwgSparqlDatabaseMaster / smwfGetSparqlDatabase

### DIFF
--- a/includes/Settings.php
+++ b/includes/Settings.php
@@ -422,7 +422,8 @@ class Settings extends Options {
 			),
 			'removal' => array(
 				'smwgOnDeleteAction' => '2.4.0',
-				'smwgAutocompleteInSpecialAsk' => '3.0.0'
+				'smwgAutocompleteInSpecialAsk' => '3.0.0',
+				'smwgSparqlDatabaseMaster' => '3.0.0'
 			)
 		);
 	}

--- a/src/GlobalFunctions.php
+++ b/src/GlobalFunctions.php
@@ -3,7 +3,6 @@
 use SMW\CompatibilityMode;
 use SMW\NamespaceManager;
 use SMW\IntlNumberFormatter;
-use SMW\SPARQLStore\SparqlDBConnectionProvider;
 use SMW\ProcessingErrorMsgHandler;
 use SMW\Highlighter;
 
@@ -173,31 +172,6 @@ function smwfCacheKey( $namespace, $key ) {
 	}
 
 	return $cachePrefix . $namespace . ':' . md5( $key );
-}
-
-/**
- * @codeCoverageIgnore
- *
- * Get the SMWSparqlDatabase object to use for connecting to a SPARQL store,
- * or null if no SPARQL backend has been set up.
- *
- * Currently, it just returns one globally defined object, but the
- * infrastructure allows to set up load balancing and task-dependent use of
- * stores (e.g. using other stores for fast querying than for storing new
- * facts), somewhat similar to MediaWiki's DB implementation.
- *
- * @since 1.6
- *
- * @return SMWSparqlDatabase or null
- */
-function &smwfGetSparqlDatabase() {
-
-	if ( !isset( $GLOBALS['smwgSparqlDatabaseMaster'] ) ) {
-		$connectionProvider = new SparqlDBConnectionProvider();
-		$GLOBALS['smwgSparqlDatabaseMaster'] = $connectionProvider->getConnection();
-	}
-
-	return $GLOBALS['smwgSparqlDatabaseMaster'];
 }
 
 /**

--- a/tests/phpunit/Unit/GlobalFunctionsTest.php
+++ b/tests/phpunit/Unit/GlobalFunctionsTest.php
@@ -112,7 +112,6 @@ class GlobalFunctionsTest extends \PHPUnit_Framework_TestCase {
 			array( 'smwfNumberFormat' ),
 			array( 'smwfEncodeMessages' ),
 			array( 'smwfGetStore' ),
-			array( 'smwfGetSparqlDatabase' ),
 			array( 'smwfGetLinker' ),
 		);
 	}


### PR DESCRIPTION
This PR is made in reference to: #

This PR addresses or contains:

- Removes setting `$smwgSparqlDatabaseMaster` and function `smwfGetSparqlDatabase`

This PR includes:
- [ ] Tests (unit/integration)
- [x] CI build passed

Fixes #