### PR TITLE
ResultPrinter isolate $wgParser access

### DIFF
--- a/i18n/en.json
+++ b/i18n/en.json
@@ -621,6 +621,6 @@
 	"apihelp-browsebysubject-summary": "API module to retrieve information about a subject.",
 	"apihelp-smwtask-summary": "API module to execute Semantic MediaWiki related tasks.",
 	"apihelp-smwbrowse-summary": "Semantic MediaWiki API module to support selected browse activties.",
-	"smw-api-smwbrowse-invalid-parameters": "Parameters format is invalid, expected a valid JSON format."
-
+	"smw-api-smwbrowse-invalid-parameters": "Parameters format is invalid, expected a valid JSON format.",
+	"smw-parser-recursion-level-exceeded": "The level of $1 recursions was exceeded during a parse process. It is suggested to validated the template structure, or if necessary adjust `maxRecursionDepth`."
 }

--- a/includes/queryprinters/EmbeddedResultPrinter.php
+++ b/includes/queryprinters/EmbeddedResultPrinter.php
@@ -54,6 +54,13 @@ class EmbeddedResultPrinter extends ResultPrinter {
 	}
 
 	protected function getResultText( SMWQueryResult $res, $outputMode ) {
+
+		// Ensure that there is an annotation block in place before starting the
+		// parse and transclution process. Unfortunately we are unable to block
+		// the inclusion of categories which are attached to a MediaWiki
+		// object we have no immediate access or control.
+		$this->transcludeAnnotation = false;
+
 		global $wgParser;
 		// No page should embed itself, find out who we are:
 		if ( $wgParser->getTitle() instanceof Title ) {

--- a/src/Parser/RecursiveTextProcessor.php
+++ b/src/Parser/RecursiveTextProcessor.php
@@ -1,0 +1,208 @@
+<?php
+
+namespace SMW\Parser;
+
+use Parser;
+use Title;
+use ParserOptions;
+use ParserOutput;
+use RuntimeException;
+use SMW\ParserData;
+
+/**
+ * @private
+ *
+ * Helper class in processing content that requires to be parsed internally and
+ * recursively mostly in connection with templates.
+ *
+ * @license GNU GPL v2+
+ * @since 3.0
+ *
+ * @author mwjames
+ */
+class RecursiveTextProcessor {
+
+	/**
+	 * @var Parser
+	 */
+	private $parser;
+
+	/**
+	 * Incremented while expanding templates inserted during printout; stop
+	 * expansion at some point
+	 *
+	 * @var integer
+	 */
+	private $recursionDepth = 0;
+
+	/**
+	 * @var integer
+	 */
+	private $maxRecursionDepth = 2;
+
+	/**
+	 * @var boolean
+	 */
+	private $recursiveAnnotation = false;
+
+	/**
+	 * @var string
+	 */
+	private $error = [];
+
+	/**
+	 * @since 3.0
+	 *
+	 * @param Parser $parser|null
+	 */
+	public function __construct( Parser $parser = null ) {
+		$this->parser = $parser;
+
+		if ( $this->parser === null ) {
+			$this->parser = $GLOBALS['wgParser'];
+		}
+	}
+
+	/**
+	 * @since 3.0
+	 *
+	 * @return Parser
+	 */
+	public function getParser() {
+		return $this->parser;
+	}
+
+	/**
+	 * @since 3.0
+	 *
+	 * @return []
+	 */
+	public function getError() {
+		return $this->error;
+	}
+
+	/**
+	 * @since 3.0
+	 *
+	 * @param integer $maxRecursionDepth
+	 */
+	public function setMaxRecursionDepth( $maxRecursionDepth ) {
+		$this->maxRecursionDepth = $maxRecursionDepth;
+	}
+
+	/**
+	 * @since 3.0
+	 *
+	 * @param boolean $transcludeAnnotation
+	 */
+	public function transcludeAnnotation( $transcludeAnnotation ) {
+		if ( $this->parser->getOutput() !== null ) {
+			$this->parser->getOutput()->setExtensionData( ParserData::ANNOTATION_BLOCK, !(bool)$transcludeAnnotation );
+		}
+	}
+
+	/**
+	 * @since 3.0
+	 */
+	public function releaseAnyAnnotationBlock() {
+		if ( $this->parser->getOutput() !== null ) {
+			$this->parser->getOutput()->setExtensionData( ParserData::ANNOTATION_BLOCK, false );
+		}
+	}
+
+	/**
+	 * @since 3.0
+	 *
+	 * @param boolean $recursiveAnnotation
+	 */
+	public function setRecursiveAnnotation( $recursiveAnnotation ) {
+		$this->recursiveAnnotation = (bool)$recursiveAnnotation;
+	}
+
+	/**
+	 * @since 3.0
+	 *
+	 * @param ParserData $parserData
+	 */
+	public function copyData( ParserData $parserData ) {
+		if ( $this->recursiveAnnotation ) {
+			$parserData->importFromParserOutput( $this->parser->getOutput() );
+		}
+	}
+
+	/**
+	 * @since 3.0
+	 *
+	 * @param string $text
+	 *
+	 * @return text
+	 */
+	public function recursivePreprocess( $text ) {
+
+		// not during parsing, no preprocessing needed, still protect the result
+		if ( $this->parser === null || !$this->parser->getTitle() instanceof Title || !$this->parser->getOptions() instanceof ParserOptions ) {
+			return $this->recursiveAnnotation ? $text : '[[SMW::off]]' . $text . '[[SMW::on]]';
+		}
+
+		$this->recursionDepth++;
+
+		// restrict recursion
+		if ( $this->recursionDepth <= $this->maxRecursionDepth && $this->recursiveAnnotation ) {
+			$text =  $this->parser->recursivePreprocess( $text );
+		} elseif ( $this->recursionDepth <= $this->maxRecursionDepth ) {
+			$text = '[[SMW::off]]' . $this->parser->replaceVariables( $text ) . '[[SMW::on]]';
+		} else {
+			$this->error = [ 'smw-parser-recursion-level-exceeded', $this->maxRecursionDepth ];
+			$text = '';
+		}
+
+		$this->recursionDepth--;
+
+		return $text;
+	}
+
+	/**
+	 * @since 3.0
+	 *
+	 * @param string $text
+	 *
+	 * @return text
+	 */
+	public function recursiveTagParse( $text ) {
+
+		if ( $this->parser === null ) {
+			throw new RuntimeException( 'Missing a parser instance' );
+		}
+
+		$this->recursionDepth++;
+		$isValid = $this->parser->getTitle() instanceof Title && $this->parser->getOptions() instanceof ParserOptions;
+
+		if ( $this->recursionDepth <= $this->maxRecursionDepth && $isValid ) {
+				$text = $this->parser->recursiveTagParse( $text );
+		} elseif ( $this->recursionDepth <= $this->maxRecursionDepth ) {
+			$title = $GLOBALS['wgTitle'];
+
+			if ( $title === null ) {
+				$title = Title::newFromText( 'UNKNOWN_TITLE' );
+			}
+
+			$popt = new ParserOptions();
+			$popt->setEditSection( false );
+			$parserOutput = $this->parser->parse( $text . '__NOTOC__', $title, $popt );
+
+			// Maybe better to use Parser::recursiveTagParseFully ??
+
+			/// NOTE: as of MW 1.14SVN, there is apparently no better way to hide the TOC
+			\SMWOutputs::requireFromParserOutput( $parserOutput );
+			$text = $parserOutput->getText();
+		} else {
+			$this->error = [ 'smw-parser-recursion-level-exceeded', $this->maxRecursionDepth ];
+			$text = '';
+		}
+
+		$this->recursionDepth--;
+
+		return $text;
+	}
+
+}

--- a/src/ParserFunctionFactory.php
+++ b/src/ParserFunctionFactory.php
@@ -12,6 +12,7 @@ use SMW\ParserFunctions\ConceptParserFunction;
 use SMW\ParserFunctions\DeclareParserFunction;
 use SMW\ParserFunctions\ExpensiveFuncExecutionWatcher;
 use SMW\Utils\CircularReferenceGuard;
+use SMW\Parser\RecursiveTextProcessor;
 use Parser;
 
 /**
@@ -149,6 +150,10 @@ class ParserFunctionFactory {
 
 		$askParserFunction->setPostProcHandler(
 			$applicationFactory->create( 'PostProcHandler', $parser->getOutput() )
+		);
+
+		$askParserFunction->setRecursiveTextProcessor(
+			new RecursiveTextProcessor( $parser )
 		);
 
 		return $askParserFunction;

--- a/tests/phpunit/Unit/Parser/RecursiveTextProcessorTest.php
+++ b/tests/phpunit/Unit/Parser/RecursiveTextProcessorTest.php
@@ -1,0 +1,203 @@
+<?php
+
+namespace SMW\Tests\Parser;
+
+use SMW\Parser\RecursiveTextProcessor;
+
+/**
+ * @covers \SMW\Parser\RecursiveTextProcessor
+ * @group semantic-mediawiki
+ *
+ * @license GNU GPL v2+
+ * @since 3.0
+ *
+ * @author mwjames
+ */
+class RecursiveTextProcessorTest extends \PHPUnit_Framework_TestCase {
+
+	private $parser;
+	private $parserOptions;
+	private $parserOutput;
+	private $title;
+
+	protected function setUp() {
+		parent::setUp();
+
+		$this->parser = $this->getMockBuilder( '\Parser' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$this->parserOptions = $this->getMockBuilder( '\ParserOptions' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$this->parserOutput = $this->getMockBuilder( '\ParserOutput' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$this->parserOutput->expects( $this->any() )
+			->method( 'getHeadItems' )
+			->will( $this->returnValue( [] ) );
+
+		$this->title = $this->getMockBuilder( '\Title' )
+			->disableOriginalConstructor()
+			->getMock();
+	}
+
+	public function testCanConstruct() {
+
+		$this->assertInstanceOf(
+			RecursiveTextProcessor::class,
+			new RecursiveTextProcessor( $this->parser )
+		);
+	}
+
+	public function testRecursivePreprocess_NO_RecursiveAnnotation() {
+
+		$this->parser->expects( $this->atLeastOnce() )
+			->method( 'getTitle' )
+			->will( $this->returnValue( $this->title ) );
+
+		$this->parser->expects( $this->atLeastOnce() )
+			->method( 'getOptions' )
+			->will( $this->returnValue( $this->parserOptions ) );
+
+		$this->parser->expects( $this->once() )
+			->method( 'replaceVariables' )
+			->with( $this->equalTo( 'Foo' ) )
+			->will( $this->returnArgument( 0 ) );
+
+		$instance = new RecursiveTextProcessor(
+			$this->parser
+		);
+
+		$this->assertSame(
+			'[[SMW::off]]Foo[[SMW::on]]',
+			$instance->recursivePreprocess( 'Foo' )
+		);
+	}
+
+	public function testRecursivePreprocess_WITH_RecursiveAnnotation() {
+
+		$this->parser->expects( $this->atLeastOnce() )
+			->method( 'getTitle' )
+			->will( $this->returnValue( $this->title ) );
+
+		$this->parser->expects( $this->atLeastOnce() )
+			->method( 'getOptions' )
+			->will( $this->returnValue( $this->parserOptions ) );
+
+		$this->parser->expects( $this->once() )
+			->method( 'recursivePreprocess' )
+			->with( $this->equalTo( 'Foo' ) )
+			->will( $this->returnArgument( 0 ) );
+
+		$instance = new RecursiveTextProcessor(
+			$this->parser
+		);
+
+		$instance->setRecursiveAnnotation( true );
+
+		$this->assertSame(
+			'Foo',
+			$instance->recursivePreprocess( 'Foo' )
+		);
+	}
+
+	public function testRecursivePreprocess_WITH_IncompleteParser() {
+
+		$instance = new RecursiveTextProcessor(
+			$this->parser
+		);
+
+		$instance->setRecursiveAnnotation( false );
+
+		$this->assertSame(
+			'[[SMW::off]]Foo[[SMW::on]]',
+			$instance->recursivePreprocess( 'Foo' )
+		);
+
+		$instance->setRecursiveAnnotation( true );
+
+		$this->assertSame(
+			'Foo',
+			$instance->recursivePreprocess( 'Foo' )
+		);
+	}
+
+	public function testRecursiveTagParse() {
+
+		$this->parser->expects( $this->atLeastOnce() )
+			->method( 'getTitle' )
+			->will( $this->returnValue( $this->title ) );
+
+		$this->parser->expects( $this->atLeastOnce() )
+			->method( 'getOptions' )
+			->will( $this->returnValue( $this->parserOptions ) );
+
+		$this->parser->expects( $this->once() )
+			->method( 'recursiveTagParse' )
+			->with( $this->equalTo( 'Foo' ) )
+			->will( $this->returnArgument( 0 ) );
+
+		$instance = new RecursiveTextProcessor(
+			$this->parser
+		);
+
+		$this->assertSame(
+			'Foo',
+			$instance->recursiveTagParse( 'Foo' )
+		);
+	}
+
+	public function testRecursiveTagParse_WITH_IncompleteParser() {
+
+		$this->parser->expects( $this->once() )
+			->method( 'parse' )
+			->with( $this->equalTo( 'Foo__NOTOC__' ) )
+			->will( $this->returnValue( $this->parserOutput ) );
+
+		$instance = new RecursiveTextProcessor(
+			$this->parser
+		);
+
+		$instance->recursiveTagParse( 'Foo' );
+	}
+
+	public function testRecursivePreprocess_ExceededRecursion() {
+
+		$this->parser->expects( $this->atLeastOnce() )
+			->method( 'getTitle' )
+			->will( $this->returnValue( $this->title ) );
+
+		$this->parser->expects( $this->atLeastOnce() )
+			->method( 'getOptions' )
+			->will( $this->returnValue( $this->parserOptions ) );
+
+		$instance = new RecursiveTextProcessor(
+			$this->parser
+		);
+
+		$instance->setMaxRecursionDepth( 0 );
+		$instance->recursivePreprocess( 'Foo' );
+
+		$this->assertNotEmpty(
+			$instance->getError()
+		);
+	}
+
+	public function testRecursiveTagParse_ExceededRecursion() {
+
+		$instance = new RecursiveTextProcessor(
+			$this->parser
+		);
+
+		$instance->setMaxRecursionDepth( 0 );
+		$instance->recursiveTagParse( 'Foo' );
+
+		$this->assertNotEmpty(
+			$instance->getError()
+		);
+	}
+
+}


### PR DESCRIPTION
This PR is made in reference to: #

This PR addresses or contains:

- Introduces `RecursiveTextProcessor` to isolate direct access to `wgParser` in `ResultPrinter`
- `RecursiveTextProcessor` carries the parser instance from the initial `#ask` request, and if no parser is available (as during `Special:Ask`) falls back to the global `wgParser` instance
- Fixes "/// TODO: explain problem (too much recursive parses)" and "// FIXME Parser should be injected into the ResultPrinter"
- Removes handling of `import-annotation` from the `AskParserFunction`

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed
