### PR TITLE
Ren smwgSparqlDatabaseConnector to smwgSparqlRepositoryConnector

### DIFF
--- a/DefaultSettings.php
+++ b/DefaultSettings.php
@@ -123,7 +123,7 @@ return array(
 	# supports this. Different wikis should normally use different default graphs
 	# unless there is a good reason to share one graph.
 	##
-	'smwgSparqlDatabase' => 'SMWSparqlDatabase',
+	'smwgSparqlCustomConnector' => 'SMWSparqlDatabase',
 	'smwgSparqlQueryEndpoint' => 'http://localhost:8080/sparql/',
 	'smwgSparqlUpdateEndpoint' => 'http://localhost:8080/update/',
 	'smwgSparqlDataEndpoint' => 'http://localhost:8080/data/',
@@ -131,32 +131,28 @@ return array(
 	##
 
 	##
-	# SparqlDBConnectionProvider
+	# Sparql repository connector
 	#
-	# Identifies a database connector that ought to be used together with the
-	# SPARQLStore
+	# Identifies a pre-deployed repository connector that is ought to be used
+	# together with the SPARQLStore.
 	#
-	# List of standard connectors ($smwgSparqlDatabase will have no effect)
+	# List of standard connectors ($smwgSparqlCustomConnector will have no effect)
 	# - 'fuseki'
 	# - 'virtuoso'
 	# - '4store'
 	# - 'sesame'
 	# - 'generic'
 	#
-	# With 2.0 it is suggested to assign the necessary connector to
-	# $smwgSparqlDatabaseConnector in order to avoid arbitrary class assignments in
-	# $smwgSparqlDatabase (which can change in future releases without further notice).
+	# In case $smwgSparqlRepositoryConnector = 'custom' is maintained, $smwgSparqlCustomConnector
+	# is expected to contain a custom class connector where $smwgSparqlCustomConnector is only
+	# for the definition of a custom connector.
 	#
-	# In case $smwgSparqlDatabaseConnector = 'custom' is maintained, $smwgSparqlDatabase
-	# is expected to contain a custom class connector where $smwgSparqlDatabase is only
-	# to be sued for when a custom database connector is necessary.
-	#
-	# $smwgSparqlDatabaseConnector = 'custom' is set as legacy configuration to allow for
+	# $smwgSparqlRepositoryConnector = 'custom' is set as legacy configuration to allow for
 	# existing (prior 2.0) customizing to work without changes.
 	#
 	# @since 2.0
 	##
-	'smwgSparqlDatabaseConnector' => 'custom',
+	'smwgSparqlRepositoryConnector' => 'custom',
 	##
 
 	##

--- a/includes/Settings.php
+++ b/includes/Settings.php
@@ -54,8 +54,8 @@ class Settings extends Options {
 			'smwgEnabledCompatibilityMode' => $GLOBALS['smwgEnabledCompatibilityMode'],
 			'smwgDefaultStore' => $GLOBALS['smwgDefaultStore'],
 			'smwgLocalConnectionConf' => $GLOBALS['smwgLocalConnectionConf'],
-			'smwgSparqlDatabaseConnector' => $GLOBALS['smwgSparqlDatabaseConnector'],
-			'smwgSparqlDatabase' => $GLOBALS['smwgSparqlDatabase'],
+			'smwgSparqlRepositoryConnector' => $GLOBALS['smwgSparqlRepositoryConnector'],
+			'smwgSparqlCustomConnector' => $GLOBALS['smwgSparqlCustomConnector'],
 			'smwgSparqlQueryEndpoint' => $GLOBALS['smwgSparqlQueryEndpoint'],
 			'smwgSparqlUpdateEndpoint' => $GLOBALS['smwgSparqlUpdateEndpoint'],
 			'smwgSparqlDataEndpoint' => $GLOBALS['smwgSparqlDataEndpoint'],
@@ -375,6 +375,14 @@ class Settings extends Options {
 			$configuration['smwgQueryProfiler'] = $configuration['smwgQueryProfiler'] | SMW_QPRFL_PARAMS;
 		}
 
+		if ( isset( $GLOBALS['smwgSparqlDatabaseConnector'] ) ) {
+			$configuration['smwgSparqlRepositoryConnector'] = $GLOBALS['smwgSparqlDatabaseConnector'];
+		}
+
+		if ( isset( $GLOBALS['smwgSparqlDatabase'] ) ) {
+			$configuration['smwgSparqlCustomConnector'] = $GLOBALS['smwgSparqlDatabase'];
+		}
+
 		// Deprecated mapping used in DeprecationNoticeTaskHandler to detect and
 		// output notices
 		$GLOBALS['smwgDeprecationNotices'] = array(
@@ -384,6 +392,8 @@ class Settings extends Options {
 				'smwgQueryDependencyAffiliatePropertyDetectionlist' => '3.1.0',
 				'smwgSubPropertyListLimit' => '3.1.0',
 				'smwgRedirectPropertyListLimit' => '3.1.0',
+				'smwgSparqlDatabaseConnector' => '3.1.0',
+				'smwgSparqlDatabase' => '3.1.0',
 				'options' => [
 					'smwgCacheUsage' =>  [
 						'smwgStatisticsCache' => '3.1.0',
@@ -407,6 +417,8 @@ class Settings extends Options {
 				'smwgQueryDependencyAffiliatePropertyDetectionlist' => 'smwgQueryDependencyAffiliatePropertyDetectionList',
 				'smwgSubPropertyListLimit' => 'smwgPropertyListLimit',
 				'smwgRedirectPropertyListLimit' => 'smwgPropertyListLimit',
+				'smwgSparqlDatabaseConnector' => 'smwgSparqlRepositoryConnector',
+				'smwgSparqlDatabase' => 'smwgSparqlCustomConnector',
 				'options' => [
 					'smwgCacheUsage' => [
 						'smwgStatisticsCacheExpiry' => 'special.statistics',

--- a/load.php
+++ b/load.php
@@ -155,7 +155,7 @@ class SemanticMediaWiki {
 		};
 
 		if ( strpos( strtolower( $store ), 'sparql' ) ) {
-			$store .= '::' . strtolower( $GLOBALS['smwgSparqlDatabaseConnector'] );
+			$store .= '::' . strtolower( $GLOBALS['smwgSparqlRepositoryConnector'] );
 		}
 
 		return array(

--- a/src/SPARQLStore/RepositoryConnectionProvider.php
+++ b/src/SPARQLStore/RepositoryConnectionProvider.php
@@ -2,13 +2,18 @@
 
 namespace SMW\SPARQLStore;
 
+use SMW\SPARQLStore\RepositoryConnectors\GenericHttpRepositoryConnector;
+use SMW\SPARQLStore\RepositoryConnectors\FusekiHttpRepositoryConnector;
+use SMW\SPARQLStore\RepositoryConnectors\VirtuosoHttpRepositoryConnector;
+use SMW\SPARQLStore\RepositoryConnectors\FourstoreHttpRepositoryConnector;
 use Onoi\HttpRequest\CurlRequest;
 use RuntimeException;
 use SMW\DBConnectionProvider;
 
 /**
- * Provides an one-stop solution for creating a valid instance for a
- * RepositoryConnection using available settings
+ * @private
+ *
+ * Provides a RepositoryConnection on the available settings.
  *
  * @license GNU GPL v2+
  * @since 2.0
@@ -22,13 +27,13 @@ class RepositoryConnectionProvider implements DBConnectionProvider {
 	 *
 	 * @var array
 	 */
-	private $connectorIdToClass = array(
-		'default'   => 'SMW\SPARQLStore\RepositoryConnectors\GenericHttpRepositoryConnector',
-		'generic'   => 'SMW\SPARQLStore\RepositoryConnectors\GenericHttpRepositoryConnector',
-		'sesame'    => 'SMW\SPARQLStore\RepositoryConnectors\GenericHttpRepositoryConnector',
-		'fuseki'    => 'SMW\SPARQLStore\RepositoryConnectors\FusekiHttpRepositoryConnector',
-		'virtuoso'  => 'SMW\SPARQLStore\RepositoryConnectors\VirtuosoHttpRepositoryConnector',
-		'4store'    => 'SMW\SPARQLStore\RepositoryConnectors\FourstoreHttpRepositoryConnector',
+	private $repositoryConnectors = array(
+		'default'   => GenericHttpRepositoryConnector::class,
+		'generic'   => GenericHttpRepositoryConnector::class,
+		'sesame'    => GenericHttpRepositoryConnector::class,
+		'fuseki'    => FusekiHttpRepositoryConnector::class,
+		'virtuoso'  => VirtuosoHttpRepositoryConnector::class,
+		'4store'    => FourstoreHttpRepositoryConnector::class,
 	);
 
 	/**
@@ -62,6 +67,11 @@ class RepositoryConnectionProvider implements DBConnectionProvider {
 	private $dataEndpoint = null;
 
 	/**
+	 * @var HttpRequest
+	 */
+	private $httpRequest;
+
+	/**
 	 * @var boolean|integer
 	 */
 	private $httpVersion = false;
@@ -83,7 +93,7 @@ class RepositoryConnectionProvider implements DBConnectionProvider {
 		$this->dataEndpoint = $dataEndpoint;
 
 		if ( $this->connectorId === null ) {
-			$this->connectorId = $GLOBALS['smwgSparqlDatabaseConnector'];
+			$this->connectorId = $GLOBALS['smwgSparqlRepositoryConnector'];
 		}
 
 		if ( $this->defaultGraph === null ) {
@@ -101,6 +111,15 @@ class RepositoryConnectionProvider implements DBConnectionProvider {
 		if ( $this->dataEndpoint === null ) {
 			$this->dataEndpoint = $GLOBALS['smwgSparqlDataEndpoint'];
 		}
+	}
+
+	/**
+	 * @since 3.0
+	 *
+	 * @return HttpRequest $httpRequest
+	 */
+	public function setHttpRequest( HttpRequest $httpRequest ) {
+		$this->httpRequest = $httpRequest;
 	}
 
 	/**
@@ -138,46 +157,53 @@ class RepositoryConnectionProvider implements DBConnectionProvider {
 		$this->connection = null;
 	}
 
-	private function connectTo( $connectorId ) {
+	private function connectTo( $id ) {
 
-		$repositoryConnector = $this->mapConnectorIdToClass( $connectorId );
-
-		$curlRequest = new CurlRequest( curl_init() );
+		if ( $this->httpRequest === null ) {
+			$this->httpRequest = new CurlRequest( curl_init() );
+		}
 
 		// https://github.com/SemanticMediaWiki/SemanticMediaWiki/issues/1306
 		if ( $this->httpVersion ) {
-			$curlRequest->setOption( CURLOPT_HTTP_VERSION, $this->httpVersion );
+			$this->httpRequest->setOption( CURLOPT_HTTP_VERSION, $this->httpVersion );
 		}
 
-		$connection = new $repositoryConnector(
-			new RepositoryClient( $this->defaultGraph, $this->queryEndpoint, $this->updateEndpoint, $this->dataEndpoint ),
-			$curlRequest
+		$repositoryClient = new RepositoryClient(
+			$this->defaultGraph,
+			$this->queryEndpoint,
+			$this->updateEndpoint,
+			$this->dataEndpoint
 		);
 
-		if ( $this->isRepositoryConnection( $connection ) ) {
-			return $connection;
+		$repositoryConnector = $this->createRepositoryConnector(
+			$id,
+			$repositoryClient
+		);
+
+		if ( $this->isRepositoryConnection( $repositoryConnector ) ) {
+			return $repositoryConnector;
 		}
 
 		throw new RuntimeException( 'Expected a RepositoryConnection instance' );
 	}
 
-	private function mapConnectorIdToClass( $connectorId ) {
+	private function createRepositoryConnector( $id, $repositoryClient ) {
 
-		$databaseConnector = $this->connectorIdToClass['default'];
+		$repositoryConnector = $this->repositoryConnectors['default'];
 
-		if ( isset( $this->connectorIdToClass[$connectorId] ) ) {
-			$databaseConnector = $this->connectorIdToClass[$connectorId];
+		if ( isset( $this->repositoryConnectors[$id] ) ) {
+			$repositoryConnector = $this->repositoryConnectors[$id];
 		}
 
-		if ( $connectorId === 'custom' ) {
-			$databaseConnector = $GLOBALS['smwgSparqlDatabase'];
+		if ( $id === 'custom' ) {
+			$repositoryConnector = $GLOBALS['smwgSparqlCustomConnector'];
 		}
 
-		if ( !class_exists( $databaseConnector ) ) {
-			throw new RuntimeException( "{$databaseConnector} is not available" );
+		if ( !class_exists( $repositoryConnector ) ) {
+			throw new RuntimeException( "{$repositoryConnector} is not available" );
 		}
 
-		return $databaseConnector;
+		return new $repositoryConnector( $repositoryClient, $this->httpRequest );
 	}
 
 	private function isRepositoryConnection( $connection ) {

--- a/tests/phpunit/Integration/MediaWiki/Import/TimeDataTypeTest.php
+++ b/tests/phpunit/Integration/MediaWiki/Import/TimeDataTypeTest.php
@@ -32,7 +32,7 @@ class TimeDataTypeTest extends MwDBaseUnitTestCase {
 	protected function setUp() {
 		parent::setUp();
 
-		if ( strpos( strtolower( $GLOBALS['smwgSparqlDatabaseConnector'] ), 'virtuoso' ) !== false ) {
+		if ( strpos( strtolower( $GLOBALS['smwgSparqlRepositoryConnector'] ), 'virtuoso' ) !== false ) {
 			$this->markTestIncomplete(
 				"Virtuoso will fail for '1 January 300 BC' with 'Virtuoso 22007 Error DT006: Cannot convert -0302-12-28Z to datetime : Incorrect month field length'"
 			);

--- a/tests/phpunit/JsonTestCaseScriptRunner.php
+++ b/tests/phpunit/JsonTestCaseScriptRunner.php
@@ -82,7 +82,7 @@ abstract class JsonTestCaseScriptRunner extends MwDBaseUnitTestCase {
 		);
 
 		if ( $this->getStore() instanceof \SMWSparqlStore ) {
-			$this->connectorId = strtolower( $GLOBALS['smwgSparqlDatabaseConnector'] );
+			$this->connectorId = strtolower( $GLOBALS['smwgSparqlRepositoryConnector'] );
 		} else {
 			$this->connectorId = strtolower( $this->getDBConnection()->getType() );
 		}
@@ -258,7 +258,7 @@ abstract class JsonTestCaseScriptRunner extends MwDBaseUnitTestCase {
 			$this->markTestSkipped( $jsonTestCaseFileHandler->getReasonForSkip() );
 		}
 
-		if ( $this->getStore() instanceof \SMWSparqlStore && $jsonTestCaseFileHandler->requiredToSkipForConnector( $GLOBALS['smwgSparqlDatabaseConnector'] ) ) {
+		if ( $this->getStore() instanceof \SMWSparqlStore && $jsonTestCaseFileHandler->requiredToSkipForConnector( $GLOBALS['smwgSparqlRepositoryConnector'] ) ) {
 			$this->markTestSkipped( $jsonTestCaseFileHandler->getReasonForSkip() );
 		}
 	}

--- a/tests/phpunit/Unit/SPARQLStore/RepositoryConnectionProviderTest.php
+++ b/tests/phpunit/Unit/SPARQLStore/RepositoryConnectionProviderTest.php
@@ -17,28 +17,28 @@ use SMW\Tests\Utils\GlobalsProvider;
 class RepositoryConnectionProviderTest extends \PHPUnit_Framework_TestCase {
 
 	private $globalsProvider;
-	private $smwgSparqlDatabase;
-	private $smwgSparqlDatabaseConnector;
+	private $smwgSparqlCustomConnector;
+	private $smwgSparqlRepositoryConnector;
 
 	protected function setUp() {
 		parent::setUp();
 
 		$this->globalsProvider = GlobalsProvider::getInstance();
 
-		$this->smwgSparqlDatabaseConnector = $this->globalsProvider->get( 'smwgSparqlDatabaseConnector' );
-		$this->smwgSparqlDatabase = $this->globalsProvider->get( 'smwgSparqlDatabase' );
+		$this->smwgSparqlRepositoryConnector = $this->globalsProvider->get( 'smwgSparqlRepositoryConnector' );
+		$this->smwgSparqlCustomConnector = $this->globalsProvider->get( 'smwgSparqlCustomConnector' );
 	}
 
 	protected function tearDown() {
 
 		$this->globalsProvider->set(
-			'smwgSparqlDatabaseConnector',
-			$this->smwgSparqlDatabaseConnector
+			'smwgSparqlRepositoryConnector',
+			$this->smwgSparqlRepositoryConnector
 		);
 
 		$this->globalsProvider->set(
-			'smwgSparqlDatabase',
-			$this->smwgSparqlDatabase
+			'smwgSparqlCustomConnector',
+			$this->smwgSparqlCustomConnector
 		);
 
 		$this->globalsProvider->clear();
@@ -149,7 +149,7 @@ class RepositoryConnectionProviderTest extends \PHPUnit_Framework_TestCase {
 	public function testGetDefaultConnectorForUnknownConnectorId() {
 
 		$this->globalsProvider->set(
-			'smwgSparqlDatabaseConnector',
+			'smwgSparqlRepositoryConnector',
 			'default'
 		);
 
@@ -164,7 +164,7 @@ class RepositoryConnectionProviderTest extends \PHPUnit_Framework_TestCase {
 	public function testGetDefaultConnectorForEmptyConnectorId() {
 
 		$this->globalsProvider->set(
-			'smwgSparqlDatabaseConnector',
+			'smwgSparqlRepositoryConnector',
 			'default'
 		);
 
@@ -179,7 +179,7 @@ class RepositoryConnectionProviderTest extends \PHPUnit_Framework_TestCase {
 	public function testGetDefaultConnectorForUnMappedId() {
 
 		$this->globalsProvider->set(
-			'smwgSparqlDatabaseConnector',
+			'smwgSparqlRepositoryConnector',
 			'idThatCanNotBeMapped'
 		);
 
@@ -194,7 +194,7 @@ class RepositoryConnectionProviderTest extends \PHPUnit_Framework_TestCase {
 	public function testInvalidCustomClassConnectorThrowsException() {
 
 		$this->globalsProvider->set(
-			'smwgSparqlDatabase',
+			'smwgSparqlCustomConnector',
 			'InvalidCustomClassConnector'
 		);
 
@@ -207,7 +207,7 @@ class RepositoryConnectionProviderTest extends \PHPUnit_Framework_TestCase {
 	public function testInvalidCustomRespositoryConnectorThrowsException() {
 
 		$this->globalsProvider->set(
-			'smwgSparqlDatabase',
+			'smwgSparqlCustomConnector',
 			'\SMW\Tests\Utils\Fixtures\InvalidCustomRespositoryConnector'
 		);
 

--- a/tests/travis/update-configuration-settings.sh
+++ b/tests/travis/update-configuration-settings.sh
@@ -21,7 +21,7 @@ echo '$smwgNamespace = "http://example.org/id/";' >> LocalSettings.php
 if [ "$FOURSTORE" != "" ]
 then
 	echo '$smwgDefaultStore = "SMWSparqlStore";' >> LocalSettings.php
-	echo '$smwgSparqlDatabaseConnector = "4Store";' >> LocalSettings.php
+	echo '$smwgSparqlRepositoryConnector = "4Store";' >> LocalSettings.php
 	echo '$smwgSparqlQueryEndpoint = "http://localhost:8088/sparql/";' >> LocalSettings.php
 	echo '$smwgSparqlUpdateEndpoint = "http://localhost:8088/update/";' >> LocalSettings.php
 	echo '$smwgSparqlDataEndpoint = "";' >> LocalSettings.php
@@ -29,21 +29,21 @@ then
 elif [ "$FUSEKI" != "" ]
 then
 	echo '$smwgDefaultStore = "SMWSparqlStore";' >> LocalSettings.php
-	echo '$smwgSparqlDatabaseConnector = "Fuseki";' >> LocalSettings.php
+	echo '$smwgSparqlRepositoryConnector = "Fuseki";' >> LocalSettings.php
 	echo '$smwgSparqlQueryEndpoint = "http://localhost:3030/db/query";' >> LocalSettings.php
 	echo '$smwgSparqlUpdateEndpoint = "http://localhost:3030/db/update";' >> LocalSettings.php
 	echo '$smwgSparqlDataEndpoint = "";' >> LocalSettings.php
 elif [ "$SESAME" != "" ]
 then
 	echo '$smwgDefaultStore = "SMWSparqlStore";' >> LocalSettings.php
-	echo '$smwgSparqlDatabaseConnector = "Sesame";' >> LocalSettings.php
+	echo '$smwgSparqlRepositoryConnector = "Sesame";' >> LocalSettings.php
 	echo '$smwgSparqlQueryEndpoint = "http://localhost:8080/openrdf-sesame/repositories/test-smw";' >> LocalSettings.php
 	echo '$smwgSparqlUpdateEndpoint = "http://localhost:8080/openrdf-sesame/repositories/test-smw/statements";' >> LocalSettings.php
 	echo '$smwgSparqlDataEndpoint = "";' >> LocalSettings.php
 elif [ "$BLAZEGRAPH" != "" ]
 then
 	echo '$smwgDefaultStore = "SMWSparqlStore";' >> LocalSettings.php
-	echo '$smwgSparqlDatabaseConnector = "Blazegraph";' >> LocalSettings.php
+	echo '$smwgSparqlRepositoryConnector = "Blazegraph";' >> LocalSettings.php
 	echo '$smwgSparqlQueryEndpoint = "http://localhost:9999/bigdata/namespace/kb/sparql";' >> LocalSettings.php
 	echo '$smwgSparqlUpdateEndpoint = "http://localhost:9999/bigdata/namespace/kb/sparql";' >> LocalSettings.php
 	echo '$smwgSparqlDataEndpoint = "";' >> LocalSettings.php
@@ -51,7 +51,7 @@ then
 elif [ "$VIRTUOSO" != "" ]
 then
 	echo '$smwgDefaultStore = "SMWSparqlStore";' >> LocalSettings.php
-	echo '$smwgSparqlDatabaseConnector = "Virtuoso";' >> LocalSettings.php
+	echo '$smwgSparqlRepositoryConnector = "Virtuoso";' >> LocalSettings.php
 	echo '$smwgSparqlQueryEndpoint = "http://localhost:8890/sparql";' >> LocalSettings.php
 	echo '$smwgSparqlUpdateEndpoint = "http://localhost:8890/sparql";' >> LocalSettings.php
 	echo '$smwgSparqlDataEndpoint = "";' >> LocalSettings.php


### PR DESCRIPTION
This PR is made in reference to: #

This PR addresses or contains:

- Replaces `$smwgSparqlDatabaseConnector` with `$smwgSparqlRepositoryConnector`

This PR includes:
- [ ] Tests (unit/integration)
- [x] CI build passed
