### PR TITLE
Update ext.smw.suggester.textInput.js

### DIFF
--- a/res/smw/suggester/ext.smw.suggester.textInput.js
+++ b/res/smw/suggester/ext.smw.suggester.textInput.js
@@ -78,6 +78,32 @@
 		};
 
 		/**
+		 * Support text input on Special:Upload
+		 *
+		 * @since 3.0
+		 */
+		var upload = function() {
+
+			var context = $( '#wpUploadDescription' );
+
+			if ( context.length ) {
+
+				var entitySuggester= smw.Factory.newEntitySuggester(
+				context
+				);
+
+				// Register autocomplete default tokens
+				entitySuggester.registerDefaultTokenList(
+					[
+						'property',
+						'concept',
+						'category'
+					]
+				);
+			};
+		};
+
+		/**
 		 * Support text input on the wikiEditor textbox
 		 *
 		 * @since 3.0
@@ -151,6 +177,10 @@
 			load( search );
 		};
 
+		if ( mw.config.get( 'wgCanonicalSpecialPageName' ) == 'Upload' ) {
+			load( upload );
+		};
+			
 		var wgAction = mw.config.get( 'wgAction' );
 
 		if ( ( wgAction == 'edit' || wgAction == 'submit' ) && mw.config.get( 'wgPageContentModel' ) == 'wikitext'  ) {


### PR DESCRIPTION
This PR is made in reference to: #2726 

This PR addresses or contains:
- Adds support for the input assistance suggester on special page "Upload" as proposed by @mwjames in https://github.com/SemanticMediaWiki/SemanticMediaWiki/pull/2726#issuecomment-333350717

This PR includes:
- [ ] Tests (unit/integration)
- [ ] CI build passed