### PR TITLE
Ren smwgDeclarationProperties, refs 2495

### DIFF
--- a/DefaultSettings.php
+++ b/DefaultSettings.php
@@ -729,9 +729,21 @@ return array(
 	#
 	# @since 1.5
 	##
-	'smwgDeclarationProperties' => array(
+	'smwgChangePropagationWatchlist' => array(
 		'_PVAL', '_LIST', '_PVAP', '_PVUC', '_PDESC', '_PPLB', '_PREC', '_PDESC'
 	),
+	##
+
+	##
+	# Change propagation protection
+	#
+	# An administrative intervention to disable the protection for an active change
+	# propagation.
+	#
+	# @since 3.0
+	# @default true
+	##
+	'smwgChangePropagationProtection' => true,
 	##
 
 	###
@@ -1666,18 +1678,6 @@ return array(
 	# @default false
 	##
 	'smwgFieldTypeFeatures' => false,
-	##
-
-	##
-	# Change propagation protection
-	#
-	# An administrative intervention to disable the protection for an active change
-	# propagation.
-	#
-	# @since 3.0
-	# @default true
-	##
-	'smwgChangePropagationProtection' => true,
 	##
 
 	##

--- a/includes/Settings.php
+++ b/includes/Settings.php
@@ -126,7 +126,7 @@ class Settings extends Options {
 			'smwgEnableUpdateJobs' => $GLOBALS['smwgEnableUpdateJobs'],
 			'smwgNamespacesWithSemanticLinks' => $GLOBALS['smwgNamespacesWithSemanticLinks'],
 			'smwgPageSpecialProperties' => $GLOBALS['smwgPageSpecialProperties'],
-			'smwgDeclarationProperties' => $GLOBALS['smwgDeclarationProperties'],
+			'smwgChangePropagationWatchlist' => $GLOBALS['smwgChangePropagationWatchlist'],
 			'smwgDataTypePropertyExemptionList' => $GLOBALS['smwgDataTypePropertyExemptionList'],
 			'smwgTranslate' => $GLOBALS['smwgTranslate'],
 			'smwgAutoRefreshSubject' => $GLOBALS['smwgAutoRefreshSubject'],
@@ -383,6 +383,10 @@ class Settings extends Options {
 			$configuration['smwgSparqlCustomConnector'] = $GLOBALS['smwgSparqlDatabase'];
 		}
 
+		if ( isset( $GLOBALS['smwgDeclarationProperties'] ) ) {
+			$configuration['smwgChangePropagationWatchlist'] = $GLOBALS['smwgDeclarationProperties'];
+		}
+
 		// Deprecated mapping used in DeprecationNoticeTaskHandler to detect and
 		// output notices
 		$GLOBALS['smwgDeprecationNotices'] = array(
@@ -394,6 +398,7 @@ class Settings extends Options {
 				'smwgRedirectPropertyListLimit' => '3.1.0',
 				'smwgSparqlDatabaseConnector' => '3.1.0',
 				'smwgSparqlDatabase' => '3.1.0',
+				'smwgDeclarationProperties' => '3.1.0',
 				'options' => [
 					'smwgCacheUsage' =>  [
 						'smwgStatisticsCache' => '3.1.0',
@@ -419,6 +424,7 @@ class Settings extends Options {
 				'smwgRedirectPropertyListLimit' => 'smwgPropertyListLimit',
 				'smwgSparqlDatabaseConnector' => 'smwgSparqlRepositoryConnector',
 				'smwgSparqlDatabase' => 'smwgSparqlCustomConnector',
+				'smwgDeclarationProperties' => 'smwgChangePropagationWatchlist',
 				'options' => [
 					'smwgCacheUsage' => [
 						'smwgStatisticsCacheExpiry' => 'special.statistics',

--- a/src/PropertyChangePropagationNotifier.php
+++ b/src/PropertyChangePropagationNotifier.php
@@ -114,7 +114,7 @@ class PropertyChangePropagationNotifier {
 	 * Compare and detect differences between the invoked semantic data
 	 * and the current stored data
 	 *
-	 * @note Compare on extra properties from `smwgDeclarationProperties`
+	 * @note Compare on extra properties from `smwgChangePropagationWatchlist`
 	 * (e.g '_PLIST') to find a possible specification change
 	 *
 	 * @since 1.9

--- a/src/Updater/StoreUpdater.php
+++ b/src/Updater/StoreUpdater.php
@@ -236,7 +236,7 @@ class StoreUpdater {
 		);
 
 		$propertyChangePropagationNotifier->setPropertyList(
-			$applicationFactory->getSettings()->get( 'smwgDeclarationProperties' )
+			$applicationFactory->getSettings()->get( 'smwgChangePropagationWatchlist' )
 		);
 
 		$propertyChangePropagationNotifier->isCommandLineMode(

--- a/tests/phpunit/Unit/MediaWiki/Hooks/ParserAfterTidyTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Hooks/ParserAfterTidyTest.php
@@ -30,7 +30,7 @@ class ParserAfterTidyTest extends \PHPUnit_Framework_TestCase {
 		parent::setUp();
 
 		$settings = array(
-			'smwgDeclarationProperties' => array(),
+			'smwgChangePropagationWatchlist' => array(),
 			'smwgCacheType'        => 'hash',
 			'smwgEnableUpdateJobs' => false
 		);

--- a/tests/phpunit/Unit/PropertyChangePropagationNotifierTest.php
+++ b/tests/phpunit/Unit/PropertyChangePropagationNotifierTest.php
@@ -28,7 +28,7 @@ class PropertyChangePropagationNotifierTest extends \PHPUnit_Framework_TestCase 
 
 		$this->testEnvironment = new TestEnvironment(
 			array(
-				'smwgDeclarationProperties' => array( '_PVAL' ),
+				'smwgChangePropagationWatchlist' => array( '_PVAL' ),
 				'smwgCacheType'  => 'hash',
 				'smwgEnableUpdateJobs' => false
 			)


### PR DESCRIPTION
This PR is made in reference to: #2495

This PR addresses or contains:

- Renames `$smwgDeclarationProperties` to `$smwgChangePropagationWatchlist` in order to clarify the intend

This PR includes:
- [ ] Tests (unit/integration)
- [x] CI build passed

Fixes #