### PR TITLE
Add `SMW::Setup::AfterInitializationComplete` hook, refs 2565

### DIFF
--- a/docs/technical/hooks.md
+++ b/docs/technical/hooks.md
@@ -265,6 +265,24 @@ Implementing a hook should be made in consideration of the expected performance 
 } );
 </pre>
 
+### SMW::Setup::AfterInitializationComplete
+
+* Version: 3.0
+* Description: Hook allows to modify global configuration after initialization of Semantic MediaWiki is completed
+* Reference class: `\SMW\Setup`
+
+<pre>
+use Hooks;
+
+Hooks::register( 'SMW::Setup::AfterInitializationComplete', function( &$vars ) {
+
+	// #2565
+	unset( $GLOBALS['wgGroupPermissions']['smwcurator'] );
+
+	return true;
+} );
+</pre>
+
 ## Other available hooks
 
 Subsequent hooks should be renamed to follow a common naming practice that help distinguish them from other hook providers. In any case this list needs details and examples.

--- a/includes/Setup.php
+++ b/includes/Setup.php
@@ -3,6 +3,7 @@
 namespace SMW;
 
 use SMW\MediaWiki\Hooks\HookRegistry;
+use Hooks;
 
 /**
  * Extension setup and registration
@@ -46,6 +47,7 @@ final class Setup {
 	 * @since 1.9
 	 */
 	public function run() {
+
 		$this->addSomeDefaultConfigurations();
 
 		if ( CompatibilityMode::extensionNotEnabled() ) {
@@ -64,6 +66,8 @@ final class Setup {
 		$this->registerParamDefinitions();
 		$this->registerFooterIcon();
 		$this->registerHooks();
+
+		Hooks::run( 'SMW::Setup::AfterInitializationComplete', [ &$this->globalVars ] );
 	}
 
 	private function addSomeDefaultConfigurations() {


### PR DESCRIPTION
This PR is made in reference to: #2565 

This PR addresses or contains:

- Adds `SMW::Setup::AfterInitializationComplete` hook to address https://github.com/SemanticMediaWiki/SemanticMediaWiki/issues/2565#issuecomment-318791542

This PR includes:
- [ ] Tests (unit/integration)
- [x] CI build passed

Fixes: #2565
