### PR TITLE
Force update on template refresh, refs 2365

### DIFF
--- a/src/MediaWiki/Hooks/LinksUpdateConstructed.php
+++ b/src/MediaWiki/Hooks/LinksUpdateConstructed.php
@@ -88,6 +88,12 @@ class LinksUpdateConstructed implements LoggerAwareInterface {
 			$parserData->setOption( $parserData::OPT_FORCED_UPDATE, true );
 		}
 
+		// Update incurred by a template change and is signaled through
+		// the following condition
+		if ( $linksUpdate->mTemplates !== [] && $linksUpdate->mRecursive === false ) {
+			$parserData->setOption( $parserData::OPT_FORCED_UPDATE, true );
+		}
+
 		$parserData->setOrigin( 'LinksUpdateConstructed' );
 
 		$parserData->updateStore(

--- a/tests/phpunit/Unit/MediaWiki/Hooks/LinksUpdateConstructedTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Hooks/LinksUpdateConstructedTest.php
@@ -155,4 +155,50 @@ class LinksUpdateConstructedTest extends \PHPUnit_Framework_TestCase {
 		);
 	}
 
+	public function testTemplateUpdate() {
+
+		$this->testEnvironment->addConfiguration(
+			'smwgNamespacesWithSemanticLinks',
+			[ NS_HELP => false ]
+		);
+
+		$title = Title::newFromText( __METHOD__, NS_HELP );
+		$parserOutput = new ParserOutput();
+
+		$parserData = $this->getMockBuilder( '\SMW\ParserData' )
+			->disableOriginalConstructor()
+			->setMethods( [ 'getSemanticData', 'updateStore', 'markUpdate' ] )
+			->getMock();
+
+		$parserData->expects( $this->never() )
+			->method( 'getSemanticData' );
+
+		$parserData->expects( $this->once() )
+			->method( 'updateStore' );
+
+		$this->testEnvironment->registerObject( 'ParserData', $parserData );
+
+		$linksUpdate = $this->getMockBuilder( '\LinksUpdate' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$linksUpdate->expects( $this->any() )
+			->method( 'getTitle' )
+			->will( $this->returnValue( $title ) );
+
+		$linksUpdate->expects( $this->atLeastOnce() )
+			->method( 'getParserOutput' )
+			->will( $this->returnValue( $parserOutput ) );
+
+		$linksUpdate->mTemplates = [ 'Foo' ];
+		$linksUpdate->mRecursive = false;
+
+		$instance = new LinksUpdateConstructed();
+		$instance->process( $linksUpdate );
+
+		$this->assertTrue(
+			$parserData->getOption( $parserData::OPT_FORCED_UPDATE )
+		);
+	}
+
 }


### PR DESCRIPTION
This PR is made in reference to: #2365

This PR addresses or contains:

- If we somehow detect a template update is ongoing through the means of a `refreshLinks` job force an update even though the revision hasn't changed (and hereby the updater marker)

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed
