### PR TITLE
Changes the default setting for `smwgSparqlRepositoryConnector`

### DIFF
--- a/DefaultSettings.php
+++ b/DefaultSettings.php
@@ -137,11 +137,12 @@ return array(
 	# together with the SPARQLStore.
 	#
 	# List of standard connectors ($smwgSparqlCustomConnector will have no effect)
+	# - '4store'
+	# - 'blazegraph'
 	# - 'fuseki'
 	# - 'virtuoso'
-	# - '4store'
 	# - 'sesame'
-	# - 'generic'
+	# - 'default'
 	#
 	# In case $smwgSparqlRepositoryConnector = 'custom' is maintained, $smwgSparqlCustomConnector
 	# is expected to contain a custom class connector where $smwgSparqlCustomConnector is only

--- a/DefaultSettings.php
+++ b/DefaultSettings.php
@@ -133,22 +133,22 @@ return array(
 	##
 	# Sparql repository connector
 	#
-	# Identifies a pre-deployed repository connector that is ought to be used
-	# together with the SPARQLStore.
+	# Identifies a pre-deployed repository connector that is ought to be used together
+	# with the SPARQLStore.
 	#
-	# List of standard connectors ($smwgSparqlCustomConnector will have no effect)
+	# List of standard connectors ($smwgSparqlCustomConnector will have no effect):
 	# - '4store'
 	# - 'blazegraph'
 	# - 'fuseki'
-	# - 'virtuoso'
 	# - 'sesame'
-	# - 'default'
+	# - 'virtuoso'
 	#
 	# In case $smwgSparqlRepositoryConnector = 'custom' is maintained, $smwgSparqlCustomConnector
 	# is expected to contain a custom class connector where $smwgSparqlCustomConnector is only
 	# for the definition of a custom connector.
 	#
 	# @since 2.0
+	# @default default, meaning that the default connector is used
 	##
 	'smwgSparqlRepositoryConnector' => 'default',
 	##

--- a/DefaultSettings.php
+++ b/DefaultSettings.php
@@ -147,12 +147,9 @@ return array(
 	# is expected to contain a custom class connector where $smwgSparqlCustomConnector is only
 	# for the definition of a custom connector.
 	#
-	# $smwgSparqlRepositoryConnector = 'custom' is set as legacy configuration to allow for
-	# existing (prior 2.0) customizing to work without changes.
-	#
 	# @since 2.0
 	##
-	'smwgSparqlRepositoryConnector' => 'custom',
+	'smwgSparqlRepositoryConnector' => 'default',
 	##
 
 	##


### PR DESCRIPTION
This PR is made in reference to: #2752 

This PR addresses or contains:
- Changes (BREAKING) the default setting to `default` since three years of transition appear sufficient. Since the configuration parameter was renamed anyways ...

This PR includes:
- [ ] Tests (unit/integration)
- [x] CI build passed

Fixes #