### PR TITLE
Additional checks for enabled namespaces

### DIFF
--- a/src/MediaWiki/Hooks/ParserAfterTidy.php
+++ b/src/MediaWiki/Hooks/ParserAfterTidy.php
@@ -23,7 +23,12 @@ class ParserAfterTidy extends HookHandler {
 	/**
 	 * @var Parser
 	 */
-	private $parser = null;
+	private $parser;
+
+	/**
+	 * @var NamespaceExaminer
+	 */
+	private $namespaceExaminer;
 
 	/**
 	 * @var boolean
@@ -42,6 +47,7 @@ class ParserAfterTidy extends HookHandler {
 	 */
 	public function __construct( Parser &$parser ) {
 		$this->parser = $parser;
+		$this->namespaceExaminer = ApplicationFactory::getInstance()->getNamespaceExaminer();
 	}
 
 	/**
@@ -88,16 +94,22 @@ class ParserAfterTidy extends HookHandler {
 			return false;
 		}
 
+		$title = $this->parser->getTitle();
+
+		if ( !$this->namespaceExaminer->isSemanticEnabled( $title->getNamespace() ) ) {
+			return false;
+		}
+
 		// ParserOptions::getInterfaceMessage is being used to identify whether a
 		// parse was initiated by `Message::parse`
-		if ( $this->parser->getTitle()->isSpecialPage() || $this->parser->getOptions()->getInterfaceMessage() ) {
+		if ( $title->isSpecialPage() || $this->parser->getOptions()->getInterfaceMessage() ) {
 			return false;
 		}
 
 		// @see ParserData::setSemanticDataStateToParserOutputProperty
 		if ( $this->parser->getOutput()->getProperty( 'smw-semanticdata-status' ) ||
 			$this->parser->getOutput()->getProperty( 'displaytitle' ) ||
-			$this->parser->getTitle()->isProtected( 'edit' ) ||
+			$title->isProtected( 'edit' ) ||
 			$this->parser->getOutput()->getCategoryLinks() ||
 			$this->parser->getDefaultSort() ) {
 			return true;

--- a/tests/phpunit/Integration/JSONScript/TestCases/p-0207.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/p-0207.json
@@ -7,8 +7,13 @@
 			"contents": "[[Has type::Number]]"
 		},
 		{
-			"page": "Example/0207",
-			"contents": "{{#set:Has number=12}} {{#set:Undeclared property=abc}} [[Undeclared prop::0207]]"
+			"page": "Test/P0207",
+			"contents": "{{#set:Has number=12}} {{#set:Undeclared property=abc}} [[Undeclared prop::P0207]]"
+		},
+		{
+			"namespace": "NS_HELP",
+			"page": "Test/P0207/1",
+			"contents": "{{:Test/P0207}}"
 		}
 	],
 	"beforeTest": {
@@ -20,7 +25,7 @@
 		{
 			"type": "parser",
 			"about": "#0 Rebuild + clear cache to verify that the disposer (#1216) didn't remove undeclared properties that still contain references",
-			"subject": "Example/0207",
+			"subject": "Test/P0207",
 			"store": {
 				"clear-cache": true
 			},
@@ -39,9 +44,29 @@
 					"propertyValues": [
 						12,
 						"Abc",
-						"0207"
+						"P0207"
 					]
 				}
+			}
+		},
+		{
+			"type": "parser",
+			"about": "#1 embedded page on disabled namespace",
+			"namespace": "NS_HELP",
+			"subject": "Test/P0207/1",
+			"store": {
+				"clear-cache": true
+			},
+			"assert-store": {
+				"semantic-data": {
+					"strictPropertyValueMatch": false,
+					"propertyCount": 0
+				}
+			},
+			"assert-output": {
+				"to-contain": [
+					"<a href=\".* title=\"P0207.*\">P0207</a>"
+				]
 			}
 		}
 	],
@@ -49,7 +74,12 @@
 		"wgContLang": "en",
 		"smwgPageSpecialProperties": [
 			"_MDAT"
-		]
+		],
+		"smwgNamespacesWithSemanticLinks": {
+			"NS_MAIN": true,
+			"NS_HELP": false,
+			"SMW_NS_PROPERTY": true
+		}
 	},
 	"meta": {
 		"version": "2",

--- a/tests/phpunit/Unit/MediaWiki/Hooks/ParserAfterTidyTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Hooks/ParserAfterTidyTest.php
@@ -84,6 +84,47 @@ class ParserAfterTidyTest extends \PHPUnit_Framework_TestCase {
 		$instance->process( $text );
 	}
 
+	public function testNotEnabledNamespace() {
+
+		$namespaceExaminer = $this->getMockBuilder( '\SMW\NamespaceExaminer' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$namespaceExaminer->expects( $this->once() )
+			->method( 'isSemanticEnabled' )
+			->will( $this->returnValue( false ) );
+
+		$this->testEnvironment->registerObject( 'NamespaceExaminer', $namespaceExaminer );
+
+		$title = MockTitle::buildMock( __METHOD__ );
+
+		$title->expects( $this->atLeastOnce() )
+			->method( 'getNamespace' )
+			->will( $this->returnValue( NS_MAIN ) );
+
+		$title = $this->getMockBuilder( 'Title' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		// Using this step to verify that the previous NS check
+		// bailed out.
+		$title->expects( $this->never() )
+			->method( 'isSpecialPage' );
+
+		$parser = $this->getMockBuilder( 'Parser' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$parser->expects( $this->any() )
+			->method( 'getTitle' )
+			->will( $this->returnValue( $title ) );
+
+		$instance = new ParserAfterTidy( $parser );
+
+		$text = '';
+		$instance->process( $text );
+	}
+
 	private function newMockCache( $id, $containsStatus, $fetchStatus ) {
 
 		$key = $this->applicationFactory->newCacheFactory()->getPurgeCacheKey( $id );
@@ -259,6 +300,10 @@ class ParserAfterTidyTest extends \PHPUnit_Framework_TestCase {
 			->method( 'updateData' );
 
 		$title = MockTitle::buildMock( __METHOD__ );
+
+		$title->expects( $this->atLeastOnce() )
+			->method( 'getNamespace' )
+			->will( $this->returnValue( NS_MAIN ) );
 
 		$title->expects( $this->atLeastOnce() )
 			->method( 'isSpecialPage' )

--- a/tests/phpunit/Unit/SQLStore/PropertyTableIdReferenceFinderTest.php
+++ b/tests/phpunit/Unit/SQLStore/PropertyTableIdReferenceFinderTest.php
@@ -35,19 +35,15 @@ class PropertyTableIdReferenceFinderTest extends \PHPUnit_Framework_TestCase {
 		);
 	}
 
-	public function testTryToFindAtLeastOneReferenceForId() {
+	public function testFindAtLeastOneActiveReferenceById() {
 
-		$tableDefinition = $connection = $this->getMockBuilder( '\SMW\SQLStore\TableDefinition' )
+		$tableDefinition = $this->getMockBuilder( '\SMW\SQLStore\TableDefinition' )
 			->disableOriginalConstructor()
 			->getMock();
 
 		$tableDefinition->expects( $this->atLeastOnce() )
 			->method( 'getFields' )
 			->will( $this->returnValue( array( 'o_id' => 42 ) ) );
-
-		$PropertyTableIdReferenceFinder = $connection = $this->getMockBuilder( '\SMW\SQLStore\PropertyTableIdReferenceFinder' )
-			->disableOriginalConstructor()
-			->getMock();
 
 		$connection = $this->getMockBuilder( '\SMW\MediaWiki\Database' )
 			->disableOriginalConstructor()
@@ -69,7 +65,9 @@ class PropertyTableIdReferenceFinderTest extends \PHPUnit_Framework_TestCase {
 			$this->store
 		);
 
-		$instance->tryToFindAtLeastOneReferenceForId( 42 );
+		$this->assertFalse(
+			$instance->findAtLeastOneActiveReferenceById( 42 )
+		);
 	}
 
 	public function testTryToFindAtLeastOneReferenceForProperty() {


### PR DESCRIPTION
This PR is made in reference to: #

This PR addresses or contains:

- While looking at [0], I found entries like the sample below which should not happen because `  "smw_namespace": "200"` (Print namespace) is disabled for SMW usage
- This is caused by a page transclusion [1] that hosts embedded queries with the `QueryDependencyLinksStore` not explicitly checking the  context page namespace prior creating an id reference

```
    "109866": {
        "smw_id": "109866",
        "smw_title": "User_manual",
        "smw_namespace": "200",
        "smw_iw": "",
        "smw_subobject": "_QUERY85faec9baa9a72381449338d9fb87801",
        "smw_sortkey": "User manual"
    },
```

[0] https://www.semantic-mediawiki.org/w/index.php?title=Special%3ASemanticMediaWiki&action=idlookup&id=&id=User+manual
[1] https://www.semantic-mediawiki.org/wiki/Print:User_manual

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed

Fixes #