### PR TITLE
Move SMWQueryParser to SMW\Query\Parser

### DIFF
--- a/src/Aliases.php
+++ b/src/Aliases.php
@@ -14,6 +14,7 @@ class_alias( 'SMW\Query\ExportPrinter', 'SMW\ExportPrinter' );
 class_alias( 'SMW\Query\ResultPrinters\ResultPrinter', 'SMW\ResultPrinter' );
 class_alias( 'SMW\Query\ResultPrinters\ResultPrinter', 'SMWResultPrinter' );
 class_alias( 'SMW\Query\ResultPrinters\FileExportPrinter', 'SMW\FileExportPrinter' );
+class_alias( 'SMW\Query\Parser', 'SMWQueryParser' );
 
 // 1.9.
 class_alias( 'SMW\Store', 'SMWStore' );

--- a/src/ApplicationFactory.php
+++ b/src/ApplicationFactory.php
@@ -523,8 +523,8 @@ class ApplicationFactory {
 	 *
 	 * @return QueryParser
 	 */
-	public function newQueryParser() {
-		return $this->getQueryFactory()->newQueryParser();
+	public function newQueryParser( $queryFeatures = false ) {
+		return $this->getQueryFactory()->newQueryParser( $queryFeatures );
 	}
 
 	/**

--- a/src/Query/Parser.php
+++ b/src/Query/Parser.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace SMW\Query;
+
+use SMW\Query\Language\Description;
+
+/**
+ * @license GNU GPL v2+
+ * @since 3.0
+ *
+ * @author mwjames
+ */
+interface Parser {
+
+	/**
+	 * @since 3.0
+	 *
+	 * @param string $condition
+	 *
+	 * @return Description
+	 */
+	public function getQueryDescription( $condition );
+
+}

--- a/src/Query/Parser/DescriptionProcessor.php
+++ b/src/Query/Parser/DescriptionProcessor.php
@@ -115,7 +115,7 @@ class DescriptionProcessor {
 	 *
 	 * @return Description|null
 	 */
-	public function constructDescriptionForPropertyObjectValue( DIProperty $property, $chunk ) {
+	public function newDescriptionForPropertyObjectValue( DIProperty $property, $chunk ) {
 
 		$dataValue = $this->dataValueFactory->newDataValueByProperty( $property );
 		$dataValue->setContextPage( $this->contextPage );
@@ -137,7 +137,7 @@ class DescriptionProcessor {
 	 *
 	 * @return Description|null
 	 */
-	public function constructDescriptionForWikiPageValueChunk( $chunk ) {
+	public function newDescriptionForWikiPageValueChunk( $chunk ) {
 
 		// Only create a simple WpgValue to initiate the query description target
 		// operation. If the chunk contains something like "≤Issue/1220" then the
@@ -158,6 +158,11 @@ class DescriptionProcessor {
 	}
 
 	/**
+	 * The method was supposed to be named just `or` and `and` but this works
+	 * only on PHP 7.1 therefore ...
+	 */
+
+	/**
 	 * @since 2.4
 	 *
 	 * @param Description|null $currentDescription
@@ -165,7 +170,7 @@ class DescriptionProcessor {
 	 *
 	 * @return Description|null
 	 */
-	public function constructDisjunctiveCompoundDescriptionFrom( Description $currentDescription = null, Description $newDescription = null ) {
+	public function asOr( Description $currentDescription = null, Description $newDescription = null ) {
 		return $this->newCompoundDescription( $currentDescription, $newDescription, SMW_DISJUNCTION_QUERY );
 	}
 
@@ -177,7 +182,7 @@ class DescriptionProcessor {
 	 *
 	 * @return Description|null
 	 */
-	public function constructConjunctiveCompoundDescriptionFrom( Description $currentDescription = null, Description $newDescription = null ) {
+	public function asAnd( Description $currentDescription = null, Description $newDescription = null ) {
 		return $this->newCompoundDescription( $currentDescription, $newDescription, SMW_CONJUNCTION_QUERY );
 	}
 
@@ -223,24 +228,24 @@ class DescriptionProcessor {
 		} elseif ( $currentDescription === null ) {
 			return $newDescription;
 		} else { // we already found descriptions
-			return $this->newCompoundDescriptionFor( $compoundType, $currentDescription, $newDescription );
+			return $this->newCompoundDescriptionByType( $compoundType, $currentDescription, $newDescription );
 		}
 	}
 
-	private function newCompoundDescriptionFor( $compoundType, $currentDescription, $newDescription ) {
+	private function newCompoundDescriptionByType( $compoundType, $currentDescription, $newDescription ) {
 
 		if ( ( ( $compoundType & SMW_CONJUNCTION_QUERY ) != 0 && ( $currentDescription instanceof Conjunction ) ) ||
 		     ( ( $compoundType & SMW_DISJUNCTION_QUERY ) != 0 && ( $currentDescription instanceof Disjunction ) ) ) { // use existing container
 			$currentDescription->addDescription( $newDescription );
 			return $currentDescription;
 		} elseif ( ( $compoundType & SMW_CONJUNCTION_QUERY ) != 0 ) { // make new conjunction
-			return $this->newConjunctionFor( $currentDescription, $newDescription );
+			return $this->newConjunction( $currentDescription, $newDescription );
 		} elseif ( ( $compoundType & SMW_DISJUNCTION_QUERY ) != 0 ) { // make new disjunction
-			return $this->newDisjunctionFor( $currentDescription, $newDescription );
+			return $this->newDisjunction( $currentDescription, $newDescription );
 		}
 	}
 
-	private function newConjunctionFor( $currentDescription, $newDescription ) {
+	private function newConjunction( $currentDescription, $newDescription ) {
 
 		if ( $this->queryFeatures & SMW_CONJUNCTION_QUERY ) {
 			return $this->descriptionFactory->newConjunction( array( $currentDescription, $newDescription ) );
@@ -251,7 +256,7 @@ class DescriptionProcessor {
 		return $currentDescription;
 	}
 
-	private function newDisjunctionFor( $currentDescription, $newDescription ) {
+	private function newDisjunction( $currentDescription, $newDescription ) {
 
 		if ( $this->queryFeatures & SMW_DISJUNCTION_QUERY ) {
 			return $this->descriptionFactory->newDisjunction( array( $currentDescription, $newDescription ) );

--- a/src/Query/Parser/Tokenizer.php
+++ b/src/Query/Parser/Tokenizer.php
@@ -1,0 +1,92 @@
+<?php
+
+namespace SMW\Query\Parser;
+
+/**
+ * @license GNU GPL v2+
+ * @since 3.0
+ *
+ * @author Markus Krötzsch
+ */
+class Tokenizer {
+
+	/**
+	 * @var string
+	 */
+	private $defaultPattern = '';
+
+	/**
+	 * @since 3.0
+	 *
+	 * @param array $prefixes
+	 */
+	public function setDefaultPattern( array $prefixes ) {
+
+		$pattern = '';
+
+		foreach ( $prefixes as $pref ) {
+			$pattern .= '|^' . $pref;
+		}
+
+		$this->defaultPattern = '\[\[|\]\]|::|:=|<q>|<\/q>' . $pattern . '|\|\||\|';
+	}
+
+	/**
+	 * Get the next unstructured string chunk from the query string.
+	 * Chunks are delimited by any of the special strings used in inline queries
+	 * (such as [[, ]], <q>, ...). If the string starts with such a delimiter,
+	 * this delimiter is returned. Otherwise the first string in front of such a
+	 * delimiter is returned.
+	 * Trailing and initial spaces are ignored if $trim is true, and chunks
+	 * consisting only of spaces are not returned.
+	 * If there is no more qurey string left to process, the empty string is
+	 * returned (and in no other case).
+	 *
+	 * The stoppattern can be used to customise the matching, especially in order to
+	 * overread certain special symbols.
+	 *
+	 * $consume specifies whether the returned chunk should be removed from the
+	 * query string.
+	 *
+	 * @param string $currentString
+	 * @param string $stoppattern
+	 * @param boolean $consume
+	 * @param boolean $trim
+	 *
+	 * @return string
+	 */
+	public function getToken( &$currentString, $stoppattern = '', $consume = true, $trim = true ) {
+
+		if ( $stoppattern === '' ) {
+			$stoppattern = $this->defaultPattern;
+		}
+
+		$chunks = preg_split( '/[\s]*(' . $stoppattern . ')/iu', $currentString, 2, PREG_SPLIT_DELIM_CAPTURE );
+
+		if ( count( $chunks ) == 1 ) { // no matches anymore, strip spaces and finish
+			if ( $consume ) {
+				$currentString = '';
+			}
+
+			return $trim ? trim( $chunks[0] ) : $chunks[0];
+		} elseif ( count( $chunks ) == 3 ) { // this should generally happen if count is not 1
+			if ( $chunks[0] === '' ) { // string started with delimiter
+				if ( $consume ) {
+					$currentString = $chunks[2];
+				}
+
+				return $trim ? trim( $chunks[1] ) : $chunks[1];
+			} else {
+				if ( $consume ) {
+					$currentString = $chunks[1] . $chunks[2];
+				}
+
+				return $trim ? trim( $chunks[0] ) : $chunks[0];
+			}
+		}
+
+		// should never happen
+		return false;
+	}
+
+}

--- a/src/QueryFactory.php
+++ b/src/QueryFactory.php
@@ -7,8 +7,13 @@ use SMW\Query\Language\Description;
 use SMW\Query\PrintRequestFactory;
 use SMW\Query\ProfileAnnotatorFactory;
 use SMW\Query\QueryCreator;
+use SMW\Query\Parser\LegacyParser;
+use SMW\Query\Parser\DescriptionProcessor;
+use SMW\Query\Parser\Tokenizer;
+use SMW\Query\QueryToken;
+use SMW\Applicationfactory;
 use SMWQuery as Query;
-use SMWQueryParser as QueryParser;
+use SMW\Query\Parser as QueryParser;
 use SMWQueryResult as QueryResult;
 
 /**
@@ -88,7 +93,27 @@ class QueryFactory {
 	 * @return QueryParser
 	 */
 	public function newQueryParser( $queryFeatures = false ) {
-		return new QueryParser( $queryFeatures );
+		return $this->newLegacyQueryParser( $queryFeatures );
+	}
+
+	/**
+	 * @since 3.0
+	 *
+	 * @param integer|boolean $queryFeatures
+	 *
+	 * @return QueryParser
+	 */
+	public function newLegacyQueryParser( $queryFeatures = false ) {
+
+		if ( $queryFeatures === false ) {
+			$queryFeatures = Applicationfactory::getInstance()->getSettings()->get( 'smwgQFeatures' );
+		}
+
+		return new LegacyParser(
+			new DescriptionProcessor( $queryFeatures ),
+			new Tokenizer(),
+			new QueryToken()
+		);
 	}
 
 	/**

--- a/src/SQLStore/QueryEngine/DescriptionInterpreterFactory.php
+++ b/src/SQLStore/QueryEngine/DescriptionInterpreterFactory.php
@@ -2,6 +2,7 @@
 
 namespace SMW\SQLStore\QueryEngine;
 
+use SMW\ApplicationFactory;
 use SMW\SQLStore\QueryEngine\DescriptionInterpreters\ClassDescriptionInterpreter;
 use SMW\SQLStore\QueryEngine\DescriptionInterpreters\ConceptDescriptionInterpreter;
 use SMW\SQLStore\QueryEngine\DescriptionInterpreters\DisjunctionConjunctionInterpreter;
@@ -28,6 +29,7 @@ class DescriptionInterpreterFactory {
 	 */
 	public function newDispatchingDescriptionInterpreter( QuerySegmentListBuilder $querySegmentListBuilder ) {
 
+		$pplicationFactory = ApplicationFactory::getInstance();
 		$dispatchingDescriptionInterpreter = new DispatchingDescriptionInterpreter();
 
 		$dispatchingDescriptionInterpreter->addDefaultInterpreter(
@@ -54,8 +56,18 @@ class DescriptionInterpreterFactory {
 			new ValueDescriptionInterpreter( $querySegmentListBuilder )
 		);
 
+		$conceptDescriptionInterpreter = new ConceptDescriptionInterpreter(
+			$querySegmentListBuilder
+		);
+
+		$conceptDescriptionInterpreter->setQueryParser(
+			$pplicationFactory->getQueryFactory()->newQueryParser(
+				$pplicationFactory->getSettings()->get( 'smwgQConceptFeatures' )
+			)
+		);
+
 		$dispatchingDescriptionInterpreter->addInterpreter(
-			new ConceptDescriptionInterpreter( $querySegmentListBuilder )
+			$conceptDescriptionInterpreter
 		);
 
 		return $dispatchingDescriptionInterpreter;

--- a/src/SQLStore/QueryEngine/DescriptionInterpreters/ConceptDescriptionInterpreter.php
+++ b/src/SQLStore/QueryEngine/DescriptionInterpreters/ConceptDescriptionInterpreter.php
@@ -9,8 +9,9 @@ use SMW\Query\Language\Disjunction;
 use SMW\SQLStore\QueryEngine\DescriptionInterpreter;
 use SMW\SQLStore\QueryEngine\QuerySegment;
 use SMW\SQLStore\QueryEngine\QuerySegmentListBuilder;
-use SMWQueryParser as QueryParser;
 use SMWSQLStore3;
+use SMW\Query\Parser as QueryParser;
+use RuntimeException;
 
 /**
  * @license GNU GPL v2+
@@ -28,6 +29,11 @@ class ConceptDescriptionInterpreter implements DescriptionInterpreter {
 	private $querySegmentListBuilder;
 
 	/**
+	 * @var QueryParser
+	 */
+	private $queryParser;
+
+	/**
 	 * @since 2.2
 	 *
 	 * @param QuerySegmentListBuilder $querySegmentListBuilder
@@ -43,6 +49,15 @@ class ConceptDescriptionInterpreter implements DescriptionInterpreter {
 	 */
 	public function canInterpretDescription( Description $description ) {
 		return $description instanceof ConceptDescription;
+	}
+
+	/**
+	 * @since 3.0
+	 *
+	 * @param QueryParser $queryParser
+	 */
+	public function setQueryParser( QueryParser $queryParser ) {
+		$this->queryParser = $queryParser;
 	}
 
 	/**
@@ -151,9 +166,12 @@ class ConceptDescriptionInterpreter implements DescriptionInterpreter {
 	 * Unescaping is the same as in SMW_DV_Conept's getWikiValue().
 	 */
 	private function getConceptQueryDescriptionFrom( $conceptQuery ) {
-		$queryParser = new QueryParser();
 
-		return $queryParser->getQueryDescription(
+		if ( $this->queryParser === null ) {
+			throw new RuntimeException( 'Missing a QueryParser instance' );
+		}
+
+		return $this->queryParser->getQueryDescription(
 			str_replace( array( '&lt;', '&gt;', '&amp;' ), array( '<', '>', '&' ), $conceptQuery )
 		);
 	}

--- a/src/SQLStore/QueryEngineFactory.php
+++ b/src/SQLStore/QueryEngineFactory.php
@@ -140,13 +140,17 @@ class QueryEngineFactory {
 	 */
 	public function newConceptQuerySegmentBuilder() {
 
+		$pplicationFactory = ApplicationFactory::getInstance();
+
 		$conceptQuerySegmentBuilder = new ConceptQuerySegmentBuilder(
 			$this->newQuerySegmentListBuilder(),
 			$this->newQuerySegmentListProcessor()
 		);
 
-		$conceptQuerySegmentBuilder->setConceptFeatures(
-			$this->applicationFactory->getSettings()->get( 'smwgQConceptFeatures' )
+		$conceptQuerySegmentBuilder->setQueryParser(
+			$pplicationFactory->getQueryFactory()->newQueryParser(
+				$pplicationFactory->getSettings()->get( 'smwgQConceptFeatures' )
+			)
 		);
 
 		return $conceptQuerySegmentBuilder;

--- a/tests/phpunit/Integration/JSONScript/QueryTestCaseProcessor.php
+++ b/tests/phpunit/Integration/JSONScript/QueryTestCaseProcessor.php
@@ -4,7 +4,7 @@ namespace SMW\Tests\Integration\JSONScript;
 
 use SMW\Store;
 use SMWQuery as Query;
-use SMWQueryParser as QueryParser;
+use SMW\Query\Parser as QueryParser;
 use Title;
 
 /**

--- a/tests/phpunit/Integration/Query/ConjunctionQueryDBIntegrationTest.php
+++ b/tests/phpunit/Integration/Query/ConjunctionQueryDBIntegrationTest.php
@@ -4,6 +4,7 @@ namespace SMW\Tests\Integration\Query;
 
 use SMW\DIProperty;
 use SMW\DIWikiPage;
+use SMW\ApplicationFactory;
 use SMW\Query\Language\ClassDescription;
 use SMW\Query\Language\Conjunction;
 use SMW\Query\Language\SomeProperty;
@@ -11,7 +12,6 @@ use SMW\Query\Language\ValueDescription;
 use SMW\Tests\MwDBaseUnitTestCase;
 use SMW\Tests\Utils\UtilityFactory;
 use SMWQuery as Query;
-use SMWQueryParser as QueryParser;
 
 /**
  * @group SMW
@@ -46,7 +46,7 @@ class ConjunctionQueryDBIntegrationTest extends MwDBaseUnitTestCase {
 		$this->fixturesProvider = $utilityFactory->newFixturesFactory()->newFixturesProvider();
 		$this->fixturesProvider->setupDependencies( $this->getStore() );
 
-		$this->queryParser = new QueryParser();
+		$this->queryParser = ApplicationFactory::getInstance()->getQueryFactory()->newQueryParser();
 	}
 
 	protected function tearDown() {

--- a/tests/phpunit/Integration/Query/DisjunctionQueryDBIntegrationTest.php
+++ b/tests/phpunit/Integration/Query/DisjunctionQueryDBIntegrationTest.php
@@ -11,7 +11,7 @@ use SMW\Query\Language\ValueDescription;
 use SMW\Tests\MwDBaseUnitTestCase;
 use SMW\Tests\Utils\UtilityFactory;
 use SMWQuery as Query;
-use SMWQueryParser as QueryParser;
+use SMW\ApplicationFactory;
 
 /**
  *
@@ -39,7 +39,7 @@ class DisjunctionQueryDBIntegrationTest extends MwDBaseUnitTestCase {
 
 		$this->queryResultValidator = UtilityFactory::getInstance()->newValidatorFactory()->newQueryResultValidator();
 		$this->semanticDataFactory = UtilityFactory::getInstance()->newSemanticDataFactory();
-		$this->queryParser = new QueryParser();
+		$this->queryParser = ApplicationFactory::getInstance()->getQueryFactory()->newQueryParser();
 
 	//	$this->getStore()->getSparqlDatabase()->deleteAll();
 	}

--- a/tests/phpunit/Integration/Query/InversePropertyRelationshipDBIntegrationTest.php
+++ b/tests/phpunit/Integration/Query/InversePropertyRelationshipDBIntegrationTest.php
@@ -10,7 +10,7 @@ use SMW\Query\Language\ValueDescription;
 use SMW\Tests\MwDBaseUnitTestCase;
 use SMW\Tests\Utils\UtilityFactory;
 use SMWQuery as Query;
-use SMWQueryParser as QueryParser;
+use SMW\ApplicationFactory;
 
 /**
  * @see http://semantic-mediawiki.org/wiki/Inverse_Properties
@@ -46,7 +46,7 @@ class InversePropertyRelationshipDBIntegrationTest extends MwDBaseUnitTestCase {
 		$this->semanticDataFactory = UtilityFactory::getInstance()->newSemanticDataFactory();
 
 		$this->dataValueFactory = DataValueFactory::getInstance();
-		$this->queryParser = new QueryParser();
+		$this->queryParser = ApplicationFactory::getInstance()->getQueryFactory()->newQueryParser();
 	}
 
 	protected function tearDown() {

--- a/tests/phpunit/Integration/QueryResultQueryProcessorIntegrationTest.php
+++ b/tests/phpunit/Integration/QueryResultQueryProcessorIntegrationTest.php
@@ -3,10 +3,10 @@
 namespace SMW\Tests\Integration;
 
 use SMW\DataValueFactory;
+use SMW\ApplicationFactory;
 use SMW\Tests\MwDBaseUnitTestCase;
 use SMW\Tests\Utils\UtilityFactory;
 use SMWQuery as Query;
-use SMWQueryParser as QueryParser;
 use SMWQueryProcessor as QueryProcessor;
 
 /**
@@ -46,7 +46,7 @@ class QueryResultQueryProcessorIntegrationTest extends MwDBaseUnitTestCase {
 		$this->fixturesProvider->setupDependencies( $this->getStore() );
 
 		$this->dataValueFactory = DataValueFactory::getInstance();
-		$this->queryParser = new QueryParser();
+		$this->queryParser = ApplicationFactory::getInstance()->getQueryFactory()->newQueryParser();
 	}
 
 	protected function tearDown() {

--- a/tests/phpunit/Unit/Query/Parser/DescriptionProcessorTest.php
+++ b/tests/phpunit/Unit/Query/Parser/DescriptionProcessorTest.php
@@ -45,21 +45,21 @@ class DescriptionProcessorTest extends \PHPUnit_Framework_TestCase {
 		);
 	}
 
-	public function testconstructDescriptionForPropertyObjectValue() {
+	public function testDescriptionForPropertyObjectValue() {
 
 		$instance = new DescriptionProcessor();
 
 		$this->assertInstanceOf(
 			'SMW\Query\Language\Description',
-			$instance->constructDescriptionForPropertyObjectValue( new DIProperty( 'Foo' ), 'bar' )
+			$instance->newDescriptionForPropertyObjectValue( new DIProperty( 'Foo' ), 'bar' )
 		);
 	}
 
-	public function testconstructDescriptionForWikiPageValueChunk() {
+	public function testDescriptionForWikiPageValueChunk() {
 
 		$instance = new DescriptionProcessor();
 
-		$valueDescription = $instance->constructDescriptionForWikiPageValueChunk( 'bar' );
+		$valueDescription = $instance->newDescriptionForWikiPageValueChunk( 'bar' );
 
 		$this->assertInstanceOf(
 			'SMW\Query\Language\ValueDescription',
@@ -72,11 +72,11 @@ class DescriptionProcessorTest extends \PHPUnit_Framework_TestCase {
 		);
 	}
 
-	public function testconstructDescriptionForWikiPageValueChunkOnApproximateValue() {
+	public function testnewDescriptionForWikiPageValueChunkOnApproximateValue() {
 
 		$instance = new DescriptionProcessor();
 
-		$valueDescription = $instance->constructDescriptionForWikiPageValueChunk( '~bar' );
+		$valueDescription = $instance->newDescriptionForWikiPageValueChunk( '~bar' );
 
 		$this->assertEquals(
 			new DIWikiPage( 'bar', NS_MAIN ),
@@ -88,16 +88,16 @@ class DescriptionProcessorTest extends \PHPUnit_Framework_TestCase {
 
 		$instance = new DescriptionProcessor();
 
-		$currentDescription = $instance->constructDescriptionForWikiPageValueChunk( 'bar' );
+		$currentDescription = $instance->newDescriptionForWikiPageValueChunk( 'bar' );
 
-		$newDescription = $instance->constructDescriptionForPropertyObjectValue(
+		$newDescription = $instance->newDescriptionForPropertyObjectValue(
 			new DIProperty( 'Foo' ),
 			'foobar'
 		);
 
 		$this->assertInstanceOf(
 			'SMW\Query\Language\Disjunction',
-			$instance->constructDisjunctiveCompoundDescriptionFrom( $currentDescription, $newDescription )
+			$instance->asOr( $currentDescription, $newDescription )
 		);
 	}
 
@@ -107,14 +107,14 @@ class DescriptionProcessorTest extends \PHPUnit_Framework_TestCase {
 
 		$currentDescription = new Conjunction();
 
-		$newDescription = $instance->constructDescriptionForPropertyObjectValue(
+		$newDescription = $instance->newDescriptionForPropertyObjectValue(
 			new DIProperty( 'Foo' ),
 			'foobar'
 		);
 
 		$this->assertInstanceOf(
 			'SMW\Query\Language\Disjunction',
-			$instance->constructDisjunctiveCompoundDescriptionFrom( $currentDescription, $newDescription )
+			$instance->asOr( $currentDescription, $newDescription )
 		);
 	}
 
@@ -124,14 +124,14 @@ class DescriptionProcessorTest extends \PHPUnit_Framework_TestCase {
 
 		$currentDescription = new Disjunction();
 
-		$newDescription = $instance->constructDescriptionForPropertyObjectValue(
+		$newDescription = $instance->newDescriptionForPropertyObjectValue(
 			new DIProperty( 'Foo' ),
 			'foobar'
 		);
 
 		$this->assertInstanceOf(
 			'SMW\Query\Language\Disjunction',
-			$instance->constructDisjunctiveCompoundDescriptionFrom( $currentDescription, $newDescription )
+			$instance->asOr( $currentDescription, $newDescription )
 		);
 	}
 
@@ -139,11 +139,11 @@ class DescriptionProcessorTest extends \PHPUnit_Framework_TestCase {
 
 		$instance = new DescriptionProcessor();
 
-		$currentDescription = $instance->constructDescriptionForWikiPageValueChunk( 'bar' );
+		$currentDescription = $instance->newDescriptionForWikiPageValueChunk( 'bar' );
 
 		$this->assertInstanceOf(
 			'SMW\Query\Language\ValueDescription',
-			$instance->constructDisjunctiveCompoundDescriptionFrom( $currentDescription, null )
+			$instance->asOr( $currentDescription, null )
 		);
 	}
 
@@ -151,11 +151,11 @@ class DescriptionProcessorTest extends \PHPUnit_Framework_TestCase {
 
 		$instance = new DescriptionProcessor();
 
-		$newDescription = $instance->constructDescriptionForWikiPageValueChunk( 'bar' );
+		$newDescription = $instance->newDescriptionForWikiPageValueChunk( 'bar' );
 
 		$this->assertInstanceOf(
 			'SMW\Query\Language\ValueDescription',
-			$instance->constructDisjunctiveCompoundDescriptionFrom( null, $newDescription )
+			$instance->asOr( null, $newDescription )
 		);
 	}
 
@@ -163,16 +163,16 @@ class DescriptionProcessorTest extends \PHPUnit_Framework_TestCase {
 
 		$instance = new DescriptionProcessor();
 
-		$currentDescription = $instance->constructDescriptionForWikiPageValueChunk( 'bar' );
+		$currentDescription = $instance->newDescriptionForWikiPageValueChunk( 'bar' );
 
-		$newDescription = $instance->constructDescriptionForPropertyObjectValue(
+		$newDescription = $instance->newDescriptionForPropertyObjectValue(
 			new DIProperty( 'Foo' ),
 			'foobar'
 		);
 
 		$this->assertInstanceOf(
 			'SMW\Query\Language\Conjunction',
-			$instance->constructConjunctiveCompoundDescriptionFrom( $currentDescription, $newDescription )
+			$instance->asAnd( $currentDescription, $newDescription )
 		);
 	}
 
@@ -182,14 +182,14 @@ class DescriptionProcessorTest extends \PHPUnit_Framework_TestCase {
 
 		$currentDescription = new Conjunction();
 
-		$newDescription = $instance->constructDescriptionForPropertyObjectValue(
+		$newDescription = $instance->newDescriptionForPropertyObjectValue(
 			new DIProperty( 'Foo' ),
 			'foobar'
 		);
 
 		$this->assertInstanceOf(
 			'SMW\Query\Language\Conjunction',
-			$instance->constructConjunctiveCompoundDescriptionFrom( $currentDescription, $newDescription )
+			$instance->asAnd( $currentDescription, $newDescription )
 		);
 	}
 
@@ -199,14 +199,14 @@ class DescriptionProcessorTest extends \PHPUnit_Framework_TestCase {
 
 		$currentDescription = new Disjunction();
 
-		$newDescription = $instance->constructDescriptionForPropertyObjectValue(
+		$newDescription = $instance->newDescriptionForPropertyObjectValue(
 			new DIProperty( 'Foo' ),
 			'foobar'
 		);
 
 		$this->assertInstanceOf(
 			'SMW\Query\Language\Conjunction',
-			$instance->constructConjunctiveCompoundDescriptionFrom( $currentDescription, $newDescription )
+			$instance->asAnd( $currentDescription, $newDescription )
 		);
 	}
 
@@ -214,11 +214,11 @@ class DescriptionProcessorTest extends \PHPUnit_Framework_TestCase {
 
 		$instance = new DescriptionProcessor();
 
-		$currentDescription = $instance->constructDescriptionForWikiPageValueChunk( 'bar' );
+		$currentDescription = $instance->newDescriptionForWikiPageValueChunk( 'bar' );
 
 		$this->assertInstanceOf(
 			'SMW\Query\Language\ValueDescription',
-			$instance->constructConjunctiveCompoundDescriptionFrom( $currentDescription, null )
+			$instance->asAnd( $currentDescription, null )
 		);
 	}
 
@@ -226,11 +226,11 @@ class DescriptionProcessorTest extends \PHPUnit_Framework_TestCase {
 
 		$instance = new DescriptionProcessor();
 
-		$newDescription = $instance->constructDescriptionForWikiPageValueChunk( 'bar' );
+		$newDescription = $instance->newDescriptionForWikiPageValueChunk( 'bar' );
 
 		$this->assertInstanceOf(
 			'SMW\Query\Language\ValueDescription',
-			$instance->constructConjunctiveCompoundDescriptionFrom( null, $newDescription )
+			$instance->asAnd( null, $newDescription )
 		);
 	}
 
@@ -244,14 +244,14 @@ class DescriptionProcessorTest extends \PHPUnit_Framework_TestCase {
 
 		$currentDescription = new Disjunction();
 
-		$newDescription = $instance->constructDescriptionForPropertyObjectValue(
+		$newDescription = $instance->newDescriptionForPropertyObjectValue(
 			new DIProperty( 'Foo' ),
 			'foobar'
 		);
 
 		$this->assertInstanceOf(
 			'SMW\Query\Language\Conjunction',
-			$instance->constructConjunctiveCompoundDescriptionFrom( $currentDescription, $newDescription )
+			$instance->asAnd( $currentDescription, $newDescription )
 		);
 	}
 

--- a/tests/phpunit/Unit/Query/Parser/TokenizerTest.php
+++ b/tests/phpunit/Unit/Query/Parser/TokenizerTest.php
@@ -1,0 +1,99 @@
+<?php
+
+namespace SMW\Tests\Query\Parser;
+
+use SMW\Query\Parser\Tokenizer;
+
+/**
+ * @covers \SMW\Query\Parser\Tokenizer
+ * @group semantic-mediawiki
+ *
+ * @license GNU GPL v2+
+ * @since 3.0
+ *
+ * @author mwjames
+ */
+class TokenizerTest extends \PHPUnit_Framework_TestCase {
+
+	public function testCanConstruct() {
+
+		$this->assertInstanceOf(
+			Tokenizer::class,
+			new Tokenizer()
+		);
+	}
+
+	/**
+	 * @dataProvider tokenProvider
+	 */
+	public function testGetToken( $currentString, $stoppattern, $expectedRes, $expectedCurrent ) {
+
+		$instance = new Tokenizer();
+		$instance->setDefaultPattern( [] );
+
+		$res = $instance->getToken( $currentString, $stoppattern );
+
+		$this->assertEquals(
+			$expectedRes,
+			$res
+		);
+
+		$this->assertEquals(
+			$expectedCurrent,
+			$currentString
+		);
+	}
+
+	public function tokenProvider() {
+
+		yield [
+			'',
+			'',
+			'',
+			''
+		];
+
+		yield [
+			'[[Foo]]',
+			'',
+			'[[',
+			'Foo]]'
+		];
+
+		yield [
+			'|Foo',
+			'',
+			'|',
+			'Foo'
+		];
+
+		yield [
+			'::Foo',
+			'',
+			'::',
+			'Foo'
+		];
+
+		yield [
+			'Foo]]',
+			'',
+			'Foo',
+			']]'
+		];
+
+		yield [
+			'Foo]][[Bar',
+			'',
+			'Foo',
+			']][[Bar'
+		];
+
+		yield [
+			']][[Bar',
+			'',
+			']]',
+			'[[Bar'
+		];
+	}
+
+}

--- a/tests/phpunit/Unit/QueryFactoryTest.php
+++ b/tests/phpunit/Unit/QueryFactoryTest.php
@@ -93,7 +93,7 @@ class QueryFactoryTest extends \PHPUnit_Framework_TestCase {
 		$instance = new QueryFactory();
 
 		$this->assertInstanceOf(
-			'\SMWQueryParser',
+			'\SMW\Query\Parser',
 			$instance->newQueryParser()
 		);
 	}

--- a/tests/phpunit/Unit/SQLStore/QueryEngine/ConceptQuerySegmentBuilderTest.php
+++ b/tests/phpunit/Unit/SQLStore/QueryEngine/ConceptQuerySegmentBuilderTest.php
@@ -18,6 +18,7 @@ class ConceptQuerySegmentBuilderTest extends \PHPUnit_Framework_TestCase {
 
 	private $querySegmentListBuilder;
 	private $querySegmentListProcessor;
+	private $queryParser;
 
 	protected function setUp() {
 		parent::setUp();
@@ -27,6 +28,10 @@ class ConceptQuerySegmentBuilderTest extends \PHPUnit_Framework_TestCase {
 			->getMock();
 
 		$this->querySegmentListProcessor = $this->getMockBuilder( '\SMW\SQLStore\QueryEngine\QuerySegmentListProcessor' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$this->queryParser = $this->getMockBuilder( '\SMW\Query\Parser' )
 			->disableOriginalConstructor()
 			->getMock();
 	}
@@ -41,9 +46,21 @@ class ConceptQuerySegmentBuilderTest extends \PHPUnit_Framework_TestCase {
 
 	public function testGetQuerySegmentFromOnNull() {
 
+		$description = $this->getMockBuilder( '\SMW\Query\Language\Description' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$this->queryParser->expects( $this->any() )
+			->method( 'getQueryDescription' )
+			->will( $this->returnValue( $description ) );
+
 		$instance = new ConceptQuerySegmentBuilder(
 			$this->querySegmentListBuilder,
 			$this->querySegmentListProcessor
+		);
+
+		$instance->setQueryParser(
+			$this->queryParser
 		);
 
 		$this->assertNull(

--- a/tests/phpunit/Unit/SQLStore/QueryEngine/DescriptionInterpreters/ConceptDescriptionInterpreterTest.php
+++ b/tests/phpunit/Unit/SQLStore/QueryEngine/DescriptionInterpreters/ConceptDescriptionInterpreterTest.php
@@ -2,7 +2,7 @@
 
 namespace SMW\Tests\SQLStore\QueryEngine\DescriptionInterpreters;
 
-use SMW\DataItemFactory;
+use SMW\ApplicationFactory;
 use SMW\Query\DescriptionFactory;
 use SMW\SQLStore\QueryEngine\DescriptionInterpreters\ConceptDescriptionInterpreter;
 use SMW\SQLStore\QueryEngineFactory;
@@ -21,6 +21,7 @@ class ConceptDescriptionInterpreterTest extends \PHPUnit_Framework_TestCase {
 
 	private $querySegmentValidator;
 	private $descriptionInterpreterFactory;
+	private $queryParser;
 
 	private $descriptionFactory;
 	private $dataItemFactory;
@@ -28,8 +29,12 @@ class ConceptDescriptionInterpreterTest extends \PHPUnit_Framework_TestCase {
 	protected function setUp() {
 		parent::setUp();
 
-		$this->descriptionFactory = new DescriptionFactory();
-		$this->dataItemFactory = new DataItemFactory();
+		$applicationFactory = ApplicationFactory::getInstance();
+		$queryFactory = $applicationFactory->getQueryFactory();
+
+		$this->descriptionFactory = $queryFactory->newDescriptionFactory();
+		$this->queryParser = $queryFactory->newQueryParser();
+		$this->dataItemFactory = $applicationFactory->getDataItemFactory();
 
 		$this->descriptionInterpreterFactory = $this->getMockBuilder( '\SMW\SQLStore\QueryEngine\DescriptionInterpreterFactory' )
 			->disableOriginalConstructor()
@@ -146,6 +151,10 @@ class ConceptDescriptionInterpreterTest extends \PHPUnit_Framework_TestCase {
 			$queryEngineFactory->newQuerySegmentListBuilder()
 		);
 
+		$instance->setQueryParser(
+			$this->queryParser
+		);
+
 		$this->assertTrue(
 			$instance->canInterpretDescription( $description )
 		);
@@ -158,8 +167,10 @@ class ConceptDescriptionInterpreterTest extends \PHPUnit_Framework_TestCase {
 
 	public function descriptionProvider() {
 
-		$descriptionFactory = new DescriptionFactory();
-		$dataItemFactory = new DataItemFactory();
+		$applicationFactory = ApplicationFactory::getInstance();
+
+		$descriptionFactory = $applicationFactory->getQueryFactory()->newDescriptionFactory();
+		$dataItemFactory = $applicationFactory->getDataItemFactory();
 
 		#0 No concept
 		$concept = false;


### PR DESCRIPTION
This PR is made in reference to: #1291

This PR addresses or contains:

- Moves `SMWQueryParser` to `SMW\Query\Parser\LegacyParser`
- Adds `SMW\Query\Parser` as interface to hide the implementation
- Part that deals with tokens/pattern matching haven been moved to its own `Tokenizer` class
-  `LegacyParser` constructor signature has changed to `__construct( DescriptionProcessor $descriptionProcessor, Tokenizer $tokenizer, QueryToken $queryToken )` therefore the correct way is to use the Factory class to get an instance object
- `LegacyParser` generally needs more clean-up but I'm not bored enough to take on this task

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed
