### PR TITLE
Clean table entries for known redirects

### DIFF
--- a/src/SQLStore/EntityRebuildDispatcher.php
+++ b/src/SQLStore/EntityRebuildDispatcher.php
@@ -310,6 +310,8 @@ class EntityRebuildDispatcher {
 					$this->dispatchedEntities[] = array( 's' => $title->getPrefixedDBKey() );
 					$updateJobs[] = $this->newUpdateJob( $title );
 				}
+
+				$this->propertyTableIdReferenceDisposer->cleanUpTableEntriesById( $row->smw_id );
 			} elseif ( $row->smw_iw == SMW_SQL3_SMWIW_OUTDATED || $row->smw_iw == SMW_SQL3_SMWDELETEIW ) { // remove outdated internal object references
 				$this->propertyTableIdReferenceDisposer->cleanUpTableEntriesById( $row->smw_id );
 			} elseif ( $titleKey != '' ) { // "normal" interwiki pages or outdated internal objects -- delete


### PR DESCRIPTION
This PR is made in reference to: #

This PR addresses or contains:

- Allow the rebuild dispatcher (executed as part of `rebuildData.php`) that inspects an existing redirect to remove outdated table content

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed
