### PR TITLE
Add JsonSchemaValidator

### DIFF
--- a/src/Services/SharedServicesContainer.php
+++ b/src/Services/SharedServicesContainer.php
@@ -45,6 +45,8 @@ use SMW\Localizer;
 use SMW\MediaWiki\DatabaseConnectionProvider;
 use SMW\Utils\TempFile;
 use SMW\PostProcHandler;
+use SMW\Utils\JsonSchemaValidator;
+use JsonSchema\Validator as SchemaValidator;
 
 /**
  * @license GNU GPL v2+
@@ -213,6 +215,27 @@ class SharedServicesContainer implements CallbackContainer {
 			);
 
 			return $postProcHandler;
+		} );
+
+		/**
+		 * @var JsonSchemaValidator
+		 */
+		$containerBuilder->registerCallback( 'JsonSchemaValidator', function( $containerBuilder ) {
+			$containerBuilder->registerExpectedReturnType( 'JsonSchemaValidator', JsonSchemaValidator::class );
+			$containerBuilder->registerAlias( 'JsonSchemaValidator', JsonSchemaValidator::class );
+
+			$schemaValidator = null;
+
+			// justinrainbow/json-schema
+			if ( class_exists( SchemaValidator::class ) ) {
+				$schemaValidator = new SchemaValidator();
+			}
+
+			$jsonSchemaValidator = new JsonSchemaValidator(
+				$schemaValidator
+			);
+
+			return $jsonSchemaValidator;
 		} );
 	}
 

--- a/src/Utils/JsonSchemaValidator.php
+++ b/src/Utils/JsonSchemaValidator.php
@@ -1,0 +1,98 @@
+<?php
+
+namespace SMW\Utils;
+
+use JsonSchema\Validator as SchemaValidator;
+use JsonSchema\Exception\ResourceNotFoundException;
+use JsonSerializable;
+
+/**
+ * @license GNU GPL v2+
+ * @since 3.0
+ *
+ * @author mwjames
+ */
+class JsonSchemaValidator {
+
+	/**
+	 * @var SchemaValidator
+	 */
+	private $schemaValidator;
+
+	/**
+	 * @var boolen
+	 */
+	private $isValid = true;
+
+	/**
+	 * @var []
+	 */
+	private $errors = [];
+
+	/**
+	 * @since 3.0
+	 *
+	 * @param SchemaValidator|null $schemaValidator
+	 */
+	public function __construct( SchemaValidator $schemaValidator = null ) {
+		$this->schemaValidator = $schemaValidator;
+	}
+
+	/**
+	 * @since 3.0
+	 *
+	 * @param JsonSerializable $data
+	 * @param string|null $schema
+	 */
+	public function validate( JsonSerializable $data, $schema = null ) {
+
+		if ( $this->schemaValidator === null || $schema === null ) {
+			return;
+		}
+
+		// https://github.com/justinrainbow/json-schema/issues/203
+		$data = json_decode( $data->jsonSerialize() );
+
+		// https://github.com/justinrainbow/json-schema
+		try {
+			$this->schemaValidator->check(
+				$data,
+				(object)[ '$ref' => 'file://' . $schema ]
+			);
+
+			$this->isValid = $this->schemaValidator->isValid();
+			$this->errors = $this->schemaValidator->getErrors();
+		} catch ( ResourceNotFoundException $e ) {
+			$this->isValid = false;
+			$this->errors[] = $e->getMessage();
+		}
+	}
+
+	/**
+	 * @since 3.0
+	 *
+	 * @param boolean
+	 */
+	public function hasSchemaValidator() {
+		return $this->schemaValidator !== null;
+	}
+
+	/**
+	 * @since 3.0
+	 *
+	 * @param boolean
+	 */
+	public function isValid() {
+		return $this->isValid;
+	}
+
+	/**
+	 * @since 3.0
+	 *
+	 * @return []
+	 */
+	public function getErrors() {
+		return $this->errors;
+	}
+
+}

--- a/tests/phpunit/Unit/Utils/JsonSchemaValidatorTest.php
+++ b/tests/phpunit/Unit/Utils/JsonSchemaValidatorTest.php
@@ -1,0 +1,121 @@
+<?php
+
+namespace SMW\Tests\Utils;
+
+use SMW\Utils\JsonSchemaValidator;
+use SMW\ApplicationFactory;
+use JsonSchema\Validator as SchemaValidator;
+use JsonSchema\Exception\ResourceNotFoundException;
+use JsonSerializable;
+
+/**
+ * @covers \SMW\Utils\JsonSchemaValidator
+ * @group semantic-mediawiki
+ *
+ * @license GNU GPL v2+
+ * @since 3.0
+ *
+ * @author mwjames
+ */
+class JsonSchemaValidatorTest extends \PHPUnit_Framework_TestCase {
+
+	public function testCanConstruct() {
+
+		$this->assertInstanceOf(
+			JsonSchemaValidator::class,
+			new JsonSchemaValidator()
+		);
+
+		$applicationFactory = ApplicationFactory::getInstance();
+
+		$this->assertInstanceOf(
+			JsonSchemaValidator::class,
+			$applicationFactory->create( 'JsonSchemaValidator' )
+		);
+
+		$this->assertInstanceOf(
+			JsonSchemaValidator::class,
+			$applicationFactory->create( JsonSchemaValidator::class )
+		);
+	}
+
+	public function testNoSchemaValidator() {
+
+		$instance = new JsonSchemaValidator();
+
+		$this->assertFalse(
+			$instance->hasSchemaValidator()
+		);
+	}
+
+	public function testValidate() {
+
+		if ( !class_exists( SchemaValidator::class ) ) {
+			$this->markTestSkipped( 'JsonSchema\Validator is not available.' );
+		}
+
+		$data = $this->getMockBuilder( JsonSerializable::class )
+			->setMethods( [ 'jsonSerialize' ] )
+			->getMock();
+
+		$data->expects( $this->any() )
+			->method( 'jsonSerialize' )
+			->will( $this->returnValue( json_encode( [ 'Foo' ] ) ) );
+
+		$schemaValidator = $this->getMockBuilder( SchemaValidator::class )
+			->setMethods( [ 'check' ] )
+			->getMock();
+
+		$instance = new JsonSchemaValidator(
+			$schemaValidator
+		);
+
+		$instance->validate( $data, 'Foo' );
+
+		$this->assertTrue(
+			$instance->isValid()
+		);
+
+		$this->assertEmpty(
+			$instance->getErrors()
+		);
+	}
+
+	public function testValidateWhereSchemaValidatorThrowsException() {
+
+		if ( !class_exists( SchemaValidator::class ) ) {
+			$this->markTestSkipped( 'JsonSchema\Validator is not available.' );
+		}
+
+		$data = $this->getMockBuilder( JsonSerializable::class )
+			->setMethods( [ 'jsonSerialize' ] )
+			->getMock();
+
+		$data->expects( $this->any() )
+			->method( 'jsonSerialize' )
+			->will( $this->returnValue( json_encode( [ 'Foo' ] ) ) );
+
+		$schemaValidator = $this->getMockBuilder( SchemaValidator::class )
+			->setMethods( [ 'check' ] )
+			->getMock();
+
+		$schemaValidator->expects( $this->any() )
+			->method( 'check' )
+			->will($this->throwException( new ResourceNotFoundException() ) );
+
+		$instance = new JsonSchemaValidator(
+			$schemaValidator
+		);
+
+		$instance->validate( $data, 'Foo' );
+
+		$this->assertFalse(
+			$instance->isValid()
+		);
+
+		$this->assertNotEmpty(
+			$instance->getErrors()
+		);
+	}
+
+}


### PR DESCRIPTION
This PR is made in reference to: #

This PR addresses or contains:

- Encapsulates the `justinrainbow/json-schema` access to `JsonSchema\Validator` that is deployed with MW
- Allows to validate a JSON schema against an actual JSON content
- Schema files used for validation in SMW-core should be placed in `/data/schema/myTopic/schema.v$1.json` ($1denoting the version)

```php

$schema = __DIR__ '/data/schema/foo/foo.v1.json';

$jsonSchemaValidator =  ApplicationFactory::getInstance()->create( 'JsonSchemaValidator' );
$jsonSchemaValidator ->validate( JsonSerializable, $schema );

```

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed
