### PR TITLE
Changes default setting for `smwgExportResourcesAsIri` (breaking)

### DIFF
--- a/DefaultSettings.php
+++ b/DefaultSettings.php
@@ -1215,12 +1215,10 @@ return array(
 	#
 	# @see https://www.w3.org/TR/rdf11-concepts/#section-IRIs
 	#
-	# This setting should be set TRUE with beginning of 3.x.
-	#
 	# @since 2.5
-	# @default false (to avoid any BC break for exsiting systems)
+	# @default true
 	##
-	'smwgExportResourcesAsIri' => false,
+	'smwgExportResourcesAsIri' => true,
 	##
 
 	##

--- a/tests/phpunit/Unit/Exporter/EscaperTest.php
+++ b/tests/phpunit/Unit/Exporter/EscaperTest.php
@@ -26,7 +26,7 @@ class EscaperTest extends \PHPUnit_Framework_TestCase {
 		$this->testEnvironment->addConfiguration( 'smwgExportResourcesAsIri', false );
 	}
 
-	protected function setU() {
+	protected function tearDown() {
 		$this->testEnvironment->tearDown();
 		parent::tearDown();
 	}


### PR DESCRIPTION
This PR is made in reference to: #2207 

This PR addresses or contains:
- Switches (BREAKING) the default to use IRIs for resource export
- Fixes test per [comment](#2788 (comment)) by @mwjames

This PR includes:
- [x] Tests (unit/integration)
- [ ] CI build passed