### PR TITLE
Provide RELEASE-NOTES of SMW 2.5.5 to master 

### DIFF
--- a/docs/releasenotes/README.md
+++ b/docs/releasenotes/README.md
@@ -1,5 +1,6 @@
 ## Release notes
 
+* [SMW 2.5.5 release notes](RELEASE-NOTES-2.5.5.md)
 * [SMW 2.5.4 release notes](RELEASE-NOTES-2.5.4.md)
 * [SMW 2.5.3 release notes](RELEASE-NOTES-2.5.3.md)
 * [SMW 2.5.2 release notes](RELEASE-NOTES-2.5.2.md)

--- a/docs/releasenotes/RELEASE-NOTES-2.5.5.md
+++ b/docs/releasenotes/RELEASE-NOTES-2.5.5.md
@@ -1,0 +1,11 @@
+# Semantic MediaWiki 2.5.5
+
+Released on October 25, 2017.
+
+## Bug fixes and internal code changes
+
+* [#2672](https://github.com/SemanticMediaWiki/SemanticMediaWiki/pull/2672) as `e17160e` Changes obfuscator to use `&#x005B;` instead of `&#91;` for the links in values detection
+* [#2692](https://github.com/SemanticMediaWiki/SemanticMediaWiki/pull/2692) as `5ddd9ca` Fixes "EventListenerRegistry.php: Call to a member function getArticleID() on null"
+* [#2767](https://github.com/SemanticMediaWiki/SemanticMediaWiki/pull/2767) as `848ed0c` Forces data updates on template refreshs
+* [#2773](https://github.com/SemanticMediaWiki/SemanticMediaWiki/pull/2773) as `55b6b72` Adds in MediaWiki's default script parameters in non-standard setups
+* [#2780](https://github.com/SemanticMediaWiki/SemanticMediaWiki/pull/2780) as `4bc0d5f` Brings additional checks for namespaces that are enabled for links and annotations


### PR DESCRIPTION
This PR is made in reference to: #2604 

This PR addresses or contains:
- Provide RELEASE-NOTES of SMW 2.5.5 to master 

This PR includes:
- [ ] Tests (unit/integration)
- [x] CI build passed