### PR TITLE
Stop testing against MediaWiki < 1.27

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,34 +12,34 @@ matrix:
       php: 7.1
     - env: DB=mysql; MW=REL1_28; FUSEKI=2.4.0
       php: 5.5
-    - env: DB=mysql; MW=REL1_25; VIRTUOSO=6.1
+    - env: DB=mysql; MW=REL1_29; VIRTUOSO=6.1
       php: 5.6
-    - env: DB=mysql; MW=REL1_23; SESAME=2.8.7
+    - env: DB=mysql; MW=REL1_27; SESAME=2.8.7
       php: 5.5
     - env: DB=sqlite; MW=REL1_27; SITELANG=ja
       php: 5.5
-    - env: DB=postgres; MW=REL1_26;
+    - env: DB=postgres; MW=REL1_30;
       php: 5.5
-    - env: DB=mysql; MW=REL1_26; BLAZEGRAPH=1.5.2; PHPUNIT=4.8.*
+    - env: DB=mysql; MW=REL1_30; BLAZEGRAPH=1.5.2; PHPUNIT=4.8.*
       php: 5.6
-    - env: DB=mysql; MW=REL1_25; TYPE=benchmark; PHPUNIT=5.7.*
+    - env: DB=mysql; MW=REL1_29; TYPE=benchmark; PHPUNIT=5.7.*
       php: hhvm-3.18
     - env: DB=sqlite; MW=master; PHPUNIT=5.7.*
       php: hhvm-3.18
     - env: DB=sqlite; MW=REL1_27; TYPE=composer; PHPUNIT=4.8.*
       php: 5.6
-    - env: DB=mysql; MW=REL1_25; TYPE=relbuild
+    - env: DB=mysql; MW=REL1_29; TYPE=relbuild
       php: 5.5
   allow_failures:
     # Can fail when pushed/used with newly Composer dependencies
-    - env: DB=mysql; MW=REL1_25; TYPE=relbuild
+    - env: DB=mysql; MW=REL1_29; TYPE=relbuild
     # Can fail when pushed/used with newly Composer dependencies
     - env: DB=sqlite; MW=REL1_27; TYPE=composer; PHPUNIT=4.8.*
     # This is MW master, you never know what WMF developers have put in for easter eggs
     - env: DB=sqlite; MW=master; PHPUNIT=5.7.*
     # May take a moment and is non-critical therefore allow it to run without delaying the status
-    - env: DB=mysql; MW=REL1_25; TYPE=benchmark; PHPUNIT=5.7.*
-    - env: DB=mysql; MW=REL1_23; SESAME=2.8.7
+    - env: DB=mysql; MW=REL1_29; TYPE=benchmark; PHPUNIT=5.7.*
+    - env: DB=mysql; MW=REL1_27; SESAME=2.8.7
 
 # Dec 16, 2015 (GCE switch): Travis support wrote (Tomcat + Java):
 # bug in the JDK: http://bugs.java.com/bugdatabase/view_bug.do?bug_id=7089443.


### PR DESCRIPTION
So they killed old branches in an effort to make digital preservation much easier. Besides this was subject of two talks during the past WikidataCon and this appears imho to be an rather unexpected conclusion to me. However in our context I updated the branches to the ones SMW 3.0 will be supporting, i.e. I added four to the obsolete branches.

This PR is made in reference to: #1365 

This PR addresses or contains:
- Switches to supported branches

This PR includes:
- [ ] Tests (unit/integration)
- [ ] CI build passed