### PR TITLE
Consolidate browse settings, `smwgBrowseFeatures`, refs 2798

### DIFF
--- a/DefaultSettings.php
+++ b/DefaultSettings.php
@@ -281,14 +281,6 @@ return array(
 	##
 
 	###
-	# Should the toolbox of each content page show a link to browse the properties
-	# of that page using Special:Browse? This is a useful way to access properties
-	# and it is somewhat more subtle than showing a Factbox on every page.
-	##
-	'smwgToolboxBrowseLink' => true,
-	##
-
-	###
 	# Should warnings be displayed in wikitexts right after the problematic input?
 	# This affects only semantic annotations, not warnings that are displayed by
 	# inline queries or other features.
@@ -371,25 +363,28 @@ return array(
 	##
 
 	###
-	# Should the browse view for incoming links show the incoming links via its
-	# inverses, or shall they be displayed on the other side?
-	##
-	'smwgBrowseShowInverse' => false,
-	##
-
-	###
-	# Should the browse view always show the incoming links as well, and more of
-	# the incoming values?
-	##
-	'smwgBrowseShowAll' => true,
-	##
-
-	###
-	# Whether the browse display is to be generated using an API request or not.
+	# Special:Browse related settings
 	#
-	# @since 2.5
+	# - SMW_BROWSE_NONE
+	#
+	# - SMW_BROWSE_TLINK: Should the toolbox of each content page show a link
+	#   to browse the properties of that page using Special:Browse? This is a
+	#   useful way to access properties and it is somewhat more subtle than
+	#   showing a Factbox on every page. (was $smwgToolboxBrowseLink)
+	#
+	# - SMW_BROWSE_SHOW_INVERSE: Should the browse view for incoming links show
+	#   the incoming links via its inverses, or shall they be displayed on the
+	#   other side? (was $smwgBrowseShowInverse)
+	#
+	# - SMW_BROWSE_SHOW_INCOMING: Should the browse view always show the incoming links
+	#   as well, and more of the incoming values? (was $smwgBrowseShowAll)
+	#
+	# - SMW_BROWSE_USE_API: Whether the browse display is to be generated using
+	#   an API request or not. (was $smwgBrowseByApi)
+	#
+	# @since 3.0
 	##
-	'smwgBrowseByApi' => true,
+	'smwgBrowseFeatures' => SMW_BROWSE_TLINK | SMW_BROWSE_SHOW_INCOMING | SMW_BROWSE_USE_API,
 	##
 
 	###

--- a/includes/Settings.php
+++ b/includes/Settings.php
@@ -67,7 +67,6 @@ class Settings extends Options {
 			'smwgNamespaceIndex' => $GLOBALS['smwgNamespaceIndex'],
 			'smwgShowFactbox' => $GLOBALS['smwgShowFactbox'],
 			'smwgShowFactboxEdit' => $GLOBALS['smwgShowFactboxEdit'],
-			'smwgToolboxBrowseLink' => $GLOBALS['smwgToolboxBrowseLink'],
 			'smwgInlineErrors' => $GLOBALS['smwgInlineErrors'],
 			'smwgUseCategoryHierarchy' => $GLOBALS['smwgUseCategoryHierarchy'],
 			'smwgCategoriesAsInstances' => $GLOBALS['smwgCategoriesAsInstances'],
@@ -75,9 +74,6 @@ class Settings extends Options {
 			'smwgLinksInValues' => $GLOBALS['smwgLinksInValues'],
 			'smwgDefaultNumRecurringEvents' => $GLOBALS['smwgDefaultNumRecurringEvents'],
 			'smwgMaxNumRecurringEvents' => $GLOBALS['smwgMaxNumRecurringEvents'],
-			'smwgBrowseShowInverse' => $GLOBALS['smwgBrowseShowInverse'],
-			'smwgBrowseShowAll' => $GLOBALS['smwgBrowseShowAll'],
-			'smwgBrowseByApi' => $GLOBALS['smwgBrowseByApi'],
 			'smwgSearchByPropertyFuzzy' => $GLOBALS['smwgSearchByPropertyFuzzy'],
 			'smwgTypePagingLimit' => $GLOBALS['smwgTypePagingLimit'],
 			'smwgConceptPagingLimit' => $GLOBALS['smwgConceptPagingLimit'],
@@ -182,6 +178,7 @@ class Settings extends Options {
 			'smwgFieldTypeFeatures' => $GLOBALS['smwgFieldTypeFeatures'],
 			'smwgChangePropagationProtection' => $GLOBALS['smwgChangePropagationProtection'],
 			'smwgUseComparableContentHash' => $GLOBALS['smwgUseComparableContentHash'],
+			'smwgBrowseFeatures' => $GLOBALS['smwgBrowseFeatures'],
 		);
 
 		self::initLegacyMapping( $configuration );
@@ -387,6 +384,22 @@ class Settings extends Options {
 			$configuration['smwgChangePropagationWatchlist'] = $GLOBALS['smwgDeclarationProperties'];
 		}
 
+		if ( isset( $GLOBALS['smwgToolboxBrowseLink'] ) && $GLOBALS['smwgToolboxBrowseLink'] === false ) {
+			$configuration['smwgBrowseFeatures'] = $configuration['smwgBrowseFeatures'] & ~SMW_BROWSE_TLINK;
+		}
+
+		if ( isset( $GLOBALS['smwgBrowseShowInverse'] ) && $GLOBALS['smwgBrowseShowInverse'] === true ) {
+			$configuration['smwgBrowseFeatures'] = $configuration['smwgBrowseFeatures'] | SMW_BROWSE_SHOW_INVERSE;
+		}
+
+		if ( isset( $GLOBALS['smwgBrowseShowAll'] ) && $GLOBALS['smwgBrowseShowAll'] === false ) {
+			$configuration['smwgBrowseFeatures'] = $configuration['smwgBrowseFeatures'] & ~SMW_BROWSE_SHOW_INCOMING;
+		}
+
+		if ( isset( $GLOBALS['smwgBrowseByApi'] ) && $GLOBALS['smwgBrowseByApi'] === false ) {
+			$configuration['smwgBrowseFeatures'] = $configuration['smwgBrowseFeatures'] & ~SMW_BROWSE_USE_API;
+		}
+
 		// Deprecated mapping used in DeprecationNoticeTaskHandler to detect and
 		// output notices
 		$GLOBALS['smwgDeprecationNotices'] = array(
@@ -399,6 +412,10 @@ class Settings extends Options {
 				'smwgSparqlDatabaseConnector' => '3.1.0',
 				'smwgSparqlDatabase' => '3.1.0',
 				'smwgDeclarationProperties' => '3.1.0',
+				'smwgToolboxBrowseLink' => '3.1.0',
+				'smwgBrowseShowInverse' => '3.1.0',
+				'smwgBrowseShowAll' => '3.1.0',
+				'smwgBrowseByApi' => '3.1.0',
 				'options' => [
 					'smwgCacheUsage' =>  [
 						'smwgStatisticsCache' => '3.1.0',
@@ -425,6 +442,10 @@ class Settings extends Options {
 				'smwgSparqlDatabaseConnector' => 'smwgSparqlRepositoryConnector',
 				'smwgSparqlDatabase' => 'smwgSparqlCustomConnector',
 				'smwgDeclarationProperties' => 'smwgChangePropagationWatchlist',
+				'smwgToolboxBrowseLink' => 'smwgBrowseFeatures',
+				'smwgBrowseShowInverse' => 'smwgBrowseFeatures',
+				'smwgBrowseShowAll' => 'smwgBrowseFeatures',
+				'smwgBrowseByApi' => 'smwgBrowseFeatures',
 				'options' => [
 					'smwgCacheUsage' => [
 						'smwgStatisticsCacheExpiry' => 'special.statistics',

--- a/src/Defines.php
+++ b/src/Defines.php
@@ -229,3 +229,13 @@ define( 'SMW_QPRFL_NONE', 0 );
 define( 'SMW_QPRFL_PARAMS', 2 ); // Support for Query parameters
 define( 'SMW_QPRFL_DUR', 4 ); // Support for Query duration
 /**@}*/
+
+/**@{
+  * Constants for $smwgBrowseFeatures
+  */
+define( 'SMW_BROWSE_NONE', 0 );
+define( 'SMW_BROWSE_TLINK', 2 ); // Support for the toolbox link
+define( 'SMW_BROWSE_SHOW_INVERSE', 4 ); // Support inverse direction
+define( 'SMW_BROWSE_SHOW_INCOMING', 8 ); // Support for incoming links
+define( 'SMW_BROWSE_USE_API', 16 ); // Support for using the API as request backend
+/**@}*/

--- a/src/MediaWiki/Hooks/BaseTemplateToolbox.php
+++ b/src/MediaWiki/Hooks/BaseTemplateToolbox.php
@@ -60,7 +60,7 @@ class BaseTemplateToolbox {
 
 	protected function canPerformUpdate( Title $title ) {
 		return !$title->isSpecialPage() &&
-			ApplicationFactory::getInstance()->getSettings()->get( 'smwgToolboxBrowseLink' ) &&
+			ApplicationFactory::getInstance()->getSettings()->isFlagSet( 'smwgBrowseFeatures', SMW_BROWSE_TLINK ) &&
 			$this->isEnabledNamespace( $title ) &&
 			$this->skinTemplate->data['isarticle'];
 	}

--- a/src/MediaWiki/Specials/SpecialBrowse.php
+++ b/src/MediaWiki/Specials/SpecialBrowse.php
@@ -221,17 +221,17 @@ class SpecialBrowse extends SpecialPage {
 
 		$contentsBuilder->setOption(
 			'showInverse',
-			$settings->get( 'smwgBrowseShowInverse' )
+			$settings->isFlagSet( 'smwgBrowseFeatures', SMW_BROWSE_SHOW_INVERSE )
 		);
 
 		$contentsBuilder->setOption(
 			'showAll',
-			$settings->get( 'smwgBrowseShowAll' )
+			$settings->isFlagSet( 'smwgBrowseFeatures', SMW_BROWSE_SHOW_INCOMING )
 		);
 
 		$contentsBuilder->setOption(
 			'byApi',
-			$settings->get( 'smwgBrowseByApi' )
+			$settings->isFlagSet( 'smwgBrowseFeatures', SMW_BROWSE_USE_API )
 		);
 
 		return $contentsBuilder;

--- a/tests/phpunit/Integration/EncodingIntegrationTest.php
+++ b/tests/phpunit/Integration/EncodingIntegrationTest.php
@@ -66,7 +66,7 @@ class EncodingIntegrationTest extends \PHPUnit_Framework_TestCase {
 
 		$settings = array(
 			'smwgNamespacesWithSemanticLinks' => array( NS_MAIN => true ),
-			'smwgToolboxBrowseLink'           => true
+			'smwgBrowseFeatures'           => SMW_BROWSE_TLINK
 		);
 
 		$message = $this->getMockBuilder( '\Message' )

--- a/tests/phpunit/Unit/MediaWiki/Hooks/BaseTemplateToolboxTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Hooks/BaseTemplateToolboxTest.php
@@ -70,7 +70,7 @@ class BaseTemplateToolboxTest extends \PHPUnit_Framework_TestCase {
 		#0 Standard title
 		$settings = array(
 			'smwgNamespacesWithSemanticLinks' => array( NS_MAIN => true ),
-			'smwgToolboxBrowseLink'           => true
+			'smwgBrowseFeatures'           => SMW_BROWSE_TLINK
 		);
 
 		$skinTemplate = $this->getMockBuilder( '\SkinTemplate' )
@@ -104,7 +104,7 @@ class BaseTemplateToolboxTest extends \PHPUnit_Framework_TestCase {
 			array( 'count'        => 0 ),
 		);
 
-		#2 smwgToolboxBrowseLink = false
+		#2 smwgBrowseFeatures = false
 		$skinTemplate = $this->getMockBuilder( '\SkinTemplate' )
 			->disableOriginalConstructor()
 			->getMock();
@@ -117,7 +117,7 @@ class BaseTemplateToolboxTest extends \PHPUnit_Framework_TestCase {
 
 		$settings = array(
 			'smwgNamespacesWithSemanticLinks' => array( NS_MAIN => true ),
-			'smwgToolboxBrowseLink'           => false
+			'smwgBrowseFeatures'           => SMW_BROWSE_NONE
 		);
 
 		$provider[] = array(
@@ -138,7 +138,7 @@ class BaseTemplateToolboxTest extends \PHPUnit_Framework_TestCase {
 
 		$settings = array(
 			'smwgNamespacesWithSemanticLinks' => array( NS_MAIN => false ),
-			'smwgToolboxBrowseLink'           => true
+			'smwgBrowseFeatures'           => SMW_BROWSE_TLINK
 		);
 
 		$provider[] = array(
@@ -149,7 +149,7 @@ class BaseTemplateToolboxTest extends \PHPUnit_Framework_TestCase {
 		#4 Special page
 		$settings = array(
 			'smwgNamespacesWithSemanticLinks' => array( NS_MAIN => true ),
-			'smwgToolboxBrowseLink'           => true
+			'smwgBrowseFeatures'           => SMW_BROWSE_TLINK
 		);
 
 		$title = MockTitle::buildMock( __METHOD__ );

--- a/tests/phpunit/Unit/MediaWiki/Specials/SpecialBrowseTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Specials/SpecialBrowseTest.php
@@ -24,9 +24,7 @@ class SpecialBrowseTest extends \PHPUnit_Framework_TestCase {
 		parent::setUp();
 
 		$this->testEnvironment = new TestEnvironment( array(
-			'smwgBrowseShowInverse' => false,
-			'smwgBrowseShowAll'     => true,
-			'smwgBrowseByApi'       => true
+			'smwgBrowseFeatures' => SMW_BROWSE_SHOW_INCOMING | SMW_BROWSE_USE_API
 		) );
 
 		$store = $this->getMockBuilder( '\SMW\Store' )


### PR DESCRIPTION
This PR is made in reference to: #2798

This PR addresses or contains:

- Adds `smwgBrowseFeatures` and replaces:
  - `smwgToolboxBrowseLink` with `SMW_BROWSE_TLINK`
  - `smwgBrowseShowInverse` with `SMW_BROWSE_SHOW_INVERSE`
  - `smwgBrowseShowAll` with `SMW_BROWSE_SHOW_INCOMING`
  - `smwgBrowseByApi` with `SMW_BROWSE_USE_API`
- Default is defined with `SMW_BROWSE_TLINK | SMW_BROWSE_SHOW_INCOMING | SMW_BROWSE_USE_API`

This PR includes:
- [ ] Tests (unit/integration)
- [x] CI build passed

Fixes #