### PR TITLE
Add --skip-optimize, --skip-import to `setupStore.php`, refs 2516

### DIFF
--- a/includes/storage/SMW_Store.php
+++ b/includes/storage/SMW_Store.php
@@ -427,14 +427,32 @@ abstract class Store implements QueryEngine {
 	 * @since 1.8
 	 *
 	 * @param bool $verbose
-	 * @param bool $isFromExtensionSchemaUpdate
+	 * @param Options|null $options
 	 *
 	 * @return boolean Success indicator
 	 */
-	public static function setupStore( $verbose = true, $isFromExtensionSchemaUpdate = false ) {
+	public static function setupStore( $verbose = true, $options = null ) {
+
+		// See notes in ExtensionSchemaUpdates
+		if ( is_bool( $verbose ) ) {
+			$verbose = $verbose;
+		}
+
+		if ( isset( $options['verbose'] ) ) {
+			$verbose = $options['verbose'];
+		}
+
+		if ( isset( $options['options'] ) ) {
+			$options = $options['options'];
+		}
 
 		$store = StoreFactory::getStore();
-		$store->getOptions()->set( 'isFromExtensionSchemaUpdate', $isFromExtensionSchemaUpdate );
+
+		if ( $options instanceof Options ) {
+			foreach ( $options->getOptions() as $key => $value ) {
+				$store->getOptions()->set( $key, $value );
+			}
+		}
 
 		return $store->setup( $verbose );
 	}

--- a/maintenance/setupStore.php
+++ b/maintenance/setupStore.php
@@ -38,8 +38,12 @@ require_once $basePath . '/maintenance/Maintenance.php';
  *
  * --backend  The backend to use, e.g. SMWSQLStore3.
  *
- * --nochecks When specied, no prompts are provided. Deletion will thus happen
- *            without the need to provide any confomration.
+ * --skip-optimize Skips the table optimization process.
+ *
+ * --skip-import Skips the import process.
+ *
+ * --nochecks When specified, no prompts are provided. Deletion will thus happen
+ *            without the need to provide any confirmation.
  *
  * @author Markus Krötzsch
  * @author Jeroen De Dauw < jeroendedauw@gmail.com >
@@ -59,17 +63,6 @@ class SetupStore extends \Maintenance {
 	 */
 	public function __construct() {
 		parent::__construct();
-
-		$this->mDescription = 'Sets up the SMW storage backend currently selected in LocalSettings.php.';
-
-		$this->addOption( 'backend', 'Execute the operation for the storage backend of the given name.', false, true, 'b' );
-
-		$this->addOption( 'delete', 'Delete all SMW data, uninstall the selected storage backend.' );
-
-		$this->addOption(
-			'nochecks',
-			'Run the script without providing prompts. Deletion will thus happen without the need to provide any confirmation.'
-		);
 	}
 
 	/**
@@ -78,8 +71,20 @@ class SetupStore extends \Maintenance {
 	 * @since 2.0
 	 */
 	protected function addDefaultParams() {
-
 		parent::addDefaultParams();
+
+		$this->mDescription = 'Sets up the SMW storage backend currently selected in LocalSettings.php.';
+
+		$this->addOption( 'backend', 'Execute the operation for the storage backend of the given name.', false, true, 'b' );
+
+		$this->addOption( 'delete', 'Delete all SMW data, uninstall the selected storage backend.' );
+		$this->addOption( 'skip-optimize', 'Skipping the table optimization process (not recommended).', false );
+		$this->addOption( 'skip-import', 'Skipping the import process.', false );
+
+		$this->addOption(
+			'nochecks',
+			'Run the script without providing prompts. Deletion will thus happen without the need to provide any confirmation.'
+		);
 	}
 
 	/**
@@ -109,6 +114,16 @@ class SetupStore extends \Maintenance {
 		$store->getOptions()->set(
 			Installer::OPT_MESSAGEREPORTER,
 			$messageReporter
+		);
+
+		$store->getOptions()->set(
+			Installer::OPT_TABLE_OPTIMZE,
+			!$this->hasOption( 'skip-optimize' )
+		);
+
+		$store->getOptions()->set(
+			Installer::OPT_IMPORT,
+			!$this->hasOption( 'skip-import' )
 		);
 
 		if ( $this->hasOption( 'delete' ) ) {

--- a/src/Importer/Importer.php
+++ b/src/Importer/Importer.php
@@ -30,6 +30,11 @@ class Importer implements MessageReporterAware {
 	private $messageReporter;
 
 	/**
+	 * @var boolean
+	 */
+	private $isEnabled = true;
+
+	/**
 	 * @var integer|boolean
 	 */
 	private $reqVersion = false;
@@ -57,6 +62,15 @@ class Importer implements MessageReporterAware {
 	}
 
 	/**
+	 * @since 3.0
+	 *
+	 * @param boolean $isEnabled
+	 */
+	public function isEnabled( $isEnabled ) {
+		$this->isEnabled = $isEnabled;
+	}
+
+	/**
 	 * @since 2.5
 	 *
 	 * @param integer|boolean $reqVersion
@@ -69,6 +83,10 @@ class Importer implements MessageReporterAware {
 	 * @since 2.5
 	 */
 	public function doImport() {
+
+		if ( $this->isEnabled === false ) {
+			return $this->messageReporter->reportMessage( "\nSkipping the import process.\n" );
+		}
 
 		if ( $this->reqVersion === false ) {
 			return $this->messageReporter->reportMessage( "\nImport support not enabled, processing completed.\n" );

--- a/src/MediaWiki/Hooks/ExtensionSchemaUpdates.php
+++ b/src/MediaWiki/Hooks/ExtensionSchemaUpdates.php
@@ -3,6 +3,8 @@
 namespace SMW\MediaWiki\Hooks;
 
 use DatabaseUpdater;
+use SMW\SQLStore\Installer;
+use SMW\Options;
 
 /**
  * Schema update to set up the needed database tables
@@ -38,15 +40,32 @@ class ExtensionSchemaUpdates {
 	public function process() {
 
 		$verbose = true;
-		$isFromExtensionSchemaUpdate = true;
+
+		$options = new Options(
+			[
+				Installer::OPT_SCHEMA_UPDATE => true,
+				Installer::OPT_TABLE_OPTIMZE => true,
+				Installer::OPT_IMPORT => true
+			]
+		);
 
 		// Needs a static caller otherwise the DatabaseUpdater returns with:
 		// "Warning: call_user_func_array() expects parameter 1 to be a
 		// valid callback ..."
-		$this->updater->addExtensionUpdate( array( 'SMWStore::setupStore', array(
-			$verbose,
-			$isFromExtensionSchemaUpdate
-		) ) );
+		//
+		// DatabaseUpdater notes "... $callback is the method to call; either a
+		// DatabaseUpdater method name or a callable. Must be serializable (ie.
+		// no anonymous functions allowed). The rest of the parameters (if any)
+		// will be passed to the callback. ..."
+		$this->updater->addExtensionUpdate(
+			[
+				'SMWStore::setupStore',
+				[
+					'verbose' => $verbose,
+					'options' => $options
+				]
+			]
+		);
 
 		return true;
 	}

--- a/src/MediaWiki/Hooks/HookRegistry.php
+++ b/src/MediaWiki/Hooks/HookRegistry.php
@@ -740,14 +740,17 @@ class HookRegistry {
 		/**
 		 * @see https://www.semantic-mediawiki.org/wiki/Hooks#SMW::Store::AfterQueryResultLookupComplete
 		 */
-		$this->handlers['SMW::SQLStore::Installer::AfterCreateTablesComplete'] = function ( $tableBuilder, $messageReporter ) use ( $applicationFactory ) {
+		$this->handlers['SMW::SQLStore::Installer::AfterCreateTablesComplete'] = function ( $tableBuilder, $messageReporter, $options ) use ( $applicationFactory ) {
 
 			$importerServiceFactory = $applicationFactory->create( 'ImporterServiceFactory' );
 
 			$importer = $importerServiceFactory->newImporter(
-				$importerServiceFactory->newJsonContentIterator( $applicationFactory->getSettings()->get( 'smwgImportFileDir' ) )
+				$importerServiceFactory->newJsonContentIterator(
+					$applicationFactory->getSettings()->get( 'smwgImportFileDir' )
+				)
 			);
 
+			$importer->isEnabled( $options->safeGet( \SMW\SQLStore\Installer::OPT_IMPORT, false ) );
 			$importer->setMessageReporter( $messageReporter );
 			$importer->doImport();
 

--- a/src/Options.php
+++ b/src/Options.php
@@ -104,4 +104,24 @@ class Options {
 		return $this->options;
 	}
 
+	/**
+	 * @since 3.0
+	 *
+	 * @param array $keys
+	 *
+	 * @return array
+	 */
+	public function filter( array $keys ) {
+
+		$options = [];
+
+		foreach ( $keys as $key ) {
+			if ( isset( $this->options[$key] ) ) {
+				$options[$key] = $this->options[$key];
+			}
+		}
+
+		return $options;
+	}
+
 }

--- a/src/SQLStore/SQLStoreFactory.php
+++ b/src/SQLStore/SQLStoreFactory.php
@@ -359,7 +359,6 @@ class SQLStoreFactory {
 		$settings = ApplicationFactory::getInstance()->getSettings();
 
 		$messageReporter = MessageReporterFactory::getInstance()->newNullMessageReporter();
-		$options = $this->store->getOptions();
 
 		$tableBuilder = TableBuilder::factory(
 			$this->store->getConnection( DB_MASTER )
@@ -387,12 +386,15 @@ class SQLStoreFactory {
 			$tableIntegrityExaminer
 		);
 
-		if ( $options->has( Installer::OPT_MESSAGEREPORTER ) ) {
-			$installer->setMessageReporter( $options->get( Installer::OPT_MESSAGEREPORTER ) );
-		}
-
-		$installer->isFromExtensionSchemaUpdate(
-			( $options->has( 'isFromExtensionSchemaUpdate' ) ? $options->get( 'isFromExtensionSchemaUpdate' ) : false )
+		$installer->setOptions(
+			$this->store->getOptions()->filter(
+				[
+					Installer::OPT_MESSAGEREPORTER,
+					Installer::OPT_TABLE_OPTIMZE,
+					Installer::OPT_IMPORT,
+					Installer::OPT_SCHEMA_UPDATE
+				]
+			)
 		);
 
 		return $installer;

--- a/src/SQLStore/TableBuilder/MySQLTableBuilder.php
+++ b/src/SQLStore/TableBuilder/MySQLTableBuilder.php
@@ -364,7 +364,7 @@ class MySQLTableBuilder extends TableBuilder {
 	 */
 	protected function doOptimize( $tableName ) {
 
-		$this->reportMessage( "   Table $tableName ...\n" );
+		$this->reportMessage( "Checking table $tableName ...\n" );
 
 		// https://dev.mysql.com/doc/refman/5.7/en/analyze-table.html
 		// Performs a key distribution analysis and stores the distribution for

--- a/src/SQLStore/TableBuilder/PostgresTableBuilder.php
+++ b/src/SQLStore/TableBuilder/PostgresTableBuilder.php
@@ -377,7 +377,7 @@ EOT;
 	 */
 	protected function doOptimize( $tableName ) {
 
-		$this->reportMessage( "   Table $tableName ...\n" );
+		$this->reportMessage( "Checking table $tableName ...\n" );
 
 		// https://www.postgresql.org/docs/9.0/static/sql-analyze.html
 		$this->reportMessage( "   ... analyze " );

--- a/src/SQLStore/TableBuilder/SQLiteTableBuilder.php
+++ b/src/SQLStore/TableBuilder/SQLiteTableBuilder.php
@@ -330,7 +330,7 @@ class SQLiteTableBuilder extends TableBuilder {
 	 */
 	protected function doOptimize( $tableName ) {
 
-		$this->reportMessage( "   Table $tableName ...\n" );
+		$this->reportMessage( "Checking table $tableName ...\n" );
 
 		// https://sqlite.org/lang_analyze.html
 		$this->reportMessage( "   ... analyze " );

--- a/tests/phpunit/Unit/Importer/ImporterTest.php
+++ b/tests/phpunit/Unit/Importer/ImporterTest.php
@@ -20,6 +20,7 @@ use SMW\Tests\TestEnvironment;
  */
 class ImporterTest extends \PHPUnit_Framework_TestCase {
 
+	private $spyMessageReporter;
 	private $testEnvironment;
 	private $contentIterator;
 	private $jsonImportContentsFileDirReader;
@@ -53,6 +54,26 @@ class ImporterTest extends \PHPUnit_Framework_TestCase {
 		$this->assertInstanceOf(
 			'\SMW\Importer\Importer',
 			new Importer( $this->contentIterator, $this->contentCreator )
+		);
+	}
+
+	public function testDisabled() {
+
+		$spyMessageReporter = $this->testEnvironment->getUtilityFactory()->newSpyMessageReporter();
+
+		$instance = new Importer(
+			new JsoncontentIterator( $this->jsonImportContentsFileDirReader ),
+			$this->contentCreator
+		);
+
+		$instance->setMessageReporter( $spyMessageReporter );
+		$instance->isEnabled( false );
+
+		$instance->doImport();
+
+		$this->assertContains(
+			'Skipping the import process',
+			$spyMessageReporter->getMessagesAsString()
 		);
 	}
 

--- a/tests/phpunit/Unit/MediaWiki/Hooks/HookRegistryTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Hooks/HookRegistryTest.php
@@ -173,6 +173,7 @@ class HookRegistryTest extends \PHPUnit_Framework_TestCase {
 		//$this->doTestExecutionForSMWStoreDropTables( $instance );
 		$this->doTestExecutionForSMWSQLStorAfterDataUpdateComplete( $instance );
 		$this->doTestExecutionForSMWStoreAfterQueryResultLookupComplete( $instance );
+		$this->doTestExecutionForSMWSQLStoreInstallerAfterCreateTablesComplete( $instance );
 	}
 
 	public function doTestExecutionForParserAfterTidy( $instance ) {
@@ -1086,6 +1087,34 @@ class HookRegistryTest extends \PHPUnit_Framework_TestCase {
 		$this->assertThatHookIsExcutable(
 			$instance->getHandlerFor( $handler ),
 			array( $this->store, &$result )
+		);
+	}
+
+	public function doTestExecutionForSMWSQLStoreInstallerAfterCreateTablesComplete( $instance ) {
+
+		$handler = 'SMW::SQLStore::Installer::AfterCreateTablesComplete';
+
+		$result = '';
+
+		$this->assertTrue(
+			$instance->isRegistered( $handler )
+		);
+
+		$tableBuilder = $this->getMockBuilder( '\SMW\SQLStore\TableBuilder' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$messageReporter = $this->getMockBuilder( '\Onoi\MessageReporter\MessageReporter' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$options = $this->getMockBuilder( '\SMW\Options' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$this->assertThatHookIsExcutable(
+			$instance->getHandlerFor( $handler ),
+			array( $tableBuilder, $messageReporter, $options )
 		);
 	}
 

--- a/tests/phpunit/Unit/OptionsTest.php
+++ b/tests/phpunit/Unit/OptionsTest.php
@@ -69,6 +69,20 @@ class OptionsTest extends \PHPUnit_Framework_TestCase {
 		);
 	}
 
+	public function testFilter() {
+
+		$instance = new Options();
+		$instance->set( 'Foo', '123' );
+		$instance->set( 'Bar', '456' );
+
+		$this->assertEquals(
+			[
+				'Foo' => '123'
+			],
+			$instance->filter( [ 'Foo' ] )
+		);
+	}
+
 	/**
 	 * @dataProvider isFlagSetProvider
 	 */

--- a/tests/phpunit/Unit/SQLStore/InstallerTest.php
+++ b/tests/phpunit/Unit/SQLStore/InstallerTest.php
@@ -82,7 +82,7 @@ class InstallerTest extends \PHPUnit_Framework_TestCase {
 		);
 
 		$instance->setMessageReporter( $this->spyMessageReporter );
-		$instance->isFromExtensionSchemaUpdate( true );
+		$instance->setOptions( [ Installer::OPT_SCHEMA_UPDATE => true ] );
 
 		$this->assertTrue(
 			$instance->install()


### PR DESCRIPTION
This PR is made in reference to: #2516

This PR addresses or contains:

- Allows to use `--skip-optimize` and `--skip-import` in `setupStore.php`
- Fixes a wrong assumption about parameters in `ExtensionSchemaUpdates` about the `DatabaseUpdater::addExtensionUpdate` execution

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed
