### PR TITLE
Consolidate parser settings `smwgParserFeatures`, refs 2798

### DIFF
--- a/DefaultSettings.php
+++ b/DefaultSettings.php
@@ -281,14 +281,6 @@ return array(
 	##
 
 	###
-	# Should warnings be displayed in wikitexts right after the problematic input?
-	# This affects only semantic annotations, not warnings that are displayed by
-	# inline queries or other features.
-	##
-	'smwgInlineErrors' => true,
-	##
-
-	###
 	# Category hierarchy recognition
 	#
 	# Should a subcategory be considered a hierarchy element in the
@@ -994,20 +986,6 @@ return array(
 	##
 
 	###
-	# This option enables to omit categories (marked with __HIDDENCAT__) from
-	# the annotation process.
-	#
-	# If a category is updated of either being hidden or visible, pages need to
-	# be refreshed to ensure that the StoreUpdater can make use of the changed
-	# environment.
-	#
-	# @since 1.9
-	# @default true (true = legacy behaviour, false = not to show hidden categories)
-	##
-	'smwgShowHiddenCategories' => true,
-	##
-
-	###
 	# QueryProfiler related settings
 	#
 	# @note If these settings are changed, please ensure to run update.php/rebuildData.php
@@ -1216,34 +1194,34 @@ return array(
 	'smwgExportResourcesAsIri' => true,
 	##
 
-	##
-	# The strict mode is to help to remove ambiguity during the annotation [[ ... :: ... ]]
-	# parsing process.
-	#
-	# The default interpretation (strict) is to find a single triple such as
-	# [[property::value:partOfTheValue::alsoPartOfTheValue]] where in case the strict
-	# mode is disabled multiple properties can be assigned using a
-	# [[property1::property2::value]] notation but may cause value strings to be
-	# interpret unanticipated in case of additional colons.
-	#
-	# @since 2.3
-	# @default true
-	##
-	'smwgEnabledInTextAnnotationParserStrictMode' => true,
-	##
-
 	###
-	# InText unstrip support
+	# Features related to text and annotion parsing
 	#
-	# Support decoding (unstripping) of hidden text elements (e.g. `<nowiki>` as in
-	# `[[Has description::<nowiki>{{#ask: HasStripMarkers }}</nowiki>]]` etc.)
-	# within an annotation value (can only be stored together with a `_txt` type
-	# property).
+	# - SMW_PARSER_NONE
+	#
+	# - SMW_PARSER_STRICT: The default interpretation (strict) is to find a single
+	#   triple such as [[property::value:partOfTheValue::alsoPartOfTheValue]] where
+	#   in case the strict mode is disabled multiple properties can be assigned
+	#   using a [[property1::property2::value]] notation but may cause value
+	#   strings to be interpret unanticipated in case of additional colons.
+	#
+	# - SMW_PARSER_UNSTRIP: Support decoding (unstripping) of hidden text elements
+	#   (e.g. `<nowiki>` as in `[[Has description::<nowiki>{{#ask: HasStripMarkers
+	#   }}</nowiki>]]` etc.) within an annotation value (can only be stored together
+	#   with a `_txt` type property).
+	#
+	# - SMW_PARSER_INL_ERROR: Should warnings be displayed in wikitexts right after
+	#   the problematic input? This affects only semantic annotations, not warnings
+	#   that are displayed by inline queries or other features. (was $smwgInlineErrors)
+	#
+	# - SMW_PARSER_HID_CATS: Switch to omit hidden categories (marked with
+	#   __HIDDENCAT__) from the annotation process. Changing the setting requires
+	#   to run a full rebuild to ensure hidden categories are discarded during
+	#   the parsing process. (was $smwgShowHiddenCategories 1.9)
 	#
 	# @since 3.0
-	# @default false
 	##
-	'smwgDecodeTextAnnotationWithStripMarker' => false,
+	'smwgParserFeatures' => SMW_PARSER_STRICT | SMW_PARSER_INL_ERROR | SMW_PARSER_HID_CATS,
 	##
 
 	##

--- a/includes/Settings.php
+++ b/includes/Settings.php
@@ -67,7 +67,6 @@ class Settings extends Options {
 			'smwgNamespaceIndex' => $GLOBALS['smwgNamespaceIndex'],
 			'smwgShowFactbox' => $GLOBALS['smwgShowFactbox'],
 			'smwgShowFactboxEdit' => $GLOBALS['smwgShowFactboxEdit'],
-			'smwgInlineErrors' => $GLOBALS['smwgInlineErrors'],
 			'smwgUseCategoryHierarchy' => $GLOBALS['smwgUseCategoryHierarchy'],
 			'smwgCategoriesAsInstances' => $GLOBALS['smwgCategoriesAsInstances'],
 			'smwgUseCategoryRedirect' => $GLOBALS['smwgUseCategoryRedirect'],
@@ -143,7 +142,6 @@ class Settings extends Options {
 			'smwgFixedProperties' => $GLOBALS['smwgFixedProperties'],
 			'smwgPropertyLowUsageThreshold' => $GLOBALS['smwgPropertyLowUsageThreshold'],
 			'smwgPropertyZeroCountDisplay' => $GLOBALS['smwgPropertyZeroCountDisplay'],
-			'smwgShowHiddenCategories' => $GLOBALS['smwgShowHiddenCategories'],
 			'smwgFactboxUseCache' => $GLOBALS['smwgFactboxUseCache'],
 			'smwgFactboxCacheRefreshOnPurge' => $GLOBALS['smwgFactboxCacheRefreshOnPurge'],
 			'smwgQueryProfiler' => $GLOBALS['smwgQueryProfiler'],
@@ -155,8 +153,7 @@ class Settings extends Options {
 			'smwgEnabledQueryDependencyLinksStore' => $GLOBALS['smwgEnabledQueryDependencyLinksStore'],
 			'smwgQueryDependencyPropertyExemptionList' => $GLOBALS['smwgQueryDependencyPropertyExemptionList'],
 			'smwgQueryDependencyAffiliatePropertyDetectionList' => $GLOBALS['smwgQueryDependencyAffiliatePropertyDetectionList'],
-			'smwgEnabledInTextAnnotationParserStrictMode' => $GLOBALS['smwgEnabledInTextAnnotationParserStrictMode'],
-			'smwgDecodeTextAnnotationWithStripMarker' => $GLOBALS['smwgDecodeTextAnnotationWithStripMarker'],
+			'smwgParserFeatures' => $GLOBALS['smwgParserFeatures'],
 			'smwgDVFeatures' => $GLOBALS['smwgDVFeatures'],
 			'smwgEnabledFulltextSearch' => $GLOBALS['smwgEnabledFulltextSearch'],
 			'smwgFulltextDeferredUpdate' => $GLOBALS['smwgFulltextDeferredUpdate'],
@@ -316,6 +313,18 @@ class Settings extends Options {
 			$configuration['smwgAdminFeatures'] = $configuration['smwgAdminFeatures'] & ~SMW_ADM_REFRESH;
 		}
 
+		if ( isset( $GLOBALS['smwgEnabledInTextAnnotationParserStrictMode'] ) && $GLOBALS['smwgEnabledInTextAnnotationParserStrictMode'] === false ) {
+			$configuration['smwgParserFeatures'] = $configuration['smwgParserFeatures'] & ~SMW_PARSER_STRICT;
+		}
+
+		if ( isset( $GLOBALS['smwgInlineErrors'] ) && $GLOBALS['smwgInlineErrors'] === false ) {
+			$configuration['smwgParserFeatures'] = $configuration['smwgParserFeatures'] & ~SMW_PARSER_INL_ERROR;
+		}
+
+		if ( isset( $GLOBALS['smwgShowHiddenCategories'] ) && $GLOBALS['smwgShowHiddenCategories'] === false ) {
+			$configuration['smwgParserFeatures'] = $configuration['smwgParserFeatures'] & ~SMW_PARSER_HID_CATS;
+		}
+
 		if ( isset( $GLOBALS['smwgQueryDependencyPropertyExemptionlist'] ) ) {
 			$configuration['smwgQueryDependencyPropertyExemptionList'] = $GLOBALS['smwgQueryDependencyPropertyExemptionlist'];
 		}
@@ -416,6 +425,9 @@ class Settings extends Options {
 				'smwgBrowseShowInverse' => '3.1.0',
 				'smwgBrowseShowAll' => '3.1.0',
 				'smwgBrowseByApi' => '3.1.0',
+				'smwgEnabledInTextAnnotationParserStrictMode' => '3.1.0',
+				'smwgInlineErrors' => '3.1.0',
+				'smwgShowHiddenCategories' => '3.1.0',
 				'options' => [
 					'smwgCacheUsage' =>  [
 						'smwgStatisticsCache' => '3.1.0',
@@ -446,6 +458,9 @@ class Settings extends Options {
 				'smwgBrowseShowInverse' => 'smwgBrowseFeatures',
 				'smwgBrowseShowAll' => 'smwgBrowseFeatures',
 				'smwgBrowseByApi' => 'smwgBrowseFeatures',
+				'smwgEnabledInTextAnnotationParserStrictMode' => 'smwgParserFeatures',
+				'smwgInlineErrors' => 'smwgParserFeatures',
+				'smwgShowHiddenCategories' => 'smwgParserFeatures',
 				'options' => [
 					'smwgCacheUsage' => [
 						'smwgStatisticsCacheExpiry' => 'special.statistics',

--- a/src/ApplicationFactory.php
+++ b/src/ApplicationFactory.php
@@ -12,9 +12,6 @@ use SMW\MediaWiki\Jobs\JobFactory;
 use SMW\MediaWiki\MwCollaboratorFactory;
 use SMW\MediaWiki\PageCreator;
 use SMW\MediaWiki\TitleCreator;
-// Due to aliasing, on 5.+ it causes a:
-// Fatal error: Cannot use SMW\Parser\InTextAnnotationParser as InTextAnnotationParser because the name is already in use ...
-use SMW\Parser\InTextAnnotationParser as EmbeddedTextAnnotationParser;
 use SMW\Query\ProfileAnnotator\QueryProfileAnnotatorFactory;
 use SMWQueryParser as QueryParser;
 use Title;
@@ -318,10 +315,10 @@ class ApplicationFactory {
 		$linksProcessor = $this->containerBuilder->create( 'LinksProcessor' );
 
 		$linksProcessor->isStrictMode(
-			$this->getSettings()->get( 'smwgEnabledInTextAnnotationParserStrictMode' )
+			$this->getSettings()->isFlagSet( 'smwgParserFeatures', SMW_PARSER_STRICT )
 		);
 
-		$inTextAnnotationParser = new EmbeddedTextAnnotationParser(
+		$inTextAnnotationParser = new InTextAnnotationParser(
 			$parserData,
 			$linksProcessor,
 			$mwCollaboratorFactory->newMagicWordsFinder(),
@@ -333,6 +330,10 @@ class ApplicationFactory {
 
 		$inTextAnnotationParser->enabledLinksInValues(
 			$linksInValues === true ? SMW_LINV_PCRE : $linksInValues
+		);
+
+		$inTextAnnotationParser->showErrors(
+			$this->getSettings()->isFlagSet( 'smwgParserFeatures', SMW_PARSER_INL_ERROR )
 		);
 
 		return $inTextAnnotationParser;

--- a/src/CompatibilityMode.php
+++ b/src/CompatibilityMode.php
@@ -63,7 +63,7 @@ class CompatibilityMode {
 			'smwgPageSpecialProperties' => array(),
 			'smwgEnableUpdateJobs' => false,
 			'smwgEnabledEditPageHelp' => false,
-			'smwgInlineErrors' => false,
+			'smwgParserFeatures' => SMW_PARSER_NONE,
 		);
 
 		foreach ( $disabledSettings as $key => $value) {

--- a/src/Defines.php
+++ b/src/Defines.php
@@ -239,3 +239,13 @@ define( 'SMW_BROWSE_SHOW_INVERSE', 4 ); // Support inverse direction
 define( 'SMW_BROWSE_SHOW_INCOMING', 8 ); // Support for incoming links
 define( 'SMW_BROWSE_USE_API', 16 ); // Support for using the API as request backend
 /**@}*/
+
+/**@{
+  * Constants for $smwgParserFeatures
+  */
+define( 'SMW_PARSER_NONE', 0 );
+define( 'SMW_PARSER_STRICT', 2 ); // Support for strict mode
+define( 'SMW_PARSER_UNSTRIP', 4 ); // Support for using the StripMarkerDecoder
+define( 'SMW_PARSER_INL_ERROR', 8 ); // Support for display of inline errors
+define( 'SMW_PARSER_HID_CATS', 16 ); // Support for parsing hidden categories
+/**@}*/

--- a/src/MediaWiki/MwCollaboratorFactory.php
+++ b/src/MediaWiki/MwCollaboratorFactory.php
@@ -218,7 +218,7 @@ class MwCollaboratorFactory {
 		);
 
 		$stripMarkerDecoder->isSupported(
-			$this->applicationFactory->getSettings()->get( 'smwgDecodeTextAnnotationWithStripMarker' )
+			$this->applicationFactory->getSettings()->isFlagSet( 'smwgParserFeatures', SMW_PARSER_UNSTRIP )
 		);
 
 		return $stripMarkerDecoder;

--- a/src/Parser/InTextAnnotationParser.php
+++ b/src/Parser/InTextAnnotationParser.php
@@ -21,9 +21,6 @@ use Title;
  * This class is contains all functions necessary for parsing wiki text before
  * it is displayed or previewed while identifying SMW related annotations.
  *
- * @note Settings involve smwgNamespacesWithSemanticLinks, smwgLinksInValues,
- * smwgInlineErrors
- *
  * @license GNU GPL v2+
  * @since 1.9
  *
@@ -76,11 +73,6 @@ class InTextAnnotationParser {
 	private $stripMarkerDecoder;
 
 	/**
-	 * @var Settings
-	 */
-	protected $settings = null;
-
-	/**
 	 * @var boolean
 	 */
 	protected $isEnabledNamespace;
@@ -96,6 +88,11 @@ class InTextAnnotationParser {
 	 * @var boolean|integer
 	 */
 	private $enabledLinksInValues = false;
+
+	/**
+	 * @var boolean
+	 */
+	private $showErrors = true;
 
 	/**
 	 * @since 1.9
@@ -124,6 +121,15 @@ class InTextAnnotationParser {
 	}
 
 	/**
+	 * @since 3.0
+	 *
+	 * @param boolean $showErrors
+	 */
+	public function showErrors( $showErrors ) {
+		$this->showErrors = (bool)$showErrors;
+	}
+
+	/**
 	 * Parsing text before an article is displayed or previewed, strip out
 	 * semantic properties and add them to the ParserOutput object
 	 *
@@ -134,7 +140,6 @@ class InTextAnnotationParser {
 	public function parse( &$text ) {
 
 		$title = $this->parserData->getTitle();
-		$this->settings = $this->applicationFactory->getSettings();
 		Timer::start( __CLASS__ );
 
 		// Identifies the current parser run (especially when called recursively)
@@ -389,7 +394,7 @@ class InTextAnnotationParser {
 		}
 
 		// If necessary add an error text
-		if ( ( $this->settings->get( 'smwgInlineErrors' ) &&
+		if ( ( $this->showErrors &&
 			$this->isEnabledNamespace && $this->isAnnotation ) &&
 			( !$dataValue->isValid() ) ) {
 			// Encode `:` to avoid a comment block and instead of the nowiki tag

--- a/src/ParserFunctionFactory.php
+++ b/src/ParserFunctionFactory.php
@@ -373,7 +373,7 @@ class ParserFunctionFactory {
 			);
 
 			if ( !$settings->get( 'smwgQEnabled' ) ) {
-				return $settings->get( 'smwgInlineErrors' ) ? $askParserFunction->isQueryDisabled(): '';
+				return $settings->isFlagSet( 'smwgParserFeatures', SMW_PARSER_INL_ERROR ) ? $askParserFunction->isQueryDisabled(): '';
 			}
 
 			return $askParserFunction->parse( func_get_args() );
@@ -399,7 +399,7 @@ class ParserFunctionFactory {
 			);
 
 			if ( !$settings->get( 'smwgQEnabled' ) ) {
-				return $settings->get( 'smwgInlineErrors' ) ? $showParserFunction->isQueryDisabled(): '';
+				return $settings->isFlagSet( 'smwgParserFeatures', SMW_PARSER_INL_ERROR ) ? $showParserFunction->isQueryDisabled(): '';
 			}
 
 			return $showParserFunction->parse( func_get_args() );

--- a/src/PropertyAnnotatorFactory.php
+++ b/src/PropertyAnnotatorFactory.php
@@ -149,7 +149,7 @@ class PropertyAnnotatorFactory {
 		);
 
 		$categoryPropertyAnnotator->showHiddenCategories(
-			$settings->get( 'smwgShowHiddenCategories' )
+			$settings->isFlagSet( 'smwgParserFeatures', SMW_PARSER_HID_CATS )
 		);
 
 		$categoryPropertyAnnotator->useCategoryInstance(

--- a/tests/phpunit/Integration/JSONScript/JsonTestCaseScriptRunnerTest.php
+++ b/tests/phpunit/Integration/JSONScript/JsonTestCaseScriptRunnerTest.php
@@ -205,8 +205,6 @@ class JsonTestCaseScriptRunnerTest extends JsonTestCaseScriptRunner {
 			'smwgQSubpropertyDepth',
 			'smwgQSubcategoryDepth',
 			'smwgQConceptCaching',
-			'smwgEnabledInTextAnnotationParserStrictMode',
-			'smwgDecodeTextAnnotationWithStripMarker',
 			'smwgMaxNonExpNumber',
 			'smwgDVFeatures',
 			'smwgEnabledQueryDependencyLinksStore',
@@ -226,6 +224,7 @@ class JsonTestCaseScriptRunnerTest extends JsonTestCaseScriptRunner {
 			'smwgQExpensiveExecutionLimit',
 			'smwgFieldTypeFeatures',
 			'smwgCreateProtectionRight',
+			'smwgParserFeatures',
 
 			// MW related
 			'wgLanguageCode',

--- a/tests/phpunit/Integration/JSONScript/TestCases/p-0408.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/p-0408.json
@@ -33,7 +33,9 @@
 		"smwgPageSpecialProperties": [
 			"_MDAT"
 		],
-		"smwgEnabledInTextAnnotationParserStrictMode": false
+		"smwgParserFeatures": [
+			"SMW_PARSER_NONE"
+		]
 	},
 	"meta": {
 		"version": "2",

--- a/tests/phpunit/Integration/JSONScript/TestCases/p-0455.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/p-0455.json
@@ -1,5 +1,5 @@
 {
-	"description": "Test paser/in-text annotation with unstripped tags (nowiki etc.) (`smwgDecodeTextAnnotationWithStripMarker`)",
+	"description": "Test paser/in-text annotation with unstripped tags (nowiki etc.) (`SMW_PARSER_UNSTRIP`)",
 	"setup": [
 		{
 			"namespace": "SMW_NS_PROPERTY",
@@ -231,7 +231,10 @@
 	"settings": {
 		"wgContLang": "en",
 		"wgLang": "en",
-		"smwgDecodeTextAnnotationWithStripMarker": true
+		"smwgParserFeatures": [
+			"SMW_PARSER_UNSTRIP",
+			"SMW_PARSER_STRICT"
+		]
 	},
 	"meta": {
 		"version": "2",

--- a/tests/phpunit/Integration/Parser/InTextAnnotationParserTemplateTransclusionTest.php
+++ b/tests/phpunit/Integration/Parser/InTextAnnotationParserTemplateTransclusionTest.php
@@ -123,9 +123,9 @@ class InTextAnnotationParserTemplateTransclusionTest extends \PHPUnit_Framework_
 			NS_MAIN,
 			array(
 				'smwgNamespacesWithSemanticLinks' => array( NS_MAIN => true ),
-				'smwgLinksInValues' => false,
-				'smwgInlineErrors'  => true,
-				'smwgCacheType'     => 'hash'
+				'smwgLinksInValues'  => false,
+				'smwgParserFeatures' => SMW_PARSER_INL_ERROR,
+				'smwgCacheType'      => 'hash'
 			),
 			'[[Foo::{{Bam}}]]',
 			'?bar',

--- a/tests/phpunit/JsonTestCaseFileHandler.php
+++ b/tests/phpunit/JsonTestCaseFileHandler.php
@@ -240,7 +240,8 @@ class JsonTestCaseFileHandler {
 			'smwgDVFeatures',
 			'smwgFulltextSearchIndexableDataTypes',
 			'smwgFieldTypeFeatures',
-			'smwgQueryProfiler'
+			'smwgQueryProfiler',
+			'smwgParserFeatures'
 		);
 
 		foreach ( $constantFeaturesList as $constantFeatures ) {

--- a/tests/phpunit/Unit/Factbox/CachedFactboxTest.php
+++ b/tests/phpunit/Unit/Factbox/CachedFactboxTest.php
@@ -9,6 +9,7 @@ use SMW\DIProperty;
 use SMW\DIWikiPage;
 use SMW\Factbox\CachedFactbox;
 use SMW\Tests\Utils\Mock\MockTitle;
+use SMW\Tests\TestEnvironment;
 
 /**
  * @covers \SMW\Factbox\CachedFactbox
@@ -22,30 +23,26 @@ use SMW\Tests\Utils\Mock\MockTitle;
  */
 class CachedFactboxTest extends \PHPUnit_Framework_TestCase {
 
-	private $applicationFactory;
+	private $testEnvironment;
 	private $memoryCache;
 
 	protected function setUp() {
 		parent::setUp();
 
-		$this->applicationFactory = ApplicationFactory::getInstance();
-		$this->memoryCache = $this->applicationFactory->newCacheFactory()->newFixedInMemoryCache();
+		$this->testEnvironment = new TestEnvironment();
+		$this->memoryCache = ApplicationFactory::getInstance()->newCacheFactory()->newFixedInMemoryCache();
 
-		$settings = array(
-			'smwgFactboxUseCache' => true,
-			'smwgCacheType'       => 'hash',
-			'smwgLinksInValues'   => false,
-			'smwgInlineErrors'    => true
+		$this->testEnvironment->withConfiguration(
+			[
+				'smwgFactboxUseCache' => true,
+				'smwgCacheType'       => 'hash',
+				'smwgLinksInValues'   => false
+			]
 		);
-
-		foreach ( $settings as $key => $value ) {
-			$this->applicationFactory->getSettings()->set( $key, $value );
-		}
 	}
 
 	protected function tearDown() {
-		$this->applicationFactory->clear();
-
+		$this->testEnvironment->tearDown();
 		parent::tearDown();
 	}
 
@@ -66,17 +63,17 @@ class CachedFactboxTest extends \PHPUnit_Framework_TestCase {
 	 */
 	public function testProcessAndRetrieveContent( $parameters, $expected ) {
 
-		$this->applicationFactory->getSettings()->set(
+		$this->testEnvironment->addConfiguration(
 			'smwgNamespacesWithSemanticLinks',
 			$parameters['smwgNamespacesWithSemanticLinks']
 		);
 
-		$this->applicationFactory->getSettings()->set(
+		$this->testEnvironment->addConfiguration(
 			'smwgShowFactbox',
 			$parameters['smwgShowFactbox']
 		);
 
-		$this->applicationFactory->registerObject( 'Store', $parameters['store'] );
+		$this->testEnvironment->registerObject( 'Store', $parameters['store'] );
 
 		$outputPage = $parameters['outputPage'];
 

--- a/tests/phpunit/Unit/Factbox/FactboxMagicWordsTest.php
+++ b/tests/phpunit/Unit/Factbox/FactboxMagicWordsTest.php
@@ -9,6 +9,7 @@ use SMW\Factbox\Factbox;
 use SMW\ParserData;
 use SMW\Settings;
 use Title;
+use SMW\Tests\TestEnvironment;
 
 /**
  * @covers \SMW\Factbox\Factbox
@@ -21,23 +22,22 @@ use Title;
  */
 class FactboxMagicWordsTest extends \PHPUnit_Framework_TestCase {
 
-	private $applicationFactory;
+	private $testEnvironment;
 
 	protected function setUp() {
 		parent::setUp();
 
-		$this->applicationFactory = ApplicationFactory::getInstance();
+		$this->testEnvironment = new TestEnvironment();
 
 		$store = $this->getMockBuilder( '\SMW\Store' )
 			->disableOriginalConstructor()
 			->getMockForAbstractClass();
 
-		$this->applicationFactory->registerObject( 'Store', $store );
+		$this->testEnvironment->registerObject( 'Store', $store );
 	}
 
 	protected function tearDown() {
-		$this->applicationFactory->clear();
-
+		$this->testEnvironment->tearDown();
 		parent::tearDown();
 	}
 
@@ -49,15 +49,13 @@ class FactboxMagicWordsTest extends \PHPUnit_Framework_TestCase {
 		$title  = Title::newFromText( __METHOD__ );
 		$parserOutput = new ParserOutput();
 
-		$settings = Settings::newFromArray( array(
-			'smwgNamespacesWithSemanticLinks' => array( $title->getNamespace() => true ),
-			'smwgEnabledInTextAnnotationParserStrictMode' => true,
-			'smwgLinksInValues' => false,
-			'smwgInlineErrors'  => true,
-			)
+		$this->testEnvironment->withConfiguration(
+			[
+				'smwgNamespacesWithSemanticLinks' => array( $title->getNamespace() => true ),
+				'smwgParserFeatures' => SMW_PARSER_STRICT | SMW_PARSER_INL_ERROR,
+				'smwgLinksInValues' => false,
+			]
 		);
-
-		$this->applicationFactory->registerObject( 'Settings', $settings );
 
 		$parserData = new ParserData( $title, $parserOutput );
 
@@ -78,13 +76,11 @@ class FactboxMagicWordsTest extends \PHPUnit_Framework_TestCase {
 
 		$title = Title::newFromText( __METHOD__ );
 
-		$settings = Settings::newFromArray( array(
+		$this->testEnvironment->withConfiguration( array(
 			'smwgShowFactboxEdit' => SMW_FACTBOX_HIDDEN,
 			'smwgShowFactbox'     => SMW_FACTBOX_HIDDEN
 			)
 		);
-
-		$this->applicationFactory->registerObject( 'Settings', $settings );
 
 		$parserOutput = $this->getMockBuilder( '\ParserOutput' )
 			->disableOriginalConstructor()

--- a/tests/phpunit/Unit/MediaWiki/Hooks/ArticlePurgeTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Hooks/ArticlePurgeTest.php
@@ -32,8 +32,7 @@ class ArticlePurgeTest extends \PHPUnit_Framework_TestCase {
 		$settings = array(
 			'smwgFactboxUseCache' => true,
 			'smwgCacheType'       => 'hash',
-			'smwgLinksInValues'   => false,
-			'smwgInlineErrors'    => true
+			'smwgLinksInValues'   => false
 		);
 
 		$this->testEnvironment = new TestEnvironment( $settings );

--- a/tests/phpunit/Unit/MediaWiki/Hooks/InternalParseBeforeLinksTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Hooks/InternalParseBeforeLinksTest.php
@@ -350,9 +350,8 @@ class InternalParseBeforeLinksTest extends \PHPUnit_Framework_TestCase {
 				'title'    => $title,
 				'settings' => array(
 					'smwgNamespacesWithSemanticLinks' => array( NS_MAIN => true ),
-					'smwgEnabledInTextAnnotationParserStrictMode' => true,
+					'smwgParserFeatures' => SMW_PARSER_STRICT,
 					'smwgLinksInValues' => false,
-					'smwgInlineErrors'  => true,
 				),
 				'text'  => 'Lorem ipsum dolor sit &$% [[FooBar::dictumst|寒い]]' .
 					' [[Bar::tincidunt semper]] facilisi {{volutpat}} Ut quis' .
@@ -374,9 +373,8 @@ class InternalParseBeforeLinksTest extends \PHPUnit_Framework_TestCase {
 				'title'    => $title,
 				'settings' => array(
 					'smwgNamespacesWithSemanticLinks' => array( NS_MAIN => true ),
-					'smwgEnabledInTextAnnotationParserStrictMode' => true,
+					'smwgParserFeatures' => SMW_PARSER_STRICT,
 					'smwgLinksInValues' => false,
-					'smwgInlineErrors'  => true,
 				),
 				'text'  => '#REDIRECT [[Foo]]',
 				),
@@ -396,9 +394,8 @@ class InternalParseBeforeLinksTest extends \PHPUnit_Framework_TestCase {
 				'title'    => $title,
 				'settings' => array(
 					'smwgNamespacesWithSemanticLinks' => array( NS_MAIN => true ),
-					'smwgEnabledInTextAnnotationParserStrictMode' => true,
+					'smwgParserFeatures' => SMW_PARSER_STRICT,
 					'smwgLinksInValues' => false,
-					'smwgInlineErrors'  => true,
 					'smwgEnabledSpecialPage' => array( 'Ask', 'Foo' )
 				),
 				'text'  => 'Lorem ipsum dolor sit &$% [[FooBar::dictumst|寒い]]' .
@@ -421,9 +418,8 @@ class InternalParseBeforeLinksTest extends \PHPUnit_Framework_TestCase {
 				'title'    => $title,
 				'settings' => array(
 					'smwgNamespacesWithSemanticLinks' => array( NS_MAIN => true ),
-					'smwgEnabledInTextAnnotationParserStrictMode' => true,
+					'smwgParserFeatures' => SMW_PARSER_STRICT,
 					'smwgLinksInValues' => false,
-					'smwgInlineErrors'  => true,
 					'smwgEnabledSpecialPage' => array( 'Ask', 'Foo' )
 				),
 				'text'  => 'Lorem ipsum dolor sit &$% [[FooBar::dictumst|寒い]]' .
@@ -446,9 +442,8 @@ class InternalParseBeforeLinksTest extends \PHPUnit_Framework_TestCase {
 				'title'    => $title,
 				'settings' => array(
 					'smwgNamespacesWithSemanticLinks' => array( NS_MAIN => true ),
-					'smwgEnabledInTextAnnotationParserStrictMode' => true,
+					'smwgParserFeatures' => SMW_PARSER_STRICT,
 					'smwgLinksInValues' => false,
-					'smwgInlineErrors'  => true,
 					'smwgEnabledSpecialPage' => []
 				),
 				'text'  => 'Lorem ipsum dolor sit &$% [[FooBar::dictumst|寒い]]' .

--- a/tests/phpunit/Unit/MediaWiki/Hooks/OutputPageParserOutputTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Hooks/OutputPageParserOutputTest.php
@@ -9,6 +9,7 @@ use SMW\DIProperty;
 use SMW\DIWikiPage;
 use SMW\MediaWiki\Hooks\OutputPageParserOutput;
 use SMW\Tests\Utils\Mock\MockTitle;
+use SMW\Tests\TestEnvironment;
 
 /**
  * @covers \SMW\MediaWiki\Hooks\OutputPageParserOutput
@@ -27,24 +28,21 @@ class OutputPageParserOutputTest extends \PHPUnit_Framework_TestCase {
 	protected function setUp() {
 		parent::setUp();
 
+		$this->testEnvironment = new TestEnvironment();
 		$this->applicationFactory = ApplicationFactory::getInstance();
 
-		$settings = array(
-			'smwgShowFactbox'      => SMW_FACTBOX_NONEMPTY,
-			'smwgFactboxUseCache'  => true,
-			'smwgCacheType'        => 'hash',
-			'smwgLinksInValues'    => false,
-			'smwgInlineErrors'     => true,
+		$this->testEnvironment->withConfiguration(
+			[
+				'smwgShowFactbox'      => SMW_FACTBOX_NONEMPTY,
+				'smwgFactboxUseCache'  => true,
+				'smwgCacheType'        => 'hash',
+				'smwgLinksInValues'    => false
+			]
 		);
-
-		foreach ( $settings as $key => $value ) {
-			$this->applicationFactory->getSettings()->set( $key, $value );
-		}
 	}
 
 	protected function tearDown() {
-		$this->applicationFactory->clear();
-
+		$this->testEnvironment->tearDown();
 		parent::tearDown();
 	}
 
@@ -73,9 +71,9 @@ class OutputPageParserOutputTest extends \PHPUnit_Framework_TestCase {
 			->disableOriginalConstructor()
 			->getMockForAbstractClass();
 
-		$this->applicationFactory->registerObject( 'Store', $store );
+		$this->testEnvironment->registerObject( 'Store', $store );
 
-		$this->applicationFactory->getSettings()->set(
+		$this->testEnvironment->addConfiguration(
 			'smwgNamespacesWithSemanticLinks',
 			$parameters['smwgNamespacesWithSemanticLinks']
 		);

--- a/tests/phpunit/Unit/MediaWiki/Hooks/ParserAfterTidyTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Hooks/ParserAfterTidyTest.php
@@ -189,7 +189,7 @@ class ParserAfterTidyTest extends \PHPUnit_Framework_TestCase {
 			'smwgEnableUpdateJobs'      => false,
 			'smwgUseCategoryHierarchy'  => false,
 			'smwgCategoriesAsInstances' => true,
-			'smwgShowHiddenCategories'  => true
+			'smwgParserFeatures'        => SMW_PARSER_HID_CATS
 		);
 
 		$this->testEnvironment->withConfiguration( $settings );

--- a/tests/phpunit/Unit/Parser/InTextAnnotationParserTest.php
+++ b/tests/phpunit/Unit/Parser/InTextAnnotationParserTest.php
@@ -40,7 +40,7 @@ class InTextAnnotationParserTest extends \PHPUnit_Framework_TestCase {
 
 		$this->testEnvironment->registerObject( 'Store', $store );
 
-		$this->LinksProcessor = new LinksProcessor();
+		$this->linksProcessor = new LinksProcessor();
 	}
 
 	protected function tearDown() {
@@ -65,7 +65,7 @@ class InTextAnnotationParserTest extends \PHPUnit_Framework_TestCase {
 
 		$instance =	new InTextAnnotationParser(
 			new ParserData( $title, $parserOutput ),
-			$this->LinksProcessor,
+			$this->linksProcessor,
 			new MagicWordsFinder(),
 			$redirectTargetFinder
 		);
@@ -105,7 +105,7 @@ class InTextAnnotationParserTest extends \PHPUnit_Framework_TestCase {
 
 		$instance = new InTextAnnotationParser(
 			$parserData,
-			$this->LinksProcessor,
+			$this->linksProcessor,
 			$magicWordsFinder,
 			new RedirectTargetFinder()
 		);
@@ -128,15 +128,19 @@ class InTextAnnotationParserTest extends \PHPUnit_Framework_TestCase {
 			new ParserOutput()
 		);
 
-		$this->LinksProcessor->isStrictMode(
-			isset( $settings['smwgEnabledInTextAnnotationParserStrictMode'] ) ? $settings['smwgEnabledInTextAnnotationParserStrictMode'] : true
+		$this->linksProcessor->isStrictMode(
+			isset( $settings['smwgParserFeatures'] ) ? $settings['smwgParserFeatures'] : true
 		);
 
 		$instance = new InTextAnnotationParser(
 			$parserData,
-			$this->LinksProcessor,
+			$this->linksProcessor,
 			new MagicWordsFinder(),
 			new RedirectTargetFinder()
+		);
+
+		$instance->showErrors(
+			isset( $settings['smwgParserFeatures'] ) ? $settings['smwgParserFeatures'] : true
 		);
 
 		$instance->enabledLinksInValues(
@@ -174,7 +178,7 @@ class InTextAnnotationParserTest extends \PHPUnit_Framework_TestCase {
 		$settings = array(
 			'smwgNamespacesWithSemanticLinks' => array( $namespace => true ),
 			'smwgLinksInValues' => false,
-			'smwgInlineErrors'  => true,
+			'smwgParserFeatures' => SMW_PARSER_INL_ERROR,
 		);
 
 		$this->testEnvironment->withConfiguration(
@@ -190,7 +194,7 @@ class InTextAnnotationParserTest extends \PHPUnit_Framework_TestCase {
 
 		$instance = new InTextAnnotationParser(
 			$parserData,
-			$this->LinksProcessor,
+			$this->linksProcessor,
 			new MagicWordsFinder(),
 			$redirectTargetFinder
 		);
@@ -218,7 +222,7 @@ class InTextAnnotationParserTest extends \PHPUnit_Framework_TestCase {
 		$settings = array(
 			'smwgNamespacesWithSemanticLinks' => array( $namespace => true ),
 			'smwgLinksInValues' => false,
-			'smwgInlineErrors'  => true,
+			'smwgParserFeatures' => SMW_PARSER_INL_ERROR,
 		);
 
 		$this->testEnvironment->withConfiguration(
@@ -234,7 +238,7 @@ class InTextAnnotationParserTest extends \PHPUnit_Framework_TestCase {
 
 		$instance = new InTextAnnotationParser(
 			$parserData,
-			$this->LinksProcessor,
+			$this->linksProcessor,
 			new MagicWordsFinder(),
 			$redirectTargetFinder
 		);
@@ -279,7 +283,7 @@ class InTextAnnotationParserTest extends \PHPUnit_Framework_TestCase {
 
 		$instance = new InTextAnnotationParser(
 			$parserData,
-			$this->LinksProcessor,
+			$this->linksProcessor,
 			new MagicWordsFinder(),
 			$redirectTargetFinder
 		);
@@ -315,7 +319,7 @@ class InTextAnnotationParserTest extends \PHPUnit_Framework_TestCase {
 
 		$instance = new InTextAnnotationParser(
 			$parserData,
-			$this->LinksProcessor,
+			$this->linksProcessor,
 			new MagicWordsFinder(),
 			new RedirectTargetFinder()
 		);
@@ -378,7 +382,7 @@ class InTextAnnotationParserTest extends \PHPUnit_Framework_TestCase {
 			array(
 				'smwgNamespacesWithSemanticLinks' => array( NS_MAIN => true ),
 				'smwgLinksInValues' => false,
-				'smwgInlineErrors' => true,
+				'smwgParserFeatures' => SMW_PARSER_INL_ERROR,
 			),
 			'Lorem ipsum dolor sit &$% consectetuer auctor at quis' .
 			' [[FooBar::dictumst|寒い]] cursus. Nisl sit condimentum Quisque facilisis' .
@@ -401,7 +405,7 @@ class InTextAnnotationParserTest extends \PHPUnit_Framework_TestCase {
 			array(
 				'smwgNamespacesWithSemanticLinks' => array( NS_MAIN => true ),
 				'smwgLinksInValues' => SMW_LINV_PCRE,
-				'smwgInlineErrors'  => true,
+				'smwgParserFeatures' => SMW_PARSER_INL_ERROR,
 			),
 			'Lorem ipsum dolor sit &$% consectetuer auctor at quis' .
 			' [[FooBar::dictumst|寒い]] cursus. Nisl sit condimentum Quisque facilisis' .
@@ -426,7 +430,7 @@ class InTextAnnotationParserTest extends \PHPUnit_Framework_TestCase {
 			array(
 				'smwgNamespacesWithSemanticLinks' => array( NS_MAIN => true ),
 				'smwgLinksInValues' => false,
-				'smwgInlineErrors' => true,
+				'smwgParserFeatures' => SMW_PARSER_INL_ERROR,
 			),
 			'Lorem ipsum dolor sit &$% consectetuer auctor at quis' .
 			' [[-FooBar::dictumst|重い]] cursus. Nisl sit condimentum Quisque facilisis' .
@@ -447,7 +451,7 @@ class InTextAnnotationParserTest extends \PHPUnit_Framework_TestCase {
 			array(
 				'smwgNamespacesWithSemanticLinks' => array( NS_MAIN => true ),
 				'smwgLinksInValues' => false,
-				'smwgInlineErrors'  => false,
+				'smwgParserFeatures' => SMW_PARSER_NONE,
 			),
 			'Lorem ipsum dolor sit &$% consectetuer auctor at quis' .
 			' [[-FooBar::dictumst|軽い]] cursus. Nisl sit condimentum Quisque facilisis' .
@@ -471,7 +475,7 @@ class InTextAnnotationParserTest extends \PHPUnit_Framework_TestCase {
 			array(
 				'smwgNamespacesWithSemanticLinks' => array( NS_HELP => false ),
 				'smwgLinksInValues' => false,
-				'smwgInlineErrors'  => true,
+				'smwgParserFeatures' => SMW_PARSER_INL_ERROR,
 			),
 			'Lorem ipsum dolor sit &$% consectetuer auctor at quis' .
 			' [[FooBar::dictumst|おもろい]] cursus. Nisl sit condimentum Quisque facilisis' .
@@ -494,7 +498,7 @@ class InTextAnnotationParserTest extends \PHPUnit_Framework_TestCase {
 			array(
 				'smwgNamespacesWithSemanticLinks' => array( NS_HELP => true ),
 				'smwgLinksInValues' => false,
-				'smwgInlineErrors'  => true,
+				'smwgParserFeatures' => SMW_PARSER_INL_ERROR,
 			),
 			'Lorem ipsum dolor sit &$% consectetuer auctor at quis' .
 			' Suspendisse tincidunt semper facilisi dolor Aenean.',
@@ -513,7 +517,7 @@ class InTextAnnotationParserTest extends \PHPUnit_Framework_TestCase {
 			array(
 				'smwgNamespacesWithSemanticLinks' => array( NS_MAIN => true ),
 				'smwgLinksInValues' => false,
-				'smwgInlineErrors'  => true,
+				'smwgParserFeatures' => SMW_PARSER_INL_ERROR,
 			),
 			'[[Foo::?bar]], [[Foo::Baz?]], [[Quxey::B?am]]',
 			array(
@@ -534,7 +538,7 @@ class InTextAnnotationParserTest extends \PHPUnit_Framework_TestCase {
 			array(
 				'smwgNamespacesWithSemanticLinks' => array( SMW_NS_PROPERTY => true ),
 				'smwgLinksInValues' => false,
-				'smwgInlineErrors'  => true,
+				'smwgParserFeatures' => SMW_PARSER_INL_ERROR,
 			),
 			'[[has type::number]], [[has Type::page]] ',
 			array(
@@ -551,7 +555,7 @@ class InTextAnnotationParserTest extends \PHPUnit_Framework_TestCase {
 			array(
 				'smwgNamespacesWithSemanticLinks' => array( NS_MAIN => true ),
 				'smwgLinksInValues' => false,
-				'smwgInlineErrors'  => true,
+				'smwgParserFeatures' => SMW_PARSER_INL_ERROR,
 			),
 			'[[Foo::Bar::Foobar]], [[IPv6::fc00:123:8000::/64]] [[ABC::10.1002/::AID-MRM16::]]',
 			array(
@@ -568,7 +572,7 @@ class InTextAnnotationParserTest extends \PHPUnit_Framework_TestCase {
 			array(
 				'smwgNamespacesWithSemanticLinks' => array( NS_MAIN => true ),
 				'smwgLinksInValues' => false,
-				'smwgInlineErrors'  => true,
+				'smwgParserFeatures' => SMW_PARSER_INL_ERROR,
 			),
 			'[[Foo:::Foobar]] [[Bar:::ABC|DEF]] [[Foo:::0049 30 12345678/::Foo]] ',
 			array(
@@ -585,8 +589,7 @@ class InTextAnnotationParserTest extends \PHPUnit_Framework_TestCase {
 			array(
 				'smwgNamespacesWithSemanticLinks' => array( NS_MAIN => true ),
 				'smwgLinksInValues' => false,
-				'smwgInlineErrors'  => true,
-				'smwgEnabledInTextAnnotationParserStrictMode' => false
+				'smwgParserFeatures' => SMW_PARSER_NONE
 			),
 			'[[Foo::Foobar::テスト]] [[Bar:::ABC|DEF]] [[Foo:::0049 30 12345678/::Foo]] ',
 			array(
@@ -603,8 +606,7 @@ class InTextAnnotationParserTest extends \PHPUnit_Framework_TestCase {
 			array(
 				'smwgNamespacesWithSemanticLinks' => array( NS_MAIN => true ),
 				'smwgLinksInValues' => false,
-				'smwgInlineErrors'  => true,
-				'smwgEnabledInTextAnnotationParserStrictMode' => false
+				'smwgParserFeatures' => SMW_PARSER_INL_ERROR | SMW_PARSER_NONE
 			),
 			'[[Foo|Bar::Foobar]] [[File:Example.png|alt=Bar::Foobar|Caption]] [[File:Example.png|Bar::Foobar|link=Foo]]',
 			array(
@@ -619,8 +621,7 @@ class InTextAnnotationParserTest extends \PHPUnit_Framework_TestCase {
 			array(
 				'smwgNamespacesWithSemanticLinks' => array( NS_MAIN => true ),
 				'smwgLinksInValues' => false,
-				'smwgInlineErrors'  => true,
-				'smwgEnabledInTextAnnotationParserStrictMode' => true
+				'smwgParserFeatures' => SMW_PARSER_INL_ERROR | SMW_PARSER_STRICT
 			),
 			'[[Foo|Bar::Foobar]] [[File:Example.png|alt=Bar::Foobar|Caption]] [[Foo::Foobar::テスト]] [[File:Example.png|Bar::Foobar|link=Foo]]',
 			array(
@@ -637,8 +638,7 @@ class InTextAnnotationParserTest extends \PHPUnit_Framework_TestCase {
 			array(
 				'smwgNamespacesWithSemanticLinks' => array( NS_MAIN => true ),
 				'smwgLinksInValues' => false,
-				'smwgInlineErrors'  => true,
-				'smwgEnabledInTextAnnotationParserStrictMode' => true
+				'smwgParserFeatures' => SMW_PARSER_INL_ERROR | SMW_PARSER_STRICT
 			),
 			'[[Foo::@@@]] [[Bar::@@@en|Foobar]]',
 			array(
@@ -653,8 +653,7 @@ class InTextAnnotationParserTest extends \PHPUnit_Framework_TestCase {
 			array(
 				'smwgNamespacesWithSemanticLinks' => array( NS_MAIN => true ),
 				'smwgLinksInValues' => SMW_LINV_OBFU,
-				'smwgInlineErrors'  => true,
-				'smwgEnabledInTextAnnotationParserStrictMode' => true
+				'smwgParserFeatures' => SMW_PARSER_INL_ERROR | SMW_PARSER_STRICT
 			),
 			'[[Text::Bar [http://example.org/Foo Foo]]] [[Code::Foo[1] Foobar]]',
 			array(
@@ -671,8 +670,7 @@ class InTextAnnotationParserTest extends \PHPUnit_Framework_TestCase {
 			array(
 				'smwgNamespacesWithSemanticLinks' => array( NS_MAIN => true ),
 				'smwgLinksInValues' => SMW_LINV_OBFU,
-				'smwgInlineErrors'  => true,
-				'smwgEnabledInTextAnnotationParserStrictMode' => true
+				'smwgParserFeatures' => SMW_PARSER_INL_ERROR | SMW_PARSER_STRICT
 			),
 			'<sup id="cite_ref-1" class="reference">[[#cite_note-1|&#91;1&#93;]]</sup>',
 			array(

--- a/tests/phpunit/Unit/PropertyAnnotators/CategoryPropertyAnnotatorTest.php
+++ b/tests/phpunit/Unit/PropertyAnnotators/CategoryPropertyAnnotatorTest.php
@@ -77,7 +77,7 @@ class CategoryPropertyAnnotatorTest extends \PHPUnit_Framework_TestCase {
 		);
 
 		$instance->showHiddenCategories(
-			$parameters['settings']['smwgShowHiddenCategories']
+			$parameters['settings']['showHiddenCategories']
 		);
 
 		$instance->useCategoryInstance(
@@ -119,7 +119,7 @@ class CategoryPropertyAnnotatorTest extends \PHPUnit_Framework_TestCase {
 		);
 
 		$instance->showHiddenCategories(
-			$parameters['settings']['smwgShowHiddenCategories']
+			$parameters['settings']['showHiddenCategories']
 		);
 
 		$instance->useCategoryInstance(
@@ -150,7 +150,7 @@ class CategoryPropertyAnnotatorTest extends \PHPUnit_Framework_TestCase {
 	 */
 	public function testAddCategoriesWithHiddenCategories( array $parameters, array $expected ) {
 
-		$expectedPageLookup = $parameters['settings']['smwgShowHiddenCategories'] ? $this->never() : $this->atLeastOnce();
+		$expectedPageLookup = $parameters['settings']['showHiddenCategories'] ? $this->never() : $this->atLeastOnce();
 
 		$wikiPage = $this->getMockBuilder( '\WikiPage' )
 			->disableOriginalConstructor()
@@ -183,7 +183,7 @@ class CategoryPropertyAnnotatorTest extends \PHPUnit_Framework_TestCase {
 		);
 
 		$instance->showHiddenCategories(
-			$parameters['settings']['smwgShowHiddenCategories']
+			$parameters['settings']['showHiddenCategories']
 		);
 
 		$instance->useCategoryInstance(
@@ -257,7 +257,7 @@ class CategoryPropertyAnnotatorTest extends \PHPUnit_Framework_TestCase {
 				'settings'   => array(
 					'smwgUseCategoryHierarchy'  => false,
 					'smwgCategoriesAsInstances' => true,
-					'smwgShowHiddenCategories'  => true
+					'showHiddenCategories'  => true
 				)
 			),
 			array(
@@ -275,7 +275,7 @@ class CategoryPropertyAnnotatorTest extends \PHPUnit_Framework_TestCase {
 				'settings'   => array(
 					'smwgUseCategoryHierarchy'  => true,
 					'smwgCategoriesAsInstances' => false,
-					'smwgShowHiddenCategories'  => true
+					'showHiddenCategories'  => true
 				)
 			),
 			array(
@@ -314,7 +314,7 @@ class CategoryPropertyAnnotatorTest extends \PHPUnit_Framework_TestCase {
 				'settings'   => array(
 					'smwgUseCategoryHierarchy'  => false,
 					'smwgCategoriesAsInstances' => true,
-					'smwgShowHiddenCategories'  => true
+					'showHiddenCategories'  => true
 				)
 			),
 			array(
@@ -333,7 +333,7 @@ class CategoryPropertyAnnotatorTest extends \PHPUnit_Framework_TestCase {
 				'settings'   => array(
 					'smwgUseCategoryHierarchy'  => false,
 					'smwgCategoriesAsInstances' => true,
-					'smwgShowHiddenCategories'  => false
+					'showHiddenCategories'  => false
 				)
 			),
 			array(
@@ -352,7 +352,7 @@ class CategoryPropertyAnnotatorTest extends \PHPUnit_Framework_TestCase {
 				'settings'   => array(
 					'smwgUseCategoryHierarchy'  => true,
 					'smwgCategoriesAsInstances' => false,
-					'smwgShowHiddenCategories'  => true
+					'showHiddenCategories'  => true
 				)
 			),
 			array(
@@ -371,7 +371,7 @@ class CategoryPropertyAnnotatorTest extends \PHPUnit_Framework_TestCase {
 				'settings'   => array(
 					'smwgUseCategoryHierarchy'  => true,
 					'smwgCategoriesAsInstances' => false,
-					'smwgShowHiddenCategories'  => false
+					'showHiddenCategories'  => false
 				)
 			),
 			array(

--- a/tests/phpunit/Unit/PropertyAnnotators/ChainablePropertyAnnotatorTest.php
+++ b/tests/phpunit/Unit/PropertyAnnotators/ChainablePropertyAnnotatorTest.php
@@ -50,7 +50,7 @@ class ChainablePropertyAnnotatorTest extends \PHPUnit_Framework_TestCase {
 		);
 
 		$categoryPropertyAnnotator->showHiddenCategories(
-			$parameters['settings']['smwgShowHiddenCategories']
+			$parameters['settings']['showHiddenCategories']
 		);
 
 		$categoryPropertyAnnotator->useCategoryInstance(
@@ -100,7 +100,7 @@ class ChainablePropertyAnnotatorTest extends \PHPUnit_Framework_TestCase {
 				'settings'   => array(
 					'smwgUseCategoryHierarchy'  => false,
 					'smwgCategoriesAsInstances' => true,
-					'smwgShowHiddenCategories'  => true,
+					'showHiddenCategories'  => true,
 					'smwgPageSpecialProperties' => array( DIProperty::TYPE_MODIFICATION_DATE )
 				)
 			),


### PR DESCRIPTION
This PR is made in reference to: #2798

This PR addresses or contains:

- Adds `smwgParserFeatures` and replaces:
  - `smwgInlineErrors` with `SMW_PARSER_INL_ERROR`
  - `smwgShowHiddenCategories` with `SMW_PARSER_HID_CATS`
  - `smwgEnabledInTextAnnotationParserStrictMode` with `SMW_PARSER_STRICT`
  - `smwgDecodeTextAnnotationWithStripMarker` with `SMW_PARSER_UNSTRIP`
- Default is defined with `SMW_PARSER_STRICT | SMW_PARSER_INL_ERROR | SMW_PARSER_HID_CATS`

This PR includes:
- [ ] Tests (unit/integration)
- [x] CI build passed
