### PR TITLE
Filter categories from transcluded content in `format=embedded`, refs 1455, 2751

### DIFF
--- a/src/Query/ResultPrinters/ResultPrinter.php
+++ b/src/Query/ResultPrinters/ResultPrinter.php
@@ -335,6 +335,8 @@ abstract class ResultPrinter implements IResultPrinter {
 			$this->recursiveTextProcessor = new RecursiveTextProcessor();
 		}
 
+		$this->recursiveTextProcessor->uniqid();
+
 		$this->recursiveTextProcessor->setMaxRecursionDepth(
 			self::$maxRecursionDepth
 		);
@@ -376,11 +378,11 @@ abstract class ResultPrinter implements IResultPrinter {
 			$result = $this->recursiveTextProcessor->recursiveTagParse( $result );
 		}
 
-		$this->recursiveTextProcessor->releaseAnyAnnotationBlock();
-
 		if ( $this->mShowErrors && $this->recursiveTextProcessor->getError() !== [] ) {
 			$result .= Message::get( $this->recursiveTextProcessor->getError(), Message::TEXT, Message::USER_LANGUAGE );
 		}
+
+		$this->recursiveTextProcessor->releaseAnnotationBlock();
 
 		return $result;
 	}

--- a/tests/phpunit/Integration/JSONScript/TestCases/f-0801.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/f-0801.json
@@ -1,5 +1,5 @@
 {
-	"description": "Test `format=embedded` output (skip 1.19)",
+	"description": "Test `format=embedded` output",
 	"setup": [
 		{
 			"namespace": "SMW_NS_PROPERTY",
@@ -33,7 +33,7 @@
 		},
 		{
 			"page": "Format/Embedded/B",
-			"contents": "{{#ask:[[Category:Embedded format]] |format=count/B}} {{#ask:[[Category:Embedded format/B]] |format=embedded |link=none |headers=show |embedformat=h1 }}"
+			"contents": "{{#ask:[[Category:Embedded format/B]] |format=count}} {{#ask:[[Category:Embedded format/B]] |format=embedded |link=none |headers=show |embedformat=h1 }}"
 		},
 		{
 			"page": "Format/Embedded/C",
@@ -41,7 +41,15 @@
 		},
 		{
 			"page": "Format/Embedded/D",
-			"contents": "[[Has another property::A123]] {{#ask:[[Category:Embedded format]] |format=count/B}} {{#ask:[[Category:Embedded format/B]] [[!Format/Embedded/B]]|format=embedded |link=none |headers=show |embedformat=h1 }} {{#set:Has another property=ABCD}}"
+			"contents": "[[Has another property::A123]] {{#ask:[[Category:Embedded format/B]] |format=count}} {{#ask:[[Category:Embedded format/B]] [[!Format/Embedded/B]]|format=embedded |link=none |headers=show |embedformat=h1 }} {{#set:Has another property=ABCD}}"
+		},
+		{
+			"page": "Format/Embedded/E/1",
+			"contents": "{{#ask:[[Category:Embedded format/A]] |format=embedded |link=none |headers=show |embedformat=h1 }} {{#ask:[[Category:Embedded format/B]] |format=embedded |link=none |headers=show |embedformat=h1 }} [[Category:Embedded format/E]]"
+		},
+		{
+			"page": "Format/Embedded/E",
+			"contents": "{{#ask:[[Category:Embedded format/E]] |format=embedded |link=none |headers=show |embedformat=h1 }}"
 		}
 	],
 	"tests": [
@@ -52,25 +60,26 @@
 			"assert-store": {
 				"semantic-data": {
 					"strictPropertyValueMatch": false,
-					"propertyCount": 4,
+					"propertyCount": 3,
 					"propertyKeys": [
-						"_INST",
 						"_MDAT",
 						"_SKEY",
 						"_ASK"
 					],
 					"propertyValues": [
-						"Embedded format/A"
+						"Format/Embedded/A#_QUERYc91dabd03c0f49de2dc535c5b099aa45"
 					]
 				}
 			},
 			"assert-output": {
 				"to-contain": [
-					"<h1><span class=\"mw-headline\" id=\"Format.2FEmbedded.2FA\">.*selflink\">Format/Embedded/A.*</h1>",
 					"<h1><span class=\"mw-headline\" id=\"Format.2FEmbedded.2FA.2F1\">",
 					"<h1><span class=\"mw-headline\" id=\"Format.2FEmbedded.2FA.2F2\">",
 					"ABC",
 					"DEF"
+				],
+				"not-contain": [
+					"<h1><span class=\"mw-headline\" id=\"Format.2FEmbedded.2FA\">.*selflink\">Format/Embedded/A.*</h1>"
 				]
 			}
 		},
@@ -81,25 +90,27 @@
 			"assert-store": {
 				"semantic-data": {
 					"strictPropertyValueMatch": false,
-					"propertyCount": 4,
+					"propertyCount": 3,
 					"propertyKeys": [
-						"_INST",
 						"_MDAT",
 						"_SKEY",
 						"_ASK"
 					],
 					"propertyValues": [
-						"Embedded format/B"
+						"Format/Embedded/B#_QUERY62dcea2c67d5ddb3d9304fc34b792da2",
+						"Format/Embedded/B#_QUERYe368d606dd919a1d87cb50f61cfff289"
 					]
 				}
 			},
 			"assert-output": {
 				"to-contain": [
-					"<h1><span class=\"mw-headline\" id=\"Format.2FEmbedded.2FB\">.*selflink\">Format/Embedded/B.*</h1>",
 					"<h1><span class=\"mw-headline\" id=\"Format.2FEmbedded.2FB.2F1\">",
 					"<h1><span class=\"mw-headline\" id=\"Format.2FEmbedded.2FB.2F2\">",
 					"ABC",
 					"DEF"
+				],
+				"not-contain": [
+					"<h1><span class=\"mw-headline\" id=\"Format.2FEmbedded.2FB\">.*selflink\">Format/Embedded/B.*</h1>"
 				]
 			}
 		},
@@ -132,16 +143,14 @@
 			"assert-store": {
 				"semantic-data": {
 					"strictPropertyValueMatch": false,
-					"propertyCount": 5,
+					"propertyCount": 4,
 					"propertyKeys": [
-						"_INST",
 						"_MDAT",
 						"_SKEY",
 						"_ASK",
 						"Has_another_property"
 					],
 					"propertyValues": [
-						"Embedded format/B",
 						"A123",
 						"ABCD"
 					]
@@ -149,12 +158,39 @@
 			},
 			"assert-output": {
 				"to-contain": [
-					"<h1><span class=\"mw-headline\" id=\"Format.2FEmbedded.2FD\">.*selflink\">Format/Embedded/D.*</h1>",
 					"<h1><span class=\"mw-headline\" id=\"Format.2FEmbedded.2FB.2F1\">",
 					"<h1><span class=\"mw-headline\" id=\"Format.2FEmbedded.2FB.2F2\">",
 					"A123",
 					"ABC",
 					"DEF"
+				],
+				"not-contain": [
+					"<h1><span class=\"mw-headline\" id=\"Format.2FEmbedded.2FD\">.*selflink\">Format/Embedded/D.*</h1>"
+				]
+			}
+		},
+		{
+			"type": "parser",
+			"about": "#4 embedded an #ask embbeded page",
+			"subject": "Format/Embedded/E",
+			"assert-store": {
+				"semantic-data": {
+					"strictPropertyValueMatch": false,
+					"propertyCount": 3,
+					"propertyKeys": [
+						"_MDAT",
+						"_SKEY",
+						"_ASK"
+					]
+				}
+			},
+			"assert-output": {
+				"to-contain": [
+					"<a href=.* title=\"Format/Embedded/E/1\">Format/Embedded/E/1</a>",
+					"<a href=.* title=\"Format/Embedded/A/1\">Format/Embedded/A/1</a>",
+					"<a href=.* title=\"Format/Embedded/A/2\">Format/Embedded/A/2</a>",
+					"<a href=.* title=\"Format/Embedded/B/1\">Format/Embedded/B/1</a>",
+					"<a href=.* title=\"Format/Embedded/B/2\">Format/Embedded/B/2</a>"
 				]
 			}
 		}
@@ -168,9 +204,6 @@
 		}
 	},
 	"meta": {
-		"skip-on": {
-			"mw-1.19.20": "<h1> contains an extra space"
-		},
 		"version": "2",
 		"is-incomplete": false,
 		"debug": false

--- a/tests/phpunit/Integration/JSONScript/TestCases/f-0804.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/f-0804.json
@@ -1,0 +1,83 @@
+{
+	"description": "Test `format=embedded` with template transclution",
+	"setup": [
+		{
+			"namespace": "SMW_NS_PROPERTY",
+			"page": "HasSomePageProperty",
+			"contents": "[[Has type::Page]]"
+		},
+		{
+			"namespace": "NS_TEMPLATE",
+			"page": "TmplP0804",
+			"contents": "<includeonly>[[Category:P0804]]</includeonly>"
+		},
+		{
+			"page": "Example/P0804/1",
+			"contents": "[[Category:P0804]]"
+		},
+		{
+			"page": "Example/P0804/2",
+			"contents": "{{TmplP0804}} [[Category:P0804/1]]"
+		},
+		{
+			"page": "Example/P0804/3",
+			"contents": "{{#ask:[[Category:P0804]] [[Category:P0804/1]] |format=embedded }} [[Category:P0804/3]]"
+		},
+		{
+			"page": "Example/P0804/Q.1",
+			"contents": "{{#ask:[[Category:P0804]] |format=embedded }}"
+		},
+		{
+			"page": "Example/P0804/Q.2",
+			"contents": "{{#ask:[[Category:P0804/3]] |format=embedded }}"
+		}
+	],
+	"tests": [
+		{
+			"type": "parser",
+			"about": "#0 only those with [[Category:P0804]] (exludes Example/P0804/3 as no class was imported)",
+			"subject": "Example/P0804/Q.1",
+			"assert-store": {
+				"semantic-data": {
+					"strictPropertyValueMatch": false,
+					"propertyCount": 3,
+					"propertyKeys": [
+						"_MDAT",
+						"_SKEY",
+						"_ASK"
+					]
+				}
+			},
+			"assert-output": {
+				"to-contain": [
+					"<span class=\"mw-headline\" id=\"Example.2FP0804.2F1\"><a href=.* title=\"Example/P0804/1\">Example/P0804/1</a></span>",
+					"<span class=\"mw-headline\" id=\"Example.2FP0804.2F2\"><a href=.* title=\"Example/P0804/2\">Example/P0804/2</a></span>"
+				]
+			}
+		},
+		{
+			"type": "parser",
+			"about": "#1 only those reachable via [[Category:P0804/3]] ",
+			"subject": "Example/P0804/Q.2",
+			"assert-output": {
+				"to-contain": [
+					"<span class=\"mw-headline\" id=\"Example.2FP0804.2F3\"><a href=.* title=\"Example/P0804/3\">Example/P0804/3</a></span>",
+					"<span class=\"mw-headline\" id=\"Example.2FP0804.2F2\"><a href=.* title=\"Example/P0804/2\">Example/P0804/2</a></span>"
+				]
+			}
+		}
+	],
+	"settings": {
+		"smwgPageSpecialProperties": [ "_MDAT" ],
+		"smwgQueryResultCacheType": false,
+		"smwgNamespacesWithSemanticLinks": {
+			"NS_MAIN": true,
+			"SMW_NS_PROPERTY": true
+		}
+	},
+	"meta": {
+		"version": "2",
+		"is-incomplete": false,
+		"debug": false
+	}
+}

--- a/tests/phpunit/Integration/JSONScript/TestCases/p-0444.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/p-0444.json
@@ -147,12 +147,11 @@
 			"assert-store": {
 				"semantic-data": {
 					"strictPropertyValueMatch": false,
-					"propertyCount": 4,
+					"propertyCount": 3,
 					"propertyKeys": [
 						"_SKEY",
 						"_MDAT",
-						"_ASK",
-						"_INST"
+						"_ASK"
 					],
 					"propertyValues": []
 				}

--- a/tests/phpunit/Integration/JSONScript/TestCases/p-0449.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/p-0449.json
@@ -125,12 +125,11 @@
 			"assert-store": {
 				"semantic-data": {
 					"strictPropertyValueMatch": false,
-					"propertyCount": 4,
+					"propertyCount": 3,
 					"propertyKeys": [
 						"_SKEY",
 						"_MDAT",
-						"_ASK",
-						"_INST"
+						"_ASK"
 					],
 					"propertyValues": []
 				}

--- a/tests/phpunit/Unit/Parser/RecursiveTextProcessorTest.php
+++ b/tests/phpunit/Unit/Parser/RecursiveTextProcessorTest.php
@@ -77,6 +77,73 @@ class RecursiveTextProcessorTest extends \PHPUnit_Framework_TestCase {
 		);
 	}
 
+	public function testRecursivePreprocess_NO_RecursiveAnnotationWithAnnotationBlockToRemoveCategories() {
+
+		$this->parserOutput->expects( $this->atLeastOnce() )
+			->method( 'getExtensionData' )
+			->with(	$this->equalTo( \SMW\ParserData::ANNOTATION_BLOCK ) )
+			->will( $this->returnValue( [ '123' => true ] ) );
+
+		$this->parser->expects( $this->atLeastOnce() )
+			->method( 'getOutput' )
+			->will( $this->returnValue( $this->parserOutput ) );
+
+		$this->parser->expects( $this->atLeastOnce() )
+			->method( 'getTitle' )
+			->will( $this->returnValue( $this->title ) );
+
+		$this->parser->expects( $this->atLeastOnce() )
+			->method( 'getOptions' )
+			->will( $this->returnValue( $this->parserOptions ) );
+
+		$this->parser->expects( $this->once() )
+			->method( 'replaceVariables' )
+			->with( $this->equalTo( 'Foo [[Category:Bar]][[Category:Test: Abc]]' ) )
+			->will( $this->returnArgument( 0 ) );
+
+		$instance = new RecursiveTextProcessor(
+			$this->parser
+		);
+
+		$instance->uniqid( '123' );
+
+		$this->assertSame(
+			'[[SMW::off]]Foo [[SMW::on]]',
+			$instance->recursivePreprocess( 'Foo [[Category:Bar]][[Category:Test: Abc]]' )
+		);
+	}
+
+	public function testRecursivePreprocess_NO_RecursiveAnnotationWithNoAnnotationBlockToRetainCategories() {
+
+		$this->parser->expects( $this->atLeastOnce() )
+			->method( 'getOutput' )
+			->will( $this->returnValue( $this->parserOutput ) );
+
+		$this->parser->expects( $this->atLeastOnce() )
+			->method( 'getTitle' )
+			->will( $this->returnValue( $this->title ) );
+
+		$this->parser->expects( $this->atLeastOnce() )
+			->method( 'getOptions' )
+			->will( $this->returnValue( $this->parserOptions ) );
+
+		$this->parser->expects( $this->once() )
+			->method( 'replaceVariables' )
+			->with( $this->equalTo( 'Foo [[Category:Bar]][[Category:Test: Abc]]' ) )
+			->will( $this->returnArgument( 0 ) );
+
+		$instance = new RecursiveTextProcessor(
+			$this->parser
+		);
+
+		$instance->uniqid( '123' );
+
+		$this->assertSame(
+			'[[SMW::off]]Foo [[Category:Bar]][[Category:Test: Abc]][[SMW::on]]',
+			$instance->recursivePreprocess( 'Foo [[Category:Bar]][[Category:Test: Abc]]' )
+		);
+	}
+
 	public function testRecursivePreprocess_WITH_RecursiveAnnotation() {
 
 		$this->parser->expects( $this->atLeastOnce() )
@@ -198,6 +265,65 @@ class RecursiveTextProcessorTest extends \PHPUnit_Framework_TestCase {
 		$this->assertNotEmpty(
 			$instance->getError()
 		);
+	}
+
+	public function testTranscludeAnnotationWithoutUniquidThrowsException() {
+
+		$this->parser->expects( $this->atLeastOnce() )
+			->method( 'getOutput' )
+			->will( $this->returnValue( $this->parserOutput ) );
+
+		$instance = new RecursiveTextProcessor(
+			$this->parser
+		);
+
+		$this->setExpectedException( 'RuntimeException' );
+		$instance->transcludeAnnotation( false );
+	}
+
+	public function testTranscludeAnnotation_FALSE() {
+
+		$this->parserOutput->expects( $this->atLeastOnce() )
+			->method( 'setExtensionData' )
+			->with(
+				$this->equalTo( \SMW\ParserData::ANNOTATION_BLOCK ),
+				$this->equalTo( [ '123' => true ] ) );
+
+		$this->parser->expects( $this->atLeastOnce() )
+			->method( 'getOutput' )
+			->will( $this->returnValue( $this->parserOutput ) );
+
+		$instance = new RecursiveTextProcessor(
+			$this->parser
+		);
+
+		$instance->uniqid( '123' );
+		$instance->transcludeAnnotation( false );
+	}
+
+	public function testReleaseAnnotationBlock() {
+
+		$this->parserOutput->expects( $this->atLeastOnce() )
+			->method( 'getExtensionData' )
+			->with(	$this->equalTo( \SMW\ParserData::ANNOTATION_BLOCK ) )
+			->will( $this->returnValue( [ '123' => true ] ) );
+
+		$this->parserOutput->expects( $this->atLeastOnce() )
+			->method( 'setExtensionData' )
+			->with(
+				$this->equalTo( \SMW\ParserData::ANNOTATION_BLOCK ),
+				$this->equalTo( false ) );
+
+		$this->parser->expects( $this->atLeastOnce() )
+			->method( 'getOutput' )
+			->will( $this->returnValue( $this->parserOutput ) );
+
+		$instance = new RecursiveTextProcessor(
+			$this->parser
+		);
+
+		$instance->uniqid( '123' );
+		$instance->releaseAnnotationBlock();
 	}
 
 }


### PR DESCRIPTION
This PR is made in reference to: #1455, #2751

This PR addresses or contains:

- Fixes " ... that embedding pages may accidentally include category statements if the embedded articles have any categories ..." [0] by preventing transclusion of categories before the source text is returned to MediaWiki
- Importing of other "foreign" value statements was fixed in #1455

[0] https://www.semantic-mediawiki.org/wiki/Help:Embedded_format

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed

Fixes #