### PR TITLE
Consolidate category settings `smwgCategoryFeatures`, refs 2798

### DIFF
--- a/DefaultSettings.php
+++ b/DefaultSettings.php
@@ -281,41 +281,24 @@ return array(
 	##
 
 	###
-	# Category hierarchy recognition
 	#
-	# Should a subcategory be considered a hierarchy element in the
-	# annotation process?
+	# - SMW_CAT_NONE
 	#
-	# If set to true, subcategories will always be interpreted as subclasses
-	# and automatically annotated with `Subcategory of`.
+	# - SMW_CAT_REDI: resolves redirects and errors in connection with categories
 	#
-	# @see CategoryPropertyAnnotator
+	# - SMW_CAT_INSTANCE: Should category pages that use some [[Category:Foo]]
+	#   statement be treated as elements of the category Foo? If disabled, then
+	#   it is not possible to make category pages elements of other categories.
+	#   See also SMW_CAT_HIERARCHY. (was $smwgCategoriesAsInstances)
 	#
-	# @since 1.5
-	# @default true
-	##
-	'smwgUseCategoryHierarchy' => true,
-	##
-
-	###
-	# Should category pages that use some [[Category:Foo]] statement be treated as
-	# elements of the category Foo? If disabled, then it is not possible to make
-	# category pages elements of other categories. See also the above setting
-	# $smwgUseCategoryHierarchy.
-	#
-	# @since 1.5
-	# @default true
-	##
-	'smwgCategoriesAsInstances' => true,
-	##
-
-	###
-	# Resolves redirects and errors in connection with categories
+	# - SMW_CAT_HIERARCHY: Should a subcategory be considered a hierarchy element
+	#   in the annotation process? If set to true, subcategories will always be
+	#   interpreted as subclasses and automatically annotated with
+	#   `Subcategory of`. (was $smwgUseCategoryHierarchy)
 	#
 	# @since 3.0
-	# @default true
 	##
-	'smwgUseCategoryRedirect' => true,
+	'smwgCategoryFeatures' => SMW_CAT_REDI | SMW_CAT_INSTANCE | SMW_CAT_HIERARCHY,
 	##
 
 	###

--- a/includes/Settings.php
+++ b/includes/Settings.php
@@ -67,9 +67,6 @@ class Settings extends Options {
 			'smwgNamespaceIndex' => $GLOBALS['smwgNamespaceIndex'],
 			'smwgShowFactbox' => $GLOBALS['smwgShowFactbox'],
 			'smwgShowFactboxEdit' => $GLOBALS['smwgShowFactboxEdit'],
-			'smwgUseCategoryHierarchy' => $GLOBALS['smwgUseCategoryHierarchy'],
-			'smwgCategoriesAsInstances' => $GLOBALS['smwgCategoriesAsInstances'],
-			'smwgUseCategoryRedirect' => $GLOBALS['smwgUseCategoryRedirect'],
 			'smwgLinksInValues' => $GLOBALS['smwgLinksInValues'],
 			'smwgDefaultNumRecurringEvents' => $GLOBALS['smwgDefaultNumRecurringEvents'],
 			'smwgMaxNumRecurringEvents' => $GLOBALS['smwgMaxNumRecurringEvents'],
@@ -176,6 +173,7 @@ class Settings extends Options {
 			'smwgChangePropagationProtection' => $GLOBALS['smwgChangePropagationProtection'],
 			'smwgUseComparableContentHash' => $GLOBALS['smwgUseComparableContentHash'],
 			'smwgBrowseFeatures' => $GLOBALS['smwgBrowseFeatures'],
+			'smwgCategoryFeatures' => $GLOBALS['smwgCategoryFeatures'],
 		);
 
 		self::initLegacyMapping( $configuration );
@@ -325,6 +323,18 @@ class Settings extends Options {
 			$configuration['smwgParserFeatures'] = $configuration['smwgParserFeatures'] & ~SMW_PARSER_HID_CATS;
 		}
 
+		if ( isset( $GLOBALS['smwgUseCategoryRedirect'] ) && $GLOBALS['smwgUseCategoryRedirect'] === false ) {
+			$configuration['smwgCategoryFeatures'] = $configuration['smwgCategoryFeatures'] & ~SMW_CAT_REDI;
+		}
+
+		if ( isset( $GLOBALS['smwgCategoriesAsInstances'] ) && $GLOBALS['smwgCategoriesAsInstances'] === false ) {
+			$configuration['smwgCategoryFeatures'] = $configuration['smwgCategoryFeatures'] & ~SMW_CAT_INSTANCE;
+		}
+
+		if ( isset( $GLOBALS['smwgUseCategoryHierarchy'] ) && $GLOBALS['smwgUseCategoryHierarchy'] === false ) {
+			$configuration['smwgCategoryFeatures'] = $configuration['smwgCategoryFeatures'] & ~SMW_CAT_HIERARCHY;
+		}
+
 		if ( isset( $GLOBALS['smwgQueryDependencyPropertyExemptionlist'] ) ) {
 			$configuration['smwgQueryDependencyPropertyExemptionList'] = $GLOBALS['smwgQueryDependencyPropertyExemptionlist'];
 		}
@@ -428,6 +438,9 @@ class Settings extends Options {
 				'smwgEnabledInTextAnnotationParserStrictMode' => '3.1.0',
 				'smwgInlineErrors' => '3.1.0',
 				'smwgShowHiddenCategories' => '3.1.0',
+				'smwgUseCategoryRedirect' => '3.1.0',
+				'smwgCategoriesAsInstances' => '3.1.0',
+				'smwgUseCategoryHierarchy' => '3.1.0',
 				'options' => [
 					'smwgCacheUsage' =>  [
 						'smwgStatisticsCache' => '3.1.0',
@@ -461,6 +474,9 @@ class Settings extends Options {
 				'smwgEnabledInTextAnnotationParserStrictMode' => 'smwgParserFeatures',
 				'smwgInlineErrors' => 'smwgParserFeatures',
 				'smwgShowHiddenCategories' => 'smwgParserFeatures',
+				'smwgUseCategoryRedirect' => 'smwgCategoryFeatures',
+				'smwgCategoriesAsInstances' => 'smwgCategoryFeatures',
+				'smwgUseCategoryHierarchy' => 'smwgCategoryFeatures',
 				'options' => [
 					'smwgCacheUsage' => [
 						'smwgStatisticsCacheExpiry' => 'special.statistics',

--- a/src/Defines.php
+++ b/src/Defines.php
@@ -249,3 +249,12 @@ define( 'SMW_PARSER_UNSTRIP', 4 ); // Support for using the StripMarkerDecoder
 define( 'SMW_PARSER_INL_ERROR', 8 ); // Support for display of inline errors
 define( 'SMW_PARSER_HID_CATS', 16 ); // Support for parsing hidden categories
 /**@}*/
+
+/**@{
+  * Constants for $smwgCategoryFeatures
+  */
+define( 'SMW_CAT_NONE', 0 );
+define( 'SMW_CAT_REDI', 2 ); // Support resolving category redirects
+define( 'SMW_CAT_INSTANCE', 4 ); // Support using a category as instantiatable object
+define( 'SMW_CAT_HIERARCHY', 8 ); // Support for category hierarchies
+/**@}*/

--- a/src/PropertyAnnotatorFactory.php
+++ b/src/PropertyAnnotatorFactory.php
@@ -153,15 +153,15 @@ class PropertyAnnotatorFactory {
 		);
 
 		$categoryPropertyAnnotator->useCategoryInstance(
-			$settings->get( 'smwgCategoriesAsInstances' )
+			$settings->isFlagSet( 'smwgCategoryFeatures', SMW_CAT_INSTANCE )
 		);
 
 		$categoryPropertyAnnotator->useCategoryHierarchy(
-			$settings->get( 'smwgUseCategoryHierarchy' )
+			$settings->isFlagSet( 'smwgCategoryFeatures', SMW_CAT_HIERARCHY )
 		);
 
 		$categoryPropertyAnnotator->useCategoryRedirect(
-			$settings->get( 'smwgUseCategoryRedirect' )
+			$settings->isFlagSet( 'smwgCategoryFeatures', SMW_CAT_REDI )
 		);
 
 		return $categoryPropertyAnnotator;

--- a/src/PropertyRegistry.php
+++ b/src/PropertyRegistry.php
@@ -68,13 +68,16 @@ class PropertyRegistry {
 			return self::$instance;
 		}
 
-		$propertyLabelFinder = ApplicationFactory::getInstance()->getPropertyLabelFinder();
+		$applicationFactory = ApplicationFactory::getInstance();
+		$propertyLabelFinder = $applicationFactory->getPropertyLabelFinder();
 		$extraneousLanguage = Localizer::getInstance()->getExtraneousLanguage();
 
 		$propertyAliasFinder = new PropertyAliasFinder(
 			$extraneousLanguage->getPropertyAliases(),
 			$extraneousLanguage->getCanonicalPropertyAliases()
 		);
+
+		$settings = $applicationFactory->getSettings();
 
 		self::$instance = new self(
 			DataTypeRegistry::getInstance(),
@@ -83,7 +86,9 @@ class PropertyRegistry {
 			$GLOBALS['smwgDataTypePropertyExemptionList']
 		);
 
-		self::$instance->registerPredefinedProperties( $GLOBALS['smwgUseCategoryHierarchy'] );
+		self::$instance->registerPredefinedProperties(
+			$settings->isFlagSet( 'smwgCategoryFeatures', SMW_CAT_HIERARCHY )
+		);
 
 		return self::$instance;
 	}

--- a/tests/phpunit/Integration/JSONScript/JsonTestCaseScriptRunnerTest.php
+++ b/tests/phpunit/Integration/JSONScript/JsonTestCaseScriptRunnerTest.php
@@ -219,12 +219,12 @@ class JsonTestCaseScriptRunnerTest extends JsonTestCaseScriptRunner {
 			'smwgQueryProfiler',
 			'smwgEntityCollation',
 			'smwgSparqlQFeatures',
-			'smwgUseCategoryRedirect',
 			'smwgQExpensiveThreshold',
 			'smwgQExpensiveExecutionLimit',
 			'smwgFieldTypeFeatures',
 			'smwgCreateProtectionRight',
 			'smwgParserFeatures',
+			'smwgCategoryFeatures',
 
 			// MW related
 			'wgLanguageCode',

--- a/tests/phpunit/Integration/JSONScript/TestCases/p-0915.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/p-0915.json
@@ -1,5 +1,5 @@
 {
-	"description": "Test category redirect (`smwgUseCategoryRedirect`)",
+	"description": "Test category redirect (`SMW_CAT_REDI`)",
 	"setup": [
 		{
 			"namespace": "NS_CATEGORY",
@@ -90,7 +90,11 @@
 	"settings": {
 		"wgContLang": "en",
 		"wgLang": "en",
-		"smwgUseCategoryRedirect": true,
+		"smwgCategoryFeatures": [
+			"SMW_CAT_INSTANCE",
+			"SMW_CAT_REDI",
+			"SMW_CAT_HIERARCHY"
+		],
 		"smwgPageSpecialProperties": [
 			"_MDAT"
 		],

--- a/tests/phpunit/JsonTestCaseFileHandler.php
+++ b/tests/phpunit/JsonTestCaseFileHandler.php
@@ -241,7 +241,8 @@ class JsonTestCaseFileHandler {
 			'smwgFulltextSearchIndexableDataTypes',
 			'smwgFieldTypeFeatures',
 			'smwgQueryProfiler',
-			'smwgParserFeatures'
+			'smwgParserFeatures',
+			'smwgCategoryFeatures'
 		);
 
 		foreach ( $constantFeaturesList as $constantFeatures ) {

--- a/tests/phpunit/Unit/MediaWiki/Hooks/ParserAfterTidyTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Hooks/ParserAfterTidyTest.php
@@ -187,9 +187,8 @@ class ParserAfterTidyTest extends \PHPUnit_Framework_TestCase {
 		$settings = array(
 			'smwgCacheType'             => 'hash',
 			'smwgEnableUpdateJobs'      => false,
-			'smwgUseCategoryHierarchy'  => false,
-			'smwgCategoriesAsInstances' => true,
-			'smwgParserFeatures'        => SMW_PARSER_HID_CATS
+			'smwgParserFeatures'        => SMW_PARSER_HID_CATS,
+			'smwgCategoryFeatures'      => SMW_CAT_REDI | SMW_CAT_INSTANCE
 		);
 
 		$this->testEnvironment->withConfiguration( $settings );

--- a/tests/phpunit/Unit/PropertyAnnotators/CategoryPropertyAnnotatorTest.php
+++ b/tests/phpunit/Unit/PropertyAnnotators/CategoryPropertyAnnotatorTest.php
@@ -81,11 +81,11 @@ class CategoryPropertyAnnotatorTest extends \PHPUnit_Framework_TestCase {
 		);
 
 		$instance->useCategoryInstance(
-			$parameters['settings']['smwgCategoriesAsInstances']
+			$parameters['settings']['categoriesAsInstances']
 		);
 
 		$instance->useCategoryHierarchy(
-			$parameters['settings']['smwgUseCategoryHierarchy']
+			$parameters['settings']['categoryHierarchy']
 		);
 
 		$instance->useCategoryRedirect(
@@ -123,11 +123,11 @@ class CategoryPropertyAnnotatorTest extends \PHPUnit_Framework_TestCase {
 		);
 
 		$instance->useCategoryInstance(
-			$parameters['settings']['smwgCategoriesAsInstances']
+			$parameters['settings']['categoriesAsInstances']
 		);
 
 		$instance->useCategoryHierarchy(
-			$parameters['settings']['smwgUseCategoryHierarchy']
+			$parameters['settings']['categoryHierarchy']
 		);
 
 		$instance->useCategoryRedirect(
@@ -187,11 +187,11 @@ class CategoryPropertyAnnotatorTest extends \PHPUnit_Framework_TestCase {
 		);
 
 		$instance->useCategoryInstance(
-			$parameters['settings']['smwgCategoriesAsInstances']
+			$parameters['settings']['categoriesAsInstances']
 		);
 
 		$instance->useCategoryHierarchy(
-			$parameters['settings']['smwgUseCategoryHierarchy']
+			$parameters['settings']['categoryHierarchy']
 		);
 
 		$instance->useCategoryRedirect(
@@ -255,8 +255,8 @@ class CategoryPropertyAnnotatorTest extends \PHPUnit_Framework_TestCase {
 				'namespace'  => NS_MAIN,
 				'categories' => array( 'Foo', 'Bar' ),
 				'settings'   => array(
-					'smwgUseCategoryHierarchy'  => false,
-					'smwgCategoriesAsInstances' => true,
+					'categoryHierarchy'  => false,
+					'categoriesAsInstances' => true,
 					'showHiddenCategories'  => true
 				)
 			),
@@ -273,8 +273,8 @@ class CategoryPropertyAnnotatorTest extends \PHPUnit_Framework_TestCase {
 				'namespace'  => NS_CATEGORY,
 				'categories' => array( 'Foo', 'Bar' ),
 				'settings'   => array(
-					'smwgUseCategoryHierarchy'  => true,
-					'smwgCategoriesAsInstances' => false,
+					'categoryHierarchy'  => true,
+					'categoriesAsInstances' => false,
 					'showHiddenCategories'  => true
 				)
 			),
@@ -312,8 +312,8 @@ class CategoryPropertyAnnotatorTest extends \PHPUnit_Framework_TestCase {
 				'categories'    => array( 'Foo', 'Bar' ),
 				'hidCategories' => array( $hidCategory ),
 				'settings'   => array(
-					'smwgUseCategoryHierarchy'  => false,
-					'smwgCategoriesAsInstances' => true,
+					'categoryHierarchy'  => false,
+					'categoriesAsInstances' => true,
 					'showHiddenCategories'  => true
 				)
 			),
@@ -331,8 +331,8 @@ class CategoryPropertyAnnotatorTest extends \PHPUnit_Framework_TestCase {
 				'categories'    => array( 'Foo', 'Bar' ),
 				'hidCategories' => array( $hidCategory ),
 				'settings'   => array(
-					'smwgUseCategoryHierarchy'  => false,
-					'smwgCategoriesAsInstances' => true,
+					'categoryHierarchy'  => false,
+					'categoriesAsInstances' => true,
 					'showHiddenCategories'  => false
 				)
 			),
@@ -350,8 +350,8 @@ class CategoryPropertyAnnotatorTest extends \PHPUnit_Framework_TestCase {
 				'categories'    => array( 'Foo', 'Bar' ),
 				'hidCategories' => array( $hidCategory ),
 				'settings'   => array(
-					'smwgUseCategoryHierarchy'  => true,
-					'smwgCategoriesAsInstances' => false,
+					'categoryHierarchy'  => true,
+					'categoriesAsInstances' => false,
 					'showHiddenCategories'  => true
 				)
 			),
@@ -369,8 +369,8 @@ class CategoryPropertyAnnotatorTest extends \PHPUnit_Framework_TestCase {
 				'categories'    => array( 'Foo', 'Bar' ),
 				'hidCategories' => array( $hidCategory ),
 				'settings'   => array(
-					'smwgUseCategoryHierarchy'  => true,
-					'smwgCategoriesAsInstances' => false,
+					'categoryHierarchy'  => true,
+					'categoriesAsInstances' => false,
 					'showHiddenCategories'  => false
 				)
 			),

--- a/tests/phpunit/Unit/PropertyAnnotators/ChainablePropertyAnnotatorTest.php
+++ b/tests/phpunit/Unit/PropertyAnnotators/ChainablePropertyAnnotatorTest.php
@@ -54,11 +54,11 @@ class ChainablePropertyAnnotatorTest extends \PHPUnit_Framework_TestCase {
 		);
 
 		$categoryPropertyAnnotator->useCategoryInstance(
-			$parameters['settings']['smwgCategoriesAsInstances']
+			$parameters['settings']['categoriesAsInstances']
 		);
 
 		$categoryPropertyAnnotator->useCategoryHierarchy(
-			$parameters['settings']['smwgUseCategoryHierarchy']
+			$parameters['settings']['categoryHierarchy']
 		);
 
 		$categoryPropertyAnnotator->useCategoryRedirect(
@@ -98,8 +98,8 @@ class ChainablePropertyAnnotatorTest extends \PHPUnit_Framework_TestCase {
 				'categories' => array( 'Foo', 'Bar' ),
 				'sortkey'    => 'Lala',
 				'settings'   => array(
-					'smwgUseCategoryHierarchy'  => false,
-					'smwgCategoriesAsInstances' => true,
+					'categoryHierarchy'  => false,
+					'categoriesAsInstances' => true,
 					'showHiddenCategories'  => true,
 					'smwgPageSpecialProperties' => array( DIProperty::TYPE_MODIFICATION_DATE )
 				)


### PR DESCRIPTION
This PR is made in reference to: #2798 

This PR addresses or contains:

- Adds `smwgCategoryFeatures` and replaces:
  - `smwgUseCategoryHierarchy` with `SMW_CAT_HIERARCHY`
  - `smwgCategoriesAsInstances` with `SMW_CAT_INSTANCE`
  - `smwgUseCategoryRedirect` with `SMW_CAT_REDI`
- Default is defined with `SMW_CAT_REDI | SMW_CAT_INSTANCE | SMW_CAT_HIERARCHY`

This PR includes:
- [ ] Tests (unit/integration)
- [x] CI build passed

Fixes #