### PR TITLE
External identifier to support #nowiki, refs 2808

### DIFF
--- a/src/DataValues/ExternalIdentifierValue.php
+++ b/src/DataValues/ExternalIdentifierValue.php
@@ -24,7 +24,7 @@ class ExternalIdentifierValue extends StringValue {
 	/**
 	 * @var string|null
 	 */
-	private $substitutedUri = null;
+	private $uri = null;
 
 	/**
 	 * @param string $typeid
@@ -61,7 +61,7 @@ class ExternalIdentifierValue extends StringValue {
 			return $this->m_caption;
 		}
 
-		$substitutedUri = $this->getUriWithPlaceholderSubstitution(
+		$uri = $this->makeUri(
 			$this->m_dataitem->getString()
 		);
 
@@ -69,12 +69,18 @@ class ExternalIdentifierValue extends StringValue {
 			return '';
 		}
 
+		if ( $this->getOutputFormat() == 'nowiki' ) {
+			$url = $this->makeNonlinkedWikiText( $uri );
+		} else {
+			$url = '['. $uri . ' '. $this->m_caption . ']';
+		}
+
 		return \Html::rawElement(
 			'span',
 			array(
 				'class' => 'plainlinks smw-eid'
 			),
-			'['. $substitutedUri . ' '. $this->m_caption . ']'
+			$url
 		);
 	}
 
@@ -95,7 +101,7 @@ class ExternalIdentifierValue extends StringValue {
 			return $this->m_caption;
 		}
 
-		$substitutedUri = $this->getUriWithPlaceholderSubstitution(
+		$uri = $this->makeUri(
 			$this->m_dataitem->getString()
 		);
 
@@ -106,7 +112,7 @@ class ExternalIdentifierValue extends StringValue {
 		return \Html::rawElement(
 			'a',
 			array(
-				'href'   => $substitutedUri,
+				'href'   => $uri,
 				'target' => '_blank'
 			),
 			$this->m_caption
@@ -140,16 +146,16 @@ class ExternalIdentifierValue extends StringValue {
 
 		$dataValue = $this->dataValueServiceFactory->getDataValueFactory()->newDataValueByType(
 			'_uri',
-			$this->getUriWithPlaceholderSubstitution( $this->m_dataitem->getString() )
+			$this->makeUri( $this->m_dataitem->getString() )
 		);
 
 		return $dataValue->getDataItem();
 	}
 
-	private function getUriWithPlaceholderSubstitution( $value ) {
+	private function makeUri( $value ) {
 
-		if ( $this->substitutedUri !== null ) {
-			return $this->substitutedUri;
+		if ( $this->uri !== null ) {
+			return $this->uri;
 		}
 
 		$dataItem = $this->dataValueServiceFactory->getPropertySpecificationLookup()->getExternalFormatterUri(
@@ -171,7 +177,11 @@ class ExternalIdentifierValue extends StringValue {
 			return;
 		}
 
-		return $this->substitutedUri = $dataValue->getUriWithPlaceholderSubstitution( $value );
+		return $this->uri = $dataValue->getUriWithPlaceholderSubstitution( $value );
+	}
+
+	private function makeNonlinkedWikiText( $url ) {
+		return str_replace( ':', '&#58;', $url );
 	}
 
 }

--- a/tests/phpunit/Integration/JSONScript/TestCases/p-0430.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/p-0430.json
@@ -1,5 +1,5 @@
 {
-	"description": "Test in-text annotation for `_eid` type (`wgContLang=en`, `wgLang=en`)",
+	"description": "Test in-text annotation for `_eid` type (`#nowiki`) (`wgContLang=en`, `wgLang=en`)",
 	"setup": [
 		{
 			"namespace": "SMW_NS_PROPERTY",
@@ -26,6 +26,14 @@
 		{
 			"page": "Example/P0430/2",
 			"contents": "[[Some ID::W%D6LLEKLA01]]"
+		},
+		{
+			"page": "Example/P0430/Q2.1",
+			"contents": "{{#ask: [[Some ID::W%D6LLEKLA01]] |?Some ID }}"
+		},
+		{
+			"page": "Example/P0430/Q2.2",
+			"contents": "{{#ask: [[Some ID::W%D6LLEKLA01]] |?Some ID#nowiki }}"
 		}
 	],
 	"tests": [
@@ -86,6 +94,29 @@
 				],
 				"not-contain": [
 					"<a rel=\"nofollow\" class=\"external text\" href=\"https://example.org/W%25D6LLEKLA01\">W%D6LLEKLA01</a>"
+				]
+			}
+		},
+		{
+			"type": "parser",
+			"about": "#4",
+			"subject": "Example/P0430/Q2.1",
+			"assert-output": {
+				"to-contain": [
+					"<span class=\"plainlinks smw-eid\"><a rel=\"nofollow\" class=\"external text\" href=\"https://example.org/W%D6LLEKLA01\">W%D6LLEKLA01</a></span>"
+				]
+			}
+		},
+		{
+			"type": "parser",
+			"about": "#5 #nowiki",
+			"subject": "Example/P0430/Q2.2",
+			"assert-output": {
+				"to-contain": [
+					"<span class=\"plainlinks smw-eid\">https&#58;//example.org/W%D6LLEKLA01</span>"
+				],
+				"not-contain": [
+					"<span class=\"plainlinks smw-eid\"><a rel=\"nofollow\" class=\"external text\" href=\"https://example.org/W%D6LLEKLA01\">W%D6LLEKLA01</a></span>"
 				]
 			}
 		}

--- a/tests/phpunit/Unit/DataValues/ExternalIdentifierValueTest.php
+++ b/tests/phpunit/Unit/DataValues/ExternalIdentifierValueTest.php
@@ -96,6 +96,30 @@ class ExternalIdentifierValueTest extends \PHPUnit_Framework_TestCase {
 		);
 	}
 
+	public function testGetShortWikiText_Nowiki() {
+
+		$this->propertySpecificationLookup->expects( $this->once() )
+			->method( 'getExternalFormatterUri' )
+			->will( $this->returnValue( $this->dataItemFactory->newDIUri( 'http', 'example.org/$1' ) ) );
+
+		$instance = new ExternalIdentifierValue();
+		$instance->setDataValueServiceFactory( $this->dataValueServiceFactory );
+
+		$instance->setUserValue( 'foo' );
+		$instance->setOutputFormat( 'nowiki' );
+		$instance->setProperty( $this->dataItemFactory->newDIProperty( 'Bar' ) );
+
+		$this->assertEquals(
+			'foo',
+			$instance->getShortWikiText()
+		);
+
+		$this->assertEquals(
+			'<span class="plainlinks smw-eid">http&#58;//example.org/foo</span>',
+			$instance->getShortWikiText( 'linker' )
+		);
+	}
+
 	public function testGetShortHTMLText() {
 
 		$this->propertySpecificationLookup->expects( $this->once() )


### PR DESCRIPTION
This PR is made in reference to: #2808

This PR addresses or contains:

- Adds support for `#nowiki` as printout output formatter option

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed

Fixes #2808