### PR TITLE
Rename `SMW_CAT_REDI` to `SMW_CAT_REDIRECT`

### DIFF
--- a/DefaultSettings.php
+++ b/DefaultSettings.php
@@ -284,7 +284,7 @@ return array(
 	#
 	# - SMW_CAT_NONE
 	#
-	# - SMW_CAT_REDI: resolves redirects and errors in connection with categories
+	# - SMW_CAT_REDIRECT: resolves redirects and errors in connection with categories
 	#
 	# - SMW_CAT_INSTANCE: Should category pages that use some [[Category:Foo]]
 	#   statement be treated as elements of the category Foo? If disabled, then
@@ -298,7 +298,7 @@ return array(
 	#
 	# @since 3.0
 	##
-	'smwgCategoryFeatures' => SMW_CAT_REDI | SMW_CAT_INSTANCE | SMW_CAT_HIERARCHY,
+	'smwgCategoryFeatures' => SMW_CAT_REDIRECT | SMW_CAT_INSTANCE | SMW_CAT_HIERARCHY,
 	##
 
 	###

--- a/includes/Settings.php
+++ b/includes/Settings.php
@@ -324,7 +324,7 @@ class Settings extends Options {
 		}
 
 		if ( isset( $GLOBALS['smwgUseCategoryRedirect'] ) && $GLOBALS['smwgUseCategoryRedirect'] === false ) {
-			$configuration['smwgCategoryFeatures'] = $configuration['smwgCategoryFeatures'] & ~SMW_CAT_REDI;
+			$configuration['smwgCategoryFeatures'] = $configuration['smwgCategoryFeatures'] & ~SMW_CAT_REDIRECT;
 		}
 
 		if ( isset( $GLOBALS['smwgCategoriesAsInstances'] ) && $GLOBALS['smwgCategoriesAsInstances'] === false ) {

--- a/src/Defines.php
+++ b/src/Defines.php
@@ -254,7 +254,7 @@ define( 'SMW_PARSER_HID_CATS', 16 ); // Support for parsing hidden categories
   * Constants for $smwgCategoryFeatures
   */
 define( 'SMW_CAT_NONE', 0 );
-define( 'SMW_CAT_REDI', 2 ); // Support resolving category redirects
+define( 'SMW_CAT_REDIRECT', 2 ); // Support resolving category redirects
 define( 'SMW_CAT_INSTANCE', 4 ); // Support using a category as instantiatable object
 define( 'SMW_CAT_HIERARCHY', 8 ); // Support for category hierarchies
 /**@}*/

--- a/src/PropertyAnnotatorFactory.php
+++ b/src/PropertyAnnotatorFactory.php
@@ -161,7 +161,7 @@ class PropertyAnnotatorFactory {
 		);
 
 		$categoryPropertyAnnotator->useCategoryRedirect(
-			$settings->isFlagSet( 'smwgCategoryFeatures', SMW_CAT_REDI )
+			$settings->isFlagSet( 'smwgCategoryFeatures', SMW_CAT_REDIRECT )
 		);
 
 		return $categoryPropertyAnnotator;

--- a/tests/phpunit/Integration/JSONScript/TestCases/p-0915.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/p-0915.json
@@ -1,5 +1,5 @@
 {
-	"description": "Test category redirect (`SMW_CAT_REDI`)",
+	"description": "Test category redirect (`SMW_CAT_REDIRECT`)",
 	"setup": [
 		{
 			"namespace": "NS_CATEGORY",
@@ -92,7 +92,7 @@
 		"wgLang": "en",
 		"smwgCategoryFeatures": [
 			"SMW_CAT_INSTANCE",
-			"SMW_CAT_REDI",
+			"SMW_CAT_REDIRECT",
 			"SMW_CAT_HIERARCHY"
 		],
 		"smwgPageSpecialProperties": [

--- a/tests/phpunit/Unit/MediaWiki/Hooks/ParserAfterTidyTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Hooks/ParserAfterTidyTest.php
@@ -188,7 +188,7 @@ class ParserAfterTidyTest extends \PHPUnit_Framework_TestCase {
 			'smwgCacheType'             => 'hash',
 			'smwgEnableUpdateJobs'      => false,
 			'smwgParserFeatures'        => SMW_PARSER_HID_CATS,
-			'smwgCategoryFeatures'      => SMW_CAT_REDI | SMW_CAT_INSTANCE
+			'smwgCategoryFeatures'      => SMW_CAT_REDIRECT | SMW_CAT_INSTANCE
 		);
 
 		$this->testEnvironment->withConfiguration( $settings );


### PR DESCRIPTION
This PR is made in reference to: #2806 

This PR addresses or contains:
- Establish naming consistency for `smwgCategoryFeatures`

This PR includes:
- [ ] Tests (unit/integration)
- [x] CI build passed