### PR TITLE
Follow-up on table header output mode change, refs 2796

### DIFF
--- a/src/Query/ResultPrinters/TableResultPrinter.php
+++ b/src/Query/ResultPrinters/TableResultPrinter.php
@@ -107,6 +107,7 @@ class TableResultPrinter extends ResultPrinter {
 
 		 // building headers
 		if ( $this->mShowHeaders != SMW_HEADERS_HIDE ) {
+			$isPlain = $this->mShowHeaders == SMW_HEADERS_PLAIN;
 			foreach ( $res->getPrintRequests() as /* SMWPrintRequest */ $pr ) {
 				$attributes = array();
 				$columnClass = str_replace( array( ' ', '_' ), '-', strip_tags( $pr->getText( SMW_OUTPUT_WIKI ) ) );
@@ -114,7 +115,10 @@ class TableResultPrinter extends ResultPrinter {
 				// Also add this to the array of classes, for
 				// use in displaying each row.
 				$columnClasses[] = $columnClass;
-				$text = $pr->getText( SMW_OUTPUT_WIKI, ( $this->mShowHeaders == SMW_HEADERS_PLAIN ? null : $this->mLinker ) );
+
+				// #2702 Use a fixed output on a requested plain printout
+				$mode = $this->isHTML && $isPlain ? SMW_OUTPUT_WIKI : $outputMode;
+				$text = $pr->getText( $mode, ( $isPlain ? null : $this->mLinker ) );
 				$headerList[] = $pr->getCanonicalLabel();
 				$this->htmlTable->header( ( $text === '' ? '&nbsp;' : $text ), $attributes );
 			}

--- a/tests/phpunit/Integration/JSONScript/TestCases/s-0016.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/s-0016.json
@@ -42,7 +42,7 @@
 			},
 			"assert-output": {
 				"to-contain": [
-					"<th class=\"Has-monolingual-text\">[[:Property:Has monolingual text|Has monolingual text]]</th><th class=\"Category\">[[:Special:Categories|Category]]</th><th class=\"Has-monolingual-text\">[[:Property:Has monolingual text|Has monolingual text]]</th>",
+					"<th class=\"Has-monolingual-text\"><a .* title=\"Property:Has monolingual text\">Has monolingual text</a></th><th class=\"Category\"><a .*>Category</a></th><th class=\"Has-monolingual-text\"><a .* title=\"Property:Has monolingual text\">Has monolingual text</a></th>",
 					"<tbody><tr data-row-number=\"1\" class=\"row-odd\"><td class=\"smwtype_wpg\">Example/S0016/1</td><td class=\"Has-monolingual-text smwtype_txt\">Test</td><td class=\"Category smwtype_wpg\">Category:S0016</td><td class=\"Has-monolingual-text smwtype_txt\">テスト</td></tr></tbody>"
 				],
 				"not-contain": [
@@ -70,7 +70,7 @@
 			},
 			"assert-output": {
 				"to-contain": [
-					"<th class=\"Has-monolingual-text\">[[:Property:Has monolingual text|Has monolingual text]]</th><th class=\"Category\">[[:Special:Categories|Category]]</th><th class=\"Has-monolingual-text\">[[:Property:Has monolingual text|Has monolingual text]]</th>",
+					"<th class=\"Has-monolingual-text\"><a .* title=\"Property:Has monolingual text\">Has monolingual text</a></th><th class=\"Category\"><a .*>Category</a></th><th class=\"Has-monolingual-text\"><a .* title=\"Property:Has monolingual text\">Has monolingual text</a></th>",
 					"<tbody><tr data-row-number=\"1\" class=\"row-odd\"><td class=\"smwtype_wpg\">Example/S0016/1</td><td class=\"Has-monolingual-text smwtype_txt\">Test</td><td class=\"Category smwtype_wpg\">Category:S0016</td><td class=\"Has-monolingual-text smwtype_txt\">テスト</td></tr></tbody>"
 				],
 				"not-contain": [
@@ -98,11 +98,12 @@
 			},
 			"assert-output": {
 				"to-contain": [
-					"<th class=\"Has-monolingual-text\">[[:Property:Has monolingual text|Has monolingual text]]</th><th class=\"Category\">[[:Special:Categories|Category]]</th><th class=\"Has-monolingual-text\">[[:Property:Has monolingual text|Has monolingual text]]</th>",
+					"<th class=\"Has-monolingual-text\"><a .* title=\"Property:Has monolingual text\">Has monolingual text</a></th><th class=\"Category\"><a .*>Category</a></th><th class=\"Has-monolingual-text\"><a .* title=\"Property:Has monolingual text\">Has monolingual text</a></th>",
 					"<tbody><tr data-row-number=\"1\" class=\"row-odd\"><td class=\"smwtype_wpg\">Example/S0016/1</td><td class=\"Has-monolingual-text smwtype_txt\">Test</td><td class=\"Category smwtype_wpg\">Category:S0016</td><td class=\"Has-monolingual-text smwtype_txt\">テスト</td></tr></tbody>"
 				],
 				"not-contain": [
-					"<tbody><tr data-row-number=\"1\" class=\"row-odd\"><td class=\"smwtype_wpg\">Example/S0016/1</td><td class=\"Has-monolingual-text smwtype_txt\">Test</td><td class=\"Has-monolingual-text smwtype_txt\">テスト</td></tr></tbody>"				]
+					"<tbody><tr data-row-number=\"1\" class=\"row-odd\"><td class=\"smwtype_wpg\">Example/S0016/1</td><td class=\"Has-monolingual-text smwtype_txt\">Test</td><td class=\"Has-monolingual-text smwtype_txt\">テスト</td></tr></tbody>"
+				]
 			}
 		}
 	],

--- a/tests/phpunit/Integration/JSONScript/TestCases/s-0021.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/s-0021.json
@@ -1,5 +1,5 @@
 {
-	"description": "Test header rendering on special page Ask for `#ask` with `format=table` and `headers=plain` as further results (#2702, `wgContLang=en`, `wgLang=en`)",
+	"description": "Test `format=table` on `Special:Ask` with `headers=plain` (#2702, `wgContLang=en`, `wgLang=en`)",
 	"setup": [
 		{
 			"namespace": "SMW_NS_PROPERTY",
@@ -7,42 +7,60 @@
 			"contents": "[[Has type::Text]]"
 		},
 		{
-			"page": "Example/P0708/1",
-			"contents": "[[Has text::P0708]]"
+			"page": "Example/S0021/1",
+			"contents": "[[Has text::S0021]]"
 		},
 		{
-			"page": "Example/P0708/2",
-			"contents": "[[Has text::P0708]]"
-		},
-		{
-			"page": "Example/P0708/Q.1",
-			"contents": "{{#ask: [[Has text::P0708]] |?Has text=Modified <i>label</i> for text |format=table |limit=1 |headers=plain }}"
-		},
-		{
-			"page": "Example/P0708/Q.2",
-			"contents": "{{#ask: [[Has text::P0708]] |?Has text=Modified label for text {{#info: Foo Bar }} |format=table |limit=1 |headers=plain }}"
+			"page": "Example/S0021/2",
+			"contents": "[[Has text::S0021]]"
 		}
 	],
 	"tests": [
 		{
-			"type": "parser",
-			"about": "#0",
-			"subject": "Example/P0708/Q.1",
+			"type": "special",
+			"about": "#0 with headers",
+			"special-page": {
+				"page": "Ask",
+				"request-parameters": {
+					"p": {
+						"limit": "10",
+						"offset": "0",
+						"headers": "",
+						"format": "table"
+					},
+					"q": "[[Has text::S0021]]",
+					"po": "?Has text=Modified <i>label</i> for text"
+				}
+			},
 			"assert-output": {
 				"to-contain": [
-					"class=\"Modified-label-for-text\">Modified <i>label</i> for text",
-					"Special:Ask/-5B-5BHas-20text::P0708-5D-5D/-3FHas-20text%3DModified-20-3Ci-3Elabel-3C-2Fi-3E-20for-20text/mainlabel%3D/limit%3D1/offset%3D1/format%3Dtable/headers%3Dplain"
+					"<thead><th>&nbsp;</th><th class=\"Modified-label-for-text\"><a href=.* title=\"Property:Has text\">Modified <i>label</i> for text</a></th></thead>",
+					"<a href=.* title=\"Example/S0021/1\">Example/S0021/1</a>",
+					"<a href=.* title=\"Example/S0021/2\">Example/S0021/2</a>"
 				]
 			}
 		},
 		{
-			"type": "parser",
-			"about": "#1 with #info parser",
-			"subject": "Example/P0708/Q.2",
+			"type": "special",
+			"about": "#1 with headers plain",
+			"special-page": {
+				"page": "Ask",
+				"request-parameters": {
+					"p": {
+						"limit": "10",
+						"offset": "0",
+						"headers": "plain",
+						"format": "table"
+					},
+					"q": "[[Has text::S0021]]",
+					"po": "?Has text=Modified <i>label</i> for text"
+				}
+			},
 			"assert-output": {
 				"to-contain": [
-					"class=\"Modified-label-for-text-Foo-Bar\">Modified label for text <span class=\"smw-highlighter\" data-type=\"6\" data-state=\"persistent\" data-title=\"Information\" title=\"Foo Bar\"><span class=\"smwtticon info\"></span><div class=\"smwttcontent\">Foo Bar</div></span>",
-					"Special:Ask/-5B-5BHas-20text::P0708-5D-5D/-3FHas-20text%3DModified-20label-20for-20text-20-3Cspan-20class%3D%22smw-2Dhighlighter%22-20data-2Dtype%3D%226%22-20data-2Dstate%3D%22persistent%22-20data-2Dtitle%3D%22Information%22-20title%3D%22Foo-20Bar%22-3E-3Cspan-20class%3D%22smwtticon-20info%22-3E-3C-2Fspan-3E-3Cdiv-20class%3D%22smwttcontent%22-3EFoo-20Bar-3C-2Fdiv-3E-3C-2Fspan-3E/mainlabel%3D/limit%3D1/offset%3D1/format%3Dtable/headers%3Dplain"
+					"<thead><th>&nbsp;</th><th class=\"Modified-label-for-text\">Modified <i>label</i> for text</th></thead>",
+					"<a href=.* title=\"Example/S0021/1\">Example/S0021/1</a>",
+					"<a href=.* title=\"Example/S0021/2\">Example/S0021/2</a>"
 				]
 			}
 		}


### PR DESCRIPTION
This PR is made in reference to: #2796

This PR addresses or contains:

-  #2796 contained a regression as demonstrated below
- Fixes regression, restores the `s-0016.json` test, and modifies `s-0021.json` to test changes on `headers=` and `headers=plain`
- https://sandbox.semantic-mediawiki.org/wiki/Issue/2819

![image](https://user-images.githubusercontent.com/1245473/32689552-620035ec-c72a-11e7-9745-72858c032894.png)

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed

Fixes #