### PR TITLE
Consolidate sort settings `smwgQSortFeatures`, refs 2798

### DIFF
--- a/DefaultSettings.php
+++ b/DefaultSettings.php
@@ -431,11 +431,25 @@ return array(
 												// performance-relevant restrictions depending on the storage engine
 	// 	'smwgQEqualitySupport' => SMW_EQ_FULL, // Evaluate 	#redirects as equality between page names in all cases
 	// 	'smwgQEqualitySupport' => SMW_EQ_NONE, // Never evaluate 	#redirects as equality between page names
-	'smwgQSortingSupport' => true, // (De)activate sorting of results.
-	'smwgQRandSortingSupport' => true, // (De)activate random sorting of results.
 	'smwgQDefaultNamespaces' => null, // Which namespaces should be searched by default?
 										// (value NULL switches off default restrictions on searching -- this is faster)
 										// Example with namespaces: 	'smwgQDefaultNamespaces' => array(NS_MAIN, NS_FILE),
+
+	###
+	# Sort features
+	#
+	# - SMW_QSORT_NONE
+	#
+	# - SMW_QSORT: General sort support for query results (was
+	#   $smwgQSortingSupport)
+	#
+	# - SMW_QSORT_RANDOM: Random sorting support for query results (was
+	#   $smwgQRandSortingSupport)
+	#
+	# @since 3.0
+	##
+	'smwgQSortFeatures' => SMW_QSORT | SMW_QSORT_RANDOM,
+	##
 
 	###
 	# List of comparator characters

--- a/includes/Settings.php
+++ b/includes/Settings.php
@@ -81,8 +81,6 @@ class Settings extends Options {
 			'smwgQSubcategoryDepth' => $GLOBALS['smwgQSubcategoryDepth'],
 			'smwgQSubpropertyDepth' => $GLOBALS['smwgQSubpropertyDepth'],
 			'smwgQEqualitySupport' => $GLOBALS['smwgQEqualitySupport'],
-			'smwgQSortingSupport' => $GLOBALS['smwgQSortingSupport'],
-			'smwgQRandSortingSupport' => $GLOBALS['smwgQRandSortingSupport'],
 			'smwgQDefaultNamespaces' => $GLOBALS['smwgQDefaultNamespaces'],
 			'smwgQComparators' => $GLOBALS['smwgQComparators'],
 			'smwgQFilterDuplicates' => $GLOBALS['smwgQFilterDuplicates'],
@@ -105,6 +103,7 @@ class Settings extends Options {
 			'smwgQExpensiveExecutionLimit' => $GLOBALS['smwgQExpensiveExecutionLimit'],
 			'smwgQuerySources' => $GLOBALS['smwgQuerySources'],
 			'smwgQTemporaryTablesAutoCommitMode' => $GLOBALS['smwgQTemporaryTablesAutoCommitMode'],
+			'smwgQSortFeatures' => $GLOBALS['smwgQSortFeatures'],
 			'smwgResultFormats' => $GLOBALS['smwgResultFormats'],
 			'smwgResultFormatsFeatures' => $GLOBALS['smwgResultFormatsFeatures'],
 			'smwgResultAliases' => $GLOBALS['smwgResultAliases'],
@@ -311,6 +310,7 @@ class Settings extends Options {
 			$configuration['smwgAdminFeatures'] = $configuration['smwgAdminFeatures'] & ~SMW_ADM_REFRESH;
 		}
 
+		// smwgParserFeatures
 		if ( isset( $GLOBALS['smwgEnabledInTextAnnotationParserStrictMode'] ) && $GLOBALS['smwgEnabledInTextAnnotationParserStrictMode'] === false ) {
 			$configuration['smwgParserFeatures'] = $configuration['smwgParserFeatures'] & ~SMW_PARSER_STRICT;
 		}
@@ -323,6 +323,7 @@ class Settings extends Options {
 			$configuration['smwgParserFeatures'] = $configuration['smwgParserFeatures'] & ~SMW_PARSER_HID_CATS;
 		}
 
+		// smwgCategoryFeatures
 		if ( isset( $GLOBALS['smwgUseCategoryRedirect'] ) && $GLOBALS['smwgUseCategoryRedirect'] === false ) {
 			$configuration['smwgCategoryFeatures'] = $configuration['smwgCategoryFeatures'] & ~SMW_CAT_REDIRECT;
 		}
@@ -343,6 +344,7 @@ class Settings extends Options {
 			$configuration['smwgQueryDependencyAffiliatePropertyDetectionList'] = $GLOBALS['smwgQueryDependencyAffiliatePropertyDetectionlist'];
 		}
 
+		// smwgPropertyListLimit
 		if ( isset( $GLOBALS['smwgSubPropertyListLimit'] ) ) {
 			$configuration['smwgPropertyListLimit']['subproperty'] = $GLOBALS['smwgSubPropertyListLimit'];
 		}
@@ -351,6 +353,7 @@ class Settings extends Options {
 			$configuration['smwgPropertyListLimit']['redirect'] = $GLOBALS['smwgRedirectPropertyListLimit'];
 		}
 
+		// smwgCacheUsage
 		if ( isset( $GLOBALS['smwgCacheUsage']['smwgStatisticsCacheExpiry'] ) ) {
 			$configuration['smwgCacheUsage']['special.statistics'] = $GLOBALS['smwgCacheUsage']['smwgStatisticsCacheExpiry'];
 		}
@@ -383,6 +386,7 @@ class Settings extends Options {
 			$configuration['smwgCacheUsage']['special.wantedproperties'] = false;
 		}
 
+		// smwgQueryProfiler
 		if ( isset( $GLOBALS['smwgQueryProfiler']['smwgQueryDurationEnabled'] ) && $GLOBALS['smwgQueryProfiler']['smwgQueryDurationEnabled'] === true ) {
 			$configuration['smwgQueryProfiler'] = $configuration['smwgQueryProfiler'] | SMW_QPRFL_DUR;
 		}
@@ -403,6 +407,7 @@ class Settings extends Options {
 			$configuration['smwgChangePropagationWatchlist'] = $GLOBALS['smwgDeclarationProperties'];
 		}
 
+		// smwgBrowseFeatures
 		if ( isset( $GLOBALS['smwgToolboxBrowseLink'] ) && $GLOBALS['smwgToolboxBrowseLink'] === false ) {
 			$configuration['smwgBrowseFeatures'] = $configuration['smwgBrowseFeatures'] & ~SMW_BROWSE_TLINK;
 		}
@@ -417,6 +422,15 @@ class Settings extends Options {
 
 		if ( isset( $GLOBALS['smwgBrowseByApi'] ) && $GLOBALS['smwgBrowseByApi'] === false ) {
 			$configuration['smwgBrowseFeatures'] = $configuration['smwgBrowseFeatures'] & ~SMW_BROWSE_USE_API;
+		}
+
+		// smwgQSortFeatures
+		if ( isset( $GLOBALS['smwgQSortingSupport'] ) && $GLOBALS['smwgQSortingSupport'] === false ) {
+			$configuration['smwgQSortFeatures'] = $configuration['smwgQSortFeatures'] & ~SMW_QSORT;
+		}
+
+		if ( isset( $GLOBALS['smwgQRandSortingSupport'] ) && $GLOBALS['smwgQRandSortingSupport'] === false ) {
+			$configuration['smwgQSortFeatures'] = $configuration['smwgQSortFeatures'] & ~SMW_QSORT_RANDOM;
 		}
 
 		// Deprecated mapping used in DeprecationNoticeTaskHandler to detect and
@@ -441,6 +455,8 @@ class Settings extends Options {
 				'smwgUseCategoryRedirect' => '3.1.0',
 				'smwgCategoriesAsInstances' => '3.1.0',
 				'smwgUseCategoryHierarchy' => '3.1.0',
+				'smwgQSortingSupport' => '3.1.0',
+				'smwgQRandSortingSupport' => '3.1.0',
 				'options' => [
 					'smwgCacheUsage' =>  [
 						'smwgStatisticsCache' => '3.1.0',
@@ -477,6 +493,8 @@ class Settings extends Options {
 				'smwgUseCategoryRedirect' => 'smwgCategoryFeatures',
 				'smwgCategoriesAsInstances' => 'smwgCategoryFeatures',
 				'smwgUseCategoryHierarchy' => 'smwgCategoryFeatures',
+				'smwgQSortingSupport' => 'smwgQSortFeatures',
+				'smwgQRandSortingSupport' => 'smwgQSortFeatures',
 				'options' => [
 					'smwgCacheUsage' => [
 						'smwgStatisticsCacheExpiry' => 'special.statistics',

--- a/src/Defines.php
+++ b/src/Defines.php
@@ -258,3 +258,11 @@ define( 'SMW_CAT_REDIRECT', 2 ); // Support resolving category redirects
 define( 'SMW_CAT_INSTANCE', 4 ); // Support using a category as instantiatable object
 define( 'SMW_CAT_HIERARCHY', 8 ); // Support for category hierarchies
 /**@}*/
+
+/**@{
+  * Constants for $smwgQSortFeatures
+  */
+define( 'SMW_QSORT_NONE', 0 );
+define( 'SMW_QSORT', 2 ); // General sort support
+define( 'SMW_QSORT_RANDOM', 4 ); // Random sort support
+/**@}*/

--- a/src/MediaWiki/Specials/SpecialAsk.php
+++ b/src/MediaWiki/Specials/SpecialAsk.php
@@ -121,6 +121,8 @@ class SpecialAsk extends SpecialPage {
 
 		$out->addHTML( ErrorWidget::noScript() );
 
+		$settings = ApplicationFactory::getInstance()->getSettings();
+
 		NavigationLinksWidget::setMaxInlineLimit(
 			$GLOBALS['smwgQMaxInlineLimit']
 		);
@@ -138,12 +140,12 @@ class SpecialAsk extends SpecialPage {
 		);
 
 		SortWidget::setSortingSupport(
-			$GLOBALS['smwgQSortingSupport']
+			$settings->isFlagSet( 'smwgQSortFeatures', SMW_QSORT )
 		);
 
 		// @see #835
 		SortWidget::setRandSortingSupport(
-			$GLOBALS['smwgQRandSortingSupport']
+			$settings->isFlagSet( 'smwgQSortFeatures', SMW_QSORT_RANDOM )
 		);
 
 		ParametersProcessor::setDefaultLimit(

--- a/src/SPARQLStore/QueryEngine/EngineOptions.php
+++ b/src/SPARQLStore/QueryEngine/EngineOptions.php
@@ -18,8 +18,7 @@ class EngineOptions extends Options {
 	public function __construct() {
 		parent::__construct( array(
 			'smwgIgnoreQueryErrors'   => $GLOBALS['smwgIgnoreQueryErrors'],
-			'smwgQSortingSupport'     => $GLOBALS['smwgQSortingSupport'],
-			'smwgQRandSortingSupport' => $GLOBALS['smwgQRandSortingSupport'],
+			'smwgQSortFeatures'       => $GLOBALS['smwgQSortFeatures'],
 			'smwgQSubpropertyDepth'   => $GLOBALS['smwgQSubpropertyDepth'],
 			'smwgQSubcategoryDepth'   => $GLOBALS['smwgQSubcategoryDepth'],
 			'smwgSparqlQFeatures'     => $GLOBALS['smwgSparqlQFeatures']

--- a/src/SPARQLStore/QueryEngine/QueryEngine.php
+++ b/src/SPARQLStore/QueryEngine/QueryEngine.php
@@ -243,7 +243,7 @@ class QueryEngine implements QueryEngineInterface {
 		);
 
 		// Build ORDER BY options using discovered sorting fields.
-		if ( !$this->engineOptions->get( 'smwgQSortingSupport' ) || !is_array( $this->sortKeys ) ) {
+		if ( !$this->engineOptions->isFlagSet( 'smwgQSortFeatures', SMW_QSORT ) || !is_array( $this->sortKeys ) ) {
 			return $options;
 		}
 
@@ -257,7 +257,7 @@ class QueryEngine implements QueryEngineInterface {
 
 			if ( ( $order != 'RANDOM' ) && array_key_exists( $propkey, $compoundCondition->orderVariables ) ) {
 				$orderByString .= "$order(?" . $compoundCondition->orderVariables[$propkey] . ") ";
-			} elseif ( ( $order == 'RANDOM' ) && $this->engineOptions->get( 'smwgQRandSortingSupport' ) ) {
+			} elseif ( ( $order == 'RANDOM' ) && $this->engineOptions->isFlagSet( 'smwgQSortFeatures', SMW_QSORT_RANDOM ) ) {
 				// not supported in SPARQL; might be possible via function calls in some stores
 			}
 		}

--- a/src/SQLStore/QueryEngine/EngineOptions.php
+++ b/src/SQLStore/QueryEngine/EngineOptions.php
@@ -18,8 +18,7 @@ class EngineOptions extends Options {
 	public function __construct() {
 		parent::__construct( array(
 			'smwgIgnoreQueryErrors'   => $GLOBALS['smwgIgnoreQueryErrors'],
-			'smwgQSortingSupport'     => $GLOBALS['smwgQSortingSupport'],
-			'smwgQRandSortingSupport' => $GLOBALS['smwgQRandSortingSupport'],
+			'smwgQSortFeatures'     => $GLOBALS['smwgQSortFeatures'],
 			'smwgQFilterDuplicates'   => $GLOBALS['smwgQFilterDuplicates']
 		) );
 	}

--- a/src/SQLStore/QueryEngine/QueryEngine.php
+++ b/src/SQLStore/QueryEngine/QueryEngine.php
@@ -211,7 +211,10 @@ class QueryEngine implements QueryEngineInterface, LoggerAwareInterface {
 		// SELECT DISTINCT and ORDER BY RANDOM causes an issue for postgres
 		// Disable RANDOM support for postgres
 		if ( $connection->isType( 'postgres' ) ) {
-			$this->engineOptions->set( 'smwgQRandSortingSupport', false );
+			$this->engineOptions->set(
+				'smwgQSortFeatures',
+				$this->engineOptions->get( 'smwgQSortFeatures' ) & ~SMW_QSORT_RANDOM
+			);
 		}
 
 		switch ( $query->querymode ) {
@@ -532,7 +535,7 @@ class QueryEngine implements QueryEngineInterface, LoggerAwareInterface {
 			'OFFSET' => $query->getOffset()
 		);
 
-		if ( !$this->engineOptions->get( 'smwgQSortingSupport' ) ) {
+		if ( !$this->engineOptions->isFlagSet( 'smwgQSortFeatures', SMW_QSORT ) ) {
 			return $result;
 		}
 
@@ -555,7 +558,7 @@ class QueryEngine implements QueryEngineInterface, LoggerAwareInterface {
 				}
 
 				$result['ORDER BY'] = ( array_key_exists( 'ORDER BY', $result ) ? $result['ORDER BY'] . ', ' : '' ) . $list . " $order ";
-			} elseif ( ( $order == 'RANDOM' ) && $this->engineOptions->get( 'smwgQRandSortingSupport' ) ) {
+			} elseif ( ( $order == 'RANDOM' ) && $this->engineOptions->isFlagSet( 'smwgQSortFeatures', SMW_QSORT_RANDOM ) ) {
 				$result['ORDER BY'] = ( array_key_exists( 'ORDER BY', $result ) ? $result['ORDER BY'] . ', ' : '' ) . ' RAND() ';
 			}
 		}

--- a/src/SQLStore/QueryEngineFactory.php
+++ b/src/SQLStore/QueryEngineFactory.php
@@ -110,7 +110,7 @@ class QueryEngineFactory {
 		);
 
 		$orderConditionsComplementor->isSupported(
-			$this->applicationFactory->getSettings()->get( 'smwgQSortingSupport' )
+			$this->applicationFactory->getSettings()->isFlagSet( 'smwgQSortFeatures', SMW_QSORT )
 		);
 
 		$querySegmentListBuildManager = new QuerySegmentListBuildManager(

--- a/tests/phpunit/Unit/SPARQLStore/QueryEngine/EngineOptionsTest.php
+++ b/tests/phpunit/Unit/SPARQLStore/QueryEngine/EngineOptionsTest.php
@@ -67,13 +67,8 @@ class EngineOptionsTest extends \PHPUnit_Framework_TestCase {
 		);
 
 		$provider[] = array(
-			'smwgQSortingSupport',
-			'boolean'
-		);
-
-		$provider[] = array(
-			'smwgQRandSortingSupport',
-			'boolean'
+			'smwgQSortFeatures',
+			'integer'
 		);
 
 		$provider[] = array(

--- a/tests/phpunit/Unit/SQLStore/QueryEngine/EngineOptionsTest.php
+++ b/tests/phpunit/Unit/SQLStore/QueryEngine/EngineOptionsTest.php
@@ -33,13 +33,8 @@ class EngineOptionsTest extends \PHPUnit_Framework_TestCase {
 		);
 
 		$this->assertInternalType(
-			'boolean',
-			$instance->get( 'smwgQSortingSupport' )
-		);
-
-		$this->assertInternalType(
-			'boolean',
-			$instance->get( 'smwgQRandSortingSupport' )
+			'integer',
+			$instance->get( 'smwgQSortFeatures' )
 		);
 	}
 


### PR DESCRIPTION
This PR is made in reference to: #2798

This PR addresses or contains:

- Adds `smwgQSortFeatures` and replaces:
  - `smwgQSortingSupport` with `SMW_QSORT`
  - `smwgQRandSortingSupport` with `SMW_QSORT_RANDOM`
- Default is defined with `SMW_QSORT | SMW_QSORT_RANDOM`


This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed

Fixes #