### PR TITLE
Move Csv to utility, add `merge` parameter to `format=csv`

### DIFF
--- a/i18n/en.json
+++ b/i18n/en.json
@@ -69,6 +69,7 @@
 	"smw-paramdesc-table-transpose": "Display table headers vertically and results horizontally",
 	"smw-paramdesc-rdfsyntax": "The RDF syntax to be used",
 	"smw-paramdesc-csv-sep": "The separator to use",
+	"smw-paramdesc-csv-merge": "Merge rows and column values with an identical subject identifier (aka first column)",
 	"smw-paramdesc-dsv-separator": "The separator to use",
 	"smw-paramdesc-dsv-filename": "The name for the DSV file",
 	"smw-paramdesc-filename": "The name for the output file",

--- a/src/Utils/Csv.php
+++ b/src/Utils/Csv.php
@@ -1,0 +1,117 @@
+<?php
+
+namespace SMW\Utils;
+
+/**
+ * @license GNU GPL v2+
+ * @since 3.0
+ *
+ * @author mwjames
+ */
+class Csv {
+
+	/**
+	 * @var boolean
+	 */
+	private $show = false;
+
+	/**
+	 * @since 3.0
+	 *
+	 * @param boolean $show
+	 */
+	public function __construct( $show = false ) {
+		$this->show = $show;
+	}
+
+	/**
+	 * @since 3.0
+	 *
+	 * @param array $header
+	 * @param array $rows
+	 * @param string $sep
+	 *
+	 * @return string
+	 */
+	public function toString( array $header, array $rows, $sep = ',' ) {
+
+		$handle = fopen( 'php://temp', 'r+' );
+
+		// https://en.wikipedia.org/wiki/Comma-separated_values#Application_support
+		if ( $this->show ) {
+			fputs( $handle, "sep=" . $sep . "\n" );
+		}
+
+		if ( $header !== [] ) {
+			fputcsv( $handle, $header, $sep );
+		}
+
+		foreach ( $rows as $row ) {
+			fputcsv( $handle, $row, $sep );
+		}
+
+		rewind( $handle );
+
+		return stream_get_contents( $handle );
+	}
+
+	/**
+	 * Merge row and column values where the subject (first column) uses the same
+	 * identifier.
+	 *
+	 * @since 3.0
+	 *
+	 * @param array $rows
+	 * @param string $sep
+	 *
+	 * @return array
+	 */
+	public function merge( $rows, $sep = ',' ) {
+
+		$map = [];
+		$order = [];
+
+		foreach ( $rows as $key => $row ) {
+
+			// First column is used to build the hash index to find rows with
+			// the same hash
+			$hash = md5( $row[0] );
+
+			// Retain the order
+			if ( !isset( $order[$hash] ) ) {
+				$order[$hash] = $key;
+			}
+
+			if ( !isset( $map[$hash] ) ) {
+				$map[$hash] = $row;
+			} else {
+				$concat = [];
+
+				foreach ( $map[$hash] as $k => $v ) {
+					// Index 0 represents the first column, same hash, only
+					// concatenate the rest of the columns
+					if ( $k != 0 ) {
+						$v = $v . ( isset( $row[$k] ) ? "$sep" . $row[$k] : '' );
+						// Filter duplicate values
+						$v = array_flip( explode( $sep, $v ) );
+						// Make it a simple list
+						$v = implode( $sep, array_keys( $v ) );
+					}
+
+					$concat[$k] = $v;
+				}
+
+				$map[$hash] = $concat;
+			}
+		}
+
+		$order = array_flip( $order );
+
+		foreach ( $order as $key => $hash ) {
+			$order[$key] = $map[$hash];
+		}
+
+		return $order;
+	}
+
+}

--- a/tests/phpunit/Integration/JSONScript/Fixtures/res.s-0022.3.csv
+++ b/tests/phpunit/Integration/JSONScript/Fixtures/res.s-0022.3.csv
@@ -1,0 +1,4 @@
+"Has number","Has text"
+,"Some example"
+"123,345",
+123,"ABC,DEF"

--- a/tests/phpunit/Integration/JSONScript/TestCases/s-0022.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/s-0022.json
@@ -102,6 +102,30 @@
 					"contents-file" : "/../Fixtures/res.s-0022.2.csv"
 				}
 			}
+		},
+		{
+			"type": "special",
+			"about": "#3 merge rows with identical first column identifier",
+			"special-page": {
+				"page": "Ask",
+				"request-parameters": {
+					"p": {
+						"link": "none",
+						"limit": "10",
+						"offset": "0",
+						"mainlabel": "-",
+						"format": "csv",
+						"merge": true
+					},
+					"q": "[[Category:S0022]]",
+					"po": "?Has number|?Has text"
+				}
+			},
+			"assert-output": {
+				"to-contain": {
+					"contents-file" : "/../Fixtures/res.s-0022.3.csv"
+				}
+			}
 		}
 	],
 	"settings": {

--- a/tests/phpunit/Unit/Utils/CsvTest.php
+++ b/tests/phpunit/Unit/Utils/CsvTest.php
@@ -1,0 +1,172 @@
+<?php
+
+namespace SMW\Tests\Utils;
+
+use SMW\Utils\Csv;
+
+/**
+ * @covers \SMW\Utils\Csv
+ * @group semantic-mediawiki
+ *
+ * @license GNU GPL v2+
+ * @since 3.0
+ *
+ * @author mwjames
+ */
+class CsvTest extends \PHPUnit_Framework_TestCase {
+
+	/**
+	 * @dataProvider rowsProvider
+	 */
+	public function testConcatenate( $rows, $sep, $expected ) {
+
+		$instance = new Csv();
+
+		$this->assertEquals(
+			$expected,
+			$instance->merge( $rows, $sep )
+		);
+	}
+
+	/**
+	 * @dataProvider makeProvider
+	 */
+	public function testMake( $header, $rows, $sep, $show, $expected ) {
+
+		$instance = new Csv( $show );
+
+		$this->assertEquals(
+			$expected,
+			$instance->toString( $header, $rows, $sep )
+		);
+	}
+
+	public function rowsProvider() {
+
+		// No change
+		yield [
+			[
+				[ 'Foo', '1', '2', '3' ],
+				[ 'Bar', '1', '2', '3' ],
+			],
+			',',
+			[
+				[ 'Foo', '1', '2', '3' ],
+				[ 'Bar', '1', '2', '3' ],
+			]
+		];
+
+		// Concatenate duplicate
+		yield [
+			[
+				[ 'Foo', '1', '2', '3' ],
+				[ 'Foo', '1', '2', '3' ],
+			],
+			',',
+			[
+				[ 'Foo', '1', '2', '3' ]
+			]
+		];
+
+		// Concatenate column values
+		yield [
+			[
+				[ 'Foo', '1', '2', '3' ],
+				[ 'Foo', '1', '2', '4' ],
+			],
+			',',
+			[
+				[ 'Foo', '1', '2', '3,4' ]
+			]
+		];
+
+		// Concatenate column values
+		yield [
+			[
+				[ 'Foo', '1', '2', '3' ],
+				[ 'Foo', '1', '2', '3', '4' ],
+			],
+			',',
+			[
+				[ 'Foo', '1', '2', '3' ]
+			]
+		];
+
+		yield [
+			[
+				[ 'Foo', '1', '2', '3', '4' ],
+				[ 'Foo', '1', '2', '3' ],
+			],
+			',',
+			[
+				[ 'Foo', '1', '2', '3', '4' ]
+			]
+		];
+
+		yield [
+			[
+				[ 'Foo', '1', '2', '3' ],
+				[ 'Bar', '1', '2', '3' ],
+				[ 'Foo', '4', '5', '6' ],
+				[ 'Bar', 'A', 'B', 'C' ],
+			],
+			',',
+			[
+				[ 'Foo', '1,4', '2,5', '3,6' ],
+				[ 'Bar', '1,A', '2,B', '3,C' ]
+			]
+		];
+	}
+
+	public function makeProvider() {
+
+		// Without header
+		yield [
+			[],
+			[
+				[ 'Foo', '1', '2', '3' ],
+				[ 'Bar', '1', '2', '3' ],
+			],
+			',',
+			false,
+			"Foo,1,2,3\nBar,1,2,3\n"
+		];
+
+		// Without header, multiple value assignment
+		yield [
+			[],
+			[
+				[ 'Foo', '1', '2', '3,4' ],
+				[ 'Bar', '1', '2', '3' ],
+			],
+			',',
+			false,
+			"Foo,1,2,\"3,4\"\nBar,1,2,3\n"
+		];
+
+		// With header
+		yield [
+			[ 'H1', 'H2', 'H3', 'H4' ],
+			[
+				[ 'Foo', '1', '2', '3' ],
+				[ 'Bar', '1', '2', '3' ],
+			],
+			',',
+			false,
+			"H1,H2,H3,H4\nFoo,1,2,3\nBar,1,2,3\n"
+		];
+
+		// With header
+		yield [
+			[ 'H1', 'H2', 'H3', 'H4' ],
+			[
+				[ 'Foo', '1', '2', '3' ],
+				[ 'Bar', '1', '2', '3' ],
+			],
+			',',
+			true,
+			"sep=,\nH1,H2,H3,H4\nFoo,1,2,3\nBar,1,2,3\n"
+		];
+	}
+
+}

--- a/tests/phpunit/includes/queryprinters/CsvResultPrinterTest.php
+++ b/tests/phpunit/includes/queryprinters/CsvResultPrinterTest.php
@@ -133,7 +133,8 @@ class CsvResultPrinterTest extends QueryPrinterTestCase {
 			'format'    => 'csv',
 			'sep'       => ',',
 			'showsep'   => false,
-			'offset'    => 0
+			'offset'    => 0,
+			'merge'     => false
 		);
 
 		$provider[] = array(


### PR DESCRIPTION
This PR is made in reference to: #2804

This PR addresses or contains:

- Moves csv operations (`fputcsv` etc.) to a utility class
- Adds a `merge` option where rows and column values with an identical subject identifier are combined       
  - such as lines containing `'Foo', '1', '2', '3'` `'Foo', '4', '5', '6'` will result in `'Foo', '1,4', '2,5', '3,6'`
  - situation can normally only appear when `mainlabel=-` is used that creates a specific first column and contains identical identifier

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed

Fixes #