### PR TITLE
Add SMW_QSORT_UNCONDITIONAL, refs 874

### DIFF
--- a/src/Defines.php
+++ b/src/Defines.php
@@ -272,6 +272,7 @@ define( 'SMW_CAT_HIERARCHY', 8 ); // Support for category hierarchies
 define( 'SMW_QSORT_NONE', 0 );
 define( 'SMW_QSORT', 2 ); // General sort support
 define( 'SMW_QSORT_RANDOM', 4 ); // Random sort support
+define( 'SMW_QSORT_UNCONDITIONAL', 8 ); // Unconditional sort support
 /**@}*/
 
 /**@{

--- a/src/SQLStore/QueryEngine/OrderCondition.php
+++ b/src/SQLStore/QueryEngine/OrderCondition.php
@@ -47,6 +47,11 @@ class OrderCondition {
 	private $isSupported = true;
 
 	/**
+	 * @var boolean
+	 */
+	private $asUnconditional = false;
+
+	/**
 	 * @since 2.5
 	 *
 	 * @param QuerySegmentListBuilder $querySegmentListBuilder
@@ -90,6 +95,15 @@ class OrderCondition {
 	 */
 	public function isSupported( $isSupported ) {
 		$this->isSupported = $isSupported;
+	}
+
+	/**
+	 * @since 3.0
+	 *
+	 * @param boolean $asUnconditional
+	 */
+	public function asUnconditional( $asUnconditional ) {
+		$this->asUnconditional = $asUnconditional;
 	}
 
 	/**
@@ -221,6 +235,11 @@ class OrderCondition {
 		 // ... so just re-wire its dependencies
 		foreach ( $newQuerySegment->components as $cid => $field ) {
 			$querySegment->components[$cid] = $querySegment->joinfield;
+
+			if ( $this->asUnconditional ) {
+				$this->querySegmentListBuilder->findQuerySegment( $cid )->joinType = 'LEFT OUTER';
+			}
+
 			$querySegment->sortfields = array_merge(
 				$querySegment->sortfields,
 				$this->querySegmentListBuilder->findQuerySegment( $cid )->sortfields

--- a/src/SQLStore/QueryEngine/QuerySegment.php
+++ b/src/SQLStore/QueryEngine/QuerySegment.php
@@ -77,6 +77,16 @@ class QuerySegment {
 	public $fingerprint = '';
 
 	/**
+	 * @var boolean
+	 */
+	public $null = false;
+
+	/**
+	 * @var boolean
+	 */
+	public $not = false;
+
+	/**
 	 * @var string
 	 */
 	public $joinType = '';

--- a/src/SQLStore/QueryEngine/QuerySegmentListProcessor.php
+++ b/src/SQLStore/QueryEngine/QuerySegmentListProcessor.php
@@ -121,19 +121,39 @@ class QuerySegmentListProcessor {
 					$this->resolve( $subQuery );
 
 					if ( $subQuery->joinTable !== '' ) { // Join with jointable.joinfield
-						$query->from .= ' INNER JOIN ' . $this->connection->tableName( $subQuery->joinTable ) . " AS $subQuery->alias ON $joinField=" . $subQuery->joinfield;
+						$op = $subQuery->not ? '!' : '';
+
+						$joinType = $subQuery->joinType ? $subQuery->joinType : 'INNER';
+						$t = $this->connection->tableName( $subQuery->joinTable ) ." AS $subQuery->alias";
+
+						if ( $subQuery->from ) {
+							$t = "($t $subQuery->from)";
+						}
+
+						$query->from .= " $joinType JOIN $t ON $joinField$op=" . $subQuery->joinfield;
+
+						if ( $joinType === 'LEFT' ) {
+							$query->where .= ( ( $query->where === '' ) ? '' : ' AND ' ) . '(' . $subQuery->joinfield . ' IS NULL)';
+						}
+
 					} elseif ( $subQuery->joinfield !== '' ) { // Require joinfield as "value" via WHERE.
 						$condition = '';
 
-						foreach ( $subQuery->joinfield as $value ) {
-							$condition .= ( $condition ? ' OR ':'' ) . "$joinField=" . $this->connection->addQuotes( $value );
+						if ( $subQuery->null === true ) {
+								$condition .= ( $condition ? ' OR ': '' ) . "$joinField IS NULL";
+						} else {
+							foreach ( $subQuery->joinfield as $value ) {
+								$op = $subQuery->not ? '!' : '';
+								$condition .= ( $condition ? ' OR ': '' ) . "$joinField$op=" . $this->connection->addQuotes( $value );
+							}
 						}
 
 						if ( count( $subQuery->joinfield ) > 1 ) {
 							$condition = "($condition)";
 						}
 
-						$query->where .= ( ( $query->where === '' ) ? '':' AND ' ) . $condition;
+						$query->where .= ( ( $query->where === '' || $subQuery->where === null ) ? '' : ' AND ' ) . $condition;
+						$query->from .= $subQuery->from;
 					} else { // interpret empty joinfields as impossible condition (empty result)
 						$query->joinfield = ''; // make whole query false
 						$query->joinTable = '';
@@ -142,11 +162,13 @@ class QuerySegmentListProcessor {
 						break;
 					}
 
-					if ( $subQuery->where !== '' ) {
-						$query->where .= ( ( $query->where === '' ) ? '':' AND ' ) . '(' . $subQuery->where . ')';
+					if ( $subQuery->where !== '' && $subQuery->where !== null ) {
+						if ( $subQuery->joinType === 'LEFT' || $subQuery->joinType == 'LEFT OUTER' ) {
+							$query->from .= ' AND (' . $subQuery->where . ')';
+						} else {
+							$query->where .= ( ( $query->where === '' ) ? '' : ' AND ' ) . '(' . $subQuery->where . ')';
+						}
 					}
-
-					$query->from .= $subQuery->from;
 				}
 
 				$query->components = array();

--- a/src/SQLStore/QueryEngineFactory.php
+++ b/src/SQLStore/QueryEngineFactory.php
@@ -104,13 +104,20 @@ class QueryEngineFactory {
 	public function newQueryEngine() {
 
 		$querySegmentListBuilder = $this->newQuerySegmentListBuilder();
+		$applicationFactory = ApplicationFactory::getInstance();
+
+		$settings = $applicationFactory->getSettings();
 
 		$orderCondition = new OrderCondition(
 			$querySegmentListBuilder
 		);
 
 		$orderCondition->isSupported(
-			$this->applicationFactory->getSettings()->isFlagSet( 'smwgQSortFeatures', SMW_QSORT )
+			$settings->isFlagSet( 'smwgQSortFeatures', SMW_QSORT )
+		);
+
+		$orderCondition->asUnconditional(
+			$settings->isFlagSet( 'smwgQSortFeatures', SMW_QSORT_UNCONDITIONAL )
 		);
 
 		$querySegmentListBuildManager = new QuerySegmentListBuildManager(
@@ -127,7 +134,7 @@ class QueryEngineFactory {
 		);
 
 		$queryEngine->setLogger(
-			$this->applicationFactory->getMediaWikiLogger()
+			$applicationFactory->getMediaWikiLogger()
 		);
 
 		return $queryEngine;

--- a/tests/phpunit/Integration/JSONScript/JsonTestCaseScriptRunnerTest.php
+++ b/tests/phpunit/Integration/JSONScript/JsonTestCaseScriptRunnerTest.php
@@ -230,6 +230,7 @@ class JsonTestCaseScriptRunnerTest extends JsonTestCaseScriptRunner {
 			'smwgDefaultOutputFormatters',
 			'smwgCompactLinkSupport',
 			'smwgCacheUsage',
+			'smwgQSortFeatures',
 
 			// MW related
 			'wgLanguageCode',

--- a/tests/phpunit/Integration/JSONScript/TestCases/q-0910.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/q-0910.json
@@ -1,0 +1,108 @@
+{
+	"description": "Test `SMW_QSORT_UNCONDITIONAL` (`smwgQSortFeatures`, skip-on all SPARQL repositories, postgres)",
+	"setup": [
+		{
+			"namespace": "SMW_NS_PROPERTY",
+			"page": "Has page",
+			"contents": "[[Has type::Page]]"
+		},
+		{
+			"namespace": "SMW_NS_PROPERTY",
+			"page": "Has text",
+			"contents": "[[Has type::Text]]"
+		},
+		{
+			"page": "Q0910/1",
+			"contents": "[[Has page::123]] [[Category:Q0910]]"
+		},
+		{
+			"page": "Q0910/2",
+			"contents": "[[Has text::ABC]] [[Category:Q0910]]"
+		},
+		{
+			"page": "Q0910/3",
+			"contents": "[[Has text::345]] [[Category:Q0910]]"
+		},
+		{
+			"page": "Q0910/Q.1",
+			"contents": "{{#ask: [[Category:Q0910]] |?Has page |?Has text |sort=Has page,Has text |order=desc, desc }}"
+		},
+		{
+			"page": "Q0910/Q.2",
+			"contents": "{{#ask: [[Category:Q0910]] |?Has page |?Has text |sort=Has page,Has text |order=desc, asc }}"
+		}
+	],
+	"tests": [
+		{
+			"type": "query",
+			"about": "#0 (SMW_QSORT_UNCONDITIONAL display, 2, 3)",
+			"condition": "[[Category:Q0910]]",
+			"printouts": [],
+			"parameters": {
+				"limit": "10",
+				"sort": {
+					"Has_page" : "DESC"
+				}
+			},
+			"assert-queryresult": {
+				"count": 3,
+				"results": [
+					"Q0910/1#0##",
+					"Q0910/2#0##",
+					"Q0910/3#0##"
+				]
+			}
+		},
+		{
+			"type": "parser",
+			"about": "#1 (SMW_QSORT_UNCONDITIONAL on Has page=desc, Has text=desc)",
+			"skip-on": {
+				"postgres": "Has different order than MySQL/SQLite, needs investigation."
+			},
+			"subject": "Q0910/Q.1",
+			"assert-output": {
+				"to-contain": [
+					"<tr data-row-number=\"1\" class=\"row-odd\"><td class=\"smwtype_wpg\"><a href=.* title=\"Q0910/1\">Q0910/1</a></td><td class=\"Has-page smwtype_wpg\" data-sort-value=\"123\">",
+					"<tr data-row-number=\"2\" class=\"row-even\"><td class=\"smwtype_wpg\"><a href=.* title=\"Q0910/2\">Q0910/2</a></td><td class=\"Has-page smwtype_wpg\"></td><td class=\"Has-text smwtype_txt\">ABC</td>",
+					"<tr data-row-number=\"3\" class=\"row-odd\"><td class=\"smwtype_wpg\"><a href=.* title=\"Q0910/3\">Q0910/3</a></td><td class=\"Has-page smwtype_wpg\"></td><td class=\"Has-text smwtype_txt\" data-sort-value=\"345\">345</td>"
+				]
+			}
+		},
+		{
+			"type": "parser",
+			"about": "#2 (SMW_QSORT_UNCONDITIONAL on Has page=desc, Has text=asc)",
+			"skip-on": {
+				"postgres": "Has different order than MySQL/SQLite, needs investigation."
+			},
+			"subject": "Q0910/Q.2",
+			"assert-output": {
+				"to-contain": [
+					"<tr data-row-number=\"1\" class=\"row-odd\"><td class=\"smwtype_wpg\"><a href=.* title=\"Q0910/1\">Q0910/1</a></td><td class=\"Has-page smwtype_wpg\" data-sort-value=\"123\">",
+					"<tr data-row-number=\"2\" class=\"row-even\"><td class=\"smwtype_wpg\"><a href=.* title=\"Q0910/3\">Q0910/3</a></td><td class=\"Has-page smwtype_wpg\"></td><td class=\"Has-text smwtype_txt\" data-sort-value=\"345\">345</td>",
+					"<tr data-row-number=\"3\" class=\"row-odd\"><td class=\"smwtype_wpg\"><a href=.* title=\"Q0910/2\">Q0910/2</a></td><td class=\"Has-page smwtype_wpg\"></td><td class=\"Has-text smwtype_txt\">ABC</td>"
+				]
+			}
+		}
+	],
+	"settings": {
+		"smwgNamespacesWithSemanticLinks": {
+			"NS_MAIN": true,
+			"SMW_NS_PROPERTY": true
+		},
+		"smwgQSortFeatures": [
+			"SMW_QSORT",
+			"SMW_QSORT_UNCONDITIONAL"
+		]
+	},
+	"meta": {
+		"skip-on": {
+			"virtuoso": "SMW_QSORT_UNCONDITIONAL isn't implemented",
+			"sesame": "SMW_QSORT_UNCONDITIONAL isn't implemented",
+			"fuseki": "SMW_QSORT_UNCONDITIONAL isn't implemented",
+			"blazegraph": "SMW_QSORT_UNCONDITIONAL isn't implemented"
+		},
+		"version": "2",
+		"is-incomplete": false,
+		"debug": false
+	}
+}

--- a/tests/phpunit/JsonTestCaseFileHandler.php
+++ b/tests/phpunit/JsonTestCaseFileHandler.php
@@ -278,7 +278,8 @@ class JsonTestCaseFileHandler {
 			'smwgFieldTypeFeatures',
 			'smwgQueryProfiler',
 			'smwgParserFeatures',
-			'smwgCategoryFeatures'
+			'smwgCategoryFeatures',
+			'smwgQSortFeatures'
 		);
 
 		foreach ( $constantFeaturesList as $constantFeatures ) {


### PR DESCRIPTION
This PR is made in reference to: #874

This PR addresses or contains:

- Original from https://github.com/mediawiki4intranet/SemanticMediaWiki/commit/53ba5309452f651c1a671a3c816883c475f4ab5e
- Experimental setting (`$GLOBALS['smwgQSortFeatures'] = $GLOBALS['smwgQSortFeatures'] | SMW_QSORT_UNCONDITIONAL;`) that allows to apply an unconditional sort which means that sorting on something like `Has page, Has text` will work even though not all subjects contain a `Has page` or `Has text` assignment
- `SPARQLStore` currently does not support this feature and would require some refactoring of the `ConditionBuilder` to make sort statements `OPTIONAL`
- Experimental status can only be lifted by the time the `SPARQLStore` supports the same feature
- Integration test `"q-0910.json"` shows a different sorting behavior for `postgres`

Some references for SPARQL on the `LEFT OUTER JOIN` discussion:

- https://www.w3.org/2008/07/MappingRules/StemMapping (see Optionals)
- https://arxiv.org/abs/1304.7799
- https://supportcenter.cambridgesemantics.com/semantic-university/sparql-vs-sql-intro (NULLs, OPTIONALS and LEFT OUTER JOINs)


This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed

Fixes #