### PR TITLE
Add `bom` as parameter to `format=csv`, refs 647

### DIFF
--- a/i18n/en.json
+++ b/i18n/en.json
@@ -70,6 +70,7 @@
 	"smw-paramdesc-rdfsyntax": "The RDF syntax to be used",
 	"smw-paramdesc-csv-sep": "The separator to use",
 	"smw-paramdesc-csv-merge": "Merge rows and column values with an identical subject identifier (aka first column)",
+	"smw-paramdesc-csv-bom": "Add a BOM (character to signal endianness) at the top of the output file",
 	"smw-paramdesc-dsv-separator": "The separator to use",
 	"smw-paramdesc-dsv-filename": "The name for the DSV file",
 	"smw-paramdesc-filename": "The name for the output file",

--- a/includes/queryprinters/CsvResultPrinter.php
+++ b/includes/queryprinters/CsvResultPrinter.php
@@ -67,7 +67,8 @@ class CsvResultPrinter extends FileExportPrinter {
 		if ( $outputMode == SMW_OUTPUT_FILE ) { // make CSV file
 
 			$csv = new Csv(
-				$this->params['showsep']
+				$this->params['showsep'],
+				$this->params['bom']
 			);
 
 			$sep = str_replace( '_', ' ', $this->params['sep'] );
@@ -149,6 +150,12 @@ class CsvResultPrinter extends FileExportPrinter {
 			'type' => 'boolean',
 			'default' => false,
 			'message' => 'smw-paramdesc-csv-merge',
+		);
+
+		$params['bom'] = array(
+			'type' => 'boolean',
+			'default' => false,
+			'message' => 'smw-paramdesc-csv-bom',
 		);
 
 		return $params;

--- a/src/Utils/Csv.php
+++ b/src/Utils/Csv.php
@@ -16,12 +16,19 @@ class Csv {
 	private $show = false;
 
 	/**
+	 * @var boolean
+	 */
+	private $bom = false;
+
+	/**
 	 * @since 3.0
 	 *
 	 * @param boolean $show
+	 * @param boolean $bom
 	 */
-	public function __construct( $show = false ) {
+	public function __construct( $show = false, $bom = false ) {
 		$this->show = $show;
+		$this->bom = $bom;
 	}
 
 	/**
@@ -36,6 +43,12 @@ class Csv {
 	public function toString( array $header, array $rows, $sep = ',' ) {
 
 		$handle = fopen( 'php://temp', 'r+' );
+
+		// https://en.wikipedia.org/wiki/Comma-separated_values#Standardization
+		// http://php.net/manual/en/function.fputcsv.php
+		if ( $this->bom ) {
+			fputs( $handle, ( chr( 0xEF ) . chr( 0xBB ) . chr( 0xBF ) ) );
+		}
 
 		// https://en.wikipedia.org/wiki/Comma-separated_values#Application_support
 		if ( $this->show ) {

--- a/tests/phpunit/Unit/Utils/CsvTest.php
+++ b/tests/phpunit/Unit/Utils/CsvTest.php
@@ -41,6 +41,23 @@ class CsvTest extends \PHPUnit_Framework_TestCase {
 		);
 	}
 
+	public function testWithBOM() {
+
+		$header = [];
+		$rows = [
+			[ 'Foo', '1', '2', '3' ]
+		];
+
+		$bom = ( chr( 0xEF ) . chr( 0xBB ) . chr( 0xBF ) );
+
+		$instance = new Csv( false, true );
+
+		$this->assertEquals(
+			"{$bom}Foo,1,2,3\n",
+			$instance->toString( $header, $rows, ',' )
+		);
+	}
+
 	public function rowsProvider() {
 
 		// No change

--- a/tests/phpunit/includes/queryprinters/CsvResultPrinterTest.php
+++ b/tests/phpunit/includes/queryprinters/CsvResultPrinterTest.php
@@ -134,7 +134,8 @@ class CsvResultPrinterTest extends QueryPrinterTestCase {
 			'sep'       => ',',
 			'showsep'   => false,
 			'offset'    => 0,
-			'merge'     => false
+			'merge'     => false,
+			'bom'       => false
 		);
 
 		$provider[] = array(


### PR DESCRIPTION
This PR is made in reference to: #647

This PR addresses or contains:

- Allows to add `bom=true` (https://en.wikipedia.org/wiki/Comma-separated_values#Standardization)

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed

Fixes #647