### PR TITLE
Importer use content modeller

### DIFF
--- a/DefaultSettings.php
+++ b/DefaultSettings.php
@@ -35,7 +35,7 @@ return array(
 	# Controls the content import directory and version that is expected to be
 	# imported during the setup process.
 	#
-	# For all legitimate files in `smwgImportFileDir`, the import is initiated
+	# For all legitimate files in `smwgImportFileDirs`, the import is initiated
 	# if the `smwgImportReqVersion` compares with the declared version in the file.
 	#
 	# In case `smwgImportReqVersion` is maintained with `false` then the import
@@ -43,7 +43,7 @@ return array(
 	#
 	# @since 2.5
 	##
-	'smwgImportFileDir' => __DIR__ . '/src/Importer/data',
+	'smwgImportFileDirs' => [ 'default' => __DIR__ . '/src/Importer/data' ],
 	'smwgImportReqVersion' => 1,
 	##
 

--- a/includes/Settings.php
+++ b/includes/Settings.php
@@ -48,7 +48,7 @@ class Settings extends Options {
 			'smwgIP' => $GLOBALS['smwgIP'],
 			'smwgExtraneousLanguageFileDir' => $GLOBALS['smwgExtraneousLanguageFileDir'],
 			'smwgServicesFileDir' => $GLOBALS['smwgServicesFileDir'],
-			'smwgImportFileDir' => $GLOBALS['smwgImportFileDir'],
+			'smwgImportFileDirs' => $GLOBALS['smwgImportFileDirs'],
 			'smwgImportReqVersion' => $GLOBALS['smwgImportReqVersion'],
 			'smwgSemanticsEnabled' => $GLOBALS['smwgSemanticsEnabled'],
 			'smwgEnabledCompatibilityMode' => $GLOBALS['smwgEnabledCompatibilityMode'],
@@ -433,6 +433,10 @@ class Settings extends Options {
 			$configuration['smwgQSortFeatures'] = $configuration['smwgQSortFeatures'] & ~SMW_QSORT_RANDOM;
 		}
 
+		if ( isset( $GLOBALS['smwgImportFileDir'] ) ) {
+			$configuration['smwgImportFileDirs'] = (array)$GLOBALS['smwgImportFileDir'];
+		}
+
 		// Deprecated mapping used in DeprecationNoticeTaskHandler to detect and
 		// output notices
 		$GLOBALS['smwgDeprecationNotices'] = array(
@@ -495,6 +499,7 @@ class Settings extends Options {
 				'smwgUseCategoryHierarchy' => 'smwgCategoryFeatures',
 				'smwgQSortingSupport' => 'smwgQSortFeatures',
 				'smwgQRandSortingSupport' => 'smwgQSortFeatures',
+				'smwgImportFileDir' => 'smwgImportFileDirs',
 				'options' => [
 					'smwgCacheUsage' => [
 						'smwgStatisticsCacheExpiry' => 'special.statistics',

--- a/src/Importer/ContentModeller.php
+++ b/src/Importer/ContentModeller.php
@@ -1,0 +1,113 @@
+<?php
+
+namespace SMW\Importer;
+
+/**
+ * @license GNU GPL v2+
+ * @since 3.0
+ *
+ * @author mwjames
+ */
+class ContentModeller {
+
+	/**
+	 * @since 3.0
+	 *
+	 * @param string $fileDir
+	 * @param array $fileContents
+	 *
+	 * @return ImportContents[]|[]
+	 */
+	public function makeContentList( $fileDir, array $fileContents ) {
+
+		$contents = [];
+
+		if ( !isset( $fileContents['import'] ) ) {
+			return $contents;
+		}
+
+		foreach ( $fileContents['import'] as $value ) {
+
+			$importContents = new ImportContents();
+
+			if ( isset( $value['namespace'] ) ) {
+				$importContents->setNamespace(
+					defined( $value['namespace'] ) ? constant( $value['namespace'] ) : 0
+				);
+			}
+
+			if ( isset( $value['page'] ) ) {
+				$importContents->setName( $value['page'] );
+			}
+
+			if ( isset( $value['description'] ) ) {
+				$importContents->setDescription( $value['description'] );
+			} elseif ( isset( $fileContents['description'] ) ) {
+				$importContents->setDescription( $fileContents['description'] );
+			} else {
+				$importContents->setDescription( 'No description' );
+			}
+
+			if ( isset( $fileContents['meta']['version'] ) ) {
+				$importContents->setVersion( $fileContents['meta']['version'] );
+			} else {
+				$importContents->setVersion( 0 );
+			}
+
+			if ( isset( $value['contents']['type'] ) && $value['contents']['type'] === 'xml' ) {
+				$contents[] = $this->newImportContents( $importContents, $fileDir, $value );
+			} else {
+				$contents[] = $this->newImportContents( $importContents, $fileDir, $value );
+			}
+		}
+
+		return $contents;
+	}
+
+	private function newImportContents( $importContents, $fileDir, $value ) {
+
+		$importContents->setContentType( ImportContents::CONTENT_TEXT );
+
+		if ( !isset( $value['contents'] ) || $value['contents'] === '' ) {
+			$importContents->addError( 'Missing, or has empty contents section' );
+		} else {
+			$this->setContents( $importContents, $fileDir, $value['contents'] );
+		}
+
+		if ( isset( $value['options'] ) ) {
+			$importContents->setOptions( $value['options'] );
+		}
+
+		return $importContents;
+	}
+
+	private function setContents( $importContents, $fileDir, $contents ) {
+
+		if ( !is_array( $contents ) || !isset( $contents['importFrom'] ) ) {
+			return $importContents->setContents( $contents );
+		}
+
+		$file = $this->normalizeFile( $fileDir, $contents['importFrom'] );
+
+		if ( !is_readable( $file ) ) {
+			return $importContents->addError( "File: " . $file . " wasn't accessible" );
+		}
+
+		$extension = pathinfo( $file, PATHINFO_EXTENSION );
+
+		if ( isset( $contents['type'] ) && $contents['type'] === 'xml' && $extension !== 'xml' ) {
+			return $importContents->addError( "XML: " . $file . " is not recognized as xml file extension" );
+		}
+
+		if ( $extension === 'xml' ) {
+			$importContents->setContentType( ImportContents::CONTENT_XML );
+		}
+
+		$importContents->setContentsFile( $file );
+	}
+
+	private function normalizeFile( $fileDir, $file ) {
+		return str_replace( [ '\\', '/' ], DIRECTORY_SEPARATOR, $fileDir . ( $file{0} === '/' ? '' : '/' ) . $file );
+	}
+
+}

--- a/src/MediaWiki/Hooks/HookRegistry.php
+++ b/src/MediaWiki/Hooks/HookRegistry.php
@@ -746,7 +746,7 @@ class HookRegistry {
 
 			$importer = $importerServiceFactory->newImporter(
 				$importerServiceFactory->newJsonContentIterator(
-					$applicationFactory->getSettings()->get( 'smwgImportFileDir' )
+					$applicationFactory->getSettings()->get( 'smwgImportFileDirs' )
 				)
 			);
 

--- a/src/Services/ImporterServices.php
+++ b/src/Services/ImporterServices.php
@@ -6,6 +6,7 @@ use SMW\Importer\Importer;
 use SMW\Importer\ContentIterator;
 use SMW\Importer\JsonContentIterator;
 use SMW\Importer\JsonImportContentsFileDirReader;
+use SMW\Importer\ContentModeller;
 use SMW\Importer\ContentCreators\DispatchingContentCreator;
 use SMW\Importer\ContentCreators\XmlContentCreator;
 use SMW\Importer\ContentCreators\TextContentCreator;
@@ -91,11 +92,12 @@ return array(
 	 *
 	 * @return callable
 	 */
-	'JsonContentIterator' => function( $containerBuilder, $importFileDir ) {
+	'JsonContentIterator' => function( $containerBuilder, $importFileDirs ) {
 		$containerBuilder->registerExpectedReturnType( 'JsonContentIterator', '\SMW\Importer\JsonContentIterator' );
 
 		$jsonImportContentsFileDirReader = new JsonImportContentsFileDirReader(
-			$importFileDir
+			new ContentModeller(),
+			$importFileDirs
 		);
 
 		return new JsonContentIterator( $jsonImportContentsFileDirReader );

--- a/tests/phpunit/Integration/Importer/ImporterIntegrationTest.php
+++ b/tests/phpunit/Integration/Importer/ImporterIntegrationTest.php
@@ -35,7 +35,7 @@ class ImporterIntegrationTest extends MwDBaseUnitTestCase {
 	public function testValidTextContent() {
 
 		$importer = $this->importerServiceFactory->newImporter(
-			$this->importerServiceFactory->newJsonContentIterator( $this->fixtures . '/ValidTextContent' )
+			$this->importerServiceFactory->newJsonContentIterator( [ $this->fixtures . '/ValidTextContent' ] )
 		);
 
 		$importer->setMessageReporter( $this->spyMessageReporter );
@@ -59,7 +59,7 @@ class ImporterIntegrationTest extends MwDBaseUnitTestCase {
 		}
 
 		$importer = $this->importerServiceFactory->newImporter(
-			$this->importerServiceFactory->newJsonContentIterator( $this->fixtures . '/ValidXmlContent' )
+			$this->importerServiceFactory->newJsonContentIterator( [ $this->fixtures . '/ValidXmlContent' ] )
 		);
 
 		$importer->setMessageReporter( $this->spyMessageReporter );

--- a/tests/phpunit/Unit/Importer/ContentModellerTest.php
+++ b/tests/phpunit/Unit/Importer/ContentModellerTest.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace SMW\TestsImporter;
+
+use SMW\Importer\ContentModeller;
+use SMW\Tests\TestEnvironment;
+
+/**
+ * @covers \SMW\Importer\ContentModeller
+ * @group semantic-mediawiki
+ *
+ * @license GNU GPL v2+
+ * @since 3.0
+ *
+ * @author mwjames
+ */
+class ContentModellerTest extends \PHPUnit_Framework_TestCase {
+
+	private $contentModeller;
+	private $testEnvironment;
+	private $fixtures;
+
+	protected function setUp() {
+		parent::setUp();
+
+		$this->contentModeller = new ContentModeller();
+
+		$this->testEnvironment = new TestEnvironment();
+		$this->fixtures = __DIR__ . '/Fixtures';
+	}
+
+	public function testCanConstruct() {
+
+		$this->assertInstanceOf(
+			ContentModeller::class,
+			new ContentModeller()
+		);
+	}
+
+	public function testMakeContentList() {
+
+		$contents = [
+			'description' => '...',
+			'import' => [
+				'page' => 'Foo',
+				'version' => 1
+			]
+		];
+
+		$instance = new ContentModeller();
+
+		$contents = $instance->makeContentList( 'Foo', $contents );
+
+		foreach ( $contents as $content ) {
+			$this->assertInstanceOf(
+				'\SMW\Importer\ImportContents',
+				$content
+			);
+		}
+	}
+
+}

--- a/tests/phpunit/Unit/Importer/JsonImportContentsFileDirReaderTest.php
+++ b/tests/phpunit/Unit/Importer/JsonImportContentsFileDirReaderTest.php
@@ -3,6 +3,7 @@
 namespace SMW\TestsImporter;
 
 use SMW\Importer\JsonImportContentsFileDirReader;
+use SMW\Importer\ContentModeller;
 use SMW\Tests\TestEnvironment;
 
 /**
@@ -16,11 +17,14 @@ use SMW\Tests\TestEnvironment;
  */
 class JsonImportContentsFileDirReaderTest extends \PHPUnit_Framework_TestCase {
 
+	private $contentModeller;
 	private $testEnvironment;
 	private $fixtures;
 
 	protected function setUp() {
 		parent::setUp();
+
+		$this->contentModeller = new ContentModeller();
 
 		$this->testEnvironment = new TestEnvironment();
 		$this->fixtures = __DIR__ . '/Fixtures';
@@ -30,14 +34,15 @@ class JsonImportContentsFileDirReaderTest extends \PHPUnit_Framework_TestCase {
 
 		$this->assertInstanceOf(
 			JsonImportContentsFileDirReader::class,
-			new JsonImportContentsFileDirReader( $this->fixtures )
+			new JsonImportContentsFileDirReader( $this->contentModeller, $this->fixtures )
 		);
 	}
 
 	public function testGetContentList() {
 
 		$instance = new JsonImportContentsFileDirReader(
-			$this->fixtures . '/ValidTextContent'
+			$this->contentModeller,
+			[ $this->fixtures . '/ValidTextContent' ]
 		);
 
 		$contents = $instance->getContentList();
@@ -60,7 +65,8 @@ class JsonImportContentsFileDirReaderTest extends \PHPUnit_Framework_TestCase {
 	public function testGetContentListOnFalseImportFormat() {
 
 		$instance = new JsonImportContentsFileDirReader(
-			$this->fixtures . '/NoImportFormat'
+			$this->contentModeller,
+			[ $this->fixtures . '/NoImportFormat' ]
 		);
 
 		$this->assertEmpty(
@@ -71,7 +77,8 @@ class JsonImportContentsFileDirReaderTest extends \PHPUnit_Framework_TestCase {
 	public function testGetContentListOnMissingSections() {
 
 		$instance = new JsonImportContentsFileDirReader(
-			$this->fixtures . '/MissingSections'
+			$this->contentModeller,
+			[ $this->fixtures . '/MissingSections' ]
 		);
 
 		$contents = $instance->getContentList();
@@ -85,7 +92,8 @@ class JsonImportContentsFileDirReaderTest extends \PHPUnit_Framework_TestCase {
 	public function testGetContentListWithInvalidPath() {
 
 		$instance = new JsonImportContentsFileDirReader(
-			__DIR__ . '/InvalidPath'
+			$this->contentModeller,
+			[ __DIR__ . '/InvalidPath' ]
 		);
 
 		$this->assertEmpty(
@@ -96,7 +104,8 @@ class JsonImportContentsFileDirReaderTest extends \PHPUnit_Framework_TestCase {
 	public function testGetContentListOnInvalidJsonThrowsException() {
 
 		$instance = new JsonImportContentsFileDirReader(
-			$this->fixtures . '/InvalidJsonContent'
+			$this->contentModeller,
+			[ $this->fixtures . '/InvalidJsonContent' ]
 		);
 
 		$this->setExpectedException( 'RuntimeException' );

--- a/tests/phpunit/Unit/Services/ImporterServiceFactoryTest.php
+++ b/tests/phpunit/Unit/Services/ImporterServiceFactoryTest.php
@@ -60,7 +60,7 @@ class ImporterServiceFactoryTest extends \PHPUnit_Framework_TestCase {
 
 		$this->containerBuilder->registerObject( 'Settings', new Settings( array(
 			'smwgImportReqVersion' => 1,
-			'smwgImportFileDir' => 'foo'
+			'smwgImportFileDirs' => 'foo'
 		) ) );
 
 		$this->containerBuilder->registerFromFile( $GLOBALS['smwgServicesFileDir'] . '/' . 'ImporterServices.php' );

--- a/tests/phpunit/Unit/Services/ImporterServicesContainerBuildTest.php
+++ b/tests/phpunit/Unit/Services/ImporterServicesContainerBuildTest.php
@@ -56,7 +56,7 @@ class ImporterServicesContainerBuildTest extends \PHPUnit_Framework_TestCase {
 
 		$containerBuilder->registerObject( 'Settings', new Settings( array(
 			'smwgImportReqVersion' => 1,
-			'smwgImportFileDir' => 'foo'
+			'smwgImportFileDirs' => [ 'foo' ]
 		) ) );
 
 		$containerBuilder->registerFromFile( $this->servicesFileDir . '/' . 'ImporterServices.php' );


### PR DESCRIPTION
This PR is made in reference to: #

This PR addresses or contains:

- Renames `smwgImportFileDir` to `smwgImportFileDirs` and uses an array instead of a simple string
- Moves content modelling from `JsonImportContentsFileDirReader` to its own class

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed
