### PR TITLE
Add reserved name list for properties, refs 2835

### DIFF
--- a/DefaultSettings.php
+++ b/DefaultSettings.php
@@ -1564,6 +1564,26 @@ return array(
 	##
 
 	##
+	# Reserved property names
+	#
+	# Listed names are reserved as they may interfere with Semantic MediaWiki or
+	# MediaWiki itself.
+	#
+	# Removing default names from the list is not recommended (extending the list
+	# is supported and may be used to customize use cases for an individual wiki).
+	#
+	# The list can contain simple names or identifiers that start with
+	# `smw-property-reserved-` to link to a translatable representation that
+	# matches a string in a content language.
+	#
+	# @see #2835, #2840
+	#
+	# @since 3.0
+	##
+	'smwgPropertyReservedNameList' => array( 'Category', 'smw-property-reserved-category' ),
+	##
+
+	##
 	# Entity specific collation
 	#
 	# This should correspond to the $wgCategoryCollation setting (also in regards

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -159,6 +159,7 @@
 	"smw_propertylackstype": "No type was specified for this property (assuming type $1 for now).",
 	"smw_propertyhardlyused": "This property is hardly used within the wiki!",
 	"smw-property-name-invalid": "Property $1 can not be used (invalid property name).",
+	"smw-property-name-reserved": "\"$1\" was listed as reserved name and should not be used as a property. The following [https://www.semantic-mediawiki.org/wiki/Help:Property_naming help page] may contain information as to why this name was reserved.",
 	"smw-sp-property-searchform": "Display properties that contain:",
 	"smw-sp-property-searchform-inputinfo": "The input is case sensitive and when used for filtering, only properties that match the condition are displayed.",
 	"smw-special-property-searchform": "Display properties that contain:",
@@ -637,5 +638,6 @@
 	"smw-api-smwbrowse-invalid-parameters": "Parameters format is invalid, expected a valid JSON format.",
 	"smw-parser-recursion-level-exceeded": "The level of $1 recursions was exceeded during a parse process. It is suggested to validated the template structure, or if necessary adjust configuration parameter <code>$maxRecursionDepth</code>.",
 	"smw-property-page-list-count": "Showing $1 {{PLURAL:$1|page|pages}} using this property.",
-	"smw-property-page-list-search-count": "Showing $1 {{PLURAL:$1|page|pages}} using this property with a \"$2\" value match."
+	"smw-property-page-list-search-count": "Showing $1 {{PLURAL:$1|page|pages}} using this property with a \"$2\" value match.",
+	"smw-property-reserved-category": "Category"
 }

--- a/i18n/ja.json
+++ b/i18n/ja.json
@@ -366,5 +366,6 @@
 	"smw-format-datatable-previous": "前",
 	"smw-format-datatable-sortascending": ": 列を昇順に並べ替えるにはアクティブにする",
 	"smw-format-datatable-sortdescending": ": 列を降順に並べ替えるにはアクティブにする",
-	"smw-format-datatable-toolbar-export": "エクスポート"
+	"smw-format-datatable-toolbar-export": "エクスポート",
+	"smw-property-reserved-category": "カテゴリ"
 }

--- a/includes/Settings.php
+++ b/includes/Settings.php
@@ -166,6 +166,7 @@ class Settings extends Options {
 			'smwgCreateProtectionRight' => $GLOBALS['smwgCreateProtectionRight'],
 			'smwgSimilarityLookupExemptionProperty' => $GLOBALS['smwgSimilarityLookupExemptionProperty'],
 			'smwgPropertyInvalidCharacterList' => $GLOBALS['smwgPropertyInvalidCharacterList'],
+			'smwgPropertyReservedNameList' => $GLOBALS['smwgPropertyReservedNameList'],
 			'smwgEntityCollation' => $GLOBALS['smwgEntityCollation'],
 			'smwgEntityLookupFeatures' => $GLOBALS['smwgEntityLookupFeatures'],
 			'smwgFieldTypeFeatures' => $GLOBALS['smwgFieldTypeFeatures'],

--- a/src/Page/PageFactory.php
+++ b/src/Page/PageFactory.php
@@ -79,6 +79,10 @@ class PageFactory {
 			$propertySpecificationReqExaminer
 		);
 
+		$propertySpecificationReqMsgBuilder->setPropertyReservedNameList(
+			$settings->get( 'smwgPropertyReservedNameList' )
+		);
+
 		$propertyPage = new PropertyPage(
 			$title,
 			$this->store,

--- a/tests/phpunit/Integration/JSONScript/TestCases/p-0111.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/p-0111.json
@@ -1,0 +1,35 @@
+{
+	"description": "Test reserved property names",
+	"setup": [
+		{
+			"namespace": "SMW_NS_PROPERTY",
+			"page": "Category",
+			"contents": "[[Has type::Page]]"
+		}
+	],
+	"tests": [
+		{
+			"type": "parser",
+			"about": "#0 reserved category name",
+			"namespace": "SMW_NS_PROPERTY",
+			"subject": "Category",
+			"assert-output": {
+				"onPageView": {},
+				"to-contain": [
+					"<div id=\"smw-property-name-reserved\" class=\"plainlinks smw-callout smw-callout-error\">"
+				]
+			}
+		}
+	],
+	"settings": {
+		"wgContLang": "en",
+		"smwgPageSpecialProperties": [
+			"_MDAT"
+		]
+	},
+	"meta": {
+		"version": "2",
+		"is-incomplete": false,
+		"debug": false
+	}
+}

--- a/tests/phpunit/Unit/PropertySpecificationReqMsgBuilderTest.php
+++ b/tests/phpunit/Unit/PropertySpecificationReqMsgBuilderTest.php
@@ -115,6 +115,31 @@ class PropertySpecificationReqMsgBuilderTest extends \PHPUnit_Framework_TestCase
 		);
 	}
 
+	public function testCheckReservedName() {
+
+		$instance = new PropertySpecificationReqMsgBuilder(
+			$this->store,
+			$this->propertySpecificationReqExaminer
+		);
+
+		$instance->setPropertyReservedNameList(
+			[
+				'Bar'
+			]
+		);
+
+		$dataItemFactory = new DataItemFactory();
+
+		$instance->checkOn(
+			$dataItemFactory->newDIProperty( 'Bar' )
+		);
+
+		$this->assertContains(
+			'smw-property-name-reserved',
+			$instance->getMessage()
+		);
+	}
+
 	public function propertyProvider() {
 
 		$dataItemFactory = new DataItemFactory();


### PR DESCRIPTION
This PR is made in reference to: #2835

This PR addresses or contains:

- Adds the `smwgPropertyReservedNameList` setting to list reserved names either as simple string or translatable representation using `smw-property-reserved-...`
- The creation isn't blocked and a reserved property can still be used but the following message will appear on the property page for a matchable name.

![image](https://user-images.githubusercontent.com/1245473/33229184-fd029426-d20c-11e7-9ae1-e83ee973922b.png)

![image](https://user-images.githubusercontent.com/1245473/33229143-2469b874-d20c-11e7-9cd6-c274bbf8baf5.png)

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed

Fixes #