### PR TITLE
Replace `smwgLinksInValues` setting, refs 2802

### DIFF
--- a/DefaultSettings.php
+++ b/DefaultSettings.php
@@ -302,33 +302,6 @@ return array(
 	##
 
 	###
-	# InText annotation to support "links in value"
-	#
-	# SMW_LINV_OBFU (2.5+)
-	#
-	# Parse [[SomeProperty::Foo [[link]] in [[Bar::AnotherValue]]]] annotation
-	# using a non-PCRE approach and hereby avoids potential PHP crashes caused
-	# by PCRE OOM.
-	#
-	# SMW_LINV_PCRE (1.3+)
-	#
-	# Should SMW accept inputs like [[property::Some [[link]] in value]]? If
-	# enabled, this may lead to PHP crashes (!) when very long texts are used as
-	# values. This is due to limitations in the library PCRE that PHP uses for
-	# pattern matching. The provoked PHP crashes will prevent requests from being
-	# completed -- usually clients will receive server errors ("invalid response")
-	# or be offered to download "index.php". It might be okay to enable this if
-	# such problems are not observed in your wiki.
-	#
-	# To enable this feature use either SMW_LINV_PCRE (for BC) or SMW_LINV_OBFU.
-	#
-	# @since 1.3
-	# @default false
-	##
-	'smwgLinksInValues' => false,
-	##
-
-	###
 	# Settings for recurring events, created with the 	#set_recurring_event parser
 	# function: the default number of instances defined, if no end date is set,
 	# and the maximum number that can be defined, regardless of end date.
@@ -1215,6 +1188,10 @@ return array(
 	#   __HIDDENCAT__) from the annotation process. Changing the setting requires
 	#   to run a full rebuild to ensure hidden categories are discarded during
 	#   the parsing process. (was $smwgShowHiddenCategories 1.9)
+	#
+	# - SMW_PARSER_LINV: Support parsing of "links in values" for annotations like
+	#   [[SomeProperty::Foo [[link]] in [[Bar::AnotherValue]]]] (was $smwgLinksInValues
+	#   with SMW_LINV_OBFU, SMW_LINV_PCRE is no longer available)
 	#
 	# @since 3.0
 	##

--- a/includes/Settings.php
+++ b/includes/Settings.php
@@ -67,7 +67,6 @@ class Settings extends Options {
 			'smwgNamespaceIndex' => $GLOBALS['smwgNamespaceIndex'],
 			'smwgShowFactbox' => $GLOBALS['smwgShowFactbox'],
 			'smwgShowFactboxEdit' => $GLOBALS['smwgShowFactboxEdit'],
-			'smwgLinksInValues' => $GLOBALS['smwgLinksInValues'],
 			'smwgDefaultNumRecurringEvents' => $GLOBALS['smwgDefaultNumRecurringEvents'],
 			'smwgMaxNumRecurringEvents' => $GLOBALS['smwgMaxNumRecurringEvents'],
 			'smwgSearchByPropertyFuzzy' => $GLOBALS['smwgSearchByPropertyFuzzy'],
@@ -324,6 +323,19 @@ class Settings extends Options {
 			$configuration['smwgParserFeatures'] = $configuration['smwgParserFeatures'] & ~SMW_PARSER_HID_CATS;
 		}
 
+		// smwgLinksInValues
+		if ( isset( $GLOBALS['smwgLinksInValues'] ) && $GLOBALS['smwgLinksInValues'] === SMW_LINV_PCRE ) {
+			$configuration['smwgParserFeatures'] = $configuration['smwgParserFeatures'] | SMW_PARSER_LINV;
+		}
+
+		if ( isset( $GLOBALS['smwgLinksInValues'] ) && $GLOBALS['smwgLinksInValues'] === SMW_LINV_OBFU ) {
+			$configuration['smwgParserFeatures'] = $configuration['smwgParserFeatures'] | SMW_PARSER_LINV;
+		}
+
+		if ( isset( $GLOBALS['smwgLinksInValues'] ) && $GLOBALS['smwgLinksInValues'] === true ) {
+			$configuration['smwgParserFeatures'] = $configuration['smwgParserFeatures'] | SMW_PARSER_LINV;
+		}
+
 		// smwgCategoryFeatures
 		if ( isset( $GLOBALS['smwgUseCategoryRedirect'] ) && $GLOBALS['smwgUseCategoryRedirect'] === false ) {
 			$configuration['smwgCategoryFeatures'] = $configuration['smwgCategoryFeatures'] & ~SMW_CAT_REDIRECT;
@@ -462,6 +474,7 @@ class Settings extends Options {
 				'smwgUseCategoryHierarchy' => '3.1.0',
 				'smwgQSortingSupport' => '3.1.0',
 				'smwgQRandSortingSupport' => '3.1.0',
+				'smwgLinksInValues' => '3.1.0',
 				'options' => [
 					'smwgCacheUsage' =>  [
 						'smwgStatisticsCache' => '3.1.0',
@@ -495,6 +508,7 @@ class Settings extends Options {
 				'smwgEnabledInTextAnnotationParserStrictMode' => 'smwgParserFeatures',
 				'smwgInlineErrors' => 'smwgParserFeatures',
 				'smwgShowHiddenCategories' => 'smwgParserFeatures',
+				'smwgLinksInValues' => 'smwgParserFeatures',
 				'smwgUseCategoryRedirect' => 'smwgCategoryFeatures',
 				'smwgCategoriesAsInstances' => 'smwgCategoryFeatures',
 				'smwgUseCategoryHierarchy' => 'smwgCategoryFeatures',

--- a/includes/datavalues/SMW_DV_WikiPage.php
+++ b/includes/datavalues/SMW_DV_WikiPage.php
@@ -103,7 +103,7 @@ class SMWWikiPageValue extends SMWDataValue {
 		global $wgContLang;
 
 		// support inputs like " [[Test]] ";
-		// note that this only works in pages if $smwgLinksInValues is set to true
+		// note that this only works when SMW_PARSER_LINV is set
 		$value = ltrim( rtrim( $value, ' ]' ), ' [' );
 
 		// #1066, Manipulate the output only for when the value has no caption

--- a/src/ApplicationFactory.php
+++ b/src/ApplicationFactory.php
@@ -325,11 +325,8 @@ class ApplicationFactory {
 			$mwCollaboratorFactory->newRedirectTargetFinder()
 		);
 
-		// 2.5+ Changed modus operandi
-		$linksInValues = $this->getSettings()->get( 'smwgLinksInValues' );
-
-		$inTextAnnotationParser->enabledLinksInValues(
-			$linksInValues === true ? SMW_LINV_PCRE : $linksInValues
+		$inTextAnnotationParser->isLinksInValues(
+			$this->getSettings()->isFlagSet( 'smwgParserFeatures', SMW_PARSER_LINV )
 		);
 
 		$inTextAnnotationParser->showErrors(

--- a/src/Defines.php
+++ b/src/Defines.php
@@ -194,13 +194,6 @@ define( 'SMW_ADM_FULLT', 32 ); // Fulltext update
 /**@}*/
 
 /**@{
-  * Constants for LinksInValue features
-  */
-define( 'SMW_LINV_PCRE', 2 ); // Using the PCRE approach
-define( 'SMW_LINV_OBFU', 4 ); // Using the Obfuscator approach
-/**@}*/
-
-/**@{
   * Constants for ResultPrinter
   */
 define( 'SMW_RF_NONE', 0 );
@@ -248,6 +241,15 @@ define( 'SMW_PARSER_STRICT', 2 ); // Support for strict mode
 define( 'SMW_PARSER_UNSTRIP', 4 ); // Support for using the StripMarkerDecoder
 define( 'SMW_PARSER_INL_ERROR', 8 ); // Support for display of inline errors
 define( 'SMW_PARSER_HID_CATS', 16 ); // Support for parsing hidden categories
+define( 'SMW_PARSER_LINV', 32 ); // Support for links in value
+define( 'SMW_PARSER_LINKS_IN_VALUES', 32 ); // Support for links in value
+/**@}*/
+
+/**@{
+  * Constants for LinksInValue features
+  */
+define( 'SMW_LINV_PCRE', 2 ); // Using the PCRE approach
+define( 'SMW_LINV_OBFU', 4 ); // Using the Obfuscator approach
 /**@}*/
 
 /**@{

--- a/src/Parser/InTextAnnotationParser.php
+++ b/src/Parser/InTextAnnotationParser.php
@@ -87,7 +87,7 @@ class InTextAnnotationParser {
 	/**
 	 * @var boolean|integer
 	 */
-	private $enabledLinksInValues = false;
+	private $isLinksInValues = false;
 
 	/**
 	 * @var boolean
@@ -114,10 +114,10 @@ class InTextAnnotationParser {
 	/**
 	 * @since 2.5
 	 *
-	 * @param boolean $enabledLinksInValues
+	 * @param boolean $isLinksInValues
 	 */
-	public function enabledLinksInValues( $enabledLinksInValues ) {
-		$this->enabledLinksInValues = $enabledLinksInValues;
+	public function isLinksInValues( $isLinksInValues ) {
+		$this->isLinksInValues = $isLinksInValues;
 	}
 
 	/**
@@ -154,13 +154,14 @@ class InTextAnnotationParser {
 		);
 
 		// Obscure [/] to find a set of [[ :: ... ]] while those in-between are left for
-		// decoding for a later processing so that the regex can split the text
+		// decoding in a post-processing so that the regex can split the text
 		// appropriately
-		if ( ( $this->enabledLinksInValues & SMW_LINV_OBFU ) != 0 ) {
+		if ( $this->isLinksInValues ) {
 			$text = Obfuscator::obfuscateLinks( $text, $this );
 		}
 
-		$linksInValuesPcre = ( $this->enabledLinksInValues & SMW_LINV_PCRE ) != 0;
+		// No longer used with 3.0 given that the Obfuscator is safer and faster
+		$linksInValuesPcre = false;
 
 		$text = preg_replace_callback(
 			$this->getRegexpPattern( $linksInValuesPcre ),

--- a/tests/phpunit/Integration/JSONScript/TestCases/p-0102.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/p-0102.json
@@ -221,7 +221,11 @@
 	],
 	"settings": {
 		"wgContLang": "en",
-		"smwgLinksInValues": false,
+		"smwgParserFeatures": [
+			"SMW_PARSER_STRICT",
+			"SMW_PARSER_INL_ERROR",
+			"SMW_PARSER_HID_CATS"
+		],
 		"smwgPageSpecialProperties": [
 			"_MDAT"
 		]

--- a/tests/phpunit/Integration/JSONScript/TestCases/p-0433.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/p-0433.json
@@ -1,5 +1,5 @@
 {
-	"description": "Test in-text annotation `::` with left pipe (#1747, `wgContLang=en`, `smwgLinksInValues=false`)",
+	"description": "Test in-text annotation `::` with left pipe (#1747, `wgContLang=en`)",
 	"setup": [
 		{
 			"namespace": "SMW_NS_PROPERTY",
@@ -70,7 +70,11 @@
 	],
 	"settings": {
 		"wgContLang": "en",
-		"smwgLinksInValues": false,
+		"smwgParserFeatures": [
+			"SMW_PARSER_STRICT",
+			"SMW_PARSER_INL_ERROR",
+			"SMW_PARSER_HID_CATS"
+		],
 		"smwgPageSpecialProperties": [
 			"_MDAT"
 		]

--- a/tests/phpunit/Integration/JSONScript/TestCases/p-0444.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/p-0444.json
@@ -1,5 +1,5 @@
 {
-	"description": "Test in-text annotation LinksInValue `SMW_LINV_OBFU` (#2153, `wgContLang=en`, `smwgLinksInValues=SMW_LINV_OBFU`)",
+	"description": "Test in-text annotation with links in values (#2153, `wgContLang=en`)",
 	"setup": [
 		{
 			"namespace": "SMW_NS_PROPERTY",
@@ -160,7 +160,12 @@
 	],
 	"settings": {
 		"wgContLang": "en",
-		"smwgLinksInValues": "SMW_LINV_OBFU",
+		"smwgParserFeatures": [
+			"SMW_PARSER_STRICT",
+			"SMW_PARSER_INL_ERROR",
+			"SMW_PARSER_HID_CATS",
+			"SMW_PARSER_LINV"
+		],
 		"smwgPageSpecialProperties": [
 			"_MDAT"
 		]

--- a/tests/phpunit/Integration/JSONScript/TestCases/p-0448.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/p-0448.json
@@ -1,5 +1,5 @@
 {
-	"description": "Test in-text legacy `:=` annotation style (#2153, `wgContLang=en`, `smwgLinksInValues=false`)",
+	"description": "Test in-text legacy `:=` annotation style (#2153, `wgContLang=en`)",
 	"setup": [
 		{
 			"namespace": "SMW_NS_PROPERTY",
@@ -34,7 +34,11 @@
 	],
 	"settings": {
 		"wgContLang": "en",
-		"smwgLinksInValues": false,
+		"smwgParserFeatures": [
+			"SMW_PARSER_STRICT",
+			"SMW_PARSER_INL_ERROR",
+			"SMW_PARSER_HID_CATS"
+		],
 		"smwgPageSpecialProperties": [
 			"_MDAT"
 		]

--- a/tests/phpunit/Integration/JSONScript/TestCases/p-0449.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/p-0449.json
@@ -1,5 +1,5 @@
 {
-	"description": "Test in-text legacy `:=` and `::` annotation style with enabled LinksInValue (#2153, `wgContLang=en`, `smwgLinksInValues=SMW_LINV_OBFU`)",
+	"description": "Test in-text legacy `:=` and `::` annotation style with enabled links in values (#2153, `wgContLang=en`)",
 	"setup": [
 		{
 			"namespace": "SMW_NS_PROPERTY",
@@ -138,7 +138,12 @@
 	],
 	"settings": {
 		"wgContLang": "en",
-		"smwgLinksInValues": "SMW_LINV_OBFU",
+		"smwgParserFeatures": [
+			"SMW_PARSER_STRICT",
+			"SMW_PARSER_INL_ERROR",
+			"SMW_PARSER_HID_CATS",
+			"SMW_PARSER_LINV"
+		],
 		"smwgPageSpecialProperties": [
 			"_MDAT"
 		]

--- a/tests/phpunit/Integration/JSONScript/TestCases/p-0454.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/p-0454.json
@@ -1,5 +1,5 @@
 {
-	"description": "Test in-text annotation with enabled LinksInValue on `&#91;`, `&#93;` (#2671, `wgContLang=en`, `smwgLinksInValues=SMW_LINV_OBFU`)",
+	"description": "Test in-text annotation with enabled links in values on `&#91;`, `&#93;` (#2671, `wgContLang=en`)",
 	"setup": [
 		{
 			"namespace": "SMW_NS_PROPERTY",
@@ -30,7 +30,12 @@
 	"settings": {
 		"wgContLang": "en",
 		"wgLang": "en",
-		"smwgLinksInValues": "SMW_LINV_OBFU",
+		"smwgParserFeatures": [
+			"SMW_PARSER_STRICT",
+			"SMW_PARSER_INL_ERROR",
+			"SMW_PARSER_HID_CATS",
+			"SMW_PARSER_LINV"
+		],
 		"smwgPageSpecialProperties": [
 			"_MDAT"
 		],

--- a/tests/phpunit/Integration/JSONScript/TestCases/p-0913.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/p-0913.json
@@ -1,5 +1,5 @@
 {
-	"description": "Test `#ask` with (`#-ia`) formatter using `smwgLinksInValues` (#..., `wgContLang=en`, `wgLang=en`, `smwgLinksInValues=SMW_LINV_OBFU`)",
+	"description": "Test `#ask` with (`#-ia`) formatter with links in values (#..., `wgContLang=en`, `wgLang=en`)",
 	"setup": [
 		{
 			"namespace": "SMW_NS_PROPERTY",
@@ -89,7 +89,12 @@
 	"settings": {
 		"wgContLang": "en",
 		"wgLang": "en",
-		"smwgLinksInValues": "SMW_LINV_OBFU",
+		"smwgParserFeatures": [
+			"SMW_PARSER_STRICT",
+			"SMW_PARSER_INL_ERROR",
+			"SMW_PARSER_HID_CATS",
+			"SMW_PARSER_LINV"
+		],
 		"smwgPageSpecialProperties": [
 			"_MDAT"
 		],

--- a/tests/phpunit/JsonTestCaseFileHandler.php
+++ b/tests/phpunit/JsonTestCaseFileHandler.php
@@ -267,11 +267,6 @@ class JsonTestCaseFileHandler {
 		}
 
 		// Needs special attention due to constant usage
-		if ( $key === 'smwgLinksInValues' && isset( $settings[$key] ) ) {
-			return is_string( $settings[$key] ) ? constant( $settings[$key] ) : $settings[$key];
-		}
-
-		// Needs special attention due to constant usage
 		if ( strpos( $key, 'CacheType' ) !== false && isset( $settings[$key] ) ) {
 			return $settings[$key] === false ? CACHE_NONE : defined( $settings[$key] ) ? constant( $settings[$key] ) : $settings[$key];
 		}

--- a/tests/phpunit/Unit/Factbox/CachedFactboxTest.php
+++ b/tests/phpunit/Unit/Factbox/CachedFactboxTest.php
@@ -35,8 +35,7 @@ class CachedFactboxTest extends \PHPUnit_Framework_TestCase {
 		$this->testEnvironment->withConfiguration(
 			[
 				'smwgFactboxUseCache' => true,
-				'smwgCacheType'       => 'hash',
-				'smwgLinksInValues'   => false
+				'smwgCacheType'       => 'hash'
 			]
 		);
 	}

--- a/tests/phpunit/Unit/Factbox/FactboxMagicWordsTest.php
+++ b/tests/phpunit/Unit/Factbox/FactboxMagicWordsTest.php
@@ -52,8 +52,7 @@ class FactboxMagicWordsTest extends \PHPUnit_Framework_TestCase {
 		$this->testEnvironment->withConfiguration(
 			[
 				'smwgNamespacesWithSemanticLinks' => array( $title->getNamespace() => true ),
-				'smwgParserFeatures' => SMW_PARSER_STRICT | SMW_PARSER_INL_ERROR,
-				'smwgLinksInValues' => false,
+				'smwgParserFeatures' => SMW_PARSER_STRICT | SMW_PARSER_INL_ERROR
 			]
 		);
 

--- a/tests/phpunit/Unit/MediaWiki/Hooks/ArticlePurgeTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Hooks/ArticlePurgeTest.php
@@ -31,8 +31,7 @@ class ArticlePurgeTest extends \PHPUnit_Framework_TestCase {
 
 		$settings = array(
 			'smwgFactboxUseCache' => true,
-			'smwgCacheType'       => 'hash',
-			'smwgLinksInValues'   => false
+			'smwgCacheType'       => 'hash'
 		);
 
 		$this->testEnvironment = new TestEnvironment( $settings );

--- a/tests/phpunit/Unit/MediaWiki/Hooks/InternalParseBeforeLinksTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Hooks/InternalParseBeforeLinksTest.php
@@ -350,8 +350,7 @@ class InternalParseBeforeLinksTest extends \PHPUnit_Framework_TestCase {
 				'title'    => $title,
 				'settings' => array(
 					'smwgNamespacesWithSemanticLinks' => array( NS_MAIN => true ),
-					'smwgParserFeatures' => SMW_PARSER_STRICT,
-					'smwgLinksInValues' => false,
+					'smwgParserFeatures' => SMW_PARSER_STRICT
 				),
 				'text'  => 'Lorem ipsum dolor sit &$% [[FooBar::dictumst|寒い]]' .
 					' [[Bar::tincidunt semper]] facilisi {{volutpat}} Ut quis' .
@@ -373,8 +372,7 @@ class InternalParseBeforeLinksTest extends \PHPUnit_Framework_TestCase {
 				'title'    => $title,
 				'settings' => array(
 					'smwgNamespacesWithSemanticLinks' => array( NS_MAIN => true ),
-					'smwgParserFeatures' => SMW_PARSER_STRICT,
-					'smwgLinksInValues' => false,
+					'smwgParserFeatures' => SMW_PARSER_STRICT
 				),
 				'text'  => '#REDIRECT [[Foo]]',
 				),
@@ -395,7 +393,6 @@ class InternalParseBeforeLinksTest extends \PHPUnit_Framework_TestCase {
 				'settings' => array(
 					'smwgNamespacesWithSemanticLinks' => array( NS_MAIN => true ),
 					'smwgParserFeatures' => SMW_PARSER_STRICT,
-					'smwgLinksInValues' => false,
 					'smwgEnabledSpecialPage' => array( 'Ask', 'Foo' )
 				),
 				'text'  => 'Lorem ipsum dolor sit &$% [[FooBar::dictumst|寒い]]' .
@@ -419,7 +416,6 @@ class InternalParseBeforeLinksTest extends \PHPUnit_Framework_TestCase {
 				'settings' => array(
 					'smwgNamespacesWithSemanticLinks' => array( NS_MAIN => true ),
 					'smwgParserFeatures' => SMW_PARSER_STRICT,
-					'smwgLinksInValues' => false,
 					'smwgEnabledSpecialPage' => array( 'Ask', 'Foo' )
 				),
 				'text'  => 'Lorem ipsum dolor sit &$% [[FooBar::dictumst|寒い]]' .
@@ -443,7 +439,6 @@ class InternalParseBeforeLinksTest extends \PHPUnit_Framework_TestCase {
 				'settings' => array(
 					'smwgNamespacesWithSemanticLinks' => array( NS_MAIN => true ),
 					'smwgParserFeatures' => SMW_PARSER_STRICT,
-					'smwgLinksInValues' => false,
 					'smwgEnabledSpecialPage' => []
 				),
 				'text'  => 'Lorem ipsum dolor sit &$% [[FooBar::dictumst|寒い]]' .

--- a/tests/phpunit/Unit/MediaWiki/Hooks/OutputPageParserOutputTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Hooks/OutputPageParserOutputTest.php
@@ -35,8 +35,7 @@ class OutputPageParserOutputTest extends \PHPUnit_Framework_TestCase {
 			[
 				'smwgShowFactbox'      => SMW_FACTBOX_NONEMPTY,
 				'smwgFactboxUseCache'  => true,
-				'smwgCacheType'        => 'hash',
-				'smwgLinksInValues'    => false
+				'smwgCacheType'        => 'hash'
 			]
 		);
 	}

--- a/tests/phpunit/Unit/Parser/InTextAnnotationParserTest.php
+++ b/tests/phpunit/Unit/Parser/InTextAnnotationParserTest.php
@@ -143,8 +143,8 @@ class InTextAnnotationParserTest extends \PHPUnit_Framework_TestCase {
 			isset( $settings['smwgParserFeatures'] ) ? $settings['smwgParserFeatures'] : true
 		);
 
-		$instance->enabledLinksInValues(
-			isset( $settings['smwgLinksInValues'] ) ? $settings['smwgLinksInValues'] : true
+		$instance->isLinksInValues(
+			( ( $settings['smwgParserFeatures'] & SMW_PARSER_LINV ) == SMW_PARSER_LINV )
 		);
 
 		$this->testEnvironment->withConfiguration(
@@ -177,7 +177,6 @@ class InTextAnnotationParserTest extends \PHPUnit_Framework_TestCase {
 
 		$settings = array(
 			'smwgNamespacesWithSemanticLinks' => array( $namespace => true ),
-			'smwgLinksInValues' => false,
 			'smwgParserFeatures' => SMW_PARSER_INL_ERROR,
 		);
 
@@ -221,7 +220,6 @@ class InTextAnnotationParserTest extends \PHPUnit_Framework_TestCase {
 
 		$settings = array(
 			'smwgNamespacesWithSemanticLinks' => array( $namespace => true ),
-			'smwgLinksInValues' => false,
 			'smwgParserFeatures' => SMW_PARSER_INL_ERROR,
 		);
 
@@ -381,7 +379,6 @@ class InTextAnnotationParserTest extends \PHPUnit_Framework_TestCase {
 			NS_MAIN,
 			array(
 				'smwgNamespacesWithSemanticLinks' => array( NS_MAIN => true ),
-				'smwgLinksInValues' => false,
 				'smwgParserFeatures' => SMW_PARSER_INL_ERROR,
 			),
 			'Lorem ipsum dolor sit &$% consectetuer auctor at quis' .
@@ -399,13 +396,12 @@ class InTextAnnotationParserTest extends \PHPUnit_Framework_TestCase {
 			)
 		);
 
-		// #1 NS_MAIN; [[FooBar...]] with a different caption and smwgLinksInValues = true
+		// #1 NS_MAIN; [[FooBar...]] with a different caption and enabled SMW_PARSER_LINV
 		$provider[] = array(
 			NS_MAIN,
 			array(
 				'smwgNamespacesWithSemanticLinks' => array( NS_MAIN => true ),
-				'smwgLinksInValues' => SMW_LINV_PCRE,
-				'smwgParserFeatures' => SMW_PARSER_INL_ERROR,
+				'smwgParserFeatures' => SMW_PARSER_INL_ERROR | SMW_PARSER_LINV,
 			),
 			'Lorem ipsum dolor sit &$% consectetuer auctor at quis' .
 			' [[FooBar::dictumst|寒い]] cursus. Nisl sit condimentum Quisque facilisis' .
@@ -429,7 +425,6 @@ class InTextAnnotationParserTest extends \PHPUnit_Framework_TestCase {
 			NS_MAIN,
 			array(
 				'smwgNamespacesWithSemanticLinks' => array( NS_MAIN => true ),
-				'smwgLinksInValues' => false,
 				'smwgParserFeatures' => SMW_PARSER_INL_ERROR,
 			),
 			'Lorem ipsum dolor sit &$% consectetuer auctor at quis' .
@@ -450,7 +445,6 @@ class InTextAnnotationParserTest extends \PHPUnit_Framework_TestCase {
 			NS_MAIN,
 			array(
 				'smwgNamespacesWithSemanticLinks' => array( NS_MAIN => true ),
-				'smwgLinksInValues' => false,
 				'smwgParserFeatures' => SMW_PARSER_NONE,
 			),
 			'Lorem ipsum dolor sit &$% consectetuer auctor at quis' .
@@ -474,7 +468,6 @@ class InTextAnnotationParserTest extends \PHPUnit_Framework_TestCase {
 			NS_HELP,
 			array(
 				'smwgNamespacesWithSemanticLinks' => array( NS_HELP => false ),
-				'smwgLinksInValues' => false,
 				'smwgParserFeatures' => SMW_PARSER_INL_ERROR,
 			),
 			'Lorem ipsum dolor sit &$% consectetuer auctor at quis' .
@@ -497,7 +490,6 @@ class InTextAnnotationParserTest extends \PHPUnit_Framework_TestCase {
 			NS_HELP,
 			array(
 				'smwgNamespacesWithSemanticLinks' => array( NS_HELP => true ),
-				'smwgLinksInValues' => false,
 				'smwgParserFeatures' => SMW_PARSER_INL_ERROR,
 			),
 			'Lorem ipsum dolor sit &$% consectetuer auctor at quis' .
@@ -516,7 +508,6 @@ class InTextAnnotationParserTest extends \PHPUnit_Framework_TestCase {
 			NS_MAIN,
 			array(
 				'smwgNamespacesWithSemanticLinks' => array( NS_MAIN => true ),
-				'smwgLinksInValues' => false,
 				'smwgParserFeatures' => SMW_PARSER_INL_ERROR,
 			),
 			'[[Foo::?bar]], [[Foo::Baz?]], [[Quxey::B?am]]',
@@ -537,7 +528,6 @@ class InTextAnnotationParserTest extends \PHPUnit_Framework_TestCase {
 			SMW_NS_PROPERTY,
 			array(
 				'smwgNamespacesWithSemanticLinks' => array( SMW_NS_PROPERTY => true ),
-				'smwgLinksInValues' => false,
 				'smwgParserFeatures' => SMW_PARSER_INL_ERROR,
 			),
 			'[[has type::number]], [[has Type::page]] ',
@@ -554,7 +544,6 @@ class InTextAnnotationParserTest extends \PHPUnit_Framework_TestCase {
 			NS_MAIN,
 			array(
 				'smwgNamespacesWithSemanticLinks' => array( NS_MAIN => true ),
-				'smwgLinksInValues' => false,
 				'smwgParserFeatures' => SMW_PARSER_INL_ERROR,
 			),
 			'[[Foo::Bar::Foobar]], [[IPv6::fc00:123:8000::/64]] [[ABC::10.1002/::AID-MRM16::]]',
@@ -571,7 +560,6 @@ class InTextAnnotationParserTest extends \PHPUnit_Framework_TestCase {
 			NS_MAIN,
 			array(
 				'smwgNamespacesWithSemanticLinks' => array( NS_MAIN => true ),
-				'smwgLinksInValues' => false,
 				'smwgParserFeatures' => SMW_PARSER_INL_ERROR,
 			),
 			'[[Foo:::Foobar]] [[Bar:::ABC|DEF]] [[Foo:::0049 30 12345678/::Foo]] ',
@@ -588,7 +576,6 @@ class InTextAnnotationParserTest extends \PHPUnit_Framework_TestCase {
 			NS_MAIN,
 			array(
 				'smwgNamespacesWithSemanticLinks' => array( NS_MAIN => true ),
-				'smwgLinksInValues' => false,
 				'smwgParserFeatures' => SMW_PARSER_NONE
 			),
 			'[[Foo::Foobar::テスト]] [[Bar:::ABC|DEF]] [[Foo:::0049 30 12345678/::Foo]] ',
@@ -605,7 +592,6 @@ class InTextAnnotationParserTest extends \PHPUnit_Framework_TestCase {
 			NS_MAIN,
 			array(
 				'smwgNamespacesWithSemanticLinks' => array( NS_MAIN => true ),
-				'smwgLinksInValues' => false,
 				'smwgParserFeatures' => SMW_PARSER_INL_ERROR | SMW_PARSER_NONE
 			),
 			'[[Foo|Bar::Foobar]] [[File:Example.png|alt=Bar::Foobar|Caption]] [[File:Example.png|Bar::Foobar|link=Foo]]',
@@ -620,7 +606,6 @@ class InTextAnnotationParserTest extends \PHPUnit_Framework_TestCase {
 			NS_MAIN,
 			array(
 				'smwgNamespacesWithSemanticLinks' => array( NS_MAIN => true ),
-				'smwgLinksInValues' => false,
 				'smwgParserFeatures' => SMW_PARSER_INL_ERROR | SMW_PARSER_STRICT
 			),
 			'[[Foo|Bar::Foobar]] [[File:Example.png|alt=Bar::Foobar|Caption]] [[Foo::Foobar::テスト]] [[File:Example.png|Bar::Foobar|link=Foo]]',
@@ -637,7 +622,6 @@ class InTextAnnotationParserTest extends \PHPUnit_Framework_TestCase {
 			NS_MAIN,
 			array(
 				'smwgNamespacesWithSemanticLinks' => array( NS_MAIN => true ),
-				'smwgLinksInValues' => false,
 				'smwgParserFeatures' => SMW_PARSER_INL_ERROR | SMW_PARSER_STRICT
 			),
 			'[[Foo::@@@]] [[Bar::@@@en|Foobar]]',
@@ -652,8 +636,7 @@ class InTextAnnotationParserTest extends \PHPUnit_Framework_TestCase {
 			NS_MAIN,
 			array(
 				'smwgNamespacesWithSemanticLinks' => array( NS_MAIN => true ),
-				'smwgLinksInValues' => SMW_LINV_OBFU,
-				'smwgParserFeatures' => SMW_PARSER_INL_ERROR | SMW_PARSER_STRICT
+				'smwgParserFeatures' => SMW_PARSER_INL_ERROR | SMW_PARSER_STRICT | SMW_PARSER_LINV
 			),
 			'[[Text::Bar [http://example.org/Foo Foo]]] [[Code::Foo[1] Foobar]]',
 			array(
@@ -669,8 +652,7 @@ class InTextAnnotationParserTest extends \PHPUnit_Framework_TestCase {
 			NS_MAIN,
 			array(
 				'smwgNamespacesWithSemanticLinks' => array( NS_MAIN => true ),
-				'smwgLinksInValues' => SMW_LINV_OBFU,
-				'smwgParserFeatures' => SMW_PARSER_INL_ERROR | SMW_PARSER_STRICT
+				'smwgParserFeatures' => SMW_PARSER_INL_ERROR | SMW_PARSER_STRICT | SMW_PARSER_LINV
 			),
 			'<sup id="cite_ref-1" class="reference">[[#cite_note-1|&#91;1&#93;]]</sup>',
 			array(


### PR DESCRIPTION
This PR is made in reference to: #2802

This PR addresses or contains:

- Replaces `smwgLinksInValues` with `smwgParserFeatures` and flag `SMW_PARSER_LINV`
- `SMW_PARSER_LINV` represents the previous `SMW_LINV_OBFU`, an equivalent for `SMW_LINV_PCRE` has not been introduced as it was only added to avoid a BC and would create OOM in some case and is therefore removed entirely 
- Disabled by default (same as it was with `smwgLinksInValues`)

This PR includes:
- [ ] Tests (unit/integration)
- [x] CI build passed

Fixes #