### PR TITLE
Check URI scheme, refs 2825

### DIFF
--- a/DefaultSettings.php
+++ b/DefaultSettings.php
@@ -1693,4 +1693,18 @@ return array(
 	'smwgUseComparableContentHash' => true,
 	##
 
+	##
+	# List of supported schemes for a URI typed property
+	#
+	# @see https://www.iana.org/assignments/uri-schemes/uri-schemes.xhtml
+	# @see https://www.w3.org/wiki/UriSchemes
+	#
+	# @since 3.0
+	##
+	'smwgURITypeSchemeList' => [
+		'http', 'https', 'mailto', 'tel', 'ftp', 'news', 'file', 'urn', 'telnet',
+		'ldap', 'gopher'
+	],
+	##
+
 );

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -639,5 +639,6 @@
 	"smw-parser-recursion-level-exceeded": "The level of $1 recursions was exceeded during a parse process. It is suggested to validated the template structure, or if necessary adjust configuration parameter <code>$maxRecursionDepth</code>.",
 	"smw-property-page-list-count": "Showing $1 {{PLURAL:$1|page|pages}} using this property.",
 	"smw-property-page-list-search-count": "Showing $1 {{PLURAL:$1|page|pages}} using this property with a \"$2\" value match.",
-	"smw-property-reserved-category": "Category"
+	"smw-property-reserved-category": "Category",
+	"smw-datavalue-uri-invalid-scheme": " \"$1\" has not been listed as valid URI scheme."
 }

--- a/includes/Settings.php
+++ b/includes/Settings.php
@@ -174,6 +174,7 @@ class Settings extends Options {
 			'smwgUseComparableContentHash' => $GLOBALS['smwgUseComparableContentHash'],
 			'smwgBrowseFeatures' => $GLOBALS['smwgBrowseFeatures'],
 			'smwgCategoryFeatures' => $GLOBALS['smwgCategoryFeatures'],
+			'smwgURITypeSchemeList' => $GLOBALS['smwgURITypeSchemeList'],
 		);
 
 		self::initLegacyMapping( $configuration );

--- a/includes/datavalues/SMW_DV_URI.php
+++ b/includes/datavalues/SMW_DV_URI.php
@@ -45,6 +45,11 @@ class SMWURIValue extends SMWDataValue {
 	 */
 	private $showUrlContextInRawFormat = true;
 
+	/**
+	 * @var array
+	 */
+	private $schemeList = [];
+
 	public function __construct( $typeid ) {
 		parent::__construct( $typeid );
 		switch ( $typeid ) {
@@ -64,6 +69,8 @@ class SMWURIValue extends SMWDataValue {
 				$this->m_mode = SMW_URI_MODE_URI;
 			break;
 		}
+
+		$this->schemeList = array_flip( $GLOBALS['smwgURITypeSchemeList'] );
 	}
 
 	protected function parseUserValue( $value ) {
@@ -108,6 +115,11 @@ class SMWURIValue extends SMWDataValue {
 				}
 				// decompose general URI components
 				$scheme = $parts[0];
+
+				if ( !isset( $this->schemeList[$scheme] ) ) {
+					return $this->addErrorMsg( array( 'smw-datavalue-uri-invalid-scheme', $scheme ) );
+				}
+
 				$parts = explode( '?', $parts[1], 2 ); // try to split "hier-part?queryfrag"
 				if ( count( $parts ) == 2 ) {
 					$hierpart = $parts[0];

--- a/tests/phpunit/Integration/JSONScript/TestCases/p-0503.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/p-0503.json
@@ -1,0 +1,66 @@
+{
+	"description": "Test in-text annotation `_uri` on valid/invalid scheme",
+	"setup": [
+		{
+			"namespace": "SMW_NS_PROPERTY",
+			"page": "Has url",
+			"contents": "[[Has type::URL]]"
+		},
+		{
+			"page": "Example/P0503/1",
+			"contents": "[[Has url::ftp://example.com/foo]]"
+		},
+		{
+			"page": "Example/P0503/2",
+			"contents": "[[Has url::User:Test]]"
+		}
+	],
+	"tests": [
+		{
+			"type": "parser",
+			"about": "#0 valid ftp",
+			"subject": "Example/P0503/1",
+			"assert-store": {
+				"semantic-data": {
+					"strictPropertyValueMatch": false,
+					"propertyCount": 3,
+					"propertyKeys": [
+						"_SKEY",
+						"_MDAT",
+						"Has url"
+					],
+					"propertyValues": [
+						"ftp://example.com/foo"
+					]
+				}
+			}
+		},
+		{
+			"type": "parser",
+			"about": "#1 invalid User:",
+			"subject": "Example/P0503/2",
+			"assert-store": {
+				"semantic-data": {
+					"strictPropertyValueMatch": false,
+					"propertyCount": 3,
+					"propertyKeys": [
+						"_SKEY",
+						"_MDAT",
+						"_ERRC"
+					]
+				}
+			}
+		}
+	],
+	"settings": {
+		"wgContLang": "en",
+		"smwgPageSpecialProperties": [
+			"_MDAT"
+		]
+	},
+	"meta": {
+		"version": "2",
+		"is-incomplete": false,
+		"debug": false
+	}
+}


### PR DESCRIPTION
This PR is made in reference to: #2825

This PR addresses or contains:

- Adds `smwgURITypeSchemeList` setting to restrict valid URI schemes and avoid misunderstandings like the one in https://github.com/SemanticMediaWiki/SemanticMediaWiki/issues/2825#issuecomment-344224554 due to wrongful assignments such as `User:Foo` to a URI typed property
- List can be extended and currently includes `'http', 'https', 'mailto', 'tel', 'ftp', 'news', 'file', 'urn', 'telnet',	'ldap', 'gopher'`

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed

Fixes #