### PR TITLE
Extend use of cached hierarchy instance, refs 2698

### DIFF
--- a/src/SQLStore/QueryDependency/QueryResultDependencyListResolver.php
+++ b/src/SQLStore/QueryDependency/QueryResultDependencyListResolver.php
@@ -214,11 +214,10 @@ class QueryResultDependencyListResolver {
 		// Safeguard against a possible category (or redirect thereof) to point
 		// to itself by relying on tracking the hash of already inserted objects
 		if ( !isset( $subjects[$hash] ) ) {
-			$subcategories = $this->hierarchyLookup->findSubcategoryList( $category );
+			$subcategories = $this->hierarchyLookup->getConsecutiveHierarchyList( $category );
 		}
 
 		foreach ( $subcategories as $subcategory ) {
-
 			$subjects[$subcategory->getHash()] = $subcategory;
 
 			if ( $this->hierarchyLookup->hasSubcategory( $subcategory ) ) {
@@ -237,17 +236,19 @@ class QueryResultDependencyListResolver {
 		if (
 			!isset( $subjects[$subject->getHash()] ) &&
 			!isset( $this->propertyDependencyExemptionlist[$subject->getDBKey()] ) ) {
-			$subproperties = $this->hierarchyLookup->findSubpropertyList( $property );
+			$subproperties = $this->hierarchyLookup->getConsecutiveHierarchyList( $property );
 		}
 
 		foreach ( $subproperties as $subproperty ) {
 
-			if ( isset( $this->propertyDependencyExemptionlist[$subproperty->getDBKey()] ) ) {
+			if ( isset( $this->propertyDependencyExemptionlist[$subproperty->getKey()] ) ) {
 				continue;
 			}
 
-			$subjects[$subproperty->getHash()] = $subproperty;
-			$this->doMatchProperty( $subjects, new DIProperty( $subproperty->getDBKey() ) );
+			$subject = $subproperty->getCanonicalDiWikiPage();
+			$subjects[$subject->getHash()] = $subject;
+
+			$this->doMatchProperty( $subjects, $subproperty );
 		}
 	}
 

--- a/tests/phpunit/Unit/HierarchyLookupTest.php
+++ b/tests/phpunit/Unit/HierarchyLookupTest.php
@@ -164,7 +164,7 @@ class HierarchyLookupTest extends \PHPUnit_Framework_TestCase {
 		$this->cache->expects( $this->once() )
 			->method( 'save' )
 			->with(
-				$this->stringContains( ':smw:hlkp:eebbf01df970d569b285cb5b417c7ec3' ),
+				$this->stringContains( ':smw:hierarchy:25840d7839e2fe0369c3fe16014d21d1' ),
 				$this->anything() );
 
 		$instance = new HierarchyLookup(
@@ -245,7 +245,7 @@ class HierarchyLookupTest extends \PHPUnit_Framework_TestCase {
 		$this->cache->expects( $this->once() )
 			->method( 'save' )
 			->with(
-				$this->stringContains( ':smw:hlkp:28d64caa88a077bb0746e3928f06e353' ),
+				$this->stringContains( ':smw:hierarchy:d27ae8a4539ee4c7ab76aedcbf1c08c0' ),
 				$this->anything() );
 
 		$instance = new HierarchyLookup(

--- a/tests/phpunit/Unit/SQLStore/QueryDependency/QueryResultDependencyListResolverTest.php
+++ b/tests/phpunit/Unit/SQLStore/QueryDependency/QueryResultDependencyListResolverTest.php
@@ -30,6 +30,7 @@ class QueryResultDependencyListResolverTest extends \PHPUnit_Framework_TestCase 
 
 	private $testEnvironment;
 	private $store;
+	private $hierarchyLookup;
 
 	protected function setUp() {
 		parent::setUp();
@@ -39,6 +40,10 @@ class QueryResultDependencyListResolverTest extends \PHPUnit_Framework_TestCase 
 		$this->store = $this->getMockBuilder( '\SMW\Store' )
 			->disableOriginalConstructor()
 			->getMockForAbstractClass();
+
+		$this->hierarchyLookup = $this->getMockBuilder( '\SMW\HierarchyLookup' )
+			->disableOriginalConstructor()
+			->getMock();
 
 		$this->testEnvironment->registerObject( 'Store', $this->store );
 	}
@@ -51,24 +56,16 @@ class QueryResultDependencyListResolverTest extends \PHPUnit_Framework_TestCase 
 
 	public function testCanConstruct() {
 
-		$hierarchyLookup = $this->getMockBuilder( '\SMW\HierarchyLookup' )
-			->disableOriginalConstructor()
-			->getMock();
-
 		$this->assertInstanceOf(
 			'\SMW\SQLStore\QueryDependency\QueryResultDependencyListResolver',
-			new QueryResultDependencyListResolver( $hierarchyLookup )
+			new QueryResultDependencyListResolver( $this->hierarchyLookup )
 		);
 	}
 
 	public function testTryTogetDependencyListFromForNonSetQueryResult() {
 
-		$hierarchyLookup = $this->getMockBuilder( '\SMW\HierarchyLookup' )
-			->disableOriginalConstructor()
-			->getMock();
-
 		$instance = new QueryResultDependencyListResolver(
-			$hierarchyLookup
+			$this->hierarchyLookup
 		);
 
 		$this->assertEmpty(
@@ -101,12 +98,16 @@ class QueryResultDependencyListResolverTest extends \PHPUnit_Framework_TestCase 
 			->method( 'getStore' )
 			->will( $this->returnValue( $this->store ) );
 
-		$hierarchyLookup = $this->getMockBuilder( '\SMW\HierarchyLookup' )
+		$this->hierarchyLookup = $this->getMockBuilder( '\SMW\HierarchyLookup' )
 			->disableOriginalConstructor()
 			->getMock();
 
+		$this->hierarchyLookup->expects( $this->any() )
+			->method( 'getConsecutiveHierarchyList' )
+			->will( $this->returnValue( [] ) );
+
 		$instance = new QueryResultDependencyListResolver(
-			$hierarchyLookup
+			$this->hierarchyLookup
 		);
 
 		$this->assertEmpty(
@@ -142,22 +143,22 @@ class QueryResultDependencyListResolverTest extends \PHPUnit_Framework_TestCase 
 			->method( 'getStore' )
 			->will( $this->returnValue( $this->store ) );
 
-		$hierarchyLookup = $this->getMockBuilder( '\SMW\HierarchyLookup' )
+		$this->hierarchyLookup = $this->getMockBuilder( '\SMW\HierarchyLookup' )
 			->disableOriginalConstructor()
 			->getMock();
 
-		$hierarchyLookup->expects( $this->any() )
+		$this->hierarchyLookup->expects( $this->any() )
 			->method( 'hasSubproperty' )
 			->will( $this->returnValue( true ) );
 
-		$hierarchyLookup->expects( $this->at( 1 ) )
-			->method( 'findSubpropertyList' )
+		$this->hierarchyLookup->expects( $this->at( 1 ) )
+			->method( 'getConsecutiveHierarchyList' )
 			->with( $this->equalTo( new DIProperty( 'Foobar' ) ) )
 			->will( $this->returnValue(
-				array( DIWikiPage::newFromText( 'Subprop', SMW_NS_PROPERTY ) ) ) );
+				array( new DIProperty( 'Subprop' ) ) ) );
 
 		$instance = new QueryResultDependencyListResolver(
-			$hierarchyLookup
+			$this->hierarchyLookup
 		);
 
 		$instance->setPropertyDependencyExemptionlist( array( 'Subprop' ) );
@@ -197,12 +198,12 @@ class QueryResultDependencyListResolverTest extends \PHPUnit_Framework_TestCase 
 			->method( 'getStore' )
 			->will( $this->returnValue( $this->store ) );
 
-		$hierarchyLookup = $this->getMockBuilder( '\SMW\HierarchyLookup' )
+		$this->hierarchyLookup = $this->getMockBuilder( '\SMW\HierarchyLookup' )
 			->disableOriginalConstructor()
 			->getMock();
 
 		$instance = new QueryResultDependencyListResolver(
-			$hierarchyLookup
+			$this->hierarchyLookup
 		);
 
 		$this->assertEquals(
@@ -242,12 +243,12 @@ class QueryResultDependencyListResolverTest extends \PHPUnit_Framework_TestCase 
 			->method( 'getQuery' )
 			->will( $this->returnValue( $query ) );
 
-		$hierarchyLookup = $this->getMockBuilder( '\SMW\HierarchyLookup' )
+		$this->hierarchyLookup = $this->getMockBuilder( '\SMW\HierarchyLookup' )
 			->disableOriginalConstructor()
 			->getMock();
 
 		$instance = new QueryResultDependencyListResolver(
-			$hierarchyLookup
+			$this->hierarchyLookup
 		);
 
 		$this->assertEquals(
@@ -284,22 +285,22 @@ class QueryResultDependencyListResolverTest extends \PHPUnit_Framework_TestCase 
 			->method( 'getStore' )
 			->will( $this->returnValue( $this->store ) );
 
-		$hierarchyLookup = $this->getMockBuilder( '\SMW\HierarchyLookup' )
+		$this->hierarchyLookup = $this->getMockBuilder( '\SMW\HierarchyLookup' )
 			->disableOriginalConstructor()
 			->getMock();
 
-		$hierarchyLookup->expects( $this->any() )
+		$this->hierarchyLookup->expects( $this->any() )
 			->method( 'hasSubproperty' )
 			->will( $this->returnValue( true ) );
 
-		$hierarchyLookup->expects( $this->at( 1 ) )
-			->method( 'findSubpropertyList' )
+		$this->hierarchyLookup->expects( $this->at( 1 ) )
+			->method( 'getConsecutiveHierarchyList' )
 			->with( $this->equalTo( new DIProperty( 'Foobar' ) ) )
 			->will( $this->returnValue(
-				array( DIWikiPage::newFromText( 'Subprop', SMW_NS_PROPERTY ) ) ) );
+				array( new DIProperty( 'Subprop' ) ) ) );
 
 		$instance = new QueryResultDependencyListResolver(
-			$hierarchyLookup
+			$this->hierarchyLookup
 		);
 
 		$expected = array(
@@ -342,16 +343,16 @@ class QueryResultDependencyListResolverTest extends \PHPUnit_Framework_TestCase 
 			->method( 'getStore' )
 			->will( $this->returnValue( $this->store ) );
 
-		$hierarchyLookup = $this->getMockBuilder( '\SMW\HierarchyLookup' )
+		$this->hierarchyLookup = $this->getMockBuilder( '\SMW\HierarchyLookup' )
 			->disableOriginalConstructor()
 			->getMock();
 
-		$hierarchyLookup->expects( $this->any() )
+		$this->hierarchyLookup->expects( $this->any() )
 			->method( 'hasSubcategory' )
 			->will( $this->returnValue( true ) );
 
-		$hierarchyLookup->expects( $this->at( 1 ) )
-			->method( 'findSubcategoryList' )
+		$this->hierarchyLookup->expects( $this->at( 1 ) )
+			->method( 'getConsecutiveHierarchyList' )
 			->with( $this->equalTo( DIWikiPage::newFromText( 'Foocat', NS_CATEGORY ) ) )
 			->will( $this->returnValue(
 				array(
@@ -359,7 +360,7 @@ class QueryResultDependencyListResolverTest extends \PHPUnit_Framework_TestCase 
 					DIWikiPage::newFromText( 'Foocat', NS_CATEGORY ) ) ) );
 
 		$instance = new QueryResultDependencyListResolver(
-			$hierarchyLookup
+			$this->hierarchyLookup
 		);
 
 		$expected = array(


### PR DESCRIPTION
This PR is made in reference to: #2698

This PR addresses or contains:

- `HierarchyLookup::hasSubproperty` and `HierarchyLookup::hasSubcategory` to use the cached instance
- `QueryResultDependencyListResolver` to use the cached instance instead of creating an active store connection 

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed
