### PR TITLE
Use different approach to update query dependencies, refs 1117

### DIFF
--- a/i18n/en.json
+++ b/i18n/en.json
@@ -627,7 +627,7 @@
 	"smw-format-datatable-toolbar-export": "Export",
 	"smw-category-invalid-redirect-target": "Category \"$1\" contains an invalid redirect target to a non-category namespace.",
 	"smw-parser-function-expensive-execution-limit": "The parser function has reached the limit for expensive executions (see configuration parameter [https://www.semantic-mediawiki.org/wiki/Help:$smwgQExpensiveExecutionLimit <code>$smwgQExpensiveExecutionLimit</code>]).",
-	"smw-postproc-queryref": "The page was marked as to be refreshed due to some required post processing.",
+	"smw-postproc-queryref": "Semantic MediaWiki will initiate a page refresh due to some required query post processing.",
 	"apihelp-smwinfo-summary": "API module to retrieve information about Semantic MediaWiki statistics and other meta information.",
 	"apihelp-ask-summary": "API module to query Semantic MediaWiki using the ask language.",
 	"apihelp-askargs-summary": "API module to query Semantic MediaWiki using the ask language as list of conditions, printouts and parameters.",

--- a/src/EventListenerRegistry.php
+++ b/src/EventListenerRegistry.php
@@ -3,6 +3,7 @@
 namespace SMW;
 
 use Onoi\EventDispatcher\EventListenerCollection;
+use SMW\SQLStore\QueryDependency\DependencyLinksUpdateJournal;
 use SMW\Query\QueryComparator;
 use SMWExporter as Exporter;
 
@@ -149,15 +150,22 @@ class EventListenerRegistry implements EventListenerCollection {
 		$this->eventListenerCollection->registerCallback(
 			'cached.update.marker.delete', function( $dispatchContext ) {
 
-				$hash = '';
+				$cache = ApplicationFactory::getInstance()->getCache();
 
 				if ( $dispatchContext->has( 'subject' ) ) {
-					$hash = $dispatchContext->get( 'subject' )->getHash();
-				}
+					$cache->delete(
+						DependencyLinksUpdateJournal::makeKey(
+							$dispatchContext->get( 'subject' )
+						)
+					);
 
-				ApplicationFactory::getInstance()->getCache()->delete(
-					smwfCacheKey( ParserData::CACHE_NAMESPACE, $hash )
-				);
+					$cache->delete(
+						smwfCacheKey(
+							ParserData::CACHE_NAMESPACE,
+							$dispatchContext->get( 'subject' )->getHash()
+						)
+					);
+				}
 			}
 		);
 	}

--- a/src/MediaWiki/Hooks/RejectParserCacheValue.php
+++ b/src/MediaWiki/Hooks/RejectParserCacheValue.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace SMW\MediaWiki\Hooks;
+
+use SMW\SQLStore\QueryDependency\DependencyLinksUpdateJournal;
+use Title;
+
+/**
+ * @see https://www.mediawiki.org/wiki/Manual:Hooks/RejectParserCacheValue
+ *
+ * @license GNU GPL v2+
+ * @since 3.0
+ *
+ * @author mwjames
+ */
+class RejectParserCacheValue extends HookHandler {
+
+	/**
+	 * @var DependencyLinksUpdateJournal
+	 */
+	private $dependencyLinksUpdateJournal;
+
+	/**
+	 * @since 3.0
+	 *
+	 * @param DependencyLinksUpdateJournal $dependencyLinksUpdateJournal
+	 */
+	public function __construct( DependencyLinksUpdateJournal $dependencyLinksUpdateJournal ) {
+		$this->dependencyLinksUpdateJournal = $dependencyLinksUpdateJournal;
+	}
+
+	/**
+	 * @since 3.0
+	 *
+	 * @param Title $title
+	 *
+	 * @return boolean
+	 */
+	public function process( Title $title ) {
+
+		if ( $this->dependencyLinksUpdateJournal->has( $title ) ) {
+			$this->dependencyLinksUpdateJournal->delete( $title );
+			return false;
+		}
+
+		return true;
+	}
+
+}

--- a/src/PostProcHandler.php
+++ b/src/PostProcHandler.php
@@ -3,9 +3,12 @@
 namespace SMW;
 
 use SMWQuery as Query;
+use SMW\DIWikiPage;
+use Onoi\Cache\Cache;
 use ParserOutput;
 use Title;
 use WebRequest;
+use SMW\SQLStore\QueryDependency\DependencyLinksUpdateJournal;
 
 /**
  * Some updates require to be handled in a "post" process meaning after an update
@@ -35,15 +38,24 @@ class PostProcHandler {
 	private $parserOutput;
 
 	/**
+	 * @var Cache
+	 */
+	private $cache;
+
+	/**
 	 * @var boolean
 	 */
 	private $isEnabled = true;
 
 	/**
 	 * @since 3.0
+	 *
+	 * @param ParserOutput $parserOutput
+	 * @param Cache $cache
 	 */
-	public function __construct( ParserOutput $parserOutput ) {
+	public function __construct( ParserOutput $parserOutput, Cache $cache ) {
 		$this->parserOutput = $parserOutput;
+		$this->cache = $cache;
 	}
 
 	/**
@@ -74,23 +86,44 @@ class PostProcHandler {
 	 */
 	public function getHtml( Title $title, WebRequest $webRequest ) {
 
-		if ( $this->isEnabled === false ) {
+		// Is `@annotation` available as part of a #ask query?
+		$refs = $this->parserOutput->getExtensionData( self::PROC_POST_QUERYREF );
+
+		if ( $this->isEnabled === false || $refs === null ) {
 			return '';
 		}
-
-		// @see Article::view
-		$key = \EditPage::POST_EDIT_COOKIE_KEY_PREFIX . $title->getLatestRevID();
-		$postEdit = $webRequest->getCookie( $key );
 
 		// Ensure to detect the post edit process to distinguish between an edit
 		// event and any other post, get request in order to only sent a html
 		// fragment once on the edit request and avoid an infinite loop when the
 		// page is reloaded using an API request
+		// @see Article::view
+		$postEdit = $webRequest->getCookie(
+			\EditPage::POST_EDIT_COOKIE_KEY_PREFIX . $title->getLatestRevID()
+		);
+
+		$key = DependencyLinksUpdateJournal::makeKey(
+			$title
+		);
+
+		// In case the dependency journal contains an active reference then
+		// prepare for an additional update since `@annotation` is used to ensure
+		// that values are recomputed without an explicit `edit` action.
+		if ( $this->cache->fetch( $key ) && !$this->cache->contains( $key . ':post' ) ) {
+			$postEdit = true;
+
+			// Add a update marker (5 min.) to avoid running twice in case the
+			// journal reference hasn't been deleted yet as result of an existing
+			// PostProcHandler update request.
+			$this->cache->save( $key . ':post', true, 300 );
+		} else {
+			$this->cache->delete( $key . ':post' );
+		}
 
 		// The element is only added temporary in the event of a postEdit, a
 		// reload of the page will not have the cookie being set and is therefore
 		// neglected
-		if ( $postEdit !== null && ( $refs = $this->parserOutput->getExtensionData( self::PROC_POST_QUERYREF ) ) !== null ) {
+		if ( $postEdit !== null && $refs !== [] ) {
 			return \Html::rawElement(
 				'div',
 				array(

--- a/src/SQLStore/QueryDependency/DependencyLinksUpdateJournal.php
+++ b/src/SQLStore/QueryDependency/DependencyLinksUpdateJournal.php
@@ -1,0 +1,162 @@
+<?php
+
+namespace SMW\SQLStore\QueryDependency;
+
+use Onoi\Cache\Cache;
+use SMW\DIWikiPage;
+use SMW\ApplicationFactory;
+use SMW\Updater\DeferredCallableUpdate;
+use Psr\Log\LoggerAwareTrait;
+use Title;
+
+/**
+ * Temporary storage of entities that are expected to be refreshed (or updated)
+ * during an article view due to being a dependency of an altered query.
+ *
+ * @license GNU GPL v2+
+ * @since 3.0
+ *
+ * @author mwjames
+ */
+class DependencyLinksUpdateJournal {
+
+	use LoggerAwareTrait;
+
+	/**
+	 * @var string
+	 */
+	const VERSION = '0.1';
+
+	/**
+	 * Namespace for the cache instance
+	 */
+	const CACHE_NAMESPACE = 'smw:update:qdep';
+
+	/**
+	 * @var Cache
+	 */
+	private $cache;
+
+	/**
+	 * @var DeferredCallableUpdate
+	 */
+	private $deferredCallableUpdate;
+
+	/**
+	 * @since 3.0
+	 *
+	 * @param Cache $cache
+	 * @param DeferredCallableUpdate $deferredCallableUpdate
+	 */
+	public function __construct( Cache $cache, DeferredCallableUpdate $deferredCallableUpdate ) {
+		$this->cache = $cache;
+		$this->deferredCallableUpdate = $deferredCallableUpdate;
+	}
+
+	/**
+	 * @since 3.0
+	 *
+	 * @param DIWikiPage $subject
+	 *
+	 * @return string
+	 */
+	public static function makeKey( $subject ) {
+
+		$segments = [];
+
+		if ( $subject instanceof DIWikiPage ) {
+			$segments = [
+				$subject->getDBKey(),
+				$subject->getNamespace(),
+				$subject->getInterwiki(),
+				''
+			];
+		}
+
+		if ( $subject instanceof Title ) {
+			$segments = [
+				$subject->getDBKey(),
+				$subject->getNamespace(),
+				$subject->getInterwiki(),
+				''
+			];
+		}
+
+		$hash = implode( '#', $segments );
+
+		return smwfCacheKey(
+			self::CACHE_NAMESPACE,
+			[
+				$hash,
+				self::VERSION
+			]
+		);
+	}
+
+	/**
+	 * @since 3.0
+	 *
+	 * @param array $hashList
+	 */
+	public function updateFromList( array $hashList ) {
+
+		foreach ( $hashList as $hash ) {
+
+			$key = smwfCacheKey(
+				self::CACHE_NAMESPACE,
+				[
+					$hash,
+					self::VERSION
+				]
+			);
+
+			$this->cache->save( $key, true );
+		}
+	}
+
+	/**
+	 * @since 3.0
+	 *
+	 * @param DIWikiPage|Title $subject
+	 */
+	public function update( $subject ) {
+		$this->cache->save( self::makeKey( $subject ), true );
+	}
+
+	/**
+	 * @since 3.0
+	 *
+	 * @param DIWikiPage|Title $subject
+	 */
+	public function has( $subject ) {
+		return $this->cache->contains( self::makeKey( $subject ) ) === true;
+	}
+
+	/**
+	 * @since 3.0
+	 *
+	 * @param DIWikiPage $subject
+	 */
+	public function delete( $subject ) {
+
+		if ( !$subject instanceof Title && !$subject instanceof DIWikiPage ) {
+			throw new RuntimeException( "Invalid subject instance" );
+		}
+
+		// Avoid interference with any other process during a preOutputCommit
+		// stage especially when CACHE_DB is used as instance
+		$this->deferredCallableUpdate->setCallback( function() use( $subject ) {
+			$this->cache->delete( self::makeKey( $subject ) );
+		} );
+
+		$this->deferredCallableUpdate->setOrigin(
+			[
+				__METHOD__,
+				$subject->getDBKey() . '#' . $subject->getNamespace() . '#' . $subject->getInterwiki()
+			]
+		);
+
+		$this->deferredCallableUpdate->pushUpdate();
+	}
+
+}

--- a/src/SQLStore/QueryDependency/QueryDependencyLinksStore.php
+++ b/src/SQLStore/QueryDependency/QueryDependencyLinksStore.php
@@ -7,6 +7,7 @@ use SMW\DIProperty;
 use SMW\DIWikiPage;
 use SMW\EventHandler;
 use SMW\SQLStore\ChangeOp\ChangeOp;
+use SMW\MediaWiki\Jobs\ParserCachePurgeJob;
 use SMW\Store;
 use SMW\RequestOptions;
 use SMW\SQLStore\SQLStore;
@@ -205,7 +206,8 @@ class QueryDependencyLinksStore implements LoggerAwareInterface {
 		}
 
 		return array(
-			'idlist' => $filteredIdList
+			'idlist' => $filteredIdList,
+			'ex:mode' => ParserCachePurgeJob::EXEC_JOURNAL
 		);
 	}
 

--- a/src/Services/SharedServicesContainer.php
+++ b/src/Services/SharedServicesContainer.php
@@ -211,7 +211,8 @@ class SharedServicesContainer implements CallbackContainer {
 			$containerBuilder->registerExpectedReturnType( 'PostProcHandler', PostProcHandler::class );
 
 			$postProcHandler = new PostProcHandler(
-				$parserOutput
+				$parserOutput,
+				$containerBuilder->singleton( 'Cache' )
 			);
 
 			return $postProcHandler;

--- a/tests/phpunit/Unit/MediaWiki/Hooks/HookRegistryTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Hooks/HookRegistryTest.php
@@ -168,6 +168,9 @@ class HookRegistryTest extends \PHPUnit_Framework_TestCase {
 		$this->doTestExecutionForParserOptionsRegister( $instance );
 		$this->doTestExecutionForParserFirstCallInit( $instance );
 		$this->doTestExecutionForTitleQuickPermissions( $instance );
+		$this->doTestExecutionForOutputPageCheckLastModified( $instance );
+		$this->doTestExecutionForIsFileCacheable( $instance );
+		$this->doTestExecutionForRejectParserCacheValue( $instance );
 
 		// Usage of registered hooks in/by smw-core
 		//$this->doTestExecutionForSMWStoreDropTables( $instance );
@@ -993,6 +996,68 @@ class HookRegistryTest extends \PHPUnit_Framework_TestCase {
 		$this->assertThatHookIsExcutable(
 			$instance->getHandlerFor( $handler ),
 			array( $title, $user, $action, &$errors, $rigor, $short )
+		);
+	}
+
+	public function doTestExecutionForOutputPageCheckLastModified( $instance ) {
+
+		$handler = 'OutputPageCheckLastModified';
+		$modifiedTimes = [];
+
+		$this->assertTrue(
+			$instance->isRegistered( $handler )
+		);
+
+		$this->assertThatHookIsExcutable(
+			$instance->getHandlerFor( $handler ),
+			array( &$modifiedTimes )
+		);
+	}
+
+	public function doTestExecutionForIsFileCacheable( $instance ) {
+
+		$handler = 'IsFileCacheable';
+
+		$article = $this->getMockBuilder( '\Article' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$article->expects( $this->any() )
+			->method( 'getTitle' )
+			->will( $this->returnValue( $this->title ) );
+
+		$this->assertTrue(
+			$instance->isRegistered( $handler )
+		);
+
+		$this->assertThatHookIsExcutable(
+			$instance->getHandlerFor( $handler ),
+			array( &$article )
+		);
+	}
+
+	public function doTestExecutionForRejectParserCacheValue( $instance ) {
+
+		$handler = 'RejectParserCacheValue';
+
+		$wikiPage = $this->getMockBuilder( '\WikiPage' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$wikiPage->expects( $this->any() )
+			->method( 'getTitle' )
+			->will( $this->returnValue( $this->title ) );
+
+		$this->assertTrue(
+			$instance->isRegistered( $handler )
+		);
+
+		$value = '';
+		$popts = '';
+
+		$this->assertThatHookIsExcutable(
+			$instance->getHandlerFor( $handler ),
+			array( $value, $wikiPage, $popts )
 		);
 	}
 

--- a/tests/phpunit/Unit/MediaWiki/Hooks/RejectParserCacheValueTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Hooks/RejectParserCacheValueTest.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace SMW\Tests\MediaWiki\Hooks;
+
+use SMW\MediaWiki\Hooks\RejectParserCacheValue;
+use SMW\Tests\TestEnvironment;
+use SMW\DIWikiPage;
+use SMW\DIProperty;
+
+/**
+ * @covers \SMW\MediaWiki\Hooks\RejectParserCacheValue
+ * @group semantic-mediawiki
+ *
+ * @license GNU GPL v2+
+ * @since 3.0
+ *
+ * @author mwjames
+ */
+class RejectParserCacheValueTest extends \PHPUnit_Framework_TestCase {
+
+	private $testEnvironment;
+	private $dependencyLinksUpdateJournal;
+
+	protected function setUp() {
+		parent::setUp();
+
+		$this->testEnvironment = new TestEnvironment();
+
+		$this->dependencyLinksUpdateJournal = $this->getMockBuilder( '\SMW\SQLStore\QueryDependency\DependencyLinksUpdateJournal' )
+			->disableOriginalConstructor()
+			->getMock();
+	}
+
+	protected function tearDown() {
+		$this->testEnvironment->tearDown();
+		parent::tearDown();
+	}
+
+	public function testCanConstruct() {
+
+		$this->assertInstanceOf(
+			RejectParserCacheValue::class,
+			new RejectParserCacheValue( $this->dependencyLinksUpdateJournal )
+		);
+	}
+
+	public function testProcessOnJournalEntryToReject() {
+
+		$subject = DIWikiPage::newFromText( __METHOD__ );
+
+		$this->dependencyLinksUpdateJournal->expects( $this->once() )
+			->method( 'has' )
+			->will( $this->returnValue( true ) );
+
+		$this->dependencyLinksUpdateJournal->expects( $this->once() )
+			->method( 'delete' );
+
+		$instance = new RejectParserCacheValue(
+			$this->dependencyLinksUpdateJournal
+		);
+
+		$this->assertFalse(
+			$instance->process( $subject->getTitle() )
+		);
+	}
+
+}

--- a/tests/phpunit/Unit/SQLStore/QueryDependency/DependencyLinksUpdateJournalTest.php
+++ b/tests/phpunit/Unit/SQLStore/QueryDependency/DependencyLinksUpdateJournalTest.php
@@ -1,0 +1,189 @@
+<?php
+
+namespace SMW\Tests\SQLStore\QueryDependency;
+
+use SMW\SQLStore\QueryDependency\DependencyLinksUpdateJournal;
+use SMW\Tests\TestEnvironment;
+use SMW\DIWikiPage;
+use Title;
+
+/**
+ * @covers \SMW\SQLStore\QueryDependency\DependencyLinksUpdateJournal
+ * @group semantic-mediawiki
+ *
+ * @license GNU GPL v2+
+ * @since 3.0
+ *
+ * @author mwjames
+ */
+class DependencyLinksUpdateJournalTest extends \PHPUnit_Framework_TestCase {
+
+	private $cache;
+	private $deferredCallableUpdate;
+
+	protected function setUp() {
+		parent::setUp();
+
+		$this->cache = $this->getMockBuilder( '\Onoi\Cache\Cache' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$this->deferredCallableUpdate = $this->getMockBuilder( '\SMW\Updater\DeferredCallableUpdate' )
+			->disableOriginalConstructor()
+			->getMock();
+	}
+
+	protected function tearDown() {
+		parent::tearDown();
+	}
+
+	public function testCanConstruct() {
+
+		$queryDependencyLinksStore = $this->getMockBuilder( '\SMW\SQLStore\QueryDependency\QueryDependencyLinksStore' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$this->assertInstanceOf(
+			DependencyLinksUpdateJournal::class,
+			new DependencyLinksUpdateJournal( $this->cache, $this->deferredCallableUpdate )
+		);
+	}
+
+	public function testUpdateFromList() {
+
+		$this->cache->expects( $this->atLeastOnce() )
+			->method( 'save' )
+			->with( $this->stringContains( 'smw:update:qdep:7ab9f795d4ce7c20051947ede72baec3' ) );
+
+		$instance = new DependencyLinksUpdateJournal(
+			$this->cache,
+			$this->deferredCallableUpdate
+		);
+
+		$hashList = [
+			'Foo#0##'
+		];
+
+		$instance->updateFromList( $hashList );
+	}
+
+	public function testUpdate() {
+
+		$this->cache->expects( $this->atLeastOnce() )
+			->method( 'save' )
+			->with( $this->stringContains( 'smw:update:qdep:7ab9f795d4ce7c20051947ede72baec3' ) );
+
+		$instance = new DependencyLinksUpdateJournal(
+			$this->cache,
+			$this->deferredCallableUpdate
+		);
+
+		$instance->update( DIWikiPage::newFromText( 'Foo' ) );
+	}
+
+	public function testUpdateFromTitle() {
+
+		$this->cache->expects( $this->atLeastOnce() )
+			->method( 'save' )
+			->with( $this->stringContains( 'smw:update:qdep:7ab9f795d4ce7c20051947ede72baec3' ) );
+
+		$instance = new DependencyLinksUpdateJournal(
+			$this->cache,
+			$this->deferredCallableUpdate
+		);
+
+		$instance->update( Title::newFromText( 'Foo' ) );
+	}
+
+	public function testHas() {
+
+		$this->cache->expects( $this->once() )
+			->method( 'contains' )
+			->with( $this->stringContains( 'smw:update:qdep:7ab9f795d4ce7c20051947ede72baec3' ) )
+			->will( $this->returnValue( true ) );
+
+		$instance = new DependencyLinksUpdateJournal(
+			$this->cache,
+			$this->deferredCallableUpdate
+		);
+
+		$this->assertTrue(
+			$instance->has( DIWikiPage::newFromText( 'Foo' ) )
+		);
+	}
+
+	public function testHasOnDIWikiPageWithSubobject() {
+
+		$this->cache->expects( $this->once() )
+			->method( 'contains' )
+			->with( $this->stringContains( 'smw:update:qdep:7ab9f795d4ce7c20051947ede72baec3' ) )
+			->will( $this->returnValue( true ) );
+
+		$instance = new DependencyLinksUpdateJournal(
+			$this->cache,
+			$this->deferredCallableUpdate
+		);
+
+		$this->assertTrue(
+			$instance->has( new DIWikiPage( 'Foo', NS_MAIN, '', 'Bar' ) )
+		);
+	}
+
+	public function testHasFromTitle() {
+
+		$this->cache->expects( $this->once() )
+			->method( 'contains' )
+			->with( $this->stringContains( 'smw:update:qdep:7ab9f795d4ce7c20051947ede72baec3' ) )
+			->will( $this->returnValue( true ) );
+
+		$instance = new DependencyLinksUpdateJournal(
+			$this->cache,
+			$this->deferredCallableUpdate
+		);
+
+		$this->assertTrue(
+			$instance->has( Title::newFromText( 'Foo' ) )
+		);
+	}
+
+	public function testDelete() {
+
+		$this->cache->expects( $this->once() )
+			->method( 'delete' )
+			->with( $this->stringContains( 'smw:update:qdep:7ab9f795d4ce7c20051947ede72baec3' ) );
+
+		$this->deferredCallableUpdate->expects( $this->once() )
+			->method( 'setCallback' )
+			->will( $this->returnCallback( function( $callback ) {
+				return call_user_func( $callback );
+			} ) );
+
+		$instance = new DependencyLinksUpdateJournal(
+			$this->cache,
+			$this->deferredCallableUpdate
+		);
+
+		$instance->delete( DIWikiPage::newFromText( 'Foo' ) );
+	}
+
+	public function testDeleteFromTitle() {
+
+		$this->cache->expects( $this->once() )
+			->method( 'delete' )
+			->with( $this->stringContains( 'smw:update:qdep:7ab9f795d4ce7c20051947ede72baec3' ) );
+
+		$this->deferredCallableUpdate->expects( $this->once() )
+			->method( 'setCallback' )
+			->will( $this->returnCallback( function( $callback ) {
+				return call_user_func( $callback );
+			} ) );
+
+		$instance = new DependencyLinksUpdateJournal(
+			$this->cache,
+			$this->deferredCallableUpdate
+		);
+
+		$instance->delete( Title::newFromText( 'Foo' ) );
+	}
+
+}

--- a/tests/phpunit/Unit/SQLStore/QueryDependency/QueryDependencyLinksStoreTest.php
+++ b/tests/phpunit/Unit/SQLStore/QueryDependency/QueryDependencyLinksStoreTest.php
@@ -192,7 +192,10 @@ class QueryDependencyLinksStoreTest extends \PHPUnit_Framework_TestCase {
 		);
 
 		$this->assertEquals(
-			array( 'idlist' => array( 1 ) ),
+			[
+				'idlist' => [ 1 ],
+				'ex:mode' => 'exec.journal'
+			],
 			$instance->buildParserCachePurgeJobParametersFrom( $entityIdListRelevanceDetectionFilter )
 		);
 	}

--- a/tests/phpunit/Unit/SQLStore/QueryDependencyLinksStoreFactoryTest.php
+++ b/tests/phpunit/Unit/SQLStore/QueryDependencyLinksStoreFactoryTest.php
@@ -79,4 +79,18 @@ class QueryDependencyLinksStoreFactoryTest extends \PHPUnit_Framework_TestCase {
 		);
 	}
 
+	public function testCanConstructDependencyLinksUpdateJournal() {
+
+		$store = $this->getMockBuilder( '\SMW\Store' )
+			->disableOriginalConstructor()
+			->getMockForAbstractClass();
+
+		$instance = new QueryDependencyLinksStoreFactory();
+
+		$this->assertInstanceOf(
+			'\SMW\SQLStore\QueryDependency\DependencyLinksUpdateJournal',
+			$instance->newDependencyLinksUpdateJournal()
+		);
+	}
+
 }


### PR DESCRIPTION
This PR is made in reference to: #1117

This PR addresses or contains:

- Rely on `OutputPageCheckLastModified` and `RejectParserCacheValue` to disable the parser cache on-demand for a requested dependency because:
  - Tracking the query and dependent subjects require `ParserCachePurgeJob` to run effectively in order to prune the parser cache so that pages with embedded `#ask` are to request a new query execution that would generate a possible new result set
  - The problem is that `ParserCachePurgeJob` relies on the `Title::invalidateCache` to push all invalidations during the page save event as deferred request (queuing the job isn't really an option since we don't know when the job is run which could be to late given that some users don't carefully monitor the job queue) which may cause a surge in DB requests due to lag or an excessive invalidation process
  - This PR tries to mitigate the issue by:
    - `ParserCachePurgeJob` adds a `ex:mode` parameter with the `EXEC_DB` to reflect the current modus operandi while the new `EXEC_JOURNAL` is to use a cache instance in connection with the `RejectParserCacheValue` hook to act as invalidation controller
    - The `EXEC_JOURNAL` mode will not try to push invalidations in `ParserCachePurgeJob` via `Title` and instead store required dependency links temporarily in cache using the `DependencyLinksUpdateJournal` so that when a specific entity (aka page) is requested for viewing the journal will check whether the page has been listed and if so will return false to reject the parser cache which in turn will allow to execute a new `#ask` request
    - Using `EXEC_JOURNAL` has the advantage that in case of successive update requests (due to other or competing query dependency updates) only the cache entry is updated leaving the DB back-end "untouched" and hereby the page table for the the journal update. Only in the event that a marked page is viewed an actual `touched`/cache invalidation takes place.

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed
