### PR TITLE
Disallow CR, LF as part of a property name, refs 2282

### DIFF
--- a/DefaultSettings.php
+++ b/DefaultSettings.php
@@ -1537,7 +1537,7 @@ return array(
 	#
 	# @since 2.5
 	##
-	'smwgPropertyInvalidCharacterList' => array( '[', ']' , '|' , '<' , '>', '{', '}', '+', '%' ),
+	'smwgPropertyInvalidCharacterList' => array( '[', ']' , '|' , '<' , '>', '{', '}', '+', '%', "\r", "\n" ),
 	##
 
 	##

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -482,7 +482,7 @@
 	"smw-datavalue-property-restricted-annotation-use": "Property \"$1\" has a restricted application area and cannot be used as annotation property by a user.",
 	"smw-datavalue-property-restricted-declarative-use": "Property \"$1\" is a declarative property and can only be used on a property or category page.",
 	"smw-datavalue-property-create-restriction": "Property \"$1\" doesn't exist and the user is missing the \"$2\" permission (see [https://www.semantic-mediawiki.org/wiki/Help:Authority_mode authority mode]) to create or annotate values with an unapproved property.",
-	"smw-datavalue-property-invalid-character": "\"$1\" contains the \"$2\" character as part of a property label and has been classified as invalid.",
+	"smw-datavalue-property-invalid-character": "\"$1\" contains a listed \"$2\" character as part of the property label and has therefore been classified as invalid.",
 	"smw-datavalue-property-invalid-chain": "Using \"$1\" as property chain is not permitted during the annotation process.",
 	"smw-datavalue-restricted-use": "Datavalue \"$1\" has been marked for restricted use.",
 	"smw-datavalue-invalid-number": "\"$1\" can not be interpreted as a number.",

--- a/src/DataValues/ValueParsers/PropertyValueParser.php
+++ b/src/DataValues/ValueParsers/PropertyValueParser.php
@@ -111,14 +111,14 @@ class PropertyValueParser implements ValueParser {
 			htmlspecialchars_decode( $userValue )
 		);
 
-		if ( !$this->doCheckValidCharacters( $userValue ) ) {
+		if ( !$this->hasValidCharacters( $userValue ) ) {
 			return array( null, null, null );
 		}
 
 		return $this->getNormalizedValueFrom( $userValue );
 	}
 
-	private function doCheckValidCharacters( $value ) {
+	private function hasValidCharacters( $value ) {
 
 		if ( trim( $value ) === '' ) {
 			$this->errors[] = array( 'smw_emptystring' );
@@ -134,12 +134,21 @@ class PropertyValueParser implements ValueParser {
 			}
 		}
 
-		// #1567, only on a query context so that |sort=# are allowed
+		// #1567, Only allowed in connection with a query context (e.g sort=#)
 		if ( $invalidCharacter === '' && strpos( $value, '#' ) !== false && !$this->isQueryContext ) {
 			$invalidCharacter = '#';
 		}
 
 		if ( $invalidCharacter !== '' ) {
+
+			// Replace selected control chars otherwise the error display becomes
+			// unreadable
+			$invalidCharacter = str_replace(
+				[ "\r", "\n", ],
+				[ "CR", "LF" ],
+				$invalidCharacter
+			);
+
 			$this->errors[] = array( 'smw-datavalue-property-invalid-character', $value, $invalidCharacter );
 			return false;
 		}

--- a/tests/phpunit/Integration/JSONScript/TestCases/p-0102.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/p-0102.json
@@ -45,6 +45,10 @@
 		{
 			"page": "Example/P0102/9",
 			"contents": "[[Foo-<Bar>::abc]]"
+		},
+		{
+			"page": "Example/P0102/10",
+			"contents": "[[Foo\nBar::abc]] [[Foo\rBar::123]] [[Foo\r\nBar::456]]"
 		}
 	],
 	"tests": [
@@ -212,6 +216,22 @@
 					"propertyCount": 3,
 					"propertyKeys": [
 						"Foo-",
+						"_MDAT",
+						"_SKEY"
+					]
+				}
+			}
+		},
+		{
+			"type": "parser",
+			"about": "#10 (CR, LF are invalid)",
+			"subject": "Example/P0102/10",
+			"assert-store": {
+				"semantic-data": {
+					"strictPropertyValueMatch": false,
+					"propertyCount": 3,
+					"propertyKeys": [
+						"_ERRC",
 						"_MDAT",
 						"_SKEY"
 					]


### PR DESCRIPTION
This PR is made in reference to: #2282

This PR addresses or contains:

- Disallow `r` (CR) and `n` (LF, newline) in property names to avoid things like

![image](https://user-images.githubusercontent.com/1245473/33795069-8be055ba-dd1c-11e7-8a62-27b7153d11df.png)

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed
