### PR TITLE
Match singular, plural category canonical form, refs 2835

### DIFF
--- a/i18n/en.json
+++ b/i18n/en.json
@@ -640,5 +640,6 @@
 	"smw-property-page-list-count": "Showing $1 {{PLURAL:$1|page|pages}} using this property.",
 	"smw-property-page-list-search-count": "Showing $1 {{PLURAL:$1|page|pages}} using this property with a \"$2\" value match.",
 	"smw-property-reserved-category": "Category",
+	"smw-category": "Category",
 	"smw-datavalue-uri-invalid-scheme": " \"$1\" has not been listed as valid URI scheme."
 }

--- a/src/MediaWiki/Specials/Browse/ValueFormatter.php
+++ b/src/MediaWiki/Specials/Browse/ValueFormatter.php
@@ -137,7 +137,7 @@ class ValueFormatter {
 			$propertyValue->setCaption( self::findPropertyLabel( $propertyValue, $incoming, $showInverse ) );
 			$proptext = $propertyValue->getShortHTMLText( $linker ) . "\n";
 		} elseif ( $property->getKey() == '_INST' ) {
-			$proptext = $linker->specialLink( 'Categories' );
+			$proptext = $linker->specialLink( 'Categories', 'smw-category' );
 		} elseif ( $property->getKey() == '_REDI' ) {
 			$proptext = $linker->specialLink( 'Listredirects', 'isredirect' );
 		}

--- a/src/Query/PrintRequest/Deserializer.php
+++ b/src/Query/PrintRequest/Deserializer.php
@@ -98,8 +98,13 @@ class Deserializer {
 	}
 
 	private static function isCategory( $text ) {
-		return Localizer::getInstance()->getNamespaceTextById( NS_CATEGORY ) == mb_convert_case( $text, MB_CASE_TITLE ) ||
-		$text == 'Category';
+
+		// Check for the canonical form (singular, plural)
+		if ( $text == 'Category' || $text == 'Categories' ) {
+			return true;
+		}
+
+		return Localizer::getInstance()->getNamespaceTextById( NS_CATEGORY ) == mb_convert_case( $text, MB_CASE_TITLE );
 	}
 
 	private static function getPartsFromText( $text ) {

--- a/tests/phpunit/Integration/JSONScript/TestCases/p-0404.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/p-0404.json
@@ -2,15 +2,27 @@
 	"description": "Test in-text annonation on different category colon identifier",
 	"setup": [
 		{
-			"page": "Page-with-category",
+			"page": "Example/P0404/1",
 			"contents": "[[Category:SingleColonNotion]], [[Category::DoubleColonNotion]]"
+		},
+		{
+			"page": "Example/P0404/2",
+			"contents": "[[Category:P4040]]"
+		},
+		{
+			"page": "Example/P0404/Q.1",
+			"contents": "{{#ask: [[Category:P4040]] |?Category }}"
+		},
+		{
+			"page": "Example/P0404/Q.2",
+			"contents": "{{#ask: [[Category:P4040]] |?Categories }}"
 		}
 	],
 	"tests": [
 		{
 			"type": "parser",
 			"about": "#0 : vs. ::",
-			"subject": "Page-with-category",
+			"subject": "Example/P0404/1",
 			"assert-store": {
 				"semantic-data": {
 					"strictPropertyValueMatch": false,
@@ -27,9 +39,33 @@
 					]
 				}
 			}
+		},
+		{
+			"type": "parser",
+			"about": "#1 (printrequest singular use)",
+			"subject": "Example/P0404/Q.1",
+			"assert-output": {
+				"to-contain": [
+					"<th class=\"Category\"><a href=.*>Category</a></th>",
+					"<td class=\"smwtype_wpg\"><a href=.*Example/P0404/2\" title=\"Example/P0404/2\">Example/P0404/2</a></td>"
+				]
+			}
+		},
+		{
+			"type": "parser",
+			"about": "#2 (printrequest plural use)",
+			"subject": "Example/P0404/Q.2",
+			"assert-output": {
+				"to-contain": [
+					"<th class=\"Category\"><a href=.*>Category</a></th>",
+					"<td class=\"smwtype_wpg\"><a href=.*Example/P0404/2\" title=\"Example/P0404/2\">Example/P0404/2</a></td>"
+				]
+			}
 		}
 	],
 	"settings": {
+		"wgContLang": "en",
+		"wgLang": "en",
 		"smwgPageSpecialProperties": [
 			"_MDAT"
 		]

--- a/tests/phpunit/Integration/JSONScript/TestCases/s-0023.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/s-0023.json
@@ -1,0 +1,44 @@
+{
+	"description": "Test `Special:Browse` output category (`wgContLang=en`, `wgLang=en`)",
+	"setup": [
+		{
+			"page": "Example/S0023/1",
+			"contents": "[[Category:S0023]]"
+		}
+	],
+	"tests": [
+		{
+			"type": "special",
+			"about": "#0 (category singular display)",
+			"special-page": {
+				"page": "Browse",
+				"query-parameters": "Example/S0023/1",
+				"request-parameters": {
+					"output": "legacy"
+				}
+			},
+			"assert-output": {
+				"to-contain": [
+					"<div class=\"smw-table-cell smwb-cell smwb-prophead\"><a href=.*>Category</a></div>",
+					"<div class=\"smw-table-cell smwb-cell smwb-propval\"><span class=\"smwb-value\"><a href=.*>S0023</a></span>"
+				]
+			}
+		}
+	],
+	"settings": {
+		"wgContLang": "en",
+		"wgLang": "en",
+		"smwgPageSpecialProperties": [
+			"_MDAT"
+		],
+		"smwgNamespacesWithSemanticLinks": {
+			"NS_MAIN": true,
+			"SMW_NS_PROPERTY": true
+		}
+	},
+	"meta": {
+		"version": "2",
+		"is-incomplete": false,
+		"debug": false
+	}
+}

--- a/tests/phpunit/Unit/Query/PrintRequest/DeserializerTest.php
+++ b/tests/phpunit/Unit/Query/PrintRequest/DeserializerTest.php
@@ -94,6 +94,17 @@ class DeserializerTest extends \PHPUnit_Framework_TestCase {
 		);
 
 		#4
+		 // Category
+		$provider[] = array(
+			'Categories',
+			false,
+			$categoryName,
+			PrintRequest::PRINT_CATS,
+			null,
+			''
+		);
+
+		#5
 		$provider[] = array(
 			'Bar#foobar',
 			false,
@@ -103,7 +114,7 @@ class DeserializerTest extends \PHPUnit_Framework_TestCase {
 			'foobar'
 		);
 
-		#5
+		#6
 		$provider[] = array(
 			'Foo#',
 			false,
@@ -113,7 +124,7 @@ class DeserializerTest extends \PHPUnit_Framework_TestCase {
 			'-'
 		);
 
-		#6, 1464
+		#7, 1464
 		$provider[] = array(
 			'Has boolean#<span style="color: green; font-size: 120%;">&#10003;</span>,<span style="color: #AA0000; font-size: 120%;">&#10005;</span>=Label on (&#10003;,&#10005;)',
 			false,
@@ -123,7 +134,7 @@ class DeserializerTest extends \PHPUnit_Framework_TestCase {
 			'<span style="color: green; font-size: 120%;">&#10003;</span>,<span style="color: #AA0000; font-size: 120%;">&#10005;</span>'
 		);
 
-		#7
+		#8
 		$provider[] = array(
 			'Foo.Bar',
 			false,
@@ -133,7 +144,7 @@ class DeserializerTest extends \PHPUnit_Framework_TestCase {
 			''
 		);
 
-		#8
+		#9
 		$provider[] = array(
 			'Foo.Bar#foobar',
 			false,
@@ -143,7 +154,7 @@ class DeserializerTest extends \PHPUnit_Framework_TestCase {
 			'foobar'
 		);
 
-		#9 ...
+		#10 ...
 		$provider[] = array(
 			'Foo = <span style="color: green; font-size: 120%;">Label</span>',
 			false,
@@ -153,7 +164,7 @@ class DeserializerTest extends \PHPUnit_Framework_TestCase {
 			''
 		);
 
-		#10 ...
+		#11 ...
 		$provider[] = array(
 			'Foo#Bar = <span style="color: green; font-size: 120%;">Label</span>',
 			false,


### PR DESCRIPTION
This PR is made in reference to: #2835

This PR addresses or contains:

- To avoid confusion about `Category` or `Categories`, use singular form display in `Special:Browse` (see 2835)
- Printrequest will use either `Category` or `Categories` as canonical match and will display it as `Category`

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed
