### PR TITLE
Add support for `in:`expression in #ask syntax

### DIFF
--- a/DefaultSettings.php
+++ b/DefaultSettings.php
@@ -451,7 +451,7 @@ return array(
 	#
 	# @since 1.0
 	##
-	'smwgQComparators' => '<|>|!~|!|~|≤|≥|<<|>>|~=|like:|nlike:',
+	'smwgQComparators' => '<|>|!~|!|~|≤|≥|<<|>>|~=|like:|nlike:|in:',
 	##
 
 	###

--- a/src/Defines.php
+++ b/src/Defines.php
@@ -91,6 +91,7 @@ define( 'SMW_CMP_LESS', 7 ); // Matches only datavalues that are less than the g
 define( 'SMW_CMP_GRTR', 8 ); // Matches only datavalues that are greater than the given value.
 define( 'SMW_CMP_PRIM_LIKE', 20 ); // Native LIKE matches (in disregards of an existing full-text index)
 define( 'SMW_CMP_PRIM_NLKE', 21 ); // Native NLIKE matches (in disregards of an existing full-text index)
+define( 'SMW_CMP_IN', 22 ); // Short-cut for ~* ... *
 /**@}*/
 
 /**@{

--- a/src/Deserializers/DVDescriptionDeserializer/DescriptionDeserializer.php
+++ b/src/Deserializers/DVDescriptionDeserializer/DescriptionDeserializer.php
@@ -119,6 +119,20 @@ abstract class DescriptionDeserializer implements DispatchableDeserializer {
 	 */
 	protected function prepareValue( &$value, &$comparator ) {
 		$comparator = QueryComparator::getInstance()->extractComparatorFromString( $value );
+
+		if ( $comparator === SMW_CMP_IN ) {
+			$comparator = SMW_CMP_LIKE;
+
+			// `in:...` is for the "busy" user to avoid adding wildcards now and
+			// then to the value string
+			$value = "*$value*";
+
+			// No property and the assumption is [[in:...]] with the expected use
+			// of the wide proximity as indicated by an additional `~`
+			if ( $this->dataValue->getProperty() === null ) {
+				$value = "~$value";
+			}
+		}
 	}
 
 }

--- a/src/Deserializers/DVDescriptionDeserializer/NumberValueDescriptionDeserializer.php
+++ b/src/Deserializers/DVDescriptionDeserializer/NumberValueDescriptionDeserializer.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace SMW\Deserializers\DVDescriptionDeserializer;
+
+use InvalidArgumentException;
+use SMWDINumber as DINumber;
+use SMWNumberValue as NumberValue;
+
+/**
+ * @private
+ *
+ * @license GNU GPL v2+
+ * @since 3.0
+ *
+ * @author mwjames
+ */
+class NumberValueDescriptionDeserializer extends DescriptionDeserializer {
+
+	/**
+	 * @since 3.0
+	 *
+	 * {@inheritDoc}
+	 */
+	public function isDeserializerFor( $serialization ) {
+		return $serialization instanceof NumberValue;
+	}
+
+	/**
+	 * @since 3.0
+	 *
+	 * @param string $value
+	 *
+	 * @return Description
+	 */
+	public function deserialize( $value ) {
+
+		$comparator = SMW_CMP_EQ;
+		$this->prepareValue( $value, $comparator );
+
+		if( $comparator !== SMW_CMP_LIKE && $comparator !== SMW_CMP_PRIM_LIKE ) {
+
+			$this->dataValue->setUserValue( $value );
+
+			if ( $this->dataValue->isValid() ) {
+				return $this->descriptionFactory->newValueDescription(
+					$this->dataValue->getDataItem(),
+					$this->dataValue->getProperty(),
+					$comparator
+				);
+			} else {
+				return $this->descriptionFactory->newThingDescription();
+			}
+		}
+
+		// Remove things that belong to SMW_CMP_LIKE
+		$value = str_replace( [ '~', '*', '!' ], '', $value );
+
+		$this->dataValue->setUserValue( $value );
+
+		if ( !$this->dataValue->isValid() ) {
+			return $this->descriptionFactory->newThingDescription();
+		}
+
+		$dataItem = $this->dataValue->getDataItem();
+		$property = $this->dataValue->getProperty();
+
+		if ( $this->getErrors() !== array() ) {
+			return $this->descriptionFactory->newThingDescription();
+		}
+
+		// in:/~ signals a range request for a number context
+		if ( $dataItem->getNumber() >= 0 ) {
+			// `[[Has number::in:99]]` -> `[[Has number:: [[≥0]] [[≤99]] ]]`)
+			$description = $this->descriptionFactory->newConjunction(
+				[
+					$this->descriptionFactory->newValueDescription( new DINumber( 0 ), $property, SMW_CMP_GEQ ),
+					$this->descriptionFactory->newValueDescription( $dataItem, $property, SMW_CMP_LEQ )
+				]
+			);
+		} else {
+			// `[[Has number::in:-100]]` -> `[[Has number:: [[≥-100]] [[≤0]] ]]`
+			$description = $this->descriptionFactory->newConjunction(
+				[
+					$this->descriptionFactory->newValueDescription( $dataItem, $property, SMW_CMP_GEQ ),
+					$this->descriptionFactory->newValueDescription( new DINumber( 0 ), $property,SMW_CMP_LEQ  )
+				]
+			);
+		}
+
+		return $description;
+	}
+
+}

--- a/src/Deserializers/DVDescriptionDeserializerRegistry.php
+++ b/src/Deserializers/DVDescriptionDeserializerRegistry.php
@@ -8,6 +8,7 @@ use SMW\Deserializers\DVDescriptionDeserializer\MonolingualTextValueDescriptionD
 use SMW\Deserializers\DVDescriptionDeserializer\RecordValueDescriptionDeserializer;
 use SMW\Deserializers\DVDescriptionDeserializer\SomeValueDescriptionDeserializer;
 use SMW\Deserializers\DVDescriptionDeserializer\TimeValueDescriptionDeserializer;
+use SMW\Deserializers\DVDescriptionDeserializer\NumberValueDescriptionDeserializer;
 use SMWDataValue as DataValue;
 
 /**
@@ -95,6 +96,7 @@ class DVDescriptionDeserializerRegistry {
 
 		$dispatchingDescriptionDeserializer = new DispatchingDescriptionDeserializer();
 		$dispatchingDescriptionDeserializer->addDescriptionDeserializer( new TimeValueDescriptionDeserializer() );
+		$dispatchingDescriptionDeserializer->addDescriptionDeserializer( new NumberValueDescriptionDeserializer() );
 		$dispatchingDescriptionDeserializer->addDescriptionDeserializer( new RecordValueDescriptionDeserializer() );
 		$dispatchingDescriptionDeserializer->addDescriptionDeserializer( new MonolingualTextValueDescriptionDeserializer() );
 

--- a/src/Query/QueryComparator.php
+++ b/src/Query/QueryComparator.php
@@ -160,6 +160,7 @@ class QueryComparator {
 		$comparators = array(
 			'like:' => SMW_CMP_PRIM_LIKE,
 			'nlike:' => SMW_CMP_PRIM_NLKE,
+			'in:' => SMW_CMP_IN,
 			'!~' => SMW_CMP_NLKE,
 			'<<' => SMW_CMP_LESS,
 			'>>' => SMW_CMP_GRTR,

--- a/tests/phpunit/Integration/JSONScript/TestCases/q-0616.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/q-0616.json
@@ -1,0 +1,128 @@
+{
+	"description": "Test `in:` syntax on `_txt`, `_dat`, and `_num` values",
+	"setup": [
+		{
+			"namespace": "SMW_NS_PROPERTY",
+			"page": "Has number",
+			"contents": "[[Has type::Number]]"
+		},
+		{
+			"namespace": "SMW_NS_PROPERTY",
+			"page": "Has text",
+			"contents": "[[Has type::Text]]"
+		},
+		{
+			"namespace": "SMW_NS_PROPERTY",
+			"page": "Has date",
+			"contents": "[[Has type::Date]]"
+		},
+		{
+			"page": "Example/Q0616/1",
+			"contents": "[[Has date::1 Jan 1970 12:00]] [[Category:0616]]"
+		},
+		{
+			"page": "Example/Q0616/2",
+			"contents": "[[Has date::1 Jan 1971 12:00]] [[Category:0616]]"
+		},
+		{
+			"page": "Example/Q0616/3",
+			"contents": "[[Has text::abc def foo]] [[Category:0616]]"
+		},
+		{
+			"page": "Example/Q0616/4",
+			"contents": "[[Has text::abc foo]] [[Category:0616]]"
+		},
+		{
+			"page": "Example/Q0616/5",
+			"contents": "[[Has number::50]] [[Category:0616]]"
+		},
+		{
+			"page": "Example/Q0616/6",
+			"contents": "[[Has number::99]] [[Category:0616]]"
+		},
+		{
+			"page": "Example/Q0616/7",
+			"contents": "[[Has number::100]] [[Category:0616]]"
+		},
+		{
+			"page": "Example/Q0616/8",
+			"contents": "[[Has number::-20]] [[Category:0616]]"
+		}
+	],
+	"tests": [
+		{
+			"type": "query",
+			"about": "#0 (in: on date converted to `[[Has date:: [[≥1970]] [[<<1 January 1971 00:00:00]] ]]`)",
+			"condition": "[[Has date::in:1970]] [[Category:0616]]",
+			"printouts": [],
+			"parameters": {
+				"limit": "10"
+			},
+			"assert-queryresult": {
+				"count": 1,
+				"results": [
+					"Example/Q0616/1#0##"
+				]
+			}
+		},
+		{
+			"type": "query",
+			"about": "#1 (in: on text converted to `[[Has text::~*abc d*]]`)",
+			"condition": "[[Has text::in:abc d]] [[Category:0616]]",
+			"printouts": [],
+			"parameters": {
+				"limit": "10"
+			},
+			"assert-queryresult": {
+				"count": 1,
+				"results": [
+					"Example/Q0616/3#0##"
+				]
+			}
+		},
+		{
+			"type": "query",
+			"about": "#2 (in: on number converted to `[[Has number:: [[≥0]] [[≤99]] ]]`)",
+			"condition": "[[Has number::in:99]] [[Category:0616]]",
+			"printouts": [],
+			"parameters": {
+				"limit": "10"
+			},
+			"assert-queryresult": {
+				"count": 2,
+				"results": [
+					"Example/Q0616/5#0##",
+					"Example/Q0616/6#0##"
+				]
+			}
+		},
+		{
+			"type": "query",
+			"about": "#3 (in: on number converted to `[[Has number:: [[≥-100]] [[≤0]] ]]`)",
+			"condition": "[[Has number::in:-100]] [[Category:0616]]",
+			"printouts": [],
+			"parameters": {
+				"limit": "10"
+			},
+			"assert-queryresult": {
+				"count": 1,
+				"results": [
+					"Example/Q0616/8#0##"
+				]
+			}
+		}
+	],
+	"settings": {
+		"smwStrictComparators": false,
+		"smwgNamespacesWithSemanticLinks": {
+			"NS_MAIN": true,
+			"SMW_NS_PROPERTY": true,
+			"NS_HELP": true
+		}
+	},
+	"meta": {
+		"version": "2",
+		"is-incomplete": false,
+		"debug": false
+	}
+}

--- a/tests/phpunit/Unit/Deserializers/DVDescriptionDeserializer/NumberValueDescriptionDeserializerTest.php
+++ b/tests/phpunit/Unit/Deserializers/DVDescriptionDeserializer/NumberValueDescriptionDeserializerTest.php
@@ -1,0 +1,113 @@
+<?php
+
+namespace SMW\Tests\Deserializers\DVDescriptionDeserializer;
+
+use SMW\Deserializers\DVDescriptionDeserializer\NumberValueDescriptionDeserializer;
+
+/**
+ * @covers \SMW\Deserializers\DVDescriptionDeserializer\NumberValueDescriptionDeserializer
+ * @group semantic-mediawiki
+ *
+ * @license GNU GPL v2+
+ * @since 3.0
+ *
+ * @author mwjames
+ */
+class NumberValueDescriptionDeserializerTest extends \PHPUnit_Framework_TestCase {
+
+	public function testCanConstruct() {
+
+		$this->assertInstanceOf(
+			NumberValueDescriptionDeserializer::class,
+			new NumberValueDescriptionDeserializer()
+		);
+	}
+
+	public function testIsDeserializerForNumberValue() {
+
+		$dataValue = $this->getMockBuilder( '\SMWNumberValue' )
+			->disableOriginalConstructor()
+			->getMockForAbstractClass();
+
+		$instance = new NumberValueDescriptionDeserializer();
+
+		$this->assertTrue(
+			$instance->isDeserializerFor( $dataValue )
+		);
+	}
+
+	/**
+	 * @dataProvider valueProvider
+	 */
+	public function testDeserialize( $value, $decription ) {
+
+		$numberValue = $this->getMockBuilder( '\SMWNumberValue' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$numberValue->expects( $this->any() )
+			->method( 'isValid' )
+			->will( $this->returnValue( true ) );
+
+		$numberValue->expects( $this->any() )
+			->method( 'getDataItem' )
+			->will( $this->returnValue( new \SMWDINumber( 42 ) ) );
+
+		$numberValue->expects( $this->any() )
+			->method( 'getProperty' )
+			->will( $this->returnValue( new \SMW\DIProperty( 'Foo' ) ) );
+
+		$instance = new NumberValueDescriptionDeserializer();
+		$instance->setDataValue( $numberValue );
+
+		$this->assertInstanceOf(
+			$decription,
+			$instance->deserialize( $value )
+		);
+	}
+
+	public function testInvalidNumberValueReturnsThingDescription() {
+
+		$numberValue = $this->getMockBuilder( '\SMWNumberValue' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$numberValue->expects( $this->any() )
+			->method( 'isValid' )
+			->will( $this->returnValue( false ) );
+
+		$instance = new NumberValueDescriptionDeserializer();
+		$instance->setDataValue( $numberValue );
+
+		$this->assertInstanceOf(
+			'\SMW\Query\Language\ThingDescription',
+			$instance->deserialize( 'Foo' )
+		);
+	}
+
+	public function valueProvider() {
+
+		$provider[] = array(
+			'42',
+			'\SMW\Query\Language\ValueDescription'
+		);
+
+		$provider[] = array(
+			'~42',
+			'\SMW\Query\Language\Conjunction'
+		);
+
+		$provider[] = array(
+			'~*42*',
+			'\SMW\Query\Language\Conjunction'
+		);
+
+		$provider[] = array(
+			'~-42',
+			'\SMW\Query\Language\Conjunction'
+		);
+
+		return $provider;
+	}
+
+}

--- a/tests/phpunit/Unit/Deserializers/DVDescriptionDeserializerRegistryTest.php
+++ b/tests/phpunit/Unit/Deserializers/DVDescriptionDeserializerRegistryTest.php
@@ -65,6 +65,20 @@ class DVDescriptionDeserializerRegistryTest extends \PHPUnit_Framework_TestCase 
 		);
 	}
 
+	public function testCanConstructNumberValueDescriptionDeserializer() {
+
+		$dataValue = $this->getMockBuilder( '\SMWNumberValue' )
+			->disableOriginalConstructor()
+			->getMockForAbstractClass();
+
+		$instance = new DVDescriptionDeserializerRegistry();
+
+		$this->assertInstanceOf(
+			'\SMW\Deserializers\DVDescriptionDeserializer\NumberValueDescriptionDeserializer',
+			$instance->getDescriptionDeserializerBy( $dataValue )
+		);
+	}
+
 	public function testCanConstructRecordValueDescriptionDeserializer() {
 
 		$dataValue = $this->getMockBuilder( '\SMWRecordValue' )


### PR DESCRIPTION
This PR is made in reference to: #

This PR addresses or contains:

- Adds the `in:` expression for the "lazy" user and is equivalent to `~*...*` so that in case of `[[Has text::in:foo]]` the condition is transformed into `[[Has text::~*foo*]]`
- Adds `NumberValueDescriptionDeserializer` so that
  - `[[Has number::in:100]]` creates a range of `[[Has number:: [[≥0]] [[≤100]] ]]` and
  - `[[Has number::in:-100]]` is established as `[[Has number:: [[≥-100]] [[≤0]] ]]`
- Using it on a date type such as `[[Has date::in:1970]]`  will create a range of `[[Has date:: [[≥1970]] [[<<1 January 1971 00:00:00]] ]]`

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed
