### PR TITLE
Special:Browse to use `smwb-theme-light`

### DIFF
--- a/res/smw/special/ext.smw.special.browse.css
+++ b/res/smw/special/ext.smw.special.browse.css
@@ -176,3 +176,22 @@ span.smwb-ivalue {
 	border-color: #ddd;
 	outline: 0;
 }
+
+/**
+ * Light theme
+ */
+.smwb-theme-light .smwb-factbox {
+	border-left: 0.5em solid #f0f0f0;
+}
+
+.smwb-theme-light .smwb-ifactbox {
+	border-right: 0.5em solid #f0f0f0;
+}
+
+.smwb-theme-light .smwb-title, .smwb-theme-light .smwb-center, .smwb-theme-light .smwb-actions, .smwb-theme-light .smwb-prophead  {
+	background-color: #f0f0f0;
+}
+
+.smwb-theme-light .smwb-propval  {
+	background-color: #f7f7f7;
+}

--- a/src/MediaWiki/Specials/Browse/ContentsBuilder.php
+++ b/src/MediaWiki/Specials/Browse/ContentsBuilder.php
@@ -190,7 +190,7 @@ class ContentsBuilder {
 	 */
 	private function createHtml() {
 
-		$html = "<div class=\"smwb-datasheet\">";
+		$html = "<div class=\"smwb-datasheet smwb-theme-light\">";
 
 		$leftside = true;
 		$modules = array();

--- a/tests/phpunit/Unit/MediaWiki/Api/BrowseBySubjectTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Api/BrowseBySubjectTest.php
@@ -194,7 +194,7 @@ class BrowseBySubjectTest extends \PHPUnit_Framework_TestCase {
 		$out = ob_get_clean();
 
 		$this->stringValidator->assertThatStringContains(
-			'"query":"<div class=\"smwb-datasheet\"><div class=\"smw-table smwb-factbox\">',
+			'"query":"<div class=\"smwb-datasheet.*\"><div class=\"smw-table smwb-factbox\">',
 			$out
 		);
 	}


### PR DESCRIPTION
This PR is made in reference to: #2786

This PR addresses or contains:

- Adds a simple set of CSS rules to create a light theme (right)

For comparison:

![image](https://user-images.githubusercontent.com/1245473/33800057-237dc7a4-dd7c-11e7-8d5d-7bed54785799.png)

This PR includes:
- [ ] Tests (unit/integration)
- [x] CI build passed

Fixes #