### PR TITLE
Allows list to use list key for comparison

### DIFF
--- a/src/DataValues/ValueValidators/AllowsListConstraintValueValidator.php
+++ b/src/DataValues/ValueValidators/AllowsListConstraintValueValidator.php
@@ -64,7 +64,10 @@ class AllowsListConstraintValueValidator implements ConstraintValueValidator {
 		$propertySpecificationLookup = ApplicationFactory::getInstance()->getPropertySpecificationLookup();
 
 		$allowedValues = $propertySpecificationLookup->getAllowedValuesBy( $property );
-		$allowedListValues = $propertySpecificationLookup->getAllowedListValueBy( $property );
+
+		$allowedListValues = $propertySpecificationLookup->getAllowedListValues(
+			$property
+		);
 
 		if ( $allowedValues === array() && $allowedListValues === array() ) {
 			return $this->hasConstraintViolation;
@@ -72,7 +75,7 @@ class AllowsListConstraintValueValidator implements ConstraintValueValidator {
 
 		$allowedValueList = array();
 
-		$isAllowed = $this->checkOnConstraintViolation(
+		$isAllowed = $this->checkConstraintViolation(
 			$dataValue,
 			$allowedValues,
 			$allowedValueList
@@ -84,9 +87,13 @@ class AllowsListConstraintValueValidator implements ConstraintValueValidator {
 					$allowedList->getString()
 				);
 			}
+
+			// On assignments like [Foo => Foo] (* Foo) or [Foo => Bar] (* Foo|Bar)
+			// use the key as comparison entity
+			$allowedValues = array_keys( $allowedValues );
 		}
 
-		$isAllowed = $this->checkOnConstraintViolation(
+		$isAllowed = $this->checkConstraintViolation(
 			$dataValue,
 			$allowedValues,
 			$allowedValueList
@@ -116,7 +123,7 @@ class AllowsListConstraintValueValidator implements ConstraintValueValidator {
 		$this->hasConstraintViolation = true;
 	}
 
-	private function checkOnConstraintViolation( $dataValue, $allowedValues, &$allowedValueList ) {
+	private function checkConstraintViolation( $dataValue, $allowedValues, &$allowedValueList ) {
 
 		if ( !is_array( $allowedValues ) ) {
 			return true;

--- a/src/PropertySpecificationLookup.php
+++ b/src/PropertySpecificationLookup.php
@@ -268,7 +268,7 @@ class PropertySpecificationLookup {
 	 *
 	 * @return array
 	 */
-	public function getAllowedListValueBy( DIProperty $property ) {
+	public function getAllowedListValues( DIProperty $property ) {
 
 		$allowsListValue = array();
 		$dataItems = $this->getSpecification( $property, new DIProperty( '_PVALI' ) );

--- a/tests/phpunit/Integration/JSONScript/TestCases/p-0502.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/p-0502.json
@@ -16,6 +16,11 @@
 			}
 		},
 		{
+			"namespace": "NS_MEDIAWIKI",
+			"page": "Smw allows list license",
+			"contents": "* BSD-2-Clause|2-clause BSD License (BSD-2-Clause)\n* Zlib|zlib/libpng license (Zlib)"
+		},
+		{
 			"namespace": "SMW_NS_PROPERTY",
 			"page": "Has list",
 			"contents": "[[Has type::Text]] [[Allows value list::Publication categories]]"
@@ -29,6 +34,11 @@
 			"namespace": "SMW_NS_PROPERTY",
 			"page": "Has combined error list",
 			"contents": "[[Has type::Text]] [[Allows value list::error]] [[Allows value::Foo]]"
+		},
+		{
+			"namespace": "SMW_NS_PROPERTY",
+			"page": "Has license",
+			"contents": "[[Has type::Text]] [[Allows value list::license]]"
 		},
 		{
 			"page": "Example/P0502/1",
@@ -45,6 +55,10 @@
 		{
 			"page": "Example/P0502/4",
 			"contents": "[[Has combined error list::Foobar]]"
+		},
+		{
+			"page": "Example/P0502/5",
+			"contents": "[[Has license::Zlib]]"
 		}
 	],
 	"tests": [
@@ -113,6 +127,25 @@
 				"to-contain": [
 					"\"Foobar\" is not in the list (Foo, Bar)"
 				]
+			}
+		},
+		{
+			"type": "parser",
+			"about": "#4 assignment on key (* key|value)",
+			"subject": "Example/P0502/5",
+			"assert-store": {
+				"semantic-data": {
+					"strictPropertyValueMatch": false,
+					"propertyCount": 3,
+					"propertyKeys": [
+						"_SKEY",
+						"_MDAT",
+						"Has license"
+					],
+					"propertyValues": [
+						"Zlib"
+					]
+				}
 			}
 		}
 	],

--- a/tests/phpunit/Unit/DataValues/ValueValidators/AllowsListConstraintValueValidatorTest.php
+++ b/tests/phpunit/Unit/DataValues/ValueValidators/AllowsListConstraintValueValidatorTest.php
@@ -58,7 +58,7 @@ class AllowsListConstraintValueValidatorTest extends \PHPUnit_Framework_TestCase
 			->will( $this->returnValue( array( $this->dataItemFactory->newDIBlob( 'Foo' ) ) ) );
 
 		$this->propertySpecificationLookup->expects( $this->any() )
-			->method( 'getAllowedListValueBy' )
+			->method( 'getAllowedListValues' )
 			->will( $this->returnValue( array() ) );
 
 		$dataValue = $this->getMockBuilder( '\SMWDataValue' )
@@ -98,7 +98,7 @@ class AllowsListConstraintValueValidatorTest extends \PHPUnit_Framework_TestCase
 			->will( $this->returnValue( array( $this->dataItemFactory->newDIBlob( 'NOTALLOWED' ) ) ) );
 
 		$this->propertySpecificationLookup->expects( $this->any() )
-			->method( 'getAllowedListValueBy' )
+			->method( 'getAllowedListValues' )
 			->will( $this->returnValue( array() ) );
 
 		$dataValue = $this->getMockBuilder( '\SMWDataValue' )
@@ -151,7 +151,7 @@ class AllowsListConstraintValueValidatorTest extends \PHPUnit_Framework_TestCase
 					$this->dataItemFactory->newDIBlob( 'VAL11' ) ) ) );
 
 		$this->propertySpecificationLookup->expects( $this->any() )
-			->method( 'getAllowedListValueBy' )
+			->method( 'getAllowedListValues' )
 			->will( $this->returnValue( array( ) ) );
 
 		$dataValue = $this->getMockBuilder( '\SMWDataValue' )

--- a/tests/phpunit/Unit/PropertySpecificationLookupTest.php
+++ b/tests/phpunit/Unit/PropertySpecificationLookupTest.php
@@ -258,7 +258,7 @@ class PropertySpecificationLookupTest extends \PHPUnit_Framework_TestCase {
 
 		$this->assertEquals(
 			array( 'Foo' ),
-			$instance->getAllowedListValueBy( $property )
+			$instance->getAllowedListValues( $property )
 		);
 	}
 


### PR DESCRIPTION
This PR is made in reference to: #2295 

This PR addresses or contains:

- Use the key (`* Foo|Bar`) for comparison

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed

Fixes #