### PR TITLE
Add value filter to property page, refs 2785

### DIFF
--- a/i18n/en.json
+++ b/i18n/en.json
@@ -647,5 +647,6 @@
 	"smw-browse-property-group-title": "Property group",
 	"smw-browse-property-group-label": "Property group label",
 	"smw-browse-property-group-description": "Property group description",
-	"smw-pa-property-predefined_ppgr": "\"$1\" is a predefined property that identifies entities (mainly categories) that are used as grouping instance for properties and is provided by [https://www.semantic-mediawiki.org/wiki/Help:Special_properties Semantic MediaWiki]."
+	"smw-pa-property-predefined_ppgr": "\"$1\" is a predefined property that identifies entities (mainly categories) that are used as grouping instance for properties and is provided by [https://www.semantic-mediawiki.org/wiki/Help:Special_properties Semantic MediaWiki].",
+	"smw-list-pager-filter": "Filter:"
 }

--- a/res/smw/ext.smw.page.css
+++ b/res/smw/ext.smw.page.css
@@ -133,7 +133,6 @@
 }
 
 .list-pager-value-filter {
-	float: right;
 	text-align: right;
 }
 
@@ -162,7 +161,7 @@
 
 	position: relative;
 		/* display: block; */
-		padding: 0.5rem 0.75rem;
+		/* padding: 0.5rem 0.75rem; */
 		/* margin-left: -1px; */
 		line-height: 1.25;
 		/* color: #0275d8; */

--- a/src/Page/ListPager.php
+++ b/src/Page/ListPager.php
@@ -47,34 +47,52 @@ class ListPager {
 	 *
 	 * @return string
 	 */
-	public static function searchInputElement( Title $title, $limit = 0, $offset = 0 ) {
+	public static function filterInput( Title $title, $limit = 0, $offset = 0, $filter = '' ) {
 
-		$searchLabel = wfMessage( 'smw-format-datatable-search' )->text();
-
-		$form = \Xml::tags( 'form', array(
-			'id'     => 'search',
-			'name'   =>'foo',
-			'action' => $GLOBALS['wgScript']
-		), Html::hidden(
+		$form = \Xml::tags(
+			'form',
+			[
+				'id'     => 'search',
+				'name'   => 'foo',
+				'action' => $GLOBALS['wgScript']
+			],
+			Html::hidden(
 			'title',
 			strtok( $title->getPrefixedText(), '/' )
-		) . Html::hidden(
-			'limit',
-			$limit
-		) . Html::hidden(
-			'offset',
-			$offset
-		) . '<label>' . $searchLabel . '<input type="search" name="value" class="" placeholder="" aria-controls="" form="search"></label>' );
+			) . Html::hidden(
+				'limit',
+				$limit
+			) . Html::hidden(
+				'offset',
+				$offset
+			)
+		);
 
-		$search = '<div id="list-pager" class="list-pager-value-filter">' . $form . '</div>';
+		$label = wfMessage( 'smw-list-pager-filter' )->text();
+
+		$form .= Html::rawElement(
+			'label',
+			[],
+			$label . Html::rawElement(
+				'input',
+				[
+					'type' => 'search',
+					'name' => 'filter',
+					'value' => $filter,
+					'form' => 'search'
+				]
+			)
+		);
 
 		return Html::rawElement(
 			'div',
-			array(),
-			$search
+			[
+				'id' => 'list-pager',
+				'class' => 'list-pager-value-filter'
+			],
+			$form
 		);
 	}
-
 
 	/**
 	 * Generate (prev x| next x) (20|50|100...) type links for paging

--- a/src/Query/Parser.php
+++ b/src/Query/Parser.php
@@ -15,6 +15,23 @@ interface Parser {
 	/**
 	 * @since 3.0
 	 *
+	 * @param DIProperty|string $property
+	 * @param string $value
+	 *
+	 * @return string
+	 */
+	public function createCondition( $property, $value );
+
+	/**
+	 * @since 3.0
+	 *
+	 * @return []
+	 */
+	public function getErrors();
+
+	/**
+	 * @since 3.0
+	 *
 	 * @param string $condition
 	 *
 	 * @return Description

--- a/src/Query/Parser/LegacyParser.php
+++ b/src/Query/Parser/LegacyParser.php
@@ -205,6 +205,20 @@ class LegacyParser implements Parser {
 	}
 
 	/**
+	 * @since 3.0
+	 *
+	 * {@inheritDoc}
+	 */
+	public function createCondition( $property, $value ) {
+
+		if ( $property instanceOf DIProperty ) {
+			$property = $property->getLabel();
+		}
+
+		return "[[$property::$value]]";
+	}
+
+	/**
 	 * Compute an SMWDescription from a query string. Returns whatever descriptions could be
 	 * wrestled from the given string (the most general result being SMWThingDescription if
 	 * no meaningful condition was extracted).

--- a/tests/phpunit/Integration/JSONScript/TestCases/p-1001.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/p-1001.json
@@ -13,6 +13,10 @@
 		{
 			"page": "Example/P1001/2",
 			"contents": "[[Has page test::Two]]"
+		},
+		{
+			"page": "Example/P1001/3",
+			"contents": "[[Has page test::Foo]]"
 		}
 	],
 	"tests": [
@@ -49,6 +53,23 @@
 				"to-contain": [
 					"Has_page_test&amp;limit=1&amp;offset=0",
 					"title=\"Example/P1001/2\""
+				]
+			}
+		},
+		{
+			"type": "parser",
+			"about": "#2 (use a filter)",
+			"namespace": "SMW_NS_PROPERTY",
+			"subject": "Has page test",
+			"assert-output": {
+				"onPageView": {
+					"parameters": {
+						"filter": "Foo"
+					}
+				},
+				"to-contain": [
+					"=&amp;filter=Foo",
+					"title=\"Example/P1001/3\""
 				]
 			}
 		}

--- a/tests/phpunit/Unit/Query/Parser/LegacyParserTest.php
+++ b/tests/phpunit/Unit/Query/Parser/LegacyParserTest.php
@@ -16,7 +16,7 @@ use SMW\Tests\TestEnvironment;
  * @group semantic-mediawiki
  *
  * @license GNU GPL v2+
- * @since 2.0
+ * @since 3.0
  *
  * @author mwjames
  */
@@ -73,6 +73,19 @@ class LegacyParserTest extends \PHPUnit_Framework_TestCase {
 		$this->assertInstanceOf(
 			'\SMW\Query\Parser',
 			new QueryParser( $descriptionProcessor, $tokenizer, $queryToken )
+		);
+	}
+
+	public function testCreateCondition() {
+
+		$this->assertEquals(
+			'[[Foo::Bar]]',
+			$this->queryParser->createCondition( 'Foo', 'Bar' )
+		);
+
+		$this->assertEquals(
+			'[[Foo::Bar]]',
+			$this->queryParser->createCondition( new DIProperty( 'Foo' ), 'Bar' )
 		);
 	}
 


### PR DESCRIPTION
This PR is made in reference to: #2785 

This PR addresses or contains:

- Adds an input field to the property page for allowing to filter values that match an entered argument

![image](https://user-images.githubusercontent.com/1245473/33808643-9a011c6c-de2d-11e7-9959-a6f0c6f4172b.png)

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed

Fixes #