### PR TITLE
DataRebuilder display dispatched ID

### DIFF
--- a/src/Maintenance/DataRebuilder.php
+++ b/src/Maintenance/DataRebuilder.php
@@ -259,6 +259,7 @@ class DataRebuilder {
 		while ( ( ( !$this->end ) || ( $id <= $this->end ) ) && ( $id > 0 ) ) {
 
 			$progress = '';
+			$dispatchedId = $id;
 
 			$this->rebuildCount++;
 			$this->exceptionLog = array();
@@ -271,16 +272,16 @@ class DataRebuilder {
 
 			foreach ( $entityRebuildDispatcher->getDispatchedEntities() as $value ) {
 
-				$text = $this->getHumanReadableTextFrom( $id, $value );
+				$text = $this->getHumanReadableTextFrom( $dispatchedId, $value );
 
 				$this->reportMessage(
 					sprintf( "%-16s%s\n", "($this->rebuildCount/$total)", "Finished processing ID " . $text ),
 					$this->options->has( 'v' )
 				);
 
-				if ( $this->options->has( 'ignore-exceptions' ) && isset( $this->exceptionLog[$id] ) ) {
+				if ( $this->options->has( 'ignore-exceptions' ) && isset( $this->exceptionLog[$dispatchedId] ) ) {
 					$this->exceptionFileLogger->doWriteExceptionLog(
-						array( $id . ' ' . $text => $this->exceptionLog[$id] )
+						array( $dispatchedId . ' ' . $text => $this->exceptionLog[$dispatchedId] )
 					);
 				}
 			}


### PR DESCRIPTION
This PR is made in reference to: #

This PR addresses or contains:

- Display the requested ID and not the forwarded one which caused the `-v` option to display a +1 increment 

This PR includes:
- [ ] Tests (unit/integration)
- [x] CI build passed

Fixes #