### PR TITLE
Detect and mark duplicate entities upon storage, refs 191, 2446

### DIFF
--- a/includes/storage/SQLStore/SMW_SQLStore3_Writers.php
+++ b/includes/storage/SQLStore/SMW_SQLStore3_Writers.php
@@ -266,6 +266,25 @@ class SMWSQLStore3Writers {
 			true
 		);
 
+		// Find any potential duplicate entries for the current subject and
+		// if matched, mark them as to be deleted
+		$idList = $this->store->getObjectIds()->getListOfIdMatchesFor(
+			$subject->getDBkey(),
+			$subject->getNamespace(),
+			$subject->getInterwiki(),
+			$subject->getSubobjectName()
+		);
+
+		foreach ( $idList as $id ) {
+			if ( $id != $sid ) {
+				$this->store->getObjectIds()->updateInterwikiField(
+					$id,
+					$subject,
+					SMW_SQL3_SMWDELETEIW
+				);
+			}
+		}
+
 		// Take care of all remaining property table data
 		list( $insertRows, $deleteRows, $newHashes ) = $this->propertyTableRowDiffer->computeTableRowDiff(
 			$sid,

--- a/tests/phpunit/includes/SQLStore/Writer/ChangeTitleTest.php
+++ b/tests/phpunit/includes/SQLStore/Writer/ChangeTitleTest.php
@@ -30,6 +30,10 @@ class ChangeTitleTest extends \PHPUnit_Framework_TestCase {
 			->disableOriginalConstructor()
 			->getMock();
 
+		$entityManager->expects( $this->any() )
+			->method( 'getListOfIdMatchesFor' )
+			->will( $this->returnValue( [] ) );
+
 		$this->store = $this->getMockBuilder( '\SMWSQLStore3' )
 			->disableOriginalConstructor()
 			->getMock();
@@ -133,6 +137,10 @@ class ChangeTitleTest extends \PHPUnit_Framework_TestCase {
 			->disableOriginalConstructor()
 			->getMock();
 
+		$objectIdGenerator->expects( $this->any() )
+			->method( 'getListOfIdMatchesFor' )
+			->will( $this->returnValue( [] ) );
+
 		$objectIdGenerator->expects( $this->at( 0 ) )
 			->method( 'getSMWPageID' )
 			->will( $this->returnValue( 1 ) );
@@ -198,6 +206,10 @@ class ChangeTitleTest extends \PHPUnit_Framework_TestCase {
 		$objectIdGenerator = $this->getMockBuilder( '\SMWSql3SmwIds' )
 			->disableOriginalConstructor()
 			->getMock();
+
+		$objectIdGenerator->expects( $this->any() )
+			->method( 'getListOfIdMatchesFor' )
+			->will( $this->returnValue( [] ) );
 
 		$objectIdGenerator->expects( $this->at( 0 ) )
 			->method( 'getSMWPageID' )

--- a/tests/phpunit/includes/SQLStore/Writer/DataUpdateTest.php
+++ b/tests/phpunit/includes/SQLStore/Writer/DataUpdateTest.php
@@ -31,6 +31,10 @@ class DataUpdateTest extends \PHPUnit_Framework_TestCase {
 			->disableOriginalConstructor()
 			->getMock();
 
+		$entityManager->expects( $this->any() )
+			->method( 'getListOfIdMatchesFor' )
+			->will( $this->returnValue( [] ) );
+
 		$this->store = $this->getMockBuilder( '\SMWSQLStore3' )
 			->disableOriginalConstructor()
 			->getMock();
@@ -141,6 +145,10 @@ class DataUpdateTest extends \PHPUnit_Framework_TestCase {
 			->disableOriginalConstructor()
 			->getMock();
 
+		$objectIdGenerator->expects( $this->any() )
+			->method( 'getListOfIdMatchesFor' )
+			->will( $this->returnValue( [] ) );
+
 		$objectIdGenerator->expects( $this->once() )
 			->method( 'getSMWPageIDandSort' )
 			->will( $this->returnValue( 0 ) );
@@ -197,6 +205,10 @@ class DataUpdateTest extends \PHPUnit_Framework_TestCase {
 		$objectIdGenerator = $this->getMockBuilder( '\SMWSql3SmwIds' )
 			->disableOriginalConstructor()
 			->getMock();
+
+		$objectIdGenerator->expects( $this->any() )
+			->method( 'getListOfIdMatchesFor' )
+			->will( $this->returnValue( [] ) );
 
 		$objectIdGenerator->expects( $this->once() )
 			->method( 'getSMWPageIDandSort' )

--- a/tests/phpunit/includes/SQLStore/Writer/DeleteSubjectTest.php
+++ b/tests/phpunit/includes/SQLStore/Writer/DeleteSubjectTest.php
@@ -134,7 +134,7 @@ class DeleteSubjectTest extends \PHPUnit_Framework_TestCase {
 			->disableOriginalConstructor()
 			->getMock();
 
-		$objectIdGenerator->expects( $this->once() )
+		$objectIdGenerator->expects( $this->atLeastOnce() )
 			->method( 'getListOfIdMatchesFor' )
 			->will( $this->returnValue( array( 0 ) ) );
 
@@ -142,7 +142,7 @@ class DeleteSubjectTest extends \PHPUnit_Framework_TestCase {
 			->disableOriginalConstructor()
 			->getMock();
 
-		$this->store->expects( $this->exactly( 6 ) )
+		$this->store->expects( $this->exactly( 7 ) )
 			->method( 'getObjectIds' )
 			->will( $this->returnValue( $objectIdGenerator ) );
 
@@ -174,7 +174,7 @@ class DeleteSubjectTest extends \PHPUnit_Framework_TestCase {
 			->disableOriginalConstructor()
 			->getMock();
 
-		$objectIdGenerator->expects( $this->once() )
+		$objectIdGenerator->expects( $this->atLeastOnce() )
 			->method( 'getListOfIdMatchesFor' )
 			->with(
 				$this->equalTo( $title->getDBkey() ),
@@ -195,7 +195,7 @@ class DeleteSubjectTest extends \PHPUnit_Framework_TestCase {
 			->method( 'getConnection' )
 			->will( $this->returnValue( $database ) );
 
-		$this->store->expects( $this->exactly( 6 ) )
+		$this->store->expects( $this->exactly( 7 ) )
 			->method( 'getObjectIds' )
 			->will( $this->returnValue( $objectIdGenerator ) );
 


### PR DESCRIPTION
This PR is made in reference to: #191, #2446

This PR addresses or contains:

- Ensure that only one ID for an individual entity exists, other entries are marked and disposed when `rebuildData.php` is executed

This PR includes:
- [ ] Tests (unit/integration)
- [x] CI build passed

Fixes #