### PR TITLE
Fix "SubobjectListFinder ... Cannot use object of type MappingIterato as array", refs 1959

### DIFF
--- a/includes/storage/SQLStore/SMW_SQLStore3_Writers.php
+++ b/includes/storage/SQLStore/SMW_SQLStore3_Writers.php
@@ -115,6 +115,8 @@ class SMWSQLStore3Writers {
 			);
 		}
 
+		$subject->setId( $id );
+
 		// Mark subject/subobjects with a special IW, the final removal is being
 		// triggered by the `EntityRebuildDispatcher`
 		$this->store->getObjectIds()->updateInterwikiField(

--- a/src/SQLStore/EntityStore/SubobjectListFinder.php
+++ b/src/SQLStore/EntityStore/SubobjectListFinder.php
@@ -65,11 +65,13 @@ class SubobjectListFinder {
 	 */
 	public function find( DIWikiPage $subject ) {
 
-		if ( !isset( $this->mappingIterator[$subject->getHash()] ) ) {
-			$this->mappingIterator = $this->newMappingIterator( $subject );
+		$key = $subject->getHash() . ':' . $subject->getId();
+
+		if ( !isset( $this->mappingIterator[$key] ) ) {
+			$this->mappingIterator[$key] = $this->newMappingIterator( $subject );
 		}
 
-		return $this->mappingIterator;
+		return $this->mappingIterator[$key];
 	}
 
 	/**


### PR DESCRIPTION
This PR is made in reference to: #1959

This PR addresses or contains:

- Fence against an edge case that came to light due to having a duplicate entity (#2882) being deleted

```
[5d1a05a6abf3bddd1de873c4] /mw-master/index.php?title=DataTablesDate&action=delete Error from line 68 of ...\extensions\SemanticMediaWiki\src\SQLStore\EntityStore\SubobjectListFinder.php: Cannot use object of type SMW\Iterators\MappingIterator as array

Backtrace:

#0 ...\extensions\SemanticMediaWiki\includes\storage\SQLStore\SMW_SQLStore3_Writers.php(126): SMW\SQLStore\EntityStore\SubobjectListFinder->find(SMW\DIWikiPage)
#1 ...\extensions\SemanticMediaWiki\includes\storage\SQLStore\SMW_SQLStore3_Writers.php(91): SMWSQLStore3Writers->doDelete(string, SMW\DIWikiPage, SMW\SQLStore\EntityStore\SubobjectListFinder)
#2 ...\extensions\SemanticMediaWiki\includes\storage\SQLStore\SMW_SQLStore3.php(248): SMWSQLStore3Writers->deleteSubject(Title)
#3 ...\extensions\SemanticMediaWiki\src\MediaWiki\Hooks\ArticleDelete.php(98): SMWSQLStore3->deleteSubject(Title)
#4 ...\extensions\SemanticMediaWiki\src\MediaWiki\Hooks\ArticleDelete.php(48): SMW\MediaWiki\Hooks\ArticleDelete->doDelete(Title)
#5 [internal function]: SMW\MediaWiki\Hooks\ArticleDelete->SMW\MediaWiki\Hooks\{closure}()
#6 ...\extensions\SemanticMediaWiki\src\Updater\DeferredCallableUpdate.php(236): call_user_func(Closure)
#7 ...\includes\deferred\DeferredUpdates.php(259): SMW\Updater\DeferredCallableUpdate->doUpdate()
#8 ...\includes\deferred\DeferredUpdates.php(210): DeferredUpdates::runUpdate(SMW\Updater\DeferredCallableUpdate, Wikimedia\Rdbms\LBFactorySimple, string, integer)
#9 ...\includes\deferred\DeferredUpdates.php(131): DeferredUpdates::execute(array, string, integer)
#10 ...\includes\MediaWiki.php(897): DeferredUpdates::doUpdates(string)
#11 ...\includes\MediaWiki.php(719): MediaWiki->restInPeace(string, boolean)
#12 ...\includes\MediaWiki.php(740): MediaWiki->{closure}()
#13 ...\includes\MediaWiki.php(553): MediaWiki->doPostOutputShutdown(string)
#14 ...\index.php(43): MediaWiki->run()
#15 {main}
```

This PR includes:
- [ ] Tests (unit/integration)
- [x] CI build passed

Fixes #