### PR TITLE
Update ext.smw.css

### DIFF
--- a/res/smw/ext.smw.css
+++ b/res/smw/ext.smw.css
@@ -40,7 +40,8 @@
 }
 
 /* highlighting for builtin elements */
-span.smwbuiltin, span.smwttactiveinline span.smwbuiltin {
+span.smwbuiltin,
+span.smwttactiveinline span.smwbuiltin {
 	font-style: italic;
 }
 
@@ -80,15 +81,18 @@ a.sortheader:hover {
 
 /* "semantic" span classes for Timeline */
 div.smwtimeline {
-	border: 1px solid #AAAAAA;
-	background-color: #F9F9F9;
+	border: 1px solid #aaa;
+	background-color: #f9f9f9;
 	/*text-align: center;*/
 	/* After hours of debugging and frustration I now can safely say: IE sucks. (mak)
 	   You can support Semantic MediaWiki development by not using Internet Explorer. Thanks.
 	   (IE centers the Timeline *elements*, which messes up the whole layout) */
 }
 
-span.smwtlevent, span.smwtlband, span.smwtlsize, span.smwtlposition {
+span.smwtlevent,
+span.smwtlband,
+span.smwtlsize,
+span.smwtlposition {
 	display: none;
 	speak: none;
 }
@@ -101,16 +105,18 @@ span.smwtlcomment {
 /* Factbox */
 div.smwfact {
 	clear: both;
-	background-color: #F9F9F9;
+	background-color: #f9f9f9;
 	padding: 5px;
 	margin-top: 1em;
-	border: 1px solid #AAAAAA;
+	border: 1px solid #aaa;
 	font-size: 95%;
 	min-height: 23px; /* required by SMW_FACTBOX_SHOWN */
 }
 
-div.smwfact td, div.smwfact tr, div.smwfact table {
-	background-color: #F9F9F9;
+div.smwfact td,
+div.smwfact tr,
+div.smwfact table {
+	background-color: #f9f9f9;
 }
 
 .smwfactboxhead {
@@ -122,12 +128,14 @@ div.smwfact td, div.smwfact tr, div.smwfact table {
 }
 
 table.smwfacttable {
-	border-top: 1px dotted #AAAAAA;
+	border-top: 1px dotted #aaa;
 	width: 100%;
 	clear: both;
 }
 
-td.smwpropname, th.smwpropname, td.smwspecname {
+td.smwpropname,
+th.smwpropname,
+td.smwspecname {
 	text-align: right;
 	vertical-align: top;
 	padding-right: 1em;
@@ -142,7 +150,8 @@ td.smwpropname, th.smwpropname, td.smwspecname {
 		width: 33%;
 	}
 
-	.smwfact td.smwprops, td.smwspecs {
+	.smwfact td.smwprops,
+	td.smwspecs {
 		width: 75%;
 	}
 }
@@ -160,19 +169,19 @@ td.smwpropname, th.smwpropname, td.smwspecname {
 }
 
 div.smwhr hr {
-	background-color: #DDDDDD;
-	color: #DDDDDD;
+	background-color: #ddd;
+	color: #ddd;
 }
 
 /* warning messages */
 span.smwwarning {
-	color: #888888;
+	color: #888;
 	font-style: italic;
 	font-size: 90%;
 }
 
 .smw-edit-protection {
-	/* @embed */ background: url('data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABwAAAAcCAYAAAByDd+UAAAAGXRFWHRTb2Z0d2FyZQBBZG9iZSBJbWFnZVJlYWR5ccllPAAABE9JREFUeNqcll1olmUcxu93e/apm83lu0a5tjk2UUGR/KpMxMTqQA0MPcgDKewgFMr8OBGEVBQ9MDBBomBSFAVCEXYSszoIP1DexWyp62Wu5YqNbW7te3vXdT1c/3HvYfOd3vBje97n4/rf/8871tfX52awMsBSsAY8BxaBACTBDXAVXAdpPxZLI1gM3gFvgTLwr0Tug1EQBxW61wu+AWfA7ccR3AcOgyFwHnwNGsHYFM9S8DXwLlgIPgMHwIOZCBaCL8HL4EPwkax3sVjMZWRkhH9tjY+Pu7GxSTa8CU7I0C2g4WGCFKsD82TxLbuRmZnphoeHXUdHh+M7FMnKynJFRUUhXKlUyh5/AnwB1oKXQGI6wR/AcrAMtNmugiBwbW1trqmpyfX390/OJuy4uLjY1dTUuPz8fDc6Ouon2vdKMrq5Myq4S75nJl6xj9HqZDLpWlpaJgSiiyIUq66udvF43Bctkpfq5OoJwbngL3AKHDEXDgwMuIaGBtfd3R3uUms92AZKwe/gc/CHubOystJVVFT4cV0vwXXgFzN3DxhQsEM3Dg0Nufr6+qjYae/lPPA2+A3ssGSi2+kNGqx1GVwCx83P2ao1ZuOg7a61tdX19PT4YttVKofAEvAqN6S414IFFOS7zc3NbnBw0Hf/MfACY2kdhO75yu7SHZ2dnb6VTsV/D5z0fmMGvSejt/reobFe+TAn/gabKbhCGZm0pGBcmY2RBJkD7k5R9El1nYKJ1IcQDfYWA3yNuwyUtn9aB6EI3cma89z5vrrJiMXZWzkKzSuK50V+o7293ZWXl7ucnByrT97bFqgR3/M7B13idxPFbZ7+PzhNK1zF5KEg32Vp0GgKarH/zg1kXcp3R15eXvRjW9U9xtNMlKTfECI5EGpQ8A542r8T6Y1OibEgjSBdchEcpZdoeMRLT4HuQPNsrV4IP8jY8SVvPasxlG7FfU9Fkm4xQxdocD4D5oMWChUWFkat26UsTLfD+5YHDEt2drbf0FeCC7ZDzq3XVfx+dtqiq6pnsMNP2X0oyG/QaHlqmZrEt4FaWq1S/ywsGuMOCwoKXG9vrwX+Y/B8GrGUJn4owibueWm/yiJhzZtJw3Gwlx+nCMUSiURYIpFsm3bZMC4rKwvHlZJvqeYhh/F3/ng6oAbLurxDEfbDxsbGsIh5HYnrJCHGis9UVVWFgrzG7yzCm6AVbIrOw0wlEPviavCfPw+7urrCYh4ZGZmUwZz6hAVeWlrqSkpKwp3pmU/ATlBjzSU68enaX3U62wz+sfSmMAWJ1ZlNFiaIuV1u5MU5sBtsBD/63cFf7OgvapcM8k6Li2Vebm5uON2Z9oS7MyGJrdM5leNsgy82laDT5F+jk1uthFmHcYpavAy5bpbmI2fjT6BdpVD3qAdh+v4D8AbDpXPpLY0zbudJHZA4kGdLgNPk58c9efuHITvyLVILo3e6QJPiflml9dD1vwADAEsW2XutLd7kAAAAAElFTkSuQmCC');
+	background: url('data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABwAAAAcCAYAAAByDd+UAAAAGXRFWHRTb2Z0d2FyZQBBZG9iZSBJbWFnZVJlYWR5ccllPAAABE9JREFUeNqcll1olmUcxu93e/apm83lu0a5tjk2UUGR/KpMxMTqQA0MPcgDKewgFMr8OBGEVBQ9MDBBomBSFAVCEXYSszoIP1DexWyp62Wu5YqNbW7te3vXdT1c/3HvYfOd3vBje97n4/rf/8871tfX52awMsBSsAY8BxaBACTBDXAVXAdpPxZLI1gM3gFvgTLwr0Tug1EQBxW61wu+AWfA7ccR3AcOgyFwHnwNGsHYFM9S8DXwLlgIPgMHwIOZCBaCL8HL4EPwkax3sVjMZWRkhH9tjY+Pu7GxSTa8CU7I0C2g4WGCFKsD82TxLbuRmZnphoeHXUdHh+M7FMnKynJFRUUhXKlUyh5/AnwB1oKXQGI6wR/AcrAMtNmugiBwbW1trqmpyfX390/OJuy4uLjY1dTUuPz8fDc6Ouon2vdKMrq5Myq4S75nJl6xj9HqZDLpWlpaJgSiiyIUq66udvF43Bctkpfq5OoJwbngL3AKHDEXDgwMuIaGBtfd3R3uUms92AZKwe/gc/CHubOystJVVFT4cV0vwXXgFzN3DxhQsEM3Dg0Nufr6+qjYae/lPPA2+A3ssGSi2+kNGqx1GVwCx83P2ao1ZuOg7a61tdX19PT4YttVKofAEvAqN6S414IFFOS7zc3NbnBw0Hf/MfACY2kdhO75yu7SHZ2dnb6VTsV/D5z0fmMGvSejt/reobFe+TAn/gabKbhCGZm0pGBcmY2RBJkD7k5R9El1nYKJ1IcQDfYWA3yNuwyUtn9aB6EI3cma89z5vrrJiMXZWzkKzSuK50V+o7293ZWXl7ucnByrT97bFqgR3/M7B13idxPFbZ7+PzhNK1zF5KEg32Vp0GgKarH/zg1kXcp3R15eXvRjW9U9xtNMlKTfECI5EGpQ8A542r8T6Y1OibEgjSBdchEcpZdoeMRLT4HuQPNsrV4IP8jY8SVvPasxlG7FfU9Fkm4xQxdocD4D5oMWChUWFkat26UsTLfD+5YHDEt2drbf0FeCC7ZDzq3XVfx+dtqiq6pnsMNP2X0oyG/QaHlqmZrEt4FaWq1S/ywsGuMOCwoKXG9vrwX+Y/B8GrGUJn4owibueWm/yiJhzZtJw3Gwlx+nCMUSiURYIpFsm3bZMC4rKwvHlZJvqeYhh/F3/ng6oAbLurxDEfbDxsbGsIh5HYnrJCHGis9UVVWFgrzG7yzCm6AVbIrOw0wlEPviavCfPw+7urrCYh4ZGZmUwZz6hAVeWlrqSkpKwp3pmU/ATlBjzSU68enaX3U62wz+sfSmMAWJ1ZlNFiaIuV1u5MU5sBtsBD/63cFf7OgvapcM8k6Li2Vebm5uON2Z9oS7MyGJrdM5leNsgy82laDT5F+jk1uthFmHcYpavAy5bpbmI2fjT6BdpVD3qAdh+v4D8AbDpXPpLY0zbudJHZA4kGdLgNPk58c9efuHITvyLVILo3e6QJPiflml9dD1vwADAEsW2XutLd7kAAAAAElFTkSuQmCC');
 	background-size: 28px 28px;
 	background-repeat: no-repeat;
 	height: 28px;
@@ -183,12 +192,12 @@ span.smwwarning {
 span.smwsearchicon {
 	padding-right: 16px;
 	margin-right: 2px;
-	color: #888888;
-	/* @embed */ background: url(../images/searchgray_iconsmall.png) center right no-repeat;
+	color: #888;
+	background: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' version='1.1' height='18' width='18' viewBox='0 0 22 22'%3E%3Cpath d='m132.77 118.03l-27.945-27.945c6.735-9.722 10.1-20.559 10.1-32.508 0-7.767-1.508-15.195-4.523-22.283-3.01-7.089-7.088-13.199-12.221-18.332-5.133-5.133-11.242-9.207-18.33-12.221-7.09-3.01-14.518-4.522-22.285-4.522-7.767 0-15.195 1.507-22.283 4.522-7.089 3.01-13.199 7.088-18.332 12.221-5.133 5.133-9.207 11.244-12.221 18.332-3.01 7.089-4.522 14.516-4.522 22.283 0 7.767 1.507 15.193 4.522 22.283 3.01 7.088 7.088 13.197 12.221 18.33 5.133 5.134 11.244 9.207 18.332 12.222 7.089 3.02 14.516 4.522 22.283 4.522 11.951 0 22.787-3.369 32.509-10.1l27.945 27.863c1.955 2.064 4.397 3.096 7.332 3.096 2.824 0 5.27-1.032 7.332-3.096 2.064-2.063 3.096-4.508 3.096-7.332.0001-2.877-1-5.322-3.01-7.331m-49.41-34.668c-7.143 7.143-15.738 10.714-25.787 10.714-10.05 0-18.643-3.572-25.786-10.714-7.143-7.143-10.714-15.737-10.714-25.786 0-10.05 3.572-18.644 10.714-25.786 7.142-7.143 15.738-10.714 25.786-10.714 10.05 0 18.643 3.572 25.787 10.714 7.143 7.142 10.715 15.738 10.715 25.786 0 10.05-3.573 18.643-10.715 25.786' transform='matrix%28.11417.00745-.00745.11417 3.93 2.548%29' fill='%23888888'/%3E%3C/svg%3E") center right no-repeat;
 }
 
 #bodyContent span.smwsearch a {
-	/* @embed */ background: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' version='1.1' height='15' width='15' viewBox='0 0 22 22'%3E%3Cpath d='m132.77 118.03l-27.945-27.945c6.735-9.722 10.1-20.559 10.1-32.508 0-7.767-1.508-15.195-4.523-22.283-3.01-7.089-7.088-13.199-12.221-18.332-5.133-5.133-11.242-9.207-18.33-12.221-7.09-3.01-14.518-4.522-22.285-4.522-7.767 0-15.195 1.507-22.283 4.522-7.089 3.01-13.199 7.088-18.332 12.221-5.133 5.133-9.207 11.244-12.221 18.332-3.01 7.089-4.522 14.516-4.522 22.283 0 7.767 1.507 15.193 4.522 22.283 3.01 7.088 7.088 13.197 12.221 18.33 5.133 5.134 11.244 9.207 18.332 12.222 7.089 3.02 14.516 4.522 22.283 4.522 11.951 0 22.787-3.369 32.509-10.1l27.945 27.863c1.955 2.064 4.397 3.096 7.332 3.096 2.824 0 5.27-1.032 7.332-3.096 2.064-2.063 3.096-4.508 3.096-7.332.0001-2.877-1-5.322-3.01-7.331m-49.41-34.668c-7.143 7.143-15.738 10.714-25.787 10.714-10.05 0-18.643-3.572-25.786-10.714-7.143-7.143-10.714-15.737-10.714-25.786 0-10.05 3.572-18.644 10.714-25.786 7.142-7.143 15.738-10.714 25.786-10.714 10.05 0 18.643 3.572 25.787 10.714 7.143 7.142 10.715 15.738 10.715 25.786 0 10.05-3.573 18.643-10.715 25.786' transform='matrix%28.11417.00745-.00745.11417 3.93 2.548%29' fill='%23ccc'/%3E%3C/svg%3E")
+	background: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' version='1.1' height='15' width='15' viewBox='0 0 22 22'%3E%3Cpath d='m132.77 118.03l-27.945-27.945c6.735-9.722 10.1-20.559 10.1-32.508 0-7.767-1.508-15.195-4.523-22.283-3.01-7.089-7.088-13.199-12.221-18.332-5.133-5.133-11.242-9.207-18.33-12.221-7.09-3.01-14.518-4.522-22.285-4.522-7.767 0-15.195 1.507-22.283 4.522-7.089 3.01-13.199 7.088-18.332 12.221-5.133 5.133-9.207 11.244-12.221 18.332-3.01 7.089-4.522 14.516-4.522 22.283 0 7.767 1.507 15.193 4.522 22.283 3.01 7.088 7.088 13.197 12.221 18.33 5.133 5.134 11.244 9.207 18.332 12.222 7.089 3.02 14.516 4.522 22.283 4.522 11.951 0 22.787-3.369 32.509-10.1l27.945 27.863c1.955 2.064 4.397 3.096 7.332 3.096 2.824 0 5.27-1.032 7.332-3.096 2.064-2.063 3.096-4.508 3.096-7.332.0001-2.877-1-5.322-3.01-7.331m-49.41-34.668c-7.143 7.143-15.738 10.714-25.787 10.714-10.05 0-18.643-3.572-25.786-10.714-7.143-7.143-10.714-15.737-10.714-25.786 0-10.05 3.572-18.644 10.714-25.786 7.142-7.143 15.738-10.714 25.786-10.714 10.05 0 18.643 3.572 25.787 10.714 7.143 7.142 10.715 15.738 10.715 25.786 0 10.05-3.573 18.643-10.715 25.786' transform='matrix%28.11417.00745-.00745.11417 3.93 2.548%29' fill='%23ccc'/%3E%3C/svg%3E")
 	 no-repeat
 	right center;
 	padding-right: 18px;
@@ -198,17 +207,17 @@ span.smwsearchicon {
 }
 
 #bodyContent span.smwsearch a:hover {
-	/* @embed */ background: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' version='1.1' height='18' width='18' viewBox='0 0 22 22'%3E%3Cpath d='m132.77 118.03l-27.945-27.945c6.735-9.722 10.1-20.559 10.1-32.508 0-7.767-1.508-15.195-4.523-22.283-3.01-7.089-7.088-13.199-12.221-18.332-5.133-5.133-11.242-9.207-18.33-12.221-7.09-3.01-14.518-4.522-22.285-4.522-7.767 0-15.195 1.507-22.283 4.522-7.089 3.01-13.199 7.088-18.332 12.221-5.133 5.133-9.207 11.244-12.221 18.332-3.01 7.089-4.522 14.516-4.522 22.283 0 7.767 1.507 15.193 4.522 22.283 3.01 7.088 7.088 13.197 12.221 18.33 5.133 5.134 11.244 9.207 18.332 12.222 7.089 3.02 14.516 4.522 22.283 4.522 11.951 0 22.787-3.369 32.509-10.1l27.945 27.863c1.955 2.064 4.397 3.096 7.332 3.096 2.824 0 5.27-1.032 7.332-3.096 2.064-2.063 3.096-4.508 3.096-7.332.0001-2.877-1-5.322-3.01-7.331m-49.41-34.668c-7.143 7.143-15.738 10.714-25.787 10.714-10.05 0-18.643-3.572-25.786-10.714-7.143-7.143-10.714-15.737-10.714-25.786 0-10.05 3.572-18.644 10.714-25.786 7.142-7.143 15.738-10.714 25.786-10.714 10.05 0 18.643 3.572 25.787 10.714 7.143 7.142 10.715 15.738 10.715 25.786 0 10.05-3.573 18.643-10.715 25.786' transform='matrix%28.11417.00745-.00745.11417 3.93 2.548%29' fill='%23888888'/%3E%3C/svg%3E")
+	background: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' version='1.1' height='18' width='18' viewBox='0 0 22 22'%3E%3Cpath d='m132.77 118.03l-27.945-27.945c6.735-9.722 10.1-20.559 10.1-32.508 0-7.767-1.508-15.195-4.523-22.283-3.01-7.089-7.088-13.199-12.221-18.332-5.133-5.133-11.242-9.207-18.33-12.221-7.09-3.01-14.518-4.522-22.285-4.522-7.767 0-15.195 1.507-22.283 4.522-7.089 3.01-13.199 7.088-18.332 12.221-5.133 5.133-9.207 11.244-12.221 18.332-3.01 7.089-4.522 14.516-4.522 22.283 0 7.767 1.507 15.193 4.522 22.283 3.01 7.088 7.088 13.197 12.221 18.33 5.133 5.134 11.244 9.207 18.332 12.222 7.089 3.02 14.516 4.522 22.283 4.522 11.951 0 22.787-3.369 32.509-10.1l27.945 27.863c1.955 2.064 4.397 3.096 7.332 3.096 2.824 0 5.27-1.032 7.332-3.096 2.064-2.063 3.096-4.508 3.096-7.332.0001-2.877-1-5.322-3.01-7.331m-49.41-34.668c-7.143 7.143-15.738 10.714-25.787 10.714-10.05 0-18.643-3.572-25.786-10.714-7.143-7.143-10.714-15.737-10.714-25.786 0-10.05 3.572-18.644 10.714-25.786 7.142-7.143 15.738-10.714 25.786-10.714 10.05 0 18.643 3.572 25.787 10.714 7.143 7.142 10.715 15.738 10.715 25.786 0 10.05-3.573 18.643-10.715 25.786' transform='matrix%28.11417.00745-.00745.11417 3.93 2.548%29' fill='%23888888'/%3E%3C/svg%3E")
 	 no-repeat
 	right center;
 	padding-right: 20px;
-	color: #888888;
+	color: #888;
 	text-decoration: none;
 	margin-right: 2px;
 }
 
 #bodyContent span.smwbrowse a {
-	/* @embed */ background: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' height='15' width='15' viewBox='0 0 22 22'%3E%3Cg transform='matrix%28.02146 0 0 .02146 1 1%29' fill='%23ccc'%3E%3Cpath d='m466.07 161.53c-205.6 0-382.8 121.2-464.2 296.1-2.5 5.3-2.5 11.5 0 16.9 81.4 174.9 258.6 296.1 464.2 296.1 205.6 0 382.8-121.2 464.2-296.1 2.5-5.3 2.5-11.5 0-16.9-81.4-174.9-258.6-296.1-464.2-296.1m0 514.7c-116.1 0-210.1-94.1-210.1-210.1 0-116.1 94.1-210.1 210.1-210.1 116.1 0 210.1 94.1 210.1 210.1 0 116-94.1 210.1-210.1 210.1'/%3E%3Ccircle cx='466.08' cy='466.02' r='134.5'/%3E%3C/g%3E%3C/svg%3E")
+	background: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' height='15' width='15' viewBox='0 0 22 22'%3E%3Cg transform='matrix%28.02146 0 0 .02146 1 1%29' fill='%23ccc'%3E%3Cpath d='m466.07 161.53c-205.6 0-382.8 121.2-464.2 296.1-2.5 5.3-2.5 11.5 0 16.9 81.4 174.9 258.6 296.1 464.2 296.1 205.6 0 382.8-121.2 464.2-296.1 2.5-5.3 2.5-11.5 0-16.9-81.4-174.9-258.6-296.1-464.2-296.1m0 514.7c-116.1 0-210.1-94.1-210.1-210.1 0-116.1 94.1-210.1 210.1-210.1 116.1 0 210.1 94.1 210.1 210.1 0 116-94.1 210.1-210.1 210.1'/%3E%3Ccircle cx='466.08' cy='466.02' r='134.5'/%3E%3C/g%3E%3C/svg%3E")
 	 no-repeat
 	right center;
 	padding-right: 18px;
@@ -218,17 +227,17 @@ span.smwsearchicon {
 }
 
 #bodyContent span.smwbrowse a:hover {
-	/* @embed */ background: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' height='18' width='18' viewBox='0 0 22 22'%3E%3Cg transform='matrix%28.02146 0 0 .02146 1 1%29' fill='%23888888'%3E%3Cpath d='m466.07 161.53c-205.6 0-382.8 121.2-464.2 296.1-2.5 5.3-2.5 11.5 0 16.9 81.4 174.9 258.6 296.1 464.2 296.1 205.6 0 382.8-121.2 464.2-296.1 2.5-5.3 2.5-11.5 0-16.9-81.4-174.9-258.6-296.1-464.2-296.1m0 514.7c-116.1 0-210.1-94.1-210.1-210.1 0-116.1 94.1-210.1 210.1-210.1 116.1 0 210.1 94.1 210.1 210.1 0 116-94.1 210.1-210.1 210.1'/%3E%3Ccircle cx='466.08' cy='466.02' r='134.5'/%3E%3C/g%3E%3C/svg%3E")
+	background: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' height='18' width='18' viewBox='0 0 22 22'%3E%3Cg transform='matrix%28.02146 0 0 .02146 1 1%29' fill='%23888888'%3E%3Cpath d='m466.07 161.53c-205.6 0-382.8 121.2-464.2 296.1-2.5 5.3-2.5 11.5 0 16.9 81.4 174.9 258.6 296.1 464.2 296.1 205.6 0 382.8-121.2 464.2-296.1 2.5-5.3 2.5-11.5 0-16.9-81.4-174.9-258.6-296.1-464.2-296.1m0 514.7c-116.1 0-210.1-94.1-210.1-210.1 0-116.1 94.1-210.1 210.1-210.1 116.1 0 210.1 94.1 210.1 210.1 0 116-94.1 210.1-210.1 210.1'/%3E%3Ccircle cx='466.08' cy='466.02' r='134.5'/%3E%3C/g%3E%3C/svg%3E")
 	 no-repeat
 	right center;
 	padding-right: 20px;
-	color: #888888;
+	color: #888;
 	text-decoration: none;
 	margin-right: 2px;
 }
 
 #bodyContent span.swmfactboxheadbrowse a {
-	/* @embed */ background: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' height='18' width='18' viewBox='0 0 22 22'%3E%3Cg transform='matrix%28.02146 0 0 .02146 1 1%29' fill='%23ccc'%3E%3Cpath d='m466.07 161.53c-205.6 0-382.8 121.2-464.2 296.1-2.5 5.3-2.5 11.5 0 16.9 81.4 174.9 258.6 296.1 464.2 296.1 205.6 0 382.8-121.2 464.2-296.1 2.5-5.3 2.5-11.5 0-16.9-81.4-174.9-258.6-296.1-464.2-296.1m0 514.7c-116.1 0-210.1-94.1-210.1-210.1 0-116.1 94.1-210.1 210.1-210.1 116.1 0 210.1 94.1 210.1 210.1 0 116-94.1 210.1-210.1 210.1'/%3E%3Ccircle cx='466.08' cy='466.02' r='134.5'/%3E%3C/g%3E%3C/svg%3E")
+	background: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' height='18' width='18' viewBox='0 0 22 22'%3E%3Cg transform='matrix%28.02146 0 0 .02146 1 1%29' fill='%23ccc'%3E%3Cpath d='m466.07 161.53c-205.6 0-382.8 121.2-464.2 296.1-2.5 5.3-2.5 11.5 0 16.9 81.4 174.9 258.6 296.1 464.2 296.1 205.6 0 382.8-121.2 464.2-296.1 2.5-5.3 2.5-11.5 0-16.9-81.4-174.9-258.6-296.1-464.2-296.1m0 514.7c-116.1 0-210.1-94.1-210.1-210.1 0-116.1 94.1-210.1 210.1-210.1 116.1 0 210.1 94.1 210.1 210.1 0 116-94.1 210.1-210.1 210.1'/%3E%3Ccircle cx='466.08' cy='466.02' r='134.5'/%3E%3C/g%3E%3C/svg%3E")
 	 no-repeat
 	right center;
 	padding-right: 20px;
@@ -237,7 +246,7 @@ span.smwsearchicon {
 }
 
 #bodyContent span.swmfactboxheadbrowse a:hover {
-	/* @embed */ background: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' height='20' width='20' viewBox='0 0 22 22'%3E%3Cg transform='matrix%28.02146 0 0 .02146 1 1%29' fill='%23888888'%3E%3Cpath d='m466.07 161.53c-205.6 0-382.8 121.2-464.2 296.1-2.5 5.3-2.5 11.5 0 16.9 81.4 174.9 258.6 296.1 464.2 296.1 205.6 0 382.8-121.2 464.2-296.1 2.5-5.3 2.5-11.5 0-16.9-81.4-174.9-258.6-296.1-464.2-296.1m0 514.7c-116.1 0-210.1-94.1-210.1-210.1 0-116.1 94.1-210.1 210.1-210.1 116.1 0 210.1 94.1 210.1 210.1 0 116-94.1 210.1-210.1 210.1'/%3E%3Ccircle cx='466.08' cy='466.02' r='134.5'/%3E%3C/g%3E%3C/svg%3E")
+	background: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' height='20' width='20' viewBox='0 0 22 22'%3E%3Cg transform='matrix%28.02146 0 0 .02146 1 1%29' fill='%23888888'%3E%3Cpath d='m466.07 161.53c-205.6 0-382.8 121.2-464.2 296.1-2.5 5.3-2.5 11.5 0 16.9 81.4 174.9 258.6 296.1 464.2 296.1 205.6 0 382.8-121.2 464.2-296.1 2.5-5.3 2.5-11.5 0-16.9-81.4-174.9-258.6-296.1-464.2-296.1m0 514.7c-116.1 0-210.1-94.1-210.1-210.1 0-116.1 94.1-210.1 210.1-210.1 116.1 0 210.1 94.1 210.1 210.1 0 116-94.1 210.1-210.1 210.1'/%3E%3Ccircle cx='466.08' cy='466.02' r='134.5'/%3E%3C/g%3E%3C/svg%3E")
 	 no-repeat
 	right center;
 	padding-right: 22px;
@@ -252,7 +261,7 @@ span.smwsearchicon {
 }
 
 .concept-documenation {
-	border-top: 1px dotted #AAAAAA;
+	border-top: 1px dotted #aaa;
 }
 
 #bodyContent span.rdflink {
@@ -261,16 +270,16 @@ span.smwsearchicon {
 
 #bodyContent span.rdflink a {
 	padding-right: 15px;
-	color: #888888;
-	/* @embed */ background: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' version='1.1' overflow='visible' height='10' width='10' viewBox='0 0 94.332 101.883'%3E%3Cg shape-rendering='geometricPrecision' text-rendering='geometricPrecision' image-rendering='optimizeQuality'%3E%3Cpath d='M84.45,66.836c-0.636-0.337-1.284-0.624-1.936-0.879l0.466-0.038c0,0-4.151-1.838-4.514-15.18 c-0.359-13.344,3.957-15.62,3.957-15.62l-0.62,0.027c3.261-1.673,6.066-4.316,7.917-7.804c4.823-9.072,1.372-20.341-7.702-25.165 C72.94-2.641,61.674,0.802,56.854,9.883c-1.982,3.725-2.545,7.817-1.919,11.683l-0.212-0.326c0,0,1.093,4.842-10.258,11.888 c-11.349,7.05-16.469,3.54-16.469,3.54l0.326,0.48c-0.325-0.201-0.636-0.406-0.975-0.583C18.269,31.741,7,35.188,2.178,44.266 c-4.82,9.077-1.372,20.341,7.703,25.167c6.766,3.591,14.744,2.59,20.365-1.914l-0.122,0.236c0,0,4.132-3.399,16.04,2.994 c9.4,5.044,10.796,9.988,10.975,11.846c-0.246,6.893,3.347,13.654,9.847,17.107c9.075,4.825,20.344,1.375,25.164-7.701 C96.974,82.926,93.528,71.656,84.45,66.836z M63.466,69.282c-1.504,0.532-5.801,1.121-14.847-3.73 c-9.797-5.26-11.251-9.654-11.464-10.973c0.139-1.6,0.05-3.197-0.223-4.755l0.06,0.09c0,0-0.798-4.274,10.412-11.235 c10.033-6.228,14.594-4.989,15.443-4.664c0.546,0.371,1.112,0.717,1.706,1.033c1.129,0.6,2.293,1.07,3.472,1.418 c1.38,1.314,3.92,5.045,4.184,14.854c0.27,9.883-2.634,13.694-4.217,15.042C66.362,67.1,64.836,68.085,63.466,69.282z' fill='%230C479C'/%3E%3Cg%3E%3Cpath d='M62.239,8.1c-5.415,5.923-5.529,14.636-0.312,19.566c-2.579-2.483-2.523-7.651,0.083-12.597 c0.335-0.443,1.306-1.49,2.725-1.014c0.143,0.049,0.237,0.062,0.292,0.053c0.321,0.069,0.65,0.11,0.99,0.095 c2.155-0.098,3.822-1.921,3.725-4.077c-0.044-0.967-0.445-1.823-1.065-2.48c5.002-3.277,10.742-3.652,13.094-1.504l0.09,0.006 C76.488,1.242,67.705,2.119,62.239,8.1z' fill='%23FFFFFF'/%3E%3C/g%3E%3Cg%3E%3Cpath d='M7.632,62.845c-0.046-0.047-0.093-0.102-0.141-0.148c0.03,0.031,0.059,0.069,0.095,0.102L7.632,62.845z' fill='%23FFFFFF'/%3E%3Cpath d='M7.805,43.13c-5.416,5.924-5.529,14.635-0.313,19.566c-2.578-2.484-2.523-7.652,0.083-12.598 c0.336-0.444,1.308-1.49,2.727-1.014c0.141,0.049,0.236,0.061,0.292,0.054c0.321,0.069,0.651,0.11,0.99,0.095 c2.156-0.099,3.822-1.922,3.725-4.076c-0.045-0.967-0.445-1.824-1.063-2.48c4.999-3.276,10.74-3.654,13.092-1.505l0.089,0.008 C22.054,36.271,13.269,37.147,7.805,43.13z' fill='%23FFFFFF'/%3E%3C/g%3E%3Cg%3E%3Cpath d='M65.256,92.504c-0.047-0.048-0.094-0.102-0.141-0.148c0.029,0.031,0.059,0.069,0.094,0.101L65.256,92.504z' fill='%23FFFFFF'/%3E%3Cpath d='M65.428,72.786c-5.416,5.926-5.529,14.639-0.313,19.569c-2.58-2.483-2.523-7.653,0.082-12.597 c0.336-0.445,1.307-1.49,2.727-1.014c0.143,0.047,0.235,0.061,0.292,0.053c0.32,0.069,0.651,0.11,0.99,0.096 c2.154-0.1,3.82-1.924,3.723-4.08c-0.044-0.966-0.445-1.822-1.063-2.479c5-3.275,10.739-3.652,13.093-1.504l0.088,0.007 C79.677,65.93,70.891,66.807,65.428,72.786z' fill='%23FFFFFF'/%3E%3C/g%3E%3C/g%3E%3C/svg%3E%0A")
+	color: #888;
+	background: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' version='1.1' overflow='visible' height='10' width='10' viewBox='0 0 94.332 101.883'%3E%3Cg shape-rendering='geometricPrecision' text-rendering='geometricPrecision' image-rendering='optimizeQuality'%3E%3Cpath d='M84.45,66.836c-0.636-0.337-1.284-0.624-1.936-0.879l0.466-0.038c0,0-4.151-1.838-4.514-15.18 c-0.359-13.344,3.957-15.62,3.957-15.62l-0.62,0.027c3.261-1.673,6.066-4.316,7.917-7.804c4.823-9.072,1.372-20.341-7.702-25.165 C72.94-2.641,61.674,0.802,56.854,9.883c-1.982,3.725-2.545,7.817-1.919,11.683l-0.212-0.326c0,0,1.093,4.842-10.258,11.888 c-11.349,7.05-16.469,3.54-16.469,3.54l0.326,0.48c-0.325-0.201-0.636-0.406-0.975-0.583C18.269,31.741,7,35.188,2.178,44.266 c-4.82,9.077-1.372,20.341,7.703,25.167c6.766,3.591,14.744,2.59,20.365-1.914l-0.122,0.236c0,0,4.132-3.399,16.04,2.994 c9.4,5.044,10.796,9.988,10.975,11.846c-0.246,6.893,3.347,13.654,9.847,17.107c9.075,4.825,20.344,1.375,25.164-7.701 C96.974,82.926,93.528,71.656,84.45,66.836z M63.466,69.282c-1.504,0.532-5.801,1.121-14.847-3.73 c-9.797-5.26-11.251-9.654-11.464-10.973c0.139-1.6,0.05-3.197-0.223-4.755l0.06,0.09c0,0-0.798-4.274,10.412-11.235 c10.033-6.228,14.594-4.989,15.443-4.664c0.546,0.371,1.112,0.717,1.706,1.033c1.129,0.6,2.293,1.07,3.472,1.418 c1.38,1.314,3.92,5.045,4.184,14.854c0.27,9.883-2.634,13.694-4.217,15.042C66.362,67.1,64.836,68.085,63.466,69.282z' fill='%230C479C'/%3E%3Cg%3E%3Cpath d='M62.239,8.1c-5.415,5.923-5.529,14.636-0.312,19.566c-2.579-2.483-2.523-7.651,0.083-12.597 c0.335-0.443,1.306-1.49,2.725-1.014c0.143,0.049,0.237,0.062,0.292,0.053c0.321,0.069,0.65,0.11,0.99,0.095 c2.155-0.098,3.822-1.921,3.725-4.077c-0.044-0.967-0.445-1.823-1.065-2.48c5.002-3.277,10.742-3.652,13.094-1.504l0.09,0.006 C76.488,1.242,67.705,2.119,62.239,8.1z' fill='%23FFFFFF'/%3E%3C/g%3E%3Cg%3E%3Cpath d='M7.632,62.845c-0.046-0.047-0.093-0.102-0.141-0.148c0.03,0.031,0.059,0.069,0.095,0.102L7.632,62.845z' fill='%23FFFFFF'/%3E%3Cpath d='M7.805,43.13c-5.416,5.924-5.529,14.635-0.313,19.566c-2.578-2.484-2.523-7.652,0.083-12.598 c0.336-0.444,1.308-1.49,2.727-1.014c0.141,0.049,0.236,0.061,0.292,0.054c0.321,0.069,0.651,0.11,0.99,0.095 c2.156-0.099,3.822-1.922,3.725-4.076c-0.045-0.967-0.445-1.824-1.063-2.48c4.999-3.276,10.74-3.654,13.092-1.505l0.089,0.008 C22.054,36.271,13.269,37.147,7.805,43.13z' fill='%23FFFFFF'/%3E%3C/g%3E%3Cg%3E%3Cpath d='M65.256,92.504c-0.047-0.048-0.094-0.102-0.141-0.148c0.029,0.031,0.059,0.069,0.094,0.101L65.256,92.504z' fill='%23FFFFFF'/%3E%3Cpath d='M65.428,72.786c-5.416,5.926-5.529,14.639-0.313,19.569c-2.58-2.483-2.523-7.653,0.082-12.597 c0.336-0.445,1.307-1.49,2.727-1.014c0.143,0.047,0.235,0.061,0.292,0.053c0.32,0.069,0.651,0.11,0.99,0.096 c2.154-0.1,3.82-1.924,3.723-4.08c-0.044-0.966-0.445-1.822-1.063-2.479c5-3.275,10.739-3.652,13.093-1.504l0.088,0.007 C79.677,65.93,70.891,66.807,65.428,72.786z' fill='%23FFFFFF'/%3E%3C/g%3E%3C/g%3E%3C/svg%3E%0A")
 	center right no-repeat;
 }
 
 #bodyContent span.rdflink a:hover {
 	padding-right: 15px;
 	text-decoration: none;
-	color: #0000FF;
-	/* @embed */ background: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' version='1.1' overflow='visible' height='12' width='12' viewBox='0 0 94.332 101.883'%3E%3Cg shape-rendering='geometricPrecision' text-rendering='geometricPrecision' image-rendering='optimizeQuality'%3E%3Cpath d='M84.45,66.836c-0.636-0.337-1.284-0.624-1.936-0.879l0.466-0.038c0,0-4.151-1.838-4.514-15.18 c-0.359-13.344,3.957-15.62,3.957-15.62l-0.62,0.027c3.261-1.673,6.066-4.316,7.917-7.804c4.823-9.072,1.372-20.341-7.702-25.165 C72.94-2.641,61.674,0.802,56.854,9.883c-1.982,3.725-2.545,7.817-1.919,11.683l-0.212-0.326c0,0,1.093,4.842-10.258,11.888 c-11.349,7.05-16.469,3.54-16.469,3.54l0.326,0.48c-0.325-0.201-0.636-0.406-0.975-0.583C18.269,31.741,7,35.188,2.178,44.266 c-4.82,9.077-1.372,20.341,7.703,25.167c6.766,3.591,14.744,2.59,20.365-1.914l-0.122,0.236c0,0,4.132-3.399,16.04,2.994 c9.4,5.044,10.796,9.988,10.975,11.846c-0.246,6.893,3.347,13.654,9.847,17.107c9.075,4.825,20.344,1.375,25.164-7.701 C96.974,82.926,93.528,71.656,84.45,66.836z M63.466,69.282c-1.504,0.532-5.801,1.121-14.847-3.73 c-9.797-5.26-11.251-9.654-11.464-10.973c0.139-1.6,0.05-3.197-0.223-4.755l0.06,0.09c0,0-0.798-4.274,10.412-11.235 c10.033-6.228,14.594-4.989,15.443-4.664c0.546,0.371,1.112,0.717,1.706,1.033c1.129,0.6,2.293,1.07,3.472,1.418 c1.38,1.314,3.92,5.045,4.184,14.854c0.27,9.883-2.634,13.694-4.217,15.042C66.362,67.1,64.836,68.085,63.466,69.282z' fill='%230C479C'/%3E%3Cg%3E%3Cpath d='M62.239,8.1c-5.415,5.923-5.529,14.636-0.312,19.566c-2.579-2.483-2.523-7.651,0.083-12.597 c0.335-0.443,1.306-1.49,2.725-1.014c0.143,0.049,0.237,0.062,0.292,0.053c0.321,0.069,0.65,0.11,0.99,0.095 c2.155-0.098,3.822-1.921,3.725-4.077c-0.044-0.967-0.445-1.823-1.065-2.48c5.002-3.277,10.742-3.652,13.094-1.504l0.09,0.006 C76.488,1.242,67.705,2.119,62.239,8.1z' fill='%23FFFFFF'/%3E%3C/g%3E%3Cg%3E%3Cpath d='M7.632,62.845c-0.046-0.047-0.093-0.102-0.141-0.148c0.03,0.031,0.059,0.069,0.095,0.102L7.632,62.845z' fill='%23FFFFFF'/%3E%3Cpath d='M7.805,43.13c-5.416,5.924-5.529,14.635-0.313,19.566c-2.578-2.484-2.523-7.652,0.083-12.598 c0.336-0.444,1.308-1.49,2.727-1.014c0.141,0.049,0.236,0.061,0.292,0.054c0.321,0.069,0.651,0.11,0.99,0.095 c2.156-0.099,3.822-1.922,3.725-4.076c-0.045-0.967-0.445-1.824-1.063-2.48c4.999-3.276,10.74-3.654,13.092-1.505l0.089,0.008 C22.054,36.271,13.269,37.147,7.805,43.13z' fill='%23FFFFFF'/%3E%3C/g%3E%3Cg%3E%3Cpath d='M65.256,92.504c-0.047-0.048-0.094-0.102-0.141-0.148c0.029,0.031,0.059,0.069,0.094,0.101L65.256,92.504z' fill='%23FFFFFF'/%3E%3Cpath d='M65.428,72.786c-5.416,5.926-5.529,14.639-0.313,19.569c-2.58-2.483-2.523-7.653,0.082-12.597 c0.336-0.445,1.307-1.49,2.727-1.014c0.143,0.047,0.235,0.061,0.292,0.053c0.32,0.069,0.651,0.11,0.99,0.096 c2.154-0.1,3.82-1.924,3.723-4.08c-0.044-0.966-0.445-1.822-1.063-2.479c5-3.275,10.739-3.652,13.093-1.504l0.088,0.007 C79.677,65.93,70.891,66.807,65.428,72.786z' fill='%23FFFFFF'/%3E%3C/g%3E%3C/g%3E%3C/svg%3E%0A")
+	color: #0000ff;
+	background: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' version='1.1' overflow='visible' height='12' width='12' viewBox='0 0 94.332 101.883'%3E%3Cg shape-rendering='geometricPrecision' text-rendering='geometricPrecision' image-rendering='optimizeQuality'%3E%3Cpath d='M84.45,66.836c-0.636-0.337-1.284-0.624-1.936-0.879l0.466-0.038c0,0-4.151-1.838-4.514-15.18 c-0.359-13.344,3.957-15.62,3.957-15.62l-0.62,0.027c3.261-1.673,6.066-4.316,7.917-7.804c4.823-9.072,1.372-20.341-7.702-25.165 C72.94-2.641,61.674,0.802,56.854,9.883c-1.982,3.725-2.545,7.817-1.919,11.683l-0.212-0.326c0,0,1.093,4.842-10.258,11.888 c-11.349,7.05-16.469,3.54-16.469,3.54l0.326,0.48c-0.325-0.201-0.636-0.406-0.975-0.583C18.269,31.741,7,35.188,2.178,44.266 c-4.82,9.077-1.372,20.341,7.703,25.167c6.766,3.591,14.744,2.59,20.365-1.914l-0.122,0.236c0,0,4.132-3.399,16.04,2.994 c9.4,5.044,10.796,9.988,10.975,11.846c-0.246,6.893,3.347,13.654,9.847,17.107c9.075,4.825,20.344,1.375,25.164-7.701 C96.974,82.926,93.528,71.656,84.45,66.836z M63.466,69.282c-1.504,0.532-5.801,1.121-14.847-3.73 c-9.797-5.26-11.251-9.654-11.464-10.973c0.139-1.6,0.05-3.197-0.223-4.755l0.06,0.09c0,0-0.798-4.274,10.412-11.235 c10.033-6.228,14.594-4.989,15.443-4.664c0.546,0.371,1.112,0.717,1.706,1.033c1.129,0.6,2.293,1.07,3.472,1.418 c1.38,1.314,3.92,5.045,4.184,14.854c0.27,9.883-2.634,13.694-4.217,15.042C66.362,67.1,64.836,68.085,63.466,69.282z' fill='%230C479C'/%3E%3Cg%3E%3Cpath d='M62.239,8.1c-5.415,5.923-5.529,14.636-0.312,19.566c-2.579-2.483-2.523-7.651,0.083-12.597 c0.335-0.443,1.306-1.49,2.725-1.014c0.143,0.049,0.237,0.062,0.292,0.053c0.321,0.069,0.65,0.11,0.99,0.095 c2.155-0.098,3.822-1.921,3.725-4.077c-0.044-0.967-0.445-1.823-1.065-2.48c5.002-3.277,10.742-3.652,13.094-1.504l0.09,0.006 C76.488,1.242,67.705,2.119,62.239,8.1z' fill='%23FFFFFF'/%3E%3C/g%3E%3Cg%3E%3Cpath d='M7.632,62.845c-0.046-0.047-0.093-0.102-0.141-0.148c0.03,0.031,0.059,0.069,0.095,0.102L7.632,62.845z' fill='%23FFFFFF'/%3E%3Cpath d='M7.805,43.13c-5.416,5.924-5.529,14.635-0.313,19.566c-2.578-2.484-2.523-7.652,0.083-12.598 c0.336-0.444,1.308-1.49,2.727-1.014c0.141,0.049,0.236,0.061,0.292,0.054c0.321,0.069,0.651,0.11,0.99,0.095 c2.156-0.099,3.822-1.922,3.725-4.076c-0.045-0.967-0.445-1.824-1.063-2.48c4.999-3.276,10.74-3.654,13.092-1.505l0.089,0.008 C22.054,36.271,13.269,37.147,7.805,43.13z' fill='%23FFFFFF'/%3E%3C/g%3E%3Cg%3E%3Cpath d='M65.256,92.504c-0.047-0.048-0.094-0.102-0.141-0.148c0.029,0.031,0.059,0.069,0.094,0.101L65.256,92.504z' fill='%23FFFFFF'/%3E%3Cpath d='M65.428,72.786c-5.416,5.926-5.529,14.639-0.313,19.569c-2.58-2.483-2.523-7.653,0.082-12.597 c0.336-0.445,1.307-1.49,2.727-1.014c0.143,0.047,0.235,0.061,0.292,0.053c0.32,0.069,0.651,0.11,0.99,0.096 c2.154-0.1,3.82-1.924,3.723-4.08c-0.044-0.966-0.445-1.822-1.063-2.479c5-3.275,10.739-3.652,13.093-1.504l0.088,0.007 C79.677,65.93,70.891,66.807,65.428,72.786z' fill='%23FFFFFF'/%3E%3C/g%3E%3C/g%3E%3C/svg%3E%0A")
 	center right no-repeat;
 }
 /* @since 1.9; Spinner */
@@ -282,16 +291,16 @@ span.smwsearchicon {
 
 /* @since 1.9; Spinner for left side in-text */
 .smw-spinner.left.mw-small-spinner {
-	background-position:left;
+	background-position: left;
 	vertical-align: middle;
-	display:inline-block;
+	display: inline-block;
 	padding: 0px !important;
 }
 
 /* @since 1.9; Sppinner for image center */
 .smw-spinner.center.mw-small-spinner {
 	vertical-align: middle;
-	display:inline-block;
+	display: inline-block;
 	padding: 0px !important;
 }
 
@@ -309,7 +318,8 @@ hr.smw-form-horizontalrule {
  	background-color: #ddd;
  }
 
-.smw-form-select, .smw-form-input {
+.smw-form-select,
+.smw-form-input {
 	padding: 1px 1px;
 }
 
@@ -324,7 +334,7 @@ label.smw-form-checkbox {
 }
 
 .smw-editpage-help {
-	background-color: #F0F0F0;
+	background-color: #f0f0f0;
 	border: 1px solid silver;
 	/* border-top: none; */
 	padding: 0.5em 1em 0.5em 1em;
@@ -454,8 +464,8 @@ label.smw-form-checkbox {
 	width: 1em;
 }
 .smw-svg-icon svg {
-	height:1em;
-	width:1em;
+	height: 1em;
+	width: 1em;
 }
 .smw-svg-icon.svg-baseline svg {
 	bottom: -0.125em;
@@ -531,15 +541,27 @@ label.smw-form-checkbox {
 .autocomplete-suggestion {
     display: block;
     padding: 5px 10px;
-    border-bottom: 1px solid #DDD;
+    border-bottom: 1px solid #ddd;
     cursor: pointer;
 }
 
-.autocomplete-selected { background: #F0F0F0; }
-.autocomplete-suggestions strong { font-weight: normal; color: #3399FF; }
-.autocomplete-group { padding: 2px 5px; }
-.autocomplete-group strong { display: block; border-bottom: 1px solid #000; }
+.autocomplete-selected {
+	background: #f0f0f0;
+}
 
+.autocomplete-suggestions strong {
+	font-weight: normal;
+	color: #3399ff;
+}
+
+.autocomplete-group {
+	padding: 2px 5px;
+}
+
+.autocomplete-group strong {
+	display: block;
+	border-bottom: 1px solid #000;
+}
 
 
 .skin-vector input#smw-property-input.autocomplete-suggestions {
@@ -557,7 +579,8 @@ label.smw-form-checkbox {
 	padding: 2px 0px 0px 8px;
 }
 
-.skin-chameleon .autocomplete-suggestion, .skin-foreground .autocomplete-suggestion {
+.skin-chameleon .autocomplete-suggestion,
+.skin-foreground .autocomplete-suggestion {
 	padding: 2px 5px;
 	white-space: nowrap;
 	overflow: hidden;
@@ -565,7 +588,7 @@ label.smw-form-checkbox {
 }
 
 .smw-breadcrumb-link {
-	color: #7D7D7D;
+	color: #7d7d7d;
 	font-size: 84%;
 	line-height: 1.2em;
 	margin: 0 0 0.8em 0;
@@ -575,14 +598,15 @@ label.smw-form-checkbox {
 .smw-breadcrumb-arrow-right {
 	border-top: 5px solid transparent;
 	border-bottom: 5px solid transparent;
-	border-left: 5px solid #AAAAAA;
+	border-left: 5px solid #aaa;
 	display: inline-block;
 	position: relative;
 	margin-left: 4px;
 	margin-right: 4px;
 }
 
-.smw-ask-action-btn, .smw-action-btn {
+.smw-ask-action-btn,
+.smw-action-btn {
 	display: inline-block;
 	padding: 3px 6px;
 	margin-bottom: 0;
@@ -605,55 +629,65 @@ label.smw-form-checkbox {
 }
 
 .smw-action-btn-min200 {
-	min-width:200px;
+	min-width: 200px;
 }
 
-.smw-ask-action-btn-lgrey, a.smw-ask-action-btn-lgrey:visited, .smw-action-btn-lgrey, .smw-action-btn-lgrey:visited {
+.smw-ask-action-btn-lgrey,
+a.smw-ask-action-btn-lgrey:visited,
+.smw-action-btn-lgrey,
+.smw-action-btn-lgrey:visited {
 	color: #222;
 	background-color: #eee;
 	border-color: #ddd;
 	text-decoration:none;
 }
 
-a.smw-ask-action-btn-lgrey:hover, .smw-action-btn-lgrey:hover {
+a.smw-ask-action-btn-lgrey:hover,
+.smw-action-btn-lgrey:hover {
 	color: #222;
 	background-color: #ddd;
 	border-color: #ddd;
 	text-decoration:none;
 }
 
-.smw-ask-action-btn-lblue, a.smw-ask-action-btn-lblue:visited {
+.smw-ask-action-btn-lblue,
+a.smw-ask-action-btn-lblue:visited {
 	color: #fff;
 	background-color: #5bc0de;
 	border-color: #46b8da;
-	text-decoration:none;
+	text-decoration: none;
 }
 
 a.smw-ask-action-btn-lblue:hover {
 	color: #fff;
 	background-color: #31b0d5;
 	border-color: #269abc;
-	text-decoration:none;
+	text-decoration: none;
 }
 
-.smw-ask-action-btn-dblue, a.smw-ask-action-btn-dblue:visited {
+.smw-ask-action-btn-dblue,
+a.smw-ask-action-btn-dblue:visited {
 	color: #fff;
 	background-color: #337ab7;
 	border-color: #2e6da4;
-	text-decoration:none;
+	text-decoration: none;
 }
 
-.smw-ask-action-btn-dblue:hover, .smw-ask-action-btn-dblue:focus, a.smw-ask-action-btn-dblue:hover, a.smw-ask-action-btn-dblue:focus {
+.smw-ask-action-btn-dblue:hover,
+.smw-ask-action-btn-dblue:focus,
+a.smw-ask-action-btn-dblue:hover,
+a.smw-ask-action-btn-dblue:focus {
 	color: #fff;
 	background-image:none;
 	background-color: #286090;
 	border-color: #204d74;
-	text-decoration:none;
+	text-decoration: none;
 }
 
-.smw-concept-page-indicator a.external.text, .smw-page-indicator a.external.text {
-	background-image:none;
-	padding-right:0;
+.smw-concept-page-indicator a.external.text,
+.smw-page-indicator a.external.text {
+	background-image: none;
+	padding-right: 0;
 }
 
 .smw-page-indicator {
@@ -712,14 +746,14 @@ a.smw-ask-action-btn-lblue:hover {
 }
 
 .smw-page-indicator.usage-count.moderate {
-	background-color: #F2D29B;
-	border: 1px solid #F2D29B;
-	color: #AA4C2C;
+	background-color: #f2d29b;
+	border: 1px solid #f2d29b;
+	color: #aa4c2c;
 }
 
 .smw-page-indicator.usage-count.high {
-	background-color: #FF887F;
-	border: 1px solid #FFB79E;
+	background-color: #ff887f;
+	border: 1px solid #ffB79e;
 	color: #800000;
 }
 
@@ -738,7 +772,7 @@ a.smw-ask-action-btn-lblue:hover {
 }
 
 .smw-page-indicator-rdflink a {
-	/* @embed */ background: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' version='1.1' overflow='visible' height='18' width='18' viewBox='0 0 94.332 101.883'%3E%3Cg shape-rendering='geometricPrecision' text-rendering='geometricPrecision' image-rendering='optimizeQuality'%3E%3Cpath d='M84.45,66.836c-0.636-0.337-1.284-0.624-1.936-0.879l0.466-0.038c0,0-4.151-1.838-4.514-15.18 c-0.359-13.344,3.957-15.62,3.957-15.62l-0.62,0.027c3.261-1.673,6.066-4.316,7.917-7.804c4.823-9.072,1.372-20.341-7.702-25.165 C72.94-2.641,61.674,0.802,56.854,9.883c-1.982,3.725-2.545,7.817-1.919,11.683l-0.212-0.326c0,0,1.093,4.842-10.258,11.888 c-11.349,7.05-16.469,3.54-16.469,3.54l0.326,0.48c-0.325-0.201-0.636-0.406-0.975-0.583C18.269,31.741,7,35.188,2.178,44.266 c-4.82,9.077-1.372,20.341,7.703,25.167c6.766,3.591,14.744,2.59,20.365-1.914l-0.122,0.236c0,0,4.132-3.399,16.04,2.994 c9.4,5.044,10.796,9.988,10.975,11.846c-0.246,6.893,3.347,13.654,9.847,17.107c9.075,4.825,20.344,1.375,25.164-7.701 C96.974,82.926,93.528,71.656,84.45,66.836z M63.466,69.282c-1.504,0.532-5.801,1.121-14.847-3.73 c-9.797-5.26-11.251-9.654-11.464-10.973c0.139-1.6,0.05-3.197-0.223-4.755l0.06,0.09c0,0-0.798-4.274,10.412-11.235 c10.033-6.228,14.594-4.989,15.443-4.664c0.546,0.371,1.112,0.717,1.706,1.033c1.129,0.6,2.293,1.07,3.472,1.418 c1.38,1.314,3.92,5.045,4.184,14.854c0.27,9.883-2.634,13.694-4.217,15.042C66.362,67.1,64.836,68.085,63.466,69.282z' fill='%230C479C'/%3E%3Cg%3E%3Cpath d='M62.239,8.1c-5.415,5.923-5.529,14.636-0.312,19.566c-2.579-2.483-2.523-7.651,0.083-12.597 c0.335-0.443,1.306-1.49,2.725-1.014c0.143,0.049,0.237,0.062,0.292,0.053c0.321,0.069,0.65,0.11,0.99,0.095 c2.155-0.098,3.822-1.921,3.725-4.077c-0.044-0.967-0.445-1.823-1.065-2.48c5.002-3.277,10.742-3.652,13.094-1.504l0.09,0.006 C76.488,1.242,67.705,2.119,62.239,8.1z' fill='%23FFFFFF'/%3E%3C/g%3E%3Cg%3E%3Cpath d='M7.632,62.845c-0.046-0.047-0.093-0.102-0.141-0.148c0.03,0.031,0.059,0.069,0.095,0.102L7.632,62.845z' fill='%23FFFFFF'/%3E%3Cpath d='M7.805,43.13c-5.416,5.924-5.529,14.635-0.313,19.566c-2.578-2.484-2.523-7.652,0.083-12.598 c0.336-0.444,1.308-1.49,2.727-1.014c0.141,0.049,0.236,0.061,0.292,0.054c0.321,0.069,0.651,0.11,0.99,0.095 c2.156-0.099,3.822-1.922,3.725-4.076c-0.045-0.967-0.445-1.824-1.063-2.48c4.999-3.276,10.74-3.654,13.092-1.505l0.089,0.008 C22.054,36.271,13.269,37.147,7.805,43.13z' fill='%23FFFFFF'/%3E%3C/g%3E%3Cg%3E%3Cpath d='M65.256,92.504c-0.047-0.048-0.094-0.102-0.141-0.148c0.029,0.031,0.059,0.069,0.094,0.101L65.256,92.504z' fill='%23FFFFFF'/%3E%3Cpath d='M65.428,72.786c-5.416,5.926-5.529,14.639-0.313,19.569c-2.58-2.483-2.523-7.653,0.082-12.597 c0.336-0.445,1.307-1.49,2.727-1.014c0.143,0.047,0.235,0.061,0.292,0.053c0.32,0.069,0.651,0.11,0.99,0.096 c2.154-0.1,3.82-1.924,3.723-4.08c-0.044-0.966-0.445-1.822-1.063-2.479c5-3.275,10.739-3.652,13.093-1.504l0.088,0.007 C79.677,65.93,70.891,66.807,65.428,72.786z' fill='%23FFFFFF'/%3E%3C/g%3E%3C/g%3E%3C/svg%3E%0A")
+	background: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' version='1.1' overflow='visible' height='18' width='18' viewBox='0 0 94.332 101.883'%3E%3Cg shape-rendering='geometricPrecision' text-rendering='geometricPrecision' image-rendering='optimizeQuality'%3E%3Cpath d='M84.45,66.836c-0.636-0.337-1.284-0.624-1.936-0.879l0.466-0.038c0,0-4.151-1.838-4.514-15.18 c-0.359-13.344,3.957-15.62,3.957-15.62l-0.62,0.027c3.261-1.673,6.066-4.316,7.917-7.804c4.823-9.072,1.372-20.341-7.702-25.165 C72.94-2.641,61.674,0.802,56.854,9.883c-1.982,3.725-2.545,7.817-1.919,11.683l-0.212-0.326c0,0,1.093,4.842-10.258,11.888 c-11.349,7.05-16.469,3.54-16.469,3.54l0.326,0.48c-0.325-0.201-0.636-0.406-0.975-0.583C18.269,31.741,7,35.188,2.178,44.266 c-4.82,9.077-1.372,20.341,7.703,25.167c6.766,3.591,14.744,2.59,20.365-1.914l-0.122,0.236c0,0,4.132-3.399,16.04,2.994 c9.4,5.044,10.796,9.988,10.975,11.846c-0.246,6.893,3.347,13.654,9.847,17.107c9.075,4.825,20.344,1.375,25.164-7.701 C96.974,82.926,93.528,71.656,84.45,66.836z M63.466,69.282c-1.504,0.532-5.801,1.121-14.847-3.73 c-9.797-5.26-11.251-9.654-11.464-10.973c0.139-1.6,0.05-3.197-0.223-4.755l0.06,0.09c0,0-0.798-4.274,10.412-11.235 c10.033-6.228,14.594-4.989,15.443-4.664c0.546,0.371,1.112,0.717,1.706,1.033c1.129,0.6,2.293,1.07,3.472,1.418 c1.38,1.314,3.92,5.045,4.184,14.854c0.27,9.883-2.634,13.694-4.217,15.042C66.362,67.1,64.836,68.085,63.466,69.282z' fill='%230C479C'/%3E%3Cg%3E%3Cpath d='M62.239,8.1c-5.415,5.923-5.529,14.636-0.312,19.566c-2.579-2.483-2.523-7.651,0.083-12.597 c0.335-0.443,1.306-1.49,2.725-1.014c0.143,0.049,0.237,0.062,0.292,0.053c0.321,0.069,0.65,0.11,0.99,0.095 c2.155-0.098,3.822-1.921,3.725-4.077c-0.044-0.967-0.445-1.823-1.065-2.48c5.002-3.277,10.742-3.652,13.094-1.504l0.09,0.006 C76.488,1.242,67.705,2.119,62.239,8.1z' fill='%23FFFFFF'/%3E%3C/g%3E%3Cg%3E%3Cpath d='M7.632,62.845c-0.046-0.047-0.093-0.102-0.141-0.148c0.03,0.031,0.059,0.069,0.095,0.102L7.632,62.845z' fill='%23FFFFFF'/%3E%3Cpath d='M7.805,43.13c-5.416,5.924-5.529,14.635-0.313,19.566c-2.578-2.484-2.523-7.652,0.083-12.598 c0.336-0.444,1.308-1.49,2.727-1.014c0.141,0.049,0.236,0.061,0.292,0.054c0.321,0.069,0.651,0.11,0.99,0.095 c2.156-0.099,3.822-1.922,3.725-4.076c-0.045-0.967-0.445-1.824-1.063-2.48c4.999-3.276,10.74-3.654,13.092-1.505l0.089,0.008 C22.054,36.271,13.269,37.147,7.805,43.13z' fill='%23FFFFFF'/%3E%3C/g%3E%3Cg%3E%3Cpath d='M65.256,92.504c-0.047-0.048-0.094-0.102-0.141-0.148c0.029,0.031,0.059,0.069,0.094,0.101L65.256,92.504z' fill='%23FFFFFF'/%3E%3Cpath d='M65.428,72.786c-5.416,5.926-5.529,14.639-0.313,19.569c-2.58-2.483-2.523-7.653,0.082-12.597 c0.336-0.445,1.307-1.49,2.727-1.014c0.143,0.047,0.235,0.061,0.292,0.053c0.32,0.069,0.651,0.11,0.99,0.096 c2.154-0.1,3.82-1.924,3.723-4.08c-0.044-0.966-0.445-1.822-1.063-2.479c5-3.275,10.739-3.652,13.093-1.504l0.088,0.007 C79.677,65.93,70.891,66.807,65.428,72.786z' fill='%23FFFFFF'/%3E%3C/g%3E%3C/g%3E%3C/svg%3E%0A")
 	center left no-repeat;
 	padding-left: 28px;
 	display: inline-block;
@@ -805,23 +839,22 @@ a.smw-ask-action-btn-lblue:hover {
 }
 
 .smw-loading-image-dots {
-    background:
-    url('data:image/gif;base64,R0lGODlhIgAUAMQRAOjp6dTW19ze3+Xm54iKjevs7IKEh/f396Olp5ianPz8/Judn9fY2YGDhp+ho4CChdHT1P///wAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACH/C05FVFNDQVBFMi4wAwEAAAAh/wtYTVAgRGF0YVhNUDw/eHBhY2tldCBiZWdpbj0i77u/IiBpZD0iVzVNME1wQ2VoaUh6cmVTek5UY3prYzlkIj8+IDx4OnhtcG1ldGEgeG1sbnM6eD0iYWRvYmU6bnM6bWV0YS8iIHg6eG1wdGs9IkFkb2JlIFhNUCBDb3JlIDUuMC1jMDYwIDYxLjEzNDc3NywgMjAxMC8wMi8xMi0xNzozMjowMCAgICAgICAgIj4gPHJkZjpSREYgeG1sbnM6cmRmPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5LzAyLzIyLXJkZi1zeW50YXgtbnMjIj4gPHJkZjpEZXNjcmlwdGlvbiByZGY6YWJvdXQ9IiIgeG1sbnM6eG1wTU09Imh0dHA6Ly9ucy5hZG9iZS5jb20veGFwLzEuMC9tbS8iIHhtbG5zOnN0UmVmPSJodHRwOi8vbnMuYWRvYmUuY29tL3hhcC8xLjAvc1R5cGUvUmVzb3VyY2VSZWYjIiB4bWxuczp4bXA9Imh0dHA6Ly9ucy5hZG9iZS5jb20veGFwLzEuMC8iIHhtcE1NOk9yaWdpbmFsRG9jdW1lbnRJRD0ieG1wLmRpZDoxRThFNDZFQ0RFQjJFMjExQUZCNUREQjU1MEFCRTI5OCIgeG1wTU06RG9jdW1lbnRJRD0ieG1wLmRpZDozNkVFNURCOUIyREYxMUUyQTBEQUNFNUIzREVGNjg0MyIgeG1wTU06SW5zdGFuY2VJRD0ieG1wLmlpZDozNkVFNURCOEIyREYxMUUyQTBEQUNFNUIzREVGNjg0MyIgeG1wOkNyZWF0b3JUb29sPSJBZG9iZSBQaG90b3Nob3AgQ1M1IFdpbmRvd3MiPiA8eG1wTU06RGVyaXZlZEZyb20gc3RSZWY6aW5zdGFuY2VJRD0ieG1wLmlpZDoyMDhFNDZFQ0RFQjJFMjExQUZCNUREQjU1MEFCRTI5OCIgc3RSZWY6ZG9jdW1lbnRJRD0ieG1wLmRpZDoxRThFNDZFQ0RFQjJFMjExQUZCNUREQjU1MEFCRTI5OCIvPiA8L3JkZjpEZXNjcmlwdGlvbj4gPC9yZGY6UkRGPiA8L3g6eG1wbWV0YT4gPD94cGFja2V0IGVuZD0iciI/PgH//v38+/r5+Pf29fTz8vHw7+7t7Ovq6ejn5uXk4+Lh4N/e3dzb2tnY19bV1NPS0dDPzs3My8rJyMfGxcTDwsHAv769vLu6ubi3trW0s7KxsK+urayrqqmop6alpKOioaCfnp2cm5qZmJeWlZSTkpGQj46NjIuKiYiHhoWEg4KBgH9+fXx7enl4d3Z1dHNycXBvbm1sa2ppaGdmZWRjYmFgX15dXFtaWVhXVlVUU1JRUE9OTUxLSklIR0ZFRENCQUA/Pj08Ozo5ODc2NTQzMjEwLy4tLCsqKSgnJiUkIyIhIB8eHRwbGhkYFxYVFBMSERAPDg0MCwoJCAcGBQQDAgEAACH5BAkyABEALAAAAAAiABQAAAVeYCSOZGmeaKqubOu+cCzPdM0iBIGYgCAUPB8Q5XgYHw4SAMKEAJRNJ8pwfBhIgagAq0U1qg1ukyFmkk+L6oI0iD5H7ebbdEgYEweSYhAIDEp7fX82hIWGh4iJiosoIQAh+QQJMgARACwAAAAAIgAUAAAFZGAkjmRpnmiqrmzrvnAsz3TNFoIAmAhBICZArpACQI6Q3cjxaD4cJCNSaRIgIQGSwfkwkAJXAYpxzY4a3Mb3ykBJjwPSgrsgDa5U0yAQGChIBwlNCQckCnt9NoqLjI2Oj5CRKSEAIfkEBTIAEQAsAAAAACIAFAAABWNgJI5kaZ5oqq5s675wLM90zRaCAJi4biIEAiIFgBghu1HxmBQ5HtCHAyU4QgKk6hE7MkQfBhTDyhWNt6TGt4FaGgckNwQ+WnwXqUEgMFCU9Hx+IwcJUAkHNomKi4yNjo+QKCEAOw==')
+    background: url('data:image/gif;base64,R0lGODlhIgAUAMQRAOjp6dTW19ze3+Xm54iKjevs7IKEh/f396Olp5ianPz8/Judn9fY2YGDhp+ho4CChdHT1P///wAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACH/C05FVFNDQVBFMi4wAwEAAAAh/wtYTVAgRGF0YVhNUDw/eHBhY2tldCBiZWdpbj0i77u/IiBpZD0iVzVNME1wQ2VoaUh6cmVTek5UY3prYzlkIj8+IDx4OnhtcG1ldGEgeG1sbnM6eD0iYWRvYmU6bnM6bWV0YS8iIHg6eG1wdGs9IkFkb2JlIFhNUCBDb3JlIDUuMC1jMDYwIDYxLjEzNDc3NywgMjAxMC8wMi8xMi0xNzozMjowMCAgICAgICAgIj4gPHJkZjpSREYgeG1sbnM6cmRmPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5LzAyLzIyLXJkZi1zeW50YXgtbnMjIj4gPHJkZjpEZXNjcmlwdGlvbiByZGY6YWJvdXQ9IiIgeG1sbnM6eG1wTU09Imh0dHA6Ly9ucy5hZG9iZS5jb20veGFwLzEuMC9tbS8iIHhtbG5zOnN0UmVmPSJodHRwOi8vbnMuYWRvYmUuY29tL3hhcC8xLjAvc1R5cGUvUmVzb3VyY2VSZWYjIiB4bWxuczp4bXA9Imh0dHA6Ly9ucy5hZG9iZS5jb20veGFwLzEuMC8iIHhtcE1NOk9yaWdpbmFsRG9jdW1lbnRJRD0ieG1wLmRpZDoxRThFNDZFQ0RFQjJFMjExQUZCNUREQjU1MEFCRTI5OCIgeG1wTU06RG9jdW1lbnRJRD0ieG1wLmRpZDozNkVFNURCOUIyREYxMUUyQTBEQUNFNUIzREVGNjg0MyIgeG1wTU06SW5zdGFuY2VJRD0ieG1wLmlpZDozNkVFNURCOEIyREYxMUUyQTBEQUNFNUIzREVGNjg0MyIgeG1wOkNyZWF0b3JUb29sPSJBZG9iZSBQaG90b3Nob3AgQ1M1IFdpbmRvd3MiPiA8eG1wTU06RGVyaXZlZEZyb20gc3RSZWY6aW5zdGFuY2VJRD0ieG1wLmlpZDoyMDhFNDZFQ0RFQjJFMjExQUZCNUREQjU1MEFCRTI5OCIgc3RSZWY6ZG9jdW1lbnRJRD0ieG1wLmRpZDoxRThFNDZFQ0RFQjJFMjExQUZCNUREQjU1MEFCRTI5OCIvPiA8L3JkZjpEZXNjcmlwdGlvbj4gPC9yZGY6UkRGPiA8L3g6eG1wbWV0YT4gPD94cGFja2V0IGVuZD0iciI/PgH//v38+/r5+Pf29fTz8vHw7+7t7Ovq6ejn5uXk4+Lh4N/e3dzb2tnY19bV1NPS0dDPzs3My8rJyMfGxcTDwsHAv769vLu6ubi3trW0s7KxsK+urayrqqmop6alpKOioaCfnp2cm5qZmJeWlZSTkpGQj46NjIuKiYiHhoWEg4KBgH9+fXx7enl4d3Z1dHNycXBvbm1sa2ppaGdmZWRjYmFgX15dXFtaWVhXVlVUU1JRUE9OTUxLSklIR0ZFRENCQUA/Pj08Ozo5ODc2NTQzMjEwLy4tLCsqKSgnJiUkIyIhIB8eHRwbGhkYFxYVFBMSERAPDg0MCwoJCAcGBQQDAgEAACH5BAkyABEALAAAAAAiABQAAAVeYCSOZGmeaKqubOu+cCzPdM0iBIGYgCAUPB8Q5XgYHw4SAMKEAJRNJ8pwfBhIgagAq0U1qg1ukyFmkk+L6oI0iD5H7ebbdEgYEweSYhAIDEp7fX82hIWGh4iJiosoIQAh+QQJMgARACwAAAAAIgAUAAAFZGAkjmRpnmiqrmzrvnAsz3TNFoIAmAhBICZArpACQI6Q3cjxaD4cJCNSaRIgIQGSwfkwkAJXAYpxzY4a3Mb3ykBJjwPSgrsgDa5U0yAQGChIBwlNCQckCnt9NoqLjI2Oj5CRKSEAIfkEBTIAEQAsAAAAACIAFAAABWNgJI5kaZ5oqq5s675wLM90zRaCAJi4biIEAiIFgBghu1HxmBQ5HtCHAyU4QgKk6hE7MkQfBhTDyhWNt6TGt4FaGgckNwQ+WnwXqUEgMFCU9Hx+IwcJUAkHNomKi4yNjo+QKCEAOw==')
     no-repeat
     left center;
     padding: 5px 0 5px 35px;
     vertical-align: middle;
 }
 
-.smw-overlay-spinner.small{
+.smw-overlay-spinner.small {
 	height: 20px;
 	width: 20px;
 }
-.smw-overlay-spinner.medium{
+.smw-overlay-spinner.medium {
 	height: 40px;
 	width: 40px;
 }
-.smw-overlay-spinner.large{
+.smw-overlay-spinner.large {
 	height: 60px;
 	width: 60px;
 }
@@ -832,7 +865,7 @@ a.smw-ask-action-btn-lblue:hover {
 	top: 30%;
 	height: 60px;
 	width: 60px;
-	margin:0px auto;
+	margin: 0px auto;
 	-webkit-animation: rotation 1.0s infinite linear;
 	-moz-animation: rotation 1.0s infinite linear;
 	-o-animation: rotation 1.0s infinite linear;
@@ -870,14 +903,16 @@ a.smw-ask-action-btn-lblue:hover {
 }
 
 /* MobileFrontend overrides some desktop rules */
-.content table.broadtable, .smw-ask-result table.broadtable {
+.content table.broadtable,
+.smw-ask-result table.broadtable {
 	width: 100% !important;
 }
 
 /**
  * User preference
  */
-fieldset#mw-prefsection-smw-general-options, fieldset#mw-prefsection-smw-ask-options {
+fieldset#mw-prefsection-smw-general-options,
+fieldset#mw-prefsection-smw-ask-options {
 	border: 0px solid #2a4b8d;
 	border-top: 1px solid #ddd;
 	margin-top: -5px;


### PR DESCRIPTION
This PR is made in reference to: #2736 and #2869 

This PR addresses or contains:
- Addresses https://github.com/SemanticMediaWiki/SemanticMediaWiki/pull/2869#pullrequestreview-82348407
- Replaces one remaining occurance of "searchgray_iconsmall.png"
- Tidies formatting (more readable and more consistent)

This PR includes:
- [ ] Tests (unit/integration)
- [ ] CI build passed