### PR TITLE
Move skin related CSS to own file

### DIFF
--- a/res/Resources.php
+++ b/res/Resources.php
@@ -32,6 +32,7 @@ return array(
 	'ext.smw.style' => $moduleTemplate + array(
 		'styles' => array(
 			'smw/ext.smw.css',
+			'smw/ext.smw.skin.css',
 			'smw/ext.smw.dropdown.css'
 		),
 		'position' => 'top',
@@ -361,6 +362,7 @@ return array(
 		'styles' => array(
 			'smw/ext.smw.table.css',
 			'smw/special/ext.smw.special.browse.css',
+			'smw/special/ext.smw.special.browse.skin.css',
 		),
 		'position' => 'top',
 		'targets' => array(
@@ -420,7 +422,8 @@ return array(
 			'smw/printer/ext.smw.tableprinter.js'
 		),
 		'styles'   => array(
-			'smw/printer/ext.smw.tableprinter.css'
+			'smw/printer/ext.smw.tableprinter.css',
+			'smw/printer/ext.smw.tableprinter.skin.css'
 		),
 		'dependencies' => array(
 			'onoi.dataTables',
@@ -452,7 +455,10 @@ return array(
 	// Deferred
 	'ext.smw.deferred.styles'  => $moduleTemplate + array(
 		'position' => 'top',
-		'styles'   => array( 'smw/deferred/ext.smw.deferred.css' ),
+		'styles'   => array(
+			'smw/deferred/ext.smw.deferred.css',
+			'smw/deferred/ext.smw.deferred.skin.css'
+		),
 		'targets' => array(
 			'mobile',
 			'desktop'
@@ -461,7 +467,10 @@ return array(
 
 	'ext.smw.deferred'  => $moduleTemplate + array(
 		'position' => 'top',
-		'styles'   => array( 'smw/deferred/ext.smw.deferred.css' ),
+		'styles'   => array(
+			'smw/deferred/ext.smw.deferred.css',
+			'smw/deferred/ext.smw.deferred.skin.css'
+		),
 		'scripts'  => array( 'smw/deferred/ext.smw.deferred.js' ),
 		'dependencies'  => array(
 			'mediawiki.api',

--- a/res/smw/deferred/ext.smw.deferred.css
+++ b/res/smw/deferred/ext.smw.deferred.css
@@ -59,20 +59,3 @@
     height: 100%;
     content: ' ';
 }
-
-.skin-vector .smw-overlay-spinner {
-    left: 43%;
-    top: 40%;
-}
-
-@media (min-width: 400px) {
-    .skin-vector .smw-overlay-spinner {
-        left: 46%;
-    }
-}
-
-@media (max-width: 399px) {
-    .skin-vector .smw-overlay-spinner {
-        left: 47%;
-    }
-}

--- a/res/smw/deferred/ext.smw.deferred.skin.css
+++ b/res/smw/deferred/ext.smw.deferred.skin.css
@@ -1,0 +1,19 @@
+/**
+ * .skin-vector specific styles
+ */
+.skin-vector .smw-overlay-spinner {
+    left: 43%;
+    top: 40%;
+}
+
+@media (min-width: 400px) {
+    .skin-vector .smw-overlay-spinner {
+        left: 46%;
+    }
+}
+
+@media (max-width: 399px) {
+    .skin-vector .smw-overlay-spinner {
+        left: 47%;
+    }
+}

--- a/res/smw/ext.smw.css
+++ b/res/smw/ext.smw.css
@@ -757,15 +757,6 @@ a.smw-ask-action-btn-dblue:focus {
 	color: #800000;
 }
 
-.skin-chameleon .smwfact td {
-	padding: 5px;
-}
-
-.skin-chameleon .smw-page-indicator {
-	padding: 0.35rem 0.85rem;
-	line-height: 1.55;
-}
-
 .smw-page-indicator-rdflink {
 	line-height: 24px;
 	margin-right: 10px;
@@ -875,11 +866,6 @@ a.smw-ask-action-btn-dblue:focus {
 	border-bottom:6px solid rgba(0,174,239,.15);
 	border-top:6px solid rgba(0,174,239,.8);
 	border-radius:100%;
-}
-
-.skin-vector .smw-overlay-spinner {
-	left: 45%;
-	top: 30%;
 }
 
 @-webkit-keyframes rotation {

--- a/res/smw/ext.smw.skin.css
+++ b/res/smw/ext.smw.skin.css
@@ -1,0 +1,52 @@
+/**
+ * .skin-vector specific styles
+ */
+
+.skin-vector input#smw-property-input.autocomplete-suggestions {
+	height: 1.15em;
+	padding: 2px 2px;
+}
+
+.skin-vector .smw-overlay-spinner {
+	left: 45%;
+	top: 30%;
+}
+
+.skin-chameleon .smw-page-indicator {
+	padding: 0.35rem 0.85rem;
+	line-height: 1.55;
+}
+
+/**
+ * .skin-chameleon specific styles
+ */
+.skin-chameleon input#smw-property-input.autocomplete-suggestions {
+	height: 30px;
+	padding: 2px 2px;
+}
+
+.skin-chameleon .autocomplete-suggestion {
+	padding: 2px 5px;
+	white-space: nowrap;
+	overflow: hidden;
+	font-size: 0.9em;
+}
+
+.skin-chameleon .smwfact td {
+	padding: 5px;
+}
+
+/**
+ * .skin-foreground specific styles
+ */
+.skin-foreground input#smw-property-input.autocomplete-suggestions {
+	height: 32px;
+	padding: 2px 0px 0px 8px;
+}
+
+.skin-foreground .autocomplete-suggestion {
+	padding: 2px 5px;
+	white-space: nowrap;
+	overflow: hidden;
+	font-size: 0.9em;
+}

--- a/res/smw/printer/ext.smw.tableprinter.css
+++ b/res/smw/printer/ext.smw.tableprinter.css
@@ -230,6 +230,7 @@
 .smw-datatable-toolbar .smw-dropdown button {
 	padding: 4px 25px 5px 15px;
 	border: 1px solid #ddd;
+	border-radius: 0.2rem;
 }
 
 @-moz-document url-prefix() {
@@ -279,37 +280,3 @@
 .smw-datatable-button a {
 	text-decoration: none;
 }
-
-/**
- * .skin-chameleon specific styles
- */
-.skin-chameleon .smw-datatable .dataTables_wrapper .dataTables_paginate .paginate_button,
-.skin-chameleon .smw-datatable .dataTables_wrapper .dataTables_paginate .paginate_button:hover,
-.skin-chameleon .smw-datatable .dataTables_wrapper .dataTables_paginate .paginate_button.current,
-.skin-chameleon .smw-datatable .dataTables_wrapper .dataTables_paginate .paginate_button.current:hover,
-.skin-chameleon .smw-datatable .dataTables_wrapper .dataTables_paginate .paginate_button.disabled,
-.skin-chameleon .smw-datatable .dataTables_wrapper .dataTables_paginate .paginate_button.disabled:hover,
-.skin-chameleon .smw-datatable .dataTables_wrapper .dataTables_paginate .paginate_button.disabled:active {
-	padding: 0.55rem 0.85rem;
-	line-height: 1.0;
-	font-size: 14px;
-}
-
-.skin-chameleon .smw-datatable .dataTables_wrapper select,
-.skin-chameleon .smw-datatable .dataTables_wrapper select:focus,
-.skin-chameleon .smw-datatable .dataTables_wrapper select:active {
-	padding: 0.15rem 0.5rem;
-}
-
-.skin-chameleon .dataTables_wrapper label {
-	font-weight: normal;
-}
-
-.skin-chameleon table th {
-	text-align: center;
-}
-
-.skin-chameleon .smw-datatable-toolbar .smw-dropdown button {
-	padding: 2px 25px 2px 15px;
-}
-

--- a/res/smw/printer/ext.smw.tableprinter.skin.css
+++ b/res/smw/printer/ext.smw.tableprinter.skin.css
@@ -1,0 +1,37 @@
+/**
+ * .skin-chameleon specific styles
+ */
+.skin-chameleon .smw-datatable .dataTables_wrapper .dataTables_paginate .paginate_button,
+.skin-chameleon .smw-datatable .dataTables_wrapper .dataTables_paginate .paginate_button:hover,
+.skin-chameleon .smw-datatable .dataTables_wrapper .dataTables_paginate .paginate_button.current,
+.skin-chameleon .smw-datatable .dataTables_wrapper .dataTables_paginate .paginate_button.current:hover,
+.skin-chameleon .smw-datatable .dataTables_wrapper .dataTables_paginate .paginate_button.disabled,
+.skin-chameleon .smw-datatable .dataTables_wrapper .dataTables_paginate .paginate_button.disabled:hover,
+.skin-chameleon .smw-datatable .dataTables_wrapper .dataTables_paginate .paginate_button.disabled:active {
+	padding: 0.55rem 0.85rem;
+	line-height: 1.0;
+	font-size: 14px;
+}
+
+.skin-chameleon .smw-datatable .dataTables_wrapper select,
+.skin-chameleon .smw-datatable .dataTables_wrapper select:focus,
+.skin-chameleon .smw-datatable .dataTables_wrapper select:active {
+	padding: 0.15rem 0.5rem;
+}
+
+.skin-chameleon .dataTables_wrapper label {
+	font-weight: normal;
+}
+
+.skin-chameleon table th {
+	text-align: center;
+}
+
+.skin-chameleon .smw-datatable-toolbar .smw-dropdown button {
+	padding: 2px 25px 2px 15px;
+	border-radius: 0.2rem;
+}
+
+.skin-chameleon .smw-datatable .smw-datatable-sep {
+	padding: 0 0.2em 0.2em 0;
+}

--- a/res/smw/special/ext.smw.special.browse.css
+++ b/res/smw/special/ext.smw.special.browse.css
@@ -167,10 +167,6 @@ span.smwb-ivalue {
 .browse-input-resp .input-field { flex: 1; margin: 0 0 0 0; }
 .browse-input-resp .button-field { flex: 0; margin: 0 0 0 1rem; }
 
-.skin-chameleon .smwb-datasheet, .skin-chameleon .smwb-content {
-	margin-right: 0em;
-}
-
 .browse-input-resp .mw-ui-input:focus {
 	box-shadow: inset 0 0 0 1px #ddd;
 	border-color: #ddd;

--- a/res/smw/special/ext.smw.special.browse.skin.css
+++ b/res/smw/special/ext.smw.special.browse.skin.css
@@ -1,0 +1,6 @@
+/**
+ * .skin-chameleon specific styles
+ */
+.skin-chameleon .smwb-datasheet, .skin-chameleon .smwb-content {
+	margin-right: 0em;
+}


### PR DESCRIPTION
This PR is made in reference to: #

This PR addresses or contains:

- Improve readability by separating common from skin specific CSS with the skin file being loaded after the core CSS to ensure the cascading for a skin takes place

This PR includes:
- [ ] Tests (unit/integration)
- [x] CI build passed
