### PR TITLE
Make subobject sortkey distinguishable

### DIFF
--- a/includes/SemanticData.php
+++ b/includes/SemanticData.php
@@ -158,6 +158,11 @@ class SemanticData {
 	protected $options;
 
 	/**
+	 * @var array
+	 */
+	protected $extensionData = [];
+
+	/**
 	 * This is kept public to keep track of the depth during a recursive processing
 	 * when accessed through the SubSemanticData instance.
 	 *
@@ -192,7 +197,7 @@ class SemanticData {
 	 * @return array
 	 */
 	public function __sleep() {
-		return array( 'mSubject', 'mPropVals', 'mProperties', 'subSemanticData', 'mHasVisibleProps', 'mHasVisibleSpecs', 'options' );
+		return array( 'mSubject', 'mPropVals', 'mProperties', 'subSemanticData', 'mHasVisibleProps', 'mHasVisibleSpecs', 'options', 'extensionData' );
 	}
 
 	/**
@@ -241,6 +246,32 @@ class SemanticData {
 		}
 
 		return array();
+	}
+
+	/**
+	 * @since 3.0
+	 *
+	 * @param string $key
+	 * @param mixed $value
+	 */
+	public function setExtensionData( $key, $value ) {
+		$this->extensionData[$key] = $value;
+	}
+
+	/**
+	 * @since 3.0
+	 *
+	 * @param string $key
+	 *
+	 * @return mixed|null
+	 */
+	public function getExtensionData( $key ) {
+
+		if ( isset( $this->extensionData[$key] ) ) {
+			return $this->extensionData[$key];
+		}
+
+		return null;
 	}
 
 	/**
@@ -427,12 +458,12 @@ class SemanticData {
 			$this->mHasVisibleProps = true;
 		}
 
-		// Inherit the sortkey from the root if not explicitly given
+		// Account for things like DISPLAYTITLE or DEFAULTSORT which are only set
+		// after #subobject has been processed therefore keep them in-memory
+		// for a post process
 		if ( $this->mSubject->getSubobjectName() === '' && $property->getKey() === DIProperty::TYPE_SORTKEY ) {
 			foreach ( $this->getSubSemanticData() as $subSemanticData ) {
-				if ( !$subSemanticData->hasProperty( $property ) ) {
-					$subSemanticData->addPropertyObjectValue( $property, $dataItem );
-				}
+				$subSemanticData->setExtensionData( 'sort.extension', $dataItem->getString() );
 			}
 		}
 	}

--- a/includes/datavalues/SMW_DV_Record.php
+++ b/includes/datavalues/SMW_DV_Record.php
@@ -124,11 +124,10 @@ class SMWRecordValue extends AbstractMultiValue {
 			$this->addErrorMsg( array( 'smw_novalues' ) );
 		}
 
-		$this->m_dataitem = new DIContainer( $containerSemanticData );
+		// Remember the data to extend the sortkey
+		$containerSemanticData->setExtensionData( 'sort.data', implode( ';', $sortKeys ) );
 
-		// Composite sortkey is to ensure that Store::getPropertyValues can
-		// apply sorting during value selection
-		$this->m_dataitem->setSortKey( implode( ';', $sortKeys ) );
+		$this->m_dataitem = new DIContainer( $containerSemanticData );
 	}
 
 	/**

--- a/includes/storage/SQLStore/SMW_Sql3StubSemanticData.php
+++ b/includes/storage/SQLStore/SMW_Sql3StubSemanticData.php
@@ -79,7 +79,7 @@ class SMWSql3StubSemanticData extends SMWSemanticData {
 	 * @return array
 	 */
 	public function __sleep() {
-		return array( 'mSubject', 'mPropVals', 'mProperties', 'subSemanticData', 'mStubPropVals' );
+		return array( 'mSubject', 'mPropVals', 'mProperties', 'subSemanticData', 'mStubPropVals', 'options', 'extensionData' );
 	}
 
 	/**

--- a/src/DataModel/ContainerSemanticData.php
+++ b/src/DataModel/ContainerSemanticData.php
@@ -71,7 +71,8 @@ class ContainerSemanticData extends SemanticData {
 			'mNoDuplicates',
 			'skipAnonymousCheck',
 			'subSemanticData',
-			'options'
+			'options',
+			'extensionData'
 		);
 	}
 

--- a/src/DataValues/MonolingualTextValue.php
+++ b/src/DataValues/MonolingualTextValue.php
@@ -140,11 +140,10 @@ class MonolingualTextValue extends AbstractMultiValue {
 			$containerSemanticData->addDataValue( $dataValue );
 		}
 
-		$this->m_dataitem = new DIContainer( $containerSemanticData );
+		// Remember the data to extend the sortkey
+		$containerSemanticData->setExtensionData( 'sort.data', implode( ';', [ $text, $languageCode ] ) );
 
-		// Composite sortkey is to ensure that Store::getPropertyValues can
-		// apply sorting during value selection
-		$this->m_dataitem->setSortKey( implode( ';', array( $text, $languageCode ) ) );
+		$this->m_dataitem = new DIContainer( $containerSemanticData );
 	}
 
 	/**

--- a/src/DataValues/ReferenceValue.php
+++ b/src/DataValues/ReferenceValue.php
@@ -235,11 +235,10 @@ class ReferenceValue extends AbstractMultiValue {
 			$this->addErrorMsg( array( 'smw_novalues' ) );
 		}
 
-		$this->m_dataitem = new DIContainer( $containerSemanticData );
+		// Remember the data to extend the sortkey
+		$containerSemanticData->setExtensionData( 'sort.data', implode( ';', $sortKeys ) );
 
-		// Composite sortkey is to ensure that Store::getPropertyValues can
-		// apply sorting during value selection
-		$this->m_dataitem->setSortKey( implode( ';', $sortKeys ) );
+		$this->m_dataitem = new DIContainer( $containerSemanticData );
 	}
 
 	/**

--- a/tests/phpunit/Integration/JSONScript/TestCases/p-0416.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/p-0416.json
@@ -12,7 +12,7 @@
 		},
 		{
 			"page": "Example/P0416/Q1.1",
-			"contents": "{{#ask: [[~Foo]] OR [[~123]] |?Display title of |format=table }}"
+			"contents": "{{#ask: [[~Foo]] OR [[~123*]] |?Display title of |format=table }}"
 		},
 		{
 			"page": "Example/P0416/2",
@@ -20,7 +20,7 @@
 		},
 		{
 			"page": "Example/P0416/Q2.1",
-			"contents": "{{#ask: [[~Example/P0416/2*]] OR [[~Foobar]] |?Display title of |format=table }}"
+			"contents": "{{#ask: [[~Example/P0416/2*]] OR [[~Foobar*]] |?Display title of |format=table }}"
 		},
 		{
 			"page": "Example/P0416/3",
@@ -60,11 +60,15 @@
 		},
 		{
 			"page": "Example/P0416/Q6.1",
-			"contents": "{{#ask: [[Category:P0416]] [[~P0416]] |link=none |format=table |sort=# |order=asc}}"
+			"contents": "{{#ask: [[Category:P0416]] [[~P0416*]] |link=none |format=table |sort=# |order=asc}}"
 		},
 		{
-			"page": "Example/P0416/Q6.2",
+			"page": "Example/P0416/Q6.2.1",
 			"contents": "{{#ask: [[Category:P0416]] [[~BAR]] |link=none |format=table |sort=# |order=asc}}"
+		},
+		{
+			"page": "Example/P0416/Q6.2.2",
+			"contents": "{{#ask: [[Category:P0416]] [[~BAR*]] |link=none |format=table |sort=# |order=asc}}"
 		},
 		{
 			"page": "Example/P0416/Q6.3",
@@ -202,20 +206,30 @@
 		},
 		{
 			"type": "parser",
-			"about": "#8 (sortkey is copied from root)",
+			"about": "#8 (sortkey is copied from root, [1 and 3 contain both P0416 as sort while 1(sobj) contains P0416# ... ])",
 			"subject": "Example/P0416/Q6.1",
 			"assert-output": {
 				"to-contain": [
 					"<tr data-row-number=\"1\" class=\"row-odd\"><td class=\"smwtype_wpg\">Example/P0416/6/1</td></tr>",
-					"<tr data-row-number=\"2\" class=\"row-even\"><td class=\"smwtype_wpg\">Example/P0416/6/1#_4c8278b5823715af48e85d55f6118d4e</td></tr>",
-					"<tr data-row-number=\"3\" class=\"row-odd\"><td class=\"smwtype_wpg\">Example/P0416/6/3</td></tr>"
+					"<tr data-row-number=\"2\" class=\"row-even\"><td class=\"smwtype_wpg\">Example/P0416/6/3</td></tr>",
+					"<tr data-row-number=\"3\" class=\"row-odd\"><td class=\"smwtype_wpg\">Example/P0416/6/1#_4c8278b5823715af48e85d55f6118d4e</td></tr>"
 				]
 			}
 		},
 		{
 			"type": "parser",
-			"about": "#9 (sortkey is copied from root)",
-			"subject": "Example/P0416/Q6.2",
+			"about": "#9 (sortkey is copied from root, strict ~BAR)",
+			"subject": "Example/P0416/Q6.2.1",
+			"assert-output": {
+				"to-contain": [
+					"<tr data-row-number=\"1\" class=\"row-odd\"><td class=\"smwtype_wpg\">Example/P0416/6/2</td></tr>"
+				]
+			}
+		},
+		{
+			"type": "parser",
+			"about": "#10 (sortkey is copied from root, ~BAR*)",
+			"subject": "Example/P0416/Q6.2.2",
 			"assert-output": {
 				"to-contain": [
 					"<tr data-row-number=\"1\" class=\"row-odd\"><td class=\"smwtype_wpg\">Example/P0416/6/2</td></tr>",
@@ -225,7 +239,7 @@
 		},
 		{
 			"type": "parser",
-			"about": "#10 (sobj sortkey)",
+			"about": "#11 (sobj sortkey)",
 			"subject": "Example/P0416/Q6.3",
 			"assert-output": {
 				"to-contain": [
@@ -235,7 +249,7 @@
 		},
 		{
 			"type": "parser",
-			"about": "#11 Display title/query includes &",
+			"about": "#12 Display title/query includes &",
 			"subject": "Example/P0416/Q7.1",
 			"assert-output": {
 				"to-contain": [
@@ -245,7 +259,7 @@
 		},
 		{
 			"type": "parser",
-			"about": "#12 Display title/query includes '",
+			"about": "#13 Display title/query includes '",
 			"subject": "Example/P0416/Q8.1",
 			"assert-output": {
 				"to-contain": [

--- a/tests/phpunit/Integration/JSONScript/TestCases/p-0456.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/p-0456.json
@@ -1,0 +1,108 @@
+{
+	"description": "Test #subobject with assigned sortkey, default order etc.",
+	"setup": [
+		{
+			"namespace": "SMW_NS_PROPERTY",
+			"page": "Has text",
+			"contents": "[[Has type::text]]"
+		},
+		{
+			"page": "Example/P0456/1",
+			"contents": "{{#subobject: foo |Has text=foo }} {{#subobject: bar |Has text=bar }} {{#subobject: baz |Has text=baz }}"
+		},
+		{
+			"page": "Example/P0456/2",
+			"contents": "{{#subobject: baz |Has text=baz }} {{#subobject: foo |Has text=foo }} {{#subobject: bar |Has text=bar }}"
+		},
+		{
+			"page": "Example/P0456/Q.1",
+			"contents": "{{#ask: [[-Has subobject::Example/P0456/1]] |?Has text }}"
+		},
+		{
+			"page": "Example/P0456/Q.2",
+			"contents": "{{#ask: [[-Has subobject::Example/P0456/2]] |?Has text }}"
+		},
+		{
+			"page": "Example/P0456/3",
+			"contents": "{{#subobject: foo |Has text=foo }} {{#subobject: bar |Has text=bar |@sortkey=zzz }} {{#subobject: baz |Has text=baz }}"
+		},
+		{
+			"page": "Example/P0456/4",
+			"contents": "{{#subobject: baz |Has text=baz }} {{#subobject: foo |Has text=foo }} {{#subobject: bar |Has text=bar|@sortkey=zzz }}"
+		},
+		{
+			"page": "Example/P0456/Q.3",
+			"contents": "{{#ask: [[-Has subobject::Example/P0456/3]] |?Has text }}"
+		},
+		{
+			"page": "Example/P0456/Q.4",
+			"contents": "{{#ask: [[-Has subobject::Example/P0456/4]] |?Has text }}"
+		}
+	],
+	"tests": [
+		{
+			"type": "parser",
+			"about": "#0 (default order without explicit sortkey)",
+			"subject": "Example/P0456/Q.1",
+			"assert-output": {
+				"to-contain": [
+					"<tr data-row-number=\"1\" .*Example/P0456/1#bar\" title=\"Example/P0456/1\">Example/P0456/1#bar</a></span></td><td class=\"Has-text smwtype_txt\">bar</td></tr>",
+					"<tr data-row-number=\"2\" .*Example/P0456/1#baz\" title=\"Example/P0456/1\">Example/P0456/1#baz</a></span></td><td class=\"Has-text smwtype_txt\">baz</td></tr>",
+					"<tr data-row-number=\"3\" .*Example/P0456/1#foo\" title=\"Example/P0456/1\">Example/P0456/1#foo</a></span></td><td class=\"Has-text smwtype_txt\">foo</td></tr>"
+				]
+			}
+		},
+		{
+			"type": "parser",
+			"about": "#1 same as #0 (default order without explicit sortkey, order independent from the page position)",
+			"subject": "Example/P0456/Q.2",
+			"assert-output": {
+				"to-contain": [
+					"<tr data-row-number=\"1\" .*Example/P0456/2#bar\" title=\"Example/P0456/2\">Example/P0456/2#bar</a></span></td><td class=\"Has-text smwtype_txt\">bar</td></tr>",
+					"<tr data-row-number=\"2\" .*Example/P0456/2#baz\" title=\"Example/P0456/2\">Example/P0456/2#baz</a></span></td><td class=\"Has-text smwtype_txt\">baz</td></tr>",
+					"<tr data-row-number=\"3\" .*Example/P0456/2#foo\" title=\"Example/P0456/2\">Example/P0456/2#foo</a></span></td><td class=\"Has-text smwtype_txt\">foo</td></tr>"
+				]
+			}
+		},
+		{
+			"type": "parser",
+			"about": "#2 (with explicit sortkey)",
+			"subject": "Example/P0456/Q.3",
+			"assert-output": {
+				"to-contain": [
+					"<tr data-row-number=\"1\" .*Example/P0456/3#baz\" title=\"Example/P0456/3\">Example/P0456/3#baz</a></span></td><td class=\"Has-text smwtype_txt\">baz</td></tr>",
+					"<tr data-row-number=\"2\" .*Example/P0456/3#foo\" title=\"Example/P0456/3\">Example/P0456/3#foo</a></span></td><td class=\"Has-text smwtype_txt\">foo</td></tr>",
+					"<tr data-row-number=\"3\" .*Example/P0456/3#bar\" title=\"Example/P0456/3\">Example/P0456/3#bar</a></span></td><td class=\"Has-text smwtype_txt\">bar</td></tr>"
+				]
+			}
+		},
+		{
+			"type": "parser",
+			"about": "#3 same as #2 (with explicit sortkey, order independent from the page position)",
+			"subject": "Example/P0456/Q.4",
+			"assert-output": {
+				"to-contain": [
+					"<tr data-row-number=\"1\" .*Example/P0456/4#baz\" title=\"Example/P0456/4\">Example/P0456/4#baz</a></span></td><td class=\"Has-text smwtype_txt\">baz</td></tr>",
+					"<tr data-row-number=\"2\" .*Example/P0456/4#foo\" title=\"Example/P0456/4\">Example/P0456/4#foo</a></span></td><td class=\"Has-text smwtype_txt\">foo</td></tr>",
+					"<tr data-row-number=\"3\" .*Example/P0456/4#bar\" title=\"Example/P0456/4\">Example/P0456/4#bar</a></span></td><td class=\"Has-text smwtype_txt\">bar</td></tr>"
+				]
+			}
+		}
+	],
+	"settings": {
+		"wgContLang": "en",
+		"wgLang": "en",
+		"smwgPageSpecialProperties": [
+			"_MDAT"
+		],
+		"smwgNamespacesWithSemanticLinks": {
+			"NS_MAIN": true,
+			"SMW_NS_PROPERTY": true
+		}
+	},
+	"meta": {
+		"version": "2",
+		"is-incomplete": false,
+		"debug": false
+	}
+}

--- a/tests/phpunit/Integration/SemanticDataStorageDBIntegrationTest.php
+++ b/tests/phpunit/Integration/SemanticDataStorageDBIntegrationTest.php
@@ -157,7 +157,7 @@ class SemanticDataStorageDBIntegrationTest extends MwDBaseUnitTestCase {
 				new DIProperty( 'Foo' ),
 				new DIProperty( '_SKEY' )
 			),
-			'propertyValues' => array( 'Bar', __METHOD__ )
+			'propertyValues' => array( 'Bar', __METHOD__ . '#SomeSubobject' )
 		);
 
 		$this->semanticDataValidator->assertThatPropertiesAreSet(

--- a/tests/phpunit/includes/SemanticDataTest.php
+++ b/tests/phpunit/includes/SemanticDataTest.php
@@ -520,6 +520,20 @@ class SemanticDataTest extends \PHPUnit_Framework_TestCase {
 		$this->assertTrue( $instance->isEmpty() );
 	}
 
+	public function testExtensionData() {
+
+		$instance = new SemanticData(
+			DIWikiPage::newFromText( __METHOD__ )
+		);
+
+		$instance->setExtensionData( 'Foo', 42 );
+
+		$this->assertEquals(
+			42,
+			$instance->getExtensionData( 'Foo' )
+		);
+	}
+
 	/**
 	 * @dataProvider dataValueDataProvider
 	 */


### PR DESCRIPTION
This PR is made in reference to: https://sourceforge.net/p/semediawiki/mailman/message/36135782/

This PR addresses or contains:

- The email described a scenario where the sortkey of subobjects is not idempotent. The reason for this odd behaviour lies with the sortkey being not distinguished from any other subobject on the same page. One can verify that by looking at the `smw_object_ids` table and the `smw_sortkey` field. When a sort key is indistinguishable, the SQL engine will use a row sequence [0] (or any other defined by the `ORDER BY` clause) where the sortkeys are identical which then hereby depends on the storage sequence an entry is inserted into the table.
- The behaviour that a subobject sortkey does not include any subobject identifier has been verified at least for 1.9.2 so there is no regression on behalf of the sortkey storage.
- If you specify a `@sortkey` as part of a subobject, you would get a constant order no matter the position within the page (and hereby the storage order) since the `smw_sortkey` is augmented and not derived from the "root" subject.
- The PR will amend the sortkey for when `@sortkey` is not used and `p-0456.json` contains a test case for the described scenario from the mailing-l thread to verify that a constant order is produced independent of the storage order.

[0] https://stackoverflow.com/questions/6662837/how-mysql-order-the-rows-with-same-values

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed

Fixes #