### PR TITLE
Special:Ask/Browse add flex (responsive) mode to div table

### DIFF
--- a/res/smw/ext.smw.table.css
+++ b/res/smw/ext.smw.table.css
@@ -61,3 +61,18 @@
 .smw-table-body {
 	display: table-row-group;
 }
+
+/**
+ * Responsive settings
+ */
+@media screen and (max-width: 800px) {
+	.smw-table-cell {
+		display: flex;
+		flex-direction: row;
+		flex-wrap: wrap;
+	}
+
+	.smw-table-row, .smw-table-header {
+		flex: 1 1 150px;
+	}
+}

--- a/res/smw/special/ext.smw.special.ask.css
+++ b/res/smw/special/ext.smw.special.ask.css
@@ -311,3 +311,17 @@ div#ask legend {
 .smw-ask-sort-delete, .smw-ask-sort-add {
 	cursor: pointer;
 }
+
+/**
+ * Responsive settings (#see smw.table.css)
+ */
+@media screen and (max-width: 800px) {
+	.smw-table-row .smw-table-cell {
+		width: auto !important;
+		margin: 0.5em 0;
+	}
+
+	.smw-table-cell .parameter-number-input, .smw-table-cell .parameter-string-input {
+		width:100% !important;
+	}
+}

--- a/res/smw/special/ext.smw.special.browse.css
+++ b/res/smw/special/ext.smw.special.browse.css
@@ -35,18 +35,6 @@
 	width: 100%
 }
 
-.smwb-factbox .smwb-propvalue .smwb-prophead, .smwb-ifactbox .smwb-ipropvalue .smwb-prophead, .smwb-ifactbox .smwb-propvalue .smwb-prophead {
-	width: 30%;
-}
-
-/* Only apply when less then 350*/
-@media (max-width: 400px) {
-	.smwb-factbox .smwb-propvalue .smwb-prophead, .smwb-ifactbox .smwb-ipropvalue .smwb-prophead, .smwb-ifactbox .smwb-propvalue .smwb-prophead {
-		width: 50%
-		min-width: 20%;
-	}
-}
-
 .smwb-factbox .smwb-propvalue.smwb-group {
 	width: 100%;
 }
@@ -71,7 +59,6 @@
 }
 
 .smwb-prophead {
-	min-width: 5em;
 	background-color: #ddd;
 }
 
@@ -160,6 +147,14 @@ span.smwb-value {
 	padding-right: 1em;
 }
 
+.smwb-factbox .group-link:before {
+	content:"▾ ";
+}
+
+.smwb-ifactbox .group-link:after {
+	content:" ▾";
+}
+
 .smwb-input {
 	display: flex;
 }
@@ -176,6 +171,10 @@ span.smwb-value {
 	box-shadow: inset 0 0 0 1px #ddd;
 	border-color: #ddd;
 	outline: 0;
+}
+
+.smwb-factbox .smwb-propvalue .smwb-prophead, .smwb-ifactbox .smwb-ipropvalue .smwb-prophead, .smwb-ifactbox .smwb-propvalue .smwb-prophead {
+	width: 30%;
 }
 
 /**
@@ -195,4 +194,21 @@ span.smwb-value {
 
 .smwb-theme-light .smwb-propval  {
 	background-color: #f7f7f7;
+}
+
+/**
+ * Responsive settings (#see smw.table.css)
+ */
+@media screen and (max-width: 800px) {
+  .smwb-factbox .smwb-propvalue .smwb-prophead, .smwb-ifactbox .smwb-ipropvalue .smwb-prophead, .smwb-ifactbox .smwb-propvalue .smwb-prophead {
+    width: auto;
+  }
+
+  .smwb-ifactbox .smwb-ipropvalue .smwb-prophead, .smwb-ifactbox .smwb-ipropvalue .smwb-propval, .smwb-ifactbox .smwb-propvalue .smwb-prophead {
+    justify-content: flex-end;
+  }
+
+  .smwb-group .smwb-propval, .smwb-group .smwb-theme-light .smwb-propval {
+	background-color: #d9e8f3;
+  }
 }

--- a/src/MediaWiki/Specials/Ask/ParameterInput.php
+++ b/src/MediaWiki/Specials/Ask/ParameterInput.php
@@ -53,6 +53,11 @@ class ParameterInput {
 	protected $inputName;
 
 	/**
+	 * @var array
+	 */
+	private $attributes = [];
+
+	/**
 	 * Constructor.
 	 *
 	 * @since 1.9
@@ -86,6 +91,15 @@ class ParameterInput {
 	 */
 	public function setInputName( $name ) {
 		$this->inputName = $name;
+	}
+
+	/**
+	 * @since 3.0
+	 *
+	 * @param array $attributes
+	 */
+	public function setAttributes( array $attributes ) {
+		$this->attributes = $attributes;
 	}
 
 	/**
@@ -155,14 +169,22 @@ class ParameterInput {
 	 * @return string
 	 */
 	protected function getNumberInput() {
+
+		$attributes = [
+			'class' => 'parameter-number-input',
+			'size' => 6,
+			'style' => "width: 95%;"
+		];
+
+		if ( $this->attributes !==[] ) {
+			$attributes = $this->attributes;
+		}
+
 		return Html::input(
 			$this->inputName,
 			$this->getValueToUse(),
 			'text',
-			array(
-				'size' => 6,
-				'style' => "width: 95%;",
-			)
+			$attributes
 		);
 	}
 
@@ -174,14 +196,22 @@ class ParameterInput {
 	 * @return string
 	 */
 	protected function getStrInput() {
+
+		$attributes = [
+			'class' => 'parameter-string-input',
+			'size' => 20,
+			'style' => "width: 95%;"
+		];
+
+		if ( $this->attributes !==[] ) {
+			$attributes = $this->attributes;
+		}
+
 		return Html::input(
 			$this->inputName,
 			$this->getValueToUse(),
 			'text',
-			array(
-				'size'  => 20,
-				'style' => "width: 95%;",
-			)
+			$attributes
 		);
 	}
 
@@ -193,9 +223,19 @@ class ParameterInput {
 	 * @return string
 	 */
 	protected function getBooleanInput() {
+
+		$attributes = [
+			'class' => 'parameter-boolean-input'
+		];
+
+		if ( $this->attributes !==[] ) {
+			$attributes = $this->attributes;
+		}
+
 		return Xml::check(
 			$this->inputName,
-			$this->getValueToUse()
+			$this->getValueToUse(),
+			$attributes
 		);
 	}
 
@@ -227,7 +267,8 @@ class ParameterInput {
 		return Html::rawElement(
 			'select',
 			array(
-				'name' => $this->inputName
+				'name' => $this->inputName,
+				'class'=> 'parameter-select-input'
 			),
 			implode( "\n", $options )
 		);
@@ -269,6 +310,7 @@ class ParameterInput {
 			$boxes[] = Html::rawElement(
 				'span',
 				array(
+					'class' => 'parameter-checkbox-input',
 					'style' => 'white-space: nowrap; padding-right: 5px;'
 				),
 				Html::rawElement(

--- a/src/MediaWiki/Specials/Ask/ParametersWidget.php
+++ b/src/MediaWiki/Specials/Ask/ParametersWidget.php
@@ -6,6 +6,7 @@ use ParamProcessor\ParamDefinition;
 use SMW\Message;
 use SMWQueryProcessor as QueryProcessor;
 use Html;
+use SMW\Utils\HtmlDivTable;
 
 /**
  * @private
@@ -109,15 +110,12 @@ class ParametersWidget {
 		}
 
 		// Table
-		$resultHtml .= Html::openElement(
-			'table',
+		$resultHtml = HtmlDivTable::open(
 			[
 				'class' => 'smw-ask-options-list',
 				'width' => '100%'
 			]
 		);
-
-		$resultHtml .= Html::openElement( 'tbody' );
 
 		while ( $option = array_shift( $optionList ) ) {
 			$i++;
@@ -126,30 +124,27 @@ class ParametersWidget {
 			$rowHtml .=  $option;
 
 			// Create table row
-			if ( $i % 3 == 0 ){
-			$resultHtml .= Html::rawElement(
-				'tr',
-				[
-					'class' => $i % 6 == 0 ? 'smw-ask-options-row-even' : 'smw-ask-options-row-odd',
-				],
-				$rowHtml
-			);
-			$rowHtml = '';
-			$n++;
+			if ( $i % 3 == 0 ) {
+				$resultHtml .= HtmlDivTable::row(
+					$rowHtml,
+					[
+						'class' => $i % 6 == 0 ? 'smw-ask-options-row-even' : 'smw-ask-options-row-odd',
+					]
+				);
+				$rowHtml = '';
+				$n++;
 			}
 		}
 
 		// Ensure left over elements are collected as well
-		$resultHtml .= Html::rawElement(
-			'tr',
+		$resultHtml .= HtmlDivTable::row(
+			$rowHtml,
 			[
 				'class' => $n % 2 == 0 ? 'smw-ask-options-row-odd' : 'smw-ask-options-row-even',
-			],
-			$rowHtml
+			]
 		);
 
-		$resultHtml .= Html::closeElement( 'tbody' );
-		$resultHtml .= Html::closeElement( 'table' );
+		$resultHtml .= HtmlDivTable::close();
 
 		return $resultHtml;
 	}
@@ -221,14 +216,20 @@ class ParametersWidget {
 			$info = Message::get( $definition->getMessage(), Message::TEXT, Message::USER_LANGUAGE );
 		}
 
-		return Html::rawElement(
-			'span',
+		return HtmlDivTable::cell(
+			Html::rawElement(
+				'span',
+				[
+					'class'     =>  $class,
+					'word-wrap' => 'break-word',
+					'data-info' => $info
+				],
+				htmlspecialchars( $name ) . ': '
+			),
 			[
-				'class'     =>  $class,
-				'word-wrap' => 'break-word',
-				'data-info' => $info
-			],
-			htmlspecialchars( $name ) . ': '
+				'overflow' => 'hidden',
+				'style' => 'border:none;'
+			]
 		);
 	}
 
@@ -261,13 +262,12 @@ class ParametersWidget {
 			);
 		}
 
-		return Html::rawElement(
-			'td',
+		return HtmlDivTable::cell(
+			$input->getHtml() . $description,
 			[
 				'overflow' => 'hidden',
-				'style' => 'width:33%;'
-			],
-			$input->getHtml() . $description
+				'style' => 'width:33%;border:none;'
+			]
 		);
 	}
 

--- a/src/MediaWiki/Specials/Browse/ContentsBuilder.php
+++ b/src/MediaWiki/Specials/Browse/ContentsBuilder.php
@@ -288,9 +288,9 @@ class ContentsBuilder {
 			if ( $group !== '' ) {
 
 				$c = HtmlDivTable::cell(
-					$groupFormatter->getGroupLink( $group ),
+					$groupFormatter->getGroupLink( $group ) . '<span></span>',
 					[
-						"class" => 'smwb-cell smwb-propvalue smwb-propval'
+						"class" => 'smwb-cell smwb-propval'
 					]
 				);
 
@@ -455,7 +455,7 @@ class ContentsBuilder {
 			if ( $moreIncoming && $last !== '' ) {
 				$propertyValue .= $comma . $last;
 			} elseif( $list !== [] && $last !== '' ) {
-				$propertyValue .= ' ' . $and . ' ' . $last;
+				$propertyValue .= '&nbsp;' . $and . '&nbsp;' . $last;
 			} else {
 				$propertyValue .= $last;
 			}
@@ -783,7 +783,7 @@ class ContentsBuilder {
 			) . HtmlDivTable::cell(
 				$val,
 				[
-					"class" => 'smwb-cell smwb-propvalue smwb-propval'
+					"class" => 'smwb-cell smwb-propval'
 				]
 			);
 
@@ -799,12 +799,12 @@ class ContentsBuilder {
 			$h = HtmlDivTable::cell(
 				wfMessage( 'smw-browse-property-group-title' )->text(),
 				[
-					"class" => 'smwb-cell smwb-propvalue smwb-propval'
+					"class" => 'smwb-cell smwb-propval'
 				]
 			) . HtmlDivTable::cell(
 				'',
 				[
-					"class" => 'smwb-cell smwb-propvalue smwb-propval'
+					"class" => 'smwb-cell smwb-propval'
 				]
 			);
 

--- a/src/MediaWiki/Specials/Browse/GroupFormatter.php
+++ b/src/MediaWiki/Specials/Browse/GroupFormatter.php
@@ -128,7 +128,7 @@ class GroupFormatter {
 		return Html::rawElement(
 			'span',
 			[
-				'class' => 'smwb-group'
+				'class' => 'group-link'
 			],
 			$this->groupLinks[$group]
 		);

--- a/tests/phpunit/Unit/MediaWiki/Specials/Ask/ParameterInputTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Specials/Ask/ParameterInputTest.php
@@ -64,8 +64,8 @@ class ParameterInputTest extends \PHPUnit_Framework_TestCase {
 			'Foo',
 			[ 'Foo', 'Bar' ],
 			[
-				'<span style="white-space: nowrap; padding-right: 5px;"><input type="checkbox" name="[]" value="Foo" checked="".*><tt>Foo</tt></span>',
-				'<span style="white-space: nowrap; padding-right: 5px;"><input type="checkbox" name="[]" value="Bar".*><tt>Bar</tt></span>'
+				'<span class="parameter-checkbox-input" style="white-space: nowrap; padding-right: 5px;"><input type="checkbox" name="[]" value="Foo" checked="".*><tt>Foo</tt></span>',
+				'<span class="parameter-checkbox-input" style="white-space: nowrap; padding-right: 5px;"><input type="checkbox" name="[]" value="Bar".*><tt>Bar</tt></span>'
 			],
 
 		];
@@ -74,8 +74,8 @@ class ParameterInputTest extends \PHPUnit_Framework_TestCase {
 			[ 'Foo' ],
 			[ 'Foo', 'Bar' ],
 			[
-				'<span style="white-space: nowrap; padding-right: 5px;"><input type="checkbox" name="[]" value="Foo" checked="".*><tt>Foo</tt></span>',
-				'<span style="white-space: nowrap; padding-right: 5px;"><input type="checkbox" name="[]" value="Bar".*><tt>Bar</tt></span>'
+				'<span class="parameter-checkbox-input" style="white-space: nowrap; padding-right: 5px;"><input type="checkbox" name="[]" value="Foo" checked="".*><tt>Foo</tt></span>',
+				'<span class="parameter-checkbox-input" style="white-space: nowrap; padding-right: 5px;"><input type="checkbox" name="[]" value="Bar".*><tt>Bar</tt></span>'
 			],
 
 		];
@@ -84,8 +84,8 @@ class ParameterInputTest extends \PHPUnit_Framework_TestCase {
 			[ 'Foo, Bar' ],
 			[ 'Foo', 'Bar' ],
 			[
-				'<span style="white-space: nowrap; padding-right: 5px;"><input type="checkbox" name="[]" value="Foo" checked="".*><tt>Foo</tt></span>',
-				'<span style="white-space: nowrap; padding-right: 5px;"><input type="checkbox" name="[]" value="Bar" checked="".*><tt>Bar</tt></span>'
+				'<span class="parameter-checkbox-input" style="white-space: nowrap; padding-right: 5px;"><input type="checkbox" name="[]" value="Foo" checked="".*><tt>Foo</tt></span>',
+				'<span class="parameter-checkbox-input" style="white-space: nowrap; padding-right: 5px;"><input type="checkbox" name="[]" value="Bar" checked="".*><tt>Bar</tt></span>'
 			],
 
 		];
@@ -94,8 +94,8 @@ class ParameterInputTest extends \PHPUnit_Framework_TestCase {
 			[ 'Foo,foo bar' ],
 			[ 'Foo', 'foo bar' ],
 			[
-				'<span style="white-space: nowrap; padding-right: 5px;"><input type="checkbox" name="[]" value="Foo" checked="".*><tt>Foo</tt></span>',
-				'<span style="white-space: nowrap; padding-right: 5px;"><input type="checkbox" name="[]" value="foo bar" checked="".*><tt>foo bar</tt></span>'
+				'<span class="parameter-checkbox-input" style="white-space: nowrap; padding-right: 5px;"><input type="checkbox" name="[]" value="Foo" checked="".*><tt>Foo</tt></span>',
+				'<span class="parameter-checkbox-input" style="white-space: nowrap; padding-right: 5px;"><input type="checkbox" name="[]" value="foo bar" checked="".*><tt>foo bar</tt></span>'
 			],
 
 		];

--- a/tests/phpunit/Unit/MediaWiki/Specials/Ask/ParametersWidgetTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Specials/Ask/ParametersWidgetTest.php
@@ -52,16 +52,16 @@ class ParametersWidgetTest extends \PHPUnit_Framework_TestCase {
 		$provider[] = array(
 			'',
 			array(),
-			'<table class="smw-ask-options-list" width="100%"><tbody><tr class="smw-ask-options-row-odd"></tr></tbody></table>'
+			'<div class="smw-table smw-ask-options-list" width="100%"><div class="smw-table-row smw-ask-options-row-odd"></div></div>'
 		);
 
 		$provider[] = array(
 			'table',
 			array(),
 			[
-				'<table class="smw-ask-options-list"',
-				'<input size="6" style="width: 95%;" value="50" name="p[limit]"',
-				'<input size="6" style="width: 95%;" value="0" name="p[offset]"'
+				'<div class="smw-table smw-ask-options-list" width="100%"',
+				'<input class="parameter-number-input" size="6" style="width: 95%;" value="50" name="p[limit]"',
+				'<input class="parameter-number-input" size="6" style="width: 95%;" value="0" name="p[offset]"'
 			]
 		);
 
@@ -72,8 +72,8 @@ class ParametersWidgetTest extends \PHPUnit_Framework_TestCase {
 				'offset' => 42
 			],
 			[
-				'<input size="6" style="width: 95%;" value="9999" name="p[limit]"',
-				'<input size="6" style="width: 95%;" value="42" name="p[offset]"'
+				'<input class="parameter-number-input" size="6" style="width: 95%;" value="9999" name="p[limit]"',
+				'<input class="parameter-number-input" size="6" style="width: 95%;" value="42" name="p[offset]"'
 			]
 		);
 

--- a/tests/phpunit/Unit/MediaWiki/Specials/Browse/GroupFormatterTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Specials/Browse/GroupFormatterTest.php
@@ -65,7 +65,7 @@ class GroupFormatterTest extends \PHPUnit_Framework_TestCase {
 		);
 
 		$this->assertContains(
-			'<span class="smwb-group">',
+			'<span class="group-link">',
 			$instance->getGroupLink( 'Bar' )
 		);
 	}


### PR DESCRIPTION
This PR is made in reference to: #

This PR addresses or contains:

- Uses `display: flex;` on `DIV` tables so they can be transformed to create a responsive representation of content (`Special:Ask` and `Special:Browse`)
- Adds `.smwb-factbox .group-link:before` and `.smwb-ifactbox .group-link:after` to add a group icon (`▾`)
- During the responsive mode, group sections become distinguishable by colour when switching to a one-column representation

![image](https://user-images.githubusercontent.com/1245473/34073452-b6185abe-e2dd-11e7-87a7-66bb43091885.png)

This PR includes:
- [ ] Tests (unit/integration)
- [x] CI build passed

Fixes #