### PR TITLE
Special:Ask add toggle option, minimze options field default size

### DIFF
--- a/i18n/en.json
+++ b/i18n/en.json
@@ -655,5 +655,8 @@
 	"smw-browse-property-group-label": "Property group label",
 	"smw-browse-property-group-description": "Property group description",
 	"smw-property-predefined-ppgr": "\"$1\" is a predefined property that identifies entities (mainly categories) that are used as grouping instance for properties and is provided by [https://www.semantic-mediawiki.org/wiki/Help:Special_properties Semantic MediaWiki].",
-	"smw-list-pager-filter": "Filter:"
+	"smw-list-pager-filter": "Filter:",
+	"smw-section-expand": "Expand the section",
+	"smw-section-collapse": "Collapse the section"
+
 }

--- a/res/Resources.php
+++ b/res/Resources.php
@@ -108,7 +108,8 @@ return array(
 		'dependencies' => array(
 			'ext.smw',
 			'mediawiki.util'
-		)
+		),
+		'targets' => array( 'mobile', 'desktop' )
 	),
 
 	// API
@@ -336,7 +337,9 @@ return array(
 			'smw-ask-format-selection-help',
 			'smw-ask-condition-change-info',
 			'smw-ask-format-change-info',
-			'smw-ask-format-export-info'
+			'smw-ask-format-export-info',
+			'smw-section-expand',
+			'smw-section-collapse'
 		),
 		'position' => 'top',
 		'targets' => array(

--- a/res/smw/special/ext.smw.special.ask.css
+++ b/res/smw/special/ext.smw.special.ask.css
@@ -74,13 +74,12 @@ div#ask legend {
 }
 
 .smw-ask-format-selection-help {
-	vertical-align: middle;
-	padding: 5px;
+	padding: 5px 5px 0 5px;
 }
 
 .smw-ask-cond-info {
 	margin-top: 15px;
-	margin-bottom: 10px;f
+	margin-bottom: 10px;
 }
 
 .smw-ask-format-list {
@@ -89,7 +88,7 @@ div#ask legend {
 }
 
 .smw-ask-query {
-	margin-bottom: 10px;
+	margin-bottom: 5px;
 }
 
 .smw-ask-query .smw-table-header {
@@ -313,6 +312,57 @@ div#ask legend {
 }
 
 /**
+ * Toggle
+ */
+
+.options-toggle-action {
+	min-width: 15px;
+	display: inline-block;
+	text-align: center;
+}
+
+.options-toggle-action label {
+	cursor: pointer;
+}
+
+.options-parameter-list {
+	 position: relative;
+}
+
+#options-toggle {
+  display: none;
+}
+
+#options-list .options-parameter-list {
+	min-height: 80px;
+	overflow: hidden;
+	max-height: 0;
+	padding: 0;
+	margin: 0 auto;
+	-webkit-transition: all 0.3s ease;
+}
+
+#options-toggle:checked + #options-list .options-parameter-list {
+  max-height: none;
+}
+
+#options-toggle:checked + #options-list .options-message {
+  display:none;
+}
+
+#options-toggle:not(:checked) + #options-list .options-parameter-list:after {
+	content: "";
+	position: absolute;
+	z-index: 1;
+	bottom: 0;
+	left: 0;
+	pointer-events: none;
+	background-image: linear-gradient(to bottom, rgba(255,255,255,0), rgba(255,255,255, 1) 90%);
+	width: 100%;
+	height: 4em;
+}
+
+/**
  * Responsive settings (#see smw.table.css)
  */
 @media screen and (max-width: 800px) {
@@ -321,7 +371,28 @@ div#ask legend {
 		margin: 0.5em 0;
 	}
 
-	.smw-table-cell .parameter-number-input, .smw-table-cell .parameter-string-input {
+	.smw-table-cell .parameter-number-input, .smw-table-cell .parameter-string-input, .smw-ask-sort-input {
 		width:100% !important;
+	}
+
+	.smw-ask-button-right {
+		clear:both;
+		float:none;
+		margin: 0 5px 0 0;
+	}
+
+	.smw-ask-button {
+		display: flex;
+		margin-bottom: 5px;
+	}
+
+	.smw-ask-button input, .smw-ask-button-right input, .smw-ask-button a, .smw-ask-button-right a, #embed_show a, #embed_hide a {
+		width: 100%;
+		text-align: center;
+	}
+
+	.smw-ask-format-selector {
+		display: inline-block;
+		margin-bottom: 0;
 	}
 }

--- a/res/smw/special/ext.smw.special.ask.js
+++ b/res/smw/special/ext.smw.special.ask.js
@@ -287,6 +287,17 @@
 			addSortInstance( 'sorting_starter', 'sorting_main' );
 		} );
 
+		// Options toggle icon
+		$( '.options-toggle-action label' ).click( function() {
+			if ( $( '#options-toggle' ).prop( 'checked' ) ) {
+				$( this).html( '+' );
+				$( this).attr( 'title', mw.msg( 'smw-section-expand' ) );
+			} else {
+				$( this).html( '-' );
+				$( this).attr( 'title', mw.msg( 'smw-section-collapse' ) );
+			}
+		} );
+
 		// Submit the form via CTRL + q
 		$( "form" ).keypress( function ( event ) {
 			if ( event.ctrlKey && event.keyCode == 17 ) {
@@ -337,7 +348,9 @@
 				'url': $this.data( 'url' ).replace( 'this.value',  $this.val() ),
 				'context': document.body,
 				'success': function( data ) {
-					$( '#options-list' ).html( data );
+					$( '#options-list' ).html(
+						'<div class="options-parameter-list">' + data + '</div>'
+					);
 
 					// Remove disable state that was set at the beginning of the
 					// onChange event

--- a/src/MediaWiki/Specials/Ask/ParametersWidget.php
+++ b/src/MediaWiki/Specials/Ask/ParametersWidget.php
@@ -57,19 +57,44 @@ class ParametersWidget {
 	 */
 	public static function fieldset( $format, array $parameters ) {
 
+		$toggle = '&#160;[' . Html::rawElement(
+			'span',
+			[
+				'class' => 'options-toggle-action',
+			],
+			Html::rawElement(
+				'label',
+				[
+					'for' => 'options-toggle',
+					'title' => Message::get( 'smw-section-expand', Message::TEXT, Message::USER_LANGUAGE )
+				],
+				'+'
+			)
+		) . ']&#160;';
+
 		return Html::rawElement(
 			'fieldset',
 			[],
-			Html::element(
+			Html::rawElement(
 				'legend',
 				[],
-				Message::get( 'smw-ask-options', Message::TEXT, Message::USER_LANGUAGE )
-			) . Html::rawElement(
+				Html::rawElement(
+					'span',
+					[],
+					Message::get( 'smw-ask-options', Message::TEXT, Message::USER_LANGUAGE )
+				) . $toggle
+			) . '<input type="checkbox" id="options-toggle"/>' . Html::rawElement(
 				'div',
 				[
 					'id' => 'options-list'
 				],
-				self::parameterList( $format, $parameters )
+				Html::rawElement(
+					'div',
+					[
+						'class' => 'options-parameter-list'
+					],
+					self::parameterList( $format, $parameters )
+				)
 			) . SortWidget::sortSection( $parameters )
 		);
 	}

--- a/tests/phpunit/Unit/MediaWiki/Specials/Ask/ParametersWidgetTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Specials/Ask/ParametersWidgetTest.php
@@ -30,7 +30,7 @@ class ParametersWidgetTest extends \PHPUnit_Framework_TestCase {
 
 		$this->stringValidator->assertThatStringContains(
 			[
-				'<fieldset><legend>.*</legend><div id="options-list">'
+				'<fieldset><legend>.*</legend><input type="checkbox" id="options-toggle"/><div id="options-list">'
 			],
 			ParametersWidget::fieldset( 'foo', $parameters )
 		);


### PR DESCRIPTION
This PR is made in reference to: #

This PR addresses or contains:

- #2611 removed the user-preference toggle since the JS was totally broken but allowing the options fields to take a dominating role on the screen seems counter productive when one once to "just" execute a query 
- The default size of the option field section is now minimized, `[ + ]` can be used to expand on the available parameters with a collapsed section showing a fading input progression indicating the availability of additional parameters
- #2891 introduced a flex mode and with the help of the collapsed option section another step is made to ease the navigation of `Special:Ask` on small screens

![image](https://user-images.githubusercontent.com/1245473/34074697-e31e33d4-e2ac-11e7-81ba-8ad714b7cd76.png)

![image](https://user-images.githubusercontent.com/1245473/34074760-007d3c26-e2ae-11e7-92a2-45ab8ca7e8f6.png)


This PR includes:
- [ ] Tests (unit/integration)
- [x] CI build passed

Fixes #