### PR TITLE
Use global instead of $GLOBALS to avoid "PHP Notice:  Undefined index: smwgNamespace in ...", refs 2892

### DIFF
--- a/src/GlobalFunctions.php
+++ b/src/GlobalFunctions.php
@@ -214,19 +214,20 @@ function smwfGetLinker() {
  * @codeCoverageIgnore
  */
 function enableSemantics( $namespace = null, $complete = false ) {
+	global $smwgNamespace;
 
 	// Apparently this is required (1.28+) as the earliest possible execution
 	// point in order for settings that refer to the SMW_NS_PROPERTY namespace
 	// to be available in LocalSettings
 	NamespaceManager::initCustomNamespace( $GLOBALS );
 
-	if ( !$complete && ( $GLOBALS['smwgNamespace'] !== '' ) ) {
+	if ( !$complete && ( $smwgNamespace !== '' ) ) {
 		// The dot tells that the domain is not complete. It will be completed
 		// in the Export since we do not want to create a title object here when
 		// it is not needed in many cases.
-		$GLOBALS['smwgNamespace'] = '.' . $namespace;
+		$smwgNamespace = '.' . $namespace;
 	} else {
-		$GLOBALS['smwgNamespace'] = $namespace;
+		$smwgNamespace = $namespace;
 	}
 
 	$GLOBALS['smwgSemanticsEnabled'] = true;


### PR DESCRIPTION
This PR is made in reference to: #2892

This PR addresses or contains:

- Fix `PHP Notice:  Undefined index: smwgNamespace in /../w/extensions/SemanticMediaWiki/src/GlobalFunctions.php on line 223
Notice: Undefined index: smwgNamespace in /../w/extensions/SemanticMediaWiki/src/GlobalFunctions.php on line 223`

This PR includes:
- [ ] Tests (unit/integration)
- [ ] CI build passed

Fixes #