### PR TITLE
Display named subobject caption without an underscore

### DIFF
--- a/includes/datavalues/SMW_DV_WikiPage.php
+++ b/includes/datavalues/SMW_DV_WikiPage.php
@@ -578,7 +578,7 @@ class SMWWikiPageValue extends SMWDataValue {
 	 */
 	protected function getShortCaptionText() {
 		if ( $this->m_fragment !== '' && $this->m_fragment[0] != '_' ) {
-			$fragmentText = '#' . $this->m_fragment;
+			$fragmentText = '#' . str_replace( '_', ' ', $this->m_fragment );
 		} else {
 			$fragmentText = '';
 		}
@@ -608,7 +608,7 @@ class SMWWikiPageValue extends SMWDataValue {
 	 */
 	protected function getLongCaptionText() {
 		if ( $this->m_fragment !== '' && $this->m_fragment[0] != '_' ) {
-			$fragmentText = '#' . $this->m_fragment;
+			$fragmentText = '#' . str_replace( '_', ' ', $this->m_fragment );
 		} else {
 			$fragmentText = '';
 		}

--- a/tests/phpunit/Integration/JSONScript/TestCases/p-0457.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/p-0457.json
@@ -1,0 +1,70 @@
+{
+	"description": "Test named subobject caption display (#2895)",
+	"setup": [
+		{
+			"namespace": "SMW_NS_PROPERTY",
+			"page": "Has text",
+			"contents": "[[Has type::text]]"
+		},
+		{
+			"page": "Example/P0457/1",
+			"contents": "{{#subobject:Foo bar|Has text=123|@category=P0457/1}}"
+		},
+		{
+			"page": "Example/P0457/2",
+			"contents": "{{#subobject:Foo bar|Has text=123|@category=P0457/2|display title of=Bar foo}}"
+		},
+		{
+			"page": "Example/P0454/Q.1",
+			"contents": "{{#ask: [[Category:P0457/1]] }}"
+		},
+		{
+			"page": "Example/P0454/Q.2",
+			"contents": "{{#ask: [[Category:P0457/2]] }}"
+		}
+	],
+	"tests": [
+		{
+			"type": "parser",
+			"about": "#0 (named sobj without `_` in caption)",
+			"subject": "Example/P0454/Q.1",
+			"assert-output": {
+				"to-contain": [
+					"<a href=.*Example/P0457/1#Foo_bar\" title=\"Example/P0457/1\">Example/P0457/1#Foo bar</a>"
+				],
+				"not-contain": [
+					"<a href=.*Example/P0457/1#Foo_bar\" title=\"Example/P0457/1\">Example/P0457/1#Foo_bar</a>"
+				]
+			}
+		},
+		{
+			"type": "parser",
+			"about": "#1 (named sobj without `_` in caption and `display title of`)",
+			"subject": "Example/P0454/Q.2",
+			"assert-output": {
+				"to-contain": [
+					"<a href=.*Example/P0457/2#Foo_bar\" title=\"Example/P0457/2\">Bar foo#Foo bar</a>"
+				],
+				"not-contain": [
+					"<a href=.*Example/P0457/2#Foo_bar\" title=\"Example/P0457/2\">Example/P0457/2#Foo_bar</a>"
+				]
+			}
+		}
+	],
+	"settings": {
+		"wgContLang": "en",
+		"wgLang": "en",
+		"smwgPageSpecialProperties": [
+			"_MDAT"
+		],
+		"smwgNamespacesWithSemanticLinks": {
+			"NS_MAIN": true,
+			"SMW_NS_PROPERTY": true
+		}
+	},
+	"meta": {
+		"version": "2",
+		"is-incomplete": false,
+		"debug": false
+	}
+}


### PR DESCRIPTION
This PR is made in reference to: #

This PR addresses or contains:

- Removes `_` from the caption display on a named subobject so that something like `Foo#Named_Subobject_1` becomes `Foo#Named Subobject 1`

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed
