### PR TITLE
Display inverse indicator for translated predefined property, refs 1360

### DIFF
--- a/src/DataValues/ValueFormatters/PropertyValueFormatter.php
+++ b/src/DataValues/ValueFormatters/PropertyValueFormatter.php
@@ -292,7 +292,13 @@ class PropertyValueFormatter extends DataValueFormatter {
 			return '';
 		}
 
-		return ApplicationFactory::getInstance()->getPropertyLabelFinder()->findPropertyLabelByLanguageCode(
+		$prefix = '';
+
+		if ( $property->isInverse() ) {
+			$prefix = '-';
+		}
+
+		return $prefix . ApplicationFactory::getInstance()->getPropertyLabelFinder()->findPropertyLabelByLanguageCode(
 			$property->getKey(),
 			$this->dataValue->getOption( PropertyValue::OPT_USER_LANGUAGE )
 		);

--- a/tests/phpunit/Integration/JSONScript/TestCases/p-0702.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/p-0702.json
@@ -1,5 +1,5 @@
 {
-	"description": "Test #ask with `format=table` on inverse property/printrquest (#1270, en)",
+	"description": "Test #ask with `format=table` on inverse property/printrequest (#1270, #1360)",
 	"setup": [
 		{
 			"namespace": "SMW_NS_PROPERTY",
@@ -17,6 +17,14 @@
 		{
 			"page": "Example/P0702/2",
 			"contents": "[[-Has inverse prop::Invalid in-text annotation]]"
+		},
+		{
+			"page": "Example/P0702/3/1",
+			"contents": "{{#ask: [[-Has query::Example/P0702/1/1]]|?-Has query |format=table}}"
+		},
+		{
+			"page": "Example/P0702/3/2",
+			"contents": "{{#ask: [[-Has query::Example/P0702/1/1]]|?-Has query=AnotherLabel |format=table}}"
 		}
 	],
 	"tests": [
@@ -48,6 +56,26 @@
 					],
 					"propertyValues": []
 				}
+			}
+		},
+		{
+			"type": "parser",
+			"about": "#2 (inverse indicator on predefined property)",
+			"subject": "Example/P0702/3/1",
+			"assert-output": {
+				"to-contain": [
+					"<a href=.*Property:Has_query\" title=\"Property:Has query\">-Has query</a>"
+				]
+			}
+		},
+		{
+			"type": "parser",
+			"about": "#3 (custom label overrides any inverse indicator from property)",
+			"subject": "Example/P0702/3/2",
+			"assert-output": {
+				"to-contain": [
+					"<a href=.*Property:Has_query\" title=\"Property:Has query\">AnotherLabel</a>"
+				]
 			}
 		}
 	],


### PR DESCRIPTION
This PR is made in reference to: #1360

This PR addresses or contains:

- Ensure that an inverse `-` prefix is displayed for a translated predefined property when requested in a query

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed

Fixes #