### PR TITLE
Avoid "LBFactory::getEmptyTransactionTicket ... does not have outer scope", refs 2482

### DIFF
--- a/src/MediaWiki/Database.php
+++ b/src/MediaWiki/Database.php
@@ -516,11 +516,20 @@ class Database {
 	 */
 	public function getEmptyTransactionTicket( $fname = __METHOD__ ) {
 
-		if ( method_exists( $this->loadBalancerFactory, 'getEmptyTransactionTicket' ) ) {
-			return $this->loadBalancerFactory->getEmptyTransactionTicket( $fname );
+		$ticket = null;
+
+		if ( !method_exists( $this->loadBalancerFactory, 'getEmptyTransactionTicket' ) ) {
+			return $ticket;
 		}
 
-		return null;
+		try {
+			$ticket = $this->loadBalancerFactory->getEmptyTransactionTicket( $fname );
+		} catch ( RuntimeException $e ) {
+			// We don't try very hard at ths point since "... does not have outer scope"
+			// isn't clear, we will continue without a ticket
+		}
+
+		return $ticket;
 	}
 
 	/**

--- a/tests/phpunit/Unit/MediaWiki/DatabaseTest.php
+++ b/tests/phpunit/Unit/MediaWiki/DatabaseTest.php
@@ -328,6 +328,35 @@ class DatabaseTest extends \PHPUnit_Framework_TestCase {
 		$instance->getEmptyTransactionTicket( __METHOD__ );
 	}
 
+	public function testGetEmptyTransactionTicketThrowsException() {
+
+		$readConnectionProvider = $this->getMockBuilder( '\SMW\DBConnectionProvider' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$writeConnectionProvider = $this->getMockBuilder( '\SMW\DBConnectionProvider' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$loadBalancerFactory = $this->getMockBuilder( '\stdClass' )
+			->setMethods( array( 'getEmptyTransactionTicket' ) )
+			->getMock();
+
+		$loadBalancerFactory->expects( $this->once() )
+			->method( 'getEmptyTransactionTicket' )
+			->will( $this->throwException( new \RuntimeException() ) );
+
+		$instance = new Database(
+			$readConnectionProvider,
+			$writeConnectionProvider,
+			$loadBalancerFactory
+		);
+
+		$this->assertNull(
+			$instance->getEmptyTransactionTicket( __METHOD__ )
+		);
+	}
+
 	public function testCommitAndWaitForReplication() {
 
 		$readConnectionProvider = $this->getMockBuilder( '\SMW\DBConnectionProvider' )


### PR DESCRIPTION
This PR is made in reference to: #2482

This PR addresses or contains:

- [0] added an exception and it is not clear why or what triggers it and since I don't expect any helpful assistance from a core developer (tried that before and didn't work!), we just silently ignore the exception and continue without a ticket
- The novel idea behind `getEmptyTransactionTicket` is that it asserts that no transaction writes are active and in combination with `commitAndWaitForReplication` allows to safely run a `commitMasterChanges`

```
[DBQuery] Wikimedia\Rdbms\LBFactory::getEmptyTransactionTicket: ["SMW\\ParserData::updateStore","LinksUpdateConstructed","Lorem_ipsum/3aa--ccc-abcdef#0#"] does not have outer scope.
#0 ...\extensions\SemanticMediaWiki\src\MediaWiki\Database.php(520): Wikimedia\Rdbms\LBFactory->getEmptyTransactionTicket('["SMW\\\\ParserDa...')
#1 ...\extensions\SemanticMediaWiki\src\Updater\DeferredTransactionalUpdate.php(80): SMW\MediaWiki\Database->getEmptyTransactionTicket('["SMW\\\\ParserDa...')
#2 ...\extensions\SemanticMediaWiki\src\ParserData.php(467): SMW\Updater\DeferredTransactionalUpdate->commitWithTransactionTicket()
#3 ...\extensions\SemanticMediaWiki\src\MediaWiki\Hooks\LinksUpdateConstructed.php(100): SMW\ParserData->updateStore(true)
#4 ...\extensions\SemanticMediaWiki\src\MediaWiki\Hooks\HookRegistry.php(534): SMW\MediaWiki\Hooks\LinksUpdateConstructed->process(Object(LinksUpdate))
#5 ...\includes\Hooks.php(177): SMW\MediaWiki\Hooks\HookRegistry->SMW\MediaWiki\Hooks\{closure}(Object(LinksUpdate))
#6 ...\includes\Hooks.php(205): Hooks::callHook('LinksUpdateCons...', Array, Array, NULL)
#7 ...\includes\deferred\LinksUpdate.php(158): Hooks::run('LinksUpdateCons...', Array)
#8 ...\includes\content\AbstractContent.php(238): LinksUpdate->__construct(Object(Title), Object(ParserOutput), true)
#9 ...\includes\page\WikiPage.php(2153): AbstractContent->getSecondaryDataUpdates(Object(Title), NULL, true, Object(ParserOutput))
#10 ...\includes\MovePage.php(598): WikiPage->doEditUpdates(Object(Revision), Object(User), Array)
#11 ...\includes\MovePage.php(270): MovePage->moveToInternal(Object(User), Object(Title), '', true, Array)
#12 ...\includes\specials\SpecialMovepage.php(590): MovePage->move(Object(User), '', true)
#13 ...\includes\specials\SpecialMovepage.php(128): MovePageForm->doSubmit()
#14 ...\includes\specialpage\SpecialPage.php(522): MovePageForm->execute(NULL)
#15 ...\includes\specialpage\SpecialPageFactory.php(578): SpecialPage->run(NULL)
#16 ...\includes\MediaWiki.php(287): SpecialPageFactory::executePath(Object(Title), Object(RequestContext))
#17 ...\includes\MediaWiki.php(851): MediaWiki->performRequest()
#18 ...\includes\MediaWiki.php(523): MediaWiki->main()
#19 ...\index.php(43): MediaWiki->run()
#20 {main}
```

[0] https://phabricator.wikimedia.org/rMWc5cba0ea15b2fe5e0fa6d72983af59bc6b899ed0

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed

Fixes #