### PR TITLE
Use LBFactory::hasMasterChanges to check avail. transaction ticket, refs 2902

### DIFF
--- a/src/MediaWiki/Database.php
+++ b/src/MediaWiki/Database.php
@@ -664,11 +664,11 @@ class Database {
 			return $ticket;
 		}
 
-		try {
+		// @see LBFactory::getEmptyTransactionTicket
+		// We don't try very hard at this point and will continue without a ticket
+		// if the check fails and hereby avoid a "... does not have outer scope" error
+		if ( !$this->loadBalancerFactory->hasMasterChanges() ) {
 			$ticket = $this->loadBalancerFactory->getEmptyTransactionTicket( $fname );
-		} catch ( RuntimeException $e ) {
-			// We don't try very hard at ths point since "... does not have outer scope"
-			// isn't clear, we will continue without a ticket
 		}
 
 		return $ticket;

--- a/tests/phpunit/Unit/MediaWiki/DatabaseTest.php
+++ b/tests/phpunit/Unit/MediaWiki/DatabaseTest.php
@@ -362,8 +362,12 @@ class DatabaseTest extends \PHPUnit_Framework_TestCase {
 			->getMock();
 
 		$loadBalancerFactory = $this->getMockBuilder( '\stdClass' )
-			->setMethods( array( 'getEmptyTransactionTicket' ) )
+			->setMethods( array( 'getEmptyTransactionTicket', 'hasMasterChanges' ) )
 			->getMock();
+
+		$loadBalancerFactory->expects( $this->once() )
+			->method( 'hasMasterChanges' )
+			->will( $this->returnValue( false ) );
 
 		$loadBalancerFactory->expects( $this->once() )
 			->method( 'getEmptyTransactionTicket' );
@@ -381,7 +385,7 @@ class DatabaseTest extends \PHPUnit_Framework_TestCase {
 		$instance->getEmptyTransactionTicket( __METHOD__ );
 	}
 
-	public function testGetEmptyTransactionTicketThrowsException() {
+	public function testGetEmptyTransactionTicketOnMasterChanges() {
 
 		$readConnectionProvider = $this->getMockBuilder( '\SMW\Connection\ConnectionProvider' )
 			->disableOriginalConstructor()
@@ -392,12 +396,15 @@ class DatabaseTest extends \PHPUnit_Framework_TestCase {
 			->getMock();
 
 		$loadBalancerFactory = $this->getMockBuilder( '\stdClass' )
-			->setMethods( array( 'getEmptyTransactionTicket' ) )
+			->setMethods( array( 'getEmptyTransactionTicket', 'hasMasterChanges' ) )
 			->getMock();
 
 		$loadBalancerFactory->expects( $this->once() )
-			->method( 'getEmptyTransactionTicket' )
-			->will( $this->throwException( new \RuntimeException() ) );
+			->method( 'hasMasterChanges' )
+			->will( $this->returnValue( true ) );
+
+		$loadBalancerFactory->expects( $this->never() )
+			->method( 'getEmptyTransactionTicket' );
 
 		$instance = new Database(
 			new ConnectionProviderRef(


### PR DESCRIPTION
This PR is made in reference to: #2902

This PR addresses or contains:

- `LBFactory::getEmptyTransactionTicket` didn't throw an exception, it just logged it as "spam" in the query log, use `LBFactory::hasMasterChanges` to check early on whether a ticket can be claimed or not

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed
