### PR TITLE
Adds job queue watchlist feature

### DIFF
--- a/DefaultSettings.php
+++ b/DefaultSettings.php
@@ -659,6 +659,34 @@ return array(
 	'smwgEnableUpdateJobs' => true,
 	##
 
+	###
+	# JobQueue watchlist
+	#
+	# This setting allows to display a personal bar link that shows the queue
+	# sizes for listed jobs. The information presented is fetched from the
+	# MediaWiki API and might be slightly inaccurate but should allow to make
+	# assumptions as to where the system needs attention.
+	#
+	# @see https://www.mediawiki.org/wiki/Manual:Job_queue#Special:Statistics
+	#
+	# To make this feature available, assign a simple list to the setting as in:
+	#
+	# $GLOBALS['smwgJobQueueWatchlist'] = [
+	#	'SMW\UpdateJob',
+	#	'SMW\ParserCachePurgeJob',
+	#	'SMW\FulltextSearchTableUpdateJob',
+	#	'SMW\ChangePropagationUpdateJob'
+	# ]
+	#
+	# Information are not displayed unless a user enables the setting in his or
+	# her preference setting.
+	#
+	# @since 3.0
+	# @default disabled (empty array)
+	##
+	'smwgJobQueueWatchlist' => [],
+	##
+
 	### List of enabled special page properties.
 	# Modification date (_MDAT) is enabled by default for backward compatibility.
 	# Extend array to enable other properties:

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -404,8 +404,9 @@
 	"smw-prefs-ask-options-tooltip-display": "Display parameter text as an info tooltip",
 	"smw-prefs-ask-options-collapsed-default": "Enable option box to be collapsed by default",
 	"smw-prefs-general-options-time-correction": "Enable time correction for special pages using the local [[Special:Preferences#mw-prefsection-rendering|time offset]] preference",
+	"smw-prefs-general-options-jobqueue-watchlist": "Show the [https://www.semantic-mediawiki.org/wiki/Help:Job_queue_watchlist job queue watchlist] in my personal bar",
 	"smw-prefs-general-options-disable-editpage-info": "Disable the introductory text on the edit page",
-	"smw-prefs-general-options-suggester-textinput": "Enable input assistance for semantic entity suggestions",
+	"smw-prefs-general-options-suggester-textinput": "Enable [https://www.semantic-mediawiki.org/wiki/Help:Input_assistance input assistance] for semantic entity suggestions",
 	"smw-ui-tooltip-title-property": "Property",
 	"smw-ui-tooltip-title-quantity": "Unit conversion",
 	"smw-ui-tooltip-title-info": "Information",
@@ -670,5 +671,6 @@
 	"smw-section-collapse": "Collapse the section",
 	"smw-ask-format-help-link": "[https://www.semantic-mediawiki.org/wiki/Help:$1_format $1] format",
 	"smw-help": "Help",
-	"smw-cheat-sheet": "Cheat sheet"
+	"smw-cheat-sheet": "Cheat sheet",
+	"smw-personal-jobqueue-watchlist": "Job queue watchlist"
 }

--- a/includes/Settings.php
+++ b/includes/Settings.php
@@ -51,6 +51,7 @@ class Settings extends Options {
 			'smwgImportFileDirs' => $GLOBALS['smwgImportFileDirs'],
 			'smwgImportReqVersion' => $GLOBALS['smwgImportReqVersion'],
 			'smwgSemanticsEnabled' => $GLOBALS['smwgSemanticsEnabled'],
+			'smwgJobQueueWatchlist' => $GLOBALS['smwgJobQueueWatchlist'],
 			'smwgEnabledCompatibilityMode' => $GLOBALS['smwgEnabledCompatibilityMode'],
 			'smwgDefaultStore' => $GLOBALS['smwgDefaultStore'],
 			'smwgLocalConnectionConf' => $GLOBALS['smwgLocalConnectionConf'],

--- a/includes/Setup.php
+++ b/includes/Setup.php
@@ -312,26 +312,33 @@ final class Setup {
 			return;
 		}
 
-		// Rights
-		$vars['wgAvailableRights'][] = 'smw-admin';
-		$vars['wgAvailableRights'][] = 'smw-patternedit';
-		$vars['wgAvailableRights'][] = 'smw-pageedit';
+		$rights = [
+			'smw-admin' => [
+				'sysop',
+				'smwadministrator'
+			],
+			'smw-patternedit' => [
+				'smwcurator'
+			],
+			'smw-pageedit' => [
+				'smwcurator'
+			],
+		//	'smw-watchlist' => [
+		//		'smwcurator'
+		//	],
+		];
 
-		// User group rights
-		if ( !isset( $vars['wgGroupPermissions']['sysop']['smw-admin'] ) ) {
-			$vars['wgGroupPermissions']['sysop']['smw-admin'] = true;
-		}
+		foreach ( $rights as $right => $roles ) {
 
-		if ( !isset( $vars['wgGroupPermissions']['smwcurator']['smw-patternedit'] ) ) {
-			$vars['wgGroupPermissions']['smwcurator']['smw-patternedit'] = true;
-		}
+			// Rights
+			$vars['wgAvailableRights'][] = $right;
 
-		if ( !isset( $vars['wgGroupPermissions']['smwcurator']['smw-pageedit'] ) ) {
-			$vars['wgGroupPermissions']['smwcurator']['smw-pageedit'] = true;
-		}
-
-		if ( !isset( $vars['wgGroupPermissions']['smwadministrator']['smw-admin'] ) ) {
-			$vars['wgGroupPermissions']['smwadministrator']['smw-admin'] = true;
+			// User group rights
+			foreach ( $roles as $role ) {
+				if ( !isset( $vars['wgGroupPermissions'][$role][$right] ) ) {
+					$vars['wgGroupPermissions'][$role][$right] = true;
+				}
+			}
 		}
 
 		// Add an additional protection level restricting edit/move/etc

--- a/res/Resources.php
+++ b/res/Resources.php
@@ -450,6 +450,23 @@ return array(
 		)
 	),
 
+	// Personal resource
+	'ext.smw.personal' => $moduleTemplate + array(
+		'scripts' => 'smw/util/ext.smw.personal.js',
+		'dependencies' => array(
+			'ext.smw.tooltip',
+			'mediawiki.api'
+		),
+		'messages' => array(
+			'smw-personal-jobqueue-watchlist'
+		),
+		'position' => 'top',
+		'targets' => array(
+			'mobile',
+			'desktop'
+		)
+	),
+
 	// TableResultPrinter resource
 	'ext.smw.tableprinter' => $moduleTemplate + array(
 		'scripts' => array(

--- a/res/smw/ext.smw.css
+++ b/res/smw/ext.smw.css
@@ -39,6 +39,15 @@
 	clear: both;
 }
 
+.smw-personal-jobqueue-watchlist:hover, .smw-personal-jobqueue-watchlist:focus, .smw-personal-jobqueue-watchlist:active {
+	text-decoration: none;
+	color: #0645ad;
+}
+
+.smw-personal-table {
+	font-size: 90%;
+}
+
 /* highlighting for builtin elements */
 span.smwbuiltin,
 span.smwttactiveinline span.smwbuiltin {

--- a/res/smw/util/ext.smw.personal.js
+++ b/res/smw/util/ext.smw.personal.js
@@ -1,0 +1,42 @@
+/**
+ * @license GNU GPL v2+
+ * @since 3.0
+ *
+ * @author mwjames
+ */
+
+/*global jQuery, mediaWiki, mw */
+( function ( $, mw ) {
+
+	'use strict';
+
+	$( document ).ready( function() {
+
+		$( '.smw-personal-jobqueue-watchlist' ).removeClass( 'is-disabled' );
+
+		// Iterate over available nav links onClick
+		$( '.smw-personal-jobqueue-watchlist' ).each( function() {
+
+			var watchlist = mw.config.get( 'smwgJobQueueWatchlist' );
+			var text = '';
+
+			for ( var prop in watchlist ) {
+				if ( watchlist.hasOwnProperty( prop ) ) {
+					text = text + '<tr><td>' + prop + '</td><td>&nbsp;</td><td>' + watchlist[prop] + '</td></tr>';
+				}
+			}
+
+			text = '<table class="smw-personal-table"><tbody>' + text + '</tbody></table>';
+
+			var tooltip = smw.Factory.newTooltip();
+			tooltip.show ( {
+				context: $( this ),
+				title: mw.msg( 'smw-personal-jobqueue-watchlist' ),
+				type: 'inline',
+				content: text
+			} );
+		} );
+
+	} );
+
+}( jQuery, mediaWiki ) );

--- a/src/MediaWiki/Hooks/GetPreferences.php
+++ b/src/MediaWiki/Hooks/GetPreferences.php
@@ -41,8 +41,6 @@ class GetPreferences extends HookHandler {
 	 */
 	public function process( array &$preferences ) {
 
-		$enabledEditPageHelp = $this->getOption( 'smwgEnabledEditPageHelp', false );
-
 		// Intro text
 		$preferences['smw-prefs-intro'] =
 			array(
@@ -67,7 +65,14 @@ class GetPreferences extends HookHandler {
 			'type' => 'toggle',
 			'label-message' => 'smw-prefs-general-options-disable-editpage-info',
 			'section' => 'smw/general-options',
-			'disabled' => !$enabledEditPageHelp
+			'disabled' => !$this->getOption( 'smwgEnabledEditPageHelp', false )
+		);
+
+		$preferences['smw-prefs-general-options-jobqueue-watchlist'] = array(
+			'type' => 'toggle',
+			'label-message' => 'smw-prefs-general-options-jobqueue-watchlist',
+			'section' => 'smw/general-options',
+			'disabled' => $this->getOption( 'smwgJobQueueWatchlist', [] ) === []
 		);
 
 		// Option to enable input assistance

--- a/src/MediaWiki/Hooks/HookRegistry.php
+++ b/src/MediaWiki/Hooks/HookRegistry.php
@@ -583,17 +583,43 @@ class HookRegistry {
 		 */
 		$this->handlers['GetPreferences'] = function ( $user, &$preferences ) use( $applicationFactory ) {
 
+			$settings = $applicationFactory->getSettings();
 			$getPreferences = new GetPreferences(
 				$user
 			);
 
 			$getPreferences->setOptions(
 				[
-					'smwgEnabledEditPageHelp' => $applicationFactory->getSettings()->get( 'smwgEnabledEditPageHelp' )
+					'smwgEnabledEditPageHelp' => $settings->get( 'smwgEnabledEditPageHelp' ),
+					'smwgJobQueueWatchlist' => $settings->get( 'smwgJobQueueWatchlist' )
 				]
 			);
 
 			return $getPreferences->process( $preferences);
+		};
+
+		/**
+		 * @see https://www.mediawiki.org/wiki/Manual:Hooks/PersonalUrls
+		 */
+		$this->handlers['PersonalUrls'] = function( array &$personal_urls, $title, $skinTemplate ) use( $applicationFactory ) {
+
+			$personalUrls = new PersonalUrls(
+				$skinTemplate,
+				$applicationFactory->getJobQueue()
+			);
+
+			$user = $skinTemplate->getUser();
+
+			$personalUrls->setOptions(
+				[
+					'smwgJobQueueWatchlist' => $applicationFactory->getSettings()->get( 'smwgJobQueueWatchlist' ),
+					'prefs-jobqueue-watchlist' => $user->getOption( 'smw-prefs-general-options-jobqueue-watchlist' )
+				]
+			);
+
+			$personalUrls->process( $personal_urls );
+
+			return true;
 		};
 
 		/**

--- a/src/MediaWiki/Hooks/PersonalUrls.php
+++ b/src/MediaWiki/Hooks/PersonalUrls.php
@@ -1,0 +1,110 @@
+<?php
+
+namespace SMW\MediaWiki\Hooks;
+
+use SkinTemplate ;
+use SMW\MediaWiki\JobQueue;
+
+/**
+ * @see https://www.mediawiki.org/wiki/Manual:Hooks/PersonalUrls
+ *
+ * @license GNU GPL v2+
+ * @since 3.0
+ *
+ * @author mwjames
+ */
+class PersonalUrls extends HookHandler {
+
+	/**
+	 * @var SkinTemplate
+	 */
+	private $skin;
+
+	/**
+	 * @var JobQueue
+	 */
+	private $jobQueue;
+
+	/**
+	 * @since 3.0
+	 *
+	 * @param SkinTemplate $skin
+	 * @param JobQueue $jobQueue
+	 */
+	public function __construct( SkinTemplate $skin, JobQueue $jobQueue ) {
+		$this->skin = $skin;
+		$this->jobQueue = $jobQueue;
+	}
+
+	/**
+	 * @since 3.0
+	 *
+	 * @param array &$personalUrls
+	 *
+	 * @return true
+	 */
+	public function process( array &$personalUrls ) {
+
+		$watchlist = $this->getOption( 'smwgJobQueueWatchlist', [] );
+
+		if ( $this->getOption( 'prefs-jobqueue-watchlist' ) !== null && $watchlist !== [] ) {
+			$this->addJobQueueWatchlist( $watchlist, $personalUrls );
+		}
+
+		return true;
+	}
+
+	private function addJobQueueWatchlist( $watchlist, &$personalUrls ) {
+
+		$queue = [];
+
+		foreach ( $watchlist as $job ) {
+			$queue[$job] = $this->humanReadable( $this->jobQueue->getQueueSize( $job ) );
+		}
+
+		$out = $this->skin->getOutput();
+		$personalUrl = [];
+
+		$out->addModules( 'ext.smw.personal' );
+		$out->addJsConfigVars( 'smwgJobQueueWatchlist', $queue );
+
+		$queue = array_filter( $queue, function( $v ) {
+			return $v > 0;
+		} );
+
+		$personalUrl['smw-jobqueue-watchlist'] = [
+			'text'   => 'ⅉ [ ' . ( $queue === [] ? '0' : implode( ' | ', $queue ) ) . ' ]' ,
+			'href'   => '#',
+			'class'  => 'smw-personal-jobqueue-watchlist is-disabled',
+			'active' => true
+		];
+
+		$keys = array_keys( $personalUrls );
+
+		// Insert the link before the watchlist
+		$personalUrls = $this->splice(
+			$personalUrls,
+			$personalUrl,
+			array_search( 'watchlist', $keys )
+		);
+	}
+
+	// https://stackoverflow.com/questions/1783089/array-splice-for-associative-arrays
+	private function splice( $array, $values, $offset ) {
+		return array_slice( $array, 0, $offset, true ) + $values + array_slice( $array, $offset, NULL, true );
+	}
+
+	private function humanReadable( $num, $decimals = 0 ) {
+
+		if ( $num < 1000 ) {
+			$num = number_format( $num );
+		} else if ( $num < 1000000) {
+			$num = number_format( $num / 1000, $decimals ) . 'K';
+		} else {
+			$num = number_format( $num / 1000000, $decimals ) . 'M';
+		}
+
+		return $num;
+	}
+
+}

--- a/tests/phpunit/Unit/MediaWiki/Hooks/GetPreferencesTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Hooks/GetPreferencesTest.php
@@ -74,6 +74,10 @@ class GetPreferencesTest extends \PHPUnit_Framework_TestCase {
 			'smw-prefs-general-options-disable-editpage-info'
 		];
 
+		$provider[] = [
+			'smw-prefs-general-options-jobqueue-watchlist'
+		];
+
 		return $provider;
 	}
 

--- a/tests/phpunit/Unit/MediaWiki/Hooks/PersonalUrlsTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Hooks/PersonalUrlsTest.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace SMW\Tests\MediaWiki\Hooks;
+
+use SMW\MediaWiki\Hooks\PersonalUrls;
+
+/**
+ * @covers \SMW\MediaWiki\Hooks\PersonalUrls
+ * @group semantic-mediawiki
+ *
+ * @license GNU GPL v2+
+ * @since 2.0
+ *
+ * @author mwjames
+ */
+class PersonalUrlsTest extends \PHPUnit_Framework_TestCase {
+
+	private $skinTemplate;
+	private $jobQueue;
+
+	protected function setUp() {
+
+		$this->skinTemplate = $this->getMockBuilder( '\SkinTemplate' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$this->jobQueue = $this->getMockBuilder( '\SMW\MediaWiki\JobQueue' )
+			->disableOriginalConstructor()
+			->getMock();
+	}
+
+	public function testCanConstruct() {
+
+		$this->assertInstanceOf(
+			PersonalUrls::class,
+			new PersonalUrls( $this->skinTemplate, $this->jobQueue )
+		);
+	}
+
+	public function testProcessOnJobQueueWatchlist() {
+
+		$output = $this->getMockBuilder( '\OutputPage' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$this->skinTemplate->expects( $this->any() )
+			->method( 'getOutput' )
+			->will( $this->returnValue( $output ) );
+
+		$personalUrls = [];
+
+		$instance = new PersonalUrls(
+			$this->skinTemplate,
+			$this->jobQueue
+		);
+
+		$instance->setOptions(
+			[
+				'smwgJobQueueWatchlist' => [ 'Foo' ],
+				'prefs-jobqueue-watchlist' => true
+			]
+		);
+
+		$instance->process( $personalUrls );
+
+		$this->assertArrayHasKey(
+			'smw-jobqueue-watchlist',
+			$personalUrls
+		);
+	}
+
+}


### PR DESCRIPTION
This PR is made in reference to: #

This PR addresses or contains:

- Knowing the lag of the job queue especially in regards to SMW related jobs can be helpful to understand how and when updates are expected therefore the `$smwgJobQueueWatchlist` setting is introduced to make those information more accessible
- Figures can be slightly inaccurate with the display relying on MediaWiki's `JobQueue::getSize` which implements its own caching strategy
- In case the setting should only made available to a certain group of users (let's say with a `smw-watchlist` right) then this can be done fairly easily (it is currently not implemented)
- `$smwgJobQueueWatchlist` by default is empty meaning that the __feature is disabled__ and a user is required to enable its display individually by modifying his/her preferences for when `$smwgJobQueueWatchlist` contains an actual list of monitorable jobs like:

```
$GLOBALS['smwgJobQueueWatchlist'] = [
	'SMW\UpdateJob',
	'SMW\ParserCachePurgeJob',
	'SMW\FulltextSearchTableUpdateJob',
	'SMW\ChangePropagationUpdateJob'
];
```

![image](https://user-images.githubusercontent.com/1245473/34329128-8bf3efa0-e8eb-11e7-8d72-955cac89b53c.png)

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed

Fixes #