### PR TITLE
Delay connection instantiation

### DIFF
--- a/includes/storage/SMW_Store.php
+++ b/includes/storage/SMW_Store.php
@@ -489,7 +489,11 @@ abstract class Store implements QueryEngine {
 	 * @since 2.0
 	 */
 	public function clear() {
-		$this->connectionManager->releaseConnections();
+
+		if ( $this->connectionManager !== null ) {
+			$this->connectionManager->releaseConnections();
+		}
+
 		InMemoryPoolCache::getInstance()->resetPoolCacheById( 'store.redirectTarget.lookup' );
 	}
 

--- a/includes/storage/SQLStore/SMW_Sql3SmwIds.php
+++ b/includes/storage/SQLStore/SMW_Sql3SmwIds.php
@@ -198,10 +198,12 @@ class SMWSql3SmwIds {
 		);
 
 		$this->redirectInfoStore = new RedirectInfoStore(
-			$this->store->getConnection( 'mw.db' )
+			$this->store
 		);
 
-		$this->tableFieldUpdater = new TableFieldUpdater( $store );
+		$this->tableFieldUpdater = new TableFieldUpdater(
+			$this->store
+		);
 	}
 
 	/**

--- a/src/SQLStore/SQLStoreFactory.php
+++ b/src/SQLStore/SQLStoreFactory.php
@@ -505,7 +505,7 @@ class SQLStoreFactory {
 	public function newIdMatchFinder( Cache $cache ) {
 
 		$idMatchFinder = new IdMatchFinder(
-			$this->store->getConnection( 'mw.db' ),
+			$this->store,
 			$this->applicationFactory->getIteratorFactory(),
 			$cache
 		);

--- a/tests/phpunit/Unit/MediaWiki/Jobs/EntityIdDisposerJobTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Jobs/EntityIdDisposerJobTest.php
@@ -32,6 +32,10 @@ class EntityIdDisposerJobTest extends \PHPUnit_Framework_TestCase {
 			->method( 'select' )
 			->will( $this->returnValue( array( 'Foo' ) ) );
 
+		$connection->expects( $this->any() )
+			->method( 'selectRow' )
+			->will( $this->returnValue( false ) );
+
 		$store = $this->getMockBuilder( '\SMW\SQLStore\SQLStore' )
 			->getMockForAbstractClass();
 
@@ -60,7 +64,7 @@ class EntityIdDisposerJobTest extends \PHPUnit_Framework_TestCase {
 			->getMock();
 
 		$this->assertInstanceOf(
-			'SMW\MediaWiki\Jobs\EntityIdDisposerJob',
+			EntityIdDisposerJob::class,
 			new EntityIdDisposerJob( $title )
 		);
 	}

--- a/tests/phpunit/Unit/SQLStore/EntityStore/IdMatchFinderTest.php
+++ b/tests/phpunit/Unit/SQLStore/EntityStore/IdMatchFinderTest.php
@@ -20,6 +20,8 @@ class IdMatchFinderTest extends \PHPUnit_Framework_TestCase {
 	private $testEnvironment;
 	private $cache;
 	private $iteratorFactory;
+	private $store;
+	private $conection;
 
 	protected function setUp() {
 		$this->testEnvironment = new TestEnvironment();
@@ -31,17 +33,26 @@ class IdMatchFinderTest extends \PHPUnit_Framework_TestCase {
 		$this->cache = $this->getMockBuilder( '\Onoi\Cache\Cache' )
 			->disableOriginalConstructor()
 			->getMock();
+
+		$this->connection = $this->getMockBuilder( '\SMW\MediaWiki\Database' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$this->store = $this->getMockBuilder( '\SMW\Store' )
+			->disableOriginalConstructor()
+			->setMethods( [ 'getConnection' ] )
+			->getMockForAbstractClass();
+
+		$this->store->expects( $this->any() )
+			->method( 'getConnection' )
+			->will( $this->returnValue( $this->connection ) );
 	}
 
 	public function testCanConstruct() {
 
-		$connection = $this->getMockBuilder( '\SMW\MediaWiki\Database' )
-			->disableOriginalConstructor()
-			->getMock();
-
 		$this->assertInstanceOf(
 			IdMatchFinder::class,
-			new IdMatchFinder( $connection, $this->iteratorFactory, $this->cache )
+			new IdMatchFinder( $this->store, $this->iteratorFactory, $this->cache )
 		);
 	}
 
@@ -63,11 +74,7 @@ class IdMatchFinderTest extends \PHPUnit_Framework_TestCase {
 			->method( 'fetch' )
 			->will( $this->returnValue( 'Foo#14##' ) );
 
-		$connection = $this->getMockBuilder( '\SMW\MediaWiki\Database' )
-			->disableOriginalConstructor()
-			->getMock();
-
-		$connection->expects( $this->once() )
+		$this->connection->expects( $this->once() )
 			->method( 'selectRow' )
 			->with(
 				$this->anything(),
@@ -76,7 +83,7 @@ class IdMatchFinderTest extends \PHPUnit_Framework_TestCase {
 			->will( $this->returnValue( $row ) );
 
 		$instance = new IdMatchFinder(
-			$connection,
+			$this->store,
 			$this->iteratorFactory,
 			$this->cache
 		);
@@ -98,15 +105,11 @@ class IdMatchFinderTest extends \PHPUnit_Framework_TestCase {
 			->method( 'fetch' )
 			->will( $this->returnValue( 'Foo#14##' ) );
 
-		$connection = $this->getMockBuilder( '\SMW\MediaWiki\Database' )
-			->disableOriginalConstructor()
-			->getMock();
-
-		$connection->expects( $this->never() )
+		$this->connection->expects( $this->never() )
 			->method( 'selectRow' );
 
 		$instance = new IdMatchFinder(
-			$connection,
+			$this->store,
 			$this->iteratorFactory,
 			$this->cache
 		);
@@ -128,15 +131,11 @@ class IdMatchFinderTest extends \PHPUnit_Framework_TestCase {
 			->method( 'fetch' )
 			->will( $this->returnValue( '_MDAT#102##' ) );
 
-		$connection = $this->getMockBuilder( '\SMW\MediaWiki\Database' )
-			->disableOriginalConstructor()
-			->getMock();
-
-		$connection->expects( $this->never() )
+		$this->connection->expects( $this->never() )
 			->method( 'selectRow' );
 
 		$instance = new IdMatchFinder(
-			$connection,
+			$this->store,
 			$this->iteratorFactory,
 			$this->cache
 		);
@@ -149,16 +148,12 @@ class IdMatchFinderTest extends \PHPUnit_Framework_TestCase {
 
 	public function testNullForUnknownId() {
 
-		$connection = $this->getMockBuilder( '\SMW\MediaWiki\Database' )
-			->disableOriginalConstructor()
-			->getMock();
-
-		$connection->expects( $this->once() )
+		$this->connection->expects( $this->once() )
 			->method( 'selectRow' )
 			->will( $this->returnValue( false ) );
 
 		$instance = new IdMatchFinder(
-			$connection,
+			$this->store,
 			$this->iteratorFactory,
 			$this->cache
 		);
@@ -176,11 +171,7 @@ class IdMatchFinderTest extends \PHPUnit_Framework_TestCase {
 		$row->smw_iw = '';
 		$row->smw_subobject ='';
 
-		$connection = $this->getMockBuilder( '\SMW\MediaWiki\Database' )
-			->disableOriginalConstructor()
-			->getMock();
-
-		$connection->expects( $this->once() )
+		$this->connection->expects( $this->once() )
 			->method( 'select' )
 			->with(
 				$this->anything(),
@@ -189,7 +180,7 @@ class IdMatchFinderTest extends \PHPUnit_Framework_TestCase {
 			->will( $this->returnValue( array( $row ) ) );
 
 		$instance = new IdMatchFinder(
-			$connection,
+			$this->store,
 			new IteratorFactory(),
 			$this->cache
 		);

--- a/tests/phpunit/Unit/SQLStore/SQLStoreFactoryTest.php
+++ b/tests/phpunit/Unit/SQLStore/SQLStoreFactoryTest.php
@@ -287,14 +287,6 @@ class SQLStoreFactoryTest extends \PHPUnit_Framework_TestCase {
 			->disableOriginalConstructor()
 			->getMock();
 
-		$connection = $this->getMockBuilder( '\SMW\MediaWiki\Database' )
-			->disableOriginalConstructor()
-			->getMock();
-
-		$this->store->expects( $this->once() )
-			->method( 'getConnection' )
-			->will( $this->returnValue( $connection ) );
-
 		$instance = new SQLStoreFactory( $this->store );
 
 		$this->assertInstanceOf(

--- a/tests/phpunit/includes/storage/sqlstore/SQLStoreSmwIdsTest.php
+++ b/tests/phpunit/includes/storage/sqlstore/SQLStoreSmwIdsTest.php
@@ -259,7 +259,7 @@ class SQLStoreSmwIdsTest extends \PHPUnit_Framework_TestCase {
 			->disableOriginalConstructor()
 			->getMock();
 
-		$this->store->expects( $this->atLeastOnce() )
+		$this->store->expects( $this->any() )
 			->method( 'getConnection' )
 			->will( $this->returnValue( $connection ) );
 


### PR DESCRIPTION
This PR is made in reference to: #1732 

This PR addresses or contains:

- Delays the connection instantiation and avoids a possible `RuntimeException` for when something like `wfLoadExtension( 'SemanticCite' );` is used before `enableSemantics` in the `LocalSettings.php`

```
Exception encountered, of type "RuntimeException"
[f52b6061501c87b31667a977] ... RuntimeException from line 60 of ...\extensions\SemanticMediaWiki\src\Connection\ConnectionManager.php: mw.db is missing a registered connection provider
Backtrace:
#0 ...\extensions\SemanticMediaWiki\src\Connection\ConnectionManager.php(32): SMW\Connection\ConnectionManager->findConnectionProvider(string)
#1 ...\extensions\SemanticMediaWiki\includes\storage\SMW_Store.php(539): SMW\Connection\ConnectionManager->getConnection(string)
#2 ...\extensions\SemanticMediaWiki\includes\storage\SQLStore\SMW_SQLStore3.php(635): SMW\Store->getConnection(string)
#3 ...\extensions\SemanticMediaWiki\src\SQLStore\SQLStoreFactory.php(508): SMWSQLStore3->getConnection(string)
#4 ...\extensions\SemanticMediaWiki\includes\storage\SQLStore\SMW_Sql3SmwIds.php(197): SMW\SQLStore\SQLStoreFactory->newIdMatchFinder(Onoi\Cache\FixedInMemoryLruCache)
#5 ...\extensions\SemanticMediaWiki\src\SQLStore\SQLStoreFactory.php(92): SMWSql3SmwIds->__construct(SMWSQLStore3, SMW\SQLStore\SQLStoreFactory)
#6 ...\extensions\SemanticMediaWiki\includes\storage\SQLStore\SMW_SQLStore3.php(166): SMW\SQLStore\SQLStoreFactory->newEntityIdManager()
#7 ...\extensions\SemanticMediaWiki\includes\storage\StoreFactory.php(76): SMWSQLStore3->__construct()
#8 ...\extensions\SemanticMediaWiki\includes\storage\StoreFactory.php(52): SMW\StoreFactory::newInstance(string)
#9 ...\extensions\SemanticMediaWiki\src\Services\SharedServicesContainer.php(83): SMW\StoreFactory::getStore(string)
#10 [internal function]: SMW\Services\SharedServicesContainer->SMW\Services\{closure}(Onoi\CallbackContainer\CallbackContainerBuilder, string)
#11 ...\vendor\onoi\callback-container\src\CallbackContainerBuilder.php(260): call_user_func_array(Closure, array)
#12 ...\vendor\onoi\callback-container\src\CallbackContainerBuilder.php(288): Onoi\CallbackContainer\CallbackContainerBuilder->getReturnValueFromCallbackHandlerFor(string, array)
#13 ...\vendor\onoi\callback-container\src\CallbackContainerBuilder.php(195): Onoi\CallbackContainer\CallbackContainerBuilder->getReturnValueFromSingletonFor(string, array)
#14 ...\extensions\SemanticMediaWiki\src\ApplicationFactory.php(220): Onoi\CallbackContainer\CallbackContainerBuilder->singleton(string, NULL)
#15 ...\extensions\SemanticCite\SemanticCite.php(165): SMW\ApplicationFactory->getStore()
#16 ...\includes\Setup.php(839): SemanticCite::onExtensionFunction()
#17 ...\includes\WebStart.php(137): require_once(string)
#18 ...\index.php(40): require(string)
#19 {main}
```

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed

Fixes #