### PR TITLE
Installer add supplement jobs

### DIFF
--- a/maintenance/setupStore.php
+++ b/maintenance/setupStore.php
@@ -126,6 +126,11 @@ class SetupStore extends \Maintenance {
 			!$this->hasOption( 'skip-import' )
 		);
 
+		$store->getOptions()->set(
+			Installer::OPT_SUPPLEMENT_JOBS,
+			true
+		);
+
 		if ( $this->hasOption( 'delete' ) ) {
 			$this->dropStore( $store );
 		} else {

--- a/src/MediaWiki/Hooks/ExtensionSchemaUpdates.php
+++ b/src/MediaWiki/Hooks/ExtensionSchemaUpdates.php
@@ -47,7 +47,8 @@ class ExtensionSchemaUpdates {
 			[
 				Installer::OPT_SCHEMA_UPDATE => true,
 				Installer::OPT_TABLE_OPTIMZE => true,
-				Installer::OPT_IMPORT => true
+				Installer::OPT_IMPORT => true,
+				Installer::OPT_SUPPLEMENT_JOBS => true
 			]
 		);
 

--- a/src/MediaWiki/Jobs/EntityIdDisposerJob.php
+++ b/src/MediaWiki/Jobs/EntityIdDisposerJob.php
@@ -34,6 +34,7 @@ class EntityIdDisposerJob extends JobBase {
 	 */
 	public function __construct( Title $title, $params = array() ) {
 		parent::__construct( 'SMW\EntityIdDisposerJob', $title, $params );
+		$this->removeDuplicates = true;
 
 		$this->propertyTableIdReferenceDisposer = new PropertyTableIdReferenceDisposer(
 			ApplicationFactory::getInstance()->getStore( '\SMW\SQLStore\SQLStore' )

--- a/src/MediaWiki/Jobs/PropertyStatisticsRebuildJob.php
+++ b/src/MediaWiki/Jobs/PropertyStatisticsRebuildJob.php
@@ -21,6 +21,7 @@ class PropertyStatisticsRebuildJob extends JobBase {
 	 */
 	public function __construct( Title $title, $params = array() ) {
 		parent::__construct( 'SMW\PropertyStatisticsRebuildJob', $title, $params );
+		$this->removeDuplicates = true;
 	}
 
 	/**

--- a/src/SQLStore/SQLStoreFactory.php
+++ b/src/SQLStore/SQLStoreFactory.php
@@ -395,7 +395,8 @@ class SQLStoreFactory {
 					Installer::OPT_MESSAGEREPORTER,
 					Installer::OPT_TABLE_OPTIMZE,
 					Installer::OPT_IMPORT,
-					Installer::OPT_SCHEMA_UPDATE
+					Installer::OPT_SCHEMA_UPDATE,
+					Installer::OPT_SUPPLEMENT_JOBS
 				]
 			)
 		);

--- a/tests/phpunit/TestEnvironment.php
+++ b/tests/phpunit/TestEnvironment.php
@@ -162,7 +162,7 @@ class TestEnvironment {
 	 *
 	 * @return string
 	 */
-	public function fetchOutputFromCallback( callable $callback ) {
+	public function outputFromCallbackExec( callable $callback ) {
 		ob_start();
 		call_user_func( $callback );
 		$output = ob_get_contents();


### PR DESCRIPTION
This PR is made in reference to: #

This PR addresses or contains:

- When a user runs `setupStore.php` or `update.php` the guidelines recommend to run `rebuildData.php` but as statistics show most users neglect that advice, and to ensure that at least outdated entities are removed and statistics are corrected once per update `PropertyStatisticsRebuildJob` and `EntityIdDisposerJob` are planned as supplementary jobs as part of the installation routine.

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed
