### PR TITLE
Avoid "DataItemException ... Unserialization failed: the string "" is … no valid URI" on null

### DIFF
--- a/includes/dataitems/SMW_DI_URI.php
+++ b/includes/dataitems/SMW_DI_URI.php
@@ -117,27 +117,42 @@ class SMWDIUri extends SMWDataItem {
 	 * @return SMWDIUri
 	 */
 	public static function doUnserialize( $serialization ) {
-		$parts = explode( ':', $serialization, 2 ); // try to split "schema:rest"
-		if ( count( $parts ) <= 1 ) {
+
+		// try to split "schema:rest"
+		$parts = explode( ':', $serialization, 2 );
+		$strict = true;
+
+		if ( $serialization !== null && count( $parts ) <= 1 ) {
 			throw new DataItemException( "Unserialization failed: the string \"$serialization\" is no valid URI." );
 		}
+
+		if ( $serialization === null ) {
+			$parts = [ '', 'NO_VALUE' ];
+			$strict = false;
+		}
+
 		$scheme = $parts[0];
-		$parts = explode( '?', $parts[1], 2 ); // try to split "hier-part?queryfrag"
+
+		 // try to split "hier-part?queryfrag"
+		$parts = explode( '?', $parts[1], 2 );
+
 		if ( count( $parts ) == 2 ) {
 			$hierpart = $parts[0];
-			$parts = explode( '#', $parts[1], 2 ); // try to split "query#frag"
+			 // try to split "query#frag"
+			$parts = explode( '#', $parts[1], 2 );
 			$query = $parts[0];
 			$fragment = ( count( $parts ) == 2 ) ? $parts[1] : '';
 		} else {
 			$query = '';
-			$parts = explode( '#', $parts[0], 2 ); // try to split "hier-part#frag"
+			 // try to split "hier-part#frag"
+			$parts = explode( '#', $parts[0], 2 );
 			$hierpart = $parts[0];
 			$fragment = ( count( $parts ) == 2 ) ? $parts[1] : '';
 		}
 
 		$hierpart = ltrim( $hierpart, '/' );
 
-		return new SMWDIUri( $scheme, $hierpart, $query, $fragment );
+		return new SMWDIUri( $scheme, $hierpart, $query, $fragment, $strict );
 	}
 
 	public function equals( SMWDataItem $di ) {


### PR DESCRIPTION
This PR is made in reference to: #

This PR addresses or contains:

- Don't wave the white flag during the display when the field value contains a NULL for a `DIUri` (is an edge, shouldn't happen but it did and the user normally cannot fix it therefore handle it gracefully)

```
[f2930347ba182d48aafc4288] .../Special:Browse/:SomeDocument-2FQ1 SMW\Exception\DataItemException from line 122 of ...\extensions\SemanticMediaWiki\includes\dataitems\SMW_DI_URI.php: Unserialization failed: the string "" is no valid URI.

Backtrace:

#0 ...\extensions\SemanticMediaWiki\src\SQLStore\EntityStore\DIHandlers\DIUriHandler.php(109): SMWDIUri::doUnserialize(NULL)
#1 ...\extensions\SemanticMediaWiki\includes\storage\SQLStore\SMW_Sql3StubSemanticData.php(166): SMW\SQLStore\EntityStore\DIHandlers\DIUriHandler->dataItemFromDBKeys(array)
#2 ...\extensions\SemanticMediaWiki\src\MediaWiki\Specials\Browse\ContentsBuilder.php(424): SMWSql3StubSemanticData->getPropertyValues(SMW\DIProperty)
#3 ...\extensions\SemanticMediaWiki\src\MediaWiki\Specials\Browse\ContentsBuilder.php(321): SMW\MediaWiki\Specials\Browse\ContentsBuilder->buildHtmlFromData(SMWSql3StubSemanticData, array, string, boolean, boolean, string, boolean)
#4 ...\extensions\SemanticMediaWiki\src\MediaWiki\Specials\Browse\ContentsBuilder.php(214): SMW\MediaWiki\Specials\Browse\ContentsBuilder->displayData(SMWSql3StubSemanticData, boolean)
#5 ...\extensions\SemanticMediaWiki\src\MediaWiki\Specials\Browse\ContentsBuilder.php(155): SMW\MediaWiki\Specials\Browse\ContentsBuilder->createHtml()
#6 ...\extensions\SemanticMediaWiki\src\MediaWiki\Specials\SpecialBrowse.php(152): SMW\MediaWiki\Specials\Browse\ContentsBuilder->getHtml()
#7 ...\extensions\SemanticMediaWiki\src\MediaWiki\Specials\SpecialBrowse.php(96): SMW\MediaWiki\Specials\SpecialBrowse->getHtml(WebRequest, boolean)
#8 ...\includes\specialpage\SpecialPage.php(522): SMW\MediaWiki\Specials\SpecialBrowse->execute(string)
#9 ...\includes\specialpage\SpecialPageFactory.php(578): SpecialPage->run(string)
#10 ...\includes\MediaWiki.php(287): SpecialPageFactory::executePath(Title, RequestContext)
#11 ...\includes\MediaWiki.php(851): MediaWiki->performRequest()
#12 ...\includes\MediaWiki.php(523): MediaWiki->main()
#13 ...\index.php(43): MediaWiki->run()
#14 {main}
```

This PR includes:
- [ ] Tests (unit/integration)
- [x] CI build passed
