### PR TITLE
PropertyAliasFinder use persistent cache

### DIFF
--- a/src/PropertyRegistry.php
+++ b/src/PropertyRegistry.php
@@ -73,6 +73,7 @@ class PropertyRegistry {
 		$extraneousLanguage = Localizer::getInstance()->getExtraneousLanguage();
 
 		$propertyAliasFinder = new PropertyAliasFinder(
+			$applicationFactory->getCache(),
 			$extraneousLanguage->getPropertyAliases(),
 			$extraneousLanguage->getCanonicalPropertyAliases()
 		);
@@ -369,8 +370,8 @@ class PropertyRegistry {
 
 		// Those are mostly from extension that register a msgKey as no dedicated
 		// lang. file exists; maybe this should be cached somehow?
-		foreach ( $this->propertyAliasFinder->getKnownPropertyAliasesWithMsgKey() as $key => $id ) {
-			if ( $label === Message::get( $key, Message::TEXT, $languageCode ) ) {
+		foreach ( $this->propertyAliasFinder->getKnownPropertyAliasesByLanguageCode( $languageCode ) as $alias => $id ) {
+			if ( $label === $alias ) {
 				return $id;
 			}
 		}

--- a/tests/phpunit/Unit/PropertyAliasFinderTest.php
+++ b/tests/phpunit/Unit/PropertyAliasFinderTest.php
@@ -15,10 +15,15 @@ use SMW\PropertyAliasFinder;
  */
 class PropertyAliasFinderTest extends \PHPUnit_Framework_TestCase {
 
+	private $cache;
 	private $store;
 
 	protected function setUp() {
 		parent::setUp();
+
+		$this->cache = $this->getMockBuilder( '\Onoi\Cache\Cache' )
+			->disableOriginalConstructor()
+			->getMock();
 
 		$this->store = $this->getMockBuilder( '\SMW\Store' )
 			->disableOriginalConstructor()
@@ -30,8 +35,8 @@ class PropertyAliasFinderTest extends \PHPUnit_Framework_TestCase {
 		$languageIndependentPropertyLabels = array();
 
 		$this->assertInstanceOf(
-			'\SMW\PropertyAliasFinder',
-			new PropertyAliasFinder()
+			PropertyAliasFinder::class,
+			new PropertyAliasFinder( $this->cache )
 		);
 	}
 
@@ -40,6 +45,7 @@ class PropertyAliasFinderTest extends \PHPUnit_Framework_TestCase {
 		$propertyAliases = array( 'Bar' => '_Foo' );
 
 		$instance = new PropertyAliasFinder(
+			$this->cache,
 			$propertyAliases
 		);
 
@@ -59,6 +65,7 @@ class PropertyAliasFinderTest extends \PHPUnit_Framework_TestCase {
 		$canonicalPropertyAliases = array( 'Bar' => '_Foo' );
 
 		$instance = new PropertyAliasFinder(
+			$this->cache,
 			array(),
 			$canonicalPropertyAliases
 		);
@@ -71,12 +78,53 @@ class PropertyAliasFinderTest extends \PHPUnit_Framework_TestCase {
 
 	public function testRegisterAliasByFixedLabel() {
 
-		$instance = new PropertyAliasFinder();
+		$instance = new PropertyAliasFinder(
+			$this->cache
+		);
+
 		$instance->registerAliasByFixedLabel( '_Foo', 'Bar' );
 
 		$this->assertEquals(
 			'_Foo',
 			$instance->findPropertyIdByAlias( 'Bar' )
+		);
+	}
+
+	public function testGetKnownPropertyAliasesByLanguageCodeCached() {
+
+		$this->cache->expects( $this->once() )
+			->method( 'fetch' )
+			->will( $this->returnValue( [ '⧼smw-bar⧽' => '_Foo' ] ) );
+
+		$instance = new PropertyAliasFinder(
+			$this->cache
+		);
+
+		$instance->registerAliasByMsgKey( '_Foo', 'smw-bar' );
+
+		$this->assertEquals(
+			[ '⧼smw-bar⧽' => '_Foo' ],
+			$instance->getKnownPropertyAliasesByLanguageCode( 'en' )
+		);
+	}
+
+	public function testGetKnownPropertyAliasesByLanguageCode() {
+
+		$this->cache->expects( $this->once() )
+			->method( 'fetch' )
+			->will( $this->returnValue( false ) );
+
+		$instance = new PropertyAliasFinder(
+			$this->cache
+		);
+
+		$instance->registerAliasByMsgKey( '_Foo', 'smw-bar' );
+
+		$msgKey = version_compare( $GLOBALS['wgVersion'], '1.28', '<' ) ? '<smw-bar>' : '⧼smw-bar⧽' ;
+
+		$this->assertEquals(
+			[ $msgKey => '_Foo' ],
+			$instance->getKnownPropertyAliasesByLanguageCode( 'en' )
 		);
 	}
 

--- a/tests/phpunit/Unit/PropertyRegistryTest.php
+++ b/tests/phpunit/Unit/PropertyRegistryTest.php
@@ -19,6 +19,17 @@ use SMW\PropertyRegistry;
  */
 class PropertyRegistryTest extends \PHPUnit_Framework_TestCase {
 
+	private $cache;
+	private $store;
+
+	protected function setUp() {
+		parent::setUp();
+
+		$this->cache = $this->getMockBuilder( '\Onoi\Cache\Cache' )
+			->disableOriginalConstructor()
+			->getMock();
+	}
+
 	protected function tearDown() {
 		PropertyRegistry::clear();
 		DataTypeRegistry::clear();
@@ -89,7 +100,10 @@ class PropertyRegistryTest extends \PHPUnit_Framework_TestCase {
 			->disableOriginalConstructor()
 			->getMock();
 
-		$propertyAliases = new PropertyAliasFinder( array( 'Has type' => '_TYPE' ) );
+		$propertyAliases = new PropertyAliasFinder(
+			$this->cache,
+			array( 'Has type' => '_TYPE' )
+		);
 
 		$instance = new PropertyRegistry(
 			$datatypeRegistry,
@@ -123,7 +137,9 @@ class PropertyRegistryTest extends \PHPUnit_Framework_TestCase {
 			->disableOriginalConstructor()
 			->getMock();
 
-		$propertyAliases = new PropertyAliasFinder();
+		$propertyAliases = new PropertyAliasFinder(
+			$this->cache
+		);
 
 		$instance = new PropertyRegistry(
 			$datatypeRegistry,
@@ -174,7 +190,9 @@ class PropertyRegistryTest extends \PHPUnit_Framework_TestCase {
 			->disableOriginalConstructor()
 			->getMock();
 
-		$propertyAliases = new PropertyAliasFinder();
+		$propertyAliases = new PropertyAliasFinder(
+			$this->cache
+		);
 
 		$instance = new PropertyRegistry(
 			$datatypeRegistry,
@@ -215,7 +233,9 @@ class PropertyRegistryTest extends \PHPUnit_Framework_TestCase {
 
 		$propertyLabelFinder = new PropertyLabelFinder( $store, array() );
 
-		$propertyAliases = new PropertyAliasFinder();
+		$propertyAliases = new PropertyAliasFinder(
+			$this->cache
+		);
 
 		$instance = new PropertyRegistry(
 			$datatypeRegistry,
@@ -269,7 +289,9 @@ class PropertyRegistryTest extends \PHPUnit_Framework_TestCase {
 
 		$propertyLabelFinder = new PropertyLabelFinder( $store, array() );
 
-		$propertyAliases = new PropertyAliasFinder();
+		$propertyAliases = new PropertyAliasFinder(
+			$this->cache
+		);
 
 		$instance = new PropertyRegistry(
 			$datatypeRegistry,
@@ -329,7 +351,9 @@ class PropertyRegistryTest extends \PHPUnit_Framework_TestCase {
 
 		$propertyLabelFinder = new PropertyLabelFinder( $store, array() );
 
-		$propertyAliases = new PropertyAliasFinder();
+		$propertyAliases = new PropertyAliasFinder(
+			$this->cache
+		);
 
 		$instance = new PropertyRegistry(
 			$datatypeRegistry,
@@ -376,7 +400,9 @@ class PropertyRegistryTest extends \PHPUnit_Framework_TestCase {
 
 		$propertyLabelFinder = new PropertyLabelFinder( $store, array() );
 
-		$propertyAliases = new PropertyAliasFinder();
+		$propertyAliases = new PropertyAliasFinder(
+			$this->cache
+		);
 
 		$instance = new PropertyRegistry(
 			$datatypeRegistry,
@@ -410,7 +436,9 @@ class PropertyRegistryTest extends \PHPUnit_Framework_TestCase {
 
 		$propertyLabelFinder = new PropertyLabelFinder( $store, array() );
 
-		$propertyAliases = new PropertyAliasFinder();
+		$propertyAliases = new PropertyAliasFinder(
+			$this->cache
+		);
 
 		$instance = new PropertyRegistry(
 			$datatypeRegistry,
@@ -444,7 +472,9 @@ class PropertyRegistryTest extends \PHPUnit_Framework_TestCase {
 
 		$propertyLabelFinder = new PropertyLabelFinder( $store, array() );
 
-		$propertyAliases = new PropertyAliasFinder();
+		$propertyAliases = new PropertyAliasFinder(
+			$this->cache
+		);
 
 		$instance = new PropertyRegistry(
 			$datatypeRegistry,
@@ -484,7 +514,9 @@ class PropertyRegistryTest extends \PHPUnit_Framework_TestCase {
 
 		$propertyLabelFinder = new PropertyLabelFinder( $store, array() );
 
-		$propertyAliases = new PropertyAliasFinder();
+		$propertyAliases = new PropertyAliasFinder(
+			$this->cache
+		);
 
 		$dataTypePropertyExemptionList = array( 'Foo', 'Bar' );
 


### PR DESCRIPTION
This PR is made in reference to: #

This PR addresses or contains:

- Avoid unnecessary DB queries on property alias msgKeys (actually `LCStoreDB::get` should handle this but then again trying to move an elephant in an elevator ... )

```
9	SELECT lc_value FROM `l10n_cache` WHERE lc_lang = 'en' AND lc_key = 'messages:sbl-property-alias-parentpage' LIMIT 1	0.5898ms	LCStoreDB::get
10	SELECT lc_value FROM `l10n_cache` WHERE lc_lang = 'en' AND lc_key = 'messages:sci-property-alias-olid' LIMIT 1	0.5240ms	LCStoreDB::get
11	SELECT lc_value FROM `l10n_cache` WHERE lc_lang = 'en' AND lc_key = 'messages:sci-property-alias-viaf' LIMIT 1	0.5169ms	LCStoreDB::get
12	SELECT lc_value FROM `l10n_cache` WHERE lc_lang = 'en' AND lc_key = 'messages:sci-property-alias-oclc' LIMIT 1	0.5190ms	LCStoreDB::get
13	SELECT lc_value FROM `l10n_cache` WHERE lc_lang = 'en' AND lc_key = 'messages:sci-property-alias-doi' LIMIT 1	0.5350ms	LCStoreDB::get
14	SELECT lc_value FROM `l10n_cache` WHERE lc_lang = 'en' AND lc_key = 'messages:sci-property-alias-pmcid' LIMIT 1	0.4029ms	LCStoreDB::get
15	SELECT lc_value FROM `l10n_cache` WHERE lc_lang = 'en' AND lc_key = 'messages:sci-property-alias-pmid' LIMIT 1	0.5140ms	LCStoreDB::get
16	SELECT lc_value FROM `l10n_cache` WHERE lc_lang = 'en' AND lc_key = 'messages:sci-property-alias-citation-key' LIMIT 1	0.3541ms	LCStoreDB::get
17	SELECT lc_value FROM `l10n_cache` WHERE lc_lang = 'en' AND lc_key = 'messages:sci-property-alias-citation-reference' LIMIT 1	0.3450ms	LCStoreDB::get
18	SELECT lc_value FROM `l10n_cache` WHERE lc_lang = 'en' AND lc_key = 'messages:sci-property-alias-citation-text' LIMIT 1	0.3340ms	LCStoreDB::get
19	SELECT lc_value FROM `l10n_cache` WHERE lc_lang = 'en' AND lc_key = 'messages:sci-property-alias-citation-resource' LIMIT 1	0.3359ms	LCStoreDB::get
20	SELECT lc_value FROM `l10n_cache` WHERE lc_lang = 'en' AND lc_key = 'messages:sil-property-alias-container' LIMIT 1	0.3409ms	LCStoreDB::get
21	SELECT lc_value FROM `l10n_cache` WHERE lc_lang = 'en' AND lc_key = 'messages:sil-property-ill-alias-language' LIMIT 1	0.3130ms	LCStoreDB::get
22	SELECT lc_value FROM `l10n_cache` WHERE lc_lang = 'en' AND lc_key = 'messages:sil-property-ill-alias-reference' LIMIT 1	0.6251ms	LCStoreDB::get
23	SELECT lc_value FROM `l10n_cache` WHERE lc_lang = 'en' AND lc_key = 'messages:sil-property-iwl-alias-language' LIMIT 1	0.7019ms	LCStoreDB::get
```

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed
