### PR TITLE
Fetch all entities (incl. redi) on delete, refs 1151

### DIFF
--- a/includes/storage/SQLStore/SMW_SQLStore3_Writers.php
+++ b/includes/storage/SQLStore/SMW_SQLStore3_Writers.php
@@ -73,10 +73,9 @@ class SMWSQLStore3Writers {
 
 		// Fetch all possible matches (including any duplicates created by
 		// incomplete rollback or DB deadlock)
-		$ids = $this->store->getObjectIds()->getListOfIdMatchesFor(
+		$ids = $this->store->getObjectIds()->findAllEntitiesThatMatch(
 			$title->getDBkey(),
-			$title->getNamespace(),
-			$title->getInterwiki()
+			$title->getNamespace()
 		);
 
 		$subject = DIWikiPage::newFromTitle( $title );
@@ -262,7 +261,7 @@ class SMWSQLStore3Writers {
 
 		// Find any potential duplicate entries for the current subject and
 		// if matched, mark them as to be deleted
-		$idList = $this->store->getObjectIds()->getListOfIdMatchesFor(
+		$idList = $this->store->getObjectIds()->findAllEntitiesThatMatch(
 			$subject->getDBkey(),
 			$subject->getNamespace(),
 			$subject->getInterwiki(),

--- a/includes/storage/SQLStore/SMW_Sql3SmwIds.php
+++ b/includes/storage/SQLStore/SMW_Sql3SmwIds.php
@@ -516,24 +516,36 @@ class SMWSql3SmwIds {
 	 *
 	 * @param string $title DB key
 	 * @param integer $namespace namespace
-	 * @param string $iw interwiki prefix
+	 * @param string|null $iw interwiki prefix
 	 * @param string $subobjectName name of subobject
 	 *
 	 * @param array
 	 */
-	public function getListOfIdMatchesFor( $title, $namespace, $iw, $subobjectName = '' ) {
+	public function findAllEntitiesThatMatch( $title, $namespace, $iw = null, $subobjectName = '' ) {
 
-		$matches = array();
+		$matches = [];
+		$query = [];
 
-		$rows = $this->store->getConnection( 'mw.db' )->select(
+		$query['fields'] = ['smw_id'];
+
+		$query['conditions'] = [
+			'smw_title' => $title,
+			'smw_namespace' => $namespace,
+			'smw_iw' => $iw,
+			'smw_subobject' => $subobjectName
+		];
+
+		// Null means select all (incl. those marked delete, redi etc.)
+		if ( $iw === null ) {
+			unset( $query['conditions']['smw_iw'] );
+		}
+
+		$connection = $this->store->getConnection( 'mw.db' );
+
+		$rows = $connection->select(
 			self::TABLE_NAME,
-			$select = array( 'smw_id' ),
-			array(
-				'smw_title' => $title,
-				'smw_namespace' => $namespace,
-				'smw_iw' => $iw,
-				'smw_subobject' => $subobjectName
-			),
+			$query['fields'],
+			$query['conditions'],
 			__METHOD__
 		);
 

--- a/tests/phpunit/Integration/SemanticMediaWikiProvidedHookInterfaceIntegrationTest.php
+++ b/tests/phpunit/Integration/SemanticMediaWikiProvidedHookInterfaceIntegrationTest.php
@@ -261,7 +261,7 @@ class SemanticMediaWikiProvidedHookInterfaceIntegrationTest extends \PHPUnit_Fra
 			->getMock();
 
 		$idGenerator->expects( $this->any() )
-			->method( 'getListOfIdMatchesFor' )
+			->method( 'findAllEntitiesThatMatch' )
 			->will( $this->returnValue( array( 42 ) ) );
 
 		$store = $this->getMockBuilder( $storeClass )
@@ -299,7 +299,7 @@ class SemanticMediaWikiProvidedHookInterfaceIntegrationTest extends \PHPUnit_Fra
 			->getMock();
 
 		$idGenerator->expects( $this->any() )
-			->method( 'getListOfIdMatchesFor' )
+			->method( 'findAllEntitiesThatMatch' )
 			->will( $this->returnValue( array( 42 ) ) );
 
 		$store = $this->getMockBuilder( $storeClass )

--- a/tests/phpunit/includes/SQLStore/Writer/ChangeTitleTest.php
+++ b/tests/phpunit/includes/SQLStore/Writer/ChangeTitleTest.php
@@ -31,7 +31,7 @@ class ChangeTitleTest extends \PHPUnit_Framework_TestCase {
 			->getMock();
 
 		$entityManager->expects( $this->any() )
-			->method( 'getListOfIdMatchesFor' )
+			->method( 'findAllEntitiesThatMatch' )
 			->will( $this->returnValue( [] ) );
 
 		$this->store = $this->getMockBuilder( '\SMWSQLStore3' )
@@ -146,7 +146,7 @@ class ChangeTitleTest extends \PHPUnit_Framework_TestCase {
 			->getMock();
 
 		$objectIdGenerator->expects( $this->any() )
-			->method( 'getListOfIdMatchesFor' )
+			->method( 'findAllEntitiesThatMatch' )
 			->will( $this->returnValue( [] ) );
 
 		$objectIdGenerator->expects( $this->at( 0 ) )
@@ -216,7 +216,7 @@ class ChangeTitleTest extends \PHPUnit_Framework_TestCase {
 			->getMock();
 
 		$objectIdGenerator->expects( $this->any() )
-			->method( 'getListOfIdMatchesFor' )
+			->method( 'findAllEntitiesThatMatch' )
 			->will( $this->returnValue( [] ) );
 
 		$objectIdGenerator->expects( $this->at( 0 ) )

--- a/tests/phpunit/includes/SQLStore/Writer/DataUpdateTest.php
+++ b/tests/phpunit/includes/SQLStore/Writer/DataUpdateTest.php
@@ -32,7 +32,7 @@ class DataUpdateTest extends \PHPUnit_Framework_TestCase {
 			->getMock();
 
 		$entityManager->expects( $this->any() )
-			->method( 'getListOfIdMatchesFor' )
+			->method( 'findAllEntitiesThatMatch' )
 			->will( $this->returnValue( [] ) );
 
 		$this->store = $this->getMockBuilder( '\SMWSQLStore3' )
@@ -154,7 +154,7 @@ class DataUpdateTest extends \PHPUnit_Framework_TestCase {
 			->getMock();
 
 		$objectIdGenerator->expects( $this->any() )
-			->method( 'getListOfIdMatchesFor' )
+			->method( 'findAllEntitiesThatMatch' )
 			->will( $this->returnValue( [] ) );
 
 		$objectIdGenerator->expects( $this->once() )
@@ -215,7 +215,7 @@ class DataUpdateTest extends \PHPUnit_Framework_TestCase {
 			->getMock();
 
 		$objectIdGenerator->expects( $this->any() )
-			->method( 'getListOfIdMatchesFor' )
+			->method( 'findAllEntitiesThatMatch' )
 			->will( $this->returnValue( [] ) );
 
 		$objectIdGenerator->expects( $this->once() )

--- a/tests/phpunit/includes/SQLStore/Writer/DeleteSubjectTest.php
+++ b/tests/phpunit/includes/SQLStore/Writer/DeleteSubjectTest.php
@@ -143,7 +143,7 @@ class DeleteSubjectTest extends \PHPUnit_Framework_TestCase {
 			->getMock();
 
 		$objectIdGenerator->expects( $this->atLeastOnce() )
-			->method( 'getListOfIdMatchesFor' )
+			->method( 'findAllEntitiesThatMatch' )
 			->will( $this->returnValue( array( 0 ) ) );
 
 		$database = $this->getMockBuilder( '\SMW\MediaWiki\Database' )
@@ -183,7 +183,7 @@ class DeleteSubjectTest extends \PHPUnit_Framework_TestCase {
 			->getMock();
 
 		$objectIdGenerator->expects( $this->atLeastOnce() )
-			->method( 'getListOfIdMatchesFor' )
+			->method( 'findAllEntitiesThatMatch' )
 			->with(
 				$this->equalTo( $title->getDBkey() ),
 				$this->equalTo( $title->getNamespace() ),


### PR DESCRIPTION
This PR is made in reference to: #1151

This PR addresses or contains:

- Ensures that during a delete all "gost" pages are found including redirects for that instance

This PR includes:
- [ ] Tests (unit/integration)
- [x] CI build passed
