### PR TITLE
Tidy (Store, redirectTarget)

### DIFF
--- a/tests/phpunit/Unit/StoreTest.php
+++ b/tests/phpunit/Unit/StoreTest.php
@@ -17,28 +17,24 @@ use SMW\Store;
  */
 class StoreTest extends \PHPUnit_Framework_TestCase {
 
-	public function testGetRedirectTargetFromInMemoryCache() {
-
-		$inMemoryPoolCache = InMemoryPoolCache::getInstance();
-
-		$instance = $this->getMockBuilder( '\SMW\Store' )
-			->disableOriginalConstructor()
-			->getMockForAbstractClass();
+	public function testGetRedirectTarget() {
 
 		$wikipage = new DIWikiPage( 'Foo', NS_MAIN );
 		$expected = new DIWikiPage( 'Bar', NS_MAIN );
 
-		$inMemoryPoolCache->getPoolCacheById( 'store.redirectTarget.lookup' )->save(
-			$wikipage->getHash(),
-			$expected
-		);
+		$instance = $this->getMockBuilder( '\SMW\Store' )
+			->disableOriginalConstructor()
+			->setMethods( [ 'getPropertyValues' ] )
+			->getMockForAbstractClass();
+
+		$instance->expects( $this->once() )
+			->method( 'getPropertyValues' )
+			->will( $this->returnValue( [ $expected ] ) );
 
 		$this->assertEquals(
 			$expected,
 			$instance->getRedirectTarget( $wikipage )
 		);
-
-		$inMemoryPoolCache->resetPoolCacheById( 'store.redirectTarget.lookup' );
 	}
 
 }


### PR DESCRIPTION
This PR is made in reference to: #

This PR addresses or contains:

- The `'store.redirectTarget.lookup'` in-memory cache was hardly used (below 1% hit rate) hence remove it to reduce complexity in `Store::getRedirectTarget`

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed

Fixes #