### PR TITLE
Special:Browse allow to show the sortkey, refs 2889

### DIFF
--- a/DefaultSettings.php
+++ b/DefaultSettings.php
@@ -331,6 +331,8 @@ return array(
 	# - SMW_BROWSE_SHOW_GROUP: Should the browse view create group sections for
 	#   properties that belong to the same property group?
 	#
+	# - SMW_BROWSE_SHOW_SORTKEY: Should the sortkey be displayed?
+	#
 	# - SMW_BROWSE_USE_API: Whether the browse display is to be generated using
 	#   an API request or not. (was $smwgBrowseByApi)
 	#

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -672,5 +672,6 @@
 	"smw-ask-format-help-link": "[https://www.semantic-mediawiki.org/wiki/Help:$1_format $1] format",
 	"smw-help": "Help",
 	"smw-cheat-sheet": "Cheat sheet",
-	"smw-personal-jobqueue-watchlist": "Job queue watchlist"
+	"smw-personal-jobqueue-watchlist": "Job queue watchlist",
+	"smw-property-predefined-label-skey": "Sortkey"
 }

--- a/src/Defines.php
+++ b/src/Defines.php
@@ -232,7 +232,8 @@ define( 'SMW_BROWSE_TLINK', 2 ); // Support for the toolbox link
 define( 'SMW_BROWSE_SHOW_INVERSE', 4 ); // Support inverse direction
 define( 'SMW_BROWSE_SHOW_INCOMING', 8 ); // Support for incoming links
 define( 'SMW_BROWSE_SHOW_GROUP', 16 ); // Support for grouping properties
-define( 'SMW_BROWSE_USE_API', 32 ); // Support for using the API as request backend
+define( 'SMW_BROWSE_SHOW_SORTKEY', 32 ); // Support for the sortkey display
+define( 'SMW_BROWSE_USE_API', 64 ); // Support for using the API as request backend
 /**@}*/
 
 /**@{

--- a/src/MediaWiki/Specials/Browse/ContentsBuilder.php
+++ b/src/MediaWiki/Specials/Browse/ContentsBuilder.php
@@ -378,6 +378,7 @@ class ContentsBuilder {
 
 		$contextPage = $semanticData->getSubject();
 		$showInverse = $this->getOption( 'showInverse' );
+		$showSort = $this->getOption( 'showSort' );
 
 		$comma = Message::get(
 			'comma-separator',
@@ -409,6 +410,11 @@ class ContentsBuilder {
 				$incoming,
 				$showInverse
 			);
+
+			// Make the sortkey visible which is otherwise hidden from the user
+			if ( $showSort && $diProperty->getKey() === '_SKEY' ) {
+				$propertyLabel = Message::get( 'smw-property-predefined-label-skey', Message::TEXT, Message::USER_LANGUAGE );
+			}
 
 			if ( $propertyLabel === null ) {
 				continue;

--- a/src/MediaWiki/Specials/Browse/ValueFormatter.php
+++ b/src/MediaWiki/Specials/Browse/ValueFormatter.php
@@ -102,11 +102,13 @@ class ValueFormatter {
 
 		$html = $dataValue->getLongHTMLText( $linker );
 
+		$noInfolinks = [ '_INST', '_SKEY' ];
+
 		if ( in_array( $dataValue->getTypeID(), [ '_wpg', '_wpp', '__sob'] ) ) {
 			$html .= "&#160;" . Infolink::newBrowsingLink( '+', $dataValue->getLongWikiText() )->getHTML( $linker );
 		} elseif ( $incoming && $propertyValue->isVisible() ) {
 			$html .= "&#160;" . Infolink::newInversePropertySearchLink( '+', $dataValue->getTitle(), $propertyValue->getDataItem()->getLabel(), 'smwsearch' )->getHTML( $linker );
-		} elseif ( $dataValue->getProperty() instanceof DIProperty && $dataValue->getProperty()->getKey() !== '_INST' ) {
+		} elseif ( $dataValue->getProperty() instanceof DIProperty && !in_array( $dataValue->getProperty()->getKey(), $noInfolinks ) ) {
 			$html .= $dataValue->getInfolinkText( SMW_OUTPUT_HTML, $linker );
 		}
 

--- a/src/MediaWiki/Specials/SpecialBrowse.php
+++ b/src/MediaWiki/Specials/SpecialBrowse.php
@@ -138,6 +138,7 @@ class SpecialBrowse extends SpecialPage {
 			'printable'   => $contentsBuilder->getOption( 'printable' ),
 			'showInverse' => $contentsBuilder->getOption( 'showInverse' ),
 			'showGroup'   => $contentsBuilder->getOption( 'showGroup' ),
+			'showSort'    => $contentsBuilder->getOption( 'showSort' ),
 			'showAll'     => $contentsBuilder->getOption( 'showAll' ),
 			'including'   => $contentsBuilder->getOption( 'including' )
 		);
@@ -239,6 +240,11 @@ class SpecialBrowse extends SpecialPage {
 		$contentsBuilder->setOption(
 			'showGroup',
 			$settings->isFlagSet( 'smwgBrowseFeatures', SMW_BROWSE_SHOW_GROUP )
+		);
+
+		$contentsBuilder->setOption(
+			'showSort',
+			$settings->isFlagSet( 'smwgBrowseFeatures', SMW_BROWSE_SHOW_SORTKEY )
 		);
 
 		$contentsBuilder->setOption(

--- a/tests/phpunit/Unit/MediaWiki/Specials/SpecialBrowseTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Specials/SpecialBrowseTest.php
@@ -78,7 +78,7 @@ class SpecialBrowseTest extends \PHPUnit_Framework_TestCase {
 			'Foo/Bar',
 			array(
 				'data-subject="Foo/Bar#0#"',
-				'data-options="{&quot;dir&quot;:null,&quot;group&quot;:null,&quot;offset&quot;:null,&quot;printable&quot;:null,&quot;showInverse&quot;:false,&quot;showGroup&quot;:false,&quot;showAll&quot;:true,&quot;including&quot;:null}"'
+				'data-options="{&quot;dir&quot;:null,&quot;group&quot;:null,&quot;offset&quot;:null,&quot;printable&quot;:null,&quot;showInverse&quot;:false,&quot;showGroup&quot;:false,&quot;showSort&quot;:false,&quot;showAll&quot;:true,&quot;including&quot;:null}"'
 			)
 		);
 
@@ -87,7 +87,7 @@ class SpecialBrowseTest extends \PHPUnit_Framework_TestCase {
 			':Main-20Page-23_QUERY140d50d705e9566904fc4a877c755964',
 			array(
 				'data-subject="Main_Page#0##_QUERY140d50d705e9566904fc4a877c755964"',
-				'data-options="{&quot;dir&quot;:null,&quot;group&quot;:null,&quot;offset&quot;:null,&quot;printable&quot;:null,&quot;showInverse&quot;:false,&quot;showGroup&quot;:false,&quot;showAll&quot;:true,&quot;including&quot;:null}"'
+				'data-options="{&quot;dir&quot;:null,&quot;group&quot;:null,&quot;offset&quot;:null,&quot;printable&quot;:null,&quot;showInverse&quot;:false,&quot;showGroup&quot;:false,&quot;showSort&quot;:false,&quot;showAll&quot;:true,&quot;including&quot;:null}"'
 			)
 		);
 


### PR DESCRIPTION
This PR is made in reference to: #2889

This PR addresses or contains:

- The sortkey (influenced by DISPLAYTITLE, DEFAULTSORT etc.) is normally not visible to a user but with the help of the `SMW_BROWSE_SHOW_SORTKEY` flag (not enabled by default), the display can be enabled to clarify the assigned value and hereby a possible ranking position within a result set.

This PR includes:
- [ ] Tests (unit/integration)
- [x] CI build passed
