### PR TITLE
Remove `SEMANTIC_EXTENSION_TYPE` flag, refs 1014

### DIFF
--- a/load.php
+++ b/load.php
@@ -78,10 +78,6 @@ class SemanticMediaWiki {
 			'license-name'   => 'GPL-2.0+'
 		);
 
-		// A flag used to indicate SMW defines a semantic extension type for extension credits.
-		// @deprecated, removal in SMW 3.0
-		define( 'SEMANTIC_EXTENSION_TYPE', true );
-
 		// Registration point for required early registration
 		Setup::initExtension( $GLOBALS );
 	}


### PR DESCRIPTION
This PR is made in reference to: #1014

This PR addresses or contains:

- Removes the `SEMANTIC_EXTENSION_TYPE` flag

This PR includes:
- [ ] Tests (unit/integration)
- [ ] CI build passed

Fixes #