### PR TITLE
Limit property page subject value selection

### DIFF
--- a/includes/storage/SQLStore/SMW_SQLStore3_Readers.php
+++ b/includes/storage/SQLStore/SMW_SQLStore3_Readers.php
@@ -4,6 +4,7 @@ use SMW\DataTypeRegistry;
 use SMW\ApplicationFactory;
 use SMW\DIWikiPage;
 use SMW\DIProperty;
+use SMW\RequestOptions;
 use SMW\SQLStore\TableDefinition;
 use SMW\SQLStore\EntityStore\Exception\DataItemHandlerException;
 use SMW\SQLStore\EntityStore\StubSemanticData;
@@ -170,8 +171,25 @@ class SMWSQLStore3Readers {
 					return array();
 				}
 
-				$sd = $this->semanticDataLookup->getSemanticDataFromTable( $sid, $subject, $proptables[$propTableId] );
-				$result = $this->store->applyRequestOptions( $sd->getPropertyValues( $property ), $requestOptions );
+				$propertyTableDef = $proptables[$propTableId];
+
+				$ropts = $this->semanticDataLookup->findConditionConstraint(
+					$propertyTableDef,
+					$property,
+					$requestOptions
+				);
+
+				$semanticData = $this->semanticDataLookup->getSemanticDataFromTable(
+					$sid,
+					$subject,
+					$propertyTableDef,
+					$ropts
+				);
+
+				$result = $this->store->applyRequestOptions(
+					$semanticData->getPropertyValues( $property ),
+					$requestOptions
+				);
 			}
 		} else { // no subject given, get all values for the given property
 			$pid = $this->store->smwIds->getSMWPropertyID( $property );
@@ -186,7 +204,6 @@ class SMWSQLStore3Readers {
 				$pid,
 				$property,
 				$proptables[$tableid],
-				false,
 				$requestOptions
 			);
 

--- a/src/Page/ListBuilder/ValueListBuilder.php
+++ b/src/Page/ListBuilder/ValueListBuilder.php
@@ -271,6 +271,13 @@ class ValueListBuilder {
 			// Property values
 			$ropts = new RequestOptions();
 			$ropts->limit = $this->maxPropertyValues + 1;
+
+			// Restrict the request otherwise the entire SemanticData record
+			// is fetched which can in case of a subject with a large
+			// subobject/subpage pool create excessive DB queries that are not
+			// used for the display
+			$ropts->conditionConstraint = true;
+
 			$values = $this->store->getPropertyValues( $diWikiPage, $property, $ropts );
 
 			// May return an iterator


### PR DESCRIPTION
This PR is made in reference to: ##2928

This PR addresses or contains:

- Background: On occasions where the property page requires values for a subject and the subject has a large value pool it currently fetches the complete `SemanticData` record only to display `maxPropertyValues` which means unnecessary queries are created for data that is not going to be displayed (one example, a subpage property page with subjects containing 2000 assignments each became inessential "slow" due to excessive fetch queries) 

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed

Fixes #