### PR TITLE
Adds script to remove duplicates, refs 2883

### DIFF
--- a/includes/storage/SQLStore/SMW_Sql3SmwIds.php
+++ b/includes/storage/SQLStore/SMW_Sql3SmwIds.php
@@ -501,7 +501,7 @@ class SMWSql3SmwIds {
 	 *
 	 * @return []
 	 */
-	public function findDuplicateEntries() {
+	public function findDuplicateEntityRecords() {
 
 		$connection = $this->store->getConnection( 'mw.db' );
 

--- a/maintenance/removeDuplicateEntities.php
+++ b/maintenance/removeDuplicateEntities.php
@@ -1,0 +1,84 @@
+<?php
+
+namespace SMW\Maintenance;
+
+use SMW\ApplicationFactory;
+
+$basePath = getenv( 'MW_INSTALL_PATH' ) !== false ? getenv(
+'MW_INSTALL_PATH' ) : __DIR__ . '/../../..';
+
+require_once $basePath . '/maintenance/Maintenance.php';
+
+/**
+ * @license GNU GPL v2+
+ * @since 3.0
+ *
+ * @author mwjames
+ */
+class RemoveDuplicateEntities extends \Maintenance {
+
+	/**
+	 * @since 3.0
+	 */
+	public function __construct() {
+		$this->mDescription = 'Remove duplicates entities without active references.';
+		$this->addOption( 's', 'ID starting point', false, true );
+
+		parent::__construct();
+	}
+
+	/**
+	 * @see Maintenance::addDefaultParams
+	 *
+	 * @since 3.0
+	 */
+	protected function addDefaultParams() {
+		parent::addDefaultParams();
+	}
+
+	/**
+	 * @see Maintenance::execute
+	 */
+	public function execute() {
+
+		if ( !defined( 'SMW_VERSION' ) ) {
+			$this->output( "You need to have SMW enabled in order to use this maintenance script!\n\n" );
+			exit;
+		}
+
+		$this->reportMessage(
+			"\nThe script will only dispose of those duplicate entities that have no active\n" .
+			"references. The log section 'untouched' contains IDs that have not been\n" .
+			"removed and the user is asked to verify the content and manually remove\n".
+			"those listed entities.\n\n"
+		);
+
+		$applicationFactory = ApplicationFactory::getInstance();
+		$maintenanceFactory = $applicationFactory->newMaintenanceFactory();
+
+		$duplicateEntitiesDisposer = $maintenanceFactory->newDuplicateEntitiesDisposer(
+			$applicationFactory->getStore( 'SMW\SQLStore\SQLStore' ),
+			array( $this, 'reportMessage' )
+		);
+
+		$duplicateEntityRecords = $duplicateEntitiesDisposer->findDuplicateEntityRecords();
+		$duplicateEntitiesDisposer->verifyAndDispose( $duplicateEntityRecords );
+
+		return true;
+	}
+
+	/**
+	 * @see Maintenance::reportMessage
+	 *
+	 * @since 1.9
+	 *
+	 * @param string $message
+	 */
+	public function reportMessage( $message ) {
+		$this->output( $message );
+	}
+
+}
+
+$maintClass = 'SMW\Maintenance\RemoveDuplicateEntities';
+require_once( RUN_MAINTENANCE_IF_MAIN );

--- a/src/Maintenance/DuplicateEntitiesDisposer.php
+++ b/src/Maintenance/DuplicateEntitiesDisposer.php
@@ -1,0 +1,111 @@
+<?php
+
+namespace SMW\Maintenance;
+
+use Onoi\MessageReporter\MessageReporterAwareTrait;
+use SMW\Store;
+use SMW\SQLStore\SQLStore;
+use SMW\SQLStore\PropertyTableIdReferenceDisposer;
+
+/**
+ * @license GNU GPL v2+
+ * @since 3.0
+ *
+ * @author mwjames
+ */
+class DuplicateEntitiesDisposer {
+
+	use MessageReporterAwareTrait;
+
+	/**
+	 * @var Store
+	 */
+	private $store = null;
+
+	/**
+	 * @since 3.0
+	 *
+	 * @param Store $store
+	 */
+	public function __construct( Store $store ) {
+		$this->store = $store;
+	}
+
+	/**
+	 * @since 3.0
+	 */
+	public function findDuplicateEntityRecords() {
+		return $this->store->getObjectIds()->findDuplicateEntityRecords();
+	}
+
+	/**
+	 * @since 3.0
+	 *
+	 * @param array $duplicateEntityRecords
+	 */
+	public function verifyAndDispose( array $duplicateEntityRecords ) {
+
+		$count = count( $duplicateEntityRecords );
+		$this->messageReporter->reportMessage( "Found: $count duplicates\n" );
+
+		if ( $count > 0 ) {
+			$this->doDispose( $duplicateEntityRecords );
+		}
+	}
+
+	private function doDispose( array $duplicateEntityRecords ) {
+
+		$propertyTableIdReferenceDisposer = new PropertyTableIdReferenceDisposer(
+			$this->store
+		);
+
+		$propertyTableIdReferenceDisposer->setRedirectRemoval( true );
+		$connection = $this->store->getConnection( 'mw.db' );
+
+		$log = [
+			'disposed' => [],
+			'untouched' => []
+		];
+
+		$i = 0;
+		foreach ( $duplicateEntityRecords as $entityRecord ) {
+			unset( $entityRecord['count'] );
+
+			if ( ( $i ) % 60 === 0 ) {
+				$this->messageReporter->reportMessage( "\n" );
+			}
+
+			$this->messageReporter->reportMessage( '.' );
+
+			$res = $connection->select(
+				SQLStore::ID_TABLE,
+				[
+					'smw_id',
+				],
+				[
+					'smw_title'=> $entityRecord['smw_title'],
+					'smw_namespace'=> $entityRecord['smw_namespace'],
+					'smw_iw'=> $entityRecord['smw_iw'],
+					'smw_subobject'=> $entityRecord['smw_subobject']
+				],
+				__METHOD__
+			);
+
+			foreach ( $res as $row ) {
+				if ( $propertyTableIdReferenceDisposer->isDisposable( $row->smw_id ) ) {
+					$propertyTableIdReferenceDisposer->cleanUpTableEntriesById( $row->smw_id );
+					$log['disposed'][$row->smw_id] = $entityRecord;
+				} else {
+					$log['untouched'][$row->smw_id] = $entityRecord;
+				}
+			}
+
+			$i++;
+		}
+
+		$this->messageReporter->reportMessage(
+			"\n\nLog\n\n" . json_encode( $log, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE ) . "\n"
+		);
+	}
+
+}

--- a/src/Maintenance/MaintenanceFactory.php
+++ b/src/Maintenance/MaintenanceFactory.php
@@ -6,6 +6,7 @@ use Onoi\MessageReporter\MessageReporterFactory;
 use SMW\ApplicationFactory;
 use SMW\MediaWiki\ManualEntryLogger;
 use SMW\SQLStore\PropertyStatisticsStore;
+use SMW\Maintenance\DuplicateEntitiesDisposer;
 use SMW\SQLStore\SQLStore;
 use SMW\Store;
 
@@ -106,6 +107,27 @@ class MaintenanceFactory {
 	 */
 	public function newRebuildPropertyStatistics() {
 		return new RebuildPropertyStatistics();
+	}
+
+	/**
+	 * @since 3.0
+	 *
+	 * @return DuplicateEntitiesDisposer
+	 */
+	public function newDuplicateEntitiesDisposer( Store $store, $reporterCallback = null  ) {
+
+		$messageReporter = MessageReporterFactory::getInstance()->newObservableMessageReporter();
+		$messageReporter->registerReporterCallback( $reporterCallback );
+
+		$duplicateEntitiesDisposer = new DuplicateEntitiesDisposer(
+			$store
+		);
+
+		$duplicateEntitiesDisposer->setMessageReporter(
+			$messageReporter
+		);
+
+		return $duplicateEntitiesDisposer;
 	}
 
 	/**

--- a/src/MediaWiki/Api/Task.php
+++ b/src/MediaWiki/Api/Task.php
@@ -75,7 +75,7 @@ class Task extends ApiBase {
 			return $result + ['isFromCache' => true ];
 		}
 
-		$rows = $applicationFactory->getStore()->getObjectIds()->findDuplicateEntries();
+		$rows = $applicationFactory->getStore()->getObjectIds()->findDuplicateEntityRecords();
 
 		$result = [
 			'list' => $rows,

--- a/tests/phpunit/Unit/Maintenance/DuplicateEntitiesDisposerTest.php
+++ b/tests/phpunit/Unit/Maintenance/DuplicateEntitiesDisposerTest.php
@@ -1,0 +1,146 @@
+<?php
+
+namespace SMW\Tests\Maintenance;
+
+use FakeResultWrapper;
+use SMW\Maintenance\DuplicateEntitiesDisposer;
+
+/**
+ * @covers \SMW\Maintenance\DuplicateEntitiesDisposer
+ * @group semantic-mediawiki
+ *
+ * @license GNU GPL v2+
+ * @since 3.0
+ *
+ * @author mwjames
+ */
+class DuplicateEntitiesDisposerTest extends \PHPUnit_Framework_TestCase {
+
+	private $store;
+	private $messageReporter;
+	private $connection;
+	private $propertyTableIdReferenceFinder;
+
+	protected function setUp() {
+
+		$this->store = $this->getMockBuilder( '\SMW\SQLStore\SQLStore' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$this->propertyTableIdReferenceFinder = $this->getMockBuilder( '\SMW\SQLStore\PropertyTableIdReferenceFinder' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$this->store->expects( $this->any() )
+			->method( 'getPropertyTableIdReferenceFinder' )
+			->will( $this->returnValue( $this->propertyTableIdReferenceFinder ) );
+
+		$this->messageReporter = $this->getMockBuilder( '\Onoi\MessageReporter\MessageReporter' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$this->connection = $this->getMockBuilder( '\SMW\MediaWiki\Database' )
+			->disableOriginalConstructor()
+			->getMock();
+	}
+
+	public function testCanConstruct() {
+
+		$this->assertInstanceOf(
+			DuplicateEntitiesDisposer::class,
+			new DuplicateEntitiesDisposer( $this->store )
+		);
+	}
+
+	public function testFindDuplicateEntityRecords() {
+
+		$idTable = $this->getMockBuilder( '\stdClss' )
+			->disableOriginalConstructor()
+			->setMethods( [ 'findDuplicateEntityRecords' ] )
+			->getMock();
+
+		$this->store->expects( $this->atLeastOnce() )
+			->method( 'getObjectIds' )
+			->will( $this->returnValue( $idTable ) );
+
+		$instance = new DuplicateEntitiesDisposer(
+			$this->store
+		);
+
+		$instance->findDuplicateEntityRecords();
+	}
+
+	public function testVerifyAndDispose_NoDuplicates() {
+
+		$this->store->expects( $this->never() )
+			->method( 'getConnection' );
+
+		$instance = new DuplicateEntitiesDisposer(
+			$this->store
+		);
+
+		$instance->setMessageReporter(
+			$this->messageReporter
+		);
+
+		$instance->verifyAndDispose( [] );
+	}
+
+	public function testVerifyAndDispose_WithDuplicateRecord() {
+
+		$record = [
+			'smw_title' => 'Foo',
+			'smw_namespace' => 0,
+			'smw_iw' => '',
+			'smw_subobject' => ''
+		];
+
+		$row = new \stdClass;
+		$row->smw_id = 42;
+
+		$this->connection->expects( $this->atLeastOnce() )
+			->method( 'select' )
+			->with(
+				$this->anything(),
+				$this->anything(),
+				$this->equalTo( $record ),
+				$this->anything() )
+			->will( $this->returnValue( [ $row ] ) );
+
+		$this->store->expects( $this->atLeastOnce() )
+			->method( 'getConnection' )
+			->will( $this->returnValue( $this->connection ) );
+
+		$idTable = $this->getMockBuilder( '\stdClss' )
+			->disableOriginalConstructor()
+			->setMethods( [ 'getDataItemById' ] )
+			->getMock();
+
+		$this->store->expects( $this->atLeastOnce() )
+			->method( 'getObjectIds' )
+			->will( $this->returnValue( $idTable ) );
+
+		$this->store->expects( $this->any() )
+			->method( 'getPropertyTables' )
+			->will( $this->returnValue( [] ) );
+
+		$this->propertyTableIdReferenceFinder->expects( $this->atLeastOnce() )
+			->method( 'hasResidualReferenceForId' )
+			->will( $this->returnValue( false ) );
+
+		$instance = new DuplicateEntitiesDisposer(
+			$this->store
+		);
+
+		$instance->setMessageReporter(
+			$this->messageReporter
+		);
+
+		$duplicates = [
+			$record
+		];
+
+		$instance->verifyAndDispose( $duplicates );
+	}
+
+}

--- a/tests/phpunit/Unit/Maintenance/MaintenanceFactoryTest.php
+++ b/tests/phpunit/Unit/Maintenance/MaintenanceFactoryTest.php
@@ -83,6 +83,16 @@ class MaintenanceFactoryTest extends \PHPUnit_Framework_TestCase {
 		);
 	}
 
+	public function testCanConstructDuplicateEntitiesDisposer() {
+
+		$instance = new MaintenanceFactory();
+
+		$this->assertInstanceOf(
+			'\SMW\Maintenance\DuplicateEntitiesDisposer',
+			$instance->newDuplicateEntitiesDisposer( $this->store )
+		);
+	}
+
 	public function testCanConstructMaintenanceLogger() {
 
 		$instance = new MaintenanceFactory();

--- a/tests/phpunit/Unit/MediaWiki/Api/TaskTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Api/TaskTest.php
@@ -95,7 +95,7 @@ class TaskTest extends \PHPUnit_Framework_TestCase {
 			->getMock();
 
 		$entityTable->expects( $this->atLeastOnce() )
-			->method( 'findDuplicateEntries' )
+			->method( 'findDuplicateEntityRecords' )
 			->will( $this->returnValue( [] ) );
 
 		$store = $this->getMockBuilder( '\SMW\SQLStore\SQLStore' )

--- a/tests/phpunit/Unit/SQLStore/PropertyTableIdReferenceDisposerTest.php
+++ b/tests/phpunit/Unit/SQLStore/PropertyTableIdReferenceDisposerTest.php
@@ -60,8 +60,32 @@ class PropertyTableIdReferenceDisposerTest extends \PHPUnit_Framework_TestCase {
 	public function testCanConstruct() {
 
 		$this->assertInstanceOf(
-			'\SMW\SQLStore\PropertyTableIdReferenceDisposer',
+			PropertyTableIdReferenceDisposer::class,
 			new PropertyTableIdReferenceDisposer( $this->store )
+		);
+	}
+
+	public function testIsDisposable() {
+
+		$propertyTableIdReferenceFinder = $connection = $this->getMockBuilder( '\SMW\SQLStore\PropertyTableIdReferenceFinder' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$propertyTableIdReferenceFinder->expects( $this->any() )
+			->method( 'hasResidualReferenceForId' )
+			->with( $this->equalTo( 42 ) )
+			->will( $this->returnValue( false ) );
+
+		$this->store->expects( $this->any() )
+			->method( 'getPropertyTableIdReferenceFinder' )
+			->will( $this->returnValue( $propertyTableIdReferenceFinder ) );
+
+		$instance = new PropertyTableIdReferenceDisposer(
+			$this->store
+		);
+
+		$this->assertTrue(
+			$instance->isDisposable( 42 )
 		);
 	}
 

--- a/tests/phpunit/includes/storage/sqlstore/SQLStoreSmwIdsTest.php
+++ b/tests/phpunit/includes/storage/sqlstore/SQLStoreSmwIdsTest.php
@@ -355,7 +355,7 @@ class SQLStoreSmwIdsTest extends \PHPUnit_Framework_TestCase {
 
 		$this->assertEquals(
 			[ $expected ],
-			$instance->findDuplicateEntries()
+			$instance->findDuplicateEntityRecords()
 		);
 	}
 


### PR DESCRIPTION
This PR is made in reference to: #2883

This PR addresses or contains:

- Adds the `removeDuplicateEntities.php` maintenance script to remove all duplicate entities with non-residual references (meaning those that have no reference in any other table) from the entity table

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed

Fixes #