### PR TITLE
Add smwgDefaultLoggerRole

### DIFF
--- a/DefaultSettings.php
+++ b/DefaultSettings.php
@@ -75,6 +75,27 @@ return array(
 	'smwgDefaultStore' => "SMWSQLStore3",
 	##
 
+	##
+	# Debug logger role
+	#
+	# A role (developer, user, production) defines the detail of information
+	# (granularity) that are expected to be logged. Roles include:
+	#
+	# - `developer` outputs any loggable event produced by SMW
+	# - `user` outputs certain events deemed important
+	# - `production` outputs a minimal set of events produced by SMW
+	#
+	# Logging only happens in case `$wgDebugLogFile` or `$wgDebugLogGroups`
+	# are actively maintained.
+	#
+	# @see https://www.mediawiki.org/wiki/Manual:How_to_debug#Logging
+	#
+	# @since 3.0
+	# @default production
+	##
+	'smwgDefaultLoggerRole' => 'production',
+	##
+
 	###
 	# Local connection configurations
 	#

--- a/includes/Settings.php
+++ b/includes/Settings.php
@@ -54,6 +54,7 @@ class Settings extends Options {
 			'smwgJobQueueWatchlist' => $GLOBALS['smwgJobQueueWatchlist'],
 			'smwgEnabledCompatibilityMode' => $GLOBALS['smwgEnabledCompatibilityMode'],
 			'smwgDefaultStore' => $GLOBALS['smwgDefaultStore'],
+			'smwgDefaultLoggerRole' => $GLOBALS['smwgDefaultLoggerRole'],
 			'smwgLocalConnectionConf' => $GLOBALS['smwgLocalConnectionConf'],
 			'smwgSparqlRepositoryConnector' => $GLOBALS['smwgSparqlRepositoryConnector'],
 			'smwgSparqlCustomConnector' => $GLOBALS['smwgSparqlCustomConnector'],

--- a/includes/storage/SQLStore/SMW_SQLStore3_Writers.php
+++ b/includes/storage/SQLStore/SMW_SQLStore3_Writers.php
@@ -940,7 +940,8 @@ class SMWSQLStore3Writers {
 
 		$jobFactory = ApplicationFactory::getInstance()->newJobFactory();
 		$parameters = array(
-			UpdateJob::FORCED_UPDATE => true
+			UpdateJob::FORCED_UPDATE => true,
+			'origin' => 'Store::changeTitle'
 		);
 
 		if ( $redirectId != 0 ) {

--- a/includes/storage/StoreFactory.php
+++ b/includes/storage/StoreFactory.php
@@ -5,7 +5,7 @@ namespace SMW;
 use RuntimeException;
 use SMW\Exception\StoreNotFoundException;
 use Onoi\MessageReporter\NullMessageReporter;
-use Onoi\MessageReporter\MessageReporterAware;
+use Psr\Log\NullLogger;
 
 /**
  * Factory method that returns an instance of the default store, or an
@@ -27,11 +27,6 @@ class StoreFactory {
 	private static $instance = array();
 
 	/**
-	 * @var null
-	 */
-	private static $defaultStore = null;
-
-	/**
 	 * @since 1.9
 	 *
 	 * @param string|null $store
@@ -42,12 +37,8 @@ class StoreFactory {
 	 */
 	public static function getStore( $store = null ) {
 
-		if ( self::$defaultStore === null ) {
-			self::$defaultStore = self::getConfiguration()->get( 'smwgDefaultStore' );
-		}
-
 		if ( $store === null ) {
-			$store = self::$defaultStore;
+			$store = $GLOBALS['smwgDefaultStore'];
 		}
 
 		if ( !isset( self::$instance[$store] ) ) {
@@ -62,11 +53,6 @@ class StoreFactory {
 	 */
 	public static function clear() {
 		self::$instance = array();
-		self::$defaultStore = null;
-	}
-
-	private static function getConfiguration() {
-		return Settings::newFromGlobals();
 	}
 
 	private static function newInstance( $store ) {
@@ -81,11 +67,8 @@ class StoreFactory {
 			throw new StoreNotFoundException( "{$store} can not be used as a store instance" );
 		}
 
-		// Traits cannot implement an interface (really!!) so we check for the
-		// method otherwise we would use an interface
-		if ( method_exists( $instance, 'setMessageReporter' ) ) {
-			$instance->setMessageReporter( new NullMessageReporter() );
-		}
+		$instance->setMessageReporter( new NullMessageReporter() );
+		$instance->setLogger( new NullLogger() );
 
 		return $instance;
 	}

--- a/src/ApplicationFactory.php
+++ b/src/ApplicationFactory.php
@@ -548,8 +548,8 @@ class ApplicationFactory {
 	 *
 	 * @return LoggerInterface
 	 */
-	public function getMediaWikiLogger() {
-		return $this->containerBuilder->singleton( 'MediaWikiLogger' );
+	public function getMediaWikiLogger( $channel = 'smw' ) {
+		return $this->containerBuilder->singleton( 'MediaWikiLogger', $channel, $GLOBALS['smwgDefaultLoggerRole'] );
 	}
 
 	/**

--- a/src/EventListenerRegistry.php
+++ b/src/EventListenerRegistry.php
@@ -21,6 +21,11 @@ class EventListenerRegistry implements EventListenerCollection {
 	private $eventListenerCollection = null;
 
 	/**
+	 * @var LoggerInterface
+	 */
+	private $logger;
+
+	/**
 	 * @since 2.2
 	 *
 	 * @param EventListenerCollection $eventListenerCollection
@@ -39,6 +44,8 @@ class EventListenerRegistry implements EventListenerCollection {
 	}
 
 	private function addListenersToCollection() {
+
+		$this->logger = ApplicationFactory::getInstance()->getMediaWikiLogger();
 
 		/**
 		 * Emitted during UpdateJob, ArticlePurge
@@ -85,9 +92,14 @@ class EventListenerRegistry implements EventListenerCollection {
 				}
 
 				$applicationFactory = ApplicationFactory::getInstance();
-				$applicationFactory->getMediaWikiLogger()->info(
-					'Event (cached.propertyvalues.prefetcher.reset) on ' . $subject->getHash()
-				);
+
+				$context = [
+					'role' => 'developer',
+					'event' => 'cached.propertyvalues.prefetcher.reset',
+					'origin' => $subject
+				];
+
+				$this->logger->info( '[Event] {event}: {origin}', $context );
 
 				$applicationFactory->singleton( 'CachedPropertyValuesPrefetcher' )->resetCacheBy(
 					$subject
@@ -113,9 +125,14 @@ class EventListenerRegistry implements EventListenerCollection {
 				$context = $dispatchContext->has( 'context' ) ? $dispatchContext->get( 'context' ) : '';
 
 				$applicationFactory = ApplicationFactory::getInstance();
-				$applicationFactory->getMediaWikiLogger()->info(
-					'Event (cached.prefetcher.reset) on ' . $subject->getHash()
-				);
+
+				$context = [
+					'role' => 'developer',
+					'event' => 'cached.prefetcher.reset',
+					'origin' => $subject
+				];
+
+				$this->logger->info( '[Event] {event}: {origin}', $context );
 
 				$applicationFactory->singleton( 'CachedPropertyValuesPrefetcher' )->resetCacheBy(
 					$subject

--- a/src/HierarchyLookup.php
+++ b/src/HierarchyLookup.php
@@ -4,8 +4,7 @@ namespace SMW;
 
 use Onoi\Cache\Cache;
 use SMW\Store;
-use Psr\Log\LoggerInterface;
-use Psr\Log\LoggerAwareInterface;
+use Psr\Log\LoggerAwareTrait;
 use InvalidArgumentException;
 
 /**
@@ -14,7 +13,9 @@ use InvalidArgumentException;
  *
  * @author mwjames
  */
-class HierarchyLookup implements LoggerAwareInterface {
+class HierarchyLookup {
+
+	use LoggerAwareTrait;
 
 	/**
 	 * Persistent cache namespace
@@ -46,11 +47,6 @@ class HierarchyLookup implements LoggerAwareInterface {
 	 * @var integer
 	 */
 	private $cacheTTL;
-
-	/**
-	 * @var LoggerInterface
-	 */
-	private $logger;
 
 	/**
 	 * Use 0 to disable the hierarchy lookup
@@ -109,17 +105,6 @@ class HierarchyLookup implements LoggerAwareInterface {
 		};
 
 		$changePropListener->addListenerCallback( '_SUBC', $callback );
-	}
-
-	/**
-	 * @see LoggerAwareInterface::setLogger
-	 *
-	 * @since 2.5
-	 *
-	 * @param LoggerInterface $logger
-	 */
-	public function setLogger( LoggerInterface $logger ) {
-		$this->logger = $logger;
 	}
 
 	/**
@@ -356,25 +341,16 @@ class HierarchyLookup implements LoggerAwareInterface {
 
 		$this->inMemoryCache[$key] = $res;
 
-		$this->log(
-			"{fname} ID: {id}, subject: {subject}",
-			[
-				'fname' => __METHOD__,
-				'id' => $id,
-				'subject' => $subject->getDBKey()
-			]
-		);
+		$context = [
+			'method' => __METHOD__,
+			'role' => 'user',
+			'id' => $id,
+			'origin' => $subject
+		];
+
+		$this->logger->info( "[HierarchyLookup] Lookup: {id}, {origin}", $context );
 
 		return $res;
-	}
-
-	private function log( $message, $context = array() ) {
-
-		if ( $this->logger === null ) {
-			return;
-		}
-
-		$this->logger->info( $message, $context );
 	}
 
 }

--- a/src/MediaWiki/DBConnectionProvider.php
+++ b/src/MediaWiki/DBConnectionProvider.php
@@ -128,16 +128,14 @@ class DBConnectionProvider implements ConnectionProvider {
 		// Only required because of SQlite
 		$connection->setDBPrefix( $GLOBALS['wgDBprefix'] );
 
-		if ( $this->logger !== null ) {
-			$this->logger->info(
-				"Init '{provider}' connection provider with [read:{read}, write:{write}]",
-				[
-					'provider' => $this->provider,
-					'read' => $connectionConf['read'],
-					'write' => $connectionConf['write']
-				]
-			);
-		}
+		$context = [
+			'role' => 'developer',
+			'provider' => $this->provider,
+			'read' => $connectionConf['read'],
+			'write' => $connectionConf['write'],
+		];
+
+		$this->logger->info( "[Connection] '{provider}': [read:{read}, write:{write}]", $context );
 
 		return $connection;
 	}

--- a/src/MediaWiki/Hooks/ArticleDelete.php
+++ b/src/MediaWiki/Hooks/ArticleDelete.php
@@ -89,6 +89,8 @@ class ArticleDelete extends HookHandler {
 			$semanticData
 		);
 
+		$parameters['origin'] = 'ArticleDelete';
+
 		// Restricted to the available SemanticData
 		$parameters[UpdateDispatcherJob::RESTRICTED_DISPATCH_POOL] = true;
 

--- a/src/MediaWiki/Jobs/ChangePropagationClassUpdateJob.php
+++ b/src/MediaWiki/Jobs/ChangePropagationClassUpdateJob.php
@@ -23,6 +23,11 @@ class ChangePropagationClassUpdateJob extends ChangePropagationUpdateJob {
 	 * @param array $params job parameters
 	 */
 	public function __construct( Title $title, $params = array() ) {
+
+		$params = $params + [
+			'origin' => 'ChangePropagationClassUpdateJob'
+		];
+
 		parent::__construct( $title, $params, 'SMW\ChangePropagationClassUpdateJob' );
 	}
 

--- a/src/MediaWiki/Jobs/ChangePropagationDispatchJob.php
+++ b/src/MediaWiki/Jobs/ChangePropagationDispatchJob.php
@@ -412,6 +412,7 @@ class ChangePropagationDispatchJob extends JobBase {
 	private function newChangePropagationUpdateJob( $title, $parameters ) {
 
 		$namespace = $this->getTitle()->getNamespace();
+		$parameters =  $parameters + [ 'origin' => 'ChangePropagationDispatchJob' ];
 
 		if ( $namespace === NS_CATEGORY ) {
 			return new ChangePropagationClassUpdateJob( $title, $parameters );

--- a/src/MediaWiki/Jobs/ChangePropagationUpdateJob.php
+++ b/src/MediaWiki/Jobs/ChangePropagationUpdateJob.php
@@ -50,7 +50,7 @@ class ChangePropagationUpdateJob extends JobBase {
 
 		$updateJob = new UpdateJob(
 			$this->getTitle(),
-			$this->params
+			$this->params + [ 'origin' => 'ChangePropagationUpdateJob' ]
 		);
 
 		$updateJob->run();

--- a/src/MediaWiki/Jobs/JobBase.php
+++ b/src/MediaWiki/Jobs/JobBase.php
@@ -119,8 +119,18 @@ abstract class JobBase extends Job {
 	 *
 	 * @return boolean
 	 */
-	public function getParameter( $key ) {
-		return $this->hasParameter( $key ) ? $this->params[$key] : false;
+	public function getParameter( $key, $default = false ) {
+		return $this->hasParameter( $key ) ? $this->params[$key] : $default;
+	}
+
+	/**
+	 * @since  3.0
+	 *
+	 * @param mixed $key
+	 * @param mixed $value
+	 */
+	public function setParameter( $key, $value ) {
+		$this->params[$key] = $value;
 	}
 
 	/**

--- a/src/MediaWiki/Jobs/ParserCachePurgeJob.php
+++ b/src/MediaWiki/Jobs/ParserCachePurgeJob.php
@@ -107,16 +107,19 @@ class ParserCachePurgeJob extends JobBase {
 
 		Hooks::run( 'SMW::Job::AfterParserCachePurgeComplete', array( $this ) );
 
+		$context = [
+			'method'  => __METHOD__,
+			'role' => 'user',
+			'procTime' => Timer::getElapsedTime( __METHOD__, 7 ),
+			'limit'  => $this->limit,
+			'offset' => $this->offset,
+			'count'  => $count,
+			'links'  => $links
+		];
+
 		$this->applicationFactory->getMediaWikiLogger()->info(
-			"{fname} (procTime in sec: {time}) | C:{count} LC:{links} | L:{limit} O:{offset}",
-			[
-				'fname'  => __METHOD__,
-				'time'   => Timer::getElapsedTime( __METHOD__, 7 ),
-				'limit'  => $this->limit,
-				'offset' => $this->offset,
-				'count'  => $count,
-				'links'  => $links
-			]
+			"[Job] ParserCachePurgeJob: Count:{count} Links:{links} | Limit:{limit} Offset:{offset} (procTime in sec: {procTime})",
+			$context
 		);
 
 		return true;

--- a/src/MediaWiki/Jobs/UpdateDispatcherJob.php
+++ b/src/MediaWiki/Jobs/UpdateDispatcherJob.php
@@ -192,7 +192,8 @@ class UpdateDispatcherJob extends JobBase {
 	private function createUpdateJobsFromJobList( array $subjects ) {
 
 		$parameters = array(
-			UpdateJob::FORCED_UPDATE => true
+			UpdateJob::FORCED_UPDATE => true,
+			'origin' => $this->getParameter( 'origin', 'UpdateDispatcherJob' )
 		);
 
 		// We expect non-duplicate subjects in the list and therefore deserialize

--- a/src/MediaWiki/PageUpdater.php
+++ b/src/MediaWiki/PageUpdater.php
@@ -3,8 +3,7 @@
 namespace SMW\MediaWiki;
 
 use Title;
-use Psr\Log\LoggerInterface;
-use Psr\Log\LoggerAwareInterface;
+use Psr\Log\LoggerAwareTrait;
 use SMW\Utils\Timer;
 use DeferrableUpdate;
 use DeferredpendingUpdates;
@@ -17,7 +16,9 @@ use SMW\MediaWiki\Database;
  *
  * @author mwjames
  */
-class PageUpdater implements LoggerAwareInterface, DeferrableUpdate {
+class PageUpdater implements DeferrableUpdate {
+
+	use LoggerAwareTrait;
 
 	/**
 	 * @var DeferredTransactionalUpdate
@@ -33,11 +34,6 @@ class PageUpdater implements LoggerAwareInterface, DeferrableUpdate {
 	 * @var Title[]
 	 */
 	private $titles = array();
-
-	/**
-	 * LoggerInterface
-	 */
-	private $logger;
 
 	/**
 	 * @var string
@@ -83,17 +79,6 @@ class PageUpdater implements LoggerAwareInterface, DeferrableUpdate {
 	public function __construct( Database $connection = null, DeferredTransactionalUpdate $deferredTransactionalUpdate = null ) {
 		$this->connection = $connection;
 		$this->deferredTransactionalUpdate = $deferredTransactionalUpdate;
-	}
-
-	/**
-	 * @see LoggerAwareInterface::setLogger
-	 *
-	 * @since 2.5
-	 *
-	 * @param LoggerInterface $logger
-	 */
-	public function setLogger( LoggerInterface $logger ) {
-		$this->logger = $logger;
 	}
 
 	/**
@@ -338,16 +323,13 @@ class PageUpdater implements LoggerAwareInterface, DeferrableUpdate {
 			__METHOD__
 		);
 
-		$this->log( __METHOD__ . ' (procTime in sec: ' . Timer::getElapsedTime( __METHOD__, 7 ) . ')' );
-	}
+		$context = [
+			'method' => __METHOD__,
+			'procTime' => Timer::getElapsedTime( __METHOD__, 7 ),
+			'role' => 'developer'
+		];
 
-	private function log( $message, $context = array() ) {
-
-		if ( $this->logger === null ) {
-			return;
-		}
-
-		$this->logger->info( $message, $context );
+		$this->logger->info( 'Page update, pool update (procTime in sec: {procTime})', $context );
 	}
 
 }

--- a/src/ParserData.php
+++ b/src/ParserData.php
@@ -415,7 +415,14 @@ class ParserData {
 		$latestRevID = $this->title->getLatestRevID( Title::GAID_FOR_UPDATE );
 
 		if ( $this->skipUpdateOn( $latestRevID ) ) {
-			return $applicationFactory->getMediaWikiLogger()->info( __METHOD__ . " (Found rev:$latestRevID, skip update)" );
+
+			$context = [
+				'method' => __METHOD__,
+				'role' => 'user',
+				'revID' => $latestRevID
+			];
+
+			return $applicationFactory->getMediaWikiLogger()->info( 'Update (Found rev:{revID}, skip update)' );
 		}
 
 		$this->semanticData->setOption(

--- a/src/Query/Result/CachedQueryResultPrefetcher.php
+++ b/src/Query/Result/CachedQueryResultPrefetcher.php
@@ -299,6 +299,10 @@ class CachedQueryResultPrefetcher implements QueryEngine, LoggerAwareInterface {
 		$recordStats = false;
 		$context = $context === '' ? 'Undefined' : $context;
 
+		if ( is_array( $context ) ) {
+			$context = implode( '.', $context );
+		}
+
 		foreach ( $items as $item ) {
 			$id = $this->getHashFrom( $item );
 			$this->tempCache->delete( $id );

--- a/src/SQLStore/EntityRebuildDispatcher.php
+++ b/src/SQLStore/EntityRebuildDispatcher.php
@@ -420,7 +420,7 @@ class EntityRebuildDispatcher {
 	}
 
 	private function newUpdateJob( $title ) {
-		return $this->jobFactory->newUpdateJob( $title, array( 'pm' => $this->updateJobParseMode ) );
+		return $this->jobFactory->newUpdateJob( $title, array( 'pm' => $this->updateJobParseMode, 'origin' => 'EntityRebuildDispatcher' ) );
 	}
 
 }

--- a/src/SQLStore/QueryDependency/EntityIdListRelevanceDetectionFilter.php
+++ b/src/SQLStore/QueryDependency/EntityIdListRelevanceDetectionFilter.php
@@ -5,8 +5,7 @@ namespace SMW\SQLStore\QueryDependency;
 use SMW\SQLStore\ChangeOp\ChangeOp;
 use SMW\SQLStore\SQLStore;
 use SMW\Store;
-use Psr\Log\LoggerInterface;
-use Psr\Log\LoggerAwareInterface;
+use Psr\Log\LoggerAwareTrait;
 use SMW\Utils\Timer;
 
 /**
@@ -25,7 +24,9 @@ use SMW\Utils\Timer;
  *
  * @author mwjames
  */
-class EntityIdListRelevanceDetectionFilter implements LoggerAwareInterface {
+class EntityIdListRelevanceDetectionFilter {
+
+	use LoggerAwareTrait;
 
 	/**
 	 * @var Store
@@ -48,11 +49,6 @@ class EntityIdListRelevanceDetectionFilter implements LoggerAwareInterface {
 	private $affiliatePropertyDetectionList = array();
 
 	/**
-	 * @var LoggerInterface
-	 */
-	private $logger;
-
-	/**
 	 * @since 2.4
 	 *
 	 * @param Store $store
@@ -61,17 +57,6 @@ class EntityIdListRelevanceDetectionFilter implements LoggerAwareInterface {
 	public function __construct( Store $store, ChangeOp $changeOp ) {
 		$this->store = $store;
 		$this->changeOp = $changeOp;
-	}
-
-	/**
-	 * @see LoggerAwareInterface::setLogger
-	 *
-	 * @since 2.5
-	 *
-	 * @param LoggerInterface $logger
-	 */
-	public function setLogger( LoggerInterface $logger ) {
-		$this->logger = $logger;
 	}
 
 	/**
@@ -125,7 +110,13 @@ class EntityIdListRelevanceDetectionFilter implements LoggerAwareInterface {
 			array_keys( $affiliateEntityList )
 		);
 
-		$this->log( __METHOD__ . ' procTime (sec): ' . Timer::getElapsedTime( __CLASS__, 6 ) );
+		$context = [
+			'method' => __METHOD__,
+			'role' => 'developer',
+			'procTime' => Timer::getElapsedTime( __CLASS__, 6 )
+		];
+
+		$this->logger->info( '[QueryDependency] Filter changeOp list (procTime in sec: {procTime})', $context );
 
 		return $filteredIdList;
 	}
@@ -185,15 +176,6 @@ class EntityIdListRelevanceDetectionFilter implements LoggerAwareInterface {
 		if ( $fieldChangeOp->has( 's_id' ) ) {
 			unset( $changedEntityIdSummaryList[$fieldChangeOp->get( 's_id' )] );
 		}
-	}
-
-	private function log( $message, $context = array() ) {
-
-		if ( $this->logger === null ) {
-			return;
-		}
-
-		$this->logger->info( $message, $context );
 	}
 
 }

--- a/src/Services/MediaWikiServices.php
+++ b/src/Services/MediaWikiServices.php
@@ -10,6 +10,7 @@ use WikiImporter;
 use LBFactory;
 use JobQueueGroup;
 use Psr\Log\NullLogger;
+use SMW\Utils\Logger;
 
 /**
  * @codeCoverageIgnore
@@ -132,15 +133,17 @@ return array(
 	 *
 	 * @return callable
 	 */
-	'MediaWikiLogger' => function( $containerBuilder ) {
+	'MediaWikiLogger' => function( $containerBuilder, $channel = 'smw', $role = Logger::ROLE_DEVELOPER ) {
 
 		$containerBuilder->registerExpectedReturnType( 'MediaWikiLogger', '\Psr\Log\LoggerInterface' );
 
 		if ( class_exists( '\MediaWiki\Logger\LoggerFactory' ) ) {
-			return LoggerFactory::getInstance( 'smw' );
+			$logger = LoggerFactory::getInstance( $channel );
+		} else {
+			$logger = new NullLogger();
 		}
 
-		return new NullLogger();
+		return new Logger( $logger, $role );
 	},
 
 	/**

--- a/src/Services/SharedServicesContainer.php
+++ b/src/Services/SharedServicesContainer.php
@@ -94,6 +94,10 @@ class SharedServicesContainer implements CallbackContainer {
 				$store->setOption( $config, $settings->get( $config ) );
 			}
 
+			$store->setLogger(
+				$containerBuilder->singleton( 'MediaWikiLogger' )
+			);
+
 			return $store;
 		} );
 
@@ -199,7 +203,14 @@ class SharedServicesContainer implements CallbackContainer {
 		 */
 		$containerBuilder->registerCallback( 'DBConnectionProvider', function( $containerBuilder ) {
 			$containerBuilder->registerExpectedReturnType( 'DBConnectionProvider', '\SMW\MediaWiki\DBConnectionProvider' );
-			return new DBConnectionProvider();
+
+			$dbConnectionProvider = new DBConnectionProvider();
+
+			$dbConnectionProvider->setLogger(
+				$containerBuilder->singleton( 'MediaWikiLogger' )
+			);
+
+			return $dbConnectionProvider;
 		} );
 
 		/**

--- a/src/Utils/Logger.php
+++ b/src/Utils/Logger.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace SMW\Utils;
+
+use Psr\Log\AbstractLogger;
+use Psr\Log\LoggerInterface;
+
+/**
+ * @license GNU GPL v2+
+ * @since 3.0
+ *
+ * @author mwjames
+ */
+class Logger extends AbstractLogger {
+
+	const ROLE_DEVELOPER = 'developer';
+	const ROLE_USER = 'user';
+	const ROLE_PRODUCTION = 'production';
+
+	/**
+	 * @var LoggerInterface
+	 */
+	protected $logger;
+
+	/**
+	 * @var string
+	 */
+	protected $role;
+
+	/**
+	 * @since 3.0
+	 *
+	 * @param LoggerInterface $logger
+	 * @param string $role
+	 */
+	public function __construct( LoggerInterface $logger, $role = self::ROLE_DEVELOPER ) {
+		$this->logger = $logger;
+		$this->role = $role;
+	}
+
+	/**
+	 * @since 3.0
+	 *
+	 * {@inheritDoc}
+	 */
+	public function log( $level, $message, array $context = array() ) {
+
+		$canLog = false;
+
+		// Everthings goes for the developer role!
+		if ( $this->role === self::ROLE_DEVELOPER ) {
+			$canLog = true;
+		} elseif ( isset( $context['role'] ) && $context['role'] === $this->role ) {
+			$canLog = true;
+		} elseif ( isset( $context['role'] ) && $context['role'] === self::ROLE_PRODUCTION && $this->role === self::ROLE_USER ) {
+			$canLog = true;
+		}
+
+		if ( $canLog ) {
+			$this->logger->log( $level, $message, $context );
+		}
+	}
+
+}

--- a/tests/phpunit/TestEnvironment.php
+++ b/tests/phpunit/TestEnvironment.php
@@ -198,6 +198,15 @@ class TestEnvironment {
 	}
 
 	/**
+	 * @since 3.0
+	 *
+	 * @return SpyLogger
+	 */
+	public static function newSpyLogger() {
+		return self::getUtilityFactory()->newSpyLogger();
+	}
+
+	/**
 	 * @since 2.5
 	 *
 	 * @param integer $index

--- a/tests/phpunit/Unit/HierarchyLookupTest.php
+++ b/tests/phpunit/Unit/HierarchyLookupTest.php
@@ -5,6 +5,7 @@ namespace SMW\Tests;
 use SMW\DIProperty;
 use SMW\DIWikiPage;
 use SMW\HierarchyLookup;
+use SMW\Tests\TestEnvironment;
 
 /**
  * @covers \SMW\HierarchyLookup
@@ -19,8 +20,11 @@ class HierarchyLookupTest extends \PHPUnit_Framework_TestCase {
 
 	private $store;
 	private $cache;
+	private $spyLogger;
 
 	protected function setUp() {
+
+		$this->spyLogger = TestEnvironment::newSpyLogger();
 
 		$this->store = $this->getMockBuilder( '\SMW\Store' )
 			->disableOriginalConstructor()
@@ -62,6 +66,10 @@ class HierarchyLookupTest extends \PHPUnit_Framework_TestCase {
 			$this->cache
 		);
 
+		$instance->setLogger(
+			$this->spyLogger
+		);
+
 		$instance->addListenersTo( $changePropListener );
 	}
 
@@ -82,6 +90,10 @@ class HierarchyLookupTest extends \PHPUnit_Framework_TestCase {
 		$instance = new HierarchyLookup(
 			$store,
 			$cache
+		);
+
+		$instance->setLogger(
+			$this->spyLogger
 		);
 
 		$property = new DIProperty( 'Foo' );
@@ -120,6 +132,10 @@ class HierarchyLookupTest extends \PHPUnit_Framework_TestCase {
 		$instance = new HierarchyLookup(
 			$store,
 			$cache
+		);
+
+		$instance->setLogger(
+			$this->spyLogger
 		);
 
 		$this->assertEquals(
@@ -172,6 +188,10 @@ class HierarchyLookupTest extends \PHPUnit_Framework_TestCase {
 			$this->cache
 		);
 
+		$instance->setLogger(
+			$this->spyLogger
+		);
+
 		$instance->setSubpropertyDepth( 2 );
 
 		$this->assertEquals(
@@ -199,6 +219,10 @@ class HierarchyLookupTest extends \PHPUnit_Framework_TestCase {
 		$instance = new HierarchyLookup(
 			$this->store,
 			$this->cache
+		);
+
+		$instance->setLogger(
+			$this->spyLogger
 		);
 
 		$instance->setSubpropertyDepth( 2 );
@@ -253,6 +277,10 @@ class HierarchyLookupTest extends \PHPUnit_Framework_TestCase {
 			$this->cache
 		);
 
+		$instance->setLogger(
+			$this->spyLogger
+		);
+
 		$instance->setSubcategoryDepth( 2 );
 
 		$this->assertEquals(
@@ -280,6 +308,10 @@ class HierarchyLookupTest extends \PHPUnit_Framework_TestCase {
 		$instance = new HierarchyLookup(
 			$this->store,
 			$this->cache
+		);
+
+		$instance->setLogger(
+			$this->spyLogger
 		);
 
 		$instance->setSubcategoryDepth( 2 );
@@ -329,6 +361,10 @@ class HierarchyLookupTest extends \PHPUnit_Framework_TestCase {
 		$instance = new HierarchyLookup(
 			$store,
 			$cache
+		);
+
+		$instance->setLogger(
+			$this->spyLogger
 		);
 
 		$this->assertEquals(

--- a/tests/phpunit/Unit/Maintenance/DistinctEntityDataRebuilderTest.php
+++ b/tests/phpunit/Unit/Maintenance/DistinctEntityDataRebuilderTest.php
@@ -32,10 +32,14 @@ class DistinctEntityDataRebuilderTest extends \PHPUnit_Framework_TestCase {
 			->disableOriginalConstructor()
 			->getMockForAbstractClass();
 
-		$store->getOptions()->set( 'smwgSemanticsEnabled', true );
-		$store->getOptions()->set( 'smwgAutoRefreshSubject', true );
+		$store->setOption( 'smwgSemanticsEnabled', true );
+		$store->setOption( 'smwgAutoRefreshSubject', true );
 
 		$this->testEnvironment = new TestEnvironment();
+		$spyLogger = $this->testEnvironment->newSpyLogger();
+
+		$store->setLogger( $spyLogger );
+
 		$this->testEnvironment->registerObject( 'Store', $store );
 
 		$connection = $this->getMockBuilder( '\SMW\MediaWiki\Database' )

--- a/tests/phpunit/Unit/MediaWiki/DBConnectionProviderTest.php
+++ b/tests/phpunit/Unit/MediaWiki/DBConnectionProviderTest.php
@@ -3,6 +3,7 @@
 namespace SMW\Tests\MediaWiki;
 
 use SMW\MediaWiki\DBConnectionProvider;
+use SMW\Tests\TestEnvironment;
 
 /**
  * @covers \SMW\MediaWiki\DBConnectionProvider
@@ -25,6 +26,9 @@ class DBConnectionProviderTest extends \PHPUnit_Framework_TestCase {
 	public function testGetConnection() {
 
 		$instance = new DBConnectionProvider();
+		$instance->setLogger(
+			TestEnvironment::newSpyLogger()
+		);
 
 		$connection = $instance->getConnection();
 
@@ -50,6 +54,10 @@ class DBConnectionProviderTest extends \PHPUnit_Framework_TestCase {
 
 		$instance = new DBConnectionProvider(
 			'foo'
+		);
+
+		$instance->setLogger(
+			TestEnvironment::newSpyLogger()
 		);
 
 		$conf = array(

--- a/tests/phpunit/Unit/MediaWiki/PageUpdaterTest.php
+++ b/tests/phpunit/Unit/MediaWiki/PageUpdaterTest.php
@@ -3,6 +3,7 @@
 namespace SMW\Tests\MediaWiki;
 
 use SMW\MediaWiki\PageUpdater;
+use SMW\Tests\TestEnvironment;
 
 /**
  * @covers \SMW\MediaWiki\PageUpdater
@@ -16,9 +17,12 @@ use SMW\MediaWiki\PageUpdater;
 class PageUpdaterTest extends \PHPUnit_Framework_TestCase {
 
 	private $connection;
+	private $spyLogger;
 
 	protected function setUp() {
 		parent::setup();
+
+		$this->spyLogger = TestEnvironment::newSpyLogger();
 
 		$this->connection = $this->getMockBuilder( '\SMW\MediaWiki\Database' )
 			->disableOriginalConstructor()
@@ -276,6 +280,7 @@ class PageUpdaterTest extends \PHPUnit_Framework_TestCase {
 			->method( 'invalidateCache' );
 
 		$instance = new PageUpdater( $this->connection );
+		$instance->setLogger( $this->spyLogger );
 		$instance->addPage( $title );
 
 		$instance->waitOnTransactionIdle();

--- a/tests/phpunit/Unit/MediaWiki/Specials/SpecialDeferredRequestDispatcherTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Specials/SpecialDeferredRequestDispatcherTest.php
@@ -4,7 +4,7 @@ namespace SMW\Tests\MediaWiki\Specials;
 
 use SMW\ApplicationFactory;
 use SMW\MediaWiki\Specials\SpecialDeferredRequestDispatcher;
-use SMW\Tests\Utils\UtilityFactory;
+use SMW\Tests\TestEnvironment;
 use Title;
 
 /**
@@ -20,9 +20,13 @@ class SpecialDeferredRequestDispatcherTest extends \PHPUnit_Framework_TestCase {
 
 	private $applicationFactory;
 	private $stringValidator;
+	private $spyLogger;
 
 	protected function setUp() {
 		parent::setUp();
+
+		$this->testEnvironment = new TestEnvironment();
+		$this->spyLogger = $this->testEnvironment->newSpyLogger();
 
 		$this->applicationFactory = ApplicationFactory::getInstance();
 
@@ -35,16 +39,18 @@ class SpecialDeferredRequestDispatcherTest extends \PHPUnit_Framework_TestCase {
 			->method( 'getPropertySubjects' )
 			->will( $this->returnValue( array() ) );
 
-		$store->getOptions()->set( 'smwgSemanticsEnabled', true );
-		$store->getOptions()->set( 'smwgAutoRefreshSubject', true );
+		$store->setOption( 'smwgSemanticsEnabled', true );
+		$store->setOption( 'smwgAutoRefreshSubject', true );
 
-		$this->applicationFactory->registerObject( 'Store', $store );
+		$store->setLogger( $this->spyLogger );
 
-		$this->stringValidator = UtilityFactory::getInstance()->newValidatorFactory()->newStringValidator();
+		$this->testEnvironment->registerObject( 'Store', $store );
+
+		$this->stringValidator = $this->testEnvironment->newValidatorFactory()->newStringValidator();
 	}
 
 	protected function tearDown() {
-		$this->applicationFactory->clear();
+		$this->testEnvironment->tearDown();
 		parent::tearDown();
 	}
 
@@ -117,6 +123,8 @@ class SpecialDeferredRequestDispatcherTest extends \PHPUnit_Framework_TestCase {
 		$store->expects( $this->any() )
 			->method( 'getPropertySubjects' )
 			->will( $this->returnValue( array() ) );
+
+		$store->setLogger( $this->spyLogger );
 
 		$this->applicationFactory->registerObject( 'Store', $store );
 

--- a/tests/phpunit/Unit/SQLStore/QueryDependency/DependencyLinksTableUpdaterTest.php
+++ b/tests/phpunit/Unit/SQLStore/QueryDependency/DependencyLinksTableUpdaterTest.php
@@ -19,12 +19,14 @@ use SMW\Tests\TestEnvironment;
 class DependencyLinksTableUpdaterTest extends \PHPUnit_Framework_TestCase {
 
 	private $testEnvironment;
+	private $spyLogger;
 	private $store;
 
 	protected function setUp() {
 		parent::setUp();
 
 		$this->testEnvironment = new TestEnvironment();
+		$this->spyLogger = $this->testEnvironment->newSpyLogger();
 
 		$this->store = $this->getMockBuilder( '\SMW\Store' )
 			->disableOriginalConstructor()
@@ -98,6 +100,10 @@ class DependencyLinksTableUpdaterTest extends \PHPUnit_Framework_TestCase {
 
 		$instance = new DependencyLinksTableUpdater(
 			$store
+		);
+
+		$instance->setLogger(
+			$this->spyLogger
 		);
 
 		$instance->clear();
@@ -195,6 +201,10 @@ class DependencyLinksTableUpdaterTest extends \PHPUnit_Framework_TestCase {
 
 		$instance = new DependencyLinksTableUpdater(
 			$store
+		);
+
+		$instance->setLogger(
+			$this->spyLogger
 		);
 
 		$instance->clear();

--- a/tests/phpunit/Unit/SQLStore/QueryDependency/EntityIdListRelevanceDetectionFilterTest.php
+++ b/tests/phpunit/Unit/SQLStore/QueryDependency/EntityIdListRelevanceDetectionFilterTest.php
@@ -19,11 +19,13 @@ use SMW\Tests\TestEnvironment;
 class EntityIdListRelevanceDetectionFilterTest extends \PHPUnit_Framework_TestCase {
 
 	private $testEnvironment;
+	private $spyLogger;
 
 	protected function setUp() {
 		parent::setUp();
 
 		$this->testEnvironment = new TestEnvironment();
+		$this->spyLogger = $this->testEnvironment->newSpyLogger();
 
 		$store = $this->getMockBuilder( '\SMW\Store' )
 			->disableOriginalConstructor()
@@ -100,6 +102,10 @@ class EntityIdListRelevanceDetectionFilterTest extends \PHPUnit_Framework_TestCa
 			$changeOp
 		);
 
+		$instance->setLogger(
+			$this->spyLogger
+		);
+
 		$instance->setPropertyExemptionList(
 			array( '_MDAT' )
 		);
@@ -155,6 +161,10 @@ class EntityIdListRelevanceDetectionFilterTest extends \PHPUnit_Framework_TestCa
 		$instance = new EntityIdListRelevanceDetectionFilter(
 			$store,
 			$changeOp
+		);
+
+		$instance->setLogger(
+			$this->spyLogger
 		);
 
 		$instance->setAffiliatePropertyDetectionList(
@@ -224,6 +234,10 @@ class EntityIdListRelevanceDetectionFilterTest extends \PHPUnit_Framework_TestCa
 		$instance = new EntityIdListRelevanceDetectionFilter(
 			$store,
 			$changeOp
+		);
+
+		$instance->setLogger(
+			$this->spyLogger
 		);
 
 		$instance->setPropertyExemptionList(

--- a/tests/phpunit/Unit/SQLStore/QueryDependency/QueryDependencyLinksStoreTest.php
+++ b/tests/phpunit/Unit/SQLStore/QueryDependency/QueryDependencyLinksStoreTest.php
@@ -20,16 +20,22 @@ use SMW\RequestOptions;
 class QueryDependencyLinksStoreTest extends \PHPUnit_Framework_TestCase {
 
 	private $store;
+	private $spyLogger;
 	private $testEnvironment;
 
 	protected function setUp() {
 		parent::setUp();
 
 		$this->testEnvironment = new TestEnvironment();
+		$this->spyLogger = $this->testEnvironment->newSpyLogger();
 
 		$this->store = $this->getMockBuilder( '\SMW\Store' )
 			->disableOriginalConstructor()
 			->getMockForAbstractClass();
+
+		$this->store->setLogger(
+			$this->spyLogger
+		);
 
 		$namespaceExaminer = $this->getMockBuilder( '\SMW\NamespaceExaminer' )
 			->disableOriginalConstructor()
@@ -109,6 +115,10 @@ class QueryDependencyLinksStoreTest extends \PHPUnit_Framework_TestCase {
 		$instance = new QueryDependencyLinksStore(
 			$queryResultDependencyListResolver,
 			$dependencyLinksTableUpdater
+		);
+
+		$instance->setLogger(
+			$this->spyLogger
 		);
 
 		$this->assertTrue(
@@ -441,6 +451,10 @@ class QueryDependencyLinksStoreTest extends \PHPUnit_Framework_TestCase {
 			$dependencyLinksTableUpdater
 		);
 
+		$instance->setLogger(
+			$this->spyLogger
+		);
+
 		$instance->setEnabled( false );
 		$queryResult = '';
 
@@ -489,6 +503,10 @@ class QueryDependencyLinksStoreTest extends \PHPUnit_Framework_TestCase {
 		$instance = new QueryDependencyLinksStore(
 			$queryResultDependencyListResolver,
 			$dependencyLinksTableUpdater
+		);
+
+		$instance->setLogger(
+			$this->spyLogger
 		);
 
 		$instance->setEnabled( true );
@@ -658,6 +676,10 @@ class QueryDependencyLinksStoreTest extends \PHPUnit_Framework_TestCase {
 			$dependencyLinksTableUpdater
 		);
 
+		$instance->setLogger(
+			$this->spyLogger
+		);
+
 		$query = $this->getMockBuilder( '\SMWQuery' )
 			->disableOriginalConstructor()
 			->getMock();
@@ -732,6 +754,10 @@ class QueryDependencyLinksStoreTest extends \PHPUnit_Framework_TestCase {
 			$dependencyLinksTableUpdater
 		);
 
+		$instance->setLogger(
+			$this->spyLogger
+		);
+
 		$query = $this->getMockBuilder( '\SMWQuery' )
 			->disableOriginalConstructor()
 			->getMock();
@@ -766,7 +792,7 @@ class QueryDependencyLinksStoreTest extends \PHPUnit_Framework_TestCase {
 			->disableOriginalConstructor()
 			->getMock();
 
-		$subject->expects( $this->once() )
+		$subject->expects( $this->atLeastOnce() )
 			->method( 'getHash' )
 			->will( $this->returnValue( 'Foo###' ) );
 
@@ -815,6 +841,10 @@ class QueryDependencyLinksStoreTest extends \PHPUnit_Framework_TestCase {
 		$instance = new QueryDependencyLinksStore(
 			$queryResultDependencyListResolver,
 			$dependencyLinksTableUpdater
+		);
+
+		$instance->setLogger(
+			$this->spyLogger
 		);
 
 		$query = $this->getMockBuilder( '\SMWQuery' )

--- a/tests/phpunit/Unit/Updater/DeferredCallableUpdateTest.php
+++ b/tests/phpunit/Unit/Updater/DeferredCallableUpdateTest.php
@@ -77,7 +77,7 @@ class DeferredCallableUpdateTest extends \PHPUnit_Framework_TestCase {
 		$this->testEnvironment->executePendingDeferredUpdates();
 
 		$this->assertContains(
-			'DeferredCallableUpdate::emptyCallback',
+			'Empty callback',
 			$this->spyLogger->getMessagesAsString()
 		);
 	}
@@ -106,7 +106,7 @@ class DeferredCallableUpdateTest extends \PHPUnit_Framework_TestCase {
 		$this->testEnvironment->executePendingDeferredUpdates();
 
 		$this->assertContains(
-			'DeferredCallableUpdate::addUpdate',
+			'[DeferrableUpdate] Added',
 			$this->spyLogger->getMessagesAsString()
 		);
 	}
@@ -128,6 +128,8 @@ class DeferredCallableUpdateTest extends \PHPUnit_Framework_TestCase {
 		$instance = new DeferredCallableUpdate(
 			$callback
 		);
+
+		$instance->setLogger( $this->spyLogger );
 
 		$instance->markAsPending( true );
 		$instance->pushUpdate();
@@ -155,6 +157,8 @@ class DeferredCallableUpdateTest extends \PHPUnit_Framework_TestCase {
 			$callback
 		);
 
+		$instance->setLogger( $this->spyLogger );
+
 		$instance->enabledDeferredUpdate( false );
 		$instance->pushUpdate();
 	}
@@ -170,7 +174,7 @@ class DeferredCallableUpdateTest extends \PHPUnit_Framework_TestCase {
 
 		$instance->setOrigin( 'Foo' );
 
-		$this->assertEquals(
+		$this->assertContains(
 			'Foo',
 			$instance->getOrigin()
 		);
@@ -194,6 +198,8 @@ class DeferredCallableUpdateTest extends \PHPUnit_Framework_TestCase {
 			$callback
 		);
 
+		$instance->setLogger( $this->spyLogger );
+
 		$instance->setFingerprint( __METHOD__ );
 		$instance->markAsPending( true );
 		$instance->pushUpdate();
@@ -201,6 +207,8 @@ class DeferredCallableUpdateTest extends \PHPUnit_Framework_TestCase {
 		$instance = new DeferredCallableUpdate(
 			$callback
 		);
+
+		$instance->setLogger( $this->spyLogger );
 
 		$instance->setFingerprint( __METHOD__ );
 		$instance->markAsPending( true );

--- a/tests/phpunit/Unit/Updater/DeferredTransactionalUpdateTest.php
+++ b/tests/phpunit/Unit/Updater/DeferredTransactionalUpdateTest.php
@@ -86,7 +86,7 @@ class DeferredTransactionalUpdateTest extends \PHPUnit_Framework_TestCase {
 		$this->testEnvironment->executePendingDeferredUpdates();
 
 		$this->assertContains(
-			'DeferredCallableUpdate::emptyCallback',
+			'Empty callback',
 			$this->spyLogger->getMessagesAsString()
 		);
 	}
@@ -118,7 +118,7 @@ class DeferredTransactionalUpdateTest extends \PHPUnit_Framework_TestCase {
 		$this->testEnvironment->executePendingDeferredUpdates();
 
 		$this->assertContains(
-			'DeferredCallableUpdate::addUpdate',
+			'[DeferrableUpdate] Added',
 			$this->spyLogger->getMessagesAsString()
 		);
 	}
@@ -141,6 +141,8 @@ class DeferredTransactionalUpdateTest extends \PHPUnit_Framework_TestCase {
 			$callback,
 			$this->connection
 		);
+
+		$instance->setLogger( $this->spyLogger );
 
 		$instance->markAsPending( true );
 		$instance->pushUpdate();
@@ -169,6 +171,8 @@ class DeferredTransactionalUpdateTest extends \PHPUnit_Framework_TestCase {
 			$this->connection
 		);
 
+		$instance->setLogger( $this->spyLogger );
+
 		$instance->enabledDeferredUpdate( false );
 		$instance->pushUpdate();
 	}
@@ -183,9 +187,11 @@ class DeferredTransactionalUpdateTest extends \PHPUnit_Framework_TestCase {
 			$this->connection
 		);
 
+		$instance->setLogger( $this->spyLogger );
+
 		$instance->setOrigin( 'Foo' );
 
-		$this->assertEquals(
+		$this->assertContains(
 			'Foo',
 			$instance->getOrigin()
 		);
@@ -210,6 +216,8 @@ class DeferredTransactionalUpdateTest extends \PHPUnit_Framework_TestCase {
 			$this->connection
 		);
 
+		$instance->setLogger( $this->spyLogger );
+
 		$instance->setFingerprint( __METHOD__ );
 		$instance->markAsPending( true );
 		$instance->pushUpdate();
@@ -218,6 +226,8 @@ class DeferredTransactionalUpdateTest extends \PHPUnit_Framework_TestCase {
 			$callback,
 			$this->connection
 		);
+
+		$instance->setLogger( $this->spyLogger );
 
 		$instance->setFingerprint( __METHOD__ );
 		$instance->markAsPending( true );
@@ -259,6 +269,8 @@ class DeferredTransactionalUpdateTest extends \PHPUnit_Framework_TestCase {
 			$connection
 		);
 
+		$instance->setLogger( $this->spyLogger );
+
 		$instance->waitOnTransactionIdle();
 		$instance->pushUpdate();
 
@@ -292,6 +304,8 @@ class DeferredTransactionalUpdateTest extends \PHPUnit_Framework_TestCase {
 			$callback,
 			$connection
 		);
+
+		$instance->setLogger( $this->spyLogger );
 
 		$instance->isDeferrableUpdate( true );
 		$instance->commitWithTransactionTicket();
@@ -327,6 +341,8 @@ class DeferredTransactionalUpdateTest extends \PHPUnit_Framework_TestCase {
 			$callback,
 			$connection
 		);
+
+		$instance->setLogger( $this->spyLogger );
 
 		$instance->isDeferrableUpdate( false );
 		$instance->commitWithTransactionTicket();

--- a/tests/phpunit/Unit/Updater/StoreUpdaterTest.php
+++ b/tests/phpunit/Unit/Updater/StoreUpdaterTest.php
@@ -21,6 +21,7 @@ class StoreUpdaterTest  extends \PHPUnit_Framework_TestCase {
 
 	private $testEnvironment;
 	private $semanticDataFactory;
+	private $spyLogger;
 	private $store;
 
 	protected function setUp() {
@@ -31,6 +32,8 @@ class StoreUpdaterTest  extends \PHPUnit_Framework_TestCase {
 			'smwgEnableUpdateJobs'            => false,
 			'smwgNamespacesWithSemanticLinks' => array( NS_MAIN => true )
 		) );
+
+		$this->spyLogger = $this->testEnvironment->newSpyLogger();
 
 		$idTable = $this->getMockBuilder( '\stdClass' )
 			->setMethods( array( 'exists' ) )
@@ -44,6 +47,8 @@ class StoreUpdaterTest  extends \PHPUnit_Framework_TestCase {
 		$this->store->expects( $this->any() )
 			->method( 'getObjectIds' )
 			->will( $this->returnValue( $idTable ) );
+
+		$this->store->setLogger( $this->spyLogger );
 
 		$this->testEnvironment->registerObject( 'Store', $this->store );
 		$this->semanticDataFactory = $this->testEnvironment->getUtilityFactory()->newSemanticDataFactory();
@@ -273,8 +278,10 @@ class StoreUpdaterTest  extends \PHPUnit_Framework_TestCase {
 		$store->expects( $this->once() )
 			->method( 'changeTitle' );
 
-		$store->getOptions()->set( 'smwgSemanticsEnabled', true );
-		$store->getOptions()->set( 'smwgAutoRefreshSubject', true );
+		$store->setOption( 'smwgSemanticsEnabled', true );
+		$store->setOption( 'smwgAutoRefreshSubject', true );
+
+		$store->setLogger( $this->spyLogger );
 
 		$semanticData = new SemanticData( $subject );
 


### PR DESCRIPTION
This PR is made in reference to: #

This PR addresses or contains:

- Adds the `smwgDefaultLoggerRole` admin setting to filter the amount (in terms of granularity) of information being logged when either `$wgDebugLogFile` or `$wgDebugLogGroups` is enabled 
- The default role is set to `$GLOBALS['smwgDefaultLoggerRole'] = 'production'` which means that only a very limited log output is generated, to show all SMW related loggable events the `developer` role is required, the `user` role will include extra events such executions of jobs 
- Use `LoggerAwareTrait` more consistently instead of `implements LoggerAwareInterface`

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed

Fixes #