### PR TITLE
Separate caching and lookup, refs 2928

### DIFF
--- a/includes/storage/SQLStore/SMW_SQLStore3_Readers.php
+++ b/includes/storage/SQLStore/SMW_SQLStore3_Readers.php
@@ -173,7 +173,7 @@ class SMWSQLStore3Readers {
 
 				$propertyTableDef = $proptables[$propTableId];
 
-				$ropts = $this->semanticDataLookup->findConditionConstraint(
+				$opts = $this->semanticDataLookup->makeOptionsFromConstraint(
 					$propertyTableDef,
 					$property,
 					$requestOptions
@@ -183,7 +183,7 @@ class SMWSQLStore3Readers {
 					$sid,
 					$subject,
 					$propertyTableDef,
-					$ropts
+					$opts
 				);
 
 				$result = $this->store->applyRequestOptions(

--- a/src/SQLStore/EntityStore/CachingSemanticDataLookup.php
+++ b/src/SQLStore/EntityStore/CachingSemanticDataLookup.php
@@ -1,0 +1,262 @@
+<?php
+
+namespace SMW\SQLStore\EntityStore;
+
+use SMW\DIProperty;
+use SMW\DIWikiPage;
+use SMW\SQLStore\SQLStore;
+use SMWDataItem as DataItem;
+use SMW\RequestOptions;
+use Onoi\Cache\Cache;
+use Onoi\Cache\NullCache;
+use SMW\SemanticData;
+use SMW\SQLStore\PropertyTableDefinition;
+use Psr\Log\LoggerAwareTrait;
+use RuntimeException;
+
+/**
+ * @license GNU GPL v2+
+ * @since 3.0
+ *
+ * @author mwjames
+ */
+class CachingSemanticDataLookup {
+
+	use LoggerAwareTrait;
+
+	/**
+	 * @var SemanticDataLookup
+	 */
+	private $semanticDataLookup;
+
+	/**
+	 * @var Cache
+	 */
+	private $cache;
+
+	/**
+	 * Cache for SemanticData dataItems, indexed by SMW ID.
+	 *
+	 * @var array
+	 */
+	private static $data = [];
+
+	/**
+	 * Like SMWSQLStore3::data, but containing flags indicating
+	 * completeness of the SemanticData objs.
+	 *
+	 * @var array
+	 */
+	private static $state = [];
+
+	/**
+	 * >0 while getSemanticData runs, used to prevent nested calls from clearing
+	 * the cache while another call runs and is about to fill it with data
+	 *
+	 * @var int
+	 */
+	private static $lookupCount = 0;
+
+	/**
+	 * @since 3.0
+	 *
+	 * @param SemanticDataLookup $semanticDataLookup
+	 * @param Cache|null $cache
+	 */
+	public function __construct( SemanticDataLookup $semanticDataLookup, Cache $cache = null ) {
+		$this->semanticDataLookup = $semanticDataLookup;
+		$this->cache = $cache;
+
+		if ( $this->cache === null ) {
+			$this->cache = new NullCache();
+		}
+	}
+
+	/**
+	 * @since 3.0
+	 */
+	public function lockCache() {
+		self::$lookupCount++;
+	}
+
+	/**
+	 * @since 3.0
+	 */
+	public function unlockCache() {
+		self::$lookupCount--;
+	}
+
+	/**
+	 * @since 3.0
+	 *
+	 * @param integer $id
+	 */
+	public function invalidateCache( $id ) {
+		unset( self::$data[$id] );
+		unset( self::$state[$id] );
+	}
+
+	/**
+	 * @since 3.0
+	 */
+	public static function clear() {
+		self::$data = [];
+		self::$state = [];
+		self::$lookupCount = 0;
+	}
+
+	/**
+	 * Helper method to make sure there is a cache entry for the data about
+	 * the given subject with the given ID.
+	 *
+	 * @todo The management of this cache should be revisited.
+	 *
+	 * @since 3.0
+	 *
+	 * @param int $id
+	 * @param DIWikiPage $subject
+	 */
+	public function initLookupCache( $id, DIWikiPage $subject ) {
+
+		// *** Prepare the cache ***//
+		if ( !isset( self::$data[$id] ) ) {
+			self::$data[$id] = $this->semanticDataLookup->newStubSemanticData( $subject );
+			self::$state[$id] = [];
+		}
+
+		// Issue #622
+		// If a redirect was cached preceding this request and points to the same
+		// subject id ensure that in all cases the requested subject matches with
+		// the selected DB id
+		if ( self::$data[$id]->getSubject()->getHash() !== $subject->getHash() ) {
+			self::$data[$id] = $this->semanticDataLookup->newStubSemanticData( $subject );
+			self::$state[$id] = [];
+		}
+
+		// prevent memory leak;
+		// It is not so easy to find the sweet spot between cache size and performance gains (both memory and time),
+		// The value of 20 was chosen by profiling runtimes for large inline queries and heavily annotated pages.
+		// However, things might have changed in the meantime ...
+		if ( ( count( self::$data ) > 20 ) && ( self::$lookupCount == 1 ) ) {
+			self::$data = array( $id => self::$data[$id] );
+			self::$state = array( $id => self::$state[$id] );
+		}
+	}
+
+	/**
+	 * Set the semantic data lookup cache to hold exactly the given value for the
+	 * given ID.
+	 *
+	 * @since 3.0
+	 *
+	 * @param integer $id
+	 * @param SemanticData $semanticData
+	 */
+	public function setLookupCache( $id, SemanticData $semanticData ) {
+
+		self::$data[$id] = $this->semanticDataLookup->newFromSemanticData(
+			$semanticData
+		);
+
+		self::$state[$id] = $this->semanticDataLookup->getTableUsageInfo(
+			$semanticData
+		);
+	}
+
+	/**
+	 * Helper method to make sure there is a cache entry for the data about
+	 * the given subject with the given ID.
+	 *
+	 * @since 3.0
+	 *
+	 * @param int $id
+	 * @param DIWikiPage $subject
+	 */
+	public function getSemanticDataById( $id ) {
+
+		if ( !isset( self::$data[$id] ) ) {
+			throw new RuntimeException( 'Data are not initialized.' );
+		}
+
+		return self::$data[$id];
+	}
+
+	/**
+	 * @since 3.0
+	 *
+	 * @param PropertyTableDefinition $propertyTableDef
+	 * @param DIProperty $property
+	 * @param RequestOptions|null $requestOptions
+	 *
+	 * @return RequestOptions|null
+	 */
+	public function makeOptionsFromConstraint( PropertyTableDefinition $propertyTableDef, DIProperty $property, RequestOptions $requestOptions = null ) {
+		return $this->semanticDataLookup->makeOptionsFromConstraint( $propertyTableDef, $property, $requestOptions );
+	}
+
+	/**
+	 * @since 3.0
+	 *
+	 * @param integer $id
+	 * @param DataItem $dataItem
+	 * @param PropertyTableDefinition $propertyTableDef
+	 * @param RequestOptions $requestOptions
+	 *
+	 * @return RequestOptions|null
+	 */
+	public function fetchSemanticData( $id, DataItem $dataItem = null, PropertyTableDefinition $propertyTableDef, RequestOptions $requestOptions = null ) {
+		return $this->semanticDataLookup->fetchSemanticData( $id, $dataItem, $propertyTableDef, $requestOptions );
+	}
+
+	/**
+	 * Fetch and cache the data about one subject for one particular table
+	 *
+	 * @param integer $id
+	 * @param DIWikiPage $subject
+	 * @param PropertyTableDefinition $propertyTableDef
+	 * @param RequestOptions|null $requestOptions
+	 *
+	 * @return SemanticData
+	 */
+	public function getSemanticDataFromTable( $id, DataItem $dataItem = null, PropertyTableDefinition $propertyTableDef, RequestOptions $requestOptions = null ) {
+
+		// Avoid the cache when a request is constrainted
+		if ( $requestOptions !== null || !$dataItem instanceof DIWikiPage ) {
+			return $this->semanticDataLookup->getSemanticData( $id, $dataItem, $propertyTableDef, $requestOptions );
+		}
+
+		return $this->fetchFromCache( $id, $dataItem, $propertyTableDef );
+	}
+
+	private function fetchFromCache( $id, DataItem $dataItem = null, PropertyTableDefinition $propertyTableDef ) {
+
+		// Do not clear the cache when called recursively.
+		$this->lockCache();
+		$this->initLookupCache( $id, $dataItem );
+
+		// @see also setLookupCache
+		$name = $propertyTableDef->getName();
+
+		if ( isset( self::$state[$id][$name] ) ) {
+			$this->unlockCache();
+			return self::$data[$id];
+		}
+
+		$data = $this->semanticDataLookup->fetchSemanticData(
+			$id,
+			$dataItem,
+			$propertyTableDef
+		);
+
+		foreach ( $data as $d ) {
+			self::$data[$id]->addPropertyStubValue( reset( $d ), end( $d ) );
+		}
+
+		self::$state[$id][$name] = true;
+
+		$this->unlockCache();
+
+		return self::$data[$id];
+	}
+
+}

--- a/src/SQLStore/SQLStoreFactory.php
+++ b/src/SQLStore/SQLStoreFactory.php
@@ -25,6 +25,7 @@ use SMW\SQLStore\EntityStore\CachingEntityLookup;
 use SMW\SQLStore\EntityStore\NativeEntityLookup;
 use SMW\SQLStore\EntityStore\TraversalPropertyLookup;
 use SMW\SQLStore\EntityStore\SemanticDataLookup;
+use SMW\SQLStore\EntityStore\CachingSemanticDataLookup;
 use SMW\ProcessLruCache;
 use SMW\SQLStore\EntityStore\ByIdEntityFinder;
 use SMW\SQLStore\EntityStore\SubobjectListFinder;
@@ -567,7 +568,12 @@ class SQLStoreFactory {
 			$this->getLogger()
 		);
 
-		return $semanticDataLookup;
+		$cachingSemanticDataLookup = new CachingSemanticDataLookup(
+			$semanticDataLookup,
+			ApplicationFactory::getInstance()->getCache()
+		);
+
+		return $cachingSemanticDataLookup;
 	}
 
 	/**

--- a/tests/phpunit/Unit/SQLStore/EntityStore/CachingSemanticDataLookupTest.php
+++ b/tests/phpunit/Unit/SQLStore/EntityStore/CachingSemanticDataLookupTest.php
@@ -1,0 +1,244 @@
+<?php
+
+namespace SMW\Tests\SQLStore\EntityStore;
+
+use SMW\SQLStore\EntityStore\CachingSemanticDataLookup;
+use SMW\DIWikiPage;
+use SMW\RequestOptions;
+
+/**
+ * @covers \SMW\SQLStore\EntityStore\CachingSemanticDataLookup
+ * @group semantic-mediawiki
+ *
+ * @license GNU GPL v2+
+ * @since 3.0
+ *
+ * @author mwjames
+ */
+class CachingSemanticDataLookupTest extends \PHPUnit_Framework_TestCase {
+
+	private $store;
+	private $connection;
+	private $semanticDataLookup;
+
+	public function setUp() {
+		parent::setUp();
+
+		$this->semanticDataLookup = $this->getMockBuilder( '\SMW\SQLStore\EntityStore\SemanticDataLookup' )
+			->disableOriginalConstructor()
+			->getMock();
+	}
+
+	public function tearDown() {
+		CachingSemanticDataLookup::clear();
+	}
+
+	public function testCanConstruct() {
+
+		$this->assertInstanceOf(
+			CachingSemanticDataLookup::class,
+			new CachingSemanticDataLookup( $this->semanticDataLookup )
+		);
+	}
+
+	public function testInitLookupCache() {
+
+		$subject = DIWikiPage::newFromText( 'Foo' );
+
+		$stubSemanticData = $this->getMockBuilder( '\SMW\SQLStore\EntityStore\StubSemanticData' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$stubSemanticData->expects( $this->once() )
+			->method( 'getSubject' )
+			->will( $this->returnValue( $subject ) );
+
+		$this->semanticDataLookup->expects( $this->once() )
+			->method( 'newStubSemanticData' )
+			->will( $this->returnValue( $stubSemanticData ) );
+
+		$instance = new CachingSemanticDataLookup(
+			$this->semanticDataLookup
+		);
+
+		$instance->initLookupCache( 42, $subject );
+
+		$this->assertInstanceOf(
+			'\SMW\SQLStore\EntityStore\StubSemanticData',
+			$instance->getSemanticDataById( 42 )
+		);
+	}
+
+	public function testUninitializedGetSemanticDataByIdThrowsException() {
+
+		$instance = new CachingSemanticDataLookup(
+			$this->semanticDataLookup
+		);
+
+		$this->setExpectedException( '\RuntimeException' );
+		$instance->getSemanticDataById( 42 );
+	}
+
+	public function testSetLookupCache() {
+
+		$semanticData = $this->getMockBuilder( '\SMW\SemanticData' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$this->semanticDataLookup->expects( $this->once() )
+			->method( 'newFromSemanticData' )
+			->will( $this->returnValue( $semanticData ) );
+
+		$this->semanticDataLookup->expects( $this->once() )
+			->method( 'getTableUsageInfo' )
+			->will( $this->returnValue( [] ) );
+
+		$instance = new CachingSemanticDataLookup(
+			$this->semanticDataLookup
+		);
+
+		$instance->setLookupCache( 42, $semanticData );
+
+		$this->assertEquals(
+			$semanticData,
+			$instance->getSemanticDataById( 42 )
+		);
+	}
+
+	public function testGetOptionsFromConstraint() {
+
+		$propertyTableDefinition = $this->getMockBuilder( '\SMW\SQLStore\PropertyTableDefinition' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$property = $this->getMockBuilder( '\SMW\DIProperty' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$this->semanticDataLookup->expects( $this->once() )
+			->method( 'makeOptionsFromConstraint' );
+
+		$instance = new CachingSemanticDataLookup(
+			$this->semanticDataLookup
+		);
+
+		$instance->makeOptionsFromConstraint( $propertyTableDefinition, $property );
+	}
+
+	public function testFetchSemanticData() {
+
+		$propertyTableDefinition = $this->getMockBuilder( '\SMW\SQLStore\PropertyTableDefinition' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$this->semanticDataLookup->expects( $this->once() )
+			->method( 'fetchSemanticData' );
+
+		$instance = new CachingSemanticDataLookup(
+			$this->semanticDataLookup
+		);
+
+		$instance->fetchSemanticData( 42, null, $propertyTableDefinition );
+	}
+
+	public function testGetSemanticDataFromTable_Uncached() {
+
+		$propertyTableDefinition = $this->getMockBuilder( '\SMW\SQLStore\PropertyTableDefinition' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$requestOptions = $this->getMockBuilder( '\SMW\RequestOptions' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$this->semanticDataLookup->expects( $this->once() )
+			->method( 'getSemanticData' );
+
+		$instance = new CachingSemanticDataLookup(
+			$this->semanticDataLookup
+		);
+
+		$instance->getSemanticDataFromTable( 42, null, $propertyTableDefinition, $requestOptions );
+	}
+
+	public function testGetSemanticDataFromTable_FreshFetch() {
+
+		$subject = DIWikiPage::newFromText( 'Foo' );
+
+		$propertyTableDefinition = $this->getMockBuilder( '\SMW\SQLStore\PropertyTableDefinition' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$stubSemanticData = $this->getMockBuilder( '\SMW\SQLStore\EntityStore\StubSemanticData' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$stubSemanticData->expects( $this->once() )
+			->method( 'getSubject' )
+			->will( $this->returnValue( $subject ) );
+
+		$this->semanticDataLookup->expects( $this->once() )
+			->method( 'newStubSemanticData' )
+			->will( $this->returnValue( $stubSemanticData ) );
+
+		$this->semanticDataLookup->expects( $this->once() )
+			->method( 'fetchSemanticData' )
+			->will( $this->returnValue( [] ) );
+
+		$instance = new CachingSemanticDataLookup(
+			$this->semanticDataLookup
+		);
+
+		$instance->getSemanticDataFromTable( 42, $subject, $propertyTableDefinition );
+	}
+
+	public function testGetSemanticDataFromTable_FromStaticCache() {
+
+		$subject = DIWikiPage::newFromText( 'Foo' );
+
+		$propertyTableDefinition = $this->getMockBuilder( '\SMW\SQLStore\PropertyTableDefinition' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$propertyTableDefinition->expects( $this->once() )
+			->method( 'getName' )
+			->will( $this->returnValue( '__foo__' ) );
+
+		$stubSemanticData = $this->getMockBuilder( '\SMW\SQLStore\EntityStore\StubSemanticData' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$this->semanticDataLookup->expects( $this->any() )
+			->method( 'newStubSemanticData' )
+			->will( $this->returnValue( $stubSemanticData ) );
+
+		$semanticData = $this->getMockBuilder( '\SMW\SemanticData' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$semanticData->expects( $this->atLeastOnce() )
+			->method( 'getSubject' )
+			->will( $this->returnValue( $subject ) );
+
+		$this->semanticDataLookup->expects( $this->once() )
+			->method( 'newFromSemanticData' )
+			->will( $this->returnValue( $semanticData ) );
+
+		$this->semanticDataLookup->expects( $this->once() )
+			->method( 'getTableUsageInfo' )
+			->will( $this->returnValue( [ '__foo__' => true ] ) );
+
+		$this->semanticDataLookup->expects( $this->never() )
+			->method( 'fetchSemanticData' );
+
+		$instance = new CachingSemanticDataLookup(
+			$this->semanticDataLookup
+		);
+
+		$instance->invalidateCache( 42 );
+		$instance->setLookupCache( 42, $stubSemanticData );
+
+		$instance->getSemanticDataFromTable( 42, $subject, $propertyTableDefinition );
+	}
+
+}

--- a/tests/phpunit/Unit/SQLStore/SQLStoreFactoryTest.php
+++ b/tests/phpunit/Unit/SQLStore/SQLStoreFactoryTest.php
@@ -320,7 +320,7 @@ class SQLStoreFactoryTest extends \PHPUnit_Framework_TestCase {
 		$instance = new SQLStoreFactory( $this->store );
 
 		$this->assertInstanceOf(
-			'\SMW\SQLStore\EntityStore\SemanticDataLookup',
+			'\SMW\SQLStore\EntityStore\CachingSemanticDataLookup',
 			$instance->newSemanticDataLookup()
 		);
 	}

--- a/tests/phpunit/includes/SQLStore/Writer/ChangeTitleTest.php
+++ b/tests/phpunit/includes/SQLStore/Writer/ChangeTitleTest.php
@@ -74,7 +74,7 @@ class ChangeTitleTest extends \PHPUnit_Framework_TestCase {
 			->disableOriginalConstructor()
 			->getMock();
 
-		$semanticDataLookup = $this->getMockBuilder( '\SMW\SQLStore\EntityStore\SemanticDataLookup' )
+		$semanticDataLookup = $this->getMockBuilder( '\SMW\SQLStore\EntityStore\CachingSemanticDataLookup' )
 			->disableOriginalConstructor()
 			->getMock();
 

--- a/tests/phpunit/includes/SQLStore/Writer/DataUpdateTest.php
+++ b/tests/phpunit/includes/SQLStore/Writer/DataUpdateTest.php
@@ -75,7 +75,7 @@ class DataUpdateTest extends \PHPUnit_Framework_TestCase {
 			->disableOriginalConstructor()
 			->getMock();
 
-		$semanticDataLookup = $this->getMockBuilder( '\SMW\SQLStore\EntityStore\SemanticDataLookup' )
+		$semanticDataLookup = $this->getMockBuilder( '\SMW\SQLStore\EntityStore\CachingSemanticDataLookup' )
 			->disableOriginalConstructor()
 			->getMock();
 

--- a/tests/phpunit/includes/SQLStore/Writer/DeleteSubjectTest.php
+++ b/tests/phpunit/includes/SQLStore/Writer/DeleteSubjectTest.php
@@ -89,7 +89,7 @@ class DeleteSubjectTest extends \PHPUnit_Framework_TestCase {
 			->method( 'computeTableRowDiff' )
 			->will( $this->returnValue( [ [], [], [] ] ) );
 
-		$semanticDataLookup = $this->getMockBuilder( '\SMW\SQLStore\EntityStore\SemanticDataLookup' )
+		$semanticDataLookup = $this->getMockBuilder( '\SMW\SQLStore\EntityStore\CachingSemanticDataLookup' )
 			->disableOriginalConstructor()
 			->getMock();
 


### PR DESCRIPTION
This PR is made in reference to: #2928 

This PR addresses or contains:

- Split into `SemanticDataLookup` and `CachingSemanticDataLookup`

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed

Fixes #