### PR TITLE
Adds `removeDuplicateEntities` integration test, refs 2932

### DIFF
--- a/includes/storage/SQLStore/SMW_Sql3SmwIds.php
+++ b/includes/storage/SQLStore/SMW_Sql3SmwIds.php
@@ -516,7 +516,10 @@ class SMWSql3SmwIds {
 		"COUNT(*) as count, smw_title, smw_namespace, smw_iw, smw_subobject " .
 		"FROM $tableName WHERE $condition " .
 		"GROUP BY smw_title, smw_namespace, smw_iw, smw_subobject ".
-		"HAVING count > 1";
+		"HAVING count(*) > 1";
+
+		// @see https://stackoverflow.com/questions/8119489/postgresql-where-count-condition
+		// "HAVING count > 1"; doesn't work on postgres
 
 		$rows = $connection->query(
 			$query,

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -21,5 +21,6 @@ $autoloader->addClassMap( array(
 	'SMW\Maintenance\RebuildFulltextSearchTable' => __DIR__ . '/../maintenance/rebuildFulltextSearchTable.php',
 	'SMW\Maintenance\DumpRdf'                    => __DIR__ . '/../maintenance/dumpRDF.php',
 	'SMW\Maintenance\SetupStore'                 => __DIR__ . '/../maintenance/setupStore.php',
-	'SMW\Maintenance\UpdateEntityCollation'      => __DIR__ . '/../maintenance/updateEntityCollation.php'
+	'SMW\Maintenance\UpdateEntityCollation'      => __DIR__ . '/../maintenance/updateEntityCollation.php',
+	'SMW\Maintenance\RemoveDuplicateEntities'    => __DIR__ . '/../maintenance/removeDuplicateEntities.php'
 ) );

--- a/tests/phpunit/Integration/Maintenance/RemoveDuplicateEntitiesTest.php
+++ b/tests/phpunit/Integration/Maintenance/RemoveDuplicateEntitiesTest.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace SMW\Tests\Integration\Maintenance;
+
+use SMW\Tests\MwDBaseUnitTestCase;
+use SMW\Tests\TestEnvironment;
+
+/**
+ * @group semantic-mediawiki
+ * @group medium
+ *
+ * @license GNU GPL v2+
+ * @since 3.0
+ *
+ * @author mwjames
+ */
+class RemoveDuplicateEntitiesTest extends MwDBaseUnitTestCase {
+
+	protected $destroyDatabaseTablesAfterRun = true;
+	private $runnerFactory;
+
+	protected function setUp() {
+		parent::setUp();
+
+		$this->runnerFactory  = TestEnvironment::getUtilityFactory()->newRunnerFactory();
+	}
+
+	protected function tearDown() {
+		parent::tearDown();
+	}
+
+	public function testRun() {
+
+		$maintenanceRunner = $this->runnerFactory->newMaintenanceRunner(
+			'SMW\Maintenance\RemoveDuplicateEntities'
+		);
+
+		$maintenanceRunner->setQuiet();
+
+		$this->assertTrue(
+			$maintenanceRunner->run()
+		);
+	}
+
+}

--- a/tests/phpunit/includes/storage/sqlstore/SQLStoreSmwIdsTest.php
+++ b/tests/phpunit/includes/storage/sqlstore/SQLStoreSmwIdsTest.php
@@ -337,7 +337,7 @@ class SQLStoreSmwIdsTest extends \PHPUnit_Framework_TestCase {
 
 		$connection->expects( $this->once() )
 			->method( 'query' )
-			->with( $this->stringContains( 'HAVING count > 1' ) )
+			->with( $this->stringContains( 'HAVING count(*) > 1' ) )
 			->will( $this->returnValue( [ $row ] ) );
 
 		$store = $this->getMockBuilder( 'SMWSQLStore3' )


### PR DESCRIPTION
This PR is made in reference to: #2932

This PR addresses or contains:

- The integration test found an issue with `HAVING count > 1` on postgres which causes an error due to [0] therefore needs to be changed to `HAVING count(*) > 1`

[0] https://stackoverflow.com/questions/8119489/postgresql-where-count-condition

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed

Fixes #