### PR TITLE
Avoid "ApiBase::dieUsage was deprecated ...", refs 2553

### DIFF
--- a/i18n/en.json
+++ b/i18n/en.json
@@ -674,5 +674,6 @@
 	"smw-cheat-sheet": "Cheat sheet",
 	"smw-personal-jobqueue-watchlist": "Job queue watchlist",
 	"smw-property-predefined-label-skey": "Sortkey",
-	"smw-processing": "Processing..."
+	"smw-processing": "Processing...",
+	"smw-redirect-target-unresolvable": "The target is unresolvable on the reason of \"$1\""
 }

--- a/src/MediaWiki/Api/BrowseBySubject.php
+++ b/src/MediaWiki/Api/BrowseBySubject.php
@@ -78,7 +78,13 @@ class BrowseBySubject extends ApiBase {
 		try {
 			$title = $deepRedirectTargetResolver->findRedirectTargetFor( $title );
 		} catch ( \Exception $e ) {
-			$this->dieUsage( $e->getMessage(), 'redirect-target-unresolvable'  );
+
+			// 1.29+
+			if ( method_exists( $this, 'dieWithError' ) ) {
+				$this->dieWithError( [ 'smw-redirect-target-unresolvable', $e->getMessage() ] );
+			} else {
+				$this->dieUsage( $e->getMessage(), 'redirect-target-unresolvable'  );
+			}
 		}
 
 		$dataItem = new DIWikiPage(


### PR DESCRIPTION
This PR is made in reference to: #2553

This PR addresses or contains:

This PR includes:
- [ ] Tests (unit/integration)
- [x] CI build passed

Fixes #2553