### PR TITLE
DIProperty remove deprecated methods, refs 1014

### DIFF
--- a/docs/technical/README.md
+++ b/docs/technical/README.md
@@ -23,6 +23,8 @@ If you are new to SMW development, have a look at the:
 - [`Serializers`](https://github.com/SemanticMediaWiki/SemanticMediaWiki/blob/master/docs/technical/doc.serializers.md) contains information about the Semantic MediaWiki serializers
 - [`ext.smw.suggester`](https://github.com/SemanticMediaWiki/SemanticMediaWiki/blob/master/res/smw/suggester/README.md) on how to register additional tokens or context objects
 
+- ['3.0 migration guide'](https://github.com/SemanticMediaWiki/SemanticMediaWiki/blob/master/docs/technical/migration-guide-3.0.md) contains information about the wmigration from 2.x to 3.x
+
 ## Code snippets and code examples
 
 - [phpunit.test.property](code-snippets/phpunit.test.property.md)

--- a/docs/technical/migration-guide-3.0.md
+++ b/docs/technical/migration-guide-3.0.md
@@ -1,3 +1,4 @@
+# Migration guide
 
 ## Maintenance scripts
 
@@ -13,8 +14,32 @@
   See the help page on configuration parameter [`$smwgExportResourcesAsIri`](https://www.semantic-mediawiki.org/wiki/Help:$smwgExportResourcesAsIri)
   for furhter information.
 
+## Removed classes and methods
+
+- Removed `DIProperty::findPropertyID`, deprecated since 2.1, use PropertyRegistry::findPropertyIdByLabel
+- Removed `DIProperty::getPredefinedPropertyTypeId`, deprecated since 2.1, use PropertyRegistry::getPropertyValueTypeById
+- Removed `DIProperty::findPropertyLabel`, deprecated since 2.1, use PropertyRegistry::findPropertyLabelById
+- Removed `DIProperty::registerProperty`, deprecated since 2.1, use PropertyRegistry::registerProperty
+- Removed `DIProperty::registerPropertyAlias`, deprecated since 2.1, use PropertyRegistry::registerPropertyAlias
+
 ## Store
 
-- `Store::getPropertySubjects` is to return an `Iterator`, using an `array`
+- `Store::getPropertySubjects` is to return an `Iterator` hence an `array`
   type check should be avoided and if necessary use `iterator_to_array` to
   transform a result instance into a standard array
+
+### Register predefined property
+
+```
+\Hooks::register( 'SMW::Property::initProperties', function( $propertyRegistry ) {
+
+	$propertyRegistry->registerProperty( '__FOO', '_txt', 'Foo' );
+
+	$propertyRegistry->registerPropertyDescriptionByMsgKey(
+		'__FOO',
+		'a-mediawiki-msg-key-with-a-description'
+	);
+
+	return true;
+} );
+```

--- a/includes/dataitems/SMW_DI_Property.php
+++ b/includes/dataitems/SMW_DI_Property.php
@@ -11,11 +11,11 @@ use SMW\Exception\DataTypeLookupExeption;
 use SMW\Exception\PredefinedPropertyLabelMismatchException;
 
 /**
- * This class implements Property data items.
+ * This class implements Property item
  *
- * @note PropertyRegistry class manages global registrations of
- * predefined (built-in) properties, and maintains an association of
- * property IDs, localized labels, and aliases.
+ * @note PropertyRegistry class manages global registrations of predefined
+ * (built-in) properties, and maintains an association of property IDs, localized
+ * labels, and aliases.
  *
  * @since 1.6
  *
@@ -63,10 +63,9 @@ class DIProperty extends SMWDataItem {
 	private $m_inverse;
 
 	/**
-	 * Cache for property type ID.
 	 * @var string
 	 */
-	private $m_proptypeid;
+	private $propertyValueType;
 
 	/**
 	 * Interwiki prefix for when a property represents a non-local entity
@@ -92,7 +91,7 @@ class DIProperty extends SMWDataItem {
 		}
 
 		if ( $key{0} == '_' ) {
-			if ( !PropertyRegistry::getInstance()->isKnownPropertyId( $key ) ) {
+			if ( !PropertyRegistry::getInstance()->isRegistered( $key ) ) {
 				throw new PredefinedPropertyLabelMismatchException( "There is no predefined property with \"$key\"." );
 			}
 		}
@@ -166,6 +165,25 @@ class DIProperty extends SMWDataItem {
 	}
 
 	/**
+	 * Whether a user can freely use this property for value annotation or
+	 * not.
+	 *
+	 * @since 3.0
+	 *
+	 * @return boolean
+	 */
+	public function isUserAnnotable() {
+
+		// A user defined property is generally assumed to be unrestricted for
+		// usage
+		if ( $this->isUserDefined() ) {
+			return true;
+		}
+
+		return PropertyRegistry::getInstance()->isAnnotable( $this->m_key );
+	}
+
+	/**
 	 * Find a user-readable label for this property, or return '' if it is
 	 * a predefined property that has no label. For inverse properties, the
 	 * label starts with a "-".
@@ -213,7 +231,10 @@ class DIProperty extends SMWDataItem {
 	 */
 	public function getPreferredLabel( $languageCode = '' ) {
 
-		$label = PropertyRegistry::getInstance()->findPreferredPropertyLabelFromIdByLanguageCode( $this->m_key, $languageCode );
+		$label = PropertyRegistry::getInstance()->findPreferredPropertyLabelFromIdByLanguageCode(
+			$this->m_key,
+			$languageCode
+		);
 
 		if ( $label !== '' ) {
 			return ( $this->m_inverse ? '-' : '' ) . $label;
@@ -244,9 +265,9 @@ class DIProperty extends SMWDataItem {
 	 */
 	public function getDiWikiPage( $subobjectName = '' ) {
 
-		if ( $this->isUserDefined() ) {
-			$dbkey = $this->m_key;
-		} else {
+		$dbkey = $this->m_key;
+
+		if ( !$this->isUserDefined() ) {
 			$dbkey = $this->getLabel();
 		}
 
@@ -290,29 +311,45 @@ class DIProperty extends SMWDataItem {
 	}
 
 	/**
-	 * @since  2.0
+	 * @deprecated since 3.0, use DIProperty::setPropertyValueType
+	 */
+	public function setPropertyTypeId( $valueType ) {
+		return $this->setPropertyValueType( $valueType );
+	}
+
+	/**
+	 * @since 3.0
+	 *
+	 * @param string $valueType
 	 *
 	 * @return self
 	 * @throws DataTypeLookupExeption
-	 * @throws InvalidArgumentException
+	 * @throws RuntimeException
 	 */
-	public function setPropertyTypeId( $propertyTypeId ) {
+	public function setPropertyValueType( $valueType ) {
 
-		if ( !DataTypeRegistry::getInstance()->isRegistered( $propertyTypeId ) ) {
-			throw new DataTypeLookupExeption( "{$propertyTypeId} is an unknown type id" );
+		if ( !DataTypeRegistry::getInstance()->isRegistered( $valueType ) ) {
+			throw new DataTypeLookupExeption( "{$valueType} is an unknown type id" );
 		}
 
-		if ( $this->isUserDefined() && $this->m_proptypeid === null ) {
-			$this->m_proptypeid = $propertyTypeId;
+		if ( $this->isUserDefined() && $this->propertyValueType === null ) {
+			$this->propertyValueType = $valueType;
 			return $this;
 		}
 
-		if ( !$this->isUserDefined() && $propertyTypeId === self::getPredefinedPropertyTypeId( $this->m_key ) ) {
-			$this->m_proptypeid = $propertyTypeId;
+		if ( !$this->isUserDefined() && $valueType === PropertyRegistry::getInstance()->getPropertyValueTypeById( $this->m_key ) ) {
+			$this->propertyValueType = $valueType;
 			return $this;
 		}
 
-		throw new RuntimeException( 'Property type can not be altered for a predefined object' );
+		throw new RuntimeException( 'DataType cannot be altered for a predefined property' );
+	}
+
+	/**
+	 * @deprecated since 3.0, use DIProperty::findPropertyValueType
+	 */
+	public function findPropertyTypeId() {
+		return $this->findPropertyValueType();
 	}
 
 	/**
@@ -321,41 +358,55 @@ class DIProperty extends SMWDataItem {
 	 * If no type is stored for a user defined property, the global default
 	 * type will be used.
 	 *
+	 * @since 3.0
+	 *
 	 * @return string type ID
 	 */
-	public function findPropertyTypeID() {
-		global $smwgPDefaultType;
+	public function findPropertyValueType() {
 
-		if ( !isset( $this->m_proptypeid ) ) {
-			if ( $this->isUserDefined() ) { // normal property
-				$diWikiPage = new DIWikiPage( $this->getKey(), SMW_NS_PROPERTY, $this->interwiki );
-				$typearray = ApplicationFactory::getInstance()->getStore()->getPropertyValues( $diWikiPage, new self( '_TYPE' ) );
-
-				if ( count( $typearray ) >= 1 ) { // some types given, pick one (hopefully unique)
-					$typeDataItem = reset( $typearray );
-
-					if ( $typeDataItem instanceof SMWDIUri ) {
-						$this->m_proptypeid = $typeDataItem->getFragment();
-					} else {
-						$this->m_proptypeid = $smwgPDefaultType;
-						// This is important. If a page has an invalid assignment to "has type", no
-						// value will be stored, so the elseif case below occurs. But if the value
-						// is retrieved within the same run, then the error value for "has type" is
-						// cached and thus this case occurs. This is why it is important to tolerate
-						// this case -- it is not necessarily a DB error.
-					}
-				} elseif ( count( $typearray ) == 0 ) { // no type given
-					$this->m_proptypeid = $smwgPDefaultType;
-				}
-			} else { // pre-defined property
-				$this->m_proptypeid = PropertyRegistry::getInstance()->getPredefinedPropertyTypeId( $this->m_key );
-			}
+		if ( isset( $this->propertyValueType ) ) {
+			return $this->propertyValueType;
 		}
 
-		return $this->m_proptypeid;
+		if ( !$this->isUserDefined() ) {
+			return $this->propertyValueType = PropertyRegistry::getInstance()->getPropertyValueTypeById( $this->m_key );
+		}
+
+		$diWikiPage = new DIWikiPage( $this->getKey(), SMW_NS_PROPERTY, $this->interwiki );
+		$applicationFactory = ApplicationFactory::getInstance();
+
+		$defaultType = $applicationFactory->getSettings()->get( 'smwgPDefaultType' );
+
+		$typearray = $applicationFactory->getStore()->getPropertyValues(
+			$diWikiPage,
+			new self( '_TYPE' )
+		);
+
+		if ( count( $typearray ) >= 1 ) { // some types given, pick one (hopefully unique)
+			$typeDataItem = reset( $typearray );
+
+			if ( $typeDataItem instanceof SMWDIUri ) {
+				$this->propertyValueType = $typeDataItem->getFragment();
+			} else {
+				// This is important. If a page has an invalid assignment to "has type", no
+				// value will be stored, so the elseif case below occurs. But if the value
+				// is retrieved within the same run, then the error value for "has type" is
+				// cached and thus this case occurs. This is why it is important to tolerate
+				// this case -- it is not necessarily a DB error.
+				$this->propertyValueType = $defaultType;
+			}
+		} elseif ( count( $typearray ) == 0 ) { // no type given
+			$this->propertyValueType = $defaultType;
+		}
+
+		return $this->propertyValueType;
 	}
 
-
+	/**
+	 * @see DataItem::getSerialization
+	 *
+	 * @return string
+	 */
 	public function getSerialization() {
 		return ( $this->m_inverse ? '-' : '' ) . $this->m_key;
 	}
@@ -441,41 +492,6 @@ class DIProperty extends SMWDataItem {
 		}
 
 		return new self( $id, $inverse );
-	}
-
-	/**
-	 * @deprecated since 2.1, use PropertyRegistry::findPropertyIdByLabel
-	 */
-	public static function findPropertyID( $label, $useAlias = true ) {
-		return PropertyRegistry::getInstance()->findPropertyIdByLabel( $label, $useAlias );
-	}
-
-	/**
-	 * @deprecated since 2.1, use PropertyRegistry::getPredefinedPropertyTypeId
-	 */
-	public static function getPredefinedPropertyTypeId( $key ) {
-		return PropertyRegistry::getInstance()->getPredefinedPropertyTypeId( $key );
-	}
-
-	/**
-	 * @deprecated since 2.1, use PropertyRegistry::findPropertyLabelById
-	 */
-	static public function findPropertyLabel( $id ) {
-		return PropertyRegistry::getInstance()->findPropertyLabel( $id );
-	}
-
-	/**
-	 * @deprecated since 2.1, use PropertyRegistry::registerProperty
-	 */
-	static public function registerProperty( $id, $typeid, $label = false, $show = false ) {
-		PropertyRegistry::getInstance()->registerProperty( $id, $typeid, $label, $show);
-	}
-
-	/**
-	 * @deprecated since 2.1, use PropertyRegistry::registerPropertyAlias
-	 */
-	static public function registerPropertyAlias( $id, $label ) {
-		PropertyRegistry::getInstance()->registerPropertyAlias( $id, $label );
 	}
 
 	private function newDIWikiPage( $dbkey, $subobjectName ) {

--- a/src/HashBuilder.php
+++ b/src/HashBuilder.php
@@ -157,7 +157,7 @@ class HashBuilder {
 		// A leading underscore is an internal SMW convention to describe predefined
 		// properties and as such need to be transformed into a valid representation
 		if ( $title{0} === '_' ) {
-			$title = str_replace( ' ', '_', DIProperty::findPropertyLabel( $title ) );
+			$title = str_replace( ' ', '_', PropertyRegistry::getInstance()->findPropertyLabelById( $title ) );
 		}
 
 		return new DIWikiPage( $title, $namespace, $interwiki, $subobjectName );

--- a/src/PropertyRestrictionExaminer.php
+++ b/src/PropertyRestrictionExaminer.php
@@ -158,7 +158,7 @@ class PropertyRestrictionExaminer {
 			return false;
 		}
 
-		if ( PropertyRegistry::getInstance()->isAnnotable( $property->getKey() ) ) {
+		if ( $property->isUserAnnotable() ) {
 			return false;
 		}
 

--- a/src/SQLStore/EntityRebuildDispatcher.php
+++ b/src/SQLStore/EntityRebuildDispatcher.php
@@ -4,9 +4,9 @@ namespace SMW\SQLStore;
 
 use Hooks;
 use SMW\ApplicationFactory;
-use SMW\DIProperty;
 use SMW\DIWikiPage;
 use SMW\SemanticData;
+use SMW\PropertyRegistry;
 use SMW\Store;
 use Title;
 
@@ -282,7 +282,7 @@ class EntityRebuildDispatcher {
 			if ( $row->smw_title != '' && $row->smw_title{0} != '_' ) {
 				$titleKey = $row->smw_title;
 			} elseif ( $row->smw_namespace == SMW_NS_PROPERTY && $row->smw_iw == '' && $row->smw_subobject == '' ) {
-				$titleKey = str_replace( ' ', '_', DIProperty::findPropertyLabel( $row->smw_title ) );
+				$titleKey = str_replace( ' ', '_', PropertyRegistry::getInstance()->findPropertyLabelById( $row->smw_title ) );
 			} else {
 				$titleKey = '';
 			}

--- a/src/SQLStore/PropertyTableDefinitionBuilder.php
+++ b/src/SQLStore/PropertyTableDefinitionBuilder.php
@@ -5,6 +5,7 @@ namespace SMW\SQLStore;
 use Hooks;
 use SMW\DataTypeRegistry;
 use SMW\DIProperty;
+use SMW\PropertyRegistry;
 use SMWDataItem as DataItem;
 
 /**
@@ -186,7 +187,7 @@ class PropertyTableDefinitionBuilder {
 			$propertyKey = is_int( $propertyKey ) ? $propertyTableSuffix : $propertyKey;
 
 			$this->addPropertyTable(
-				DataTypeRegistry::getInstance()->getDataItemId( DIProperty::getPredefinedPropertyTypeId( $propertyKey ) ),
+				DataTypeRegistry::getInstance()->getDataItemByType( PropertyRegistry::getInstance()->getPropertyValueTypeById( $propertyKey ) ),
 				$tablePrefix . strtolower( $propertyTableSuffix ),
 				$propertyKey
 			);
@@ -223,7 +224,7 @@ class PropertyTableDefinitionBuilder {
 			$property = new DIProperty( $propertyKey );
 
 			$this->addPropertyTable(
-				DataTypeRegistry::getInstance()->getDataItemId( $this->propertyTypeFinder->findTypeID( $property ) ),
+				DataTypeRegistry::getInstance()->getDataItemByType( $this->propertyTypeFinder->findTypeID( $property ) ),
 				$this->createHashedTableNameFrom( $propertyKey ),
 				$propertyKey
 			);

--- a/tests/phpunit/includes/dataitems/DIPropertyTest.php
+++ b/tests/phpunit/includes/dataitems/DIPropertyTest.php
@@ -3,39 +3,80 @@
 namespace SMW\Tests;
 
 use SMW\DIProperty;
+use SMW\PropertyRegistry;
 use SMW\DIWikiPage;
+use SMWDataItem as DataItem;
 
 /**
  * @covers \SMW\DIProperty
- * @covers SMWDataItem
+ * @group semantic-mediawiki
  *
- * @group SMW
- * @group SMWExtension
- * @group SMWDataItems
+ * @license GNU GPL v2+
+ * @since 2.1
  *
+ * @author mwjames
  * @author Nischay Nahata
  * @author Jeroen De Dauw < jeroendedauw@gmail.com >
  */
-class DIPropertyTest extends DataItemTest {
+class DIPropertyTest extends \PHPUnit_Framework_TestCase {
 
-	/**
-	 * @see DataItemTest::getClass
-	 *
-	 * @since 1.8
-	 *
-	 * @return string
-	 */
-	public function getClass() {
-		return '\SMWDIProperty';
+	protected function tearDown() {
+		PropertyRegistry::clear();
+		parent::tearDown();
 	}
 
 	/**
-	 * @see DataItemTest::constructorProvider
-	 *
-	 * @since 1.8
-	 *
-	 * @return array
+	 * @dataProvider constructorProvider
 	 */
+	public function testCanConstruct( $arg ) {
+
+		$this->assertInstanceOf(
+			DataItem::class,
+			new DIProperty( $arg )
+		);
+
+		$this->assertInstanceOf(
+			DIProperty::class,
+			new DIProperty( $arg )
+		);
+	}
+
+	/**
+	 * @dataProvider constructorProvider
+	 */
+	public function testSerialization( $arg ) {
+		$instance = new DIProperty( $arg );
+
+		$this->assertEquals(
+			$instance,
+			$instance->doUnserialize( $instance->getSerialization() )
+		);
+	}
+
+	/**
+	 * @dataProvider constructorProvider
+	 */
+	public function testInstanceEqualsItself( $arg ) {
+
+		$instance = new DIProperty( $arg );
+
+		$this->assertTrue(
+			$instance->equals( $instance )
+		);
+	}
+
+	/**
+	 * @dataProvider constructorProvider
+	 */
+	public function testInstanceDoesNotEqualNyanData( $arg ) {
+
+		$instance = new DIProperty( $arg );
+
+		$this->assertFalse(
+			$instance->equals( new \SMWDIBlob( '~=[,,_,,]:3' ) )
+		);
+	}
+
 	public function constructorProvider() {
 		return array(
 			array( 0 ),


### PR DESCRIPTION
This PR is made in reference to: #1014

This PR addresses or contains:

- Selected methods have been deprecated since 2.1 including:
  - Removed `DIProperty::findPropertyID`, deprecated since 2.1, use `PropertyRegistry::findPropertyIdByLabel`
  - Removed `DIProperty::getPredefinedPropertyTypeId`, deprecated since 2.1, use `PropertyRegistry::getPropertyValueTypeById`
  - Removed `DIProperty::findPropertyLabel`, deprecated since 2.1, use `PropertyRegistry::findPropertyLabelById`
  - Removed `DIProperty::registerProperty`, deprecated since 2.1, use `PropertyRegistry::registerProperty`
  - Removed `DIProperty::registerPropertyAlias`, deprecated since 2.1, use `PropertyRegistry::registerPropertyAlias`

This PR includes:
- [ ] Tests (unit/integration)
- [x] CI build passed

Fixes #