### PR TITLE
Adds a default message to the `#smwdoc` parser function

### DIFF
--- a/i18n/en.json
+++ b/i18n/en.json
@@ -80,6 +80,7 @@
 	"smw-paramdesc-dsv-filename": "The name for the DSV file",
 	"smw-paramdesc-filename": "The name for the output file",
 	"smw-smwdoc-description": "Shows a table of all parameters that can be used for the specified result format together with default values and descriptions.",
+	"smw-smwdoc-default-no-parameter-list": "This result format does not provide format specific parameters.",
 	"smw-smwdoc-par-format": "The result format to display parameter documentation for.",
 	"smw-smwdoc-par-parameters": "Which parameters to show. \"specific\" for those added by the format, \"base\" for those available in all formats, and \"all\" for both.",
 	"smw-paramdesc-sort": "Property to sort the query by",

--- a/i18n/qqq.json
+++ b/i18n/qqq.json
@@ -90,6 +90,7 @@
 	"smw-paramdesc-dsv-filename": "This is the description of the \"filename\" parameter for the \"dsv\" [https://semantic-mediawiki.org/wiki/Help:Result_formats result format] for [https://semantic-mediawiki.org/wiki/Help:Inline_queries inline queries].",
 	"smw-paramdesc-filename": "This is the description of the \"filename\" parameter for the [https://semantic-mediawiki.org/wiki/Help:Result_formats result format] for [https://semantic-mediawiki.org/wiki/Help:Inline_queries inline queries].",
 	"smw-smwdoc-description": "This is the short description of the [https://semantic-mediawiki.org/wiki/Help:Generating_documentation smwdoc parser function].",
+	"smw-smwdoc-default-no-parameter-list": "This is an informatory message.",
 	"smw-smwdoc-par-format": "This is the description of the parameter \"format\" of the [https://semantic-mediawiki.org/wiki/Help:Generating_documentation smwdoc parser function].",
 	"smw-smwdoc-par-parameters": "This is the description of the parameter \"parameters\" of the [https://semantic-mediawiki.org/wiki/Help:Generating_documentation smwdoc parser function]. {{doc-important|Do not translate the possible parameter values \"specific\", \"base\" and \"all\".}}",
 	"smw-paramdesc-sort": "This is the description of the \"sort\" parameter for [https://semantic-mediawiki.org/wiki/Help:Inline_queries#Standard_parameters_for_inline_queries inline queries].",

--- a/src/ParserFunctions/DocumentationParserFunction.php
+++ b/src/ParserFunctions/DocumentationParserFunction.php
@@ -25,7 +25,7 @@ class DocumentationParserFunction implements HookHandler {
 	/**
 	 * @var string
 	 */
-	private $language;
+	private $language = 'en';
 
 	/**
 	 * @param Parser $parser

--- a/src/ParserFunctions/DocumentationParserFunction.php
+++ b/src/ParserFunctions/DocumentationParserFunction.php
@@ -57,7 +57,13 @@ class DocumentationParserFunction implements HookHandler {
 
 		$docBuilder = new ParameterListDocBuilder( $this->newMessageFunction() );
 
-		return $docBuilder->getParameterTable( $params );
+		if ( ( $output = $docBuilder->getParameterTable( $params ) ) === '' ) {
+			$output = wfMessage(
+				'smw-smwdoc-default-no-parameter-list',	$parameters['format']->getValue()
+			)->inLanguage( $this->language )->text();
+		}
+		
+		return $output;
 	}
 
 	private function newMessageFunction() {

--- a/tests/phpunit/Unit/ParserFunctions/DocumentationParserFunctionTest.php
+++ b/tests/phpunit/Unit/ParserFunctions/DocumentationParserFunctionTest.php
@@ -34,6 +34,14 @@ class DocumentationParserFunctionTest extends \PHPUnit_Framework_TestCase {
 		$processedParam = $this->getMockBuilder( '\ParamProcessor\ProcessedParam' )
 			->disableOriginalConstructor()
 			->getMock();
+		
+		$language = $this->getMockBuilder( '\ParamProcessor\ProcessedParam' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$language->expects( $this->any() )
+			->method( 'getValue' )
+			->will( $this->returnValue( 'en' ) );
 
 		$processingResult = $this->getMockBuilder( '\ParamProcessor\ProcessingResult' )
 			->disableOriginalConstructor()
@@ -42,7 +50,7 @@ class DocumentationParserFunctionTest extends \PHPUnit_Framework_TestCase {
 		$processingResult->expects( $this->any() )
 			->method( 'getParameters' )
 			->will( $this->returnValue( array(
-				'language'   => $processedParam,
+				'language'   => $language,
 				'format'     => $processedParam,
 				'parameters' => $processedParam ) ) );
 


### PR DESCRIPTION
This PR is made in reference to: #2950 

This PR addresses or contains:
- Adds a default message to the `#smwdoc` parser function which is being shown in case not parameters are available

Code changes as suggested by @mwjames 

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed

Fixes: #2950