### PR TITLE
ExportController to mark subobject entities as done

### DIFF
--- a/includes/export/SMW_ExportController.php
+++ b/includes/export/SMW_ExportController.php
@@ -149,8 +149,20 @@ class SMWExportController {
 		$expData = SMWExporter::getInstance()->makeExportData( $semData );
 		$this->serializer->serializeExpData( $expData, $recursiondepth );
 
-		foreach( $semData->getSubSemanticData() as $subobjectSemData ) {
-			$this->serializer->serializeExpData( SMWExporter::getInstance()->makeExportData( $subobjectSemData ) );
+		foreach( $semData->getSubSemanticData() as $subSemanticData ) {
+
+			// Mark SubSemanticData subjects as well to ensure that backlinks to
+			// the same subject do not create duplicate XML export entities
+			$this->markPageAsDone(
+				$subSemanticData->getSubject(),
+				$recursiondepth
+			);
+
+			$expData = SMWExporter::getInstance()->makeExportData(
+				$subSemanticData
+			);
+
+			$this->serializer->serializeExpData( $expData );
 		}
 
 		// let other extensions add additional RDF data for this page


### PR DESCRIPTION
This PR is made in reference to: #

This PR addresses or contains:

- This ensures that `subobject` entities are not added twice especially when backlinks are requested

![image](https://user-images.githubusercontent.com/1245473/35183048-7886e87c-fdd7-11e7-83ae-3d82c19f745e.png)

This PR includes:
- [ ] Tests (unit/integration)
- [x] CI build passed

Fixes #