### PR TITLE
Renamed `smwAddToRDFExport` hook, refs 1014

### DIFF
--- a/docs/technical/hooks.md
+++ b/docs/technical/hooks.md
@@ -281,11 +281,29 @@ Hooks::register( 'SMW::Setup::AfterInitializationComplete', function( &$vars ) {
 } );
 </pre>
 
+### SMW::Exporter::AddExpDataAfterPageSerializationComplete
+
+* Version: 3.0
+* Description: Hook allows to add additional RDF data for a selected page (was `smwAddToRDFExport`)
+* Reference class: `SMWExportController`
+
+<pre>
+use Hooks;
+
+Hooks::register( 'SMW::Exporter::AddExpDataAfterPageSerializationComplete', function( DIWikiPage $subject, &$extraExpDataList, $hasRecursionDepth, $withBacklinks ) {
+
+	$expData = new ExpData( ... );
+
+	$extraExpDataList[] = $expData;
+
+	return true;
+} );
+</pre>
+
 ## Other available hooks
 
 Subsequent hooks should be renamed to follow a common naming practice that help distinguish them from other hook providers. In any case this list needs details and examples.
 
-* `SMWExportController`, smwAddToRDFExport (SMW::Exporter::AfterRdfExportComplete)
 * `SMWParamFormat`, SMWResultFormat
 * `\SMW\Store`, SMWStore::updateDataBefore (SMW::Store::BeforeDataUpdateComplete)
 * `\SMW\Store`, SMWStore::updateDataAfter (SMW::Store::AfterDataUpdateComplete)

--- a/docs/technical/migration-guide-3.0.md
+++ b/docs/technical/migration-guide-3.0.md
@@ -22,6 +22,10 @@
 - Removed `DIProperty::registerProperty`, deprecated since 2.1, use PropertyRegistry::registerProperty
 - Removed `DIProperty::registerPropertyAlias`, deprecated since 2.1, use PropertyRegistry::registerPropertyAlias
 
+## Hooks
+
+- Renamed `smwAddToRDFExport` to `SMW::Exporter::AddExpDataAfterPageSerializationComplete`
+
 ## Store
 
 - `Store::getPropertySubjects` is to return an `Iterator` hence an `array`

--- a/includes/export/SMW_ExportController.php
+++ b/includes/export/SMW_ExportController.php
@@ -166,10 +166,25 @@ class SMWExportController {
 		}
 
 		// let other extensions add additional RDF data for this page
-		$additionalDataArray = array();
-		\Hooks::run( 'smwAddToRDFExport', array( $diWikiPage, &$additionalDataArray, ( $recursiondepth != 0 ), $this->add_backlinks ) );
-		foreach ( $additionalDataArray as $additionalData ) {
-			$this->serializer->serializeExpData( $additionalData ); // serialise
+		$extraExpDataList = array();
+
+		\Hooks::run(
+			'SMW::Exporter::AddExpDataAfterPageSerializationComplete',
+			[
+				$diWikiPage,
+				&$extraExpDataList,
+				( $recursiondepth != 0 ),
+				$this->add_backlinks
+			]
+		);
+
+		foreach ( $extraExpDataList as $extraExpData ) {
+
+			if ( !$extraExpData instanceof SMWExpData ) {
+				continue;
+			}
+
+			$this->serializer->serializeExpData( $extraExpData );
 		}
 
 		if ( $recursiondepth != 0 ) {


### PR DESCRIPTION
This PR is made in reference to: #1014

This PR addresses or contains:

- Renames the hook `smwAddToRDFExport` to `SMW::Exporter::AddExpDataAfterPageSerializationComplete`

This PR includes:
- [ ] Tests (unit/integration)
- [x] CI build passed

Fixes #