### PR TITLE
Option allow dot notation array access

### DIFF
--- a/src/Options.php
+++ b/src/Options.php
@@ -87,6 +87,37 @@ class Options {
 	 * @since 3.0
 	 *
 	 * @param string $key
+	 * @param mixed $default
+	 *
+	 * @return mixed
+	 */
+	public function dotGet( $key, $default = false ) {
+		return $this->digDeep( $this->options, $key, $default );
+	}
+
+	private function digDeep( $array, $key, $default ) {
+
+		if ( strpos( $key, '.' ) !== false ) {
+			$list = explode( '.', $key, 2 );
+
+			foreach ( $list as $k => $v ) {
+				if ( isset( $array[$v] ) ) {
+					return $this->digDeep( $array[$v], $list[$k+1], $default );
+				}
+			}
+		}
+
+		if ( isset( $array[$key] ) ) {
+			return $array[$key];
+		}
+
+		return $default;
+	}
+
+	/**
+	 * @since 3.0
+	 *
+	 * @param string $key
 	 * @param integer $flag
 	 *
 	 * @return boolean

--- a/tests/phpunit/Unit/OptionsTest.php
+++ b/tests/phpunit/Unit/OptionsTest.php
@@ -84,6 +84,19 @@ class OptionsTest extends \PHPUnit_Framework_TestCase {
 	}
 
 	/**
+	 * @dataProvider dotProvider
+	 */
+	public function testDotGet( $options, $key, $expected ) {
+
+		$instance = new Options( $options );
+
+		$this->assertEquals(
+			$expected,
+			$instance->dotGet( $key )
+		);
+	}
+
+	/**
 	 * @dataProvider isFlagSetProvider
 	 */
 	public function testIsFlagSet( $value, $flag, $expected ) {
@@ -171,6 +184,46 @@ class OptionsTest extends \PHPUnit_Framework_TestCase {
 		yield [
 			false,
 			2,
+			false
+		];
+	}
+
+	public function dotProvider() {
+
+		$o = [ 'Foo' => [
+			'Bar' => [ 'Foobar' => 42 ],
+			'Foobar' => 1001,
+			'some.other.options' => 9999
+			],
+		];
+
+		yield [
+			$o,
+			'Foo.Bar',
+			[ 'Foobar' => 42 ]
+		];
+
+		yield [
+			$o,
+			'Foo.Foobar',
+			1001
+		];
+
+		yield [
+			$o,
+			'Foo.Bar.Foobar',
+			 42
+		];
+
+		yield [
+			$o,
+			'Foo.some.other.options',
+			9999
+		];
+
+		yield [
+			$o,
+			'Foo.Bar.Foobar.unkown',
 			false
 		];
 	}


### PR DESCRIPTION
This PR is made in reference to: #

This PR addresses or contains:

- Convenience access to an array element via `Foo.Bar` (traverses the key path e.g. `[ Foo => [ 'Bar' => 42 ] ];`)

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed
