### PR TITLE
Use `Maintenance::getDB` in `setupStore.php`, refs 2963

### DIFF
--- a/src/Connection/CallbackConnectionProvider.php
+++ b/src/Connection/CallbackConnectionProvider.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace SMW\Connection;
+
+use Closure;
+
+/**
+ * @license GNU GPL v2+
+ * @since 3.0
+ *
+ * @author mwjames
+ */
+class CallbackConnectionProvider implements ConnectionProvider {
+
+	/**
+	 * @var callable
+	 */
+	private $callback;
+
+	/**
+	 * @var mixed
+	 */
+	private $connection;
+
+	/**
+	 * @since 3.0
+	 *
+	 * @param callable $callback
+	 */
+	public function __construct( callable $callback ) {
+		$this->callback = $callback;
+	}
+
+	/**
+	 * @since 3.0
+	 *
+	 * @return mixed
+	 */
+	public function getConnection() {
+
+		if ( $this->connection === null ) {
+			$this->connection = call_user_func( $this->callback );
+		}
+
+		return $this->connection;
+	}
+
+	/**
+	 * @since 3.0
+	 */
+	public function releaseConnection() {
+		$this->connection = null;
+	}
+
+}

--- a/tests/phpunit/Unit/Connection/CallbackConnectionProviderTest.php
+++ b/tests/phpunit/Unit/Connection/CallbackConnectionProviderTest.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace SMW\Tests\Connection;
+
+use SMW\Connection\CallbackConnectionProvider;
+
+/**
+ * @covers \SMW\Connection\CallbackConnectionProvider
+ * @group semantic-mediawiki
+ *
+ * @license GNU GPL v2+
+ * @since 3.0
+ *
+ * @author mwjames
+ */
+class CallbackConnectionProviderTest extends \PHPUnit_Framework_TestCase {
+
+	private $conection;
+
+	public function setUp() {
+
+		$this->connection = $this->getMockBuilder( '\stdClass' )
+			->disableOriginalConstructor()
+			->getMock();
+	}
+
+	public function testCanConstruct() {
+
+		$callback = function() {};
+
+		$this->assertInstanceOf(
+			CallbackConnectionProvider::class,
+			new CallbackConnectionProvider( $callback )
+		);
+	}
+
+	public function getConnection() {
+		return $this->connection;
+	}
+
+	public function testGetConnectionFormCallback() {
+
+		$callback = function() {
+			return $this->connection;
+		};
+
+		$instance = new CallbackConnectionProvider(
+			$callback
+		);
+
+		$this->assertEquals(
+			$this->connection,
+			$instance->getConnection()
+		);
+	}
+
+	public function testGetConnectionFormStaticCallback() {
+
+		$instance = new CallbackConnectionProvider(
+			[ $this, 'getConnection' ]
+		);
+
+		$this->assertEquals(
+			$this->connection,
+			$instance->getConnection()
+		);
+	}
+
+}


### PR DESCRIPTION
This PR is made in reference to: #2963

This PR addresses or contains:

- Adds `CallbackConnectionProvider`
- Uses `Maintenance::getDB` in `setupStore.php` which is expected to address #2963 (`$wgDBadminuser` issue) but has not explicitly tested whether this resolves it or not

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed

Fixes #2963