### PR TITLE
Fix PHP 7.2 Countable issue, refs 2965, 2964

### DIFF
--- a/includes/dataitems/SMW_DI_Property.php
+++ b/includes/dataitems/SMW_DI_Property.php
@@ -382,7 +382,7 @@ class DIProperty extends SMWDataItem {
 			new self( '_TYPE' )
 		);
 
-		if ( count( $typearray ) >= 1 ) { // some types given, pick one (hopefully unique)
+		if ( is_array( $typearray ) && count( $typearray ) >= 1 ) { // some types given, pick one (hopefully unique)
 			$typeDataItem = reset( $typearray );
 
 			if ( $typeDataItem instanceof SMWDIUri ) {
@@ -395,7 +395,7 @@ class DIProperty extends SMWDataItem {
 				// this case -- it is not necessarily a DB error.
 				$this->propertyValueType = $defaultType;
 			}
-		} elseif ( count( $typearray ) == 0 ) { // no type given
+		} else { // no type given
 			$this->propertyValueType = $defaultType;
 		}
 

--- a/includes/datavalues/SMW_DV_Time.php
+++ b/includes/datavalues/SMW_DV_Time.php
@@ -256,7 +256,7 @@ class SMWTimeValue extends SMWDataValue {
 			} elseif ( $prevmatchwasnumber && $prevmatchwasdate && in_array( $match, array( 'st', 'nd', 'rd', 'th' ) ) ) {
 				$datecomponents[] = 'd' . strval( array_pop( $datecomponents ) ); // must be a day; add standard marker
 				$matchisdate = true;
-			} elseif ( count( $match ) == 1 ) {
+			} elseif ( is_string( $match ) ) {
 				$microseconds = $match;
 			} else {
 				$unclearparts[] = $match;

--- a/includes/querypages/PropertiesQueryPage.php
+++ b/includes/querypages/PropertiesQueryPage.php
@@ -223,7 +223,7 @@ class PropertiesQueryPage extends QueryPage {
 		$typeProperty = new DIProperty( '_TYPE' );
 		$types = $this->store->getPropertyValues( $property->getDiWikiPage(), $typeProperty );
 
-		if ( count( $types ) >= 1 ) {
+		if ( is_array( $types ) && count( $types ) >= 1 ) {
 			$typeDataValue = DataValueFactory::getInstance()->newDataValueByItem( current( $types ), $typeProperty );
 			$typestring = $typeDataValue->getLongHTMLText( $this->getLinker() );
 		} else {

--- a/includes/querypages/UnusedPropertiesQueryPage.php
+++ b/includes/querypages/UnusedPropertiesQueryPage.php
@@ -157,7 +157,7 @@ class UnusedPropertiesQueryPage extends QueryPage {
 
 			$types = $this->store->getPropertyValues( $property->getDiWikiPage(), new DIProperty( '_TYPE' ) );
 
-			if ( count( $types ) >= 1 ) {
+			if ( is_array( $types ) && count( $types ) >= 1 ) {
 				$typeDataValue = DataValueFactory::getInstance()->newDataValueByItem( current( $types ), new DIProperty( '_TYPE' ) );
 			} else {
 				$typeDataValue = SMWTypesValue::newFromTypeId( '_wpg' );

--- a/includes/storage/SMW_Store.php
+++ b/includes/storage/SMW_Store.php
@@ -126,7 +126,7 @@ abstract class Store implements QueryEngine {
 
 		$dataItems = $this->getPropertyValues( $dataItem, new DIProperty( '_SKEY' ) );
 
-		if ( count( $dataItems ) > 0 ) {
+		if ( is_array( $dataItems ) && count( $dataItems ) > 0 ) {
 			return end( $dataItems )->getString();
 		}
 
@@ -163,7 +163,7 @@ abstract class Store implements QueryEngine {
 
 		$dataItems = $this->getPropertyValues( $wikipage, new DIProperty( '_REDI' ) );
 
-		if ( count( $dataItems ) > 0 ) {
+		if ( is_array( $dataItems ) && count( $dataItems ) > 0 ) {
 
 			$redirectDataItem = end( $dataItems );
 

--- a/src/MediaWiki/Specials/Ask/ParametersProcessor.php
+++ b/src/MediaWiki/Specials/Ask/ParametersProcessor.php
@@ -112,7 +112,7 @@ class ParametersProcessor {
 			// Count doesn't match means we have a order from an
 			// empty (#subject) carrying around which we don't permit when
 			// sorting via columns
-			if ( count( $order_values ) != $sort_count ) {
+			if ( is_array( $order_values ) && count( $order_values ) != $sort_count ) {
 				array_pop( $order_values );
 			}
 

--- a/src/MediaWiki/Specials/PropertyLabelSimilarity/ContentsBuilder.php
+++ b/src/MediaWiki/Specials/PropertyLabelSimilarity/ContentsBuilder.php
@@ -65,10 +65,12 @@ class ContentsBuilder {
 			$requestOptions
 		);
 
+		$resultCount = is_array( $result ) ? count( $result ) : 0;
+
 		$html = $this->getForm(
 			$requestOptions->getLimit(),
 			$requestOptions->getOffset(),
-			count( $result ),
+			$resultCount,
 			$threshold,
 			$type
 		);

--- a/src/Page/ListBuilder/ListBuilder.php
+++ b/src/Page/ListBuilder/ListBuilder.php
@@ -126,13 +126,13 @@ class ListBuilder {
 		$more = false;
 
 		// Pop the +1 look ahead from the list
-		if ( count( $subjectList ) > $this->listLimit ) {
+		if ( is_array( $subjectList ) && count( $subjectList ) > $this->listLimit ) {
 			array_pop( $subjectList );
 			$more = true;
 		}
 
 		$result = '';
-		$resultCount = count( $subjectList );
+		$resultCount = is_array( $subjectList ) ? count( $subjectList ) : 0;
 
 		$callback = null;
 		$message = wfMessage( 'smw-propertylist-count', $resultCount )->text();

--- a/src/Query/Processor/ParamListProcessor.php
+++ b/src/Query/Processor/ParamListProcessor.php
@@ -214,7 +214,7 @@ class ParamListProcessor {
 		// #1645
 		$parts = $showMode && $name == 0 ? $param : explode( '=', $param, 2 );
 
-		if ( count( $parts ) >= 2 ) {
+		if ( is_array( $parts ) && count( $parts ) >= 2 ) {
 			$p = strtolower( trim( $parts[0] ) );
 
 			// don't trim here, some parameters care for " "

--- a/src/SPARQLStore/RepositoryRedirectLookup.php
+++ b/src/SPARQLStore/RepositoryRedirectLookup.php
@@ -82,7 +82,7 @@ class RepositoryRedirectLookup {
 			return $expNsResource;
 		}
 
-		if ( count( $firstRow ) > 1 && !is_null( $firstRow[1] ) ) {
+		if ( is_array( $firstRow ) && count( $firstRow ) > 1 && !is_null( $firstRow[1] ) ) {
 			return $this->getResourceForTargetElement( $expNsResource, $firstRow[1] );
 		}
 

--- a/tests/phpunit/Unit/SQLStore/EntityStore/TraversalPropertyLookupTest.php
+++ b/tests/phpunit/Unit/SQLStore/EntityStore/TraversalPropertyLookupTest.php
@@ -93,7 +93,7 @@ class TraversalPropertyLookupTest extends \PHPUnit_Framework_TestCase {
 
 		$resultWrapper = $this->getMockBuilder( '\FakeResultWrapper' )
 			->disableOriginalConstructor()
-			->getMockForAbstractClass();
+			->getMock();
 
 		$dataItemHandler = $this->getMockBuilder( '\SMW\SQLStore\EntityStore\DataItemHandler' )
 			->disableOriginalConstructor()


### PR DESCRIPTION
This PR is made in reference to: #2965, #2964

This PR addresses or contains:

- Making some educated guesses on the Countable issue "Warning: count(): Parameter must be an array or an object that implements Countable"

This PR includes:
- [ ] Tests (unit/integration)
- [x] CI build passed

Fixes #2964