### PR TITLE
Make QUnit tests great again, refs 2849

### DIFF
--- a/tests/qunit/smw/data/ext.smw.data.test.js
+++ b/tests/qunit/smw/data/ext.smw.data.test.js
@@ -50,7 +50,8 @@
 	 *
 	 * @since: 1.9
 	 */
-	QUnit.test( 'instance', 1, function ( assert ) {
+	QUnit.test( 'instance', function ( assert ) {
+		assert.expect( 1 );
 
 		var result = new smw.Data();
 		assert.ok( result instanceof Object, pass + 'the smw.dataItem instance was accessible' );
@@ -62,7 +63,9 @@
 	 *
 	 * @since: 1.9
 	 */
-	QUnit.test( 'comparison $.parseJSON() vs. smw.Api.parse()', 2, function ( assert ) {
+	QUnit.test( 'comparison $.parseJSON() vs. smw.Api.parse()', function ( assert ) {
+		assert.expect( 2 );
+
 		var result;
 		var startDate;
 		var smwApi = new smw.Api();
@@ -82,7 +85,8 @@
 	 *
 	 * @since: 1.9
 	 */
-	QUnit.test( 'smw.dataItem.property factory test', 5, function ( assert ) {
+	QUnit.test( 'smw.dataItem.property factory test', function ( assert ) {
+		assert.expect( 5 );
 
 		// Testing indirect via the smw.Api otherwise the whole JSON parsing
 		// needs to be copied
@@ -102,7 +106,8 @@
 	 *
 	 * @since: 1.9
 	 */
-	QUnit.test( 'smw.dataItem.property subject less factory test', 3, function ( assert ) {
+	QUnit.test( 'smw.dataItem.property subject less factory test', function ( assert ) {
+		assert.expect( 3 );
 
 		// Testing indirect via the smw.Api otherwise the whole JSON parsing
 		// needs to be copied
@@ -126,7 +131,8 @@
 	 *
 	 * @since: 1.9
 	 */
-	QUnit.test( 'smw.dataItem.wikiPage subject factory test', 3, function ( assert ) {
+	QUnit.test( 'smw.dataItem.wikiPage subject factory test', function ( assert ) {
+		assert.expect( 3 );
 
 		// Testing indirect via the smw.Api otherwise the whole JSON parsing
 		// needs to be copied
@@ -144,7 +150,8 @@
 	 *
 	 * @since: 1.9
 	 */
-	QUnit.test( 'smw.dataItem.wikiPage multiValue factory test', 4, function ( assert ) {
+	QUnit.test( 'smw.dataItem.wikiPage multiValue factory test', function ( assert ) {
+		assert.expect( 4 );
 
 		// Testing indirect via the smw.Api otherwise the whole JSON parsing
 		// needs to be copied
@@ -171,7 +178,8 @@
 	 *
 	 * @since: 1.9
 	 */
-	QUnit.test( 'smw.dataItem.time factory', 4, function ( assert ) {
+	QUnit.test( 'smw.dataItem.time factory', function ( assert ) {
+		assert.expect( 4 );
 
 		// Use as helper to fetch language dep. month name
 		var monthNames = [];
@@ -215,7 +223,8 @@
 	 *
 	 * @since: 1.9
 	 */
-	QUnit.test( 'smw.dataItem.uri factory', 4, function ( assert ) {
+	QUnit.test( 'smw.dataItem.uri factory', function ( assert ) {
+		assert.expect( 4 );
 
 		// Testing indirect via the smw.Api otherwise the whole JSON parsing
 		// needs to be copied
@@ -241,7 +250,8 @@
 	 *
 	 * @since: 1.9
 	 */
-	QUnit.test( 'smw.dataItem.number factory', 3, function ( assert ) {
+	QUnit.test( 'smw.dataItem.number factory', function ( assert ) {
+		assert.expect( 3 );
 
 		// Testing indirect via the smw.Api otherwise the whole JSON parsing
 		// needs to be copied
@@ -250,18 +260,16 @@
 		var expectedNumber = [1220,1320,99];
 		var i=0;
 
-		$.map ( result.query.result.results, function( printouts ) {
-			$.map ( printouts, function( values ) {
-				$.map ( values, function( property ) {
-					if ( property instanceof smw.dataItem.property ){
-						$.map ( property, function( value ) {
-							if ( value instanceof smw.dataItem.number ){
-								assert.equal( value.getNumber(), expectedNumber[i] , pass + 'getNumber() returned ' + expectedNumber[i] );
-								i++;
-							}
-						} );
-					}
-				} );
+		Object.values( result.query.result.results ).forEach( function ( result ) {
+			Object.values( result.printouts ).forEach( function ( property ) {
+				if ( property instanceof smw.dataItem.property ){
+					$.map ( property, function( value ) {
+						if ( value instanceof smw.dataItem.number ){
+							assert.equal( value.getNumber(), expectedNumber[i] , pass + 'getNumber() returned ' + expectedNumber[i] );
+							i++;
+						}
+					} );
+				}
 			} );
 		} );
 	} );
@@ -271,7 +279,8 @@
 	 *
 	 * @since: 1.9
 	 */
-	QUnit.test( 'smw.dataValue.quantity factory', 2, function ( assert ) {
+	QUnit.test( 'smw.dataValue.quantity factory', function ( assert ) {
+		assert.expect( 2 );
 
 		// Testing indirect via the smw.Api otherwise the whole JSON parsing
 		// needs to be copied
@@ -279,18 +288,16 @@
 		var result = smwApi.parse( quantityType );
 		var expected = { value: 891.85, unit: 'km²' };
 
-		$.map ( result.query.result.results, function( printouts ) {
-			$.map ( printouts, function( values ) {
-				$.map ( values, function( property ) {
-					if ( property instanceof smw.dataItem.property ){
-						$.map ( property, function( value ) {
-							if ( value instanceof smw.dataValue.quantity ){
-								assert.equal( value.getValue(), expected.value , pass + 'getValue() returned ' + expected.value );
-								assert.equal( value.getUnit(), expected.unit , pass + 'getUnit() returned ' + expected.unit );
-							}
-						} );
-					}
-				} );
+		Object.values( result.query.result.results ).forEach( function ( result ) {
+			Object.values( result.printouts ).forEach( function ( property ) {
+				if ( property instanceof smw.dataItem.property ){
+					$.map ( property, function( value ) {
+						if ( value instanceof smw.dataValue.quantity ){
+							assert.equal( value.getValue(), expected.value , pass + 'getValue() returned ' + expected.value );
+							assert.equal( value.getUnit(), expected.unit , pass + 'getUnit() returned ' + expected.unit );
+						}
+					} );
+				}
 			} );
 		} );
 	} );
@@ -301,25 +308,24 @@
 	 *
 	 * @since: 1.9
 	 */
-	QUnit.test( 'smw.dataItem.unknown factory', 4, function ( assert ) {
+	QUnit.test( 'smw.dataItem.unknown factory', function ( assert ) {
+		assert.expect( 4 );
 
 		// Testing indirect via the smw.Api otherwise the whole JSON parsing
 		// needs to be copied
 		var smwApi = new smw.Api();
 		var result = smwApi.parse( unknownType );
 
-		$.map ( result.query.result.results, function( printouts ) {
-			$.map ( printouts, function( values ) {
-				$.map ( values, function( property ) {
-					if ( property instanceof smw.dataItem.property ){
-						$.map ( property, function( value ) {
-							if ( value instanceof smw.dataItem.unknown ){
-								assert.ok( value instanceof smw.dataItem.unknown, pass + 'the parser returned a smw.dataItem.unknown object' );
-								assert.equal( value.getDIType(), '_foo' , pass + 'getDIType() returned an unknown type _foo' );
-							}
-						} );
-					}
-				} );
+		Object.values( result.query.result.results ).forEach( function ( result ) {
+			Object.values( result.printouts ).forEach( function ( property ) {
+				if ( property instanceof smw.dataItem.property ){
+					$.map ( property, function( value ) {
+						if ( value instanceof smw.dataItem.unknown ){
+							assert.ok( value instanceof smw.dataItem.unknown, pass + 'the parser returned a smw.dataItem.unknown object' );
+							assert.equal( value.getDIType(), '_foo' , pass + 'getDIType() returned an unknown type _foo' );
+						}
+					} );
+				}
 			} );
 		} );
 	} );

--- a/tests/qunit/smw/data/ext.smw.dataItem.number.test.js
+++ b/tests/qunit/smw/data/ext.smw.dataItem.number.test.js
@@ -28,12 +28,13 @@
 	 *
 	 * @since: 1.9
 	 */
-	QUnit.test( 'instance', 2, function ( assert ) {
+	QUnit.test( 'instance', function ( assert ) {
+		assert.expect( 2 );
 
 		var result = new smw.dataItem.number( 3 );
 		assert.ok( result instanceof Object, pass + 'the smw.dataItem.number instance was accessible' );
 
-		QUnit.raises( function() {
+		assert.throws( function() {
 			new smw.dataItem.number( 'foo' );
 		}, pass + 'an error was raised due to wrong type' );
 
@@ -44,7 +45,8 @@
 	 *
 	 * @since: 1.9
 	 */
-	QUnit.test( 'getDIType', 1, function ( assert ) {
+	QUnit.test( 'getDIType', function ( assert ) {
+		assert.expect( 1 );
 
 		var result = new smw.dataItem.number( 3 );
 		assert.equal( result.getDIType(), '_num', pass + 'returned _num' );
@@ -56,7 +58,9 @@
 	 *
 	 * @since: 1.9
 	 */
-	QUnit.test( 'getNumber', 3, function ( assert ) {
+	QUnit.test( 'getNumber', function ( assert ) {
+		assert.expect( 3 );
+
 		var result;
 
 		$.map( testCases, function ( testCase ) {

--- a/tests/qunit/smw/data/ext.smw.dataItem.property.test.js
+++ b/tests/qunit/smw/data/ext.smw.dataItem.property.test.js
@@ -21,7 +21,8 @@
 	 *
 	 * @since: 1.9
 	 */
-	QUnit.test( 'instance', 1, function ( assert ) {
+	QUnit.test( 'instance', function ( assert ) {
+		assert.expect( 1 );
 
 		var result = new smw.dataItem.property( 'Has test' );
 		assert.ok( result instanceof Object, pass + 'the smw.dataItem.property instance was accessible' );
@@ -33,7 +34,8 @@
 	 *
 	 * @since: 1.9
 	 */
-	QUnit.test( 'getLabel', 1, function ( assert ) {
+	QUnit.test( 'getLabel', function ( assert ) {
+		assert.expect( 1 );
 
 		var result = new smw.dataItem.property( 'Has test' );
 		assert.equal( result.getLabel(), 'Has test', pass + 'a label was returned' );
@@ -45,7 +47,8 @@
 	 *
 	 * @since: 1.9
 	 */
-	QUnit.test( 'getHtml', 2, function ( assert ) {
+	QUnit.test( 'getHtml', function ( assert ) {
+		assert.expect( 2 );
 
 		var result = new smw.dataItem.property( 'Has type' );
 		var href = mw.util.wikiGetlink( 'Property:');

--- a/tests/qunit/smw/data/ext.smw.dataItem.text.test.js
+++ b/tests/qunit/smw/data/ext.smw.dataItem.text.test.js
@@ -21,20 +21,21 @@
 	 *
 	 * @since: 1.9
 	 */
-	QUnit.test( 'instance', 4, function ( assert ) {
+	QUnit.test( 'instance', function ( assert ) {
+		assert.expect( 4 );
 
 		var result = new smw.dataItem.text( 'foo' );
 		assert.ok( result instanceof Object, pass + 'the smw.dataItem.text instance was accessible' );
 
-		QUnit.raises( function() {
+		assert.throws( function() {
 			new smw.dataItem.text( {} );
 		}, pass + 'an error was raised due to the wrong type' );
 
-		QUnit.raises( function() {
+		assert.throws( function() {
 			new smw.dataItem.text( [] );
 		}, pass + 'an error was raised due to the wrong type' );
 
-		QUnit.raises( function() {
+		assert.throws( function() {
 			new smw.dataItem.text( 3 );
 		}, pass + 'an error was raised due to the wrong type' );
 
@@ -45,7 +46,9 @@
 	 *
 	 * @since: 1.9
 	 */
-	QUnit.test( 'getDIType', 2, function ( assert ) {
+	QUnit.test( 'getDIType', function ( assert ) {
+		assert.expect( 2 );
+
 		var result;
 
 		result = new smw.dataItem.text( 'foo' );
@@ -61,7 +64,9 @@
 	 *
 	 * @since: 1.9
 	 */
-	QUnit.test( 'getText', 2, function ( assert ) {
+	QUnit.test( 'getText', function ( assert ) {
+		assert.expect( 2 );
+
 		var result;
 
 		var testString = 'Lorem ipsum dolor sit ...';

--- a/tests/qunit/smw/data/ext.smw.dataItem.time.test.js
+++ b/tests/qunit/smw/data/ext.smw.dataItem.time.test.js
@@ -21,7 +21,8 @@
 	 *
 	 * @since: 1.9
 	 */
-	QUnit.test( 'instance', 1, function ( assert ) {
+	QUnit.test( 'instance', function ( assert ) {
+		assert.expect( 1 );
 
 		var result = new smw.dataItem.time( '1362200400' );
 		assert.ok( result instanceof Object, pass + 'the smw.dataItem.time instance was accessible' );
@@ -33,7 +34,8 @@
 	 *
 	 * @since: 1.9
 	 */
-	QUnit.test( 'getDIType', 1, function ( assert ) {
+	QUnit.test( 'getDIType', function ( assert ) {
+		assert.expect( 1 );
 
 		var result = new smw.dataItem.time( '1362200400' );
 		assert.equal( result.getDIType(), '_dat', pass + 'returned _dat' );
@@ -45,7 +47,9 @@
 	 *
 	 * @since: 1.9
 	 */
-	QUnit.test( 'getMwTimestamp', 2, function ( assert ) {
+	QUnit.test( 'getMwTimestamp', function ( assert ) {
+		assert.expect( 2 );
+
 		var result;
 
 		result = new smw.dataItem.time( '1362200400' );
@@ -61,7 +65,9 @@
 	 *
 	 * @since: 1.9
 	 */
-	QUnit.test( 'getDate', 1, function ( assert ) {
+	QUnit.test( 'getDate', function ( assert ) {
+		assert.expect( 1 );
+
 		var result;
 
 		result = new smw.dataItem.time( '1362200400' );
@@ -74,7 +80,9 @@
 	 *
 	 * @since: 1.9
 	 */
-	QUnit.test( 'getISO8601Date', 1, function ( assert ) {
+	QUnit.test( 'getISO8601Date', function ( assert ) {
+		assert.expect( 1 );
+
 		var result;
 
 		result = new smw.dataItem.time( '1362200400' );
@@ -87,7 +95,9 @@
 	 *
 	 * @since: 1.9
 	 */
-	QUnit.test( 'getTimeString', 1, function ( assert ) {
+	QUnit.test( 'getTimeString', function ( assert ) {
+		assert.expect( 1 );
+
 		var result;
 
 		result = new smw.dataItem.time( '1362200400' );
@@ -100,7 +110,9 @@
 	 *
 	 * @since: 1.9
 	 */
-	QUnit.test( 'getMediaWikiDate', 1, function ( assert ) {
+	QUnit.test( 'getMediaWikiDate', function ( assert ) {
+		assert.expect( 1 );
+
 		var result;
 
 		// Use as helper to fetch language dep. month name

--- a/tests/qunit/smw/data/ext.smw.dataItem.unknown.test.js
+++ b/tests/qunit/smw/data/ext.smw.dataItem.unknown.test.js
@@ -27,7 +27,8 @@
 	 *
 	 * @since: 1.9
 	 */
-	QUnit.test( 'instance', 1, function ( assert ) {
+	QUnit.test( 'instance', function ( assert ) {
+		assert.expect( 1 );
 
 		var result = new smw.dataItem.unknown( 'foo', '_bar' );
 		assert.ok( result instanceof Object, pass + 'the smw.dataItem.unknown instance was accessible' );
@@ -39,7 +40,8 @@
 	 *
 	 * @since: 1.9
 	 */
-	QUnit.test( 'getDIType', 1, function ( assert ) {
+	QUnit.test( 'getDIType', function ( assert ) {
+		assert.expect( 1 );
 
 		var result = new smw.dataItem.unknown( 'foo', '_bar' );
 		assert.equal( result.getDIType(), '_bar', pass + 'returned "_bar"' );
@@ -51,7 +53,9 @@
 	 *
 	 * @since: 1.9
 	 */
-	QUnit.test( 'getValue', 2, function ( assert ) {
+	QUnit.test( 'getValue', function ( assert ) {
+		assert.expect( 2 );
+
 		var result;
 
 		$.map( testCases, function ( testCase ) {

--- a/tests/qunit/smw/data/ext.smw.dataItem.uri.test.js
+++ b/tests/qunit/smw/data/ext.smw.dataItem.uri.test.js
@@ -27,7 +27,8 @@
 	 *
 	 * @since: 1.9
 	 */
-	QUnit.test( 'instance', 1, function ( assert ) {
+	QUnit.test( 'instance', function ( assert ) {
+		assert.expect( 1 );
 
 		var result = new smw.dataItem.uri( 'http://foo.com/test/' );
 		assert.ok( result instanceof Object, pass + 'the smw.dataItem.uri instance was accessible' );
@@ -39,7 +40,8 @@
 	 *
 	 * @since: 1.9
 	 */
-	QUnit.test( 'getDIType', 1, function ( assert ) {
+	QUnit.test( 'getDIType', function ( assert ) {
+		assert.expect( 1 );
 
 		var result = new smw.dataItem.uri( 'http://foo.com/test/' );
 		assert.equal( result.getDIType(), '_uri', pass + 'returned _uri' );
@@ -51,7 +53,9 @@
 	 *
 	 * @since: 1.9
 	 */
-	QUnit.test( 'getUri', 2, function ( assert ) {
+	QUnit.test( 'getUri', function ( assert ) {
+		assert.expect( 2 );
+
 		var result;
 
 		$.map( testCases, function ( testCase ) {
@@ -66,7 +70,9 @@
 	 *
 	 * @since: 1.9
 	 */
-	QUnit.test( 'getHtml', 4, function ( assert ) {
+	QUnit.test( 'getHtml', function ( assert ) {
+		assert.expect( 4 );
+
 		var result;
 
 		$.map( testCases, function ( testCase ) {

--- a/tests/qunit/smw/data/ext.smw.dataItem.wikiPage.test.js
+++ b/tests/qunit/smw/data/ext.smw.dataItem.wikiPage.test.js
@@ -81,7 +81,8 @@
 	 *
 	 * @since: 1.9
 	 */
-	QUnit.test( 'instance', 1, function ( assert ) {
+	QUnit.test( 'instance', function ( assert ) {
+		assert.expect( 1 );
 
 		var result = new smw.dataItem.wikiPage( 'foo', 'bar' );
 		assert.ok( result instanceof Object, 'the smw.dataItem.wikiPage instance was accessible' );
@@ -93,7 +94,8 @@
 	 *
 	 * @since: 1.9
 	 */
-	QUnit.test( 'getDIType', 1, function ( assert ) {
+	QUnit.test( 'getDIType', function ( assert ) {
+		assert.expect( 1 );
 
 		var result = new smw.dataItem.wikiPage( 'foo', 'bar' );
 		assert.equal( result.getDIType(), '_wpg', 'returned _wpg' );
@@ -105,7 +107,9 @@
 	 *
 	 * @since: 1.9
 	 */
-	QUnit.test( 'getPrefixedText', 10, function ( assert ) {
+	QUnit.test( 'getPrefixedText', function ( assert ) {
+		assert.expect( 10 );
+
 		var result;
 
 		$.map( testCases, function ( testCase ) {
@@ -120,7 +124,9 @@
 	 *
 	 * @since: 1.9
 	 */
-	QUnit.test( 'getText', 10, function ( assert ) {
+	QUnit.test( 'getText', function ( assert ) {
+		assert.expect( 10 );
+
 		var result;
 
 		$.map( testCases, function ( testCase ) {
@@ -135,7 +141,9 @@
 	 *
 	 * @since: 1.9
 	 */
-	QUnit.test( 'getUri', 10, function ( assert ) {
+	QUnit.test( 'getUri', function ( assert ) {
+		assert.expect( 10 );
+
 		var result;
 
 		$.map( testCases, function ( testCase ) {
@@ -150,7 +158,9 @@
 	 *
 	 * @since: 1.9
 	 */
-	QUnit.test( 'getNamespaceId', 10, function ( assert ) {
+	QUnit.test( 'getNamespaceId', function ( assert ) {
+		assert.expect( 10 );
+
 		var result;
 
 		$.map( testCases, function ( testCase ) {
@@ -165,7 +175,8 @@
 	 *
 	 * @since: 1.9
 	 */
-	QUnit.test( 'getTitle', 2, function ( assert ) {
+	QUnit.test( 'getTitle', function ( assert ) {
+		assert.expect( 2 );
 
 		var wikiPage = new smw.dataItem.wikiPage( 'File:foo', 'bar' );
 		var title = new mw.Title( 'File:foo' );
@@ -180,7 +191,9 @@
 	 *
 	 * @since: 1.9
 	 */
-	QUnit.test( 'isKnown', 10, function ( assert ) {
+	QUnit.test( 'isKnown', function ( assert ) {
+		assert.expect( 10 );
+
 		var result;
 
 		$.map( testCases, function ( testCase ) {
@@ -195,7 +208,9 @@
 	 *
 	 * @since: 1.9
 	 */
-	QUnit.test( 'getHtml( false )', 10, function ( assert ) {
+	QUnit.test( 'getHtml( false )', function ( assert ) {
+		assert.expect( 10 );
+
 		var result;
 
 		$.map( testCases, function ( testCase ) {
@@ -210,7 +225,9 @@
 	 *
 	 * @since: 1.9
 	 */
-	QUnit.test( 'getHtml( true )', 10, function ( assert ) {
+	QUnit.test( 'getHtml( true )', function ( assert ) {
+		assert.expect( 10 );
+
 		var result;
 
 		$.map( testCases, function ( testCase ) {

--- a/tests/qunit/smw/data/ext.smw.dataValue.quantity.test.js
+++ b/tests/qunit/smw/data/ext.smw.dataValue.quantity.test.js
@@ -28,12 +28,13 @@
 	 *
 	 * @since: 1.9
 	 */
-	QUnit.test( 'instance', 2, function ( assert ) {
+	QUnit.test( 'instance', function ( assert ) {
+		assert.expect( 2 );
 
 		var result = new smw.dataValue.quantity( 3 );
 		assert.ok( result instanceof Object, pass + 'the smw.dataValue.quantity instance was accessible' );
 
-		QUnit.raises( function() {
+		assert.throws( function() {
 			new smw.dataValue.quantity( 'foo' );
 		}, pass + 'an error was raised due to wrong type' );
 
@@ -44,7 +45,8 @@
 	 *
 	 * @since: 1.9
 	 */
-	QUnit.test( 'getDIType', 1, function ( assert ) {
+	QUnit.test( 'getDIType', function ( assert ) {
+		assert.expect( 1 );
 
 		var result = new smw.dataValue.quantity( 3 );
 		assert.equal( result.getDIType(), '_qty', pass + 'returned _qty' );
@@ -56,7 +58,9 @@
 	 *
 	 * @since: 1.9
 	 */
-	QUnit.test( 'getValue', 3, function ( assert ) {
+	QUnit.test( 'getValue', function ( assert ) {
+		assert.expect( 3 );
+
 		var result;
 
 		$.map( testCases, function ( testCase ) {
@@ -71,7 +75,9 @@
 	 *
 	 * @since: 1.9
 	 */
-	QUnit.test( 'getUnit', 3, function ( assert ) {
+	QUnit.test( 'getUnit', function ( assert ) {
+		assert.expect( 3 );
+
 		var result;
 
 		$.map( testCases, function ( testCase ) {

--- a/tests/qunit/smw/ext.smw.test.js
+++ b/tests/qunit/smw/ext.smw.test.js
@@ -38,7 +38,8 @@
 	 *
 	 * @since: 1.9
 	 */
-	QUnit.test( 'init', 17, function ( assert ) {
+	QUnit.test( 'init', function ( assert ) {
+		assert.expect( 17 );
 
 		assert.ok( smw instanceof Object, 'the smw instance was accessible' );
 
@@ -70,7 +71,8 @@
 	 *
 	 * @since: 1.9
 	 */
-	QUnit.test( 'settings', 4, function ( assert ) {
+	QUnit.test( 'settings', function ( assert ) {
+		assert.expect( 4 );
 
 		assert.equal( $.type( smw.settings.getList() ), 'object', '.getList() returned a list of settings object' );
 		assert.equal( $.type( smw.settings.get( 'smwgQMaxLimit' ) ), 'number', '.get( "smwgQMaxLimit" ) returned a value for the key' );
@@ -84,7 +86,8 @@
 	 *
 	 * @since: 1.9
 	 */
-	QUnit.test( 'util', 3, function ( assert ) {
+	QUnit.test( 'util', function ( assert ) {
+		assert.expect( 3 );
 
 		assert.equal( smw.util.clean( ' Foo | ; : - < >_= () {} bar ' ), 'Foo_;_:_-__=_()_bar', '.clean() returned a cleaned string' );
 		assert.equal( smw.util.clean( 'Foo | ; : - < >_= () {} bar' ), 'Foo_;_:_-__=_()_bar', '.clean() returned a cleaned string' );
@@ -97,7 +100,8 @@
 	 *
 	 * @since: 1.9
 	 */
-	QUnit.test( 'util.namespace', 7, function ( assert ) {
+	QUnit.test( 'util.namespace', function ( assert ) {
+		assert.expect( 7 );
 
 		assert.equal( $.type( smw.util.namespace.getList() ), 'object', '.getList() returned a list of namespaces' );
 
@@ -116,13 +120,16 @@
 	 *
 	 * @since: 1.9
 	 */
-	QUnit.asyncTest( 'async', 7, function ( assert ) {
+	QUnit.test( 'async', function ( assert ) {
+		assert.expect( 7 );
+
+		var done = assert.async();
 
 		var context;
 		var argument;
 		var result;
 
-		QUnit.raises( function() {
+		assert.throws( function() {
 			smw.async.load( context );
 		}, '.async.load() thrown an error because of a missing method callback' );
 
@@ -166,9 +173,11 @@
 				argument = 'lila-' + i;
 				smw.async.load( context, test1, argument );
 			}
-			QUnit.start();
+
 			assert.ok( smw.async.isEnabled(), '.async.isEnabled() returned true' );
 			assert.ok( context.find( '#' + argument ), '.async.load() was executed and created an element using the invoked argument in async mode' );
+
+			done();
 		} );
 
 	} );
@@ -178,7 +187,8 @@
 	 *
 	 * @since: 1.9
 	 */
-	QUnit.test( 'formats', 7, function ( assert ) {
+	QUnit.test( 'formats', function ( assert ) {
+		assert.expect( 7 );
 
 		assert.equal( $.type( smw.formats.getList() ), 'object', '.getList() returned an object' );
 		assert.equal( $.type( smw.formats.getName( 'table' ) ), 'string', '.getName( "table" ) returned a string' );
@@ -196,7 +206,8 @@
 	 *
 	 * @since: 1.9
 	 */
-	QUnit.test( 'version', 1, function ( assert ) {
+	QUnit.test( 'version', function ( assert ) {
+		assert.expect( 1 );
 
 		assert.equal( $.type( smw.version() ), 'string', '.version() returned a string' );
 

--- a/tests/qunit/smw/query/ext.smw.query.test.js
+++ b/tests/qunit/smw/query/ext.smw.query.test.js
@@ -47,7 +47,9 @@
 	 * @since: 1.9
 	 * @ignore
 	 */
-	QUnit.test( 'instance', 2, function ( assert ) {
+	QUnit.test( 'instance', function ( assert ) {
+		assert.expect( 2 );
+
 		var result;
 
 		result = new smw.api();
@@ -64,30 +66,32 @@
 	 * @since: 1.9
 	 * @ignore
 	 */
-	QUnit.test( 'toString sanity test', 11, function ( assert ) {
+	QUnit.test( 'toString sanity test', function ( assert ) {
+		assert.expect( 11 );
+
 		var result;
 
-		QUnit.raises( function() {
+		assert.throws( function() {
 			new smw.query( '', '' ,'' ).toString();
 		}, pass + 'an error was raised due to missing conditions' );
 
-		QUnit.raises( function() {
+		assert.throws( function() {
 			new smw.query( [], {} ,'' ).toString();
 		}, pass + 'an error was raised due to missing conditions' );
 
-		QUnit.raises( function() {
+		assert.throws( function() {
 			new smw.query( [], [] , '[[Modification date::+]]' ).toString();
 		}, pass + 'an error was raised due to parameters being a non object' );
 
-		QUnit.raises( function() {
+		assert.throws( function() {
 			new smw.query( '', [] , '[[Modification date::+]]' ).toString();
 		}, pass + 'an error was raised due to parameters being a non object' );
 
-		QUnit.raises( function() {
+		assert.throws( function() {
 			new smw.query( '?Modification date', {'limit' : 10, 'offset': 0 } , '[[Modification date::+]]' ).toString();
 		}, pass + 'an error was raised due to printouts weren\'t empty at first, contained values but those weren\'t of type array' );
 
-		QUnit.raises( function() {
+		assert.throws( function() {
 			new smw.query( ['?Modification date'], ['limit'], '[[Modification date::+]]' ).toString();
 		}, pass + 'an error was raised due to parameters weren\'t empty at first, contained values but those weren\'t of type object' );
 
@@ -126,7 +130,10 @@
 	 * @since: 1.9
 	 * @ignore
 	 */
-	QUnit.test( 'toString Ajax response test', 4, function ( assert ) {
+	QUnit.test( 'toString Ajax response test', function ( assert ) {
+		assert.expect( 4 );
+
+		var done = assert.async();
 
 		var smwApi = new smw.api();
 		var queryObject = smwApi.parse( jsonString );
@@ -137,13 +144,13 @@
 		assert.ok( $.type( query.getQueryString() ) === 'string', pass + 'the function alias returned a string' );
 
 		// Ajax
-		QUnit.stop();
 		smwApi.fetch( query.toString() )
 		.done( function ( results ) {
 
 			assert.ok( true, pass + 'the query returned with a positive server response' );
 			assert.ok( results instanceof Object, pass + 'the query returned with a result object' );
-			QUnit.start();
+
+			done();
 		} );
 
 	} );
@@ -154,7 +161,8 @@
 	 * @since: 1.9
 	 * @ignore
 	 */
-	QUnit.test( 'getLimit', 1, function ( assert ) {
+	QUnit.test( 'getLimit', function ( assert ) {
+		assert.expect( 1 );
 
 		var smwApi = new smw.api();
 		var queryObject = smwApi.parse( jsonString );
@@ -171,7 +179,9 @@
 	 * @since: 1.9
 	 * @ignore
 	 */
-	QUnit.test( 'getLink', 5, function ( assert ) {
+	QUnit.test( 'getLink', function ( assert ) {
+		assert.expect( 5 );
+
 		var result, context;
 
 		var smwApi = new smw.api();

--- a/tests/qunit/smw/util/ext.smw.util.tooltip.test.js
+++ b/tests/qunit/smw/util/ext.smw.util.tooltip.test.js
@@ -37,7 +37,9 @@
 	 *
 	 * @since: 1.9
 	 */
-	QUnit.test( 'instance', 1, function ( assert ) {
+	QUnit.test( 'instance', function ( assert ) {
+		assert.expect( 1 );
+
 		var tooltip = new smw.util.tooltip();
 
 		assert.ok( tooltip instanceof Object, 'smw.util.tooltip instance was accessible' );
@@ -49,7 +51,9 @@
 	 *
 	 * @since: 1.9
 	 */
-	QUnit.test( 'show', 2, function ( assert ) {
+	QUnit.test( 'show', function ( assert ) {
+		assert.expect( 2 );
+
 		var tooltip = new smw.util.tooltip();
 		var fixture = $( '#qunit-fixture' );
 
@@ -71,7 +75,9 @@
 	 *
 	 * @since: 1.9
 	 */
-	QUnit.test( 'add', 3, function ( assert ) {
+	QUnit.test( 'add', function ( assert ) {
+		assert.expect( 3 );
+
 		var tooltip = new smw.util.tooltip();
 		var fixture = $( '#qunit-fixture' );
 


### PR DESCRIPTION
This PR is made in reference to: #2849 

This PR addresses or contains:
- QUnit tests were updated for 2.4 API (MW 1.31)
- All tests pass except for `ext.smw.util.tooltip`
- The tests that have already been `@ignore`d long before this change are flaky. I updated their syntax anyways to conform to the new QUnit version.

A potential way to avoid upstream changes causing unexpected test breakage would be to decouple JS tests from MW test runner by using some node.js based executor such as [karma](https://karma-runner.github.io/2.0/index.html) + phantomjs/headless Chrome. This would allow for the JS tests to be run as part of the standard CI build while allowing considerably more flexibility in testing/assertion libraries. However extra setup and potentially rewrites would be required to fully realize such an enterprise.

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed

Fixes #2849 
Fixes #542 