### PR TITLE
Use html format for _eid types in a reference, refs 2985

### DIFF
--- a/src/DataValues/ValueFormatters/ReferenceValueFormatter.php
+++ b/src/DataValues/ValueFormatters/ReferenceValueFormatter.php
@@ -5,6 +5,7 @@ namespace SMW\DataValues\ValueFormatters;
 use RuntimeException;
 use SMW\DataValueFactory;
 use SMW\DataValues\ReferenceValue;
+use SMW\DataValues\ExternalIdentifierValue;
 use SMW\DIProperty;
 use SMW\DIWikiPage;
 use SMW\Message;
@@ -152,7 +153,7 @@ class ReferenceValueFormatter extends DataValueFormatter {
 		// Turn Uri/Page links into a href representation when not used as value
 		if ( !$isValue &&
 			( $dataItem instanceof DIUri || $dataItem instanceof DIWikiPage ) &&
-			$type !== self::VALUE ) {
+			$type !== self::VALUE || $dataValue->getTypeID() === ExternalIdentifierValue::TYPE_ID ) {
 			return $dataValue->getShortHTMLText( smwfGetLinker() );
 		}
 

--- a/tests/phpunit/Integration/JSONScript/TestCases/p-0916.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/p-0916.json
@@ -1,0 +1,62 @@
+{
+	"description": "Test `_ref_rec` with a `_eid` field (#2985)",
+	"setup": [
+		{
+			"namespace": "SMW_NS_PROPERTY",
+			"page": "WDID",
+			"contents": "[[Has type::External identifier]][[External formatter uri::https://www.wikidata.org/entity/$1]]"
+		},
+		{
+			"namespace": "SMW_NS_PROPERTY",
+			"page": "WD reference",
+			"contents": "[[Has type::Reference]] [[Has fields::URL;WDID]]"
+		},
+		{
+			"page": "Example/P0916/1",
+			"contents": "[[WD reference::https://en.wikipedia.org/wiki/Franz_Schubert;Q7312]]"
+		}
+	],
+	"tests": [
+		{
+			"type": "parser",
+			"about": "#0 (correct formatting for external identifier)",
+			"subject": "Example/P0916/1",
+			"assert-store": {
+				"semantic-data": {
+					"strict-mode-valuematch": false,
+					"propertyCount": 3,
+					"propertyKeys": [
+						"_MDAT",
+						"_SKEY",
+						"WD reference"
+					]
+				}
+			},
+			"assert-output": {
+				"to-contain": [
+					"data-content=\"&lt;ul&gt;&lt;li&gt;&lt;a href=&quot;.*:WDID&quot;",
+					"title=&quot;.*:WDID&quot;&gt;WDID&lt;/a&gt;: &lt;a href=&quot;https://www.wikidata.org/entity/Q7312&quot; target=&quot;_blank&quot;&gt;Q7312&lt;/a&gt;&lt;/li&gt;&lt;/ul&gt;\" title=\"WDID: Q7312\">"
+				],
+				"not-contain": [
+					"title=&quot;.*:WDID&quot;&gt;WDID&lt;/a&gt;: &lt;span class=&quot;plainlinks smw-eid&quot;&gt;<a rel=\"nofollow\" class=\"external text\" href=\"https://www.wikidata.org/entity/Q7312\">Q7312</a>&lt;/span&gt;&lt;/li&gt;&lt;/ul&gt;\" title=\"WDID: <a rel=\"nofollow\" class=\"external text\" href=\"https://www.wikidata.org/entity/Q7312\">Q7312</a>\">"
+				]
+			}
+		}
+	],
+	"settings": {
+		"wgContLang": "en",
+		"wgLang": "en",
+		"smwgPageSpecialProperties": [
+			"_MDAT"
+		],
+		"smwgNamespacesWithSemanticLinks": {
+			"NS_MAIN": true,
+			"SMW_NS_PROPERTY": true
+		}
+	},
+	"meta": {
+		"version": "2",
+		"is-incomplete": false,
+		"debug": false
+	}
+}


### PR DESCRIPTION
This PR is made in reference to: #2985

This PR addresses or contains:

- When building a reference list, formatting of values need to be cared for to ensure that raw wikitext  (either as `[ ...]` or `[[ ... ]]` and in which case of the `_eid` type was `[https://www.wikidata.org/entity/...]` caused a double parse and ultimately broke the link representation) is transformed before embedded in the outer content representation 

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed

Fixes #2985