### PR TITLE
Updating old namespace in Spanish

### DIFF
--- a/i18n/extra/es.json
+++ b/i18n/extra/es.json
@@ -77,8 +77,8 @@
         "SMW_PREC_YMDT": "H:i:s j M Y"
     },
     "namespaces": {
-        "SMW_NS_PROPERTY": "Atributo",
-        "SMW_NS_PROPERTY_TALK": "Atributo_discusión",
+        "SMW_NS_PROPERTY": "Propiedad",
+        "SMW_NS_PROPERTY_TALK": "Propiedad_discusión",
         "SMW_NS_TYPE": "Tipo",
         "SMW_NS_TYPE_TALK": "Tipo_discusión",
         "SMW_NS_CONCEPT": "Concepto",

--- a/i18n/extra/es.json
+++ b/i18n/extra/es.json
@@ -84,7 +84,10 @@
         "SMW_NS_CONCEPT": "Concepto",
         "SMW_NS_CONCEPT_TALK": "Concepto_discusión"
     },
-    "namespaceAliases": [],
+    "namespaceAliases": {
+      "Atributo": "SMW_NS_PROPERTY",
+      "Atributo_discusión": "SMW_NS_PROPERTY_TALK"
+     },
     "dateFormats": [
         [
             "SMW_Y"

--- a/i18n/extra/es.json
+++ b/i18n/extra/es.json
@@ -85,8 +85,8 @@
         "SMW_NS_CONCEPT_TALK": "Concepto_discusión"
     },
     "namespaceAliases": {
-      "Atributo": "SMW_NS_PROPERTY",
-      "Atributo_discusión": "SMW_NS_PROPERTY_TALK"
+        "Atributo": "SMW_NS_PROPERTY",
+        "Atributo_discusión": "SMW_NS_PROPERTY_TALK"
      },
     "dateFormats": [
         [


### PR DESCRIPTION
This PR addresses or contains:
- Changing an old namespace in Spanish. Atribute is not being used since the version 1.0, ~11 years ago.
This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed