### PR TITLE
Check for isCapitalLinks, refs 2982

### DIFF
--- a/includes/datavalues/SMW_DV_WikiPage.php
+++ b/includes/datavalues/SMW_DV_WikiPage.php
@@ -126,10 +126,20 @@ class SMWWikiPageValue extends SMWDataValue {
 		// If the vaue contains a valid NS then use the Title to create a correct
 		// instance to distinguish [[~Foo*]] from [[Help:~Foo*]]
 		if ( $this->getOption( self::OPT_QUERY_COMP_CONTEXT ) || $this->getOption( self::OPT_QUERY_CONTEXT ) ) {
+
+			$userCase = true;
+
+			// If we know that it is a wikipage in a query context and the wiki
+			// requires `isCapitalLinks` then use the standard transformation so
+			// they appear as standard links even though the user input was `abc.
+			if ( $this->getOption( 'isCapitalLinks' ) ) {
+				$userCase = false;
+			}
+
 			if ( ( $title = Title::newFromText( $value ) ) !== null ) {
 				// T:P0427 If the user value says `ab c*` then make sure to use this one
 				// instead of the transformed DBKey which would be `Ab c*`
-				return $this->m_dataitem = SMWDIWikiPage::newFromTitle( $title, true );
+				return $this->m_dataitem = SMWDIWikiPage::newFromTitle( $title, $userCase );
 			// T:P0902 (`[[Help:]]`)
 			} elseif( !Localizer::getInstance()->getNamespaceIndexByName( substr( $value, 0, -1 ) ) ) {
 				return $this->m_dataitem = new SMWDIWikiPage( $value, NS_MAIN );

--- a/src/Query/Parser/DescriptionProcessor.php
+++ b/src/Query/Parser/DescriptionProcessor.php
@@ -6,6 +6,7 @@ use SMW\DataValueFactory;
 use SMWDataValue as DataValue;
 use SMW\DIProperty;
 use SMW\DIWikiPage;
+use SMW\Site;
 use SMW\Message;
 use SMW\Query\DescriptionFactory;
 use SMW\Query\Language\Conjunction;
@@ -123,6 +124,7 @@ class DescriptionProcessor {
 		// Indicates whether a value is being used by a query condition or not which
 		// can lead to a modified validation of a value.
 		$dataValue->setOption( DataValue::OPT_QUERY_CONTEXT, true );
+		$dataValue->setOption( 'isCapitalLinks', Site::isCapitalLinks() );
 
 		$description = $dataValue->getQueryDescription( $chunk );
 		$this->addError( $dataValue->getErrors() );

--- a/tests/phpunit/Integration/JSONScript/TestCases/q-0619.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/q-0619.json
@@ -1,0 +1,80 @@
+{
+	"description": "Test `_wpg` user case (#2982)",
+	"setup": [
+		{
+			"namespace": "SMW_NS_PROPERTY",
+			"page": "Has page",
+			"contents": "[[Has type::Page]]"
+		},
+		{
+			"page": "Example/Q0619/1",
+			"contents": "[[Has page::userCase]]"
+		},
+		{
+			"page": "Example/Q0619/user Case",
+			"contents": "[[Has page::Example/Q0619/1]]"
+		}
+	],
+	"tests": [
+		{
+			"type": "query",
+			"about": "#0 (userCase, UserCase on _wpg type)",
+			"condition": "[[Has page::userCase]]",
+			"printouts": [],
+			"parameters": {
+				"limit": 10
+			},
+			"assert-queryresult": {
+				"count": 1,
+				"results": [
+					"Example/Q0619/1#0##"
+				]
+			}
+		},
+		{
+			"type": "query",
+			"about": "#1 (userCase, UserCase on _wpg type)",
+			"condition": "[[Has page::UserCase]]",
+			"printouts": [],
+			"parameters": {
+				"limit": 10
+			},
+			"assert-queryresult": {
+				"count": 1,
+				"results": [
+					"Example/Q0619/1#0##"
+				]
+			}
+		},
+		{
+			"type": "query",
+			"about": "#2",
+			"condition": "[[~*user Case*]]",
+			"printouts": [],
+			"parameters": {
+				"limit": 10
+			},
+			"assert-queryresult": {
+				"count": 1,
+				"results": [
+					"Example/Q0619/user Case#0##"
+				]
+			}
+		}
+	],
+	"settings": {
+		"smwgNamespacesWithSemanticLinks": {
+			"NS_MAIN": true,
+			"NS_CATEGORY": true,
+			"SMW_NS_PROPERTY": true,
+			"NS_HELP": true
+		},
+		"wgContLang": "en",
+		"wgLang": "en"
+	},
+	"meta": {
+		"version": "2",
+		"is-incomplete": false,
+		"debug": false
+	}
+}


### PR DESCRIPTION
This PR is made in reference to: #2982

This PR addresses or contains:

- Ensures that `[[Has page::userCase]]` is equal to `[[Has page::UserCase]]` when `isCapitalLinks` is enabled for a `_wpg` type value since all "standard" links expect a capital letter
- Added integration test to verify the case

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed
