### PR TITLE
Allow to delay a job (if the JobQueue supports it)

### DIFF
--- a/src/MediaWiki/JobQueue.php
+++ b/src/MediaWiki/JobQueue.php
@@ -50,6 +50,17 @@ class JobQueue {
 	 *
 	 * @param string $type
 	 *
+	 * @return boolean
+	 */
+	public function isDelayedJobsEnabled( $type ) {
+		return $this->jobQueueGroup->get( $type )->delayedJobsEnabled();
+	}
+
+	/**
+	 * @since 3.0
+	 *
+	 * @param string $type
+	 *
 	 * @return Job|boolean
 	 */
 	public function pop( $type ) {


### PR DESCRIPTION
This PR is made in reference to: #

This PR addresses or contains:

- Add function to delay a job if the `JobQueue::delayedJobsEnabled` supports it (which only the `JobQueueRedis` does) 

This PR includes:
- [ ] Tests (unit/integration)
- [x] CI build passed
