### PR TITLE
Avoid autocomplete on `[[...` in Special:Search for `SMWSearch` type

### DIFF
--- a/res/Resources.php
+++ b/res/Resources.php
@@ -260,6 +260,16 @@ return array(
 		)
 	),
 
+	// Special:Search
+	'ext.smw.special.search' => $moduleTemplate + array(
+		'scripts' => 'smw/special/ext.smw.special.search.js',
+		'position' => 'top',
+		'targets' => array(
+			'mobile',
+			'desktop'
+		)
+	),
+
 	// Postproc resources
 	'ext.smw.postproc' => $moduleTemplate + array(
 		'scripts' => 'smw/util/ext.smw.util.postproc.js',

--- a/res/smw/special/ext.smw.special.search.js
+++ b/res/smw/special/ext.smw.special.search.js
@@ -1,0 +1,73 @@
+/*!
+ * This file is part of the Semantic MediaWiki
+ *
+ * @section LICENSE
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ * http://www.gnu.org/copyleft/gpl.html
+ *
+ * @license GNU GPL v2+
+ * @since  3.0
+ *
+ * @author mwjames
+ */
+( function( $, mw ) {
+	'use strict';
+
+	/**
+	 * Support text input on Special:Search
+	 *
+	 * @since 3.0
+	 */
+	var search = function() {
+
+		var context = $( '#searchText > input' ),
+			isHidden = false;
+
+		if ( context.length ) {
+
+			// Disable the standard autocompleter as no meaningfull help can be
+			// expected on a [[ ... ]] input
+			context.on( 'keyup keypres focus', function( e ) {
+				var highlighter = context.parent().find( '.oo-ui-widget' ),
+					style = '';
+
+				if ( context.val().indexOf( '[' ) > -1 ) {
+					style = highlighter.attr( 'style' );
+					highlighter.hide();
+					isHidden = true;
+				} else if( isHidden ) {
+					highlighter.attr( 'style', style );
+					highlighter.show();
+					isHidden = false;
+				};
+			} );
+		}
+	};
+
+	function load( callback ) {
+		if ( document.readyState == 'complete' ) {
+			callback();
+		} else {
+			window.addEventListener( 'load', callback );
+		}
+	}
+
+	// Only load when it is Special:Search and the search type supports
+	// https://www.semantic-mediawiki.org/wiki/Help:SMWSearch
+	if ( mw.config.get( 'wgCanonicalSpecialPageName' ) == 'Search' && mw.config.get( 'wgSearchType' ) == 'SMWSearch' ) {
+		load( search );
+	};
+
+} )( jQuery, mediaWiki );

--- a/src/MediaWiki/Hooks/SpecialSearchResultsPrepend.php
+++ b/src/MediaWiki/Hooks/SpecialSearchResultsPrepend.php
@@ -50,6 +50,8 @@ class SpecialSearchResultsPrepend extends HookHandler {
 		$html = '';
 
 		if ( $this->specialSearch->getSearchEngine() instanceof SMWSearch ) {
+			$this->outputPage->addModules( 'ext.smw.special.search');
+
 			$html .= Message::get(
 				'smw-search-syntax-support',
 				Message::PARSE,
@@ -62,7 +64,7 @@ class SpecialSearchResultsPrepend extends HookHandler {
 					Message::PARSE,
 					Message::USER_LANGUAGE
 				);
-			}		
+			}
 		}
 
 		if ( $html !== '' ) {


### PR DESCRIPTION
This PR is made in reference to: #

This PR addresses or contains:

- If the `SMWSearch` type is enabled and `[[` is entered as part of the #ask syntax search indication then the `Special:Search` autocompleter is disabled as no meaningful support function can be expected from an input like `[[Has number::+]]`.

This PR includes:
- [ ] Tests (unit/integration)
- [x] CI build passed
