### PR TITLE
CodeStringValueFormatter encode `[`

### DIFF
--- a/src/DataValues/ValueFormatters/CodeStringValueFormatter.php
+++ b/src/DataValues/ValueFormatters/CodeStringValueFormatter.php
@@ -37,12 +37,12 @@ class CodeStringValueFormatter extends StringValueFormatter {
 		Outputs::requireResource( 'ext.smw.style' );
 
 		if ( $this->isJson( $text ) ) {
-			$result = self::formatAsPrettyJson( $text );
+			$result = self::asJson( $text );
 		} else {
 			// This disables all active wiki and HTML markup:
 			$result = str_replace(
-				array( '<', '>', ' ', '[', '{', '=', "'", ':', "\n" ),
-				array( '&lt;', '&gt;', '&#160;', '&#91;', '&#x007B;', '&#x003D;', '&#x0027;', '&#58;', "<br />" ),
+				array( '<code>', '</code>', '<nowiki>', '</nowiki>', '<', '>', ' ', '[', '{', '=', "'", ':', "\n", '&#x005B;' ),
+				array( '', '', '', '', '&lt;', '&gt;', '&#160;', '&#91;', '&#x007B;', '&#x003D;', '&#x0027;', '&#58;', "<br />", '&#91;' ),
 				$text
 			);
 		}
@@ -61,8 +61,13 @@ class CodeStringValueFormatter extends StringValueFormatter {
 	 *
 	 * @return string
 	 */
-	public static function formatAsPrettyJson( $string ) {
-		return defined( 'JSON_PRETTY_PRINT' ) ? json_encode( json_decode( $string ), JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE ) : $string;
+	public static function asJson( $string, $flag = 0 ) {
+
+		if ( $flag > 0 ) {
+			return json_encode( json_decode( $string ), $flag );
+		}
+
+		return json_encode( json_decode( $string ), JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE );
 	}
 
 	private function isJson( $string ) {

--- a/tests/phpunit/Unit/DataValues/ValueFormatters/CodeStringValueFormatterTest.php
+++ b/tests/phpunit/Unit/DataValues/ValueFormatters/CodeStringValueFormatterTest.php
@@ -77,6 +77,20 @@ class CodeStringValueFormatterTest extends \PHPUnit_Framework_TestCase {
 			'<div class="smwpre"><div style="min-height:5em; overflow:auto;">foo</div></div>'
 		);
 
+		$provider[] = array(
+			'<code><nowiki>&#x005B;&#x005B;Foo]]</nowiki></code>',
+			CodeStringValueFormatter::HTML_LONG,
+			null,
+			'<div class="smwpre"><div style="min-height:5em; overflow:auto;">&#91;&#91;Foo]]</div></div>'
+		);
+
+		$provider[] = array(
+			'<code><nowiki>[[Foo]]</nowiki></code>',
+			CodeStringValueFormatter::HTML_LONG,
+			null,
+			'<div class="smwpre"><div style="min-height:5em; overflow:auto;">&#91;&#91;Foo]]</div></div>'
+		);
+
 		// > 255
 		$text = 'Lorem ipsum dolor sit amet consectetuer justo Nam quis lobortis vel. Sapien nulla enim Lorem enim pede ' .
 		'lorem nulla justo diam wisi. Libero Nam turpis neque leo scelerisque nec habitasse a lacus mattis. Accumsan ' .
@@ -130,7 +144,7 @@ class CodeStringValueFormatterTest extends \PHPUnit_Framework_TestCase {
 			$jsonString,
 			CodeStringValueFormatter::WIKI_LONG,
 			null,
-			'<div class="smwpre"><div style="min-height:5em; overflow:auto;">' . CodeStringValueFormatter::formatAsPrettyJson( $jsonString ) . '</div></div>'
+			'<div class="smwpre"><div style="min-height:5em; overflow:auto;">' . CodeStringValueFormatter::asJson( $jsonString ) . '</div></div>'
 		);
 
 		return $provider;


### PR DESCRIPTION
This PR is made in reference to: #

This PR addresses or contains:

- Encode `[` and remove `code` and `nowiki` from strings that are annotated with something like `[[Code::<nowiki>[[Has number::+]]</nowiki>]]` where the intention is to represent a `code` snippet with `nowiki` only acting as mediator to actually allow for an unparsed annotation. The encoding of `[` ensures that those snippets remain unparsed even when included using `#ask`. 

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed

Fixes #