### PR TITLE
StringValueFormatter avoid breaking links in an abbreviated text

### DIFF
--- a/src/DataValues/ValueFormatters/StringValueFormatter.php
+++ b/src/DataValues/ValueFormatters/StringValueFormatter.php
@@ -99,7 +99,19 @@ class StringValueFormatter extends DataValueFormatter {
 			$ellipsis = $highlighter->getHtml();
 		}
 
-		return mb_substr( $text, 0, 42 ) . $ellipsis . mb_substr( $text, $length - 42 );
+		$startOff = 42;
+		$endOff = 42;
+
+		// Avoid breaking a link (i.e. [[ ... ]])
+		if ( ( $pos = stripos ( $text, '[[' ) ) && $pos < 42 ) {
+			$startOff = stripos ( $text, ']]' ) + 2;
+		}
+
+		if ( ( $pos = strrpos ( $text, ']]' ) ) && $pos > $length - $endOff ) {
+			$endOff = $length - strrpos( $text, '[[' );
+		}
+
+		return mb_substr( $text, 0, $startOff ) . $ellipsis . mb_substr( $text, $length - $endOff );
 	}
 
 }

--- a/tests/phpunit/Unit/DataValues/ValueFormatters/StringValueFormatterTest.php
+++ b/tests/phpunit/Unit/DataValues/ValueFormatters/StringValueFormatterTest.php
@@ -161,6 +161,18 @@ class StringValueFormatterTest extends \PHPUnit_Framework_TestCase {
 			'Lorem ipsum dolor sit amet consectetuer ju <span class="smwwarning">…</span> nec facilisis tortor Nunc Sed ipsum tellus'
 		);
 
+		// Avoid breaking links
+		$text = 'Lorem ipsum dolor sit amet consectetuer [[justo Nam quis lobortis vel]]. Sapien nulla enim Lorem enim pede ' .
+		'lorem nulla justo diam wisi. Libero Nam turpis neque leo scelerisque nec habitasse a lacus mattis. Accumsan ' .
+		'tincidunt [[Sed adipiscing nec]] facilisis tortor Nunc Sed ipsum tellus';
+
+		$provider[] = array(
+			$text,
+			StringValueFormatter::HTML_LONG,
+			null,
+			'Lorem ipsum dolor sit amet consectetuer [[justo Nam quis lobortis vel]] <span class="smwwarning">…</span> [[Sed adipiscing nec]] facilisis tortor Nunc Sed ipsum tellus'
+		);
+
 		// XMLContentEncode
 		$provider[] = array(
 			'<foo>',


### PR DESCRIPTION
This PR is made in reference to: #

This PR addresses or contains:

- A text that contains a link as in `Lorem ipsum [[Some link ...` should only abbreviated after the closing element (`]]`) either before or after `…` has been found.

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed

Fixes #