### PR TITLE
Add `smwgDefaultOutputFormatters`, refs 2994

### DIFF
--- a/DefaultSettings.php
+++ b/DefaultSettings.php
@@ -771,6 +771,33 @@ return array(
 	),
 	##
 
+	##
+	# Default output formatter
+	#
+	# Users who want to alter the default output for a specific type can do so by
+	# setting a specify default formatter.
+	#
+	# The expected form is:
+	#
+	# [ <_typeID> => '<Formatter>' ] OR
+	# [ <typeName> => '<Formatter>' ] OR
+	# [ <propertyName> => '<Formatter>' ]
+	#
+	# Only valid formatters will be considered for an individual type, no
+	# errors or exceptions are raised in case of an improper formatter.
+	#
+	# The formatter is applied to values displayed on special pages
+	# as well.
+	#
+	# @since 3.0
+	# @default: []
+	##
+	'smwgDefaultOutputFormatters' => [
+		// '_dat' => 'LOCL',
+		// 'Boolean' => 'tick',
+	],
+	##
+
 	// some default settings which usually need no modification
 
 	###

--- a/includes/Settings.php
+++ b/includes/Settings.php
@@ -120,6 +120,7 @@ class Settings extends Options {
 			'smwgPageSpecialProperties' => $GLOBALS['smwgPageSpecialProperties'],
 			'smwgChangePropagationWatchlist' => $GLOBALS['smwgChangePropagationWatchlist'],
 			'smwgDataTypePropertyExemptionList' => $GLOBALS['smwgDataTypePropertyExemptionList'],
+			'smwgDefaultOutputFormatters' => $GLOBALS['smwgDefaultOutputFormatters'],
 			'smwgTranslate' => $GLOBALS['smwgTranslate'],
 			'smwgAutoRefreshSubject' => $GLOBALS['smwgAutoRefreshSubject'],
 			'smwgAdminFeatures' => $GLOBALS['smwgAdminFeatures'],

--- a/includes/datavalues/SMW_DV_Property.php
+++ b/includes/datavalues/SMW_DV_Property.php
@@ -285,7 +285,13 @@ class SMWPropertyValue extends SMWDataValue {
 	}
 
 	public function setOutputFormat( $formatstring ) {
+
+		if ( $formatstring === false || $formatstring === '' ) {
+			return;
+		}
+
 		$this->m_outformat = $formatstring;
+
 		if ( $this->getWikiPageValue() instanceof SMWDataValue ) {
 			$this->m_wikipage->setOutputFormat( $formatstring );
 		}

--- a/src/Factbox/Factbox.php
+++ b/src/Factbox/Factbox.php
@@ -413,7 +413,10 @@ class Factbox {
 			foreach ( $semanticData->getPropertyValues( $property ) as $dataItem ) {
 
 				$dataValue = $this->dataValueFactory->newDataValueByItem( $dataItem, $property );
-				$dataValue->setOutputFormat( 'LOCL' );
+
+				$outputFormat = $dataValue->getOutputFormat();
+				$dataValue->setOutputFormat( $outputFormat ? $outputFormat : 'LOCL' );
+
 				$dataValue->setOption( $dataValue::OPT_DISABLE_INFOLINKS, true );
 
 				if ( $dataValue->isValid() ) {

--- a/src/MediaWiki/Specials/Browse/ValueFormatter.php
+++ b/src/MediaWiki/Specials/Browse/ValueFormatter.php
@@ -86,10 +86,14 @@ class ValueFormatter {
 			Localizer::getInstance()->getUserLanguage()->getCode()
 		);
 
-		$outputFormat = 'LOCL';
+		$outputFormat = $dataValue->getOutputFormat();
 
-		if ( Localizer::getInstance()->hasLocalTimeOffsetPreference( $user ) ) {
-			$outputFormat .= '#TO';
+		if ( $outputFormat === false ) {
+			$outputFormat = 'LOCL';
+
+			if ( Localizer::getInstance()->hasLocalTimeOffsetPreference( $user ) ) {
+				$outputFormat .= '#TO';
+			}
 		}
 
 		// Use LOCL formatting where appropriate (date)

--- a/src/MediaWiki/Specials/SearchByProperty/PageBuilder.php
+++ b/src/MediaWiki/Specials/SearchByProperty/PageBuilder.php
@@ -273,7 +273,9 @@ class PageBuilder {
 
 		foreach ( $results as $result ) {
 
-			$result[0]->setOutputFormat( 'LOCL' );
+			$outputFormat = $result[0]->getOutputFormat();
+			$result[0]->setOutputFormat( $outputFormat ? $outputFormat : 'LOCL' );
+
 			$listitem = $result[0]->getLongHTMLText( $this->linker );
 
 			if ( $this->canShowSearchByPropertyLink( $result[0] ) ) {
@@ -307,7 +309,8 @@ class PageBuilder {
 				( !$this->pageRequestOptions->value->getDataItem()->equals( $result[1]->getDataItem() )
 					|| $highlight ) ) {
 
-				$result[1]->setOutputFormat( 'LOCL' );
+				$outputFormat = $result[1]->getOutputFormat();
+				$result[1]->setOutputFormat( $outputFormat ? $outputFormat : 'LOCL' );
 
 				$listitem .= "&#160;<em><small>" . $this->messageBuilder->getMessage( 'parentheses' )
 					->rawParams( $result[1]->getLongHTMLText( $this->linker ) )
@@ -365,7 +368,8 @@ class PageBuilder {
 			$dataItem
 		);
 
-		$dataValue->setOutputFormat( 'LOCL' );
+		$outputFormat = $dataValue->getOutputFormat();
+		$dataValue->setOutputFormat( $outputFormat ? $outputFormat : 'LOCL' );
 
 		if ( $dataValue->isValid() ) {
 			//$resultMessage = 'Item reference for a zero-marked property.';

--- a/src/Page/ListBuilder/ValueListBuilder.php
+++ b/src/Page/ListBuilder/ValueListBuilder.php
@@ -285,14 +285,10 @@ class ValueListBuilder {
 				$values = iterator_to_array( $values );
 			}
 
+			$hasLocalTimeOffsetPreference = Localizer::getInstance()->hasLocalTimeOffsetPreference();
+
 			$i = 0;
 			$pvCells = '';
-
-			$outputFormat = 'LOCL';
-
-			if ( Localizer::getInstance()->hasLocalTimeOffsetPreference() ) {
-				$outputFormat .= '#TO';
-			}
 
 			foreach ( $values as $di ) {
 				if ( $i != 0 ) {
@@ -302,6 +298,12 @@ class ValueListBuilder {
 
 				if ( $i < $this->maxPropertyValues + 1 ) {
 					$dataValue = DataValueFactory::getInstance()->newDataValueByItem( $di, $property );
+					$outputFormat = $dataValue->getOutputFormat();
+
+					if ( $outputFormat === false ) {
+						$outputFormat = 'LOCL' . ( $hasLocalTimeOffsetPreference ? '#TO' : '' );
+					}
+
 					$dataValue->setOutputFormat( $outputFormat );
 
 					$pvCells .= $dataValue->getShortHTMLText( smwfGetLinker() ) . $dataValue->getInfolinkText( SMW_OUTPUT_HTML, smwfGetLinker() );

--- a/tests/phpunit/Integration/JSONScript/JsonTestCaseScriptRunnerTest.php
+++ b/tests/phpunit/Integration/JSONScript/JsonTestCaseScriptRunnerTest.php
@@ -226,6 +226,7 @@ class JsonTestCaseScriptRunnerTest extends JsonTestCaseScriptRunner {
 			'smwgCreateProtectionRight',
 			'smwgParserFeatures',
 			'smwgCategoryFeatures',
+			'smwgDefaultOutputFormatters',
 
 			// MW related
 			'wgLanguageCode',

--- a/tests/phpunit/Integration/JSONScript/TestCases/p-1004.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/p-1004.json
@@ -1,0 +1,59 @@
+{
+	"description": "Test different default output formatter `_dat` (`smwgDefaultOutputFormatters`)",
+	"setup": [
+		{
+			"namespace": "SMW_NS_PROPERTY",
+			"page": "Has date",
+			"contents": "[[Has type::Date]]"
+		},
+		{
+			"namespace": "SMW_NS_PROPERTY",
+			"page": "Has date 2",
+			"contents": "[[Has type::Date]]"
+		},
+		{
+			"page": "Example/P1004/1",
+			"contents": "[[Has date::1 Jan 1970]] [[Has date 2::2 Jan 2000]] [[Category:P1004]]"
+		},
+		{
+			"page": "Example/P1004/Q.1",
+			"contents": "{{#ask: [[Category:P1004]] |?Modification date |?Has date |?Has date 2 |?Has date#ISO |limit=10 }}"
+		}
+	],
+	"tests": [
+		{
+			"type": "parser",
+			"about": "#0 (all `_dat` (Has date 2) -> JD, `_MDAT` (Modification date) -> ISO, First `Has date` -> MEDIAWIKI, Second `Has date` overrides default with ISO)",
+			"subject": "Example/P1004/Q.1",
+			"assert-output": {
+				"to-contain": [
+					"<td class=\"Modification-date smwtype_dat\" data-sort-value=.*T.*</td>",
+					"<td class=\"Has-date smwtype_dat\" data-sort-value=\"2440587.5\">1 January 1970</td>",
+					"<td class=\"Has-date-2 smwtype_dat\" data-sort-value=\"2451545.5\">2451545.5</td>",
+					"<td class=\"Has-date smwtype_dat\" data-sort-value=\"2440587.5\">1970-01-01</td>"
+				]
+			}
+		}
+	],
+	"settings": {
+		"wgContLang": "en",
+		"wgLang": "en",
+		"smwgDefaultOutputFormatters": {
+			"_dat": "JD",
+			"_MDAT": "ISO",
+			"Has date": "MEDIAWIKI"
+		},
+		"smwgPageSpecialProperties": [
+			"_MDAT"
+		],
+		"smwgNamespacesWithSemanticLinks": {
+			"NS_MAIN": true,
+			"SMW_NS_PROPERTY": true
+		}
+	},
+	"meta": {
+		"version": "2",
+		"is-incomplete": false,
+		"debug": false
+	}
+}


### PR DESCRIPTION
This PR is made in reference to: #2994

This PR addresses or contains:

- Adds `$smwgDefaultOutputFormatters` setting to define default output formatter for a type or a specific property. It should be noted that a property default takes precedence over a possible type assigned default while a local formatter (i.e. the one maintained directly via a `#ask`) will always be predominate over any default.

```
$GLOBALS['smwgDefaultOutputFormatters'] => [
	'_dat' => 'LOCL',
	'Boolean' => 'tick',
	'_MDAT' => 'ISO',
],
```

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed

Fixes #2994