### PR TITLE
Add `smwgCompactLinkSupport`

### DIFF
--- a/DefaultSettings.php
+++ b/DefaultSettings.php
@@ -303,6 +303,29 @@ return array(
 	##
 
 	###
+	# Compact infolink support
+	#
+	# Special:Browse, Special:Ask, and Special:SearchByProperty links can contain
+	# arbitrary text elements and therefore become difficult to transfer when its
+	# length exceeds a certain character length.
+	#
+	# A compact link will be encoded and compressed to ensure that it can be handled
+	# more easily when referring to it as an URL representation.
+	#
+	# It is not expected to be used as a short-url service, yet in some instances
+	# the generate URL can be comparatively shorter than the plain URL.
+	#
+	# The generated link has no security relevance therefore is is not
+	# cryptographically hashed or secure and should not be seen as such, it is
+	# foremost to "compact" an URL address.
+	#
+	# @since 3.0
+	# @default true
+	##
+	'smwgCompactLinkSupport' => true,
+	##
+
+	###
 	#
 	# - SMW_CAT_NONE
 	#

--- a/includes/Settings.php
+++ b/includes/Settings.php
@@ -69,6 +69,7 @@ class Settings extends Options {
 			'smwgNamespaceIndex' => $GLOBALS['smwgNamespaceIndex'],
 			'smwgShowFactbox' => $GLOBALS['smwgShowFactbox'],
 			'smwgShowFactboxEdit' => $GLOBALS['smwgShowFactboxEdit'],
+			'smwgCompactLinkSupport' => $GLOBALS['smwgCompactLinkSupport'],
 			'smwgDefaultNumRecurringEvents' => $GLOBALS['smwgDefaultNumRecurringEvents'],
 			'smwgMaxNumRecurringEvents' => $GLOBALS['smwgMaxNumRecurringEvents'],
 			'smwgSearchByPropertyFuzzy' => $GLOBALS['smwgSearchByPropertyFuzzy'],

--- a/includes/datavalues/SMW_DataValue.php
+++ b/includes/datavalues/SMW_DataValue.php
@@ -75,6 +75,11 @@ abstract class SMWDataValue {
 	const OPT_DISABLE_INFOLINKS = 'disable.infolinks';
 
 	/**
+	 * Option to use compact infolinks
+	 */
+	const OPT_COMPACT_INFOLINKS = 'compact.infolinks';
+
+	/**
 	 * Associated data item. This is the reference to the immutable object
 	 * that represents the current data content. All other data stored here
 	 * is only about presentation and parsing, but is not relevant to the
@@ -331,13 +336,13 @@ abstract class SMWDataValue {
 	 *
 	 * @return mixed|false
 	 */
-	public function getOption( $key ) {
+	public function getOption( $key, $default = false ) {
 
 		if ( $this->options !== null && $this->options->has( $key ) ) {
 			return $this->options->get( $key );
 		}
 
-		return false;
+		return $default;
 	}
 
 	/**
@@ -665,6 +670,10 @@ abstract class SMWDataValue {
 		if ( $this->getOption( self::OPT_DISABLE_INFOLINKS ) === true ) {
 			$this->infoLinksProvider->disableServiceLinks();
 		}
+
+		$this->infoLinksProvider->setCompactLink(
+			$this->getOption( self::OPT_COMPACT_INFOLINKS, false )
+		);
 
 		return $this->infoLinksProvider->getInfolinkText( $outputformat, $linker );
 	}

--- a/includes/specials/SMW_SpecialPageProperty.php
+++ b/includes/specials/SMW_SpecialPageProperty.php
@@ -1,4 +1,8 @@
 <?php
+
+use SMWInfolink as Infolink;
+use SMW\Encoder;
+
 /**
  * @ingroup SMWSpecialPage
  * @ingroup SpecialPage
@@ -30,6 +34,16 @@ class SMWPageProperty extends SpecialPage {
 	public function execute( $query ) {
 		global $wgRequest, $wgOut;
 		$this->setHeaders();
+
+		if ( $wgRequest->getText( 'cl', '' ) !== '' ) {
+			$query = Infolink::decodeCompactLink( 'cl:'. $wgRequest->getText( 'cl' ) );
+		} else {
+			$query = Infolink::decodeCompactLink( $query );
+		}
+
+		if ( $query !== '' ) {
+			$query = Encoder::unescape( $query );
+		}
 
 		// Get parameters
 		$pagename = $wgRequest->getVal( 'from' );

--- a/src/DataValueFactory.php
+++ b/src/DataValueFactory.php
@@ -166,6 +166,11 @@ class DataValueFactory {
 			$localizer->getContentLanguage()->getCode()
 		);
 
+		$dataValue->setOption(
+			DataValue::OPT_COMPACT_INFOLINKS,
+			$GLOBALS['smwgCompactLinkSupport']
+		);
+
 		if ( isset( $this->defaultOutputFormatters[$typeId] ) ) {
 			$dataValue->setOutputFormat( $this->defaultOutputFormatters[$typeId] );
 		}

--- a/src/DataValues/InfoLinksProvider.php
+++ b/src/DataValues/InfoLinksProvider.php
@@ -46,6 +46,11 @@ class InfoLinksProvider {
 	private $enabledServiceLinks = true;
 
 	/**
+	 * @var boolean
+	 */
+	private $compactLink = false;
+
+	/**
 	 * @var boolean|array
 	 */
 	private $serviceLinkParameters = false;
@@ -73,6 +78,7 @@ class InfoLinksProvider {
 		$this->hasServiceLinks = false;
 		$this->enabledServiceLinks = true;
 		$this->serviceLinkParameters = false;
+		$this->compactLink = false;
 	}
 
 	/**
@@ -80,6 +86,15 @@ class InfoLinksProvider {
 	 */
 	public function disableServiceLinks() {
 		$this->enabledServiceLinks = false;
+	}
+
+	/**
+	 * @since 3.0
+	 *
+	 * @param boolean $compactLink
+	 */
+	public function setCompactLink( $compactLink ) {
+		$this->compactLink = (bool)$compactLink;
 	}
 
 	/**
@@ -124,6 +139,7 @@ class InfoLinksProvider {
 		$this->dataValue->setOutputFormat( '' );
 
 		$value = $this->dataValue->getWikiValue();
+		$property = $this->dataValue->getProperty();
 
 		// InTextAnnotationParser will detect :: therefore avoid link
 		// breakage by encoding the string
@@ -132,18 +148,14 @@ class InfoLinksProvider {
 		}
 
 		if ( in_array( $this->dataValue->getTypeID(), $this->browseLinks ) ) {
-			$this->infoLinks[] = Infolink::newBrowsingLink(
-				'+',
-				$this->dataValue->getLongWikiText()
-			);
-		} elseif ( $this->dataValue->getProperty() !== null ) {
-			$this->infoLinks[] = Infolink::newPropertySearchLink(
-				'+',
-				$this->dataValue->getProperty()->getLabel(),
-				$value
-			);
+			$infoLink = Infolink::newBrowsingLink( '+', $this->dataValue->getLongWikiText() );
+			$infoLink->setCompactLink( $this->compactLink );
+		} elseif ( $property !== null ) {
+			$infoLink = Infolink::newPropertySearchLink( '+', $property->getLabel(), $value );
+			$infoLink->setCompactLink( $this->compactLink );
 		}
 
+		$this->infoLinks[] = $infoLink;
 		$this->hasSearchLink = $this->infoLinks !== [];
 
 		 // add further service links

--- a/src/Defines.php
+++ b/src/Defines.php
@@ -27,6 +27,7 @@ define( 'SMW_HEADERS_HIDE', 0 ); // Used to be "false" hence use "0" to support 
 define( 'SMW_OUTPUT_HTML', 1 );
 define( 'SMW_OUTPUT_WIKI', 2 );
 define( 'SMW_OUTPUT_FILE', 3 );
+define( 'SMW_OUTPUT_RAW', 4 );
 /**@}*/
 
 /**@{

--- a/src/MediaWiki/Specials/Ask/NavigationLinksWidget.php
+++ b/src/MediaWiki/Specials/Ask/NavigationLinksWidget.php
@@ -164,6 +164,11 @@ class NavigationLinksWidget {
 		$limit = $urlArgs->get( 'limit' );
 		$offset = $urlArgs->get( 'offset' );
 
+		// Remove any contents that is cruft
+		if ( strpos( $urlArgs->get( 'p' ), 'cl=' ) !== false ) {
+			$urlArgs->set( 'p', mb_substr( $urlArgs->get( 'p' ), stripos( $urlArgs->get( 'p' ), '/' ) + 1 ) );
+		}
+
 		// @todo FIXME: i18n: Patchwork text.
 		$navigation .=
 			'<b>' .

--- a/src/MediaWiki/Specials/Browse/ValueFormatter.php
+++ b/src/MediaWiki/Specials/Browse/ValueFormatter.php
@@ -105,13 +105,18 @@ class ValueFormatter {
 		}
 
 		$html = $dataValue->getLongHTMLText( $linker );
+		$isCompactLink = $dataValue->getOption( DataValue::OPT_COMPACT_INFOLINKS, false );
 
 		$noInfolinks = [ '_INST', '_SKEY' ];
 
 		if ( in_array( $dataValue->getTypeID(), [ '_wpg', '_wpp', '__sob'] ) ) {
-			$html .= "&#160;" . Infolink::newBrowsingLink( '+', $dataValue->getLongWikiText() )->getHTML( $linker );
+			$infolink = Infolink::newBrowsingLink( '+', $dataValue->getLongWikiText() );
+			$infolink->setCompactLink( $isCompactLink );
+			$html .= "&#160;" . $infolink->getHTML( $linker );
 		} elseif ( $incoming && $propertyValue->isVisible() ) {
-			$html .= "&#160;" . Infolink::newInversePropertySearchLink( '+', $dataValue->getTitle(), $propertyValue->getDataItem()->getLabel(), 'smwsearch' )->getHTML( $linker );
+			$infolink = Infolink::newInversePropertySearchLink( '+', $dataValue->getTitle(), $propertyValue->getDataItem()->getLabel(), 'smwsearch' );
+			$infolink->setCompactLink( $isCompactLink );
+			$html .= "&#160;" . $infolink->getHTML( $linker );
 		} elseif ( $dataValue->getProperty() instanceof DIProperty && !in_array( $dataValue->getProperty()->getKey(), $noInfolinks ) ) {
 			$html .= $dataValue->getInfolinkText( SMW_OUTPUT_HTML, $linker );
 		}

--- a/src/MediaWiki/Specials/SpecialAsk.php
+++ b/src/MediaWiki/Specials/SpecialAsk.php
@@ -223,6 +223,12 @@ class SpecialAsk extends SpecialPage {
 		$request = $this->getRequest();
 		$this->isEditMode = false;
 
+		if ( $request->getText( 'cl', '' ) !== '' ) {
+			$p = Infolink::decodeCompactLink( 'cl:'. $request->getText( 'cl' ) );
+		} else {
+			$p = Infolink::decodeCompactLink( $p );
+		}
+
 		list( $this->queryString, $this->parameters, $this->printouts ) = ParametersProcessor::process(
 			$request,
 			$p

--- a/src/MediaWiki/Specials/SpecialBrowse.php
+++ b/src/MediaWiki/Specials/SpecialBrowse.php
@@ -11,6 +11,7 @@ use SMW\Encoder;
 use SMW\MediaWiki\Specials\Browse\ContentsBuilder;
 use SMW\MediaWiki\Specials\Browse\FormHelper;
 use SMW\Message;
+use SMWInfolink as Infolink;
 use SpecialPage;
 use Html;
 
@@ -54,6 +55,13 @@ class SpecialBrowse extends SpecialPage {
 
 		// get the GET parameters
 		$articletext = $webRequest->getVal( 'article' );
+
+		if ( $webRequest->getText( 'cl', '' ) !== '' ) {
+			$query = Infolink::decodeCompactLink( 'cl:'. $webRequest->getText( 'cl' ) );
+		} else {
+			$query = Infolink::decodeCompactLink( $query );
+		}
+
 		$isEmptyRequest = $query === null && ( $webRequest->getVal( 'article' ) === '' || $webRequest->getVal( 'article' ) === null );
 
 		// @see SMWInfolink::encodeParameters

--- a/src/MediaWiki/Specials/SpecialSearchByProperty.php
+++ b/src/MediaWiki/Specials/SpecialSearchByProperty.php
@@ -7,6 +7,7 @@ use SMW\MediaWiki\Specials\SearchByProperty\PageBuilder;
 use SMW\MediaWiki\Specials\SearchByProperty\PageRequestOptions;
 use SMW\MediaWiki\Specials\SearchByProperty\QueryResultLookup;
 use SpecialPage;
+use SMWInfolink as Infolink;
 
 /**
  * A special page to search for entities that have a certain property with
@@ -37,12 +38,19 @@ class SpecialSearchByProperty extends SpecialPage {
 
 		$this->setHeaders();
 		$output = $this->getOutput();
+		$request = $this->getRequest();
 
 		$output->setPageTitle( $this->msg( 'searchbyproperty' )->text() );
 		$output->addModules( 'ext.smw.tooltip' );
 		$output->addModules( 'ext.smw.autocomplete.property' );
 
 		list( $limit, $offset ) = $this->getLimitOffset();
+
+		if ( $request->getText( 'cl', '' ) !== '' ) {
+			$query = Infolink::decodeCompactLink( 'cl:'. $request->getText( 'cl' ) );
+		} else {
+			$query = Infolink::decodeCompactLink( $query );
+		}
 
 		// @see SMWInfolink::encodeParameters
 		if ( $query === null && $this->getRequest()->getCheck( 'x' ) ) {

--- a/src/Query/QueryLinker.php
+++ b/src/Query/QueryLinker.php
@@ -26,6 +26,7 @@ class QueryLinker {
 	public static function get( Query $query, array $parameters = array() ) {
 
 		$link = Infolink::newInternalLink( '', ':Special:Ask', false, array() );
+		$link->setCompactLink( $GLOBALS['smwgCompactLinkSupport'] );
 
 		foreach ( $parameters as $key => $value ) {
 

--- a/tests/phpunit/Integration/JSONScript/JsonTestCaseScriptRunnerTest.php
+++ b/tests/phpunit/Integration/JSONScript/JsonTestCaseScriptRunnerTest.php
@@ -132,6 +132,7 @@ class JsonTestCaseScriptRunnerTest extends JsonTestCaseScriptRunner {
 				'smwgQueryResultCacheType' => false,
 				'smwgQFilterDuplicates' => false,
 				'smwgExportResourcesAsIri' => false,
+				'smwgCompactLinkSupport' => false,
 				'smwgSparqlReplicationPropertyExemptionList' => array(),
 				'smwgFieldTypeFeatures' => SMW_FIELDT_NONE,
 				'smwgDVFeatures' => $GLOBALS['smwgDVFeatures'] & ~SMW_DV_NUMV_USPACE,
@@ -227,6 +228,7 @@ class JsonTestCaseScriptRunnerTest extends JsonTestCaseScriptRunner {
 			'smwgParserFeatures',
 			'smwgCategoryFeatures',
 			'smwgDefaultOutputFormatters',
+			'smwgCompactLinkSupport',
 
 			// MW related
 			'wgLanguageCode',

--- a/tests/phpunit/Integration/JSONScript/TestCases/s-0024.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/s-0024.json
@@ -1,0 +1,49 @@
+{
+	"description": "Test `Special:Browse` with compact links (`smwgCompactLinkSupport`)",
+	"setup": [
+		{
+			"namespace": "SMW_NS_PROPERTY",
+			"page": "Has page",
+			"contents": "[[Has type::Page]]"
+		},
+		{
+			"page": "Example/S0024/L'oéal",
+			"contents": "[[Has page::{{FULLPAGENAME}}]] [[Category:S0024]]"
+		}
+	],
+	"tests": [
+		{
+			"type": "special",
+			"about": "#0",
+			"special-page": {
+				"page": "Browse",
+				"query-parameters": "cl:OkV4YW1wbGUtMkZTMDAyNC0yRkwnb8OpYWw",
+				"request-parameters": {
+					"output": "legacy"
+				}
+			},
+			"assert-output": {
+				"to-contain": [
+					"<span class=\"smwbrowse\"><a href=.*cl:OkV4YW1wbGUtMkZTMDAyNC0yRkwnb8OpYWw\" title=\"Special:Browse/cl:OkV4YW1wbGUtMkZTMDAyNC0yRkwnb8OpYWw\">+</a></span>"
+				]
+			}
+		}
+	],
+	"settings": {
+		"wgContLang": "en",
+		"wgLang": "en",
+		"smwgCompactLinkSupport": true,
+		"smwgPageSpecialProperties": [
+			"_MDAT"
+		],
+		"smwgNamespacesWithSemanticLinks": {
+			"NS_MAIN": true,
+			"SMW_NS_PROPERTY": true
+		}
+	},
+	"meta": {
+		"version": "2",
+		"is-incomplete": false,
+		"debug": false
+	}
+}

--- a/tests/phpunit/Unit/MediaWiki/Specials/Ask/NavigationLinksWidgetTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Specials/Ask/NavigationLinksWidgetTest.php
@@ -97,26 +97,26 @@ class NavigationLinksWidgetTest extends \PHPUnit_Framework_TestCase {
 			->will( $this->returnValue( 10 ) );
 
 		// Previous
-		$urlArgs->expects( $this->at( 2 ) )
+		$urlArgs->expects( $this->at( 3 ) )
 			->method( 'set' )
 			->with(
 				$this->equalTo( 'offset' ),
 				$this->equalTo( 7 ) );
 
-		$urlArgs->expects( $this->at( 3 ) )
+		$urlArgs->expects( $this->at( 4 ) )
 			->method( 'set' )
 			->with(
 				$this->equalTo( 'limit' ),
 				$this->equalTo( 3 ) );
 
 		// Next
-		$urlArgs->expects( $this->at( 4 ) )
+		$urlArgs->expects( $this->at( 5 ) )
 			->method( 'set' )
 			->with(
 				$this->equalTo( 'offset' ),
 				$this->equalTo( 13 ) );
 
-		$urlArgs->expects( $this->at( 5 ) )
+		$urlArgs->expects( $this->at( 6 ) )
 			->method( 'set' )
 			->with(
 				$this->equalTo( 'limit' ),

--- a/tests/phpunit/Unit/Page/ListBuilder/ValueListBuilderTest.php
+++ b/tests/phpunit/Unit/Page/ListBuilder/ValueListBuilderTest.php
@@ -19,16 +19,23 @@ use SMW\Tests\TestEnvironment;
 class ValueListBuilderTest extends \PHPUnit_Framework_TestCase {
 
 	private $store;
+	private $testEnvironment;
 	private $stringValidator;
 
 	protected function setUp() {
 		parent::setUp();
 
-		$this->stringValidator = TestEnvironment::newValidatorFactory()->newStringValidator();
+		$this->testEnvironment = new TestEnvironment( [ 'smwgCompactLinkSupport' => false ] );
+		$this->stringValidator = $this->testEnvironment->newValidatorFactory()->newStringValidator();
 
 		$this->store = $this->getMockBuilder( '\SMW\Store' )
 			->disableOriginalConstructor()
 			->getMockForAbstractClass();
+	}
+
+	protected function tearDown() {
+		$this->testEnvironment->tearDown();
+		parent::tearDown();
 	}
 
 	public function testCanConstruct() {

--- a/tests/phpunit/includes/InfolinkTest.php
+++ b/tests/phpunit/includes/InfolinkTest.php
@@ -2,44 +2,164 @@
 
 namespace SMW\Test;
 
-use SMWInfolink;
+use SMWInfolink as Infolink;
+use SMW\Tests\TestEnvironment;
 
 /**
- * Tests for the SMWInfolink class
+ * @covers \SMWInfolink
+ * @group semantic-mediawiki
  *
+ * @license GNU GPL v2+
  * @since 1.9
  *
- * @file
- *
- * @licence GNU GPL v2+
  * @author mwjames
  */
+class InfolinkTest extends \PHPUnit_Framework_TestCase {
 
-/**
- * Tests for the SMWInfolink class
- * @covers \SMWInfolink
- *
- *
- * @group SMW
- * @group SMWExtension
- */
-class InfolinkTest extends SemanticMediaWikiTestCase {
+	private $testEnvironment;
 
-	/**
-	 * Returns the name of the class to be tested
-	 *
-	 * @return string|false
-	 */
-	public function getClass() {
-		return '\SMWInfolink';
+	protected function setUp() {
+
+		$this->testEnvironment = new TestEnvironment(
+			[
+				'wgContLang' => \Language::factory( 'en' )
+			]
+		);
+	}
+
+	protected function tearDown() {
+		$this->testEnvironment->tearDown();
+		parent::tearDown();
 	}
 
 	/**
-	 * Parameter dataProvider
-	 *
-	 * @return array
+	 * @dataProvider parameterDataProvider
 	 */
-	public function getParameterDataProvider() {
+	public function testEncodeParameters_ForTitle( array $params, array $expected ) {
+
+		$encodeResult = Infolink::encodeParameters( $params, true );
+
+		$this->assertEquals(
+			$expected[0],
+			$encodeResult
+		);
+	}
+
+	/**
+	 * @dataProvider parameterDataProvider
+	 */
+	public function testEncodeParameters_NotForTitle( array $params, array $expected ) {
+
+		$encodeResult = Infolink::encodeParameters( $params, false );
+
+		$this->assertEquals(
+			$expected[1],
+			$encodeResult
+		);
+	}
+
+	public function testNewPropertySearchLink_GetText() {
+
+		$instance = Infolink::newPropertySearchLink( 'Foo', 'Bar', 'Foobar' );
+
+		$instance->setCompactLink( false );
+
+		$this->assertContains(
+			'title=Special:SearchByProperty&x=%3ABar%2FFoobar',
+			$instance->getText( SMW_OUTPUT_RAW )
+		);
+
+		$instance->setCompactLink( true );
+
+		$this->assertContains(
+			'title=Special:SearchByProperty&cl=eD0lM0FCYXIlMkZGb29iYXI',
+			$instance->getText( SMW_OUTPUT_RAW )
+		);
+
+		$this->assertEquals(
+			$instance->getURL(),
+			$instance->getText( SMW_OUTPUT_RAW )
+		);
+	}
+
+	/**
+	 * @dataProvider base64Provider
+	 */
+	public function testEncodeBase64( $source, $target ) {
+
+		$this->assertContains(
+			$target,
+			Infolink::encodeCompactLink( $source )
+		);
+	}
+
+	/**
+	 * @dataProvider base64Provider
+	 */
+	public function testEncodeDecodeBase64RoundTrip( $source, $target ) {
+
+		$this->assertEquals(
+			$source,
+			Infolink::decodeCompactLink( Infolink::encodeCompactLink( $source ) )
+		);
+	}
+
+	/**
+	 * @dataProvider base64DecodeProvider
+	 */
+	public function testDecodeBase64( $source, $target ) {
+
+		$this->assertEquals(
+			$source,
+			Infolink::decodeCompactLink( $target )
+		);
+	}
+
+	public function testNotDecodable() {
+
+		$this->assertNotContains(
+			'%3ABar/Foobar',
+			Infolink::decodeCompactLink( 'eD0lM0FCYXIlMkZGb29iYXI' )
+		);
+	}
+
+	public function base64Provider() {
+
+		yield [
+			'%3ABar/Foobar',
+			'cl:JTNBQmFyL0Zvb2Jhcg'
+		];
+
+		yield [
+			'-5B-5BProperty%3A%2B-5D-5D-20-5B-5BCategory%3ALorem-20ipsum-5D-5D/-3FHas-20description%3DDescription/-3FHas-20type/mainlabel=/format=table/class=datatable/sort=/order=asc/offset=100/limit=50',
+			'cl:YzpFijEOgzAMRU_DGCUFMXooRVUHhl7BgKkiJTiy3YHbF8qA9Jf33ndt59ruLVxIbKuae1Xvoj9WB_ePDzT6sBxxYKG8h1j0m8-bd83zhbrLmXSSWCzyWjV9f9F1sa2QzxjXhCMl8AtLRgPDMZGfEqrCjIYnK4uBZ5lJAHXyvCxKBrcQfIo5GrThBw'
+		];
+	}
+
+	public function base64DecodeProvider() {
+
+		yield [
+			'%3ABar/Foobar',
+			'cl:JTNBQmFyL0Zvb2Jhcg'
+		];
+
+		yield [
+			'%3ABar/Foobar',
+			'%3ABar/Foobar'
+		];
+
+		yield [
+			'-5B-5BProperty%3A%2B-5D-5D-20-5B-5BCategory%3ALorem-20ipsum-5D-5D/-3FHas-20description%3DDescription/-3FHas-20type/mainlabel=/format=table/class=datatable/sort=/order=asc/offset=100/limit=50',
+			'cl:YzpNijEOgzAMRU-TbJVSEKOHtgh16NArGDBVpARHtiuV2zeIBekv773_g0t3r3sLFxLbXHtzTRX9viYc8YFGH5Y9vlgo1xCLfvNxc81waYcnatUz6SSxWOTVtX1_otPJtkI-Y1wTjpTALywZDQzHRH5KqAozGh6sLAaeZSYB1MnzsigZXEPwKeZo0IU'
+		];
+
+		yield [
+			'-5B-5BProperty%3A%2B-5D-5D-20-5B-5BCategory%3ALorem-20ipsum-5D-5D/-3FHas-20description%3DDescription/-3FHas-20type/mainlabel=/format=table/class=datatable/sort=/order=asc/offset=100/limit=50',
+			'cl:YzpFijEOgzAMRU_DGCUFMXooRVUHhl7BgKkiJTiy3YHbF8qA9Jf33ndt59ruLVxIbKuae1Xvoj9WB_ePDzT6sBxxYKG8h1j0m8-bd83zhbrLmXSSWCzyWjV9f9F1sa2QzxjXhCMl8AtLRgPDMZGfEqrCjIYnK4uBZ5lJAHXyvCxKBrcQfIo5GrThBw'
+		];
+	}
+
+	public function parameterDataProvider() {
 		return array(
 			array(
 				// #0
@@ -79,20 +199,4 @@ class InfolinkTest extends SemanticMediaWikiTestCase {
 		);
 	}
 
-	/**
-	 * @test SMWInfolink::encodeParameters
-	 * @dataProvider getParameterDataProvider
-	 *
-	 * @since 1.9
-	 *
-	 * @param array $params
-	 * @param array $expectedEncode
-	 */
-	public function testEncodeParameters( array $params, array $expectedEncode ) {
-		$encodeResult = SMWInfolink::encodeParameters( $params, true );
-		$this->assertEquals( $expectedEncode[0], $encodeResult );
-
-		$encodeResult = SMWInfolink::encodeParameters( $params, false );
-		$this->assertEquals( $expectedEncode[1], $encodeResult );
-	}
 }


### PR DESCRIPTION
This PR is made in reference to: #

This PR addresses or contains:

- Adds `$smwgCompactLinkSupport` setting (default: `true`) to generate "compact" (aka base64) links for pages like `Special:Ask`, `Special:Browse`, and `Special:SearchByProperty`
- Links will be similar to something like `Special:Browse/cl:OkV4YW1wbGUtMkZTMDAyNA` and depending on the size of the query string (especially for `Special:Ask` links) some space saving can be considered but is not the main objective
  - `Special:Ask/-5B-5BProperty:%2B-5D-5D-20-5B-5BCategory:Lorem-20ipsum-5D-5D/-3FHas-20description%3DDescription/-3FHas-20type/mainlabel%3D/limit%3D50/offset%3D50/format%3Dtable/class%3Ddatatable`
  -  `Special:Ask/cl:YzpFirEKwzAMRD-oGIcWLwEvaSgdOvQXlEQuAjsykjLk75u6Q-CGd-_OhcGF4S1cUWzvLy6Mv1w714Y7GH5Y9v7FguXQVHUr_5N3t8cT9JAL6ixUjXiN48nnwfaKvgCtGSbM0WcqZDF0nlNSbJRYClg0mDL6OYNqXMCg9S8`

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed

Fixes #