### PR TITLE
Add keyword (`_keyw`) type

### DIFF
--- a/DefaultSettings.php
+++ b/DefaultSettings.php
@@ -798,7 +798,8 @@ return array(
 	##
 	'smwgDataTypePropertyExemptionList' => array(
 		'Record',
-		'Reference'
+		'Reference',
+		'Keyword'
 	),
 	##
 

--- a/data/schema/rule/link-format-rule-schema.v1.json
+++ b/data/schema/rule/link-format-rule-schema.v1.json
@@ -71,9 +71,6 @@
                 "default": "",
                 "examples": [
                   "Has description"
-                ],
-                "enum": [
-                  "Has description"
                 ]
               }
             }
@@ -89,14 +86,15 @@
               "enum": ["Special:Ask"]
             }
           },
-          "required": ["parameters"]
+          "required": [ "parameters" ]
         },
         {
           "properties": {
             "link_to": {
-              "enum": ["Special:SearchByProperty"]
+              "enum": ["Special:SearchByProperty" ]
             }
-          }
+          },
+          "additionalProperties": false
         }
       ]
     },

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -586,11 +586,14 @@
 	"smw-datavalue-external-formatter-uri-missing-placeholder": "Formatter URI is missing the ''$1'' placeholder.",
 	"smw-datavalue-external-formatter-invalid-uri": " \"$1\" is an invalid URL.",
 	"smw-datavalue-external-identifier-formatter-missing": "The property is missing an [[Property:External formatter uri|\"External formatter URI\"]] assignment.",
+	"smw-datavalue-keyword-maximum-length": "Keyword exceeded the maximum length of $1.",
 	"smw-property-predefined-eid": "\"$1\" is a [[Special:Types/External identifier|type]] and predefined property provided by [https://www.semantic-mediawiki.org/wiki/Help:Special_properties Semantic MediaWiki] to represent external identifiers.",
 	"smw-property-predefined-peid": "\"$1\" is a predefined property that specifies an external identifier and is provided by [https://www.semantic-mediawiki.org/wiki/Help:Special_properties Semantic MediaWiki].",
 	"smw-property-predefined-pefu": "\"$1\" is a predefined property provided by [https://www.semantic-mediawiki.org/wiki/Help:Special_properties Semantic MediaWiki] to specify an external resource with a placeholder.",
 	"smw-property-predefined-long-pefu": "The URI is expected to contain a placeholder that will be adjusted with an [[Special:Types/External identifier|external identifier]] value to form a valid resource reference.",
 	"smw-type-eid": "\"$1\" is a restricted [https://www.semantic-mediawiki.org/wiki/Type_String String] type that requires assigned properties to declare an [[Property:External formatter uri|External formatter URI]].",
+	"smw-property-predefined-keyw": "\"$1\" is a predefined property and [[Special:Types/Keyword|type]] provided by [https://www.semantic-mediawiki.org/wiki/Help:Special_properties Semantic MediaWiki] that normalizes a text and has a restricted character length.",
+	"smw-type-keyw": "\"$1\" is a text type that has a restricted character length and normalizes its content representation.",
 	"smw-datavalue-stripmarker-parse-error": "The given value \"$1\" contains [https://en.wikipedia.org/wiki/Help:Strip_markers strip markers] and therefore it cannot be parsed sufficiently.",
 	"smw-datavalue-parse-error": "The given value \"$1\" was not understood.",
 	"smw-datavalue-propertylist-invalid-property-key": "The property list \"$1\" contained an invalid property key \"$2\".",
@@ -694,5 +697,7 @@
 	"smw-property-predefined-rl-tag": "\"$1\" is a predefined property provided by [https://www.semantic-mediawiki.org/wiki/Help:Special_properties Semantic MediaWiki] to tag listed rules.",
 	"smw-property-predefined-long-rl-tag": "An annotated textual tag is to identify a group of rules that apply to the same content or topic.",
 	"smw-property-predefined-rl-type": "\"$1\" is a predefined property that describes a type by which a rule or set of rules is interpret and is provided by [https://www.semantic-mediawiki.org/wiki/Help:Special_properties Semantic MediaWiki].",
-	"smw-property-predefined-long-rl_type": "Each rule type has it own [https://www.semantic-mediawiki.org/wiki/Help:Rule#schema schema] assigned and the following [https://www.semantic-mediawiki.org/wiki/Help:Rule/Type help page] should contain a comprehensive overview and description."
+	"smw-property-predefined-long-rl_type": "Each rule type has it own [https://www.semantic-mediawiki.org/wiki/Help:Rule#schema schema] assigned and the following [https://www.semantic-mediawiki.org/wiki/Help:Rule/Type help page] should contain a comprehensive overview and description.",
+	"smw-ask-title-keyword-type":"Keyword search",
+	"smw-ask-message-keyword-type": "This search matches the <code><nowiki>$1</nowiki></code> condition."
 }

--- a/i18n/extra/en.json
+++ b/i18n/extra/en.json
@@ -20,6 +20,7 @@
 		"_qty": "Quantity",
 		"_mlt_rec": "Monolingual text",
 		"_eid": "External identifier",
+		"_keyw": "Keyword",
 		"_ref_rec": "Reference"
 	},
 	"dataTypeAliases":{
@@ -48,6 +49,7 @@
 		"Record": "_rec",
 		"Monolingual text": "_mlt_rec",
 		"External identifier": "_eid",
+		"Keyword": "_keyw",
 		"Reference": "_ref_rec"
 	},
 	"propertyLabels":{
@@ -97,7 +99,8 @@
 		"_RL_DESC": "Rule description",
 		"_RL_TAG": "Rule tag",
 		"_RL_TYPE": "Rule type",
-		"_RL_DEF": "Rule definition"
+		"_RL_DEF": "Rule definition",
+		"_FORMAT_RL": "Formatter rule"
 	},
 	"propertyAliases": {
 		"Display unit": "_UNIT",
@@ -154,7 +157,8 @@
 		"Rule description": "_RL_DESC",
 		"Rule tag": "_RL_TAG",
 		"Rule type": "_RL_TYPE",
-		"Rule definition": "_RL_DEF"
+		"Rule definition": "_RL_DEF",
+		"Formatter rule": "_FORMAT_RL"
 	},
 	"namespaces":{
 		"SMW_NS_PROPERTY": "Property",

--- a/includes/dataitems/SMW_DI_Blob.php
+++ b/includes/dataitems/SMW_DI_Blob.php
@@ -1,4 +1,7 @@
 <?php
+
+use Onoi\Tesa\Normalizer;
+
 /**
  * @ingroup SMWDataItems
  */
@@ -29,6 +32,14 @@ class SMWDIBlob extends SMWDataItem {
 
 	public function getString() {
 		return $this->m_string;
+	}
+
+	public static function normalize( $text ) {
+		return Normalizer::convertDoubleWidth(
+			Normalizer::applyTransliteration(
+				Normalizer::toLowercase( $text )
+			)
+		);
 	}
 
 	public function getSortKey() {

--- a/src/DataValues/KeywordValue.php
+++ b/src/DataValues/KeywordValue.php
@@ -1,0 +1,284 @@
+<?php
+
+namespace SMW\DataValues;
+
+use SMWStringValue as StringValue;
+use SMWInfolink as Infolink;
+use SMW\ApplicationFactory;
+use SMW\DIProperty;
+use SMW\Localizer;
+use SMWDataItem as DataItem;
+use SMWDIBlob as DIBlob;
+
+/**
+ * @private
+ *
+ * @license GNU GPL v2+
+ * @since 3.0
+ *
+ * @author mwjames
+ */
+class KeywordValue extends StringValue {
+
+	/**
+	 * DV identifier
+	 */
+	const TYPE_ID = '_keyw';
+
+	/**
+	 * @var string|null
+	 */
+	private $uri = null;
+
+	/**
+	 * @param string $typeid
+	 */
+	public function __construct( $typeid = '' ) {
+		parent::__construct( self::TYPE_ID );
+	}
+
+	/**
+	 * @see DataValue::parseUserValue
+	 *
+	 * @param string $value
+	 */
+	protected function parseUserValue( $value ) {
+
+		// For the normal blob field setup multi-byte requires more space and
+		// since we use the o_hash field to store the normalized content and
+		// as match field, ensure to have enough space to actually store
+		// a mb keyword
+		$maxLength = mb_detect_encoding( $value, 'ASCII', true ) ? 150: 85;
+
+		if ( mb_strlen( $value, 'utf8' ) > $maxLength ) {
+			$this->addErrorMsg( [ 'smw-datavalue-keyword-maximum-length', $maxLength ] );
+			return;
+		}
+
+		if ( $this->getOption( self::OPT_QUERY_COMP_CONTEXT ) || $this->getOption( self::OPT_QUERY_CONTEXT ) ) {
+			$value = DIBlob::normalize( $value );
+		}
+
+		if ( $this->m_caption === false ) {
+			$this->m_caption = $value;
+		}
+
+		parent::parseUserValue( $value );
+
+		$this->m_dataitem->setOption( 'is.keyword', true );
+	}
+
+	/**
+	 * @see DataValue::getDataItem
+	 */
+	public function getDataItem() {
+
+		if ( $this->isValid() && $this->getOption( 'is.search' ) ) {
+			return new DIBlob( DIBlob::normalize( $this->m_dataitem->getString() ) );
+		}
+
+		return parent::getDataItem();
+	}
+
+	/**
+	 * @see DataValue::getShortWikiText
+	 *
+	 * @param string $value
+	 */
+	public function getShortWikiText( $linker = null ) {
+
+		if ( !$this->isValid() ) {
+			return '';
+		}
+
+		if ( !$this->m_caption ) {
+			$this->m_caption = $this->m_dataitem->getString();
+		}
+
+		if ( $linker === null ) {
+			return $this->m_caption;
+		}
+
+		$uri = $this->makeUri(
+			$this->m_dataitem->getString(),
+			SMW_OUTPUT_WIKI,
+			$linker
+		);
+
+		if ( $uri === '' ) {
+			return $this->m_caption;
+		}
+
+		return $uri;
+	}
+
+	/**
+	 * @see StringValue::getShortHTMLText
+	 */
+	public function getShortHTMLText( $linker = null ) {
+
+		if ( !$this->isValid() ) {
+			return '';
+		}
+
+		if ( !$this->m_caption ) {
+			$this->m_caption = $this->m_dataitem->getString();
+		}
+
+		if ( $linker === null ) {
+			return $this->m_caption;
+		}
+
+		$uri = $this->makeUri(
+			$this->m_dataitem->getString(),
+			SMW_OUTPUT_HTML,
+			$linker
+		);
+
+		if ( $uri === '' ) {
+			return $this->m_caption;
+		}
+
+		return $uri;
+	}
+
+	/**
+	 * @see StringValue::getLongWikiText
+	 */
+	public function getLongWikiText( $linked = null ) {
+		return $this->getShortWikiText( $linked );
+	}
+
+	/**
+	 * @see StringValue::getLongHTMLText
+	 */
+	public function getLongHTMLText( $linker = null ) {
+		return $this->getShortHTMLText( $linker );
+	}
+
+	/**
+	 * @since 2.5
+	 *
+	 * @return DataItem
+	 */
+	public function getUri() {
+
+		if ( !$this->isValid() ) {
+			return '';
+		}
+
+		$uri = $this->makeUri(
+			$this->m_dataitem->getString(),
+			SMW_OUTPUT_RAW
+		);
+
+		if ( $uri === '' ) {
+			return '';
+		}
+
+		$dataValue = $this->dataValueServiceFactory->getDataValueFactory()->newDataValueByType(
+			'_uri',
+			$uri
+		);
+
+		return $dataValue->getDataItem();
+	}
+
+	private function makeUri( $value, $outputformat, $linker = null ) {
+
+		if ( $this->uri !== null ) {
+			return $this->uri;
+		}
+
+		$propertySpecificationLookup = $this->dataValueServiceFactory->getPropertySpecificationLookup();
+
+		// Formatter Rule?
+		$dataItems = $propertySpecificationLookup->getSpecification(
+			$this->getProperty(),
+			new DIProperty( '_FORMAT_RL' )
+		);
+
+		if ( $dataItems === [] ) {
+			return '';
+		}
+
+		$dataItem = end( $dataItems );
+
+		$dataItems = $propertySpecificationLookup->getSpecification(
+			$dataItem,
+			new DIProperty( '_RL_DEF' )
+		);
+
+		if ( $dataItems === [] ) {
+			return '';
+		}
+
+		$dataItem = end( $dataItems );
+
+		$link = $this->getFormatLink( $dataItem, $value );
+
+		if ( $link === '' ) {
+			return '';
+		}
+
+		$this->uri = $link->getText( $outputformat );
+
+		$this->uri = Localizer::getInstance()->getCanonicalizedUrlByNamespace(
+			NS_SPECIAL,
+			$this->uri
+		);
+
+		return $this->uri;
+	}
+
+	private function getFormatLink( $dataItem, $value ) {
+
+		$infolink = '';
+
+		$data = json_decode(
+			$dataItem->getString(),
+			true
+		);
+
+		// Schema enforced
+		if ( $data['type'] !== 'LINK_FORMAT_RULE' ) {
+			return '';
+		}
+
+		if ( !isset( $data['rule']['link_to'] ) ) {
+			return '';
+		}
+
+		$link_to = $data['rule']['link_to'];
+		$label = $this->getProperty()->getLabel();
+
+		if ( $link_to === 'Special:Ask' ) {
+			$infolink = Infolink::newInternalLink( $this->m_caption, ':Special:Ask', false, [] );
+			$infolink->setParameter( "[[$label::$value]]", false );
+			$infolink->setCompactLink( $this->getOption( KeywordValue::OPT_COMPACT_INFOLINKS, false ) );
+
+			foreach ( $data['rule']['parameters'] as $key => $value ) {
+				if ( $key === 'printouts' ) {
+					foreach ( $value as $v ) {
+						$infolink->setParameter( "?$v" );
+					}
+				} else {
+					$infolink->setParameter( $value, $key );
+				}
+			}
+
+		} elseif ( $link_to === 'Special:SearchByProperty' ) {
+			$infolink = Infolink::newInternalLink( $this->m_caption, ':Special:SearchByProperty', false, [] );
+			$infolink->setCompactLink( $this->getOption( KeywordValue::OPT_COMPACT_INFOLINKS, false ) );
+			$infolink->setParameter( ":$label" );
+			$infolink->setParameter( $value );
+		}
+
+		return $infolink;
+	}
+
+	private function makeNonlinkedWikiText( $url ) {
+		return str_replace( ':', '&#58;', $url );
+	}
+
+}

--- a/src/DefaultList.php
+++ b/src/DefaultList.php
@@ -10,6 +10,7 @@ use SMW\DataValues\TemperatureValue;
 use SMW\DataValues\MonolingualTextValue;
 use SMW\DataValues\ReferenceValue;
 use SMW\DataValues\ExternalIdentifierValue;
+use SMW\DataValues\KeywordValue;
 use SMW\DataValues\LanguageCodeValue;
 use SMW\DataValues\AllowsValue;
 use SMW\DataValues\AllowsListValue;
@@ -95,6 +96,8 @@ class DefaultList {
 			'_gpo' => [ null, DataItem::TYPE_BLOB, false ],
 			// External identifier
 			ExternalIdentifierValue::TYPE_ID => [ ExternalIdentifierValue::class, DataItem::TYPE_BLOB, false ],
+			// KeywordValue
+			KeywordValue::TYPE_ID => [ KeywordValue::class, DataItem::TYPE_BLOB, false ],
 			 // Type for numbers with units of measurement
 			QuantityValue::TYPE_ID => [ QuantityValue::class, DataItem::TYPE_NUMBER, false ],
 			// Special types are not avaialble directly for users (and have no local language name):
@@ -210,6 +213,10 @@ class DefaultList {
 			'_RL_DEF'  => [ '_cod', true, false, false ], // "Rule definition"
 			'_RL_DESC' => [ '_txt', true, false, false ], // "Rule description"
 			'_RL_TAG'  => [ '_txt', true, false, false ], // "Rule tag"
+
+			//
+			'_FORMAT_RL'  => [ '_wpr', true, true, false ], // "Formatter rule"
+
 		];
 	}
 

--- a/src/Exporter/ResourceBuilders/DispatchingResourceBuilder.php
+++ b/src/Exporter/ResourceBuilders/DispatchingResourceBuilder.php
@@ -114,14 +114,15 @@ class DispatchingResourceBuilder implements ResourceBuilder {
 		$this->addResourceBuilder( new PreferredPropertyLabelResourceBuilder() );
 
 		$this->addResourceBuilder( new ExternalIdentifierPropertyValueResourceBuilder() );
+		$this->addResourceBuilder( new KeywordPropertyValueResourceBuilder() );
+
 		$this->addResourceBuilder( new MonolingualTextPropertyValueResourceBuilder() );
-
 		$this->addResourceBuilder( new ConceptPropertyValueResourceBuilder() );
+
 		$this->addResourceBuilder( new ImportFromPropertyValueResourceBuilder() );
-
 		$this->addResourceBuilder( new RedirectPropertyValueResourceBuilder() );
-		$this->addResourceBuilder( new AuxiliaryPropertyValueResourceBuilder() );
 
+		$this->addResourceBuilder( new AuxiliaryPropertyValueResourceBuilder() );
 		$this->addResourceBuilder( new PredefinedPropertyValueResourceBuilder() );
 
 		$this->addDefaultResourceBuilder( new PropertyValueResourceBuilder() );

--- a/src/Exporter/ResourceBuilders/KeywordPropertyValueResourceBuilder.php
+++ b/src/Exporter/ResourceBuilders/KeywordPropertyValueResourceBuilder.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace SMW\Exporter\ResourceBuilders;
+
+use SMW\Exporter\ResourceBuilder;
+use SMW\DIProperty;
+use SMWExporter as Exporter;
+use SMW\DataValueFactory;
+use SMWDataItem as DataItem;
+use SMWExpData as ExpData;
+use SMWDIUri as DIUri;
+use SMWDIBlob as DIBlob;
+
+/**
+ * @private
+ *
+ * @license GNU GPL v2+
+ * @since 3.0
+ *
+ * @author mwjames
+ */
+class KeywordPropertyValueResourceBuilder extends PropertyValueResourceBuilder {
+
+	/**
+	 * @since 3.0
+	 *
+	 * {@inheritDoc}
+	 */
+	public function isResourceBuilderFor( DIProperty $property ) {
+		return $property->findPropertyTypeID() === '_keyw';
+	}
+
+	/**
+	 * @since 3.0
+	 *
+	 * {@inheritDoc}
+	 */
+	public function addResourceValue( ExpData $expData, DIProperty $property, DataItem $dataItem ) {
+
+		$dataItem = new DIBlob(
+			DIBlob::normalize( $dataItem->getString() )
+		);
+
+		parent::addResourceValue( $expData, $property, $dataItem );
+
+		$dataValue = DataValueFactory::getInstance()->newDataValueByItem(
+			$dataItem,
+			$property
+		);
+
+		$uri = $dataValue->getUri();
+
+		/**
+		 * @see https://www.w3.org/2009/08/skos-reference/skos.rdf
+		 *
+		 * "skos:relatedMatch" has been defined as "... used to state an associative
+		 * mapping link between two conceptual resources in different concept
+		 * schemes ..."
+		 */
+		if ( $uri instanceof DIUri ) {
+			$expData->addPropertyObjectValue(
+				$this->exporter->getSpecialNsResource( 'skos', 'relatedMatch' ),
+				$this->exporter->getDataItemExpElement( $uri )
+			);
+		}
+	}
+
+}

--- a/src/Localizer.php
+++ b/src/Localizer.php
@@ -301,6 +301,17 @@ class Localizer {
 
 		$namespace = $this->getNamespaceTextById( $index );
 
+		if ( strpos( $url, 'title=' ) !== false ) {
+			return str_replace(
+				[
+					'title=' . wfUrlencode( $namespace ) . ':',
+					'title=' . $namespace . ':'
+				],
+				'title=' . $this->getCanonicalNamespaceTextById( $index ) .':',
+				$url
+			);
+		}
+
 		return str_replace(
 			array(
 				wfUrlencode( '/' . $namespace .':' ),

--- a/src/MediaWiki/Specials/SearchByProperty/QueryResultLookup.php
+++ b/src/MediaWiki/Specials/SearchByProperty/QueryResultLookup.php
@@ -202,6 +202,9 @@ class QueryResultLookup {
 	}
 
 	private function doQueryForExactValue( PageRequestOptions $pageRequestOptions, RequestOptions $requestOptions ) {
+
+		$pageRequestOptions->value->setOption( 'is.search', true );
+
 		return $this->store->getPropertySubjects(
 			$pageRequestOptions->property->getDataItem(),
 			$pageRequestOptions->value->getDataItem(),

--- a/src/PropertySpecificationLookup.php
+++ b/src/PropertySpecificationLookup.php
@@ -8,6 +8,7 @@ use SMW\Message;
 use SMWDIBlob as DIBlob;
 use SMWDIBoolean as DIBoolean;
 use SMWQuery as Query;
+use RuntimeException;
 
 /**
  * This class should be accessed via ApplicationFactory::getPropertySpecificationLookup
@@ -68,14 +69,22 @@ class PropertySpecificationLookup {
 	/**
 	 * @since 2.5
 	 *
-	 * @param DIProperty $source
+	 * @param DIProperty|DIWikiPage $source
 	 * @param DIProperty $target
 	 *
 	 * @return []|DataItem[]
 	 */
-	public function getSpecification( DIProperty $source, DIProperty $target ) {
+	public function getSpecification( $source, DIProperty $target ) {
 
-		$hash = $source->getCanonicalDiWikiPage()->getHash();
+		if ( $source instanceof DIProperty ) {
+			$dataItem = $source->getCanonicalDiWikiPage();
+		} elseif( $source instanceof DIWikiPage ) {
+			$dataItem = $source;
+		} else {
+			throw new RuntimeException( "Invalid request instance type" );
+		}
+
+		$hash = $dataItem->getHash();
 		$key = $target->getKey();
 
 		$definition = $this->intermediaryMemoryCache->fetch( $hash );
@@ -89,7 +98,7 @@ class PropertySpecificationLookup {
 		}
 
 		$dataItems = $this->cachedPropertyValuesPrefetcher->getPropertyValues(
-			$source->getCanonicalDiWikiPage(),
+			$dataItem,
 			$target
 		);
 

--- a/src/SQLStore/EntityStore/DIHandlers/DIBlobHandler.php
+++ b/src/SQLStore/EntityStore/DIHandlers/DIBlobHandler.php
@@ -58,7 +58,13 @@ class DIBlobHandler extends DataItemHandler {
 	 * {@inheritDoc}
 	 */
 	public function getWhereConds( DataItem $dataItem ) {
-		return array( 'o_hash' => $this->makeHash( $dataItem->getString() ) );
+
+		$isKeyword = $dataItem->getOption( 'is.keyword' );
+		$text = $dataItem->getString();
+
+		return [
+			'o_hash' => $isKeyword ? $dataItem->normalize( $text ) : $this->makeHash( $text )
+		];
 	}
 
 	/**
@@ -68,14 +74,16 @@ class DIBlobHandler extends DataItemHandler {
 	 */
 	public function getInsertValues( DataItem $dataItem ) {
 
+		$isKeyword = $dataItem->getOption( 'is.keyword' );
+
 		$text = htmlspecialchars_decode( trim( $dataItem->getString() ), ENT_QUOTES );
-		$hash = $this->makeHash( $text );
+		$hash = $isKeyword ? $dataItem->normalize( $text ) : $this->makeHash( $text );
 
 		if ( $this->isDbType( 'postgres' ) ) {
 			$text = pg_escape_bytea( $text );
 		}
 
-		if ( mb_strlen( $text ) <= $this->getMaxLength() ) {
+		if ( mb_strlen( $text ) <= $this->getMaxLength() && !$isKeyword ) {
 			$text = null;
 		}
 

--- a/tests/phpunit/Integration/JSONScript/Fixtures/p-0549-keyword-formatter-rule.json
+++ b/tests/phpunit/Integration/JSONScript/Fixtures/p-0549-keyword-formatter-rule.json
@@ -1,0 +1,15 @@
+{
+    "description": "Specifies a formatting rule for a keyword type",
+    "type": "LINK_FORMAT_RULE",
+    "rule": {
+        "link_to": "Special:Ask",
+        "parameters": {
+            "format": "list"
+        }
+    },
+    "tags": [
+        "formatter",
+        "link formatter",
+        "keyword"
+    ]
+}

--- a/tests/phpunit/Integration/JSONScript/TestCases/p-0457.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/p-0457.json
@@ -15,11 +15,11 @@
 			"contents": "{{#subobject:Foo bar|Has text=123|@category=P0457/2|display title of=Bar foo}}"
 		},
 		{
-			"page": "Example/P0454/Q.1",
+			"page": "Example/P0457/Q.1",
 			"contents": "{{#ask: [[Category:P0457/1]] }}"
 		},
 		{
-			"page": "Example/P0454/Q.2",
+			"page": "Example/P0457/Q.2",
 			"contents": "{{#ask: [[Category:P0457/2]] }}"
 		}
 	],
@@ -27,7 +27,7 @@
 		{
 			"type": "parser",
 			"about": "#0 (named sobj without `_` in caption)",
-			"subject": "Example/P0454/Q.1",
+			"subject": "Example/P0457/Q.1",
 			"assert-output": {
 				"to-contain": [
 					"<a href=.*Example/P0457/1#Foo_bar\" title=\"Example/P0457/1\">Example/P0457/1#Foo bar</a>"
@@ -40,7 +40,7 @@
 		{
 			"type": "parser",
 			"about": "#1 (named sobj without `_` in caption and `display title of`)",
-			"subject": "Example/P0454/Q.2",
+			"subject": "Example/P0457/Q.2",
 			"assert-output": {
 				"to-contain": [
 					"<a href=.*Example/P0457/2#Foo_bar\" title=\"Example/P0457/2\">Bar foo#Foo bar</a>"

--- a/tests/phpunit/Integration/JSONScript/TestCases/p-0458.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/p-0458.json
@@ -1,0 +1,72 @@
+{
+	"description": "Test keyword type `_keyw`",
+	"setup": [
+		{
+			"namespace": "SMW_NS_PROPERTY",
+			"page": "Has keyword",
+			"contents": "[[Has type::Keyword]]"
+		},
+		{
+			"page": "Example/P0458/1",
+			"contents": "[[Has keyword::aBcDEF]]"
+		},
+		{
+			"page": "Example/P0458/2",
+			"contents": "[[Has keyword::abcdef]]"
+		},
+		{
+			"page": "Example/P0458/3",
+			"contents": "[[Has keyword::ABCDEF]]"
+		},
+		{
+			"page": "Example/P0458/Q.1",
+			"contents": "{{#ask: [[Has keyword::ABCDEF]] |?Has keyword }}"
+		},
+		{
+			"page": "Example/P0458/Q.2",
+			"contents": "{{#ask: [[Has keyword::abcdef]] |?Has keyword }}"
+		}
+	],
+	"tests": [
+		{
+			"type": "parser",
+			"about": "#0",
+			"subject": "Example/P0458/Q.1",
+			"assert-output": {
+				"to-contain": [
+					"<td class=\"smwtype_wpg\"><a href=.*Example/P0458/1\" title=\"Example/P0458/1\">Example/P0458/1</a></td><td class=\"Has-keyword smwtype_keyw\">aBcDEF</td>",
+					"<td class=\"smwtype_wpg\"><a href=.*Example/P0458/2\" title=\"Example/P0458/2\">Example/P0458/2</a></td><td class=\"Has-keyword smwtype_keyw\">abcdef</td>",
+					"<td class=\"smwtype_wpg\"><a href=.*Example/P0458/3\" title=\"Example/P0458/3\">Example/P0458/3</a></td><td class=\"Has-keyword smwtype_keyw\">ABCDEF</td>"
+				]
+			}
+		},
+		{
+			"type": "parser",
+			"about": "#1",
+			"subject": "Example/P0458/Q.2",
+			"assert-output": {
+				"to-contain": [
+					"<td class=\"smwtype_wpg\"><a href=.*Example/P0458/1\" title=\"Example/P0458/1\">Example/P0458/1</a></td><td class=\"Has-keyword smwtype_keyw\">aBcDEF</td>",
+					"<td class=\"smwtype_wpg\"><a href=.*Example/P0458/2\" title=\"Example/P0458/2\">Example/P0458/2</a></td><td class=\"Has-keyword smwtype_keyw\">abcdef</td>",
+					"<td class=\"smwtype_wpg\"><a href=.*Example/P0458/3\" title=\"Example/P0458/3\">Example/P0458/3</a></td><td class=\"Has-keyword smwtype_keyw\">ABCDEF</td>"
+				]
+			}
+		}
+	],
+	"settings": {
+		"wgContLang": "en",
+		"wgLang": "en",
+		"smwgPageSpecialProperties": [
+			"_MDAT"
+		],
+		"smwgNamespacesWithSemanticLinks": {
+			"NS_MAIN": true,
+			"SMW_NS_PROPERTY": true
+		}
+	},
+	"meta": {
+		"version": "2",
+		"is-incomplete": false,
+		"debug": false
+	}
+}

--- a/tests/phpunit/Integration/JSONScript/TestCases/p-0459.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/p-0459.json
@@ -1,0 +1,119 @@
+{
+	"description": "Test keyword type `_keyw` with a formatter rule (`smwgCompactLinkSupport`)",
+	"setup": [
+		{
+			"namespace": "SMW_NS_RULE",
+			"page": "Keyword link formatter rule",
+			"contents": {
+				"import-from": "/../Fixtures/p-0549-keyword-formatter-rule.json"
+			}
+		},
+		{
+			"namespace": "SMW_NS_PROPERTY",
+			"page": "Has keyword",
+			"contents": "[[Has type::Keyword]] [[Formatter rule::Keyword link formatter rule]]"
+		},
+		{
+			"page": "Example/P0459/1",
+			"contents": "[[Has keyword::aBcDEF]]"
+		},
+		{
+			"page": "Example/P0459/2",
+			"contents": "[[Has keyword::abcdef]]"
+		},
+		{
+			"page": "Example/P0459/3",
+			"contents": "[[Has keyword::ABCDEF]]"
+		},
+		{
+			"page": "Example/P0459/Q.1",
+			"contents": "{{#ask: [[Has keyword::ABCDEF]] |?Has keyword }}"
+		},
+		{
+			"page": "Example/P0459/Q.2",
+			"contents": "{{#ask: [[Has keyword::abcdef]] |?Has keyword }}"
+		}
+	],
+	"tests": [
+		{
+			"type": "parser",
+			"about": "#0",
+			"subject": "Keyword link formatter rule",
+			"namespace": "SMW_NS_RULE",
+			"assert-store": {
+				"semantic-data": {
+					"strictPropertyValueMatch": false,
+					"propertyCount": 6,
+					"propertyKeys": [
+						"_MDAT",
+						"_RL_DEF",
+						"_RL_DESC",
+						"_RL_TAG",
+						"_RL_TYPE",
+						"_SKEY"
+					]
+				}
+			}
+		},
+		{
+			"type": "parser",
+			"about": "#1",
+			"subject": "Has keyword",
+			"namespace": "SMW_NS_PROPERTY",
+			"assert-store": {
+				"semantic-data": {
+					"strictPropertyValueMatch": false,
+					"propertyCount": 4,
+					"propertyKeys": [
+						"_FORMAT_RL",
+						"_SKEY",
+						"_MDAT",
+						"_TYPE"
+					]
+				}
+			}
+		},
+		{
+			"type": "parser",
+			"about": "#2",
+			"subject": "Example/P0459/Q.1",
+			"assert-output": {
+				"to-contain": [
+					"<td class=\"smwtype_wpg\"><a href=.*Example/P0459/1\" title=\"Example/P0459/1\">Example/P0459/1</a></td><td class=\"Has-keyword smwtype_keyw\"><a href=.*Special:Ask/cl:LTVCLTVCSGFzLTIwa2V5d29yZDo6YUJjREVGLTVELTVEL2Zvcm1hdD1saXN0\" title=\"Special:Ask/cl:LTVCLTVCSGFzLTIwa2V5d29yZDo6YUJjREVGLTVELTVEL2Zvcm1hdD1saXN0\">aBcDEF</a></td>",
+					"<td class=\"smwtype_wpg\"><a href=.*Example/P0459/2\" title=\"Example/P0459/2\">Example/P0459/2</a></td><td class=\"Has-keyword smwtype_keyw\"><a href=.*Special:Ask/cl:LTVCLTVCSGFzLTIwa2V5d29yZDo6YWJjZGVmLTVELTVEL2Zvcm1hdD1saXN0\" title=\"Special:Ask/cl:LTVCLTVCSGFzLTIwa2V5d29yZDo6YWJjZGVmLTVELTVEL2Zvcm1hdD1saXN0\">abcdef</a></td>",
+					"<td class=\"smwtype_wpg\"><a href=.*Example/P0459/3\" title=\"Example/P0459/3\">Example/P0459/3</a></td><td class=\"Has-keyword smwtype_keyw\"><a href=.*Special:Ask/cl:LTVCLTVCSGFzLTIwa2V5d29yZDo6QUJDREVGLTVELTVEL2Zvcm1hdD1saXN0\" title=\"Special:Ask/cl:LTVCLTVCSGFzLTIwa2V5d29yZDo6QUJDREVGLTVELTVEL2Zvcm1hdD1saXN0\">ABCDEF</a></td>"
+				]
+			}
+		},
+		{
+			"type": "parser",
+			"about": "#3",
+			"subject": "Example/P0459/Q.2",
+			"assert-output": {
+				"to-contain": [
+					"<td class=\"smwtype_wpg\"><a href=.*Example/P0459/1\" title=\"Example/P0459/1\">Example/P0459/1</a></td><td class=\"Has-keyword smwtype_keyw\"><a href=.*Special:Ask/cl:LTVCLTVCSGFzLTIwa2V5d29yZDo6YUJjREVGLTVELTVEL2Zvcm1hdD1saXN0\" title=\"Special:Ask/cl:LTVCLTVCSGFzLTIwa2V5d29yZDo6YUJjREVGLTVELTVEL2Zvcm1hdD1saXN0\">aBcDEF</a></td>",
+					"<td class=\"smwtype_wpg\"><a href=.*Example/P0459/2\" title=\"Example/P0459/2\">Example/P0459/2</a></td><td class=\"Has-keyword smwtype_keyw\"><a href=.*Special:Ask/cl:LTVCLTVCSGFzLTIwa2V5d29yZDo6YWJjZGVmLTVELTVEL2Zvcm1hdD1saXN0\" title=\"Special:Ask/cl:LTVCLTVCSGFzLTIwa2V5d29yZDo6YWJjZGVmLTVELTVEL2Zvcm1hdD1saXN0\">abcdef</a></td>",
+					"<td class=\"smwtype_wpg\"><a href=.*Example/P0459/3\" title=\"Example/P0459/3\">Example/P0459/3</a></td><td class=\"Has-keyword smwtype_keyw\"><a href=.*Special:Ask/cl:LTVCLTVCSGFzLTIwa2V5d29yZDo6QUJDREVGLTVELTVEL2Zvcm1hdD1saXN0\" title=\"Special:Ask/cl:LTVCLTVCSGFzLTIwa2V5d29yZDo6QUJDREVGLTVELTVEL2Zvcm1hdD1saXN0\">ABCDEF</a></td>"
+				]
+			}
+		}
+	],
+	"settings": {
+		"wgContLang": "en",
+		"wgLang": "en",
+		"smwgCompactLinkSupport": true,
+		"smwgPageSpecialProperties": [
+			"_MDAT"
+		],
+		"smwgNamespacesWithSemanticLinks": {
+			"NS_MAIN": true,
+			"SMW_NS_PROPERTY": true,
+			"SMW_NS_RULE": true
+		}
+	},
+	"meta": {
+		"version": "2",
+		"is-incomplete": false,
+		"debug": false
+	}
+}

--- a/tests/phpunit/Unit/DataValues/KeywordValueTest.php
+++ b/tests/phpunit/Unit/DataValues/KeywordValueTest.php
@@ -1,0 +1,163 @@
+<?php
+
+namespace SMW\Tests\DataValues;
+
+use SMW\DataValues\KeywordValue;
+use SMW\DataItemFactory;
+use SMW\DataValueFactory;
+use SMW\Tests\TestEnvironment;
+use SMW\PropertySpecificationLookup;
+
+/**
+ * @covers \SMW\DataValues\KeywordValue
+ * @group semantic-mediawiki
+ *
+ * @license GNU GPL v2+
+ * @since 2.5
+ *
+ * @author mwjames
+ */
+class KeywordValueTest extends \PHPUnit_Framework_TestCase {
+
+	private $testEnvironment;
+	private $dataItemFactory;
+	private $propertySpecificationLookup;
+	private $dataValueServiceFactory;
+
+	protected function setUp() {
+		parent::setUp();
+
+		$this->testEnvironment = new TestEnvironment();
+		$this->dataItemFactory = new DataItemFactory();
+
+		$this->propertySpecificationLookup = $this->getMockBuilder( PropertySpecificationLookup::class )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$constraintValueValidator = $this->getMockBuilder( '\SMW\DataValues\ValueValidators\ConstraintValueValidator' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$externalFormatterUriValue = $this->getMockBuilder( '\SMW\DataValues\ExternalFormatterUriValue' )
+			->disableOriginalConstructor()
+			->getMockForAbstractClass();
+
+		$this->dataValueServiceFactory = $this->getMockBuilder( '\SMW\Services\DataValueServiceFactory' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$this->dataValueServiceFactory->expects( $this->any() )
+			->method( 'getPropertySpecificationLookup' )
+			->will( $this->returnValue( $this->propertySpecificationLookup ) );
+
+		$this->dataValueServiceFactory->expects( $this->any() )
+			->method( 'getConstraintValueValidator' )
+			->will( $this->returnValue( $constraintValueValidator ) );
+
+		$this->dataValueServiceFactory->expects( $this->any() )
+			->method( 'getDataValueFactory' )
+			->will( $this->returnValue( DataValueFactory::getInstance() ) );
+
+		$this->testEnvironment->registerObject( 'PropertySpecificationLookup', $this->propertySpecificationLookup );
+	}
+
+	protected function tearDown() {
+		$this->testEnvironment->tearDown();
+	}
+
+	public function testCanConstruct() {
+
+		$this->assertInstanceOf(
+			KeywordValue::class,
+			new KeywordValue()
+		);
+	}
+
+	public function testErrorWhenLengthExceedsLimit() {
+
+		$this->propertySpecificationLookup->expects( $this->any() )
+			->method( 'getSpecification' )
+			->will( $this->returnValue( [] ) );
+
+		$instance = new KeywordValue();
+		$instance->setDataValueServiceFactory( $this->dataValueServiceFactory );
+
+		$instance->setUserValue( 'LTVCLTVCSGFzLTIwa2V5d29yZC0yMHRlc3Q6OnRFc3QtMjAyLTVELTVEL2Zvcm1hdD1jYXRlZ29yeS8tM0ZIYXMtMjBkZXNjcmlwdGlvbgLTVCLTVCSGFzLTIwa2V5d29yZC0yMHRlc3Q6OnRFc3QtMjAyLTVELTVEL2Zvcm1hdD1jYXRlZ29yeS8tM0ZIYXMtMjBkZXNjcmlwdGlvbgLTVCLTVCSGFzLTIwaLTVCLTVCSGFzLTIwa..........' );
+		$instance->setProperty( $this->dataItemFactory->newDIProperty( 'Bar' ) );
+
+		$this->assertEquals(
+			'',
+			$instance->getShortWikiText()
+		);
+
+		$this->assertContains(
+			'smw-datavalue-keyword-maximum-length',
+			implode( ', ',  $instance->getErrors() )
+		);
+	}
+
+	public function testGetShortWikiText_WithoutLink() {
+
+		$this->propertySpecificationLookup->expects( $this->any() )
+			->method( 'getSpecification' )
+			->will( $this->returnValue( [] ) );
+
+		$instance = new KeywordValue();
+		$instance->setDataValueServiceFactory( $this->dataValueServiceFactory );
+
+		$instance->setUserValue( 'foo' );
+		$instance->setProperty( $this->dataItemFactory->newDIProperty( 'Bar' ) );
+
+		$this->assertEquals(
+			'foo',
+			$instance->getShortWikiText()
+		);
+
+		$this->assertEquals(
+			'foo',
+			$instance->getShortWikiText( 'linker' )
+		);
+	}
+
+	public function testGetShortWikiText_WithLink() {
+
+		$data = json_encode(
+			[
+				'type' => 'LINK_FORMAT_RULE',
+				'rule' => [ 'link_to' => 'Special:SearchByProperty' ]
+			]
+		);
+
+		$this->propertySpecificationLookup->expects( $this->at( 0 ) )
+			->method( 'getSpecification' )
+			->with(
+				$this->anything(),
+				$this->equalTo( $this->dataItemFactory->newDIProperty( '_FORMAT_RL' ) ) )
+			->will( $this->returnValue( [ $this->dataItemFactory->newDIWikiPage( 'Bar', SMW_NS_RULE ) ] ) );
+
+		$this->propertySpecificationLookup->expects( $this->at( 1 ) )
+			->method( 'getSpecification' )
+			->with(
+				$this->anything(),
+				$this->equalTo( $this->dataItemFactory->newDIProperty( '_RL_DEF' ) ) )
+			->will( $this->returnValue( [ $this->dataItemFactory->newDIBlob( $data ) ] ) );
+
+		$instance = new KeywordValue();
+		$instance->setDataValueServiceFactory( $this->dataValueServiceFactory );
+		$instance->setOption( KeywordValue::OPT_COMPACT_INFOLINKS, true );
+
+		$instance->setUserValue( 'foo' );
+		$instance->setProperty( $this->dataItemFactory->newDIProperty( 'Bar' ) );
+
+		$this->assertEquals(
+			'foo',
+			$instance->getShortWikiText()
+		);
+
+		$this->assertContains(
+			'[[:Special:SearchByProperty/cl:OkJhci9mb28|foo]]',
+			$instance->getShortWikiText( 'linker' )
+		);
+	}
+
+}

--- a/tests/phpunit/Unit/Exporter/ResourceBuilders/KeywordPropertyValueResourceBuilderTest.php
+++ b/tests/phpunit/Unit/Exporter/ResourceBuilders/KeywordPropertyValueResourceBuilderTest.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace SMW\Tests\Exporter\ResourceBuilders;
+
+use SMW\Exporter\ResourceBuilders\KeywordPropertyValueResourceBuilder;
+use SMW\DataItemFactory;
+use SMW\Tests\TestEnvironment;
+use SMWExpData as ExpData;
+use SMW\Exporter\Element\ExpNsResource;
+
+/**
+ * @covers \SMW\Exporter\ResourceBuilders\KeywordPropertyValueResourceBuilder
+ * @group semantic-mediawiki
+ *
+ * @license GNU GPL v2+
+ * @since 2.5
+ *
+ * @author mwjames
+ */
+class KeywordPropertyValueResourceBuilderTest extends \PHPUnit_Framework_TestCase {
+
+	private $dataItemFactory;
+	private $testEnvironment;
+
+	protected function setUp() {
+		parent::setUp();
+		$this->dataItemFactory = new DataItemFactory();
+		$this->testEnvironment = new TestEnvironment();
+
+		$this->testEnvironment->resetPoolCacheById( \SMWExporter::POOLCACHE_ID );
+	}
+
+	protected function tearDown() {
+		$this->testEnvironment->tearDown();
+		parent::tearDown();
+	}
+
+	public function testCanConstruct() {
+
+		$this->assertInstanceof(
+			KeywordPropertyValueResourceBuilder::class,
+			new KeywordPropertyValueResourceBuilder()
+		);
+	}
+
+	public function testIsNotResourceBuilderForNonExternalIdentifierTypedProperty() {
+
+		$property = $this->dataItemFactory->newDIProperty( 'Foo' );
+
+		$instance = new KeywordPropertyValueResourceBuilder();
+
+		$this->assertFalse(
+			$instance->isResourceBuilderFor( $property )
+		);
+	}
+
+	public function testAddResourceValueForValidProperty() {
+
+		$property = $this->dataItemFactory->newDIProperty( 'Foo' );
+		$property->setPropertyTypeId( '_keyw' );
+
+		$dataItem = $this->dataItemFactory->newDIBlob( 'Bar' );
+
+		$expData = new ExpData(
+			new ExpNsResource( 'Foobar', 'Bar', 'Mo', null )
+		);
+
+		$instance = new KeywordPropertyValueResourceBuilder();
+
+		$instance->addResourceValue(
+			$expData,
+			$property,
+			$dataItem
+		);
+
+		$this->assertTrue(
+			$instance->isResourceBuilderFor( $property )
+		);
+	}
+
+}

--- a/tests/phpunit/Unit/LocalizerTest.php
+++ b/tests/phpunit/Unit/LocalizerTest.php
@@ -284,7 +284,7 @@ class LocalizerTest extends \PHPUnit_Framework_TestCase {
 			->disableOriginalConstructor()
 			->getMock();
 
-		$language->expects( $this->exactly( 2 ) )
+		$language->expects( $this->exactly( 3 ) )
 			->method( 'getNsText' )
 			->will( $this->returnValue( 'Spécial' ) );
 
@@ -298,6 +298,11 @@ class LocalizerTest extends \PHPUnit_Framework_TestCase {
 		$this->assertEquals(
 			'http://example.org/wiki/Special:URIResolver/Property-3AHas_query',
 			$instance->getCanonicalizedUrlByNamespace( NS_SPECIAL, 'http://example.org/wiki/Spécial:URIResolver/Property-3AHas_query' )
+		);
+
+		$this->assertEquals(
+			'http://example.org/index.php?title=Special:URIResolver&Property-3AHas_query',
+			$instance->getCanonicalizedUrlByNamespace( NS_SPECIAL, 'http://example.org/index.php?title=Spécial:URIResolver&Property-3AHas_query' )
 		);
 	}
 


### PR DESCRIPTION
This PR is made in reference to: #

This PR addresses or contains:

- As the name suggests this PR adds a keyword type that is different from the standard text type by:
  - being restricted in length (150 for ASCII, 85 for UTF-8 to ensure that it fits into the 255 char `o_hash` field)
  - is normalized (lowercased, removed diacritics)
  - the original annotation value is kept but during a query request the normalized value is used to match the broadest possible result set which means whether you use `teSt`, `TEST`, or `test` the normalized version will always match the keyword `test` independent of any `SMW_FIELDT_CHAR_NOCASE` or the full-text index settings
  - allows to add a formatter rule (#3019, `[[Formatter rule:...]]`) which will self link any keyword to a `link_to` target (which can either be a `Special:SearchByProperty` or `Special:Ask`) to have immediate access to entities that have the same normalized keyword annotated
- The `Keyword` as property has been added to `smwgDataTypePropertyExemptionList` so that `Property:Keyword` is not automatically occupied and doesn't override any existing user properties with the same name

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed

## Why?

Users apply the `#lc` parser function to normalize texts and in a later phase format those via a template to help generate query links. Both functions `#lc` and templates can lengthen the parser time of a page therefore the keyword type and hereby any property defined as such should help minimize the work related to it.

## Formatter rule

Any keyword typed property can have its own formatter rule assigned which defines how links should be generated where #3017 was added to allow those links to become compact and easier to handle from a user point of view.

Link to `Special:Ask` with format `list`
```
{
    "description": "Specifies a formatting rule for a keyword type",
    "type": "LINK_FORMAT_RULE",
    "rule": {
        "link_to": "Special:Ask",
        "parameters": {
            "format": "list"
        }
    },
    "tags": [
        "formatter",
        "link formatter",
        "keyword"
    ]
}
```
Link to `Special:Ask` with format `table` and show `Has description` as printout.
```
{
    "description": "Specifies a formatting rule for a keyword type",
    "type": "LINK_FORMAT_RULE",
    "rule": {
        "link_to": "Special:Ask",
        "parameters": {
            "format": "table",
            "printouts": [
                "Has description"
            ]
        }
    },
    "tags": [
        "formatter",
        "link formatter",
        "keyword"
    ]
}
```
Link to `Special:SearchByProperty` with no parameters required (the link definition is clear by just being a property and a value).
```
{
    "description": "Specifies a formatting rule for a keyword type",
    "type": "LINK_FORMAT_RULE",
    "rule": {
        "link_to": "Special:SearchByProperty"
    },
    "tags": [
        "formatter",
        "link formatter",
        "keyword"
    ]
}
```
