### PR TITLE
adding Spanish translation for new namespaces and properties

### DIFF
--- a/i18n/extra/es.json
+++ b/i18n/extra/es.json
@@ -72,7 +72,11 @@
         "_PPLB": "Etiqueta de propiedad preferida",
         "_EDIP": "Está protegida de edición",
         "_CHGPRO": "Propagación de cambio",
-        "_PPGR": "Es un grupo de propiedad"
+        "_PPGR": "Es un grupo de propiedad",
+        "_RL_DESC": "Descripción de regla",
+        "_RL_TAG": "Etiqueta de regla",
+        "_RL_TYPE": "Tipo de regla",
+        "_RL_DEF": "Definición de regla"
     },
     "propertyAliases": {
         "Es página nueva": "_NEWP",
@@ -91,7 +95,9 @@
         "SMW_NS_TYPE": "Tipo",
         "SMW_NS_TYPE_TALK": "Tipo_discusión",
         "SMW_NS_CONCEPT": "Concepto",
-        "SMW_NS_CONCEPT_TALK": "Concepto_discusión"
+        "SMW_NS_CONCEPT_TALK": "Concepto_discusión",
+        "SMW_NS_RULE": "Regla",
+        "SMW_NS_RULE_TALK": "Regla discusión"
     },
     "namespaceAliases": {
         "Atributo": "SMW_NS_PROPERTY",


### PR DESCRIPTION
This PR is made in reference to: #3019

This PR addresses or contains:
- Translation of new properties for the rule scheme
- Translation of the new namespace (Rule) for the rule scheme

This PR includes:
- [ ] Tests (unit/integration)
- [x] CI build passed

----
I translated the new strings in `i18n/extra/es.json` but I could not tested it because I can not create a rule, check #3022 to know the reason.