### PR TITLE
Add `templatefile` result printer

### DIFF
--- a/DefaultSettings.php
+++ b/DefaultSettings.php
@@ -615,7 +615,9 @@ return array(
 	'smwgQConceptCacheLifetime' => 24 * 60,
 	##
 
-	### Predefined result formats for queries
+	##
+	# Predefined result formats for queries
+	#
 	# Array of available formats for formatting queries. Can be redefined in
 	# the settings to disallow certain formats or to register extension formats.
 	# To disable a format, do "unset($smwgResultFormats['template'])," Disabled
@@ -636,19 +638,25 @@ return array(
 		'debug'      => 'SMW\ListResultPrinter',
 		'feed'       => 'SMW\FeedResultPrinter',
 		'csv'        => 'SMW\Query\ResultPrinters\CsvFileExportPrinter',
+		'templatefile' => 'SMW\Query\ResultPrinters\TemplateFileExportPrinter',
 		'dsv'        => 'SMW\DsvResultPrinter',
 		'json'       => 'SMW\JsonResultPrinter',
 		'rdf'        => 'SMW\RdfResultPrinter'
 	),
 	##
 
-	### Predefined aliases for result formats
+	##
+	# Predefined aliases for result formats
+	#
 	# Array of available aliases for result formats. Can be redefined in
 	# the settings to disallow certain aliases or to register extension aliases.
 	# To disable an alias, do "unset($smwgResultAliases['alias'])," Disabled
 	# aliases will be treated like if the alias parameter had been omitted.
 	##
-	'smwgResultAliases' => array( 'feed' => array( 'rss' ) ),
+	'smwgResultAliases' => [
+		'feed' => [ 'rss' ],
+		'templatefile' => [ 'template file' ]
+	],
 	##
 
 	##

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -45,6 +45,7 @@
 	"smw_printername_table": "Table",
 	"smw_printername_broadtable": "Broad table",
 	"smw_printername_template": "Template",
+	"smw_printername_templatefile": "Template file",
 	"smw_printername_rdf": "RDF export",
 	"smw_printername_category": "Category",
 	"validator-type-class-SMWParamSource": "text",

--- a/src/Query/ResultPrinters/ResultPrinter.php
+++ b/src/Query/ResultPrinters/ResultPrinter.php
@@ -223,6 +223,17 @@ abstract class ResultPrinter implements IResultPrinter {
 	/**
 	 * @since 3.0
 	 *
+	 * @param string $text
+	 *
+	 * @return string
+	 */
+	public function expandTemplates( $text ) {
+		return $this->recursiveTextProcessor->expandTemplates( $text );
+	}
+
+	/**
+	 * @since 3.0
+	 *
 	 * @param array $modules
 	 * @param array $styleModules
 	 */

--- a/src/Query/ResultPrinters/TemplateFileExportPrinter.php
+++ b/src/Query/ResultPrinters/TemplateFileExportPrinter.php
@@ -1,0 +1,252 @@
+<?php
+
+namespace SMW\Query\ResultPrinters;
+
+use Sanitizer;
+use SMWQueryResult as QueryResult;
+use SMW\ApplicationFactory;
+
+/**
+ * Exports data as file in a format that is defined by its invoked templates.
+ * Custom specifications and requirements can be specified freely by relying on
+ * the available template system.
+ *
+ * @license GNU GPL v2+
+ * @since 3.0
+ *
+ * @author mwjames
+ */
+class TemplateFileExportPrinter extends FileExportPrinter {
+
+	/**
+	 * @var integer
+	 */
+	private $numRows = 0;
+
+	/**
+	 * @var TemplateRenderer
+	 */
+	private $templateRenderer;
+
+	/**
+	 * @see ResultPrinter::getName
+	 *
+	 * {@inheritDoc}
+	 */
+	public function getName() {
+		return $this->msg( 'smw_printername_templatefile' )->text();
+	}
+
+	/**
+	 * @see FileExportPrinter::getMimeType
+	 *
+	 * @since 3.0
+	 *
+	 * {@inheritDoc}
+	 */
+	public function getMimeType( QueryResult $queryResult ) {
+
+		if ( $this->params['mimetype'] !== '' ) {
+			return $this->params['mimetype'];
+		}
+
+		return 'text/plain';
+	}
+
+	/**
+	 * @see FileExportPrinter::getFileName
+	 *
+	 * @since 3.0
+	 *
+	 * {@inheritDoc}
+	 */
+	public function getFileName( QueryResult $queryResult ) {
+		return $this->params['filename'];
+	}
+
+	/**
+	 * @see ResultPrinter::getParamDefinitions
+	 *
+	 * @since 3.0
+	 *
+	 * {@inheritDoc}
+	 */
+	public function getParamDefinitions( array $definitions ) {
+		$params = parent::getParamDefinitions( $definitions );
+
+		$params['searchlabel']->setDefault( 'templateFile' );
+
+		$params['template arguments'] = [
+			'message' => 'smw-paramdesc-template-arguments',
+			'default' => 'legacy',
+			'values' => [ 'numbered', 'named', 'legacy' ],
+		];
+
+		$params['template'] = [
+			'type' => 'string',
+			'default' => '',
+			'message' => 'smw-paramdesc-template',
+		];
+
+		$params['valuesep'] = [
+			'message' => 'smw-paramdesc-sep',
+			'default' => ',',
+		];
+
+		$params['userparam'] = [
+			'message' => 'smw-paramdesc-userparam',
+			'default' => '',
+		];
+
+		$params['introtemplate'] = [
+			'message' => 'smw-paramdesc-introtemplate',
+			'default' => '',
+		];
+
+		$params['outrotemplate'] = [
+			'message' => 'smw-paramdesc-outrotemplate',
+			'default' => '',
+		];
+
+		$params['filename'] = [
+			'message' => 'smw-paramdesc-filename',
+			'default' => 'file.txt',
+		];
+
+		$params['mimetype'] = [
+			'type' => 'string',
+			'message' => 'smw-paramdesc-mimetype',
+			'default' => 'text/plain',
+		];
+
+		return $params;
+	}
+
+	/**
+	 * @see ResultPrinter::getResultText
+	 *
+	 * {@inheritDoc}
+	 */
+	protected function getResultText( QueryResult $queryResult, $outputMode ) {
+
+		// Always return a link for when the output mode is not a file request,
+		// a file request is normally only initiated when resolving the query
+		// via Special:Ask
+		if ( $outputMode !== SMW_OUTPUT_FILE ) {
+			return $this->getFileLink( $queryResult, $outputMode );
+		}
+
+		$text = $this->expandTemplates(
+			$this->getText( $queryResult )
+		);
+
+		return trim( $text, "\n" );
+	}
+
+	private function getFileLink( QueryResult $queryResult, $outputMode ) {
+
+		// Can be viewed as HTML if requested, no more parsing needed
+		$this->isHTML = $outputMode == SMW_OUTPUT_HTML;
+
+		$link = $this->getLink(
+			$queryResult,
+			$outputMode
+		);
+
+		return $link->getText( $outputMode, $this->mLinker );
+	}
+
+	private function getText( $queryResult ) {
+
+		$this->templateRenderer = ApplicationFactory::getInstance()->newMwCollaboratorFactory()->newWikitextTemplateRenderer();
+		$result = '';
+
+		$link = $this->getLink(
+			$queryResult,
+			SMW_OUTPUT_RAW
+		);
+
+		$link = $link->getText( SMW_OUTPUT_RAW, $this->mLinker );
+
+		// Extra fields include:
+		// - {{{userparam}}}
+		// - {{{querylink}}}
+
+		if ( $this->params['introtemplate'] !== '' ) {
+			$this->templateRenderer->addField( 'userparam', $this->params['userparam'] );
+			$this->templateRenderer->addField( 'querylink', $link );
+
+			$this->templateRenderer->packFieldsForTemplate(
+				$this->params['introtemplate']
+			);
+
+			$result .= $this->templateRenderer->render();
+		}
+
+		while ( $row = $queryResult->getNext() ) {
+			$result .= $this->row( $queryResult, $row );
+		}
+
+		// Extra fields include:
+		// - {{{userparam}}}
+		// - {{{querylink}}}
+
+		if ( $this->params['outrotemplate'] !== '' ) {
+			$this->templateRenderer->addField( 'userparam', $this->params['userparam'] );
+			$this->templateRenderer->addField( 'querylink', $link );
+
+			$this->templateRenderer->packFieldsForTemplate(
+				$this->params['outrotemplate']
+			);
+
+			$result .= $this->templateRenderer->render();
+		}
+
+		return $result;
+	}
+
+	private function row( QueryResult $queryResult, array $row ) {
+
+		$this->numRows + 1;
+		$this->addFields( $row );
+
+		$this->templateRenderer->packFieldsForTemplate(
+			$this->params['template']
+		);
+
+		return $this->templateRenderer->render();
+	}
+
+	private function addFields( $row ) {
+
+		foreach ( $row as $i => $field ) {
+
+			$value = '';
+			$fieldName = '';
+
+			// {{{?Foo}}}
+			if ( $this->params['template arguments'] === 'legacy'  ) {
+				$fieldName = '?' . $field->getPrintRequest()->getLabel();
+			}
+
+			// {{{Foo}}}
+			if ( $this->params['template arguments'] === 'named' ) {
+				$fieldName = $field->getPrintRequest()->getLabel();
+			}
+
+			// {{{1}}}
+			if ( $fieldName === '' || $fieldName === '?' || $this->params['template arguments'] === 'numbered' ) {
+				$fieldName = intval( $i + 1 );
+			}
+
+			while ( ( $text = $field->getNextText( SMW_OUTPUT_WIKI, $this->getLinker( $i == 0 ) ) ) !== false ) {
+				$value .= $value === '' ? $text : $this->params['valuesep'] . ' ' . $text;
+			}
+
+			$this->templateRenderer->addField( $fieldName, $value );
+		}
+
+		$this->templateRenderer->addField( '#', $this->numRows );
+	}
+
+}

--- a/tests/phpunit/Integration/JSONScript/Fixtures/res.s-0025.0.txt
+++ b/tests/phpunit/Integration/JSONScript/Fixtures/res.s-0025.0.txt
@@ -1,0 +1,12 @@
+#FORMAT: BEACON
+#PREFIX: http://d-nb.info/gnd/
+#TARGET:.*
+#VERSION: 0.1
+#HOMEPAGE: https://www.semantic-mediawiki.org/w/index.php?title=Help:BEACON
+#FEED: https://www.semantic-mediawiki.org/w/index.php?title=BEACON&action=render
+#LINK: http://www.w3.org/2000/01/rdf-schema#seeAlso
+#INSTITUTION: Semantic MediaWiki
+#MESSAGE: Person test data in Semantic MediaWiki
+#TIMESTAMP: .*
+#UPDATE: always
+123456789||John Doe

--- a/tests/phpunit/Integration/JSONScript/Fixtures/res.s-0025.1.txt
+++ b/tests/phpunit/Integration/JSONScript/Fixtures/res.s-0025.1.txt
@@ -1,0 +1,13 @@
+#FORMAT: BEACON
+#PREFIX: http://d-nb.info/gnd/
+#TARGET:.*
+#VERSION: 0.1
+#HOMEPAGE: https://www.semantic-mediawiki.org/w/index.php?title=Help:BEACON
+#FEED: https://www.semantic-mediawiki.org/w/index.php?title=BEACON&action=render
+#LINK: http://www.w3.org/2000/01/rdf-schema#seeAlso
+#INSTITUTION: Semantic MediaWiki
+#MESSAGE: Person test data in Semantic MediaWiki
+#TIMESTAMP: .*
+#UPDATE: always
+123456789||John Doe
+987654321||Jane Doe

--- a/tests/phpunit/Integration/JSONScript/Fixtures/s-0025-beacon-intro.txt
+++ b/tests/phpunit/Integration/JSONScript/Fixtures/s-0025-beacon-intro.txt
@@ -1,0 +1,11 @@
+<includeonly>#FORMAT: BEACON
+#PREFIX: http://d-nb.info/gnd/
+#TARGET: {{{querylink}}}
+#VERSION: 0.1
+#HOMEPAGE: https://www.semantic-mediawiki.org/w/index.php?title=Help:BEACON
+#FEED: https://www.semantic-mediawiki.org/w/index.php?title=BEACON&action=render
+#LINK: http://www.w3.org/2000/01/rdf-schema#seeAlso
+#INSTITUTION: Semantic MediaWiki
+#MESSAGE: Person test data in Semantic MediaWiki
+#TIMESTAMP: {{CURRENTTIMESTAMP}}
+#UPDATE: always</includeonly>

--- a/tests/phpunit/Integration/JSONScript/Fixtures/s-0025-beacon.txt
+++ b/tests/phpunit/Integration/JSONScript/Fixtures/s-0025-beacon.txt
@@ -1,0 +1,2 @@
+<includeonly>
+{{{?GND|}}}||{{{?Name|}}}</includeonly>

--- a/tests/phpunit/Integration/JSONScript/TestCases/s-0025.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/s-0025.json
@@ -1,0 +1,106 @@
+{
+	"description": "Test `format=templatefile` (with `_eid`) output via `Special:Ask`",
+	"setup": [
+		{
+			"namespace": "SMW_NS_PROPERTY",
+			"page": "Has GND",
+			"contents": "[[Has type::External identifier]] [[External formatter uri::http://d-nb.info/gnd/$1]]"
+		},
+		{
+			"namespace": "SMW_NS_PROPERTY",
+			"page": "Has name",
+			"contents": "[[Has type::Text]]"
+		},
+		{
+			"namespace": "NS_TEMPLATE",
+			"page": "BEACON",
+			"contents": {
+				"import-from": "/../Fixtures/s-0025-beacon.txt"
+			}
+		},
+		{
+			"namespace": "NS_TEMPLATE",
+			"page": "BEACON-INTRO",
+			"contents": {
+				"import-from": "/../Fixtures/s-0025-beacon-intro.txt"
+			}
+		},
+		{
+			"page": "Example/S0025/1",
+			"contents": "[[Has name::John Doe]] [[Has GND::123456789]]"
+		},
+		{
+			"page": "Example/S0025/2",
+			"contents": "[[Has name::Jane Doe]] [[Has GND::987654321]]"
+		}
+	],
+	"tests": [
+		{
+			"type": "special",
+			"about": "#0",
+			"special-page": {
+				"page": "Ask",
+				"request-parameters": {
+					"p": {
+						"link": "none",
+						"limit": "10",
+						"offset": "0",
+						"mainlabel": "",
+						"format": "templatefile",
+						"template": "BEACON",
+						"introtemplate": "BEACON-INTRO"
+					},
+					"q": "[[Has GND::123456789]]",
+					"po": "?Has GND=GND|?Has name=Name"
+				}
+			},
+			"assert-output": {
+				"to-contain": {
+					"contents-file" : "/../Fixtures/res.s-0025.0.txt"
+				}
+			}
+		},
+		{
+			"type": "special",
+			"about": "#0",
+			"special-page": {
+				"page": "Ask",
+				"request-parameters": {
+					"p": {
+						"link": "none",
+						"limit": "10",
+						"offset": "0",
+						"mainlabel": "",
+						"format": "templatefile",
+						"template": "BEACON",
+						"introtemplate": "BEACON-INTRO"
+					},
+					"q": "[[Has GND::123456789]] OR [[Has GND::987654321]]",
+					"po": "?Has GND=GND|?Has name=Name"
+				}
+			},
+			"assert-output": {
+				"to-contain": {
+					"contents-file" : "/../Fixtures/res.s-0025.1.txt"
+				}
+			}
+		}
+	],
+	"settings": {
+		"wgContLang": "en",
+		"wgLang": "en",
+		"wgLanguageCode": "en",
+		"smwgPageSpecialProperties": [
+			"_MDAT"
+		],
+		"smwgNamespacesWithSemanticLinks": {
+			"NS_MAIN": true,
+			"SMW_NS_PROPERTY": true
+		}
+	},
+	"meta": {
+		"version": "2",
+		"is-incomplete": false,
+		"debug": false
+	}
+}

--- a/tests/phpunit/Unit/Parser/RecursiveTextProcessorTest.php
+++ b/tests/phpunit/Unit/Parser/RecursiveTextProcessorTest.php
@@ -231,6 +231,19 @@ class RecursiveTextProcessorTest extends \PHPUnit_Framework_TestCase {
 		$instance->recursiveTagParse( 'Foo' );
 	}
 
+	public function testExpandTemplates() {
+
+		$this->parser->expects( $this->once() )
+			->method( 'preprocess' )
+			->with( $this->equalTo( '{{Foo}}' ) );
+
+		$instance = new RecursiveTextProcessor(
+			$this->parser
+		);
+
+		$instance->expandTemplates( '{{Foo}}' );
+	}
+
 	public function testRecursivePreprocess_ExceededRecursion() {
 
 		$this->parser->expects( $this->atLeastOnce() )

--- a/tests/phpunit/Unit/Query/ResultPrinters/TemplateFileExportPrinterTest.php
+++ b/tests/phpunit/Unit/Query/ResultPrinters/TemplateFileExportPrinterTest.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace SMW\Tests\Query\ResultPrinters;
+
+use SMW\Query\ResultPrinters\TemplateFileExportPrinter;
+
+/**
+ * @covers SMW\Query\ResultPrinters\TemplateFileExportPrinter
+ * @group semantic-mediawiki
+ *
+ * @license GNU GPL v2+
+ * @since 3.0
+ *
+ * @author mwjames
+ */
+class TemplateFileExportPrinterTest extends \PHPUnit_Framework_TestCase {
+
+	public function testCanConstruct() {
+
+		$this->assertInstanceOf(
+			TemplateFileExportPrinter::class,
+			new TemplateFileExportPrinter( 'templatefile' )
+		);
+	}
+
+	public function testGetResult_Empty() {
+
+		$queryResult = $this->getMockBuilder( '\SMWQueryResult' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$queryResult->expects( $this->any() )
+			->method( 'getErrors' )
+			->will( $this->returnValue( [] ) );
+
+		$instance = new TemplateFileExportPrinter( 'templatefile' );
+
+		$this->assertInternalType(
+			'string',
+			$instance->getResult( $queryResult, [], SMW_OUTPUT_WIKI )
+		);
+	}
+
+	public function testLink() {
+
+		$link = $this->getMockBuilder( '\SMWInfolink' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$queryResult = $this->getMockBuilder( '\SMWQueryResult' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$queryResult->expects( $this->once() )
+			->method( 'getQueryLink' )
+			->will( $this->returnValue( $link ) );
+
+		$queryResult->expects( $this->any() )
+			->method( 'getCount' )
+			->will( $this->returnValue( 1 ) );
+
+		$queryResult->expects( $this->any() )
+			->method( 'getErrors' )
+			->will( $this->returnValue( [] ) );
+
+		$instance = new TemplateFileExportPrinter( 'templatefile' );
+		$instance->getResult( $queryResult, [], SMW_OUTPUT_WIKI );
+	}
+
+}


### PR DESCRIPTION
This PR is made in reference to: https://www.semantic-mediawiki.org/wiki/Help:BEACON

This PR addresses or contains:

- Adds `TemplateFileExportPrinter`  (`format=templatefile`)
- BEACON integration test based on the example 

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed

## Why?
SMW provides different specialized export formats (json, csv etc.) to accommodate various user needs and requirements but it is not always strategically meaningful (looking at the implementation cost, maintenance cost, expected audience etc.) to implement all sorts of export formats that the wide internet, some companies, or selected institutions do promote.  To serve those that require a custom format or want to pull data in a more exotic output form, 3.0 will provide a `format=templatefile` that enables users to define templates (incl. `introtemplate`, `outrotemplate`) and hereby its form on what needs where without burden SMW about specific export requirements.

## Example

https://sandbox.semantic-mediawiki.org/wiki/Issue/3024