### PR TITLE
QueryDependencyLinksStore to avoid activities during 'preview', refs 2485

### DIFF
--- a/src/SQLStore/QueryDependency/QueryDependencyLinksStore.php
+++ b/src/SQLStore/QueryDependency/QueryDependencyLinksStore.php
@@ -445,8 +445,18 @@ class QueryDependencyLinksStore {
 
 		$query = $queryResult->getQuery();
 
-		// #2484 Avoid any update activities during a stashedit API access
-		if ( $query->getOption( 'request.action' ) === 'stashedit' ) {
+		$actions = [
+			// #2484 Avoid any update activities during a stashedit API access
+			'stashedit',
+
+			// Avoid update on `submit` during a preview
+			'submbit',
+
+			// Avoid update on `parse` during a wikieditor preview
+			'parse'
+		];
+
+		if ( in_array( $query->getOption( 'request.action' ), $actions ) ) {
 			return false;
 		}
 

--- a/tests/phpunit/Unit/SQLStore/QueryDependency/QueryDependencyLinksStoreTest.php
+++ b/tests/phpunit/Unit/SQLStore/QueryDependency/QueryDependencyLinksStoreTest.php
@@ -461,6 +461,65 @@ class QueryDependencyLinksStoreTest extends \PHPUnit_Framework_TestCase {
 		$instance->updateDependencies( $queryResult );
 	}
 
+	public function testUpdateDependencies_ExcludedRequestAction() {
+
+		$store = $this->getMockBuilder( '\SMW\Store' )
+			->disableOriginalConstructor()
+			->getMockForAbstractClass();
+
+		$dependencyLinksTableUpdater = $this->getMockBuilder( '\SMW\SQLStore\QueryDependency\DependencyLinksTableUpdater' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$dependencyLinksTableUpdater->expects( $this->any() )
+			->method( 'getStore' )
+			->will( $this->returnValue( $store ) );
+
+		$queryResultDependencyListResolver = $this->getMockBuilder( '\SMW\SQLStore\QueryDependency\QueryResultDependencyListResolver' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$queryResultDependencyListResolver->expects( $this->never() )
+			->method( 'getDependencyListByLateRetrievalFrom' )
+			->will( $this->returnValue( array() ) );
+
+		$queryResultDependencyListResolver->expects( $this->never() )
+			->method( 'getDependencyListFrom' )
+			->will( $this->returnValue( array() ) );
+
+		$instance = new QueryDependencyLinksStore(
+			$queryResultDependencyListResolver,
+			$dependencyLinksTableUpdater
+		);
+
+		$instance->setLogger(
+			$this->spyLogger
+		);
+
+		$instance->setEnabled( true );
+
+		$query = $this->getMockBuilder( '\SMWQuery' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$query->expects( $this->once() )
+			->method( 'getOption' )
+			->with(	$this->equalTo( 'request.action' ) )
+			->will( $this->returnValue( 'parse' ) );
+
+		$queryResult = $this->getMockBuilder( '\SMWQueryResult' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$queryResult->expects( $this->any() )
+			->method( 'getQuery' )
+			->will( $this->returnValue( $query ) );
+
+		$this->assertNull(
+			$instance->updateDependencies( $queryResult )
+		);
+	}
+
 	public function testTryDoUpdateDependenciesByForWhenDependencyListReturnsEmpty() {
 
 		$idTable = $this->getMockBuilder( '\stdClass' )


### PR DESCRIPTION
This PR is made in reference to: #2485

This PR addresses or contains:

- Avoid storing gost references when query execution is done as part of a preview process

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed
