### PR TITLE
Fix replace of `smw_proptable_hash` during setup

### DIFF
--- a/tests/phpunit/Unit/SQLStore/TableIntegrityExaminerTest.php
+++ b/tests/phpunit/Unit/SQLStore/TableIntegrityExaminerTest.php
@@ -41,7 +41,7 @@ class TableIntegrityExaminerTest extends \PHPUnit_Framework_TestCase {
 		$row->smw_id = 42;
 
 		$idTable = $this->getMockBuilder( '\stdClass' )
-			->setMethods( array( 'getPropertyInterwiki', 'moveSMWPageID' ) )
+			->setMethods( array( 'getPropertyInterwiki', 'moveSMWPageID', 'getPropertyTableHashes' ) )
 			->getMock();
 
 		$idTable->expects( $this->atLeastOnce() )


### PR DESCRIPTION
This PR is made in reference to: #

This PR addresses or contains:

- The issue is in existence at least since [0] where during the setup predefined properties are replaced but if those would have a page with additional annotations (category etc.) then there would vanish because the `smw_proptable_hash` reference was reset during the replace action

[0] https://github.com/SemanticMediaWiki/SemanticMediaWiki/blob/1.8.0.5/includes/storage/SQLStore/SMW_SQLStore3_SetupHandlers.php#L246-L263

This PR includes:
- [ ] Tests (unit/integration)
- [x] CI build passed
