### PR TITLE
Keep updated entites in in-memory queue

### DIFF
--- a/src/Utils/Lru.php
+++ b/src/Utils/Lru.php
@@ -1,0 +1,102 @@
+<?php
+
+namespace SMW\Utils;
+
+/**
+ * @license GNU GPL v2+
+ * @since 3.0
+ *
+ * @author mwjames
+ */
+class Lru {
+
+	/**
+	 * @var integer
+	 */
+	private $size;
+
+	/**
+	 * @var array
+	 */
+	private $cache = [];
+
+	/**
+	 * @var array
+	 */
+	private $count = 0;
+
+	/**
+	 * @since 3.0
+	 *
+	 * @param integer size
+	 */
+	public function __construct( $size = 1000 ) {
+		$this->size = $size;
+	}
+
+	/**
+	 * @since 3.0
+	 *
+	 * @param string|integer $key
+	 * @param mixed $value
+	 */
+	public function set( $key, $value ) {
+
+		$this->count++;
+
+		if ( isset( $this->cache[$key] ) ) {
+			$this->count--;
+			$value = $this->cache[$key];
+			unset( $this->cache[$key] );
+		} elseif ( $this->count > $this->size ) {
+			$this->count--;
+			reset( $this->cache );
+			unset( $this->cache[ key( $this->cache ) ] );
+		}
+
+		$this->cache[$key] = $value;
+	}
+
+	/**
+	 * @since 3.0
+	 *
+	 * @param string|integer $key
+	 *
+	 * @return mixed
+	 */
+	public function get( $key, $default = null ) {
+
+		if ( !isset( $this->cache[$key] ) ) {
+			return $default;
+		}
+
+		$value = $this->cache[$key];
+		unset( $this->cache[$key] );
+		$this->cache[$key] = $value;
+
+		return $value;
+	}
+
+	/**
+	 * @since 3.0
+	 *
+	 * @param string|integer $key
+	 */
+	public function delete( $key ) {
+
+		if ( !isset( $this->cache[$key] ) ) {
+			return $default;
+		}
+
+		$this->count--;
+		unset( $this->cache[$key] );
+	}
+
+	/**
+	 * @since 3.0
+	 */
+	public function toArray() {
+		return $this->cache;
+	}
+
+}

--- a/tests/phpunit/Unit/Utils/LruTest.php
+++ b/tests/phpunit/Unit/Utils/LruTest.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace SMW\Tests\Utils;
+
+use SMW\Utils\Lru;
+
+/**
+ * @covers \SMW\Utils\Lru
+ * @group semantic-mediawiki
+ *
+ * @license GNU GPL v2+
+ * @since 3.0
+ *
+ * @author mwjames
+ */
+class LruTest extends \PHPUnit_Framework_TestCase {
+
+	public function testSetGet() {
+
+		$instance = new Lru( 3 );
+
+		$instance->set( 'a', 3 );
+		$instance->set( 'b', 'abc' );
+		$instance->set( 'c', 'def' );
+		$instance->set( 'd', 2 );
+
+		$this->assertEquals(
+			[
+				'b' => 'abc',
+				'c' => 'def',
+				'd' => 2
+			],
+			$instance->toArray()
+		);
+
+		$this->assertEquals(
+			'def',
+			$instance->get( 'c' )
+		);
+
+		$instance->get( 'b' );
+		$instance->set( 'foo', 'bar' );
+
+		$this->assertEquals(
+			[
+				'b' => 'abc',
+				'c' => 'def',
+				'foo' => 'bar'
+			],
+			$instance->toArray()
+		);
+
+		$instance->get( 'c' );
+		$instance->get( 'foo' );
+		$instance->set( 'foobar', 'xyz' );
+
+		$this->assertEquals(
+			[
+				'c' => 'def',
+				'foo' => 'bar',
+				'foobar' => 'xyz'
+			],
+			$instance->toArray()
+		);
+	}
+
+	public function testDelete() {
+
+		$instance = new Lru( 3 );
+
+		$instance->set( 'a', 3 );
+		$instance->delete( 'a' );
+
+		$this->assertEquals(
+			[],
+			$instance->toArray()
+		);
+	}
+
+}


### PR DESCRIPTION
This PR is made in reference to: #

This PR addresses or contains:

- For those entities that were already updated, keep a list and skip processing in case it is seen again during the `rebuildData.php` execution.
- Should slightly help improve performance for the `rebuildData.php` script

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed

## Notes

Benchmark from before this PR [0, 1].

```
        "16ad62c876ac514022196ef145b63ff1": {
            "type": "maintenance",
            "case": "rebuildData",
            "repetitionCount": 1,
            "memory": 83886080,
            "time": {
                "sum": 87.3771,
                "mean": 87.3771,
                "sd": 0,
                "norm": 87.3771
            }
        }
```
```
        "16ad62c876ac514022196ef145b63ff1": {
            "type": "maintenance",
            "case": "rebuildData",
            "repetitionCount": 1,
            "memory": 83886080,
            "time": {
                "sum": 87.1746199,
                "mean": 87.1746199,
                "sd": 0,
                "norm": 87.1746199
            }
        }
```

Benchmark with this PR [2].

```
        "16ad62c876ac514022196ef145b63ff1": {
            "type": "maintenance",
            "case": "rebuildData",
            "repetitionCount": 1,
            "memory": 62914560,
            "time": {
                "sum": 59.9649551,
                "mean": 59.9649551,
                "sd": 0,
                "norm": 59.9649551
            }
        }
```

[0] https://travis-ci.org/SemanticMediaWiki/SemanticMediaWiki/jobs/344807175
[1] https://travis-ci.org/SemanticMediaWiki/SemanticMediaWiki/jobs/345612771
[2] https://travis-ci.org/SemanticMediaWiki/SemanticMediaWiki/jobs/345619685