### PR TITLE
Add `SMW::LinksUpdate::ApprovedUpdate`, `SMW::Parser::ChangeRevision` hook

### DIFF
--- a/docs/technical/code-snippets/README.md
+++ b/docs/technical/code-snippets/README.md
@@ -2,6 +2,7 @@
 ## Examples and code snippets
 
 * [register.datatype.md](register.datatype.md) Shows how to register a new dataType/dataValue
+* [approve.update.md](register.datatype.md) Shows how to alter the data representation in Semantic MediaWiki with the help of selected hooks in connection with the `ApprovedRevs` extension
 
 ### Using hooks
 

--- a/docs/technical/code-snippets/approve.update.md
+++ b/docs/technical/code-snippets/approve.update.md
@@ -1,0 +1,91 @@
+
+For certain user scenarios it may be necessary to refuse or alter an update by changing the revision used as basis for what the semantic data should represent.
+
+Please ensure that when changes are applied to [log][log] those to make them recoverable. See [`$wgLogTypes`][wgLogTypes] on how to add and use an appropriate type and action description.
+
+## Example
+
+The following can be used in connection with the `ApprovedRevs` extension to alter the data representation in Semantic MediaWiki.
+
+### SMW::LinksUpdate::ApprovedUpdate
+
+Check whether the current revision ID used by SMW is the one expected as approved version and if not, refuse its usage by returning `false` to signal that the update should be declined.
+
+```php
+use Hooks;
+use ApprovedRevs;
+use LogPage;
+use Xml;
+
+Hooks::register( 'SMW::LinksUpdate::ApprovedUpdate', function( $title, $latestRevID ) {
+
+	if ( !class_exists( 'ApprovedRevs' ) || ( $approvedRevID = ApprovedRevs::getApprovedRevID( $title ) ) === null ) {
+		return true;
+	}
+
+	if ( $approvedRevID != $latestRevID ) {
+		static $logged = [];
+
+		// Only log the action once in case LinksUpdate is called several
+		// times by MediaWiki::preOutputCommit/RefreshLinksJob
+		if ( isset( $logged[$latestRevID . ':' . $approvedRevID] ) ) {
+			return false;
+		}
+
+		$log = new LogPage( 'myType' );
+		$rev_url = $title->getFullURL( [ 'oldid' => $approvedRevID, 'diff' => $latestRevID ] );
+
+		$rev_link = Xml::element(
+			'a',
+			[ 'href' => $rev_url ],
+			$approvedRevID
+		);
+
+		$log->addEntry( 'myType', $title, '', [ $rev_link ] );
+		$logged[$latestRevID . ':' . $approvedRevID] = true;
+
+		return false;
+	}
+
+	return true;
+} );
+```
+
+### SMW::Parser::ChangeRevision
+
+During a `UpdateJob` or `rebuildData.php` script execution, SMW always chooses the latest available revision to represent its data.  Use the hook to change the revision when the approved revision is different from what the parser is going to use as basis for the update process.
+
+```php
+use Hooks;
+use ApprovedRevs;
+use LogPage;
+use Xml;
+use Revision;
+
+Hooks::register( 'SMW::Parser::ChangeRevision', function( $title, &$revision ) {
+
+	if ( !class_exists( 'ApprovedRevs' ) || ( $approvedRevID = ApprovedRevs::getApprovedRevID( $title ) ) === null ) {
+		return true;
+	}
+
+	// Forcibly change the revision to match the approved version
+	$currentRevison = $revision;
+	$revision = Revision::newFromId( $approvedRevID );
+
+	$log = new LogPage( 'myType' );
+	$rev_url = $title->getFullURL( array( 'oldid' => $approvedRevID ) );
+
+	$rev_link = Xml::element(
+		'a',
+		[ 'href' => $rev_url ],
+		$approvedRevID
+	);
+
+	$log->addEntry( 'myType', $title, '', [ $rev_link ] );
+
+	return true;
+} );
+```
+
+[log]: https://www.mediawiki.org/wiki/Manual:Logging_to_Special:Log
+[wgLogTypes]: https://www.mediawiki.org/wiki/Manual:$wgLogTypes

--- a/docs/technical/hooks.md
+++ b/docs/technical/hooks.md
@@ -315,6 +315,46 @@ Hooks::register( 'SMW::SQLStore::EntityReferenceCleanUpComplete', function( $sto
 } );
 </pre>
 
+### SMW::LinksUpdate::ApprovedUpdate
+
+* Version: 3.0
+* Description: Hook allows to suppress an update where for example the `latestRevID` is not the revision that is approved an should not be used for the `SemanticData` representation.
+* Reference class: `SMW\MediaWiki\Hooks\LinksUpdateConstructed`
+
+If you do suppress a revision, please log the event and make it visible to a user (or administrator) that an update was refused.
+
+<pre>
+use Hooks;
+
+Hooks::register( 'SMW::LinksUpdate::ApprovedUpdate', function( $title, $latestRevID ) {
+
+	// If you need to decline an update
+	// return false;
+
+	return true;
+} );
+</pre>
+
+### SMW::Parser::ChangeRevision
+
+* Version: 3.0
+* Description: Hook allows to forcibly to change a revision used during content parsing as in case of execution the `UpdateJob` or running `rebuildData.php`.
+* Reference class: `SMW\ContentParser`
+
+If you do alter a revision, please log the event and make it visible to a user (or administrator) that it was changed.
+
+<pre>
+use Hooks;
+
+Hooks::register( 'SMW::Parser::ChangeRevision', function( $title, &$revision ) {
+
+	// Set a revision
+	// $revision = \Revision::newFromId( $id );
+
+	return true;
+} );
+</pre>
+
 ## Other available hooks
 
 Subsequent hooks should be renamed to follow a common naming practice that help distinguish them from other hook providers. In any case this list needs details and examples.

--- a/includes/ContentParser.php
+++ b/includes/ContentParser.php
@@ -239,6 +239,8 @@ class ContentParser {
 			$this->revision = Revision::newFromTitle( $this->getTitle() );
 		}
 
+		\Hooks::run( 'SMW::Parser::ChangeRevision', [ $this->getTitle(), &$this->revision ] );
+
 		return $this->revision;
 	}
 


### PR DESCRIPTION
This PR is made in reference to: https://sourceforge.net/p/semediawiki/mailman/message/36228453/

This PR addresses or contains:

- Adds `SMW::LinksUpdate::ApprovedUpdate`, `SMW::Parser::ChangeRevision` hooks to influence which updates (and hereby revision) can be used in SMW.

This PR includes:
- [ ] Tests (unit/integration)
- [x] CI build passed

## Notes

> Also note that I'm using ApprovedRevs.  I assumed that it wasn't returning
the values that are on unapproved pages.  However, that isn't the case.

SMW doesn't depend or check for an approved revision from any of the available extensions including `Extension:FlaggedRevs`, `Extension:Moderation`, or `Extension:Approved Revs` during the `LinksUpdateConstructed` hook execution. If a third-party extension stores revision information in a different form or table which is not part of the `LinksUpdateConstructed` interface then SMW cannot use those information during its data validation phase.

Yet, to improve the situation for users that rely on those extensions and want to reflect the state of an approved status within SMW `approve.update.md` contains an example on how to facilitate the newly added hooks.
