### PR TITLE
Fix "The supplied ParserOptions are not safe ... set $forceParse = true"

### DIFF
--- a/src/MediaWiki/Hooks/FileUpload.php
+++ b/src/MediaWiki/Hooks/FileUpload.php
@@ -63,9 +63,13 @@ class FileUpload extends HookHandler {
 		$applicationFactory = ApplicationFactory::getInstance();
 		$filePage = $this->makeFilePage( $file, $reUploadStatus );
 
+		// Avoid WikiPage.php: The supplied ParserOptions are not safe to cache.
+		// Fix the options or set $forceParse = true.
+		$forceParse = true;
+
 		$parserData = $applicationFactory->newParserData(
 			$file->getTitle(),
-			$filePage->getParserOutput( $this->makeCanonicalParserOptions() )
+			$filePage->getParserOutput( $this->makeCanonicalParserOptions(), null, $forceParse )
 		);
 
 		$pageInfoProvider = $applicationFactory->newMwCollaboratorFactory()->newPageInfoProvider(


### PR DESCRIPTION
This PR is made in reference to: #

This PR addresses or contains:

- Issue starts to appear with MW 1.30+ that changed the `ParserOptions` and now throws a `InvalidArgumentException` during `Special:Upload`.

This PR includes:
- [ ] Tests (unit/integration)
- [x] CI build passed

## Stack

```
Special:Upload   InvalidArgumentException from line 1062 of ...\includes\page\WikiPage.php: The supplied ParserOptions are not safe to cache. Fix the options or set $forceParse = true.
#0 ...\extensions\SemanticMediaWiki\src\MediaWiki\Hooks\FileUpload.php(68): WikiPage->getParserOutput(ParserOptions)
#1 ...\extensions\SemanticMediaWiki\src\MediaWiki\Hooks\FileUpload.php(51): SMW\MediaWiki\Hooks\FileUpload->doProcess(LocalFile, boolean)
#2 ...\extensions\SemanticMediaWiki\src\MediaWiki\Hooks\HookRegistry.php(569): SMW\MediaWiki\Hooks\FileUpload->process(LocalFile, boolean)
#3 ...\includes\Hooks.php(177): SMW\MediaWiki\Hooks\HookRegistry->SMW\MediaWiki\Hooks\{closure}(LocalFile, boolean, boolean)
#4 ...\includes\Hooks.php(205): Hooks::callHook(string, array, array, NULL)
#5 ...\includes\filerepo\file\LocalFile.php(1615): Hooks::run(string, array)
#6 ...\includes\deferred\AutoCommitUpdate.php(42): LocalFile->{closure}(Wikimedia\Rdbms\DatabaseMysqli, string)
#7 ...\includes\deferred\DeferredUpdates.php(257): AutoCommitUpdate->doUpdate()
#8 ...\includes\deferred\DeferredUpdates.php(210): DeferredUpdates::runUpdate(AutoCommitUpdate, Wikimedia\Rdbms\LBFactorySimple, string, integer)
#9 ...\includes\deferred\DeferredUpdates.php(127): DeferredUpdates::execute(array, string, integer)
#10 ...\includes\MediaWiki.php(602): DeferredUpdates::doUpdates(string, integer)
#11 ...\includes\MediaWiki.php(571): MediaWiki::preOutputCommit(RequestContext, Closure)
#12 ...\includes\MediaWiki.php(867): MediaWiki->doPreOutputCommit(Closure)
#13 ...\includes\MediaWiki.php(523): MediaWiki->main()
#14 ...\index.php(43): MediaWiki->run()
```