### PR TITLE
Pr3019fu

### DIFF
--- a/src/MediaWiki/Hooks/ParserAfterTidy.php
+++ b/src/MediaWiki/Hooks/ParserAfterTidy.php
@@ -100,6 +100,10 @@ class ParserAfterTidy extends HookHandler {
 			return false;
 		}
 
+		if ( $title->getNamespace() === SMW_NS_RULE ) {
+			return true;
+		}
+		
 		// ParserOptions::getInterfaceMessage is being used to identify whether a
 		// parse was initiated by `Message::parse`
 		if ( $title->isSpecialPage() || $this->parser->getOptions()->getInterfaceMessage() ) {
@@ -190,7 +194,7 @@ class ParserAfterTidy extends HookHandler {
 		// Only carry out a purge where InTextAnnotationParser have set
 		// an appropriate context reference otherwise it is assumed that the hook
 		// call is part of another non SMW related parse
-		if ( $parserData->getSemanticData()->getSubject()->getContextReference() === null ) {
+		if ( $parserData->getSemanticData()->getSubject()->getContextReference() === null && $this->parser->getTitle()->getNamespace() !== SMW_NS_RULE ) {
 			return true;
 		}
 

--- a/src/Updater/StoreUpdater.php
+++ b/src/Updater/StoreUpdater.php
@@ -201,6 +201,23 @@ class StoreUpdater {
 			$pageInfoProvider
 		);
 
+		// Standard text hooks are not run through a JSON content object therefore
+		// we attach possible annotations at this point
+		if ( $title->getNamespace() === SMW_NS_RULE ) {
+
+			$ruleFactory = $applicationFactory->singleton( 'RuleFactory' );
+
+			$ruleDefinition = $ruleFactory->newRuleDefinition(
+				$title->getDBKey(),
+				$wikiPage->getContent()->getNativeData()
+			);
+
+			$propertyAnnotator = $propertyAnnotatorFactory->newRuleDefinitionPropertyAnnotator(
+				$propertyAnnotator,
+				$ruleDefinition
+			);
+		}		
+		
 		$propertyAnnotator->addAnnotation();
 	}
 


### PR DESCRIPTION
This PR is made in reference to: #3019 

This PR addresses or contains:
- Make `Parser::parse` run in namespace rule for JSON content
- Make `Parser::parse` run in namespace rule for JSON content in connection with `action=purge`

This PR includes:
- [ ] Tests (unit/integration)
- [ ] CI build passed