### PR TITLE
Tidy (PropertyValue)

### DIFF
--- a/docs/technical/migration-guide-3.0.md
+++ b/docs/technical/migration-guide-3.0.md
@@ -21,6 +21,8 @@
 - Removed `DIProperty::findPropertyLabel`, deprecated since 2.1, use PropertyRegistry::findPropertyLabelById
 - Removed `DIProperty::registerProperty`, deprecated since 2.1, use PropertyRegistry::registerProperty
 - Removed `DIProperty::registerPropertyAlias`, deprecated since 2.1, use PropertyRegistry::registerPropertyAlias
+- Deprecated `PropertyValue::makeUserProperty`, use DataValueFactory::getInstance()->newPropertyValueByLabel;
+- Removed `PropertyValue::makeProperty`, use DataValueFactory
 
 ## Hooks
 

--- a/includes/SemanticData.php
+++ b/includes/SemanticData.php
@@ -486,7 +486,7 @@ class SemanticData {
 				self::$mPropertyPrefix = $wgContLang->getNsText( SMW_NS_PROPERTY ) . ':';
 			} // explicitly use prefix to cope with things like [[Property:User:Stupid::somevalue]]
 
-			$propertyDV = SMWPropertyValue::makeUserProperty( self::$mPropertyPrefix . $propertyName );
+			$propertyDV = DataValueFactory::getInstance()->newPropertyValueByLabel( self::$mPropertyPrefix . $propertyName );
 
 			if ( !$propertyDV->isValid() ) { // error, maybe illegal title text
 				return;

--- a/includes/specials/SMW_SpecialPageProperty.php
+++ b/includes/specials/SMW_SpecialPageProperty.php
@@ -2,6 +2,7 @@
 
 use SMWInfolink as Infolink;
 use SMW\Encoder;
+use SMW\DataValueFactory;
 
 /**
  * @ingroup SMWSpecialPage
@@ -60,9 +61,9 @@ class SMWPageProperty extends SpecialPage {
 			}
 		}
 
-		$subject = \SMW\DataValueFactory::getInstance()->newTypeIDValue( '_wpg', $pagename );
+		$subject = DataValueFactory::getInstance()->newTypeIDValue( '_wpg', $pagename );
 		$pagename = $subject->isValid() ? $subject->getPrefixedText() : '';
-		$property = SMWPropertyValue::makeUserProperty( $propname );
+		$property = DataValueFactory::getInstance()->newPropertyValueByLabel( $propname );
 		$propname = $property->isValid() ? $property->getWikiValue() : '';
 
 		// Produce output
@@ -140,11 +141,11 @@ class SMWPageProperty extends SpecialPage {
 						continue;
 					}
 
-					$dv = \SMW\DataValueFactory::getInstance()->newDataValueByItem( $di, $property->getDataItem() );
+					$dv = DataValueFactory::getInstance()->newDataValueByItem( $di, $property->getDataItem() );
 					$html .= '<li>' . $dv->getLongHTMLText( $linker ); // do not show infolinks, the magnifier "+" is ambiguous with the browsing '+' for '_wpg' (see below)
 
 					if ( $property->getDataItem()->findPropertyTypeID() == '_wpg' ) {
-						$browselink = SMWInfolink::newBrowsingLink( '+', $dv->getLongWikiText() );
+						$browselink = Infolink::newBrowsingLink( '+', $dv->getLongWikiText() );
 						$html .= ' &#160;' . $browselink->getHTML( $linker );
 					}
 

--- a/src/Aliases.php
+++ b/src/Aliases.php
@@ -18,6 +18,7 @@ class_alias( 'SMW\Query\Parser', 'SMWQueryParser' );
 class_alias( 'SMW\SQLStore\ChangeOp\ChangeOp', 'SMW\SQLStore\CompositePropertyTableDiffIterator' );
 class_alias( 'SMW\Connection\ConnectionProvider', 'SMW\DBConnectionProvider' );
 class_alias( 'SMW\DataValues\TypesValue', 'SMWTypesValue' );
+class_alias( 'SMW\DataValues\PropertyValue', 'SMWPropertyValue' );
 
 // 1.9.
 class_alias( 'SMW\Store', 'SMWStore' );

--- a/src/DataValueFactory.php
+++ b/src/DataValueFactory.php
@@ -6,7 +6,7 @@ use SMWDataItem as DataItem;
 use SMWDataValue as DataValue;
 use SMWDIError;
 use SMWErrorValue as ErrorValue;
-use SMWPropertyValue as PropertyValue;
+use SMW\DataValues\PropertyValue;
 use SMW\Services\DataValueServiceFactory;
 
 /**

--- a/src/DataValues/PropertyChainValue.php
+++ b/src/DataValues/PropertyChainValue.php
@@ -3,9 +3,9 @@
 namespace SMW\DataValues;
 
 use SMWStringValue as StringValue;
-use SMWPropertyValue as PropertyValue;
 use SMWDIBlob as DIBlob;
 use SMWDataItem as DataItem;
+use SMW\DataValueFactory;
 
 /**
  * @private
@@ -191,7 +191,7 @@ class PropertyChainValue extends StringValue {
 		// Foo.Bar.Foobar.Baz
 		$last = array_pop( $chain );
 
-		$this->lastPropertyChainValue = PropertyValue::makeUserProperty( $last );
+		$this->lastPropertyChainValue = DataValueFactory::getInstance()->newPropertyValueByLabel( $last );
 
 		if ( !$this->lastPropertyChainValue->isValid() ) {
 			return $this->addError( $this->lastPropertyChainValue->getErrors() );
@@ -202,7 +202,7 @@ class PropertyChainValue extends StringValue {
 		// Generate a forward list from the remaining property labels
 		// Foo.Bar.Foobar
 		foreach ( $chain as $value ) {
-			$propertyValue = PropertyValue::makeUserProperty( $value );
+			$propertyValue = DataValueFactory::getInstance()->newPropertyValueByLabel( $value );
 
 			if ( !$propertyValue->isValid() ) {
 				continue;

--- a/src/DefaultList.php
+++ b/src/DefaultList.php
@@ -20,7 +20,7 @@ use SMW\DataValues\ExternalFormatterUriValue;
 use SMW\DataValues\TypesValue;
 use SMW\DataValues\ErrorMsgTextValue;
 use SMW\DataValues\BooleanValue;
-use SMWPropertyValue as PropertyValue;
+use SMW\DataValues\PropertyValue;
 use SMWStringValue as StringValue;
 use SMWQuantityValue as QuantityValue;
 use SMWNumberValue as NumberValue;

--- a/src/MediaWiki/Specials/Browse/ValueFormatter.php
+++ b/src/MediaWiki/Specials/Browse/ValueFormatter.php
@@ -6,7 +6,7 @@ use SMW\Message;
 use SMW\ApplicationFactory;
 use SMWDataValue as DataValue;
 use SMWDataItem as DataItem;
-use SMWPropertyValue as PropertyValue;
+use SMW\DataValues\PropertyValue;
 use SMW\DataValueFactory;
 use SMW\DataValues\ValueFormatters\DataValueFormatter;
 use SMWInfolink as Infolink;
@@ -170,7 +170,7 @@ class ValueFormatter {
 			return self::addNonBreakingSpace( $propertyValue->getWikiValue() );
 		}
 
-		$inverseProperty = PropertyValue::makeUserProperty( wfMessage( 'smw_inverse_label_property' )->text() );
+		$inverseProperty = DataValueFactory::getInstance()->newPropertyValueByLabel( wfMessage( 'smw_inverse_label_property' )->text() );
 
 		$dataItems = ApplicationFactory::getInstance()->getStore()->getPropertyValues(
 			$property->getDiWikiPage(),

--- a/src/MediaWiki/Specials/SearchByProperty/PageRequestOptions.php
+++ b/src/MediaWiki/Specials/SearchByProperty/PageRequestOptions.php
@@ -7,7 +7,6 @@ use SMW\DataValues\TelephoneUriValue;
 use SMWUriValue as UriValue;
 use SMW\Encoder;
 use SMWNumberValue as NumberValue;
-use SMWPropertyValue as PropertyValue;
 use SMWStringValue as TextValue;
 
 /**
@@ -101,7 +100,7 @@ class PageRequestOptions {
 			$property = $this->urlEncoder->unescape( ltrim( $property, ':' ) );
 		}
 
-		$this->property = PropertyValue::makeUserProperty(
+		$this->property = DataValueFactory::getInstance()->newPropertyValueByLabel(
 			str_replace( array( '_' ), array( ' ' ), $property )
 		);
 

--- a/src/Query/Parser/LegacyParser.php
+++ b/src/Query/Parser/LegacyParser.php
@@ -505,9 +505,11 @@ class LegacyParser implements Parser {
 				return null;
 			}
 
-			$typeid = $propertyValue->getDataItem()->findPropertyTypeID();
-			$inverse = $propertyValue->isInverse();
+			$property = $propertyValue->getDataItem();
 			$propertyValueList[] = $propertyValue;
+
+			$typeid = $property->findPropertyTypeID();
+			$inverse = $property->isInverse();
 		}
 
 		$innerdesc = null;

--- a/src/Query/PrintRequest/Deserializer.php
+++ b/src/Query/PrintRequest/Deserializer.php
@@ -3,7 +3,6 @@
 namespace SMW\Query\PrintRequest;
 
 use SMW\Query\PrintRequest;
-use SMWPropertyValue as PropertyValue;
 use SMW\DataValueFactory;
 use SMW\DataValues\PropertyChainValue;
 use SMW\Localizer;
@@ -70,7 +69,7 @@ class Deserializer {
 				$label = $showMode ? '' : $title->getText();  // default
 			} else { // enforce interpretation as property (even if it starts with something that looks like another namespace)
 				$printmode = PrintRequest::PRINT_PROP;
-				$data = PropertyValue::makeUserProperty( $printRequestLabel );
+				$data = DataValueFactory::getInstance()->newPropertyValueByLabel( $printRequestLabel );
 				if ( !$data->isValid() ) { // not a property; give up
 					return null;
 				}

--- a/tests/phpunit/Integration/JSONScript/QueryTestCaseInterpreter.php
+++ b/tests/phpunit/Integration/JSONScript/QueryTestCaseInterpreter.php
@@ -9,7 +9,6 @@ use SMW\DIProperty;
 use SMW\Query\PrintRequest as PrintRequest;
 use SMW\Tests\Utils\UtilityFactory;
 use SMWDataItem as DataItem;
-use SMWPropertyValue as PropertyValue;
 
 /**
  * @license GNU GPL v2+
@@ -129,7 +128,7 @@ class QueryTestCaseInterpreter {
 			$extraPrintouts[] = new PrintRequest(
 				PrintRequest::PRINT_PROP,
 				$label,
-				PropertyValue::makeUserProperty( $printout )
+				DataValueFactory::getInstance()->newPropertyValueByLabel( $printout )
 			);
 		}
 

--- a/tests/phpunit/Unit/DataValueFactoryTest.php
+++ b/tests/phpunit/Unit/DataValueFactoryTest.php
@@ -6,7 +6,6 @@ use SMW\DataValueFactory;
 use SMW\DIProperty;
 use SMW\DIWikiPage;
 use SMWDataItem;
-use SMWPropertyValue;
 
 /**
  * @covers \SMW\DataValueFactory
@@ -73,7 +72,7 @@ class DataValueFactoryTest extends \PHPUnit_Framework_TestCase {
 	 */
 	public function testNewPropertyObjectValue( $propertyName, $value, $expectedValue, $expectedInstance ) {
 
-		$propertyDV = SMWPropertyValue::makeUserProperty( $propertyName );
+		$propertyDV = DataValueFactory::getInstance()->newPropertyValueByLabel( $propertyName );
 		$propertyDI = $propertyDV->getDataItem();
 
 		$dataValue = DataValueFactory::getInstance()->newDataValueByProperty( $propertyDI, $value );

--- a/tests/phpunit/Unit/DataValues/PropertyValueTest.php
+++ b/tests/phpunit/Unit/DataValues/PropertyValueTest.php
@@ -3,10 +3,10 @@
 namespace SMW\Tests\DataValues;
 
 use SMW\Options;
-use SMWPropertyValue as PropertyValue;
+use SMW\DataValues\PropertyValue;
 
 /**
- * @covers \SMWPropertyValue
+ * @covers \SMW\DataValues\PropertyValue
  * @group semantic-mediawiki
  *
  * @license GNU GPL v2+
@@ -19,21 +19,18 @@ class PropertyValueTest extends \PHPUnit_Framework_TestCase {
 	public function testCanConstruct() {
 
 		$this->assertInstanceOf(
-			'\SMWPropertyValue',
-			new PropertyValue( '__pro' )
+			PropertyValue::class,
+			new PropertyValue()
 		);
 	}
 
 	/**
-	 * @dataProvider optionsProvider
+	 * @dataProvider featuresProvider
 	 */
 	public function testOptions( $options, $expected ) {
 
-		$instance = new PropertyValue( '__pro' );
-
-		$instance->copyOptions(
-			new Options( array( 'smwgDVFeatures' => $options ) )
-		);
+		$instance = new PropertyValue();
+		$instance->setOption( 'smwgDVFeatures', $options );
 
 		$this->assertEquals(
 			$expected,
@@ -41,7 +38,7 @@ class PropertyValueTest extends \PHPUnit_Framework_TestCase {
 		);
 	}
 
-	public function optionsProvider() {
+	public function featuresProvider() {
 
 		$provider[] = array(
 			SMW_DV_PROV_REDI,

--- a/tests/phpunit/Unit/SQLStore/QueryDependency/QueryResultDependencyListResolverTest.php
+++ b/tests/phpunit/Unit/SQLStore/QueryDependency/QueryResultDependencyListResolverTest.php
@@ -13,6 +13,7 @@ use SMW\Query\Language\SomeProperty;
 use SMW\Query\Language\ValueDescription;
 use SMW\Query\PrintRequest;
 use SMW\SQLStore\QueryDependency\QueryResultDependencyListResolver;
+use SMW\DataValueFactory;
 use SMWDIBlob as DIBlob;
 use SMWQuery as Query;
 use SMW\Tests\TestEnvironment;
@@ -510,7 +511,7 @@ class QueryResultDependencyListResolverTest extends \PHPUnit_Framework_TestCase 
 		);
 
 		#7 Printrequest
-		$pv = \SMWPropertyValue::makeUserProperty( 'Foobaz' );
+		$pv = DataValueFactory::getInstance()->newPropertyValueByLabel( 'Foobaz' );
 
 		$description = new SomeProperty(
 			new DIProperty( 'Foobar', true ),
@@ -535,7 +536,7 @@ class QueryResultDependencyListResolverTest extends \PHPUnit_Framework_TestCase 
 		);
 
 		#8 Inverse printrequest
-		$pv = \SMWPropertyValue::makeUserProperty( 'Foobaz' );
+		$pv = DataValueFactory::getInstance()->newPropertyValueByLabel( 'Foobaz' );
 		$pv->setInverse( true );
 
 		$description = new SomeProperty(


### PR DESCRIPTION
This PR is made in reference to: #1014 

This PR addresses or contains:

- Moves `SMWPropertyValue` to `SMW\DataValues\PropertyValue`
- Deprecated `PropertyValue::makeUserProperty`
- Removed `PropertyValue::makeProperty`

This PR includes:
- [ ] Tests (unit/integration)
- [x] CI build passed
