### PR TITLE
Fix concept selection, refs 3043

### DIFF
--- a/includes/SMW_PageLister.php
+++ b/includes/SMW_PageLister.php
@@ -231,6 +231,11 @@ class SMWPageLister {
 
 			// output all diWikiPages
 			for ( $index = $startChunk; $index < $endChunk && $index < $end; ++$index ) {
+
+				if ( !isset( $diWikiPages[$index] ) ) {
+					continue;
+				}
+
 				$dataValue = \SMW\DataValueFactory::getInstance()->newDataValueByItem( $diWikiPages[$index], $diProperty );
 				$searchlink = \SMWInfolink::newBrowsingLink( '+', $dataValue->getWikiValue() );
 

--- a/tests/phpunit/includes/specials/SpecialConceptsTest.php
+++ b/tests/phpunit/includes/specials/SpecialConceptsTest.php
@@ -65,7 +65,7 @@ class SpecialConceptsTest extends SpecialPageTestCase {
 
 		$this->stringValidator->assertThatStringContains(
 			'span class="smw-sp-concept-empty"',
-			$instance->getHtml( array(), 0, 0, 0 )
+			$instance->getHtml( array(), 0, 0, 0, 0 )
 		);
 	}
 
@@ -79,7 +79,7 @@ class SpecialConceptsTest extends SpecialPageTestCase {
 
 		$this->stringValidator->assertThatStringContains(
 			'span class="smw-sp-concept-count"',
-			$instance->getHtml( array( $subject ), 1, 1, 1 )
+			$instance->getHtml( array( $subject ), 1, 0, 1, 1 )
 		);
 	}
 


### PR DESCRIPTION
This PR is made in reference to: #3043 

This PR addresses or contains:

- To avoid an issue with possible selected subobjects as part of a `NamespaceDescription( SMW_NS_CONCEPT )`, directly query the `ID_TABLE`to to fetch entities that match `SMW_NS_CONCEPT`

This PR includes:
- [ ] Tests (unit/integration)
- [x] CI build passed

Fixes #3043 