### PR TITLE
RequestOptions to support not

### DIFF
--- a/src/RequestOptions.php
+++ b/src/RequestOptions.php
@@ -77,10 +77,11 @@ class RequestOptions {
 	 *
 	 * @param string $string to match
 	 * @param integer $condition one of STRCOND_PRE, STRCOND_POST, STRCOND_MID
-	 * @param boolean $isDisjunctiveCondition
+	 * @param boolean $isOr
+	 * @param boolean $isNot
 	 */
-	public function addStringCondition( $string, $condition, $isDisjunctiveCondition = false ) {
-		$this->stringConditions[] = new StringCondition( $string, $condition, $isDisjunctiveCondition );
+	public function addStringCondition( $string, $condition, $isOr = false, $isNot = false ) {
+		$this->stringConditions[] = new StringCondition( $string, $condition, $isOr, $isNot );
 	}
 
 	/**

--- a/src/SQLStore/RequestOptionsProc.php
+++ b/src/SQLStore/RequestOptionsProc.php
@@ -110,9 +110,13 @@ class RequestOptionsProc {
 					break;
 				}
 
-				$conditionOperator = $strcond->isDisjunctiveCondition ? ' OR ' : ' AND ';
+				$conditionOperator = $strcond->isOr ? ' OR ' : ' AND ';
 
-				$sqlConds .= ( ( $addAnd || ( $sqlConds !== '' ) ) ? $conditionOperator : '' ) . "$labelCol $condition " . $connection->addQuotes( $string );
+				if ( $strcond->isNot ) {
+					$sqlConds = " ($sqlConds) AND ($labelCol NOT $condition ". $connection->addQuotes( $string ) . ") ";
+				} else {
+					$sqlConds .= ( ( $addAnd || ( $sqlConds !== '' ) ) ? $conditionOperator : '' ) . "$labelCol $condition " . $connection->addQuotes( $string );
+				}
 			}
 		}
 

--- a/src/StringCondition.php
+++ b/src/StringCondition.php
@@ -50,7 +50,12 @@ class StringCondition {
 	 *
 	 * @var boolean
 	 */
-	public $isDisjunctiveCondition;
+	public $isOr;
+
+	/**
+	 * @var boolean
+	 */
+	public $isNot;
 
 	/**
 	 * @var integer
@@ -62,12 +67,13 @@ class StringCondition {
 	 *
 	 * @param srting $string
 	 * @param integer $condition
-	 * @param boolean $isDisjunctiveCondition
+	 * @param boolean $isOr
 	 */
-	public function __construct( $string, $condition, $isDisjunctiveCondition = false ) {
+	public function __construct( $string, $condition, $isOr = false, $isNot = false ) {
 		$this->string = $string;
 		$this->condition = $condition;
-		$this->isDisjunctiveCondition = $isDisjunctiveCondition;
+		$this->isOr = $isOr;
+		$this->isNot = $isNot;
 	}
 
 	/**
@@ -76,7 +82,7 @@ class StringCondition {
 	 * @return string
 	 */
 	public function getHash() {
-		return $this->string . '#' . $this->condition . '#' . $this->isDisjunctiveCondition;
+		return $this->string . '#' . $this->condition . '#' . $this->isOr . '#' . $this->isNot;
 	}
 
 }

--- a/tests/phpunit/Unit/RequestOptionsTest.php
+++ b/tests/phpunit/Unit/RequestOptionsTest.php
@@ -19,7 +19,7 @@ class RequestOptionsTest extends \PHPUnit_Framework_TestCase {
 	public function testCanConstruct() {
 
 		$this->assertInstanceOf(
-			'\SMW\RequestOptions',
+			RequestOptions::class,
 			new RequestOptions()
 		);
 	}
@@ -36,12 +36,12 @@ class RequestOptionsTest extends \PHPUnit_Framework_TestCase {
 			);
 
 			$this->assertFalse(
-				$stringCondition->isDisjunctiveCondition
+				$stringCondition->isOr
 			);
 		}
 
 		$this->assertEquals(
-			'[-1,0,false,true,null,true,"Foo#0#",[]]',
+			'[-1,0,false,true,null,true,"Foo#0##",[]]',
 			$instance->getHash()
 		);
 	}

--- a/tests/phpunit/Unit/SQLStore/RequestOptionsProcTest.php
+++ b/tests/phpunit/Unit/SQLStore/RequestOptionsProcTest.php
@@ -182,6 +182,48 @@ class RequestOptionsProcTest extends \PHPUnit_Framework_TestCase {
 			' AND Foo >= 1 AND Bar = foo\_bar OR abd = 123'
 		);
 
+		# 6
+		$requestOptions = new RequestOptions();
+		$requestOptions->boundary = true;
+
+		$requestOptions->addStringCondition( 'foo_bar', StringCondition::COND_EQ, true, true );
+
+		$provider[] = array(
+			$requestOptions,
+			'Foo',
+			'Bar',
+			' ( AND Foo >= 1) AND (Bar NOT = foo\_bar) '
+		);
+
+		# 7
+		$requestOptions = new RequestOptions();
+		$requestOptions->boundary = true;
+
+		$requestOptions->addStringCondition( 'foo_bar', StringCondition::COND_EQ, true );
+		$requestOptions->addStringCondition( 'foobar', StringCondition::COND_POST, true, true );
+
+		$provider[] = array(
+			$requestOptions,
+			'Foo',
+			'Bar',
+			' ( AND Foo >= 1 OR Bar = foo\_bar) AND (Bar NOT LIKE %foobar) '
+		);
+
+		# 8
+		$requestOptions = new RequestOptions();
+		$requestOptions->boundary = true;
+
+		$requestOptions->addStringCondition( 'foo_bar', StringCondition::COND_EQ, true );
+		$requestOptions->addStringCondition( 'foobar', StringCondition::COND_POST, false, true );
+		$requestOptions->addStringCondition( 'foobar_ex', StringCondition::COND_EQ, false, true );
+
+		$provider[] = array(
+			$requestOptions,
+			'Foo',
+			'Bar',
+			' ( ( AND Foo >= 1 OR Bar = foo\_bar) AND (Bar NOT LIKE %foobar) ) AND (Bar NOT = foobar\_ex) '
+		);
+
 		return $provider;
 	}
 

--- a/tests/phpunit/Unit/StringConditionTest.php
+++ b/tests/phpunit/Unit/StringConditionTest.php
@@ -30,7 +30,7 @@ class StringConditionTest extends \PHPUnit_Framework_TestCase {
 		);
 
 		$this->assertEquals(
-			'Foo#0#1',
+			'Foo#0#1#',
 			$instance->getHash()
 		);
 
@@ -40,7 +40,11 @@ class StringConditionTest extends \PHPUnit_Framework_TestCase {
 		);
 
 		$this->assertTrue(
-			$instance->isDisjunctiveCondition
+			$instance->isOr
+		);
+
+		$this->assertFalse(
+			$instance->isNot
 		);
 	}
 


### PR DESCRIPTION
This PR is made in reference to: #

This PR addresses or contains:

- Support for a `NOT` condition

This PR includes:
- [x] Tests (unit/integration)
- [X] CI build passed
