### PR TITLE
smw-property-predefined-rl-desc typo fixed

### DIFF
--- a/i18n/en.json
+++ b/i18n/en.json
@@ -693,7 +693,7 @@
 	"smw-rule-page-description": "Description:",
 	"smw-rule-page-type": "Type:",
 	"smw-rule-page-tag": "Tag:",
-	"smw-property-predefined-rl-desc": "\"$1\" is a predefined property the stores a rule description and is provided by [https://www.semantic-mediawiki.org/wiki/Help:Special_properties Semantic MediaWiki].",
+	"smw-property-predefined-rl-desc": "\"$1\" is a predefined property that stores a rule description and is provided by [https://www.semantic-mediawiki.org/wiki/Help:Special_properties Semantic MediaWiki].",
 	"smw-property-predefined-rl-tag": "\"$1\" is a predefined property provided by [https://www.semantic-mediawiki.org/wiki/Help:Special_properties Semantic MediaWiki] to tag listed rules.",
 	"smw-property-predefined-long-rl-tag": "An annotated textual tag is to identify a group of rules that apply to the same content or topic.",
 	"smw-property-predefined-rl-type": "\"$1\" is a predefined property that describes a type by which a rule or set of rules is interpret and is provided by [https://www.semantic-mediawiki.org/wiki/Help:Special_properties Semantic MediaWiki].",


### PR DESCRIPTION
This PR is made in reference to: #3019 

This PR addresses or contains:
- Typo fixed
- Translating the string [smw-property-predefined-rl-desc](https://translatewiki.net/w/i.php?title=Special:Translate&showMessage=smw-property-predefined-rl-desc&group=mwgithub-semanticmediawiki) i found what seems to me like a typo error, where is a "the" I think should be a "that". If I am wrong, just close this PR, but this "the" sounds strange to me.

This PR includes:
- [ ] Tests (unit/integration)
- [x] CI build passed

Regards,
Iván