### PR TITLE
 Spanish translation for _keyw and _FORMAT_RL

### DIFF
--- a/i18n/extra/es.json
+++ b/i18n/extra/es.json
@@ -20,6 +20,7 @@
         "_qty": "Cantidad",
         "_mlt_rec": "Texto monolingüe",
         "_eid": "Identificador externo",
+        "_keyw": "Palabra clave",
         "_ref_rec": "Referencia"
     },
     "dataTypeAliases": {
@@ -76,7 +77,8 @@
         "_RL_DESC": "Descripción de regla",
         "_RL_TAG": "Etiqueta de regla",
         "_RL_TYPE": "Tipo de regla",
-        "_RL_DEF": "Definición de regla"
+        "_RL_DEF": "Definición de regla",
+        "_FORMAT_RL": "Regla de formateador"
     },
     "propertyAliases": {
         "Es página nueva": "_NEWP",


### PR DESCRIPTION
This PR is made in reference to: #3019 #3020

This PR addresses or contains:
- Spanish translation for `_keyw`
- Spanish translation for `_FORMAT_RL`

This PR includes:
- [ ] Tests (unit/integration)
- [x] CI build passed

Note:
- Excuse me for the duplicated PR (#3056). It was automatically closed by the system because I clean the repo to not make two commits for the same thing, because I check again the translation and I fixed a typo error.