### PR TITLE
fixed Spanish translation of _PEFU

### DIFF
--- a/i18n/extra/es.json
+++ b/i18n/extra/es.json
@@ -69,7 +69,7 @@
         "_DTITLE": "Mostrar título de",
         "_PVUC": "Tiene restricción de singularidad",
         "_PEID": "Identificador externo",
-        "_PEFU": "Formateador de URI externa",
+        "_PEFU": "URI del formateador externo",
         "_PPLB": "Etiqueta de propiedad preferida",
         "_EDIP": "Está protegida de edición",
         "_CHGPRO": "Propagación de cambio",


### PR DESCRIPTION
This PR is made in reference to: #3001

This PR addresses or contains:
- Fixed the Spanish translation of _PEFU ("External Formatter URI").

This PR includes:
- [ ] Tests (unit/integration)
- [ ] CI build passed

Fixes #3001