### PR TITLE
Detect changes on BlockIpComplete, UnblockUserComplete, UserGroupsChanged

### DIFF
--- a/src/MediaWiki/Hooks/HookRegistry.php
+++ b/src/MediaWiki/Hooks/HookRegistry.php
@@ -256,6 +256,10 @@ class HookRegistry {
 			'ExtensionTypes' => 'newExtensionTypes',
 			'SpecialSearchResultsPrepend' => 'newSpecialSearchResultsPrepend',
 			'SpecialStatsAddExtra' => 'newSpecialStatsAddExtra',
+
+			'BlockIpComplete' => 'newBlockIpComplete',
+			'UnblockUserComplete' => 'newUnblockUserComplete',
+			'UserGroupsChanged' => 'newUserGroupsChanged',
 		];
 
 		foreach ( $hooks as $hook => $handler ) {
@@ -857,6 +861,62 @@ class HookRegistry {
 		$docsFunctionHandler = new DocumentationParserFunction();
 		$hookRegistrant->registerFunctionHandler( $docsFunctionDefinition, $docsFunctionHandler );
 		$hookRegistrant->registerHookHandler( $docsFunctionDefinition, $docsFunctionHandler );
+
+		return true;
+	}
+
+	/**
+	 * @see https://www.mediawiki.org/wiki/Manual:Hooks/BlockIpComplete
+	 * @provided by MW 1.4
+	 *
+	 * "... occurs after the request to block (or change block settings of)
+	 * an IP or user has been processed ..."
+	 */
+	public function newBlockIpComplete( $block, $performer, $priorBlock ) {
+
+		$userChange = new UserChange(
+			$this->applicationFactory->getNamespaceExaminer()
+		);
+
+		$userChange->setOrigin( 'BlockIpComplete' );
+		$userChange->process( $block->getTarget() );
+
+		return true;
+	}
+
+	/**
+	 * @see https://www.mediawiki.org/wiki/Manual:Hooks/UnblockUserComplete
+	 * @provided by MW 1.29
+	 *
+	 * "... occurs after the request to unblock an IP or user has been
+	 * processed ..."
+	 */
+	public function newUnblockUserComplete( $block, $performer ) {
+
+		$userChange = new UserChange(
+			$this->applicationFactory->getNamespaceExaminer()
+		);
+
+		$userChange->setOrigin( 'UnblockUserComplete' );
+		$userChange->process( $block->getTarget() );
+
+		return true;
+	}
+
+	/**
+	 * @see https://www.mediawiki.org/wiki/Manual:Hooks/UserGroupsChanged
+	 * @provided by MW 1.26
+	 *
+	 * "... called after user groups are changed ..."
+	 */
+	public function newUserGroupsChanged( $user ) {
+
+		$userChange = new UserChange(
+			$this->applicationFactory->getNamespaceExaminer()
+		);
+
+		$userChange->setOrigin( 'UserGroupsChanged' );
+		$userChange->process( $user->getName() );
 
 		return true;
 	}

--- a/src/MediaWiki/Hooks/UserChange.php
+++ b/src/MediaWiki/Hooks/UserChange.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace SMW\MediaWiki\Hooks;
+
+use SMW\NamespaceExaminer;
+use SMW\ApplicationFactory;
+use SMW\MediaWiki\Jobs\UpdateJob;
+use Title;
+
+/**
+ * @see https://www.mediawiki.org/wiki/Manual:Hooks/BlockIpComplete
+ * @see https://www.mediawiki.org/wiki/Manual:Hooks/UnblockUserComplete
+ * @see https://www.mediawiki.org/wiki/Manual:Hooks/UserGroupsChanged
+ *
+ * Act on events that happen outside of the normal parser process and hereby
+ * ensures that updates of pre-defined properties related to a user status can
+ * be detected.
+ *
+ * @license GNU GPL v2+
+ * @since 3.0
+ *
+ * @author mwjames
+ */
+class UserChange extends HookHandler {
+
+	/**
+	 * @var NamespaceExaminer
+	 */
+	private $namespaceExaminer;
+
+	/**
+	 * @var string
+	 */
+	private $origin = '';
+
+	/**
+	 * @since 3.0
+	 *
+	 * @param NamespaceExaminer $namespaceExaminer
+	 */
+	public function __construct( NamespaceExaminer $namespaceExaminer ) {
+		$this->namespaceExaminer = $namespaceExaminer;
+	}
+
+	/**
+	 * @since 3.0
+	 *
+	 * @param string $origin
+	 */
+	public function setOrigin( $origin ) {
+		$this->origin = $origin;
+	}
+
+	/**
+	 * @since 3.0
+	 *
+	 * @param string $user
+	 */
+	public function process( $user ) {
+
+		if ( !$this->namespaceExaminer->isSemanticEnabled( NS_USER ) ) {
+			return false;
+		}
+
+		$updateJob = ApplicationFactory::getInstance()->newJobFactory()->newUpdateJob(
+			Title::newFromText( $user, NS_USER ),
+			[
+				UpdateJob::FORCED_UPDATE => true,
+				'origin' => $this->origin
+			]
+		);
+
+		$updateJob->insert();
+
+		return true;
+	}
+
+}

--- a/tests/phpunit/Unit/MediaWiki/Hooks/HookRegistryTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Hooks/HookRegistryTest.php
@@ -211,6 +211,9 @@ class HookRegistryTest extends \PHPUnit_Framework_TestCase {
 		$this->doTestExecutionForOutputPageCheckLastModified( $instance );
 		$this->doTestExecutionForIsFileCacheable( $instance );
 		$this->doTestExecutionForRejectParserCacheValue( $instance );
+		$this->doTestExecutionForBlockIpComplete( $instance );
+		$this->doTestExecutionForUnblockUserComplete( $instance );
+		$this->doTestExecutionForUserGroupsChanged( $instance );
 
 		// Usage of registered hooks in/by smw-core
 		//$this->doTestExecutionForSMWStoreDropTables( $instance );
@@ -1203,6 +1206,84 @@ class HookRegistryTest extends \PHPUnit_Framework_TestCase {
 		$this->assertThatHookIsExcutable(
 			$instance->getHandlerFor( $handler ),
 			array( $value, $wikiPage, $popts )
+		);
+
+		$this->handlers[$handler] = true;
+	}
+
+	public function doTestExecutionForBlockIpComplete( $instance ) {
+
+		$handler = 'BlockIpComplete';
+
+		$block = $this->getMockBuilder( '\Block' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$block->expects( $this->any() )
+			->method( 'getTarget' )
+			->will( $this->returnValue( 'Foo' ) );
+
+		$performer = '';
+		$priorBlock = '';
+
+		$this->assertTrue(
+			$instance->isRegistered( $handler )
+		);
+
+		$this->assertThatHookIsExcutable(
+			$instance->getHandlerFor( $handler ),
+			array( $block, $performer, $priorBlock )
+		);
+
+		$this->handlers[$handler] = true;
+	}
+
+	public function doTestExecutionForUnblockUserComplete( $instance ) {
+
+		$handler = 'UnblockUserComplete';
+
+		$block = $this->getMockBuilder( '\Block' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$block->expects( $this->any() )
+			->method( 'getTarget' )
+			->will( $this->returnValue( 'Foo' ) );
+
+		$performer = '';
+		$priorBlock = '';
+
+		$this->assertTrue(
+			$instance->isRegistered( $handler )
+		);
+
+		$this->assertThatHookIsExcutable(
+			$instance->getHandlerFor( $handler ),
+			array( $block, $performer, $priorBlock )
+		);
+
+		$this->handlers[$handler] = true;
+	}
+
+	public function doTestExecutionForUserGroupsChanged( $instance ) {
+
+		$handler = 'UserGroupsChanged';
+
+		$user = $this->getMockBuilder( '\User' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$user->expects( $this->any() )
+			->method( 'getName' )
+			->will( $this->returnValue( 'Foo' ) );
+
+		$this->assertTrue(
+			$instance->isRegistered( $handler )
+		);
+
+		$this->assertThatHookIsExcutable(
+			$instance->getHandlerFor( $handler ),
+			array( $user )
 		);
 
 		$this->handlers[$handler] = true;

--- a/tests/phpunit/Unit/MediaWiki/Hooks/UserChangeTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Hooks/UserChangeTest.php
@@ -1,0 +1,97 @@
+<?php
+
+namespace SMW\Tests\MediaWiki\Hooks;
+
+use SMW\MediaWiki\Hooks\UserChange;
+use SMW\Tests\TestEnvironment;
+
+/**
+ * @covers \SMW\MediaWiki\Hooks\UserChange
+ * @group semantic-mediawiki
+ *
+ * @license GNU GPL v2+
+ * @since 3.0
+ *
+ * @author mwjames
+ */
+class UserChangeTest extends \PHPUnit_Framework_TestCase {
+
+	private $namespaceExaminer;
+	private $testEnvironment;
+	private $jobFactory;
+
+	protected function setUp() {
+		parent::setUp();
+
+		$this->testEnvironment = new TestEnvironment();
+
+		$this->namespaceExaminer = $this->getMockBuilder( '\SMW\NamespaceExaminer' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$this->jobFactory = $this->getMockBuilder( '\SMW\MediaWiki\Jobs\JobFactory' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$this->testEnvironment->registerObject( 'JobFactory', $this->jobFactory );
+	}
+
+	protected function tearDown() {
+		$this->testEnvironment->tearDown();
+		parent::tearDown();
+	}
+
+	public function testCanConstruct() {
+
+		$this->assertInstanceOf(
+			UserChange::class,
+			new UserChange( $this->namespaceExaminer )
+		);
+	}
+
+	public function testOnEnabledUserNamespace() {
+
+		$job = $this->getMockBuilder( '\SMW\MediaWiki\Jobs\UpdateJob' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$this->jobFactory->expects( $this->once() )
+			->method( 'newUpdateJob' )
+			->will( $this->returnValue( $job ) );
+
+		$this->namespaceExaminer->expects( $this->any() )
+			->method( 'isSemanticEnabled' )
+			->with( $this->equalTo( NS_USER ) )
+			->will( $this->returnValue( true ) );
+
+		$instance = new UserChange(
+			$this->namespaceExaminer
+		);
+
+		$instance->setOrigin( 'Foo' );
+
+		$this->assertTrue(
+			$instance->process( 'Foo' )
+		);
+	}
+
+	public function testOnDisabledUserNamespace() {
+
+		$this->jobFactory->expects( $this->never() )
+			->method( 'newUpdateJob' );
+
+		$this->namespaceExaminer->expects( $this->any() )
+			->method( 'isSemanticEnabled' )
+			->with( $this->equalTo( NS_USER ) )
+			->will( $this->returnValue( false ) );
+
+		$instance = new UserChange(
+			$this->namespaceExaminer
+		);
+
+		$this->assertFalse(
+			$instance->process( 'Foo' )
+		);
+	}
+
+}


### PR DESCRIPTION
This PR is made in reference to: https://github.com/SemanticMediaWiki/SemanticExtraSpecialProperties/issues/80

This PR addresses or contains:

- Detect changes to a `User` that are not run through the Parser and require different hooks (`BlockIpComplete`, `UnblockUserComplete`, `UserGroupsChanged`) to fetch the change event.

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed
