### PR TITLE
Process simple links within an annotation

### DIFF
--- a/src/Parser/Obfuscator.php
+++ b/src/Parser/Obfuscator.php
@@ -181,8 +181,9 @@ class Obfuscator {
 		// identify the boundaries of the enclosing annotation
 		foreach ( $matches[0] as $match ) {
 
-			// Normal link
-			if ( strpos( $match, '[[:' ) !== false ) {
+			// Ignore simple links like `[[:Property:Has URL|Has URL]]` but
+			// do parse `[[Has description::[[foo]][[:bar]]]]` (:= legacy notation)
+			if ( strpos( $match, '[[' ) !== false && strpos( $match, '::' ) === false && strpos( $match, ':=' ) === false ) {
 				continue;
 			}
 

--- a/tests/phpunit/Integration/JSONScript/TestCases/p-0444.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/p-0444.json
@@ -42,6 +42,10 @@
 		{
 			"page": "Example/P0444/Q.1",
 			"contents": "{{#ask: [[Category:P0444]] |format=embedded }}"
+		},
+		{
+			"page": "Example/P0444/5",
+			"contents": "[[Has text::[[:Lorem ipsum]] [[:Lorem ipsum|Bar]]]]"
 		}
 	],
 	"tests": [
@@ -155,6 +159,31 @@
 					],
 					"propertyValues": []
 				}
+			}
+		},
+		{
+			"type": "parser",
+			"about": "#5 internal wiki link (`[[:...`)",
+			"subject": "Example/P0444/5",
+			"assert-store": {
+				"semantic-data": {
+					"strictPropertyValueMatch": false,
+					"propertyCount": 3,
+					"propertyKeys": [
+						"_SKEY",
+						"_MDAT",
+						"Has text"
+					],
+					"propertyValues": [
+						"[[:Lorem ipsum]] [[:Lorem ipsum|Bar]]"
+					]
+				}
+			},
+			"assert-output": {
+				"to-contain": [
+					">Lorem ipsum</a>",
+					">Bar</a>"
+				]
 			}
 		}
 	],


### PR DESCRIPTION
This PR is made in reference to: #

This PR addresses or contains:

- Ignore links like `[[:Property:Has URL|Has URL]]` but process `[[Has description::[[foo]][[:bar]]]]`

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed
