### PR TITLE
Add SMW::Admin::TaskHandlerFactory hook, refs 3054

### DIFF
--- a/docs/technical/hooks.md
+++ b/docs/technical/hooks.md
@@ -338,7 +338,7 @@ Hooks::register( 'SMW::LinksUpdate::ApprovedUpdate', function( $title, $latestRe
 ### SMW::Parser::ChangeRevision
 
 * Version: 3.0
-* Description: Hook allows to forcibly to change a revision used during content parsing as in case of execution the `UpdateJob` or running `rebuildData.php`.
+* Description: Hook allows to forcibly change a revision used during content parsing as in case of the `UpdateJob` execution or when running `rebuildData.php`.
 * Reference class: `SMW\ContentParser`
 
 If you do alter a revision, please log the event and make it visible to a user (or administrator) that it was changed.
@@ -350,6 +350,24 @@ Hooks::register( 'SMW::Parser::ChangeRevision', function( $title, &$revision ) {
 
 	// Set a revision
 	// $revision = \Revision::newFromId( $id );
+
+	return true;
+} );
+</pre>
+
+### SMW::Admin::TaskHandlerFactory
+
+* Version: 3.0
+* Description: Hook allows to extend available `TaskHandler` in `Special:SemanticMediaWiki`
+* Reference class: `SMW\MediaWiki\Specials\Admin\TaskHandlerFactory`
+
+<pre>
+use Hooks;
+
+Hooks::register( 'SMW::Admin::TaskHandlerFactory', function( &$taskHandlers, $store, $outputFormatter, $user ) {
+
+	// Instance of TaskHandler
+	// $taskHandlers[] = new FooTaskHandler();
 
 	return true;
 } );

--- a/src/MediaWiki/Specials/Admin/TaskHandlerFactory.php
+++ b/src/MediaWiki/Specials/Admin/TaskHandlerFactory.php
@@ -48,7 +48,7 @@ class TaskHandlerFactory {
 	 */
 	public function getTaskHandlerList( $user, $adminFeatures ) {
 
-		$handlers = [
+		$taskHandlers = [
 			// TaskHandler::SECTION_SCHEMA
 			$this->newTableSchemaTaskHandler(),
 
@@ -71,6 +71,8 @@ class TaskHandlerFactory {
 			$this->newSupportListTaskHandler()
 		];
 
+		\Hooks::run( 'SMW::Admin::TaskHandlerFactory', [ &$taskHandlers, $this->store, $this->outputFormatter, $user ] );
+
 		$taskHandlerList = [
 			TaskHandler::SECTION_SCHEMA => [],
 			TaskHandler::SECTION_DATAREPAIR => [],
@@ -80,36 +82,40 @@ class TaskHandlerFactory {
 			'actions' => []
 		];
 
-		foreach ( $handlers as $handler ) {
+		foreach ( $taskHandlers as $taskHandler ) {
 
-			$handler->setEnabledFeatures(
+			if ( !is_a( $taskHandler, 'SMW\MediaWiki\Specials\Admin\TaskHandler' ) ) {
+				continue;
+			}
+
+			$taskHandler->setEnabledFeatures(
 				$adminFeatures
 			);
 
-			$handler->setStore(
+			$taskHandler->setStore(
 				$this->store
 			);
 
-			switch ( $handler->getSection() ) {
+			switch ( $taskHandler->getSection() ) {
 				case TaskHandler::SECTION_SCHEMA:
-					$taskHandlerList[TaskHandler::SECTION_SCHEMA][] = $handler;
+					$taskHandlerList[TaskHandler::SECTION_SCHEMA][] = $taskHandler;
 					break;
 				case TaskHandler::SECTION_DATAREPAIR:
-					$taskHandlerList[TaskHandler::SECTION_DATAREPAIR][] = $handler;
+					$taskHandlerList[TaskHandler::SECTION_DATAREPAIR][] = $taskHandler;
 					break;
 				case TaskHandler::SECTION_DEPRECATION:
-					$taskHandlerList[TaskHandler::SECTION_DEPRECATION][] = $handler;
+					$taskHandlerList[TaskHandler::SECTION_DEPRECATION][] = $taskHandler;
 					break;
 				case TaskHandler::SECTION_SUPPLEMENT:
-					$taskHandlerList[TaskHandler::SECTION_SUPPLEMENT][] = $handler;
+					$taskHandlerList[TaskHandler::SECTION_SUPPLEMENT][] = $taskHandler;
 					break;
 				case TaskHandler::SECTION_SUPPORT:
-					$taskHandlerList[TaskHandler::SECTION_SUPPORT][] = $handler;
+					$taskHandlerList[TaskHandler::SECTION_SUPPORT][] = $taskHandler;
 					break;
 			}
 
-			if ( $handler->hasAction() ) {
-				$taskHandlerList['actions'][] = $handler;
+			if ( $taskHandler->hasAction() ) {
+				$taskHandlerList['actions'][] = $taskHandler;
 			}
 		}
 


### PR DESCRIPTION
This PR is made in reference to: #3054

This PR addresses or contains:

- Hook to extend functions available in `Special:SemanticMediaWiki`

This PR includes:
- [ ] Tests (unit/integration)
- [ ] CI build passed

[skip ci]