### PR TITLE
Use …::class feature in class_alias() instead of strings

### DIFF
--- a/src/Aliases.php
+++ b/src/Aliases.php
@@ -5,90 +5,90 @@
  */
 
 // 3.0
-class_alias( 'SMW\MediaWiki\Deferred\CallableUpdate', 'SMW\DeferredCallableUpdate' );
-class_alias( 'SMW\Parser\InTextAnnotationParser', 'SMW\InTextAnnotationParser' );
-class_alias( 'SMW\Encoder', 'SMW\UrlEncoder' );
-class_alias( 'SMW\Query\ResultPrinter', 'SMW\QueryResultPrinter' );
-class_alias( 'SMW\Query\ResultPrinter', 'SMWIResultPrinter' );
-class_alias( 'SMW\Query\ExportPrinter', 'SMW\ExportPrinter' );
-class_alias( 'SMW\Query\ResultPrinters\ResultPrinter', 'SMW\ResultPrinter' );
-class_alias( 'SMW\Query\ResultPrinters\ResultPrinter', 'SMWResultPrinter' );
-class_alias( 'SMW\Query\ResultPrinters\FileExportPrinter', 'SMW\FileExportPrinter' );
-class_alias( 'SMW\Query\Parser', 'SMWQueryParser' );
-class_alias( 'SMW\SQLStore\ChangeOp\ChangeOp', 'SMW\SQLStore\CompositePropertyTableDiffIterator' );
-class_alias( 'SMW\Connection\ConnectionProvider', 'SMW\DBConnectionProvider' );
-class_alias( 'SMW\DataValues\TypesValue', 'SMWTypesValue' );
-class_alias( 'SMW\DataValues\PropertyValue', 'SMWPropertyValue' );
+class_alias( \SMW\MediaWiki\Deferred\CallableUpdate::class, 'SMW\DeferredCallableUpdate' );
+class_alias( \SMW\Parser\InTextAnnotationParser::class, 'SMW\InTextAnnotationParser' );
+class_alias( \SMW\Encoder::class, 'SMW\UrlEncoder' );
+class_alias( \SMW\Query\ResultPrinter::class, 'SMW\QueryResultPrinter' );
+class_alias( \SMW\Query\ResultPrinter::class, 'SMWIResultPrinter' );
+class_alias( \SMW\Query\ExportPrinter::class, 'SMW\ExportPrinter' );
+class_alias( \SMW\Query\ResultPrinters\ResultPrinter::class, 'SMW\ResultPrinter' );
+class_alias( \SMW\Query\ResultPrinters\ResultPrinter::class, 'SMWResultPrinter' );
+class_alias( \SMW\Query\ResultPrinters\FileExportPrinter::class, 'SMW\FileExportPrinter' );
+class_alias( \SMW\Query\Parser::class, 'SMWQueryParser' );
+class_alias( \SMW\SQLStore\ChangeOp\ChangeOp::class, 'SMW\SQLStore\CompositePropertyTableDiffIterator' );
+class_alias( \SMW\Connection\ConnectionProvider::class, 'SMW\DBConnectionProvider' );
+class_alias( \SMW\DataValues\TypesValue::class, 'SMWTypesValue' );
+class_alias( \SMW\DataValues\PropertyValue::class, 'SMWPropertyValue' );
 
 // 1.9.
-class_alias( 'SMW\Store', 'SMWStore' );
-class_alias( 'SMW\MediaWiki\Jobs\UpdateJob', 'SMWUpdateJob' );
-class_alias( 'SMW\MediaWiki\Jobs\RefreshJob', 'SMWRefreshJob' );
-class_alias( 'SMW\SemanticData', 'SMWSemanticData' );
-class_alias( 'SMW\DIWikiPage', 'SMWDIWikiPage' );
-class_alias( 'SMW\DIProperty', 'SMWDIProperty' );
-class_alias( 'SMW\Serializers\QueryResultSerializer', 'SMWDISerializer' );
-class_alias( 'SMW\DataValueFactory', 'SMWDataValueFactory' );
-class_alias( 'SMW\Exception\DataItemException', 'SMWDataItemException' );
-class_alias( 'SMW\SQLStore\PropertyTableDefinition', 'SMWSQLStore3Table' );
-class_alias( 'SMW\DIConcept', 'SMWDIConcept' );
-class_alias( 'SMW\Query\ResultPrinters\TableResultPrinter', 'SMWTableResultPrinter' );
+class_alias( \SMW\Store::class, 'SMWStore' );
+class_alias( \SMW\MediaWiki\Jobs\UpdateJob::class, 'SMWUpdateJob' );
+class_alias( \SMW\MediaWiki\Jobs\RefreshJob::class, 'SMWRefreshJob' );
+class_alias( \SMW\SemanticData::class, 'SMWSemanticData' );
+class_alias( \SMW\DIWikiPage::class, 'SMWDIWikiPage' );
+class_alias( \SMW\DIProperty::class, 'SMWDIProperty' );
+class_alias( \SMW\Serializers\QueryResultSerializer::class, 'SMWDISerializer' );
+class_alias( \SMW\DataValueFactory::class, 'SMWDataValueFactory' );
+class_alias( \SMW\Exception\DataItemException::class, 'SMWDataItemException' );
+class_alias( \SMW\SQLStore\PropertyTableDefinition::class, 'SMWSQLStore3Table' );
+class_alias( \SMW\DIConcept::class, 'SMWDIConcept' );
+class_alias( \SMW\Query\ResultPrinters\TableResultPrinter::class, 'SMWTableResultPrinter' );
 
 // 2.0
-class_alias( 'SMW\FileExportPrinter', 'SMWExportPrinter' );
-class_alias( 'SMW\AggregatablePrinter', 'SMWAggregatablePrinter' );
-class_alias( 'SMW\CategoryResultPrinter', 'SMWCategoryResultPrinter' );
-class_alias( 'SMW\DsvResultPrinter', 'SMWDSVResultPrinter' );
-class_alias( 'SMW\EmbeddedResultPrinter', 'SMWEmbeddedResultPrinter' );
-class_alias( 'SMW\RdfResultPrinter', 'SMWRDFResultPrinter' );
-class_alias( 'SMW\ListResultPrinter', 'SMWListResultPrinter' );
-class_alias( 'SMW\RawResultPrinter', 'SMW\ApiResultPrinter' );
+class_alias( \SMW\Query\ResultPrinters\FileExportPrinter::class, 'SMWExportPrinter' );
+class_alias( \SMW\AggregatablePrinter::class, 'SMWAggregatablePrinter' );
+class_alias( \SMW\CategoryResultPrinter::class, 'SMWCategoryResultPrinter' );
+class_alias( \SMW\DsvResultPrinter::class, 'SMWDSVResultPrinter' );
+class_alias( \SMW\EmbeddedResultPrinter::class, 'SMWEmbeddedResultPrinter' );
+class_alias( \SMW\RdfResultPrinter::class, 'SMWRDFResultPrinter' );
+class_alias( \SMW\ListResultPrinter::class, 'SMWListResultPrinter' );
+class_alias( \SMW\RawResultPrinter::class, 'SMW\ApiResultPrinter' );
 
 // 2.0
-class_alias( 'SMW\SPARQLStore\SPARQLStore', 'SMWSparqlStore' );
-class_alias( 'SMW\SPARQLStore\RepositoryConnectors\FourstoreRepositoryConnector', 'SMWSparqlDatabase4Store' );
-class_alias( 'SMW\SPARQLStore\RepositoryConnectors\VirtuosoRepositoryConnector', 'SMWSparqlDatabaseVirtuoso' );
-class_alias( 'SMW\SPARQLStore\RepositoryConnectors\GenericRepositoryConnector', 'SMWSparqlDatabase' );
+class_alias( \SMW\SPARQLStore\SPARQLStore::class, 'SMWSparqlStore' );
+class_alias( \SMW\SPARQLStore\RepositoryConnectors\FourstoreRepositoryConnector::class, 'SMWSparqlDatabase4Store' );
+class_alias( \SMW\SPARQLStore\RepositoryConnectors\VirtuosoRepositoryConnector::class, 'SMWSparqlDatabaseVirtuoso' );
+class_alias( \SMW\SPARQLStore\RepositoryConnectors\GenericRepositoryConnector::class, 'SMWSparqlDatabase' );
 
 // 2.1
-class_alias( 'SMWSQLStore3', 'SMW\SQLStore\SQLStore' );
-class_alias( 'SMW\Query\Language\Description', 'SMWDescription' );
-class_alias( 'SMW\Query\Language\ThingDescription', 'SMWThingDescription' );
-class_alias( 'SMW\Query\Language\ClassDescription', 'SMWClassDescription' );
-class_alias( 'SMW\Query\Language\ConceptDescription', 'SMWConceptDescription' );
-class_alias( 'SMW\Query\Language\NamespaceDescription', 'SMWNamespaceDescription' );
-class_alias( 'SMW\Query\Language\ValueDescription', 'SMWValueDescription' );
-class_alias( 'SMW\Query\Language\Conjunction', 'SMWConjunction' );
-class_alias( 'SMW\Query\Language\Disjunction', 'SMWDisjunction' );
-class_alias( 'SMW\Query\Language\SomeProperty', 'SMWSomeProperty' );
-class_alias( 'SMW\Query\PrintRequest', 'SMWPrintRequest' );
-class_alias( 'SMW\MediaWiki\Search\Search', 'SMWSearch' );
+class_alias( \SMWSQLStore3::class, 'SMW\SQLStore\SQLStore' );
+class_alias( \SMW\Query\Language\Description::class, 'SMWDescription' );
+class_alias( \SMW\Query\Language\ThingDescription::class, 'SMWThingDescription' );
+class_alias( \SMW\Query\Language\ClassDescription::class, 'SMWClassDescription' );
+class_alias( \SMW\Query\Language\ConceptDescription::class, 'SMWConceptDescription' );
+class_alias( \SMW\Query\Language\NamespaceDescription::class, 'SMWNamespaceDescription' );
+class_alias( \SMW\Query\Language\ValueDescription::class, 'SMWValueDescription' );
+class_alias( \SMW\Query\Language\Conjunction::class, 'SMWConjunction' );
+class_alias( \SMW\Query\Language\Disjunction::class, 'SMWDisjunction' );
+class_alias( \SMW\Query\Language\SomeProperty::class, 'SMWSomeProperty' );
+class_alias( \SMW\Query\PrintRequest::class, 'SMWPrintRequest' );
+class_alias( \SMW\MediaWiki\Search\Search::class, 'SMWSearch' );
 
 // 2.2
 // Some weird SF dependency needs to be removed as quick as possible
-class_alias( 'SMW\SQLStore\Lookup\ListLookup', 'SMW\SQLStore\PropertiesCollector' );
-class_alias( 'SMW\SQLStore\Lookup\ListLookup', 'SMW\SQLStore\UnusedPropertiesCollector' );
+class_alias( \SMW\SQLStore\Lookup\ListLookup::class, 'SMW\SQLStore\PropertiesCollector' );
+class_alias( \SMW\SQLStore\Lookup\ListLookup::class, 'SMW\SQLStore\UnusedPropertiesCollector' );
 
-class_alias( 'SMW\Exporter\Element\ExpElement', 'SMWExpElement' );
-class_alias( 'SMW\Exporter\Element\ExpResource', 'SMWExpResource' );
-class_alias( 'SMW\Exporter\Element\ExpNsResource', 'SMWExpNsResource' );
-class_alias( 'SMW\Exporter\Element\ExpLiteral', 'SMWExpLiteral' );
-class_alias( 'SMW\DataValues\ImportValue', 'SMWImportValue' );
-class_alias( 'SMW\SQLStore\QueryEngine\QueryEngine', 'SMWSQLStore3QueryEngine' );
+class_alias( \SMW\Exporter\Element\ExpElement::class, 'SMWExpElement' );
+class_alias( \SMW\Exporter\Element\ExpResource::class, 'SMWExpResource' );
+class_alias( \SMW\Exporter\Element\ExpNsResource::class, 'SMWExpNsResource' );
+class_alias( \SMW\Exporter\Element\ExpLiteral::class, 'SMWExpLiteral' );
+class_alias( \SMW\DataValues\ImportValue::class, 'SMWImportValue' );
+class_alias( \SMW\SQLStore\QueryEngine\QueryEngine::class, 'SMWSQLStore3QueryEngine' );
 
 // 2.3
-class_alias( 'SMW\ParserParameterProcessor', 'SMW\ParserParameterFormatter' );
-class_alias( 'SMW\ParameterProcessorFactory', 'SMW\ParameterFormatterFactory' );
+class_alias( \SMW\ParserParameterProcessor::class, 'SMW\ParserParameterFormatter' );
+class_alias( \SMW\ParameterProcessorFactory::class, 'SMW\ParameterFormatterFactory' );
 
 // 2.4
-class_alias( 'SMW\RequestOptions', 'SMWRequestOptions' );
-class_alias( 'SMW\StringCondition', 'SMWStringCondition' );
-class_alias( 'SMW\HashBuilder', 'SMW\Hash' );
-class_alias( 'SMW\DataValues\BooleanValue', 'SMWBoolValue' );
+class_alias( \SMW\RequestOptions::class, 'SMWRequestOptions' );
+class_alias( \SMW\StringCondition::class, 'SMWStringCondition' );
+class_alias( \SMW\HashBuilder::class, 'SMW\Hash' );
+class_alias( \SMW\DataValues\BooleanValue::class, 'SMWBoolValue' );
 
 // 2.5
-class_alias( 'SMW\QueryPrinterFactory', 'SMW\FormatFactory' );
-class_alias( 'SMW\ParserFunctions\SubobjectParserFunction', 'SMW\SubobjectParserFunction' );
-class_alias( 'SMW\ParserFunctions\RecurringEventsParserFunction', 'SMW\RecurringEventsParserFunction' );
-class_alias( 'SMW\SQLStore\PropertyTableDefinition', 'SMW\SQLStore\TableDefinition' );
-class_alias( 'SMW\DataModel\ContainerSemanticData', 'SMWContainerSemanticData' );
+class_alias( \SMW\QueryPrinterFactory::class, 'SMW\FormatFactory' );
+class_alias( \SMW\ParserFunctions\SubobjectParserFunction::class, 'SMW\SubobjectParserFunction' );
+class_alias( \SMW\ParserFunctions\RecurringEventsParserFunction::class, 'SMW\RecurringEventsParserFunction' );
+class_alias( \SMW\SQLStore\PropertyTableDefinition::class, 'SMW\SQLStore\TableDefinition' );
+class_alias( \SMW\DataModel\ContainerSemanticData::class, 'SMWContainerSemanticData' );


### PR DESCRIPTION
This is not different in so far that a …::class still is a string, and class_alias() still does nothing but adding an entry to a string => string map.

But utilizing the …::class feature does have the benefit that IDEs, linters and such are aware that a class is referenced, and will include these lines into usage reports and such.