### PR TITLE
Check magic words list

### DIFF
--- a/src/MediaWiki/MagicWordsFinder.php
+++ b/src/MediaWiki/MagicWordsFinder.php
@@ -72,7 +72,7 @@ class MagicWordsFinder {
 		// Filter empty lines
 		$words = array_values( array_filter( $words ) );
 
-		if ( $this->hasExtensionData() ) {
+		if ( $this->hasExtensionData() && $words !== [] ) {
 			return $this->parserOutput->setExtensionData( 'smwmagicwords', $words );
 		}
 

--- a/tests/phpunit/Unit/Factbox/FactboxMagicWordsTest.php
+++ b/tests/phpunit/Unit/Factbox/FactboxMagicWordsTest.php
@@ -160,7 +160,7 @@ class FactboxMagicWordsTest extends \PHPUnit_Framework_TestCase {
 			' [[Foo::dictumst cursus]]. Nisl sit condimentum Quisque facilisis' .
 			' Suspendisse [[Bar::tincidunt semper]] facilisi dolor Aenean. Ut',
 			array(
-				'magicWords' => array(),
+				'magicWords' => null,
 				'constants'  => SMW_FACTBOX_HIDDEN,
 				'textOutput' => ''
 			)
@@ -172,7 +172,7 @@ class FactboxMagicWordsTest extends \PHPUnit_Framework_TestCase {
 			' [[Foo::dictumst cursus]]. Nisl sit condimentum Quisque facilisis' .
 			' Suspendisse [[Bar::tincidunt semper]] facilisi dolor Aenean. Ut',
 			array(
-				'magicWords' => array(),
+				'magicWords' => null,
 				'preview'    => true,
 				'constants'  => SMW_FACTBOX_HIDDEN,
 				'textOutput' => ''

--- a/tests/phpunit/Unit/MediaWiki/MagicWordsFinderTest.php
+++ b/tests/phpunit/Unit/MediaWiki/MagicWordsFinderTest.php
@@ -90,6 +90,28 @@ class MagicWordsFinderTest extends \PHPUnit_Framework_TestCase {
 		);
 	}
 
+	public function testNoPushOnEmptyMagicWordsList() {
+
+		$parserOutput = $this->getMockBuilder( '\ParserOutput' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$parserOutput->expects( $this->never() )
+			->method( 'setExtensionData' );
+
+		$instance = $this->getMockBuilder( '\SMW\MediaWiki\MagicWordsFinder' )
+			->disableOriginalConstructor()
+			->setMethods( array( 'hasExtensionData' ) )
+			->getMock();
+
+		$instance->expects( $this->any() )
+			->method( 'hasExtensionData' )
+			->will( $this->returnValue( true ) );
+
+		$instance->setOutput( $parserOutput );
+		$instance->pushMagicWordsToParserOutput( [] );
+	}
+
 	protected function assertMagicWordFromParserOutput( $instance, $magicWord, $expectedMagicWords ) {
 
 		$this->assertEmpty(


### PR DESCRIPTION
This PR is made in reference to: https://sourceforge.net/p/semediawiki/mailman/message/36246292/

This PR addresses or contains:

- Ensures that different (hereby recursive) parse runs that return a magic words list and are merged (as in case of using the Cite extension) together don't override (such as with an empty list) an already registered list from a preceding parse that belong to the same process chain.

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed
