### PR TITLE
Add IDs warmUpCache

### DIFF
--- a/includes/storage/SQLStore/SMW_SQLStore3_Readers.php
+++ b/includes/storage/SQLStore/SMW_SQLStore3_Readers.php
@@ -129,6 +129,14 @@ class SMWSQLStore3Readers {
 
 		$this->semanticDataLookup->unlockCache();
 
+		$this->store->smwIds->warmUpCache(
+			$semanticData->getProperties()
+		);
+
+		$this->store->smwIds->warmUpCache(
+			$semanticData->getPropertyValues( new DIProperty( '_INST' ) )
+		);
+
 		return $semanticData;
 	}
 
@@ -222,6 +230,7 @@ class SMWSQLStore3Readers {
 			}
 		}
 
+		$this->store->smwIds->warmUpCache( $result );
 
 		return $result;
 	}
@@ -331,6 +340,8 @@ class SMWSQLStore3Readers {
 			$iteratorFactory->newResultIterator( $res ),
 			$callback
 		);
+
+		$this->store->smwIds->warmUpCache( $result );
 
 		return $result;
 	}
@@ -484,7 +495,7 @@ class SMWSQLStore3Readers {
 
 		// apply options to overall result
 		$result = $this->store->applyRequestOptions( $result, $requestOptions );
-
+		$this->store->smwIds->warmUpCache( $result );
 
 		return $result;
 	}
@@ -570,6 +581,7 @@ class SMWSQLStore3Readers {
 		}
 
 		$result = $this->store->applyRequestOptions( $result, $requestOptions ); // apply options to overall result
+		$this->store->smwIds->warmUpCache( $result );
 
 		return $result;
 	}

--- a/src/MediaWiki/Hooks/HookRegistry.php
+++ b/src/MediaWiki/Hooks/HookRegistry.php
@@ -998,6 +998,8 @@ class HookRegistry {
 
 			$applicationFactory->singleton( 'CachedQueryResultPrefetcher' )->recordStats();
 
+			$store->getObjectIds()->warmUpCache( $result );
+
 			return true;
 		};
 

--- a/src/SQLStore/TableBuilder/FieldType.php
+++ b/src/SQLStore/TableBuilder/FieldType.php
@@ -30,6 +30,11 @@ class FieldType {
 	/**
 	 * @var string
 	 */
+	const FIELD_HASH = 'hash';
+
+	/**
+	 * @var string
+	 */
 	const FIELD_NAMESPACE = 'namespace';
 
 	/**

--- a/src/SQLStore/TableBuilder/MySQLTableBuilder.php
+++ b/src/SQLStore/TableBuilder/MySQLTableBuilder.php
@@ -34,6 +34,7 @@ class MySQLTableBuilder extends TableBuilder {
 			 // like iw_prefix in MW interwiki table
 			'interwiki'  => 'VARBINARY(32)',
 			'iw'         => 'VARBINARY(32)',
+			'hash'       => 'VARBINARY(40)',
 			 // larger blobs of character data, usually not subject to SELECT conditions
 			'blob'       => 'MEDIUMBLOB',
 			'text'       => 'TEXT',

--- a/src/SQLStore/TableBuilder/PostgresTableBuilder.php
+++ b/src/SQLStore/TableBuilder/PostgresTableBuilder.php
@@ -34,6 +34,7 @@ class PostgresTableBuilder extends TableBuilder {
 			 // like iw_prefix in MW interwiki table
 			'interwiki'  => 'TEXT',
 			'iw'         => 'TEXT',
+			'hash'       => 'TEXT',
 			 // larger blobs of character data, usually not subject to SELECT conditions
 			'blob'       => 'BYTEA',
 			'text'       => 'TEXT',

--- a/src/SQLStore/TableBuilder/SQLiteTableBuilder.php
+++ b/src/SQLStore/TableBuilder/SQLiteTableBuilder.php
@@ -33,6 +33,7 @@ class SQLiteTableBuilder extends TableBuilder {
 			 // like iw_prefix in MW interwiki table
 			'interwiki'  => 'TEXT',
 			'iw'         => 'TEXT',
+			'hash'       => 'VARBINARY(40)',
 			 // larger blobs of character data, usually not subject to SELECT conditions
 			'blob'       => 'MEDIUMBLOB',
 			'text'       => 'TEXT',

--- a/src/SQLStore/TableSchemaManager.php
+++ b/src/SQLStore/TableSchemaManager.php
@@ -156,9 +156,12 @@ class TableSchemaManager {
 
 		$table->addColumn( 'smw_sort', array( FieldType::FIELD_TITLE ) );
 		$table->addColumn( 'smw_proptable_hash', FieldType::TYPE_BLOB );
+		$table->addColumn( 'smw_hash', FieldType::FIELD_HASH );
 
 		$table->addIndex( 'smw_id' );
 		$table->addIndex( 'smw_id,smw_sortkey' );
+		$table->addIndex( 'smw_hash,smw_id' );
+
 		// IW match lookup
 		$table->addIndex( 'smw_iw' );
 		$table->addIndex( 'smw_iw,smw_id' );

--- a/tests/phpunit/Unit/MediaWiki/Hooks/HookRegistryTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Hooks/HookRegistryTest.php
@@ -1401,6 +1401,19 @@ class HookRegistryTest extends \PHPUnit_Framework_TestCase {
 
 		$handler = 'SMW::Store::AfterQueryResultLookupComplete';
 
+		$idTableLookup = $this->getMockBuilder( '\stdClass' )
+			->setMethods( [ 'warmUpCache' ] )
+			->getMock();
+
+		$store = $this->getMockBuilder( '\SMW\SQLStore\SQLStore' )
+			->disableOriginalConstructor()
+			->setMethods( [ 'getObjectIds', 'getPropertyValues' ] )
+			->getMock();
+
+		$store->expects( $this->any() )
+			->method( 'getObjectIds' )
+			->will( $this->returnValue( $idTableLookup ) );
+
 		$result = '';
 
 		$this->assertTrue(
@@ -1409,7 +1422,7 @@ class HookRegistryTest extends \PHPUnit_Framework_TestCase {
 
 		$this->assertThatHookIsExcutable(
 			$instance->getHandlerFor( $handler ),
-			array( $this->store, &$result )
+			array( $store, &$result )
 		);
 
 		$this->handlers[$handler] = true;

--- a/tests/phpunit/Unit/SPARQLStore/SPARQLStoreTest.php
+++ b/tests/phpunit/Unit/SPARQLStore/SPARQLStoreTest.php
@@ -260,9 +260,18 @@ class SPARQLStoreTest extends \PHPUnit_Framework_TestCase {
 			->method( 'getDescription' )
 			->will( $this->returnValue( $description ) );
 
-		$store = $this->getMockBuilder( '\SMW\Store' )
+		$idLookup = $this->getMockBuilder( '\stdClass' )
 			->disableOriginalConstructor()
-			->getMockForAbstractClass();
+			->setMethods( [ 'warmUpCache' ] )
+			->getMock();
+
+		$store = $this->getMockBuilder( '\SMW\SQLStore\SQLStore' )
+			->setMethods( array( 'getObjectIds' ) )
+			->getMock();
+
+		$store->expects( $this->any() )
+			->method( 'getObjectIds' )
+			->will( $this->returnValue( $idLookup ) );
 
 		$repositoryClient = $this->getMockBuilder( '\SMW\SPARQLStore\RepositoryClient' )
 			->disableOriginalConstructor()

--- a/tests/phpunit/Unit/SQLStore/TableIntegrityExaminerTest.php
+++ b/tests/phpunit/Unit/SQLStore/TableIntegrityExaminerTest.php
@@ -37,8 +37,12 @@ class TableIntegrityExaminerTest extends \PHPUnit_Framework_TestCase {
 
 	public function testCheckOnPostCreationOnValidProperty() {
 
-		$row = new \stdClass;
-		$row->smw_id = 42;
+		$row = [
+			'smw_id' => 42,
+			'smw_iw' => '',
+			'smw_proptable_hash' => '',
+			'smw_hash' => ''
+		];
 
 		$idTable = $this->getMockBuilder( '\stdClass' )
 			->setMethods( array( 'getPropertyInterwiki', 'moveSMWPageID', 'getPropertyTableHashes' ) )
@@ -54,7 +58,7 @@ class TableIntegrityExaminerTest extends \PHPUnit_Framework_TestCase {
 
 		$connection->expects( $this->atLeastOnce() )
 			->method( 'selectRow' )
-			->will( $this->returnValue( $row ) );
+			->will( $this->returnValue( (object)$row ) );
 
 		$connection->expects( $this->atLeastOnce() )
 			->method( 'replace' );


### PR DESCRIPTION
This PR is made in reference to: #

This PR addresses or contains:

- Adds a `smw_hash` field to the `smw_objects_ids` table to contain a sha1 hash which is composed of title, namespace, iw, and the subobject identifier.
- Objective is to reduce queries required to match IDs for entities during a `webrequest` by collecting the sha1 hash and run a collective `WHERE IN` query before any access happens to find an ID. The warm up reduces the amount of queries necessary for finding entity IDs and may only marginal improve the lookup performance. 
- Requires to run `update.php` or `setupStore.php`. In case the `smw_hash` is `NULL`, the installer will compute and update the field during the setup.

For example, run one query instead of 7 individual ones.

```
SELECT smw_id,smw_title,smw_namespace,smw_iw,smw_subobject,smw_sortkey,smw_sort
FROM `smw_object_ids`
WHERE smw_hash IN (
'eac3684cbe0a08de88176820b2231f4a51de287f',
'670186d9da6d1f44ac46cedf92668143eb9d8b1a',
'17ad580112fdc0835b2b7d2494bf3ee0247b8807',
'68c3a3f3fbd9c847efa5f716a85193e414e31172',
'20b13a83a8986fabe4bccc84886e8c2ace31d302',
'aaf522f8c6262e768bcac3bd28be4ecf07a7c6b4',
'4db87b67e34bba23b746fe6595274567736f39c2')

1.5681ms | SMWSql3SmwIds::warmUpCache
```

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed

Fixes #