### PR TITLE
Don't use ParserOptions::setEditSection() for MW 1.31+

### DIFF
--- a/includes/queryprinters/FeedResultPrinter.php
+++ b/includes/queryprinters/FeedResultPrinter.php
@@ -221,8 +221,13 @@ final class FeedResultPrinter extends FileExportPrinter {
 	 */
 	protected function getPageContent( WikiPage $wikiPage ) {
 		if ( in_array( $this->params['page'], array( 'abstract', 'full' ) ) ) {
+
 			$parserOptions = new ParserOptions();
-			$parserOptions->setEditSection( false );
+
+			// FIXME: Remove the if block once compatibility with MW <1.31 is dropped
+			if ( ! defined( '\ParserOutput::SUPPORTS_STATELESS_TRANSFORMS' ) || \ParserOutput::SUPPORTS_STATELESS_TRANSFORMS !== 1 ) {
+				$parserOptions->setEditSection( false );
+			}
 
 			if ( $this->params['page'] === 'abstract' ) {
 				// Abstract of the first 30 words
@@ -241,7 +246,7 @@ final class FeedResultPrinter extends FileExportPrinter {
 					$text = $wikiPage->getText();
 				}
 			}
-			return $GLOBALS['wgParser']->parse( $text, $wikiPage->getTitle(), $parserOptions )->getText();
+			return $GLOBALS['wgParser']->parse( $text, $wikiPage->getTitle(), $parserOptions )->getText( [ 'enableSectionEditLinks' => false ] );
 		} else {
 			return '';
 		}

--- a/src/Parser/RecursiveTextProcessor.php
+++ b/src/Parser/RecursiveTextProcessor.php
@@ -309,14 +309,18 @@ class RecursiveTextProcessor {
 			}
 
 			$popt = new ParserOptions();
-			$popt->setEditSection( false );
+
+			// FIXME: Remove the if block once compatibility with MW <1.31 is dropped
+			if ( ! defined( '\ParserOutput::SUPPORTS_STATELESS_TRANSFORMS' ) || \ParserOutput::SUPPORTS_STATELESS_TRANSFORMS !== 1 ) {
+				$popt->setEditSection( false );
+			}
 			$parserOutput = $this->parser->parse( $text . '__NOTOC__', $title, $popt );
 
 			// Maybe better to use Parser::recursiveTagParseFully ??
 
 			/// NOTE: as of MW 1.14SVN, there is apparently no better way to hide the TOC
 			\SMWOutputs::requireFromParserOutput( $parserOutput );
-			$text = $parserOutput->getText();
+			$text = $parserOutput->getText( [ 'enableSectionEditLinks' => false ] );
 		} else {
 			$this->error = [ 'smw-parser-recursion-level-exceeded', $this->maxRecursionDepth ];
 			$text = '';


### PR DESCRIPTION
This PR is made in reference to: Deprecation of `ParserOptions::setEditSection()`
* [RELEASE-NOTES-1.31](https://github.com/wikimedia/mediawiki/blob/92cf49df5ca0c5dea25f5ae651996d79a2ce25af/RELEASE-NOTES-1.31#L124)
* https://github.com/wikimedia/mediawiki/commit/2791fb08619545b12e58dd576ee6a98c38082c64

This PR addresses or contains:
- Wrap the call of `ParserOptions::setEditSection()` in an if block checking `ParserOutput::SUPPORTS_STATELESS_TRANSFORMS`
- Add the equivalent options array as parameter to the call of `ParserOutput::getText()`

This PR includes:
- [ ] Tests (unit/integration)
- [x] CI build passed

Fixes: #3012