### PR TITLE
Don't use ParserOptions::setEditSection for MW 1.31+ (Backport to 2.5.x); Fix CI scripts

### DIFF
--- a/includes/queryprinters/FeedResultPrinter.php
+++ b/includes/queryprinters/FeedResultPrinter.php
@@ -222,7 +222,12 @@ final class FeedResultPrinter extends FileExportPrinter {
 	protected function getPageContent( WikiPage $wikiPage ) {
 		if ( in_array( $this->params['page'], array( 'abstract', 'full' ) ) ) {
 			$parserOptions = new ParserOptions();
-			$parserOptions->setEditSection( false );
+
+			// FIXME: Remove the if block once compatibility with MW <1.31 is dropped
+			if ( !defined( '\ParserOutput::SUPPORTS_STATELESS_TRANSFORMS' ) || \ParserOutput::SUPPORTS_STATELESS_TRANSFORMS !== 1 ) {
+				$parserOptions->setEditSection( false );
+
+			}
 
 			if ( $this->params['page'] === 'abstract' ) {
 				// Abstract of the first 30 words
@@ -241,7 +246,7 @@ final class FeedResultPrinter extends FileExportPrinter {
 					$text = $wikiPage->getText();
 				}
 			}
-			return $GLOBALS['wgParser']->parse( $text, $wikiPage->getTitle(), $parserOptions )->getText();
+			return $GLOBALS['wgParser']->parse( $text, $wikiPage->getTitle(), $parserOptions )->getText( [ 'enableSectionEditLinks' => false ] );
 		} else {
 			return '';
 		}

--- a/includes/queryprinters/ResultPrinter.php
+++ b/includes/queryprinters/ResultPrinter.php
@@ -344,12 +344,18 @@ abstract class ResultPrinter extends \ContextSource implements QueryResultPrinte
 					global $wgTitle;
 
 					$popt = new ParserOptions();
-					$popt->setEditSection( false );
+
+					// FIXME: Remove the if block once compatibility with MW <1.31 is dropped
+					if ( !defined( '\ParserOutput::SUPPORTS_STATELESS_TRANSFORMS' ) || \ParserOutput::SUPPORTS_STATELESS_TRANSFORMS !== 1 ) {
+						$popt->setEditSection( false );
+
+					}
+
 					$pout = $wgParser->parse( $result . '__NOTOC__', $wgTitle, $popt );
 
 					/// NOTE: as of MW 1.14SVN, there is apparently no better way to hide the TOC
 					\SMWOutputs::requireFromParserOutput( $pout );
-					$result = $pout->getText();
+					$result = $pout->getText( [ 'enableSectionEditLinks' => false ] );
 				}
 			} else {
 				$result = ''; /// TODO: explain problem (too much recursive parses)

--- a/tests/travis/install-services.sh
+++ b/tests/travis/install-services.sh
@@ -22,11 +22,11 @@ then
 	then
 
 		# Fuseki requires Java8 for Fuseki2 v2.3.0 onwards
-		sudo apt-get install oracle-java8-installer
+		#sudo apt-get install oracle-java8-installer
 
-		export JAVA_HOME="/usr/lib/jvm/java-8-oracle";
-		export PATH="$PATH:/usr/lib/jvm/java-8-oracle/bin";
-		export java_path="/usr/lib/jvm/java-8-oracle/jre/bin/java";
+		#export JAVA_HOME="/usr/lib/jvm/java-8-oracle";
+		#export PATH="$PATH:/usr/lib/jvm/java-8-oracle/bin";
+		#export java_path="/usr/lib/jvm/java-8-oracle/jre/bin/java";
 
 		wget https://github.com/mwjames/travis-support/raw/master/fuseki/$FUSEKI/apache-jena-fuseki-$FUSEKI.tar.gz
 


### PR DESCRIPTION
This PR is made in reference to: Deprecation of `ParserOptions::setEditSection()`
* [RELEASE-NOTES-1.31](https://github.com/wikimedia/mediawiki/blob/92cf49df5ca0c5dea25f5ae651996d79a2ce25af/RELEASE-NOTES-1.31#L124)
* https://github.com/wikimedia/mediawiki/commit/2791fb08619545b12e58dd576ee6a98c38082c64

This PR addresses or contains:
- Wrap the call of `ParserOptions::setEditSection()` in an if block checking `ParserOutput::SUPPORTS_STATELESS_TRANSFORMS`
- Add the equivalent options array as parameter to the call of `ParserOutput::getText()`
- Remove Java download from Travis CI scripts

This PR includes:
- [ ] Tests (unit/integration)
- [ ] CI build passed

Fixes: #3012