### PR TITLE
Use canonical label

### DIFF
--- a/src/SQLStore/EntityRebuildDispatcher.php
+++ b/src/SQLStore/EntityRebuildDispatcher.php
@@ -302,7 +302,7 @@ class EntityRebuildDispatcher {
 			if ( $row->smw_title != '' && $row->smw_title{0} != '_' ) {
 				$titleKey = $row->smw_title;
 			} elseif ( $row->smw_namespace == SMW_NS_PROPERTY && $row->smw_iw == '' && $row->smw_subobject == '' ) {
-				$titleKey = str_replace( ' ', '_', PropertyRegistry::getInstance()->findPropertyLabelById( $row->smw_title ) );
+				$titleKey = str_replace( ' ', '_', PropertyRegistry::getInstance()->findCanonicalPropertyLabelById( $row->smw_title ) );
 			} else {
 				$titleKey = '';
 			}

--- a/src/SQLStore/TableIntegrityExaminer.php
+++ b/src/SQLStore/TableIntegrityExaminer.php
@@ -256,46 +256,50 @@ class TableIntegrityExaminer implements MessageReporterAware {
 			if ( $row !== false ) {
 				$id = $row->smw_id;
 			}
-		} else {
-			$label = $property->getCanonicalLabel();
-
-			$iw = $this->store->getObjectIds()->getPropertyInterwiki(
-				$property
-			);
-
-			$row = $connection->selectRow(
-				SQLStore::ID_TABLE,
-				[
-					'smw_proptable_hash',
-					'smw_hash'
-				],
-				[
-					'smw_id' => $id
-				],
-				__METHOD__
-			);
-
-			if ( $row === false ) {
-				$row = (object)[ 'smw_proptable_hash' => null, 'smw_hash' => null ];
-			}
-
-			$connection->replace(
-				SQLStore::ID_TABLE,
-				[ 'smw_id' ],
-				[
-					'smw_id' => $id,
-					'smw_title' => $property->getKey(),
-					'smw_namespace' => SMW_NS_PROPERTY,
-					'smw_iw' =>  $iw,
-					'smw_subobject' => '',
-					'smw_sortkey' => $label,
-					'smw_sort' => Collator::singleton()->getSortKey( $label ),
-					'smw_proptable_hash' => $row->smw_proptable_hash,
-					'smw_hash' => $row->smw_hash
-				],
-				__METHOD__
-			);
 		}
+
+		if ( $id === null ) {
+			return;
+		}
+
+		$label = $property->getCanonicalLabel();
+
+		$iw = $this->store->getObjectIds()->getPropertyInterwiki(
+			$property
+		);
+
+		$row = $connection->selectRow(
+			SQLStore::ID_TABLE,
+			[
+				'smw_proptable_hash',
+				'smw_hash'
+			],
+			[
+				'smw_id' => $id
+			],
+			__METHOD__
+		);
+
+		if ( $row === false ) {
+			$row = (object)[ 'smw_proptable_hash' => null, 'smw_hash' => null ];
+		}
+
+		$connection->replace(
+			SQLStore::ID_TABLE,
+			[ 'smw_id' ],
+			[
+				'smw_id' => $id,
+				'smw_title' => $property->getKey(),
+				'smw_namespace' => SMW_NS_PROPERTY,
+				'smw_iw' =>  $iw,
+				'smw_subobject' => '',
+				'smw_sortkey' => $label,
+				'smw_sort' => Collator::singleton()->getSortKey( $label ),
+				'smw_proptable_hash' => $row->smw_proptable_hash,
+				'smw_hash' => $row->smw_hash
+			],
+			__METHOD__
+		);
 
 		if ( $id === null ) {
 			return;

--- a/tests/phpunit/Unit/SQLStore/TableIntegrityExaminerTest.php
+++ b/tests/phpunit/Unit/SQLStore/TableIntegrityExaminerTest.php
@@ -97,11 +97,15 @@ class TableIntegrityExaminerTest extends \PHPUnit_Framework_TestCase {
 
 	public function testCheckOnPostCreationOnValidProperty_NotFixed() {
 
-		$row = new \stdClass;
-		$row->smw_id = 42;
+		$row = [
+			'smw_id' => 42,
+			'smw_iw' => '',
+			'smw_proptable_hash' => '',
+			'smw_hash' => ''
+		];
 
 		$idTable = $this->getMockBuilder( '\stdClass' )
-			->setMethods( array( 'moveSMWPageID' ) )
+			->setMethods( array( 'moveSMWPageID', 'getPropertyInterwiki' ) )
 			->getMock();
 
 		$connection = $this->getMockBuilder( '\SMW\MediaWiki\Database' )
@@ -117,11 +121,11 @@ class TableIntegrityExaminerTest extends \PHPUnit_Framework_TestCase {
 					'smw_title' => 'Foo',
 					'smw_namespace' => SMW_NS_PROPERTY,
 					'smw_subobject' => '' ] ) )
-			->will( $this->returnValue( $row ) );
+			->will( $this->returnValue( (object)$row ) );
 
 		$connection->expects( $this->at( 3 ) )
 			->method( 'selectRow' )
-			->will( $this->returnValue( $row ) );
+			->will( $this->returnValue( (object)$row ) );
 
 		$store = $this->getMockBuilder( '\SMW\SQLStore\SQLStore' )
 			->disableOriginalConstructor()


### PR DESCRIPTION
This PR is made in reference to: #

This PR addresses or contains:

- Use the canonical label when rebuilding the data so that predefined properties are content language agnostic.

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed
