### PR TITLE
Add upgrade check

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,7 +8,7 @@ build/release/build-*
 
 composer.phar
 composer.lock
-.smw.json
 
 !.*
 .idea/
+.smw.json

--- a/DefaultSettings.php
+++ b/DefaultSettings.php
@@ -63,6 +63,24 @@ return array(
 	##
 
 	###
+	# Upgrade key
+	#
+	# This key verifies that a correct upgrade (update.php/setupStore.php) path
+	# was selected and hereby ensures a consistent DB setup.
+	#
+	# Whenever a DB table change occurs, modify the key value (e.g. `DB-Foo...`)
+	# to reflect the requirement for the client to follow the processes as
+	# outlined in the installation manual.
+	#
+	# Once the installer is run, the `.smw.json` will be updated and no longer
+	# causes an exception.
+	#
+	# @since 3.0
+	##
+	'smwgUpgradeKey' => 'DB-2018-03',
+	##
+
+	###
 	# CompatibilityMode is to force SMW to work with other extensions that may impact
 	# performance in an unanticipated way or may contain potential incompatibilities.
 	#
@@ -934,7 +952,7 @@ return array(
 
 	###
 	# Sets whether or not to refresh the pages of which semantic data is stored.
-	# 
+	#
 	# @since 1.5.6
 	##
 	'smwgAutoRefreshSubject' => true,

--- a/SemanticMediaWiki.php
+++ b/SemanticMediaWiki.php
@@ -54,6 +54,13 @@ class SemanticMediaWiki {
 				$GLOBALS[$key] = $value;
 			}
 		}
+
+		if ( is_readable( __DIR__ . '/.smw.json' ) ) {
+			$GLOBALS['smw.json'] = json_decode(
+				file_get_contents( __DIR__ . '/.smw.json' ),
+				true
+			);
+		}
 	}
 
 	/**

--- a/includes/Settings.php
+++ b/includes/Settings.php
@@ -51,6 +51,7 @@ class Settings extends Options {
 			'smwgImportFileDirs' => $GLOBALS['smwgImportFileDirs'],
 			'smwgImportReqVersion' => $GLOBALS['smwgImportReqVersion'],
 			'smwgSemanticsEnabled' => $GLOBALS['smwgSemanticsEnabled'],
+			'smwgUpgradeKey' => $GLOBALS['smwgUpgradeKey'],
 			'smwgJobQueueWatchlist' => $GLOBALS['smwgJobQueueWatchlist'],
 			'smwgEnabledCompatibilityMode' => $GLOBALS['smwgEnabledCompatibilityMode'],
 			'smwgDefaultStore' => $GLOBALS['smwgDefaultStore'],

--- a/includes/Setup.php
+++ b/includes/Setup.php
@@ -4,6 +4,7 @@ namespace SMW;
 
 use SMW\MediaWiki\Hooks\HookRegistry;
 use SMW\Connection\ConnectionManager;
+use SMW\SQLStore\Installer;
 use Hooks;
 
 /**
@@ -150,12 +151,34 @@ final class Setup {
 	}
 
 	/**
+	 * @since 3.0
+	 */
+	public static function isEnabled() {
+		return defined( 'SMW_VERSION' ) && $GLOBALS['smwgSemanticsEnabled'];
+	}
+
+	/**
+	 * @since 3.0
+	 */
+	public static function hasUpgradeKey( $isCli = false ) {
+		return Installer::hasUpgradeKey( $isCli );
+	}
+
+	/**
 	 * @since 1.9
 	 *
 	 * @param array &$vars
 	 * @param string $directory
 	 */
 	public function init( &$vars, $directory ) {
+
+		if ( $this->hasUpgradeKey() === false ) {
+			die(
+				'<b>Error:</b> Semantic MediaWiki was installed and enabled but is missing an appropriate ' .
+				'<a href="https://www.semantic-mediawiki.org/wiki/Help:Upgrade">upgrade key</a>. ' .
+				'Please run the `update.php` or <a href="https://www.semantic-mediawiki.org/wiki/Help:SetupStore.php">setupStore.php</a> script first.'
+			);
+		}
 
 		$this->addDefaultConfigurations( $vars );
 

--- a/maintenance/rebuildData.php
+++ b/maintenance/rebuildData.php
@@ -5,6 +5,7 @@ namespace SMW\Maintenance;
 use SMW\ApplicationFactory;
 use SMW\StoreFactory;
 use SMW\Store;
+use SMW\Setup;
 use SMW\Options;
 
 $basePath = getenv( 'MW_INSTALL_PATH' ) !== false ? getenv( 'MW_INSTALL_PATH' ) : __DIR__ . '/../../..';
@@ -116,8 +117,13 @@ class RebuildData extends \Maintenance {
 	 */
 	public function execute() {
 
-		if ( !defined( 'SMW_VERSION' ) || !$GLOBALS['smwgSemanticsEnabled'] ) {
+		if ( !Setup::isEnabled() ) {
 			$this->reportMessage( "\nYou need to have SMW enabled in order to run the maintenance script!\n" );
+			return false;
+		}
+
+		if ( !Setup::hasUpgradeKey( true ) ) {
+			$this->reportMessage( "\nYou need to run `update.php` or `setupStore.php` first!\n" );
 			return false;
 		}
 

--- a/tests/phpunit/Unit/SQLStore/InstallerTest.php
+++ b/tests/phpunit/Unit/SQLStore/InstallerTest.php
@@ -212,4 +212,41 @@ class InstallerTest extends \PHPUnit_Framework_TestCase {
 		);
 	}
 
+	public function testHasUpgradeKey() {
+
+		$instance = new Installer(
+			$this->tableSchemaManager,
+			$this->tableBuilder,
+			$this->tableIntegrityExaminer
+		);
+
+		$this->assertInternalType(
+			'boolean',
+			$instance->hasUpgradeKey()
+		);
+	}
+
+	public function testSetUpgradeKey() {
+
+		$file = $this->getMockBuilder( '\SMW\Utils\File' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$file->expects( $this->once() )
+			->method( 'write' );
+
+		$instance = new Installer(
+			$this->tableSchemaManager,
+			$this->tableBuilder,
+			$this->tableIntegrityExaminer
+		);
+
+		$vars = [
+			'smwgIP' => '',
+			'smwgUpgradeKey' => ''
+		];
+
+		$instance->setUpgradeKey( $file, $vars );
+	}
+
 }


### PR DESCRIPTION
This PR is made in reference to: #

This PR addresses or contains:

- Whenever we change the DB schema (new field, altered index etc.) we need to ensure that users do actually run `update.php` or `setupStore.php` and in order to do that we introduce `smwgUpgradeKey` which contains an arbitrary identifier that is used to validate the status by comparing the local result of `.smw.json` against the upgrade key.
- If `.smw.json` doesn't exists or contains an invalid key then the system stops before it can access any data or tables and shows a message to the user such as: "Error: The Semantic MediaWiki extension was enabled but the installation is incomplete ...".

This PR includes:
- [ ] Tests (unit/integration)
- [x] CI build passed

Fixes #