### PR TITLE
SMWSearch, display section title (subobject)

### DIFF
--- a/src/MediaWiki/Search/SearchResult.php
+++ b/src/MediaWiki/Search/SearchResult.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace SMW\MediaWiki\Search;
+
+/**
+ * @ingroup SMW
+ *
+ * @license GNU GPL v2+
+ * @since 3.0
+ *
+ * @author mwjames
+ */
+class SearchResult extends \SearchResult {
+
+	/**
+	 * @see SearchResult::getSectionTitle
+	 */
+	function getSectionTitle() {
+
+		if ( !isset( $this->mTitle ) || $this->mTitle->getFragment() === '' ) {
+			return null;
+		}
+
+		return $this->mTitle;
+	}
+
+}

--- a/src/MediaWiki/Search/SearchResultSet.php
+++ b/src/MediaWiki/Search/SearchResultSet.php
@@ -2,7 +2,6 @@
 
 namespace SMW\MediaWiki\Search;
 
-use SearchResult;
 use SMW\DIWikiPage;
 
 /**

--- a/tests/phpunit/Unit/MediaWiki/Search/SearchResultSetTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Search/SearchResultSetTest.php
@@ -5,7 +5,7 @@ namespace SMW\Tests\MediaWiki\Search;
 use SMW\MediaWiki\Search\SearchResultSet;
 
 /**
- * @covers  \SMW\MediaWiki\Search\SearchResultSet
+ * @covers \SMW\MediaWiki\Search\SearchResultSet
  * @group semantic-mediawiki
  *
  * @license GNU GPL v2+

--- a/tests/phpunit/Unit/MediaWiki/Search/SearchResultTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Search/SearchResultTest.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace SMW\Tests\MediaWiki\Search;
+
+use SMW\MediaWiki\Search\SearchResult;
+
+/**
+ * @covers \SMW\MediaWiki\Search\SearchResult
+ * @group semantic-mediawiki
+ *
+ * @license GNU GPL v2+
+ * @since 3.0
+ *
+ * @author mwjames
+ */
+class SearchResultTest extends \PHPUnit_Framework_TestCase {
+
+	public function testGetSectionTitle_WithFragment() {
+
+		$title = $this->getMockBuilder( '\Title' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$title->expects( $this->any() )
+			->method( 'getFragment' )
+			->will( $this->returnValue( 'Foo' ) );
+
+		$instance = SearchResult::newFromTitle( $title );
+
+		$this->assertInstanceOf(
+			'\Title',
+			$instance->getSectionTitle()
+		);
+	}
+
+	public function testGetSectionTitle_WithoutFragment() {
+
+		$title = $this->getMockBuilder( '\Title' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$title->expects( $this->any() )
+			->method( 'getFragment' )
+			->will( $this->returnValue( '' ) );
+
+		$instance = SearchResult::newFromTitle( $title );
+
+		$this->assertNull(
+			$instance->getSectionTitle()
+		);
+	}
+
+}


### PR DESCRIPTION
This PR is made in reference to: #

This PR addresses or contains:

- Show the section title in case SMWSearch matches a subobject to indicate different entities
- This method is selected instead of trying to manipulate the result count to distinguish a page from a page with fragment

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed

![image](https://user-images.githubusercontent.com/1245473/38165713-3e81a8c6-3507-11e8-9eb1-859edaa0baf2.png)
