### PR TITLE
Block::getTarget can return User|string, refs 3094

### DIFF
--- a/src/MediaWiki/Hooks/UserChange.php
+++ b/src/MediaWiki/Hooks/UserChange.php
@@ -6,6 +6,7 @@ use SMW\NamespaceExaminer;
 use SMW\ApplicationFactory;
 use SMW\MediaWiki\Jobs\UpdateJob;
 use Title;
+use User;
 
 /**
  * @see https://www.mediawiki.org/wiki/Manual:Hooks/BlockIpComplete
@@ -54,12 +55,16 @@ class UserChange extends HookHandler {
 	/**
 	 * @since 3.0
 	 *
-	 * @param string $user
+	 * @param User|string $user
 	 */
 	public function process( $user ) {
 
 		if ( !$this->namespaceExaminer->isSemanticEnabled( NS_USER ) ) {
 			return false;
+		}
+
+		if ( $user instanceof User ) {
+			$user = $user->getName();
 		}
 
 		$updateJob = ApplicationFactory::getInstance()->newJobFactory()->newUpdateJob(

--- a/tests/phpunit/Unit/MediaWiki/Hooks/UserChangeTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Hooks/UserChangeTest.php
@@ -75,6 +75,40 @@ class UserChangeTest extends \PHPUnit_Framework_TestCase {
 		);
 	}
 
+	public function testOnEnabledUserNamespace_User() {
+
+		$user = $this->getMockBuilder( '\User' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$user->expects( $this->once() )
+			->method( 'getName' )
+			->will( $this->returnValue( 'Foo' ) );
+
+		$job = $this->getMockBuilder( '\SMW\MediaWiki\Jobs\UpdateJob' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$this->jobFactory->expects( $this->once() )
+			->method( 'newUpdateJob' )
+			->will( $this->returnValue( $job ) );
+
+		$this->namespaceExaminer->expects( $this->any() )
+			->method( 'isSemanticEnabled' )
+			->with( $this->equalTo( NS_USER ) )
+			->will( $this->returnValue( true ) );
+
+		$instance = new UserChange(
+			$this->namespaceExaminer
+		);
+
+		$instance->setOrigin( 'Foo' );
+
+		$this->assertTrue(
+			$instance->process( $user )
+		);
+	}
+
 	public function testOnDisabledUserNamespace() {
 
 		$this->jobFactory->expects( $this->never() )


### PR DESCRIPTION
This PR is made in reference to: #3094

This PR addresses or contains:

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed

Fixes #3094