### PR TITLE
Account for changes to fixed tables, refs 3095

### DIFF
--- a/tests/phpunit/Unit/SQLStore/InstallerTest.php
+++ b/tests/phpunit/Unit/SQLStore/InstallerTest.php
@@ -226,6 +226,26 @@ class InstallerTest extends \PHPUnit_Framework_TestCase {
 		);
 	}
 
+	public function testGetUpgradeKey() {
+
+		$var1 = [
+			'smwgUpgradeKey' => '',
+			'smwgFixedProperties' => [ 'Foo', 'Bar' ],
+			'smwgPageSpecialProperties' => [ 'Foo', 'Bar' ]
+		];
+
+		$var2 = [
+			'smwgUpgradeKey' => '',
+			'smwgFixedProperties' => [ 'Bar', 'Foo' ],
+			'smwgPageSpecialProperties' => [ 'Bar', 'Foo' ]
+		];
+
+		$this->assertEquals(
+			Installer::getUpgradeKey( $var1 ),
+			Installer::getUpgradeKey( $var2 )
+		);
+	}
+
 	public function testSetUpgradeKey() {
 
 		$file = $this->getMockBuilder( '\SMW\Utils\File' )
@@ -243,7 +263,9 @@ class InstallerTest extends \PHPUnit_Framework_TestCase {
 
 		$vars = [
 			'smwgIP' => '',
-			'smwgUpgradeKey' => ''
+			'smwgUpgradeKey' => '',
+			'smwgFixedProperties' => [],
+			'smwgPageSpecialProperties' => []
 		];
 
 		$instance->setUpgradeKey( $file, $vars );


### PR DESCRIPTION
This PR is made in reference to: #3095

This PR addresses or contains:

- Content of `smwgFixedProperties` and `smwgPageSpecialProperties` influence the shape of the DB therefore use it to compute the upgrade key

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed
