### PR TITLE
Move date/time parsing to TimeValueParser

### DIFF
--- a/src/DataValues/Time/Components.php
+++ b/src/DataValues/Time/Components.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace SMW\DataValues\Time;
+
+/**
+ * @private
+ *
+ * @license GNU GPL v2+
+ * @since 3.0
+ *
+ * @author mwjames
+ */
+class Components {
+
+	/**
+	 * @var array
+	 */
+	public static $months = [
+		'January',
+		'February',
+		'March',
+		'April',
+		'May',
+		'June',
+		'July',
+		'August',
+		'September',
+		'October',
+		'November',
+		'December'
+	];
+
+	/**
+	 * @var array
+	 */
+	public static $monthsShort = [
+		'Jan',
+		'Feb',
+		'Mar',
+		'Apr',
+		'May',
+		'Jun',
+		'Jul',
+		'Aug',
+		'Sep',
+		'Oct',
+		'Nov',
+		'Dec'
+	];
+
+	/**
+	 * @var []
+	 */
+	private $components = [];
+
+	/**
+	 * @since 3.0
+	 *
+	 * @param array $components
+	 */
+	public function __construct( array $components = [] ) {
+		$this->components = $components;
+	}
+
+	/**
+	 * @since 3.0
+	 */
+	public function get( $key ) {
+
+		if ( isset( $this->components[$key] ) ) {
+			return $this->components[$key];
+		}
+
+		return false;
+	}
+
+}

--- a/src/DataValues/ValueParsers/TimeValueParser.php
+++ b/src/DataValues/ValueParsers/TimeValueParser.php
@@ -1,0 +1,369 @@
+<?php
+
+namespace SMW\DataValues\ValueParsers;
+
+use SMW\DataValues\Time\Timezone;
+use SMW\Localizer;
+use SMW\DataValues\Time\Components;
+
+/**
+ * @private
+ *
+ * @license GNU GPL v2+
+ * @since 3.0
+ *
+ * @author Markus Krötzsch
+ * @author Fabian Howahl
+ * @author Terry A. Hurlbut
+ * @author mwjames
+ */
+class TimeValueParser implements ValueParser {
+
+	/**
+	 * @var array
+	 */
+	private $errors = [];
+
+	/**
+	 * @var string
+	 */
+	private $userValue = '';
+
+	/**
+	 * @var array
+	 */
+	private $languageCode = 'en';
+
+	/**
+	 * @since 3.0
+	 *
+	 * @return array
+	 */
+	public function getErrors() {
+		return $this->errors;
+	}
+
+	/**
+	 * @since 3.0
+	 *
+	 * @param string $languageCode
+	 */
+	public function setLanguageCode( $languageCode ) {
+		$this->languageCode = $languageCode;
+	}
+
+	/**
+	 * @since 3.0
+	 */
+	public function clearErrors() {
+		$this->errors = [];
+	}
+
+	/**
+	 * @since 3.0
+	 *
+	 * @param string $userValue
+	 *
+	 * @return string|false
+	 */
+	public function parse( $userValue ) {
+
+		$this->errors = [];
+		$this->userValue = $userValue;
+
+		$datecomponents = [];
+		$calendarmodel = $era = $hours = $minutes = $seconds = $microseconds = $timeoffset = $timezone = false;
+
+ 		$status = $this->parseDateString(
+ 			$userValue,
+ 			$datecomponents,
+ 			$calendarmodel,
+ 			$era,
+ 			$hours,
+ 			$minutes,
+ 			$seconds,
+ 			$microseconds,
+ 			$timeoffset,
+ 			$timezone
+ 		);
+
+		 // Default to JD input if a single number was given as the date
+		if ( ( $calendarmodel === false ) && ( $era === false ) && ( count( $datecomponents ) == 1 || count( $datecomponents ) == 2 ) && ( intval( end( $datecomponents ) ) >= 100000 ) ) {
+			$calendarmodel = 'JD';
+		}
+
+		$components = new Components(
+			[
+				'value' => $userValue,
+				'datecomponents' => $datecomponents,
+				'calendarmodel' => $calendarmodel,
+				'era' => $era,
+				'hours' => $hours,
+				'minutes' => $minutes,
+				'seconds' => $seconds,
+				'microseconds' => $microseconds,
+				'timeoffset' => $timeoffset,
+				'timezone' => $timezone
+			]
+		);
+
+		return $status ? $components : false;
+	}
+
+	/**
+	 * Parse the given string to check if it a date/time value.
+	 * The function sets the provided call-by-ref values to the respective
+	 * values. If errors are encountered, they are added to the objects
+	 * error list and false is returned. Otherwise, true is returned.
+	 *
+	 * @todo This method in principle allows date parsing to be internationalized
+	 * further.
+	 *
+	 * @param $string string input time representation, e.g. "12 May 2007 13:45:23-3:30"
+	 * @param $datecomponents array of strings that might belong to the specification of a date
+	 * @param $calendarmodesl string if model was set in input, otherwise false
+	 * @param $era string '+' or '-' if provided, otherwise false
+	 * @param $hours integer set to a value between 0 and 24
+	 * @param $minutes integer set to a value between 0 and 59
+	 * @param $seconds integer set to a value between 0 and 59, or false if not given
+	 * @param $timeoffset double set to a value for time offset (e.g. 3.5), or false if not given
+	 *
+	 * @return boolean stating if the parsing succeeded
+	 */
+	private function parseDateString( $string, &$datecomponents, &$calendarmodel, &$era, &$hours, &$minutes, &$seconds, &$microseconds, &$timeoffset, &$timezone ) {
+
+		$calendarmodel = $timezoneoffset = $era = $ampm = false;
+		$hours = $minutes = $seconds = $microseconds = $timeoffset = $timezone = false;
+
+		// Fetch possible "America/Argentina/Mendoza"
+		$timzoneIdentifier = substr( $string, strrpos( $string, ' ' ) + 1 );
+
+		if ( Timezone::isValid( $timzoneIdentifier ) ) {
+			$string = str_replace( $timzoneIdentifier, '', $string );
+			$timezoneoffset = Timezone::getOffsetByAbbreviation( $timzoneIdentifier ) / 3600;
+			$timezone = Timezone::getIdByAbbreviation( $timzoneIdentifier );
+		}
+
+		// Preprocessing for supporting different date separation characters;
+		// * this does not allow localized time notations such as "10.34 pm"
+		// * this creates problems with keywords that contain "." such as "p.m."
+		// * yet "." is an essential date separation character in languages such as German
+		$parsevalue = str_replace( array( '/', '.', '&nbsp;', ',', '年', '月', '日', '時', '分' ), array( '-', ' ', ' ', ' ', ' ', ' ', ' ', ':', ' ' ), $string );
+
+		$matches = preg_split( "/([T]?[0-2]?[0-9]:[\:0-9]+[+\-]?[0-2]?[0-9\:]+|[\p{L}]+|[0-9]+|[ ])/u", $parsevalue, -1, PREG_SPLIT_DELIM_CAPTURE | PREG_SPLIT_NO_EMPTY );
+		$datecomponents = array();
+		$unclearparts = array();
+
+		 // Used for looking back; numbers are days/months/years by default but
+		 // may be re-interpreted if certain further symbols are found
+		$matchisnumber = false;
+
+		// Used for ensuring that date parts are in one block
+		$matchisdate = false;
+
+		foreach ( $matches as $match ) {
+			$prevmatchwasnumber = $matchisnumber;
+			$prevmatchwasdate   = $matchisdate;
+			$matchisnumber = $matchisdate = false;
+
+			if ( $match == ' ' ) {
+				$matchisdate = $prevmatchwasdate; // spaces in dates do not end the date
+			} elseif ( $match == '-' ) { // can only occur separately between date components
+				$datecomponents[] = $match; // we check later if this makes sense
+				$matchisdate = true;
+			} elseif ( is_numeric( $match ) &&
+			           ( $prevmatchwasdate || count( $datecomponents ) == 0 ) ) {
+				$datecomponents[] = $match;
+				$matchisnumber = true;
+				$matchisdate = true;
+			} elseif ( $era === false && in_array( $match, array( 'AD', 'CE' ) ) ) {
+				$era = '+';
+			} elseif ( $era === false && in_array( $match, array( 'BC', 'BCE' ) ) ) {
+				$era = '-';
+			} elseif ( $calendarmodel === false && in_array( $match, array( 'Gr', 'GR' , 'He', 'Jl', 'JL', 'MJD', 'JD', 'OS' ) ) ) {
+				$calendarmodel = $match;
+			} elseif ( $ampm === false && ( strtolower( $match ) === 'am' || strtolower( $match ) === 'pm' ) ) {
+				$ampm = strtolower( $match );
+			} elseif ( $hours === false && self::parseTimeString( $match, $hours, $minutes, $seconds, $timeoffset ) ) {
+				// nothing to do
+			} elseif ( $hours !== false && $timezoneoffset === false && Timezone::isValid( $match ) ) {
+				// only accept timezone if time has already been set
+				$timezoneoffset = Timezone::getOffsetByAbbreviation( $match ) / 3600;
+				$timezone = Timezone::getIdByAbbreviation( $match );
+			} elseif ( $prevmatchwasnumber && $hours === false && $timezoneoffset === false &&
+					Timezone::isMilitary( $match ) &&
+					self::parseMilTimeString( end( $datecomponents ), $hours, $minutes, $seconds ) ) {
+					// military timezone notation is found after a number -> re-interpret the number as military time
+					array_pop( $datecomponents );
+					$timezoneoffset = Timezone::getOffsetByAbbreviation( $match ) / 3600;
+					$timezone = Timezone::getIdByAbbreviation( $match );
+			} elseif ( ( $prevmatchwasdate || count( $datecomponents ) == 0 ) &&
+				   $this->parseMonthString( $match, $monthname ) ) {
+				$datecomponents[] = $monthname;
+				$matchisdate = true;
+			} elseif ( $prevmatchwasnumber && $prevmatchwasdate && in_array( $match, array( 'st', 'nd', 'rd', 'th' ) ) ) {
+				$datecomponents[] = 'd' . strval( array_pop( $datecomponents ) ); // must be a day; add standard marker
+				$matchisdate = true;
+			} elseif ( is_string( $match ) ) {
+				$microseconds = $match;
+			} else {
+				$unclearparts[] = $match;
+			}
+		}
+
+		// $this->debug( $datecomponents, $calendarmodel, $era, $hours, $minutes, $seconds, $microseconds, $timeoffset, $timezone );
+
+		// Abort if we found unclear or over-specific information:
+		if ( count( $unclearparts ) != 0 ) {
+			$this->errors[] = [ 'smw-datavalue-time-invalid-values', $this->userValue, implode( ', ', $unclearparts ) ];
+			return false;
+		}
+
+		if ( ( $timezoneoffset !== false && $timeoffset !== false ) ) {
+			$this->errors[] = [ 'smw-datavalue-time-invalid-offset-zone-usage', $this->userValue ];
+			return false;
+		}
+
+		if ( ( $timezoneoffset !== false && $timeoffset !== false ) ) {
+			$this->errors[] = [ 'smw-datavalue-time-invalid-offset-zone-usage', $this->userValue ];
+			return false;
+		}
+
+		$timeoffset = $timeoffset + $timezoneoffset;
+
+		// Check if the a.m. and p.m. information is meaningful
+		// Note: the == 0 check subsumes $hours===false
+		if ( $ampm !== false && ( $hours > 12 || $hours == 0 ) ) {
+			$this->errors[] = [ 'smw-datavalue-time-invalid-ampm', $this->userValue, $hours ];
+			return false;
+		} elseif ( $ampm == 'am' && $hours == 12 ) {
+			$hours = 0;
+		} elseif ( $ampm == 'pm' && $hours < 12 ) {
+			$hours += 12;
+		}
+
+		return true;
+	}
+
+	/**
+	 * Parse the given string to check if it encodes an international time.
+	 * If successful, the function sets the provided call-by-ref values to
+	 * the respective numbers and returns true. Otherwise, it returns
+	 * false and does not set any values.
+	 *
+	 * @param $string string input time representation, e.g. "13:45:23-3:30"
+	 * @param $hours integer between 0 and 24
+	 * @param $minutes integer between 0 and 59
+	 * @param $seconds integer between 0 and 59, or false if not given
+	 * @param $timeoffset double for time offset (e.g. 3.5), or false if not given
+	 *
+	 * @return boolean stating if the parsing succeeded
+	 */
+	private static function parseTimeString( $string, &$hours, &$minutes, &$seconds, &$timeoffset ) {
+
+		if ( !preg_match( "/^[T]?([0-2]?[0-9]):([0-5][0-9])(:[0-5][0-9])?(([+\-][0-2]?[0-9])(:(30|00))?)?$/u", $string, $match ) ) {
+			return false;
+		} else {
+			$nhours = intval( $match[1] );
+			$nminutes = $match[2] ? intval( $match[2] ) : false;
+
+			if ( ( count( $match ) > 3 ) && ( $match[3] !== '' ) ) {
+				$nseconds = intval( substr( $match[3], 1 ) );
+			} else {
+				$nseconds = false;
+			}
+
+			if ( ( $nhours < 25 ) && ( ( $nhours < 24 ) || ( $nminutes + $nseconds == 0 ) ) ) {
+				$hours = $nhours;
+				$minutes = $nminutes;
+				$seconds = $nseconds;
+				if ( ( count( $match ) > 5 ) && ( $match[5] !== '' ) ) {
+					$timeoffset = intval( $match[5] );
+					if ( ( count( $match ) > 7 ) && ( $match[7] == '30' ) ) {
+						$timeoffset += 0.5;
+					}
+				} else {
+					$timeoffset = false;
+				}
+
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	/**
+	 * Parse the given string to check if it encodes a "military time".
+	 * If successful, the function sets the provided call-by-ref values to
+	 * the respective numbers and returns true. Otherwise, it returns
+	 * false and does not set any values.
+	 *
+	 * @param $string string input time representation, e.g. "134523"
+	 * @param $hours integer between 0 and 24
+	 * @param $minutes integer between 0 and 59
+	 * @param $seconds integer between 0 and 59, or false if not given
+	 *
+	 * @return boolean stating if the parsing succeeded
+	 */
+	private static function parseMilTimeString( $string, &$hours, &$minutes, &$seconds ) {
+
+		if ( !preg_match( "/^([0-2][0-9])([0-5][0-9])([0-5][0-9])?$/u", $string, $match ) ) {
+			return false;
+		} else {
+			$nhours = intval( $match[1] );
+			$nminutes = $match[2] ? intval( $match[2] ) : false;
+			$nseconds = ( ( count( $match ) > 3 ) && $match[3] ) ? intval( $match[3] ) : false;
+
+			if ( ( $nhours < 25 ) && ( ( $nhours < 24 ) || ( $nminutes + $nseconds == 0 ) ) ) {
+				$hours = $nhours;
+				$minutes = $nminutes;
+				$seconds = $nseconds;
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	/**
+	 * Parse the given string to check if it refers to the string name ot
+	 * abbreviation of a month name. If yes, it is replaced by a normalized
+	 * month name (placed in the call-by-ref parameter) and true is
+	 * returned. Otherwise, false is returned and $monthname is not changed.
+	 *
+	 * @param $string string month name or abbreviation to parse
+	 * @param $monthname string with standard 3-letter English month abbreviation
+	 *
+	 * @return boolean stating whether a month was found
+	 */
+	private function parseMonthString( $string, &$monthname ) {
+
+		// takes precedence over English month names!
+		$monthnum = Localizer::getInstance()->getLang( $this->languageCode )->findMonthNumberByLabel( $string );
+
+		if ( $monthnum !== false ) {
+			$monthnum -= 1;
+		} else {
+			$monthnum = array_search( $string, Components::$months ); // check English names
+		}
+
+		if ( $monthnum !== false ) {
+			$monthname = Components::$monthsShort[$monthnum];
+			return true;
+		} elseif ( array_search( $string, Components::$monthsShort ) !== false ) {
+			$monthname = $string;
+			return true;
+		}
+
+		return false;
+	}
+
+	private function debug( $datecomponents, $calendarmodel, $era, $hours, $minutes, $seconds, $microseconds, $timeoffset, $timezone ) {
+		//print "\n\n Results \n\n";
+		//debug_zval_dump( $datecomponents );
+		//print "\ncalendarmodel: $calendarmodel   \ntimezoneoffset: $timezoneoffset  \nera: $era  \nampm: $ampm  \nh: $hours  \nm: $minutes  \ns:$seconds  \ntimeoffset: $timeoffset  \n";
+		//debug_zval_dump( $unclearparts );
+	}
+
+}

--- a/src/Services/DataValueServices.php
+++ b/src/Services/DataValueServices.php
@@ -29,6 +29,7 @@ use SMWQuantityValue as QuantityValue;
 use SMW\DataValues\ValueFormatters\NumberValueFormatter;
 use SMWTimeValue as TimeValue;
 use SMW\DataValues\ValueFormatters\TimeValueFormatter;
+use SMW\DataValues\ValueParsers\TimeValueParser;
 
 /**
  * @codeCoverageIgnore
@@ -284,6 +285,21 @@ return array(
 		);
 
 		return new TimeValueFormatter();
+	},
+
+	/**
+	 * TimeValueParser
+	 *
+	 * @return callable
+	 */
+	DataValueServiceFactory::TYPE_PARSER . TimeValue::TYPE_ID => function( $containerBuilder ) {
+
+		$containerBuilder->registerExpectedReturnType(
+			DataValueServiceFactory::TYPE_PARSER . TimeValue::TYPE_ID,
+			TimeValueParser::class
+		);
+
+		return new TimeValueParser();
 	},
 
 );

--- a/tests/phpunit/Integration/JSONScript/TestCases/p-0423.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/p-0423.json
@@ -40,6 +40,9 @@
 			"contents": "{{#show: Example/P0423/2 |?Has date }}"
 		},
 		{
+			"skip-on": {
+				"virtuoso": "Virtuoso 6.1 does not support `-4715-11-24T12:00:00Z\"^^xsd:dateTime` and goes '...Error: Malformed query...'"
+			},
 			"page": "Example/P0423/3",
 			"contents": "[[Has date::Jan 10000000000]]"
 		},
@@ -142,6 +145,9 @@
 			}
 		},
 		{
+			"skip-on": {
+				"virtuoso": "Virtuoso 6.1, see Example/P0423/3 comment!"
+			},
 			"type": "parser",
 			"about": "#7 avoid a possible `DateTime ... Failed to parse time ...` on large dates, only checking some minor output since WINOS reports 784354016999.5, yet Linux returns 3652426721059.5 (float precision issue)",
 			"subject": "Example/P0423/Q3.1",

--- a/tests/phpunit/Integration/JSONScript/TestCases/p-0451.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/p-0451.json
@@ -41,6 +41,10 @@
 		{
 			"page": "Example/P0451/Q.1",
 			"contents": "{{#ask: [[Category:P0451]] |?Has date  |?Has date#LOCL#TZ |?Has date#JD=JD |format=list }}"
+		},
+		{
+			"page": "Example/P0451/9",
+			"contents": "[[Has date::2458119.500000]]"
 		}
 	],
 	"tests": [
@@ -58,6 +62,30 @@
 					"Example/P0451/6.* 25 April 2017 23:00:00.* 19:00:00 EDT, 25 April 2017.* 2457869.4583333",
 					"Example/P0451/7.* 26 April 2017 00:00:00.* 00:00:00 UTC, 26 April 2017.* 2457869.5",
 					"Example/P0451/8.* 26 April 2017 00:00:00.* 00:00:00 UTC, 26 April 2017.* 2457869.5"
+				]
+			}
+		},
+		{
+			"type": "parser",
+			"about": "#1 (recognized as JD not as timestamp)",
+			"subject": "Example/P0451/9",
+			"assert-store": {
+				"semantic-data": {
+					"strictPropertyValueMatch": false,
+					"propertyCount": 3,
+					"propertyKeys": [
+						"_SKEY",
+						"_MDAT",
+						"Has date"
+					],
+					"propertyValues": [
+						"2018-01-01T00:00:00"
+					]
+				}
+			},
+			"assert-output": {
+				"to-contain": [
+					"2458119.500000"
 				]
 			}
 		}

--- a/tests/phpunit/Unit/DataValues/Time/ComponentsTest.php
+++ b/tests/phpunit/Unit/DataValues/Time/ComponentsTest.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace SMW\Tests\DataValues\Time;
+
+use SMW\DataValues\Time\Components;
+
+/**
+ * @covers \SMW\DataValues\Time\Components
+ * @group semantic-mediawiki
+ *
+ * @license GNU GPL v2+
+ * @since 3.0
+ *
+ * @author mwjames
+ */
+class ComponentsTest extends \PHPUnit_Framework_TestCase {
+
+	public function testPublicProperties() {
+
+		$this->assertInternalType(
+			'array',
+			Components::$months
+		);
+
+		$this->assertInternalType(
+			'array',
+			Components::$monthsShort
+		);
+	}
+
+	public function testGet() {
+
+		$instance = new Components( [ 'foo' => 'bar' ] );
+
+		$this->assertEquals(
+			false,
+			$instance->get( 'bar' )
+		);
+
+		$this->assertEquals(
+			'bar',
+			$instance->get( 'foo' )
+		);
+	}
+
+}

--- a/tests/phpunit/Unit/DataValues/ValueFormatters/TimeValueFormatterTest.php
+++ b/tests/phpunit/Unit/DataValues/ValueFormatters/TimeValueFormatterTest.php
@@ -3,6 +3,7 @@
 namespace SMW\Tests\DataValues\ValueFormatters;
 
 use SMW\DataValues\ValueFormatters\TimeValueFormatter;
+use SMW\DataValues\ValueParsers\TimeValueParser;
 use SMWTimeValue as TimeValue;
 
 /**
@@ -15,6 +16,28 @@ use SMWTimeValue as TimeValue;
  * @author mwjames
  */
 class TimeValueFormatterTest extends \PHPUnit_Framework_TestCase {
+
+	private $dataValueServiceFactory;
+
+	protected function setUp() {
+		parent::setUp();
+
+		$constraintValueValidator = $this->getMockBuilder( '\SMW\DataValues\ValueValidators\ConstraintValueValidator' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$this->dataValueServiceFactory = $this->getMockBuilder( '\SMW\Services\DataValueServiceFactory' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$this->dataValueServiceFactory->expects( $this->any() )
+			->method( 'getValueParser' )
+			->will( $this->returnValue( new TimeValueParser() ) );
+
+		$this->dataValueServiceFactory->expects( $this->any() )
+			->method( 'getConstraintValueValidator' )
+			->will( $this->returnValue( $constraintValueValidator ) );
+	}
 
 	public function testCanConstruct() {
 
@@ -59,6 +82,10 @@ class TimeValueFormatterTest extends \PHPUnit_Framework_TestCase {
 	public function testToUseCaptionOutput() {
 
 		$timeValue = new TimeValue( '_dat' );
+		$timeValue->setDataValueServiceFactory(
+			$this->dataValueServiceFactory
+		);
+
 		$timeValue->setCaption( 'ABC[<>]' );
 
 		$instance = new TimeValueFormatter( $timeValue );
@@ -75,6 +102,10 @@ class TimeValueFormatterTest extends \PHPUnit_Framework_TestCase {
 	public function testFormat( $timeUserValue, $type, $format, $linker, $languageCode, $expected ) {
 
 		$timeValue = new TimeValue( '_dat' );
+		$timeValue->setDataValueServiceFactory(
+			$this->dataValueServiceFactory
+		);
+
 		$timeValue->setUserValue( $timeUserValue );
 
 		$timeValue->setOutputFormat( $format );
@@ -93,6 +124,10 @@ class TimeValueFormatterTest extends \PHPUnit_Framework_TestCase {
 	public function testGetISO8601DateForMinDefault() {
 
 		$timeValue = new TimeValue( '_dat' );
+		$timeValue->setDataValueServiceFactory(
+			$this->dataValueServiceFactory
+		);
+
 		$timeValue->setUserValue( '2000' );
 
 		$instance = new TimeValueFormatter( $timeValue );
@@ -103,6 +138,10 @@ class TimeValueFormatterTest extends \PHPUnit_Framework_TestCase {
 		);
 
 		$timeValue = new TimeValue( '_dat' );
+		$timeValue->setDataValueServiceFactory(
+			$this->dataValueServiceFactory
+		);
+
 		$timeValue->setUserValue( '2000-02-23 12:02' );
 
 		$instance = new TimeValueFormatter( $timeValue );
@@ -116,6 +155,10 @@ class TimeValueFormatterTest extends \PHPUnit_Framework_TestCase {
 	public function testGetISO8601DateForMaxDefault() {
 
 		$timeValue = new TimeValue( '_dat' );
+		$timeValue->setDataValueServiceFactory(
+			$this->dataValueServiceFactory
+		);
+
 		$timeValue->setUserValue( '2000' );
 
 		$instance = new TimeValueFormatter( $timeValue );
@@ -126,6 +169,10 @@ class TimeValueFormatterTest extends \PHPUnit_Framework_TestCase {
 		);
 
 		$timeValue = new TimeValue( '_dat' );
+		$timeValue->setDataValueServiceFactory(
+			$this->dataValueServiceFactory
+		);
+
 		$timeValue->setUserValue( '2000-02-23 12:02' );
 
 		$instance = new TimeValueFormatter( $timeValue );
@@ -139,6 +186,10 @@ class TimeValueFormatterTest extends \PHPUnit_Framework_TestCase {
 	public function testGetCaptionFromDataItemForPositiveYearWithEraMarker() {
 
 		$timeValue = new TimeValue( '_dat' );
+		$timeValue->setDataValueServiceFactory(
+			$this->dataValueServiceFactory
+		);
+
 		$timeValue->setUserValue( '2000 AD' );
 
 		$instance = new TimeValueFormatter( $timeValue );
@@ -152,6 +203,10 @@ class TimeValueFormatterTest extends \PHPUnit_Framework_TestCase {
 	public function testLeapYear() {
 
 		$timeValue = new TimeValue( '_dat' );
+		$timeValue->setDataValueServiceFactory(
+			$this->dataValueServiceFactory
+		);
+
 		$timeValue->setUserValue( '2016-02-29' );
 
 		$instance = new TimeValueFormatter( $timeValue );
@@ -166,6 +221,10 @@ class TimeValueFormatterTest extends \PHPUnit_Framework_TestCase {
 		);
 
 		$timeValue = new TimeValue( '_dat' );
+		$timeValue->setDataValueServiceFactory(
+			$this->dataValueServiceFactory
+		);
+
 		$timeValue->setUserValue( '2016-02' );
 
 		$instance = new TimeValueFormatter( $timeValue );
@@ -176,6 +235,10 @@ class TimeValueFormatterTest extends \PHPUnit_Framework_TestCase {
 		);
 
 		$timeValue = new TimeValue( '_dat' );
+		$timeValue->setDataValueServiceFactory(
+			$this->dataValueServiceFactory
+		);
+
 		$timeValue->setUserValue( '2015-02' );
 
 		$instance = new TimeValueFormatter( $timeValue );
@@ -189,6 +252,10 @@ class TimeValueFormatterTest extends \PHPUnit_Framework_TestCase {
 	public function testInvalidLeapYear() {
 
 		$timeValue = new TimeValue( '_dat' );
+		$timeValue->setDataValueServiceFactory(
+			$this->dataValueServiceFactory
+		);
+
 		$timeValue->setUserValue( '2015-02-29' );
 
 		$instance = new TimeValueFormatter( $timeValue );
@@ -201,6 +268,9 @@ class TimeValueFormatterTest extends \PHPUnit_Framework_TestCase {
 	public function testMediaWikiDate_WithDifferentLanguage() {
 
 		$timeValue = new TimeValue( '_dat' );
+		$timeValue->setDataValueServiceFactory(
+			$this->dataValueServiceFactory
+		);
 
 		$timeValue->setUserValue( '2015-02-28' );
 		$timeValue->setOption( 'user.language', 'en' );
@@ -225,6 +295,10 @@ class TimeValueFormatterTest extends \PHPUnit_Framework_TestCase {
 	public function testLOCLOutputFormat() {
 
 		$timeValue = new TimeValue( '_dat' );
+		$timeValue->setDataValueServiceFactory(
+			$this->dataValueServiceFactory
+		);
+
 		$timeValue->setUserValue( '2015-02-28' );
 
 		$timeValue->setOption( TimeValue::OPT_USER_LANGUAGE, 'en' );
@@ -246,6 +320,10 @@ class TimeValueFormatterTest extends \PHPUnit_Framework_TestCase {
 	public function testLOCLOutputFormatWithSpecificAnnotatedLanguage() {
 
 		$timeValue = new TimeValue( '_dat' );
+		$timeValue->setDataValueServiceFactory(
+			$this->dataValueServiceFactory
+		);
+
 		$timeValue->setUserValue( '2015-02-28' );
 
 		$timeValue->setOption( TimeValue::OPT_USER_LANGUAGE, 'en' );
@@ -262,6 +340,10 @@ class TimeValueFormatterTest extends \PHPUnit_Framework_TestCase {
 	public function testLOCLOutputFormatWithTimeZone() {
 
 		$timeValue = new TimeValue( '_dat' );
+		$timeValue->setDataValueServiceFactory(
+			$this->dataValueServiceFactory
+		);
+
 		$timeValue->setUserValue( '2015-02-28 12:12:00 A' );
 
 		$timeValue->setOption( TimeValue::OPT_USER_LANGUAGE, 'en' );
@@ -283,6 +365,10 @@ class TimeValueFormatterTest extends \PHPUnit_Framework_TestCase {
 	public function testLOCLOutputFormatWithTimeZoneOnSpecificAnnotatedLanguage() {
 
 		$timeValue = new TimeValue( '_dat' );
+		$timeValue->setDataValueServiceFactory(
+			$this->dataValueServiceFactory
+		);
+
 		$timeValue->setUserValue( '2015-02-28 12:12:00 A' );
 
 		$timeValue->setOption( TimeValue::OPT_USER_LANGUAGE, 'en' );

--- a/tests/phpunit/Unit/DataValues/ValueParsers/TimeValueParserTest.php
+++ b/tests/phpunit/Unit/DataValues/ValueParsers/TimeValueParserTest.php
@@ -1,0 +1,88 @@
+<?php
+
+namespace SMW\Tests\DataValues\ValueParsers;
+
+use SMW\DataValues\ValueParsers\TimeValueParser;
+use SMW\DataValues\Time\Components;
+
+/**
+ * @covers \SMW\DataValues\ValueParsers\TimeValueParser
+ * @group semantic-mediawiki
+ *
+ * @license GNU GPL v2+
+ * @since 3.0
+ *
+ * @author mwjames
+ */
+class TimeValueParserTest extends \PHPUnit_Framework_TestCase {
+
+	public function testCanConstruct() {
+
+		$this->assertInstanceOf(
+			TimeValueParser::class,
+			new TimeValueParser()
+		);
+	}
+
+	/**
+	 * @dataProvider valueProvider
+	 */
+	public function testParse( $value, $expected, $errors ) {
+
+		$instance = new TimeValueParser();
+
+		$this->assertEquals(
+			new Components( $expected ),
+			$instance->parse( $value )
+		);
+
+		$this->assertEquals(
+			$errors,
+			$instance->getErrors()
+		);
+	}
+
+	public function valueProvider() {
+
+		yield [
+			'1 Jan 1970',
+			[
+				'value' => '1 Jan 1970',
+				'datecomponents' => [
+					'1', 'Jan', '1970'
+				],
+				'calendarmodel' => false,
+				'era' => false,
+				'hours' => false,
+				'minutes' => false,
+				'seconds' => false,
+				'microseconds' => false,
+				'timeoffset' => 0,
+				'timezone' => false
+			],
+			[]
+		];
+
+		// JD value
+		yield [
+			'2458119.500000',
+			[
+				'value' => '2458119.500000',
+				'datecomponents' => [
+					'2458119', '500000'
+				],
+				'calendarmodel' => 'JD',
+				'era' => false,
+				'hours' => false,
+				'minutes' => false,
+				'seconds' => false,
+				'microseconds' => false,
+				'timeoffset' => 0,
+				'timezone' => false
+			],
+			[]
+		];
+
+	}
+
+}


### PR DESCRIPTION
This PR is made in reference to: #

This PR addresses or contains:

- First attempt to break the mammoth `SMW_DV_Time.php` into some maintainable pieces by moving the the date/time parsing to the `TimeValueParser`
- Neither `TimeValueParser` nor `SMW_DV_Time.php` contains code that is self-explanatory and would require some real effort to make it readable! 
- Fixed parsing of something like `[[Date::2458119.500000]]` that was interpreted as timestamp (due to being 14 char length) but is in fact a JD value.

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed

Fixes #