### PR TITLE
LinksProcessor to correctly recognize `::=`

### DIFF
--- a/src/Parser/LinksProcessor.php
+++ b/src/Parser/LinksProcessor.php
@@ -142,6 +142,14 @@ class LinksProcessor {
 
 		if ( array_key_exists( 1, $semanticLink ) ) {
 
+			// Use case [[Foo::=Bar]] (:= being the legacy notation < 1.4) where
+			// the regex splits it into `Foo:` and `Bar` loosing `=` from the value.
+			// Restore the link to its previous form of `Foo::=Bar` and reapply
+			// a simple split.
+			if( strpos( $semanticLink[0], '::=' ) && substr( $semanticLink[1], -1 ) == ':' ) {
+				list( $semanticLink[1], $semanticLink[2] ) = explode( '::', $semanticLink[1] . ':=' . $semanticLink[2], 2 );
+			}
+
 			// #1252 Strict mode being disabled for support of multi property
 			// assignments (e.g. [[property1::property2::value]])
 

--- a/tests/phpunit/Integration/JSONScript/TestCases/p-0448.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/p-0448.json
@@ -9,6 +9,10 @@
 		{
 			"page": "Example/P0448/1",
 			"contents": "[[Has text:=Lorem ipsum]]"
+		},
+		{
+			"page": "Example/P0448/2",
+			"contents": "[[Has text::==Lorem ipsum==]]"
 		}
 	],
 	"tests": [
@@ -27,6 +31,25 @@
 					],
 					"propertyValues": [
 						"Lorem ipsum"
+					]
+				}
+			}
+		},
+		{
+			"type": "parser",
+			"about": "#1",
+			"subject": "Example/P0448/2",
+			"assert-store": {
+				"semantic-data": {
+					"strictPropertyValueMatch": false,
+					"propertyCount": 3,
+					"propertyKeys": [
+						"_SKEY",
+						"_MDAT",
+						"Has text"
+					],
+					"propertyValues": [
+						"==Lorem ipsum=="
 					]
 				}
 			}

--- a/tests/phpunit/Unit/Parser/LinksProcessorTest.php
+++ b/tests/phpunit/Unit/Parser/LinksProcessorTest.php
@@ -118,6 +118,21 @@ class LinksProcessorTest extends \PHPUnit_Framework_TestCase {
 			)
 		);
 
+		$provider[] = array(
+			array(
+				'[[Foo::=Bar|Foobar]]',
+				'Foo',
+				'=Bar'
+			),
+			array(
+				array(
+					'Foo'
+				),
+				'=Bar',
+				false
+			)
+		);
+
 		return $provider;
 	}
 


### PR DESCRIPTION
This PR is made in reference to: #https://github.com/Wikifab/SemanticMediaWiki/commit/8b89a5a4da028f01a30a907f3e47db94c2fdef4b

This PR addresses or contains:

- Ensures to correctly recognize `[[Foo::=Bar]]` (where `:=` is the legacy notation) and splits the string into `Foo` and `=Bar`

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed
