### PR TITLE
Fix " Call to undefined method SMW\SPARQLStore\SPARQLStore::getDataItemHandlerForDIType"

### DIFF
--- a/src/MediaWiki/Jobs/PropertyStatisticsRebuildJob.php
+++ b/src/MediaWiki/Jobs/PropertyStatisticsRebuildJob.php
@@ -40,8 +40,12 @@ class PropertyStatisticsRebuildJob extends JobBase {
 		$applicationFactory = ApplicationFactory::getInstance();
 		$maintenanceFactory = $applicationFactory->newMaintenanceFactory();
 
+		// Use a fixed store to avoid issues like "Call to undefined method
+		// SMW\SPARQLStore\SPARQLStore::getDataItemHandlerForDIType" because
+		// the property statistics table and hereby its update is bound to
+		// the SQLStore
 		$propertyStatisticsRebuilder = $maintenanceFactory->newPropertyStatisticsRebuilder(
-			$applicationFactory->getStore()
+			$applicationFactory->getStore( '\SMW\SQLStore\SQLStore' )
 		);
 
 		$propertyStatisticsRebuilder->rebuild();


### PR DESCRIPTION
This PR is made in reference to: #

This PR addresses or contains:

```
$ php ../../maintenance/runJobs.php
2018-04-07 18:58:39 SMW\PropertyStatisticsRebuildJob SMW\SQLStore\Installer waitOnCommandLine=15 requestId=9f0fe0918d4c102660c89c
11 (id=36,timestamp=20180407184547) STARTING
[9f0fe0918d4c102660c89c11] [no req]   Error from line 136 of ...\SemanticMediaWiki\src\Maintenance\PropertyStatisticsRebuilder.php: Call to undefined method SMW\SPARQLStore\SPARQLStore::getDataItemHandlerForDIType()
Backtrace:
#0 ...\SemanticMediaWiki\src\Maintenance\PropertyStatisticsRebuilder.php(117): SMW\Maintenance\PropertyStatisticsRebuilder->getPropertyTableRowCount(SMW\SQLStore\PropertyTableDefinition, string)
#1 ...\SemanticMediaWiki\src\Maintenance\PropertyStatisticsRebuilder.php(94): SMW\Maintenance\PropertyStatisticsRebuilder->getCountFormRow(stdClass)
#2 ...\SemanticMediaWiki\src\MediaWiki\Jobs\PropertyStatisticsRebuildJob.php(47): SMW\Maintenance\PropertyStatisticsRebuilder->rebuild()
#3 ...\includes\jobqueue\JobRunner.php(289): SMW\MediaWiki\Jobs\PropertyStatisticsRebuildJob->run()
#4 ...\includes\jobqueue\JobRunner.php(189): JobRunner->executeJob(SMW\MediaWiki\Jobs\PropertyStatisticsRebuildJob, Wikimedia\Rdbms\LBFactorySimple, BufferingStatsdDataFactory, integer)
#5 ...\maintenance\runJobs.php(86): JobRunner->run(array)
#6 ...\maintenance\doMaintenance.php(111): RunJobs->execute()
#7 ...\maintenance\runJobs.php(119): require_once(string)
#8 {main}
```

This PR includes:
- [ ] Tests (unit/integration)
- [x] CI build passed

Fixes #