### PR TITLE
Add WikiPageValue::isImage

### DIFF
--- a/includes/datavalues/SMW_DV_WikiPage.php
+++ b/includes/datavalues/SMW_DV_WikiPage.php
@@ -234,6 +234,35 @@ class SMWWikiPageValue extends SMWDataValue {
 	}
 
 	/**
+	 * @since 3.0
+	 *
+	 * @return boolean
+	 */
+	public function isImage() {
+
+		if ( $this->m_dataitem->getNamespace() !== NS_FILE || $this->m_dataitem->getSubobjectName() !== '' ) {
+			return false;
+		}
+
+		$imageExtensions = [
+			'gif',
+			'jpg',
+			'jpeg',
+			'png',
+			'bmp',
+			'svg',
+			'tiff'
+		];
+
+		$extension = strtolower(
+			substr( strrchr( $this->m_dataitem->getDBKey(), "." ) , 1 )
+			// pathinfo( $this->m_dataitem->getDBKey(), PATHINFO_EXTENSION )
+		);
+
+		return in_array( $extension, $imageExtensions );
+	}
+
+	/**
 	 * Display the value on a wiki page. This is used to display the value
 	 * in the place where it was annotated on a wiki page. The desired
 	 * behavior is that the display in this case looks as if no property
@@ -265,7 +294,7 @@ class SMWWikiPageValue extends SMWDataValue {
 			return $this->m_caption !== false ? $this->m_caption : $this->getWikiValue();
 		}
 
-		if ( $this->m_dataitem->getNamespace() == NS_FILE && $this->m_dataitem->getInterwiki() === '' ) {
+		if ( $this->isImage() && $this->m_dataitem->getInterwiki() === '' ) {
 			$linkEscape = '';
 			$options = $this->m_outformat === false ? 'frameless|border|text-top|' : str_replace( ';', '|', \Sanitizer::removeHTMLtags( $this->m_outformat ) );
 			$defaultCaption = '|' . $this->getShortCaptionText() . '|' . $options;
@@ -351,7 +380,7 @@ class SMWWikiPageValue extends SMWDataValue {
 
 		if ( is_null( $linked ) || $linked === false || $this->m_outformat == '-' ) {
 			return $this->getWikiValue();
-		} elseif ( $this->m_dataitem->getNamespace() == NS_FILE && $this->m_dataitem->getInterwiki() === '' ) {
+		} elseif ( $this->isImage() && $this->m_dataitem->getInterwiki() === '' ) {
 			// Embed images and other files
 			// Note that the embedded file links to the image, hence needs no additional link text.
 			// There should not be a linebreak after an impage, just like there is no linebreak after
@@ -402,8 +431,10 @@ class SMWWikiPageValue extends SMWDataValue {
 		if ( $linker === null || $linker === false || $this->m_outformat == '-' ) {
 			return \Sanitizer::removeHTMLtags( $this->getWikiValue() );
 		} elseif ( $this->getNamespace() == NS_MEDIA ) { // this extra case is really needed
-			return $linker->makeMediaLinkObj( $this->getTitle(),
-				 \Sanitizer::removeHTMLtags( $this->getLongCaptionText() ) );
+			return $linker->makeMediaLinkObj(
+				$this->getTitle(),
+				\Sanitizer::removeHTMLtags( $this->getLongCaptionText() )
+			);
 		}
 
 		// all others use default linking, no embedding of images here

--- a/tests/phpunit/Integration/JSONScript/Fixtures/file-upload.txt
+++ b/tests/phpunit/Integration/JSONScript/Fixtures/file-upload.txt
@@ -1,0 +1,1 @@
+Test file for a non image upload!

--- a/tests/phpunit/Integration/JSONScript/TestCases/p-0705.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/p-0705.json
@@ -12,7 +12,7 @@
 			"contents": {
 				"upload": {
 					"file" : "/../Fixtures/image-upload-480.png",
-					"text" : "[[Has file::{{FULLPAGENAME}}]] [[Has caption::123]]"
+					"text" : "[[Has file::{{FULLPAGENAME}}]] [[Has caption::123]] {{#subobject:Test|Has text=Foo}}"
 				}
 			}
 		},
@@ -23,6 +23,10 @@
 		{
 			"page": "Example/P0705/Q.2",
 			"contents": "{{#ask: [[Has file::+]] |?Has file#120px;thumb;<b>{{#show: File:P0705.png |?Has caption |link=none}}</b>[[Extra]] |format=table |limit=1 }}"
+		},
+		{
+			"page": "Example/P0705/Q.3",
+			"contents": "{{#ask: [[File:+]] }}"
 		}
 	],
 	"tests": [
@@ -53,6 +57,17 @@
 					"class=\"thumb tright\"",
 					"<div class=\"thumbcaption\"><div class=\"magnify\">",
 					"Extra"
+				]
+			}
+		},
+		{
+			"type": "parser",
+			"about": "#2 (subobject is displayed as normal link and not with an image reference)",
+			"subject": "Example/P0705/Q.3",
+			"assert-output": {
+				"to-contain": [
+					"<span class=\"smw-subobject-entity\"><a href=.*P0705.png#Test\" title=.*P0705.png\">P0705.png#Test</a></span>",
+					"<a href=.*P0705.png\" class=\"image\"><img alt=\"P0705.png\" .*class=\"thumbborder\" .*</a>"
 				]
 			}
 		}

--- a/tests/phpunit/Integration/JSONScript/TestCases/p-0708.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/p-0708.json
@@ -1,0 +1,61 @@
+{
+	"description": "Test `#ask` NS_FILE and DISPLAYTITLE (`wgContLang=en`, `wgLang=en`, `wgEnableUploads`, `wgFileExtensions`, 'wgDefaultUserOptions', `wgRestrictDisplayTitle`)",
+	"setup": [
+		{
+			"namespace": "SMW_NS_PROPERTY",
+			"page": "Has text",
+			"contents": "[[Has type::Text]]"
+		},
+		{
+			"namespace": "NS_FILE",
+			"page": "P0708-text-file.txt",
+			"contents": {
+				"upload": {
+					"file" : "/../Fixtures/file-upload.txt",
+					"text" : "[[File type::txt]] {{DISPLAYTITLE:DIFFERENT TITLE}}"
+				}
+			}
+		},
+		{
+			"page": "Example/P0708/Q.1",
+			"contents": "{{#ask: [[File type::txt]] |format=table |limit=1 }}"
+		}
+	],
+	"tests": [
+		{
+			"type": "parser",
+			"about": "#0 (using DISPLAYTITLE)",
+			"subject": "Example/P0708/Q.1",
+			"assert-output": {
+				"to-contain": [
+					"<a href=\".*:P0708-text-file.txt\" title=\"File:P0708-text-file.txt\">DIFFERENT TITLE</a>"
+				]
+			}
+		}
+	],
+	"settings": {
+		"wgContLang": "en",
+		"wgLang": "en",
+		"wgRestrictDisplayTitle": false,
+		"wgEnableUploads": true,
+		"wgFileExtensions": [
+			"png",
+			"txt"
+		],
+		"wgDefaultUserOptions": {
+			"thumbsize": 5
+		},
+		"smwgPageSpecialProperties": [
+			"_MDAT"
+		],
+		"smwgNamespacesWithSemanticLinks": {
+			"NS_MAIN": true,
+			"NS_FILE": true
+		}
+	},
+	"meta": {
+		"version": "2",
+		"is-incomplete": false,
+		"debug": false
+	}
+}


### PR DESCRIPTION
This PR is made in reference to: #

This PR addresses or contains:

- Checks whether a NS_FILE entity is a subobject or not and suppresses to be listed as image
- Checks whether it is  "real" image (using image extensions as identifier to avoid having to read a media info record) or not and only if adds transformations such as `... 'frameless|border|text-top ...` while any other subject is displayed as normal link including a possible DISPLAYTITLE

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed

Fixes #