### PR TITLE
Add set/getExtensionData to DataValue

### DIFF
--- a/src/DataTypeRegistry.php
+++ b/src/DataTypeRegistry.php
@@ -105,11 +105,15 @@ class DataTypeRegistry {
 		//DataItem::TYPE_ERROR => '',
 	);
 
-
 	/**
 	 * @var Closure[]
 	 */
 	private $extraneousFunctions = array();
+
+	/**
+	 * @var []
+	 */
+	private $extenstionData = [];
 
 	/**
 	 * @var Options
@@ -502,6 +506,7 @@ class DataTypeRegistry {
 	}
 
 	/**
+	 * @deprecated since 3.0, use DataTypeRegistry::setExtensionData
 	 * Inject services and objects that are planned to be used during the invocation of
 	 * a DataValue
 	 *
@@ -515,6 +520,7 @@ class DataTypeRegistry {
 	}
 
 	/**
+	 * @deprecated since 3.0, use DataTypeRegistry::getExtensionData
 	 * @since 2.3
 	 *
 	 * @return Closure[]
@@ -545,6 +551,51 @@ class DataTypeRegistry {
 	 */
 	public function setOption( $key, $value ) {
 		$this->getOptions()->set( $key, $value );
+	}
+
+	/**
+	 * This function allows for registered types to add additional data or functions
+	 * required by an individual DataValue of that type.
+	 *
+	 * Register the data:
+	 * $dataTypeRegistry = DataTypeRegistry::getInstance();
+	 *
+	 * $dataTypeRegistry->registerDataType( '__foo', ... );
+	 * $dataTypeRegistry->setExtensionData( '__foo', [ 'ext.function' => ... ] );
+	 * ...
+	 *
+	 * Access the data:
+	 * $dataValueFactory = DataValueFactory::getInstance();
+	 *
+	 * $dataValue = $dataValueFactory->newDataValueByType( '__foo' );
+	 * $dataValue->getExtensionData( 'ext.function' )
+	 * ...
+	 *
+	 * @since 3.0
+	 *
+	 * @param string $id
+	 * @param array $data
+	 */
+	public function setExtensionData( $id, array $data = [] ) {
+		if ( $this->isRegistered( $id ) ) {
+			$this->extenstionData[$id] = $data;
+		}
+	}
+
+	/**
+	 * @since 3.0
+	 *
+	 * @param string $id
+	 *
+	 * @return []
+	 */
+	public function getExtensionData( $id ) {
+
+		if ( isset( $this->extenstionData[$id] ) ) {
+			return $this->extenstionData[$id];
+		}
+
+		return [];
 	}
 
 	private function registerLabels() {

--- a/src/DataValueFactory.php
+++ b/src/DataValueFactory.php
@@ -154,6 +154,15 @@ class DataValueFactory {
 			$this->dataTypeRegistry->getOptions()
 		);
 
+		foreach ( $this->dataTypeRegistry->getExtensionData( $typeId ) as $key => $value ) {
+
+			if ( !is_string( $key ) ) {
+				continue;
+			}
+
+			$dataValue->setExtensionData( $key, $value );
+		}
+
 		$localizer = Localizer::getInstance();
 
 		$dataValue->setOption(

--- a/src/Options.php
+++ b/src/Options.php
@@ -123,7 +123,7 @@ class Options {
 	 * @return boolean
 	 */
 	public function isFlagSet( $key, $flag ) {
-		return ( ( $this->safeGet( $key ) & $flag ) == $flag );
+		return ( ( (int)$this->safeGet( $key, 0 ) & $flag ) == $flag );
 	}
 
 	/**

--- a/tests/phpunit/Unit/DataTypeRegistryTest.php
+++ b/tests/phpunit/Unit/DataTypeRegistryTest.php
@@ -414,6 +414,40 @@ class DataTypeRegistryTest extends \PHPUnit_Framework_TestCase {
 		}
 	}
 
+	public function testExtensionData() {
+
+		$lang = $this->getMockBuilder( '\SMW\Lang\Lang' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$lang->expects( $this->once() )
+			->method( 'getDatatypeLabels' )
+			->will( $this->returnValue( array() ) );
+
+		$lang->expects( $this->once() )
+			->method( 'getDatatypeAliases' )
+			->will( $this->returnValue( array() ) );
+
+		$lang->expects( $this->once() )
+			->method( 'getCanonicalDatatypeLabels' )
+			->will( $this->returnValue( array() ) );
+
+		$instance = new DataTypeRegistry(
+			$lang
+		);
+
+		$instance->registerDataType(
+			'__foo', '\SMW\Tests\FooValue', DataItem::TYPE_NOTYPE, 'FooValue'
+		);
+
+		$instance->setExtensionData( '__foo', [ 'ext.test' => 'test' ] );
+
+		$this->assertEquals(
+			[ 'ext.test' => 'test' ],
+			$instance->getExtensionData( '__foo' )
+		);
+	}
+
 }
 
 class FooValue {


### PR DESCRIPTION
This PR is made in reference to: #

This PR addresses or contains:

- Allows to register extension data per type during the initialization and provides access to those typed assigned data for individual dataValues of that type

```
Register the data:
$dataTypeRegistry = DataTypeRegistry::getInstance();

$dataTypeRegistry->registerDataType( '__foo', ... );
$dataTypeRegistry->setExtensionData( '__foo', [ 'ext.function' => ..., 'ext.callback' => ... ] );
...

Access the data:
$dataValueFactory = DataValueFactory::getInstance();

$dataValue = $dataValueFactory->newDataValueByType( '__foo' );
$dataValue->getExtensionData( 'ext.function' )
...
```

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed
