### PR TITLE
Add Excerpts, extend SearchResultSet

### DIFF
--- a/includes/storage/SMW_QueryResult.php
+++ b/includes/storage/SMW_QueryResult.php
@@ -4,6 +4,7 @@ use SMW\HashBuilder;
 use SMW\Query\PrintRequest;
 use SMW\Query\QueryLinker;
 use SMW\Query\ScoreSet;
+use SMW\Query\Excerpts;
 use SMW\Query\Result\InMemoryEntityProcessList;
 use SMW\SerializerFactory;
 
@@ -87,6 +88,11 @@ class SMWQueryResult {
 	private $scoreSet;
 
 	/**
+	 * @var Excerpts
+	 */
+	private $excerpts;
+
+	/**
 	 * Initialise the object with an array of SMWPrintRequest objects, which
 	 * define the structure of the result "table" (one for each column).
 	 *
@@ -144,6 +150,26 @@ class SMWQueryResult {
 	 */
 	public function getScoreSet() {
 		return $this->scoreSet;
+	}
+
+	/**
+	 * Only available by some stores that support the retrieval of excerpts.
+	 *
+	 * @since 3.0
+	 *
+	 * @param Excerpts $excerpts
+	 */
+	public function setExcerpts( Excerpts $excerpts ) {
+		$this->excerpts = $excerpts;
+	}
+
+	/**
+	 * @since 3.0
+	 *
+	 * @return Excerpts|null
+	 */
+	public function getExcerpts() {
+		return $this->excerpts;
 	}
 
 	/**

--- a/src/MediaWiki/Search/SearchResult.php
+++ b/src/MediaWiki/Search/SearchResult.php
@@ -24,4 +24,30 @@ class SearchResult extends \SearchResult {
 		return $this->mTitle;
 	}
 
+	/**
+	 * Set a text excerpt retrieved from a different back-end.
+	 *
+	 * @param string $text|null
+	 */
+	public function setExcerpt( $text = null ) {
+		$this->mText = $text;
+	}
+
+	/**
+	 * @return string|null
+	 */
+	public function getExcerpt() {
+		return $this->mText;
+	}
+
+	/**
+	 * @see SearchResult::getSectionTitle
+	 */
+	public function getTitleSnippet() {
+
+		// Extend the title preferably using the DISPLAYTITLE if available!
+
+		return '';
+	}
+
 }

--- a/src/Query/Excerpts.php
+++ b/src/Query/Excerpts.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace SMW\Query;
+
+use DIWikiPage;
+
+/**
+ * Record excerpts for query results that support an excerpt retrieval function.
+ *
+ * @license GNU GPL v2+
+ * @since 3.0
+ *
+ * @author mwjames
+ */
+class Excerpts {
+
+	/**
+	 * @var []
+	 */
+	protected $excerpts = [];
+
+	/**
+	 * @note The hash is expected to match DIWikiPage::getHash to easily match
+	 * result subjects available in an QueryResult instance.
+	 *
+	 * @since 3.0
+	 *
+	 * @param DIWikiPage|string $hash
+	 * @param string|integer $score
+	 */
+	public function addExcerpt( $hash, $excerpt ) {
+
+		if ( $hash instanceof DIWikiPage ) {
+			$hash = $hash->getHash();
+		}
+
+		$this->excerpts[] = [ $hash, $excerpt ];
+	}
+
+	/**
+	 * @since 3.0
+	 *
+	 * @param DIWIkiPage|string $hash
+	 *
+	 * @return string|integer|false
+	 */
+	public function getExcerpt( $hash ) {
+
+		if ( $hash instanceof DIWikiPage ) {
+			$hash = $hash->getHash();
+		}
+
+		foreach ( $this->excerpts as $map ) {
+			if ( $map[0] === $hash ) {
+				return $map[1];
+			}
+		}
+
+		return false;
+	}
+
+	/**
+	 * @since 3.0
+	 *
+	 * @return []
+	 */
+	public function getExcerpts() {
+		return $this->excerpts;
+	}
+
+}

--- a/tests/phpunit/Unit/MediaWiki/Search/SearchResultSetTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Search/SearchResultSetTest.php
@@ -19,11 +19,29 @@ class SearchResultSetTest extends \PHPUnit_Framework_TestCase {
 	 * @var SearchResultSet The search result set under test
 	 */
 	protected $resultSet;
+	private $queryResult;
 
 	protected function setUp() {
 
-		$queryResultMock = $this->getMockBuilder( 'SMWQueryResult' )
+		$queryToken = $this->getMockBuilder( '\SMW\Query\QueryToken' )
 			->disableOriginalConstructor()
+			->getMock();
+
+		$queryToken->expects( $this->any() )
+			->method( 'getTokens' )
+			->will( $this->returnValue( [] ) );
+
+		$query = $this->getMockBuilder( '\SMWQuery' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$query->expects( $this->any() )
+			->method( 'getQueryToken' )
+			->will( $this->returnValue( $queryToken ) );
+
+		$this->queryResult = $this->getMockBuilder( 'SMWQueryResult' )
+			->disableOriginalConstructor()
+			->setMethods( [ 'getQuery', 'getResults' ] )
 			->getMock();
 
 		$pageMock = $this->getMockBuilder( 'SMW\DIWikiPage' )
@@ -34,11 +52,15 @@ class SearchResultSetTest extends \PHPUnit_Framework_TestCase {
 			->method( 'getTitle' )
 			->will( $this->returnValue( null ) );
 
-		$queryResultMock->expects( $this->any() )
+		$this->queryResult->expects( $this->any() )
+			->method( 'getQuery' )
+			->will( $this->returnValue( $query ) );
+
+		$this->queryResult->expects( $this->any() )
 			->method( 'getResults' )
 			->will( $this->returnValue( array( $pageMock, $pageMock, $pageMock ) ) );
 
-		$this->resultSet = new SearchResultSet( $queryResultMock, 42 );
+		$this->resultSet = new SearchResultSet( $this->queryResult, 42 );
 
 	}
 
@@ -67,6 +89,62 @@ class SearchResultSetTest extends \PHPUnit_Framework_TestCase {
 
 	public function testGetTotalHits() {
 		$this->assertEquals( 42, $this->resultSet->getTotalHits() );
+	}
+
+	public function testExcerpt() {
+
+		$excerpts = $this->getMockBuilder( 'SMW\Query\Excerpts' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$excerpts->expects( $this->any() )
+			->method( 'getExcerpt' )
+			->will( $this->returnValue( 'Foo ...' ) );
+
+		$this->queryResult->setExcerpts( $excerpts );
+
+		$resultSet = new SearchResultSet( $this->queryResult, 42 );
+		$searchResult = $resultSet->next();
+
+		$this->assertEquals(
+			'Foo ...',
+			$searchResult->getExcerpt()
+		);
+	}
+
+	public function testTermMatches() {
+
+		$queryToken = $this->getMockBuilder( '\SMW\Query\QueryToken' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$queryToken->expects( $this->any() )
+			->method( 'getTokens' )
+			->will( $this->returnValue( [ 'Foo' => 1, 'Bar' => 2 ] ) );
+
+		$query = $this->getMockBuilder( '\SMWQuery' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$query->expects( $this->any() )
+			->method( 'getQueryToken' )
+			->will( $this->returnValue( $queryToken ) );
+
+		$queryResult = $this->getMockBuilder( 'SMWQueryResult' )
+			->disableOriginalConstructor()
+			->setMethods( [ 'getQuery', 'getResults' ] )
+			->getMock();
+
+		$queryResult->expects( $this->any() )
+			->method( 'getQuery' )
+			->will( $this->returnValue( $query ) );
+
+		$resultSet = new SearchResultSet( $queryResult, 42 );
+
+		$this->assertEquals(
+			[ '\bFoo\b', '\bBar\b' ],
+			$resultSet->termMatches()
+		);
 	}
 
 }

--- a/tests/phpunit/Unit/MediaWiki/Search/SearchResultTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Search/SearchResultTest.php
@@ -50,4 +50,23 @@ class SearchResultTest extends \PHPUnit_Framework_TestCase {
 		);
 	}
 
+	public function testExcerpt() {
+
+		$title = $this->getMockBuilder( '\Title' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$title->expects( $this->any() )
+			->method( 'getFragment' )
+			->will( $this->returnValue( '' ) );
+
+		$instance = SearchResult::newFromTitle( $title );
+		$instance->setExcerpt( 'Foo ...' );
+
+		$this->assertEquals(
+			'Foo ...',
+			$instance->getExcerpt()
+		);
+	}
+
 }

--- a/tests/phpunit/Unit/MediaWiki/Search/SearchTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Search/SearchTest.php
@@ -181,9 +181,17 @@ class SearchTest extends \PHPUnit_Framework_TestCase {
 
 		$term = '[[Some string that can be interpreted as a semantic query]]';
 
+		$query = $this->getMockBuilder( '\SMWQuery' )
+			->disableOriginalConstructor()
+			->getMock();
+
 		$queryResult = $this->getMockBuilder( '\SMWQueryResult' )
 			->disableOriginalConstructor()
 			->getMock();
+
+		$queryResult->expects( $this->any() )
+			->method( 'getQuery' )
+			->will( $this->returnValue( $query ) );
 
 		$store = $this->getMockBuilder( '\SMW\Store' )
 			->disableOriginalConstructor()

--- a/tests/phpunit/Unit/Query/ExcerptsTest.php
+++ b/tests/phpunit/Unit/Query/ExcerptsTest.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace SMW\Tests\Query;
+
+use SMW\Query\Excerpts;
+use SMW\DIWikiPage;
+
+/**
+ * @covers \SMW\Query\Excerpts
+ * @group semantic-mediawiki
+ *
+ * @license GNU GPL v2+
+ * @since 3.0
+ *
+ * @author mwjames
+ */
+class ExcerptsTest extends \PHPUnit_Framework_TestCase {
+
+	public function testCanConstruct() {
+
+		$this->assertInstanceOf(
+			Excerpts::class,
+			new Excerpts()
+		);
+	}
+
+	public function testAddExcerpt() {
+
+		$instance = new Excerpts();
+
+		$instance->addExcerpt( 'Foo', 0.1 );
+
+		$this->assertEquals(
+			0.1,
+			$instance->getExcerpt( 'Foo' )
+		);
+
+		$this->assertFalse(
+			$instance->getExcerpt( 'Bar' )
+		);
+	}
+
+	public function testAddExcerpt_DIWikiPage() {
+
+		$dataItem = DIWikiPage::newFromText( 'Bar' );
+		$instance = new Excerpts();
+
+		$instance->addExcerpt( $dataItem, 10 );
+
+		$this->assertEquals(
+			10,
+			$instance->getExcerpt( $dataItem )
+		);
+	}
+
+	public function testGetExcerpts() {
+
+		$instance = new Excerpts();
+
+		$instance->addExcerpt( 'Foo', '...' );
+		$instance->addExcerpt( 'Bar', 1001 );
+
+		$this->assertEquals(
+			[
+				[ 'Foo', '...' ],
+				[ 'Bar', 1001 ]
+			],
+			$instance->getExcerpts()
+		);
+	}
+
+}


### PR DESCRIPTION
This PR is made in reference to: #

This PR addresses or contains:

- Adds the `Excerpts` component to be injected as part of the query request into a `QueryResult` (the standard `SQLStore` doesn't use it, has been isolated from https://github.com/SemanticMediaWiki/SemanticMediaWiki/pull/3054#issuecomment-379488988)
- Extends `SearchResultSet` that if an excerpt is available it is injected and used instead of the standard text provided by the `Special:Search`
- `SearchResultSet::termMatches` will return matches retrieved from the `QueryToken` instance (if those token related to a query context, not a filter context) and hereby allows the standard `Special:Search` highlighter to mark relevant words

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed

![image](https://user-images.githubusercontent.com/1245473/38470503-70527482-3b53-11e8-8ed1-8075baec428a.png)
