### PR TITLE
DIWikiPage produce complete hash

### DIFF
--- a/docs/technical/api.md
+++ b/docs/technical/api.md
@@ -102,7 +102,7 @@ An interface to browse facts (the equivalent of `Special:Browse`) of a subject (
 ```php
 {
 	"query": {
-		"subject": "Main_Page#0#",
+		"subject": "Main_Page#0##",
 		"data": [
 			{
 				"property": "Foo",

--- a/docs/technical/doc.serializers.md
+++ b/docs/technical/doc.serializers.md
@@ -53,14 +53,14 @@ Implements the Serializer interface for the SMW\SemanticData object.
 For a page called "Foo" that contains <code>[[Has property::Bar]]</code>, <code>{{#subobject:|Has subobjects=Bam}}</code>, <code>{{#ask:[[Has subobjects::Bam]]}}</code>, the Serializer will output:
 
 ```php
-"subject": "Foo#0#",
+"subject": "Foo#0##",
 "data": [
 	{
 		"property": "Has_property",
 		"dataitem": [
 			{
 				"type": 9,
-				"item": "Bar#0#"
+				"item": "Bar#0##"
 			}
 		]
 	},
@@ -107,7 +107,7 @@ For a page called "Foo" that contains <code>[[Has property::Bar]]</code>, <code>
 				"dataitem": [
 					{
 						"type": 9,
-						"item": "Bam#0#"
+						"item": "Bam#0##"
 					}
 				]
 			},

--- a/includes/dataitems/SMW_DI_WikiPage.php
+++ b/includes/dataitems/SMW_DI_WikiPage.php
@@ -237,9 +237,7 @@ class DIWikiPage extends SMWDataItem {
 			$this->m_interwiki
 		);
 
-		if ( $this->m_subobjectname !== '' ) {
-			$segments[] = $this->m_subobjectname;
-		}
+		$segments[] = $this->m_subobjectname;
 
 		return implode( '#', $segments );
 	}

--- a/tests/phpunit/Integration/JSONScript/Fixtures/s-0020.1.txt
+++ b/tests/phpunit/Integration/JSONScript/Fixtures/s-0020.1.txt
@@ -1,1 +1,1 @@
-{"Example/S0020/1#0#":{"Has text":["Some example"],"Has number":[]},"Example/S0020/2#0#":{"Has text":[],"Has number":["123","345"]}}
+{"Example/S0020/1#0##":{"Has text":["Some example"],"Has number":[]},"Example/S0020/2#0##":{"Has text":[],"Has number":["123","345"]}}

--- a/tests/phpunit/Integration/JSONScript/TestCases/p-0405.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/p-0405.json
@@ -69,7 +69,7 @@
 							"_REDI"
 						],
 						"propertyValues": [
-							"Page-with-template-for-unknown-redirect-target#0#"
+							"Page-with-template-for-unknown-redirect-target#0##"
 						]
 					}
 				}
@@ -91,7 +91,7 @@
 							"_REDI"
 						],
 						"propertyValues": [
-							"Page-with-template-for-unknown-redirect-target#0#"
+							"Page-with-template-for-unknown-redirect-target#0##"
 						]
 					}
 				}
@@ -117,8 +117,8 @@
 							"Has_page"
 						],
 						"propertyValues": [
-							"Page-with-template-for-known-redirect-target#0#",
-							"To-be-known-template-redirect-target#0#"
+							"Page-with-template-for-known-redirect-target#0##",
+							"To-be-known-template-redirect-target#0##"
 						]
 					}
 				}
@@ -144,8 +144,8 @@
 							"Has_page"
 						],
 						"propertyValues": [
-							"Page-with-template-for-known-redirect-target#0#",
-							"To-be-known-template-redirect-target#0#"
+							"Page-with-template-for-known-redirect-target#0##",
+							"To-be-known-template-redirect-target#0##"
 						]
 					}
 				}
@@ -167,7 +167,7 @@
 							"_REDI"
 						],
 						"propertyValues": [
-							"Page-with-annotation-for-unknown-redirect-target#0#"
+							"Page-with-annotation-for-unknown-redirect-target#0##"
 						]
 					}
 				}
@@ -192,7 +192,7 @@
 							"Has_page"
 						],
 						"propertyValues": [
-							"Page-with-template-was-redirected-now-restored#0#"
+							"Page-with-template-was-redirected-now-restored#0##"
 						]
 					}
 				}

--- a/tests/phpunit/Integration/JSONScript/TestCases/p-0909.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/p-0909.json
@@ -56,7 +56,7 @@
 		{
 			"type": "parser",
 			"about": "#0",
-			"subject": "Example/P0909/Q.1#_QUERY68dcb8216fabceb5e68b48e29f7a507f",
+			"subject": "Example/P0909/Q.1#_QUERYced3dc3308e03e4ff0c92578d616e6a5",
 			"assert-store": {
 				"semantic-data": {
 					"strict-mode-valuematch": false,
@@ -77,7 +77,7 @@
 		{
 			"type": "parser",
 			"about": "#1",
-			"subject": "Example/P0909/Q.2#_QUERY68dcb8216fabceb5e68b48e29f7a507f",
+			"subject": "Example/P0909/Q.2#_QUERYced3dc3308e03e4ff0c92578d616e6a5",
 			"assert-store": {
 				"semantic-data": {
 					"strict-mode-valuematch": false,
@@ -98,7 +98,7 @@
 		{
 			"type": "parser",
 			"about": "#2",
-			"subject": "Example/P0909/Q.3#_QUERYd86ef53760e21dc939ac35e8ba96cbe9",
+			"subject": "Example/P0909/Q.3#_QUERY84456d5e55da8a3ba2279a5eb73ce483",
 			"assert-store": {
 				"semantic-data": {
 					"strict-mode-valuematch": false,
@@ -119,7 +119,7 @@
 		{
 			"type": "parser",
 			"about": "#3",
-			"subject": "Example/P0909/Q.4#_QUERY83e07614d84828b684e2f82618a6b0a3",
+			"subject": "Example/P0909/Q.4#_QUERYcdd649eae7a93d114d44b75d9c1ed65c",
 			"assert-store": {
 				"semantic-data": {
 					"strict-mode-valuematch": false,
@@ -140,7 +140,7 @@
 		{
 			"type": "parser",
 			"about": "#4",
-			"subject": "Example/P0909/Q.5#_QUERY2d77e744274cc4d8a102dfaf9ff3825d",
+			"subject": "Example/P0909/Q.5#_QUERY13b773c8ea18d4839f069a8a88dbe783",
 			"assert-store": {
 				"semantic-data": {
 					"strict-mode-valuematch": false,
@@ -161,7 +161,7 @@
 		{
 			"type": "parser",
 			"about": "#5",
-			"subject": "Example/P0909/Q.6#_QUERY9842313cc7d4e02ae3e26d9e3c7a69bc",
+			"subject": "Example/P0909/Q.6#_QUERYfb6756e6bb1d5cf0c37b0c305caf6d6e",
 			"assert-store": {
 				"semantic-data": {
 					"strict-mode-valuematch": false,
@@ -182,7 +182,7 @@
 		{
 			"type": "parser",
 			"about": "#6",
-			"subject": "Example/P0909/Q.7#_QUERY5a9ddfda092ddc2a398e4f92c2052387",
+			"subject": "Example/P0909/Q.7#_QUERYbcb06ea6a827c21b2ae2fbc8359bef8c",
 			"assert-store": {
 				"semantic-data": {
 					"strict-mode-valuematch": false,
@@ -203,7 +203,7 @@
 		{
 			"type": "parser",
 			"about": "#7",
-			"subject": "Example/P0909/Q.8#_QUERY36189e7306ea60137006a12b6d887930",
+			"subject": "Example/P0909/Q.8#_QUERYecd911af9ce2cf69bacfbab3041114c7",
 			"assert-store": {
 				"semantic-data": {
 					"strict-mode-valuematch": false,
@@ -224,7 +224,7 @@
 		{
 			"type": "parser",
 			"about": "#8",
-			"subject": "Example/P0909/Q.9#_QUERY24970035b091ffcb344b52db4e53a16b",
+			"subject": "Example/P0909/Q.9#_QUERY69098f6e24f5bf124fec18d6339450ce",
 			"assert-store": {
 				"semantic-data": {
 					"strict-mode-valuematch": false,

--- a/tests/phpunit/Integration/JSONScript/TestCases/p-0911.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/p-0911.json
@@ -19,7 +19,7 @@
 		{
 			"type": "parser",
 			"about": "#0",
-			"subject": "Example/P0911/Q.1#_QUERY646f64bc5a757dee7a3910f07115d771",
+			"subject": "Example/P0911/Q.1#_QUERY7f8c02d826a5987a65a9de7ba8d9abfd",
 			"assert-store": {
 				"semantic-data": {
 					"strict-mode-valuematch": false,

--- a/tests/phpunit/Integration/JSONScript/TestCases/p-0915.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/p-0915.json
@@ -81,7 +81,7 @@
 						"_INST"
 					],
 					"propertyValues": [
-						"Example/P0915/ValidCat2#14#"
+						"Example/P0915/ValidCat2#14##"
 					]
 				}
 			}

--- a/tests/phpunit/Integration/JSONScript/TestCases/p-1000.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/p-1000.json
@@ -52,7 +52,7 @@
 							"_REDI"
 						],
 						"propertyValues": [
-							"Some_redirect#102#"
+							"Some_redirect#102##"
 						]
 					}
 				}
@@ -90,7 +90,7 @@
 							"_REDI"
 						],
 						"propertyValues": [
-							"Some_redirect2#102#"
+							"Some_redirect2#102##"
 						]
 					}
 				}

--- a/tests/phpunit/Integration/JSONScript/TestCases/p-1003.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/p-1003.json
@@ -25,7 +25,7 @@
 						"_SKEY"
 					],
 					"propertyValues": [
-						"Has_unknown#102#",
+						"Has_unknown#102##",
 						"[8,\"smw-datavalue-property-create-restriction\",\"Has unknown\",\"foo\"]"
 					]
 				}
@@ -45,7 +45,7 @@
 						"_SKEY"
 					],
 					"propertyValues": [
-						"Has_unknown#102#",
+						"Has_unknown#102##",
 						"[2,\"smw-datavalue-property-create-restriction\",\"Has unknown\",\"foo\"]"
 					]
 				}

--- a/tests/phpunit/Integration/JSONScript/TestCases/q-0908.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/q-0908.json
@@ -131,7 +131,7 @@
 			"assert-queryresult": {
 				"count": 2,
 				"results": [
-					"Example/Q0908/3#0#",
+					"Example/Q0908/3#0##",
 					"Example/Q0908/3#0##_bc98426861e347260e7aa56265803598"
 				]
 			}
@@ -147,7 +147,7 @@
 			"assert-queryresult": {
 				"count": 2,
 				"results": [
-					"Example/Q0908/3#0#",
+					"Example/Q0908/3#0##",
 					"Example/Q0908/3#0##_bc98426861e347260e7aa56265803598"
 				]
 			}

--- a/tests/phpunit/Unit/Deserializers/SemanticDataDeserializerTest.php
+++ b/tests/phpunit/Unit/Deserializers/SemanticDataDeserializerTest.php
@@ -59,7 +59,7 @@ class SemanticDataDeserializerTest extends \PHPUnit_Framework_TestCase {
 
 		$this->assertInstanceOf(
 			'SMW\SemanticData',
-			$instance->deserialize( array( 'subject' => 'Foo#0#' ) )
+			$instance->deserialize( array( 'subject' => 'Foo#0##' ) )
 		);
 	}
 

--- a/tests/phpunit/Unit/Exporter/Element/ExpLiteralTest.php
+++ b/tests/phpunit/Unit/Exporter/Element/ExpLiteralTest.php
@@ -163,7 +163,7 @@ class ExpLiteralTest extends \PHPUnit_Framework_TestCase {
 				'lang'      => '',
 				'dataitem' => array(
 					'type' => DataItem::TYPE_WIKIPAGE,
-					'item' => 'Foo#0#'
+					'item' => 'Foo#0##'
 				)
 			)
 		);
@@ -178,7 +178,7 @@ class ExpLiteralTest extends \PHPUnit_Framework_TestCase {
 				'lang'      => 'en',
 				'dataitem' => array(
 					'type' => DataItem::TYPE_WIKIPAGE,
-					'item' => 'Foo#0#'
+					'item' => 'Foo#0##'
 				)
 			)
 		);

--- a/tests/phpunit/Unit/Exporter/Element/ExpNsResourceTest.php
+++ b/tests/phpunit/Unit/Exporter/Element/ExpNsResourceTest.php
@@ -175,7 +175,7 @@ class ExpNsResourceTest extends \PHPUnit_Framework_TestCase {
 				'uri'  => 'Foo|Bar|Fum',
 				'dataitem' => array(
 					'type' => DataItem::TYPE_WIKIPAGE,
-					'item' => 'Foo#0#'
+					'item' => 'Foo#0##'
 				)
 			)
 		);

--- a/tests/phpunit/Unit/Exporter/Element/ExpResourceTest.php
+++ b/tests/phpunit/Unit/Exporter/Element/ExpResourceTest.php
@@ -137,7 +137,7 @@ class ExpResourceTest extends \PHPUnit_Framework_TestCase {
 				'uri'  => 'Foo',
 				'dataitem' => array(
 					'type' => DataItem::TYPE_WIKIPAGE,
-					'item' => 'Foo#0#'
+					'item' => 'Foo#0##'
 				)
 			)
 		);

--- a/tests/phpunit/Unit/Exporter/ExpResourceMapperTest.php
+++ b/tests/phpunit/Unit/Exporter/ExpResourceMapperTest.php
@@ -145,7 +145,7 @@ class ExpResourceMapperTest extends \PHPUnit_Framework_TestCase {
 			array(
 				'type' => Element::TYPE_NSRESOURCE,
 				'uri'  => "Foo|{$wiki}|wiki",
-				'dataitem' => array( 'type' => 9, 'item' => 'Foo#0#' )
+				'dataitem' => array( 'type' => 9, 'item' => 'Foo#0##' )
 			)
 		);
 
@@ -156,7 +156,7 @@ class ExpResourceMapperTest extends \PHPUnit_Framework_TestCase {
 			array(
 				'type' => Element::TYPE_NSRESOURCE,
 				'uri'  => "bar-3AFoo|{$wiki}|wiki",
-				'dataitem' => array( 'type' => 9, 'item' => 'Foo#0#bar' )
+				'dataitem' => array( 'type' => 9, 'item' => 'Foo#0#bar#' )
 			)
 		);
 
@@ -189,7 +189,7 @@ class ExpResourceMapperTest extends \PHPUnit_Framework_TestCase {
 			array(
 				'type' => Element::TYPE_NSRESOURCE,
 				'uri'  => "Foo|{$property}|property",
-				'dataitem' => array( 'type' => 9, 'item' => 'Foo#102#' )
+				'dataitem' => array( 'type' => 9, 'item' => 'Foo#102##' )
 			)
 		);
 
@@ -200,7 +200,7 @@ class ExpResourceMapperTest extends \PHPUnit_Framework_TestCase {
 			array(
 				'type' => Element::TYPE_NSRESOURCE,
 				'uri'  => "Foo-23aux|{$property}|property",
-				'dataitem' => array( 'type' => 9, 'item' => 'Foo#102#' )
+				'dataitem' => array( 'type' => 9, 'item' => 'Foo#102##' )
 			)
 		);
 
@@ -215,7 +215,7 @@ class ExpResourceMapperTest extends \PHPUnit_Framework_TestCase {
 			array(
 				'type' => Element::TYPE_NSRESOURCE,
 				'uri'  => "$name-23aux|{$wiki}|wiki",
-				'dataitem' => array( 'type' => 9, 'item' => '-Foo#102#' )
+				'dataitem' => array( 'type' => 9, 'item' => '-Foo#102##' )
 			)
 		);
 
@@ -230,7 +230,7 @@ class ExpResourceMapperTest extends \PHPUnit_Framework_TestCase {
 		$expected =	array(
 			'type' => Element::TYPE_NSRESOURCE,
 			'uri'  => "||",
-			'dataitem' => array( 'type' => 9, 'item' => 'Foo#102#' )
+			'dataitem' => array( 'type' => 9, 'item' => 'Foo#102##' )
 		);
 
 		$provider[] = array(
@@ -241,7 +241,7 @@ class ExpResourceMapperTest extends \PHPUnit_Framework_TestCase {
 		$expected =	array(
 			'type' => Element::TYPE_NSRESOURCE,
 			'uri'  => "||",
-			'dataitem' => array( 'type' => 9, 'item' => 'Foo#14#' )
+			'dataitem' => array( 'type' => 9, 'item' => 'Foo#14##' )
 		);
 
 		$provider[] = array(

--- a/tests/phpunit/Unit/MediaWiki/Jobs/UpdateDispatcherJobTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Jobs/UpdateDispatcherJobTest.php
@@ -80,8 +80,8 @@ class UpdateDispatcherJobTest extends \PHPUnit_Framework_TestCase {
 
 		$instance = new UpdateDispatcherJob( $title, array(
 			'job-list' => array(
-				'Foo#0#' => true,
-				'Bar#102#'
+				'Foo#0##' => true,
+				'Bar#102##'
 			)
 		) );
 
@@ -102,7 +102,7 @@ class UpdateDispatcherJobTest extends \PHPUnit_Framework_TestCase {
 
 		$instance = new UpdateDispatcherJob( $title, array(
 			'job-list' => array(
-				'|nulltitle#0#' => true,
+				'|nulltitle#0##' => true,
 				'deserlizeerror#0' => true
 			)
 		) );

--- a/tests/phpunit/Unit/MediaWiki/Specials/SpecialBrowseTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Specials/SpecialBrowseTest.php
@@ -77,7 +77,7 @@ class SpecialBrowseTest extends \PHPUnit_Framework_TestCase {
 		$provider[] = array(
 			'Foo/Bar',
 			array(
-				'data-subject="Foo/Bar#0#"',
+				'data-subject="Foo/Bar#0##"',
 				'data-options="{&quot;dir&quot;:null,&quot;group&quot;:null,&quot;offset&quot;:null,&quot;printable&quot;:null,&quot;showInverse&quot;:false,&quot;showGroup&quot;:false,&quot;showSort&quot;:false,&quot;showAll&quot;:true,&quot;including&quot;:null}"'
 			)
 		);

--- a/tests/phpunit/Unit/ParserDataTest.php
+++ b/tests/phpunit/Unit/ParserDataTest.php
@@ -283,12 +283,12 @@ class ParserDataTest extends \PHPUnit_Framework_TestCase {
 
 		$cache->expects( $this->once() )
 			->method( 'fetch' )
-			->with( $this->stringContains( ':smw:update:55fd50809b6221a77f8f3dbd49e0d5bc' ) )
+			->with( $this->stringContains( ':smw:update:7fe0bc8114c23c928b25316e4858fceb' ) )
 			->will( $this->returnValue( 42 ) );
 
 		$cache->expects( $this->once() )
 			->method( 'save' )
-			->with( $this->stringContains( ':smw:update:55fd50809b6221a77f8f3dbd49e0d5bc' ) );
+			->with( $this->stringContains( ':smw:update:7fe0bc8114c23c928b25316e4858fceb' ) );
 
 		$instance = new ParserData(
 			$title,

--- a/tests/phpunit/Unit/PostProcHandlerTest.php
+++ b/tests/phpunit/Unit/PostProcHandlerTest.php
@@ -81,7 +81,7 @@ class PostProcHandlerTest extends \PHPUnit_Framework_TestCase {
 			->will( $this->returnValue( 'FakeCookie' ) );
 
 		$this->assertContains(
-			'<div class="smw-postproc" data-subject="Foo#0#" data-ref="[&quot;Bar&quot;]"></div>',
+			'<div class="smw-postproc" data-subject="Foo#0##" data-ref="[&quot;Bar&quot;]"></div>',
 			$instance->getHtml( $title,  $webRequest )
 		);
 	}
@@ -132,7 +132,7 @@ class PostProcHandlerTest extends \PHPUnit_Framework_TestCase {
 			->getMock();
 
 		$this->assertContains(
-			'<div class="smw-postproc" data-subject="Foo#0#" data-ref="[&quot;Bar&quot;]"></div>',
+			'<div class="smw-postproc" data-subject="Foo#0##" data-ref="[&quot;Bar&quot;]"></div>',
 			$instance->getHtml( $title,  $webRequest )
 		);
 	}
@@ -201,7 +201,7 @@ class PostProcHandlerTest extends \PHPUnit_Framework_TestCase {
 			->will( $this->returnValue( 'FakeCookie' ) );
 
 		$this->assertContains(
-			'<div class="smw-postproc" data-subject="Foo#0#" data-ref="[0]"></div>',
+			'<div class="smw-postproc" data-subject="Foo#0##" data-ref="[0]"></div>',
 			$instance->getHtml( $title,  $webRequest )
 		);
 	}

--- a/tests/phpunit/Unit/Query/Language/ClassDescriptionTest.php
+++ b/tests/phpunit/Unit/Query/Language/ClassDescriptionTest.php
@@ -148,7 +148,7 @@ class ClassDescriptionTest extends \PHPUnit_Framework_TestCase {
 		);
 
 		$this->assertSame(
-			'Cl:f35b531270067b4772aa3a1a907b8c81',
+			'Cl:c2d00d69a4e9517d075d9adf6aafea6e',
 			$instance->getFingerprint()
 		);
 	}

--- a/tests/phpunit/Unit/Query/Language/ConjunctionTest.php
+++ b/tests/phpunit/Unit/Query/Language/ConjunctionTest.php
@@ -132,9 +132,9 @@ class ConjunctionTest extends \PHPUnit_Framework_TestCase {
 		);
 
 		$description = array(
-			'V:03e5f313638479d132c1aeabd1eacc24' => $valueDescriptionFoo,
-			'V:26116b41f908d8ba2ce60d4f455c8d4d' => $valueDescriptionBar,
-			'V:f47714f302b181e713015c02c48cf86f' => $valueDescriptionYim
+			'V:903e513c13559ffaa66a23270a2922ff' => $valueDescriptionFoo,
+			'V:246b70c7cb6a9fe4613cad14405b682f' => $valueDescriptionBar,
+			'V:a3f71a427c6f9533ea1f093ff47bf958' => $valueDescriptionYim
 		);
 
 		$provider[] = array(

--- a/tests/phpunit/Unit/Query/Language/DisjunctionTest.php
+++ b/tests/phpunit/Unit/Query/Language/DisjunctionTest.php
@@ -130,9 +130,9 @@ class DisjunctionTest extends \PHPUnit_Framework_TestCase {
 		);
 
 		$expectedDescriptions = array(
-			'V:03e5f313638479d132c1aeabd1eacc24' => new ValueDescription( new DIWikiPage( 'Foo', NS_MAIN ) ),
-			'V:26116b41f908d8ba2ce60d4f455c8d4d' => new ValueDescription( new DIWikiPage( 'Bar', NS_MAIN ) ),
-			'V:f47714f302b181e713015c02c48cf86f' => new ValueDescription( new DIWikiPage( 'Yim', NS_MAIN ) )
+			'V:903e513c13559ffaa66a23270a2922ff' => new ValueDescription( new DIWikiPage( 'Foo', NS_MAIN ) ),
+			'V:246b70c7cb6a9fe4613cad14405b682f' => new ValueDescription( new DIWikiPage( 'Bar', NS_MAIN ) ),
+			'V:a3f71a427c6f9533ea1f093ff47bf958' => new ValueDescription( new DIWikiPage( 'Yim', NS_MAIN ) )
 		);
 
 		$provider[] = array(
@@ -149,8 +149,8 @@ class DisjunctionTest extends \PHPUnit_Framework_TestCase {
 		);
 
 		$descriptions = array(
-			'V:03e5f313638479d132c1aeabd1eacc24' => new ValueDescription( new DIWikiPage( 'Foo', NS_MAIN ) ),
-			'C:52a399e1faa619c79ecec246102125b8' => new Conjunction( array(
+			'V:903e513c13559ffaa66a23270a2922ff' => new ValueDescription( new DIWikiPage( 'Foo', NS_MAIN ) ),
+			'C:d0da0541e2e099655342be3af203814e' => new Conjunction( array(
 				new ValueDescription( new DIWikiPage( 'Bar', NS_MAIN ) ),
 				new ValueDescription( new DIWikiPage( 'Yim', NS_MAIN ) )
 			) )

--- a/tests/phpunit/Unit/Query/Language/SomePropertyTest.php
+++ b/tests/phpunit/Unit/Query/Language/SomePropertyTest.php
@@ -281,7 +281,7 @@ class SomePropertyTest extends \PHPUnit_Framework_TestCase {
 		);
 
 		$this->assertSame(
-			'S:17184798751fd76ae86d1c18bbce6954',
+			'S:8c2cab8d14dcd45d49aadb7fb5ab44a7',
 			$instance->getFingerprint()
 		);
 	}

--- a/tests/phpunit/Unit/Query/Result/CachedQueryResultPrefetcherTest.php
+++ b/tests/phpunit/Unit/Query/Result/CachedQueryResultPrefetcherTest.php
@@ -225,7 +225,7 @@ class CachedQueryResultPrefetcherTest extends \PHPUnit_Framework_TestCase {
 
 		$this->blobStore->expects( $this->atLeastOnce() )
 			->method( 'delete' )
-			->with( $this->equalTo( '063682d55f277990d70fa8213e5eccd8' ) );
+			->with( $this->equalTo( '1d1e1d94a78b9476c8213a16febe2c9b' ) );
 
 		$this->bufferedStatsdCollector->expects( $this->once() )
 			->method( 'recordStats' );
@@ -254,7 +254,7 @@ class CachedQueryResultPrefetcherTest extends \PHPUnit_Framework_TestCase {
 
 		$this->blobStore->expects( $this->atLeastOnce() )
 			->method( 'delete' )
-			->with( $this->equalTo( '855d675e0900f43bab62c191295af40d' ) );
+			->with( $this->equalTo( '1e5509cfde15f1f569db295e845ce997' ) );
 
 		$this->bufferedStatsdCollector->expects( $this->once() )
 			->method( 'recordStats' );

--- a/tests/phpunit/Unit/Query/Result/InMemoryEntityProcessListTest.php
+++ b/tests/phpunit/Unit/Query/Result/InMemoryEntityProcessListTest.php
@@ -34,7 +34,7 @@ class InMemoryEntityProcessListTest extends \PHPUnit_Framework_TestCase {
 		$instance->addDataItem( $dataItem );
 
 		$this->assertEquals(
-			array( 'Foo#0#' => $dataItem ),
+			array( 'Foo#0##' => $dataItem ),
 			$instance->getEntityList( 'FOO:123' )
 		);
 

--- a/tests/phpunit/Unit/SQLStore/QueryDependency/QueryResultDependencyListResolverTest.php
+++ b/tests/phpunit/Unit/SQLStore/QueryDependency/QueryResultDependencyListResolverTest.php
@@ -167,7 +167,7 @@ class QueryResultDependencyListResolverTest extends \PHPUnit_Framework_TestCase 
 		$expected = array(
 			DIWikiPage::newFromText( 'Foo' ),
 			DIWikiPage::newFromText( 'Bar' ),
-			'Foobar#102#' => DIWikiPage::newFromText( 'Foobar', SMW_NS_PROPERTY )
+			'Foobar#102##' => DIWikiPage::newFromText( 'Foobar', SMW_NS_PROPERTY )
 		//	DIWikiPage::newFromText( 'Subprop', SMW_NS_PROPERTY ) removed
 		);
 
@@ -307,8 +307,8 @@ class QueryResultDependencyListResolverTest extends \PHPUnit_Framework_TestCase 
 		$expected = array(
 			DIWikiPage::newFromText( 'Foo' ),
 			DIWikiPage::newFromText( 'Bar' ),
-			'Subprop#102#' => DIWikiPage::newFromText( 'Subprop', SMW_NS_PROPERTY ),
-			'Foobar#102#' => DIWikiPage::newFromText( 'Foobar', SMW_NS_PROPERTY )
+			'Subprop#102##' => DIWikiPage::newFromText( 'Subprop', SMW_NS_PROPERTY ),
+			'Foobar#102##' => DIWikiPage::newFromText( 'Foobar', SMW_NS_PROPERTY )
 		);
 
 		$this->assertEquals(
@@ -366,8 +366,8 @@ class QueryResultDependencyListResolverTest extends \PHPUnit_Framework_TestCase 
 
 		$expected = array(
 			DIWikiPage::newFromText( 'Foo' ),
-			'Subcat#14#' => DIWikiPage::newFromText( 'Subcat', NS_CATEGORY ),
-			'Foocat#14#' => DIWikiPage::newFromText( 'Foocat', NS_CATEGORY ),
+			'Subcat#14##' => DIWikiPage::newFromText( 'Subcat', NS_CATEGORY ),
+			'Foocat#14##' => DIWikiPage::newFromText( 'Foocat', NS_CATEGORY ),
 			DIWikiPage::newFromText( 'Foocat', NS_CATEGORY )
 		);
 
@@ -395,7 +395,7 @@ class QueryResultDependencyListResolverTest extends \PHPUnit_Framework_TestCase 
 			array(
 				DIWikiPage::newFromText( 'Foo' ),
 				DIWikiPage::newFromText( 'Bar' ),
-				'Foobar#102#' => DIWikiPage::newFromText( 'Foobar', SMW_NS_PROPERTY )
+				'Foobar#102##' => DIWikiPage::newFromText( 'Foobar', SMW_NS_PROPERTY )
 			)
 		);
 
@@ -412,7 +412,7 @@ class QueryResultDependencyListResolverTest extends \PHPUnit_Framework_TestCase 
 			$query,
 			array(
 				DIWikiPage::newFromText( 'Foo' ),
-				'Foobar#102#' => DIWikiPage::newFromText( 'Foobar', SMW_NS_PROPERTY )
+				'Foobar#102##' => DIWikiPage::newFromText( 'Foobar', SMW_NS_PROPERTY )
 			)
 		);
 
@@ -430,7 +430,7 @@ class QueryResultDependencyListResolverTest extends \PHPUnit_Framework_TestCase 
 			array(
 				DIWikiPage::newFromText( 'Foo' ),
 				DIWikiPage::newFromText( 'Bar' ),
-				'Foobar#102#' => DIWikiPage::newFromText( 'Foobar', SMW_NS_PROPERTY )
+				'Foobar#102##' => DIWikiPage::newFromText( 'Foobar', SMW_NS_PROPERTY )
 			)
 		);
 
@@ -452,7 +452,7 @@ class QueryResultDependencyListResolverTest extends \PHPUnit_Framework_TestCase 
 			array(
 				DIWikiPage::newFromText( 'Foo' ),
 				DIWikiPage::newFromText( 'Bar' ),
-				'Foobar#102#' => DIWikiPage::newFromText( 'Foobar', SMW_NS_PROPERTY )
+				'Foobar#102##' => DIWikiPage::newFromText( 'Foobar', SMW_NS_PROPERTY )
 			)
 		);
 
@@ -474,7 +474,7 @@ class QueryResultDependencyListResolverTest extends \PHPUnit_Framework_TestCase 
 			array(
 				DIWikiPage::newFromText( 'Foo' ),
 				DIWikiPage::newFromText( 'Bar' ),
-				'Foobar#102#' => DIWikiPage::newFromText( 'Foobar', SMW_NS_PROPERTY )
+				'Foobar#102##' => DIWikiPage::newFromText( 'Foobar', SMW_NS_PROPERTY )
 			)
 		);
 
@@ -506,7 +506,7 @@ class QueryResultDependencyListResolverTest extends \PHPUnit_Framework_TestCase 
 			$query,
 			array(
 				DIWikiPage::newFromText( 'Foo' ),
-				'FooConcept#108#' => DIWikiPage::newFromText( 'FooConcept', SMW_NS_CONCEPT )
+				'FooConcept#108##' => DIWikiPage::newFromText( 'FooConcept', SMW_NS_CONCEPT )
 			)
 		);
 
@@ -531,7 +531,7 @@ class QueryResultDependencyListResolverTest extends \PHPUnit_Framework_TestCase 
 				DIWikiPage::newFromText( 'Foo' ),
 				DIWikiPage::newFromText( 'Bar' ),
 				DIWikiPage::newFromText( 'Foobaz', SMW_NS_PROPERTY ),
-				'Foobar#102#' => DIWikiPage::newFromText( 'Foobar', SMW_NS_PROPERTY ),
+				'Foobar#102##' => DIWikiPage::newFromText( 'Foobar', SMW_NS_PROPERTY ),
 			)
 		);
 
@@ -557,7 +557,7 @@ class QueryResultDependencyListResolverTest extends \PHPUnit_Framework_TestCase 
 				DIWikiPage::newFromText( 'Foo' ),
 				DIWikiPage::newFromText( 'Bar' ),
 				DIWikiPage::newFromText( 'Foobaz', SMW_NS_PROPERTY ),
-				'Foobar#102#' => DIWikiPage::newFromText( 'Foobar', SMW_NS_PROPERTY ),
+				'Foobar#102##' => DIWikiPage::newFromText( 'Foobar', SMW_NS_PROPERTY ),
 			)
 		);
 
@@ -575,7 +575,7 @@ class QueryResultDependencyListResolverTest extends \PHPUnit_Framework_TestCase 
 			array(
 				DIWikiPage::newFromText( 'Foo' ),
 				DIWikiPage::newFromText( 'EQ_Comparator' ),
-				'Foobar#102#' => DIWikiPage::newFromText( 'Foobar', SMW_NS_PROPERTY )
+				'Foobar#102##' => DIWikiPage::newFromText( 'Foobar', SMW_NS_PROPERTY )
 			)
 		);
 
@@ -592,7 +592,7 @@ class QueryResultDependencyListResolverTest extends \PHPUnit_Framework_TestCase 
 			$query,
 			array(
 				DIWikiPage::newFromText( 'Foo' ),
-				'Foobar#102#' => DIWikiPage::newFromText( 'Foobar', SMW_NS_PROPERTY )
+				'Foobar#102##' => DIWikiPage::newFromText( 'Foobar', SMW_NS_PROPERTY )
 			)
 		);
 

--- a/tests/phpunit/Unit/SQLStore/QueryEngine/Fulltext/TextByChangeUpdaterTest.php
+++ b/tests/phpunit/Unit/SQLStore/QueryEngine/Fulltext/TextByChangeUpdaterTest.php
@@ -144,7 +144,7 @@ class TextByChangeUpdaterTest extends \PHPUnit_Framework_TestCase {
 			->method( 'dispatchFulltextSearchTableUpdateJobWith' )
 			->with(
 				$this->anything(),
-				$this->equalTo( array( 'slot:id' => 'Foo#0#' ) ) );
+				$this->equalTo( array( 'slot:id' => 'Foo#0##' ) ) );
 
 		$instance = new TextByChangeUpdater(
 			$this->connection,

--- a/tests/phpunit/Unit/SerializerFactoryTest.php
+++ b/tests/phpunit/Unit/SerializerFactoryTest.php
@@ -153,7 +153,7 @@ class SerializerFactoryTest extends \PHPUnit_Framework_TestCase {
 
 		#0
 		$provider[] = array(
-			array( 'serializer' => 'SMW\Serializers\SemanticDataSerializer', 'subject' => 'Foo#0#' )
+			array( 'serializer' => 'SMW\Serializers\SemanticDataSerializer', 'subject' => 'Foo#0##' )
 		);
 
 		#1

--- a/tests/phpunit/includes/SemanticDataTest.php
+++ b/tests/phpunit/includes/SemanticDataTest.php
@@ -90,7 +90,7 @@ class SemanticDataTest extends \PHPUnit_Framework_TestCase {
 
 		$instance->addPropertyValue(
 			'addPropertyValue',
-			DIWikiPage::doUnserialize( 'Foo#0#' )
+			DIWikiPage::doUnserialize( 'Foo#0##' )
 		);
 
 		$key = Localizer::getInstance()->getNamespaceTextById( SMW_NS_PROPERTY ) . ':' . 'addPropertyValue';

--- a/tests/phpunit/includes/dataitems/DIWikiPageTest.php
+++ b/tests/phpunit/includes/dataitems/DIWikiPageTest.php
@@ -65,6 +65,21 @@ class DIWikiPageTest extends DataItemTest {
 		);
 	}
 
+	public function testDoUnserialize() {
+
+		$expected = new DIWikiPage( 'Foo', 0 , '', '' );
+
+		$this->assertEquals(
+			$expected,
+			DIWikiPage::doUnserialize( 'Foo#0##' )
+		);
+
+		$this->assertEquals(
+			$expected,
+			DIWikiPage::doUnserialize( 'Foo#0##' )
+		);
+	}
+
 	public function sortKeyProvider() {
 
 		$provider[] = array(


### PR DESCRIPTION
This PR is made in reference to: #

This PR addresses or contains:

- This issue has annoyed me for sometime where the `DIWikiPage::getHash` would produce a different hash depending on whether a subobject was present or not. This now drops that ambiguity and always returns `#` which means `Foo#0#` becomes `Foo#0##` allowing to simply use # as separator without having to distinguish between one or two `#` at the end.

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed
