### PR TITLE
Special:Search add preference to disable note, refs 2738

### DIFF
--- a/i18n/en.json
+++ b/i18n/en.json
@@ -411,6 +411,7 @@
 	"smw-prefs-general-options-time-correction": "Enable time correction for special pages using the local [[Special:Preferences#mw-prefsection-rendering|time offset]] preference",
 	"smw-prefs-general-options-jobqueue-watchlist": "Show the [https://www.semantic-mediawiki.org/wiki/Help:Job_queue_watchlist job queue watchlist] in my personal bar",
 	"smw-prefs-general-options-disable-editpage-info": "Disable the introductory text on the edit page",
+	"smw-prefs-general-options-disable-search-info": "Disable the syntax suppport information on the standard search page",
 	"smw-prefs-general-options-suggester-textinput": "Enable [https://www.semantic-mediawiki.org/wiki/Help:Input_assistance input assistance] for semantic entity suggestions",
 	"smw-ui-tooltip-title-property": "Property",
 	"smw-ui-tooltip-title-quantity": "Unit conversion",

--- a/src/MediaWiki/Hooks/GetPreferences.php
+++ b/src/MediaWiki/Hooks/GetPreferences.php
@@ -68,6 +68,13 @@ class GetPreferences extends HookHandler {
 			'disabled' => !$this->getOption( 'smwgEnabledEditPageHelp', false )
 		);
 
+		$preferences['smw-prefs-general-options-disable-search-info'] = array(
+			'type' => 'toggle',
+			'label-message' => 'smw-prefs-general-options-disable-search-info',
+			'section' => 'smw/general-options',
+			'disabled' => $this->getOption( 'wgSearchType' ) !== 'SMWSearch'
+		);
+
 		$preferences['smw-prefs-general-options-jobqueue-watchlist'] = array(
 			'type' => 'toggle',
 			'label-message' => 'smw-prefs-general-options-jobqueue-watchlist',

--- a/src/MediaWiki/Hooks/HookRegistry.php
+++ b/src/MediaWiki/Hooks/HookRegistry.php
@@ -399,9 +399,18 @@ class HookRegistry {
 	 */
 	public function newSpecialSearchResultsPrepend( $specialSearch, $outputPage, $term ) {
 
+		$user = $outputPage->getUser();
+
 		$specialSearchResultsPrepend = new SpecialSearchResultsPrepend(
 			$specialSearch,
 			$outputPage
+		);
+
+		$specialSearchResultsPrepend->setOptions(
+			[
+				'prefs-suggester-textinput' => $user->getOption( 'smw-prefs-general-options-suggester-textinput' ),
+				'prefs-disable-search-info' => $user->getOption( 'smw-prefs-general-options-disable-search-info' )
+			]
 		);
 
 		return $specialSearchResultsPrepend->process( $term );
@@ -659,6 +668,7 @@ class HookRegistry {
 		$getPreferences->setOptions(
 			[
 				'smwgEnabledEditPageHelp' => $settings->get( 'smwgEnabledEditPageHelp' ),
+				'wgSearchType' => $GLOBALS['wgSearchType'],
 				'smwgJobQueueWatchlist' => $settings->get( 'smwgJobQueueWatchlist' )
 			]
 		);

--- a/src/MediaWiki/Hooks/SpecialSearchResultsPrepend.php
+++ b/src/MediaWiki/Hooks/SpecialSearchResultsPrepend.php
@@ -58,7 +58,7 @@ class SpecialSearchResultsPrepend extends HookHandler {
 				Message::USER_LANGUAGE
 			);
 
-			if ( $this->outputPage->getUser()->getOption( 'smw-prefs-general-options-suggester-textinput' ) ) {
+			if ( $this->getOption( 'prefs-suggester-textinput' ) ) {
 				$html .= ' ' . Message::get(
 					'smw-search-input-assistance',
 					Message::PARSE,
@@ -67,7 +67,7 @@ class SpecialSearchResultsPrepend extends HookHandler {
 			}
 		}
 
-		if ( $html !== '' ) {
+		if ( $html !== '' && !$this->getOption( 'prefs-disable-search-info' ) ) {
 			$this->outputPage->addHtml(
 				"<div class='smw-search-results-prepend plainlinks'>$html</div>"
 			);

--- a/tests/phpunit/Unit/MediaWiki/Hooks/SpecialSearchResultsPrependTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Hooks/SpecialSearchResultsPrependTest.php
@@ -54,10 +54,6 @@ class SpecialSearchResultsPrependTest extends \PHPUnit_Framework_TestCase {
 			->getMock();
 
 		$outputPage->expects( $this->atLeastOnce() )
-			->method( 'getUser' )
-			->will( $this->returnValue( $user ) );
-
-		$outputPage->expects( $this->atLeastOnce() )
 			->method( 'addHtml' );
 
 		$instance = new SpecialSearchResultsPrepend(
@@ -65,9 +61,56 @@ class SpecialSearchResultsPrependTest extends \PHPUnit_Framework_TestCase {
 			$outputPage
 		);
 
+		$instance->setOptions(
+			[
+				'prefs-suggester-textinput' => true,
+				'prefs-disable-search-info' => null
+			]
+		);
+
 		$this->assertTrue(
 			$instance->process( '' )
 		);
+	}
+
+	public function testProcess_DisabledInfo() {
+
+		$search = $this->getMockBuilder( '\SMWSearch' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$user = $this->getMockBuilder( '\User' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$specialSearch = $this->getMockBuilder( '\SpecialSearch' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$specialSearch->expects( $this->atLeastOnce() )
+			->method( 'getSearchEngine' )
+			->will( $this->returnValue( $search ) );
+
+		$outputPage = $this->getMockBuilder( '\OutputPage' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$outputPage->expects( $this->never() )
+			->method( 'addHtml' );
+
+		$instance = new SpecialSearchResultsPrepend(
+			$specialSearch,
+			$outputPage
+		);
+
+		$instance->setOptions(
+			[
+				'prefs-suggester-textinput' => true,
+				'prefs-disable-search-info' => true
+			]
+		);
+
+		$instance->process( '' );
 	}
 
 }


### PR DESCRIPTION
This PR is made in reference to: #2738 

This PR addresses or contains:

- Allows for logged-in users the disable the `Special:Search` info notice in their preferences

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed
