### PR TITLE
Switch from searchTitle to searchText

### DIFF
--- a/src/MediaWiki/Search/Search.php
+++ b/src/MediaWiki/Search/Search.php
@@ -158,6 +158,32 @@ class Search extends SearchEngine {
 	 */
 	public function searchTitle( $term ) {
 
+		if ( $this->getSearchQuery( $term ) !== null ) {
+			return null;
+		}
+
+		return $this->searchFallbackSearchEngine( $term, false );
+	}
+
+	/**
+	 * Perform a full text search query and return a result set.
+	 * If title searches are not supported or disabled, return null.
+	 *
+	 * @param string $term Raw search term
+	 *
+	 * @return SearchResultSet|\Status|null
+	 */
+	public function searchText( $term ) {
+
+		if ( $this->getSearchQuery( $term ) !== null ) {
+			return $this->getSearchResultSet( $term );
+		}
+
+		return $this->searchFallbackSearchEngine( $term, true );
+	}
+
+	private function getSearchResultSet( $term ) {
+
 		$query = $this->getSearchQuery( $term );
 
 		if ( $query !== null ) {
@@ -176,6 +202,9 @@ class Search extends SearchEngine {
 
 			$store = ApplicationFactory::getInstance()->getStore();
 
+			// Sort by score/relevance if available
+			$query->setOption( SMWQuery::SCORE_SORT, 'desc' );
+
 			$result = $store->getQueryResult( $query );
 
 			$query->querymode = SMWQuery::MODE_COUNT;
@@ -186,26 +215,6 @@ class Search extends SearchEngine {
 
 			return new SearchResultSet( $result, $count );
 		}
-
-		return $this->searchFallbackSearchEngine( $term, false );
-	}
-
-	/**
-	 * Perform a full text search query and return a result set.
-	 * If title searches are not supported or disabled, return null.
-	 *
-	 * @param string $term Raw search term
-	 *
-	 * @return SearchResultSet|\Status|null
-	 */
-	public function searchText( $term ) {
-
-		if ( $this->getSearchQuery( $term ) !== null ) {
-			// No fulltext search for semantic queries
-			return null;
-		}
-
-		return $this->searchFallbackSearchEngine( $term, true );
 	}
 
 	/**

--- a/tests/phpunit/Integration/MediaWiki/SearchInPageDBIntegrationTest.php
+++ b/tests/phpunit/Integration/MediaWiki/SearchInPageDBIntegrationTest.php
@@ -42,7 +42,7 @@ class SearchInPageDBIntegrationTest extends MwDBaseUnitTestCase {
 		$this->testEnvironment->executePendingDeferredUpdates();
 
 		$search = new Search();
-		$results = $search->searchTitle( '[[Has some page value::Foo]]' );
+		$results = $search->searchText( '[[Has some page value::Foo]]' );
 
 		$this->assertInstanceOf(
 			'\SMW\MediaWiki\Search\SearchResultSet',
@@ -81,7 +81,7 @@ class SearchInPageDBIntegrationTest extends MwDBaseUnitTestCase {
 		$this->testEnvironment->executePendingDeferredUpdates();
 
 		$search = new Search();
-		$results = $search->searchTitle( "[[Has coordinates::52°31'N, 13°24'E]]" );
+		$results = $search->searchText( "[[Has coordinates::52°31'N, 13°24'E]]" );
 
 		$this->assertInstanceOf(
 			'\SMW\MediaWiki\Search\SearchResultSet',

--- a/tests/phpunit/Unit/MediaWiki/Search/SearchTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Search/SearchTest.php
@@ -177,7 +177,7 @@ class SearchTest extends \PHPUnit_Framework_TestCase {
 		);
 	}
 
-	public function testSearchTitle_withSemanticQuery() {
+	public function testSearchText_withSemanticQuery() {
 
 		$term = '[[Some string that can be interpreted as a semantic query]]';
 
@@ -206,7 +206,7 @@ class SearchTest extends \PHPUnit_Framework_TestCase {
 		ApplicationFactory::getInstance()->registerObject( 'Store', $store );
 
 		$search = new Search();
-		$result = $search->searchTitle( $term );
+		$result = $search->searchText( $term );
 
 		$this->assertInstanceOf(
 			'SMW\MediaWiki\Search\SearchResultSet',
@@ -252,13 +252,13 @@ class SearchTest extends \PHPUnit_Framework_TestCase {
 		);
 	}
 
-	public function testSearchText_withSemanticQuery() {
+	public function testSearchTitle_withSemanticQuery() {
 
 		$term = '[[Some string that can be interpreted as a semantic query]]';
 
 		$search = new Search();
 
-		$this->assertNull( $search->searchText( $term ) );
+		$this->assertNull( $search->searchTitle( $term ) );
 	}
 
 	public function testSupports() {


### PR DESCRIPTION
This PR is made in reference to: #

This PR addresses or contains:

- We actually do a text search on what is annotated and not simply compare the title itself, so switch from `searchTitle` to `searchText`.

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed
