### PR TITLE
Add support for `phrase:` expression, refs 3054, 2873

### DIFF
--- a/DefaultSettings.php
+++ b/DefaultSettings.php
@@ -554,7 +554,7 @@ return array(
 	#
 	# @since 1.0
 	##
-	'smwgQComparators' => '<|>|!~|!|~|≤|≥|<<|>>|~=|like:|nlike:|in:',
+	'smwgQComparators' => '<|>|!~|!|~|≤|≥|<<|>>|~=|like:|nlike:|in:|phrase:',
 	##
 
 	###

--- a/src/Defines.php
+++ b/src/Defines.php
@@ -93,6 +93,7 @@ define( 'SMW_CMP_GRTR', 8 ); // Matches only datavalues that are greater than th
 define( 'SMW_CMP_PRIM_LIKE', 20 ); // Native LIKE matches (in disregards of an existing full-text index)
 define( 'SMW_CMP_PRIM_NLKE', 21 ); // Native NLIKE matches (in disregards of an existing full-text index)
 define( 'SMW_CMP_IN', 22 ); // Short-cut for ~* ... *
+define( 'SMW_CMP_PHRASE', 23 ); // Short-cut for a phrase match ~" ... " mostly for a full-text context
 /**@}*/
 
 /**@{

--- a/src/Query/QueryComparator.php
+++ b/src/Query/QueryComparator.php
@@ -161,6 +161,7 @@ class QueryComparator {
 			'like:' => SMW_CMP_PRIM_LIKE,
 			'nlike:' => SMW_CMP_PRIM_NLKE,
 			'in:' => SMW_CMP_IN,
+			'phrase:' => SMW_CMP_PHRASE,
 			'!~' => SMW_CMP_NLKE,
 			'<<' => SMW_CMP_LESS,
 			'>>' => SMW_CMP_GRTR,


### PR DESCRIPTION
This PR is made in reference to: #3054, #2873

This PR addresses or contains:

- Just a short cut expression for a proximity search such as `[[Has text::phrase:match the whole]]` or `[[phrase:find all matches]]` where the entire string (incl. word order) needs to satisfy the condition
- Mostly interesting for query engines that support full-text searches

This PR includes:
- [ ] Tests (unit/integration)
- [x] CI build passed
