### PR TITLE
Add SMWSearch power profile form

### DIFF
--- a/i18n/en.json
+++ b/i18n/en.json
@@ -493,6 +493,8 @@
 	"smw-search-input": "Input and search",
 	"smw-search-help-input-assistance": "[https://www.semantic-mediawiki.org/wiki/Help:Input_assistance Input assistance] is provided for the input field and requires to use one of following prefixes:\n\n*<code>p:</code> to enable property suggestions (e.g. <code><nowiki>[[p:Has ...</nowiki></code>)\n\n*<code>c:</code> to enable category suggestions\n\n*<code>con:</code> to enable concept suggestions",
 	"smw-search-syntax": "Syntax",
+	"smw-search-profile": "Extended",
+	"smw-search-profile-tooltip": "Search functions in connection with Semantic MediaWiki",
 	"log-name-smw": "Semantic MediaWiki log",
 	"log-show-hide-smw": "$1 Semantic MediaWiki log",
 	"log-description-smw": "Activities for [https://www.semantic-mediawiki.org/wiki/Help:Logging enabled event types] that have been reported by Semantic MediaWiki and its components.",

--- a/res/smw/special/ext.smw.special.search.css
+++ b/res/smw/special/ext.smw.special.search.css
@@ -71,6 +71,14 @@
     margin-left: 10px;
 }
 
+#smw-searchoptions {
+    margin: 0;
+    padding: 0.5em 0.75em 0.75em 0.75em;
+    background-color: #f8f9fa;
+    border: 1px solid #c8ccd1;
+    border-top-width: 0;
+}
+
 /**
 + * .skin-chameleon specific styles
 + */

--- a/res/smw/special/ext.smw.special.search.js
+++ b/res/smw/special/ext.smw.special.search.js
@@ -68,6 +68,23 @@
 	// https://www.semantic-mediawiki.org/wiki/Help:SMWSearch
 	if ( mw.config.get( 'wgCanonicalSpecialPageName' ) == 'Search' && mw.config.get( 'wgSearchType' ) == 'SMWSearch' ) {
 		load( search );
+
+		// Copied from mediawiki.special.search.js in order
+		// to have the NS button to work without #powersearch
+		var $checkboxes = $( '#search input[id^=mw-search-ns]' );
+
+		$( document ).on( "click", "#mw-search-toggleall", function(){
+			$checkboxes.prop( 'checked', true );
+		} );
+
+		$( document ).on( "click", "#mw-search-togglenone", function(){
+			$checkboxes.prop( 'checked', false );
+		} );
+
+		// When saving settings, use the proper request method (POST instead of GET).
+		$( document ).on( "change", "#mw-search-powersearch-remember", function() {
+			this.form.method = this.checked ? 'post' : 'get';
+		} ).trigger( 'change' );
 	};
 
 } )( jQuery, mediaWiki );

--- a/src/MediaWiki/Hooks/HookRegistry.php
+++ b/src/MediaWiki/Hooks/HookRegistry.php
@@ -254,8 +254,10 @@ class HookRegistry {
 			'LoadExtensionSchemaUpdates' => 'newLoadExtensionSchemaUpdates',
 
 			'ExtensionTypes' => 'newExtensionTypes',
-			'SpecialSearchResultsPrepend' => 'newSpecialSearchResultsPrepend',
 			'SpecialStatsAddExtra' => 'newSpecialStatsAddExtra',
+			'SpecialSearchResultsPrepend' => 'newSpecialSearchResultsPrepend',
+			'SpecialSearchProfileForm' => 'newSpecialSearchProfileForm',
+			'SpecialSearchProfiles' => 'newSpecialSearchProfiles',
 
 			'BlockIpComplete' => 'newBlockIpComplete',
 			'UnblockUserComplete' => 'newUnblockUserComplete',
@@ -414,6 +416,40 @@ class HookRegistry {
 		);
 
 		return $specialSearchResultsPrepend->process( $term );
+	}
+
+	/**
+	 * @see https://www.mediawiki.org/wiki/Manual:Hooks/SpecialSearchProfiles
+	 */
+	public function newSpecialSearchProfiles( array &$profiles ) {
+
+		\SMW\MediaWiki\Search\SearchProfile::addProfile(
+			$profiles
+		);
+
+		return true;
+	}
+
+	/**
+	 * @see https://www.mediawiki.org/wiki/Manual:Hooks/SpecialSearchProfileForm
+	 */
+	public function newSpecialSearchProfileForm( $specialSearch, &$form, $profile, $term, $opts ) {
+
+		if ( $profile !== \SMW\MediaWiki\Search\SearchProfile::PROFILE_NAME ) {
+			return true;
+		}
+
+		$searchProfile = new \SMW\MediaWiki\Search\SearchProfile(
+			$specialSearch
+		);
+
+		$searchProfile ->setSearchableNamespaces(
+			\MediaWiki\MediaWikiServices::getInstance()->getSearchEngineConfig()->searchableNamespaces()
+		);
+
+		$searchProfile->getForm( $form, $opts );
+
+		return false;
 	}
 
 	/**

--- a/src/MediaWiki/Search/Search.php
+++ b/src/MediaWiki/Search/Search.php
@@ -188,6 +188,8 @@ class Search extends SearchEngine {
 
 		if ( $query !== null ) {
 
+			$this->findNamespaces();
+
 			$namespacesDisjunction = new Disjunction(
 				array_map( function ( $ns ) {
 					return new NamespaceDescription( $ns );
@@ -202,9 +204,7 @@ class Search extends SearchEngine {
 
 			$store = ApplicationFactory::getInstance()->getStore();
 
-			// Sort by score/relevance if available
-			$query->setOption( SMWQuery::SCORE_SORT, 'desc' );
-
+			$this->findSortPreference( $query );
 			$result = $store->getQueryResult( $query );
 
 			$query->querymode = SMWQuery::MODE_COUNT;
@@ -340,6 +340,35 @@ class Search extends SearchEngine {
 		return $this->showSuggestion;
 	}
 
+	/**
+	 * @return []
+	 */
+	public function findNamespaces() {
+
+		$searchableNamespaces = $this->searchableNamespaces();
+
+		$this->namespaces = [];
+
+		foreach ( $searchableNamespaces as $ns => $name ) {
+			if ( $GLOBALS['wgRequest']->getCheck( 'ns' . $ns ) ) {
+				$this->namespaces[] = $ns;
+			}
+		}
+	}
+
+	public function findSortPreference( $query ) {
+
+		$sort = $GLOBALS['wgRequest']->getVal( 'sort' );
+
+		if ( $sort === 'recent') {
+			$query->setSortKeys( [ '_MDAT' => 'desc' ] );
+		} elseif ( $sort === 'title') {
+			$query->setSortKeys( [ '' => 'asc' ] );
+		} else {
+			// Sort by score/relevance if available
+			$query->setOption( SMWQuery::SCORE_SORT, 'desc' );
+		}
+	}
 
 	public function setLimitOffset( $limit, $offset = 0 ) {
 		parent::setLimitOffset( $limit, $offset );

--- a/src/MediaWiki/Search/SearchProfile.php
+++ b/src/MediaWiki/Search/SearchProfile.php
@@ -1,0 +1,212 @@
+<?php
+
+namespace SMW\MediaWiki\Search;
+
+use SMW;
+use SpecialSearch;
+use Html;
+use Xml;
+use MWNamespace;
+use SMW\Message;
+
+/**
+ * @ingroup SMW
+ *
+ * @license GNU GPL v2+
+ * @since 3.0
+ *
+ * @author mwjames
+ */
+class SearchProfile {
+
+	const PROFILE_NAME = 'smw';
+
+	/**
+	 * @var SpecialSearch
+	 */
+	private $specialSearch;
+
+	/**
+	 * @var []
+	 */
+	private $searchableNamespaces = [];
+
+	/**
+	 * @since 3.0
+	 *
+	 * @param SpecialSearch $specialSearch
+	 */
+	public function __construct( SpecialSearch $specialSearch ) {
+		$this->specialSearch = $specialSearch;
+	}
+
+	/**
+	 * @since 3.0
+	 *
+	 * @param array &$profiles
+	 */
+	public static function addProfile( array &$profiles ) {
+
+		if ( $GLOBALS['wgSearchType'] !== 'SMWSearch' ) {
+			return;
+		}
+
+		$profiles[self::PROFILE_NAME] = array(
+			'message' => 'smw-search-profile',
+			'tooltip' => 'smw-search-profile-tooltip',
+			'namespaces' => \SearchEngine::defaultNamespaces()
+		);
+	}
+
+	/**
+	 * @since 3.0
+	 */
+	public function setSearchableNamespaces( array $searchableNamespaces ) {
+		$this->searchableNamespaces = $searchableNamespaces;
+	}
+
+	/**
+	 * @since 3.0
+	 */
+	public function getForm( &$form, $opts ) {
+
+		$hidden = '';
+		$html = '';
+
+		foreach ( $opts as $key => $value ) {
+			$hidden .= Html::hidden( $key, $value );
+		}
+
+		$request = $this->specialSearch->getContext()->getRequest();
+		$sort = $request->getVal( 'sort' );
+
+		$this->specialSearch->setExtraParam( 'sort', $sort );
+
+		$list = [
+			'best'   => 'Best Match',
+			'recent' => 'Most Recent',
+			'title'  => 'Title'
+		];
+
+		foreach ( $list as $key => $value ) {
+			$opt = '';
+
+			if ( $sort === $key ) {
+				$opt = 'selected';
+			}
+
+			$html .= "<option value='$key' $opt>$value</option>";
+		}
+
+		$html = '<select name="sort">' . $html . '</select>';
+
+		$params = array( 'id' => 'smw-searchoptions' );
+
+		$form = Xml::fieldset( false, false, $params ) . $hidden . $html . Html::closeElement( 'fieldset' );
+
+		$activeNamespaces = $this->specialSearch->getNamespaces();
+
+		foreach ( $this->searchableNamespaces as $ns => $name ) {
+			if ( $request->getCheck( 'ns' . $ns ) ) {
+				$activeNamespaces[] = $ns;
+				$this->specialSearch->setExtraParam( 'ns' . $ns, true );
+			}
+		}
+
+		$searchEngine = $this->specialSearch->getSearchEngine();
+
+		if ( $searchEngine !== null ) {
+			$searchEngine->setNamespaces( $activeNamespaces );
+		}
+
+		$divider = "<div class='divider'></div>";
+
+		$form .= $this->createMWNamespaceForm( $activeNamespaces, $divider, '' );
+	}
+
+	/**
+	 * @notes Copied from SearchFormWidget::powerSearchBox
+	 */
+	private function createMWNamespaceForm( $activeNamespaces, $divider, $hidden ) {
+		global $wgContLang;
+
+		$rows = [];
+
+		foreach ( $this->searchableNamespaces as $namespace => $name ) {
+			$subject = MWNamespace::getSubject( $namespace );
+
+			if ( MWNamespace::isTalk( $namespace ) ) {
+			//	continue;
+			}
+
+			if ( !isset( $rows[$subject] ) ) {
+				$rows[$subject] = "";
+			}
+
+			$name = $wgContLang->getConverter()->convertNamespace( $namespace );
+
+			if ( $name === '' ) {
+				$name = Message::get( 'blanknamespace', Message::TEXT, Message::USER_LANGUAGE );
+			}
+
+			$rows[$subject] .=
+				'<td>' .
+					Xml::checkLabel(
+						$name,
+						"ns{$namespace}",
+						"mw-search-ns{$namespace}",
+						in_array( $namespace, $activeNamespaces )
+					) .
+				'</td>';
+		}
+
+		// Lays out namespaces in multiple floating two-column tables so they'll
+		// be arranged nicely while still accomodating diferent screen widths
+		$tableRows = [];
+		foreach ( $rows as $row ) {
+			$tableRows[] = "<tr>{$row}</tr>";
+		}
+		$namespaceTables = [];
+		foreach ( array_chunk( $tableRows, 4 ) as $chunk ) {
+			$namespaceTables[] = implode( '', $chunk );
+		}
+
+		$showSections = [
+			'namespaceTables' => "<table>" . implode( '</table><table>', $namespaceTables ) . '</table>',
+		];
+
+		// Stuff to feed SpecialSearch::saveNamespaces()
+		$user = $this->specialSearch->getUser();
+		$remember = '';
+		if ( $user->isLoggedIn() ) {
+			$remember = $divider . Xml::checkLabel(
+				Message::get( 'powersearch-remember', Message::TEXT, Message::USER_LANGUAGE ),
+				'nsRemember',
+				'mw-search-powersearch-remember',
+				false,
+				// The token goes here rather than in a hidden field so it
+				// is only sent when necessary (not every form submission)
+				[ 'value' => $user->getEditToken(
+					'searchnamespace',
+					$this->specialSearch->getRequest()
+				) ]
+			);
+		}
+
+		return
+			"<fieldset id='mw-searchoptions'>" .
+				"<legend>" . Message::get( 'powersearch-legend', Message::ESCAPED, Message::USER_LANGUAGE ) . '</legend>' .
+				"<h4>" . Message::get( 'powersearch-ns', Message::PARSE, Message::USER_LANGUAGE ) . '</h4>' .
+				// populated by js if available
+				"<div id='mw-search-togglebox'></div>" .
+				$divider .
+				implode(
+					$divider,
+					$showSections
+				) .
+				$hidden .
+				$remember .
+			"</fieldset>";
+	}
+
+}

--- a/tests/phpunit/Unit/MediaWiki/Hooks/HookRegistryTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Hooks/HookRegistryTest.php
@@ -183,6 +183,8 @@ class HookRegistryTest extends \PHPUnit_Framework_TestCase {
 		$this->doTestExecutionForOutputPageParserOutput( $instance );
 		$this->doTestExecutionForBeforePageDisplay( $instance );
 		$this->doTestExecutionForSpecialSearchResultsPrepend( $instance );
+		$this->doTestExecutionForSpecialSearchProfiles( $instance );
+		$this->doTestExecutionForSpecialSearchProfileForm( $instance );
 		$this->doTestExecutionForInternalParseBeforeLinks( $instance );
 		$this->doTestExecutionForNewRevisionFromEditComplete( $instance );
 		$this->doTestExecutionForTitleMoveComplete( $instance );
@@ -384,6 +386,65 @@ class HookRegistryTest extends \PHPUnit_Framework_TestCase {
 		$this->assertThatHookIsExcutable(
 			$instance->getHandlerFor( $handler ),
 			array( $specialSearch, $this->outputPage, '' )
+		);
+
+		$this->handlers[$handler] = true;
+	}
+
+	public function doTestExecutionForSpecialSearchProfiles( $instance ) {
+
+		$handler = 'SpecialSearchProfiles';
+
+		$this->assertTrue(
+			$instance->isRegistered( $handler )
+		);
+
+		$profiles = [];
+
+		$this->assertThatHookIsExcutable(
+			$instance->getHandlerFor( $handler ),
+			[ &$profiles ]
+		);
+
+		$this->handlers[$handler] = true;
+	}
+
+	public function doTestExecutionForSpecialSearchProfileForm( $instance ) {
+
+		$handler = 'SpecialSearchProfileForm';
+
+		$user = $this->getMockBuilder( '\USer' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$specialSearch = $this->getMockBuilder( '\SpecialSearch' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$specialSearch->expects( $this->any() )
+			->method( 'getUser' )
+			->will( $this->returnValue( $user ) );
+
+		$specialSearch->expects( $this->any() )
+			->method( 'getNamespaces' )
+			->will( $this->returnValue( [] ) );
+
+		$specialSearch->expects( $this->any() )
+			->method( 'getContext' )
+			->will( $this->returnValue( $this->requestContext ) );
+
+		$this->assertTrue(
+			$instance->isRegistered( $handler )
+		);
+
+		$form = '';
+		$profile = 'smw';
+		$term = '';
+		$opts = [];
+
+		$this->assertThatHookIsExcutable(
+			$instance->getHandlerFor( $handler ),
+			[ $specialSearch, &$form, $profile, $term, $opts ]
 		);
 
 		$this->handlers[$handler] = true;


### PR DESCRIPTION
This PR is made in reference to: #

This PR addresses or contains:

- Adds a `smw` power form to `Special:Search` for when `$wgSearchType = 'SMWSearch';` is used

This PR includes:
- [ ] Tests (unit/integration)
- [ ] CI build passed

![image](https://user-images.githubusercontent.com/1245473/38772320-123a57aa-4023-11e8-9890-edc23212d013.png)
