### PR TITLE
SMW_NS_RULE switch to own content handler, refs 3019

### DIFF
--- a/src/Defines.php
+++ b/src/Defines.php
@@ -279,3 +279,10 @@ define( 'SMW_QSORT_RANDOM', 4 ); // Random sort support
   */
 define( 'SMW_RULE_GROUP_FORMAT', 'rule.group.format' );
 /**@}*/
+
+/**@{
+  * Constants for content types
+  */
+define( 'CONTENT_MODEL_RULE', 'rule-json' );
+define( 'CONTENT_FORMAT_RULE', 'application/json' );
+/**@}*/

--- a/src/MediaWiki/Hooks/HookRegistry.php
+++ b/src/MediaWiki/Hooks/HookRegistry.php
@@ -77,6 +77,8 @@ class HookRegistry {
 	 */
 	public static function initExtension( array &$vars ) {
 
+		$vars['wgContentHandlers'][CONTENT_MODEL_RULE] = 'SMW\Rule\RuleContentHandler';
+
 		/**
 		 * CanonicalNamespaces initialization
 		 *

--- a/src/NamespaceManager.php
+++ b/src/NamespaceManager.php
@@ -223,7 +223,7 @@ class NamespaceManager {
 			$vars['smwgNamespacesWithSemanticLinks']
 		);
 
-		$vars['wgNamespaceContentModels'][SMW_NS_RULE] = CONTENT_MODEL_JSON;
+		$vars['wgNamespaceContentModels'][SMW_NS_RULE] = CONTENT_MODEL_RULE;
 	}
 
 	private function addExtraNamespaceSettings( &$vars ) {

--- a/src/Page/RulePage.php
+++ b/src/Page/RulePage.php
@@ -293,17 +293,19 @@ class RulePage extends Page {
 		$description = $this->ruleDefinition->get( 'description', '' );
 		$type = $this->ruleDefinition->get( 'type', '' );
 
-		$list[] = Html::rawElement(
-			'span',
-			[
-				'class' => 'plainlinks'
-			],
-			Message::get(
-				'smw-rule-page-description',
-				Message::PARSE,
-				Message::USER_LANGUAGE
-			) . '&nbsp;' . $description
-		);
+		if ( $description !== '' ) {
+			$list[] = Html::rawElement(
+				'span',
+				[
+					'class' => 'plainlinks'
+				],
+				Message::get(
+					'smw-rule-page-description',
+					Message::PARSE,
+					Message::USER_LANGUAGE
+				) . '&nbsp;' . $description
+			);
+		}
 
 		$list[] = Html::rawElement(
 			'span',

--- a/src/Rule/RuleContent.php
+++ b/src/Rule/RuleContent.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace SMW\Rule;
+
+use JsonContent;
+use Title;
+use WikiPage;
+use User;
+use Status;
+
+/**
+ * @license GNU GPL v2+
+ * @since 3.0
+ *
+ * @author mwjames
+ */
+class RuleContent extends JsonContent {
+
+	/**
+	 * @see JsonContent
+	 */
+	public function __construct( $text ) {
+		parent::__construct( $text, CONTENT_MODEL_RULE );
+	}
+
+}

--- a/src/Rule/RuleContentHandler.php
+++ b/src/Rule/RuleContentHandler.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace SMW\Rule;
+
+use JsonContentHandler;
+use Title;
+
+/**
+ * @license GNU GPL v2+
+ * @since 3.0
+ *
+ * @author mwjames
+ */
+class RuleContentHandler extends JsonContentHandler {
+
+	/**
+	 * @since 3.0
+	 *
+	 * {@inheritDoc}
+	 */
+	public function __construct() {
+		parent::__construct( CONTENT_MODEL_RULE, [ CONTENT_FORMAT_RULE ] );
+	}
+
+	/**
+	 * @since 3.0
+	 *
+	 * {@inheritDoc}
+	 */
+	protected function getContentClass() {
+		return RuleContent::class;
+	}
+
+}

--- a/tests/phpunit/Unit/NamespaceManagerTest.php
+++ b/tests/phpunit/Unit/NamespaceManagerTest.php
@@ -279,7 +279,7 @@ class NamespaceManagerTest extends \PHPUnit_Framework_TestCase {
 		$instance->init( $vars );
 
 		$this->assertEquals(
-			CONTENT_MODEL_JSON,
+			CONTENT_MODEL_RULE,
 			$vars['wgNamespaceContentModels'][SMW_NS_RULE]
 		);
 	}

--- a/tests/phpunit/Unit/Rule/RuleContentHandlerTest.php
+++ b/tests/phpunit/Unit/Rule/RuleContentHandlerTest.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace SMW\Tests\Rule;
+
+use SMW\Rule\RuleContentHandler;
+
+/**
+ * @covers \SMW\Rule\RuleContentHandler
+ * @group semantic-mediawiki
+ *
+ * @license GNU GPL v2+
+ * @since 3.0
+ *
+ * @author mwjames
+ */
+class RuleContentHandlerTest extends \PHPUnit_Framework_TestCase {
+
+	public function testCanConstruct() {
+
+		$this->assertInstanceof(
+			'\JsonContentHandler',
+			new RuleContentHandler()
+		);
+	}
+
+}

--- a/tests/phpunit/Unit/Rule/RuleContentTest.php
+++ b/tests/phpunit/Unit/Rule/RuleContentTest.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace SMW\Tests\Rule;
+
+use SMW\Rule\RuleContent;
+
+/**
+ * @covers \SMW\Rule\RuleContent
+ * @group semantic-mediawiki
+ *
+ * @license GNU GPL v2+
+ * @since 3.0
+ *
+ * @author mwjames
+ */
+class RuleContentTest extends \PHPUnit_Framework_TestCase {
+
+	public function testCanConstruct() {
+
+		$this->assertInstanceof(
+			'\JsonContent',
+			new RuleContent( 'foo' )
+		);
+	}
+
+}


### PR DESCRIPTION
This PR is made in reference to: #3019

This PR addresses or contains:

- Adds `CONTENT_MODEL_RULE` and for now just wraps around `JsonContent`/`JsonContentHandler` to be able to do schema validation before a save [0] sometime in future. Switching to an alternate model at a later stage will only create headaches.

[0] https://github.com/wikimedia/mediawiki-extensions-examples/blob/master/DataPages/XmlContent.php#L98-L136

This PR includes:
- [ ] Tests (unit/integration)
- [x] CI build passed

Fixes #