### PR TITLE
Don't rely on $wgExtensionDirectory to find SMW's extension.json

### DIFF
--- a/src/GlobalFunctions.php
+++ b/src/GlobalFunctions.php
@@ -217,7 +217,7 @@ function enableSemantics( $namespace = null, $complete = false ) {
 	global $smwgNamespace;
 
 	// #1732 + #2813
-	wfLoadExtension( 'SemanticMediaWiki' );
+	wfLoadExtension( 'SemanticMediaWiki', dirname( __DIR__ ) . '/extension.json' );
 
 	// Apparently this is required (1.28+) as the earliest possible execution
 	// point in order for settings that refer to the SMW_NS_PROPERTY namespace


### PR DESCRIPTION
While extension.json expects that all extensions will be in a single directory,
SemanticMediaWiki previously didn't require this. By passing the second
argument to `wfLoadExtension()`, we can specify exactly which extension.json
to read from, instead of relying upon `$wgExtensionDirectory`.

Fixes #3133.

I didn't test this.

This PR is made in reference to: #3133 and #1732 

This PR addresses or contains:
- Bug fix for linked bug

This PR includes:
- [ ] Tests (unit/integration)
- [x] CI build passed