### PR TITLE
Replace DISTINCT with GROUP BY in SQLStore::getPropertySubjects

### DIFF
--- a/DefaultSettings.php
+++ b/DefaultSettings.php
@@ -77,7 +77,7 @@ return array(
 	#
 	# @since 3.0
 	##
-	'smwgUpgradeKey' => 'DB-2018-04',
+	'smwgUpgradeKey' => 'DB-2018-04.1',
 	##
 
 	###

--- a/includes/storage/SQLStore/SMW_Sql3SmwIds.php
+++ b/includes/storage/SQLStore/SMW_Sql3SmwIds.php
@@ -710,7 +710,7 @@ class SMWSql3SmwIds {
 					'smw_iw' => $iw,
 					'smw_subobject' => $subobjectName,
 					'smw_sortkey' => $sortkey,
-					'smw_sort' => Collator::singleton()->getSortKey( $sortkey ),
+					'smw_sort' => Collator::singleton()->getTruncatedSortKey( $sortkey ),
 					'smw_hash' => $this->computeSha1( [ $title, (int)$namespace, $iw, $subobjectName ] )
 				),
 				__METHOD__

--- a/src/MediaWiki/Collator.php
+++ b/src/MediaWiki/Collator.php
@@ -99,6 +99,19 @@ class Collator {
 	 *
 	 * @return string
 	 */
+	public function getTruncatedSortKey( $text, $id = '' ) {
+		// #2089 (MySQL 5.7 complained with "Data too long for column")
+		//return mb_substr( $this->getSortKey( $text ), 0, 240 ) . '#'. $id;
+		return mb_substr( $this->getSortKey( $text ), 0, 254 );
+	}
+
+	/**
+	 * @since 3.0
+	 *
+	 * @param string $text
+	 *
+	 * @return string
+	 */
 	public function getSortKey( $text ) {
 		return $this->collation->getSortKey( $text );
 	}

--- a/src/RequestOptions.php
+++ b/src/RequestOptions.php
@@ -73,6 +73,11 @@ class RequestOptions {
 	private $extraConditions = array();
 
 	/**
+	 * @var array
+	 */
+	private $options = [];
+
+	/**
 	 * @since 1.0
 	 *
 	 * @param string $string to match
@@ -111,6 +116,33 @@ class RequestOptions {
 	 */
 	public function getExtraConditions() {
 		return $this->extraConditions;
+	}
+
+	/**
+	 * @since 3.0
+	 *
+	 * @param string $key
+	 * @param string $value
+	 */
+	public function setOption( $key, $value ) {
+		$this->options[$key] = $value;
+	}
+
+	/**
+	 * @since 3.0
+	 *
+	 * @param string $key
+	 * @param mixed $default
+	 *
+	 * @return mixed
+	 */
+	public function getOption( $key, $default = null ) {
+
+		if ( isset( $this->options[$key] ) ) {
+			return $this->options[$key];
+		}
+
+		return $default;
 	}
 
 	/**
@@ -170,7 +202,8 @@ class RequestOptions {
 			$this->boundary,
 			$this->include_boundary,
 			$stringConditions,
-			$this->extraConditions
+			$this->extraConditions,
+			$this->options,
 		) );
 	}
 

--- a/src/SQLStore/EntityStore/DIHandlers/DIBlobHandler.php
+++ b/src/SQLStore/EntityStore/DIHandlers/DIBlobHandler.php
@@ -49,7 +49,26 @@ class DIBlobHandler extends DataItemHandler {
 	 * {@inheritDoc}
 	 */
 	public function getTableIndexes() {
-		return array( 's_id,o_hash' );
+		return array(
+
+			's_id,o_hash',
+
+			// Store::getPropertySubjects
+			/**
+			* SELECT smw_title, smw_namespace, smw_iw, smw_subobject, smw_sortkey, smw_sort FROM `smw_object_ids`
+			* INNER JOIN `smw_di_blob` AS t1 ON t1.s_id=smw_id
+			* WHERE t1.p_id='310174' AND smw_iw!=':smw' AND smw_iw!=':smw-delete' AND smw_iw!=':smw-redi'
+			* GROUP BY smw_sort ORDER BY smw_sort LIMIT 26	18666.3489ms	SMWSQLStore3Readers::getPropertySubjects
+			*
+			* vs.
+			*
+			* SELECT smw_title, smw_namespace, smw_iw, smw_subobject, smw_sortkey, smw_sort FROM `smw_object_ids`
+			* INNER JOIN `smw_di_blob` AS t1 ON t1.s_id=smw_id
+			* WHERE t1.p_id='310174' AND smw_iw!=':smw' AND smw_iw!=':smw-delete' AND smw_iw!=':smw-redi'
+			* GROUP BY smw_sort ORDER BY smw_sort LIMIT 26	59.3290ms	SMWSQLStore3Readers::getPropertySubjects
+			*/
+			'p_id',
+		);
 	}
 
 	/**

--- a/src/SQLStore/RequestOptionsProc.php
+++ b/src/SQLStore/RequestOptionsProc.php
@@ -48,9 +48,17 @@ class RequestOptionsProc {
 			$sqlConds['ORDER BY'] = $requestOptions->ascending ? $valueCol : $valueCol . ' DESC';
 		}
 
+		if ( $requestOptions->getOption( 'GROUP BY' ) ) {
+			$sqlConds['GROUP BY'] = $requestOptions->getOption( 'GROUP BY' );
+		}
+
+		if ( $requestOptions->getOption( 'DISTINCT' ) ) {
+			$sqlConds['DISTINCT'] = $requestOptions->getOption( 'DISTINCT' );
+		}
+
 		// Avoid a possible filesort (likely caused by ORDER BY) when limit is
 		// less than 2
-		if ( $requestOptions->limit < 2 ) {
+		if ( $requestOptions->limit < 2 || $requestOptions->getOption( 'ORDER BY' ) === false ) {
 			unset( $sqlConds['ORDER BY'] );
 		}
 

--- a/src/SQLStore/TableFieldUpdater.php
+++ b/src/SQLStore/TableFieldUpdater.php
@@ -62,7 +62,12 @@ class TableFieldUpdater {
 
 		// #2089 (MySQL 5.7 complained with "Data too long for column")
 		$searchKey = mb_substr( $searchKey, 0, 254 );
-		$sort = mb_substr(  $this->collator->getSortKey( $searchKey ), 0, 254 );
+
+		// http://www.mysqltutorial.org/mysql-distinct.aspx
+		// Make the sort unique at the last position so that when GROUP by is used
+		// it executes "... the GROUP BY clause sorts the result set" and as the
+		// same time picks a uniqueue set avoiding a SELECT DISTINCT and a filesort
+		$sort = $this->collator->getTruncatedSortKey( $searchKey, $id );
 
 		$connection->beginAtomicTransaction( __METHOD__ );
 

--- a/src/SQLStore/TableSchemaManager.php
+++ b/src/SQLStore/TableSchemaManager.php
@@ -175,10 +175,9 @@ class TableSchemaManager {
 		// Select by sortkey (range queries)
 		$table->addIndex( 'smw_sortkey' );
 
-		// Sort related indices
+		// Sort related indices, Store::getPropertySubjects (GROUP BY)
 		// $table->addIndex( 'smw_sort' );
-		$table->addIndex( 'smw_id,smw_sort' );
-		//$table->addIndex( 'smw_sort,smw_id' );
+		$table->addIndex( 'smw_sort,smw_id' );
 
 		// API smwbrowse primary lookup
 		// Limit the index length for MySQL (only 1000 Bytes are allowed)
@@ -293,7 +292,15 @@ class TableSchemaManager {
 
 		if ( !$propertyTable->isFixedPropertyTable() ) {
 			$fieldarray['p_id'] = array( FieldType::FIELD_ID, 'NOT NULL' );
-			$indexes['po'] = 'p_id,' . $indexes['po'];
+
+			// In order to find the right index for the blob related tables,
+			// individual index declared in the table method
+			if ( strpos( $indexes['po'] , 'o_hash' ) === false ) {
+				$indexes['po'] = 'p_id,' . $indexes['po'];
+			} else {
+				$indexes['p'] = 'p_id';
+			}
+
 			$indexes['sp'] = $indexes['sp'] . ',p_id';
 		}
 

--- a/tests/phpunit/Integration/JSONScript/TestCases/p-1006.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/p-1006.json
@@ -1,0 +1,78 @@
+{
+	"description": "Test property page sorting (`wgRestrictDisplayTitle`, `smwgEntityCollation`)",
+	"setup": [
+		{
+			"namespace": "SMW_NS_PROPERTY",
+			"page": "Has page test",
+			"contents": "[[Has type::Page]]"
+		},
+		{
+			"page": "Example/P1006/1",
+			"contents": "[[Has page test::123]] {{DISPLAYTITLE:AA}}"
+		},
+		{
+			"page": "Example/P1006/2",
+			"contents": "[[Has page test::123]] {{DISPLAYTITLE:AA}} {{#subobject: |Has page test=456 |@sortkey=AA}}"
+		},
+		{
+			"page": "Example/P1006/3",
+			"contents": "[[Has page test::123]] {{DISPLAYTITLE:BB}}"
+		},
+		{
+			"page": "Example/P1006/4",
+			"contents": "[[Has page test::123]] {{DISPLAYTITLE:CC}} {{#subobject: |Has page test=456 |@sortkey=BB}}"
+		},
+		{
+			"page": "Example/P1006/5",
+			"contents": "[[Has page test::123]] {{DISPLAYTITLE:DD}} {{#subobject: |Has page test=456 |@sortkey=DD}}"
+		},
+		{
+			"page": "Example/P1006/6",
+			"contents": "[[Has page test::123]] {{DISPLAYTITLE:DD}} {{#subobject: |Has page test=456 |@sortkey=DD}}"
+		}
+	],
+	"tests": [
+		{
+			"type": "parser",
+			"about": "#0 (verify item list order)",
+			"namespace": "SMW_NS_PROPERTY",
+			"subject": "Has page test",
+			"assert-output": {
+				"onPageView": {
+					"parameters": {}
+				},
+				"to-contain": [
+					"<div class=\"smw-table-cell smwpropname\" data-list-index=\"0\"><a href=.*Example/P1006/1\" title=\"Example/P1006/1\">AA</a>",
+					"<div class=\"smw-table-cell smwpropname\" data-list-index=\"1\"><a href=.*Example/P1006/2\" title=\"Example/P1006/2\">AA</a>",
+					"<div class=\"smw-table-cell smwpropname\" data-list-index=\"2\"><a href=.*Example/P1006/2#_14d8b802a338f5900237277114a2cc2f\" .*title=\"Example/P1006/2\".*>AA</a>",
+					"<div class=\"smw-table-cell smwpropname\" data-list-index=\"3\"><a href=.*Example/P1006/3\" title=\"Example/P1006/3\">BB</a>",
+					"<div class=\"smw-table-cell smwpropname\" data-list-index=\"4\"><a href=.*Example/P1006/4#_6961cf334b7bc5632473cf15ebfc3094\" .*title=\"Example/P1006/4\".*>CC</a>",
+					"<div class=\"smw-table-cell smwpropname\" data-list-index=\"5\"><a href=.*Example/P1006/4\" title=\"Example/P1006/4\">CC</a>",
+					"<div class=\"smw-table-cell smwpropname\" data-list-index=\"6\"><a href=.*Example/P1006/5\" title=\"Example/P1006/5\">DD</a>",
+					"<div class=\"smw-table-cell smwpropname\" data-list-index=\"7\"><a href=.*Example/P1006/5#_e4e502c29803cb65c90fa99b6abd99da\" .*title=\"Example/P1006/5\".*>DD</a>",
+					"<div class=\"smw-table-cell smwpropname\" data-list-index=\"8\"><a href=.*Example/P1006/6\" title=\"Example/P1006/6\">DD</a>",
+					"<div class=\"smw-table-cell smwpropname\" data-list-index=\"9\"><a href=.*Example/P1006/6#_e4e502c29803cb65c90fa99b6abd99da\" .*title=\"Example/P1006/6\".*>DD</a>"
+				]
+			}
+		}
+	],
+	"settings": {
+		"wgContLang": "en",
+		"wgLang": "en",
+		"wgAllowDisplayTitle": true,
+		"wgRestrictDisplayTitle": false,
+		"smwgEntityCollation": "identity",
+		"smwgPageSpecialProperties": [
+			"_MDAT"
+		],
+		"smwgNamespacesWithSemanticLinks": {
+			"NS_MAIN": true,
+			"SMW_NS_PROPERTY": true
+		}
+	},
+	"meta": {
+		"version": "2",
+		"is-incomplete": false,
+		"debug": false
+	}
+}

--- a/tests/phpunit/Unit/RequestOptionsTest.php
+++ b/tests/phpunit/Unit/RequestOptionsTest.php
@@ -41,7 +41,7 @@ class RequestOptionsTest extends \PHPUnit_Framework_TestCase {
 		}
 
 		$this->assertEquals(
-			'[-1,0,false,true,null,true,"Foo#0##",[]]',
+			'[-1,0,false,true,null,true,"Foo#0##",[],[]]',
 			$instance->getHash()
 		);
 	}
@@ -61,7 +61,7 @@ class RequestOptionsTest extends \PHPUnit_Framework_TestCase {
 		);
 
 		$this->assertEquals(
-			'[-1,0,false,true,null,true,"",["Foo",{"Bar":"Foobar"}]]',
+			'[-1,0,false,true,null,true,"",["Foo",{"Bar":"Foobar"}],[]]',
 			$instance->getHash()
 		);
 	}

--- a/tests/phpunit/Unit/SQLStore/TableFieldUpdaterTest.php
+++ b/tests/phpunit/Unit/SQLStore/TableFieldUpdaterTest.php
@@ -58,7 +58,7 @@ class TableFieldUpdaterTest extends \PHPUnit_Framework_TestCase {
 			->getMock();
 
 		$collator->expects( $this->once() )
-			->method( 'getSortKey' );
+			->method( 'getTruncatedSortKey' );
 
 		$connection = $this->getMockBuilder( '\SMW\MediaWiki\Database' )
 			->disableOriginalConstructor()


### PR DESCRIPTION
This PR is made in reference to: #2040, #305, #2519

This PR addresses or contains:

- Replaces DISTINCT with GROUP BY
- Using `GROUP BY smw_sort, smw_id` to retain distinctiveness 

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed

## Issue
The following analysis is based on a `smw_object_ids` table with 177,925 rows and a `smw_di_wikipage`  table with 1,478,566 rows.

A `SELECT DISTINCT` in combination with a `ORDER BY` will in most events cause a `filesort` as demonstrated in the `SMWSQLStore3Readers::getPropertySubjects` method.

```
SELECT DISTINCT smw_title, smw_namespace, smw_iw, smw_subobject, smw_sortkey, smw_sort
FROM `smw_object_ids`
INNER JOIN `smw_di_wikipage` AS t1 ON t1.s_id=smw_id
WHERE t1.p_id='310167' AND smw_iw!=':smw' AND smw_iw!=':smw-delete' AND smw_iw!=':smw-redi'
ORDER BY smw_sort
LIMIT 51

14350.2071ms | SMWSQLStore3Readers::getPropertySubjects
```

The explain output shows that is has to read 177050 rows into a `temporary_table` before in can order them.

```
{
 "query_block": {
   "select_id": 1,
   "filesort": {
     "temporary_table": {
       "function": "buffer",
       "table": {
         "table_name": "smw_object_ids",
         "access_type": "range",
         "possible_keys": ["PRIMARY", "smw_iw", "smw_iw_2", "smw_id"],
         "key": "smw_iw",
         "key_length": "34",
         "used_key_parts": ["smw_iw"],
         "rows": 177050,
         "filtered": 100,
         "index_condition": "((smw_object_ids.smw_iw <> ':smw') and (smw_object_ids.smw_iw <> ':smw-delete') and (smw_object_ids.smw_iw <> ':smw-redi'))"
       },
       "table": {
         "table_name": "t1",
         "access_type": "ref",
         "possible_keys": ["p_id", "s_id", "s_id_2", "s_id_3", "p_id_2"],
         "key": "s_id",
         "key_length": "8",
         "used_key_parts": ["s_id", "p_id"],
         "ref": ["mw-master.smw_object_ids.smw_id", "const"],
         "rows": 3,
         "filtered": 100,
         "using_index": true,
         "distinct": true
       }
     }
   }
 }
}
```
## Solution

Adding a new `smw_sort,smw_id` index and replacing `DISTINCT` with `GROUP BY` achieves an improvement in terms of query execution time from `14350.2071ms` to `533.3791ms` . This also avoids a temporary table which would cause a `filesort` and hereby a lengthen in execution time.

```
SELECT smw_title, smw_namespace, smw_iw, smw_subobject, smw_sortkey, smw_sort
FROM `smw_object_ids`
INNER JOIN `smw_di_wikipage` AS t1 ON t1.s_id=smw_id
WHERE t1.p_id='310167' AND smw_iw!=':smw' AND smw_iw!=':smw-delete' AND smw_iw!=':smw-redi'
GROUP BY smw_sort, smw_id
ORDER BY smw_sort LIMIT 51

533.3791ms | SMWSQLStore3Readers::getPropertySubjects
```
```
{
 "query_block": {
   "select_id": 1,
   "table": {
     "table_name": "smw_object_ids",
     "access_type": "index",
     "possible_keys": ["PRIMARY", "smw_iw", "smw_iw_2", "smw_id"],
     "key": "smw_sort",
     "key_length": "262",
     "used_key_parts": ["smw_sort", "smw_id"],
     "rows": 17,
     "filtered": 100,
     "attached_condition": "((smw_object_ids.smw_iw <> ':smw') and (smw_object_ids.smw_iw <> ':smw-delete') and (smw_object_ids.smw_iw <> ':smw-redi'))"
   },
   "table": {
     "table_name": "t1",
     "access_type": "ref",
     "possible_keys": ["p_id", "s_id", "s_id_2", "s_id_3", "p_id_2"],
     "key": "s_id",
     "key_length": "8",
     "used_key_parts": ["s_id", "p_id"],
     "ref": ["mw-master.smw_object_ids.smw_id", "const"],
     "rows": 3,
     "filtered": 100,
     "using_index": true
   }
 }
}
```