### PR TITLE
Hide namespace section, auto-discovery, refs 3126

### DIFF
--- a/res/smw/special/ext.smw.special.search.css
+++ b/res/smw/special/ext.smw.special.search.css
@@ -170,6 +170,34 @@
   margin-left: unset;
 }
 
+#smw-search-togglensview {
+    float: right;
+}
+
+.ns-list-off {
+    display:none;
+}
+
+.ns-list-on {
+    display:block;
+}
+
+#smw-togglensview {
+    margin-left: 1em;
+    text-align: center;
+    text-decoration: none;
+    display: inline-block;
+    opacity: 0.6;
+}
+
+#smw-togglensview:hover {
+    opacity: 1
+}
+
+#smw-togglensview:focus{
+    outline: none;
+}
+
 #smw-searchoptions {
     margin: 0;
     padding: 0.5em 0.75em 0.75em 0.75em;
@@ -185,12 +213,6 @@
     margin-bottom: 0.5em;
 }
 
-/**
-+ * .skin-chameleon specific styles
-+ */
-.skin-chameleon .smw-search-help-proximity {
-	margin-top: 10px;
-}
 
 /**
  * Responsive settings (#see smw.table.css)
@@ -207,4 +229,19 @@
     .smw-input-group {
     /*    display:block;*/
     }
+}
+
+/**
+ * .skin-chameleon specific styles
+ */
+.skin-chameleon .smw-search-help-proximity {
+    margin-top: 10px;
+}
+
+.skin-chameleon .smw-select-field {
+    margin-right: -3px;
+}
+
+.skin-chameleon .smw-fields .smw-input-field {
+    margin: 5px -3px 0 10px;
 }

--- a/src/MediaWiki/Search/Form/CustomForm.php
+++ b/src/MediaWiki/Search/Form/CustomForm.php
@@ -94,6 +94,7 @@ class CustomForm {
 
 		$fields = [];
 		$this->parameters = [];
+		$nameList = [];
 
 		foreach ( $definition as $property ) {
 			$options = [];
@@ -108,6 +109,11 @@ class CustomForm {
 			// Transforms (Foo bar -> foobar), better URL query conformity
 			$name = FormsBuilder::toLowerCase( $property );
 			$value = '';
+
+			// Field with the same name should only appear once in a form
+			if ( isset( $nameList[$name] ) ) {
+				continue;
+			}
 
 			// Each form definition may contain properties that are also defined
 			// in other forms therefore count its member position so that only
@@ -128,6 +134,7 @@ class CustomForm {
 				$this->parameters[$name] = $value;
 			}
 
+			$nameList[$name] = true;
 			$fields[] = $this->makeField( $name, $property, $value, $options );
 		}
 

--- a/src/MediaWiki/Search/Form/FormsFinder.php
+++ b/src/MediaWiki/Search/Form/FormsFinder.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace SMW\MediaWiki\Search\Form;
+
+use SMW\MediaWiki\Search\SearchProfileForm;
+use SMW\Store;
+use SMW\RequestOptions;
+use SMWDIBlob as DIBlob;
+use SMW\DIProperty;
+use WikiPage;
+use Title;
+
+/**
+ * @private
+ *
+ * @license GNU GPL v2+
+ * @since 3.0
+ *
+ * @author mwjames
+ */
+class FormsFinder {
+
+	/**
+	 * @var Store
+	 */
+	private $store;
+
+	/**
+	 * @since 3.0
+	 *
+	 * @param Store $store
+	 */
+	public function __construct( Store $store ) {
+		$this->store = $store;
+	}
+
+	/**
+	 * @since 3.0
+	 *
+	 * @return array
+	 */
+	public function getFormDefinitions() {
+
+		$data = [];
+		$requestOptions = new RequestOptions();
+		$requestOptions->setOption( 'DISTINCT', false );
+
+		$subjects = $this->store->getPropertySubjects(
+			new DIProperty( '_RL_TYPE' ),
+			new DIBlob( SearchProfileForm::RULE_TYPE ),
+			$requestOptions
+		);
+
+		foreach ( $subjects as $subject ) {
+
+			if ( ( $nativeData = $this->getNativeData( $subject->getTitle() ) ) === '' ) {
+				continue;
+			}
+
+			$d = json_decode( $nativeData, true );
+
+			if ( json_last_error() !== JSON_ERROR_NONE ) {
+				continue;
+			}
+
+			$data = array_merge_recursive( $data, $d );
+		}
+
+		return $data;
+	}
+
+	protected function getNativeData( $title ) {
+
+		$content = WikiPage::factory( $title )->getContent();
+
+		if ( $content === null ) {
+			return '';
+		}
+
+		return $content->getNativeData();
+	}
+
+}

--- a/src/MediaWiki/Search/Form/NamespaceForm.php
+++ b/src/MediaWiki/Search/Form/NamespaceForm.php
@@ -27,6 +27,11 @@ class NamespaceForm {
 	/**
 	 * @var []
 	 */
+	private $hiddenNamespaces = [];
+
+	/**
+	 * @var []
+	 */
 	private $searchableNamespaces = [];
 
 	/**
@@ -35,12 +40,35 @@ class NamespaceForm {
 	private $token;
 
 	/**
+	 * @var null|string
+	 */
+	private $hideList = false;
+
+	/**
 	 * @since 3.0
 	 *
 	 * @param array $activeNamespaces
 	 */
 	public function setActiveNamespaces( array $activeNamespaces ) {
 		$this->activeNamespaces = $activeNamespaces;
+	}
+
+	/**
+	 * @since 3.0
+	 *
+	 * @param boolean $hideList
+	 */
+	public function setHideList( $hideList ) {
+		$this->hideList = (bool)$hideList;
+	}
+
+	/**
+	 * @since 3.0
+	 *
+	 * @param array $hiddenNamespaces
+	 */
+	public function setHiddenNamespaces( array $hiddenNamespaces ) {
+		$this->hiddenNamespaces = $hiddenNamespaces;
 	}
 
 	/**
@@ -80,12 +108,19 @@ class NamespaceForm {
 
 		$divider = "<div class='divider'></div>";
 		$rows = [];
+		$tableRows = [];
+
+		$hiddenNamespaces = array_flip( $this->hiddenNamespaces );
 
 		foreach ( $this->searchableNamespaces as $namespace => $name ) {
 			$subject = MWNamespace::getSubject( $namespace );
 
 			if ( MWNamespace::isTalk( $namespace ) ) {
 			//	continue;
+			}
+
+			if ( isset( $hiddenNamespaces[$namespace] ) ) {
+				continue;
 			}
 
 			if ( !isset( $rows[$subject] ) ) {
@@ -109,12 +144,12 @@ class NamespaceForm {
 
 		// Lays out namespaces in multiple floating two-column tables so they'll
 		// be arranged nicely while still accomodating diferent screen widths
-		$tableRows = [];
 		foreach ( $rows as $row ) {
 			$tableRows[] = "<tr>{$row}</tr>";
 		}
 
 		$namespaceTables = [];
+		$display = $this->hideList ? 'none' : 'block';
 
 		foreach ( array_chunk( $tableRows, 4 ) as $chunk ) {
 			$namespaceTables[] = implode( '', $chunk );
@@ -143,13 +178,14 @@ class NamespaceForm {
 			"<legend>" . Message::get( 'powersearch-legend', Message::ESCAPED, Message::USER_LANGUAGE ) . '</legend>' .
 			"<h4>" . Message::get( 'powersearch-ns', Message::PARSE, Message::USER_LANGUAGE ) . '</h4>' .
 			// populated by js if available
+			"<div id='smw-search-togglensview'></div>" .
 			"<div id='mw-search-togglebox'></div>" .
-			$divider .
+			"<div id='ns-list' style='display:$display'>" . $divider .
 			implode(
 				$divider,
 				$showSections
 			) .
-			$remember .
+			$remember . "</div>" .
 		"</fieldset>";
 	}
 

--- a/src/MediaWiki/Search/README.md
+++ b/src/MediaWiki/Search/README.md
@@ -2,7 +2,7 @@
 
 [SMWSearch](https://www.semantic-mediawiki.org/wiki/Help:SMWSearch) contains classes and functions that integrates SMW with `Special:Search`.
 
-### Search engine
+## Search engine
 
 Classes that provide an interface to support MW's `SearchEngine` by transforming a search terms into a SMW equivalent expression of query elements.
 
@@ -10,14 +10,14 @@ Classes that provide an interface to support MW's `SearchEngine` by transforming
 - `SearchResult`
 - `SearchResultSet`
 
-### Search profile
+## Search profile
 
 Classes that provide an additional search form to support structured searches in `Special:Search` with the help of the [`SpecialSearchProfileForm`](https://www.mediawiki.org/wiki/Manual:Hooks/SpecialSearchProfileForm) hook.
 
 - `SearchProfileForm`
 - `QueryBuilder`
 
-Form specific classes to generate a HTML from a JSON definition that is hosted in `Rule:Search-profile-form-definition`.
+Form specific classes to generate a HTML from a JSON definition that are assigned a `"type": "SEARCH_FORM_DEFINITION_RULE"`.
 
 - `Form\FormsBuilder`
 - `Form\FormsFactory`
@@ -27,12 +27,12 @@ Form specific classes to generate a HTML from a JSON definition that is hosted i
 - `Form\SortForm`
 - `Form\Field`
 
-#### JSON
+### Defining forms
 
-Defining forms
 
 ```
 {
+    "type": "SEARCH_FORM_DEFINITION_RULE",
     "forms": {
         "Books and journals": [
             "Has title",
@@ -48,6 +48,7 @@ Defining forms
             {
                 "Publisher": {
                     "autocomplete": true
+                    "tooltip": "message-can-be-a-msg-key"
                 }
             }
         ]
@@ -57,26 +58,50 @@ Defining forms
 
 | Attributes | Values | Description |
 |--------------|-----------------|-----------------------------------|
-| autocomplete | true, false | whether the field should add a autocomplete function or not |
+| autocomplete | true, false | whether the field should add an autocomplete function or not |
 | tooltip | text or msg key | shows a tooltip with either a text or retrieves information from a message key |
 | placeholder | text | shown instead of the property name |
-| required | true, false | whether the field input is required before submitting |
-| type | HTML5 | preselect a specific type field |type | HTML5 | preselect a specific type field |
+| required | true, false | whether the field input is required before submitting or not |
+| type | HTML5 | preselect a specific type field |
 
-Enforcing a namespace selection for a specific form
+### Namespaces
+
+Assign a preselection of namespaces to a specific form.
 
 ```
+{
     "namespaces": {
-        "Books and journals": [
-            "NS_CUSTOM_BOOKS"
+        "preselect": {
+           "Books and journals": [
+                "NS_CUSTOM_BOOKS"
+            ]
+        }
+    }
+}
+```
+
+Hide namespaces from appearing in any SMW related form.
+
+```
+{
+    "namespaces": {
+        "hidden": [
+           "NS_PROJECT",
+           "NS_PROJECT_TALK"
         ]
-    },
+    }
+}
 ```
 
-Describing a form
+### Descriptions
+
+Describe a form and shown a top of the form fields to inform users about the intent of
+the form.
 
 ```
+{
     "descriptions": {
         "Books and journals": "Short description to be shown on top of a selected form"
     }
+}
 ```

--- a/src/MediaWiki/Search/Search.php
+++ b/src/MediaWiki/Search/Search.php
@@ -50,6 +50,11 @@ class Search extends SearchEngine {
 	private $queryString = '';
 
 	/**
+	 * @var string
+	 */
+	private $queryLink = '';
+
+	/**
 	 * @param null|SearchEngine $fallbackSearch
 	 */
 	public function setFallbackSearchEngine( SearchEngine $fallbackSearch = null ) {
@@ -98,7 +103,6 @@ class Search extends SearchEngine {
 	}
 
 	/**
-	 * @see Search::getSearchResultSet
 	 * @since 3.0
 	 *
 	 * @return []
@@ -108,13 +112,21 @@ class Search extends SearchEngine {
 	}
 
 	/**
-	 * @see Search::getSearchResultSet
 	 * @since 3.0
 	 *
 	 * @return string
 	 */
 	public function getQueryString() {
 		return $this->queryString;
+	}
+
+	/**
+	 * @since 3.0
+	 *
+	 * @return string
+	 */
+	public function getQueryLink() {
+		return $this->queryLink;
 	}
 
 	/**
@@ -149,6 +161,7 @@ class Search extends SearchEngine {
 		}
 
 		$this->queryString = $this->queryBuilder->getQueryString(
+			ApplicationFactory::getInstance()->getStore(),
 			$term
 		);
 
@@ -230,9 +243,13 @@ class Search extends SearchEngine {
 
 		$store = ApplicationFactory::getInstance()->getStore();
 		$query->clearErrors();
+		$query->setOption( 'is.special_search', true );
 
 		$result = $store->getQueryResult( $query );
 		$this->errors = $query->getErrors();
+		$this->queryLink = $result->getQueryLink();
+		$this->queryLink->setParameter( $this->offset, 'offset' );
+		$this->queryLink->setParameter( $this->limit, 'limit' );
 
 		$query->querymode = SMWQuery::MODE_COUNT;
 		$query->setOffset( 0 );

--- a/tests/phpunit/Unit/MediaWiki/Hooks/HookRegistryTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Hooks/HookRegistryTest.php
@@ -417,6 +417,10 @@ class HookRegistryTest extends \PHPUnit_Framework_TestCase {
 
 		$handler = 'SpecialSearchProfileForm';
 
+		$this->store->expects( $this->any() )
+			->method( 'getPropertySubjects' )
+			->will( $this->returnValue( [] ) );
+
 		$user = $this->getMockBuilder( '\User' )
 			->disableOriginalConstructor()
 			->getMock();

--- a/tests/phpunit/Unit/MediaWiki/Search/Form/FormsBuilderTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Search/Form/FormsBuilderTest.php
@@ -37,7 +37,7 @@ class FormsBuilderTest extends \PHPUnit_Framework_TestCase {
 		);
 	}
 
-	public function testBuildFromJSON() {
+	public function testBuildForm() {
 
 		$title = $this->getMockBuilder( '\Title' )
 			->disableOriginalConstructor()
@@ -68,7 +68,7 @@ class FormsBuilderTest extends \PHPUnit_Framework_TestCase {
 			$this->formsFactory
 		);
 
-		$form = [
+		$data = [
 			'forms' => [
 				'Foo' => [
 					'Property one'
@@ -82,27 +82,27 @@ class FormsBuilderTest extends \PHPUnit_Framework_TestCase {
 		$expected = [
 			"<div class='divider' style='display:none;'></div>",
 			'<div id="smw-form-definitions" class="is-disabled">',
-			'<div id="smw-form-foo" class="smw-fields"></div>',
-			'<div id="smw-form-bar" class="smw-fields"></div></div>'
+			'<div id="smw-form-bar" class="smw-fields"></div>',
+			'<div id="smw-form-foo" class="smw-fields"></div></div>'
 		];
 
 		$this->assertContains(
 			implode( '', $expected ),
-			$instance->buildFromJSON( json_encode( $form ) )
+			$instance->buildForm( $data )
 		);
 
 		$expected = [
 			'<div id="smw-search-forms" class="smw-select is-disabled" data-nslist="[]">',
 			'<label for="smw-form"><a>Form</a>:&nbsp;</label><select id="smw-form" name="smw-form">',
 			"<option value='' ></option>",
-			"<option value='foo' >Foo</option>",
 			"<option value='bar' >Bar</option>",
+			"<option value='foo' >Foo</option>",
 			'</select></div>'
 		];
 
 		$this->assertContains(
 			implode( '', $expected ),
-			$instance->makeSelectList( $title )
+			$instance->buildFormList( $title )
 		);
 	}
 

--- a/tests/phpunit/Unit/MediaWiki/Search/Form/FormsFinderTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Search/Form/FormsFinderTest.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace SMW\Tests\MediaWiki\Search\Form;
+
+use SMW\MediaWiki\Search\Form\FormsFinder;
+use SMW\DIWikiPage;
+
+/**
+ * @covers \SMW\MediaWiki\Search\Form\FormsFinder
+ * @group semantic-mediawiki
+ *
+ * @license GNU GPL v2+
+ * @since 3.0
+ *
+ * @author mwjames
+ */
+class FormsFinderTest extends \PHPUnit_Framework_TestCase {
+
+	private $store;
+
+	protected function setUp() {
+
+		$this->store = $this->getMockBuilder( '\SMW\Store' )
+			->disableOriginalConstructor()
+			->getMockForAbstractClass();
+	}
+
+	public function testCanConstruct() {
+
+		$this->assertInstanceOf(
+			FormsFinder::class,
+			new FormsFinder( $this->store )
+		);
+	}
+
+	public function testGetFormDefinitions() {
+
+		$data[] = json_encode( [ 'Foo' => [ 'Bar' => 42 ], 1001 ] );
+		$data[] = json_encode( [ 'Foo' => [ 'Foobar' => 'test' ], [ 'Foo' => 'Bar' ] ] );
+
+		$this->store->expects( $this->any() )
+			->method( 'getPropertySubjects' )
+			->will( $this->returnValue( [
+				DIWikiPage::newFromText( 'Foo' ),
+				DIWikiPage::newFromText( 'Bar' ) ] ) );
+
+		$instance = $this->getMockBuilder( '\SMW\MediaWiki\Search\Form\FormsFinder' )
+			->setConstructorArgs( [ $this->store ] )
+			->setMethods( [ 'getNativeData' ] )
+			->getMock();
+
+		$instance->expects( $this->any() )
+			->method( 'getNativeData' )
+			->will( $this->onConsecutiveCalls( $data[0], $data[1] ) );
+
+		$this->assertEquals(
+			[
+				'Foo' => [ 'Bar' => 42, 'Foobar' => 'test' ],
+				1001,
+				[ 'Foo' => 'Bar' ]
+			],
+			$instance->getFormDefinitions()
+		);
+	}
+
+}

--- a/tests/phpunit/Unit/MediaWiki/Search/QueryBuilderTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Search/QueryBuilderTest.php
@@ -16,8 +16,13 @@ use SMW\MediaWiki\Search\QueryBuilder;
 class QueryBuilderTest extends \PHPUnit_Framework_TestCase {
 
 	private $webRequest;
+	private $store;
 
 	protected function setUp() {
+
+		$this->store = $this->getMockBuilder( '\SMW\Store' )
+			->disableOriginalConstructor()
+			->getMockForAbstractClass();
 
 		$this->webRequest = $this->getMockBuilder( '\WebRequest' )
 			->disableOriginalConstructor()
@@ -75,7 +80,6 @@ class QueryBuilderTest extends \PHPUnit_Framework_TestCase {
 			->method( 'setDescription' );
 
 		$instance->addNamespaceCondition( $query, [ 6 => true ] );
-
 	}
 
 	public function testAddSort() {
@@ -97,7 +101,6 @@ class QueryBuilderTest extends \PHPUnit_Framework_TestCase {
 			->method( 'setSortKeys' );
 
 		$instance->addSort( $query );
-
 	}
 
 	public function testGetQueryString_EmptyFieldValues_ReturnsTermOnly() {
@@ -111,7 +114,7 @@ class QueryBuilderTest extends \PHPUnit_Framework_TestCase {
 
 		$this->assertEquals(
 			'Foo',
-			$instance->getQueryString( 'Foo' )
+			$instance->getQueryString( $this->store, 'Foo' )
 		);
 	}
 
@@ -144,7 +147,7 @@ class QueryBuilderTest extends \PHPUnit_Framework_TestCase {
 
 		$this->assertEquals(
 			'<q>[[Bar property::Foobar]]</q>  Foo',
-			$instance->getQueryString( 'Foo' )
+			$instance->getQueryString( $this->store, 'Foo' )
 		);
 	}
 
@@ -180,7 +183,7 @@ class QueryBuilderTest extends \PHPUnit_Framework_TestCase {
 
 		$this->assertEquals(
 			'<q>[[Bar property::42]]</q>  Foo',
-			$instance->getQueryString( 'Foo' )
+			$instance->getQueryString( $this->store, 'Foo' )
 		);
 	}
 
@@ -221,7 +224,7 @@ class QueryBuilderTest extends \PHPUnit_Framework_TestCase {
 
 		$this->assertEquals(
 			'<q>[[Bar::42]] </q> OR Foo',
-			$instance->getQueryString( 'Foo' )
+			$instance->getQueryString( $this->store, 'Foo' )
 		);
 	}
 

--- a/tests/phpunit/Unit/MediaWiki/Search/SearchProfileFormTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Search/SearchProfileFormTest.php
@@ -86,6 +86,10 @@ class SearchProfileFormTest extends \PHPUnit_Framework_TestCase {
 		$form = '';
 		$opts = [];
 
+		$this->store->expects( $this->any() )
+			->method( 'getPropertySubjects' )
+			->will( $this->returnValue( [] ) );
+
 		$searchEngine = $this->getMockBuilder( '\SMW\MediaWiki\Search\Search' )
 			->disableOriginalConstructor()
 			->getMock();
@@ -117,8 +121,16 @@ class SearchProfileFormTest extends \PHPUnit_Framework_TestCase {
 
 		$instance->getForm( $form, $opts );
 
+		$expected = [
+			'<fieldset id="smw-searchoptions">',
+			'<input type="hidden" name="ns-list"/>',
+			'<div id="smw-query" style="display:none;"></div>',
+			'<div class="smw-search-options">',
+			'<div id="smw-search-sort" class="smw-select" style="margin-right:10px;">',
+		];
+
 		$this->assertContains(
-			'<fieldset id="smw-searchoptions"><div id="smw-query" style="display:none;"></div><div class="smw-search-options"><div id="smw-search-sort" class="smw-select" style="margin-right:10px;">',
+			implode( '', $expected ),
 			$form
 		);
 	}


### PR DESCRIPTION
This PR is made in reference to: #3126

This PR addresses or contains:

- Follow-up to https://github.com/SemanticMediaWiki/SemanticMediaWiki/pull/3126#issuecomment-384204421 and https://github.com/SemanticMediaWiki/SemanticMediaWiki/pull/3126#issuecomment-383365361

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed

> If I really have time I may make an discovery on the `SEARCH_FORM_DEFINITION_RULE` type but for the now all form definitions are expected to be hosted in `Rule:Search-profile-form-definition`.

You no longer are bound by the fixed name of  `Rule:Search-profile-form-definition`, any `Rule:...` with the type of `SEARCH_FORM_DEFINITION_RULE` will be auto-discovered and merged into one single form definition during the build process. It goes without saying that if form some reason you have two `Rule:...` pages that refer to the same form name then fields are merged!

> I would like so see alle Namespaces hidden from the user unless I want to show them.

Last week when we deployed the profile, I could see that we have a bunch of namespaces that are  irrelevant for structured searches and only clutter the interface. You may use them on a different profile but it seems less likely to be useful in combination with SMW.

![image](https://user-images.githubusercontent.com/1245473/39302711-884a968e-498e-11e8-958e-41b88acef0c9.png)

To improve the situation:

### `namespaces`

Since we had to copy the namespace form from core in order to provide a common component within the search interface we are also under the control for the `smw` profile of what is being shown and how. First, a hide/show button is added to control the ability to toggle the display of the namespace form. If no form has been selected, the namespace section will be shown but as soon as the user selects a form this will be hidden and the user can choose to have it displayed by using the provided button.

![image](https://user-images.githubusercontent.com/1245473/39303263-67e4bfe4-4990-11e8-8782-431486016974.png)

The above mentioned show/hide will alter the display but not alter the appearance of which namespaces should be shown. To reduce the amount of selectable namepaces from a form, you can now add `namespaces`/`hidden` to a form definition allowing it to hide the mentioned namespace for any `smw` related form.

```
    "namespaces": {
        "hidden": [
            "SMW_NS_PROPERTY",
            "SMW_NS_PROPERTY_TALK",
            "SMW_NS_CONCEPT",
            "SMW_NS_CONCEPT_TALK",
            "SMW_NS_RULE",
            "SMW_NS_RULE_TALK",
            "NS_MEDIAWIKI",
            "NS_MEDIAWIKI_TALK",
            "NS_TEMPLATE",
            "NS_TEMPLATE_TALK",
            "NS_PROJECT",
            "NS_PROJECT_TALK",
            "NS_HELP_TALK",
            "NS_USER_TALK",
            "NS_CATEGORY_TALK"
        ],
        "preselect": {
            "Media": [
                "NS_FILE"
            ]
        }
    },
```
The `preselect` is there to support a preselection for certain namespace on a particular form so that for example in case of the a `Media` form, the `NS_FILE` is checked when the user selects that form without having him/her to explicitly mark the namespace as the form context most likely requires a search to include this namespace.