### PR TITLE
SMWSearch simplified term parser, refs 3126

### DIFF
--- a/tests/phpunit/Unit/MediaWiki/Search/QueryBuilderTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Search/QueryBuilderTest.php
@@ -228,4 +228,89 @@ class QueryBuilderTest extends \PHPUnit_Framework_TestCase {
 		);
 	}
 
+	/**
+	 * @dataProvider termProvider
+	 */
+	public function testTerm_parser( $term, $expected ) {
+
+		$this->assertEquals(
+			$expected,
+			QueryBuilder::term_parser( $term )
+		);
+	}
+
+	public function termProvider() {
+
+		yield [
+			'in:foo',
+			'[[in:foo]]'
+		];
+
+		yield [
+			'[[in:foo]]',
+			'[[in:foo]]'
+		];
+
+		yield [
+			'in:foo || bar',
+			'[[in:foo]] || bar'
+		];
+
+		yield [
+			'in:foo && bar',
+			'[[in:foo]] && bar'
+		];
+
+		yield [
+			'in:foo || in:bar',
+			'[[in:foo]] || [[in:bar]]'
+		];
+
+		yield [
+			'in:foo bar in:bar ',
+			'[[in:foo bar]] [[in:bar]]'
+		];
+
+		yield [
+			'in:foo bar && in:bar',
+			'[[in:foo bar]] && [[in:bar]]'
+		];
+
+		yield [
+			'in:foo bar || in:bar ',
+			'[[in:foo bar]] || [[in:bar]]'
+		];
+
+		yield [
+			'(in:foo bar && in:foo) || in:bar ',
+			'<q>[[in:foo bar]] && [[in:foo]]</q> || [[in:bar]]'
+		];
+
+		yield [
+			'in:foo bar in:bar phrase:foobar 123 && in:oooo',
+			'[[in:foo bar]] [[in:bar]] [[phrase:foobar 123]] && [[in:oooo]]'
+		];
+
+		yield [
+			'<q>in:foo bar && in:bar</q> OR phrase:foo bar foobar',
+			'<q>[[in:foo bar]] && [[in:bar]]</q> OR [[phrase:foo bar foobar]]'
+		];
+
+		yield [
+			'(in:foo && in:bar)||in:foobar',
+			'<q>[[in:foo]] && [[in:bar]]</q> || [[in:foobar]]'
+		];
+
+		yield [
+			'(in:foo && (in:bar AND not:ooo)) || in:foobar',
+			'<q>[[in:foo]] && <q>[[in:bar]] AND [[not:ooo]]</q></q> || [[in:foobar]]'
+		];
+
+
+		yield [
+			'<q>in:foo bar && in:bar</q> OR [[Has number::123]]',
+			'<q>[[in:foo bar]] && [[in:bar]]</q> OR [[Has number::123]]'
+		];
+	}
+
 }


### PR DESCRIPTION
This PR is made in reference to: #

This PR addresses or contains:

- Experimental feature hat simplifies the SMWSearch input term parsing and is only relevant for those who use a full-text integration and should only be enabled by users that think it doesn't dilute the syntax understanding of #ask for their users.

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed

### term.parser

By default, the __big__ `Special:Search` input field in context with SMW only understands well defined (meaning terms that are isolated and structured with `[[` `]]` ) terms such  `[[Has text::foo bar]]` or `[[in:some text within any article]]` to start a search request with the SMW query engine.

Yet, when searching a user that uses `Special:Search` is most likely less concerned with forms and structures and all s(he) wants is to search quick (and easy) and adding extra `[[` `]]` around each term seems soporific therefore to relax the input process the `term.parser` can work with a simplified input to build the final #ask conform syntax.

Simple | #ask conform
------------ | -------------
`(in:foo bar \|\| phrase:some text that appears in the same order) && category:Loose text` |  `<q>[[in:foo bar]] \|\| [[phrase:some text that appears in the same order]]</q> && [[Category:Loose text]]`

Without the `term.parser` enabled the left search query is required to be rewritten to represent the exact #ask elements in order to express the query intent.

The `term.parser`  will recognize the following `'in:', 'phrase:', 'not:', 'category:', '&&', 'AND', '||', 'OR', ')', '('` expressions to build a query that adheres the #ask syntax.

The `'in:', 'phrase:', 'not:'` expression are almost always only meaningful in the context of the full-text search and while not limited to `Special:Search` (or the smw profile) there where introduced as part of SMW 3.0 to broaden the expressiveness of a search request.
