### PR TITLE
Test sorting on Pages will not exclude non-existent pages from result (#540)

### DIFF
--- a/tests/phpunit/Integration/JSONScript/TestCases/p-1007.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/p-1007.json
@@ -1,0 +1,57 @@
+{
+	"description": "Test sorting on Pages will not exclude non-existent pages from result (#540)",
+	"setup": [
+		{
+			"namespace": "SMW_NS_PROPERTY",
+			"page": "knows page",
+			"contents": "[[Has type::Page]]"
+		},
+		{
+			"page": "Example/P1007/1",
+			"contents": "[[knows page::Example/P1007/Ref 3]]"
+		},
+		{
+			"page": "Example/P1007/2",
+			"contents": "[[knows page::Example/P1007/Ref 2]]"
+		},
+		{
+			"page": "Example/P1007/3",
+			"contents": "[[knows page::Example/P1007/Ref 1]]"
+		},
+		{
+			"page": "Example/P1007/Ref 1",
+			"contents": "SomeContent"
+		},
+		{
+			"page": "Example/P1007/Ref 3",
+			"contents": "SomeContent"
+		},
+		{
+			"page": "Example/P1007/Test",
+			"contents": "{{#ask:[[knows page::+]]|?knows page |sort=knows page|format=plainlist}}"
+		}
+	],
+	"tests": [
+		{
+			"type": "parser",
+			"about": "#0 (verify pages referencing non-existent pages are included in the result)",
+			"subject": "Example/P1007/Test",
+			"assert-output": {
+				"to-contain": "Example/P1007/3.*Example/P1007/2.*Example/P1007/1"
+			}
+		}
+	],
+	"settings": {
+		"wgContLang": "en",
+		"wgLang": "en",
+		"smwgNamespacesWithSemanticLinks": {
+			"NS_MAIN": true,
+			"SMW_NS_PROPERTY": true
+		}
+	},
+	"meta": {
+		"version": "2",
+		"is-incomplete": false,
+		"debug": false
+	}
+}


### PR DESCRIPTION
This PR is made in reference to: #540

This PR tests that sorting on a Pages type attribute will not exclude pages referencing non-existent pages from the result

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed