### PR TITLE
Special:Ask add extra debug query parameter (score_set, q_engine)

### DIFF
--- a/src/Query/QuerySourceFactory.php
+++ b/src/Query/QuerySourceFactory.php
@@ -43,6 +43,9 @@ class QuerySourceFactory {
 		$this->store = $store;
 		$this->querySources = $querySources;
 		$this->queryEndpoint = $queryEndpoint;
+
+		// Standard store
+		$this->querySources['sql_store'] = 'SMW\SQLStore\SQLStore';
 	}
 
 	/**
@@ -86,6 +89,10 @@ class QuerySourceFactory {
 	 * @return string
 	 */
 	public function getAsString( $source = null ) {
+
+		if ( $source === 'sql_store' ) {
+			return 'SMWSQLStore';
+		}
 
 		if ( $source !== '' && $source !== null ) {
 			return $source;

--- a/tests/phpunit/Unit/Query/QuerySourceFactoryTest.php
+++ b/tests/phpunit/Unit/Query/QuerySourceFactoryTest.php
@@ -60,6 +60,24 @@ class QuerySourceFactoryTest extends \PHPUnit_Framework_TestCase {
 		);
 	}
 
+	public function testGetStandardStore() {
+
+		$instance = new QuerySourceFactory(
+			$this->store,
+			[]
+		);
+
+		$this->assertInstanceOf(
+			'\SMW\SQLStore\SQLStore',
+			$instance->get( 'sql_store' )
+		);
+
+		$this->assertEquals(
+			'SMWSQLStore',
+			$instance->getAsString( 'sql_store' )
+		);
+	}
+
 	public function testGetAsString() {
 
 		$store = $this->getMockBuilder( '\SMW\SPARQLStore\SPARQLStore' )


### PR DESCRIPTION
This PR is made in reference to: #

This PR addresses or contains:

- Allows to set some query parameters which are useful when debugging or getting extra information from a selected query engine
  - `q_engine=sql_store`
  - `score_set=show` (only works where a score set is available such as ES)

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed

Fixes #