### PR TITLE
Add custom prefix map to term.parser, refs 3145

### DIFF
--- a/res/smw/special/ext.smw.special.search.css
+++ b/res/smw/special/ext.smw.special.search.css
@@ -213,6 +213,9 @@
     margin-bottom: 0.5em;
 }
 
+#mw-searchoptions h4, #smw-search-togglensview, #mw-search-togglebox {
+    margin-top: 2px !important;
+}
 
 /**
  * Responsive settings (#see smw.table.css)

--- a/src/MediaWiki/Search/Form/FormsBuilder.php
+++ b/src/MediaWiki/Search/Form/FormsBuilder.php
@@ -141,7 +141,9 @@ class FormsBuilder {
 			$html[] = "<option value='$k' $selected>$name</option>";
 		}
 
-		$link = ( $link !== '' ? $link . ' ⦁ ' : '' ) . Html::element(
+		$attr = [ 'style' => 'border-right:1px solid #ccc;margin-right:4px;' ];
+
+		$link = ( $link !== '' ? $link . Html::rawElement( 'span', [], '&nbsp;⦁&nbsp;' ) : '' ) . Html::element(
 			'a',
 			[
 				'href' => $title->getFullUrl()
@@ -223,11 +225,15 @@ class FormsBuilder {
 		}
 
 		if ( isset( $data['namespaces']['preselect'] ) && is_array( $data['namespaces']['preselect'] ) ) {
-			$this->preselect_namespaces( $data );
+			$this->preselect_namespaces( $data['namespaces']['preselect'] );
 		}
 
-		if ( isset( $data['namespaces']['hidden'] ) && is_array( $data['namespaces']['hidden'] ) ) {
-			$this->hidden_namespaces( $data );
+		if ( isset( $data['namespaces']['hidden'] ) && is_array(  ) ) {
+			$this->hidden_namespaces( $data['namespaces']['hidden'] );
+		}
+
+		if ( isset( $data['namespaces']['hide'] ) && is_array( $data['namespaces']['hide'] ) ) {
+			$this->hidden_namespaces( $data['namespaces']['hide'] );
 		}
 
 		return $divider . Html::rawElement(
@@ -277,8 +283,8 @@ class FormsBuilder {
 		);
 	}
 
-	private function preselect_namespaces( $data ) {
-		foreach ( $data['namespaces']['preselect'] as $k => $values ) {
+	private function preselect_namespaces( $preselect ) {
+		foreach ( $preselect as $k => $values ) {
 			$k = self::toLowerCase( $k );
 			$this->preselectNsList[$k] = [];
 
@@ -290,8 +296,8 @@ class FormsBuilder {
 		}
 	}
 
-	private function hidden_namespaces( $data ) {
-		foreach ( $data['namespaces']['hidden'] as $ns ) {
+	private function hidden_namespaces( $hidden ) {
+		foreach ( $hidden as $ns ) {
 			if ( is_string( $ns ) && defined( $ns ) ) {
 				$this->hiddenNsList[] = constant( $ns );
 			}

--- a/src/MediaWiki/Search/SearchProfileForm.php
+++ b/src/MediaWiki/Search/SearchProfileForm.php
@@ -157,7 +157,7 @@ class SearchProfileForm {
 		$searchEngine = $this->specialSearch->getSearchEngine();
 
 		if ( ( $queryLink = $searchEngine->getQueryLink() ) instanceof \SMWInfolink ) {
-			$queryLink->setCaption( '⋯' );
+			$queryLink->setCaption( 'Query' );
 			$queryLink->setLinkAttributes( [ 'title' => 'Special:Ask' ] );
 			$link = $queryLink->getHtml();
 		}
@@ -297,8 +297,8 @@ class SearchProfileForm {
 				'class' => 'smw-errors',
 				'style' => 'color:#b32424;'
 			],
-			'<li>' . implode( '</li><li>', $list ) . '</li>' . $divider
-		);
+			'<li>' . implode( '</li><li>', $list ) . '</li>'
+		) . $divider;
 	}
 
 	private function buildSortForm( $request ) {

--- a/src/Query/Parser/TermParser.php
+++ b/src/Query/Parser/TermParser.php
@@ -1,0 +1,170 @@
+<?php
+
+namespace SMW\Query\Parser;
+
+/**
+ * The term parser uses a simplified string to build an #ask conform query
+ * string, for example `in:foo bar || (phrase:bar && not:foo)` becomes `[[in:
+ * foo bar]] || <q>[[phrase:bar]] && [[not:foo]]</q>`.
+ *
+ * A prefix map can contain assignments to define a query construct, hereby
+ * allowing to use a custom prefix to simplify the input process.
+ *
+ * @license GNU GPL v2+
+ * @since 3.0
+ *
+ * @author mwjames
+ */
+class TermParser {
+
+	/**
+	 * @var []
+	 */
+	private $standard_prefix = [ 'in:', 'phrase:', 'not:', 'category:' ];
+
+	/**
+	 * The `prefix_map` is expected to contain assignments of prefixes that link
+	 * to a collection of properties. The prefix is used as short-cut to cover a
+	 * range of disjunctive query declarations to simplify the creation of a
+	 * query construct such as:
+	 *
+	 * - Map: `'keyword:' => [ 'Has keyword', 'Keyword' ]`
+	 * - Input: `keyword:foo bar`
+	 * - Output: `([[Has keyword::foo bar]] || [[Keyword::foo bar]])`
+	 *
+	 * @var []
+	 */
+	private $prefix_map = [];
+
+	/**
+	 * @since 3.0
+	 *
+	 * @param array $prefix_map
+	 */
+	public function __construct( array $prefix_map = [] ) {
+		$this->prefix_map = $prefix_map;
+
+		// Just in case, `in:`, `phrase:`, and `not:` are not permitted to be
+		// overridden by a prefix assignment, `category:` can.
+		unset( $this->prefix_map['in:'] );
+		unset( $this->prefix_map['phrase:'] );
+		unset( $this->prefix_map['not:'] );
+	}
+
+	/**
+	 * @param string $term
+	 *
+	 * @return string
+	 */
+	public function parse( $term ) {
+
+		$pattern = '';
+		$custom_prefix = [];
+
+		foreach ( array_keys( $this->prefix_map ) as $p ) {
+			$pattern .= '|(' . $p . ':)';
+			$custom_prefix[] = "$p:";
+		}
+
+		// Simplify the processing by normalizing expressions
+		$term = str_replace([ '<q>', '</q>' ],  [ '(', ')' ], $term );
+
+		$terms = preg_split(
+			"/(in:)|(phrase:)|(not:)|(category:)$pattern|(&&)|(AND)|(OR)|(\|\|)|(\()|(\)|(\[\[))/",
+			$term,
+			-1,
+			PREG_SPLIT_DELIM_CAPTURE | PREG_SPLIT_NO_EMPTY
+		);
+
+		$affix = array_merge(
+			[ '&&', 'AND', '||', 'OR', '(', ')', '[[' ],
+			$this->standard_prefix,
+			$custom_prefix
+		);
+
+		$term = '';
+		$custom = '';
+		$prefix = '';
+		$k = 0;
+
+		while ( key( $terms ) !== null ) {
+			$new = trim( current( $terms ) );
+			$next = next( $terms );
+			$last = substr( $term, -2 );
+
+			if ( $new === '' ) {
+				continue;
+			}
+
+			if ( $new === '[[' && $next === '[[' ) {
+				continue;
+			}
+
+			if ( in_array( $new, $custom_prefix ) ) {
+				$custom = "[[$new";
+				$prefix = $new;
+			} elseif( in_array( $new, $this->standard_prefix ) ) {
+				$term .= "[[$new";
+			} elseif ( $custom !== '' ) {
+				$custom .= $new;
+				$last = substr( $new, -2 );
+			} else {
+				$term .= $new;
+			}
+
+			if ( $last === ']]' || $new === '(' || $new === '||' ) {
+				continue;
+			}
+
+			// Check next element, close expression in case of a matching
+			// affix
+			if ( $k > 0 && in_array( $next, $affix ) ) {
+				$term .= $this->close( $custom, $prefix );
+			}
+
+			// Last element
+			if ( $next === false && !in_array( $last, [ '&&', 'AND', '||', 'OR', ']]' ] ) ) {
+				$term .= $this->close( $custom, $prefix );
+			}
+
+			$k++;
+		}
+
+		return $this->normalize( $term );
+	}
+
+	private function close( &$custom, $prefix ) {
+
+		// Standard closing
+		if ( $custom === '' ) {
+			return "]]";
+		}
+
+		$term = "$custom]]";
+		$custom = '';
+		$terms =  [];
+		$p_map = str_replace( ':', '', $prefix );
+
+		if ( !isset( $this->prefix_map[$p_map] ) ) {
+			return $term;
+		}
+
+		// A custom prefix adds additional disjunctive conditions to broaden the
+		// search radius for all its assigned properties.
+		foreach ( $this->prefix_map[$p_map] as $val ) {
+			$terms[] = str_replace( $prefix, $val . '::', $term );
+		}
+
+		// `keyword:foo bar` -> ([[Has keyword::foo bar]] || [[Keyword::foo bar]])
+		return '(' . implode( '||', $terms ) . ')';
+	}
+
+	private function normalize( $term ) {
+		return str_replace(
+			[ ')[[', ']](', '(', ')', '||', '&&', 'AND', 'OR', ']][[', '[[[[', ']]]]' ],
+			[ ') [[', ']] (', '<q>', '</q>', ' || ', ' && ', ' AND ', ' OR ', ']] [[', '[[', ']]' ],
+			$term
+		);
+	}
+
+}

--- a/tests/phpunit/Unit/MediaWiki/Search/QueryBuilderTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Search/QueryBuilderTest.php
@@ -110,8 +110,6 @@ class QueryBuilderTest extends \PHPUnit_Framework_TestCase {
 			[ 'foo' ]
 		);
 
-		$instance->noCheck();
-
 		$this->assertEquals(
 			'Foo',
 			$instance->getQueryString( $this->store, 'Foo' )
@@ -142,8 +140,6 @@ class QueryBuilderTest extends \PHPUnit_Framework_TestCase {
 			$this->webRequest,
 			$form_def
 		);
-
-		$instance->noCheck();
 
 		$this->assertEquals(
 			'<q>[[Bar property::Foobar]]</q>  Foo',
@@ -178,8 +174,6 @@ class QueryBuilderTest extends \PHPUnit_Framework_TestCase {
 			$this->webRequest,
 			$form_def
 		);
-
-		$instance->noCheck();
 
 		$this->assertEquals(
 			'<q>[[Bar property::42]]</q>  Foo',
@@ -220,97 +214,11 @@ class QueryBuilderTest extends \PHPUnit_Framework_TestCase {
 			$form_def
 		);
 
-		$instance->noCheck();
-
 		$this->assertEquals(
 			'<q>[[Bar::42]] </q> OR Foo',
 			$instance->getQueryString( $this->store, 'Foo' )
 		);
 	}
 
-	/**
-	 * @dataProvider termProvider
-	 */
-	public function testTerm_parser( $term, $expected ) {
-
-		$this->assertEquals(
-			$expected,
-			QueryBuilder::term_parser( $term )
-		);
-	}
-
-	public function termProvider() {
-
-		yield [
-			'in:foo',
-			'[[in:foo]]'
-		];
-
-		yield [
-			'[[in:foo]]',
-			'[[in:foo]]'
-		];
-
-		yield [
-			'in:foo || bar',
-			'[[in:foo]] || bar'
-		];
-
-		yield [
-			'in:foo && bar',
-			'[[in:foo]] && bar'
-		];
-
-		yield [
-			'in:foo || in:bar',
-			'[[in:foo]] || [[in:bar]]'
-		];
-
-		yield [
-			'in:foo bar in:bar ',
-			'[[in:foo bar]] [[in:bar]]'
-		];
-
-		yield [
-			'in:foo bar && in:bar',
-			'[[in:foo bar]] && [[in:bar]]'
-		];
-
-		yield [
-			'in:foo bar || in:bar ',
-			'[[in:foo bar]] || [[in:bar]]'
-		];
-
-		yield [
-			'(in:foo bar && in:foo) || in:bar ',
-			'<q>[[in:foo bar]] && [[in:foo]]</q> || [[in:bar]]'
-		];
-
-		yield [
-			'in:foo bar in:bar phrase:foobar 123 && in:oooo',
-			'[[in:foo bar]] [[in:bar]] [[phrase:foobar 123]] && [[in:oooo]]'
-		];
-
-		yield [
-			'<q>in:foo bar && in:bar</q> OR phrase:foo bar foobar',
-			'<q>[[in:foo bar]] && [[in:bar]]</q> OR [[phrase:foo bar foobar]]'
-		];
-
-		yield [
-			'(in:foo && in:bar)||in:foobar',
-			'<q>[[in:foo]] && [[in:bar]]</q> || [[in:foobar]]'
-		];
-
-		yield [
-			'(in:foo && (in:bar AND not:ooo)) || in:foobar',
-			'<q>[[in:foo]] && <q>[[in:bar]] AND [[not:ooo]]</q></q> || [[in:foobar]]'
-		];
-
-
-		yield [
-			'<q>in:foo bar && in:bar</q> OR [[Has number::123]]',
-			'<q>[[in:foo bar]] && [[in:bar]]</q> OR [[Has number::123]]'
-		];
-	}
 
 }

--- a/tests/phpunit/Unit/Query/Parser/TermParserTest.php
+++ b/tests/phpunit/Unit/Query/Parser/TermParserTest.php
@@ -1,0 +1,184 @@
+<?php
+
+namespace SMW\Tests\Query\Parser;
+
+use SMW\Query\Parser\TermParser;
+
+/**
+ * @covers \SMW\Query\Parser\TermParser
+ * @group semantic-mediawiki
+ *
+ * @license GNU GPL v2+
+ * @since 3.0
+ *
+ * @author mwjames
+ */
+class TermParserTest extends \PHPUnit_Framework_TestCase {
+
+	public function testCanConstruct() {
+
+		$this->assertInstanceOf(
+			TermParser::class,
+			new TermParser()
+		);
+	}
+
+	/**
+	 * @dataProvider termProvider
+	 */
+	public function testTerm_parser( $term, $expected ) {
+
+		$instance = new TermParser();
+
+		$this->assertEquals(
+			$expected,
+			$instance->parse( $term )
+		);
+	}
+
+	/**
+	 * @dataProvider term_prefixProvider
+	 */
+	public function testTerm_prefix_parser( $term, $prefixes, $expected ) {
+
+		$instance = new TermParser( $prefixes );
+
+		$this->assertEquals(
+			$expected,
+			$instance->parse( $term )
+		);
+	}
+
+	public function termProvider() {
+
+		yield [
+			'in:foo',
+			'[[in:foo]]'
+		];
+
+		yield [
+			'[[in:foo]]',
+			'[[in:foo]]'
+		];
+
+		yield [
+			'in:foo || bar',
+			'[[in:foo]] || bar'
+		];
+
+		yield [
+			'in:foo && bar',
+			'[[in:foo]] && bar'
+		];
+
+		yield [
+			'in:foo || in:bar',
+			'[[in:foo]] || [[in:bar]]'
+		];
+
+		yield [
+			'in:foo && in:bar',
+			'[[in:foo]] && [[in:bar]]'
+		];
+
+		yield [
+			'in:foo bar in:bar ',
+			'[[in:foo bar]] [[in:bar]]'
+		];
+
+		yield [
+			'in:foo bar && in:bar',
+			'[[in:foo bar]] && [[in:bar]]'
+		];
+
+		yield [
+			'in:foo bar || in:bar ',
+			'[[in:foo bar]] || [[in:bar]]'
+		];
+
+		yield [
+			'(in:foo bar && in:foo) || in:bar ',
+			'<q>[[in:foo bar]] && [[in:foo]]</q> || [[in:bar]]'
+		];
+
+		yield [
+			'in:foo bar in:bar phrase:foobar 123 && in:oooo',
+			'[[in:foo bar]] [[in:bar]] [[phrase:foobar 123]] && [[in:oooo]]'
+		];
+
+		yield [
+			'<q>in:foo bar && in:bar</q> OR phrase:foo bar foobar',
+			'<q>[[in:foo bar]] && [[in:bar]]</q> OR [[phrase:foo bar foobar]]'
+		];
+
+		yield [
+			'(in:foo && in:bar)||in:foobar',
+			'<q>[[in:foo]] && [[in:bar]]</q> || [[in:foobar]]'
+		];
+
+		yield [
+			'(in:foo && (in:bar AND not:ooo)) || in:foobar',
+			'<q>[[in:foo]] && <q>[[in:bar]] AND [[not:ooo]]</q></q> || [[in:foobar]]'
+		];
+
+		yield [
+			'<q>in:foo bar && in:bar</q> OR [[Has number::123]]',
+			'<q>[[in:foo bar]] && [[in:bar]]</q> OR [[Has number::123]]'
+		];
+
+		yield [
+			'in:foo [[Has foo::bar]]',
+			'[[in:foo]] [[Has foo::bar]]'
+		];
+
+		yield [
+			'in:foo [[Has foo::bar]] (in:foo bar)',
+			'[[in:foo]] [[Has foo::bar]] <q>[[in:foo bar]]</q>'
+		];
+
+		yield [
+			'category:foo',
+			'[[category:foo]]'
+		];
+	}
+
+	public function term_prefixProvider() {
+
+		yield [
+			'in:foo || not:bar',
+			[ 'keyw' => [ 'Has keyword', 'Keyw' ] ],
+			'[[in:foo]] || [[not:bar]]'
+		];
+
+		yield [
+			'in:foo || keyword:foo bar || keyw:foo bar',
+			[ 'keyw' => [ 'Has keyword', 'Keyw' ] ],
+			'[[in:foo]] || keyword:foo bar]] || <q>[[Has keyword::foo bar]] || [[Keyw::foo bar]]</q>'
+		];
+
+		yield [
+			'in:foo keyw:foo bar',
+			[ 'keyw' => [ 'Has keyword', 'Keyw' ] ],
+			'[[in:foo]] <q>[[Has keyword::foo bar]] || [[Keyw::foo bar]]</q>'
+		];
+
+		yield [
+			'in:foo keyw:foo bar [[Foo::bar]]',
+			[ 'keyw' => [ 'Has keyword', 'Keyw' ] ],
+			'[[in:foo]] <q>[[Has keyword::foo bar]] || [[Keyw::foo bar]]</q> [[Foo::bar]]'
+		];
+
+		yield [
+			'in:foo (a:foo bar || not:bar)',
+			[ 'a' => [ 'Has keyword', 'Keyw' ] ],
+			'[[in:foo]] <q><q>[[Has keyword::foo bar]] || [[Keyw::foo bar]]</q> || [[not:bar]]</q>'
+		];
+
+		yield [
+			'in:foo',
+			[ 'in:' => [ 'a', 'b' ] ],
+			'[[in:foo]]'
+		];
+	}
+
+}


### PR DESCRIPTION
This PR is made in reference to: #3145

This PR addresses or contains:

- As outlined in #3145 `term.parser` adds a simplified syntax to the `Special:Search` input field, the PR extends the parser to recognize custom prefixes so that a set of properties can be collected under a specific search prefix.
- For example, by adding prefix assignments (as demonstrated below)
  - A `keyword:foobar` input will be transformed into a #ask conform expression of `<q>[[Has keyword::foobar]] OR [[Has keywords::foobar]] OR [[Keyword::foobar]]</q>` allowing the shorten the input sequence without a user being require to remember particular properties.
  - Various language related properties are used for different purposes but during a quick search a user wants to find certain documents that match any of the possible language properties by simply referring to `lang:foo in:some documents with xyz`

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed

## Example

```
    "term.parser": {
        "keyword": [
            "Has keyword",
            "Has keywords",
            "Keyword"
        ],
        "abstract": [
            "Has abstract",
            "Has description"
        ],
        "lang": [
            "Language code",
            "Document language",
            "File attachment.Content language",
            "Has interlanguage link.Page content language"
        ]
    },
```
