### PR TITLE
Remove SMW_NS_TYPE ns, $smwgHistoricTypeNamespace, refs 399

### DIFF
--- a/DefaultSettings.php
+++ b/DefaultSettings.php
@@ -263,18 +263,6 @@ return array(
 	##
 
 	###
-	# Setting this option to true before including this file to enable the old
-	# Type: namespace that SMW used up to version 1.5.*. This should only be
-	# done to make the pages of this namespace temporarily accessible in order to
-	# move their content to other pages. If the namespace is not registered, then
-	# existing pages in this namespace cannot be found in the wiki.
-	#
-	# @since 1.6
-	##
-	'smwgHistoricTypeNamespace' => false,
-	##
-
-	###
 	# If you already have custom namespaces on your site, insert
 	#    	'smwgNamespaceIndex' => ???,
 	# into your LocalSettings.php *before* including this file. The number ??? must

--- a/includes/Settings.php
+++ b/includes/Settings.php
@@ -66,7 +66,6 @@ class Settings extends Options {
 			'smwgSparqlRepositoryConnectorForcedHttpVersion' => $GLOBALS['smwgSparqlRepositoryConnectorForcedHttpVersion'],
 			'smwgSparqlReplicationPropertyExemptionList' => $GLOBALS['smwgSparqlReplicationPropertyExemptionList'],
 			'smwgSparqlQFeatures' => $GLOBALS['smwgSparqlQFeatures'],
-			'smwgHistoricTypeNamespace' => $GLOBALS['smwgHistoricTypeNamespace'],
 			'smwgNamespaceIndex' => $GLOBALS['smwgNamespaceIndex'],
 			'smwgShowFactbox' => $GLOBALS['smwgShowFactbox'],
 			'smwgShowFactboxEdit' => $GLOBALS['smwgShowFactboxEdit'],
@@ -554,7 +553,8 @@ class Settings extends Options {
 			'removal' => array(
 				'smwgOnDeleteAction' => '2.4.0',
 				'smwgAutocompleteInSpecialAsk' => '3.0.0',
-				'smwgSparqlDatabaseMaster' => '3.0.0'
+				'smwgSparqlDatabaseMaster' => '3.0.0',
+				'smwgHistoricTypeNamespace' => '3.0.0'
 			)
 		);
 	}

--- a/includes/datavalues/SMW_DV_WikiPage.php
+++ b/includes/datavalues/SMW_DV_WikiPage.php
@@ -82,9 +82,6 @@ class SMWWikiPageValue extends SMWDataValue {
 	public function __construct( $typeid ) {
 		parent::__construct( $typeid );
 		switch ( $typeid ) {
-			case '__typ':
-				$this->m_fixNamespace = SMW_NS_TYPE;
-			break;
 			case '_wpp' : case '__sup':
 				$this->m_fixNamespace = SMW_NS_PROPERTY;
 			break;

--- a/includes/export/SMW_ExportController.php
+++ b/includes/export/SMW_ExportController.php
@@ -753,7 +753,7 @@ class SMWExportController {
 		if ( $res >= 0 ) {
 			return ( $res == $ns );
 		}
-		return ( ( $res != NS_CATEGORY ) && ( $res != SMW_NS_PROPERTY ) && ( $res != SMW_NS_TYPE ) );
+		return ( ( $res != NS_CATEGORY ) && ( $res != SMW_NS_PROPERTY ) );
 	}
 
 	private function getDeepRedirectTargetResolver() {

--- a/maintenance/dumpRDF.php
+++ b/maintenance/dumpRDF.php
@@ -141,8 +141,6 @@ class DumpRdf extends \Maintenance {
 			$this->restrictNamespaceTo = array( NS_CATEGORY, SMW_NS_CONCEPT );
 		} elseif ( $this->hasOption( 'properties' ) ) {
 			$this->restrictNamespaceTo = SMW_NS_PROPERTY;
-		} elseif ( $this->hasOption( 'types' ) ) {
-			$this->restrictNamespaceTo = SMW_NS_TYPE;
 		} elseif ( $this->hasOption( 'individuals' ) ) {
 			$this->restrictNamespaceTo = - 1;
 		}

--- a/src/DataValues/TypesValue.php
+++ b/src/DataValues/TypesValue.php
@@ -189,7 +189,6 @@ class TypesValue extends DataValue {
 	 * {@inheritDoc}
 	 */
 	protected function parseUserValue( $value ) {
-		global $smwgHistoricTypeNamespace;
 
 		if ( $this->m_caption === false ) {
 			$this->m_caption = $value;
@@ -197,16 +196,6 @@ class TypesValue extends DataValue {
 
 		$valueParts = explode( ':', $value, 2 );
 		$contentLanguage = $this->getOption( self::OPT_CONTENT_LANGUAGE );
-
-		if ( $smwgHistoricTypeNamespace && count( $valueParts ) > 1 ) {
-			$namespace = smwfNormalTitleText( $valueParts[0] );
-			$value = $valueParts[1];
-			$typeNamespace = Localizer::getInstance()->getLanguage( $contentLanguage )->getNsText( SMW_NS_TYPE );
-
-			if ( $namespace != $typeNamespace ) {
-				$this->addErrorMsg( [ 'smw_wrong_namespace', $typeNamespace ] );
-			}
-		}
 
 		if ( $value !== '' && $value{0} === '_' ) {
 			$this->m_typeId = $value;

--- a/src/Lang/Lang.php
+++ b/src/Lang/Lang.php
@@ -27,11 +27,6 @@ class Lang {
 	private $languageContents;
 
 	/**
-	 * @var boolean
-	 */
-	private $historicTypeNamespace = false;
-
-	/**
 	 * @var string
 	 */
 	private $languageCode = 'en';
@@ -87,10 +82,6 @@ class Lang {
 			)
 		);
 
-		self::$instance->setHistoricTypeNamespace(
-			$GLOBALS['smwgHistoricTypeNamespace']
-		);
-
 		return self::$instance;
 	}
 
@@ -99,15 +90,6 @@ class Lang {
 	 */
 	public static function clear() {
 		self::$instance = null;
-	}
-
-	/**
-	 * @since 2.5
-	 *
-	 * @param boolean $historicTypeNamespace
-	 */
-	public function setHistoricTypeNamespace( $historicTypeNamespace ) {
-		$this->historicTypeNamespace = (bool)$historicTypeNamespace;
 	}
 
 	/**
@@ -168,15 +150,11 @@ class Lang {
 
 		foreach ( $namespaces as $key => $value ) {
 			unset( $namespaces[$key] );
-			$namespaces[constant($key)] = $value;
-		}
 
-		if ( $this->historicTypeNamespace ) {
-			return $namespaces;
+			if ( defined( $key ) ) {
+				$namespaces[constant($key)] = $value;
+			}
 		}
-
-		unset( $namespaces[SMW_NS_TYPE] );
-		unset( $namespaces[SMW_NS_TYPE_TALK] );
 
 		return $namespaces;
 	}
@@ -201,16 +179,8 @@ class Lang {
 		);
 
 		foreach ( $namespaceAliases as $alias => $namespace ) {
-			$namespaceAliases[$alias] = constant( $namespace );
-		}
-
-		if ( $this->historicTypeNamespace ) {
-			return $namespaceAliases;
-		}
-
-		foreach ( $namespaceAliases as $alias => $namespace ) {
-			if ( $namespace === SMW_NS_TYPE || $namespace === SMW_NS_TYPE_TALK ) {
-				unset( $namespaceAliases[$alias] );
+			if ( defined( $namespace ) ) {
+				$namespaceAliases[$alias] = constant( $namespace );
 			}
 		}
 

--- a/src/MediaWiki/Jobs/RefreshJob.php
+++ b/src/MediaWiki/Jobs/RefreshJob.php
@@ -127,7 +127,7 @@ class RefreshJob extends JobBase {
 			return false;
 		}
 
-		return ( ( $this->getParameter( 'rc' ) > 1 ) && ( $run == 1 ) ) ? array( SMW_NS_PROPERTY, SMW_NS_TYPE ) : false;
+		return ( ( $this->getParameter( 'rc' ) > 1 ) && ( $run == 1 ) ) ? [ SMW_NS_PROPERTY ] : false;
 	}
 
 }

--- a/src/NamespaceManager.php
+++ b/src/NamespaceManager.php
@@ -96,18 +96,11 @@ class NamespaceManager {
 		$canonicalNames = array(
 			SMW_NS_PROPERTY      => 'Property',
 			SMW_NS_PROPERTY_TALK => 'Property_talk',
-			SMW_NS_TYPE          => 'Type',
-			SMW_NS_TYPE_TALK     => 'Type_talk',
 			SMW_NS_CONCEPT       => 'Concept',
 			SMW_NS_CONCEPT_TALK  => 'Concept_talk',
 			SMW_NS_RULE          => 'Rule',
 			SMW_NS_RULE_TALK     => 'Rule_talk'
 		);
-
-		if ( !array_key_exists( 'smwgHistoricTypeNamespace', $GLOBALS ) || !$GLOBALS['smwgHistoricTypeNamespace'] ) {
-			unset( $canonicalNames[SMW_NS_TYPE] );
-			unset( $canonicalNames[SMW_NS_TYPE_TALK] );
-		}
 
 		return $canonicalNames;
 	}
@@ -130,8 +123,6 @@ class NamespaceManager {
 		$namespaceIndex = array(
 			'SMW_NS_PROPERTY'      => $offset + 2,
 			'SMW_NS_PROPERTY_TALK' => $offset + 3,
-			'SMW_NS_TYPE'          => $offset + 4,
-			'SMW_NS_TYPE_TALK'     => $offset + 5,
 			'SF_NS_FORM'           => $offset + 6,
 			'SF_NS_FORM_TALK'      => $offset + 7,
 			'SMW_NS_CONCEPT'       => $offset + 8,
@@ -202,19 +193,11 @@ class NamespaceManager {
 		$smwNamespacesSettings = array(
 			SMW_NS_PROPERTY  => true,
 			SMW_NS_PROPERTY_TALK  => false,
-			SMW_NS_TYPE => true,
-			SMW_NS_TYPE_TALK => false,
 			SMW_NS_CONCEPT => true,
 			SMW_NS_CONCEPT_TALK => false,
 			SMW_NS_RULE => true,
 			SMW_NS_RULE_TALK => false,
 		);
-
-		if ( !array_key_exists( 'smwgHistoricTypeNamespace', $GLOBALS ) || !$GLOBALS['smwgHistoricTypeNamespace'] ) {
-			unset( $smwNamespacesSettings[SMW_NS_TYPE] );
-			unset( $smwNamespacesSettings[SMW_NS_TYPE_TALK] );
-			unset( $vars['wgNamespacesWithSubpages'][SMW_NS_TYPE_TALK] );
-		}
 
 		// Combine default values with values specified in other places
 		// (LocalSettings etc.)

--- a/tests/phpunit/Unit/NamespaceManagerTest.php
+++ b/tests/phpunit/Unit/NamespaceManagerTest.php
@@ -81,11 +81,6 @@ class NamespaceManagerTest extends \PHPUnit_Framework_TestCase {
 
 	public function testGetCanonicalNames() {
 
-		$this->testEnvironment->addConfiguration(
-			'smwgHistoricTypeNamespace',
-			false
-		);
-
 		$result = NamespaceManager::getCanonicalNames();
 
 		$this->assertInternalType(
@@ -101,11 +96,6 @@ class NamespaceManagerTest extends \PHPUnit_Framework_TestCase {
 
 	public function testGetCanonicalNamesWithTypeNamespace() {
 
-		$this->testEnvironment->addConfiguration(
-			'smwgHistoricTypeNamespace',
-			true
-		);
-
 		$result = NamespaceManager::getCanonicalNames();
 
 		$this->assertInternalType(
@@ -114,7 +104,7 @@ class NamespaceManagerTest extends \PHPUnit_Framework_TestCase {
 		);
 
 		$this->assertCount(
-			8,
+			6,
 			$result
 		);
 	}
@@ -145,11 +135,6 @@ class NamespaceManagerTest extends \PHPUnit_Framework_TestCase {
 
 	public function testNamespacesInitWithEmptySettings() {
 
-		$this->testEnvironment->addConfiguration(
-			'smwgHistoricTypeNamespace',
-			false
-		);
-
 		$vars = $this->default + array(
 			'wgExtraNamespaces'  => '',
 			'wgNamespaceAliases' => ''
@@ -169,18 +154,9 @@ class NamespaceManagerTest extends \PHPUnit_Framework_TestCase {
 		$this->assertTrue(
 			$vars['smwgNamespacesWithSemanticLinks'][SMW_NS_RULE]
 		);
-
-		$this->assertFalse(
-			isset( $vars['smwgNamespacesWithSemanticLinks'][SMW_NS_TYPE] )
-		);
 	}
 
 	public function testInitToKeepPreInitSettings() {
-
-		$this->testEnvironment->addConfiguration(
-			'smwgHistoricTypeNamespace',
-			true
-		);
 
 		$vars = $this->default + array(
 			'wgExtraNamespaces'  => '',
@@ -200,10 +176,6 @@ class NamespaceManagerTest extends \PHPUnit_Framework_TestCase {
 
 		$this->assertTrue(
 			$vars['smwgNamespacesWithSemanticLinks'][SMW_NS_CONCEPT]
-		);
-
-		$this->assertTrue(
-			$vars['smwgNamespacesWithSemanticLinks'][SMW_NS_TYPE]
 		);
 	}
 


### PR DESCRIPTION
This PR is made in reference to: #399

This PR addresses or contains:

- Removes SMW_NS_TYPE and SMW_NS_TYPE_TALK
- Removes the `$smwgHistoricTypeNamespace` setting
- It doesn't remove any reference to `SMW_NS_TYPE`/`SMW_NS_TYPE_TALK` from any l18n file

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed

Fixes #399