### PR TITLE
Test empty chain/subquery

### DIFF
--- a/tests/phpunit/Integration/JSONScript/TestCases/q-0911.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/q-0911.json
@@ -1,0 +1,54 @@
+{
+	"description": "Test `_wpg` empty chain/subquery (AND, OR)",
+	"setup": [
+		{
+			"namespace": "SMW_NS_PROPERTY",
+			"page": "Has page",
+			"contents": "[[Has type::Page]]"
+		},
+		{
+			"page": "Q0911/1",
+			"contents": "[[Has page::Q0911]]"
+		}
+	],
+	"tests": [
+		{
+			"type": "query",
+			"about": "#0 (OR)",
+			"condition": "[[Has page::Q0911]] OR [[Some page.Another page::Foo]]",
+			"printouts": [],
+			"parameters": {
+				"limit": "10"
+			},
+			"assert-queryresult": {
+				"count": 1,
+				"results": [
+					"Q0911/1#0##"
+				]
+			}
+		},
+		{
+			"type": "query",
+			"about": "#1 (AND)",
+			"condition": "[[Has page::Q0911]] [[Some page.Another page::Foo]]",
+			"printouts": [],
+			"parameters": {
+				"limit": "10"
+			},
+			"assert-queryresult": {
+				"count": 0
+			}
+		}
+	],
+	"settings": {
+		"smwgNamespacesWithSemanticLinks": {
+			"NS_MAIN": true,
+			"SMW_NS_PROPERTY": true
+		}
+	},
+	"meta": {
+		"version": "2",
+		"is-incomplete": false,
+		"debug": false
+	}
+}


### PR DESCRIPTION
This PR is made in reference to: #

This PR addresses or contains:

- Just hasn't been tested `[[Has page::Q0911]] OR [[Some page.Another page::Foo]]` (`[[Some page.Another page::Foo]]` returns an empty set) before!

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed
