### PR TITLE
Removes obsolete translations for former namespace "Type"

### DIFF
--- a/i18n/extra/ar.json
+++ b/i18n/extra/ar.json
@@ -79,8 +79,6 @@
     "namespaces": {
         "SMW_NS_PROPERTY": "خاصية",
         "SMW_NS_PROPERTY_TALK": "نقاش_الخاصية",
-        "SMW_NS_TYPE": "نوع",
-        "SMW_NS_TYPE_TALK": "نقاش_النوع",
         "SMW_NS_CONCEPT": "مبدأ",
         "SMW_NS_CONCEPT_TALK": "نقاش_المبدأ"
     },

--- a/i18n/extra/arz.json
+++ b/i18n/extra/arz.json
@@ -79,8 +79,6 @@
     "namespaces": {
         "SMW_NS_PROPERTY": "خاصية",
         "SMW_NS_PROPERTY_TALK": "نقاش_الخاصية",
-        "SMW_NS_TYPE": "نوع",
-        "SMW_NS_TYPE_TALK": "نقاش_النوع",
         "SMW_NS_CONCEPT": "مبدأ",
         "SMW_NS_CONCEPT_TALK": "نقاش_المبدأ"
     },

--- a/i18n/extra/ca.json
+++ b/i18n/extra/ca.json
@@ -95,8 +95,6 @@
     "namespaces": {
         "SMW_NS_PROPERTY": "Propietat",
         "SMW_NS_PROPERTY_TALK": "Propietat_Discussió",
-        "SMW_NS_TYPE": "Tipus",
-        "SMW_NS_TYPE_TALK": "Tipus_Discussió",
         "SMW_NS_CONCEPT": "Concepte",
         "SMW_NS_CONCEPT_TALK": "Concepte_Discussió",
         "SMW_NS_RULE": "Regla",

--- a/i18n/extra/de.json
+++ b/i18n/extra/de.json
@@ -122,8 +122,6 @@
     "namespaces": {
         "SMW_NS_PROPERTY": "Attribut",
         "SMW_NS_PROPERTY_TALK": "Attribut_Diskussion",
-        "SMW_NS_TYPE": "Datentyp",
-        "SMW_NS_TYPE_TALK": "Datentyp_Diskussion",
         "SMW_NS_CONCEPT": "Konzept",
         "SMW_NS_CONCEPT_TALK": "Konzept_Diskussion",
         "SMW_NS_RULE": "Regel",

--- a/i18n/extra/en.json
+++ b/i18n/extra/en.json
@@ -173,8 +173,6 @@
 	"namespaces":{
 		"SMW_NS_PROPERTY": "Property",
 		"SMW_NS_PROPERTY_TALK": "Property_talk",
-		"SMW_NS_TYPE": "Type",
-		"SMW_NS_TYPE_TALK": "Type_talk",
 		"SMW_NS_CONCEPT": "Concept",
 		"SMW_NS_CONCEPT_TALK": "Concept_talk",
 		"SMW_NS_RULE": "Rule",
@@ -183,8 +181,6 @@
 	"namespace.aliases": {
 		"Property": "SMW_NS_PROPERTY",
 		"Property_talk": "SMW_NS_PROPERTY_TALK",
-		"Type": "SMW_NS_TYPE",
-		"Type_talk": "SMW_NS_TYPE_TALK",
 		"Concept": "SMW_NS_CONCEPT",
 		"Concept_talk": "SMW_NS_CONCEPT_TALK",
 		"Rule": "SMW_NS_RULE",

--- a/i18n/extra/es.json
+++ b/i18n/extra/es.json
@@ -94,8 +94,6 @@
     "namespaces": {
         "SMW_NS_PROPERTY": "Propiedad",
         "SMW_NS_PROPERTY_TALK": "Propiedad_discusión",
-        "SMW_NS_TYPE": "Tipo",
-        "SMW_NS_TYPE_TALK": "Tipo_discusión",
         "SMW_NS_CONCEPT": "Concepto",
         "SMW_NS_CONCEPT_TALK": "Concepto_discusión",
         "SMW_NS_RULE": "Regla",

--- a/i18n/extra/fi.json
+++ b/i18n/extra/fi.json
@@ -73,8 +73,6 @@
     "namespaces": {
         "SMW_NS_PROPERTY": "Ominaisuus",
         "SMW_NS_PROPERTY_TALK": "Keskustelu_ominaisuudesta",
-        "SMW_NS_TYPE": "Tyyppi",
-        "SMW_NS_TYPE_TALK": "Keskustelu_tyypistä",
         "SMW_NS_CONCEPT": "Konsepti",
         "SMW_NS_CONCEPT_TALK": "Keskustelu_konseptista"
     },

--- a/i18n/extra/fr.json
+++ b/i18n/extra/fr.json
@@ -79,8 +79,6 @@
     "namespaces": {
         "SMW_NS_PROPERTY": "Attribut",
         "SMW_NS_PROPERTY_TALK": "Discussion_attribut",
-        "SMW_NS_TYPE": "Type",
-        "SMW_NS_TYPE_TALK": "Discussion_type",
         "SMW_NS_CONCEPT": "Concept",
         "SMW_NS_CONCEPT_TALK": "Discussion_concept"
     },

--- a/i18n/extra/he.json
+++ b/i18n/extra/he.json
@@ -78,8 +78,6 @@
     "namespaces": {
         "SMW_NS_PROPERTY": "תכונה",
         "SMW_NS_PROPERTY_TALK": "שיחת_תכונה",
-        "SMW_NS_TYPE": "טיפוס",
-        "SMW_NS_TYPE_TALK": "שיחת_טיפוס",
         "SMW_NS_CONCEPT": "רעיון",
         "SMW_NS_CONCEPT_TALK": "שיחת_רעיון"
     },

--- a/i18n/extra/hu.json
+++ b/i18n/extra/hu.json
@@ -75,8 +75,6 @@
     "namespaces": {
         "SMW_NS_PROPERTY": "Tulajdonság",
         "SMW_NS_PROPERTY_TALK": "Tulajdonságvita",
-        "SMW_NS_TYPE": "Típus",
-        "SMW_NS_TYPE_TALK": "Típusvita",
         "SMW_NS_CONCEPT": "Koncepció",
         "SMW_NS_CONCEPT_TALK": "Koncepcióvita"
     },

--- a/i18n/extra/id.json
+++ b/i18n/extra/id.json
@@ -77,8 +77,6 @@
     "namespaces": {
         "SMW_NS_PROPERTY": "Properti",
         "SMW_NS_PROPERTY_TALK": "Pembicaraan_Properti",
-        "SMW_NS_TYPE": "Tipe",
-        "SMW_NS_TYPE_TALK": "Pembicaraan_Tipe",
         "SMW_NS_CONCEPT": "Konsep",
         "SMW_NS_CONCEPT_TALK": "Pembicaraan_Konsep"
     },

--- a/i18n/extra/it.json
+++ b/i18n/extra/it.json
@@ -81,8 +81,6 @@
     "namespaces": {
         "SMW_NS_PROPERTY": "Proprietà",
         "SMW_NS_PROPERTY_TALK": "Discussione proprietà",
-        "SMW_NS_TYPE": "Tipo",
-        "SMW_NS_TYPE_TALK": "Discussione tipo",
         "SMW_NS_CONCEPT": "Concetto",
         "SMW_NS_CONCEPT_TALK": "Discussione concetto"
     },

--- a/i18n/extra/nb.json
+++ b/i18n/extra/nb.json
@@ -91,8 +91,6 @@
     "namespaces": {
         "SMW_NS_PROPERTY": "Egenskap",
         "SMW_NS_PROPERTY_TALK": "Egenskap-diskusjon",
-        "SMW_NS_TYPE": "Type",
-        "SMW_NS_TYPE_TALK": "Type-diskusjon",
         "SMW_NS_CONCEPT": "Konsept",
         "SMW_NS_CONCEPT_TALK": "Konsept-diskusjon"
     },

--- a/i18n/extra/nl.json
+++ b/i18n/extra/nl.json
@@ -83,8 +83,6 @@
     "namespaces": {
         "SMW_NS_PROPERTY": "Eigenschap",
         "SMW_NS_PROPERTY_TALK": "Overleg_eigenschap",
-        "SMW_NS_TYPE": "Type",
-        "SMW_NS_TYPE_TALK": "Overleg_type",
         "SMW_NS_CONCEPT": "Concept",
         "SMW_NS_CONCEPT_TALK": "Overleg_concept"
     },

--- a/i18n/extra/pl.json
+++ b/i18n/extra/pl.json
@@ -79,8 +79,6 @@
     "namespaces": {
         "SMW_NS_PROPERTY": "Atrybut",
         "SMW_NS_PROPERTY_TALK": "Dyskusja_atrybutu",
-        "SMW_NS_TYPE": "Typ",
-        "SMW_NS_TYPE_TALK": "Dyskusja_typu",
         "SMW_NS_CONCEPT": "Pojęcie",
         "SMW_NS_CONCEPT_TALK": "Dyskusja pojęcia"
     },

--- a/i18n/extra/pt.json
+++ b/i18n/extra/pt.json
@@ -99,8 +99,6 @@
     "namespaces": {
         "SMW_NS_PROPERTY": "Propriedade",
         "SMW_NS_PROPERTY_TALK": "Discussão_propriedade",
-        "SMW_NS_TYPE": "Tipo",
-        "SMW_NS_TYPE_TALK": "Discussão_tipo",
         "SMW_NS_CONCEPT": "Conceito",
         "SMW_NS_CONCEPT_TALK": "Discussão_conceito"
     },

--- a/i18n/extra/ru.json
+++ b/i18n/extra/ru.json
@@ -82,8 +82,6 @@
     "namespaces": {
         "SMW_NS_PROPERTY": "Свойство",
         "SMW_NS_PROPERTY_TALK": "Обсуждение_свойства",
-        "SMW_NS_TYPE": "Тип",
-        "SMW_NS_TYPE_TALK": "Обсуждение_типа",
         "SMW_NS_CONCEPT": "Концепция",
         "SMW_NS_CONCEPT_TALK": "Обсуждение_концепции"
     },

--- a/i18n/extra/sk.json
+++ b/i18n/extra/sk.json
@@ -78,8 +78,6 @@
     "namespaces": {
         "SMW_NS_PROPERTY": "Atribút",
         "SMW_NS_PROPERTY_TALK": "Diskusia o atribúte",
-        "SMW_NS_TYPE": "Typ",
-        "SMW_NS_TYPE_TALK": "Diskusia o type",
         "SMW_NS_CONCEPT": "Concept",
         "SMW_NS_CONCEPT_TALK": "Concept_talk"
     },

--- a/i18n/extra/zh-cn.json
+++ b/i18n/extra/zh-cn.json
@@ -82,8 +82,6 @@
     "namespaces": {
         "SMW_NS_PROPERTY": "属性",
         "SMW_NS_PROPERTY_TALK": "属性讨论",
-        "SMW_NS_TYPE": "类型",
-        "SMW_NS_TYPE_TALK": "类型讨论",
         "SMW_NS_CONCEPT": "概念",
         "SMW_NS_CONCEPT_TALK": "概念讨论"
     },

--- a/i18n/extra/zh-tw.json
+++ b/i18n/extra/zh-tw.json
@@ -82,8 +82,6 @@
     "namespaces": {
         "SMW_NS_PROPERTY": "屬性",
         "SMW_NS_PROPERTY_TALK": "屬性討論",
-        "SMW_NS_TYPE": "類型",
-        "SMW_NS_TYPE_TALK": "類型討論",
         "SMW_NS_CONCEPT": "概念",
         "SMW_NS_CONCEPT_TALK": "概念討論"
     },


### PR DESCRIPTION
This PR is made in reference to: #399 / #3164 

This PR addresses or contains:
- Removes obsolete translations for former namespace Type

This PR includes:
- [ ] Tests (unit/integration)
- [x] CI build passed