### PR TITLE
Remove use of deprecated wfBCP47() global function

### DIFF
--- a/src/Localizer.php
+++ b/src/Localizer.php
@@ -262,7 +262,12 @@ class Localizer {
 	 * @return string
 	 */
 	public static function asBCP47FormattedLanguageCode( $languageCode ) {
-		return wfBCP47( $languageCode );
+		if ( !is_callable( [ '\LanguageCode', 'bcp47' ] ) ) {
+			// Backwards compatibility: remove once MW 1.30 is no
+			// longer supported (#3179)
+			return wfBCP47( $languageCode );
+		}
+		return \LanguageCode::bcp47( $languageCode );
 	}
 
 	/**


### PR DESCRIPTION
This function was deprecated in MW 1.31 and is slated to be hard-deprecated in MW 1.32.