### PR TITLE
Avoid use of deprecated "json" module

### DIFF
--- a/res/Resources.php
+++ b/res/Resources.php
@@ -57,12 +57,11 @@ return array(
 		'targets' => array( 'mobile', 'desktop' )
 	),
 
-	// MW 1.24+ Fix Uncaught Error: Unknown dependency: jquery.json
-	// Introducing a mega-hack
+	// Avoid "Warning: Use of the json module is deprecated since MediaWiki 1.29"
 	// jStorage was added in MW 1.20
 	'ext.jquery.jStorage' => $moduleTemplate + array(
 		'scripts' => 'jquery/jquery.jstorage.js',
-		'dependencies' => version_compare( $GLOBALS['wgVersion'], '1.24', '<' ) ? 'jquery.json' : 'json',
+		'dependencies' => version_compare( $GLOBALS['wgVersion'], '1.29', '<' ) ? 'json' : [],
 	),
 
 	// md5 hash key generator


### PR DESCRIPTION
The jquery.json module was removed in MW 1.25 (deprecated in MW 1.24).
Given SMW requires MW 1.27, logic for that is now redundant.

In MW 1.29, the json module was replaced with a deprecated dummy, given MW's
JS feature test now confirms native support in browsers. The dummy will be
removed in MW 1.32.

Fixes #3177.
