### PR TITLE
Add PHPUnitCompat trait, support PHPUnit 6.5+, refs 2713

### DIFF
--- a/src/MediaWiki/TitleCreator.php
+++ b/src/MediaWiki/TitleCreator.php
@@ -19,7 +19,12 @@ class TitleCreator {
 	 *
 	 * @return Title|null
 	 */
-	public function createFromText( $text, $namespace = NS_MAIN ) {
+	public function createFromText( $text, $namespace = null ) {
+
+		if ( $namespace === null ) {
+			$namespace = NS_MAIN;
+		}
+
 		return Title::newFromText( $text, $namespace );
 	}
 

--- a/tests/autoloader.php
+++ b/tests/autoloader.php
@@ -58,6 +58,7 @@ $autoloader->addPsr4( 'SMW\\Tests\\Utils\\', __DIR__ . '/phpunit/Utils' );
 $autoloader->addClassMap( array(
 	'SMW\Tests\TestEnvironment'             => __DIR__ . '/phpunit/TestEnvironment.php',
 	'SMW\Tests\TestConfig'                  => __DIR__ . '/phpunit/TestConfig.php',
+	'SMW\Tests\PHPUnitCompat'               => __DIR__ . '/phpunit/PHPUnitCompat.php',
 	'SMW\Tests\MwDBaseUnitTestCase'         => __DIR__ . '/phpunit/MwDBaseUnitTestCase.php',
 	'SMW\Tests\JsonTestCaseScriptRunner'    => __DIR__ . '/phpunit/JsonTestCaseScriptRunner.php',
 	'SMW\Tests\JsonTestCaseFileHandler'     => __DIR__ . '/phpunit/JsonTestCaseFileHandler.php',

--- a/tests/phpunit/ExecutionTimeTestListener.php
+++ b/tests/phpunit/ExecutionTimeTestListener.php
@@ -7,6 +7,7 @@ use PHPUnit_Framework_AssertionFailedError;
 use PHPUnit_Framework_Test;
 use PHPUnit_Framework_TestListener;
 use PHPUnit_Framework_TestSuite;
+use PHPUnit_Framework_Warning;
 
 class ExecutionTimeTestListener implements PHPUnit_Framework_TestListener {
 
@@ -38,6 +39,13 @@ class ExecutionTimeTestListener implements PHPUnit_Framework_TestListener {
 	 * @see PHPUnit_Framework_TestListener::addError
 	 */
 	public function addError( PHPUnit_Framework_Test $test, Exception $e, $time ) {
+	}
+
+	/**
+	 * @see PHPUnit_Framework_TestListener::addError
+	 */
+	public function addWarning( PHPUnit_Framework_Test $test, PHPUnit_Framework_Warning $e, $time) {
+
 	}
 
 	/**

--- a/tests/phpunit/Integration/MediaWiki/RedirectTargetFinderIntegrationTest.php
+++ b/tests/phpunit/Integration/MediaWiki/RedirectTargetFinderIntegrationTest.php
@@ -7,6 +7,7 @@ use SMW\DIProperty;
 use SMW\DIWikiPage;
 use SMW\Tests\MwDBaseUnitTestCase;
 use SMW\Tests\Utils\UtilityFactory;
+use SMW\Tests\PHPUnitCompat;
 use Title;
 
 /**
@@ -21,6 +22,8 @@ use Title;
  * @author mwjames
  */
 class RedirectTargetFinderIntegrationTest extends MwDBaseUnitTestCase {
+
+	use PHPUnitCompat;
 
 	private $deletePoolOfPages = array();
 

--- a/tests/phpunit/Integration/Query/QuerySourceIntegrationTest.php
+++ b/tests/phpunit/Integration/Query/QuerySourceIntegrationTest.php
@@ -3,6 +3,7 @@
 namespace SMW\Tests\Integration\Query;
 
 use SMW\Tests\TestEnvironment;
+use SMW\Tests\PHPUnitCompat;
 use SMWQueryProcessor;
 
 /**
@@ -15,6 +16,8 @@ use SMWQueryProcessor;
  * @author mwjames
  */
 class QuerySourceIntegrationTest extends \PHPUnit_Framework_TestCase {
+
+	use PHPUnitCompat;
 
 	private $testEnvironment;
 	private $store;

--- a/tests/phpunit/PHPUnitCompat.php
+++ b/tests/phpunit/PHPUnitCompat.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace SMW\Tests;
+
+/**
+ * @license GNU GPL v2+
+ * @since 3.0
+ *
+ * @author mwjames
+ */
+trait PHPUnitCompat {
+
+	/**
+	 * @see PHPUnit_Framework_TestCase::setExpectedException
+	 */
+	public function setExpectedException( $name, $message = '', $code = null ) {
+		if ( is_callable( [ $this, 'expectException' ] ) ) {
+			if ( $name !== null ) {
+				$this->expectException( $name );
+			}
+			if ( $message !== '' ) {
+				$this->expectExceptionMessage( $message );
+			}
+			if ( $code !== null ) {
+				$this->expectExceptionCode( $code );
+			}
+		} else {
+			parent::setExpectedException( $name, $message, $code );
+		}
+	}
+}

--- a/tests/phpunit/Unit/CacheFactoryTest.php
+++ b/tests/phpunit/Unit/CacheFactoryTest.php
@@ -17,6 +17,8 @@ use SMW\CacheFactory;
  */
 class CacheFactoryTest extends \PHPUnit_Framework_TestCase {
 
+	use PHPUnitCompat;
+
 	public function testCanConstruct() {
 
 		$this->assertInstanceOf(

--- a/tests/phpunit/Unit/Connection/ConnectionManagerTest.php
+++ b/tests/phpunit/Unit/Connection/ConnectionManagerTest.php
@@ -3,6 +3,7 @@
 namespace SMW\Tests\Connection;
 
 use SMW\Connection\ConnectionManager;
+use SMW\Tests\PHPUnitCompat;
 
 /**
  * @covers \SMW\Connection\ConnectionManager
@@ -14,6 +15,8 @@ use SMW\Connection\ConnectionManager;
  * @author mwjames
  */
 class ConnectionManagerTest extends \PHPUnit_Framework_TestCase {
+
+	use PHPUnitCompat;
 
 	public function testCanConstruct() {
 

--- a/tests/phpunit/Unit/Connection/ConnectionProviderRefTest.php
+++ b/tests/phpunit/Unit/Connection/ConnectionProviderRefTest.php
@@ -3,6 +3,7 @@
 namespace SMW\Tests\Connection;
 
 use SMW\Connection\ConnectionProviderRef;
+use SMW\Tests\PHPUnitCompat;
 
 /**
  * @covers \SMW\Connection\ConnectionProviderRef
@@ -14,6 +15,8 @@ use SMW\Connection\ConnectionProviderRef;
  * @author mwjames
  */
 class ConnectionProviderRefTest extends \PHPUnit_Framework_TestCase {
+
+	use PHPUnitCompat;
 
 	public function testCanConstruct() {
 

--- a/tests/phpunit/Unit/DataModel/ContainerSemanticDataTest.php
+++ b/tests/phpunit/Unit/DataModel/ContainerSemanticDataTest.php
@@ -5,6 +5,7 @@ namespace SMW\Tests\DataModel;
 use SMW\DataItemFactory;
 use SMW\DataModel\ContainerSemanticData;
 use SMW\SemanticData;
+use SMW\Tests\PHPUnitCompat;
 
 /**
  * @covers \SMW\DataModel\ContainerSemanticData
@@ -16,6 +17,8 @@ use SMW\SemanticData;
  * @author mwjames
  */
 class ContainerSemanticDataTest extends \PHPUnit_Framework_TestCase {
+
+	use PHPUnitCompat;
 
 	private $dataItemFactory;
 

--- a/tests/phpunit/Unit/DataModel/SubSemanticDataTest.php
+++ b/tests/phpunit/Unit/DataModel/SubSemanticDataTest.php
@@ -5,6 +5,7 @@ namespace SMW\Tests\DataModel;
 use SMW\DataItemFactory;
 use SMW\DataModel\ContainerSemanticData;
 use SMW\DataModel\SubSemanticData;
+use SMW\Tests\PHPUnitCompat;
 
 /**
  * @covers \SMW\DataModel\SubSemanticData
@@ -16,6 +17,8 @@ use SMW\DataModel\SubSemanticData;
  * @author mwjames
  */
 class SubSemanticDataTest extends \PHPUnit_Framework_TestCase {
+
+	use PHPUnitCompat;
 
 	private $dataItemFactory;
 

--- a/tests/phpunit/Unit/DataValues/Number/IntlNumberFormatterTest.php
+++ b/tests/phpunit/Unit/DataValues/Number/IntlNumberFormatterTest.php
@@ -4,6 +4,7 @@ namespace SMW\Tests\DataValues\Number;
 
 use Language;
 use SMW\DataValues\Number\IntlNumberFormatter;
+use SMW\Tests\PHPUnitCompat;
 
 /**
  * @covers \SMW\DataValues\Number\IntlNumberFormatter
@@ -15,6 +16,8 @@ use SMW\DataValues\Number\IntlNumberFormatter;
  * @author mwjames
  */
 class IntlNumberFormatterTest extends \PHPUnit_Framework_TestCase {
+
+	use PHPUnitCompat;
 
 	public function testCanConstruct() {
 

--- a/tests/phpunit/Unit/DataValues/ValueFormatters/DispatchingDataValueFormatterTest.php
+++ b/tests/phpunit/Unit/DataValues/ValueFormatters/DispatchingDataValueFormatterTest.php
@@ -3,6 +3,7 @@
 namespace SMW\Tests\DataValues\ValueFormatters;
 
 use SMW\DataValues\ValueFormatters\DispatchingDataValueFormatter;
+use SMW\Tests\PHPUnitCompat;
 
 /**
  * @covers \SMW\DataValues\ValueFormatters\DispatchingDataValueFormatter
@@ -14,6 +15,8 @@ use SMW\DataValues\ValueFormatters\DispatchingDataValueFormatter;
  * @author mwjames
  */
 class DispatchingDataValueFormatterTest extends \PHPUnit_Framework_TestCase {
+
+	use PHPUnitCompat;
 
 	public function testCanConstruct() {
 

--- a/tests/phpunit/Unit/DataValues/ValueFormatters/MonolingualTextValueFormatterTest.php
+++ b/tests/phpunit/Unit/DataValues/ValueFormatters/MonolingualTextValueFormatterTest.php
@@ -5,6 +5,7 @@ namespace SMW\Tests\DataValues\ValueFormatters;
 use SMW\DataValues\MonolingualTextValue;
 use SMW\DataValues\ValueFormatters\MonolingualTextValueFormatter;
 use SMW\DataValues\ValueParsers\MonolingualTextValueParser;
+use SMW\Tests\PHPUnitCompat;
 
 /**
  * @covers \SMW\DataValues\ValueFormatters\MonolingualTextValueFormatter
@@ -16,6 +17,8 @@ use SMW\DataValues\ValueParsers\MonolingualTextValueParser;
  * @author mwjames
  */
 class MonolingualTextValueFormatterTest extends \PHPUnit_Framework_TestCase {
+
+	use PHPUnitCompat;
 
 	private $dataValueServiceFactory;
 

--- a/tests/phpunit/Unit/DataValues/ValueFormatters/NoValueFormatterTest.php
+++ b/tests/phpunit/Unit/DataValues/ValueFormatters/NoValueFormatterTest.php
@@ -3,6 +3,7 @@
 namespace SMW\Tests\DataValues\ValueFormatters;
 
 use SMW\DataValues\ValueFormatters\NoValueFormatter;
+use SMW\Tests\PHPUnitCompat;
 
 /**
  * @covers \SMW\DataValues\ValueFormatters\NoValueFormatter
@@ -14,6 +15,8 @@ use SMW\DataValues\ValueFormatters\NoValueFormatter;
  * @author mwjames
  */
 class NoValueFormatterTest extends \PHPUnit_Framework_TestCase {
+
+	use PHPUnitCompat;
 
 	public function testCanConstruct() {
 

--- a/tests/phpunit/Unit/DataValues/ValueFormatters/NumberValueFormatterTest.php
+++ b/tests/phpunit/Unit/DataValues/ValueFormatters/NumberValueFormatterTest.php
@@ -5,6 +5,7 @@ namespace SMW\Tests\DataValues\ValueFormatters;
 use SMW\DataValues\TemperatureValue;
 use SMW\DataValues\ValueFormatters\NumberValueFormatter;
 use SMWNumberValue as NumberValue;
+use SMW\Tests\PHPUnitCompat;
 
 /**
  * @covers \SMW\DataValues\ValueFormatters\NumberValueFormatter
@@ -16,6 +17,8 @@ use SMWNumberValue as NumberValue;
  * @author mwjames
  */
 class NumberValueFormatterTest extends \PHPUnit_Framework_TestCase {
+
+	use PHPUnitCompat;
 
 	public function testCanConstruct() {
 

--- a/tests/phpunit/Unit/DataValues/ValueFormatters/PropertyValueFormatterTest.php
+++ b/tests/phpunit/Unit/DataValues/ValueFormatters/PropertyValueFormatterTest.php
@@ -6,6 +6,7 @@ use SMW\DataItemFactory;
 use SMW\DataValues\ValueFormatters\PropertyValueFormatter;
 use SMW\DataValues\ValueParsers\PropertyValueParser;
 use SMW\Tests\TestEnvironment;
+use SMW\Tests\PHPUnitCompat;
 use SMWPropertyValue as PropertyValue;
 
 /**
@@ -18,6 +19,8 @@ use SMWPropertyValue as PropertyValue;
  * @author mwjames
  */
 class PropertyValueFormatterTest extends \PHPUnit_Framework_TestCase {
+
+	use PHPUnitCompat;
 
 	private $dataItemFactory;
 	private $propertyLabelFinder;

--- a/tests/phpunit/Unit/DataValues/ValueFormatters/ReferenceValueFormatterTest.php
+++ b/tests/phpunit/Unit/DataValues/ValueFormatters/ReferenceValueFormatterTest.php
@@ -6,6 +6,7 @@ use SMW\DataItemFactory;
 use SMW\DataValues\ReferenceValue;
 use SMW\DataValues\ValueFormatters\ReferenceValueFormatter;
 use SMW\Tests\TestEnvironment;
+use SMW\Tests\PHPUnitCompat;
 
 /**
  * @covers \SMW\DataValues\ValueFormatters\ReferenceValueFormatter
@@ -17,6 +18,8 @@ use SMW\Tests\TestEnvironment;
  * @author mwjames
  */
 class ReferenceValueFormatterTest extends \PHPUnit_Framework_TestCase {
+
+	use PHPUnitCompat;
 
 	private $testEnvironment;
 	private $dataItemFactory;

--- a/tests/phpunit/Unit/DataValues/ValueFormatters/StringValueFormatterTest.php
+++ b/tests/phpunit/Unit/DataValues/ValueFormatters/StringValueFormatterTest.php
@@ -4,6 +4,7 @@ namespace SMW\Tests\DataValues\ValueFormatters;
 
 use SMW\DataValues\StringValue;
 use SMW\DataValues\ValueFormatters\StringValueFormatter;
+use SMW\Tests\PHPUnitCompat;
 
 /**
  * @covers \SMW\DataValues\ValueFormatters\StringValueFormatter
@@ -15,6 +16,8 @@ use SMW\DataValues\ValueFormatters\StringValueFormatter;
  * @author mwjames
  */
 class StringValueFormatterTest extends \PHPUnit_Framework_TestCase {
+
+	use PHPUnitCompat;
 
 	public function testCanConstruct() {
 

--- a/tests/phpunit/Unit/DataValues/ValueFormatters/TimeValueFormatterTest.php
+++ b/tests/phpunit/Unit/DataValues/ValueFormatters/TimeValueFormatterTest.php
@@ -5,6 +5,7 @@ namespace SMW\Tests\DataValues\ValueFormatters;
 use SMW\DataValues\ValueFormatters\TimeValueFormatter;
 use SMW\DataValues\ValueParsers\TimeValueParser;
 use SMWTimeValue as TimeValue;
+use SMW\Tests\PHPUnitCompat;
 
 /**
  * @covers \SMW\DataValues\ValueFormatters\TimeValueFormatter
@@ -16,6 +17,8 @@ use SMWTimeValue as TimeValue;
  * @author mwjames
  */
 class TimeValueFormatterTest extends \PHPUnit_Framework_TestCase {
+
+	use PHPUnitCompat;
 
 	private $dataValueServiceFactory;
 

--- a/tests/phpunit/Unit/DataValues/ValueValidators/CompoundConstraintValueValidatorTest.php
+++ b/tests/phpunit/Unit/DataValues/ValueValidators/CompoundConstraintValueValidatorTest.php
@@ -3,6 +3,7 @@
 namespace SMW\Tests\DataValues\ValueValidators;
 
 use SMW\DataValues\ValueValidators\CompoundConstraintValueValidator;
+use SMW\Tests\PHPUnitCompat;
 
 /**
  * @covers \SMW\DataValues\ValueValidators\CompoundConstraintValueValidator
@@ -14,6 +15,8 @@ use SMW\DataValues\ValueValidators\CompoundConstraintValueValidator;
  * @author mwjames
  */
 class CompoundConstraintValueValidatorTest extends \PHPUnit_Framework_TestCase {
+
+	use PHPUnitCompat;
 
 	public function testCanConstruct() {
 

--- a/tests/phpunit/Unit/Deserializers/DVDescriptionDeserializer/DispatchingDescriptionDeserializerTest.php
+++ b/tests/phpunit/Unit/Deserializers/DVDescriptionDeserializer/DispatchingDescriptionDeserializerTest.php
@@ -3,6 +3,7 @@
 namespace SMW\Tests\Deserializers\DVDescriptionDeserializer;
 
 use SMW\Deserializers\DVDescriptionDeserializer\DispatchingDescriptionDeserializer;
+use SMW\Tests\PHPUnitCompat;
 
 /**
  * @covers \SMW\Deserializers\DVDescriptionDeserializer\DispatchingDescriptionDeserializer
@@ -14,6 +15,8 @@ use SMW\Deserializers\DVDescriptionDeserializer\DispatchingDescriptionDeserializ
  * @author mwjames
  */
 class DispatchingDescriptionDeserializerTest extends \PHPUnit_Framework_TestCase {
+
+	use PHPUnitCompat;
 
 	public function testCanConstruct() {
 

--- a/tests/phpunit/Unit/Deserializers/DVDescriptionDeserializer/MonolingualTextValueDescriptionDeserializerTest.php
+++ b/tests/phpunit/Unit/Deserializers/DVDescriptionDeserializer/MonolingualTextValueDescriptionDeserializerTest.php
@@ -5,6 +5,7 @@ namespace SMW\Tests\Deserializers\DVDescriptionDeserializer;
 use SMW\DataValueFactory;
 use SMW\DataValues\MonolingualTextValue;
 use SMW\Deserializers\DVDescriptionDeserializer\MonolingualTextValueDescriptionDeserializer;
+use SMW\Tests\PHPUnitCompat;
 
 /**
  * @covers \SMW\Deserializers\DVDescriptionDeserializer\MonolingualTextValueDescriptionDeserializer
@@ -16,6 +17,8 @@ use SMW\Deserializers\DVDescriptionDeserializer\MonolingualTextValueDescriptionD
  * @author mwjames
  */
 class MonolingualTextValueDescriptionDeserializerTest extends \PHPUnit_Framework_TestCase {
+
+	use PHPUnitCompat;
 
 	public function testCanConstruct() {
 

--- a/tests/phpunit/Unit/Deserializers/DVDescriptionDeserializer/RecordValueDescriptionDeserializerTest.php
+++ b/tests/phpunit/Unit/Deserializers/DVDescriptionDeserializer/RecordValueDescriptionDeserializerTest.php
@@ -4,6 +4,7 @@ namespace SMW\Tests\Deserializers\DVDescriptionDeserializer;
 
 use SMW\Deserializers\DVDescriptionDeserializer\RecordValueDescriptionDeserializer;
 use SMW\DIProperty;
+use SMW\Tests\PHPUnitCompat;
 
 /**
  * @covers \SMW\Deserializers\DVDescriptionDeserializer\RecordValueDescriptionDeserializer
@@ -15,6 +16,8 @@ use SMW\DIProperty;
  * @author mwjames
  */
 class RecordValueDescriptionDeserializerTest extends \PHPUnit_Framework_TestCase {
+
+	use PHPUnitCompat;
 
 	public function testCanConstruct() {
 

--- a/tests/phpunit/Unit/Deserializers/DVDescriptionDeserializer/SomeValueDescriptionDeserializerTest.php
+++ b/tests/phpunit/Unit/Deserializers/DVDescriptionDeserializer/SomeValueDescriptionDeserializerTest.php
@@ -4,6 +4,7 @@ namespace SMW\Tests\Deserializers\DVDescriptionDeserializer;
 
 use SMW\ApplicationFactory;
 use SMW\Deserializers\DVDescriptionDeserializer\SomeValueDescriptionDeserializer;
+use SMW\Tests\PHPUnitCompat;
 
 /**
  * @covers \SMW\Deserializers\DVDescriptionDeserializer\SomeValueDescriptionDeserializer
@@ -15,6 +16,8 @@ use SMW\Deserializers\DVDescriptionDeserializer\SomeValueDescriptionDeserializer
  * @author mwjames
  */
 class SomeValueDescriptionDeserializerTest extends \PHPUnit_Framework_TestCase {
+
+	use PHPUnitCompat;
 
 	private $dataItemFactory;
 

--- a/tests/phpunit/Unit/Deserializers/DVDescriptionDeserializer/TimeValueDescriptionDeserializerTest.php
+++ b/tests/phpunit/Unit/Deserializers/DVDescriptionDeserializer/TimeValueDescriptionDeserializerTest.php
@@ -3,6 +3,7 @@
 namespace SMW\Tests\Deserializers\DVDescriptionDeserializer;
 
 use SMW\Deserializers\DVDescriptionDeserializer\TimeValueDescriptionDeserializer;
+use SMW\Tests\PHPUnitCompat;
 
 /**
  * @covers \SMW\Deserializers\DVDescriptionDeserializer\TimeValueDescriptionDeserializer
@@ -14,6 +15,8 @@ use SMW\Deserializers\DVDescriptionDeserializer\TimeValueDescriptionDeserializer
  * @author mwjames
  */
 class TimeValueDescriptionDeserializerTest extends \PHPUnit_Framework_TestCase {
+
+	use PHPUnitCompat;
 
 	public function testCanConstruct() {
 

--- a/tests/phpunit/Unit/Deserializers/ExpDataDeserializerTest.php
+++ b/tests/phpunit/Unit/Deserializers/ExpDataDeserializerTest.php
@@ -8,6 +8,7 @@ use SMW\Exporter\Element\ExpNsResource;
 use SMW\Serializers\ExpDataSerializer;
 use SMWDIBlob as DIBlob;
 use SMWExpData as ExpData;
+use SMW\Tests\PHPUnitCompat;
 
 /**
  * @covers \SMW\Deserializers\ExpDataDeserializer
@@ -19,6 +20,8 @@ use SMWExpData as ExpData;
  * @author mwjames
  */
 class ExpDataDeserializerTest extends \PHPUnit_Framework_TestCase {
+
+	use PHPUnitCompat;
 
 	public function testCanConstructor() {
 

--- a/tests/phpunit/Unit/Deserializers/SemanticDataDeserializerTest.php
+++ b/tests/phpunit/Unit/Deserializers/SemanticDataDeserializerTest.php
@@ -3,6 +3,7 @@
 namespace SMW\Tests\Deserializers;
 
 use SMW\Deserializers\SemanticDataDeserializer;
+use SMW\Tests\PHPUnitCompat;
 
 /**
  * @covers \SMW\Deserializers\SemanticDataDeserializer
@@ -14,6 +15,8 @@ use SMW\Deserializers\SemanticDataDeserializer;
  * @author mwjames
  */
 class SemanticDataDeserializerTest extends \PHPUnit_Framework_TestCase {
+
+	use PHPUnitCompat;
 
 	public function testCanConstructor() {
 

--- a/tests/phpunit/Unit/Elastic/Connection/ClientTest.php
+++ b/tests/phpunit/Unit/Elastic/Connection/ClientTest.php
@@ -4,6 +4,7 @@ namespace SMW\Tests\Elastic\Connection;
 
 use SMW\Elastic\Connection\Client;
 use SMW\Options;
+use SMW\Tests\PHPUnitCompat;
 
 /**
  * @covers \SMW\Elastic\Connection\Client
@@ -15,6 +16,8 @@ use SMW\Options;
  * @author mwjames
  */
 class ClientTest extends \PHPUnit_Framework_TestCase {
+
+	use PHPUnitCompat;
 
 	private $elasticClient;
 	private $cache;

--- a/tests/phpunit/Unit/Exporter/Element/ExpLiteralTest.php
+++ b/tests/phpunit/Unit/Exporter/Element/ExpLiteralTest.php
@@ -6,6 +6,7 @@ use SMW\DIWikiPage;
 use SMW\Exporter\Element\ExpElement;
 use SMW\Exporter\Element\ExpLiteral;
 use SMWDataItem as DataItem;
+use SMW\Tests\PHPUnitCompat;
 
 /**
  * @covers \SMW\Exporter\Element\ExpLiteral
@@ -17,6 +18,8 @@ use SMWDataItem as DataItem;
  * @author mwjames
  */
 class ExpLiteralTest extends \PHPUnit_Framework_TestCase {
+
+	use PHPUnitCompat;
 
 	public function testCanConstruct() {
 

--- a/tests/phpunit/Unit/Exporter/Element/ExpNsResourceTest.php
+++ b/tests/phpunit/Unit/Exporter/Element/ExpNsResourceTest.php
@@ -6,6 +6,7 @@ use SMW\DIWikiPage;
 use SMW\Exporter\Element\ExpElement;
 use SMW\Exporter\Element\ExpNsResource;
 use SMWDataItem as DataItem;
+use SMW\Tests\PHPUnitCompat;
 
 /**
  * @covers \SMW\Exporter\Element\ExpNsResource
@@ -17,6 +18,8 @@ use SMWDataItem as DataItem;
  * @author mwjames
  */
 class ExpNsResourceTest extends \PHPUnit_Framework_TestCase {
+
+	use PHPUnitCompat;
 
 	public function testCanConstruct() {
 

--- a/tests/phpunit/Unit/Exporter/Element/ExpResourceTest.php
+++ b/tests/phpunit/Unit/Exporter/Element/ExpResourceTest.php
@@ -6,6 +6,7 @@ use SMW\DIWikiPage;
 use SMW\Exporter\Element\ExpElement;
 use SMW\Exporter\Element\ExpResource;
 use SMWDataItem as DataItem;
+use SMW\Tests\PHPUnitCompat;
 
 /**
  * @covers \SMW\Exporter\Element\ExpResource
@@ -17,6 +18,8 @@ use SMWDataItem as DataItem;
  * @author mwjames
  */
 class ExpResourceTest extends \PHPUnit_Framework_TestCase {
+
+	use PHPUnitCompat;
 
 	public function testCanConstruct() {
 

--- a/tests/phpunit/Unit/Exporter/ElementFactoryTest.php
+++ b/tests/phpunit/Unit/Exporter/ElementFactoryTest.php
@@ -4,6 +4,7 @@ namespace SMW\Tests\Exporter;
 
 use SMW\DataItemFactory;
 use SMW\Exporter\ElementFactory;
+use SMW\Tests\PHPUnitCompat;
 
 /**
  * @covers \SMW\Exporter\ElementFactory
@@ -15,6 +16,8 @@ use SMW\Exporter\ElementFactory;
  * @author mwjames
  */
 class ElementFactoryTest extends \PHPUnit_Framework_TestCase {
+
+	use PHPUnitCompat;
 
 	/**
 	 * @dataProvider supportedDataItemProvider

--- a/tests/phpunit/Unit/Exporter/XsdValueMapperTest.php
+++ b/tests/phpunit/Unit/Exporter/XsdValueMapperTest.php
@@ -5,6 +5,7 @@ namespace SMW\Tests\Exporter;
 use SMW\DIProperty;
 use SMW\DIWikiPage;
 use SMW\Exporter\XsdValueMapper;
+use SMW\Tests\PHPUnitCompat;
 
 /**
  * @covers \SMW\Exporter\XsdValueMapper
@@ -16,6 +17,8 @@ use SMW\Exporter\XsdValueMapper;
  * @author mwjames
  */
 class XsdValueMapperTest extends \PHPUnit_Framework_TestCase {
+
+	use PHPUnitCompat;
 
 	/**
 	 * @dataProvider supportedDataItemProvider

--- a/tests/phpunit/Unit/HierarchyLookupTest.php
+++ b/tests/phpunit/Unit/HierarchyLookupTest.php
@@ -17,6 +17,8 @@ use SMW\HierarchyLookup;
  */
 class HierarchyLookupTest extends \PHPUnit_Framework_TestCase {
 
+	use PHPUnitCompat;
+
 	private $store;
 	private $cache;
 	private $spyLogger;

--- a/tests/phpunit/Unit/Importer/ContentCreators/DispatchingContentCreatorTest.php
+++ b/tests/phpunit/Unit/Importer/ContentCreators/DispatchingContentCreatorTest.php
@@ -1,9 +1,10 @@
 <?php
 
-namespace SMW\TestsImporter\ContentCreators;
+namespace SMW\Tests\Importer\ContentCreators;
 
 use SMW\Importer\ContentCreators\DispatchingContentCreator;
 use SMW\Importer\ImportContents;
+use SMW\Tests\PHPUnitCompat;
 
 /**
  * @covers \SMW\Importer\ContentCreators\DispatchingContentCreator
@@ -15,6 +16,8 @@ use SMW\Importer\ImportContents;
  * @author mwjames
  */
 class DispatchingContentCreatorTest extends \PHPUnit_Framework_TestCase {
+
+	use PHPUnitCompat;
 
 	private $wikiImporter;
 	private $messageReporter;

--- a/tests/phpunit/Unit/Importer/ContentCreators/TextContentCreatorTest.php
+++ b/tests/phpunit/Unit/Importer/ContentCreators/TextContentCreatorTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace SMW\TestsImporter\ContentCreators;
+namespace SMW\Tests\Importer\ContentCreators;
 
 use SMW\Importer\ContentCreators\TextContentCreator;
 use SMW\Importer\ImportContents;

--- a/tests/phpunit/Unit/Importer/ContentModellerTest.php
+++ b/tests/phpunit/Unit/Importer/ContentModellerTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace SMW\TestsImporter;
+namespace SMW\Tests\Importer;
 
 use SMW\Importer\ContentModeller;
 use SMW\Tests\TestEnvironment;

--- a/tests/phpunit/Unit/Importer/ImportContentsTest.php
+++ b/tests/phpunit/Unit/Importer/ImportContentsTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace SMW\TestsImporter;
+namespace SMW\Tests\Importer;
 
 use SMW\Importer\ImportContents;
 

--- a/tests/phpunit/Unit/Importer/ImporterTest.php
+++ b/tests/phpunit/Unit/Importer/ImporterTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace SMW\TestsImporter;
+namespace SMW\Tests\Importer;
 
 use SMW\Importer\ContentIterator;
 use SMW\Importer\ImportContents;

--- a/tests/phpunit/Unit/Importer/JsonContentIteratorTest.php
+++ b/tests/phpunit/Unit/Importer/JsonContentIteratorTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace SMW\TestsImporter;
+namespace SMW\Tests\Importer;
 
 use SMW\Importer\JsonContentIterator;
 use SMW\Importer\JsonImportContentsFileDirReader;

--- a/tests/phpunit/Unit/Importer/JsonImportContentsFileDirReaderTest.php
+++ b/tests/phpunit/Unit/Importer/JsonImportContentsFileDirReaderTest.php
@@ -1,10 +1,11 @@
 <?php
 
-namespace SMW\TestsImporter;
+namespace SMW\Tests\Importer;
 
 use SMW\Importer\ContentModeller;
 use SMW\Importer\JsonImportContentsFileDirReader;
 use SMW\Tests\TestEnvironment;
+use SMW\Tests\PHPUnitCompat;
 
 /**
  * @covers \SMW\Importer\JsonImportContentsFileDirReader
@@ -16,6 +17,8 @@ use SMW\Tests\TestEnvironment;
  * @author mwjames
  */
 class JsonImportContentsFileDirReaderTest extends \PHPUnit_Framework_TestCase {
+
+	use PHPUnitCompat;
 
 	private $contentModeller;
 	private $testEnvironment;

--- a/tests/phpunit/Unit/IteratorFactoryTest.php
+++ b/tests/phpunit/Unit/IteratorFactoryTest.php
@@ -15,6 +15,8 @@ use SMW\IteratorFactory;
  */
 class IteratorFactoryTest extends \PHPUnit_Framework_TestCase {
 
+	use PHPUnitCompat;
+
 	public function testCanConstructResultIterator() {
 
 		$instance = new IteratorFactory();

--- a/tests/phpunit/Unit/Iterators/AppendIteratorTest.php
+++ b/tests/phpunit/Unit/Iterators/AppendIteratorTest.php
@@ -1,8 +1,9 @@
 <?php
 
-namespace SMW\Iterators\Tests;
+namespace SMW\Tests\Iterators;
 
 use SMW\Iterators\AppendIterator;
+use SMW\Tests\PHPUnitCompat;
 
 /**
  * @covers \SMW\Iterators\AppendIterator
@@ -14,6 +15,8 @@ use SMW\Iterators\AppendIterator;
  * @author mwjames
  */
 class AppendIteratorTest extends \PHPUnit_Framework_TestCase {
+
+	use PHPUnitCompat;
 
 	public function testCanConstruct() {
 

--- a/tests/phpunit/Unit/Iterators/ChunkedIteratorTest.php
+++ b/tests/phpunit/Unit/Iterators/ChunkedIteratorTest.php
@@ -1,8 +1,9 @@
 <?php
 
-namespace SMW\Iterators\Tests;
+namespace SMW\Tests\Iterators;
 
 use SMW\Iterators\ChunkedIterator;
+use SMW\Tests\PHPUnitCompat;
 
 /**
  * @covers \SMW\Iterators\ChunkedIterator
@@ -14,6 +15,8 @@ use SMW\Iterators\ChunkedIterator;
  * @author mwjames
  */
 class ChunkedIteratorTest extends \PHPUnit_Framework_TestCase {
+
+	use PHPUnitCompat;
 
 	public function testCanConstruct() {
 

--- a/tests/phpunit/Unit/Iterators/CsvFileIteratorTest.php
+++ b/tests/phpunit/Unit/Iterators/CsvFileIteratorTest.php
@@ -1,9 +1,10 @@
 <?php
 
-namespace SMW\Iterators\Tests;
+namespace SMW\Tests\Iterators;
 
 use SMW\Iterators\CsvFileIterator;
 use SMW\Utils\TempFile;
+use SMW\Tests\PHPUnitCompat;
 
 /**
  * @covers \SMW\Iterators\CsvFileIterator
@@ -15,6 +16,8 @@ use SMW\Utils\TempFile;
  * @author mwjames
  */
 class CsvFileIteratorTest extends \PHPUnit_Framework_TestCase {
+
+	use PHPUnitCompat;
 
 	private $file;
 	private $tempFile;

--- a/tests/phpunit/Unit/Iterators/MappingIteratorTest.php
+++ b/tests/phpunit/Unit/Iterators/MappingIteratorTest.php
@@ -1,9 +1,10 @@
 <?php
 
-namespace SMW\Iterators\Tests;
+namespace SMW\Tests\Iterators;
 
 use ArrayIterator;
 use SMW\Iterators\MappingIterator;
+use SMW\Tests\PHPUnitCompat;
 
 /**
  * @covers \SMW\Iterators\MappingIterator
@@ -15,6 +16,8 @@ use SMW\Iterators\MappingIterator;
  * @author mwjames
  */
 class MappingIteratorTest extends \PHPUnit_Framework_TestCase {
+
+	use PHPUnitCompat;
 
 	public function testCanConstruct() {
 

--- a/tests/phpunit/Unit/Iterators/ResultIteratorTest.php
+++ b/tests/phpunit/Unit/Iterators/ResultIteratorTest.php
@@ -1,8 +1,9 @@
 <?php
 
-namespace SMW\Iterators\Tests;
+namespace SMW\Tests\Iterators;
 
 use SMW\Iterators\ResultIterator;
+use SMW\Tests\PHPUnitCompat;
 
 /**
  * @covers \SMW\Iterators\ResultIterator
@@ -14,6 +15,8 @@ use SMW\Iterators\ResultIterator;
  * @author mwjames
  */
 class ResultIteratorTest extends \PHPUnit_Framework_TestCase {
+
+	use PHPUnitCompat;
 
 	public function testCanConstruct() {
 

--- a/tests/phpunit/Unit/Lang/JsonContentsFileReaderTest.php
+++ b/tests/phpunit/Unit/Lang/JsonContentsFileReaderTest.php
@@ -3,6 +3,7 @@
 namespace SMW\Tests\Lang;
 
 use SMW\Lang\JsonContentsFileReader;
+use SMW\Tests\PHPUnitCompat;
 
 /**
  * @covers \SMW\Lang\JsonContentsFileReader
@@ -14,6 +15,8 @@ use SMW\Lang\JsonContentsFileReader;
  * @author mwjames
  */
 class JsonContentsFileReaderTest extends \PHPUnit_Framework_TestCase {
+
+	use PHPUnitCompat;
 
 	public function testCanConstruct() {
 

--- a/tests/phpunit/Unit/Lang/LanguageContentsTest.php
+++ b/tests/phpunit/Unit/Lang/LanguageContentsTest.php
@@ -5,6 +5,7 @@ namespace SMW\Tests\Lang;
 use SMW\Lang\FallbackFinder;
 use SMW\Lang\JsonContentsFileReader;
 use SMW\Lang\LanguageContents;
+use SMW\Tests\PHPUnitCompat;
 
 /**
  * @covers \SMW\Lang\LanguageContents
@@ -16,6 +17,8 @@ use SMW\Lang\LanguageContents;
  * @author mwjames
  */
 class LanguageContentsTest extends \PHPUnit_Framework_TestCase {
+
+	use PHPUnitCompat;
 
 	private $jsonContentsFileReader;
 	private $fallbackFinder;

--- a/tests/phpunit/Unit/Maintenance/DataRebuilderTest.php
+++ b/tests/phpunit/Unit/Maintenance/DataRebuilderTest.php
@@ -5,6 +5,7 @@ namespace SMW\Tests\Maintenance;
 use SMW\Maintenance\DataRebuilder;
 use SMW\Options;
 use Title;
+use SMW\Tests\PHPUnitCompat;
 
 /**
  * @covers \SMW\Maintenance\DataRebuilder
@@ -17,6 +18,8 @@ use Title;
  * @author mwjames
  */
 class DataRebuilderTest extends \PHPUnit_Framework_TestCase {
+
+	use PHPUnitCompat;
 
 	protected $obLevel;
 	private $connectionManager;

--- a/tests/phpunit/Unit/Maintenance/MaintenanceLoggerTest.php
+++ b/tests/phpunit/Unit/Maintenance/MaintenanceLoggerTest.php
@@ -3,6 +3,7 @@
 namespace SMW\Tests\Maintenance;
 
 use SMW\Maintenance\MaintenanceLogger;
+use SMW\Tests\PHPUnitCompat;
 
 /**
  * @covers \SMW\Maintenance\MaintenanceLogger
@@ -14,6 +15,8 @@ use SMW\Maintenance\MaintenanceLogger;
  * @author mwjames
  */
 class MaintenanceLoggerTest extends \PHPUnit_Framework_TestCase {
+
+	use PHPUnitCompat;
 
 	public function testCanConstruct() {
 

--- a/tests/phpunit/Unit/MediaWiki/Api/ApiQueryResultFormatterTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Api/ApiQueryResultFormatterTest.php
@@ -3,6 +3,7 @@
 namespace SMW\Tests\MediaWiki\Api;
 
 use SMW\MediaWiki\Api\ApiQueryResultFormatter;
+use SMW\Tests\PHPUnitCompat;
 
 /**
  * @covers \SMW\MediaWiki\Api\ApiQueryResultFormatter
@@ -14,6 +15,8 @@ use SMW\MediaWiki\Api\ApiQueryResultFormatter;
  * @author mwjames
  */
 class ApiQueryResultFormatterTest extends \PHPUnit_Framework_TestCase {
+
+	use PHPUnitCompat;
 
 	public function testCanConstruct() {
 

--- a/tests/phpunit/Unit/MediaWiki/Api/BrowseBySubjectTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Api/BrowseBySubjectTest.php
@@ -5,6 +5,7 @@ namespace SMW\Tests\MediaWiki\Api;
 use SMW\DIWikiPage;
 use SMW\MediaWiki\Api\BrowseBySubject;
 use SMW\Tests\TestEnvironment;
+use SMW\Tests\PHPUnitCompat;
 use Title;
 
 /**
@@ -17,6 +18,8 @@ use Title;
  * @author mwjames
  */
 class BrowseBySubjectTest extends \PHPUnit_Framework_TestCase {
+
+	use PHPUnitCompat;
 
 	private $apiFactory;
 	private $semanticDataFactory;

--- a/tests/phpunit/Unit/MediaWiki/DBConnectionProviderTest.php
+++ b/tests/phpunit/Unit/MediaWiki/DBConnectionProviderTest.php
@@ -4,6 +4,7 @@ namespace SMW\Tests\MediaWiki;
 
 use SMW\MediaWiki\DBConnectionProvider;
 use SMW\Tests\TestEnvironment;
+use SMW\Tests\PHPUnitCompat;
 
 /**
  * @covers \SMW\MediaWiki\DBConnectionProvider
@@ -15,6 +16,8 @@ use SMW\Tests\TestEnvironment;
  * @author mwjames
  */
 class DBConnectionProviderTest extends \PHPUnit_Framework_TestCase {
+
+	use PHPUnitCompat;
 
 	public function testCanConstruct() {
 		$this->assertInstanceOf(

--- a/tests/phpunit/Unit/MediaWiki/DBLoadBalancerConnectionProviderTest.php
+++ b/tests/phpunit/Unit/MediaWiki/DBLoadBalancerConnectionProviderTest.php
@@ -5,6 +5,7 @@ namespace SMW\Tests\MediaWiki;
 use DatabaseBase;
 use ReflectionClass;
 use SMW\MediaWiki\DBLoadBalancerConnectionProvider;
+use SMW\Tests\PHPUnitCompat;
 
 /**
  * @covers \SMW\MediaWiki\DBLoadBalancerConnectionProvider
@@ -16,6 +17,8 @@ use SMW\MediaWiki\DBLoadBalancerConnectionProvider;
  * @author mwjames
  */
 class DBLoadBalancerConnectionProviderTest extends \PHPUnit_Framework_TestCase {
+
+	use PHPUnitCompat;
 
 	public function testCanConstruct() {
 

--- a/tests/phpunit/Unit/MediaWiki/DatabaseTest.php
+++ b/tests/phpunit/Unit/MediaWiki/DatabaseTest.php
@@ -4,6 +4,7 @@ namespace SMW\Tests\MediaWiki;
 
 use SMW\Connection\ConnectionProviderRef;
 use SMW\MediaWiki\Database;
+use SMW\Tests\PHPUnitCompat;
 
 /**
  * @covers \SMW\MediaWiki\Database
@@ -15,6 +16,8 @@ use SMW\MediaWiki\Database;
  * @author mwjames
  */
 class DatabaseTest extends \PHPUnit_Framework_TestCase {
+
+	use PHPUnitCompat;
 
 	public function testCanConstruct() {
 

--- a/tests/phpunit/Unit/MediaWiki/DeepRedirectTargetResolverTest.php
+++ b/tests/phpunit/Unit/MediaWiki/DeepRedirectTargetResolverTest.php
@@ -4,6 +4,7 @@ namespace SMW\Tests\MediaWiki;
 
 use SMW\MediaWiki\DeepRedirectTargetResolver;
 use SMW\Tests\Utils\Mock\MockTitle;
+use SMW\Tests\PHPUnitCompat;
 
 /**
  * @covers \SMW\MediaWiki\DeepRedirectTargetResolver
@@ -15,6 +16,8 @@ use SMW\Tests\Utils\Mock\MockTitle;
  * @author mwjames
  */
 class DeepRedirectTargetResolverTest extends \PHPUnit_Framework_TestCase {
+
+	use PHPUnitCompat;
 
 	public function testCanConstruct() {
 

--- a/tests/phpunit/Unit/MediaWiki/Jobs/JobFactoryTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Jobs/JobFactoryTest.php
@@ -4,6 +4,7 @@ namespace SMW\Tests\MediaWiki\Jobs;
 
 use SMW\MediaWiki\Jobs\JobFactory;
 use Title;
+use SMW\Tests\PHPUnitCompat;
 
 /**
  * @covers \SMW\MediaWiki\Jobs\JobFactory
@@ -15,6 +16,8 @@ use Title;
  * @author mwjames
  */
 class JobFactoryTest extends \PHPUnit_Framework_TestCase {
+
+	use PHPUnitCompat;
 
 	public function testCanConstruct() {
 

--- a/tests/phpunit/Unit/MediaWiki/MessageBuilderTest.php
+++ b/tests/phpunit/Unit/MediaWiki/MessageBuilderTest.php
@@ -3,6 +3,7 @@
 namespace SMW\Tests\MediaWiki;
 
 use SMW\MediaWiki\MessageBuilder;
+use SMW\Tests\PHPUnitCompat;
 
 /**
  * @covers \SMW\MediaWiki\MessageBuilder
@@ -14,6 +15,8 @@ use SMW\MediaWiki\MessageBuilder;
  * @author mwjames
  */
 class MessageBuilderTest extends \PHPUnit_Framework_TestCase {
+
+	use PHPUnitCompat;
 
 	public function testCanConstruct() {
 

--- a/tests/phpunit/Unit/MediaWiki/Search/SearchTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Search/SearchTest.php
@@ -4,6 +4,7 @@ namespace SMW\Tests\MediaWiki\Search;
 
 use SMW\MediaWiki\Search\Search;
 use SMW\Tests\TestEnvironment;
+use SMW\Tests\PHPUnitCompat;
 use SMWQuery;
 
 /**
@@ -16,6 +17,8 @@ use SMWQuery;
  * @author Stephan Gambke
  */
 class SearchTest extends \PHPUnit_Framework_TestCase {
+
+	use PHPUnitCompat;
 
 	private $testEnvironment;
 

--- a/tests/phpunit/Unit/MediaWiki/Specials/SpecialAdminTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Specials/SpecialAdminTest.php
@@ -4,6 +4,7 @@ namespace SMW\Tests\MediaWiki\Specials;
 
 use SMW\MediaWiki\Specials\SpecialAdmin;
 use SMW\Tests\TestEnvironment;
+use SMW\Tests\PHPUnitCompat;
 use SMW\Tests\Utils\Mock\MockSuperUser;
 use Title;
 
@@ -17,6 +18,8 @@ use Title;
  * @author mwjames
  */
 class SpecialAdminTest extends \PHPUnit_Framework_TestCase {
+
+	use PHPUnitCompat;
 
 	private $testEnvironment;
 

--- a/tests/phpunit/Unit/MediaWiki/TitleLookupTest.php
+++ b/tests/phpunit/Unit/MediaWiki/TitleLookupTest.php
@@ -4,6 +4,7 @@ namespace SMW\Tests\MediaWiki;
 
 use SMW\MediaWiki\TitleLookup;
 use Title;
+use SMW\Tests\PHPUnitCompat;
 
 /**
  * @covers \SMW\MediaWiki\TitleLookup
@@ -15,6 +16,8 @@ use Title;
  * @author mwjames
  */
 class TitleLookupTest extends \PHPUnit_Framework_TestCase {
+
+	use PHPUnitCompat;
 
 	public function testCanConstruct() {
 

--- a/tests/phpunit/Unit/NamespaceExaminerTest.php
+++ b/tests/phpunit/Unit/NamespaceExaminerTest.php
@@ -15,6 +15,8 @@ use SMW\NamespaceExaminer;
  */
 class NamespaceExaminerTest extends \PHPUnit_Framework_TestCase {
 
+	use PHPUnitCompat;
+
 	public function testCanConstruct() {
 
 		$this->assertInstanceOf(

--- a/tests/phpunit/Unit/OptionsTest.php
+++ b/tests/phpunit/Unit/OptionsTest.php
@@ -15,6 +15,8 @@ use SMW\Options;
  */
 class OptionsTest extends \PHPUnit_Framework_TestCase {
 
+	use PHPUnitCompat;
+
 	public function testCanConstruct() {
 
 		$this->assertInstanceOf(

--- a/tests/phpunit/Unit/Page/PageFactoryTest.php
+++ b/tests/phpunit/Unit/Page/PageFactoryTest.php
@@ -3,6 +3,7 @@
 namespace SMW\Tests\Page;
 
 use SMW\Page\PageFactory;
+use SMW\Tests\PHPUnitCompat;
 
 /**
  * @covers \SMW\Page\PageFactory
@@ -14,6 +15,8 @@ use SMW\Page\PageFactory;
  * @author mwjames
  */
 class PageFactoryTest extends \PHPUnit_Framework_TestCase {
+
+	use PHPUnitCompat;
 
 	private $store;
 

--- a/tests/phpunit/Unit/Parser/RecursiveTextProcessorTest.php
+++ b/tests/phpunit/Unit/Parser/RecursiveTextProcessorTest.php
@@ -3,6 +3,7 @@
 namespace SMW\Tests\Parser;
 
 use SMW\Parser\RecursiveTextProcessor;
+use SMW\Tests\PHPUnitCompat;
 
 /**
  * @covers \SMW\Parser\RecursiveTextProcessor
@@ -14,6 +15,8 @@ use SMW\Parser\RecursiveTextProcessor;
  * @author mwjames
  */
 class RecursiveTextProcessorTest extends \PHPUnit_Framework_TestCase {
+
+	use PHPUnitCompat;
 
 	private $parser;
 	private $parserOptions;

--- a/tests/phpunit/Unit/ParserFunctions/SubobjectParserFunctionTest.php
+++ b/tests/phpunit/Unit/ParserFunctions/SubobjectParserFunctionTest.php
@@ -11,6 +11,7 @@ use SMW\ParserFunctions\SubobjectParserFunction;
 use SMW\ParserParameterFormatter;
 use SMW\Subobject;
 use SMW\Tests\Utils\UtilityFactory;
+use SMW\Tests\PHPUnitCompat;
 use Title;
 
 /**
@@ -23,6 +24,8 @@ use Title;
  * @author mwjames
  */
 class SubobjectParserFunctionTest extends \PHPUnit_Framework_TestCase {
+
+	use PHPUnitCompat;
 
 	private $semanticDataValidator;
 

--- a/tests/phpunit/Unit/Query/Language/ClassDescriptionTest.php
+++ b/tests/phpunit/Unit/Query/Language/ClassDescriptionTest.php
@@ -6,6 +6,7 @@ use SMW\DIWikiPage;
 use SMW\Localizer;
 use SMW\Query\Language\ClassDescription;
 use SMW\Query\Language\ThingDescription;
+use SMW\Tests\PHPUnitCompat;
 
 /**
  * @covers \SMW\Query\Language\ClassDescription
@@ -17,6 +18,8 @@ use SMW\Query\Language\ThingDescription;
  * @author mwjames
  */
 class ClassDescriptionTest extends \PHPUnit_Framework_TestCase {
+
+	use PHPUnitCompat;
 
 	public function testCanConstruct() {
 

--- a/tests/phpunit/Unit/Query/Result/CachedQueryResultPrefetcherTest.php
+++ b/tests/phpunit/Unit/Query/Result/CachedQueryResultPrefetcherTest.php
@@ -7,6 +7,7 @@ use Onoi\BlobStore\Container;
 use SMW\DIWikiPage;
 use SMW\Query\Result\CachedQueryResultPrefetcher;
 use SMW\Utils\BufferedStatsdCollector;
+use SMW\Tests\PHPUnitCompat;
 
 /**
  * @covers \SMW\Query\Result\CachedQueryResultPrefetcher
@@ -18,6 +19,8 @@ use SMW\Utils\BufferedStatsdCollector;
  * @author mwjames
  */
 class CachedQueryResultPrefetcherTest extends \PHPUnit_Framework_TestCase {
+
+	use PHPUnitCompat;
 
 	private $store;
 	private $queryFactory;

--- a/tests/phpunit/Unit/Rule/RuleFactoryTest.php
+++ b/tests/phpunit/Unit/Rule/RuleFactoryTest.php
@@ -3,6 +3,7 @@
 namespace SMW\Tests\Rule;
 
 use SMW\Rule\RuleFactory;
+use SMW\Tests\PHPUnitCompat;
 
 /**
  * @covers \SMW\Rule\RuleFactory
@@ -14,6 +15,8 @@ use SMW\Rule\RuleFactory;
  * @author mwjames
  */
 class RuleFactoryTest extends \PHPUnit_Framework_TestCase {
+
+	use PHPUnitCompat;
 
 	public function testCanConstruct() {
 

--- a/tests/phpunit/Unit/SPARQLStore/HttpResponseErrorMapperTest.php
+++ b/tests/phpunit/Unit/SPARQLStore/HttpResponseErrorMapperTest.php
@@ -3,6 +3,7 @@
 namespace SMW\Tests\SPARQLStore;
 
 use SMW\SPARQLStore\HttpResponseErrorMapper;
+use SMW\Tests\PHPUnitCompat;
 
 /**
  * @covers \SMW\SPARQLStore\HttpResponseErrorMapper
@@ -14,6 +15,8 @@ use SMW\SPARQLStore\HttpResponseErrorMapper;
  * @author mwjames
  */
 class HttpResponseErrorMapperTest extends \PHPUnit_Framework_TestCase {
+
+	use PHPUnitCompat;
 
 	public function testCanConstruct() {
 

--- a/tests/phpunit/Unit/SPARQLStore/QueryEngine/ConditionBuilderTest.php
+++ b/tests/phpunit/Unit/SPARQLStore/QueryEngine/ConditionBuilderTest.php
@@ -18,6 +18,7 @@ use SMWDataItem as DataItem;
 use SMWDIBlob as DIBlob;
 use SMWDINumber as DINumber;
 use SMWDITime as DITime;
+use SMW\Tests\PHPUnitCompat;
 
 /**
  * @covers \SMW\SPARQLStore\QueryEngine\ConditionBuilder
@@ -29,6 +30,8 @@ use SMWDITime as DITime;
  * @author mwjames
  */
 class ConditionBuilderTest extends \PHPUnit_Framework_TestCase {
+
+	use PHPUnitCompat;
 
 	private $stringBuilder;
 	private $descriptionInterpreterFactory;

--- a/tests/phpunit/Unit/SPARQLStore/QueryEngine/EngineOptionsTest.php
+++ b/tests/phpunit/Unit/SPARQLStore/QueryEngine/EngineOptionsTest.php
@@ -3,6 +3,7 @@
 namespace SMW\Tests\SPARQLStore\QueryEngine;
 
 use SMW\SPARQLStore\QueryEngine\EngineOptions;
+use SMW\Tests\PHPUnitCompat;
 
 /**
  * @covers \SMW\SPARQLStore\QueryEngine\EngineOptions
@@ -14,6 +15,8 @@ use SMW\SPARQLStore\QueryEngine\EngineOptions;
  * @author mwjames
  */
 class EngineOptionsTest extends \PHPUnit_Framework_TestCase {
+
+	use PHPUnitCompat;
 
 	public function testCanConstruct() {
 

--- a/tests/phpunit/Unit/SPARQLStore/QueryEngine/QueryEngineTest.php
+++ b/tests/phpunit/Unit/SPARQLStore/QueryEngine/QueryEngineTest.php
@@ -6,6 +6,7 @@ use SMW\SPARQLStore\QueryEngine\EngineOptions;
 use SMW\SPARQLStore\QueryEngine\QueryEngine;
 use SMW\SPARQLStore\QueryEngine\QueryResultFactory;
 use SMWQuery as Query;
+use SMW\Tests\PHPUnitCompat;
 
 /**
  * @covers \SMW\SPARQLStore\QueryEngine\QueryEngine
@@ -17,6 +18,8 @@ use SMWQuery as Query;
  * @author mwjames
  */
 class QueryEngineTest extends \PHPUnit_Framework_TestCase {
+
+	use PHPUnitCompat;
 
 	public function testCanConstruct() {
 

--- a/tests/phpunit/Unit/SPARQLStore/QueryEngine/XmlResponseParserTest.php
+++ b/tests/phpunit/Unit/SPARQLStore/QueryEngine/XmlResponseParserTest.php
@@ -6,6 +6,7 @@ use SMW\SPARQLStore\QueryEngine\XmlResponseParser;
 use SMW\Tests\Utils\Fixtures\Results\FakeRawResultProvider;
 use SMWExpLiteral as ExpLiteral;
 use SMWExpResource as ExpResource;
+use SMW\Tests\PHPUnitCompat;
 
 /**
  * @covers \SMW\SPARQLStore\QueryEngine\XmlResponseParser
@@ -17,6 +18,8 @@ use SMWExpResource as ExpResource;
  * @author mwjames
  */
 class XmlResponseParserTest extends \PHPUnit_Framework_TestCase {
+
+	use PHPUnitCompat;
 
 	public function testCanConstruct() {
 		$this->assertInstanceOf(

--- a/tests/phpunit/Unit/SPARQLStore/RepositoryConnectionProviderTest.php
+++ b/tests/phpunit/Unit/SPARQLStore/RepositoryConnectionProviderTest.php
@@ -4,6 +4,7 @@ namespace SMW\Tests\SPARQLStore;
 
 use SMW\SPARQLStore\RepositoryConnectionProvider;
 use SMW\Tests\Utils\GlobalsProvider;
+use SMW\Tests\PHPUnitCompat;
 
 /**
  * @covers \SMW\SPARQLStore\RepositoryConnectionProvider
@@ -15,6 +16,8 @@ use SMW\Tests\Utils\GlobalsProvider;
  * @author mwjames
  */
 class RepositoryConnectionProviderTest extends \PHPUnit_Framework_TestCase {
+
+	use PHPUnitCompat;
 
 	private $globalsProvider;
 	private $smwgSparqlCustomConnector;

--- a/tests/phpunit/Unit/SPARQLStore/RepositoryConnectors/RepositoryConnectorsExceptionTest.php
+++ b/tests/phpunit/Unit/SPARQLStore/RepositoryConnectors/RepositoryConnectorsExceptionTest.php
@@ -3,6 +3,7 @@
 namespace SMW\Tests\SPARQLStore\RepositoryConnectors;
 
 use SMW\SPARQLStore\RepositoryClient;
+use SMW\Tests\PHPUnitCompat;
 
 /**
  * @covers \SMW\SPARQLStore\RepositoryConnectors\FusekiRepositoryConnector
@@ -18,6 +19,8 @@ use SMW\SPARQLStore\RepositoryClient;
  * @author mwjames
  */
 class RepositoryConnectorsExceptionTest extends \PHPUnit_Framework_TestCase {
+
+	use PHPUnitCompat;
 
 	private $defaultGraph;
 

--- a/tests/phpunit/Unit/SPARQLStore/RepositoryRedirectLookupTest.php
+++ b/tests/phpunit/Unit/SPARQLStore/RepositoryRedirectLookupTest.php
@@ -9,6 +9,7 @@ use SMW\SPARQLStore\RepositoryRedirectLookup;
 use SMWExpLiteral as ExpLiteral;
 use SMWExpNsResource as ExpNsResource;
 use SMWExporter as Exporter;
+use SMW\Tests\PHPUnitCompat;
 
 /**
  * @covers \SMW\SPARQLStore\RepositoryRedirectLookup
@@ -20,6 +21,8 @@ use SMWExporter as Exporter;
  * @author mwjames
  */
 class RepositoryRedirectLookupTest extends \PHPUnit_Framework_TestCase {
+
+	use PHPUnitCompat;
 
 	public function testCanConstruct() {
 

--- a/tests/phpunit/Unit/SQLStore/ChangeOp/FieldChangeOpTest.php
+++ b/tests/phpunit/Unit/SQLStore/ChangeOp/FieldChangeOpTest.php
@@ -3,6 +3,7 @@
 namespace SMW\Tests\SQLStore\ChangeOp;
 
 use SMW\SQLStore\ChangeOp\FieldChangeOp;
+use SMW\Tests\PHPUnitCompat;
 
 /**
  * @covers \SMW\SQLStore\ChangeOp\FieldChangeOp
@@ -14,6 +15,8 @@ use SMW\SQLStore\ChangeOp\FieldChangeOp;
  * @author mwjames
  */
 class FieldChangeOpTest extends \PHPUnit_Framework_TestCase {
+
+	use PHPUnitCompat;
 
 	public function testCanConstruct() {
 

--- a/tests/phpunit/Unit/SQLStore/ChangePropagationEntityFinderTest.php
+++ b/tests/phpunit/Unit/SQLStore/ChangePropagationEntityFinderTest.php
@@ -5,6 +5,7 @@ namespace SMW\Tests\SQLStore;
 use SMW\DIProperty;
 use SMW\DIWikiPage;
 use SMW\SQLStore\ChangePropagationEntityFinder;
+use SMW\Tests\PHPUnitCompat;
 
 /**
  * @covers \SMW\SQLStore\ChangePropagationEntityFinder
@@ -16,6 +17,8 @@ use SMW\SQLStore\ChangePropagationEntityFinder;
  * @author mwjames
  */
 class ChangePropagationEntityFinderTest extends \PHPUnit_Framework_TestCase {
+
+	use PHPUnitCompat;
 
 	private $store;
 	private $iteratorFactory;

--- a/tests/phpunit/Unit/SQLStore/EntityStore/CachingSemanticDataLookupTest.php
+++ b/tests/phpunit/Unit/SQLStore/EntityStore/CachingSemanticDataLookupTest.php
@@ -4,6 +4,7 @@ namespace SMW\Tests\SQLStore\EntityStore;
 
 use SMW\DIWikiPage;
 use SMW\SQLStore\EntityStore\CachingSemanticDataLookup;
+use SMW\Tests\PHPUnitCompat;
 
 /**
  * @covers \SMW\SQLStore\EntityStore\CachingSemanticDataLookup
@@ -15,6 +16,8 @@ use SMW\SQLStore\EntityStore\CachingSemanticDataLookup;
  * @author mwjames
  */
 class CachingSemanticDataLookupTest extends \PHPUnit_Framework_TestCase {
+
+	use PHPUnitCompat;
 
 	private $store;
 	private $connection;

--- a/tests/phpunit/Unit/SQLStore/EntityStore/DIHandlers/DIBlobHandlerTest.php
+++ b/tests/phpunit/Unit/SQLStore/EntityStore/DIHandlers/DIBlobHandlerTest.php
@@ -5,6 +5,7 @@ namespace SMW\Tests\SQLStore\EntityStore\DIHandlers;
 use SMW\SQLStore\EntityStore\DIHandlers\DIBlobHandler;
 use SMW\SQLStore\TableBuilder\FieldType;
 use SMWDIBlob as DIBlob;
+use SMW\Tests\PHPUnitCompat;
 
 /**
  * @covers \SMW\SQLStore\EntityStore\DIHandlers\DIBlobHandler
@@ -16,6 +17,8 @@ use SMWDIBlob as DIBlob;
  * @author mwjames
  */
 class DIBlobHandlerTest extends \PHPUnit_Framework_TestCase {
+
+	use PHPUnitCompat;
 
 	private $store;
 

--- a/tests/phpunit/Unit/SQLStore/EntityStore/DIHandlers/DIUriHandlerTest.php
+++ b/tests/phpunit/Unit/SQLStore/EntityStore/DIHandlers/DIUriHandlerTest.php
@@ -5,6 +5,7 @@ namespace SMW\Tests\SQLStore\EntityStore\DIHandlers;
 use SMW\SQLStore\EntityStore\DIHandlers\DIUriHandler;
 use SMW\SQLStore\TableBuilder\FieldType;
 use SMWDIUri as DIUri;
+use SMW\Tests\PHPUnitCompat;
 
 /**
  * @covers \SMW\SQLStore\EntityStore\DIHandlers\DIUriHandler
@@ -16,6 +17,8 @@ use SMWDIUri as DIUri;
  * @author mwjames
  */
 class DIUriHandlerTest extends \PHPUnit_Framework_TestCase {
+
+	use PHPUnitCompat;
 
 	private $store;
 

--- a/tests/phpunit/Unit/SQLStore/EntityStore/DIHandlers/DIWikiPageHandlerTest.php
+++ b/tests/phpunit/Unit/SQLStore/EntityStore/DIHandlers/DIWikiPageHandlerTest.php
@@ -4,6 +4,7 @@ namespace SMW\Tests\SQLStore\EntityStore\DIHandlers;
 
 use SMW\DIWikiPage;
 use SMW\SQLStore\EntityStore\DIHandlers\DIWikiPageHandler;
+use SMW\Tests\PHPUnitCompat;
 
 /**
  * @covers \SMW\SQLStore\EntityStore\DIHandlers\DIWikiPageHandler
@@ -15,6 +16,8 @@ use SMW\SQLStore\EntityStore\DIHandlers\DIWikiPageHandler;
  * @author mwjames
  */
 class DIWikiPageHandlerTest extends \PHPUnit_Framework_TestCase {
+
+	use PHPUnitCompat;
 
 	public function testCanConstruct() {
 

--- a/tests/phpunit/Unit/SQLStore/EntityStore/DataItemHandlerDispatcherTest.php
+++ b/tests/phpunit/Unit/SQLStore/EntityStore/DataItemHandlerDispatcherTest.php
@@ -4,6 +4,7 @@ namespace SMW\Tests\SQLStore\EntityStore;
 
 use SMW\SQLStore\EntityStore\DataItemHandlerDispatcher;
 use SMWDataItem as DataItem;
+use SMW\Tests\PHPUnitCompat;
 
 /**
  * @covers \SMW\SQLStore\EntityStore\DataItemHandlerDispatcher
@@ -15,6 +16,8 @@ use SMWDataItem as DataItem;
  * @author mwjames
  */
 class DataItemHandlerDispatcherTest extends \PHPUnit_Framework_TestCase {
+
+	use PHPUnitCompat;
 
 	public function testCanConstruct() {
 

--- a/tests/phpunit/Unit/SQLStore/EntityStore/IdCacheManagerTest.php
+++ b/tests/phpunit/Unit/SQLStore/EntityStore/IdCacheManagerTest.php
@@ -4,6 +4,7 @@ namespace SMW\Tests\SQLStore\EntityStore;
 
 use Onoi\Cache\FixedInMemoryLruCache;
 use SMW\SQLStore\EntityStore\IdCacheManager;
+use SMW\Tests\PHPUnitCompat;
 
 /**
  * @covers \SMW\SQLStore\EntityStore\IdCacheManager
@@ -15,6 +16,8 @@ use SMW\SQLStore\EntityStore\IdCacheManager;
  * @author mwjames
  */
 class IdCacheManagerTest extends \PHPUnit_Framework_TestCase {
+
+	use PHPUnitCompat;
 
 	private $caches;
 

--- a/tests/phpunit/Unit/SQLStore/Lookup/PropertyUsageListLookupTest.php
+++ b/tests/phpunit/Unit/SQLStore/Lookup/PropertyUsageListLookupTest.php
@@ -5,6 +5,7 @@ namespace SMW\Tests\SQLStore\Lookup;
 use SMW\DIProperty;
 use SMW\RequestOptions;
 use SMW\SQLStore\Lookup\PropertyUsageListLookup;
+use SMW\Tests\PHPUnitCompat;
 
 /**
  * @covers \SMW\SQLStore\Lookup\PropertyUsageListLookup
@@ -16,6 +17,8 @@ use SMW\SQLStore\Lookup\PropertyUsageListLookup;
  * @author mwjames
  */
 class PropertyUsageListLookupTest extends \PHPUnit_Framework_TestCase {
+
+	use PHPUnitCompat;
 
 	private $store;
 	private $propertyStatisticsStore;

--- a/tests/phpunit/Unit/SQLStore/Lookup/UndeclaredPropertyListLookupTest.php
+++ b/tests/phpunit/Unit/SQLStore/Lookup/UndeclaredPropertyListLookupTest.php
@@ -5,6 +5,7 @@ namespace SMW\Tests\SQLStore\Lookup;
 use SMW\DIProperty;
 use SMW\RequestOptions;
 use SMW\SQLStore\Lookup\UndeclaredPropertyListLookup;
+use SMW\Tests\PHPUnitCompat;
 
 /**
  * @covers \SMW\SQLStore\Lookup\UndeclaredPropertyListLookup
@@ -16,6 +17,8 @@ use SMW\SQLStore\Lookup\UndeclaredPropertyListLookup;
  * @author mwjames
  */
 class UndeclaredPropertyListLookupTest extends \PHPUnit_Framework_TestCase {
+
+	use PHPUnitCompat;
 
 	private $store;
 	private $requestOptions;

--- a/tests/phpunit/Unit/SQLStore/Lookup/UnusedPropertyListLookupTest.php
+++ b/tests/phpunit/Unit/SQLStore/Lookup/UnusedPropertyListLookupTest.php
@@ -5,6 +5,7 @@ namespace SMW\Tests\SQLStore\Lookup;
 use SMW\DIProperty;
 use SMW\RequestOptions;
 use SMW\SQLStore\Lookup\UnusedPropertyListLookup;
+use SMW\Tests\PHPUnitCompat;
 
 /**
  * @covers \SMW\SQLStore\Lookup\UnusedPropertyListLookup
@@ -16,6 +17,8 @@ use SMW\SQLStore\Lookup\UnusedPropertyListLookup;
  * @author mwjames
  */
 class UnusedPropertyListLookupTest extends \PHPUnit_Framework_TestCase {
+
+	use PHPUnitCompat;
 
 	private $store;
 	private $propertyStatisticsStore;

--- a/tests/phpunit/Unit/SQLStore/Lookup/UsageStatisticsListLookupTest.php
+++ b/tests/phpunit/Unit/SQLStore/Lookup/UsageStatisticsListLookupTest.php
@@ -3,6 +3,7 @@
 namespace SMW\Tests\SQLStore\Lookup;
 
 use SMW\SQLStore\Lookup\UsageStatisticsListLookup;
+use SMW\Tests\PHPUnitCompat;
 
 /**
  * @covers \SMW\SQLStore\Lookup\UsageStatisticsListLookup
@@ -15,6 +16,8 @@ use SMW\SQLStore\Lookup\UsageStatisticsListLookup;
  * @author mwjames
  */
 class UsageStatisticsListLookupTest extends \PHPUnit_Framework_TestCase {
+
+	use PHPUnitCompat;
 
 	private $store;
 	private $propertyStatisticsStore;

--- a/tests/phpunit/Unit/SQLStore/PropertyStatisticsStoreTest.php
+++ b/tests/phpunit/Unit/SQLStore/PropertyStatisticsStoreTest.php
@@ -5,6 +5,7 @@ namespace SMW\Tests\SQLStore;
 use SMW\SQLStore\PropertyStatisticsStore;
 use SMW\SQLStore\SQLStore;
 use SMW\Tests\MwDBaseUnitTestCase;
+use SMW\Tests\PHPUnitCompat;
 
 /**
  * @covers \SMW\SQLStore\PropertyStatisticsStore
@@ -18,6 +19,8 @@ use SMW\Tests\MwDBaseUnitTestCase;
  * @author Jeroen De Dauw < jeroendedauw@gmail.com >
  */
 class PropertyStatisticsStoreTest extends MwDBaseUnitTestCase {
+
+	use PHPUnitCompat;
 
 	protected $statsTable = null;
 

--- a/tests/phpunit/Unit/SQLStore/PropertyTableDefinitionTest.php
+++ b/tests/phpunit/Unit/SQLStore/PropertyTableDefinitionTest.php
@@ -5,6 +5,7 @@ namespace SMW\Tests\SQLStore;
 use SMW\SQLStore\PropertyTableDefinition;
 use SMW\StoreFactory;
 use SMWDataItem;
+use SMW\Tests\PHPUnitCompat;
 
 /**
  * @covers \SMW\SQLStore\PropertyTableDefinition
@@ -16,6 +17,8 @@ use SMWDataItem;
  * @author mwjames
  */
 class PropertyTableDefinitionTest extends \PHPUnit_Framework_TestCase {
+
+	use PHPUnitCompat;
 
 	public function testCanConstruct() {
 

--- a/tests/phpunit/Unit/SQLStore/QueryEngine/DescriptionInterpreters/ComparatorMapperTest.php
+++ b/tests/phpunit/Unit/SQLStore/QueryEngine/DescriptionInterpreters/ComparatorMapperTest.php
@@ -3,6 +3,7 @@
 namespace SMW\Tests\SQLStore\QueryEngine\DescriptionInterpreters;
 
 use SMW\SQLStore\QueryEngine\DescriptionInterpreters\ComparatorMapper;
+use SMW\Tests\PHPUnitCompat;
 
 /**
  * @covers \SMW\SQLStore\QueryEngine\DescriptionInterpreters\ComparatorMapper
@@ -14,6 +15,8 @@ use SMW\SQLStore\QueryEngine\DescriptionInterpreters\ComparatorMapper;
  * @author mwjames
  */
 class ComparatorMapperTest extends \PHPUnit_Framework_TestCase {
+
+	use PHPUnitCompat;
 
 	public function testCanConstruct() {
 

--- a/tests/phpunit/Unit/SQLStore/QueryEngine/EngineOptionsTest.php
+++ b/tests/phpunit/Unit/SQLStore/QueryEngine/EngineOptionsTest.php
@@ -3,6 +3,7 @@
 namespace SMW\Tests\SQLStore\QueryEngine;
 
 use SMW\SQLStore\QueryEngine\EngineOptions;
+use SMW\Tests\PHPUnitCompat;
 
 /**
  * @covers \SMW\SQLStore\QueryEngine\EngineOptions
@@ -14,6 +15,8 @@ use SMW\SQLStore\QueryEngine\EngineOptions;
  * @author mwjames
  */
 class EngineOptionsTest extends \PHPUnit_Framework_TestCase {
+
+	use PHPUnitCompat;
 
 	public function testCanConstruct() {
 

--- a/tests/phpunit/Unit/SQLStore/QueryEngine/HierarchyTempTableBuilderTest.php
+++ b/tests/phpunit/Unit/SQLStore/QueryEngine/HierarchyTempTableBuilderTest.php
@@ -3,6 +3,7 @@
 namespace SMW\Tests\SQLStore\QueryEngine;
 
 use SMW\SQLStore\QueryEngine\HierarchyTempTableBuilder;
+use SMW\Tests\PHPUnitCompat;
 
 /**
  * @covers \SMW\SQLStore\QueryEngine\HierarchyTempTableBuilder
@@ -14,6 +15,8 @@ use SMW\SQLStore\QueryEngine\HierarchyTempTableBuilder;
  * @author mwjames
  */
 class HierarchyTempTableBuilderTest extends \PHPUnit_Framework_TestCase {
+
+	use PHPUnitCompat;
 
 	private $connection;
 	private $temporaryTableBuilder;

--- a/tests/phpunit/Unit/SQLStore/QueryEngine/OrderConditionTest.php
+++ b/tests/phpunit/Unit/SQLStore/QueryEngine/OrderConditionTest.php
@@ -4,6 +4,7 @@ namespace SMW\Tests\SQLStore\QueryEngine;
 
 use SMW\SQLStore\QueryEngine\OrderCondition;
 use SMW\SQLStore\QueryEngine\QuerySegment;
+use SMW\Tests\PHPUnitCompat;
 
 /**
  * @covers \SMW\SQLStore\QueryEngine\OrderCondition
@@ -15,6 +16,8 @@ use SMW\SQLStore\QueryEngine\QuerySegment;
  * @author mwjames
  */
 class OrderConditionTest extends \PHPUnit_Framework_TestCase {
+
+	use PHPUnitCompat;
 
 	private $querySegmentListBuilder;
 

--- a/tests/phpunit/Unit/SQLStore/QueryEngine/QuerySegmentListBuilderTest.php
+++ b/tests/phpunit/Unit/SQLStore/QueryEngine/QuerySegmentListBuilderTest.php
@@ -10,6 +10,7 @@ use SMW\SQLStore\QueryEngine\DescriptionInterpreterFactory;
 use SMW\SQLStore\QueryEngine\QuerySegment;
 use SMW\SQLStore\QueryEngine\QuerySegmentListBuilder;
 use SMW\Tests\TestEnvironment;
+use SMW\Tests\PHPUnitCompat;
 
 /**
  * @covers \SMW\SQLStore\QueryEngine\QuerySegmentListBuilder
@@ -21,6 +22,8 @@ use SMW\Tests\TestEnvironment;
  * @author mwjames
  */
 class QuerySegmentListBuilderTest extends \PHPUnit_Framework_TestCase {
+
+	use PHPUnitCompat;
 
 	private $querySegmentValidator;
 	private $descriptionInterpreterFactory;

--- a/tests/phpunit/Unit/SQLStore/QueryEngine/QuerySegmentListProcessorTest.php
+++ b/tests/phpunit/Unit/SQLStore/QueryEngine/QuerySegmentListProcessorTest.php
@@ -3,6 +3,7 @@
 namespace SMW\Tests\SQLStore\QueryEngine;
 
 use SMW\SQLStore\QueryEngine\QuerySegmentListProcessor;
+use SMW\Tests\PHPUnitCompat;
 
 /**
  * @covers \SMW\SQLStore\QueryEngine\QuerySegmentListProcessor
@@ -14,6 +15,8 @@ use SMW\SQLStore\QueryEngine\QuerySegmentListProcessor;
  * @author mwjames
  */
 class QuerySegmentListProcessorTest extends \PHPUnit_Framework_TestCase {
+
+	use PHPUnitCompat;
 
 	public function testCanConstruct() {
 

--- a/tests/phpunit/Unit/SQLStore/TableBuilder/TableBuilderTest.php
+++ b/tests/phpunit/Unit/SQLStore/TableBuilder/TableBuilderTest.php
@@ -3,6 +3,7 @@
 namespace SMW\Tests\SQLStore\TableBuilder;
 
 use SMW\SQLStore\TableBuilder\TableBuilder;
+use SMW\Tests\PHPUnitCompat;
 
 /**
  * @covers \SMW\SQLStore\TableBuilder\TableBuilder
@@ -14,6 +15,8 @@ use SMW\SQLStore\TableBuilder\TableBuilder;
  * @author mwjames
  */
 class TableBuilderTest extends \PHPUnit_Framework_TestCase {
+
+	use PHPUnitCompat;
 
 	public function testCanConstructForMySQL() {
 

--- a/tests/phpunit/Unit/SQLStore/TableBuilder/TableTest.php
+++ b/tests/phpunit/Unit/SQLStore/TableBuilder/TableTest.php
@@ -3,6 +3,7 @@
 namespace SMW\Tests\SQLStore\TableBuilder;
 
 use SMW\SQLStore\TableBuilder\Table;
+use SMW\Tests\PHPUnitCompat;
 
 /**
  * @covers \SMW\SQLStore\TableBuilder\Table
@@ -14,6 +15,8 @@ use SMW\SQLStore\TableBuilder\Table;
  * @author mwjames
  */
 class TableTest extends \PHPUnit_Framework_TestCase {
+
+	use PHPUnitCompat;
 
 	public function testCanConstruct() {
 

--- a/tests/phpunit/Unit/SerializerFactoryTest.php
+++ b/tests/phpunit/Unit/SerializerFactoryTest.php
@@ -1,8 +1,9 @@
 <?php
 
-namespace SMW\Test;
+namespace SMW\Tests;
 
 use SMW\SerializerFactory;
+use SMW\Tests\PHPUnitCompat;
 
 /**
  * @covers \SMW\SerializerFactory
@@ -14,6 +15,8 @@ use SMW\SerializerFactory;
  * @author mwjames
  */
 class SerializerFactoryTest extends \PHPUnit_Framework_TestCase {
+
+	use PHPUnitCompat;
 
 	public function testCanConstruct() {
 

--- a/tests/phpunit/Unit/Serializers/ExpDataSerializerTest.php
+++ b/tests/phpunit/Unit/Serializers/ExpDataSerializerTest.php
@@ -7,6 +7,7 @@ use SMW\Exporter\Element\ExpNsResource;
 use SMW\Serializers\ExpDataSerializer;
 use SMWDIBlob as DIBlob;
 use SMWExpData as ExpData;
+use SMW\Tests\PHPUnitCompat;
 
 /**
  * @covers \SMW\Serializers\ExpDataSerializer
@@ -18,6 +19,8 @@ use SMWExpData as ExpData;
  * @author mwjames
  */
 class ExpDataSerializerTest extends \PHPUnit_Framework_TestCase {
+
+	use PHPUnitCompat;
 
 	public function testCanConstructor() {
 

--- a/tests/phpunit/Unit/Serializers/QueryResultSerializerTest.php
+++ b/tests/phpunit/Unit/Serializers/QueryResultSerializerTest.php
@@ -9,6 +9,7 @@ use SMW\Tests\Utils\Mock\CoreMockObjectRepository;
 use SMW\Tests\Utils\Mock\MediaWikiMockObjectRepository;
 use SMW\Tests\Utils\Mock\MockObjectBuilder;
 use SMWDataItem as DataItem;
+use SMW\Tests\PHPUnitCompat;
 
 /**
  * @covers \SMW\Serializers\QueryResultSerializer
@@ -20,6 +21,8 @@ use SMWDataItem as DataItem;
  * @author mwjames
  */
 class QueryResultSerializerTest extends \PHPUnit_Framework_TestCase {
+
+	use PHPUnitCompat;
 
 	private $testEnvironment;
 	private $dataItemFactory;

--- a/tests/phpunit/Unit/Serializers/SemanticDataSerializerTest.php
+++ b/tests/phpunit/Unit/Serializers/SemanticDataSerializerTest.php
@@ -8,6 +8,7 @@ use SMW\Serializers\SemanticDataSerializer;
 use SMW\Subobject;
 use SMW\Tests\Utils\UtilityFactory;
 use Title;
+use SMW\Tests\PHPUnitCompat;
 
 /**
  * @covers \SMW\Serializers\SemanticDataSerializer
@@ -19,6 +20,8 @@ use Title;
  * @author mwjames
  */
 class SemanticDataSerializerTest extends \PHPUnit_Framework_TestCase {
+
+	use PHPUnitCompat;
 
 	private $dataValueFactory;
 	private $semanticDataFactory;

--- a/tests/phpunit/includes/QueryPrinterFactoryTest.php
+++ b/tests/phpunit/includes/QueryPrinterFactoryTest.php
@@ -18,6 +18,8 @@ use SMWListResultPrinter;
  */
 class QueryPrinterFactoryTest extends \PHPUnit_Framework_TestCase {
 
+	use PHPUnitCompat;
+
 	public function testSingleton() {
 		$instance = QueryPrinterFactory::singleton();
 

--- a/tests/phpunit/includes/SemanticDataTest.php
+++ b/tests/phpunit/includes/SemanticDataTest.php
@@ -23,6 +23,8 @@ use Title;
  */
 class SemanticDataTest extends \PHPUnit_Framework_TestCase {
 
+	use PHPUnitCompat;
+
 	private $semanticDataValidator;
 	private $dataValueFactory;
 	private $testEnvironment;

--- a/tests/phpunit/includes/SettingsTest.php
+++ b/tests/phpunit/includes/SettingsTest.php
@@ -4,6 +4,7 @@ namespace SMW\Test;
 
 use SMW\Settings;
 use SMW\Tests\TestEnvironment;
+use SMW\Tests\PHPUnitCompat;
 
 /**
  * @covers \SMW\Settings
@@ -16,6 +17,8 @@ use SMW\Tests\TestEnvironment;
  * @author Jeroen De Dauw < jeroendedauw@gmail.com >
  */
 class SettingsTest extends \PHPUnit_Framework_TestCase {
+
+	use PHPUnitCompat;
 
 	protected function tearDown() {
 		Settings::clear();

--- a/tests/phpunit/includes/SubobjectTest.php
+++ b/tests/phpunit/includes/SubobjectTest.php
@@ -21,6 +21,8 @@ use Title;
  */
 class SubobjectTest extends \PHPUnit_Framework_TestCase {
 
+	use PHPUnitCompat;
+
 	private $semanticDataValidator;
 
 	protected function setUp() {

--- a/tests/phpunit/includes/dataitems/DIPropertyTest.php
+++ b/tests/phpunit/includes/dataitems/DIPropertyTest.php
@@ -20,6 +20,8 @@ use SMWDataItem as DataItem;
  */
 class DIPropertyTest extends \PHPUnit_Framework_TestCase {
 
+	use PHPUnitCompat;
+
 	protected function tearDown() {
 		PropertyRegistry::clear();
 		parent::tearDown();

--- a/tests/phpunit/includes/dataitems/DITimeTest.php
+++ b/tests/phpunit/includes/dataitems/DITimeTest.php
@@ -14,6 +14,8 @@ use SMWDITime as DITime;
  */
 class DITimeTest extends \PHPUnit_Framework_TestCase {
 
+	use PHPUnitCompat;
+
 	public function testCanConstruct() {
 
 		$this->assertInstanceOf(

--- a/tests/phpunit/includes/dataitems/DI_GeoCoordTest.php
+++ b/tests/phpunit/includes/dataitems/DI_GeoCoordTest.php
@@ -12,6 +12,8 @@ use SMW\Exception\DataItemException;
  */
 class SMWDIGeoCoordTest extends \PHPUnit_Framework_TestCase {
 
+	use PHPUnitCompat;
+
 	public function testConstructorWithArrayArgumentForm() {
 		$coordinate = new \SMWDIGeoCoord( [ 'lat' => 13.37, 'lon' => 42.42 ] );
 

--- a/tests/phpunit/includes/querypages/PropertiesQueryPageTest.php
+++ b/tests/phpunit/includes/querypages/PropertiesQueryPageTest.php
@@ -6,6 +6,7 @@ use SMW\ArrayAccessor;
 use SMW\DataItemFactory;
 use SMW\PropertiesQueryPage;
 use SMW\Settings;
+use SMW\Tests\PHPUnitCompat;
 
 /**
  * @covers \SMW\PropertiesQueryPage
@@ -17,6 +18,8 @@ use SMW\Settings;
  * @author mwjames
  */
 class PropertiesQueryPageTest extends \PHPUnit_Framework_TestCase {
+
+	use PHPUnitCompat;
 
 	private $store;
 	private $skin;

--- a/tests/phpunit/includes/querypages/UnusedPropertiesQueryPageTest.php
+++ b/tests/phpunit/includes/querypages/UnusedPropertiesQueryPageTest.php
@@ -6,6 +6,7 @@ use SMW\DataItemFactory;
 use SMW\Settings;
 use SMW\Tests\TestEnvironment;
 use SMW\UnusedPropertiesQueryPage;
+use SMW\Tests\PHPUnitCompat;
 
 /**
  * @covers \SMW\UnusedPropertiesQueryPage
@@ -17,6 +18,8 @@ use SMW\UnusedPropertiesQueryPage;
  * @author mwjames
  */
 class UnusedPropertiesQueryPageTest extends \PHPUnit_Framework_TestCase {
+
+	use PHPUnitCompat;
 
 	private $store;
 	private $skin;

--- a/tests/phpunit/includes/storage/StoreFactoryTest.php
+++ b/tests/phpunit/includes/storage/StoreFactoryTest.php
@@ -19,6 +19,8 @@ use SMW\StoreFactory;
  */
 class StoreFactoryTest extends \PHPUnit_Framework_TestCase {
 
+	use PHPUnitCompat;
+
 	protected function tearDown() {
 		StoreFactory::clear();
 


### PR DESCRIPTION
This PR is made in reference to: #2713

This PR addresses or contains:

- Adds compat layer `PHPUnitCompat` so tests run on 4.8 and 6.5

This PR includes:
- [ ] Tests (unit/integration)
- [x] CI build passed

Fixes #2713