### PR TITLE
Set `CloneDatabase::changePrefix`, refs 3197

### DIFF
--- a/tests/phpunit/Utils/Connection/TestDatabaseTableBuilder.php
+++ b/tests/phpunit/Utils/Connection/TestDatabaseTableBuilder.php
@@ -207,10 +207,6 @@ class TestDatabaseTableBuilder {
 			return true;
 		}
 
-		if ( $GLOBALS['wgDBprefix'] === $this->getDBPrefix() ) {
-			throw new RuntimeException( 'The database prefix is already set to "' . $this->getDBPrefix() . '"' );
-		}
-
 		$this->cloneDatabaseTables();
 		$this->store->setup( false );
 		$this->createDummyPage();
@@ -219,12 +215,6 @@ class TestDatabaseTableBuilder {
 	}
 
 	private function cloneDatabaseTables() {
-
-		// MW's DatabaseSqlite does some magic on its own therefore
-		// we force our way
-		if ( $this->getDBConnection()->getType() === 'sqlite' ) {
-			CloneDatabase::changePrefix( self::$MWDB_PREFIX );
-		}
 
 		$tablesToBeCloned = $this->generateListOfTables();
 
@@ -244,6 +234,10 @@ class TestDatabaseTableBuilder {
 		// "Error: 1137 Can't reopen table" on MySQL (see Issue #80)
 		$this->cloneDatabase->useTemporaryTables( false );
 		$this->cloneDatabase->cloneTableStructure();
+
+		// #3197
+		// @see https://github.com/wikimedia/mediawiki/commit/6badc7415684df54d6672098834359223b859507
+		CloneDatabase::changePrefix( self::$UTDB_PREFIX );
 	}
 
 	private function createDummyPage() {


### PR DESCRIPTION
This PR is made in reference to: #3197

This PR addresses or contains:

- wikimedia/mediawiki@55420ab broke the entire SMW test suite for all DB environments
- Changes like wikimedia/mediawiki@55420ab in MW core are really unpleasant (unclear in scope and impact) as it provides no migration path nor did the developer make any attempts to inform extension developers in beforehand or ensure they are not adversely impacted. After a 2h investigation and https://github.com/wikimedia/mediawiki/commit/6badc7415684df54d6672098834359223b859507 track down it seems the status quo is restored from before the wikimedia/mediawiki@55420ab merge.

This PR includes:
- [ ] Tests (unit/integration)
- [x] CI build passed

Fixes  #3197