### PR TITLE
Counter a possible "CloneDatabase.php: Not dropping new table, as 'sunittest_user' is name of both the old and the new table", refs #3203

### DIFF
--- a/tests/phpunit/Utils/Connection/TestDatabaseTableBuilder.php
+++ b/tests/phpunit/Utils/Connection/TestDatabaseTableBuilder.php
@@ -277,7 +277,7 @@ class TestDatabaseTableBuilder {
 	}
 
 	private function isNotUnittest( $table ) {
-		return strpos( $table, 'unittest_' ) === false;
+		return strpos( $table, 'unittest_' ) === false && strpos( $table, 'sunittest_' ) === false;
 	}
 
 	private function isNotSearchindex( $table ) {


### PR DESCRIPTION
This PR is made in reference to: #3203

This PR addresses or contains:

- Unable to replicate the issue locally but has been observed in https://travis-ci.org/SemanticMediaWiki/SemanticScribunto/jobs/403922327

This PR includes:
- [ ] Tests (unit/integration)
- [x] CI build passed

[skip ci]
