### PR TITLE
CloneDatabase/SQLite set mw-prefix for before cloning, refs 3203

### DIFF
--- a/tests/phpunit/Utils/Connection/TestDatabaseTableBuilder.php
+++ b/tests/phpunit/Utils/Connection/TestDatabaseTableBuilder.php
@@ -218,6 +218,12 @@ class TestDatabaseTableBuilder {
 
 		$tablesToBeCloned = $this->generateListOfTables();
 
+		// MW's DatabaseSqlite does some magic on its own therefore
+		// we force our way
+		if ( $this->getDBConnection()->getType() === 'sqlite' ) {
+			CloneDatabase::changePrefix( self::$MWDB_PREFIX );
+		}
+
 		$this->cloneDatabase = new CloneDatabase(
 			$this->getDBConnection(),
 			$tablesToBeCloned,


### PR DESCRIPTION
This PR is made in reference to: https://travis-ci.org/SemanticMediaWiki/SemanticScribunto/jobs/403949829

This PR addresses or contains:

```
LogicException from line 100 of /home/travis/build/SemanticMediaWiki/mw/includes/db/CloneDatabase.php: Not dropping new table, as 'sunittest_user' is name of both the old and the new table.
Backtrace:
#0 /home/travis/build/SemanticMediaWiki/mw/extensions/SemanticMediaWiki/tests/phpunit/Utils/Connection/TestDatabaseTableBuilder.php(236): CloneDatabase->cloneTableStructure()
#1 /home/travis/build/SemanticMediaWiki/mw/extensions/SemanticMediaWiki/tests/phpunit/Utils/Connection/TestDatabaseTableBuilder.php(210): SMW\Tests\Utils\Connection\TestDatabaseTableBuilder->cloneDatabaseTables()
#2 /home/travis/build/SemanticMediaWiki/mw/extensions/SemanticMediaWiki/tests/phpunit/Utils/Connection/TestDatabaseTableBuilder.php(129): SMW\Tests\Utils\Connection\TestDatabaseTableBuilder->setupDatabaseTables()
#3 /home/travis/build/SemanticMediaWiki/mw/extensions/SemanticMediaWiki/tests/phpunit/DatabaseTestCase.php(128): SMW\Tests\Utils\Connection\TestDatabaseTableBuilder->doBuild()
#4 /home/travis/build/SemanticMediaWiki/mw/vendor/phpunit/phpunit/PHPUnit/Framework/TestSuite.php(779): SMW\Tests\DatabaseTestCase->run(PHPUnit_Framework_TestResult)
#5 /home/travis/build/SemanticMediaWiki/mw/vendor/phpunit/phpunit/PHPUnit/Framework/TestSuite.php(749): PHPUnit_Framework_TestSuite->runTest(SMW\Scribunto\Integration\JSONScript\SemanticScribuntoJsonTestCaseScriptRunnerTest, PHPUnit_Framework_TestResult)
#6 /home/travis/build/SemanticMediaWiki/mw/vendor/phpunit/phpunit/PHPUnit/Framework/TestSuite.php(709): PHPUnit_Framework_TestSuite->run(PHPUnit_Framework_TestResult, boolean, array, array, boolean)
#7 /home/travis/build/SemanticMediaWiki/mw/vendor/phpunit/phpunit/PHPUnit/Framework/TestSuite.php(709): PHPUnit_Framework_TestSuite->run(PHPUnit_Framework_TestResult, boolean, array, array, boolean)
#8 /home/travis/build/SemanticMediaWiki/mw/vendor/phpunit/phpunit/PHPUnit/Framework/TestSuite.php(709): PHPUnit_Framework_TestSuite->run(PHPUnit_Framework_TestResult, boolean, array, array, boolean)
#9 /home/travis/build/SemanticMediaWiki/mw/vendor/phpunit/phpunit/PHPUnit/TextUI/TestRunner.php(350): PHPUnit_Framework_TestSuite->run(PHPUnit_Framework_TestResult, boolean, array, array, boolean)
#10 /home/travis/build/SemanticMediaWiki/mw/vendor/phpunit/phpunit/PHPUnit/TextUI/Command.php(176): PHPUnit_TextUI_TestRunner->doRun(PHPUnit_Framework_TestSuite, array)
#11 /home/travis/build/SemanticMediaWiki/mw/vendor/phpunit/phpunit/PHPUnit/TextUI/Command.php(129): PHPUnit_TextUI_Command->run(array, boolean)
#12 /home/travis/build/SemanticMediaWiki/mw/tests/phpunit/phpunit.php(133): PHPUnit_TextUI_Command::main()
#13 /home/travis/build/SemanticMediaWiki/mw/maintenance/doMaintenance.php(111): PHPUnitMaintClass->execute()
#14 /home/travis/build/SemanticMediaWiki/mw/tests/phpunit/phpunit.php(163): require(string)
#15 {main}
```

This PR includes:
- [ ] Tests (unit/integration)
- [x] CI build passed

[skip ci]