### PR TITLE
Cleaner output in case of an invalid upgrade key, refs 3095

### DIFF
--- a/includes/Setup.php
+++ b/includes/Setup.php
@@ -160,8 +160,8 @@ final class Setup {
 	/**
 	 * @since 3.0
 	 */
-	public static function hasUpgradeKey( $isCli = false ) {
-		return Installer::hasUpgradeKey( $isCli );
+	public static function isValid( $isCli = false ) {
+		return Installer::isGoodSchema( $isCli );
 	}
 
 	/**
@@ -172,13 +172,17 @@ final class Setup {
 	 */
 	public function init( &$vars, $directory ) {
 
-		if ( $this->hasUpgradeKey() === false ) {
-			die(
-				'<b>Error:</b> Semantic MediaWiki was installed and enabled but is missing an appropriate ' .
-				'<a href="https://www.semantic-mediawiki.org/wiki/Help:Upgrade">upgrade key</a>. ' .
-				'Please run MediaWiki\'s <a href="https://www.mediawiki.org/wiki/Manual:Update.php">update.php</a> ' .
-				'or Semantic MediaWiki\'s <a href="https://www.semantic-mediawiki.org/wiki/Help:SetupStore.php">setupStore.php</a> maintenance script first.'
-			);
+		if ( $this->isValid() === false ) {
+
+			$text = 'Semantic MediaWiki was installed and enabled but is missing an appropriate ';
+			$text .= '<a href="https://www.semantic-mediawiki.org/wiki/Help:Upgrade">upgrade key</a>. ';
+			$text .= 'Please run MediaWiki\'s <a href="https://www.mediawiki.org/wiki/Manual:Update.php">update.php</a> ';
+			$text .= 'or Semantic MediaWiki\'s <a href="https://www.semantic-mediawiki.org/wiki/Help:SetupStore.php">setupStore.php</a> maintenance script first. ';
+			$text .= 'You may also consult the following pages:';
+			$text .= '<ul><li><a href="https://www.semantic-mediawiki.org/wiki/Help:Installation">Installation</a></li>';
+			$text .= '<li><a href="https://www.semantic-mediawiki.org/wiki/Help:Installation/Troubleshooting">Troubleshooting</a></li></ul>';
+
+			smwfAbort( $text );
 		}
 
 		$this->addDefaultConfigurations( $vars );

--- a/maintenance/rebuildConceptCache.php
+++ b/maintenance/rebuildConceptCache.php
@@ -3,6 +3,7 @@
 namespace SMW\Maintenance;
 
 use SMW\ApplicationFactory;
+use SMW\Setup;
 
 $basePath = getenv( 'MW_INSTALL_PATH' ) !== false ? getenv( 'MW_INSTALL_PATH' ) : __DIR__ . '/../../..';
 
@@ -114,9 +115,14 @@ class RebuildConceptCache extends \Maintenance {
 	 */
 	public function execute() {
 
-		if ( !defined( 'SMW_VERSION' ) || !$GLOBALS['smwgSemanticsEnabled'] ) {
+		if ( !Setup::isEnabled() ) {
 			$this->reportMessage( "\nYou need to have SMW enabled in order to run the maintenance script!\n" );
-			return false;
+			exit;
+		}
+
+		if ( !Setup::isValid( true ) ) {
+			$this->reportMessage( "\nYou need to run `update.php` or `setupStore.php` first before continuing\nwith any maintenance tasks!\n" );
+			exit;
 		}
 
 		$applicationFactory = ApplicationFactory::getInstance();

--- a/maintenance/rebuildData.php
+++ b/maintenance/rebuildData.php
@@ -119,12 +119,12 @@ class RebuildData extends \Maintenance {
 
 		if ( !Setup::isEnabled() ) {
 			$this->reportMessage( "\nYou need to have SMW enabled in order to run the maintenance script!\n" );
-			return false;
+			exit;
 		}
 
-		if ( !Setup::hasUpgradeKey( true ) ) {
-			$this->reportMessage( "\nYou need to run `update.php` or `setupStore.php` first!\n" );
-			return false;
+		if ( !Setup::isValid( true ) ) {
+			$this->reportMessage( "\nYou need to run `update.php` or `setupStore.php` first before continuing\nwith any maintenance tasks!\n" );
+			exit;
 		}
 
 		$maintenanceFactory = ApplicationFactory::getInstance()->newMaintenanceFactory();

--- a/maintenance/rebuildElasticIndex.php
+++ b/maintenance/rebuildElasticIndex.php
@@ -5,9 +5,9 @@ namespace SMW\Maintenance;
 use SMW\ApplicationFactory;
 use SMW\SQLStore\SQLStore;
 use SMW\Elastic\ElasticFactory;
+use SMW\Setup;
 
-$basePath = getenv( 'MW_INSTALL_PATH' ) !== false ? getenv(
-'MW_INSTALL_PATH' ) : __DIR__ . '/../../..';
+$basePath = getenv( 'MW_INSTALL_PATH' ) !== false ? getenv('MW_INSTALL_PATH' ) : __DIR__ . '/../../..';
 
 require_once $basePath . '/maintenance/Maintenance.php';
 
@@ -70,8 +70,13 @@ class RebuildElasticIndex extends \Maintenance {
 	 */
 	public function execute() {
 
-		if ( !defined( 'SMW_VERSION' ) ) {
+		if ( !Setup::isEnabled() ) {
 			$this->output( "You need to have SMW enabled in order to use this maintenance script!\n\n" );
+			exit;
+		}
+
+		if ( !Setup::isValid( true ) ) {
+			$this->reportMessage( "\nYou need to run `update.php` or `setupStore.php` first before continuing\nwith any maintenance tasks!\n" );
 			exit;
 		}
 

--- a/maintenance/rebuildFulltextSearchTable.php
+++ b/maintenance/rebuildFulltextSearchTable.php
@@ -6,6 +6,7 @@ use Onoi\MessageReporter\MessageReporterFactory;
 use SMW\SQLStore\QueryEngine\FulltextSearchTableFactory;
 use SMW\ApplicationFactory;
 use SMWDataItem as DataItem;
+use SMW\Setup;
 
 $basePath = getenv( 'MW_INSTALL_PATH' ) !== false ? getenv( 'MW_INSTALL_PATH' ) : __DIR__ . '/../../..';
 
@@ -46,8 +47,13 @@ class RebuildFulltextSearchTable extends \Maintenance {
 	 */
 	public function execute() {
 
-		if ( !defined( 'SMW_VERSION' ) || !$GLOBALS['smwgSemanticsEnabled'] ) {
-			$this->output( "You need to have SMW enabled in order to use this maintenance script!\n\n" );
+		if ( !Setup::isEnabled() ) {
+			$this->reportMessage( "\nYou need to have SMW enabled in order to run the maintenance script!\n" );
+			exit;
+		}
+
+		if ( !Setup::isValid( true ) ) {
+			$this->reportMessage( "\nYou need to run `update.php` or `setupStore.php` first before continuing\nwith any maintenance tasks!\n" );
 			exit;
 		}
 

--- a/maintenance/rebuildPropertyStatistics.php
+++ b/maintenance/rebuildPropertyStatistics.php
@@ -3,6 +3,7 @@
 namespace SMW\Maintenance;
 
 use SMW\ApplicationFactory;
+use SMW\Setup;
 
 $basePath = getenv( 'MW_INSTALL_PATH' ) !== false ? getenv( 'MW_INSTALL_PATH' ) : __DIR__ . '/../../..';
 
@@ -31,7 +32,6 @@ class RebuildPropertyStatistics extends \Maintenance {
 	 * @since 1.9
 	 */
 	protected function addDefaultParams() {
-
 		parent::addDefaultParams();
 	}
 
@@ -40,8 +40,13 @@ class RebuildPropertyStatistics extends \Maintenance {
 	 */
 	public function execute() {
 
-		if ( !defined( 'SMW_VERSION' ) || !$GLOBALS['smwgSemanticsEnabled'] ) {
-			$this->output( "\nYou need to have SMW enabled in order to use this maintenance script!\n" );
+		if ( !Setup::isEnabled() ) {
+			$this->output( "You need to have SMW enabled in order to use this maintenance script!\n\n" );
+			exit;
+		}
+
+		if ( !Setup::isValid( true ) ) {
+			$this->reportMessage( "\nYou need to run `update.php` or `setupStore.php` first before continuing\nwith any maintenance tasks!\n" );
 			exit;
 		}
 

--- a/maintenance/removeDuplicateEntities.php
+++ b/maintenance/removeDuplicateEntities.php
@@ -3,6 +3,7 @@
 namespace SMW\Maintenance;
 
 use SMW\ApplicationFactory;
+use SMW\Setup;
 
 $basePath = getenv( 'MW_INSTALL_PATH' ) !== false ? getenv(
 'MW_INSTALL_PATH' ) : __DIR__ . '/../../..';
@@ -41,8 +42,13 @@ class RemoveDuplicateEntities extends \Maintenance {
 	 */
 	public function execute() {
 
-		if ( !defined( 'SMW_VERSION' ) ) {
-			$this->output( "You need to have SMW enabled in order to use this maintenance script!\n\n" );
+		if ( !Setup::isEnabled() ) {
+			$this->reportMessage( "\nYou need to have SMW enabled in order to run the maintenance script!\n" );
+			exit;
+		}
+
+		if ( !Setup::isValid() ) {
+			$this->reportMessage( "\nYou need to run `update.php` or `setupStore.php` first before continuing\nwith any maintenance tasks!\n" );
 			exit;
 		}
 

--- a/maintenance/setupStore.php
+++ b/maintenance/setupStore.php
@@ -8,6 +8,7 @@ use Onoi\MessageReporter\MessageReporterFactory;
 use Onoi\MessageReporter\MessageReporter;
 use SMW\Connection\ConnectionManager;
 use SMW\SQLStore\Installer;
+use SMW\Setup;
 
 $basePath = getenv( 'MW_INSTALL_PATH' ) !== false ? getenv( 'MW_INSTALL_PATH' ) : __DIR__ . '/../../..';
 
@@ -126,8 +127,8 @@ class SetupStore extends \Maintenance {
 	 */
 	public function execute() {
 
-		if ( !defined( 'SMW_VERSION' ) || !$GLOBALS['smwgSemanticsEnabled'] ) {
-			$this->output( "\nYou need to have SMW enabled in order to use this maintenance script!\n" );
+		if ( !Setup::isEnabled() ) {
+			$this->reportMessage( "\nYou need to have SMW enabled in order to run the maintenance script!\n" );
 			exit;
 		}
 

--- a/maintenance/updateEntityCollation.php
+++ b/maintenance/updateEntityCollation.php
@@ -9,9 +9,9 @@ use SMW\DIWikiPage;
 use SMW\DIProperty;
 use SMWDataItem as DataItem;
 use SMW\Exception\PredefinedPropertyLabelMismatchException;
+use SMW\Setup;
 
-$basePath = getenv( 'MW_INSTALL_PATH' ) !== false ? getenv(
-'MW_INSTALL_PATH' ) : __DIR__ . '/../../..';
+$basePath = getenv( 'MW_INSTALL_PATH' ) !== false ? getenv('MW_INSTALL_PATH' ) : __DIR__ . '/../../..';
 
 require_once $basePath . '/maintenance/Maintenance.php';
 
@@ -45,8 +45,13 @@ class UpdateEntityCollation extends \Maintenance {
 	 */
 	public function execute() {
 
-		if ( !defined( 'SMW_VERSION' ) ) {
-			$this->output( "You need to have SMW enabled in order to use this maintenance script!\n\n" );
+		if ( !Setup::isEnabled() ) {
+			$this->reportMessage( "\nYou need to have SMW enabled in order to run the maintenance script!\n" );
+			exit;
+		}
+
+		if ( !Setup::isValid( true ) ) {
+			$this->reportMessage( "\nYou need to run `update.php` or `setupStore.php` first before continuing\nwith any maintenance tasks!\n" );
 			exit;
 		}
 

--- a/src/GlobalFunctions.php
+++ b/src/GlobalFunctions.php
@@ -93,6 +93,26 @@ function smwfNumberFormat( $value, $decplaces = 3 ) {
 }
 
 /**
+ * @since 3.0
+ *
+ * @param string $text
+ */
+function smwfAbort( $text ) {
+
+	if ( PHP_SAPI === 'cli' && PHP_SAPI === 'phpdbg' ) {
+		die( $text );
+	}
+
+	$html = "<!DOCTYPE html PUBLIC \"-//W3C//DTD XHTML 1.0 Transitional//EN\"  \"http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd\">\n";
+	$html .= "<html xmlns=\"http://www.w3.org/1999/xhtml\" xml:lang=\"en\" lang=\"en\" dir=\"ltr\">\n";
+	$html .= "<head><meta http-equiv=\"Content-Type\" content=\"text/html; charset=utf-8\" />";
+	$html .= "<title>Error</title></head><body><h2>Error</h2><hr style='border: 0; height: 0; border-top: 1px solid rgba(0, 0, 0, 0.1); border-bottom: 1px solid rgba(255, 255, 255, 0.3);'>";
+	$html .= "<p>{$text}</p></body></html>";
+
+	die( $html );
+}
+
+/**
  * Formats an array of message strings so that it appears as a tooltip.
  * $icon should be one of: 'warning' (default), 'info'.
  *

--- a/src/SQLStore/Installer.php
+++ b/src/SQLStore/Installer.php
@@ -130,9 +130,7 @@ class Installer implements MessageReporter {
 		$this->tableOptimization( $messageReporter );
 		$this->addSupplementJobs( $messageReporter );
 
-		if ( $this->setUpgradeKey( new File(), $GLOBALS ) ) {
-			$messageReporter->reportMessage( "\nSetting upgrade key ...\n   ... done.\n" );
-		};
+		$this->setUpgradeKey( new File(), $GLOBALS, $messageReporter );
 
 		Hooks::run(
 			'SMW::SQLStore::Installer::AfterCreateTablesComplete',
@@ -194,7 +192,7 @@ class Installer implements MessageReporter {
 	 *
 	 * @return boolean
 	 */
-	public static function hasUpgradeKey( $isCli = false ) {
+	public static function isGoodSchema( $isCli = false ) {
 
 		if ( $isCli === false && ( PHP_SAPI === 'cli' || PHP_SAPI === 'phpdbg' ) ) {
 			return true;
@@ -241,13 +239,15 @@ class Installer implements MessageReporter {
 	 * @param File $file
 	 * @param array $vars
 	 */
-	public function setUpgradeKey( File $file, $vars ) {
+	public function setUpgradeKey( File $file, $vars, $messageReporter ) {
 
 		$key = $this->getUpgradeKey( $vars );
 
 		if ( isset( $vars['smw.json']['upgradeKey'] ) && $key === $vars['smw.json']['upgradeKey'] ) {
 			return false;
 		}
+
+		$messageReporter->reportMessage( "\Writting upgrade key ...\n" );
 
 		if ( !isset( $vars['smw.json'] ) ) {
 			$vars['smw.json'] = [];
@@ -257,7 +257,7 @@ class Installer implements MessageReporter {
 
 		$file->write( $vars['smwgIP'] . '/.smw.json', json_encode( $vars['smw.json'] ) );
 
-		return true;
+		$messageReporter->reportMessage( "\n   ... done.\n" );
 	}
 
 	/**

--- a/tests/phpunit/Unit/SQLStore/InstallerTest.php
+++ b/tests/phpunit/Unit/SQLStore/InstallerTest.php
@@ -212,7 +212,7 @@ class InstallerTest extends \PHPUnit_Framework_TestCase {
 		);
 	}
 
-	public function testHasUpgradeKey() {
+	public function testIsGoodSchema() {
 
 		$instance = new Installer(
 			$this->tableSchemaManager,
@@ -222,7 +222,7 @@ class InstallerTest extends \PHPUnit_Framework_TestCase {
 
 		$this->assertInternalType(
 			'boolean',
-			$instance->hasUpgradeKey()
+			$instance->isGoodSchema()
 		);
 	}
 
@@ -268,7 +268,7 @@ class InstallerTest extends \PHPUnit_Framework_TestCase {
 			'smwgPageSpecialProperties' => []
 		];
 
-		$instance->setUpgradeKey( $file, $vars );
+		$instance->setUpgradeKey( $file, $vars, $this->spyMessageReporter );
 	}
 
 }


### PR DESCRIPTION
This PR is made in reference to: #3095

This PR addresses or contains:

- Add a more visually appealing error output

![image](https://user-images.githubusercontent.com/1245473/42727382-27dc5720-8795-11e8-9bff-71702ab6e49c.png)


This PR includes:
- [ ] Tests (unit/integration)
- [x] CI build passed
