### PR TITLE
Decode `-3D` in parameter list, refs 640, 3196

### DIFF
--- a/src/Query/Processor/ParamListProcessor.php
+++ b/src/Query/Processor/ParamListProcessor.php
@@ -217,8 +217,12 @@ class ParamListProcessor {
 		if ( is_array( $parts ) && count( $parts ) >= 2 ) {
 			$p = strtolower( trim( $parts[0] ) );
 
-			// don't trim here, some parameters care for " "
-			$serialization['parameters'][$p] = $parts[1];
+			// Don't trim here, some parameters care for " "
+			//
+			// #3196
+			// Ensure to decode `-3D` from encodeEq to support things like
+			// `|intro=[[File:Foo.png|link=Bar]]`
+			$serialization['parameters'][$p] = str_replace( array( '-3D' ), array( '=' ), $parts[1] );
 		} else {
 			$serialization['query'] .= $param;
 		}

--- a/tests/phpunit/Integration/JSONScript/TestCases/s-0011.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/s-0011.json
@@ -19,6 +19,11 @@
 			"page": "Example/S0011/Q.1",
 			"contents": "{{#ask: [[Category:S0011]] |?Has text |limit=0 |link=none |format=table |intro=with [[intro parameter]] {{#info:intro bubble}} |outro=with [[outro parameter]] {{#info:outro bubble}} }}",
 			"message-cache": "clear"
+		},
+		{
+			"page": "Example/S0011/Q.2",
+			"contents": "{{#ask: [[Category:S0011]] |?Has text |limit=0 |link=none |format=table |intro=[[File:Foo.png|link=Bar]] }}",
+			"message-cache": "clear"
 		}
 	],
 	"tests": [
@@ -96,6 +101,16 @@
 					"S0011%outro link",
 					"class=\"new\" title=\"S0011%outro",
 					"\">S0011%outro</a>"
+				]
+			}
+		},
+		{
+			"type": "parser",
+			"about": "#4 (#3196, `-3D/=` decode)",
+			"subject": "Example/S0011/Q.2",
+			"assert-output": {
+				"to-contain": [
+					"-5B-5BCategory:S0011-5D-5D/-3FHas-20text/mainlabel%3D/offset%3D0/format%3Dtable/link%3Dnone/intro%3D-5B-5BFile:Foo.png-7Clink%3DBar-5D-5D"
 				]
 			}
 		}

--- a/tests/phpunit/Unit/Query/Processor/ParamListProcessorTest.php
+++ b/tests/phpunit/Unit/Query/Processor/ParamListProcessorTest.php
@@ -245,6 +245,22 @@ class ParamListProcessorTest extends \PHPUnit_Framework_TestCase {
 			]
 		];
 
+		// #3196
+		yield [
+			[ 'Foo=Bar', 'link=none', 'intro=[[File:Foo.png|link=Bar]]' ],
+			true,
+			[
+				'showMode'   => true,
+				'query'      => '[[:Foo=Bar]]',
+				'printouts'  => [],
+				'parameters' => [
+					'link' => 'none',
+					'intro' => '[[File:Foo.png|link=Bar]]'
+				],
+				'this'       => []
+			]
+		];
+
 	}
 
 	public function legacyParametersProvider() {


### PR DESCRIPTION
This PR is made in reference to: #640, #3196

This PR addresses or contains:

- `#ask` and its elements that contain `=` are assigned special treatment and encoded to solve something like #640
- `[[File:Foo.png|link=Bar]]` contains `=` and is internally encoded with `-3D` to distinguish it from the first part of `intro=[[File:Foo.png|link=Bar]]`
- To solve #3196, decode the second part after the general parameter processing has been completed so that original content state is restored

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed

Fixes #3196