### PR TITLE
Fix TypeError in DuplicateEntitiesDisposer, refs 2932

### DIFF
--- a/src/Maintenance/DuplicateEntitiesDisposer.php
+++ b/src/Maintenance/DuplicateEntitiesDisposer.php
@@ -56,7 +56,7 @@ class DuplicateEntitiesDisposer {
 		$count = count( $duplicates );
 		$this->messageReporter->reportMessage( "Found: $count duplicates\n" );
 
-		if ( $count > 0 ) {
+		if ( $count > 0 && $this->isIterable( $duplicates ) ) {
 			$this->doDispose( $duplicates );
 		}
 
@@ -65,7 +65,7 @@ class DuplicateEntitiesDisposer {
 		}
 	}
 
-	private function doDispose( array $duplicates ) {
+	private function doDispose( $duplicates ) {
 
 		$propertyTableIdReferenceDisposer = new PropertyTableIdReferenceDisposer(
 			$this->store
@@ -118,6 +118,17 @@ class DuplicateEntitiesDisposer {
 		$this->messageReporter->reportMessage(
 			"\n\nLog\n\n" . json_encode( $log, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE ) . "\n"
 		);
+	}
+
+	/**
+	 * Polyfill for PHP 7.0-
+	 *
+	 * @see http://php.net/manual/en/function.is-iterable.php
+	 *
+	 * @since 3.0
+	 */
+	private function isIterable( $obj ) {
+		return is_array( $obj ) || ( is_object( $obj ) && ( $obj instanceof \Traversable ) );
 	}
 
 }

--- a/tests/phpunit/Unit/Maintenance/DuplicateEntitiesDisposerTest.php
+++ b/tests/phpunit/Unit/Maintenance/DuplicateEntitiesDisposerTest.php
@@ -91,6 +91,22 @@ class DuplicateEntitiesDisposerTest extends \PHPUnit_Framework_TestCase {
 		$instance->verifyAndDispose( [] );
 	}
 
+	public function testVerifyAndDispose_NonIterable() {
+
+		$this->store->expects( $this->never() )
+			->method( 'getConnection' );
+
+		$instance = new DuplicateEntitiesDisposer(
+			$this->store
+		);
+
+		$instance->setMessageReporter(
+			$this->messageReporter
+		);
+
+		$instance->verifyAndDispose( 'Foo' );
+	}
+
 	public function testVerifyAndDispose_NoDuplicates_WithCache() {
 
 		$this->store->expects( $this->never() )


### PR DESCRIPTION
This PR is made in reference to: #2932

This PR addresses or contains:

- Check whether an object is iterable or not

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed

### Error

```
TypeError from line 68 of ...\extensions\SemanticMediaWiki\src\Maintenance\DuplicateEntitiesDisposer.php:
Argument 1 passed to SMW\Maintenance\DuplicateEntitiesDisposer::doDispose() must be of the type array, object given, called in ...\extensions\SemanticMediaWiki\src\Maintenance\DuplicateEntitiesDisposer.php on line 60
```