### PR TITLE
Backport of #3196

### DIFF
--- a/includes/query/SMW_QueryProcessor.php
+++ b/includes/query/SMW_QueryProcessor.php
@@ -295,7 +295,9 @@ class SMWQueryProcessor implements QueryContext {
 
 				if ( count( $parts ) >= 2 ) {
 					// don't trim here, some parameters care for " "
-					$parameters[strtolower( trim( $parts[0] ) )] = $parts[1];
+					// #3196 Ensure to decode `-3D` from encodeEq to
+					// support things like `|intro=[[File:Foo.png|link=Bar]]`
+					$parameters[strtolower( trim( $parts[0] ) )] = str_replace( array( '-3D' ), array( '=' ), $parts[1] );
 				} else {
 					$queryString .= $rawParam;
 				}


### PR DESCRIPTION
This PR is made in reference to: #3196 / #3211 

This PR addresses or contains:
- Backport of "Decode `-3D` in parameter list" to 2.5.x

This PR includes:
- [ ] Tests (unit/integration)
- [x] CI build passed