### PR TITLE
Add `$smwgPagingLimit`, consolidate paging limit settings

### DIFF
--- a/DefaultSettings.php
+++ b/DefaultSettings.php
@@ -425,18 +425,24 @@ return array(
 	##
 
 	###
-	# Number results shown in the listings on pages in the namespaces Property,
-	# Type, and Concept. If a value of 0 is given, the respective listings are
-	# hidden completely.
+	# Number of results shown in the listings on pages in the Property and Concept
+	# namespaces as well as other services that require a limit.
 	#
-	# @since 0.7
-	##
-	'smwgTypePagingLimit' => 200,   // same number as for categories
-	'smwgPropertyPagingLimit' => 25, // use smaller value since property lists need more space
+	# If a value of 0 is given, the respective listings are hidden completely.
 	#
-	# @since 1.3
+	# - `type` used for `Special:Types` (was $smwgTypePagingLimit)
+	# - `errorlist` used for `Special:ProcessingErrorList`
+	# - `concept` (was $smwgConceptPagingLimit)
+	# - `property` (was $smwgPropertyPagingLimit)
+	#
+	# @since 3.0
 	##
-	'smwgConceptPagingLimit' => 200, // same number as for categories
+	'smwgPagingLimit' => [
+		'type' => 200,
+		'concept' => 200,
+		'property' => 20,
+		'errorlist' => 25,
+	],
 	##
 
 	###

--- a/includes/Settings.php
+++ b/includes/Settings.php
@@ -73,9 +73,7 @@ class Settings extends Options {
 			'smwgDefaultNumRecurringEvents' => $GLOBALS['smwgDefaultNumRecurringEvents'],
 			'smwgMaxNumRecurringEvents' => $GLOBALS['smwgMaxNumRecurringEvents'],
 			'smwgSearchByPropertyFuzzy' => $GLOBALS['smwgSearchByPropertyFuzzy'],
-			'smwgTypePagingLimit' => $GLOBALS['smwgTypePagingLimit'],
-			'smwgConceptPagingLimit' => $GLOBALS['smwgConceptPagingLimit'],
-			'smwgPropertyPagingLimit' => $GLOBALS['smwgPropertyPagingLimit'],
+			'smwgPagingLimit'  => $GLOBALS['smwgPagingLimit'],
 			'smwgPropertyListLimit' => $GLOBALS['smwgPropertyListLimit'],
 			'smwgQEnabled' => $GLOBALS['smwgQEnabled'],
 			'smwgQMaxLimit' => $GLOBALS['smwgQMaxLimit'],
@@ -473,6 +471,19 @@ class Settings extends Options {
 			$configuration['smwgEntityLookupFeatures'] = $GLOBALS['smwgValueLookupFeatures'];
 		}
 
+		// smwgPagingLimit
+		if ( isset( $GLOBALS['smwgTypePagingLimit'] ) ) {
+			$configuration['smwgPagingLimit']['type'] = $GLOBALS['smwgTypePagingLimit'];
+		}
+
+		if ( isset( $GLOBALS['smwgConceptPagingLimit'] ) ) {
+			$configuration['smwgPagingLimit']['concept'] = $GLOBALS['smwgConceptPagingLimit'];
+		}
+
+		if ( isset( $GLOBALS['smwgPropertyPagingLimit'] ) ) {
+			$configuration['smwgPagingLimit']['property'] = $GLOBALS['smwgPropertyPagingLimit'];
+		}
+
 		// Deprecated mapping used in DeprecationNoticeTaskHandler to detect and
 		// output notices
 		$GLOBALS['smwgDeprecationNotices'] = array(
@@ -498,6 +509,9 @@ class Settings extends Options {
 				'smwgQSortingSupport' => '3.1.0',
 				'smwgQRandSortingSupport' => '3.1.0',
 				'smwgLinksInValues' => '3.1.0',
+				'smwgTypePagingLimit'  => '3.1.0',
+				'smwgConceptPagingLimit'  => '3.1.0',
+				'smwgPropertyPagingLimit'  => '3.1.0',
 				'options' => [
 					'smwgCacheUsage' =>  [
 						'smwgStatisticsCache' => '3.1.0',
@@ -541,6 +555,9 @@ class Settings extends Options {
 				'smwgValueLookupCacheType' => 'smwgEntityLookupCacheType',
 				'smwgValueLookupCacheLifetime' => 'smwgEntityLookupCacheLifetime',
 				'smwgValueLookupFeatures' => 'smwgEntityLookupFeatures',
+				'smwgTypePagingLimit'  => 'smwgPagingLimit',
+				'smwgConceptPagingLimit'  => 'smwgPagingLimit',
+				'smwgPropertyPagingLimit'  => 'smwgPagingLimit',
 				'options' => [
 					'smwgCacheUsage' => [
 						'smwgStatisticsCacheExpiry' => 'special.statistics',

--- a/includes/specials/SMW_SpecialTypes.php
+++ b/includes/specials/SMW_SpecialTypes.php
@@ -78,9 +78,11 @@ class SMWSpecialTypes extends SpecialPage {
 	}
 
 	protected function getTypeProperties( $typeLabel ) {
-		global $wgRequest, $smwgTypePagingLimit;
+		global $wgRequest;
 
-		if ( $smwgTypePagingLimit <= 0 ) {
+		$pagingLimit = ApplicationFactory::getInstance()->getSettings()->dotGet( 'smwgPagingLimit.type' );
+
+		if ( $pagingLimit <= 0 ) {
 			return ''; // not too useful, but we comply to this request
 		}
 
@@ -95,7 +97,7 @@ class SMWSpecialTypes extends SpecialPage {
 		}
 
 		$store = \SMW\StoreFactory::getStore();
-		$options = SMWPageLister::getRequestOptions( $smwgTypePagingLimit, $from, $until );
+		$options = SMWPageLister::getRequestOptions( $pagingLimit, $from, $until );
 		$diWikiPages = $store->getPropertySubjects( new SMW\DIProperty( '_TYPE' ), $typeValue->getDataItem(), $options );
 
 		// May return an iterator
@@ -125,13 +127,13 @@ class SMWSpecialTypes extends SpecialPage {
 		);
 
 		if ( count( $diWikiPages ) > 0 ) {
-			$pageLister = new SMWPageLister( $diWikiPages, null, $smwgTypePagingLimit, $from, $until );
+			$pageLister = new SMWPageLister( $diWikiPages, null, $pagingLimit, $from, $until );
 
 			$title = $this->getTitleFor( 'Types', $typeLabel );
 			$title->setFragment( '#SMWResults' ); // Make navigation point to the result list.
 			$navigation = $pageLister->getNavigationLinks( $title );
 
-			$resultNumber = min( $smwgTypePagingLimit, count( $diWikiPages ) );
+			$resultNumber = min( $pagingLimit, count( $diWikiPages ) );
 			$typeName = $typeValue->getLongWikiText();
 
 			$result .= "<a name=\"SMWResults\"></a><div id=\"mw-pages\">\n" .

--- a/src/MediaWiki/Specials/SpecialProcessingErrorList.php
+++ b/src/MediaWiki/Specials/SpecialProcessingErrorList.php
@@ -28,7 +28,7 @@ class SpecialProcessingErrorList extends SpecialPage {
 	 */
 	public function execute( $query ) {
 
-		$limit = ApplicationFactory::getInstance()->getSettings()->get( 'smwgPropertyPagingLimit' );
+		$limit = ApplicationFactory::getInstance()->getSettings()->dotGet( 'smwgPagingLimit.errorlist' );
 
 		$this->getOutput()->redirect(
 			$this->getLocalAskRedirectUrl( $limit )

--- a/src/Page/ConceptPage.php
+++ b/src/Page/ConceptPage.php
@@ -40,7 +40,7 @@ class ConceptPage extends Page {
 	 * @note We use a smaller limit here; property pages might become large.
 	 */
 	protected function initParameters() {
-		$this->limit = $this->getOption( 'smwgConceptPagingLimit' );
+		$this->limit = $this->getOption( 'pagingLimit' );
 	}
 
 	/**
@@ -57,7 +57,7 @@ class ConceptPage extends Page {
 			$description = $descriptionFactory->newConceptDescription( $this->getDataItem() );
 			$query = \SMWPageLister::getQuery( $description, $this->limit, $this->from, $this->until );
 
-			$query->setLimit( $wgRequest->getVal( 'limit', $this->getOption( 'smwgConceptPagingLimit' ) ) );
+			$query->setLimit( $wgRequest->getVal( 'limit', $this->getOption( 'pagingLimit' ) ) );
 			$query->setOffset( $wgRequest->getVal( 'offset', '0' ) );
 			$query->setContextPage( $this->getDataItem() );
 			$query->setOption( $query::NO_DEPENDENCY_TRACE, true );
@@ -83,7 +83,7 @@ class ConceptPage extends Page {
 
 		$request = $this->getContext()->getRequest();
 
-		$limit = $request->getVal( 'limit', $this->getOption( 'smwgConceptPagingLimit' ) );
+		$limit = $request->getVal( 'limit', $this->getOption( 'pagingLimit' ) );
 		$offset = $request->getVal( 'offset', '0' );
 
 		$query = array(

--- a/src/Page/PageFactory.php
+++ b/src/Page/PageFactory.php
@@ -95,8 +95,8 @@ class PageFactory {
 		);
 
 		$propertyPage->setOption(
-			'smwgPropertyPagingLimit',
-			$settings->get( 'smwgPropertyPagingLimit' )
+			'pagingLimit',
+			$settings->dotGet( 'smwgPagingLimit.property' )
 		);
 
 		$propertyPage->setOption(
@@ -130,8 +130,8 @@ class PageFactory {
 		);
 
 		$conceptPage->setOption(
-			'smwgConceptPagingLimit',
-			$settings->get( 'smwgConceptPagingLimit' )
+			'pagingLimit',
+			$settings->dotGet( 'smwgPagingLimit.concept' )
 		);
 
 		return $conceptPage;

--- a/src/Page/PropertyPage.php
+++ b/src/Page/PropertyPage.php
@@ -68,7 +68,7 @@ class PropertyPage extends Page {
 	 */
 	protected function initParameters() {
 		// We use a smaller limit here; property pages might become large
-		$this->limit = $this->getOption( 'smwgPropertyPagingLimit' );
+		$this->limit = $this->getOption( 'pagingLimit' );
 		$this->property = DIProperty::newFromUserLabel( $this->getTitle()->getText() );
 		$this->propertyValue = DataValueFactory::getInstance()->newDataValueByItem( $this->property );
 	}
@@ -313,7 +313,7 @@ class PropertyPage extends Page {
 		);
 
 		$valueListBuilder->setPagingLimit(
-			$this->getOption( 'smwgPropertyPagingLimit' )
+			$this->getOption( 'pagingLimit' )
 		);
 
 		$valueListBuilder->setMaxPropertyValues(
@@ -324,7 +324,7 @@ class PropertyPage extends Page {
 			$this->property,
 			$this->getDataItem(),
 			[
-				'limit'  => $request->getVal( 'limit', $this->getOption( 'smwgPropertyPagingLimit' ) ),
+				'limit'  => $request->getVal( 'limit', $this->getOption( 'pagingLimit' ) ),
 				'offset' => $request->getVal( 'offset', '0' ),
 				'from'   => $request->getVal( 'from', '' ),
 				'until'  => $request->getVal( 'until', '' ),


### PR DESCRIPTION
This PR is made in reference to: #2798

This PR addresses or contains:

- Consolidates `$smwgTypePagingLimit`, `$smwgConceptPagingLimit`, and `$smwgPropertyPagingLimit` into one `$smwgPagingLimit` setting with default values of:

```
'smwgPagingLimit' => [
   'type' => 200,   // $smwgTypePagingLimit
   'concept' => 200, // $smwgConceptPagingLimit
   'property' => 20, // $smwgPropertyPagingLimit
   'errorlist' => 25, // `Special:ProcessingErrorList`
]
```

This PR includes:
- [ ] Tests (unit/integration)
- [x] CI build passed
