### PR TITLE
[ES] Use `filter` in ClassDescriptionInterpreter

### DIFF
--- a/src/Elastic/QueryEngine/DescriptionInterpreters/ClassDescriptionInterpreter.php
+++ b/src/Elastic/QueryEngine/DescriptionInterpreters/ClassDescriptionInterpreter.php
@@ -44,7 +44,7 @@ class ClassDescriptionInterpreter {
 		$dataItems = $description->getCategories();
 		$hierarchyDepth = $description->getHierarchyDepth();
 
-		$should = !$isConjunction;
+		$should = false;
 		$params = [];
 
 		// More than one member per list means OR

--- a/tests/phpunit/Integration/JSONScript/TestCases/q-1204.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/q-1204.json
@@ -3,6 +3,16 @@
 	"setup": [
 		{
 			"namespace": "NS_CATEGORY",
+			"page": "Q1204/1",
+			"contents": "[[Category:Q1204/0]]"
+		},
+		{
+			"namespace": "NS_CATEGORY",
+			"page": "Q1204/2",
+			"contents": "[[Category:Q1204/0]]"
+		},
+		{
+			"namespace": "NS_CATEGORY",
 			"page": "Q1204/1/1",
 			"contents": "[[Category:Q1204/1]]"
 		},
@@ -15,6 +25,10 @@
 			"namespace": "SMW_NS_PROPERTY",
 			"page": "Has page",
 			"contents": "[[Has type::Page]]"
+		},
+		{
+			"page": "Q1204/0",
+			"contents": "[[Category:Q1204/0]]"
 		},
 		{
 			"page": "Q1204/1",
@@ -146,6 +160,25 @@
 					"Q1204/1#0##",
 					"Q1204/3#0##",
 					"Q1204/4#0##"
+				]
+			}
+		},
+		{
+			"type": "query",
+			"about": "#6 (!Q1204/2)",
+			"skip-on": {
+				"elastic": [ "not", "Only works with ES out of the box." ]
+			},
+			"condition": "[[Category:Q1204/0]] [[Category:!Q1204/2]] ",
+			"printouts": [],
+			"parameters": {
+				"limit": "10"
+			},
+			"assert-queryresult": {
+				"count": 2,
+				"results": [
+					"Q1204/0#0##",
+					"Q1204/1#0##"
 				]
 			}
 		}

--- a/tests/phpunit/Unit/Elastic/QueryEngine/DescriptionInterpreters/ClassDescriptionInterpreterTest.php
+++ b/tests/phpunit/Unit/Elastic/QueryEngine/DescriptionInterpreters/ClassDescriptionInterpreterTest.php
@@ -73,7 +73,7 @@ class ClassDescriptionInterpreterTest extends \PHPUnit_Framework_TestCase {
 			$descriptionFactory->newClassDescription( $cat_foo ),
 			false,
 			[],
-			'{"bool":{"should":[{"term":{"P:42.wpgID":1001}}]}}'
+			'{"bool":{"filter":[{"term":{"P:42.wpgID":1001}}]}}'
 		];
 
 		yield [
@@ -106,7 +106,7 @@ class ClassDescriptionInterpreterTest extends \PHPUnit_Framework_TestCase {
 			$descriptionFactory->newClassDescription( $cat_foo ),
 			false,
 			[ 5000, 5001 ],
-			'{"bool":{"should":[{"bool":{"should":[{"term":{"P:42.wpgID":1001}},{"terms":{"P:42.wpgID":[5000,5001]}}]}}]}}'
+			'{"bool":{"filter":[{"bool":{"should":[{"term":{"P:42.wpgID":1001}},{"terms":{"P:42.wpgID":[5000,5001]}}]}}]}}'
 		];
 
 		yield [


### PR DESCRIPTION
This PR is made in reference to: #

This PR addresses or contains:

- Use `filter` [0] where possible 

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed

[0] https://www.elastic.co/guide/en/elasticsearch/reference/current/query-filter-context.html