### PR TITLE
[SMWSearch] SearchResult support display title

### DIFF
--- a/src/MediaWiki/Search/SearchResult.php
+++ b/src/MediaWiki/Search/SearchResult.php
@@ -2,6 +2,9 @@
 
 namespace SMW\MediaWiki\Search;
 
+use SMW\DataValueFactory;
+use SMW\DIWikiPage;
+
 /**
  * @ingroup SMW
  *
@@ -45,9 +48,16 @@ class SearchResult extends \SearchResult {
 	 */
 	public function getTitleSnippet() {
 
-		// Extend the title preferably using the DISPLAYTITLE if available!
+		if ( !isset( $this->mTitle ) ) {
+			return '';
+		}
 
-		return '';
+		$dataValue = DataValueFactory::getInstance()->newDataValueByItem(
+			DIWikiPage::newFromTitle( $this->mTitle )
+		);
+
+		// Will return the DISPLAYTITLE, if available
+		return $dataValue->getPreferredCaption();
 	}
 
 }

--- a/tests/phpunit/Unit/MediaWiki/Search/SearchResultTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Search/SearchResultTest.php
@@ -69,4 +69,30 @@ class SearchResultTest extends \PHPUnit_Framework_TestCase {
 		);
 	}
 
+	public function testGetTitleSnippet() {
+
+		$title = $this->getMockBuilder( '\Title' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$title->expects( $this->any() )
+			->method( 'getNamespace' )
+			->will( $this->returnValue( NS_MAIN ) );
+
+		$title->expects( $this->any() )
+			->method( 'getDBKey' )
+			->will( $this->returnValue( 'Foo' ) );
+
+		$title->expects( $this->any() )
+			->method( 'getFragment' )
+			->will( $this->returnValue( '' ) );
+
+		$instance = SearchResult::newFromTitle( $title );
+
+		$this->assertEquals(
+			'Foo',
+			$instance->getTitleSnippet()
+		);
+	}
+
 }


### PR DESCRIPTION
This PR is made in reference to: #

This PR addresses or contains:

- Shows the display title, if available 

This PR includes:
- [ ] Tests (unit/integration)
- [x] CI build passed
