### PR TITLE
[ES] Support ClassDescription in SomePropertyInterpreter

### DIFF
--- a/src/Elastic/QueryEngine/DescriptionInterpreters/SomePropertyInterpreter.php
+++ b/src/Elastic/QueryEngine/DescriptionInterpreters/SomePropertyInterpreter.php
@@ -14,6 +14,7 @@ use SMW\Query\Language\Disjunction;
 use SMW\Query\Language\SomeProperty;
 use SMW\Query\Language\ThingDescription;
 use SMW\Query\Language\ValueDescription;
+use SMW\Query\Language\ClassDescription;
 use SMWDataItem as DataItem;
 use SMWDIBlob as DIBlob;
 use SMWDIBoolean as DIBoolean;
@@ -115,6 +116,10 @@ class SomePropertyInterpreter {
 
 		if ( $params !== [] ) {
 			$params = $this->fieldMapper->hierarchy( $params, $pid, $hierarchy );
+		}
+
+		if ( $desc instanceof ClassDescription ) {
+			$params = $this->interpretClassDescription( $desc, $property, $pid, $field );
 		}
 
 		// [[-Person:: <q>[[Person.-Has friend.Person::Andy Mars]] [[Age::>>32]]</q> ]]
@@ -226,6 +231,33 @@ class SomePropertyInterpreter {
 
 		//$this->fieldMapper->bool( 'should', $p );
 		$condition = $this->conditionBuilder->newCondition( $p );
+
+		return $condition;
+	}
+
+	private function interpretClassDescription( $description, $property, $pid, $field ) {
+
+		$queryString = $description->getQueryString();
+		$condition = $this->conditionBuilder->interpretDescription( $description );
+
+		$parameters = $this->termsLookup->newParameters(
+			[
+				'query.string' => $queryString,
+				'field' => "$pid.wpgID",
+				'params' => $condition
+			]
+		);
+
+		$params = $this->termsLookup->lookup( 'predef', $parameters );
+		$this->conditionBuilder->addQueryInfo( $parameters->get( 'query.info' ) );
+
+		if ( $params === [] ) {
+			return [];
+		}
+
+		$condition = $this->conditionBuilder->newCondition( $params );
+		$condition->type( Condition::TYPE_MUST );
+		$condition->log( [ 'SomeProperty' => [ 'ClassDescription' => $queryString ] ] );
 
 		return $condition;
 	}

--- a/src/Elastic/QueryEngine/TermsLookup/TermsLookup.php
+++ b/src/Elastic/QueryEngine/TermsLookup/TermsLookup.php
@@ -189,7 +189,13 @@ class TermsLookup implements ITermsLookup {
 	public function predef_index_lookup( Parameters $parameters ) {
 
 		$id = $parameters->get( 'id' );
-		$query = $this->fieldMapper->bool( 'must', $parameters->get( 'params' ) );
+		$params = $parameters->get( 'params' );
+
+		if ( $params instanceof Condition ) {
+			$query = $params->toArray();
+		} else {
+			$query = $this->fieldMapper->bool( 'must', $params );
+		}
 
 		if ( $this->options->safeGet( 'subquery.constant.score', true ) ) {
 			$query = $this->fieldMapper->constant_score( $query );

--- a/tests/phpunit/Integration/JSONScript/TestCases/q-0620.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/q-0620.json
@@ -1,0 +1,134 @@
+{
+	"description": "Test `_wpg` and category using subquery construct",
+	"setup": [
+		{
+			"namespace": "SMW_NS_PROPERTY",
+			"page": "Has page",
+			"contents": "[[Has type::Page]]"
+		},
+		{
+			"namespace": "SMW_NS_PROPERTY",
+			"page": "Has page",
+			"contents": "[[Has type::Page]]"
+		},
+		{
+			"page": "Q0620/1",
+			"contents": "[[Has page::Q0620/1]] [[Category:Q0620]]"
+		},
+		{
+			"page": "Q0620/2",
+			"contents": "[[Category:Q0620]]"
+		},
+		{
+			"page": "Q0620/3",
+			"contents": "[[Has page::Q0620/1]]"
+		}
+	],
+	"tests": [
+		{
+			"type": "query",
+			"about": "#0 (match all with `Has page::Q0620/1`)",
+			"condition": "[[Has page::<q>[[Category:Q0620]]</q>]]",
+			"printouts": [],
+			"parameters": {
+				"limit": "10"
+			},
+			"assert-queryresult": {
+				"count": 2,
+				"results": [
+					"Q0620/1#0##",
+					"Q0620/3#0##"
+				]
+			}
+		},
+		{
+			"type": "query",
+			"about": "#1",
+			"condition": "[[Has page::<q>[[Category:Q0620]]</q>]] [[Category:Q0620]]",
+			"printouts": [],
+			"parameters": {
+				"limit": "10"
+			},
+			"assert-queryresult": {
+				"count": 1,
+				"results": [
+					"Q0620/1#0##"
+				]
+			}
+		},
+		{
+			"type": "query",
+			"about": "#2",
+			"condition": "[[Has page::<q>[[Has page::<q>[[Category:Q0620]]</q>]]</q>]]",
+			"printouts": [],
+			"parameters": {
+				"limit": "10"
+			},
+			"assert-queryresult": {
+				"count": 2,
+				"results": [
+					"Q0620/1#0##",
+					"Q0620/3#0##"
+				]
+			}
+		},
+		{
+			"type": "query",
+			"about": "#3",
+				"condition": "[[Has page::<q>[[Has page::<q>[[Category:Q0620]]</q>]]</q>]]",
+			"printouts": [],
+			"parameters": {
+				"limit": "10"
+			},
+			"assert-queryresult": {
+				"count": 2,
+				"results": [
+					"Q0620/1#0##",
+					"Q0620/3#0##"
+				]
+			}
+		},
+		{
+			"type": "query",
+			"about": "#4",
+			"condition": "[[Has page.Has page::<q>[[Category:Q0620]]</q>]]",
+			"printouts": [],
+			"parameters": {
+				"limit": "10"
+			},
+			"assert-queryresult": {
+				"count": 2,
+				"results": [
+					"Q0620/1#0##",
+					"Q0620/3#0##"
+				]
+			}
+		},
+		{
+			"type": "query",
+			"about": "#5",
+			"skip-on": {
+				"elastic": [ "not", "`Category:!` only works with ES." ]
+			},
+			"condition": "[[Has page::<q>[[Has page::<q>[[Category:Q0620]]</q>]]</q>]] [[Category:!Q0620]]",
+			"printouts": [],
+			"parameters": {
+				"limit": "10"
+			},
+			"assert-queryresult": {
+				"count": 1,
+				"results": [
+					"Q0620/3#0##"
+				]
+			}
+		}
+	],
+	"settings": {
+		"smwgQSubcategoryDepth": 10
+	},
+	"meta": {
+		"version": "2",
+		"is-incomplete": false,
+		"debug": false
+	}
+}


### PR DESCRIPTION
This PR is made in reference to: #

This PR addresses or contains:

- Adds support for `[[Has page::<q>[[Category:Q0620]]</q>]]`
- Adds an integration test for all stores (query construction was never tested before)

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed
