### PR TITLE
[SMWSearch] Return highlighted text, if available

### DIFF
--- a/src/Elastic/QueryEngine/Excerpts.php
+++ b/src/Elastic/QueryEngine/Excerpts.php
@@ -3,7 +3,6 @@
 namespace SMW\Elastic\QueryEngine;
 
 use SMW\DIWikiPage;
-use SMW\Query\Excerpts as QExcerpts;
 
 /**
  * @license GNU GPL v2+
@@ -11,7 +10,7 @@ use SMW\Query\Excerpts as QExcerpts;
  *
  * @author mwjames
  */
-class Excerpts extends QExcerpts {
+class Excerpts extends \SMW\Query\Excerpts {
 
 	/**
 	 * @since 3.0
@@ -33,6 +32,15 @@ class Excerpts extends QExcerpts {
 		}
 
 		return false;
+	}
+
+	/**
+	 * @since 3.0
+	 *
+	 * @return boolean
+	 */
+	public function hasHighlight() {
+		return true;
 	}
 
 	private function format( $v ) {

--- a/src/MediaWiki/Search/SearchResult.php
+++ b/src/MediaWiki/Search/SearchResult.php
@@ -16,6 +16,23 @@ use SMW\DIWikiPage;
 class SearchResult extends \SearchResult {
 
 	/**
+	 * @var boolean
+	 */
+	private $hasHighlight = false;
+
+	/**
+	 * @see SearchResult::getTextSnippet
+	 */
+	function getTextSnippet( $terms ) {
+
+		if ( $this->hasHighlight ) {
+			return str_replace( [ '<em>', '</em>' ], [ "<span class='searchmatch'>", '</span>' ], $this->mText );
+		}
+
+		return parent::getTextSnippet( $terms );
+	}
+
+	/**
 	 * @see SearchResult::getSectionTitle
 	 */
 	function getSectionTitle() {
@@ -31,9 +48,11 @@ class SearchResult extends \SearchResult {
 	 * Set a text excerpt retrieved from a different back-end.
 	 *
 	 * @param string $text|null
+	 * @param boolean $hasHighlight
 	 */
-	public function setExcerpt( $text = null ) {
+	public function setExcerpt( $text = null, $hasHighlight = false ) {
 		$this->mText = $text;
+		$this->hasHighlight = $hasHighlight;
 	}
 
 	/**
@@ -44,7 +63,7 @@ class SearchResult extends \SearchResult {
 	}
 
 	/**
-	 * @see SearchResult::getSectionTitle
+	 * @see SearchResult::getTitleSnippet
 	 */
 	public function getTitleSnippet() {
 

--- a/src/MediaWiki/Search/SearchResultSet.php
+++ b/src/MediaWiki/Search/SearchResultSet.php
@@ -72,10 +72,8 @@ class SearchResultSet extends \SearchResultSet {
 
 		// Attempt to use excerpts available from a different back-end
 		if ( $searchResult && $this->excerpts !== null ) {
-			$this->excerpts->noHighlight();
-
 			if ( ( $excerpt = $this->excerpts->getExcerpt( $page ) ) !== false ) {
-				$searchResult->setExcerpt( $excerpt );
+				$searchResult->setExcerpt( $excerpt, $this->excerpts->hasHighlight() );
 			}
 		}
 

--- a/src/Query/Excerpts.php
+++ b/src/Query/Excerpts.php
@@ -25,6 +25,11 @@ class Excerpts {
 	protected $noHighlight = false;
 
 	/**
+	 * @var boolean
+	 */
+	protected $hasHighlight = false;
+
+	/**
 	 * @since 3.0
 	 */
 	public function noHighlight() {
@@ -78,6 +83,15 @@ class Excerpts {
 	 */
 	public function getExcerpts() {
 		return $this->excerpts;
+	}
+
+	/**
+	 * @since 3.0
+	 *
+	 * @return boolean
+	 */
+	public function hasHighlight() {
+		return $this->hasHighlight;
 	}
 
 }

--- a/tests/phpunit/Unit/MediaWiki/Search/SearchResultTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Search/SearchResultTest.php
@@ -95,4 +95,36 @@ class SearchResultTest extends \PHPUnit_Framework_TestCase {
 		);
 	}
 
+	public function testGetTextSnippet_HasHighlight() {
+
+		$title = $this->getMockBuilder( '\Title' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$instance = SearchResult::newFromTitle( $title );
+
+		$instance->setExcerpt( '<em>Foo</em>bar', true );
+
+		$this->assertEquals(
+			"<span class='searchmatch'>Foo</span>bar",
+			$instance->getTextSnippet( [ 'Foo' ] )
+		);
+	}
+
+	public function testGetTextSnippet_NoHighlight() {
+
+		$title = $this->getMockBuilder( '\Title' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$instance = SearchResult::newFromTitle( $title );
+
+		$instance->setExcerpt( 'Foobar' );
+
+		$this->assertEquals(
+			"<span class='searchmatch'>Foo</span>bar\n",
+			$instance->getTextSnippet( [ 'Foo' ] )
+		);
+	}
+
 }


### PR DESCRIPTION
This PR is made in reference to: #

This PR addresses or contains:

- If ES (ElasticStore) is used then we are able to retrieve highlighted text excerpts without having to go through the MW `SearchEngine ` highlighter therefore provide the text as-is directly in `SearchResult::getTextSnippet`

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed
