### PR TITLE
[ES] Support NamespaceDescription in SomePropertyInterpreter

### DIFF
--- a/src/Elastic/QueryEngine/TermsLookup/CachingTermsLookup.php
+++ b/src/Elastic/QueryEngine/TermsLookup/CachingTermsLookup.php
@@ -4,6 +4,7 @@ namespace SMW\Elastic\QueryEngine\TermsLookup;
 
 use Onoi\Cache\Cache;
 use RuntimeException;
+use SMW\Elastic\QueryEngine\Condition;
 
 /**
  * @license GNU GPL v2+
@@ -177,7 +178,14 @@ class CachingTermsLookup extends TermsLookup {
 	 */
 	public function chain_lookup( Parameters $parameters ) {
 
-		$id = 'chain:' . md5( json_encode( $parameters->get( 'params' ) ) );
+		$params = $parameters->get( 'params' );
+
+		if ( $params instanceof Condition ) {
+			$id = 'chain:' . md5( $params->__toString() );
+		} else {
+			$id = 'chain:' . md5( json_encode( $params ) );
+		}
+
 		$parameters->set( 'id', $id );
 		$parameters->set( 'count', 0 );
 
@@ -243,7 +251,14 @@ class CachingTermsLookup extends TermsLookup {
 	 */
 	public function predef_lookup( Parameters $parameters ) {
 
-		$id = 'pre:' . md5( json_encode( $parameters->get( 'params' ) ) );
+		$params = $parameters->get( 'params' );
+
+		if ( $params instanceof Condition ) {
+			$id = 'pre:' . md5( $params->__toString() );
+		} else {
+			$id = 'pre:' . md5( json_encode( $params ) );
+		}
+
 		$parameters->set( 'id', $id );
 		$parameters->set( 'count', 0 );
 
@@ -304,7 +319,14 @@ class CachingTermsLookup extends TermsLookup {
 	 */
 	public function inverse_lookup( Parameters $parameters ) {
 
-		$id = 'inv:' . md5( json_encode( [ $parameters->get( 'field' ), $parameters->get( 'params' ) ] ) );
+		$params = $parameters->get( 'params' );
+
+		if ( $params instanceof Condition ) {
+			$id = 'inv:' . md5( $parameters->get( 'field' ) . $params->__toString() );
+		} else {
+			$id = 'inv:' . md5( json_encode( [ $parameters->get( 'field' ), $params ] ) );
+		}
+
 		$parameters->set( 'id', $id );
 		$parameters->set( 'count', 0 );
 

--- a/tests/phpunit/Integration/JSONScript/TestCases/q-0621.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/q-0621.json
@@ -1,0 +1,105 @@
+{
+	"description": "Test `_wpg` and namespace using subquery construct",
+	"setup": [
+		{
+			"namespace": "SMW_NS_PROPERTY",
+			"page": "Has page",
+			"contents": "[[Has type::Page]]"
+		},
+		{
+			"namespace": "NS_HELP",
+			"page": "Q0621",
+			"contents": "[[Has page::Q0621/1]] [[Category:Q0621]]"
+		},
+		{
+			"namespace": "NS_HELP",
+			"page": "Q0621/1",
+			"contents": "[[Has page::Q0621/2]] [[Category:Q0621]]"
+		},
+		{
+			"page": "Q0621/1",
+			"contents": "[[Has page::Help:Q0621]]"
+		},
+		{
+			"page": "Q0621/2",
+			"contents": "[[Has page::Q0621/2]] [[Category:Q0621/1]]"
+		}
+	],
+	"tests": [
+		{
+			"type": "query",
+			"about": "#0",
+			"condition": "[[Has page::<q>[[Help:+]]</q>]]",
+			"printouts": [],
+			"parameters": {
+				"limit": "10"
+			},
+			"assert-queryresult": {
+				"count": 1,
+				"results": [
+					"Q0621/1#0##"
+				]
+			}
+		},
+		{
+			"type": "query",
+			"about": "#1",
+			"condition": "[[Has page::<q>[[Help:+]] [[Has page::+]]</q>]]",
+			"printouts": [],
+			"parameters": {
+				"limit": "10"
+			},
+			"assert-queryresult": {
+				"count": 1,
+				"results": [
+					"Q0621/1#0##"
+				]
+			}
+		},
+		{
+			"type": "query",
+			"about": "#2",
+			"condition": "[[Has page::<q>[[Help:+]] [[Has page::+]] [[Category:Q0621]]</q>]]",
+			"printouts": [],
+			"parameters": {
+				"limit": "10"
+			},
+			"assert-queryresult": {
+				"count": 1,
+				"results": [
+					"Q0621/1#0##"
+				]
+			}
+		},
+		{
+			"type": "query",
+			"about": "#3",
+			"condition": "[[-Has page::<q>[[Help:+]] [[Has page::<q> [[Category:Q0621/1]]</q>]]</q>]]",
+			"printouts": [],
+			"parameters": {
+				"limit": "10"
+			},
+			"assert-queryresult": {
+				"count": 1,
+				"results": [
+					"Q0621/2#0##"
+				]
+			}
+		}
+	],
+	"settings": {
+		"smwgNamespacesWithSemanticLinks": {
+			"NS_MAIN": true,
+			"NS_CATEGORY": true,
+			"SMW_NS_PROPERTY": true,
+			"NS_HELP": true
+		},
+		"wgContLang": "en",
+		"wgLang": "en"
+	},
+	"meta": {
+		"version": "2",
+		"is-incomplete": false,
+		"debug": false
+	}
+}


### PR DESCRIPTION
This PR is made in reference to: #

This PR addresses or contains:

- Adds support for `[[Has page::<q>[[Help:+]]</q>]]`
- Adds an integration test for all stores as the condition construct hasn't been tested before

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed
