### PR TITLE
[ES] Add Aggregations, refs 3054

### DIFF
--- a/src/Elastic/QueryEngine/Aggregations.php
+++ b/src/Elastic/QueryEngine/Aggregations.php
@@ -1,0 +1,114 @@
+<?php
+
+namespace SMW\Elastic\QueryEngine;
+
+/**
+ * @license GNU GPL v2+
+ * @since 3.0
+ *
+ * @author mwjames
+ */
+class Aggregations {
+
+	/**
+	 * @var array
+	 */
+	private $parameters = [];
+
+	/**
+	 * @var array
+	 */
+	private $subAggregations = [];
+
+	/**
+	 * @var boolean
+	 */
+	private $plain = false;
+
+	/**
+	 * @since 3.0
+	 *
+	 * @param Aggregations|array $parameters
+	 */
+	public function __construct( $parameters = [] ) {
+		$this->parameters = $parameters;
+	}
+
+	/**
+	 * @since 3.0
+	 *
+	 * @param Aggregations $aggregations
+	 */
+	public function addSubAggregations( Aggregations $aggregations ) {
+		$this->subAggregations[] = $aggregations;
+	}
+
+	/**
+	 * @since 3.0
+	 */
+	public function plain() {
+		$this->plain = true;
+	}
+
+	/**
+	 * @since 3.0
+	 *
+	 * @return array
+	 */
+	public function toArray() {
+
+		$params = $this->params( $this->parameters );
+
+		foreach ( $this->subAggregations as $subAggregation ) {
+			foreach ( $params as $key => $value) {
+				$params[$key] += $subAggregation->toArray();
+			}
+		}
+
+		if ( $params === [] || $this->plain ) {
+			return $params;
+		}
+
+		return [ 'aggregations' => $params ];
+	}
+
+	private function params( &$params ) {
+
+		$aggregation = $params;
+
+		if ( $aggregation instanceof Aggregations ) {
+			$aggregation->plain();
+			$params = $aggregation->toArray();
+		}
+
+		if ( !is_array( $params ) ) {
+			return $params;
+		}
+
+		$p = [];
+
+		foreach ( $params as $k => $aggregation ) {
+			if ( $aggregation instanceof Aggregations ) {
+				$aggregation = $this->params( $aggregation );
+			}
+
+			if ( is_string( $k ) ) {
+				$p[$k] = $aggregation;
+			} else {
+				$p = array_merge( $p, $aggregation );
+			}
+		}
+
+		return $p;
+	}
+
+	/**
+	 * @since 3.0
+	 *
+	 * @return string
+	 */
+	public function __toString() {
+		return json_encode( $this->toArray() );
+	}
+
+}

--- a/src/Elastic/QueryEngine/FieldMapper.php
+++ b/src/Elastic/QueryEngine/FieldMapper.php
@@ -550,6 +550,86 @@ class FieldMapper {
 	}
 
 	/**
+	 * @see https://www.elastic.co/guide/en/elasticsearch/reference/6.2/search-aggregations.html
+	 *
+	 * @since 3.0
+	 *
+	 * @param string $field
+	 * @param mixed $value
+	 *
+	 * @return string
+	 */
+	public function aggs( $name, $params ) {
+		return [ 'aggregations' => [ "$name" => $params ] ];
+	}
+
+	/**
+	 * @see https://www.elastic.co/guide/en/elasticsearch/reference/6.2/search-aggregations-bucket-terms-aggregation.html
+	 *
+	 * @since 3.0
+	 *
+	 * @param string $field
+	 * @param mixed $value
+	 *
+	 * @return string
+	 */
+	public function aggs_terms( $key, $field, $params = [] ) {
+		return [ $key => [ 'terms' => [ "field" => $field ] + $params ] ];
+	}
+
+	/**
+	 * @see https://www.elastic.co/guide/en/elasticsearch/reference/6.2/search-aggregations-bucket-significantterms-aggregation.html
+	 *
+	 * Aggregation based on terms that have undergone a significant change in
+	 * popularity measured between a foreground and background set.
+	 *
+	 * @since 3.0
+	 *
+	 * @param string $field
+	 * @param mixed $value
+	 *
+	 * @return string
+	 */
+	public function aggs_significant_terms( $key, $field, $params = [] ) {
+		return [ $key => [ 'significant_terms' => [ "field" => $field ] + $params ] ];
+	}
+
+	/**
+	 * @see https://www.elastic.co/guide/en/elasticsearch/reference/6.2/search-aggregations-bucket-histogram-aggregation.html
+	 *
+	 * A multi-bucket values source based aggregation that can be applied on
+	 * numeric values extracted from the documents. It dynamically builds fixed
+	 * size (a.k.a. interval) buckets over the values.
+	 *
+	 * @since 3.0
+	 *
+	 * @param string $field
+	 * @param mixed $value
+	 *
+	 * @return string
+	 */
+	public static function aggs_histogram( $key, $field, $interval ) {
+		return [ $key => [ 'histogram' => [ "field" => $field, 'interval' => $interval ] ] ];
+	}
+
+	/**
+	 * @see https://www.elastic.co/guide/en/elasticsearch/reference/6.2/search-aggregations-bucket-datehistogram-aggregation.html
+	 *
+	 * A multi-bucket aggregation similar to the histogram except it can only be
+	 * applied on date values.
+	 *
+	 * @since 3.0
+	 *
+	 * @param string $field
+	 * @param mixed $value
+	 *
+	 * @return string
+	 */
+	public static function aggs_date_histogram( $key, $field, $interval ) {
+		return [ $key => [ 'date_histogram' => [ "field" => $field, 'interval' => $interval ] ] ];
+	}
+
+	/**
 	 * @since 3.0
 	 *
 	 * @param Condition|array $params

--- a/tests/phpunit/Unit/Elastic/QueryEngine/AggregationsTest.php
+++ b/tests/phpunit/Unit/Elastic/QueryEngine/AggregationsTest.php
@@ -1,0 +1,115 @@
+<?php
+
+namespace SMW\Tests\Elastic\QueryEngine;
+
+use SMW\Elastic\QueryEngine\Aggregations;
+use SMW\Elastic\QueryEngine\FieldMapper;
+
+/**
+ * @covers \SMW\Elastic\QueryEngine\Aggregations
+ * @group semantic-mediawiki
+ *
+ * @license GNU GPL v2+
+ * @since 3.0
+ *
+ * @author mwjames
+ */
+class AggregationsTest extends \PHPUnit_Framework_TestCase {
+
+	public function testCanConstruct() {
+
+		$this->assertInstanceOf(
+			Aggregations::class,
+			new Aggregations()
+		);
+	}
+
+	/**
+	 * @dataProvider parametersProvider
+	 */
+	public function testResolve( $parameters, $expected ) {
+
+		$instance = new Aggregations( $parameters );
+
+		$this->assertEquals(
+			$expected,
+			(string)$instance
+		);
+	}
+
+	public function parametersProvider() {
+
+		$fieldMapper = new FieldMapper();
+
+		yield [
+			[],
+			'[]'
+		];
+
+		yield [
+			$fieldMapper->aggs_terms( 'test_1', 'category' ),
+			'{"aggregations":{"test_1":{"terms":{"field":"category"}}}}'
+		];
+
+		yield [
+			$fieldMapper->aggs_terms( 'test_2', 'category', [ 'size' => 5 ] ),
+			'{"aggregations":{"test_2":{"terms":{"field":"category","size":5}}}}'
+		];
+
+		yield [
+			[
+				$fieldMapper->aggs_terms( 'test_1', 'foo' ),
+				$fieldMapper->aggs_terms( 'test_2', 'bar' )
+			],
+			'{"aggregations":{"test_1":{"terms":{"field":"foo"}},"test_2":{"terms":{"field":"bar"}}}}'
+		];
+
+		yield [
+			[
+				new Aggregations( $fieldMapper->aggs_terms( 'test_1', 'foo' ) ),
+				new Aggregations( $fieldMapper->aggs_terms( 'test_2', 'bar' ) )
+			],
+			'{"aggregations":{"test_1":{"terms":{"field":"foo"}},"test_2":{"terms":{"field":"bar"}}}}'
+		];
+
+		// https://www.elastic.co/blog/intro-to-Aggregations-pt-2-sub-Aggregations
+		$aggs = new Aggregations(
+			$fieldMapper->aggs_terms( 'all_boroughs', 'borough' )
+		);
+
+		$aggs->addSubAggregations(
+			new Aggregations(
+				$fieldMapper->aggs_terms( 'cause', 'contributing_factor_vehicle', [ 'size' => 3 ] )
+			)
+		);
+
+		yield [
+			$aggs,
+			'{"aggregations":{"all_boroughs":{"terms":{"field":"borough"},"aggregations":{"cause":{"terms":{"field":"contributing_factor_vehicle","size":3}}}}}}'
+		];
+
+		$cause = new Aggregations(
+			$fieldMapper->aggs_terms( 'cause', 'contributing_factor_vehicle', [ 'size' => 3 ] )
+		);
+
+		$cause->addSubAggregations(
+			new Aggregations(
+				$fieldMapper->aggs_date_histogram( 'incidents_per_month', '@timestamp', 'month' )
+			)
+		);
+
+		$aggs = new Aggregations(
+			$fieldMapper->aggs_terms( 'all_boroughs', 'borough' )
+		);
+
+		$aggs->addSubAggregations(
+			$cause
+		);
+
+		yield [
+			$aggs,
+			'{"aggregations":{"all_boroughs":{"terms":{"field":"borough"},"aggregations":{"cause":{"terms":{"field":"contributing_factor_vehicle","size":3},"aggregations":{"incidents_per_month":{"date_histogram":{"field":"@timestamp","interval":"month"}}}}}}}}'
+		];
+	}
+
+}

--- a/tests/phpunit/Unit/Elastic/QueryEngine/FieldMapperTest.php
+++ b/tests/phpunit/Unit/Elastic/QueryEngine/FieldMapperTest.php
@@ -45,4 +45,50 @@ class FieldMapperTest extends \PHPUnit_Framework_TestCase {
 		);
 	}
 
+	/**
+	 * @dataProvider aggregationsProvider
+	 */
+	public function testAggregations( $method, $params, $expected ) {
+
+		$instance = new FieldMapper();
+
+		$this->assertEquals(
+			$expected,
+			call_user_func_array( [ $instance, $method ], $params )
+		);
+	}
+
+	public function aggregationsProvider() {
+
+		yield [
+			'aggs',
+			[ 'Foo', 'bar' ],
+			[ 'aggregations' => [ "Foo" => 'bar' ] ]
+		];
+
+		yield [
+			'aggs_terms',
+			[ 'Foo', 'bar', [] ],
+			[ 'Foo' => [ 'terms' => [ "field" => 'bar' ] ] ]
+		];
+
+		yield [
+			'aggs_significant_terms',
+			[ 'Foo', 'bar', [] ],
+			[ 'Foo' => [ 'significant_terms' => [ "field" => 'bar' ] ] ]
+		];
+
+		yield [
+			'aggs_histogram',
+			[ 'Foo', 'bar', 100 ],
+			[ 'Foo' => [ 'histogram' => [ "field" => 'bar', 'interval' => 100 ] ] ]
+		];
+
+		yield [
+			'aggs_date_histogram',
+			[ 'Foo', 'bar', 100 ],
+			[ 'Foo' => [ 'date_histogram' => [ "field" => 'bar', 'interval' => 100 ] ] ]
+		];
+	}
+
 }


### PR DESCRIPTION
This PR is made in reference to: #3054

This PR addresses or contains:

- Adds `Aggregations` to support ES aggregations at a later point to help create facet browsing or other filtered results

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed
