### PR TITLE
Localizer avoid a "MWUnknownContentModelException ... " when content model is unknown

### DIFF
--- a/src/Localizer.php
+++ b/src/Localizer.php
@@ -149,7 +149,14 @@ class Localizer {
 		// then we assume that an explicit language object was given otherwise
 		// the Title is using the content language as fallback
 		if ( $title instanceof Title ) {
-			$language = $title->getPageLanguage();
+
+			// Avoid "MWUnknownContentModelException ... " when content model
+			// is not registered
+			try {
+				$language = $title->getPageLanguage();
+			} catch ( \Exception $e ) {
+
+			}
 		}
 
 		return $language instanceof Language ? $language : $this->getContentLanguage();


### PR DESCRIPTION
This PR is made in reference to: #

This PR addresses or contains:

- Normally `Title::getPageLanguage` shouldn't throw an exception but it does so we try/catch any exception (`MWUnknownContentModelException`) since there is nothing we can do at this point when a content model isn't registered.

This PR includes:
- [ ] Tests (unit/integration)
- [x] CI build passed

```
79ebe530931ecb1b1a1d1825] /.../index.php?title=Special:Ask&q=%5B%5BHas+processing+error+text%3A%3A%2B%5D%5D&po=%3FHas+improper+value+for%7C%3FHas+processing+error+text&p=class%3Dsortable-20wikitable-20smwtable-2Dstriped&eq=no&limit=5&bTitle=processingerrorlist&bMsg=smw-processingerrorlist-intro MWUnknownContentModelException from line 306 of ...\includes\content\ContentHandler.php: The content model 'rule/json' is not registered on this wiki.
See https://www.mediawiki.org/wiki/Content_handlers to find out which extensions handle this content model.

Backtrace:

#0 ...\includes\content\ContentHandler.php(243): ContentHandler::getForModelID(string)
#1 ...\includes\Title.php(4746): ContentHandler::getForTitle(Title)
#2 ...\extensions\SemanticMediaWiki\src\Localizer.php(152): Title->getPageLanguage()
#3 ...\extensions\SemanticMediaWiki\includes\datavalues\SMW_DataValue.php(299): SMW\Localizer->getPreferredContentLanguage(Title)
#4 ...\extensions\SemanticMediaWiki\includes\storage\SMW_ResultArray.php(219): SMWDataValue->setContextPage(SMW\DIWikiPage)
#5 ...\extensions\SemanticMediaWiki\src\Query\ResultPrinters\TableResultPrinter.php(227): SMWResultArray->getNextDataValue()
#6 ...\extensions\SemanticMediaWiki\src\Query\ResultPrinters\TableResultPrinter.php(208): SMW\Query\ResultPrinters\TableResultPrinter->getCellForPropVals(SMWResultArray, integer, string)
#7 ...\extensions\SemanticMediaWiki\src\Query\ResultPrinters\TableResultPrinter.php(130): SMW\Query\ResultPrinters\TableResultPrinter->getRowForSubject(array, integer, array)
#8 ...\extensions\SemanticMediaWiki\src\Query\ResultPrinters\ResultPrinter.php(334): SMW\Query\ResultPrinters\TableResultPrinter->getResultText(SMWQueryResult, integer)
#9 ...\extensions\SemanticMediaWiki\src\Query\ResultPrinters\ResultPrinter.php(299): SMW\Query\ResultPrinters\ResultPrinter->buildResult(SMWQueryResult)
#10 ...\extensions\SemanticMediaWiki\src\MediaWiki\Specials\SpecialAsk.php(316): SMW\Query\ResultPrinters\ResultPrinter->getResult(SMWQueryResult, array, integer)
#11 ...\extensions\SemanticMediaWiki\src\MediaWiki\Specials\SpecialAsk.php(149): SMW\MediaWiki\Specials\SpecialAsk->makeHTMLResult()
#12 ...\includes\specialpage\SpecialPage.php(522): SMW\MediaWiki\Specials\SpecialAsk->execute(NULL)
#13 ...\includes\specialpage\SpecialPageFactory.php(578): SpecialPage->run(NULL)
#14 ...\includes\MediaWiki.php(287): SpecialPageFactory::executePath(Title, RequestContext)
#15 ...\includes\MediaWiki.php(862): MediaWiki->performRequest()
#16 ...\includes\MediaWiki.php(523): MediaWiki->main()
#17 ...\index.php(43): MediaWiki->run()
#18 {main}
```