### PR TITLE
Add DataItemHandler::getIndexHint, refs 3142

### DIFF
--- a/DefaultSettings.php
+++ b/DefaultSettings.php
@@ -77,7 +77,7 @@ return array(
 	#
 	# @since 3.0
 	##
-	'smwgUpgradeKey' => 'DB-2018-04.1',
+	'smwgUpgradeKey' => 'DB-2018-07',
 	##
 
 	###

--- a/src/SQLStore/EntityStore/DIHandlers/DIGeoCoordinateHandler.php
+++ b/src/SQLStore/EntityStore/DIHandlers/DIGeoCoordinateHandler.php
@@ -59,7 +59,10 @@ class DIGeoCoordinateHandler extends DataItemHandler {
 	 * {@inheritDoc}
 	 */
 	public function getTableIndexes() {
-		return array( 'o_lat,o_lon' );
+		return array(
+			'p_id,o_serialized',
+			'o_lat,o_lon'
+		);
 	}
 
 	/**

--- a/src/SQLStore/EntityStore/DIHandlers/DITimeHandler.php
+++ b/src/SQLStore/EntityStore/DIHandlers/DITimeHandler.php
@@ -51,6 +51,7 @@ class DITimeHandler extends DataItemHandler {
 
 			// API module pvalue lookup
 			'p_id,o_serialized',
+			'p_id,o_sortkey',
 
 			// SMWSQLStore3Readers::fetchSemanticData
 			// SELECT p.smw_title as prop,o_serialized AS v0, o_sortkey AS v2
@@ -60,6 +61,20 @@ class DITimeHandler extends DataItemHandler {
 			// o_id=o0.smw_id WHERE s_id='104322'
 			's_id,p_id,o_sortkey,o_serialized',
 		);
+	}
+
+	/**
+	 * @since 3.0
+	 *
+	 * {@inheritDoc}
+	 */
+	public function getIndexHint( $key ) {
+
+		if ( 'property.subjects' && $this->isDbType( 'mysql' ) ) {
+			return 's_id';
+		}
+
+		return '';
 	}
 
 	/**

--- a/src/SQLStore/EntityStore/DIHandlers/DIUriHandler.php
+++ b/src/SQLStore/EntityStore/DIHandlers/DIUriHandler.php
@@ -47,6 +47,49 @@ class DIUriHandler extends DataItemHandler {
 	 *
 	 * {@inheritDoc}
 	 */
+	public function getTableIndexes() {
+		return [
+			'p_id,o_serialized',
+		];
+	}
+
+	/**
+	 * @since 3.0
+	 *
+	 * {@inheritDoc}
+	 */
+	public function getIndexHint( $key ) {
+
+		// SELECT smw_id, smw_title, smw_namespace, smw_iw, smw_subobject, smw_sortkey, smw_sort
+		// FROM `smw_object_ids`
+		// INNER JOIN `smw_di_uri` AS t1
+		// FORCE INDEX(s_id) ON t1.s_id=smw_id
+		// WHERE t1.p_id='310165' AND smw_iw!=':smw' AND smw_iw!=':smw-delete' AND smw_iw!=':smw-redi'
+		// GROUP BY smw_sort, smw_id LIMIT 26
+		//
+		// 606.8370ms SMWSQLStore3Readers::getPropertySubjects
+		//
+		// vs.
+		//
+		// SELECT smw_id, smw_title, smw_namespace, smw_iw, smw_subobject, smw_sortkey, smw_sort
+		// FROM `smw_object_ids`
+		// INNER JOIN `smw_di_uri` AS t1 ON t1.s_id=smw_id
+		// WHERE t1.p_id='310165' AND smw_iw!=':smw' AND smw_iw!=':smw-delete' AND smw_iw!=':smw-redi'
+		// GROUP BY smw_sort, smw_id LIMIT 26
+		//
+		// 8052.2099ms SMWSQLStore3Readers::getPropertySubjects
+		if ( 'property.subjects' && $this->isDbType( 'mysql' ) ) {
+			return 's_id';
+		}
+
+		return '';
+	}
+
+	/**
+	 * @since 1.8
+	 *
+	 * {@inheritDoc}
+	 */
 	public function getWhereConds( DataItem $dataItem ) {
 		return array( 'o_serialized' => rawurldecode( $dataItem->getSerialization() ) );
 	}

--- a/src/SQLStore/EntityStore/DIHandlers/DIWikiPageHandler.php
+++ b/src/SQLStore/EntityStore/DIHandlers/DIWikiPageHandler.php
@@ -54,6 +54,9 @@ class DIWikiPageHandler extends DataItemHandler {
 		return array(
 			'o_id',
 
+			// SMWSQLStore3Readers::getPropertySubjects
+			'p_id,s_id',
+
 			// SMWSQLStore3Readers::fetchSemanticData
 			// ... FROM `smw_fpt_sobj` INNER JOIN `smw_object_ids` AS o0 ON
 			// o_id=o0.smw_id WHERE s_id='104322'
@@ -72,9 +75,6 @@ class DIWikiPageHandler extends DataItemHandler {
 
 			// QueryEngine::getInstanceQueryResult
 			//'p_id,o_id,s_sort',
-
-			// SMWSQLStore3Readers::getPropertySubjects
-			//'p_id,s_sort,s_id',
 
 			// SMWSQLStore3Readers::getPropertySubjects
 			// SELECT DISTINCT s_id FROM `smw_fpt_sobj` ORDER BY s_sort

--- a/src/SQLStore/EntityStore/DataItemHandler.php
+++ b/src/SQLStore/EntityStore/DataItemHandler.php
@@ -122,6 +122,19 @@ abstract class DataItemHandler {
 	}
 
 	/**
+	 * Provides a possibility to return a specific index hint for a domain.
+	 *
+	 * @since 3.0
+	 *
+	 * @param string $key
+	 *
+	 * @return string
+	 */
+	public function getIndexHint( $key ) {
+		return '';
+	}
+
+	/**
 	 * Return an array of fields=>values to conditions (WHERE part) in SQL
 	 * queries for the given DataItem. This method can return fewer
 	 * fields than getInstertValues as long as they are enough to identify

--- a/src/SQLStore/TableSchemaManager.php
+++ b/src/SQLStore/TableSchemaManager.php
@@ -180,9 +180,8 @@ class TableSchemaManager {
 		$table->addIndex( 'smw_sort,smw_id' );
 
 		// API smwbrowse primary lookup
-		// Limit the index length for MySQL (only 1000 Bytes are allowed)
-		// https://stackoverflow.com/questions/3489041/mysqlerror-specified-key-was-too-long-max-key-length-is-1000-bytes
-		$table->addIndex( 'smw_namespace,smw_iw,smw_sort(220),smw_sortkey(220),smw_id' );
+		// SMW\MediaWiki\Api\Browse\ListLookup::fetchFromTable
+		$table->addIndex( 'smw_namespace,smw_sortkey' );
 
 		// Interfered with the API lookup index, couldn't find a use case
 		// that would require the this index
@@ -292,15 +291,6 @@ class TableSchemaManager {
 
 		if ( !$propertyTable->isFixedPropertyTable() ) {
 			$fieldarray['p_id'] = array( FieldType::FIELD_ID, 'NOT NULL' );
-
-			// In order to find the right index for the blob related tables,
-			// individual index declared in the table method
-			if ( strpos( $indexes['po'] , 'o_hash' ) === false ) {
-				$indexes['po'] = 'p_id,' . $indexes['po'];
-			} else {
-				$indexes['p'] = 'p_id';
-			}
-
 			$indexes['sp'] = $indexes['sp'] . ',p_id';
 		}
 


### PR DESCRIPTION
This PR is made in reference to: #3142 

This PR addresses or contains:

- Provide a index hint on those queries that showed an irregular behaviour due to the query planner to choose an sup-optimal query.

This PR includes:
- [ ] Tests (unit/integration)
- [x] CI build passed

### Example

```
// SELECT smw_id, smw_title, smw_namespace, smw_iw, smw_subobject, smw_sortkey, smw_sort
// FROM `smw_object_ids`
// INNER JOIN `smw_di_blob` AS t1 FORCE INDEX(s_id) ON t1.s_id=smw_id
// WHERE t1.p_id='310174' AND smw_iw!=':smw'
// AND smw_iw!=':smw-delete' AND smw_iw!=':smw-redi'
// GROUP BY smw_sort, smw_id LIMIT 26
//
// 137.4161ms SMWSQLStore3Readers::getPropertySubjects
//
// vs.
//
// SELECT smw_id, smw_title, smw_namespace, smw_iw, smw_subobject, smw_sortkey, smw_sort
// FROM `smw_object_ids`
// INNER JOIN `smw_di_blob` AS t1 ON t1.s_id=smw_id
// WHERE t1.p_id='310174' AND smw_iw!=':smw' AND smw_iw!=':smw-delete'
// AND smw_iw!=':smw-redi'
// GROUP BY smw_sort, smw_id LIMIT 26
//
// 23482.1451ms SMWSQLStore3Readers::getPropertySubjects
```

```
// SELECT smw_id, smw_title, smw_namespace, smw_iw, smw_subobject, smw_sortkey, smw_sort
// FROM `smw_object_ids` INNER JOIN `smw_di_number` AS t1 FORCE INDEX(s_id) ON t1.s_id=smw_id
// WHERE t1.p_id='310194' AND smw_iw!=':smw' AND smw_iw!=':smw-delete' AND smw_iw!=':smw-redi'
// GROUP BY smw_sort, smw_id
// LIMIT 26
//
// 584.9450ms SMWSQLStore3Readers::getPropertySubjects
//
// vs.
//
// SELECT smw_id, smw_title, smw_namespace, smw_iw, smw_subobject, smw_sortkey, smw_sort
// FROM `smw_object_ids`
// INNER JOIN `smw_di_number` AS t1 ON t1.s_id=smw_id
// WHERE t1.p_id='310194' AND smw_iw!=':smw' AND smw_iw!=':smw-delete' AND smw_iw!=':smw-redi'
// GROUP BY smw_sort, smw_id
// LIMIT 26
//
// 21448.2622ms	SMWSQLStore3Readers::getPropertySubjects
```