### PR TITLE
Move SMWSQLStore3Readers::getPropertySubjects to PropertySubjectsLookup

### DIFF
--- a/src/SQLStore/EntityStore/PropertySubjectsLookup.php
+++ b/src/SQLStore/EntityStore/PropertySubjectsLookup.php
@@ -1,0 +1,261 @@
+<?php
+
+namespace SMW\SQLStore\EntityStore;
+
+use SMW\SQLStore\SQLStore;
+use SMW\SQLStore\PropertyTableDefinition as TableDefinition;
+use SMWDataItem as DataItem;
+use SMW\DIContainer;
+use SMW\RequestOptions;
+use SMW\Options;
+use SMW\MediaWiki\DatabaseHelper;
+use SMW\ApplicationFactory;
+use SMW\SQLStore\RequestOptionsProc;
+use RuntimeException;
+
+/**
+ * @license GNU GPL v2
+ * @since 3.0
+ *
+ * @author mwjames
+ */
+class PropertySubjectsLookup {
+
+	/**
+	 * @var SQLStore
+	 */
+	private $store;
+
+	/**
+	 * @var IteratorFactory
+	 */
+	private $iteratorFactory;
+
+	/**
+	 * @var Options
+	 */
+	private $options;
+
+	/**
+	 * @var DataItemHandler
+	 */
+	private $dataItemHandler;
+
+	/**
+	 * @since 3.0
+	 *
+	 * @param SQLStore $store
+	 */
+	public function __construct( SQLStore $store ) {
+		$this->store = $store;
+		$this->iteratorFactory = ApplicationFactory::getInstance()->getIteratorFactory();
+	}
+
+	/**
+	 * @see Store::getPropertySubjects
+	 *
+	 * @since 3.0
+	 *
+	 * {@inheritDoc}
+	 */
+	public function fetchFromTable( $pid, TableDefinition $proptable, DataItem $dataItem = null, RequestOptions $requestOptions = null ) {
+
+		$connection = $this->store->getConnection( 'mw.db' );
+		$group = false;
+
+		$dataItemHandler = $this->store->getDataItemHandlerForDIType(
+			$proptable->getDiType()
+		);
+
+		$sortField = $dataItemHandler->getSortField();
+		$query = $connection->newQuery();
+		$query->type( 'SELECT' );
+
+		if ( $requestOptions === null ) {
+			$requestOptions = new RequestOptions();
+		} else{
+			// Clone a `RequestOptions` instance so that it can be modified freely
+			// for the current request without a possible interference on an
+			// upcoming request (as in case where it is called from within a loop
+			// with the same initial RequestOptions instance)
+			$requestOptions = clone $requestOptions;
+		}
+
+		if ( $sortField === '' ) {
+			$sortField = 'smw_sort';
+		}
+
+		$index = '';
+
+		// For certain tables (blob) the query planner chooses a suboptimal plan
+		// and causes an unacceptable query time therefore force an index for
+		// those tables where the behaviour has been observed.
+		if ( $dataItemHandler->getIndexHint( 'property.subjects' ) !== '' && $dataItem === null ) {
+			$index = 'FORCE INDEX(' . $dataItemHandler->getIndexHint( 'property.subjects' ) . ')';
+		}
+
+		$result = [];
+
+		if ( $proptable->usesIdSubject() ) {
+			$group = true;
+
+			$query->table( SQLStore::ID_TABLE );
+
+			$query->join(
+				'INNER JOIN',
+				[ $proptable->getName() => "t1 $index ON t1.s_id=smw_id" ]
+			);
+
+			$query->fields(
+				[
+					'smw_id',
+					'smw_title',
+					'smw_namespace',
+					'smw_iw',
+					'smw_subobject',
+					'smw_sortkey',
+					'smw_sort'
+				]
+			);
+
+		} else { // no join needed, title+namespace as given in proptable
+			$query->table( $proptable->getName(), "t1" );
+
+			$query->fields(
+				[
+					's_title AS smw_title',
+					's_namespace AS smw_namespace',
+					'\'\' AS smw_iw',
+					'\'\' AS smw_subobject',
+					's_title AS smw_sortkey',
+					's_title AS smw_sort'
+				]
+			);
+
+			$requestOptions->setOption( 'ORDER BY', false );
+		}
+
+		if ( !$proptable->isFixedPropertyTable() ) {
+			$query->condition( $query->eq( "t1.p_id", $pid ) );
+		}
+
+		$this->getWhereConds( $query, $dataItem );
+
+		if ( $proptable->usesIdSubject() ) {
+			foreach ( [ SMW_SQL3_SMWIW_OUTDATED, SMW_SQL3_SMWDELETEIW, SMW_SQL3_SMWREDIIW ] as $v ) {
+				$query->condition( $query->neq( "smw_iw", $v ) );
+			}
+		}
+
+		if ( $group && $connection->isType( 'postgres') ) {
+			// Avoid a "... 42803 ERROR:  column "s....smw_title" must appear in
+			// the GROUP BY clause or be used in an aggregate function ..."
+			// https://stackoverflow.com/questions/1769361/postgresql-group-by-different-from-mysql
+			$requestOptions->setOption( 'DISTINCT', 'ON (smw_sort, smw_id)' );
+			$requestOptions->setOption( 'ORDER BY', false );
+		} elseif ( $group ) {
+			// Using GROUP BY will sort on the field and since we disinguish smw_sort
+			// and the ID at the end of the field, we ensure
+			// the filter duplicates while sorting the list without using DISTINCT which
+			// would cause a filesort
+			// http://www.mysqltutorial.org/mysql-distinct.aspx
+			$requestOptions->setOption( 'GROUP BY', $sortField . ', smw_id' );
+			$requestOptions->setOption( 'ORDER BY', false );
+		} else {
+			$requestOptions->setOption( 'DISTINCT', true );
+		}
+
+		$cond = $this->store->getSQLConditions(
+			$requestOptions,
+			'smw_sortkey',
+			'smw_sortkey',
+			false
+		);
+
+		$query->condition( $cond );
+
+		$opts = $this->store->getSQLOptions(
+			$requestOptions,
+			$sortField
+		);
+
+		$query->options( $opts );
+
+		$res = $connection->query(
+			$query,
+			__METHOD__
+		);
+
+		$this->dataItemHandler = $this->store->getDataItemHandlerForDIType(
+			DataItem::TYPE_WIKIPAGE
+		);
+
+		// Return an iterator and avoid resolving the resources directly as it
+		// may contain a large list of possible matches
+		$res = $this->iteratorFactory->newMappingIterator(
+			$this->iteratorFactory->newResultIterator( $res ),
+			[ $this, 'newFromRow' ]
+		);
+
+		return $res;
+	}
+
+	/**
+	 * @since 3.0
+	 *
+	 * @param stdClass $row
+	 *
+	 * @return DIWikiPage
+	 */
+	public function newFromRow( $row ) {
+
+		try {
+			if ( $row->smw_iw === '' || $row->smw_iw{0} != ':' ) { // filter special objects
+
+				$keys = [
+					$row->smw_title,
+					$row->smw_namespace,
+					$row->smw_iw,
+					$row->smw_sort,
+					$row->smw_subobject
+
+				];
+
+				$dataItem = $this->dataItemHandler->dataItemFromDBKeys( $keys );
+
+				if ( isset( $row->smw_id ) ) {
+					$dataItem->setId( $row->smw_id );
+				}
+
+				return $dataItem;
+			}
+		} catch ( DataItemHandlerException $e ) {
+			// silently drop data, should be extremely rare and will usually fix itself at next edit
+		}
+
+		$title = ( $row->smw_title !== '' ? $row->smw_title : 'Empty' ) . '/' . $row->smw_namespace;
+
+		// Avoid null return in Iterator
+		return $this->dataItemHandler->dataItemFromDBKeys( [ 'Blankpage/' . $title, NS_SPECIAL, '', '', '' ] );
+	}
+
+	private function getWhereConds( $query, $dataItem ) {
+
+		$conds = '';
+
+		if ( $dataItem instanceof \SMWDIContainer ) {
+			throw new RuntimeException( 'SMWDIContainer support is missing!');
+		}
+
+		if ( $dataItem !== null ) {
+			$dataItemHandler = $this->store->getDataItemHandlerForDIType(
+				$dataItem->getDIType()
+			);
+
+			foreach ( $dataItemHandler->getWhereConds( $dataItem ) as $fieldname => $value ) {
+				$query->condition( $query->eq( "t1.$fieldname", $value ) );
+			}
+		}
+	}
+
+}

--- a/src/SQLStore/SQLStoreFactory.php
+++ b/src/SQLStore/SQLStoreFactory.php
@@ -21,6 +21,7 @@ use SMW\SQLStore\EntityStore\NativeEntityLookup;
 use SMW\SQLStore\EntityStore\SemanticDataLookup;
 use SMW\SQLStore\EntityStore\SubobjectListFinder;
 use SMW\SQLStore\EntityStore\TraversalPropertyLookup;
+use SMW\SQLStore\EntityStore\PropertySubjectsLookup;
 use SMW\SQLStore\Lookup\CachedListLookup;
 use SMW\SQLStore\Lookup\ListLookup;
 use SMW\SQLStore\Lookup\PropertyUsageListLookup;
@@ -466,6 +467,15 @@ class SQLStoreFactory {
 		);
 
 		return new TraversalPropertyLookup( $this->store, $options );
+	}
+
+	/**
+	 * @since 3.0
+	 *
+	 * @return PropertySubjectsLookup
+	 */
+	public function newPropertySubjectsLookup() {
+		return new PropertySubjectsLookup( $this->store );
 	}
 
 	/**

--- a/tests/phpunit/Unit/SQLStore/EntityStore/PropertySubjectsLookupTest.php
+++ b/tests/phpunit/Unit/SQLStore/EntityStore/PropertySubjectsLookupTest.php
@@ -1,0 +1,156 @@
+<?php
+
+namespace SMW\Tests\SQLStore\EntityStore;
+
+use SMW\DIWikiPage;
+use SMW\Options;
+use SMW\SQLStore\EntityStore\PropertySubjectsLookup;
+
+/**
+ * @covers \SMW\SQLStore\EntityStore\PropertySubjectsLookup
+ * @group semantic-mediawiki
+ *
+ * @license GNU GPL v2+
+ * @since 3.0
+ *
+ * @author mwjames
+ */
+class PropertySubjectsLookupTest extends \PHPUnit_Framework_TestCase {
+
+	public function testCanConstruct() {
+
+		$store = $this->getMockBuilder( '\SMW\SQLStore\SQLStore' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$this->assertInstanceOf(
+			PropertySubjectsLookup::class,
+			new PropertySubjectsLookup( $store )
+		);
+	}
+
+	public function testLookupForNonFixedPropertyTable() {
+
+		$dataItem = DIWikiPage::newFromText( __METHOD__ );
+
+		$dataItemHandler = $this->getMockBuilder( '\SMW\SQLStore\EntityStore\DataItemHandler' )
+			->disableOriginalConstructor()
+			->getMockForAbstractClass();
+
+		$dataItemHandler->expects( $this->atLeastOnce() )
+			->method( 'getWhereConds' )
+			->will( $this->returnValue( array( 'o_id' => 42 ) ) );
+
+		$propertyTableDef = $this->getMockBuilder( '\SMW\SQLStore\PropertyTableDefinition' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$propertyTableDef->expects( $this->atLeastOnce() )
+			->method( 'isFixedPropertyTable' )
+			->will( $this->returnValue( false ) );
+
+		$query = $this->getMockBuilder( '\SMW\MediaWiki\Connection\Query' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$connection = $this->getMockBuilder( '\SMW\MediaWiki\Database' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$connection->expects( $this->atLeastOnce() )
+			->method( 'newQuery' )
+			->will( $this->returnValue( $query ) );
+
+		$connection->expects( $this->atLeastOnce() )
+			->method( 'query' )
+			->will( $this->returnValue( array() ) );
+
+		$store = $this->getMockBuilder( '\SMW\SQLStore\SQLStore' )
+			->disableOriginalConstructor()
+			->setMethods( array( 'getConnection', 'getDataItemHandlerForDIType', 'getSQLOptions', 'getSQLConditions' ) )
+			->getMock();
+
+		$store->expects( $this->atLeastOnce() )
+			->method( 'getSQLOptions' )
+			->will( $this->returnValue( array() ) );
+
+		$store->expects( $this->atLeastOnce() )
+			->method( 'getSQLConditions' )
+			->will( $this->returnValue( '' ) );
+
+		$store->expects( $this->atLeastOnce() )
+			->method( 'getConnection' )
+			->will( $this->returnValue( $connection ) );
+
+		$store->expects( $this->atLeastOnce() )
+			->method( 'getDataItemHandlerForDIType' )
+			->will( $this->returnValue( $dataItemHandler ) );
+
+		$instance = new PropertySubjectsLookup(
+			$store
+		);
+
+		$instance->fetchFromTable( 42, $propertyTableDef, $dataItem );
+	}
+
+	public function testLookupForFixedPropertyTable() {
+
+		$dataItem = DIWikiPage::newFromText( __METHOD__ );
+
+		$resultWrapper = $this->getMockBuilder( '\FakeResultWrapper' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$dataItemHandler = $this->getMockBuilder( '\SMW\SQLStore\EntityStore\DataItemHandler' )
+			->disableOriginalConstructor()
+			->getMockForAbstractClass();
+
+		$dataItemHandler->expects( $this->atLeastOnce() )
+			->method( 'getWhereConds' )
+			->will( $this->returnValue( array( 'o_id' => 42 ) ) );
+
+		$propertyTableDef = $this->getMockBuilder( '\SMW\SQLStore\PropertyTableDefinition' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$propertyTableDef->expects( $this->atLeastOnce() )
+			->method( 'isFixedPropertyTable' )
+			->will( $this->returnValue( true ) );
+
+		$query = $this->getMockBuilder( '\SMW\MediaWiki\Connection\Query' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$connection = $this->getMockBuilder( '\SMW\MediaWiki\Database' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$connection->expects( $this->atLeastOnce() )
+			->method( 'newQuery' )
+			->will( $this->returnValue( $query ) );
+
+		$connection->expects( $this->atLeastOnce() )
+			->method( 'query' )
+			->will( $this->returnValue( $resultWrapper ) );
+
+		$store = $this->getMockBuilder( '\SMW\SQLStore\SQLStore' )
+			->disableOriginalConstructor()
+			->setMethods( array( 'getConnection', 'getDataItemHandlerForDIType' ) )
+			->getMock();
+
+		$store->expects( $this->atLeastOnce() )
+			->method( 'getConnection' )
+			->will( $this->returnValue( $connection ) );
+
+		$store->expects( $this->atLeastOnce() )
+			->method( 'getDataItemHandlerForDIType' )
+			->will( $this->returnValue( $dataItemHandler ) );
+
+		$instance = new PropertySubjectsLookup(
+			$store
+		);
+
+		$instance->fetchFromTable( 42, $propertyTableDef, $dataItem );
+	}
+
+}

--- a/tests/phpunit/Unit/SQLStore/SQLStoreFactoryTest.php
+++ b/tests/phpunit/Unit/SQLStore/SQLStoreFactoryTest.php
@@ -242,6 +242,16 @@ class SQLStoreFactoryTest extends \PHPUnit_Framework_TestCase {
 		);
 	}
 
+	public function testCanConstrucPropertySubjectsLookup() {
+
+		$instance = new SQLStoreFactory( $this->store );
+
+		$this->assertInstanceOf(
+			'\SMW\SQLStore\EntityStore\PropertySubjectsLookup',
+			$instance->newPropertySubjectsLookup()
+		);
+	}
+
 	public function testCanConstructPropertyStatisticsStore() {
 
 		$connection = $this->getMockBuilder( '\SMW\MediaWiki\Database' )


### PR DESCRIPTION
This PR is made in reference to: #

This PR addresses or contains:

- Moves `SMWSQLStore3Readers::getPropertySubjects` to its own `PropertySubjectsLookup` class 

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed
