### PR TITLE
Test category with NS prefix

### DIFF
--- a/tests/phpunit/Integration/JSONScript/TestCases/q-0804.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/q-0804.json
@@ -1,0 +1,34 @@
+{
+	"description": "Test `_INST` with namespace prefix",
+	"setup": [
+		{
+			"page": "Example/Q0804/1",
+			"contents": "[[Category:Help:Q0804]]"
+		}
+	],
+	"tests": [
+		{
+			"type": "query",
+			"about": "#0 (Category: is correctly parsed despite the Help: NS prefix)",
+			"condition": "[[Category:Help:Q0804]]",
+			"printouts": [],
+			"parameters": {
+				"limit": "10"
+			},
+			"assert-queryresult": {
+				"count": 1,
+				"results": [
+					"Example/Q0804/1#0##"
+				]
+			}
+		}
+	],
+	"settings": {
+		"wgContLang": "es"
+	},
+	"meta": {
+		"version": "2",
+		"is-incomplete": false,
+		"debug": false
+	}
+}


### PR DESCRIPTION
This PR is made in reference to: #

This PR addresses or contains:

- Test something like `[[Category:Help:Q0804]]` to ensure the NS prefix doesn't interfere with the `Category` NS detection

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed
