### PR TITLE
Move SMWSQLStore3Readers::getProperties to PropertiesLookup

### DIFF
--- a/src/MediaWiki/Connection/Query.php
+++ b/src/MediaWiki/Connection/Query.php
@@ -166,7 +166,8 @@ class Query {
 			foreach ( $join[1] as $table => $value ) {
 
 				if ( is_string( $table ) ) {
-					$value = $this->connection->tableName( $table ) . " AS $value";
+					$value = $value{0} . $value{1} === 'ON' ? "$value" : "AS $value";
+					$value = $this->connection->tableName( $table ) . " $value";
 				}
 
 				$joins[] = $value;
@@ -293,6 +294,17 @@ class Query {
 		$this->index = 0;
 
 		return $statement;
+	}
+
+	/**
+	 * @since 3.0
+	 *
+	 * @param string $fname
+	 *
+	 * @return iterable
+	 */
+	public function execute( $fname ) {
+		return $this->connection->query( $this, $fname );
 	}
 
 	private function sql() {

--- a/src/SQLStore/EntityStore/PropertiesLookup.php
+++ b/src/SQLStore/EntityStore/PropertiesLookup.php
@@ -1,0 +1,122 @@
+<?php
+
+namespace SMW\SQLStore\EntityStore;
+
+use SMW\SQLStore\SQLStore;
+use SMW\SQLStore\PropertyTableDefinition as TableDefinition;
+use SMWDataItem as DataItem;
+use SMW\DIWikiPage;
+use SMW\RequestOptions;
+use RuntimeException;
+
+/**
+ * @license GNU GPL v2
+ * @since 3.0
+ *
+ * @author mwjames
+ */
+class PropertiesLookup {
+
+	/**
+	 * @var SQLStore
+	 */
+	private $store;
+
+	/**
+	 * @since 3.0
+	 *
+	 * @param SQLStore $store
+	 */
+	public function __construct( SQLStore $store ) {
+		$this->store = $store;
+	}
+
+	/**
+	 * @since 3.0
+	 *
+	 * @return RequestOptions|null
+	 */
+	public function newRequestOptions( RequestOptions $requestOptions = null ) {
+
+		if ( $requestOptions !== null ) {
+			$clone = clone $requestOptions;
+			$clone->limit = $requestOptions->limit + $requestOptions->offset;
+			$clone->offset = 0;
+		} else {
+			$clone = null;
+		}
+
+		return $clone;
+	}
+
+	/**
+	 * @see Store::getProperties
+	 *
+	 * @since 3.0
+	 *
+	 * {@inheritDoc}
+	 */
+	public function fetchFromTable( DIWikiPage $subject, TableDefinition $propertyTable, RequestOptions $requestOptions = null ) {
+
+		$connection = $this->store->getConnection( 'mw.db' );
+		$query = $connection->newQuery();
+
+		$query->type( 'SELECT' );
+		$query->table( $propertyTable->getName() );
+
+		if ( $propertyTable->usesIdSubject() ) {
+			$query->condition( $query->eq( 's_id', $subject->getId() ) );
+		} elseif ( $subject->getInterwiki() === '' ) {
+			$query->condition( $query->eq( 's_title', $subject->getDBkey() ) );
+			$query->condition( $query->eq( 's_namespace', $subject->getNamespace() ) );
+		} else {
+			// subjects with non-empty interwiki cannot have properties
+			return [];
+		}
+
+		if ( $propertyTable->isFixedPropertyTable() ) {
+			return $this->fetchFromFixedTable( $query, $propertyTable->getFixedProperty() );
+		}
+
+		$query->join(
+			'INNER JOIN',
+			[ SQLStore::ID_TABLE => "ON smw_id=p_id" ]
+		);
+
+		$query->fields( [ 'smw_title', 'smw_sortkey' ] );
+
+		// (select sortkey since it might be used in ordering (needed by Postgres))
+		$query->condition( $this->store->getSQLConditions(
+			$requestOptions,
+			'smw_sortkey',
+			'smw_sortkey'
+		) );
+
+		$opt =  $this->store->getSQLOptions(
+			$requestOptions,
+			'smw_sortkey'
+		);
+
+		$query->options( $opt + [ 'DISTINCT' => true ] );
+
+		return $query->execute( __METHOD__ );
+	}
+
+	private function fetchFromFixedTable( $query, $title ) {
+
+		// just check if subject occurs in table
+		$query->options(
+			[ 'LIMIT' => 1 ]
+		);
+
+		$query->field( '*' );
+		$res = $query->execute( __METHOD__ );
+
+		if ( $res->numRows() > 0 ) {
+			return [ $title ];
+		}
+
+		return [];
+	}
+
+}

--- a/src/SQLStore/SQLStoreFactory.php
+++ b/src/SQLStore/SQLStoreFactory.php
@@ -22,6 +22,7 @@ use SMW\SQLStore\EntityStore\SemanticDataLookup;
 use SMW\SQLStore\EntityStore\SubobjectListFinder;
 use SMW\SQLStore\EntityStore\TraversalPropertyLookup;
 use SMW\SQLStore\EntityStore\PropertySubjectsLookup;
+use SMW\SQLStore\EntityStore\PropertiesLookup;
 use SMW\SQLStore\Lookup\CachedListLookup;
 use SMW\SQLStore\Lookup\ListLookup;
 use SMW\SQLStore\Lookup\PropertyUsageListLookup;
@@ -467,6 +468,15 @@ class SQLStoreFactory {
 	 */
 	public function newPropertySubjectsLookup() {
 		return new PropertySubjectsLookup( $this->store );
+	}
+
+	/**
+	 * @since 3.0
+	 *
+	 * @return PropertiesLookup
+	 */
+	public function newPropertiesLookup() {
+		return new PropertiesLookup( $this->store );
 	}
 
 	/**

--- a/tests/phpunit/Integration/SemanticDataStorageDBIntegrationTest.php
+++ b/tests/phpunit/Integration/SemanticDataStorageDBIntegrationTest.php
@@ -11,6 +11,7 @@ use SMW\Subobject;
 use SMW\Tests\MwDBaseUnitTestCase;
 use SMW\Tests\Utils\UtilityFactory;
 use SMWDIBlob as DIBlob;
+use SMWDITime as DITime;
 use Title;
 
 /**
@@ -67,7 +68,7 @@ class SemanticDataStorageDBIntegrationTest extends MwDBaseUnitTestCase {
 		parent::tearDown();
 	}
 
-	public function testAddUserDefinedPagePropertyAsObjectToSemanticDataForStorage() {
+	public function testUserDefined_PageProperty_ToSemanticDataForStorage() {
 
 		$property = new DIProperty( 'SomePageProperty' );
 
@@ -84,6 +85,48 @@ class SemanticDataStorageDBIntegrationTest extends MwDBaseUnitTestCase {
 		$this->assertArrayHasKey(
 			$property->getKey(),
 			$this->getStore()->getSemanticData( $subject )->getProperties()
+		);
+
+		foreach ( $this->getStore()->getProperties( $subject ) as $prop ) {
+			$this->assertTrue( $prop->equals( $property ) );
+		}
+	}
+
+	public function testFixedProperty_MDAT_ToSemanticDataForStorage() {
+
+		$property = new DIProperty( '_MDAT' );
+
+		$this->subjects[] = $subject = DIWikiPage::newFromTitle( Title::newFromText( __METHOD__ ) );
+		$semanticData = new SemanticData( $subject );
+
+		$semanticData->addPropertyObjectValue(
+			$property,
+			new DITime( 1, '1970', '1', '1' )
+		);
+
+		$this->getStore()->updateData( $semanticData );
+
+		$this->assertArrayHasKey(
+			$property->getKey(),
+			$this->getStore()->getSemanticData( $subject )->getProperties()
+		);
+
+		foreach ( $this->getStore()->getProperties( $subject ) as $prop ) {
+			$this->assertTrue( $prop->equals( $property ) );
+		}
+	}
+
+	public function testFixedProperty_ASK_NotForStorage() {
+
+		$property = new DIProperty( '_ASK' );
+
+		$this->subjects[] = $subject = DIWikiPage::newFromTitle( Title::newFromText( __METHOD__ ) );
+		$semanticData = new SemanticData( $subject );
+
+		$this->getStore()->updateData( $semanticData );
+
+		$this->assertEmpty(
+			$this->getStore()->getProperties( $subject )
 		);
 	}
 

--- a/tests/phpunit/Unit/MediaWiki/Connection/QueryTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Connection/QueryTest.php
@@ -176,6 +176,23 @@ class QueryTest extends \PHPUnit_Framework_TestCase {
 		);
 	}
 
+	public function testTable_Join_ON_Field_Conditions() {
+
+		$instance = new Query( $this->connection );
+		$instance->type( 'select' );
+
+		$instance->table( 'foo' );
+		$instance->field( 'f', 'a' );
+		$instance->join( 'LEFT JOIN', [ 'abc' => 'ON p=d' ] );
+
+		$instance->condition( $instance->asAnd( 'foo_bar' ) );
+
+		$this->assertSame(
+			'SELECT f AS a FROM foo LEFT JOIN abc ON p=d WHERE (foo_bar)',
+			$instance->build()
+		);
+	}
+
 	public function testTable_Field_Condition_Options_Distinct_Order() {
 
 		$instance = new Query( $this->connection );
@@ -283,6 +300,22 @@ class QueryTest extends \PHPUnit_Framework_TestCase {
 			'Foo!=`Bar`',
 			$instance->neq( 'Foo', 'Bar' )
 		);
+	}
+
+	public function testExecute() {
+
+		$instance = new Query(
+			$this->connection
+		);
+
+		$this->connection->expects( $this->once() )
+			->method( 'query' )
+			->with(
+				$this->equalTo( $instance ),
+				$this->equalTo( 'Foo' ) );
+
+
+		$instance->execute( 'Foo' );
 	}
 
 }

--- a/tests/phpunit/Unit/SQLStore/EntityStore/PropertiesLookupTest.php
+++ b/tests/phpunit/Unit/SQLStore/EntityStore/PropertiesLookupTest.php
@@ -1,0 +1,138 @@
+<?php
+
+namespace SMW\Tests\SQLStore\EntityStore;
+
+use SMW\DIWikiPage;
+use SMW\Options;
+use SMW\SQLStore\EntityStore\PropertiesLookup;
+
+/**
+ * @covers \SMW\SQLStore\EntityStore\PropertiesLookup
+ * @group semantic-mediawiki
+ *
+ * @license GNU GPL v2+
+ * @since 3.0
+ *
+ * @author mwjames
+ */
+class PropertiesLookupTest extends \PHPUnit_Framework_TestCase {
+
+	public function testCanConstruct() {
+
+		$store = $this->getMockBuilder( '\SMW\SQLStore\SQLStore' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$this->assertInstanceOf(
+			PropertiesLookup::class,
+			new PropertiesLookup( $store )
+		);
+	}
+
+	public function testLookupForNonFixedPropertyTable() {
+
+		$dataItem = DIWikiPage::newFromText( __METHOD__ );
+		$dataItem->setId( 42 );
+
+		$resultWrapper = $this->getMockBuilder( '\FakeResultWrapper' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$propertyTableDef = $this->getMockBuilder( '\SMW\SQLStore\PropertyTableDefinition' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$propertyTableDef->expects( $this->atLeastOnce() )
+			->method( 'isFixedPropertyTable' )
+			->will( $this->returnValue( false ) );
+
+		$query = $this->getMockBuilder( '\SMW\MediaWiki\Connection\Query' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$query->expects( $this->atLeastOnce() )
+			->method( 'execute' )
+			->will( $this->returnValue( $resultWrapper ) );
+
+		$connection = $this->getMockBuilder( '\SMW\MediaWiki\Database' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$connection->expects( $this->atLeastOnce() )
+			->method( 'newQuery' )
+			->will( $this->returnValue( $query ) );
+
+		$store = $this->getMockBuilder( '\SMW\SQLStore\SQLStore' )
+			->disableOriginalConstructor()
+			->setMethods( array( 'getConnection', 'getSQLOptions', 'getSQLConditions' ) )
+			->getMock();
+
+		$store->expects( $this->atLeastOnce() )
+			->method( 'getSQLOptions' )
+			->will( $this->returnValue( array() ) );
+
+		$store->expects( $this->atLeastOnce() )
+			->method( 'getSQLConditions' )
+			->will( $this->returnValue( '' ) );
+
+		$store->expects( $this->atLeastOnce() )
+			->method( 'getConnection' )
+			->will( $this->returnValue( $connection ) );
+
+		$instance = new PropertiesLookup(
+			$store
+		);
+
+		$instance->fetchFromTable( $dataItem, $propertyTableDef );
+	}
+
+	public function testLookupForFixedPropertyTable() {
+
+		$dataItem = DIWikiPage::newFromText( __METHOD__ );
+		$dataItem->setId( 1001 );
+
+		$resultWrapper = $this->getMockBuilder( '\FakeResultWrapper' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$propertyTableDef = $this->getMockBuilder( '\SMW\SQLStore\PropertyTableDefinition' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$propertyTableDef->expects( $this->atLeastOnce() )
+			->method( 'isFixedPropertyTable' )
+			->will( $this->returnValue( true ) );
+
+		$query = $this->getMockBuilder( '\SMW\MediaWiki\Connection\Query' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$query->expects( $this->atLeastOnce() )
+			->method( 'execute' )
+			->will( $this->returnValue( $resultWrapper ) );
+
+		$connection = $this->getMockBuilder( '\SMW\MediaWiki\Database' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$connection->expects( $this->atLeastOnce() )
+			->method( 'newQuery' )
+			->will( $this->returnValue( $query ) );
+
+		$store = $this->getMockBuilder( '\SMW\SQLStore\SQLStore' )
+			->disableOriginalConstructor()
+			->setMethods( array( 'getConnection' ) )
+			->getMock();
+
+		$store->expects( $this->atLeastOnce() )
+			->method( 'getConnection' )
+			->will( $this->returnValue( $connection ) );
+
+		$instance = new PropertiesLookup(
+			$store
+		);
+
+		$instance->fetchFromTable( $dataItem, $propertyTableDef );
+	}
+
+}


### PR DESCRIPTION
This PR is made in reference to: #

This PR addresses or contains:

- Moves `SMWSQLStore3Readers::getProperties` to its own `PropertiesLookup` class

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed
