### PR TITLE
Special:Browse, Special:PageProperty limit value pool, refs 2930

### DIFF
--- a/DefaultSettings.php
+++ b/DefaultSettings.php
@@ -435,6 +435,10 @@ return array(
 	# - `concept` (was $smwgConceptPagingLimit)
 	# - `property` (was $smwgPropertyPagingLimit)
 	#
+	# Special:Browse
+	# - `valuelist.outgoingt` outgoing value list count
+	# - `valuelist.incoming` incoming value list count
+	#
 	# @since 3.0
 	##
 	'smwgPagingLimit' => [
@@ -442,6 +446,12 @@ return array(
 		'concept' => 200,
 		'property' => 20,
 		'errorlist' => 25,
+
+		// Special:Browse
+		'browse' => [
+			'valuelist.outgoing' => 200,
+			'valuelist.incoming' => 20,
+		]
 	],
 	##
 

--- a/src/EntityLookup.php
+++ b/src/EntityLookup.php
@@ -27,7 +27,7 @@ interface EntityLookup {
 	 * @since 2.5
 	 *
 	 * @param DIWikiPage $subject
-	 * @param string[]|bool $filter
+	 * @param RequestOptions|string[]|bool $filter
 	 *
 	 * @return SemanticData
 	 */

--- a/src/MediaWiki/Specials/SpecialBrowse.php
+++ b/src/MediaWiki/Specials/SpecialBrowse.php
@@ -169,7 +169,19 @@ class SpecialBrowse extends SpecialPage {
 				'showAll' => $settings->isFlagSet( 'smwgBrowseFeatures', SMW_BROWSE_SHOW_INCOMING ),
 				'showGroup' => $settings->isFlagSet( 'smwgBrowseFeatures', SMW_BROWSE_SHOW_GROUP ),
 				'showSort' => $settings->isFlagSet( 'smwgBrowseFeatures', SMW_BROWSE_SHOW_SORTKEY ),
-				'api' => $settings->isFlagSet( 'smwgBrowseFeatures', SMW_BROWSE_USE_API )
+				'api' => $settings->isFlagSet( 'smwgBrowseFeatures', SMW_BROWSE_USE_API ),
+
+				// WebRequest::getGPCVal/getVal doesn't understand `.` as in
+				// `valuelistlimit.out`
+
+				'valuelistlimit.out' => $webRequest->getVal(
+					'valuelistlimit-out',
+					$settings->dotGet( 'smwgPagingLimit.browse.valuelist.outgoing' )
+				),
+				'valuelistlimit.in' => $webRequest->getVal(
+					'valuelistlimit-in',
+					$settings->dotGet( 'smwgPagingLimit.browse.valuelist.incoming' )
+				),
 			]
 		);
 

--- a/src/MediaWiki/Specials/SpecialPageProperty.php
+++ b/src/MediaWiki/Specials/SpecialPageProperty.php
@@ -140,6 +140,12 @@ class SpecialPageProperty extends SpecialPage {
 			$requestOptions->setOffset( $options->get( 'offset' ) );
 			$requestOptions->sort = true;
 
+			// Restrict the request otherwise the entire SemanticData record
+			// is fetched which can in case of a subject with a large
+			// subobject/subpage pool create excessive DB queries that are not
+			// used for the display
+			$requestOptions->conditionConstraint = true;
+
 			$dataItem = $pagename !== '' ? $subject->getDataItem() : null;
 
 			$results = $applicationFactory->getStore()->getPropertyValues(

--- a/src/SQLStore/EntityStore/CachingSemanticDataLookup.php
+++ b/src/SQLStore/EntityStore/CachingSemanticDataLookup.php
@@ -227,6 +227,17 @@ class CachingSemanticDataLookup {
 		return $this->fetchFromCache( $id, $dataItem, $propertyTableDef );
 	}
 
+	/**
+	 * @since 3.0
+	 *
+	 * @param DIWikiPage $subject
+	 *
+	 * @return StubSemanticData
+	 */
+	public function newStubSemanticData( DIWikiPage $subject ) {
+		return $this->semanticDataLookup->newStubSemanticData( $subject );
+	}
+
 	private function fetchFromCache( $id, DataItem $dataItem = null, PropertyTableDefinition $propertyTableDef ) {
 
 		// Do not clear the cache when called recursively.

--- a/src/SQLStore/RequestOptionsProc.php
+++ b/src/SQLStore/RequestOptionsProc.php
@@ -283,6 +283,12 @@ class RequestOptionsProc {
 
 	private static function applyLimitRestriction( $requestOptions, &$result ) {
 
+		// In case of a `conditionConstraint` the restriction is set forth by the
+		// SELECT statement.
+		if ( isset( $requestOptions->conditionConstraint ) ) {
+			return $result;
+		}
+
 		if ( $requestOptions->limit > 0 ) {
 			return $result = array_slice( $result, $requestOptions->offset, $requestOptions->limit );
 		}

--- a/tests/phpunit/Integration/JSONScript/TestCases/s-0028.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/s-0028.json
@@ -1,0 +1,94 @@
+{
+	"description": "Test `Special:Browse` limited value list",
+	"setup": [
+		{
+			"namespace": "SMW_NS_PROPERTY",
+			"page": "Has page",
+			"contents": "[[Has type::Page]]"
+		},
+		{
+			"namespace": "SMW_NS_PROPERTY",
+			"page": "Has text",
+			"contents": "[[Has type::Text]]"
+		},
+		{
+			"page": "Example/S0028/1",
+			"contents": "[[Has text::S1]], [[Has text::S2]], [[Has text::S3]], [[Has text::S4]], [[Has text::S5]], [[Has text::S6]]"
+		},
+		{
+			"page": "Example/S0028/2",
+			"contents": "[[Has page::Example/S0028/5]]"
+		},
+		{
+			"page": "Example/S0028/3",
+			"contents": "[[Has page::Example/S0028/5]]"
+		},
+		{
+			"page": "Example/S0028/4",
+			"contents": "[[Has page::Example/S0028/5]]"
+		}
+	],
+	"tests": [
+		{
+			"type": "special",
+			"about": "#0 (limited outgoing value list)",
+			"special-page": {
+				"page": "Browse",
+				"query-parameters": "Example/S0028/1",
+				"request-parameters": {
+					"output": "legacy",
+					"valuelistlimit-out": 5
+				}
+			},
+			"assert-output": {
+				"to-contain": [
+					"<span class=\"smwb-value\">S1",
+					"<span class=\"smwb-value\">S2",
+					"<span class=\"smwb-value\">S3",
+					"<span class=\"smwb-value\">S4",
+					"<span class=\"smwb-value\">S5"
+				],
+				"not-contain": [
+					"<span class=\"smwb-value\">S6"
+				]
+			}
+		},
+		{
+			"type": "special",
+			"about": "#1 (limited incoming value list)",
+			"special-page": {
+				"page": "Browse",
+				"query-parameters": "Example/S0028/5",
+				"request-parameters": {
+					"output": "legacy",
+					"valuelistlimit-in": 3
+				}
+			},
+			"assert-output": {
+				"to-contain": [
+					"<span class=\"smwb-ivalue\"><a href=\".*/Example/S0028/2\"",
+					"<span class=\"smwb-ivalue\"><a href=\".*/Example/S0028/3\""
+				],
+				"not-contain": [
+					"<span class=\"smwb-ivalue\"><a href=\".*/Example/S0028/4\""
+				]
+			}
+		}
+	],
+	"settings": {
+		"wgContLang": "en",
+		"wgLang": "en",
+		"smwgPageSpecialProperties": [
+			"_MDAT"
+		],
+		"smwgNamespacesWithSemanticLinks": {
+			"NS_MAIN": true,
+			"SMW_NS_PROPERTY": true
+		}
+	},
+	"meta": {
+		"version": "2",
+		"is-incomplete": false,
+		"debug": false
+	}
+}

--- a/tests/phpunit/Unit/MediaWiki/Specials/SpecialBrowseTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Specials/SpecialBrowseTest.php
@@ -78,7 +78,7 @@ class SpecialBrowseTest extends \PHPUnit_Framework_TestCase {
 			'Foo/Bar',
 			array(
 				'data-subject="Foo/Bar#0##"',
-				'data-options="{&quot;dir&quot;:null,&quot;group&quot;:null,&quot;printable&quot;:null,&quot;offset&quot;:null,&quot;including&quot;:null,&quot;showInverse&quot;:false,&quot;showAll&quot;:true,&quot;showGroup&quot;:false,&quot;showSort&quot;:false,&quot;api&quot;:true}"'
+				'data-options="{&quot;dir&quot;:null,&quot;group&quot;:null,&quot;printable&quot;:null,&quot;offset&quot;:null,&quot;including&quot;:null,&quot;showInverse&quot;:false,&quot;showAll&quot;:true,&quot;showGroup&quot;:false,&quot;showSort&quot;:false,&quot;api&quot;:true,&quot;valuelistlimit.out&quot;:&quot;200&quot;,&quot;valuelistlimit.in&quot;:&quot;20&quot;}"'
 			)
 		);
 
@@ -87,7 +87,7 @@ class SpecialBrowseTest extends \PHPUnit_Framework_TestCase {
 			':Main-20Page-23_QUERY140d50d705e9566904fc4a877c755964',
 			array(
 				'data-subject="Main_Page#0##_QUERY140d50d705e9566904fc4a877c755964"',
-				'data-options="{&quot;dir&quot;:null,&quot;group&quot;:null,&quot;printable&quot;:null,&quot;offset&quot;:null,&quot;including&quot;:null,&quot;showInverse&quot;:false,&quot;showAll&quot;:true,&quot;showGroup&quot;:false,&quot;showSort&quot;:false,&quot;api&quot;:true}"'
+				'data-options="{&quot;dir&quot;:null,&quot;group&quot;:null,&quot;printable&quot;:null,&quot;offset&quot;:null,&quot;including&quot;:null,&quot;showInverse&quot;:false,&quot;showAll&quot;:true,&quot;showGroup&quot;:false,&quot;showSort&quot;:false,&quot;api&quot;:true,&quot;valuelistlimit.out&quot;:&quot;200&quot;,&quot;valuelistlimit.in&quot;:&quot;20&quot;}"'
 			)
 		);
 


### PR DESCRIPTION
This PR is made in reference to: #2930

This PR addresses or contains:

- Limits the value pool that is displayed for each property in `Special:Browse` to avoid excessive DB queries. Normally, the display will become user unfriendly on occasions where more than 200 values per property are expected to be displayed therefore the default value for the display is is set to 200 and in case of "more" values, a "..." link is shown and redirects to the `Special:PageProperty` to lookup all values.
- `smwgPagingLimit` contains anew section for the `browse` outgoing and incoming value list

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed
