### PR TITLE
Combine different value lists, support JSON, refs 2295

### DIFF
--- a/src/DataValues/AllowsListValue.php
+++ b/src/DataValues/AllowsListValue.php
@@ -50,9 +50,9 @@ class AllowsListValue extends StringValue {
 			foreach ( $allowsListValueParser->getErrors() as $error ) {
 				$this->addErrorMsg( $error );
 			}
+		} else {
+			parent::parseUserValue( $value );
 		}
-
-		parent::parseUserValue( $value );
 	}
 
 	/**

--- a/src/DataValues/ValueValidators/AllowsListConstraintValueValidator.php
+++ b/src/DataValues/ValueValidators/AllowsListConstraintValueValidator.php
@@ -89,16 +89,22 @@ class AllowsListConstraintValueValidator implements ConstraintValueValidator {
 			$allowedValueList
 		);
 
+
 		if ( !$isAllowed ) {
-			foreach ( $allowedListValues as $allowedList ) {
-				$allowedValues = $this->allowsListValueParser->parse(
-					$allowedList->getString()
-				);
+			foreach ( $allowedListValues as $dataItem ) {
+				$list = $this->allowsListValueParser->parse( $dataItem->getString() );
+
+				// Combine different lists into one
+				if ( is_array( $list ) ) {
+					$allowedValues = array_merge( $allowedValues, $list );
+				}
 			}
 
 			// On assignments like [Foo => Foo] (* Foo) or [Foo => Bar] (* Foo|Bar)
 			// use the key as comparison entity
 			$allowedValues = array_keys( $allowedValues );
+		} else {
+			return;
 		}
 
 		$isAllowed = $this->checkConstraintViolation(

--- a/tests/phpunit/Integration/JSONScript/Fixtures/p-0502-other-license.json
+++ b/tests/phpunit/Integration/JSONScript/Fixtures/p-0502-other-license.json
@@ -1,0 +1,4 @@
+{
+    "CC Zero": "Public Domain Dedication",
+    "PD": "Public Domain"
+}

--- a/tests/phpunit/Integration/JSONScript/TestCases/p-0502.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/p-0502.json
@@ -21,6 +21,13 @@
 			"contents": "* BSD-2-Clause|2-clause BSD License (BSD-2-Clause)\n* Zlib|zlib/libpng license (Zlib)"
 		},
 		{
+			"namespace": "NS_MEDIAWIKI",
+			"page": "Smw allows list other license.json",
+			"contents": {
+				"import-from": "/../Fixtures/p-0502-other-license.json"
+			}
+		},
+		{
 			"namespace": "SMW_NS_PROPERTY",
 			"page": "Has list",
 			"contents": "[[Has type::Text]] [[Allows value list::Publication categories]]"
@@ -38,7 +45,7 @@
 		{
 			"namespace": "SMW_NS_PROPERTY",
 			"page": "Has license",
-			"contents": "[[Has type::Text]] [[Allows value list::license]]"
+			"contents": "[[Has type::Text]] [[Allows value list::license]] [[Allows value list::other license.json]]"
 		},
 		{
 			"page": "Example/P0502/1",
@@ -59,6 +66,10 @@
 		{
 			"page": "Example/P0502/5",
 			"contents": "[[Has license::Zlib]]"
+		},
+		{
+			"page": "Example/P0502/6",
+			"contents": "[[Has license::PD]]"
 		}
 	],
 	"tests": [
@@ -144,6 +155,25 @@
 					],
 					"propertyValues": [
 						"Zlib"
+					]
+				}
+			}
+		},
+		{
+			"type": "parser",
+			"about": "#5 assignment from JSON",
+			"subject": "Example/P0502/6",
+			"assert-store": {
+				"semantic-data": {
+					"strictPropertyValueMatch": false,
+					"propertyCount": 3,
+					"propertyKeys": [
+						"_SKEY",
+						"_MDAT",
+						"Has license"
+					],
+					"propertyValues": [
+						"PD"
 					]
 				}
 			}

--- a/tests/phpunit/Unit/DataValues/ValueParsers/AllowsListValueParserTest.php
+++ b/tests/phpunit/Unit/DataValues/ValueParsers/AllowsListValueParserTest.php
@@ -50,4 +50,27 @@ class AllowsListValueParserTest extends \PHPUnit_Framework_TestCase {
 		);
 	}
 
+	public function testParseAndMatchFromJSON() {
+
+		$contents = json_encode( [ 'Foo' => 'Foo', 'Foobar' => 'fooooo bar' ] );
+
+		$this->mediaWikiNsContentReader->expects( $this->once() )
+			->method( 'read' )
+			->will( $this->returnValue( $contents ) );
+
+		$instance = new AllowsListValueParser(
+			$this->mediaWikiNsContentReader
+		);
+
+		$instance->clear();
+
+		$this->assertEquals(
+			array(
+				'Foo' => 'Foo',
+				'Foobar' => 'fooooo bar'
+			),
+			$instance->parse( 'Bar' )
+		);
+	}
+
 }


### PR DESCRIPTION
This PR is made in reference to: #2295

This PR addresses or contains:

- The content of the "Allows value list" may become lengthy and challenging to edit via wikitext hence this PR adds support for JSON as format. The value list is using a simple key, value assignment with the key (e.g. "PD") being used as constraint value with the assigned value argument is there only to described the key and has for the validation no specific relevance.

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed

### Example

`MediaWiki:Smw_allows_list_other_license.json` contains:

```
{
    "CC Zero": "Public Domain Dedication",
    "PD": "Public Domain"
}
```

`Property:Has license` with an assignment of `[[Allows value list::other license.json]]`.