### PR TITLE
Add tanslation page annotation, refs 2300

### DIFF
--- a/DefaultSettings.php
+++ b/DefaultSettings.php
@@ -847,20 +847,26 @@ return array(
 	'smwgJobQueueWatchlist' => [],
 	##
 
-	### List of enabled special page properties.
-	# Modification date (_MDAT) is enabled by default for backward compatibility.
-	# Extend array to enable other properties:
+	###
+	# List of enabled special page properties.
+	#
+	# - `_MDAT` Modification date is enabled by default for backward compatibility.
+	# - `_TRANS` Add annotations (language, source etc. ) when a page is
+	#   indentified as translation page (as done by the Translation extension)
+	#
+	#  Extend array to enable other properties:
 	#     $smwgPageSpecialProperties[ => '_CDAT',
 	# Or:
 	#     array_merge( $smwgPageSpecialProperties, array( '_CDAT' ) ),
 	# Or rewrite entire array:
 	#     	'smwgPageSpecialProperties' => array( '_MDAT', '_CDAT' ),
+	#
 	# However, DO NOT use `+=' operator! This DOES NOT work:
 	#     $smwgPageSpecialProperties += array( '_MDAT' ),
 	#
 	# @since 1.7
 	##
-	'smwgPageSpecialProperties' => array( '_MDAT' ),
+	'smwgPageSpecialProperties' => array( '_MDAT', '_TRANS' ),
 	##
 
 	###

--- a/i18n/extra/en.json
+++ b/i18n/extra/en.json
@@ -129,7 +129,10 @@
             "_CONT_LANG": "Content language",
             "_CONT_TITLE": "Content title",
             "_CONT_DATE": "Content date",
-            "_CONT_KEYW": "Content keyword"
+            "_CONT_KEYW": "Content keyword",
+            "_TRANS": "Translation",
+            "_TRANS_SOURCE": "Translation source",
+            "_TRANS_GROUP": "Translation group"
         },
         "aliases": {
             "Display unit": "_UNIT",
@@ -188,7 +191,8 @@
             "Rule definition": "_RL_DEF",
             "Formatter rule": "_FORMAT_RL",
             "File attachment": "_FILE_ATTCH",
-            "Has file attachment": "_FILE_ATTCH"
+            "Has file attachment": "_FILE_ATTCH",
+            "Has translation":"_TRANS"
         }
     },
     "date": {

--- a/src/DataItemFactory.php
+++ b/src/DataItemFactory.php
@@ -8,8 +8,9 @@ use SMWDIBoolean as DIBoolean;
 use SMWDIContainer as DIContainer;
 use SMWDIError as DIError;
 use SMWDINumber as DINumber;
-use SMWDITime as DITime;
 use SMWDIUri as DIUri;
+use SMWDITime  as DITime;
+use Title;
 
 /**
  * @private
@@ -47,15 +48,20 @@ class DataItemFactory {
 	/**
 	 * @since 2.4
 	 *
-	 * @param string $dbKey
+	 * @param string|Title $title
 	 * @param integer $namespace
 	 * @param string $interwiki
 	 * @param string $subobjectName
 	 *
 	 * @return DIWikiPage
 	 */
-	public function newDIWikiPage( $dbKey, $namespace = NS_MAIN, $interwiki = '', $subobjectName = '' ) {
-		return new DIWikiPage( $dbKey, $namespace, $interwiki, $subobjectName );
+	public function newDIWikiPage( $title, $namespace = NS_MAIN, $interwiki = '', $subobjectName = '' ) {
+
+		if ( $title instanceof Title ) {
+			return DIWikiPage::newFromTitle( $title );
+		}
+
+		return new DIWikiPage( $title, $namespace, $interwiki, $subobjectName );
 	}
 
 	/**
@@ -67,6 +73,17 @@ class DataItemFactory {
 	 */
 	public function newDIContainer( ContainerSemanticData $containerSemanticData ) {
 		return new DIContainer( $containerSemanticData );
+	}
+
+	/**
+	 * @since 3.0
+	 *
+	 * @param DIWikiPage $subject
+	 *
+	 * @return ContainerSemanticData
+	 */
+	public function newContainerSemanticData( DIWikiPage $subject ) {
+		return new ContainerSemanticData( $subject );
 	}
 
 	/**

--- a/src/PropertyAnnotatorFactory.php
+++ b/src/PropertyAnnotatorFactory.php
@@ -12,6 +12,8 @@ use SMW\PropertyAnnotators\PredefinedPropertyAnnotator;
 use SMW\PropertyAnnotators\RedirectPropertyAnnotator;
 use SMW\PropertyAnnotators\RuleDefinitionPropertyAnnotator;
 use SMW\PropertyAnnotators\SortKeyPropertyAnnotator;
+use SMW\PropertyAnnotators\TranslationPropertyAnnotator;
+use SMW\Store;
 use SMW\Rule\RuleDefinition;
 use Title;
 
@@ -124,6 +126,28 @@ class PropertyAnnotatorFactory {
 			$propertyAnnotator,
 			$sortkey
 		);
+	}
+
+	/**
+	 * @since 3.0
+	 *
+	 * @param SemanticData $semanticData
+	 * @param arrat|null $translation
+	 *
+	 * @return TranslationPropertyAnnotator
+	 */
+	public function newTranslationPropertyAnnotator( PropertyAnnotator $propertyAnnotator, $translation ) {
+
+		$translationPropertyAnnotator = new TranslationPropertyAnnotator(
+			$propertyAnnotator,
+			$translation
+		);
+
+		$translationPropertyAnnotator->setPredefinedPropertyList(
+			ApplicationFactory::getInstance()->getSettings()->get( 'smwgPageSpecialProperties' )
+		);
+
+		return $translationPropertyAnnotator;
 	}
 
 	/**

--- a/src/PropertyAnnotators/TranslationPropertyAnnotator.php
+++ b/src/PropertyAnnotators/TranslationPropertyAnnotator.php
@@ -1,0 +1,106 @@
+<?php
+
+namespace SMW\PropertyAnnotators;
+
+use SMW\PropertyAnnotator;
+use SMW\DataModel\ContainerSemanticData;
+use Title;
+
+/**
+ * @license GNU GPL v2+
+ * @since 3.0
+ *
+ * @author mwjames
+ */
+class TranslationPropertyAnnotator extends PropertyAnnotatorDecorator {
+
+	/**
+	 * @var array|null
+	 */
+	private $translation;
+
+	/**
+	 * @var array
+	 */
+	private $predefinedPropertyList = array();
+
+	/**
+	 * @since 3.0
+	 *
+	 * @param PropertyAnnotator $propertyAnnotator
+	 * @param array|null $translation
+	 */
+	public function __construct( PropertyAnnotator $propertyAnnotator, $translation ) {
+		parent::__construct( $propertyAnnotator );
+		$this->translation = $translation;
+	}
+
+	/**
+	 * @since 3.0
+	 *
+	 * @param array $predefinedPropertyList
+	 */
+	public function setPredefinedPropertyList( array $predefinedPropertyList ) {
+		$this->predefinedPropertyList = array_flip( $predefinedPropertyList );
+	}
+
+	protected function addPropertyValues() {
+
+		// Expected identifiers, @see https://gerrit.wikimedia.org/r/387548
+		if ( !is_array( $this->translation ) || !isset( $this->predefinedPropertyList['_TRANS'] ) ) {
+			return;
+		}
+
+		$containerSemanticData = null;
+
+		if ( isset( $this->translation['languagecode'] ) ) {
+			$languageCode = $this->translation['languagecode'];
+			$containerSemanticData = $this->newContainerSemanticData( $languageCode );
+
+			// Translation.Language code
+			$containerSemanticData->addPropertyObjectValue(
+				$this->dataItemFactory->newDIProperty( '_LCODE' ),
+				$this->dataItemFactory->newDIBlob( $languageCode )
+			);
+		}
+
+		if ( isset( $this->translation['sourcepagetitle'] ) && $this->translation['sourcepagetitle'] instanceof Title ) {
+			// Translation.Translation source
+			$containerSemanticData->addPropertyObjectValue(
+				$this->dataItemFactory->newDIProperty( '_TRANS_SOURCE' ),
+				$this->dataItemFactory->newDIWikiPage( $this->translation['sourcepagetitle'] )
+			);
+		}
+
+		if ( isset( $this->translation['messagegroupid'] ) ) {
+			// Translation.Translation group
+			$containerSemanticData->addPropertyObjectValue(
+				$this->dataItemFactory->newDIProperty( '_TRANS_GROUP' ),
+				$this->dataItemFactory->newDIBlob( $this->translation['messagegroupid'] )
+			);
+		}
+
+		if ( $containerSemanticData !== null ) {
+			$this->getSemanticData()->addPropertyObjectValue(
+				$this->dataItemFactory->newDIProperty( '_TRANS' ),
+				$this->dataItemFactory->newDIContainer( $containerSemanticData )
+			);
+		}
+	}
+
+	private function newContainerSemanticData( $languageCode ) {
+
+		$dataItem = $this->getSemanticData()->getSubject();
+		$subobjectName = 'trans.' . $languageCode;
+
+		$subject = $this->dataItemFactory->newDIWikiPage(
+			$dataItem->getDBkey(),
+			$dataItem->getNamespace(),
+			$dataItem->getInterwiki(),
+			$subobjectName
+		);
+
+		return $this->dataItemFactory->newContainerSemanticData( $subject );
+	}
+
+}

--- a/src/TypesRegistry.php
+++ b/src/TypesRegistry.php
@@ -226,6 +226,11 @@ class TypesRegistry {
 			'_CONT_TITLE' => [ '_txt', true, true, false ], // "Content title"
 			'_CONT_DATE' => [ '_dat', true, true, false ], // "Content date",
 			'_CONT_KEYW' => [ '_keyw', true, true, false ], // "Content keyword"
+
+			// Translation
+			'_TRANS' => [ '__sob', false, false, false ], // "Translation"
+			'_TRANS_SOURCE' => [ '_wpg', true, false, false ], // "Translation source"
+			'_TRANS_GROUP' => [ '_txt', true, false, false ], // "Translation group"
 		];
 	}
 

--- a/tests/phpunit/Unit/DataItemFactoryTest.php
+++ b/tests/phpunit/Unit/DataItemFactoryTest.php
@@ -55,6 +55,24 @@ class DataItemFactoryTest extends \PHPUnit_Framework_TestCase {
 		);
 	}
 
+	public function testCanConstructDIWikiPageFromTitle() {
+
+		$title = $this->getMockBuilder( '\Title' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$title->expects( $this->atLeastOnce() )
+			->method( 'getNamespace' )
+			->will( $this->returnValue( NS_MAIN ) );
+
+		$instance = new DataItemFactory();
+
+		$this->assertInstanceOf(
+			'\SMW\DIWikiPage',
+			$instance->newDIWikiPage( $title )
+		);
+	}
+
 	public function testCanConstructDIContainer() {
 
 		$containerSemanticData = $this->getMockBuilder( '\SMWContainerSemanticData' )
@@ -66,6 +84,20 @@ class DataItemFactoryTest extends \PHPUnit_Framework_TestCase {
 		$this->assertInstanceOf(
 			'\SMWDIContainer',
 			$instance->newDIContainer( $containerSemanticData )
+		);
+	}
+
+	public function testCanConstructContainerSemanticData() {
+
+		$subject = $this->getMockBuilder( '\SMW\DIWikiPage' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$instance = new DataItemFactory();
+
+		$this->assertInstanceOf(
+			'\SMW\DataModel\ContainerSemanticData',
+			$instance->newContainerSemanticData( $subject )
 		);
 	}
 

--- a/tests/phpunit/Unit/PropertyAnnotatorFactoryTest.php
+++ b/tests/phpunit/Unit/PropertyAnnotatorFactoryTest.php
@@ -87,6 +87,20 @@ class PropertyAnnotatorFactoryTest extends \PHPUnit_Framework_TestCase {
 		);
 	}
 
+	public function testNewTranslationPropertyAnnotator() {
+
+		$propertyAnnotator = $this->getMockBuilder( '\SMW\PropertyAnnotator' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$instance = new PropertyAnnotatorFactory();
+
+		$this->assertInstanceOf(
+			'\SMW\PropertyAnnotators\TranslationPropertyAnnotator',
+			$instance->newTranslationPropertyAnnotator( $propertyAnnotator, [] )
+		);
+	}
+
 	public function testNewCategoryPropertyAnnotator() {
 
 		$propertyAnnotator = $this->getMockBuilder( '\SMW\PropertyAnnotator' )

--- a/tests/phpunit/Unit/PropertyAnnotators/TranslationPropertyAnnotatorTest.php
+++ b/tests/phpunit/Unit/PropertyAnnotators/TranslationPropertyAnnotatorTest.php
@@ -1,0 +1,160 @@
+<?php
+
+namespace SMW\Tests\PropertyAnnotators;
+
+use SMW\DataItemFactory;
+use SMW\SemanticData;
+use SMW\PropertyAnnotators\NullPropertyAnnotator;
+use SMW\PropertyAnnotators\TranslationPropertyAnnotator;
+use SMW\Tests\TestEnvironment;
+
+/**
+ * @covers \SMW\PropertyAnnotators\TranslationPropertyAnnotator
+ * @group semantic-mediawiki
+ *
+ * @license GNU GPL v2+
+ * @since 3.0
+ *
+ * @author mwjames
+ */
+class TranslationPropertyAnnotatorTest extends \PHPUnit_Framework_TestCase {
+
+	private $semanticDataValidator;
+	private $dataItemFactory;
+
+	protected function setUp() {
+		parent::setUp();
+
+		$this->semanticDataValidator = TestEnvironment::newValidatorFactory()->newSemanticDataValidator();
+		$this->dataItemFactory = new DataItemFactory();
+	}
+
+	public function testCanConstruct() {
+
+		$semanticData = $this->getMockBuilder( '\SMW\SemanticData' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$instance = new TranslationPropertyAnnotator(
+			new NullPropertyAnnotator( $semanticData ),
+			[]
+		);
+
+		$this->assertInstanceOf(
+			TranslationPropertyAnnotator::class,
+			$instance
+		);
+	}
+
+	public function testAddAnnotation() {
+
+		$semanticData = new SemanticData(
+			$this->dataItemFactory->newDIWikiPage( 'Foo' )
+		);
+
+		$title = $this->getMockBuilder( '\Title' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$title->expects( $this->once() )
+			->method( 'getDBKey' )
+			->will( $this->returnValue( 'Foobar' ) );
+
+		$title->expects( $this->once() )
+			->method( 'getNamespace' )
+			->will( $this->returnValue( NS_MAIN ) );
+
+		$translation = [
+			'languagecode' => 'foo',
+			'sourcepagetitle' => $title,
+			'messagegroupid' => 'bar'
+		];
+
+		$expected = [
+			'propertyCount'  => 3,
+			'propertyKeys'   => [ '_LCODE', '_TRANS_GROUP', '_TRANS_SOURCE' ],
+			'propertyValues' => [ 'foo', 'bar', ':Foobar' ],
+		];
+
+		$instance = new TranslationPropertyAnnotator(
+			new NullPropertyAnnotator( $semanticData ),
+			$translation
+		);
+
+		$instance->setPredefinedPropertyList( [ '_TRANS' ] );
+
+		$instance->addAnnotation();
+
+		$this->semanticDataValidator->assertThatPropertiesAreSet(
+			[
+				'propertyCount'  => 1,
+				'propertyKeys'   => '_TRANS'
+			],
+			$instance->getSemanticData()
+		);
+
+		$this->semanticDataValidator->assertThatPropertiesAreSet(
+			$expected,
+			$instance->getSemanticData()->findSubSemanticData( 'trans.foo' )
+		);
+	}
+
+	public function testAddAnnotation_NotListed() {
+
+		$semanticData = new SemanticData(
+			$this->dataItemFactory->newDIWikiPage( 'Foo' )
+		);
+
+		$title = $this->getMockBuilder( '\Title' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$title->expects( $this->never() )
+			->method( 'getDBKey' )
+			->will( $this->returnValue( 'Foobar' ) );
+
+		$title->expects( $this->never() )
+			->method( 'getNamespace' )
+			->will( $this->returnValue( NS_MAIN ) );
+
+		$translation = [
+			'languagecode' => 'foo',
+			'sourcepagetitle' => $title,
+			'messagegroupid' => 'bar'
+		];
+
+		$instance = new TranslationPropertyAnnotator(
+			new NullPropertyAnnotator( $semanticData ),
+			$translation
+		);
+
+		$instance->setPredefinedPropertyList( [] );
+		$instance->addAnnotation();
+	}
+
+	public function testAddAnnotation_EmptyData() {
+
+		$semanticData = new SemanticData(
+			$this->dataItemFactory->newDIWikiPage( 'Foo' )
+		);
+
+		$title = $this->getMockBuilder( '\Title' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$translation = [];
+
+		$instance = new TranslationPropertyAnnotator(
+			new NullPropertyAnnotator( $semanticData ),
+			$translation
+		);
+
+		$instance->addAnnotation();
+
+		$this->assertEquals(
+			$semanticData,
+			$instance->getSemanticData()
+		);
+	}
+
+}


### PR DESCRIPTION
This PR is made in reference to: #2300

This PR addresses or contains:

- Adds support for `translate-translation-page` and `_TRANS`
- `_TRANS` related value annotations are stored as separate subobject, the property chain notation can be used to get access to the values such as:
  - `Translation.Language` (languagecode)
  - `Translation.Translation source` (sourcepagetitle)
  - `Translation.Translation group` (messagegroupid)
-  `_TRANS` is set as default in `'smwgPageSpecialProperties' => array( '_MDAT', '_TRANS' ),` so translation related annotations should work out-of-the box given that the Translation extension sets `translate-translation-page`

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed

Fixes #2300