### PR TITLE
Remove `_TRANS` from the `$smwgPageSpecialProperties` configuration parameter

### DIFF
--- a/DefaultSettings.php
+++ b/DefaultSettings.php
@@ -866,7 +866,7 @@ return array(
 	#
 	# @since 1.7
 	##
-	'smwgPageSpecialProperties' => array( '_MDAT', '_TRANS' ),
+	'smwgPageSpecialProperties' => array( '_MDAT' ),
 	##
 
 	###


### PR DESCRIPTION
This PR is made in reference to: #3293 

This PR addresses or contains:
- Removes `_TRANS` from the `$smwgPageSpecialProperties` configuration parameter

This PR includes:
- [ ] Tests (unit/integration)
- [x] CI build passed

Fixes #