### PR TITLE
Add SearchResultSet::extractResults, refs 3204

### DIFF
--- a/tests/phpunit/Unit/MediaWiki/Search/SearchResultSetTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Search/SearchResultSetTest.php
@@ -83,6 +83,28 @@ class SearchResultSetTest extends \PHPUnit_Framework_TestCase {
 		$this->assertFalse( $this->resultSet->next() );
 	}
 
+	public function testExtractResults() {
+
+		$res = $this->resultSet->extractResults();
+
+		$this->assertCount(
+			3,
+			$res
+		);
+
+		$this->assertEquals(
+			3,
+			$this->resultSet->numRows()
+		);
+
+		foreach ( $res as $searchResult ) {
+			$this->assertInstanceOf(
+				'SearchResult',
+				 $searchResult
+			);
+		}
+	}
+
 	public function testSearchContainedSyntax() {
 		$this->assertTrue( $this->resultSet->searchContainedSyntax() );
 	}


### PR DESCRIPTION
This PR is made in reference to: #3204

This PR addresses or contains:

- Adds `SearchResultSet::extractResults` as noted in https://github.com/wikimedia/mediawiki/commit/720fdfa7901cbba93b5695ed5f00f982272ced27

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed

Fixes #3204