### PR TITLE
[UI] Use tabs on property, concept page

### DIFF
--- a/DefaultSettings.php
+++ b/DefaultSettings.php
@@ -443,7 +443,7 @@ return array(
 	##
 	'smwgPagingLimit' => [
 		'type' => 200,
-		'concept' => 200,
+		'concept' => 250,
 		'property' => 20,
 		'errorlist' => 25,
 

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -772,5 +772,11 @@
 	"smw-remote-source-unmatched-id": "The '''$1''' source does not match a version of Semantic MediaWiki that can support a remote request.",
 	"smw-remote-request-note": "The result is fetched from the '''$1''' remote source and it is likely for generated content to contain information that is not available from within the current wiki.",
 	"smw-remote-request-note-cached": "The result is '''cached''' from the '''$1''' remote source and it is likely for generated content to contain information that is not available from within the current wiki.",
-	"smw-parameter-missing": "Parameter \"$1\" is missing."
+	"smw-parameter-missing": "Parameter \"$1\" is missing.",
+	"smw-property-tab-usage": "Usage",
+	"smw-property-tab-redirects": "Synonyms",
+	"smw-property-tab-subproperties": "Subproperties",
+	"smw-property-tab-errors": "Improper assignments",
+	"smw-concept-tab-list": "List",
+	"smw-concept-tab-errors": "Errors"
 }

--- a/res/Resources.php
+++ b/res/Resources.php
@@ -630,5 +630,21 @@ return array(
 		)
 	),
 
+	'smw.property.page'  => $moduleTemplate + array(
+		'position' => 'top',
+		'scripts'  => array( 'smw/util/smw.property.page.js' ),
+		'dependencies'  => array(
+			'mediawiki.api',
+			'mediawiki.api.parse',
+			'ext.smw.tooltip',
+		),
+		'messages' => array(
+			'smw_result_noresults'
+		),
+		'targets' => array(
+			'mobile',
+			'desktop'
+		)
+	),
 
 );

--- a/res/smw/ext.smw.page.css
+++ b/res/smw/ext.smw.page.css
@@ -100,7 +100,7 @@
 }
 
 .smw-page-navigation {
-	margin-top: 0.8em;
+	margin-top: 1.2em;
 }
 
 .smw-page-nav-note, .smw-page-nav-container {
@@ -124,23 +124,24 @@
 
 .smw-ui-pagination .page-link {
     display: inline-block;
-    padding: .30rem .55rem;
+    padding: .30em .55em;
     margin-left: -1px;
     line-height: 1.25;
     color: #007bff;
     background-color: #fff;
     border: 1px solid #dee2e6;
+    padding-top: 0.35em;
 }
 
 .smw-ui-pagination .page-link:first-child {
     margin-left: 0;
-    border-top-left-radius: .2rem;
-    border-bottom-left-radius: .2rem;
+    border-top-left-radius: .2em;
+    border-bottom-left-radius: .2em;
  }
 
 .smw-ui-pagination .page-link:last-child {
-    border-top-right-radius: .2rem;
-    border-bottom-right-radius: .2rem;
+    border-top-right-radius: .2em;
+    border-bottom-right-radius: .2em;
 }
 
 .smw-ui-pagination .page-link:hover {
@@ -198,13 +199,13 @@
 	-ms-user-select: none;
 	user-select: none;
 	border: 1px solid transparent;
-	padding: 0.5rem 1rem;
-	border-radius: 0.25rem;
+	padding: 0.5em 1em;
+	border-radius: 0.25em;
 	-webkit-transition: all 0.2s ease-in-out;
 	-o-transition: all 0.2s ease-in-out;
 	transition: all 0.2s ease-in-out;
-	padding: 0.25rem 0.5rem;
-	border-radius: 0.2rem;
+	padding: 0.25em 0.5em;
+	border-radius: 0.2em;
 	color: #292b2c;
 	border-color: #ddd;
 	display: inline-block;
@@ -213,7 +214,7 @@
 
 	position: relative;
 	/* display: block; */
-	/* padding: 0.5rem 0.75rem; */
+	/* padding: 0.5em 0.75em; */
 	/* margin-left: -1px; */
 	line-height: 1.25;
 	/* color: #0275d8; */
@@ -223,31 +224,35 @@
 
 .smw-ui-input-filter {
 	display: inline-block;
-    padding: 0 .25rem;
+    padding: 0 .25em;
     /* margin-left: 10px; */
     line-height: 1.25;
     color: #007bff;
     background-color: #fff;
     border: 1px solid #dee2e6;
-    border-top-left-radius: .2rem;
-    border-bottom-left-radius: .2rem;
-    border-top-right-radius: .2rem;
-    border-bottom-right-radius: .2rem;
+    border-top-left-radius: .2em;
+    border-bottom-left-radius: .2em;
+    border-top-right-radius: .2em;
+    border-bottom-right-radius: .2em;
 }
 
 .smw-ui-input-filter label {
-	margin-left: 0.25rem;
+	margin-left: 0.25em;
+	margin-bottom: 0px;
+	font-weight: normal;
 }
 
 .smw-ui-input-filter input {
 	border :0px solid #ddd;
-    padding: .42rem .55rem .35rem .55rem;
-    border-top-left-radius: .0rem;
-    border-bottom-left-radius: .0rem;
+    padding: .42em .55em .35em .55em;
+    border-top-left-radius: .0em;
+    border-bottom-left-radius: .0em;
     outline: none;
     border-left: 0.1em solid #ddd;
     /* border-left: 0; */
-    margin-left: 0.45rem;
+    margin-left: 0.45em;
+    font-weight: normal;
+    color: #333333;
 }
 
 .smw-property-page-results .value-row:nth-child(odd) {
@@ -288,6 +293,30 @@
 .smw-property-page-results.legacy .smwprops {
 	padding: 0px 0px;
 	padding-top: 0.3em;
+}
+
+.smw-property-page-info {
+	float:right;
+	padding-top: 8px;
+}
+
+/**
+ * Tabs
+ */
+.smw-tabs.smw-property, .smw-tabs.smw-property p {
+	margin-top: 15px;
+}
+
+.smw-property #tab-smw-property-value:checked ~ #tab-content-smw-property-value,
+.smw-property #tab-smw-property-subp:checked ~ #tab-content-smw-property-subp,
+.smw-property #tab-smw-property-errp:checked ~ #tab-content-smw-property-errp,
+.smw-property #tab-smw-property-redi:checked ~ #tab-content-smw-property-redi {
+	display: block;
+}
+
+.smw-concept #tab-smw-concept-list:checked ~ #tab-content-smw-concept-list,
+.smw-concept #tab-smw-concept-errors:checked ~ #tab-content-smw-concept-errors {
+	display: block;
 }
 
 /**

--- a/res/smw/ext.smw.tabs.css
+++ b/res/smw/ext.smw.tabs.css
@@ -44,7 +44,7 @@
 	display: inline-block;
 	margin: 0 0 -1px;
 	padding: 5px 25px;
-	font-weight: 600;
+	font-weight: normal;
 	text-align: center;
 	color: #bbb;
 	border: 1px solid transparent;
@@ -66,7 +66,7 @@
 }
 
 .smw-tabs input.nav-tab:checked + label.nav-label {
-	color: #555;
+	color: #24292e;
 	border: 1px solid #ddd;
 	border-top: 2px solid #337ab7;
 	border-bottom: 1px solid #fff;

--- a/res/smw/util/smw.property.page.js
+++ b/res/smw/util/smw.property.page.js
@@ -1,0 +1,50 @@
+/**
+ * @license GNU GPL v2+
+ * @since 3.0
+ *
+ * @author mwjames
+ */
+
+/*global jQuery, mediaWiki, mw */
+( function ( $, mw ) {
+
+	'use strict';
+
+	$( document ).ready( function() {
+
+		$( '.smw-property-page-info' ).removeClass( 'is-disabled' );
+
+		$( '.smw-property-page-info' ).each( function() {
+
+			var context = $( this );
+
+			var params = {
+				'search': $( this ).data( 'label' ),
+				'limit' : 1,
+				'strict': true,
+				'usageCount': true
+			};
+
+			var postArgs = {
+				'action': 'smwbrowse',
+				'browse': 'property',
+				'params': JSON.stringify( params )
+			};
+
+			new mw.Api().post( postArgs ).then( function ( data ) {
+				var text = '<table class="smw-personal-table"><tbody>' + data.query[context.data( 'key' )].usageCount + '</tbody></table>';
+
+				smw.Factory.newTooltip().show ( {
+					context: context,
+					title: mw.msg( 'smw-personal-jobqueue-watchlist' ),
+					type: 'persitent',
+					content: text
+				} );
+			}, function () {
+				// Do nothing
+			} );
+		} );
+
+	} );
+
+}( jQuery, mediaWiki ) );

--- a/src/Page/ListBuilder/ListBuilder.php
+++ b/src/Page/ListBuilder/ListBuilder.php
@@ -156,7 +156,7 @@ class ListBuilder {
 
 		if ( $resultCount > 0 ) {
 			$titleText = htmlspecialchars( str_replace( '_', ' ', $dataItem->getDBKey() ) );
-			$result .= "<div id=\"{$this->listHeader}\">" . Html::rawElement( 'h2', array(), wfMessage( $this->listHeader . '-header', $titleText )->text() ) . "\n<p>";
+			$result .= "<div id=\"{$this->listHeader}\">" . "\n<p>";
 
 			$result .= $message . "</p>";
 			$property = $this->checkProperty ? $property : null;

--- a/src/Page/ListBuilder/ValueListBuilder.php
+++ b/src/Page/ListBuilder/ValueListBuilder.php
@@ -206,11 +206,7 @@ class ValueListBuilder {
 		) . Html::rawElement(
 			'div',
 			array( 'id' => 'mw-pages' ),
-			Html::rawElement(
-				'h2',
-				array(),
-				wfMessage( 'smw_attribute_header', $titleText )->text()
-			) . $result
+			$result
 		);
 	}
 

--- a/src/Page/ListPager.php
+++ b/src/Page/ListPager.php
@@ -72,7 +72,7 @@ class ListPager {
 			Html::rawElement(
 				'input',
 				[
-					//'type' => 'search',
+					'type' => 'search',
 					'name' => 'filter',
 					'value' => $filter,
 					'form' => 'search',

--- a/src/Page/PropertyPage.php
+++ b/src/Page/PropertyPage.php
@@ -16,6 +16,7 @@ use SMW\RequestOptions;
 use SMW\Store;
 use SMW\StringCondition;
 use Title;
+use SMW\Utils\HtmlTabs;
 
 /**
  * @license GNU GPL v2+
@@ -206,6 +207,9 @@ class PropertyPage extends Page {
 		$html = '';
 		$languageCode = $context->getLanguage()->getCode();
 
+		$context->getOutput()->addModuleStyles( 'ext.smw.page.styles' );
+		$context->getOutput()->addModules( 'smw.property.page' );
+
 		$context->getOutput()->setPageTitle(
 			$this->propertyValue->getFormattedLabel( DataValueFormatter::WIKI_LONG )
 		);
@@ -222,28 +226,37 @@ class PropertyPage extends Page {
 			$this->property->isUserDefined()
 		);
 
+		$htmlTabs = new HtmlTabs();
+		$htmlTabs->setGroup( 'property' );
+
+		$html = $this->makeValueList( $languageCode );
+
+		$htmlTabs->tab( 'smw-property-value', $this->msg( 'smw-property-tab-usage' ), [ 'hide' => $html === '' ] );
+		$htmlTabs->content( 'smw-property-value', $html );
+
 		// Redirects
-		$html .= $this->makeList( 'redirect', '_REDI', true );
+		$html = $this->makeList( 'redirect', '_REDI', true );
+
+		$htmlTabs->tab( 'smw-property-redi', $this->msg( 'smw-property-tab-redirects' ), [ 'hide' => $html === '' ] );
+		$htmlTabs->content( 'smw-property-redi', $html );
 
 		// Subproperties
-		$html .= $this->makeList( 'subproperty', '_SUBP', true );
+		$html = $this->makeList( 'subproperty', '_SUBP', true );
 
-		// Improper assignments
-		$html .= $this->makeList( 'error', '_ERRP', false );
+		$htmlTabs->tab( 'smw-property-subp', $this->msg( 'smw-property-tab-subproperties' ),  [ 'hide' => $html === '' ] );
+		$htmlTabs->content( 'smw-property-subp', $html );
 
-		// Value and entity list
-		$html .= $this->makeValueList( $languageCode );
+		// Improperty values
+		$html = $this->makeList( 'error', '_ERRP', false );
 
-		if ( $html === '' ) {
-			return '';
-		}
+		$htmlTabs->tab( 'smw-property-errp', $this->msg( 'smw-property-tab-errors' ),  [ 'hide' => $html === '' ] );
+		$htmlTabs->content( 'smw-property-errp', $html );
 
-		return Html::element(
-			'div',
-			[
-				'id' => 'smwfootbr'
-			]
-		) . $html;
+		$html = $htmlTabs->buildHTML(
+			[ 'class' => 'smw-property clearfix' ]
+		);
+
+		return $html;
 	}
 
 	private function fetchSemanticDataFromEditInfo() {
@@ -331,6 +344,10 @@ class PropertyPage extends Page {
 				'filter' => $request->getVal( 'filter', '' )
 			]
 		);
+	}
+
+	private function msg( $params, $type = Message::TEXT, $lang = Message::USER_LANGUAGE ) {
+		return Message::get( $params, $type, $lang );
 	}
 
 }

--- a/src/Utils/HtmlTabs.php
+++ b/src/Utils/HtmlTabs.php
@@ -28,9 +28,14 @@ class HtmlTabs {
 	private $hidden = [];
 
 	/**
-	 * @var []
+	 * @var string|null
 	 */
-	private $activeTab = '';
+	private $activeTab = null;
+
+	/**
+	 * @var string
+	 */
+	private $group = 'tabs';
 
 	/**
 	 * @since 3.0
@@ -39,6 +44,15 @@ class HtmlTabs {
 	 */
 	public function setActiveTab( $activeTab ) {
 		$this->activeTab = $activeTab;
+	}
+
+	/**
+	 * @since 3.0
+	 *
+	 * @param string $group
+	 */
+	public function setGroup( $group ) {
+		$this->group = $group;
 	}
 
 	/**
@@ -74,6 +88,24 @@ class HtmlTabs {
 	 *
 	 * @return string
 	 */
+	public function html( $html, array $params = [] ) {
+
+		if ( isset( $params['hide'] ) && $params['hide'] ) {
+			return;
+		}
+
+		$this->tabs[] = $html;
+	}
+
+	/**
+	 * @since 3.0
+	 *
+	 * @param string $id
+	 * @param string $name
+	 * @param array $params
+	 *
+	 * @return string
+	 */
 	public function tab( $id, $name = '', array $params = [] ) {
 
 		if ( isset( $params['hide'] ) && $params['hide'] ) {
@@ -81,6 +113,11 @@ class HtmlTabs {
 		}
 
 		$isChecked = false;
+
+		// No acive tab means, select the first tab being added
+		if ( $this->activeTab === null ) {
+			$this->activeTab = $id;
+		}
 
 		if ( $id === $this->activeTab ) {
 			$isChecked = true;
@@ -92,7 +129,7 @@ class HtmlTabs {
 				'id'    => "tab-$id",
 				'class' => 'nav-tab',
 				'type'  => 'radio',
-				'name'  => 'tabs'
+				'name'  => $this->group
 			] + ( $isChecked ? [ 'checked' => 'checked' ] : [] )
 		) . Html::rawElement(
 			'label',

--- a/tests/phpunit/Unit/Utils/HtmlTabsTest.php
+++ b/tests/phpunit/Unit/Utils/HtmlTabsTest.php
@@ -32,6 +32,22 @@ class HtmlTabsTest extends \PHPUnit_Framework_TestCase {
 		);
 	}
 
+	public function testTab_Contents_AutoChecked() {
+
+		$instance = new HtmlTabs();
+		$instance->tab( 'foo', 'FOO' );
+		$instance->content( 'foo', '< ... bar ... >' );
+
+		$this->assertContains(
+			'<div class="smw-tabs foo-bar">' .
+			'<input id="tab-foo" class="nav-tab" type="radio" name="tabs" checked=""/>' .
+			'<label for="tab-foo" class="nav-label">FOO</label>' .
+			'<section id="tab-content-foo">< ... bar ... ></section>'.
+			'</div>',
+			$instance->buildHTML( [ 'class' => 'foo-bar' ] )
+		);
+	}
+
 	public function testTab_Contents_Hidden() {
 
 		$instance = new HtmlTabs();
@@ -42,6 +58,20 @@ class HtmlTabsTest extends \PHPUnit_Framework_TestCase {
 		$this->assertContains(
 			'<div class="smw-tabs foo-bar"></div>',
 			$instance->buildHTML( [ 'class' => 'foo-bar' ] )
+		);
+	}
+
+	public function testTab_WithExtraHtml() {
+
+		$instance = new HtmlTabs();
+
+		$instance->tab( 'foo', 'FOO' );
+		$instance->content( 'foo', '< ... bar ... >' );
+		$instance->html( '<span>Foobar</span>' );
+
+		$this->assertContains(
+			'<span>Foobar</span>',
+			$instance->buildHTML()
 		);
 	}
 


### PR DESCRIPTION
This PR is made in reference to: #

This PR addresses or contains:

- As part of the continues effort to improve UI components, use tabs to hide auxiliary information while allowing users to select them when required and hereby unclutter the display space available.
- Tabs do not require JS therefore functionality is available also on those devices with no JS support

This PR includes:
- [ ] Tests (unit/integration)
- [x] CI build passed

### Before

![image](https://user-images.githubusercontent.com/1245473/43994705-28393bc2-9d91-11e8-9ce1-e726ceabd925.png)

### After

![image](https://user-images.githubusercontent.com/1245473/43994643-fcff2e54-9d8f-11e8-89b0-38e6bbcf8998.png)
