### PR TITLE
Process `#-` in print request, refs 481

### DIFF
--- a/includes/query/SMW_Query.php
+++ b/includes/query/SMW_Query.php
@@ -482,9 +482,8 @@ class SMWQuery implements QueryContext {
 		}
 
 		foreach ( $this->getExtraPrintouts() as $printout ) {
-			$serialization = $printout->getSerialisation();
-			if ( $serialization !== '?#' ) {
-				$serialized['printouts'][] = $serialization;
+			if ( ( $serialisation = $printout->getSerialisation() ) !== '' ) {
+				$serialized['printouts'][] = $serialisation;
 			}
 		}
 

--- a/includes/query/SMW_QueryProcessor.php
+++ b/includes/query/SMW_QueryProcessor.php
@@ -164,15 +164,31 @@ class SMWQueryProcessor implements QueryContext {
 	 * @param array $rawParams
 	 */
 	public static function addThisPrintout( array &$printRequests, array $rawParams ) {
-		if ( !is_null( $printRequests ) ) {
-			$hasMainlabel = array_key_exists( 'mainlabel', $rawParams );
 
-			if  ( !$hasMainlabel || trim( $rawParams['mainlabel'] ) !== '-' ) {
-				array_unshift( $printRequests, new PrintRequest(
-					PrintRequest::PRINT_THIS,
-					$hasMainlabel ? $rawParams['mainlabel'] : ''
-				) );
+		if ( $printRequests === null ) {
+			return;
+		}
+
+		// If THIS is already registered, bail-out!
+		foreach ( $printRequests as $printRequest ) {
+			if ( $printRequest->isMode( PrintRequest::PRINT_THIS ) ) {
+				return;
 			}
+		}
+
+		$hasMainlabel = array_key_exists( 'mainlabel', $rawParams );
+
+		if  ( !$hasMainlabel || trim( $rawParams['mainlabel'] ) !== '-' ) {
+			$printRequest = new PrintRequest(
+				PrintRequest::PRINT_THIS,
+				$hasMainlabel ? $rawParams['mainlabel'] : ''
+			);
+
+			// Signal to any post-processing that THIS was added outside of
+			// the normal processing chain
+			$printRequest->isDisconnected( true );
+
+			array_unshift( $printRequests, $printRequest );
 		}
 	}
 

--- a/src/MediaWiki/Specials/SpecialAsk.php
+++ b/src/MediaWiki/Specials/SpecialAsk.php
@@ -575,10 +575,7 @@ class SpecialAsk extends SpecialPage {
 		$code = $this->queryString ? htmlspecialchars( $this->queryString ) . "\n" : "\n";
 
 		foreach ( $this->printouts as $printout ) {
-			$serialization = $printout->getSerialisation( true );
-			$mainlabel = isset( $this->parameters['mainlabel'] ) ? '?=' . $this->parameters['mainlabel'] . '#' : '';
-
-			if ( $serialization !== '?#' && $serialization !== $mainlabel ) {
+			if ( ( $serialization = $printout->getSerialisation( true ) ) !== '' ) {
 				$code .= ' |' . $serialization . "\n";
 			}
 		}
@@ -684,7 +681,10 @@ class SpecialAsk extends SpecialPage {
 		$duration = 0;
 		$queryobj = null;
 
-		// FIXME: this is a hack
+		// Copy the printout to retain the orginal state while in case of no
+		// specific subject (THIS) request extend the query with a
+		// `PrintRequest::PRINT_THIS` column
+
 		QueryProcessor::addThisPrintout( $this->printouts, $this->parameters );
 
 		$params = QueryProcessor::getProcessedParams(

--- a/src/Query/PrintRequest/Serializer.php
+++ b/src/Query/PrintRequest/Serializer.php
@@ -137,12 +137,25 @@ class Serializer {
 
 		$result = '?';
 
+		// Has leading ?#
+		if ( $printRequest->hasLabelMarker() ) {
+			$result .= '#';
+		}
+
 		if ( $printRequest->getLabel() !== '' ) {
 			$result .= '=' . $printRequest->getLabel();
 		}
 
-		if ( $printRequest->getOutputFormat() !== '' ) {
-			$result .= '#' . $printRequest->getOutputFormat();
+		$outputFormat = $printRequest->getOutputFormat();
+
+		if ( $outputFormat !== '' && $outputFormat !== false && $outputFormat !== null ) {
+
+			// Handle ?, ?#- vs. ?#Foo=#-
+			if ( $printRequest->getLabel() !== '' ) {
+				$result .= '#';
+			}
+
+			$result .= $outputFormat;
 		}
 
 		return $result . $parameters;

--- a/src/Query/QueryLinker.php
+++ b/src/Query/QueryLinker.php
@@ -55,12 +55,8 @@ class QueryLinker {
 		$params = array( trim( $query->getQueryString( true ) ) );
 
 		foreach ( $query->getExtraPrintouts() as /* PrintRequest */ $printout ) {
-			$serialization = $printout->getSerialisation( true );
-
-			// TODO: this is a hack to get rid of the mainlabel param in case it was automatically added
-			// by SMWQueryProcessor::addThisPrintout. Should be done nicer when this link creation gets redone.
-			if ( $serialization !== '?#' && $serialization !== '?=' . $query->getMainLabel() . '#' ) {
-				$params[] = $serialization;
+			if ( ( $serialisation = $printout->getSerialisation( true ) ) !== '' ) {
+				$params[] = $serialisation;
 			}
 		}
 

--- a/src/Query/QueryStringifier.php
+++ b/src/Query/QueryStringifier.php
@@ -113,11 +113,8 @@ class QueryStringifier {
 		}
 
 		foreach ( $query->getExtraPrintouts() as $printout ) {
-			$serialization = $printout->getSerialisation( $showParams );
-			if ( $serialization !== '?#' ) {
-				// #show adds an extra = at the end which is interpret as
-				// requesting an empty result hence it is removed
-				$printouts[] = substr( $serialization, -1 ) === '=' ? substr( $serialization, 0, -1 ) : $serialization;
+			if ( ( $serialisation = $printout->getSerialisation( $showParams ) ) !== '' ) {
+				$printouts[] = $serialisation;
 			}
 		}
 

--- a/tests/phpunit/Integration/JSONScript/TestCases/f-0211.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/f-0211.json
@@ -1,0 +1,230 @@
+{
+	"description": "Test `format=plainlist` with `limit=0` (further result links) for `mainlabel/?#...` (#481)",
+	"setup": [
+		{
+			"namespace": "SMW_NS_PROPERTY",
+			"page": "Has text",
+			"contents": "[[Has type::Text]]"
+		},
+		{
+			"namespace": "SMW_NS_PROPERTY",
+			"page": "Has page",
+			"contents": "[[Has type::Page]]"
+		},
+		{
+			"page": "Example/F0211/1",
+			"contents": "[[Has text::F0211]] [[Has page::F0211]] [[Category:F0211]]"
+		},
+		{
+			"page": "Example/F0211/Q1.1",
+			"contents": "{{#ask: [[Has page::F0211]] |?#=Foo |?Has page |format=plainlist |template=Template/F0211 |named args=yes |limit=0 }}"
+		},
+		{
+			"page": "Example/F0211/Q1.2",
+			"contents": "{{#ask: [[Has page::F0211]] |?#=Foo |?Has page |format=plainlist |template=Template/F0211 |named args=yes |limit=0 |mainlabel=- }}"
+		},
+		{
+			"page": "Example/F0211/Q1.3",
+			"contents": "{{#ask: [[Has page::F0211]] |?#=Foo# |?Has page |format=plainlist |template=Template/F0211 |named args=yes |limit=0 }}"
+		},
+		{
+			"page": "Example/F0211/Q1.4",
+			"contents": "{{#ask: [[Has page::F0211]] |?#=Foo#- |?Has page |format=plainlist |template=Template/F0211 |named args=yes |limit=0 }}"
+		},
+		{
+			"page": "Example/F0211/Q2.1",
+			"contents": "{{#ask: [[Has page::F0211]] |?Has page |format=plainlist |template=Template/F0211 |named args=yes |limit=0 |mainlabel= }}"
+		},
+		{
+			"page": "Example/F0211/Q2.2",
+			"contents": "{{#ask: [[Has page::F0211]] |?Has page |format=plainlist |template=Template/F0211 |named args=yes |limit=0 |mainlabel=- }}"
+		},
+		{
+			"page": "Example/F0211/Q2.3",
+			"contents": "{{#ask: [[Has page::F0211]] |?Has page |format=plainlist |template=Template/F0211 |named args=yes |limit=0 |mainlabel=FOO }}"
+		},
+		{
+			"page": "Example/F0211/Q3.1",
+			"contents": "{{#ask: [[Has page::F0211]] |?Has page |?#  | mainlabel= |format=plainlist |template=Template/F0211 |named args=yes |limit=0 }}"
+		},
+		{
+			"page": "Example/F0211/Q3.2",
+			"contents": "{{#ask: [[Has page::F0211]] |?Has page |?#- | mainlabel= |format=plainlist |template=Template/F0211 |named args=yes |limit=0 }}"
+		},
+		{
+			"page": "Example/F0211/Q3.3",
+			"contents": "{{#ask: [[Has page::F0211]] |?Has page |?#- | mainlabel=- |format=plainlist |template=Template/F0211 |named args=yes |limit=0 }}"
+		},
+		{
+			"page": "Example/F0211/Q3.4",
+			"contents": "{{#ask: [[Has page::F0211]] |?Has page |?#- | mainlabel=FOO |format=plainlist |template=Template/F0211 |named args=yes |limit=0 }}"
+		},
+		{
+			"page": "Example/F0211/Q4.1",
+			"contents": "{{#ask: [[Has page::F0211]] |?Has page |? | mainlabel= |format=plainlist |template=Template/F0211 |named args=yes |limit=0 }}"
+		},
+		{
+			"page": "Example/F0211/Q4.2",
+			"contents": "{{#ask: [[Has page::F0211]] |?Has page |?- | mainlabel= |format=plainlist |template=Template/F0211 |named args=yes |limit=0 }}"
+		},
+		{
+			"page": "Example/F0211/Q4.3",
+			"contents": "{{#ask: [[Has page::F0211]] |?Has page |?=Foo | mainlabel= |format=plainlist |template=Template/F0211 |named args=yes |limit=0 }}"
+		}
+	],
+	"tests": [
+		{
+			"type": "format",
+			"about": "#0",
+			"subject": "Example/F0211/Q1.1",
+			"assert-output": {
+				"to-contain": [
+					"Special:Ask/-5B-5BHas-20page::F0211-5D-5D/-3F-23%3DFoo/-3FHas-20page/mainlabel%3D/offset%3D0/format%3Dplainlist/template%3DTemplate-2FF0211/named-20args%3Dyes"
+				]
+			}
+		},
+		{
+			"type": "format",
+			"about": "#1",
+			"subject": "Example/F0211/Q1.2",
+			"assert-output": {
+				"to-contain": [
+					"Special:Ask/-5B-5BHas-20page::F0211-5D-5D/-3F-23%3DFoo/-3FHas-20page/mainlabel%3D-2D/offset%3D0/format%3Dplainlist/template%3DTemplate-2FF0211/named-20args%3Dyes"
+				]
+			}
+		},
+		{
+			"type": "format",
+			"about": "#2",
+			"subject": "Example/F0211/Q1.3",
+			"assert-output": {
+				"to-contain": [
+					"Special:Ask/-5B-5BHas-20page::F0211-5D-5D/-3F-23%3DFoo-23-2D/-3FHas-20page/mainlabel%3D/offset%3D0/format%3Dplainlist/template%3DTemplate-2FF0211/named-20args%3Dyes"
+				]
+			}
+		},
+		{
+			"type": "format",
+			"about": "#3 (link is the same as in #2 due to `-`)",
+			"subject": "Example/F0211/Q1.4",
+			"assert-output": {
+				"to-contain": [
+					"Special:Ask/-5B-5BHas-20page::F0211-5D-5D/-3F-23%3DFoo-23-2D/-3FHas-20page/mainlabel%3D/offset%3D0/format%3Dplainlist/template%3DTemplate-2FF0211/named-20args%3Dyes"
+				]
+			}
+		},
+		{
+			"type": "format",
+			"about": "#4 (mainlabel)",
+			"subject": "Example/F0211/Q2.1",
+			"assert-output": {
+				"to-contain": [
+					"Special:Ask/-5B-5BHas-20page::F0211-5D-5D/-3FHas-20page/mainlabel%3D/offset%3D0/format%3Dplainlist/template%3DTemplate-2FF0211/named-20args%3Dyes"
+				]
+			}
+		},
+		{
+			"type": "format",
+			"about": "#5 (mainlabel)",
+			"subject": "Example/F0211/Q2.2",
+			"assert-output": {
+				"to-contain": [
+					"Special:Ask/-5B-5BHas-20page::F0211-5D-5D/-3FHas-20page/mainlabel%3D-2D/offset%3D0/format%3Dplainlist/template%3DTemplate-2FF0211/named-20args%3Dyes"
+				]
+			}
+		},
+		{
+			"type": "format",
+			"about": "#6 (mainlabel)",
+			"subject": "Example/F0211/Q2.3",
+			"assert-output": {
+				"to-contain": [
+					"Special:Ask/-5B-5BHas-20page::F0211-5D-5D/-3FHas-20page/mainlabel%3DFOO/offset%3D0/format%3Dplainlist/template%3DTemplate-2FF0211/named-20args%3Dyes"
+				]
+			}
+		},
+		{
+			"type": "format",
+			"about": "#7",
+			"subject": "Example/F0211/Q3.1",
+			"assert-output": {
+				"to-contain": [
+					"Special:Ask/-5B-5BHas-20page::F0211-5D-5D/-3FHas-20page/-3F-23/mainlabel%3D/offset%3D0/format%3Dplainlist/template%3DTemplate-2FF0211/named-20args%3Dyes"
+				]
+			}
+		},
+		{
+			"type": "format",
+			"about": "#8",
+			"subject": "Example/F0211/Q3.2",
+			"assert-output": {
+				"to-contain": [
+					"Special:Ask/-5B-5BHas-20page::F0211-5D-5D/-3FHas-20page/-3F-23-2D/mainlabel%3D/offset%3D0/format%3Dplainlist/template%3DTemplate-2FF0211/named-20args%3Dyes"
+				]
+			}
+		},
+		{
+			"type": "format",
+			"about": "#9",
+			"subject": "Example/F0211/Q3.3",
+			"assert-output": {
+				"to-contain": [
+					"Special:Ask/-5B-5BHas-20page::F0211-5D-5D/-3FHas-20page/-3F-23-2D/mainlabel%3D-2D/offset%3D0/format%3Dplainlist/template%3DTemplate-2FF0211/named-20args%3Dyes"
+				]
+			}
+		},
+		{
+			"type": "format",
+			"about": "#10",
+			"subject": "Example/F0211/Q3.4",
+			"assert-output": {
+				"to-contain": [
+					"Special:Ask/-5B-5BHas-20page::F0211-5D-5D/-3FHas-20page/-3F-23-2D/mainlabel%3DFOO/offset%3D0/format%3Dplainlist/template%3DTemplate-2FF0211/named-20args%3Dyes"
+				]
+			}
+		},
+		{
+			"type": "format",
+			"about": "#11",
+			"subject": "Example/F0211/Q4.1",
+			"assert-output": {
+				"to-contain": [
+					"Special:Ask/-5B-5BHas-20page::F0211-5D-5D/-3FHas-20page/-3F/mainlabel%3D/offset%3D0/format%3Dplainlist/template%3DTemplate-2FF0211/named-20args%3Dyes"
+				]
+			}
+		},
+		{
+			"type": "format",
+			"about": "#12 (?- is not valid and is therefore ignored)",
+			"subject": "Example/F0211/Q4.2",
+			"assert-output": {
+				"to-contain": [
+					"Special:Ask/-5B-5BHas-20page::F0211-5D-5D/-3FHas-20page/mainlabel%3D/offset%3D0/format%3Dplainlist/template%3DTemplate-2FF0211/named-20args%3Dyes"
+				]
+			}
+		},
+		{
+			"type": "format",
+			"about": "#13",
+			"subject": "Example/F0211/Q4.3",
+			"assert-output": {
+				"to-contain": [
+					"Special:Ask/-5B-5BHas-20page::F0211-5D-5D/-3FHas-20page/-3F%3DFoo/mainlabel%3D/offset%3D0/format%3Dplainlist/template%3DTemplate-2FF0211/named-20args%3Dyes"
+				]
+			}
+		}
+	],
+	"settings": {
+		"wgContLang": "en",
+		"wgLang": "en",
+		"smwgNamespacesWithSemanticLinks": {
+			"NS_MAIN": true,
+			"SMW_NS_PROPERTY": true
+		}
+	},
+	"meta": {
+		"version": "2",
+		"is-incomplete": false,
+		"debug": false
+	}
+}

--- a/tests/phpunit/Integration/JSONScript/TestCases/s-0029.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/s-0029.json
@@ -1,0 +1,185 @@
+{
+	"description": "Test `Special:Ask` output on `mainlabel=.../?#...`, `format=table`",
+	"setup": [
+		{
+			"namespace": "SMW_NS_PROPERTY",
+			"page": "Has page",
+			"contents": "[[Has type::Page]]"
+		},
+		{
+			"page": "Example/S0029/1",
+			"contents": "[[Has page::123]] [[Category:S0029]]"
+		}
+	],
+	"tests": [
+		{
+			"type": "special",
+			"about": "#0 (?#, empty mainlabel)",
+			"special-page": {
+				"page": "Ask",
+				"query-parameters": "-5B-5BCategory:S0029-5D-5D/-3FHas-20page/-3F-23/mainlabel%3D/offset%3D0/format%3Dtable",
+				"request-parameters": []
+			},
+			"assert-output": {
+				"to-contain": [
+					"<table class=\"sortable wikitable smwtable\">",
+					"<a href=.*Property:Has_page\" title=\"Property:Has page\">Has page</a></th><th>&nbsp;</th>",
+					"<tr data-row-number=\"1\" class=\"row-odd\"><td class=\"Has-page smwtype_wpg\" data-sort-value=\"123\">",
+					"<td class=\"smwtype_wpg\"><a href=.*Example/S0029/1\" title=\"Example/S0029/1\">Example/S0029/1</a></td>"
+				]
+			}
+		},
+		{
+			"type": "special",
+			"about": "#0.1 (?, empty mainlabel)",
+			"special-page": {
+				"page": "Ask",
+				"query-parameters": "-5B-5BCategory:S0029-5D-5D/-3FHas-20page/-3F/mainlabel%3D/offset%3D0/format%3Dtable",
+				"request-parameters": []
+			},
+			"assert-output": {
+				"to-contain": [
+					"<table class=\"sortable wikitable smwtable\">",
+					"<a href=.*Property:Has_page\" title=\"Property:Has page\">Has page</a></th><th>&nbsp;</th>",
+					"<tr data-row-number=\"1\" class=\"row-odd\"><td class=\"Has-page smwtype_wpg\" data-sort-value=\"123\">",
+					"<td class=\"smwtype_wpg\"><a href=.*Example/S0029/1\" title=\"Example/S0029/1\">Example/S0029/1</a></td>"
+				]
+			}
+		},
+		{
+			"type": "special",
+			"about": "#1 (?#, mainlabel=-, output the same as in #0)",
+			"special-page": {
+				"page": "Ask",
+				"query-parameters": "-5B-5BCategory:S0029-5D-5D/-3FHas-20page/-3F-23/mainlabel%3D-2D/offset%3D0/format%3Dtable",
+				"request-parameters": []
+			},
+			"assert-output": {
+				"to-contain": [
+					"<table class=\"sortable wikitable smwtable\">",
+					"<a href=.*Property:Has_page\" title=\"Property:Has page\">Has page</a></th><th>&nbsp;</th>",
+					"<tr data-row-number=\"1\" class=\"row-odd\"><td class=\"Has-page smwtype_wpg\" data-sort-value=\"123\">",
+					"<td class=\"smwtype_wpg\"><a href=.*Example/S0029/1\" title=\"Example/S0029/1\">Example/S0029/1</a></td>"
+				]
+			}
+		},
+		{
+			"type": "special",
+			"about": "#2 (?#, mainlabel=FOO, ?# takes precedence over mainlabel, same output as in #0)",
+			"special-page": {
+				"page": "Ask",
+				"query-parameters": "-5B-5BCategory:S0029-5D-5D/-3FHas-20page/-3F-23/mainlabel%3DFOO/offset%3D0/format%3Dtable",
+				"request-parameters": []
+			},
+			"assert-output": {
+				"to-contain": [
+					"<table class=\"sortable wikitable smwtable\">",
+					"<a href=.*Property:Has_page\" title=\"Property:Has page\">Has page</a></th><th>&nbsp;</th>",
+					"<tr data-row-number=\"1\" class=\"row-odd\"><td class=\"Has-page smwtype_wpg\" data-sort-value=\"123\">",
+					"<td class=\"smwtype_wpg\"><a href=.*Example/S0029/1\" title=\"Example/S0029/1\">Example/S0029/1</a></td>"
+				]
+			}
+		},
+		{
+			"type": "special",
+			"about": "#3 (?#- forces plain output, empty mainlabel)",
+			"special-page": {
+				"page": "Ask",
+				"query-parameters": "-5B-5BCategory:S0029-5D-5D/-3FHas-20page/-3F-23-2D/mainlabel%3D/offset%3D0/format%3Dtable",
+				"request-parameters": []
+			},
+			"assert-output": {
+				"to-contain": [
+					"<table class=\"sortable wikitable smwtable\">",
+					"<a href=.*Property:Has_page\" title=\"Property:Has page\">Has page</a></th><th>&nbsp;</th>",
+					"<tr data-row-number=\"1\" class=\"row-odd\"><td class=\"Has-page smwtype_wpg\" data-sort-value=\"123\">",
+					"<td class=\"smwtype_wpg\">Example/S0029/1</td>"
+				]
+			}
+		},
+		{
+			"type": "special",
+			"about": "#4 (?#=Foo, empty mainlabel)",
+			"special-page": {
+				"page": "Ask",
+				"query-parameters": "-5B-5BCategory:S0029-5D-5D/-3FHas-20page/-3F-23%3DFoo/mainlabel%3D/offset%3D0/format%3Dtable",
+				"request-parameters": []
+			},
+			"assert-output": {
+				"to-contain": [
+					"<table class=\"sortable wikitable smwtable\">",
+					"<a href=.*Property:Has_page\" title=\"Property:Has page\">Has page</a></th><th class=\"Foo\">Foo</th>",
+					"<tr data-row-number=\"1\" class=\"row-odd\"><td class=\"Has-page smwtype_wpg\" data-sort-value=\"123\">",
+					"<td class=\"Foo smwtype_wpg\"><a href=.*Example/S0029/1\" title=\"Example/S0029/1\">Example/S0029/1</a></td>"
+				]
+			}
+		},
+		{
+			"type": "special",
+			"about": "#4.1 (?=Foo, empty mainlabel)",
+			"special-page": {
+				"page": "Ask",
+				"query-parameters": "-5B-5BCategory:S0029-5D-5D/-3FHas-20page/-3F%3DFoo/mainlabel%3D/offset%3D0/format%3Dtable",
+				"request-parameters": []
+			},
+			"assert-output": {
+				"to-contain": [
+					"<table class=\"sortable wikitable smwtable\">",
+					"<a href=.*Property:Has_page\" title=\"Property:Has page\">Has page</a></th><th class=\"Foo\">Foo</th>",
+					"<tr data-row-number=\"1\" class=\"row-odd\"><td class=\"Has-page smwtype_wpg\" data-sort-value=\"123\">",
+					"<td class=\"Foo smwtype_wpg\"><a href=.*Example/S0029/1\" title=\"Example/S0029/1\">Example/S0029/1</a></td>"
+				]
+			}
+		},
+		{
+			"type": "special",
+			"about": "#5 (?#=Foo#- forces plain output, empty mainlabel)",
+			"special-page": {
+				"page": "Ask",
+				"query-parameters": "-5B-5BCategory:S0029-5D-5D/-3FHas-20page/-3F-23%3DFoo-23-2D/mainlabel%3D/offset%3D0/format%3Dtable",
+				"request-parameters": []
+			},
+			"assert-output": {
+				"to-contain": [
+					"<table class=\"sortable wikitable smwtable\">",
+					"<a href=.*Property:Has_page\" title=\"Property:Has page\">Has page</a></th><th class=\"Foo\">Foo</th>",
+					"<tr data-row-number=\"1\" class=\"row-odd\"><td class=\"Has-page smwtype_wpg\" data-sort-value=\"123\">",
+					"<td class=\"Foo smwtype_wpg\">Example/S0029/1</td>"
+				]
+			}
+		},
+		{
+			"type": "special",
+			"about": "#6 (?#=Foo#- forces plain output, mainlabel=-, same output as in #5)",
+			"special-page": {
+				"page": "Ask",
+				"query-parameters": "-5B-5BCategory:S0029-5D-5D/-3FHas-20page/-3F-23%3DFoo-23-2D/mainlabel%3D-2D/offset%3D0/format%3Dtable",
+				"request-parameters": []
+			},
+			"assert-output": {
+				"to-contain": [
+					"<table class=\"sortable wikitable smwtable\">",
+					"<a href=.*Property:Has_page\" title=\"Property:Has page\">Has page</a></th><th class=\"Foo\">Foo</th>",
+					"<tr data-row-number=\"1\" class=\"row-odd\"><td class=\"Has-page smwtype_wpg\" data-sort-value=\"123\">",
+					"<td class=\"Foo smwtype_wpg\">Example/S0029/1</td>"
+				]
+			}
+		}
+	],
+	"settings": {
+		"wgContLang": "en",
+		"wgLanguageCode": "en",
+		"smwgPageSpecialProperties": [
+			"_MDAT"
+		],
+		"smwgNamespacesWithSemanticLinks": {
+			"NS_MAIN": true,
+			"SMW_NS_PROPERTY": true
+		}
+	},
+	"meta": {
+		"version": "2",
+		"is-incomplete": false,
+		"debug": false
+	}
+}

--- a/tests/phpunit/Unit/Query/PrintRequest/DeserializerTest.php
+++ b/tests/phpunit/Unit/Query/PrintRequest/DeserializerTest.php
@@ -174,6 +174,36 @@ class DeserializerTest extends \PHPUnit_Framework_TestCase {
 			'Bar'
 		);
 
+		#12 #481
+		$provider[] = array(
+			'#=Foo',
+			false,
+			'Foo',
+			PrintRequest::PRINT_THIS,
+			null,
+			''
+		);
+
+		#13 #481
+		$provider[] = array(
+			'#=Foo#',
+			false,
+			'Foo',
+			PrintRequest::PRINT_THIS,
+			null,
+			'-'
+		);
+
+		#13 #481
+		$provider[] = array(
+			'#=Foo#-',
+			false,
+			'Foo',
+			PrintRequest::PRINT_THIS,
+			null,
+			'-'
+		);
+
 		return $provider;
 	}
 

--- a/tests/phpunit/Unit/Query/PrintRequest/SerializerTest.php
+++ b/tests/phpunit/Unit/Query/PrintRequest/SerializerTest.php
@@ -49,7 +49,13 @@ class SerializerTest extends \PHPUnit_Framework_TestCase {
 		$provider['print-this'] = array(
 			new PrintRequest( PrintRequest::PRINT_THIS, 'Foo' ),
 			false,
-			'?=Foo#'
+			'?=Foo'
+		);
+
+		$provider['print-this-plain'] = array(
+			new PrintRequest( PrintRequest::PRINT_THIS, 'Foo', null, '-' ),
+			false,
+			'?=Foo#-'
 		);
 
 		$data = DataValueFactory::getInstance()->newPropertyValueByLabel( 'Bar' );

--- a/tests/phpunit/Unit/Query/QueryStringifierTest.php
+++ b/tests/phpunit/Unit/Query/QueryStringifierTest.php
@@ -259,7 +259,7 @@ class QueryStringifierTest extends \PHPUnit_Framework_TestCase {
 
 		$printRequest->expects( $this->any() )
 			->method( 'getSerialisation' )
-			->will( $this->returnValue( '?ABC=' ) );
+			->will( $this->returnValue( '?ABC' ) );
 
 		$query = $this->getMockBuilder( '\SMWQuery' )
 			->disableOriginalConstructor()


### PR DESCRIPTION
This PR is made in reference to: #481

This PR addresses or contains:

- Moves the handling of `#` into the `PrintRequest` class and removes special treatment of it from different places 
- To limit the possibilities of a regression in terms of `#` as mainlabel/subject identifier, add `f-0211.json` and `s-0029.json` to cover known uses case of `... |?#=Foo ...`


This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed

Fixes #481