### PR TITLE
Move FIXED_PROPERTY_ID_UPPERBOUND from 50 to 500, refs 1579

### DIFF
--- a/DefaultSettings.php
+++ b/DefaultSettings.php
@@ -77,7 +77,7 @@ return array(
 	#
 	# @since 3.0
 	##
-	'smwgUpgradeKey' => 'DB-2018-07',
+	'smwgUpgradeKey' => 'DB-2018-08',
 	##
 
 	###

--- a/includes/storage/SQLStore/SMW_SQLStore3.php
+++ b/includes/storage/SQLStore/SMW_SQLStore3.php
@@ -51,9 +51,9 @@ class SMWSQLStore3 extends SMWStore {
 	 * in the ID_TABLE
 	 *
 	 * When changing the upper bound, please make sure to copy the current upper
-	 * bound as legcy to the SMWSQLStore3SetupHandlers::checkPredefinedPropertyBorder
+	 * bound as legcy to the TableIntegrityExaminer::checkPredefinedPropertyUpperbound
 	 */
-	const FIXED_PROPERTY_ID_UPPERBOUND = 50;
+	const FIXED_PROPERTY_ID_UPPERBOUND = 500;
 
 	/**
 	 * Name of the table to store the concept cache in.

--- a/src/TypesRegistry.php
+++ b/src/TypesRegistry.php
@@ -234,4 +234,58 @@ class TypesRegistry {
 		];
 	}
 
+	/**
+	 * Use pre-defined ids for Very Important Properties, avoiding frequent
+	 * ID lookups for those.
+	 *
+	 * @note These constants also occur in the store. Changing them will
+	 * require to run setup.php again.
+	 *
+	 * @since 3.0
+	 *
+	 * @return array
+	 */
+	public static function getFixedPropertyIdList() {
+		return [
+			'_TYPE' => 1,
+			'_URI'  => 2,
+			'_INST' => 4,
+			'_UNIT' => 7,
+			'_IMPO' => 8,
+			'_PPLB' => 9,
+			'_PDESC' => 10,
+			'_PREC' => 11,
+			'_CONV' => 12,
+			'_SERV' => 13,
+			'_PVAL' => 14,
+			'_REDI' => 15,
+			'_DTITLE' => 16,
+			'_SUBP' => 17,
+			'_SUBC' => 18,
+			'_CONC' => 19,
+			'_ERRP' => 22,
+	// 		'_1' => 23, // properties for encoding (short) lists
+	// 		'_2' => 24,
+	// 		'_3' => 25,
+	// 		'_4' => 26,
+	// 		'_5' => 27,
+	// 		'_SOBJ' => 27
+			'_LIST' => 28,
+			'_MDAT' => 29,
+			'_CDAT' => 30,
+			'_NEWP' => 31,
+			'_LEDT' => 32,
+			// properties related to query management
+			'_ASK'   => 33,
+			'_ASKST' => 34,
+			'_ASKFO' => 35,
+			'_ASKSI' => 36,
+			'_ASKDE' => 37,
+			'_ASKPA' => 38,
+			'_ASKSC' => 39,
+			'_LCODE' => 40,
+			'_TEXT'  => 41,
+		];
+	}
+
 }

--- a/tests/phpunit/Unit/SQLStore/EntityRebuildDispatcherTest.php
+++ b/tests/phpunit/Unit/SQLStore/EntityRebuildDispatcherTest.php
@@ -4,6 +4,8 @@ namespace SMW\Tests\SQLStore;
 
 use SMW\ApplicationFactory;
 use SMW\SQLStore\EntityRebuildDispatcher;
+use SMW\SQLStore\SQLStore;
+use SMW\Tests\TestEnvironment;
 
 /**
  * @covers \SMW\SQLStore\EntityRebuildDispatcher
@@ -16,12 +18,25 @@ use SMW\SQLStore\EntityRebuildDispatcher;
  */
 class EntityRebuildDispatcherTest extends \PHPUnit_Framework_TestCase {
 
-	private $applicationFactory;
+	private $testEnvironment;
 
 	protected function setUp() {
 		parent::setUp();
 
-		$this->applicationFactory = ApplicationFactory::getInstance();
+		$this->testEnvironment = new TestEnvironment(
+			[
+				'smwgSemanticsEnabled' => true,
+				'smwgAutoRefreshSubject' => true,
+				'smwgCacheType' => 'hash',
+				'smwgEnableUpdateJobs' => false,
+			]
+		);
+
+		$jobQueue = $this->getMockBuilder( '\SMW\MediaWiki\JobQueue' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$this->testEnvironment->registerObject( 'JobQueue', $jobQueue );
 
 		$idTable = $this->getMockBuilder( '\stdClass' )
 			->disableOriginalConstructor()
@@ -45,14 +60,11 @@ class EntityRebuildDispatcherTest extends \PHPUnit_Framework_TestCase {
 			->method( 'getObjectIds' )
 			->will( $this->returnValue( $idTable ) );
 
-		$this->applicationFactory->registerObject( 'Store', $store );
-		$this->applicationFactory->getSettings()->set( 'smwgMainCacheType', 'hash' );
-		$this->applicationFactory->getSettings()->set( 'smwgEnableUpdateJobs', false );
+		$this->testEnvironment->registerObject( 'Store', $store );
 	}
 
 	protected function tearDown() {
-		$this->applicationFactory->clear();
-
+		$this->testEnvironment->tearDown();
 		parent::tearDown();
 	}
 
@@ -121,7 +133,7 @@ class EntityRebuildDispatcherTest extends \PHPUnit_Framework_TestCase {
 		);
 
 		$provider[] = array(
-			51,
+			9999999999999999999,
 			-1
 		);
 

--- a/tests/phpunit/Unit/SQLStore/TableIntegrityExaminerTest.php
+++ b/tests/phpunit/Unit/SQLStore/TableIntegrityExaminerTest.php
@@ -112,6 +112,10 @@ class TableIntegrityExaminerTest extends \PHPUnit_Framework_TestCase {
 			->disableOriginalConstructor()
 			->getMock();
 
+		$connection->expects( $this->at( 1 ) )
+			->method( 'selectRow' )
+			->will( $this->returnValue( (object)[ 'smw_id' => \SMW\SQLStore\SQLStore::FIXED_PROPERTY_ID_UPPERBOUND ] ) );
+
 		$connection->expects( $this->at( 2 ) )
 			->method( 'selectRow' )
 			->with(
@@ -222,22 +226,34 @@ class TableIntegrityExaminerTest extends \PHPUnit_Framework_TestCase {
 			->disableOriginalConstructor()
 			->getMock();
 
-		$connection->expects( $this->atLeastOnce() )
-			->method( 'query' )
-			->with( $this->equalTo( 'UPDATE smw_object_ids SET smw_sort = smw_sortkey' ) );
+		$connection->expects( $this->any() )
+			->method( 'selectRow' )
+			->will( $this->returnValue( false ) );
 
 		$connection->expects( $this->atLeastOnce() )
 			->method( 'tableName' )
 			->will( $this->returnValue( 'smw_object_ids' ) );
 
+		$connection->expects( $this->atLeastOnce() )
+			->method( 'tableName' )
+			->will( $this->returnValue( 'smw_object_ids' ) );
+
+		$idTable = $this->getMockBuilder( '\stdClass' )
+			->setMethods( array( 'moveSMWPageID' ) )
+			->getMock();
+
 		$store = $this->getMockBuilder( '\SMW\SQLStore\SQLStore' )
 			->disableOriginalConstructor()
-			->setMethods( array( 'getConnection' ) )
+			->setMethods( array( 'getConnection', 'getObjectIds' ) )
 			->getMock();
 
 		$store->expects( $this->any() )
 			->method( 'getConnection' )
 			->will( $this->returnValue( $connection ) );
+
+		$store->expects( $this->any() )
+			->method( 'getObjectIds' )
+			->will( $this->returnValue( $idTable ) );
 
 		$tableBuilder = $this->getMockBuilder( '\SMW\SQLStore\TableBuilder' )
 			->disableOriginalConstructor()

--- a/tests/phpunit/Unit/TypesRegistryTest.php
+++ b/tests/phpunit/Unit/TypesRegistryTest.php
@@ -31,6 +31,15 @@ class TypesRegistryTest extends \PHPUnit_Framework_TestCase {
 		);
 	}
 
+	public function testGetFixedPropertyIdList() {
+
+		$propertyList = TypesRegistry::getPropertyList();
+
+		foreach ( TypesRegistry::getFixedPropertyIdList() as $key => $id ) {
+			$this->assertArrayHasKey( $key, $propertyList );
+		}
+	}
+
 	/**
 	 * @dataProvider typeList
 	 */


### PR DESCRIPTION
This PR is made in reference to: #1579, https://github.com/SemanticMediaWiki/SemanticMediaWiki/issues/1014#issuecomment-230363632

This PR addresses or contains:

- To allow assigning fixed IDs to properties in upcoming releases
- This PR moves the `FIXED_PROPERTY_ID_UPPERBOUND` to 500 with all objects from in that range that are not predefined properties to be moved and assigned a new ID

This PR includes:
- [ ] Tests (unit/integration)
- [x] CI build passed
