### PR TITLE
Add smwgPostEditUpdate, refs 3310

### DIFF
--- a/DefaultSettings.php
+++ b/DefaultSettings.php
@@ -1260,6 +1260,28 @@ return array(
 	##
 
 	###
+	# Regulates task specific settings for the postEdit process.
+	#
+	# The main objective is to defer secondary updates until after the GET request
+	# has been finalized so that resource requirements are part of an API request
+	# (and not a GET) and hereby ensures that a client remains responsive
+	# independent of the update workload.
+	#
+	# `job.task` specifies jobs that should be executed on a post-edit to run in a
+	# timely manner independent of a users job scheduler environment. The number
+	# indicates the expected amount of jobs to be executed per request.
+	#
+	# @since 3.0
+	##
+	'smwgPostEditUpdate' => [
+		'job.task' => [
+			'SMW\FulltextSearchTableUpdateJob' => 1,
+			'SMW\ParserCachePurgeJob' => 5
+		]
+	],
+	##
+
+	###
 	# Query dependency and parser cache invalidation
 	#
 	# If enabled it will store dependencies for queries allowing it to purge

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -721,7 +721,7 @@
 	"smw-format-list-other-fields-close": ")",
 	"smw-category-invalid-redirect-target": "Category \"$1\" contains an invalid redirect target to a non-category namespace.",
 	"smw-parser-function-expensive-execution-limit": "The parser function has reached the limit for expensive executions (see configuration parameter [https://www.semantic-mediawiki.org/wiki/Help:$smwgQExpensiveExecutionLimit <code>$smwgQExpensiveExecutionLimit</code>]).",
-	"smw-postproc-queryref": "Semantic MediaWiki will initiate a page refresh due to some required query post processing.",
+	"smw-postproc-queryref": "Semantic MediaWiki is refreshing the current a page on the condition of some required query post processing.",
 	"apihelp-smwinfo-summary": "API module to retrieve information about Semantic MediaWiki statistics and other meta information.",
 	"apihelp-ask-summary": "API module to query Semantic MediaWiki using the ask language.",
 	"apihelp-askargs-summary": "API module to query Semantic MediaWiki using the ask language as list of conditions, printouts and parameters.",

--- a/includes/Settings.php
+++ b/includes/Settings.php
@@ -180,6 +180,7 @@ class Settings extends Options {
 			'smwgElasticsearchConfig' => $GLOBALS['smwgElasticsearchConfig'],
 			'smwgElasticsearchProfile' => $GLOBALS['smwgElasticsearchProfile'],
 			'smwgElasticsearchEndpoints' => $GLOBALS['smwgElasticsearchEndpoints'],
+			'smwgPostEditUpdate' => $GLOBALS['smwgPostEditUpdate'],
 		);
 
 		self::initLegacyMapping( $configuration );

--- a/res/smw/util/ext.smw.util.postproc.js
+++ b/res/smw/util/ext.smw.util.postproc.js
@@ -25,15 +25,17 @@
 
 		$( '.smw-postproc' ).each( function() {
 
+			var api = new mw.Api();
 			var ref = $( this ).data( 'ref' );
 
-			if ( ref !== '' ) {
+			if ( ref !== undefined && ref !== '' ) {
 				mw.notify( mw.msg( 'smw-postproc-queryref' ), { type: 'info', autoHide: false } );
 
 				var params = {
 					'subject': $( this ).data( 'subject' ),
 					'origin': 'api-postproc',
-					'ref' : ref
+					'ref' : ref,
+					'cache-key': $( this ).data( 'cache-key' )
 				};
 
 				var postArgs = {
@@ -42,11 +44,28 @@
 					'params': JSON.stringify( params )
 				};
 
-				new mw.Api().postWithToken( 'csrf', postArgs ).then( function ( data ) {
+				api.postWithToken( 'csrf', postArgs ).then( function ( data ) {
 					location.reload( true );
-				}, function () {
-					// Do nothing
 				} );
+			};
+
+			var jobs = $( this ).data( 'jobs' );
+
+			if ( jobs !== '' ) {
+
+				var params = {
+					'subject': $( this ).data( 'subject' ),
+					'origin': 'api-postproc',
+					'jobs' : jobs
+				};
+
+				var postArgs = {
+					'action': 'smwtask',
+					'task': 'run-joblist',
+					'params': JSON.stringify( params )
+				};
+
+				api.postWithToken( 'csrf', postArgs );
 			};
 
 		} );

--- a/src/MediaWiki/Jobs/ParserCachePurgeJob.php
+++ b/src/MediaWiki/Jobs/ParserCachePurgeJob.php
@@ -65,6 +65,7 @@ class ParserCachePurgeJob extends JobBase {
 	 */
 	public function __construct( Title $title, $params = array() ) {
 		parent::__construct( 'SMW\ParserCachePurgeJob', $title, $params );
+		$this->removeDuplicates = true;
 	}
 
 	/**
@@ -196,7 +197,7 @@ class ParserCachePurgeJob extends JobBase {
 		);
 
 		if ( $this->getParameter( 'exec.mode' ) === self::EXEC_JOURNAL ) {
-			$dependencyLinksUpdateJournal->updateFromList( $hashList );
+			$dependencyLinksUpdateJournal->updateFromList( $hashList, $this->getTitle()->getLatestRevID() );
 		} else{
 			$this->addPagesToUpdater( $hashList );
 		}

--- a/src/MediaWiki/Jobs/UpdateJob.php
+++ b/src/MediaWiki/Jobs/UpdateJob.php
@@ -270,6 +270,11 @@ class UpdateJob extends JobBase {
 		$parserData->setOrigin( $origin );
 
 		$parserData->setOption(
+			Enum::OPT_SUSPEND_PURGE,
+			$this->getParameter( Enum::OPT_SUSPEND_PURGE )
+		);
+
+		$parserData->setOption(
 			$parserData::OPT_FORCED_UPDATE,
 			$this->getParameter( self::FORCED_UPDATE )
 		);

--- a/src/SQLStore/QueryDependency/DependencyLinksUpdateJournal.php
+++ b/src/SQLStore/QueryDependency/DependencyLinksUpdateJournal.php
@@ -63,30 +63,14 @@ class DependencyLinksUpdateJournal {
 
 		$segments = [];
 
-		if ( $subject instanceof DIWikiPage ) {
-			$segments = [
-				$subject->getDBKey(),
-				$subject->getNamespace(),
-				$subject->getInterwiki(),
-				''
-			];
+		if ( $subject instanceof DIWikiPage || $subject instanceof Title ) {
+			$segments = [ $subject->getDBKey(), $subject->getNamespace(), $subject->getInterwiki(), '' ];
 		}
-
-		if ( $subject instanceof Title ) {
-			$segments = [
-				$subject->getDBKey(),
-				$subject->getNamespace(),
-				$subject->getInterwiki(),
-				''
-			];
-		}
-
-		$hash = implode( '#', $segments );
 
 		return smwfCacheKey(
 			self::CACHE_NAMESPACE,
 			[
-				$hash,
+				implode( '#', $segments ),
 				self::VERSION
 			]
 		);
@@ -96,8 +80,9 @@ class DependencyLinksUpdateJournal {
 	 * @since 3.0
 	 *
 	 * @param array $hashList
+	 * @param integer|true $revID
 	 */
-	public function updateFromList( array $hashList ) {
+	public function updateFromList( array $hashList, $revID = true ) {
 
 		foreach ( $hashList as $hash ) {
 
@@ -109,17 +94,19 @@ class DependencyLinksUpdateJournal {
 				]
 			);
 
-			$this->cache->save( $key, true );
+			$this->cache->save( $key, $revID );
 		}
+
 	}
 
 	/**
 	 * @since 3.0
 	 *
 	 * @param DIWikiPage|Title $subject
+	 * @param integer|true $revID
 	 */
-	public function update( $subject ) {
-		$this->cache->save( self::makeKey( $subject ), true );
+	public function update( $subject, $revID = true ) {
+		$this->cache->save( self::makeKey( $subject ), $revID );
 	}
 
 	/**

--- a/src/Services/SharedServicesContainer.php
+++ b/src/Services/SharedServicesContainer.php
@@ -42,6 +42,7 @@ use SMW\Query\QuerySourceFactory;
 use SMW\Query\Result\CachedQueryResultPrefetcher;
 use SMW\Rule\RuleFactory;
 use SMW\Settings;
+use SMW\Options;
 use SMW\StoreFactory;
 use SMW\Utils\BufferedStatsdCollector;
 use SMW\Utils\JsonSchemaValidator;
@@ -256,9 +257,17 @@ class SharedServicesContainer implements CallbackContainer {
 		$containerBuilder->registerCallback( 'PostProcHandler', function( $containerBuilder, \ParserOutput $parserOutput ) {
 			$containerBuilder->registerExpectedReturnType( 'PostProcHandler', PostProcHandler::class );
 
+			$settings = $containerBuilder->singleton( 'Settings' );
+
 			$postProcHandler = new PostProcHandler(
 				$parserOutput,
 				$containerBuilder->singleton( 'Cache' )
+			);
+
+			$postProcHandler->setOptions(
+				$settings->get( 'smwgPostEditUpdate' ) +
+				[ 'smwgEnabledQueryDependencyLinksStore' => $settings->get( 'smwgEnabledQueryDependencyLinksStore' ) ] +
+				[ 'smwgEnabledFulltextSearch' => $settings->get( 'smwgEnabledFulltextSearch' ) ]
 			);
 
 			return $postProcHandler;

--- a/tests/phpunit/Unit/MediaWiki/Api/TaskTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Api/TaskTest.php
@@ -167,4 +167,56 @@ class TaskTest extends \PHPUnit_Framework_TestCase {
 		$instance->execute();
 	}
 
+	public function testRunJobListTask() {
+
+		$title = $this->getMockBuilder( '\Title' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$nullJob = $this->getMockBuilder( '\SMW\MediaWiki\Jobs\NullJob' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$nullJob->expects( $this->atLeastOnce() )
+			->method( 'getTitle' )
+			->will( $this->returnValue( $title ) );
+
+		$nullJob->expects( $this->atLeastOnce() )
+			->method( 'run' );
+
+		$jobQueue = $this->getMockBuilder( '\SMW\MediaWiki\JobQueue' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$jobQueue->expects( $this->atLeastOnce() )
+			->method( 'pop' )
+			->with( $this->equalTo( 'FooJob' ) )
+			->will( $this->returnValue( $nullJob ) );
+
+		$jobQueue->expects( $this->atLeastOnce() )
+			->method( 'ack' )
+			->with( $this->equalTo( $nullJob ) );
+
+		$this->testEnvironment->registerObject( 'JobQueue', $jobQueue );
+
+		$instance = new Task(
+			$this->apiFactory->newApiMain(
+				[
+					'action'   => 'smwtask',
+					'task'     => 'run-joblist',
+					'params'   => json_encode(
+						[
+							'subject' => 'Foo#0##',
+							'jobs' => [ 'FooJob' => 1 ]
+						]
+					),
+					'token'    => 'foo'
+				]
+			),
+			'smwtask'
+		);
+
+		$instance->execute();
+	}
+
 }

--- a/tests/phpunit/Unit/PostProcHandlerTest.php
+++ b/tests/phpunit/Unit/PostProcHandlerTest.php
@@ -42,13 +42,9 @@ class PostProcHandlerTest extends \PHPUnit_Framework_TestCase {
 
 	public function testGetHtmlOnCookie() {
 
-		$this->cache->expects( $this->once() )
-			->method( 'delete' )
-			->with( $this->stringContains( ':post' ) );
-
 		$this->parserOutput->expects( $this->once() )
 			->method( 'getExtensionData' )
-			->with( $this->equalTo( PostProcHandler::PROC_POST_QUERYREF ) )
+			->with( $this->equalTo( PostProcHandler::POST_PROC_QUERYREF ) )
 			->will( $this->returnValue( [ 'Bar' => true ] ) );
 
 		$instance = new PostProcHandler(
@@ -68,7 +64,7 @@ class PostProcHandlerTest extends \PHPUnit_Framework_TestCase {
 			->method( 'getNamespace' )
 			->will( $this->returnValue( NS_MAIN ) );
 
-		$title->expects( $this->once() )
+		$title->expects( $this->atLeastOnce() )
 			->method( 'getLatestRevID' )
 			->will( $this->returnValue( 42 ) );
 
@@ -93,17 +89,12 @@ class PostProcHandlerTest extends \PHPUnit_Framework_TestCase {
 			->will( $this->returnValue( true ) );
 
 		$this->cache->expects( $this->once() )
-			->method( 'contains' )
-			->with( $this->stringContains( ':post' ) )
-			->will( $this->returnValue( false ) );
-
-		$this->cache->expects( $this->once() )
 			->method( 'save' )
 			->with( $this->stringContains( ':post' ) );
 
 		$this->parserOutput->expects( $this->once() )
 			->method( 'getExtensionData' )
-			->with( $this->equalTo( PostProcHandler::PROC_POST_QUERYREF ) )
+			->with( $this->equalTo( PostProcHandler::POST_PROC_QUERYREF ) )
 			->will( $this->returnValue( [ 'Bar' => true ] ) );
 
 		$instance = new PostProcHandler(
@@ -123,7 +114,7 @@ class PostProcHandlerTest extends \PHPUnit_Framework_TestCase {
 			->method( 'getNamespace' )
 			->will( $this->returnValue( NS_MAIN ) );
 
-		$title->expects( $this->once() )
+		$title->expects( $this->atLeastOnce() )
 			->method( 'getLatestRevID' )
 			->will( $this->returnValue( 42 ) );
 
@@ -137,7 +128,10 @@ class PostProcHandlerTest extends \PHPUnit_Framework_TestCase {
 		);
 	}
 
-	public function testGetHtmlOnCookieAndValidChangeDiff() {
+	/**
+	 * @dataProvider validPropertyKey
+	 */
+	public function testGetHtmlOnCookieAndValidChangeDiff( $key ) {
 
 		$fieldChangeOp = $this->getMockBuilder( '\SMW\SQLStore\ChangeOp\FieldChangeOp' )
 			->disableOriginalConstructor()
@@ -159,7 +153,7 @@ class PostProcHandlerTest extends \PHPUnit_Framework_TestCase {
 			DIWikiPage::newFromText( 'Foo' ),
 			[ $tableChangeOp ],
 			[],
-			[ 'Foo' => 42 ]
+			[ $key => 42 ]
 		);
 
 		$this->cache->expects( $this->at( 0 ) )
@@ -168,7 +162,7 @@ class PostProcHandlerTest extends \PHPUnit_Framework_TestCase {
 
 		$this->parserOutput->expects( $this->once() )
 			->method( 'getExtensionData' )
-			->with( $this->equalTo( PostProcHandler::PROC_POST_QUERYREF ) )
+			->with( $this->equalTo( PostProcHandler::POST_PROC_QUERYREF ) )
 			->will( $this->returnValue( [ 'Bar' ] ) );
 
 		$instance = new PostProcHandler(
@@ -188,7 +182,7 @@ class PostProcHandlerTest extends \PHPUnit_Framework_TestCase {
 			->method( 'getNamespace' )
 			->will( $this->returnValue( NS_MAIN ) );
 
-		$title->expects( $this->once() )
+		$title->expects( $this->atLeastOnce() )
 			->method( 'getLatestRevID' )
 			->will( $this->returnValue( 42 ) );
 
@@ -213,12 +207,12 @@ class PostProcHandlerTest extends \PHPUnit_Framework_TestCase {
 
 		$this->parserOutput->expects( $this->once() )
 			->method( 'getExtensionData' )
-			->with( $this->equalTo( PostProcHandler::PROC_POST_QUERYREF ) )
+			->with( $this->equalTo( PostProcHandler::POST_PROC_QUERYREF ) )
 			->will( $this->returnValue( $gExtensionData ) );
 
 		$this->parserOutput->expects( $this->once() )
 			->method( 'setExtensionData' )
-			->with( $this->equalTo( PostProcHandler::PROC_POST_QUERYREF ) )
+			->with( $this->equalTo( PostProcHandler::POST_PROC_QUERYREF ) )
 			->will( $this->returnValue( $sExtensionData ) );
 
 		$instance = new PostProcHandler(
@@ -252,6 +246,21 @@ class PostProcHandlerTest extends \PHPUnit_Framework_TestCase {
 		];
 
 		return $provider;
+	}
+
+	public function validPropertyKey() {
+
+		yield [
+			'Foo'
+		];
+
+		yield [
+			'_INST'
+		];
+
+		yield [
+			'_ASK'
+		];
 	}
 
 }

--- a/tests/phpunit/Unit/SQLStore/QueryDependency/DependencyLinksUpdateJournalTest.php
+++ b/tests/phpunit/Unit/SQLStore/QueryDependency/DependencyLinksUpdateJournalTest.php
@@ -48,6 +48,22 @@ class DependencyLinksUpdateJournalTest extends \PHPUnit_Framework_TestCase {
 		);
 	}
 
+	public function testMakeKey() {
+
+		$subject = DIWikiPage::newFromText( 'Foo' );
+		$title = \Title::newFromText( 'Foo' );
+
+		$this->assertContains(
+			'smw:update:qdep',
+			DependencyLinksUpdateJournal::makeKey( $subject )
+		);
+
+		$this->assertSame(
+			DependencyLinksUpdateJournal::makeKey( $title ),
+			DependencyLinksUpdateJournal::makeKey( $subject )
+		);
+	}
+
 	public function testUpdateFromList() {
 
 		$this->cache->expects( $this->atLeastOnce() )


### PR DESCRIPTION
This PR is made in reference to: #3310

This PR addresses or contains:

- Follow-up to #3310 where instead of a socket connection via a special page it uses an API request to invoke extra "work" after an update has been completed as part of an independent transaction
- Uses the `smwtask` API interface with `task=run-joblist` to run listed jobs from the queue without the job scheduler and hereby circumvents the randomness of its execution
- Builds on the existing `PostProcHandler` (used to direct `@annotation` post processing of queries via the API)
- Adds `smwgPostEditUpdate` as __internal__ setting (meaning a normal users shouldn't care for it, yet an administrator can regulate those listed jobs if the necessity arises) to regulate which and how many jobs should be executed as part of a post-edit event with the default being:
  - 'SMW\FulltextSearchTableUpdateJob' => 1,
  - 'SMW\ParserCachePurgeJob' => 5 (5 means that it attempts to execute 5 parked jobs from the queue to increase the likelihood that entities get refreshed in time that have been detected by the `QueryDependencyLinksStore` )

This PR includes:
- [ ] Tests (unit/integration)
- [x] CI build passed

Fixes #