### PR TITLE
Set extra parser key when a query with self reference is detected, refs 3230

### DIFF
--- a/src/Query/Parser.php
+++ b/src/Query/Parser.php
@@ -30,6 +30,17 @@ interface Parser {
 	public function getErrors();
 
 	/**
+	 * Describes a processed description instance in terms of the existence of
+	 * a self reference in connection with the context page a query is
+	 * embedded.
+	 *
+	 * @since 3.0
+	 *
+	 * @return boolean
+	 */
+	public function containsSelfReference();
+
+	/**
 	 * @since 3.0
 	 *
 	 * @param string $condition

--- a/src/Query/Parser/DescriptionProcessor.php
+++ b/src/Query/Parser/DescriptionProcessor.php
@@ -10,6 +10,7 @@ use SMW\Query\DescriptionFactory;
 use SMW\Query\Language\Conjunction;
 use SMW\Query\Language\Description;
 use SMW\Query\Language\Disjunction;
+use SMW\Query\Language\ValueDescription;
 use SMW\Site;
 use SMWDataValue as DataValue;
 
@@ -43,6 +44,11 @@ class DescriptionProcessor {
 	private $contextPage;
 
 	/**
+	 * @var boolean
+	 */
+	private $selfReference = false;
+
+	/**
 	 * @var array
 	 */
 	private $errors = array();
@@ -72,6 +78,7 @@ class DescriptionProcessor {
 	 */
 	public function clear() {
 		$this->errors = array();
+		$this->selfReference = false;
 	}
 
 	/**
@@ -81,6 +88,15 @@ class DescriptionProcessor {
 	 */
 	public function getErrors() {
 		return $this->errors;
+	}
+
+	/**
+	 * @since 3.0
+	 *
+	 * @return boolean
+	 */
+	public function containsSelfReference() {
+		return $this->selfReference;
 	}
 
 	/**
@@ -155,6 +171,10 @@ class DescriptionProcessor {
 
 		$description = $dataValue->getQueryDescription( $chunk );
 		$this->addError( $dataValue->getErrors() );
+
+		if ( !$this->selfReference && $this->contextPage !== null && $description instanceof ValueDescription ) {
+			$this->selfReference = $description->getDataItem()->equals( $this->contextPage );
+		}
 
 		return $description;
 	}

--- a/src/Query/Processor/QueryCreator.php
+++ b/src/Query/Processor/QueryCreator.php
@@ -133,6 +133,11 @@ class QueryCreator implements QueryContext {
 			$this->getParam( 'source', null )
 		);
 
+		$query->setOption(
+			'self.reference',
+			$queryParser->containsSelfReference()
+		);
+
 		// keep parsing or other errors for later output
 		$query->addErrors(
 			$queryParser->getErrors()


### PR DESCRIPTION
This PR is made in reference to: #3230

This PR addresses or contains:

- Setting a different parser cache key in case of a self-reference to force a re-parse on the next GET request for the page that embeds the query

This PR includes:
- [ ] Tests (unit/integration)
- [x] CI build passed
