### PR TITLE
Fix 'WIki' typo in src/Elastic/QueryEngine/Excerpts.php

### DIFF
--- a/src/Elastic/QueryEngine/Excerpts.php
+++ b/src/Elastic/QueryEngine/Excerpts.php
@@ -15,7 +15,7 @@ class Excerpts extends \SMW\Query\Excerpts {
 	/**
 	 * @since 3.0
 	 *
-	 * @param DIWIkiPage|string $hash
+	 * @param DIWikiPage|string $hash
 	 *
 	 * @return string|integer|false
 	 */


### PR DESCRIPTION
https://phabricator.wikimedia.org/T201491