### PR TITLE
Fix 'WIki' typo in src/Query/Excerpts.php

### DIFF
--- a/src/Query/Excerpts.php
+++ b/src/Query/Excerpts.php
@@ -57,7 +57,7 @@ class Excerpts {
 	/**
 	 * @since 3.0
 	 *
-	 * @param DIWIkiPage|string $hash
+	 * @param DIWikiPage|string $hash
 	 *
 	 * @return string|integer|false
 	 */


### PR DESCRIPTION
https://phabricator.wikimedia.org/T201491