### PR TITLE
[ES] Support num/dat field aggregation via terms

### DIFF
--- a/data/elastic/smw-data-icu.json
+++ b/data/elastic/smw-data-icu.json
@@ -81,11 +81,11 @@
 								"sort": {
 									"type": "icu_collation_keyword",
 									"index": false,
-									"ignore_above": 2000
+									"ignore_above": 256
 								},
 								"keyword": {
 									"type": "keyword",
-									"ignore_above": 256
+									"ignore_above": 2000
 								}
 							}
 						}
@@ -102,11 +102,11 @@
 								"sort": {
 									"type": "icu_collation_keyword",
 									"index": false,
-									"ignore_above": 2000
+									"ignore_above": 256
 								},
 								"keyword": {
 									"type": "keyword",
-									"ignore_above": 256
+									"ignore_above": 2000
 								},
 								"lowercase": {
 									"type":     "text",
@@ -128,11 +128,11 @@
 								"sort": {
 									"type": "icu_collation_keyword",
 									"index": false,
-									"ignore_above": 500
+									"ignore_above": 256
 								},
 								"keyword": {
 									"type": "keyword",
-									"ignore_above": 256
+									"ignore_above": 500
 								},
 								"lowercase": {
 									"type": "keyword",
@@ -156,7 +156,13 @@
 						"path_match": "P:*.numField",
 						"match_mapping_type": "*",
 						"mapping": {
-							"type": "double"
+							"type": "double",
+							"fields": {
+								"keyword": {
+									"type": "keyword",
+									"ignore_above": 256
+								}
+							}
 						}
 					}
 				},
@@ -172,6 +178,15 @@
 									"ignore_above": 256
 								}
 							}
+						}
+					}
+				},
+				{
+					"date_fields_raw": {
+						"path_match": "P:*.dat_raw",
+						"match_mapping_type": "*",
+						"mapping": {
+							"type": "keyword"
 						}
 					}
 				},

--- a/data/elastic/smw-data-standard.json
+++ b/data/elastic/smw-data-standard.json
@@ -71,7 +71,7 @@
 									"type": "keyword",
 									"normalizer": "standard_sort_normalizer",
 									"index": false,
-									"ignore_above": 2000
+									"ignore_above": 256
 								},
 								"keyword": {
 									"type": "keyword",
@@ -93,7 +93,7 @@
 									"type": "keyword",
 									"normalizer": "standard_sort_normalizer",
 									"index": false,
-									"ignore_above": 2000
+									"ignore_above": 256
 								},
 								"keyword": {
 									"type": "keyword",
@@ -119,11 +119,11 @@
 									"type": "keyword",
 									"normalizer": "standard_sort_normalizer",
 									"index": false,
-									"ignore_above": 500
+									"ignore_above": 256
 								},
 								"keyword": {
 									"type": "keyword",
-									"ignore_above": 256
+									"ignore_above": 500
 								},
 								"lowercase": {
 									"type": "keyword",
@@ -147,7 +147,13 @@
 						"path_match": "P:*.numField",
 						"match_mapping_type": "*",
 						"mapping": {
-							"type": "double"
+							"type": "double",
+							"fields": {
+								"keyword": {
+									"type": "keyword",
+									"ignore_above": 256
+								}
+							}
 						}
 					}
 				},
@@ -163,6 +169,15 @@
 									"ignore_above": 256
 								}
 							}
+						}
+					}
+				},
+				{
+					"date_fields_raw": {
+						"path_match": "P:*.dat_raw",
+						"match_mapping_type": "*",
+						"mapping": {
+							"type": "keyword"
 						}
 					}
 				},

--- a/src/Elastic/Indexer/Indexer.php
+++ b/src/Elastic/Indexer/Indexer.php
@@ -675,6 +675,17 @@ class Indexer {
 			$insertRows[$sid][$pid][$type],
 			[ $val ]
 		);
+
+		// Replicate dates in the serialized raw_format to give aggregations a chance
+		// to filter dates by term
+		if ( $type === 'datField' && isset( $ins['o_serialized'] ) ) {
+
+			if ( !isset( $insertRows[$sid][$pid]["dat_raw"] ) ) {
+				$insertRows[$sid][$pid]["dat_raw"] = [];
+			}
+
+			$insertRows[$sid][$pid]["dat_raw"][] = $ins['o_serialized'];
+		}
 	}
 
 	/**


### PR DESCRIPTION
This PR is made in reference to: #

This PR addresses or contains:

- Allow to use `aggs`, `terms` [0] on a literal num/dat field instead of the numeric representation which is either a double or float.

This PR includes:
- [ ] Tests (unit/integration)
- [x] CI build passed

[0] https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-bucket-terms-aggregation.html