### PR TITLE
Special:Ask recognize first empty sort parameter

### DIFF
--- a/src/MediaWiki/Specials/Ask/ParametersProcessor.php
+++ b/src/MediaWiki/Specials/Ask/ParametersProcessor.php
@@ -90,15 +90,31 @@ class ParametersProcessor {
 		}
 
 		$sort_count = 0;
+		$empty_first_sort = false;
 
 		// First check whether the sorting options input send an
 		// request data as array
-		if ( $request->getArray( 'sort_num', [] ) !== array() ) {
-			$sort_values = $request->getArray( 'sort_num' );
+		if ( ( $sort_values = $request->getArray( 'sort_num', [] ) ) !== [] ) {
+
+			// Find out whether something like `|?sort=,Has text` was used
+			if ( $sort_values[0] === '' ) {
+				$empty_first_sort = true;
+			}
 
 			if ( is_array( $sort_values ) ) {
+
+				// Filter all empty values
 				$sort = array_filter( $sort_values );
 				$sort_count = count( $sort );
+
+				// Add an empty element on the first position which got filter
+				// and was to prevent countless empty elements when no other sort
+				// was metioned
+				if ( $sort_count > 0 && $empty_first_sort ) {
+					array_unshift( $sort, '' );
+					$sort_count++;
+				}
+
 				$parameters['sort'] = implode( ',', $sort );
 			}
 		} elseif ( $request->getCheck( 'sort' ) ) {
@@ -107,8 +123,7 @@ class ParametersProcessor {
 
 		// First check whether the order options input send an
 		// request data as array
-		if ( $request->getArray( 'order_num', [] ) !== array()  ) {
-			$order_values = $request->getArray( 'order_num' );
+		if ( ( $order_values = $request->getArray( 'order_num', [] ) ) !== [] ) {
 
 			// Count doesn't match means we have a order from an
 			// empty (#subject) carrying around which we don't permit when

--- a/tests/phpunit/Unit/MediaWiki/Specials/Ask/ParametersProcessorTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Specials/Ask/ParametersProcessorTest.php
@@ -52,13 +52,13 @@ class ParametersProcessorTest extends \PHPUnit_Framework_TestCase {
 			->disableOriginalConstructor()
 			->getMock();
 
-		$request->expects( $this->at( 7 ) )
+		$request->expects( $this->at( 5 ) )
 			->method( 'getVal' )
 			->with(
 				$this->equalTo( 'offset' ),
 				$this->equalTo( 0 ) );
 
-		$request->expects( $this->at( 8 ) )
+		$request->expects( $this->at( 6 ) )
 			->method( 'getVal' )
 			->with(
 				$this->equalTo( 'limit' ),
@@ -72,6 +72,78 @@ class ParametersProcessorTest extends \PHPUnit_Framework_TestCase {
 		];
 
 		ParametersProcessor::process( $request, $parameters );
+	}
+
+	public function testParameters_Sort_FirstEmpty() {
+
+		$request = $this->getMockBuilder( '\WebRequest' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$request->expects( $this->at( 3 ) )
+			->method( 'getArray' )
+			->with( $this->equalTo( 'sort_num' ) )
+			->will( $this->returnValue( [ '', '', 'Foo' ] ) );
+
+		$request->expects( $this->at( 4 ) )
+			->method( 'getArray' )
+			->with( $this->equalTo( 'order_num' ) )
+			->will( $this->returnValue( [ 'asc', 'desc' ] ) );
+
+		$parameters = [
+			'[[Foo::bar]]'
+		];
+
+		list( $q, $p, $po ) = ParametersProcessor::process(
+			$request,
+			$parameters
+		);
+
+		$this->assertSame(
+			$p['sort'],
+			',Foo'
+		);
+
+		$this->assertSame(
+			$p['order'],
+			'asc,desc'
+		);
+	}
+
+	public function testParameters_Sort_FirstNotEmpty() {
+
+		$request = $this->getMockBuilder( '\WebRequest' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$request->expects( $this->at( 3 ) )
+			->method( 'getArray' )
+			->with( $this->equalTo( 'sort_num' ) )
+			->will( $this->returnValue( [ 'Foo', '' ] ) );
+
+		$request->expects( $this->at( 4 ) )
+			->method( 'getArray' )
+			->with( $this->equalTo( 'order_num' ) )
+			->will( $this->returnValue( [ 'asc', 'desc' ] ) );
+
+		$parameters = [
+			'[[Foo::bar]]'
+		];
+
+		list( $q, $p, $po ) = ParametersProcessor::process(
+			$request,
+			$parameters
+		);
+
+		$this->assertSame(
+			$p['sort'],
+			'Foo'
+		);
+
+		$this->assertSame(
+			$p['order'],
+			'asc'
+		);
 	}
 
 	public function testParametersOn_p_Array_Request() {


### PR DESCRIPTION
This PR is made in reference to: https://github.com/SemanticMediaWiki/SemanticMediaWiki/issues/3323#issuecomment-414043347

This PR addresses or contains:

- Recognizes `|sort=,Has foo` (first empty value) and ensure a corresponding placeholder in `Special:Ask`

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed
