### PR TITLE
[ES] Test `terms aggregation` for `ProximityPropertyValueLookup` service

### DIFF
--- a/includes/storage/SQLStore/SMW_SQLStore3.php
+++ b/includes/storage/SQLStore/SMW_SQLStore3.php
@@ -113,6 +113,11 @@ class SMWSQLStore3 extends SMWStore {
 	private $entityLookup;
 
 	/**
+	 * @var ServicesContainer
+	 */
+	protected $servicesContainer;
+
+	/**
 	 * Object to access the SMW IDs table.
 	 *
 	 * @since 1.8
@@ -342,6 +347,19 @@ class SMWSQLStore3 extends SMWStore {
 
 ///// Setup store /////
 
+	/**
+	 * @see Store::service
+	 *
+	 * {@inheritDoc}
+	 */
+	public function service( $service, ...$args ) {
+
+		if ( $this->servicesContainer === null ) {
+			$this->servicesContainer = $this->newServicesContainer();
+		}
+
+		return $this->servicesContainer->get( $service, ...$args );
+	}
 
 	/**
 	 * @since 1.8
@@ -605,6 +623,13 @@ class SMWSQLStore3 extends SMWStore {
 		}
 
 		return $this->propertyTableIdReferenceFinder;
+	}
+
+	/**
+	 * @return ServicesContainer
+	 */
+	protected function newServicesContainer() {
+		return $this->factory->newServicesContainer();
 	}
 
 	/**

--- a/src/Elastic/ElasticFactory.php
+++ b/src/Elastic/ElasticFactory.php
@@ -34,6 +34,7 @@ use SMW\Elastic\QueryEngine\DescriptionInterpreters\NamespaceDescriptionInterpre
 use SMW\Elastic\QueryEngine\DescriptionInterpreters\SomePropertyInterpreter;
 use SMW\Elastic\QueryEngine\DescriptionInterpreters\ValueDescriptionInterpreter;
 use SMW\Elastic\QueryEngine\DescriptionInterpreters\SomeValueInterpreter;
+use SMW\Elastic\Lookup\ProximityPropertyValueLookup;
 
 /**
  * @license GNU GPL v2+
@@ -99,6 +100,17 @@ class ElasticFactory {
 		);
 
 		return $connectionProvider;
+	}
+
+	/**
+	 * @since 3.0
+	 *
+	 * @param Store $store
+	 *
+	 * @return ProximityPropertyValueLookup
+	 */
+	public function newProximityPropertyValueLookup( Store $store ) {
+		return new ProximityPropertyValueLookup( $store );
 	}
 
 	/**

--- a/src/Elastic/ElasticStore.php
+++ b/src/Elastic/ElasticStore.php
@@ -55,6 +55,27 @@ class ElasticStore extends SQLStore {
 	}
 
 	/**
+	 * @see Store::service
+	 *
+	 * {@inheritDoc}
+	 */
+	public function service( $service, ...$args ) {
+
+		if ( $this->servicesContainer === null ) {
+			$this->servicesContainer = parent::newServicesContainer();
+
+			// Replace an existing (or add) SQLStore service with a ES specific
+			// optimized service
+
+			// $this->servicesContainer->add( 'ProximityPropertyValueLookup', function() {
+			//	return $this->elasticFactory->newProximityPropertyValueLookup( $this );
+			// } );
+		}
+
+		return $this->servicesContainer->get( $service, ...$args );
+	}
+
+	/**
 	 * @see SQLStore::deleteSubject
 	 * @since 3.0
 	 *

--- a/src/Elastic/Lookup/ProximityPropertyValueLookup.php
+++ b/src/Elastic/Lookup/ProximityPropertyValueLookup.php
@@ -1,0 +1,310 @@
+<?php
+
+namespace SMW\Elastic\Lookup;
+
+use SMW\Elastic\Connection\Client as ElasticClient;
+use SMW\Elastic\QueryEngine\FieldMapper;
+use SMW\DataTypeRegistry;
+use SMW\DataValueFactory;
+use SMWDITime as DITime;
+use SMWDataItem as DataItem;
+use SMW\DIProperty;
+use SMW\Store;
+use SMW\RequestOptions;
+use RuntimeException;
+
+/**
+ * Experimental implementation to showcase how a Elasticsearch specific implementation
+ * for a property value lookup can be used and override the default SQL service.
+ *
+ * The class is targeted to be used for API (e.g. autocomplete etc.) intensive
+ * services.
+ *
+ * @license GNU GPL v2+
+ * @since 3.0
+ *
+ * @author mwjames
+ */
+class ProximityPropertyValueLookup {
+
+	/**
+	 * @var Store
+	 */
+	private $store;
+
+	/**
+	 * @since 3.0
+	 *
+	 * @param Store $store
+	 */
+	public function __construct( Store $store ) {
+		$this->store = $store;
+		$this->fieldMapper = new FieldMapper();
+	}
+
+	/**
+	 * @since 3.0
+	 *
+	 * @param DIProperty $property
+	 * @param string $value
+	 * @param RequestOptions $opts
+	 *
+	 * @return array
+	 */
+	public function lookup( DIProperty $property, $value = '', RequestOptions $opts ) {
+
+		$connection = $this->store->getConnection( 'elastic' );
+		$continueOffset = 0;
+
+		$pid = $this->fieldMapper->getPID(
+			$this->store->getObjectIds()->getSMWPropertyID( $property )
+		);
+
+		$diType = DataTypeRegistry::getInstance()->getDataItemByType(
+			$property->findPropertyTypeID()
+		);
+
+		$field = $this->fieldMapper->getField( $property );
+
+		if ( $value === '' ) {
+			// Just create a list of available values where the property exists
+			$params = $this->fieldMapper->exists( "$pid.$field" );
+
+			// Increase the range of the initial match since a property field
+			// stores are all sorts of values, this is to make sure that the
+			// aggregation has enough objects available to build a selection
+			// list that satisfies the RequestOptions::getLimit
+			$limit = 500;
+		} elseif( $diType === DataItem::TYPE_TIME ) {
+			$limit = 500;
+
+			$dataValue = DataValueFactory::getInstance()->newDataValueByProperty(
+				$property,
+				$value
+			);
+
+			$params = $this->fieldMapper->bool(
+				'must',
+				$this->fieldMapper->range( "$pid.$field", $dataValue->getDataItem()->getJD(), SMW_CMP_GEQ )
+			);
+		} elseif( $diType === DataItem::TYPE_NUMBER ) {
+			$limit = 500;
+
+			if ( strpos( $value, '*' ) === false ) {
+				$value = "*$value*";
+			}
+
+			$params = $this->fieldMapper->bool(
+				'must',
+				$this->fieldMapper->wildcard( "$pid.$field.keyword", $value )
+			);
+		} else {
+			$limit = 500;
+
+			if ( strpos( $value, '*' ) === false ) {
+				$value = "$value*";
+			}
+
+			$params = $this->fieldMapper->bool(
+				'must',
+				$this->fieldMapper->match_phrase( "$pid.$field", $value )
+			);
+		}
+
+		$body = [
+			'_source' => [ "$pid.$field" ],
+			'from'    => $opts->getOffset(),
+			'size'    => $limit,
+			'query'   => $params
+		];
+
+		$limit = $opts->getLimit() + 1;
+
+		// Aggregation is used to filter a specific value aspect from a property
+		// field contents
+		if ( $value !== '' ) {
+			// Setting size to 0 which avoids executing the fetch query of the search
+			// hereby making the request more efficient.
+			$body['size'] = 0;
+
+			$body += $this->aggs_filter( $diType, $pid, $field, $limit, $property, trim( $value, '*' ) );
+		}
+
+		if ( $opts->sort ) {
+			$body += [ 'sort' => [ "$pid.$field" => [ 'order' => $opts->sort ] ] ];
+		}
+
+		$params = [
+			'index' => $connection->getIndexName( ElasticClient::TYPE_DATA ),
+			'type'  => ElasticClient::TYPE_DATA,
+			'body'  => $body
+		];
+
+		list( $res, $errors ) = $connection->search( $params );
+
+		if ( isset( $res['aggregations'] ) ) {
+			list( $list, $i ) = $this->match_aggregations( $res['aggregations'], $diType, $limit );
+		} elseif ( isset( $res['hits'] ) ) {
+			list( $list, $i ) = $this->match_hits( $res['hits'], $pid, $field, $limit );
+		} else {
+			$list = [];
+			$i = 0;
+		}
+
+		if ( $list !== [] ) {
+			$list = array_values( $list );
+
+			if (  $diType === DataItem::TYPE_TIME ) {
+				foreach ( $list as $key => $value ) {
+
+					if ( strpos( $value, '/' ) !== false ) {
+						$dataItem = DITime::doUnserialize( $value );
+					} else {
+						$dataItem = DITime::newFromJD( $value );
+					}
+
+					$list[$key] = DataValueFactory::getInstance()->newDataValueByItem( $dataItem, $property )->getWikiValue();
+				}
+			}
+		}
+
+		return $list;
+	}
+
+	private function aggs_filter( $diType, $pid, $field, $limit, $property, $value ) {
+
+		// A field on ES to a property can can all different kind of values and
+		// the request is only interested in those values that match a certain
+		// prefix or affix hence use `include` to only return aggregated values
+		// that contain the search term or value
+
+		if ( $diType === DataItem::TYPE_TIME ) {
+
+			$dataValue = DataValueFactory::getInstance()->newDataValueByProperty(
+				$property,
+				$value
+			);
+
+			return [
+				'aggs' => [
+					'value_terms' => [
+						'terms' => [
+							'field' => "$pid.datRaw",
+							'size'  => $limit,
+							"order" => [ "_key" => "asc" ],
+							'include' => $dataValue->getDataItem()->getSerialization() . ".*"
+						]
+					]
+				]
+			];
+		}
+
+		if ( $diType === DataItem::TYPE_NUMBER ) {
+			return [
+				'aggs' => [
+					'value_terms' => [
+						'terms' => [
+							'field' => "$pid.$field.keyword",
+							'size'  => $limit,
+							"order" => [ "_key" => "asc" ],
+							'include' => ".*" . $value . ".*"
+						]
+					]
+				]
+			];
+		}
+
+		return [
+			'aggs' => [
+				'value_terms' => [
+					'terms' => [
+						'field' => "$pid.$field.keyword",
+						'size' => $limit,
+						'include' =>
+							".*" . $value . ".*|" .
+							".*" . ucfirst( $value ) . ".*|" .
+							".*" . mb_strtoupper( $value ) . ".*"
+					]
+				]
+			]
+		];
+	}
+
+	private function match_aggregations( $res, $diType, $limit ) {
+
+		$isNumeric = $diType === DataItem::TYPE_NUMBER;
+		$list = [];
+		$i = 0;
+
+		foreach ( $res as $aggs ) {
+			foreach ( $aggs as $val ) {
+
+				if ( !is_array( $val ) ) {
+					continue;
+				}
+
+				foreach ( $val as $v ) {
+
+					if ( $i >= $limit ) {
+						break;
+					}
+
+					if ( isset( $v['key'] ) ) {
+						$val = (string)$v['key'];
+
+						// Aggregation happens on keyword field, numerics are of type
+						// double hence is coerced as 5 -> 5.0
+						if ( $isNumeric && substr( $val, -2 ) === '.0' ) {
+							$val = substr( $val, 0, -2 );
+						}
+
+						$list[] = $val;
+						$i++;
+					}
+				}
+			}
+		}
+
+		return [ $list, $i ];
+	}
+
+	private function match_hits( $res, $pid, $field, $limit ) {
+
+		$list = [];
+		$i = 0;
+
+		foreach ( $res as $key => $value ) {
+
+			if ( $key !== 'hits' ) {
+				continue;
+			}
+
+			foreach ( $value as $v ) {
+
+				if ( !isset( $v['_source'][$pid][$field] ) ) {
+					continue;
+				}
+
+				foreach ( $v['_source'][$pid][$field] as $match ) {
+
+					if ( $i >= $limit ) {
+						break;
+					}
+
+					// Filter duplicates
+					$hash = md5( $match );
+
+					if ( isset( $list[$hash] ) ) {
+						continue;
+					}
+
+					$list[$hash] = (string)$match;
+					$i++;
+				}
+			}
+		}
+
+		return [ $list, $i ];
+	}
+
+}

--- a/src/MediaWiki/Api/Browse/PValueLookup.php
+++ b/src/MediaWiki/Api/Browse/PValueLookup.php
@@ -102,8 +102,8 @@ class PValueLookup extends Lookup {
 				$property
 			);
 
-			$proximityPropertyValueLookup = new ProximityPropertyValueLookup(
-				$this->store
+			$proximityPropertyValueLookup = $this->store->service(
+				'ProximityPropertyValueLookup'
 			);
 
 			$res = $proximityPropertyValueLookup->lookup(

--- a/src/SPARQLStore/SPARQLStore.php
+++ b/src/SPARQLStore/SPARQLStore.php
@@ -351,6 +351,15 @@ class SPARQLStore extends Store {
 	}
 
 	/**
+	 * @see Store::service
+	 *
+	 * {@inheritDoc}
+	 */
+	public function service( $service, ...$args ) {
+		return $this->baseStore->service( $service, ...$args );
+	}
+
+	/**
 	 * @see Store::setup()
 	 * @since 1.8
 	 */

--- a/src/SQLStore/SQLStoreFactory.php
+++ b/src/SQLStore/SQLStoreFactory.php
@@ -31,10 +31,13 @@ use SMW\SQLStore\Lookup\RedirectTargetLookup;
 use SMW\SQLStore\Lookup\UndeclaredPropertyListLookup;
 use SMW\SQLStore\Lookup\UnusedPropertyListLookup;
 use SMW\SQLStore\Lookup\UsageStatisticsListLookup;
+use SMW\SQLStore\Lookup\ProximityPropertyValueLookup;
 use SMW\SQLStore\TableBuilder\TableBuilder;
 use SMW\Utils\CircularReferenceGuard;
 use SMWRequestOptions as RequestOptions;
 use SMWSql3SmwIds as EntityIdManager;
+use SMW\Services\ServicesContainer;
+use SMW\RequestData;
 use SMWSQLStore3;
 
 /**
@@ -679,6 +682,34 @@ class SQLStoreFactory {
 		);
 
 		return $changeOp;
+	}
+
+	/**
+	 * @since 3.0
+	 *
+	 * @return ProximityPropertyValueLookup
+	 */
+	public function newProximityPropertyValueLookup() {
+		return new ProximityPropertyValueLookup( $this->store );
+	}
+
+	/**
+	 * @since 3.0
+	 *
+	 * @return ServicesContainer
+	 */
+	public function newServicesContainer() {
+
+		$servicesContainer = new ServicesContainer(
+			[
+				'ProximityPropertyValueLookup' => [
+					'_service' => [ $this, 'newProximityPropertyValueLookup' ],
+					'_type'    => ProximityPropertyValueLookup::class
+				]
+			]
+		);
+
+		return $servicesContainer;
 	}
 
 }

--- a/src/Services/Exception/ServiceNotFoundException.php
+++ b/src/Services/Exception/ServiceNotFoundException.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace SMW\Services\Exception;
+
+use InvalidArgumentException;
+
+/**
+ * @license GNU GPL v2+
+ * @since 3.0
+ *
+ * @author mwjames
+ */
+class ServiceNotFoundException extends InvalidArgumentException {
+
+	/**
+	 * @since 3.0
+	 *
+	 * {@inheritDoc}
+	 */
+	public function __construct( $service ) {
+		parent::__construct( "`$service` is not registered as service!" );
+	}
+
+}

--- a/src/Store.php
+++ b/src/Store.php
@@ -12,6 +12,7 @@ use SMWQuery;
 use SMWQueryResult;
 use SMWRequestOptions;
 use SMWSemanticData;
+use SMW\Services\Exception\ServiceNotFoundException;
 use Title;
 
 /**
@@ -53,11 +54,6 @@ abstract class Store implements QueryEngine {
 	 * @var Options
 	 */
 	protected $options = null;
-
-	/**
-	 * @var array
-	 */
-	public $extensionData = [];
 
 ///// Reading methods /////
 
@@ -215,6 +211,7 @@ abstract class Store implements QueryEngine {
 		}
 
 		Timer::start( __METHOD__ );
+
 		$applicationFactory = ApplicationFactory::getInstance();
 
 		$subject = $semanticData->getSubject();
@@ -374,7 +371,27 @@ abstract class Store implements QueryEngine {
 	 */
 	public abstract function getStatistics();
 
-///// Setup store /////
+	/**
+	 * Store administration
+	 */
+
+	/**
+	 * @private
+	 *
+	 * Returns store specific services. Services are registered with the store
+	 * implementation and may provide different services that are only available
+	 * for a particular store.
+	 *
+	 * @since 3.0
+	 *
+	 * @param string $service
+	 *
+	 * @return mixed
+	 * @throws ServiceNotFoundException
+	 */
+	public function service( $service, ...$args ) {
+		throw new ServiceNotFoundException( $service );
+	}
 
 	/**
 	 * Setup all storage structures properly for using the store. This

--- a/tests/phpunit/Unit/Elastic/Lookup/ProximityPropertyValueLookupTest.php
+++ b/tests/phpunit/Unit/Elastic/Lookup/ProximityPropertyValueLookupTest.php
@@ -1,0 +1,94 @@
+<?php
+
+namespace SMW\Tests\Elastic\Lookup;
+
+use SMW\Elastic\Lookup\ProximityPropertyValueLookup;
+use SMW\Tests\PHPUnitCompat;
+use SMW\DIProperty;
+use SMW\RequestOptions;
+
+/**
+ * @covers \SMW\Elastic\Lookup\ProximityPropertyValueLookup
+ * @group semantic-mediawiki
+ *
+ * @license GNU GPL v2+
+ * @since 3.0
+ *
+ * @author mwjames
+ */
+class ProximityPropertyValueLookupTest extends \PHPUnit_Framework_TestCase {
+
+	use PHPUnitCompat;
+
+	private $logger;
+	private $store;
+	private $elasticClient;
+
+	protected function setUp() {
+
+		$this->logger = $this->getMockBuilder( '\Psr\Log\LoggerInterface' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$this->idTable = $this->getMockBuilder( '\stdClass' )
+			->disableOriginalConstructor()
+			->setMethods( [ 'getSMWPropertyID' ] )
+			->getMock();
+
+		$this->idTable->expects( $this->any() )
+			->method( 'getSMWPropertyID' )
+			->will( $this->onConsecutiveCalls( 42, 1001, 9000, 110001 ) );
+
+		$this->store = $this->getMockBuilder( '\SMW\SQLStore\SQLStore' )
+			->disableOriginalConstructor()
+			->setMethods( [ 'getObjectIds', 'getConnection' ] )
+			->getMock();
+
+		$this->store->expects( $this->any() )
+			->method( 'getObjectIds' )
+			->will( $this->returnValue( $this->idTable ) );
+
+		$this->elasticClient = $this->getMockBuilder( '\Elasticsearch\Client' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$this->store->expects( $this->any() )
+			->method( 'getConnection' )
+			->will( $this->returnValue( $this->elasticClient ) );
+	}
+
+	public function testCanConstruct() {
+
+		$this->assertInstanceOf(
+			ProximityPropertyValueLookup::class,
+			new ProximityPropertyValueLookup( $this->store )
+		);
+	}
+
+	public function testLookup_AnyValue() {
+
+		$params = [
+			'index' => null,
+			'type' => 'data',
+			'body' => [
+				'_source' => [ 'P:42.wpgField' ],
+				'from' => 0,
+				'size' => 500,
+				'query' => [
+					'exists' => [ 'field' => 'P:42.wpgField' ]
+				]
+			]
+		];
+
+		$this->elasticClient->expects( $this->once() )
+			->method( 'search' )
+			->with( $this->equalTo( $params ) );
+
+		$instance = new ProximityPropertyValueLookup(
+			$this->store
+		);
+
+		$instance->lookup( new DIProperty( 'Foo' ), '', new RequestOptions() );
+	}
+
+}

--- a/tests/phpunit/Unit/MediaWiki/Api/Browse/PValueLookupTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Api/Browse/PValueLookupTest.php
@@ -5,6 +5,7 @@ namespace SMW\Tests\MediaWiki\Api\Browse;
 use SMW\DIProperty;
 use SMW\MediaWiki\Api\Browse\PValueLookup;
 use SMW\MediaWiki\Connection\Query;
+use SMW\Services\ServicesContainer;
 use FakeResultWrapper;
 
 /**
@@ -18,15 +19,25 @@ use FakeResultWrapper;
  */
 class PValueLookupTest extends \PHPUnit_Framework_TestCase {
 
-	public function testCanConstruct() {
+	private $store;
 
-		$store = $this->getMockBuilder( '\SMW\SQLStore\SQLStore' )
+	protected function setUp() {
+
+		$this->store = $this->getMockBuilder( '\SMW\SQLStore\SQLStore' )
 			->disableOriginalConstructor()
 			->getMock();
 
+		$this->store->expects( $this->any() )
+			->method( 'service' )
+			->with( $this->equalTo( 'ProximityPropertyValueLookup' ) )
+			->will( $this->returnValue( new \SMW\SQLStore\Lookup\ProximityPropertyValueLookup( $this->store ) ) );
+	}
+
+	public function testCanConstruct() {
+
 		$this->assertInstanceOf(
 			PValueLookup::class,
-			new PValueLookup( $store )
+			new PValueLookup( $this->store )
 		);
 	}
 
@@ -71,28 +82,24 @@ class PValueLookupTest extends \PHPUnit_Framework_TestCase {
 			->disableOriginalConstructor()
 			->getMockForAbstractClass();
 
-		$store = $this->getMockBuilder( '\SMW\SQLStore\SQLStore' )
-			->disableOriginalConstructor()
-			->getMock();
-
-		$store->expects( $this->any() )
+		$this->store->expects( $this->any() )
 			->method( 'getPropertyTables' )
 			->will( $this->returnValue( [] ) );
 
-		$store->expects( $this->any() )
+		$this->store->expects( $this->any() )
 			->method( 'getObjectIds' )
 			->will( $this->returnValue( $idTable ) );
 
-		$store->expects( $this->any() )
+		$this->store->expects( $this->any() )
 			->method( 'getDataItemHandlerForDIType' )
 			->will( $this->returnValue( $dataItemHandler ) );
 
-		$store->expects( $this->atLeastOnce() )
+		$this->store->expects( $this->atLeastOnce() )
 			->method( 'getConnection' )
 			->will( $this->returnValue( $connection ) );
 
 		$instance = new PValueLookup(
-			$store
+			$this->store
 		);
 
 		$parameters = [
@@ -151,28 +158,24 @@ class PValueLookupTest extends \PHPUnit_Framework_TestCase {
 			->disableOriginalConstructor()
 			->getMockForAbstractClass();
 
-		$store = $this->getMockBuilder( '\SMW\SQLStore\SQLStore' )
-			->disableOriginalConstructor()
-			->getMock();
-
-		$store->expects( $this->any() )
+		$this->store->expects( $this->any() )
 			->method( 'getPropertyTables' )
 			->will( $this->returnValue( [] ) );
 
-		$store->expects( $this->any() )
+		$this->store->expects( $this->any() )
 			->method( 'getObjectIds' )
 			->will( $this->returnValue( $idTable ) );
 
-		$store->expects( $this->any() )
+		$this->store->expects( $this->any() )
 			->method( 'getDataItemHandlerForDIType' )
 			->will( $this->returnValue( $dataItemHandler ) );
 
-		$store->expects( $this->atLeastOnce() )
+		$this->store->expects( $this->atLeastOnce() )
 			->method( 'getConnection' )
 			->will( $this->returnValue( $connection ) );
 
 		$instance = new PValueLookup(
-			$store
+			$this->store
 		);
 
 		$parameters = [
@@ -235,28 +238,24 @@ class PValueLookupTest extends \PHPUnit_Framework_TestCase {
 			->method( 'getLabelField' )
 			->will( $this->returnValue( 'o_hash' ) );
 
-		$store = $this->getMockBuilder( '\SMW\SQLStore\SQLStore' )
-			->disableOriginalConstructor()
-			->getMock();
-
-		$store->expects( $this->any() )
+		$this->store->expects( $this->any() )
 			->method( 'getPropertyTables' )
 			->will( $this->returnValue( [] ) );
 
-		$store->expects( $this->any() )
+		$this->store->expects( $this->any() )
 			->method( 'getObjectIds' )
 			->will( $this->returnValue( $idTable ) );
 
-		$store->expects( $this->any() )
+		$this->store->expects( $this->any() )
 			->method( 'getDataItemHandlerForDIType' )
 			->will( $this->returnValue( $dataItemHandler ) );
 
-		$store->expects( $this->atLeastOnce() )
+		$this->store->expects( $this->atLeastOnce() )
 			->method( 'getConnection' )
 			->will( $this->returnValue( $connection ) );
 
 		$instance = new PValueLookup(
-			$store
+			$this->store
 		);
 
 		$parameters = [

--- a/tests/phpunit/Unit/MediaWiki/Api/BrowseTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Api/BrowseTest.php
@@ -16,6 +16,7 @@ use SMW\Tests\TestEnvironment;
  */
 class BrowseTest extends \PHPUnit_Framework_TestCase {
 
+	private $store;
 	private $apiFactory;
 	private $testEnvironment;
 
@@ -29,6 +30,19 @@ class BrowseTest extends \PHPUnit_Framework_TestCase {
 		);
 
 		$this->apiFactory = $this->testEnvironment->getUtilityFactory()->newMwApiFactory();
+
+		$proximityPropertyValueLookup = $this->getMockBuilder( '\SMW\SQLStore\Lookup\ProximityPropertyValueLookup' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$this->store = $this->getMockBuilder( '\SMW\SQLStore\SQLStore' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$this->store->expects( $this->any() )
+			->method( 'service' )
+			->with( $this->equalTo( 'ProximityPropertyValueLookup' ) )
+			->will( $this->returnValue( $proximityPropertyValueLookup ) );
 	}
 
 	protected function tearDown() {
@@ -99,32 +113,28 @@ class BrowseTest extends \PHPUnit_Framework_TestCase {
 			->disableOriginalConstructor()
 			->getMockForAbstractClass();
 
-		$store = $this->getMockBuilder( '\SMW\SQLStore\SQLStore' )
-			->disableOriginalConstructor()
-			->getMock();
-
-		$store->expects( $this->any() )
+		$this->store->expects( $this->any() )
 			->method( 'getSQLOptions' )
 			->will( $this->returnValue( [] ) );
 
-		$store->expects( $this->any() )
+		$this->store->expects( $this->any() )
 			->method( 'getPropertyTables' )
 			->will( $this->returnValue( [] ) );
 
-		$store->expects( $this->any() )
+		$this->store->expects( $this->any() )
 			->method( 'getDataItemHandlerForDIType' )
 			->will( $this->returnValue( $dataItemHandler ) );
 
-		$store->expects( $this->any() )
+		$this->store->expects( $this->any() )
 			->method( 'getObjectIds' )
 			->will( $this->returnValue( $idTable ) );
 
-		$store->expects( $this->atLeastOnce() )
+		$this->store->expects( $this->any() )
 			->method( 'getConnection' )
 			->will( $this->returnValue( $connection ) );
 
 		$this->testEnvironment->registerObject( 'Cache', $cache );
-		$this->testEnvironment->registerObject( 'Store', $store );
+		$this->testEnvironment->registerObject( 'Store', $this->store );
 
 		$instance = new Browse(
 			$this->apiFactory->newApiMain(
@@ -162,15 +172,11 @@ class BrowseTest extends \PHPUnit_Framework_TestCase {
 			->method( 'getSubSemanticData' )
 			->will( $this->returnValue( [] ) );
 
-		$store = $this->getMockBuilder( '\SMW\SQLStore\SQLStore' )
-			->disableOriginalConstructor()
-			->getMock();
-
-		$store->expects( $this->atLeastOnce() )
+		$this->store->expects( $this->atLeastOnce() )
 			->method( 'getSemanticData' )
 			->will( $this->returnValue( $semanticData ) );
 
-		$this->testEnvironment->registerObject( 'Store', $store );
+		$this->testEnvironment->registerObject( 'Store', $this->store );
 
 		$instance = new Browse(
 			$this->apiFactory->newApiMain(

--- a/tests/phpunit/Unit/SQLStore/SQLStoreFactoryTest.php
+++ b/tests/phpunit/Unit/SQLStore/SQLStoreFactoryTest.php
@@ -395,4 +395,24 @@ class SQLStoreFactoryTest extends \PHPUnit_Framework_TestCase {
 		);
 	}
 
+	public function testCanConstructProximityPropertyValueLookup() {
+
+		$instance = new SQLStoreFactory( $this->store );
+
+		$this->assertInstanceOf(
+			'\SMW\SQLStore\Lookup\ProximityPropertyValueLookup',
+			$instance->newProximityPropertyValueLookup()
+		);
+	}
+
+	public function testCanConstructServicesContainer() {
+
+		$instance = new SQLStoreFactory( $this->store );
+
+		$this->assertInstanceOf(
+			'\SMW\Services\ServicesContainer',
+			$instance->newServicesContainer()
+		);
+	}
+
 }

--- a/tests/phpunit/Unit/Services/Exception/ServiceNotFoundExceptionTest.php
+++ b/tests/phpunit/Unit/Services/Exception/ServiceNotFoundExceptionTest.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace SMW\Tests\Services\Exception;
+
+use SMW\Services\Exception\ServiceNotFoundException;
+
+/**
+ * @covers \SMW\Services\Exception\ServiceNotFoundException
+ * @group semantic-mediawiki
+ *
+ * @license GNU GPL v2+
+ * @since 3.0
+ *
+ * @author mwjames
+ */
+class ServiceNotFoundExceptionTest extends \PHPUnit_Framework_TestCase {
+
+	public function testCanConstruct() {
+
+		$instance = new ServiceNotFoundException( 'foo' );
+
+		$this->assertInstanceof(
+			ServiceNotFoundException::class,
+			$instance
+		);
+
+		$this->assertInstanceof(
+			'\InvalidArgumentException',
+			$instance
+		);
+	}
+
+}


### PR DESCRIPTION
This PR is made in reference to: #3335 

This PR addresses or contains:

- Experimental service to showcase how ES and aggregation can be used to replace a SQL specific service
- #3335 has isolated the SQL part from the `pvalue` API module into the `ProximityPropertyValueLookup` class, this PR provides the same service just as ES implementation (using `terms aggregation` to generate list property values for a dedicated property ) hereby allows to avoid select heavy DB queries while relying on ES to retrieve those data
- Service is marked experimental therefore is disabled by default.

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed
