### PR TITLE
[ES] FileIndexer to avoid "failed to open stream: HTTP request failed"

### DIFF
--- a/src/Elastic/Indexer/FileIndexer.php
+++ b/src/Elastic/Indexer/FileIndexer.php
@@ -193,10 +193,21 @@ class FileIndexer {
 			return $this->logger->info( $msg, $context );
 		}
 
+		$contents = '';
+
+		// Avoid a "failed to open stream: HTTP request failed! HTTP/1.1 404 Not Found"
+		$file_headers = @get_headers( $url );
+
+		if ( $file_headers[0] !== 'HTTP/1.1 404 Not Found' && $file_headers[0] !== 'HTTP/1.0 404 Not Found' ) {
+			$contents = file_get_contents( $url );
+		} else {
+			$this->logger->info( [ 'File indexer', "HTTP/1.1 404 Not Found for $url" ], $context );
+		}
+
 		$params += [
 			'pipeline' => 'attachment',
 			'body' => [
-				'file_content' => base64_encode( file_get_contents( $url ) ),
+				'file_content' => base64_encode( $contents ),
 				'file_path' => $url,
 				'file_sha1' => $sha1,
 			] + $doc['_source']

--- a/tests/phpunit/Unit/Elastic/Indexer/FileIndexerTest.php
+++ b/tests/phpunit/Unit/Elastic/Indexer/FileIndexerTest.php
@@ -1,0 +1,86 @@
+<?php
+
+namespace SMW\Tests\Elastic\Indexer;
+
+use SMW\Elastic\Indexer\FileIndexer;
+use SMW\DIWikiPage;
+use SMW\Tests\PHPUnitCompat;
+
+/**
+ * @covers \SMW\Elastic\Indexer\FileIndexer
+ * @group semantic-mediawiki
+ *
+ * @license GNU GPL v2+
+ * @since 3.0
+ *
+ * @author mwjames
+ */
+class FileIndexerTest extends \PHPUnit_Framework_TestCase {
+
+	use PHPUnitCompat;
+
+	private $indexer;
+	private $logger;
+
+	protected function setUp() {
+
+		$this->indexer = $this->getMockBuilder( '\SMW\Elastic\Indexer\Indexer' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$this->logger = $this->getMockBuilder( '\Psr\Log\NullLogger' )
+			->disableOriginalConstructor()
+			->getMock();
+	}
+
+	public function testCanConstruct() {
+
+		$this->assertInstanceOf(
+			FileIndexer::class,
+			new FileIndexer( $this->indexer )
+		);
+	}
+
+	public function testIndex() {
+
+		$file = $this->getMockBuilder( '\File' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$file->expects( $this->once() )
+			->method( 'getFullURL' )
+			->will( $this->returnValue( 'http://example.org/Foo.txt' ) );
+
+		$ingest = $this->getMockBuilder( '\stdClass' )
+			->disableOriginalConstructor()
+			->setMethods( [ 'putPipeline' ] )
+			->getMock();
+
+		$ingest->expects( $this->once() )
+			->method( 'putPipeline' );
+
+		$client = $this->getMockBuilder( '\SMW\Elastic\Connection\Client' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$client->expects( $this->once() )
+			->method( 'ingest' )
+			->will( $this->returnValue( $ingest ) );
+
+		$this->indexer->expects( $this->atLeastOnce() )
+			->method( 'getConnection' )
+			->will( $this->returnValue( $client ) );
+
+		$instance = new FileIndexer(
+			$this->indexer
+		);
+
+		$instance->setLogger( $this->logger );
+
+		$dataItem = DIWikiPage::newFromText( __METHOD__, NS_FILE );
+		$dataItem->setId( 42 );
+
+		$instance->index( $dataItem, $file );
+	}
+
+}


### PR DESCRIPTION
This PR is made in reference to: #

This PR addresses or contains:

- Checking the header response before using `file_get_contents` to avoid a "HTTP/1.1 404 Not Found" (or "HTTP/1.0 404 Not Found") error during the background process for an unreachable file.

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed
