### PR TITLE
 [ES] Use `title.sort` only when no other sort is available, refs 3323

### DIFF
--- a/src/Elastic/QueryEngine/SortBuilder.php
+++ b/src/Elastic/QueryEngine/SortBuilder.php
@@ -96,6 +96,7 @@ class SortBuilder {
 		$isConstantScore = true;
 		$sort = [];
 		$sortFields = [];
+		$sortKeysCount = count( $sortKeys );
 
 		foreach ( $sortKeys as $key => $order ) {
 			$order = strtolower( $order );
@@ -108,7 +109,7 @@ class SortBuilder {
 			}
 
 			if ( $key === '' || $key === '#' ) {
-				$this->addDefaultField( $sort, $order );
+				$this->addDefaultField( $sort, $order, $sortKeysCount );
 			} else {
 				$this->addField( $sort, $sortFields, $key, $order );
 			}
@@ -117,12 +118,16 @@ class SortBuilder {
 		return [ $sort, $sortFields, $isRandom, $isConstantScore ];
 	}
 
-	private function addDefaultField( &$sort, $order ) {
+	private function addDefaultField( &$sort, $order, $sortKeysCount ) {
 		$sort['subject.sortkey.sort'] = [ 'order' => $order ];
 
 		// Add title as extra criteria in case an entity uses the same sortkey
 		// to clarify its relative position, @see T:P0416#8
-		$sort['subject.title.sort'] = [ 'order' => $order ];
+		// Only add the title as determining factor when no other sort parameter
+		// is available
+		if ( $sortKeysCount == 1 ) {
+			$sort['subject.title.sort'] = [ 'order' => $order ];
+		}
 	}
 
 	private function addField( &$sort, &$sortFields, $key, $order ) {

--- a/tests/phpunit/Integration/JSONScript/TestCases/f-0308.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/f-0308.json
@@ -1,0 +1,93 @@
+{
+	"description": "Test `format=table` with DEFAULTSORT and subject,property sorting",
+	"setup": [
+		{
+			"namespace": "SMW_NS_PROPERTY",
+			"page": "Is performer",
+			"contents": "[[Has type::Page]]"
+		},
+		{
+			"page": "F0308/A",
+			"contents": "[[Category:F0308]] {{DEFAULTSORT:F0308/A}} [[Is performer::August]]"
+		},
+		{
+			"page": "F0308/AB",
+			"contents": "[[Category:F0308]] {{DEFAULTSORT:F0308/A}} [[Is performer::September]]"
+		},
+		{
+			"page": "F0308/Q.1",
+			"contents": "{{#ask: [[Category:F0308]] |sort=,Is performer |order=asc,asc |format=table}}"
+		},
+		{
+			"page": "F0308/Q.2",
+			"contents": "{{#ask: [[Category:F0308]] |sort=,Is performer |order=asc,desc |format=table}}"
+		},
+		{
+			"page": "F0308/Q.3",
+			"contents": "{{#ask: [[Category:F0308]] |sort=,Is performer |order=desc,asc |format=table}}"
+		},
+		{
+			"page": "F0308/Q.4",
+			"contents": "{{#ask: [[Category:F0308]] |sort=,Is performer |order=desc,desc |format=table}}"
+		}
+	],
+	"tests": [
+		{
+			"type": "format",
+			"about": "#0 ( ,Is performer | asc,asc)",
+			"subject": "F0308/Q.1",
+			"assert-output": {
+				"to-contain": [
+					"<tr data-row-number=\"1\" class=\"row-odd\"><td class=\"smwtype_wpg\"><a href=.* title=\"F0308/A\">F0308/A</a></td></tr>",
+					"<tr data-row-number=\"2\" class=\"row-even\"><td class=\"smwtype_wpg\"><a href=.* title=\"F0308/AB\">F0308/AB</a></td></tr>"
+				]
+			}
+		},
+		{
+			"type": "format",
+			"about": "#1 ( ,Is performer | asc,desc)",
+			"subject": "F0308/Q.2",
+			"assert-output": {
+				"to-contain": [
+					"<tr data-row-number=\"1\" class=\"row-odd\"><td class=\"smwtype_wpg\"><a href=.* title=\"F0308/AB\">F0308/AB</a></td></tr>",
+					"<tr data-row-number=\"2\" class=\"row-even\"><td class=\"smwtype_wpg\"><a href=.* title=\"F0308/A\">F0308/A</a></td></tr>"
+				]
+			}
+		},
+		{
+			"type": "format",
+			"about": "#2 ( ,Is performer | desc,asc)",
+			"subject": "F0308/Q.3",
+			"assert-output": {
+				"to-contain": [
+					"<tr data-row-number=\"1\" class=\"row-odd\"><td class=\"smwtype_wpg\"><a href=.* title=\"F0308/A\">F0308/A</a></td></tr>",
+					"<tr data-row-number=\"2\" class=\"row-even\"><td class=\"smwtype_wpg\"><a href=.* title=\"F0308/AB\">F0308/AB</a></td></tr>"
+				]
+			}
+		},
+		{
+			"type": "format",
+			"about": "#3 ( ,Is performer | desc,desc)",
+			"subject": "F0308/Q.4",
+			"assert-output": {
+				"to-contain": [
+					"<tr data-row-number=\"1\" class=\"row-odd\"><td class=\"smwtype_wpg\"><a href=.* title=\"F0308/AB\">F0308/AB</a></td></tr>",
+					"<tr data-row-number=\"2\" class=\"row-even\"><td class=\"smwtype_wpg\"><a href=.* title=\"F0308/A\">F0308/A</a></td></tr>"
+				]
+			}
+		}
+	],
+	"settings": {
+		"wgContLang": "en",
+		"wgLang": "en",
+		"smwgNamespacesWithSemanticLinks": {
+			"NS_MAIN": true,
+			"SMW_NS_PROPERTY": true
+		}
+	},
+	"meta": {
+		"version": "2",
+		"is-incomplete": false,
+		"debug": false
+	}
+}


### PR DESCRIPTION
This PR is made in reference to: #3323 

This PR addresses or contains:
- As suggested https://github.com/SemanticMediaWiki/SemanticMediaWiki/issues/3323#issuecomment-414194051

This PR includes:
- [ ] Tests (unit/integration)
- [x] CI build passed

Fixes #