### PR TITLE
[CI] Drop hhvm-3.18/master test run, refs 2688

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,8 +28,8 @@ matrix:
       php: 7.2
     - env: DB=mysql; MW=REL1_27; TYPE=benchmark; PHPUNIT=5.7.*
       php: hhvm-3.18
-    - env: DB=sqlite; MW=master; PHPUNIT=5.7.*
-      php: hhvm-3.18
+    - env: DB=sqlite; MW=master; PHPUNIT=6.5.*
+      php: 7.2
     - env: DB=sqlite; MW=REL1_27; TYPE=composer; PHPUNIT=4.8.*
       php: 5.6
     - env: DB=mysql; MW=REL1_27; TYPE=relbuild; PHPUNIT=4.8.*
@@ -40,7 +40,7 @@ matrix:
     # Can fail when pushed/used with newly Composer dependencies
     - env: DB=sqlite; MW=REL1_27; TYPE=composer; PHPUNIT=4.8.*
     # This is MW master, you never know what WMF developers have put in for easter eggs
-    - env: DB=sqlite; MW=master; PHPUNIT=5.7.*
+    - env: DB=sqlite; MW=master; PHPUNIT=6.5.*
     # May take a moment and is non-critical therefore allow it to run without delaying the status
     - env: DB=mysql; MW=REL1_27; TYPE=benchmark; PHPUNIT=5.7.*
     - env: DB=mysql; MW=REL1_27; SESAME=2.8.7


### PR DESCRIPTION
This PR is made in reference to: #2688

This PR addresses or contains:

- Stop testing hhvm-3.18/master (replace with PHP 7.2/master) because in recent runs [0] errors with certain messages became unmanageable to be meaningful such as:
  - `Fatal error: Parameter $args is variadic and has a type constraint (array); variadic params with type constraints are not supported in non-Hack files in /home/travis/build/SemanticMediaWiki/mw/extensions/SemanticMediaWiki/vendor/phpunit/phpunit-mock-objects/src/Framework/MockObject/Generator.php(345)(2153ee533b9a2a9ecfb0fd63e4401dfd) : eval()'d code on line 408`
  - `Fatal error: Syntax only allowed in Hack files (<?hh) or with -v Eval.EnableHipHopSyntax=true in /home/travis/build/SemanticMediaWiki/mw/extensions/SemanticMediaWiki/vendor/phpunit/phpunit-mock-objects/src/Framework/MockObject/Generator.php(345)(8b7308937991c3944e78e62cf2884eba) : eval()'d code on line 34`
- "Syntax only allowed in Hack files (<?hh)" we don't do Hack!
- Keep hhvm-3.18/REL1_27 to provide benchmark insights and keep consistency with past runs to make them somewhat comparable

This PR includes:
- [ ] Tests (unit/integration)
- [x] CI build passed

[0] https://api.travis-ci.org/v3/job/420450284/log.txt