### PR TITLE
[ES] Add cjk.best.effort.proximity.match

### DIFF
--- a/DefaultSettings.php
+++ b/DefaultSettings.php
@@ -2116,8 +2116,8 @@ return array(
 			'query_string.boolean.operators' => true,
 
 			// ES works different with text elements compared to the SQL interface
-			// (and its and its DSL query logic) therefore we try to modify some
-			// common scenarios and alter strings (and boolean oeprators) to pass
+			// (and its DSL query logic) therefore we try to modify some
+			// common scenarios and alter strings (and boolean operators) to pass
 			// most use cases from the SQLStore integration test suite and hereby
 			// allows to be compatible with the SMW SQL answering behaviour.
 			//
@@ -2191,6 +2191,15 @@ return array(
 			// @default 1h
 			'concept.terms.lookup.cache.lifetime' => 60 * 60,
 
+			// In case search terms contains CJK terms, remove `*` prefix/affix
+			// from a search request in an effort to best match single characters
+			// that created as part of the standard analyzer. Use a phrase match
+			// instead of a wildcard proximity.
+			//
+			// This setting may be disabled when using a different index definition
+			// (e.g. ICU).
+			'cjk.best.effort.proximity.match' => true,
+
 			// Specifies that a wide proximity search (e.g. [[~~Foo bar]] or
 			// [[in:Foo bar]]) is executed as a match_phrase search meaning that
 			// that all elements of the query string need to be present in the
@@ -2250,7 +2259,7 @@ return array(
 			//
 			// @see https://www.elastic.co/guide/en/elasticsearch/reference/current/search-request-highlighting.html#plain-highlighter
 			// @see https://www.elastic.co/guide/en/elasticsearch/reference/current/term-vector.html
-			'special_search.highlight.fragment' => [ 'count' => 1, 'size' => 250, 'type' => false ]
+			'special_search.highlight.fragment' => [ 'number' => 1, 'size' => 250, 'type' => false ]
 		]
 	],
 	##

--- a/src/Elastic/QueryEngine/Condition.php
+++ b/src/Elastic/QueryEngine/Condition.php
@@ -120,7 +120,7 @@ class Condition {
 	 * @return string
 	 */
 	public function __toString() {
-		return json_encode( $this->toArray() );
+		return json_encode( $this->toArray(), JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE );
 	}
 
 }

--- a/src/Elastic/QueryEngine/QueryEngine.php
+++ b/src/Elastic/QueryEngine/QueryEngine.php
@@ -348,7 +348,7 @@ class QueryEngine implements IQueryEngine {
 		}
 
 		$body['highlight'] = [
-			'number_of_fragments' => $this->options->dotGet( 'query.special_search.highlight.fragment.count', 1 ),
+			'number_of_fragments' => $this->options->dotGet( 'query.special_search.highlight.fragment.number', 1 ),
 			'fragment_size' => $this->options->dotGet( 'query.special_search.highlight.fragment.size', 150 ),
 			'fields' => [
 				'attachment.content' => [ "type" => $type ],

--- a/src/MediaWiki/Search/SearchResultSet.php
+++ b/src/MediaWiki/Search/SearchResultSet.php
@@ -3,6 +3,7 @@
 namespace SMW\MediaWiki\Search;
 
 use SMW\DIWikiPage;
+use SMW\Utils\CharExaminer;
 
 /**
  * @ingroup SMW
@@ -172,7 +173,9 @@ class SearchResultSet extends \SearchResultSet {
 		// such as [[Category:Foo]] is not considered eligible to provide a
 		// token.
 		foreach ( $this->queryToken->getTokens() as $key => $value ) {
-			$tokens[] = "\b$key\b";
+			// Avoid add \b boundary checks for CJK where whitespace is not used
+			// as word break
+			$tokens[] = CharExaminer::isCJK( $key ) ? "$key" : "\b$key\b";
 		}
 
 		return $tokens;

--- a/src/Utils/CharExaminer.php
+++ b/src/Utils/CharExaminer.php
@@ -1,0 +1,90 @@
+<?php
+
+namespace SMW\Utils;
+
+/**
+ * @license GNU GPL v2+
+ * @since 3.0
+ *
+ * @author mwjames
+ */
+class CharExaminer {
+
+	const CYRILLIC = 'CYRILLIC';
+	const LATIN = 'LATIN';
+	const HIRAGANA_KATAKANA = 'HIRAGANA_KATAKANA';
+	const HANGUL = 'HANGUL';
+	const CJK_UNIFIED = 'CJK_UNIFIED';
+	const HAN = 'HAN';
+
+	/**
+	 * @since 3.0
+	 *
+	 * @param string $text
+	 *
+	 * @return boolean
+	 */
+	public static function isCJK( $text ) {
+
+		if ( self::contains( self::HAN, $text ) ) {
+			return true;
+		}
+
+		if ( self::contains( self::HIRAGANA_KATAKANA, $text ) ) {
+			return true;
+		}
+
+		if ( self::contains( self::HANGUL, $text ) ) {
+			return true;
+		}
+
+		if ( self::contains( self::CJK_UNIFIED, $text ) ) {
+			return true;
+		}
+
+		return false;
+	}
+
+	/**
+	 * @see http://jrgraphix.net/research/unicode_blocks.php
+	 * @since 0.1
+	 *
+	 * @param string $type
+	 * @param string $text
+	 *
+	 * @return boolean
+	 */
+	public static function contains( $type, $text ) {
+
+		if ( $type === self::CYRILLIC ) {
+			return preg_match('/\p{Cyrillic}/u', $text ) > 0;
+		}
+
+		if ( $type === self::LATIN ) {
+			return preg_match('/\p{Latin}/u', $text ) > 0;
+		}
+
+		if ( $type === self::HAN ) {
+			return preg_match('/\p{Han}/u', $text ) > 0;
+		}
+
+		if ( $type === self::HIRAGANA_KATAKANA ) {
+			return preg_match('/[\x{3040}-\x{309F}]/u', $text ) > 0 || preg_match('/[\x{30A0}-\x{30FF}]/u', $text ) > 0; // isHiragana || isKatakana
+		}
+
+		if ( $type === self::HANGUL ) {
+			return preg_match('/[\x{3130}-\x{318F}]/u', $text ) > 0 || preg_match('/[\x{AC00}-\x{D7AF}]/u', $text ) > 0;
+		}
+
+		// @see https://en.wikipedia.org/wiki/CJK_Unified_Ideographs
+		// Chinese, Japanese and Korean (CJK) scripts share common characters
+		// known as CJK characters
+
+		if ( $type === self::CJK_UNIFIED ) {
+			return preg_match('/[\x{4e00}-\x{9fa5}]/u', $text ) > 0;
+		}
+
+		return false;
+	}
+
+}

--- a/tests/phpunit/Integration/JSONScript/TestCases/q-1206.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/q-1206.json
@@ -1,0 +1,142 @@
+{
+	"description": "Test `cjk.best.effort.proximity.match` (ES only)",
+	"setup": [
+		{
+			"namespace": "SMW_NS_PROPERTY",
+			"page": "Has page",
+			"contents": "[[Has type::Page]]"
+		},
+		{
+			"namespace": "SMW_NS_PROPERTY",
+			"page": "Has text",
+			"contents": "[[Has type::Text]]"
+		},
+		{
+			"page": "Q1206/1",
+			"contents": "[[Has page::東日本]] [[Has text::東日本]]"
+		},
+		{
+			"page": "Q1206/2",
+			"contents": "[[Has page::西日本]] [[Has text::西日本]]"
+		},
+		{
+			"page": "Q1206/3",
+			"contents": "[[Has text::。。。　暑さが続いている西日本と東日本では　。。。]]"
+		}
+	],
+	"tests": [
+		{
+			"type": "query",
+			"about": "#0",
+			"skip-on": {
+				"elastic": [ "not", "Only works with ES out of the box." ]
+			},
+			"condition": "[[Has page::in:西日本]]",
+			"printouts": [],
+			"parameters": {
+				"limit": "10"
+			},
+			"assert-queryresult": {
+				"count": 1,
+				"results": [
+					"Q1206/2#0##"
+				]
+			}
+		},
+		{
+			"type": "query",
+			"about": "#1",
+			"skip-on": {
+				"elastic": [ "not", "Only works with ES out of the box." ]
+			},
+			"condition": "[[in:西日本]]",
+			"printouts": [],
+			"parameters": {
+				"limit": "10"
+			},
+			"assert-queryresult": {
+				"count": 3,
+				"results": [
+					"Q1206/2#0##",
+					"Q1206/3#0##",
+					"西日本#0##"
+				]
+			}
+		},
+		{
+			"type": "query",
+			"about": "#2",
+			"skip-on": {
+				"elastic": [ "not", "Only works with ES out of the box." ]
+			},
+			"condition": "[[in:日本]]",
+			"printouts": [],
+			"parameters": {
+				"limit": "10"
+			},
+			"assert-queryresult": {
+				"count": 5,
+				"results": [
+					"Q1206/1#0##",
+					"Q1206/2#0##",
+					"Q1206/3#0##",
+					"西日本#0##",
+					"東日本#0##"
+				]
+			}
+		},
+		{
+			"type": "query",
+			"about": "#3",
+			"skip-on": {
+				"elastic": [ "not", "Only works with ES out of the box." ]
+			},
+			"condition": "[[in:東日本]] [[in:西日本]]",
+			"printouts": [],
+			"parameters": {
+				"limit": "10"
+			},
+			"assert-queryresult": {
+				"count": 1,
+				"results": [
+					"Q1206/3#0##"
+				]
+			}
+		},
+		{
+			"type": "query",
+			"about": "#4",
+			"skip-on": {
+				"elastic": [ "not", "Only works with ES out of the box." ]
+			},
+			"condition": "[[in:東日本]] [[not:西日本]]",
+			"printouts": [],
+			"parameters": {
+				"limit": "10"
+			},
+			"assert-queryresult": {
+				"count": 2,
+				"results": [
+					"Q1206/1#0##",
+					"東日本#0##"
+				]
+			}
+		}
+	],
+	"settings": {
+		"smwgNamespacesWithSemanticLinks": {
+			"NS_MAIN": true,
+			"SMW_NS_PROPERTY": true
+		},
+		"smwgElasticsearchConfig": {
+			"query": {
+				"cjk.best.effort.proximity.match": true
+			}
+		}
+	},
+	"meta": {
+		"version": "2",
+		"is-incomplete": false,
+		"debug": false
+	}
+}

--- a/tests/phpunit/Unit/Elastic/QueryEngine/DescriptionInterpreters/ValueDescriptionInterpreterTest.php
+++ b/tests/phpunit/Unit/Elastic/QueryEngine/DescriptionInterpreters/ValueDescriptionInterpreterTest.php
@@ -1,0 +1,129 @@
+<?php
+
+namespace SMW\Tests\Elastic\QueryEngine\DescriptionInterpreters;
+
+use SMW\Elastic\QueryEngine\DescriptionInterpreters\ValueDescriptionInterpreter;
+use SMW\DIWikiPage;
+use SMW\Query\DescriptionFactory;
+use SMW\DataItemFactory;
+use SMW\Options;
+
+/**
+ * @covers \SMW\Elastic\QueryEngine\DescriptionInterpreters\ValueDescriptionInterpreter
+ * @group semantic-mediawiki
+ *
+ * @license GNU GPL v2+
+ * @since 3.0
+ *
+ * @author mwjames
+ */
+class ValueDescriptionInterpreterTest extends \PHPUnit_Framework_TestCase {
+
+	private $conditionBuilder;
+
+	public function setUp() {
+
+		$this->descriptionFactory = new DescriptionFactory();
+		$this->dataItemFactory = new DataItemFactory();
+
+		$this->conditionBuilder = $this->getMockBuilder( '\SMW\Elastic\QueryEngine\ConditionBuilder' )
+			->disableOriginalConstructor()
+			->setMethods( [ 'getID' ] )
+			->getMock();
+
+		$this->conditionBuilder->expects( $this->any() )
+			->method( 'getID' )
+			->will( $this->onConsecutiveCalls( 42, 1001, 9000, 110001 ) );
+	}
+
+	public function testCanConstruct() {
+
+		$this->assertInstanceOf(
+			ValueDescriptionInterpreter::class,
+			new ValueDescriptionInterpreter( $this->conditionBuilder )
+		);
+	}
+
+	/**
+	 * @dataProvider valueProvider
+	 */
+	public function testInterpretDescription( $dataItem, $comparator, $options, $expected ) {
+
+		$this->conditionBuilder->setOptions( new Options(
+			[
+				'cjk.best.effort.proximity.match' => true
+			]
+		) );
+
+		$instance = new ValueDescriptionInterpreter(
+			$this->conditionBuilder
+		);
+
+		$description = $this->descriptionFactory->newValueDescription(
+			$dataItem,
+			null,
+			$comparator
+		);
+
+		$condition = $instance->interpretDescription(
+			$description,
+			$options
+		);
+
+		$this->assertEquals(
+			$expected,
+			(string)$condition
+		);
+	}
+
+	public function valueProvider() {
+
+		$dataItemFactory = new DataItemFactory();
+
+		$options = [
+			'property' => $dataItemFactory->newDIProperty( 'Bar' ),
+			'pid'   => 'P:42',
+			'field' => 'wpgID',
+			'type'  => 'must'
+		];
+
+		$dataItem = $dataItemFactory->newDIWikiPage( 'test' );
+
+		yield [
+			$dataItem,
+			SMW_CMP_EQ,
+			$options,
+			'{"bool":{"must":{"terms":{"_id":[42]}}}}'
+		];
+
+		yield [
+			$dataItem,
+			SMW_CMP_LIKE,
+			$options,
+			'{"bool":{"must":[{"match":{"subject.sortkey":"test"}}]}}'
+		];
+
+		// wide.proximity.fields
+		$dataItem = $dataItemFactory->newDIWikiPage( '~*test*' );
+
+		yield [
+			$dataItem,
+			SMW_CMP_LIKE,
+			$options,
+			'{"bool":{"must":{"query_string":{"fields":["text_copy"],"query":"*test*","minimum_should_match":1}}}}'
+		];
+
+		// wide.proximity.fields
+		// cjk.best.effort.proximity.match
+		$dataItem = $dataItemFactory->newDIWikiPage( '~*テスト*' );
+
+		yield [
+			$dataItem,
+			SMW_CMP_LIKE,
+			$options,
+			'{"bool":{"must":[{"multi_match":{"fields":["text_copy"],"query":"テスト","type":"phrase"}}]}}'
+		];
+	}
+
+
+}

--- a/tests/phpunit/Unit/Utils/CharExaminerTest.php
+++ b/tests/phpunit/Unit/Utils/CharExaminerTest.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace SMW\Tests\Utils;
+
+use SMW\Utils\CharExaminer;
+
+/**
+ * @covers \SMW\Utils\CharExaminer
+ * @group semantic-mediawiki
+ *
+ * @license GNU GPL v2+
+ * @since 3.0
+ *
+ * @author mwjames
+ */
+class CharExaminerTest extends \PHPUnit_Framework_TestCase {
+
+	public function testToContainKoreanCharacters() {
+		$this->assertTrue(
+			CharExaminer::contains( CharExaminer::HANGUL, '한국어 텍스트의 예' )
+		);
+
+		$this->assertFalse(
+			CharExaminer::contains( CharExaminer::HAN, '한국어 텍스트의 예' )
+		);
+	}
+
+	public function testToContainJapaneseCharacters() {
+
+		$this->assertTrue(
+			CharExaminer::contains( CharExaminer::LATIN, '脳のIQテスト' )
+		);
+
+		$this->assertTrue(
+			CharExaminer::contains( CharExaminer::HIRAGANA_KATAKANA, '脳のIQテスト' )
+		);
+
+		$this->assertTrue(
+			CharExaminer::contains( CharExaminer::HAN, '脳のIQテスト' )
+		);
+	}
+
+	public function testToContainChineseCharacters() {
+
+		$this->assertFalse(
+			CharExaminer::contains( CharExaminer::LATIN, '才可以过关' )
+		);
+
+		$this->assertTrue(
+			CharExaminer::contains( CharExaminer::CJK_UNIFIED, '才可以过关' )
+		);
+
+		$this->assertTrue(
+			CharExaminer::contains( CharExaminer::HAN, '才可以过关' )
+		);
+	}
+
+	public function testToContainCyrillic() {
+
+		$this->assertFalse(
+			CharExaminer::contains( CharExaminer::LATIN, 'Привет' )
+		);
+
+		$this->assertTrue(
+			CharExaminer::contains( CharExaminer::CYRILLIC, 'Привет' )
+		);
+	}
+
+	public function testToContainUnknownCharacters() {
+		$this->assertFalse(
+			CharExaminer::contains( 'Foo', '鿩' )
+		);
+	}
+
+}


### PR DESCRIPTION
This PR is made in reference to: #

This PR addresses or contains:

- When using the standard analyzer (as declared in `index_def` and not the ICU deployed example), CJK related terms and texts are split into single characters by Elasticsearch. A proximity search such as  `[[in:東日本]]` would produce a prefix/affix match pattern with wildcards (i.e. adding `*` before and after a search term as in `*東日本*`) which would normally increase the proximity range but those wildcards will have an adverse effect in combination with CJK terms. The `*` fails the request since it hinders the standard analyzer to split the search term into single characters hereby actually decreases the match accuracy compared to when just searching without any wildcard. To improve accuracy for this use case when relying on the standard analyzer `cjk.best.effort.proximity.match` is introduced to make a "best effort" by:
  - Detecting that a search terms contains CJK
  - In case of a CJK search term, remove `*` from the `in:` and replace it with a `phrase` match so it can generate  `東 日 本` while keeping the character boundary
- Other possibilities would include to build ngrams [0, 1, 2] for selected fields but that is a separate discussion.

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed

[0] https://www.elastic.co/guide/en/elasticsearch/reference/6.3/analysis-ngram-tokenizer.html
[1] https://qbox.io/blog/an-introduction-to-ngrams-in-elasticsearch
[2] https://devticks.com/how-to-improve-your-full-text-search-in-elasticsearch-with-ngram-tokenizer-e346f29f8ddb?gi=1be95a46f159