### PR TITLE
[ES] Strip tags from excerpts

### DIFF
--- a/src/Elastic/QueryEngine/Excerpts.php
+++ b/src/Elastic/QueryEngine/Excerpts.php
@@ -27,7 +27,7 @@ class Excerpts extends \SMW\Query\Excerpts {
 
 		foreach ( $this->excerpts as $map ) {
 			if ( $map[0] === $hash ) {
-				return is_string( $map[1] ) ? $map[1] : $this->format( $map[1] );
+				return $this->format( $map[1] );
 			}
 		}
 
@@ -40,14 +40,39 @@ class Excerpts extends \SMW\Query\Excerpts {
 	 * @return boolean
 	 */
 	public function hasHighlight() {
-		return true;
+		return $this->noHighlight ? false : true;
 	}
 
 	private function format( $v ) {
+
+		// https://www.elastic.co/guide/en/elasticsearch/reference/current/search-request-highlighting.html
+		// By default, highlighted text is wrapped in <em> and </em> tags
+
 		$text = '';
 
-		foreach ( $v as $key => $value ) {
-			$text .= implode( ' ', $value ) ;
+		if ( is_array( $v ) ) {
+			foreach ( $v as $key => $value ) {
+				$text .= implode( ' ', $value ) ;
+			}
+		} else {
+			$text = $v;
+		}
+
+		if ( $this->stripTags ) {
+			$text = str_replace(
+				[ '<em>', '</em>' ],
+				[ '&lt;em&gt;', '&lt;/em&gt;' ],
+				$text
+			);
+
+			// Remove tags to avoid any output disruption
+			$text = strip_tags( $text );
+
+			$text = str_replace(
+				[ '&lt;em&gt;', '&lt;/em&gt;' ],
+				[ '<em>', '</em>' ],
+				$text
+			);
 		}
 
 		if ( $this->noHighlight ) {

--- a/src/Query/Excerpts.php
+++ b/src/Query/Excerpts.php
@@ -30,6 +30,11 @@ class Excerpts {
 	protected $hasHighlight = false;
 
 	/**
+	 * @var boolean
+	 */
+	protected $stripTags = true;
+
+	/**
 	 * @since 3.0
 	 */
 	public function noHighlight() {

--- a/tests/phpunit/Unit/Elastic/QueryEngine/ExcerptsTest.php
+++ b/tests/phpunit/Unit/Elastic/QueryEngine/ExcerptsTest.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace SMW\Tests\Elastic\QueryEngine;
+
+use SMW\Elastic\QueryEngine\Excerpts;
+
+/**
+ * @covers \SMW\Elastic\QueryEngine\Excerpts
+ * @group semantic-mediawiki
+ *
+ * @license GNU GPL v2+
+ * @since 3.0
+ *
+ * @author mwjames
+ */
+class ExcerptsTest extends \PHPUnit_Framework_TestCase {
+
+	public function testCanConstruct() {
+
+		$this->assertInstanceOf(
+			Excerpts::class,
+			new Excerpts()
+		);
+	}
+
+	public function testGetExcerpt_StrippedTagsOnString() {
+
+		$instance = new Excerpts();
+
+		$instance->addExcerpt( 'Foo', '<div style="display:none;">Foo<em>bar</em></div>' );
+
+		$this->assertEquals(
+			'Foo<em>bar</em>',
+			$instance->getExcerpt( 'Foo' )
+		);
+	}
+
+	public function testGetExcerpt_StrippedTagsOnArray() {
+
+		$instance = new Excerpts();
+
+		$instance->addExcerpt( 'Bar', [
+			'test_field' => [ '<div style="display:none;">Foo<em>bar</em></div>', 'Fooba<em>r</em>' ]
+		] );
+
+		$this->assertEquals(
+			'Foo<em>bar</em> Fooba<em>r</em>',
+			$instance->getExcerpt( 'Bar' )
+		);
+	}
+
+}


### PR DESCRIPTION
This PR is made in reference to: #

This PR addresses or contains:

- When using excerpts (as in the highlighted text used for the `Special:Search` display) remove any tags from those text snippets that may disturb the HTML representation

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed
