### PR TITLE
[DB] Extend ID field length, refs 1184

### DIFF
--- a/DefaultSettings.php
+++ b/DefaultSettings.php
@@ -77,7 +77,7 @@ return array(
 	#
 	# @since 3.0
 	##
-	'smwgUpgradeKey' => 'DB-2018-08',
+	'smwgUpgradeKey' => 'DB-2018-08-25',
 	##
 
 	###

--- a/src/SQLStore/TableBuilder/MySQLTableBuilder.php
+++ b/src/SQLStore/TableBuilder/MySQLTableBuilder.php
@@ -24,9 +24,9 @@ class MySQLTableBuilder extends TableBuilder {
 
 		$fieldTypes = array(
 			 // like page_id in MW page table
-			'id'         => 'INT(8) UNSIGNED',
+			'id'         => 'INT(11) UNSIGNED',
 			 // like page_id in MW page table
-			'id primary' => 'INT(8) UNSIGNED NOT NULL KEY AUTO_INCREMENT',
+			'id primary' => 'INT(11) UNSIGNED NOT NULL KEY AUTO_INCREMENT',
 			 // like page_namespace in MW page table
 			'namespace'  => 'INT(11)',
 			 // like page_title in MW page table


### PR DESCRIPTION
This PR is made in reference to: #1184

This PR addresses or contains:

- Use int(11) instead of int(8) for MySQL/MariaDB (Postgres and SQLite remain unrestricted) which should give enough room to generate IDs for the upcoming 3.x release

This PR includes:
- [ ] Tests (unit/integration)
- [x] CI build passed

Fixes #1184