### PR TITLE
PHP 7.2 Skip some tests

### DIFF
--- a/src/DataValues/Number/IntlNumberFormatter.php
+++ b/src/DataValues/Number/IntlNumberFormatter.php
@@ -316,10 +316,19 @@ class IntlNumberFormatter {
 			$precision = $actualPrecision;
 		}
 
+		$value = (float)$value;
+		$isNegative = $value < 0;
+
 		// Format to some level of precision; number_format does rounding and
 		// locale formatting, x and y are used temporarily since number_format
 		// supports only single characters for either
-		$value = number_format( (float)$value, $precision, 'x', 'y' );
+		$value = number_format( $value, $precision, 'x', 'y' );
+
+		// Due to https://bugs.php.net/bug.php?id=76824
+		if ( $isNegative && $value >= 0 ) {
+			$value = "-$value";
+		}
+
 		$value = str_replace(
 			array( 'x', 'y' ),
 			array(

--- a/tests/phpunit/Unit/DataValues/Time/IntlTimeFormatterTest.php
+++ b/tests/phpunit/Unit/DataValues/Time/IntlTimeFormatterTest.php
@@ -135,7 +135,8 @@ class IntlTimeFormatterTest extends \PHPUnit_Framework_TestCase {
 		);
 
 		// Skip on HHVM to avoid .888500 vs. .888499 msec @see hhvm#6899
-		if ( !defined( 'HHVM_VERSION' ) ) {
+		// https://bugs.php.net/bug.php?id=76822
+		if ( !defined( 'HHVM_VERSION' ) && version_compare( PHP_VERSION, '7.2', '<' ) ) {
 			#3
 			$provider[] = array(
 				'2/1300/11/02/12/03/25.888499949',


### PR DESCRIPTION
This PR is made in reference to: #

This PR addresses or contains:

- Relates to:
  - https://bugs.php.net/bug.php?id=76822 currently pending so we skip the test
  - https://bugs.php.net/bug.php?id=76824 the explanation and reasoning is unsatisfactory "Previously, it was possible for the number_format() function to return -0. Whilst this is perfectly valid according to the IEEE 754 floating point specification, this oddity was not desirable for displaying formatted numbers in a human-readable form." yet there is a semantic difference between -0.00000 and 0.00000. First I thought we skip the test but I decided that we keep the format of -0.00000 when we detect that PHP changed the value arbitrarily to an unsigned float.

This PR includes:
- [ ] Tests (unit/integration)
- [x] CI build passed
