### PR TITLE
Special:Search Avoid "Invalid sort: title. Must be one of: relevance"

### DIFF
--- a/src/MediaWiki/Search/Search.php
+++ b/src/MediaWiki/Search/Search.php
@@ -52,6 +52,24 @@ class Search extends SearchEngine {
 	private $queryLink = '';
 
 	/**
+	 * @see SearchEngine::getValidSorts
+	 *
+	 * @since 3.0
+	 *
+	 * @return array
+	 */
+	public function getValidSorts() {
+		return [
+
+			// SemanticMediaWiki supported
+			'title', 'recent', 'best',
+
+			// MediaWiki default
+			'relevance'
+		];
+	}
+
+	/**
 	 * @param null|SearchEngine $fallbackSearch
 	 */
 	public function setFallbackSearchEngine( SearchEngine $fallbackSearch = null ) {


### PR DESCRIPTION
This PR is made in reference to: #

This PR addresses or contains:

- MW 1.32+ fails with "InvalidArgumentException from line 370 of ...\includes\search\SearchEngine.php: Invalid sort: title. Must be one of: relevance" if those are not specified 
- I suspect https://github.com/wikimedia/mediawiki/commit/9171317645de4d31c61c570a9e4fa765e09ecc4d to be the reason why the `SearchEngine` suddenly throws an `InvalidArgumentException` for unknown sorts

## Stack

```
[af06e762520c981f3ec420ce] /.../index.php?search=in%3Alorem&title=Special%3ASearch&profile=smw&fulltext=1&ns-list=1&sort=title&smw-form=booksandjournals&hastitle%5B%5D=&hasauthor%5B%5D=&published%5B%5D=&hasgenre%5B%5D=&haspublisher%5B%5D=&mediatype%5B%5D=&mimetype%5B%5D=&fileattachment.contenttype%5B%5D=&property%5B%5D=&pvalue%5B%5D=&op%5B%5D=&ns0=1&ns102=1&ns108=1 InvalidArgumentException from line 370 of ...\includes\search\SearchEngine.php: Invalid sort: title. Must be one of: relevance

Backtrace:

#0 ...\includes\specials\SpecialSearch.php(314): SearchEngine->setSort(string)
#1 ...\includes\specials\SpecialSearch.php(190): SpecialSearch->showResults(string)
#2 ...\includes\specialpage\SpecialPage.php(569): SpecialSearch->execute(NULL)
#3 ...\includes\specialpage\SpecialPageFactory.php(581): SpecialPage->run(NULL)
#4 ...\includes\MediaWiki.php(288): MediaWiki\Special\SpecialPageFactory->executePath(Title, RequestContext)
#5 ...\includes\MediaWiki.php(868): MediaWiki->performRequest()
#6 ...\includes\MediaWiki.php(525): MediaWiki->main()
#7 ...\index.php(42): MediaWiki->run()
#8 {main}
```

This PR includes:
- [ ] Tests (unit/integration)
- [x] CI build passed
