### PR TITLE
Add API `psubject` smwbrowse module

### DIFF
--- a/DefaultSettings.php
+++ b/DefaultSettings.php
@@ -1107,8 +1107,13 @@ return array(
 	#
 	# - api.browse TTL (in sec, or false to disable it) for the API browse module
 	#   as general cache
+	#
 	# - api.browse.pvalue TTL (in sec, or false to disable it) for the API browse
 	#   pvalue module when requesting property values
+	#
+	# - api.browse.psubject TTL (in sec, or false to disable it) for the API browse
+	#   psubject module when requesting property subjects
+	#
 	# - api.task TTL (in sec, or false to disable it) for the API task module
 	#
 	# @since 1.9
@@ -1120,6 +1125,7 @@ return array(
 		'special.statistics' => 3600,
 		'api.browse' => 3600,
 		'api.browse.pvalue' => 3600,
+		'api.browse.psubject' => 3600,
 		'api.task'  => 3600
 	),
 	##

--- a/res/Resources.php
+++ b/res/Resources.php
@@ -404,7 +404,8 @@ return array(
 	'ext.smw.autocomplete.property' => $moduleTemplate + array(
 		'scripts' => [
 			'smw/util/ext.smw.util.autocomplete.property.js',
-			'smw/util/ext.smw.util.autocomplete.propertyvalue.js'
+			'smw/util/ext.smw.util.autocomplete.propertyvalue.js',
+			'smw/util/ext.smw.util.autocomplete.propertysubject.js'
 		],
 		'dependencies' => array(
 			'mediawiki.util',

--- a/res/smw/util/ext.smw.util.autocomplete.propertysubject.js
+++ b/res/smw/util/ext.smw.util.autocomplete.propertysubject.js
@@ -1,0 +1,126 @@
+/**
+ * JavaScript for property value autocomplete function
+ *
+ * @license GNU GPL v2+
+ * @since 3.0
+ *
+ * @author mwjames
+ */
+( function( $, mw ) {
+	'use strict';
+
+	var autocomplete = function( context ) {
+
+		// Keep the list small to minimize straining the DB
+		var limit = 10;
+		var currentValue = context.val();
+
+		// There is no reason for the field to be enabled as long as their is no
+		// property
+		if ( context.data( 'property' ) === '' || context.data( 'property' ) === undefined ) {
+			return context.addClass( 'is-disabled' );;
+		};
+
+		context.removeClass( 'is-disabled' );
+
+		var params = {
+			'action': 'smwbrowse',
+			'format': 'json',
+			'browse': 'psubject',
+			'params': {
+				"search": '',
+				'property': context.data( 'property' ),
+				'value': context.data( 'value' ),
+				"limit": limit
+			}
+		};
+
+		// https://github.com/devbridge/jQuery-Autocomplete
+		context.autocomplete( {
+			serviceUrl: mw.util.wikiScript( 'api' ),
+			dataType: 'json',
+			minChars: 0,
+			maxHeight: 150,
+			paramName: 'search',
+			delimiter: "\n",
+			noCache: false,
+			triggerSelectOnValidInput: false,
+			params: params,
+			onSearchStart: function( query ) {
+
+				// Avoid a search request on options or invalid characters
+				if (
+					query.search.indexOf( '#' ) > -1 ||
+					query.search.indexOf( '|' ) > -1 ) {
+					return false;
+				};
+
+				// Avoid a request for when the search term on the current
+				// selected value are the same
+				if ( currentValue !== '' && currentValue === query.search ) {
+					return false;
+				};
+
+				context.removeClass( 'autocomplete-arrow' );
+				context.addClass( 'is-disabled' );
+				context.addClass( 'autocomplete-loading' );
+
+				query.params = JSON.stringify( {
+					'search': query.search.replace( "?", '' ),
+					'property': context.data( 'property' ),
+					'value': context.data( 'value' ),
+					'limit': limit
+				} );
+
+				// Avoids {"warnings":{"main":{"*":"Unrecognized parameter: search."}
+				// from the API request
+				delete query.search;
+			},
+			onSelect: function( suggestion ) {
+
+				if ( suggestion ) {
+					currentValue = suggestion.value;
+				};
+
+				context.trigger( 'smw.autocomplete.propertysubject.select.complete', {
+					suggestion: suggestion,
+					context : context
+				} );
+			},
+			onSearchComplete: function( query ) {
+				context.removeClass( 'is-disabled' );
+				context.removeClass( 'autocomplete-loading' );
+				context.addClass( 'autocomplete-arrow' );
+			},
+			transformResult: function( response ) {
+
+				if ( !response.hasOwnProperty( 'query' ) ) {
+					return { suggestions: [] };
+				};
+
+				return {
+					suggestions: $.map( response.query, function( key ) {
+						return { value: key, data: key };
+					} )
+				};
+			}
+		} );
+
+		// https://github.com/devbridge/jQuery-Autocomplete/issues/498
+		// context.off( 'focus.autocomplete' );
+	}
+
+	// Listen to any event that requires a value autocomplete
+	// The trigger needs to set { context: ... } so we isolate the processing
+	// to a specific instance
+	$ ( document ).on( 'smw.autocomplete.propertysubject', function( event, opts ) {
+		autocomplete( opts.context.find( '.smw-propertysubject-input' ) );
+	} );
+
+	$( document ).ready( function() {
+		$( '.smw-propertysubject-input' ).each( function() {
+			autocomplete( $( this ) );
+		} );
+	} );
+
+} )( jQuery, mediaWiki );

--- a/src/MediaWiki/Api/Browse/PSubjectLookup.php
+++ b/src/MediaWiki/Api/Browse/PSubjectLookup.php
@@ -1,0 +1,215 @@
+<?php
+
+namespace SMW\MediaWiki\Api\Browse;
+
+use SMW\DIProperty;
+use Exception;
+use SMW\Store;
+use SMW\DIWikiPage;
+use SMW\RequestOptions;
+use SMW\StringCondition;
+use SMW\ApplicationFactory;
+use SMW\DataValueFactory;
+
+/**
+ * @license GNU GPL v2+
+ * @since 3.0
+ *
+ * @author mwjames
+ */
+class PSubjectLookup extends Lookup {
+
+	const VERSION = 1;
+
+	/**
+	 * @var Store
+	 */
+	private $store;
+
+	/**
+	 * @since 3.0
+	 *
+	 * @param Store $store
+	 */
+	public function __construct( Store $store ) {
+		$this->store = $store;
+	}
+
+	/**
+	 * @since 3.0
+	 *
+	 * @return string|integer
+	 */
+	public function getVersion() {
+		return __METHOD__ . self::VERSION;
+	}
+
+	/**
+	 * @since 3.0
+	 *
+	 * @param array $parameters
+	 *
+	 * @return array
+	 */
+	public function lookup( array $parameters ) {
+
+		$limit = 20;
+		$offset = 0;
+
+		if ( isset( $parameters['limit'] ) ) {
+			$limit = (int)$parameters['limit'];
+		}
+
+		if ( isset( $parameters['offset'] ) ) {
+			$offset = (int)$parameters['offset'];
+		}
+
+		$list = [];
+		$continueOffset = 0;
+		$property = null;
+		$value = null;
+
+		if ( isset( $parameters['property'] ) ) {
+			$property = $parameters['property'];
+
+			// Get the last which represents the final output
+			// Foo.Bar.Foobar.Baz
+			if ( strpos( $property, '.' ) !== false ) {
+				$chain = explode( '.', $property );
+				$property = array_pop( $chain );
+			}
+		}
+
+		if ( isset( $parameters['value'] ) ) {
+			$value = $parameters['value'];
+		}
+
+		if ( $property === '' || $property === null ) {
+			return [];
+		}
+
+		list( $list, $continueOffset ) = $this->findPropertySubjects(
+			$property,
+			$value,
+			$limit,
+			$offset,
+			$parameters
+		);
+
+		// Changing this output format requires to set a new version
+		$res = [
+			'query' => $list,
+			'query-continue-offset' => $continueOffset,
+			'version' => self::VERSION,
+			'meta' => [
+				'type'  => 'psubject',
+				'limit' => $limit,
+				'count' => count( $list )
+			]
+		];
+
+		return $res;
+	}
+
+	private function findPropertySubjects( $property, $value, $limit, $offset, $parameters ) {
+
+		$list = [];
+		$dataItem = null;
+
+		$property = DIProperty::newFromUserLabel( $property );
+
+		if ( $value !== '' && $value !== null ) {
+			$dataItem = DataValueFactory::getInstance()->newDataValueByProperty( $property, $value )->getDataItem();
+		}
+
+		$continueOffset = 0;
+		$count = 0;
+		$requestOptions = $this->newRequestOptions( $parameters );
+
+		$res = $this->store->getPropertySubjects(
+			$property,
+			$dataItem,
+			$requestOptions
+		);
+
+		foreach ( $res as $dataItem ) {
+
+			if ( !$dataItem instanceof DIWikiPage ) {
+				continue;
+			}
+
+			$list[] = $dataItem->getTitle()->getPrefixedText();
+		}
+
+		if ( $this->is_iterable( $res ) ) {
+			$count = count( $res );
+		}
+
+		if ( $count > $limit ) {
+			$continueOffset = $offset + $count;
+			array_pop( $list );
+		}
+
+		return [ $list, $continueOffset ];
+	}
+
+	private function newRequestOptions( $parameters ) {
+
+		$limit = 20;
+		$offset = 0;
+		$search = '';
+
+		if ( isset( $parameters['limit'] ) ) {
+			$limit = (int)$parameters['limit'];
+		}
+
+		if ( isset( $parameters['offset'] ) ) {
+			$offset = (int)$parameters['offset'];
+		}
+
+		$requestOptions = new RequestOptions();
+		$requestOptions->sort = true;
+		$requestOptions->setLimit( $limit + 1 );
+		$requestOptions->setOffset( $offset );
+
+		if ( isset( $parameters['search'] ) && $parameters['search'] !== '' ) {
+			$search = $parameters['search'];
+
+			if ( $search !== '' && $search{0} !== '_' ) {
+				$search = str_replace( "_", " ", $search );
+			}
+
+			$requestOptions->addStringCondition(
+				$search,
+				StringCondition::STRCOND_MID
+			);
+
+			// Disjunctive condition to allow for auto searches to match foaf OR Foaf
+			$requestOptions->addStringCondition(
+				ucfirst( $search ),
+				StringCondition::STRCOND_MID,
+				true
+			);
+
+			// Allow something like FOO to match the search string `foo`
+			$requestOptions->addStringCondition(
+				strtoupper( $search ),
+				StringCondition::STRCOND_MID,
+				true
+			);
+
+			$requestOptions->addStringCondition(
+				strtolower( $search ),
+				StringCondition::STRCOND_MID,
+				true
+			);
+		}
+
+		return $requestOptions;
+	}
+
+	private function is_iterable( $obj ) {
+		return is_array( $obj ) || ( is_object( $obj ) && ( $obj instanceof \Traversable ) );
+	}
+
+}

--- a/tests/phpunit/Integration/JSONScript/Fixtures/res.a-0001.10.txt
+++ b/tests/phpunit/Integration/JSONScript/Fixtures/res.a-0001.10.txt
@@ -1,0 +1,1 @@
+{"query":["A0001\/3","A0001\/4"],"query-continue-offset":0,"version":1,"meta":{"type":"psubject","limit":10,"count":2,"isFromCache":false,"queryTime":.*}

--- a/tests/phpunit/Integration/JSONScript/Fixtures/res.a-0001.11.txt
+++ b/tests/phpunit/Integration/JSONScript/Fixtures/res.a-0001.11.txt
@@ -1,0 +1,1 @@
+{"query":["A0001\/4"],"query-continue-offset":0,"version":1,"meta":{"type":"psubject","limit":10,"count":1,"isFromCache":false,"queryTime":.*}

--- a/tests/phpunit/Integration/JSONScript/Fixtures/res.a-0001.9.txt
+++ b/tests/phpunit/Integration/JSONScript/Fixtures/res.a-0001.9.txt
@@ -1,0 +1,1 @@
+{"query":["A0001\/3"],"query-continue-offset":0,"version":1,"meta":{"type":"psubject","limit":10,"count":1,"isFromCache":false,"queryTime":.*}

--- a/tests/phpunit/Integration/JSONScript/TestCases/a-0001.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/a-0001.json
@@ -225,6 +225,57 @@
 					"contents-file" : "/../Fixtures/res.a-0001.8.txt"
 				}
 			}
+		},
+		{
+			"type": "api",
+			"about": "#9 `smwbrowse` (distinct value, empty search) psubject search",
+			"api": {
+				"parameters": {
+					"action": "smwbrowse",
+					"format": "json",
+					"browse": "psubject",
+					"params": "{ \"limit\": 10, \"offset\": 0, \"property\": \"API page property\", \"value\": \"Page 1\", \"sort\": \"asc\" }"
+				}
+			},
+			"assert-output": {
+				"to-contain": {
+					"contents-file" : "/../Fixtures/res.a-0001.9.txt"
+				}
+			}
+		},
+		{
+			"type": "api",
+			"about": "#10 `smwbrowse` (empty value, empty search) psubject search",
+			"api": {
+				"parameters": {
+					"action": "smwbrowse",
+					"format": "json",
+					"browse": "psubject",
+					"params": "{ \"limit\": 10, \"offset\": 0, \"property\": \"API page property\", \"value\": \"\", \"sort\": \"asc\" }"
+				}
+			},
+			"assert-output": {
+				"to-contain": {
+					"contents-file" : "/../Fixtures/res.a-0001.10.txt"
+				}
+			}
+		},
+		{
+			"type": "api",
+			"about": "#11 `smwbrowse` (empty value, distinct search) psubject search",
+			"api": {
+				"parameters": {
+					"action": "smwbrowse",
+					"format": "json",
+					"browse": "psubject",
+					"params": "{ \"limit\": 10, \"offset\": 0, \"property\": \"API page property\", \"value\": \"\", \"search\": \"/4\", \"sort\": \"asc\" }"
+				}
+			},
+			"assert-output": {
+				"to-contain": {
+					"contents-file" : "/../Fixtures/res.a-0001.11.txt"
+				}
+			}
 		}
 	],
 	"settings": {
@@ -232,7 +283,8 @@
 		"wgLang": "en",
 		"smwgCacheUsage": {
 			"api.browse": false,
-			"api.browse.pvalue": false
+			"api.browse.pvalue": false,
+			"api.browse.psubject": false
 		},
 		"smwgNamespacesWithSemanticLinks": {
 			"NS_MAIN": true,

--- a/tests/phpunit/Unit/MediaWiki/Api/Browse/PSubjectLookupTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Api/Browse/PSubjectLookupTest.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace SMW\Tests\MediaWiki\Api\Browse;
+
+use SMW\DIProperty;
+use SMW\MediaWiki\Api\Browse\PSubjectLookup;
+use SMW\DIWikiPage;
+
+/**
+ * @covers \SMW\MediaWiki\Api\Browse\PSubjectLookup
+ * @group semantic-mediawiki
+ *
+ * @license GNU GPL v2+
+ * @since 3.0
+ *
+ * @author mwjames
+ */
+class PSubjectLookupTest extends \PHPUnit_Framework_TestCase {
+
+	private $store;
+
+	protected function setUp() {
+
+		$this->store = $this->getMockBuilder( '\SMW\SQLStore\SQLStore' )
+			->disableOriginalConstructor()
+			->getMock();
+	}
+
+	public function testCanConstruct() {
+
+		$this->assertInstanceOf(
+			PSubjectLookup::class,
+			new PSubjectLookup( $this->store )
+		);
+	}
+
+	public function testLookup() {
+
+		$this->store->expects( $this->any() )
+			->method( 'getPropertySubjects' )
+			->will( $this->returnValue( [ new DIWikiPage( 'Foobar', NS_MAIN ) ] ) );
+
+		$instance = new PSubjectLookup(
+			$this->store
+		);
+
+		$parameters = [
+			'search' => 'Foo',
+			'property' => 'Bar'
+		];
+
+		$res = $instance->lookup( $parameters );
+
+		$this->assertEquals(
+			$res['query'],
+			[
+				'Foobar'
+			]
+		);
+	}
+
+}

--- a/tests/phpunit/Unit/MediaWiki/Api/BrowseTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Api/BrowseTest.php
@@ -122,6 +122,10 @@ class BrowseTest extends \PHPUnit_Framework_TestCase {
 			->will( $this->returnValue( [] ) );
 
 		$this->store->expects( $this->any() )
+			->method( 'getPropertySubjects' )
+			->will( $this->returnValue( [] ) );
+
+		$this->store->expects( $this->any() )
 			->method( 'getDataItemHandlerForDIType' )
 			->will( $this->returnValue( $dataItemHandler ) );
 
@@ -212,6 +216,11 @@ class BrowseTest extends \PHPUnit_Framework_TestCase {
 
 		$provider[] = [
 			'pvalue',
+			[ 'property' => 'Bar' ]
+		];
+
+		$provider[] = [
+			'psubject',
 			[ 'property' => 'Bar' ]
 		];
 


### PR DESCRIPTION
This PR is made in reference to: #

This PR addresses or contains:

- Adds `psubject` as smwbrowse module to provide the equivalent access of `Store::getPropertySubjects` via the API:
  - `api.php?action=smwbrowse&browse=psubject&params={ "limit": 10, "offset": 0, "property" : "Foo", "value" : "Bar", "search": "foo" }`

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed
