### PR TITLE
Add PropertyTableUpdater

### DIFF
--- a/src/Parameters.php
+++ b/src/Parameters.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace SMW;
+
+use InvalidArgumentException;
+
+/**
+ * @license GNU GPL v2+
+ * @since 3.0
+ *
+ * @author mwjames
+ */
+class Parameters {
+
+	/**
+	 * @var array
+	 */
+	private $parameters = array();
+
+	/**
+	 * @since 3.0
+	 */
+	public function __construct( array $parameters = array() ) {
+		$this->parameters = $parameters;
+	}
+
+	/**
+	 * @since 3.0
+	 *
+	 * @param string $key
+	 * @param mixed $value
+	 */
+	public function set( $key, $value ) {
+		$this->parameters[$key] = $value;
+	}
+
+	/**
+	 * @since 3.0
+	 *
+	 * @param string $key
+	 * @param array $value
+	 */
+	public function merge( $key, array $value ) {
+
+		if ( !isset( $this->parameters[$key] ) ) {
+			$this->parameters[$key] = [];
+		}
+
+		$this->parameters[$key] += $value;
+	}
+
+	/**
+	 * @since 3.0
+	 *
+	 * @param string $key
+	 *
+	 * @return boolean
+	 */
+	public function has( $key ) {
+		return isset( $this->parameters[$key] ) || array_key_exists( $key, $this->parameters );
+	}
+
+	/**
+	 * @since 3.0
+	 *
+	 * @param string $key
+	 *
+	 * @return string
+	 * @throws InvalidArgumentException
+	 */
+	public function get( $key ) {
+
+		if ( $this->has( $key ) ) {
+			return $this->parameters[$key];
+		}
+
+		throw new InvalidArgumentException( "$key is an unregistered key." );
+	}
+
+}

--- a/src/SQLStore/Exception/TableMissingIdFieldException.php
+++ b/src/SQLStore/Exception/TableMissingIdFieldException.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace SMW\SQLStore\Exception;
+
+use RuntimeException;
+
+/**
+ * @license GNU GPL v2+
+ * @since 3.0
+ *
+ * @author mwjames
+ */
+class TableMissingIdFieldException extends RuntimeException {
+
+	/**
+	 * @since 3.0
+	 */
+	public function __construct( $name ) {
+		parent::__construct( "Operation is not supported for a table ({$name}) without subject IDs." );
+	}
+
+}

--- a/src/SQLStore/PropertyTableUpdater.php
+++ b/src/SQLStore/PropertyTableUpdater.php
@@ -1,0 +1,231 @@
+<?php
+
+namespace SMW\SQLStore;
+
+use SMW\Store;
+use SMW\ChangePropListener;
+use SMW\Parameters;
+use SMW\DIProperty;
+use SMW\SQLStore\Exception\TableMissingIdFieldException;
+
+/**
+ * @private
+ *
+ * @license GNU GPL v2+
+ * @since 3.0
+ *
+ * @author mwjames
+ */
+class PropertyTableUpdater {
+
+	/**
+	 * @var Store
+	 */
+	private $store;
+
+	/**
+	 * @var PropertyStatisticsStore
+	 */
+	private $propertyStatisticsStore;
+
+	/**
+	 * @var array
+	 */
+	private $stats = [];
+
+	/**
+	 * @since 3.0
+	 *
+	 * @param Store $store
+	 * @param PropertyStatisticsStore $propertyStatisticsStore
+	 */
+	public function __construct( Store $store, PropertyStatisticsStore $propertyStatisticsStore ) {
+		$this->store = $store;
+		$this->propertyStatisticsStore = $propertyStatisticsStore;
+	}
+
+	/**
+	 * Update all property tables and any dependent data (hashes,
+	 * statistics, etc.) by inserting/deleting the given values. The ID of
+	 * the page that is updated, and the hashes of the properties must be
+	 * given explicitly (the hashes could not be computed from the insert
+	 * and delete data alone anyway).
+	 *
+	 * @since 3.0
+	 *
+	 * @param integer $id
+	 * @param Parameters $parameters
+	 */
+	public function update( $id, Parameters $parameters ) {
+
+		$this->stats = [];
+
+		$insert_rows = $parameters->get( 'insert_rows' );
+		$delete_rows = $parameters->get( 'delete_rows' );
+
+		$this->doUpdate( $insert_rows, $delete_rows );
+		$new_hashes = $parameters->get( 'new_hashes' );
+
+		// If only rows are marked for deletion then modify hashs to ensure that
+		// any inbalance can be corrected by the next insert operation for which
+		// the new_hashes are computed (seen in connection with redirects)
+		if ( $insert_rows === [] && $delete_rows !== [] ) {
+			foreach ( $new_hashes as $key => $hash ) {
+				$new_hashes[$key] = $hash . '.d';
+			}
+		}
+
+		if ( $insert_rows !== [] || $delete_rows !== [] ) {
+			$this->store->getObjectIds()->setPropertyTableHashes( $id, $new_hashes );
+		}
+
+		$this->propertyStatisticsStore->addToUsageCounts(
+			$this->stats
+		);
+	}
+
+	/**
+	 * It is assumed and required that the tables mentioned in
+	 * $tablesInsertRows and $tablesDeleteRows are the same, and that all
+	 * $rows in these datasets refer to the same subject ID.
+	 *
+	 * @param array $insert_rows
+	 * @param array $delete_rows
+	 */
+	private function doUpdate( array $insert_rows, array $delete_rows ) {
+
+		$propertyTables = $this->store->getPropertyTables();
+
+		// Note: by construction, the inserts and deletes have the same table keys.
+		// Note: by construction, the inserts and deletes are currently disjoint;
+		// yet we delete first to make the method more robust/versatile.
+		foreach ( $insert_rows as $tableName => $insertRows ) {
+
+			$propertyTable = $propertyTables[$tableName];
+
+			// Should not occur, but let's be strict
+			if ( !$propertyTable->usesIdSubject() ) {
+				throw new TableMissingIdFieldException( $propertyTable->getName() );
+			}
+
+			// Delete
+			$this->update_rows( $propertyTable, $delete_rows[$tableName], false );
+
+			// Insert
+			$this->update_rows( $propertyTable, $insertRows, true );
+		}
+	}
+
+	/**
+	 * Update one property table by inserting or deleting rows, and compute
+	 * the changes that this entails for the property usage counts. The
+	 * given rows are inserted into the table if $insert is true; otherwise
+	 * they are deleted. The property usage counts are recorded in the
+	 * call-by-ref parameter $propertyUseIncrements.
+	 *
+	 * The method assumes that all of the given rows are about the same
+	 * subject. This is ensured by callers.
+	 *
+	 * @param PropertyTableDefinition $propertyTable
+	 * @param array $rows array of rows to insert/delete
+	 * @param boolean $insert
+	 */
+	private function update_rows( PropertyTableDefinition $propertyTable, array $rows, $insert ) {
+
+		if ( empty( $rows ) ) {
+			return;
+		}
+
+		if ( $insert ) {
+			$this->insert( $propertyTable, $rows );
+		} else {
+			$this->delete( $propertyTable, $rows );
+		}
+
+		if ( $propertyTable->isFixedPropertyTable() ) {
+
+			$property = new DIProperty(
+				$propertyTable->getFixedProperty()
+			);
+
+			$pid = $this->store->getObjectIds()->makeSMWPropertyID( $property );
+		}
+
+		foreach ( $rows as $row ) {
+
+			if ( !$propertyTable->isFixedPropertyTable() ) {
+				$pid = $row['p_id'];
+			}
+
+			ChangePropListener::record(
+				$pid,
+				[
+					'row' => $row,
+					'is_insert' => $insert
+				]
+			);
+
+			if ( !array_key_exists( $pid, $this->stats ) ) {
+				$this->stats[$pid] = 0;
+			}
+
+			$this->stats[$pid] += ( $insert ? 1 : -1 );
+		}
+	}
+
+	private function insert( PropertyTableDefinition $propertyTable, array $rows ) {
+
+		$connection = $this->store->getConnection( 'mw.db' );
+		$tableName = $propertyTable->getName();
+
+		$connection->insert(
+			$tableName,
+			$rows,
+			__METHOD__ . "-$tableName"
+		);
+	}
+
+	private function delete( PropertyTableDefinition $propertyTable, array $rows ) {
+
+		$condition = '';
+		$connection = $this->store->getConnection( 'mw.db' );
+
+		// We build a condition that mentions s_id only once,
+		// since it must be the same for all rows. This should
+		// help the DBMS in selecting the rows (it would not be
+		// easy for to detect that all tuples share one s_id).
+		$sid = false;
+		$tableName = $propertyTable->getName();
+
+		foreach ( $rows as $row ) {
+			if ( $sid === false ) {
+				if ( !array_key_exists( 's_id', (array)$row ) ) {
+					// FIXME: The assumption that s_id is present does not hold.
+					// This return is there to prevent fatal errors, but does
+					// not fix the issue of this code being broken
+					return;
+				}
+
+				// 's_id' exists for all tables with $propertyTable->usesIdSubject()
+				$sid = $row['s_id'];
+			}
+
+			unset( $row['s_id'] );
+
+			if ( $condition != '' ) {
+				$condition .= ' OR ';
+			}
+
+			$condition .= '(' . $connection->makeList( $row, LIST_AND ) . ')';
+		}
+
+		$condition = "s_id=" . $connection->addQuotes( $sid ) . " AND ($condition)";
+
+		$connection->delete(
+			$tableName,
+			array( $condition ),
+			__METHOD__ . "-$tableName"
+		);
+	}
+
+}

--- a/src/SQLStore/SQLStoreFactory.php
+++ b/src/SQLStore/SQLStoreFactory.php
@@ -10,7 +10,6 @@ use SMW\ChangePropListener;
 use SMW\DIWikiPage;
 use SMW\Options;
 use SMW\Site;
-use SMW\ProcessLruCache;
 use SMW\SQLStore\ChangeOp\ChangeOp;
 use SMW\SQLStore\EntityStore\CachingEntityLookup;
 use SMW\SQLStore\EntityStore\CachingSemanticDataLookup;
@@ -107,6 +106,15 @@ class SQLStoreFactory {
 	 */
 	public function newEntityTable() {
 		return new EntityIdManager( $this->store, $this );
+	}
+
+	/**
+	 * @since 3.0
+	 *
+	 * @return PropertyTableUpdater
+	 */
+	public function newPropertyTableUpdater() {
+		return new PropertyTableUpdater( $this->store, $this->newPropertyStatisticsStore() );
 	}
 
 	/**

--- a/tests/phpunit/Unit/ParametersTest.php
+++ b/tests/phpunit/Unit/ParametersTest.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace SMW\Tests;
+
+use SMW\Parameters;
+
+/**
+ * @covers \SMW\Parameters
+ * @group semantic-mediawiki
+ *
+ * @license GNU GPL v2+
+ * @since   3.0
+ *
+ * @author mwjames
+ */
+class ParametersTest extends \PHPUnit_Framework_TestCase {
+
+	use PHPUnitCompat;
+
+	public function testCanConstruct() {
+
+		$this->assertInstanceOf(
+			Parameters::class,
+			new Parameters()
+		);
+	}
+
+	public function testAddOption() {
+
+		$instance = new Parameters();
+
+		$this->assertFalse(
+			$instance->has( 'Foo' )
+		);
+
+		$instance->set( 'Foo', 42 );
+
+		$this->assertEquals(
+			42,
+			$instance->get( 'Foo' )
+		);
+	}
+
+	public function testUnregisteredKeyThrowsException() {
+
+		$instance = new Parameters();
+
+		$this->setExpectedException( 'InvalidArgumentException' );
+		$instance->get( 'Foo' );
+	}
+
+}

--- a/tests/phpunit/Unit/SQLStore/Exception/TableMissingIdFieldExceptionTest.php
+++ b/tests/phpunit/Unit/SQLStore/Exception/TableMissingIdFieldExceptionTest.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace SMW\Tests\SQLStore\Exception;
+
+use SMW\SQLStore\Exception\TableMissingIdFieldException;
+
+/**
+ * @covers \SMW\SQLStore\Exception\TableMissingIdFieldException
+ * @group semantic-mediawiki
+ *
+ * @license GNU GPL v2+
+ * @since 3.0
+ *
+ * @author mwjames
+ */
+class TableMissingIdFieldExceptionTest extends \PHPUnit_Framework_TestCase {
+
+	public function testCanConstruct() {
+
+		$instance = new TableMissingIdFieldException( 'foo' );
+
+		$this->assertInstanceof(
+			TableMissingIdFieldException::class,
+			$instance
+		);
+
+		$this->assertInstanceof(
+			'\RuntimeException',
+			$instance
+		);
+	}
+
+}

--- a/tests/phpunit/Unit/SQLStore/PropertyTableUpdaterTest.php
+++ b/tests/phpunit/Unit/SQLStore/PropertyTableUpdaterTest.php
@@ -1,0 +1,167 @@
+<?php
+
+namespace SMW\Tests\SQLStore;
+
+use SMW\SQLStore\PropertyTableUpdater;
+use SMW\Parameters;
+use SMW\Tests\PHPUnitCompat;
+
+/**
+ * @covers \SMW\SQLStore\PropertyTableUpdater
+ * @group semantic-mediawiki
+ *
+ * @license GNU GPL v2+
+ * @since 3.0
+ *
+ * @author mwjames
+ */
+class PropertyTableUpdaterTest extends \PHPUnit_Framework_TestCase {
+
+	use PHPUnitCompat;
+
+	private $store;
+	private $idTable;
+	private $connection;
+	private $propertyTable;
+	private $propertyStatisticsStore;
+
+	protected function setUp() {
+		parent::setUp();
+
+		$this->connection = $this->getMockBuilder( '\SMW\MediaWiki\Database' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$this->idTable = $this->getMockBuilder( '\SMWSql3SmwIds' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$this->store = $this->getMockBuilder( '\SMW\SQLStore\SQLStore' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$this->store->expects( $this->any() )
+			->method( 'getObjectIds' )
+			->will( $this->returnValue( $this->idTable ) );
+
+		$this->store->expects( $this->any() )
+			->method( 'getConnection' )
+			->will( $this->returnValue( $this->connection ) );
+
+		$this->propertyTable = $this->getMockBuilder( '\SMW\SQLStore\PropertyTableDefinition' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$this->propertyStatisticsStore = $this->getMockBuilder( '\SMW\SQLStore\PropertyStatisticsStore' )
+			->disableOriginalConstructor()
+			->getMock();
+	}
+
+	public function testCanConstruct() {
+
+		$this->assertInstanceOf(
+			PropertyTableUpdater::class,
+			new PropertyTableUpdater( $this->store, $this->propertyStatisticsStore )
+		);
+	}
+
+	public function testUpdate_OnEmptyInsertRows() {
+
+		$this->store->expects( $this->any() )
+			->method( 'getPropertyTables' )
+			->will( $this->returnValue( [] ) );
+
+		$this->propertyStatisticsStore->expects( $this->once() )
+			->method( 'addToUsageCounts' );
+
+		$instance = new PropertyTableUpdater(
+			$this->store,
+			$this->propertyStatisticsStore
+		);
+
+		$params= new Parameters(
+			[
+				'insert_rows' => [],
+				'delete_rows' => [],
+				'new_hashes'  => []
+			]
+		);
+
+		$instance->update( 42, $params );
+	}
+
+	public function testUpdate_WithInsertRows() {
+
+		$this->connection->expects( $this->once() )
+			->method( 'insert' );
+
+		$this->connection->expects( $this->once() )
+			->method( 'delete' );
+
+		$this->idTable->expects( $this->once() )
+			->method( 'setPropertyTableHashes' );
+
+		$this->propertyTable->expects( $this->any() )
+			->method( 'usesIdSubject' )
+			->will( $this->returnValue( true ) );
+
+		$this->store->expects( $this->any() )
+			->method( 'getPropertyTables' )
+			->will( $this->returnValue( [ 'table_foo' => $this->propertyTable ] ) );
+
+		$this->propertyStatisticsStore->expects( $this->once() )
+			->method( 'addToUsageCounts' )
+			 ->with( $this->equalTo( [ 99998 => -1, 99999 => 1 ] ) );
+
+		$instance = new PropertyTableUpdater(
+			$this->store,
+			$this->propertyStatisticsStore
+		);
+
+		$params = new Parameters(
+			[
+				'insert_rows' => [
+					'table_foo' => [
+						[ 's_id' => 1001, 'p_id' => 99999 ]
+					]
+				],
+				'delete_rows' => [
+					'table_foo' => [
+						[ 's_id' => 1001, 'p_id' => 99998 ]
+					]
+				],
+				'new_hashes'  => []
+			]
+		);
+
+		$instance->update( 42, $params );
+	}
+
+	public function testUpdate_WithInsertRowsButMissingIdFieldThrowsException() {
+
+		$this->store->expects( $this->any() )
+			->method( 'getPropertyTables' )
+			->will( $this->returnValue( [ 'table_foo' => $this->propertyTable ] ) );
+
+		$instance = new PropertyTableUpdater(
+			$this->store,
+			$this->propertyStatisticsStore
+		);
+
+		$params= new Parameters(
+			[
+				'insert_rows' => [
+					'table_foo' => []
+				],
+				'delete_rows' => [
+					'table_foo' => []
+				],
+				'new_hashes'  => []
+			]
+		);
+
+		$this->setExpectedException( '\SMW\SQLStore\Exception\TableMissingIdFieldException' );
+		$instance->update( 42, $params );
+	}
+
+}

--- a/tests/phpunit/includes/SQLStore/Writer/ChangeTitleTest.php
+++ b/tests/phpunit/includes/SQLStore/Writer/ChangeTitleTest.php
@@ -71,6 +71,10 @@ class ChangeTitleTest extends \PHPUnit_Framework_TestCase {
 			->method( 'computeTableRowDiff' )
 			->will( $this->returnValue( [ [], [], [] ] ) );
 
+		$propertyTableUpdater = $this->getMockBuilder( '\SMW\SQLStore\PropertyTableUpdater' )
+			->disableOriginalConstructor()
+			->getMock();
+
 		$propertyStatisticsStore = $this->getMockBuilder( '\SMW\SQLStore\PropertyStatisticsStore' )
 			->disableOriginalConstructor()
 			->getMock();
@@ -98,6 +102,14 @@ class ChangeTitleTest extends \PHPUnit_Framework_TestCase {
 		$changeDiff = $this->getMockBuilder( '\SMW\SQLStore\ChangeOp\ChangeDiff' )
 			->disableOriginalConstructor()
 			->getMock();
+
+		$changeDiff->expects( $this->any() )
+			->method( 'getTextItems' )
+			->will( $this->returnValue( [] ) );
+
+		$changeDiff->expects( $this->any() )
+			->method( 'getTableChangeOps' )
+			->will( $this->returnValue( [] ) );
 
 		$changeOp = $this->getMockBuilder( '\SMW\SQLStore\ChangeOp\ChangeOp' )
 			->disableOriginalConstructor()
@@ -150,6 +162,10 @@ class ChangeTitleTest extends \PHPUnit_Framework_TestCase {
 		$this->factory->expects( $this->any() )
 			->method( 'newPropertyTableRowDiffer' )
 			->will( $this->returnValue( $propertyTableRowDiffer ) );
+
+		$this->factory->expects( $this->any() )
+			->method( 'newPropertyTableUpdater' )
+			->will( $this->returnValue( $propertyTableUpdater ) );
 
 		$this->factory->expects( $this->any() )
 			->method( 'newSemanticDataLookup' )
@@ -229,7 +245,7 @@ class ChangeTitleTest extends \PHPUnit_Framework_TestCase {
 			->method( 'getConnection' )
 			->will( $this->returnValue( $database ) );
 
-		$parentStore->expects( $this->atLeastOnce() )
+		$parentStore->expects( $this->any() )
 			->method( 'getPropertyTables' )
 			->will( $this->returnValue( array() ) );
 
@@ -292,7 +308,7 @@ class ChangeTitleTest extends \PHPUnit_Framework_TestCase {
 			->method( 'getConnection' )
 			->will( $this->returnValue( $database ) );
 
-		$parentStore->expects( $this->atLeastOnce() )
+		$parentStore->expects( $this->any() )
 			->method( 'getPropertyTables' )
 			->will( $this->returnValue( array() ) );
 

--- a/tests/phpunit/includes/SQLStore/Writer/DataUpdateTest.php
+++ b/tests/phpunit/includes/SQLStore/Writer/DataUpdateTest.php
@@ -55,6 +55,10 @@ class DataUpdateTest extends \PHPUnit_Framework_TestCase {
 			->method( 'computeTableRowDiff' )
 			->will( $this->returnValue( [ [], [], [] ] ) );
 
+		$propertyTableUpdater = $this->getMockBuilder( '\SMW\SQLStore\PropertyTableUpdater' )
+			->disableOriginalConstructor()
+			->getMock();
+
 		$propertyStatisticsStore = $this->getMockBuilder( '\SMW\SQLStore\PropertyStatisticsStore' )
 			->disableOriginalConstructor()
 			->getMock();
@@ -82,6 +86,14 @@ class DataUpdateTest extends \PHPUnit_Framework_TestCase {
 		$changeDiff = $this->getMockBuilder( '\SMW\SQLStore\ChangeOp\ChangeDiff' )
 			->disableOriginalConstructor()
 			->getMock();
+
+		$changeDiff->expects( $this->any() )
+			->method( 'getTextItems' )
+			->will( $this->returnValue( [] ) );
+
+		$changeDiff->expects( $this->any() )
+			->method( 'getTableChangeOps' )
+			->will( $this->returnValue( [] ) );
 
 		$changeOp = $this->getMockBuilder( '\SMW\SQLStore\ChangeOp\ChangeOp' )
 			->disableOriginalConstructor()
@@ -130,6 +142,10 @@ class DataUpdateTest extends \PHPUnit_Framework_TestCase {
 		$this->factory->expects( $this->any() )
 			->method( 'newPropertyTableRowDiffer' )
 			->will( $this->returnValue( $propertyTableRowDiffer ) );
+
+		$this->factory->expects( $this->any() )
+			->method( 'newPropertyTableUpdater' )
+			->will( $this->returnValue( $propertyTableUpdater ) );
 
 		$this->factory->expects( $this->any() )
 			->method( 'newSemanticDataLookup' )
@@ -197,7 +213,7 @@ class DataUpdateTest extends \PHPUnit_Framework_TestCase {
 			->method( 'getConnection' )
 			->will( $this->returnValue( $database ) );
 
-		$parentStore->expects( $this->atLeastOnce() )
+		$parentStore->expects( $this->any() )
 			->method( 'getPropertyTables' )
 			->will( $this->returnValue( array() ) );
 
@@ -258,7 +274,7 @@ class DataUpdateTest extends \PHPUnit_Framework_TestCase {
 			->method( 'getConnection' )
 			->will( $this->returnValue( $database ) );
 
-		$parentStore->expects( $this->atLeastOnce() )
+		$parentStore->expects( $this->any() )
 			->method( 'getPropertyTables' )
 			->will( $this->returnValue( array() ) );
 

--- a/tests/phpunit/includes/SQLStore/Writer/DeleteSubjectTest.php
+++ b/tests/phpunit/includes/SQLStore/Writer/DeleteSubjectTest.php
@@ -89,6 +89,10 @@ class DeleteSubjectTest extends \PHPUnit_Framework_TestCase {
 			->method( 'computeTableRowDiff' )
 			->will( $this->returnValue( [ [], [], [] ] ) );
 
+		$propertyTableUpdater = $this->getMockBuilder( '\SMW\SQLStore\PropertyTableUpdater' )
+			->disableOriginalConstructor()
+			->getMock();
+
 		$semanticDataLookup = $this->getMockBuilder( '\SMW\SQLStore\EntityStore\CachingSemanticDataLookup' )
 			->disableOriginalConstructor()
 			->getMock();
@@ -96,6 +100,14 @@ class DeleteSubjectTest extends \PHPUnit_Framework_TestCase {
 		$changeDiff = $this->getMockBuilder( '\SMW\SQLStore\ChangeOp\ChangeDiff' )
 			->disableOriginalConstructor()
 			->getMock();
+
+		$changeDiff->expects( $this->any() )
+			->method( 'getTextItems' )
+			->will( $this->returnValue( [] ) );
+
+		$changeDiff->expects( $this->any() )
+			->method( 'getTableChangeOps' )
+			->will( $this->returnValue( [] ) );
 
 		$changeOp = $this->getMockBuilder( '\SMW\SQLStore\ChangeOp\ChangeOp' )
 			->disableOriginalConstructor()
@@ -124,6 +136,10 @@ class DeleteSubjectTest extends \PHPUnit_Framework_TestCase {
 		$this->factory->expects( $this->any() )
 			->method( 'newPropertyTableRowDiffer' )
 			->will( $this->returnValue( $propertyTableRowDiffer ) );
+
+		$this->factory->expects( $this->any() )
+			->method( 'newPropertyTableUpdater' )
+			->will( $this->returnValue( $propertyTableUpdater ) );
 
 		$this->factory->expects( $this->any() )
 			->method( 'newSemanticDataLookup' )
@@ -170,7 +186,7 @@ class DeleteSubjectTest extends \PHPUnit_Framework_TestCase {
 			->method( 'getProperties' )
 			->will( $this->returnValue( array() ) );
 
-		$this->store->expects( $this->exactly( 1 ) )
+		$this->store->expects( $this->any() )
 			->method( 'getPropertyTables' )
 			->will( $this->returnValue( array() ) );
 
@@ -219,7 +235,7 @@ class DeleteSubjectTest extends \PHPUnit_Framework_TestCase {
 			->method( 'getProperties' )
 			->will( $this->returnValue( array() ) );
 
-		$this->store->expects( $this->exactly( 1 ) )
+		$this->store->expects( $this->any() )
 			->method( 'getPropertyTables' )
 			->will( $this->returnValue( array() ) );
 


### PR DESCRIPTION
This PR is made in reference to: #

This PR addresses or contains:

- Part of the "Make the SQLStore maintainable" by moving the entire table update logic into one concise class 

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed