### PR TITLE
Improve encode/decode in external formatter uri, refs 3386

### DIFF
--- a/src/DataValues/ExternalFormatterUriValue.php
+++ b/src/DataValues/ExternalFormatterUriValue.php
@@ -66,10 +66,18 @@ class ExternalFormatterUriValue extends UriValue {
 
 		// Avoid already encoded values like `W%D6LLEKLA01` to be
 		// encoded twice
-		$value = rawurlencode( rawurldecode( $value ) );
+		$value = $this->encode( rawurldecode( $value ) );
 
 		// %241 == encoded $1
 		return str_replace( array( '%241', '$1' ), array( '$1', $value ), $this->getDataItem()->getUri() );
 	}
 
+	// http://php.net/manual/en/function.urlencode.php#97969
+	private function encode( $string ) {
+		return str_replace(
+			[ '%21', '%2A', '%27', '%28', '%29', '%3B', '%3A', '%40', '%26', '%3D', '%2B', '%24', '%2C', '%2F', '%3F', '%25', '%23', '%5B', '%5D' ],
+			[ '!', '*', "'", "(", ")", ";", ":", "@", "&", "=", "+", "$", ",", "/", "?", "%", "#", "[", "]" ],
+			urlencode( $string )
+		);
+	}
 }

--- a/tests/phpunit/Unit/DataValues/ExternalFormatterUriValueTest.php
+++ b/tests/phpunit/Unit/DataValues/ExternalFormatterUriValueTest.php
@@ -156,6 +156,13 @@ class ExternalFormatterUriValueTest extends \PHPUnit_Framework_TestCase {
 			'http://foo/bar/W%D6LLEKLA01'
 		);
 
+		// #3386
+		$provider[] = array(
+			'http://foo/bar/$1',
+			'A/B/C',
+			'http://foo/bar/A/B/C'
+		);
+
 		return $provider;
 	}
 


### PR DESCRIPTION
This PR is made in reference to: #3386

This PR addresses or contains:

- Use a different encode method to ensure that `/` remains `/` and is not transformed into `%2F`

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed

Fixes #3386