### PR TITLE
[DB] Use SERIAL type to avoid "Error: 23505 ERROR:  duplicate key value violates unique constraint "smw_new_pkey"

### DIFF
--- a/src/SQLStore/TableBuilder/TemporaryTableBuilder.php
+++ b/src/SQLStore/TableBuilder/TemporaryTableBuilder.php
@@ -103,7 +103,7 @@ class TemporaryTableBuilder {
 				. " IF EXISTS(SELECT NULL FROM pg_tables WHERE tablename='{$tableName}' AND schemaname = ANY (current_schemas(true))) "
 				. " THEN DELETE FROM {$tableName}; "
 				. " ELSE "
-				. "  CREATE TEMPORARY TABLE {$tableName} (id INTEGER PRIMARY KEY); "
+				. "  CREATE TEMPORARY TABLE {$tableName} (id SERIAL); "
 				. "    CREATE RULE {$tableName}_ignore AS ON INSERT TO {$tableName} WHERE (EXISTS (SELECT 1 FROM {$tableName} "
 				. "	 WHERE ({$tableName}.id = new.id))) DO INSTEAD NOTHING; "
 				. " END IF; "

--- a/tests/phpunit/Integration/JSONScript/TestCases/q-0622.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/q-0622.json
@@ -1,0 +1,71 @@
+{
+	"description": "Test query with category hierarchy",
+	"setup": [
+		{
+			"namespace": "SMW_NS_PROPERTY",
+			"page": "Has page",
+			"contents": "[[Has type::Page]]"
+		},
+		{
+			"namespace": "NS_CATEGORY",
+			"page": "Q0622/A",
+			"contents": "[[Category:Q0622]]"
+		},
+		{
+			"namespace": "NS_CATEGORY",
+			"page": "Q0622/B",
+			"contents": "[[Category:Q0622/A]] [[Category:Q0622/C]]"
+		},
+		{
+			"namespace": "NS_CATEGORY",
+			"page": "Q0622/C",
+			"contents": "[[Category:Q0622]]"
+		},
+		{
+			"namespace": "NS_MAIN",
+			"page": "Q0622",
+			"contents": "[[Category:Q0622]]"
+		}
+	],
+	"tests": [
+		{
+			"type": "query",
+			"about": "#0",
+			"condition": "[[Category:Q0622]]",
+			"printouts": [],
+			"parameters": {
+				"limit": "10"
+			},
+			"assert-queryresult": {
+				"count": 1,
+				"results": [
+					"Q0622#0##"
+				]
+			}
+		}
+	],
+	"settings": {
+		"smwgNamespacesWithSemanticLinks": {
+			"NS_MAIN": true,
+			"NS_CATEGORY": true,
+			"SMW_NS_PROPERTY": true,
+			"NS_HELP": true
+		},
+		"wgContLang": "en",
+		"wgLang": "en",
+		"smwgQSubpropertyDepth": 10,
+		"smwgQSubcategoryDepth": 10,
+		"smwgSparqlQFeatures": [
+			"SMW_SPARQL_QF_SUBP",
+			"SMW_SPARQL_QF_SUBC"
+		]
+	},
+	"meta": {
+		"skip-on": {
+			"virtuoso": "Virtuoso 6.1 rdfs / subproperty/subcategory hierarchies are not supported"
+		},
+		"version": "2",
+		"is-incomplete": false,
+		"debug": false
+	}
+}


### PR DESCRIPTION
This PR is made in reference to: #

This PR addresses or contains:

- As an edge case (== was never reported in all those years where the SQL was used) in the postgres, the temporary builder code uses `id INTEGER PRIMARY KEY` which can cause a "Error: 23505 ERROR:  duplicate key value violates unique constraint" when as shown in the attached integration test some of the hierarchy elements are circular.

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed
