### PR TITLE
[DB] Add `smw_rev` field to track associated revision

### DIFF
--- a/DefaultSettings.php
+++ b/DefaultSettings.php
@@ -77,7 +77,7 @@ return array(
 	#
 	# @since 3.0
 	##
-	'smwgUpgradeKey' => 'DB-2018-08-25',
+	'smwgUpgradeKey' => 'DB-2018-09-01',
 	##
 
 	###

--- a/includes/storage/SQLStore/SMW_SQLStore3_Writers.php
+++ b/includes/storage/SQLStore/SMW_SQLStore3_Writers.php
@@ -188,6 +188,7 @@ class SMWSQLStore3Writers {
 
 		// Update data about our main subject
 		$this->doFlatDataUpdate( $semanticData );
+		$sid = $subject->getId();
 
 		// Update data about our subobjects
 		$subSemanticData = $semanticData->getSubSemanticData();
@@ -214,6 +215,10 @@ class SMWSQLStore3Writers {
 					SMW_SQL3_SMWDELETEIW
 				);
 			}
+		}
+
+		if ( ( $rev_id = $semanticData->getExtensionData( 'revision_id' ) ) !== null ) {
+			$this->store->getObjectIds()->updateRevField( $sid, $rev_id );
 		}
 
 		$connection->endAtomicTransaction( __METHOD__ );
@@ -292,6 +297,7 @@ class SMWSQLStore3Writers {
 		);
 
 		$subject->setSortKey( $sortKey );
+		$subject->setId( $sid );
 
 		// Find any potential duplicate entries for the current subject and
 		// if matched, mark them as to be deleted

--- a/includes/storage/SQLStore/SMW_Sql3SmwIds.php
+++ b/includes/storage/SQLStore/SMW_Sql3SmwIds.php
@@ -733,6 +733,16 @@ class SMWSql3SmwIds {
 	}
 
 	/**
+	 * @since 3.0
+	 *
+	 * @param integer $sid
+	 * @param integer $sid
+	 */
+	public function updateRevField( $sid, $rev_id ) {
+		$this->tableFieldUpdater->updateRevField( $sid, $rev_id );
+	}
+
+	/**
 	 * Fetch the ID for an SMWDIProperty object. This method achieves the
 	 * same as getSMWPageID(), but avoids additional normalization steps
 	 * that have already been performed when creating an SMWDIProperty

--- a/src/DataUpdater.php
+++ b/src/DataUpdater.php
@@ -242,10 +242,7 @@ class DataUpdater {
 			$user
 		);
 
-		$this->semanticData->setExtensionData(
-			'revision.id',
-			$revision->getId()
-		);
+		$this->semanticData->setExtensionData( 'revision_id', $revision->getId() );
 
 		$propertyAnnotatorFactory = $applicationFactory->singleton( 'PropertyAnnotatorFactory' );
 

--- a/src/Elastic/ElasticStore.php
+++ b/src/Elastic/ElasticStore.php
@@ -249,7 +249,7 @@ class ElasticStore extends SQLStore {
 
 		$config = $this->getConnection( 'elastic' )->getConfig();
 
-		if ( $config->dotGet( 'indexer.raw.text', false ) && ( $revID = $semanticData->getExtensionData( 'revision.id' ) ) !== null ) {
+		if ( $config->dotGet( 'indexer.raw.text', false ) && ( $revID = $semanticData->getExtensionData( 'revision_id' ) ) !== null ) {
 			$this->doTextUpdate( $subject, $revID );
 		}
 

--- a/src/SQLStore/TableFieldUpdater.php
+++ b/src/SQLStore/TableFieldUpdater.php
@@ -38,8 +38,6 @@ class TableFieldUpdater {
 	 *
 	 * @param integer $id
 	 * @param string $searchKey
-	 *
-	 * @return integer
 	 */
 	public function updateSortField( $id, $searchKey ) {
 
@@ -64,6 +62,28 @@ class TableFieldUpdater {
 		);
 
 		$connection->endAtomicTransaction( __METHOD__ );
+	}
+
+	/**
+	 * @since 3.0
+	 *
+	 * @param integer $id
+	 * @param intege $rev_id
+	 */
+	public function updateRevField( $sid, $rev_id ) {
+
+		$connection = $this->store->getConnection( 'mw.db' );
+
+		$connection->update(
+			SQLStore::ID_TABLE,
+			[
+				'smw_rev' => $rev_id
+			],
+			[
+				'smw_id' => $sid
+			],
+			__METHOD__
+		);
 	}
 
 }

--- a/src/SQLStore/TableSchemaManager.php
+++ b/src/SQLStore/TableSchemaManager.php
@@ -157,6 +157,7 @@ class TableSchemaManager {
 		$table->addColumn( 'smw_sort', array( FieldType::FIELD_TITLE ) );
 		$table->addColumn( 'smw_proptable_hash', FieldType::TYPE_BLOB );
 		$table->addColumn( 'smw_hash', FieldType::FIELD_HASH );
+		$table->addColumn( 'smw_rev', FieldType::FIELD_ID );
 
 		$table->addIndex( 'smw_id' );
 		$table->addIndex( 'smw_id,smw_sortkey' );
@@ -186,6 +187,8 @@ class TableSchemaManager {
 		// Interfered with the API lookup index, couldn't find a use case
 		// that would require the this index
 		// $table->addIndex( 'smw_sort,smw_id,smw_iw' );
+
+		$table->addIndex( 'smw_rev,smw_id' );
 
 		return $table;
 	}

--- a/tests/phpunit/Unit/SQLStore/TableFieldUpdaterTest.php
+++ b/tests/phpunit/Unit/SQLStore/TableFieldUpdaterTest.php
@@ -63,4 +63,32 @@ class TableFieldUpdaterTest extends \PHPUnit_Framework_TestCase {
 		$instance->updateSortField( 42, 'Foo' );
 	}
 
+	public function testUpdateRevField() {
+
+		$connection = $this->getMockBuilder( '\SMW\MediaWiki\Database' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$connection->expects( $this->once() )
+			->method( 'update' )
+				->with(
+					$this->anything(),
+					$this->equalTo( [ 'smw_rev' => 1001 ] ),
+					$this->equalTo( [ 'smw_id'  => 42 ] ) );
+
+		$store = $this->getMockBuilder( '\SMW\SQLStore\SQLStore' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$store->expects( $this->once() )
+			->method( 'getConnection' )
+			->will( $this->returnValue( $connection ) );
+
+		$instance = new TableFieldUpdater(
+			$store
+		);
+
+		$instance->updateRevField( 42, 1001 );
+	}
+
 }


### PR DESCRIPTION
This PR is made in reference to: #

This PR addresses or contains:

- Adds the `smw_rev` field to the `smw_object_ids` table to track an entity instance and its associated revision ID (represents the raw content)

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed
