### PR TITLE
Add PHPUnitCommand to run with `--with-phpunitclass`

### DIFF
--- a/SemanticMediaWiki.php
+++ b/SemanticMediaWiki.php
@@ -46,6 +46,7 @@ class SemanticMediaWiki {
 		include_once __DIR__ . '/src/Aliases.php';
 		include_once __DIR__ . '/src/Defines.php';
 		include_once __DIR__ . '/src/GlobalFunctions.php';
+		include_once __DIR__ . '/tests/phpunit/PHPUnitCommand.php';
 
 		// If the function is called more than once then this will fail on
 		// purpose

--- a/tests/phpunit/PHPUnitCommand.php
+++ b/tests/phpunit/PHPUnitCommand.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace SMW\Tests;
+
+use SMW\MediaWiki\Connection\Sequence;
+use SMW\ApplicationFactory;
+
+if ( !class_exists( '\PHPUnit_TextUI_Command' ) ) {
+	class_alias( '\PHPUnit\TextUI\Command', '\PHPUnit_TextUI_Command' );
+}
+
+/**
+ * @private
+ *
+ * Warp the standard PHPUnit_TextUI_Command to allow for running some clean up,
+ * tear down at the very last. Common inception points are not eligible to only
+ * run after all tests have been completed (or failed).
+ *
+ * @license GNU GPL v2+
+ * @since 3.0
+ *
+ * @author mwjames
+ */
+class PHPUnitCommand extends \PHPUnit_TextUI_Command {
+
+	/**
+	 * @see PHPUnit_TextUI_Command::main
+	 *
+	 * @param bool $exit
+	 */
+	public static function main( $exit = true ) {
+		$command = new static;
+		$return = $command->run( $_SERVER['argv'], false );
+
+		$sequence = new Sequence(
+			ApplicationFactory::getInstance()->getConnectionManager()->getConnection( 'mw.db' )
+		);
+
+		$sequence->tablePrefix( '' );
+		$sequence->restart( \SMW\SQLStore\SQLStore::ID_TABLE, 'smw_id' );
+
+		if ( $exit ) {
+			exit( $return );
+		}
+
+		return $return;
+	}
+
+}


### PR DESCRIPTION
This PR is made in reference to: #

This PR addresses or contains:

- Ceates an inception point after all tests (failed or successful) have been run to allow for some final clean-up
  - ` composer test -- --with-phpunitclass="\SMW\Tests\PHPUnitCommand"`
  - `php ../../tests/phpunit/phpunit.php -c phpunit.xml.dist "--with-phpunitclass=\SMW\Tests\PHPUnitCommand"`

This PR includes:
- [ ] Tests (unit/integration)
- [x] CI build passed
