### PR TITLE
Check consistency of ParserOutput and re-parse if necessary, refs 3395

### DIFF
--- a/src/MediaWiki/Hooks/LinksUpdateConstructed.php
+++ b/src/MediaWiki/Hooks/LinksUpdateConstructed.php
@@ -93,6 +93,17 @@ class LinksUpdateConstructed extends HookHandler {
 		);
 
 		if ( $this->namespaceExaminer->isSemanticEnabled( $title->getNamespace() ) ) {
+
+			// #3395
+			// https://github.com/wikimedia/mediawiki/commit/a3357744c34d6f5b8e39114e64c6937800698069
+			// Introduced a regression which is reproducible on the move of pages with
+			// the ParserOutput holding an outdated reference to an extension
+			// data which is inconsistent with the Title object used in the LinksUpdate
+			// request.
+			if ( !$parserData->isConsistent() ) {
+				$this->updateSemanticData( $parserData, $title, 'inconsistent title' );
+			}
+
 			// #347 showed that an external process (e.g. RefreshLinksJob) can inject a
 			// ParserOutput without/cleared SemanticData which forces the Store updater
 			// to create an empty container that will clear all existing data.

--- a/src/ParserData.php
+++ b/src/ParserData.php
@@ -324,6 +324,18 @@ class ParserData {
 	}
 
 	/**
+	 * Whether the title used during inception is the same as reference found
+	 * in the parser output or not.
+	 *
+	 * @since 3.0
+	 *
+	 * @param boolean
+	 */
+	public function isConsistent() {
+		return $this->getSubject()->equals( DIWikiPage::newFromTitle( $this->title ) );
+	}
+
+	/**
 	 * @since 3.0
 	 */
 	public function copyToParserOutput() {


### PR DESCRIPTION
This PR is made in reference to: #3395 

This PR addresses or contains:

- As outlined in #3395, this follows as regression introduced by MCR 
- We can try to cover up the issue by comparing the ParserOutput content we retrieve an see if it is consistent and in case it is not re-parse the entire content of the page (which is costly and I'd like to avoid that)
- How do we know it fixes the issue? because all tests pass again!! [0]

This PR includes:
- [ ] Tests (unit/integration)
- [x] CI build passed

Fixes #3395

[0] https://travis-ci.org/SemanticMediaWiki/SemanticMediaWiki/jobs/423572872