### PR TITLE
Remove long deprecated getNextObject

### DIFF
--- a/includes/storage/SMW_ResultArray.php
+++ b/includes/storage/SMW_ResultArray.php
@@ -135,14 +135,6 @@ class SMWResultArray {
 	}
 
 	/**
-	 * Compatibility alias for getNextDatItem().
-	 * @deprecated since 1.6. Call getNextDataValue() or getNextDataItem() directly as needed. Method will vanish before SMW 1.7.
-	 */
-	public function getNextObject() {
-		return $this->getNextDataValue();
-	}
-
-	/**
 	 * Return the next SMWDataItem object or false if no further object exists.
 	 *
 	 * @since 1.6


### PR DESCRIPTION
Part of https://github.com/SemanticMediaWiki/SemanticMediaWiki/issues/1014
