### PR TITLE
Remove long deprecated SMWJsonResultPrinter class alias

### DIFF
--- a/includes/queryprinters/JsonResultPrinter.php
+++ b/includes/queryprinters/JsonResultPrinter.php
@@ -187,11 +187,3 @@ class JsonResultPrinter extends FileExportPrinter {
 	}
 
 }
-
-/**
- * SMWJsonResultPrinter
- * @codeCoverageIgnore
- *
- * @deprecated since SMW 1.9
- */
-class_alias( 'SMW\JsonResultPrinter', 'SMWJsonResultPrinter' );


### PR DESCRIPTION
Part of https://github.com/SemanticMediaWiki/SemanticMediaWiki/issues/1014
