### PR TITLE
Property page add <section> support, refs 3308

### DIFF
--- a/i18n/en.json
+++ b/i18n/en.json
@@ -781,6 +781,7 @@
 	"smw-property-tab-redirects": "Synonyms",
 	"smw-property-tab-subproperties": "Subproperties",
 	"smw-property-tab-errors": "Improper assignments",
+	"smw-property-tab-specification": "... more",
 	"smw-concept-tab-list": "List",
 	"smw-concept-tab-errors": "Errors"
 }

--- a/res/smw/ext.smw.page.css
+++ b/res/smw/ext.smw.page.css
@@ -300,6 +300,10 @@
 	padding-top: 8px;
 }
 
+.smw-property-specification {
+	display: none;
+}
+
 /**
  * Tabs
  */
@@ -307,10 +311,17 @@
 	margin-top: 15px;
 }
 
+.smw-tabs label.nav-label.smw-tab-right {
+	float: right;
+    clear: both;
+    margin: -1px 0 0 0;
+}
+
 .smw-property #tab-smw-property-value:checked ~ #tab-content-smw-property-value,
 .smw-property #tab-smw-property-subp:checked ~ #tab-content-smw-property-subp,
 .smw-property #tab-smw-property-errp:checked ~ #tab-content-smw-property-errp,
-.smw-property #tab-smw-property-redi:checked ~ #tab-content-smw-property-redi {
+.smw-property #tab-smw-property-redi:checked ~ #tab-content-smw-property-redi,
+.smw-property #tab-smw-property-spec:checked ~ #tab-content-smw-property-spec {
 	display: block;
 }
 
@@ -324,6 +335,11 @@
     border-top: 2px solid rgb(204,0,0);
 }
 
+.smw-property input.nav-tab:checked + label.nav-label.smw-tab-spec,
+.smw-concept input.nav-tab:checked + label.nav-label.smw-tab-spec {
+    border-top: 2px solid orange;
+}
+
 /**
  * Responsive settings (@see ext.smw.table)
  */
@@ -331,6 +347,11 @@
 
 	.smw-page-nav-right {
 		float: left;
+	}
+
+	.smw-tabs label.nav-label.smw-tab-right  {
+		float: unset;
+		margin: 0 0 -1px;
 	}
 
 	.smw-page-nav-left {

--- a/src/MediaWiki/Hooks/HookListener.php
+++ b/src/MediaWiki/Hooks/HookListener.php
@@ -7,6 +7,7 @@ use ParserHooks\HookRegistrant;
 use SMW\ApplicationFactory;
 use SMW\ParserFunctions\DocumentationParserFunction;
 use SMW\ParserFunctions\InfoParserFunction;
+use SMW\ParserFunctions\SectionTag;
 use SMW\MediaWiki\Search\SearchProfileForm;
 use SMW\Site;
 use SMW\Store;
@@ -724,6 +725,13 @@ class HookListener {
 		$docsFunctionHandler = new DocumentationParserFunction();
 		$hookRegistrant->registerFunctionHandler( $docsFunctionDefinition, $docsFunctionHandler );
 		$hookRegistrant->registerHookHandler( $docsFunctionDefinition, $docsFunctionHandler );
+
+		/**
+		 * Support for <section> ... </section>
+		 */
+		$parser->setHook( 'section', function( $input, array $args, \Parser $parser, \PPFrame $frame ) {
+			return ( new SectionTag( $parser, $frame ) )->parse( $input, $args );
+		} );
 
 		return true;
 	}

--- a/src/ParserFunctions/SectionTag.php
+++ b/src/ParserFunctions/SectionTag.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace SMW\ParserFunctions;
+
+use Parser;
+use PPFrame;
+use Html;
+
+/**
+ * To support the generation of <section> ... </section>
+ *
+ * @license GNU GPL v2+
+ * @since 3.0
+ *
+ * @author mwjames
+ */
+class SectionTag {
+
+	/**
+	 * @var Parser
+	 */
+	private $parser;
+
+	/**
+	 * @var PPFrame
+	 */
+	private $frame;
+
+	/**
+	 * @since 3.0
+	 *
+	 * @param Parser $parser
+	 * @param PPFrame $frame
+	 */
+	public function __construct( Parser $parser, PPFrame $frame ) {
+		$this->parser = $parser;
+		$this->frame = $frame;
+	}
+
+	/**
+	 * @since 3.0
+	 *
+	 * @param string $input
+	 * @param array $args
+	 *
+	 * @return string
+	 */
+	public function parse( $input, array $args ) {
+
+		$attributes = [];
+		$title = $this->parser->getTitle();
+
+		foreach( $args as $name => $value ) {
+			$value = htmlspecialchars( $value );
+
+			if ( $name === 'class' ) {
+				$attributes['class'] = $value;
+			}
+
+			if ( $name === 'id' ) {
+				$attributes['id'] = $value;
+			}
+		}
+
+		if ( $title !== null && $title->getNamespace() === SMW_NS_PROPERTY ) {
+			$attributes['class'] = ( isset( $attributes['class'] ) ? ' ' : '' ) . "smw-property-specification";
+		}
+
+		return Html::rawElement(
+			'section',
+			$attributes,
+			$this->parser->recursiveTagParse( $input, $this->frame )
+		);
+	}
+
+}

--- a/tests/phpunit/Unit/ParserFunctions/SectionTagTest.php
+++ b/tests/phpunit/Unit/ParserFunctions/SectionTagTest.php
@@ -1,0 +1,98 @@
+<?php
+
+namespace SMW\Tests\ParserFunctions;
+
+use SMW\ParserFunctions\SectionTag;
+
+/**
+ * @covers \SMW\ParserFunctions\SectionTag
+ * @group semantic-mediawiki
+ *
+ * @license GNU GPL v2+
+ * @since  3.0
+ *
+ * @author mwjames
+ */
+class SectionTagTest extends \PHPUnit_Framework_TestCase {
+
+	private $frame;
+	private $parser;
+
+	protected function setUp() {
+
+		$this->frame = $this->getMockBuilder( '\PPFrame' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$this->parser = $this->getMockBuilder( '\Parser' )
+			->disableOriginalConstructor()
+			->getMock();
+	}
+
+	public function testCanConstruct() {
+
+		$this->assertInstanceOf(
+			SectionTag::class,
+			new SectionTag( $this->parser, $this->frame )
+		);
+	}
+
+	public function testParse() {
+
+		$title = $this->getMockBuilder( '\Title' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$this->parser->expects( $this->any() )
+			->method( 'recursiveTagParse' )
+			->will( $this->returnValue( 'Foo' ) );
+
+		$this->parser->expects( $this->any() )
+			->method( 'getTitle' )
+			->will( $this->returnValue( $title ) );
+
+		$instance = new SectionTag(
+			$this->parser,
+			$this->frame
+		);
+
+		$args = [];
+
+		$this->assertContains(
+			'<section>Foo</section>',
+			$instance->parse( 'Foo', $args )
+		);
+	}
+
+	public function testParse_PropertyNamespace() {
+
+		$title = $this->getMockBuilder( '\Title' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$title->expects( $this->any() )
+			->method( 'getNamespace' )
+			->will( $this->returnValue( SMW_NS_PROPERTY ) );
+
+		$this->parser->expects( $this->any() )
+			->method( 'recursiveTagParse' )
+			->will( $this->returnValue( 'Foo' ) );
+
+		$this->parser->expects( $this->any() )
+			->method( 'getTitle' )
+			->will( $this->returnValue( $title ) );
+
+		$instance = new SectionTag(
+			$this->parser,
+			$this->frame
+		);
+
+		$args = [];
+
+		$this->assertContains(
+			'<section class="smw-property-specification">Foo</section>',
+			$instance->parse( 'Foo', $args )
+		);
+	}
+
+}


### PR DESCRIPTION
This PR is made in reference to: #3308

This PR addresses or contains:

- Since #3308 content on a property page is condensed with tabs allowing to mask auxiliary information to keep the page clean and focused, yet user content can still contain amounts of text that may hinder users from selecting (seeing) the essential facts
- PR adds the `<section>` tag by which users can define parts of a text (on the property page marked with a special class) that should be displayed on a "secondary" tab
- Why `section` and not `div` because:
  - HTML `<section>` [0] tag is not officially supported by the MW Parser
  - Doing a preg_replace on `div` elements is tedious, using `<section>` keeps it simple and allows to keep custom design elements without doing unnecessary DOM parsing in PHP

This PR includes:
- [ ] Tests (unit/integration)
- [x] CI build passed

Fixes #

[0] https://www.w3schools.com/tags/tag_section.asp

## Example

![image](https://user-images.githubusercontent.com/1245473/45250564-3b9b5e80-b325-11e8-883d-2d0b54571e46.png)

![image](https://user-images.githubusercontent.com/1245473/45250565-3f2ee580-b325-11e8-8985-4e331956e598.png)

![image](https://user-images.githubusercontent.com/1245473/45250568-4f46c500-b325-11e8-8564-e7cb780b20a0.png)
