### PR TITLE
[SMWSearch] Support completion search (in:, has:, phrase: prefix)

### DIFF
--- a/DefaultSettings.php
+++ b/DefaultSettings.php
@@ -2255,9 +2255,8 @@ return array(
 			// [[Has page::~Foo bar/bar/*]]
 			'page.field.case.insensitive.proximity.match' => true,
 
-			// Allows to retrieve text fragments from ES for a `Special:Search`
-			// query request and depending on the type selected can require more
-			// query time.
+			// Allows to retrieve text fragments from ES for query request and
+			// depending on the type selected can require more query time.
 			//
 			// Available types are `plain`, `unified`, and `fvh`. The `fvh` type
 			// requires text fields to have the `term_vector` with `with_positions_offsets`
@@ -2265,7 +2264,7 @@ return array(
 			//
 			// @see https://www.elastic.co/guide/en/elasticsearch/reference/current/search-request-highlighting.html#plain-highlighter
 			// @see https://www.elastic.co/guide/en/elasticsearch/reference/current/term-vector.html
-			'special_search.highlight.fragment' => [ 'number' => 1, 'size' => 250, 'type' => false ]
+			'highlight.fragment' => [ 'number' => 1, 'size' => 250, 'type' => false ]
 		]
 	],
 	##

--- a/data/elastic/default-profile.json
+++ b/data/elastic/default-profile.json
@@ -47,6 +47,6 @@
 		"uri.field.case.insensitive": false,
 		"text.field.case.insensitive.eq.match": false,
 		"page.field.case.insensitive.proximity.match": true,
-		"special_search.highlight.fragment.type": false
+		"highlight.fragment.type": false
 	}
 }

--- a/src/Elastic/QueryEngine/QueryEngine.php
+++ b/src/Elastic/QueryEngine/QueryEngine.php
@@ -173,7 +173,7 @@ class QueryEngine implements IQueryEngine {
 		}
 
 		// If at all only consider the retrieval for Special:Search queries
-		if ( $query->getOption( 'is.special_search' ) !== false && $query->querymode !== Query::MODE_COUNT ) {
+		if ( $query->getOption( 'highlight.fragment' ) !== false && $query->querymode !== Query::MODE_COUNT ) {
 			$this->addHighlight( $body );
 		}
 
@@ -338,7 +338,7 @@ class QueryEngine implements IQueryEngine {
 
 	private function addHighlight( &$body ) {
 
-		if ( ( $type = $this->options->dotGet( 'query.special_search.highlight.fragment.type', false ) ) === false ) {
+		if ( ( $type = $this->options->dotGet( 'query.highlight.fragment.type', false ) ) === false ) {
 			return;
 		}
 
@@ -348,8 +348,8 @@ class QueryEngine implements IQueryEngine {
 		}
 
 		$body['highlight'] = [
-			'number_of_fragments' => $this->options->dotGet( 'query.special_search.highlight.fragment.number', 1 ),
-			'fragment_size' => $this->options->dotGet( 'query.special_search.highlight.fragment.size', 150 ),
+			'number_of_fragments' => $this->options->dotGet( 'query.highlight.fragment.number', 1 ),
+			'fragment_size' => $this->options->dotGet( 'query.highlight.fragment.size', 150 ),
 			'fields' => [
 				'attachment.content' => [ "type" => $type ],
 				'text_raw' => [ "type" => $type ],

--- a/src/MediaWiki/Search/QueryBuilder.php
+++ b/src/MediaWiki/Search/QueryBuilder.php
@@ -151,6 +151,7 @@ class QueryBuilder {
 		// term" to avoid being blocked on an empty request which only contains
 		// structured searches.
 		$term = rtrim( $term, " " );
+		$prefix_map = [];
 
 		if ( $this->data === [] ) {
 			$data = SearchProfileForm::getFormDefinitions( $store );
@@ -159,9 +160,11 @@ class QueryBuilder {
 		}
 
 		if ( isset( $data['term_parser']['prefix'] ) && $data['term_parser']['prefix'] ) {
-			$termParser = new TermParser( (array)$data['term_parser']['prefix'] );
-			$term = $termParser->parse( $term );
+			$prefix_map = (array)$data['term_parser']['prefix'];
 		}
+
+		$termParser = new TermParser( $prefix_map );
+		$term = $termParser->parse( $term );
 
 		$form = $this->request->getVal( 'smw-form' );
 

--- a/src/MediaWiki/Search/SearchResultSet.php
+++ b/src/MediaWiki/Search/SearchResultSet.php
@@ -84,6 +84,26 @@ class SearchResultSet extends \SearchResultSet {
 	}
 
 	/**
+	 * @since 3.0
+	 *
+	 * @return SearchSuggestionSet
+	 */
+	public function newSearchSuggestionSet() {
+
+		$suggestions = [];
+		$hasMoreResults = false;
+		$score = count( $this->pages );
+
+		foreach ( $this->pages as $page ) {
+			if ( ( $title = $page->getTitle() ) && $title->exists() ) {
+				$suggestions[] = \SearchSuggestion::fromTitle( $score--, $title );
+			}
+		}
+
+		return new \SearchSuggestionSet( $suggestions, $hasMoreResults );
+	}
+
+	/**
 	 * @see SearchResultSet::extractResults
 	 *
 	 * @since 3.0

--- a/src/Query/Parser/TermParser.php
+++ b/src/Query/Parser/TermParser.php
@@ -89,7 +89,12 @@ class TermParser {
 		$k = 0;
 
 		while ( key( $terms ) !== null ) {
-			$new = trim( current( $terms ) );
+
+			$t_term = current( $terms );
+			$new = trim( $t_term );
+			$space = $t_term{0} == ' ' ? ' ' : '';
+
+			// Look ahead
 			$next = next( $terms );
 			$last = substr( $term, -2 );
 
@@ -110,7 +115,7 @@ class TermParser {
 				$custom .= $new;
 				$last = substr( $new, -2 );
 			} else {
-				$term .= $new;
+				$term .= "{$space}{$new}";
 			}
 
 			if ( $last === ']]' || $new === '(' || $new === '||' ) {
@@ -125,7 +130,11 @@ class TermParser {
 
 			// Last element
 			if ( $next === false && !in_array( $last, [ '&&', 'AND', '||', 'OR', ']]' ] ) ) {
-				$term .= $this->close( $custom, $prefix );
+				if ( $custom === '' && mb_substr_count( $term, '[[' ) > mb_substr_count( $term, ']]' ) ) {
+					$term .= $this->close( $custom, $prefix );
+				} elseif ( $custom !== '' ) {
+					$term .= $this->close( $custom, $prefix );
+				}
 			}
 
 			$k++;
@@ -162,8 +171,8 @@ class TermParser {
 
 	private function normalize( $term ) {
 		return str_replace(
-			[ ')[[', ']](', '(', ')', '||', '&&', 'AND', 'OR', ']][[', '[[[[', ']]]]' ],
-			[ ') [[', ']] (', '<q>', '</q>', ' || ', ' && ', ' AND ', ' OR ', ']] [[', '[[', ']]' ],
+			[ ')[[', ']](', '(', ')', '||', '&&', 'AND', 'OR', ']][[', '[[[[', ']]]]', '  ' ],
+			[ ') [[', ']] (', '<q>', '</q>', ' || ', ' && ', ' AND ', ' OR ', ']] [[', '[[', ']]', ' ' ],
 			$term
 		);
 	}

--- a/tests/phpunit/Unit/MediaWiki/Search/SearchResultSetTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Search/SearchResultSetTest.php
@@ -169,4 +169,54 @@ class SearchResultSetTest extends \PHPUnit_Framework_TestCase {
 		);
 	}
 
+	public function testNewSearchSuggestionSet() {
+
+		$title = $this->getMockBuilder( '\Title' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$title->expects( $this->any() )
+			->method( 'exists' )
+			->will( $this->returnValue( true ) );
+
+		$page = $this->getMockBuilder( '\SMW\DIWikiPage' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$page->expects( $this->any() )
+			->method( 'getTitle' )
+			->will( $this->returnValue( $title ) );
+
+		$queryToken = $this->getMockBuilder( '\SMW\Query\QueryToken' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$query = $this->getMockBuilder( '\SMWQuery' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$query->expects( $this->any() )
+			->method( 'getQueryToken' )
+			->will( $this->returnValue( $queryToken ) );
+
+		$queryResult = $this->getMockBuilder( 'SMWQueryResult' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$queryResult->expects( $this->any() )
+			->method( 'getResults' )
+			->will( $this->returnValue( [ $page ] ) );
+
+		$queryResult->expects( $this->any() )
+			->method( 'getQuery' )
+			->will( $this->returnValue( $query ) );
+
+		$resultSet = new SearchResultSet( $queryResult, 42 );
+
+		$this->assertInstanceOf(
+			'\SearchSuggestionSet',
+			$resultSet->newSearchSuggestionSet()
+		);
+	}
+
 }

--- a/tests/phpunit/Unit/MediaWiki/Search/SearchTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Search/SearchTest.php
@@ -543,4 +543,93 @@ class SearchTest extends \PHPUnit_Framework_TestCase {
 		$this->assertTrue( $search->getShowSuggestion() );
 	}
 
+	public function testCompletionSearch_OnEligiblePrefix() {
+
+		$infoLink = $this->getMockBuilder( '\SMWInfolink' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$query = $this->getMockBuilder( '\SMWQuery' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$queryResult = $this->getMockBuilder( '\SMWQueryResult' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$queryResult->expects( $this->any() )
+			->method( 'getQuery' )
+			->will( $this->returnValue( $query ) );
+
+		$queryResult->expects( $this->any() )
+			->method( 'getQueryLink' )
+			->will( $this->returnValue( $infoLink ) );
+
+		$queryResult->expects( $this->any() )
+			->method( 'getResults' )
+			->will( $this->returnValue( [] ) );
+
+		$store = $this->getMockBuilder( '\SMW\Store' )
+			->disableOriginalConstructor()
+			->getMockForAbstractClass();
+
+		$store->expects( $this->any() )
+			->method( 'getQueryResult' )
+			->will( $this->returnValue( $queryResult ) );
+
+		$this->testEnvironment->registerObject( 'Store', $store );
+
+		$title = $this->getMockBuilder( '\Title' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$searchEngine = $this->getMockBuilder( 'SearchEngine' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$search = new Search();
+		$search->setFallbackSearchEngine( $searchEngine );
+
+		$this->assertInstanceof(
+			'\SearchSuggestionSet',
+			$search->completionSearch( 'in:Foo' )
+		);
+	}
+
+	public function testCompletionSearch_NoRelevantPrefix() {
+
+		$title = $this->getMockBuilder( '\Title' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$searchSuggestionSet = $this->getMockBuilder( '\SearchSuggestionSet' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$searchSuggestionSet->expects( $this->any() )
+			->method( 'map')
+			->will( $this->returnValue( [] ) );
+
+		$searchEngine = $this->getMockBuilder( 'SearchEngine' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$searchEngine->expects( $this->once() )
+			->method( 'setShowSuggestion')
+			->with( $this->equalTo( true ) );
+
+		$searchEngine->expects( $this->once() )
+			->method( 'completionSearch' )
+			->will( $this->returnValue( $searchSuggestionSet ) );
+
+		$search = new Search();
+		$search->setFallbackSearchEngine( $searchEngine );
+		$search->setShowSuggestion( true );
+
+		$this->assertInstanceof(
+			'\SearchSuggestionSet',
+			$search->completionSearch( 'Foo' )
+		);
+	}
+
 }

--- a/tests/phpunit/Unit/Query/Parser/TermParserTest.php
+++ b/tests/phpunit/Unit/Query/Parser/TermParserTest.php
@@ -140,6 +140,16 @@ class TermParserTest extends \PHPUnit_Framework_TestCase {
 			'category:foo',
 			'[[category:foo]]'
 		];
+
+		yield [
+			'foo',
+			'foo'
+		];
+
+		yield [
+			'<q>[[Bar property::Foobar]]</q> Foo',
+			'<q>[[Bar property::Foobar]]</q> Foo'
+		];
 	}
 
 	public function term_prefixProvider() {


### PR DESCRIPTION
This PR is made in reference to: #

This PR addresses or contains:

- In case `$wgSearchType = 'SMWSearch';` is set, this PR will redirect search requests via the completion box on the `in:`, `has:`, and `phrase:` prefix to the SMW backend to try match content via the content body instead of just a simple title match such as:
  - `in:Foo bar` (== `[[~~*Foo bar*]]` or `phrase:Foo bar` ( == `[[~~"Foo bar"]]`) to find those that contain "Foo bar"
  - `has:Foo bar` (== `[[Foo bar::+]]`) to carry out a quick find on entities that have a `Some property` assignment
- In case of the `ElasticStore`, sorting is done by "best match" (meaning by score)
- In general, using `in:`, `has:`, and `phrase:` only make much sense when either the full-text/TYPE_CHAR_NOCASE is enabled or the `ElasticStore` is the selected as backend

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed

### Example

![image](https://user-images.githubusercontent.com/1245473/45253115-2b997400-b351-11e8-8f2e-81b9959e88bd.png)
