### PR TITLE
TermParser support compact form in:( ... ), has:..., refs 3157

### DIFF
--- a/res/smw/special.search/search.input.js
+++ b/res/smw/special.search/search.input.js
@@ -32,7 +32,7 @@
 				};
 
 				// Disable (hide) the MW's search input highlighter
-				if ( context.val().search( /\[|\[\[|in:|not:|phrase:|::/gi ) > -1 ) {
+				if ( context.val().search( /\[|\[\[|in:|not:|has:|phrase:|::/gi ) > -1 ) {
 					highlighter.hide();
 					isHidden = true;
 				} else if( isHidden ) {

--- a/res/smw/suggester/ext.smw.suggester.textInput.js
+++ b/res/smw/suggester/ext.smw.suggester.textInput.js
@@ -47,18 +47,23 @@
 				// field contains [[ ... ]] we assume a search via the QueryEngine
 				// therefore disable the standard highlighlter as no meaningfull
 				// input help will be shown
-				context.on( 'keyup keypres focus', function( e ) {
-					var highlighter = context.parent().find( '.oo-ui-widget' ),
-						style = '';
+				context.on( 'keyup keypres mouseenter', function( e ) {
 
-					if ( context.val().indexOf( '[' ) > -1 ) {
-						style = highlighter.attr( 'style' );
+					// MW 1.27 - MW 1.31
+					var highlighter = context.parent().find( '.oo-ui-widget' );
+
+					// MW 1.32+
+					if ( highlighter.length == 0 ) {
+						highlighter = $( '.oo-ui-defaultOverlay > .oo-ui-widget' );
+					};
+
+					// Disable (hide) the MW's search input highlighter
+					if ( context.val().search( /\[|\[\[|in:|not:|has:|phrase:|::/gi ) > -1 ) {
 						highlighter.hide();
 						isHidden = true;
 					} else if( isHidden ) {
-						highlighter.attr( 'style', style );
-						highlighter.show();
 						isHidden = false;
+						highlighter.show();
 					};
 				} );
 
@@ -73,6 +78,16 @@
 						'concept',
 						'category'
 					]
+				);
+
+				entitySuggester.registerTokenDefinition(
+					'property',
+					{
+						token: 'has:?',
+						beforeInsert: function( token, value ) {
+							return value.replace( '?', '' );
+						}
+					}
 				);
 			};
 		};

--- a/tests/phpunit/Unit/Query/Parser/TermParserTest.php
+++ b/tests/phpunit/Unit/Query/Parser/TermParserTest.php
@@ -150,6 +150,31 @@ class TermParserTest extends \PHPUnit_Framework_TestCase {
 			'<q>[[Bar property::Foobar]]</q> Foo',
 			'<q>[[Bar property::Foobar]]</q> Foo'
 		];
+
+		yield [
+			'in:foo [[Has foo::bar]] (in:(foo bar && fin))',
+			'[[in:foo]] [[Has foo::bar]] <q>[[in:foo bar]] && [[in:fin]]</q>'
+		];
+
+		yield [
+			'has:foo has:bar',
+			'[[foo::+]] [[bar::+]]'
+		];
+
+		yield [
+			'has:(foo && bar)',
+			'[[foo::+]] && [[bar::+]]'
+		];
+
+		yield [
+			'in:(foo && bar) in:(ham && cheese)',
+			'[[in:foo]] && [[in:bar]] [[in:ham]] && [[in:cheese]]'
+		];
+
+		yield [
+			'has:(foo && bar) in:(ham && cheese)',
+			'[[foo::+]] && [[bar::+]] [[in:ham]] && [[in:cheese]]'
+		];
 	}
 
 	public function term_prefixProvider() {


### PR DESCRIPTION
This PR is made in reference to: #3157

This PR addresses or contains:

- Only applies to the Special:Search and the completion box (#3419) input where quick matches are the focus and any removal of unnecessary keystrokes helps to find things faster without compromising on the intend of the search
- Adds support for `in:( ... )` to condense a collective condition set so that something like`in:ham in:cheese` (or `in:ham && in:cheese` or as raw condition `[[~~*ham*]] [[~~*cheese*]]`) can be simply expressed as `in:(ham && cheese)` 
- Adds `has:` (and `has:( ... )`) has fixed prefix to transform something like `has:Foo bar` into the equivalent of `[[Foo bar::+]]`

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed
