### PR TITLE
Special:Ask indicate query cache usage

### DIFF
--- a/i18n/en.json
+++ b/i18n/en.json
@@ -249,7 +249,7 @@
 	"smw-ask-search": "Search",
 	"smw-ask-debug": "Debug",
 	"smw-ask-debug-desc": "Generates query debug information",
-	"smw-ask-no-cache": "No cache",
+	"smw-ask-no-cache": "Disable query cache",
 	"smw-ask-no-cache-desc": "Results without query cache",
 	"smw-ask-result": "Result",
 	"smw-ask-empty": "Clear all entries",

--- a/res/smw/special/ext.smw.special.ask.css
+++ b/res/smw/special/ext.smw.special.ask.css
@@ -560,6 +560,10 @@ display: inline-block;
 	display: block;
 }
 
+.smw-tabs input.nav-tab:checked + label.nav-label.result-cache {
+    border-top: 2px solid orange;
+}
+
 /**
  * Responsive settings (#see smw.table.css)
  */

--- a/src/MediaWiki/Specials/Ask/LinksWidget.php
+++ b/src/MediaWiki/Specials/Ask/LinksWidget.php
@@ -322,7 +322,7 @@ class LinksWidget {
 			'span',
 			[
 				'id' => 'ask-cache',
-				'class' => 'smw-ask-button smw-ask-button-right',
+				'class' => '',
 				'title' => Message::get( 'smw-ask-no-cache-desc', Message::TEXT, Message::USER_LANGUAGE )
 			],
 			Html::element(
@@ -332,7 +332,7 @@ class LinksWidget {
 					'href'  => $title->getLocalURL( $urlArgs ),
 					'rel'   => 'nofollow'
 				],
-				'⊘'
+				Message::get( 'smw-ask-no-cache', Message::TEXT, Message::USER_LANGUAGE )
 			)
 		);
 	}

--- a/src/MediaWiki/Specials/SpecialAsk.php
+++ b/src/MediaWiki/Specials/SpecialAsk.php
@@ -539,10 +539,10 @@ class SpecialAsk extends SpecialPage {
 		$htmlTabs->tab(
 			'smw-askt-result',
 			wfMessage( 'smw-ask-tab-result' )->text(),
-			[ 'hide' => $isEmpty ]
+			[ 'hide' => $isEmpty, 'class' => $isFromCache ? ' result-cache' : '' ]
 		);
 
-		$links = '';
+		$links = [];
 
 		$htmlTabs->tab(
 			'smw-askt-code',
@@ -572,8 +572,6 @@ class SpecialAsk extends SpecialPage {
 				$debugLink,
 				[ 'hide' => $debugLink === '' || !$this->isEditMode , 'class' => 'smw-tab-right' ]
 			);
-
-			$links .= LinksWidget::noQCacheLink( $title, $urlArgs, $isFromCache );
 		}
 
 		$this->applyFinalOutputChanges(
@@ -597,9 +595,21 @@ class SpecialAsk extends SpecialPage {
 				[ 'class' => 'smw-tab-right' ]
 			);
 
+			if ( is_array( $links ) ) {
+				$links[] = $infoText;
+
+				if ( ( $noCacheLink = LinksWidget::noQCacheLink( $title, $urlArgs, $isFromCache ) ) !== '' ) {
+					$links[] = $noCacheLink;
+				}
+
+				$infoText = '<ul><li>' . implode( '</li><li>', $links ) . '</li></ul>';
+			} else {
+				$infoText = $links;
+			}
+
 			$htmlTabs->content(
 				'smw-askt-extra',
-				'<div style="margin-top:15px;">' . $infoText . '</div><div style="margin-top:15px;margin-bottom:20px;"><p></p>'. $links . '</div>'
+				'<div style="margin-top:15px;margin-bottom:20px;">' . $infoText . '</div>'
 			);
 		}
 


### PR DESCRIPTION
This PR is made in reference to: #3415 

This PR addresses or contains:

- Instead of yet another button, indicate that the result is retrieved from the query cache by changing the tab colour to orange (default is blue)

This PR includes:
- [ ] Tests (unit/integration)
- [x] CI build passed

## Example

![image](https://user-images.githubusercontent.com/1245473/45265560-54e2fe80-b43c-11e8-87ec-bb694037d300.png)


