### PR TITLE
[RDF] Encode `/` in property name, refs 3134

### DIFF
--- a/src/Exporter/Escaper.php
+++ b/src/Exporter/Escaper.php
@@ -41,6 +41,15 @@ class Escaper {
 	}
 
 	/**
+	 * @param string
+	 *
+	 * @return string
+	 */
+	static public function armorChars( $string ) {
+		return str_replace( array( '/' ), array( '-2F' ), $string );
+	}
+
+	/**
 	 * This function escapes symbols that might be problematic in XML in a uniform
 	 * and injective way.
 	 *

--- a/src/Exporter/ExpResourceMapper.php
+++ b/src/Exporter/ExpResourceMapper.php
@@ -229,24 +229,35 @@ class ExpResourceMapper {
 	private function defineElementsForDiWikiPage( DIWikiPage $diWikiPage, $modifier ) {
 
 		$localName = '';
+		$hasFixedNamespace = false;
 
 		if ( $diWikiPage->getNamespace() === NS_CATEGORY ) {
 			$namespace = Exporter::getInstance()->getNamespaceUri( 'category' );
 			$namespaceId = 'category';
 			$localName = Escaper::encodeUri( $diWikiPage->getDBkey() );
+			$hasFixedNamespace = true;
 		}
 
 		if ( $diWikiPage->getNamespace() === SMW_NS_PROPERTY ) {
 			$namespace = Exporter::getInstance()->getNamespaceUri( 'property' );
 			$namespaceId = 'property';
 			$localName = Escaper::encodeUri( $diWikiPage->getDBkey() );
+			$hasFixedNamespace = true;
 		}
 
 		if ( ( $localName === '' ) ||
-		     ( in_array( $localName{0}, array( '-', '0', '1', '2', '3', '4', '5', '6', '7', '8', '9' ) ) ) ) {
+		     ( in_array( $localName{0}, array( '-', '0', '1', '2', '3', '4', '5', '6', '7', '8', '9' ) ) ) ||
+		     ( $hasFixedNamespace && strpos( $localName, '/' ) !== false )
+		     ) {
 			$namespace = Exporter::getInstance()->getNamespaceUri( 'wiki' );
 			$namespaceId = 'wiki';
 			$localName = Escaper::encodePage( $diWikiPage );
+		}
+
+		if ( $hasFixedNamespace && strpos( $localName, '/' ) !== false ) {
+			$namespace = Exporter::getInstance()->getNamespaceUri( 'wiki' );
+			$namespaceId = 'wiki';
+			$localName = Escaper::armorChars( Escaper::encodePage( $diWikiPage ) );
 		}
 
 		// "-23$modifier" where "-23" is the URI encoding of "#" (a symbol not

--- a/tests/phpunit/Integration/JSONScript/TestCases/r-0020.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/r-0020.json
@@ -1,0 +1,45 @@
+{
+	"description": "Test RDF output on `/` in porperty name (#3134)",
+	"setup": [
+		{
+			"namespace": "SMW_NS_PROPERTY",
+			"page": "R0020/URL",
+			"contents": "[[Has type::URL]]"
+		},
+		{
+			"page": "Example/R0020/1",
+			"contents": "[[R0020/URL::https://example.org/Foo]]"
+		}
+	],
+	"tests": [
+		{
+			"type": "rdf",
+			"about": "#0",
+			"dumpRDF": {
+				"parameters": {
+					"page": "Example/R0020/1"
+				}
+			},
+			"assert-output": {
+				"to-contain": [
+					"<wiki:Property-3AR0020-2FURL rdf:resource=\"https://example.org/Foo\"/>",
+					"<owl:ObjectProperty rdf:about=\"http://example.org/id/Property-3AR0020-2FURL\" />"
+				]
+			}
+		}
+	],
+	"settings": {
+		"wgContLang": "en",
+		"wgLang": "en",
+		"smwgNamespacesWithSemanticLinks": {
+			"NS_MAIN": true,
+			"SMW_NS_PROPERTY": true
+		},
+		"smwgNamespace": "http://example.org/id/"
+	},
+	"meta": {
+		"version": "2",
+		"is-incomplete": false,
+		"debug": false
+	}
+}

--- a/tests/phpunit/Unit/Exporter/ExpResourceMapperTest.php
+++ b/tests/phpunit/Unit/Exporter/ExpResourceMapperTest.php
@@ -219,6 +219,17 @@ class ExpResourceMapperTest extends \PHPUnit_Framework_TestCase {
 			)
 		);
 
+		#7
+		$provider[] = array(
+			new DIWikiPage( 'Foo/Bar', SMW_NS_PROPERTY, '', '' ),
+			'',
+			array(
+				'type' => Element::TYPE_NSRESOURCE,
+				'uri'  => "Property-3AFoo-2FBar|{$wiki}|wiki",
+				'dataitem' => array( 'type' => 9, 'item' => 'Foo/Bar#102##' )
+			)
+		);
+
 		return $provider;
 	}
 


### PR DESCRIPTION
This PR is made in reference to: #3134

This PR addresses or contains:

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed

Fixes #3134