### PR TITLE
Special:Ask support different form submit methods

### DIFF
--- a/DefaultSettings.php
+++ b/DefaultSettings.php
@@ -1978,6 +1978,26 @@ return array(
 	##
 
 	##
+	# Special:Ask form submit method
+	#
+	# - SMW_SASK_SUBMIT_POST uses `post` as submit method, allows to jump
+	#   directly to the search result but will not produce any copyable URL
+	#   string (use the result bookmark button instead)
+	#
+	# - SMW_SASK_SUBMIT_GET uses `get` as submit method and was the default
+	#   until 2.5, is not able to jump the search result directly after a submit
+	#
+	# - SMW_SASK_SUBMIT_GET_REDIRECT uses `get` as submit method and provides
+	#   the means to directly jump to the search result after a submit but
+	#   requires an extra HTTP request to follow a redirect
+	#
+	# @since 3.0
+	# @default SMW_SASK_SUBMIT_POST
+	##
+	'smwgSpecialAskFormSubmitMethod' => SMW_SASK_SUBMIT_POST,
+	##
+
+	##
 	# Rule types
 	#
 	# The mapping defines the relation between a specific type, group and

--- a/includes/Settings.php
+++ b/includes/Settings.php
@@ -178,6 +178,7 @@ class Settings extends Options {
 			'smwgElasticsearchProfile' => $GLOBALS['smwgElasticsearchProfile'],
 			'smwgElasticsearchEndpoints' => $GLOBALS['smwgElasticsearchEndpoints'],
 			'smwgPostEditUpdate' => $GLOBALS['smwgPostEditUpdate'],
+			'smwgSpecialAskFormSubmitMethod' => $GLOBALS['smwgSpecialAskFormSubmitMethod'],
 		);
 
 		self::initLegacyMapping( $configuration );
@@ -475,7 +476,7 @@ class Settings extends Options {
 		if ( isset( $GLOBALS['smwgSparqlDataEndpoint'] ) ) {
 			$configuration['smwgSparqlEndpoint']['data'] = $GLOBALS['smwgSparqlDataEndpoint'];
     }
-    
+
 		if ( isset( $GLOBALS['smwgCacheType'] ) ) {
 			$configuration['smwgMainCacheType'] = $GLOBALS['smwgCacheType'];
 		}

--- a/src/Defines.php
+++ b/src/Defines.php
@@ -280,6 +280,12 @@ define( 'SMW_REMOTE_REQ_SHOW_NOTE', 4 ); // Shows a note
 define( 'SMW_RULE_GROUP_FORMAT', 'rule.group.format' );
 define( 'SMW_RULE_GROUP_FORM_DEFINITION', 'rule.group.form.definition' );
 
+/**@{
+  * Constants for Special:Ask submit method
+  */
+define( 'SMW_SASK_SUBMIT_GET', 'get' );
+define( 'SMW_SASK_SUBMIT_GET_REDIRECT', 'get.redirect' );
+define( 'SMW_SASK_SUBMIT_POST', 'post' );
 /**@}*/
 
 /**@{

--- a/src/Options.php
+++ b/src/Options.php
@@ -56,6 +56,18 @@ class Options {
 	}
 
 	/**
+	 * @since 3.0
+	 *
+	 * @param string $key
+	 * @param string $value
+	 *
+	 * @return boolean
+	 */
+	public function is( $key, $value ) {
+		return $this->get( $key ) === $value;
+	}
+
+	/**
 	 * @since 2.3
 	 *
 	 * @param string $key

--- a/tests/phpunit/Integration/SpecialAskTest.php
+++ b/tests/phpunit/Integration/SpecialAskTest.php
@@ -4,6 +4,7 @@ namespace SMW\Tests\Integration;
 
 use DOMDocument;
 use SMW\MediaWiki\Specials\SpecialAsk;
+use SMW\Tests\TestEnvironment;
 
 /**
  * @group semantic-mediawiki
@@ -17,6 +18,22 @@ class SpecialAskTest extends \PHPUnit_Framework_TestCase {
 
 	private $oldRequestValues;
 	private $oldBodyText;
+	private $testEnvironment;
+
+	protected function setUp() {
+		parent::setUp();
+
+		$this->testEnvironment = new TestEnvironment(
+			[
+				'smwgSpecialAskFormSubmitMethod' => SMW_SASK_SUBMIT_GET
+			]
+		);
+	}
+
+	protected function tearDown() {
+		$this->testEnvironment->tearDown();
+		parent::tearDown();
+	}
 
 	/**
 	 * @dataProvider provideTestData


### PR DESCRIPTION
This PR is made in reference to: #

This PR addresses or contains:

- Filling the Special:Ask form and submitting it for a search on a GET request fails to attach a `#...` anchor which is the reason why any such request jumps to the top after a response which kind of sucks and is annoying
- Adds `$smwgSpecialAskFormSubmitMethod` to switch settings in case the following settings doesn't suite a user group with:
  - SMW 3.0 switches to a POST submit method (`SMW_SASK_SUBMIT_POST`) allowing for any submitted  request to jump directly to a dedicated anchor but loses the ability to copy the URL (a HTTP POST request doesn't create any copyable URL) from the address bar (use the bookmark button)
  - `SMW_SASK_SUBMIT_GET` use GET as it was the default til SMW 3.0-
  - `SMW_SASK_SUBMIT_GET_REDIRECT` is a compromise between GET and POST by being an actual GET but redirects shortly after a request and setting an anchor to jump to a dedicated target, URL remains copyable but it requires two requests one GET and one REDIRECT to achieve the same outcome as a POST request would

This PR includes:
- [ ] Tests (unit/integration)
- [x] CI build passed
