### PR TITLE
Run ParserCachePurgeJob from queue on move, refs #3422

### DIFF
--- a/src/DataUpdater.php
+++ b/src/DataUpdater.php
@@ -221,6 +221,11 @@ class DataUpdater {
 		$this->checkChangePropagation();
 		$this->updateData();
 
+		if ( $this->semanticData->getOption( Enum::PURGE_ASSOC_PARSERCACHE ) === true ) {
+			$jobQueue = $applicationFactory->getJobQueue();
+			$jobQueue->runFromQueue( [ 'SMW\ParserCachePurgeJob' => 2 ] );
+		}
+
 		return true;
 	}
 

--- a/src/Enum.php
+++ b/src/Enum.php
@@ -15,4 +15,9 @@ class Enum {
 	 */
 	const OPT_SUSPEND_PURGE = 'smw.opt.suspend.purge';
 
+	/**
+	 * Indicates to purge an associated parser cache
+	 */
+	const PURGE_ASSOC_PARSERCACHE = 'smw.purge.assoc.parsercache';
+
 }

--- a/src/MediaWiki/Jobs/UpdateJob.php
+++ b/src/MediaWiki/Jobs/UpdateJob.php
@@ -290,6 +290,11 @@ class UpdateJob extends JobBase {
 			false
 		);
 
+		$parserData->getSemanticData()->setOption(
+			Enum::PURGE_ASSOC_PARSERCACHE,
+			(bool)$this->getParameter( Enum::PURGE_ASSOC_PARSERCACHE )
+		);
+
 		$parserData->updateStore();
 
 		return true;

--- a/src/SQLStore/QueryDependency/QueryDependencyLinksStore.php
+++ b/src/SQLStore/QueryDependency/QueryDependencyLinksStore.php
@@ -221,7 +221,7 @@ class QueryDependencyLinksStore {
 		if ( $this->isPrimary || $this->isCommandLineMode ) {
 			$parserCachePurgeJob->run();
 		} else {
-			$parserCachePurgeJob->lazyPush();
+			$parserCachePurgeJob->insert();
 		}
 	}
 


### PR DESCRIPTION
This PR is made in reference to: #3422, #3318 

This PR addresses or contains:

- `Special:MovePage` invokes update jobs and requires a different execution mode to make sure the `ParserCachePurgeJob` can run close to the move since no post-edit event is triggered which would normally handle the execution of the job

This PR includes:
- [ ] Tests (unit/integration)
- [x] CI build passed
