### PR TITLE
QueryLinker avoid predefined property key in sort

### DIFF
--- a/tests/phpunit/Unit/Query/QueryLinkerTest.php
+++ b/tests/phpunit/Unit/Query/QueryLinkerTest.php
@@ -31,7 +31,11 @@ class QueryLinkerTest extends \PHPUnit_Framework_TestCase {
 
 		$query->expects( $this->once() )
 			->method( 'getExtraPrintouts' )
-			->will( $this->returnValue( array() ) );
+			->will( $this->returnValue( [] ) );
+
+		$query->expects( $this->once() )
+			->method( 'getSortKeys' )
+			->will( $this->returnValue( [] ) );
 
 		$parameters = array(
 			'Foo' => 'Bar',
@@ -42,6 +46,56 @@ class QueryLinkerTest extends \PHPUnit_Framework_TestCase {
 			'SMWInfolink',
 			QueryLinker::get( $query, $parameters )
 		);
+	}
+
+	/**
+	 * @dataProvider sortOrderProvider
+	 */
+	public function testSort_PredefinedProperty( $sortKeys, $expected ) {
+
+		$query = $this->getMockBuilder( '\SMWQuery' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$query->expects( $this->once() )
+			->method( 'getExtraPrintouts' )
+			->will( $this->returnValue( array() ) );
+
+		$query->expects( $this->once() )
+			->method( 'getSortKeys' )
+			->will( $this->returnValue( $sortKeys ) );
+
+		$link = QueryLinker::get( $query );
+		$link->setCompactLink( false );
+
+		$this->assertContains(
+			$expected,
+			$link->getLocalURL()
+		);
+	}
+
+	public function sortOrderProvider() {
+
+		yield[
+			[ '_MDAT' => 'DESC' ],
+			'&order=desc&sort=Modification%20date'
+		];
+
+		yield[
+			[ '' => 'ASC' ],
+			'&mainlabel=&source=&offset='
+		];
+
+		yield[
+			[ 'Foo_bar' => 'ASC' ],
+			'&mainlabel=&source=&offset=&order=asc&sort=Foo%20bar'
+		];
+
+		yield[
+			[ '' => 'ASC', 'Foo_bar' => 'DESC' ],
+			'&mainlabel=&source=&offset=&order=asc%2Cdesc&sort=%2CFoo%20bar'
+		];
+
 	}
 
 }


### PR DESCRIPTION
This PR is made in reference to: #

This PR addresses or contains:

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed
