### PR TITLE
[DB] Avoid autoincrementing integer on the smw_rev field, refs 3390

### DIFF
--- a/src/SQLStore/TableBuilder/FieldType.php
+++ b/src/SQLStore/TableBuilder/FieldType.php
@@ -25,6 +25,11 @@ class FieldType {
 	/**
 	 * @var string
 	 */
+	const FIELD_ID_UNSIGNED = 'id_unsigned';
+
+	/**
+	 * @var string
+	 */
 	const FIELD_TITLE = 'title';
 
 	/**

--- a/src/SQLStore/TableBuilder/MySQLTableBuilder.php
+++ b/src/SQLStore/TableBuilder/MySQLTableBuilder.php
@@ -27,6 +27,10 @@ class MySQLTableBuilder extends TableBuilder {
 			'id'         => 'INT(11) UNSIGNED',
 			 // like page_id in MW page table
 			'id_primary' => 'INT(11) UNSIGNED NOT NULL KEY AUTO_INCREMENT',
+
+			 // (see postgres on the difference)
+			'id_unsigned' => 'INT(11) UNSIGNED',
+
 			 // like page_namespace in MW page table
 			'namespace'  => 'INT(11)',
 			 // like page_title in MW page table

--- a/src/SQLStore/TableBuilder/PostgresTableBuilder.php
+++ b/src/SQLStore/TableBuilder/PostgresTableBuilder.php
@@ -23,11 +23,17 @@ class PostgresTableBuilder extends TableBuilder {
 	 */
 	public function getStandardFieldType( $fieldType ) {
 
+		// serial is a 4 bytes autoincrementing integer (1 to 2147483647)
+
 		$fieldTypes = array(
 			 // like page_id in MW page table
 			'id'         => 'SERIAL',
 			 // like page_id in MW page table
 			'id_primary' => 'SERIAL NOT NULL PRIMARY KEY',
+
+			 // not autoincrementing integer
+			'id_unsigned' => 'INTEGER',
+
 			 // like page_namespace in MW page table
 			'namespace'  => 'BIGINT',
 			 // like page_title in MW page table

--- a/src/SQLStore/TableBuilder/SQLiteTableBuilder.php
+++ b/src/SQLStore/TableBuilder/SQLiteTableBuilder.php
@@ -26,6 +26,10 @@ class SQLiteTableBuilder extends TableBuilder {
 			 // like page_id in MW page table
 			'id'         => 'INTEGER',
 			'id_primary' => 'INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT',
+
+			 // (see postgres, mysql on the difference)
+			'id_unsigned' => 'INTEGER',
+
 			 // like page_namespace in MW page table
 			'namespace'  => 'INT(11)',
 			 // like page_title in MW page table

--- a/src/SQLStore/TableSchemaManager.php
+++ b/src/SQLStore/TableSchemaManager.php
@@ -157,7 +157,7 @@ class TableSchemaManager {
 		$table->addColumn( 'smw_sort', array( FieldType::FIELD_TITLE ) );
 		$table->addColumn( 'smw_proptable_hash', FieldType::TYPE_BLOB );
 		$table->addColumn( 'smw_hash', FieldType::FIELD_HASH );
-		$table->addColumn( 'smw_rev', FieldType::FIELD_ID );
+		$table->addColumn( 'smw_rev', FieldType::FIELD_ID_UNSIGNED );
 
 		$table->addIndex( 'smw_id' );
 		$table->addIndex( 'smw_id,smw_sortkey' );


### PR DESCRIPTION
This PR is made in reference to: #3390

This PR addresses or contains:

- Using `SERIAL` for the `smw_rev` field is the wrong type as it is defined as [0] "4 bytes autoincrementing integer ..." in postgres

This PR includes:
- [ ] Tests (unit/integration)
- [x] CI build passed

[0] https://www.postgresql.org/docs/9.1/static/datatype-numeric.html