### PR TITLE
Special:Ask set target on pagination links, refs 3429

### DIFF
--- a/res/smw/ext.smw.css
+++ b/res/smw/ext.smw.css
@@ -453,6 +453,13 @@ label.smw-form-checkbox {
 	background-position: center;
 }
 
+.smw-icon-bookmark {
+	background-image: url("data:image/svg+xml,%3C%3Fxml version='1.0' encoding='UTF-8'%3F%3E%3Csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16' viewBox='0 0 20 20'%3E%3Ctitle%3E bookmark outlined %3C/title%3E%3Cpath d='M15 1H5a2 2 0 0 0-2 2v16l7-5 7 5V3a2 2 0 0 0-2-2zm0 14.25l-5-3.5-5 3.5V3h10z'/%3E%3C/svg%3E%0A");
+	background-repeat: no-repeat;
+	padding: 0 0 0 25px;
+	background-position: center;
+}
+
 .smw-icon-compact {
 	background-image: url("data:image/svg+xml,%3C%3Fxml version='1.0' encoding='utf-8'%3F%3E%3Csvg xmlns='http://www.w3.org/2000/svg' width='23' height='12'%3E%3Cpath stroke-width='3' stroke='%23000' d='M1,3.5h21M1,9.5h9m3,0h9'/%3E%3C/svg%3E");
 	background-repeat: no-repeat;

--- a/res/smw/special/ext.smw.special.ask.css
+++ b/res/smw/special/ext.smw.special.ask.css
@@ -41,7 +41,7 @@
 
 /* MobileFrontend sets those to 0 therefore declare them explicitly */
 div#ask fieldset {
-	margin: 0.5em 0 0.5em 0;
+	margin: 0 0 0.5em 0;
 	padding: 0 1em 1em;
 }
 
@@ -50,6 +50,10 @@ div#ask legend {
 	font-size: 95%;
 	font-weight:normal;
 	text-transform:none;
+}
+
+div#query legend {
+	font-weight:bold;
 }
 
 .smw-ask-toplinks {
@@ -215,7 +219,6 @@ display: inline-block;
 }
 
 .smw-ask-button-submit input:hover {
-    color: #fff;
     background-color: #ddd;
     border-color: #ddd;
 }
@@ -384,14 +387,11 @@ display: inline-block;
 	hyphens: auto;
 }
 
-}
-.smw-ask-sort-input {
-	margin-bottom: 10px;
-}
-
 .smw-ask-sort-input input, .smw-propertysubject-input {
 	padding: 4px;
 	border: 1px solid #aaa;
+	margin-right: 10px;
+	margin-top: 5px;
 }
 
 .options-list .smw-property-input {
@@ -426,9 +426,17 @@ display: inline-block;
 	padding: 0.625em 0.625em 0.546875em;
 }
 
-.smw-ask-sort-input select, .smw-ask-sort-input .smw-ask-sort-delete {
+.smw-ask-sort-input .smw-ask-sort-delete {
 	padding: 3px;
-    margin-left: 10px;
+    margin-right: 10px;
+    margin-bottom: 5px;
+}
+
+.smw-ask-sort-input select {
+	padding: 3px;
+    margin-right: 10px;
+    margin-bottom: 5px;
+    margin-top: 5px;
 }
 
 .smw-ask-sort-add a::before, .smw-ask-sort-delete a::before {
@@ -564,6 +572,28 @@ display: inline-block;
     border-top: 2px solid orange;
 }
 
+.smw-tabs input.nav-tab:checked + label.nav-label.clipboard-bookmark {
+    border:0;
+}
+
+.smw-tabs input.nav-tab:checked + label.nav-label.edit-action {
+    border: 0;
+}
+
+.smw-tabs label.nav-label.edit-action,
+.smw-tabs label.nav-label.compact-action,
+.smw-tabs label.nav-label.clipboard-bookmark.smw-tab-right {
+	padding: 5px 0px;
+}
+
+.clipboard.smw-icon-bookmark {
+	padding: 0 0 0 60px;
+}
+
+.smw-tabs input.nav-tab:checked + label.nav-label.compact-action {
+    border:0;
+}
+
 /**
  * Responsive settings (#see smw.table.css)
  */
@@ -620,18 +650,6 @@ display: inline-block;
 		display: inline-block;
 		margin-bottom: 0;
 	}
-}
-
-/**
- * Responsive settings (#see smw.table.css)
- */
-@media screen and (max-width: 530px) {
-
-	.smw-ask-sort-input select {
-		margin-top: 10px;
-		margin-left: 0px;
-	}
-
 }
 
 .skin-chameleon .autocomplete-arrow {

--- a/res/smw/special/ext.smw.special.ask.js
+++ b/res/smw/special/ext.smw.special.ask.js
@@ -42,7 +42,7 @@
 		this.messages = {};
 
 		this.html = mw.html;
-		this.hideList = '#ask-embed, #inlinequeryembed, #ask-showhide, #ask-debug, #ask-clipboard, #ask-navinfo, #ask-cache, #result, #result-error, #ask-pagination, #ask-export-links, #tab-label-smw-askt-compact, #tab-label-smw-askt-code, #tab-label-smw-askt-debug, #tab-label-smw-askt-extra, #tab-label-smw-askt-result';
+		this.hideList = '#ask-embed, #inlinequeryembed, #ask-showhide, #ask-debug, #ask-clipboard, #ask-navinfo, #ask-cache, #result, #result-error, #ask-pagination, #ask-export-links, #tab-label-smw-askt-compact, #tab-label-smw-askt-code, #tab-label-smw-askt-debug, #tab-label-smw-askt-extra, #tab-label-smw-askt-result, #tab-label-smw-askt-clipboard, #search';
 
 		return this;
 	};

--- a/src/MediaWiki/Specials/Ask/LinksWidget.php
+++ b/src/MediaWiki/Specials/Ask/LinksWidget.php
@@ -113,14 +113,15 @@ class LinksWidget {
 		return Html::rawElement(
 				'a',
 				[
-					'href'  => $href,
-					'rel'   => 'href'
+					'href'  => $href . '#search',
+					'rel'   => 'href',
+					'style' => 'display:block; width:60px'
 				],
 				Html::rawElement(
 				'span',
 				[
 					'class' => 'smw-icon-pen',
-					'title' => wfMessage( 'smw_ask_editquery' )->text()
+					'title' => wfMessage( 'smw_ask_editquery' )->text(),
 				],
 				''
 			)
@@ -139,7 +140,8 @@ class LinksWidget {
 				'a',
 				[
 					'href'  => $href,
-					'rel'   => 'nofollow'
+					'rel'   => 'nofollow',
+					'style' => 'display:block; width:60px'
 				],
 				Html::rawElement(
 				'span',
@@ -353,7 +355,7 @@ class LinksWidget {
 		return Html::rawElement(
 			'span',
 			[
-				'id' => 'ask-clipboard',
+				'id' => 'ask-clipboard ',
 			//	'class' => 'smw-ask-button smw-ask-button-right smw-ask-button-lgrey'
 			],
 			Html::element(
@@ -362,11 +364,10 @@ class LinksWidget {
 					'data-clipboard-action' => 'copy',
 					'data-clipboard-target' => '.clipboard',
 					'data-onoi-clipboard-field' => 'value',
-					'class' => 'clipboard',
+					'class' => 'clipboard smw-icon-bookmark',
 					'value' => $infolink->getURL(),
 					'title' =>  wfMessage( 'smw-clipboard-copy-link' )->text()
-				],
-				'⧟'
+				]
 			)
 		);
 	}

--- a/src/MediaWiki/Specials/Ask/NavigationLinksWidget.php
+++ b/src/MediaWiki/Specials/Ask/NavigationLinksWidget.php
@@ -181,7 +181,7 @@ class NavigationLinksWidget {
 			[
 				'id' => 'ask-pagination'
 			],
-			ListPager::pagination( $title, $limit, $offset, $count, $urlArgs->toArray(), $html )
+			ListPager::pagination( $title, $limit, $offset, $count, $urlArgs->toArray() + [ '_target' => '#search' ] , $html )
 		);
 	}
 

--- a/src/MediaWiki/Specials/SpecialAsk.php
+++ b/src/MediaWiki/Specials/SpecialAsk.php
@@ -549,9 +549,9 @@ class SpecialAsk extends SpecialPage {
 		);
 
 		if ( !$this->isEditMode && !$isEmpty ) {
-			$htmlTabs->tab( 'smw-askt-edit', LinksWidget::editLink( $editLink ), [ 'hide' => $this->isBorrowedMode ] );
+			$htmlTabs->tab( 'smw-askt-edit', LinksWidget::editLink( $editLink ), [ 'hide' => $this->isBorrowedMode, 'class' => 'edit-action' ] );
 		} elseif ( !$isEmpty ) {
-			$htmlTabs->tab( 'smw-askt-compact', LinksWidget::hideLink( $editLink ), [ 'hide' => $this->isBorrowedMode ] );
+			$htmlTabs->tab( 'smw-askt-compact', LinksWidget::hideLink( $editLink ), [ 'hide' => $this->isBorrowedMode, 'class' => 'compact-action' ] );
 		}
 
 		$htmlTabs->tab(
@@ -579,7 +579,7 @@ class SpecialAsk extends SpecialPage {
 		$htmlTabs->tab(
 			'smw-askt-clipboard',
 			$clipboardLink,
-			[ 'hide' => $clipboardLink === '', 'class' => 'smw-tab-right' ]
+			[ 'hide' => $clipboardLink === '', 'class' => 'clipboard-bookmark smw-tab-right' ]
 		);
 
 		if ( !isset( $this->parameters['source'] ) || $this->parameters['source'] === '' ) {
@@ -615,6 +615,11 @@ class SpecialAsk extends SpecialPage {
 
 			if ( is_array( $links ) ) {
 				$links[] = $infoText;
+
+				// External source cannot disable the cache
+				if ( isset( $this->parameters['source'] ) && $this->parameters['source'] !== '' ) {
+					$isFromCache = false;
+				}
 
 				if ( ( $noCacheLink = LinksWidget::noQCacheLink( $title, $urlArgs, $isFromCache ) ) !== '' ) {
 					$links[] = $noCacheLink;

--- a/src/Page/ListPager.php
+++ b/src/Page/ListPager.php
@@ -175,10 +175,16 @@ class ListPager {
 		$query = [ 'limit' => $limit, 'offset' => $offset ] + $query;
 
 		$tooltip = wfMessage( $tooltipMsg )->inLanguage( $language )->title( $title )->numParams( $limit )->text();
+		$target = '';
+
+		if ( isset( $query['_target' ] ) ) {
+			$target = $query['_target' ];
+			unset( $query['_target' ] );
+		}
 
 		return Html::element( 'a',
 			[
-				'href' => $title->getLocalURL( $query ),
+				'href' => $title->getLocalURL( $query ) . $target,
 				'title' => $tooltip,
 				'class' => 'page-link' . ( $active ? ' link-active' : '' )
 			],


### PR DESCRIPTION
This PR is made in reference to: #3429 

This PR addresses or contains:

- Sets a `_target` anchor for pagination links allowing to jump directly to the `#search` section when such link is clicked

This PR includes:
- [ ] Tests (unit/integration)
- [x] CI build passed
