### PR TITLE
Check ID reference on delete

### DIFF
--- a/includes/storage/SQLStore/SMW_SQLStore3.php
+++ b/includes/storage/SQLStore/SMW_SQLStore3.php
@@ -564,6 +564,7 @@ class SMWSQLStore3 extends SMWStore {
 		parent::clear();
 		$this->factory->newSemanticDataLookup()->clear();
 		$this->propertyTableInfoFetcher = null;
+		$this->servicesContainer = null;
 		$this->getObjectIds()->initCache();
 	}
 

--- a/src/SQLStore/EntityStore/IdCacheManager.php
+++ b/src/SQLStore/EntityStore/IdCacheManager.php
@@ -145,6 +145,33 @@ class IdCacheManager {
 	}
 
 	/**
+	 * @since 3.0
+	 *
+	 * @param string $id
+	 */
+	public function deleteCacheById( $id ) {
+
+		$dataItem = $this->caches['entity.lookup']->fetch( $id );
+
+		if ( !$dataItem instanceof DIWikiPage ) {
+			return;
+		}
+
+		$hash = $this->computeSha1(
+			[
+				$dataItem->getDBKey(),
+				(int)$dataItem->getNamespace(),
+				$dataItem->getInterwiki(),
+				$dataItem->getSubobjectName()
+			]
+		);
+
+		$this->caches['entity.id']->delete( $hash );
+		$this->caches['entity.sort']->delete( $hash );
+		$this->caches['entity.lookup']->delete( $id );
+	}
+
+	/**
 	 * Get a cached SMW ID, or false if no cache entry is found.
 	 *
 	 * @since 3.0

--- a/src/SQLStore/SQLStoreFactory.php
+++ b/src/SQLStore/SQLStoreFactory.php
@@ -739,7 +739,11 @@ class SQLStoreFactory {
 				'EntityValueUniquenessConstraintChecker' => [
 					'_service' => [ $this, 'newEntityValueUniquenessConstraintChecker' ],
 					'_type'    => EntityValueUniquenessConstraintChecker::class
-				]
+				],
+				'PropertyTableIdReferenceFinder' => function() {
+					static $singleton;
+					return $singleton = $singleton === null ? $this->newPropertyTableIdReferenceFinder() : $singleton;
+				}
 			]
 		);
 

--- a/tests/phpunit/Unit/SQLStore/EntityStore/IdCacheManagerTest.php
+++ b/tests/phpunit/Unit/SQLStore/EntityStore/IdCacheManagerTest.php
@@ -129,4 +129,22 @@ class IdCacheManagerTest extends \PHPUnit_Framework_TestCase {
 
 	}
 
+	public function testDeleteCacheById() {
+
+		$cache = $this->getMockBuilder( '\Onoi\Cache\Cache' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$cache->expects( $this->once() )
+			->method( 'delete' )
+			->with( $this->equalTo( IdCacheManager::computeSha1( [ 'foo', 0, '', '' ] ) ) );
+
+		$this->caches['entity.id'] = $cache;
+
+		$instance = new IdCacheManager( $this->caches );
+		$instance->setCache( 'foo', 0, '', '', '42', 'bar' );
+
+		$instance->deleteCacheById( 42 );
+	}
+
 }

--- a/tests/phpunit/includes/SQLStore/Writer/DeleteSubjectTest.php
+++ b/tests/phpunit/includes/SQLStore/Writer/DeleteSubjectTest.php
@@ -65,6 +65,10 @@ class DeleteSubjectTest extends \PHPUnit_Framework_TestCase {
 			->method( 'newChangePropListener' )
 			->will( $this->returnValue( $changePropListener ) );
 
+		$propertyTableIdReferenceFinder = $this->getMockBuilder( '\SMW\SQLStore\PropertyTableIdReferenceFinder' )
+			->disableOriginalConstructor()
+			->getMock();
+
 		$propertyTableInfoFetcher = $this->getMockBuilder( '\SMW\SQLStore\PropertyTableInfoFetcher' )
 			->disableOriginalConstructor()
 			->getMock();
@@ -80,6 +84,11 @@ class DeleteSubjectTest extends \PHPUnit_Framework_TestCase {
 		$this->store->expects( $this->any() )
 			->method( 'getPropertyTableInfoFetcher' )
 			->will( $this->returnValue( $propertyTableInfoFetcher ) );
+
+		$this->store->expects( $this->any() )
+			->method( 'service' )
+			->with( $this->equalTo( 'PropertyTableIdReferenceFinder' ) )
+			->will( $this->returnValue( $propertyTableIdReferenceFinder ) );
 
 		$propertyTableRowDiffer = $this->getMockBuilder( '\SMW\SQLStore\PropertyTableRowDiffer' )
 			->disableOriginalConstructor()


### PR DESCRIPTION
This PR is made in reference to: #

This PR addresses or contains:

- When an entity is deleted, check for possible open references and keep the ID in case it has a residual reference by turning it into a simple object instance (setting `smw_rev` and `smw_proptable_hash` to null)

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed
