### PR TITLE
Adds `SMWDIString` as an alias to `SMWDIBlob`

### DIFF
--- a/src/Aliases.php
+++ b/src/Aliases.php
@@ -22,6 +22,7 @@ class_alias( \SMW\DataValues\TypesValue::class, 'SMWTypesValue' );
 class_alias( \SMW\DataValues\PropertyValue::class, 'SMWPropertyValue' );
 class_alias( \SMW\DataValues\StringValue::class, 'SMWStringValue' );
 class_alias( \SMW\MediaWiki\Connection\Database::class, '\SMW\MediaWiki\Database' );
+class_alias( \SMWDIBlob::class, 'SMWDIString' );
 
 // 1.9.
 class_alias( \SMW\Store::class, 'SMWStore' );


### PR DESCRIPTION
This PR is made in reference to: #3426

This PR addresses or contains:
- Adds `SMWDIString` as an alias to `SMWDIBlob`

This PR includes:
- [ ] Tests (unit/integration)
- [x] CI build passed

Fixes #3426