### PR TITLE
Add deprecation notice section

### DIFF
--- a/includes/Settings.php
+++ b/includes/Settings.php
@@ -483,7 +483,7 @@ class Settings extends Options {
 
 		// Deprecated mapping used in DeprecationNoticeTaskHandler to detect and
 		// output notices
-		$GLOBALS['smwgDeprecationNotices'] = array(
+		$GLOBALS['smwgDeprecationNotices']['smw'] = array(
 			'notice' => array(
 				'smwgAdminRefreshStore' => '3.1.0',
 				'smwgQueryDependencyPropertyExemptionlist' => '3.1.0',

--- a/src/MediaWiki/Specials/Admin/DeprecationNoticeTaskHandler.php
+++ b/src/MediaWiki/Specials/Admin/DeprecationNoticeTaskHandler.php
@@ -60,36 +60,25 @@ class DeprecationNoticeTaskHandler extends TaskHandler {
 	 */
 	public function getHtml() {
 
-		$noticeConfigList = array();
-		$replacementConfigList = array();
-		$removedConfigList = array();
+		$html = '';
 
-		if ( isset( $this->deprecationNoticeList['notice'] ) ) {
-			$noticeConfigList = $this->deprecationNoticeList['notice'];
+		// Push `smw` to the top
+		uksort( $this->deprecationNoticeList, function( $a, $b ) {
+			return $b === 'smw';
+		} );
+
+		foreach ( $this->deprecationNoticeList as $section => $deprecationNoticeList ) {
+			$html .= $this->buildSection( $section, $deprecationNoticeList );
 		}
 
-		if ( isset( $this->deprecationNoticeList['replacement'] ) ) {
-			$replacementConfigList = $this->deprecationNoticeList['replacement'];
-		}
-
-		if ( isset( $this->deprecationNoticeList['removal'] ) ) {
-			$removedConfigList = $this->deprecationNoticeList['removal'];
-		}
-
-		$noticeList = $this->buildLIST(
-			$noticeConfigList,
-			$replacementConfigList,
-			$removedConfigList
-		);
-
-		if ( $noticeList === array() ) {
+		if ( $html === '' ) {
 			return '';
 		}
 
 		return Html::rawElement(
 			'div',
 			array(
-				'class' => 'smw-admin-deprecation-notice-section'
+				'class' => 'smw-admin-deprecation'
 			),
 			Html::rawElement(
 				'p',
@@ -97,17 +86,7 @@ class DeprecationNoticeTaskHandler extends TaskHandler {
 					'class' => 'plainlinks'
 				),
 				$this->msg( 'smw-admin-deprecation-notice-docu' )
-			) . Html::rawElement(
-					'div',
-					array(
-						'class' => 'plainlinks'
-				),
-				Html::rawElement(
-					'p',
-					[],
-					implode( '', $noticeList )
-				)
-			)
+			) . $html
 		);
 	}
 
@@ -125,7 +104,56 @@ class DeprecationNoticeTaskHandler extends TaskHandler {
 	 */
 	public function handleRequest( WebRequest $webRequest ) {}
 
-	private function buildLIST( $noticeConfigList, $replacementConfigList, $removedConfigList ) {
+	private function buildSection( $section, $deprecationNoticeList ) {
+
+		$noticeConfigList = array();
+		$replacementConfigList = array();
+		$removedConfigList = array();
+		$html = '';
+
+		if ( isset( $deprecationNoticeList['notice'] ) ) {
+			$noticeConfigList = $deprecationNoticeList['notice'];
+		}
+
+		if ( isset( $deprecationNoticeList['replacement'] ) ) {
+			$replacementConfigList = $deprecationNoticeList['replacement'];
+		}
+
+		if ( isset( $deprecationNoticeList['removal'] ) ) {
+			$removedConfigList = $deprecationNoticeList['removal'];
+		}
+
+		$sectionList = $this->build_list(
+			$section,
+			$noticeConfigList,
+			$replacementConfigList,
+			$removedConfigList
+		);
+
+		if ( $sectionList === [] ) {
+			return '';
+		}
+
+		if ( $section !== 'smw' ) {
+			$html .= Html::rawElement(
+			'h2',
+				[
+					'class' => "$section-admin-deprecation-notice-section"
+				],
+				$this->msg( "$section-admin-deprecation-notice-section" )
+			);
+		}
+
+		return Html::rawElement(
+			'div',
+			[
+				'class' => "$section-admin-deprecation-section"
+			],
+			$html . implode( '', $sectionList )
+		);
+	}
+
+	private function build_list( $section, $noticeConfigList, $replacementConfigList, $removedConfigList ) {
 
 		$noticeList = [];
 		$list = array();
@@ -133,44 +161,44 @@ class DeprecationNoticeTaskHandler extends TaskHandler {
 		// Replacements
 		foreach ( $replacementConfigList as $setting => $value ) {
 			if ( $setting === 'options' ) {
-				$list[] = $this->createListItems( 'smw-admin-deprecation-notice-config-replacement', $value );
+				$list[] = $this->createListItems( "$section-admin-deprecation-notice-config-replacement", $value );
 			} elseif ( isset( $GLOBALS[$setting] ) ) {
-				$list[] = $this->createListItem( array( 'smw-admin-deprecation-notice-config-replacement', '$' . $setting, '$' . $value ) );
+				$list[] = $this->createListItem( array( "$section-admin-deprecation-notice-config-replacement", '$' . $setting, '$' . $value ) );
 			}
 		}
 
-		if ( $list !== [] && ( $mList = $this->mergeList( 'smw-admin-deprecation-notice-title-replacement', $list ) ) !== null ) {
+		if ( $list !== [] && ( $mList = $this->mergeList( "$section-admin-deprecation-notice-title-replacement", $section, $list ) ) !== null ) {
 			$noticeList[] = $mList;
 		}
 
 		// Changes
 		foreach ( $noticeConfigList as $setting => $value ) {
 			if ( $setting === 'options' ) {
-				$list[] = $this->createListItems( 'smw-admin-deprecation-notice-config-notice', $value );
+				$list[] = $this->createListItems( "$section-admin-deprecation-notice-config-notice", $value );
 			} elseif ( isset( $GLOBALS[$setting] ) ) {
-				$list[] = $this->createListItem( array( 'smw-admin-deprecation-notice-config-notice', '$' . $setting, $value ) );
+				$list[] = $this->createListItem( array( "$section-admin-deprecation-notice-config-notice", '$' . $setting, $value ) );
 			}
 		}
 
-		if ( $list !== [] && ( $mList = $this->mergeList( 'smw-admin-deprecation-notice-title-notice', $list ) ) !== null ) {
+		if ( $list !== [] && ( $mList = $this->mergeList( "$section-admin-deprecation-notice-title-notice", $section, $list ) ) !== null ) {
 			$noticeList[] = $mList;
 		}
 
 		// Removals
 		foreach ( $removedConfigList as $setting => $msg ) {
 			if ( isset( $GLOBALS[$setting] ) ) {
-				$list[] = $this->createListItem( array( 'smw-admin-deprecation-notice-config-removal', '$' . $setting, $msg ) );
+				$list[] = $this->createListItem( array( "$section-admin-deprecation-notice-config-removal", '$' . $setting, $msg ) );
 			}
 		}
 
-		if ( $list !== [] && ( $mList = $this->mergeList( 'smw-admin-deprecation-notice-title-removal', $list ) ) !== null ) {
+		if ( $list !== [] && ( $mList = $this->mergeList( "$section-admin-deprecation-notice-title-removal", $section, $list ) ) !== null ) {
 			$noticeList[] = $mList;
 		}
 
 		return $noticeList;
 	}
 
-	private function mergeList( $title, &$list ) {
+	private function mergeList( $title, $section, &$list ) {
 
 		if ( $list === array() || ( $items = implode( '', $list ) ) === '' ) {
 			return;
@@ -183,7 +211,7 @@ class DeprecationNoticeTaskHandler extends TaskHandler {
 		) . Html::rawElement(
 			'p',
 			[
-				'class' => 'smw-admin-deprecation-notice-section-explanation',
+				'class' => "$section-admin-deprecation-notice-section-explanation",
 				'style' => 'margin-bottom:10px;'
 			],
 			$this->msg( $title . '-explanation' )

--- a/tests/phpunit/Unit/MediaWiki/Specials/Admin/DeprecationNoticeTaskHandlerTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Specials/Admin/DeprecationNoticeTaskHandlerTest.php
@@ -60,7 +60,7 @@ class DeprecationNoticeTaskHandlerTest extends \PHPUnit_Framework_TestCase {
 		$GLOBALS['deprecationNoticeFoobar'] = 'Foo';
 		$GLOBALS['deprecationNoticeFooFoo'] = 'Foo';
 
-		$deprecationNotice = array(
+		$deprecationNotice['smw'] = array(
 			'notice' => array(
 				'deprecationNoticeFoo' => '...',
 				'options' => [
@@ -101,7 +101,7 @@ class DeprecationNoticeTaskHandlerTest extends \PHPUnit_Framework_TestCase {
 		$GLOBALS['deprecationNoticeFoobar'] = 'Foo';
 		$GLOBALS['deprecationNoticeFooFoo'] = 'Foo';
 
-		$deprecationNotice = array(
+		$deprecationNotice['smw'] = array(
 			'notice' => array(
 				'deprecationNoticeFoo' => '...',
 				'options' => [
@@ -130,8 +130,8 @@ class DeprecationNoticeTaskHandlerTest extends \PHPUnit_Framework_TestCase {
 			$deprecationNotice
 		);
 
-		$this->assertInternalType(
-			'string',
+		$this->assertContains(
+			'<div class="smw-admin-deprecation">',
 			$instance->getHtml()
 		);
 	}


### PR DESCRIPTION
This PR is made in reference to: #

This PR addresses or contains:

- Extends the notice list with a section to enable extensions to add their own list. For example, `$GLOBALS['smwgDeprecationNotices']['sbl'] = [ 'replacement' => $deprecationNotices['replacement'] ];` where the `sbl` section identifies the block and is matched to a pool of predefined message keys that need to be added to the relevant extension that makes use of the notice list.
- `$GLOBALS['smwgDeprecationNotices']['smw']` is reserved for SMW-core

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed

### Example 

![image](https://user-images.githubusercontent.com/1245473/45590336-b7993600-b925-11e8-89ab-0635779350fa.png)
