### PR TITLE
Property page, move usage count display to tab

### DIFF
--- a/res/smw/ext.smw.page.css
+++ b/res/smw/ext.smw.page.css
@@ -304,6 +304,37 @@
 	display: none;
 }
 
+.usage-count, .item-count {
+	display: inline-block;
+    padding: 2px 5px;
+    font-size: 12px;
+    font-weight: 600;
+    line-height: 1;
+    background-color: rgba(27,31,35,0.04);
+    border-radius: 4px;
+    color: #bbb;
+    margin-left: 10px;
+}
+
+#tab-smw-property-value:checked + label.nav-label .usage-count,
+#tab-smw-property-subp:checked + label.nav-label .item-count,
+#tab-smw-property-errp:checked + label.nav-label .item-count,
+#tab-smw-property-redi:checked + label.nav-label .item-count,
+#tab-smw-property-spec:checked + label.nav-label .item-count {
+    background-color: rgba(27,31,35,0.08);
+    color: #444d56;
+}
+
+#tab-smw-property-value:checked + label.nav-label .usage-count.moderate {
+    background-color: rgba(43,157,239,0.18);
+    color: #444d56;
+}
+
+#tab-smw-property-value:checked + label.nav-label .usage-count.high {
+    background-color: rgba(186,0,0,0.16);
+    color: #444d56;
+}
+
 /**
  * Tabs
  */

--- a/src/Page/ListBuilder/ListBuilder.php
+++ b/src/Page/ListBuilder/ListBuilder.php
@@ -48,6 +48,11 @@ class ListBuilder {
 	private $checkProperty = true;
 
 	/**
+	 * @var integer
+	 */
+	private $itemCount = 0;
+
+	/**
 	 * @since 3.0
 	 *
 	 * @param Store $store
@@ -104,6 +109,15 @@ class ListBuilder {
 	/**
 	 * @since 3.0
 	 *
+	 * @return integer
+	 */
+	public function getItemCount() {
+		return $this->itemCount;
+	}
+
+	/**
+	 * @since 3.0
+	 *
 	 * @param DIProperty $property
 	 * @param DataItem $dataItem
 	 * @param RequestOptions $requestOptions
@@ -132,10 +146,10 @@ class ListBuilder {
 		}
 
 		$result = '';
-		$resultCount = is_array( $subjectList ) ? count( $subjectList ) : 0;
+		$this->itemCount = is_array( $subjectList ) ? count( $subjectList ) : 0;
 
 		$callback = null;
-		$message = wfMessage( 'smw-propertylist-count', $resultCount )->text();
+		$message = wfMessage( 'smw-propertylist-count', $this->itemCount )->text();
 
 		if ( $more ) {
 			$callback = function() use ( $property, $dataItem ) {
@@ -151,20 +165,20 @@ class ListBuilder {
 				);
 			};
 
-			$message = wfMessage( 'smw-propertylist-count-more-available', $resultCount )->text();
+			$message = wfMessage( 'smw-propertylist-count-more-available', $this->itemCount )->text();
 		}
 
-		if ( $resultCount > 0 ) {
+		if ( $this->itemCount > 0 ) {
 			$titleText = htmlspecialchars( str_replace( '_', ' ', $dataItem->getDBKey() ) );
 			$result .= "<div id=\"{$this->listHeader}\">" . "\n<p>";
 
 			$result .= $message . "</p>";
 			$property = $this->checkProperty ? $property : null;
 
-			if ( $resultCount < 6 ) {
-				$result .= PageLister::getShortList( 0, $resultCount, $subjectList, $property, $callback );
+			if ( $this->itemCount < 6 ) {
+				$result .= PageLister::getShortList( 0, $this->itemCount, $subjectList, $property, $callback );
 			} else {
-				$result .= PageLister::getColumnList( 0, $resultCount, $subjectList, $property, $callback );
+				$result .= PageLister::getColumnList( 0, $this->itemCount, $subjectList, $property, $callback );
 			}
 
 			$result .= "\n</div>";

--- a/src/Page/PropertyPage.php
+++ b/src/Page/PropertyPage.php
@@ -112,61 +112,6 @@ class PropertyPage extends Page {
 	}
 
 	/**
-	 * @see Page::getTopIndicators
-	 *
-	 * @since 3.0
-	 *
-	 * @return string
-	 */
-	protected function getTopIndicators() {
-
-		if ( !$this->store->getRedirectTarget( $this->property )->equals( $this->property ) ) {
-			return '';
-		}
-
-		// Label that corresponds to the display and sort characteristics
-		$searchLabel = $this->property->isUserDefined() ? $this->propertyValue->getSearchLabel() : $this->property->getCanonicalLabel();
-		$usageCountHtml = '';
-
-		$requestOptions = new RequestOptions();
-		$requestOptions->setLimit( 1 );
-		$requestOptions->addStringCondition( $searchLabel, StringCondition::COND_EQ );
-
-		$cachedLookupList = $this->store->getPropertiesSpecial( $requestOptions );
-		$usageList = $cachedLookupList->fetchList();
-
-		if ( $usageList && $usageList !== array() ) {
-
-			$usage = end( $usageList );
-			$usageCount = $usage[1];
-			$date = $this->getContext()->getLanguage()->timeanddate( $cachedLookupList->getTimestamp() );
-
-			$countMsg = Message::get( array( 'smw-property-indicator-last-count-update', $date ) );
-			$indicatorClass = ( $usageCount < 25000 ? ( $usageCount > 5000 ? ' moderate' : '' ) : ' high' );
-
-			$usageCountHtml = Html::rawElement(
-				'div', array(
-					'title' => $countMsg,
-					'class' => 'smw-page-indicator usage-count' . $indicatorClass ),
-				$usageCount
-			);
-		}
-
-		$type = Html::rawElement(
-				'div',
-				array(
-					'class' => 'smw-page-indicator property-type',
-					'title' => Message::get( array( 'smw-property-indicator-type-info', $this->property->isUserDefined() ), Message::PARSE )
-			), ( $this->property->isUserDefined() ? 'U' : 'S' )
-		);
-
-		return array(
-			'smw-prop-count' => $usageCountHtml,
-			'smw-prop-type' => $type
-		);
-	}
-
-	/**
 	 * @see Page::getRedirectTargetURL
 	 *
 	 * @since 3.0
@@ -244,28 +189,28 @@ class PropertyPage extends Page {
 		$html = $this->makeValueList( $languageCode );
 		$isFirst = $html === '';
 
-		$htmlTabs->tab( 'smw-property-value', $this->msg( 'smw-property-tab-usage' ), [ 'hide' => $html === '' ] );
+		$htmlTabs->tab( 'smw-property-value', $this->msg( 'smw-property-tab-usage' ) . $this->getUsageCount(), [ 'hide' => $html === '' ] );
 		$htmlTabs->content( 'smw-property-value', $html );
 
 		// Redirects
-		$html = $this->makeList( 'redirect', '_REDI', true );
+		list( $html, $itemCount ) = $this->makeList( 'redirect', '_REDI', true );
 		$isFirst = $isFirst && $html === '';
 
-		$htmlTabs->tab( 'smw-property-redi', $this->msg( 'smw-property-tab-redirects' ), [ 'hide' => $html === '' ] );
+		$htmlTabs->tab( 'smw-property-redi', $this->msg( 'smw-property-tab-redirects' ) . $itemCount, [ 'hide' => $html === '' ] );
 		$htmlTabs->content( 'smw-property-redi', $html );
 
 		// Subproperties
-		$html = $this->makeList( 'subproperty', '_SUBP', true );
+		list( $html, $itemCount ) = $this->makeList( 'subproperty', '_SUBP', true );
 		$isFirst = $isFirst && $html === '';
 
-		$htmlTabs->tab( 'smw-property-subp', $this->msg( 'smw-property-tab-subproperties' ),  [ 'hide' => $html === '' ] );
+		$htmlTabs->tab( 'smw-property-subp', $this->msg( 'smw-property-tab-subproperties' ) . $itemCount,  [ 'hide' => $html === '' ] );
 		$htmlTabs->content( 'smw-property-subp', $html );
 
 		// Improperty values
-		$html = $this->makeList( 'error', '_ERRP', false );
+		list( $html, $itemCount ) = $this->makeList( 'error', '_ERRP', false );
 		$isFirst = $isFirst && $html === '';
 
-		$htmlTabs->tab( 'smw-property-errp', $this->msg( 'smw-property-tab-errors' ), [ 'hide' => $html === '', 'class' => 'smw-tab-warning' ] );
+		$htmlTabs->tab( 'smw-property-errp', $this->msg( 'smw-property-tab-errors' ) . $itemCount, [ 'hide' => $html === '', 'class' => 'smw-tab-warning' ] );
 		$htmlTabs->content( 'smw-property-errp', $html );
 
 		if ( isset( $matches[2] ) && $matches[2] !== [] ) {
@@ -312,7 +257,7 @@ class PropertyPage extends Page {
 
 		// Ignore the list when a filter is present
 		if ( $this->getContext()->getRequest()->getVal( 'filter', '' ) !== '' ) {
-			return '';
+			return [ '', '' ];
 		}
 
 		$propertyListLimit = $this->getOption( 'smwgPropertyListLimit' );
@@ -339,11 +284,21 @@ class PropertyPage extends Page {
 			$checkProperty
 		);
 
-		return $this->listBuilder->createHtml(
+		$html = $this->listBuilder->createHtml(
 			new DIProperty( $propertyKey ),
 			$this->getDataItem(),
 			$requestOptions
 		);
+
+		$itemCount = Html::rawElement(
+			'span',
+			[
+				'class' => 'item-count'
+			],
+			$this->listBuilder->getItemCount()
+		);
+
+		return [ $html, $itemCount ];
 	}
 
 	private function makeValueList( $languageCode ) {
@@ -381,6 +336,43 @@ class PropertyPage extends Page {
 
 	private function msg( $params, $type = Message::TEXT, $lang = Message::USER_LANGUAGE ) {
 		return Message::get( $params, $type, $lang );
+	}
+
+	private function getUsageCount() {
+
+		// Label that corresponds to the display and sort characteristics
+		if ( $this->property->isUserDefined() ) {
+			$searchLabel = $this->propertyValue->getSearchLabel();
+		} else {
+			$searchLabel = $this->property->getCanonicalLabel();
+		}
+
+		$requestOptions = new RequestOptions();
+		$requestOptions->setLimit( 1 );
+		$requestOptions->addStringCondition( $searchLabel, StringCondition::COND_EQ );
+
+		$cachedLookupList = $this->store->getPropertiesSpecial( $requestOptions );
+		$usageList = $cachedLookupList->fetchList();
+
+		if ( !$usageList || $usageList === [] ) {
+			return '';
+		}
+
+		$usage = end( $usageList );
+		$usageCount = $usage[1];
+		$date = $this->getContext()->getLanguage()->timeanddate( $cachedLookupList->getTimestamp() );
+
+		$countMsg = Message::get( array( 'smw-property-indicator-last-count-update', $date ) );
+		$indicatorClass = ( $usageCount < 25000 ? ( $usageCount > 5000 ? ' moderate' : '' ) : ' high' );
+
+		return Html::rawElement(
+			'span',
+			[
+				'title' => $countMsg,
+				'class' => 'usage-count'  . $indicatorClass
+			],
+			$usageCount
+		);
 	}
 
 }


### PR DESCRIPTION
This PR is made in reference to: #

This PR addresses or contains:

- Moves the count display from the top indicator to an individual tab

This PR includes:
- [ ] Tests (unit/integration)
- [x] CI build passed

### Example

![image](https://user-images.githubusercontent.com/1245473/45595573-a7bd3880-b99d-11e8-8d26-ae99896a6b29.png)

