### PR TITLE
rebuildData.php add "--revision-mode", refs 1698, 3390

### DIFF
--- a/includes/storage/SQLStore/SMW_Sql3SmwIds.php
+++ b/includes/storage/SQLStore/SMW_Sql3SmwIds.php
@@ -740,6 +740,31 @@ class SMWSql3SmwIds {
 	/**
 	 * @since 3.0
 	 *
+	 * @param string $title
+	 * @param integer $namespace
+	 * @param string $iw
+	 */
+	public function findAssociatedRev( $title, $namespace, $iw = '' ) {
+		$connection = $this->store->getConnection( 'mw.db' );
+
+		$row = $connection->selectRow(
+			self::TABLE_NAME,
+			'smw_rev',
+			[
+				"smw_title =" . $connection->addQuotes( $title ),
+				"smw_namespace =" . $connection->addQuotes( $namespace ),
+				"smw_iw =" . $connection->addQuotes( $iw ),
+				"smw_subobject =''"
+			],
+			__METHOD__
+		);
+
+		return $row === false ? 0 : $row->smw_rev;
+	}
+
+	/**
+	 * @since 3.0
+	 *
 	 * @param integer $sid
 	 * @param integer $sid
 	 */

--- a/maintenance/rebuildData.php
+++ b/maintenance/rebuildData.php
@@ -90,8 +90,11 @@ class RebuildData extends \Maintenance {
 		$this->addOption( 'dispose-outdated', 'Only Remove outdated marked entities (including pending references).', false );
 
 		$this->addOption( 'skip-properties', 'Skip the default properties rebuild (only recommended when successive build steps are used)', false );
-		$this->addOption( 'shallow-update', 'Skip processing of entitites that compare to the last known revision date', false );
+		$this->addOption( 'shallow-update', 'Skip processing of entities that compare to the last known revision date', false );
 		$this->addOption( 'property-statistics', 'Execute `rebuildPropertyStatistics` after the `rebuildData` run has finished.', false );
+
+		$this->addOption( 'force-update', 'Force an update even when an associated revision is known', false );
+		$this->addOption( 'revision-mode', 'Skip entities where its associated revision matches the latests referenced revision of an associated page', false );
 
 		$this->addOption( 'ignore-exceptions', 'Ignore exceptions and log exception to a file', false );
 		$this->addOption( 'exception-log', 'Exception log file location (e.g. /tmp/logs/)', false, true );

--- a/src/Maintenance/DataRebuilder.php
+++ b/src/Maintenance/DataRebuilder.php
@@ -254,6 +254,7 @@ class DataRebuilder {
 			[
 				'shallow-update' => $this->options->safeGet( 'shallow-update', false ),
 				'force-update' => $this->options->safeGet( 'force-update', false ),
+				'revision-mode' => $this->options->safeGet( 'revision-mode', false ),
 				'use-job' => false
 			]
 		);

--- a/tests/phpunit/Integration/JSONScript/TestCases/s-0006.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/s-0006.json
@@ -1,9 +1,17 @@
 {
-	"description": "Test output of `Special:WantedProperties` (`wgContLang=en`, `wgLang=en`, skip-on sqlite, 1.19)",
+	"description": "Test output of `Special:WantedProperties` (`wgContLang=en`, `wgLang=en`, skip-on sqlite)",
 	"setup": [
 		{
 			"page": "Example/S0006/1",
 			"contents": "[[Has property without type::123]]"
+		},
+		{
+			"page": "Example/S0006/2",
+			"contents": "[[Has property without type::456]]"
+		},
+		{
+			"page": "Example/S0006/3",
+			"contents": "[[Has property without type::789]]"
 		}
 	],
 	"beforeTest": {
@@ -33,8 +41,7 @@
 	},
 	"meta": {
 		"skip-on": {
-			"sqlite": "Returns a `database is locked`",
-			"mw-1.19.20": "The table update on 1.19 lacks behind"
+			"sqlite": "Returns a `database is locked`"
 		},
 		"version": "2",
 		"is-incomplete": false,

--- a/tests/phpunit/Unit/SQLStore/EntityRebuildDispatcherTest.php
+++ b/tests/phpunit/Unit/SQLStore/EntityRebuildDispatcherTest.php
@@ -129,6 +129,67 @@ class EntityRebuildDispatcherTest extends \PHPUnit_Framework_TestCase {
 		);
 	}
 
+	public function testRevisionMode() {
+
+		$row = [
+			'smw_id' => 9999999999999999,
+			'smw_title' => 'Foo',
+			'smw_namespace' => 0,
+			'smw_iw' => '',
+			'smw_subobject' => '',
+			'smw_proptable_hash' => [],
+			'smw_rev' => 0
+		];
+
+		$idTable = $this->getMockBuilder( '\SMWSql3SmwIds' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$idTable->expects( $this->any() )
+			->method( 'findAssociatedRev' )
+			->will( $this->returnValue( 1001 ) );
+
+		$connection = $this->getMockBuilder( '\SMW\MediaWiki\Database' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$connection->expects( $this->atLeastOnce() )
+			->method( 'select' )
+			->will( $this->returnValue( [ (object)$row] ) );
+
+		$connection->expects( $this->any() )
+			->method( 'selectField' )
+			->will( $this->returnValue( 500 ) );
+
+		$store = $this->getMockBuilder( '\SMW\SQLStore\SQLStore' )
+			->disableOriginalConstructor()
+			->setMethods( array( 'getConnection', 'getObjectIds' ) )
+			->getMock();
+
+		$store->expects( $this->any() )
+			->method( 'getConnection' )
+			->will( $this->returnValue( $connection ) );
+
+		$store->expects( $this->any() )
+			->method( 'getObjectIds' )
+			->will( $this->returnValue( $idTable ) );
+
+		$instance = new EntityRebuildDispatcher( $store );
+
+		$instance->setDispatchRangeLimit( 1 );
+		$instance->setOptions(
+			[
+				'revision-mode' => true,
+				'force-update' => false,
+				'use-job' => false
+			]
+		);
+
+		$id = 999999999;
+
+		$instance->rebuild( $id );
+	}
+
 	public function idProvider() {
 
 		$provider[] = array(

--- a/tests/phpunit/includes/storage/sqlstore/SQLStoreSmwIdsTest.php
+++ b/tests/phpunit/includes/storage/sqlstore/SQLStoreSmwIdsTest.php
@@ -451,6 +451,66 @@ class SQLStoreSmwIdsTest extends \PHPUnit_Framework_TestCase {
 		$instance->warmUpCache( [ new DIWikiPage( 'Bar', NS_MAIN ) ] );
 	}
 
+	public function testFindAssociatedRev() {
+
+		$row = [
+			'smw_id' => 42,
+			'smw_title' => 'Foo',
+			'smw_namespace' => 0,
+			'smw_iw' => '',
+			'smw_subobject' => '',
+			'smw_sortkey' => 'Foo',
+			'smw_sort' => '',
+			'smw_rev' => 1001,
+		];
+
+		$idCacheManager = $this->getMockBuilder( '\SMW\SQLStore\EntityStore\IdCacheManager' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$idCacheManager->expects( $this->any() )
+			->method( 'get' )
+			->will( $this->returnValue( $this->cache ) );
+
+		$factory = $this->getMockBuilder( '\SMW\SQLStore\SQLStoreFactory' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$factory->expects( $this->any() )
+			->method( 'newIdCacheManager' )
+			->will( $this->returnValue( $idCacheManager ) );
+
+		$factory->expects( $this->any() )
+			->method( 'newIdEntityFinder' )
+			->will( $this->returnValue( $this->idEntityFinder ) );
+
+		$connection = $this->getMockBuilder( '\SMW\MediaWiki\Database' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$connection->expects( $this->once() )
+			->method( 'selectRow' )
+			->will( $this->returnValue( (object)$row ) );
+
+		$store = $this->getMockBuilder( '\SMW\SQLStore\SQLStore' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$store->expects( $this->any() )
+			->method( 'getConnection' )
+			->will( $this->returnValue( $connection ) );
+
+		$instance = new SMWSql3SmwIds(
+			$store,
+			$factory
+		);
+
+		$this->assertEquals(
+			1001,
+			$instance->findAssociatedRev( 'Foo', NS_MAIN, '', '' )
+		);
+	}
+
 	public function pageIdandSortProvider() {
 
 		$provider[] = array( 'Foo', NS_MAIN, '' , '', 'FOO', false, false );


### PR DESCRIPTION
This PR is made in reference to: #1698, #3390

This PR addresses or contains:

- #3390 tracks the revision ID for an associated entity hereby allows to identify which content elements in MW relates to the annotation body created in SMW
- Running in  "--revision-mode" will use the revision information and compares the latest title/page revision ID with that of the associated revision ID in SMW hereby allowing to make some assumptions about the content state including:
  - If both revision IDs match then it is assumed that no content divergence occurred.
  - The wiki content (including those embedded annotations) should match on what is stored in SMW for that particular entity.
  - As a result, further processing (especially the parsing of content which is the most costly operation during a data rebuild) of that entity is skipped.
- Skipping the processing of entities where no content divergence is expected should speed-up the rebuild process.
- "--force-update" is added as additional parameter to "force" an update under any circumstance 

This PR includes:
- [ ] Tests (unit/integration)
- [x] CI build passed

Fixes #1698