### PR TITLE
Move jobs from `SMW\\` to `smw.`

### DIFF
--- a/DefaultSettings.php
+++ b/DefaultSettings.php
@@ -858,10 +858,10 @@ return array(
 	# To make this feature available, assign a simple list to the setting as in:
 	#
 	# $GLOBALS['smwgJobQueueWatchlist'] = [
-	#	'SMW\UpdateJob',
-	#	'SMW\ParserCachePurgeJob',
-	#	'SMW\FulltextSearchTableUpdateJob',
-	#	'SMW\ChangePropagationUpdateJob'
+	#	'smw.update',
+	#	'smw.parserCachePurge',
+	#	'smw.fulltextSearchTableUpdate',
+	#	'smw.changePropagationUpdate'
 	# ]
 	#
 	# Information are not displayed unless a user enables the setting in his or
@@ -1313,8 +1313,8 @@ return array(
 	##
 	'smwgPostEditUpdate' => [
 		'job.task' => [
-			'SMW\FulltextSearchTableUpdateJob' => 1,
-			'SMW\ParserCachePurgeJob' => 5
+			'smw.fulltextSearchTableUpdate' => 1,
+			'smw.parserCachePurge' => 5
 		]
 	],
 	##

--- a/includes/Settings.php
+++ b/includes/Settings.php
@@ -481,6 +481,15 @@ class Settings extends Options {
 			$configuration['smwgMainCacheType'] = $GLOBALS['smwgCacheType'];
 		}
 
+		$jobQueueWatchlist = [];
+
+		// FIXME Remove with 3.1
+		foreach ( $GLOBALS['smwgJobQueueWatchlist'] as $job ) {
+			if ( strpos( $job, 'SMW\\' ) !== false ) {
+				$jobQueueWatchlist[$job] = \SMW\MediaWiki\JobQueue::mapLegacyType( $job );
+			}
+		}
+
 		// Deprecated mapping used in DeprecationNoticeTaskHandler to detect and
 		// output notices
 		$GLOBALS['smwgDeprecationNotices']['smw'] = array(
@@ -574,7 +583,7 @@ class Settings extends Options {
 						'smwgQueryDurationEnabled' => 'SMW_QPRFL_DUR',
 						'smwgQueryParametersEnabled' => 'SMW_QPRFL_PARAMS'
 					]
-				]
+				] + ( $jobQueueWatchlist !== [] ? [ 'smwgJobQueueWatchlist' => $jobQueueWatchlist ] : [] )
 			),
 			'removal' => array(
 				'smwgOnDeleteAction' => '2.4.0',

--- a/includes/Setup.php
+++ b/includes/Setup.php
@@ -311,6 +311,22 @@ final class Setup {
 	private function registerJobClasses( &$vars ) {
 
 		$jobClasses = array(
+
+			'smw.update' => 'SMW\MediaWiki\Jobs\UpdateJob',
+			'smw.refresh' => 'SMW\MediaWiki\Jobs\RefreshJob',
+			'smw.updateDispatcher' => 'SMW\MediaWiki\Jobs\UpdateDispatcherJob',
+			'smw.parserCachePurge' => 'SMW\MediaWiki\Jobs\ParserCachePurgeJob',
+			'smw.fulltextSearchTableUpdate' => 'SMW\MediaWiki\Jobs\FulltextSearchTableUpdateJob',
+			'smw.entityIdDisposer' => 'SMW\MediaWiki\Jobs\EntityIdDisposerJob',
+			'smw.propertyStatisticsRebuild' => 'SMW\MediaWiki\Jobs\PropertyStatisticsRebuildJob',
+			'smw.fulltextSearchTableRebuild' => 'SMW\MediaWiki\Jobs\FulltextSearchTableRebuildJob',
+			'smw.changePropagationDispatch' => 'SMW\MediaWiki\Jobs\ChangePropagationDispatchJob',
+			'smw.changePropagationUpdate' => 'SMW\MediaWiki\Jobs\ChangePropagationUpdateJob',
+			'smw.changePropagationClassUpdate' => 'SMW\MediaWiki\Jobs\ChangePropagationClassUpdateJob',
+			'smw.elasticIndexerRecovery' => 'SMW\Elastic\Indexer\IndexerRecoveryJob',
+			'smw.elasticFileIngest' => 'SMW\Elastic\Indexer\FileIngestJob',
+
+			// Legacy 3.0-
 			'SMW\UpdateJob' => 'SMW\MediaWiki\Jobs\UpdateJob',
 			'SMW\RefreshJob' => 'SMW\MediaWiki\Jobs\RefreshJob',
 			'SMW\UpdateDispatcherJob' => 'SMW\MediaWiki\Jobs\UpdateDispatcherJob',
@@ -322,10 +338,8 @@ final class Setup {
 			'SMW\ChangePropagationDispatchJob' => 'SMW\MediaWiki\Jobs\ChangePropagationDispatchJob',
 			'SMW\ChangePropagationUpdateJob' => 'SMW\MediaWiki\Jobs\ChangePropagationUpdateJob',
 			'SMW\ChangePropagationClassUpdateJob' => 'SMW\MediaWiki\Jobs\ChangePropagationClassUpdateJob',
-			'smw.elasticIndexerRecovery' => 'SMW\Elastic\Indexer\IndexerRecoveryJob',
-			'smw.elasticFileIngest' => 'SMW\Elastic\Indexer\FileIngestJob',
 
-			// Legacy definition to be removed with 1.10
+			// Legacy 2.0-
 			'SMWUpdateJob'  => 'SMW\MediaWiki\Jobs\UpdateJob',
 			'SMWRefreshJob' => 'SMW\MediaWiki\Jobs\RefreshJob'
 		);

--- a/src/ApplicationFactory.php
+++ b/src/ApplicationFactory.php
@@ -321,9 +321,10 @@ class ApplicationFactory {
 		$mwCollaboratorFactory = $this->newMwCollaboratorFactory();
 
 		$linksProcessor = $this->containerBuilder->create( 'LinksProcessor' );
+		$settings = $this->getSettings();
 
 		$linksProcessor->isStrictMode(
-			$this->getSettings()->isFlagSet( 'smwgParserFeatures', SMW_PARSER_STRICT )
+			$settings->isFlagSet( 'smwgParserFeatures', SMW_PARSER_STRICT )
 		);
 
 		$inTextAnnotationParser = new InTextAnnotationParser(
@@ -334,11 +335,11 @@ class ApplicationFactory {
 		);
 
 		$inTextAnnotationParser->isLinksInValues(
-			$this->getSettings()->isFlagSet( 'smwgParserFeatures', SMW_PARSER_LINV )
+			$settings->isFlagSet( 'smwgParserFeatures', SMW_PARSER_LINV )
 		);
 
 		$inTextAnnotationParser->showErrors(
-			$this->getSettings()->isFlagSet( 'smwgParserFeatures', SMW_PARSER_INL_ERROR )
+			$settings->isFlagSet( 'smwgParserFeatures', SMW_PARSER_INL_ERROR )
 		);
 
 		return $inTextAnnotationParser;

--- a/src/Elastic/Indexer/FileIngestJob.php
+++ b/src/Elastic/Indexer/FileIngestJob.php
@@ -3,10 +3,11 @@
 namespace SMW\Elastic\Indexer;
 
 use SMW\ApplicationFactory;
-use SMW\DIWikiPage;
-use SMW\Elastic\Connection\Client as ElasticClient;
+use SMW\MediaWiki\Job;
 use SMW\Elastic\ElasticFactory;
-use SMW\MediaWiki\Jobs\JobBase;
+use SMW\Elastic\Connection\Client as ElasticClient;
+use SMW\SQLStore\ChangeOp\ChangeDiff;
+use SMW\DIWikiPage;
 use Title;
 
 /**
@@ -15,7 +16,7 @@ use Title;
  *
  * @author mwjames
  */
-class FileIngestJob extends JobBase {
+class FileIngestJob extends Job {
 
 	/**
 	 * @since 3.0

--- a/src/Elastic/Indexer/IndexerRecoveryJob.php
+++ b/src/Elastic/Indexer/IndexerRecoveryJob.php
@@ -4,9 +4,9 @@ namespace SMW\Elastic\Indexer;
 
 use SMW\ApplicationFactory;
 use SMW\DIWikiPage;
+use SMW\MediaWiki\Job;
 use SMW\Elastic\Connection\Client as ElasticClient;
 use SMW\Elastic\ElasticFactory;
-use SMW\MediaWiki\Jobs\JobBase;
 use SMW\SQLStore\ChangeOp\ChangeDiff;
 use Title;
 
@@ -16,7 +16,7 @@ use Title;
  *
  * @author mwjames
  */
-class IndexerRecoveryJob extends JobBase {
+class IndexerRecoveryJob extends Job {
 
 	/**
 	 * @since 3.0

--- a/src/MediaWiki/Hooks/ArticleDelete.php
+++ b/src/MediaWiki/Hooks/ArticleDelete.php
@@ -118,7 +118,7 @@ class ArticleDelete extends HookHandler {
 		);
 
 		$jobQueue = $applicationFactory->getJobQueue();
-		$jobQueue->runFromQueue( [ 'SMW\ParserCachePurgeJob' => 2 ] );
+		$jobQueue->runFromQueue( [ 'smw.parserCachePurge' => 2 ] );
 	}
 
 }

--- a/src/MediaWiki/Hooks/UserChange.php
+++ b/src/MediaWiki/Hooks/UserChange.php
@@ -13,9 +13,8 @@ use User;
  * @see https://www.mediawiki.org/wiki/Manual:Hooks/UnblockUserComplete
  * @see https://www.mediawiki.org/wiki/Manual:Hooks/UserGroupsChanged
  *
- * Act on events that happen outside of the normal parser process and hereby
- * ensures that updates of pre-defined properties related to a user status can
- * be detected.
+ * Act on events that happen outside of the normal parser process to ensure that
+ * changes to pre-defined properties related to a user status can be invoked.
  *
  * @license GNU GPL v2+
  * @since 3.0

--- a/src/MediaWiki/Job.php
+++ b/src/MediaWiki/Job.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace SMW\MediaWiki\Jobs;
+namespace SMW\MediaWiki;
 
-use Job;
+use Job as MediaWikiJob;
 use JobQueueGroup;
 use SMW\ApplicationFactory;
 use SMW\Site;
@@ -17,7 +17,7 @@ use Title;
  *
  * @author mwjames
  */
-abstract class JobBase extends Job {
+abstract class Job extends MediaWikiJob {
 
 	/**
 	 * @var boolean
@@ -55,7 +55,7 @@ abstract class JobBase extends Job {
 	 *
 	 * @param boolean|true $enableJobQueue
 	 *
-	 * @return JobBase
+	 * @return AbstractJob
 	 */
 	public function isEnabledJobQueue( $enableJobQueue = true ) {
 		$this->isEnabledJobQueue = (bool)$enableJobQueue;

--- a/src/MediaWiki/JobFactory.php
+++ b/src/MediaWiki/JobFactory.php
@@ -1,7 +1,19 @@
 <?php
 
-namespace SMW\MediaWiki\Jobs;
+namespace SMW\MediaWiki;
 
+use SMW\MediaWiki\Jobs\NullJob;
+use SMW\MediaWiki\Jobs\RefreshJob;
+use SMW\MediaWiki\Jobs\UpdateJob;
+use SMW\MediaWiki\Jobs\UpdateDispatcherJob;
+use SMW\MediaWiki\Jobs\ParserCachePurgeJob;
+use SMW\MediaWiki\Jobs\EntityIdDisposerJob;
+use SMW\MediaWiki\Jobs\PropertyStatisticsRebuildJob;
+use SMW\MediaWiki\Jobs\FulltextSearchTableUpdateJob;
+use SMW\MediaWiki\Jobs\FulltextSearchTableRebuildJob;
+use SMW\MediaWiki\Jobs\ChangePropagationDispatchJob;
+use SMW\MediaWiki\Jobs\ChangePropagationUpdateJob;
+use SMW\MediaWiki\Jobs\ChangePropagationClassUpdateJob;
 use RuntimeException;
 use Title;
 
@@ -18,8 +30,8 @@ class JobFactory {
 	 *
 	 * @param array $jobs
 	 */
-	public function batchInsert( array $jobs ) {
-		JobBase::batchInsert( $jobs );
+	public static function batchInsert( array $jobs ) {
+		Job::batchInsert( $jobs );
 	}
 
 	/**
@@ -40,25 +52,38 @@ class JobFactory {
 
 		switch ( $type ) {
 			case 'SMW\RefreshJob':
+			case 'smw.refresh':
 				return $this->newRefreshJob( $title, $parameters );
 			case 'SMW\UpdateJob':
+			case 'smw.update':
 				return $this->newUpdateJob( $title, $parameters );
 			case 'SMW\UpdateDispatcherJob':
+			case 'smw.updateDispatcher':
 				return $this->newUpdateDispatcherJob( $title, $parameters );
 			case 'SMW\ParserCachePurgeJob':
+			case 'smw.parserCachePurge':
 				return $this->newParserCachePurgeJob( $title, $parameters );
 			case 'SMW\EntityIdDisposerJob':
+			case 'smw.entityIdDisposer':
 				return $this->newEntityIdDisposerJob( $title, $parameters );
 			case 'SMW\PropertyStatisticsRebuildJob':
+			case 'smw.propertyStatisticsRebuild':
 				return $this->newPropertyStatisticsRebuildJob( $title, $parameters );
 			case 'SMW\FulltextSearchTableUpdateJob':
+			case 'smw.fulltextSearchTableUpdate':
 				return $this->newFulltextSearchTableUpdateJob( $title, $parameters );
 			case 'SMW\FulltextSearchTableRebuildJob':
+			case 'smw.fulltextSearchTableRebuild':
 				return $this->newFulltextSearchTableRebuildJob( $title, $parameters );
 			case 'SMW\ChangePropagationDispatchJob':
+			case 'smw.changePropagationDispatch':
 				return $this->newChangePropagationDispatchJob( $title, $parameters );
 			case 'SMW\ChangePropagationUpdateJob':
+			case 'smw.changePropagationUpdate':
 				return $this->newChangePropagationUpdateJob( $title, $parameters );
+			case 'SMW\ChangePropagationClassUpdateJob':
+			case 'smw.changePropagationClassUpdate':
+				return $this->newChangePropagationClassUpdateJob( $title, $parameters );
 		}
 
 		throw new RuntimeException( "Unable to match $type to a valid Job type" );
@@ -182,6 +207,18 @@ class JobFactory {
 	 */
 	public function newChangePropagationUpdateJob( Title $title, array $parameters = array() ) {
 		return new ChangePropagationUpdateJob( $title, $parameters );
+	}
+
+	/**
+	 * @since 3.0
+	 *
+	 * @param Title $title
+	 * @param array $parameters
+	 *
+	 * @return ChangePropagationClassUpdateJob
+	 */
+	public function newChangePropagationClassUpdateJob( Title $title, array $parameters = array() ) {
+		return new ChangePropagationClassUpdateJob( $title, $parameters );
 	}
 
 }

--- a/src/MediaWiki/JobQueue.php
+++ b/src/MediaWiki/JobQueue.php
@@ -2,7 +2,6 @@
 
 namespace SMW\MediaWiki;
 
-use Job;
 use JobQueueGroup;
 
 /**
@@ -53,7 +52,7 @@ class JobQueue {
 	 * @return boolean
 	 */
 	public function isDelayedJobsEnabled( $type ) {
-		return $this->jobQueueGroup->get( $type )->delayedJobsEnabled();
+		return $this->jobQueueGroup->get( $this->mapLegacyType( $type ) )->delayedJobsEnabled();
 	}
 
 	/**
@@ -101,7 +100,7 @@ class JobQueue {
 	 * @return Job|boolean
 	 */
 	public function pop( $type ) {
-		return $this->jobQueueGroup->get( $type )->pop();
+		return $this->jobQueueGroup->get( $this->mapLegacyType( $type ) )->pop();
 	}
 
 	/**
@@ -111,7 +110,7 @@ class JobQueue {
 	 *
 	 * @param Job $job
 	 */
-	public function ack( Job $job ) {
+	public function ack( \Job $job ) {
 		$this->jobQueueGroup->get( $job->getType() )->ack( $job );
 	}
 
@@ -122,7 +121,7 @@ class JobQueue {
 	 */
 	public function delete( $type ) {
 
-		$jobQueue = $this->jobQueueGroup->get( $type );
+		$jobQueue = $this->jobQueueGroup->get( $this->mapLegacyType( $type ) );
 		$jobQueue->delete();
 
 		if ( $this->disableCache ) {
@@ -172,7 +171,7 @@ class JobQueue {
 	 */
 	public function getQueueSize( $type ) {
 
-		$jobQueue = $this->jobQueueGroup->get( $type );
+		$jobQueue = $this->jobQueueGroup->get( $this->mapLegacyType( $type ) );
 
 		if ( $this->disableCache ) {
 			$jobQueue->flushCaches();
@@ -191,6 +190,24 @@ class JobQueue {
 	 */
 	public function hasPendingJob( $type ) {
 		return $this->getQueueSize( $type ) > 0;
+	}
+
+	/**
+	 * @note FIXME Remove with 3.1
+	 * @since 3.0
+	 *
+	 * @param string $type
+	 *
+	 * @return string
+	 */
+	public static function mapLegacyType( $type ) {
+
+		// Legacy names
+		if ( strpos( $type, 'SMW\\' ) !== false ) {
+			$type = 'smw.' . lcfirst( str_replace( [ 'SMW\\', 'Job' ], '', $type ) );
+		}
+
+		return $type;
 	}
 
 }

--- a/src/MediaWiki/Jobs/ChangePropagationClassUpdateJob.php
+++ b/src/MediaWiki/Jobs/ChangePropagationClassUpdateJob.php
@@ -27,7 +27,7 @@ class ChangePropagationClassUpdateJob extends ChangePropagationUpdateJob {
 			'origin' => 'ChangePropagationClassUpdateJob'
 		];
 
-		parent::__construct( $title, $params, 'SMW\ChangePropagationClassUpdateJob' );
+		parent::__construct( $title, $params, 'smw.changePropagationClassUpdate' );
 	}
 
 }

--- a/src/MediaWiki/Jobs/ChangePropagationDispatchJob.php
+++ b/src/MediaWiki/Jobs/ChangePropagationDispatchJob.php
@@ -2,6 +2,7 @@
 
 namespace SMW\MediaWiki\Jobs;
 
+use SMW\MediaWiki\Job;
 use SMW\ApplicationFactory;
 use SMW\DIProperty;
 use SMW\DIWikiPage;
@@ -37,7 +38,7 @@ use Title;
  *
  * @author mwjames
  */
-class ChangePropagationDispatchJob extends JobBase {
+class ChangePropagationDispatchJob extends Job {
 
 	/**
 	 * Size of rows stored in a temp file
@@ -56,7 +57,7 @@ class ChangePropagationDispatchJob extends JobBase {
 	 * @param array $params
 	 */
 	public function __construct( Title $title, $params = array() ) {
-		parent::__construct( 'SMW\ChangePropagationDispatchJob', $title, $params );
+		parent::__construct( 'smw.changePropagationDispatch', $title, $params );
 		$this->removeDuplicates = true;
 	}
 
@@ -115,10 +116,10 @@ class ChangePropagationDispatchJob extends JobBase {
 
 		$applicationFactory = ApplicationFactory::getInstance();
 
-		$jobType = 'SMW\ChangePropagationUpdateJob';
+		$jobType = 'smw.changePropagationUpdate';
 
 		if ( $subject->getNamespace() === NS_CATEGORY ) {
-			$jobType = 'SMW\ChangePropagationClassUpdateJob';
+			$jobType = 'smw.changePropagationClassUpdate';
 		}
 
 		if ( $applicationFactory->getJobQueue()->hasPendingJob( $jobType ) ) {
@@ -148,10 +149,10 @@ class ChangePropagationDispatchJob extends JobBase {
 
 		$applicationFactory = ApplicationFactory::getInstance();
 
-		$jobType = 'SMW\ChangePropagationUpdateJob';
+		$jobType = 'smw.changePropagationUpdate';
 
 		if ( $subject->getNamespace() === NS_CATEGORY ) {
-			$jobType = 'SMW\ChangePropagationClassUpdateJob';
+			$jobType = 'smw.changePropagationClassUpdate';
 		}
 
 		$count = $applicationFactory->getJobQueue()->getQueueSize( $jobType );

--- a/src/MediaWiki/Jobs/ChangePropagationUpdateJob.php
+++ b/src/MediaWiki/Jobs/ChangePropagationUpdateJob.php
@@ -2,8 +2,9 @@
 
 namespace SMW\MediaWiki\Jobs;
 
-use SMW\DIWikiPage;
+use SMW\MediaWiki\Job;
 use Title;
+use SMW\DIWikiPage;
 
 /**
  * Make sufficient use of the job table by only tracking remaining jobs without
@@ -19,7 +20,7 @@ use Title;
  *
  * @author mwjames
  */
-class ChangePropagationUpdateJob extends JobBase {
+class ChangePropagationUpdateJob extends Job {
 
 	/**
 	 * @since 3.0
@@ -30,7 +31,7 @@ class ChangePropagationUpdateJob extends JobBase {
 	public function __construct( Title $title, $params = array(), $jobType = null ) {
 
 		if ( $jobType === null ) {
-			$jobType = 'SMW\ChangePropagationUpdateJob';
+			$jobType = 'smw.changePropagationUpdate';
 		}
 
 		parent::__construct( $jobType, $title, $params );

--- a/src/MediaWiki/Jobs/EntityIdDisposerJob.php
+++ b/src/MediaWiki/Jobs/EntityIdDisposerJob.php
@@ -2,6 +2,7 @@
 
 namespace SMW\MediaWiki\Jobs;
 
+use SMW\MediaWiki\Job;
 use Hooks;
 use SMW\ApplicationFactory;
 use SMW\SQLStore\PropertyTableIdReferenceDisposer;
@@ -14,7 +15,7 @@ use Title;
  *
  * @author mwjames
  */
-class EntityIdDisposerJob extends JobBase {
+class EntityIdDisposerJob extends Job {
 
 	/**
 	 * Commit chunk size
@@ -28,7 +29,7 @@ class EntityIdDisposerJob extends JobBase {
 	 * @param array $params job parameters
 	 */
 	public function __construct( Title $title, $params = array() ) {
-		parent::__construct( 'SMW\EntityIdDisposerJob', $title, $params );
+		parent::__construct( 'smw.entityIdDisposer', $title, $params );
 		$this->removeDuplicates = true;
 	}
 

--- a/src/MediaWiki/Jobs/FulltextSearchTableRebuildJob.php
+++ b/src/MediaWiki/Jobs/FulltextSearchTableRebuildJob.php
@@ -2,6 +2,7 @@
 
 namespace SMW\MediaWiki\Jobs;
 
+use SMW\MediaWiki\Job;
 use SMW\ApplicationFactory;
 use SMW\SQLStore\QueryEngine\FulltextSearchTableFactory;
 use Title;
@@ -12,7 +13,7 @@ use Title;
  *
  * @author mwjames
  */
-class FulltextSearchTableRebuildJob extends JobBase {
+class FulltextSearchTableRebuildJob extends Job {
 
 	/**
 	 * @since 2.5
@@ -21,7 +22,7 @@ class FulltextSearchTableRebuildJob extends JobBase {
 	 * @param array $params job parameters
 	 */
 	public function __construct( Title $title, $params = array() ) {
-		parent::__construct( 'SMW\FulltextSearchTableRebuildJob', $title, $params );
+		parent::__construct( 'smw.fulltextSearchTableRebuild', $title, $params );
 	}
 
 	/**

--- a/src/MediaWiki/Jobs/FulltextSearchTableUpdateJob.php
+++ b/src/MediaWiki/Jobs/FulltextSearchTableUpdateJob.php
@@ -2,6 +2,7 @@
 
 namespace SMW\MediaWiki\Jobs;
 
+use SMW\MediaWiki\Job;
 use Hooks;
 use SMW\ApplicationFactory;
 use SMW\SQLStore\QueryEngine\FulltextSearchTableFactory;
@@ -13,7 +14,7 @@ use Title;
  *
  * @author mwjames
  */
-class FulltextSearchTableUpdateJob extends JobBase {
+class FulltextSearchTableUpdateJob extends Job {
 
 	/**
 	 * @since 2.5
@@ -22,7 +23,7 @@ class FulltextSearchTableUpdateJob extends JobBase {
 	 * @param array $params job parameters
 	 */
 	public function __construct( Title $title, $params = array() ) {
-		parent::__construct( 'SMW\FulltextSearchTableUpdateJob', $title, $params );
+		parent::__construct( 'smw.fulltextSearchTableUpdate', $title, $params );
 		$this->removeDuplicates = true;
 	}
 

--- a/src/MediaWiki/Jobs/NullJob.php
+++ b/src/MediaWiki/Jobs/NullJob.php
@@ -2,6 +2,8 @@
 
 namespace SMW\MediaWiki\Jobs;
 
+use SMW\MediaWiki\Job;
+use SMW\ApplicationFactory;
 use Title;
 
 /**
@@ -10,7 +12,7 @@ use Title;
  *
  * @author mwjames
  */
-class NullJob extends JobBase {
+class NullJob extends Job {
 
 	/**
 	 * @since 2.5
@@ -18,8 +20,7 @@ class NullJob extends JobBase {
 	 * @param Title|null $title
 	 * @param array $params job parameters
 	 */
-	public function __construct( Title $title = null, $params = array() ) {
-	}
+	public function __construct( Title $title = null, $params = array() ) {}
 
 	/**
 	 * @see Job::run
@@ -31,11 +32,10 @@ class NullJob extends JobBase {
 	}
 
 	/**
-	 * @see JobBase::insert
+	 * @see Job::insert
 	 *
 	 * @since  2.5
 	 */
-	public function insert() {
-	}
+	public function insert() {}
 
 }

--- a/src/MediaWiki/Jobs/ParserCachePurgeJob.php
+++ b/src/MediaWiki/Jobs/ParserCachePurgeJob.php
@@ -2,6 +2,7 @@
 
 namespace SMW\MediaWiki\Jobs;
 
+use SMW\MediaWiki\Job;
 use Hooks;
 use SMW\ApplicationFactory;
 use SMW\HashBuilder;
@@ -17,7 +18,7 @@ use Title;
  *
  * @author mwjames
  */
-class ParserCachePurgeJob extends JobBase {
+class ParserCachePurgeJob extends Job {
 
 	/**
 	 * A balanced size that should be carefully monitored in order to not have a
@@ -64,7 +65,7 @@ class ParserCachePurgeJob extends JobBase {
 	 * @param array $params job parameters
 	 */
 	public function __construct( Title $title, $params = array() ) {
-		parent::__construct( 'SMW\ParserCachePurgeJob', $title, $params );
+		parent::__construct( 'smw.parserCachePurge', $title, $params );
 		$this->removeDuplicates = true;
 	}
 

--- a/src/MediaWiki/Jobs/PropertyStatisticsRebuildJob.php
+++ b/src/MediaWiki/Jobs/PropertyStatisticsRebuildJob.php
@@ -2,6 +2,7 @@
 
 namespace SMW\MediaWiki\Jobs;
 
+use SMW\MediaWiki\Job;
 use SMW\ApplicationFactory;
 use Title;
 
@@ -11,7 +12,7 @@ use Title;
  *
  * @author mwjames
  */
-class PropertyStatisticsRebuildJob extends JobBase {
+class PropertyStatisticsRebuildJob extends Job {
 
 	/**
 	 * @since 2.5
@@ -20,7 +21,7 @@ class PropertyStatisticsRebuildJob extends JobBase {
 	 * @param array $params job parameters
 	 */
 	public function __construct( Title $title, $params = array() ) {
-		parent::__construct( 'SMW\PropertyStatisticsRebuildJob', $title, $params );
+		parent::__construct( 'smw.propertyStatisticsRebuild', $title, $params );
 		$this->removeDuplicates = true;
 	}
 

--- a/src/MediaWiki/Jobs/RefreshJob.php
+++ b/src/MediaWiki/Jobs/RefreshJob.php
@@ -2,6 +2,7 @@
 
 namespace SMW\MediaWiki\Jobs;
 
+use SMW\MediaWiki\Job;
 use SMW\ApplicationFactory;
 
 /**
@@ -21,7 +22,7 @@ use SMW\ApplicationFactory;
  * @author Markus Krötzsch
  * @author mwjames
  */
-class RefreshJob extends JobBase {
+class RefreshJob extends Job {
 
 	/**
 	 * Constructor. The parameters optionally specified in the second
@@ -39,7 +40,7 @@ class RefreshJob extends JobBase {
 	 * @param array $params
 	 */
 	public function __construct( $title, $params = array( 'spos' => 1, 'prog' => 0, 'rc' => 1 ) ) {
-		parent::__construct( 'SMW\RefreshJob', $title, $params );
+		parent::__construct( 'smw.refresh', $title, $params );
 	}
 
 	/**
@@ -118,7 +119,8 @@ class RefreshJob extends JobBase {
 			$parameters
 		);
 
-		$job->isEnabledJobQueue( $this->isEnabledJobQueue )->insert();
+		$job->isEnabledJobQueue( $this->isEnabledJobQueue );
+		$job->insert();
 	}
 
 	protected function getNamespace( $run ) {

--- a/src/MediaWiki/Jobs/UpdateDispatcherJob.php
+++ b/src/MediaWiki/Jobs/UpdateDispatcherJob.php
@@ -3,6 +3,7 @@
 namespace SMW\MediaWiki\Jobs;
 
 use Hooks;
+use SMW\MediaWiki\Job;
 use SMW\ApplicationFactory;
 use SMW\DIProperty;
 use SMW\DIWikiPage;
@@ -18,7 +19,7 @@ use Title;
  *
  * @author mwjames
  */
-class UpdateDispatcherJob extends JobBase {
+class UpdateDispatcherJob extends Job {
 
 	/**
 	 * Restict disptach process on available pool of data
@@ -43,7 +44,7 @@ class UpdateDispatcherJob extends JobBase {
 	 * @param integer $id job id
 	 */
 	public function __construct( Title $title, $params = array(), $id = 0 ) {
-		parent::__construct( 'SMW\UpdateDispatcherJob', $title, $params, $id );
+		parent::__construct( 'smw.updateDispatcher', $title, $params, $id );
 		$this->removeDuplicates = true;
 
 		$this->setStore(

--- a/src/MediaWiki/Jobs/UpdateJob.php
+++ b/src/MediaWiki/Jobs/UpdateJob.php
@@ -2,6 +2,7 @@
 
 namespace SMW\MediaWiki\Jobs;
 
+use SMW\MediaWiki\Job;
 use LinkCache;
 use ParserOutput;
 use SMW\ApplicationFactory;
@@ -31,7 +32,7 @@ use Title;
  * @author Markus Krötzsch
  * @author mwjames
  */
-class UpdateJob extends JobBase {
+class UpdateJob extends Job {
 
 	/**
 	 * Enforces an update independent of the update marker status
@@ -60,7 +61,7 @@ class UpdateJob extends JobBase {
 	 * @param array $params
 	 */
 	function __construct( Title $title, $params = array() ) {
-		parent::__construct( 'SMW\UpdateJob', $title, $params );
+		parent::__construct( 'smw.update', $title, $params );
 		$this->removeDuplicates = true;
 
 		$this->isEnabledJobQueue(

--- a/src/MediaWiki/Specials/Admin/DataRefreshJobTaskHandler.php
+++ b/src/MediaWiki/Specials/Admin/DataRefreshJobTaskHandler.php
@@ -4,10 +4,10 @@ namespace SMW\MediaWiki\Specials\Admin;
 
 use Html;
 use SMW\ApplicationFactory;
-use SMW\MediaWiki\Jobs\JobBase;
 use SMW\MediaWiki\Renderer\HtmlFormRenderer;
 use Title;
 use WebRequest;
+use SMW\MediaWiki\Job;
 
 /**
  * @license GNU GPL v2+
@@ -180,10 +180,10 @@ class DataRefreshJobTaskHandler extends TaskHandler {
 		}
 
 		// Pop and acknowledge the job to fetch progress details
-		// from the itself
+		// from itself
 		$refreshJob = $jobQueue->pop( 'SMW\RefreshJob' );
 
-		if ( $refreshJob instanceof JobBase ) {
+		if ( $refreshJob instanceof Job ) {
 			$refreshJob->run();
 			$jobQueue->ack( $refreshJob );
 			$this->refreshjob = $refreshJob;

--- a/src/MediaWiki/Specials/Admin/DisposeJobTaskHandler.php
+++ b/src/MediaWiki/Specials/Admin/DisposeJobTaskHandler.php
@@ -157,18 +157,18 @@ class DisposeJobTaskHandler extends TaskHandler {
 			return $this->outputFormatter->redirectToRootPage( '', [ 'tab' => 'rebuild' ] );
 		}
 
-		$entityIdDisposerJob = ApplicationFactory::getInstance()->newJobFactory()->newByType(
-			'SMW\EntityIdDisposerJob',
+		$job = ApplicationFactory::getInstance()->newJobFactory()->newByType(
+			'smw.entityIdDisposer',
 			\SpecialPage::getTitleFor( 'SMWAdmin' )
 		);
 
-		$entityIdDisposerJob->insert();
+		$job->insert();
 
 		$this->outputFormatter->redirectToRootPage( '', [ 'tab' => 'rebuild' ] );
 	}
 
 	private function hasPendingJob() {
-		return ApplicationFactory::getInstance()->getJobQueue()->hasPendingJob( 'SMW\EntityIdDisposerJob' );
+		return ApplicationFactory::getInstance()->getJobQueue()->hasPendingJob( 'smw.entityIdDisposer' );
 	}
 
 }

--- a/src/MediaWiki/Specials/Admin/FulltextSearchTableRebuildJobTaskHandler.php
+++ b/src/MediaWiki/Specials/Admin/FulltextSearchTableRebuildJobTaskHandler.php
@@ -142,21 +142,21 @@ class FulltextSearchTableRebuildJobTaskHandler extends TaskHandler {
 			return $this->outputFormatter->redirectToRootPage( '', [ 'tab' => 'rebuild' ] );
 		}
 
-		$fulltextSearchTableRebuildJob = ApplicationFactory::getInstance()->newJobFactory()->newByType(
-			'SMW\FulltextSearchTableRebuildJob',
+		$job = ApplicationFactory::getInstance()->newJobFactory()->newByType(
+			'smw.fulltextSearchTableRebuild',
 			\SpecialPage::getTitleFor( 'SMWAdmin' ),
 			array(
 				'mode' => 'full'
 			)
 		);
 
-		$fulltextSearchTableRebuildJob->insert();
+		$job->insert();
 
 		$this->outputFormatter->redirectToRootPage( '', [ 'tab' => 'rebuild' ] );
 	}
 
 	private function hasPendingJob() {
-		return ApplicationFactory::getInstance()->getJobQueue()->hasPendingJob( 'SMW\FulltextSearchTableRebuildJob' );
+		return ApplicationFactory::getInstance()->getJobQueue()->hasPendingJob( 'smw.fulltextSearchTableRebuild' );
 	}
 
 }

--- a/src/MediaWiki/Specials/Admin/PropertyStatsRebuildJobTaskHandler.php
+++ b/src/MediaWiki/Specials/Admin/PropertyStatsRebuildJobTaskHandler.php
@@ -145,18 +145,18 @@ class PropertyStatsRebuildJobTaskHandler extends TaskHandler {
 			return $this->outputFormatter->redirectToRootPage( '', [ 'tab' => 'rebuild' ] );
 		}
 
-		$propertyStatisticsRebuildJob = ApplicationFactory::getInstance()->newJobFactory()->newByType(
-			'SMW\PropertyStatisticsRebuildJob',
+		$job = ApplicationFactory::getInstance()->newJobFactory()->newByType(
+			'smw.propertyStatisticsRebuild',
 			\SpecialPage::getTitleFor( 'SMWAdmin' )
 		);
 
-		$propertyStatisticsRebuildJob->insert();
+		$job->insert();
 
 		$this->outputFormatter->redirectToRootPage( '', [ 'tab' => 'rebuild' ] );
 	}
 
 	private function hasPendingJob() {
-		return ApplicationFactory::getInstance()->getJobQueue()->hasPendingJob( 'SMW\PropertyStatisticsRebuildJob' );
+		return ApplicationFactory::getInstance()->getJobQueue()->hasPendingJob( 'smw.propertyStatisticsRebuild' );
 	}
 
 }

--- a/src/PostProcHandler.php
+++ b/src/PostProcHandler.php
@@ -153,11 +153,11 @@ class PostProcHandler {
 
 			// Not enabled, no need to invoke a job!
 			if ( isset( $this->options['smwgEnabledQueryDependencyLinksStore'] ) && $this->options['smwgEnabledQueryDependencyLinksStore'] === false ) {
-				unset( $jobs['SMW\ParserCachePurgeJob'] );
+				unset( $jobs['smw.parserCachePurge'] );
 			}
 
 			if ( isset( $this->options['smwgEnabledFulltextSearch'] ) && $this->options['smwgEnabledFulltextSearch'] === false ) {
-				unset( $jobs['SMW\FulltextSearchTableUpdateJob'] );
+				unset( $jobs['smw.fulltextSearchTableUpdate'] );
 			}
 		}
 

--- a/src/Services/SharedServicesContainer.php
+++ b/src/Services/SharedServicesContainer.php
@@ -21,7 +21,7 @@ use SMW\MediaWiki\Connection\ConnectionProvider;
 use SMW\MediaWiki\Deferred\CallableUpdate;
 use SMW\MediaWiki\Deferred\TransactionalCallableUpdate;
 use SMW\MediaWiki\JobQueue;
-use SMW\MediaWiki\Jobs\JobFactory;
+use SMW\MediaWiki\JobFactory;
 use SMW\MediaWiki\ManualEntryLogger;
 use SMW\MediaWiki\MediaWikiNsContentReader;
 use SMW\MediaWiki\PageCreator;
@@ -389,7 +389,7 @@ class SharedServicesContainer implements CallbackContainer {
 		 * @var JobFactory
 		 */
 		$containerBuilder->registerCallback( 'JobFactory', function( $containerBuilder ) {
-			$containerBuilder->registerExpectedReturnType( 'JobFactory', '\SMW\MediaWiki\Jobs\JobFactory' );
+			$containerBuilder->registerExpectedReturnType( 'JobFactory', '\SMW\MediaWiki\JobFactory' );
 			return new JobFactory();
 		} );
 

--- a/src/Site.php
+++ b/src/Site.php
@@ -131,6 +131,10 @@ class Site {
 	 */
 	public static function getJobClasses( $typeFilter = '' ) {
 
+		if ( $typeFilter === 'SMW' ) {
+			$typeFilter = 'smw.';
+		}
+
 		$jobList = $GLOBALS['wgJobClasses'];
 
 		foreach ( $jobList as $type => $class ) {

--- a/tests/phpunit/Benchmark/JobQueueBenchmarkRunner.php
+++ b/tests/phpunit/Benchmark/JobQueueBenchmarkRunner.php
@@ -3,7 +3,7 @@
 namespace SMW\Tests\Benchmark;
 
 use RuntimeException;
-use SMW\MediaWiki\Jobs\JobFactory;
+use SMW\MediaWiki\JobFactory;
 use SMW\Tests\Utils\Runners\JobQueueRunner;
 use Title;
 

--- a/tests/phpunit/Integration/MediaWiki/Jobs/ChangePropagationDispatchJobTest.php
+++ b/tests/phpunit/Integration/MediaWiki/Jobs/ChangePropagationDispatchJobTest.php
@@ -67,7 +67,7 @@ class ChangePropagationDispatchJob extends MwDBaseUnitTestCase {
 
 		$this->assertGreaterThan(
 			0,
-			$this->jobQueue->getQueueSize( 'SMW\UpdateJob' )
+			$this->jobQueue->getQueueSize( 'smw.update' )
 		);
 	}
 
@@ -102,19 +102,19 @@ class ChangePropagationDispatchJob extends MwDBaseUnitTestCase {
 
 		$this->assertGreaterThan(
 			0,
-			$this->jobQueue->getQueueSize( 'SMW\ChangePropagationDispatchJob' )
+			$this->jobQueue->getQueueSize( 'smw.changePropagationDispatch' )
 		);
 
-		$this->jobQueueRunner->setType( 'SMW\ChangePropagationDispatchJob' )->run();
+		$this->jobQueueRunner->setType( 'smw.changePropagationDispatch' )->run();
 
 		$this->jobQueue->disableCache();
 
 		$this->assertGreaterThan(
 			0,
-			$this->jobQueue->getQueueSize( 'SMW\UpdateJob' )
+			$this->jobQueue->getQueueSize( 'smw.update' )
 		);
 
-		$this->jobQueueRunner->setType( 'SMW\UpdateJob' )->run();
+		$this->jobQueueRunner->setType( 'smw.update' )->run();
 
 		foreach ( $this->jobQueueRunner->getStatus() as $status ) {
 			$this->assertTrue( $status['status'] );
@@ -153,19 +153,19 @@ class ChangePropagationDispatchJob extends MwDBaseUnitTestCase {
 
 		$this->assertGreaterThan(
 			0,
-			$this->jobQueue->getQueueSize( 'SMW\ChangePropagationDispatchJob' )
+			$this->jobQueue->getQueueSize( 'smw.changePropagationDispatch' )
 		);
 
-		$this->jobQueueRunner->setType( 'SMW\ChangePropagationDispatchJob' )->run();
+		$this->jobQueueRunner->setType( 'smw.changePropagationDispatch' )->run();
 
 		$this->jobQueue->disableCache();
 
 		$this->assertGreaterThan(
 			0,
-			$this->jobQueue->getQueueSize( 'SMW\UpdateJob' )
+			$this->jobQueue->getQueueSize( 'smw.update' )
 		);
 
-		$this->jobQueueRunner->setType( 'SMW\UpdateJob' )->run();
+		$this->jobQueueRunner->setType( 'smw.update' )->run();
 
 		foreach ( $this->jobQueueRunner->getStatus() as $status ) {
 			$this->assertTrue( $status['status'] );

--- a/tests/phpunit/Integration/MediaWiki/Jobs/UpdateJobRoundtripTest.php
+++ b/tests/phpunit/Integration/MediaWiki/Jobs/UpdateJobRoundtripTest.php
@@ -112,7 +112,7 @@ class UpdateJobRoundtripTest extends MwDBaseUnitTestCase {
 		$index = 1; //pass-by-reference
 
 		$this->getStore()->refreshData( $index, 1, false, true )->rebuild( $index );
-		$this->assertJob( 'SMW\UpdateJob' );
+		$this->assertJob( 'smw.update' );
 	}
 
 	/**
@@ -133,9 +133,11 @@ class UpdateJobRoundtripTest extends MwDBaseUnitTestCase {
 
 		$provider = array();
 
+		$provider[] = array( 'SMW\UpdateJob', 'smw.update' );
 		$provider[] = array( 'SMW\UpdateJob', 'SMW\UpdateJob' );
 		$provider[] = array( 'SMWUpdateJob', 'SMW\UpdateJob' );
 
+		$provider[] = array( 'SMW\RefreshJob', 'smw.refresh' );
 		$provider[] = array( 'SMW\RefreshJob', 'SMW\RefreshJob' );
 		$provider[] = array( 'SMWRefreshJob', 'SMW\RefreshJob' );
 

--- a/tests/phpunit/Unit/ApplicationFactoryTest.php
+++ b/tests/phpunit/Unit/ApplicationFactoryTest.php
@@ -48,7 +48,7 @@ class ApplicationFactoryTest extends \PHPUnit_Framework_TestCase {
 	public function testCanConstructJobFactory() {
 
 		$this->assertInstanceOf(
-			'\SMW\MediaWiki\Jobs\JobFactory',
+			'\SMW\MediaWiki\JobFactory',
 			$this->applicationFactory->newJobFactory()
 		);
 	}

--- a/tests/phpunit/Unit/Maintenance/DataRebuilderTest.php
+++ b/tests/phpunit/Unit/Maintenance/DataRebuilderTest.php
@@ -35,7 +35,7 @@ class DataRebuilderTest extends \PHPUnit_Framework_TestCase {
 			->disableOriginalConstructor()
 			->getMock();
 
-		$jobFactory = $this->getMockBuilder( '\SMW\MediaWiki\Jobs\JobFactory' )
+		$jobFactory = $this->getMockBuilder( '\SMW\MediaWiki\JobFactory' )
 			->disableOriginalConstructor()
 			->setMethods( [ 'newUpdateJob' ] )
 			->getMock();

--- a/tests/phpunit/Unit/MediaWiki/Api/InfoTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Api/InfoTest.php
@@ -139,7 +139,7 @@ class InfoTest extends \PHPUnit_Framework_TestCase {
 		);
 
 		$this->assertArrayHasKey(
-			'SMW\UpdateJob',
+			'smw.update',
 			$result['info']['jobcount']
 		);
 	}

--- a/tests/phpunit/Unit/MediaWiki/Api/TaskTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Api/TaskTest.php
@@ -53,7 +53,7 @@ class TaskTest extends \PHPUnit_Framework_TestCase {
 		$updateJob->expects( $this->atLeastOnce() )
 			->method( 'run' );
 
-		$jobFactory = $this->getMockBuilder( '\SMW\MediaWiki\Jobs\JobFactory' )
+		$jobFactory = $this->getMockBuilder( '\SMW\MediaWiki\JobFactory' )
 			->disableOriginalConstructor()
 			->getMock();
 
@@ -133,7 +133,7 @@ class TaskTest extends \PHPUnit_Framework_TestCase {
 		$nullJob->expects( $this->atLeastOnce() )
 			->method( 'insert' );
 
-		$jobFactory = $this->getMockBuilder( '\SMW\MediaWiki\Jobs\JobFactory' )
+		$jobFactory = $this->getMockBuilder( '\SMW\MediaWiki\JobFactory' )
 			->disableOriginalConstructor()
 			->getMock();
 

--- a/tests/phpunit/Unit/MediaWiki/Deferred/ChangeTitleUpdateTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Deferred/ChangeTitleUpdateTest.php
@@ -23,7 +23,7 @@ class ChangeTitleUpdateTest extends \PHPUnit_Framework_TestCase {
 		parent::setUp();
 		$this->testEnvironment = new TestEnvironment();
 
-		$this->jobFactory = $this->getMockBuilder( '\SMW\MediaWiki\Jobs\JobFactory' )
+		$this->jobFactory = $this->getMockBuilder( '\SMW\MediaWiki\JobFactory' )
 			->disableOriginalConstructor()
 			->setMethods( [ 'newUpdateJob' ] )
 			->getMock();

--- a/tests/phpunit/Unit/MediaWiki/Hooks/ArticleDeleteTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Hooks/ArticleDeleteTest.php
@@ -31,7 +31,7 @@ class ArticleDeleteTest extends \PHPUnit_Framework_TestCase {
 			]
 		);
 
-		$this->jobFactory = $this->getMockBuilder( '\SMW\MediaWiki\Jobs\JobFactory' )
+		$this->jobFactory = $this->getMockBuilder( '\SMW\MediaWiki\JobFactory' )
 			->disableOriginalConstructor()
 			->getMock();
 

--- a/tests/phpunit/Unit/MediaWiki/Hooks/UserChangeTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Hooks/UserChangeTest.php
@@ -29,7 +29,7 @@ class UserChangeTest extends \PHPUnit_Framework_TestCase {
 			->disableOriginalConstructor()
 			->getMock();
 
-		$this->jobFactory = $this->getMockBuilder( '\SMW\MediaWiki\Jobs\JobFactory' )
+		$this->jobFactory = $this->getMockBuilder( '\SMW\MediaWiki\JobFactory' )
 			->disableOriginalConstructor()
 			->getMock();
 

--- a/tests/phpunit/Unit/MediaWiki/JobFactoryTest.php
+++ b/tests/phpunit/Unit/MediaWiki/JobFactoryTest.php
@@ -1,13 +1,13 @@
 <?php
 
-namespace SMW\Tests\MediaWiki\Jobs;
+namespace SMW\Tests\MediaWiki;
 
-use SMW\MediaWiki\Jobs\JobFactory;
+use SMW\MediaWiki\JobFactory;
 use Title;
 use SMW\Tests\PHPUnitCompat;
 
 /**
- * @covers \SMW\MediaWiki\Jobs\JobFactory
+ * @covers \SMW\MediaWiki\JobFactory
  * @group semantic-mediawiki
  *
  * @license GNU GPL v2+
@@ -22,7 +22,7 @@ class JobFactoryTest extends \PHPUnit_Framework_TestCase {
 	public function testCanConstruct() {
 
 		$this->assertInstanceOf(
-			'\SMW\MediaWiki\Jobs\JobFactory',
+			JobFactory::class,
 			new JobFactory()
 		);
 	}
@@ -69,7 +69,17 @@ class JobFactoryTest extends \PHPUnit_Framework_TestCase {
 		);
 
 		$provider[] = array(
+			'smw.refresh',
+			'\SMW\MediaWiki\Jobs\RefreshJob'
+		);
+
+		$provider[] = array(
 			'SMW\UpdateJob',
+			'\SMW\MediaWiki\Jobs\UpdateJob'
+		);
+
+		$provider[] = array(
+			'smw.update',
 			'\SMW\MediaWiki\Jobs\UpdateJob'
 		);
 
@@ -79,7 +89,17 @@ class JobFactoryTest extends \PHPUnit_Framework_TestCase {
 		);
 
 		$provider[] = array(
+			'smw.updateDispatcher',
+			'\SMW\MediaWiki\Jobs\UpdateDispatcherJob'
+		);
+
+		$provider[] = array(
 			'SMW\ParserCachePurgeJob',
+			'\SMW\MediaWiki\Jobs\ParserCachePurgeJob'
+		);
+
+		$provider[] = array(
+			'smw.parserCachePurge',
 			'\SMW\MediaWiki\Jobs\ParserCachePurgeJob'
 		);
 
@@ -89,7 +109,17 @@ class JobFactoryTest extends \PHPUnit_Framework_TestCase {
 		);
 
 		$provider[] = array(
+			'smw.fulltextSearchTableUpdate',
+			'\SMW\MediaWiki\Jobs\FulltextSearchTableUpdateJob'
+		);
+
+		$provider[] = array(
 			'SMW\EntityIdDisposerJob',
+			'\SMW\MediaWiki\Jobs\EntityIdDisposerJob'
+		);
+
+		$provider[] = array(
+			'smw.entityIdDisposer',
 			'\SMW\MediaWiki\Jobs\EntityIdDisposerJob'
 		);
 
@@ -99,7 +129,17 @@ class JobFactoryTest extends \PHPUnit_Framework_TestCase {
 		);
 
 		$provider[] = array(
+			'smw.propertyStatisticsRebuild',
+			'\SMW\MediaWiki\Jobs\PropertyStatisticsRebuildJob'
+		);
+
+		$provider[] = array(
 			'SMW\FulltextSearchTableRebuildJob',
+			'\SMW\MediaWiki\Jobs\FulltextSearchTableRebuildJob'
+		);
+
+		$provider[] = array(
+			'smw.fulltextSearchTableRebuild',
 			'\SMW\MediaWiki\Jobs\FulltextSearchTableRebuildJob'
 		);
 
@@ -109,8 +149,28 @@ class JobFactoryTest extends \PHPUnit_Framework_TestCase {
 		);
 
 		$provider[] = array(
+			'smw.changePropagationDispatch',
+			'\SMW\MediaWiki\Jobs\ChangePropagationDispatchJob'
+		);
+
+		$provider[] = array(
 			'SMW\ChangePropagationUpdateJob',
 			'\SMW\MediaWiki\Jobs\ChangePropagationUpdateJob'
+		);
+
+		$provider[] = array(
+			'smw.changePropagationUpdate',
+			'\SMW\MediaWiki\Jobs\ChangePropagationUpdateJob'
+		);
+
+		$provider[] = array(
+			'SMW\ChangePropagationClassUpdateJob',
+			'\SMW\MediaWiki\Jobs\ChangePropagationClassUpdateJob'
+		);
+
+		$provider[] = array(
+			'smw.changePropagationClassUpdate',
+			'\SMW\MediaWiki\Jobs\ChangePropagationClassUpdateJob'
 		);
 
 		return $provider;

--- a/tests/phpunit/Unit/MediaWiki/JobQueueTest.php
+++ b/tests/phpunit/Unit/MediaWiki/JobQueueTest.php
@@ -218,4 +218,27 @@ class JobQueueTest extends \PHPUnit_Framework_TestCase {
 		);
 	}
 
+	public function testHasPendingJobWithLegacyName() {
+
+		$jobQueue = $this->getMockBuilder( '\JobQueue' )
+			->disableOriginalConstructor()
+			->setMethods( array( 'doGetSize' ) )
+			->getMockForAbstractClass();
+
+		$jobQueue->expects( $this->once() )
+			->method( 'doGetSize' )
+			->will( $this->returnValue( 1 ) );
+
+		$this->jobQueueGroup->expects( $this->once() )
+			->method( 'get' )
+			->with( $this->stringContains( 'smw.fake' ) )
+			->will( $this->returnValue( $jobQueue ) );
+
+		$instance = new JobQueue( $this->jobQueueGroup );
+
+		$this->assertTrue(
+			$instance->hasPendingJob( 'SMW\FakeJob' )
+		);
+	}
+
 }

--- a/tests/phpunit/Unit/MediaWiki/Specials/Admin/DataRefreshJobTaskHandlerTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Specials/Admin/DataRefreshJobTaskHandlerTest.php
@@ -98,7 +98,7 @@ class DataRefreshJobTaskHandlerTest extends \PHPUnit_Framework_TestCase {
 			->with( $this->equalTo( 'SMW\RefreshJob' ) )
 			->will( $this->returnValue( false ) );
 
-		$jobFactory = $this->getMockBuilder( '\SMW\MediaWiki\Jobs\JobFactory' )
+		$jobFactory = $this->getMockBuilder( '\SMW\MediaWiki\JobFactory' )
 			->disableOriginalConstructor()
 			->getMock();
 

--- a/tests/phpunit/Unit/MediaWiki/Specials/Admin/DisposeJobTaskHandlerTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Specials/Admin/DisposeJobTaskHandlerTest.php
@@ -86,7 +86,7 @@ class DisposeJobTaskHandlerTest extends \PHPUnit_Framework_TestCase {
 
 		$this->jobQueue->expects( $this->once() )
 			->method( 'hasPendingJob' )
-			->with( $this->equalTo( 'SMW\EntityIdDisposerJob' ) )
+			->with( $this->equalTo( 'smw.entityIdDisposer' ) )
 			->will( $this->returnValue( false ) );
 
 		$entityIdDisposerJob = $this->getMockBuilder( '\SMW\MediaWiki\Jobs\EntityIdDisposerJob' )
@@ -96,7 +96,7 @@ class DisposeJobTaskHandlerTest extends \PHPUnit_Framework_TestCase {
 		$entityIdDisposerJob->expects( $this->once() )
 			->method( 'insert' );
 
-		$jobFactory = $this->getMockBuilder( '\SMW\MediaWiki\Jobs\JobFactory' )
+		$jobFactory = $this->getMockBuilder( '\SMW\MediaWiki\JobFactory' )
 			->disableOriginalConstructor()
 			->getMock();
 
@@ -124,10 +124,10 @@ class DisposeJobTaskHandlerTest extends \PHPUnit_Framework_TestCase {
 
 		$this->jobQueue->expects( $this->once() )
 			->method( 'hasPendingJob' )
-			->with( $this->equalTo( 'SMW\EntityIdDisposerJob' ) )
+			->with( $this->equalTo( 'smw.entityIdDisposer' ) )
 			->will( $this->returnValue( true ) );
 
-		$jobFactory = $this->getMockBuilder( '\SMW\MediaWiki\Jobs\JobFactory' )
+		$jobFactory = $this->getMockBuilder( '\SMW\MediaWiki\JobFactory' )
 			->disableOriginalConstructor()
 			->getMock();
 

--- a/tests/phpunit/Unit/MediaWiki/Specials/Admin/EntityLookupTaskHandlerTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Specials/Admin/EntityLookupTaskHandlerTest.php
@@ -149,7 +149,7 @@ class EntityLookupTaskHandlerTest extends \PHPUnit_Framework_TestCase {
 			->disableOriginalConstructor()
 			->getMock();
 
-		$jobFactory = $this->getMockBuilder( '\SMW\MediaWiki\Jobs\JobFactory' )
+		$jobFactory = $this->getMockBuilder( '\SMW\MediaWiki\JobFactory' )
 			->disableOriginalConstructor()
 			->getMock();
 

--- a/tests/phpunit/Unit/MediaWiki/Specials/Admin/FulltextSearchTableRebuildJobTaskHandlerTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Specials/Admin/FulltextSearchTableRebuildJobTaskHandlerTest.php
@@ -86,7 +86,7 @@ class FulltextSearchTableRebuildJobTaskHandlerTest extends \PHPUnit_Framework_Te
 
 		$this->jobQueue->expects( $this->once() )
 			->method( 'hasPendingJob' )
-			->with( $this->equalTo( 'SMW\FulltextSearchTableRebuildJob' ) )
+			->with( $this->equalTo( 'smw.fulltextSearchTableRebuild' ) )
 			->will( $this->returnValue( false ) );
 
 		$fulltextSearchTableRebuildJob = $this->getMockBuilder( '\SMW\MediaWiki\Jobs\FulltextSearchTableRebuildJob' )
@@ -96,7 +96,7 @@ class FulltextSearchTableRebuildJobTaskHandlerTest extends \PHPUnit_Framework_Te
 		$fulltextSearchTableRebuildJob->expects( $this->once() )
 			->method( 'insert' );
 
-		$jobFactory = $this->getMockBuilder( '\SMW\MediaWiki\Jobs\JobFactory' )
+		$jobFactory = $this->getMockBuilder( '\SMW\MediaWiki\JobFactory' )
 			->disableOriginalConstructor()
 			->getMock();
 
@@ -124,10 +124,10 @@ class FulltextSearchTableRebuildJobTaskHandlerTest extends \PHPUnit_Framework_Te
 
 		$this->jobQueue->expects( $this->once() )
 			->method( 'hasPendingJob' )
-			->with( $this->equalTo( 'SMW\FulltextSearchTableRebuildJob' ) )
+			->with( $this->equalTo( 'smw.fulltextSearchTableRebuild' ) )
 			->will( $this->returnValue( true ) );
 
-		$jobFactory = $this->getMockBuilder( '\SMW\MediaWiki\Jobs\JobFactory' )
+		$jobFactory = $this->getMockBuilder( '\SMW\MediaWiki\JobFactory' )
 			->disableOriginalConstructor()
 			->getMock();
 

--- a/tests/phpunit/Unit/MediaWiki/Specials/Admin/PropertyStatsRebuildJobTaskHandlerTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Specials/Admin/PropertyStatsRebuildJobTaskHandlerTest.php
@@ -86,7 +86,7 @@ class PropertyStatsRebuildJobTaskHandlerTest extends \PHPUnit_Framework_TestCase
 
 		$this->jobQueue->expects( $this->once() )
 			->method( 'hasPendingJob' )
-			->with( $this->equalTo( 'SMW\PropertyStatisticsRebuildJob' ) )
+			->with( $this->equalTo( 'smw.propertyStatisticsRebuild' ) )
 			->will( $this->returnValue( false ) );
 
 		$propertyStatisticsRebuildJob = $this->getMockBuilder( '\SMW\MediaWiki\Jobs\PropertyStatisticsRebuildJob' )
@@ -96,7 +96,7 @@ class PropertyStatsRebuildJobTaskHandlerTest extends \PHPUnit_Framework_TestCase
 		$propertyStatisticsRebuildJob->expects( $this->once() )
 			->method( 'insert' );
 
-		$jobFactory = $this->getMockBuilder( '\SMW\MediaWiki\Jobs\JobFactory' )
+		$jobFactory = $this->getMockBuilder( '\SMW\MediaWiki\JobFactory' )
 			->disableOriginalConstructor()
 			->getMock();
 
@@ -124,10 +124,10 @@ class PropertyStatsRebuildJobTaskHandlerTest extends \PHPUnit_Framework_TestCase
 
 		$this->jobQueue->expects( $this->once() )
 			->method( 'hasPendingJob' )
-			->with( $this->equalTo( 'SMW\PropertyStatisticsRebuildJob' ) )
+			->with( $this->equalTo( 'smw.propertyStatisticsRebuild' ) )
 			->will( $this->returnValue( true ) );
 
-		$jobFactory = $this->getMockBuilder( '\SMW\MediaWiki\Jobs\JobFactory' )
+		$jobFactory = $this->getMockBuilder( '\SMW\MediaWiki\JobFactory' )
 			->disableOriginalConstructor()
 			->getMock();
 

--- a/tests/phpunit/Unit/SQLStore/QueryDependency/QueryDependencyLinksStoreTest.php
+++ b/tests/phpunit/Unit/SQLStore/QueryDependency/QueryDependencyLinksStoreTest.php
@@ -45,7 +45,7 @@ class QueryDependencyLinksStoreTest extends \PHPUnit_Framework_TestCase {
 			->method( 'isSemanticEnabled' )
 			->will( $this->returnValue( true ) );
 
-		$this->jobFactory = $this->getMockBuilder( '\SMW\MediaWiki\Jobs\JobFactory' )
+		$this->jobFactory = $this->getMockBuilder( '\SMW\MediaWiki\JobFactory' )
 			->disableOriginalConstructor()
 			->getMock();
 

--- a/tests/phpunit/Unit/SQLStore/QueryEngine/Fulltext/TextChangeUpdaterTest.php
+++ b/tests/phpunit/Unit/SQLStore/QueryEngine/Fulltext/TextChangeUpdaterTest.php
@@ -44,7 +44,7 @@ class TextChangeUpdaterTest extends \PHPUnit_Framework_TestCase {
 			->disableOriginalConstructor()
 			->getMock();
 
-		$this->jobFactory = $this->getMockBuilder( '\SMW\MediaWiki\Jobs\JobFactory' )
+		$this->jobFactory = $this->getMockBuilder( '\SMW\MediaWiki\JobFactory' )
 			->disableOriginalConstructor()
 			->getMock();
 

--- a/tests/phpunit/includes/SQLStore/Writer/ChangeTitleTest.php
+++ b/tests/phpunit/includes/SQLStore/Writer/ChangeTitleTest.php
@@ -32,7 +32,7 @@ class ChangeTitleTest extends \PHPUnit_Framework_TestCase {
 			->disableOriginalConstructor()
 			->getMock();
 
-		$jobFactory = $this->getMockBuilder( '\SMW\MediaWiki\Jobs\JobFactory' )
+		$jobFactory = $this->getMockBuilder( '\SMW\MediaWiki\JobFactory' )
 			->disableOriginalConstructor()
 			->getMock();
 

--- a/tests/phpunit/includes/SetupTest.php
+++ b/tests/phpunit/includes/SetupTest.php
@@ -249,6 +249,22 @@ class SetupTest extends \PHPUnit_Framework_TestCase {
 	public function jobClassesDataProvider() {
 
 		$jobs = array(
+
+			'smw.update',
+			'smw.refresh',
+			'smw.updateDispatcher',
+			'smw.parserCachePurge',
+			'smw.fulltextSearchTableUpdate',
+			'smw.entityIdDisposer',
+			'smw.propertyStatisticsRebuild',
+			'smw.fulltextSearchTableRebuild',
+			'smw.changePropagationDispatch',
+			'smw.changePropagationUpdate',
+			'smw.changePropagationClassUpdate',
+			'smw.elasticIndexerRecovery',
+			'smw.elasticFileIngest',
+
+			// Legacy
 			'SMW\UpdateJob',
 			'SMW\RefreshJob',
 			'SMW\UpdateDispatcherJob',
@@ -260,8 +276,6 @@ class SetupTest extends \PHPUnit_Framework_TestCase {
 			'SMW\ChangePropagationDispatchJob',
 			'SMW\ChangePropagationUpdateJob',
 			'SMW\ChangePropagationClassUpdateJob',
-
-			// Legacy
 			'SMWUpdateJob',
 			'SMWRefreshJob',
 		);


### PR DESCRIPTION
This PR is made in reference to: #

This PR addresses or contains:

- Instead of identifying jobs with `SMW\\ ...`, use a different name scheme that is closer to the existing MW job commands.
  - `SMW\UpdateJob` -> `smw.update`
  - `SMW\UpdateDispatcherJob` -> `smw.updateDispatcher`
  - `SMW\RefreshJob` -> `smw.refresh`
  - `SMW\ParserCachePurgeJob` -> `smw.parserCachePurge`
  - `SMW\FulltextSearchTableUpdateJob` -> `smw.fulltextSearchTableUpdate`
  - `SMW\EntityIdDisposerJob` -> `smw.entityIdDisposer`
  - `SMW\PropertyStatisticsRebuildJob` -> `smw.propertyStatisticsRebuild`
  - `SMW\FulltextSearchTableRebuildJob` -> `smw.fulltextSearchTableRebuild`
  - `SMW\ChangePropagationDispatchJob` -> `smw.changePropagationDispatch`
  - `SMW\ChangePropagationUpdateJob` -> `smw.changePropagationUpdate`
  - `SMW\ChangePropagationClassUpdateJob` -> `smw.changePropagationClassUpdate`
- Legacy names will be mapped to the new scheme

This PR includes:
- [ ] Tests (unit/integration)
- [x] CI build passed
