### PR TITLE
Add `smwgSupportSectionTag`, refs 3416

### DIFF
--- a/DefaultSettings.php
+++ b/DefaultSettings.php
@@ -1998,6 +1998,15 @@ return array(
 	##
 
 	##
+	# Enable/disable <section> ... </section> support
+	#
+	# @since 3.0
+	# @default true
+	##
+	'smwgSupportSectionTag' => true,
+	##
+
+	##
 	# THE FOLLOWING SETTINGS AND SUPPORT FUNCTIONS ARE EXPERIMENTAL!
 	#
 	# Please make you read the Readme.md (see the Elastic folder) file first

--- a/includes/Settings.php
+++ b/includes/Settings.php
@@ -179,6 +179,7 @@ class Settings extends Options {
 			'smwgElasticsearchEndpoints' => $GLOBALS['smwgElasticsearchEndpoints'],
 			'smwgPostEditUpdate' => $GLOBALS['smwgPostEditUpdate'],
 			'smwgSpecialAskFormSubmitMethod' => $GLOBALS['smwgSpecialAskFormSubmitMethod'],
+			'smwgSupportSectionTag' => $GLOBALS['smwgSupportSectionTag'],
 		);
 
 		self::initLegacyMapping( $configuration );

--- a/src/MediaWiki/Hooks/HookListener.php
+++ b/src/MediaWiki/Hooks/HookListener.php
@@ -726,7 +726,8 @@ class HookListener {
 	 */
 	public function onParserFirstCallInit( &$parser ) {
 
-		$parserFunctionFactory = ApplicationFactory::getInstance()->newParserFunctionFactory();
+		$applicationFactory = ApplicationFactory::getInstance();
+		$parserFunctionFactory = $applicationFactory->newParserFunctionFactory();
 		$parserFunctionFactory->registerFunctionHandlers( $parser );
 
 		$hookRegistrant = new HookRegistrant( $parser );
@@ -744,9 +745,10 @@ class HookListener {
 		/**
 		 * Support for <section> ... </section>
 		 */
-		$parser->setHook( 'section', function( $input, array $args, \Parser $parser, \PPFrame $frame ) {
-			return ( new SectionTag( $parser, $frame ) )->parse( $input, $args );
-		} );
+		SectionTag::register(
+			$parser,
+			$applicationFactory->getSettings()->get( 'smwgSupportSectionTag' )
+		);
 
 		return true;
 	}

--- a/src/ParserFunctions/SectionTag.php
+++ b/src/ParserFunctions/SectionTag.php
@@ -40,6 +40,27 @@ class SectionTag {
 	/**
 	 * @since 3.0
 	 *
+	 * @param Parser $parser
+	 * @param boolean $supportSectionTag
+	 *
+	 * @return boolean
+	 */
+	public static function register( Parser $parser, $supportSectionTag = true ) {
+
+		if ( $supportSectionTag === false ) {
+			return false;
+		}
+
+		$parser->setHook( 'section', function( $input, array $args, Parser $parser, PPFrame $frame ) {
+			return ( new self( $parser, $frame ) )->parse( $input, $args );
+		} );
+
+		return true;
+	}
+
+	/**
+	 * @since 3.0
+	 *
 	 * @param string $input
 	 * @param array $args
 	 *

--- a/tests/phpunit/Unit/ParserFunctions/SectionTagTest.php
+++ b/tests/phpunit/Unit/ParserFunctions/SectionTagTest.php
@@ -37,6 +37,26 @@ class SectionTagTest extends \PHPUnit_Framework_TestCase {
 		);
 	}
 
+	public function testRegister_Enabled() {
+
+		$this->parser->expects( $this->once() )
+			->method( 'setHook' );
+
+		$this->assertTrue(
+			SectionTag::register( $this->parser )
+		);
+	}
+
+	public function testRegister_Disabled() {
+
+		$this->parser->expects( $this->never() )
+			->method( 'setHook' );
+
+		$this->assertFalse(
+			SectionTag::register( $this->parser, false )
+		);
+	}
+
 	public function testParse() {
 
 		$title = $this->getMockBuilder( '\Title' )


### PR DESCRIPTION
This PR is made in reference to: https://github.com/SemanticMediaWiki/SemanticMediaWiki/pull/3416#issuecomment-421809987

This PR addresses or contains:

- Adds `smwgSupportSectionTag` to control the `<section>` tag availability

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed
