### PR TITLE
Converts `maintenance` and subdirecories to PHP 5.4+ short array syntax

### DIFF
--- a/i18n/extra/SemanticMediaWiki.alias.php
+++ b/i18n/extra/SemanticMediaWiki.alias.php
@@ -8,829 +8,829 @@
  */
 // @codingStandardsIgnoreFile
 
-$specialPageAliases = array();
+$specialPageAliases = [];
 
 /** English (English) */
-$specialPageAliases['en'] = array(
-	'Ask' => array( 'Ask' ),
-	'Browse' => array( 'Browse' ),
-	'ExportRDF' => array( 'ExportRDF' ),
-	'PageProperty' => array( 'PageProperty' ),
-	'Properties' => array( 'Properties' ),
-	'Concepts' => array( 'Concepts' ),
-	'SMWAdmin' => array( 'SemanticMediaWiki', 'SMWAdmin' ),
-	'SearchByProperty' => array( 'SearchByProperty' ),
-	'ProcessingErrorList' => array( 'ProcessingErrorList' ),
-	'PropertyLabelSimilarity' => array( 'PropertyLabelSimilarity' ),
-	'Types' => array( 'Types' ),
-	'URIResolver' => array( 'URIResolver' ),
-	'UnusedProperties' => array( 'UnusedProperties' ),
-	'WantedProperties' => array( 'WantedProperties' ),
-	'DeferredRequestDispatcher' => array( 'DeferredRequestDispatcher' ),
-);
+$specialPageAliases['en'] = [
+	'Ask' => [ 'Ask' ],
+	'Browse' => [ 'Browse' ],
+	'ExportRDF' => [ 'ExportRDF' ],
+	'PageProperty' => [ 'PageProperty' ],
+	'Properties' => [ 'Properties' ],
+	'Concepts' => [ 'Concepts' ],
+	'SMWAdmin' => [ 'SemanticMediaWiki', 'SMWAdmin' ],
+	'SearchByProperty' => [ 'SearchByProperty' ],
+	'ProcessingErrorList' => [ 'ProcessingErrorList' ],
+	'PropertyLabelSimilarity' => [ 'PropertyLabelSimilarity' ],
+	'Types' => [ 'Types' ],
+	'URIResolver' => [ 'URIResolver' ],
+	'UnusedProperties' => [ 'UnusedProperties' ],
+	'WantedProperties' => [ 'WantedProperties' ],
+	'DeferredRequestDispatcher' => [ 'DeferredRequestDispatcher' ],
+];
 
 /** Afrikaans (Afrikaans) */
-$specialPageAliases['af'] = array(
-	'Ask' => array( 'Vra' ),
-	'Properties' => array( 'Eienskappe' ),
-	'Concepts' => array( 'Konsepte' ),
-	'Types' => array( 'Tipes' ),
-);
+$specialPageAliases['af'] = [
+	'Ask' => [ 'Vra' ],
+	'Properties' => [ 'Eienskappe' ],
+	'Concepts' => [ 'Konsepte' ],
+	'Types' => [ 'Tipes' ],
+];
 
 /** Arabic (العربية) */
-$specialPageAliases['ar'] = array(
-	'Ask' => array( 'سؤال' ),
-	'Browse' => array( 'تصفح' ),
-	'ExportRDF' => array( 'تصدير_RDF' ),
-	'PageProperty' => array( 'صفحة_خصيصة' ),
-	'Properties' => array( 'خصائص' ),
-	'Concepts' => array( 'مفاهيم' ),
-	'SMWAdmin' => array( 'إدارة_سمو', 'إدارة_ميدياويكي_دلالية' ),
-	'SearchByProperty' => array( 'بحث_بالخصيصة' ),
-	'Types' => array( 'أنواع' ),
-	'URIResolver' => array( 'حال_URI' ),
-	'UnusedProperties' => array( 'خصائص_غير_مستخدمة' ),
-	'WantedProperties' => array( 'خصائص_مطلوبة' ),
-);
+$specialPageAliases['ar'] = [
+	'Ask' => [ 'سؤال' ],
+	'Browse' => [ 'تصفح' ],
+	'ExportRDF' => [ 'تصدير_RDF' ],
+	'PageProperty' => [ 'صفحة_خصيصة' ],
+	'Properties' => [ 'خصائص' ],
+	'Concepts' => [ 'مفاهيم' ],
+	'SMWAdmin' => [ 'إدارة_سمو', 'إدارة_ميدياويكي_دلالية' ],
+	'SearchByProperty' => [ 'بحث_بالخصيصة' ],
+	'Types' => [ 'أنواع' ],
+	'URIResolver' => [ 'حال_URI' ],
+	'UnusedProperties' => [ 'خصائص_غير_مستخدمة' ],
+	'WantedProperties' => [ 'خصائص_مطلوبة' ],
+];
 
 /** Aramaic (ܐܪܡܝܐ) */
-$specialPageAliases['arc'] = array(
-	'Ask' => array( 'ܫܐܠ' ),
-	'Browse' => array( 'ܦܐܬ' ),
-	'PageProperty' => array( 'ܦܐܬܐ_ܕܕܝܠܝܘ̈ܬܐ' ),
-	'Properties' => array( 'ܕܝܠܝܘܬ̈ܐ' ),
-	'SearchByProperty' => array( 'ܒܨܝ_ܒܝܕ_ܕܝܠܝܘ̈ܬܐ' ),
-	'Types' => array( 'ܐܕ̈ܫܐ' ),
-	'UnusedProperties' => array( 'ܕܝܠܝܘ̈ܬܐ_ܠܐ_ܦܠܝܚ̈ܬܐ' ),
-	'WantedProperties' => array( 'ܕܝܠܝܘ̈ܬܐ_ܣܢܝܩ̈ܬܐ' ),
-);
+$specialPageAliases['arc'] = [
+	'Ask' => [ 'ܫܐܠ' ],
+	'Browse' => [ 'ܦܐܬ' ],
+	'PageProperty' => [ 'ܦܐܬܐ_ܕܕܝܠܝܘ̈ܬܐ' ],
+	'Properties' => [ 'ܕܝܠܝܘܬ̈ܐ' ],
+	'SearchByProperty' => [ 'ܒܨܝ_ܒܝܕ_ܕܝܠܝܘ̈ܬܐ' ],
+	'Types' => [ 'ܐܕ̈ܫܐ' ],
+	'UnusedProperties' => [ 'ܕܝܠܝܘ̈ܬܐ_ܠܐ_ܦܠܝܚ̈ܬܐ' ],
+	'WantedProperties' => [ 'ܕܝܠܝܘ̈ܬܐ_ܣܢܝܩ̈ܬܐ' ],
+];
 
 /** Egyptian Arabic (مصرى) */
-$specialPageAliases['arz'] = array(
-	'Ask' => array( 'سؤال' ),
-	'Browse' => array( 'براوز' ),
-	'ExportRDF' => array( 'تصدير_RDF' ),
-	'PageProperty' => array( 'خاصية_الصفحه' ),
-	'Properties' => array( 'خصايص' ),
-	'Concepts' => array( 'مبادئ' ),
-	'SMWAdmin' => array( 'ادارى_SMW' ),
-	'SearchByProperty' => array( 'دوّر_بالخاصيه' ),
-	'Types' => array( 'انواع' ),
-	'URIResolver' => array( 'محلل_يو_ار_اى' ),
-	'UnusedProperties' => array( 'خصايص_مش_مستعمله' ),
-	'WantedProperties' => array( 'خصايص_مطلوبه' ),
-);
+$specialPageAliases['arz'] = [
+	'Ask' => [ 'سؤال' ],
+	'Browse' => [ 'براوز' ],
+	'ExportRDF' => [ 'تصدير_RDF' ],
+	'PageProperty' => [ 'خاصية_الصفحه' ],
+	'Properties' => [ 'خصايص' ],
+	'Concepts' => [ 'مبادئ' ],
+	'SMWAdmin' => [ 'ادارى_SMW' ],
+	'SearchByProperty' => [ 'دوّر_بالخاصيه' ],
+	'Types' => [ 'انواع' ],
+	'URIResolver' => [ 'محلل_يو_ار_اى' ],
+	'UnusedProperties' => [ 'خصايص_مش_مستعمله' ],
+	'WantedProperties' => [ 'خصايص_مطلوبه' ],
+];
 
 /** Assamese (অসমীয়া) */
-$specialPageAliases['as'] = array(
-	'Ask' => array( 'সোধক' ),
-	'Browse' => array( 'ব্ৰাউজ' ),
-	'ExportRDF' => array( 'RDF_ৰপ্তানি' ),
-	'Types' => array( 'প্ৰকাৰসমূহ' ),
-);
+$specialPageAliases['as'] = [
+	'Ask' => [ 'সোধক' ],
+	'Browse' => [ 'ব্ৰাউজ' ],
+	'ExportRDF' => [ 'RDF_ৰপ্তানি' ],
+	'Types' => [ 'প্ৰকাৰসমূহ' ],
+];
 
 /** Western Balochi (بلوچی رخشانی) */
-$specialPageAliases['bgn'] = array(
-	'Ask' => array( 'سوال_و_سوج_ئان' ),
-	'Browse' => array( 'بروز' ),
-	'ExportRDF' => array( 'آر_ڈی_اف_ئی_ڈن_کورتین' ),
-	'PageProperty' => array( 'تاکدیمی_مالومات' ),
-	'Properties' => array( 'مالومات' ),
-	'Concepts' => array( 'موّزو_ئان' ),
-	'SMWAdmin' => array( 'اس_ام_ڈبلیو_ئی_مدیر' ),
-	'SearchByProperty' => array( 'گشتین_به_مالوماتی_اساس_ئا' ),
-	'Types' => array( 'ڈوّل_ئان' ),
-	'URIResolver' => array( 'یو_آر_آی_هل_کنۆک' ),
-	'UnusedProperties' => array( 'ایستیپاده_نه_بوته_ئین_مالومات' ),
-	'WantedProperties' => array( 'لوٹی_ته_بوته_ئین_مالومات' ),
-);
+$specialPageAliases['bgn'] = [
+	'Ask' => [ 'سوال_و_سوج_ئان' ],
+	'Browse' => [ 'بروز' ],
+	'ExportRDF' => [ 'آر_ڈی_اف_ئی_ڈن_کورتین' ],
+	'PageProperty' => [ 'تاکدیمی_مالومات' ],
+	'Properties' => [ 'مالومات' ],
+	'Concepts' => [ 'موّزو_ئان' ],
+	'SMWAdmin' => [ 'اس_ام_ڈبلیو_ئی_مدیر' ],
+	'SearchByProperty' => [ 'گشتین_به_مالوماتی_اساس_ئا' ],
+	'Types' => [ 'ڈوّل_ئان' ],
+	'URIResolver' => [ 'یو_آر_آی_هل_کنۆک' ],
+	'UnusedProperties' => [ 'ایستیپاده_نه_بوته_ئین_مالومات' ],
+	'WantedProperties' => [ 'لوٹی_ته_بوته_ئین_مالومات' ],
+];
 
 /** Banjar (Bahasa Banjar) */
-$specialPageAliases['bjn'] = array(
-	'Ask' => array( 'Takun' ),
-	'Browse' => array( 'Ambahi' ),
-	'Types' => array( 'Janis' ),
-);
+$specialPageAliases['bjn'] = [
+	'Ask' => [ 'Takun' ],
+	'Browse' => [ 'Ambahi' ],
+	'Types' => [ 'Janis' ],
+];
 
 /** Breton (brezhoneg) */
-$specialPageAliases['br'] = array(
-	'Ask' => array( 'Goulenn' ),
-	'Browse' => array( 'Furchal' ),
-	'ExportRDF' => array( 'EzorzhiañRDF' ),
-	'PageProperty' => array( 'PerzhioùPajenn' ),
-	'Properties' => array( 'Perzhioù' ),
-	'Types' => array( 'Seurtoù' ),
-);
+$specialPageAliases['br'] = [
+	'Ask' => [ 'Goulenn' ],
+	'Browse' => [ 'Furchal' ],
+	'ExportRDF' => [ 'EzorzhiañRDF' ],
+	'PageProperty' => [ 'PerzhioùPajenn' ],
+	'Properties' => [ 'Perzhioù' ],
+	'Types' => [ 'Seurtoù' ],
+];
 
 /** Bosnian (bosanski) */
-$specialPageAliases['bs'] = array(
-	'Ask' => array( 'Upit' ),
-	'Browse' => array( 'Pregledanje' ),
-	'ExportRDF' => array( 'IzvozRDF' ),
-	'Properties' => array( 'Svojstva' ),
-);
+$specialPageAliases['bs'] = [
+	'Ask' => [ 'Upit' ],
+	'Browse' => [ 'Pregledanje' ],
+	'ExportRDF' => [ 'IzvozRDF' ],
+	'Properties' => [ 'Svojstva' ],
+];
 
 /** Min Dong Chinese (Mìng-dĕ̤ng-ngṳ̄) */
-$specialPageAliases['cdo'] = array(
-	'Ask' => array( '問' ),
-	'Browse' => array( '瀏覽' ),
-	'ExportRDF' => array( '導出RDF' ),
-	'PageProperty' => array( '頁面屬性' ),
-);
+$specialPageAliases['cdo'] = [
+	'Ask' => [ '問' ],
+	'Browse' => [ '瀏覽' ],
+	'ExportRDF' => [ '導出RDF' ],
+	'PageProperty' => [ '頁面屬性' ],
+];
 
 /** German (Deutsch) */
-$specialPageAliases['de'] = array(
-	'Ask' => array( 'Semantische_Suche' ),
-	'Browse' => array( 'Durchsuchen', 'Browsen' ),
-	'ExportRDF' => array( 'RDF_exportieren', 'Exportiere_RDF' ),
-	'PageProperty' => array( 'Seitenattribut' ),
-	'Properties' => array( 'Attribute' ),
-	'Concepts' => array( 'Konzepte' ),
-	'SMWAdmin' => array( 'SemanticMediaWiki', 'SMW-Administration', 'SMW-Einrichtung' ),
-	'SearchByProperty' => array( 'Suche_mittels_Attribut' ),
-	'ProcessingErrorList' => array( 'Liste_der_Verarbeitungsfehler' ),
-	'PropertyLabelSimilarity' => array( 'Ähnliche_Attributbezeichnungen' ),
-	'Types' => array( 'Datentypen' ),
-	'URIResolver' => array( 'URI-Auflöser' ),
-	'UnusedProperties' => array( 'Verwaiste_Attribute' ),
-	'WantedProperties' => array( 'Gewünschte_Attribute' ),
-);
+$specialPageAliases['de'] = [
+	'Ask' => [ 'Semantische_Suche' ],
+	'Browse' => [ 'Durchsuchen', 'Browsen' ],
+	'ExportRDF' => [ 'RDF_exportieren', 'Exportiere_RDF' ],
+	'PageProperty' => [ 'Seitenattribut' ],
+	'Properties' => [ 'Attribute' ],
+	'Concepts' => [ 'Konzepte' ],
+	'SMWAdmin' => [ 'SemanticMediaWiki', 'SMW-Administration', 'SMW-Einrichtung' ],
+	'SearchByProperty' => [ 'Suche_mittels_Attribut' ],
+	'ProcessingErrorList' => [ 'Liste_der_Verarbeitungsfehler' ],
+	'PropertyLabelSimilarity' => [ 'Ähnliche_Attributbezeichnungen' ],
+	'Types' => [ 'Datentypen' ],
+	'URIResolver' => [ 'URI-Auflöser' ],
+	'UnusedProperties' => [ 'Verwaiste_Attribute' ],
+	'WantedProperties' => [ 'Gewünschte_Attribute' ],
+];
 
 /** Zazaki (Zazaki) */
-$specialPageAliases['diq'] = array(
-	'Ask' => array( 'Pers' ),
-	'Browse' => array( 'Bıgeyré' ),
-	'ExportRDF' => array( 'RDFTeberde' ),
-	'PageProperty' => array( 'BeğsaPeran' ),
-	'Properties' => array( 'Bexsiyeti' ),
-	'Concepts' => array( 'Konsepti' ),
-	'SMWAdmin' => array( 'SMWXızmetkar' ),
-	'SearchByProperty' => array( 'ĞısusiyetkarCıgeyrayış' ),
-	'Types' => array( 'Babeti' ),
-	'URIResolver' => array( 'URIAgozne' ),
-	'UnusedProperties' => array( 'ĞısusiyetéNékaréné' ),
-	'WantedProperties' => array( 'ĞısusiyetéWaşténé' ),
-);
+$specialPageAliases['diq'] = [
+	'Ask' => [ 'Pers' ],
+	'Browse' => [ 'Bıgeyré' ],
+	'ExportRDF' => [ 'RDFTeberde' ],
+	'PageProperty' => [ 'BeğsaPeran' ],
+	'Properties' => [ 'Bexsiyeti' ],
+	'Concepts' => [ 'Konsepti' ],
+	'SMWAdmin' => [ 'SMWXızmetkar' ],
+	'SearchByProperty' => [ 'ĞısusiyetkarCıgeyrayış' ],
+	'Types' => [ 'Babeti' ],
+	'URIResolver' => [ 'URIAgozne' ],
+	'UnusedProperties' => [ 'ĞısusiyetéNékaréné' ],
+	'WantedProperties' => [ 'ĞısusiyetéWaşténé' ],
+];
 
 /** Lower Sorbian (dolnoserbski) */
-$specialPageAliases['dsb'] = array(
-	'Ask' => array( 'Semantiske pytanhje' ),
-	'Browse' => array( 'Pśepytaś' ),
-	'ExportRDF' => array( 'RDF eksportěrowaś' ),
-	'PageProperty' => array( 'Bokowa kakosć' ),
-	'Properties' => array( 'Kakosći' ),
-	'SearchByProperty' => array( 'Z kakosću pytaś' ),
-	'Types' => array( 'Datowe typy' ),
-	'UnusedProperties' => array( 'Njewužywane kakosći' ),
-	'WantedProperties' => array( 'Póžedane kakosći' ),
-);
+$specialPageAliases['dsb'] = [
+	'Ask' => [ 'Semantiske pytanhje' ],
+	'Browse' => [ 'Pśepytaś' ],
+	'ExportRDF' => [ 'RDF eksportěrowaś' ],
+	'PageProperty' => [ 'Bokowa kakosć' ],
+	'Properties' => [ 'Kakosći' ],
+	'SearchByProperty' => [ 'Z kakosću pytaś' ],
+	'Types' => [ 'Datowe typy' ],
+	'UnusedProperties' => [ 'Njewužywane kakosći' ],
+	'WantedProperties' => [ 'Póžedane kakosći' ],
+];
 
 /** Divehi (ދިވެހިބަސް) */
-$specialPageAliases['dv'] = array(
-	'Ask' => array( 'އައްސަވާ' ),
-);
+$specialPageAliases['dv'] = [
+	'Ask' => [ 'އައްސަވާ' ],
+];
 
 /** Greek (Ελληνικά) */
-$specialPageAliases['el'] = array(
-	'Ask' => array( 'Ερώτημα' ),
-	'Browse' => array( 'Περιήγηση' ),
-	'ExportRDF' => array( 'ΕξαγωγήRDF' ),
-	'PageProperty' => array( 'ΙδιότηταΣελίδας' ),
-	'Properties' => array( 'Ιδιότητες' ),
-	'Concepts' => array( 'Έννοιες' ),
-	'SMWAdmin' => array( 'ΔιαχείρισηSMW' ),
-	'SearchByProperty' => array( 'ΑναζήτησηΜεΙδιότητα' ),
-	'Types' => array( 'Τύποι' ),
-	'URIResolver' => array( 'ΑναλυτήςURI' ),
-	'UnusedProperties' => array( 'ΜηΧρησιμοποιούμενεςΙδιότητες' ),
-	'WantedProperties' => array( 'ΖητούμενεςΙδιότητες' ),
-);
+$specialPageAliases['el'] = [
+	'Ask' => [ 'Ερώτημα' ],
+	'Browse' => [ 'Περιήγηση' ],
+	'ExportRDF' => [ 'ΕξαγωγήRDF' ],
+	'PageProperty' => [ 'ΙδιότηταΣελίδας' ],
+	'Properties' => [ 'Ιδιότητες' ],
+	'Concepts' => [ 'Έννοιες' ],
+	'SMWAdmin' => [ 'ΔιαχείρισηSMW' ],
+	'SearchByProperty' => [ 'ΑναζήτησηΜεΙδιότητα' ],
+	'Types' => [ 'Τύποι' ],
+	'URIResolver' => [ 'ΑναλυτήςURI' ],
+	'UnusedProperties' => [ 'ΜηΧρησιμοποιούμενεςΙδιότητες' ],
+	'WantedProperties' => [ 'ΖητούμενεςΙδιότητες' ],
+];
 
 /** Esperanto (Esperanto) */
-$specialPageAliases['eo'] = array(
-	'Ask' => array( 'Peti' ),
-	'Browse' => array( 'Foliumi' ),
-	'ExportRDF' => array( 'Elporti_RDF', 'Eksporti_RDF' ),
-	'PageProperty' => array( 'Ecoj_de_paĝo' ),
-	'Properties' => array( 'Ecoj' ),
-	'Types' => array( 'Specoj' ),
-);
+$specialPageAliases['eo'] = [
+	'Ask' => [ 'Peti' ],
+	'Browse' => [ 'Foliumi' ],
+	'ExportRDF' => [ 'Elporti_RDF', 'Eksporti_RDF' ],
+	'PageProperty' => [ 'Ecoj_de_paĝo' ],
+	'Properties' => [ 'Ecoj' ],
+	'Types' => [ 'Specoj' ],
+];
 
 /** Spanish (español) */
-$specialPageAliases['es'] = array(
-	'Properties' => array( 'Propiedades' ),
-	'SearchByProperty' => array( 'BuscarPorPropiedad' ),
-	'Types' => array( 'Tipos' ),
-	'UnusedProperties' => array( 'PropiedadesNoUsadas' ),
-	'WantedProperties' => array( 'PropiedadesRequeridas' ),
-);
+$specialPageAliases['es'] = [
+	'Properties' => [ 'Propiedades' ],
+	'SearchByProperty' => [ 'BuscarPorPropiedad' ],
+	'Types' => [ 'Tipos' ],
+	'UnusedProperties' => [ 'PropiedadesNoUsadas' ],
+	'WantedProperties' => [ 'PropiedadesRequeridas' ],
+];
 
 /** Persian (فارسی) */
-$specialPageAliases['fa'] = array(
-	'Ask' => array( 'پرسش' ),
-	'Browse' => array( 'مرور' ),
-	'ExportRDF' => array( 'برونریزی_آردی‌اف' ),
-	'PageProperty' => array( 'جزئیات_صفحه' ),
-	'Properties' => array( 'جزئیات' ),
-	'Concepts' => array( 'مفاهیم' ),
-	'SMWAdmin' => array( 'مدیر_اس‌ام‌دبلیو' ),
-	'SearchByProperty' => array( 'جستجو_بر_پایهٔ_جزئیات' ),
-	'Types' => array( 'نوع‌ها' ),
-	'URIResolver' => array( 'حل‌کننده_یو‌آر‌آی' ),
-	'UnusedProperties' => array( 'جزئیات_استفاده_نشده' ),
-	'WantedProperties' => array( 'جزئیات_درخواستی' ),
-);
+$specialPageAliases['fa'] = [
+	'Ask' => [ 'پرسش' ],
+	'Browse' => [ 'مرور' ],
+	'ExportRDF' => [ 'برونریزی_آردی‌اف' ],
+	'PageProperty' => [ 'جزئیات_صفحه' ],
+	'Properties' => [ 'جزئیات' ],
+	'Concepts' => [ 'مفاهیم' ],
+	'SMWAdmin' => [ 'مدیر_اس‌ام‌دبلیو' ],
+	'SearchByProperty' => [ 'جستجو_بر_پایهٔ_جزئیات' ],
+	'Types' => [ 'نوع‌ها' ],
+	'URIResolver' => [ 'حل‌کننده_یو‌آر‌آی' ],
+	'UnusedProperties' => [ 'جزئیات_استفاده_نشده' ],
+	'WantedProperties' => [ 'جزئیات_درخواستی' ],
+];
 
 /** Finnish (suomi) */
-$specialPageAliases['fi'] = array(
-	'Ask' => array( 'Kysy' ),
-	'Browse' => array( 'Selaa' ),
-	'ExportRDF' => array( 'RDF-vienti' ),
-	'Properties' => array( 'Ominaisuudet' ),
-	'SMWAdmin' => array( 'Semanttisen_Mediawikin_ylläpito' ),
-	'Types' => array( 'Tyypit' ),
-	'UnusedProperties' => array( 'Käyttämättömät_ominaisuudet' ),
-	'WantedProperties' => array( 'Halutut_ominaisuudet' ),
-);
+$specialPageAliases['fi'] = [
+	'Ask' => [ 'Kysy' ],
+	'Browse' => [ 'Selaa' ],
+	'ExportRDF' => [ 'RDF-vienti' ],
+	'Properties' => [ 'Ominaisuudet' ],
+	'SMWAdmin' => [ 'Semanttisen_Mediawikin_ylläpito' ],
+	'Types' => [ 'Tyypit' ],
+	'UnusedProperties' => [ 'Käyttämättömät_ominaisuudet' ],
+	'WantedProperties' => [ 'Halutut_ominaisuudet' ],
+];
 
 /** French (français) */
-$specialPageAliases['fr'] = array(
-	'Ask' => array( 'Requêter' ),
-	'Browse' => array( 'Parcourir' ),
-	'ExportRDF' => array( 'Export_RDF' ),
-	'PageProperty' => array( 'Propriétés_de_la_page' ),
-	'Properties' => array( 'Propriétés' ),
-	'Concepts' => array( 'Concepts' ),
-	'SearchByProperty' => array( 'Recherche_par_propriété' ),
-	'Types' => array( 'Types' ),
-	'UnusedProperties' => array( 'Propriétés_inutilisées' ),
-	'WantedProperties' => array( 'Propriétés_demandées' ),
-);
+$specialPageAliases['fr'] = [
+	'Ask' => [ 'Requêter' ],
+	'Browse' => [ 'Parcourir' ],
+	'ExportRDF' => [ 'Export_RDF' ],
+	'PageProperty' => [ 'Propriétés_de_la_page' ],
+	'Properties' => [ 'Propriétés' ],
+	'Concepts' => [ 'Concepts' ],
+	'SearchByProperty' => [ 'Recherche_par_propriété' ],
+	'Types' => [ 'Types' ],
+	'UnusedProperties' => [ 'Propriétés_inutilisées' ],
+	'WantedProperties' => [ 'Propriétés_demandées' ],
+];
 
 /** Galician (galego) */
-$specialPageAliases['gl'] = array(
-	'Ask' => array( 'Preguntar' ),
-	'Browse' => array( 'Navegar' ),
-	'ExportRDF' => array( 'Exportar_RDF' ),
-	'PageProperty' => array( 'Propiedades_da_páxina' ),
-	'Properties' => array( 'Propiedades' ),
-	'Concepts' => array( 'Conceptos' ),
-	'SearchByProperty' => array( 'Procurar_por_propiedades' ),
-	'Types' => array( 'Tipos' ),
-	'UnusedProperties' => array( 'Propiedades_sen_uso' ),
-	'WantedProperties' => array( 'Propiedades_requiridas' ),
-);
+$specialPageAliases['gl'] = [
+	'Ask' => [ 'Preguntar' ],
+	'Browse' => [ 'Navegar' ],
+	'ExportRDF' => [ 'Exportar_RDF' ],
+	'PageProperty' => [ 'Propiedades_da_páxina' ],
+	'Properties' => [ 'Propiedades' ],
+	'Concepts' => [ 'Conceptos' ],
+	'SearchByProperty' => [ 'Procurar_por_propiedades' ],
+	'Types' => [ 'Tipos' ],
+	'UnusedProperties' => [ 'Propiedades_sen_uso' ],
+	'WantedProperties' => [ 'Propiedades_requiridas' ],
+];
 
 /** Swiss German (Alemannisch) */
-$specialPageAliases['gsw'] = array(
-	'Ask' => array( 'Semantischi_Suech' ),
-	'Browse' => array( 'Duresueche' ),
-	'ExportRDF' => array( 'Exportier_ADF' ),
-	'PageProperty' => array( 'Syteattribut' ),
-	'Properties' => array( 'Attribut' ),
-	'SMWAdmin' => array( 'SMW-Yyrichtig' ),
-	'SearchByProperty' => array( 'Suech_no_Attribut' ),
-	'Types' => array( 'Datetype' ),
-	'URIResolver' => array( 'URI-Ufflöser' ),
-	'UnusedProperties' => array( 'Verwaisti_Attribut' ),
-	'WantedProperties' => array( 'Gwinschti_Attribut' ),
-);
+$specialPageAliases['gsw'] = [
+	'Ask' => [ 'Semantischi_Suech' ],
+	'Browse' => [ 'Duresueche' ],
+	'ExportRDF' => [ 'Exportier_ADF' ],
+	'PageProperty' => [ 'Syteattribut' ],
+	'Properties' => [ 'Attribut' ],
+	'SMWAdmin' => [ 'SMW-Yyrichtig' ],
+	'SearchByProperty' => [ 'Suech_no_Attribut' ],
+	'Types' => [ 'Datetype' ],
+	'URIResolver' => [ 'URI-Ufflöser' ],
+	'UnusedProperties' => [ 'Verwaisti_Attribut' ],
+	'WantedProperties' => [ 'Gwinschti_Attribut' ],
+];
 
 /** Hebrew (עברית) */
-$specialPageAliases['he'] = array(
-	'Ask' => array( 'שאלה' ),
-	'Browse' => array( 'עיון' ),
-	'ExportRDF' => array( 'ייצור_RDF' ),
-	'PageProperty' => array( 'מאפיין_דף' ),
-	'Properties' => array( 'מאפיינים' ),
-	'Concepts' => array( 'רעיונות' ),
-	'SMWAdmin' => array( 'ניהול_SMW' ),
-	'SearchByProperty' => array( 'חיפוש_לפי_שאילתה' ),
-	'Types' => array( 'סוגים' ),
-	'URIResolver' => array( 'פותר_URI' ),
-	'UnusedProperties' => array( 'מאפיינים_שאינם_בשימוש' ),
-	'WantedProperties' => array( 'מאפיינים_מבוקשים' ),
-);
+$specialPageAliases['he'] = [
+	'Ask' => [ 'שאלה' ],
+	'Browse' => [ 'עיון' ],
+	'ExportRDF' => [ 'ייצור_RDF' ],
+	'PageProperty' => [ 'מאפיין_דף' ],
+	'Properties' => [ 'מאפיינים' ],
+	'Concepts' => [ 'רעיונות' ],
+	'SMWAdmin' => [ 'ניהול_SMW' ],
+	'SearchByProperty' => [ 'חיפוש_לפי_שאילתה' ],
+	'Types' => [ 'סוגים' ],
+	'URIResolver' => [ 'פותר_URI' ],
+	'UnusedProperties' => [ 'מאפיינים_שאינם_בשימוש' ],
+	'WantedProperties' => [ 'מאפיינים_מבוקשים' ],
+];
 
 /** Hindi (हिन्दी) */
-$specialPageAliases['hi'] = array(
-	'Ask' => array( 'पूछो' ),
-);
+$specialPageAliases['hi'] = [
+	'Ask' => [ 'पूछो' ],
+];
 
 /** Upper Sorbian (hornjoserbsce) */
-$specialPageAliases['hsb'] = array(
-	'Ask' => array( 'Semantiske_pytanje' ),
-	'Browse' => array( 'Přepytać' ),
-	'ExportRDF' => array( 'RDF_eksportować' ),
-	'PageProperty' => array( 'Kajkosć_strony' ),
-	'Properties' => array( 'Kajkosće' ),
-	'Concepts' => array( 'Koncepty' ),
-	'SMWAdmin' => array( 'SMW-administracija' ),
-	'SearchByProperty' => array( 'Pytanje_po_kajkosći' ),
-	'Types' => array( 'Datowe_typy' ),
-	'UnusedProperties' => array( 'Njewužiwane_kajkosće' ),
-	'WantedProperties' => array( 'Falowace_kajkosće' ),
-);
+$specialPageAliases['hsb'] = [
+	'Ask' => [ 'Semantiske_pytanje' ],
+	'Browse' => [ 'Přepytać' ],
+	'ExportRDF' => [ 'RDF_eksportować' ],
+	'PageProperty' => [ 'Kajkosć_strony' ],
+	'Properties' => [ 'Kajkosće' ],
+	'Concepts' => [ 'Koncepty' ],
+	'SMWAdmin' => [ 'SMW-administracija' ],
+	'SearchByProperty' => [ 'Pytanje_po_kajkosći' ],
+	'Types' => [ 'Datowe_typy' ],
+	'UnusedProperties' => [ 'Njewužiwane_kajkosće' ],
+	'WantedProperties' => [ 'Falowace_kajkosće' ],
+];
 
 /** Haitian (Kreyòl ayisyen) */
-$specialPageAliases['ht'] = array(
-	'Ask' => array( 'Mande' ),
-	'Browse' => array( 'Navige' ),
-	'ExportRDF' => array( 'EkspòteRDF' ),
-	'PageProperty' => array( 'ProprietePaj' ),
-	'Properties' => array( 'Propriete' ),
-	'SMWAdmin' => array( 'AdminSMW' ),
-	'SearchByProperty' => array( 'ChachePaPropriete' ),
-	'Types' => array( 'Tip' ),
-	'UnusedProperties' => array( 'ProprietePaSèvi' ),
-	'WantedProperties' => array( 'ProprieteKiMande' ),
-);
+$specialPageAliases['ht'] = [
+	'Ask' => [ 'Mande' ],
+	'Browse' => [ 'Navige' ],
+	'ExportRDF' => [ 'EkspòteRDF' ],
+	'PageProperty' => [ 'ProprietePaj' ],
+	'Properties' => [ 'Propriete' ],
+	'SMWAdmin' => [ 'AdminSMW' ],
+	'SearchByProperty' => [ 'ChachePaPropriete' ],
+	'Types' => [ 'Tip' ],
+	'UnusedProperties' => [ 'ProprietePaSèvi' ],
+	'WantedProperties' => [ 'ProprieteKiMande' ],
+];
 
 /** Hungarian (magyar) */
-$specialPageAliases['hu'] = array(
-	'Ask' => array( 'Kérdez' ),
-	'Browse' => array( 'Böngészés' ),
-	'Properties' => array( 'Tulajdonságok' ),
-	'Types' => array( 'Típusok' ),
-	'URIResolver' => array( 'URI-feloldó' ),
-	'UnusedProperties' => array( 'Nem_használt_tulajdonságok' ),
-	'WantedProperties' => array( 'Keresett_tulajdonságok' ),
-);
+$specialPageAliases['hu'] = [
+	'Ask' => [ 'Kérdez' ],
+	'Browse' => [ 'Böngészés' ],
+	'Properties' => [ 'Tulajdonságok' ],
+	'Types' => [ 'Típusok' ],
+	'URIResolver' => [ 'URI-feloldó' ],
+	'UnusedProperties' => [ 'Nem_használt_tulajdonságok' ],
+	'WantedProperties' => [ 'Keresett_tulajdonságok' ],
+];
 
 /** Interlingua (interlingua) */
-$specialPageAliases['ia'] = array(
-	'Ask' => array( 'Consultar' ),
-	'Browse' => array( 'Percurrer' ),
-	'ExportRDF' => array( 'Exportar_RDF' ),
-	'PageProperty' => array( 'Proprietate_de_pagina' ),
-	'Properties' => array( 'Proprietates' ),
-	'SMWAdmin' => array( 'Admin_SMW' ),
-	'SearchByProperty' => array( 'Cercar_per_proprietate' ),
-	'Types' => array( 'Typos' ),
-	'URIResolver' => array( 'Resolvitor_de_URIs' ),
-	'UnusedProperties' => array( 'Proprietates_non_usate' ),
-	'WantedProperties' => array( 'Proprietates_dsesirate' ),
-);
+$specialPageAliases['ia'] = [
+	'Ask' => [ 'Consultar' ],
+	'Browse' => [ 'Percurrer' ],
+	'ExportRDF' => [ 'Exportar_RDF' ],
+	'PageProperty' => [ 'Proprietate_de_pagina' ],
+	'Properties' => [ 'Proprietates' ],
+	'SMWAdmin' => [ 'Admin_SMW' ],
+	'SearchByProperty' => [ 'Cercar_per_proprietate' ],
+	'Types' => [ 'Typos' ],
+	'URIResolver' => [ 'Resolvitor_de_URIs' ],
+	'UnusedProperties' => [ 'Proprietates_non_usate' ],
+	'WantedProperties' => [ 'Proprietates_dsesirate' ],
+];
 
 /** Indonesian (Bahasa Indonesia) */
-$specialPageAliases['id'] = array(
-	'Ask' => array( 'Tanya' ),
-	'Browse' => array( 'Jelajahi' ),
-	'ExportRDF' => array( 'EksporRDF' ),
-	'PageProperty' => array( 'PropertiHalaman' ),
-	'Properties' => array( 'Properti' ),
-	'SMWAdmin' => array( 'AdminSMW' ),
-	'SearchByProperty' => array( 'PencarianProperti' ),
-	'Types' => array( 'Tipe' ),
-	'URIResolver' => array( 'PenguraiURI' ),
-	'UnusedProperties' => array( 'PropertiTakDigunakan' ),
-	'WantedProperties' => array( 'PropertiDiinginkan' ),
-);
+$specialPageAliases['id'] = [
+	'Ask' => [ 'Tanya' ],
+	'Browse' => [ 'Jelajahi' ],
+	'ExportRDF' => [ 'EksporRDF' ],
+	'PageProperty' => [ 'PropertiHalaman' ],
+	'Properties' => [ 'Properti' ],
+	'SMWAdmin' => [ 'AdminSMW' ],
+	'SearchByProperty' => [ 'PencarianProperti' ],
+	'Types' => [ 'Tipe' ],
+	'URIResolver' => [ 'PenguraiURI' ],
+	'UnusedProperties' => [ 'PropertiTakDigunakan' ],
+	'WantedProperties' => [ 'PropertiDiinginkan' ],
+];
 
 /** Italian (italiano) */
-$specialPageAliases['it'] = array(
-	'Ask' => array( 'Chiedi' ),
-	'Browse' => array( 'Esplora' ),
-	'ExportRDF' => array( 'EsportaRDF' ),
-	'PageProperty' => array( 'ProprietàPagina' ),
-	'Properties' => array( 'Proprietà' ),
-	'Concepts' => array( 'Concetti' ),
-	'SMWAdmin' => array( 'AdminSMW' ),
-	'SearchByProperty' => array( 'CercaPerProprietà' ),
-	'Types' => array( 'Tipi' ),
-	'URIResolver' => array( 'RisolutoreURI' ),
-	'UnusedProperties' => array( 'ProprietàNonUtilizzate' ),
-	'WantedProperties' => array( 'ProprietàRichieste' ),
-);
+$specialPageAliases['it'] = [
+	'Ask' => [ 'Chiedi' ],
+	'Browse' => [ 'Esplora' ],
+	'ExportRDF' => [ 'EsportaRDF' ],
+	'PageProperty' => [ 'ProprietàPagina' ],
+	'Properties' => [ 'Proprietà' ],
+	'Concepts' => [ 'Concetti' ],
+	'SMWAdmin' => [ 'AdminSMW' ],
+	'SearchByProperty' => [ 'CercaPerProprietà' ],
+	'Types' => [ 'Tipi' ],
+	'URIResolver' => [ 'RisolutoreURI' ],
+	'UnusedProperties' => [ 'ProprietàNonUtilizzate' ],
+	'WantedProperties' => [ 'ProprietàRichieste' ],
+];
 
 /** Japanese (日本語) */
-$specialPageAliases['ja'] = array(
-	'Ask' => array( '問い合わせ', '意味的検索' ),
-	'Browse' => array( '閲覧' ),
-	'ExportRDF' => array( 'RDF書き出し', 'RDFエクスポート', 'ＲＤＦエクスポート' ),
-	'PageProperty' => array( 'ページプロパティ' ),
-	'Properties' => array( 'プロパティ一覧' ),
-	'Concepts' => array( '概念' ),
-	'SMWAdmin' => array( 'SMW管理', 'ＳＭＷ管理' ),
-	'SearchByProperty' => array( 'プロパティによる検索' ),
-	'Types' => array( '型一覧' ),
-	'URIResolver' => array( 'URIリゾルバー', 'ＵＲＩリゾルバー' ),
-	'UnusedProperties' => array( '使われていないプロパティ' ),
-	'WantedProperties' => array( '望まれているプロパティ' ),
-);
+$specialPageAliases['ja'] = [
+	'Ask' => [ '問い合わせ', '意味的検索' ],
+	'Browse' => [ '閲覧' ],
+	'ExportRDF' => [ 'RDF書き出し', 'RDFエクスポート', 'ＲＤＦエクスポート' ],
+	'PageProperty' => [ 'ページプロパティ' ],
+	'Properties' => [ 'プロパティ一覧' ],
+	'Concepts' => [ '概念' ],
+	'SMWAdmin' => [ 'SMW管理', 'ＳＭＷ管理' ],
+	'SearchByProperty' => [ 'プロパティによる検索' ],
+	'Types' => [ '型一覧' ],
+	'URIResolver' => [ 'URIリゾルバー', 'ＵＲＩリゾルバー' ],
+	'UnusedProperties' => [ '使われていないプロパティ' ],
+	'WantedProperties' => [ '望まれているプロパティ' ],
+];
 
 /** Georgian (ქართული) */
-$specialPageAliases['ka'] = array(
-	'Types' => array( 'ტიპები' ),
-);
+$specialPageAliases['ka'] = [
+	'Types' => [ 'ტიპები' ],
+];
 
 /** Khmer (ភាសាខ្មែរ) */
-$specialPageAliases['km'] = array(
-	'Browse' => array( 'រាវរក' ),
-	'Properties' => array( 'លក្ខណៈ' ),
-	'Types' => array( 'ប្រភេទ' ),
-);
+$specialPageAliases['km'] = [
+	'Browse' => [ 'រាវរក' ],
+	'Properties' => [ 'លក្ខណៈ' ],
+	'Types' => [ 'ប្រភេទ' ],
+];
 
 /** Korean (한국어) */
-$specialPageAliases['ko'] = array(
-	'Ask' => array( '묻기' ),
-	'Browse' => array( '찾아보기' ),
-	'ExportRDF' => array( 'RDF내보내기' ),
-	'PageProperty' => array( '문서속성' ),
-	'Properties' => array( '속성목록' ),
-	'Concepts' => array( '개념목록' ),
-	'SMWAdmin' => array( 'SMW관리자' ),
-	'SearchByProperty' => array( '속성별검색', '속성별찾기' ),
-	'Types' => array( '종류목록' ),
-	'URIResolver' => array( 'URI해결' ),
-	'UnusedProperties' => array( '안쓰는속성', '쓰이지않는속성' ),
-	'WantedProperties' => array( '필요한속성' ),
-);
+$specialPageAliases['ko'] = [
+	'Ask' => [ '묻기' ],
+	'Browse' => [ '찾아보기' ],
+	'ExportRDF' => [ 'RDF내보내기' ],
+	'PageProperty' => [ '문서속성' ],
+	'Properties' => [ '속성목록' ],
+	'Concepts' => [ '개념목록' ],
+	'SMWAdmin' => [ 'SMW관리자' ],
+	'SearchByProperty' => [ '속성별검색', '속성별찾기' ],
+	'Types' => [ '종류목록' ],
+	'URIResolver' => [ 'URI해결' ],
+	'UnusedProperties' => [ '안쓰는속성', '쓰이지않는속성' ],
+	'WantedProperties' => [ '필요한속성' ],
+];
 
 /** Colognian (Ripoarisch) */
-$specialPageAliases['ksh'] = array(
-	'Ask' => array( 'Froore' ),
-	'Browse' => array( 'Bläddere' ),
-	'ExportRDF' => array( 'RDF', 'RDF Äxpotteere' ),
-	'PageProperty' => array( 'Eijeschaffte vun Sigge' ),
-	'Properties' => array( 'Eijeschaffte' ),
-	'SMWAdmin' => array( 'Semantesch MediaWiki Ennreschte' ),
-	'SearchByProperty' => array( 'Noh Eijeschaffte söke' ),
-	'Types' => array( 'Zoote vun Daate' ),
-	'UnusedProperties' => array( 'Eijeschaffte di nit jebruch wääde' ),
-	'WantedProperties' => array( 'Eijeschaffte di noch jebruch wääde' ),
-);
+$specialPageAliases['ksh'] = [
+	'Ask' => [ 'Froore' ],
+	'Browse' => [ 'Bläddere' ],
+	'ExportRDF' => [ 'RDF', 'RDF Äxpotteere' ],
+	'PageProperty' => [ 'Eijeschaffte vun Sigge' ],
+	'Properties' => [ 'Eijeschaffte' ],
+	'SMWAdmin' => [ 'Semantesch MediaWiki Ennreschte' ],
+	'SearchByProperty' => [ 'Noh Eijeschaffte söke' ],
+	'Types' => [ 'Zoote vun Daate' ],
+	'UnusedProperties' => [ 'Eijeschaffte di nit jebruch wääde' ],
+	'WantedProperties' => [ 'Eijeschaffte di noch jebruch wääde' ],
+];
 
 /** Cornish (kernowek) */
-$specialPageAliases['kw'] = array(
-	'Ask' => array( 'Govyn' ),
-	'Browse' => array( 'Peuri' ),
-	'ExportRDF' => array( 'EsperthiRDF' ),
-	'PageProperty' => array( 'GnasFolen' ),
-	'Properties' => array( 'Gnasow' ),
-	'SearchByProperty' => array( 'HwilasHerwydhGnas' ),
-);
+$specialPageAliases['kw'] = [
+	'Ask' => [ 'Govyn' ],
+	'Browse' => [ 'Peuri' ],
+	'ExportRDF' => [ 'EsperthiRDF' ],
+	'PageProperty' => [ 'GnasFolen' ],
+	'Properties' => [ 'Gnasow' ],
+	'SearchByProperty' => [ 'HwilasHerwydhGnas' ],
+];
 
 /** Luxembourgish (Lëtzebuergesch) */
-$specialPageAliases['lb'] = array(
-	'Ask' => array( 'Froen' ),
-	'Browse' => array( 'Browsen' ),
-	'ExportRDF' => array( 'RDF_exportéieren' ),
-	'PageProperty' => array( 'Säiten-Eegeschaften' ),
-	'Properties' => array( 'Eegeschaften' ),
-	'Concepts' => array( 'Konzepter' ),
-	'SMWAdmin' => array( 'SMW-Administratioun' ),
-	'SearchByProperty' => array( 'No_Eegeschaft_sichen' ),
-	'Types' => array( 'Datentypen' ),
-	'UnusedProperties' => array( 'Netbenotzt_Eegeschaften' ),
-	'WantedProperties' => array( 'Gewënscht_Eegeschaften' ),
-);
+$specialPageAliases['lb'] = [
+	'Ask' => [ 'Froen' ],
+	'Browse' => [ 'Browsen' ],
+	'ExportRDF' => [ 'RDF_exportéieren' ],
+	'PageProperty' => [ 'Säiten-Eegeschaften' ],
+	'Properties' => [ 'Eegeschaften' ],
+	'Concepts' => [ 'Konzepter' ],
+	'SMWAdmin' => [ 'SMW-Administratioun' ],
+	'SearchByProperty' => [ 'No_Eegeschaft_sichen' ],
+	'Types' => [ 'Datentypen' ],
+	'UnusedProperties' => [ 'Netbenotzt_Eegeschaften' ],
+	'WantedProperties' => [ 'Gewënscht_Eegeschaften' ],
+];
 
 /** Lombard (lumbaart) */
-$specialPageAliases['lmo'] = array(
-	'Ask' => array( 'Ciama' ),
-);
+$specialPageAliases['lmo'] = [
+	'Ask' => [ 'Ciama' ],
+];
 
 /** Macedonian (македонски) */
-$specialPageAliases['mk'] = array(
-	'Ask' => array( 'Прашај' ),
-	'Browse' => array( 'Прелистај' ),
-	'ExportRDF' => array( 'ИзвезиRDF' ),
-	'PageProperty' => array( 'СвојстваНаСтраница' ),
-	'Properties' => array( 'Својства' ),
-	'Concepts' => array( 'Концепти' ),
-	'SMWAdmin' => array( 'СМВАдминистратор' ),
-	'SearchByProperty' => array( 'ПребарајПоСвојство' ),
-	'Types' => array( 'Типови' ),
-	'URIResolver' => array( 'URIРешавач' ),
-	'UnusedProperties' => array( 'НекористениСвојства' ),
-	'WantedProperties' => array( 'ПотребниСвојства' ),
-);
+$specialPageAliases['mk'] = [
+	'Ask' => [ 'Прашај' ],
+	'Browse' => [ 'Прелистај' ],
+	'ExportRDF' => [ 'ИзвезиRDF' ],
+	'PageProperty' => [ 'СвојстваНаСтраница' ],
+	'Properties' => [ 'Својства' ],
+	'Concepts' => [ 'Концепти' ],
+	'SMWAdmin' => [ 'СМВАдминистратор' ],
+	'SearchByProperty' => [ 'ПребарајПоСвојство' ],
+	'Types' => [ 'Типови' ],
+	'URIResolver' => [ 'URIРешавач' ],
+	'UnusedProperties' => [ 'НекористениСвојства' ],
+	'WantedProperties' => [ 'ПотребниСвојства' ],
+];
 
 /** Malayalam (മലയാളം) */
-$specialPageAliases['ml'] = array(
-	'Ask' => array( 'ചോദിക്കുക' ),
-	'Browse' => array( 'ബ്രൗസ്' ),
-	'Types' => array( 'തരങ്ങൾ' ),
-);
+$specialPageAliases['ml'] = [
+	'Ask' => [ 'ചോദിക്കുക' ],
+	'Browse' => [ 'ബ്രൗസ്' ],
+	'Types' => [ 'തരങ്ങൾ' ],
+];
 
 /** Marathi (मराठी) */
-$specialPageAliases['mr'] = array(
-	'Ask' => array( 'विचारा' ),
-	'Browse' => array( 'न्याहाळा' ),
-	'ExportRDF' => array( 'आरडीएफनिर्यात' ),
-	'PageProperty' => array( 'पानवैशिष्ट्ये' ),
-	'Properties' => array( 'वैशिष्ट्ये' ),
-	'Concepts' => array( 'संकल्पना' ),
-	'SMWAdmin' => array( 'एसएमडब्ल्यूप्रचालक' ),
-	'SearchByProperty' => array( 'वैशिष्ट्येनुसारशोध' ),
-	'Types' => array( 'प्रकार' ),
-	'URIResolver' => array( 'यूआरायरिझॉल्व्हर' ),
-	'UnusedProperties' => array( 'नवापरलेलीवैशिष्ट्ये' ),
-	'WantedProperties' => array( 'हवीअसलेलीवैशिष्ट्ये' ),
-);
+$specialPageAliases['mr'] = [
+	'Ask' => [ 'विचारा' ],
+	'Browse' => [ 'न्याहाळा' ],
+	'ExportRDF' => [ 'आरडीएफनिर्यात' ],
+	'PageProperty' => [ 'पानवैशिष्ट्ये' ],
+	'Properties' => [ 'वैशिष्ट्ये' ],
+	'Concepts' => [ 'संकल्पना' ],
+	'SMWAdmin' => [ 'एसएमडब्ल्यूप्रचालक' ],
+	'SearchByProperty' => [ 'वैशिष्ट्येनुसारशोध' ],
+	'Types' => [ 'प्रकार' ],
+	'URIResolver' => [ 'यूआरायरिझॉल्व्हर' ],
+	'UnusedProperties' => [ 'नवापरलेलीवैशिष्ट्ये' ],
+	'WantedProperties' => [ 'हवीअसलेलीवैशिष्ट्ये' ],
+];
 
 /** Maltese (Malti) */
-$specialPageAliases['mt'] = array(
-	'Ask' => array( 'Staqsi' ),
-	'Browse' => array( 'Esplora' ),
-);
+$specialPageAliases['mt'] = [
+	'Ask' => [ 'Staqsi' ],
+	'Browse' => [ 'Esplora' ],
+];
 
 /** Norwegian Bokmål (norsk bokmål) */
-$specialPageAliases['nb'] = array(
-	'Ask' => array( 'Spør' ),
-	'Browse' => array( 'Se_gjennom' ),
-	'ExportRDF' => array( 'Eksporter_RDF' ),
-	'PageProperty' => array( 'Sideegenskaper' ),
-	'Properties' => array( 'Egenskaper' ),
-	'Concepts' => array( 'Konsepter' ),
-	'SMWAdmin' => array( 'SMW-administrasjon' ),
-	'SearchByProperty' => array( 'Søk_etter_egenskap' ),
-	'Types' => array( 'Typer' ),
-	'URIResolver' => array( 'URI-løser' ),
-	'UnusedProperties' => array( 'Ubrukte_egenskaper' ),
-	'WantedProperties' => array( 'Ønskede_egenskaper' ),
-);
+$specialPageAliases['nb'] = [
+	'Ask' => [ 'Spør' ],
+	'Browse' => [ 'Se_gjennom' ],
+	'ExportRDF' => [ 'Eksporter_RDF' ],
+	'PageProperty' => [ 'Sideegenskaper' ],
+	'Properties' => [ 'Egenskaper' ],
+	'Concepts' => [ 'Konsepter' ],
+	'SMWAdmin' => [ 'SMW-administrasjon' ],
+	'SearchByProperty' => [ 'Søk_etter_egenskap' ],
+	'Types' => [ 'Typer' ],
+	'URIResolver' => [ 'URI-løser' ],
+	'UnusedProperties' => [ 'Ubrukte_egenskaper' ],
+	'WantedProperties' => [ 'Ønskede_egenskaper' ],
+];
 
 /** Low Saxon (Netherlands) (Nedersaksies) */
-$specialPageAliases['nds-nl'] = array(
-	'Ask' => array( 'Vragen' ),
-	'Browse' => array( 'Bekieken' ),
-	'ExportRDF' => array( 'RDF_uutvoeren' ),
-	'PageProperty' => array( 'Ziedeigenschap' ),
-	'Properties' => array( 'Eigenschappen' ),
-	'Concepts' => array( 'Konsepten' ),
-	'SMWAdmin' => array( 'SMW-beheer' ),
-	'SearchByProperty' => array( 'Op_eigenschap_zeuken' ),
-	'Types' => array( 'Soorten' ),
-	'URIResolver' => array( 'URI-oplosser' ),
-	'UnusedProperties' => array( 'Ongebruukten_eigenschappen' ),
-	'WantedProperties' => array( 'Gewunste_eigenschappen' ),
-);
+$specialPageAliases['nds-nl'] = [
+	'Ask' => [ 'Vragen' ],
+	'Browse' => [ 'Bekieken' ],
+	'ExportRDF' => [ 'RDF_uutvoeren' ],
+	'PageProperty' => [ 'Ziedeigenschap' ],
+	'Properties' => [ 'Eigenschappen' ],
+	'Concepts' => [ 'Konsepten' ],
+	'SMWAdmin' => [ 'SMW-beheer' ],
+	'SearchByProperty' => [ 'Op_eigenschap_zeuken' ],
+	'Types' => [ 'Soorten' ],
+	'URIResolver' => [ 'URI-oplosser' ],
+	'UnusedProperties' => [ 'Ongebruukten_eigenschappen' ],
+	'WantedProperties' => [ 'Gewunste_eigenschappen' ],
+];
 
 /** Dutch (Nederlands) */
-$specialPageAliases['nl'] = array(
-	'Ask' => array( 'Vragen' ),
-	'Browse' => array( 'Bekijken' ),
-	'ExportRDF' => array( 'RDFExporteren' ),
-	'PageProperty' => array( 'Paginaeigenschap' ),
-	'Properties' => array( 'Eigenschappen' ),
-	'Concepts' => array( 'Concepten' ),
-	'SMWAdmin' => array( 'SMWBeheer' ),
-	'SearchByProperty' => array( 'OpEigenschapZoeken' ),
-	'Types' => array( 'Typen' ),
-	'UnusedProperties' => array( 'OngebruikteEigenschappen' ),
-	'WantedProperties' => array( 'GewensteEigenschappen' ),
-);
+$specialPageAliases['nl'] = [
+	'Ask' => [ 'Vragen' ],
+	'Browse' => [ 'Bekijken' ],
+	'ExportRDF' => [ 'RDFExporteren' ],
+	'PageProperty' => [ 'Paginaeigenschap' ],
+	'Properties' => [ 'Eigenschappen' ],
+	'Concepts' => [ 'Concepten' ],
+	'SMWAdmin' => [ 'SMWBeheer' ],
+	'SearchByProperty' => [ 'OpEigenschapZoeken' ],
+	'Types' => [ 'Typen' ],
+	'UnusedProperties' => [ 'OngebruikteEigenschappen' ],
+	'WantedProperties' => [ 'GewensteEigenschappen' ],
+];
 
 /** Occitan (occitan) */
-$specialPageAliases['oc'] = array(
-	'Browse' => array( 'Percórrer' ),
-	'Properties' => array( 'Proprietats' ),
-	'Types' => array( 'Tipes' ),
-	'UnusedProperties' => array( 'Proprietats inutilizadas', 'ProprietatsInutilizadas' ),
-	'WantedProperties' => array( 'Proprietats demandadas', 'ProprietatsDemandadas' ),
-);
+$specialPageAliases['oc'] = [
+	'Browse' => [ 'Percórrer' ],
+	'Properties' => [ 'Proprietats' ],
+	'Types' => [ 'Tipes' ],
+	'UnusedProperties' => [ 'Proprietats inutilizadas', 'ProprietatsInutilizadas' ],
+	'WantedProperties' => [ 'Proprietats demandadas', 'ProprietatsDemandadas' ],
+];
 
 /** Oriya (ଓଡ଼ିଆ) */
-$specialPageAliases['or'] = array(
-	'Ask' => array( 'ପଚାରନ୍ତୁ' ),
-	'Browse' => array( 'ଖୋଜିବା' ),
-	'PageProperty' => array( 'ପୃଷ୍ଠାର_ଗୁଣ' ),
-	'Properties' => array( 'ଗୁଣ' ),
-	'UnusedProperties' => array( 'ବ୍ୟବହାର_ହୋଇନଥିବା_ଗୁଣ' ),
-	'WantedProperties' => array( 'ଦରକାରୀ_ଗୁଣ' ),
-);
+$specialPageAliases['or'] = [
+	'Ask' => [ 'ପଚାରନ୍ତୁ' ],
+	'Browse' => [ 'ଖୋଜିବା' ],
+	'PageProperty' => [ 'ପୃଷ୍ଠାର_ଗୁଣ' ],
+	'Properties' => [ 'ଗୁଣ' ],
+	'UnusedProperties' => [ 'ବ୍ୟବହାର_ହୋଇନଥିବା_ଗୁଣ' ],
+	'WantedProperties' => [ 'ଦରକାରୀ_ଗୁଣ' ],
+];
 
 /** Punjabi (ਪੰਜਾਬੀ) */
-$specialPageAliases['pa'] = array(
-	'Ask' => array( 'ਪੁੱਛੋ' ),
-	'Browse' => array( 'ਫੇਰੀ_ਪਾਓ' ),
-	'Types' => array( 'ਕਿਸਮਾਂ' ),
-);
+$specialPageAliases['pa'] = [
+	'Ask' => [ 'ਪੁੱਛੋ' ],
+	'Browse' => [ 'ਫੇਰੀ_ਪਾਓ' ],
+	'Types' => [ 'ਕਿਸਮਾਂ' ],
+];
 
 /** Polish (polski) */
-$specialPageAliases['pl'] = array(
-	'Ask' => array( 'Pytanie' ),
-	'Browse' => array( 'Przegląd' ),
-	'ExportRDF' => array( 'EksportRDF' ),
-	'PageProperty' => array( 'WłasnośćStrony' ),
-	'Properties' => array( 'Własności' ),
-	'Concepts' => array( 'Koncepty' ),
-	'SMWAdmin' => array( 'AdminSMW' ),
-	'SearchByProperty' => array( 'SzukanieWgWłasności' ),
-	'Types' => array( 'Typy' ),
-	'URIResolver' => array( 'ResolverURI' ),
-	'UnusedProperties' => array( 'NieużywaneWłasności' ),
-	'WantedProperties' => array( 'PotrzebneWłasności' ),
-);
+$specialPageAliases['pl'] = [
+	'Ask' => [ 'Pytanie' ],
+	'Browse' => [ 'Przegląd' ],
+	'ExportRDF' => [ 'EksportRDF' ],
+	'PageProperty' => [ 'WłasnośćStrony' ],
+	'Properties' => [ 'Własności' ],
+	'Concepts' => [ 'Koncepty' ],
+	'SMWAdmin' => [ 'AdminSMW' ],
+	'SearchByProperty' => [ 'SzukanieWgWłasności' ],
+	'Types' => [ 'Typy' ],
+	'URIResolver' => [ 'ResolverURI' ],
+	'UnusedProperties' => [ 'NieużywaneWłasności' ],
+	'WantedProperties' => [ 'PotrzebneWłasności' ],
+];
 
 /** Pashto (پښتو) */
-$specialPageAliases['ps'] = array(
-	'Ask' => array( 'پوښتل' ),
-	'Browse' => array( 'سپړل' ),
-	'PageProperty' => array( 'د مخ ځانتياوې' ),
-	'Properties' => array( 'ځانتياوې' ),
-	'Types' => array( 'ډولونه' ),
-	'UnusedProperties' => array( 'ناکارېدلې ځانتياوې' ),
-);
+$specialPageAliases['ps'] = [
+	'Ask' => [ 'پوښتل' ],
+	'Browse' => [ 'سپړل' ],
+	'PageProperty' => [ 'د مخ ځانتياوې' ],
+	'Properties' => [ 'ځانتياوې' ],
+	'Types' => [ 'ډولونه' ],
+	'UnusedProperties' => [ 'ناکارېدلې ځانتياوې' ],
+];
 
 /** Portuguese (português) */
-$specialPageAliases['pt'] = array(
-	'Ask' => array( 'Consultar' ),
-	'Browse' => array( 'Navegar' ),
-	'ExportRDF' => array( 'ExportarRDF' ),
-	'PageProperty' => array( 'Propriedade_de_página' ),
-	'Properties' => array( 'Propriedades' ),
-	'Concepts' => array( 'Conceitos' ),
-	'SearchByProperty' => array( 'Pesquisa_por_propriedade' ),
-	'Types' => array( 'Tipos' ),
-	'UnusedProperties' => array( 'Propriedades_não_utilizadas' ),
-	'WantedProperties' => array( 'Propriedades_desejadas' ),
-);
+$specialPageAliases['pt'] = [
+	'Ask' => [ 'Consultar' ],
+	'Browse' => [ 'Navegar' ],
+	'ExportRDF' => [ 'ExportarRDF' ],
+	'PageProperty' => [ 'Propriedade_de_página' ],
+	'Properties' => [ 'Propriedades' ],
+	'Concepts' => [ 'Conceitos' ],
+	'SearchByProperty' => [ 'Pesquisa_por_propriedade' ],
+	'Types' => [ 'Tipos' ],
+	'UnusedProperties' => [ 'Propriedades_não_utilizadas' ],
+	'WantedProperties' => [ 'Propriedades_desejadas' ],
+];
 
 /** Brazilian Portuguese (português do Brasil) */
-$specialPageAliases['pt-br'] = array(
-	'Ask' => array( 'Consultar' ),
-	'Browse' => array( 'Navegar' ),
-	'Concepts' => array( 'Conceitos' ),
-	'ExportRDF' => array( 'ExportarRDF' ),
-	'PageProperty' => array( 'Propriedade_de_página' ),
-	'ProcessingErrorList' => array( 'Lista_de_erro_de_processamento' ),
-	'Properties' => array( 'Propriedades' ),
-	'PropertyLabelSimilarity' => array( 'Similaridade_de_nome_de_propriedade' ),
-	'SearchByProperty' => array( 'Pesquisar_por_propriedade' ),
-	'SMWAdmin' => array( 'SemanticMediaWiki', 'SMWAdmin' ),
-	'Types' => array( 'Tipos' ),
-	'UnusedProperties' => array( 'Propriedades_não_utilizadas' ),
-	'URIResolver' => array( 'URIResolver' ),
-	'WantedProperties' => array( 'Propriedades_desejadas' ),
-);
+$specialPageAliases['pt-br'] = [
+	'Ask' => [ 'Consultar' ],
+	'Browse' => [ 'Navegar' ],
+	'Concepts' => [ 'Conceitos' ],
+	'ExportRDF' => [ 'ExportarRDF' ],
+	'PageProperty' => [ 'Propriedade_de_página' ],
+	'ProcessingErrorList' => [ 'Lista_de_erro_de_processamento' ],
+	'Properties' => [ 'Propriedades' ],
+	'PropertyLabelSimilarity' => [ 'Similaridade_de_nome_de_propriedade' ],
+	'SearchByProperty' => [ 'Pesquisar_por_propriedade' ],
+	'SMWAdmin' => [ 'SemanticMediaWiki', 'SMWAdmin' ],
+	'Types' => [ 'Tipos' ],
+	'UnusedProperties' => [ 'Propriedades_não_utilizadas' ],
+	'URIResolver' => [ 'URIResolver' ],
+	'WantedProperties' => [ 'Propriedades_desejadas' ],
+];
 
 /** Romanian (română) */
-$specialPageAliases['ro'] = array(
-	'Browse' => array( 'Răsfoieşte' ),
-);
+$specialPageAliases['ro'] = [
+	'Browse' => [ 'Răsfoieşte' ],
+];
 
 /** Sicilian (sicilianu) */
-$specialPageAliases['scn'] = array(
-	'Ask' => array( 'Chiedi' ),
-	'Browse' => array( 'Esplora' ),
-	'ExportRDF' => array( 'EsportaRDF' ),
-	'PageProperty' => array( 'ProprietàPagina' ),
-	'Properties' => array( 'Proprietà' ),
-	'SMWAdmin' => array( 'AdminSMW' ),
-	'SearchByProperty' => array( 'CercaPerProprietà' ),
-	'Types' => array( 'Tipi' ),
-	'URIResolver' => array( 'RisolutoreURI' ),
-	'UnusedProperties' => array( 'ProprietàNonUtilizzate' ),
-	'WantedProperties' => array( 'ProprietàRichieste' ),
-);
+$specialPageAliases['scn'] = [
+	'Ask' => [ 'Chiedi' ],
+	'Browse' => [ 'Esplora' ],
+	'ExportRDF' => [ 'EsportaRDF' ],
+	'PageProperty' => [ 'ProprietàPagina' ],
+	'Properties' => [ 'Proprietà' ],
+	'SMWAdmin' => [ 'AdminSMW' ],
+	'SearchByProperty' => [ 'CercaPerProprietà' ],
+	'Types' => [ 'Tipi' ],
+	'URIResolver' => [ 'RisolutoreURI' ],
+	'UnusedProperties' => [ 'ProprietàNonUtilizzate' ],
+	'WantedProperties' => [ 'ProprietàRichieste' ],
+];
 
 /** Slovak (slovenčina) */
-$specialPageAliases['sk'] = array(
-	'Ask' => array( 'SpýtaťSa' ),
-	'Browse' => array( 'Prehliadať' ),
-	'PageProperty' => array( 'VlastnostiStránky' ),
-	'Properties' => array( 'Vlastnosti' ),
-	'SMWAdmin' => array( 'SprávcaSMW' ),
-	'SearchByProperty' => array( 'HľadaniePodľaVlastností' ),
-	'Types' => array( 'Typy' ),
-	'URIResolver' => array( 'PrekladURI' ),
-	'UnusedProperties' => array( 'NepoužívanéVlastnosti' ),
-	'WantedProperties' => array( 'ŽiadanéVlastnosti' ),
-);
+$specialPageAliases['sk'] = [
+	'Ask' => [ 'SpýtaťSa' ],
+	'Browse' => [ 'Prehliadať' ],
+	'PageProperty' => [ 'VlastnostiStránky' ],
+	'Properties' => [ 'Vlastnosti' ],
+	'SMWAdmin' => [ 'SprávcaSMW' ],
+	'SearchByProperty' => [ 'HľadaniePodľaVlastností' ],
+	'Types' => [ 'Typy' ],
+	'URIResolver' => [ 'PrekladURI' ],
+	'UnusedProperties' => [ 'NepoužívanéVlastnosti' ],
+	'WantedProperties' => [ 'ŽiadanéVlastnosti' ],
+];
 
 /** Albanian (shqip) */
-$specialPageAliases['sq'] = array(
-	'Ask' => array( 'Pyet' ),
-	'Browse' => array( 'Sille' ),
-);
+$specialPageAliases['sq'] = [
+	'Ask' => [ 'Pyet' ],
+	'Browse' => [ 'Sille' ],
+];
 
 /** Serbian (Cyrillic script) (српски (ћирилица)‎) */
-$specialPageAliases['sr-ec'] = array(
-	'Ask' => array( 'Питај' ),
-	'Browse' => array( 'Потражи' ),
-	'Properties' => array( 'Својства' ),
-	'Types' => array( 'Врсте' ),
-	'UnusedProperties' => array( 'НекоришћенаСвојства', 'Некоришћена_својства' ),
-	'WantedProperties' => array( 'ТраженаСвојства', 'Тражена_својства' ),
-);
+$specialPageAliases['sr-ec'] = [
+	'Ask' => [ 'Питај' ],
+	'Browse' => [ 'Потражи' ],
+	'Properties' => [ 'Својства' ],
+	'Types' => [ 'Врсте' ],
+	'UnusedProperties' => [ 'НекоришћенаСвојства', 'Некоришћена_својства' ],
+	'WantedProperties' => [ 'ТраженаСвојства', 'Тражена_својства' ],
+];
 
 /** Swedish (svenska) */
-$specialPageAliases['sv'] = array(
-	'Ask' => array( 'Fråga' ),
-	'Browse' => array( 'Bläddra' ),
-	'ExportRDF' => array( 'Exportera_RDF' ),
-	'Properties' => array( 'Egenskaper' ),
-	'Types' => array( 'Typer' ),
-);
+$specialPageAliases['sv'] = [
+	'Ask' => [ 'Fråga' ],
+	'Browse' => [ 'Bläddra' ],
+	'ExportRDF' => [ 'Exportera_RDF' ],
+	'Properties' => [ 'Egenskaper' ],
+	'Types' => [ 'Typer' ],
+];
 
 /** Swahili (Kiswahili) */
-$specialPageAliases['sw'] = array(
-	'Ask' => array( 'Uliza' ),
-	'Browse' => array( 'Fungua' ),
-	'Types' => array( 'Aina' ),
-);
+$specialPageAliases['sw'] = [
+	'Ask' => [ 'Uliza' ],
+	'Browse' => [ 'Fungua' ],
+	'Types' => [ 'Aina' ],
+];
 
 /** Telugu (తెలుగు) */
-$specialPageAliases['te'] = array(
-	'Ask' => array( 'అడుగు' ),
-);
+$specialPageAliases['te'] = [
+	'Ask' => [ 'అడుగు' ],
+];
 
 /** Tagalog (Tagalog) */
-$specialPageAliases['tl'] = array(
-	'Ask' => array( 'Magtanong' ),
-	'Browse' => array( 'Tumingin-tingin' ),
-	'ExportRDF' => array( 'Iluwas_ang_RDF' ),
-	'PageProperty' => array( 'Pag-aari_ng_pahina' ),
-	'Properties' => array( 'Mga_pag-aari' ),
-	'SMWAdmin' => array( 'Tagapangasiwa_ng_SMW' ),
-	'SearchByProperty' => array( 'Maghanap_ayon_sa_pag-aari' ),
-	'Types' => array( 'Mga_uri' ),
-	'URIResolver' => array( 'Tagapaglutas_ng_URI' ),
-	'UnusedProperties' => array( 'Mga_pag-aaring_hindi_ginagamit' ),
-	'WantedProperties' => array( 'Mga_pag-aaring_ninanais' ),
-);
+$specialPageAliases['tl'] = [
+	'Ask' => [ 'Magtanong' ],
+	'Browse' => [ 'Tumingin-tingin' ],
+	'ExportRDF' => [ 'Iluwas_ang_RDF' ],
+	'PageProperty' => [ 'Pag-aari_ng_pahina' ],
+	'Properties' => [ 'Mga_pag-aari' ],
+	'SMWAdmin' => [ 'Tagapangasiwa_ng_SMW' ],
+	'SearchByProperty' => [ 'Maghanap_ayon_sa_pag-aari' ],
+	'Types' => [ 'Mga_uri' ],
+	'URIResolver' => [ 'Tagapaglutas_ng_URI' ],
+	'UnusedProperties' => [ 'Mga_pag-aaring_hindi_ginagamit' ],
+	'WantedProperties' => [ 'Mga_pag-aaring_ninanais' ],
+];
 
 /** Turkish (Türkçe) */
-$specialPageAliases['tr'] = array(
-	'Ask' => array( 'Sor' ),
-	'Browse' => array( 'Gezin' ),
-	'ExportRDF' => array( 'RDFAktar' ),
-	'PageProperty' => array( 'SayfaÖzelliği' ),
-	'Properties' => array( 'Özellikler' ),
-	'SMWAdmin' => array( 'SMWHizmetlisi', 'SMWYöneticisi' ),
-	'SearchByProperty' => array( 'ÖzelliğeGöreAra' ),
-	'Types' => array( 'Türler', 'Tipler' ),
-	'URIResolver' => array( 'URIÇözücü' ),
-	'UnusedProperties' => array( 'KullanılmayanÖzellikler' ),
-	'WantedProperties' => array( 'İstenenÖzellikler' ),
-);
+$specialPageAliases['tr'] = [
+	'Ask' => [ 'Sor' ],
+	'Browse' => [ 'Gezin' ],
+	'ExportRDF' => [ 'RDFAktar' ],
+	'PageProperty' => [ 'SayfaÖzelliği' ],
+	'Properties' => [ 'Özellikler' ],
+	'SMWAdmin' => [ 'SMWHizmetlisi', 'SMWYöneticisi' ],
+	'SearchByProperty' => [ 'ÖzelliğeGöreAra' ],
+	'Types' => [ 'Türler', 'Tipler' ],
+	'URIResolver' => [ 'URIÇözücü' ],
+	'UnusedProperties' => [ 'KullanılmayanÖzellikler' ],
+	'WantedProperties' => [ 'İstenenÖzellikler' ],
+];
 
 /** Ukrainian (українська) */
-$specialPageAliases['uk'] = array(
-	'Properties' => array( 'Властивості' ),
-	'Types' => array( 'Типи' ),
-);
+$specialPageAliases['uk'] = [
+	'Properties' => [ 'Властивості' ],
+	'Types' => [ 'Типи' ],
+];
 
 /** Urdu (اردو) */
-$specialPageAliases['ur'] = array(
-	'Ask' => array( 'پوچھیں' ),
-	'Types' => array( 'اقسام' ),
-);
+$specialPageAliases['ur'] = [
+	'Ask' => [ 'پوچھیں' ],
+	'Types' => [ 'اقسام' ],
+];
 
 /** Venetian (vèneto) */
-$specialPageAliases['vec'] = array(
-	'Browse' => array( 'Sfója' ),
-	'Properties' => array( 'Proprietà' ),
-	'Types' => array( 'Tipi' ),
-);
+$specialPageAliases['vec'] = [
+	'Browse' => [ 'Sfója' ],
+	'Properties' => [ 'Proprietà' ],
+	'Types' => [ 'Tipi' ],
+];
 
 /** Vietnamese (Tiếng Việt) */
-$specialPageAliases['vi'] = array(
-	'Ask' => array( 'Hỏi' ),
-	'Browse' => array( 'Duyệt' ),
-	'ExportRDF' => array( 'Xuất_RDF' ),
-	'PageProperty' => array( 'Thuộc_tính_trang' ),
-	'Properties' => array( 'Thuộc_tính' ),
-	'Concepts' => array( 'Khái_niệm' ),
-	'SMWAdmin' => array( 'Quản_lý_SMW', 'Quản_lí_SMW' ),
-	'SearchByProperty' => array( 'Tìm_theo_thuộc_tính' ),
-	'Types' => array( 'Kiểu' ),
-	'URIResolver' => array( 'Bộ_giải_URI' ),
-	'UnusedProperties' => array( 'Thuộc_tính_không_dùng' ),
-	'WantedProperties' => array( 'Thuộc_tính_cần_thiết' ),
-);
+$specialPageAliases['vi'] = [
+	'Ask' => [ 'Hỏi' ],
+	'Browse' => [ 'Duyệt' ],
+	'ExportRDF' => [ 'Xuất_RDF' ],
+	'PageProperty' => [ 'Thuộc_tính_trang' ],
+	'Properties' => [ 'Thuộc_tính' ],
+	'Concepts' => [ 'Khái_niệm' ],
+	'SMWAdmin' => [ 'Quản_lý_SMW', 'Quản_lí_SMW' ],
+	'SearchByProperty' => [ 'Tìm_theo_thuộc_tính' ],
+	'Types' => [ 'Kiểu' ],
+	'URIResolver' => [ 'Bộ_giải_URI' ],
+	'UnusedProperties' => [ 'Thuộc_tính_không_dùng' ],
+	'WantedProperties' => [ 'Thuộc_tính_cần_thiết' ],
+];
 
 /** Simplified Chinese (中文（简体）‎) */
-$specialPageAliases['zh-hans'] = array(
-	'Ask' => array( '询问' ),
-	'Browse' => array( '浏览' ),
-	'ExportRDF' => array( '导出RDF' ),
-	'PageProperty' => array( '页面属性' ),
-	'Properties' => array( '属性' ),
-	'Concepts' => array( '概念' ),
-	'SMWAdmin' => array( 'SMW管理' ),
-	'SearchByProperty' => array( '按属性搜索' ),
-	'Types' => array( '类型' ),
-	'URIResolver' => array( 'URI分解器' ),
-	'UnusedProperties' => array( '未使用属性' ),
-	'WantedProperties' => array( '尚缺属性' ),
-);
+$specialPageAliases['zh-hans'] = [
+	'Ask' => [ '询问' ],
+	'Browse' => [ '浏览' ],
+	'ExportRDF' => [ '导出RDF' ],
+	'PageProperty' => [ '页面属性' ],
+	'Properties' => [ '属性' ],
+	'Concepts' => [ '概念' ],
+	'SMWAdmin' => [ 'SMW管理' ],
+	'SearchByProperty' => [ '按属性搜索' ],
+	'Types' => [ '类型' ],
+	'URIResolver' => [ 'URI分解器' ],
+	'UnusedProperties' => [ '未使用属性' ],
+	'WantedProperties' => [ '尚缺属性' ],
+];
 
 /** Traditional Chinese (中文（繁體）‎) */
-$specialPageAliases['zh-hant'] = array(
-	'Ask' => array( '詢問' ),
-	'Browse' => array( '瀏覽' ),
-	'ExportRDF' => array( '匯出_RDF' ),
-	'PageProperty' => array( '頁面屬性' ),
-	'Properties' => array( '屬性' ),
-	'Concepts' => array( '概念' ),
-	'SMWAdmin' => array( 'SMW_管理員' ),
-	'SearchByProperty' => array( '依屬性搜尋' ),
-	'Types' => array( '型態' ),
-	'URIResolver' => array( 'URI_分解器' ),
-	'UnusedProperties' => array( '未使用屬性' ),
-	'WantedProperties' => array( '需要的屬性' ),
-);
+$specialPageAliases['zh-hant'] = [
+	'Ask' => [ '詢問' ],
+	'Browse' => [ '瀏覽' ],
+	'ExportRDF' => [ '匯出_RDF' ],
+	'PageProperty' => [ '頁面屬性' ],
+	'Properties' => [ '屬性' ],
+	'Concepts' => [ '概念' ],
+	'SMWAdmin' => [ 'SMW_管理員' ],
+	'SearchByProperty' => [ '依屬性搜尋' ],
+	'Types' => [ '型態' ],
+	'URIResolver' => [ 'URI_分解器' ],
+	'UnusedProperties' => [ '未使用屬性' ],
+	'WantedProperties' => [ '需要的屬性' ],
+];

--- a/i18n/extra/SemanticMediaWiki.magic.php
+++ b/i18n/extra/SemanticMediaWiki.magic.php
@@ -9,401 +9,401 @@
  * @ingroup SMWLanguage
  */
 
-$magicWords = array();
+$magicWords = [];
 
 /** English (English) */
-$magicWords['en'] = array(
-	'ask' => array( 0, 'ask' ),
-	'show' => array( 0, 'show' ),
-	'info' => array( 0, 'info' ),
-	'concept' => array( 0, 'concept' ),
-	'subobject' => array( 0, 'subobject' ),
-	'smwdoc' => array( 0, 'smwdoc' ),
-	'set' => array( 0, 'set' ),
-	'set_recurring_event' => array( 0, 'set_recurring_event' ),
-	'declare' => array( 0, 'declare' ),
-	'SMW_NOFACTBOX' => array( 0, '__NOFACTBOX__' ),
-	'SMW_SHOWFACTBOX' => array( 0, '__SHOWFACTBOX__' ),
-);
+$magicWords['en'] = [
+	'ask' => [ 0, 'ask' ],
+	'show' => [ 0, 'show' ],
+	'info' => [ 0, 'info' ],
+	'concept' => [ 0, 'concept' ],
+	'subobject' => [ 0, 'subobject' ],
+	'smwdoc' => [ 0, 'smwdoc' ],
+	'set' => [ 0, 'set' ],
+	'set_recurring_event' => [ 0, 'set_recurring_event' ],
+	'declare' => [ 0, 'declare' ],
+	'SMW_NOFACTBOX' => [ 0, '__NOFACTBOX__' ],
+	'SMW_SHOWFACTBOX' => [ 0, '__SHOWFACTBOX__' ],
+];
 
 /** Afrikaans (Afrikaans) */
-$magicWords['af'] = array(
-	'ask' => array( 0, 'vra', 'ask' ),
-	'show' => array( 0, 'wys', 'show' ),
-	'concept' => array( 0, 'konsep', 'concept' ),
-	'set' => array( 0, 'stel', 'set' ),
-	'declare' => array( 0, 'verklaar', 'declare' ),
-);
+$magicWords['af'] = [
+	'ask' => [ 0, 'vra', 'ask' ],
+	'show' => [ 0, 'wys', 'show' ],
+	'concept' => [ 0, 'konsep', 'concept' ],
+	'set' => [ 0, 'stel', 'set' ],
+	'declare' => [ 0, 'verklaar', 'declare' ],
+];
 
 /** Arabic (العربية) */
-$magicWords['ar'] = array(
-	'ask' => array( 0, 'سؤال' ),
-	'show' => array( 0, 'عرض' ),
-	'info' => array( 0, 'معلومات' ),
-	'concept' => array( 0, 'مفهوم' ),
-	'subobject' => array( 0, 'كائن_فرعي' ),
-	'smwdoc' => array( 0, 'وثائق_سمو', 'توثيق_سمو' ),
-	'set' => array( 0, 'تعيين' ), //من تعيين القيمة للمتغير\الكائن
-	'set_recurring_event' => array( 0, 'تعيين_حدث_متكرر' ),
-	'declare' => array( 0, 'إقرار', 'إعلان' ),
-	'SMW_NOFACTBOX' => array( 0, '__لا_صندوق_حقائق__', '__لا_صندوق_حقيقة__' ),
-	'SMW_SHOWFACTBOX' => array( 0, '__عرض_صندوق_الحقائق__', '__عرض_صندوق_الحقيقة__' ,)
-);
+$magicWords['ar'] = [
+	'ask' => [ 0, 'سؤال' ],
+	'show' => [ 0, 'عرض' ],
+	'info' => [ 0, 'معلومات' ],
+	'concept' => [ 0, 'مفهوم' ],
+	'subobject' => [ 0, 'كائن_فرعي' ],
+	'smwdoc' => [ 0, 'وثائق_سمو', 'توثيق_سمو' ],
+	'set' => [ 0, 'تعيين' ], //من تعيين القيمة للمتغير\الكائن
+	'set_recurring_event' => [ 0, 'تعيين_حدث_متكرر' ],
+	'declare' => [ 0, 'إقرار', 'إعلان' ],
+	'SMW_NOFACTBOX' => [ 0, '__لا_صندوق_حقائق__', '__لا_صندوق_حقيقة__' ],
+	'SMW_SHOWFACTBOX' => [ 0, '__عرض_صندوق_الحقائق__', '__عرض_صندوق_الحقيقة__' ,]
+];
 
 /** Egyptian Arabic (مصرى) */
-$magicWords['arz'] = array(
-	'ask' => array( 0, 'سؤال' ),
-	'show' => array( 0, 'عرض' ),
-	'info' => array( 0, 'معلومات' ),
-	'concept' => array( 0, 'مبدأ' ),
-	'subobject' => array( 0, 'كائن_فرعى' ),
-	'smwdoc' => array( 0, 'توثيق_سمو' ),
-	'set' => array( 0, 'مجموعة' ),
-	'set_recurring_event' => array( 0, 'ضبط_حدث_جارى' ),
-	'declare' => array( 0, 'إعلان' ),
-	'SMW_NOFACTBOX' => array( 0, '__لا_صندوق_حقيقة__' ),
-	'SMW_SHOWFACTBOX' => array( 0, '__عرض_صندوق_الحقيقة__' ),
-);
+$magicWords['arz'] = [
+	'ask' => [ 0, 'سؤال' ],
+	'show' => [ 0, 'عرض' ],
+	'info' => [ 0, 'معلومات' ],
+	'concept' => [ 0, 'مبدأ' ],
+	'subobject' => [ 0, 'كائن_فرعى' ],
+	'smwdoc' => [ 0, 'توثيق_سمو' ],
+	'set' => [ 0, 'مجموعة' ],
+	'set_recurring_event' => [ 0, 'ضبط_حدث_جارى' ],
+	'declare' => [ 0, 'إعلان' ],
+	'SMW_NOFACTBOX' => [ 0, '__لا_صندوق_حقيقة__' ],
+	'SMW_SHOWFACTBOX' => [ 0, '__عرض_صندوق_الحقيقة__' ],
+];
 
 /** Assamese (অসমীয়া) */
-$magicWords['as'] = array(
-	'ask' => array( 0, 'সোধক' ),
-	'show' => array( 0, 'দেখুৱাওক' ),
-	'info' => array( 0, 'তথ্য' ),
-);
+$magicWords['as'] = [
+	'ask' => [ 0, 'সোধক' ],
+	'show' => [ 0, 'দেখুৱাওক' ],
+	'info' => [ 0, 'তথ্য' ],
+];
 
 /** Breton (brezhoneg) */
-$magicWords['br'] = array(
-	'ask' => array( 0, 'goulenn' ),
-	'show' => array( 0, 'diskouez' ),
-	'info' => array( 0, 'keloù' ),
-	'concept' => array( 0, 'meizad' ),
-	'declare' => array( 0, 'disklêriañ' ),
-);
+$magicWords['br'] = [
+	'ask' => [ 0, 'goulenn' ],
+	'show' => [ 0, 'diskouez' ],
+	'info' => [ 0, 'keloù' ],
+	'concept' => [ 0, 'meizad' ],
+	'declare' => [ 0, 'disklêriañ' ],
+];
 
 /** Czech (čeština) */
-$magicWords['cs'] = array(
-	'ask' => array( 0, 'otázka' ),
-	'show' => array( 0, 'zobrazit' ),
-	'set' => array( 0, 'nastavit' ),
-);
+$magicWords['cs'] = [
+	'ask' => [ 0, 'otázka' ],
+	'show' => [ 0, 'zobrazit' ],
+	'set' => [ 0, 'nastavit' ],
+];
 
 /** Chuvash (Чӑвашла) */
-$magicWords['cv'] = array(
-	'SMW_NOFACTBOX' => array( 0, '__NOFACTBOX__' ),
-	'SMW_SHOWFACTBOX' => array( 0, '__SHOWFACTBOX__' ),
-);
+$magicWords['cv'] = [
+	'SMW_NOFACTBOX' => [ 0, '__NOFACTBOX__' ],
+	'SMW_SHOWFACTBOX' => [ 0, '__SHOWFACTBOX__' ],
+];
 
 /** German (Deutsch) */
-$magicWords['de'] = array(
-	'ask' => array( 0, 'frage' ),
-	'show' => array( 0, 'zeige' ),
-	'info' => array( 0, 'informiere' ),
-	'concept' => array( 0, 'konzept' ),
-	'subobject' => array( 0, 'unterobjekt' ),
-	'smwdoc' => array( 0, 'smwdok' ),
-	'set' => array( 0, 'setze' ),
-	'set_recurring_event' => array( 0, 'setze_wiederholung' ),
-	'declare' => array( 0, 'deklariere' ),
-	'SMW_NOFACTBOX' => array( 0, '__KEINE_FAKTENANZEIGE__', '__KEINEFAKTENANZEIGE__' ),
-	'SMW_SHOWFACTBOX' => array( 0, '__FAKTENANZEIGE__' ),
-);
+$magicWords['de'] = [
+	'ask' => [ 0, 'frage' ],
+	'show' => [ 0, 'zeige' ],
+	'info' => [ 0, 'informiere' ],
+	'concept' => [ 0, 'konzept' ],
+	'subobject' => [ 0, 'unterobjekt' ],
+	'smwdoc' => [ 0, 'smwdok' ],
+	'set' => [ 0, 'setze' ],
+	'set_recurring_event' => [ 0, 'setze_wiederholung' ],
+	'declare' => [ 0, 'deklariere' ],
+	'SMW_NOFACTBOX' => [ 0, '__KEINE_FAKTENANZEIGE__', '__KEINEFAKTENANZEIGE__' ],
+	'SMW_SHOWFACTBOX' => [ 0, '__FAKTENANZEIGE__' ],
+];
 
 /** Zazaki (Zazaki) */
-$magicWords['diq'] = array(
-	'ask' => array( 0, 'perske' ),
-	'show' => array( 0, 'bımocne' ),
-	'info' => array( 0, 'zanışe' ),
-	'concept' => array( 0, 'konsept' ),
-	'subobject' => array( 0, 'bınobce' ),
-	'set' => array( 0, 'saz' ),
-	'declare' => array( 0, 'ilaniye' ),
-	'SMW_NOFACTBOX' => array( 0, '__DORARAŞTAYÇINİYA__' ),
-	'SMW_SHOWFACTBOX' => array( 0, '__DORARAŞTAYBIMOCNE__' ),
-);
+$magicWords['diq'] = [
+	'ask' => [ 0, 'perske' ],
+	'show' => [ 0, 'bımocne' ],
+	'info' => [ 0, 'zanışe' ],
+	'concept' => [ 0, 'konsept' ],
+	'subobject' => [ 0, 'bınobce' ],
+	'set' => [ 0, 'saz' ],
+	'declare' => [ 0, 'ilaniye' ],
+	'SMW_NOFACTBOX' => [ 0, '__DORARAŞTAYÇINİYA__' ],
+	'SMW_SHOWFACTBOX' => [ 0, '__DORARAŞTAYBIMOCNE__' ],
+];
 
 /** Spanish (español) */
-$magicWords['es'] = array(
-	'ask' => array( 0, 'preguntar', 'pregunta' ),
-	'show' => array( 0, 'muestra', 'mostrar' ),
-	'info' => array( 0, 'informacion', 'información' ),
-	'concept' => array( 0, 'concepto' ),
-	'set' => array( 0, 'establecer', 'determinar' ),
-	'set_recurring_event' => array( 0, 'establecer_evento_recurrente', 'determinar_evento_recurrente' ),
-	'declare' => array( 0, 'declarar', 'declara' ),
-);
+$magicWords['es'] = [
+	'ask' => [ 0, 'preguntar', 'pregunta' ],
+	'show' => [ 0, 'muestra', 'mostrar' ],
+	'info' => [ 0, 'informacion', 'información' ],
+	'concept' => [ 0, 'concepto' ],
+	'set' => [ 0, 'establecer', 'determinar' ],
+	'set_recurring_event' => [ 0, 'establecer_evento_recurrente', 'determinar_evento_recurrente' ],
+	'declare' => [ 0, 'declarar', 'declara' ],
+];
 
 /** Persian (فارسی) */
-$magicWords['fa'] = array(
-	'ask' => array( 0, 'پرسش','سوال' ),
-	'show' => array( 0, 'نمایش' ),
-	'info' => array( 0, 'اطلاع' ),
-	'concept' => array( 0, 'مفهوم' ),
-	'subobject' => array( 0, 'جزءشیء' ),
-	'smwdoc' => array( 0, 'smwdoc' ),
-	'set' => array( 0, 'مجموعه' ),
-	'set_recurring_event' => array( 0, 'set_recurring_event' ),
-	'declare' => array( 0, 'declare' ),
-	'SMW_NOFACTBOX' => array( 0, '__NOFACTBOX__' ),
-	'SMW_SHOWFACTBOX' => array( 0, '__SHOWFACTBOX__' ),
-);
+$magicWords['fa'] = [
+	'ask' => [ 0, 'پرسش','سوال' ],
+	'show' => [ 0, 'نمایش' ],
+	'info' => [ 0, 'اطلاع' ],
+	'concept' => [ 0, 'مفهوم' ],
+	'subobject' => [ 0, 'جزءشیء' ],
+	'smwdoc' => [ 0, 'smwdoc' ],
+	'set' => [ 0, 'مجموعه' ],
+	'set_recurring_event' => [ 0, 'set_recurring_event' ],
+	'declare' => [ 0, 'declare' ],
+	'SMW_NOFACTBOX' => [ 0, '__NOFACTBOX__' ],
+	'SMW_SHOWFACTBOX' => [ 0, '__SHOWFACTBOX__' ],
+];
 
 /** French (français) */
-$magicWords['fr'] = array(
-	'ask' => array( 0, 'demander' ),
-	'show' => array( 0, 'afficher' ),
-	'info' => array( 0, 'infos' ),
-	'concept' => array( 0, 'concept' ),
-	'subobject' => array( 0, 'sousobjet' ),
-	'smwdoc' => array( 0, 'docsmw' ),
-	'set' => array( 0, 'définit' ),
-	'set_recurring_event' => array( 0, 'définit_périodique' ),
-	'declare' => array( 0, 'déclare' ),
-	'SMW_NOFACTBOX' => array( 0, '__SANSBOÎTEFAITS__', '__SANSBOITEFAITS__' ),
-	'SMW_SHOWFACTBOX' => array( 0, '__AFFICHERBOÎTEFAITS__', '__AFFICHERBOITEFAITS__' ),
-);
+$magicWords['fr'] = [
+	'ask' => [ 0, 'demander' ],
+	'show' => [ 0, 'afficher' ],
+	'info' => [ 0, 'infos' ],
+	'concept' => [ 0, 'concept' ],
+	'subobject' => [ 0, 'sousobjet' ],
+	'smwdoc' => [ 0, 'docsmw' ],
+	'set' => [ 0, 'définit' ],
+	'set_recurring_event' => [ 0, 'définit_périodique' ],
+	'declare' => [ 0, 'déclare' ],
+	'SMW_NOFACTBOX' => [ 0, '__SANSBOÎTEFAITS__', '__SANSBOITEFAITS__' ],
+	'SMW_SHOWFACTBOX' => [ 0, '__AFFICHERBOÎTEFAITS__', '__AFFICHERBOITEFAITS__' ],
+];
 
 /** Western Frisian (Frysk) */
-$magicWords['fy'] = array(
-	'info' => array( 0, 'ynfo' ),
-);
+$magicWords['fy'] = [
+	'info' => [ 0, 'ynfo' ],
+];
 
 /** Hebrew (עברית) */
-$magicWords['he'] = array(
-	'ask' => array( 0, 'שאל' ),
-);
+$magicWords['he'] = [
+	'ask' => [ 0, 'שאל' ],
+];
 
 /** Indonesian (Bahasa Indonesia) */
-$magicWords['id'] = array(
-	'ask' => array( 0, 'tanya' ),
-	'show' => array( 0, 'tampilkan' ),
-	'info' => array( 0, 'info' ),
-	'concept' => array( 0, 'konsep' ),
-	'set' => array( 0, 'tetapkan' ),
-	'declare' => array( 0, 'deklarasi' ),
-);
+$magicWords['id'] = [
+	'ask' => [ 0, 'tanya' ],
+	'show' => [ 0, 'tampilkan' ],
+	'info' => [ 0, 'info' ],
+	'concept' => [ 0, 'konsep' ],
+	'set' => [ 0, 'tetapkan' ],
+	'declare' => [ 0, 'deklarasi' ],
+];
 
 /** Igbo (Igbo) */
-$magicWords['ig'] = array(
-	'ask' => array( 0, 'jüo', 'ask' ),
-);
+$magicWords['ig'] = [
+	'ask' => [ 0, 'jüo', 'ask' ],
+];
 
 /** Georgian (ქართული) */
-$magicWords['ka'] = array(
-	'ask' => array( 0, 'კითხვა' ),
-	'show' => array( 0, 'ჩვენება' ),
-	'info' => array( 0, 'ინფო' ),
-);
+$magicWords['ka'] = [
+	'ask' => [ 0, 'კითხვა' ],
+	'show' => [ 0, 'ჩვენება' ],
+	'info' => [ 0, 'ინფო' ],
+];
 
 /** Korean (한국어) */
-$magicWords['ko'] = array(
-	'ask' => array( 0, '묻기' ),
-	'show' => array( 0, '보이기' ),
-	'info' => array( 0, '정보' ),
-	'concept' => array( 0, '생각' ),
-	'subobject' => array( 0, '하위객체' ),
-	'smwdoc' => array( 0, 'smw문서' ),
-	'set' => array( 0, '설정' ),
-	'set_recurring_event' => array( 0, '반복_일정_설정' ),
-	'declare' => array( 0, '선언' ),
-	'SMW_NOFACTBOX' => array( 0, '__사실상자숨김__' ),
-	'SMW_SHOWFACTBOX' => array( 0, '__사실상자보이기__', '__사실상자표시__' ),
-);
+$magicWords['ko'] = [
+	'ask' => [ 0, '묻기' ],
+	'show' => [ 0, '보이기' ],
+	'info' => [ 0, '정보' ],
+	'concept' => [ 0, '생각' ],
+	'subobject' => [ 0, '하위객체' ],
+	'smwdoc' => [ 0, 'smw문서' ],
+	'set' => [ 0, '설정' ],
+	'set_recurring_event' => [ 0, '반복_일정_설정' ],
+	'declare' => [ 0, '선언' ],
+	'SMW_NOFACTBOX' => [ 0, '__사실상자숨김__' ],
+	'SMW_SHOWFACTBOX' => [ 0, '__사실상자보이기__', '__사실상자표시__' ],
+];
 
 /** Cornish (kernowek) */
-$magicWords['kw'] = array(
-	'ask' => array( 0, 'govyn' ),
-	'show' => array( 0, 'diskwedhes' ),
-	'info' => array( 0, 'kedhlow' ),
-	'set' => array( 0, 'settya' ),
-);
+$magicWords['kw'] = [
+	'ask' => [ 0, 'govyn' ],
+	'show' => [ 0, 'diskwedhes' ],
+	'info' => [ 0, 'kedhlow' ],
+	'set' => [ 0, 'settya' ],
+];
 
 /** Luxembourgish (Lëtzebuergesch) */
-$magicWords['lb'] = array(
-	'ask' => array( 0, 'froen' ),
-	'show' => array( 0, 'weisen' ),
-	'concept' => array( 0, 'Konzept' ),
-);
+$magicWords['lb'] = [
+	'ask' => [ 0, 'froen' ],
+	'show' => [ 0, 'weisen' ],
+	'concept' => [ 0, 'Konzept' ],
+];
 
 /** Macedonian (македонски) */
-$magicWords['mk'] = array(
-	'ask' => array( 0, 'прашај' ),
-	'show' => array( 0, 'прикажи' ),
-	'info' => array( 0, 'инфо' ),
-	'concept' => array( 0, 'поим' ),
-	'subobject' => array( 0, 'подобјект' ),
-	'smwdoc' => array( 0, 'смвдок' ),
-	'set' => array( 0, 'постави' ),
-	'set_recurring_event' => array( 0, 'постави_повторлив_настан' ),
-	'declare' => array( 0, 'изјави' ),
-	'SMW_NOFACTBOX' => array( 0, '__БЕЗФАКТКУТИЈА__' ),
-	'SMW_SHOWFACTBOX' => array( 0, '__ПРИКАЖИФАКТКУТИЈА__' ),
-);
+$magicWords['mk'] = [
+	'ask' => [ 0, 'прашај' ],
+	'show' => [ 0, 'прикажи' ],
+	'info' => [ 0, 'инфо' ],
+	'concept' => [ 0, 'поим' ],
+	'subobject' => [ 0, 'подобјект' ],
+	'smwdoc' => [ 0, 'смвдок' ],
+	'set' => [ 0, 'постави' ],
+	'set_recurring_event' => [ 0, 'постави_повторлив_настан' ],
+	'declare' => [ 0, 'изјави' ],
+	'SMW_NOFACTBOX' => [ 0, '__БЕЗФАКТКУТИЈА__' ],
+	'SMW_SHOWFACTBOX' => [ 0, '__ПРИКАЖИФАКТКУТИЈА__' ],
+];
 
 /** Malayalam (മലയാളം) */
-$magicWords['ml'] = array(
-	'ask' => array( 0, 'ചോദിക്കുക' ),
-	'show' => array( 0, 'പ്രദർശിപ്പിക്കുക' ),
-	'info' => array( 0, 'വിവരം' ),
-	'concept' => array( 0, 'ആശയം' ),
-	'set' => array( 0, 'ഗണം' ),
-	'declare' => array( 0, 'പ്രഖ്യാപിക്കുക' ),
-);
+$magicWords['ml'] = [
+	'ask' => [ 0, 'ചോദിക്കുക' ],
+	'show' => [ 0, 'പ്രദർശിപ്പിക്കുക' ],
+	'info' => [ 0, 'വിവരം' ],
+	'concept' => [ 0, 'ആശയം' ],
+	'set' => [ 0, 'ഗണം' ],
+	'declare' => [ 0, 'പ്രഖ്യാപിക്കുക' ],
+];
 
 /** Marathi (मराठी) */
-$magicWords['mr'] = array(
-	'ask' => array( 0, 'विचारा' ),
-	'show' => array( 0, 'दाखवा' ),
-	'info' => array( 0, 'माहिती' ),
-	'concept' => array( 0, 'कंसेप्ट', 'कल्पना' ),
-	'set' => array( 0, 'प्रयुक्त', 'सेट', 'स्थापित' ),
-	'set_recurring_event' => array( 0, 'प्रयुक्त_पुर्न_कार्य' ),
-	'declare' => array( 0, 'प्रकटकरा' ),
-	'SMW_NOFACTBOX' => array( 0, '__फॅक्टबॉक्सनाही__' ),
-	'SMW_SHOWFACTBOX' => array( 0, '__फॅक्टबॉक्सदाखवा__' ),
-);
+$magicWords['mr'] = [
+	'ask' => [ 0, 'विचारा' ],
+	'show' => [ 0, 'दाखवा' ],
+	'info' => [ 0, 'माहिती' ],
+	'concept' => [ 0, 'कंसेप्ट', 'कल्पना' ],
+	'set' => [ 0, 'प्रयुक्त', 'सेट', 'स्थापित' ],
+	'set_recurring_event' => [ 0, 'प्रयुक्त_पुर्न_कार्य' ],
+	'declare' => [ 0, 'प्रकटकरा' ],
+	'SMW_NOFACTBOX' => [ 0, '__फॅक्टबॉक्सनाही__' ],
+	'SMW_SHOWFACTBOX' => [ 0, '__फॅक्टबॉक्सदाखवा__' ],
+];
 
 /** Low Saxon (Netherlands) (Nedersaksies) */
-$magicWords['nds-nl'] = array(
-	'concept' => array( 0, 'konsept' ),
-	'set_recurring_event' => array( 0, 'herhaolende_gebeurtenisse_instellen' ),
-	'declare' => array( 0, 'deklareren' ),
-	'SMW_NOFACTBOX' => array( 0, '__GIENFEITENKAODER__' ),
-	'SMW_SHOWFACTBOX' => array( 0, '__FEITENKAODERWEERGEVEN__' ),
-);
+$magicWords['nds-nl'] = [
+	'concept' => [ 0, 'konsept' ],
+	'set_recurring_event' => [ 0, 'herhaolende_gebeurtenisse_instellen' ],
+	'declare' => [ 0, 'deklareren' ],
+	'SMW_NOFACTBOX' => [ 0, '__GIENFEITENKAODER__' ],
+	'SMW_SHOWFACTBOX' => [ 0, '__FEITENKAODERWEERGEVEN__' ],
+];
 
 /** Dutch (Nederlands) */
-$magicWords['nl'] = array(
-	'ask' => array( 0, 'vragen' ),
-	'show' => array( 0, 'weergeven' ),
-	'subobject' => array( 0, 'onderobject' ),
-	'set' => array( 0, 'instellen' ),
-	'set_recurring_event' => array( 0, 'herhalende_gebeurtenis_instellen' ),
-	'declare' => array( 0, 'declareren' ),
-	'SMW_NOFACTBOX' => array( 0, '__GEENFEITENKADER__' ),
-	'SMW_SHOWFACTBOX' => array( 0, '__FEITENKADERWEERGEVEN__' ),
-);
+$magicWords['nl'] = [
+	'ask' => [ 0, 'vragen' ],
+	'show' => [ 0, 'weergeven' ],
+	'subobject' => [ 0, 'onderobject' ],
+	'set' => [ 0, 'instellen' ],
+	'set_recurring_event' => [ 0, 'herhalende_gebeurtenis_instellen' ],
+	'declare' => [ 0, 'declareren' ],
+	'SMW_NOFACTBOX' => [ 0, '__GEENFEITENKADER__' ],
+	'SMW_SHOWFACTBOX' => [ 0, '__FEITENKADERWEERGEVEN__' ],
+];
 
 /** Punjabi (ਪੰਜਾਬੀ) */
-$magicWords['pa'] = array(
-	'ask' => array( 0, 'ਪੁੱਛੋ' ),
-	'show' => array( 0, 'ਵਿਖਾਓ' ),
-	'info' => array( 0, 'ਜਾਣਕਾਰੀ' ),
-);
+$magicWords['pa'] = [
+	'ask' => [ 0, 'ਪੁੱਛੋ' ],
+	'show' => [ 0, 'ਵਿਖਾਓ' ],
+	'info' => [ 0, 'ਜਾਣਕਾਰੀ' ],
+];
 
 /** Polish (polski) */
-$magicWords['pl'] = array(
-	'ask' => array( 0, 'pytanie' ),
-	'show' => array( 0, 'pokaż' ),
-	'info' => array( 0, 'informacja' ),
-	'concept' => array( 0, 'koncept' ),
-	'set' => array( 0, 'ustaw' ),
-	'declare' => array( 0, 'zadeklaruj' ),
-);
+$magicWords['pl'] = [
+	'ask' => [ 0, 'pytanie' ],
+	'show' => [ 0, 'pokaż' ],
+	'info' => [ 0, 'informacja' ],
+	'concept' => [ 0, 'koncept' ],
+	'set' => [ 0, 'ustaw' ],
+	'declare' => [ 0, 'zadeklaruj' ],
+];
 
 /** Pashto (پښتو) */
-$magicWords['ps'] = array(
-	'ask' => array( 0, 'پوښتل', 'ask' ),
-	'show' => array( 0, 'ښکاره_کول', 'show' ),
-	'info' => array( 0, 'مالومات', 'info' ),
-);
+$magicWords['ps'] = [
+	'ask' => [ 0, 'پوښتل', 'ask' ],
+	'show' => [ 0, 'ښکاره_کول', 'show' ],
+	'info' => [ 0, 'مالومات', 'info' ],
+];
 
 /** Portuguese (português) */
-$magicWords['pt'] = array(
-	'ask' => array( 0, 'consultar' ),
-	'show' => array( 0, 'mostrar' ),
-	'concept' => array( 0, 'conceito' ),
-	'subobject' => array( 0, 'subobjeto' ),
-	'set' => array( 0, 'definir' ),
-	'set_recurring_event' => array( 0, 'definir_evento_recorrente' ),
-	'declare' => array( 0, 'declarar' ),
-	'SMW_NOFACTBOX' => array( 0, '__SEMCAIXADEFATOS__' ),
-	'SMW_SHOWFACTBOX' => array( 0, '__EXIBIRCAIXADEFATOS__' ),
-);
+$magicWords['pt'] = [
+	'ask' => [ 0, 'consultar' ],
+	'show' => [ 0, 'mostrar' ],
+	'concept' => [ 0, 'conceito' ],
+	'subobject' => [ 0, 'subobjeto' ],
+	'set' => [ 0, 'definir' ],
+	'set_recurring_event' => [ 0, 'definir_evento_recorrente' ],
+	'declare' => [ 0, 'declarar' ],
+	'SMW_NOFACTBOX' => [ 0, '__SEMCAIXADEFATOS__' ],
+	'SMW_SHOWFACTBOX' => [ 0, '__EXIBIRCAIXADEFATOS__' ],
+];
 
 /** Brazilian Portuguese (português do Brasil) */
-$magicWords['pt-br'] = array(
-	'ask' => array( 0, 'consultar' ),
-	'show' => array( 0, 'mostrar' ),
-	'info' => array( 0, 'info' ),
-	'concept' => array( 0, 'conceito' ),
-	'subobject' => array( 0, 'subobjeto' ),
-	'smwdoc' => array( 0, 'smwdoc' ),
-	'set' => array( 0, 'definir' ),
-	'set_recurring_event' => array( 0, 'definir_evento_recorrente' ),
-	'declare' => array( 0, 'declarar' ),
-	'SMW_NOFACTBOX' => array( 0, '__SEMCAIXADEFATOS__' ),
-	'SMW_SHOWFACTBOX' => array( 0, '__EXIBIRCAIXADEFATOS__' ),
-);
+$magicWords['pt-br'] = [
+	'ask' => [ 0, 'consultar' ],
+	'show' => [ 0, 'mostrar' ],
+	'info' => [ 0, 'info' ],
+	'concept' => [ 0, 'conceito' ],
+	'subobject' => [ 0, 'subobjeto' ],
+	'smwdoc' => [ 0, 'smwdoc' ],
+	'set' => [ 0, 'definir' ],
+	'set_recurring_event' => [ 0, 'definir_evento_recorrente' ],
+	'declare' => [ 0, 'declarar' ],
+	'SMW_NOFACTBOX' => [ 0, '__SEMCAIXADEFATOS__' ],
+	'SMW_SHOWFACTBOX' => [ 0, '__EXIBIRCAIXADEFATOS__' ],
+];
 
 /** Serbian (Cyrillic script) (српски (ћирилица)‎) */
-$magicWords['sr-ec'] = array(
-	'ask' => array( 0, 'питај' ),
-	'show' => array( 0, 'прикажи' ),
-	'info' => array( 0, 'подаци' ),
-	'concept' => array( 0, 'концепт' ),
-	'set' => array( 0, 'постави' ),
-	'set_recurring_event' => array( 0, 'постави_периодични_догађај' ),
-	'declare' => array( 0, 'одреди' ),
-);
+$magicWords['sr-ec'] = [
+	'ask' => [ 0, 'питај' ],
+	'show' => [ 0, 'прикажи' ],
+	'info' => [ 0, 'подаци' ],
+	'concept' => [ 0, 'концепт' ],
+	'set' => [ 0, 'постави' ],
+	'set_recurring_event' => [ 0, 'постави_периодични_догађај' ],
+	'declare' => [ 0, 'одреди' ],
+];
 
 /** Serbian (Latin script) (srpski (latinica)‎) */
-$magicWords['sr-el'] = array(
-	'ask' => array( 0, 'pitaj' ),
-	'show' => array( 0, 'prikaži' ),
-	'info' => array( 0, 'podaci' ),
-	'concept' => array( 0, 'koncept' ),
-	'set' => array( 0, 'postavi' ),
-	'set_recurring_event' => array( 0, 'postavi_periodični_događaj' ),
-	'declare' => array( 0, 'odredi' ),
-	'SMW_NOFACTBOX' => array( 0, '__BEZČINJENICA__', '__BEZ_ČINJENICA__' ),
-	'SMW_SHOWFACTBOX' => array( 0, '__PRIKAŽIČINJENICE__', '__PRIKAŽI_ČINJENICE__' ),
-);
+$magicWords['sr-el'] = [
+	'ask' => [ 0, 'pitaj' ],
+	'show' => [ 0, 'prikaži' ],
+	'info' => [ 0, 'podaci' ],
+	'concept' => [ 0, 'koncept' ],
+	'set' => [ 0, 'postavi' ],
+	'set_recurring_event' => [ 0, 'postavi_periodični_događaj' ],
+	'declare' => [ 0, 'odredi' ],
+	'SMW_NOFACTBOX' => [ 0, '__BEZČINJENICA__', '__BEZ_ČINJENICA__' ],
+	'SMW_SHOWFACTBOX' => [ 0, '__PRIKAŽIČINJENICE__', '__PRIKAŽI_ČINJENICE__' ],
+];
 
 /** Swedish (svenska) */
-$magicWords['sv'] = array(
-	'ask' => array( 0, 'fråga', 'ask' ),
-	'show' => array( 0, 'visa', 'show' ),
-	'concept' => array( 0, 'koncept', 'concept' ),
-);
+$magicWords['sv'] = [
+	'ask' => [ 0, 'fråga', 'ask' ],
+	'show' => [ 0, 'visa', 'show' ],
+	'concept' => [ 0, 'koncept', 'concept' ],
+];
 
 /** Tatar (Cyrillic script) (татарча) */
-$magicWords['tt-cyrl'] = array(
-	'ask' => array( 0, 'сорау' ),
-	'show' => array( 0, 'күрсәт' ),
-	'info' => array( 0, 'мәгълүмат' ),
-);
+$magicWords['tt-cyrl'] = [
+	'ask' => [ 0, 'сорау' ],
+	'show' => [ 0, 'күрсәт' ],
+	'info' => [ 0, 'мәгълүмат' ],
+];
 
 /** Vietnamese (Tiếng Việt) */
-$magicWords['vi'] = array(
-	'ask' => array( 0, 'hỏi' ),
-	'show' => array( 0, 'hiển_thị' ),
-	'info' => array( 0, 'thông_tin' ),
-	'concept' => array( 0, 'khái_niệm' ),
-	'set' => array( 0, 'đặt' ),
-);
+$magicWords['vi'] = [
+	'ask' => [ 0, 'hỏi' ],
+	'show' => [ 0, 'hiển_thị' ],
+	'info' => [ 0, 'thông_tin' ],
+	'concept' => [ 0, 'khái_niệm' ],
+	'set' => [ 0, 'đặt' ],
+];
 
 /** Simplified Chinese (中文（简体）‎) */
-$magicWords['zh-hans'] = array(
-	'ask' => array( 0, '询问' ),
-	'show' => array( 0, '显示' ),
-	'info' => array( 0, '信息' ),
-	'concept' => array( 0, '概念' ),
-	'subobject' => array( 0, '子对象' ),
-	'smwdoc' => array( 0, 'SMW文档' ),
-	'set' => array( 0, '设置' ),
-	'set_recurring_event' => array( 0, '设置循环活动' ),
-	'declare' => array( 0, '宣布' ),
-	'SMW_NOFACTBOX' => array( 0, '__无实际内容框__' ),
-	'SMW_SHOWFACTBOX' => array( 0, '__显示实际内容框__' ),
-);
+$magicWords['zh-hans'] = [
+	'ask' => [ 0, '询问' ],
+	'show' => [ 0, '显示' ],
+	'info' => [ 0, '信息' ],
+	'concept' => [ 0, '概念' ],
+	'subobject' => [ 0, '子对象' ],
+	'smwdoc' => [ 0, 'SMW文档' ],
+	'set' => [ 0, '设置' ],
+	'set_recurring_event' => [ 0, '设置循环活动' ],
+	'declare' => [ 0, '宣布' ],
+	'SMW_NOFACTBOX' => [ 0, '__无实际内容框__' ],
+	'SMW_SHOWFACTBOX' => [ 0, '__显示实际内容框__' ],
+];
 
 /** Traditional Chinese (中文（繁體）‎) */
-$magicWords['zh-hant'] = array(
-	'ask' => array( 0, '訪問' ),
-	'show' => array( 0, '顯示' ),
-	'info' => array( 0, '資訊' ),
-	'smwdoc' => array( 0, 'SMW檔案' ),
-	'set' => array( 0, '設定' ),
-	'set_recurring_event' => array( 0, '設定循環活動', '設置定期活動' ),
-);
+$magicWords['zh-hant'] = [
+	'ask' => [ 0, '訪問' ],
+	'show' => [ 0, '顯示' ],
+	'info' => [ 0, '資訊' ],
+	'smwdoc' => [ 0, 'SMW檔案' ],
+	'set' => [ 0, '設定' ],
+	'set_recurring_event' => [ 0, '設定循環活動', '設置定期活動' ],
+];

--- a/includes/ContentParser.php
+++ b/includes/ContentParser.php
@@ -35,7 +35,7 @@ class ContentParser {
 	protected $revision = null;
 
 	/** @var array */
-	protected $errors = array();
+	protected $errors = [];
 
 	/**
 	 * @var boolean
@@ -205,7 +205,7 @@ class ContentParser {
 	}
 
 	protected function msgForNullRevision( $fname = __METHOD__ ) {
-		$this->errors = array( $fname . " No revision available for {$this->getTitle()->getPrefixedDBkey()}" );
+		$this->errors = [ $fname . " No revision available for {$this->getTitle()->getPrefixedDBkey()}" ];
 		return $this;
 	}
 

--- a/includes/Highlighter.php
+++ b/includes/Highlighter.php
@@ -143,8 +143,8 @@ class Highlighter {
 	public static function decode( $text ) {
 		// #2347, '[' is handled by the MediaWiki parser/sanitizer itself
 		return str_replace(
-			array( '&amp;', '&lt;', '&gt;', '&#160;', '<nowiki>', '</nowiki>' ),
-			array( '&', '<', '>', ' ', '', '' ),
+			[ '&amp;', '&lt;', '&gt;', '&#160;', '<nowiki>', '</nowiki>' ],
+			[ '&', '<', '>', ' ', '', '' ],
 			$text
 		);
 	}
@@ -294,7 +294,7 @@ class Highlighter {
 	 * @return array
 	 */
 	private function getTypeConfiguration( $type ) {
-		$settings = array();
+		$settings = [];
 		$settings['type'] = $type;
 		$settings['caption'] = '';
 		$settings['content'] = '';
@@ -361,7 +361,7 @@ class Highlighter {
 		// Pre-process the content when used as title to avoid breaking elements
 		// (URLs etc.)
 		if ( strpos( $content, '[' ) !== false || strpos( $content, '//' ) !== false ) {
-			$content = Message::get( array( 'smw-parse', $content ), Message::PARSE, $language );
+			$content = Message::get( [ 'smw-parse', $content ], Message::PARSE, $language );
 		}
 
 		return strip_tags( htmlspecialchars_decode( str_replace( [ "[", '&#160;' ], [ "&#91;", ' ' ], $content ) ) );

--- a/includes/QueryPrinterFactory.php
+++ b/includes/QueryPrinterFactory.php
@@ -51,14 +51,14 @@ final class QueryPrinterFactory {
 	 *
 	 * @var string[]
 	 */
-	private $formats = array();
+	private $formats = [];
 
 	/**
 	 * Form alias registry. Aliases pointing to their canonical format name.
 	 *
 	 * @var string[]
 	 */
-	private $aliases = array();
+	private $aliases = [];
 
 	/**
 	 * Registers a format.

--- a/includes/RecurringEvents.php
+++ b/includes/RecurringEvents.php
@@ -30,17 +30,17 @@ class RecurringEvents {
 	/**
 	 * Defines the dates
 	 */
-	private $dates = array();
+	private $dates = [];
 
 	/**
 	 * Defines remaining / unused parameters
 	 */
-	private $parameters = array();
+	private $parameters = [];
 
 	/**
 	 * Defines errors
 	 */
-	private $errors = array();
+	private $errors = [];
 
 	/**
 	 * @var integer
@@ -159,11 +159,11 @@ class RecurringEvents {
 	 */
 	private function parse( array $parameters ) {
 		// Initialize variables.
-		$all_date_strings = array();
+		$all_date_strings = [];
 		$start_date = $end_date = $unit = $period = $week_num = null;
-		$included_dates = array();
-		$excluded_dates = array();
-		$excluded_dates_jd = array();
+		$included_dates = [];
+		$excluded_dates = [];
+		$excluded_dates_jd = [];
 
 		// Parse parameters and assign values
 		foreach ( $parameters as $name => $values ) {

--- a/includes/SMW_Infolink.php
+++ b/includes/SMW_Infolink.php
@@ -78,7 +78,7 @@ class SMWInfolink {
 	 * @param mixed $style CSS class of a span to embedd the link into, or false if no extra style is required.
 	 * @param array $params Array of parameters, format $name => $value, if any.
 	 */
-	public function __construct( $internal, $caption, $target, $style = false, array $params = array() ) {
+	public function __construct( $internal, $caption, $target, $style = false, array $params = [] ) {
 		$this->mInternal = $internal;
 		$this->mCaption = $caption;
 		$this->mTarget = $target;
@@ -116,7 +116,7 @@ class SMWInfolink {
 	 *
 	 * @return SMWInfolink
 	 */
-	public static function newInternalLink( $caption, $target, $style = false, array $params = array() ) {
+	public static function newInternalLink( $caption, $target, $style = false, array $params = [] ) {
 		return new SMWInfolink( true, $caption, $target, $style, $params );
 	}
 
@@ -130,7 +130,7 @@ class SMWInfolink {
 	 *
 	 * @return SMWInfolink
 	 */
-	public static function newExternalLink( $caption, $url, $style = false, array $params = array() ) {
+	public static function newExternalLink( $caption, $url, $style = false, array $params = [] ) {
 		return new SMWInfolink( false, $caption, $url, $style, $params );
 	}
 
@@ -152,7 +152,7 @@ class SMWInfolink {
 			$caption,
 			$wgContLang->getNsText( NS_SPECIAL ) . ':SearchByProperty',
 			$style,
-			array( ':' . $propertyName, $propertyValue ) // `:` is marking that the link was auto-generated
+			[ ':' . $propertyName, $propertyValue ] // `:` is marking that the link was auto-generated
 		);
 
 		// Link that reaches a length restriction will most likely cause a
@@ -201,7 +201,7 @@ class SMWInfolink {
 			$caption,
 			$wgContLang->getNsText( NS_SPECIAL ) . ':Browse',
 			$style,
-			array( ':' . $titleText )
+			[ ':' . $titleText ]
 		);
 	}
 
@@ -487,8 +487,8 @@ class SMWInfolink {
 				//      make URLs less readable
 				//
 				$value = str_replace(
-					array( '-', '#', "\n", ' ', '/', '[', ']', '<', '>', '&lt;', '&gt;', '&amp;', '\'\'', '|', '&', '%', '?', '$', "\\", ";", "_" ),
-					array( '-2D', '-23', '-0A', '-20', '-2F', '-5B', '-5D', '-3C', '-3E', '-3C', '-3E', '-26', '-27-27', '-7C', '-26', '-25', '-3F', '-24', '-5C', "-3B", "-5F" ),
+					[ '-', '#', "\n", ' ', '/', '[', ']', '<', '>', '&lt;', '&gt;', '&amp;', '\'\'', '|', '&', '%', '?', '$', "\\", ";", "_" ],
+					[ '-2D', '-23', '-0A', '-20', '-2F', '-5B', '-5D', '-3C', '-3E', '-3C', '-3E', '-26', '-27-27', '-7C', '-26', '-25', '-3F', '-24', '-5C', "-3B", "-5F" ],
 					$value
 				);
 
@@ -499,7 +499,7 @@ class SMWInfolink {
 				$result .= $value;
 			}
 		} else { // Note: this requires to have HTTP compatible parameter names (ASCII)
-			$q = array(); // collect unlabelled query parameters here
+			$q = []; // collect unlabelled query parameters here
 
 			foreach ( $params as $name => $value ) {
 				if ( is_string( $name ) && ( $name !== '' ) ) {
@@ -551,7 +551,7 @@ class SMWInfolink {
 	static public function decodeParameters( $titleParam = '', $allParams = false ) {
 		global $wgRequest;
 
-		$result = array();
+		$result = [];
 
 		if ( $allParams ) {
 			$result = $wgRequest->getValues();

--- a/includes/SMW_Outputs.php
+++ b/includes/SMW_Outputs.php
@@ -31,7 +31,7 @@ class SMWOutputs {
 	 * Format $id => $headItem where $id is used only to avoid duplicate
 	 * items in the time before they are forwarded to the output.
 	 */
-	protected static $headItems = array();
+	protected static $headItems = [];
 
 	/**
 	 * Protected member for temporarily storing additional Javascript
@@ -39,21 +39,21 @@ class SMWOutputs {
 	 * avoid duplicate scripts in the time before they are forwarded
 	 * to the output.
 	 */
-	protected static $scripts = array();
+	protected static $scripts = [];
 
 	/**
 	 * Protected member for temporarily storing resource modules.
 	 *
 	 * @var array
 	 */
-	protected static $resourceModules = array();
+	protected static $resourceModules = [];
 
 	/**
 	 * Protected member for temporarily storing resource modules.
 	 *
 	 * @var array
 	 */
-	protected static $resourceStyles = array();
+	protected static $resourceStyles = [];
 
 	/**
 	 * Adds a resource module to the parser output.
@@ -191,9 +191,9 @@ class SMWOutputs {
 		$parserOutput->addModuleStyles( array_values( self::$resourceStyles ) );
 		$parserOutput->addModules( array_values( self::$resourceModules ) );
 
-		self::$resourceStyles = array();
-		self::$resourceModules = array();
-		self::$headItems = array();
+		self::$resourceStyles = [];
+		self::$resourceModules = [];
+		self::$headItems = [];
 	}
 
 	/**
@@ -217,9 +217,9 @@ class SMWOutputs {
 		$output->addModuleStyles( array_values( self::$resourceStyles ) );
 		$output->addModules( array_values( self::$resourceModules ) );
 
-		self::$resourceStyles = array();
-		self::$resourceModules = array();
-		self::$headItems = array();
+		self::$resourceStyles = [];
+		self::$resourceModules = [];
+		self::$headItems = [];
 	}
 
 }

--- a/includes/SMW_PageLister.php
+++ b/includes/SMW_PageLister.php
@@ -54,7 +54,7 @@ class SMWPageLister {
 	 * @param $query array that associates parameter names to parameter values
 	 * @return string
 	 */
-	public function getNavigationLinks( Title $title, $query = array() ) {
+	public function getNavigationLinks( Title $title, $query = [] ) {
 		global $wgLang;
 
 		$limitText = $wgLang->formatNum( $this->mLimit );
@@ -84,12 +84,12 @@ class SMWPageLister {
 
 		$prevLink = wfMessage( 'prevn', $limitText )->escaped();
 		if ( $first !== '' ) {
-			$prevLink = $this->makeSelfLink( $title, $prevLink, $query + array( 'until' => $first ) );
+			$prevLink = $this->makeSelfLink( $title, $prevLink, $query + [ 'until' => $first ] );
 		}
 
 		$nextLink = wfMessage( 'nextn', $limitText )->escaped();
 		if ( $last !== '' ) {
-			$nextLink = $this->makeSelfLink( $title, $nextLink, $query + array( 'from' => $last ) );
+			$nextLink = $this->makeSelfLink( $title, $nextLink, $query + [ 'from' => $last ] );
 		}
 
 		return "($prevLink) ($nextLink)";
@@ -101,7 +101,7 @@ class SMWPageLister {
 	 * @return string
 	 */
 	protected function makeSelfLink( Title $title, $linkText, array $parameters ) {
-		return smwfGetLinker()->link( $title, $linkText, array(), $parameters );
+		return smwfGetLinker()->link( $title, $linkText, [], $parameters );
 	}
 
 	/**
@@ -149,12 +149,12 @@ class SMWPageLister {
 		if ( $from !== '' ) {
 			$diWikiPage = new SMWDIWikiPage( $from, NS_MAIN, '' ); // make a dummy wiki page as boundary
 			$fromDescription = new SMWValueDescription( $diWikiPage, null, SMW_CMP_GEQ );
-			$queryDescription = new SMWConjunction( array( $description, $fromDescription ) );
+			$queryDescription = new SMWConjunction( [ $description, $fromDescription ] );
 			$order = 'ASC';
 		} elseif ( $until !== '' ) {
 			$diWikiPage = new SMWDIWikiPage( $until, NS_MAIN, '' ); // make a dummy wiki page as boundary
 			$untilDescription = new SMWValueDescription( $diWikiPage, null, SMW_CMP_LESS ); // do not include boundary in this case
-			$queryDescription = new SMWConjunction( array( $description, $untilDescription ) );
+			$queryDescription = new SMWConjunction( [ $description, $untilDescription ] );
 			$order = 'DESC';
 		} else {
 			$queryDescription = $description;

--- a/includes/SMW_PageSchemas.php
+++ b/includes/SMW_PageSchemas.php
@@ -31,8 +31,8 @@ class SMWPageSchemas extends PSExtensionHandler {
 		foreach ( $templateXML->children() as $tag => $child ) {
 			if ( $tag == "semanticmediawiki_ConnectingProperty" ) {
 				$propName = $child->attributes()->name;
-				$values = array();
-				return array( $propName, $values );
+				$values = [];
+				return [ $propName, $values ];
 			}
 		}
 		return null;
@@ -46,11 +46,11 @@ class SMWPageSchemas extends PSExtensionHandler {
 		foreach ( $fieldXML->children() as $tag => $child ) {
 			if ( $tag == "semanticmediawiki_Property" ) {
 				$propName = $child->attributes()->name;
-				$values = array();
+				$values = [];
 				foreach ( $child->children() as $prop => $value ) {
 					$values[$prop] = (string)$value;
 				}
-				return array( $propName, $values );
+				return [ $propName, $values ];
 			}
 		}
 		return null;
@@ -60,7 +60,7 @@ class SMWPageSchemas extends PSExtensionHandler {
 	 * Returns the set of SMW property data from the entire page schema.
 	 */
 	static function getAllPropertyData( $pageSchemaObj ) {
-		$propertyDataArray = array();
+		$propertyDataArray = [];
 		$psTemplates = $pageSchemaObj->getTemplates();
 		foreach ( $psTemplates as $psTemplate ) {
 			$psTemplateFields = $psTemplate->getFields();
@@ -87,7 +87,7 @@ class SMWPageSchemas extends PSExtensionHandler {
 	public static function createTemplateXMLFromForm() {
 		global $wgRequest;
 
-		$xmlPerTemplate = array();
+		$xmlPerTemplate = [];
 		foreach ( $wgRequest->getValues() as $var => $val ) {
 			if ( substr( $var, 0, 24 ) == 'smw_connecting_property_' ) {
 				$templateNum = substr( $var, 24 );
@@ -110,7 +110,7 @@ class SMWPageSchemas extends PSExtensionHandler {
 	 * Page Schemas object.
 	 */
 	public static function getPagesToGenerate( $pageSchemaObj ) {
-		$pagesToGenerate = array();
+		$pagesToGenerate = [];
 
 		$psTemplates = $pageSchemaObj->getTemplates();
 		foreach ( $psTemplates as $psTemplate ) {
@@ -137,7 +137,7 @@ class SMWPageSchemas extends PSExtensionHandler {
 		global $wgRequest;
 
 		$fieldNum = -1;
-		$xmlPerField = array();
+		$xmlPerField = [];
 		foreach ( $wgRequest->getValues() as $var => $val ) {
 			if ( substr( $var, 0, 18 ) == 'smw_property_name_' ) {
 				$fieldNum = substr( $var, 18 );
@@ -179,7 +179,7 @@ class SMWPageSchemas extends PSExtensionHandler {
 			return null;
 		}
 
-		$prop_array = array();
+		$prop_array = [];
 		$hasExistingValues = false;
 		if ( !is_null( $psTemplate ) ) {
 			$prop_array = $psTemplate->getObject( 'semanticmediawiki_ConnectingProperty' );
@@ -189,9 +189,9 @@ class SMWPageSchemas extends PSExtensionHandler {
 		}
 		$text = '<p>' . 'Name of property to connect this template\'s fields to the rest of the page:' . ' ' . '(should only be used if this template can have multiple instances)' . ' ';
 		$propName = PageSchemas::getValueFromObject( $prop_array, 'name' );
-		$text .= Html::input( 'smw_connecting_property_num', $propName, array( 'size' => 15 ) ) . "\n";
+		$text .= Html::input( 'smw_connecting_property_num', $propName, [ 'size' => 15 ] ) . "\n";
 
-		return array( $text, $hasExistingValues );
+		return [ $text, $hasExistingValues ];
 	}
 
 	/**
@@ -201,7 +201,7 @@ class SMWPageSchemas extends PSExtensionHandler {
 	public static function getFieldEditingHTML( $psTemplateField ) {
 		global $smwgContLang;
 
-		$prop_array = array();
+		$prop_array = [];
 		$hasExistingValues = false;
 		if ( !is_null( $psTemplateField ) ) {
 			$prop_array = $psTemplateField->getObject('semanticmediawiki_Property');
@@ -211,22 +211,22 @@ class SMWPageSchemas extends PSExtensionHandler {
 		}
 		$html_text = '<p>' . wfMessage( 'ps-optional-name' )->text() . ' ';
 		$propName = PageSchemas::getValueFromObject( $prop_array, 'name' );
-		$html_text .= Html::input( 'smw_property_name_num', $propName, array( 'size' => 15 ) ) . "\n";
+		$html_text .= Html::input( 'smw_property_name_num', $propName, [ 'size' => 15 ] ) . "\n";
 		$propType = PageSchemas::getValueFromObject( $prop_array, 'Type' );
 		$select_body = "";
 		$datatype_labels = $smwgContLang->getDatatypeLabels();
 		foreach ( $datatype_labels as $label ) {
-			$optionAttrs = array();
+			$optionAttrs = [];
 			if ( $label == $propType) {
 				$optionAttrs['selected'] = 'selected';
 			}
 			$select_body .= "\t" . Xml::element( 'option', $optionAttrs, $label ) . "\n";
 		}
-		$propertyDropdownAttrs = array(
+		$propertyDropdownAttrs = [
 			'id' => 'property_dropdown',
 			'name' => 'smw_property_type_num',
 			'value' => $propType
-		);
+		];
 		$html_text .= "Type: " . Xml::tags( 'select', $propertyDropdownAttrs, $select_body ) . "</p>\n";
 
 		// This can't be last, because of the hacky way the XML is
@@ -234,14 +234,14 @@ class SMWPageSchemas extends PSExtensionHandler {
 		if ( defined( 'SF_VERSION' ) ) {
 			$html_text .= '<p>' . wfMessage( 'sf_createproperty_linktoform' )->text() . ' ';
 			$linkedForm = PageSchemas::getValueFromObject( $prop_array, 'LinkedForm' );
-			$html_text .= Html::input( 'smw_linked_form_num', $linkedForm, array( 'size' => 15 ) ) . "\n";
+			$html_text .= Html::input( 'smw_linked_form_num', $linkedForm, [ 'size' => 15 ] ) . "\n";
 			$html_text .= "(for Page properties only)</p>\n";
 		}
 
 		$html_text .= '<p>If you want this property to only be allowed to have certain values, enter the list of allowed values, separated by commas (if a value contains a comma, replace it with "\,"):</p>';
-		$allowedValsInputAttrs = array(
+		$allowedValsInputAttrs = [
 			'size' => 80
-		);
+		];
 		$allowedValues = PageSchemas::getValueFromObject( $prop_array, 'allowed_values' );
 		if ( is_null( $allowedValues ) ) {
 			$allowed_val_string = '';
@@ -250,7 +250,7 @@ class SMWPageSchemas extends PSExtensionHandler {
 		}
 		$html_text .= '<p>' . Html::input( 'smw_values_num', $allowed_val_string, 'text', $allowedValsInputAttrs ) . "</p>\n";
 
-		return array( $html_text, $hasExistingValues );
+		return [ $html_text, $hasExistingValues ];
 	}
 
 	/**
@@ -263,8 +263,8 @@ class SMWPageSchemas extends PSExtensionHandler {
 		$datatypeLabels = $smwgContLang->getDatatypeLabels();
 		$pageTypeLabel = $datatypeLabels['_wpg'];
 
-		$jobs = array();
-		$jobParams = array();
+		$jobs = [];
+		$jobParams = [];
 		$jobParams['user_id'] = $wgUser->getId();
 
 		// First, create jobs for all "connecting properties".
@@ -345,7 +345,7 @@ class SMWPageSchemas extends PSExtensionHandler {
 		if ( $tagName == "semanticmediawiki_ConnectingProperty" ) {
 			foreach ( $xml->children() as $tag => $child ) {
 				if ( $tag == $tagName ) {
-					$smw_array = array();
+					$smw_array = [];
 					$propName = $child->attributes()->name;
 					$smw_array['name'] = (string)$propName;
 					foreach ( $child->children() as $prop => $value ) {
@@ -357,10 +357,10 @@ class SMWPageSchemas extends PSExtensionHandler {
 		} elseif ( $tagName == "semanticmediawiki_Property" ) {
 			foreach ( $xml->children() as $tag => $child ) {
 				if ( $tag == $tagName ) {
-					$smw_array = array();
+					$smw_array = [];
 					$propName = $child->attributes()->name;
 					$smw_array['name'] = (string)$propName;
-					$allowed_values = array();
+					$allowed_values = [];
 					$count = 0;
 					foreach ( $child->children() as $prop => $value ) {
 						if ( $prop == "AllowedValue" ) {

--- a/includes/SemanticData.php
+++ b/includes/SemanticData.php
@@ -69,14 +69,14 @@ class SemanticData {
 	 *
 	 * @var SMWDataItem[]
 	 */
-	protected $mPropVals = array();
+	protected $mPropVals = [];
 
 	/**
 	 * Array mapping property keys (string) to DIProperty objects.
 	 *
 	 * @var DIProperty[]
 	 */
-	protected $mProperties = array();
+	protected $mProperties = [];
 
 	/**
 	 * States whether the container holds any normal properties.
@@ -140,7 +140,7 @@ class SemanticData {
 	/**
 	 * @var array
 	 */
-	protected $errors = array();
+	protected $errors = [];
 
 	/**
 	 * Cache the hash to ensure a minimal impact in case of repeated usage. Any
@@ -196,7 +196,7 @@ class SemanticData {
 	 * @return array
 	 */
 	public function __sleep() {
-		return array( 'mSubject', 'mPropVals', 'mProperties', 'subSemanticData', 'mHasVisibleProps', 'mHasVisibleSpecs', 'options', 'extensionData' );
+		return [ 'mSubject', 'mPropVals', 'mProperties', 'subSemanticData', 'mHasVisibleProps', 'mHasVisibleSpecs', 'options', 'extensionData' ];
 	}
 
 	/**
@@ -237,14 +237,14 @@ class SemanticData {
 	 */
 	public function getPropertyValues( DIProperty $property ) {
 		if ( $property->isInverse() ) { // we never have any data for inverses
-			return array();
+			return [];
 		}
 
 		if ( array_key_exists( $property->getKey(), $this->mPropVals ) ) {
 			return array_values( $this->mPropVals[$property->getKey()] );
 		}
 
-		return array();
+		return [];
 	}
 
 	/**
@@ -445,7 +445,7 @@ class SemanticData {
 		}
 
 		if ( !array_key_exists( $property->getKey(), $this->mPropVals ) ) {
-			$this->mPropVals[$property->getKey()] = array();
+			$this->mPropVals[$property->getKey()] = [];
 			$this->mProperties[$property->getKey()] = $property;
 		}
 
@@ -589,7 +589,7 @@ class SemanticData {
 			$this->mPropVals[$property->getKey()] = array_values( $this->mPropVals[$property->getKey()] );
 		}
 
-		if ( $this->mPropVals[$property->getKey()] === array() ) {
+		if ( $this->mPropVals[$property->getKey()] === [] ) {
 			unset( $this->mProperties[$property->getKey()] );
 			unset( $this->mPropVals[$property->getKey()] );
 		}
@@ -637,8 +637,8 @@ class SemanticData {
 	 * Delete all data other than the subject.
 	 */
 	public function clear() {
-		$this->mPropVals = array();
-		$this->mProperties = array();
+		$this->mPropVals = [];
+		$this->mProperties = [];
 		$this->mHasVisibleProps = false;
 		$this->mHasVisibleSpecs = false;
 		$this->stubObject = false;
@@ -657,7 +657,7 @@ class SemanticData {
 	 * @return boolean
 	 */
 	public function isEmpty() {
-		return $this->getProperties() === array() && $this->getSubSemanticData() === array();
+		return $this->getProperties() === [] && $this->getSubSemanticData() === [];
 	}
 
 	/**
@@ -684,7 +684,7 @@ class SemanticData {
 		if ( count( $this->mProperties ) == 0 &&
 		     ( $semanticData->mNoDuplicates >= $this->mNoDuplicates ) ) {
 			$this->mProperties = $semanticData->getProperties();
-			$this->mPropVals = array();
+			$this->mPropVals = [];
 
 			foreach ( $this->mProperties as $property ) {
 				$this->mPropVals[$property->getKey()] = $semanticData->getPropertyValues( $property );

--- a/includes/Settings.php
+++ b/includes/Settings.php
@@ -23,7 +23,7 @@ class Settings extends Options {
 	/**
 	 * @var array
 	 */
-	private $iterate = array();
+	private $iterate = [];
 
 	/**
 	 * Assemble individual SMW related settings into one accessible array for
@@ -43,7 +43,7 @@ class Settings extends Options {
 	 */
 	public static function newFromGlobals() {
 
-		$configuration = array(
+		$configuration = [
 			'smwgIP' => $GLOBALS['smwgIP'],
 			'smwgExtraneousLanguageFileDir' => $GLOBALS['smwgExtraneousLanguageFileDir'],
 			'smwgServicesFileDir' => $GLOBALS['smwgServicesFileDir'],
@@ -180,11 +180,11 @@ class Settings extends Options {
 			'smwgPostEditUpdate' => $GLOBALS['smwgPostEditUpdate'],
 			'smwgSpecialAskFormSubmitMethod' => $GLOBALS['smwgSpecialAskFormSubmitMethod'],
 			'smwgSupportSectionTag' => $GLOBALS['smwgSupportSectionTag'],
-		);
+		];
 
 		self::initLegacyMapping( $configuration );
 
-		\Hooks::run( 'SMW::Config::BeforeCompletion', array( &$configuration ) );
+		\Hooks::run( 'SMW::Config::BeforeCompletion', [ &$configuration ] );
 
 		if ( self::$instance === null ) {
 			self::$instance = self::newFromArray( $configuration );
@@ -493,8 +493,8 @@ class Settings extends Options {
 
 		// Deprecated mapping used in DeprecationNoticeTaskHandler to detect and
 		// output notices
-		$GLOBALS['smwgDeprecationNotices']['smw'] = array(
-			'notice' => array(
+		$GLOBALS['smwgDeprecationNotices']['smw'] = [
+			'notice' => [
 				'smwgAdminRefreshStore' => '3.1.0',
 				'smwgQueryDependencyPropertyExemptionlist' => '3.1.0',
 				'smwgQueryDependencyAffiliatePropertyDetectionlist' => '3.1.0',
@@ -539,8 +539,8 @@ class Settings extends Options {
 						'smwgQueryParametersEnabled' => '3.1.0'
 					]
 				]
-			),
-			'replacement' => array(
+			],
+			'replacement' => [
 				'smwgAdminRefreshStore' => 'smwgAdminFeatures',
 				'smwgQueryDependencyPropertyExemptionlist' => 'smwgQueryDependencyPropertyExemptionList',
 				'smwgQueryDependencyAffiliatePropertyDetectionlist' => 'smwgQueryDependencyAffiliatePropertyDetectionList',
@@ -585,15 +585,15 @@ class Settings extends Options {
 						'smwgQueryParametersEnabled' => 'SMW_QPRFL_PARAMS'
 					]
 				] + ( $jobQueueWatchlist !== [] ? [ 'smwgJobQueueWatchlist' => $jobQueueWatchlist ] : [] )
-			),
-			'removal' => array(
+			],
+			'removal' => [
 				'smwgOnDeleteAction' => '2.4.0',
 				'smwgAutocompleteInSpecialAsk' => '3.0.0',
 				'smwgSparqlDatabaseMaster' => '3.0.0',
 				'smwgHistoricTypeNamespace' => '3.0.0',
 				'smwgEnabledHttpDeferredJobRequest' => '3.0.0'
-			)
-		);
+			]
+		];
 	}
 
 }

--- a/includes/Setup.php
+++ b/includes/Setup.php
@@ -78,67 +78,67 @@ final class Setup {
 			return;
 		}
 
-		$specials = array(
-			'Ask' => array(
+		$specials = [
+			'Ask' => [
 				'page' => 'SMW\MediaWiki\Specials\SpecialAsk',
 				'group' => 'smw_group'
-			),
-			'Browse' => array(
+			],
+			'Browse' => [
 				'page' =>  'SMW\MediaWiki\Specials\SpecialBrowse',
 				'group' => 'smw_group'
-			),
-			'PageProperty' => array(
+			],
+			'PageProperty' => [
 				'page' =>  'SMW\MediaWiki\Specials\SpecialPageProperty',
 				'group' => 'smw_group'
-			),
-			'SearchByProperty' => array(
+			],
+			'SearchByProperty' => [
 				'page' => 'SMW\MediaWiki\Specials\SpecialSearchByProperty',
 				'group' => 'smw_group'
-			),
-			'ProcessingErrorList' => array(
+			],
+			'ProcessingErrorList' => [
 				'page' => 'SMW\MediaWiki\Specials\SpecialProcessingErrorList',
 				'group' => 'smw_group'
-			),
-			'PropertyLabelSimilarity' => array(
+			],
+			'PropertyLabelSimilarity' => [
 				'page' => 'SMW\MediaWiki\Specials\SpecialPropertyLabelSimilarity',
 				'group' => 'smw_group'
-			),
-			'SMWAdmin' => array(
+			],
+			'SMWAdmin' => [
 				'page' => 'SMW\MediaWiki\Specials\SpecialAdmin',
 				'group' => 'smw_group'
-			),
-			'Concepts' => array(
+			],
+			'Concepts' => [
 				'page' => 'SMW\SpecialConcepts',
 				'group' => 'pages'
-			),
-			'ExportRDF' => array(
+			],
+			'ExportRDF' => [
 				'page' => 'SMWSpecialOWLExport',
 				'group' => 'smw_group'
-			),
-			'Types' => array(
+			],
+			'Types' => [
 				'page' => 'SMWSpecialTypes',
 				'group' => 'pages'
-			),
-			'URIResolver' => array(
+			],
+			'URIResolver' => [
 				'page' => 'SMW\MediaWiki\Specials\SpecialURIResolver'
-			),
-			'Properties' => array(
+			],
+			'Properties' => [
 				'page' => 'SMW\SpecialProperties',
 				'group' => 'pages'
-			),
-			'UnusedProperties' => array(
+			],
+			'UnusedProperties' => [
 				'page' => 'SMW\SpecialUnusedProperties',
 				'group' => 'maintenance'
-			),
-			'WantedProperties' => array(
+			],
+			'WantedProperties' => [
 				'page' => 'SMW\SpecialWantedProperties',
 				'group' => 'maintenance'
-			),
-			'DeferredRequestDispatcher' => array(
+			],
+			'DeferredRequestDispatcher' => [
 				'page' => 'SMW\MediaWiki\Specials\SpecialDeferredRequestDispatcher',
 				'group' => 'maintenance'
-			),
-		);
+			],
+		];
 
 		// Register data
 		foreach ( $specials as $special => $page ) {
@@ -310,7 +310,7 @@ final class Setup {
 	 */
 	private function registerJobClasses( &$vars ) {
 
-		$jobClasses = array(
+		$jobClasses = [
 
 			'smw.update' => 'SMW\MediaWiki\Jobs\UpdateJob',
 			'smw.refresh' => 'SMW\MediaWiki\Jobs\RefreshJob',
@@ -342,7 +342,7 @@ final class Setup {
 			// Legacy 2.0-
 			'SMWUpdateJob'  => 'SMW\MediaWiki\Jobs\UpdateJob',
 			'SMWRefreshJob' => 'SMW\MediaWiki\Jobs\RefreshJob'
-		);
+		];
 
 		foreach ( $jobClasses as $job => $class ) {
 			$vars['wgJobClasses'][$job] = $class;
@@ -398,9 +398,9 @@ final class Setup {
 	}
 
 	private function registerParamDefinitions( &$vars ) {
-		$vars['wgParamDefinitions']['smwformat'] = array(
+		$vars['wgParamDefinitions']['smwformat'] = [
 			'definition'=> 'SMWParamFormat',
-		);
+		];
 	}
 
 	/**

--- a/includes/Subobject.php
+++ b/includes/Subobject.php
@@ -32,7 +32,7 @@ class Subobject {
 	/**
 	 * @var array
 	 */
-	protected $errors = array();
+	protected $errors = [];
 
 	/**
 	 * @since 1.9
@@ -89,7 +89,7 @@ class Subobject {
 	public function addError( $error ) {
 
 		if ( is_string( $error ) ) {
-			$error = array( md5( $error ) => $error );
+			$error = [ md5( $error ) => $error ];
 		}
 
 		// Preserve the keys, avoid using array_merge to avert a possible

--- a/includes/dataitems/SMW_DI_Container.php
+++ b/includes/dataitems/SMW_DI_Container.php
@@ -99,7 +99,7 @@ class SMWDIContainer extends SMWDataItem {
 
 	private function getValueHash( $semanticData ) {
 
-		$hash = array();
+		$hash = [];
 
 		foreach ( $semanticData->getProperties() as $property ) {
 			$hash[] = $property->getKey();

--- a/includes/dataitems/SMW_DI_GeoCoord.php
+++ b/includes/dataitems/SMW_DI_GeoCoord.php
@@ -100,7 +100,7 @@ class SMWDIGeoCoord extends SMWDataItem {
 	 * @return array
 	 */
 	public function getCoordinateSet() {
-		$coords = array( 'lat' => $this->latitude, 'lon' => $this->longitude );
+		$coords = [ 'lat' => $this->latitude, 'lon' => $this->longitude ];
 
 		if ( !is_null( $this->altitude ) ) {
 			$coords['alt'] = $this->altitude;
@@ -143,7 +143,7 @@ class SMWDIGeoCoord extends SMWDataItem {
 			throw new DataItemException( 'Unserialization of coordinates failed' );
 		}
 
-		$coords = array( 'lat' => (float)$parts[0], 'lon' => (float)$parts[1] );
+		$coords = [ 'lat' => (float)$parts[0], 'lon' => (float)$parts[1] ];
 
 		if ( $count === 3 ) {
 			$coords['alt'] = (float)$parts[2];

--- a/includes/dataitems/SMW_DI_Time.php
+++ b/includes/dataitems/SMW_DI_Time.php
@@ -44,7 +44,7 @@ class SMWDITime extends SMWDataItem implements CalendarModel {
 	 * Maximal number of days in a given month.
 	 * @var array
 	 */
-	protected static $m_daysofmonths = array( 1 => 31, 2 => 29, 3 => 31, 4 => 30, 5 => 31, 6 => 30, 7 => 31, 8 => 31, 9 => 30, 10 => 31, 11 => 30, 12 => 31 );
+	protected static $m_daysofmonths = [ 1 => 31, 2 => 29, 3 => 31, 4 => 30, 5 => 31, 6 => 30, 7 => 31, 8 => 31, 9 => 30, 10 => 31, 11 => 30, 12 => 31 ];
 
 	/**
 	 * Precision SMWDITime::PREC_Y, SMWDITime::PREC_YM,
@@ -267,10 +267,10 @@ class SMWDITime extends SMWDataItem implements CalendarModel {
 	 */
 	public function getCalendarModelLiteral() {
 
-		$literal = array(
+		$literal = [
 			self::CM_GREGORIAN => '',
 			self::CM_JULIAN    => 'JL'
-		);
+		];
 
 		return $literal[$this->m_model];
 	}
@@ -367,14 +367,14 @@ class SMWDITime extends SMWDataItem implements CalendarModel {
 	public function getMwTimestamp( $outputtype = TS_UNIX ) {
 		return wfTimestamp(
 			$outputtype,
-			implode( '', array(
+			implode( '', [
 				str_pad( $this->m_year, 4, '0', STR_PAD_LEFT ),
 				str_pad( $this->m_month, 2, '0', STR_PAD_LEFT ),
 				str_pad( $this->m_day, 2, '0', STR_PAD_LEFT ),
 				str_pad( $this->m_hours, 2, '0', STR_PAD_LEFT ),
 				str_pad( $this->m_minutes, 2, '0', STR_PAD_LEFT ),
 				str_pad( $this->m_seconds, 2, '0', STR_PAD_LEFT ),
-			) )
+			] )
 		);
 	}
 
@@ -468,7 +468,7 @@ class SMWDITime extends SMWDataItem implements CalendarModel {
 	 */
 	public static function doUnserialize( $serialization ) {
 		$parts = explode( '/', $serialization, 8 );
-		$values = array();
+		$values = [];
 
 		if ( count( $parts ) <= 1 ) {
 			throw new DataItemException( "Unserialization failed: the string \"$serialization\" is no valid URI." );

--- a/includes/dataitems/SMW_DI_URI.php
+++ b/includes/dataitems/SMW_DI_URI.php
@@ -65,9 +65,9 @@ class SMWDIUri extends SMWDataItem {
 
 	/// @todo This should be changed to the spelling getUri().
 	public function getURI() {
-		$schemesWithDoubleslesh = array(
+		$schemesWithDoubleslesh = [
 			'http', 'https', 'ftp'
-		);
+		];
 
 		$uri = $this->m_scheme . ':'
 			. ( in_array( $this->m_scheme, $schemesWithDoubleslesh ) ? '//' : '' )
@@ -79,7 +79,7 @@ class SMWDIUri extends SMWDataItem {
 		// https://tools.ietf.org/html/rfc3986
 		// Normalize spaces to use `_` instead of %20 and so ensure
 		// that http://example.org/Foo bar === http://example.org/Foo_bar === http://example.org/Foo%20bar
-		return str_replace( array( ' ', '%20'), '_', $uri );
+		return str_replace( [ ' ', '%20'], '_', $uri );
 	}
 
 	public function getScheme() {

--- a/includes/dataitems/SMW_DI_WikiPage.php
+++ b/includes/dataitems/SMW_DI_WikiPage.php
@@ -231,11 +231,11 @@ class DIWikiPage extends SMWDataItem {
 	 * @return string
 	 */
 	public function getSerialization() {
-		$segments = array(
+		$segments = [
 			$this->m_dbkey,
 			$this->m_namespace,
 			$this->m_interwiki
-		);
+		];
 
 		$segments[] = $this->m_subobjectname;
 

--- a/includes/dataitems/SMW_DataItem.php
+++ b/includes/dataitems/SMW_DataItem.php
@@ -156,7 +156,7 @@ abstract class SMWDataItem {
 	 */
 	public static function newFromSerialization( $diType, $serialization ) {
 		$diClass = self::getDataItemClassNameForId( $diType );
-		return call_user_func( array( $diClass, 'doUnserialize' ), $serialization );
+		return call_user_func( [ $diClass, 'doUnserialize' ], $serialization );
 	}
 
 	/**

--- a/includes/datavalues/SMW_DV_Concept.php
+++ b/includes/datavalues/SMW_DV_Concept.php
@@ -65,7 +65,7 @@ class SMWConceptValue extends SMWDataValue {
 
 	public function getWikiValue() {
 		/// This should not be used for anything. This class does not support wiki values.
-		return str_replace( array( '&lt;', '&gt;', '&amp;' ), array( '<', '>', '&' ), $this->m_dataitem->getConceptQuery() );
+		return str_replace( [ '&lt;', '&gt;', '&amp;' ], [ '<', '>', '&' ], $this->m_dataitem->getConceptQuery() );
 	}
 
 	/// Return the concept's defining text (in SMW query syntax)

--- a/includes/datavalues/SMW_DV_Error.php
+++ b/includes/datavalues/SMW_DV_Error.php
@@ -30,7 +30,7 @@ class SMWErrorValue extends SMWDataValue {
 		if ( $this->m_caption === false ) {
 			$this->m_caption = $value;
 		}
-		$this->addErrorMsg( array( 'smw-datavalue-parse-error', $value ) );
+		$this->addErrorMsg( [ 'smw-datavalue-parse-error', $value ] );
 	}
 
 	/**

--- a/includes/datavalues/SMW_DV_Number.php
+++ b/includes/datavalues/SMW_DV_Number.php
@@ -69,7 +69,7 @@ class SMWNumberValue extends SMWDataValue {
 	 *
 	 * @var array
 	 */
-	protected $prefixalUnitPreference = array();
+	protected $prefixalUnitPreference = [];
 
 	/**
 	 * Canonical identifier for the unit that the user gave as input. Used
@@ -146,7 +146,7 @@ class SMWNumberValue extends SMWDataValue {
 
 		$parts = preg_split(
 			$regex,
-			trim( str_replace( array( '&nbsp;', '&#160;', '&thinsp;', ' ' ), $space, $value ) ),
+			trim( str_replace( [ '&nbsp;', '&#160;', '&thinsp;', ' ' ], $space, $value ) ),
 			2,
 			PREG_SPLIT_DELIM_CAPTURE
 		);
@@ -182,7 +182,7 @@ class SMWNumberValue extends SMWDataValue {
 		}
 
 		if ( $value !== '' && $value{0} === ':' ) {
-			$this->addErrorMsg( array( 'smw-datavalue-invalid-number', $value ) );
+			$this->addErrorMsg( [ 'smw-datavalue-invalid-number', $value ] );
 			return;
 		}
 
@@ -192,15 +192,15 @@ class SMWNumberValue extends SMWDataValue {
 		$error = $this->parseNumberValue( $value, $number, $unit );
 
 		if ( $error == 1 ) { // no number found
-			$this->addErrorMsg( array( 'smw_nofloat', $value ) );
+			$this->addErrorMsg( [ 'smw_nofloat', $value ] );
 		} elseif ( $error == 2 ) { // number is too large for this platform
-			$this->addErrorMsg( array( 'smw_infinite', $value ) );
+			$this->addErrorMsg( [ 'smw_infinite', $value ] );
 		} elseif ( $this->getTypeID() === '_num' && $unit !== '' ) {
-			$this->addErrorMsg( array( 'smw-datavalue-number-textnotallowed', $unit, $number ) );
+			$this->addErrorMsg( [ 'smw-datavalue-number-textnotallowed', $unit, $number ] );
 		} elseif ( $number === null ) {
-			$this->addErrorMsg( array( 'smw-datavalue-number-nullnotallowed', $value ) ); // #1628
+			$this->addErrorMsg( [ 'smw-datavalue-number-nullnotallowed', $value ] ); // #1628
 		} elseif ( $this->convertToMainUnit( $number, $unit ) === false ) { // so far so good: now convert unit and check if it is allowed
-			$this->addErrorMsg( array( 'smw_unitnotallowed', $unit ) );
+			$this->addErrorMsg( [ 'smw_unitnotallowed', $unit ] );
 		} // note that convertToMainUnit() also sets m_dataitem if valid
 	}
 
@@ -433,9 +433,9 @@ class SMWNumberValue extends SMWDataValue {
 	 */
 	protected function getServiceLinkParams() {
 		if ( $this->isValid() ) {
-			return array( strval( $this->m_dataitem->getNumber() ), strval( round( $this->m_dataitem->getNumber() ) ) );
+			return [ strval( $this->m_dataitem->getNumber() ), strval( round( $this->m_dataitem->getNumber() ) ) ];
 		} else {
-			return array();
+			return [];
 		}
 	}
 
@@ -445,9 +445,9 @@ class SMWNumberValue extends SMWDataValue {
 	 * distinguished.
 	 */
 	public function normalizeUnit( $unit ) {
-		$unit = str_replace( array( '[[', ']]' ), '', trim( $unit ) ); // allow simple links to be used inside annotations
-		$unit = str_replace( array( '²', '<sup>2</sup>' ), '&sup2;', $unit );
-		$unit = str_replace( array( '³', '<sup>3</sup>' ), '&sup3;', $unit );
+		$unit = str_replace( [ '[[', ']]' ], '', trim( $unit ) ); // allow simple links to be used inside annotations
+		$unit = str_replace( [ '²', '<sup>2</sup>' ], '&sup2;', $unit );
+		$unit = str_replace( [ '³', '<sup>3</sup>' ], '&sup3;', $unit );
 		return smwfXMLContentEncode( $unit );
 	}
 
@@ -483,7 +483,7 @@ class SMWNumberValue extends SMWDataValue {
 	 * Overwritten by subclasses that support units.
 	 */
 	protected function makeConversionValues() {
-		$this->m_unitvalues = array( '' => $this->m_dataitem->getNumber() );
+		$this->m_unitvalues = [ '' => $this->m_dataitem->getNumber() ];
 	}
 
 	/**
@@ -520,7 +520,7 @@ class SMWNumberValue extends SMWDataValue {
 	 * Overwritten by subclasses that support units.
 	 */
 	public function getUnitList() {
-		return array( '' );
+		return [ '' ];
 	}
 
 	protected function getPreferredDisplayPrecision() {
@@ -596,7 +596,7 @@ class SMWNumberValue extends SMWDataValue {
 		}
 
 		// Remove any remaining
-		$formatstring = str_replace( array( '#LOCL', 'LOCL' ), '', $formatstring );
+		$formatstring = str_replace( [ '#LOCL', 'LOCL' ], '', $formatstring );
 	}
 
 }

--- a/includes/datavalues/SMW_DV_PropertyList.php
+++ b/includes/datavalues/SMW_DV_PropertyList.php
@@ -23,7 +23,7 @@ class SMWPropertyListValue extends SMWDataValue {
 	protected function parseUserValue( $value ) {
 		global $wgContLang;
 
-		$this->m_diProperties = array();
+		$this->m_diProperties = [];
 		$stringValue = '';
 		$valueList = preg_split( '/[\s]*;[\s]*/u', trim( $value ) );
 		foreach ( $valueList as $propertyName ) {
@@ -33,7 +33,7 @@ class SMWPropertyListValue extends SMWDataValue {
 				$propertyName = $propertyNameParts[1];
 				$propertyNamespace = $wgContLang->getNsText( SMW_NS_PROPERTY );
 				if ( $namespace != $propertyNamespace ) {
-					$this->addErrorMsg( array( 'smw_wrong_namespace', $propertyNamespace ) );
+					$this->addErrorMsg( [ 'smw_wrong_namespace', $propertyNamespace ] );
 				}
 			}
 
@@ -43,7 +43,7 @@ class SMWPropertyListValue extends SMWDataValue {
 				$diProperty = SMW\DIProperty::newFromUserLabel( $propertyName );
 			} catch ( SMWDataItemException $e ) {
 				$diProperty = new SMW\DIProperty( 'Error' );
-				$this->addErrorMsg( array( 'smw_noproperty', $propertyName ) );
+				$this->addErrorMsg( [ 'smw_noproperty', $propertyName ] );
 			}
 
 			$this->m_diProperties[] = $diProperty;
@@ -67,7 +67,7 @@ class SMWPropertyListValue extends SMWDataValue {
 		}
 
 		$this->m_dataitem = $dataItem;
-		$this->m_diProperties = array();
+		$this->m_diProperties = [];
 
 		foreach ( explode( ';', $dataItem->getString() ) as $propertyKey ) {
 			$property = null;
@@ -76,7 +76,7 @@ class SMWPropertyListValue extends SMWDataValue {
 				$property = new SMW\DIProperty( $propertyKey );
 			} catch ( SMWDataItemException $e ) {
 				$property = new SMW\DIProperty( 'Error' );
-				$this->addErrorMsg( array( 'smw-datavalue-propertylist-invalid-property-key', $dataItem->getString(), $propertyKey ) );
+				$this->addErrorMsg( [ 'smw-datavalue-propertylist-invalid-property-key', $dataItem->getString(), $propertyKey ] );
 			}
 
 			if ( $property instanceof SMWDIProperty ) {

--- a/includes/datavalues/SMW_DV_Quantity.php
+++ b/includes/datavalues/SMW_DV_Quantity.php
@@ -64,7 +64,7 @@ class SMWQuantityValue extends SMWNumberValue {
 			return; // do this only once
 		}
 
-		$this->m_unitvalues = array();
+		$this->m_unitvalues = [];
 
 		if ( !$this->isValid() ) {
 			return;
@@ -174,7 +174,7 @@ class SMWQuantityValue extends SMWNumberValue {
 		$unitConverter = new UnitConverter( $this );
 		$unitConverter->initConversionData( $this->m_property );
 
-		if ( $unitConverter->getErrors() !== array() ) {
+		if ( $unitConverter->getErrors() !== [] ) {
 			foreach ( $unitConverter->getErrors() as $error ) {
 				$this->addErrorMsg(
 					$error,
@@ -198,7 +198,7 @@ class SMWQuantityValue extends SMWNumberValue {
 			return; // do the below only once
 		}
 		$this->initConversionData(); // needed to normalise unit strings
-		$this->m_displayunits = array();
+		$this->m_displayunits = [];
 
 		if ( is_null( $this->m_property ) || is_null( $this->m_property->getDIWikiPage() ) ) {
 			return;

--- a/includes/datavalues/SMW_DV_Record.php
+++ b/includes/datavalues/SMW_DV_Record.php
@@ -75,12 +75,12 @@ class SMWRecordValue extends AbstractMultiValue {
 	protected function parseUserValue( $value ) {
 
 		if ( $value === '' ) {
-			$this->addErrorMsg( array( 'smw_novalues' ) );
+			$this->addErrorMsg( [ 'smw_novalues' ] );
 			return;
 		}
 
 		$containerSemanticData = $this->newContainerSemanticData( $value );
-		$sortKeys = array();
+		$sortKeys = [];
 
 		$values = $this->getValuesFromString( $value );
 		$valueIndex = 0; // index in value array
@@ -89,7 +89,7 @@ class SMWRecordValue extends AbstractMultiValue {
 
 		foreach ( $this->getPropertyDataItems() as $diProperty ) {
 
-			if ( !array_key_exists( $valueIndex, $values ) || $this->getErrors() !== array() ) {
+			if ( !array_key_exists( $valueIndex, $values ) || $this->getErrors() !== [] ) {
 				break; // stop if there are no values left
 			}
 
@@ -119,8 +119,8 @@ class SMWRecordValue extends AbstractMultiValue {
 			++$propertyIndex;
 		}
 
-		if ( $empty && $this->getErrors() === array()  ) {
-			$this->addErrorMsg( array( 'smw_novalues' ) );
+		if ( $empty && $this->getErrors() === []  ) {
+			$this->addErrorMsg( [ 'smw_novalues' ] );
 		}
 
 		// Remember the data to extend the sortkey
@@ -224,7 +224,7 @@ class SMWRecordValue extends AbstractMultiValue {
 
 		$this->m_diProperties = $this->getFieldProperties( $this->m_property );
 
-		if ( $this->m_diProperties  === array() ) { // TODO internalionalize
+		if ( $this->m_diProperties  === [] ) { // TODO internalionalize
 			$this->addError( 'The list of properties to be used for the data fields has not been specified properly.' );
 		}
 

--- a/includes/datavalues/SMW_DV_Time.php
+++ b/includes/datavalues/SMW_DV_Time.php
@@ -228,7 +228,7 @@ class SMWTimeValue extends SMWDataValue {
 		//   011 component could be a day or a year but no month etc.
 		// For three components, we thus get a 10 digit bit vector.
 		$datevector = 1;
-		$propercomponents = array();
+		$propercomponents = [];
 		$justfounddash = true; // avoid two dashes in a row, or dashes at the end
 		$error = false;
 		$numvalue = 0;
@@ -260,13 +260,13 @@ class SMWTimeValue extends SMWDataValue {
 				$msgKey .= '-common';
 			}
 
-			$this->addErrorMsg( array( $msgKey, $this->m_wikivalue ) );
+			$this->addErrorMsg( [ $msgKey, $this->m_wikivalue ] );
 			return false;
 		}
 
 		// Now use the bitvector to find the preferred interpretation of the date components:
 		$dateformats = Localizer::getInstance()->getLang( $this->getOption( self::OPT_CONTENT_LANGUAGE ) )->getDateFormats();
-		$date = array( 'y' => false, 'm' => false, 'd' => false );
+		$date = [ 'y' => false, 'm' => false, 'd' => false ];
 
 		foreach ( $dateformats[count( $propercomponents ) - 1] as $formatvector ) {
 			if ( !( ~$datevector & $formatvector ) ) { // check if $formatvector => $datevector ("the input supports the format")
@@ -280,7 +280,7 @@ class SMWTimeValue extends SMWDataValue {
 		}
 
 		if ( $date['y'] === false ) { // no band matches the entered date
-			$this->addErrorMsg( array( 'smw-datavalue-time-invalid-date-components-sequence', $this->m_wikivalue ) );
+			$this->addErrorMsg( [ 'smw-datavalue-time-invalid-date-components-sequence', $this->m_wikivalue ] );
 			return false;
 		}
 
@@ -367,7 +367,7 @@ class SMWTimeValue extends SMWDataValue {
 		try {
 			$this->m_dataitem = new DITime( $calmod, $date['y'], $date['m'], $date['d'], $hours, $minutes, $seconds . '.' . $microseconds, $timezone );
 		} catch ( SMWDataItemException $e ) {
-			$this->addErrorMsg( array( 'smw-datavalue-time-invalid', $this->m_wikivalue, $e->getMessage() ) );
+			$this->addErrorMsg( [ 'smw-datavalue-time-invalid', $this->m_wikivalue, $e->getMessage() ] );
 			return false;
 		}
 
@@ -376,7 +376,7 @@ class SMWTimeValue extends SMWDataValue {
 		// conversion would not be reliable if JD numbers get too huge:
 		if ( ( $date['y'] <= self::PREHISTORY ) &&
 		     ( ( $this->m_dataitem->getPrecision() > DITime::PREC_Y ) || ( $calendarmodel !== false ) ) ) {
-			$this->addErrorMsg( array( 'smw-datavalue-time-invalid-prehistoric', $this->m_wikivalue ) );
+			$this->addErrorMsg( [ 'smw-datavalue-time-invalid-prehistoric', $this->m_wikivalue ] );
 			return false;
 		}
 
@@ -385,7 +385,7 @@ class SMWTimeValue extends SMWDataValue {
 			try {
 				$this->m_dataitem = DITime::newFromJD( $newjd, $calmod, $this->m_dataitem->getPrecision(), $timezone );
 			} catch ( SMWDataItemException $e ) {
-				$this->addErrorMsg( array( 'smw-datavalue-time-invalid-jd', $this->m_wikivalue, $e->getMessage() ) );
+				$this->addErrorMsg( [ 'smw-datavalue-time-invalid-jd', $this->m_wikivalue, $e->getMessage() ] );
 				return false;
 			}
 		}

--- a/includes/datavalues/SMW_DV_URI.php
+++ b/includes/datavalues/SMW_DV_URI.php
@@ -82,7 +82,7 @@ class SMWURIValue extends SMWDataValue {
 
 		$scheme = $hierpart = $query = $fragment = '';
 		if ( $value === '' ) { // do not accept empty strings
-			$this->addErrorMsg( array( 'smw_emptystring' ) );
+			$this->addErrorMsg( [ 'smw_emptystring' ] );
 			return;
 		}
 
@@ -109,7 +109,7 @@ class SMWURIValue extends SMWDataValue {
 				foreach ( $uri_blacklist as $uri ) {
 					$uri = trim( $uri );
 					if ( $uri !== '' && $uri == mb_substr( $value, 0, mb_strlen( $uri ) ) ) { // disallowed URI!
-						$this->addErrorMsg( array( 'smw_baduri', $value ) );
+						$this->addErrorMsg( [ 'smw_baduri', $value ] );
 						return;
 					}
 				}
@@ -117,7 +117,7 @@ class SMWURIValue extends SMWDataValue {
 				$scheme = $parts[0];
 
 				if ( !$this->getOption( self::OPT_QUERY_CONTEXT ) && !isset( $this->schemeList[$scheme] ) ) {
-					$this->addErrorMsg( array( 'smw-datavalue-uri-invalid-scheme', $scheme ) );
+					$this->addErrorMsg( [ 'smw-datavalue-uri-invalid-scheme', $scheme ] );
 					return;
 				}
 
@@ -135,9 +135,9 @@ class SMWURIValue extends SMWDataValue {
 				}
 				// We do not validate the URI characters (the data item will do this) but we do some escaping:
 				// encode most characters, but leave special symbols as given by user:
-				$hierpart = str_replace( array( '%3A', '%2F', '%23', '%40', '%3F', '%3D', '%26', '%25' ), array( ':', '/', '#', '@', '?', '=', '&', '%' ), rawurlencode( $hierpart ) );
-				$query = str_replace( array( '%3A', '%2F', '%23', '%40', '%3F', '%3D', '%26', '%25' ), array( ':', '/', '#', '@', '?', '=', '&', '%' ), rawurlencode( $query ) );
-				$fragment = str_replace( array( '%3A', '%2F', '%23', '%40', '%3F', '%3D', '%26', '%25' ), array( ':', '/', '#', '@', '?', '=', '&', '%' ), rawurlencode( $fragment ) );
+				$hierpart = str_replace( [ '%3A', '%2F', '%23', '%40', '%3F', '%3D', '%26', '%25' ], [ ':', '/', '#', '@', '?', '=', '&', '%' ], rawurlencode( $hierpart ) );
+				$query = str_replace( [ '%3A', '%2F', '%23', '%40', '%3F', '%3D', '%26', '%25' ], [ ':', '/', '#', '@', '?', '=', '&', '%' ], rawurlencode( $query ) );
+				$fragment = str_replace( [ '%3A', '%2F', '%23', '%40', '%3F', '%3D', '%26', '%25' ], [ ':', '/', '#', '@', '?', '=', '&', '%' ], rawurlencode( $fragment ) );
 				/// NOTE: we do not support raw [ (%5D) and ] (%5E), although they are needed for ldap:// (but rarely in a wiki)
 				/// NOTE: "+" gets encoded, as it is interpreted as space by most browsers when part of a URL;
 				///       this prevents tel: from working directly, but we have a datatype for this anyway.
@@ -164,7 +164,7 @@ class SMWURIValue extends SMWDataValue {
 				if ( !$this->getOption( self::OPT_QUERY_CONTEXT ) && ( ( strlen( preg_replace( '/[^0-9]/', '', $hierpart ) ) < 6 ) ||
 					( preg_match( '<[-+./][-./]>', $hierpart ) ) ||
 					( !self::isValidTelURI( 'tel:' . $hierpart ) ) ) ) { /// TODO: introduce error-message for "bad" phone number
-					$this->addErrorMsg( array( 'smw_baduri', $this->m_wikitext ) );
+					$this->addErrorMsg( [ 'smw_baduri', $this->m_wikitext ] );
 					return;
 				}
 				break;
@@ -177,17 +177,17 @@ class SMWURIValue extends SMWDataValue {
 
 				if ( !$this->getOption( self::OPT_QUERY_CONTEXT ) && !Sanitizer::validateEmail( $value ) ) {
 					/// TODO: introduce error-message for "bad" email
-					$this->addErrorMsg( array( 'smw_baduri', $value ) );
+					$this->addErrorMsg( [ 'smw_baduri', $value ] );
 					return;
 				}
-				$hierpart = str_replace( array( '%3A', '%2F', '%23', '%40', '%3F', '%3D', '%26', '%25' ), array( ':', '/', '#', '@', '?', '=', '&', '%' ), rawurlencode( $value ) );
+				$hierpart = str_replace( [ '%3A', '%2F', '%23', '%40', '%3F', '%3D', '%26', '%25' ], [ ':', '/', '#', '@', '?', '=', '&', '%' ], rawurlencode( $value ) );
 		}
 
 		// Now create the URI data item:
 		try {
 			$this->m_dataitem = new SMWDIUri( $scheme, $hierpart, $query, $fragment, !$this->getOption( self::OPT_QUERY_CONTEXT ) );
 		} catch ( SMWDataItemException $e ) {
-			$this->addErrorMsg( array( 'smw_baduri', $this->m_wikitext ) );
+			$this->addErrorMsg( [ 'smw_baduri', $this->m_wikitext ] );
 		}
 	}
 
@@ -305,7 +305,7 @@ class SMWURIValue extends SMWDataValue {
 		// Create links to mapping services based on a wiki-editable message. The parameters
 		// available to the message are:
 		// $1: urlencoded version of URI/URL value (includes mailto: for emails)
-		return array( rawurlencode( $this->getUriDataitem()->getURI() ) );
+		return [ rawurlencode( $this->getUriDataitem()->getURI() ) ];
 	}
 
 	/**
@@ -368,7 +368,7 @@ class SMWURIValue extends SMWDataValue {
 		// Allow the display without `_` so that URIs can be split
 		// during the outout by the browser without breaking the URL itself
 		// as it contains the `_` for spaces
-		return array( $this->getURL(), $context );
+		return [ $this->getURL(), $context ];
 	}
 
 }

--- a/includes/datavalues/SMW_DV_WikiPage.php
+++ b/includes/datavalues/SMW_DV_WikiPage.php
@@ -73,12 +73,12 @@ class SMWWikiPageValue extends SMWDataValue {
 	/**
 	 * @var array
 	 */
-	protected $linkAttributes = array();
+	protected $linkAttributes = [];
 
 	/**
 	 * @var array
 	 */
-	protected $queryParameters = array();
+	protected $queryParameters = [];
 
 	public function __construct( $typeid ) {
 		parent::__construct( $typeid );
@@ -118,7 +118,7 @@ class SMWWikiPageValue extends SMWDataValue {
 		}
 
 		if ( $value === '' && !$this->getOption( self::OPT_QUERY_CONTEXT ) ) {
-			$this->addErrorMsg( array( 'smw-datavalue-wikipage-empty' ), Message::ESCAPED );
+			$this->addErrorMsg( [ 'smw-datavalue-wikipage-empty' ], Message::ESCAPED );
 			return;
 		}
 
@@ -148,7 +148,7 @@ class SMWWikiPageValue extends SMWDataValue {
 
 		if ( $value[0] == '#' ) {
 			if ( is_null( $this->m_contextPage ) ) {
-				$this->addErrorMsg( array( 'smw-datavalue-wikipage-missing-fragment-context', $value ) );
+				$this->addErrorMsg( [ 'smw-datavalue-wikipage-missing-fragment-context', $value ] );
 				return;
 			} else {
 				$this->m_title = Title::makeTitle( $this->m_contextPage->getNamespace(),
@@ -161,12 +161,12 @@ class SMWWikiPageValue extends SMWDataValue {
 
 		/// TODO: Escape the text so users can see punctuation problems (bug 11666).
 		if ( $this->m_title === null && $this->getProperty() !== null ) {
-			$this->addErrorMsg( array( 'smw-datavalue-wikipage-property-invalid-title', $this->getProperty()->getLabel(), $value ) );
+			$this->addErrorMsg( [ 'smw-datavalue-wikipage-property-invalid-title', $this->getProperty()->getLabel(), $value ] );
 		} elseif ( $this->m_title === null ) {
-			$this->addErrorMsg( array( 'smw-datavalue-wikipage-invalid-title', $value ) );
+			$this->addErrorMsg( [ 'smw-datavalue-wikipage-invalid-title', $value ] );
 		} elseif ( ( $this->m_fixNamespace != NS_MAIN ) &&
 			 ( $this->m_fixNamespace != $this->m_title->getNamespace() ) ) {
-			$this->addErrorMsg( array( 'smw_wrong_namespace', $wgContLang->getNsText( $this->m_fixNamespace ) ) );
+			$this->addErrorMsg( [ 'smw_wrong_namespace', $wgContLang->getNsText( $this->m_fixNamespace ) ] );
 		} else {
 			$this->m_fragment = str_replace( ' ', '_', $this->m_title->getFragment() );
 			$this->m_prefixedtext = '';
@@ -197,15 +197,15 @@ class SMWWikiPageValue extends SMWDataValue {
 		$this->m_fragment = $dataItem->getSubobjectName();
 		$this->m_prefixedtext = '';
 		$this->m_caption = false; // this class can handle this
-		$this->linkAttributes = array();
+		$this->linkAttributes = [];
 
 		if ( ( $this->m_fixNamespace != NS_MAIN ) &&
 			( $this->m_fixNamespace != $dataItem->getNamespace() ) ) {
 				$this->addErrorMsg(
-					array(
+					[
 						'smw_wrong_namespace',
 						Localizer::getInstance()->getNamespaceTextById( $this->m_fixNamespace )
-					)
+					]
 				);
 		}
 
@@ -281,7 +281,7 @@ class SMWWikiPageValue extends SMWDataValue {
 			$this->linkAttributes['class'] = 'smw-subobject-entity';
 		}
 
-		if ( $this->linkAttributes !== array() ) {
+		if ( $this->linkAttributes !== [] ) {
 			$link = \Html::rawElement(
 				'span',
 				$this->linkAttributes,
@@ -363,7 +363,7 @@ class SMWWikiPageValue extends SMWDataValue {
 			$this->linkAttributes['class'] = 'smw-subobject-entity';
 		}
 
-		if ( $this->linkAttributes !== array() ) {
+		if ( $this->linkAttributes !== [] ) {
 			$link = \Html::rawElement(
 				'span',
 				$this->linkAttributes,
@@ -448,9 +448,9 @@ class SMWWikiPageValue extends SMWDataValue {
 	 */
 	protected function getServiceLinkParams() {
 		if ( $this->isValid() ) {
-			return array( rawurlencode( str_replace( '_', ' ', $this->m_dataitem->getDBkey() ) ) );
+			return [ rawurlencode( str_replace( '_', ' ', $this->m_dataitem->getDBkey() ) ) ];
 		} else {
-			return array();
+			return [];
 		}
 	}
 
@@ -472,10 +472,10 @@ class SMWWikiPageValue extends SMWDataValue {
 
 			if ( is_null( $this->m_title ) ) { // should not normally happen, but anyway ...
 				$this->addErrorMsg(
-					array(
+					[
 						'smw_notitle',
 						Localizer::getInstance()->getNamespaceTextById( $this->m_dataitem->getNamespace() ) . ':' . $this->m_dataitem->getDBkey()
-					)
+					]
 				);
 			}
 		}
@@ -696,7 +696,7 @@ class SMWWikiPageValue extends SMWDataValue {
 			new DIProperty( '_DTITLE' )
 		);
 
-		if ( $dataItems !== null && $dataItems !== array() ) {
+		if ( $dataItems !== null && $dataItems !== [] ) {
 			$displayTitle = end( $dataItems )->getString();
 		} elseif ( $subject->getSubobjectName() !== '' ) {
 			// Check whether the base subject has a DISPLAYTITLE

--- a/includes/datavalues/SMW_DataValue.php
+++ b/includes/datavalues/SMW_DataValue.php
@@ -136,7 +136,7 @@ abstract class SMWDataValue {
 	 * (PHP's count() is too slow when called often) by using $mHasErrors.
 	 * @var array
 	 */
-	private $mErrors = array();
+	private $mErrors = [];
 
 	/**
 	 * Boolean indicating if there where any errors.
@@ -200,7 +200,7 @@ abstract class SMWDataValue {
 	public function setUserValue( $value, $caption = false ) {
 
 		$this->m_dataitem = null;
-		$this->mErrors = array(); // clear errors
+		$this->mErrors = []; // clear errors
 		$this->mHasErrors = false;
 		$this->m_caption = is_string( $caption ) ? trim( $caption ) : false;
 		$this->userValue = $value;
@@ -221,7 +221,7 @@ abstract class SMWDataValue {
 		// just fails, even if parseUserValue() above might not have noticed this issue.
 		// Note: \x07 was used in MediaWiki 1.11.0, \x7f is used now (backwards compatibility, b/c)
 		if ( is_string( $value ) && ( ( strpos( $value, "\x7f" ) !== false ) || ( strpos( $value, "\x07" ) !== false ) ) ) {
-			$this->addErrorMsg( array( 'smw-datavalue-stripmarker-parse-error', $value ) );
+			$this->addErrorMsg( [ 'smw-datavalue-stripmarker-parse-error', $value ] );
 		}
 
 		if ( $this->isValid() && !$this->getOption( self::OPT_QUERY_CONTEXT ) ) {
@@ -245,7 +245,7 @@ abstract class SMWDataValue {
 	 */
 	public function setDataItem( SMWDataItem $dataItem ) {
 		$this->m_dataitem = null;
-		$this->mErrors = array();
+		$this->mErrors = [];
 		$this->mHasErrors = $this->m_caption = false;
 		return $this->loadDataItem( $dataItem );
 	}
@@ -441,7 +441,7 @@ abstract class SMWDataValue {
 	 * @since 2.4
 	 */
 	public function clearErrors() {
-		$this->mErrors = array();
+		$this->mErrors = [];
 		$this->mHasErrors = false;
 	}
 
@@ -725,7 +725,7 @@ abstract class SMWDataValue {
 	 * @return mixed
 	 * @throws RuntimeException
 	 */
-	public function getExtraneousFunctionFor( $name, array $parameters = array() ) {
+	public function getExtraneousFunctionFor( $name, array $parameters = [] ) {
 		return $this->dataValueServiceFactory->newExtraneousFunctionByName( $name, $parameters );
 	}
 

--- a/includes/export/SMW_Exp_Data.php
+++ b/includes/export/SMW_Exp_Data.php
@@ -41,13 +41,13 @@ class SMWExpData implements Element {
 	 * SMWExpElement objects.
 	 * @var array of array of SMWElement
 	 */
-	protected $m_children = array();
+	protected $m_children = [];
 
 	/**
 	 * Array mapping property URIs to arrays their SMWExpResource
 	 * @var array of SMWExpResource
 	 */
-	protected $m_edges = array();
+	protected $m_edges = [];
 
 	/**
 	 * @var string|null
@@ -83,7 +83,7 @@ class SMWExpData implements Element {
 			return $this->hash;
 		}
 
-		$hashes = array();
+		$hashes = [];
 		$hashes[] = $this->m_subject->getHash();
 
 		foreach ( $this->getProperties() as $property ) {
@@ -157,7 +157,7 @@ class SMWExpData implements Element {
 		$this->hash = null;
 
 		if ( !array_key_exists( $property->getUri(), $this->m_edges ) ) {
-			$this->m_children[$property->getUri()] = array();
+			$this->m_children[$property->getUri()] = [];
 			$this->m_edges[$property->getUri()] = $property;
 		}
 
@@ -186,7 +186,7 @@ class SMWExpData implements Element {
 			return $this->m_children[$property->getUri()];
 		}
 
-		return array();
+		return [];
 	}
 
 	/**
@@ -269,7 +269,7 @@ class SMWExpData implements Element {
 					}
 				} elseif ( ( $rest instanceof SMWExpResource ) &&
 				           ( $rest->getUri() == $rdfnilUri ) )  {
-					return array( $first );
+					return [ $first ];
 				} else {
 					return false;
 				}
@@ -277,7 +277,7 @@ class SMWExpData implements Element {
 				return false;
 			}
 		} elseif ( ( count( $this->m_children ) == 0 ) && ( $this->m_subject->getUri() == $rdfnilUri ) ) {
-			return array();
+			return [];
 		} else {
 			return false;
 		}
@@ -299,7 +299,7 @@ class SMWExpData implements Element {
 			$subject = $this->m_subject;
 		}
 
-		$result = array();
+		$result = [];
 
 		foreach ( $this->m_edges as $key => $edge ) {
 			foreach ( $this->m_children[$key] as $childElement ) {
@@ -315,7 +315,7 @@ class SMWExpData implements Element {
 					$childSubject = new SMWExpResource( '_' . $smwgBnodeCount++, $childSubject->getDataItem() );
 				}
 
-				$result[] = array( $subject, $edge, $childSubject );
+				$result[] = [ $subject, $edge, $childSubject ];
 				if ( $childElement instanceof SMWExpData ) { // recursively add child's triples
 					$result = array_merge( $result, $childElement->getTripleList( $childSubject ) );
 				}

--- a/includes/export/SMW_ExportController.php
+++ b/includes/export/SMW_ExportController.php
@@ -104,8 +104,8 @@ class SMWExportController {
 	 */
 	protected function prepareSerialization( $outfilename = '' ) {
 		$this->serializer->clear();
-		$this->element_queue = array();
-		$this->element_done = array();
+		$this->element_queue = [];
+		$this->element_done = [];
 		if ( $outfilename !== '' ) {
 			$this->outputfile = fopen( $outfilename, 'w' );
 			if ( !$this->outputfile ) { // TODO Rather throw an exception here.
@@ -393,10 +393,10 @@ class SMWExportController {
 			return $semData;
 		}
 
-		$semdata = \SMW\StoreFactory::getStore()->getSemanticData( $diWikiPage, $core_props_only ? array( '__spu', '__typ', '__imp' ) : false ); // advise store to retrieve only core things
+		$semdata = \SMW\StoreFactory::getStore()->getSemanticData( $diWikiPage, $core_props_only ? [ '__spu', '__typ', '__imp' ] : false ); // advise store to retrieve only core things
 		if ( $core_props_only ) { // be sure to filter all non-relevant things that may still be present in the retrieved
 			$result = new SMWSemanticData( $diWikiPage );
-			foreach ( array( '_URI', '_TYPE', '_IMPO' ) as $propid ) {
+			foreach ( [ '_URI', '_TYPE', '_IMPO' ] as $propid ) {
 				$prop = new SMW\DIProperty( $propid );
 				$values = $semdata->getPropertyValues( $prop );
 				foreach ( $values as $dv ) {
@@ -616,7 +616,7 @@ class SMWExportController {
 		}
 		$res = $db->select( $db->tableName( 'page' ),
 		                    'page_id,page_title,page_namespace', $query,
-		                    'SMW::RDF::PrintPageList', array( 'ORDER BY' => 'page_id ASC', 'OFFSET' => $offset, 'LIMIT' => $limit ) );
+		                    'SMW::RDF::PrintPageList', [ 'ORDER BY' => 'page_id ASC', 'OFFSET' => $offset, 'LIMIT' => $limit ] );
 		$foundpages = false;
 
 		foreach ( $res as $row ) {

--- a/includes/export/SMW_Exporter.php
+++ b/includes/export/SMW_Exporter.php
@@ -528,9 +528,9 @@ class SMWExporter {
 	 */
 	static public function expandURI( $uri ) {
 		self::initBaseURIs();
-		$uri = str_replace( array( '&wiki;', '&wikiurl;', '&property;', '&category;', '&owl;', '&rdf;', '&rdfs;', '&swivt;', '&export;' ),
-		                    array( self::$m_ent_wiki, self::$m_ent_wikiurl, self::$m_ent_property, self::$m_ent_category, 'http://www.w3.org/2002/07/owl#', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#', 'http://www.w3.org/2000/01/rdf-schema#', 'http://semantic-mediawiki.org/swivt/1.0#',
-		                    self::$m_exporturl ),
+		$uri = str_replace( [ '&wiki;', '&wikiurl;', '&property;', '&category;', '&owl;', '&rdf;', '&rdfs;', '&swivt;', '&export;' ],
+		                    [ self::$m_ent_wiki, self::$m_ent_wikiurl, self::$m_ent_property, self::$m_ent_category, 'http://www.w3.org/2002/07/owl#', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#', 'http://www.w3.org/2000/01/rdf-schema#', 'http://semantic-mediawiki.org/swivt/1.0#',
+		                    self::$m_exporturl ],
 		                    $uri );
 		return $uri;
 	}

--- a/includes/export/SMW_Serializer.php
+++ b/includes/export/SMW_Serializer.php
@@ -95,10 +95,10 @@ abstract class SMWSerializer {
 	public function clear() {
 		$this->pre_ns_buffer = '';
 		$this->post_ns_buffer = '';
-		$this->decl_todo = array();
-		$this->decl_done = array();
-		$this->global_namespaces = array();
-		$this->extra_namespaces = array();
+		$this->decl_todo = [];
+		$this->decl_done = [];
+		$this->global_namespaces = [];
+		$this->extra_namespaces = [];
 	}
 
 	/**
@@ -139,7 +139,7 @@ abstract class SMWSerializer {
 	 */
 	public function serializeDeclarations() {
 		foreach ( $this->decl_todo as $name => $flag ) {
-			$types = array();
+			$types = [];
 			if ( $flag & SMW_SERIALIZER_DECL_CLASS ) {
 				$types[] = 'owl:Class';
 			}
@@ -155,7 +155,7 @@ abstract class SMWSerializer {
 			$curdone = array_key_exists( $name, $this->decl_done ) ? $this->decl_done[$name] : 0;
 			$this->decl_done[$name] = $curdone | $flag;
 		}
-		$this->decl_todo = array(); // reset all
+		$this->decl_todo = []; // reset all
 	}
 
 	/**
@@ -200,7 +200,7 @@ abstract class SMWSerializer {
 		foreach ( $this->extra_namespaces as $nsshort => $nsuri ) {
 			$this->serializeNamespace( $nsshort, $nsuri );
 		}
-		$this->extra_namespaces = array();
+		$this->extra_namespaces = [];
 	}
 
 	/**

--- a/includes/export/SMW_Serializer_RDFXML.php
+++ b/includes/export/SMW_Serializer_RDFXML.php
@@ -63,7 +63,7 @@ class SMWRDFXMLSerializer extends SMWSerializer {
 			"\txmlns:wiki=\"&wiki;\"\n" .
 			"\txmlns:category=\"&category;\"\n" .
 			"\txmlns:property=\"&property;\"";
-		$this->global_namespaces = array( 'rdf' => true, 'rdfs' => true, 'owl' => true, 'swivt' => true, 'wiki' => true, 'property' => true, 'category' => true );
+		$this->global_namespaces = [ 'rdf' => true, 'rdfs' => true, 'owl' => true, 'swivt' => true, 'wiki' => true, 'property' => true, 'category' => true ];
 		$this->post_ns_buffer .= ">\n\n";
 	}
 
@@ -271,7 +271,7 @@ class SMWRDFXMLSerializer extends SMWSerializer {
 	 * @return string
 	 */
 	protected function makeAttributeValueString( $string ) {
-		return str_replace( array( '&', '>', '<' ), array( '&amp;', '&gt;', '&lt;' ), $string );
+		return str_replace( [ '&', '>', '<' ], [ '&amp;', '&gt;', '&lt;' ], $string );
 	}
 
 }

--- a/includes/export/SMW_Serializer_Turtle.php
+++ b/includes/export/SMW_Serializer_Turtle.php
@@ -49,7 +49,7 @@ class SMWTurtleSerializer extends SMWSerializer {
 
 	public function clear() {
 		parent::clear();
-		$this->sparql_namespaces = array();
+		$this->sparql_namespaces = [];
 	}
 
 	/**
@@ -69,14 +69,14 @@ class SMWTurtleSerializer extends SMWSerializer {
 	 */
 	public function flushSparqlPrefixes() {
 		$result = $this->sparql_namespaces;
-		$this->sparql_namespaces = array();
+		$this->sparql_namespaces = [];
 		return $result;
 	}
 
 	protected function serializeHeader() {
 		if ( $this->sparqlmode ) {
 			$this->pre_ns_buffer = '';
-			$this->sparql_namespaces = array(
+			$this->sparql_namespaces = [
 				"rdf" => SMWExporter::getInstance()->expandURI( '&rdf;' ),
 				"rdfs" => SMWExporter::getInstance()->expandURI( '&rdfs;' ),
 				"owl" => SMWExporter::getInstance()->expandURI( '&owl;' ),
@@ -86,7 +86,7 @@ class SMWTurtleSerializer extends SMWSerializer {
 				"property" => SMWExporter::getInstance()->expandURI( '&property;' ),
 				"xsd" => "http://www.w3.org/2001/XMLSchema#" ,
 				"wikiurl" => SMWExporter::getInstance()->expandURI( '&wikiurl;' )
-			);
+			];
 		} else {
 			$this->pre_ns_buffer =
 			"@prefix rdf: <" . SMWExporter::getInstance()->expandURI( '&rdf;' ) . "> .\n" .
@@ -101,7 +101,7 @@ class SMWTurtleSerializer extends SMWSerializer {
 			"@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .\n" . // note that this XSD URI is hardcoded below (its unlikely to change, of course)
 			"@prefix wikiurl: <" . SMWExporter::getInstance()->expandURI( '&wikiurl;' ) . "> .\n";
 		}
-		$this->global_namespaces = array( 'rdf' => true, 'rdfs' => true, 'owl' => true, 'swivt' => true, 'wiki' => true, 'property' => true, 'category' => true );
+		$this->global_namespaces = [ 'rdf' => true, 'rdfs' => true, 'owl' => true, 'swivt' => true, 'wiki' => true, 'property' => true, 'category' => true ];
 		$this->post_ns_buffer = "\n";
 	}
 
@@ -117,7 +117,7 @@ class SMWTurtleSerializer extends SMWSerializer {
 
 	public function serializeExpData( SMWExpData $expData ) {
 
-		$this->subExpData = array( $expData );
+		$this->subExpData = [ $expData ];
 
 		while ( count( $this->subExpData ) > 0 ) {
 			$this->serializeNestedExpData( array_pop( $this->subExpData ), '' );
@@ -278,7 +278,7 @@ class SMWTurtleSerializer extends SMWSerializer {
 
 	private static function getCorrectLexicalForm( $expElement ) {
 
-		$lexicalForm = str_replace( array( '\\', "\n", '"' ), array( '\\\\', "\\n", '\"' ), $expElement->getLexicalForm() );
+		$lexicalForm = str_replace( [ '\\', "\n", '"' ], [ '\\\\', "\\n", '\"' ], $expElement->getLexicalForm() );
 
 		if ( $expElement->getLang() !== '' && ( $expElement->getDatatype() === 'http://www.w3.org/1999/02/22-rdf-syntax-ns#langString' ) ) {
 			$lexicalForm = '"' . $lexicalForm . '@' . $expElement->getLang() . '"';

--- a/includes/formatters/MessageFormatter.php
+++ b/includes/formatters/MessageFormatter.php
@@ -27,7 +27,7 @@ use Language;
 class MessageFormatter {
 
 	/** @var array */
-	protected $messages = array();
+	protected $messages = [];
 
 	/** @var string */
 	protected $type = 'warning';
@@ -63,7 +63,7 @@ class MessageFormatter {
 	 *
 	 * @return MessageFormatter
 	 */
-	public static function newFromArray( Language $language, array $messages = array () ) {
+	public static function newFromArray( Language $language, array $messages =  [] ) {
 		$instance = new self( $language );
 		return $instance->addFromArray( $messages );
 	}
@@ -80,7 +80,7 @@ class MessageFormatter {
 	public function addFromKey( $key /*...*/ ) {
 		$params = func_get_args();
 		array_shift( $params );
-		$this->addFromArray( array( new \Message( $key, $params ) ) );
+		$this->addFromArray( [ new \Message( $key, $params ) ] );
 		return $this;
 	}
 
@@ -167,7 +167,7 @@ class MessageFormatter {
 	 * @return MessageFormatter
 	 */
 	public function clear() {
-		$this->messages = array();
+		$this->messages = [];
 		return $this;
 	}
 
@@ -179,7 +179,7 @@ class MessageFormatter {
 	 * @return boolean
 	 */
 	public function exists() {
-		return $this->messages !== array();
+		return $this->messages !== [];
 	}
 
 	/**
@@ -211,7 +211,7 @@ class MessageFormatter {
 	 * @return array
 	 */
 	protected function doFormat( array $messages ) {
-		$newArray = array();
+		$newArray = [];
 
 		foreach ( $messages as $msg ) {
 
@@ -252,11 +252,11 @@ class MessageFormatter {
 			$messageString = $messages[0];
 		} else {
 			foreach ( $messages as &$message ) {
-				$message = $html ? Html::rawElement( 'li', array(), $message ) : $message;
+				$message = $html ? Html::rawElement( 'li', [], $message ) : $message;
 			}
 
 			$messageString = implode( $this->separator, $messages );
-			$messageString = $html ? Html::rawElement( 'ul', array(), $messageString ) : $messageString;
+			$messageString = $html ? Html::rawElement( 'ul', [], $messageString ) : $messageString;
 		}
 
 		return $messageString;
@@ -274,7 +274,7 @@ class MessageFormatter {
 		if ( $this->exists() ) {
 
 			$highlighter = Highlighter::factory( $this->type );
-			$highlighter->setContent( array( 'content' => $this->getString( true ) ) );
+			$highlighter->setContent( [ 'content' => $this->getString( true ) ] );
 
 			return $highlighter->getHtml();
 		}

--- a/includes/params/SMW_ParamFormat.php
+++ b/includes/params/SMW_ParamFormat.php
@@ -27,7 +27,7 @@ class SMWParamFormat extends StringParam {
 	 *
 	 * @var PrintRequest[]
 	 */
-	protected $printRequests = array();
+	protected $printRequests = [];
 
 	protected $showMode = false;
 

--- a/includes/query/SMW_Query.php
+++ b/includes/query/SMW_Query.php
@@ -80,13 +80,13 @@ class SMWQuery implements QueryContext {
 	const SCORE_SORT = 'score.sort';
 
 	public $sort = false;
-	public $sortkeys = array(); // format: "Property key" => "ASC" / "DESC" (note: order of entries also matters)
+	public $sortkeys = []; // format: "Property key" => "ASC" / "DESC" (note: order of entries also matters)
 	public $querymode = self::MODE_INSTANCES;
 
 	private $limit;
 	private $offset = 0;
 	private $description;
-	private $errors = array(); // keep any errors that occurred so far
+	private $errors = []; // keep any errors that occurred so far
 	private $queryString = false; // string (inline query) version (if fixed and known)
 	private $isInline; // query used inline? (required for finding right default parameters)
 	private $isUsedInConcept; // query used in concept? (required for finding right default parameters)
@@ -94,7 +94,7 @@ class SMWQuery implements QueryContext {
 	/**
 	 * @var PrintRequest[]
 	 */
-	private $m_extraprintouts = array(); // SMWPrintoutRequest objects supplied outside querystring
+	private $m_extraprintouts = []; // SMWPrintoutRequest objects supplied outside querystring
 	private $m_mainlabel = ''; // Since 1.6
 
 	/**
@@ -117,7 +117,7 @@ class SMWQuery implements QueryContext {
 	/**
 	 * @var array
 	 */
-	private $options = array();
+	private $options = [];
 
 	/**
 	 * @since 1.6
@@ -432,15 +432,15 @@ class SMWQuery implements QueryContext {
 				$maxdepth = $smwgQMaxDepth;
 			}
 
-			$log = array();
+			$log = [];
 			$this->description = $this->description->prune( $maxsize, $maxdepth, $log );
 
 			if ( count( $log ) > 0 ) {
-				$this->errors[] = Message::encode( array(
+				$this->errors[] = Message::encode( [
 					'smw_querytoolarge',
 					str_replace( '[', '&#91;', implode( ', ', $log ) ),
 					count( $log )
-				) );
+				] );
 			}
 		}
 	}
@@ -459,20 +459,20 @@ class SMWQuery implements QueryContext {
 	 * @return array
 	 */
 	public function toArray() {
-		$serialized = array();
+		$serialized = [];
 
 		$serialized['conditions'] = $this->getQueryString();
 
 		// This can be extended but for the current use cases that is
 		// sufficient since most printer related parameters have to be sourced
 		// in the result printer class
-		$serialized['parameters'] = array(
+		$serialized['parameters'] = [
 				'limit'     => $this->limit,
 				'offset'    => $this->offset,
 				'sortkeys'  => $this->sortkeys,
 				'mainlabel' => $this->m_mainlabel,
 				'querymode' => $this->querymode
-		);
+		];
 
 		// @2.4 Keep the queryID stable with previous versions unless
 		// a query source is selected. The "same" query executed on different
@@ -533,19 +533,19 @@ class SMWQuery implements QueryContext {
 
 	private function createFromFingerprint( $fingerprint ) {
 
-		$serialized = array();
+		$serialized = [];
 
 		// Don't use the QueryString, use the canonized fingerprint to ensure that
 		// [[Foo::123]][[Bar::abc]] returns the same ID as [[Bar::abc]][[Foo::123]]
 		// given that limit, offset, and sort/order are the same
 		$serialized['fingerprint'] = $fingerprint;
 
-		$serialized['parameters'] = array(
+		$serialized['parameters'] = [
 			'limit'     => $this->limit,
 			'offset'    => $this->offset,
 			'sortkeys'  => $this->sortkeys,
 			'querymode' => $this->querymode // COUNT, DEBUG ...
-		);
+		];
 
 		// Make to sure to distinguish queries and results from a foreign repository
 		if ( $this->querySource !== null && $this->querySource !== '' ) {

--- a/includes/query/SMW_QueryProcessor.php
+++ b/includes/query/SMW_QueryProcessor.php
@@ -95,7 +95,7 @@ class SMWQueryProcessor implements QueryContext {
 	 *
 	 * @return SMWQuery
 	 */
-	static public function createQuery( $queryString, array $params, $context = self::INLINE_QUERY, $format = '', array $extraPrintouts = array(), $contextPage = null ) {
+	static public function createQuery( $queryString, array $params, $context = self::INLINE_QUERY, $format = '', array $extraPrintouts = [], $contextPage = null ) {
 
 		if ( $format === '' || is_null( $format ) ) {
 			$format = $params['format']->getValue();
@@ -272,7 +272,7 @@ class SMWQueryProcessor implements QueryContext {
 			$query->setOption( Deferred::CONTROL_ELEMENT, isset( $params['@control'] ) ? $params['@control']->getValue() : '' );
 		}
 
-		return array( $query, $params );
+		return [ $query, $params ];
 	}
 
 	/**
@@ -505,7 +505,7 @@ class SMWQueryProcessor implements QueryContext {
 	 *
 	 * @return Processor
 	 */
-	private static function getValidatorForParams( array $params, array $printRequests = array(), $unknownInvalid = true, $context = null, $showMode = false ) {
+	private static function getValidatorForParams( array $params, array $printRequests = [], $unknownInvalid = true, $context = null, $showMode = false ) {
 		$paramDefinitions = self::getParameters( $context );
 
 		$paramDefinitions['format']->setPrintRequests( $printRequests );

--- a/includes/querypages/PropertiesQueryPage.php
+++ b/includes/querypages/PropertiesQueryPage.php
@@ -66,12 +66,12 @@ class PropertiesQueryPage extends QueryPage {
 	function getPageHeader() {
 		return Html::rawElement(
 			'p',
-			array( 'class' => 'smw-sp-properties-docu' ),
+			[ 'class' => 'smw-sp-properties-docu' ],
 			$this->msg( 'smw-sp-properties-docu' )->parse()
 		) . $this->getSearchForm( $this->getRequest()->getVal( 'property' ), $this->getCacheInfo() ) .
 		Html::element(
 			'h2',
-			array(),
+			[],
 			$this->msg( 'smw-sp-properties-header-label' )->text()
 		);
 	}
@@ -104,7 +104,7 @@ class PropertiesQueryPage extends QueryPage {
 		} elseif ( $dataItem instanceof SMWDIError ) {
 			return $this->getMessageFormatter()->clear()
 				->setType( 'warning' )
-				->addFromArray( array( $dataItem->getErrors(), 'ID: ' . ( isset( $dataItem->id ) ? $dataItem->id : 'N/A' ) ) )
+				->addFromArray( [ $dataItem->getErrors(), 'ID: ' . ( isset( $dataItem->id ) ? $dataItem->id : 'N/A' ) ] )
 				->getHtml();
 		}
 
@@ -140,7 +140,7 @@ class PropertiesQueryPage extends QueryPage {
 				$typestring = '';
 				$proplink = $property->getLabel();
 				$this->getMessageFormatter()
-					->addFromArray( array( 'ID: ' . ( isset( $property->id ) ? $property->id : 'N/A' ) ) )
+					->addFromArray( [ 'ID: ' . ( isset( $property->id ) ? $property->id : 'N/A' ) ] )
 					->addFromKey( 'smw_notitle', $proplink );
 			} else {
 				list( $typestring, $proplink ) = $this->getUserDefinedPropertyInfo( $title, $property, $useCount );
@@ -202,7 +202,7 @@ class PropertiesQueryPage extends QueryPage {
 		$typestring = SMWTypesValue::newFromTypeId( $this->settings->get( 'smwgPDefaultType' ) )->getLongHTMLText( $this->getLinker() );
 
 		$label = htmlspecialchars( $property->getLabel() );
-		$linkAttributes = array();
+		$linkAttributes = [];
 
 		if ( isset( $property->id ) ) {
 			$linkAttributes['title'] = 'ID: ' . $property->id;
@@ -230,7 +230,7 @@ class PropertiesQueryPage extends QueryPage {
 			$this->getMessageFormatter()->addFromKey( 'smw_propertylackstype', $typestring );
 		}
 
-		return array( $typestring, $proplink );
+		return [ $typestring, $proplink ];
 	}
 
 	/**
@@ -246,19 +246,19 @@ class PropertiesQueryPage extends QueryPage {
 
 		$dataValue = DataValueFactory::getInstance()->newDataValueByItem( $property, null );
 
-		$dataValue->setLinkAttributes( array(
+		$dataValue->setLinkAttributes( [
 			'title' => 'ID: ' . ( isset( $property->id ) ? $property->id : 'N/A' ) . ' (' . $property->getKey() . ')'
-		) );
+		] );
 
 		$label = $dataValue->getFormattedLabel(
 			DataValueFormatter::HTML_SHORT,
 			$this->getLinker()
 		);
 
-		return array(
+		return [
 			SMWTypesValue::newFromTypeId( $property->findPropertyTypeID() )->getLongHTMLText( $this->getLinker() ),
 			$label
-		);
+		];
 	}
 
 	/**

--- a/includes/querypages/QueryPage.php
+++ b/includes/querypages/QueryPage.php
@@ -35,7 +35,7 @@ abstract class QueryPage extends \QueryPage {
 	protected $linker = null;
 
 	/** @var array */
-	protected $selectOptions = array();
+	protected $selectOptions = [];
 
 	/** @var array */
 	protected $useSerchForm = false;
@@ -70,7 +70,7 @@ abstract class QueryPage extends \QueryPage {
 	 */
 	public function linkParameters() {
 
-		$parameters = array();
+		$parameters = [];
 		$property   = $this->getRequest()->getVal( 'property' );
 
 		if ( $property !== null && $property !== '' ) {
@@ -145,27 +145,27 @@ abstract class QueryPage extends \QueryPage {
 		);
 
 		if ( $cacheDate !== '' ) {
-			$cacheDate = Xml::tags( 'p', array(), $cacheDate );
+			$cacheDate = Xml::tags( 'p', [], $cacheDate );
 		}
 
 		if ( $propertySearch ) {
-			$propertySearch = Xml::tags( 'hr', array( 'style' => 'margin-bottom:10px;' ), '' ) .
+			$propertySearch = Xml::tags( 'hr', [ 'style' => 'margin-bottom:10px;' ], '' ) .
 				Xml::inputLabel( $this->msg( 'smw-special-property-searchform' )->text(), 'property', 'smw-property-input', 20, $property ) . ' ' .
 				Xml::submitButton( $this->msg( 'allpagessubmit' )->text() );
 		}
 
 		if ( $filter !== '' ) {
-			$filter = Xml::tags( 'hr', array( 'style' => 'margin-bottom:10px;' ), '' ) . $filter;
+			$filter = Xml::tags( 'hr', [ 'style' => 'margin-bottom:10px;' ], '' ) . $filter;
 		}
 
-		return Xml::tags( 'form', array(
+		return Xml::tags( 'form', [
 			'method' => 'get',
 			'action' => htmlspecialchars( $GLOBALS['wgScript'] ),
 			'class' => 'plainlinks'
-		), Html::hidden( 'title', $this->getContext()->getTitle()->getPrefixedText() ) .
+		], Html::hidden( 'title', $this->getContext()->getTitle()->getPrefixedText() ) .
 			Xml::fieldset( $this->msg( 'smw-special-property-searchform-options' )->text(),
-				Xml::tags( 'p', array(), $resultCount ) .
-				Xml::tags( 'p', array(), $selection ) .
+				Xml::tags( 'p', [], $resultCount ) .
+				Xml::tags( 'p', [], $selection ) .
 				$cacheDate .
 				$propertySearch .
 				$filter
@@ -206,12 +206,12 @@ abstract class QueryPage extends \QueryPage {
 		// often disable 'next' link when we reach the end
 		$atend = $num < $limit;
 
-		$this->selectOptions = array(
+		$this->selectOptions = [
 			'offset' => $offset,
 			'limit'  => $limit,
 			'end'    => $atend,
 			'count'  => $num
-		);
+		];
 
 		$out->addHTML( $this->getPageHeader() );
 
@@ -222,7 +222,7 @@ abstract class QueryPage extends \QueryPage {
 		}
 
 		if ( $num > 0 ) {
-			$s = array();
+			$s = [];
 			if ( ! $this->listoutput ) {
 				$s[] = $this->openList( $offset );
 			}

--- a/includes/querypages/UnusedPropertiesQueryPage.php
+++ b/includes/querypages/UnusedPropertiesQueryPage.php
@@ -91,12 +91,12 @@ class UnusedPropertiesQueryPage extends QueryPage {
 
 		return Html::rawElement(
 			'p',
-			array( 'class' => 'smw-unusedproperties-docu' ),
+			[ 'class' => 'smw-unusedproperties-docu' ],
 			$this->msg( 'smw-unusedproperties-docu' )->parse()
 		) . $this->getSearchForm( $this->getRequest()->getVal( 'property' ), $this->getCacheInfo() ) .
 		Html::element(
 			'h2',
-			array(),
+			[],
 			$this->msg( 'smw-sp-properties-header-label' )->text()
 		);
 	}
@@ -119,7 +119,7 @@ class UnusedPropertiesQueryPage extends QueryPage {
 		} elseif ( $result instanceof SMWDIError ) {
 			return $this->getMessageFormatter()->clear()
 				->setType( 'warning' )
-				->addFromArray( array( $result->getErrors() ) )
+				->addFromArray( [ $result->getErrors() ] )
 				->getHtml();
 		}
 

--- a/includes/querypages/WantedPropertiesQueryPage.php
+++ b/includes/querypages/WantedPropertiesQueryPage.php
@@ -130,12 +130,12 @@ class WantedPropertiesQueryPage extends QueryPage {
 
 		return Html::rawElement(
 			'p',
-			array( 'class' => 'smw-wantedproperties-docu plainlinks' ),
+			[ 'class' => 'smw-wantedproperties-docu plainlinks' ],
 			$this->msg( 'smw-special-wantedproperties-docu' )->parse()
 		) . $this->getSearchForm( $this->getRequest()->getVal( 'property' ), $this->getCacheInfo(), false, $filter )  .
 		Html::element(
 			'h2',
-			array(),
+			[],
 			$this->msg( 'smw-sp-properties-header-label' )->text()
 		);
 	}
@@ -165,7 +165,7 @@ class WantedPropertiesQueryPage extends QueryPage {
 			$title,
 			htmlspecialchars( $result[0]->getLabel() ),
 			[],
-			array( 'action' => 'view' )
+			[ 'action' => 'view' ]
 		);
 
 		return $this->msg( 'smw-special-wantedproperties-template' )

--- a/includes/queryprinters/AggregatablePrinter.php
+++ b/includes/queryprinters/AggregatablePrinter.php
@@ -60,10 +60,10 @@ abstract class AggregatablePrinter extends ResultPrinter {
 	protected function getResultText( SMWQueryResult $queryResult, $outputMode ) {
 		$data = $this->getResults( $queryResult, $outputMode );
 
-		if ( $data === array() ) {
-			$queryResult->addErrors( array(
+		if ( $data === [] ) {
+			$queryResult->addErrors( [
 				$this->msg( 'smw-qp-empty-data' )->inContentLanguage()->text()
-			) );
+			] );
 			return '';
 		} else {
 			$this->applyDistributionParams( $data );
@@ -125,7 +125,7 @@ abstract class AggregatablePrinter extends ResultPrinter {
 	 * @return array label => value
 	 */
 	protected function getDistributionResults( SMWQueryResult $result, $outputMode ) {
-		$values = array();
+		$values = [];
 
 		while ( /* array of SMWResultArray */ $row = $result->getNext() ) { // Objects (pages)
 			for ( $i = 0, $n = count( $row ); $i < $n; $i++ ) { // SMWResultArray for a sinlge property
@@ -162,7 +162,7 @@ abstract class AggregatablePrinter extends ResultPrinter {
 	 * @return array label => value
 	 */
 	protected function getNumericResults( SMWQueryResult $res, $outputMode ) {
-		$values = array();
+		$values = [];
 
 		// print all result rows
 		while ( $subject = $res->getNext() ) {
@@ -244,35 +244,35 @@ abstract class AggregatablePrinter extends ResultPrinter {
 	public function getParamDefinitions( array $definitions ) {
 		$definitions = parent::getParamDefinitions( $definitions );
 
-		$definitions['distribution'] = array(
+		$definitions['distribution'] = [
 			'name' => 'distribution',
 			'type' => 'boolean',
 			'default' => false,
 			'message' => 'smw-paramdesc-distribution',
-		);
+		];
 
-		$definitions['distributionsort'] = array(
+		$definitions['distributionsort'] = [
 			'name' => 'distributionsort',
 			'type' => 'string',
 			'default' => 'none',
 			'message' => 'smw-paramdesc-distributionsort',
-			'values' => array( 'asc', 'desc', 'none' ),
-		);
+			'values' => [ 'asc', 'desc', 'none' ],
+		];
 
-		$definitions['distributionlimit'] = array(
+		$definitions['distributionlimit'] = [
 			'name' => 'distributionlimit',
 			'type' => 'integer',
 			'default' => false,
 			'manipulatedefault' => false,
 			'message' => 'smw-paramdesc-distributionlimit',
 			'lowerbound' => 1,
-		);
+		];
 
-		$definitions['aggregation'] = array(
+		$definitions['aggregation'] = [
 			'message' => 'smw-paramdesc-aggregation',
 			'default' => 'subject',
-			'values' => array( 'property', 'subject' ),
-		);
+			'values' => [ 'property', 'subject' ],
+		];
 
 		return $definitions;
 	}

--- a/includes/queryprinters/DsvResultPrinter.php
+++ b/includes/queryprinters/DsvResultPrinter.php
@@ -86,10 +86,10 @@ class DsvResultPrinter extends FileExportPrinter {
 	 * @return string
 	 */
 	protected function getResultFileContents( SMWQueryResult $queryResult ) {
-		$lines = array();
+		$lines = [];
 
 		if ( $this->mShowHeaders ) {
-			$headerItems = array();
+			$headerItems = [];
 
 			foreach ( $queryResult->getPrintRequests() as $printRequest ) {
 				$headerItems[] = $printRequest->getLabel();
@@ -100,14 +100,14 @@ class DsvResultPrinter extends FileExportPrinter {
 
 		// Loop over the result objects (pages).
 		while ( $row = $queryResult->getNext() ) {
-			$rowItems = array();
+			$rowItems = [];
 
 			/**
 			 * Loop over their fields (properties).
 			 * @var SMWResultArray $field
 			 */
 			foreach ( $row as $field ) {
-				$itemSegments = array();
+				$itemSegments = [];
 
 				// Loop over all values for the property.
 				while ( ( $object = $field->getNextDataValue() ) !== false ) {
@@ -134,7 +134,7 @@ class DsvResultPrinter extends FileExportPrinter {
 	 * @return string
 	 */
 	protected function getDSVLine( array $fields ) {
-		return implode( $this->separator, array_map( array( $this, 'encodeDSV' ), $fields ) );
+		return implode( $this->separator, array_map( [ $this, 'encodeDSV' ], $fields ) );
 	}
 
 	/**
@@ -153,8 +153,8 @@ class DsvResultPrinter extends FileExportPrinter {
 		// \dnnn for the character with decimal value nnn
 		// \unnnn for a hexadecimal Unicode literal.
 		return str_replace(
-			array( '\n', '\r', '\t', '\b', '\f', '\\', $this->separator ),
-			array( "\n", "\r", "\t", "\b", "\f", '\\\\', "\\$this->separator" ),
+			[ '\n', '\r', '\t', '\b', '\f', '\\', $this->separator ],
+			[ "\n", "\r", "\t", "\b", "\f", '\\\\', "\\$this->separator" ],
 			$value
 		);
 	}
@@ -191,18 +191,18 @@ class DsvResultPrinter extends FileExportPrinter {
 
 		$params['limit']->setDefault( 100 );
 
-		$params[] = array(
+		$params[] = [
 			'name' => 'separator',
 			'message' => 'smw-paramdesc-dsv-separator',
 			'default' => $this->separator,
 			'aliases' => 'sep',
-		);
+		];
 
-		$params[] = array(
+		$params[] = [
 			'name' => 'filename',
 			'message' => 'smw-paramdesc-dsv-filename',
 			'default' => $this->fileName,
-		);
+		];
 
 		return $params;
 	}

--- a/includes/queryprinters/JsonResultPrinter.php
+++ b/includes/queryprinters/JsonResultPrinter.php
@@ -130,23 +130,23 @@ class JsonResultPrinter extends FileExportPrinter {
 
 		$params['limit']->setDefault( 100 );
 
-		$params['type'] = array(
-			'values' => array( 'simple', 'full' ),
+		$params['type'] = [
+			'values' => [ 'simple', 'full' ],
 			'default' => 'full',
 			'message' => 'smw-paramdesc-json-type',
-		);
+		];
 
-		$params['prettyprint'] = array(
+		$params['prettyprint'] = [
 			'type' => 'boolean',
 			'default' => '',
 			'message' => 'smw-paramdesc-prettyprint',
-		);
+		];
 
-		$params['unescape'] = array(
+		$params['unescape'] = [
 			'type' => 'boolean',
 			'default' => '',
 			'message' => 'smw-paramdesc-json-unescape',
-		);
+		];
 
 		return $params;
 	}

--- a/includes/queryprinters/RawResultPrinter.php
+++ b/includes/queryprinters/RawResultPrinter.php
@@ -57,10 +57,10 @@ abstract class RawResultPrinter extends ResultPrinter {
 
 		return Html::rawElement(
 			'div',
-			array( 'class' => 'smw-spinner left mw-small-spinner' ),
+			[ 'class' => 'smw-spinner left mw-small-spinner' ],
 			Html::element(
 				'p',
-				array( 'class' => 'text' ),
+				[ 'class' => 'text' ],
 				$this->msg( 'smw-livepreview-loading' )->inContentLanguage()->text()
 			)
 		);
@@ -84,7 +84,7 @@ abstract class RawResultPrinter extends ResultPrinter {
 	protected function encodeToJsonForId( $id, $data ) {
 		SMWOutputs::requireHeadItem(
 			$id,
-			$this->getSkin()->makeVariablesScript( array ( $id => FormatJson::encode( $data ) )
+			$this->getSkin()->makeVariablesScript(  [ $id => FormatJson::encode( $data ) ]
 		) );
 
 		return $this;
@@ -118,12 +118,12 @@ abstract class RawResultPrinter extends ResultPrinter {
 		}
 
 		// Combine all data into one object
-		$data = array(
-			'query' => array(
+		$data = [
+			'query' => [
 				'result' => $queryResult->toArray(),
 				'ask'    => $ask
-			)
-		);
+			]
+		];
 
 		return $this->getHtml( $data );
 	}

--- a/includes/queryprinters/RdfResultPrinter.php
+++ b/includes/queryprinters/RdfResultPrinter.php
@@ -128,12 +128,12 @@ class RdfResultPrinter extends FileExportPrinter {
 
 		$definitions['searchlabel']->setDefault( wfMessage( 'smw_rdf_link' )->inContentLanguage()->text() );
 
-		$definitions[] = array(
+		$definitions[] = [
 			'name' => 'syntax',
 			'message' => 'smw-paramdesc-rdfsyntax',
-			'values' => array( 'rdfxml', 'turtle' ),
+			'values' => [ 'rdfxml', 'turtle' ],
 			'default' => 'rdfxml',
-		);
+		];
 
 		return $definitions;
 	}

--- a/includes/specials/SMW_SpecialOWLExport.php
+++ b/includes/specials/SMW_SpecialOWLExport.php
@@ -34,7 +34,7 @@ class SMWSpecialOWLExport extends SpecialPage {
 			$page = is_null( $page ) ? $wgRequest->getCheck( 'text' ) : $page;
 
 			if ( $page !== '' ) {
-				$pages = array( $page );
+				$pages = [ $page ];
 			}
 		}
 

--- a/includes/specials/SMW_SpecialTypes.php
+++ b/includes/specials/SMW_SpecialTypes.php
@@ -47,7 +47,7 @@ class SMWSpecialTypes extends SpecialPage {
 
 		$typeLabels = DataTypeRegistry::getInstance()->getKnownTypeLabels();
 
-		$contentsByIndex = array();
+		$contentsByIndex = [];
 		asort( $typeLabels, SORT_STRING );
 
 		$mwCollaboratorFactory = ApplicationFactory::getInstance()->newMwCollaboratorFactory();
@@ -66,11 +66,11 @@ class SMWSpecialTypes extends SpecialPage {
 
 		$html = \Html::rawElement(
 			'p',
-			array( 'class' => 'plainlinks smw-types-intro' ),
+			[ 'class' => 'plainlinks smw-types-intro' ],
 			wfMessage( 'smw_types_docu' )->parse()
 		).  \Html::element(
 			'h2',
-			array(),
+			[],
 			wfMessage( 'smw-types-list' )->escaped()
 		);
 
@@ -121,7 +121,7 @@ class SMWSpecialTypes extends SpecialPage {
 
 		$result = \Html::rawElement(
 			'div',
-			array( 'class' => 'plainlinks smw-types-intro '. $typeKey ),
+			[ 'class' => 'plainlinks smw-types-intro '. $typeKey ],
 			wfMessage( $messageKey, str_replace( '_', ' ', $escapedTypeLabel ) )->parse() . ' ' .
 			wfMessage( 'smw-types-help', str_replace( ' ', '_', $canonicalLabel ) )->parse() . $this->displayExtraInformationAbout( $typeValue )
 		);
@@ -179,15 +179,15 @@ class SMWSpecialTypes extends SpecialPage {
 	private function getTypesLink() {
 		return \Html::rawElement(
 			'div',
-			array( 'class' => 'smw-breadcrumb-link' ),
+			[ 'class' => 'smw-breadcrumb-link' ],
 			\Html::rawElement(
 				'span',
-				array( 'class' => 'smw-breadcrumb-arrow-right' ),
+				[ 'class' => 'smw-breadcrumb-arrow-right' ],
 				''
 			) .
 			\Html::rawElement(
 				'a',
-				array( 'href' => \SpecialPage::getTitleFor( 'Types')->getFullURL() ),
+				[ 'href' => \SpecialPage::getTitleFor( 'Types')->getFullURL() ],
 				$this->msg( 'types' )->escaped()
 		) );
 	}

--- a/includes/specials/SpecialConcepts.php
+++ b/includes/specials/SpecialConcepts.php
@@ -103,14 +103,14 @@ class SpecialConcepts extends SpecialPage {
 
 		$html = Html::rawElement(
 				'div',
-				array( 'id' => 'mw-pages'),
+				[ 'id' => 'mw-pages'],
 			Html::rawElement(
 				'div',
 				[ 'class' => 'smw-page-navigation' ],
 				ListPager::pagination( $this->getPageTitle(), $limit, $offset, count( $diWikiPages ) )
 			) . Html::element(
 				'div',
-				array( 'class' => $key, 'style' => 'margin-top:10px;' ),
+				[ 'class' => $key, 'style' => 'margin-top:10px;' ],
 				$this->msg( $key, $resultNumber )->parse()
 			) . $pageLister->getColumnList( $offset, $limit, $diWikiPages, null )
 		);
@@ -124,7 +124,7 @@ class SpecialConcepts extends SpecialPage {
 
 		return Html::rawElement(
 			'p',
-			array( 'class' => 'smw-special-concept-docu plainlinks' ),
+			[ 'class' => 'smw-special-concept-docu plainlinks' ],
 			$this->msg( 'smw-special-concept-docu' )->parse()
 		) . $html;
 	}

--- a/includes/specials/SpecialWantedProperties.php
+++ b/includes/specials/SpecialWantedProperties.php
@@ -41,9 +41,9 @@ class SpecialWantedProperties extends SpecialPage {
 
 		$out = $this->getOutput();
 
-		$out->addModuleStyles( array(
+		$out->addModuleStyles( [
 			'ext.smw.special.style'
-		) );
+		] );
 
 		$out->setPageTitle( $this->msg( 'wantedproperties' )->text() );
 

--- a/includes/storage/SMW_QueryResult.php
+++ b/includes/storage/SMW_QueryResult.php
@@ -214,7 +214,7 @@ class SMWQueryResult {
 			return false;
 		}
 
-		$row = array();
+		$row = [];
 
 		foreach ( $this->mPrintRequests as $p ) {
 			$resultArray = new SMWResultArray( $page, $p, $this->mStore );
@@ -422,15 +422,15 @@ class SMWQueryResult {
 		// @note count + offset equals total therefore we deploy both values
 		$serializeArray = $this->serializeToArray();
 
-		return array_merge( $serializeArray, array(
-			'meta'=> array(
+		return array_merge( $serializeArray, [
+			'meta'=> [
 				'hash'   => HashBuilder::createFromContent( $serializeArray ),
 				'count'  => $this->getCount(),
 				'offset' => $this->mQuery->getOffset(),
 				'source' => $this->mQuery->getQuerySource(),
 				'time'   => number_format( ( microtime( true ) - $time ), 6, '.', '' )
-				)
-			)
+				]
+			]
 		);
 	}
 

--- a/includes/storage/SQLStore/SMW_SQLStore3.php
+++ b/includes/storage/SQLStore/SMW_SQLStore3.php
@@ -295,12 +295,12 @@ class SMWSQLStore3 extends SMWStore {
 		$result = null;
 		$start = microtime( true );
 
-		if ( \Hooks::run( 'SMW::Store::BeforeQueryResultLookupComplete', array( $this, $query, &$result, $this->factory->newSlaveQueryEngine() ) ) ) {
+		if ( \Hooks::run( 'SMW::Store::BeforeQueryResultLookupComplete', [ $this, $query, &$result, $this->factory->newSlaveQueryEngine() ] ) ) {
 			$result = $this->fetchQueryResult( $query );
 		}
 
-		\Hooks::run( 'SMW::SQLStore::AfterQueryResultLookupComplete', array( $this, &$result ) );
-		\Hooks::run( 'SMW::Store::AfterQueryResultLookupComplete', array( $this, &$result ) );
+		\Hooks::run( 'SMW::SQLStore::AfterQueryResultLookupComplete', [ $this, &$result ] );
+		\Hooks::run( 'SMW::Store::AfterQueryResultLookupComplete', [ $this, &$result ] );
 
 		$query->setOption( SMWQuery::PROC_QUERY_TIME, microtime( true ) - $start );
 

--- a/includes/storage/SQLStore/SMW_SQLStore3_Readers.php
+++ b/includes/storage/SQLStore/SMW_SQLStore3_Readers.php
@@ -149,7 +149,7 @@ class SMWSQLStore3Readers {
 
 		// Avoid adding a sortkey for an already extended stub
 		if ( !$semanticData->hasProperty( new DIProperty( '_SKEY' ) ) ) {
-			$semanticData->addPropertyStubValue( '_SKEY', array( '', $sortKey ) );
+			$semanticData->addPropertyStubValue( '_SKEY', [ '', $sortKey ] );
 		}
 
 		$this->store->smwIds->warmUpCache(
@@ -187,19 +187,19 @@ class SMWSQLStore3Readers {
 				$subject->getNamespace(), $subject->getInterwiki(),
 				$subject->getSubobjectName(), true );
 			if ( $sid == 0 ) {
-				$result = array();
+				$result = [];
 			} elseif ( $property->getKey() == '_SKEY' ) {
 				$this->store->smwIds->getSMWPageIDandSort( $subject->getDBkey(),
 				$subject->getNamespace(), $subject->getInterwiki(),
 				$subject->getSubobjectName(), $sortKey, true );
 				$sortKeyDi = new SMWDIBlob( $sortKey );
-				$result = $this->store->applyRequestOptions( array( $sortKeyDi ), $requestOptions );
+				$result = $this->store->applyRequestOptions( [ $sortKeyDi ], $requestOptions );
 			} else {
 				$propTableId = $this->store->findPropertyTableID( $property );
 				$proptables =  $this->store->getPropertyTables();
 
 				if ( !isset( $proptables[$propTableId] ) ) {
-					return array();
+					return [];
 				}
 
 				$propertyTableDef = $proptables[$propTableId];
@@ -230,7 +230,7 @@ class SMWSQLStore3Readers {
 			$tableid =  $this->store->findPropertyTableID( $property );
 
 			if ( ( $pid == 0 ) || ( $tableid === '' ) ) {
-				return array();
+				return [];
 			}
 
 			$proptables =  $this->store->getPropertyTables();
@@ -241,7 +241,7 @@ class SMWSQLStore3Readers {
 				$requestOptions
 			);
 
-			$result = array();
+			$result = [];
 			$propertyTypeId = $property->findPropertyTypeID();
 			$propertyDiId = DataTypeRegistry::getInstance()->getDataItemId( $propertyTypeId );
 

--- a/includes/storage/SQLStore/SMW_SQLStore3_Writers.php
+++ b/includes/storage/SQLStore/SMW_SQLStore3_Writers.php
@@ -84,9 +84,9 @@ class SMWSQLStore3Writers {
 	public function deleteSubject( Title $title ) {
 
 		// @deprecated since 2.1, use 'SMW::SQLStore::BeforeDeleteSubjectComplete'
-		\Hooks::run( 'SMWSQLStore3::deleteSubjectBefore', array( $this->store, $title ) );
+		\Hooks::run( 'SMWSQLStore3::deleteSubjectBefore', [ $this->store, $title ] );
 
-		\Hooks::run( 'SMW::SQLStore::BeforeDeleteSubjectComplete', array( $this->store, $title ) );
+		\Hooks::run( 'SMW::SQLStore::BeforeDeleteSubjectComplete', [ $this->store, $title ] );
 
 		// Fetch all possible matches (including any duplicates created by
 		// incomplete rollback or DB deadlock)
@@ -129,9 +129,9 @@ class SMWSQLStore3Writers {
 		$this->store->extensionData['delete.list'] = $extensionList;
 
 		// @deprecated since 2.1, use 'SMW::SQLStore::AfterDeleteSubjectComplete'
-		\Hooks::run( 'SMWSQLStore3::deleteSubjectAfter', array( $this->store, $title ) );
+		\Hooks::run( 'SMWSQLStore3::deleteSubjectAfter', [ $this->store, $title ] );
 
-		\Hooks::run( 'SMW::SQLStore::AfterDeleteSubjectComplete', array( $this->store, $title ) );
+		\Hooks::run( 'SMW::SQLStore::AfterDeleteSubjectComplete', [ $this->store, $title ] );
 	}
 
 	private function doDelete( $id, $subject, $subobjectListFinder, &$extensionList ) {
@@ -143,13 +143,13 @@ class SMWSQLStore3Writers {
 
 			$db->delete(
 				SMWSQLStore3::CONCEPT_TABLE,
-				array( 's_id' => $id ),
+				[ 's_id' => $id ],
 				'SMW::deleteSubject::Conc'
 			);
 
 			$db->delete(
 				SMWSQLStore3::CONCEPT_CACHE_TABLE,
-				array( 'o_id' => $id ),
+				[ 'o_id' => $id ],
 				'SMW::deleteSubject::Conccache'
 			);
 		}
@@ -174,7 +174,7 @@ class SMWSQLStore3Writers {
 	 * @param SMWSemanticData $data
 	 */
 	public function doDataUpdate( SMWSemanticData $semanticData ) {
-		\Hooks::run( 'SMWSQLStore3::updateDataBefore', array( $this->store, $semanticData ) );
+		\Hooks::run( 'SMWSQLStore3::updateDataBefore', [ $this->store, $semanticData ] );
 
 		$subject = $semanticData->getSubject();
 		$connection = $this->store->getConnection( 'mw.db' );
@@ -250,13 +250,13 @@ class SMWSQLStore3Writers {
 		$this->store->extensionData['change.diff'] = $changeDiff;
 
 		// Deprecated since 2.3, use SMW::SQLStore::AfterDataUpdateComplete
-		\Hooks::run( 'SMWSQLStore3::updateDataAfter', array( $this->store, $semanticData ) );
+		\Hooks::run( 'SMWSQLStore3::updateDataAfter', [ $this->store, $semanticData ] );
 
-		\Hooks::run( 'SMW::SQLStore::AfterDataUpdateComplete', array(
+		\Hooks::run( 'SMW::SQLStore::AfterDataUpdateComplete', [
 			$this->store,
 			$semanticData,
 			$changeOp
-		) );
+		] );
 
 		$connection->endAtomicTransaction( __METHOD__ );
 	}
@@ -349,7 +349,7 @@ class SMWSQLStore3Writers {
 
 		$this->propertyTableUpdater->update( $sid, $params );
 
-		if ( $redirects === array() && $subject->getSubobjectName() === ''  ) {
+		if ( $redirects === [] && $subject->getSubobjectName() === ''  ) {
 
 			$dataItemFromId = $this->store->getObjectIds()->getDataItemById( $sid );
 
@@ -441,7 +441,7 @@ class SMWSQLStore3Writers {
 
 		\Hooks::run(
 			'SMW::SQLStore::BeforeChangeTitleComplete',
-			array( $this->store, $oldTitle, $newTitle, $pageId, $redirectId )
+			[ $this->store, $oldTitle, $newTitle, $pageId, $redirectId ]
 		);
 
 		$db = $this->store->getConnection();
@@ -473,16 +473,16 @@ class SMWSQLStore3Writers {
 				// Note that this also changes the reference for internal objects (subobjects)
 				$db->update(
 					SMWSql3SmwIds::TABLE_NAME,
-					array(
+					[
 						'smw_title' => $newTitle->getDBkey(),
 						'smw_namespace' => $newTitle->getNamespace(),
 						'smw_iw' => ''
-					),
-					array(
+					],
+					[
 						'smw_title' => $oldTitle->getDBkey(),
 						'smw_namespace' => $oldTitle->getNamespace(),
 						'smw_iw' => ''
-					),
+					],
 					__METHOD__
 				);
 
@@ -568,11 +568,11 @@ class SMWSQLStore3Writers {
 			// Associate internal objects (subobjects) with the new title:
 			$table = $db->tableName( SMWSql3SmwIds::TABLE_NAME );
 
-			$values = array(
+			$values = [
 				'smw_title' => $newTitle->getDBkey(),
 				'smw_namespace' => $newTitle->getNamespace(),
 				'smw_iw' => ''
-			);
+			];
 
 			$sql = "UPDATE $table SET " . $db->makeList( $values, LIST_SET ) .
 				' WHERE smw_title = ' . $db->addQuotes( $oldTitle->getDBkey() ) . ' AND ' .
@@ -692,7 +692,7 @@ class SMWSQLStore3Writers {
 		} // note that this means $old_tid != $new_tid in all cases below
 
 		// *** Make relevant changes in property tables (don't write the new redirect yet) ***//
-		$jobs = array();
+		$jobs = [];
 
 		if ( ( $old_tid == 0 ) && ( $sid != 0 ) && ( $smwgQEqualitySupport != SMW_EQ_NONE ) ) { // new redirect
 			// $smwgQEqualitySupport requires us to change all tables' page references from $sid to $new_tid.
@@ -740,8 +740,8 @@ class SMWSQLStore3Writers {
 				} else {
 					$db->update(
 						SMWSql3SmwIds::TABLE_NAME,
-						array( 'smw_iw' => SMW_SQL3_SMWREDIIW ),
-						array( 'smw_id' => $sid ),
+						[ 'smw_iw' => SMW_SQL3_SMWREDIIW ],
+						[ 'smw_id' => $sid ],
 						__METHOD__
 					);
 
@@ -781,8 +781,8 @@ class SMWSQLStore3Writers {
 
 				$db->update(
 					SMWSql3SmwIds::TABLE_NAME,
-					array( 'smw_iw' => '' ),
-					array( 'smw_id' => $sid ),
+					[ 'smw_iw' => '' ],
+					[ 'smw_id' => $sid ],
 					__METHOD__
 				);
 

--- a/includes/storage/SQLStore/SMW_Sql3SmwIds.php
+++ b/includes/storage/SQLStore/SMW_Sql3SmwIds.php
@@ -302,15 +302,15 @@ class SMWSql3SmwIds {
 			if ( $id != 0 ) {
 
 				if ( $fetchHashes ) {
-					$select = array( 'smw_sortkey', 'smw_sort', 'smw_proptable_hash' );
+					$select = [ 'smw_sortkey', 'smw_sort', 'smw_proptable_hash' ];
 				} else {
-					$select = array( 'smw_sortkey', 'smw_sort' );
+					$select = [ 'smw_sortkey', 'smw_sort' ];
 				}
 
 				$row = $db->selectRow(
 					self::TABLE_NAME,
 					$select,
-					array( 'smw_id' => $id ),
+					[ 'smw_id' => $id ],
 					__METHOD__
 				);
 
@@ -330,9 +330,9 @@ class SMWSql3SmwIds {
 		} else {
 
 			if ( $fetchHashes ) {
-				$select = array( 'smw_id', 'smw_sortkey', 'smw_sort', 'smw_proptable_hash' );
+				$select = [ 'smw_id', 'smw_sortkey', 'smw_sort', 'smw_proptable_hash' ];
 			} else {
-				$select = array( 'smw_id', 'smw_sortkey', 'smw_sort' );
+				$select = [ 'smw_id', 'smw_sortkey', 'smw_sort' ];
 			}
 
 			// #2001
@@ -350,12 +350,12 @@ class SMWSql3SmwIds {
 			$row = $db->selectRow(
 				self::TABLE_NAME,
 				$select,
-				array(
+				[
 					'smw_title' => $title,
 					'smw_namespace' => $namespace,
 					'smw_iw' => $iw,
 					'smw_subobject' => $subobjectName
-				),
+				],
 				__METHOD__
 			);
 
@@ -511,13 +511,13 @@ class SMWSql3SmwIds {
 
 		$row = $this->store->getConnection( 'mw.db' )->selectRow(
 			self::TABLE_NAME,
-			array( 'smw_id' ),
-			array(
+			[ 'smw_id' ],
+			[
 				'smw_title' => $subject->getDBKey(),
 				'smw_namespace' => $subject->getNamespace(),
 				'smw_iw' => $subject->getInterWiki(),
 				'smw_subobject' => $subject->getSubobjectName()
-			),
+			],
 			__METHOD__
 		);
 
@@ -633,7 +633,7 @@ class SMWSql3SmwIds {
 
 			$db->insert(
 				self::TABLE_NAME,
-				array(
+				[
 					'smw_id' => $sequenceValue,
 					'smw_title' => $title,
 					'smw_namespace' => $namespace,
@@ -642,7 +642,7 @@ class SMWSql3SmwIds {
 					'smw_sortkey' => $sortkey,
 					'smw_sort' => $collator->getSortKey( $sortkey ),
 					'smw_hash' => $this->computeSha1( [ $title, (int)$namespace, $iw, $subobjectName ] )
-				),
+				],
 				__METHOD__
 			);
 
@@ -886,7 +886,7 @@ class SMWSql3SmwIds {
 		$row = $db->selectRow(
 			self::TABLE_NAME,
 			'*',
-			array( 'smw_id' => $curid ),
+			[ 'smw_id' => $curid ],
 			__METHOD__
 		);
 
@@ -905,7 +905,7 @@ class SMWSql3SmwIds {
 
 			$db->insert(
 				self::TABLE_NAME,
-				array(
+				[
 					'smw_id' => $sequenceValue,
 					'smw_title' => $row->smw_title,
 					'smw_namespace' => $row->smw_namespace,
@@ -913,7 +913,7 @@ class SMWSql3SmwIds {
 					'smw_subobject' => $row->smw_subobject,
 					'smw_sortkey' => $row->smw_sortkey,
 					'smw_sort' => $row->smw_sort
-				),
+				],
 				__METHOD__
 			);
 
@@ -921,23 +921,23 @@ class SMWSql3SmwIds {
 		} else { // change to given id
 			$db->insert(
 				self::TABLE_NAME,
-				array( 'smw_id' => $targetid,
+				[ 'smw_id' => $targetid,
 					'smw_title' => $row->smw_title,
 					'smw_namespace' => $row->smw_namespace,
 					'smw_iw' => $row->smw_iw,
 					'smw_subobject' => $row->smw_subobject,
 					'smw_sortkey' => $row->smw_sortkey,
 					'smw_sort' => $row->smw_sort
-				),
+				],
 				__METHOD__
 			);
 		}
 
 		$db->delete(
 			self::TABLE_NAME,
-			array(
+			[
 				'smw_id' => $curid
-			),
+			],
 			__METHOD__
 		);
 
@@ -1198,7 +1198,7 @@ class SMWSql3SmwIds {
 
 		$row = $connection->selectRow(
 			self::TABLE_NAME,
-			array( 'smw_proptable_hash' ),
+			[ 'smw_proptable_hash' ],
 			'smw_id=' . $sid,
 			__METHOD__
 		);
@@ -1240,7 +1240,7 @@ class SMWSql3SmwIds {
 		$connection->update(
 			self::TABLE_NAME,
 			$update,
-			array( 'smw_id' => $sid ),
+			[ 'smw_id' => $sid ],
 			__METHOD__
 		);
 

--- a/maintenance/dumpRDF.php
+++ b/maintenance/dumpRDF.php
@@ -51,7 +51,7 @@ class DumpRdf extends \Maintenance {
 	/**
 	 * @var array
 	 */
-	private $pages = array();
+	private $pages = [];
 
 	/**
 	 * @since 2.0
@@ -138,7 +138,7 @@ class DumpRdf extends \Maintenance {
 		} elseif ( $this->hasOption( 'concepts' ) ) {
 			$this->restrictNamespaceTo = SMW_NS_CONCEPT;
 		} elseif ( $this->hasOption( 'classes' ) ) {
-			$this->restrictNamespaceTo = array( NS_CATEGORY, SMW_NS_CONCEPT );
+			$this->restrictNamespaceTo = [ NS_CATEGORY, SMW_NS_CONCEPT ];
 		} elseif ( $this->hasOption( 'properties' ) ) {
 			$this->restrictNamespaceTo = SMW_NS_PROPERTY;
 		} elseif ( $this->hasOption( 'individuals' ) ) {
@@ -160,7 +160,7 @@ class DumpRdf extends \Maintenance {
 
 		$exportController = new ExportController( new RDFXMLSerializer() );
 
-		if ( $this->pages !== array() ) {
+		if ( $this->pages !== [] ) {
 			return $exportController->printPages(
 				$this->pages
 			);

--- a/maintenance/rebuildConceptCache.php
+++ b/maintenance/rebuildConceptCache.php
@@ -139,7 +139,7 @@ class RebuildConceptCache extends \Maintenance {
 
 		$conceptCacheRebuilder = $maintenanceFactory->newConceptCacheRebuilder(
 			$applicationFactory->getStore(),
-			array( $this, 'reportMessage' )
+			[ $this, 'reportMessage' ]
 		);
 
 		$conceptCacheRebuilder->setParameters( $this->mOptions );

--- a/maintenance/rebuildFulltextSearchTable.php
+++ b/maintenance/rebuildFulltextSearchTable.php
@@ -101,7 +101,7 @@ class RebuildFulltextSearchTable extends \Maintenance {
 		// Need to instantiate an extra object here since we cannot make this class itself
 		// into a MessageReporter since the maintenance script does not load the interface in time.
 		$reporter = MessageReporterFactory::getInstance()->newObservableMessageReporter();
-		$reporter->registerReporterCallback( array( $this, 'reportMessage' ) );
+		$reporter->registerReporterCallback( [ $this, 'reportMessage' ] );
 
 		$searchTableRebuilder->setMessageReporter( $reporter );
 		$result = $searchTableRebuilder->rebuild();
@@ -129,13 +129,13 @@ class RebuildFulltextSearchTable extends \Maintenance {
 		}
 
 		$searchTable = $searchTableRebuilder->getSearchTable();
-		$indexableDataTypes = array();
+		$indexableDataTypes = [];
 
-		$dataTypes = array(
+		$dataTypes = [
 			DataItem::TYPE_BLOB => 'BLOB',
 			DataItem::TYPE_URI  => 'URI',
 			DataItem::TYPE_WIKIPAGE => 'WIKIPAGE'
-		);
+		];
 
 		foreach ( $dataTypes as $key => $value ) {
 			if ( $searchTable->isValidByType( $key ) ) {

--- a/maintenance/rebuildPropertyStatistics.php
+++ b/maintenance/rebuildPropertyStatistics.php
@@ -58,7 +58,7 @@ class RebuildPropertyStatistics extends \Maintenance {
 
 		$statisticsRebuilder = $maintenanceFactory->newPropertyStatisticsRebuilder(
 			$applicationFactory->getStore( 'SMW\SQLStore\SQLStore' ),
-			array( $this, 'reportMessage' )
+			[ $this, 'reportMessage' ]
 		);
 
 		$statisticsRebuilder->rebuild();

--- a/maintenance/removeDuplicateEntities.php
+++ b/maintenance/removeDuplicateEntities.php
@@ -64,7 +64,7 @@ class RemoveDuplicateEntities extends \Maintenance {
 
 		$duplicateEntitiesDisposer = $maintenanceFactory->newDuplicateEntitiesDisposer(
 			$applicationFactory->getStore( 'SMW\SQLStore\SQLStore' ),
-			array( $this, 'reportMessage' )
+			[ $this, 'reportMessage' ]
 		);
 
 		$duplicateEntityRecords = $duplicateEntitiesDisposer->findDuplicates();

--- a/maintenance/setupStore.php
+++ b/maintenance/setupStore.php
@@ -173,7 +173,7 @@ class SetupStore extends \Maintenance {
 			$this->messageReporter = $messageReporterFactory->newNullMessageReporter();
 		} elseif( $this->messageReporter === null ) {
 			$this->messageReporter = $messageReporterFactory->newObservableMessageReporter();
-			$this->messageReporter->registerReporterCallback( array( $this, 'reportMessage' ) );
+			$this->messageReporter->registerReporterCallback( [ $this, 'reportMessage' ] );
 		}
 
 		return $this->messageReporter;

--- a/maintenance/updateEntityCollation.php
+++ b/maintenance/updateEntityCollation.php
@@ -71,11 +71,11 @@ class UpdateEntityCollation extends \Maintenance {
 
 		$res = $connection->select(
 			SQLStore::ID_TABLE,
-			array(
+			[
 				'smw_id',
 				'smw_title',
 				'smw_sortkey'
-			),
+			],
 			$condition,
 			__METHOD__
 		);
@@ -133,7 +133,7 @@ class UpdateEntityCollation extends \Maintenance {
 
 	private function getSortKey( $row, $pv ) {
 
-		if ( $pv !== array() ) {
+		if ( $pv !== [] ) {
 			return end( $pv )->getString();
 		}
 


### PR DESCRIPTION
This PR is made in reference to: #2318 

This PR addresses or contains:
- Converts `maintenance` and subdirecories to PHP 5.4+ short array syntax

This PR includes:
- [x] Tests (unit/integration)
- [ ] CI build passed

Fixes #