### PR TITLE
Property page, predefined property usage count, refs 3440

### DIFF
--- a/src/Page/PropertyPage.php
+++ b/src/Page/PropertyPage.php
@@ -340,15 +340,17 @@ class PropertyPage extends Page {
 
 	private function getUsageCount() {
 
+		$requestOptions = new RequestOptions();
+		$requestOptions->setLimit( 1 );
+
 		// Label that corresponds to the display and sort characteristics
 		if ( $this->property->isUserDefined() ) {
 			$searchLabel = $this->propertyValue->getSearchLabel();
 		} else {
-			$searchLabel = $this->property->getCanonicalLabel();
+			$searchLabel = $this->property->getKey();
+			$requestOptions->setOption( RequestOptions::SEARCH_FIELD, 'smw_title' );
 		}
 
-		$requestOptions = new RequestOptions();
-		$requestOptions->setLimit( 1 );
 		$requestOptions->addStringCondition( $searchLabel, StringCondition::COND_EQ );
 
 		$cachedLookupList = $this->store->getPropertiesSpecial( $requestOptions );

--- a/src/RequestOptions.php
+++ b/src/RequestOptions.php
@@ -17,6 +17,8 @@ namespace SMW;
  */
 class RequestOptions {
 
+	const SEARCH_FIELD = 'search_field';
+
 	/**
 	 * The maximum number of results that should be returned.
 	 */

--- a/src/SQLStore/Lookup/PropertyUsageListLookup.php
+++ b/src/SQLStore/Lookup/PropertyUsageListLookup.php
@@ -93,6 +93,7 @@ class PropertyUsageListLookup implements ListLookup {
 
 		// the query needs to do the filtering of internal properties, else LIMIT is wrong
 		$options = [ 'ORDER BY' => 'smw_sort' ];
+		$search_field = 'smw_sortkey';
 
 		$conditions = [
 			'smw_namespace' => SMW_NS_PROPERTY,
@@ -105,8 +106,12 @@ class PropertyUsageListLookup implements ListLookup {
 			$options['OFFSET'] = max( $this->requestOptions->offset, 0 );
 		}
 
+		if ( $this->requestOptions->getOption( RequestOptions::SEARCH_FIELD ) ) {
+			$search_field = $this->requestOptions->getOption( RequestOptions::SEARCH_FIELD );
+		}
+
 		if ( $this->requestOptions->getStringConditions() ) {
-			$conditions[] = $this->store->getSQLConditions( $this->requestOptions, '', 'smw_sortkey', false );
+			$conditions[] = $this->store->getSQLConditions( $this->requestOptions, '', $search_field, false );
 		}
 
 		$db = $this->store->getConnection( 'mw.db' );

--- a/src/SQLStore/RequestOptionsProc.php
+++ b/src/SQLStore/RequestOptionsProc.php
@@ -108,13 +108,18 @@ class RequestOptionsProc {
 				$condition = 'LIKE';
 
 				switch ( $strcond->condition ) {
-					case StringCondition::COND_PRE:  $string .= '%';
+					case StringCondition::COND_PRE:
+						$string .= '%';
 					break;
-					case StringCondition::COND_POST: $string = '%' . $string;
+					case StringCondition::COND_POST:
+						$string = '%' . $string;
 					break;
-					case StringCondition::COND_MID:  $string = '%' . $string . '%';
+					case StringCondition::COND_MID:
+						$string = '%' . $string . '%';
 					break;
-					case StringCondition::COND_EQ:  $condition = '=';
+					case StringCondition::COND_EQ:
+						$string = $strcond->string;
+						$condition = '=';
 					break;
 				}
 

--- a/tests/phpunit/Unit/SQLStore/RequestOptionsProcTest.php
+++ b/tests/phpunit/Unit/SQLStore/RequestOptionsProcTest.php
@@ -151,7 +151,7 @@ class RequestOptionsProcTest extends \PHPUnit_Framework_TestCase {
 			$requestOptions,
 			'Foo',
 			'Bar',
-			' AND Foo >= 1 AND Bar = foo\_bar'
+			' AND Foo >= 1 AND Bar = foo_bar'
 		];
 
 		# 4
@@ -165,7 +165,7 @@ class RequestOptionsProcTest extends \PHPUnit_Framework_TestCase {
 			$requestOptions,
 			'Foo',
 			'Bar',
-			' AND Foo >= 1 AND Bar = foo\_bar AND abd = 123'
+			' AND Foo >= 1 AND Bar = foo_bar AND abd = 123'
 		];
 
 		# 5
@@ -179,7 +179,7 @@ class RequestOptionsProcTest extends \PHPUnit_Framework_TestCase {
 			$requestOptions,
 			'Foo',
 			'Bar',
-			' AND Foo >= 1 AND Bar = foo\_bar OR abd = 123'
+			' AND Foo >= 1 AND Bar = foo_bar OR abd = 123'
 		];
 
 		# 6
@@ -192,7 +192,7 @@ class RequestOptionsProcTest extends \PHPUnit_Framework_TestCase {
 			$requestOptions,
 			'Foo',
 			'Bar',
-			' ( AND Foo >= 1) AND (Bar NOT = foo\_bar) '
+			' ( AND Foo >= 1) AND (Bar NOT = foo_bar) '
 		];
 
 		# 7
@@ -206,7 +206,7 @@ class RequestOptionsProcTest extends \PHPUnit_Framework_TestCase {
 			$requestOptions,
 			'Foo',
 			'Bar',
-			' ( AND Foo >= 1 OR Bar = foo\_bar) AND (Bar NOT LIKE %foobar) '
+			' ( AND Foo >= 1 OR Bar = foo_bar) AND (Bar NOT LIKE %foobar) '
 		];
 
 		# 8
@@ -221,7 +221,7 @@ class RequestOptionsProcTest extends \PHPUnit_Framework_TestCase {
 			$requestOptions,
 			'Foo',
 			'Bar',
-			' ( ( AND Foo >= 1 OR Bar = foo\_bar) AND (Bar NOT LIKE %foobar) ) AND (Bar NOT = foobar\_ex) '
+			' ( ( AND Foo >= 1 OR Bar = foo_bar) AND (Bar NOT LIKE %foobar) ) AND (Bar NOT = foobar_ex) '
 		];
 
 		return $provider;


### PR DESCRIPTION
This PR is made in reference to: #https://github.com/SemanticMediaWiki/SemanticMediaWiki/pull/3440#issuecomment-422023749

This PR addresses or contains:

- Use different select field for a predefined property (using the canonical key  `_...`) in order to match the usage count

This PR includes:
- [ ] Tests (unit/integration)
- [x] CI build passed
