### PR TITLE
API psubject support `title-prefix`, refs 3381

### DIFF
--- a/res/smw/special/ext.smw.special.ask.css
+++ b/res/smw/special/ext.smw.special.ask.css
@@ -395,8 +395,6 @@ display: inline-block;
 }
 
 .options-list .smw-property-input {
-	padding: 2px 1px 2px 1px;
-	border: 1px solid #aaa;
 }
 
 .smw-ask-sort-input .autocomplete-arrow, .smw-table-cell .autocomplete-arrow {
@@ -404,7 +402,6 @@ display: inline-block;
 }
 
 .options-list .smw-table-cell .autocomplete-arrow {
-	background-position-y: -2px;
 }
 
 .smw-ask-sort-input .autocomplete-loading {
@@ -417,8 +414,6 @@ display: inline-block;
 }
 
 .options-list .smw-table-cell .autocomplete-loading {
-	vertical-align: unset;
-	padding: 2px 1px 2px 1px;
 }
 
 .smw-table-cell .mw-ui-input.autocomplete-loading {

--- a/res/smw/util/ext.smw.util.autocomplete.propertysubject.js
+++ b/res/smw/util/ext.smw.util.autocomplete.propertysubject.js
@@ -31,6 +31,7 @@
 				"search": '',
 				'property': context.data( 'property' ),
 				'value': context.data( 'value' ),
+				'title-prefix': context.data( 'title-prefix' ),
 				"limit": limit
 			}
 		};
@@ -69,6 +70,7 @@
 					'search': query.search.replace( "?", '' ),
 					'property': context.data( 'property' ),
 					'value': context.data( 'value' ),
+					'title-prefix': context.data( 'title-prefix' ),
 					'limit': limit
 				} );
 

--- a/src/MediaWiki/Api/Browse/PSubjectLookup.php
+++ b/src/MediaWiki/Api/Browse/PSubjectLookup.php
@@ -138,7 +138,11 @@ class PSubjectLookup extends Lookup {
 				continue;
 			}
 
-			$list[] = $dataItem->getTitle()->getPrefixedText();
+			if ( isset( $parameters['title-prefix'] ) && (bool)$parameters['title-prefix'] === false ) {
+				$list[] = $dataItem->getTitle()->getText();
+			} else {
+				$list[] = $dataItem->getTitle()->getPrefixedText();
+			}
 		}
 
 		if ( $this->is_iterable( $res ) ) {

--- a/src/MediaWiki/Specials/Ask/ParametersWidget.php
+++ b/src/MediaWiki/Specials/Ask/ParametersWidget.php
@@ -308,12 +308,15 @@ class ParametersWidget {
 			$attributes['size'] = $opts['size'];
 		}
 
-		if ( isset( $opts['data-property'] ) ) {
-			$attributes['data-property'] = $opts['data-property'];
-		}
-
-		if ( isset( $opts['data-value'] ) ) {
-			$attributes['data-value'] = $opts['data-value'];
+		// [ 'data-props' => [
+		//   'property' => Foo, 'value' => 'Bar', 'title-prefix' => 'false'
+		// ] ]
+		if ( isset( $opts['data-props'] ) && is_array( $opts['data-props'] ) ) {
+			foreach ( $opts['data-props'] as $key => $value ) {
+				if ( is_string( $key ) ) {
+					$attributes["data-$key"] = $value;
+				}
+			}
 		}
 
 		if ( isset( $opts['class'] ) ) {

--- a/tests/phpunit/Unit/MediaWiki/Api/Browse/PSubjectLookupTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Api/Browse/PSubjectLookupTest.php
@@ -34,29 +34,51 @@ class PSubjectLookupTest extends \PHPUnit_Framework_TestCase {
 		);
 	}
 
-	public function testLookup() {
+	/**
+	 * @dataProvider lookupProvider
+	 */
+	public function testLookup( $subject, $parameters, $expected ) {
 
 		$this->store->expects( $this->any() )
 			->method( 'getPropertySubjects' )
-			->will( $this->returnValue( [ new DIWikiPage( 'Foobar', NS_MAIN ) ] ) );
+			->will( $this->returnValue( [ $subject ] ) );
 
 		$instance = new PSubjectLookup(
 			$this->store
 		);
 
-		$parameters = [
-			'search' => 'Foo',
-			'property' => 'Bar'
-		];
-
 		$res = $instance->lookup( $parameters );
 
 		$this->assertEquals(
 			$res['query'],
-			[
-				'Foobar'
-			]
+			$expected
 		);
+	}
+
+	public function lookupProvider() {
+
+		yield [
+			new DIWikiPage( 'Foo bar', NS_MAIN ),
+			[
+				'search' => 'Foo',
+				'property' => 'Bar'
+			],
+			[
+				'Foo bar'
+			]
+		];
+
+		yield [
+			new DIWikiPage( 'Foo bar', NS_HELP ),
+			[
+				'search' => 'Foo',
+				'property' => 'Bar',
+				'title-prefix' => false
+			],
+			[
+				'Foo bar'
+			]
+		];
 	}
 
 }


### PR DESCRIPTION
This PR is made in reference to: #3381

This PR addresses or contains

- `title-prefix=false` to suppress the title prefix of a result subject on the `smwbrowse/psubject` output

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed
