### PR TITLE
Remove FIXME (Query hash/fingerprint)

### DIFF
--- a/tests/phpunit/Integration/JSONScript/TestCases/f-0103.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/f-0103.json
@@ -44,8 +44,8 @@
 			},
 			"assert-queryresult": {
 				"results": [
-					"PageContainsAskWithTemplateUsage#0##_QUERY79869d791f05c5123300513f7746bdd9",
-					"PageContainsAskWithTemplateUsage#0##_QUERYce80902a7df821d01b8f9c6f06ad9d6c"
+					"PageContainsAskWithTemplateUsage#0##_QUERY243ffe4b18342e8ae68152cedc5b1966",
+					"PageContainsAskWithTemplateUsage#0##_QUERYe295f9adeb904a1cbab1e30eb56d79ba"
 				],
 				"count": "2",
 				"datavalues": [
@@ -90,7 +90,7 @@
 			},
 			"assert-queryresult": {
 				"results": [
-					"PageContainsTemplateTransclusion#0##_QUERY79869d791f05c5123300513f7746bdd9"
+					"PageContainsTemplateTransclusion#0##_QUERY243ffe4b18342e8ae68152cedc5b1966"
 				],
 				"count": "1",
 				"datavalues": [

--- a/tests/phpunit/Integration/JSONScript/TestCases/r-0010.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/r-0010.json
@@ -76,7 +76,7 @@
 			"assert-output": {
 				"to-contain": [
 					"<swivt:wikiPageContentLanguage rdf:datatype=\"http://www.w3.org/2001/XMLSchema#string\">fr</swivt:wikiPageContentLanguage>",
-					"<property:Has_query rdf:resource=\"&wiki;Example/R0010/Q1-23_QUERY3873375c1eb14b2382922133b97c8379\"/>"
+					"<property:Has_query rdf:resource=\"&wiki;Example/R0010/Q1-23_QUERY5223a22ba7ce6ccf63e5701b6d6093b6\"/>"
 				],
 				"not-contain": [
 					"Sp%C3%A9cial:ExportRDF/Example/R0010/2",

--- a/tests/phpunit/Unit/ParserFunctions/AskParserFunctionTest.php
+++ b/tests/phpunit/Unit/ParserFunctions/AskParserFunctionTest.php
@@ -226,57 +226,8 @@ class AskParserFunctionTest extends \PHPUnit_Framework_TestCase {
 		);
 	}
 
-	public function testQueryIdStabilityForFixedSetOfParameters() {
-
-		$this->testEnvironment->addConfiguration( 'smwgQueryResultCacheType', false );
-		$this->testEnvironment->addConfiguration( 'smwgQFilterDuplicates', false );
-
-		$parserData = ApplicationFactory::getInstance()->newParserData(
-			Title::newFromText( __METHOD__ ),
-			new ParserOutput()
-		);
-
-		$instance = new AskParserFunction(
-			$parserData,
-			$this->messageFormatter,
-			$this->circularReferenceGuard,
-			$this->expensiveFuncExecutionWatcher
-		);
-
-		$params = [
-			'[[Modification date::+]]',
-			'?Modification date',
-			'format=list'
-		];
-
-		$instance->parse( $params );
-
-		$this->assertTrue(
-			$parserData->getSemanticData()->hasSubSemanticData( '_QUERY702bb82fc5ac212df176709f98b4f5b9' )
-		);
-
-		// Limit is a factor that influences the query id, count uses the
-		// max limit available in $GLOBALS['smwgQMaxLimit'] therefore we set
-		// the limit to make the test independent from possible other settings
-
-		$params = [
-			'[[Modification date::+]]',
-			'?Modification date',
-			'format=count'
-		];
-
-		$instance->parse( $params );
-
-		$this->assertTrue(
-			$parserData->getSemanticData()->hasSubSemanticData( '_QUERYf161b0f405d169d1f038812484619c1f' )
-		);
-	}
-
 	public function testQueryIdStabilityForFixedSetOfParametersWithFingerprintMethod() {
 
-		$this->testEnvironment->addConfiguration( 'smwgQueryResultCacheType', false );
-		$this->testEnvironment->addConfiguration( 'smwgQFilterDuplicates', true );
-
 		$parserData = ApplicationFactory::getInstance()->newParserData(
 			Title::newFromText( __METHOD__ ),
 			new ParserOutput()
@@ -314,7 +265,7 @@ class AskParserFunctionTest extends \PHPUnit_Framework_TestCase {
 		$instance->parse( $params );
 
 		$this->assertTrue(
-			$parserData->getSemanticData()->hasSubSemanticData( '_QUERYaa38249db4bc6d3e8133588fb08d0f0d' )
+			$parserData->getSemanticData()->hasSubSemanticData( '_QUERYb6a190747f7d3c2775730f6bc6c5e469' )
 		);
 	}
 

--- a/tests/phpunit/Unit/ParserFunctions/ShowParserFunctionTest.php
+++ b/tests/phpunit/Unit/ParserFunctions/ShowParserFunctionTest.php
@@ -219,7 +219,7 @@ class ShowParserFunctionTest extends \PHPUnit_Framework_TestCase {
 
 		$this->semanticDataValidator->assertThatPropertiesAreSet(
 			$expected,
-			$parserData->getSemanticData()->findSubSemanticData( '_QUERYda9bddddc9907eafb60792ca4bed3008' )
+			$parserData->getSemanticData()->findSubSemanticData( '_QUERY6ee7d0bb3ac4ed35537bcb89914b30ac' )
 		);
 
 		$expected = [


### PR DESCRIPTION
This PR is made in reference to: #

This PR addresses or contains:

- Removes the FIXME in SMW 3.0 from `Query` to distinguish full hash vs. fingerprint only specific computation of the `_QUERY...` identifier 
- The fingerprint method makes sure that it returns the same ID for ` [[Foo::123]][[Bar::abc]] ` as for `[[Bar::abc]][[Foo::123]]` where in a "full hash" case would create different IDs even though the query representation would return the same results (given that limit, offset, sort are the same)
- Some users (those that didn't use `smwgQueryResultCacheType` which already applied the new method to minimize the cache fragmentation) may see an increased level of recompilation (hereby level of outdated entities) once on behalf of the query assigned (`Has query`) subobject which is the reason why only a full version jump (from 2.x to 3.x) allows to make such adjustments

This PR includes:
- [ ] Tests (unit/integration)
- [x] CI build passed
