### PR TITLE
QueryResult add inexpensive hashing

### DIFF
--- a/includes/storage/SMW_QueryResult.php
+++ b/includes/storage/SMW_QueryResult.php
@@ -1,6 +1,5 @@
 <?php
 
-use SMW\HashBuilder;
 use SMW\Query\Excerpts;
 use SMW\Query\PrintRequest;
 use SMW\Query\QueryLinker;
@@ -424,7 +423,7 @@ class SMWQueryResult {
 
 		return array_merge( $serializeArray, [
 			'meta'=> [
-				'hash'   => HashBuilder::createFromContent( $serializeArray ),
+				'hash'   => md5( json_encode( $serializeArray ) ),
 				'count'  => $this->getCount(),
 				'offset' => $this->mQuery->getOffset(),
 				'source' => $this->mQuery->getQuerySource(),
@@ -441,8 +440,23 @@ class SMWQueryResult {
 	 *
 	 * @return string
 	 */
-	public function getHash() {
-		return HashBuilder::createFromContent( $this->serializeToArray() );
+	public function getHash( $type = null ) {
+
+		// Just iterate over available subjects to create a "quick" hash given
+		// that resolving the entire object tree is costly due to recursive
+		// processing of all data items including its printouts
+		if ( $type === 'quick' ) {
+			$hash = [];
+
+			foreach ( $this->mResults as $dataItem ) {
+				$hash[] = $dataItem->getHash();
+			}
+
+			reset( $this->mResults );
+			return 'q:' . md5( json_encode( $hash ) );
+		}
+
+		return md5( json_encode( $this->serializeToArray() ) );
 	}
 
 }

--- a/tests/phpunit/includes/storage/QueryResultTest.php
+++ b/tests/phpunit/includes/storage/QueryResultTest.php
@@ -102,4 +102,30 @@ class QueryResultTest extends \PHPUnit_Framework_TestCase {
 		);
 	}
 
+	public function testGetHash() {
+
+		$query = $this->getMockBuilder( '\SMWQuery' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$store = $this->getMockBuilder( '\SMW\Store' )
+			->disableOriginalConstructor()
+			->getMockForAbstractClass();
+
+		$printRequests = [];
+		$results = [];
+
+		$instance = new QueryResult(
+			$printRequests,
+			$query,
+			$results,
+			$store
+		);
+
+		$this->assertNotSame(
+			$instance->getHash( 'quick' ),
+			$instance->getHash()
+		);
+	}
+
 }


### PR DESCRIPTION
This PR is made in reference to: #

This PR addresses or contains:

- `QueryResult` object hashing (to compare two results) is expensive therefore provide a `quick` method to only compare the result subjects and allow to make a judgement about the query result without resolving the entire data item and printout object tree

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed
