### PR TITLE
IdEntityFinder to help warm up the cache

### DIFF
--- a/includes/storage/SQLStore/SMW_Sql3SmwIds.php
+++ b/includes/storage/SQLStore/SMW_Sql3SmwIds.php
@@ -74,7 +74,7 @@ class SMWSql3SmwIds {
 	 */
 	const TABLE_NAME = SMWSQLStore3::ID_TABLE;
 
-	const MAX_CACHE_SIZE = 500;
+	const MAX_CACHE_SIZE = 1000;
 	const POOLCACHE_ID = 'smw.sqlstore';
 
 	/**
@@ -140,7 +140,7 @@ class SMWSql3SmwIds {
 		$this->initCache();
 
 		$this->idEntityFinder = $this->factory->newIdEntityFinder(
-			$this->idCacheManager->get( 'entity.lookup' )
+			$this->idCacheManager
 		);
 
 		$this->redirectStore = $this->factory->newRedirectStore();

--- a/src/SQLStore/SQLStoreFactory.php
+++ b/src/SQLStore/SQLStoreFactory.php
@@ -558,16 +558,16 @@ class SQLStoreFactory {
 	/**
 	 * @since 3.0
 	 *
-	 * @param Cache $cache
+	 * @param IdCacheManager $idCacheManager
 	 *
 	 * @return IdEntityFinder
 	 */
-	public function newIdEntityFinder( Cache $cache ) {
+	public function newIdEntityFinder( IdCacheManager $idCacheManager ) {
 
 		$idMatchFinder = new IdEntityFinder(
 			$this->store,
 			$this->getIteratorFactory(),
-			$cache
+			$idCacheManager
 		);
 
 		return $idMatchFinder;

--- a/tests/phpunit/Unit/SQLStore/EntityStore/IdEntityFinderTest.php
+++ b/tests/phpunit/Unit/SQLStore/EntityStore/IdEntityFinderTest.php
@@ -22,17 +22,26 @@ class IdEntityFinderTest extends \PHPUnit_Framework_TestCase {
 	private $testEnvironment;
 	private $cache;
 	private $iteratorFactory;
+	private $idCacheManager;
 	private $store;
 	private $conection;
 
 	protected function setUp() {
 		$this->testEnvironment = new TestEnvironment();
 
-		$this->iteratorFactory = $this->getMockBuilder( '\SMW\IteratorFactory' )
+		$this->cache = $this->getMockBuilder( '\Onoi\Cache\Cache' )
 			->disableOriginalConstructor()
 			->getMock();
 
-		$this->cache = $this->getMockBuilder( '\Onoi\Cache\Cache' )
+		$this->idCacheManager = $this->getMockBuilder( '\SMW\SQLStore\EntityStore\IdCacheManager' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$this->idCacheManager->expects( $this->any() )
+			->method( 'get' )
+			->will( $this->returnValue( $this->cache ) );
+
+		$this->iteratorFactory = $this->getMockBuilder( '\SMW\IteratorFactory' )
 			->disableOriginalConstructor()
 			->getMock();
 
@@ -54,7 +63,7 @@ class IdEntityFinderTest extends \PHPUnit_Framework_TestCase {
 
 		$this->assertInstanceOf(
 			IdEntityFinder::class,
-			new IdEntityFinder( $this->store, $this->iteratorFactory, $this->cache )
+			new IdEntityFinder( $this->store, $this->iteratorFactory, $this->idCacheManager )
 		);
 	}
 
@@ -67,6 +76,7 @@ class IdEntityFinderTest extends \PHPUnit_Framework_TestCase {
 		$row->smw_subobject ='';
 		$row->smw_sortkey ='';
 		$row->smw_sort ='';
+		$row->smw_hash = 'x99w';
 
 		$this->cache->expects( $this->once() )
 			->method( 'save' )
@@ -89,7 +99,7 @@ class IdEntityFinderTest extends \PHPUnit_Framework_TestCase {
 		$instance = new IdEntityFinder(
 			$this->store,
 			$this->iteratorFactory,
-			$this->cache
+			$this->idCacheManager
 		);
 
 		$this->assertInstanceOf(
@@ -110,7 +120,7 @@ class IdEntityFinderTest extends \PHPUnit_Framework_TestCase {
 		$instance = new IdEntityFinder(
 			$this->store,
 			$this->iteratorFactory,
-			$this->cache
+			$this->idCacheManager
 		);
 
 		$this->assertInstanceOf(
@@ -133,6 +143,7 @@ class IdEntityFinderTest extends \PHPUnit_Framework_TestCase {
 		$row->smw_subobject = '';
 		$row->smw_sortkey = 'bar';
 		$row->smw_sort = 'BAR';
+		$row->smw_hash = 'x99w';
 
 		$this->cache->expects( $this->once() )
 			->method( 'fetch' )
@@ -149,7 +160,7 @@ class IdEntityFinderTest extends \PHPUnit_Framework_TestCase {
 		$instance = new IdEntityFinder(
 			$this->store,
 			$this->iteratorFactory,
-			$this->cache
+			$this->idCacheManager
 		);
 
 		$this->assertEquals(
@@ -171,7 +182,7 @@ class IdEntityFinderTest extends \PHPUnit_Framework_TestCase {
 		$instance = new IdEntityFinder(
 			$this->store,
 			$this->iteratorFactory,
-			$this->cache
+			$this->idCacheManager
 		);
 
 		$this->assertNull(
@@ -183,6 +194,8 @@ class IdEntityFinderTest extends \PHPUnit_Framework_TestCase {
 
 		$expected = new DIWikiPage( 'Foo', 0, '', '' );
 		$expected->setId( 42 );
+		$expected->setSortKey( '...' );
+		$expected->setOption( 'sort', '...' );
 
 		$row = new \stdClass;
 		$row->smw_id = 42;
@@ -190,6 +203,9 @@ class IdEntityFinderTest extends \PHPUnit_Framework_TestCase {
 		$row->smw_namespace = 0;
 		$row->smw_iw = '';
 		$row->smw_subobject ='';
+		$row->smw_sortkey = '...';
+		$row->smw_sort = '...';
+		$row->smw_hash = 'x99w';
 
 		$this->connection->expects( $this->once() )
 			->method( 'select' )
@@ -202,7 +218,7 @@ class IdEntityFinderTest extends \PHPUnit_Framework_TestCase {
 		$instance = new IdEntityFinder(
 			$this->store,
 			new IteratorFactory(),
-			$this->cache
+			$this->idCacheManager
 		);
 
 		foreach ( $instance->getDataItemsFromList( [ 42 ] ) as $value ) {

--- a/tests/phpunit/Unit/SQLStore/SQLStoreFactoryTest.php
+++ b/tests/phpunit/Unit/SQLStore/SQLStoreFactoryTest.php
@@ -299,7 +299,7 @@ class SQLStoreFactoryTest extends \PHPUnit_Framework_TestCase {
 
 	public function testCanConstructIdEntityFinder() {
 
-		$cache = $this->getMockBuilder( '\Onoi\Cache\Cache' )
+		$idCacheManager = $this->getMockBuilder( '\SMW\SQLStore\EntityStore\IdCacheManager' )
 			->disableOriginalConstructor()
 			->getMock();
 
@@ -307,7 +307,7 @@ class SQLStoreFactoryTest extends \PHPUnit_Framework_TestCase {
 
 		$this->assertInstanceOf(
 			'\SMW\SQLStore\EntityStore\IdEntityFinder',
-			$instance->newIdEntityFinder( $cache )
+			$instance->newIdEntityFinder( $idCacheManager )
 		);
 	}
 


### PR DESCRIPTION
This PR is made in reference to: #

This PR addresses or contains:

- If the `IdEntityFinder` access firsts the DB (as in case of the `ElasticStore` and the `QueryResult` matching) to find all matching entities for a list of IDs then fill the cache to avoid running the reverse warm up after the process.

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed

### Before

```
7 | SELECT smw_id,smw_title,smw_namespace,smw_iw,smw_subobject,smw_sortkey,smw_sort FROM `smw_object_ids` WHERE smw_id IN ('1165','1166','1176','1281','1283','1284','1285','1287','1288','1289','1291','1292','1293','1177','1295','1296','1297','1298','1299','1300','1301','1302','1303','1304','1178','1305','1306','1307','1308','1309','1310','1311','1312','1313','1314','1180','1315','1316','1318','1319','1320','1321','1322','1323','1324','1326','1181','1327','1328','1329') | 13.3018ms | SMW\SQLStore\EntityStore\IdEntityFinder::fetchFromTable

8 | SELECT smw_id,smw_title,smw_namespace,smw_iw,smw_subobject,smw_sortkey,smw_sort FROM `smw_object_ids` WHERE smw_hash IN ('b7b7dcd4d07cb0e444c101d377549505a829ee67','d01a1344b0d09d4f070142e59f08036234203406','6c35ff6e8dfc81512423171436f3b56b48e9ad93','7988469cd345c6e19f8d2d13323e21cd8ac596de','aae5b4fdbc754f8eda3717927f00742e0d24ba69','a9dbe752165b07126073bdaf0828bc706bbbd510','760df213d018b3601dfd4c919bd6623e78760a87','33204a2bddb3b4d4106e9211c4f6efd20583b245','a537706dab9a1e3629cdcdbb7c0262ae3295bb95','d75a9c2e68cfa539c773700156a38d56cc387ca1','0b16172ffe20f7bbebc9434cc249d3950d2063ce','18368819648fa75192523374de75c40e4a9dc8ad','a2ca1a722833584c5b4b43d9cb61bf75616c5a02','007bdb6d26b310720655c6bcf9170244c27a8a5d','459ddb001a5267b7bc70fea6d9910562ac3ced51','34a1aa44180b1724c162d087032b09815661bc94','00bff8247a52b454a14c985975c13869405e877c','c306ed05a46d65d99652c6b477a91ad247ff014c','f69651f9a0085c0a14659a5ad45006c35a6d41fa','3d10639611d237a0aada2d13117700a34405bef0','cb069bf30475fea669b992d0a18cc23004295d98','0c4b0b1816a50c463bea9397a517d6b69a636445','b9362c1763ea54913d6997866ba33870949a71c5','a666528bfd807a9234496c26a3280036e3b0a005','1d64ef2f7d627ef302b0fbcdf6a46beeedea82d8','04d257e2b88bb4bb2e6034b4a4547adc097e134e','04ebffda8d5cebcd398845d1809fcffe100fb7ac','1cdb894d5f919de0a7ab61bca066f422a949b97e','c3ff2feb59384122990c1208a130bf9c43f6104c','67b480470027a8fec1a0f9592fa2ebf2b3993f8a','2b443751d3599443ea59345d193323b0493de919','f39d1dfba8f50c7b97c6e32ca0fadc71553c3218','0f72c0eefe5c160cadf3c9f26a51e946806fb542','b9b84ac2acc0bf33c3ad2b41dc3bbea862714c68','5ec97e305e718984994d361e8c646f79747c5266','a234b3d54ea8022eb2e2ae52a228b7d63231b413','4ea0170e2d3de0ab664165c1d2fc612fcf47f7ad','de5dcf9c80f4f1db12cb25cfa5e7b6544f54548b','0f9e369d0da6005ce20980f55fc50fcd114872b0','952c24c470f75a7f94888c1f7e4d42f7836e259b','da18c05905e2131473884c97c9fcec9172b5624c','e6ee50b462492e5d69b65e51bdd384a00ba7feaa','4c1958d11e4890ef0006e36c3ae52f8e0a71ccce','547f1e6a070aaa6762fcf0af6faa7842cbf75954','e359829ebe17a7ce4e548156428074b98014942e','6ab568521b1be40142b17efb4e5de27d76a5c234','9e0239de4e8b2297d39d0e5c629923f993e61cb5','e24e026578dc9fd6be251ffb2ba80d9ed7e20aa1','2241ebf785df1c597496af954159c86230ddc306','23c9b028f648f31f6d694301436137d0a48e6947') | 6.6769ms | SMWSql3SmwIds::warmUpCache

9 | SELECT page_id,page_len,page_is_redirect,page_latest,page_content_model FROM `page` WHERE page_namespace = '102' AND page_title = 'Modification_date' LIMIT 1 | 1.4091ms | LinkCache::fetchPageRow
```

### After

```
7 | SELECT smw_id,smw_title,smw_namespace,smw_iw,smw_subobject,smw_sortkey,smw_sort,smw_hash FROM `smw_object_ids` WHERE smw_id IN ('1165','1166','1176','1281','1283','1284','1285','1287','1288','1289','1291','1292','1293','1177','1295','1296','1297','1298','1299','1300','1301','1302','1303','1304','1178','1305','1306','1307','1308','1309','1310','1311','1312','1313','1314','1180','1315','1316','1318','1319','1320','1321','1322','1323','1324','1326','1181','1327','1328','1329') | 10.7369ms | SMW\SQLStore\EntityStore\IdEntityFinder::fetchFromTable

8 | SELECT page_id,page_len,page_is_redirect,page_latest,page_content_model FROM `page` WHERE page_namespace = '102' AND page_title = 'Modification_date' LIMIT 1 | 0.9880ms | LinkCache::fetchPageRow
```