### PR TITLE
Check ID reference on delete but only for property tables, refs 3436

### DIFF
--- a/includes/storage/SQLStore/SMW_SQLStore3_Writers.php
+++ b/includes/storage/SQLStore/SMW_SQLStore3_Writers.php
@@ -107,7 +107,7 @@ class SMWSQLStore3Writers {
 			$this->doDelete( $id, $subject, $subobjectListFinder, $extensionList );
 			$this->doDataUpdate( $emptySemanticData );
 
-			if ( $this->store->service( 'PropertyTableIdReferenceFinder' )->hasResidualReferenceForId( $id ) === false ) {
+			if ( $this->store->service( 'PropertyTableIdReferenceFinder' )->hasResidualPropertyTableReference( $id ) === false ) {
 				// Mark subject/subobjects with a special IW, the final removal is being
 				// triggered by the `EntityRebuildDispatcher`
 				$this->store->getObjectIds()->updateInterwikiField(

--- a/src/SQLStore/PropertyTableIdReferenceFinder.php
+++ b/src/SQLStore/PropertyTableIdReferenceFinder.php
@@ -91,6 +91,22 @@ class PropertyTableIdReferenceFinder {
 	}
 
 	/**
+	 * @since 3.0
+	 *
+	 * @param integer $id
+	 *
+	 * @return boolean
+	 */
+	public function hasResidualPropertyTableReference( $id ) {
+
+		if ( $id == SQLStore::FIXED_PROPERTY_ID_UPPERBOUND ) {
+			return true;
+		}
+
+		return (bool)$this->findAtLeastOneActiveReferenceById( $id, false );
+	}
+
+	/**
 	 * @since 2.4
 	 *
 	 * @param integer $id
@@ -136,10 +152,11 @@ class PropertyTableIdReferenceFinder {
 	 * @since 2.4
 	 *
 	 * @param integer $id
+	 * @param boolean $secondary_ref
 	 *
 	 * @return DataItem|false
 	 */
-	public function findAtLeastOneActiveReferenceById( $id ) {
+	public function findAtLeastOneActiveReferenceById( $id, $secondary_ref = true ) {
 
 		$reference = false;
 
@@ -165,7 +182,7 @@ class PropertyTableIdReferenceFinder {
 			}
 		}
 
-		if ( !isset( $reference->s_id ) ) {
+		if ( $secondary_ref && !isset( $reference->s_id ) ) {
 			$reference = $this->findQueryLinksTableReferenceById( $id );
 		}
 

--- a/tests/phpunit/Unit/SQLStore/PropertyTableIdReferenceFinderTest.php
+++ b/tests/phpunit/Unit/SQLStore/PropertyTableIdReferenceFinderTest.php
@@ -111,6 +111,34 @@ class PropertyTableIdReferenceFinderTest extends \PHPUnit_Framework_TestCase {
 		$instance->tryToFindAtLeastOneReferenceForProperty( new DIProperty( 'Foo' ) );
 	}
 
+	public function testHasResidualPropertyTableReference() {
+
+		$connection = $this->getMockBuilder( '\SMW\MediaWiki\Database' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$connection->expects( $this->any() )
+			->method( 'selectRow' )
+			->will( $this->returnValue( false ) );
+
+		$this->store->expects( $this->any() )
+			->method( 'getConnection' )
+			->will( $this->returnValue( $connection ) );
+
+		$this->store->expects( $this->any() )
+			->method( 'getPropertyTables' )
+			->will( $this->returnValue( [] ) );
+
+		$instance = new PropertyTableIdReferenceFinder(
+			$this->store
+		);
+
+		$this->assertInternalType(
+			'boolean',
+			$instance->hasResidualPropertyTableReference( 42 )
+		);
+	}
+
 	public function testHasResidualReferenceFor() {
 
 		$connection = $this->getMockBuilder( '\SMW\MediaWiki\Database' )


### PR DESCRIPTION
This PR is made in reference to: #3436

This PR addresses or contains:

- Avoid using secondary tables (such as the query links table) to check whether a reference to an ID still exists (being residual) or not during a delete event 
- Makes the #3436 more strict in terms of what defines a residual reference

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed
