### PR TITLE
UpdateDispatcherJob to update tracked queries, refs 3340

### DIFF
--- a/src/MediaWiki/Hooks/ArticleDelete.php
+++ b/src/MediaWiki/Hooks/ArticleDelete.php
@@ -91,6 +91,12 @@ class ArticleDelete extends HookHandler {
 
 		$parameters['origin'] = 'ArticleDelete';
 
+		// Fetch the ID before the delete process marks it as outdated to help
+		// run a dispatch process on secondary tables
+		$parameters['_id'] = $this->store->getObjectIds()->getId(
+			$subject
+		);
+
 		// Restricted to the available SemanticData
 		$parameters[UpdateDispatcherJob::RESTRICTED_DISPATCH_POOL] = true;
 

--- a/src/SQLStore/QueryDependency/QueryDependencyLinksStore.php
+++ b/src/SQLStore/QueryDependency/QueryDependencyLinksStore.php
@@ -266,6 +266,40 @@ class QueryDependencyLinksStore {
 	}
 
 	/**
+	 * @since 3.0
+	 *
+	 * @param integer|array $id
+	 *
+	 * @return integer
+	 */
+	public function countDependencies( $id ) {
+
+		$count = 0;
+		$ids = !is_array( $id ) ? (array)$id : $id;
+
+		if ( $ids === [] || !$this->isEnabled() ) {
+			return $count;
+		}
+
+		$connection = $this->store->getConnection( 'mw.db' );
+
+		$row = $connection->selectRow(
+			SQLStore::QUERY_LINKS_TABLE,
+			[
+				'COUNT(s_id) AS count'
+			],
+			[
+				'o_id' => $ids
+			],
+			__METHOD__
+		);
+
+		$count = $row ? $row->count : $count;
+
+		return (int)$count;
+	}
+
+	/**
 	 * Finds a partial list (given limit and offset) of registered subjects that
 	 * that represent a dependency on something like a subject in a query list,
 	 * a property, or a printrequest.

--- a/tests/phpunit/Unit/MediaWiki/Hooks/ArticleDeleteTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Hooks/ArticleDeleteTest.php
@@ -64,6 +64,10 @@ class ArticleDeleteTest extends \PHPUnit_Framework_TestCase {
 
 	public function testProcess() {
 
+		$idTable = $this->getMockBuilder( '\SMWSql3SmwIds' )
+			->disableOriginalConstructor()
+			->getMock();
+
 		$updateDispatcherJob = $this->getMockBuilder( '\SMW\MediaWiki\Jobs\UpdateDispatcherJob' )
 			->disableOriginalConstructor()
 			->getMock();
@@ -74,9 +78,9 @@ class ArticleDeleteTest extends \PHPUnit_Framework_TestCase {
 
 		$subject = DIWikiPage::newFromText( __METHOD__ );
 
-		$store = $this->getMockBuilder( '\SMW\Store' )
+		$store = $this->getMockBuilder( '\SMW\SQLStore\SQLStore' )
 			->disableOriginalConstructor()
-			->getMockForAbstractClass();
+			->getMock();
 
 		$store->expects( $this->atLeastOnce() )
 			->method( 'deleteSubject' );
@@ -84,6 +88,10 @@ class ArticleDeleteTest extends \PHPUnit_Framework_TestCase {
 		$store->expects( $this->atLeastOnce() )
 			->method( 'getInProperties' )
 			->will( $this->returnValue( [ new DIProperty( 'Foo' ) ] ) );
+
+		$store->expects( $this->atLeastOnce() )
+			->method( 'getObjectIds' )
+			->will( $this->returnValue( $idTable ) );
 
 		$wikiPage = $this->getMockBuilder( '\WikiPage' )
 			->disableOriginalConstructor()

--- a/tests/phpunit/Unit/SQLStore/QueryDependency/QueryDependencyLinksStoreTest.php
+++ b/tests/phpunit/Unit/SQLStore/QueryDependency/QueryDependencyLinksStoreTest.php
@@ -441,6 +441,52 @@ class QueryDependencyLinksStoreTest extends \PHPUnit_Framework_TestCase {
 		$instance->findDependencyTargetLinksForSubject( DIWikiPage::newFromText( 'Foo' ), $requestOptions );
 	}
 
+	public function testCountDependencies() {
+
+		$row = new \stdClass;
+		$row->count = 1001;
+
+		$dependencyLinksTableUpdater = $this->getMockBuilder( '\SMW\SQLStore\QueryDependency\DependencyLinksTableUpdater' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$queryResultDependencyListResolver = $this->getMockBuilder( '\SMW\SQLStore\QueryDependency\QueryResultDependencyListResolver' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$connection = $this->getMockBuilder( '\SMW\MediaWiki\Database' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$connection->expects( $this->once() )
+			->method( 'selectRow' )
+			->with(
+				$this->equalTo( \SMWSQLStore3::QUERY_LINKS_TABLE ),
+				$this->anything(),
+				$this->equalTo( [ 'o_id' => [ 42 ] ] ) )
+			->will( $this->returnValue( $row ) );
+
+		$store = $this->getMockBuilder( '\SMW\SQLStore\SQLStore' )
+			->disableOriginalConstructor()
+			->setMethods( [ 'getConnection' ] )
+			->getMock();
+
+		$store->expects( $this->any() )
+			->method( 'getConnection' )
+			->will( $this->returnValue( $connection ) );
+
+		$dependencyLinksTableUpdater->expects( $this->any() )
+			->method( 'getStore' )
+			->will( $this->returnValue( $store ) );
+
+		$instance = new QueryDependencyLinksStore(
+			$queryResultDependencyListResolver,
+			$dependencyLinksTableUpdater
+		);
+
+		$instance->countDependencies( 42 );
+	}
+
 	public function testTryDoUpdateDependenciesByWhileBeingDisabled() {
 
 		$store = $this->getMockBuilder( '\SMW\Store' )


### PR DESCRIPTION
This PR is made in reference to: #3340

This PR addresses or contains:

- While #3340 reduced the amount of unrelated subjects that require an update it also prevents all non-user defined properties from being used as identifying body for a subject list
- For users who track queries via `QueryDependencyLinksStore` this PR will make sure that referenced queries will be selected as well and contribute to the list of subjects that require updates via the job queue where the entity in question (the one deleted for example) is part of the query result

This PR includes:
- [ ] Tests (unit/integration)
- [x] CI build passed
