### PR TITLE
Consolidate factbox setting `smwgFactboxFeatures`, refs 2798

### DIFF
--- a/DefaultSettings.php
+++ b/DefaultSettings.php
@@ -333,21 +333,39 @@ return array(
 	##
 
 	###
+	# Specifies features supported by the in-page factbox
+	#
+	# - SMW_FACTBOX_CACHE to use the main cache to avoid reparsing the content on
+	#   each page view (replaced smwgFactboxUseCache)
+	#
+	# - SMW_FACTBOX_PURGE_REFRESH to refresh the faxtbox content on the purge
+	#   event (replaced smwgFactboxCacheRefreshOnPurge)
+	#
+	# - SMW_FACTBOX_DISPLAY_SUBOBJECT displays subobject references
+	#
+	# @since 3.0
+	##
+	'smwgFactboxFeatures' => SMW_FACTBOX_CACHE | SMW_FACTBOX_PURGE_REFRESH | SMW_FACTBOX_DISPLAY_SUBOBJECT,
+
+	###
 	# This setting allows you to select in which cases you want to have a factbox
-	# appear below an article. Note that the Magic Words __SHOWFACTBOX__ and
-	# __HIDEFACTBOX__ can be used to control Factbox display for individual pages.
-	# Other options for this setting include:
+	# appear below an article and includes the following options:
+	#
+	# - SMW_FACTBOX_NONEMPTY show only those factboxes that have some content
+	# - SMW_FACTBOX_SPECIAL show only if special properties were set
+	# - SMW_FACTBOX_HIDDEN hide always
+	# - SMW_FACTBOX_SHOWN  show always
+	#
+	# @note  The Magic Words __SHOWFACTBOX__ and __HIDEFACTBOX__ can be used to
+	# control Factbox display for individual pages.
 	#
 	# @since 0.7
 	##
-	// 	'smwgShowFactbox' => SMW_FACTBOX_NONEMPTY, 	# show only those factboxes that have some content
-	// 	'smwgShowFactbox' => SMW_FACTBOX_SPECIAL 	# show only if special properties were set
-	'smwgShowFactbox' => SMW_FACTBOX_HIDDEN, 	# hide always
-	// 	'smwgShowFactbox' => SMW_FACTBOX_SHOWN,  	# show always, buggy and not recommended
+	'smwgShowFactbox' => SMW_FACTBOX_HIDDEN,
 	##
 
 	###
-	# Same as $smwgShowFactbox but for edit mode and same possible values.
+	# Same as $smwgShowFactbox but for the edit mode with same possible values.
 	#
 	# @since 1.0
 	##
@@ -1197,39 +1215,6 @@ return array(
 	# default = true (legacy behaviour)
 	##
 	'smwgPropertyZeroCountDisplay' => true,
-	##
-
-	###
-	# Sets whether or not a factbox content should be stored in cache. This will
-	# considerable improve page response time as non-changed page content will
-	# not cause re-parsing of factbox content and instead is served directly from
-	# cache while only a new revision will trigger to re-parse the factbox.
-	#
-	# If smwgFactboxUseCache is set false (equals legacy behaviour) then every page
-	# request will bind the factbox to be re-parsed.
-	#
-	# @since 1.9
-	#
-	# @requires $smwgMainCacheType be set
-	# @default true
-	##
-	'smwgFactboxUseCache' => true,
-	##
-
-	###
-	# Sets whether or not a cached factbox should be invalidated on an action=purge
-	# event
-	#
-	# If set false the factbox cache will be only reset after a new page revision
-	# but if set true each purge request (no new page revision) will invalidate
-	# the factbox cache
-	#
-	# @since 1.9
-	#
-	# @requires $smwgMainCacheType be set
-	# @default true
-	##
-	'smwgFactboxCacheRefreshOnPurge' => true,
 	##
 
 	###

--- a/includes/Settings.php
+++ b/includes/Settings.php
@@ -65,6 +65,7 @@ class Settings extends Options {
 			'smwgSparqlReplicationPropertyExemptionList' => $GLOBALS['smwgSparqlReplicationPropertyExemptionList'],
 			'smwgSparqlQFeatures' => $GLOBALS['smwgSparqlQFeatures'],
 			'smwgNamespaceIndex' => $GLOBALS['smwgNamespaceIndex'],
+			'smwgFactboxFeatures' => $GLOBALS['smwgFactboxFeatures'],
 			'smwgShowFactbox' => $GLOBALS['smwgShowFactbox'],
 			'smwgShowFactboxEdit' => $GLOBALS['smwgShowFactboxEdit'],
 			'smwgCompactLinkSupport' => $GLOBALS['smwgCompactLinkSupport'],
@@ -137,8 +138,6 @@ class Settings extends Options {
 			'smwgFixedProperties' => $GLOBALS['smwgFixedProperties'],
 			'smwgPropertyLowUsageThreshold' => $GLOBALS['smwgPropertyLowUsageThreshold'],
 			'smwgPropertyZeroCountDisplay' => $GLOBALS['smwgPropertyZeroCountDisplay'],
-			'smwgFactboxUseCache' => $GLOBALS['smwgFactboxUseCache'],
-			'smwgFactboxCacheRefreshOnPurge' => $GLOBALS['smwgFactboxCacheRefreshOnPurge'],
 			'smwgQueryProfiler' => $GLOBALS['smwgQueryProfiler'],
 			'smwgEnabledSpecialPage' => $GLOBALS['smwgEnabledSpecialPage'],
 			'smwgFallbackSearchType' => $GLOBALS['smwgFallbackSearchType'],
@@ -310,6 +309,15 @@ class Settings extends Options {
 
 		if ( isset( $GLOBALS['smwgShowHiddenCategories'] ) && $GLOBALS['smwgShowHiddenCategories'] === false ) {
 			$configuration['smwgParserFeatures'] = $configuration['smwgParserFeatures'] & ~SMW_PARSER_HID_CATS;
+		}
+
+		// smwgFactboxFeatures
+		if ( isset( $GLOBALS['smwgFactboxUseCache'] ) && $GLOBALS['smwgFactboxUseCache'] === false ) {
+			$configuration['smwgFactboxFeatures'] = $configuration['smwgFactboxFeatures'] & ~SMW_FACTBOX_CACHE;
+		}
+
+		if ( isset( $GLOBALS['smwgFactboxCacheRefreshOnPurge'] ) && $GLOBALS['smwgFactboxCacheRefreshOnPurge'] === false ) {
+			$configuration['smwgFactboxFeatures'] = $configuration['smwgFactboxFeatures'] & ~SMW_FACTBOX_PURGE_REFRESH;
 		}
 
 		// smwgLinksInValues
@@ -523,6 +531,8 @@ class Settings extends Options {
 				'smwgSparqlUpdateEndpoint' => '3.1.0',
 				'smwgSparqlDataEndpoint' => '3.1.0',
 				'smwgCacheType' => '3.1.0',
+				'smwgFactboxUseCache' => '3.1.0',
+				'smwgFactboxCacheRefreshOnPurge' => '3.1.0',
 				'options' => [
 					'smwgCacheUsage' =>  [
 						'smwgStatisticsCache' => '3.1.0',
@@ -573,6 +583,8 @@ class Settings extends Options {
 				'smwgSparqlUpdateEndpoint' => 'smwgSparqlEndpoint',
 				'smwgSparqlDataEndpoint' => 'smwgSparqlEndpoint',
 				'smwgCacheType' => 'smwgMainCacheType',
+				'smwgFactboxUseCache' => 'smwgFactboxFeatures',
+				'smwgFactboxCacheRefreshOnPurge' => 'smwgFactboxFeatures',
 				'options' => [
 					'smwgCacheUsage' => [
 						'smwgStatisticsCacheExpiry' => 'special.statistics',

--- a/src/CacheFactory.php
+++ b/src/CacheFactory.php
@@ -58,22 +58,6 @@ class CacheFactory {
 	 *
 	 * @return string
 	 */
-	public static function getFactboxCacheKey( $key ) {
-
-		if ( $key instanceof Title ) {
-			$key = $key->getArticleID();
-		}
-
-		return self::getCachePrefix() . ':smw:fc:' . md5( $key );
-	}
-
-	/**
-	 * @since 2.2
-	 *
-	 * @param Title|integer|string $key
-	 *
-	 * @return string
-	 */
 	public static function getPurgeCacheKey( $key ) {
 
 		if ( $key instanceof Title ) {

--- a/src/Defines.php
+++ b/src/Defines.php
@@ -37,6 +37,11 @@ define( 'SMW_FACTBOX_HIDDEN', 1 );
 define( 'SMW_FACTBOX_SPECIAL', 2 );
 define( 'SMW_FACTBOX_NONEMPTY', 3 );
 define( 'SMW_FACTBOX_SHOWN', 5 );
+
+define( 'SMW_FACTBOX_CACHE', 16 );
+define( 'SMW_FACTBOX_PURGE_REFRESH', 32 );
+define( 'SMW_FACTBOX_DISPLAY_SUBOBJECT', 64 );
+
 /**@}*/
 
 /**@{

--- a/src/EventListenerRegistry.php
+++ b/src/EventListenerRegistry.php
@@ -62,7 +62,7 @@ class EventListenerRegistry implements EventListenerCollection {
 				$applicationFactory = ApplicationFactory::getInstance();
 
 				$applicationFactory->getCache()->delete(
-					$applicationFactory->newCacheFactory()->getFactboxCacheKey( $title )
+					\SMW\Factbox\CachedFactbox::makeCacheKey( $title )
 				);
 			}
 		);

--- a/src/Factbox/CachedFactbox.php
+++ b/src/Factbox/CachedFactbox.php
@@ -8,12 +8,10 @@ use ParserOutput;
 use SMW\ApplicationFactory;
 use SMW\Parser\InTextAnnotationParser;
 use Title;
+use Language;
 
 /**
  * Factbox output caching
- *
- * Enable ($smwgFactboxUseCache) to use a CacheStore to avoid unaltered
- * content being re-parsed every time the OutputPage hook is executed
  *
  * @license GNU GPL v2+
  * @since 1.9
@@ -22,15 +20,12 @@ use Title;
  */
 class CachedFactbox {
 
+	const CACHE_NAMESPACE = 'smw:fc';
+
 	/**
 	 * @var Cache
 	 */
-	private $cache = null;
-
-	/**
-	 * @var CacheFactory
-	 */
-	private $cacheFactory = null;
+	private $cache;
 
 	/**
 	 * @var boolean
@@ -45,6 +40,11 @@ class CachedFactbox {
 	/**
 	 * @var integer
 	 */
+	private $featureSet = 0;
+
+	/**
+	 * @var integer
+	 */
 	private $expiryInSeconds = 0;
 
 	/**
@@ -55,16 +55,26 @@ class CachedFactbox {
 	/**
 	 * @since 1.9
 	 *
-	 * @param Cache|null $cache
+	 * @param Cache $cache
 	 */
-	public function __construct( Cache $cache = null ) {
+	public function __construct( Cache $cache ) {
 		$this->cache = $cache;
+	}
 
-		$this->cacheFactory = ApplicationFactory::getInstance()->getCacheFactory();
+	/**
+	 * @since 3.0
+	 *
+	 * @param Title|integer $id
+	 *
+	 * @return string
+	 */
+	public static function makeCacheKey( $id ) {
 
-		if ( $this->cache === null ) {
-			$this->cache = $this->cacheFactory->newNullCache();
+		if ( $id instanceof Title ) {
+			$id = $id->getArticleID();
 		}
+
+		return smwfCacheKey( self::CACHE_NAMESPACE, $id );
 	}
 
 	/**
@@ -74,6 +84,15 @@ class CachedFactbox {
 	 */
 	public function isCached() {
 		return $this->isCached;
+	}
+
+	/**
+	 * @since 3.0
+	 *
+	 * @param integer $featureSet
+	 */
+	public function setFeatureSet( $featureSet ) {
+		$this->featureSet = $featureSet;
 	}
 
 	/**
@@ -115,25 +134,24 @@ class CachedFactbox {
 	 * @since 1.9
 	 *
 	 * @param OutputPage &$outputPage
+	 * @param Language $language
 	 * @param ParserOutput $parserOutput
 	 */
-	public function prepareFactboxContent( OutputPage &$outputPage, ParserOutput $parserOutput ) {
+	public function prepareFactboxContent( OutputPage &$outputPage, Language $language, ParserOutput $parserOutput ) {
 
 		$content = '';
 		$title = $outputPage->getTitle();
 
-		$revId = $this->findRevId( $title, $outputPage->getContext() );
-		$lang = $outputPage->getContext()->getLanguage()->getCode();
+		$rev_id = $this->findRevId( $title, $outputPage->getContext() );
+		$lang = $language->getCode();
 
-		$key = $this->cacheFactory->getFactboxCacheKey(
-			$title->getArticleID()
-		);
+		$key = self::makeCacheKey( $title );
 
 		if ( $this->cache->contains( $key ) ) {
 			$content = $this->retrieveFromCache( $key );
 		}
 
-		if ( $this->hasCachedContent( $revId, $lang, $content, $outputPage->getContext() ) ) {
+		if ( $this->hasCachedContent( $rev_id, $lang, $content, $outputPage->getContext() ) ) {
 			return $outputPage->mSMWFactboxText = $content['text'];
 		}
 
@@ -146,8 +164,9 @@ class CachedFactbox {
 		$this->addContentToCache(
 			$key,
 			$text,
-			$revId,
-			$lang
+			$rev_id,
+			$lang,
+			$this->featureSet
 		);
 
 		$outputPage->mSMWFactboxText = $text;
@@ -160,12 +179,13 @@ class CachedFactbox {
 	 * @param string $text
 	 * @param integer|null $revisionId
 	 */
-	public function addContentToCache( $key, $text, $revisionId = null, $lang = 'en' ) {
+	public function addContentToCache( $key, $text, $revisionId = null, $lang = 'en', $fset = null ) {
 		$this->saveToCache(
 			$key,
 			[
 				'revId' => $revisionId,
 				'lang'  => $lang,
+				'fset'  => $fset,
 				'text'  => $text
 			]
 		);
@@ -194,11 +214,10 @@ class CachedFactbox {
 			$text = $outputPage->mSMWFactboxText;
 		} elseif ( $title instanceof Title ) {
 
-			$key = $this->cacheFactory->getFactboxCacheKey(
-				$title->getArticleID()
+			$content = $this->retrieveFromCache(
+				self::makeCacheKey( $title )
 			);
 
-			$content = $this->retrieveFromCache( $key );
 			$text = isset( $content['text'] ) ? $content['text'] : '';
 		}
 
@@ -227,7 +246,8 @@ class CachedFactbox {
 		$applicationFactory = ApplicationFactory::getInstance();
 
 		$factbox = $applicationFactory->singleton( 'FactboxFactory' )->newFactbox(
-			$applicationFactory->newParserData( $title, $parserOutput )
+			$title,
+			$parserOutput
 		);
 
 		$factbox->setPreviewFlag(
@@ -256,7 +276,10 @@ class CachedFactbox {
 		}
 
 		if ( $revId !== 0 && isset( $content['revId'] ) && ( $content['revId'] === $revId ) && $content['text'] !== null ) {
-			if ( isset( $content['lang'] ) && ( $content['lang'] === $lang ) ) {
+
+			if (
+				( isset( $content['lang'] ) && $content['lang'] === $lang ) &&
+				( isset( $content['fset'] ) && $content['fset'] === $this->featureSet )  ) {
 				return $this->isCached = true;
 			}
 		}

--- a/src/Factbox/Factbox.php
+++ b/src/Factbox/Factbox.php
@@ -4,6 +4,7 @@ namespace SMW\Factbox;
 
 use Html;
 use Sanitizer;
+use Title;
 use SMW\ApplicationFactory;
 use SMW\DataValueFactory;
 use SMW\DIProperty;
@@ -50,6 +51,11 @@ class Factbox {
 	private $dataValueFactory;
 
 	/**
+	 * @var integer
+	 */
+	private $featureSet = 0;
+
+	/**
 	 * @var boolean
 	 */
 	protected $isVisible = false;
@@ -75,6 +81,15 @@ class Factbox {
 		$this->parserData = $parserData;
 		$this->applicationFactory = ApplicationFactory::getInstance();
 		$this->dataValueFactory = DataValueFactory::getInstance();
+	}
+
+	/**
+	 * @since 3.0
+	 *
+	 * @param integer $featureSet
+	 */
+	public function setFeatureSet( $featureSet ) {
+		$this->featureSet = $featureSet;
 	}
 
 	/**
@@ -356,6 +371,11 @@ class Factbox {
 		);
 
 		foreach ( $semanticData->getProperties() as $property ) {
+
+			if ( $property->getKey() === '_SOBJ' && !$this->hasFeature( SMW_FACTBOX_DISPLAY_SUBOBJECT ) ) {
+				continue;
+			}
+
 			$propertyDv = $this->dataValueFactory->newDataValueByItem( $property, null );
 			$row = '';
 
@@ -431,6 +451,11 @@ class Factbox {
 		);
 
 		return $semanticData->isEmpty();
+	}
+
+
+	private function hasFeature( $feature ) {
+		return ( (int)$this->featureSet & $feature ) != 0;
 	}
 
 }

--- a/src/Factbox/FactboxFactory.php
+++ b/src/Factbox/FactboxFactory.php
@@ -5,7 +5,8 @@ namespace SMW\Factbox;
 use IContextSource;
 use OutputPage;
 use SMW\ApplicationFactory;
-use SMW\ParserData;
+use Title;
+use ParserOutput;
 
 /**
  * @license GNU GPL v2+
@@ -23,10 +24,11 @@ class FactboxFactory {
 	public function newCachedFactbox() {
 
 		$applicationFactory = ApplicationFactory::getInstance();
+		$settings = $applicationFactory->getSettings();
 
 		$cachedFactbox = new CachedFactbox(
 			$applicationFactory->getCache(
-				$applicationFactory->getSettings()->get( 'smwgMainCacheType' )
+				$settings->get( 'smwgMainCacheType' )
 			)
 		);
 
@@ -34,7 +36,11 @@ class FactboxFactory {
 		$cachedFactbox->setExpiryInSeconds( 2592000 );
 
 		$cachedFactbox->isEnabled(
-			$applicationFactory->getSettings()->get( 'smwgFactboxUseCache' )
+			$settings->isFlagSet( 'smwgFactboxFeatures', SMW_FACTBOX_CACHE )
+		);
+
+		$cachedFactbox->setFeatureSet(
+			$settings->get( 'smwgFactboxFeatures' )
 		);
 
 		return $cachedFactbox;
@@ -43,15 +49,25 @@ class FactboxFactory {
 	/**
 	 * @since 2.0
 	 *
-	 * @param ParserData $parserData
+	 * @param Title $title
+	 * @param ParserOutput $parserOutput
 	 *
 	 * @return Factbox
 	 */
-	public function newFactbox( ParserData $parserData ) {
-		return new Factbox(
-			ApplicationFactory::getInstance()->getStore(),
-			$parserData
+	public function newFactbox( Title $title, ParserOutput $parserOutput ) {
+
+		$applicationFactory = ApplicationFactory::getInstance();
+
+		$factbox = new Factbox(
+			$applicationFactory->getStore(),
+			$applicationFactory->newParserData( $title, $parserOutput )
 		);
+
+		$factbox->setFeatureSet(
+			$applicationFactory->getSettings()->get( 'smwgFactboxFeatures' )
+		);
+
+		return $factbox;
 	}
 
 }

--- a/src/MediaWiki/Hooks/ArticlePurge.php
+++ b/src/MediaWiki/Hooks/ArticlePurge.php
@@ -49,7 +49,7 @@ class ArticlePurge {
 		$dispatchContext->set( 'title', $wikiPage->getTitle() );
 		$dispatchContext->set( 'context', 'ArticlePurge' );
 
-		if ( $settings->get( 'smwgFactboxCacheRefreshOnPurge' ) ) {
+		if ( $settings->isFlagSet( 'smwgFactboxFeatures', SMW_FACTBOX_PURGE_REFRESH ) ) {
 			EventHandler::getInstance()->getEventDispatcher()->dispatch(
 				'factbox.cache.delete',
 				$dispatchContext

--- a/src/MediaWiki/Hooks/OutputPageParserOutput.php
+++ b/src/MediaWiki/Hooks/OutputPageParserOutput.php
@@ -67,11 +67,11 @@ class OutputPageParserOutput {
 
 		$request = $this->outputPage->getContext()->getRequest();
 
-		$this->execFactbox( $request );
-		$this->execPostProc( $title, $request );
+		$this->factbox( $request );
+		$this->postProc( $title, $request );
 	}
 
-	private function execPostProc( $title, $request) {
+	private function postProc( $title, $request) {
 
 		if ( in_array( $request->getVal( 'action' ), [ 'delete', 'purge', 'protect', 'unprotect', 'history', 'edit' ] ) ) {
 			return '';
@@ -92,7 +92,7 @@ class OutputPageParserOutput {
 		}
 	}
 
-	protected function execFactbox( $request ) {
+	protected function factbox( $request ) {
 
 		if ( isset( $this->outputPage->mSMWFactboxText ) && $request->getCheck( 'wpPreview' ) ) {
 			return '';
@@ -104,6 +104,7 @@ class OutputPageParserOutput {
 
 		$cachedFactbox->prepareFactboxContent(
 			$this->outputPage,
+			$this->outputPage->getLanguage(),
 			$this->getParserOutput()
 		);
 

--- a/tests/phpunit/Integration/SemanticMediaWikiProvidedHookInterfaceIntegrationTest.php
+++ b/tests/phpunit/Integration/SemanticMediaWikiProvidedHookInterfaceIntegrationTest.php
@@ -192,19 +192,19 @@ class SemanticMediaWikiProvidedHookInterfaceIntegrationTest extends \PHPUnit_Fra
 			return false;
 		} );
 
-		$parserData = $this->getMockBuilder( '\SMW\ParserData' )
+		$title = $this->getMockBuilder( '\Title' )
 			->disableOriginalConstructor()
 			->getMock();
 
-		$parserData->expects( $this->any() )
-			->method( 'getOutput' )
-			->will( $this->returnValue( new \ParserOutput() ) );
+		$title->expects( $this->any() )
+			->method( 'getNamespace' )
+			->will( $this->returnValue(  NS_MAIN ) );
 
-		$parserData->expects( $this->once() )
-			->method( 'getSubject' )
-			->will( $this->returnValue( new DIWikiPage( 'Foo', NS_MAIN ) ) );
+		$title->expects( $this->once() )
+			->method( 'getDBKey' )
+			->will( $this->returnValue( 'Foo' ) );
 
-		$instance = $this->applicationFactory->singleton( 'FactboxFactory' )->newFactbox( $parserData );
+		$instance = $this->applicationFactory->singleton( 'FactboxFactory' )->newFactbox( $title, new \ParserOutput() );
 		$instance->doBuild();
 
 		$this->assertEquals(

--- a/tests/phpunit/Unit/CacheFactoryTest.php
+++ b/tests/phpunit/Unit/CacheFactoryTest.php
@@ -54,24 +54,6 @@ class CacheFactoryTest extends \PHPUnit_Framework_TestCase {
 		);
 	}
 
-	public function testGetFactboxCacheKey() {
-
-		$title = $this->getMockBuilder( '\Title' )
-			->disableOriginalConstructor()
-			->getMock();
-
-		$title->expects( $this->once() )
-			->method( 'getArticleID' )
-			->will( $this->returnValue( 42 ) );
-
-		$instance = new CacheFactory( 'hash' );
-
-		$this->assertInternalType(
-			'string',
-			$instance->getFactboxCacheKey( $title )
-		);
-	}
-
 	public function testGetPurgeCacheKey() {
 
 		$title = $this->getMockBuilder( '\Title' )

--- a/tests/phpunit/Unit/Factbox/CachedFactboxTest.php
+++ b/tests/phpunit/Unit/Factbox/CachedFactboxTest.php
@@ -34,8 +34,8 @@ class CachedFactboxTest extends \PHPUnit_Framework_TestCase {
 
 		$this->testEnvironment->withConfiguration(
 			[
-				'smwgFactboxUseCache' => true,
-				'smwgMainCacheType'       => 'hash'
+				'smwgFactboxFeatures' => SMW_FACTBOX_CACHE | SMW_FACTBOX_PURGE_REFRESH | SMW_FACTBOX_DISPLAY_SUBOBJECT,
+				'smwgMainCacheType' => 'hash'
 			]
 		);
 	}
@@ -72,12 +72,18 @@ class CachedFactboxTest extends \PHPUnit_Framework_TestCase {
 			$parameters['smwgShowFactbox']
 		);
 
+		$this->testEnvironment->addConfiguration(
+			'smwgFactboxFeatures',
+			$parameters['smwgFactboxFeatures']
+		);
+
 		$this->testEnvironment->registerObject( 'Store', $parameters['store'] );
 
 		$outputPage = $parameters['outputPage'];
 
 		$instance = new CachedFactbox( $this->memoryCache );
 		$instance->isEnabled( true );
+		$instance->setFeatureSet( $parameters['smwgFactboxFeatures'] );
 
 		$this->assertEmpty(
 			$instance->retrieveContent( $outputPage )
@@ -85,6 +91,7 @@ class CachedFactboxTest extends \PHPUnit_Framework_TestCase {
 
 		$instance->prepareFactboxContent(
 			$outputPage,
+			$parameters['language'],
 			$parameters['parserOutput']
 		);
 
@@ -100,6 +107,7 @@ class CachedFactboxTest extends \PHPUnit_Framework_TestCase {
 		// Re-run on the same instance
 		$instance->prepareFactboxContent(
 			$outputPage,
+			$parameters['language'],
 			$parameters['parserOutput']
 		);
 
@@ -242,9 +250,11 @@ class CachedFactboxTest extends \PHPUnit_Framework_TestCase {
 		$provider[] = [
 			[
 				'smwgNamespacesWithSemanticLinks' => [ NS_MAIN => true ],
+				'smwgFactboxFeatures' => SMW_FACTBOX_CACHE | SMW_FACTBOX_PURGE_REFRESH | SMW_FACTBOX_DISPLAY_SUBOBJECT,
 				'smwgShowFactbox' => SMW_FACTBOX_NONEMPTY,
 				'outputPage'      => $outputPage,
 				'store'           => $store,
+				'language'        => $language,
 				'parserOutput'    => $this->makeParserOutput( $semanticData )
 			],
 			[
@@ -293,9 +303,11 @@ class CachedFactboxTest extends \PHPUnit_Framework_TestCase {
 		$provider[] = [
 			[
 				'smwgNamespacesWithSemanticLinks' => [ NS_MAIN => true ],
+				'smwgFactboxFeatures' => SMW_FACTBOX_CACHE | SMW_FACTBOX_PURGE_REFRESH | SMW_FACTBOX_DISPLAY_SUBOBJECT,
 				'smwgShowFactbox' => SMW_FACTBOX_NONEMPTY,
 				'outputPage'      => $outputPage,
 				'store'           => $store,
+				'language'        => $language,
 				'parserOutput'    => $this->makeParserOutput( $semanticData )
 			],
 			[
@@ -337,9 +349,11 @@ class CachedFactboxTest extends \PHPUnit_Framework_TestCase {
 		$provider[] = [
 			[
 				'smwgNamespacesWithSemanticLinks' => [ NS_MAIN => false ],
+				'smwgFactboxFeatures' => SMW_FACTBOX_CACHE | SMW_FACTBOX_PURGE_REFRESH | SMW_FACTBOX_DISPLAY_SUBOBJECT,
 				'smwgShowFactbox' => SMW_FACTBOX_HIDDEN,
 				'outputPage'      => $outputPage,
 				'store'           => $store,
+				'language'        => $language,
 				'parserOutput'    => $this->makeParserOutput( $semanticData )
 			],
 			[
@@ -397,9 +411,11 @@ class CachedFactboxTest extends \PHPUnit_Framework_TestCase {
 		$provider[] = [
 			[
 				'smwgNamespacesWithSemanticLinks' => [ NS_MAIN => true ],
+				'smwgFactboxFeatures' => SMW_FACTBOX_CACHE | SMW_FACTBOX_PURGE_REFRESH | SMW_FACTBOX_DISPLAY_SUBOBJECT,
 				'smwgShowFactbox' => SMW_FACTBOX_NONEMPTY,
 				'outputPage'      => $outputPage,
 				'store'           => $store,
+				'language'        => $language,
 				'parserOutput'    => $this->makeParserOutput( null ),
 			],
 			[
@@ -441,9 +457,11 @@ class CachedFactboxTest extends \PHPUnit_Framework_TestCase {
 		$provider[] = [
 			[
 				'smwgNamespacesWithSemanticLinks' => [ NS_MAIN => true ],
+				'smwgFactboxFeatures' => SMW_FACTBOX_CACHE | SMW_FACTBOX_PURGE_REFRESH | SMW_FACTBOX_DISPLAY_SUBOBJECT,
 				'smwgShowFactbox' => SMW_FACTBOX_NONEMPTY,
 				'outputPage'      => $outputPage,
 				'store'           => $store,
+				'language'        => $language,
 				'parserOutput'    => $this->makeParserOutput( null ),
 			],
 			[
@@ -485,9 +503,11 @@ class CachedFactboxTest extends \PHPUnit_Framework_TestCase {
 		$provider[] = [
 			[
 				'smwgNamespacesWithSemanticLinks' => [ NS_MAIN => true ],
+				'smwgFactboxFeatures' => SMW_FACTBOX_CACHE | SMW_FACTBOX_PURGE_REFRESH | SMW_FACTBOX_DISPLAY_SUBOBJECT,
 				'smwgShowFactbox' => SMW_FACTBOX_NONEMPTY,
 				'outputPage'      => $outputPage,
 				'store'           => $store,
+				'language'        => $language,
 				'parserOutput'    => $this->makeParserOutput( null ),
 			],
 			[

--- a/tests/phpunit/Unit/Factbox/FactboxFactoryTest.php
+++ b/tests/phpunit/Unit/Factbox/FactboxFactoryTest.php
@@ -36,7 +36,15 @@ class FactboxFactoryTest extends \PHPUnit_Framework_TestCase {
 
 	public function testCanConstructFactbox() {
 
-		$parserData = $this->getMockBuilder( '\SMW\ParserData' )
+		$title = $this->getMockBuilder( '\Title' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$title->expects( $this->any() )
+			->method( 'getNamespace' )
+			->will( $this->returnValue( NS_MAIN ) );
+
+		$parserOutput = $this->getMockBuilder( '\ParserOutput' )
 			->disableOriginalConstructor()
 			->getMock();
 
@@ -44,7 +52,7 @@ class FactboxFactoryTest extends \PHPUnit_Framework_TestCase {
 
 		$this->assertInstanceOf(
 			'\SMW\Factbox\Factbox',
-			$instance->newFactbox( $parserData )
+			$instance->newFactbox( $title, $parserOutput )
 		);
 	}
 

--- a/tests/phpunit/Unit/MediaWiki/Hooks/ArticlePurgeTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Hooks/ArticlePurgeTest.php
@@ -73,8 +73,8 @@ class ArticlePurgeTest extends \PHPUnit_Framework_TestCase {
 		);
 
 		$this->testEnvironment->addConfiguration(
-			'smwgFactboxCacheRefreshOnPurge',
-			$setup['smwgFactboxCacheRefreshOnPurge']
+			'smwgFactboxFeatures',
+			SMW_FACTBOX_PURGE_REFRESH
 		);
 
 		$this->testEnvironment->addConfiguration(
@@ -85,7 +85,7 @@ class ArticlePurgeTest extends \PHPUnit_Framework_TestCase {
 		$instance = new ArticlePurge();
 
 		$cacheFactory = $this->applicationFactory->newCacheFactory();
-		$factboxCacheKey = $cacheFactory->getFactboxCacheKey( $pageId );
+		$factboxCacheKey = \SMW\Factbox\CachedFactbox::makeCacheKey( $pageId );
 		$purgeCacheKey = $cacheFactory->getPurgeCacheKey( $pageId );
 
 		$this->assertEquals(

--- a/tests/phpunit/Unit/MediaWiki/Hooks/OutputPageParserOutputTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Hooks/OutputPageParserOutputTest.php
@@ -191,6 +191,10 @@ class OutputPageParserOutputTest extends \PHPUnit_Framework_TestCase {
 			->method( 'getContext' )
 			->will( $this->returnValue( new \RequestContext() ) );
 
+		$outputPage->expects( $this->atLeastOnce() )
+			->method( 'getLanguage' )
+			->will( $this->returnValue( $language ) );
+
 		$provider[] = [
 			[
 				'smwgNamespacesWithSemanticLinks' => [ NS_MAIN => true ],
@@ -321,6 +325,10 @@ class OutputPageParserOutputTest extends \PHPUnit_Framework_TestCase {
 		$outputPage->expects( $this->atLeastOnce() )
 			->method( 'getContext' )
 			->will( $this->returnValue( $context ) );
+
+		$outputPage->expects( $this->atLeastOnce() )
+			->method( 'getLanguage' )
+			->will( $this->returnValue( $language ) );
 
 		$provider[] = [
 			[

--- a/tests/phpunit/Unit/MediaWiki/Hooks/SkinAfterContentTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Hooks/SkinAfterContentTest.php
@@ -26,7 +26,7 @@ class SkinAfterContentTest extends \PHPUnit_Framework_TestCase {
 		$this->applicationFactory = ApplicationFactory::getInstance();
 
 		$settings = Settings::newFromArray( [
-			'smwgFactboxUseCache'  => true,
+			'smwgFactboxFeatures'  => SMW_FACTBOX_CACHE,
 			'smwgMainCacheType'        => 'hash',
 			'smwgSemanticsEnabled' => true
 		] );
@@ -77,7 +77,7 @@ class SkinAfterContentTest extends \PHPUnit_Framework_TestCase {
 			$cachedFactbox = $this->applicationFactory->create( 'FactboxFactory' )->newCachedFactbox();
 
 			$cachedFactbox->addContentToCache(
-				$this->applicationFactory->newCacheFactory()->getFactboxCacheKey( $parameters['title']->getArticleID() ),
+				$cachedFactbox->makeCacheKey( $parameters['title'] ),
 				$parameters['text']
 			);
 


### PR DESCRIPTION
This PR is made in reference to: #2798

This PR addresses or contains:

- Adds `smwgFactboxFeatures` and removes `smwgFactboxUseCache`, `smwgFactboxCacheRefreshOnPurge`
- Default setting for `smwgFactboxFeatures` is `SMW_FACTBOX_CACHE | SMW_FACTBOX_PURGE_REFRESH | SMW_FACTBOX_DISPLAY_SUBOBJECT` which is equivalent to the existing setting

This PR includes:
- [ ] Tests (unit/integration)
- [x] CI build passed
