### PR TITLE
Silence the TransactionProfiler, refs 1499

### DIFF
--- a/src/MediaWiki/Connection/ConnectionProvider.php
+++ b/src/MediaWiki/Connection/ConnectionProvider.php
@@ -116,8 +116,18 @@ class ConnectionProvider implements IConnectionProvider {
 			);
 		}
 
+		$transactionProfiler = new TransactionProfiler(
+			\Profiler::instance()->getTransactionProfiler()
+		);
+
+		$transactionProfiler->silenceTransactionProfiler();
+
 		$connection = new Database(
 			new ConnectionProviderRef( $connectionProviders )
+		);
+
+		$connection->setTransactionProfiler(
+			$transactionProfiler
 		);
 
 		// Only required because of SQlite

--- a/src/MediaWiki/Connection/Database.php
+++ b/src/MediaWiki/Connection/Database.php
@@ -61,9 +61,9 @@ class Database {
 	private $dbPrefix = '';
 
 	/**
-	 * @var boolean
+	 * @var TransactionProfiler
 	 */
-	private $resetTransactionProfiler = false;
+	private $transactionProfiler;
 
 	/**
 	 * @var boolean
@@ -93,6 +93,15 @@ class Database {
 		if ( $this->loadBalancerFactory === null ) {
 			$this->loadBalancerFactory = ApplicationFactory::getInstance()->create( 'DBLoadBalancerFactory' );
 		}
+	}
+
+	/**
+	 * @since 3.0
+	 *
+	 * @param TransactionProfiler $transactionProfiler
+	 */
+	public function setTransactionProfiler( TransactionProfiler $transactionProfiler ) {
+		$this->transactionProfiler = $transactionProfiler;
 	}
 
 	/**
@@ -553,15 +562,6 @@ class Database {
 	}
 
 	/**
-	 * @note Use a blank trx profiler to ignore exceptions
-	 *
-	 * @since 2.4
-	 */
-	function resetTransactionProfiler( $resetTransactionProfiler ) {
-		$this->resetTransactionProfiler = $resetTransactionProfiler;
-	}
-
-	/**
 	 * @see DatabaseBase::clearFlag
 	 *
 	 * @since 2.4
@@ -618,7 +618,17 @@ class Database {
 			$this->initConnection();
 		}
 
-		return $this->writeConnection->insert( $table, $rows, $fname, $options );
+		$oldSilenced = $this->transactionProfiler->setSilenced(
+			true
+		);
+
+		$res = $this->writeConnection->insert( $table, $rows, $fname, $options );
+
+		$this->transactionProfiler->setSilenced(
+			$oldSilenced
+		);
+
+		return $res;
 	}
 
 	/**
@@ -632,7 +642,17 @@ class Database {
 			$this->initConnection();
 		}
 
-		return $this->writeConnection->update( $table, $values, $conds, $fname, $options );
+		$oldSilenced = $this->transactionProfiler->setSilenced(
+			true
+		);
+
+		$res = $this->writeConnection->update( $table, $values, $conds, $fname, $options );
+
+		$this->transactionProfiler->setSilenced(
+			$oldSilenced
+		);
+
+		return $res;
 	}
 
 	/**
@@ -646,7 +666,17 @@ class Database {
 			$this->initConnection();
 		}
 
-		return $this->writeConnection->delete( $table, $conds, $fname );
+		$oldSilenced = $this->transactionProfiler->setSilenced(
+			true
+		);
+
+		$res = $this->writeConnection->delete( $table, $conds, $fname );
+
+		$this->transactionProfiler->setSilenced(
+			$oldSilenced
+		);
+
+		return $res;
 	}
 
 	/**
@@ -660,7 +690,17 @@ class Database {
 			$this->initConnection();
 		}
 
-		return $this->writeConnection->replace( $table, $uniqueIndexes, $rows, $fname );
+		$oldSilenced = $this->transactionProfiler->setSilenced(
+			true
+		);
+
+		$res = $this->writeConnection->replace( $table, $uniqueIndexes, $rows, $fname );
+
+		$this->transactionProfiler->setSilenced(
+			$oldSilenced
+		);
+
+		return $res;
 	}
 
 	/**

--- a/src/MediaWiki/Connection/TransactionProfiler.php
+++ b/src/MediaWiki/Connection/TransactionProfiler.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace SMW\MediaWiki\Connection;
+
+/**
+ * @license GNU GPL v2+
+ * @since 3.0
+ *
+ * @author mwjames
+ */
+class TransactionProfiler {
+
+	/**
+	 * @var TransactionProfiler
+	 */
+	private $transactionProfiler;
+
+	/**
+	 * @var boolean
+	 */
+	private $silenceTransactionProfiler = false;
+
+	/**
+	 * @since 3.0
+	 *
+	 * @param TransactionProfiler|null $transactionProfiler
+	 */
+	public function __construct( $transactionProfiler = null ) {
+
+		// MW 1.28+
+		if ( method_exists( $transactionProfiler, 'setSilenced' ) ) {
+			$this->transactionProfiler = $transactionProfiler;
+		}
+	}
+
+	/**
+	 * @since 3.0
+	 */
+	public function silenceTransactionProfiler() {
+		$this->silenceTransactionProfiler = true;
+	}
+
+	/**
+	 * @since 3.0
+	 *
+	 * @param boolean $state
+	 */
+	public function setSilenced( $state ) {
+
+		if ( $this->transactionProfiler === null || $this->silenceTransactionProfiler === false ) {
+			return;
+		}
+
+		// @see https://gerrit.wikimedia.org/r/c/mediawiki/core/+/462130/3/includes/objectcache/SqlBagOStuff.php#836
+		return $this->transactionProfiler->setSilenced( $state );
+	}
+
+}

--- a/tests/phpunit/Unit/MediaWiki/Connection/TransactionProfilerTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Connection/TransactionProfilerTest.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace SMW\Tests\MediaWiki\Connection;
+
+use SMW\MediaWiki\Connection\TransactionProfiler;
+use SMW\Tests\PHPUnitCompat;
+
+/**
+ * @covers \SMW\MediaWiki\Connection\TransactionProfiler
+ * @group semantic-mediawiki
+ *
+ * @license GNU GPL v2+
+ * @since 3.0
+ *
+ * @author mwjames
+ */
+class TransactionProfilerTest extends \PHPUnit_Framework_TestCase {
+
+	use PHPUnitCompat;
+
+	private $connection;
+
+	protected function setUp() {
+
+		$this->transactionProfiler = $this->getMockBuilder( '\stdClass' )
+			->disableOriginalConstructor()
+			->setMethods( [ 'setSilenced' ] )
+			->getMock();
+	}
+
+	public function testCanConstruct() {
+		$this->assertInstanceOf(
+			TransactionProfiler::class,
+			new TransactionProfiler( $this->transactionProfiler )
+		);
+	}
+
+	public function testSetSilenced_Enabled() {
+
+		$instance = new TransactionProfiler(
+			$this->transactionProfiler
+		);
+
+		$instance->silenceTransactionProfiler();
+
+		$this->transactionProfiler->expects( $this->once() )
+			->method( 'setSilenced' );
+
+		$instance->setSilenced( true );
+	}
+
+	public function testSetSilenced_NotEnabled() {
+
+		$instance = new TransactionProfiler(
+			$this->transactionProfiler
+		);
+
+		$this->transactionProfiler->expects( $this->never() )
+			->method( 'setSilenced' );
+
+		$instance->setSilenced( true );
+	}
+
+}


### PR DESCRIPTION
This PR is made in reference to: #1499, https://phabricator.wikimedia.org/T154424

This PR addresses or contains:

- Based on [0], silence the `TransactionProfiler` for actions carried by the `Database` object since expectation violations have no actionable value to any SMW user and only spams the log without any possibility to remove those expectations

This PR includes:
- [ ] Tests (unit/integration)
- [x] CI build passed

[0] https://gerrit.wikimedia.org/r/c/mediawiki/core/+/462130/3/includes/objectcache/SqlBagOStuff.php#836