### PR TITLE
Adds a "dash" to the array of invalid characters

### DIFF
--- a/DefaultSettings.php
+++ b/DefaultSettings.php
@@ -1799,11 +1799,11 @@ return array(
 	# Listed characters are categorized as invalid for a property label and will
 	# result in an error.
 	#
-	# @see #1568, #1638
+	# @see #1568, #1638, 3134
 	#
 	# @since 2.5
 	##
-	'smwgPropertyInvalidCharacterList' => array( '[', ']' , '|' , '<' , '>', '{', '}', '+', '%', "\r", "\n" ),
+	'smwgPropertyInvalidCharacterList' => array( '[', ']' , '|' , '<' , '>', '{', '}', '+', '–', '%', "\r", "\n" ),
 	##
 
 	##


### PR DESCRIPTION
This PR is made in reference to: #3134 

This PR addresses or contains:
- Adds a "dash" to the array of invalid characters for usage in property names

This PR includes:
- [x] Tests (unit/integration)
- [ ] CI build passed

Fixes #