### PR TITLE
Catch PredefinedPropertyLabelMismatchException

### DIFF
--- a/src/SQLStore/QueryEngine/Fulltext/SearchTable.php
+++ b/src/SQLStore/QueryEngine/Fulltext/SearchTable.php
@@ -8,6 +8,7 @@ use SMW\DIWikiPage;
 use SMW\MediaWiki\Database;
 use SMW\SQLStore\SQLStore;
 use SMWDataItem as DataItem;
+use SMW\Exception\PredefinedPropertyLabelMismatchException;
 
 /**
  * @license GNU GPL v2+
@@ -101,9 +102,17 @@ class SearchTable {
 			return false;
 		}
 
-		return $this->isExemptedProperty(
-			DIProperty::newFromUserLabel( $dataItem->getDBKey() )
-		);
+		try {
+			$property = DIProperty::newFromUserLabel(
+				$dataItem->getDBKey()
+			);
+		} catch( PredefinedPropertyLabelMismatchException $e ) {
+			// The property no longer exists (or is no longer available) therefore
+			// exempt it.
+			return true;
+		}
+
+		return $this->isExemptedProperty( $property );
 	}
 
 	/**


### PR DESCRIPTION
This PR is made in reference to: #3482 

This PR addresses or contains:
- Catch `PredefinedPropertyLabelMismatchException` when rebuilding full-text search-index // Change as suggested in https://github.com/SemanticMediaWiki/SemanticMediaWiki/issues/3482#issuecomment-423996529

This PR includes:
- [ ] Tests (unit/integration)
- [x] CI build passed

Fixes #3482 