### PR TITLE
Extends testing by `ResultFormatNotFoundException`

### DIFF
--- a/includes/query/SMW_QueryProcessor.php
+++ b/includes/query/SMW_QueryProcessor.php
@@ -12,7 +12,7 @@ use SMW\Query\PrintRequest;
 use SMW\Query\Processor\ParamListProcessor;
 use SMW\Query\Processor\DefaultParamDefinition;
 use SMW\Query\QueryContext;
-use SMW\Query\ResultFormatNotFoundException;
+use SMW\Query\Exception\ResultFormatNotFoundException;
 
 /**
  * This file contains a static class for accessing functions to generate and execute

--- a/tests/phpunit/includes/QueryProcessorTest.php
+++ b/tests/phpunit/includes/QueryProcessorTest.php
@@ -8,6 +8,7 @@ namespace SMW\Test;
 
 use SMW\Tests\MwDBaseUnitTestCase;
 use SMWQueryProcessor;
+use SMW\Tests\PHPUnitCompat;
 
 /**
  * Tests for the SMWQueryProcessor class.
@@ -24,11 +25,20 @@ use SMWQueryProcessor;
  */
 class SMWQueryProcessorTest extends MwDBaseUnitTestCase {
 
+	use PHPUnitCompat;
+	
 	public function createQueryDataProvider() {
 		return [
 			[ '[[Modification date::+]]|?Modification date|sort=Modification date|order=desc' ],
 		];
 	}
+	
+	public function testGetResultPrinter_ThrowsException() {
+
+		$this->setExpectedException( '\SMW\Query\Exception\ResultFormatNotFoundException' );
+		SMWQueryProcessor::getResultPrinter( 'unknown_format' );
+	}
+	
 
 	/**
 	* @dataProvider createQueryDataProvider


### PR DESCRIPTION
This PR is made in reference to: #3479 

This PR addresses or contains:
- Extends testing by `ResultFormatNotFoundException` allowing to detect the transgressing result format // Code change as suggested in https://github.com/SemanticMediaWiki/SemanticMediaWiki/issues/3479#issuecomment-423965960

This PR includes:
- [x] Tests (unit/integration)
- [ ] CI build passed

Fixes #