### PR TITLE
Increase protection against database deadlocks

### DIFF
--- a/tests/phpunit/Unit/SQLStore/PropertyTableIdReferenceDisposerTest.php
+++ b/tests/phpunit/Unit/SQLStore/PropertyTableIdReferenceDisposerTest.php
@@ -276,8 +276,11 @@ class PropertyTableIdReferenceDisposerTest extends \PHPUnit_Framework_TestCase {
 			->disableOriginalConstructor()
 			->getMock();
 
-		$connection->expects( $this->never() )
-			->method( 'onTransactionIdle' );
+		$connection->expects( $this->once() )
+			->method( 'onTransactionIdle' )
+			->will( $this->returnCallback( function( $callback ) {
+				return $callback();
+			} ) );
 
 		$connection->expects( $this->atLeastOnce() )
 			->method( 'delete' )


### PR DESCRIPTION
This PR is made in reference to: 24.09.2018 18:01 CEST

This PR addresses or contains:
- Increase protection against database deadlocks (1213 Deadlock found when trying to get lock) // Code changes as suggested.

This PR includes:
- [ ] Tests (unit/integration)
- [x] CI build passed

In reference to:

```
when updating my internal working wiki I got the following database
issue when trying to run "rebuildData.php" (MW 1.27.5 on PHP 5.6.36 and
MySQL 5.5.60:

Es ist ein Datenbankabfragefehler aufgetreten.
Abfrage: DELETE FROM `08200_smw_di_bool` WHERE p_id = '1900'
Funktion:
SMW\SQLStore\PropertyTableIdReferenceDisposer::cleanUpTableEntriesById
Fehler: 1213 Deadlock found when trying to get lock; try restarting
transaction (localhost)

Backtrace:
#0 /../w/includes/db/Database.php(901): DatabaseBase->reportQueryError('Deadlock found ...', 1213, 'DELETE FROM `08...', 'SMW\\SQLStore\\Pr...', false)
#1 /../w/includes/db/Database.php(2259): DatabaseBase->query('DELETE FROM `08...', 'SMW\\SQLStore\\Pr...')
#2 /../w/extensions/SemanticMediaWiki/src/MediaWiki/Connection/Database.php(649): DatabaseBase->delete('smw_di_bool', Array, 'SMW\\SQLStore\\Pr...')
#3 /../w/extensions/SemanticMediaWiki/src/SQLStore/PropertyTableIdReferenceDisposer.php(182): SMW\MediaWiki\Connection\Database->delete('smw_di_bool', Array,
'SMW\\SQLStore\\Pr...')
#4 /../w/extensions/SemanticMediaWiki/src/SQLStore/EntityRebuildDispatcher.php(350): SMW\SQLStore\PropertyTableIdReferenceDisposer->cleanUpTableEntriesById('1900')
#5 /../w/extensions/SemanticMediaWiki/src/SQLStore/EntityRebuildDispatcher.php(198): SMW\SQLStore\EntityRebuildDispatcher->match_subject(1900, false)
#6 /../w/extensions/SemanticMediaWiki/src/Maintenance/DataRebuilder.php(369): SMW\SQLStore\EntityRebuildDispatcher->rebuild(1900)
#7 /../w/extensions/SemanticMediaWiki/src/Maintenance/DataRebuilder.php(307): SMW\Maintenance\DataRebuilder->do_update(1900)
#8 /../w/extensions/SemanticMediaWiki/src/Maintenance/DataRebuilder.php(182): SMW\Maintenance\DataRebuilder->rebuild_all()
#9 /../w/extensions/SemanticMediaWiki/maintenance/rebuildData.php(167): SMW\Maintenance\DataRebuilder->rebuild()
#10 /../w/maintenance/doMaintenance.php(103): SMW\Maintenance\RebuildData->execute()
#11 /../w/extensions/SemanticMediaWiki/maintenance/rebuildData.php(225): require_once('/var/www/htdocs...')
#12 {main}
```