### PR TITLE
 Fixes result format aliases not being found

### DIFF
--- a/includes/query/SMW_QueryProcessor.php
+++ b/includes/query/SMW_QueryProcessor.php
@@ -430,11 +430,13 @@ class SMWQueryProcessor implements QueryContext {
 	 */
 	static public function getResultPrinter( $format, $context = self::SPECIAL_PAGE ) {
 		global $smwgResultFormats;
+		
+		SMWParamFormat::resolveFormatAliases( $format );
 
 		if ( !array_key_exists( $format, $smwgResultFormats ) ) {
 			throw new ResultFormatNotFoundException( "There is no result format for '$format'." );
 		}
-
+		
 		$formatClass = $smwgResultFormats[$format];
 
 		$printer = new $formatClass( $format, ( $context != self::SPECIAL_PAGE ) );

--- a/tests/phpunit/includes/QueryProcessorTest.php
+++ b/tests/phpunit/includes/QueryProcessorTest.php
@@ -33,6 +33,26 @@ class SMWQueryProcessorTest extends MwDBaseUnitTestCase {
 		];
 	}
 	
+	/**
+	* @dataProvider resultAliasDataProvider
+	*/
+	public function testGetResultPrinter_MatchAlias( $alias ) {
+
+		$this->assertInstanceOf(
+			'\SMW\Query\ResultPrinter',
+			SMWQueryProcessor::getResultPrinter( $alias )
+		);
+	}
+
+	public function resultAliasDataProvider() {
+
+		foreach ( $GLOBALS['smwgResultAliases'] as $format => $aliases ) {
+			foreach ( $aliases as $alias ) {
+				yield [ $alias ];
+			}
+		}
+	}
+	
 	public function testGetResultPrinter_ThrowsException() {
 
 		$this->setExpectedException( '\SMW\Query\Exception\ResultFormatNotFoundException' );


### PR DESCRIPTION
This PR is made in reference to: #3479 

This PR addresses or contains:
-  Fixes result format aliases not being found 

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed

Fixes #3479 