### PR TITLE
Make 'plainlist' default over 'list'

### DIFF
--- a/includes/params/SMW_ParamFormat.php
+++ b/includes/params/SMW_ParamFormat.php
@@ -117,11 +117,7 @@ class SMWParamFormat extends StringParam {
 			return 'table';
 		}
 
-		if ( $this->showMode ) {
-			return 'plainlist';
-		}
-
-		return 'list';
+		return 'plainlist';
 	}
 
 	/**

--- a/tests/phpunit/Integration/JSONScript/TestCases/f-0402.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/f-0402.json
@@ -166,15 +166,19 @@
 	"tests": [
 		{
 			"type": "parser-html",
-			"about": "#1 List format is called as standard output",
+			"about": "#1 Plainlist format is called as standard output",
 			"subject": "f-0402/Test-01",
 			"assert-output": {
 				"to-be-valid-html": true,
 				"to-contain": [
-					[
-						"span.list-format > span.smw-row > span.smw-field > span.smw-value > a[title]",
-						10
-					]
+						"a[title] ~ a[title]"
+				],
+				"not-contain": [
+					".smw-format",
+					".list-format",
+					".smw-row",
+					".smw-field",
+					".smw-value"
 				]
 			}
 		},

--- a/tests/phpunit/Integration/JSONScript/TestCases/p-0202.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/p-0202.json
@@ -9,7 +9,7 @@
 		{
 			"namespace": "NS_TEMPLATE",
 			"page": "SetParserTemplateToCreateAskLink",
-			"contents": "<includeonly>{{#ask: [[{{{property}}}::{{{value}}}]]|limit=0|searchlabel={{{value}}} }}</includeonly>"
+			"contents": "<includeonly>{{#ask: [[{{{property}}}::{{{value}}}]]|limit=0|searchlabel={{{value}}}|format=list }}</includeonly>"
 		},
 		{
 			"page": "Transclude-Template-Using-Set",

--- a/tests/phpunit/Integration/JSONScript/TestCases/p-0432.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/p-0432.json
@@ -45,11 +45,11 @@
 		},
 		{
 			"page": "Example/P0432/Q5.1",
-			"contents": "{{#ask: [[Has number with ref::999]] |order=asc |link=none}}"
+			"contents": "{{#ask: [[Has number with ref::999]] |order=asc |link=none |format=list}}"
 		},
 		{
 			"page": "Example/P0432/Q5.2",
-			"contents": "{{#ask: [[Has number with ref::999]] |order=desc |link=none}}"
+			"contents": "{{#ask: [[Has number with ref::999]] |order=desc |link=none |format=list}}"
 		}
 	],
 	"tests": [


### PR DESCRIPTION
This PR is made in reference to: #3472

This PR addresses or contains:
- As agreed to in #3472, `plainlist` is a better default result format since it is more backwards compatible than `list`.

This PR includes:
- [ ] Tests (unit/integration)
- [ ] CI build passed

Fixes: #3472 