### PR TITLE
Add ParserCachePurgeJob on delete, refs 3430

### DIFF
--- a/src/MediaWiki/Hooks/HookHandler.php
+++ b/src/MediaWiki/Hooks/HookHandler.php
@@ -46,6 +46,11 @@ class HookHandler {
 	 * @return mixed
 	 */
 	public function getOption( $key, $default = null ) {
+
+		if ( $this->options === null ) {
+			$this->setOptions( [] );
+		}
+
 		return $this->options->safeGet( $key, $default );
 	}
 

--- a/src/MediaWiki/Hooks/HookListener.php
+++ b/src/MediaWiki/Hooks/HookListener.php
@@ -422,6 +422,12 @@ class HookListener {
 			$applicationFactory->getMediaWikiLogger()
 		);
 
+		$articleDelete->setOptions(
+			[
+				'smwgEnabledQueryDependencyLinksStore' => $applicationFactory->getSettings()->get( 'smwgEnabledQueryDependencyLinksStore' )
+			]
+		);
+
 		return $articleDelete->process( $wikiPage );
 	}
 

--- a/src/SQLStore/QueryDependency/QueryDependencyLinksStore.php
+++ b/src/SQLStore/QueryDependency/QueryDependencyLinksStore.php
@@ -362,7 +362,7 @@ class QueryDependencyLinksStore {
 		}
 
 		// Return the expected count of targets
-		$requestOptions->targetLinksCount = count( $targetLinksIdList );
+		$requestOptions->setOption( 'links.count', count( $targetLinksIdList ) );
 
 		$poolRequestOptions = new RequestOptions();
 

--- a/tests/phpunit/Unit/MediaWiki/Hooks/ArticleDeleteTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Hooks/ArticleDeleteTest.php
@@ -72,9 +72,17 @@ class ArticleDeleteTest extends \PHPUnit_Framework_TestCase {
 			->disableOriginalConstructor()
 			->getMock();
 
+		$parserCachePurgeJob = $this->getMockBuilder( '\SMW\MediaWiki\Jobs\NullJob' )
+			->disableOriginalConstructor()
+			->getMock();
+
 		$this->jobFactory->expects( $this->atLeastOnce() )
 			->method( 'newUpdateDispatcherJob' )
 			->will( $this->returnValue( $updateDispatcherJob ) );
+
+		$this->jobFactory->expects( $this->atLeastOnce() )
+			->method( 'newParserCachePurgeJob' )
+			->will( $this->returnValue( $parserCachePurgeJob ) );
 
 		$subject = DIWikiPage::newFromText( __METHOD__ );
 


### PR DESCRIPTION
This PR is made in reference to: #3430 

This PR addresses or contains:

- Add a purge job on a delete action before the entity ID becomes marked as outdated to create a possibility for the job to select pending dependencies from the query links table

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed

Fixes #