### PR TITLE
Special:Concepts only match concepts with features, refs 3049

### DIFF
--- a/includes/specials/SpecialConcepts.php
+++ b/includes/specials/SpecialConcepts.php
@@ -57,7 +57,9 @@ class SpecialConcepts extends SpecialPage {
 		$conditions = [
 			'smw_namespace' => SMW_NS_CONCEPT,
 			'smw_iw' => '',
-			'smw_subobject' => ''
+			'smw_subobject' => '',
+			'smw_proptable_hash IS NOT NULL',
+			'concept_features > 0'
 		];
 
 		$options = [
@@ -66,11 +68,17 @@ class SpecialConcepts extends SpecialPage {
 		];
 
 		$res = $connection->select(
-			$connection->tableName( SQLStore::ID_TABLE ),
+			[
+				$connection->tableName( SQLStore::ID_TABLE ),
+				$connection->tableName( SQLStore::CONCEPT_TABLE )
+			],
 			$fields,
 			$conditions,
 			__METHOD__,
-			$options
+			$options,
+			[
+				$connection->tableName( SQLStore::ID_TABLE ) => [ 'INNER JOIN', [ 'smw_id=s_id' ] ]
+			]
 		);
 
 		foreach ( $res as $row ) {

--- a/tests/phpunit/Integration/JSONScript/TestCases/s-0030.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/s-0030.json
@@ -1,0 +1,50 @@
+{
+	"description": "Test `Special:Concepts`",
+	"setup": [
+		{
+			"namespace": "SMW_NS_CONCEPT",
+			"page": "S0030/1",
+			"contents": "{{#concept: [[ConceptTest::+]] |Concept with no results}}"
+		},
+		{
+			"page": "S0030/2",
+			"contents": "{{#ask: [[Concept:S0030/Unknown]] }}"
+		}
+	],
+	"tests": [
+		{
+			"type": "special",
+			"about": "#0",
+			"special-page": {
+				"page": "Concepts",
+				"query-parameters": "",
+				"request-parameters": []
+			},
+			"assert-output": {
+				"to-contain": [
+					"<a href=\".*Concept:S0030/1\" title=\"Concept:S0030/1\">Concept:S0030/1</a>"
+				],
+				"not-contain": [
+					"Concept:S0030/Unknown"
+				]
+			}
+		}
+	],
+	"settings": {
+		"wgContLang": "en",
+		"wgLanguageCode": "en",
+		"smwgPageSpecialProperties": [
+			"_MDAT"
+		],
+		"smwgNamespacesWithSemanticLinks": {
+			"NS_MAIN": true,
+			"SMW_NS_PROPERTY": true,
+			"SMW_NS_CONCEPT": true
+		}
+	},
+	"meta": {
+		"version": "2",
+		"is-incomplete": false,
+		"debug": false
+	}
+}


### PR DESCRIPTION
This PR is made in reference to: #3049

This PR addresses or contains:

- Only select those concepts that have actual features and are not to be mistaken with simple entities used for example as part of an #ask query
- Adds an extra integration test to verify the feature requirement

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed

![image](https://user-images.githubusercontent.com/1245473/46248604-f55c8b00-c40a-11e8-8583-0dc7c3f3cc4b.png)


Fixes #