### PR TITLE
UpdateDispatcherJob improve dispatch selection, refs 3469

### DIFF
--- a/includes/storage/SQLStore/SMW_SQLStore3_Readers.php
+++ b/includes/storage/SQLStore/SMW_SQLStore3_Readers.php
@@ -2,6 +2,7 @@
 
 use SMW\ApplicationFactory;
 use SMW\DataTypeRegistry;
+use SMW\Enum;
 use SMW\DIProperty;
 use SMW\DIWikiPage;
 use SMW\SQLStore\EntityStore\Exception\DataItemHandlerException;
@@ -309,6 +310,13 @@ class SMWSQLStore3Readers {
 			$dataItem,
 			$requestOptions
 		);
+
+		// Keep the result as iterator which is normally advised when the result
+		// size is expected to be larger than 1000 or results are retrieved through
+		// a job which may process them in batches.
+		if ( $requestOptions !== null && $requestOptions->getOption( Enum::SUSPEND_CACHE_WARMUP ) ) {
+			return $result;
+		}
 
 		$this->store->smwIds->warmUpCache( $result );
 

--- a/src/Enum.php
+++ b/src/Enum.php
@@ -20,4 +20,9 @@ class Enum {
 	 */
 	const PURGE_ASSOC_PARSERCACHE = 'smw.purge.assoc.parsercache';
 
+	/**
+	 * Indicates whether to proceed with the cache warming or not
+	 */
+	const SUSPEND_CACHE_WARMUP = 'smw.suspend.cache.warmup';
+
 }

--- a/src/SQLStore/EntityStore/PropertySubjectsLookup.php
+++ b/src/SQLStore/EntityStore/PropertySubjectsLookup.php
@@ -186,6 +186,18 @@ class PropertySubjectsLookup {
 
 		$this->getWhereConds( $query, $dataItem );
 
+		if ( $requestOptions !== null ) {
+			foreach ( $requestOptions->getExtraConditions() as $extraCondition ) {
+				if ( isset( $extraCondition['o_id'] ) ) {
+					$query->condition( $query->eq( 't1.o_id', $extraCondition['o_id'] ) );
+				}
+
+				if ( is_callable( $extraCondition ) ) {
+					$extraCondition( $query );
+				}
+			}
+		}
+
 		if ( $proptable->usesIdSubject() ) {
 			foreach ( [ SMW_SQL3_SMWIW_OUTDATED, SMW_SQL3_SMWDELETEIW, SMW_SQL3_SMWREDIIW ] as $v ) {
 				$query->condition( $query->neq( "smw_iw", $v ) );


### PR DESCRIPTION
This PR is made in reference to: #3469, #3340

This PR addresses or contains:

- While the approach used in #3340 reduced the entities selected yet isn't scalable when for example a property has ~50.000 referenced subjects (just happen to myself) the `getAllPropertySubjects` select will OOM hence
  - since #3469 we know the ID of the referenced entity, use it to restrict the select 
  - suspend the cache warmup and keep the iterator around til it is accessed (with the dispatcher working in batch mode there is not really a need for the ID cache since it is unlikely that all matches are processed at once)

This PR includes:
- [ ] Tests (unit/integration)
- [x] CI build passed
