### PR TITLE
[ES] Fix concept ids lookup on "Failed ... parsing_exception ... [ids] values doesn't support ..."

### DIFF
--- a/src/Elastic/QueryEngine/TermsLookup/CachingTermsLookup.php
+++ b/src/Elastic/QueryEngine/TermsLookup/CachingTermsLookup.php
@@ -166,6 +166,13 @@ class CachingTermsLookup extends TermsLookup {
 			'info' => $parameters->get( 'query.info' )
 		];
 
+		if ( isset( $params['type'] ) && isset( $params['id'] ) ) {
+			$params = $this->termsLookup->terms_filter(
+				'_id',
+				$this->termsLookup->path_filter( $params['id'] )
+			);
+		}
+
 		return $params;
 	}
 

--- a/src/Elastic/QueryEngine/TermsLookup/TermsLookup.php
+++ b/src/Elastic/QueryEngine/TermsLookup/TermsLookup.php
@@ -139,7 +139,14 @@ class TermsLookup implements ITermsLookup {
 
 		$parameters->set( 'query.info', $info );
 
-		return $this->ids_filter( $this->query_result( $parameters ) );
+		$results = $this->query_result( $parameters );
+
+		// Already in the `terms_filter` structure?
+		if ( isset( $results['type'] ) && isset( $results['id'] ) ) {
+			return $results;
+		}
+
+		return $this->ids_filter( $results );
 	}
 
 	/**


### PR DESCRIPTION
This PR is made in reference to: #

This PR addresses or contains:

- If the `terms_filter` structure is already provided (for a concept lookup in ES) avoid the `ids_filter`.

This PR includes:
- [ ] Tests (unit/integration)
- [x] CI build passed

### Log

```
2018-09-29 19:38:33 mw-30-00-elastic: Failed the search with: {"error":{"root_cause":[{"type":"parsing_exception","reason":"[ids] values doesn't support values of type: START_OBJECT","line":1,"col":90}],"type":"parsing_exception","reason":"[ids] values doesn't support values of type: START_OBJECT","line":1,"col":90},status":400}"
```