### PR TITLE
Add `check-query` to post-edit update

### DIFF
--- a/DefaultSettings.php
+++ b/DefaultSettings.php
@@ -1283,7 +1283,7 @@ return [
 	##
 
 	###
-	# Regulates task specific settings for the postEdit process.
+	# Regulates task specific settings for the post-edit process.
 	#
 	# The main objective is to defer secondary updates until after the GET request
 	# has been finalized so that resource requirements are part of an API request
@@ -1294,9 +1294,29 @@ return [
 	# timely manner independent of a users job scheduler environment. The number
 	# indicates the expected number of jobs to be executed per request.
 	#
+	# @experimental
+	#
+	# `check-query` The display of query results and the storage of entities that
+	# make up the results of a query are two distinct processes. The display
+	# normally happens before the storage due to how the MW parser works meaning
+	# that a query can only display the most recent results after a page has
+	# been processed and rendered while the storage is being deferred (or in case
+	# of an external store is influenced by the network lag).
+	#
+	# The `check-query` uses the `post-edit` event to run registered queries and
+	# if necessary reloads the page (hereby refreshes the results) in case the
+	# result is different by comparing the `result_hash` from before and after.
+	# To determine the query state, the `post-edit` has to invoke the API (as
+	# background task) which has to probe the query and to only run the query once
+	# for the page that embeds the query, it is strongly recommended that this
+	# option is only enabled together with:
+	#   - the query cache (@see $smwgQueryResultCacheType) and
+	#   - the query links store (@see $smwgEnabledQueryDependencyLinksStore)
+	#
 	# @since 3.0
 	##
 	'smwgPostEditUpdate' => [
+		'check-query' => false,
 		'run-jobs' => [
 			'smw.fulltextSearchTableUpdate' => 1,
 			'smw.parserCachePurge' => 5

--- a/includes/query/SMW_QueryProcessor.php
+++ b/includes/query/SMW_QueryProcessor.php
@@ -378,6 +378,10 @@ class SMWQueryProcessor implements QueryContext {
 		$res = self::getStoreFromParams( $params )->getQueryResult( $query );
 		$start = microtime( true );
 
+		if ( $res instanceof SMWQueryResult && $query->getOption( 'calc.result_hash' ) ) {
+			$query->setOption( 'result_hash', $res->getHash( 'quick' ) );
+		}
+
 		if ( ( $query->querymode == SMWQuery::MODE_INSTANCES ) ||
 			( $query->querymode == SMWQuery::MODE_NONE ) ) {
 
@@ -430,13 +434,13 @@ class SMWQueryProcessor implements QueryContext {
 	 */
 	static public function getResultPrinter( $format, $context = self::SPECIAL_PAGE ) {
 		global $smwgResultFormats;
-		
+
 		SMWParamFormat::resolveFormatAliases( $format );
 
 		if ( !array_key_exists( $format, $smwgResultFormats ) ) {
 			throw new ResultFormatNotFoundException( "There is no result format for '$format'." );
 		}
-		
+
 		$formatClass = $smwgResultFormats[$format];
 
 		$printer = new $formatClass( $format, ( $context != self::SPECIAL_PAGE ) );

--- a/res/smw/util/ext.smw.util.postproc.js
+++ b/res/smw/util/ext.smw.util.postproc.js
@@ -27,6 +27,7 @@
 
 			var api = new mw.Api();
 			var ref = $( this ).data( 'ref' );
+			var query = $( this ).data( 'query' );
 
 			if ( ref !== undefined && ref !== '' ) {
 				mw.notify( mw.msg( 'smw-postproc-queryref' ), { type: 'info', autoHide: false } );
@@ -47,7 +48,28 @@
 				api.postWithToken( 'csrf', postArgs ).then( function ( data ) {
 					location.reload( true );
 				} );
-			};
+			} else if ( query !== undefined ) {
+
+				var params = {
+					'subject': $( this ).data( 'subject' ),
+					'origin': 'api-postproc',
+					'query' : query,
+					'cache-key': $( this ).data( 'cache-key' )
+				};
+
+				var postArgs = {
+					'action': 'smwtask',
+					'task': 'check-query',
+					'params': JSON.stringify( params )
+				};
+
+				api.postWithToken( 'csrf', postArgs ).then( function ( data ) {
+					if ( data.task.hasOwnProperty( 'reload' ) ) {
+						mw.notify( mw.msg( 'smw-postproc-queryref' ), { type: 'info', autoHide: false } );
+						location.reload( true );
+					};
+				} );
+			}
 
 			var jobs = $( this ).data( 'jobs' );
 

--- a/src/ParserFunctionFactory.php
+++ b/src/ParserFunctionFactory.php
@@ -223,7 +223,9 @@ class ParserFunctionFactory {
 	 */
 	public function newConceptParserFunction( Parser $parser ) {
 
-		$parserData = ApplicationFactory::getInstance()->newParserData(
+		$applicationFactory = ApplicationFactory::getInstance();
+
+		$parserData = $applicationFactory->newParserData(
 			$parser->getTitle(),
 			$parser->getOutput()
 		);
@@ -235,6 +237,10 @@ class ParserFunctionFactory {
 		$conceptParserFunction = new ConceptParserFunction(
 			$parserData,
 			$messageFormatter
+		);
+
+		$conceptParserFunction->setPostProcHandler(
+			$applicationFactory->create( 'PostProcHandler', $parser->getOutput() )
 		);
 
 		return $conceptParserFunction;

--- a/src/ParserFunctions/AskParserFunction.php
+++ b/src/ParserFunctions/AskParserFunction.php
@@ -278,7 +278,7 @@ class AskParserFunction {
 
 		if ( $this->postProcHandler !== null && isset( $extraKeys[self::IS_ANNOTATION] ) ) {
 			$status[] = 100;
-			$this->postProcHandler->addQueryRef( $query );
+			$this->postProcHandler->addUpdate( $query );
 		}
 
 		if ( $this->context === QueryProcessor::DEFERRED_QUERY ) {
@@ -316,12 +316,21 @@ class AskParserFunction {
 
 		$query->setOption( 'query.params', $params );
 
+		// Only request a result_hash in case the `check-query` is enabled
+		if ( $this->postProcHandler !== null ) {
+			$query->setOption( 'calc.result_hash', $this->postProcHandler->getOption( 'check-query' ) );
+		}
+
 		$result = QueryProcessor::getResultFromQuery(
 			$query,
 			$this->params,
 			SMW_OUTPUT_WIKI,
 			$this->context
 		);
+
+		if ( $this->postProcHandler !== null && $this->context !== QueryProcessor::DEFERRED_QUERY ) {
+			$this->postProcHandler->addCheck( $query );
+		}
 
 		$format = $this->params['format']->getValue();
 

--- a/src/ParserFunctions/ConceptParserFunction.php
+++ b/src/ParserFunctions/ConceptParserFunction.php
@@ -9,6 +9,7 @@ use SMW\DIConcept;
 use SMW\DIProperty;
 use SMW\MessageFormatter;
 use SMW\ParserData;
+use SMW\PostProcHandler;
 use SMWInfolink;
 use SMWQueryProcessor as QueryProcessor;
 use Title;
@@ -36,6 +37,11 @@ class ConceptParserFunction {
 	private $messageFormatter;
 
 	/**
+	 * @var PostProcHandler
+	 */
+	private $postProcHandler;
+
+	/**
 	 * @since 1.9
 	 *
 	 * @param ParserData $parserData
@@ -44,6 +50,15 @@ class ConceptParserFunction {
 	public function __construct( ParserData $parserData, MessageFormatter $messageFormatter ) {
 		$this->parserData = $parserData;
 		$this->messageFormatter = $messageFormatter;
+	}
+
+	/**
+	 * @since 3.0
+	 *
+	 * @param PostProcHandler $postProcHandler
+	 */
+	public function setPostProcHandler( PostProcHandler $postProcHandler ) {
+		$this->postProcHandler = $postProcHandler;
 	}
 
 	/**
@@ -97,6 +112,10 @@ class ConceptParserFunction {
 		$this->messageFormatter
 			->addFromArray( $query->getErrors() )
 			->addFromArray( $this->parserData->getErrors() );
+
+		if ( $this->postProcHandler !== null ) {
+			$this->postProcHandler->addCheck( $query );
+		}
 
 		$this->addQueryProfile( $query );
 

--- a/src/PostProcHandler.php
+++ b/src/PostProcHandler.php
@@ -31,7 +31,17 @@ use WebRequest;
  */
 class PostProcHandler {
 
-	const POST_PROC_QUERYREF = 'smw-postproc-queryref';
+	/**
+	 * Identifier on whether an update to subject is to be carried out or not
+	 * given the query reference used as part of an @annotation request.
+	 */
+	const POST_EDIT_UPDATE = 'smw-postedit-update';
+
+	/**
+	 * Check registered queries and its results on wether the result_hash before
+	 * and after is different or not.
+	 */
+	const POST_EDIT_CHECK = 'smw-postedit-check';
 
 	/**
 	 * Specifies the TTL for the temporary tracking of a post edit
@@ -86,6 +96,23 @@ class PostProcHandler {
 	 */
 	public function setOptions( array $options ) {
 		$this->options = $options;
+	}
+
+	/**
+	 * @since 3.0
+	 *
+	 * @param string $key
+	 * @param mixed $default
+	 *
+	 * @return mixed
+	 */
+	public function getOption( $key, $default = false ) {
+
+		if ( isset( $this->options[$key] ) ) {
+			return $this->options[$key];
+		}
+
+		return $default;
 	}
 
 	/**
@@ -146,7 +173,7 @@ class PostProcHandler {
 		}
 
 		// Is `@annotation` available as part of a #ask query?
-		$refs = $this->parserOutput->getExtensionData( self::POST_PROC_QUERYREF );
+		$refs = $this->parserOutput->getExtensionData( self::POST_EDIT_UPDATE );
 
 		if ( $refs !== null && $refs !== [] ) {
 			$postEdit = $this->checkRef( $title, $postEdit );
@@ -154,6 +181,13 @@ class PostProcHandler {
 
 		if ( $postEdit !== null && $refs !== null && $refs !== [] ) {
 			$attributes['data-ref'] = json_encode( array_keys( $refs ) );
+		}
+
+		if (
+			$postEdit !== null &&
+			isset( $this->options['check-query'] ) &&
+			( $queries = $this->parserOutput->getExtensionData( self::POST_EDIT_CHECK ) ) !== null ) {
+			$attributes['data-query'] = json_encode( $queries );
 		}
 
 		// The element is only added temporarily in the event of a postEdit, a
@@ -171,7 +205,7 @@ class PostProcHandler {
 	 *
 	 * @param Query $query
 	 */
-	public function addQueryRef( Query $query ) {
+	public function addUpdate( Query $query ) {
 
 		// Query:getHash returns a hash based on a fingerprint
 		// (when $smwgQueryResultCacheType is set) that eliminates duplicate
@@ -180,7 +214,7 @@ class PostProcHandler {
 		// alternating updates as in case of cascading value dependencies
 		$queryRef = HashBuilder::createFromArray( $query->toArray() );
 
-		$data = $this->parserOutput->getExtensionData( self::POST_PROC_QUERYREF );
+		$data = $this->parserOutput->getExtensionData( self::POST_EDIT_UPDATE );
 
 		if ( $data === null ) {
 			$data = [];
@@ -189,7 +223,42 @@ class PostProcHandler {
 		$data[$queryRef] = true;
 
 		$this->parserOutput->setExtensionData(
-			self::POST_PROC_QUERYREF,
+			self::POST_EDIT_UPDATE,
+			$data
+		);
+	}
+
+	/**
+	 * @since 3.0
+	 *
+	 * @param Query $query
+	 */
+	public function addCheck( Query $query ) {
+
+		if ( !isset( $this->options['check-query'] ) || $this->options['check-query'] === false ) {
+			return;
+		}
+
+		$q_array = $query->toArray();
+
+		// Build a concatenated hash from the query and the result_hash
+		$hash = md5( json_encode( $q_array ) ) . '#';
+		$data = $this->parserOutput->getExtensionData( self::POST_EDIT_CHECK );
+
+		if ( $data === null ) {
+			$data = [];
+		}
+
+		// Use the result hash to determine whether results differ during the
+		// post-edit examination when running the same query
+		if ( $query->getOption( 'result_hash' ) ) {
+			$hash .= $query->getOption( 'result_hash' );
+		}
+
+		$data[$hash] = $q_array;
+
+		$this->parserOutput->setExtensionData(
+			self::POST_EDIT_CHECK,
 			$data
 		);
 	}

--- a/tests/phpunit/Unit/MediaWiki/Api/TaskTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Api/TaskTest.php
@@ -204,4 +204,49 @@ class TaskTest extends \PHPUnit_Framework_TestCase {
 		$instance->execute();
 	}
 
+	public function testCheckQueryTask() {
+
+		$queryResult = $this->getMockBuilder( '\SMWQueryResult' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$store = $this->getMockBuilder( '\SMW\Store' )
+			->disableOriginalConstructor()
+			->getMockForAbstractClass();
+
+		$store->expects( $this->atLeastOnce() )
+			->method( 'getQueryResult' )
+			->will( $this->returnValue( $queryResult ) );
+
+		$this->testEnvironment->registerObject( 'Store', $store );
+
+		$instance = new Task(
+			$this->apiFactory->newApiMain(
+				[
+					'action'   => 'smwtask',
+					'task'     => 'check-query',
+					'params'   => json_encode(
+						[
+							'subject' => 'Foo#0##',
+							'query' => [
+								'query_hash_1#result_hash_2' => [
+									'parameters' => [
+										'limit' => 5,
+										'offset' => 0,
+										'querymode' => 1
+									],
+									'conditions' => ''
+								]
+							]
+						]
+					),
+					'token'    => 'foo'
+				]
+			),
+			'smwtask'
+		);
+
+		$instance->execute();
+	}
+
 }

--- a/tests/phpunit/Unit/ParserFunctions/AskParserFunctionTest.php
+++ b/tests/phpunit/Unit/ParserFunctions/AskParserFunctionTest.php
@@ -413,7 +413,7 @@ class AskParserFunctionTest extends \PHPUnit_Framework_TestCase {
 			->getMock();
 
 		$postProcHandler->expects( $this->once() )
-			->method( 'addQueryRef' );
+			->method( 'addUpdate' );
 
 		$parserData = ApplicationFactory::getInstance()->newParserData(
 			Title::newFromText( __METHOD__ ),

--- a/tests/phpunit/Unit/PostProcHandlerTest.php
+++ b/tests/phpunit/Unit/PostProcHandlerTest.php
@@ -44,7 +44,7 @@ class PostProcHandlerTest extends \PHPUnit_Framework_TestCase {
 
 		$this->parserOutput->expects( $this->once() )
 			->method( 'getExtensionData' )
-			->with( $this->equalTo( PostProcHandler::POST_PROC_QUERYREF ) )
+			->with( $this->equalTo( PostProcHandler::POST_EDIT_UPDATE ) )
 			->will( $this->returnValue( [ 'Bar' => true ] ) );
 
 		$instance = new PostProcHandler(
@@ -94,7 +94,7 @@ class PostProcHandlerTest extends \PHPUnit_Framework_TestCase {
 
 		$this->parserOutput->expects( $this->once() )
 			->method( 'getExtensionData' )
-			->with( $this->equalTo( PostProcHandler::POST_PROC_QUERYREF ) )
+			->with( $this->equalTo( PostProcHandler::POST_EDIT_UPDATE ) )
 			->will( $this->returnValue( [ 'Bar' => true ] ) );
 
 		$instance = new PostProcHandler(
@@ -124,6 +124,63 @@ class PostProcHandlerTest extends \PHPUnit_Framework_TestCase {
 
 		$this->assertContains(
 			'<div class="smw-postproc" data-subject="Foo#0##" data-ref="[&quot;Bar&quot;]"></div>',
+			$instance->getHtml( $title,  $webRequest )
+		);
+	}
+
+	public function testGetHtml_CheckQuery() {
+
+		$this->cache->expects( $this->atLeastOnce() )
+			->method( 'fetch' )
+			->will( $this->returnValue( true ) );
+
+		$this->cache->expects( $this->once() )
+			->method( 'save' )
+			->with( $this->stringContains( ':post' ) );
+
+		$this->parserOutput->expects( $this->at( 0 ) )
+			->method( 'getExtensionData' )
+			->with( $this->equalTo( PostProcHandler::POST_EDIT_UPDATE ) )
+			->will( $this->returnValue( [ 'Bar' => true ] ) );
+
+		$this->parserOutput->expects( $this->at( 1 ) )
+			->method( 'getExtensionData' )
+			->with( $this->equalTo( PostProcHandler::POST_EDIT_CHECK ) )
+			->will( $this->returnValue( [ 'Foobar' ] ) );
+
+		$instance = new PostProcHandler(
+			$this->parserOutput,
+			$this->cache
+		);
+
+		$instance->setOptions(
+			[
+				'check-query' => true
+			]
+		);
+
+		$title = $this->getMockBuilder( '\Title' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$title->expects( $this->atLeastOnce() )
+			->method( 'getDBKey' )
+			->will( $this->returnValue( 'Foo' ) );
+
+		$title->expects( $this->atLeastOnce() )
+			->method( 'getNamespace' )
+			->will( $this->returnValue( NS_MAIN ) );
+
+		$title->expects( $this->atLeastOnce() )
+			->method( 'getLatestRevID' )
+			->will( $this->returnValue( 42 ) );
+
+		$webRequest = $this->getMockBuilder( '\WebRequest' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$this->assertContains(
+			'<div class="smw-postproc" data-subject="Foo#0##" data-ref="[&quot;Bar&quot;]" data-query="[&quot;Foobar&quot;]"></div>',
 			$instance->getHtml( $title,  $webRequest )
 		);
 	}
@@ -205,7 +262,7 @@ class PostProcHandlerTest extends \PHPUnit_Framework_TestCase {
 
 		$this->parserOutput->expects( $this->once() )
 			->method( 'getExtensionData' )
-			->with( $this->equalTo( PostProcHandler::POST_PROC_QUERYREF ) )
+			->with( $this->equalTo( PostProcHandler::POST_EDIT_UPDATE ) )
 			->will( $this->returnValue( [ 'Bar' ] ) );
 
 		$instance = new PostProcHandler(
@@ -244,18 +301,18 @@ class PostProcHandlerTest extends \PHPUnit_Framework_TestCase {
 	}
 
 	/**
-	 * @dataProvider queryRefProvider
+	 * @dataProvider queryProvider
 	 */
-	public function testAddQueryRef( $gExtensionData, $sExtensionData, $query ) {
+	public function testAddUpdate( $gExtensionData, $sExtensionData, $query ) {
 
 		$this->parserOutput->expects( $this->once() )
 			->method( 'getExtensionData' )
-			->with( $this->equalTo( PostProcHandler::POST_PROC_QUERYREF ) )
+			->with( $this->equalTo( PostProcHandler::POST_EDIT_UPDATE ) )
 			->will( $this->returnValue( $gExtensionData ) );
 
 		$this->parserOutput->expects( $this->once() )
 			->method( 'setExtensionData' )
-			->with( $this->equalTo( PostProcHandler::POST_PROC_QUERYREF ) )
+			->with( $this->equalTo( PostProcHandler::POST_EDIT_UPDATE ) )
 			->will( $this->returnValue( $sExtensionData ) );
 
 		$instance = new PostProcHandler(
@@ -263,10 +320,39 @@ class PostProcHandlerTest extends \PHPUnit_Framework_TestCase {
 			$this->cache
 		);
 
-		$instance->addQueryRef( $query );
+		$instance->addUpdate( $query );
 	}
 
-	public function queryRefProvider() {
+	/**
+	 * @dataProvider queryProvider
+	 */
+	public function testAddCheck( $gExtensionData, $sExtensionData, $query ) {
+
+		$this->parserOutput->expects( $this->once() )
+			->method( 'getExtensionData' )
+			->with( $this->equalTo( PostProcHandler::POST_EDIT_CHECK ) )
+			->will( $this->returnValue( $gExtensionData ) );
+
+		$this->parserOutput->expects( $this->once() )
+			->method( 'setExtensionData' )
+			->with( $this->equalTo( PostProcHandler::POST_EDIT_CHECK ) )
+			->will( $this->returnValue( $sExtensionData ) );
+
+		$instance = new PostProcHandler(
+			$this->parserOutput,
+			$this->cache
+		);
+
+		$instance->setOptions(
+			[
+				'check-query' => true
+			]
+		);
+
+		$instance->addCheck( $query );
+	}
+
+	public function queryProvider() {
 
 		$query = $this->getMockBuilder( '\SMWQuery' )
 			->disableOriginalConstructor()


### PR DESCRIPTION
This PR is made in reference to: #

This PR addresses or contains:

- Disabled by default, marked as experimental
- The idea behind `check-query` is to check/compare registered queries on a post-edit via the API and trigger a page reload (not an update!) in case a query differs in its results list from before the storage (storage of data, display, and querying of related data are distinct processes with the display happening before the storage making it a likely occurrence that results used for display not reflect the most recent update state)
- Since the API has to probe registered queries, the query cache should be enabled to ensure that generated results are reused during the display/rendering of a page

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed
