### PR TITLE
Extend `smwgURITypeSchemeList` array

### DIFF
--- a/DefaultSettings.php
+++ b/DefaultSettings.php
@@ -1977,8 +1977,8 @@ return [
 	# @since 3.0
 	##
 	'smwgURITypeSchemeList' => [
-		'http', 'https', 'mailto', 'tel', 'ftp', 'news', 'file', 'urn', 'telnet',
-		'ldap', 'gopher'
+		'http', 'https', 'mailto', 'tel', 'ftp', 'sftp', 'news', 'file', 'urn',
+		'telnet', 'ldap', 'gopher', 'ssh', 'git', 'irc', 'ircs'
 	],
 	##
 


### PR DESCRIPTION
This PR is made in reference to: #3533 

This PR addresses or contains:
- Added "sftp" as the secure equivalent to "ftp"
- Added "git" as a popular URI type
- Added "ssh" as a popular URI type
- Added "irc" and "ircs" since a higher proportion of smw users might be nerdy.

This PR includes:
- [ ] Tests (unit/integration)
- [x] CI build passed

Fixes #3533