### PR TITLE
MW 1.32, Modify tests to avoid "Call to a member function getSchema() on null", refs 3571

### DIFF
--- a/tests/phpunit/Unit/SQLStore/TableBuilder/PostgresTableBuilderTest.php
+++ b/tests/phpunit/Unit/SQLStore/TableBuilder/PostgresTableBuilderTest.php
@@ -16,42 +16,73 @@ use SMW\SQLStore\TableBuilder\Table;
  */
 class PostgresTableBuilderTest extends \PHPUnit_Framework_TestCase {
 
-	public function testCanConstruct() {
+	private $connection;
 
-		$connection = $this->getMockBuilder( '\DatabaseBase' )
+	protected function setUp() {
+
+		$this->connection = $this->getMockBuilder( '\DatabaseBase' )
 			->disableOriginalConstructor()
+			->setMethods( [ 'tableExists', 'query', 'dbSchema', 'tablePrefix', 'onTransactionIdle' ] )
 			->getMockForAbstractClass();
 
-		$connection->expects( $this->any() )
+		$this->connection->expects( $this->any() )
 			->method( 'getType' )
 			->will( $this->returnValue( 'postgres' ) );
 
+		$this->connection->expects( $this->any() )
+			->method( 'dbSchema' )
+			->will( $this->returnValue( '' ) );
+
+		$this->connection->expects( $this->any() )
+			->method( 'tablePrefix' )
+			->will( $this->returnValue( '' ) );
+	}
+
+	public function testCanConstruct() {
+
 		$this->assertInstanceOf(
 			PostgresTableBuilder::class,
-			PostgresTableBuilder::factory( $connection )
+			PostgresTableBuilder::factory( $this->connection )
 		);
 	}
 
 	public function testCreateTableOnNewTable() {
 
-		$connection = $this->getMockBuilder( '\DatabaseBase' )
-			->disableOriginalConstructor()
-			->setMethods( [ 'tableExists', 'query' ] )
-			->getMockForAbstractClass();
+		if ( version_compare( $GLOBALS['wgVersion'], '1.32', '>=' ) ) {
+			$this->markTestSkipped( 'MediaWiki changed the Database signature!' );
+		}
 
-		$connection->expects( $this->any() )
-			->method( 'getType' )
-			->will( $this->returnValue( 'postgres' ) );
-
-		$connection->expects( $this->any() )
+		$this->connection->expects( $this->any() )
 			->method( 'tableExists' )
 			->will( $this->returnValue( false ) );
 
-		$connection->expects( $this->once() )
+		$this->connection->expects( $this->once() )
 			->method( 'query' )
 			->with( $this->stringContains( 'CREATE TABLE' ) );
 
-		$instance = PostgresTableBuilder::factory( $connection );
+		$instance = PostgresTableBuilder::factory( $this->connection );
+
+		$table = new Table( 'foo' );
+		$table->addColumn( 'bar', 'text' );
+
+		$instance->create( $table );
+	}
+
+	public function testCreateTableOnNewTable_132() {
+
+		if ( version_compare( $GLOBALS['wgVersion'], '1.32', '<' ) ) {
+			$this->markTestSkipped( 'MediaWiki changed the Database signature!' );
+		}
+
+		$this->connection->expects( $this->any() )
+			->method( 'tableExists' )
+			->will( $this->returnValue( false ) );
+
+		$this->connection->expects( $this->once() )
+			->method( 'query' )
+			->with( $this->stringContains( 'CREATE TABLE' ) );
+
+		$instance = PostgresTableBuilder::factory( $this->connection );
 
 		$table = new Table( 'foo' );
 		$table->addColumn( 'bar', 'text' );
@@ -61,29 +92,51 @@ class PostgresTableBuilderTest extends \PHPUnit_Framework_TestCase {
 
 	public function testUpdateTableWithNewField() {
 
-		$connection = $this->getMockBuilder( '\DatabaseBase' )
-			->disableOriginalConstructor()
-			->setMethods( [ 'tableExists', 'query' ] )
-			->getMockForAbstractClass();
+		if ( version_compare( $GLOBALS['wgVersion'], '1.32', '>=' ) ) {
+			$this->markTestSkipped( 'MediaWiki changed the Database signature!' );
+		}
 
-		$connection->expects( $this->any() )
-			->method( 'getType' )
-			->will( $this->returnValue( 'postgres' ) );
-
-		$connection->expects( $this->any() )
+		$this->connection->expects( $this->any() )
 			->method( 'tableExists' )
 			->will( $this->returnValue( true ) );
 
-		$connection->expects( $this->at( 2 ) )
+		$this->connection->expects( $this->at( 2 ) )
 			->method( 'query' )
 			->with( $this->stringContains( 'SELECT a.attname as' ) )
 			->will( $this->returnValue( [] ) );
 
-		$connection->expects( $this->at( 3 ) )
+		$this->connection->expects( $this->at( 3 ) )
 			->method( 'query' )
 			->with( $this->stringContains( 'ALTER TABLE "foo" ADD "bar" TEXT' ) );
 
-		$instance = PostgresTableBuilder::factory( $connection );
+		$instance = PostgresTableBuilder::factory( $this->connection );
+
+		$table = new Table( 'foo' );
+		$table->addColumn( 'bar', 'text' );
+
+		$instance->create( $table );
+	}
+
+	public function testUpdateTableWithNewField_132() {
+
+		if ( version_compare( $GLOBALS['wgVersion'], '1.32', '<' ) ) {
+			$this->markTestSkipped( 'MediaWiki changed the Database signature!' );
+		}
+
+		$this->connection->expects( $this->any() )
+			->method( 'tableExists' )
+			->will( $this->returnValue( true ) );
+
+		$this->connection->expects( $this->at( 4 ) )
+			->method( 'query' )
+			->with( $this->stringContains( 'SELECT a.attname as' ) )
+			->will( $this->returnValue( [] ) );
+
+		$this->connection->expects( $this->at( 5 ) )
+			->method( 'query' )
+			->with( $this->stringContains( 'ALTER TABLE "foo" ADD "bar" TEXT' ) );
+
+		$instance = PostgresTableBuilder::factory( $this->connection );
 
 		$table = new Table( 'foo' );
 		$table->addColumn( 'bar', 'text' );
@@ -93,29 +146,52 @@ class PostgresTableBuilderTest extends \PHPUnit_Framework_TestCase {
 
 	public function testUpdateTableWithNewFieldAndDefault() {
 
-		$connection = $this->getMockBuilder( '\DatabaseBase' )
-			->disableOriginalConstructor()
-			->setMethods( [ 'tableExists', 'query' ] )
-			->getMockForAbstractClass();
+		if ( version_compare( $GLOBALS['wgVersion'], '1.32', '>=' ) ) {
+			$this->markTestSkipped( 'MediaWiki changed the Database signature!' );
+		}
 
-		$connection->expects( $this->any() )
-			->method( 'getType' )
-			->will( $this->returnValue( 'postgres' ) );
-
-		$connection->expects( $this->any() )
+		$this->connection->expects( $this->any() )
 			->method( 'tableExists' )
 			->will( $this->returnValue( true ) );
 
-		$connection->expects( $this->at( 2 ) )
+		$this->connection->expects( $this->at( 2 ) )
 			->method( 'query' )
 			->with( $this->stringContains( 'SELECT a.attname as' ) )
 			->will( $this->returnValue( [] ) );
 
-		$connection->expects( $this->at( 3 ) )
+		$this->connection->expects( $this->at( 3 ) )
 			->method( 'query' )
 			->with( $this->stringContains( 'ALTER TABLE "foo" ADD "bar" TEXT'. " DEFAULT '0'" ) );
 
-		$instance = PostgresTableBuilder::factory( $connection );
+		$instance = PostgresTableBuilder::factory( $this->connection );
+
+		$table = new Table( 'foo' );
+		$table->addColumn( 'bar', 'text' );
+		$table->addDefault( 'bar', 0 );
+
+		$instance->create( $table );
+	}
+
+	public function testUpdateTableWithNewFieldAndDefault_132() {
+
+		if ( version_compare( $GLOBALS['wgVersion'], '1.32', '<' ) ) {
+			$this->markTestSkipped( 'MediaWiki changed the Database signature!' );
+		}
+
+		$this->connection->expects( $this->any() )
+			->method( 'tableExists' )
+			->will( $this->returnValue( true ) );
+
+		$this->connection->expects( $this->at( 4 ) )
+			->method( 'query' )
+			->with( $this->stringContains( 'SELECT a.attname as' ) )
+			->will( $this->returnValue( [] ) );
+
+		$this->connection->expects( $this->at( 5 ) )
+			->method( 'query' )
+			->with( $this->stringContains( 'ALTER TABLE "foo" ADD "bar" TEXT'. " DEFAULT '0'" ) );
+
+		$instance = PostgresTableBuilder::factory( $this->connection );
 
 		$table = new Table( 'foo' );
 		$table->addColumn( 'bar', 'text' );
@@ -126,33 +202,60 @@ class PostgresTableBuilderTest extends \PHPUnit_Framework_TestCase {
 
 	public function testCreateIndex() {
 
-		$connection = $this->getMockBuilder( '\DatabaseBase' )
-			->disableOriginalConstructor()
-			->setMethods( [ 'tableExists', 'query', 'indexInfo' ] )
-			->getMockForAbstractClass();
+		if ( version_compare( $GLOBALS['wgVersion'], '1.32', '>=' ) ) {
+			$this->markTestSkipped( 'MediaWiki changed the Database signature!' );
+		}
 
-		$connection->expects( $this->any() )
-			->method( 'getType' )
-			->will( $this->returnValue( 'postgres' ) );
-
-		$connection->expects( $this->any() )
+		$this->connection->expects( $this->any() )
 			->method( 'tableExists' )
 			->will( $this->returnValue( false ) );
 
-		$connection->expects( $this->any() )
+		$this->connection->expects( $this->any() )
 			->method( 'indexInfo' )
 			->will( $this->returnValue( false ) );
 
-		$connection->expects( $this->at( 3 ) )
+		$this->connection->expects( $this->at( 3 ) )
 			->method( 'query' )
 			->with( $this->stringContains( 'SELECT  i.relname AS indexname' ) )
 			->will( $this->returnValue( [] ) );
 
-		$connection->expects( $this->at( 5 ) )
+		$this->connection->expects( $this->at( 5 ) )
 			->method( 'query' )
 			->with( $this->stringContains( 'CREATE INDEX foo_idx_bar ON foo (bar)' ) );
 
-		$instance = PostgresTableBuilder::factory( $connection );
+		$instance = PostgresTableBuilder::factory( $this->connection );
+
+		$table = new Table( 'foo' );
+		$table->addColumn( 'bar', 'text' );
+		$table->addIndex( 'bar' );
+
+		$instance->create( $table );
+	}
+
+	public function testCreateIndex_132() {
+
+		if ( version_compare( $GLOBALS['wgVersion'], '1.32', '<' ) ) {
+			$this->markTestSkipped( 'MediaWiki changed the Database signature!' );
+		}
+
+		$this->connection->expects( $this->any() )
+			->method( 'tableExists' )
+			->will( $this->returnValue( false ) );
+
+		$this->connection->expects( $this->any() )
+			->method( 'indexInfo' )
+			->will( $this->returnValue( false ) );
+
+		$this->connection->expects( $this->at( 7 ) )
+			->method( 'query' )
+			->with( $this->stringContains( 'SELECT  i.relname AS indexname' ) )
+			->will( $this->returnValue( [] ) );
+
+		$this->connection->expects( $this->at( 11 ) )
+			->method( 'query' )
+			->with( $this->stringContains( 'CREATE INDEX foo_idx_bar ON foo (bar)' ) );
+
+		$instance = PostgresTableBuilder::factory( $this->connection );
 
 		$table = new Table( 'foo' );
 		$table->addColumn( 'bar', 'text' );
@@ -163,24 +266,39 @@ class PostgresTableBuilderTest extends \PHPUnit_Framework_TestCase {
 
 	public function testDropTable() {
 
-		$connection = $this->getMockBuilder( '\DatabaseBase' )
-			->disableOriginalConstructor()
-			->setMethods( [ 'tableExists', 'query' ] )
-			->getMockForAbstractClass();
+		if ( version_compare( $GLOBALS['wgVersion'], '1.32', '>=' ) ) {
+			$this->markTestSkipped( 'MediaWiki changed the Database signature!' );
+		}
 
-		$connection->expects( $this->any() )
-			->method( 'getType' )
-			->will( $this->returnValue( 'postgres' ) );
-
-		$connection->expects( $this->once() )
+		$this->connection->expects( $this->once() )
 			->method( 'tableExists' )
 			->will( $this->returnValue( true ) );
 
-		$connection->expects( $this->once() )
+		$this->connection->expects( $this->once() )
 			->method( 'query' )
 			->with( $this->stringContains( 'DROP TABLE IF EXISTS "foo"' ) );
 
-		$instance = PostgresTableBuilder::factory( $connection );
+		$instance = PostgresTableBuilder::factory( $this->connection );
+
+		$table = new Table( 'foo' );
+		$instance->drop( $table );
+	}
+
+	public function testDropTable_132() {
+
+		if ( version_compare( $GLOBALS['wgVersion'], '1.32', '<' ) ) {
+			$this->markTestSkipped( 'MediaWiki changed the Database signature!' );
+		}
+
+		$this->connection->expects( $this->once() )
+			->method( 'tableExists' )
+			->will( $this->returnValue( true ) );
+
+		$this->connection->expects( $this->once() )
+			->method( 'query' )
+			->with( $this->stringContains( 'DROP TABLE IF EXISTS "foo"' ) );
+
+		$instance = PostgresTableBuilder::factory( $this->connection );
 
 		$table = new Table( 'foo' );
 		$instance->drop( $table );
@@ -188,44 +306,77 @@ class PostgresTableBuilderTest extends \PHPUnit_Framework_TestCase {
 
 	public function testDoCheckOnAfterCreate() {
 
-		$connection = $this->getMockBuilder( '\DatabaseBase' )
-			->disableOriginalConstructor()
-			->setMethods( [ 'query', 'getType', 'onTransactionIdle' ] )
-			->getMockForAbstractClass();
+		if ( version_compare( $GLOBALS['wgVersion'], '1.32', '>=' ) ) {
+			$this->markTestSkipped( 'MediaWiki changed the Database signature!' );
+		}
 
-		$connection->expects( $this->any() )
-			->method( 'getType' )
-			->will( $this->returnValue( 'postgres' ) );
-
-		$connection->expects( $this->any() )
+		$this->connection->expects( $this->any() )
 			->method( 'onTransactionIdle' )
 			->will( $this->returnCallback( function( $callback ) { return $callback(); } ) );
 
-		$connection->expects( $this->at( 4 ) )
+		$this->connection->expects( $this->at( 4 ) )
 			->method( 'query' )
 			->with( $this->stringContains( 'ALTER SEQUENCE' ) );
 
-		$instance = PostgresTableBuilder::factory( $connection );
+		$instance = PostgresTableBuilder::factory( $this->connection );
+
+		$instance->checkOn( $instance::POST_CREATION );
+	}
+
+	public function testDoCheckOnAfterCreate_132() {
+
+		if ( version_compare( $GLOBALS['wgVersion'], '1.32', '<' ) ) {
+			$this->markTestSkipped( 'MediaWiki changed the Database signature!' );
+		}
+
+		$this->connection->expects( $this->any() )
+			->method( 'onTransactionIdle' )
+			->will( $this->returnCallback( function( $callback ) { return $callback(); } ) );
+
+		$this->connection->expects( $this->at( 6 ) )
+			->method( 'query' )
+			->with( $this->stringContains( 'ALTER SEQUENCE' ) );
+
+		$instance = PostgresTableBuilder::factory( $this->connection );
 
 		$instance->checkOn( $instance::POST_CREATION );
 	}
 
 	public function testOptimizeTable() {
 
-		$connection = $this->getMockBuilder( '\DatabaseBase' )
-			->disableOriginalConstructor()
-			->setMethods( [ 'query' ] )
-			->getMockForAbstractClass();
+		if ( version_compare( $GLOBALS['wgVersion'], '1.32', '>=' ) ) {
+			$this->markTestSkipped( 'MediaWiki changed the Database signature!' );
+		}
 
-		$connection->expects( $this->any() )
+		$this->connection->expects( $this->any() )
 			->method( 'getType' )
 			->will( $this->returnValue( 'postgres' ) );
 
-		$connection->expects( $this->at( 1 ) )
+		$this->connection->expects( $this->at( 1 ) )
 			->method( 'query' )
 			->with( $this->stringContains( 'ANALYZE "foo"' ) );
 
-		$instance = PostgresTableBuilder::factory( $connection );
+		$instance = PostgresTableBuilder::factory( $this->connection );
+
+		$table = new Table( 'foo' );
+		$instance->optimize( $table );
+	}
+
+	public function testOptimizeTable_132() {
+
+		if ( version_compare( $GLOBALS['wgVersion'], '1.32', '<' ) ) {
+			$this->markTestSkipped( 'MediaWiki changed the Database signature!' );
+		}
+
+		$this->connection->expects( $this->any() )
+			->method( 'getType' )
+			->will( $this->returnValue( 'postgres' ) );
+
+		$this->connection->expects( $this->at( 3 ) )
+			->method( 'query' )
+			->with( $this->stringContains( 'ANALYZE "foo"' ) );
+
+		$instance = PostgresTableBuilder::factory( $this->connection );
 
 		$table = new Table( 'foo' );
 		$instance->optimize( $table );


### PR DESCRIPTION
This PR is made in reference to: #3571, #3556, #3569

This PR addresses or contains:

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed

Fixes #3571