### PR TITLE
Avoid `decoding="async"` in tests, refs 3569

### DIFF
--- a/tests/phpunit/Integration/JSONScript/TestCases/p-0705.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/p-0705.json
@@ -37,7 +37,7 @@
 			"assert-output": {
 				"to-contain": [
 					"class=\"image\"><img alt=\"P0705.png\"",
-					"300px-P0705.png\" width=\"300\" height=\"300\" style=\"vertical-align: text-top\" class=\"thumbborder\""
+					"300px-P0705.png\" .*width=\"300\" height=\"300\" style=\"vertical-align: text-top\" class=\"thumbborder\""
 				],
 				"not-contain": [
 					"P0705.png\" width=\"480\" height=\"480\""
@@ -50,9 +50,9 @@
 			"subject": "Example/P0705/Q.2",
 			"assert-output": {
 				"to-contain": [
-					"300px-P0705.png\" width=\"300\" height=\"300\" style=\"vertical-align: text-top\" class=\"thumbborder\"",
+					"300px-P0705.png\" .*width=\"300\" height=\"300\" style=\"vertical-align: text-top\" class=\"thumbborder\"",
 					"class=\"image\"><img alt=\"P0705.png\"",
-					"120px-P0705.png\" width=\"120\" height=\"120\" class=\"thumbimage\"",
+					"120px-P0705.png\" .*width=\"120\" height=\"120\" class=\"thumbimage\"",
 					"<b>123</b>",
 					"class=\"thumb tright\"",
 					"<div class=\"thumbcaption\"><div class=\"magnify\">",

--- a/tests/phpunit/Integration/JSONScript/TestCases/s-0012.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/s-0012.json
@@ -29,7 +29,7 @@
 			"assert-output": {
 				"to-contain": [
 					"<td class=\"Has-file smwtype_wpg\"><div class=\"thumb tright\"><div class=\"thumbinner\" style=\"width:52px;\">",
-					"S0012.png/50px-S0012.png\" width=\"50\" height=\"50\" class=\"thumbimage\"",
+					"S0012.png/50px-S0012.png\" .*width=\"50\" height=\"50\" class=\"thumbimage\"",
 					"<div class=\"thumbcaption\"><div class=\"magnify\">",
 					"class=\"internal\" title=\"Enlarge\">",
 					"</a></div>123</div>"


### PR DESCRIPTION
This PR is made in reference to: https://github.com/wikimedia/mediawiki/commit/4a79eefc78e6c9c782bf946b8be01803734f0635

This PR addresses or contains:

- Skip matching `decoding="async"` added with MW 1.33
- Passes `mw-master` / PHP 7.2

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed

Fixes #