### PR TITLE
[CI] Replace HHVM with PHP 7.2, refs 2688

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,8 +24,8 @@ matrix:
       php: 5.6
     - env: DB=mysql; MW=REL1_30; ES=5.6.6; PHPUNIT=5.7.*
       php: 7.1
-    - env: DB=mysql; MW=REL1_27; TYPE=benchmark; PHPUNIT=5.7.*
-      php: hhvm-3.18
+    - env: DB=mysql; MW=REL1_31; TYPE=benchmark; PHPUNIT=6.5.*
+      php: 7.2
     - env: DB=sqlite; MW=master; PHPUNIT=6.5.*
       php: 7.2
     - env: DB=sqlite; MW=REL1_27; TYPE=composer; PHPUNIT=4.8.*
@@ -40,7 +40,7 @@ matrix:
     # This is MW master, you never know what WMF developers have put in for easter eggs
     - env: DB=sqlite; MW=master; PHPUNIT=6.5.*
     # May take a moment and is non-critical therefore allow it to run without delaying the status
-    - env: DB=mysql; MW=REL1_27; TYPE=benchmark; PHPUNIT=5.7.*
+    - env: DB=mysql; MW=REL1_31; TYPE=benchmark; PHPUNIT=6.5.*
     - env: DB=mysql; MW=REL1_27; SESAME=2.8.7
     - env: DB=mysql; MW=REL1_30; ES=5.6.6; PHPUNIT=5.7.*
 


### PR DESCRIPTION
This PR is made in reference to: #2688

This PR addresses or contains:

- Final task to remove support for HHVM

This PR includes:
- [ ] Tests (unit/integration)
- [x] CI build passed

Fixes #2688