### PR TITLE
Detect pipe `[[ ... | ... ]]` in printrequest label, refs 3523, 3211

### DIFF
--- a/tests/phpunit/Integration/JSONScript/TestCases/s-0031.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/s-0031.json
@@ -1,0 +1,95 @@
+{
+	"description": "Test `Special:Ask` output on `?...=[[...|...]]|+index...`",
+	"setup": [
+		{
+			"namespace": "SMW_NS_PROPERTY",
+			"page": "Has page",
+			"contents": "[[Has type::Page]]"
+		},
+		{
+			"page": "Example/S0031/1",
+			"contents": "[[Has page::123]] [[Category:S0031]]"
+		}
+	],
+	"tests": [
+		{
+			"type": "special",
+			"about": "#0 (#3211, label `?Has page=[[Foo|bar]]` ",
+			"special-page": {
+				"page": "Ask",
+				"query-parameters": "-5B-5BHas-20page::123-5D-5D-20-5B-5BCategory:S0031-5D-5D/-3FHas-20page%3D-5B-5BFoo-7Cbar-5D-5D/mainlabel%3D/offset%3D0/format%3Dtable/headers%3Dplain",
+				"request-parameters": []
+			},
+			"assert-output": {
+				"to-contain": [
+					"{{#ask: [[Has page::123]] [[Category:S0031]]",
+					" |?Has page=[[Foo|bar]]",
+					" |order=asc",
+					" |headers=plain",
+					" |mainlabel="
+				]
+			}
+		},
+		{
+			"type": "special",
+			"about": "#1 (#3211, label `?Has page=[[Foo|bar]]|+index=1` ",
+			"special-page": {
+				"page": "Ask",
+				"query-parameters": "-5B-5BHas-20page::123-5D-5D-20-5B-5BCategory:S0031-5D-5D/-3FHas-20page%3D-5B-5BFoo-7Cbar-5D-5D-7C%2Bindex%3D1/mainlabel%3D/offset%3D0/format%3Dtable/headers%3Dplain",
+				"request-parameters": []
+			},
+			"assert-output": {
+				"to-contain": [
+					"{{#ask: [[Has page::123]] [[Category:S0031]]",
+					" |?Has page=[[Foo|bar]]|+index=1",
+					" |order=asc",
+					" |headers=plain",
+					" |mainlabel="
+				]
+			}
+		},
+		{
+			"type": "special",
+			"about": "#2 (#3211, label `?Has page=[[Foo|bar]]|+index=1` ",
+			"special-page": {
+				"page": "Ask",
+				"query-parameters": [],
+				"request-parameters": {
+					"p": {
+						"headers": "plain",
+						"limit": "10",
+						"offset": "0",
+						"mainlabel": "",
+						"searchlabel": ""
+					},
+					"q": "[[Has page::123]] [[Category:S0031]]",
+					"po": "?Has page=[[Foo|bar]]|+index=1"
+				}
+			},
+			"assert-output": {
+				"to-contain": [
+					"{{#ask: [[Has page::123]] [[Category:S0031]]",
+					" |?Has page=[[Foo|bar]]|+index=1",
+					" |order=asc",
+					" |headers=plain"
+				]
+			}
+		}
+	],
+	"settings": {
+		"wgContLang": "en",
+		"wgLanguageCode": "en",
+		"smwgPageSpecialProperties": [
+			"_MDAT"
+		],
+		"smwgNamespacesWithSemanticLinks": {
+			"NS_MAIN": true,
+			"SMW_NS_PROPERTY": true
+		}
+	},
+	"meta": {
+		"version": "2",
+		"is-incomplete": false,
+		"debug": false
+	}
+}

--- a/tests/phpunit/Unit/MediaWiki/Specials/Ask/ParametersProcessorTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Specials/Ask/ParametersProcessorTest.php
@@ -46,6 +46,63 @@ class ParametersProcessorTest extends \PHPUnit_Framework_TestCase {
 		);
 	}
 
+	public function testParameters_Printrequest_PlusPipe() {
+
+		$request = $this->getMockBuilder( '\WebRequest' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$parameters = [
+			'[[Foo::bar]]',
+			'|?Foo=Bar|+index=1'
+		];
+
+		$result = ParametersProcessor::process( $request, $parameters );
+
+		$this->assertEquals(
+			'Bar|+index=1',
+			$result[1]['|?foo']
+		);
+	}
+
+	public function testParameters_Printrequest_WikiLink() {
+
+		$request = $this->getMockBuilder( '\WebRequest' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$parameters = [
+			'[[Foo::bar]]',
+			'|?Foo=[[Some|other]]'
+		];
+
+		$result = ParametersProcessor::process( $request, $parameters );
+
+		$this->assertEquals(
+			'[[Some|other]]',
+			$result[1]['|?foo']
+		);
+	}
+
+	public function testParameters_Printrequest_WikiLink_PlusPipe() {
+
+		$request = $this->getMockBuilder( '\WebRequest' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$parameters = [
+			'[[Foo::bar]]',
+			'|?Foo=[[Some|other]]|+index=1'
+		];
+
+		$result = ParametersProcessor::process( $request, $parameters );
+
+		$this->assertEquals(
+			'[[Some|other]]|+index=1',
+			$result[1]['|?foo']
+		);
+	}
+
 	public function testParametersWithDefaults() {
 
 		$request = $this->getMockBuilder( '\WebRequest' )


### PR DESCRIPTION
This PR is made in reference to: #3523, #3211, https://github.com/SemanticMediaWiki/SemanticMediaWiki/commit/6d351bbf2e0fee679196bfa7f37d18a7bd3b85e2

This PR addresses or contains:

- Encodes `|` in `[[ ... | ... ]]` before splitting the value parameter

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed

Fixes #3523