### PR TITLE
Enable testing for PHP 7.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,8 @@ matrix:
   include:
     - env: DB=mysql; MW=REL1_29; PHPUNIT=5.7.*
       php: 7.1
+    - env: DB=mysql: MW=master; PHPUNIT=6.5.*
+      php: 7.3
     - env: DB=mysql; MW=REL1_28; FUSEKI=2.4.0; PHPUNIT=4.8.*
       php: 5.6
     - env: DB=mysql; MW=REL1_27; VIRTUOSO=6.1; PHPUNIT=4.8.*
@@ -27,7 +29,7 @@ matrix:
     - env: DB=mysql; MW=REL1_31; TYPE=benchmark; PHPUNIT=6.5.*
       php: 7.2
     - env: DB=sqlite; MW=master; PHPUNIT=6.5.*
-      php: 7.2
+      php: 7.3
     - env: DB=sqlite; MW=REL1_27; TYPE=composer; PHPUNIT=4.8.*
       php: 5.6
     - env: DB=mysql; MW=REL1_27; TYPE=relbuild; PHPUNIT=4.8.*

--- a/README.md
+++ b/README.md
@@ -46,7 +46,6 @@ to the version of the code it comes bundled with. The most important files are l
 
 [![Twitter](https://www.semantic-mediawiki.org/w/images/c/c9/Twitter_icon.jpg)](https://twitter.com/#!/semanticmw)
 [![Facebook](https://www.semantic-mediawiki.org/w/images/thumb/7/77/677166248.png/30px-677166248.png)](https://www.facebook.com/pages/Semantic-MediaWiki/160459700707245)
-[![Google+](https://www.semantic-mediawiki.org/w/images/a/ae/30px-Google%2B.png)](https://plus.google.com/115301028320198614441/posts)
 
 Many people have contributed to SMW. A list of people who have made contributions in the past can
 be found [here][contributors] or on the [wiki for Semantic MediaWiki](https://www.semantic-mediawiki.org/wiki/Help:SMW_Project#Contributors).


### PR DESCRIPTION
This PR is made in reference to: #3579, #3556, #3585

This PR addresses or contains:
- Enable testing for PHP 7.3
- Also run tests for master and mysql and not just sqlite

This PR includes:
- [ ] Tests (unit/integration)
- [ ] CI build passed

Fixes #