### PR TITLE
[CI] Avoid "... PermissionsError: The action you have ... "

### DIFF
--- a/tests/phpunit/Integration/JSONScript/ParserTestCaseProcessor.php
+++ b/tests/phpunit/Integration/JSONScript/ParserTestCaseProcessor.php
@@ -44,6 +44,11 @@ class ParserTestCaseProcessor extends \PHPUnit_Framework_TestCase {
 	private $pageReader;
 
 	/**
+	 * @var User
+	 */
+	private $superUser;
+
+	/**
 	 * @var SerializerFactory
 	 */
 	private $serializerFactory;
@@ -65,6 +70,7 @@ class ParserTestCaseProcessor extends \PHPUnit_Framework_TestCase {
 		$this->incomingSemanticDataValidator = $incomingSemanticDataValidator;
 		$this->stringValidator = $stringValidator;
 		$this->pageReader = UtilityFactory::getInstance()->newPageReader();
+		$this->superUser = UtilityFactory::getInstance()->newMockSuperUser();
 		$this->serializerFactory = \SMW\ApplicationFactory::getInstance()->newSerializerFactory();
 	}
 
@@ -169,6 +175,11 @@ class ParserTestCaseProcessor extends \PHPUnit_Framework_TestCase {
 				$title,
 				$parameters
 			);
+
+			// Avoid "... PermissionsError: The action you have requested is
+			// limited to users in the group ..."
+			$context->setUser( $this->superUser );
+
 			\Article::newFromTitle( $title, $context )->view();
 			$output = $context->getOutput()->getHtml();
 		} else {

--- a/tests/phpunit/Utils/UtilityFactory.php
+++ b/tests/phpunit/Utils/UtilityFactory.php
@@ -11,6 +11,7 @@ use SMW\Tests\Utils\Fixtures\FixturesFactory;
 use SMW\Tests\Utils\Page\PageEditor;
 use SMW\Tests\Utils\Runners\RunnerFactory;
 use SMW\Tests\Utils\Validators\ValidatorFactory;
+use SMW\Tests\Utils\Mock\MockSuperUser;
 
 /**
  * @license GNU GPL v2+
@@ -243,6 +244,15 @@ class UtilityFactory {
 	 */
 	public function newSpyMessageReporter() {
 		return new SpyMessageReporter();
+	}
+
+	/**
+	 * @since 3.1
+	 *
+	 * @return MockSuperUser
+	 */
+	public function newMockSuperUser() {
+		return new MockSuperUser();
 	}
 
 }


### PR DESCRIPTION
This PR is made in reference to: #

This PR addresses or contains:

- "PermissionsError: The action you have requested is limited to users in the group ... " appeared on a "closed" wiki while testing, setting `MockSuperUser` resolves the issue.

This PR includes:
- [ ] Tests (unit/integration)
- [x] CI build passed

### Stack trace

```
1) SMW\Tests\Integration\JSONScript\JsonTestCaseScriptRunnerTest::testCaseFile with data set "p-0111.json" ('...\...1.json')
PermissionsError: The action you have requested is limited to users in the group: [[Mw-31-00-git:Users|Users]].

...\includes\page\Article.php:449
...\extensions\SemanticMediaWiki\src\Page\Page.php:97
...\extensions\SemanticMediaWiki\tests\phpunit\Integration\JSONScript\ParserTestCaseProcessor.php:172
...\extensions\SemanticMediaWiki\tests\phpunit\Integration\JSONScript\ParserTestCaseProcessor.php:95
...\extensions\SemanticMediaWiki\tests\phpunit\Integration\JSONScript\JsonTestCaseScriptRunnerTest.php:377
...\extensions\SemanticMediaWiki\tests\phpunit\Integration\JSONScript\JsonTestCaseScriptRunnerTest.php:213
...\extensions\SemanticMediaWiki\tests\phpunit\JsonTestCaseScriptRunner.php:215
...\extensions\SemanticMediaWiki\tests\phpunit\DatabaseTestCase.php:133
...\maintenance\doMaintenance.php:94
```