### PR TITLE
Unlink invalid user names, refs 3278

### DIFF
--- a/includes/datavalues/SMW_DataValue.php
+++ b/includes/datavalues/SMW_DataValue.php
@@ -72,9 +72,14 @@ abstract class SMWDataValue {
 	const OPT_QUERY_COMP_CONTEXT = 'query.comparator.context';
 
 	/**
-	 * Option to disable an infolinks highlight/tooltip
+	 * Option to disable related infolinks
 	 */
 	const OPT_DISABLE_INFOLINKS = 'disable.infolinks';
+
+	/**
+	 * Option to disable service links
+	 */
+	const OPT_DISABLE_SERVICELINKS = 'disable.servicelinks';
 
 	/**
 	 * Option to use compact infolinks
@@ -635,11 +640,15 @@ abstract class SMWDataValue {
 	 */
 	public function getInfolinkText( $outputFormat, $linker = null ) {
 
+		if ( $this->getOption( self::OPT_DISABLE_INFOLINKS ) === true ) {
+			return '';
+		}
+
 		if ( $this->infoLinksProvider === null ) {
 			$this->infoLinksProvider = $this->dataValueServiceFactory->newInfoLinksProvider( $this );
 		}
 
-		if ( $this->getOption( self::OPT_DISABLE_INFOLINKS ) === true ) {
+		if ( $this->getOption( self::OPT_DISABLE_SERVICELINKS ) === true ) {
 			$this->infoLinksProvider->disableServiceLinks();
 		}
 

--- a/src/Factbox/Factbox.php
+++ b/src/Factbox/Factbox.php
@@ -407,7 +407,7 @@ class Factbox {
 				$outputFormat = $dataValue->getOutputFormat();
 				$dataValue->setOutputFormat( $outputFormat ? $outputFormat : 'LOCL' );
 
-				$dataValue->setOption( $dataValue::OPT_DISABLE_INFOLINKS, true );
+				$dataValue->setOption( $dataValue::OPT_DISABLE_SERVICELINKS, true );
 
 				if ( $dataValue->isValid() ) {
 					$list[] = $dataValue->getLongWikiText( true ) . $dataValue->getInfolinkText( SMW_OUTPUT_WIKI );

--- a/src/MediaWiki/Specials/Browse/ValueFormatter.php
+++ b/src/MediaWiki/Specials/Browse/ValueFormatter.php
@@ -103,8 +103,12 @@ class ValueFormatter {
 		}
 
 		$html = $dataValue->getLongHTMLText( $linker );
-		$isCompactLink = $dataValue->getOption( DataValue::OPT_COMPACT_INFOLINKS, false );
 
+		if ( $dataValue->getOption( DataValue::OPT_DISABLE_INFOLINKS, false ) === true ) {
+			return $html;
+		}
+
+		$isCompactLink = $dataValue->getOption( DataValue::OPT_COMPACT_INFOLINKS, false );
 		$noInfolinks = [ '_INST', '_SKEY' ];
 
 		if ( in_array( $dataValue->getTypeID(), [ '_wpg', '_wpp', '__sob'] ) ) {

--- a/tests/phpunit/includes/DataValues/WikiPageValueTest.php
+++ b/tests/phpunit/includes/DataValues/WikiPageValueTest.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace SMW\Tests\DataValues;
+
+use SMW\DataItemFactory;
+use SMW\Tests\TestEnvironment;
+use SMWWikiPageValue as WikiPageValue;
+
+/**
+ * @covers \SMWWikiPageValue
+ * @group semantic-mediawiki
+ *
+ * @license GNU GPL v2+
+ * @since 3.1
+ *
+ * @author mwjames
+ */
+class WikiPageValueTest extends \PHPUnit_Framework_TestCase {
+
+	private $testEnvironment;
+	private $dataItemFactory;
+
+	protected function setUp() {
+		parent::setUp();
+
+		$this->testEnvironment = new TestEnvironment();
+		$this->dataItemFactory = new DataItemFactory();
+
+		$this->propertySpecificationLookup = $this->getMockBuilder( '\SMW\PropertySpecificationLookup' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$this->testEnvironment->registerObject( 'PropertySpecificationLookup', $this->propertySpecificationLookup );
+	}
+
+	protected function tearDown() {
+		$this->testEnvironment->tearDown();
+		parent::tearDown();
+	}
+
+	public function testCanConstruct() {
+
+		$this->assertInstanceOf(
+			WikiPageValue::class,
+			new WikiPageValue( '' )
+		);
+	}
+
+	public function testDisableInfolinksOnSpecialUsernamePrefix() {
+
+		$instance = new WikiPageValue( '_wpg' );
+
+		$this->assertFalse(
+			$instance->getOption( WikiPageValue::OPT_DISABLE_INFOLINKS )
+		);
+
+		$instance->setDataItem(
+			$this->dataItemFactory->newDIWikiPage( '>Foo', NS_USER )
+		);
+
+		$instance->getTitle();
+
+		$this->assertTrue(
+			$instance->getOption( WikiPageValue::OPT_DISABLE_INFOLINKS )
+		);
+	}
+
+}


### PR DESCRIPTION
This PR is made in reference to: #3278 

This PR addresses or contains:

- I found myself clicking on users that don't exist such as `User:Test>Importer`, fixing related ticked for the SMW specific interfaces.

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed
