### PR TITLE
Add `smwgConfigFileDir`, refs 3506, 3563

### DIFF
--- a/DefaultSettings.php
+++ b/DefaultSettings.php
@@ -34,6 +34,41 @@ return [
 	##
 
 	###
+	# Configuration directory
+	# @see #3506
+	#
+	# The maintained directory needs to be writable in order for configuration
+	# information to be stored persistently and be accessible for Semantic
+	# MediaWiki throughout its operation.
+	#
+	# You may assign the same directory as in `wgUploadDirectory` (e.g
+	# $smwgConfigFileDir = $wgUploadDirectory;) or select an entire different
+	# location. The default location is the Semantic MediaWiki extension root.
+	#
+	# @since 3.0
+	##
+	'smwgConfigFileDir' => __DIR__,
+	##
+
+	###
+	# Upgrade key
+	#
+	# This key verifies that a correct upgrade (update.php/setupStore.php) path
+	# was selected and hereby ensures a consistent DB setup.
+	#
+	# Whenever a DB table change occurs, modify the key value (e.g. `smw:20...`)
+	# to reflect the requirement for the client to follow the processes as
+	# outlined in the installation manual.
+	#
+	# Once the installer is run, the `.smw.json` will be updated and no longer
+	# cause any exception.
+	#
+	# @since 3.0
+	##
+	'smwgUpgradeKey' => 'smw:2018-09-01',
+	##
+
+	###
 	# Content import
 	#
 	# Controls the content import directory and version that is expected to be
@@ -60,24 +95,6 @@ return [
 	# @since 2.4
 	##
 	'smwgSemanticsEnabled' => false,
-	##
-
-	###
-	# Upgrade key
-	#
-	# This key verifies that a correct upgrade (update.php/setupStore.php) path
-	# was selected and hereby ensures a consistent DB setup.
-	#
-	# Whenever a DB table change occurs, modify the key value (e.g. `DB-Foo...`)
-	# to reflect the requirement for the client to follow the processes as
-	# outlined in the installation manual.
-	#
-	# Once the installer is run, the `.smw.json` will be updated and no longer
-	# causes an exception.
-	#
-	# @since 3.0
-	##
-	'smwgUpgradeKey' => 'DB-2018-09-01',
 	##
 
 	###

--- a/SemanticMediaWiki.php
+++ b/SemanticMediaWiki.php
@@ -54,13 +54,6 @@ class SemanticMediaWiki {
 				$GLOBALS[$key] = $value;
 			}
 		}
-
-		if ( is_readable( __DIR__ . '/.smw.json' ) ) {
-			$GLOBALS['smw.json'] = json_decode(
-				file_get_contents( __DIR__ . '/.smw.json' ),
-				true
-			);
-		}
 	}
 
 	/**
@@ -93,6 +86,8 @@ class SemanticMediaWiki {
 		$namespace->init( $GLOBALS );
 
 		$setup = new Setup( $applicationFactory );
+
+		$setup->loadSchema( $GLOBALS );
 		$setup->init( $GLOBALS, __DIR__ );
 	}
 

--- a/includes/Settings.php
+++ b/includes/Settings.php
@@ -48,6 +48,7 @@ class Settings extends Options {
 			'smwgExtraneousLanguageFileDir' => $GLOBALS['smwgExtraneousLanguageFileDir'],
 			'smwgServicesFileDir' => $GLOBALS['smwgServicesFileDir'],
 			'smwgResourceLoaderDefFiles' => $GLOBALS['smwgResourceLoaderDefFiles'],
+			'smwgConfigFileDir' => $GLOBALS['smwgConfigFileDir'],
 			'smwgImportFileDirs' => $GLOBALS['smwgImportFileDirs'],
 			'smwgImportReqVersion' => $GLOBALS['smwgImportReqVersion'],
 			'smwgSemanticsEnabled' => $GLOBALS['smwgSemanticsEnabled'],

--- a/includes/Setup.php
+++ b/includes/Setup.php
@@ -147,6 +147,15 @@ final class Setup {
 	}
 
 	/**
+	 * @since 3.0
+	 *
+	 * @param array &$vars
+	 */
+	public function loadSchema( &$vars ) {
+		Installer::loadSchema( $vars );
+	}
+
+	/**
 	 * @since 1.9
 	 *
 	 * @param array &$vars

--- a/src/Exception/FileNotReadableException.php
+++ b/src/Exception/FileNotReadableException.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace SMW\Exception;
+
+use RuntimeException;
+
+/**
+ * @license GNU GPL v2+
+ * @since 3.0
+ *
+ * @author mwjames
+ */
+class FileNotReadableException extends RuntimeException {
+
+	/**
+	 * @since 3.0
+	 *
+	 * @param string $file
+	 */
+	public function __construct( $file ) {
+		parent::__construct( "$file is not readable." );
+	}
+
+}

--- a/src/Exception/FileNotWritableException.php
+++ b/src/Exception/FileNotWritableException.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace SMW\Exception;
+
+use RuntimeException;
+
+/**
+ * @license GNU GPL v2+
+ * @since 3.0
+ *
+ * @author mwjames
+ */
+class FileNotWritableException extends RuntimeException {
+
+	/**
+	 * @since 3.0
+	 *
+	 * @param string $file
+	 */
+	public function __construct( $file ) {
+		parent::__construct( "$file is not writable." );
+	}
+
+}

--- a/src/Query/RemoteRequest.php
+++ b/src/Query/RemoteRequest.php
@@ -229,7 +229,7 @@ class RemoteRequest implements QueryEngine {
 
 			$this->httpRequest->setOption(
 				ONOI_HTTP_REQUEST_RESPONSECACHE_PREFIX,
-				Site::prefix( 'smw:query:remote:' )
+				Site::id( 'smw:query:remote:' )
 			);
 		}
 

--- a/src/Site.php
+++ b/src/Site.php
@@ -95,15 +95,17 @@ class Site {
 	/**
 	 * @since 3.0
 	 *
-	 * @return boolean
+	 * @param $affix string
+	 *
+	 * @return string
 	 */
-	public static function prefix( $name = '' ) {
+	public static function id( $affix = '' ) {
 
-		if ( $name{0} !== ':' ) {
-			$name = ':' . $name;
+		if ( $affix !== '' && $affix{0} !== ':' ) {
+			$affix = ':' . $affix;
 		}
 
-		return wfWikiID() . $name;
+		return wfWikiID() . $affix;
 	}
 
 	/**

--- a/src/Utils/File.php
+++ b/src/Utils/File.php
@@ -3,6 +3,7 @@
 namespace SMW\Utils;
 
 use RuntimeException;
+use SMW\Exception\FileNotWritableException;
 
 /**
  * @license GNU GPL v2+
@@ -20,6 +21,13 @@ class File {
 	 * @param integer $flags
 	 */
 	public function write( $file, $contents, $flags = 0 ) {
+
+		$file = str_replace( [ '\\', '//', '/' ], DIRECTORY_SEPARATOR, $file );
+
+		if ( !is_writable( dirname( $file ) ) ) {
+			throw new FileNotWritableException( "$file" );
+		}
+
 		file_put_contents( $file, $contents, $flags );
 	}
 

--- a/tests/phpunit/Unit/Exception/FileNotReadableExceptionTest.php
+++ b/tests/phpunit/Unit/Exception/FileNotReadableExceptionTest.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace SMW\Tests\Exception;
+
+use SMW\Exception\FileNotReadableException;
+
+/**
+ * @covers \SMW\Exception\FileNotReadableException
+ * @group semantic-mediawiki
+ *
+ * @license GNU GPL v2+
+ * @since 3.0
+ *
+ * @author mwjames
+ */
+class FileNotReadableExceptionTest extends \PHPUnit_Framework_TestCase {
+
+	public function testCanConstruct() {
+
+		$instance = new FileNotReadableException( 'Foo' );
+
+		$this->assertInstanceof(
+			FileNotReadableException::class,
+			$instance
+		);
+
+		$this->assertInstanceof(
+			'\RuntimeException',
+			$instance
+		);
+	}
+
+}

--- a/tests/phpunit/Unit/Exception/FileNotWritableExceptionTest.php
+++ b/tests/phpunit/Unit/Exception/FileNotWritableExceptionTest.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace SMW\Tests\Exception;
+
+use SMW\Exception\FileNotWritableException;
+
+/**
+ * @covers \SMW\Exception\FileNotWritableException
+ * @group semantic-mediawiki
+ *
+ * @license GNU GPL v2+
+ * @since 3.0
+ *
+ * @author mwjames
+ */
+class FileNotWritableExceptionTest extends \PHPUnit_Framework_TestCase {
+
+	public function testCanConstruct() {
+
+		$instance = new FileNotWritableException( 'Foo' );
+
+		$this->assertInstanceof(
+			FileNotWritableException::class,
+			$instance
+		);
+
+		$this->assertInstanceof(
+			'\RuntimeException',
+			$instance
+		);
+	}
+
+}

--- a/tests/phpunit/Unit/SQLStore/InstallerTest.php
+++ b/tests/phpunit/Unit/SQLStore/InstallerTest.php
@@ -22,6 +22,7 @@ class InstallerTest extends \PHPUnit_Framework_TestCase {
 	private $tableSchemaManager;
 	private $tableBuilder;
 	private $tableIntegrityExaminer;
+	private $file;
 
 	protected function setUp() {
 		parent::setUp();
@@ -41,6 +42,10 @@ class InstallerTest extends \PHPUnit_Framework_TestCase {
 			->getMock();
 
 		$this->jobQueue = $this->getMockBuilder( '\SMW\MediaWiki\JobQueue' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$this->file = $this->getMockBuilder( '\SMW\Utils\File' )
 			->disableOriginalConstructor()
 			->getMock();
 
@@ -83,6 +88,7 @@ class InstallerTest extends \PHPUnit_Framework_TestCase {
 		);
 
 		$instance->setMessageReporter( $this->spyMessageReporter );
+		$instance->setFile( $this->file );
 
 		$instance->setOptions(
 			[
@@ -126,6 +132,8 @@ class InstallerTest extends \PHPUnit_Framework_TestCase {
 		);
 
 		$instance->setMessageReporter( $this->spyMessageReporter );
+		$instance->setFile( $this->file );
+
 		$instance->setOptions(
 			[
 				Installer::OPT_SUPPLEMENT_JOBS => true
@@ -157,6 +165,7 @@ class InstallerTest extends \PHPUnit_Framework_TestCase {
 		);
 
 		$instance->setMessageReporter( $this->spyMessageReporter );
+		$instance->setFile( $this->file );
 
 		$this->assertTrue(
 			$instance->install( false )
@@ -282,6 +291,7 @@ class InstallerTest extends \PHPUnit_Framework_TestCase {
 		);
 
 		$vars = [
+			'smwgConfigFileDir' => 'Foo/',
 			'smwgIP' => '',
 			'smwgUpgradeKey' => '',
 			'smwgFixedProperties' => [],

--- a/tests/phpunit/Unit/Utils/FileTest.php
+++ b/tests/phpunit/Unit/Utils/FileTest.php
@@ -3,6 +3,7 @@
 namespace SMW\Tests\Utils;
 
 use SMW\Utils\File;
+use SMW\Tests\PHPUnitCompat;
 
 /**
  * @covers \SMW\Utils\File
@@ -15,6 +16,8 @@ use SMW\Utils\File;
  */
 class FileTest extends \PHPUnit_Framework_TestCase {
 
+	use PHPUnitCompat;
+
 	public function testCanConstruct() {
 
 		$instance = new File();
@@ -23,6 +26,14 @@ class FileTest extends \PHPUnit_Framework_TestCase {
 			File::class,
 			$instance
 		);
+	}
+
+	public function testWrite_ThrowsException() {
+
+		$instance = new File();
+
+		$this->setExpectedException( '\SMW\Exception\FileNotWritableException' );
+		$instance->write( 'abc/Foo', '' );
 	}
 
 }

--- a/tests/phpunit/includes/SetupTest.php
+++ b/tests/phpunit/includes/SetupTest.php
@@ -59,7 +59,8 @@ class SetupTest extends \PHPUnit_Framework_TestCase {
 			'wgLanguageCode'    => 'en',
 			'wgLang'            => $language,
 			'IP'                => 'Foo',
-			'smwgSemanticsEnabled' => true
+			'smwgSemanticsEnabled' => true,
+			'smwgConfigFileDir' => ''
 		];
 
 		foreach ( $this->defaultConfig as $key => $value ) {


### PR DESCRIPTION
This PR is made in reference to: #3506, #3563

This PR addresses or contains:

- Adds `smwgConfigFileDir` to specify the location (`$smwgConfigFileDir = __DIR__ . "/../.config/{$wgDBname}";`) that is expected to be writable and persistent (by default uses the SMW extension root)
- Raises an `FileNotWritableException` when the file cannot be written
- Using the wiki-id as internal identifier (#3563) in the file to distinguish between different instances
- `smwgUpgradeKey` uses a new schema 'smw:2018-09-01' to identify core changes with other extensions being able to alter the key by adding their own `sesp:..` identifier when modify the DB structure (adding fixed tables etc.)

This change when backported **will cause the upgrade key to be regenerated** now that includes the wiki-id (and new schema) as factor for comparing values.

This PR includes:
- [ ] Tests (unit/integration)
- [x] CI build passed

Fixes #3506, Fixes #3563