### PR TITLE
Conditional create full-text table (default MyISAM)

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -65,7 +65,7 @@
        <var name="smwgEntityLookupCacheType" value="hash"/>
        <var name="smwgEnabledDeferredUpdate" value="false"/>
        <var name="smwgImportReqVersion" value="false"/>
-       <var name="smwgEnabledFulltextSearch" value="false"/>
+       <var name="smwgEnabledFulltextSearch" value="true"/>
        <var name="smwgEnabledQueryDependencyLinksStore" value="true"/>
        <var name="smwgQueryResultCacheType" value="hash"/>
        <var name="benchmarkPageCopyCount" value="1000"/>

--- a/src/MediaWiki/Specials/Admin/EntityLookupTaskHandler.php
+++ b/src/MediaWiki/Specials/Admin/EntityLookupTaskHandler.php
@@ -269,23 +269,7 @@ class EntityLookupTaskHandler extends TaskHandler {
 				);
 
 				$formattedRows[$id] = (array)$row;
-
-				$row = $connection->selectRow(
-						SQLStore::FT_SEARCH_TABLE,
-						[
-							's_id',
-							'p_id',
-							'o_text'
-						],
-						[
-							's_id' => $id
-						],
-						__METHOD__
-				);
-
-				if ( $row !== false ) {
-					$references[$id][SQLStore::FT_SEARCH_TABLE] = (array)$row;
-				}
+				$this->addFulltextInfo( $id, $references );
 			}
 		}
 
@@ -320,6 +304,31 @@ class EntityLookupTaskHandler extends TaskHandler {
 		}
 
 		return [ $output, $error ];
+	}
+
+	private function addFulltextInfo( $id, &$references ) {
+		$connection = $this->store->getConnection( 'mw.db' );
+
+		if ( !$connection->tableExists( SQLStore::FT_SEARCH_TABLE ) ) {
+			return;
+		}
+
+		$row = $connection->selectRow(
+				SQLStore::FT_SEARCH_TABLE,
+				[
+					's_id',
+					'p_id',
+					'o_text'
+				],
+				[
+					's_id' => $id
+				],
+				__METHOD__
+		);
+
+		if ( $row !== false ) {
+			$references[$id][SQLStore::FT_SEARCH_TABLE] = (array)$row;
+		}
 	}
 
 }

--- a/src/SQLStore/Installer.php
+++ b/src/SQLStore/Installer.php
@@ -258,10 +258,6 @@ class Installer implements MessageReporter {
 	 */
 	public static function getUpgradeKey( $vars ) {
 
-		// The following settings influence the "shape" of the tables required
-		// therefore use the content to compute a key that reflects any
-		// changes to them
-
 		// Only recognize those properties that require a fixed table
 		$pageSpecialProperties = array_intersect(
 			$vars['smwgPageSpecialProperties'],
@@ -272,15 +268,17 @@ class Installer implements MessageReporter {
 		sort( $vars['smwgFixedProperties'] );
 		sort( $pageSpecialProperties );
 
-		return sha1(
-			json_encode(
-				[
-					$vars['smwgUpgradeKey'],
-					$vars['smwgFixedProperties'],
-					$pageSpecialProperties
-				]
-			)
-		);
+		// The following settings influence the "shape" of the tables required
+		// therefore use the content to compute a key that reflects any
+		// changes to them
+		$components = [
+			$vars['smwgUpgradeKey'],
+			$vars['smwgFixedProperties'],
+			$vars['smwgEnabledFulltextSearch'],
+			$pageSpecialProperties
+		];
+
+		return sha1( json_encode( $components ) );
 	}
 
 	/**

--- a/src/SQLStore/PropertyTableIdReferenceDisposer.php
+++ b/src/SQLStore/PropertyTableIdReferenceDisposer.php
@@ -242,11 +242,9 @@ class PropertyTableIdReferenceDisposer {
 		// Avoid Query: DELETE FROM `smw_ft_search` WHERE s_id = '92575'
 		// Error: 126 Incorrect key file for table '.\mw@002d25@002d01\smw_ft_search.MYI'; ...
 		try {
-			$this->connection->delete(
-				SQLStore::FT_SEARCH_TABLE,
-				[ 's_id' => $id ],
-				__METHOD__
-			);
+			if ( $this->connection->tableExists( SQLStore::FT_SEARCH_TABLE ) ) {
+				$this->connection->delete( SQLStore::FT_SEARCH_TABLE, [ 's_id' => $id ], __METHOD__ );
+			}
 		} catch ( \DBError $e ) {
 			ApplicationFactory::getInstance()->getMediaWikiLogger()->info( __METHOD__ . ' reported: ' . $e->getMessage() );
 		}

--- a/src/SQLStore/QueryEngine/Fulltext/TextChangeUpdater.php
+++ b/src/SQLStore/QueryEngine/Fulltext/TextChangeUpdater.php
@@ -186,9 +186,9 @@ class TextChangeUpdater {
 	 *
 	 * @param ChangeOp $changeOp
 	 */
-	public function doUpdateFromChangeDiff( ChangeDiff $changeDiff ) {
+	public function doUpdateFromChangeDiff( ChangeDiff $changeDiff = null ) {
 
-		if ( !$this->searchTableUpdater->isEnabled() ) {
+		if ( !$this->searchTableUpdater->isEnabled() || $changeDiff === null ) {
 			return;
 		}
 

--- a/src/SQLStore/SQLStoreFactory.php
+++ b/src/SQLStore/SQLStoreFactory.php
@@ -406,6 +406,13 @@ class SQLStoreFactory {
 			$this->store
 		);
 
+		$tableSchemaManager->setOptions(
+			[
+				'smwgEnabledFulltextSearch' => $settings->get( 'smwgEnabledFulltextSearch' ),
+				'smwgFulltextSearchTableOptions' => $settings->get( 'smwgFulltextSearchTableOptions' )
+			]
+		);
+
 		$tableSchemaManager->setFeatureFlags(
 			$settings->get( 'smwgFieldTypeFeatures' )
 		);

--- a/tests/phpunit/Integration/JSONScript/JsonTestCaseScriptRunnerTest.php
+++ b/tests/phpunit/Integration/JSONScript/JsonTestCaseScriptRunnerTest.php
@@ -137,6 +137,7 @@ class JsonTestCaseScriptRunnerTest extends JsonTestCaseScriptRunner {
 				'smwgQFilterDuplicates' => false,
 				'smwgExportResourcesAsIri' => false,
 				'smwgCompactLinkSupport' => false,
+				'smwgEnabledFulltextSearch' => false,
 				'smwgSparqlReplicationPropertyExemptionList' => [],
 				'smwgPageSpecialProperties' => [ '_MDAT' ],
 				'smwgFieldTypeFeatures' => SMW_FIELDT_NONE,

--- a/tests/phpunit/Unit/SQLStore/InstallerTest.php
+++ b/tests/phpunit/Unit/SQLStore/InstallerTest.php
@@ -239,12 +239,14 @@ class InstallerTest extends \PHPUnit_Framework_TestCase {
 
 		$var1 = [
 			'smwgUpgradeKey' => '',
+			'smwgEnabledFulltextSearch' => '',
 			'smwgFixedProperties' => [ 'Foo', 'Bar' ],
 			'smwgPageSpecialProperties' => [ 'Foo', 'Bar' ]
 		];
 
 		$var2 = [
 			'smwgUpgradeKey' => '',
+			'smwgEnabledFulltextSearch' => '',
 			'smwgFixedProperties' => [ 'Bar', 'Foo' ],
 			'smwgPageSpecialProperties' => [ 'Bar', 'Foo' ]
 		];
@@ -259,12 +261,14 @@ class InstallerTest extends \PHPUnit_Framework_TestCase {
 
 		$var1 = [
 			'smwgUpgradeKey' => '',
+			'smwgEnabledFulltextSearch' => '',
 			'smwgFixedProperties' => [ 'Foo', 'Bar' ],
 			'smwgPageSpecialProperties' => [ 'Foo', 'Bar' ]
 		];
 
 		$var2 = [
 			'smwgUpgradeKey' => '',
+			'smwgEnabledFulltextSearch' => '',
 			'smwgFixedProperties' => [ 'Bar', 'Foo' ],
 			'smwgPageSpecialProperties' => [ 'Bar', '_MDAT' ]
 		];
@@ -294,6 +298,7 @@ class InstallerTest extends \PHPUnit_Framework_TestCase {
 			'smwgConfigFileDir' => 'Foo/',
 			'smwgIP' => '',
 			'smwgUpgradeKey' => '',
+			'smwgEnabledFulltextSearch' => '',
 			'smwgFixedProperties' => [],
 			'smwgPageSpecialProperties' => []
 		];

--- a/tests/phpunit/Unit/SQLStore/QueryEngine/Fulltext/TextChangeUpdaterTest.php
+++ b/tests/phpunit/Unit/SQLStore/QueryEngine/Fulltext/TextChangeUpdaterTest.php
@@ -201,4 +201,38 @@ class TextChangeUpdaterTest extends \PHPUnit_Framework_TestCase {
 		);
 	}
 
+	public function testNullUpdate() {
+
+		$this->searchTableUpdater->expects( $this->atLeastOnce() )
+			->method( 'isEnabled' )
+			->will( $this->returnValue( true ) );
+
+		$changeOp = $this->getMockBuilder( '\SMW\SQLStore\ChangeOp\ChangeOp' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$changeOp->expects( $this->once() )
+			->method( 'newChangeDiff' )
+			->will( $this->returnValue( null ) );
+
+		$changeOp->expects( $this->never() )
+			->method( 'getSubject' );
+
+		$instance = new TextChangeUpdater(
+			$this->connection,
+			$this->cache,
+			$this->searchTableUpdater
+		);
+
+		$instance->setLogger(
+			$this->logger
+		);
+
+		$instance->isCommandLineMode( true );
+
+		$instance->pushUpdates(
+			$changeOp
+		);
+	}
+
 }

--- a/tests/phpunit/Unit/SQLStore/TableSchemaManagerTest.php
+++ b/tests/phpunit/Unit/SQLStore/TableSchemaManagerTest.php
@@ -112,4 +112,49 @@ class TableSchemaManagerTest extends \PHPUnit_Framework_TestCase {
 		);
 	}
 
+	public function testFindTableFullTextTable_Disabled() {
+
+		$store = $this->getMockBuilder( '\SMW\SQLStore\SQLStore' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$store->expects( $this->any() )
+			->method( 'getPropertyTables' )
+			->will( $this->returnValue( [] ) );
+
+		$instance = new TableSchemaManager(
+			$store
+		);
+
+		$this->assertNull(
+			$instance->findTable( \SMW\SQLStore\SQLStore::FT_SEARCH_TABLE )
+		);
+	}
+
+	public function testFindTableFullTextTable_Enabled() {
+
+		$store = $this->getMockBuilder( '\SMW\SQLStore\SQLStore' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$store->expects( $this->any() )
+			->method( 'getPropertyTables' )
+			->will( $this->returnValue( [] ) );
+
+		$instance = new TableSchemaManager(
+			$store
+		);
+
+		$instance->setOptions(
+			[
+				'smwgEnabledFulltextSearch' => true
+			]
+		);
+
+		$this->assertInstanceOf(
+			'\SMW\SQLStore\TableBuilder\Table',
+			$instance->findTable( \SMW\SQLStore\SQLStore::FT_SEARCH_TABLE )
+		);
+	}
+
 }


### PR DESCRIPTION
This PR is made in reference to: #3604

This PR addresses or contains:

- `Installer` checks if `smwgEnabledFulltextSearch` is enabled (which by default is not) and the `Setup` routine will compare the `smwgEnabledFulltextSearch` value as part of the upgrade key so it is ensured once you enable the option that you run `update.php`/`setupStore.php` before able to continue.

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed

Fixes #3604