### PR TITLE
QueryResultSerializer to handle `_qty` on chained property, refs 3517

### DIFF
--- a/tests/phpunit/Integration/JSONScript/TestCases/s-0032.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/s-0032.json
@@ -1,0 +1,65 @@
+{
+	"description": "Test `format=json` output via `Special:Ask` for `_ref_rec`/`_qty` type (#3517)",
+	"setup": [
+		{
+			"namespace": "SMW_NS_PROPERTY",
+			"page": "Ref prop",
+			"contents": "[[Has type::Reference]] [[Has fields::Field prop;other prop]]"
+		},
+		{
+			"namespace": "SMW_NS_PROPERTY",
+			"page": "Field prop",
+			"contents": "[[Has type::Quantity]] [[Corresponds to::1 km]]"
+		},
+		{
+			"namespace": "NS_MAIN",
+			"page": "S0032/1",
+			"contents": "[[Ref prop::123;S0032/2]] [[Category:S0032]]"
+		}
+	],
+	"tests": [
+		{
+			"type": "special",
+			"about": "#0",
+			"special-page": {
+				"page": "Ask",
+				"request-parameters": {
+					"p": {
+						"link": "none",
+						"limit": "10",
+						"offset": "0",
+						"mainlabel": "",
+						"prettyprint": false,
+						"unescape": true,
+						"format": "json"
+					},
+					"q": "[[Category:S0032]]",
+					"po": "?Ref prop.Field prop"
+				}
+			},
+			"assert-output": {
+				"to-contain": [
+					"\"chain\":\"Ref prop.Field prop\"",
+					"{\"Field prop\":[{\"value\":123,\"unit\":\"km\"}]}"
+				]
+			}
+		}
+	],
+	"settings": {
+		"wgContLang": "en",
+		"wgLang": "en",
+		"wgLanguageCode": "en",
+		"smwgPageSpecialProperties": [
+			"_MDAT"
+		],
+		"smwgNamespacesWithSemanticLinks": {
+			"NS_MAIN": true,
+			"SMW_NS_PROPERTY": true
+		}
+	},
+	"meta": {
+		"version": "2",
+		"is-incomplete": false,
+		"debug": false
+	}
+}


### PR DESCRIPTION
This PR is made in reference to: #3517

This PR addresses or contains:

- Fixes the "TypeError: Argument 2 passed to SMW\DataValueFactory::newDataValueByItem() must be an instance of SMW\DIProperty or null, instance of SMWDIBlob given, called in ...\SemanticMediaWiki\src\Serializers\QueryResultSerializer.php on line 133" caused by the property chain
- Adds integration test with the example from #3517 that uncovered the error
- However it does not resolve the `DataTables` format (initially reported) in how it should interpret the values from the API and display them which is an entire different matter in SRF

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed

Fixes #