### PR TITLE
Restore use of `wgDBTableOptions`, refs 3361

### DIFF
--- a/src/SQLStore/TableBuilder/MySQLTableBuilder.php
+++ b/src/SQLStore/TableBuilder/MySQLTableBuilder.php
@@ -100,10 +100,10 @@ class MySQLTableBuilder extends TableBuilder {
 			return $tableOption;
 		}
 
-		// @see $wgDBattributes, This replacement is needed for compatibility,
+		// @see $wgDBTableOptions, This replacement is needed for compatibility,
 		// http://bugs.mysql.com/bug.php?id=17501
-		if ( isset( $this->config['wgDBattributes'] ) ) {
-			return str_replace( 'TYPE', 'ENGINE', $this->config['wgDBattributes'] );
+		if ( isset( $this->config['wgDBTableOptions'] ) ) {
+			return str_replace( 'TYPE', 'ENGINE', $this->config['wgDBTableOptions'] );
 		}
 	}
 

--- a/tests/phpunit/Unit/SQLStore/TableBuilder/MySQLTableBuilderTest.php
+++ b/tests/phpunit/Unit/SQLStore/TableBuilder/MySQLTableBuilderTest.php
@@ -67,10 +67,11 @@ class MySQLTableBuilderTest extends \PHPUnit_Framework_TestCase {
 
 		$connection->expects( $this->once() )
 			->method( 'query' )
-			->with( $this->stringContains( 'CREATE TABLE `xyz`."foo"' ) );
+			->with( $this->equalTo( 'CREATE TABLE `xyz`."foo" (bar TEXT) tableoptions_foobar' ) );
 
 		$instance = MySQLTableBuilder::factory( $connection );
 		$instance->addConfig( 'wgDBname', 'xyz' );
+		$instance->addConfig( 'wgDBTableOptions', 'tableoptions_foobar' );
 
 		$table = new Table( 'foo' );
 		$table->addColumn( 'bar', 'text' );


### PR DESCRIPTION
This PR is made in reference to: #3361 

This PR addresses or contains:

- #3361 removed part of the settings name and since no test where in place the issue wasn't detected till today

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed
