### PR TITLE
Add `FieldType::TYPE_ENUM` support

### DIFF
--- a/src/SQLStore/TableBuilder/FieldType.php
+++ b/src/SQLStore/TableBuilder/FieldType.php
@@ -103,6 +103,22 @@ class FieldType {
 	const TYPE_DOUBLE = 'double';
 
 	/**
+	 * @var string
+	 */
+	const TYPE_ENUM = 'enum';
+
+	/**
+	 * @since 3.1
+	 *
+	 * @param array $enum
+	 *
+	 * @return string
+	 */
+	public static function enum( array $enum ) {
+		return "('" . implode( "','", $enum ) . "')";
+	}
+
+	/**
 	 * @since 2.5
 	 *
 	 * @param string|array $type
@@ -116,7 +132,12 @@ class FieldType {
 		// [ FieldType::FIELD_ID, 'NOT NULL' ]
 		if ( is_array( $type ) && count( $type ) > 1 ) {
 			$fieldType = $type[0];
-			$auxilary = ' ' . $type[1];
+
+			if ( $type[0] === self::TYPE_ENUM ) {
+				$auxilary = '' . self::enum( $type[1] );
+			} else {
+				$auxilary = ' ' . $type[1];
+			}
 		} elseif ( is_array( $type ) ) {
 			$fieldType = $type[0];
 		}

--- a/src/SQLStore/TableBuilder/MySQLTableBuilder.php
+++ b/src/SQLStore/TableBuilder/MySQLTableBuilder.php
@@ -49,7 +49,8 @@ class MySQLTableBuilder extends TableBuilder {
 			'char_nocase'      => 'VARCHAR(255) CHARSET utf8 COLLATE utf8_general_ci',
 			'char_long_nocase' => "VARCHAR($charLongLength) CHARSET utf8 COLLATE utf8_general_ci",
 			'usage_count'      => 'INT(8) UNSIGNED',
-			'integer_unsigned' => 'INT(8) UNSIGNED'
+			'integer_unsigned' => 'INT(8) UNSIGNED',
+			'enum' => 'ENUM'
 		];
 
 		return FieldType::mapType( $fieldType, $fieldTypes );
@@ -147,7 +148,12 @@ class MySQLTableBuilder extends TableBuilder {
 		$currentFields = [];
 
 		foreach ( $res as $row ) {
-			$type = strtoupper( $row->Type );
+
+			if ( strpos( $row->Type, 'enum' ) !== false ) {
+				$type = str_replace( 'enum', 'ENUM', $row->Type );
+			} else {
+				$type = strtoupper( $row->Type );
+			}
 
 			if ( substr( $type, 0, 8 ) == 'VARCHAR(' ) {
 				$type .= ' binary'; // just assume this to be the case for VARCHAR, though DESCRIBE will not tell us

--- a/src/SQLStore/TableBuilder/PostgresTableBuilder.php
+++ b/src/SQLStore/TableBuilder/PostgresTableBuilder.php
@@ -53,7 +53,8 @@ class PostgresTableBuilder extends TableBuilder {
 			'char_nocase' => 'citext NOT NULL',
 			'char_long_nocase' => 'citext NOT NULL',
 			'usage_count'      => 'bigint',
-			'integer_unsigned' => 'INTEGER'
+			'integer_unsigned' => 'INTEGER',
+			'enum' => 'ENUM'
 		];
 
 		return FieldType::mapType( $fieldType, $fieldTypes );
@@ -163,7 +164,12 @@ EOT;
 		$currentFields = [];
 
 		foreach ( $res as $row ) {
-			$type = strtoupper( $row->Type );
+
+			if ( strpos( $row->Type, 'enum' ) !== false ) {
+				$type = str_replace( 'enum', 'ENUM', $row->Type );
+			} else {
+				$type = strtoupper( $row->Type );
+			}
 
 			if ( preg_match( '/^nextval\\(.+\\)/i', $row->Extra ) ) {
 				$type = 'SERIAL NOT NULL';
@@ -186,7 +192,11 @@ EOT;
 			$fieldType = substr( $fieldType, 0, $keypos );
 		}
 
-		$fieldType = strtoupper( $fieldType );
+		// Avoid disrupting ENUM values
+		if ( strpos( $fieldType, 'ENUM' ) === false ) {
+			$fieldType = strtoupper( $fieldType );
+		}
+
 		$default = '';
 
 		if ( isset( $attributes['defaults'][$fieldName] ) ) {
@@ -195,6 +205,29 @@ EOT;
 
 		if ( !array_key_exists( $fieldName, $currentFields ) ) {
 			$this->doCreateField( $tableName, $fieldName, $position, $fieldType, $default );
+		} elseif ( strpos( $fieldType, 'ENUM' ) !== false ) {
+			$enum_type = strtolower( $currentFields[$fieldName] );
+			$current_enums = '';
+
+			// https://stackoverflow.com/questions/1616123/sql-query-to-get-all-values-a-enum-can-have/1616161
+			$res = $this->connection->query( "SELECT enum_range(NULL::$enum_type)", __METHOD__ );
+
+			foreach ( $res as $row ) {
+				if ( isset( $row->enum_range ) ) {
+					$current_enums = str_replace( [ '{', '}' ], '', $row->enum_range );
+				}
+			}
+
+			// Normalize the notation to make it comparable to what postgres returns
+			$expected_enums = str_replace( [ 'ENUM', "'", '(', ')' ], '', $fieldType );
+
+			if ( $current_enums === $expected_enums ) {
+				$this->reportMessage( "   ... field $fieldName with type '$enum_type' is fine.\n" );
+			} else {
+				// Recreate the field and type which is the simplest way of
+				// ensuring consistency
+				$this->doCreateField( $tableName, $fieldName, $position, $fieldType, $default );
+			}
 		} elseif ( $currentFields[$fieldName] != $fieldType ) {
 			$this->reportMessage( "   ... changing type of field $fieldName from '$currentFields[$fieldName]' to '$fieldType' ... " );
 
@@ -231,6 +264,16 @@ EOT;
 	private function doCreateField( $tableName, $fieldName, $position, $fieldType, $default ) {
 
 		$this->activityLog[$tableName][$fieldName] = self::PROC_FIELD_NEW;
+
+		// https://www.postgresql.org/docs/9.1/datatype-enum.html
+		if ( strpos( $fieldType, 'ENUM' ) !== false ) {
+			$enum_type = "{$fieldName}_t";
+			$this->reportMessage( "   ... dropping type $enum_type ... \n" );
+			$this->connection->query( "DROP TYPE IF EXISTS $enum_type CASCADE", __METHOD__ );
+			$this->reportMessage( "   ... creating type $enum_type ... \n" );
+			$this->connection->query( "CREATE TYPE $enum_type AS $fieldType", __METHOD__ );
+			$fieldType = $enum_type;
+		}
 
 		$this->reportMessage( "   ... creating field $fieldName ... " );
 		$this->connection->query( "ALTER TABLE $tableName ADD \"" . $fieldName . "\" $fieldType $default", __METHOD__ );

--- a/src/SQLStore/TableBuilder/SQLiteTableBuilder.php
+++ b/src/SQLStore/TableBuilder/SQLiteTableBuilder.php
@@ -20,6 +20,12 @@ class SQLiteTableBuilder extends TableBuilder {
 	 */
 	public function getStandardFieldType( $fieldType ) {
 
+		// SQLite has no native support for an ENUM type
+		// https://stackoverflow.com/questions/5299267/how-to-create-enum-type-in-sqlite
+		if ( is_array( $fieldType ) && $fieldType[0] === FieldType::TYPE_ENUM ) {
+			unset( $fieldType[1] );
+		}
+
 		$charLongLength = FieldType::CHAR_LONG_LENGTH;
 
 		$fieldTypes = [
@@ -48,7 +54,10 @@ class SQLiteTableBuilder extends TableBuilder {
 			'char_nocase'      => 'VARCHAR(255) NOT NULL COLLATE NOCASE',
 			'char_long_nocase' => "VARCHAR($charLongLength) NOT NULL COLLATE NOCASE",
 			'usage_count'      => 'INT(8)',
-			'integer_unsigned' => 'INTEGER'
+			'integer_unsigned' => 'INTEGER',
+
+			// SQLite has not native support for an ENUM type
+			'enum' => 'TEXT'
 		];
 
 		return FieldType::mapType( $fieldType, $fieldTypes );

--- a/tests/phpunit/Unit/SQLStore/TableBuilder/FieldTypeTest.php
+++ b/tests/phpunit/Unit/SQLStore/TableBuilder/FieldTypeTest.php
@@ -62,6 +62,12 @@ class FieldTypeTest extends \PHPUnit_Framework_TestCase {
 			'notMatchableTypeThereforeReturnAsIs'
 		];
 
+		$provider[] = [
+			[ FieldType::TYPE_ENUM, [ 'a', 'b', 'c' ] ],
+			[ 'enum' => 'ENUM' ],
+			"ENUM('a','b','c')"
+		];
+
 		return $provider;
 	}
 


### PR DESCRIPTION
This PR is made in reference to: #

This PR addresses or contains:

- Adds `FieldType::TYPE_ENUM` to support ENUM as type for fields used by SMW
- Only Postgres and MySQL support ENUM natively, for SQLite we use a simple text field [0]

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed

[0] https://stackoverflow.com/questions/5299267/how-to-create-enum-type-in-sqlite