### PR TITLE
Set `isCapitalLinks` in `_wpg` description context, refs 3587

### DIFF
--- a/src/Query/Parser/DescriptionProcessor.php
+++ b/src/Query/Parser/DescriptionProcessor.php
@@ -13,6 +13,7 @@ use SMW\Query\Language\Disjunction;
 use SMW\Query\Language\ValueDescription;
 use SMW\Site;
 use SMWDataValue as DataValue;
+use SMW\Query\QueryComparator;
 
 /**
  * @license GNU GPL v2+
@@ -167,6 +168,20 @@ class DescriptionProcessor {
 		$dataValue->setContextPage( $this->contextPage );
 
 		$dataValue->setOption( DataValue::OPT_QUERY_CONTEXT, true );
+
+		// #3587
+		// Requesting capital links is influenced by two factors, `wgCapitalLinks`
+		// is enabled sitewide and the `WikiPageValue` condition is identified
+		// as SMW_CMP_EQ/NEQ (e.g. [[Foo]], [[!Foo]]) with other expressions
+		// (e.g. [[~foo*]]) to remain in the form of the user input
+		$queryComparator = QueryComparator::getInstance();
+
+		if ( Site::isCapitalLinks() && (
+			$queryComparator->containsComparator( $chunk, SMW_CMP_EQ ) ||
+			$queryComparator->containsComparator( $chunk, SMW_CMP_NEQ ) ) ) {
+			$dataValue->setOption( 'isCapitalLinks', true );
+		}
+
 		$description = null;
 
 		$description = $dataValue->getQueryDescription( $chunk );

--- a/tests/phpunit/Integration/JSONScript/TestCases/p-0461.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/p-0461.json
@@ -1,0 +1,92 @@
+{
+	"description": "Test `_wpg` value with lower/upper first case letter +DISPLAYTITLE (#3587, `wgRestrictDisplayTitle`, `wgCapitalLinks`)",
+	"setup": [
+		{
+			"namespace": "SMW_NS_PROPERTY",
+			"page": "Has number",
+			"contents": "[[Has type::Number]]"
+		},
+		{
+			"namespace": "SMW_NS_PROPERTY",
+			"page": "Has text",
+			"contents": "[[Has type::Text]]"
+		},
+		{
+			"page": "P0461/1",
+			"contents": "[[Has number::123]] [[Has text::abc]] [[Category:P0461]] {{DISPLAYTITLE:p0461/1}}"
+		},
+		{
+			"page": "P0461/2",
+			"contents": "[[Category:P0461]] [[Has text::ABC]] {{DISPLAYTITLE:p0461/2}}"
+		},
+		{
+			"page": "P0461/Q.1",
+			"contents": "{{#show: p0461/1 |?Has number |intro=p0461: }}"
+		},
+		{
+			"page": "P0461/Q.2",
+			"contents": "{{#show: P0461/1 |?Has number |intro=P0461: }}"
+		},
+		{
+			"page": "P0461/Q.3",
+			"contents": "{{#ask: [[p0461/1]] |?Has text |intro=p0461: |format=plain |mainlabel=- |headers=hide }}"
+		},
+		{
+			"page": "P0461/Q.4",
+			"contents": "{{#ask: [[P0461/1]] |?Has text |intro=P0461: |format=plain |mainlabel=- |headers=hide }}"
+		}
+	],
+	"tests": [
+		{
+			"type": "parser",
+			"about": "#0 (#show, lower case `p0461`)",
+			"subject": "P0461/Q.1",
+			"assert-output": {
+				"to-contain": [
+					"p0461:123"
+				]
+			}
+		},
+		{
+			"type": "parser",
+			"about": "#1 (#show, upper case `P0461`)",
+			"subject": "P0461/Q.2",
+			"assert-output": {
+				"to-contain": [
+					"P0461:123"
+				]
+			}
+		},
+		{
+			"type": "parser",
+			"about": "#2 (#ask, lower case `p0461`)",
+			"subject": "P0461/Q.3",
+			"assert-output": {
+				"to-contain": [
+					"p0461:abc"
+				]
+			}
+		},
+		{
+			"type": "parser",
+			"about": "#3 (#ask, upper case `P0461`)",
+			"subject": "P0461/Q.4",
+			"assert-output": {
+				"to-contain": [
+					"P0461:abc"
+				]
+			}
+		}
+	],
+	"settings": {
+		"wgContLang": "en",
+		"wgLang": "en",
+		"wgCapitalLinks": true,
+		"wgRestrictDisplayTitle": false
+	},
+	"meta": {
+		"version": "2",
+		"is-incomplete": false,
+		"debug": false
+	}
+}

--- a/tests/phpunit/Unit/Query/Parser/DescriptionProcessorTest.php
+++ b/tests/phpunit/Unit/Query/Parser/DescriptionProcessorTest.php
@@ -22,7 +22,7 @@ class DescriptionProcessorTest extends \PHPUnit_Framework_TestCase {
 	public function testCanConstruct() {
 
 		$this->assertInstanceOf(
-			'SMW\Query\Parser\DescriptionProcessor',
+			DescriptionProcessor::class,
 			new DescriptionProcessor()
 		);
 	}
@@ -55,7 +55,7 @@ class DescriptionProcessorTest extends \PHPUnit_Framework_TestCase {
 		);
 	}
 
-	public function testDescriptionForWikiPageValueChunk() {
+	public function testDescriptionForWikiPageValueChunkOnEqualMatch() {
 
 		$instance = new DescriptionProcessor();
 
@@ -67,7 +67,7 @@ class DescriptionProcessorTest extends \PHPUnit_Framework_TestCase {
 		);
 
 		$this->assertEquals(
-			new DIWikiPage( 'bar', NS_MAIN ),
+			new DIWikiPage( 'Bar', NS_MAIN ),
 			$valueDescription->getDataItem()
 		);
 	}


### PR DESCRIPTION
This PR is made in reference to: #3587

This PR addresses or contains:

- Set the `isCapitalLinks` context for a `_wpg` type when it matches SMW_CMP_EQ or SMW_CMP_NEQ and `wgCapitalLinks` is `true` to result in:
  - `{{#show: foo ...}}` === `{{#show: Foo}}` 
  - `{{#ask: [[foo]] ...}}` === `{{#ask: [[Foo]] ...}}`
- `isCapitalLinks` only affects the first letter (same rules applies for `Title::newFromText`)

This PR includes:
- [x] Tests (unit/integration)
- [X] CI build passed

Fixes #3587