### PR TITLE
SemanticDataLookup, use `DISTINCT` for non subject items, refs 2928, 3531

### DIFF
--- a/tests/phpunit/Integration/JSONScript/TestCases/s-0033.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/s-0033.json
@@ -1,0 +1,59 @@
+{
+	"description": "Test output from `Special:SearchByProperty` to show all values for a property (#3531)",
+	"setup": [
+		{
+			"namespace": "SMW_NS_PROPERTY",
+			"page": "Has vtext",
+			"contents": "[[Has type::Text]]"
+		},
+		{
+			"page": "Test/S0033/1",
+			"contents": "[[Has vtext::123]] [[Has vtext::456]] [[Has vtext::abc]] [[Has vtext::def]] [[Has vtext::1001]] [[Has vtext::42]]"
+		},
+		{
+			"page": "Test/S0033/2",
+			"contents": "[[Has vtext::123]] [[Has vtext::456]] [[Has vtext::abc]] [[Has vtext::def]] [[Has vtext::1001]] [[Has vtext::42]]"
+		},
+		{
+			"page": "Test/S0033/3",
+			"contents": "[[Has vtext::123]] [[Has vtext::456]] [[Has vtext::abc]] [[Has vtext::def]] [[Has vtext::1001]] [[Has vtext::42]]"
+		},
+		{
+			"page": "Test/S0033/4",
+			"contents": "[[Has vtext::123]] [[Has vtext::456]] [[Has vtext::abc]] [[Has vtext::def]] [[Has vtext::1001]] [[Has vtext::42]]"
+		}
+	],
+	"tests": [
+		{
+			"type": "special",
+			"about": "#0 (find all values for property `Has vtext`)",
+			"special-page": {
+				"page": "SearchByProperty",
+				"query-parameters": "",
+				"request-parameters": {
+					"limit": 6,
+					"property": "Has vtext"
+				}
+			},
+			"assert-output": {
+				"to-contain": [
+					"<li>1001.*</li>",
+					"<li>123.*</li>",
+					"<li>42.*</li>",
+					"<li>456.*</li>",
+					"<li>abc.*</li>",
+					"<li>def.*</ul>"
+				]
+			}
+		}
+	],
+	"settings": {
+		"wgContLang": "en",
+		"wgLanguageCode": "en"
+	},
+	"meta": {
+		"version": "2",
+		"is-incomplete": false,
+		"debug": false
+	}
+}

--- a/tests/phpunit/Unit/SQLStore/EntityStore/SemanticDataLookupTest.php
+++ b/tests/phpunit/Unit/SQLStore/EntityStore/SemanticDataLookupTest.php
@@ -4,6 +4,7 @@ namespace SMW\Tests\SQLStore\EntityStore;
 
 use SMW\DIProperty;
 use SMW\DIWikiPage;
+use SMWDIBlob as DIBlob;
 use SMW\RequestOptions;
 use SMW\SQLStore\EntityStore\SemanticDataLookup;
 use SMW\Tests\PHPUnitCompat;
@@ -301,6 +302,53 @@ class SemanticDataLookupTest extends \PHPUnit_Framework_TestCase {
 			"SELECT p.smw_title AS prop, fooField AS v0 FROM  " .
 			"INNER JOIN smw_object_ids AS p ON p_id=p.smw_id " .
 			"WHERE (s_id='42') AND (p.smw_iw!=':smw') AND (p.smw_iw!=':smw-delete')",
+			$this->query->build()
+		);
+	}
+
+	public function testFetchSemanticData_NonWikiPageTable_DISTINCT_SELECT() {
+
+		$row = new \stdClass;
+		$row->prop = 'FOO';
+		$row->v0 = '1001';
+
+		$this->dataItemHandler->expects( $this->any() )
+			->method( 'getFetchFields' )
+			->will( $this->returnValue( [ 'fooField' => 'fieldType' ] ) );
+
+		$propertyTable = $this->getMockBuilder( '\SMW\SQLStore\PropertyTableDefinition' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$propertyTable->expects( $this->atLeastOnce() )
+			->method( 'getDIType' )
+			->will( $this->returnValue( 'Foo' ) );
+
+		$propertyTable->expects( $this->atLeastOnce() )
+			->method( 'getName' )
+			->will( $this->returnValue( 'bar_table' ) );
+
+		$this->connection->expects( $this->any() )
+			->method( 'addQuotes' )
+			->will( $this->returnCallback( function( $value ) { return "'$value'"; } ) );
+
+		$this->connection->expects( $this->once() )
+			->method( 'query' )
+			->will( $this->returnValue( [ $row ] ) );
+
+		$dataItem = new DIBlob( __METHOD__ );
+
+		$requestOptions = new RequestOptions();
+		$requestOptions->setLimit( 4 );
+
+		$instance = new SemanticDataLookup(
+			$this->store
+		);
+
+		$instance->fetchSemanticData( 42, $dataItem, $propertyTable, $requestOptions );
+
+		$this->assertEquals(
+			"SELECT DISTINCT fooField AS v0 FROM bar_table WHERE (p_id='42') LIMIT 4",
 			$this->query->build()
 		);
 	}


### PR DESCRIPTION
This PR is made in reference to: #2928, #3531

This PR addresses or contains:

- #2928 caused a regression with the case described in #3531

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed

Fixes #3531