### PR TITLE
Allows recurring events to start on a 30th or 31st of a month

### DIFF
--- a/includes/RecurringEvents.php
+++ b/includes/RecurringEvents.php
@@ -283,13 +283,15 @@ class RecurringEvents {
 					$display_month = ( $cur_month == 0 ) ? 12 : $cur_month;
 				}
 
-				// If the date is February 29, and this isn't
-				// a leap year, change it to February 28.
-				if ( $cur_month == 2 && $cur_day == 29 ) {
-					if ( !date( 'L', strtotime( "$cur_year-1-1" ) ) ) {
-						$cur_day = 28;
-					}
-				}
+				// If the date is greater than 28 for February, and it is not
+				// a leap year, change it to be a fixed 28 otherwise set it to
+				// 29 (for a leap year date)
+				if ( $cur_month == 2 && $cur_day > 28 ) {
+					$cur_day = !date( 'L', strtotime( "$cur_year-1-1" ) ) ? 28 : 29;
+				} elseif ( $cur_day > 30 ) {
+					// Check whether 31 is a valid day of a month
+					$cur_day = ( $display_month - 1 ) % 7 % 2 ? 30 : 31;
+ 				}
 
 				$date_str = "$cur_year-$display_month-$cur_day $cur_time";
 				$cur_date = DataValueFactory::getInstance()->newTypeIDValue( '_dat', $date_str );
@@ -306,7 +308,7 @@ class RecurringEvents {
 				if ( $new_month == 0 ) {
 					$new_month = 12;
 				}
-				
+
 				$new_year = $prev_year + floor( ( $prev_month + $period - 1 ) / 12 );
 				$cur_date_jd += ( 28 * $period ) - 7;
 

--- a/tests/phpunit/Integration/JSONScript/TestCases/p-0115.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/p-0115.json
@@ -8,15 +8,15 @@
 		},
 		{
 			"page": "Team meetings - en",
-			"contents": "{{#set_recurring_event: Is team meeting |property=Has date |start=January 31, 2003 9:30 am |end=December 31, 2004 |unit=month }}"
+			"contents": "{{#set_recurring_event: Is team meeting |property=Has date |start=January 31, 2003 9:30 am |end=December 31, 2004 9:30 am |unit=month }}"
 		},
 		{
 			"page": "Team meetings - fr",
-			"contents": "{{#set_recurring_event: Is team meeting |property=Has date |start=30 janvier 2003 9:30 am |end=30 décembre 2004 |unit=month }}"
+			"contents": "{{#set_recurring_event: Is team meeting |property=Has date |start=30 janvier 2003 9:30 am |end=31 décembre 2004 9:30 am |unit=month }}"
 		},
 		{
 			"page": "Team meetings - ISO",
-			"contents": "{{#set_recurring_event: Is team meeting |property=Has date |start=2003-01-29T09:30:00 |end=2004-12-31 |unit=month }}"
+			"contents": "{{#set_recurring_event: Is team meeting |property=Has date |start=2003-01-29T09:30:00 |end=2004-12-31T09:30:00 |unit=month }}"
 		},
 		{
 			"page": "Team meetings in 2003 and 2004 - 0 - en",
@@ -62,8 +62,8 @@
 				"to-contain": [
 					"31 mars 2003 09:30:00",
 					"30 avril 2003 09:30:00",
-					"31 octobre 2004 09:30:00",
-					"30 novembre 2004 09:30:00"
+					"30 novembre 2004 09:30:00",
+					"31 décembre 2004 09:30:00"
 				]
 			}
 		},

--- a/tests/phpunit/Integration/JSONScript/TestCases/p-0115.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/p-0115.json
@@ -1,0 +1,130 @@
+{
+	"description": "Test `#set_recurring_event` parser for events on 29th to 31st of the month (#3598 - `wgContLang=fr`, `wgLang=en`)",
+	"setup": [
+		{
+			"namespace": "SMW_NS_PROPERTY",
+			"page": "Has date",
+			"contents": "[[Has type::Date]]"
+		},
+		{
+			"page": "Team meetings - en",
+			"contents": "{{#set_recurring_event: Is team meeting |property=Has date |start=January 31, 2003 9:30 am |end=December 31, 2004 |unit=month }}"
+		},
+		{
+			"page": "Team meetings - fr",
+			"contents": "{{#set_recurring_event: Is team meeting |property=Has date |start=30 janvier 2003 9:30 am |end=30 décembre 2004 |unit=month }}"
+		},
+		{
+			"page": "Team meetings - ISO",
+			"contents": "{{#set_recurring_event: Is team meeting |property=Has date |start=2003-01-29T09:30:00 |end=2004-12-31 |unit=month }}"
+		},
+		{
+			"page": "Team meetings in 2003 and 2004 - 0 - en",
+			"contents": "{{#ask: [[Is team meeting::Team meetings - en]] |format=count }}"
+		},
+		{
+			"page": "Team meetings in 2003 and 2004 - 1 - en",
+			"contents": "{{#ask: [[Is team meeting::Team meetings - en]] |?Has date |format=plainlist }}"
+		},
+		{
+			"page": "Team meetings in 2003 and 2004 - 2 - fr",
+			"contents": "{{#ask: [[Is team meeting::Team meetings - fr]] |format=count }}"
+		},
+		{
+			"page": "Team meetings in 2003 and 2004 - 3 - fr",
+			"contents": "{{#ask: [[Is team meeting::Team meetings - fr]] |?Has date |format=plainlist }}"
+		},
+		{
+			"page": "Team meetings in 2003 and 2004 - 4 - ISO",
+			"contents": "{{#ask: [[Is team meeting::Team meetings - ISO]] |format=count }}"
+		},
+		{
+			"page": "Team meetings in 2003 and 2004 - 5 - ISO",
+			"contents": "{{#ask: [[Is team meeting::Team meetings - ISO]] |?Has date |format=plainlist }}"
+		}
+	],
+	"tests": [
+		{
+			"type": "parser",
+			"about": "#0 #set_recurring_event parser for the 31st or alternatively the last day of a month - count",
+			"subject": "Team meetings in 2003 and 2004 - 0 - en",
+			"assert-output": {
+				"to-contain": [
+					"24"
+				]
+			}
+		},
+		{
+			"type": "parser",
+			"about": "#1 #set_recurring_event parser for the 31st or alternatively the last day of a month - print",
+			"subject": "Team meetings in 2003 and 2004 - 1 - en",
+			"assert-output": {
+				"to-contain": [
+					"31 mars 2003 09:30:00",
+					"30 avril 2003 09:30:00",
+					"31 octobre 2004 09:30:00",
+					"30 novembre 2004 09:30:00"
+				]
+			}
+		},
+		{
+			"type": "parser",
+			"about": "#2 #set_recurring_event parser for the 30th or alternatively the last day of a month - count",
+			"subject": "Team meetings in 2003 and 2004 - 2 - fr",
+			"assert-output": {
+				"to-contain": [
+					"24"
+				]
+			}
+		},
+		{
+			"type": "parser",
+			"about": "#3 #set_recurring_event parser for the 30th or alternatively the last day of a month - print",
+			"subject": "Team meetings in 2003 and 2004 - 3 - fr",
+			"assert-output": {
+				"to-contain": [
+					"28 février 2003 09:30:00",
+					"30 mars 2003 09:30:00",
+					"29 février 2004 09:30:00",
+					"30 mars 2004 09:30:00"
+				]
+			}
+		},
+		{
+			"type": "parser",
+			"about": "#4 #set_recurring_event parser for the 29th or alternatively the last day of a month - count",
+			"subject": "Team meetings in 2003 and 2004 - 4 - ISO",
+			"assert-output": {
+				"to-contain": [
+					"24"
+				]
+			}
+		},
+		{
+			"type": "parser",
+			"about": "#5 #set_recurring_event parser for the 29th or alternatively the last day of a month - print",
+			"subject": "Team meetings in 2003 and 2004 - 5 - ISO",
+			"assert-output": {
+				"to-contain": [
+					"28 février 2003 09:30:00",
+					"29 août 2003 09:30:00",
+					"29 février 2004 09:30:00",
+					"29 août 2004 09:30:00"
+				],
+				"not-contain": [
+					"29 février 2003 09:30:00",
+					"28 février 2004 09:30:00"
+				]
+			}
+		}
+	],
+	"settings": {
+		"wgContLang": "fr",
+		"wgLang": "en"
+	},
+	"meta": {
+		"version": "2",
+		"is-incomplete": false,
+		"debug": false
+	}
+}


### PR DESCRIPTION
This PR is made in reference to: #3619 

This PR addresses or contains:
- Fixes recurring events not being created for every month if they start on a 30th or 31st
- Provides integration tests for recurring events starting on 29th (including a check for leap years), 30th and 31st. This assumes that recurring events are being created for the last day of the month if the respective month does not have a 29th, 30th or 31st day (per https://github.com/SemanticMediaWiki/SemanticMediaWiki/issues/3619#issuecomment-454549841)

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed

Fixes #3619 