### PR TITLE
Use `0x003D` instead of `-3D` to encode `=`, refs 640, 3560

### DIFF
--- a/src/Query/Processor/ParamListProcessor.php
+++ b/src/Query/Processor/ParamListProcessor.php
@@ -120,7 +120,7 @@ class ParamListProcessor {
 		}
 
 		$serialization['query'] = str_replace(
-			[ '&lt;', '&gt;', '-3D' ],
+			[ '&lt;', '&gt;', '0x003D' ],
 			['<', '>', '=' ],
 			$serialization['query']
 		);
@@ -173,11 +173,17 @@ class ParamListProcessor {
 
 	private function encodeEq ( $param ) {
 		// Bug 32955 / #640
-		// Modify (e.g. replace `=`) a condition string only if enclosed by [[ ... ]]
+		// Modify (e.g. replace `=`) a condition string only if enclosed by
+		// [[ ... ]]
+		//
+		// #3560
+		// Instead of `-3D` as temporary replacement, use the UTF representation
+		// to decode the `=` sign and eliminate possible collisions with a search
+		// request that contains `-3D` string
 		return preg_replace_callback(
 			'/\[\[([^\[\]]*)\]\]/xu',
 			function( array $matches ) {
-				return str_replace( [ '=' ], [ '-3D' ], $matches[0] );
+				return str_replace( [ '=' ], [ '0x003D' ], $matches[0] );
 			},
 			$param
 		);
@@ -246,9 +252,9 @@ class ParamListProcessor {
 			// Don't trim here, some parameters care for " "
 			//
 			// #3196
-			// Ensure to decode `-3D` from encodeEq to support things like
+			// Ensure to decode `0x003D` from encodeEq to support things like
 			// `|intro=[[File:Foo.png|link=Bar]]`
-			$serialization['parameters'][$p] = str_replace( [ '-3D' ], [ '=' ], $parts[1] );
+			$serialization['parameters'][$p] = str_replace( [ '0x003D' ], [ '=' ], $parts[1] );
 		} else {
 			$serialization['query'] .= $param;
 		}

--- a/tests/phpunit/Integration/JSONScript/TestCases/q-0612.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/q-0612.json
@@ -1,5 +1,5 @@
 {
-	"description": "Test `_wpg` object value that contains `=` (equals sign) (#640, #710, #1542, #1645, `wgContLang=en`, `wgLang=en`)",
+	"description": "Test `_wpg` object value that contains `=` (equals sign) (#640, #710, #1542, #1645, #3560)",
 	"setup": [
 		{
 			"namespace": "SMW_NS_PROPERTY",
@@ -8,6 +8,10 @@
 		},
 		{
 			"page": "Example/Q0612/1(=)",
+			"contents": "[[Category:Q0612]] [[Has page::{{FULLPAGENAME}}]]"
+		},
+		{
+			"page": "Example/Q0612/-3D=",
 			"contents": "[[Category:Q0612]] [[Has page::{{FULLPAGENAME}}]]"
 		},
 		{
@@ -59,6 +63,21 @@
 				"count": 1,
 				"results": [
 					"Example/Q0612/1(=)#0##"
+				]
+			}
+		},
+		{
+			"type": "query",
+			"about": "#1",
+			"condition": "[[Category:Q0612]] [[Has page::Example/Q0612/-3D=]]",
+			"printouts": [],
+			"parameters": {
+				"limit": 10
+			},
+			"assert-queryresult": {
+				"count": 1,
+				"results": [
+					"Example/Q0612/-3D=#0##"
 				]
 			}
 		}

--- a/tests/phpunit/Unit/Query/Processor/ParamListProcessorTest.php
+++ b/tests/phpunit/Unit/Query/Processor/ParamListProcessorTest.php
@@ -122,6 +122,47 @@ class ParamListProcessorTest extends \PHPUnit_Framework_TestCase {
 			]
 		];
 
+		// #3560
+		yield [
+			[ '[[Foo::Bar=-3DFoo]]' ],
+			false,
+			[
+				'showMode'   => false,
+				'templateArgs' => false,
+				'query'      => '[[Foo::Bar=-3DFoo]]',
+				'printouts'  => [],
+				'parameters' => [],
+				'this'       => []
+			]
+		];
+
+		yield [
+			[ '[[Foo::Bar=-3DFoox003D]]' ],
+			false,
+			[
+				'showMode'   => false,
+				'templateArgs' => false,
+				'query'      => '[[Foo::Bar=-3DFoox003D]]',
+				'printouts'  => [],
+				'parameters' => [],
+				'this'       => []
+			]
+		];
+
+		// A user shouldn't use `0x003D` as representation for `=`
+		yield [
+			[ '[[Foo::Bar=-3DFoo0x003D]]' ],
+			false,
+			[
+				'showMode'   => false,
+				'templateArgs' => false,
+				'query'      => '[[Foo::Bar=-3DFoo=]]',
+				'printouts'  => [],
+				'parameters' => [],
+				'this'       => []
+			]
+		];
+
 		yield [
 			[ '[[Foo::Bar]]', 'mainlabel=-' ],
 			false,


### PR DESCRIPTION
This PR is made in reference to: #640, #3560

This PR addresses or contains:

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed

Fixes #3560