### PR TITLE
Inject container subject as context, refs 3547

### DIFF
--- a/includes/datavalues/SMW_DV_Record.php
+++ b/includes/datavalues/SMW_DV_Record.php
@@ -101,7 +101,7 @@ class SMWRecordValue extends AbstractMultiValue {
 					$diProperty,
 					$values[$valueIndex],
 					false,
-					$this->getContextPage()
+					$containerSemanticData->getSubject()
 				);
 
 				if ( $dataValue->isValid() ) { // valid DV: keep

--- a/src/DataValues/ReferenceValue.php
+++ b/src/DataValues/ReferenceValue.php
@@ -212,7 +212,7 @@ class ReferenceValue extends AbstractMultiValue {
 					$property,
 					$values[$index],
 					false,
-					$this->getContextPage()
+					$containerSemanticData->getSubject()
 				);
 
 				if ( $dataValue->isValid() ) { // valid DV: keep

--- a/tests/phpunit/Integration/JSONScript/TestCases/p-0443.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/p-0443.json
@@ -1,5 +1,5 @@
 {
-	"description": "Test conditions and strict constraint validations for uniqueness `_PVUC` (#1463, `wgContLang=en`, `wgLang=en`, `smwgDVFeatures`)",
+	"description": "Test conditions and strict constraint validations for uniqueness `_PVUC` on `_txt`/`_rec`/`_ref_rec` with unique field (#1463, #3547, `smwgDVFeatures`)",
 	"setup": [
 		{
 			"namespace": "SMW_NS_PROPERTY",
@@ -12,12 +12,52 @@
 			"contents": "[[Has type::Text]] [[Has uniqueness constraint::true]]"
 		},
 		{
+			"namespace": "SMW_NS_PROPERTY",
+			"page": "Unique field",
+			"contents": "[[Has type::Text]] [[Has uniqueness constraint::true]]"
+		},
+		{
+			"namespace": "SMW_NS_PROPERTY",
+			"page": "Another unique field",
+			"contents": "[[Has type::Text]] [[Has uniqueness constraint::true]]"
+		},
+		{
+			"namespace": "SMW_NS_PROPERTY",
+			"page": "Unique record",
+			"contents": "[[Has type::Record]] [[Has fields::Unique field;Non unique field]]"
+		},
+		{
+			"namespace": "SMW_NS_PROPERTY",
+			"page": "Unique reference",
+			"contents": "[[Has type::Reference]] [[Has fields::Unique field;Another unique field;Non unique field]]"
+		},
+		{
 			"page": "Example/P0443/1",
 			"contents": "[[Has uniqueness one::Allowed one]] [[Has uniqueness one::Not permitted]] [[Has uniqueness two::Allowed two]] [[Has uniqueness two::Not permitted]]"
 		},
 		{
 			"page": "Example/P0443/2",
 			"contents": "[[Has uniqueness one::1111]] {{#ask: [[Has uniqueness one::1111]] |link=none |format=plainlist}}"
+		},
+		{
+			"page": "Example/P0443/3",
+			"contents": "[[Unique record::abc;123]]"
+		},
+		{
+			"page": "Example/P0443/4",
+			"contents": "[[Unique record::abc;123]] (fails on abc)"
+		},
+		{
+			"page": "Example/P0443/5",
+			"contents": "[[Unique reference::abc;def;123]] (fails on abc)"
+		},
+		{
+			"page": "Example/P0443/6",
+			"contents": "[[Unique reference::abcd;def;123]]"
+		},
+		{
+			"page": "Example/P0443/7",
+			"contents": "[[Unique reference::abcde;def;123]] (fails on def)"
 		}
 	],
 	"tests": [
@@ -54,6 +94,92 @@
 				"to-contain": [
 					"<p>1111 Example/P0443/2"
 				]
+			}
+		},
+		{
+			"type": "parser",
+			"about": "#2 (verify uniqueness of field in record )",
+			"subject": "Example/P0443/3",
+			"assert-store": {
+				"semantic-data": {
+					"strictPropertyValueMatch": false,
+					"propertyCount": 3,
+					"propertyKeys": [
+						"_MDAT",
+						"_SKEY",
+						"Unique record"
+					],
+					"propertyValues": [
+						"abc; 123"
+					]
+				}
+			}
+		},
+		{
+			"type": "parser",
+			"about": "#3 (verify uniqueness of field in record fails for same value as used in Example/P0443/3)",
+			"subject": "Example/P0443/4",
+			"assert-store": {
+				"semantic-data": {
+					"strictPropertyValueMatch": false,
+					"propertyCount": 3,
+					"propertyKeys": [
+						"_MDAT",
+						"_SKEY",
+						"_ERRC"
+					]
+				}
+			}
+		},
+		{
+			"type": "parser",
+			"about": "#4 (verify uniqueness of field in reference fails for same value as used in Example/P0443/3)",
+			"subject": "Example/P0443/5",
+			"assert-store": {
+				"semantic-data": {
+					"strictPropertyValueMatch": false,
+					"propertyCount": 3,
+					"propertyKeys": [
+						"_MDAT",
+						"_SKEY",
+						"_ERRC"
+					]
+				}
+			}
+		},
+		{
+			"type": "parser",
+			"about": "#5 (verify uniqueness for reference with uniqueness fields)",
+			"subject": "Example/P0443/6",
+			"assert-store": {
+				"semantic-data": {
+					"strictPropertyValueMatch": false,
+					"propertyCount": 3,
+					"propertyKeys": [
+						"_MDAT",
+						"_SKEY",
+						"Unique reference"
+					],
+					"propertyValues": [
+						"abcd"
+					]
+				}
+			}
+		},
+		{
+			"type": "parser",
+			"about": "#6 (verify uniqueness of field in reference fails for same value as used in Example/P0443/6)",
+			"subject": "Example/P0443/7",
+			"assert-store": {
+				"semantic-data": {
+					"strictPropertyValueMatch": false,
+					"propertyCount": 3,
+					"propertyKeys": [
+						"_MDAT",
+						"_SKEY",
+						"_ERRC"
+					]
+				}
 			}
 		}
 	],


### PR DESCRIPTION
This PR is made in reference to: #3547

This PR addresses or contains:

- Uses the container subject as context to check uniqueness, yet uniqueness was never tested for members of a record or reference field

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed

Fixes #3547