### PR TITLE
WikiPageValue to use provided fixed namespace, refs 3325, 3550

### DIFF
--- a/includes/datavalues/SMW_DV_WikiPage.php
+++ b/includes/datavalues/SMW_DV_WikiPage.php
@@ -139,7 +139,7 @@ class SMWWikiPageValue extends SMWDataValue {
 		// instance to distinguish [[~Foo*]] from [[Help:~Foo*]]
 		if ( $this->getOption( self::OPT_QUERY_COMP_CONTEXT ) || $this->getOption( self::OPT_QUERY_CONTEXT ) ) {
 
-			$title = Title::newFromText( $value );
+			$title = Title::newFromText( $value, $this->m_fixNamespace );
 
 			// T:P0427 If the user value says `ab c*` then make sure to use this one
 			// instead of the transformed DBKey which would be `Ab c*`

--- a/tests/phpunit/Integration/JSONScript/TestCases/q-0623.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/q-0623.json
@@ -1,0 +1,85 @@
+{
+	"description": "Test query with `_SUBC`",
+	"setup": [
+		{
+			"namespace": "SMW_NS_PROPERTY",
+			"page": "Has page",
+			"contents": "[[Has type::Page]]"
+		},
+		{
+			"namespace": "NS_CATEGORY",
+			"page": "Q0623",
+			"contents": ""
+		},
+		{
+			"namespace": "NS_CATEGORY",
+			"page": "Q0623/1",
+			"contents": "[[Category:Q0623]]"
+		},
+		{
+			"namespace": "NS_CATEGORY",
+			"page": "Q0623/1/1",
+			"contents": "[[Category:Q0623/1]]"
+		},
+		{
+			"namespace": "NS_CATEGORY",
+			"page": "Q0623/1/2",
+			"contents": "[[Category:Q0623/1]]"
+		}
+	],
+	"tests": [
+		{
+			"type": "query",
+			"about": "#0 (without `Category:` namespace, #3550)",
+			"condition": "[[Subcategory of::Q0623/1]]",
+			"printouts": [],
+			"parameters": {
+				"limit": "10"
+			},
+			"assert-queryresult": {
+				"count": 2,
+				"results": [
+					"Q0623/1/1#14##",
+					"Q0623/1/2#14##"
+				]
+			}
+		},
+		{
+			"type": "query",
+			"about": "#1 (with `Category:` namespace)",
+			"condition": "[[Subcategory of::Category:Q0623/1]]",
+			"printouts": [],
+			"parameters": {
+				"limit": "10"
+			},
+			"assert-queryresult": {
+				"count": 2,
+				"results": [
+					"Q0623/1/1#14##",
+					"Q0623/1/2#14##"
+				]
+			}
+		}
+	],
+	"settings": {
+		"smwgNamespacesWithSemanticLinks": {
+			"NS_MAIN": true,
+			"NS_CATEGORY": true,
+			"SMW_NS_PROPERTY": true,
+			"NS_HELP": true
+		},
+		"wgContLang": "en",
+		"wgLang": "en",
+		"smwgQSubpropertyDepth": 10,
+		"smwgQSubcategoryDepth": 10,
+		"smwgSparqlQFeatures": [
+			"SMW_SPARQL_QF_SUBP",
+			"SMW_SPARQL_QF_SUBC"
+		]
+	},
+	"meta": {
+		"version": "2",
+		"is-incomplete": false,
+		"debug": false
+	}
+}


### PR DESCRIPTION
This PR is made in reference to: #3325, #3550

This PR addresses or contains:

- Another victim of #3325, the `m_fixNamespace` wasn't honored and no test was in place to recognize the regression

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed

Fixes #3550