### PR TITLE
Use MW_VERSION instead of $wgVersion

### DIFF
--- a/SemanticMediaWiki.php
+++ b/SemanticMediaWiki.php
@@ -63,6 +63,11 @@ class SemanticMediaWiki {
 
 		define( 'SMW_VERSION', isset( $credits['version'] ) ? $credits['version'] : 'N/A' );
 
+		// https://phabricator.wikimedia.org/T212738
+		if ( !defined( 'MW_VERSION' ) ) {
+			define( 'MW_VERSION', $GLOBALS['wgVersion'] );
+		}
+
 		// Registration point for required early registration
 		Setup::initExtension( $GLOBALS );
 	}
@@ -89,20 +94,6 @@ class SemanticMediaWiki {
 
 		$setup->loadSchema( $GLOBALS );
 		$setup->init( $GLOBALS, __DIR__ );
-	}
-
-	/**
-	 * @since 2.4
-	 *
-	 * @return string|null
-	 */
-	public static function getVersion() {
-
-		if ( !defined( 'SMW_VERSION' ) ) {
-			return null;
-		}
-
-		return SMW_VERSION;
 	}
 
 }

--- a/res/Resources.php
+++ b/res/Resources.php
@@ -101,7 +101,7 @@ return [
 	// jStorage was added in MW 1.20
 	'ext.jquery.jStorage' => $moduleTemplate + [
 		'scripts' => 'jquery/jquery.jstorage.js',
-		'dependencies' => version_compare( $GLOBALS['wgVersion'], '1.29', '<' ) ? 'json' : [],
+		'dependencies' => version_compare( MW_VERSION, '1.29', '<' ) ? 'json' : [],
 	],
 
 	// md5 hash key generator

--- a/src/MediaWiki/Specials/Admin/SupportListTaskHandler.php
+++ b/src/MediaWiki/Specials/Admin/SupportListTaskHandler.php
@@ -86,7 +86,7 @@ class SupportListTaskHandler extends TaskHandler {
 
 		$info = $this->getStore()->getInfo() + [
 			'smw' => SMW_VERSION,
-			'mediawiki' => $GLOBALS['wgVersion']
+			'mediawiki' => MW_VERSION
 		] + (
 			defined( 'HHVM_VERSION' ) ? [ 'hhvm' => HHVM_VERSION ] : [ 'php' => PHP_VERSION ]
 		);

--- a/tests/autoloader.php
+++ b/tests/autoloader.php
@@ -16,7 +16,7 @@ if ( !defined( 'MEDIAWIKI' ) ) {
 	die( 'MediaWiki is not available.' );
 }
 
-if ( !class_exists( 'SemanticMediaWiki' ) || SemanticMediaWiki::getVersion() === null ) {
+if ( !class_exists( 'SemanticMediaWiki' ) || !defined( 'SMW_VERSION' ) ) {
 	die( "\nSemantic MediaWiki is not available, please check your LocalSettings or Composer settings.\n" );
 }
 

--- a/tests/phpUnitEnvironment.php
+++ b/tests/phpUnitEnvironment.php
@@ -80,7 +80,7 @@ class PHPUnitEnvironment {
 			);
 
 			$info = [
-				SemanticMediaWiki::getVersion(),
+				SMW_VERSION,
 				'git: ' . $this->getGitInfo( 'smw' ),
 				$store
 			] + $extra;
@@ -88,7 +88,7 @@ class PHPUnitEnvironment {
 
 		if ( $id === 'mw' ) {
 			$info = [
-				$GLOBALS['wgVersion'],
+				MW_VERSION,
 				'git: ' . $this->getGitInfo( 'mw' )
 			] + $extra;
 		}
@@ -118,9 +118,9 @@ class PHPUnitEnvironment {
 				// reference therefore try to fetch it from github; `MW` is
 				// exported by the Travis-CI environment to point to the selected
 				// release/branch
-				$release = ( $env = getenv( 'MW' ) ) ? $env : 'master';
-				exec( "git ls-remote https://github.com/wikimedia/mediawiki refs/heads/$release", $output );
-				$this->gitHead['mw'] = isset( $output[0] ) ? substr( $output[0], 0, 7 ) . " (refs/heads/$release)" : 'n/a';
+				$refs = ( $env = getenv( 'MW' ) ) ? "refs/heads/$env" : "refs/tags/" . MW_VERSION;
+				exec( "git ls-remote https://github.com/wikimedia/mediawiki $refs", $output );
+				$this->gitHead['mw'] = isset( $output[0] ) ? substr( $output[0], 0, 7 ) . " ($refs)"  : 'n/a';
 			} else {
 				$this->gitHead['mw'] = 'N/A';
 			}

--- a/tests/phpunit/Benchmark/BenchmarkJsonScriptRunnerTest.php
+++ b/tests/phpunit/Benchmark/BenchmarkJsonScriptRunnerTest.php
@@ -154,8 +154,8 @@ class BenchmarkJsonScriptRunnerTest extends JsonTestCaseScriptRunner {
 		);
 
 		$report = [
-			'mediawiki' => $GLOBALS['wgVersion'],
-			'semantic-mediawiki' => \SemanticMediaWiki::getVersion(),
+			'mediawiki' => MW_VERSION,
+			'semantic-mediawiki' => SMW_VERSION,
 			'environment' => $this->getStore()->getInfo(),
 			'benchmarks' => $this->benchmarkReports
 		];

--- a/tests/phpunit/DatabaseTestCase.php
+++ b/tests/phpunit/DatabaseTestCase.php
@@ -154,10 +154,10 @@ abstract class DatabaseTestCase extends \PHPUnit_Framework_TestCase {
 	protected function skipTestForMediaWikiVersionLowerThan( $version, $message = '' ) {
 
 		if ( $message === '' ) {
-			$message = "This test is skipped for MediaWiki version {$GLOBALS['wgVersion']}";
+			$message = "This test is skipped for MediaWiki version " . MW_VERSION;
 		}
 
-		if ( version_compare( $GLOBALS['wgVersion'], $version, '<' ) ) {
+		if ( version_compare( MW_VERSION, $version, '<' ) ) {
 			$this->markTestSkipped( $message );
 		}
 	}

--- a/tests/phpunit/Integration/MediaWiki/Import/Maintenance/DumpRdfMaintenanceTest.php
+++ b/tests/phpunit/Integration/MediaWiki/Import/Maintenance/DumpRdfMaintenanceTest.php
@@ -31,10 +31,6 @@ class DumpRdfMaintenanceTest extends MwDBaseUnitTestCase {
 	protected function setUp() {
 		parent::setUp();
 
-		if ( version_compare( $GLOBALS['wgVersion'], '1.20', '<' ) ) {
-			$this->markTestSkipped( "Skipping this test, MW 1.19 doesn't clean-up the title cache correctly." );
-		}
-
 		$this->runnerFactory  = UtilityFactory::getInstance()->newRunnerFactory();
 		$this->titleValidator = UtilityFactory::getInstance()->newValidatorFactory()->newTitleValidator();
 		$this->stringValidator = UtilityFactory::getInstance()->newValidatorFactory()->newStringValidator();

--- a/tests/phpunit/Integration/MediaWiki/Import/RedirectPageTest.php
+++ b/tests/phpunit/Integration/MediaWiki/Import/RedirectPageTest.php
@@ -141,7 +141,7 @@ class RedirectPageTest extends MwDBaseUnitTestCase {
 		// implementation and for non-sqlite see #212 / bug 62856
 		if ( $inSemanticData->getProperties() === [] ) {
 			$this->markTestSkipped(
-				"Skipping test either because of sqlite or MW-{$GLOBALS['wgVersion']} / bug 62856"
+				"Skipping test either because of sqlite or MW-" . MW_VERSION . "/ bug 62856"
 			);
 		}
 

--- a/tests/phpunit/JsonTestCaseFileHandler.php
+++ b/tests/phpunit/JsonTestCaseFileHandler.php
@@ -108,7 +108,7 @@ class JsonTestCaseFileHandler {
 		$skipOn = isset( $case['skip-on'] ) ? $case['skip-on'] : [];
 		$identifier = strtolower( $identifier );
 
-		$version = $GLOBALS['wgVersion'];
+		$version = MW_VERSION;
 
 		foreach ( $skipOn as $id => $value ) {
 
@@ -149,7 +149,7 @@ class JsonTestCaseFileHandler {
 			if ( strpos( $id, 'smw' ) !== false ) {
 				$version = SMW_VERSION;
 			} elseif ( strpos( $id, 'mediawiki' ) !== false || strpos( $id, 'mw' ) !== false ) {
-				$version = $GLOBALS['wgVersion'];
+				$version = MW_VERSION;
 			} elseif ( strpos( $id, 'hhvm' ) !== false ) {
 				$version = defined( 'HHVM_VERSION' ) ? HHVM_VERSION : 0;
 			} elseif ( strpos( $id, 'php' ) !== false ) {

--- a/tests/phpunit/JsonTestCaseScriptRunner.php
+++ b/tests/phpunit/JsonTestCaseScriptRunner.php
@@ -273,7 +273,7 @@ abstract class JsonTestCaseScriptRunner extends MwDBaseUnitTestCase {
 			$this->markTestSkipped( $jsonTestCaseFileHandler->getReasonForSkip() );
 		}
 
-		if ( $jsonTestCaseFileHandler->requiredToSkipForMwVersion( $GLOBALS['wgVersion'] ) ) {
+		if ( $jsonTestCaseFileHandler->requiredToSkipForMwVersion( MW_VERSION ) ) {
 			$this->markTestSkipped( $jsonTestCaseFileHandler->getReasonForSkip() );
 		}
 

--- a/tests/phpunit/Unit/DataValues/LanguageCodeValueTest.php
+++ b/tests/phpunit/Unit/DataValues/LanguageCodeValueTest.php
@@ -35,10 +35,6 @@ class LanguageCodeValueTest extends \PHPUnit_Framework_TestCase {
 
 	public function testHasErrorForInvalidLanguageCode() {
 
-		if ( version_compare( $GLOBALS['wgVersion'], '1.20', '<' ) ) {
-			$this->markTestSkipped( 'Skipping because `Language::isKnownLanguageTag` is not supported on 1.19' );
-		}
-
 		$instance = new LanguageCodeValue();
 		$instance->setUserValue( '-Foo' );
 

--- a/tests/phpunit/Unit/DataValues/MonolingualTextValueTest.php
+++ b/tests/phpunit/Unit/DataValues/MonolingualTextValueTest.php
@@ -81,10 +81,6 @@ class MonolingualTextValueTest extends \PHPUnit_Framework_TestCase {
 
 	public function testErrorForInvalidLanguageCode() {
 
-		if ( version_compare( $GLOBALS['wgVersion'], '1.20', '<' ) ) {
-			$this->markTestSkipped( 'Skipping because `Language::isKnownLanguageTag` is not supported on 1.19' );
-		}
-
 		$instance = new MonolingualTextValue();
 
 		$instance->setDataValueServiceFactory(
@@ -169,10 +165,6 @@ class MonolingualTextValueTest extends \PHPUnit_Framework_TestCase {
 	}
 
 	public function testGetWikiValueForInvalidMonolingualTextValue() {
-
-		if ( version_compare( $GLOBALS['wgVersion'], '1.20', '<' ) ) {
-			$this->markTestSkipped( 'Skipping because `Language::isKnownLanguageTag` is not supported on 1.19' );
-		}
 
 		$instance = new MonolingualTextValue();
 

--- a/tests/phpunit/Unit/LocalizerTest.php
+++ b/tests/phpunit/Unit/LocalizerTest.php
@@ -78,20 +78,12 @@ class LocalizerTest extends \PHPUnit_Framework_TestCase {
 
 	public function testSupportedLanguageForLowerCaseLetter() {
 
-		if ( version_compare( $GLOBALS['wgVersion'], '1.20', '<' ) ) {
-			$this->markTestSkipped( 'Skipping because `Language::isKnownLanguageTag` is not supported on 1.19' );
-		}
-
 		$this->assertTrue(
 			Localizer::isKnownLanguageTag( 'en' )
 		);
 	}
 
 	public function testSupportedLanguageForUpperCaseLetter() {
-
-		if ( version_compare( $GLOBALS['wgVersion'], '1.20', '<' ) ) {
-			$this->markTestSkipped( 'Skipping because `Language::isKnownLanguageTag` is not supported on 1.19' );
-		}
 
 		$this->assertTrue(
 			Localizer::isKnownLanguageTag( 'ZH-HANS' )

--- a/tests/phpunit/Unit/MediaWiki/Hooks/HookRegistryTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Hooks/HookRegistryTest.php
@@ -174,7 +174,7 @@ class HookRegistryTest extends \PHPUnit_Framework_TestCase {
 
 		$vars = [
 			'IP' => 'bar',
-			'wgVersion' => '1.24',
+		//	'wgVersion' => '1.24',
 			'wgLang' => $language,
 			'smwgEnabledDeferredUpdate' => false
 		];
@@ -196,7 +196,7 @@ class HookRegistryTest extends \PHPUnit_Framework_TestCase {
 
 		$vars = [
 			'IP' => 'bar',
-			'wgVersion' => '1.24',
+		//	'wgVersion' => '1.24',
 			'wgLang' => $language,
 			'smwgEnabledDeferredUpdate' => false
 		];

--- a/tests/phpunit/Unit/MediaWiki/Specials/SpecialDeferredRequestDispatcherTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Specials/SpecialDeferredRequestDispatcherTest.php
@@ -85,7 +85,7 @@ class SpecialDeferredRequestDispatcherTest extends \PHPUnit_Framework_TestCase {
 
 	public function testValidPostAsyncUpdateJob() {
 
-		if ( version_compare( $GLOBALS['wgVersion'], '1.20', '<' ) ) {
+		if ( version_compare( MW_VERSION, '1.20', '<' ) ) {
 			$this->markTestSkipped( "Skipping test because of missing method" );
 		}
 
@@ -111,7 +111,7 @@ class SpecialDeferredRequestDispatcherTest extends \PHPUnit_Framework_TestCase {
 
 	public function testValidPostAsyncParserCachePurgeJob() {
 
-		if ( version_compare( $GLOBALS['wgVersion'], '1.20', '<' ) ) {
+		if ( version_compare( MW_VERSION, '1.20', '<' ) ) {
 			$this->markTestSkipped( "Skipping test because of missing method" );
 		}
 
@@ -151,7 +151,7 @@ class SpecialDeferredRequestDispatcherTest extends \PHPUnit_Framework_TestCase {
 
 	public function testInvalidPostRequestToken() {
 
-		if ( version_compare( $GLOBALS['wgVersion'], '1.20', '<' ) ) {
+		if ( version_compare( MW_VERSION, '1.20', '<' ) ) {
 			$this->markTestSkipped( "Skipping test because of missing method" );
 		}
 
@@ -176,7 +176,7 @@ class SpecialDeferredRequestDispatcherTest extends \PHPUnit_Framework_TestCase {
 
 	public function testGetRequestForAsyncJob() {
 
-		if ( version_compare( $GLOBALS['wgVersion'], '1.20', '<' ) ) {
+		if ( version_compare( MW_VERSION, '1.20', '<' ) ) {
 			$this->markTestSkipped( "Skipping test because of missing method" );
 		}
 

--- a/tests/phpunit/Unit/PropertyAliasFinderTest.php
+++ b/tests/phpunit/Unit/PropertyAliasFinderTest.php
@@ -120,7 +120,7 @@ class PropertyAliasFinderTest extends \PHPUnit_Framework_TestCase {
 
 		$instance->registerAliasByMsgKey( '_Foo', 'smw-bar' );
 
-		$msgKey = version_compare( $GLOBALS['wgVersion'], '1.28', '<' ) ? '<smw-bar>' : '⧼smw-bar⧽' ;
+		$msgKey = version_compare( MW_VERSION, '1.28', '<' ) ? '<smw-bar>' : '⧼smw-bar⧽' ;
 
 		$this->assertEquals(
 			[ $msgKey => '_Foo' ],

--- a/tests/phpunit/Utils/MwApiFactory.php
+++ b/tests/phpunit/Utils/MwApiFactory.php
@@ -35,7 +35,7 @@ class MwApiFactory {
 	 */
 	public function newApiResult( array $params ) {
 
-		if ( version_compare( $GLOBALS['wgVersion'], '1.25', '<' ) ) {
+		if ( version_compare( MW_VERSION, '1.25', '<' ) ) {
 			return new ApiResult( $this->newApiMain( $params ) );
 		}
 

--- a/tests/phpunit/includes/DataValues/UriValueTest.php
+++ b/tests/phpunit/includes/DataValues/UriValueTest.php
@@ -121,9 +121,7 @@ class UriValueTest extends \PHPUnit_Framework_TestCase {
 	public function uriProvider() {
 
 		$linker = smwfGetLinker();
-
-		// FIXME MW 1.19*
-		$noFollowAttribute = version_compare( $GLOBALS['wgVersion'], '1.20', '<' ) ? '' : ' rel="nofollow"';
+		$noFollowAttribute = ' rel="nofollow"';
 
 		// https://github.com/lanthaler/IRI/blob/master/Test/IriTest.php
 		$provider[] = [

--- a/tests/phpunit/includes/SetupTest.php
+++ b/tests/phpunit/includes/SetupTest.php
@@ -55,7 +55,7 @@ class SetupTest extends \PHPUnit_Framework_TestCase {
 			'wgResourceModules' => [],
 			'wgScriptPath'      => '/Foo',
 			'wgServer'          => 'http://example.org',
-			'wgVersion'         => '1.21',
+			//'wgVersion'         => '1.21',
 			'wgLanguageCode'    => 'en',
 			'wgLang'            => $language,
 			'IP'                => 'Foo',


### PR DESCRIPTION
This PR is made in reference to: https://phabricator.wikimedia.org/T212738

This PR addresses or contains:

- Isolates access to $wgVersion to rely on `MW_VERSION` and if it is not defined then we do `define( 'MW_VERSION', $GLOBALS['wgVersion'] );` 
- Removes a couple of `markTestSkipped` (an used `$wgVersion`) that are no longer required due minimum MW
- Precautionary change in light of T212738

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed
