### PR TITLE
[ES] Use `keyword` as type for `P:*.geoField` mapping

### DIFF
--- a/data/elastic/smw-data-icu.json
+++ b/data/elastic/smw-data-icu.json
@@ -195,7 +195,7 @@
 						"path_match": "P:*.geoField",
 						"match_mapping_type": "string",
 						"mapping": {
-							"type": "text",
+							"type": "keyword",
 							"fields": {
 								"point": {
 									"type": "geo_point"

--- a/data/elastic/smw-data-standard.json
+++ b/data/elastic/smw-data-standard.json
@@ -186,7 +186,7 @@
 						"path_match": "P:*.geoField",
 						"match_mapping_type": "string",
 						"mapping": {
-							"type": "text",
+							"type": "keyword",
 							"fields": {
 								"point": {
 									"type": "geo_point"

--- a/tests/phpunit/Integration/JSONScript/TestCases/q-1300.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/q-1300.json
@@ -12,6 +12,10 @@
 		{
 			"page": "Q1300/1",
 			"contents": "[[Has coordinates::52°31'N, 13°24'E]]"
+		},
+		{
+			"page": "Q1300/2",
+			"contents": "[[Has coordinates::52° 8' 13\", -0° 28' 0\"]]"
 		}
 	],
 	"tests": [
@@ -62,6 +66,21 @@
 				"count": 1,
 				"results": [
 					"Q1300/1#0##"
+				]
+			}
+		},
+		{
+			"type": "query",
+			"about": "#2 (coordinates transformed to decimal representation => 52.136944444444,-0.46666666666667)",
+			"condition": "[[Has coordinates::52° 8' 13\", -0° 28' 0\"]]",
+			"printouts": [],
+			"parameters": {
+				"limit": "10"
+			},
+			"assert-queryresult": {
+				"count": 1,
+				"results": [
+					"Q1300/2#0##"
 				]
 			}
 		}


### PR DESCRIPTION
This PR is made in reference to: #

This PR addresses or contains:

- Switching from `text` to `keyword` as type for the `P:*.geoField` mapping because `text` is analyzed and gets us in trouble when a geo value like `52° 8' 13", -0° 28' 0"` is represented as decimal `52.136944444444,-0.46666666666667` notation (retrieved from Maps extension as value) and we are expected to match `[[Has coordinates::52° 8' 13", -0° 28' 0"]]"`
- Any change to the mapping of types require to reload the entire index since ES cannot swap those fields and means those who use Maps and ES are required to run `rebuildElasticIndex.php`

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed
