### PR TITLE
[ES] Add minimal doc body for an empty bulk request

### DIFF
--- a/src/Elastic/Indexer/Bulk.php
+++ b/src/Elastic/Indexer/Bulk.php
@@ -83,6 +83,13 @@ class Bulk {
 	}
 
 	/**
+	 * @since 3.1
+	 */
+	public function isEmpty() {
+		return $this->bulk === [];
+	}
+
+	/**
 	 * @since 3.0
 	 */
 	public function execute() {


### PR DESCRIPTION
This PR is made in reference to: #

This PR addresses or contains:

- If during the mapping of the data for a bulk request it came up empty, create a minimal doc body for the subject expected to be indexed.

This PR includes:
- [ ] Tests (unit/integration)
- [x] CI build passed
