### PR TITLE
Move fixed property registration to TypesRegistry

### DIFF
--- a/includes/storage/SQLStore/SMW_Sql3SmwIds.php
+++ b/includes/storage/SQLStore/SMW_Sql3SmwIds.php
@@ -143,7 +143,7 @@ class SMWSql3SmwIds {
 
 		$this->tableFieldUpdater = $this->factory->newTableFieldUpdater();
 
-		self::$special_ids = TypesRegistry::getFixedPropertyIdList();
+		self::$special_ids = TypesRegistry::getFixedProperties( 'id' );
 	}
 
 	/**
@@ -482,7 +482,7 @@ class SMWSql3SmwIds {
 			$key = $property->getKey();
 
 			// Has a fixed ID?
-			if ( isset( self::$special_ids[$key] ) && $subject->getSubobjectName() === '' ) {
+			if ( isset( self::$special_ids[$key] ) && is_int( self::$special_ids[$key] ) && $subject->getSubobjectName() === '' ) {
 				return self::$special_ids[$key];
 			}
 
@@ -779,12 +779,22 @@ class SMWSql3SmwIds {
 	 * @return integer
 	 */
 	public function getSMWPropertyID( SMWDIProperty $property ) {
-		if ( array_key_exists( $property->getKey(), self::$special_ids ) ) {
-			return self::$special_ids[$property->getKey()];
-		} else {
-			$sortkey = '';
-			return $this->getDatabaseIdAndSort( $property->getKey(), SMW_NS_PROPERTY, $this->getPropertyInterwiki( $property ), '', $sortkey, true, false );
+		$key = $property->getKey();
+		$sortkey = '';
+
+		if ( isset( self::$special_ids[$key] ) && is_int( self::$special_ids[$key] ) ) {
+			return self::$special_ids[$key];
 		}
+
+		return $this->getDatabaseIdAndSort(
+			$key,
+			SMW_NS_PROPERTY,
+			$this->getPropertyInterwiki( $property ),
+			'',
+			$sortkey,
+			true,
+			false
+		);
 	}
 
 	/**
@@ -798,19 +808,22 @@ class SMWSql3SmwIds {
 	 * @return integer
 	 */
 	public function makeSMWPropertyID( SMWDIProperty $property ) {
-		if ( array_key_exists( $property->getKey(), self::$special_ids ) ) {
-			return (int)self::$special_ids[$property->getKey()];
-		} else {
-			return (int)$this->makeDatabaseId(
-				$property->getKey(),
-				SMW_NS_PROPERTY,
-				$this->getPropertyInterwiki( $property ),
-				'',
-				true,
-				$property->getLabel(),
-				false
-			);
+
+		$key = $property->getKey();
+
+		if ( isset( self::$special_ids[$key] ) && is_int( self::$special_ids[$key] ) ) {
+			return self::$special_ids[$key];
 		}
+
+		return (int)$this->makeDatabaseId(
+			$key,
+			SMW_NS_PROPERTY,
+			$this->getPropertyInterwiki( $property ),
+			'',
+			true,
+			$property->getLabel(),
+			false
+		);
 	}
 
 	/**
@@ -854,7 +867,7 @@ class SMWSql3SmwIds {
 			}
 
 			// Check if this is a property with a fixed SMW ID:
-			if ( $subobjectName === '' && array_key_exists( $title, self::$special_ids ) ) {
+			if ( $subobjectName === '' && isset( self::$special_ids[$title] ) && is_int( self::$special_ids[$title] ) ) {
 				return self::$special_ids[$title];
 			}
 		}

--- a/src/SQLStore/Installer.php
+++ b/src/SQLStore/Installer.php
@@ -11,6 +11,7 @@ use SMW\MediaWiki\Jobs\EntityIdDisposerJob;
 use SMW\MediaWiki\Jobs\PropertyStatisticsRebuildJob;
 use SMW\Options;
 use SMW\Site;
+use SMW\TypesRegistry;
 use SMW\Utils\File;
 use SMW\Exception\FileNotWritableException;
 
@@ -290,8 +291,11 @@ class Installer implements MessageReporter {
 
 		// Only recognize those properties that require a fixed table
 		$pageSpecialProperties = array_intersect(
+			// Special properties enabled?
 			$vars['smwgPageSpecialProperties'],
-			PropertyTableInfoFetcher::getFixedSpecialPropertyList()
+
+			// Any custom fixed properties require their own table?
+			TypesRegistry::getFixedProperties( 'custom_fixed' )
 		);
 
 		// Sort to ensure the key contains the same order

--- a/src/SQLStore/PropertyTableInfoFetcher.php
+++ b/src/SQLStore/PropertyTableInfoFetcher.php
@@ -3,6 +3,7 @@
 namespace SMW\SQLStore;
 
 use SMW\DataTypeRegistry;
+use SMW\TypesRegistry;
 use SMW\DIProperty;
 use SMWDataItem as DataItem;
 
@@ -37,43 +38,9 @@ class PropertyTableInfoFetcher {
 	private $fixedPropertyTableIds = null;
 
 	/**
-	 * Keys of special properties that should have their own
-	 * fixed property table.
-	 *
-	 * @var array
-	 */
-	private static $customizableSpecialProperties = [
-		'_MDAT', '_CDAT', '_NEWP', '_LEDT', '_MIME', '_MEDIA',
-	];
-
-	/**
 	 * @var array
 	 */
 	private $customSpecialPropertyList = [];
-
-	/**
-	 * @var array
-	 */
-	private $fixedSpecialProperties = [
-		// property declarations
-		'_TYPE', '_UNIT', '_CONV', '_PVAL', '_LIST', '_SERV', '_PREC', '_PPLB',
-		// query statistics (very frequently used)
-		'_ASK', '_ASKDE', '_ASKSI', '_ASKFO', '_ASKST', '_ASKDU', '_ASKPA',
-		// subproperties, classes, and instances
-		'_SUBP', '_SUBC', '_INST',
-		// redirects
-		'_REDI',
-		// has sub object
-		'_SOBJ',
-		// vocabulary import and URI assignments
-		'_IMPO', '_URI',
-		// Concepts
-		'_CONC',
-		// Monolingual text
-		'_LCODE', '_TEXT',
-		// Display title of
-		'_DTITLE'
-	];
 
 	/**
 	 * @var array
@@ -103,15 +70,6 @@ class PropertyTableInfoFetcher {
 	 */
 	public function __construct( PropertyTypeFinder $propertyTypeFinder ) {
 		$this->propertyTypeFinder = $propertyTypeFinder;
-	}
-
-	/**
-	 * @since 3.0
-	 *
-	 * @return array
-	 */
-	public static function getFixedSpecialPropertyList() {
-		return self::$customizableSpecialProperties;
 	}
 
 	/**
@@ -250,11 +208,14 @@ class PropertyTableInfoFetcher {
 
 	private function buildDefinitionsForPropertyTables() {
 
-		$enabledSpecialProperties = $this->fixedSpecialProperties;
-		$customizableSpecialProperties = array_flip( self::$customizableSpecialProperties );
+		$enabledSpecialProperties = TypesRegistry::getFixedProperties( 'default_fixed' );
+
+		$customFixedSpecialPropertyList = array_flip(
+			TypesRegistry::getFixedProperties( 'custom_fixed' )
+		);
 
 		foreach ( $this->customSpecialPropertyList as $property ) {
-			if ( isset( $customizableSpecialProperties[$property] ) ) {
+			if ( isset( $customFixedSpecialPropertyList[$property] ) ) {
 				$enabledSpecialProperties[] = $property;
 			}
 		}

--- a/src/SQLStore/SQLStoreFactory.php
+++ b/src/SQLStore/SQLStoreFactory.php
@@ -34,6 +34,7 @@ use SMW\SQLStore\Lookup\UsageStatisticsListLookup;
 use SMW\SQLStore\Lookup\ProximityPropertyValueLookup;
 use SMW\SQLStore\TableBuilder\TableBuilder;
 use SMW\SQLStore\TableBuilder\Examiner\HashField;
+use SMW\SQLStore\TableBuilder\Examiner\FixedProperties;
 use SMW\Utils\CircularReferenceGuard;
 use SMWRequestOptions as RequestOptions;
 use SMWSql3SmwIds as EntityIdManager;
@@ -401,7 +402,8 @@ class SQLStoreFactory {
 
 		$tableIntegrityExaminer = new TableIntegrityExaminer(
 			$this->store,
-			new HashField( $this->store )
+			new HashField( $this->store ),
+			new FixedProperties( $this->store )
 		);
 
 		$tableSchemaManager = new TableSchemaManager(

--- a/src/SQLStore/TableBuilder/Examiner/FixedProperties.php
+++ b/src/SQLStore/TableBuilder/Examiner/FixedProperties.php
@@ -1,0 +1,154 @@
+<?php
+
+namespace SMW\SQLStore\TableBuilder\Examiner;
+
+use Onoi\MessageReporter\MessageReporterAwareTrait;
+use SMW\SQLStore\SQLStore;
+use SMW\TypesRegistry;
+
+/**
+ * @license GNU GPL v2+
+ * @since 3.1
+ *
+ * @author mwjames
+ */
+class FixedProperties {
+
+	use MessageReporterAwareTrait;
+
+	/**
+	 * @var SQLStore
+	 */
+	private $store;
+
+	/**
+	 * @var []
+	 */
+	private $fixedProperties = [];
+
+	/**
+	 * @var []
+	 */
+	private $properties = [];
+
+	/**
+	 * @since 3.1
+	 *
+	 * @param SQLStore $store
+	 */
+	public function __construct( SQLStore $store ) {
+		$this->store = $store;
+	}
+
+	/**
+	 * @since 3.1
+	 *
+	 * @param array $fixedProperties
+	 */
+	public function setFixedProperties( array $fixedProperties = [] ) {
+		$this->fixedProperties = $fixedProperties;
+	}
+
+	/**
+	 * @since 3.1
+	 *
+	 * @param array $properties
+	 */
+	public function setProperties( array $properties = [] ) {
+		$this->properties = $properties;
+	}
+
+	/**
+	 * @since 3.1
+	 *
+	 * @param array $opts
+	 */
+	public function check( array $opts = [] ) {
+
+		$this->messageReporter->reportMessage( "Checking selected fixed properties IDs ...\n" );
+
+		if ( $this->fixedProperties === [] ) {
+			$this->fixedProperties = TypesRegistry::getFixedProperties( 'id' );
+		}
+
+		if ( $this->properties === [] ) {
+			$this->properties = TypesRegistry::getFixedProperties( 'id_conversion' );
+		}
+
+		foreach ( $this->properties as $prop ) {
+			$this->checkAndMove( $prop );
+		}
+	}
+
+	private function checkAndMove( $prop ) {
+
+		if ( !isset( $this->fixedProperties[$prop] ) ) {
+			return;
+		}
+
+		$target_id = (int)$this->fixedProperties[$prop];
+
+		$connection = $this->store->getConnection( DB_MASTER );
+		$this->messageReporter->reportMessage( "   ... reading `$prop` ...\n"  );
+
+		$row = $connection->selectRow(
+			SQLStore::ID_TABLE,
+			[
+				'smw_id'
+			],
+			[
+				'smw_title' => $prop,
+				'smw_namespace' => SMW_NS_PROPERTY,
+				'smw_subobject' => ''
+			],
+			__METHOD__
+		);
+
+		if ( $row === false || (int)$row->smw_id == $target_id ) {
+			return $this->messageReporter->reportMessage( "   ... done.\n"  );
+		}
+
+		$current_id = (int)$row->smw_id;
+
+		$this->messageReporter->reportMessage( "   ... moving from $current_id to $target_id ...\n"  );
+
+		// Avoid "Error: 1062 Duplicate entry '52' for key 'PRIMARY' ..." before moving
+		$connection->delete(
+			SQLStore::ID_TABLE,
+			[
+				'smw_id' => $target_id
+			],
+			__METHOD__
+		);
+
+		$this->store->getObjectIds()->moveSMWPageID(
+			$current_id,
+			$target_id
+		);
+
+		$connection->update(
+			SQLStore::QUERY_LINKS_TABLE,
+			[
+				'o_id' => $target_id
+			],
+			[
+				'o_id' => $current_id
+			],
+			__METHOD__
+		);
+
+		$connection->update(
+			SQLStore::PROPERTY_STATISTICS_TABLE,
+			[
+				'p_id' => $target_id
+			],
+			[
+				'p_id' => $current_id
+			],
+			__METHOD__
+		);
+
+		$this->messageReporter->reportMessage( "   ... done.\n"  );
+	}
+
+}

--- a/src/TypesRegistry.php
+++ b/src/TypesRegistry.php
@@ -254,57 +254,114 @@ class TypesRegistry {
 	}
 
 	/**
-	 * Use pre-defined ids for Very Important Properties, avoiding frequent
-	 * ID lookups for those.
+	 * @private
 	 *
 	 * @note These constants also occur in the store. Changing them will
-	 * require to run setup.php again.
+	 * require to run `setup.php` again.
 	 *
-	 * @since 3.0
+	 * The highest assignable ID is defined by:
+	 * ( SQLStore::FIXED_PROPERTY_ID_UPPERBOUND - 1)
+	 *
+	 * - `id` refers to the fixed ID in the entity table assigned to a property
+	 *
+	 * - `default_fixed` refers to properties that by default are fixed and require
+	 * their own table space
+	 *
+	 * - `custom_fixed` refers to properties that are not enabled by default but
+	 * when the user enables them require their own table space
+	 *
+	 * - `id_conversion` contains properties planned to be converted and move to
+	 * a fixed ID
+	 *
+	 * @since 3.1
+	 *
+	 * @param string $key
 	 *
 	 * @return array
 	 */
-	public static function getFixedPropertyIdList() {
-		return [
-			'_TYPE' => 1,
-			'_URI'  => 2,
-			'_INST' => 4,
-			'_UNIT' => 7,
-			'_IMPO' => 8,
-			'_PPLB' => 9,
-			'_PDESC' => 10,
-			'_PREC' => 11,
-			'_CONV' => 12,
-			'_SERV' => 13,
-			'_PVAL' => 14,
-			'_REDI' => 15,
-			'_DTITLE' => 16,
-			'_SUBP' => 17,
-			'_SUBC' => 18,
-			'_CONC' => 19,
-			'_ERRP' => 22,
-	// 		'_1' => 23, // properties for encoding (short) lists
-	// 		'_2' => 24,
-	// 		'_3' => 25,
-	// 		'_4' => 26,
-	// 		'_5' => 27,
-	// 		'_SOBJ' => 27
-			'_LIST' => 28,
-			'_MDAT' => 29,
-			'_CDAT' => 30,
-			'_NEWP' => 31,
-			'_LEDT' => 32,
-			// properties related to query management
-			'_ASK'   => 33,
-			'_ASKST' => 34,
-			'_ASKFO' => 35,
-			'_ASKSI' => 36,
-			'_ASKDE' => 37,
-			'_ASKPA' => 38,
-			'_ASKSC' => 39,
-			'_LCODE' => 40,
-			'_TEXT'  => 41,
+	public static function getFixedProperties( $key = '' ) {
+
+		// PROP_ID => [ ID (SQL), default_fixed, custom_fixed ]
+		$fixedProperties = [
+
+			// FIXED ID
+			'_TYPE'   => [ 1,  true,  false ],
+			'_URI'    => [ 2,  true,  false ],
+			'_INST'   => [ 4,  true,  false ],
+			'_UNIT'   => [ 7,  true,  false ],
+			'_IMPO'   => [ 8,  true,  false ],
+			'_PPLB'   => [ 9,  true,  false ],
+			'_PDESC'  => [ 10, false, false ],
+			'_PREC'   => [ 11, true,  false ],
+			'_CONV'   => [ 12, true,  false ],
+			'_SERV'   => [ 13, true,  false ],
+			'_PVAL'   => [ 14, true,  false ],
+			'_REDI'   => [ 15, true,  false ],
+			'_DTITLE' => [ 16, true,  false ],
+			'_SUBP'   => [ 17, true,  false ],
+			'_SUBC'   => [ 18, true,  false ],
+			'_CONC'   => [ 19, true,  false ],
+			'_ERRP'   => [ 22, false, false ],
+
+			// Properties for encoding (short) lists
+			// '_1'  => [ 23, false, false ],
+			// '_2'  => [ 24, false, false ],
+			// '_3'  => [ 25, false, false ],
+			// '_4'  => [ 26, false, false ],
+			// '_5'  => [ 27, false, false ],
+			'_LIST'  => [ 28, true,  false ],
+			'_MDAT'  => [ 29, false, true  ],
+			'_CDAT'  => [ 30, false, true  ],
+			'_NEWP'  => [ 31, false, true  ],
+			'_LEDT'  => [ 32, false, true  ],
+
+			// Properties related to query management
+			'_ASK'   => [ 33, true,  false ],
+			'_ASKST' => [ 34, true,  false ],
+			'_ASKFO' => [ 35, true,  false ],
+			'_ASKSI' => [ 36, true,  false ],
+			'_ASKDE' => [ 37, true,  false ],
+			'_ASKPA' => [ 38, true,  false ],
+			'_ASKSC' => [ 39, false, false ],
+			'_LCODE' => [ 40, true,  false ],
+			'_TEXT'  => [ 41, true,  false ],
+
+			// NON FIXED ID
+			// If you convert an "non" ID fixed property (without an ID) to one
+			// with a fixed ID, add the property to the `id_conversion` array
+			// so that setup can start the conversion task.
+
+			'_SOBJ'   => [ false, true,  false ],
+			'_ASKDU'  => [ false, true,  false ],
+			'_MIME'   => [ false, false, true  ],
+			'_MEDIA'  => [ false, false, true  ],
+
 		];
+
+		if ( $key === 'id' ) {
+			array_walk( $fixedProperties, function( &$v, $k ) { $v = $v[0]; } );
+		}
+
+		// Default fixed property table for selected special properties
+		if ( $key === 'default_fixed' ) {
+			$fixedProperties = array_keys(
+				array_filter( $fixedProperties, function( $v ) { return $v[1]; } )
+			);
+		}
+
+		// Customizable (meaning that there are added or removed via a setting)
+		// special properties that can have their own fixed property table
+		if ( $key === 'custom_fixed' ) {
+			$fixedProperties = array_keys(
+				array_filter( $fixedProperties, function( $v ) { return $v[2]; } )
+			);
+		}
+
+		if ( $key === 'id_conversion' ) {
+			$fixedProperties = [];
+		}
+
+		return $fixedProperties;
 	}
 
 }

--- a/tests/phpunit/Unit/SQLStore/TableBuilder/Examiner/FixedPropertiesTest.php
+++ b/tests/phpunit/Unit/SQLStore/TableBuilder/Examiner/FixedPropertiesTest.php
@@ -1,0 +1,92 @@
+<?php
+
+namespace SMW\Tests\SQLStore\TableBuilder\Examiner;
+
+use SMW\SQLStore\TableBuilder\Examiner\FixedProperties;
+use SMW\Tests\TestEnvironment;
+
+/**
+ * @covers \SMW\SQLStore\TableBuilder\Examiner\FixedProperties
+ * @group semantic-mediawiki
+ *
+ * @license GNU GPL v2+
+ * @since 3.1
+ *
+ * @author mwjames
+ */
+class FixedPropertiesTest extends \PHPUnit_Framework_TestCase {
+
+	private $spyMessageReporter;
+	private $store;
+	private $connection;
+
+	protected function setUp() {
+		parent::setUp();
+		$this->spyMessageReporter = TestEnvironment::getUtilityFactory()->newSpyMessageReporter();
+
+		$this->store = $this->getMockBuilder( '\SMW\SQLStore\SQLStore' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$this->connection = $this->getMockBuilder( '\SMW\MediaWiki\Database' )
+			->disableOriginalConstructor()
+			->getMock();
+	}
+
+	public function testCanConstruct() {
+
+		$this->assertInstanceOf(
+			FixedProperties::class,
+			new FixedProperties( $this->store )
+		);
+	}
+
+	public function testCheck() {
+
+		$idTable = $this->getMockBuilder( '\SMWSql3SmwIds' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$this->connection->expects( $this->atLeastOnce() )
+			->method( 'selectRow' )
+			->will($this->onConsecutiveCalls(
+				(object)[ 'smw_id' => 99999 ],
+				(object)[ 'smw_id' => 11111 ] ) );
+
+		$this->store->expects( $this->any() )
+			->method( 'getConnection' )
+			->will( $this->returnValue( $this->connection ) );
+
+		$this->store->expects( $this->any() )
+			->method( 'getObjectIds' )
+			->will( $this->returnValue( $idTable ) );
+
+		$instance = new FixedProperties(
+			$this->store
+		);
+
+		$instance->setMessageReporter( $this->spyMessageReporter );
+		$instance->setFixedProperties( [ '_FOO' => 51, '_BAR' => 52 ] );
+		$instance->setProperties( [ '_FOO', '_BAR' ] );
+
+		$instance->check();
+
+		$expected = $this->spyMessageReporter->getMessagesAsString();
+
+		$this->assertContains(
+			'Checking selected fixed properties IDs',
+			$expected
+		);
+
+		$this->assertContains(
+			'moving from 99999 to 51',
+			$expected
+		);
+
+		$this->assertContains(
+			'moving from 11111 to 52',
+			$expected
+		);
+	}
+
+}

--- a/tests/phpunit/Unit/SQLStore/TableIntegrityExaminerTest.php
+++ b/tests/phpunit/Unit/SQLStore/TableIntegrityExaminerTest.php
@@ -19,12 +19,17 @@ class TableIntegrityExaminerTest extends \PHPUnit_Framework_TestCase {
 	private $spyMessageReporter;
 	private $hashField;
 	private $store;
+	private $fixedProperties;
 
 	protected function setUp() {
 		parent::setUp();
 		$this->spyMessageReporter = TestEnvironment::getUtilityFactory()->newSpyMessageReporter();
 
 		$this->hashField = $this->getMockBuilder( '\SMW\SQLStore\TableBuilder\Examiner\HashField' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$this->fixedProperties = $this->getMockBuilder( '\SMW\SQLStore\TableBuilder\Examiner\FixedProperties' )
 			->disableOriginalConstructor()
 			->getMock();
 
@@ -37,7 +42,7 @@ class TableIntegrityExaminerTest extends \PHPUnit_Framework_TestCase {
 
 		$this->assertInstanceOf(
 			TableIntegrityExaminer::class,
-			new TableIntegrityExaminer( $this->store, $this->hashField )
+			new TableIntegrityExaminer( $this->store, $this->hashField, $this->fixedProperties )
 		);
 	}
 
@@ -91,7 +96,8 @@ class TableIntegrityExaminerTest extends \PHPUnit_Framework_TestCase {
 
 		$instance = new TableIntegrityExaminer(
 			$store,
-			$this->hashField
+			$this->hashField,
+			$this->fixedProperties
 		);
 
 		$instance->setPredefinedPropertyList( [
@@ -160,7 +166,8 @@ class TableIntegrityExaminerTest extends \PHPUnit_Framework_TestCase {
 
 		$instance = new TableIntegrityExaminer(
 			$store,
-			$this->hashField
+			$this->hashField,
+			$this->fixedProperties
 		);
 
 		$instance->setPredefinedPropertyList( [
@@ -213,7 +220,8 @@ class TableIntegrityExaminerTest extends \PHPUnit_Framework_TestCase {
 
 		$instance = new TableIntegrityExaminer(
 			$store,
-			$this->hashField
+			$this->hashField,
+			$this->fixedProperties
 		);
 
 		$instance->setPredefinedPropertyList( [
@@ -273,7 +281,8 @@ class TableIntegrityExaminerTest extends \PHPUnit_Framework_TestCase {
 
 		$instance = new TableIntegrityExaminer(
 			$store,
-			$this->hashField
+			$this->hashField,
+			$this->fixedProperties
 		);
 
 		$instance->setPredefinedPropertyList( [] );
@@ -319,7 +328,8 @@ class TableIntegrityExaminerTest extends \PHPUnit_Framework_TestCase {
 
 		$instance = new TableIntegrityExaminer(
 			$store,
-			$this->hashField
+			$this->hashField,
+			$this->fixedProperties
 		);
 
 		$instance->setMessageReporter( $this->spyMessageReporter );

--- a/tests/phpunit/Unit/TypesRegistryTest.php
+++ b/tests/phpunit/Unit/TypesRegistryTest.php
@@ -31,12 +31,41 @@ class TypesRegistryTest extends \PHPUnit_Framework_TestCase {
 		);
 	}
 
-	public function testGetFixedPropertyIdList() {
+	public function testGetFixedProperties_IDList() {
 
 		$propertyList = TypesRegistry::getPropertyList();
 
-		foreach ( TypesRegistry::getFixedPropertyIdList() as $key => $id ) {
+		foreach ( TypesRegistry::getFixedProperties( 'id' ) as $key => $id ) {
 			$this->assertArrayHasKey( $key, $propertyList );
+		}
+	}
+
+	public function testGetFixedProperties_DefaultFixed() {
+
+		$propertyList = TypesRegistry::getPropertyList();
+
+		foreach ( TypesRegistry::getFixedProperties( 'default_fixed' ) as $key ) {
+			$this->assertArrayHasKey( $key, $propertyList );
+		}
+	}
+
+	public function testGetFixedProperties_CustomFixed() {
+
+		$propertyList = TypesRegistry::getPropertyList();
+
+		foreach ( TypesRegistry::getFixedProperties( 'custom_fixed' ) as $key ) {
+			$this->assertArrayHasKey( $key, $propertyList );
+		}
+	}
+
+	public function testGetFixedProperties_CompareFixed() {
+
+		$customList = TypesRegistry::getFixedProperties( 'custom_fixed' );
+
+		// Both list are exclusive (members of one list should not appear in the
+		// other list)
+		foreach ( TypesRegistry::getFixedProperties( 'default_fixed' ) as $key ) {
+			$this->assertFalse( array_search( $key, $customList ), $key );
 		}
 	}
 


### PR DESCRIPTION
This PR is made in reference to: #

This PR addresses or contains:

- Moves the registration for fixed properties from `PropertyTableInfoFetcher` to `TypesRegistry` to have all property related registrations in one place
- Adds `SMW\SQLStore\TableBuilder\Examiner\FixedProperties` to allow for a non ID fixed property to be converted into the 500- ID namespace

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed
