### PR TITLE
Dispose outdated query links, refs 1117

### DIFF
--- a/src/Maintenance/DataRebuilder/OutdatedDisposer.php
+++ b/src/Maintenance/DataRebuilder/OutdatedDisposer.php
@@ -1,0 +1,117 @@
+<?php
+
+namespace SMW\Maintenance\DataRebuilder;
+
+use Onoi\MessageReporter\MessageReporterAwareTrait;
+use SMW\MediaWiki\Jobs\EntityIdDisposerJob;
+use SMW\IteratorFactory;
+use Title;
+
+/**
+ * @private
+ *
+ * @license GNU GPL v2+
+ * @since 3.1
+ *
+ * @author mwjames
+ */
+class OutdatedDisposer {
+
+	use MessageReporterAwareTrait;
+
+	/**
+	 * @var EntityIdDisposerJob
+	 */
+	private $entityIdDisposerJob;
+
+	/**
+	 * @var IteratorFactory
+	 */
+	private $iteratorFactory;
+
+	/**
+	 * @since 3.1
+	 *
+	 * @param EntityIdDisposerJob $entityIdDisposerJob
+	 * @param IteratorFactory $iteratorFactory
+	 */
+	public function __construct( EntityIdDisposerJob $entityIdDisposerJob, IteratorFactory $iteratorFactory ) {
+		$this->entityIdDisposerJob = $entityIdDisposerJob;
+		$this->iteratorFactory = $iteratorFactory;
+	}
+
+	/**
+	 * @since 3.1
+	 */
+	public function run() {
+
+		$this->messageReporter->reportMessage( "Removing outdated entities and query links ..." );
+		$this->messageReporter->reportMessage( "\n   ... checking entities ..." );
+
+		$resultIterator = $this->entityIdDisposerJob->newOutdatedEntitiesResultIterator();
+
+		if ( ( $count = $resultIterator->count() ) > 0 ) {
+			$this->disposeOutdatedEntities( $resultIterator, $count );
+		}
+
+		$this->messageReporter->reportMessage( "\n   ... done." );
+		$this->messageReporter->reportMessage( "\n   ... checking query links ..." );
+
+		$resultIterator = $this->entityIdDisposerJob->newOutdatedQueryLinksResultIterator();
+
+		if ( ( $count = $resultIterator->count() ) > 0 ) {
+			$this->disposeOutdatedQueryLinks( $resultIterator, $count, 'query links (invalid)' );
+		}
+
+		$resultIterator = $this->entityIdDisposerJob->newUnassignedQueryLinksResultIterator();
+
+		if ( ( $count = $resultIterator->count() ) > 0 ) {
+			$this->disposeOutdatedQueryLinks( $resultIterator, $count, 'query links (unassigned)' );
+		}
+
+		$this->messageReporter->reportMessage( "\n   ... done.\n" );
+	}
+
+	private function disposeOutdatedEntities( $resultIterator, $count ) {
+
+		$this->messageReporter->reportMessage( "\n" );
+		$chunkedIterator = $this->iteratorFactory->newChunkedIterator( $resultIterator, 200 );
+
+		$counter = 0;
+
+		foreach ( $chunkedIterator as $chunk ) {
+			foreach ( $chunk as $row ) {
+				$counter++;
+				$msg = sprintf( "%s (%1.0f%%)", $row->smw_id, round( $counter / $count * 100 ) );
+
+				$this->messageReporter->reportMessage(
+					"\r". sprintf( "%-50s%s", "       ... cleaning up entity", $msg )
+				);
+
+				$this->entityIdDisposerJob->dispose( $row );
+			}
+		}
+
+		$this->messageReporter->reportMessage( "\n       ... {$count} IDs removed ..." );
+	}
+
+	private function disposeOutdatedQueryLinks( $resultIterator, $count, $label ) {
+
+		$this->messageReporter->reportMessage( "\n" );
+		$counter = 0;
+
+		foreach ( $resultIterator as $row ) {
+			$counter++;
+			$msg = sprintf( "%s (%1.0f%%)", $row->id, round( $counter / $count * 100 ) );
+
+			$this->messageReporter->reportMessage(
+				"\r". sprintf( "%-50s%s", "       ... cleaning up {$label}", $msg )
+			);
+
+			$this->entityIdDisposerJob->disposeQueryLinks( $row );
+		}
+
+		$this->messageReporter->reportMessage( "\n       ... {$count} IDs removed ..." );
+	}
+
+}

--- a/src/SQLStore/EntityRebuildDispatcher.php
+++ b/src/SQLStore/EntityRebuildDispatcher.php
@@ -312,6 +312,8 @@ class EntityRebuildDispatcher {
 				// to be changed with their pages
 				if ( $title !== null && !$title->exists() ) {
 					$this->propertyTableIdReferenceDisposer->cleanUpTableEntriesById( $row->smw_id );
+				} elseif ( $row->smw_proptable_hash === null && substr( $row->smw_subobject, 0, 6 ) === \SMWQuery::ID_PREFIX ) {
+					$this->propertyTableIdReferenceDisposer->cleanUpTableEntriesById( $row->smw_id );
 				} else {
 					$this->dispatchedEntities[] = [ 's' => $row->smw_title . '#' . $row->smw_namespace . '#' .$row->smw_subobject ];
 				}

--- a/src/SQLStore/QueryDependency/QueryLinksTableDisposer.php
+++ b/src/SQLStore/QueryDependency/QueryLinksTableDisposer.php
@@ -1,0 +1,155 @@
+<?php
+
+namespace SMW\SQLStore\QueryDependency;
+
+use SMW\ApplicationFactory;
+use SMW\DIWikiPage;
+use SMW\SQLStore\SQLStore;
+use SMW\Store;
+use SMW\IteratorFactory;
+
+/**
+ * @private
+ *
+ * @license GNU GPL v2+
+ * @since 3.1
+ *
+ * @author mwjames
+ */
+class QueryLinksTableDisposer {
+
+	/**
+	 * @var SQLStore
+	 */
+	private $store;
+
+	/**
+	 * @var IteratorFactory
+	 */
+	private $iteratorFactory;
+
+	/**
+	 * @var Database
+	 */
+	private $connection;
+
+	/**
+	 * @var boolean
+	 */
+	private $onTransactionIdle = false;
+
+	/**
+	 * @var boolean
+	 */
+	private $waitForReplication = false;
+
+	/**
+	 * @since 3.1
+	 *
+	 * @param Store $store
+	 * @param IteratorFactory $iteratorFactory
+	 */
+	public function __construct( Store $store, IteratorFactory $iteratorFactory ) {
+		$this->store = $store;
+		$this->iteratorFactory = $iteratorFactory;
+		$this->connection = $this->store->getConnection( 'mw.db' );
+	}
+
+	/**
+	 * @since 3.1
+	 */
+	public function waitOnTransactionIdle() {
+		$this->onTransactionIdle = true;
+	}
+
+	/**
+	 * @since 3.1
+	 */
+	public function waitForReplication() {
+		$this->waitForReplication = true;
+	}
+
+	/**
+	 * @since 3.1
+	 *
+	 * @return ResultIterator
+	 */
+	public function newOutdatedQueryLinksResultIterator() {
+
+		$res = $this->connection->select(
+			[ SQLStore::QUERY_LINKS_TABLE, SQLStore::ID_TABLE ],
+			's_id as id',
+			[
+				"smw_subobject=''"
+			],
+			__METHOD__,
+			[],
+			[
+				SQLStore::QUERY_LINKS_TABLE => [ 'INNER JOIN', "s_id=smw_id" ]
+			]
+		);
+
+		return $this->iteratorFactory->newResultIterator( $res );
+	}
+
+	/**
+	 * Returns a list of matches with IDs being listed in the query links table
+	 * but no longer reside in the entity (ID) table.
+	 *
+	 * @since 3.1
+	 *
+	 * @return ResultIterator
+	 */
+	public function newUnassignedQueryLinksResultIterator() {
+
+		$res = $this->connection->select(
+			[ SQLStore::QUERY_LINKS_TABLE, SQLStore::ID_TABLE ],
+			's_id as id',
+			[
+				"smw_id IS NULL"
+			],
+			__METHOD__,
+			[],
+			[
+				SQLStore::ID_TABLE => [ 'LEFT JOIN', "smw_id=s_id" ]
+			]
+		);
+
+		return $this->iteratorFactory->newResultIterator( $res );
+	}
+
+	/**
+	 * @since 3.1
+	 *
+	 * @param stdClass|integer $id
+	 */
+	public function cleanUpTableEntriesById( $id ) {
+
+		$fname = __METHOD__;
+
+		if ( isset( $id->id ) ) {
+			$id = $id->id;
+		}
+
+		if ( $this->onTransactionIdle ) {
+			return $this->connection->onTransactionIdle( function() use ( $id, $fname ) {
+				$this->connection->delete(
+					SQLStore::QUERY_LINKS_TABLE,
+					[
+						's_id' => $id
+					],
+					$fname
+				);
+			} );
+		}
+
+		$this->connection->delete(
+			SQLStore::QUERY_LINKS_TABLE,
+			[
+				's_id' => $id
+			],
+			$fname
+		);
+	}
+
+}

--- a/src/SQLStore/QueryDependencyLinksStoreFactory.php
+++ b/src/SQLStore/QueryDependencyLinksStoreFactory.php
@@ -11,6 +11,7 @@ use SMW\SQLStore\QueryDependency\EntityIdListRelevanceDetectionFilter;
 use SMW\SQLStore\QueryDependency\QueryDependencyLinksStore;
 use SMW\SQLStore\QueryDependency\QueryReferenceBacklinks;
 use SMW\SQLStore\QueryDependency\QueryResultDependencyListResolver;
+use SMW\SQLStore\QueryDependency\QueryLinksTableDisposer;
 use SMW\Store;
 
 /**
@@ -145,6 +146,25 @@ class QueryDependencyLinksStoreFactory {
 	 */
 	public function newQueryReferenceBacklinks( Store $store ) {
 		return new QueryReferenceBacklinks( $this->newQueryDependencyLinksStore( $store ) );
+	}
+
+	/**
+	 * @since 3.0
+	 *
+	 * @param Store $store
+	 *
+	 * @return QueryLinksTableDisposer
+	 */
+	public function newQueryLinksTableDisposer( Store $store ) {
+
+		$applicationFactory = ApplicationFactory::getInstance();
+
+		$queryLinksTableDisposer = new QueryLinksTableDisposer(
+			$store,
+			$applicationFactory->getIteratorFactory()
+		);
+
+		return $queryLinksTableDisposer;
 	}
 
 }

--- a/src/SQLStore/SQLStoreFactory.php
+++ b/src/SQLStore/SQLStoreFactory.php
@@ -738,6 +738,27 @@ class SQLStoreFactory {
 	}
 
 	/**
+	 * @since 3.1
+	 *
+	 * @return QueryDependencyLinksStoreFactory
+	 */
+	public function newQueryDependencyLinksStoreFactory() {
+		return new QueryDependencyLinksStoreFactory();
+	}
+
+	/**
+	 * @since 3.1
+	 *
+	 * @return PropertyTableIdReferenceDisposer
+	 */
+	public function newPropertyTableIdReferenceDisposer() {
+		return new PropertyTableIdReferenceDisposer(
+			$this->store,
+			$this->getIteratorFactory()
+		);
+	}
+
+	/**
 	 * @since 3.0
 	 *
 	 * @return ServicesContainer
@@ -753,6 +774,14 @@ class SQLStoreFactory {
 				'EntityValueUniquenessConstraintChecker' => [
 					'_service' => [ $this, 'newEntityValueUniquenessConstraintChecker' ],
 					'_type'    => EntityValueUniquenessConstraintChecker::class
+				],
+				'PropertyTableIdReferenceDisposer' => [
+					'_service' => [ $this, 'newPropertyTableIdReferenceDisposer' ],
+					'_type'    => PropertyTableIdReferenceDisposer::class
+				],
+				'QueryDependencyLinksStoreFactory' => [
+					'_service' => [ $this, 'newQueryDependencyLinksStoreFactory' ],
+					'_type'    => QueryDependencyLinksStoreFactory::class
 				],
 				'PropertyTableIdReferenceFinder' => function() {
 					static $singleton;

--- a/tests/phpunit/Unit/Maintenance/DataRebuilder/OutdatedDisposerTest.php
+++ b/tests/phpunit/Unit/Maintenance/DataRebuilder/OutdatedDisposerTest.php
@@ -1,0 +1,210 @@
+<?php
+
+namespace SMW\Tests\Maintenance\DataRebuilder;
+
+use SMW\Maintenance\DataRebuilder\OutdatedDisposer;
+use SMW\Tests\TestEnvironment;
+use SMW\Tests\Utils\Mock\IteratorMockBuilder;
+
+/**
+ * @covers \SMW\Maintenance\DataRebuilder\OutdatedDisposer
+ * @group semantic-mediawiki
+ *
+ * @license GNU GPL v2+
+ * @since 3.1
+ *
+ * @author mwjames
+ */
+class OutdatedDisposerTest extends \PHPUnit_Framework_TestCase {
+
+	private $spyMessageReporter;
+	private $entityIdDisposerJob;
+	private $iteratorFactory;
+	private $iteratorMockBuilder;
+	private $resultIterator;
+
+	protected function setUp() {
+		parent::setUp();
+		$this->spyMessageReporter = TestEnvironment::getUtilityFactory()->newSpyMessageReporter();
+
+		$this->entityIdDisposerJob = $this->getMockBuilder( '\SMW\MediaWiki\Jobs\EntityIdDisposerJob' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$this->iteratorFactory = $this->getMockBuilder( '\SMW\IteratorFactory' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$this->iteratorMockBuilder = new IteratorMockBuilder();
+
+		$this->resultIterator = $this->getMockBuilder( '\SMW\Iterators\ResultIterator' )
+			->disableOriginalConstructor()
+			->getMock();
+	}
+
+	public function testCanConstruct() {
+
+		$this->assertInstanceOf(
+			OutdatedDisposer::class,
+			new OutdatedDisposer( $this->entityIdDisposerJob, $this->iteratorFactory )
+		);
+	}
+
+	public function testDispose_Entities() {
+
+		$row = new \stdClass;
+		$row->smw_id = 1001;
+
+		$chunkedIterator = $this->iteratorMockBuilder->setClass( '\SMW\Iterators\ChunkedIterator' )
+			->with( [ [ $row ] ] )
+			->getMockForIterator();
+
+		$resultIterator = $this->getMockBuilder( '\SMW\Iterators\ResultIterator' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$resultIterator->expects( $this->once() )
+			->method( 'count' )
+			->will( $this->returnValue( 42 ) );
+
+		$this->entityIdDisposerJob->expects( $this->once() )
+			->method( 'newOutdatedEntitiesResultIterator' )
+			->will( $this->returnValue( $resultIterator ) );
+
+		$this->entityIdDisposerJob->expects( $this->once() )
+			->method( 'newOutdatedQueryLinksResultIterator' )
+			->will( $this->returnValue( $this->resultIterator ) );
+
+		$this->entityIdDisposerJob->expects( $this->once() )
+			->method( 'newUnassignedQueryLinksResultIterator' )
+			->will( $this->returnValue( $this->resultIterator ) );
+
+		$this->entityIdDisposerJob->expects( $this->once() )
+			->method( 'dispose' );
+
+		$this->iteratorFactory->expects( $this->once() )
+			->method( 'newChunkedIterator' )
+			->will( $this->returnValue( $chunkedIterator ) );
+
+		$instance = new OutdatedDisposer(
+			$this->entityIdDisposerJob,
+			$this->iteratorFactory
+		);
+
+		$instance->setMessageReporter( $this->spyMessageReporter );
+		$instance->run();
+
+		$messages = $this->spyMessageReporter->getMessagesAsString();
+
+		$this->assertContains(
+			'42 IDs removed',
+			$messages
+		);
+
+		$this->assertContains(
+			'1001 (2%)',
+			$messages
+		);
+	}
+
+	public function testDispose_QueryLinks_Invalid() {
+
+		$row = new \stdClass;
+		$row->id = 1002;
+
+		$resultIterator = $this->iteratorMockBuilder->setClass( '\SMW\Iterators\ResultIterator' )
+			->with( [ $row ] )
+			->incrementInvokedCounterBy( 1 )
+			->getMockForIterator();
+
+		$resultIterator->expects( $this->once() )
+			->method( 'count' )
+			->will( $this->returnValue( 9999 ) );
+
+		$this->entityIdDisposerJob->expects( $this->once() )
+			->method( 'newOutdatedQueryLinksResultIterator' )
+			->will( $this->returnValue( $resultIterator ) );
+
+		$this->entityIdDisposerJob->expects( $this->once() )
+			->method( 'newOutdatedEntitiesResultIterator' )
+			->will( $this->returnValue( $this->resultIterator ) );
+
+		$this->entityIdDisposerJob->expects( $this->once() )
+			->method( 'newUnassignedQueryLinksResultIterator' )
+			->will( $this->returnValue( $this->resultIterator ) );
+
+		$this->entityIdDisposerJob->expects( $this->once() )
+			->method( 'disposeQueryLinks' );
+
+		$instance = new OutdatedDisposer(
+			$this->entityIdDisposerJob,
+			$this->iteratorFactory
+		);
+
+		$instance->setMessageReporter( $this->spyMessageReporter );
+		$instance->run();
+
+		$messages = $this->spyMessageReporter->getMessagesAsString();
+
+		$this->assertContains(
+			'9999 IDs removed',
+			$messages
+		);
+
+		$this->assertContains(
+			'cleaning up query links (invalid)      1002 (0%)',
+			$messages
+		);
+	}
+
+	public function testDispose_QueryLinks_Unassigned() {
+
+		$row = new \stdClass;
+		$row->id = 3333;
+
+		$resultIterator = $this->iteratorMockBuilder->setClass( '\SMW\Iterators\ResultIterator' )
+			->with( [ $row ] )
+			->incrementInvokedCounterBy( 1 )
+			->getMockForIterator();
+
+		$resultIterator->expects( $this->once() )
+			->method( 'count' )
+			->will( $this->returnValue( 10 ) );
+
+		$this->entityIdDisposerJob->expects( $this->once() )
+			->method( 'newUnassignedQueryLinksResultIterator' )
+			->will( $this->returnValue( $resultIterator ) );
+
+		$this->entityIdDisposerJob->expects( $this->once() )
+			->method( 'newOutdatedEntitiesResultIterator' )
+			->will( $this->returnValue( $this->resultIterator ) );
+
+		$this->entityIdDisposerJob->expects( $this->once() )
+			->method( 'newOutdatedQueryLinksResultIterator' )
+			->will( $this->returnValue( $this->resultIterator ) );
+
+		$this->entityIdDisposerJob->expects( $this->once() )
+			->method( 'disposeQueryLinks' );
+
+		$instance = new OutdatedDisposer(
+			$this->entityIdDisposerJob,
+			$this->iteratorFactory
+		);
+
+		$instance->setMessageReporter( $this->spyMessageReporter );
+		$instance->run();
+
+		$messages = $this->spyMessageReporter->getMessagesAsString();
+
+		$this->assertContains(
+			'10 IDs removed',
+			$messages
+		);
+
+		$this->assertContains(
+			'cleaning up query links (unassigned)   3333 (10%)',
+			$messages
+		);
+	}
+
+}

--- a/tests/phpunit/Unit/MediaWiki/Jobs/EntityIdDisposerJobTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Jobs/EntityIdDisposerJobTest.php
@@ -65,6 +65,48 @@ class EntityIdDisposerJobTest extends \PHPUnit_Framework_TestCase {
 		);
 	}
 
+	public function testCanConstructOutdatedEntitiesResultIterator() {
+
+		$title = $this->getMockBuilder( 'Title' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$instance = new EntityIdDisposerJob( $title );
+
+		$this->assertInstanceOf(
+			'\SMW\Iterators\ResultIterator',
+			$instance->newOutdatedEntitiesResultIterator()
+		);
+	}
+
+	public function testCanConstructOutdatedQueryLinksResultIterator() {
+
+		$title = $this->getMockBuilder( 'Title' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$instance = new EntityIdDisposerJob( $title );
+
+		$this->assertInstanceOf(
+			'\SMW\Iterators\ResultIterator',
+			$instance->newOutdatedQueryLinksResultIterator()
+		);
+	}
+
+	public function testCanConstructUnassignedQueryLinksResultIterator() {
+
+		$title = $this->getMockBuilder( 'Title' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$instance = new EntityIdDisposerJob( $title );
+
+		$this->assertInstanceOf(
+			'\SMW\Iterators\ResultIterator',
+			$instance->newUnassignedQueryLinksResultIterator()
+		);
+	}
+
 	/**
 	 * @dataProvider parametersProvider
 	 */

--- a/tests/phpunit/Unit/SQLStore/QueryDependencyLinksStoreFactoryTest.php
+++ b/tests/phpunit/Unit/SQLStore/QueryDependencyLinksStoreFactoryTest.php
@@ -93,4 +93,18 @@ class QueryDependencyLinksStoreFactoryTest extends \PHPUnit_Framework_TestCase {
 		);
 	}
 
+	public function testCanConstructQueryLinksTableDisposer() {
+
+		$store = $this->getMockBuilder( '\SMW\Store' )
+			->disableOriginalConstructor()
+			->getMockForAbstractClass();
+
+		$instance = new QueryDependencyLinksStoreFactory();
+
+		$this->assertInstanceOf(
+			'\SMW\SQLStore\QueryDependency\QueryLinksTableDisposer',
+			$instance->newQueryLinksTableDisposer( $store )
+		);
+	}
+
 }

--- a/tests/phpunit/Unit/SQLStore/SQLStoreFactoryTest.php
+++ b/tests/phpunit/Unit/SQLStore/SQLStoreFactoryTest.php
@@ -425,6 +425,26 @@ class SQLStoreFactoryTest extends \PHPUnit_Framework_TestCase {
 		);
 	}
 
+	public function testCanConstructQueryDependencyLinksStoreFactory() {
+
+		$instance = new SQLStoreFactory( $this->store );
+
+		$this->assertInstanceOf(
+			'\SMW\SQLStore\QueryDependencyLinksStoreFactory',
+			$instance->newQueryDependencyLinksStoreFactory()
+		);
+	}
+
+	public function testCanConstructPropertyTableIdReferenceDisposer() {
+
+		$instance = new SQLStoreFactory( $this->store );
+
+		$this->assertInstanceOf(
+			'\SMW\SQLStore\PropertyTableIdReferenceDisposer',
+			$instance->newPropertyTableIdReferenceDisposer()
+		);
+	}
+
 	public function testCanConstructServicesContainer() {
 
 		$instance = new SQLStoreFactory( $this->store );


### PR DESCRIPTION
This PR is made in reference to: #1117

This PR addresses or contains:

- Adds `QueryLinksTableDisposer` and extends the disposing routine to detect outdated and unassigned links

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed
