### PR TITLE
Track attachments via `_ATTCH_LINK`, refs 3640

### DIFF
--- a/DefaultSettings.php
+++ b/DefaultSettings.php
@@ -915,6 +915,7 @@ return [
 	# - `_MDAT` Modification date is enabled by default for backward compatibility.
 	# - `_TRANS` Add annotations (language, source etc. ) when a page is
 	#   indentified as translation page (as done by the Translation extension)
+	# - `_ATTCH_LINK` tracks embedded files and images
 	#
 	#  Extend array to enable other properties:
 	#     $smwgPageSpecialProperties[ => '_CDAT',

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -651,6 +651,7 @@
 	"smw-property-predefined-askco": "\"$1\" is a predefined property provided by [https://www.semantic-mediawiki.org/wiki/Help:Special_properties Semantic MediaWiki] to describe the state of a query or its components.",
 	"smw-property-predefined-long-askco": "The number or numbers assigned represent an internal codified state that is explained on the [https://www.semantic-mediawiki.org/wiki/Help:Query_profiler help page].",
 	"smw-property-predefined-prec": "\"$1\" is a predefined property that describes a [https://www.semantic-mediawiki.org/wiki/Help:Display_precision display precision] (in decimal digits) for numeric datatypes.",
+	"smw-property-predefined-attch-link": "\"$1\" is a predefined property that collects embedded file and image links found in a page and is provided by [https://www.semantic-mediawiki.org/wiki/Help:Special_properties Semantic MediaWiki].",
 	"smw-types-extra-geo-not-available": "[https://www.semantic-mediawiki.org/wiki/Extension:Maps Extension \"Maps\"] was not detected therefore \"$1\" is restricted in its capacity to operate.",
 	"smw-datavalue-monolingual-dataitem-missing": "An expected item for building a monolingual compound value is missing.",
 	"smw-datavalue-monolingual-lcode-parenthesis":"($1)",

--- a/i18n/extra/en.json
+++ b/i18n/extra/en.json
@@ -123,6 +123,7 @@
             "_SCHEMA_DEF": "Schema definition",
             "_SCHEMA_LINK": "Schema link",
             "_FORMAT_SCHEMA": "Formatter schema",
+            "_ATTCH_LINK": "Attachment link",
             "_FILE_ATTCH": "File attachment",
             "_CONT_TYPE": "Content type",
             "_CONT_AUTHOR": "Content author",

--- a/src/MediaWiki/Hooks/ParserAfterTidy.php
+++ b/src/MediaWiki/Hooks/ParserAfterTidy.php
@@ -116,6 +116,7 @@ class ParserAfterTidy extends HookHandler {
 		$parserOutput = $this->parser->getOutput();
 
 		if ( $parserOutput->getProperty( 'displaytitle' ) ||
+			$parserOutput->getImages() !== [] ||
 			$parserOutput->getExtensionData( 'translate-translation-page' ) ||
 			$parserOutput->getCategoryLinks() ) {
 			return true;
@@ -199,6 +200,12 @@ class ParserAfterTidy extends HookHandler {
 		$propertyAnnotator = $propertyAnnotatorFactory->newTranslationPropertyAnnotator(
 			$propertyAnnotator,
 			$parserOutput->getExtensionData( 'translate-translation-page' )
+		);
+
+		// #3640
+		$propertyAnnotator = $propertyAnnotatorFactory->newAttachmentLinkPropertyAnnotator(
+			$propertyAnnotator,
+			$parserOutput->getImages()
 		);
 
 		$propertyAnnotator->addAnnotation();

--- a/src/PropertyAnnotatorFactory.php
+++ b/src/PropertyAnnotatorFactory.php
@@ -13,6 +13,7 @@ use SMW\PropertyAnnotators\RedirectPropertyAnnotator;
 use SMW\PropertyAnnotators\SchemaPropertyAnnotator;
 use SMW\PropertyAnnotators\SortKeyPropertyAnnotator;
 use SMW\PropertyAnnotators\TranslationPropertyAnnotator;
+use SMW\PropertyAnnotators\AttachmentLinkPropertyAnnotator;
 use SMW\Store;
 use SMW\Schema\Schema;
 use Title;
@@ -67,6 +68,28 @@ class PropertyAnnotatorFactory {
 		);
 
 		return $schemaPropertyAnnotator;
+	}
+
+	/**
+	 * @since 3.1
+	 *
+	 * @param PropertyAnnotator $propertyAnnotator
+	 * @param array $images
+	 *
+	 * @return AttachmentLinkPropertyAnnotator
+	 */
+	public function newAttachmentLinkPropertyAnnotator( PropertyAnnotator $propertyAnnotator, array $images = [] ) {
+
+		$attachmentLinkPropertyAnnotator = new AttachmentLinkPropertyAnnotator(
+			$propertyAnnotator,
+			$images
+		);
+
+		$attachmentLinkPropertyAnnotator->setPredefinedPropertyList(
+			ApplicationFactory::getInstance()->getSettings()->get( 'smwgPageSpecialProperties' )
+		);
+
+		return $attachmentLinkPropertyAnnotator;
 	}
 
 	/**

--- a/src/PropertyAnnotators/AttachmentLinkPropertyAnnotator.php
+++ b/src/PropertyAnnotators/AttachmentLinkPropertyAnnotator.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace SMW\PropertyAnnotators;
+
+use SMW\PropertyAnnotator;
+use SMW\DIWikiPage;
+use SMW\DIProperty;
+use Title;
+
+/**
+ * @license GNU GPL v2+
+ * @since 3.1
+ *
+ * @author mwjames
+ */
+class AttachmentLinkPropertyAnnotator extends PropertyAnnotatorDecorator {
+
+	/**
+	 * @var []
+	 */
+	private $attachments;
+
+	/**
+	 * @var array
+	 */
+	private $predefinedPropertyList = [];
+
+	/**
+	 * @since 3.1
+	 *
+	 * @param PropertyAnnotator $propertyAnnotator
+	 * @param array|null $attachments
+	 */
+	public function __construct( PropertyAnnotator $propertyAnnotator, $attachments ) {
+		parent::__construct( $propertyAnnotator );
+		$this->attachments = $attachments;
+	}
+
+	/**
+	 * @since 3.1
+	 *
+	 * @param array $predefinedPropertyList
+	 */
+	public function setPredefinedPropertyList( array $predefinedPropertyList ) {
+		$this->predefinedPropertyList = array_flip( $predefinedPropertyList );
+	}
+
+	protected function addPropertyValues() {
+
+		if ( !is_array( $this->attachments ) || !isset( $this->predefinedPropertyList['_ATTCH_LINK'] ) ) {
+			return;
+		}
+
+		$semanticData = $this->getSemanticData();
+		$property = $this->dataItemFactory->newDIProperty( '_ATTCH_LINK' );
+
+		foreach ( $this->attachments as $attachment => $v ) {
+			$semanticData->addPropertyObjectValue(
+				$property,
+				$this->dataItemFactory->newDIWikiPage( $attachment, NS_FILE )
+			);
+		}
+
+	}
+}

--- a/src/TypesRegistry.php
+++ b/src/TypesRegistry.php
@@ -219,6 +219,7 @@ class TypesRegistry {
 			'_FORMAT_SCHEMA' => [ '_wps', true, true, false ], // "Formatter schema"
 
 			// File attachment
+			'_ATTCH_LINK'  => [ '_wpg', false, false, false ], // "Attachment link"
 			'_FILE_ATTCH'  => [ '__sob', false, false, false ], // "File attachment"
 			'_CONT_TYPE' => [ '_txt', true, true, false ], // "Content type"
 			'_CONT_AUTHOR' => [ '_txt', true, true, false ], // "Content author"
@@ -325,6 +326,10 @@ class TypesRegistry {
 			'_ASKSC' => [ 39, false, false ],
 			'_LCODE' => [ 40, true,  false ],
 			'_TEXT'  => [ 41, true,  false ],
+
+			// Due to the potential size of related links, make it a custom_fixed
+			// when enabled
+			'_ATTCH_LINK' => [ 60, false, true ],
 
 			// NON FIXED ID
 			// If you convert an "non" ID fixed property (without an ID) to one

--- a/tests/phpunit/Unit/PropertyAnnotatorFactoryTest.php
+++ b/tests/phpunit/Unit/PropertyAnnotatorFactoryTest.php
@@ -143,4 +143,18 @@ class PropertyAnnotatorFactoryTest extends \PHPUnit_Framework_TestCase {
 		);
 	}
 
+	public function testCanConstructAttachmentLinkPropertyAnnotator() {
+
+		$propertyAnnotator = $this->getMockBuilder( '\SMW\PropertyAnnotator' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$instance = new PropertyAnnotatorFactory();
+
+		$this->assertInstanceOf(
+			'\SMW\PropertyAnnotators\AttachmentLinkPropertyAnnotator',
+			$instance->newAttachmentLinkPropertyAnnotator( $propertyAnnotator )
+		);
+	}
+
 }

--- a/tests/phpunit/Unit/PropertyAnnotators/AttachmentLinkPropertyAnnotatorTest.php
+++ b/tests/phpunit/Unit/PropertyAnnotators/AttachmentLinkPropertyAnnotatorTest.php
@@ -1,0 +1,108 @@
+<?php
+
+namespace SMW\Tests\PropertyAnnotators;
+
+use SMW\DataItemFactory;
+use SMW\SemanticData;
+use SMW\PropertyAnnotators\NullPropertyAnnotator;
+use SMW\PropertyAnnotators\AttachmentLinkPropertyAnnotator;
+use SMW\Tests\TestEnvironment;
+use SMW\Localizer;
+
+/**
+ * @covers \SMW\PropertyAnnotators\AttachmentLinkPropertyAnnotator
+ * @group semantic-mediawiki
+ *
+ * @license GNU GPL v2+
+ * @since 3.1
+ *
+ * @author mwjames
+ */
+class AttachmentLinkPropertyAnnotatorTest extends \PHPUnit_Framework_TestCase {
+
+	private $semanticDataValidator;
+	private $dataItemFactory;
+	private $nsFileName;
+
+	protected function setUp() {
+		parent::setUp();
+
+		$this->semanticDataValidator = TestEnvironment::newValidatorFactory()->newSemanticDataValidator();
+		$this->dataItemFactory = new DataItemFactory();
+		$this->fileNS = Localizer::getInstance()->getNamespaceTextById( NS_FILE );
+	}
+
+	public function testCanConstruct() {
+
+		$semanticData = $this->getMockBuilder( '\SMW\SemanticData' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$instance = new AttachmentLinkPropertyAnnotator(
+			new NullPropertyAnnotator( $semanticData ),
+			[]
+		);
+
+		$this->assertInstanceOf(
+			AttachmentLinkPropertyAnnotator::class,
+			$instance
+		);
+	}
+
+	public function testAddAnnotation() {
+
+		$semanticData = new SemanticData(
+			$this->dataItemFactory->newDIWikiPage( 'Foo' )
+		);
+
+		$attachments = [
+			'Foo.png' => 1
+		];
+
+		$expected = [
+			'propertyCount'  => 1,
+			'propertyKeys'   => [ '_ATTCH_LINK' ],
+			'propertyValues' => [ $this->fileNS . ':Foo.png' ],
+		];
+
+		$instance = new AttachmentLinkPropertyAnnotator(
+			new NullPropertyAnnotator( $semanticData ),
+			$attachments
+		);
+
+		$instance->setPredefinedPropertyList( [ '_ATTCH_LINK' ] );
+
+		$instance->addAnnotation();
+
+		$this->semanticDataValidator->assertThatPropertiesAreSet(
+			$expected,
+			$instance->getSemanticData()
+		);
+	}
+
+	public function testAddAnnotation_EmptyAttachments() {
+
+		$semanticData = new SemanticData(
+			$this->dataItemFactory->newDIWikiPage( 'Foo' )
+		);
+
+		$title = $this->getMockBuilder( '\Title' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$attachments = [];
+
+		$instance = new AttachmentLinkPropertyAnnotator(
+			new NullPropertyAnnotator( $semanticData ),
+			$attachments
+		);
+
+		$instance->addAnnotation();
+
+		$this->assertEquals(
+			$semanticData,
+			$instance->getSemanticData()
+		);
+	}
+
+}


### PR DESCRIPTION
This PR is made in reference to: #3640

This PR addresses or contains:

- Adds `_ATTCH_LINK` to record embedded files, images if `smwgPageSpecialProperties` contains the property
- It will record all files, images that are accessible via `ParserOutput::getImages`

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed
