### PR TITLE
InfoLinksProvider detect `TYPE_WIKIPAGE`, refs 2910

### DIFF
--- a/src/DataValues/InfoLinksProvider.php
+++ b/src/DataValues/InfoLinksProvider.php
@@ -8,6 +8,7 @@ use SMW\Message;
 use SMW\Parser\InTextAnnotationParser;
 use SMW\PropertySpecificationLookup;
 use SMWDataValue as DataValue;
+use SMWDataItem as DataItem;
 use SMWDIBlob as DIBlob;
 use SMWInfolink as Infolink;
 
@@ -145,6 +146,7 @@ class InfoLinksProvider {
 
 		// Avoid any localization when generating the value
 		$this->dataValue->setOutputFormat( '' );
+		$dataItem = $this->dataValue->getDataItem();
 
 		$value = $this->dataValue->getWikiValue();
 		$property = $this->dataValue->getProperty();
@@ -156,6 +158,9 @@ class InfoLinksProvider {
 		}
 
 		if ( in_array( $this->dataValue->getTypeID(), $this->browseLinks ) ) {
+			$infoLink = Infolink::newBrowsingLink( '+', $this->dataValue->getLongWikiText() );
+			$infoLink->setCompactLink( $this->compactLink );
+		} elseif ( in_array( $dataItem->getDIType(), [ DataItem::TYPE_WIKIPAGE, DataItem::TYPE_CONTAINER ] ) ) {
 			$infoLink = Infolink::newBrowsingLink( '+', $this->dataValue->getLongWikiText() );
 			$infoLink->setCompactLink( $this->compactLink );
 		} elseif ( $property !== null ) {

--- a/tests/phpunit/Unit/Page/ListBuilder/ValueListBuilderTest.php
+++ b/tests/phpunit/Unit/Page/ListBuilder/ValueListBuilderTest.php
@@ -88,7 +88,7 @@ class ValueListBuilderTest extends \PHPUnit_Framework_TestCase {
 			[
 				'<div class="smw-table-row header-row"><div class="smw-table-cell header-title"><div id="B">B</div>',
 				'title="SMW\Tests\Page\ListBuilder\ValueListBuilderTest::testCreateHtml',
-				'<span class="smwsearch">.*:Foo/Bar">+</a>'
+				'<span class="smwbrowse">.*:Bar">+</a>'
 			],
 			$instance->createHtml( $property, $dataItem, [ 'limit' => 10 ] )
 		);


### PR DESCRIPTION
This PR is made in reference to: #2910 

This PR addresses or contains:

- Restores the `Browse` link for `TYPE_WIKIPAGE` entities

This PR includes:
- [ ] Tests (unit/integration)
- [x] CI build passed
