### PR TITLE
WikiPageValue to support `noimage` output option

### DIFF
--- a/includes/datavalues/SMW_DV_WikiPage.php
+++ b/includes/datavalues/SMW_DV_WikiPage.php
@@ -39,6 +39,11 @@ class SMWWikiPageValue extends SMWDataValue {
 	const NO_TEXT_TRANSFORMATION = 'no.text.transformation';
 
 	/**
+	 * Whether images should be displayed as media or simple link.
+	 */
+	const NO_IMAGE = 'no.image';
+
+	/**
 	 * Whether to use the short form or not.
 	 */
 	const SHORT_FORM = 'short.form';
@@ -272,7 +277,13 @@ class SMWWikiPageValue extends SMWDataValue {
 			return $this->m_caption !== false ? $this->m_caption : $this->getWikiValue();
 		}
 
-		if ( Image::isImage( $this->m_dataitem ) && $this->m_dataitem->getInterwiki() === '' ) {
+		$noImage = $this->getOption( self::NO_IMAGE, false );
+
+		if ( $this->m_outformat == 'noimage' ) {
+			$noImage = true;
+		}
+
+		if ( Image::isImage( $this->m_dataitem ) && $this->m_dataitem->getInterwiki() === '' && !$noImage ) {
 			$linkEscape = '';
 			$options = $this->m_outformat === false ? 'frameless|border|text-top|' : str_replace( ';', '|', \Sanitizer::removeHTMLtags( $this->m_outformat ) );
 			$defaultCaption = '|' . $this->getShortCaptionText() . '|' . $options;
@@ -356,9 +367,15 @@ class SMWWikiPageValue extends SMWDataValue {
 			return $this->getErrorText();
 		}
 
+		$noImage = $this->getOption( self::NO_IMAGE, false );
+
+		if ( $this->m_outformat == 'noimage' ) {
+			$noImage = true;
+		}
+
 		if ( is_null( $linked ) || $linked === false || $this->m_outformat == '-' ) {
 			return $this->getWikiValue();
-		} elseif ( Image::isImage( $this->m_dataitem ) && $this->m_dataitem->getInterwiki() === '' ) {
+		} elseif ( Image::isImage( $this->m_dataitem ) && $this->m_dataitem->getInterwiki() === '' && !$noImage ) {
 			// Embed images and other files
 			// Note that the embedded file links to the image, hence needs no additional link text.
 			// There should not be a linebreak after an impage, just like there is no linebreak after

--- a/tests/phpunit/Integration/JSONScript/TestCases/p-0705.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/p-0705.json
@@ -1,10 +1,20 @@
 {
-	"description": "Test `#ask`/ NS_FILE option (`wgContLang=en`, `wgLang=en`, `wgEnableUploads`, `wgFileExtensions`, 'wgDefaultUserOptions')",
+	"description": "Test `#ask`/ NS_FILE option, `noimage` (`wgEnableUploads`, `wgFileExtensions`, `wgDefaultUserOptions`)",
 	"setup": [
 		{
 			"namespace": "SMW_NS_PROPERTY",
 			"page": "Has text",
 			"contents": "[[Has type::Text]]"
+		},
+		{
+			"namespace": "SMW_NS_PROPERTY",
+			"page": "Has file",
+			"contents": "[[Has type::Page]]"
+		},
+		{
+			"namespace": "SMW_NS_PROPERTY",
+			"page": "Has text",
+			"contents": "[[Has page::Page]]"
 		},
 		{
 			"namespace": "NS_FILE",
@@ -27,6 +37,14 @@
 		{
 			"page": "Example/P0705/Q.3",
 			"contents": "{{#ask: [[File:+]] }}"
+		},
+		{
+			"page": "Example/P0705/4",
+			"contents": "[[Has page::File:P0705.png]]"
+		},
+		{
+			"page": "Example/P0705/Q.4",
+			"contents": "{{#ask: [[Has page::<q>[[File:+]]</q>]] |?Has page#noimage |format=table |limit=1 }}"
 		}
 	],
 	"tests": [
@@ -68,6 +86,19 @@
 				"to-contain": [
 					"<span class=\"smw-subobject-entity\"><a href=.*P0705.png#Test\" title=.*P0705.png\">P0705.png#Test</a></span>",
 					"<a href=.*P0705.png\" class=\"image\"><img alt=\"P0705.png\" .*class=\"thumbborder\" .*</a>"
+				]
+			}
+		},
+		{
+			"type": "parser",
+			"about": "#3 (#noimage)",
+			"subject": "Example/P0705/Q.4",
+			"assert-output": {
+				"to-contain": [
+					"<td class=\"smwtype_wpg\"><a href=\".*Example/P0705/4\" title=\"Example/P0705/4\">Example/P0705/4</a></td><td class=\"Has-page smwtype_wpg\"><a href=\".*P0705.png\" title=\".*P0705.png\">P0705.png</a></td>"
+				],
+				"not-contain": [
+					"P0705.png\" width=\"480\" height=\"480\""
 				]
 			}
 		}


### PR DESCRIPTION
This PR is made in reference to: #3640 

This PR addresses or contains:

- We need the `noimage` option for #3640 to show simple links
- In the past, users have ask that there would want to have a possibility to suppress an image display and instead create simple links for an image, `#noimage` (e.g. `?Has page#noimage`) is introduced to support that request (refs #2552, #2470, https://sourceforge.net/p/semediawiki/mailman/message/35848786/)

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed
