### PR TITLE
Factbox display attachments, refs 3640

### DIFF
--- a/DefaultSettings.php
+++ b/DefaultSettings.php
@@ -361,9 +361,11 @@ return [
 	#
 	# - SMW_FACTBOX_DISPLAY_SUBOBJECT displays subobject references
 	#
+	# - SMW_FACTBOX_DISPLAY_ATTACHMENT displays attachment list
+	#
 	# @since 3.0
 	##
-	'smwgFactboxFeatures' => SMW_FACTBOX_CACHE | SMW_FACTBOX_PURGE_REFRESH | SMW_FACTBOX_DISPLAY_SUBOBJECT,
+	'smwgFactboxFeatures' => SMW_FACTBOX_CACHE | SMW_FACTBOX_PURGE_REFRESH | SMW_FACTBOX_DISPLAY_SUBOBJECT | SMW_FACTBOX_DISPLAY_ATTACHMENT,
 
 	###
 	# This setting allows you to select in which cases you want to have a factbox

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -20,6 +20,8 @@
 	"smw-factbox-head": "... more about \"$1\"",
 	"smw-factbox-facts": "Facts",
 	"smw-factbox-facts-help": "Shows statements and facts that have been created by a user",
+	"smw-factbox-attachments": "Attachments",
+	"smw-factbox-attachments-help": "Shows available attachments",
 	"smw-factbox-facts-derived": "Derived facts",
 	"smw-factbox-facts-derived-help": "Shows facts that have been derived from rules or with the help of other reasoning techniques",
 	"smw_isspecprop": "This property is a special property in this wiki.",

--- a/res/smw/ext.smw.factbox.css
+++ b/res/smw/ext.smw.factbox.css
@@ -146,7 +146,8 @@
 /**
  * Tabbed factbox
  */
-.smw-factbox #tab-facts-rendered:checked ~ #tab-content-facts-rendered,
+.smw-factbox #tab-facts-list:checked ~ #tab-content-facts-list,
+.smw-factbox #tab-facts-attachment:checked ~ #tab-content-facts-attachment,
 .smw-factbox #tab-facts-derived:checked ~ #tab-content-facts-derived {
 	display: block;
 }
@@ -156,7 +157,7 @@
 }
 
 .smw-factbox label.nav-label {
-	padding: 3px 25px 1px 25px;
+	padding: 5px 25px 3px 25px;
 }
 
 .smw-factbox input.nav-tab:checked + label.nav-label {

--- a/src/Defines.php
+++ b/src/Defines.php
@@ -41,6 +41,7 @@ define( 'SMW_FACTBOX_SHOWN', 5 );
 define( 'SMW_FACTBOX_CACHE', 16 );
 define( 'SMW_FACTBOX_PURGE_REFRESH', 32 );
 define( 'SMW_FACTBOX_DISPLAY_SUBOBJECT', 64 );
+define( 'SMW_FACTBOX_DISPLAY_ATTACHMENT', 128 );
 
 /**@}*/
 

--- a/src/Factbox/CachedFactbox.php
+++ b/src/Factbox/CachedFactbox.php
@@ -254,19 +254,30 @@ class CachedFactbox {
 			$requestContext->getRequest()->getCheck( 'wpPreview' )
 		);
 
-		if ( $factbox->doBuild()->isVisible() ) {
+		$factbox->doBuild();
 
-			$contentParser = $applicationFactory->newContentParser( $title );
-			$contentParser->parse( $factbox->getContent() );
-
-			$text = InTextAnnotationParser::removeAnnotation(
-				$contentParser->getOutput()->getText()
-			);
-
-			$text = $factbox->tabs( $text );
+		if ( !$factbox->isVisible() ) {
+			return $text;
 		}
 
-		return $text;
+		$contentParser = $applicationFactory->newContentParser( $title );
+		$content = '';
+
+		if ( ( $content = $factbox->getContent() ) !== '' ) {
+			$contentParser->parse( $content );
+			$content = InTextAnnotationParser::removeAnnotation(
+				$contentParser->getOutput()->getText()
+			);
+		}
+
+		$attachmentContent = '';
+
+		if ( ( $attachmentContent = $factbox->getAttachmentContent() ) !== '' ) {
+			$contentParser->parse( $attachmentContent );
+			$attachmentContent = $contentParser->getOutput()->getText();
+		}
+
+		return $factbox->tabs( $content, $attachmentContent );
 	}
 
 	private function hasCachedContent( $revId, $lang, $content, $requestContext ) {

--- a/src/TypesRegistry.php
+++ b/src/TypesRegistry.php
@@ -219,7 +219,7 @@ class TypesRegistry {
 			'_FORMAT_SCHEMA' => [ '_wps', true, true, false ], // "Formatter schema"
 
 			// File attachment
-			'_ATTCH_LINK'  => [ '_wpg', false, false, false ], // "Attachment link"
+			'_ATTCH_LINK'  => [ '_wpg', true, false, false ], // "Attachment link"
 			'_FILE_ATTCH'  => [ '__sob', false, false, false ], // "File attachment"
 			'_CONT_TYPE' => [ '_txt', true, true, false ], // "Content type"
 			'_CONT_AUTHOR' => [ '_txt', true, true, false ], // "Content author"

--- a/tests/phpunit/Unit/Factbox/FactboxTest.php
+++ b/tests/phpunit/Unit/Factbox/FactboxTest.php
@@ -105,6 +105,51 @@ class FactboxTest extends \PHPUnit_Framework_TestCase {
 		$this->assertTrue( $instance->isVisible() );
 	}
 
+	public function testGetAttachmentContent() {
+
+		$dataItem = $this->getMockBuilder( '\SMWDataItem' )
+			->disableOriginalConstructor()
+			->getMockForAbstractClass();
+
+		$store = $this->getMockBuilder( '\SMW\Store' )
+			->disableOriginalConstructor()
+			->getMockForAbstractClass();
+
+		$store->expects( $this->any() )
+			->method( 'getPropertyValues' )
+			->will( $this->returnValue( [ $dataItem ] ) );
+
+		$parserOutput = $this->getMockBuilder( '\ParserOutput' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$title = Title::newFromText( __METHOD__ );
+
+		$instance = new Factbox(
+			$store,
+			new ParserData( $title, $parserOutput )
+		);
+
+		$instance->setAttachments(
+			[
+				DIWikiPage::newFromText( 'Foo', NS_FILE )
+			]
+		);
+
+		$instance->setFeatureSet( SMW_FACTBOX_DISPLAY_ATTACHMENT );
+		$attachmentContent = $instance->getAttachmentContent();
+
+		$this->assertContains(
+			__METHOD__,
+			$attachmentContent
+		);
+
+		$this->assertContains(
+			'|Foo]]',
+			$attachmentContent
+		);
+	}
+
 	public function testGetContentRoundTripForNonEmptyContent() {
 
 		$subject = DIWikiPage::newFromTitle( Title::newFromText( __METHOD__ ) );
@@ -186,13 +231,18 @@ class FactboxTest extends \PHPUnit_Framework_TestCase {
 	public function testTabs() {
 
 		$this->assertContains(
-			'tab-facts-rendered',
+			'tab-facts-list',
 			Factbox::tabs( 'Foo' )
 		);
 
 		$this->assertContains(
-			'tab-facts-derived',
+			'tab-facts-attachment',
 			Factbox::tabs( 'Foo', 'Bar' )
+		);
+
+		$this->assertContains(
+			'tab-facts-derived',
+			Factbox::tabs( 'Foo', 'Bar','Foobar' )
 		);
 	}
 


### PR DESCRIPTION
This PR is made in reference to: #3640

This PR addresses or contains:

- Adds a new "Attachment" tab to the `Factbox` for the `_ATTCH_LINK` (#3643) annotations
- Adds `SMW_FACTBOX_DISPLAY_ATTACHMENT` (display the tab) as part of `smwgFactboxFeatures` and is enabled by default

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed
