### PR TITLE
[SMWSearch] Use HTML instead of JS for the namespace buttons

### DIFF
--- a/res/smw/special.search/search.css
+++ b/res/smw/special.search/search.css
@@ -244,8 +244,28 @@
     margin-top: 2px !important;
 }
 
-#smw-search-togglensview, #mw-search-togglebox {
+#smw-search-togglensview, #smw-search-togglebox {
     margin-top: 2px !important;
+}
+
+#smw-search-togglebox {
+    float: right;
+}
+
+#smw-search-togglebox label {
+    margin-right: 0.25em;
+}
+
+#smw-search-togglebox input {
+    margin-left: 0.25em;
+}
+
+.client-nojs #smw-search-togglebox, .client-nojs #smw-search-togglensview {
+    display: none;
+}
+
+.client-nojs #mw-search-ns {
+    display: block !important;
 }
 
 .searchresult {
@@ -313,7 +333,7 @@
     margin-bottom: 2px !important;
 }
 
-.skin-chameleon #smw-search-togglensview, .skin-chameleon #mw-search-togglebox {
+.skin-chameleon #smw-search-togglensview, .skin-chameleon #smw-search-togglebox {
     margin-top: 0px !important;
 }
 

--- a/res/smw/special.search/search.namespace.js
+++ b/res/smw/special.search/search.namespace.js
@@ -36,32 +36,30 @@
 			this.form.method = this.checked ? 'post' : 'get';
 		} ).trigger( 'change' );
 
-		var nsList = $( '#mw-search-ns' ).css( 'display' ) !== 'none' ? mw.msg( 'smw-search-hide' ) : mw.msg( 'smw-search-show' );
+		var nsList = '';
 
-		/**
-		 * Append hide/show button to the NS section
-		 */
-		$( '#smw-search-togglensview' ).append(
-			$( '<input>' ).attr( 'type', 'button' )
-				.attr( 'id', 'smw-togglensview' )
-				.prop( 'value', nsList )
-				.click( function ( event ) {
+		if ( $( '#mw-search-ns' ).css( 'display' ) !== 'none' ) {
+			nsList = mw.msg( 'smw-search-hide' );
+		} else {
+			nsList = mw.msg( 'smw-search-show' );
+		};
 
-					// We carry the hidden `ns-list` on a submit so the status
-					// of the prevsious acion is retained to either show or hide
-					// the section
-					if ( $( '#mw-search-ns' ).css( 'display' ) !== 'none' ) {
-						$( 'input[name=ns-list]' ).attr( 'value', 1 );
-						event.target.value = mw.msg( 'smw-search-show' );
-						$( '#mw-search-ns' ).css( 'display', 'none' );
-					} else {
-						event.target.value = mw.msg( 'smw-search-hide' );
-						$( 'input[name=ns-list]' ).attr( 'value', 0 );
-						$( '#mw-search-ns' ).css( 'display', 'block' );
-					}
-				} )
-		)
-
+		$( document ).on( "click", "#smw-togglensview", function(){
+			// We carry the hidden `ns-list` on a submit so the status
+			// of the previous action is retained to either show or hide
+			// the section
+			if ( $( '#mw-search-ns' ).css( 'display' ) !== 'none' ) {
+				$( 'input[name=ns-list]' ).attr( 'value', 1 );
+				event.target.value = mw.msg( 'smw-search-show' );
+				$( '#mw-search-ns' ).css( 'display', 'none' );
+				$( '#smw-search-togglebox' ).css( 'display', 'none' );
+			} else {
+				event.target.value = mw.msg( 'smw-search-hide' );
+				$( 'input[name=ns-list]' ).attr( 'value', 0 );
+				$( '#mw-search-ns' ).css( 'display', 'block' );
+				$( '#smw-search-togglebox' ).css( 'display', 'block' );
+			}
+		} );
 	};
 
 	// Only load when it is Special:Search and the search type supports

--- a/src/MediaWiki/Search/Form/NamespaceForm.php
+++ b/src/MediaWiki/Search/Form/NamespaceForm.php
@@ -174,12 +174,29 @@ class NamespaceForm {
 			);
 		}
 
+		if ( !$this->hideList ) {
+			$val = $this->msg( 'smw-search-hide', Message::ESCAPED );
+		} else {
+			$val = $this->msg( 'smw-search-show', Message::ESCAPED );
+		}
+
 		return "<fieldset id='mw-searchoptions'>" .
 			"<legend>" . Message::get( 'powersearch-legend', Message::ESCAPED, Message::USER_LANGUAGE ) . '</legend>' .
 			"<h4>" . Message::get( 'powersearch-ns', Message::PARSE, Message::USER_LANGUAGE ) . '</h4>' .
 			// populated by js if available
-			"<div id='smw-search-togglensview'></div>" .
-			"<div id='mw-search-togglebox'></div>" .
+			"<div id='smw-search-togglensview'>" .
+			'<input type="button" id="smw-togglensview" value="' . $val . '">' .
+			'</div>' .
+			// Use `smw-search-togglebox` instead of `mw-search-togglebox` to avoid
+			// issues with the search JS before the changes of
+			// (MW 1.33) https://github.com/wikimedia/mediawiki/commit/c5a61564618e156d7aa9fc876d67cf4b736b2aea
+			"<div id='smw-search-togglebox' style='display:$display'>" .
+			'<label>' . $this->msg( 'powersearch-togglelabel', Message::ESCAPED ) . '</label>' .
+			'<input type="button" id="mw-search-toggleall" value="' .
+			$this->msg( 'powersearch-toggleall', Message::ESCAPED ) . '"/>' .
+			'<input type="button" id="mw-search-togglenone" value="' .
+			$this->msg( 'powersearch-togglenone', Message::ESCAPED ) . '"/>' .
+			'</div>' .
 			"<div id='mw-search-ns' style='display:$display'>" . $divider .
 			implode(
 				$divider,
@@ -187,6 +204,10 @@ class NamespaceForm {
 			) .
 			$remember . "</div>" .
 		"</fieldset>";
+	}
+
+	private function msg( $key, $type = Message::PARSE, $lang = Message::USER_LANGUAGE ) {
+		return Message::get( $key, $type, $lang );
 	}
 
 }


### PR DESCRIPTION
This PR is made in reference to: #https://github.com/wikimedia/mediawiki/commit/c5a61564618e156d7aa9fc876d67cf4b736b2aea

This PR addresses or contains:

- HTML is used to set the buttons

This PR includes:
- [ ] Tests (unit/integration)
- [x] CI build passed
