### PR TITLE
Invalidate result cache, refs 3644

### DIFF
--- a/src/ApplicationFactory.php
+++ b/src/ApplicationFactory.php
@@ -238,6 +238,15 @@ class ApplicationFactory {
 	}
 
 	/**
+	 * @since 3.1
+	 *
+	 * @return EventDispatcher
+	 */
+	public function getEventDispatcher() {
+		return EventHandler::getInstance()->getEventDispatcher();
+	}
+
+	/**
 	 * @since 2.0
 	 *
 	 * @return TitleFactory
@@ -577,6 +586,7 @@ class ApplicationFactory {
 		$containerBuilder->registerCallbackContainer( new SharedServicesContainer() );
 		$containerBuilder->registerFromFile( $servicesFileDir . '/' . 'MediaWikiServices.php' );
 		$containerBuilder->registerFromFile( $servicesFileDir . '/' . 'ImporterServices.php' );
+		$containerBuilder->registerFromFile( $servicesFileDir . '/' . 'events.php' );
 
 		//	$containerBuilder = $callbackContainerFactory->newLoggableContainerBuilder(
 		//		$containerBuilder,

--- a/src/EventListenerRegistry.php
+++ b/src/EventListenerRegistry.php
@@ -39,7 +39,18 @@ class EventListenerRegistry implements EventListenerCollection {
 	 * @since 2.2
 	 */
 	public function getCollection() {
-		return $this->addListenersToCollection()->getCollection();
+
+		$applicationFactory = ApplicationFactory::getInstance();
+		$invalidateResultCacheEventListener = $applicationFactory->create( 'InvalidateResultCacheEventListener' );
+
+		$invalidateResultCacheEventListener->setLogger(
+			$applicationFactory->getMediaWikiLogger()
+		);
+
+		$this->eventListenerCollection->registerListener( 'InvalidateResultCache', $invalidateResultCacheEventListener );
+		$this->addListenersToCollection();
+
+		return $this->eventListenerCollection->getCollection();
 	}
 
 	private function addListenersToCollection() {

--- a/src/Events/InvalidateResultCacheEventListener.php
+++ b/src/Events/InvalidateResultCacheEventListener.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace SMW\Events;
+
+use Onoi\EventDispatcher\EventListener;
+use Onoi\EventDispatcher\DispatchContext;
+use SMW\Query\Result\CachedQueryResultPrefetcher;
+use Psr\Log\LoggerAwareTrait;
+
+/**
+ * @license GNU GPL v2+
+ * @since 3.1
+ *
+ * @author mwjames
+ */
+class InvalidateResultCacheEventListener implements EventListener {
+
+	use LoggerAwareTrait;
+
+	/**
+	 * @var CachedQueryResultPrefetcher
+	 */
+	private $cachedQueryResultPrefetcher;
+
+	/**
+	 * @since 3.1
+	 */
+	public function __construct( CachedQueryResultPrefetcher $cachedQueryResultPrefetcher ) {
+		$this->cachedQueryResultPrefetcher = $cachedQueryResultPrefetcher;
+	}
+
+	/**
+	 * @since 3.1
+	 *
+	 * {@inheritDoc}
+	 */
+	public function execute( DispatchContext $dispatchContext = null ) {
+
+		$context = $dispatchContext->get( 'context' );
+		$subject = $dispatchContext->get( 'subject' );
+
+		$this->cachedQueryResultPrefetcher->invalidate(
+			$dispatchContext->get( 'dependency_list' ),
+			$context
+		);
+
+		$this->logger->info(
+			[ 'Event', 'InvalidateResultCache', "{caused_by}", "{subject}" ],
+			[ 'role' => 'user', 'caused_by' => $context, 'subject' => $subject ]
+		);
+	}
+
+	/**
+	 * @since 3.1
+	 *
+	 * {@inheritDoc}
+	 */
+	public function isPropagationStopped() {
+		return true;
+	}
+
+}

--- a/src/MediaWiki/Hooks/HookListener.php
+++ b/src/MediaWiki/Hooks/HookListener.php
@@ -368,10 +368,15 @@ class HookListener {
 	 */
 	public function onRejectParserCacheValue( $value, $wikiPage, $popts ) {
 
-		$queryDependencyLinksStoreFactory = ApplicationFactory::getInstance()->singleton( 'QueryDependencyLinksStoreFactory' );
+		$applicationFactory = ApplicationFactory::getInstance();
+		$queryDependencyLinksStoreFactory = $applicationFactory->singleton( 'QueryDependencyLinksStoreFactory' );
 
 		$rejectParserCacheValue = new RejectParserCacheValue(
 			$queryDependencyLinksStoreFactory->newDependencyLinksValidator()
+		);
+
+		$rejectParserCacheValue->setEventDispatcher(
+			$applicationFactory->getEventDispatcher()
 		);
 
 		// Return false to reject the parser cache

--- a/src/Query/Result/CachedQueryResultPrefetcher.php
+++ b/src/Query/Result/CachedQueryResultPrefetcher.php
@@ -15,6 +15,7 @@ use SMW\Utils\BufferedStatsdCollector;
 use SMW\Utils\Timer;
 use SMWQuery as Query;
 use SMWQueryResult as QueryResult;
+use SMW\SQLStore\SQLStore;
 
 /**
  * The prefetcher only caches the subject list from a computed a query
@@ -278,6 +279,16 @@ class CachedQueryResultPrefetcher implements QueryEngine, LoggerAwareInterface {
 		}
 
 		return $queryResult;
+	}
+
+	/**
+	 * @since 3.1
+	 *
+	 * @param array $ids
+	 * @param string $context
+	 */
+	public function invalidate( array $queryList, $context = '' ) {
+		$this->resetCacheBy( $queryList, $context );
 	}
 
 	/**

--- a/src/SQLStore/QueryDependency/DependencyLinksValidator.php
+++ b/src/SQLStore/QueryDependency/DependencyLinksValidator.php
@@ -29,6 +29,11 @@ class DependencyLinksValidator {
 	private $checkDependencies = false;
 
 	/**
+	 * @var []
+	 */
+	private $checkedDependencies = [];
+
+	/**
 	 * @since 3.1
 	 *
 	 * @param Store $store
@@ -44,6 +49,15 @@ class DependencyLinksValidator {
 	 */
 	public function canCheckDependencies( $checkDependencies ) {
 		$this->checkDependencies = (bool)$checkDependencies;
+	}
+
+	/**
+	 * @since 3.1
+	 *
+	 * @return []
+	 */
+	public function getCheckedDependencies() {
+		return $this->checkedDependencies;
 	}
 
 	/**
@@ -67,6 +81,8 @@ class DependencyLinksValidator {
 	 * @return boolean
 	 */
 	public function hasArchaicDependencies( DIWikiPage $subject ) {
+
+		$this->checkedDependencies = [];
 
 		if ( $this->checkDependencies === false ) {
 			return false;
@@ -96,7 +112,7 @@ class DependencyLinksValidator {
 		$rows = $connection->select(
 			[ $proptables[$tableid]->getName(), $id_table . ' AS p', $id_table . ' AS v' ],
 			[
-				'v.smw_id', 'v.smw_touched'
+				'v.smw_id', 'v.smw_subobject', 'v.smw_touched'
 			],
 			[
 				'p.smw_hash' => $subject->getSha1(),
@@ -124,6 +140,7 @@ class DependencyLinksValidator {
 			}
 
 			$list[] = $row->smw_id;
+			$this->checkedDependencies[] = $row->smw_subobject;
 		}
 
 		if ( $list === [] ) {

--- a/src/Services/events.php
+++ b/src/Services/events.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace SMW\Services;
+
+use SMW\Events\InvalidateResultCacheEventListener;
+
+/**
+ * @codeCoverageIgnore
+ *
+ * Services defined in this file SHOULD only be accessed either via the
+ * ApplicationFactory or a different factory instance.
+ *
+ * @license GNU GPL v2
+ * @since 3.1
+ *
+ * @author mwjames
+ */
+return [
+
+	/**
+	 * InvalidateResultCacheEventListener
+	 *
+	 * @return callable
+	 */
+	'InvalidateResultCacheEventListener' => function( $containerBuilder ) {
+
+		$invalidateResultCacheEventListener = new InvalidateResultCacheEventListener(
+			$containerBuilder->singleton( 'CachedQueryResultPrefetcher' )
+		);
+
+		return $invalidateResultCacheEventListener;
+	}
+
+];

--- a/tests/phpunit/Unit/ApplicationFactoryTest.php
+++ b/tests/phpunit/Unit/ApplicationFactoryTest.php
@@ -281,6 +281,14 @@ class ApplicationFactoryTest extends \PHPUnit_Framework_TestCase {
 		);
 	}
 
+	public function testCanConstructEventDispatcher() {
+
+		$this->assertInstanceOf(
+			'\Onoi\EventDispatcher\EventDispatcher',
+			$this->applicationFactory->getEventDispatcher()
+		);
+	}
+
 	public function testCanConstructJobQueue() {
 
 		$this->assertInstanceOf(

--- a/tests/phpunit/Unit/EventHandlerTest.php
+++ b/tests/phpunit/Unit/EventHandlerTest.php
@@ -73,7 +73,7 @@ class EventHandlerTest extends \PHPUnit_Framework_TestCase {
 
 	public function testAddCallbackListenerForAdhocRegistration() {
 
-		$eventDispatcher = $this->getMockBuilder( '\Onoi\EventDispatcher\EventDispatcher' )
+		$eventDispatcher = $this->getMockBuilder( '\Onoi\EventDispatcher\Dispatcher\GenericEventDispatcher' )
 			->disableOriginalConstructor()
 			->getMock();
 
@@ -84,8 +84,7 @@ class EventHandlerTest extends \PHPUnit_Framework_TestCase {
 				$this->anything() );
 
 		$instance = new EventHandler( $eventDispatcher );
-		$instance->addCallbackListener( 'foo', function (){
-		} );
+		$instance->addCallbackListener( 'foo', function (){} );
 	}
 
 }

--- a/tests/phpunit/Unit/Events/InvalidateResultCacheEventListenerTest.php
+++ b/tests/phpunit/Unit/Events/InvalidateResultCacheEventListenerTest.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace SMW\Tests\Events;
+
+use SMW\DIWikiPage;
+use SMW\Events\InvalidateResultCacheEventListener;
+use Onoi\EventDispatcher\DispatchContext;
+use SMW\Tests\TestEnvironment;
+
+/**
+ * @covers \SMW\Events\InvalidateResultCacheEventListener
+ * @group semantic-mediawiki
+ *
+ * @license GNU GPL v2+
+ * @since 3.1
+ *
+ * @author mwjames
+ */
+class InvalidateResultCacheEventListenerTest extends \PHPUnit_Framework_TestCase {
+
+	private $cachedQueryResultPrefetcher;
+	private $spyLogger;
+
+	protected function setUp() {
+		parent::setUp();
+
+		$this->spyLogger = TestEnvironment::newSpyLogger();
+
+		$this->cachedQueryResultPrefetcher = $this->getMockBuilder( '\SMW\Query\Result\CachedQueryResultPrefetcher' )
+			->disableOriginalConstructor()
+			->getMock();
+	}
+
+	protected function tearDown() {
+		parent::tearDown();
+	}
+
+	public function testCanConstruct() {
+
+		$this->assertInstanceOf(
+			InvalidateResultCacheEventListener::class,
+			new InvalidateResultCacheEventListener( $this->cachedQueryResultPrefetcher )
+		);
+	}
+
+	public function testExecute() {
+
+		$context = DispatchContext::newFromArray(
+			[
+				'subject' => 'Foo',
+				'context' => 'Bar',
+				'dependency_list' => []
+			]
+		);
+
+		$this->cachedQueryResultPrefetcher->expects( $this->once() )
+			->method( 'invalidate' );
+
+		$instance = new InvalidateResultCacheEventListener(
+			$this->cachedQueryResultPrefetcher
+		);
+
+		$instance->setLogger(
+			$this->spyLogger
+		);
+
+		$instance->execute( $context );
+	}
+
+}

--- a/tests/phpunit/Unit/MediaWiki/Hooks/RejectParserCacheValueTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Hooks/RejectParserCacheValueTest.php
@@ -45,6 +45,14 @@ class RejectParserCacheValueTest extends \PHPUnit_Framework_TestCase {
 
 	public function testProcessOnArchaicDependencies_RejectParserCacheValue() {
 
+		$eventDispatcher = $this->getMockBuilder( '\Onoi\EventDispatcher\EventDispatcher' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$eventDispatcher->expects( $this->once() )
+			->method( 'dispatch' )
+			->with( $this->equalTo( 'InvalidateResultCache' ) );
+
 		$subject = DIWikiPage::newFromText( __METHOD__ );
 
 		$this->dependencyLinksValidator->expects( $this->once() )
@@ -52,8 +60,16 @@ class RejectParserCacheValueTest extends \PHPUnit_Framework_TestCase {
 			->with( $this->equalTo( $subject ) )
 			->will( $this->returnValue( true ) );
 
+		$this->dependencyLinksValidator->expects( $this->once() )
+			->method( 'getCheckedDependencies' )
+			->will( $this->returnValue( [] ) );
+
 		$instance = new RejectParserCacheValue(
 			$this->dependencyLinksValidator
+		);
+
+		$instance->setEventDispatcher(
+			$eventDispatcher
 		);
 
 		$this->assertFalse(

--- a/tests/phpunit/Unit/SQLStore/QueryDependency/DependencyLinksValidatorTest.php
+++ b/tests/phpunit/Unit/SQLStore/QueryDependency/DependencyLinksValidatorTest.php
@@ -75,7 +75,7 @@ class DependencyLinksValidatorTest extends \PHPUnit_Framework_TestCase {
 
 		$connection->expects( $this->once() )
 			->method( 'select' )
-			->will( $this->returnValue( [ (object)[ 'smw_id' => 42, 'smw_touched' => '99999' ] ] ) );
+			->will( $this->returnValue( [ (object)[ 'smw_id' => 42, 'smw_subobject' => '_foo', 'smw_touched' => '99999' ] ] ) );
 
 		$this->store->expects( $this->any() )
 			->method( 'getConnection' )
@@ -105,6 +105,11 @@ class DependencyLinksValidatorTest extends \PHPUnit_Framework_TestCase {
 
 		$this->assertTrue(
 			$instance->hasArchaicDependencies( $subject )
+		);
+
+		$this->assertEquals(
+			[ '_foo' ],
+			$instance->getCheckedDependencies()
 		);
 	}
 


### PR DESCRIPTION
This PR is made in reference to: #3644 

This PR addresses or contains:

- Previously the `ParserCachePurgeJob` would invalidate the `ResultCache` in case of outdated dependencies but now that the class is gone, `RejectParserCacheValue` will trigger the `InvalidateResultCache` event

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed
