### PR TITLE
Use unbound limit/offset to match correct query, refs 3501

### DIFF
--- a/includes/query/SMW_Query.php
+++ b/includes/query/SMW_Query.php
@@ -367,6 +367,17 @@ class SMWQuery implements QueryContext {
 		return $this->offset;
 	}
 
+	/**
+	 * @note Sets an unbound offset that is independent from GLOBAL settings
+	 *
+	 * @since 3.0
+	 *
+	 * @param integer $offset
+	 */
+	public function setUnboundOffset( $offset ) {
+		$this->offset = (int)$offset;
+	}
+
 	public function getLimit() {
 		return $this->limit;
 	}

--- a/src/MediaWiki/Api/Task.php
+++ b/src/MediaWiki/Api/Task.php
@@ -160,11 +160,11 @@ class Task extends ApiBase {
 				$printouts
 			);
 
-			$query->setLimit(
+			$query->setUnboundLimit(
 				$parameters['limit']
 			);
 
-			$query->setOffset(
+			$query->setUnboundOffset(
 				$parameters['offset']
 			);
 


### PR DESCRIPTION
This PR is made in reference to: #3501 

This PR addresses or contains:

- PR makes it possible that the original query can be executed by the `Task` API (appeared in connection with count queries that run though the `check-query` task)

This PR includes:
- [ ] Tests (unit/integration)
- [x] CI build passed
