### PR TITLE
Isolate LinkBatch access

### DIFF
--- a/src/MediaWiki/LinkBatch.php
+++ b/src/MediaWiki/LinkBatch.php
@@ -1,0 +1,100 @@
+<?php
+
+namespace SMW\MediaWiki;
+
+use Title;
+use SMW\DIWikiPage;
+
+/**
+ * Isolate access to the LinkBatch class which allows to bulk load a list
+ * of titles into the LinkCache.
+ *
+ * @license GNU GPL v2+
+ * @since 3.1
+ *
+ * @author mwjames
+ */
+class LinkBatch {
+
+	/**
+	 * @var []
+	 */
+	private $log = [];
+
+	/**
+	 * @var []
+	 */
+	private $batch = [];
+
+	/**
+	 * @since 3.1
+	 *
+	 * @param LinkBatch|null $linkBatch
+	 */
+	public function __construct( \LinkBatch $linkBatch = null ) {
+		$this->linkBatch = $linkBatch;
+	}
+
+	/**
+	 * @since 3.1
+	 *
+	 * @param $dataItem
+	 */
+	public function add( $dataItem ) {
+
+		if ( !$dataItem instanceof DIWikiPage || isset( $this->log[$dataItem->getHash()] ) ) {
+			return;
+		}
+
+		// PHP 5.6! -> PHP 7 $dataItem->getDBKey(){0}
+		$dbkey = $dataItem->getDBKey();
+
+		// Avoid "... ParameterAssertionException: Bad value for parameter
+		// $dbkey: invalid DB key '_ASK'"
+		if ( $dbkey{0} === '_' ) {
+			return;
+		}
+
+		// Track which have already been registered because \LinkBatch doesn't
+		// check for it
+		$this->log[$dataItem->getHash()] = true;
+		$this->batch[] = $dataItem;
+	}
+
+	/**
+	 * @since 3.1
+	 *
+	 * @param DataItem|null|false $dataItem
+	 *
+	 * @return boolean
+	 */
+	public function has( $dataItem ) {
+
+		if ( $dataItem instanceof DIWikiPage && isset( $this->log[$dataItem->getHash()] ) ) {
+			return true;
+		}
+
+		return false;
+	}
+
+	/**
+	 * @since 3.1
+	 */
+	public function execute() {
+
+		if ( $this->linkBatch === null ) {
+			$this->linkBatch = new \LinkBatch();
+		}
+
+		foreach ( $this->batch as $dataItem ) {
+			$this->linkBatch->add( $dataItem->getNamespace(), $dataItem->getDBKey() );
+		}
+
+		if ( $this->batch !== [] ) {
+			$this->linkBatch->execute();
+		}
+
+		$this->batch = [];
+	}
+
+}

--- a/tests/phpunit/Unit/MediaWiki/LinkBatchTest.php
+++ b/tests/phpunit/Unit/MediaWiki/LinkBatchTest.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace SMW\Tests\MediaWiki;
+
+use SMW\MediaWiki\LinkBatch;
+use SMW\DIWikiPage;
+
+/**
+ * @covers \SMW\MediaWiki\LinkBatch
+ * @group semantic-mediawiki
+ *
+ * @license GNU GPL v2+
+ * @since   3.1
+ *
+ * @author mwjames
+ */
+class LinkBatchTest extends \PHPUnit_Framework_TestCase {
+
+	public function testCanConstruct() {
+
+		$this->assertInstanceOf(
+			LinkBatch::class,
+			 new LinkBatch()
+		);
+	}
+
+	public function testAdd_NoPage() {
+
+		$instance = new LinkBatch();
+		$instance->add( 'Foo' );
+
+		$this->assertFalse(
+			$instance->has( 'Foo' )
+		);
+	}
+
+	public function testAdd_PageButRefuseFirstUnderscore() {
+
+		$subject = DIWikiPage::newFromText( '_ASK' );
+
+		$instance = new LinkBatch();
+		$instance->add( $subject );
+
+		$this->assertFalse(
+			$instance->has( $subject )
+		);
+	}
+
+	public function testExecute() {
+
+		$subject = DIWikiPage::newFromText( 'Foo' );
+
+		$linkBatch = $this->getMockBuilder( '\LinkBatch' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$linkBatch->expects( $this->once() )
+			->method( 'add' );
+
+		$linkBatch->expects( $this->once() )
+			->method( 'execute' );
+
+		$instance = new LinkBatch( $linkBatch );
+		$instance->add( $subject );
+
+		$instance->execute();
+	}
+
+}


### PR DESCRIPTION
This PR is made in reference to: #

This PR addresses or contains:

- Isolates access to the `LinkBatch` class in MediaWiki (required for an upcoming PR where when generating a `QueryResult` it pushes a batch of known subjects (aka "page" links) to have them cached hereby avoids MW making single requests for each result row)

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed

```
SELECT page_id,page_len,page_is_redirect,page_latest,page_content_model,page_namespace,page_title FROM `page` WHERE (page_namespace = '0' AND page_title IN ('PropChain','PropChain/1','PropChain/1/1','PropChain/2','PropChain/A','PropChain/1/1/1','PropChain/1/1/2','PropChain/1/1/3') ) | 1.1711ms | LinkBatch::doQuery

vs.

SELECT page_id,page_len,page_is_redirect,page_latest,page_content_model FROM `page` WHERE page_namespace = '102' AND page_title = 'PropChain' LIMIT 1 | 4.3590ms | LinkCache::fetchPageRow
```