### PR TITLE
Avoid "Error: 42804 ERROR:  argument of AND must be ..."

### DIFF
--- a/src/RequestOptions.php
+++ b/src/RequestOptions.php
@@ -121,6 +121,13 @@ class RequestOptions {
 	}
 
 	/**
+	 * @since 3.1
+	 */
+	public function emptyExtraConditions() {
+		$this->extraConditions = [];
+	}
+
+	/**
 	 * @since 3.0
 	 *
 	 * @param string $key

--- a/src/SQLStore/EntityStore/PropertySubjectsLookup.php
+++ b/src/SQLStore/EntityStore/PropertySubjectsLookup.php
@@ -196,6 +196,9 @@ class PropertySubjectsLookup {
 					$extraCondition( $query );
 				}
 			}
+
+			// Avoid `getSQLConditions` to work on the condition
+			$requestOptions->emptyExtraConditions();
 		}
 
 		if ( $proptable->usesIdSubject() ) {


### PR DESCRIPTION
This PR is made in reference to: #

This PR addresses or contains:

- Should avoid "Error: 42804 ERROR:  argument of AND must be type boolean, not type integer
LINE 1: ... (smw_iw!=':smw-delete') AND (smw_iw!=':smw-redi') AND (716)" in `PropertySubjectsLookup`

This PR includes:
- [ ] Tests (unit/integration)
- [x] CI build passed

## Stack


```
[DBQuery] ROLLBACK
[exception] [9caea0f3f18638b80b7fef2e] [no req]   Wikimedia\Rdbms\DBQueryError from line 1506 of ...\includes\libs\rdbms\database\Database.php: A database query error has occurred. Did you forget to run your application's database schema updater after upgrading?
Query: SELECT DISTINCT ON (smw_sort, smw_id) smw_id, smw_title, smw_namespace, smw_iw, smw_subobject, smw_sortkey, smw_sort FROM "smw_object_ids" INNER JOIN "smw_di_wikipage" AS t1  ON t1.s_id=smw_id WHERE (t1.p_id='716') AND (t1.o_id='716') AND (smw_iw!=':smw') AND (smw_iw!=':smw-delete') AND (smw_iw!=':smw-redi') AND (716)
Function: SMW\SQLStore\EntityStore\PropertySubjectsLookup::fetchFromTable
Error: 42804 ERROR:  argument of AND must be type boolean, not type integer
LINE 1: ... (smw_iw!=':smw-delete') AND (smw_iw!=':smw-redi') AND (716)
                                                                   ^


#0 ...\includes\libs\rdbms\database\Database.php(1476): Wikimedia\Rdbms\Database->makeQueryException(string, string, string, string)
#1 ...\includes\libs\rdbms\database\Database.php(1236): Wikimedia\Rdbms\Database->reportQueryError(string, string, string, string, boolean)
#2 ...\extensions\SemanticMediaWiki\src\MediaWiki\Connection\Database.php(439): Wikimedia\Rdbms\Database->query(string, string, boolean)
#3 ...\extensions\SemanticMediaWiki\src\SQLStore\EntityStore\PropertySubjectsLookup.php(243): SMW\MediaWiki\Connection\Database->query(string, string)
#4 ...\extensions\SemanticMediaWiki\includes\storage\SQLStore\SMW_SQLStore3_Readers.php(307): SMW\SQLStore\EntityStore\PropertySubjectsLookup->fetchFromTable(string, SMW\SQLStore\PropertyTableDefinition, NULL, SMW\RequestOptions)
#5 ...\extensions\SemanticMediaWiki\includes\storage\SQLStore\SMW_SQLStore3_Readers.php(395): SMWSQLStore3Readers->getPropertySubjects(SMW\DIProperty, NULL, SMW\RequestOptions)
#6 ...\extensions\SemanticMediaWiki\src\SQLStore\EntityStore\NativeEntityLookup.php(86): SMWSQLStore3Readers->getAllPropertySubjects(SMW\DIProperty, SMW\RequestOptions)
#7 ...\extensions\SemanticMediaWiki\includes\storage\SQLStore\SMW_SQLStore3.php(206): SMW\SQLStore\EntityStore\NativeEntityLookup->getAllPropertySubjects(SMW\DIProperty, SMW\RequestOptions)
#8 ...\extensions\SemanticMediaWiki\src\MediaWiki\Jobs\UpdateDispatcherJob.php(235): SMWSQLStore3->getAllPropertySubjects(SMW\DIProperty, SMW\RequestOptions)
#9 ...\extensions\SemanticMediaWiki\src\MediaWiki\Jobs\UpdateDispatcherJob.php(196): SMW\MediaWiki\Jobs\UpdateDispatcherJob->addUpdateJobsForProperties(array)
#10 ...\extensions\SemanticMediaWiki\src\MediaWiki\Jobs\UpdateDispatcherJob.php(87): SMW\MediaWiki\Jobs\UpdateDispatcherJob->dispatchUpdateForProperty(SMW\DIProperty)
#11 ...\includes\jobqueue\JobRunner.php(290): SMW\MediaWiki\Jobs\UpdateDispatcherJob->run()
#12 ...\includes\jobqueue\JobRunner.php(192): JobRunner->executeJob(SMW\MediaWiki\Jobs\UpdateDispatcherJob, Wikimedia\Rdbms\LBFactorySimple, BufferingStatsdDataFactory, integer)
#13 ...\maintenance\runJobs.php(89): JobRunner->run(array)
#14 ...\maintenance\doMaintenance.php(94): RunJobs->execute()
#15 ...\maintenance\runJobs.php(122): require_once(string)
#16 {main}
```
