### PR TITLE
Allow to define field index type, refs 3559

### DIFF
--- a/src/SQLStore/TableSchemaManager.php
+++ b/src/SQLStore/TableSchemaManager.php
@@ -351,22 +351,31 @@ class TableSchemaManager {
 
 		foreach ( $diHandler->getTableIndexes() as $value ) {
 
-			if ( strpos( $value, 'p_id' ) !== false && $propertyTable->isFixedPropertyTable() ) {
+			// For an array, the first defines the column, the second the type
+			// (e.g. `[ 'p_id,s_id,o_hash', 'PRIMARY KEY' ]`)
+			$val = is_array( $value ) ? $value[0] : $value;
+
+			// Unique?
+			if ( array_search( $val, $indexes ) !== false ) {
 				continue;
 			}
 
-			if ( strpos( $value, 'o_id' ) !== false && !$propertyTable->usesIdSubject() ) {
+			// Test that a selected index can actually be created given it field
+			// constraints
+			if ( strpos( $val, 'p_id' ) !== false && $propertyTable->isFixedPropertyTable() ) {
 				continue;
 			}
 
-			if ( strpos( $value, 's_id' ) !== false && !$propertyTable->usesIdSubject() ) {
+			if ( strpos( $val, 'o_id' ) !== false && !$propertyTable->usesIdSubject() ) {
+				continue;
+			}
+
+			if ( strpos( $val, 's_id' ) !== false && !$propertyTable->usesIdSubject() ) {
 				continue;
 			}
 
 			$indexes = array_merge( $indexes, [ $value ] );
 		}
-
-		$indexes = array_unique( $indexes );
 
 		foreach ( $diHandler->getTableFields() as $fieldname => $fieldType ) {
 			$fieldarray[$fieldname] = $fieldType;

--- a/tests/phpunit/Unit/SQLStore/TableSchemaManagerTest.php
+++ b/tests/phpunit/Unit/SQLStore/TableSchemaManagerTest.php
@@ -155,4 +155,118 @@ class TableSchemaManagerTest extends \PHPUnit_Framework_TestCase {
 		);
 	}
 
+	public function testPropertyTable_UniqueIndex() {
+
+		$propertyTableDefinition = $this->getMockBuilder( '\SMW\SQLStore\PropertyTableDefinition' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$propertyTableDefinition->expects( $this->once() )
+			->method( 'getName' )
+			->will( $this->returnValue( 'foo_table' ) );
+
+		$propertyTableDefinition->expects( $this->once() )
+			->method( 'usesIdSubject' )
+			->will( $this->returnValue( true ) );
+
+		$dataItemHandler = $this->getMockBuilder( '\SMW\SQLStore\EntityStore\DataItemHandler' )
+			->disableOriginalConstructor()
+			->setMethods( [ 'getTableIndexes' ] )
+			->getMockForAbstractClass();
+
+		$dataItemHandler->expects( $this->once() )
+			->method( 'getTableFields' )
+			->will( $this->returnValue( [] ) );
+
+		$dataItemHandler->expects( $this->once() )
+			->method( 'getIndexField' )
+			->will( $this->returnValue( 'foo' ) );
+
+		$dataItemHandler->expects( $this->once() )
+			->method( 'getTableIndexes' )
+			->will( $this->returnValue( [ 'foo', [ 'cols', 'type'], 'foo' ] ) );
+
+		$this->store->expects( $this->once() )
+			->method( 'getPropertyTables' )
+			->will( $this->returnValue( [ $propertyTableDefinition ] ) );
+
+		$this->store->expects( $this->once() )
+			->method( 'getDataItemHandlerForDIType' )
+			->will( $this->returnValue( $dataItemHandler ) );
+
+		$instance = new TableSchemaManager(
+			$this->store
+		);
+
+		$table = $instance->findTable( 'foo_table' );
+
+		$this->assertEquals(
+			[
+				'sp' => 's_id,p_id',
+				'po' => 'foo',
+				[ 'cols', 'type' ]
+			],
+			$table->get( 'indices' )
+		);
+	}
+
+	public function testPropertyTable_FixedTable() {
+
+		$propertyTableDefinition = $this->getMockBuilder( '\SMW\SQLStore\PropertyTableDefinition' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$propertyTableDefinition->expects( $this->once() )
+			->method( 'getName' )
+			->will( $this->returnValue( 'foo_fixed_table' ) );
+
+		$propertyTableDefinition->expects( $this->once() )
+			->method( 'usesIdSubject' )
+			->will( $this->returnValue( true ) );
+
+		$propertyTableDefinition->expects( $this->once() )
+			->method( 'isFixedPropertyTable' )
+			->will( $this->returnValue( true ) );
+
+		$dataItemHandler = $this->getMockBuilder( '\SMW\SQLStore\EntityStore\DataItemHandler' )
+			->disableOriginalConstructor()
+			->setMethods( [ 'getTableIndexes' ] )
+			->getMockForAbstractClass();
+
+		$dataItemHandler->expects( $this->once() )
+			->method( 'getTableFields' )
+			->will( $this->returnValue( [] ) );
+
+		$dataItemHandler->expects( $this->once() )
+			->method( 'getIndexField' )
+			->will( $this->returnValue( 'bar' ) );
+
+		$dataItemHandler->expects( $this->once() )
+			->method( 'getTableIndexes' )
+			->will( $this->returnValue( [ 'foo' ] ) );
+
+		$this->store->expects( $this->once() )
+			->method( 'getPropertyTables' )
+			->will( $this->returnValue( [ $propertyTableDefinition ] ) );
+
+		$this->store->expects( $this->once() )
+			->method( 'getDataItemHandlerForDIType' )
+			->will( $this->returnValue( $dataItemHandler ) );
+
+		$instance = new TableSchemaManager(
+			$this->store
+		);
+
+		$table = $instance->findTable( 'foo_fixed_table' );
+
+		$this->assertEquals(
+			[
+				'sp' => 's_id',
+				'po' => 'bar',
+				'foo',
+			],
+			$table->get( 'indices' )
+		);
+	}
+
 }


### PR DESCRIPTION
This PR is made in reference to: #3559

This PR addresses or contains:

- Allows to define something like `[ 'p_id,s_id,o_hash', 'PRIMARY KEY' ]`

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed
