### PR TITLE
Decode `#` in record text field

### DIFF
--- a/includes/datavalues/SMW_DV_Record.php
+++ b/includes/datavalues/SMW_DV_Record.php
@@ -97,9 +97,20 @@ class SMWRecordValue extends AbstractMultiValue {
 			if ( ( $values[$valueIndex] === '' ) || ( $values[$valueIndex] == '?' ) ) { // explicit omission
 				$valueIndex++;
 			} else {
+
+				$val = $values[$valueIndex];
+
+				// If an annotation starts with `#` and remains unmodified
+				// then the wiki parser would interpret it as list element
+				// and format it accordingly eventhough it is not suppose to
+				// be an ul/ol list item.
+				if ( $val !== '' && $val{0} === '#' ) {
+					$val = str_replace( "#", '&#x23;', $val );
+				}
+
 				$dataValue = DataValueFactory::getInstance()->newDataValueByProperty(
 					$diProperty,
-					$values[$valueIndex],
+					$val,
 					false,
 					$containerSemanticData->getSubject()
 				);

--- a/tests/phpunit/Integration/JSONScript/TestCases/p-0431.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/p-0431.json
@@ -21,6 +21,10 @@
 			"contents": "[[Has record::Foo;123]]"
 		},
 		{
+			"page": "Example/P0431/2",
+			"contents": "[[Has record::#abc;123]]"
+		},
+		{
 			"page": "Example/P0431/Q1.1",
 			"contents": "{{#ask: [[Has record::+]] |?Has record|+index=Has text}}"
 		},
@@ -68,6 +72,19 @@
 				"to-contain": [
 					"Property:Has record",
 					"<td class=\"Property-description smwtype&#95;_lcode\">en</td>"
+				]
+			}
+		},
+		{
+			"type": "parser",
+			"about": "#3 (no ul/ol list output for #... annotated value)",
+			"subject": "Example/P0431/2",
+			"assert-output": {
+				"to-contain": [
+					"&#x23;abc (123)"
+				],
+				"not-contain": [
+					"<ol><li>abc</li></ol>"
 				]
 			}
 		}


### PR DESCRIPTION
This PR is made in reference to: #

This PR addresses or contains:

- [0] brought to light that annotating a record value with `#` (e.g. `[[Shift record::1 Feb 2019;Shift 4;#d43898]]`) as the first character will turn it into a list item (by the MW parser)
- This issue has been present since the inception of the record type

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed

![image](https://user-images.githubusercontent.com/1245473/52159719-33f7a000-26a0-11e9-80f7-08781b8e3273.png)

[0] https://sandbox.semantic-mediawiki.org/wiki/Shift_example/Person_2