### PR TITLE
Remove `IsFileCacheable` hook

### DIFF
--- a/src/MediaWiki/Hooks/HookListener.php
+++ b/src/MediaWiki/Hooks/HookListener.php
@@ -146,24 +146,6 @@ class HookListener {
 	}
 
 	/**
-	 * Hook: Allow an extension to disable file caching on pages
-	 *
-	 * @see https://www.mediawiki.org/wiki/Manual:Hooks/IsFileCacheable
-	 */
-	public function onIsFileCacheable( &$article ) {
-
-		$applicationFactory = ApplicationFactory::getInstance();
-
-		if ( !$applicationFactory->getNamespaceExaminer()->isSemanticEnabled( $article->getTitle()->getNamespace() ) ) {
-			return true;
-		}
-
-		// Disallow the file cache to avoid skipping the ArticleViewHeader hook
-		// on Article::tryFileCache
-		return !$applicationFactory->getSettings( 'smwgEnabledQueryDependencyLinksStore' );
-	}
-
-	/**
 	 * Hook: Add changes to the output page, e.g. adding of CSS or JavaScript
 	 *
 	 * @see https://www.mediawiki.org/wiki/Manual:Hooks/BeforePageDisplay

--- a/src/MediaWiki/Hooks/HookRegistry.php
+++ b/src/MediaWiki/Hooks/HookRegistry.php
@@ -173,7 +173,6 @@ class HookRegistry {
 			'ParserFirstCallInit' => [ $hookListener, 'onParserFirstCallInit' ],
 			'InternalParseBeforeLinks' => [ $hookListener, 'onInternalParseBeforeLinks' ],
 			'RejectParserCacheValue' => [ $hookListener, 'onRejectParserCacheValue' ],
-			'IsFileCacheable' => [ $hookListener, 'onIsFileCacheable' ],
 
 			'BaseTemplateToolbox' => [ $hookListener, 'onBaseTemplateToolbox' ],
 			'SkinAfterContent' => [ $hookListener, 'onSkinAfterContent' ],

--- a/tests/phpunit/Unit/MediaWiki/Hooks/HookRegistryTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Hooks/HookRegistryTest.php
@@ -252,7 +252,6 @@ class HookRegistryTest extends \PHPUnit_Framework_TestCase {
 			[ 'callParserFirstCallInit' ],
 			[ 'callTitleQuickPermissions' ],
 			[ 'callOutputPageCheckLastModified' ],
-			[ 'callIsFileCacheable' ],
 			[ 'callRejectParserCacheValue' ],
 			[ 'callSoftwareInfo' ],
 			[ 'callBlockIpComplete' ],
@@ -1287,30 +1286,6 @@ class HookRegistryTest extends \PHPUnit_Framework_TestCase {
 		$this->assertThatHookIsExcutable(
 			$instance->getHandlerFor( $handler ),
 			[ &$modifiedTimes ]
-		);
-
-		return $handler;
-	}
-
-	public function callIsFileCacheable( $instance ) {
-
-		$handler = 'IsFileCacheable';
-
-		$article = $this->getMockBuilder( '\Article' )
-			->disableOriginalConstructor()
-			->getMock();
-
-		$article->expects( $this->any() )
-			->method( 'getTitle' )
-			->will( $this->returnValue( $this->title ) );
-
-		$this->assertTrue(
-			$instance->isRegistered( $handler )
-		);
-
-		$this->assertThatHookIsExcutable(
-			$instance->getHandlerFor( $handler ),
-			[ &$article ]
 		);
 
 		return $handler;


### PR DESCRIPTION
This PR is made in reference to: #2847, https://sourceforge.net/p/semediawiki/mailman/message/36531972/

This PR addresses or contains:

- Introduced as part of #2847 to "Disallow the file cache to avoid skipping the ArticleViewHeader hook on Article::tryFileCache" in connection with `$smwgEnabledQueryDependencyLinksStore` but since we switched on using `RejectParserCacheValue` and no longer have to rely on the `ArticleViewHeader` hook to evict the parser cache we can remove the `IsFileCacheable` hook usage.
- `IsFileCacheable` hook allows an extension to disable file caching on pages

This PR includes:
- [ ] Tests (unit/integration)
- [x] CI build passed
