### PR TITLE
Provide hook to support adding auxiliary indices, refs 3559

### DIFF
--- a/docs/technical/hooks.md
+++ b/docs/technical/hooks.md
@@ -393,6 +393,27 @@ Hooks::register( 'SMW::DataUpdater::ContentProcessor', function( $semanticData, 
 } );
 </pre>
 
+### SMW::SQLStore::Installer::AddAuxiliaryIndicesBeforeCreateTablesComplete
+
+* Version: 3.1
+* Description: Hook allows to add additional indices
+* Reference class: `SMW\SQLStore\Installer`
+
+When using this hook, please make sure you understand the implications adding auxiliary indices which are not part of the core declaration and may alter performance expectations.
+
+<pre>
+use Hooks;
+
+Hooks::register( 'SMW::SQLStore::Installer::AddAuxiliaryIndicesBeforeCreateTablesComplete', function( &$auxiliaryIndices ) {
+
+	$auxiliaryIndices = [
+		// SMW table name => index declaration
+		'smw_query_links' => [ "s_id,o_id", "PRIMARY KEY" ],
+	];
+
+} );
+</pre>
+
 ## Other available hooks
 
 Subsequent hooks should be renamed to follow a common naming practice that help distinguish them from other hook providers. In any case this list needs details and examples.

--- a/src/SQLStore/Installer.php
+++ b/src/SQLStore/Installer.php
@@ -141,6 +141,20 @@ class Installer implements MessageReporter {
 			$messageReporter
 		);
 
+		// #3559
+		$auxiliaryIndices = [];
+
+		Hooks::run(
+			'SMW::SQLStore::Installer::AddAuxiliaryIndicesBeforeCreateTablesComplete',
+			[
+				&$auxiliaryIndices
+			]
+		);
+
+		$this->tableSchemaManager->addAuxiliaryIndices(
+			$auxiliaryIndices
+		);
+
 		foreach ( $this->tableSchemaManager->getTables() as $table ) {
 			$this->tableBuilder->create( $table );
 		}

--- a/src/SQLStore/TableSchemaManager.php
+++ b/src/SQLStore/TableSchemaManager.php
@@ -5,6 +5,8 @@ namespace SMW\SQLStore;
 use SMW\SQLStore\TableBuilder\FieldType;
 use SMW\SQLStore\TableBuilder\Table;
 use SMWDataItem as DataItem;
+use RuntimeException;
+use Hooks;
 
 /**
  * @private
@@ -32,6 +34,11 @@ class TableSchemaManager {
 	 * @var Table[]
 	 */
 	private $tables = [];
+
+	/**
+	 * @var []
+	 */
+	private $auxiliaryIndices = [];
 
 	/**
 	 * @var []
@@ -133,6 +140,15 @@ class TableSchemaManager {
 		}
 
 		return null;
+	}
+
+	/**
+	 * @since 3.1
+	 *
+	 * @param array $auxiliaryIndices
+	 */
+	public function addAuxiliaryIndices( array $auxiliaryIndices ) {
+		$this->auxiliaryIndices = $auxiliaryIndices;
 	}
 
 	/**
@@ -398,6 +414,12 @@ class TableSchemaManager {
 
 		if ( $table === null ) {
 			return;
+		}
+
+		$name = $table->getName();
+
+		if ( isset( $this->auxiliaryIndices[$name] ) ) {
+			$table->addIndex( $this->auxiliaryIndices[$name] );
 		}
 
 		$this->tables[] = $table;


### PR DESCRIPTION
This PR is made in reference to: #3559

This PR addresses or contains:

- Adds the `SMW::SQLStore::Installer::AddAuxiliaryIndicesBeforeCreateTablesComplete` to support adding auxiliary indices such as those requested in #3559
- In future we may switch to a more strict `PRIMARY KEY` validation schema but without knowing when and what it means for users who cannot easily switch, the hook should cater for the needs of those that require a more strict environment such as Percona XtraDB Cluster [0]

This PR includes:
- [ ] Tests (unit/integration)
- [x] CI build passed

Fixes #3559

[0] https://www.percona.com/doc/percona-xtradb-cluster/LATEST/features/pxc-strict-mode.html#tables-without-primary-keys which states "...  cannot properly propagate certain write operations to tables that do not have primary keys defined.  ... "