### PR TITLE
Add IndicatorRegistry

### DIFF
--- a/src/MediaWiki/Hooks/HookListener.php
+++ b/src/MediaWiki/Hooks/HookListener.php
@@ -119,12 +119,19 @@ class HookListener {
 	 */
 	public function onOutputPageParserOutput( &$outputPage, $parserOutput ) {
 
+		$applicationFactory = ApplicationFactory::getInstance();
+
 		$outputPageParserOutput = new OutputPageParserOutput(
-			$outputPage,
-			$parserOutput
+			$applicationFactory->getNamespaceExaminer()
 		);
 
-		return $outputPageParserOutput->process();
+		$outputPageParserOutput->setIndicatorRegistry(
+			$applicationFactory->create( 'IndicatorRegistry' )
+		);
+
+		$outputPageParserOutput->process( $outputPage, $parserOutput );
+
+		return true;
 	}
 
 	/**

--- a/src/MediaWiki/IndicatorProvider.php
+++ b/src/MediaWiki/IndicatorProvider.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace SMW\MediaWiki;
+
+use Title;
+
+/**
+ * @license GNU GPL v2+
+ * @since 3.1
+ *
+ * @author mwjames
+ */
+interface IndicatorProvider {
+
+	/**
+	 * @since 3.1
+	 *
+	 * @param Title $title
+	 *
+	 * @return boolean
+	 */
+	public function hasIndicator( Title $title, $parserOutput );
+
+	/**
+	 * @since 3.1
+	 *
+	 * @return []
+	 */
+	public function getIndicators();
+
+}

--- a/src/MediaWiki/IndicatorRegistry.php
+++ b/src/MediaWiki/IndicatorRegistry.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace SMW\MediaWiki;
+
+use Title;
+use OutputPage;
+
+/**
+ * @license GNU GPL v2+
+ * @since 3.1
+ *
+ * @author mwjames
+ */
+class IndicatorRegistry {
+
+	/**
+	 * @var IndicatorProvider[]
+	 */
+	private $indicatorProviders = [];
+
+	/**
+	 * @var []
+	 */
+	private $indicators = [];
+
+	/**
+	 * @since 3.1
+	 *
+	 * @param IndicatorProvider|null $indicatorProvider
+	 */
+	public function addIndicatorProvider( IndicatorProvider $indicatorProvider = null ) {
+
+		if ( $indicatorProvider === null ) {
+			return;
+		}
+
+		$this->indicatorProviders[] = $indicatorProvider;
+	}
+
+	/**
+	 * @since 3.1
+	 *
+	 * @param Title $title
+	 *
+	 * @return boolean
+	 */
+	public function hasIndicator( Title $title, $parserOutput ) {
+
+		foreach ( $this->indicatorProviders as $indicatorProvider ) {
+
+			if ( !$indicatorProvider->hasIndicator( $title, $parserOutput ) ) {
+				continue;
+			}
+
+			$this->indicators = array_merge( $this->indicators, $indicatorProvider->getIndicators() );
+		}
+
+		return $this->indicators !== [];
+	}
+
+	/**
+	 * @since 3.1
+	 *
+	 * @param OutputPage $outputPage
+	 */
+	public function attachIndicators( OutputPage $outputPage ) {
+		$outputPage->setIndicators( $this->indicators );
+	}
+
+}

--- a/src/Services/ServicesContainer.php
+++ b/src/Services/ServicesContainer.php
@@ -3,6 +3,7 @@
 namespace SMW\Services;
 
 use RuntimeException;
+use SMW\Services\Exception\ServiceNotFoundException;
 
 /**
  * @private
@@ -36,7 +37,7 @@ class ServicesContainer {
 	public function get( $key, ...$args ) {
 
 		if ( !isset( $this->services[$key] ) ) {
-			throw new RuntimeException( "$key is an unknown service!" );
+			throw new ServiceNotFoundException( "$key is an unknown service!" );
 		};
 
 		$type = null;

--- a/src/Services/SharedServicesContainer.php
+++ b/src/Services/SharedServicesContainer.php
@@ -53,6 +53,7 @@ use SMW\SQLStore\QueryDependencyLinksStoreFactory;
 use SMW\QueryFactory;
 use SMW\Query\Processor\QueryCreator;
 use SMW\Query\Processor\ParamListProcessor;
+use SMW\MediaWiki\IndicatorRegistry;
 
 /**
  * @license GNU GPL v2+
@@ -70,6 +71,7 @@ class SharedServicesContainer implements CallbackContainer {
 	public function register( ContainerBuilder $containerBuilder ) {
 
 		$containerBuilder->registerCallback( 'Store', [ $this, 'newStore' ] );
+		$containerBuilder->registerCallback( 'IndicatorRegistry', [ $this, 'newIndicatorRegistry' ] );
 
 		$this->registerCallbackHandlers( $containerBuilder );
 		$this->registerCallableFactories( $containerBuilder );
@@ -110,6 +112,29 @@ class SharedServicesContainer implements CallbackContainer {
 		);
 
 		return $store;
+	}
+
+	/**
+	 * @since 3.1
+	 *
+	 * @return IndicatorRegistry
+	 */
+	public function newIndicatorRegistry( $containerBuilder ) {
+
+		$indicatorRegistry = new IndicatorRegistry();
+		$store = $containerBuilder->singleton( 'Store', null );
+
+		try{
+			$indicatorProvider = $store->service( 'IndicatorProvider' );
+		} catch( \SMW\Services\Exception\ServiceNotFoundException $e ) {
+			$indicatorProvider = null;
+		}
+
+		$indicatorRegistry->addIndicatorProvider(
+			$indicatorProvider
+		);
+
+		return $indicatorRegistry;
 	}
 
 	private function registerCallbackHandlers( $containerBuilder ) {

--- a/tests/phpunit/Unit/MediaWiki/IndicatorRegistryTest.php
+++ b/tests/phpunit/Unit/MediaWiki/IndicatorRegistryTest.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace SMW\Tests\MediaWiki;
+
+use SMW\MediaWiki\IndicatorRegistry;
+use SMW\DIWikiPage;
+
+/**
+ * @covers \SMW\MediaWiki\IndicatorRegistry
+ * @group semantic-mediawiki
+ *
+ * @license GNU GPL v2+
+ * @since   3.1
+ *
+ * @author mwjames
+ */
+class IndicatorRegistryTest extends \PHPUnit_Framework_TestCase {
+
+	private $indicatorProvider;
+
+	protected function setUp() {
+
+		$this->indicatorProvider = $this->getMockBuilder( '\SMW\MediaWiki\IndicatorProvider' )
+			->disableOriginalConstructor()
+			->getMock();
+	}
+
+	public function testCanConstruct() {
+
+		$this->assertInstanceOf(
+			IndicatorRegistry::class,
+			 new IndicatorRegistry()
+		);
+	}
+
+	public function testAddIndicatorProvider() {
+
+		$title = $this->getMockBuilder( '\Title' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$this->indicatorProvider->expects( $this->once() )
+			->method( 'hasIndicator' )
+			->will( $this->returnValue( true ) );
+
+		$this->indicatorProvider->expects( $this->once() )
+			->method( 'getIndicators' )
+			->will( $this->returnValue( [] ) );
+
+		$instance = new IndicatorRegistry();
+		$instance->addIndicatorProvider( $this->indicatorProvider );
+
+		$instance->hasIndicator( $title, '' );
+	}
+
+	public function testAttachIndicators() {
+
+		$outputPage = $this->getMockBuilder( '\OutputPage' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$outputPage->expects( $this->once() )
+			->method( 'setIndicators' );
+
+		$instance = new IndicatorRegistry();
+		$instance->attachIndicators( $outputPage );
+	}
+
+}

--- a/tests/phpunit/Unit/Services/ServicesContainerTest.php
+++ b/tests/phpunit/Unit/Services/ServicesContainerTest.php
@@ -122,7 +122,7 @@ class ServicesContainerTest extends \PHPUnit_Framework_TestCase {
 
 		$instance = new ServicesContainer();
 
-		$this->setExpectedException( '\RuntimeException' );
+		$this->setExpectedException( '\SMW\Services\Exception\ServiceNotFoundException' );
 		$instance->get( 'test' );
 	}
 


### PR DESCRIPTION
This PR is made in reference to: #

This PR addresses or contains:

- Adds `IndicatorRegistry` to collect indicators that then can be attach via the `OutputPageParserOutput` hook using `OutputPage::setIndicators`

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed
