### PR TITLE
[ES] Monitor replication (per entity)

### DIFF
--- a/DefaultSettings.php
+++ b/DefaultSettings.php
@@ -2111,7 +2111,13 @@ return [
 			'job.recovery.retries' => 5,
 
 			// Number of max. retries before the file ingest
-			'job.file.ingest.retries' => 3
+			'job.file.ingest.retries' => 3,
+
+			// Compare and report the status of the replication on a page view
+			// about entities hereby allowing users to immediately comprehend a
+			// possible discrepancy between the stored on-wiki data and the data
+			// replicated to Elasticsearch.
+			'monitor.entity.replication' => true,
 		],
 		'query' => [
 

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -427,6 +427,7 @@
 	"smw-admin-supplementary-elastic-status-recovery-job-count": "Recovery job backlog: $1 (estimation)",
 	"smw-admin-supplementary-elastic-status-file-ingest-job-count": "Injest (file) job backlog: $1 (estimation)",
 	"smw-admin-supplementary-elastic-status-rebuild-lock": "Replication locked: $1 (rebuild in-progress)",
+	"smw-admin-supplementary-elastic-status-replication-monitoring":"Replication monitoring (active): $1",
 	"smw-list-count": "The list contains $1 {{PLURAL:$1|entry|entries}}.",
 	"smw-list-count-from-cache": "The list contains $1 {{PLURAL:$1|entry|entries}} and was retrieved from cache (UTC: $2).",
 	"smw-property-label-uniqueness" : "The \"$1\" label was matched to at least one other property representation. Please consult the [https://www.semantic-mediawiki.org/wiki/Help:Property_uniqueness help page] on how to resolve this issue.",
@@ -871,5 +872,10 @@
 	"smw-helplink-concepts": "https://www.semantic-mediawiki.org/wiki/Help:Concepts",
 	"smw-install-incomplete-intro": "The installation (or upgrade) of <b>Semantic MediaWiki</b> has not been finalized and an administrator should run the following tasks to prevent data inconsistencies before users continue to create or alter content.",
 	"smw-install-incomplete-populate-hash-field": "The <code>smw_hash</code> field population was skipped during the setup, the [https://www.semantic-mediawiki.org/wiki/Help:populateHashField.php populateHashField.php] script is required to be executed.",
-	"smw-helplink": "https://www.semantic-mediawiki.org/wiki/Help:$1"
+	"smw-helplink": "https://www.semantic-mediawiki.org/wiki/Help:$1",
+	"smw-es-replication-error": "Replication issue",
+	"smw-es-replication-error-missing-id": "The replication monitoring has found that article \"$1\" (ID: $2) is missing from the Elasticsearch backend.",
+	"smw-es-replication-error-divergent-date": "The replication monitoring has found that for the \"$1\" article (ID: $2) the modification date shows a discrepancy.",
+	"smw-es-replication-error-divergent-date-detail": "*$1 (Elasticsearch)\n*$2 (SQLStore)",
+	"smw-es-replication-error-suggestions": "It is suggested to edit or purge the page to remove the discrepancy. If the issue remains then check the Elasticsearch cluster itself (allocator, exceptions, disk space etc.)."
 }

--- a/res/Resources.php
+++ b/res/Resources.php
@@ -36,7 +36,8 @@ return [
 			'smw/ext.smw.dropdown.css',
 			'smw/ext.smw.table.css',
 			'smw/ext.smw.tabs.css',
-			'smw/factbox/smw.factbox.css'
+			'smw/factbox/smw.factbox.css',
+			'smw/smw.indicators.css'
 		],
 		'position' => 'top',
 		'targets' => [ 'mobile', 'desktop' ]
@@ -759,6 +760,21 @@ return [
 			'smw-ui-tooltip-title-note',
 			'smw-ui-tooltip-title-legend',
 			'smw-ui-tooltip-title-reference'
+		],
+		'targets' => [
+			'mobile',
+			'desktop'
+		]
+	],
+
+	'smw.check.replication'  => $moduleTemplate + [
+		'position' => 'top',
+		'scripts'  => [
+			'smw/util/smw.check.replication.js'
+		],
+		'dependencies'  => [
+			'mediawiki.api',
+			'smw.tippy',
 		],
 		'targets' => [
 			'mobile',

--- a/res/smw/ext.smw.css
+++ b/res/smw/ext.smw.css
@@ -217,6 +217,7 @@ span.smwwarning {
 	background-repeat: no-repeat;
 	height: 28px;
 	width: 28px;
+	display: inline-block;
 }
 
 /* Search, browse, RDF icons/ FIXME: this was only used for Factbox docu, should be removed from code */
@@ -826,27 +827,22 @@ a.smw-ask-action-btn-dblue:focus {
 
 .smw-protection-indicator {
 	display: inline-block;
-	/* font-weight: normal; */
-	/* line-height: 1.25; */
-	/* text-align: center; */
-	/* white-space: nowrap; */
-	vertical-align: middle;
 	-webkit-user-select: none;
 	-moz-user-select: none;
 	-ms-user-select: none;
 	user-select: none;
 	border: 1px solid transparent;
-	padding: 0.5rem 1rem;
 	/* font-size: 1rem; */
 	border-radius: 0.25rem;
 	-webkit-transition: all 0.2s ease-in-out;
 	-o-transition: all 0.2s ease-in-out;
 	transition: all 0.2s ease-in-out;
-	padding: 0.15rem 0.25rem;
 	/* font-size: 0.875rem; */
 	border-radius: 0.2rem;
 	color: #292b2c;
 	border-color: transparent;
+	width: 28px;
+	height: 28px;
 }
 
 .smw-protection-indicator.with-border {

--- a/res/smw/smw.indicators.css
+++ b/res/smw/smw.indicators.css
@@ -1,0 +1,91 @@
+/*!
+ * This file is part of the Semantic MediaWiki Extension
+ * @see https://www.semantic-mediawiki.org/
+ *
+ * @section LICENSE
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA
+ *
+ * @since 3.1
+ *
+ * @file
+ * @ingroup SMW
+ *
+ * @licence GNU GPL v2+
+ * @author mwjames
+ */
+.smw-icon-indicator-replication-error {
+    background: url("data:image/svg+xml,%3C%3Fxml version='1.0' encoding='UTF-8'%3F%3E%3Csvg xmlns='http://www.w3.org/2000/svg' width='20' height='20' viewBox='0 0 20 20'%3E%3Cstyle type='text/css'%3E* %7B fill: %23e67e22 %7D%3C/style%3E%3Cpath d='M10 0a10 10 0 1 0 10 10A10 10 0 0 0 10 0zm1 16H9v-2h2zm0-4H9V4h2z'/%3E%3C/svg%3E%0A") center left no-repeat;
+    padding-left: 20px;
+    display: inline-block;
+    height: 28px;
+}
+
+.smw-icon-indicator-replication-error {
+    background: url("data:image/svg+xml,%3C%3Fxml version='1.0' encoding='UTF-8'%3F%3E%3Csvg xmlns='http://www.w3.org/2000/svg' width='20' height='20' viewBox='0 0 20 20'%3E%3Cg stroke='%23d33' stroke-width='2.23'%3E%3Ccircle fill='%23ffffff' cx='10' cy='10' r='8.5652'/%3E%3Cpath d='M10,4.188V12.657M10,13.438V15.813'/%3E%3C/g%3E%3C/svg%3E") center left no-repeat;
+    padding-left: 20px;
+    display: inline-block;
+    height: 28px;
+    margin-right: 5px;
+}
+
+.smw-icon-constraint-violation {
+    background:
+    url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' version='1.1' width='26' height='26' viewBox='0 0 24 24'%3E%3Cpath fill='%23ce4844' d='M13,13H11V7H13M13,17H11V15H13M12,2A10,10 0 0,0 2,12A10,10 0 0,0 12,22A10,10 0 0,0 22,12A10,10 0 0,0 12,2Z' /%3E%3C/svg%3E")
+    no-repeat
+    left center;
+    padding: 28px 0 0px 28px;
+    vertical-align: middle;
+    display: inline-block;
+}
+
+.smw-icon-es-engine {
+    background: url("data:image/svg+xml,%3C%3Fxml version='1.0' encoding='UTF-8'%3F%3E%3Csvg width='20px' height='20px' viewBox='0 0 30 30' version='1.1' xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink'%3E%3Cg id='es-logo' stroke='none' stroke-width='1' fill='none' fill-rule='evenodd'%3E%3Cg id='Group-11' transform='translate(1.000000, 0.000000)'%3E%3Cpath d='M0,15 C0,16.388 0.203,17.725 0.556,19 L19,19 C21.209,19 23,17.209 23,15 C23,12.791 21.209,11 19,11 L0.556,11 C0.203,12.275 0,13.612 0,15' id='Fill-1' fill='%23343741'%3E%3C/path%3E%3Cpath d='M25.3301,6.8613 C25.7831,6.4353 26.2111,5.9823 26.6051,5.5003 C23.8541,2.1433 19.6791,0.0003 15.0001,0.0003 C9.2481,0.0003 4.2721,3.2473 1.7601,8.0003 L22.3371,8.0003 C23.4401,8.0003 24.5251,7.6173 25.3301,6.8613' id='Fill-3' fill='%23FEC514'%3E%3C/path%3E%3Cpath d='M22.3369,22 L1.7599,22 C4.2729,26.753 9.2479,30 14.9999,30 C19.6789,30 23.8549,27.856 26.6059,24.5 C26.2109,24.018 25.7829,23.564 25.3299,23.139 C24.5249,22.383 23.4409,22 22.3369,22' id='Fill-5' fill='%2300BFB3'%3E%3C/path%3E%3Cpath d='M11.1035,19 L0.5555,19 L11.1035,19 Z' id='Fill-7' fill='%23FFC100'%3E%3C/path%3E%3C/g%3E%3C/g%3E%3C/svg%3E")
+    no-repeat
+    left center;
+    padding: 28px 0 0px 28px;
+    vertical-align: middle;
+    display: inline-block;
+}
+
+.smw-issue-label {
+    border-radius: 2px;
+    box-shadow: inset 0 -1px 0 rgba(27,31,35,.12);
+    font-size: 12px;
+    font-weight: 600;
+    height: 20px;
+    line-height: 15px;
+    padding: .15em 4px;
+}
+
+.smw-rule-constraint-violation ul.smw-list-rule {
+	margin: 0;
+}
+
+.smw-rule-constraint-violation ul.smw-list-rule li {
+	margin: 0;
+	margin-bottom: 0.2em;
+}
+
+.smw-list-rule {
+	list-style-image: none;
+	list-style-type: none;
+	margin: 0.2em 0 0 0.6em;
+}
+
+.smw-list-rule-title {
+    border-bottom: 0px solid #ddd;
+    border-collapse: collapse;
+    color: #000;
+}

--- a/res/smw/util/smw.check.replication.js
+++ b/res/smw/util/smw.check.replication.js
@@ -1,0 +1,55 @@
+/*!
+ * This file is part of the Semantic MediaWiki Reload module
+ * @see https://www.semantic-mediawiki.org/wiki/Help:Purge
+ *
+ * @since 3.0
+ *
+ * @file
+ * @ingroup SMW
+ *
+ * @licence GNU GPL v2+
+ * @author mwjames
+ */
+
+/*global jQuery, mediaWiki, smw */
+/*jslint white: true */
+
+( function( $, mw ) {
+
+	'use strict';
+
+	/**
+	 * @since 3.0
+	 */
+	mw.loader.using( [ 'mediawiki.api', 'smw.tippy' ] ).then( function () {
+
+		$( '.smw-es-replication' ).each( function() {
+
+			var self = $( this );
+			var api = new mw.Api();
+			var subject = $( this ).data( 'subject' );
+
+			if ( subject !== undefined && subject !== '' ) {
+
+				var params = {
+					'subject': subject,
+					'dir': $( this ).data( 'dir' )
+				};
+
+				var postArgs = {
+					'action': 'smwtask',
+					'task': 'check-es-replication',
+					'params': JSON.stringify( params )
+				};
+
+				api.postWithToken( 'csrf', postArgs ).then( function ( data ) {
+					self.replaceWith( data.task.html );
+					self.find( '.is-disabled' ).removeClass( 'is-disabled' );
+				} );
+			}
+
+		} );
+
+	} );
+
+}( jQuery, mediaWiki ) );

--- a/res/smw/util/smw.tippy.css
+++ b/res/smw/util/smw.tippy.css
@@ -59,6 +59,8 @@
     word-break: break-word;
    /* max-width: 260px; */
    font-size: 14px;
+   max-height: 250px;
+   overflow-y: auto;
 }
 
 .tippy-content-overlay {
@@ -100,4 +102,24 @@
     text-decoration: none;
     cursor: pointer;
     opacity: 0.4;
+}
+
+.tippy-header.wide-popup {
+    padding: .8em .8em .6em .8em;
+}
+
+.tippy-content-container.wide-popup {
+    padding: .5em .8em;
+    margin-bottom: 0px;
+    font-size: 14px;
+    max-height: unset;
+    overflow: unset;
+}
+
+.tippy-content-container.wide-popup ul {
+    font-size: 12px;
+}
+
+.tippy-bottom.wide-popup {
+     padding: .8em .8em .95em .8em;
 }

--- a/res/smw/util/smw.tippy.js
+++ b/res/smw/util/smw.tippy.js
@@ -16,18 +16,22 @@
 		canFetch: true
 	}
 
-	var container = function( title, content, isPersistent ) {
+	var container = function( title, content, tip ) {
 
-		var cancel = '';
+		var cancel = '', head = '', bottom = '', theme = '';
+		var theme = tip.smw.theme;
 
-		if ( isPersistent ) {
+		if ( tip.smw.isPersistent ) {
 			cancel = '<span class="tippy-cancel"></span>';
 		};
 
-		var head = '<div class="tippy-header">' + cancel + title + '</div>';
-		//var bottom = '<div class="tippy-bottom">' + cancel + title + '</div>';
+		head = '<div class="tippy-header ' + theme + '">' + cancel + title + '</div>';
 
-		return head + '<div class="tippy-content-container">' + content + '</div>';
+		if ( tip.reference.getAttribute( "data-bottom" ) ) {
+			bottom = '<div class="tippy-bottom ' + theme + '">' + tip.reference.getAttribute( "data-bottom" ) + '</div>';
+		};
+
+		return head + '<div class="tippy-content-container ' + theme + '">' + content + '</div>' + bottom;
 	}
 
 	var options = {
@@ -73,6 +77,7 @@
 					isDeferred: false,
 					hasContent: false,
 					wasClicked: false,
+					theme: '',
 					title: ''
 				};
 
@@ -82,6 +87,10 @@
 
 				if ( tip.reference.getAttribute( "data-maxwidth" ) ) {
 					tip.set( { maxWidth: parseInt( tip.reference.getAttribute( "data-maxwidth" ) ) } );
+				}
+
+				if ( tip.reference.getAttribute( "data-theme" ) ) {
+					tip.smw.theme = tip.reference.getAttribute( "data-theme" );
 				}
 
 				tip.reference.setAttribute( "title", '' );
@@ -131,7 +140,7 @@
 				}
 
 				tip.setContent(
-					container( title, content, tip.smw.isPersistent )
+					container( title, content, tip )
 				);
 			}
 
@@ -267,9 +276,14 @@
 		return self;
 	};
 
+	if ( document.getElementsByClassName( "smw-highlighter.is-disabled" ).length > 0 ) {
+		document.getElementsByClassName( "smw-highlighter.is-disabled" )[0].classList.remove( 'is-disabled' );
+	};
+
 	// Running in default mode which would be on
 	// $( document ).ready( function() { ... } ); when relying on jQuery
 	tippy( '#bodyContent', options )
+	tippy( '.mw-indicators', options )
 
 	/**
 	 * Factory

--- a/src/Elastic/Admin/ElasticClientTaskHandler.php
+++ b/src/Elastic/Admin/ElasticClientTaskHandler.php
@@ -189,16 +189,25 @@ class ElasticClientTaskHandler extends TaskHandler {
 			$this->outputFormatter->encodeAsJson( $connection->info() )
 		);
 
-		$replicationStatus = new ReplicationStatus(
+		$applicationFactory = ApplicationFactory::getInstance();
+		$elasticFactory = $applicationFactory->singleton( 'ElasticFactory' );
+
+		$replicationStatus = $elasticFactory->newReplicationStatus(
 			$connection
 		);
 
-		$jobQueue = ApplicationFactory::getInstance()->getJobQueue();
+		$jobQueue = $applicationFactory->getJobQueue();
 
 		$html .= Html::element(
 			'li',
 			[],
 			$this->msg( [ 'smw-admin-supplementary-elastic-status-last-active-replication', $replicationStatus->get( 'last_update' ) ] )
+		);
+
+		$html .= Html::element(
+			'li',
+			[],
+			$this->msg( [ 'smw-admin-supplementary-elastic-status-replication-monitoring', $connection->getConfig()->dotGet( 'indexer.monitor.entity.replication' ) ? '✓' : '✗' ] )
 		);
 
 		$html .= Html::rawElement(

--- a/src/Elastic/ElasticStore.php
+++ b/src/Elastic/ElasticStore.php
@@ -70,6 +70,12 @@ class ElasticStore extends SQLStore {
 			// $this->servicesContainer->add( 'ProximityPropertyValueLookup', function() {
 			//	return $this->elasticFactory->newProximityPropertyValueLookup( $this );
 			// } );
+			//
+			$this->servicesContainer->add( 'IndicatorProvider', function() {
+				return $this->elasticFactory->newIndicatorProvider(
+					$this
+				);
+			} );
 		}
 
 		return $this->servicesContainer->get( $service, ...$args );

--- a/src/Elastic/Indexer/IndicatorProvider.php
+++ b/src/Elastic/Indexer/IndicatorProvider.php
@@ -1,0 +1,119 @@
+<?php
+
+namespace SMW\Elastic\Indexer;
+
+use SMWDITime as DITime;
+use SMW\DIProperty;
+use SMW\DIWikiPage;
+use SMW\Store;
+use SMW\SemanticData;
+use SMW\MediaWiki\IndicatorProvider as IIndicatorProvider;
+use Title;
+use Html;
+use SMW\Message;
+
+/**
+ * @license GNU GPL v2+
+ * @since 3.1
+ *
+ * @author mwjames
+ */
+class IndicatorProvider implements IIndicatorProvider {
+
+	/**
+	 * @var Store
+	 */
+	private $store;
+
+	/**
+	 * @var []
+	 */
+	private $indicators = [];
+
+	/**
+	 * @var boolean
+	 */
+	private $checkReplication = false;
+
+	/**
+	 * @since 3.1
+	 *
+	 * @param Store $store
+	 */
+	public function __construct( Store $store ) {
+		$this->store = $store;
+	}
+
+	/**
+	 * @since 3.1
+	 *
+	 * @param boolean $checkReplication
+	 */
+	public function canCheckReplication( $checkReplication ) {
+		$this->checkReplication = (bool)$checkReplication;
+	}
+
+	/**
+	 * @since 3.1
+	 *
+	 * @param Title $title
+	 * @param array $options
+	 *
+	 * @return boolean
+	 */
+	public function hasIndicator( Title $title, $options ) {
+
+		if ( $this->checkReplication ) {
+			return $this->checkReplication( $title, $options );
+		}
+
+		return $this->indicators !== [];
+	}
+
+	/**
+	 * @since 3.1
+	 *
+	 * @return []
+	 */
+	public function getIndicators() {
+		return $this->indicators;
+	}
+
+	/**
+	 * @since 3.1
+	 *
+	 * @return []
+	 */
+	public function getModules() {
+		return [ 'smw.check.replication' ];
+	}
+
+	private function checkReplication( $title, $options ) {
+
+		if ( $options['action'] === 'edit' || $options['diff'] !== null || $options['action'] === 'history' ) {
+			return false;
+		}
+
+		$subject = DIWikiPage::newFromTitle(
+			$title
+		);
+
+		$dir = 'ltr';
+
+		if ( isset( $options['isRTL'] ) && $options['isRTL'] ) {
+			$dir = 'rtl';
+		}
+
+		$this->indicators['smw-es-replication'] = Html::rawElement(
+			'div',
+			[
+				'class' => 'smw-es-replication',
+				'data-subject' => $subject->getHash(),
+				'data-dir' => $dir,
+			]
+		);
+
+		return true;
+	}
+
+}

--- a/src/Elastic/Indexer/Replication/CheckReplicationTask.php
+++ b/src/Elastic/Indexer/Replication/CheckReplicationTask.php
@@ -1,0 +1,149 @@
+<?php
+
+namespace SMW\Elastic\Indexer\Replication;
+
+use SMW\Store;
+use SMW\DIWikiPage;
+use SMW\DIProperty;
+use SMW\MediaWiki\Api\Tasks\Task;
+use SMW\Message;
+use Html;
+
+/**
+ * @license GNU GPL v2+
+ * @since 3.1
+ *
+ * @author mwjames
+ */
+class CheckReplicationTask extends Task {
+
+	/**
+	 * @var Store
+	 */
+	private $store;
+
+	/**
+	 * @var ReplicationStatus
+	 */
+	private $replicationStatus;
+
+	/**
+	 * @since 3.1
+	 *
+	 * @param Store $store
+	 * @param ReplicationStatus $replicationStatus
+	 */
+	public function __construct( Store $store, ReplicationStatus $replicationStatus ) {
+		$this->store = $store;
+		$this->replicationStatus = $replicationStatus;
+	}
+
+	/**
+	 * @since 3.1
+	 *
+	 * @param array $parameters
+	 *
+	 * @return array
+	 */
+	public function process( array $parameters ) {
+
+		if ( $parameters['subject'] === '' ) {
+			return [ 'done' => false ];
+		}
+
+		$subject = DIWikiPage::doUnserialize(
+			$parameters['subject']
+		);
+
+		$html = $this->checkReplication(
+			$subject,
+			$parameters
+		);
+
+		return [ 'done' => true, 'html' => $html ];
+	}
+
+	/**
+	 * @since 3.1
+	 *
+	 * @param DIWikiPage $subject
+	 * @param array $options
+	 *
+	 * @return string
+	 */
+	public function checkReplication( DIWikiPage $subject, array $options = [] ) {
+
+		$isRTL = isset( $options['dir'] ) && $options['dir'] === 'rtl';
+		$html = '';
+
+		$id = $this->store->getObjectIds()->getID( $subject );
+		$title = $subject->getTitle();
+
+		// Find the time from elastic
+		$dataItem = $this->replicationStatus->getModificationDate(
+			$id
+		);
+
+		// What is stored in the DB
+		$pv = $this->store->getPropertyValues(
+			$subject,
+			new DIProperty( '_MDAT' )
+		);
+
+		if ( $dataItem === false || $pv === [] ) {
+			$html = $this->buildHTML( $title->getPrefixedText(), $id, $isRTL );
+		} elseif ( !end( $pv )->equals( $dataItem ) ) {
+			$dates = [
+				'time_es' => $dataItem->getSerialization(),
+				'time_store' => end( $pv )->getSerialization()
+			];
+			$html = $this->buildHTML( $title->getPrefixedText(), $id, $isRTL, $dates );
+		}
+
+		return $html;
+	}
+
+	private function buildHTML( $title_text, $id, $isRTL = false, $dates = [] ) {
+
+		if ( $isRTL ) {
+			$line = '<div style="border-top: 1px solid #ebebeb;margin-top: 10px;margin-bottom: 8px;margin-right: -10px;width: 280px;"></div>';
+		} else {
+			$line = '<div style="border-top: 1px solid #ebebeb;margin-top: 10px;margin-bottom: 8px;margin-left: -10px;width: 280px;"></div>';
+		}
+
+		$content = '';
+		$bottom = '<span class="smw-issue-label" style="background-color: #cc317c;color: #ffffff;">elastic</span>';
+
+		if ( $dates !== [] ) {
+			$content .= $this->msg( [ 'smw-es-replication-error-divergent-date', $title_text, $id ] );
+			$content .= $line;
+			$content .= $this->msg( [ 'smw-es-replication-error-divergent-date-detail', $dates['time_es'], $dates['time_store'] ], Message::PARSE );
+			$content .= $line;
+			$content .= '<span style="font-size:12px;">' . $this->msg( 'smw-es-replication-error-suggestions' ) . '</span>';
+		} else {
+			$content .= $this->msg( [ 'smw-es-replication-error-missing-id', $title_text, $id ] );
+			$content .= $line;
+			$content .= '<span style="font-size:12px;">' . $this->msg( 'smw-es-replication-error-suggestions' ) . '</span>';
+		}
+
+		return Html::rawElement(
+			'div',
+			[
+				'class' => 'smw-highlighter smw-icon-indicator-replication-error',
+				'data-maxWidth' => '280',
+				'data-state' => 'inline',
+				'data-placement' => 'auto',
+				'data-animation' => 'fade',
+				'data-theme' => 'wide-popup',
+				'data-title' => $this->msg( 'smw-es-replication-error' ),
+				'data-content' => $content,
+				'data-bottom' => $bottom
+			]
+		);
+	}
+
+	private function msg( $key, $type = Message::TEXT, $lang = Message::USER_LANGUAGE ) {
+		return Message::get( $key, $type, $lang );
+	}
+
+}

--- a/src/MediaWiki/Hooks.php
+++ b/src/MediaWiki/Hooks.php
@@ -258,6 +258,7 @@ class Hooks {
 
 			'SMW::SQLStore::EntityReferenceCleanUpComplete' => [ $elasticFactory, 'onEntityReferenceCleanUpComplete' ],
 			'SMW::Admin::TaskHandlerFactory' => [ $elasticFactory, 'onTaskHandlerFactory' ],
+			'SMW::Api::AddTasks' => [ $elasticFactory, 'onApiTasks' ],
 
 			'AdminLinks' => [ $this, 'onAdminLinks' ],
 			'PageSchemasRegisterHandlers' => [ $this, 'onPageSchemasRegisterHandlers' ]

--- a/src/MediaWiki/Hooks/OutputPageParserOutput.php
+++ b/src/MediaWiki/Hooks/OutputPageParserOutput.php
@@ -77,7 +77,16 @@ class OutputPageParserOutput extends HookHandler {
 			return true;
 		}
 
-		if ( $this->indicatorRegistry !== null && $this->indicatorRegistry->hasIndicator( $title, $parserOutput ) ) {
+		$context = $outputPage->getContext();
+		$request = $context->getRequest();
+
+		$options = [
+			'action' => $request->getVal( 'action' ),
+			'diff' => $request->getVal( 'diff' ),
+			'isRTL' => $context->getLanguage()->isRTL()
+		];
+
+		if ( $this->indicatorRegistry !== null && $this->indicatorRegistry->hasIndicator( $title, $options ) ) {
 			$this->indicatorRegistry->attachIndicators( $outputPage );
 		}
 

--- a/src/MediaWiki/IndicatorProvider.php
+++ b/src/MediaWiki/IndicatorProvider.php
@@ -28,4 +28,11 @@ interface IndicatorProvider {
 	 */
 	public function getIndicators();
 
+	/**
+	 * @since 3.1
+	 *
+	 * @return []
+	 */
+	public function getModules();
+
 }

--- a/src/MediaWiki/IndicatorRegistry.php
+++ b/src/MediaWiki/IndicatorRegistry.php
@@ -24,6 +24,11 @@ class IndicatorRegistry {
 	private $indicators = [];
 
 	/**
+	 * @var []
+	 */
+	private $modules = [];
+
+	/**
 	 * @since 3.1
 	 *
 	 * @param IndicatorProvider|null $indicatorProvider
@@ -53,6 +58,7 @@ class IndicatorRegistry {
 			}
 
 			$this->indicators = array_merge( $this->indicators, $indicatorProvider->getIndicators() );
+			$this->modules = array_merge( $this->modules, $indicatorProvider->getModules() );
 		}
 
 		return $this->indicators !== [];
@@ -64,6 +70,7 @@ class IndicatorRegistry {
 	 * @param OutputPage $outputPage
 	 */
 	public function attachIndicators( OutputPage $outputPage ) {
+		$outputPage->addModules( $this->modules );
 		$outputPage->setIndicators( $this->indicators );
 	}
 

--- a/tests/phpunit/Unit/Elastic/Indexer/IndicatorProviderTest.php
+++ b/tests/phpunit/Unit/Elastic/Indexer/IndicatorProviderTest.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace SMW\Tests\Elastic\Indexer;
+
+use SMW\Elastic\Indexer\IndicatorProvider;
+use SMW\Tests\PHPUnitCompat;
+
+/**
+ * @covers \SMW\Elastic\Indexer\IndicatorProvider
+ * @group semantic-mediawiki
+ *
+ * @license GNU GPL v2+
+ * @since 3.0
+ *
+ * @author mwjames
+ */
+class IndicatorProviderTest extends \PHPUnit_Framework_TestCase {
+
+	use PHPUnitCompat;
+
+	private $store;
+
+	protected function setUp() {
+
+		$this->store = $this->getMockBuilder( '\SMW\Store' )
+			->disableOriginalConstructor()
+			->getMockForAbstractClass();
+	}
+
+	public function testCanConstruct() {
+
+		$this->assertInstanceOf(
+			IndicatorProvider::class,
+			new IndicatorProvider( $this->store )
+		);
+	}
+
+	public function testCheckReplicatioIndicator() {
+
+		$title = $this->getMockBuilder( '\Title' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$title->expects( $this->once() )
+			->method( 'getDBKey' )
+			->will( $this->returnValue( 'Foo' ) );
+
+		$title->expects( $this->once() )
+			->method( 'getNamespace' )
+			->will( $this->returnValue( NS_MAIN ) );
+
+		$instance = new IndicatorProvider(
+			$this->store
+		);
+
+		$instance->canCheckReplication( true );
+
+		$options = [
+			'action' => 'foo',
+			'diff' => null
+		];
+
+		$this->assertTrue(
+			$instance->hasIndicator( $title, $options )
+		);
+
+		$this->assertArrayHasKey(
+			'smw-es-replication',
+			$instance->getIndicators()
+		);
+	}
+
+}

--- a/tests/phpunit/Unit/Elastic/Indexer/Replication/CheckReplicationTaskTest.php
+++ b/tests/phpunit/Unit/Elastic/Indexer/Replication/CheckReplicationTaskTest.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace SMW\Tests\Elastic\Indexer\Replication;
+
+use SMW\Elastic\Indexer\Replication\CheckReplicationTask;
+use SMW\Tests\PHPUnitCompat;
+use SMW\DIWikiPage;
+
+/**
+ * @covers \SMW\Elastic\Indexer\Replication\CheckReplicationTask
+ * @group semantic-mediawiki
+ *
+ * @license GNU GPL v2+
+ * @since 3.0
+ *
+ * @author mwjames
+ */
+class CheckReplicationTaskTest extends \PHPUnit_Framework_TestCase {
+
+	use PHPUnitCompat;
+
+	private $store;
+	private $replicationStatus;
+
+	protected function setUp() {
+
+		$idTable = $this->getMockBuilder( '\SMWSql3SmwIds' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$this->store = $this->getMockBuilder( '\SMW\Store' )
+			->disableOriginalConstructor()
+			->setMethods( [ 'getObjectIds' ] )
+			->getMockForAbstractClass();
+
+		$this->store->expects( $this->any() )
+			->method( 'getObjectIds' )
+			->will( $this->returnValue( $idTable ) );
+
+		$this->replicationStatus = $this->getMockBuilder( '\SMW\Elastic\Indexer\Replication\ReplicationStatus' )
+			->disableOriginalConstructor()
+			->getMock();
+	}
+
+	public function testCanConstruct() {
+
+		$this->assertInstanceOf(
+			CheckReplicationTask::class,
+			new CheckReplicationTask( $this->store, $this->replicationStatus )
+		);
+	}
+
+	public function testCheckReplication_NotExists() {
+
+		$this->replicationStatus->expects( $this->once() )
+			->method( 'getModificationDate' )
+			->will( $this->returnValue( false ) );
+
+		$this->store->expects( $this->once() )
+			->method( 'getPropertyValues' )
+			->will( $this->returnValue( [] ) );
+
+		$instance = new CheckReplicationTask(
+			$this->store,
+			$this->replicationStatus
+		);
+
+		$html = $instance->checkReplication( DIWikiPage::newFromText( 'Foo' ), [] );
+
+		$this->assertContains(
+			'smw-highlighter',
+			$html
+		);
+	}
+
+}

--- a/tests/phpunit/Unit/Elastic/Indexer/Replication/ReplicationStatusTest.php
+++ b/tests/phpunit/Unit/Elastic/Indexer/Replication/ReplicationStatusTest.php
@@ -1,12 +1,12 @@
 <?php
 
-namespace SMW\Tests\Elastic\Indexer;
+namespace SMW\Tests\Elastic\Indexer\Replication;
 
-use SMW\Elastic\Indexer\ReplicationStatus;
+use SMW\Elastic\Indexer\Replication\ReplicationStatus;
 use SMW\Tests\PHPUnitCompat;
 
 /**
- * @covers \SMW\Elastic\Indexer\ReplicationStatus
+ * @covers \SMW\Elastic\Indexer\Replication\ReplicationStatus
  * @group semantic-mediawiki
  *
  * @license GNU GPL v2+

--- a/tests/phpunit/Unit/MediaWiki/HooksTest.php
+++ b/tests/phpunit/Unit/MediaWiki/HooksTest.php
@@ -269,6 +269,7 @@ class HooksTest extends \PHPUnit_Framework_TestCase {
 			[ 'callUserGroupsChanged' ],
 			[ 'callSMWSQLStoreEntityReferenceCleanUpComplete' ],
 			[ 'callSMWAdminTaskHandlerFactory' ],
+			[ 'callSMWApiAddTasks' ],
 			[ 'callSMWSQLStorAfterDataUpdateComplete' ],
 			[ 'callSMWStoreBeforeQueryResultLookupComplete' ],
 			[ 'callSMWStoreAfterQueryResultLookupComplete' ],
@@ -1498,6 +1499,24 @@ class HooksTest extends \PHPUnit_Framework_TestCase {
 		$this->assertThatHookIsExcutable(
 			$instance->getHandlerFor( $handler ),
 			[ &$taskHandlers, $store, $outputFormatter, $user ]
+		);
+
+		return $handler;
+	}
+
+	public function callSMWApiAddTasks( $instance ) {
+
+		$handler = 'SMW::Api::AddTasks';
+
+		if ( !$instance->getHandlerFor( $handler ) ) {
+			return $this->markTestSkipped( "$handler not used" );
+		}
+
+		$services = [];
+
+		$this->assertThatHookIsExcutable(
+			$instance->getHandlerFor( $handler ),
+			[ &$services ]
 		);
 
 		return $handler;

--- a/tests/phpunit/Unit/MediaWiki/IndicatorRegistryTest.php
+++ b/tests/phpunit/Unit/MediaWiki/IndicatorRegistryTest.php
@@ -47,6 +47,10 @@ class IndicatorRegistryTest extends \PHPUnit_Framework_TestCase {
 			->method( 'getIndicators' )
 			->will( $this->returnValue( [] ) );
 
+		$this->indicatorProvider->expects( $this->once() )
+			->method( 'getModules' )
+			->will( $this->returnValue( [] ) );
+
 		$instance = new IndicatorRegistry();
 		$instance->addIndicatorProvider( $this->indicatorProvider );
 


### PR DESCRIPTION
This PR is made in reference to: #3687 

This PR addresses or contains:

- After recent incidents on the sandbox whether the replication of entities (aka wikipage) to ES was successful or not, this PR adds the `indexer.monitor.entity.replication` (default `true`) setting to allow to actively monitor the replication status for a page that is being viewed
- The monitoring will distinguish two cases:
  - The page wasn't replicated at all
  - The `modification date` differs (the one stored in the DB and ES) indicating a potential discrepancy of data
- The status monitoring (checking) is deferred using the new `check-es-replication` API task

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed

## Example

### Missing entity

![image](https://user-images.githubusercontent.com/1245473/52519281-c378f200-2c50-11e9-9813-2b764b6136b2.png)

### Modification date discrepancy
![image](https://user-images.githubusercontent.com/1245473/52519282-ca076980-2c50-11e9-8e29-bf8a36a53c50.png)
