### PR TITLE
[ES] Restrict value length in query, refs 3698

### DIFF
--- a/DefaultSettings.php
+++ b/DefaultSettings.php
@@ -2137,6 +2137,12 @@ return [
 			// when resolved in connection with a query
 			'debug.description.log' => true,
 
+			// #3698
+			// Restrict the length of an individual input value to avoid a potential
+			// "... "java.lang.IllegalArgumentException:input automaton is too
+			// large: 1001 ..."
+			'maximum.value.length' => 500,
+
 			// When `!...` is used make sure that the condition is only applied
 			// on entities where the property exists together with the negated
 			// value condition otherwise the ! condition becomes unrestricted

--- a/src/Elastic/QueryEngine/DescriptionInterpreters/SomeValueInterpreter.php
+++ b/src/Elastic/QueryEngine/DescriptionInterpreters/SomeValueInterpreter.php
@@ -145,6 +145,10 @@ class SomeValueInterpreter {
 			$value = $dataItem->getSortKey();
 		}
 
+		if ( mb_strlen( $value ) > $this->conditionBuilder->getOption( 'maximum.value.length' ) ) {
+			$value = mb_substr( $value, 0, $this->conditionBuilder->getOption( 'maximum.value.length' ) );
+		}
+
 		if ( $this->isRange( $comparator ) ) {
 			$match = $this->fieldMapper->range( "$pid.$field", $value, $comparator );
 		} elseif ( $isSubDataType && $dataItem->getDBKey() === '' && $comparator === SMW_CMP_NEQ ) {
@@ -271,6 +275,10 @@ class SomeValueInterpreter {
 		$type = $options['type'];
 
 		$value = $dataItem->getSerialization();
+
+		if ( mb_strlen( $value ) > $this->conditionBuilder->getOption( 'maximum.value.length' ) ) {
+			$value = mb_substr( $value, 0, $this->conditionBuilder->getOption( 'maximum.value.length' ) );
+		}
 
 		if ( $this->isRange( $comparator ) ) {
 			// Use a not_analyzed field
@@ -440,6 +448,10 @@ class SomeValueInterpreter {
 	 * @return array
 	 */
 	public function plain( $value, array &$options ) {
+
+		if ( mb_strlen( $value ) > $this->conditionBuilder->getOption( 'maximum.value.length' ) ) {
+			$value = mb_substr( $value, 0, $this->conditionBuilder->getOption( 'maximum.value.length' ) );
+		}
 
 		$comparator = $options['comparator'];
 		$pid = $options['pid'];

--- a/src/Elastic/QueryEngine/DescriptionInterpreters/ValueDescriptionInterpreter.php
+++ b/src/Elastic/QueryEngine/DescriptionInterpreters/ValueDescriptionInterpreter.php
@@ -108,6 +108,10 @@ class ValueDescriptionInterpreter {
 			$value = $dataItem->getSerialization();
 		}
 
+		if ( mb_strlen( $value ) > $this->conditionBuilder->getOption( 'maximum.value.length' ) ) {
+			$value = mb_substr( $value, 0, $this->conditionBuilder->getOption( 'maximum.value.length' ) );
+		}
+
 		if ( $dataItem instanceof DIWikiPage && $this->isRange( $comparator ) ) {
 			$params = $this->fieldMapper->range( "$field.keyword", $value, $comparator );
 		} elseif ( $dataItem instanceof DIBlob && $comparator === SMW_CMP_EQ ) {

--- a/tests/phpunit/Unit/Elastic/QueryEngine/DescriptionInterpreters/SomeValueInterpreterTest.php
+++ b/tests/phpunit/Unit/Elastic/QueryEngine/DescriptionInterpreters/SomeValueInterpreterTest.php
@@ -35,6 +35,12 @@ class SomeValueInterpreterTest extends \PHPUnit_Framework_TestCase {
 			->disableOriginalConstructor()
 			->setMethods( [ 'getID' ] )
 			->getMock();
+
+		$this->conditionBuilder->setOptions( new Options(
+			[
+				'maximum.value.length' => 500
+			]
+		) );
 	}
 
 	public function testCanConstruct() {
@@ -168,7 +174,8 @@ class SomeValueInterpreterTest extends \PHPUnit_Framework_TestCase {
 
 		$this->conditionBuilder->setOptions( new Options(
 			[
-				'cjk.best.effort.proximity.match' => true
+				'cjk.best.effort.proximity.match' => true,
+				'maximum.value.length' => 500
 			]
 		) );
 

--- a/tests/phpunit/Unit/Elastic/QueryEngine/DescriptionInterpreters/ValueDescriptionInterpreterTest.php
+++ b/tests/phpunit/Unit/Elastic/QueryEngine/DescriptionInterpreters/ValueDescriptionInterpreterTest.php
@@ -51,7 +51,8 @@ class ValueDescriptionInterpreterTest extends \PHPUnit_Framework_TestCase {
 
 		$this->conditionBuilder->setOptions( new Options(
 			[
-				'cjk.best.effort.proximity.match' => true
+				'cjk.best.effort.proximity.match' => true,
+				'maximum.value.length' => 500
 			]
 		) );
 
@@ -72,6 +73,43 @@ class ValueDescriptionInterpreterTest extends \PHPUnit_Framework_TestCase {
 
 		$this->assertEquals(
 			$expected,
+			(string)$condition
+		);
+	}
+
+	public function testRestrictedLength() {
+
+		$options = [
+			'property' => $this->dataItemFactory->newDIProperty( 'Bar' ),
+			'pid'   => 'P:42',
+			'field' => 'wpgID',
+			'type'  => 'must'
+		];
+
+		$this->conditionBuilder->setOptions( new Options(
+			[
+				'maximum.value.length' => 1
+			]
+		) );
+
+		$instance = new ValueDescriptionInterpreter(
+			$this->conditionBuilder
+		);
+
+		$description = $this->descriptionFactory->newValueDescription(
+			$this->dataItemFactory->newDIWikiPage( 'test' ),
+			null,
+			SMW_CMP_EQ
+		);
+
+		$condition = $instance->interpretDescription(
+			$description,
+			$options
+		);
+
+		// 4 vs. 42
+		$this->assertEquals(
+			'{"bool":{"must":{"terms":{"_id":["4"]}}}}',
 			(string)$condition
 		);
 	}


### PR DESCRIPTION
This PR is made in reference to: #3698

This PR addresses or contains:

- Adds `query.maximum.value.length` with 500 as default restriction for a value input making it unlikely to run into the #3698 (`java.lang.IllegalArgumentException:input automaton is too large: 1001`) issue
- 500 was selected as value to give enough context for a "long" query, any query that uses longer string segments as a value input should reevaluate their habit for building queries as it seems unproductive to search (while possible) for passages of considerable length
- The restriction is applied to each input value (__not__ to the whole query string)

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed

Fixes #3698

## Example

The following query [0] contains 445 characters as input value (which is still below `query.maximum.value.length) and should give an impression about the possible freedom for constructing and expressing a query context.

[0] `[[Has text::Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.]]`