### PR TITLE
Use smw_rev field to check if update is skippable, refs 2365, 3390

### DIFF
--- a/src/DataUpdater.php
+++ b/src/DataUpdater.php
@@ -140,6 +140,29 @@ class DataUpdater {
 	}
 
 	/**
+	 * Is the update skippable given that a revision has already been stored in
+	 * SMW?
+	 *
+	 * MW 1.29 made the LinksUpdate a EnqueueableDataUpdate which creates updates
+	 * as JobSpecification (refreshLinksPrioritized) and posses a possibility of
+	 * running an update more than once for the same RevID.
+	 *
+	 * @since 3.1
+	 *
+	 * @return boolean
+	 */
+	public function isSkippable( Title $title ) {
+
+		$associatedRev = $this->store->getObjectIds()->findAssociatedRev(
+			$title->getDBKey(),
+			$title->getNamespace(),
+			$title->getInterwiki()
+		);
+
+		return $associatedRev == $title->getLatestRevID( Title::GAID_FOR_UPDATE );
+	}
+
+	/**
 	 * @since 1.9
 	 *
 	 * @return boolean

--- a/src/MediaWiki/Hooks/LinksUpdateConstructed.php
+++ b/src/MediaWiki/Hooks/LinksUpdateConstructed.php
@@ -120,12 +120,6 @@ class LinksUpdateConstructed extends HookHandler {
 		$parserData->setOrigin( 'LinksUpdateConstructed' );
 		$parserData->updateStore( $opts );
 
-		// Track the update on per revision because MW 1.29 made the LinksUpdate a
-		// EnqueueableDataUpdate which creates updates as JobSpecification
-		// (refreshLinksPrioritized) and posses a possibility of running an
-		// update more than once for the same RevID
-		$parserData->markUpdate( $latestRevID );
-
 		return true;
 	}
 

--- a/tests/phpunit/Unit/MediaWiki/Hooks/ArticleProtectCompleteTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Hooks/ArticleProtectCompleteTest.php
@@ -36,6 +36,19 @@ class ArticleProtectCompleteTest extends \PHPUnit_Framework_TestCase {
 			->disableOriginalConstructor()
 			->getMockForAbstractClass();
 
+		$idTable = $this->getMockBuilder( '\stdClass' )
+			->setMethods( [ 'exists', 'findAssociatedRev' ] )
+			->getMock();
+
+		$store = $this->getMockBuilder( '\SMW\SQLStore\SQLStore' )
+			->disableOriginalConstructor()
+			->setMethods( [ 'getObjectIds' ] )
+			->getMock();
+
+		$store->expects( $this->any() )
+			->method( 'getObjectIds' )
+			->will( $this->returnValue( $idTable ) );
+
 		$this->testEnvironment->registerObject( 'Store', $store );
 	}
 

--- a/tests/phpunit/Unit/MediaWiki/Hooks/FileUploadTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Hooks/FileUploadTest.php
@@ -31,7 +31,7 @@ class FileUploadTest extends \PHPUnit_Framework_TestCase {
 		] );
 
 		$idTable = $this->getMockBuilder( '\stdClass' )
-			->setMethods( [ 'exists' ] )
+			->setMethods( [ 'exists', 'findAssociatedRev' ] )
 			->getMock();
 
 		$store = $this->getMockBuilder( '\SMW\SQLStore\SQLStore' )

--- a/tests/phpunit/Unit/MediaWiki/Hooks/LinksUpdateConstructedTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Hooks/LinksUpdateConstructedTest.php
@@ -32,7 +32,7 @@ class LinksUpdateConstructedTest extends \PHPUnit_Framework_TestCase {
 			->getMock();
 
 		$idTable = $this->getMockBuilder( '\stdClass' )
-			->setMethods( [ 'exists' ] )
+			->setMethods( [ 'exists', 'findAssociatedRev' ] )
 			->getMock();
 
 		$store = $this->getMockBuilder( '\SMW\SQLStore\SQLStore' )
@@ -90,12 +90,16 @@ class LinksUpdateConstructedTest extends \PHPUnit_Framework_TestCase {
 		$parserOutput->setTitleText( $title->getPrefixedText() );
 
 		$idTable = $this->getMockBuilder( '\stdClass' )
-			->setMethods( [ 'exists' ] )
+			->setMethods( [ 'exists', 'findAssociatedRev' ] )
 			->getMock();
 
 		$idTable->expects( $this->atLeastOnce() )
 			->method( 'exists' )
 			->will( $this->returnValue( true ) );
+
+		$idTable->expects( $this->atLeastOnce() )
+			->method( 'findAssociatedRev' )
+			->will( $this->returnValue( 42 ) );
 
 		$store = $this->getMockBuilder( '\SMW\SQLStore\SQLStore' )
 			->disableOriginalConstructor()

--- a/tests/phpunit/Unit/MediaWiki/HooksTest.php
+++ b/tests/phpunit/Unit/MediaWiki/HooksTest.php
@@ -821,7 +821,7 @@ class HooksTest extends \PHPUnit_Framework_TestCase {
 		$handler = 'LinksUpdateConstructed';
 
 		$idTable = $this->getMockBuilder( '\stdClass' )
-			->setMethods( [ 'exists' ] )
+			->setMethods( [ 'exists', 'findAssociatedRev' ] )
 			->getMock();
 
 		$store = $this->getMockBuilder( '\SMW\SQLStore\SQLStore' )

--- a/tests/phpunit/Unit/MediaWiki/Jobs/UpdateJobTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Jobs/UpdateJobTest.php
@@ -35,7 +35,7 @@ class UpdateJobTest extends \PHPUnit_Framework_TestCase {
 		] );
 
 		$idTable = $this->getMockBuilder( '\stdClass' )
-			->setMethods( [ 'exists' ] )
+			->setMethods( [ 'exists', 'findAssociatedRev' ] )
 			->getMock();
 
 		$store = $this->getMockBuilder( '\SMW\SQLStore\SQLStore' )
@@ -178,12 +178,16 @@ class UpdateJobTest extends \PHPUnit_Framework_TestCase {
 		$this->testEnvironment->registerObject( 'ContentParser', $contentParser );
 
 		$idTable = $this->getMockBuilder( '\stdClass' )
-			->setMethods( [ 'exists' ] )
+			->setMethods( [ 'exists', 'findAssociatedRev' ] )
 			->getMock();
 
 		$idTable->expects( $this->atLeastOnce() )
 			->method( 'exists' )
 			->will( $this->returnValue( true ) );
+
+		$idTable->expects( $this->atLeastOnce() )
+			->method( 'findAssociatedRev' )
+			->will( $this->returnValue( 42 ) );
 
 		$store = $this->getMockBuilder( '\SMW\SQLStore\SQLStore' )
 			->disableOriginalConstructor()
@@ -234,7 +238,7 @@ class UpdateJobTest extends \PHPUnit_Framework_TestCase {
 		$this->testEnvironment->registerObject( 'ContentParser', $contentParser );
 
 		$idTable = $this->getMockBuilder( '\stdClass' )
-			->setMethods( [ 'exists' ] )
+			->setMethods( [ 'exists', 'findAssociatedRev' ] )
 			->getMock();
 
 		$store = $this->getMockBuilder( '\SMW\SQLStore\SQLStore' )

--- a/tests/phpunit/Unit/ParserDataTest.php
+++ b/tests/phpunit/Unit/ParserDataTest.php
@@ -228,12 +228,16 @@ class ParserDataTest extends \PHPUnit_Framework_TestCase {
 	public function testUpdateStore() {
 
 		$idTable = $this->getMockBuilder( '\stdClass' )
-			->setMethods( [ 'exists' ] )
+			->setMethods( [ 'exists', 'findAssociatedRev' ] )
 			->getMock();
 
 		$idTable->expects( $this->any() )
 			->method( 'exists' )
 			->will( $this->returnValue( true ) );
+
+		$idTable->expects( $this->any() )
+			->method( 'findAssociatedRev' )
+			->will( $this->returnValue( 42 ) );
 
 		$store = $this->getMockBuilder( '\SMW\SQLStore\SQLStore' )
 			->disableOriginalConstructor()
@@ -261,11 +265,30 @@ class ParserDataTest extends \PHPUnit_Framework_TestCase {
 
 	public function testSkipUpdateOnMatchedMarker() {
 
+		$idTable = $this->getMockBuilder( '\stdClass' )
+			->setMethods( [ 'findAssociatedRev' ] )
+			->getMock();
+
+		$idTable->expects( $this->once() )
+			->method( 'findAssociatedRev' )
+			->will( $this->returnValue( 42 ) );
+
+		$store = $this->getMockBuilder( '\SMW\SQLStore\SQLStore' )
+			->disableOriginalConstructor()
+			->setMethods( [ 'getObjectIds' ] )
+			->getMock();
+
+		$store->expects( $this->any() )
+			->method( 'getObjectIds' )
+			->will( $this->returnValue( $idTable ) );
+
+		$this->testEnvironment->registerObject( 'Store', $store );
+
 		$title = $this->getMockBuilder( '\Title' )
 			->disableOriginalConstructor()
 			->getMock();
 
-		$title->expects( $this->once() )
+		$title->expects( $this->any() )
 			->method( 'getNamespace' )
 			->will( $this->returnValue( NS_MAIN ) );
 
@@ -277,27 +300,12 @@ class ParserDataTest extends \PHPUnit_Framework_TestCase {
 			->disableOriginalConstructor()
 			->getMock();
 
-		$cache = $this->getMockBuilder( '\Onoi\Cache\Cache' )
-			->disableOriginalConstructor()
-			->getMock();
-
-		$cache->expects( $this->once() )
-			->method( 'fetch' )
-			->with( $this->stringContains( ':smw:update:7fe0bc8114c23c928b25316e4858fceb' ) )
-			->will( $this->returnValue( 42 ) );
-
-		$cache->expects( $this->once() )
-			->method( 'save' )
-			->with( $this->stringContains( ':smw:update:7fe0bc8114c23c928b25316e4858fceb' ) );
-
 		$instance = new ParserData(
 			$title,
-			new ParserOutput(),
-			$cache
+			new ParserOutput()
 		);
 
 		$instance->setLogger( $logger );
-		$instance->markUpdate( 42 );
 
 		$this->assertFalse(
 			$instance->updateStore()


### PR DESCRIPTION
This PR is made in reference to: #2365, #3390

This PR addresses or contains:

- Since #3390 we have an associate revision field, so instead of using the cache to temporary store which update belongs to which revision (to avoid duplicates updates when refreshlinks runs `LinksUpdate` as `EnqueueableDataUpdate`, see #2365) use the `smw_rev` to probe whether the update is skippable or not due to SMW already knowing the revision.

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed
