### PR TITLE
[ES] Cache successful replication check requests, refs 3697, 3700

### DIFF
--- a/DefaultSettings.php
+++ b/DefaultSettings.php
@@ -2118,6 +2118,7 @@ return [
 			// possible discrepancy between the stored on-wiki data and the data
 			// replicated to Elasticsearch.
 			'monitor.entity.replication' => true,
+			'monitor.entity.replication.cache.lifetime' => 3660,
 		],
 		'query' => [
 

--- a/data/elastic/default-profile.json
+++ b/data/elastic/default-profile.json
@@ -17,7 +17,9 @@
 		"experimental.file.ingest": false,
 		"throw.exception.on.illegal.argument.error": true,
 		"job.recovery.retries": 5,
-		"job.file.ingest.retries": 3
+		"job.file.ingest.retries": 3,
+		"monitor.entity.replication": true,
+		"monitor.entity.replication.cache.lifetime": 3600,
 	},
 	"query": {
 		"fallback.no.connection": false,
@@ -36,6 +38,7 @@
 		"concept.terms.lookup": true,
 		"concept.terms.lookup.result.size.index.write.threshold": 10,
 		"concept.terms.lookup.cache.lifetime": 3600,
+		"cjk.best.effort.proximity.match": true,
 		"wide.proximity.as.match_phrase": true,
 		"wide.proximity.fields": [
 			"subject.title^8",

--- a/src/ApplicationFactory.php
+++ b/src/ApplicationFactory.php
@@ -321,6 +321,15 @@ class ApplicationFactory {
 	}
 
 	/**
+	 * @since 3.1
+	 *
+	 * @return EntityCache
+	 */
+	public function getEntityCache() {
+		return $this->containerBuilder->singleton( 'EntityCache' );
+	}
+
+	/**
 	 * @since 2.0
 	 *
 	 * @return InTextAnnotationParser

--- a/src/Elastic/Indexer/IndicatorProvider.php
+++ b/src/Elastic/Indexer/IndicatorProvider.php
@@ -6,6 +6,8 @@ use SMW\DIWikiPage;
 use SMW\Store;
 use SMW\Message;
 use SMW\MediaWiki\IndicatorProvider as IIndicatorProvider;
+use SMW\Elastic\Indexer\Replication\CheckReplicationTask;
+use SMW\EntityCache;
 use Html;
 use Title;
 
@@ -23,6 +25,11 @@ class IndicatorProvider implements IIndicatorProvider {
 	private $store;
 
 	/**
+	 * @var EntityCache
+	 */
+	private $entityCache;
+
+	/**
 	 * @var []
 	 */
 	private $indicators = [];
@@ -36,9 +43,11 @@ class IndicatorProvider implements IIndicatorProvider {
 	 * @since 3.1
 	 *
 	 * @param Store $store
+	 * @param EntityCache $entityCache
 	 */
-	public function __construct( Store $store ) {
+	public function __construct( Store $store, EntityCache $entityCache ) {
 		$this->store = $store;
+		$this->entityCache = $entityCache;
 	}
 
 	/**
@@ -94,6 +103,10 @@ class IndicatorProvider implements IIndicatorProvider {
 		$subject = DIWikiPage::newFromTitle(
 			$title
 		);
+
+		if ( $this->entityCache->fetch( CheckReplicationTask::makeCacheKey( $subject ) ) === 'success' ) {
+			return;
+		}
 
 		$dir = 'ltr';
 

--- a/src/EntityCache.php
+++ b/src/EntityCache.php
@@ -1,0 +1,193 @@
+<?php
+
+namespace SMW;
+
+use Onoi\Cache\Cache;
+use Title;
+
+/**
+ * @license GNU GPL v2+
+ * @since 3.1
+ *
+ * @author mwjames
+ */
+class EntityCache {
+
+	const CACHE_NAMESPACE = 'smw:entity';
+
+	const VERSION = 1;
+
+	/**
+	 * @var Cache
+	 */
+	private $cache = null;
+
+	/**
+	 * @since 3.1
+	 *
+	 * @param Cache $cache
+	 */
+	public function __construct( Cache $cache ) {
+		$this->cache = $cache;
+	}
+
+	/**
+	 * @since 3.1
+	 *
+	 * @param string|array $key
+	 *
+	 * @return string
+	 */
+	public static function makeCacheKey( ...$params ) {
+		return smwfCacheKey( self::CACHE_NAMESPACE, $params + [ 'version' => self::VERSION ] );
+	}
+
+	/**
+	 * @since 3.1
+	 *
+	 * @return []
+	 */
+	public function getStats() {
+		return $this->cache->getStats();
+	}
+
+	/**
+	 * @since 3.1
+	 *
+	 * @param string $key
+	 * @param mixed $value
+	 */
+	public function fetch( $key ) {
+		return $this->cache->fetch( $key );
+	}
+
+	/**
+	 * @since 3.1
+	 *
+	 * @param string $key
+	 * @param mixed $value
+	 */
+	public function fetchSub( $key, $sub ) {
+
+		$res = $this->cache->fetch( $key );
+		$sub = md5( $sub );
+
+		if ( !is_array( $res ) ) {
+			return false;
+		}
+
+		return isset( $res[$sub] ) ? $res[$sub] : false;
+	}
+
+	/**
+	 * @since 3.1
+	 *
+	 * @param string $key
+	 * @param mixed $value
+	 */
+	public function save( $key, $value = null, $ttl = 0 ) {
+		 $this->cache->save( $key, $value, $ttl );
+	}
+
+	/**
+	 * @since 3.1
+	 *
+	 * @param string $key
+	 * @param mixed $value
+	 */
+	public function saveSub( $key, $sub, $value = null, $ttl = 0 ) {
+
+		$res = $this->cache->fetch( $key );
+		$sub = md5( $sub );
+
+		if ( !is_array( $res ) ) {
+			$res = [];
+		}
+
+		$res[$sub] = $value;
+
+		$this->cache->save( $key, $res, $ttl );
+	}
+
+	/**
+	 * @since 3.1
+	 *
+	 * @param string $key
+	 */
+	public function delete( $key ) {
+		 $this->cache->delete( $key );
+	}
+
+	/**
+	 * Bind a cache key to a subject so that when a page gets flushed or
+	 * modified, any associate keys can be invalidated at once.
+	 *
+	 * @since 3.1
+	 *
+	 * @param DIWikiPage|Title $subject
+	 */
+	public function associate( $subject = null, $key ) {
+
+		if ( $subject === null ) {
+			return;
+		}
+
+		if ( $subject instanceof Title ) {
+			$subject = DIWikiPage::newFromTitle( $subject );
+		}
+
+		if ( !$subject instanceof DIWikiPage ) {
+			return;
+		}
+
+		$k = $this->makeCacheKey( $subject->getHash() );
+		$res = $this->cache->fetch( $k );
+
+		// Initialize the record that binds the "page" entity to all associated
+		// subkeys
+		if ( !isset( $res['__subject'] ) ) {
+			$res['__subject'] = $subject->getHash();
+		}
+
+		if ( !isset( $res['__assoc'] ) ) {
+			$res['__assoc'] = [];
+		}
+
+		$res['__assoc'][$key] = true;
+
+		// Store without expiry
+		$this->cache->save( $k, $res );
+	}
+
+	/**
+	 * @since 3.1
+	 *
+	 * @param DIWikiPage|Title $subject
+	 */
+	public function invalidate( $subject = null ) {
+
+		if ( $subject === null ) {
+			return;
+		}
+
+		if ( $subject instanceof Title ) {
+			$subject = DIWikiPage::newFromTitle( $subject );
+		}
+
+		if ( !$subject instanceof DIWikiPage ) {
+			return;
+		}
+
+		$k = $this->makeCacheKey( $subject->getHash() );
+		$res = $this->cache->fetch( $k );
+
+		if ( isset( $res['__assoc'] ) ) {
+			foreach ( $res['__assoc'] as $key => $bool ) {
+				$this->cache->delete( $key );
+			}
+		}
+
+		$this->cache->delete( $k );
+	}
+
+}

--- a/src/EventListenerRegistry.php
+++ b/src/EventListenerRegistry.php
@@ -48,6 +48,15 @@ class EventListenerRegistry implements EventListenerCollection {
 		);
 
 		$this->eventListenerCollection->registerListener( 'InvalidateResultCache', $invalidateResultCacheEventListener );
+
+		$invalidateEntityCacheEventListener = $applicationFactory->create( 'InvalidateEntityCacheEventListener' );
+
+		$invalidateEntityCacheEventListener->setLogger(
+			$applicationFactory->getMediaWikiLogger()
+		);
+
+		$this->eventListenerCollection->registerListener( 'InvalidateEntityCache', $invalidateEntityCacheEventListener );
+
 		$this->addListenersToCollection();
 
 		return $this->eventListenerCollection->getCollection();

--- a/src/Events/InvalidateEntityCacheEventListener.php
+++ b/src/Events/InvalidateEntityCacheEventListener.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace SMW\Events;
+
+use Onoi\EventDispatcher\EventListener;
+use Onoi\EventDispatcher\DispatchContext;
+use SMW\EntityCache;
+use Psr\Log\LoggerAwareTrait;
+
+/**
+ * @license GNU GPL v2+
+ * @since 3.1
+ *
+ * @author mwjames
+ */
+class InvalidateEntityCacheEventListener implements EventListener {
+
+	use LoggerAwareTrait;
+
+	/**
+	 * @var EntityCache
+	 */
+	private $entityCache;
+
+	/**
+	 * @since 3.1
+	 */
+	public function __construct( EntityCache $entityCache ) {
+		$this->entityCache = $entityCache;
+	}
+
+	/**
+	 * @since 3.1
+	 *
+	 * {@inheritDoc}
+	 */
+	public function execute( DispatchContext $dispatchContext = null ) {
+
+		$title = $dispatchContext->get( 'title' );
+		$context = $dispatchContext->get( 'context' );
+
+		$this->entityCache->invalidate( $title );
+		$subject = $title->getPrefixedDBKey();
+
+		$this->logger->info(
+			[ 'Event', 'InvalidateEntityCache', "{caused_by}", "{subject}" ],
+			[ 'role' => 'user', 'caused_by' => $context, 'subject' => $subject ]
+		);
+	}
+
+	/**
+	 * @since 3.1
+	 *
+	 * {@inheritDoc}
+	 */
+	public function isPropagationStopped() {
+		return false;
+	}
+
+}

--- a/src/MediaWiki/Hooks.php
+++ b/src/MediaWiki/Hooks.php
@@ -486,7 +486,8 @@ class Hooks {
 	 */
 	public function onNewRevisionFromEditComplete( $wikiPage, $revision, $baseId, $user ) {
 
-		$mwCollaboratorFactory = ApplicationFactory::getInstance()->newMwCollaboratorFactory();
+		$applicationFactory = ApplicationFactory::getInstance();
+		$mwCollaboratorFactory = $applicationFactory->newMwCollaboratorFactory();
 
 		$editInfoProvider = $mwCollaboratorFactory->newEditInfoProvider(
 			$wikiPage,
@@ -504,6 +505,10 @@ class Hooks {
 			$wikiPage->getTitle(),
 			$editInfoProvider,
 			$pageInfoProvider
+		);
+
+		$newRevisionFromEditComplete->setEventDispatcher(
+			$applicationFactory->getEventDispatcher()
 		);
 
 		return $newRevisionFromEditComplete->process();
@@ -604,12 +609,18 @@ class Hooks {
 	 */
 	public function onTitleMoveComplete( $oldTitle, $newTitle, $user, $oldId, $newId ) {
 
+		$applicationFactory = ApplicationFactory::getInstance();
+
 		$titleMoveComplete = new TitleMoveComplete(
 			$oldTitle,
 			$newTitle,
 			$user,
 			$oldId,
 			$newId
+		);
+
+		$titleMoveComplete->setEventDispatcher(
+			$applicationFactory->getEventDispatcher()
 		);
 
 		return $titleMoveComplete->process();
@@ -622,7 +633,12 @@ class Hooks {
 	 */
 	public function onArticlePurge( &$wikiPage ) {
 
+		$applicationFactory = ApplicationFactory::getInstance();
 		$articlePurge = new ArticlePurge();
+
+		$articlePurge->setEventDispatcher(
+			$applicationFactory->getEventDispatcher()
+		);
 
 		return $articlePurge->process( $wikiPage );
 	}
@@ -643,6 +659,10 @@ class Hooks {
 
 		$articleDelete->setLogger(
 			$applicationFactory->getMediaWikiLogger()
+		);
+
+		$articleDelete->setEventDispatcher(
+			$applicationFactory->getEventDispatcher()
 		);
 
 		$articleDelete->setOptions(

--- a/src/MediaWiki/Hooks/ArticleDelete.php
+++ b/src/MediaWiki/Hooks/ArticleDelete.php
@@ -2,6 +2,7 @@
 
 namespace SMW\MediaWiki\Hooks;
 
+use Onoi\EventDispatcher\EventDispatcherAwareTrait;
 use SMW\ApplicationFactory;
 use SMW\DIWikiPage;
 use SMW\EventHandler;
@@ -20,6 +21,8 @@ use Wikipage;
  * @author mwjames
  */
 class ArticleDelete extends HookHandler {
+
+	use EventDispatcherAwareTrait;
 
 	/**
 	 * @var
@@ -122,6 +125,13 @@ class ArticleDelete extends HookHandler {
 			'cached.update.marker.delete',
 			$dispatchContext
 		);
+
+		$context = [
+			'context' => 'ArticleDelete',
+			'title' => $title
+		];
+
+		$this->eventDispatcher->dispatch( 'InvalidateEntityCache', $context );
 	}
 
 }

--- a/src/MediaWiki/Hooks/NewRevisionFromEditComplete.php
+++ b/src/MediaWiki/Hooks/NewRevisionFromEditComplete.php
@@ -2,6 +2,7 @@
 
 namespace SMW\MediaWiki\Hooks;
 
+use Onoi\EventDispatcher\EventDispatcherAwareTrait;
 use ParserOutput;
 use SMW\ApplicationFactory;
 use SMW\EventHandler;
@@ -27,6 +28,8 @@ use Title;
  * @author mwjames
  */
 class NewRevisionFromEditComplete extends HookHandler {
+
+	use EventDispatcherAwareTrait;
 
 	/**
 	 * @var Title
@@ -112,6 +115,13 @@ class NewRevisionFromEditComplete extends HookHandler {
 		}
 
 		$parserData->pushSemanticDataToParserOutput();
+
+		$context = [
+			'context' => 'NewRevisionFromEditComplete',
+			'title' => $this->title
+		];
+
+		$this->eventDispatcher->dispatch( 'InvalidateEntityCache', $context );
 
 		return true;
 	}

--- a/src/MediaWiki/Hooks/TitleMoveComplete.php
+++ b/src/MediaWiki/Hooks/TitleMoveComplete.php
@@ -2,6 +2,7 @@
 
 namespace SMW\MediaWiki\Hooks;
 
+use Onoi\EventDispatcher\EventDispatcherAwareTrait;
 use SMW\ApplicationFactory;
 use SMW\EventHandler;
 use SMW\Factbox\FactboxCache;
@@ -21,6 +22,8 @@ use SMW\Factbox\FactboxCache;
  * @author mwjames
  */
 class TitleMoveComplete {
+
+	use EventDispatcherAwareTrait;
 
 	/**
 	 * @var Title
@@ -113,6 +116,13 @@ class TitleMoveComplete {
 			'cached.prefetcher.reset',
 			$dispatchContext
 		);
+
+		$context = [
+			'context' => 'TitleMoveComplete'
+		];
+
+		$this->eventDispatcher->dispatch( 'InvalidateEntityCache', $context + [ 'title' => $this->oldTitle ] );
+		$this->eventDispatcher->dispatch( 'InvalidateEntityCache', $context + [ 'title' => $this->newTitle ] );
 
 		return true;
 	}

--- a/src/MediaWiki/Jobs/UpdateJob.php
+++ b/src/MediaWiki/Jobs/UpdateJob.php
@@ -237,6 +237,7 @@ class UpdateJob extends Job {
 		);
 
 		$eventHandler = EventHandler::getInstance();
+		$eventDispatcher = $eventHandler->getEventDispatcher();
 
 		$dispatchContext = $eventHandler->newDispatchContext();
 		$dispatchContext->set( 'title', $this->getTitle() );
@@ -250,6 +251,8 @@ class UpdateJob extends Job {
 			'cached.propertyvalues.prefetcher.reset',
 			$dispatchContext
 		);
+
+		$eventDispatcher->dispatch( 'InvalidateEntityCache', [ 'context' => 'UpdateJob', 'title' => $this->getTitle() ] );
 
 		// TODO
 		// Rebuild the factbox

--- a/src/SQLStore/PropertyTableIdReferenceDisposer.php
+++ b/src/SQLStore/PropertyTableIdReferenceDisposer.php
@@ -263,19 +263,30 @@ class PropertyTableIdReferenceDisposer {
 		}
 
 		$eventHandler = EventHandler::getInstance();
+		$eventDispatcher = $eventHandler->getEventDispatcher();
 
 		$dispatchContext = $eventHandler->newDispatchContext();
 		$dispatchContext->set( 'subject', $subject );
 		$dispatchContext->set( 'context', 'PropertyTableIdReferenceDisposal' );
 
-		$eventHandler->getEventDispatcher()->dispatch(
+		$eventDispatcher->dispatch(
 			'cached.prefetcher.reset',
 			$dispatchContext
 		);
 
-		$eventHandler->getEventDispatcher()->dispatch(
+		$eventDispatcher->dispatch(
 			'factbox.cache.delete',
 			$dispatchContext
+		);
+
+		$context = [
+			'context' => 'PropertyTableIdReferenceDisposal',
+			'title' => $subject->getTitle()
+		];
+
+		$eventDispatcher->dispatch(
+			'InvalidateEntityCache',
+			$context
 		);
 	}
 

--- a/src/Services/SharedServicesContainer.php
+++ b/src/Services/SharedServicesContainer.php
@@ -54,6 +54,7 @@ use SMW\QueryFactory;
 use SMW\Query\Processor\QueryCreator;
 use SMW\Query\Processor\ParamListProcessor;
 use SMW\MediaWiki\IndicatorRegistry;
+use SMW\EntityCache;
 
 /**
  * @license GNU GPL v2+
@@ -198,6 +199,11 @@ class SharedServicesContainer implements CallbackContainer {
 		$containerBuilder->registerCallback( 'PageUpdater', function( $containerBuilder, $connection, TransactionalCallableUpdate $transactionalCallableUpdate = null ) {
 			$containerBuilder->registerExpectedReturnType( 'PageUpdater', '\SMW\MediaWiki\PageUpdater' );
 			return new PageUpdater( $connection, $transactionalCallableUpdate );
+		} );
+
+		$containerBuilder->registerCallback( 'EntityCache', function( $containerBuilder ) {
+			$containerBuilder->registerExpectedReturnType( 'EntityCache', '\SMW\EntityCache' );
+			return new EntityCache( $containerBuilder->singleton( 'Cache' ) );
 		} );
 
 		/**

--- a/src/Services/events.php
+++ b/src/Services/events.php
@@ -3,6 +3,7 @@
 namespace SMW\Services;
 
 use SMW\Events\InvalidateResultCacheEventListener;
+use SMW\Events\InvalidateEntityCacheEventListener;
 
 /**
  * @codeCoverageIgnore
@@ -29,6 +30,20 @@ return [
 		);
 
 		return $invalidateResultCacheEventListener;
+	},
+
+	/**
+	 * InvalidateEntityCacheEventListener
+	 *
+	 * @return callable
+	 */
+	'InvalidateEntityCacheEventListener' => function( $containerBuilder ) {
+
+		$invalidateEntityCacheEventListener = new InvalidateEntityCacheEventListener(
+			$containerBuilder->singleton( 'EntityCache' )
+		);
+
+		return $invalidateEntityCacheEventListener;
 	}
 
 ];

--- a/tests/phpunit/Unit/Elastic/Indexer/IndicatorProviderTest.php
+++ b/tests/phpunit/Unit/Elastic/Indexer/IndicatorProviderTest.php
@@ -19,19 +19,24 @@ class IndicatorProviderTest extends \PHPUnit_Framework_TestCase {
 	use PHPUnitCompat;
 
 	private $store;
+	private $entityCache;
 
 	protected function setUp() {
 
 		$this->store = $this->getMockBuilder( '\SMW\Store' )
 			->disableOriginalConstructor()
 			->getMockForAbstractClass();
+
+		$this->entityCache = $this->getMockBuilder( '\SMW\EntityCache' )
+			->disableOriginalConstructor()
+			->getMock();
 	}
 
 	public function testCanConstruct() {
 
 		$this->assertInstanceOf(
 			IndicatorProvider::class,
-			new IndicatorProvider( $this->store )
+			new IndicatorProvider( $this->store, $this->entityCache )
 		);
 	}
 
@@ -54,7 +59,8 @@ class IndicatorProviderTest extends \PHPUnit_Framework_TestCase {
 			->will( $this->returnValue( NS_MAIN ) );
 
 		$instance = new IndicatorProvider(
-			$this->store
+			$this->store,
+			$this->entityCache
 		);
 
 		$instance->canCheckReplication( true );
@@ -85,7 +91,8 @@ class IndicatorProviderTest extends \PHPUnit_Framework_TestCase {
 			->will( $this->returnValue( false ) );
 
 		$instance = new IndicatorProvider(
-			$this->store
+			$this->store,
+			$this->entityCache
 		);
 
 		$instance->canCheckReplication( true );

--- a/tests/phpunit/Unit/Elastic/Indexer/Replication/CheckReplicationTaskTest.php
+++ b/tests/phpunit/Unit/Elastic/Indexer/Replication/CheckReplicationTaskTest.php
@@ -21,6 +21,7 @@ class CheckReplicationTaskTest extends \PHPUnit_Framework_TestCase {
 
 	private $store;
 	private $replicationStatus;
+	private $entityCache;
 
 	protected function setUp() {
 
@@ -40,13 +41,17 @@ class CheckReplicationTaskTest extends \PHPUnit_Framework_TestCase {
 		$this->replicationStatus = $this->getMockBuilder( '\SMW\Elastic\Indexer\Replication\ReplicationStatus' )
 			->disableOriginalConstructor()
 			->getMock();
+
+		$this->entityCache = $this->getMockBuilder( '\SMW\EntityCache' )
+			->disableOriginalConstructor()
+			->getMock();
 	}
 
 	public function testCanConstruct() {
 
 		$this->assertInstanceOf(
 			CheckReplicationTask::class,
-			new CheckReplicationTask( $this->store, $this->replicationStatus )
+			new CheckReplicationTask( $this->store, $this->replicationStatus, $this->entityCache )
 		);
 	}
 
@@ -62,7 +67,8 @@ class CheckReplicationTaskTest extends \PHPUnit_Framework_TestCase {
 
 		$instance = new CheckReplicationTask(
 			$this->store,
-			$this->replicationStatus
+			$this->replicationStatus,
+			$this->entityCache
 		);
 
 		$html = $instance->checkReplication( DIWikiPage::newFromText( 'Foo' ), [] );

--- a/tests/phpunit/Unit/EntityCacheTest.php
+++ b/tests/phpunit/Unit/EntityCacheTest.php
@@ -1,0 +1,201 @@
+<?php
+
+namespace SMW\Tests;
+
+use SMW\EntityCache;
+use SMW\DIWikiPage;
+
+/**
+ * @covers \SMW\EntityCache
+ * @group semantic-mediawiki
+ *
+ * @license GNU GPL v2+
+ * @since 3.1
+ *
+ * @author mwjames
+ */
+class EntityCacheTest extends \PHPUnit_Framework_TestCase {
+
+	private $cache;
+
+	protected function setUp() {
+
+		$this->cache = $this->getMockBuilder( '\Onoi\Cache\Cache' )
+			->disableOriginalConstructor()
+			->getMockForAbstractClass();
+	}
+
+	public function testCanConstruct() {
+
+		$this->assertInstanceOf(
+			EntityCache::class,
+			new EntityCache( $this->cache )
+		);
+	}
+
+	public function testMakeCacheKey() {
+
+		$instance = new EntityCache(
+			$this->cache
+		);
+
+		$this->assertContains(
+			EntityCache::CACHE_NAMESPACE,
+			$instance->makeCacheKey( 'Foo' )
+		);
+	}
+
+	public function testFetch() {
+
+		$this->cache->expects( $this->once() )
+			->method( 'fetch' )
+			->with( $this->equalTo( 'Foo' ) )
+			->will( $this->returnValue( 'bar' ) );
+
+		$instance = new EntityCache(
+			$this->cache
+		);
+
+		$instance->fetch( 'Foo' );
+	}
+
+	public function testSave() {
+
+		$this->cache->expects( $this->once() )
+			->method( 'save' )
+			->with(
+				$this->equalTo( 'Foo' ),
+				$this->equalTo( 'bar' ) );
+
+		$instance = new EntityCache(
+			$this->cache
+		);
+
+		$instance->save( 'Foo', 'bar' );
+	}
+
+	public function testDelete() {
+
+		$this->cache->expects( $this->once() )
+			->method( 'delete' )
+			->with( $this->equalTo( 'Foo' ) );
+
+		$instance = new EntityCache(
+			$this->cache
+		);
+
+		$instance->delete( 'Foo' );
+	}
+
+	public function testFetchSub() {
+
+		$this->cache->expects( $this->once() )
+			->method( 'fetch' )
+			->with( $this->equalTo( 'Foo' ) )
+			->will( $this->returnValue( [ md5( 'bar' ) => 'Foobar' ] ) );
+
+		$instance = new EntityCache(
+			$this->cache
+		);
+
+		$this->assertEquals(
+			'Foobar',
+			$instance->fetchSub( 'Foo', 'bar' )
+		);
+	}
+
+	public function tesSaveSub() {
+
+		$this->cache->expects( $this->once() )
+			->method( 'fetch' )
+			->with( $this->equalTo( 'Foo' ) )
+			->will( $this->returnValue( [ md5( 'bar' ) => 'Foobar' ] ) );
+
+		$this->cache->expects( $this->once() )
+			->method( 'save' )
+			->with(
+				$this->equalTo( 'Foo' ),
+				$this->equalTo( [ md5( 'bar' ) => '123' ] ) );
+
+		$instance = new EntityCache(
+			$this->cache
+		);
+
+		$instance->saveSub( 'Foo', 'bar', '123' );
+	}
+
+	public function testAssociate() {
+
+		$subject = DIWikiPage::newFromText( 'Foo' );
+
+		$expected = [
+			md5( 'bar' ) => 'Foobar',
+			'__assoc' => [ 'Foo' => true ],
+			'__subject' => $subject->getHash()
+		];
+
+		$this->cache->expects( $this->once() )
+			->method( 'fetch' )
+			->will( $this->returnValue( [ md5( 'bar' ) => 'Foobar' ] ) );
+
+		$this->cache->expects( $this->once() )
+			->method( 'save' )
+			->with(
+				$this->stringContains( 'smw:entity:44ab375ee7ebac04b8e4471a70180dc5' ),
+				$this->equalTo( $expected ) );
+
+		$instance = new EntityCache(
+			$this->cache
+		);
+
+		$instance->associate( $subject, 'Foo' );
+	}
+
+	public function testAssociate_NoValidSubject() {
+
+		$this->cache->expects( $this->never() )
+			->method( 'fetch' );
+
+		$instance = new EntityCache(
+			$this->cache
+		);
+
+		$instance->associate( 'notASubject', 'Foo' );
+	}
+
+	public function testInvalidate() {
+
+		$subject = DIWikiPage::newFromText( 'Foo' );
+
+		$this->cache->expects( $this->once() )
+			->method( 'fetch' )
+			->will( $this->returnValue( [ md5( 'bar' ) => 'Foobar', '__assoc' => [ 'Foo' => true ] ] ) );
+
+		$this->cache->expects( $this->at( 1 ) )
+			->method( 'delete' )
+			->with(	$this->stringContains( 'Foo' ) );
+
+		$this->cache->expects( $this->at( 2 ) )
+			->method( 'delete' )
+			->with(	$this->stringContains( 'smw:entity:44ab375ee7ebac04b8e4471a70180dc5' ) );
+
+		$instance = new EntityCache(
+			$this->cache
+		);
+
+		$instance->invalidate( $subject );
+	}
+
+	public function testInvalidate_NoValidSubject() {
+
+		$this->cache->expects( $this->never() )
+			->method( 'fetch' );
+
+		$instance = new EntityCache(
+			$this->cache
+		);
+
+		$instance->invalidate( 'notASubject' );
+	}
+
+}

--- a/tests/phpunit/Unit/MediaWiki/Hooks/ArticleDeleteTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Hooks/ArticleDeleteTest.php
@@ -20,6 +20,7 @@ class ArticleDeleteTest extends \PHPUnit_Framework_TestCase {
 
 	private $testEnvironment;
 	private $jobFactory;
+	private $eventDispatcher;
 
 	protected function setUp() {
 		parent::setUp();
@@ -41,6 +42,10 @@ class ArticleDeleteTest extends \PHPUnit_Framework_TestCase {
 
 		$this->testEnvironment->registerObject( 'JobFactory', $this->jobFactory );
 		$this->testEnvironment->registerObject( 'JobQueue', $jobQueue );
+
+		$this->eventDispatcher = $this->getMockBuilder( '\Onoi\EventDispatcher\EventDispatcher' )
+			->disableOriginalConstructor()
+			->getMock();
 	}
 
 	protected function tearDown() {
@@ -101,8 +106,16 @@ class ArticleDeleteTest extends \PHPUnit_Framework_TestCase {
 			->method( 'getTitle' )
 			->will( $this->returnValue( $subject->getTitle() ) );
 
+		$this->eventDispatcher->expects( $this->atLeastOnce() )
+			->method( 'dispatch' )
+			->with( $this->equalTo( 'InvalidateEntityCache' ) );
+
 		$instance = new ArticleDelete(
 			$store
+		);
+
+		$instance->setEventDispatcher(
+			$this->eventDispatcher
 		);
 
 		$this->assertTrue(

--- a/tests/phpunit/Unit/MediaWiki/Hooks/NewRevisionFromEditCompleteTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Hooks/NewRevisionFromEditCompleteTest.php
@@ -23,6 +23,7 @@ class NewRevisionFromEditCompleteTest extends \PHPUnit_Framework_TestCase {
 
 	private $semanticDataValidator;
 	private $testEnvironment;
+	private $eventDispatcher;
 
 	protected function setUp() {
 		parent::setUp();
@@ -36,6 +37,10 @@ class NewRevisionFromEditCompleteTest extends \PHPUnit_Framework_TestCase {
 			->getMockForAbstractClass();
 
 		$this->testEnvironment->registerObject( 'Store', $store );
+
+		$this->eventDispatcher = $this->getMockBuilder( '\Onoi\EventDispatcher\EventDispatcher' )
+			->disableOriginalConstructor()
+			->getMock();
 	}
 
 	protected function tearDown() {
@@ -68,12 +73,20 @@ class NewRevisionFromEditCompleteTest extends \PHPUnit_Framework_TestCase {
 	 */
 	public function testProcess( $settings, $title, $editInfoProvider, $pageInfoProvider, $expected ) {
 
+		$this->eventDispatcher->expects( $expected ? $this->atLeastOnce() : $this->never() )
+			->method( 'dispatch' )
+			->with( $this->equalTo( 'InvalidateEntityCache' ) );
+
 		$this->testEnvironment->withConfiguration( $settings );
 
 		$instance = new NewRevisionFromEditComplete(
 			$title,
 			$editInfoProvider,
 			$pageInfoProvider
+		);
+
+		$instance->setEventDispatcher(
+			$this->eventDispatcher
 		);
 
 		$this->assertTrue(

--- a/tests/phpunit/Unit/MediaWiki/Hooks/TitleMoveCompleteTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Hooks/TitleMoveCompleteTest.php
@@ -20,6 +20,7 @@ class TitleMoveCompleteTest extends \PHPUnit_Framework_TestCase {
 
 	private $user;
 	private $testEnvironment;
+	private $eventDispatcher;
 
 	protected function setUp() {
 		parent::setUp();
@@ -36,6 +37,10 @@ class TitleMoveCompleteTest extends \PHPUnit_Framework_TestCase {
 		$this->testEnvironment->withConfiguration(
 			$settings
 		);
+
+		$this->eventDispatcher = $this->getMockBuilder( '\Onoi\EventDispatcher\EventDispatcher' )
+			->disableOriginalConstructor()
+			->getMock();
 	}
 
 	protected function tearDown() {
@@ -64,6 +69,10 @@ class TitleMoveCompleteTest extends \PHPUnit_Framework_TestCase {
 
 	public function testChangeSubjectForSupportedSemanticNamespace() {
 
+		$this->eventDispatcher->expects( $this->atLeastOnce() )
+			->method( 'dispatch' )
+			->with( $this->equalTo( 'InvalidateEntityCache' ) );
+
 		$oldTitle = \Title::newFromText( 'Old' );
 		$newTitle = \Title::newFromText( 'New' );
 
@@ -84,12 +93,20 @@ class TitleMoveCompleteTest extends \PHPUnit_Framework_TestCase {
 			0
 		);
 
+		$instance->setEventDispatcher(
+			$this->eventDispatcher
+		);
+
 		$this->assertTrue(
 			$instance->process()
 		);
 	}
 
 	public function testDeleteSubjectForNotSupportedSemanticNamespace() {
+
+		$this->eventDispatcher->expects( $this->atLeastOnce() )
+			->method( 'dispatch' )
+			->with( $this->equalTo( 'InvalidateEntityCache' ) );
 
 		$oldTitle = \Title::newFromText( 'Old' );
 		$newTitle = \Title::newFromText( 'New', NS_HELP );
@@ -111,6 +128,10 @@ class TitleMoveCompleteTest extends \PHPUnit_Framework_TestCase {
 			$this->user,
 			0,
 			0
+		);
+
+		$instance->setEventDispatcher(
+			$this->eventDispatcher
 		);
 
 		$this->assertTrue(


### PR DESCRIPTION
This PR is made in reference to: #3697, #3700

This PR addresses or contains:

- #3697 introduced active monitoring about the replication status between SMW and ES and to reduce the amount of API request made to check on individual entities, once a check was successful keep a cache tracker with a TTL of (`monitor.entity.replication.cache.lifetime`, by default 1h)
- If an entity (== page) is purged, deleted, edited, or otherwise updated the `InvalidateEntityCache` event will be emitted and the tracker is removed so that on the next page view request the replication check is executed again.

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed

Fixes #