### PR TITLE
Check if ID exists before DB `update` during page move, refs 3636

### DIFF
--- a/src/SQLStore/EntityStore/IdChanger.php
+++ b/src/SQLStore/EntityStore/IdChanger.php
@@ -163,6 +163,18 @@ class IdChanger {
 		foreach ( $this->store->getPropertyTables() as $proptable ) {
 
 			if ( $s_data && $proptable->usesIdSubject() ) {
+
+				$row = $connection->selectRow(
+					$proptable->getName(),
+					[ 's_id' ],
+					[ 's_id' => $old_id ],
+					__METHOD__
+				);
+
+				if ( $row === false ) {
+					continue;
+				}
+
 				$connection->update(
 					$proptable->getName(),
 					[ 's_id' => $new_id ],
@@ -190,14 +202,28 @@ class IdChanger {
 				}
 
 				foreach ( $proptable->getFields( $this->store ) as $fieldName => $fieldType ) {
-					if ( $fieldType === FieldType::FIELD_ID ) {
-						$connection->update(
-							$proptable->getName(),
-							[ $fieldName => $new_id ],
-							[ $fieldName => $old_id ],
-							__METHOD__
-						);
+
+					if ( $fieldType !== FieldType::FIELD_ID ) {
+						continue;
 					}
+
+					$row = $connection->selectRow(
+						$proptable->getName(),
+						[ $fieldName ],
+						[ $fieldName => $old_id ],
+						__METHOD__
+					);
+
+					if ( $row === false ) {
+						continue;
+					}
+
+					$connection->update(
+						$proptable->getName(),
+						[ $fieldName => $new_id ],
+						[ $fieldName => $old_id ],
+						__METHOD__
+					);
 				}
 			}
 		}

--- a/tests/phpunit/Unit/SQLStore/EntityStore/IdChangerTest.php
+++ b/tests/phpunit/Unit/SQLStore/EntityStore/IdChangerTest.php
@@ -211,20 +211,28 @@ class IdChangerTest extends \PHPUnit_Framework_TestCase {
 			->will( $this->onConsecutiveCalls( [ $table ] ) );
 
 		$this->connection->expects( $this->at( 0 ) )
+			->method( 'selectRow' )
+			->with(
+				$this->anything(),
+				$this->anything(),
+				$this->equalTo( [ 's_id' => 42 ] ) )
+			->will( $this->returnValue( true ) );
+
+		$this->connection->expects( $this->at( 1 ) )
 			->method( 'update' )
 			->with(
 				$this->anything(),
 				$this->equalTo( [ 's_id' => 1001 ] ),
 				$this->equalTo( [ 's_id' => 42 ] ) );
 
-		$this->connection->expects( $this->at( 1 ) )
+		$this->connection->expects( $this->at( 2 ) )
 			->method( 'update' )
 			->with(
 				$this->anything(),
 				$this->equalTo( [ 'p_id' => 1001 ] ),
 				$this->equalTo( [ 'p_id' => 42 ] ) );
 
-		$this->connection->expects( $this->at( 2 ) )
+		$this->connection->expects( $this->at( 4 ) )
 			->method( 'update' )
 			->with(
 				$this->anything(),
@@ -261,19 +269,27 @@ class IdChangerTest extends \PHPUnit_Framework_TestCase {
 			->will( $this->onConsecutiveCalls( [ $table ] ) );
 
 		$this->connection->expects( $this->at( 0 ) )
+			->method( 'selectRow' )
+			->with(
+				$this->anything(),
+				$this->anything(),
+				$this->equalTo( [ 's_id' => 42 ] ) )
+			->will( $this->returnValue( true ) );
+
+		$this->connection->expects( $this->at( 1 ) )
 			->method( 'update' )
 			->with(
 				$this->anything(),
 				$this->equalTo( [ 's_id' => 1001 ] ),
 				$this->equalTo( [ 's_id' => 42 ] ) );
 
-		$this->connection->expects( $this->at( 1 ) )
+		$this->connection->expects( $this->at( 2 ) )
 			->method( 'delete' )
 			->with(
 				$this->anything(),
 				$this->equalTo( [ 'p_id' => 42 ] ) );
 
-		$this->connection->expects( $this->at( 2 ) )
+		$this->connection->expects( $this->at( 4 ) )
 			->method( 'update' )
 			->with(
 				$this->anything(),
@@ -310,16 +326,18 @@ class IdChangerTest extends \PHPUnit_Framework_TestCase {
 			->will( $this->onConsecutiveCalls( [ $table ] ) );
 
 		$this->connection->expects( $this->at( 0 ) )
+			->method( 'selectRow' )
+			->with(
+				$this->anything(),
+				$this->anything(),
+				$this->equalTo( [ 's_id' => 42 ] ) )
+			->will( $this->returnValue( true ) );
+
+		$this->connection->expects( $this->at( 1 ) )
 			->method( 'update' )
 			->with(
 				$this->anything(),
 				$this->equalTo( [ 's_id' => 1001 ] ),
-				$this->equalTo( [ 's_id' => 42 ] ) );
-
-		$this->connection->expects( $this->at( 1 ) )
-			->method( 'delete' )
-			->with(
-				$this->anything(),
 				$this->equalTo( [ 's_id' => 42 ] ) );
 
 		$this->connection->expects( $this->at( 2 ) )
@@ -329,6 +347,12 @@ class IdChangerTest extends \PHPUnit_Framework_TestCase {
 				$this->equalTo( [ 's_id' => 42 ] ) );
 
 		$this->connection->expects( $this->at( 3 ) )
+			->method( 'delete' )
+			->with(
+				$this->anything(),
+				$this->equalTo( [ 's_id' => 42 ] ) );
+
+		$this->connection->expects( $this->at( 4 ) )
 			->method( 'update' )
 			->with(
 				$this->anything(),


### PR DESCRIPTION
This PR is made in reference to: #3636

This PR addresses or contains:

- When moving a page the method does arbitrary updates to all property tables (and may cause sub-optimal transactions) therefore before `Database::update` check whether the selected table has an actual row with the subjected ID or not

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed

## Stack 

```
[DBPerformance] Sub-optimal transaction on DB(s) [localhost (mwmasterpg2-mediawiki-) (TRX#49b970)]: 
0	0.001382	query-m: DELETE FROM 'X' WHERE (s_id='X'))) [TRX#49b970]
1	0.000821	query-m: DELETE FROM 'X' WHERE (s_id='X'))) [TRX#49b970]
2	0.001888	query-m: DELETE FROM 'X' WHERE (s_id='X'))) [TRX#49b970]
3	0.004003	query-m: UPDATE 'X' SET smw_touched = 'X')  [TRX#49b970]
4	0.001326	query-m: UPDATE 'X' SET smw_proptable_hash = 'X' [TRX#49b970]
5	0.001224	query-m: UPDATE 'X' SET usage_count = usage_count - 'X' [TRX#49b970]
6	0.001053	query-m: UPDATE 'X' SET usage_count = usage_count - 'X' [TRX#49b970]
7	0.001299	query-m: UPDATE 'X' SET usage_count = usage_count - 'X' [TRX#49b970]
8	0.000999	query-m: UPDATE 'X' SET usage_count = usage_count - 'X' [TRX#49b970]
9	0.099622	query-m: UPDATE 'X' SET s_id = 'X' [TRX#49b970]
10	0.084472	query-m: UPDATE 'X' SET s_id = 'X' [TRX#49b970]
11	0.047926	query-m: UPDATE 'X' SET s_id = 'X' [TRX#49b970]
12	0.144806	query-m: UPDATE 'X' SET s_id = 'X' [TRX#49b970]
13	0.119754	query-m: UPDATE 'X' SET s_id = 'X' [TRX#49b970]
14	0.022718	query-m: UPDATE 'X' SET s_id = 'X' [TRX#49b970]
15	0.000785	query-m: UPDATE 'X' SET s_id = 'X' [TRX#49b970]
16	0.057911	query-m: UPDATE 'X' SET s_id = 'X' [TRX#49b970]
17	0.054880	query-m: UPDATE 'X' SET s_id = 'X' [TRX#49b970]
18	0.000801	query-m: UPDATE 'X' SET s_id = 'X' [TRX#49b970]
19	0.087053	query-m: UPDATE 'X' SET s_id = 'X' [TRX#49b970]
20	0.098002	query-m: UPDATE 'X' SET s_id = 'X' [TRX#49b970]
21	0.018831	query-m: UPDATE 'X' SET s_id = 'X' [TRX#49b970]
22	0.060816	query-m: UPDATE 'X' SET s_id = 'X' [TRX#49b970]
23	0.142038	query-m: UPDATE 'X' SET s_id = 'X' [TRX#49b970]
24	0.014539	query-m: UPDATE 'X' SET s_id = 'X' [TRX#49b970]
25	0.056088	query-m: UPDATE 'X' SET s_id = 'X' [TRX#49b970]
26	0.002638	query-m: UPDATE 'X' SET s_id = 'X' [TRX#49b970]
27	0.070504	query-m: UPDATE 'X' SET s_id = 'X' [TRX#49b970]
28	0.065171	query-m: UPDATE 'X' SET s_id = 'X' [TRX#49b970]
29	0.036534	query-m: UPDATE 'X' SET s_id = 'X' [TRX#49b970]
30	0.053488	query-m: UPDATE 'X' SET s_id = 'X' [TRX#49b970]
31	0.002106	query-m: UPDATE 'X' SET s_id = 'X' [TRX#49b970]
32	0.059537	query-m: UPDATE 'X' SET s_id = 'X' [TRX#49b970]
33	0.067932	query-m: UPDATE 'X' SET s_id = 'X' [TRX#49b970]
34	0.045163	query-m: UPDATE 'X' SET s_id = 'X' [TRX#49b970]
35	0.041301	query-m: UPDATE 'X' SET s_id = 'X' [TRX#49b970]
36	0.013088	query-m: UPDATE 'X' SET s_id = 'X' [TRX#49b970]
37	0.054569	query-m: UPDATE 'X' SET s_id = 'X' [TRX#49b970]
38	0.059301	query-m: UPDATE 'X' SET s_id = 'X' [TRX#49b970]
39	0.084890	query-m: UPDATE 'X' SET s_id = 'X' [TRX#49b970]
40	0.010718	query-m: UPDATE 'X' SET s_id = 'X' [TRX#49b970]
41	0.000807	query-m: UPDATE 'X' SET s_id = 'X' [TRX#49b970]
42	0.018663	query-m: UPDATE 'X' SET s_id = 'X' [TRX#49b970]
43	0.027117	query-m: UPDATE 'X' SET s_id = 'X' [TRX#49b970]
44	0.017680	query-m: UPDATE 'X' SET s_id = 'X' [TRX#49b970]
45	0.025055	query-m: UPDATE 'X' SET s_id = 'X' [TRX#49b970]
46	0.018567	query-m: UPDATE 'X' SET s_id = 'X' [TRX#49b970]
47	0.046412	query-m: UPDATE 'X' SET s_id = 'X' [TRX#49b970]
48	0.025479	query-m: UPDATE 'X' SET s_id = 'X' [TRX#49b970]
49	0.015854	query-m: UPDATE 'X' SET s_id = 'X' [TRX#49b970]
50	0.017401	query-m: UPDATE 'X' SET s_id = 'X' [TRX#49b970]
51	0.016405	query-m: UPDATE 'X' SET s_id = 'X' [TRX#49b970]
52	0.001440	query-m: UPDATE 'X' SET smw_title = 'X' [TRX#49b970]
53	0.001232	query-m: UPDATE 'X' SET o_id = 'X' [TRX#49b970]
54	0.000791	query-m: UPDATE 'X' SET o_id = 'X' [TRX#49b970]
55	0.000934	query-m: UPDATE 'X' SET o_id = 'X' [TRX#49b970]
56	0.000767	query-m: UPDATE 'X' SET o_id = 'X' [TRX#49b970]
57	0.000718	query-m: UPDATE 'X' SET o_id = 'X' [TRX#49b970]
58	0.000677	query-m: UPDATE 'X' SET o_id = 'X' [TRX#49b970]
59	0.001609	query-m: UPDATE 'X' SET o_id = 'X' [TRX#49b970]
60	0.001384	query-m: UPDATE 'X' SET o_id = 'X' [TRX#49b970]
61	0.002022	query-m: UPDATE 'X' SET o_id = 'X' [TRX#49b970]
62	0.009007	query-m: UPDATE 'X' SET o_id = 'X' [TRX#49b970]
63	0.003939	query-m: UPDATE 'X' SET smw_iw = 'X' [TRX#49b970]
64	0.038372	query-m: INSERT INTO 'X' (s_title,s_namespace,o_id) VALUES ('X') [TRX#49b970]
65	0.001263	query-m: UPDATE 'X' SET usage_count = usage_count + 'X' [TRX#49b970]
```