### PR TITLE
Add SetupFile, refs 3596

### DIFF
--- a/includes/Setup.php
+++ b/includes/Setup.php
@@ -4,7 +4,6 @@ namespace SMW;
 
 use SMW\Connection\ConnectionManager;
 use SMW\MediaWiki\Hooks;
-use SMW\SQLStore\Installer;
 
 /**
  * Extension setup and registration
@@ -125,7 +124,7 @@ final class Setup {
 	 * @since 3.0
 	 */
 	public static function isValid( $isCli = false ) {
-		return Installer::isGoodSchema( $isCli );
+		return SetupFile::isGoodSchema( $isCli );
 	}
 
 	/**
@@ -134,7 +133,7 @@ final class Setup {
 	 * @param array &$vars
 	 */
 	public function loadSchema( &$vars ) {
-		Installer::loadSchema( $vars );
+		SetupFile::loadSchema( $vars );
 	}
 
 	/**

--- a/maintenance/populateHashField.php
+++ b/maintenance/populateHashField.php
@@ -6,6 +6,7 @@ use Onoi\MessageReporter\MessageReporter;
 use SMW\ApplicationFactory;
 use SMW\SQLStore\SQLStore;
 use SMW\SQLStore\Installer;
+use SMW\SetupFile;
 use SMW\Setup;
 use SMW\Store;
 
@@ -59,7 +60,9 @@ class PopulateHashField extends \Maintenance {
 			"   ... writing the status to the setup information file ... \n"
 		);
 
-		Installer::setUpgradeFile(
+		$setupFile = new SetupFile();
+
+		$setupFile->write(
 			$GLOBALS,
 			[
 				Installer::POPULATE_HASH_FIELD_COMPLETE => $incomplete

--- a/src/MediaWiki/Hooks.php
+++ b/src/MediaWiki/Hooks.php
@@ -17,7 +17,7 @@ use SMW\DataTypeRegistry;
 use SMW\ParserFunctions\DocumentationParserFunction;
 use SMW\ParserFunctions\InfoParserFunction;
 use SMW\ParserFunctions\SectionTag;
-use SMW\SQLStore\Installer;
+use SMW\SetupFile;
 use SMW\Store;
 use SMW\Options;
 use SMW\MediaWiki\Hooks\ArticleDelete;
@@ -385,7 +385,7 @@ class Hooks {
 
 		$beforePageDisplay->setOptions(
 			[
-				'installer.incomplete_tasks' => Installer::incompleteTasks( $GLOBALS )
+				'incomplete_tasks' => SetupFile::findIncompleteTasks( $GLOBALS )
 			]
 		);
 

--- a/src/MediaWiki/Hooks/BeforePageDisplay.php
+++ b/src/MediaWiki/Hooks/BeforePageDisplay.php
@@ -48,7 +48,7 @@ class BeforePageDisplay extends HookHandler {
 			$outputPage->addModules( 'ext.smw.suggester.textInput' );
 		}
 
-		if ( ( $tasks = $this->getOption( 'installer.incomplete_tasks', [] ) ) !== [] ) {
+		if ( ( $tasks = $this->getOption( 'incomplete_tasks', [] ) ) !== [] ) {
 			$outputPage->prependHTML( $this->incompleteTasksHTML( $tasks ) );
 		}
 

--- a/src/SetupFile.php
+++ b/src/SetupFile.php
@@ -1,0 +1,210 @@
+<?php
+
+namespace SMW;
+
+use Onoi\MessageReporter\MessageReporterAwareTrait;
+use SMW\Exception\FileNotWritableException;
+use SMW\Utils\File;
+use SMW\SQLStore\Installer;
+
+/**
+ * @private
+ *
+ * @license GNU GPL v2+
+ * @since 3.1
+ *
+ * @author mwjames
+ */
+class SetupFile {
+
+	use MessageReporterAwareTrait;
+
+	/**
+	 * @var File
+	 */
+	private $file;
+
+	/**
+	 * @since 3.1
+	 *
+	 * @param File|null $file
+	 */
+	public function __construct( File $file = null ) {
+		$this->file = $file;
+
+		if ( $this->file === null ) {
+			$this->file = new File();
+		}
+	}
+
+	/**
+	 * @since 3.1
+	 *
+	 * @param array $vars
+	 */
+	public static function loadSchema( &$vars ) {
+
+		// @see #3506
+		$file = File::dir( $vars['smwgConfigFileDir'] . '/.smw.json' );
+
+		// Doesn't exist? The `Setup::init` will take care of it by trying to create
+		// a new file and if it fails or unable to do so wail raise an exception
+		// as we expect to have access to it.
+		if ( is_readable( $file ) ) {
+			$vars['smw.json'] = json_decode( file_get_contents( $file ), true );
+		}
+	}
+
+	/**
+	 * @since 3.1
+	 *
+	 * @param boolean $isCli
+	 *
+	 * @return boolean
+	 */
+	public static function isGoodSchema( $isCli = false ) {
+
+		if ( $isCli && defined( 'MW_PHPUNIT_TEST' ) ) {
+			return true;
+		}
+
+		if ( $isCli === false && ( PHP_SAPI === 'cli' || PHP_SAPI === 'phpdbg' ) ) {
+			return true;
+		}
+
+		// #3563, Use the specific wiki-id as identifier for the instance in use
+		$id = Site::id();
+
+		if ( !isset( $GLOBALS['smw.json'][$id]['upgrade_key'] ) ) {
+			return false;
+		}
+
+		return self::makeUpgradeKey( $GLOBALS ) === $GLOBALS['smw.json'][$id]['upgrade_key'];
+	}
+
+	/**
+	 * @since 3.1
+	 *
+	 * @param array $vars
+	 *
+	 * @return []
+	 */
+	public static function findIncompleteTasks( $vars ) {
+
+		$id = Site::id();
+		$tasks = [];
+
+		// Key field => [ value that constitutes the `INCOMPLETE` state, error msg ]
+		$checks = [
+			Installer::POPULATE_HASH_FIELD_COMPLETE => [ false, 'smw-install-incomplete-populate-hash-field' ]
+		];
+
+		foreach ( $checks as $key => $value ) {
+			if ( isset( $vars['smw.json'][$id][$key] ) && $vars['smw.json'][$id][$key] === $value[0] ) {
+				$tasks[] = $value[1];
+			}
+		}
+
+		return $tasks;
+	}
+
+	/**
+	 * @since 3.1
+	 *
+	 * @param array $vars
+	 *
+	 * @return string
+	 */
+	public static function makeUpgradeKey( $vars ) {
+
+		// Only recognize those properties that require a fixed table
+		$pageSpecialProperties = array_intersect(
+			// Special properties enabled?
+			$vars['smwgPageSpecialProperties'],
+
+			// Any custom fixed properties require their own table?
+			TypesRegistry::getFixedProperties( 'custom_fixed' )
+		);
+
+		// Sort to ensure the key contains the same order
+		sort( $vars['smwgFixedProperties'] );
+		sort( $pageSpecialProperties );
+
+		// The following settings influence the "shape" of the tables required
+		// therefore use the content to compute a key that reflects any
+		// changes to them
+		$components = [
+			$vars['smwgUpgradeKey'],
+			$vars['smwgFixedProperties'],
+			$vars['smwgEnabledFulltextSearch'],
+			$pageSpecialProperties
+		];
+
+		return sha1( json_encode( $components ) );
+	}
+
+	/**
+	 * @since 3.1
+	 *
+	 * @param array $vars
+	 */
+	public function setUpgradeKey( $vars ) {
+
+		// #3563, Use the specific wiki-id as identifier for the instance in use
+		$key = self::makeUpgradeKey( $vars );
+		$id = Site::id();
+
+		if (
+			isset( $vars['smw.json'][$id]['upgrade_key'] ) &&
+			$key === $vars['smw.json'][$id]['upgrade_key'] ) {
+			return false;
+		}
+
+		if ( $this->messageReporter !== null ) {
+			$this->messageReporter->reportMessage( "\nSetting upgrade key for $id ..." );
+		}
+
+		$this->write( $vars, [ 'upgrade_key' => $key ] );
+
+		if ( $this->messageReporter !== null ) {
+			$this->messageReporter->reportMessage( "\n   ... done.\n" );
+		}
+	}
+
+	/**
+	 * @since 3.1
+	 *
+	 * @param array $vars
+	 * @param array $args
+	 */
+	public function write( $vars, $args = [] ) {
+
+		$configFile = File::dir( $vars['smwgConfigFileDir'] . '/.smw.json' );
+		$id = Site::id();
+
+		if ( !isset( $vars['smw.json'] ) ) {
+			$vars['smw.json'] = [];
+		}
+
+		foreach ( $args as $key => $value ) {
+			$vars['smw.json'][$id][$key] = $value;
+		}
+
+		try {
+			$this->file->write(
+				$configFile,
+				json_encode( $vars['smw.json'], JSON_PRETTY_PRINT )
+			);
+		} catch( FileNotWritableException $e ) {
+			// Users may not have `wgShowExceptionDetails` enabled and would
+			// therefore not see the exception error message hence we fail hard
+			// and die
+			die(
+				"\n\nERROR: " . $e->getMessage() . "\n" .
+				"\n       The \"smwgConfigFileDir\" setting should point to a" .
+				"\n       directory that is persistent and writable!\n"
+			);
+		}
+	}
+
+}

--- a/tests/phpunit/Unit/MediaWiki/Hooks/BeforePageDisplayTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Hooks/BeforePageDisplayTest.php
@@ -77,7 +77,7 @@ class BeforePageDisplayTest extends \PHPUnit_Framework_TestCase {
 		$instance->process( $this->outputPage, $this->skin );
 	}
 
-	public function testPrependHTML_InstallerIncompleteTasks() {
+	public function testPrependHTML_IncompleteTasks() {
 
 		$user = $this->getMockBuilder( '\User' )
 			->disableOriginalConstructor()
@@ -94,7 +94,7 @@ class BeforePageDisplayTest extends \PHPUnit_Framework_TestCase {
 
 		$instance->setOptions(
 			[
-				'installer.incomplete_tasks' => [ 'Foo', 'Bar' ]
+				'incomplete_tasks' => [ 'Foo', 'Bar' ]
 			]
 		);
 

--- a/tests/phpunit/Unit/SQLStore/InstallerTest.php
+++ b/tests/phpunit/Unit/SQLStore/InstallerTest.php
@@ -22,7 +22,7 @@ class InstallerTest extends \PHPUnit_Framework_TestCase {
 	private $tableSchemaManager;
 	private $tableBuilder;
 	private $tableIntegrityExaminer;
-	private $file;
+	private $SetupFile;
 
 	protected function setUp() {
 		parent::setUp();
@@ -45,7 +45,7 @@ class InstallerTest extends \PHPUnit_Framework_TestCase {
 			->disableOriginalConstructor()
 			->getMock();
 
-		$this->file = $this->getMockBuilder( '\SMW\Utils\File' )
+		$this->setupFile = $this->getMockBuilder( '\SMW\SetupFile' )
 			->disableOriginalConstructor()
 			->getMock();
 
@@ -88,7 +88,7 @@ class InstallerTest extends \PHPUnit_Framework_TestCase {
 		);
 
 		$instance->setMessageReporter( $this->spyMessageReporter );
-		$instance->setFile( $this->file );
+		$instance->setSetupFile( $this->setupFile );
 
 		$instance->setOptions(
 			[
@@ -132,7 +132,7 @@ class InstallerTest extends \PHPUnit_Framework_TestCase {
 		);
 
 		$instance->setMessageReporter( $this->spyMessageReporter );
-		$instance->setFile( $this->file );
+		$instance->setSetupFile( $this->setupFile );
 
 		$instance->setOptions(
 			[
@@ -165,7 +165,7 @@ class InstallerTest extends \PHPUnit_Framework_TestCase {
 		);
 
 		$instance->setMessageReporter( $this->spyMessageReporter );
-		$instance->setFile( $this->file );
+		$instance->setSetupFile( $this->setupFile );
 
 		$this->assertTrue(
 			$instance->install( false )
@@ -218,135 +218,6 @@ class InstallerTest extends \PHPUnit_Framework_TestCase {
 		$this->assertEquals(
 			'Foo',
 			$this->testEnvironment->outputFromCallbackExec( $callback )
-		);
-	}
-
-	public function testIsGoodSchema() {
-
-		$instance = new Installer(
-			$this->tableSchemaManager,
-			$this->tableBuilder,
-			$this->tableIntegrityExaminer
-		);
-
-		$this->assertInternalType(
-			'boolean',
-			$instance->isGoodSchema()
-		);
-	}
-
-	public function testMakeUpgradeKey() {
-
-		$var1 = [
-			'smwgUpgradeKey' => '',
-			'smwgEnabledFulltextSearch' => '',
-			'smwgFixedProperties' => [ 'Foo', 'Bar' ],
-			'smwgPageSpecialProperties' => [ 'Foo', 'Bar' ]
-		];
-
-		$var2 = [
-			'smwgUpgradeKey' => '',
-			'smwgEnabledFulltextSearch' => '',
-			'smwgFixedProperties' => [ 'Bar', 'Foo' ],
-			'smwgPageSpecialProperties' => [ 'Bar', 'Foo' ]
-		];
-
-		$this->assertEquals(
-			Installer::makeUpgradeKey( $var1 ),
-			Installer::makeUpgradeKey( $var2 )
-		);
-	}
-
-	public function testMakeUpgradeKey_SpecialFixedProperties() {
-
-		$var1 = [
-			'smwgUpgradeKey' => '',
-			'smwgEnabledFulltextSearch' => '',
-			'smwgFixedProperties' => [ 'Foo', 'Bar' ],
-			'smwgPageSpecialProperties' => [ 'Foo', 'Bar' ]
-		];
-
-		$var2 = [
-			'smwgUpgradeKey' => '',
-			'smwgEnabledFulltextSearch' => '',
-			'smwgFixedProperties' => [ 'Bar', 'Foo' ],
-			'smwgPageSpecialProperties' => [ 'Bar', '_MDAT' ]
-		];
-
-		$this->assertNotEquals(
-			Installer::makeUpgradeKey( $var1 ),
-			Installer::makeUpgradeKey( $var2 )
-		);
-	}
-
-	public function testSetUpgradeKey() {
-
-		$file = $this->getMockBuilder( '\SMW\Utils\File' )
-			->disableOriginalConstructor()
-			->getMock();
-
-		$file->expects( $this->once() )
-			->method( 'write' );
-
-		$instance = new Installer(
-			$this->tableSchemaManager,
-			$this->tableBuilder,
-			$this->tableIntegrityExaminer
-		);
-
-		$vars = [
-			'smwgConfigFileDir' => 'Foo/',
-			'smwgIP' => '',
-			'smwgUpgradeKey' => '',
-			'smwgEnabledFulltextSearch' => '',
-			'smwgFixedProperties' => [],
-			'smwgPageSpecialProperties' => []
-		];
-
-		$instance->setUpgradeKey( $vars, $this->spyMessageReporter, $file );
-	}
-
-	public function testSetUpgradeFile() {
-
-		$expected = json_encode( [ \SMW\Site::id() => [ 'Foo' => 42 ] ], JSON_PRETTY_PRINT );
-
-		$file = $this->getMockBuilder( '\SMW\Utils\File' )
-			->disableOriginalConstructor()
-			->getMock();
-
-		$file->expects( $this->once() )
-			->method( 'write' )
-			->with(
-				$this->equalTo( 'Foo_dir/.smw.json' ),
-				$this->equalTo( $expected ) );
-
-		$instance = new Installer(
-			$this->tableSchemaManager,
-			$this->tableBuilder,
-			$this->tableIntegrityExaminer
-		);
-
-		$vars = [
-			'smwgConfigFileDir' => 'Foo_dir'
-		];
-
-		$instance->setUpgradeFile( $vars, [ 'Foo' => 42 ], $file );
-	}
-
-	public function testIncompleteTasks() {
-
-		$vars = [
-			'smw.json' => [ \SMW\Site::id() => [ Installer::POPULATE_HASH_FIELD_COMPLETE => false ] ]
-		];
-
-		$this->assertEquals(
-			[ 'smw-install-incomplete-populate-hash-field' ],
-			Installer::incompleteTasks( $vars )
-		);
-
-		$this->assertEquals(
-			[],
-			Installer::incompleteTasks( [] )
 		);
 	}
 

--- a/tests/phpunit/Unit/SetupFileTest.php
+++ b/tests/phpunit/Unit/SetupFileTest.php
@@ -1,0 +1,148 @@
+<?php
+
+namespace SMW\Tests;
+
+use SMW\SetupFile;
+use SMW\Utils\File;
+use SMW\Tests\TestEnvironment;
+
+/**
+ * @covers \SMW\SetupFile
+ * @group semantic-mediawiki
+ *
+ * @license GNU GPL v2+
+ * @since 3.1
+ *
+ * @author mwjames
+ */
+class SetupFileTest extends \PHPUnit_Framework_TestCase {
+
+	private $spyMessageReporter;
+
+	protected function setUp() {
+		parent::setUp();
+		$this->spyMessageReporter = TestEnvironment::getUtilityFactory()->newSpyMessageReporter();
+	}
+
+	public function testIsGoodSchema() {
+
+		$this->assertInternalType(
+			'boolean',
+			SetupFile::isGoodSchema()
+		);
+	}
+
+	public function testMakeUpgradeKey() {
+
+		$var1 = [
+			'smwgUpgradeKey' => '',
+			'smwgEnabledFulltextSearch' => '',
+			'smwgFixedProperties' => [ 'Foo', 'Bar' ],
+			'smwgPageSpecialProperties' => [ 'Foo', 'Bar' ]
+		];
+
+		$var2 = [
+			'smwgUpgradeKey' => '',
+			'smwgEnabledFulltextSearch' => '',
+			'smwgFixedProperties' => [ 'Bar', 'Foo' ],
+			'smwgPageSpecialProperties' => [ 'Bar', 'Foo' ]
+		];
+
+		$this->assertEquals(
+			SetupFile::makeUpgradeKey( $var1 ),
+			SetupFile::makeUpgradeKey( $var2 )
+		);
+	}
+
+	public function testMakeUpgradeKey_SpecialFixedProperties() {
+
+		$var1 = [
+			'smwgUpgradeKey' => '',
+			'smwgEnabledFulltextSearch' => '',
+			'smwgFixedProperties' => [ 'Foo', 'Bar' ],
+			'smwgPageSpecialProperties' => [ 'Foo', 'Bar' ]
+		];
+
+		$var2 = [
+			'smwgUpgradeKey' => '',
+			'smwgEnabledFulltextSearch' => '',
+			'smwgFixedProperties' => [ 'Bar', 'Foo' ],
+			'smwgPageSpecialProperties' => [ 'Bar', '_MDAT' ]
+		];
+
+		$this->assertNotEquals(
+			SetupFile::makeUpgradeKey( $var1 ),
+			SetupFile::makeUpgradeKey( $var2 )
+		);
+	}
+
+	public function testSetUpgradeKey() {
+
+		$file = $this->getMockBuilder( '\SMW\Utils\File' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$file->expects( $this->once() )
+			->method( 'write' );
+
+		$instance = new SetupFile(
+			$file
+		);
+
+		$vars = [
+			'smwgConfigFileDir' => 'Foo/',
+			'smwgIP' => '',
+			'smwgUpgradeKey' => '',
+			'smwgEnabledFulltextSearch' => '',
+			'smwgFixedProperties' => [],
+			'smwgPageSpecialProperties' => []
+		];
+
+		$instance->setMessageReporter( $this->spyMessageReporter );
+		$instance->setUpgradeKey( $vars );
+	}
+
+	public function testSetUpgradeFile() {
+
+		$configFile = File::dir( 'Foo_dir/.smw.json' );
+		$expected = json_encode( [ \SMW\Site::id() => [ 'Foo' => 42 ] ], JSON_PRETTY_PRINT );
+
+		$file = $this->getMockBuilder( '\SMW\Utils\File' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$file->expects( $this->once() )
+			->method( 'write' )
+			->with(
+				$this->equalTo( $configFile ),
+				$this->equalTo( $expected ) );
+
+		$instance = new SetupFile(
+			$file
+		);
+
+		$vars = [
+			'smwgConfigFileDir' => 'Foo_dir'
+		];
+
+		$instance->write( $vars, [ 'Foo' => 42 ] );
+	}
+
+	public function testIncompleteTasks() {
+
+		$vars = [
+			'smw.json' => [ \SMW\Site::id() => [ \SMW\SQLStore\Installer::POPULATE_HASH_FIELD_COMPLETE => false ] ]
+		];
+
+		$this->assertEquals(
+			[ 'smw-install-incomplete-populate-hash-field' ],
+			SetupFile::findIncompleteTasks( $vars )
+		);
+
+		$this->assertEquals(
+			[],
+			SetupFile::findIncompleteTasks( [] )
+		);
+	}
+
+}


### PR DESCRIPTION
This PR is made in reference to: #3596 

This PR addresses or contains:

- Isolates all methods in the `Installer` related to `.smw.json` handling and have them move into a separate `SetupFile` class

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed
