### PR TITLE
Highlighter, decode \n in content, refs 3696

### DIFF
--- a/includes/Highlighter.php
+++ b/includes/Highlighter.php
@@ -278,7 +278,7 @@ class Highlighter {
 				// will make the parser go berserk (injecting <p> elements etc.)
 				// hence encode the identifying </> and decode it within the
 				// tooltip
-				str_replace( [ '<', '>' ], [ '&lt;', '&gt;' ], htmlspecialchars_decode( $this->options['content'] ) )
+				str_replace( [ "\n", '<', '>' ], [ '</br>', '&lt;', '&gt;' ], htmlspecialchars_decode( $this->options['content'] ) )
 			)
 		);
 

--- a/res/smw/util/smw.tippy.css
+++ b/res/smw/util/smw.tippy.css
@@ -63,6 +63,11 @@
    overflow-y: auto;
 }
 
+.tippy-content-container ul {
+    padding-inline-start: 20px;
+    margin: 0.3em 0.3em 0.3em 0.5em;
+}
+
 .tippy-content-overlay {
     height: 40px;
     width: 260px;


### PR DESCRIPTION
This PR is made in reference to: #3696 

This PR addresses or contains:

- If a text content contains a `\n` (line break) then it is discarded as part of the encapsulated highlighter content, so encode it as HTML to ensure the MW parser doesn't inject some `<p>` element.

This PR includes:
- [ ] Tests (unit/integration)
- [x] CI build passed
