### PR TITLE
Add prefetch lookup support for semantic data

### DIFF
--- a/src/RequestOptions.php
+++ b/src/RequestOptions.php
@@ -17,12 +17,37 @@ namespace SMW;
  */
 class RequestOptions {
 
+	/**
+	 * Used to identify a constraint conition set forth by the QueryResult
+	 * process which doesn't modify the `limit`.
+	 */
+	const CONDITION_CONSTRAINT_RESULT = 'condition.constraint.result';
+
+	/**
+	 * Used to identify a constraint conidtion set forth by any other query
+	 * process.
+	 */
+	const CONDITION_CONSTRAINT = 'conditon.constraint';
+
+	/**
+	 * Defines a prefetch fingerprint
+	 */
+	const PREFETCH_FINGERPRINT = 'prefetch.fingerprint';
+
 	const SEARCH_FIELD = 'search_field';
 
 	/**
 	 * The maximum number of results that should be returned.
 	 */
 	public $limit = -1;
+
+	/**
+	 * For certain queries (e.g. prefetch using WHERE IN) using the limit will
+	 * cause the whole retrievable set to be restricted instead of just be
+	 * applied to a subset therefore allow to exclude the limit and apply an
+	 * restriction during the post-processing.
+	 */
+	public $exclude_limit = false;
 
 	/**
 	 * A numerical offset. The first $offset results are skipped.
@@ -210,6 +235,7 @@ class RequestOptions {
 			$this->ascending,
 			$this->boundary,
 			$this->include_boundary,
+			$this->exclude_limit,
 			$stringConditions,
 			$this->extraConditions,
 			$this->options,

--- a/src/SQLStore/EntityStore/PrefetchItemLookup.php
+++ b/src/SQLStore/EntityStore/PrefetchItemLookup.php
@@ -1,0 +1,164 @@
+<?php
+
+namespace SMW\SQLStore\EntityStore;
+
+use SMW\DIWikiPage;
+use SMW\DIProperty;
+use SMW\RequestOptions;
+use SMW\SQLStore\SQLStore;
+use SMW\Store;
+use SMWDataItem as DataItem;
+use SMW\MediaWiki\LinkBatch;
+use RuntimeException;
+
+/**
+ * Prefetch from a list of known subjects for a selected property to avoid
+ * using `Store::getPropertyValues` for each single subject.
+ *
+ * @license GNU GPL v2+
+ * @since 3.1
+ *
+ * @author mwjames
+ */
+class PrefetchItemLookup {
+
+	/**
+	 * @var Store
+	 */
+	private $store;
+
+	/**
+	 * @var SemanticDataLookup
+	 */
+	private $semanticDataLookup;
+
+	/**
+	 * @var LinkBatch
+	 */
+	private $linkBatch;
+
+	/**
+	 * @var boolean
+	 */
+	private $itemIndex = false;
+
+	/**
+	 * @since 3.1
+	 *
+	 * @param Store $store
+	 * @param CachingSemanticDataLookup $semanticDataLookup
+	 */
+	public function __construct( Store $store, CachingSemanticDataLookup $semanticDataLookup, LinkBatch $linkBatch = null ) {
+		$this->store = $store;
+		$this->semanticDataLookup = $semanticDataLookup;
+
+		// Help reduce the amount of queries by allowing to prefetch those
+		// links we know will be used for the display
+		if ( $this->linkBatch === null ) {
+			$this->linkBatch = new LinkBatch();
+		}
+	}
+
+	/**
+	 * @since 3.1
+	 *
+	 * @param boolean $itemIndex
+	 */
+	public function asItemIndex( $itemIndex = true ) {
+		$this->itemIndex = (bool)$itemIndex;
+	}
+
+	/**
+	 * @since 3.1
+	 *
+	 * @param array $subjects
+	 * @param DIProperty $property
+	 * @param RequestOptions $requestOptions
+	 *
+	 * @return []
+	 */
+	public function getPropertyValues( array $subjects, DIProperty $property, RequestOptions $requestOptions ) {
+
+		// Not supported!
+		if ( $property->isInverse() ) {
+			throw new RuntimeException( "Operation is not supported for inverse properties!" );
+		}
+
+		$tableid = $this->store->findPropertyTableID( $property );
+		$proptables = $this->store->getPropertyTables();
+
+		if ( $tableid === '' || !isset( $proptables[$tableid] ) ) {
+			return [];
+		}
+
+		$propTable = $proptables[$tableid];
+		$result = [];
+		$list = [];
+
+		// In prefetch mode avoid restricting the result due to use of WHERE IN
+		$requestOptions->exclude_limit = true;
+
+		$data = $this->semanticDataLookup->prefetchDataFromTable(
+			$subjects,
+			$property,
+			$propTable,
+			$requestOptions
+		);
+
+		$diHandler = $this->store->getDataItemHandlerForDIType(
+			$propTable->getDiType()
+		);
+
+		foreach ( $data as $sid => $dbkeys ) {
+
+			$i = 0;
+
+			if ( $this->itemIndex ) {
+				$subject = $this->store->getObjectIds()->getDataItemById(
+					$sid
+				);
+
+				// Subject hash is used as identifying hash to split
+				// the collected set of values
+				$hash = $subject->getHash();
+			} else {
+				// SID, the caller is responsible to reassign the
+				// results to a corresponding output
+				$hash = $sid;
+			}
+
+			if ( !isset( $result[$hash] ) ) {
+				$result[$hash] = [];
+			}
+
+			foreach ( $dbkeys as $k => $v ) {
+
+				if ( $i > $requestOptions->limit ) {
+					break;
+				}
+
+				try {
+					$dataItem = $diHandler->dataItemFromDBKeys( $v );
+					$list[] = $dataItem;
+					$result[$hash][$dataItem->getHash()] = $dataItem;
+				} catch ( \SMWDataItemException $e ) {
+					// maybe type assignment changed since data was stored;
+					// don't worry, but we can only drop the data here
+				}
+
+				$i++;
+			}
+		}
+
+		if ( $propTable->getDiType() === DataItem::TYPE_WIKIPAGE ) {
+			$this->store->getObjectIds()->warmUpCache( $list );
+			$this->linkBatch->addFromList( $list );
+		}
+
+		$this->linkBatch->addFromList( $subjects );
+		$this->linkBatch->execute();
+
+		return $result;
+	}
+
+}

--- a/src/SQLStore/SQLStoreFactory.php
+++ b/src/SQLStore/SQLStoreFactory.php
@@ -16,6 +16,7 @@ use SMW\SQLStore\ChangeOp\ChangeOp;
 use SMW\SQLStore\EntityStore\CachingEntityLookup;
 use SMW\SQLStore\EntityStore\CachingSemanticDataLookup;
 use SMW\SQLStore\EntityStore\DataItemHandlerDispatcher;
+use SMW\SQLStore\EntityStore\PrefetchItemLookup;
 use SMW\SQLStore\EntityStore\IdCacheManager;
 use SMW\SQLStore\EntityStore\IdEntityFinder;
 use SMW\SQLStore\EntityStore\IdChanger;
@@ -784,6 +785,18 @@ class SQLStoreFactory {
 	}
 
 	/**
+	 * @since 3.1
+	 *
+	 * @return PrefetchItemLookup
+	 */
+	public function newPrefetchItemLookup() {
+		return new PrefetchItemLookup(
+			$this->store,
+			$this->newSemanticDataLookup()
+		);
+	}
+
+	/**
 	 * @since 3.0
 	 *
 	 * @return ServicesContainer
@@ -819,7 +832,11 @@ class SQLStoreFactory {
 				'PropertyTableIdReferenceFinder' => function() {
 					static $singleton;
 					return $singleton = $singleton === null ? $this->newPropertyTableIdReferenceFinder() : $singleton;
-				}
+				},
+				'PrefetchItemLookup' => [
+					'_service' => [ $this, 'newPrefetchItemLookup' ],
+					'_type'    => PrefetchItemLookup::class
+				]
 			]
 		);
 

--- a/tests/phpunit/Unit/Page/ListBuilder/ValueListBuilderTest.php
+++ b/tests/phpunit/Unit/Page/ListBuilder/ValueListBuilderTest.php
@@ -61,22 +61,32 @@ class ValueListBuilderTest extends \PHPUnit_Framework_TestCase {
 
 	public function testCreateHtml() {
 
+		$subject = DIWikiPage::newFromText( __METHOD__ );
+
+		$prefetchItemLookup = $this->getMockBuilder( '\SMW\SQLStore\EntityStore\PrefetchItemLookup' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$prefetchItemLookup->expects( $this->once() )
+			->method( 'getPropertyValues' )
+			->will( $this->returnValue( [ $subject->getHash() => [ DIWikiPage::newFromText( 'Bar' ) ] ] ) );
+
 		$store = $this->getMockBuilder( '\SMW\Store' )
 			->disableOriginalConstructor()
-			->setMethods( [ 'getAllPropertySubjects', 'getPropertyValues', 'getWikiPageSortKey' ] )
+			->setMethods( [ 'getAllPropertySubjects', 'getPropertyValues', 'getWikiPageSortKey', 'service' ] )
 			->getMockForAbstractClass();
 
 		$store->expects( $this->once() )
 			->method( 'getAllPropertySubjects' )
-			->will( $this->returnValue( [ DIWikiPage::newFromText( __METHOD__ ) ] ) );
+			->will( $this->returnValue( [ $subject ] ) );
 
 		$store->expects( $this->once() )
 			->method( 'getWikiPageSortKey' )
 			->will( $this->returnValue( 'Bar' ) );
 
 		$store->expects( $this->once() )
-			->method( 'getPropertyValues' )
-			->will( $this->returnValue( [ DIWikiPage::newFromText( 'Bar' ) ] ) );
+			->method( 'service' )
+			->will( $this->returnValue( $prefetchItemLookup ) );
 
 		$instance = new ValueListBuilder( $store );
 		$instance->setLanguageCode( 'en' );

--- a/tests/phpunit/Unit/RequestOptionsTest.php
+++ b/tests/phpunit/Unit/RequestOptionsTest.php
@@ -41,7 +41,7 @@ class RequestOptionsTest extends \PHPUnit_Framework_TestCase {
 		}
 
 		$this->assertEquals(
-			'[-1,0,false,true,null,true,"Foo#0##",[],[]]',
+			'[-1,0,false,true,null,true,false,"Foo#0##",[],[]]',
 			$instance->getHash()
 		);
 	}
@@ -61,7 +61,7 @@ class RequestOptionsTest extends \PHPUnit_Framework_TestCase {
 		);
 
 		$this->assertEquals(
-			'[-1,0,false,true,null,true,"",["Foo",{"Bar":"Foobar"}],[]]',
+			'[-1,0,false,true,null,true,false,"",["Foo",{"Bar":"Foobar"}],[]]',
 			$instance->getHash()
 		);
 	}

--- a/tests/phpunit/Unit/SQLStore/EntityStore/PrefetchItemLookupTest.php
+++ b/tests/phpunit/Unit/SQLStore/EntityStore/PrefetchItemLookupTest.php
@@ -1,0 +1,95 @@
+<?php
+
+namespace SMW\Tests\SQLStore\EntityStore;
+
+use SMW\DIWikiPage;
+use SMW\DIProperty;
+use SMW\SQLStore\EntityStore\PrefetchItemLookup;
+use SMW\Tests\PHPUnitCompat;
+
+/**
+ * @covers \SMW\SQLStore\EntityStore\PrefetchItemLookup
+ * @group semantic-mediawiki
+ *
+ * @license GNU GPL v2+
+ * @since 3.1
+ *
+ * @author mwjames
+ */
+class PrefetchItemLookupTest extends \PHPUnit_Framework_TestCase {
+
+	use PHPUnitCompat;
+
+	private $store;
+	private $semanticDataLookup;
+	private $requestOptions;
+
+	protected function setUp() {
+
+		$this->store = $this->getMockBuilder( '\SMW\SQLStore\SQLStore' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$this->semanticDataLookup = $this->getMockBuilder( '\SMW\SQLStore\EntityStore\CachingSemanticDataLookup' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$this->requestOptions = $this->getMockBuilder( '\SMW\RequestOptions' )
+			->disableOriginalConstructor()
+			->getMock();
+	}
+
+	public function testCanConstruct() {
+
+		$this->assertInstanceOf(
+			PrefetchItemLookup::class,
+			new PrefetchItemLookup( $this->store, $this->semanticDataLookup )
+		);
+	}
+
+	public function testGetPropertyValues() {
+
+		$subjects = [
+			DIWikiPage::newFromText( __METHOD__ ),
+		];
+
+		$propertyTableDef = $this->getMockBuilder( '\SMW\SQLStore\PropertyTableDefinition' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$this->store->expects( $this->atLeastOnce() )
+			->method( 'getPropertyTables' )
+			->will( $this->returnValue( [ 'smw_foo' => $propertyTableDef ] ) );
+
+		$this->store->expects( $this->atLeastOnce() )
+			->method( 'findPropertyTableID' )
+			->will( $this->returnValue( 'smw_foo' ) );
+
+		$this->semanticDataLookup->expects( $this->atLeastOnce() )
+			->method( 'prefetchDataFromTable' )
+			->will( $this->returnValue( [ 42 => [ 'Bar#0##' ] ] ) );
+
+		$instance = new PrefetchItemLookup(
+			$this->store,
+			$this->semanticDataLookup
+		);
+
+		$instance->getPropertyValues( $subjects, new DIProperty( 'Foo' ), $this->requestOptions );
+	}
+
+	public function testGetPropertyValuesThrowsException() {
+
+		$subjects = [
+			DIWikiPage::newFromText( __METHOD__ ),
+		];
+
+		$instance = new PrefetchItemLookup(
+			$this->store,
+			$this->semanticDataLookup
+		);
+
+		$this->setExpectedException( '\RuntimeException' );
+		$instance->getPropertyValues( $subjects, new DIProperty( 'Foo', true ), $this->requestOptions );
+	}
+
+}

--- a/tests/phpunit/Unit/SQLStore/SQLStoreFactoryTest.php
+++ b/tests/phpunit/Unit/SQLStore/SQLStoreFactoryTest.php
@@ -465,6 +465,16 @@ class SQLStoreFactoryTest extends \PHPUnit_Framework_TestCase {
 		);
 	}
 
+	public function testCanConstructPrefetchItemLookup() {
+
+		$instance = new SQLStoreFactory( $this->store );
+
+		$this->assertInstanceOf(
+			'\SMW\SQLStore\EntityStore\PrefetchItemLookup',
+			$instance->newPrefetchItemLookup()
+		);
+	}
+
 	public function testCanConstructServicesContainer() {
 
 		$instance = new SQLStoreFactory( $this->store );


### PR DESCRIPTION
This PR is made in reference to: #3722 

This PR addresses or contains:

- It is only the first part (in regards to #3722) of extending `SemanticDataLookup` with  `SemanticDataLookup::prefetchDataFromTable` to load a "bulk" of data for a specific property
- `PrefetchItemLookup` is used as service to provide the interface 
- Property page value list retrieval is switched on using that service instead of the `Store::getPropertyValues` (which reads row by row)
- This PR doesn't touch (or change) any behaviour of the `QueryEngine`/`QueryResult` objects (the property page `ValueListBuilder`  is used to investigate the prefetch approach as changes to the class are local and isolated)

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed

## SQL

```
SELECT s_id, p.smw_title AS prop, o_blob AS v0, o_hash AS v1
FROM `smw_di_blob` INNER JOIN `smw_object_ids` AS p ON p_id=p.smw_id
WHERE (p_id='310174') AND (s_id IN ('197396','197399','301909','120914','194751','194750','310135','310136','362119','197369','197452','197446','197440','197456','197453','197455','197451','197439','197454','197435','197441')) AND (p.smw_iw!=':smw') AND (p.smw_iw!=':smw-delete')

23.7100ms | SMW\SQLStore\EntityStore\SemanticDataLookup::prefetchDataFromTable
```


id | select_type | table | type | possible_keys | key | key_len | ref | rows | Extra |  
-- | -- | -- | -- | -- | -- | -- | -- | -- | -- | --
1 | SIMPLE | smw_di_blob | range | s_id,s_id_2,p_id | s_id | 8 | NULL | 26 | Using index condition
1 | SIMPLE | p | eq_ref | PRIMARY,smw_iw_2,smw_id,smw_iw | PRIMARY | 4 | mw-30-00-elastic.smw_di_blob.p_id | 1 | Using where
