### PR TITLE
removing stray var_dump

### DIFF
--- a/src/MediaWiki/Specials/Admin/Maintenance/DataRefreshJobTaskHandler.php
+++ b/src/MediaWiki/Specials/Admin/Maintenance/DataRefreshJobTaskHandler.php
@@ -86,7 +86,6 @@ class DataRefreshJobTaskHandler extends TaskHandler {
 		if ( !$this->isEnabledFeature( SMW_ADM_REFRESH ) ) {
 			$this->htmlFormRenderer->addParagraph( $this->msg( 'smw-admin-feature-disabled' ) );
 		} elseif ( $this->getRefreshJob() !== null ) {
-			var_dump('expression');
 			$this->htmlFormRenderer
 				->setMethod( 'post' )
 				->addHiddenField( 'action', 'refreshstore' )


### PR DESCRIPTION
This PR is made in reference to: -

This PR addresses or contains:
- This removes a stray var_dump that can be seen on Special:SemanticMediaWiki&tab=rebuild when a data rebuild job is running

This PR includes:
- [ ] Tests (unit/integration)
- [ ] CI build passed

Fixes -