### PR TITLE
Add `SMW::Factbox::OverrideRevisionID` hook, refs 3032

### DIFF
--- a/docs/technical/hooks.md
+++ b/docs/technical/hooks.md
@@ -372,26 +372,6 @@ Hooks::register( 'SMW::Admin::TaskHandlerFactory', function( &$taskHandlers, $st
 } );
 </pre>
 
-### SMW::DataUpdater::ContentProcessor
-
-* Version: 3.0
-* Description: Hook allows to extend the `SemanticData` with information from the `Content` object
-* Reference class: `SMW\DataUpdater`
-
-<pre>
-use Hooks;
-
-Hooks::register( 'SMW::DataUpdater::ContentProcessor', function( $semanticData, $content ) {
-
-	if ( $content->getModel() === ' ... ' ) {
-		// $data = $content->getNativeData();
-		// ...
-		// $semanticData->addPropertyObjectValue( ... );
-	}
-
-	return true;
-} );
-</pre>
 
 ### SMW::SQLStore::Installer::AddAuxiliaryIndicesBeforeCreateTablesComplete
 
@@ -411,6 +391,22 @@ Hooks::register( 'SMW::SQLStore::Installer::AddAuxiliaryIndicesBeforeCreateTable
 		'smw_query_links' => [ "s_id,o_id", "PRIMARY KEY" ],
 	];
 
+} );
+</pre>
+
+### SMW::Factbox::OverrideRevisionID
+
+* Version: 3.1
+* Description: Hook allows to forcibly change the revision ID used in the `Factbox` to build the content.
+* Reference class: `SMW\Factbox\CachedFactbox`
+
+<pre>
+use Hooks;
+
+Hooks::register( 'SMW::Factbox::OverrideRevisionID', function( $title, &$latestRevID ) {
+
+	// Set a revision ID
+	// $latestRevID = 42;
 } );
 </pre>
 

--- a/src/Factbox/CachedFactbox.php
+++ b/src/Factbox/CachedFactbox.php
@@ -231,11 +231,15 @@ class CachedFactbox {
 	 */
 	private function findRevId( Title $title, $requestContext ) {
 
-		if ( $requestContext->getRequest()->getCheck( 'oldid' ) ) {
+		if ( $requestContext->getRequest()->getCheck( 'oldid' ) !== null ) {
 			return (int)$requestContext->getRequest()->getVal( 'oldid' );
 		}
 
-		return $title->getLatestRevID();
+		$latestRevID = $title->getLatestRevID();
+
+		\Hooks::run( 'SMW::Factbox::OverrideRevisionID', [ $title, &$latestRevID ] );
+
+		return $latestRevID;
 	}
 
 	/**

--- a/tests/phpunit/Unit/Factbox/CachedFactboxTest.php
+++ b/tests/phpunit/Unit/Factbox/CachedFactboxTest.php
@@ -160,7 +160,7 @@ class CachedFactboxTest extends \PHPUnit_Framework_TestCase {
 			'Asserts that content from the outputpage property and retrieveContent() is equal'
 		);
 
-		if ( $expected['text'] ) {
+		if ( isset( $expected['isCached'] ) &&  $expected['isCached'] ) {
 
 			$this->assertTrue(
 				$instance->isCached(),
@@ -311,7 +311,8 @@ class CachedFactboxTest extends \PHPUnit_Framework_TestCase {
 				'parserOutput'    => $this->makeParserOutput( $semanticData )
 			],
 			[
-				'text'            => $subject->getDBKey()
+				'text'            => $subject->getDBKey(),
+				'isCached'        => true
 			]
 		];
 


### PR DESCRIPTION
This PR is made in reference to: https://github.com/SemanticMediaWiki/SemanticApprovedRevs

This PR addresses or contains:

- The hook ensures that in case of an extension manipulating the revision, the factbox can generate content according to forced revision state

This PR includes:
- [ ] Tests (unit/integration)
- [x] CI build passed
