### PR TITLE
[ES] Output indices used on setup/drop

### DIFF
--- a/maintenance/rebuildElasticIndex.php
+++ b/maintenance/rebuildElasticIndex.php
@@ -244,6 +244,11 @@ class RebuildElasticIndex extends \Maintenance {
 		if ( !$this->hasOption( 's' ) && !$this->hasOption( 'page' ) && !$this->hasOption( 'run-fileindex' ) ) {
 			$this->reportMessage( "\n" . '   ... creating required indices and aliases ...' );
 			$this->rebuilder->createIndices();
+		} else {
+			if ( !$this->rebuilder->hasIndices() ) {
+				$this->reportMessage( "\n" . '   ... creating required indices and aliases ...' );
+				$this->rebuilder->createIndices();
+			}
 		}
 
 		$this->rebuilder->prepare();

--- a/src/Elastic/ElasticStore.php
+++ b/src/Elastic/ElasticStore.php
@@ -55,6 +55,15 @@ class ElasticStore extends SQLStore {
 	}
 
 	/**
+	 * @since 3.1
+	 *
+	 * @param ElasticFactory $elasticFactory
+	 */
+	public function setElasticFactory( ElasticFactory $elasticFactory ) {
+		$this->elasticFactory = $elasticFactory;
+	}
+
+	/**
 	 * @see Store::service
 	 *
 	 * {@inheritDoc}
@@ -278,13 +287,18 @@ class ElasticStore extends SQLStore {
 			$this->indexer = $this->elasticFactory->newIndexer( $this, $this->messageReporter );
 		}
 
-		$this->indexer->setup();
+		$indices = $this->indexer->setup();
 
 		if ( $verbose ) {
 			$this->messageReporter->reportMessage( "\n" );
 			$this->messageReporter->reportMessage( 'Selected query engine: "SMWElasticStore"' );
 			$this->messageReporter->reportMessage( "\n" );
 			$this->messageReporter->reportMessage( "\nSetting up indices ...\n" );
+
+			foreach ( $indices as $index ) {
+				$this->messageReporter->reportMessage( "   ... $index ...\n" );
+			}
+
 			$this->messageReporter->reportMessage( "   ... done.\n" );
 		}
 
@@ -303,13 +317,18 @@ class ElasticStore extends SQLStore {
 			$this->indexer = $this->elasticFactory->newIndexer( $this, $this->messageReporter );
 		}
 
-		$this->indexer->drop();
+		$indices = $this->indexer->drop();
 
 		if ( $verbose ) {
 			$this->messageReporter->reportMessage( "\n" );
 			$this->messageReporter->reportMessage( 'Selected query engine: "SMWElasticStore"' );
 			$this->messageReporter->reportMessage( "\n" );
 			$this->messageReporter->reportMessage( "\nDropping indices ...\n" );
+
+			foreach ( $indices as $index ) {
+				$this->messageReporter->reportMessage( "   ... $index ...\n" );
+			}
+
 			$this->messageReporter->reportMessage( "   ... done.\n" );
 		}
 

--- a/src/Elastic/Indexer/Indexer.php
+++ b/src/Elastic/Indexer/Indexer.php
@@ -152,13 +152,10 @@ class Indexer {
 			$this->store->getConnection( 'elastic' )
 		);
 
-		$rollover->update(
-			ElasticClient::TYPE_DATA
-		);
-
-		$rollover->update(
-			ElasticClient::TYPE_LOOKUP
-		);
+		return [
+			$rollover->update( ElasticClient::TYPE_DATA ),
+			$rollover->update( ElasticClient::TYPE_LOOKUP )
+		];
 	}
 
 	/**
@@ -171,13 +168,10 @@ class Indexer {
 			$this->store->getConnection( 'elastic' )
 		);
 
-		$rollover->delete(
-			ElasticClient::TYPE_DATA
-		);
-
-		$rollover->delete(
-			ElasticClient::TYPE_LOOKUP
-		);
+		return [
+			$rollover->delete( ElasticClient::TYPE_DATA ),
+			$rollover->delete( ElasticClient::TYPE_LOOKUP )
+		];
 	}
 
 	/**

--- a/src/Elastic/Indexer/Rebuilder.php
+++ b/src/Elastic/Indexer/Rebuilder.php
@@ -172,6 +172,24 @@ class Rebuilder {
 	}
 
 	/**
+	 * @since 3.1
+	 *
+	 * @return boolean
+	 */
+	public function hasIndices() {
+
+		if ( !$this->client->hasIndex( ElasticClient::TYPE_DATA ) ) {
+			return false;
+		}
+
+		if ( !$this->client->hasIndex( ElasticClient::TYPE_LOOKUP ) ) {
+			return false;
+		}
+
+		return true;
+	}
+
+	/**
 	 * @since 3.0
 	 */
 	public function createIndices() {

--- a/src/Elastic/Indexer/Rollover.php
+++ b/src/Elastic/Indexer/Rollover.php
@@ -130,6 +130,8 @@ class Rollover {
 
 		$params['body'] = [ 'actions' => $actions ];
 		$indices->updateAliases( $params );
+
+		return $index;
 	}
 
 	/**
@@ -165,6 +167,8 @@ class Rollover {
 		}
 
 		$this->connection->releaseLock( $type );
+
+		return $index;
 	}
 
 }

--- a/tests/phpunit/Unit/Elastic/ElasticStoreTest.php
+++ b/tests/phpunit/Unit/Elastic/ElasticStoreTest.php
@@ -1,0 +1,176 @@
+<?php
+
+namespace SMW\Tests\Elastic;
+
+use SMW\Elastic\ElasticStore;
+use SMW\Tests\PHPUnitCompat;
+use SMW\Tests\TestEnvironment;
+
+/**
+ * @covers \SMW\Elastic\ElasticStore
+ * @group semantic-mediawiki
+ *
+ * @license GNU GPL v2+
+ * @since 3.0
+ *
+ * @author mwjames
+ */
+class ElasticStoreTest extends \PHPUnit_Framework_TestCase {
+
+	use PHPUnitCompat;
+
+	private $elasticFactory;
+	private $spyMessageReporter;
+
+	protected function setUp() {
+
+		$this->elasticFactory = $this->getMockBuilder( '\SMW\Elastic\ElasticFactory' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$this->spyMessageReporter = TestEnvironment::getUtilityFactory()->newSpyMessageReporter();
+	}
+
+	public function testCanConstruct() {
+
+		$this->assertInstanceOf(
+			ElasticStore::class,
+			new ElasticStore()
+		);
+	}
+
+	public function testSetup() {
+
+		$row = new \stdClass;
+		$row->smw_id = \SMW\SQLStore\SQLStore::FIXED_PROPERTY_ID_UPPERBOUND;
+		$row->smw_proptable_hash = 'foo';
+		$row->smw_hash = 42;
+		$row->count = 0;
+
+		$connection = $this->getMockBuilder( '\SMW\MediaWiki\Database' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$database = $this->getMockBuilder( '\DatabaseBase' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$database->expects( $this->any() )
+			->method( 'getType' )
+			->will( $this->returnValue( 'mysql' ) );
+
+		$database->expects( $this->any() )
+			->method( 'query' )
+			->will( $this->returnValue( [] ) );
+
+		$database->expects( $this->any() )
+			->method( 'select' )
+			->will( $this->returnValue( [ $row ] ) );
+
+		$database->expects( $this->any() )
+			->method( 'selectRow' )
+			->will( $this->returnValue( $row ) );
+
+		$connectionManager = $this->getMockBuilder( '\SMW\Connection\ConnectionManager' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$callback = function( $type ) use( $connection, $database ) {
+
+			if ( $type === 'mw.db' ) {
+				return $connection;
+			};
+
+			return $database;
+		};
+
+		$connectionManager->expects( $this->any() )
+			->method( 'getConnection' )
+			->will( $this->returnCallback( $callback ) );
+
+		$indexer = $this->getMockBuilder( '\SMW\Elastic\Indexer\Indexer' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$indexer->expects( $this->once() )
+			->method( 'setup' )
+			->will( $this->returnValue( [] ) );
+
+		$this->elasticFactory->expects( $this->once() )
+			->method( 'newIndexer' )
+			->will( $this->returnValue( $indexer ) );
+
+		$instance = new ElasticStore();
+		$instance->setConnectionManager( $connectionManager );
+		$instance->setElasticFactory( $this->elasticFactory );
+		$instance->setMessageReporter( $this->spyMessageReporter );
+
+		$instance->setup( true );
+
+		$this->assertContains(
+			'Setting up indices',
+			$this->spyMessageReporter->getMessagesAsString()
+		);
+	}
+
+	public function testDrop() {
+
+		$connection = $this->getMockBuilder( '\SMW\MediaWiki\Database' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$database = $this->getMockBuilder( '\DatabaseBase' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$database->expects( $this->any() )
+			->method( 'getType' )
+			->will( $this->returnValue( 'mysql' ) );
+
+		$database->expects( $this->any() )
+			->method( 'listTables' )
+			->will( $this->returnValue( [] ) );
+
+		$connectionManager = $this->getMockBuilder( '\SMW\Connection\ConnectionManager' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$callback = function( $type ) use( $connection, $database ) {
+
+			if ( $type === 'mw.db' ) {
+				return $connection;
+			};
+
+			return $database;
+		};
+
+		$connectionManager->expects( $this->any() )
+			->method( 'getConnection' )
+			->will( $this->returnCallback( $callback ) );
+
+		$indexer = $this->getMockBuilder( '\SMW\Elastic\Indexer\Indexer' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$indexer->expects( $this->once() )
+			->method( 'drop' )
+			->will( $this->returnValue( [] ) );
+
+		$this->elasticFactory->expects( $this->once() )
+			->method( 'newIndexer' )
+			->will( $this->returnValue( $indexer ) );
+
+		$instance = new ElasticStore();
+		$instance->setConnectionManager( $connectionManager );
+		$instance->setElasticFactory( $this->elasticFactory );
+		$instance->setMessageReporter( $this->spyMessageReporter );
+
+		$instance->drop( true );
+
+		$this->assertContains(
+			'Dropping indices',
+			$this->spyMessageReporter->getMessagesAsString()
+		);
+	}
+
+}

--- a/tests/phpunit/Unit/Elastic/Indexer/RebuilderTest.php
+++ b/tests/phpunit/Unit/Elastic/Indexer/RebuilderTest.php
@@ -105,6 +105,24 @@ class RebuilderTest extends \PHPUnit_Framework_TestCase {
 		$instance->deleteAndSetupIndices();
 	}
 
+	public function testHasIndices() {
+
+		$this->connection->expects( $this->once() )
+			->method( 'hasIndex' )
+			->will( $this->returnValue( false ) );
+
+		$instance = new Rebuilder(
+			$this->connection,
+			$this->indexer,
+			$this->propertyTableRowMapper,
+			$this->rollover
+		);
+
+		$this->assertFalse(
+			$instance->hasIndices()
+		);
+	}
+
 	public function testCreateIndices() {
 
 		$indices = $this->getMockBuilder( '\stdClass' )


### PR DESCRIPTION
This PR is made in reference to: #

This PR addresses or contains:

- Outputs the indices used during the `setupStore.php`/`udate.php` script run

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed
