### PR TITLE
Add { "LAST_EDITOR": "IS_IMPORTER" } as option for replaceable

### DIFF
--- a/data/import/smw.vocab.json
+++ b/data/import/smw.vocab.json
@@ -8,7 +8,7 @@
 				"importFrom": "/vocabularies/skos.txt"
 			},
 			"options": {
-				"canReplace": false
+				"replaceable": false
 			}
 		},
 		{
@@ -18,7 +18,7 @@
 				"importFrom": "/vocabularies/foaf.txt"
 			},
 			"options": {
-				"canReplace": false
+				"replaceable": false
 			}
 		},
 		{
@@ -28,7 +28,7 @@
 				"importFrom": "/vocabularies/owl.txt"
 			},
 			"options": {
-				"canReplace": false
+				"replaceable": false
 			}
 		},
 		{
@@ -38,7 +38,7 @@
 				"importFrom": "/properties/foaf.knows.txt"
 			},
 			"options": {
-				"canReplace": false
+				"replaceable": false
 			}
 		},
 		{
@@ -48,7 +48,7 @@
 				"importFrom": "/properties/foaf.name.txt"
 			},
 			"options": {
-				"canReplace": false
+				"replaceable": false
 			}
 		},
 		{
@@ -58,7 +58,7 @@
 				"importFrom": "/properties/foaf.homepage.txt"
 			},
 			"options": {
-				"canReplace": false
+				"replaceable": false
 			}
 		},
 		{
@@ -68,7 +68,7 @@
 				"importFrom": "/properties/owl.differentFrom.txt"
 			},
 			"options": {
-				"canReplace": false
+				"replaceable": false
 			}
 		}
 	],

--- a/src/Importer/ImportContents.php
+++ b/src/Importer/ImportContents.php
@@ -10,8 +10,8 @@ namespace SMW\Importer;
  */
 class ImportContents {
 
-	const CONTENT_TEXT = 'content.text';
-	const CONTENT_XML = 'content.xml';
+	const CONTENT_TEXT = 'text/plain';
+	const CONTENT_XML = 'text/xml';
 
 	/**
 	 * @var string

--- a/src/MediaWiki/TitleFactory.php
+++ b/src/MediaWiki/TitleFactory.php
@@ -3,6 +3,8 @@
 namespace SMW\MediaWiki;
 
 use Title;
+use WikiFilePage;
+use WikiPage;
 
 /**
  * @license GNU GPL v2+
@@ -49,6 +51,7 @@ class TitleFactory {
 	public function newFromIDs( $ids ) {
 		return Title::newFromIDs( $ids );
 	}
+
 	/**
 	 * @since 3.0
 	 *
@@ -61,6 +64,28 @@ class TitleFactory {
 	 */
 	public function makeTitleSafe( $ns, $title, $fragment = '', $interwiki = '' ) {
 		return Title::makeTitleSafe( $ns, $title, $fragment, $interwiki );
+	}
+
+	/**
+	 * @since 3.1
+	 *
+	 * @param Title $title
+	 *
+	 * @return WikiPage
+	 */
+	public function createPage( Title $title ) {
+		return WikiPage::factory( $title );
+	}
+
+	/**
+	 * @since 3.1
+	 *
+	 * @param Title $title
+	 *
+	 * @return WikiFilePage
+	 */
+	public function createFilePage( Title $title ) {
+		return new WikiFilePage( $title );
 	}
 
 }

--- a/src/Services/ImporterServices.php
+++ b/src/Services/ImporterServices.php
@@ -55,7 +55,7 @@ return [
 		$connectionManager = $containerBuilder->singleton( 'ConnectionManager' );
 
 		$textContentCreator = new TextContentCreator(
-			$containerBuilder->create( 'PageCreator' ),
+			$containerBuilder->create( 'TitleFactory' ),
 			$connectionManager->getConnection( 'mw.db' )
 		);
 

--- a/tests/phpunit/Unit/Services/ImporterServiceFactoryTest.php
+++ b/tests/phpunit/Unit/Services/ImporterServiceFactoryTest.php
@@ -26,11 +26,11 @@ class ImporterServiceFactoryTest extends \PHPUnit_Framework_TestCase {
 
 		$this->containerBuilder = $callbackContainerFactory->newCallbackContainerBuilder();
 
-		$pageCreator = $this->getMockBuilder( '\SMW\MediaWiki\PageCreator' )
+		$titleFactory = $this->getMockBuilder( '\SMW\MediaWiki\TitleFactory' )
 			->disableOriginalConstructor()
 			->getMock();
 
-		$this->containerBuilder->registerObject( 'PageCreator', $pageCreator );
+		$this->containerBuilder->registerObject( 'TitleFactory', $titleFactory );
 
 		$importStringSource = $this->getMockBuilder( '\ImportStringSource' )
 			->disableOriginalConstructor()

--- a/tests/phpunit/Unit/Services/ImporterServicesContainerBuildTest.php
+++ b/tests/phpunit/Unit/Services/ImporterServicesContainerBuildTest.php
@@ -18,7 +18,7 @@ class ImporterServicesContainerBuildTest extends \PHPUnit_Framework_TestCase {
 	private $callbackContainerFactory;
 	private $connectionManager;
 	private $servicesFileDir;
-	private $pageCreator;
+	private $titleFactory;
 
 	protected function setUp() {
 		parent::setUp();
@@ -27,7 +27,7 @@ class ImporterServicesContainerBuildTest extends \PHPUnit_Framework_TestCase {
 			->disableOriginalConstructor()
 			->getMock();
 
-		$this->pageCreator = $this->getMockBuilder( '\SMW\MediaWiki\PageCreator' )
+		$this->titleFactory = $this->getMockBuilder( '\SMW\MediaWiki\TitleFactory' )
 			->disableOriginalConstructor()
 			->getMock();
 
@@ -52,7 +52,7 @@ class ImporterServicesContainerBuildTest extends \PHPUnit_Framework_TestCase {
 
 		$containerBuilder = $this->callbackContainerFactory->newCallbackContainerBuilder();
 
-		$containerBuilder->registerObject( 'PageCreator', $this->pageCreator );
+		$containerBuilder->registerObject( 'TitleFactory', $this->titleFactory );
 		$containerBuilder->registerObject( 'ConnectionManager', $this->connectionManager );
 
 		$containerBuilder->registerObject( 'Settings', new Settings( [


### PR DESCRIPTION
This PR is made in reference to: #

This PR addresses or contains:

- Setting `{ "LAST_EDITOR": "IS_IMPORTER" }` allows for imported content to be replaced as long as the last editor is the same as the imported making sure that the content was not edited by any other individual 

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed

Fixes #