### PR TITLE
Add schema group import, refs 2874

### DIFF
--- a/DefaultSettings.php
+++ b/DefaultSettings.php
@@ -2058,6 +2058,11 @@ return [
 			'validation_schema' => __DIR__ . '/data/schema/search-form-schema.v1.json',
 			'group' => SMW_SCHEMA_GROUP_SEARCH_FORM,
 			'type_description' => 'smw-schema-description-search-form-schema'
+		],
+		'PROPERTY_GROUP_SCHEMA' => [
+			'validation_schema' => __DIR__ . '/data/schema/property-group-schema.v1.json',
+			'group' => SMW_SCHEMA_GROUP_PROPERTY,
+			'type_description' => 'smw-schema-description-property-group-schema'
 		]
 	],
 	##

--- a/data/import/groups/schema.json
+++ b/data/import/groups/schema.json
@@ -1,0 +1,22 @@
+{
+    "type": "PROPERTY_GROUP_SCHEMA",
+    "manifest_version": 1,
+    "groups": {
+        "schema_properties": {
+            "group_name": "Schema properties",
+            "msg_key": "smw-property-group-label-schema-group",
+            "property_list": [
+                "_SCHEMA_TYPE",
+                "_SCHEMA_DEF",
+                "_SCHEMA_DESC",
+                "_SCHEMA_TAG",
+                "_SCHEMA_LINK",
+                "_FORMAT_SCHEMA"
+            ]
+        }
+    },
+    "tags": [
+        "group",
+        "property group"
+    ]
+}

--- a/data/import/smw.groups.json
+++ b/data/import/smw.groups.json
@@ -1,0 +1,18 @@
+{
+	"description": "Semantic MediaWiki group import",
+	"import": [
+		{
+			"page": "Group:schema properties",
+			"namespace": "SMW_NS_SCHEMA",
+			"contents": {
+				"importFrom": "/groups/schema.json"
+			},
+			"options": {
+				"replaceable": { "LAST_EDITOR": "IS_IMPORTER" }
+			}
+		}
+	],
+	"meta": {
+		"version": "1"
+	}
+}

--- a/data/schema/property-group-schema.v1.json
+++ b/data/schema/property-group-schema.v1.json
@@ -1,0 +1,99 @@
+{
+	"$schema": "http://json-schema.org/draft-07/schema#",
+	"$id": "https://www.semantic-mediawiki.org/wiki/Help:Schema/Type/PROPERTY_GROUP_SCHEMA",
+	"type": "object",
+	"title": "Property group validation schema",
+	"required": [
+		"type",
+		"groups"
+	],
+	"properties": {
+		"type": {
+			"$id": "#/properties/type",
+			"type": "string",
+			"enum": [
+				"PROPERTY_GROUP_SCHEMA"
+			],
+			"title": "Schema type",
+			"default": "PROPERTY_GROUP_SCHEMA"
+		},
+		"manifest_version": {
+			"$id": "#/properties/manifest_version",
+			"type": "number",
+			"title": "Manifest version",
+			"default": 1
+		},
+		"tags": {
+			"$id": "#/properties/tags",
+			"type": "array",
+			"title": "tags",
+			"default": null,
+			"items": {
+				"$id": "#/properties/tags/items",
+				"type": "string",
+				"title": "tags, keywords etc.",
+				"default": "",
+				"pattern": "^(.*)$"
+			}
+		},
+		"groups": {
+			"$id": "#/properties/groups",
+			"type": "object",
+			"title": "group list",
+			"minProperties": 1,
+			"propertyNames": {
+				"pattern": "^[A-Za-z_][A-Za-z0-9_]*$"
+			},
+			"additionalProperties": {
+				"$ref": "#/definitions/group"
+			}
+		}
+	},
+	"definitions": {
+		"msg_key": {
+			"type": "string",
+			"title": "message key/label",
+			"default": "",
+			"examples": [
+				"smw-property-group-label-schema-group"
+			],
+			"pattern": "^(smw|sesp|sbl|scite|sg)-property-group-label-(.*)$"
+		},
+		"group_name": {
+			"type": "string",
+			"title": "Simple group label",
+			"default": "",
+			"pattern": "^(.*)$"
+		},
+		"property_list": {
+			"type": "array",
+			"title": "property list",
+			"minItems": 1,
+			"items": {
+				"type": "string",
+				"title": "property",
+				"default": "",
+				"pattern": "^(.*)$"
+			}
+		},
+		"group": {
+			"type": "object",
+			"title": "group",
+			"properties": {
+				"msg_key": {
+					"$ref": "#/definitions/msg_key"
+				},
+				"group_name": {
+					"$ref": "#/definitions/group_name"
+				},
+				"property_list": {
+					"$ref": "#/definitions/property_list"
+				}
+			},
+			"additionalProperties": false,
+			"required": [
+				"property_list"
+			]
+		}
+	}
+}

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -858,6 +858,7 @@
 	"smw-schema-type": "Type",
 	"smw-schema-description-link-format-schema": "This schema type is expected to define characteristics for creating context sensitive links in connection with a [[Property:Formatter schema|formatter schema]] assigned property.",
 	"smw-schema-description-search-form-schema": "This schema type is expected to be used to define input forms and characteristics for the [https://www.semantic-mediawiki.org/wiki/Help:SMWSearch extended search] profile where it contains instructions on how to generate input fields, define default namespaces, or declare prefix expressions for a search request.",
+	"smw-schema-description-property-group-schema": "This schema type defines [https://www.semantic-mediawiki.org/wiki/Help:Property_group property groups] to help structure the [https://www.semantic-mediawiki.org/wiki/Help:Special:Browse browsing] interface.",
 	"smw-schema-tag": "{{PLURAL:$1|Tag|Tags}}",
 	"smw-property-predefined-schema-desc": "\"$1\" is a predefined property that stores a schema description and is provided by [https://www.semantic-mediawiki.org/wiki/Help:Special_properties Semantic MediaWiki].",
 	"smw-property-predefined-schema-def": "\"$1\" is a predefined property that stores the schema content and is provided by [https://www.semantic-mediawiki.org/wiki/Help:Special_properties Semantic MediaWiki].",

--- a/src/Defines.php
+++ b/src/Defines.php
@@ -285,6 +285,7 @@ define( 'SMW_REMOTE_REQ_SHOW_NOTE', 4 ); // Shows a note
   */
 define( 'SMW_SCHEMA_GROUP_FORMAT', 'schema.group.format' );
 define( 'SMW_SCHEMA_GROUP_SEARCH_FORM', 'schema.group.search.form' );
+define( 'SMW_SCHEMA_GROUP_PROPERTY', 'schema.group.property' );
 
 /**@{
   * Constants for Special:Ask submit method

--- a/src/Importer/ContentCreators/TextContentCreator.php
+++ b/src/Importer/ContentCreators/TextContentCreator.php
@@ -152,7 +152,17 @@ class TextContentCreator implements ContentCreator {
 			$page->getUser()
 		);
 
-		return $page->getCreator()->equals( $lastEditor );
+		if ( !$lastEditor instanceof \User ) {
+			return false;
+		}
+
+		$creator = $page->getCreator();
+
+		if ( !$creator instanceof \User ) {
+			return false;
+		}
+
+		return $creator->equals( $lastEditor );
 	}
 
 }

--- a/src/MediaWiki/Specials/Browse/HtmlBuilder.php
+++ b/src/MediaWiki/Specials/Browse/HtmlBuilder.php
@@ -368,9 +368,11 @@ class HtmlBuilder {
 		$diProperties = $semanticData->getProperties();
 
 		$showGroup = $this->getOption( 'showGroup' ) && $this->getOption( 'group' ) !== 'hide';
+		$applicationFactory = ApplicationFactory::getInstance();
 
 		$groupFormatter = new GroupFormatter(
-			ApplicationFactory::getInstance()->getPropertySpecificationLookup()
+			$applicationFactory->getPropertySpecificationLookup(),
+			$applicationFactory->singleton( 'SchemaFactory' )->newSchemaFinder( $this->store )
 		);
 
 		$groupFormatter->showGroup( $showGroup );

--- a/tests/phpunit/Unit/MediaWiki/Api/Browse/SubjectLookupTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Api/Browse/SubjectLookupTest.php
@@ -47,6 +47,10 @@ class SubjectLookupTest extends \PHPUnit_Framework_TestCase {
 			->method( 'getSemanticData' )
 			->will( $this->returnValue( $semanticData ) );
 
+		$this->store->expects( $this->any() )
+			->method( 'getPropertySubjects' )
+			->will( $this->returnValue( [] ) );
+
 		$instance = new SubjectLookup(
 			$this->store
 		);

--- a/tests/phpunit/Unit/MediaWiki/Api/BrowseBySubjectTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Api/BrowseBySubjectTest.php
@@ -174,6 +174,10 @@ class BrowseBySubjectTest extends \PHPUnit_Framework_TestCase {
 			->with( $this->equalTo( $dataItem ) )
 			->will( $this->returnValue( $semanticData ) );
 
+		$store->expects( $this->any() )
+			->method( 'getPropertySubjects' )
+			->will( $this->returnValue( [] ) );
+
 		$this->testEnvironment->registerObject( 'Store', $store );
 
 		$instance = new BrowseBySubject(

--- a/tests/phpunit/Unit/MediaWiki/Specials/Browse/HtmlBuilderTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Specials/Browse/HtmlBuilderTest.php
@@ -33,6 +33,10 @@ class HtmlBuilderTest extends \PHPUnit_Framework_TestCase {
 			->disableOriginalConstructor()
 			->getMockForAbstractClass();
 
+		$this->store->expects( $this->any() )
+			->method( 'getPropertySubjects' )
+			->will( $this->returnValue( [] ) );
+
 		$this->testEnvironment->registerObject( 'Store', $this->store );
 	}
 

--- a/tests/phpunit/Unit/MediaWiki/Specials/SpecialBrowseTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Specials/SpecialBrowseTest.php
@@ -31,6 +31,10 @@ class SpecialBrowseTest extends \PHPUnit_Framework_TestCase {
 			->disableOriginalConstructor()
 			->getMockForAbstractClass();
 
+		$store->expects( $this->any() )
+			->method( 'getPropertySubjects' )
+			->will( $this->returnValue( [] ) );
+
 		$this->testEnvironment->registerObject( 'Store', $store );
 		$this->stringValidator = $this->testEnvironment->getUtilityFactory()->newValidatorFactory()->newStringValidator();
 	}


### PR DESCRIPTION
This PR is made in reference to: #2874

This PR addresses or contains:

- Adds `PROPERTY_GROUP_SCHEMA` for isolating the management of group assignments via a schema
- `import/smw.groups.json`/`schema.json` define the import for creating a group for schema related properties

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed

Fixes #