### PR TITLE
Declare [?, *, !] as invalid property characters, refs 2282

### DIFF
--- a/DefaultSettings.php
+++ b/DefaultSettings.php
@@ -1825,11 +1825,15 @@ return [
 	# Listed characters are categorized as invalid for a property label and will
 	# result in an error.
 	#
-	# @see #1568, #1638, 3134
+	# @see #1568, #1638, #3134
 	#
 	# @since 2.5
 	##
-	'smwgPropertyInvalidCharacterList' => [ '[', ']' , '|' , '<' , '>', '{', '}', '+', '–', '%', "\r", "\n" ],
+	'smwgPropertyInvalidCharacterList' => [
+		// Common characters
+		'[', ']' , '|' , '<' , '>', '{', '}', '+', '–', '%', "\r", "\n",
+		'?', '*', '!'
+	],
 	##
 
 	##

--- a/tests/phpunit/Integration/JSONScript/TestCases/q-0101.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/q-0101.json
@@ -18,7 +18,7 @@
 		},
 		{
 			"namespace": "SMW_NS_PROPERTY",
-			"page": "abc-123&^*",
+			"page": "abc-123&^",
 			"contents": "[[Has type::Text]]"
 		},
 		{
@@ -36,7 +36,7 @@
 		},
 		{
 			"page": "Examples/Q0101/4",
-			"contents": "[[abc-123&^*::foo-123#&^*%<1?=/->\"']]"
+			"contents": "[[abc-123&^::foo-123#&^*%<1?=/->\"']]"
 		}
 	],
 	"tests": [
@@ -100,7 +100,7 @@
 		{
 			"type": "query",
 			"about": "#3 with special chars",
-			"condition": "[[abc-123&^*::foo-123#&^*%<1?=/->\"']]",
+			"condition": "[[abc-123&^::foo-123#&^*%<1?=/->\"']]",
 			"parameters" : {
 				"limit" : "10"
 			},


### PR DESCRIPTION
This PR is made in reference to: #2282

This PR addresses or contains:

- Extends the list of invalid characters (`?`, `*`, `!`) for a property name which means that creating annotations that contain `[[Foo!::...]]`,`[[F*oo::...]]`, `[[?Foo::...]]`, or any combination of it will no longer be excepted
- `?`, `*`, `!` are part of the query language and can easily be confused or mixed when expressing  the intention
- Property names should be clear, simple, expressive to convey the intention using special characters should be avoided as they dilute the representation, of course users are free the modify `smwgPropertyInvalidCharacterList` but it is not recommended

This PR includes:
- [ ] Tests (unit/integration)
- [x] CI build passed
