### PR TITLE
ParserAfterTidy, `NS_FILE` update on purge

### DIFF
--- a/src/MediaWiki/Hooks.php
+++ b/src/MediaWiki/Hooks.php
@@ -272,6 +272,8 @@ class Hooks {
 	 */
 	public function onParserAfterTidy( &$parser, &$text ) {
 
+		$applicationFactory = ApplicationFactory::getInstance();
+
 		$parserAfterTidy = new ParserAfterTidy(
 			$parser
 		);
@@ -285,6 +287,10 @@ class Hooks {
 		// or update the Store
 		$parserAfterTidy->isReadOnly(
 			Site::isBlocked()
+		);
+
+		$parserAfterTidy->setLogger(
+			$applicationFactory->getMediaWikiLogger()
 		);
 
 		$parserAfterTidy->process( $text );

--- a/src/MediaWiki/Hooks/ParserAfterTidy.php
+++ b/src/MediaWiki/Hooks/ParserAfterTidy.php
@@ -107,6 +107,14 @@ class ParserAfterTidy extends HookHandler {
 			return false;
 		}
 
+		// Allow to perform even without a `[[...::...]]` text so that a change
+		// (such as an approved file version) is run through the annotation and
+		// update process
+		// @see SemanticApprovedRevs#2
+		if ( $title->getNamespace() === NS_FILE ) {
+			return true;
+		}
+
 		// ParserOptions::getInterfaceMessage is being used to identify whether a
 		// parse was initiated by `Message::parse`
 		if ( $title->isSpecialPage() || $this->parser->getOptions()->getInterfaceMessage() ) {
@@ -153,7 +161,7 @@ class ParserAfterTidy extends HookHandler {
 		// Only carry out a purge where the InTextAnnotationParser have set
 		// an appropriate context reference otherwise it is assumed that the hook
 		// call is part of another non SMW related parse
-		if ( $subject->getContextReference() !== null || $subject->getNamespace() === SMW_NS_SCHEMA ) {
+		if ( $subject->getContextReference() !== null || $subject->getNamespace() === NS_FILE ) {
 			$this->checkPurgeRequest( $parserData );
 		}
 	}


### PR DESCRIPTION
This PR is made in reference to: https://github.com/SemanticMediaWiki/SemanticApprovedRevs/issues/2

This PR addresses or contains:

- `ApprovedRevs` sends a purge event when changing the file revision, so in order for `SemanticApprovedRevs` to hook into the update event allow the purge to go through even without any text annotation 

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed
