### PR TITLE
Add hook to skip update, refs 3712

### DIFF
--- a/docs/technical/hooks.md
+++ b/docs/technical/hooks.md
@@ -410,6 +410,24 @@ Hooks::register( 'SMW::Factbox::OverrideRevisionID', function( $title, &$latestR
 } );
 </pre>
 
+## SMW::DataUpdater::SkipUpdate
+
+* Version: 3.1
+* Description: Hook allows to suppress an update, for example the `latestRevID` is not the revision that is approved an should not be used for the `SemanticData` representation.
+* Reference class: `SMW\DataUpdater`
+
+<pre>
+use Hooks;
+
+Hooks::register( 'SMW::DataUpdater::SkipUpdate', function( $title, $latestRevID ) {
+
+	// If you need to decline an update
+	// return false;
+
+	return true;
+} );
+</pre>
+
 ## Other available hooks
 
 Subsequent hooks should be renamed to follow a common naming practice that help distinguish them from other hook providers. In any case this list needs details and examples.

--- a/src/DataUpdater.php
+++ b/src/DataUpdater.php
@@ -153,13 +153,21 @@ class DataUpdater {
 	 */
 	public function isSkippable( Title $title ) {
 
+		$latestRevID = $title->getLatestRevID( Title::GAID_FOR_UPDATE );
+
+		// Allow a third-party extension to suppress the update process
+		// @see SemanticApprovedRevs
+		if ( \Hooks::run( 'SMW::DataUpdater::SkipUpdate', [ $title, $latestRevID ] ) === false ) {
+			return true;
+		}
+
 		$associatedRev = $this->store->getObjectIds()->findAssociatedRev(
 			$title->getDBKey(),
 			$title->getNamespace(),
 			$title->getInterwiki()
 		);
 
-		return $associatedRev == $title->getLatestRevID( Title::GAID_FOR_UPDATE );
+		return $associatedRev == $latestRevID;
 	}
 
 	/**


### PR DESCRIPTION
This PR is made in reference to: #3712, https://github.com/SemanticMediaWiki/SemanticApprovedRevs

This PR addresses or contains:

- Adds `SMW::DataUpdater::SkipUpdate`

This PR includes:
- [ ] Tests (unit/integration)
- [x] CI build passed
