### PR TITLE
[ES] FileIndexer, add hook, use `waitOnCommandLine` for `FileIngestJob`

### DIFF
--- a/docs/technical/hooks.md
+++ b/docs/technical/hooks.md
@@ -428,6 +428,23 @@ Hooks::register( 'SMW::DataUpdater::SkipUpdate', function( $title, $latestRevID 
 } );
 </pre>
 
+## SMW::ElasticStore::FileIndexer::ChangeFileBeforeIngestProcessComplete
+
+* Version: 3.1
+* Description: Hook allows to forcibly change the file version used for the ingest process.
+* Reference class: `SMW\Elastic\Indexer\FileIndexer`
+
+<pre>
+use Hooks;
+
+Hooks::register( 'SMW::ElasticStore::FileIndexer::ChangeFileBeforeIngestProcessComplete', function( $title, &$file ) {
+
+	// $file = ...;
+
+	return true;
+} );
+</pre>
+
 ## Other available hooks
 
 Subsequent hooks should be renamed to follow a common naming practice that help distinguish them from other hook providers. In any case this list needs details and examples.

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -891,8 +891,11 @@
 	"smw-helplink": "https://www.semantic-mediawiki.org/wiki/Help:$1",
 	"smw-es-replication-check": "Replication check (Elasticsearch)",
 	"smw-es-replication-error": "Replication issue",
+	"smw-es-replication-file-ingest-error": "File ingest issue",
 	"smw-es-replication-error-missing-id": "The replication monitoring has found that article \"$1\" (ID: $2) is missing from the Elasticsearch backend.",
 	"smw-es-replication-error-divergent-date": "The replication monitoring has found that for the \"$1\" article (ID: $2) the modification date shows a discrepancy.",
 	"smw-es-replication-error-divergent-date-detail": "*$1 (Elasticsearch)\n*$2 (SQLStore)",
-	"smw-es-replication-error-suggestions": "It is suggested to edit or purge the page to remove the discrepancy. If the issue remains then check the Elasticsearch cluster itself (allocator, exceptions, disk space etc.)."
+	"smw-es-replication-error-suggestions": "It is suggested to edit or purge the page to remove the discrepancy. If the issue remains then check the Elasticsearch cluster itself (allocator, exceptions, disk space etc.).",
+	"smw-es-replication-error-file-ingest-missing-file-attachment": "The replication monitoring has found that \"$1\" is missing a [[Property:File attachment|File attachment]] annotation indicating that the file ingest processor hasn't started or isn't finished.",
+	"smw-es-replication-error-file-ingest-missing-file-attachment-suggestions": "Please ensure that the [https://www.semantic-mediawiki.org/wiki/Help:ElasticStore/File_ingestion file ingest] job is scheduled and executed before the annotation and file index can be made available."
 }

--- a/src/Elastic/ElasticStore.php
+++ b/src/Elastic/ElasticStore.php
@@ -270,8 +270,8 @@ class ElasticStore extends SQLStore {
 			]
 		);
 
-		if ( $subject->getNamespace() === NS_FILE && $config->dotGet( 'indexer.experimental.file.ingest', false ) && $semanticData->getOption( 'is.fileupload' ) ) {
-			$this->indexer->getFileIndexer()->pushIngestJob( $subject->getTitle() );
+		if ( $config->dotGet( 'indexer.experimental.file.ingest', false ) && $semanticData->getOption( 'is.fileupload' ) ) {
+			$this->ingestFile( $subject->getTitle() );
  		}
 	}
 
@@ -373,6 +373,15 @@ class ElasticStore extends SQLStore {
 		return [
 			'SMWElasticStore' => $database->getInfo() + [ 'es' => $client->getVersion() ]
 		];
+	}
+
+	private function ingestFile( $title, array $params = [] ) {
+
+		if ( $title->getNamespace() !== NS_FILE ) {
+			return;
+		}
+
+		$this->indexer->getFileIndexer()->pushIngestJob( $title, $params );
 	}
 
 }

--- a/src/Elastic/Indexer/FileIngestJob.php
+++ b/src/Elastic/Indexer/FileIngestJob.php
@@ -36,6 +36,12 @@ class FileIngestJob extends Job {
 	 */
 	public function run() {
 
+		// Make sure the script is only executed from the command line to avoid
+		// Special:RunJobs to execute a queued job
+		if ( $this->waitOnCommandLineMode() ) {
+			return true;
+		}
+
 		$applicationFactory = ApplicationFactory::getInstance();
 		$store = $applicationFactory->getStore();
 

--- a/tests/phpunit/Unit/Elastic/Indexer/Replication/CheckReplicationTaskTest.php
+++ b/tests/phpunit/Unit/Elastic/Indexer/Replication/CheckReplicationTaskTest.php
@@ -5,6 +5,7 @@ namespace SMW\Tests\Elastic\Indexer\Replication;
 use SMW\Elastic\Indexer\Replication\CheckReplicationTask;
 use SMW\Tests\PHPUnitCompat;
 use SMW\DIWikiPage;
+use SMW\DIProperty;
 
 /**
  * @covers \SMW\Elastic\Indexer\Replication\CheckReplicationTask
@@ -22,6 +23,7 @@ class CheckReplicationTaskTest extends \PHPUnit_Framework_TestCase {
 	private $store;
 	private $replicationStatus;
 	private $entityCache;
+	private $elasticClient;
 
 	protected function setUp() {
 
@@ -31,7 +33,7 @@ class CheckReplicationTaskTest extends \PHPUnit_Framework_TestCase {
 
 		$this->store = $this->getMockBuilder( '\SMW\Store' )
 			->disableOriginalConstructor()
-			->setMethods( [ 'getObjectIds' ] )
+			->setMethods( [ 'getObjectIds', 'getConnection' ] )
 			->getMockForAbstractClass();
 
 		$this->store->expects( $this->any() )
@@ -39,6 +41,10 @@ class CheckReplicationTaskTest extends \PHPUnit_Framework_TestCase {
 			->will( $this->returnValue( $idTable ) );
 
 		$this->replicationStatus = $this->getMockBuilder( '\SMW\Elastic\Indexer\Replication\ReplicationStatus' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$this->elasticClient = $this->getMockBuilder( '\SMW\Elastic\Connection\Client' )
 			->disableOriginalConstructor()
 			->getMock();
 
@@ -72,6 +78,56 @@ class CheckReplicationTaskTest extends \PHPUnit_Framework_TestCase {
 		);
 
 		$html = $instance->checkReplication( DIWikiPage::newFromText( 'Foo' ), [] );
+
+		$this->assertContains(
+			'smw-highlighter',
+			$html
+		);
+	}
+
+	public function testCheckReplication_File() {
+
+		$config = $this->getMockBuilder( '\SMW\Options' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$config->expects( $this->any() )
+			->method( 'dotGet' )
+			->with(	$this->equalTo( 'indexer.experimental.file.ingest' ) )
+			->will( $this->returnValue( true ) );
+
+		$this->elasticClient->expects( $this->any() )
+			->method( 'getConfig' )
+			->will( $this->returnValue( $config ) );
+
+		$subject = DIWikiPage::newFromText( 'Foo', NS_FILE );
+
+		$this->replicationStatus->expects( $this->once() )
+			->method( 'getModificationDate' )
+			->will( $this->returnValue( $subject ) );
+
+		$this->store->expects( $this->at( 1 ) )
+			->method( 'getPropertyValues' )
+			->will( $this->returnValue( [ $subject ] ) );
+
+		$this->store->expects( $this->at( 3 ) )
+			->method( 'getPropertyValues' )
+			->with(
+				$this->equalTo( $subject ),
+				$this->equalTo( new DIProperty( '_FILE_ATTCH' ) ) )
+			->will( $this->returnValue( [] ) );
+
+		$this->store->expects( $this->any() )
+			->method( 'getConnection' )
+			->will( $this->returnValue( $this->elasticClient ) );
+
+		$instance = new CheckReplicationTask(
+			$this->store,
+			$this->replicationStatus,
+			$this->entityCache
+		);
+
+		$html = $instance->checkReplication( $subject, [] );
 
 		$this->assertContains(
 			'smw-highlighter',


### PR DESCRIPTION
This PR is made in reference to: https://github.com/SemanticMediaWiki/SemanticApprovedRevs/issues/2

This PR addresses or contains:

- Adds `SMW::ElasticStore::FileIndexer::ChangeFileBeforeIngestProcessComplete` hook
- Use `waitOnCommandLine` for the `FileIngestJob` to avoid having the job run as part of a GET request (see `Special:RunJobs`) and only allow the ingest to happen when a cron job runs index process using the command line
- `CheckReplicationTask.php` (#3700)  now also checks for ingest progress

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed

## Output

![image](https://user-images.githubusercontent.com/1245473/53702060-12065000-3dfb-11e9-8b9c-874f8c7cdc53.png)
