### PR TITLE
ParserAfterTidy, listen to external event

### DIFF
--- a/src/MediaWiki/Hooks.php
+++ b/src/MediaWiki/Hooks.php
@@ -275,7 +275,9 @@ class Hooks {
 		$applicationFactory = ApplicationFactory::getInstance();
 
 		$parserAfterTidy = new ParserAfterTidy(
-			$parser
+			$parser,
+			$applicationFactory->getNamespaceExaminer(),
+			$applicationFactory->getCache()
 		);
 
 		$parserAfterTidy->isCommandLineMode(

--- a/src/MediaWiki/Hooks/ArticlePurge.php
+++ b/src/MediaWiki/Hooks/ArticlePurge.php
@@ -26,6 +26,8 @@ class ArticlePurge {
 
 	use EventDispatcherAwareTrait;
 
+	const CACHE_NAMESPACE = 'smw:arc';
+
 	/**
 	 * @since 1.9
 	 *
@@ -36,16 +38,15 @@ class ArticlePurge {
 		$applicationFactory = ApplicationFactory::getInstance();
 
 		$title = $wikiPage->getTitle();
-		$pageId = $title->getArticleID();
+		$articleID = $title->getArticleID();
 
 		$settings = $applicationFactory->getSettings();
 
 		$cache = $applicationFactory->getCache();
-		$cacheFactory = $applicationFactory->newCacheFactory();
 
-		if ( $pageId > 0 ) {
+		if ( $articleID > 0 ) {
 			$cache->save(
-				$cacheFactory->getPurgeCacheKey( $pageId ),
+				smwfCacheKey( self::CACHE_NAMESPACE, $articleID ),
 				$settings->get( 'smwgAutoRefreshOnPurge' )
 			);
 		}

--- a/tests/phpunit/Unit/CacheFactoryTest.php
+++ b/tests/phpunit/Unit/CacheFactoryTest.php
@@ -60,7 +60,7 @@ class CacheFactoryTest extends \PHPUnit_Framework_TestCase {
 			->disableOriginalConstructor()
 			->getMock();
 
-		$title->expects( $this->once() )
+		$title->expects( $this->any() )
 			->method( 'getArticleID' )
 			->will( $this->returnValue( 42 ) );
 
@@ -68,6 +68,16 @@ class CacheFactoryTest extends \PHPUnit_Framework_TestCase {
 
 		$this->assertInternalType(
 			'string',
+			$instance->getPurgeCacheKey( $title )
+		);
+
+		$this->assertSame(
+			smwfCacheKey( 'smw:arc', 42 ),
+			$instance->getPurgeCacheKey( $title )
+		);
+
+		$this->assertSame(
+			smwfCacheKey( \SMW\MediaWiki\Hooks\ArticlePurge::CACHE_NAMESPACE, 42 ),
 			$instance->getPurgeCacheKey( $title )
 		);
 	}


### PR DESCRIPTION
This PR is made in reference to: https://github.com/SemanticMediaWiki/SemanticApprovedRevs

This PR addresses or contains:

- While working on SemanticApprovedRevs, certain events require to run an update on `ParserAfterTidy` (`ApprovedRevs` sends for any approve/unapprove a `purge` request) even though the content doesn't contain any annotations (we normally ignore those requests where no annotation is involved == being "blank" page) but an agent may switch from a version with annotations to one without and in those cases we have to ensure that the store is updated as well so no annotations are left over

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed
