### PR TITLE
Remove `doPostOutputShutdown`, refs 3690

### DIFF
--- a/src/GlobalFunctions.php
+++ b/src/GlobalFunctions.php
@@ -108,12 +108,6 @@ function smwfAbort( $text, $title = 'Error',  $type = 'error' ) {
 	$html .= "<title>{$title}</title><div style='float:right;'>$indicator</div></head><body><h2>{$title}</h2>$hr";
 	$html .= "<p>{$text}</p></body></html>";
 
-	// MW 1.26
-	// Manages deferred updates, job insertion, final commit, and the logging of
-	// profiling data
-	$mediaWiki = new \MediaWiki();
-	$mediaWiki->doPostOutputShutdown( 'fast' );
-
 	die( $html );
 }
 


### PR DESCRIPTION
This PR is made in reference to: #3690

This PR addresses or contains:

- According to #3690, if remove `doPostOutputShutdown` then there should be no issue with MW 1.33

This PR includes:
- [ ] Tests (unit/integration)
- [ ] CI build passed

Fixes #3690