### PR TITLE
Fix "... expects parameter 1 to be a valid callback ...", refs 3765

### DIFF
--- a/src/MediaWiki/Deferred/CallableUpdate.php
+++ b/src/MediaWiki/Deferred/CallableUpdate.php
@@ -323,7 +323,7 @@ class CallableUpdate implements DeferrableUpdate {
 		];
 	}
 
-	private function emptyCallback() {
+	protected function emptyCallback() {
 		$this->logger->info(
 			[
 				'DeferrableUpdate',

--- a/src/MediaWiki/Deferred/TransactionalCallableUpdate.php
+++ b/src/MediaWiki/Deferred/TransactionalCallableUpdate.php
@@ -171,7 +171,7 @@ class TransactionalCallableUpdate extends CallableUpdate {
 	 */
 	public function cancelOnRollback( $trigger ) {
 		if ( $trigger === Database::TRIGGER_ROLLBACK ) {
-			$this->callback = null;
+			$this->callback = [ $this, 'emptyCancelCallback' ];
 		}
 	}
 
@@ -263,6 +263,13 @@ class TransactionalCallableUpdate extends CallableUpdate {
 
 			call_user_func( $postCallback, $this->transactionTicket );
 		}
+	}
+
+	protected function emptyCancelCallback() {
+		$this->logger->info(
+			[ 'DeferrableUpdate', 'cancelOnRollback' ],
+			[ 'role' => 'developer', 'method' => __METHOD__ ]
+		);
 	}
 
 }


### PR DESCRIPTION
This PR is made in reference to: #3765

This PR addresses or contains:

- `cancelOnRollback` was setting a null and caused "PHP Warning:  call_user_func() expects parameter 1 to be a valid callback, no array or string given"

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed

Fixes #3765