### PR TITLE
Normalize `__` to ` `, refs 3764

### DIFF
--- a/src/DataValues/ValueParsers/PropertyValueParser.php
+++ b/src/DataValues/ValueParsers/PropertyValueParser.php
@@ -194,7 +194,10 @@ class PropertyValueParser implements ValueParser {
 			$text = Localizer::getInstance()->getContentLanguage()->ucfirst( $text );
 		}
 
-		return str_replace( '_', ' ', $text );
+		// https://www.mediawiki.org/wiki/Manual:Page_title
+		// Titles beginning or ending with a space (underscore), or containing two
+		// or more consecutive spaces (underscores).
+		return str_replace( [ '__', '_', '  ' ], ' ', $text );
 	}
 
 }

--- a/src/GlobalFunctions.php
+++ b/src/GlobalFunctions.php
@@ -52,7 +52,10 @@ function smwfNormalTitleText( $text ) {
 		$text = $wgContLang->ucfirst( $text );
 	}
 
-	return str_replace( '_', ' ', $text );
+	// https://www.mediawiki.org/wiki/Manual:Page_title
+	// Titles beginning or ending with a space (underscore), or containing two
+	// or more consecutive spaces (underscores).
+	return str_replace( [ '__', '_', '  ' ], ' ', $text );
 }
 
 /**

--- a/src/Query/PrintRequest/Deserializer.php
+++ b/src/Query/PrintRequest/Deserializer.php
@@ -174,7 +174,7 @@ class Deserializer {
 		$printRequestLabel = trim( $propparts[0] );
 		$outputFormat = isset( $propparts[1] ) ? trim( $propparts[1] ) : false;
 
-		return [ $parts, $outputFormat, $printRequestLabel ];
+		return [ $parts, $outputFormat, smwfNormalTitleText( $printRequestLabel ) ];
 	}
 
 }

--- a/tests/phpunit/Integration/JSONScript/TestCases/q-1109.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/q-1109.json
@@ -1,0 +1,98 @@
+{
+	"description": "Test `_rec` on two spaced (#3764)",
+	"setup": [
+		{
+			"namespace": "SMW_NS_PROPERTY",
+			"page": "Has two spaced record",
+			"contents": "[[Has type::Record]] [[Has fields::Two_spaced__field;other field]]"
+		},
+		{
+			"page": "Test:Q1109/1",
+			"contents": "[[Has two spaced record::abc;def]]"
+		},
+		{
+			"page": "Test:Q1109/2",
+			"contents": "{{#ask: [[Has two spaced record::+]] |?Has two spaced record.Two_spaced__field }}"
+		},
+		{
+			"page": "Test:Q1109/3",
+			"contents": "{{#ask: [[Has two spaced record::+]] |?Has two spaced record.Two spaced  field }}"
+		}
+	],
+	"tests": [
+		{
+			"type": "query",
+			"about": "#0",
+			"condition": "[[Has two spaced record.Two_spaced_field::Abc]]",
+			"printouts": [],
+			"parameters": {
+				"limit": "10"
+			},
+			"assert-queryresult": {
+				"count": 1,
+				"results": [
+					"Test:Q1109/1#0##"
+				]
+			}
+		},
+		{
+			"type": "query",
+			"about": "#1 (`__` is converted to `_`)",
+			"condition": "[[Has two spaced record.Two_spaced__field::Abc]]",
+			"printouts": [],
+			"parameters": {
+				"limit": "10"
+			},
+			"assert-queryresult": {
+				"count": 1,
+				"results": [
+					"Test:Q1109/1#0##"
+				]
+			}
+		},
+		{
+			"type": "query",
+			"about": "#2 (`__` is converted to `_`)",
+			"condition": "[[Has two spaced record.Two spaced  field::Abc]]",
+			"printouts": [],
+			"parameters": {
+				"limit": "10"
+			},
+			"assert-queryresult": {
+				"count": 1,
+				"results": [
+					"Test:Q1109/1#0##"
+				]
+			}
+		},
+		{
+			"type": "parser",
+			"about": "#3 (`__` is converted to `_`)",
+			"subject": "Test:Q1109/2",
+			"assert-output": {
+				"to-contain": [
+					"Abc"
+				]
+			}
+		},
+		{
+			"type": "parser",
+			"about": "#4 (`__` is converted to `_`)",
+			"subject": "Test:Q1109/3",
+			"assert-output": {
+				"to-contain": [
+					"Abc"
+				]
+			}
+		}
+	],
+	"settings": {
+		"wgContLang": "en",
+		"wgLang": "en"
+	},
+	"meta": {
+		"version": "2",
+		"is-incomplete": false,
+		"debug": false
+	}
+}

--- a/tests/phpunit/Unit/DataValues/ValueParsers/PropertyValueParserTest.php
+++ b/tests/phpunit/Unit/DataValues/ValueParsers/PropertyValueParserTest.php
@@ -75,6 +75,34 @@ class PropertyValueParserTest extends \PHPUnit_Framework_TestCase {
 		];
 
 		$provider[] = [
+			'Fo o',
+			[],
+			'Fo o',
+			false
+		];
+
+		$provider[] = [
+			'Fo o  bar',
+			[],
+			'Fo o bar',
+			false
+		];
+
+		$provider[] = [
+			'Fo_o__bar',
+			[],
+			'Fo o bar',
+			false
+		];
+
+		$provider[] = [
+			'Fo_o____bar',
+			[],
+			'Fo o bar',
+			false
+		];
+
+		$provider[] = [
 			'[ Foo',
 			[],
 			'Foo',


### PR DESCRIPTION
This PR is made in reference to: #3764

This PR addresses or contains:

- https://www.mediawiki.org/wiki/Manual:Page_title contains a note about consecutive spaces in titles and since we are bound to the MediaWiki environment, creating a property with say two spaces `A__B` is going to be represented by MW as `A_B`.
- SMW generally preserves what the user has entered but in certain cases it needs to make sure that data consistency prevails therefore `__` will be normalized as a single underscore so that a request to `Foo__bar` will be identical to `Foo_bar` and `Foo bar`

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed

Fixes #3764