### PR TITLE
[MW 1.33] `Store::doDataUpdate` use `Database::beginSectionTransaction`

### DIFF
--- a/src/SQLStore/SQLStoreFactory.php
+++ b/src/SQLStore/SQLStoreFactory.php
@@ -528,6 +528,8 @@ class SQLStoreFactory {
 			Site::isCommandLineMode()
 		);
 
+		$propertyStatisticsStore->waitOnTransactionIdle();
+
 		return $propertyStatisticsStore;
 	}
 

--- a/tests/phpunit/includes/SQLStore/Writer/DataUpdateTest.php
+++ b/tests/phpunit/includes/SQLStore/Writer/DataUpdateTest.php
@@ -373,10 +373,10 @@ class DataUpdateTest extends \PHPUnit_Framework_TestCase {
 			->getMock();
 
 		$database->expects( $this->atLeastOnce() )
-			->method( 'beginAtomicTransaction' );
+			->method( 'beginSectionTransaction' );
 
 		$database->expects( $this->atLeastOnce() )
-			->method( 'endAtomicTransaction' );
+			->method( 'endSectionTransaction' );
 
 		$propertyTableInfoFetcher = $this->getMockBuilder( '\SMW\SQLStore\PropertyTableInfoFetcher' )
 			->disableOriginalConstructor()


### PR DESCRIPTION
This PR is made in reference to: #

This PR addresses or contains:

- I don't know what changed and where those "startAtomic: entering level 0" messages come from but this starts to happen with MW 1.33+ and appears to slow down the overall update
- Best answer I could come up without removing all `startAtomic`/`endAtomic` calls, introduce `Database::beginSectionTransaction` with:

"The intent is to make it possible to mark a section and disable any other atomic transaction request while being part of a section hereby allowing to bundle all requests and encapsulate them into one coherent atomic transaction without changing pending callers that may require individual atomic transactions when they are not part of a section request."


This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed

## Stack

### Without `beginSectionTransaction`
```
[smw] DeferrableUpdate: ["Added: {"origin":["SMW\\DataUpdater::doUpdate","LinksUpdateConstructed","Lorem_ipsum#0##"]
MediaWiki::preOutputCommit: pre-send deferred updates completed
MediaWiki::preOutputCommit: LBFactory shutdown completed
...
[DBQuery] startAtomic: entering level 0 (Wikimedia\Rdbms\Database::onTransactionPreCommitOrIdle)
[DBQuery] endAtomic: leaving level 0 (Wikimedia\Rdbms\Database::onTransactionPreCommitOrIdle)
Title::getRestrictionTypes: applicable restrictions to [[Lorem ipsum]] are {edit,move}
[smw] SMW\Protection\EditProtectionUpdater::doUpdateFrom no update required
[DBQuery] startAtomic: entering level 0 (SMWSql3SmwIds::makeDatabaseId)
[DBQuery] endAtomic: leaving level 0 (SMWSql3SmwIds::makeDatabaseId)
[DBQuery] startAtomic: entering level 0 (SMWSql3SmwIds::makeDatabaseId)
[DBQuery] endAtomic: leaving level 0 (SMWSql3SmwIds::makeDatabaseId)
[DBQuery] startAtomic: entering level 0 (SMWSql3SmwIds::makeDatabaseId)
[DBQuery] endAtomic: leaving level 0 (SMWSql3SmwIds::makeDatabaseId)
[DBQuery] startAtomic: entering level 0 (SMWSql3SmwIds::makeDatabaseId)
[DBQuery] endAtomic: leaving level 0 (SMWSql3SmwIds::makeDatabaseId)
[DBQuery] startAtomic: entering level 0 (SMWSql3SmwIds::makeDatabaseId)
...
+ 100 (of the same line)
...
[DBQuery] startAtomic: entering level 0 (SMWSQLStore3Writers::doDataUpdate)
[smw] [QueryDependency] Prune links completed: Lorem_ipsum#0## (procTime in sec: 7.0E-5)
[smw] Connection: ["mw.db.queryengine: {"read":"DB_SLAVE","write":"DB_MASTER"}"]
[DBQuery] endAtomic: leaving level 0 (SMWSQLStore3Writers::doDataUpdate)
[smw-elastic] Connection: ["elastic : [{"host":"192.168.99.100","port":9200,"scheme":"http"}]"]
MediaWiki::preOutputCommit: primary transaction round committed
MediaWiki::preOutputCommit: pre-send deferred updates completed
MediaWiki::preOutputCommit: LBFactory shutdown completed
[objectcache] Duplicate get(): "mw?hmaster?hphpunit:preprocess-xml:64095138b79bed6c2a5cfcc4e09b928b:0" fetched 3 times
Request ended normally
[session] Saving all sessions on shutdown
[DBConnection] Wikimedia\Rdbms\LoadBalancer::closeAll: closing connection to database 'localhost'.
[smw-elastic] Indexer: ["Data index completed (Lorem_ipsum#0##)","procTime (in sec): 0.21639","Response: {"took":151,"errors":false}"]
[smw] ElasticStore: ["Data update completed","procTime in sec: 0.29302"]
[smw] Store: ["Update completed: Lorem_ipsum#0##","rev: 279","procTime: 0.70318"]
```

### With `beginSectionTransaction`

```
[smw] DeferrableUpdate: ["Added: {"origin":["SMW\\DataUpdater::doUpdate","LinksUpdateConstructed","Lorem_ipsum#0##"]
MediaWiki::preOutputCommit: pre-send deferred updates completed
MediaWiki::preOutputCommit: LBFactory shutdown completed
...
[DBQuery] startAtomic: entering level 0 (Wikimedia\Rdbms\Database::onTransactionPreCommitOrIdle)
[DBQuery] endAtomic: leaving level 0 (Wikimedia\Rdbms\Database::onTransactionPreCommitOrIdle)
Title::getRestrictionTypes: applicable restrictions to [[Lorem ipsum]] are {edit,move}
[smw] SMW\Protection\EditProtectionUpdater::doUpdateFrom no update required
[DBQuery] startAtomic: entering level 0 (SMWSQLStore3Writers::doDataUpdate)
[smw] [QueryDependency] Prune links completed: Lorem_ipsum#0## (procTime in sec: 8.0E-5)
[smw] Connection: ["mw.db.queryengine: {"read":"DB_SLAVE","write":"DB_MASTER"}"]
[DBQuery] endAtomic: leaving level 0 (SMWSQLStore3Writers::doDataUpdate)
[smw-elastic] Connection: ["elastic : [{"host":"192.168.99.100","port":9200,"scheme":"http"}]"]
[smw-elastic] Indexer: ["Data index completed (Lorem_ipsum#0##)","procTime (in sec): 0.19115","Response: {"took":137,"errors":false}"]
[smw] ElasticStore: ["Data update completed","procTime in sec: 0.2617"]
[smw] Store: ["Update completed: Lorem_ipsum#0##","rev: 280","procTime: 0.44878"]
```
