### PR TITLE
Check and mark retired properties

### DIFF
--- a/DefaultSettings.php
+++ b/DefaultSettings.php
@@ -1838,6 +1838,25 @@ return [
 	##
 
 	##
+	# Properties classified as retired/no longer in use
+	#
+	# Listed properties will be removed from the entity table hereby avoids
+	# references or display of those classified as retired.
+	#
+	# The system normally leaves properties untouched (once created) but this
+	# setting allows them to be marked as retired and eventually removed from
+	# the system.
+	#
+	# @since 3.1
+	##
+	'smwgPropertyRetiredList' => [
+
+		// No longer valid predefined property prefixes
+		'_SF_', '_SD_'
+	],
+	##
+
+	##
 	# Reserved property names
 	#
 	# Listed names are reserved as they may interfere with Semantic MediaWiki or

--- a/includes/Settings.php
+++ b/includes/Settings.php
@@ -165,6 +165,7 @@ class Settings extends Options {
 			'smwgCreateProtectionRight' => $GLOBALS['smwgCreateProtectionRight'],
 			'smwgSimilarityLookupExemptionProperty' => $GLOBALS['smwgSimilarityLookupExemptionProperty'],
 			'smwgPropertyInvalidCharacterList' => $GLOBALS['smwgPropertyInvalidCharacterList'],
+			'smwgPropertyRetiredList' => $GLOBALS['smwgPropertyRetiredList'],
 			'smwgPropertyReservedNameList' => $GLOBALS['smwgPropertyReservedNameList'],
 			'smwgEntityCollation' => $GLOBALS['smwgEntityCollation'],
 			'smwgExperimentalFeatures' => $GLOBALS['smwgExperimentalFeatures'],

--- a/includes/datavalues/SMW_DV_WikiPage.php
+++ b/includes/datavalues/SMW_DV_WikiPage.php
@@ -104,9 +104,6 @@ class SMWWikiPageValue extends SMWDataValue {
 			case '_wpc' : case '__suc': case '__sin':
 				$this->m_fixNamespace = NS_CATEGORY;
 			break;
-			case '_wpf' : case '__spf':
-				$this->m_fixNamespace = SF_NS_FORM;
-			break;
 			case '_wps' :
 				$this->m_fixNamespace = SMW_NS_SCHEMA;
 			break;

--- a/src/SQLStore/SQLStoreFactory.php
+++ b/src/SQLStore/SQLStoreFactory.php
@@ -302,10 +302,24 @@ class SQLStoreFactory {
 	 * @return EntityRebuildDispatcher
 	 */
 	public function newEntityRebuildDispatcher() {
-		return new EntityRebuildDispatcher(
+
+		$applicationFactory = ApplicationFactory::getInstance();
+		$settings = $applicationFactory->getSettings();
+
+		$entityRebuildDispatcher = new EntityRebuildDispatcher(
 			$this->store,
-			ApplicationFactory::getInstance()->newTitleFactory()
+			$applicationFactory->newTitleFactory()
 		);
+
+		$entityRebuildDispatcher->setPropertyInvalidCharacterList(
+			$settings->get( 'smwgPropertyInvalidCharacterList' )
+		);
+
+		$entityRebuildDispatcher->setPropertyRetiredList(
+			$settings->get( 'smwgPropertyRetiredList' )
+		);
+
+		return $entityRebuildDispatcher;
 	}
 
 	/**

--- a/src/TypesRegistry.php
+++ b/src/TypesRegistry.php
@@ -179,10 +179,6 @@ class TypesRegistry {
 			'_LIST' => [ '__pls', true, true, true ], // "has fields"
 			'_SKEY' => [ '__key', false, true, false ], // sort key of a page
 
-			// FIXME SF related properties to be removed with 3.0
-			'_SF_DF' => [ '__spf', true, true, false ], // Semantic Form's default form property
-			'_SF_AF' => [ '__spf', true, true, false ],  // Semantic Form's alternate form property
-
 			'_SOBJ' => [ '__sob', true, false, false ], // "has subobject"
 			'_ASK'  => [ '__sob', false, false, false ], // "has query"
 			'_ASKST' => [ '_cod', true, false, false ], // "Query string"


### PR DESCRIPTION
This PR is made in reference to: #

This PR addresses or contains:

- The rebuilder will never remove (unless it is duplicate) predefined properties once created but to have possibility to remove retired properties, `smwgPropertyRetiredList` is added to contain a list that can safely be removed.
- `smwgPropertyRetiredList` is not expected to be used by normal users and only in rare case by administrators 
- Removes predefined properties that contain `_SF_`, `_SD_`

This PR includes:
- [ ] Tests (unit/integration)
- [x] CI build passed
