### PR TITLE
Highlighter, remove trailing line feeds

### DIFF
--- a/includes/Highlighter.php
+++ b/includes/Highlighter.php
@@ -247,6 +247,12 @@ class Highlighter {
 			$style = [ 'style' => $this->options['style'] ];
 		}
 
+		// In case the text contains HTML, remove trailing line feeds to avoid breaking
+		// the display
+		if ( $this->options['content'] != strip_tags( $this->options['content'] ) ) {
+			$this->options['content'] = str_replace( [ "\n" ], [ '' ], $this->options['content'] );
+		}
+
 		// #1875
 		// title attribute contains stripped content to allow for a display in
 		// no-js environments, the tooltip will remove the element once it is

--- a/src/Message.php
+++ b/src/Message.php
@@ -184,7 +184,7 @@ class Message {
 			return $message[0];
 		}
 
-		return self::get( $message, ( $type !== null ? $type: $asType ), $language );
+		return self::get( $message, ( $asType === null ? $type: $asType ), $language );
 	}
 
 	/**


### PR DESCRIPTION
This PR is made in reference to: #

This PR addresses or contains:

- Removes trailing line feeds (when detected as HTML) to avoid display issues as observed (see the example)

This PR includes:
- [ ] Tests (unit/integration)
- [x] CI build passed

## Example

![image](https://user-images.githubusercontent.com/1245473/54470477-30c3f980-47a0-11e9-9065-8172bd0e4177.png)
