### PR TITLE
Move `SMW\PropertyAnnotators` to `SMW\Property\Annotators`

### DIFF
--- a/src/Aliases.php
+++ b/src/Aliases.php
@@ -9,6 +9,7 @@ class_alias( \SMW\Query\ResultPrinters\RdfResultPrinter::class, 'SMWRDFResultPri
 class_alias( \SMW\Query\ResultPrinters\EmbeddedResultPrinter::class, 'SMWEmbeddedResultPrinter' );
 class_alias( \SMW\Query\ResultPrinters\DsvResultPrinter::class, 'SMWDSVResultPrinter' );
 class_alias( \SMW\Query\ResultPrinters\AggregatablePrinter::class, 'SMWAggregatablePrinter' );
+class_alias( \SMW\Property\Annotator::class, 'SMW\PropertyAnnotator' );
 
 // 3.0
 class_alias( \SMW\MediaWiki\Deferred\CallableUpdate::class, 'SMW\DeferredCallableUpdate' );

--- a/src/MediaWiki/Hooks/ArticleProtectComplete.php
+++ b/src/MediaWiki/Hooks/ArticleProtectComplete.php
@@ -5,7 +5,7 @@ namespace SMW\MediaWiki\Hooks;
 use SMW\ApplicationFactory;
 use SMW\MediaWiki\EditInfoProvider;
 use SMW\Message;
-use SMW\PropertyAnnotators\EditProtectedPropertyAnnotator;
+use SMW\Property\Annotators\EditProtectedPropertyAnnotator;
 use Title;
 
 /**

--- a/src/Property/Annotator.php
+++ b/src/Property/Annotator.php
@@ -1,18 +1,16 @@
 <?php
 
-namespace SMW;
+namespace SMW\Property;
 
 /**
  * Interface specifying available methods to interact with the Decorator
- *
- * @ingroup SMW
  *
  * @license GNU GPL v2+
  * @since 1.9
  *
  * @author mwjames
  */
-interface PropertyAnnotator {
+interface Annotator {
 
 	/**
 	 * Returns a SemanticData container

--- a/src/Property/AnnotatorFactory.php
+++ b/src/Property/AnnotatorFactory.php
@@ -1,21 +1,25 @@
 <?php
 
-namespace SMW;
+namespace SMW\Property;
 
 use SMw\MediaWiki\RedirectTargetFinder;
-use SMW\PropertyAnnotators\CategoryPropertyAnnotator;
-use SMW\PropertyAnnotators\DisplayTitlePropertyAnnotator;
-use SMW\PropertyAnnotators\EditProtectedPropertyAnnotator;
-use SMW\PropertyAnnotators\MandatoryTypePropertyAnnotator;
-use SMW\PropertyAnnotators\NullPropertyAnnotator;
-use SMW\PropertyAnnotators\PredefinedPropertyAnnotator;
-use SMW\PropertyAnnotators\RedirectPropertyAnnotator;
-use SMW\PropertyAnnotators\SchemaPropertyAnnotator;
-use SMW\PropertyAnnotators\SortKeyPropertyAnnotator;
-use SMW\PropertyAnnotators\TranslationPropertyAnnotator;
-use SMW\PropertyAnnotators\AttachmentLinkPropertyAnnotator;
+use SMW\Property\Annotators\CategoryPropertyAnnotator;
+use SMW\Property\Annotators\DisplayTitlePropertyAnnotator;
+use SMW\Property\Annotators\EditProtectedPropertyAnnotator;
+use SMW\Property\Annotators\MandatoryTypePropertyAnnotator;
+use SMW\Property\Annotators\NullPropertyAnnotator;
+use SMW\Property\Annotators\PredefinedPropertyAnnotator;
+use SMW\Property\Annotators\RedirectPropertyAnnotator;
+use SMW\Property\Annotators\SchemaPropertyAnnotator;
+use SMW\Property\Annotators\SortKeyPropertyAnnotator;
+use SMW\Property\Annotators\TranslationPropertyAnnotator;
+use SMW\Property\Annotators\AttachmentLinkPropertyAnnotator;
 use SMW\Store;
 use SMW\Schema\Schema;
+use SMW\SemanticData;
+use SMW\ApplicationFactory;
+use SMW\PropertyAnnotator;
+use SMW\PageInfo;
 use Title;
 
 /**
@@ -24,7 +28,7 @@ use Title;
  *
  * @author mwjames
  */
-class PropertyAnnotatorFactory {
+class AnnotatorFactory {
 
 	/**
 	 * @since 2.0

--- a/src/Property/Annotators/AttachmentLinkPropertyAnnotator.php
+++ b/src/Property/Annotators/AttachmentLinkPropertyAnnotator.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace SMW\PropertyAnnotators;
+namespace SMW\Property\Annotators;
 
 use SMW\PropertyAnnotator;
 use SMW\DIWikiPage;

--- a/src/Property/Annotators/CategoryPropertyAnnotator.php
+++ b/src/Property/Annotators/CategoryPropertyAnnotator.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace SMW\PropertyAnnotators;
+namespace SMW\Property\Annotators;
 
 use SMW\ApplicationFactory;
 use SMW\DIProperty;

--- a/src/Property/Annotators/DisplayTitlePropertyAnnotator.php
+++ b/src/Property/Annotators/DisplayTitlePropertyAnnotator.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace SMW\PropertyAnnotators;
+namespace SMW\Property\Annotators;
 
 use SMW\PropertyAnnotator;
 

--- a/src/Property/Annotators/EditProtectedPropertyAnnotator.php
+++ b/src/Property/Annotators/EditProtectedPropertyAnnotator.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace SMW\PropertyAnnotators;
+namespace SMW\Property\Annotators;
 
 use Html;
 use ParserOutput;

--- a/src/Property/Annotators/MandatoryTypePropertyAnnotator.php
+++ b/src/Property/Annotators/MandatoryTypePropertyAnnotator.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace SMW\PropertyAnnotators;
+namespace SMW\Property\Annotators;
 
 use SMW\DataTypeRegistry;
 use SMW\DataValueFactory;

--- a/src/Property/Annotators/NullPropertyAnnotator.php
+++ b/src/Property/Annotators/NullPropertyAnnotator.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace SMW\PropertyAnnotators;
+namespace SMW\Property\Annotators;
 
 use SMW\PropertyAnnotator;
 use SMW\SemanticData;

--- a/src/Property/Annotators/PredefinedPropertyAnnotator.php
+++ b/src/Property/Annotators/PredefinedPropertyAnnotator.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace SMW\PropertyAnnotators;
+namespace SMW\Property\Annotators;
 
 use SMW\DIProperty;
 use SMW\DIWikiPage;

--- a/src/Property/Annotators/PropertyAnnotatorDecorator.php
+++ b/src/Property/Annotators/PropertyAnnotatorDecorator.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace SMW\PropertyAnnotators;
+namespace SMW\Property\Annotators;
 
 use SMW\DataItemFactory;
 use SMW\PropertyAnnotator;

--- a/src/Property/Annotators/RedirectPropertyAnnotator.php
+++ b/src/Property/Annotators/RedirectPropertyAnnotator.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace SMW\PropertyAnnotators;
+namespace SMW\Property\Annotators;
 
 use SMW\DIProperty;
 use SMW\DIWikiPage;

--- a/src/Property/Annotators/SchemaPropertyAnnotator.php
+++ b/src/Property/Annotators/SchemaPropertyAnnotator.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace SMW\PropertyAnnotators;
+namespace SMW\Property\Annotators;
 
 use SMW\DIProperty;
 use SMW\PropertyAnnotator;

--- a/src/Property/Annotators/SortKeyPropertyAnnotator.php
+++ b/src/Property/Annotators/SortKeyPropertyAnnotator.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace SMW\PropertyAnnotators;
+namespace SMW\Property\Annotators;
 
 use SMW\DIProperty;
 use SMW\PropertyAnnotator;

--- a/src/Property/Annotators/TranslationPropertyAnnotator.php
+++ b/src/Property/Annotators/TranslationPropertyAnnotator.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace SMW\PropertyAnnotators;
+namespace SMW\Property\Annotators;
 
 use SMW\PropertyAnnotator;
 use SMW\DataModel\ContainerSemanticData;

--- a/src/Property/DeclarationExaminer/UserdefinedPropertyExaminer.php
+++ b/src/Property/DeclarationExaminer/UserdefinedPropertyExaminer.php
@@ -5,7 +5,7 @@ namespace SMW\Property\DeclarationExaminer;
 use SMW\DIProperty;
 use SMW\Property\DeclarationExaminer as IDeclarationExaminer;
 use SMW\DataTypeRegistry;
-use SMW\PropertyAnnotators\MandatoryTypePropertyAnnotator;
+use SMW\Property\Annotators\MandatoryTypePropertyAnnotator;
 use SMWDataItem as DataItem;
 use SMW\Store;
 use SMW\Message;

--- a/src/Protection/EditProtectionUpdater.php
+++ b/src/Protection/EditProtectionUpdater.php
@@ -7,7 +7,7 @@ use Psr\Log\LoggerInterface;
 use SMW\DIProperty;
 use SMW\MediaWiki\Hooks\ArticleProtectComplete;
 use SMW\Message;
-use SMW\PropertyAnnotators\EditProtectedPropertyAnnotator;
+use SMW\Property\Annotators\EditProtectedPropertyAnnotator;
 use SMW\SemanticData;
 use User;
 use WikiPage;

--- a/src/Services/SharedServicesContainer.php
+++ b/src/Services/SharedServicesContainer.php
@@ -33,7 +33,7 @@ use SMW\Parser\LinksProcessor;
 use SMW\PermissionPthValidator;
 use SMW\ParserData;
 use SMW\PostProcHandler;
-use SMW\PropertyAnnotatorFactory;
+use SMW\Property\AnnotatorFactory;
 use SMW\PropertyLabelFinder;
 use SMW\PropertyRestrictionExaminer;
 use SMW\PropertySpecificationLookup;
@@ -264,8 +264,8 @@ class SharedServicesContainer implements CallbackContainer {
 		 * @var PropertyAnnotatorFactory
 		 */
 		$containerBuilder->registerCallback( 'PropertyAnnotatorFactory', function( $containerBuilder ) {
-			$containerBuilder->registerExpectedReturnType( 'PropertyAnnotatorFactory', '\SMW\PropertyAnnotatorFactory' );
-			return new PropertyAnnotatorFactory();
+			$containerBuilder->registerExpectedReturnType( 'PropertyAnnotatorFactory', AnnotatorFactory::class );
+			return new AnnotatorFactory();
 		} );
 
 		/**

--- a/tests/phpunit/Unit/ApplicationFactoryTest.php
+++ b/tests/phpunit/Unit/ApplicationFactoryTest.php
@@ -327,7 +327,7 @@ class ApplicationFactoryTest extends \PHPUnit_Framework_TestCase {
 		$provider[] = [
 			'PropertyAnnotatorFactory',
 			[],
-			'SMW\PropertyAnnotatorFactory'
+			'SMW\Property\AnnotatorFactory'
 		];
 
 		return $provider;

--- a/tests/phpunit/Unit/MediaWiki/Hooks/ArticleProtectCompleteTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Hooks/ArticleProtectCompleteTest.php
@@ -4,7 +4,7 @@ namespace SMW\Tests\MediaWiki\Hooks;
 
 use SMW\DataItemFactory;
 use SMW\MediaWiki\Hooks\ArticleProtectComplete;
-use SMW\PropertyAnnotators\EditProtectedPropertyAnnotator;
+use SMW\Property\Annotators\EditProtectedPropertyAnnotator;
 use SMW\Tests\TestEnvironment;
 
 /**

--- a/tests/phpunit/Unit/Property/AnnotatorFactoryTest.php
+++ b/tests/phpunit/Unit/Property/AnnotatorFactoryTest.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace SMW\Tests;
+namespace SMW\Tests\Property;
 
-use SMW\PropertyAnnotatorFactory;
+use SMW\Property\AnnotatorFactory;
 
 /**
- * @covers \SMW\PropertyAnnotatorFactory
+ * @covers \SMW\Property\AnnotatorFactory
  * @group semantic-mediawiki
  *
  * @license GNU GPL v2+
@@ -13,13 +13,13 @@ use SMW\PropertyAnnotatorFactory;
  *
  * @author mwjames
  */
-class PropertyAnnotatorFactoryTest extends \PHPUnit_Framework_TestCase {
+class AnnotatorFactoryTest extends \PHPUnit_Framework_TestCase {
 
 	public function testCanConstruct() {
 
 		$this->assertInstanceOf(
-			'\SMW\PropertyAnnotatorFactory',
-			new PropertyAnnotatorFactory()
+			AnnotatorFactory::class,
+			new AnnotatorFactory()
 		);
 	}
 
@@ -29,10 +29,10 @@ class PropertyAnnotatorFactoryTest extends \PHPUnit_Framework_TestCase {
 			->disableOriginalConstructor()
 			->getMock();
 
-		$instance = new PropertyAnnotatorFactory();
+		$instance = new AnnotatorFactory();
 
 		$this->assertInstanceOf(
-			'\SMW\PropertyAnnotators\NullPropertyAnnotator',
+			'\SMW\Property\Annotators\NullPropertyAnnotator',
 			$instance->newNullPropertyAnnotator( $semanticData )
 		);
 	}
@@ -47,10 +47,10 @@ class PropertyAnnotatorFactoryTest extends \PHPUnit_Framework_TestCase {
 			->disableOriginalConstructor()
 			->getMock();
 
-		$instance = new PropertyAnnotatorFactory();
+		$instance = new AnnotatorFactory();
 
 		$this->assertInstanceOf(
-			'\SMW\PropertyAnnotators\RedirectPropertyAnnotator',
+			'\SMW\Property\Annotators\RedirectPropertyAnnotator',
 			$instance->newRedirectPropertyAnnotator( $propertyAnnotator, $redirectTargetFinder )
 		);
 	}
@@ -65,10 +65,10 @@ class PropertyAnnotatorFactoryTest extends \PHPUnit_Framework_TestCase {
 			->disableOriginalConstructor()
 			->getMock();
 
-		$instance = new PropertyAnnotatorFactory();
+		$instance = new AnnotatorFactory();
 
 		$this->assertInstanceOf(
-			'\SMW\PropertyAnnotators\PredefinedPropertyAnnotator',
+			'\SMW\Property\Annotators\PredefinedPropertyAnnotator',
 			$instance->newPredefinedPropertyAnnotator( $propertyAnnotator, $pageInfo )
 		);
 	}
@@ -79,10 +79,10 @@ class PropertyAnnotatorFactoryTest extends \PHPUnit_Framework_TestCase {
 			->disableOriginalConstructor()
 			->getMock();
 
-		$instance = new PropertyAnnotatorFactory();
+		$instance = new AnnotatorFactory();
 
 		$this->assertInstanceOf(
-			'\SMW\PropertyAnnotators\SortKeyPropertyAnnotator',
+			'\SMW\Property\Annotators\SortKeyPropertyAnnotator',
 			$instance->newSortKeyPropertyAnnotator( $propertyAnnotator, 'Foo' )
 		);
 	}
@@ -93,10 +93,10 @@ class PropertyAnnotatorFactoryTest extends \PHPUnit_Framework_TestCase {
 			->disableOriginalConstructor()
 			->getMock();
 
-		$instance = new PropertyAnnotatorFactory();
+		$instance = new AnnotatorFactory();
 
 		$this->assertInstanceOf(
-			'\SMW\PropertyAnnotators\TranslationPropertyAnnotator',
+			'\SMW\Property\Annotators\TranslationPropertyAnnotator',
 			$instance->newTranslationPropertyAnnotator( $propertyAnnotator, [] )
 		);
 	}
@@ -107,10 +107,10 @@ class PropertyAnnotatorFactoryTest extends \PHPUnit_Framework_TestCase {
 			->disableOriginalConstructor()
 			->getMock();
 
-		$instance = new PropertyAnnotatorFactory();
+		$instance = new AnnotatorFactory();
 
 		$this->assertInstanceOf(
-			'\SMW\PropertyAnnotators\CategoryPropertyAnnotator',
+			'\SMW\Property\Annotators\CategoryPropertyAnnotator',
 			$instance->newCategoryPropertyAnnotator( $propertyAnnotator, [] )
 		);
 	}
@@ -121,10 +121,10 @@ class PropertyAnnotatorFactoryTest extends \PHPUnit_Framework_TestCase {
 			->disableOriginalConstructor()
 			->getMock();
 
-		$instance = new PropertyAnnotatorFactory();
+		$instance = new AnnotatorFactory();
 
 		$this->assertInstanceOf(
-			'\SMW\PropertyAnnotators\MandatoryTypePropertyAnnotator',
+			'\SMW\Property\Annotators\MandatoryTypePropertyAnnotator',
 			$instance->newMandatoryTypePropertyAnnotator( $propertyAnnotator )
 		);
 	}
@@ -135,10 +135,10 @@ class PropertyAnnotatorFactoryTest extends \PHPUnit_Framework_TestCase {
 			->disableOriginalConstructor()
 			->getMock();
 
-		$instance = new PropertyAnnotatorFactory();
+		$instance = new AnnotatorFactory();
 
 		$this->assertInstanceOf(
-			'\SMW\PropertyAnnotators\SchemaPropertyAnnotator',
+			'\SMW\Property\Annotators\SchemaPropertyAnnotator',
 			$instance->newSchemaPropertyAnnotator( $propertyAnnotator )
 		);
 	}
@@ -149,10 +149,10 @@ class PropertyAnnotatorFactoryTest extends \PHPUnit_Framework_TestCase {
 			->disableOriginalConstructor()
 			->getMock();
 
-		$instance = new PropertyAnnotatorFactory();
+		$instance = new AnnotatorFactory();
 
 		$this->assertInstanceOf(
-			'\SMW\PropertyAnnotators\AttachmentLinkPropertyAnnotator',
+			'\SMW\Property\Annotators\AttachmentLinkPropertyAnnotator',
 			$instance->newAttachmentLinkPropertyAnnotator( $propertyAnnotator )
 		);
 	}

--- a/tests/phpunit/Unit/Property/Annotators/AttachmentLinkPropertyAnnotatorTest.php
+++ b/tests/phpunit/Unit/Property/Annotators/AttachmentLinkPropertyAnnotatorTest.php
@@ -1,16 +1,16 @@
 <?php
 
-namespace SMW\Tests\PropertyAnnotators;
+namespace SMW\Tests\Property\Annotators;
 
 use SMW\DataItemFactory;
 use SMW\SemanticData;
-use SMW\PropertyAnnotators\NullPropertyAnnotator;
-use SMW\PropertyAnnotators\AttachmentLinkPropertyAnnotator;
+use SMW\Property\Annotators\NullPropertyAnnotator;
+use SMW\Property\Annotators\AttachmentLinkPropertyAnnotator;
 use SMW\Tests\TestEnvironment;
 use SMW\Localizer;
 
 /**
- * @covers \SMW\PropertyAnnotators\AttachmentLinkPropertyAnnotator
+ * @covers \SMW\Property\Annotators\AttachmentLinkPropertyAnnotator
  * @group semantic-mediawiki
  *
  * @license GNU GPL v2+

--- a/tests/phpunit/Unit/Property/Annotators/CategoryPropertyAnnotatorTest.php
+++ b/tests/phpunit/Unit/Property/Annotators/CategoryPropertyAnnotatorTest.php
@@ -1,17 +1,17 @@
 <?php
 
-namespace SMW\Tests\PropertyAnnotators;
+namespace SMW\Tests\Property\Annotators;
 
 use ParserOutput;
 use SMW\DIWikiPage;
 use SMW\ParserData;
-use SMW\PropertyAnnotators\CategoryPropertyAnnotator;
-use SMW\PropertyAnnotators\NullPropertyAnnotator;
+use SMW\Property\Annotators\CategoryPropertyAnnotator;
+use SMW\Property\Annotators\NullPropertyAnnotator;
 use SMW\Tests\TestEnvironment;
 use SMW\Tests\Utils\Mock\MockTitle;
 
 /**
- * @covers \SMW\PropertyAnnotators\CategoryPropertyAnnotator
+ * @covers \SMW\Property\Annotators\CategoryPropertyAnnotator
  * @group semantic-mediawiki
  *
  * @license GNU GPL v2+
@@ -57,7 +57,7 @@ class CategoryPropertyAnnotatorTest extends \PHPUnit_Framework_TestCase {
 		);
 
 		$this->assertInstanceOf(
-			'\SMW\PropertyAnnotators\CategoryPropertyAnnotator',
+			'\SMW\Property\Annotators\CategoryPropertyAnnotator',
 			$instance
 		);
 	}

--- a/tests/phpunit/Unit/Property/Annotators/ChainablePropertyAnnotatorTest.php
+++ b/tests/phpunit/Unit/Property/Annotators/ChainablePropertyAnnotatorTest.php
@@ -1,12 +1,12 @@
 <?php
 
-namespace SMW\Tests\PropertyAnnotators;
+namespace SMW\Tests\Property\Annotators;
 
 use SMW\DIProperty;
-use SMW\PropertyAnnotators\CategoryPropertyAnnotator;
-use SMW\PropertyAnnotators\NullPropertyAnnotator;
-use SMW\PropertyAnnotators\PredefinedPropertyAnnotator;
-use SMW\PropertyAnnotators\SortKeyPropertyAnnotator;
+use SMW\Property\Annotators\CategoryPropertyAnnotator;
+use SMW\Property\Annotators\NullPropertyAnnotator;
+use SMW\Property\Annotators\PredefinedPropertyAnnotator;
+use SMW\Property\Annotators\SortKeyPropertyAnnotator;
 use SMW\Tests\Utils\UtilityFactory;
 
 /**

--- a/tests/phpunit/Unit/Property/Annotators/DisplayTitlePropertyAnnotatorTest.php
+++ b/tests/phpunit/Unit/Property/Annotators/DisplayTitlePropertyAnnotatorTest.php
@@ -1,14 +1,14 @@
 <?php
 
-namespace SMW\Tests\PropertyAnnotators;
+namespace SMW\Tests\Property\Annotators;
 
 use SMW\DIWikiPage;
-use SMW\PropertyAnnotators\DisplayTitlePropertyAnnotator;
-use SMW\PropertyAnnotators\NullPropertyAnnotator;
+use SMW\Property\Annotators\DisplayTitlePropertyAnnotator;
+use SMW\Property\Annotators\NullPropertyAnnotator;
 use SMW\Tests\TestEnvironment;
 
 /**
- * @covers \SMW\PropertyAnnotators\DisplayTitlePropertyAnnotator
+ * @covers \SMW\Property\Annotators\DisplayTitlePropertyAnnotator
  * @group semantic-mediawiki
  *
  * @license GNU GPL v2+
@@ -41,7 +41,7 @@ class DisplayTitlePropertyAnnotatorTest extends \PHPUnit_Framework_TestCase {
 		);
 
 		$this->assertInstanceOf(
-			'\SMW\PropertyAnnotators\DisplayTitlePropertyAnnotator',
+			'\SMW\Property\Annotators\DisplayTitlePropertyAnnotator',
 			$instance
 		);
 	}

--- a/tests/phpunit/Unit/Property/Annotators/EditProtectedPropertyAnnotatorTest.php
+++ b/tests/phpunit/Unit/Property/Annotators/EditProtectedPropertyAnnotatorTest.php
@@ -1,14 +1,14 @@
 <?php
 
-namespace SMW\Tests\PropertyAnnotators;
+namespace SMW\Tests\Property\Annotators;
 
 use SMW\DataItemFactory;
-use SMW\PropertyAnnotators\EditProtectedPropertyAnnotator;
-use SMW\PropertyAnnotators\NullPropertyAnnotator;
+use SMW\Property\Annotators\EditProtectedPropertyAnnotator;
+use SMW\Property\Annotators\NullPropertyAnnotator;
 use SMW\Tests\TestEnvironment;
 
 /**
- * @covers \SMW\PropertyAnnotators\EditProtectedPropertyAnnotator
+ * @covers \SMW\Property\Annotators\EditProtectedPropertyAnnotator
  * @group semantic-mediawiki
  *
  * @license GNU GPL v2+
@@ -48,7 +48,7 @@ class EditProtectedPropertyAnnotatorTest extends \PHPUnit_Framework_TestCase {
 		);
 
 		$this->assertInstanceOf(
-			'\SMW\PropertyAnnotators\EditProtectedPropertyAnnotator',
+			'\SMW\Property\Annotators\EditProtectedPropertyAnnotator',
 			$instance
 		);
 	}

--- a/tests/phpunit/Unit/Property/Annotators/MandatoryTypePropertyAnnotatorTest.php
+++ b/tests/phpunit/Unit/Property/Annotators/MandatoryTypePropertyAnnotatorTest.php
@@ -1,18 +1,18 @@
 <?php
 
-namespace SMW\Tests\PropertyAnnotators;
+namespace SMW\Tests\Property\Annotators;
 
 use SMW\DataValueFactory;
 use SMW\DIProperty;
 use SMW\DIWikiPage;
-use SMW\PropertyAnnotators\MandatoryTypePropertyAnnotator;
-use SMW\PropertyAnnotators\NullPropertyAnnotator;
+use SMW\Property\Annotators\MandatoryTypePropertyAnnotator;
+use SMW\Property\Annotators\NullPropertyAnnotator;
 use SMW\Tests\Utils\UtilityFactory;
 use SMWDIBlob as DIBlob;
 use SMWDIUri as DIUri;
 
 /**
- * @covers \SMW\PropertyAnnotators\MandatoryTypePropertyAnnotator
+ * @covers \SMW\Property\Annotators\MandatoryTypePropertyAnnotator
  * @group semantic-mediawiki
  *
  * @license GNU GPL v2+
@@ -43,7 +43,7 @@ class MandatoryTypePropertyAnnotatorTest extends \PHPUnit_Framework_TestCase {
 		);
 
 		$this->assertInstanceOf(
-			'\SMW\PropertyAnnotators\MandatoryTypePropertyAnnotator',
+			'\SMW\Property\Annotators\MandatoryTypePropertyAnnotator',
 			$instance
 		);
 	}

--- a/tests/phpunit/Unit/Property/Annotators/NullPropertyAnnotatorTest.php
+++ b/tests/phpunit/Unit/Property/Annotators/NullPropertyAnnotatorTest.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace SMW\Tests\PropertyAnnotators;
+namespace SMW\Tests\Property\Annotators;
 
-use SMW\PropertyAnnotators\NullPropertyAnnotator;
+use SMW\Property\Annotators\NullPropertyAnnotator;
 
 /**
- * @covers \SMW\PropertyAnnotators\NullPropertyAnnotator
+ * @covers \SMW\Property\Annotators\NullPropertyAnnotator
  * @group semantic-mediawiki
  *
  * @license GNU GPL v2+
@@ -22,7 +22,7 @@ class NullPropertyAnnotatorTest extends \PHPUnit_Framework_TestCase {
 			->getMock();
 
 		$this->assertInstanceOf(
-			'\SMW\PropertyAnnotators\NullPropertyAnnotator',
+			'\SMW\Property\Annotators\NullPropertyAnnotator',
 			new NullPropertyAnnotator( $semanticData )
 		);
 	}
@@ -41,7 +41,7 @@ class NullPropertyAnnotatorTest extends \PHPUnit_Framework_TestCase {
 		);
 
 		$this->assertInstanceOf(
-			'\SMW\PropertyAnnotators\NullPropertyAnnotator',
+			'\SMW\Property\Annotators\NullPropertyAnnotator',
 			$instance->addAnnotation()
 		);
 

--- a/tests/phpunit/Unit/Property/Annotators/PredefinedPropertyAnnotatorTest.php
+++ b/tests/phpunit/Unit/Property/Annotators/PredefinedPropertyAnnotatorTest.php
@@ -1,18 +1,18 @@
 <?php
 
-namespace SMW\Tests\PropertyAnnotators;
+namespace SMW\Tests\Property\Annotators;
 
 use SMW\DIProperty;
 use SMW\DIWikiPage;
 use SMW\Localizer;
-use SMW\PropertyAnnotators\NullPropertyAnnotator;
-use SMW\PropertyAnnotators\PredefinedPropertyAnnotator;
+use SMW\Property\Annotators\NullPropertyAnnotator;
+use SMW\Property\Annotators\PredefinedPropertyAnnotator;
 use SMW\Tests\Utils\Mock\MockTitle;
 use SMW\Tests\Utils\UtilityFactory;
 use Title;
 
 /**
- * @covers \SMW\PropertyAnnotators\PredefinedPropertyAnnotator
+ * @covers \SMW\Property\Annotators\PredefinedPropertyAnnotator
  * @group semantic-mediawiki
  *
  * @license GNU GPL v2+
@@ -48,7 +48,7 @@ class PredefinedPropertyAnnotatorTest extends \PHPUnit_Framework_TestCase {
 		);
 
 		$this->assertInstanceOf(
-			'\SMW\PropertyAnnotators\PredefinedPropertyAnnotator',
+			'\SMW\Property\Annotators\PredefinedPropertyAnnotator',
 			$instance
 		);
 	}

--- a/tests/phpunit/Unit/Property/Annotators/RedirectPropertyAnnotatorTest.php
+++ b/tests/phpunit/Unit/Property/Annotators/RedirectPropertyAnnotatorTest.php
@@ -1,14 +1,14 @@
 <?php
 
-namespace SMW\Tests\PropertyAnnotators;
+namespace SMW\Tests\Property\Annotators;
 
 use SMW\MediaWiki\RedirectTargetFinder;
-use SMW\PropertyAnnotators\NullPropertyAnnotator;
-use SMW\PropertyAnnotators\RedirectPropertyAnnotator;
+use SMW\Property\Annotators\NullPropertyAnnotator;
+use SMW\Property\Annotators\RedirectPropertyAnnotator;
 use SMW\Tests\Utils\UtilityFactory;
 
 /**
- * @covers \SMW\PropertyAnnotators\RedirectPropertyAnnotator
+ * @covers \SMW\Property\Annotators\RedirectPropertyAnnotator
  * @group semantic-mediawiki
  *
  * @license GNU GPL v2+
@@ -44,7 +44,7 @@ class RedirectPropertyAnnotatorTest extends \PHPUnit_Framework_TestCase {
 		);
 
 		$this->assertInstanceOf(
-			'\SMW\PropertyAnnotators\RedirectPropertyAnnotator',
+			'\SMW\Property\Annotators\RedirectPropertyAnnotator',
 			$instance
 		);
 	}

--- a/tests/phpunit/Unit/Property/Annotators/SchemaPropertyAnnotatorTest.php
+++ b/tests/phpunit/Unit/Property/Annotators/SchemaPropertyAnnotatorTest.php
@@ -1,15 +1,15 @@
 <?php
 
-namespace SMW\Tests\PropertyAnnotators;
+namespace SMW\Tests\Property\Annotators;
 
 use SMW\DataItemFactory;
-use SMW\PropertyAnnotators\NullPropertyAnnotator;
-use SMW\PropertyAnnotators\SchemaPropertyAnnotator;
+use SMW\Property\Annotators\NullPropertyAnnotator;
+use SMW\Property\Annotators\SchemaPropertyAnnotator;
 use SMW\Schema\SchemaDefinition;
 use SMW\Tests\TestEnvironment;
 
 /**
- * @covers \SMW\PropertyAnnotators\SchemaPropertyAnnotator
+ * @covers \SMW\Property\Annotators\SchemaPropertyAnnotator
  * @group semantic-mediawiki
  *
  * @license GNU GPL v2+

--- a/tests/phpunit/Unit/Property/Annotators/SortKeyPropertyAnnotatorTest.php
+++ b/tests/phpunit/Unit/Property/Annotators/SortKeyPropertyAnnotatorTest.php
@@ -1,14 +1,14 @@
 <?php
 
-namespace SMW\Tests\PropertyAnnotators;
+namespace SMW\Tests\Property\Annotators;
 
 use SMW\DataItemFactory;
-use SMW\PropertyAnnotators\NullPropertyAnnotator;
-use SMW\PropertyAnnotators\SortKeyPropertyAnnotator;
+use SMW\Property\Annotators\NullPropertyAnnotator;
+use SMW\Property\Annotators\SortKeyPropertyAnnotator;
 use SMW\Tests\Utils\UtilityFactory;
 
 /**
- * @covers \SMW\PropertyAnnotators\SortKeyPropertyAnnotator
+ * @covers \SMW\Property\Annotators\SortKeyPropertyAnnotator
  * @group semantic-mediawiki
  *
  * @license GNU GPL v2+
@@ -42,7 +42,7 @@ class SortKeyPropertyAnnotatorTest extends \PHPUnit_Framework_TestCase {
 		);
 
 		$this->assertInstanceOf(
-			'\SMW\PropertyAnnotators\SortKeyPropertyAnnotator',
+			'\SMW\Property\Annotators\SortKeyPropertyAnnotator',
 			$instance
 		);
 	}

--- a/tests/phpunit/Unit/Property/Annotators/TranslationPropertyAnnotatorTest.php
+++ b/tests/phpunit/Unit/Property/Annotators/TranslationPropertyAnnotatorTest.php
@@ -1,15 +1,15 @@
 <?php
 
-namespace SMW\Tests\PropertyAnnotators;
+namespace SMW\Tests\Property\Annotators;
 
 use SMW\DataItemFactory;
 use SMW\SemanticData;
-use SMW\PropertyAnnotators\NullPropertyAnnotator;
-use SMW\PropertyAnnotators\TranslationPropertyAnnotator;
+use SMW\Property\Annotators\NullPropertyAnnotator;
+use SMW\Property\Annotators\TranslationPropertyAnnotator;
 use SMW\Tests\TestEnvironment;
 
 /**
- * @covers \SMW\PropertyAnnotators\TranslationPropertyAnnotator
+ * @covers \SMW\Property\Annotators\TranslationPropertyAnnotator
  * @group semantic-mediawiki
  *
  * @license GNU GPL v2+

--- a/tests/phpunit/Unit/Property/DeclarationExaminer/UserdefinedPropertyExaminerTest.php
+++ b/tests/phpunit/Unit/Property/DeclarationExaminer/UserdefinedPropertyExaminerTest.php
@@ -227,7 +227,7 @@ class UserdefinedPropertyExaminerTest extends \PHPUnit_Framework_TestCase {
 
 		$this->semanticData->expects( $this->any() )
 			->method( 'getOption' )
-			->with( $this->equalTo( \SMW\PropertyAnnotators\MandatoryTypePropertyAnnotator::IMPO_REMOVED_TYPE ) )
+			->with( $this->equalTo( \SMW\Property\Annotators\MandatoryTypePropertyAnnotator::IMPO_REMOVED_TYPE ) )
 			->will( $this->returnValue( $imported_type ) );
 
 		$this->semanticData->expects( $this->any() )
@@ -273,7 +273,7 @@ class UserdefinedPropertyExaminerTest extends \PHPUnit_Framework_TestCase {
 		);
 
 		$semanticData->setOption(
-			\SMW\PropertyAnnotators\MandatoryTypePropertyAnnotator::ENFORCED_PARENTTYPE_INHERITANCE,
+			\SMW\Property\Annotators\MandatoryTypePropertyAnnotator::ENFORCED_PARENTTYPE_INHERITANCE,
 			$dataItemFactory->newDIWikiPage( 'Bar' )
 		);
 


### PR DESCRIPTION
This PR is made in reference to: #

This PR addresses or contains:

- Part of a smaller clean-up sprint to move some classes from the root to an appropriate subclass/directory 
- Moves `SMW\PropertyAnnotators` to `SMW\Property\Annotators`

This PR includes:
- [ ] Tests (unit/integration)
- [x] CI build passed

Fixes #