### PR TITLE
TableResultPrinter to support (ul/ol) as value separator

### DIFF
--- a/res/smw/printer/ext.smw.tableprinter.css
+++ b/res/smw/printer/ext.smw.tableprinter.css
@@ -289,3 +289,7 @@
 .smw-datatable-button a {
 	text-decoration: none;
 }
+
+.smw-datatable td ul, .smw-datatable td ol, .smwtable td ul, .smwtable td ol  {
+	margin: 0.3em 0 0 1.6em;
+}

--- a/src/Query/ResultPrinters/TableResultPrinter.php
+++ b/src/Query/ResultPrinters/TableResultPrinter.php
@@ -334,7 +334,17 @@ class TableResultPrinter extends ResultPrinter {
 			$values[] = $value === '' ? '&nbsp;' : $value;
 		}
 
-		return implode( $this->params['sep'], $values );
+		$sep = strtolower( $this->params['sep'] );
+
+		if ( !$isSubject && $sep === 'ul' && count( $values ) > 1 ) {
+			$html = '<ul><li>' . implode( '</li><li>', $values ) . '</li></ul>';
+		} elseif ( !$isSubject && $sep === 'ol' && count( $values ) > 1 ) {
+			$html = '<ol><li>' . implode( '</li><li>', $values ) . '</li></ol>';
+		} else {
+			$html = implode( $this->params['sep'], $values );
+		}
+
+		return $html;
 	}
 
 	/**
@@ -345,7 +355,12 @@ class TableResultPrinter extends ResultPrinter {
 		$class = isset( $this->params['class'] ) ? $this->params['class'] : '';
 
 		if ( strpos( $class, 'datatable' ) === false ) {
-			return [];
+			return [
+				'styles' => [
+					'onoi.dataTables.styles',
+					'smw.tableprinter.datatable.styles'
+				]
+			];
 		}
 
 		return [

--- a/tests/phpunit/Integration/JSONScript/TestCases/f-0202.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/f-0202.json
@@ -1,5 +1,5 @@
 {
-	"description": "Test `format=table` with sep cell formatting, #495 (`wgContLang=en`,`wgLang=en`)",
+	"description": "Test `format=table` with sep (incl. UL/OL) cell formatting (#495)",
 	"setup": [
 		{
 			"namespace": "SMW_NS_PROPERTY",
@@ -12,49 +12,57 @@
 			"contents": "[[Has type::Text]]"
 		},
 		{
-			"page": "Table-page",
+			"page": "Test:F0202/1",
 			"contents": "[[Has page::Foo]] [[Has page::42]] [[Has text::bar]] [[Has text::1001]]"
 		},
 		{
-			"page": "Table-without-sep-parameter",
-			"contents": "{{#ask:[[Has page::Foo]] [[Has page::42]]\n |?Has page\n |?Has text\n |format=table\n |headers=plain\n |link=none\n }}"
+			"page": "Test:F0202/Q.1",
+			"contents": "{{#ask:[[Has page::Foo]] [[Has page::42]] |?Has page |?Has text|+order=asc |format=table |headers=plain |link=none }}"
 		},
 		{
-			"page": "Table-with-sep-parameter",
-			"contents": "{{#ask:[[Has page::Foo]] [[Has page::42]]\n |?Has page\n |?Has text\n |format=table\n |sep=;\n |headers=plain\n |link=none\n }}"
+			"page": "Test:F0202/Q.2",
+			"contents": "{{#ask:[[Has page::Foo]] [[Has page::42]] |?Has page |?Has text|+order=desc |format=table |sep=; |headers=plain |link=none }}"
 		},
 		{
-			"page": "Broadtable-with-sep-parameter",
-			"contents": "{{#ask:[[Has page::Foo]] [[Has page::42]]\n |?Has page\n |?Has text\n |format=broadtable\n |sep=;\n |headers=plain\n |link=none\n }}"
+			"page": "Test:F0202/Q.3",
+			"contents": "{{#ask:[[Has page::Foo]] [[Has page::42]] |?Has page |?Has text|+order=asc |format=broadtable |sep=; |headers=plain |link=none }}"
+		},
+		{
+			"page": "Test:F0202/Q.4",
+			"contents": "{{#ask:[[Has page::Foo]] [[Has page::42]] |?Has page |?Has text|+order=asc |format=broadtable |sep=UL |headers=plain |link=none }}"
+		},
+		{
+			"page": "Test:F0202/Q.5",
+			"contents": "{{#ask:[[Has page::Foo]] [[Has page::42]] |?Has page |?Has text|+order=desc |format=broadtable |sep=ol |headers=plain |link=none }}"
 		}
 	],
 	"tests": [
 		{
 			"type": "format",
 			"about": "#0 table without sep",
-			"subject": "Table-without-sep-parameter",
+			"subject": "Test:F0202/Q.1",
 			"assert-output": {
 				"to-contain": [
 					"<table class=\"sortable wikitable smwtable\">",
 					"<th>&#160;</th><th class=\"Has-page\">Has page</th>",
 					"<th class=\"Has-text\">Has text</th>",
-					"<tr data-row-number=\"1\" class=\"row-odd\"><td class=\"smwtype_wpg\">Table-page</td>",
+					"<tr data-row-number=\"1\" class=\"row-odd\"><td class=\"smwtype_wpg\">Test:F0202/1</td>",
 					"<td class=\"Has-page smwtype_wpg\">Foo<br />42</td>",
-					"<td class=\"Has-text smwtype_txt\">bar<br />1001</td></tr>",
+					"<td class=\"Has-text smwtype_txt\" data-sort-value=\"1001\">1001<br />bar</td></tr>",
 					"</table>"
 				]
 			}
 		},
 		{
 			"type": "format",
-			"about": "#1 table with sep",
-			"subject": "Table-with-sep-parameter",
+			"about": "#1 table with sep (;)",
+			"subject": "Test:F0202/Q.2",
 			"assert-output": {
 				"to-contain": [
 					"<table class=\"sortable wikitable smwtable\">",
 					"<th>&#160;</th><th class=\"Has-page\">Has page</th>",
 					"<th class=\"Has-text\">Has text</th>",
-					"<tr data-row-number=\"1\" class=\"row-odd\"><td class=\"smwtype_wpg\">Table-page</td>",
+					"<tr data-row-number=\"1\" class=\"row-odd\"><td class=\"smwtype_wpg\">Test:F0202/1</td>",
 					"<td class=\"Has-page smwtype_wpg\">Foo;42</td>",
 					"<td class=\"Has-text smwtype_txt\">bar;1001</td></tr>",
 					"</table>"
@@ -63,16 +71,48 @@
 		},
 		{
 			"type": "format",
-			"about": "#2 broadtable with sep",
-			"subject": "Broadtable-with-sep-parameter",
+			"about": "#2 broadtable with sep (;)",
+			"subject": "Test:F0202/Q.3",
 			"assert-output": {
 				"to-contain": [
 					"<table class=\"sortable wikitable smwtable broadtable\" width=\"100%\">",
 					"<th>&#160;</th><th class=\"Has-page\">Has page</th>",
 					"<th class=\"Has-text\">Has text</th>",
-					"<tr data-row-number=\"1\" class=\"row-odd\"><td class=\"smwtype_wpg\">Table-page</td>",
+					"<tr data-row-number=\"1\" class=\"row-odd\"><td class=\"smwtype_wpg\">Test:F0202/1</td>",
 					"<td class=\"Has-page smwtype_wpg\">Foo;42</td>",
-					"<td class=\"Has-text smwtype_txt\">bar;1001</td></tr>",
+					"<td class=\"Has-text smwtype_txt\" data-sort-value=\"1001\">1001;bar</td></tr>",
+					"</table>"
+				]
+			}
+		},
+		{
+			"type": "format",
+			"about": "#3 broadtable with sep (UL/ul)",
+			"subject": "Test:F0202/Q.4",
+			"assert-output": {
+				"to-contain": [
+					"<table class=\"sortable wikitable smwtable broadtable\" width=\"100%\">",
+					"<th>&#160;</th><th class=\"Has-page\">Has page</th>",
+					"<th class=\"Has-text\">Has text</th>",
+					"<tr data-row-number=\"1\" class=\"row-odd\"><td class=\"smwtype_wpg\">Test:F0202/1</td>",
+					"<td class=\"Has-page smwtype_wpg\"><ul><li>Foo</li><li>42</li></ul></td>",
+					"<td class=\"Has-text smwtype_txt\" data-sort-value=\"1001\"><ul><li>1001</li><li>bar</li></ul></td></tr>",
+					"</table>"
+				]
+			}
+		},
+		{
+			"type": "format",
+			"about": "#4 broadtable with sep (OL/ol)",
+			"subject": "Test:F0202/Q.5",
+			"assert-output": {
+				"to-contain": [
+					"<table class=\"sortable wikitable smwtable broadtable\" width=\"100%\">",
+					"<th>&#160;</th><th class=\"Has-page\">Has page</th>",
+					"<th class=\"Has-text\">Has text</th>",
+					"<tr data-row-number=\"1\" class=\"row-odd\"><td class=\"smwtype_wpg\">Test:F0202/1</td>",
+					"<td class=\"Has-page smwtype_wpg\"><ol><li>Foo</li><li>42</li></ol></td>",
+					"<td class=\"Has-text smwtype_txt\"><ol><li>bar</li><li>1001</li></ol></td></tr>",
 					"</table>"
 				]
 			}


### PR DESCRIPTION
This PR is made in reference to: #

This PR addresses or contains:

- Support `ul`/`ol` as `sep` parameter to allow creating native HTML lists for values

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed

## Example

![image](https://user-images.githubusercontent.com/1245473/54470835-f90c8000-47a6-11e9-9080-b6c756e0fac2.png)
