### PR TITLE
Factbox to use `EntityCache`

### DIFF
--- a/src/DataUpdater.php
+++ b/src/DataUpdater.php
@@ -449,14 +449,6 @@ class DataUpdater {
 			$target->getArticleID()
 		);
 
-		$dispatchContext = EventHandler::getInstance()->newDispatchContext();
-		$dispatchContext->set( 'title', $subject->getTitle() );
-
-		EventHandler::getInstance()->getEventDispatcher()->dispatch(
-			'factbox.cache.delete',
-			$dispatchContext
-		);
-
 		return $semanticData;
 	}
 

--- a/src/EventListenerRegistry.php
+++ b/src/EventListenerRegistry.php
@@ -66,26 +66,6 @@ class EventListenerRegistry implements EventListenerCollection {
 
 		$this->logger = ApplicationFactory::getInstance()->getMediaWikiLogger();
 
-		/**
-		 * Emitted during UpdateJob, ArticlePurge
-		 */
-		$this->eventListenerCollection->registerCallback(
-			'factbox.cache.delete', function( $dispatchContext ) {
-
-				if ( $dispatchContext->has( 'subject' ) ) {
-					$title = $dispatchContext->get( 'subject' )->getTitle();
-				} else {
-					$title = $dispatchContext->get( 'title' );
-				}
-
-				$applicationFactory = ApplicationFactory::getInstance();
-
-				$applicationFactory->getCache()->delete(
-					\SMW\Factbox\CachedFactbox::makeCacheKey( $title )
-				);
-			}
-		);
-
 		$this->eventListenerCollection->registerCallback(
 			'exporter.reset', function() {
 				Exporter::getInstance()->clear();

--- a/src/Factbox/CachedFactbox.php
+++ b/src/Factbox/CachedFactbox.php
@@ -2,16 +2,20 @@
 
 namespace SMW\Factbox;
 
-use Onoi\Cache\Cache;
+use SMW\EntityCache;
 use OutputPage;
 use ParserOutput;
 use SMW\ApplicationFactory;
 use SMW\Parser\InTextAnnotationParser;
 use Title;
-use Language;
+use Psr\Log\LoggerAwareTrait;
+use SMW\Utils\HmacSerializer;
 
 /**
  * Factbox output caching
+ *
+ * Use a EntityCache to avoid unaltered content being re-parsed every time the
+ * OutputPage hook is executed.
  *
  * @license GNU GPL v2+
  * @since 1.9
@@ -20,22 +24,17 @@ use Language;
  */
 class CachedFactbox {
 
-	const CACHE_NAMESPACE = 'smw:fc';
+	use LoggerAwareTrait;
 
 	/**
-	 * @var Cache
+	 * @var EntityCache
 	 */
-	private $cache;
+	private $entityCache;
 
 	/**
 	 * @var boolean
 	 */
 	private $isCached = false;
-
-	/**
-	 * @var boolean
-	 */
-	private $isEnabled = true;
 
 	/**
 	 * @var integer
@@ -45,7 +44,22 @@ class CachedFactbox {
 	/**
 	 * @var integer
 	 */
-	private $expiryInSeconds = 0;
+	private $showFactboxEdit = 0;
+
+	/**
+	 * @var integer
+	 */
+	private $showFactbox = 0;
+
+	/**
+	 * @var boolean
+	 */
+	private $isEnabled = true;
+
+	/**
+	 * @var integer
+	 */
+	private $cacheTTL = 0;
 
 	/**
 	 * @var integer
@@ -55,26 +69,10 @@ class CachedFactbox {
 	/**
 	 * @since 1.9
 	 *
-	 * @param Cache $cache
+	 * @param EntityCache $entityCache
 	 */
-	public function __construct( Cache $cache ) {
-		$this->cache = $cache;
-	}
-
-	/**
-	 * @since 3.0
-	 *
-	 * @param Title|integer $id
-	 *
-	 * @return string
-	 */
-	public static function makeCacheKey( $id ) {
-
-		if ( $id instanceof Title ) {
-			$id = $id->getArticleID();
-		}
-
-		return smwfCacheKey( self::CACHE_NAMESPACE, $id );
+	public function __construct( EntityCache $entityCache ) {
+		$this->entityCache = $entityCache;
 	}
 
 	/**
@@ -96,12 +94,30 @@ class CachedFactbox {
 	}
 
 	/**
+	 * @since 3.1
+	 *
+	 * @param integer $showFactboxEdit
+	 */
+	public function setShowFactboxEdit( $showFactboxEdit ) {
+		$this->showFactboxEdit = $showFactboxEdit;
+	}
+
+	/**
+	 * @since 3.1
+	 *
+	 * @param integer $showFactbox
+	 */
+	public function setShowFactbox( $showFactbox ) {
+		$this->showFactbox = $showFactbox;
+	}
+
+	/**
 	 * @since 2.5
 	 *
-	 * @return boolean
+	 * @param integer $cacheTTL
 	 */
-	public function setExpiryInSeconds( $expiryInSeconds ) {
-		$this->expiryInSeconds = $expiryInSeconds;
+	public function setCacheTTL( $cacheTTL ) {
+		$this->cacheTTL = $cacheTTL;
 	}
 
 	/**
@@ -123,6 +139,20 @@ class CachedFactbox {
 	}
 
 	/**
+	 * @since 2.2
+	 *
+	 * @return integer
+	 */
+	public static function makeCacheKey( $id ) {
+
+		if ( $id instanceof Title ) {
+			$id = $id->getArticleID();
+		}
+
+		return EntityCache::makeCacheKey( 'factbox', $id );
+	}
+
+	/**
 	 * Prepare and update the OutputPage property
 	 *
 	 * Factbox content is either retrieved from a CacheStore or re-parsed from
@@ -134,32 +164,56 @@ class CachedFactbox {
 	 * @since 1.9
 	 *
 	 * @param OutputPage &$outputPage
-	 * @param Language $language
 	 * @param ParserOutput $parserOutput
 	 */
-	public function prepareFactboxContent( OutputPage &$outputPage, Language $language, ParserOutput $parserOutput ) {
+	public function prepare( OutputPage &$outputPage, ParserOutput $parserOutput ) {
 
-		$content = '';
+		$outputPage->mSMWFactboxText = null;
+		$time = -microtime( true );
+
+		$context = $outputPage->getContext();
+		$request = $context->getRequest();
+
+		$checkMagicWords = new CheckMagicWords(
+			[
+				'preview' => $request->getCheck( 'wpPreview' ),
+				'showFactboxEdit' => $this->showFactboxEdit,
+				'showFactbox' => $this->showFactbox
+			]
+		);
+
+		if ( $checkMagicWords->getMagicWords( $parserOutput ) === SMW_FACTBOX_HIDDEN ) {
+			return;
+		}
+
 		$outputPage->addModules( Factbox::getModules() );
 		$title = $outputPage->getTitle();
 
-		$rev_id = $this->findRevId( $title, $outputPage->getContext() );
-		$lang = $language->getCode();
+		$rev_id = $this->findRevId( $title, $request );
+		$lang = $context->getLanguage()->getCode();
+		$content = '';
 
-		$key = self::makeCacheKey( $title );
+		$key = $this->makeCacheKey( $title );
+		$subKey = $this->makeSubCacheKey( $rev_id, $lang, $this->featureSet );
 
-		if ( $this->cache->contains( $key ) ) {
-			$content = $this->retrieveFromCache( $key );
+		if ( ( $data = $this->entityCache->fetchSub( $key, $subKey ) ) !== false ) {
+			$content = $this->findContentFromCache( $data );
 		}
 
-		if ( $this->hasCachedContent( $rev_id, $lang, $content, $outputPage->getContext() ) ) {
+		if ( $this->hasCachedContent( $subKey, $rev_id, $lang, $content, $request ) ) {
+
+			$this->logger->info(
+				[ 'Factbox', 'Using cached factbox, rev_id: {rev_id}, {lang}', 'procTime: {procTime}' ],
+				[ 'rev_id' => $rev_id, 'lang' => $lang, 'procTime' => microtime( true ) + $time ]
+			);
+
 			return $outputPage->mSMWFactboxText = $content['text'];
 		}
 
 		$text = $this->rebuild(
 			$title,
 			$parserOutput,
-			$outputPage->getContext()
+			$checkMagicWords
 		);
 
 		$this->addContentToCache(
@@ -170,6 +224,12 @@ class CachedFactbox {
 			$this->featureSet
 		);
 
+		$this->logger->info(
+			[ 'Factbox', 'Rebuild factbox, rev_id: {rev_id}, {lang}', 'procTime: {procTime}' ],
+			[ 'rev_id' => $rev_id, 'lang' => $lang, 'procTime' => microtime( true ) + $time ]
+		);
+
+		$this->entityCache->associate( $title, $key );
 		$outputPage->mSMWFactboxText = $text;
 	}
 
@@ -180,13 +240,14 @@ class CachedFactbox {
 	 * @param string $text
 	 * @param integer|null $revisionId
 	 */
-	public function addContentToCache( $key, $text, $revisionId = null, $lang = 'en', $fset = null ) {
+	public function addContentToCache( $key, $text, $rev_id = null, $lang = 'en', $feature_set = null ) {
 		$this->saveToCache(
 			$key,
+			$this->makeSubCacheKey( $rev_id, $lang, $this->featureSet ),
 			[
-				'revId' => $revisionId,
+				'rev_id' => $rev_id,
 				'lang'  => $lang,
-				'fset'  => $fset,
+				'feature_set' => $feature_set,
 				'text'  => $text
 			]
 		);
@@ -205,6 +266,7 @@ class CachedFactbox {
 	public function retrieveContent( OutputPage $outputPage ) {
 
 		$text = '';
+		$content = [];
 		$title = $outputPage->getTitle();
 
 		if ( $title instanceof Title && ( $title->isSpecialPage() || !$title->exists() ) ) {
@@ -215,11 +277,27 @@ class CachedFactbox {
 			$text = $outputPage->mSMWFactboxText;
 		} elseif ( $title instanceof Title ) {
 
-			$content = $this->retrieveFromCache(
-				self::makeCacheKey( $title )
+			$context = $outputPage->getContext();
+			$lang = $context->getLanguage()->getCode();
+
+			$rev_id = $this->findRevId(
+				$title, $context->getRequest()
 			);
 
-			$text = isset( $content['text'] ) ? $content['text'] : '';
+			$sub = $this->makeSubCacheKey( $rev_id, $lang, $this->featureSet );
+
+			$data = $this->entityCache->fetchSub(
+				$this->makeCacheKey( $title ),
+				$sub
+			);
+
+			$content = $this->findContentFromCache(
+				$data
+			);
+
+			if ( isset( $content['text'] ) ) {
+				return $content['text'];
+			}
 		}
 
 		return $text;
@@ -229,10 +307,14 @@ class CachedFactbox {
 	 * Return a revisionId either from the WebRequest object (display an old
 	 * revision or permalink etc.) or from the title object
 	 */
-	private function findRevId( Title $title, $requestContext ) {
+	private function findRevId( Title $title, $request ) {
 
-		if ( $requestContext->getRequest()->getCheck( 'oldid' ) !== null ) {
-			return (int)$requestContext->getRequest()->getVal( 'oldid' );
+		if ( $request->getInt( 'diff' ) > 0 ) {
+			return $request->getInt( 'diff' );
+		}
+
+		if ( $request->getInt( 'oldid' ) > 0 ) {
+			return $request->getInt( 'oldid' );
 		}
 
 		$latestRevID = $title->getLatestRevID();
@@ -243,9 +325,9 @@ class CachedFactbox {
 	}
 
 	/**
-	 * Processing and reparsing of the Factbox content
+	 * Processing and re-parsing of the Factbox content
 	 */
-	private function rebuild( Title $title, ParserOutput $parserOutput, $requestContext ) {
+	private function rebuild( Title $title, ParserOutput $parserOutput, $checkMagicWords ) {
 
 		$text = null;
 		$applicationFactory = ApplicationFactory::getInstance();
@@ -255,8 +337,8 @@ class CachedFactbox {
 			$parserOutput
 		);
 
-		$factbox->setPreviewFlag(
-			$requestContext->getRequest()->getCheck( 'wpPreview' )
+		$factbox->setCheckMagicWords(
+			$checkMagicWords
 		);
 
 		$factbox->doBuild();
@@ -285,53 +367,61 @@ class CachedFactbox {
 		return $factbox->tabs( $content, $attachmentContent );
 	}
 
-	private function hasCachedContent( $revId, $lang, $content, $requestContext ) {
+	private function hasCachedContent( $subKey, $rev_id, $lang, $content, $request ) {
 
-		if ( $requestContext->getRequest()->getVal( 'action' ) === 'edit' ) {
+		if ( $request->getVal( 'action' ) === 'edit' ) {
 			return $this->isCached = false;
 		}
 
-		if ( $revId !== 0 && isset( $content['revId'] ) && ( $content['revId'] === $revId ) && $content['text'] !== null ) {
+		if ( $rev_id == 0 || !isset( $content['rev_id'] ) || $content['text'] === null ) {
+			return $this->isCached = false;
+		}
 
-			if (
-				( isset( $content['lang'] ) && $content['lang'] === $lang ) &&
-				( isset( $content['fset'] ) && $content['fset'] === $this->featureSet )  ) {
-				return $this->isCached = true;
-			}
+		if ( !isset( $content['lang'] ) || !isset( $content['feature_set'] ) ) {
+			return $this->isCached = false;
+		}
+
+		if ( $subKey === $this->makeSubCacheKey( $content['rev_id'], $content['lang'], $content['feature_set'] ) ) {
+			return $this->isCached = true;
 		}
 
 		return $this->isCached = false;
 	}
 
-	private function retrieveFromCache( $key ) {
+	private function findContentFromCache( $data ) {
 
-		if ( !$this->cache->contains( $key ) || !$this->isEnabled ) {
+		if ( $data === false || !$this->isEnabled ) {
 			return [];
 		}
-
-		$data = $this->cache->fetch( $key );
 
 		$this->isCached = true;
 		$this->timestamp = $data['time'];
 
-		return unserialize( $data['content'] );
+		return HmacSerializer::uncompress( $data['content'] );
 	}
 
 	/**
 	 * Cached content is serialized in an associative array following:
-	 * { 'revId' => $revisionId, 'text' => (...) }
+	 * { 'rev_id' => $revisionId, 'text' => (...) }
 	 */
-	private function saveToCache( $key, array $content ) {
+	private function saveToCache( $key, $subKey, array $content ) {
 
 		$this->timestamp = wfTimestamp( TS_UNIX );
 		$this->isCached = false;
 
 		$data = [
 			'time' => $this->timestamp,
-			'content' => serialize( $content )
+			'content' => HmacSerializer::compress( $content )
 		];
 
-		$this->cache->save( $key, $data, $this->expiryInSeconds );
+		// Storing as sub so that different language views for the same revision
+		// can be cached together but when the entity gets flushed all keys and
+		// content are evicted
+		$this->entityCache->saveSub( $key, $subKey, $data, $this->cacheTTL );
+	}
+
+	private function makeSubCacheKey( ...$args ) {
+		return md5( json_encode( $args ) );
 	}
 
 }

--- a/src/Factbox/CheckMagicWords.php
+++ b/src/Factbox/CheckMagicWords.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace SMW\Factbox;
+
+use ParserOutput;
+
+/**
+ * @private
+ *
+ * @license GNU GPL v2+
+ * @since 3.1
+ *
+ * @author mwjames
+ */
+class CheckMagicWords {
+
+	/**
+	 * @var array
+	 */
+	private $options = [];
+
+	/**
+	 * @since 3.1
+	 *
+	 * @param array $options
+	 */
+	public function __construct( array $options ) {
+		$this->options = $options;
+	}
+
+	/**
+	 * Returns magic words attached to the ParserOutput object
+	 *
+	 * @since 3.1
+	 *
+	 * @param ParserOutput $parserOutput
+	 *
+	 * @return string|null
+	 */
+	public function getMagicWords( ParserOutput $parserOutput ) {
+
+		$smwMagicWords = $parserOutput->getExtensionData( 'smwmagicwords' );
+		$mws = [];
+
+		if ( $smwMagicWords !== null ) {
+			$mws =$smwMagicWords;
+		}
+
+		if ( in_array( 'SMW_SHOWFACTBOX', $mws ) ) {
+			$showfactbox = SMW_FACTBOX_NONEMPTY;
+		} elseif ( in_array( 'SMW_NOFACTBOX', $mws ) ) {
+			$showfactbox = SMW_FACTBOX_HIDDEN;
+		} elseif ( isset( $this->options['preview'] ) && $this->options['preview'] ) {
+			$showfactbox = $this->options['showFactboxEdit'];
+		} else {
+			$showfactbox = $this->options['showFactbox'];
+		}
+
+		return $showfactbox;
+	}
+
+}

--- a/src/Factbox/FactboxFactory.php
+++ b/src/Factbox/FactboxFactory.php
@@ -17,6 +17,17 @@ use ParserOutput;
 class FactboxFactory {
 
 	/**
+	 * @since 3.1
+	 *
+	 * @param array $options
+	 *
+	 * @return CheckMagicWords
+	 */
+	public function newCheckMagicWords( array $options ) {
+		return new CheckMagicWords( $options );
+	}
+
+	/**
 	 * @since 2.0
 	 *
 	 * @return CachedFactbox
@@ -27,13 +38,11 @@ class FactboxFactory {
 		$settings = $applicationFactory->getSettings();
 
 		$cachedFactbox = new CachedFactbox(
-			$applicationFactory->getCache(
-				$settings->get( 'smwgMainCacheType' )
-			)
+			$applicationFactory->getEntityCache()
 		);
 
 		// Month = 30 * 24 * 3600
-		$cachedFactbox->setExpiryInSeconds( 2592000 );
+		$cachedFactbox->setCacheTTL( 2592000 );
 
 		$cachedFactbox->isEnabled(
 			$settings->isFlagSet( 'smwgFactboxFeatures', SMW_FACTBOX_CACHE )
@@ -41,6 +50,18 @@ class FactboxFactory {
 
 		$cachedFactbox->setFeatureSet(
 			$settings->get( 'smwgFactboxFeatures' )
+		);
+
+		$cachedFactbox->setShowFactboxEdit(
+			$settings->get( 'smwgShowFactboxEdit' )
+		);
+
+		$cachedFactbox->setShowFactbox(
+			$settings->get( 'smwgShowFactbox' )
+		);
+
+		$cachedFactbox->setLogger(
+			$applicationFactory->getMediaWikiLogger()
 		);
 
 		return $cachedFactbox;

--- a/src/MediaWiki/Hooks/ArticlePurge.php
+++ b/src/MediaWiki/Hooks/ArticlePurge.php
@@ -55,13 +55,6 @@ class ArticlePurge {
 		$dispatchContext->set( 'title', $title );
 		$dispatchContext->set( 'context', 'ArticlePurge' );
 
-		if ( $settings->isFlagSet( 'smwgFactboxFeatures', SMW_FACTBOX_PURGE_REFRESH ) ) {
-			EventHandler::getInstance()->getEventDispatcher()->dispatch(
-				'factbox.cache.delete',
-				$dispatchContext
-			);
-		}
-
 		if ( $settings->get( 'smwgQueryResultCacheRefreshOnPurge' ) ) {
 
 			$dispatchContext->set( 'ask', $applicationFactory->getStore()->getPropertyValues(

--- a/src/MediaWiki/Hooks/OutputPageParserOutput.php
+++ b/src/MediaWiki/Hooks/OutputPageParserOutput.php
@@ -129,9 +129,8 @@ class OutputPageParserOutput extends HookHandler {
 
 		$cachedFactbox = $applicationFactory->singleton( 'FactboxFactory' )->newCachedFactbox();
 
-		$cachedFactbox->prepareFactboxContent(
+		$cachedFactbox->prepare(
 			$outputPage,
-			$outputPage->getLanguage(),
 			$this->getParserOutput( $outputPage, $parserOutput )
 		);
 

--- a/src/MediaWiki/Jobs/UpdateJob.php
+++ b/src/MediaWiki/Jobs/UpdateJob.php
@@ -243,11 +243,6 @@ class UpdateJob extends Job {
 		$dispatchContext->set( 'title', $this->getTitle() );
 
 		$eventHandler->getEventDispatcher()->dispatch(
-			'factbox.cache.delete',
-			$dispatchContext
-		);
-
-		$eventHandler->getEventDispatcher()->dispatch(
 			'cached.propertyvalues.prefetcher.reset',
 			$dispatchContext
 		);

--- a/src/SQLStore/PropertyTableIdReferenceDisposer.php
+++ b/src/SQLStore/PropertyTableIdReferenceDisposer.php
@@ -274,11 +274,6 @@ class PropertyTableIdReferenceDisposer {
 			$dispatchContext
 		);
 
-		$eventDispatcher->dispatch(
-			'factbox.cache.delete',
-			$dispatchContext
-		);
-
 		$context = [
 			'context' => 'PropertyTableIdReferenceDisposal',
 			'title' => $subject->getTitle()

--- a/tests/phpunit/Integration/SemanticMediaWikiProvidedHookInterfaceIntegrationTest.php
+++ b/tests/phpunit/Integration/SemanticMediaWikiProvidedHookInterfaceIntegrationTest.php
@@ -154,7 +154,14 @@ class SemanticMediaWikiProvidedHookInterfaceIntegrationTest extends \PHPUnit_Fra
 	 */
 	public function testRegisteredFactboxBeforeContentGenerationToSuppressDefaultTableCreation( $storeClass ) {
 
-		$this->applicationFactory->getSettings()->set( 'smwgShowFactbox', SMW_FACTBOX_NONEMPTY );
+		$factboxFactory = $this->applicationFactory->singleton( 'FactboxFactory' );
+
+		$checkMagicWords = $factboxFactory->newCheckMagicWords(
+			[
+				'smwgShowFactboxEdit' => SMW_FACTBOX_NONEMPTY,
+				'showFactbox' => SMW_FACTBOX_NONEMPTY
+			]
+		);
 
 		$connection = $this->getMockBuilder( '\SMW\MediaWiki\Database' )
 			->disableOriginalConstructor()
@@ -204,7 +211,15 @@ class SemanticMediaWikiProvidedHookInterfaceIntegrationTest extends \PHPUnit_Fra
 			->method( 'getDBKey' )
 			->will( $this->returnValue( 'Foo' ) );
 
-		$instance = $this->applicationFactory->singleton( 'FactboxFactory' )->newFactbox( $title, new \ParserOutput() );
+		$instance = $factboxFactory->newFactbox(
+			$title,
+			new \ParserOutput()
+		);
+
+		$instance->setCheckMagicWords(
+			$checkMagicWords
+		);
+
 		$instance->doBuild();
 
 		$this->assertEquals(

--- a/tests/phpunit/Unit/EventListenerRegistryTest.php
+++ b/tests/phpunit/Unit/EventListenerRegistryTest.php
@@ -66,8 +66,6 @@ class EventListenerRegistryTest extends \PHPUnit_Framework_TestCase {
 		);
 
 		$this->verifyExporterResetEvent( $instance );
-		$this->verifyFactboxCacheDeleteEvent( $instance );
-		$this->verifyFactboxCacheDeleteEventOnEmpty( $instance );
 		$this->verifyCachedPropertyValuesPrefetcherResetEvent( $instance );
 		$this->verifyCachedPrefetcherResetEvent( $instance );
 		$this->verifyCachedUpdateMarkerDeleteEvent( $instance );
@@ -79,58 +77,6 @@ class EventListenerRegistryTest extends \PHPUnit_Framework_TestCase {
 
 	public function verifyQueryComparatorResetEvent( EventListenerCollection $instance ) {
 		$this->assertListenerExecuteFor( 'query.comparator.reset', $instance, null );
-	}
-
-	public function verifyFactboxCacheDeleteEvent( EventListenerCollection $instance ) {
-
-		$cache = $this->getMockBuilder( '\Onoi\Cache\Cache' )
-			->disableOriginalConstructor()
-			->getMock();
-
-		$title = $this->getMockBuilder( '\Title' )
-			->disableOriginalConstructor()
-			->getMock();
-
-		$title->expects( $this->atLeastOnce() )
-			->method( 'getArticleID' )
-			->will( $this->returnValue( 42 ) );
-
-		$this->testEnvironment->registerObject( 'Cache', $cache );
-
-		$dispatchContext = $this->eventDispatcherFactory->newDispatchContext();
-
-		$dispatchContext->set(
-			'title',
-			$title
-		);
-
-		$this->assertListenerExecuteFor(
-			'factbox.cache.delete',
-			$instance,
-			$dispatchContext
-		);
-	}
-
-	public function verifyFactboxCacheDeleteEventOnEmpty( EventListenerCollection $instance ) {
-
-		$cache = $this->getMockBuilder( '\Onoi\Cache\Cache' )
-			->disableOriginalConstructor()
-			->getMock();
-
-		$this->testEnvironment->registerObject( 'Cache', $cache );
-
-		$dispatchContext = $this->eventDispatcherFactory->newDispatchContext();
-
-		$dispatchContext->set(
-			'title',
-			''
-		);
-
-		$this->assertListenerExecuteFor(
-			'factbox.cache.delete',
-			$instance,
-			$dispatchContext
-		);
 	}
 
 	public function verifyCachedPropertyValuesPrefetcherResetEvent( EventListenerCollection $instance ) {

--- a/tests/phpunit/Unit/Factbox/CheckMagicWordsTest.php
+++ b/tests/phpunit/Unit/Factbox/CheckMagicWordsTest.php
@@ -1,0 +1,98 @@
+<?php
+
+namespace SMW\Tests\Factbox;
+
+use SMW\Factbox\CheckMagicWords;
+
+/**
+ * @covers \SMW\Factbox\CheckMagicWords
+ * @group semantic-mediawiki
+ *
+ * @license GNU GPL v2+
+ * @since 3.1
+ *
+ * @author mwjames
+ */
+class CheckMagicWordsTest extends \PHPUnit_Framework_TestCase {
+
+	public function testCanConstruct() {
+
+		$this->assertInstanceOf(
+			CheckMagicWords::class,
+			new CheckMagicWords( [] )
+		);
+	}
+
+	/**
+	 * @dataProvider magicWordsProvider
+	 */
+	public function testGetMagicWords( $magicWords, $options, $expected ) {
+
+		$parserOutput = $this->getMockBuilder( '\ParserOutput' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$parserOutput->expects( $this->any() )
+			->method( 'getExtensionData' )
+			->will( $this->returnValue( $magicWords ) );
+
+		$instance = new CheckMagicWords(
+			$options
+		);
+
+		$this->assertSame(
+			$expected,
+			$instance->getMagicWords( $parserOutput )
+		);
+	}
+
+	public function magicWordsProvider() {
+
+		yield [
+			[ 'SMW_SHOWFACTBOX' ],
+			[],
+			SMW_FACTBOX_NONEMPTY
+		];
+
+		yield [
+			[ 'SMW_NOFACTBOX' ],
+			[],
+			SMW_FACTBOX_HIDDEN
+		];
+
+		yield [
+			null,
+			[
+				'showFactbox' => SMW_FACTBOX_NONEMPTY,
+			],
+			SMW_FACTBOX_NONEMPTY
+		];
+
+		yield [
+			null,
+			[
+				'showFactbox' => SMW_FACTBOX_HIDDEN,
+			],
+			SMW_FACTBOX_HIDDEN
+		];
+
+		yield [
+			null,
+			[
+				'preview' => true,
+				'showFactboxEdit' => SMW_FACTBOX_HIDDEN,
+			],
+			SMW_FACTBOX_HIDDEN
+		];
+
+		yield [
+			null,
+			[
+				'preview' => true,
+				'showFactboxEdit' => SMW_FACTBOX_NONEMPTY,
+			],
+			SMW_FACTBOX_NONEMPTY
+		];
+	}
+
+}

--- a/tests/phpunit/Unit/Factbox/FactboxFactoryTest.php
+++ b/tests/phpunit/Unit/Factbox/FactboxFactoryTest.php
@@ -3,7 +3,6 @@
 namespace SMW\Tests\Factbox;
 
 use SMW\Factbox\FactboxFactory;
-use Title;
 
 /**
  * @covers \SMW\Factbox\FactboxFactory
@@ -19,7 +18,7 @@ class FactboxFactoryTest extends \PHPUnit_Framework_TestCase {
 	public function testCanConstruct() {
 
 		$this->assertInstanceOf(
-			'\SMW\Factbox\FactboxFactory',
+			FactboxFactory::class,
 			new FactboxFactory()
 		);
 	}
@@ -31,6 +30,16 @@ class FactboxFactoryTest extends \PHPUnit_Framework_TestCase {
 		$this->assertInstanceOf(
 			'\SMW\Factbox\CachedFactbox',
 			$instance->newCachedFactbox()
+		);
+	}
+
+	public function testCanConstructCheckMagicWords() {
+
+		$instance = new FactboxFactory();
+
+		$this->assertInstanceOf(
+			'\SMW\Factbox\CheckMagicWords',
+			$instance->newCheckMagicWords( [] )
 		);
 	}
 

--- a/tests/phpunit/Unit/Factbox/FactboxMagicWordsTest.php
+++ b/tests/phpunit/Unit/Factbox/FactboxMagicWordsTest.php
@@ -6,6 +6,7 @@ use ParserOutput;
 use ReflectionClass;
 use SMW\ApplicationFactory;
 use SMW\Factbox\Factbox;
+use SMW\Factbox\CheckMagicWords;
 use SMW\ParserData;
 use SMW\Tests\TestEnvironment;
 use Title;
@@ -99,15 +100,23 @@ class FactboxMagicWordsTest extends \PHPUnit_Framework_TestCase {
 			->disableOriginalConstructor()
 			->getMock();
 
+		$checkMagicWords = new CheckMagicWords(
+			[
+				'preview' => isset( $expected['preview'] ) && $expected['preview'],
+				'showFactboxEdit' => SMW_FACTBOX_HIDDEN,
+				'showFactbox' => SMW_FACTBOX_HIDDEN
+			]
+		);
+
 		$instance = new Factbox(
 			$store,
 			new ParserData( $title, $parserOutput ),
 			$messageBuilder
 		);
 
-		if ( isset( $expected['preview'] ) && $expected['preview'] ) {
-			$instance->setPreviewFlag( true );
-		}
+		$instance->setCheckMagicWords(
+			$checkMagicWords
+		);
 
 		$reflector = new ReflectionClass( '\SMW\Factbox\Factbox' );
 

--- a/tests/phpunit/Unit/Factbox/FactboxTest.php
+++ b/tests/phpunit/Unit/Factbox/FactboxTest.php
@@ -7,6 +7,7 @@ use ReflectionClass;
 use SMW\DIProperty;
 use SMW\DIWikiPage;
 use SMW\Factbox\Factbox;
+use SMW\Factbox\CheckMagicWords;
 use SMW\ParserData;
 use SMW\SemanticData;
 use SMW\TableFormatter;
@@ -41,172 +42,15 @@ class FactboxTest extends \PHPUnit_Framework_TestCase {
 		parent::tearDown();
 	}
 
-	public function testCanConstruct() {
+	public function testCreateTable() {
 
-		$store = $this->getMockBuilder( '\SMW\Store' )
-			->disableOriginalConstructor()
-			->getMockForAbstractClass();
-
-		$parserData = $this->getMockBuilder( '\SMW\ParserData' )
-			->disableOriginalConstructor()
-			->getMock();
-
-		$this->assertInstanceOf(
-			Factbox::class,
-			new Factbox( $store, $parserData )
-		);
-	}
-
-	public function testGetContent() {
-
-		$text = __METHOD__;
-
-		$parserData = new ParserData(
-			Title::newFromText( __METHOD__ ),
-			new ParserOutput()
-		);
-
-		$store = $this->getMockBuilder( '\SMW\Store' )
-			->disableOriginalConstructor()
-			->getMockForAbstractClass();
-
-		// Build Factbox stub object to encapsulate the method
-		// without the need for other dependencies to occur
-		$instance = $this->getMockBuilder( '\SMW\Factbox\Factbox' )
-			->setConstructorArgs( [
-				$store,
-				$parserData
-			] )
-			->setMethods( [ 'fetchContent', 'getMagicWords' ] )
-			->getMock();
-
-		$instance->expects( $this->any() )
-			->method( 'getMagicWords' )
-			->will( $this->returnValue( 'Lula' ) );
-
-		$instance->expects( $this->any() )
-			->method( 'fetchContent' )
-			->will( $this->returnValue( $text ) );
-
-		$this->assertFalse( $instance->isVisible() );
-
-		$instance->doBuild();
-
-		$this->assertInternalType(
-			'string',
-			$instance->getContent()
-		);
-
-		$this->assertEquals(
-			$text,
-			$instance->getContent()
-		);
-
-		$this->assertTrue( $instance->isVisible() );
-	}
-
-	public function testGetAttachmentContent() {
-
-		$dataItem = $this->getMockBuilder( '\SMWDataItem' )
-			->disableOriginalConstructor()
-			->getMockForAbstractClass();
-
-		$store = $this->getMockBuilder( '\SMW\Store' )
-			->disableOriginalConstructor()
-			->getMockForAbstractClass();
-
-		$store->expects( $this->any() )
-			->method( 'getPropertyValues' )
-			->will( $this->returnValue( [ $dataItem ] ) );
-
-		$parserOutput = $this->getMockBuilder( '\ParserOutput' )
-			->disableOriginalConstructor()
-			->getMock();
-
-		$title = Title::newFromText( __METHOD__ );
-
-		$instance = new Factbox(
-			$store,
-			new ParserData( $title, $parserOutput )
-		);
-
-		$instance->setAttachments(
+		$checkMagicWords = new CheckMagicWords(
 			[
-				DIWikiPage::newFromText( 'Foo', NS_FILE )
+				'smwgShowFactboxEdit' => SMW_FACTBOX_NONEMPTY,
+				'showFactbox' => SMW_FACTBOX_NONEMPTY
 			]
 		);
 
-		$instance->setFeatureSet( SMW_FACTBOX_DISPLAY_ATTACHMENT );
-		$attachmentContent = $instance->getAttachmentContent();
-
-		$this->assertContains(
-			__METHOD__,
-			$attachmentContent
-		);
-
-		$this->assertContains(
-			'|Foo]]',
-			$attachmentContent
-		);
-	}
-
-	public function testGetContentRoundTripForNonEmptyContent() {
-
-		$subject = DIWikiPage::newFromTitle( Title::newFromText( __METHOD__ ) );
-
-		$this->testEnvironment->addConfiguration( 'smwgShowFactbox', SMW_FACTBOX_NONEMPTY );
-
-		$store = $this->getMockBuilder( '\SMW\Store' )
-			->disableOriginalConstructor()
-			->getMockForAbstractClass();
-
-		$semanticData = $this->getMockBuilder( '\SMW\SemanticData' )
-			->disableOriginalConstructor()
-			->getMock();
-
-		$semanticData->expects( $this->any() )
-			->method( 'getSubject' )
-			->will( $this->returnValue( $subject ) );
-
-		$semanticData->expects( $this->any() )
-			->method( 'hasVisibleProperties' )
-			->will( $this->returnValue( true ) );
-
-		$semanticData->expects( $this->any() )
-			->method( 'getPropertyValues' )
-			->will( $this->returnValue( [ $subject ] ) );
-
-		$semanticData->expects( $this->any() )
-			->method( 'getProperties' )
-			->will( $this->returnValue( [ DIProperty::newFromUserLabel( 'SomeFancyProperty' ) ] ) );
-
-		$parserOutput = $this->setupParserOutput( $semanticData );
-
-		$instance = new Factbox(
-			$store,
-			new ParserData( $subject->getTitle(), $parserOutput )
-		);
-
-		$result = $instance->doBuild()->getContent();
-
-		$this->assertInternalType(
-			'string',
-			$result
-		);
-
-		$this->assertContains(
-			$subject->getDBkey(),
-			 $result
-		);
-
-		$this->assertEquals(
-			$subject->getTitle(),
-			$instance->getTitle()
-		);
-	}
-
-	public function testCreateTable() {
-
 		$parserData = new ParserData(
 			Title::newFromText( __METHOD__ ),
 			new ParserOutput()
@@ -216,7 +60,14 @@ class FactboxTest extends \PHPUnit_Framework_TestCase {
 			->disableOriginalConstructor()
 			->getMockForAbstractClass();
 
-		$instance = new Factbox( $store, $parserData );
+		$instance = new Factbox(
+			$store,
+			$parserData
+		);
+
+		$instance->setCheckMagicWords(
+			$checkMagicWords
+		);
 
 		$reflector = new ReflectionClass( '\SMW\Factbox\Factbox' );
 		$createTable  = $reflector->getMethod( 'createTable' );
@@ -280,6 +131,13 @@ class FactboxTest extends \PHPUnit_Framework_TestCase {
 	 */
 	public function testGetContentDataSimulation( $setup, $expected ) {
 
+		$checkMagicWords = new CheckMagicWords(
+			[
+				'smwgShowFactboxEdit' => SMW_FACTBOX_NONEMPTY,
+				'showFactbox' => $setup['showFactbox']
+			]
+		);
+
 		$semanticData = $this->getMockBuilder( '\SMW\SemanticData' )
 			->disableOriginalConstructor()
 			->getMock();
@@ -325,6 +183,10 @@ class FactboxTest extends \PHPUnit_Framework_TestCase {
 			] )
 			->setMethods( [ 'createTable' ] )
 			->getMock();
+
+		$factbox->setCheckMagicWords(
+			$checkMagicWords
+		);
 
 		$factbox->expects( $this->any() )
 			->method( 'createTable' )
@@ -416,6 +278,13 @@ class FactboxTest extends \PHPUnit_Framework_TestCase {
 
 	public function testGetTableHeader() {
 
+		$checkMagicWords = new CheckMagicWords(
+			[
+				'smwgShowFactboxEdit' => SMW_FACTBOX_NONEMPTY,
+				'showFactbox' => SMW_FACTBOX_NONEMPTY
+			]
+		);
+
 		$title = Title::newFromText( __METHOD__ );
 
 		$parserData = new ParserData(
@@ -433,13 +302,22 @@ class FactboxTest extends \PHPUnit_Framework_TestCase {
 			->disableOriginalConstructor()
 			->getMockForAbstractClass();
 
-		$instance = new Factbox( $store, $parserData );
+		$instance = new Factbox(
+			$store,
+			$parserData
+		);
+
+		$instance->setCheckMagicWords(
+			$checkMagicWords
+		);
+
+		$instance->doBuild();
 
 		$this->stringValidator->assertThatStringContains(
 			[
 				'div class="smwrdflink"'
 			],
-			$instance->doBuild()->getContent()
+			$instance->getContent()
 		);
 	}
 
@@ -447,6 +325,13 @@ class FactboxTest extends \PHPUnit_Framework_TestCase {
 	 * @dataProvider tableContentDataProvider
 	 */
 	public function testGetTableContent( $test, $expected ) {
+
+		$checkMagicWords = new CheckMagicWords(
+			[
+				'smwgShowFactboxEdit' => SMW_FACTBOX_NONEMPTY,
+				'showFactbox' => SMW_FACTBOX_NONEMPTY
+			]
+		);
 
 		$title = Title::newFromText( __METHOD__ );
 
@@ -492,11 +377,20 @@ class FactboxTest extends \PHPUnit_Framework_TestCase {
 			DIWikiPage::newFromTitle( $title )
 		);
 
-		$instance = new Factbox( $store, $parserData );
+		$instance = new Factbox(
+			$store,
+			$parserData
+		);
+
+		$instance->setCheckMagicWords(
+			$checkMagicWords
+		);
+
+		$instance->doBuild();
 
 		$this->stringValidator->assertThatStringContains(
 			$expected,
-			$instance->doBuild()->getContent()
+			$instance->getContent()
 		);
 	}
 

--- a/tests/phpunit/Unit/MediaWiki/Hooks/OutputPageParserOutputTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Hooks/OutputPageParserOutputTest.php
@@ -77,6 +77,12 @@ class OutputPageParserOutputTest extends \PHPUnit_Framework_TestCase {
 			->method( 'isSemanticEnabled' )
 			->will( $this->returnValue( $parameters['smwgNamespacesWithSemanticLinks'] ) );
 
+		$entityCache = new \SMW\EntityCache(
+			$this->applicationFactory->newCacheFactory()->newFixedInMemoryCache()
+		);
+
+		$this->testEnvironment->registerObject( 'EntityCache', $entityCache );
+
 		$store = $this->getMockBuilder( '\SMW\Store' )
 			->disableOriginalConstructor()
 			->getMockForAbstractClass();
@@ -101,7 +107,7 @@ class OutputPageParserOutputTest extends \PHPUnit_Framework_TestCase {
 			->method( 'newCachedFactbox' )
 			->will( $this->returnValue( $cachedFactbox ) );
 
-		$this->applicationFactory->registerObject( 'FactboxFactory', $factboxFactory );
+		$this->testEnvironment->registerObject( 'FactboxFactory', $factboxFactory );
 
 		$this->assertEmpty(
 			$cachedFactbox->retrieveContent( $outputPage )
@@ -199,7 +205,7 @@ class OutputPageParserOutputTest extends \PHPUnit_Framework_TestCase {
 			->method( 'getContext' )
 			->will( $this->returnValue( new \RequestContext() ) );
 
-		$outputPage->expects( $this->atLeastOnce() )
+		$outputPage->expects( $this->any() )
 			->method( 'getLanguage' )
 			->will( $this->returnValue( $language ) );
 
@@ -341,7 +347,7 @@ class OutputPageParserOutputTest extends \PHPUnit_Framework_TestCase {
 			->method( 'getContext' )
 			->will( $this->returnValue( $context ) );
 
-		$outputPage->expects( $this->atLeastOnce() )
+		$outputPage->expects( $this->any() )
 			->method( 'getLanguage' )
 			->will( $this->returnValue( $language ) );
 

--- a/tests/phpunit/Unit/MediaWiki/Hooks/SkinAfterContentTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Hooks/SkinAfterContentTest.php
@@ -28,7 +28,9 @@ class SkinAfterContentTest extends \PHPUnit_Framework_TestCase {
 		$settings = Settings::newFromArray( [
 			'smwgFactboxFeatures'  => SMW_FACTBOX_CACHE,
 			'smwgMainCacheType'        => 'hash',
-			'smwgSemanticsEnabled' => true
+			'smwgSemanticsEnabled' => true,
+			'smwgShowFactboxEdit' => false,
+			'smwgShowFactbox' => false
 		] );
 
 		$this->applicationFactory->registerObject( 'Settings', $settings );
@@ -139,9 +141,12 @@ class SkinAfterContentTest extends \PHPUnit_Framework_TestCase {
 			->method( 'getOutput' )
 			->will( $this->returnValue( $outputPage ) );
 
+		$requestContext = new \RequestContext();
+		$requestContext->setLanguage( 'en' );
+
 		$skin->expects( $this->atLeastOnce() )
 			->method( 'getContext' )
-			->will( $this->returnValue( new \RequestContext() ) );
+			->will( $this->returnValue( $requestContext ) );
 
 		$provider[] = [
 			[ 'skin' => $skin ],
@@ -167,6 +172,13 @@ class SkinAfterContentTest extends \PHPUnit_Framework_TestCase {
 			->method( 'getTitle' )
 			->will( $this->returnValue( $title ) );
 
+		$requestContext = new \RequestContext();
+		$requestContext->setLanguage( 'en' );
+
+		$outputPage->expects( $this->atLeastOnce() )
+			->method( 'getContext' )
+			->will( $this->returnValue( $requestContext ) );
+
 		$text = __METHOD__ . 'text-1';
 
 		$skin = $this->getMockBuilder( '\Skin' )
@@ -183,7 +195,7 @@ class SkinAfterContentTest extends \PHPUnit_Framework_TestCase {
 
 		$skin->expects( $this->atLeastOnce() )
 			->method( 'getContext' )
-			->will( $this->returnValue( new \RequestContext() ) );
+			->will( $this->returnValue( $requestContext ) );
 
 		$provider[] = [
 			[ 'skin' => $skin, 'text' => $text, 'title' => $outputPage->getTitle() ],


### PR DESCRIPTION
This PR is made in reference to: #

This PR addresses or contains:

- Using the `sub` cache of the `EntityCache` to cache different language versions for the same revision without evicting other versions of the same revision, yet allow them to be evicted together when the invalidation event arrives which reduced the amount of extra parsing
- Removes the `factbox.cache.delete` event (now part of `InvalidateEntityCache`)
- Isolates `CheckMagicWords` to allow for an early check in the process and hereby bailout sooner

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed
