### PR TITLE
Decode values before comparing (&lt;/&gt;,</>), refs 3292

### DIFF
--- a/src/PropertyChangePropagationNotifier.php
+++ b/src/PropertyChangePropagationNotifier.php
@@ -197,7 +197,7 @@ class PropertyChangePropagationNotifier {
 		// of the data value arrays. These are compared.
 		$values = [];
 		foreach ( $oldDataValue as $v ) {
-			$values[] = $v->getHash();
+			$values[] = htmlspecialchars_decode( $v->getHash() );
 		}
 
 		sort( $values );
@@ -205,7 +205,7 @@ class PropertyChangePropagationNotifier {
 
 		$values = [];
 		foreach ( $newDataValue as $v ) {
-			$values[] = $v->getHash();
+			$values[] = htmlspecialchars_decode( $v->getHash() );
 		}
 
 		sort( $values );

--- a/tests/phpunit/Unit/PropertyChangePropagationNotifierTest.php
+++ b/tests/phpunit/Unit/PropertyChangePropagationNotifierTest.php
@@ -4,6 +4,7 @@ namespace SMW\Tests;
 
 use SMW\DIProperty;
 use SMW\DIWikiPage;
+use SMWDIBlob as DIBlob;
 use SMW\PropertyChangePropagationNotifier;
 
 /**
@@ -189,7 +190,8 @@ class PropertyChangePropagationNotifierTest extends \PHPUnit_Framework_TestCase 
 			[ $subjects, $subjects, [ '_PVAL'          ], [ 'diff' => false, 'job' => false ] ],
 			[ $subject,  $subject,  [ '_PVAL'          ], [ 'diff' => false, 'job' => false ] ],
 			[ $subjects, $subjects, [ '_PVAL', '_LIST' ], [ 'diff' => true,  'job' => true ] ],
-			[ $subject,  $subject,  [ '_PVAL', '_LIST' ], [ 'diff' => true,  'job' => true ] ]
+			[ $subject,  $subject,  [ '_PVAL', '_LIST' ], [ 'diff' => true,  'job' => true ] ],
+			[ [ new DIBlob( '>100') ],  [ new DIBlob( '&gt;100') ],  [ '_PVAL', '_PVAL' ], [ 'diff' => false,  'job' => false ] ]
 		];
 	}
 


### PR DESCRIPTION
This PR is made in reference to: #3292

This PR addresses or contains:

- Ensures that the comparison will yield the same result whether `<`/`>` is encoded or not (bounds and ranges)

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed
