### PR TITLE
Move PropertChangePropagationNotifier

### DIFF
--- a/src/ApplicationFactory.php
+++ b/src/ApplicationFactory.php
@@ -390,9 +390,23 @@ class ApplicationFactory {
 	 */
 	public function newDataUpdater( SemanticData $semanticData ) {
 
+		$changePropagationNotifier = new \SMW\Property\ChangePropagationNotifier(
+			$this->getStore(),
+			$this->newSerializerFactory()
+		);
+
+		$changePropagationNotifier->setPropertyList(
+			$this->getSettings()->get( 'smwgChangePropagationWatchlist' )
+		);
+
+		$changePropagationNotifier->isCommandLineMode(
+			Site::isCommandLineMode()
+		);
+
 		$dataUpdater = new DataUpdater(
 			$this->getStore(),
-			$semanticData
+			$semanticData,
+			$changePropagationNotifier
 		);
 
 		$dataUpdater->isCommandLineMode(

--- a/src/Property/ChangePropagationNotifier.php
+++ b/src/Property/ChangePropagationNotifier.php
@@ -1,10 +1,15 @@
 <?php
 
-namespace SMW;
+namespace SMW\Property;
 
 use SMW\MediaWiki\Jobs\ChangePropagationDispatchJob;
 use SMWDataItem;
 use SMWDIBlob as DIBlob;
+use SMW\SerializerFactory;
+use SMW\Store;
+use SMW\SemanticData;
+use SMW\DIWikiPage;
+use SMW\DIProperty;
 
 /**
  * Before a new set of data (type, constraints etc.) is stored about a property
@@ -17,7 +22,7 @@ use SMWDIBlob as DIBlob;
  * @author mwjames
  * @author Markus Krötzsch
  */
-class PropertyChangePropagationNotifier {
+class ChangePropagationNotifier {
 
 	/**
 	 * @var Store
@@ -97,9 +102,7 @@ class PropertyChangePropagationNotifier {
 	 */
 	public function notify( DIWikiPage $subject ) {
 
-		$namespace = $subject->getNamespace();
-
-		if ( !$this->hasDiff() || ( $namespace !== SMW_NS_PROPERTY && $namespace !== NS_CATEGORY ) ) {
+		if ( !$this->hasDiff() || !$this->inNamespace( $subject ) ) {
 			return false;
 		}
 
@@ -113,6 +116,17 @@ class PropertyChangePropagationNotifier {
 	}
 
 	/**
+	 * @since 3.1
+	 *
+	 * @param DIWikiPage $subject
+	 *
+	 * @return boolean
+	 */
+	public function inNamespace( DIWikiPage $subject ) {
+		return $subject->getNamespace() === SMW_NS_PROPERTY || $subject->getNamespace() === NS_CATEGORY;
+	}
+
+	/**
 	 * Compare and detect differences between the invoked semantic data
 	 * and the current stored data
 	 *
@@ -123,9 +137,7 @@ class PropertyChangePropagationNotifier {
 	 */
 	public function checkAndNotify( SemanticData &$semanticData ) {
 
-		$namespace = $semanticData->getSubject()->getNamespace();
-
-		if ( $namespace !== SMW_NS_PROPERTY && $namespace !== NS_CATEGORY ) {
+		if ( !$this->inNamespace( $semanticData->getSubject() ) ) {
 			return;
 		}
 

--- a/tests/phpunit/Unit/DataUpdaterTest.php
+++ b/tests/phpunit/Unit/DataUpdaterTest.php
@@ -24,6 +24,7 @@ class DataUpdaterTest  extends \PHPUnit_Framework_TestCase {
 	private $semanticDataFactory;
 	private $spyLogger;
 	private $store;
+	private $changePropagationNotifier;
 
 	protected function setUp() {
 		parent::setUp();
@@ -35,6 +36,10 @@ class DataUpdaterTest  extends \PHPUnit_Framework_TestCase {
 		] );
 
 		$this->spyLogger = $this->testEnvironment->newSpyLogger();
+
+		$this->changePropagationNotifier = $this->getMockBuilder( '\SMW\Property\ChangePropagationNotifier' )
+			->disableOriginalConstructor()
+			->getMock();
 
 		$idTable = $this->getMockBuilder( '\stdClass' )
 			->setMethods( [ 'exists' ] )
@@ -77,7 +82,7 @@ class DataUpdaterTest  extends \PHPUnit_Framework_TestCase {
 
 		$this->assertInstanceOf(
 			DataUpdater::class,
-			new DataUpdater( $this->store, $semanticData )
+			new DataUpdater( $this->store, $semanticData, $this->changePropagationNotifier )
 		);
 	}
 
@@ -87,7 +92,8 @@ class DataUpdaterTest  extends \PHPUnit_Framework_TestCase {
 
 		$instance = new DataUpdater(
 			$this->store,
-			$semanticData
+			$semanticData,
+			$this->changePropagationNotifier
 		);
 
 		$this->assertTrue(
@@ -101,7 +107,8 @@ class DataUpdaterTest  extends \PHPUnit_Framework_TestCase {
 
 		$instance = new DataUpdater(
 			$this->store,
-			$semanticData
+			$semanticData,
+			$this->changePropagationNotifier
 		);
 
 		$instance->setLogger( $this->spyLogger );
@@ -161,7 +168,8 @@ class DataUpdaterTest  extends \PHPUnit_Framework_TestCase {
 
 		$instance = new DataUpdater(
 			$store,
-			$semanticData
+			$semanticData,
+			$this->changePropagationNotifier
 		);
 
 		$instance->canCreateUpdateJob(
@@ -217,7 +225,8 @@ class DataUpdaterTest  extends \PHPUnit_Framework_TestCase {
 
 		$instance = new DataUpdater(
 			$store,
-			$semanticData
+			$semanticData,
+			$this->changePropagationNotifier
 		);
 
 		$instance->canCreateUpdateJob(
@@ -241,7 +250,8 @@ class DataUpdaterTest  extends \PHPUnit_Framework_TestCase {
 
 		$instance = new DataUpdater(
 			$this->store,
-			$semanticData
+			$semanticData,
+			$this->changePropagationNotifier
 		);
 
 		$this->assertInternalType(
@@ -262,7 +272,8 @@ class DataUpdaterTest  extends \PHPUnit_Framework_TestCase {
 
 		$instance = new DataUpdater(
 			$this->store,
-			$semanticData
+			$semanticData,
+			$this->changePropagationNotifier
 		);
 
 		$this->assertFalse(
@@ -337,7 +348,8 @@ class DataUpdaterTest  extends \PHPUnit_Framework_TestCase {
 
 		$instance = new DataUpdater(
 			$store,
-			$semanticData
+			$semanticData,
+			$this->changePropagationNotifier
 		);
 
 		$instance->canCreateUpdateJob( true );

--- a/tests/phpunit/Unit/Property/ChangePropagationNotifierTest.php
+++ b/tests/phpunit/Unit/Property/ChangePropagationNotifierTest.php
@@ -1,14 +1,15 @@
 <?php
 
-namespace SMW\Tests;
+namespace SMW\Tests\Property;
 
 use SMW\DIProperty;
 use SMW\DIWikiPage;
 use SMWDIBlob as DIBlob;
-use SMW\PropertyChangePropagationNotifier;
+use SMW\Property\ChangePropagationNotifier;
+use SMW\Tests\TestEnvironment;
 
 /**
- * @covers \SMW\PropertyChangePropagationNotifier
+ * @covers \SMW\Property\ChangePropagationNotifier
  * @group semantic-mediawiki
  *
  * @license GNU GPL v2+
@@ -16,7 +17,7 @@ use SMW\PropertyChangePropagationNotifier;
  *
  * @author mwjames
  */
-class PropertyChangePropagationNotifierTest extends \PHPUnit_Framework_TestCase {
+class ChangePropagationNotifierTest extends \PHPUnit_Framework_TestCase {
 
 	protected $mockedStoreValues;
 	private $semanticData;
@@ -62,8 +63,8 @@ class PropertyChangePropagationNotifierTest extends \PHPUnit_Framework_TestCase 
 	public function testCanConstruct() {
 
 		$this->assertInstanceOf(
-			PropertyChangePropagationNotifier::class,
-			new PropertyChangePropagationNotifier( $this->store, $this->serializerFactory )
+			ChangePropagationNotifier::class,
+			new ChangePropagationNotifier( $this->store, $this->serializerFactory )
 		);
 	}
 
@@ -151,7 +152,7 @@ class PropertyChangePropagationNotifierTest extends \PHPUnit_Framework_TestCase 
 			->method( 'getPropertyValues' )
 			->will( $this->returnValue( $dataValues ) );
 
-		$instance = new PropertyChangePropagationNotifier(
+		$instance = new ChangePropagationNotifier(
 			$store,
 			$this->serializerFactory
 		);


### PR DESCRIPTION
This PR is made in reference to: #3801

This PR addresses or contains:

- Moves `SMW\PropertChangePropagationNotifier` to `SMW\Propert\ChangePropagationNotifier`
- Inject the class into the `DataUpdater`

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed

Fixes #