### PR TITLE
SQLite, use text type for `o_hash` field

### DIFF
--- a/src/SQLStore/EntityStore/DIHandlers/DIBlobHandler.php
+++ b/src/SQLStore/EntityStore/DIHandlers/DIBlobHandler.php
@@ -232,7 +232,13 @@ class DIBlobHandler extends DataItemHandler {
 
 	private function getCharFieldType() {
 
-		$fieldType = FieldType::FIELD_TITLE;
+		// http://sqlite.1065341.n5.nabble.com/Leading-zeros-disappear-td60515.html
+		// @Test:[p-0430]
+		if ( $this->isDbType( 'sqlite' ) ) {
+			$fieldType = FieldType::TYPE_TEXT;
+		} else {
+			$fieldType = FieldType::FIELD_TITLE;
+		}
 
 		if ( $this->hasFeature( SMW_FIELDT_CHAR_NOCASE ) ) {
 			$fieldType = FieldType::TYPE_CHAR_NOCASE;


### PR DESCRIPTION
This PR is made in reference to: http://sqlite.1065341.n5.nabble.com/Leading-zeros-disappear-td60515.html

This PR addresses or contains:

- Leading zeros like `0042` are removed in SQLite when the field is defined as VCHAR, only a TEXT field will keep the original data and test `P-0430` will fail on an upcoming change when removing the caching layer, so the only option to make sure we retrieve the data we expect is to switch to `TEXT` as field type on SQLite

This PR includes:
- [ ] Tests (unit/integration)
- [x] CI build passed
