### PR TITLE
[ES] Check for associated rev, refs 3697, 3777

### DIFF
--- a/i18n/en.json
+++ b/i18n/en.json
@@ -899,6 +899,8 @@
 	"smw-es-replication-error-missing-id": "The replication monitoring has found that article \"$1\" (ID: $2) is missing from the Elasticsearch backend.",
 	"smw-es-replication-error-divergent-date": "The replication monitoring has found that for the \"$1\" article (ID: $2) the modification date shows a discrepancy.",
 	"smw-es-replication-error-divergent-date-detail": "*$1 (Elasticsearch)\n*$2 (SQLStore)",
+	"smw-es-replication-error-divergent-revision": "The replication monitoring has found that for the \"$1\" article (ID: $2) the <b>associated revision</b> shows a discrepancy.",
+	"smw-es-replication-error-divergent-revision-detail": "*$1 (Elasticsearch)\n*$2 (SQLStore)",
 	"smw-es-replication-error-suggestions": "It is suggested to edit or purge the page to remove the discrepancy. If the issue remains then check the Elasticsearch cluster itself (allocator, exceptions, disk space etc.).",
 	"smw-es-replication-error-file-ingest-missing-file-attachment": "The replication monitoring has found that \"$1\" is missing a [[Property:File attachment|File attachment]] annotation indicating that the file ingest processor hasn't started or isn't finished.",
 	"smw-es-replication-error-file-ingest-missing-file-attachment-suggestions": "Please ensure that the [https://www.semantic-mediawiki.org/wiki/Help:ElasticStore/File_ingestion file ingest] job is scheduled and executed before the annotation and file index can be made available."

--- a/tests/phpunit/Unit/Elastic/Indexer/Replication/ReplicationStatusTest.php
+++ b/tests/phpunit/Unit/Elastic/Indexer/Replication/ReplicationStatusTest.php
@@ -101,4 +101,84 @@ class ReplicationStatusTest extends \PHPUnit_Framework_TestCase {
 		);
 	}
 
+	public function testGetAssociatedRev() {
+
+		$doc = [
+			'_source' => [
+				'subject' =>[
+					'rev_id' => 1001
+				]
+			]
+		];
+
+		$params = [
+			'index' => 'FOO',
+			'type' => 'data',
+			'id' => 42,
+			'_source_include' => [ 'subject.rev_id' ]
+		];
+
+		$this->connection->expects( $this->once() )
+			->method( 'getIndexName' )
+			->will( $this->returnValue( "FOO" ) );
+
+		$this->connection->expects( $this->once() )
+			->method( 'exists' )
+			->will( $this->returnValue( true ) );
+
+		$this->connection->expects( $this->once() )
+			->method( 'get' )
+			->with(	$this->equalTo( $params ) )
+			->will( $this->returnValue( $doc ) );
+
+		$instance = new ReplicationStatus(
+			$this->connection
+		);
+
+		$this->assertEquals(
+			1001,
+			$instance->getAssociatedRev( 42 )
+		);
+	}
+
+	public function testGet_associated_revision() {
+
+		$doc = [
+			'_source' => [
+				'subject' =>[
+					'rev_id' => 1001
+				]
+			]
+		];
+
+		$params = [
+			'index' => 'FOO',
+			'type' => 'data',
+			'id' => 42,
+			'_source_include' => [ 'subject.rev_id' ]
+		];
+
+		$this->connection->expects( $this->once() )
+			->method( 'getIndexName' )
+			->will( $this->returnValue( "FOO" ) );
+
+		$this->connection->expects( $this->once() )
+			->method( 'exists' )
+			->will( $this->returnValue( true ) );
+
+		$this->connection->expects( $this->once() )
+			->method( 'get' )
+			->with(	$this->equalTo( $params ) )
+			->will( $this->returnValue( $doc ) );
+
+		$instance = new ReplicationStatus(
+			$this->connection
+		);
+
+		$this->assertEquals(
+			1001,
+			$instance->get( 'associated_revision', 42 )
+		);
+	}
+
 }


### PR DESCRIPTION
This PR is made in reference to: #3697, #3777

This PR addresses or contains:

- After #3777 tracks the `smw_rev` in Elasticsearch, it is possible to check for the associated revision hereby allows for a more fine grained replication monitoring especially when `SemanticApprovedRevs` (implicitly means `ApprovedRevs`) is used to control content revisions

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed

## Example

![image](https://user-images.githubusercontent.com/1245473/54483052-3889a980-4845-11e9-83c7-8d3eb6c2a51c.png)
