### PR TITLE
Show filter count on property page

### DIFF
--- a/i18n/en.json
+++ b/i18n/en.json
@@ -893,6 +893,7 @@
 	"smw-install-incomplete-intro": "The installation (or upgrade) of <b>Semantic MediaWiki</b> has not been finalized and an administrator should run the following tasks to prevent data inconsistencies before users continue to create or alter content.",
 	"smw-install-incomplete-populate-hash-field": "The <code>smw_hash</code> field population was skipped during the setup, the [https://www.semantic-mediawiki.org/wiki/Help:populateHashField.php populateHashField.php] script is required to be executed.",
 	"smw-helplink": "https://www.semantic-mediawiki.org/wiki/Help:$1",
+	"smw-filter-count": "Filter count",
 	"smw-es-replication-check": "Replication check (Elasticsearch)",
 	"smw-es-replication-error": "Replication issue",
 	"smw-es-replication-file-ingest-error": "File ingest issue",

--- a/src/MediaWiki/Page/ListBuilder/ValueListBuilder.php
+++ b/src/MediaWiki/Page/ListBuilder/ValueListBuilder.php
@@ -42,6 +42,11 @@ class ValueListBuilder {
 	/**
 	 * @var integer
 	 */
+	private $filterCount = 0;
+
+	/**
+	 * @var integer
+	 */
 	private $maxPropertyValues = 3;
 
 	/**
@@ -56,6 +61,15 @@ class ValueListBuilder {
 	 */
 	public function __construct( Store $store ) {
 		$this->store = $store;
+	}
+
+	/**
+	 * @since 3.1
+	 *
+	 * @param integer
+	 */
+	public function getFilterCount() {
+		return $this->filterCount;
 	}
 
 	/**
@@ -100,6 +114,8 @@ class ValueListBuilder {
 		$from = isset( $query['from'] ) ? $query['from'] : 0;
 		$until = isset( $query['until'] ) ? $query['until'] : 0;
 		$filter = isset( $query['filter'] ) ? $query['filter'] : '';
+
+		$this->filterCount = 0;
 
 		// limit==0: configuration setting to disable this completely
 		if ( $limit < 1 ) {
@@ -392,6 +408,11 @@ class ValueListBuilder {
 		// Sort on the spot via PHP, which should be enough for the search
 		// and match functionality
 		ksort( $sort );
+		$this->filterCount =  $res->getCount() + $options->offset;
+
+		if ( $res->hasFurtherResults() ) {
+			$this->filterCount = ( $this->filterCount - 1 ) . '+';
+		}
 
 		return array_values( $sort );
 	}

--- a/src/MediaWiki/Page/PropertyPage.php
+++ b/src/MediaWiki/Page/PropertyPage.php
@@ -57,6 +57,11 @@ class PropertyPage extends Page {
 	private $isLockedView = false;
 
 	/**
+	 * @var integer
+	 */
+	private $filterCount = 0;
+
+	/**
 	 * @see 3.0
 	 *
 	 * @param Title $title
@@ -196,7 +201,7 @@ class PropertyPage extends Page {
 		$html = $this->makeValueList( $languageCode );
 		$isFirst = $html === '';
 
-		$htmlTabs->tab( 'smw-property-value', $this->msg( 'smw-property-tab-usage' ) . $this->getUsageCount(), [ 'hide' => $html === '' ] );
+		$htmlTabs->tab( 'smw-property-value', $this->msg( 'smw-property-tab-usage' ) . $this->getCount(), [ 'hide' => $html === '' ] );
 		$htmlTabs->content( 'smw-property-value', $html );
 
 		// Redirects
@@ -328,7 +333,7 @@ class PropertyPage extends Page {
 			$this->getOption( 'smwgMaxPropertyValues' )
 		);
 
-		return $valueListBuilder->createHtml(
+		$html = $valueListBuilder->createHtml(
 			$this->property,
 			$this->getDataItem(),
 			[
@@ -339,13 +344,28 @@ class PropertyPage extends Page {
 				'filter' => $request->getVal( 'filter', '' )
 			]
 		);
+
+		$this->filterCount = $valueListBuilder->getFilterCount();
+
+		return $html;
 	}
 
 	private function msg( $params, $type = Message::TEXT, $lang = Message::USER_LANGUAGE ) {
 		return Message::get( $params, $type, $lang );
 	}
 
-	private function getUsageCount() {
+	private function getCount() {
+
+		if ( $this->filterCount > 0 ) {
+			return Html::rawElement(
+				'span',
+				[
+					'title' =>  $this->msg( 'smw-filter-count' ),
+					'class' => 'usage-count'
+				],
+				$this->filterCount
+			);
+		}
 
 		$requestOptions = new RequestOptions();
 		$requestOptions->setLimit( 1 );


### PR DESCRIPTION
This PR is made in reference to: #

This PR addresses or contains:

- When using the filter on the property page, display a filter count instead of the estimated overall usage count

This PR includes:
- [ ] Tests (unit/integration)
- [x] CI build passed

## Example

### Usage count

![image](https://user-images.githubusercontent.com/1245473/54489857-ba5eee80-48a8-11e9-8b64-e422a466b6cd.png)

### Filter count

![image](https://user-images.githubusercontent.com/1245473/54489862-c64ab080-48a8-11e9-8266-a8921b22c0aa.png)
