### PR TITLE
ExternalFormatterUri to replace ` ` with `_`, refs 3388

### DIFF
--- a/src/DataValues/ExternalFormatterUriValue.php
+++ b/src/DataValues/ExternalFormatterUriValue.php
@@ -64,6 +64,9 @@ class ExternalFormatterUriValue extends UriValue {
 			return '';
 		}
 
+		// Convert MediWiki's ` ` as `_`
+		$value = str_replace( ' ' , '_', $value );
+
 		// Avoid already encoded values like `W%D6LLEKLA01` to be
 		// encoded twice
 		$value = $this->encode( rawurldecode( $value ) );

--- a/tests/phpunit/Unit/DataValues/ExternalFormatterUriValueTest.php
+++ b/tests/phpunit/Unit/DataValues/ExternalFormatterUriValueTest.php
@@ -163,6 +163,13 @@ class ExternalFormatterUriValueTest extends \PHPUnit_Framework_TestCase {
 			'http://foo/bar/A/B/C'
 		];
 
+		// #...
+		$provider[] = [
+			'http://foo/bar/$1',
+			'A b C',
+			'http://foo/bar/A_b_C'
+		];
+
 		return $provider;
 	}
 


### PR DESCRIPTION
This PR is made in reference to: #3388

This PR addresses or contains:

- Avoid issues with MediaWiki's parser hence transform ` ` to `_` to ensure no information get lost for the replacement string when building the URI

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed
