### PR TITLE
External identifier to support multi substitutes using {...}, refs 3728

### DIFF
--- a/i18n/en.json
+++ b/i18n/en.json
@@ -725,6 +725,7 @@
 	"smw-datavalue-external-formatter-uri-missing-placeholder": "Formatter URI is missing the ''$1'' placeholder.",
 	"smw-datavalue-external-formatter-invalid-uri": " \"$1\" is an invalid URL.",
 	"smw-datavalue-external-identifier-formatter-missing": "The property is missing an [[Property:External formatter uri|\"External formatter URI\"]] assignment.",
+	"smw-datavalue-external-identifier-multi-substitute-parameters-missing": "The \"$1\" external identifier expects a multi field substitution but the current \"$2\" value is missing at least one value parameter to match the requirement.",
 	"smw-datavalue-keyword-maximum-length": "The keyword exceeded the maximum length of $1 {{PLURAL:$1|character|characters}}.",
 	"smw-property-predefined-eid": "\"$1\" is a [[Special:Types/External identifier|type]] and predefined property provided by [https://www.semantic-mediawiki.org/wiki/Help:Special_properties Semantic MediaWiki] to represent external identifiers.",
 	"smw-property-predefined-peid": "\"$1\" is a predefined property that specifies an external identifier and is provided by [https://www.semantic-mediawiki.org/wiki/Help:Special_properties Semantic MediaWiki].",

--- a/tests/phpunit/Integration/JSONScript/TestCases/p-0916.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/p-0916.json
@@ -8,12 +8,26 @@
 		},
 		{
 			"namespace": "SMW_NS_PROPERTY",
+			"page": "wikipedia",
+			"contents": "[[Has type::External identifier]][[External formatter uri::https://en.wikipedia.org/w/index.php?title=$1&oldid=$2]]"
+		},
+		{
+			"namespace": "SMW_NS_PROPERTY",
 			"page": "WD reference",
 			"contents": "[[Has type::Reference]] [[Has fields::URL;WDID]]"
 		},
 		{
+			"namespace": "SMW_NS_PROPERTY",
+			"page": "Wikipedia reference",
+			"contents": "[[Has type::Reference]] [[Has fields::Number;wikipedia]]"
+		},
+		{
 			"page": "Example/P0916/1",
 			"contents": "[[WD reference::https://en.wikipedia.org/wiki/Franz_Schubert;Q7312]]"
+		},
+		{
+			"page": "Test:P0916/2",
+			"contents": "[[Wikipedia reference::837787373;Truid Aagesen{837787373}]]"
 		}
 	],
 	"tests": [
@@ -39,6 +53,27 @@
 				],
 				"not-contain": [
 					"title=&quot;.*:WDID&quot;&gt;WDID&lt;/a&gt;: &lt;span class=&quot;plainlinks smw-eid&quot;&gt;<a rel=\"nofollow\" class=\"external text\" href=\"https://www.wikidata.org/entity/Q7312\">Q7312</a>&lt;/span&gt;&lt;/li&gt;&lt;/ul&gt;\" title=\"WDID: <a rel=\"nofollow\" class=\"external text\" href=\"https://www.wikidata.org/entity/Q7312\">Q7312</a>\">"
+				]
+			}
+		},
+		{
+			"type": "parser",
+			"about": "#1 (external id with multiple substitutes)",
+			"subject": "Test:P0916/2",
+			"assert-store": {
+				"semantic-data": {
+					"strict-mode-valuematch": false,
+					"propertyCount": 3,
+					"propertyKeys": [
+						"_MDAT",
+						"_SKEY",
+						"Wikipedia reference"
+					]
+				}
+			},
+			"assert-output": {
+				"to-contain": [
+					"Wikipedia&quot;&gt;Wikipedia&lt;/a&gt;: &lt;a href=&quot;https://en.wikipedia.org/w/index.php?title=Truid_Aagesen&amp;amp;oldid=837787373&quot; target=&quot;_blank&quot;&gt;Truid Aagesen"
 				]
 			}
 		}

--- a/tests/phpunit/Integration/JSONScript/TestCases/p-0918.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/p-0918.json
@@ -1,0 +1,108 @@
+{
+	"description": "Test `_eid` with multiple substitutes",
+	"setup": [
+		{
+			"namespace": "SMW_NS_PROPERTY",
+			"page": "wikipedia",
+			"contents": "[[Has type::External identifier]][[External formatter uri::https://en.wikipedia.org/w/index.php?title=$1&oldid=$2]]"
+		},
+		{
+			"namespace": "SMW_NS_PROPERTY",
+			"page": "wikipedia:diff",
+			"contents": "[[Has type::External identifier]][[External formatter uri::https://en.wikipedia.org/w/index.php?title=$1&oldid=$2&diff=$3]]"
+		},
+		{
+			"page": "Test:P0918/1",
+			"contents": "[[wikipedia::Truid Aagesen{837787373,90}]]"
+		},
+		{
+			"page": "Test:P0918/2",
+			"contents": "[[wikipedia:diff::The Good, the Bad and the Ugly{886770575,887548148}]]"
+		},
+		{
+			"page": "Test:P0918/3",
+			"contents": "[[wikipedia:diff::The Good, the Bad and the Ugly{886770575,887548148\\,comma}]]"
+		}
+	],
+	"tests": [
+		{
+			"type": "parser",
+			"about": "#0 (multiple substitutes)",
+			"subject": "Test:P0918/1",
+			"assert-store": {
+				"semantic-data": {
+					"strict-mode-valuematch": false,
+					"propertyCount": 3,
+					"propertyKeys": [
+						"_MDAT",
+						"_SKEY",
+						"Wikipedia"
+					]
+				}
+			},
+			"assert-output": {
+				"to-contain": [
+					"<span class=\"plainlinks smw-eid\"><a rel=\"nofollow\" class=\"external text\" href=\"https://en.wikipedia.org/w/index.php?title=Truid_Aagesen&amp;oldid=837787373\">Truid Aagesen</a></span>"
+				]
+			}
+		},
+		{
+			"type": "parser",
+			"about": "#1 (multiple substitutes, different commas)",
+			"subject": "Test:P0918/2",
+			"assert-store": {
+				"semantic-data": {
+					"strict-mode-valuematch": false,
+					"propertyCount": 3,
+					"propertyKeys": [
+						"_MDAT",
+						"_SKEY",
+						"Wikipedia:diff"
+					]
+				}
+			},
+			"assert-output": {
+				"to-contain": [
+					"<span class=\"plainlinks smw-eid\"><a rel=\"nofollow\" class=\"external text\" href=\"https://en.wikipedia.org/w/index.php?title=The_Good,_the_Bad_and_the_Ugly&amp;oldid=886770575&amp;diff=887548148\">The Good, the Bad and the Ugly</a></span>"
+				]
+			}
+		},
+		{
+			"type": "parser",
+			"about": "#2 (multiple substitutes, different commas)",
+			"subject": "Test:P0918/3",
+			"assert-store": {
+				"semantic-data": {
+					"strict-mode-valuematch": false,
+					"propertyCount": 3,
+					"propertyKeys": [
+						"_MDAT",
+						"_SKEY",
+						"Wikipedia:diff"
+					]
+				}
+			},
+			"assert-output": {
+				"to-contain": [
+					"<span class=\"plainlinks smw-eid\"><a rel=\"nofollow\" class=\"external text\" href=\"https://en.wikipedia.org/w/index.php?title=The_Good,_the_Bad_and_the_Ugly&amp;oldid=886770575&amp;diff=887548148,comma\">The Good, the Bad and the Ugly</a></span>"
+				]
+			}
+		}
+	],
+	"settings": {
+		"wgContLang": "en",
+		"wgLang": "en",
+		"smwgPageSpecialProperties": [
+			"_MDAT"
+		],
+		"smwgNamespacesWithSemanticLinks": {
+			"NS_MAIN": true,
+			"SMW_NS_PROPERTY": true
+		}
+	},
+	"meta": {
+		"version": "2",
+		"is-incomplete": false,
+		"debug": false
+	}
+}

--- a/tests/phpunit/Unit/DataValues/ExternalFormatterUriValueTest.php
+++ b/tests/phpunit/Unit/DataValues/ExternalFormatterUriValueTest.php
@@ -43,6 +43,16 @@ class ExternalFormatterUriValueTest extends \PHPUnit_Framework_TestCase {
 		);
 	}
 
+	public function testHasMultiSubstitute() {
+
+		$instance = new ExternalFormatterUriValue();
+		$instance->setUserValue( 'http://example.org/Foo?a=$1,$2' );
+
+		$this->assertTrue(
+			$instance->hasMultiSubstitute()
+		);
+	}
+
 	/**
 	 * @dataProvider uriProvider
 	 */
@@ -53,7 +63,21 @@ class ExternalFormatterUriValueTest extends \PHPUnit_Framework_TestCase {
 
 		$this->assertEquals(
 			$expected,
-			$instance->getUriWithPlaceholderSubstitution( $replacement )
+			$instance->substituteAndFormatUri( $replacement )
+		);
+	}
+
+	/**
+	 * @dataProvider uriWithParametersProvider
+	 */
+	public function testFormattedUriWithParameters( $uri, $replacement, $parameters, $expected ) {
+
+		$instance = new ExternalFormatterUriValue();
+		$instance->setUserValue( $uri );
+
+		$this->assertEquals(
+			$expected,
+			$instance->substituteAndFormatUri( $replacement, $parameters )
 		);
 	}
 
@@ -171,6 +195,30 @@ class ExternalFormatterUriValueTest extends \PHPUnit_Framework_TestCase {
 		];
 
 		return $provider;
+	}
+
+	public function uriWithParametersProvider() {
+
+		yield [
+			'http://example.org/$1',
+			'foo',
+			[],
+			'http://example.org/foo'
+		];
+
+		yield [
+			'http://example.org/$1&id=$2',
+			'foo',
+			[ 1001 ],
+			'http://example.org/foo&id=1001'
+		];
+
+		yield [
+			'http://example.org/$1&id=$2',
+			'foo',
+			[ "a%2Cb" ],
+			'http://example.org/foo&id=a,b'
+		];
 	}
 
 }


### PR DESCRIPTION
This PR is made in reference to: #3728 

This PR addresses or contains:

- For example, an external canonical URL can have different parameters to represent different version of the content as in case of Wikipedia and in order to pinpoint the version additional parameters are necessary.
- Support multi substitutes using `{...}` to declare the parameter substitution scheme
- For a property `wikipedia` with:
  - `[[Has type::External identifier]]`
  - `[[External formatter uri::https://en.wikipedia.org/w/index.php?title=$1&oldid=$2]]`
  - `[[wikipedia::Truid Aagesen{837787373}]]` (you can also add a space in between `Truid Aagesen {83 ...}` for better readability), `{...}` identifies the 2nd...n parameters and will resolve as:
    - `https://en.wikipedia.org/w/index.php?title=Truid_Aagesen&oldid=837787373`

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed
