### PR TITLE
Support `Has fields` to allow property names with `:`

### DIFF
--- a/includes/datavalues/SMW_DV_PropertyList.php
+++ b/includes/datavalues/SMW_DV_PropertyList.php
@@ -1,5 +1,7 @@
 <?php
 
+use SMW\Localizer;
+
 /**
  * @ingroup SMWDataValues
  */
@@ -21,19 +23,28 @@ class SMWPropertyListValue extends SMWDataValue {
 	protected $m_diProperties;
 
 	protected function parseUserValue( $value ) {
-		global $wgContLang;
 
 		$this->m_diProperties = [];
 		$stringValue = '';
+
 		$valueList = preg_split( '/[\s]*;[\s]*/u', trim( $value ) );
+		$propertyNamespace = Localizer::getInstance()->getNamespaceTextById(
+			SMW_NS_PROPERTY
+		);
+
 		foreach ( $valueList as $propertyName ) {
 			$propertyNameParts = explode( ':', $propertyName, 2 );
 			if ( count( $propertyNameParts ) > 1 ) {
 				$namespace = smwfNormalTitleText( $propertyNameParts[0] );
-				$propertyName = $propertyNameParts[1];
-				$propertyNamespace = $wgContLang->getNsText( SMW_NS_PROPERTY );
-				if ( $namespace != $propertyNamespace ) {
-					$this->addErrorMsg( [ 'smw_wrong_namespace', $propertyNamespace ] );
+
+				// Is it a registered namespace? Or just a property with a `:`
+				// divider such as `foaf:name`?
+				if ( Localizer::getInstance()->getNamespaceIndexByName( $namespace ) ) {
+					$propertyName = $propertyNameParts[1];
+
+					if ( $namespace != $propertyNamespace ) {
+						$this->addErrorMsg( [ 'smw_wrong_namespace', $propertyNamespace ] );
+					}
 				}
 			}
 

--- a/src/DataValues/ValueFormatters/PropertyValueFormatter.php
+++ b/src/DataValues/ValueFormatters/PropertyValueFormatter.php
@@ -226,6 +226,9 @@ class PropertyValueFormatter extends DataValueFormatter {
 			$wikiPageValue->setCaption( $preferredLabel );
 		} elseif ( ( $translatedPropertyLabel = $this->findTranslatedPropertyLabel( $property ) ) !== '' ) {
 			$wikiPageValue->setCaption( $translatedPropertyLabel );
+		} elseif ( ( $preferredCaption = $wikiPageValue->getPreferredCaption() ) !== '' ) {
+			// Do care for the displaytitle!
+			$wikiPageValue->setCaption( $preferredCaption );
 		} else {
 			$wikiPageValue->setCaption( $property->getLabel() );
 		}

--- a/tests/phpunit/Integration/JSONScript/TestCases/p-0919.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/p-0919.json
@@ -1,0 +1,89 @@
+{
+	"description": "Test `_ref_rec`, `_eid`, and `:` property names (`wgAllowDisplayTitle`)",
+	"setup": [
+		{
+			"namespace": "SMW_NS_PROPERTY",
+			"page": "WDID",
+			"contents": "[[Has type::External identifier]][[External formatter uri::https://www.wikidata.org/entity/$1]]"
+		},
+		{
+			"namespace": "SMW_NS_PROPERTY",
+			"page": "wp:article",
+			"contents": "[[Has type::External identifier]][[External formatter uri::https://en.wikipedia.org/wiki/$1]] {{DISPLAYTITLE:wp:article}}"
+		},
+		{
+			"namespace": "SMW_NS_PROPERTY",
+			"page": "WD reference",
+			"contents": "[[Has type::Reference]] [[Has fields::URL;WDID]]"
+		},
+		{
+			"namespace": "SMW_NS_PROPERTY",
+			"page": "wp:reference",
+			"contents": "[[Has type::Reference]] [[Has fields::Text;wp:article]] {{DISPLAYTITLE:wp:reference}}"
+		},
+		{
+			"page": "Test:P0919/1",
+			"contents": "[[WD reference::https://en.wikipedia.org/wiki/Franz_Schubert;Q7312]]"
+		},
+		{
+			"page": "Test:P0919/2",
+			"contents": "[[wp:reference::Franz Schubert;Franz Schubert]]"
+		}
+	],
+	"tests": [
+		{
+			"type": "parser",
+			"about": "#0 (correct formatting for external identifier)",
+			"subject": "Test:P0919/1",
+			"assert-store": {
+				"semantic-data": {
+					"strict-mode-valuematch": false,
+					"propertyCount": 3,
+					"propertyKeys": [
+						"_MDAT",
+						"_SKEY",
+						"WD reference"
+					]
+				}
+			},
+			"assert-output": {
+				"to-contain": [
+					"data-content=\"&lt;ul&gt;&lt;li&gt;&lt;a href=&quot;.*:WDID&quot;",
+					"title=&quot;.*:WDID&quot;&gt;WDID&lt;/a&gt;: &lt;a href=&quot;https://www.wikidata.org/entity/Q7312&quot; target=&quot;_blank&quot;&gt;Q7312&lt;/a&gt;&lt;/li&gt;&lt;/ul&gt;\" title=\"WDID: Q7312\">"
+				],
+				"not-contain": [
+					"title=&quot;.*:WDID&quot;&gt;WDID&lt;/a&gt;: &lt;span class=&quot;plainlinks smw-eid&quot;&gt;<a rel=\"nofollow\" class=\"external text\" href=\"https://www.wikidata.org/entity/Q7312\">Q7312</a>&lt;/span&gt;&lt;/li&gt;&lt;/ul&gt;\" title=\"WDID: <a rel=\"nofollow\" class=\"external text\" href=\"https://www.wikidata.org/entity/Q7312\">Q7312</a>\">"
+				]
+			}
+		},
+		{
+			"type": "parser",
+			"about": "#1 (external identifier, lower case property label)",
+			"subject": "Test:P0919/2",
+			"assert-output": {
+				"to-contain": [
+					"https://en.wikipedia.org/wiki/Franz_Schubert",
+					"wp:article: Franz Schubert"
+				]
+			}
+		}
+	],
+	"settings": {
+		"wgContLang": "en",
+		"wgLang": "en",
+		"wgAllowDisplayTitle": true,
+		"wgRestrictDisplayTitle": false,
+		"smwgPageSpecialProperties": [
+			"_MDAT"
+		],
+		"smwgNamespacesWithSemanticLinks": {
+			"NS_MAIN": true,
+			"SMW_NS_PROPERTY": true
+		}
+	},
+	"meta": {
+		"version": "2",
+		"is-incomplete": false,
+		"debug": false
+	}
+}

--- a/tests/phpunit/Integration/JSONScript/TestCases/p-0920.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/p-0920.json
@@ -1,0 +1,59 @@
+{
+	"description": "Test `Has fields` with `:` name reference",
+	"setup": [
+		{
+			"namespace": "SMW_NS_PROPERTY",
+			"page": "wd:id",
+			"contents": "[[Has type::External identifier]][[External formatter uri::https://www.wikidata.org/entity/$1]]"
+		},
+		{
+			"namespace": "SMW_NS_PROPERTY",
+			"page": "wd:reference",
+			"contents": "[[Has type::Reference]] [[Has fields::Property:URL;wd:id]]"
+		},
+		{
+			"page": "Test:P0920/1",
+			"contents": "[[wd:reference::https://en.wikipedia.org/wiki/Franz_Schubert;Q7312]]"
+		}
+	],
+	"tests": [
+		{
+			"type": "parser",
+			"about": "#0 (correct formatting for external identifier)",
+			"subject": "Test:P0920/1",
+			"assert-store": {
+				"semantic-data": {
+					"strict-mode-valuematch": false,
+					"propertyCount": 3,
+					"propertyKeys": [
+						"_MDAT",
+						"_SKEY",
+						"Wd:reference"
+					]
+				}
+			},
+			"assert-output": {
+				"to-contain": [
+					"data-content=\"&lt;ul&gt;&lt;li&gt;&lt;a href=&quot;.*:Wd:id&quot;",
+					"title=&quot;.*:Wd:id&quot;&gt;Wd:id&lt;/a&gt;: &lt;a href=&quot;https://www.wikidata.org/entity/Q7312&quot; target=&quot;_blank&quot;&gt;Q7312&lt;/a&gt;&lt;/li&gt;&lt;/ul&gt;\" title=\"Wd:id: Q7312\">"
+				]
+			}
+		}
+	],
+	"settings": {
+		"wgContLang": "en",
+		"wgLang": "en",
+		"smwgPageSpecialProperties": [
+			"_MDAT"
+		],
+		"smwgNamespacesWithSemanticLinks": {
+			"NS_MAIN": true,
+			"SMW_NS_PROPERTY": true
+		}
+	},
+	"meta": {
+		"version": "2",
+		"is-incomplete": false,
+		"debug": false
+	}
+}


### PR DESCRIPTION
This PR is made in reference to: #

This PR addresses or contains:

- Checks properties registered with `Has fields` whether a name that contains a `:` (like `wp:article`) can be used or not by establishing that `wp:` is not a namespace (previously it would just throw an error)

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed
