### PR TITLE
Support schema change to push a change propagation dispatch job, refs 3746

### DIFF
--- a/src/DataUpdater.php
+++ b/src/DataUpdater.php
@@ -334,6 +334,8 @@ class DataUpdater {
 				$propertyAnnotator,
 				$schema
 			);
+
+			$schemaFactory->pushPossibleChangePropagationDispatchJob( $schema );
 		}
 
 		$propertyAnnotator->addAnnotation();

--- a/src/Schema/Exception/SchemaParameterTypeMismatchException.php
+++ b/src/Schema/Exception/SchemaParameterTypeMismatchException.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace SMW\Schema\Exception;
+
+use RuntimeException;
+
+/**
+ * @license GNU GPL v2+
+ * @since 3.1
+ *
+ * @author mwjames
+ */
+class SchemaParameterTypeMismatchException extends RuntimeException {
+
+	/**
+	 * @since 3.1
+	 *
+	 * @param string $parameter
+	 * @param string $type
+	 */
+	public function __construct( $parameter, $type ) {
+		parent::__construct( "Expected $type for the `$parameter` parameter." );
+	}
+
+}

--- a/tests/phpunit/Unit/Schema/Exception/SchemaParameterTypeMismatchExceptionTest.php
+++ b/tests/phpunit/Unit/Schema/Exception/SchemaParameterTypeMismatchExceptionTest.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace SMW\Tests\Schema\Exception;
+
+use SMW\Schema\Exception\SchemaParameterTypeMismatchException;
+
+/**
+ * @covers \SMW\Schema\Exception\SchemaParameterTypeMismatchException
+ * @group semantic-mediawiki
+ *
+ * @license GNU GPL v2+
+ * @since 3.1
+ *
+ * @author mwjames
+ */
+class SchemaParameterTypeMismatchExceptionTest extends \PHPUnit_Framework_TestCase {
+
+	public function testCanConstruct() {
+
+		$instance = new SchemaParameterTypeMismatchException( 'foo', 'array' );
+
+		$this->assertInstanceof(
+			SchemaParameterTypeMismatchException::class,
+			$instance
+		);
+
+		$this->assertInstanceof(
+			'\RuntimeException',
+			$instance
+		);
+	}
+
+}


### PR DESCRIPTION
This PR is made in reference to: #3746

This PR addresses or contains:

- Isolated from #3746 where a schema change can trigger a `ChangePropagationDispatchJob` for connected properties 

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed
