### PR TITLE
Use local copy of 'jquery.async'

### DIFF
--- a/tests/qunit/smw/ext.smw.test.js
+++ b/tests/qunit/smw/ext.smw.test.js
@@ -167,7 +167,7 @@
 		assert.ok( context.find( '#' + argument ), '.async.load() was executed and created an element using the invoked argument' );
 
 		// Make sure async plug-in is loaded, iterate, and create some content
-		mw.loader.using( 'jquery.async', function() {
+		mw.loader.using( 'ext.jquery.async', function() {
 			context = $( '<div id="test-4"></div>', '#qunit-fixture' );
 			for ( var i = 0; i < 4; i++ ) {
 				argument = 'lila-' + i;


### PR DESCRIPTION
The repo has its own copy of this module defined in `/res/Resources.php` which is good as the one in core is been deprecated, to be removed in the next release (https://phabricator.wikimedia.org/T209699)

Update this line to refer to that module instead so that things keep working :)