### PR TITLE
Factbox check for $latestRevID > 0, refs 3739

### DIFF
--- a/src/Factbox/CachedFactbox.php
+++ b/src/Factbox/CachedFactbox.php
@@ -321,7 +321,11 @@ class CachedFactbox {
 
 		\Hooks::run( 'SMW::Factbox::OverrideRevisionID', [ $title, &$latestRevID ] );
 
-		return $latestRevID;
+		if ( $latestRevID > 0 ) {
+			return $latestRevID;
+		}
+
+		return $title->getLatestRevID();
 	}
 
 	/**


### PR DESCRIPTION
This PR is made in reference to: #3739

This PR addresses or contains:

- Make sure any hook the overrides `SMW::Factbox::OverrideRevisionID` returns `latestRevID` with something useful (had `SemanticApprovedRevs` enabled and it made some test flaky because the instance wasn't mocked and returned `false`)

This PR includes:
- [ ] Tests (unit/integration)
- [x] CI build passed
