### PR TITLE
[CI] Set `smwgMainCacheType` to `hash`

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -55,6 +55,7 @@
     </filter>
     <php>
        <var name="smwgSemanticsEnabled" value="true"/>
+       <var name="smwgMainCacheType" value="hash"/>
        <var name="wgUseFileCache" value="false"/>
        <var name="smwgEntityCollation" value="identity"/>
        <var name="smwgFieldTypeFeatures" value="false"/>


### PR DESCRIPTION
This PR is made in reference to: #

This PR addresses or contains:

- Avoid any surprises during testing when `LocalSettings.php` defines a `smwgMainCacheType`

This PR includes:
- [ ] Tests (unit/integration)
- [x] CI build passed
