### PR TITLE
Add `Constraint` interface and `ConstraintCheckRunner`, refs 3746

### DIFF
--- a/includes/Setup.php
+++ b/includes/Setup.php
@@ -293,6 +293,7 @@ final class Setup {
 			'smw.changePropagationDispatch' => 'SMW\MediaWiki\Jobs\ChangePropagationDispatchJob',
 			'smw.changePropagationUpdate' => 'SMW\MediaWiki\Jobs\ChangePropagationUpdateJob',
 			'smw.changePropagationClassUpdate' => 'SMW\MediaWiki\Jobs\ChangePropagationClassUpdateJob',
+			'smw.deferredConstraintCheckUpdateJob' => 'SMW\MediaWiki\Jobs\DeferredConstraintCheckUpdateJob',
 			'smw.elasticIndexerRecovery' => 'SMW\Elastic\Indexer\IndexerRecoveryJob',
 			'smw.elasticFileIngest' => 'SMW\Elastic\Indexer\FileIngestJob',
 

--- a/src/MediaWiki/Jobs/DeferredConstraintCheckUpdateJob.php
+++ b/src/MediaWiki/Jobs/DeferredConstraintCheckUpdateJob.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace SMW\MediaWiki\Jobs;
+
+use SMW\MediaWiki\Job;
+use Title;
+
+/**
+ * @license GNU GPL v2+
+ * @since 3.1
+ *
+ * @author mwjames
+ */
+class DeferredConstraintCheckUpdateJob extends Job {
+
+	const JOB_COMMAND = 'smw.deferredConstraintCheckUpdateJob';
+
+	/**
+	 * @since 3.1
+	 *
+	 * @param Title $title
+	 * @param array $params job parameters
+	 */
+	public function __construct( Title $title, $params = [] ) {
+		parent::__construct( self::JOB_COMMAND, $title, $params );
+		$this->removeDuplicates = true;
+	}
+
+	/**
+	 * @since 3.1
+	 *
+	 * @param Title $title
+	 * @param array $params
+	 *
+	 * @return boolean
+	 */
+	public static function pushJob( Title $title, $params = [] ) {
+
+		$deferredConstraintCheckUpdateJob = new self(
+			$title,
+			self::newRootJobParams( self::JOB_COMMAND, $title ) + [ 'waitOnCommandLine' => true ] + $params
+		);
+
+		$deferredConstraintCheckUpdateJob->insert();
+
+		return true;
+	}
+
+	/**
+	 * @see Job::run
+	 *
+	 * @since 3.1
+	 */
+	public function run() {
+
+		if ( $this->waitOnCommandLineMode() ) {
+			return true;
+		}
+
+		$updateJob = new UpdateJob(
+			$this->getTitle(),
+			$this->params + [ 'origin' => 'DeferredConstraintCheckUpdateJob' ]
+		);
+
+		$updateJob->run();
+
+		return true;
+	}
+
+}

--- a/src/Property/Constraint/Constraint.php
+++ b/src/Property/Constraint/Constraint.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace SMW\Property\Constraint;
+
+/**
+ * @license GNU GPL v2+
+ * @since 3.1
+ *
+ * @author mwjames
+ */
+interface Constraint {
+
+	/**
+	 * The constraint check happens instantaneous on a GET request (aka. online)
+	 * and should be used for "light" checks that doesn't involve the `QueryEngine`
+	 * or a rule resolver given the potential computational requirements that
+	 * are required to run checks on each individual value.
+	 */
+	const TYPE_INSTANT = 'type/instant';
+
+	/**
+	 * The constraint check happens after a GET request using the job queue.
+	 */
+	const TYPE_DEFERRED = 'type/deferred';
+
+	/**
+	 * Returns true when a violation during the check occurred.
+	 *
+	 * @since 3.1
+	 *
+	 * @return boolean
+	 */
+	public function hasViolation();
+
+	/**
+	 * @since 3.1
+	 *
+	 * @param string|integer $type
+	 *
+	 * @return boolean
+	 */
+	public function isType( $type );
+
+	/**
+	 * Checks a constraint against a single value. Any error that occurred during
+	 * the processing should be attached to an individual value using the
+	 * `ConstraintError` class.
+	 *
+	 * @since 3.1
+	 *
+	 * @param array $constraint
+	 * @param mixed $value
+	 */
+	public function checkConstraint( array $constraint, $value );
+
+}

--- a/src/Property/Constraint/ConstraintCheckRunner.php
+++ b/src/Property/Constraint/ConstraintCheckRunner.php
@@ -1,0 +1,140 @@
+<?php
+
+namespace SMW\Property\Constraint;
+
+use RuntimeException;
+use SMW\Schema\Schema;
+use SMW\Schema\SchemaList;
+
+/**
+ * @license GNU GPL v2+
+ * @since 3.1
+ *
+ * @author mwjames
+ */
+class ConstraintCheckRunner {
+
+	/**
+	 * @var ConstraintRegistry
+	 */
+	private $constraintRegistry;
+
+	/**
+	 * @var []
+	 */
+	private $constraintChecks = [];
+
+	/**
+	 * @var []
+	 */
+	private $constraints = [];
+
+	/**
+	 * @var []
+	 */
+	private $constraintSchemas = [];
+
+	/**
+	 * @var boolean
+	 */
+	private $hasViolation = false;
+
+	/**
+	 * @var boolean
+	 */
+	private $hasDeferrableConstraint = false;
+
+	/**
+	 * @since 3.1
+	 *
+	 * @param ConstraintRegistry $constraintRegistry
+	 */
+	public function __construct( ConstraintRegistry $constraintRegistry ) {
+		$this->constraintRegistry = $constraintRegistry;
+	}
+
+	/**
+	 * @since 3.1
+	 *
+	 * @return boolean
+	 */
+	public function hasViolation() {
+		return $this->hasViolation;
+	}
+
+	/**
+	 * @since 3.1
+	 *
+	 * @return boolean
+	 */
+	public function hasDeferrableConstraint() {
+		return $this->hasDeferrableConstraint;
+	}
+
+	/**
+	 * @since 3.1
+	 *
+	 * @param string $key
+	 * @param Schema|SchemaList $schema
+	 */
+	public function load( $key, $schema ) {
+
+		$this->hasViolation = false;
+		$this->constraints = [];
+
+		if ( !isset( $this->constraintSchemas[$key] ) && $schema instanceof Schema ) {
+			$this->constraintSchemas[$key] = $schema->get( 'constraints' );
+		}
+
+		if ( !isset( $this->constraintSchemas[$key] ) && $schema instanceof SchemaList ) {
+			$schema = $schema->merge( $schema );
+
+			if ( isset( $schema['constraints'] ) ) {
+				$this->constraintSchemas[$key] = $schema['constraints'];
+			}
+		}
+
+		if ( isset( $this->constraintSchemas[$key] ) ) {
+			$this->constraints = $this->constraintSchemas[$key];
+		}
+	}
+	/**
+	 * @since 3.1
+	 *
+	 * @return []
+	 */
+	public function getConstraints() {
+		return $this->constraints;
+	}
+
+	/**
+	 * @since 3.1
+	 *
+	 * @param mixed $dataValue
+	 */
+	public function check( $dataValue ) {
+
+		$this->hasDeferrableConstraint = false;
+		$this->hasViolation = false;
+
+		foreach ( $this->constraints as $key => $value ) {
+
+			// Bailout in case there is already a violation
+			if ( $this->hasViolation ) {
+				break;
+			}
+
+			$constraint = $this->constraintRegistry->getConstraintByKey(
+				$key
+			);
+
+			if ( $constraint->isType( Constraint::TYPE_DEFERRED ) ) {
+				$this->hasDeferrableConstraint = true;
+			} else {
+				$constraint->checkConstraint( [ $key => $value ], $dataValue );
+				$this->hasViolation = $constraint->hasViolation();
+			}
+		}
+	}
+
+}

--- a/src/Property/Constraint/ConstraintError.php
+++ b/src/Property/Constraint/ConstraintError.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace SMW\Property\Constraint;
+
+use SMW\Message;
+use SMW\ProcessingError;
+
+/**
+ * @license GNU GPL v2+
+ * @since 3.1
+ *
+ * @author mwjames
+ */
+class ConstraintError implements ProcessingError {
+
+	/**
+	 * @var []
+	 */
+	private $parameters = [];
+
+	/**
+	 * @var string
+	 */
+	private $type;
+
+	/**
+	 * @since 3.1
+	 *
+	 * @param string|[] $parameters
+	 * @param integer|string|null $type
+	 */
+	public function __construct( $parameters, $type = null ) {
+		$this->parameters = $parameters;
+		$this->type = $type;
+	}
+
+	/**
+	 * @since 3.1
+	 *
+	 * @return string
+	 */
+	public function getHash() {
+		return Message::getHash( $this->parameters, $this->type );
+	}
+
+	/**
+	 * @since 3.1
+	 *
+	 * @return string
+	 */
+	public function getType() {
+		return 'constraint';
+	}
+
+	/**
+	 * @since 3.1
+	 *
+	 * @return string
+	 */
+	public function encode() {
+		return Message::encode( $this->parameters, $this->type );
+	}
+
+	/**
+	 * @since 3.1
+	 *
+	 * @return string
+	 */
+	public function __toString() {
+		return $this->encode();
+	}
+
+}

--- a/src/Property/Constraint/ConstraintRegistry.php
+++ b/src/Property/Constraint/ConstraintRegistry.php
@@ -1,0 +1,100 @@
+<?php
+
+namespace SMW\Property\Constraint;
+
+use RuntimwException;
+use SMW\Property\ConstraintFactory;
+use SMW\Property\Constraint\Constraints\NullConstraint;
+
+/**
+ * @license GNU GPL v2+
+ * @since 3.1
+ *
+ * @author mwjames
+ */
+class ConstraintRegistry {
+
+	/**
+	 * @var ConstraintFactory
+	 */
+	private $constraintFactory;
+
+	/**
+	 * @var []
+	 */
+	private $constraints = [];
+
+	/**
+	 * @var []
+	 */
+	private $instances = [];
+
+	/**
+	 * @var boolean
+	 */
+	private $hasViolation = false;
+
+	/**
+	 * @since 3.1
+	 *
+	 * @param ConstraintFactory $constraintFactory
+	 */
+	public function __construct( ConstraintFactory $constraintFactory ) {
+		$this->constraintFactory = $constraintFactory;
+	}
+
+	/**
+	 * @since 3.1
+	 *
+	 * @param string $key
+	 * @param Constraint|string $constraint
+	 */
+	public function registerConstraint( $key, $constraint ) {
+
+		if ( $this->constraints === [] ) {
+			$this->constraints = $this->initConstraints();
+		}
+
+		$this->constraints[$key] = $constraint;
+	}
+
+	/**
+	 * @since 3.1
+	 *
+	 * @param string $key
+	 *
+	 * @return Constraint
+	 */
+	public function getConstraintByKey( $key ) {
+
+		if ( $this->constraints === [] ) {
+			$this->constraints = $this->initConstraints();
+		}
+
+		if ( isset( $this->constraints[$key] ) ) {
+			return $this->loadInstance( $this->constraints[$key] );
+		}
+
+		return $this->loadInstance( $this->constraints['null'] );
+	}
+
+	private function initConstraints() {
+		return [
+			'null' => NullConstraint::class
+		];
+	}
+
+	private function loadInstance( $class ) {
+
+		if ( is_callable( $class ) ) {
+			return $class();
+		} elseif ( $class instanceof Constraint ) {
+			return $class;
+		} elseif ( !isset( $this->instances[$class] ) ) {
+			$this->instances[$class] = $this->constraintFactory->newConstraintByClass( $class );
+		}
+
+		return $this->instances[$class];
+	}
+
+}

--- a/src/Property/Constraint/Constraints/NullConstraint.php
+++ b/src/Property/Constraint/Constraints/NullConstraint.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace SMW\Property\Constraint\Constraints;
+
+use SMW\Property\Constraint\Constraint;
+
+/**
+ * @license GNU GPL v2+
+ * @since 3.1
+ *
+ * @author mwjames
+ */
+class NullConstraint implements Constraint {
+
+	/**
+	 * @since 3.1
+	 *
+	 * {@inheritDoc}
+	 */
+	public function hasViolation() {
+		return false;
+	}
+
+	/**
+	 * @since 3.1
+	 *
+	 * {@inheritDoc}
+	 */
+	public function isType( $type ){
+		return $type === Constraint::TYPE_INSTANT;
+	}
+
+	/**
+	 * @since 3.1
+	 *
+	 * {@inheritDoc}
+	 */
+	public function checkConstraint( array $constraint, $value ) {}
+
+}

--- a/src/Property/ConstraintFactory.php
+++ b/src/Property/ConstraintFactory.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace SMW\Property;
+
+use SMW\Property\Constraint\ConstraintCheckRunner;
+use SMW\Property\Constraint\ConstraintRegistry;
+use SMW\Property\Constraint\Constraints\NullConstraint;
+use SMW\Site;
+use SMW\ApplicationFactory;
+
+/**
+ * @license GNU GPL v2+
+ * @since 3.1
+ *
+ * @author mwjames
+ */
+class ConstraintFactory {
+
+	/**
+	 * @since 3.1
+	 *
+	 * @return ConstraintRegistry
+	 */
+	public function newConstraintRegistry() {
+		return new ConstraintRegistry( $this );
+	}
+
+	/**
+	 * @since 3.1
+	 *
+	 * @return ConstraintCheckRunner
+	 */
+	public function newConstraintCheckRunner() {
+		return new ConstraintCheckRunner( $this->newConstraintRegistry() );
+	}
+
+	/**
+	 * @since 3.1
+	 *
+	 * @param string $class
+	 *
+	 * @return Constraint
+	 */
+	public function newConstraintByClass( $class ) {
+		return $this->newNullConstraint();
+	}
+
+	/**
+	 * @since 3.1
+	 *
+	 * @return NullConstraint
+	 */
+	public function newNullConstraint() {
+		return new NullConstraint();
+	}
+
+}

--- a/src/Services/DataValueServices.php
+++ b/src/Services/DataValueServices.php
@@ -166,6 +166,7 @@ return [
 		);
 
 		$constraintSchemaValueValidator = new ConstraintSchemaValueValidator(
+			$containerBuilder->singleton( 'ConstraintFactory' )->newConstraintCheckRunner(),
 			$containerBuilder->singleton( 'SchemaFactory' )->newSchemaFinder( $store )
 		);
 

--- a/src/Services/SharedServicesContainer.php
+++ b/src/Services/SharedServicesContainer.php
@@ -42,6 +42,7 @@ use SMW\Protection\ProtectionValidator;
 use SMW\Query\QuerySourceFactory;
 use SMW\Query\Result\CachedQueryResultPrefetcher;
 use SMW\Schema\SchemaFactory;
+use SMW\Property\ConstraintFactory;
 use SMW\Settings;
 use SMW\Options;
 use SMW\StoreFactory;
@@ -349,6 +350,14 @@ class SharedServicesContainer implements CallbackContainer {
 			);
 
 			return $schemaFactory;
+		} );
+
+		/**
+		 * @var ConstraintFactory
+		 */
+		$containerBuilder->registerCallback( 'ConstraintFactory', function( $containerBuilder ) {
+			$containerBuilder->registerExpectedReturnType( 'ConstraintFactory', ConstraintFactory::class );
+			return new ConstraintFactory();
 		} );
 
 		/**

--- a/tests/phpunit/Unit/DataValues/ValueValidators/ConstraintSchemaValueValidatorTest.php
+++ b/tests/phpunit/Unit/DataValues/ValueValidators/ConstraintSchemaValueValidatorTest.php
@@ -5,6 +5,7 @@ namespace SMW\Tests\DataValues\ValueValidators;
 use SMW\DataItemFactory;
 use SMW\DataValueFactory;
 use SMW\DataValues\ValueValidators\ConstraintSchemaValueValidator;
+use SMW\Tests\TestEnvironment;
 
 /**
  * @covers \SMW\DataValues\ValueValidators\ConstraintSchemaValueValidator
@@ -19,29 +20,55 @@ class ConstraintSchemaValueValidatorTest extends \PHPUnit_Framework_TestCase {
 
 	private $dataItemFactory;
 	private $dataValueFactory;
+	private $constraintCheckRunner;
 	private $schemafinder;
 
 	protected function setUp() {
 		parent::setUp();
+
+		$this->testEnvironment = new TestEnvironment();
+
 		$this->dataItemFactory = new DataItemFactory();
 		$this->dataValueFactory = DataValueFactory::getInstance();
+
+		$this->constraintCheckRunner = $this->getMockBuilder( '\SMW\Property\Constraint\ConstraintCheckRunner' )
+			->disableOriginalConstructor()
+			->getMock();
 
 		$this->schemafinder = $this->getMockBuilder( '\SMW\Schema\Schemafinder' )
 			->disableOriginalConstructor()
 			->getMock();
+
+		$store = $this->getMockBuilder( '\SMW\SQLStore\SQLStore' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$this->jobQueue = $this->getMockBuilder( '\SMW\MediaWiki\JobQueue' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$this->testEnvironment->registerObject( 'JobQueue', $this->jobQueue );
+		$this->testEnvironment->registerObject( 'Store', $store );
 	}
+
+	protected function tearDown() {
+		$this->testEnvironment->tearDown();
+		parent::tearDown();
+	}
+
 
 	public function testCanConstruct() {
 
 		$this->assertInstanceOf(
 			ConstraintSchemaValueValidator::class,
-			new ConstraintSchemaValueValidator( $this->schemafinder )
+			new ConstraintSchemaValueValidator( $this->constraintCheckRunner, $this->schemafinder )
 		);
 	}
 
 	public function testHasNoConstraintViolationOnNonRelatedValue() {
 
 		$instance = new ConstraintSchemaValueValidator(
+			$this->constraintCheckRunner,
 			$this->schemafinder
 		);
 
@@ -65,6 +92,7 @@ class ConstraintSchemaValueValidatorTest extends \PHPUnit_Framework_TestCase {
 		);
 
 		$instance = new ConstraintSchemaValueValidator(
+			$this->constraintCheckRunner,
 			$this->schemafinder
 		);
 
@@ -73,6 +101,114 @@ class ConstraintSchemaValueValidatorTest extends \PHPUnit_Framework_TestCase {
 		$this->assertFalse(
 			$instance->hasConstraintViolation()
 		);
+	}
+
+	public function testRunConstraintCheck() {
+
+		$property = $this->dataItemFactory->newDIProperty( 'Foo' );
+
+		$dataValue = $this->dataValueFactory->newDataValueByProperty(
+			$property
+		);
+
+		$dataValue->setContextPage(
+			$this->dataItemFactory->newDIWikiPage( 'Bar', NS_MAIN )
+		);
+
+		$schemaList = $this->getMockBuilder( '\SMW\Schema\SchemaList' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$this->schemafinder->expects( $this->once() )
+			->method( 'getConstraintSchema' )
+			->with( $this->equalTo( $property ) )
+			->will( $this->returnValue( $schemaList ) );
+
+		$this->constraintCheckRunner->expects( $this->once() )
+			->method( 'load' );
+
+		$this->constraintCheckRunner->expects( $this->once() )
+			->method( 'check' )
+			->with( $this->equalTo( $dataValue ) );
+
+		$this->constraintCheckRunner->expects( $this->once() )
+			->method( 'hasViolation' )
+			->will( $this->returnValue( false ) );
+
+		$instance = new ConstraintSchemaValueValidator(
+			$this->constraintCheckRunner,
+			$this->schemafinder
+		);
+
+		$instance->validate( $dataValue );
+
+		$this->assertFalse(
+			$instance->hasConstraintViolation()
+		);
+	}
+
+	public function testRunConstraintCheckTriggerDeferredConstraintCheckUpdateJob() {
+
+		$subject = $this->dataItemFactory->newDIWikiPage( 'Bar', NS_MAIN );
+		$property = $this->dataItemFactory->newDIProperty( 'Foo' );
+
+		$dataValue = $this->dataValueFactory->newDataValueByProperty(
+			$property
+		);
+
+		$dataValue->setContextPage(
+			$subject
+		);
+
+		$schemaList = $this->getMockBuilder( '\SMW\Schema\SchemaList' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$this->schemafinder->expects( $this->once() )
+			->method( 'getConstraintSchema' )
+			->with( $this->equalTo( $property ) )
+			->will( $this->returnValue( $schemaList ) );
+
+		$this->constraintCheckRunner->expects( $this->once() )
+			->method( 'load' );
+
+		$this->constraintCheckRunner->expects( $this->once() )
+			->method( 'check' )
+			->with( $this->equalTo( $dataValue ) );
+
+		$this->constraintCheckRunner->expects( $this->once() )
+			->method( 'hasViolation' )
+			->will( $this->returnValue( false ) );
+
+		$this->constraintCheckRunner->expects( $this->once() )
+			->method( 'hasDeferrableConstraint' )
+			->will( $this->returnValue( true ) );
+
+		$this->jobQueue->expects( $this->once() )
+			->method( 'push' )
+			->with( $this->callback( [ $this, 'checkPushedJobInstance' ] ) );
+
+		$instance = new ConstraintSchemaValueValidator(
+			$this->constraintCheckRunner,
+			$this->schemafinder
+		);
+
+		$instance->validate( $dataValue );
+
+		$this->assertFalse(
+			$instance->hasConstraintViolation()
+		);
+	}
+
+	public function checkPushedJobInstance( array $jobs ) {
+
+		foreach ( $jobs as $job ) {
+			if ( is_a( $job, '\SMW\MediaWiki\Jobs\DeferredConstraintCheckUpdateJob' ) ) {
+				return true;
+			}
+		}
+
+		return false;
 	}
 
 }

--- a/tests/phpunit/Unit/MediaWiki/Jobs/DeferredConstraintCheckUpdateJobTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Jobs/DeferredConstraintCheckUpdateJobTest.php
@@ -1,0 +1,94 @@
+<?php
+
+namespace SMW\Tests\MediaWiki\Jobs;
+
+use SMW\DIWikiPage;
+use SMW\MediaWiki\Jobs\DeferredConstraintCheckUpdateJob;
+use SMW\Tests\TestEnvironment;
+
+/**
+ * @covers \SMW\MediaWiki\Jobs\DeferredConstraintCheckUpdateJob
+ * @group semantic-mediawiki
+ *
+ * @license GNU GPL v2+
+ * @since 3.0
+ *
+ * @author mwjames
+ */
+class DeferredConstraintCheckUpdateJobTest extends \PHPUnit_Framework_TestCase {
+
+	private $testEnvironment;
+	private $jobQueue;
+
+	protected function setUp() {
+		parent::setUp();
+
+		$this->testEnvironment = new TestEnvironment();
+
+		$store = $this->getMockBuilder( '\SMW\SQLStore\SQLStore' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$this->jobQueue = $this->getMockBuilder( '\SMW\MediaWiki\JobQueue' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$this->testEnvironment->registerObject( 'JobQueue', $this->jobQueue );
+		$this->testEnvironment->registerObject( 'Store', $store );
+	}
+
+	protected function tearDown() {
+		$this->testEnvironment->tearDown();
+		parent::tearDown();
+	}
+
+	public function testCanConstruct() {
+
+		$title = $this->getMockBuilder( 'Title' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$this->assertInstanceOf(
+			DeferredConstraintCheckUpdateJob::class,
+			new DeferredConstraintCheckUpdateJob( $title )
+		);
+	}
+
+	public function testPushJob() {
+
+		$subject = DIWikiPage::newFromText( 'Foo' );
+
+		$this->jobQueue->expects( $this->once() )
+			->method( 'push' );
+
+		DeferredConstraintCheckUpdateJob::pushJob(
+			$subject->getTitle()
+		);
+	}
+
+	/**
+	 * @dataProvider jobProvider
+	 */
+	public function testRun( $subject, $parameters ) {
+
+		$instance = new DeferredConstraintCheckUpdateJob(
+			$subject->getTitle(),
+			$parameters
+		);
+
+		$this->assertTrue(
+			$instance->run()
+		);
+	}
+
+	public function jobProvider() {
+
+		$provider[] = [
+			DIWikiPage::newFromText( __METHOD__ ),
+			[]
+		];
+
+		return $provider;
+	}
+
+}

--- a/tests/phpunit/Unit/Property/Constraint/ConstraintCheckRunnerTest.php
+++ b/tests/phpunit/Unit/Property/Constraint/ConstraintCheckRunnerTest.php
@@ -1,0 +1,128 @@
+<?php
+
+namespace SMW\Tests\Property\Constraint;
+
+use SMW\Property\Constraint\ConstraintCheckRunner;
+use SMW\Property\Constraint\Constraint;
+use SMW\Schema\SchemaDefinition;
+use SMW\Tests\TestEnvironment;
+
+/**
+ * @covers \SMW\Property\Constraint\ConstraintCheckRunner
+ * @group semantic-mediawiki
+ *
+ * @license GNU GPL v2+
+ * @since 3.1
+ *
+ * @author mwjames
+ */
+class ConstraintCheckRunnerTest extends \PHPUnit_Framework_TestCase {
+
+	private $constraintRegistry;
+
+	protected function setUp() {
+
+		$this->constraintRegistry = $this->getMockBuilder( '\SMW\Property\Constraint\ConstraintRegistry' )
+			->disableOriginalConstructor()
+			->getMock();
+	}
+
+	public function testCanConstruct() {
+
+		$this->assertInstanceOf(
+			ConstraintCheckRunner::class,
+			new ConstraintCheckRunner( $this->constraintRegistry )
+		);
+	}
+
+	public function testCheck_Instance() {
+
+		$constraint = $this->getMockBuilder( '\SMW\Property\Constraint\Constraint' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$constraint->expects( $this->atLeastOnce() )
+			->method( 'isType' )
+			->with( $this->equalTo( Constraint::TYPE_DEFERRED ) )
+			->will( $this->returnValue( false ) );
+
+		$constraint->expects( $this->atLeastOnce() )
+			->method( 'checkConstraint' )
+			->with(
+				$this->equalTo( [ 'foo_bar' => [] ] ),
+			 	$this->equalTo( '__value__' ) )
+			->will( $this->returnValue( false ) );
+
+		$constraint->expects( $this->atLeastOnce() )
+			->method( 'hasViolation' )
+			->will( $this->returnValue( true ) );
+
+		$this->constraintRegistry->expects( $this->atLeastOnce() )
+			->method( 'getConstraintByKey' )
+			->with( $this->equalTo( 'foo_bar' ) )
+			->will( $this->returnValue( $constraint ) );
+
+		$instance = new ConstraintCheckRunner(
+			$this->constraintRegistry
+		);
+
+		$data = [
+			'constraints' => [
+				'foo_bar' => []
+			]
+		];
+
+		$this->assertFalse(
+			$instance->hasViolation()
+		);
+
+		$instance->load( '_FOO', new SchemaDefinition( 'test', $data ) );
+		$instance->check( '__value__' );
+
+		$this->assertTrue(
+			$instance->hasViolation()
+		);
+	}
+
+	public function testCheck_Deferred() {
+
+		$constraint = $this->getMockBuilder( '\SMW\Property\Constraint\Constraint' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$constraint->expects( $this->atLeastOnce() )
+			->method( 'isType' )
+			->with( $this->equalTo( Constraint::TYPE_DEFERRED ) )
+			->will( $this->returnValue( true ) );
+
+		$constraint->expects( $this->never() )
+			->method( 'checkConstraint' );
+
+		$this->constraintRegistry->expects( $this->atLeastOnce() )
+			->method( 'getConstraintByKey' )
+			->with( $this->equalTo( 'foo_bar' ) )
+			->will( $this->returnValue( $constraint ) );
+
+		$instance = new ConstraintCheckRunner(
+			$this->constraintRegistry
+		);
+
+		$data = [
+			'constraints' => [
+				'foo_bar' => []
+			]
+		];
+
+		$this->assertFalse(
+			$instance->hasDeferrableConstraint()
+		);
+
+		$instance->load( '_FOO', new SchemaDefinition( 'test', $data ) );
+		$instance->check( '__value__' );
+
+		$this->assertTrue(
+			$instance->hasDeferrableConstraint()
+		);
+	}
+
+}

--- a/tests/phpunit/Unit/Property/Constraint/ConstraintErrorTest.php
+++ b/tests/phpunit/Unit/Property/Constraint/ConstraintErrorTest.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace SMW\Tests\Property\Constraint;
+
+use SMW\Property\Constraint\ConstraintError;
+use SMW\Tests\TestEnvironment;
+
+/**
+ * @covers \SMW\Property\Constraint\ConstraintError
+ * @group semantic-mediawiki
+ *
+ * @license GNU GPL v2+
+ * @since 3.1
+ *
+ * @author mwjames
+ */
+class ConstraintErrorTest extends \PHPUnit_Framework_TestCase {
+
+	public function testCanConstruct() {
+
+		$this->assertInstanceOf(
+			ConstraintError::class,
+			new ConstraintError( 'Foo' )
+		);
+
+		$this->assertInstanceOf(
+			'\SMW\ProcessingError',
+			new ConstraintError( 'Foo' )
+		);
+	}
+
+	public function testGetType() {
+
+		$instance = new ConstraintError( 'Foo' );
+
+		$this->assertSame(
+			'constraint',
+			$instance->getType()
+		);
+	}
+
+	public function testGetHash() {
+
+		$instance = new ConstraintError( 'Foo' );
+
+		$this->assertSame(
+			'8da752ae5dbd5bc3ec4485dae8534271',
+			$instance->getHash()
+		);
+	}
+
+	public function testEncode() {
+
+		$instance = new ConstraintError( 'Foo' );
+
+		$this->assertSame(
+			'[2,"Foo"]',
+			$instance->encode()
+		);
+	}
+
+}

--- a/tests/phpunit/Unit/Property/Constraint/ConstraintRegistryTest.php
+++ b/tests/phpunit/Unit/Property/Constraint/ConstraintRegistryTest.php
@@ -1,0 +1,115 @@
+<?php
+
+namespace SMW\Tests\Property\Constraint;
+
+use SMW\Property\Constraint\ConstraintRegistry;
+use SMW\Tests\TestEnvironment;
+
+/**
+ * @covers \SMW\Property\Constraint\ConstraintRegistry
+ * @group semantic-mediawiki
+ *
+ * @license GNU GPL v2+
+ * @since 3.1
+ *
+ * @author mwjames
+ */
+class ConstraintRegistryTest extends \PHPUnit_Framework_TestCase {
+
+	private $constraintFactory;
+
+	protected function setUp() {
+
+		$this->constraintFactory = $this->getMockBuilder( '\SMW\Property\ConstraintFactory' )
+			->disableOriginalConstructor()
+			->getMock();
+	}
+
+	public function testCanConstruct() {
+
+		$this->assertInstanceOf(
+			ConstraintRegistry::class,
+			new ConstraintRegistry( $this->constraintFactory )
+		);
+	}
+
+	public function testGetConstraintByUnkownKey() {
+
+		$constraint = $this->getMockBuilder( '\SMW\Property\Constraint\Constraint' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$this->constraintFactory->expects( $this->atLeastOnce() )
+			->method( 'newConstraintByClass' )
+			->with( $this->equalTo( 'SMW\Property\Constraint\Constraints\NullConstraint' ) )
+			->will( $this->returnValue( $constraint ) );
+
+		$instance = new ConstraintRegistry(
+			$this->constraintFactory
+		);
+
+		$instance->getConstraintByKey( '__unknown__' );
+	}
+
+	public function testRegisterConstraintWithInstance() {
+
+		$constraint = $this->getMockBuilder( '\SMW\Property\Constraint\Constraint' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$instance = new ConstraintRegistry(
+			$this->constraintFactory
+		);
+
+		$instance->registerConstraint( 'foo', $constraint );
+
+		$this->assertInstanceOf(
+			'\SMW\Property\Constraint\Constraint',
+			$instance->getConstraintByKey( 'foo' )
+		);
+	}
+
+	public function testRegisterConstraintWithCallable() {
+
+		$constraint = $this->getMockBuilder( '\SMW\Property\Constraint\Constraint' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$instance = new ConstraintRegistry(
+			$this->constraintFactory
+		);
+
+		$instance->registerConstraint( 'foo', function() use( $constraint ) {
+			return $constraint; }
+		);
+
+		$this->assertInstanceOf(
+			'\SMW\Property\Constraint\Constraint',
+			$instance->getConstraintByKey( 'foo' )
+		);
+	}
+
+	public function testRegisterConstraintWithClassReference() {
+
+		$constraint = $this->getMockBuilder( '\SMW\Property\Constraint\Constraint' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$this->constraintFactory->expects( $this->atLeastOnce() )
+			->method( 'newConstraintByClass' )
+			->with( $this->equalTo( '__class__' ) )
+			->will( $this->returnValue( $constraint ) );
+
+		$instance = new ConstraintRegistry(
+			$this->constraintFactory
+		);
+
+		$instance->registerConstraint( 'foo', '__class__' );
+
+		$this->assertInstanceOf(
+			'\SMW\Property\Constraint\Constraint',
+			$instance->getConstraintByKey( 'foo' )
+		);
+	}
+
+}

--- a/tests/phpunit/Unit/Property/Constraint/Constraints/NullConstraintTest.php
+++ b/tests/phpunit/Unit/Property/Constraint/Constraints/NullConstraintTest.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace SMW\Tests\Property\Constraint\Constraints;
+
+use SMW\Property\Constraint\Constraints\NullConstraint;
+use SMW\Tests\TestEnvironment;
+
+/**
+ * @covers \SMW\Property\Constraint\Constraints\NullConstraint
+ * @group semantic-mediawiki
+ *
+ * @license GNU GPL v2+
+ * @since 3.1
+ *
+ * @author mwjames
+ */
+class NullConstraintTest extends \PHPUnit_Framework_TestCase {
+
+	public function testCanConstruct() {
+
+		$this->assertInstanceOf(
+			NullConstraint::class,
+			new NullConstraint()
+		);
+	}
+
+	public function testIsType() {
+
+		$instance = new NullConstraint();
+
+		$this->assertTrue(
+			$instance->isType( NullConstraint::TYPE_INSTANT )
+		);
+	}
+
+	public function testHasViolation() {
+
+		$instance = new NullConstraint();
+
+		$this->assertFalse(
+			$instance->hasViolation()
+		);
+	}
+
+}

--- a/tests/phpunit/Unit/Property/ConstraintFactoryTest.php
+++ b/tests/phpunit/Unit/Property/ConstraintFactoryTest.php
@@ -1,0 +1,84 @@
+<?php
+
+namespace SMW\Tests\Property;
+
+use SMW\Property\ConstraintFactory;
+use SMW\DataItemFactory;
+use SMW\Tests\TestEnvironment;
+
+/**
+ * @covers \SMW\Property\ConstraintFactory
+ * @group semantic-mediawiki
+ *
+ * @license GNU GPL v2+
+ * @since 3.1
+ *
+ * @author mwjames
+ */
+class ConstraintFactoryTest extends \PHPUnit_Framework_TestCase {
+
+	public function testCanConstruct() {
+
+		$this->assertInstanceOf(
+			ConstraintFactory::class,
+			new ConstraintFactory()
+		);
+	}
+
+	public function testCanConstructConstraintRegistry() {
+
+		$instance = new ConstraintFactory();
+
+		$this->assertInstanceOf(
+			'\SMW\Property\Constraint\ConstraintRegistry',
+			$instance->newConstraintRegistry()
+		);
+	}
+
+	public function testCanConstructConstraintCheckRunner() {
+
+		$instance = new ConstraintFactory();
+
+		$this->assertInstanceOf(
+			'\SMW\Property\Constraint\ConstraintCheckRunner',
+			$instance->newConstraintCheckRunner()
+		);
+	}
+
+	public function testCanConstructNullConstraint() {
+
+		$instance = new ConstraintFactory();
+
+		$this->assertInstanceOf(
+			'\SMW\Property\Constraint\Constraints\NullConstraint',
+			$instance->newNullConstraint()
+		);
+	}
+
+	/**
+	 * @dataProvider constraintByClass
+	 */
+	public function testCanConstructConstraintByClass( $class, $expected ) {
+
+		$instance = new ConstraintFactory();
+
+		$this->assertInstanceOf(
+			'\SMW\Property\Constraint\Constraint',
+			$instance->newConstraintByClass( $class )
+		);
+
+		$this->assertInstanceOf(
+			$expected,
+			$instance->newConstraintByClass( $class )
+		);
+	}
+
+	public function constraintByClass() {
+
+		yield[
+			'null',
+			'\SMW\Property\Constraint\Constraints\NullConstraint'
+		];
+	}
+
+}

--- a/tests/phpunit/Unit/Services/DataValueServicesContainerBuildTest.php
+++ b/tests/phpunit/Unit/Services/DataValueServicesContainerBuildTest.php
@@ -67,6 +67,11 @@ class DataValueServicesContainerBuildTest extends \PHPUnit_Framework_TestCase {
 			->setMethods( null )
 			->getMock();
 
+		$this->constraintFactory = $this->getMockBuilder( '\SMW\Property\ConstraintFactory' )
+			->disableOriginalConstructor()
+			->setMethods( null )
+			->getMock();
+
 		$this->callbackContainerFactory = new CallbackContainerFactory();
 		$this->servicesFileDir = $GLOBALS['smwgServicesFileDir'];
 	}
@@ -89,6 +94,7 @@ class DataValueServicesContainerBuildTest extends \PHPUnit_Framework_TestCase {
 		$containerBuilder->registerObject( 'Store', $this->store );
 		$containerBuilder->registerObject( 'MediaWikiLogger', $this->logger );
 		$containerBuilder->registerObject( 'SchemaFactory', $this->schemaFactory  );
+		$containerBuilder->registerObject( 'ConstraintFactory', $this->constraintFactory  );
 
 		$containerBuilder->registerFromFile( $this->servicesFileDir . '/' . 'DataValueServices.php' );
 


### PR DESCRIPTION
This PR is made in reference to: #3746

This PR addresses or contains:

- Adds the `Constraint` interface and `ConstraintCheckRunner`, refs 3746
- This PR doesn't implement any specific constraints, it only provides the interface and infrastructure to execute constraint checks using the newly introduced `Constraint` interface
- The validation flow is defined as:
  - When for property X a value Y is assigned and
  - Property X defines a (or has different) `Constraint schema` (#3829) then
  - `ConstraintSchemaValueValidator` will check the value against registered constraints by having
    - `SchemaFinder` to return a list of schemata that are assigned to the property X after that
    - `ConstraintCheckRunner` will load those selected schemata and for each constraint match a `Constraint` class with the help of the `ConstraintRegistry`
   - Each `Constraint` class will validate the property/value and if necessary raise a `hasViolation` together with a `ConstraintError`
   - As soon as a constraint detects a violation, the processing will stop
- #3805 logs the time on the overall processing effort for the constraint validation
- `ConstraintError` implements the `ProcessingError` (#3792), so specific errors that belong to the `constraint` category can be filtered and are distinguishable from other errors
- A `Constraint` can return a `TYPE_INSTANT` or `TYPE_DEFERRED` as type and in case of `TYPE_DEFERRED` to processing is deferred using the `DeferredConstraintCheckUpdateJob`

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed
