### PR TITLE
Track eTag from parser cache, refs 3644

### DIFF
--- a/src/EntityCache.php
+++ b/src/EntityCache.php
@@ -70,6 +70,17 @@ class EntityCache {
 	 * @since 3.1
 	 *
 	 * @param string $key
+	 *
+	 * @return boolean
+	 */
+	public function contains( $key ) {
+		return $this->cache->contains( $key );
+	}
+
+	/**
+	 * @since 3.1
+	 *
+	 * @param string $key
 	 * @param mixed $value
 	 */
 	public function fetch( $key ) {
@@ -92,7 +103,7 @@ class EntityCache {
 	 * @param string $key
 	 */
 	public function delete( $key ) {
-		 $this->cache->delete( $key );
+		$this->cache->delete( $key );
 	}
 
 	/**
@@ -131,6 +142,23 @@ class EntityCache {
 		}
 
 		$res[$sub] = $value;
+
+		$this->cache->save( $key, $res, $ttl );
+	}
+
+	/**
+	 * @since 3.1
+	 *
+	 * @param string $key
+	 * @param string $sub
+	 * @param mixed $value
+	 * @param integer $ttl
+	 */
+	public function overrideSub( $key, $sub, $value = null, $ttl = 0 ) {
+
+		$res = [
+			md5( $sub ) => $value
+		];
 
 		$this->cache->save( $key, $res, $ttl );
 	}

--- a/src/MediaWiki/Hooks.php
+++ b/src/MediaWiki/Hooks.php
@@ -597,17 +597,30 @@ class Hooks {
 		$queryDependencyLinksStoreFactory = $applicationFactory->singleton( 'QueryDependencyLinksStoreFactory' );
 
 		$rejectParserCacheValue = new RejectParserCacheValue(
-			$queryDependencyLinksStoreFactory->newDependencyLinksValidator()
+			$queryDependencyLinksStoreFactory->newDependencyLinksValidator(),
+			$applicationFactory->getEntityCache()
 		);
 
 		$rejectParserCacheValue->setEventDispatcher(
 			$applicationFactory->getEventDispatcher()
 		);
 
+		$rejectParserCacheValue->setLogger(
+			$applicationFactory->getMediaWikiLogger()
+		);
+
+		$rejectParserCacheValue->setCacheTTL(
+			Site::getCacheExpireTime( 'parser' )
+		);
+
+		// Get the key to distinguish between an anon and logged-in user stored
+		// parser cache
+		$eTag = \ParserCache::singleton()->getETag( $wikiPage, $popts );
+
 		// Return false to reject the parser cache
 		// The log will contain something like "[ParserCache] ParserOutput
 		// key valid, but rejected by RejectParserCacheValue hook handler."
-		return $rejectParserCacheValue->process( $wikiPage->getTitle() );
+		return $rejectParserCacheValue->process( $wikiPage->getTitle(), $eTag );
 	}
 
 	/**

--- a/src/MediaWiki/Hooks/RejectParserCacheValue.php
+++ b/src/MediaWiki/Hooks/RejectParserCacheValue.php
@@ -5,6 +5,7 @@ namespace SMW\MediaWiki\Hooks;
 use SMW\SQLStore\QueryDependency\DependencyLinksValidator;
 use Onoi\EventDispatcher\EventDispatcherAwareTrait;
 use SMW\DIWikiPage;
+use SMW\EntityCache;
 use Title;
 
 /**
@@ -25,27 +26,63 @@ class RejectParserCacheValue extends HookHandler {
 	private $dependencyLinksValidator;
 
 	/**
+	 * @var EntityCache
+	 */
+	private $entityCache;
+
+	/**
+	 * @var integer
+	 */
+	private $cacheTTL = 3600;
+
+	/**
 	 * @since 3.0
 	 *
 	 * @param DependencyLinksValidator $dependencyLinksValidator
+	 * @param EntityCache $entityCache
 	 */
-	public function __construct( DependencyLinksValidator $dependencyLinksValidator ) {
+	public function __construct( DependencyLinksValidator $dependencyLinksValidator, EntityCache $entityCache ) {
 		$this->dependencyLinksValidator = $dependencyLinksValidator;
+		$this->entityCache = $entityCache;
+	}
+
+	/**
+	 * @since 2.2
+	 *
+	 * @param integer $cacheTTL
+	 */
+	public function setCacheTTL( $cacheTTL ) {
+		$this->cacheTTL = $cacheTTL;
+	}
+
+	/**
+	 * @since 2.2
+	 *
+	 * @return integer
+	 */
+	public static function makeCacheKey( Title $title ) {
+		return EntityCache::makeCacheKey( 'rejectparsercachevalue', $title->getPrefixedDBKey() );
 	}
 
 	/**
 	 * @since 3.0
 	 *
 	 * @param Title $title
+	 * @param string $eTag
 	 *
 	 * @return boolean
 	 */
-	public function process( Title $title ) {
+	public function process( Title $title, $eTag ) {
+
+		if ( $this->dependencyLinksValidator->canCheckDependencies() === false ) {
+			return true;
+		}
 
 		$subject = DIWikiPage::newFromTitle( $title );
+		$cacheKey = $this->makeCacheKey( $title );
 
 		if ( $this->dependencyLinksValidator->hasArchaicDependencies( $subject ) === false ) {
-			return true;
+			return $this->canKeepParserCache( $cacheKey, $eTag );
 		}
 
 		$context = [
@@ -56,8 +93,41 @@ class RejectParserCacheValue extends HookHandler {
 
 		$this->eventDispatcher->dispatch( 'InvalidateResultCache', $context );
 
+		// The parser cache is rejected, store for which key the request has
+		// happened since the `smw_touched` is only updated once and given that
+		// an anon/logged-in user create a different eTag (ParserCache) key
+		// hereby allows us to distinguish them later
+
+		// Genuine rejection based on `hasArchaicDependencies` therefore override
+		// any previous sub keys
+		$this->entityCache->overrideSub( $cacheKey, $eTag, 'hasArchaicDependencies', $this->cacheTTL );
+
+		$this->logger->info(
+			[ 'RejectParserCacheValue', 'Rejected, found archaic query dependencies', '{etag}' ],
+			[ 'role' => 'user', 'etag' => $eTag ]
+		);
+
 		// Return false to reject an otherwise usable cached value from the
 		// parser cache
+		return false;
+	}
+
+	private function canKeepParserCache( $cacheKey, $eTag ) {
+
+		// Test for a recent rejection, being unrelated etc.
+		if (
+			$this->entityCache->contains( $cacheKey ) === false ||
+			$this->entityCache->fetchSub( $cacheKey, $eTag ) ) {
+			return true;
+		}
+
+		$this->logger->info(
+			[ 'RejectParserCacheValue', 'Rejected, found different key: {etag}' ],
+			['role' => 'user', 'etag' => $eTag ]
+		);
+
+		$this->entityCache->saveSub( $cacheKey, $eTag, 'hasArchaicDependencies', $this->cacheTTL );
+
 		return false;
 	}
 

--- a/src/SQLStore/QueryDependency/DependencyLinksValidator.php
+++ b/src/SQLStore/QueryDependency/DependencyLinksValidator.php
@@ -47,8 +47,17 @@ class DependencyLinksValidator {
 	 *
 	 * @param boolean $checkDependencies
 	 */
-	public function canCheckDependencies( $checkDependencies ) {
+	public function setCheckDependencies( $checkDependencies ) {
 		$this->checkDependencies = (bool)$checkDependencies;
+	}
+
+	/**
+	 * @since 3.1
+	 *
+	 * @return boolean
+	 */
+	public function canCheckDependencies() {
+		return $this->checkDependencies;
 	}
 
 	/**

--- a/src/SQLStore/QueryDependencyLinksStoreFactory.php
+++ b/src/SQLStore/QueryDependencyLinksStoreFactory.php
@@ -37,7 +37,7 @@ class QueryDependencyLinksStoreFactory {
 			$applicationFactory->getStore()
 		);
 
-		$dependencyLinksValidator->canCheckDependencies(
+		$dependencyLinksValidator->setCheckDependencies(
 			$applicationFactory->getSettings()->get( 'smwgEnabledQueryDependencyLinksStore' )
 		);
 

--- a/src/Site.php
+++ b/src/Site.php
@@ -93,6 +93,20 @@ class Site {
 	}
 
 	/**
+	 * @since 3.1
+	 *
+	 * @return int
+	 */
+	public static function getCacheExpireTime( $key ) {
+
+		if ( $key === 'parser' ) {
+			return $GLOBALS['wgParserCacheExpireTime'];
+		}
+
+		return 0;
+	}
+
+	/**
 	 * @since 3.0
 	 *
 	 * @param $affix string

--- a/tests/phpunit/Unit/EntityCacheTest.php
+++ b/tests/phpunit/Unit/EntityCacheTest.php
@@ -57,6 +57,19 @@ class EntityCacheTest extends \PHPUnit_Framework_TestCase {
 		);
 	}
 
+	public function testContains() {
+
+		$this->cache->expects( $this->once() )
+			->method( 'contains' )
+			->with( $this->equalTo( 'Foo' ) );
+
+		$instance = new EntityCache(
+			$this->cache
+		);
+
+		$instance->contains( 'Foo' );
+	}
+
 	public function testFetch() {
 
 		$this->cache->expects( $this->once() )
@@ -134,6 +147,21 @@ class EntityCacheTest extends \PHPUnit_Framework_TestCase {
 		);
 
 		$instance->saveSub( 'Foo', 'bar', '123' );
+	}
+
+	public function tesOverrideSub() {
+
+		$this->cache->expects( $this->once() )
+			->method( 'save' )
+			->with(
+				$this->equalTo( 'Foo' ),
+				$this->equalTo( [ md5( 'bar' ) => '123' ] ) );
+
+		$instance = new EntityCache(
+			$this->cache
+		);
+
+		$instance->overrideSub( 'Foo', 'bar', '123' );
 	}
 
 	public function tesDeleteSub() {

--- a/tests/phpunit/Unit/MediaWiki/Hooks/RejectParserCacheValueTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Hooks/RejectParserCacheValueTest.php
@@ -19,6 +19,8 @@ class RejectParserCacheValueTest extends \PHPUnit_Framework_TestCase {
 
 	private $testEnvironment;
 	private $dependencyLinksValidator;
+	private $entityCache;
+	private $logger;
 
 	protected function setUp() {
 		parent::setUp();
@@ -26,6 +28,14 @@ class RejectParserCacheValueTest extends \PHPUnit_Framework_TestCase {
 		$this->testEnvironment = new TestEnvironment();
 
 		$this->dependencyLinksValidator = $this->getMockBuilder( '\SMW\SQLStore\QueryDependency\DependencyLinksValidator' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$this->entityCache = $this->getMockBuilder( '\SMW\EntityCache' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$this->logger = $this->getMockBuilder( '\Psr\Log\LoggerInterface' )
 			->disableOriginalConstructor()
 			->getMock();
 	}
@@ -39,11 +49,17 @@ class RejectParserCacheValueTest extends \PHPUnit_Framework_TestCase {
 
 		$this->assertInstanceOf(
 			RejectParserCacheValue::class,
-			new RejectParserCacheValue( $this->dependencyLinksValidator )
+			new RejectParserCacheValue( $this->dependencyLinksValidator, $this->entityCache )
 		);
 	}
 
 	public function testProcessOnArchaicDependencies_RejectParserCacheValue() {
+
+		$this->entityCache->expects( $this->once() )
+			->method( 'overrideSub' )
+			->with(
+				$this->stringContains( 'smw:entity:316ab10349fcb05c07001bdeb1a490c4' ),
+				$this->stringContains( 'foo-etag' ) );
 
 		$eventDispatcher = $this->getMockBuilder( '\Onoi\EventDispatcher\EventDispatcher' )
 			->disableOriginalConstructor()
@@ -53,7 +69,7 @@ class RejectParserCacheValueTest extends \PHPUnit_Framework_TestCase {
 			->method( 'dispatch' )
 			->with( $this->equalTo( 'InvalidateResultCache' ) );
 
-		$subject = DIWikiPage::newFromText( __METHOD__ );
+		$subject = DIWikiPage::newFromText( 'Foo' );
 
 		$this->dependencyLinksValidator->expects( $this->once() )
 			->method( 'hasArchaicDependencies' )
@@ -65,15 +81,110 @@ class RejectParserCacheValueTest extends \PHPUnit_Framework_TestCase {
 			->will( $this->returnValue( [] ) );
 
 		$instance = new RejectParserCacheValue(
-			$this->dependencyLinksValidator
+			$this->dependencyLinksValidator,
+			$this->entityCache
 		);
 
 		$instance->setEventDispatcher(
 			$eventDispatcher
 		);
 
+		$instance->setLogger(
+			$this->logger
+		);
+
 		$this->assertFalse(
-			$instance->process( $subject->getTitle() )
+			$instance->process( $subject->getTitle(), 'foo-etag' )
+		);
+	}
+
+	public function testProcessOnArchaicDependencies_RejectParserCacheValueOnDifferentEtag() {
+
+		$this->entityCache->expects( $this->once() )
+			->method( 'contains' )
+			->will( $this->returnValue( true ) );
+
+		$this->entityCache->expects( $this->once() )
+			->method( 'fetchSub' )
+			->with( $this->stringContains( 'smw:entity:316ab10349fcb05c07001bdeb1a490c4' ) )
+			->will( $this->returnValue( false ) );
+
+		$this->entityCache->expects( $this->once() )
+			->method( 'saveSub' )
+			->with(
+				$this->stringContains( 'smw:entity:316ab10349fcb05c07001bdeb1a490c4' ),
+				$this->stringContains( 'foo-etag-2' ) );
+
+		$subject = DIWikiPage::newFromText( 'Foo' );
+
+		$this->dependencyLinksValidator->expects( $this->once() )
+			->method( 'hasArchaicDependencies' )
+			->with( $this->equalTo( $subject ) )
+			->will( $this->returnValue( false ) );
+
+		$instance = new RejectParserCacheValue(
+			$this->dependencyLinksValidator,
+			$this->entityCache
+		);
+
+		$instance->setLogger(
+			$this->logger
+		);
+
+		$this->assertFalse(
+			$instance->process( $subject->getTitle(), 'foo-etag-2' )
+		);
+	}
+
+	public function testProcessOnArchaicDependencies_KeepParserCacheValueOnUnknownDependency() {
+
+		$this->entityCache->expects( $this->once() )
+			->method( 'contains' )
+			->will( $this->returnValue( false ) );
+
+		$this->entityCache->expects( $this->never() )
+			->method( 'fetchSub' );
+
+		$subject = DIWikiPage::newFromText( 'Foo' );
+
+		$this->dependencyLinksValidator->expects( $this->once() )
+			->method( 'hasArchaicDependencies' )
+			->with( $this->equalTo( $subject ) )
+			->will( $this->returnValue( false ) );
+
+		$instance = new RejectParserCacheValue(
+			$this->dependencyLinksValidator,
+			$this->entityCache
+		);
+
+		$instance->setLogger(
+			$this->logger
+		);
+
+		$this->assertTrue(
+			$instance->process( $subject->getTitle(), 'foo-etag-2' )
+		);
+	}
+
+	public function testProcessOnDisabledDependenciesCheck() {
+
+		$subject = DIWikiPage::newFromText( 'Foo' );
+
+		$this->dependencyLinksValidator->expects( $this->once() )
+			->method( 'canCheckDependencies' )
+			->will( $this->returnValue( false ) );
+
+		$instance = new RejectParserCacheValue(
+			$this->dependencyLinksValidator,
+			$this->entityCache
+		);
+
+		$instance->setLogger(
+			$this->logger
+		);
+
+		$this->assertTrue(
+			$instance->process( $subject->getTitle(), 'foo-etag-2' )
 		);
 	}
 

--- a/tests/phpunit/Unit/MediaWiki/HooksTest.php
+++ b/tests/phpunit/Unit/MediaWiki/HooksTest.php
@@ -1307,6 +1307,10 @@ class HooksTest extends \PHPUnit_Framework_TestCase {
 
 		$handler = 'RejectParserCacheValue';
 
+		$parseOptions = $this->getMockBuilder( '\ParserOptions' )
+			->disableOriginalConstructor()
+			->getMock();
+
 		$propertyTableInfoFetcher = $this->getMockBuilder( '\SMW\SQLStore\PropertyTableInfoFetcher' )
 			->disableOriginalConstructor()
 			->getMock();
@@ -1339,11 +1343,10 @@ class HooksTest extends \PHPUnit_Framework_TestCase {
 		);
 
 		$value = '';
-		$popts = '';
 
 		$this->assertThatHookIsExcutable(
 			$instance->getHandlerFor( $handler ),
-			[ $value, $wikiPage, $popts ]
+			[ $value, $wikiPage, $parseOptions ]
 		);
 
 		return $handler;

--- a/tests/phpunit/Unit/SQLStore/QueryDependency/DependencyLinksValidatorTest.php
+++ b/tests/phpunit/Unit/SQLStore/QueryDependency/DependencyLinksValidatorTest.php
@@ -50,7 +50,11 @@ class DependencyLinksValidatorTest extends \PHPUnit_Framework_TestCase {
 			$this->store
 		);
 
-		$instance->canCheckDependencies( false );
+		$instance->setCheckDependencies( false );
+
+		$this->assertFalse(
+			$instance->canCheckDependencies()
+		);
 
 		$this->assertFalse(
 			$instance->hasArchaicDependencies( $subject )
@@ -101,7 +105,11 @@ class DependencyLinksValidatorTest extends \PHPUnit_Framework_TestCase {
 			$this->store
 		);
 
-		$instance->canCheckDependencies( true );
+		$instance->setCheckDependencies( true );
+
+		$this->assertTrue(
+			$instance->canCheckDependencies()
+		);
 
 		$this->assertTrue(
 			$instance->hasArchaicDependencies( $subject )

--- a/tests/phpunit/Unit/SiteTest.php
+++ b/tests/phpunit/Unit/SiteTest.php
@@ -71,6 +71,14 @@ class SiteTest extends \PHPUnit_Framework_TestCase {
 		);
 	}
 
+	public function testGetCacheExpireTime() {
+
+		$this->assertInternalType(
+			'integer',
+			Site::getCacheExpireTime( 'parser' )
+		);
+	}
+
 	public function testStats() {
 
 		$this->assertInternalType(


### PR DESCRIPTION
This PR is made in reference to: #3644

This PR addresses or contains:

- #3644 removed the need to rely on the job queue the invalidate outdated queries with the help of the `RejectParserCacheValue` event
- The issue is that the parser cache can hold different keys for the same page (hereby cache entries, different users, languages etc.) and the `DependencyLinksValidator` can only invalidate an outdated dependency once on the parser cache that is attached to the `RejectParserCacheValue` event but to ensure that we can evict other cache values for the same title (for example anon/logged-in users etc.) in context of a previous invalidation we need to keep track on the `etag` to distinguish between different requests
- A simple way to reproduce the issue is by having two browser windows open one with a logged-in user and one with an anon user
  - now both users look at the same page (contains a `#ask` query) and
  - the logged-in user will modify a different page to force the page with the query to become outdated,
  - after that the logged-in user will return to the page with the query and will see an updated page content due to that `DependencyLinksValidator` rejected the content and forced a re-parse (evicted the parser cache for this user and the page) but
  - the anon user who is looking at same the page with query (F5, no purging) will not see any altered content because the parser cache for the anon user is still active and the `DependencyLinksValidator` cannot reject this request because the data are already up-to date since the logged-in user forced a re-parse (but only for his request/session) therefore we need to keep track of each individual different etag (via the cache) so that we can infuse a rejection based on a previous invalidation notice.
- If we had a method to evict all keys for a page/parser cache then we wouldn't have to track those etags but I was unable to find a method that would allow to evict all keys without touching the `page_touched` field (which would create a circle).

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed
