### PR TITLE
Avoid normalizing predefined properties, refs 3779

### DIFF
--- a/src/DataValues/ValueParsers/PropertyValueParser.php
+++ b/src/DataValues/ValueParsers/PropertyValueParser.php
@@ -194,6 +194,11 @@ class PropertyValueParser implements ValueParser {
 			$text = Localizer::getInstance()->getContentLanguage()->ucfirst( $text );
 		}
 
+		// Leave predefined properties untouched!
+		if ( $text !== '' && $text[0] === '_' ) {
+			return $text;
+		}
+
 		// https://www.mediawiki.org/wiki/Manual:Page_title
 		// Titles beginning or ending with a space (underscore), or containing two
 		// or more consecutive spaces (underscores).

--- a/tests/phpunit/Unit/DataValues/ValueParsers/PropertyValueParserTest.php
+++ b/tests/phpunit/Unit/DataValues/ValueParsers/PropertyValueParserTest.php
@@ -95,10 +95,19 @@ class PropertyValueParserTest extends \PHPUnit_Framework_TestCase {
 			false
 		];
 
+		// User property
 		$provider[] = [
 			'Fo_o____bar',
 			[],
 			'Fo o bar',
+			false
+		];
+
+		// Predefined property
+		$provider[] = [
+			'_Fo_o____bar',
+			[],
+			'_Fo_o____bar',
 			false
 		];
 


### PR DESCRIPTION
This PR is made in reference to: #3779

This PR addresses or contains:

- #3779 broke [0] (SemanticCite) therefore we have to account for predefined properties to be left alone when applying the normalization

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed

[0] https://travis-ci.org/SemanticMediaWiki/SemanticCite/builds/504618265