### PR TITLE
Register subjects with `LinkBatch`, refs 3671

### DIFF
--- a/src/MediaWiki/LinkBatch.php
+++ b/src/MediaWiki/LinkBatch.php
@@ -17,6 +17,11 @@ use SMW\DIWikiPage;
 class LinkBatch {
 
 	/**
+	 * @var LinkBatch
+	 */
+	private static $instance;
+
+	/**
 	 * @var []
 	 */
 	private $log = [];
@@ -33,6 +38,27 @@ class LinkBatch {
 	 */
 	public function __construct( \LinkBatch $linkBatch = null ) {
 		$this->linkBatch = $linkBatch;
+	}
+
+	/**
+	 * @since 3.1
+	 *
+	 * @return LinkBatch
+	 */
+	public static function singleton() {
+
+		if ( self::$instance === null ) {
+			self::$instance = new self( new \LinkBatch() );
+		}
+
+		return self::$instance;
+	}
+
+	/**
+	 * @since 3.1
+	 */
+	public static function reset() {
+		self::$instance = null;
 	}
 
 	/**

--- a/src/SQLStore/EntityStore/PrefetchItemLookup.php
+++ b/src/SQLStore/EntityStore/PrefetchItemLookup.php
@@ -55,7 +55,7 @@ class PrefetchItemLookup {
 		// Help reduce the amount of queries by allowing to prefetch those
 		// links we know will be used for the display
 		if ( $this->linkBatch === null ) {
-			$this->linkBatch = new LinkBatch();
+			$this->linkBatch = LinkBatch::singleton();
 		}
 	}
 

--- a/src/SQLStore/EntityStore/StubSemanticData.php
+++ b/src/SQLStore/EntityStore/StubSemanticData.php
@@ -11,6 +11,7 @@ use SMW\SQLStore\SQLStore;
 use SMW\StoreFactory;
 use SMWDataItem as DataItem;
 use SMWSemanticData as SemanticData;
+use SMW\MediaWiki\LinkBatch;
 
 /**
  * This class provides a subclass of SemanticData that can store prefetched values
@@ -174,6 +175,14 @@ class StubSemanticData extends SemanticData {
 			}
 
 			unset( $this->mStubPropVals[$property->getKey()] );
+			$linkBatch = LinkBatch::singleton();
+
+			if ( $propertyDiId === DataItem::TYPE_WIKIPAGE ) {
+				$linkBatch->addFromList( $this->mPropVals[$property->getKey()] );
+			}
+
+			$linkBatch->add( $property->getDIWikiPage() );
+			$linkBatch->execute();
 		}
 
 		return parent::getPropertyValues( $property );
@@ -308,6 +317,7 @@ class StubSemanticData extends SemanticData {
 	 */
 	public function clear() {
 		$this->mStubPropVals = [];
+		LinkBatch::reset();
 		parent::clear();
 	}
 

--- a/tests/phpunit/Unit/MediaWiki/LinkBatchTest.php
+++ b/tests/phpunit/Unit/MediaWiki/LinkBatchTest.php
@@ -24,6 +24,18 @@ class LinkBatchTest extends \PHPUnit_Framework_TestCase {
 		);
 	}
 
+	public function testCanConstructSingleton() {
+
+		$instance = LinkBatch::singleton();
+
+		$this->assertSame(
+			$instance,
+			LinkBatch::singleton()
+		);
+
+		$instance->reset();
+	}
+
 	public function testAdd_NoPage() {
 
 		$instance = new LinkBatch();


### PR DESCRIPTION
This PR is made in reference to: #3671

This PR addresses or contains:

- Batch more links when resolving values in `StubSemanticData` of type `DataItem::TYPE_WIKIPAGE`

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed
