### PR TITLE
[ES] Check for predefined property, refs 3697

### DIFF
--- a/src/Elastic/Indexer/IndicatorProvider.php
+++ b/src/Elastic/Indexer/IndicatorProvider.php
@@ -3,6 +3,7 @@
 namespace SMW\Elastic\Indexer;
 
 use SMW\DIWikiPage;
+use SMW\DIProperty;
 use SMW\Store;
 use SMW\Message;
 use SMW\MediaWiki\IndicatorProvider as IIndicatorProvider;
@@ -114,6 +115,14 @@ class IndicatorProvider implements IIndicatorProvider {
 		$subject = DIWikiPage::newFromTitle(
 			$title
 		);
+
+		if ( $subject->getNamespace() === SMW_NS_PROPERTY ) {
+			$property = DIProperty::newFromUserLabel( $subject->getDBKey() );
+
+			if ( !$property->isUserDefined() ) {
+				$subject = new DIWikiPage( $property->getKey(), SMW_NS_PROPERTY );
+			}
+		}
 
 		if ( $this->entityCache->fetch( CheckReplicationTask::makeCacheKey( $subject ) ) === 'success' ) {
 			return;

--- a/tests/phpunit/Unit/Elastic/Indexer/IndicatorProviderTest.php
+++ b/tests/phpunit/Unit/Elastic/Indexer/IndicatorProviderTest.php
@@ -100,9 +100,63 @@ class IndicatorProviderTest extends \PHPUnit_Framework_TestCase {
 			$instance->hasIndicator( $title, $options )
 		);
 
+		$res = $instance->getIndicators();
+
 		$this->assertArrayHasKey(
 			'smw-es-replication',
-			$instance->getIndicators()
+			$res
+		);
+
+		$this->assertContains(
+			'data-subject="Foo#0##"',
+			$res['smw-es-replication']
+		);
+	}
+
+	public function testCheckReplicationIndicatorForPredefinedProperty() {
+
+		$title = $this->getMockBuilder( '\Title' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$title->expects( $this->once() )
+			->method( 'exists' )
+			->will( $this->returnValue( true ) );
+
+		$title->expects( $this->once() )
+			->method( 'getDBKey' )
+			->will( $this->returnValue( 'Modification date' ) );
+
+		$title->expects( $this->once() )
+			->method( 'getNamespace' )
+			->will( $this->returnValue( SMW_NS_PROPERTY ) );
+
+		$instance = new IndicatorProvider(
+			$this->store,
+			$this->entityCache
+		);
+
+		$instance->canCheckReplication( true );
+
+		$options = [
+			'action' => 'foo',
+			'diff' => null
+		];
+
+		$this->assertTrue(
+			$instance->hasIndicator( $title, $options )
+		);
+
+		$res = $instance->getIndicators();
+
+		$this->assertArrayHasKey(
+			'smw-es-replication',
+			$res
+		);
+
+		$this->assertContains(
+			'data-subject="_MDAT#102##"',
+			$res['smw-es-replication']
 		);
 	}
 


### PR DESCRIPTION
This PR is made in reference to: #3697

This PR addresses or contains:

- `CheckReplicationTask` to use the predefined property title when checking the replication status

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed
