### PR TITLE
[CI] Add CleanUpTables, refs 3460

### DIFF
--- a/src/MediaWiki/Connection/CleanUpTables.php
+++ b/src/MediaWiki/Connection/CleanUpTables.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace SMW\MediaWiki\Connection;
+
+use RuntimeException;
+
+/**
+ * @private
+ *
+ * @license GNU GPL v2+
+ * @since 3.1
+ *
+ * @author mwjames
+ */
+class CleanUpTables {
+
+	/**
+	 * @var Database
+	 */
+	private $connection;
+
+	/**
+	 * @since 3.1
+	 */
+	public function __construct( $connection ) {
+
+		if ( !$connection instanceof Database && !$connection instanceof \DatabaseBase ) {
+			throw new RuntimeException( "Invalid connection instance!" );
+		}
+
+		$this->connection = $connection;
+	}
+
+	/**
+	 * @since 3.1
+	 *
+	 * @param string $tablePrefix
+	 */
+	public function dropTables( $tablePrefix ) {
+
+		$tables = $this->connection->listTables();
+
+		foreach ( $tables as $table ) {
+			if ( strpos( $table, $tablePrefix ) !== false ) {
+				if ( $this->connection->getType() === 'postgres' ) {
+					$this->connection->query( "DROP TABLE IF EXISTS $table CASCADE", __METHOD__ );
+				} else {
+					$this->connection->query( "DROP TABLE $table", __METHOD__ );
+				}
+			}
+		}
+	}
+
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,6 +1,7 @@
 <?php
 
 use SMW\MediaWiki\Connection\Sequence;
+use SMW\MediaWiki\Connection\CleanUpTables;
 use SMW\ApplicationFactory;
 use SMW\SQLStore\SQLStore;
 
@@ -37,11 +38,19 @@ register_shutdown_function( function() {
 		return;
 	}
 
+	$connectionManager = ApplicationFactory::getInstance()->getConnectionManager();
+
 	// Reset any sequence modified during the test
 	$sequence = new Sequence(
-		ApplicationFactory::getInstance()->getConnectionManager()->getConnection( 'mw.db' )
+		$connectionManager->getConnection( 'mw.db' )
 	);
 
 	$sequence->tablePrefix( '' );
 	$sequence->restart( SQLStore::ID_TABLE, 'smw_id' );
+
+	$cleanUpTables =  new CleanUpTables(
+		$connectionManager->getConnection( DB_MASTER )
+	);
+
+	$cleanUpTables->dropTables( 'sunittest_' );
 } );

--- a/tests/phpunit/Unit/MediaWiki/Connection/CleanUpTablesTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Connection/CleanUpTablesTest.php
@@ -1,0 +1,90 @@
+<?php
+
+namespace SMW\Tests\MediaWiki\Connection;
+
+use SMW\MediaWiki\Connection\CleanUpTables;
+use SMW\Tests\PHPUnitCompat;
+
+/**
+ * @covers \SMW\MediaWiki\Connection\CleanUpTables
+ * @group semantic-mediawiki
+ *
+ * @license GNU GPL v2+
+ * @since 3.1
+ *
+ * @author mwjames
+ */
+class CleanUpTablesTest extends \PHPUnit_Framework_TestCase {
+
+	use PHPUnitCompat;
+
+	private $connection;
+
+	protected function setUp() {
+
+		$this->connection = $this->getMockBuilder( '\SMW\MediaWiki\Database' )
+			->disableOriginalConstructor()
+			->getMock();
+	}
+
+	public function testCanConstruct() {
+		$this->assertInstanceOf(
+			CleanUpTables::class,
+			new CleanUpTables( $this->connection )
+		);
+	}
+
+	public function testConstructWithInvalidConnectionThrowsException() {
+		$this->setExpectedException( '\RuntimeException' );
+		new CleanUpTables( 'Foo' );
+	}
+
+	public function testNonPostgres() {
+
+		$connection = $this->getMockBuilder( '\DatabaseBase' )
+			->disableOriginalConstructor()
+			->setMethods( [ 'listTables', 'query' ] )
+			->getMockForAbstractClass();
+
+		$connection->expects( $this->atLeastOnce() )
+			->method( 'listTables' )
+			->will( $this->returnValue( [ 'abcsmw_foo' ] ) );
+
+		$connection->expects( $this->atLeastOnce() )
+			->method( 'query' )
+			->with( $this->equalTo( 'DROP TABLE abcsmw_foo' ) );
+
+		$instance = new CleanUpTables(
+			$connection
+		);
+
+		$instance->dropTables( 'abcsmw_' );
+	}
+
+	public function testPostgres() {
+
+		$connection = $this->getMockBuilder( '\DatabaseBase' )
+			->disableOriginalConstructor()
+			->setMethods( [ 'listTables', 'query', 'getType' ] )
+			->getMockForAbstractClass();
+
+		$connection->expects( $this->atLeastOnce() )
+			->method( 'getType' )
+			->will( $this->returnValue( 'postgres' ) );
+
+		$connection->expects( $this->atLeastOnce() )
+			->method( 'listTables' )
+			->will( $this->returnValue( [ 'abcsmw_foo' ] ) );
+
+		$connection->expects( $this->atLeastOnce() )
+			->method( 'query' )
+			->with( $this->equalTo( 'DROP TABLE IF EXISTS abcsmw_foo CASCADE' ) );
+
+		$instance = new CleanUpTables(
+			$connection
+		);
+
+		$instance->dropTables( 'abcsmw_' );
+	}
+
+}


### PR DESCRIPTION
This PR is made in reference to: #3460 

This PR addresses or contains:

- Cleans-up all `sunittest_` tables after the test run (even in cases where PHPUnit aborted) to have no leftovers

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed
