### PR TITLE
Property page, avoid time offset display for non DITime items, refs 2515

### DIFF
--- a/src/MediaWiki/Page/PropertyPage.php
+++ b/src/MediaWiki/Page/PropertyPage.php
@@ -10,6 +10,7 @@ use SMW\DIProperty;
 use SMW\Message;
 use SMW\MediaWiki\Page\ListBuilder\ItemListBuilder;
 use SMW\MediaWiki\Page\ListBuilder\ValueListBuilder;
+use SMW\Localizer;
 use SMW\PropertyRegistry;
 use SMW\RequestOptions;
 use SMW\Store;
@@ -333,7 +334,12 @@ class PropertyPage extends Page {
 			$this->getOption( 'smwgMaxPropertyValues' )
 		);
 
+		$valueListBuilder->applyLocalTimeOffset(
+			Localizer::getInstance()->hasLocalTimeOffsetPreference( $this->getUser() )
+		);
+
 		$html = $valueListBuilder->createHtml(
+
 			$this->property,
 			$this->getDataItem(),
 			[

--- a/tests/phpunit/Unit/MediaWiki/Page/ListBuilder/ValueListBuilderTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Page/ListBuilder/ValueListBuilderTest.php
@@ -5,6 +5,7 @@ namespace SMW\Tests\MediaWiki\Page\ListBuilder;
 use SMW\DIProperty;
 use SMW\DIWikiPage;
 use SMW\MediaWiki\Page\ListBuilder\ValueListBuilder;
+use SMWDITime as DITime;
 use SMW\Tests\TestEnvironment;
 
 /**
@@ -19,6 +20,7 @@ use SMW\Tests\TestEnvironment;
 class ValueListBuilderTest extends \PHPUnit_Framework_TestCase {
 
 	private $store;
+	private $prefetchItemLookup;
 	private $testEnvironment;
 	private $stringValidator;
 
@@ -31,6 +33,10 @@ class ValueListBuilderTest extends \PHPUnit_Framework_TestCase {
 		$this->store = $this->getMockBuilder( '\SMW\Store' )
 			->disableOriginalConstructor()
 			->getMockForAbstractClass();
+
+		$this->prefetchItemLookup = $this->getMockBuilder( '\SMW\SQLStore\EntityStore\PrefetchItemLookup' )
+			->disableOriginalConstructor()
+			->getMock();
 	}
 
 	protected function tearDown() {
@@ -63,11 +69,7 @@ class ValueListBuilderTest extends \PHPUnit_Framework_TestCase {
 
 		$subject = DIWikiPage::newFromText( __METHOD__ );
 
-		$prefetchItemLookup = $this->getMockBuilder( '\SMW\SQLStore\EntityStore\PrefetchItemLookup' )
-			->disableOriginalConstructor()
-			->getMock();
-
-		$prefetchItemLookup->expects( $this->once() )
+		$this->prefetchItemLookup->expects( $this->once() )
 			->method( 'getPropertyValues' )
 			->will( $this->returnValue( [ $subject->getHash() => [ DIWikiPage::newFromText( 'Bar' ) ] ] ) );
 
@@ -86,7 +88,7 @@ class ValueListBuilderTest extends \PHPUnit_Framework_TestCase {
 
 		$store->expects( $this->once() )
 			->method( 'service' )
-			->will( $this->returnValue( $prefetchItemLookup ) );
+			->will( $this->returnValue( $this->prefetchItemLookup ) );
 
 		$instance = new ValueListBuilder( $store );
 		$instance->setLanguageCode( 'en' );
@@ -99,6 +101,48 @@ class ValueListBuilderTest extends \PHPUnit_Framework_TestCase {
 				'<div class="smw-table-row header-row"><div class="smw-table-cell header-title"><div id="B">B</div>',
 				'title="SMW\Tests\MediaWiki\Page\ListBuilder\ValueListBuilderTest::testCreateHtml',
 				'<span class="smwbrowse">.*:Bar">+</a>'
+			],
+			$instance->createHtml( $property, $dataItem, [ 'limit' => 10 ] )
+		);
+	}
+
+	public function testCreateHtml_TimeOffset() {
+
+		$subject = DIWikiPage::newFromText( __METHOD__ );
+
+		$this->prefetchItemLookup->expects( $this->once() )
+			->method( 'getPropertyValues' )
+			->will( $this->returnValue( [ $subject->getHash() => [ new DITime( DITime::CM_GREGORIAN, 1970 ) ] ] ) );
+
+		$store = $this->getMockBuilder( '\SMW\Store' )
+			->disableOriginalConstructor()
+			->setMethods( [ 'getAllPropertySubjects', 'getPropertyValues', 'getWikiPageSortKey', 'service' ] )
+			->getMockForAbstractClass();
+
+		$store->expects( $this->once() )
+			->method( 'getAllPropertySubjects' )
+			->will( $this->returnValue( [ $subject ] ) );
+
+		$store->expects( $this->once() )
+			->method( 'getWikiPageSortKey' )
+			->will( $this->returnValue( 'Bar' ) );
+
+		$store->expects( $this->once() )
+			->method( 'service' )
+			->will( $this->returnValue( $this->prefetchItemLookup ) );
+
+		$instance = new ValueListBuilder( $store );
+		$instance->setLanguageCode( 'en' );
+		$instance->applyLocalTimeOffset( true );
+
+		$property = new DIProperty( 'Foo' );
+		$property->setPropertyValueType( '_dat' );
+
+		$dataItem = new DIWikiPage( 'Bar', NS_MAIN );
+
+		$this->stringValidator->assertThatStringContains(
+			[
+				'<div class="smw-table-cell smwprops">1970&#160;&#160;'
 			],
 			$instance->createHtml( $property, $dataItem, [ 'limit' => 10 ] )
 		);


### PR DESCRIPTION
This PR is made in reference to: #2515

This PR addresses or contains:

- Only apply `#TO` on the property page where the value dislayed is a `DITime` instance

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed
