### PR TITLE
On limit, find all properties and then construct the query, refs 2930, 3286

### DIFF
--- a/DefaultSettings.php
+++ b/DefaultSettings.php
@@ -514,7 +514,7 @@ return [
 
 		// Special:Browse
 		'browse' => [
-			'valuelist.outgoing' => 200,
+			'valuelist.outgoing' => 30,
 			'valuelist.incoming' => 20,
 		]
 	],

--- a/tests/phpunit/Unit/MediaWiki/Specials/SpecialBrowseTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Specials/SpecialBrowseTest.php
@@ -82,7 +82,7 @@ class SpecialBrowseTest extends \PHPUnit_Framework_TestCase {
 			'Foo/Bar',
 			[
 				'data-subject="Foo/Bar#0##"',
-				'data-options="{&quot;dir&quot;:null,&quot;group&quot;:null,&quot;printable&quot;:null,&quot;offset&quot;:null,&quot;including&quot;:null,&quot;showInverse&quot;:false,&quot;showAll&quot;:true,&quot;showGroup&quot;:false,&quot;showSort&quot;:false,&quot;api&quot;:true,&quot;valuelistlimit.out&quot;:&quot;200&quot;,&quot;valuelistlimit.in&quot;:&quot;20&quot;}"'
+				'data-options="{&quot;dir&quot;:null,&quot;group&quot;:null,&quot;printable&quot;:null,&quot;offset&quot;:null,&quot;including&quot;:null,&quot;showInverse&quot;:false,&quot;showAll&quot;:true,&quot;showGroup&quot;:false,&quot;showSort&quot;:false,&quot;api&quot;:true,&quot;valuelistlimit.out&quot;:&quot;30&quot;,&quot;valuelistlimit.in&quot;:&quot;20&quot;}"'
 			]
 		];
 
@@ -91,7 +91,7 @@ class SpecialBrowseTest extends \PHPUnit_Framework_TestCase {
 			':Main-20Page-23_QUERY140d50d705e9566904fc4a877c755964',
 			[
 				'data-subject="Main_Page#0##_QUERY140d50d705e9566904fc4a877c755964"',
-				'data-options="{&quot;dir&quot;:null,&quot;group&quot;:null,&quot;printable&quot;:null,&quot;offset&quot;:null,&quot;including&quot;:null,&quot;showInverse&quot;:false,&quot;showAll&quot;:true,&quot;showGroup&quot;:false,&quot;showSort&quot;:false,&quot;api&quot;:true,&quot;valuelistlimit.out&quot;:&quot;200&quot;,&quot;valuelistlimit.in&quot;:&quot;20&quot;}"'
+				'data-options="{&quot;dir&quot;:null,&quot;group&quot;:null,&quot;printable&quot;:null,&quot;offset&quot;:null,&quot;including&quot;:null,&quot;showInverse&quot;:false,&quot;showAll&quot;:true,&quot;showGroup&quot;:false,&quot;showSort&quot;:false,&quot;api&quot;:true,&quot;valuelistlimit.out&quot;:&quot;30&quot;,&quot;valuelistlimit.in&quot;:&quot;20&quot;}"'
 			]
 		];
 


### PR DESCRIPTION
This PR is made in reference to: #2930, #3286

This PR addresses or contains:

- If a limit was set, make sure to find all properties first before applying the `SELECT` limit individually otherwise `Special:Browse` only shows a limited number of properties with values

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed
