### PR TITLE
Fixes warning "a non-numeric value" was encountered

### DIFF
--- a/src/MediaWiki/Specials/Admin/TaskHandler.php
+++ b/src/MediaWiki/Specials/Admin/TaskHandler.php
@@ -47,7 +47,7 @@ abstract class TaskHandler {
 	 * @return boolean
 	 */
 	public function isEnabledFeature( $feature ) {
-		return $this->hasFeature( $feature );
+		return ( ( (int)$this->featureSet & $feature ) == $feature );
 	}
 
 	/**

--- a/src/MediaWiki/Specials/Admin/TaskHandler.php
+++ b/src/MediaWiki/Specials/Admin/TaskHandler.php
@@ -47,7 +47,7 @@ abstract class TaskHandler {
 	 * @return boolean
 	 */
 	public function isEnabledFeature( $feature ) {
-		return ( ( (int)$this->featureSet & $feature ) == $feature );
+		return $this->hasFeature( $feature );
 	}
 
 	/**
@@ -58,7 +58,7 @@ abstract class TaskHandler {
 	 * @return boolean
 	 */
 	public function hasFeature( $feature ) {
-		return ( ( $this->featureSet & $feature ) == $feature );
+		return ( ( (int)$this->featureSet & $feature ) == $feature );
 	}
 
 	/**


### PR DESCRIPTION
This PR is made in reference to: #3827 

This PR addresses or contains:
- Fixes warning "a non-numeric value" was encountered (as suggested by @mwjames in https://github.com/SemanticMediaWiki/SemanticMediaWiki/issues/3827#issuecomment-475866495)

This PR includes:
- [ ] Tests (unit/integration)
- [x] CI build passed

Fixes #3827 