### PR TITLE
Switch setting of `smwgCompactLinkSupport` to "false"

### DIFF
--- a/DefaultSettings.php
+++ b/DefaultSettings.php
@@ -400,8 +400,9 @@ return [
 	# arbitrary text elements and therefore become difficult to transfer when its
 	# length exceeds a certain character length.
 	#
-	# A compact link will be encoded and compressed to ensure that it can be handled
-	# more easily when referring to it as an URL representation.
+	# The experimental feature of a compact link will be encoded and compressed to
+	# ensure that it can be handled more easily when referring to it as an URL
+	# representation.
 	#
 	# It is not expected to be used as a short-url service, yet in some instances
 	# the generate URL can be comparatively shorter than the plain URL.
@@ -413,7 +414,7 @@ return [
 	# @since 3.0
 	# @default true
 	##
-	'smwgCompactLinkSupport' => true,
+	'smwgCompactLinkSupport' => false,
 	##
 
 	###


### PR DESCRIPTION
This PR is made in reference to: #3855 

This PR addresses or contains:
- Switch setting of `smwgCompactLinkSupport` to "false" in the light of the findings described in the issue report referenced

I must note that this is a sad but necessary change.

This PR includes:
- [ ] Tests (unit/integration)
- [x] CI build passed

Fixes #3855 