### PR TITLE
Replace `localpath` with `localBasePath`, refs 3861

### DIFF
--- a/src/MediaWiki/Hooks/ResourceLoaderTestModules.php
+++ b/src/MediaWiki/Hooks/ResourceLoaderTestModules.php
@@ -83,7 +83,7 @@ class ResourceLoaderTestModules extends HookHandler {
 				'ext.smw.api'
 			],
 			'position' => 'top',
-			'localpath' => $this->path,
+			'localBasePath' => $this->path,
 			'remoteExtPath' => 'SemanticMediaWiki',
 		];
 

--- a/tests/phpunit/Unit/MediaWiki/Hooks/ResourceLoaderTestModulesTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Hooks/ResourceLoaderTestModulesTest.php
@@ -42,6 +42,16 @@ class ResourceLoaderTestModulesTest extends \PHPUnit_Framework_TestCase {
 			'ext.smw.tests',
 			$testModules['qunit']
 		);
+
+		$this->assertArrayHasKey(
+			'localBasePath',
+			$testModules['qunit']['ext.smw.tests']
+		);
+
+		$this->assertArrayHasKey(
+			'remoteExtPath',
+			$testModules['qunit']['ext.smw.tests']
+		);
 	}
 
 }


### PR DESCRIPTION
This PR is made in reference to: #3861

This PR addresses or contains:

- Regression caused by  1fad17a#r32968076

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed

Fixes #3861 