### PR TITLE
Use `MaintenanceUpdateAddParams` to support `--skip-optimize` in `update.php`, refs 3507

### DIFF
--- a/src/MediaWiki/Hooks.php
+++ b/src/MediaWiki/Hooks.php
@@ -228,6 +228,7 @@ class Hooks {
 			'NewRevisionFromEditComplete' => [ $this, 'onNewRevisionFromEditComplete' ],
 			'LinksUpdateConstructed' => [ $this, 'onLinksUpdateConstructed' ],
 			'FileUpload' => [ $this, 'onFileUpload' ],
+			'MaintenanceUpdateAddParams' => [ $this, 'onMaintenanceUpdateAddParams' ],
 
 			'ResourceLoaderGetConfigVars' => [ $this, 'onResourceLoaderGetConfigVars' ],
 			'ResourceLoaderTestModules' => [ $this, 'onResourceLoaderTestModules' ],
@@ -783,6 +784,18 @@ class Hooks {
 		);
 
 		return $fileUpload->process( $file, $reupload );
+	}
+
+	/**
+	 * @see https://www.mediawiki.org/wiki/Manual:Hooks/MaintenanceUpdateAddParams
+	 */
+	public function onMaintenanceUpdateAddParams( &$params ) {
+
+		ExtensionSchemaUpdates::addMaintenanceUpdateParams(
+			$params
+		);
+
+		return true;
 	}
 
 	/**

--- a/src/MediaWiki/Hooks/ExtensionSchemaUpdates.php
+++ b/src/MediaWiki/Hooks/ExtensionSchemaUpdates.php
@@ -35,6 +35,19 @@ class ExtensionSchemaUpdates {
 	}
 
 	/**
+	 * @since 3.1
+	 *
+	 * @param array $params
+	 */
+	public static function addMaintenanceUpdateParams( &$params ) {
+
+		// For details, see https://github.com/wikimedia/mediawiki/commit/a6facc8a0a4f9b54e0cfb1e5ef6f3991de752342
+		$params['skip-optimize'] = [
+			'desc' => 'SMW, allow to skip the table optimization during the Store setup'
+		];
+	}
+
+	/**
 	 * @since 2.0
 	 *
 	 * @return true

--- a/tests/phpunit/Unit/MediaWiki/Hooks/ExtensionSchemaUpdatesTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Hooks/ExtensionSchemaUpdatesTest.php
@@ -41,4 +41,18 @@ class ExtensionSchemaUpdatesTest extends \PHPUnit_Framework_TestCase {
 		$instance->process();
 	}
 
+	public function testAddMaintenanceUpdateParams() {
+
+		$params = [];
+
+		ExtensionSchemaUpdates::addMaintenanceUpdateParams(
+			$params
+		);
+
+		$this->assertArrayHasKey(
+			'skip-optimize',
+			$params
+		);
+	}
+
 }

--- a/tests/phpunit/Unit/MediaWiki/HooksTest.php
+++ b/tests/phpunit/Unit/MediaWiki/HooksTest.php
@@ -245,6 +245,7 @@ class HooksTest extends \PHPUnit_Framework_TestCase {
 			[ 'callLinksUpdateConstructed' ],
 			[ 'callSpecialStatsAddExtra' ],
 			[ 'callFileUpload' ],
+			[ 'callMaintenanceUpdateAddParams' ],
 			[ 'callResourceLoaderGetConfigVars' ],
 			[ 'callGetPreferences' ],
 			[ 'callPersonalUrls' ],
@@ -906,6 +907,24 @@ class HooksTest extends \PHPUnit_Framework_TestCase {
 		$this->assertThatHookIsExcutable(
 			$instance->getHandlerFor( $handler ),
 			[ $file, $reupload ]
+		);
+
+		return $handler;
+	}
+
+	public function callMaintenanceUpdateAddParams( $instance ) {
+
+		$handler = 'MaintenanceUpdateAddParams';
+
+		$this->assertTrue(
+			$instance->isRegistered( $handler )
+		);
+
+		$params = [];
+
+		$this->assertThatHookIsExcutable(
+			$instance->getHandlerFor( $handler ),
+			[ &$params ]
 		);
 
 		return $handler;


### PR DESCRIPTION
This PR is made in reference to: #3507, #2516

This PR addresses or contains:

- Uses the newly introduced `MaintenanceUpdateAddParams` to add `--skip-optimize` to the `update.php` script

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed

Fixes #3507