### PR TITLE
Support removal of remnant entities, refs 3849

### DIFF
--- a/DefaultSettings.php
+++ b/DefaultSettings.php
@@ -2009,6 +2009,36 @@ return [
 	##
 
 	##
+	# Find and remove remnant entities
+	#
+	# So called remnant entities or ghosts (i.e. assignments in tables without a
+	# corresponding entry in a `smw_proptable_hash` field) should rarely happen
+	# but can and to enable the updater to re-balance the content of the
+	# `smw_proptable_hash` field (by checking and removing any ghosts in tables
+	# currently not in use for a particular subject). This setting can be enabled
+	# to force the updater/differ to make additional inquiries during an update
+	# to find and remove remnants that have no assignments in a table for a
+	# selected subject.
+	#
+	# The impact (in terms of performance) on the updater is unknown since each
+	# update is expected to run additional queries therefore the setting is
+	# set on purge only by default.
+	#
+	# - `purge` enables the check to happen only during a purge action which
+	#    limits a possible performance impact to a single subject request hereby
+	#    avoids impacting regular updates
+	# - `true` as setting will carry out the check on every update
+	# - `false` will disable the check all together
+	#
+	# @see #3849#issuecomment-477605049
+	#
+	# @since 3.1
+	# @default 'purge'
+	##
+	'smwgCheckForRemnantEntities' => 'purge',
+	##
+
+	##
 	# THE FOLLOWING SETTINGS AND SUPPORT FUNCTIONS ARE EXPERIMENTAL!
 	#
 	# Please make you read the Readme.md (see the Elastic folder) file first

--- a/includes/SemanticData.php
+++ b/includes/SemanticData.php
@@ -37,6 +37,11 @@ class SemanticData {
 	const OPT_LAST_MODIFIED = 'opt.last.modified';
 
 	/**
+	 * @see $smwgCheckForRemnantEntities
+	 */
+	const OPT_CHECK_REMNANT_ENTITIES = 'opt.check.remnant.entities';
+
+	/**
 	 * Identifies that a data block was created by a user.
 	 */
 	const PROC_USER = 'proc.user';

--- a/includes/Settings.php
+++ b/includes/Settings.php
@@ -180,6 +180,7 @@ class Settings extends Options {
 			'smwgSpecialAskFormSubmitMethod' => $GLOBALS['smwgSpecialAskFormSubmitMethod'],
 			'smwgSupportSectionTag' => $GLOBALS['smwgSupportSectionTag'],
 			'smwgMandatorySubpropertyParentTypeInheritance' => $GLOBALS['smwgMandatorySubpropertyParentTypeInheritance'],
+			'smwgCheckForRemnantEntities' => $GLOBALS['smwgCheckForRemnantEntities'],
 		];
 
 		self::initLegacyMapping( $configuration );

--- a/includes/storage/SQLStore/SMW_SQLStore3_Writers.php
+++ b/includes/storage/SQLStore/SMW_SQLStore3_Writers.php
@@ -205,6 +205,10 @@ class SMWSQLStore3Writers {
 			$this->store
 		);
 
+		if ( $semanticData->getOption( SemanticData::OPT_CHECK_REMNANT_ENTITIES ) ) {
+			$this->propertyTableRowDiffer->checkRemnantEntities( true );
+		}
+
 		// Update data about our main subject
 		$this->doFlatDataUpdate( $semanticData );
 		$sid = $subject->getId();

--- a/maintenance/rebuildData.php
+++ b/maintenance/rebuildData.php
@@ -88,6 +88,7 @@ class RebuildData extends \Maintenance {
 		$this->addOption( 'categories', 'Only refresh category pages (and other explicitly named namespaces)', false, false, 'c' );
 		$this->addOption( 'redirects', 'Only refresh redirect pages', false );
 		$this->addOption( 'dispose-outdated', 'Only Remove outdated marked entities (including pending references).', false );
+		$this->addOption( 'check-remnantentities', 'Check and remove remnant entities (ghosts) from tables without a corresponding hash field entry', false );
 
 		$this->addOption( 'skip-properties', 'Skip the default properties rebuild (only recommended when successive build steps are used)', false );
 		$this->addOption( 'shallow-update', 'Skip processing of entities that compare to the last known revision date', false );
@@ -135,6 +136,10 @@ class RebuildData extends \Maintenance {
 
 		$maintenanceHelper = $maintenanceFactory->newMaintenanceHelper();
 		$maintenanceHelper->initRuntimeValues();
+
+		if ( $this->hasOption( 'check-remnantentities' ) ) {
+			$maintenanceHelper->setGlobalToValue( 'smwgCheckForRemnantEntities', true );
+		}
 
 		if ( $this->hasOption( 'no-cache' ) ) {
 			$maintenanceHelper->setGlobalToValue( 'wgMainCacheType', CACHE_NONE );

--- a/src/MediaWiki/Hooks.php
+++ b/src/MediaWiki/Hooks.php
@@ -274,6 +274,7 @@ class Hooks {
 	public function onParserAfterTidy( &$parser, &$text ) {
 
 		$applicationFactory = ApplicationFactory::getInstance();
+		$settings = $applicationFactory->getSettings();
 
 		$parserAfterTidy = new ParserAfterTidy(
 			$parser,
@@ -294,6 +295,12 @@ class Hooks {
 
 		$parserAfterTidy->setLogger(
 			$applicationFactory->getMediaWikiLogger()
+		);
+
+		$parserAfterTidy->setOptions(
+			[
+				'smwgCheckForRemnantEntities' => $settings->get( 'smwgCheckForRemnantEntities' )
+			]
 		);
 
 		$parserAfterTidy->process( $text );

--- a/src/MediaWiki/Hooks/ParserAfterTidy.php
+++ b/src/MediaWiki/Hooks/ParserAfterTidy.php
@@ -260,21 +260,27 @@ class ParserAfterTidy extends HookHandler {
 				return true;
 			}
 
-			$parserData->setOrigin( 'ParserAfterTidy' );
+			$semanticData = $parserData->getSemanticData();
 
 			// Set an explicit timestamp to create a new hash for the property
 			// table change row differ and force a data comparison (this doesn't
 			// change the _MDAT annotation)
-			$parserData->getSemanticData()->setOption(
+			$semanticData->setOption(
 				SemanticData::OPT_LAST_MODIFIED,
 				wfTimestamp( TS_UNIX )
 			);
+
+			// #3849
+			if ( $this->getOption( 'smwgCheckForRemnantEntities' ) === 'purge' ) {
+				$semanticData->setOption( SemanticData::OPT_CHECK_REMNANT_ENTITIES, true );
+			}
 
 			$parserData->setOption(
 				$parserData::OPT_FORCED_UPDATE,
 				true
 			);
 
+			$parserData->setOrigin( 'ParserAfterTidy' );
 			$parserData->updateStore( true );
 
 			$parserData->addLimitReport(

--- a/src/SQLStore/SQLStoreFactory.php
+++ b/src/SQLStore/SQLStoreFactory.php
@@ -557,6 +557,8 @@ class SQLStoreFactory {
 	 */
 	public function newPropertyTableRowDiffer() {
 
+		$settings = ApplicationFactory::getInstance()->getSettings();
+
 		$propertyTableRowMapper = new PropertyTableRowMapper(
 			$this->store
 		);
@@ -564,6 +566,10 @@ class SQLStoreFactory {
 		$propertyTableRowDiffer = new PropertyTableRowDiffer(
 			$this->store,
 			$propertyTableRowMapper
+		);
+
+		$propertyTableRowDiffer->checkRemnantEntities(
+			$settings->is( 'smwgCheckForRemnantEntities', true )
 		);
 
 		return $propertyTableRowDiffer;


### PR DESCRIPTION
This PR is made in reference to: #3849

This PR addresses or contains:

- See `DefaultSettings.php` for a detailed explanation on the `$smwgCheckForRemnantEntities` settings
- Default has been set to `purge` which runs checks and removals only on the dedicated purge action given a possible performance impact due to running checks on all smw* tables that are not part of the `smw_proptable_hash` content
- `--check-remnantentities` was added as option to the `rebuildData.php` to run extra table queries in order to find and eliminate so called remnant entities
- https://www.semantic-mediawiki.org/wiki/Help:Remnant_entities

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed

Fixes #3849