### PR TITLE
EntityCache, minimize redirect lookups on properties

### DIFF
--- a/src/EntityCache.php
+++ b/src/EntityCache.php
@@ -20,8 +20,15 @@ use Title;
 class EntityCache {
 
 	const CACHE_NAMESPACE = 'smw:entity';
-
 	const VERSION = 1;
+
+	const TTL_SECOND = 1;
+	const TTL_MINUTE = 60;
+	const TTL_HOUR = 3600;
+	const TTL_DAY = 86400; // 24 * 3600
+	const TTL_WEEK = 604800; // 7 * 24 * 3600
+	const TTL_MONTH = 2592000; // 30 * 24 * 3600
+	const TTL_YEAR = 31536000; // 365 * 24 * 3600
 
 	/**
 	 * @var Cache

--- a/src/Store.php
+++ b/src/Store.php
@@ -160,6 +160,13 @@ abstract class Store implements QueryEngine {
 			$wikipage = $dataItem;
 		}
 
+		$entityCache = ApplicationFactory::getInstance()->getEntityCache();
+		$key = $entityCache->makeCacheKey( 'redirect', $wikipage->getHash() );
+
+		if ( $type === DataItem::TYPE_PROPERTY && ( $serialization = $entityCache->fetch( $key ) ) !== false ) {
+			return DataItem::newFromSerialization( $type, $serialization );
+		}
+
 		$dataItems = $this->getPropertyValues( $wikipage, new DIProperty( '_REDI' ) );
 
 		if ( is_array( $dataItems ) && count( $dataItems ) > 0 ) {
@@ -171,6 +178,11 @@ abstract class Store implements QueryEngine {
 			} else {
 				$dataItem = $redirectDataItem;
 			}
+		}
+
+		if ( $type === DataItem::TYPE_PROPERTY ) {
+			$entityCache->save( $key, $dataItem->getSerialization(), $entityCache::TTL_DAY );
+			$entityCache->associate( $wikipage, $key );
 		}
 
 		return $dataItem;


### PR DESCRIPTION
This PR is made in reference to: #

This PR addresses or contains:

- Persistently cache redirect lookups for properties to minimize the need for direct DB interaction

This PR includes:
- [ ] Tests (unit/integration)
- [x] CI build passed
