### PR TITLE
Add `MonolingualTextLookup` service

### DIFF
--- a/src/SQLStore/Lookup/MonolingualTextLookup.php
+++ b/src/SQLStore/Lookup/MonolingualTextLookup.php
@@ -1,0 +1,207 @@
+<?php
+
+namespace SMW\SQLStore\Lookup;
+
+use SMW\Store;
+use SMW\DIWikiPage;
+use SMW\DIProperty;
+use SMW\SQLStore\SQLStore;
+use SMW\Message;
+use SMW\DataValueFactory;
+use SMWContainerSemanticData as ContainerSemanticData;
+use SMWDIBlob as DIBlob;
+use SMWDIContainer as DIContainer;
+
+/**
+ * @license GNU GPL v2+
+ * @since 3.1
+ *
+ * @author mwjames
+ */
+class MonolingualTextLookup {
+
+	/**
+	 * @var Store
+	 */
+	private $store;
+
+	/**
+	 * @since 3.1
+	 *
+	 * @param Store $store
+	 */
+	public function __construct( Store $store ) {
+		$this->store = $store;
+	}
+
+	/**
+	 * @since 3.1
+	 *
+	 * @param DIWikiPage $subject
+	 *
+	 * @return []
+	 */
+	public function newDataValue( DIWikiPage $subject, DIProperty $property, $languageCode = null ) {
+
+		$res = $this->fetchFromTable( $subject, $property, $languageCode );
+		$dataValue = null;
+
+		$connection = $this->store->getConnection( 'mw.db' );
+
+		foreach ( $res as $row ) {
+
+			$containerSemanticData = $this->newContainerSemanticData(
+				$row
+			);
+
+			$text = $row->text_long === null ? $row->text_short : $row->text_long;
+
+			if ( $row->text_long !== null && $connection->isType( 'postgres' ) ) {
+				$text = pg_unescape_bytea( $text );
+			}
+
+			$containerSemanticData->addPropertyObjectValue(
+				new DIProperty( '_TEXT' ),
+				new DIBlob( $text )
+			);
+
+			$containerSemanticData->addPropertyObjectValue(
+				new DIProperty( '_LCODE' ),
+				new DIBlob( $row->lcode )
+			);
+
+			$dataValue = DataValueFactory::getInstance()->newDataValueByItem(
+				$subject,
+				$property
+			);
+
+			$dataValue->setDataItem(
+				new DIContainer( $containerSemanticData )
+			);
+		}
+
+		return $dataValue;
+	}
+
+	/**
+	 * @since 3.1
+	 *
+	 * @param DIWikiPage $subject
+	 *
+	 * @return []
+	 */
+	public function fetchFromTable( DIWikiPage $subject, DIProperty $property, $languageCode = null ) {
+
+		/**
+		 * This method avoids access to `Store::getSemanticData` in order to
+		 * optimize the query and produce something like:
+		 *
+		 */
+
+		$sid = $this->store->getObjectIds()->getSMWPageID(
+			$subject->getDBKey(),
+			$subject->getNamespace(),
+			$subject->getInterWiki(),
+			$subject->getSubobjectName()
+		);
+
+		$connection = $this->store->getConnection( 'mw.db' );
+		$query = $connection->newQuery();
+
+		$query->type( 'SELECT' );
+
+		$propTable = $this->getPropertyTable(
+			$property
+		);
+
+		$query->table( $propTable->getName(), 't0' );
+		$query->condition( $query->eq( "t0.s_id", $sid ) );
+
+		if ( !$propTable->isFixedPropertyTable() ) {
+
+			$pid = $this->store->getObjectIds()->getSMWPropertyID(
+				$property
+			);
+
+			$query->condition( $query->eq( "t0.p_id", $pid ) );
+
+			$query->join(
+				'INNER JOIN',
+				[ SQLStore::ID_TABLE => 't1 ON t0.p_id=t1.smw_id' ]
+			);
+		}
+
+		$query->condition( $query->neq( "o0.smw_iw", SMW_SQL3_SMWIW_OUTDATED ) );
+		$query->condition( $query->neq( "o0.smw_iw", SMW_SQL3_SMWDELETEIW ) );
+
+		$query->join(
+			'INNER JOIN',
+			[ SQLStore::ID_TABLE => 'o0 ON t0.o_id=o0.smw_id' ]
+		);
+
+		$text = new DIProperty( '_TEXT' );
+
+		$text_table = $this->getPropertyTable(
+			$text
+		);
+
+		$query->join(
+			'INNER JOIN',
+			[ $text_table->getName() => 't2 ON t2.s_id=o0.smw_id' ]
+		);
+
+		$lcode = new DIProperty( '_LCODE' );
+
+		$lcode_table = $this->getPropertyTable(
+			$lcode
+		);
+
+		$query->join(
+			'INNER JOIN',
+			[ $lcode_table->getName() => 't3 ON t3.s_id=o0.smw_id' ]
+		);
+
+		if ( $languageCode !== null ) {
+			$query->condition( $query->eq( "t3.o_hash", $languageCode ) );
+		}
+
+		$query->field( 't0.o_id', 'id' );
+		$query->field( 'o0.smw_title', 'v0' );
+		$query->field( 'o0.smw_namespace', 'v1' );
+		$query->field( 'o0.smw_iw', 'v2' );
+		$query->field( 'o0.smw_subobject', 'v3' );
+		$query->field( 't2.o_hash', 'text_short' );
+		$query->field( 't2.o_blob', 'text_long' );
+		$query->field( 't3.o_hash', 'lcode' );
+
+		return $query->execute( __METHOD__ );
+	}
+
+	private function getPropertyTable( DIProperty $property ) {
+
+		$propTableId = $this->store->findPropertyTableID(
+			$property
+		);
+
+		$propTables = $this->store->getPropertyTables();
+
+		if ( !isset( $propTables[$propTableId] ) ) {
+			return [];
+		}
+
+		return $propTables[$propTableId];
+	}
+
+	private function newContainerSemanticData( $row ) {
+
+		$subject = new DIWikiPage(
+			$row->v0,
+			$row->v1,
+			$row->v2,
+			$row->v3
+		);
+
+		return new ContainerSemanticData( $subject );
+	}
+
+}

--- a/src/SQLStore/SQLStoreFactory.php
+++ b/src/SQLStore/SQLStoreFactory.php
@@ -36,6 +36,7 @@ use SMW\SQLStore\Lookup\UnusedPropertyListLookup;
 use SMW\SQLStore\Lookup\UsageStatisticsListLookup;
 use SMW\SQLStore\Lookup\ProximityPropertyValueLookup;
 use SMW\SQLStore\Lookup\MissingRedirectLookup;
+use SMW\SQLStore\Lookup\MonolingualTextLookup;
 use SMW\SQLStore\TableBuilder\TableBuilder;
 use SMW\SQLStore\TableBuilder\Examiner\HashField;
 use SMW\SQLStore\TableBuilder\Examiner\FixedProperties;
@@ -805,6 +806,15 @@ class SQLStoreFactory {
 	/**
 	 * @since 3.1
 	 *
+	 * @return MonolingualTextLookup
+	 */
+	public function newMonolingualTextLookup() {
+		return new MonolingualTextLookup( $this->store );
+	}
+
+	/**
+	 * @since 3.1
+	 *
 	 * @return PrefetchItemLookup
 	 */
 	public function newPrefetchItemLookup() {
@@ -855,6 +865,10 @@ class SQLStoreFactory {
 				'MissingRedirectLookup' => [
 					'_service' => [ $this, 'newMissingRedirectLookup' ],
 					'_type'    => MissingRedirectLookup::class
+				],
+				'MonolingualTextLookup' => [
+					'_service' => [ $this, 'newMonolingualTextLookup' ],
+					'_type'    => MonolingualTextLookup::class
 				],
 				'PropertyTypeFinder' => [
 					'_service' => [ $this, 'newPropertyTypeFinder' ],

--- a/src/Services/SharedServicesContainer.php
+++ b/src/Services/SharedServicesContainer.php
@@ -612,9 +612,15 @@ class SharedServicesContainer implements CallbackContainer {
 		$containerBuilder->registerCallback( 'PropertySpecificationLookup', function( $containerBuilder ) {
 			$containerBuilder->registerExpectedReturnType( 'PropertySpecificationLookup', '\SMW\PropertySpecificationLookup' );
 
+			$contentLanguage = Localizer::getInstance()->getContentLanguage();
+
 			$propertySpecificationLookup = new PropertySpecificationLookup(
-				$containerBuilder->singleton( 'CachedPropertyValuesPrefetcher' ),
-				$containerBuilder->singleton( 'InMemoryPoolCache' )->getPoolCacheById( PropertySpecificationLookup::POOLCACHE_ID )
+				$containerBuilder->singleton( 'Store', null ),
+				$containerBuilder->singleton( 'EntityCache' )
+			);
+
+			$propertySpecificationLookup->setLanguageCode(
+				$contentLanguage->getCode()
 			);
 
 			return $propertySpecificationLookup;
@@ -627,7 +633,7 @@ class SharedServicesContainer implements CallbackContainer {
 			$containerBuilder->registerExpectedReturnType( 'ProtectionValidator', '\SMW\Protection\ProtectionValidator' );
 
 			$protectionValidator = new ProtectionValidator(
-				$containerBuilder->singleton( 'Store' ),
+				$containerBuilder->singleton( 'Store', null ),
 				$containerBuilder->singleton( 'EntityCache' )
 			);
 

--- a/tests/phpunit/Integration/JSONScript/JsonTestCaseScriptRunnerTest.php
+++ b/tests/phpunit/Integration/JSONScript/JsonTestCaseScriptRunnerTest.php
@@ -127,7 +127,6 @@ class JsonTestCaseScriptRunnerTest extends JsonTestCaseScriptRunner {
 		// 'mw-changed-redirect-target'  into 'change_tag_def',
 		$this->testEnvironment->resetMediaWikiService( 'NameTableStoreFactory' );
 
-		$this->testEnvironment->resetPoolCacheById( PropertySpecificationLookup::POOLCACHE_ID );
 		$this->testEnvironment->resetPoolCacheById( TurtleTriplesBuilder::POOLCACHE_ID );
 
 		// Make sure LocalSettings don't interfere with the default settings

--- a/tests/phpunit/Unit/Factbox/CachedFactboxTest.php
+++ b/tests/phpunit/Unit/Factbox/CachedFactboxTest.php
@@ -46,7 +46,7 @@ class CachedFactboxTest extends \PHPUnit_Framework_TestCase {
 
 		$this->entityCache = $this->getMockBuilder( '\SMW\EntityCache' )
 			->disableOriginalConstructor()
-			->setMethods( ['fetch', 'save', 'saveSub' ] )
+			->setMethods( ['fetch', 'save', 'saveSub', 'fetchSub' ] )
 			->getMock();
 
 		$this->testEnvironment->registerObject( 'EntityCache', $this->entityCache );

--- a/tests/phpunit/Unit/MediaWiki/Specials/SpecialPagePropertyTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Specials/SpecialPagePropertyTest.php
@@ -27,7 +27,7 @@ class SpecialPagePropertyTest extends \PHPUnit_Framework_TestCase {
 
 		$store = $this->getMockBuilder( '\SMW\SQLStore\SQLStore' )
 			->disableOriginalConstructor()
-			->setMethods( [ 'getPropertyValues' ] )
+			->setMethods( [ 'getPropertyValues', 'service' ] )
 			->getMock();
 
 		$store->expects( $this->any() )

--- a/tests/phpunit/Unit/MediaWiki/Specials/SpecialSearchByPropertyTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Specials/SpecialSearchByPropertyTest.php
@@ -32,7 +32,7 @@ class SpecialSearchByPropertyTest extends \PHPUnit_Framework_TestCase {
 
 		$store = $this->getMockBuilder( '\SMW\SQLStore\SQLStore' )
 			->disableOriginalConstructor()
-			->setMethods( [ 'getPropertyTableIdReferenceFinder', 'getPropertyValues', 'getPropertySubjects' ] )
+			->setMethods( [ 'getPropertyTableIdReferenceFinder', 'getPropertyValues', 'getPropertySubjects', 'service' ] )
 			->getMock();
 
 		$store->expects( $this->any() )

--- a/tests/phpunit/Unit/SQLStore/Lookup/MonolingualTextLookupTest.php
+++ b/tests/phpunit/Unit/SQLStore/Lookup/MonolingualTextLookupTest.php
@@ -1,0 +1,103 @@
+<?php
+
+namespace SMW\Tests\SQLStore\Lookup;
+
+use SMW\SQLStore\Lookup\MonolingualTextLookup;
+use SMW\MediaWiki\Connection\Query;
+use SMW\DIWikiPage;
+use SMW\DIProperty;
+
+/**
+ * @covers \SMW\SQLStore\Lookup\MonolingualTextLookup
+ * @group semantic-mediawiki
+ *
+ * @license GNU GPL v2+
+ * @since   3.1
+ *
+ * @author mwjames
+ */
+class MonolingualTextLookupTest extends \PHPUnit_Framework_TestCase {
+
+	private $store;
+
+	protected function setUp() {
+
+		$this->store = $this->getMockBuilder( '\SMW\SQLStore\SQLStore' )
+			->disableOriginalConstructor()
+			->getMock();
+	}
+
+	public function testCanConstruct() {
+
+		$this->assertInstanceOf(
+			MonolingualTextLookup::class,
+			new MonolingualTextLookup( $this->store )
+		);
+	}
+
+	public function testFetchFromTable() {
+
+		$connection = $this->getMockBuilder( '\SMW\MediaWiki\Database' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$connection->expects( $this->any() )
+			->method( 'addQuotes' )
+			->will( $this->returnArgument( 0 ) );
+
+		$query = new Query( $connection );
+
+		$subject = DIWikiPage::newFromText( __METHOD__ );
+		$property = DIProperty::newFromUserLabel( 'Foo' );
+
+		$tableDefinition = $this->getMockBuilder( '\SMW\SQLStore\TableDefinition' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$idTable = $this->getMockBuilder( '\SMWSql3SmwIds' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$connection = $this->getMockBuilder( '\SMW\MediaWiki\Database' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$connection->expects( $this->any() )
+			->method( 'newQuery' )
+			->will( $this->returnValue( $query ) );
+
+		$this->store->expects( $this->any() )
+			->method( 'getObjectIds' )
+			->will( $this->returnValue( $idTable ) );
+
+		$this->store->expects( $this->any() )
+			->method( 'getConnection' )
+			->will( $this->returnValue( $connection ) );
+
+		$this->store->expects( $this->any() )
+			->method( 'findPropertyTableID' )
+			->will( $this->returnValue( 'Foo' ) );
+
+		$this->store->expects( $this->any() )
+			->method( 'getPropertyTables' )
+			->will( $this->returnValue( [ 'Foo' => $tableDefinition ] ) );
+
+		$instance = new MonolingualTextLookup(
+			$this->store
+		);
+
+		$instance->fetchFromTable( $subject, $property, 'fr' );
+
+		$this->assertSame(
+			'SELECT t0.o_id AS id, o0.smw_title AS v0, o0.smw_namespace AS v1, o0.smw_iw AS v2, o0.smw_subobject AS v3,'.
+			' t2.o_hash AS text_short, t2.o_blob AS text_long, t3.o_hash AS lcode FROM  AS t0' .
+			' INNER JOIN  AS t1 ON t0.p_id=t1.smw_id' .
+			' INNER JOIN  AS o0 ON t0.o_id=o0.smw_id' .
+			' INNER JOIN  AS t2 ON t2.s_id=o0.smw_id' .
+			' INNER JOIN  AS t3 ON t3.s_id=o0.smw_id' .
+			' WHERE (t0.s_id=) AND (t0.p_id=) AND (o0.smw_iw!=:smw) AND (o0.smw_iw!=:smw-delete) AND (t3.o_hash=fr)',
+			$query->getSQL()
+		);
+	}
+
+}

--- a/tests/phpunit/Unit/SQLStore/SQLStoreFactoryTest.php
+++ b/tests/phpunit/Unit/SQLStore/SQLStoreFactoryTest.php
@@ -478,6 +478,16 @@ class SQLStoreFactoryTest extends \PHPUnit_Framework_TestCase {
 		);
 	}
 
+	public function testCanConstructMonolingualTextLookup() {
+
+		$instance = new SQLStoreFactory( $this->store );
+
+		$this->assertInstanceOf(
+			'\SMW\SQLStore\Lookup\MonolingualTextLookup',
+			$instance->newMonolingualTextLookup()
+		);
+	}
+
 	public function testCanConstructPrefetchItemLookup() {
 
 		$instance = new SQLStoreFactory( $this->store );


### PR DESCRIPTION
This PR is made in reference to: #

This PR addresses or contains:

- Add `MonolingualTextLookup` service to directly fetch monolingual text segments without having to go through the `SemanticData` lookup

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed
