### PR TITLE
Use canonical property label in a template context, refs 3548

### DIFF
--- a/src/DataValues/PropertyValue.php
+++ b/src/DataValues/PropertyValue.php
@@ -61,6 +61,11 @@ class PropertyValue extends DataValue {
 	const OPT_NO_PREF_LHNT = 'no.preflabel.marker';
 
 	/**
+	 * Indicates to use a canonical label
+	 */
+	const OPT_CANONICAL_LABEL = 'canonical.label';
+
+	/**
 	 * Special formatting of the label/preferred label
 	 */
 	const FORMAT_LABEL = 'format.label';

--- a/src/DataValues/ValueFormatters/PropertyValueFormatter.php
+++ b/src/DataValues/ValueFormatters/PropertyValueFormatter.php
@@ -177,8 +177,9 @@ class PropertyValueFormatter extends DataValueFormatter {
 
 		$property = $this->dataValue->getDataItem();
 		$languageCode = $this->dataValue->getOption( PropertyValue::OPT_USER_LANGUAGE );
+		$asCanonicalLabel = $this->dataValue->getOption( PropertyValue::OPT_CANONICAL_LABEL, false );
 
-		if ( ( $preferredLabel = $property->getPreferredLabel( $languageCode ) ) !== '' ) {
+		if ( $asCanonicalLabel === false && ( $preferredLabel = $property->getPreferredLabel( $languageCode ) ) !== '' ) {
 			return $preferredLabel;
 		}
 

--- a/src/Query/PrintRequest.php
+++ b/src/Query/PrintRequest.php
@@ -351,12 +351,19 @@ class PrintRequest {
 	 * @since 2.4
 	 *
 	 * @param string $text
-	 * @param $showMode = false
+	 * @param boalean $showMode = false
+	 * @param boolean $useCanonicalLabel = false
 	 *
 	 * @return PrintRequest|null
 	 */
-	public static function newFromText( $text, $showMode = false ) {
-		return Deserializer::deserialize( $text, $showMode );
+	public static function newFromText( $text, $showMode = false, $useCanonicalLabel = false ) {
+
+		$options = [
+			'show_mode' => $showMode,
+			'canonical_label' => $useCanonicalLabel
+		];
+
+		return Deserializer::deserialize( $text, $options );
 	}
 
 }

--- a/src/Query/PrintRequest/Deserializer.php
+++ b/src/Query/PrintRequest/Deserializer.php
@@ -5,6 +5,7 @@ namespace SMW\Query\PrintRequest;
 use InvalidArgumentException;
 use SMW\DataValueFactory;
 use SMW\DataValues\PropertyChainValue;
+use SMW\DataValues\PropertyValue;
 use SMW\Localizer;
 use SMW\Query\PrintRequest;
 use Title;
@@ -29,11 +30,21 @@ class Deserializer {
 	 * @since 2.5
 	 *
 	 * @param string $text
-	 * @param boolean $showMode = false
+	 * @param array $options
 	 *
 	 * @return PrintRequest|null
 	 */
-	public static function deserialize( $text, $showMode = false ) {
+	public static function deserialize( $text, array $options = [] ) {
+		$showMode = false;
+		$useCanonicalLabel = false;
+
+		if ( isset( $options['show_mode'] ) ) {
+			$showMode = $options['show_mode'];
+		}
+
+		if ( isset( $options['canonical_label'] ) ) {
+			$useCanonicalLabel = $options['canonical_label'];
+		}
 
 		list( $parts, $outputFormat, $printRequestLabel ) = self::getPartsFromText(
 			$text
@@ -64,6 +75,7 @@ class Deserializer {
 				PropertyChainValue::TYPE_ID
 			);
 
+			$data->setOption( PropertyValue::OPT_CANONICAL_LABEL, $useCanonicalLabel );
 			$data->setUserValue( $printRequestLabel );
 
 			if ( $showMode === false ) {
@@ -92,6 +104,8 @@ class Deserializer {
 				$data = DataValueFactory::getInstance()->newPropertyValueByLabel(
 					$printRequestLabel
 				);
+
+				$data->setOption( PropertyValue::OPT_CANONICAL_LABEL, $useCanonicalLabel );
 
 				if ( !$data->isValid() ) { // not a property; give up
 					return null;

--- a/src/Query/PrintRequestFactory.php
+++ b/src/Query/PrintRequestFactory.php
@@ -42,12 +42,13 @@ class PrintRequestFactory {
 	 * @since 2.4
 	 *
 	 * @param string $text
-	 * @param $showMode = false
+	 * @param boolean $showMode = false
+	 * @param boolean $asCanonicalLabel = false
 	 *
 	 * @return PrintRequest|null
 	 */
-	public function newFromText( $text, $showMode = false ) {
-		return PrintRequest::newFromText( $text, $showMode );
+	public function newFromText( $text, $showMode = false, $asCanonicalLabel = false ) {
+		return PrintRequest::newFromText( $text, $showMode, $asCanonicalLabel );
 	}
 
 	/**

--- a/src/Query/Processor/ParamListProcessor.php
+++ b/src/Query/Processor/ParamListProcessor.php
@@ -148,9 +148,16 @@ class ParamListProcessor {
 			// otherwise labels will be empty and not be accessible in a template
 			$showMode = $paramList['templateArgs'] ? false : $paramList['showMode'];
 
+			// #3548
+			// Use a canonical label when referenced as part of a template to ensure
+			// that labels (such as a preferred label) don't change with a language
+			// setting
+			$asCanonicalLabel = $paramList['templateArgs'];
+
 			$printRequest = $this->printRequestFactory->newFromText(
 				$request['label'],
-				$showMode
+				$showMode,
+				$asCanonicalLabel
 			);
 
 			if ( $printRequest === null ) {

--- a/tests/phpunit/Integration/JSONScript/TestCases/f-0806.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/f-0806.json
@@ -1,0 +1,70 @@
+{
+	"description": "Test `format=template`, `named args` and preferred property labells (#3548)",
+	"setup": [
+		{
+			"namespace": "SMW_NS_PROPERTY",
+			"page": "Some text",
+			"contents": "[[Has type::Text]] [[Preferred property label::ABC@en]] [[Preferred property label::DEF@fr]]"
+		},
+		{
+			"namespace": "NS_TEMPLATE",
+			"page": "Template/F0806ByNumber",
+			"contents": "<includeonly>{{{1}}}, {{{2}}}</includeonly>"
+		},
+		{
+			"namespace": "NS_TEMPLATE",
+			"page": "Template/F0806ByPreferredPropLabel",
+			"contents": "<includeonly>{{{Some text}}}</includeonly>"
+		},
+		{
+			"page": "Example/F0806/1",
+			"contents": "[[Some text::123]]"
+		},
+		{
+			"page": "Example/F0806/Q.1",
+			"contents": "{{#ask: [[Some text::123]] |?Some text |format=template |template=Template/F0806ByNumber }}"
+		},
+		{
+			"page": "Example/F0806/Q.2",
+			"contents": "{{#ask: [[Some text::123]] |?Some text |format=template |template=Template/F0806ByPreferredPropLabel |named args=yes }}"
+		}
+	],
+	"tests": [
+		{
+			"type": "parser",
+			"about": "#0 (#ask, `format=template` default)",
+			"subject": "Example/F0806/Q.1",
+			"assert-output": {
+				"to-contain": [
+					"123"
+				]
+			}
+		},
+		{
+			"type": "parser",
+			"about": "#1 (#ask, `format=template`, `named args`, use canonical label instead of preferred label)",
+			"subject": "Example/F0806/Q.2",
+			"assert-output": {
+				"to-contain": [
+					"123"
+				]
+			}
+		}
+	],
+	"settings": {
+		"wgContLang": "en",
+		"wgLang": "en",
+		"smwgPageSpecialProperties": [
+			"_MDAT"
+		],
+		"smwgNamespacesWithSemanticLinks": {
+			"NS_MAIN": true,
+			"SMW_NS_PROPERTY": true
+		}
+	},
+	"meta": {
+		"version": "2",
+		"is-incomplete": false,
+		"debug": false
+	}
+}

--- a/tests/phpunit/Unit/Query/PrintRequest/DeserializerTest.php
+++ b/tests/phpunit/Unit/Query/PrintRequest/DeserializerTest.php
@@ -24,7 +24,11 @@ class DeserializerTest extends \PHPUnit_Framework_TestCase {
 	 */
 	public function testDeserialize( $text, $showMode, $expectedLabel, $expectedMode, $expectedDataInstance, $expectedOutputFormat ) {
 
-		$instance = Deserializer::deserialize( $text, $showMode );
+		$options = [
+			'show_mode' => $showMode
+		];
+
+		$instance = Deserializer::deserialize( $text, $options );
 
 		$this->assertEquals(
 			$expectedLabel,


### PR DESCRIPTION
This PR is made in reference to: #3548

This PR addresses or contains:

- In a template context(`format=template`) use the canonical label so that the `named args` uses a language agnostic label representation

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed

Fixes #3548