### PR TITLE
Add `DisplayTitleFinder` service

### DIFF
--- a/includes/datavalues/SMW_DV_WikiPage.php
+++ b/includes/datavalues/SMW_DV_WikiPage.php
@@ -740,26 +740,10 @@ class SMWWikiPageValue extends SMWDataValue {
 			return '';
 		}
 
-		return $this->findDisplayTitleFor( $this->m_dataitem );
-	}
+		// Should come from the DataValueServiceFactory
+		$displayTitleFinder = ApplicationFactory::getInstance()->singleton( 'DisplayTitleFinder' );
 
-	private function findDisplayTitleFor( $subject ) {
-
-		$displayTitle = '';
-
-		$dataItems = ApplicationFactory::getInstance()->getCachedPropertyValuesPrefetcher()->getPropertyValues(
-			$subject,
-			new DIProperty( '_DTITLE' )
-		);
-
-		if ( $dataItems !== null && $dataItems !== [] ) {
-			$displayTitle = end( $dataItems )->getString();
-		} elseif ( $subject->getSubobjectName() !== '' ) {
-			// Check whether the base subject has a DISPLAYTITLE
-			return $this->findDisplayTitleFor( $subject->asBase() );
-		}
-
-		return $displayTitle;
+		return $displayTitleFinder->findDisplayTitle( $this->m_dataitem );
 	}
 
 }

--- a/src/DisplayTitleFinder.php
+++ b/src/DisplayTitleFinder.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace SMW;
+
+use InvalidArgumentException;
+
+/**
+ * @license GNU GPL v2+
+ * @since 3.1
+ *
+ * @author mwjames
+ */
+class DisplayTitleFinder {
+
+	/**
+	 * @var Store
+	 */
+	private $store;
+
+	/**
+	 * @var EntityCache
+	 */
+	private $entityCache;
+
+	/**
+	 * @since 3.1
+	 *
+	 * @param Store $store
+	 * @param EntityCache $entityCache
+	 */
+	public function __construct( Store $store, EntityCache $entityCache ) {
+		$this->store = $store;
+		$this->entityCache = $entityCache;
+	}
+
+	/**
+	 * @since 3.1
+	 *
+	 * @param DIWikiPage $subject
+	 *
+	 * @return string
+	 */
+	public function findDisplayTitle( DIWikiPage $subject ) {
+
+		$base = $subject->asBase();
+		$key = $this->entityCache->makeKey( 'displaytitle', $subject->getHash() );
+
+		if ( ( $displayTitle = $this->entityCache->fetch( $key ) ) !== false && $displayTitle !== null ) {
+			return $displayTitle;
+		}
+
+		$displayTitle = $this->findDisplayTitleFor( $subject );
+		$this->entityCache->save( $key, $displayTitle, EntityCache::TTL_WEEK );
+
+		// Connect to the base subject so that all keys can be flushed at
+		// the time the subject gets altered
+		$this->entityCache->associate( $base, $key );
+
+		return $displayTitle;
+	}
+
+	private function findDisplayTitleFor( $subject ) {
+
+		$displayTitle = '';
+
+		$dataItems = $this->store->getPropertyValues(
+			$subject,
+			new DIProperty( '_DTITLE' )
+		);
+
+		if ( $dataItems !== null && $dataItems !== [] ) {
+			$displayTitle = end( $dataItems )->getString();
+		} elseif ( $subject->getSubobjectName() !== '' ) {
+			// Check whether the base subject has a DISPLAYTITLE
+			return $this->findDisplayTitleFor( $subject->asBase() );
+		}
+
+		return $displayTitle;
+	}
+
+
+}

--- a/src/EntityCache.php
+++ b/src/EntityCache.php
@@ -67,6 +67,17 @@ class EntityCache {
 	/**
 	 * @since 3.1
 	 *
+	 * @param string|array $key
+	 *
+	 * @return string
+	 */
+	public function makeKey( ...$params ) {
+		return self::makeCacheKey( ...$params );
+	}
+
+	/**
+	 * @since 3.1
+	 *
 	 * @return []
 	 */
 	public function getStats() {

--- a/src/Services/SharedServicesContainer.php
+++ b/src/Services/SharedServicesContainer.php
@@ -56,6 +56,7 @@ use SMW\Query\Processor\QueryCreator;
 use SMW\Query\Processor\ParamListProcessor;
 use SMW\MediaWiki\IndicatorRegistry;
 use SMW\EntityCache;
+use SMW\DisplayTitleFinder;
 
 /**
  * @license GNU GPL v2+
@@ -742,6 +743,22 @@ class SharedServicesContainer implements CallbackContainer {
 				$lang->getPropertyLabels(),
 				$lang->getCanonicalPropertyLabels(),
 				$lang->getCanonicalDatatypeLabels()
+			);
+
+			return $propertyLabelFinder;
+		} );
+
+		/**
+		 * @var DisplayTitleFinder
+		 */
+		$containerBuilder->registerCallback( 'DisplayTitleFinder', function( $containerBuilder ) {
+			$containerBuilder->registerExpectedReturnType( 'DisplayTitleFinder', '\SMW\DisplayTitleFinder' );
+
+			$lang = Localizer::getInstance()->getLang();
+
+			$propertyLabelFinder = new DisplayTitleFinder(
+				$containerBuilder->singleton( 'Store', null ),
+				$containerBuilder->singleton( 'EntityCache' )
 			);
 
 			return $propertyLabelFinder;

--- a/tests/phpunit/Unit/DisplayTitleFinderTest.php
+++ b/tests/phpunit/Unit/DisplayTitleFinderTest.php
@@ -1,0 +1,117 @@
+<?php
+
+namespace SMW\Tests;
+
+use SMW\DisplayTitleFinder;
+use SMW\DIWikiPage;
+use SMWDIBlob as DIBlob;
+
+/**
+ * @covers \SMW\DisplayTitleFinder
+ * @group semantic-mediawiki
+ *
+ * @license GNU GPL v2+
+ * @since   3.1
+ *
+ * @author mwjames
+ */
+class DisplayTitleFinderTest extends \PHPUnit_Framework_TestCase {
+
+	private $store;
+	private $entityCache;
+
+	protected function setUp() {
+
+		$this->store = $this->getMockBuilder( '\SMW\Store' )
+			->disableOriginalConstructor()
+			->setMethods( [ 'getWikiPageSortKey' ] )
+			->getMockForAbstractClass();
+
+		$this->entityCache = $this->getMockBuilder( '\SMW\EntityCache' )
+			->disableOriginalConstructor()
+			->getMock();
+	}
+
+	public function testCanConstruct() {
+
+		$this->assertInstanceOf(
+			DisplayTitleFinder::class,
+			new DisplayTitleFinder( $this->store, $this->entityCache )
+		);
+	}
+
+	public function testFindDisplayTitle_WithoutSubobject() {
+
+		$subject = DIWikiPage::newFromText( 'Foo' );
+
+		$this->store->expects( $this->once() )
+			->method( 'getPropertyValues' )
+			->with( $this->equalTo( $subject ) )
+			->will( $this->returnValue( [ new DIBlob( 'Bar' ) ] ) );
+
+		$this->entityCache->expects( $this->once() )
+			->method( 'makeKey' )
+			->with(
+				$this->equalTo( 'displaytitle' ),
+				$this->equalTo( $subject->getHash() ) );
+
+		$this->entityCache->expects( $this->once() )
+			->method( 'fetch' )
+			->will( $this->returnValue( false ) );
+
+		$this->entityCache->expects( $this->once() )
+			->method( 'save' );
+
+		$this->entityCache->expects( $this->once() )
+			->method( 'associate' );
+
+		$instance = new DisplayTitleFinder(
+			$this->store,
+			$this->entityCache
+		);
+
+		$this->assertSame(
+			'Bar',
+			$instance->findDisplayTitle( $subject )
+		);
+	}
+
+	public function testFindDisplayTitle_WithSubobject() {
+
+		$subject = new DIWikiPage( 'Foo', NS_MAIN, '', 'abc' );
+
+		$this->store->expects( $this->any() )
+			->method( 'getPropertyValues' )
+			->withConsecutive(
+				[ $this->equalTo( $subject ) ],
+				[ $this->equalTo( $subject->asBase() ) ] )
+			->will( $this->onConsecutiveCalls( [], [ new DIBlob( 'foobar' ) ] ) );
+
+		$this->entityCache->expects( $this->once() )
+			->method( 'makeKey' )
+			->with(
+				$this->equalTo( 'displaytitle' ),
+				$this->equalTo( $subject->getHash() ) );
+
+		$this->entityCache->expects( $this->once() )
+			->method( 'fetch' )
+			->will( $this->returnValue( false ) );
+
+		$this->entityCache->expects( $this->once() )
+			->method( 'save' );
+
+		$this->entityCache->expects( $this->once() )
+			->method( 'associate' );
+
+		$instance = new DisplayTitleFinder(
+			$this->store,
+			$this->entityCache
+		);
+
+		$this->assertSame(
+			'foobar',
+			$instance->findDisplayTitle( $subject )
+		);
+	}
+
+}

--- a/tests/phpunit/Unit/EntityCacheTest.php
+++ b/tests/phpunit/Unit/EntityCacheTest.php
@@ -55,6 +55,11 @@ class EntityCacheTest extends \PHPUnit_Framework_TestCase {
 			$instance->makeCacheKey( $subject->getTitle() ),
 			$instance->makeCacheKey( 'Foo#0##' )
 		);
+
+		$this->assertEquals(
+			EntityCache::makeCacheKey( $subject->getTitle() ),
+			$instance->makeKey( 'Foo#0##' )
+		);
 	}
 
 	public function testContains() {

--- a/tests/phpunit/Unit/Factbox/CachedFactboxTest.php
+++ b/tests/phpunit/Unit/Factbox/CachedFactboxTest.php
@@ -46,7 +46,7 @@ class CachedFactboxTest extends \PHPUnit_Framework_TestCase {
 
 		$this->entityCache = $this->getMockBuilder( '\SMW\EntityCache' )
 			->disableOriginalConstructor()
-			->setMethods( ['fetch', 'save', 'saveSub', 'fetchSub' ] )
+			->setMethods( ['fetch', 'save', 'saveSub', 'fetchSub', 'associate' ] )
 			->getMock();
 
 		$this->testEnvironment->registerObject( 'EntityCache', $this->entityCache );


### PR DESCRIPTION
This PR is made in reference to: #

This PR addresses or contains:

- Adds `DisplayTitleFinder` as service and removes any specific `DTITLE` processing from `SMW_DV_WikiPage.php` hereby allows to remove the last active `CachedPropertyValuesPrefetcher` reference

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed
