### PR TITLE
Catch MWUnknownContentModelException

### DIFF
--- a/includes/ContentParser.php
+++ b/includes/ContentParser.php
@@ -176,12 +176,17 @@ class ContentParser {
 			$content = $this->getRevision()->getContentHandler()->makeEmptyContent();
 		}
 
-		$this->parserOutput = $content->getParserOutput(
-			$this->getTitle(),
-			$this->getRevision()->getId(),
-			null,
-			true
-		);
+		// Avoid "The content model 'xyz' is not registered on this wiki."
+		try {
+			$this->parserOutput = $content->getParserOutput(
+				$this->getTitle(),
+				$this->getRevision()->getId(),
+				null,
+				true
+			);
+		} catch( \MWUnknownContentModelException $e ) {
+			$this->parserOutput = null;
+		}
 
 		return $this;
 	}


### PR DESCRIPTION
This PR is made in reference to: #

This PR addresses or contains:

- Catch `MWUnknownContentModelException` in case the `ContentParser` encounters a page where the content handler is no longer available 
- See also https://github.com/wikimedia/mediawiki/blob/1fc72ed5ac9fef8eef3bef04c3d4860a6d086c61/includes/search/SearchEngine.php#L835-L841, https://github.com/wikimedia/mediawiki/blob/75f937543b8d3eaec8d3fe4f726c088ef028abab/includes/EditPage.php#L1101-L1109

This PR includes:
- [ ] Tests (unit/integration)
- [x] CI build passed

## Stack trace


```
Rebuilding semantic data ...
   ... selecting 1 to 695 IDs ...
   ... updating document no.                      284 (13%)[0a9d7aecb1973d70b510e2a6] [no req]   MWUnknownContentModelException from line 306 of \includes\content\ContentHandler.php: The content model 'smw/tei' is not registered on this wiki. See https://www.mediawiki.org/wiki/Content_handlers to find out which extensions handle this content model.
Backtrace:
#0 \includes\content\ContentHandler.php(243): ContentHandler::getForModelID(string)
#1 \includes\Title.php(4984): ContentHandler::getForTitle(Title)
#2 \includes\parser\Parser.php(892): Title->getPageLanguage()
#3 \includes\parser\Parser.php(2126): Parser->getTargetLanguage()
#4 \includes\parser\Parser.php(2091): Parser->replaceInternalLinks2(string)
#5 \includes\parser\Parser.php(1318): Parser->replaceInternalLinks(string)
#6 \includes\parser\Parser.php(443): Parser->internalParse(string)
#7 \includes\content\WikitextContent.php(323): Parser->parse(string, Title, ParserOptions, boolean, boolean, integer)
#8 \includes\content\AbstractContent.php(516): WikitextContent->fillParserOutput(Title, integer, ParserOptions, boolean, ParserOutput)
#9 \extensions\SemanticMediaWiki\includes\ContentParser.php(183): AbstractContent->getParserOutput(Title,
 integer, ParserOptions, boolean)
#10 \extensions\SemanticMediaWiki\includes\ContentParser.php(144): SMW\ContentParser->fetchFromContent()
#11 \extensions\SemanticMediaWiki\src\MediaWiki\Jobs\UpdateJob.php(196): SMW\ContentParser->parse()
#12 \extensions\SemanticMediaWiki\src\MediaWiki\Jobs\UpdateJob.php(136): SMW\MediaWiki\Jobs\UpdateJob->parse_content()
#13 \extensions\SemanticMediaWiki\src\MediaWiki\Jobs\UpdateJob.php(93): SMW\MediaWiki\Jobs\UpdateJob->doUpdate()
#14 \extensions\SemanticMediaWiki\src\SQLStore\Rebuilder\Rebuilder.php(237): SMW\MediaWiki\Jobs\UpdateJob->run()
#15 \extensions\SemanticMediaWiki\src\Maintenance\DataRebuilder.php(370): SMW\SQLStore\Rebuilder\Rebuilder->rebuild(integer)
#16 \extensions\SemanticMediaWiki\src\Maintenance\DataRebuilder.php(308): SMW\Maintenance\DataRebuilder->do_update(integer)
#17 \extensions\SemanticMediaWiki\src\Maintenance\DataRebuilder.php(183): SMW\Maintenance\DataRebuilder->rebuild_all()
#18 \extensions\SemanticMediaWiki\maintenance\rebuildData.php(172): SMW\Maintenance\DataRebuilder->rebuild()
#19 \maintenance\doMaintenance.php(94): SMW\Maintenance\RebuildData->execute()
#20 \extensions\SemanticMediaWiki\maintenance\rebuildData.php(230): require_once(string)
#21 {main}
```