### PR TITLE
Replace `cached.prefetcher.reset` with `InvalidateResultCache`, refs 3667

### DIFF
--- a/src/EventListenerRegistry.php
+++ b/src/EventListenerRegistry.php
@@ -80,72 +80,7 @@ class EventListenerRegistry implements EventListenerCollection {
 			}
 		);
 
-		/**
-		 * Emitted during NewRevisionFromEditComplete, ArticleDelete, TitleMoveComplete,
-		 * PropertyTableIdReferenceDisposer, ArticlePurge
-		 */
-		$this->eventListenerCollection->registerCallback(
-			'cached.prefetcher.reset', function( $dispatchContext ) {
-
-				if ( $dispatchContext->has( 'title' ) ) {
-					$subject = DIWikiPage::newFromTitle( $dispatchContext->get( 'title' ) );
-				} else{
-					$subject = $dispatchContext->get( 'subject' );
-				}
-
-				$context = $dispatchContext->has( 'context' ) ? $dispatchContext->get( 'context' ) : '';
-
-				$applicationFactory = ApplicationFactory::getInstance();
-
-				$logContext = [
-					'role' => 'developer',
-					'event' => 'cached.prefetcher.reset',
-					'origin' => $subject
-				];
-
-				$this->logger->info( '[Event] {event}: {origin}', $logContext );
-
-				$applicationFactory->singleton( 'CachedQueryResultPrefetcher' )->resetCacheBy(
-					$subject,
-					$context
-				);
-
-				if ( $dispatchContext->has( 'ask' ) ) {
-					$applicationFactory->singleton( 'CachedQueryResultPrefetcher' )->resetCacheBy(
-						$dispatchContext->get( 'ask' ),
-						$context
-					);
-				}
-
-				$dispatchContext->set( 'propagationstop', true );
-			}
-		);
-
-		$this->registerStateChangeEvents();
-
 		return $this->eventListenerCollection;
-	}
-
-	private function registerStateChangeEvents() {
-
-		/**
-		 * Emitted during ArticleDelete
-		 */
-		$this->eventListenerCollection->registerCallback(
-			'cached.update.marker.delete', function( $dispatchContext ) {
-
-				$cache = ApplicationFactory::getInstance()->getCache();
-
-				if ( $dispatchContext->has( 'subject' ) ) {
-					$cache->delete(
-						smwfCacheKey(
-							ParserData::CACHE_NAMESPACE,
-							$dispatchContext->get( 'subject' )->getHash()
-						)
-					);
-				}
-			}
-		);
 	}
 
 }

--- a/src/Events/InvalidateResultCacheEventListener.php
+++ b/src/Events/InvalidateResultCacheEventListener.php
@@ -5,6 +5,7 @@ namespace SMW\Events;
 use Onoi\EventDispatcher\EventListener;
 use Onoi\EventDispatcher\DispatchContext;
 use SMW\Query\Result\CachedQueryResultPrefetcher;
+use SMW\DIWikiPage;
 use Psr\Log\LoggerAwareTrait;
 
 /**
@@ -36,11 +37,30 @@ class InvalidateResultCacheEventListener implements EventListener {
 	 */
 	public function execute( DispatchContext $dispatchContext = null ) {
 
-		$context = $dispatchContext->get( 'context' );
-		$subject = $dispatchContext->get( 'subject' );
+		if ( $dispatchContext === null ) {
+			return;
+		}
+
+		if ( $dispatchContext->has( 'title' ) ) {
+			$subject = DIWikiPage::newFromTitle( $dispatchContext->get( 'title' ) );
+		} else{
+			$subject = $dispatchContext->get( 'subject' );
+		}
+
+		if ( $dispatchContext->has( 'context' ) ) {
+			$context = $dispatchContext->get( 'context' );
+		} else {
+			$context = 'n/a';
+		}
+
+		if ( $dispatchContext->has( 'dependency_list' ) ) {
+			$items = $dispatchContext->get( 'dependency_list' );
+		} else {
+			$items = [ $subject ];
+		}
 
 		$this->cachedQueryResultPrefetcher->invalidate(
-			$dispatchContext->get( 'dependency_list' ),
+			$items,
 			$context
 		);
 

--- a/src/MediaWiki/Hooks/ArticleDelete.php
+++ b/src/MediaWiki/Hooks/ArticleDelete.php
@@ -108,29 +108,13 @@ class ArticleDelete extends HookHandler {
 
 		$this->store->deleteSubject( $title );
 
-		$eventHandler = EventHandler::getInstance();
-		$dispatchContext = $eventHandler->newDispatchContext();
-
-		$dispatchContext->set( 'title', $title );
-		$dispatchContext->set( 'subject', $subject );
-		$dispatchContext->set( 'context', 'ArticleDelete' );
-
-		$eventHandler->getEventDispatcher()->dispatch(
-			'cached.prefetcher.reset',
-			$dispatchContext
-		);
-
-		// Removes any related update marker
-		$eventHandler->getEventDispatcher()->dispatch(
-			'cached.update.marker.delete',
-			$dispatchContext
-		);
-
 		$context = [
 			'context' => 'ArticleDelete',
-			'title' => $title
+			'title' => $title,
+			'subject' => $subject
 		];
 
+		$this->eventDispatcher->dispatch( 'InvalidateResultCache', $context );
 		$this->eventDispatcher->dispatch( 'InvalidateEntityCache', $context );
 	}
 

--- a/src/MediaWiki/Hooks/ArticlePurge.php
+++ b/src/MediaWiki/Hooks/ArticlePurge.php
@@ -41,7 +41,6 @@ class ArticlePurge {
 		$articleID = $title->getArticleID();
 
 		$settings = $applicationFactory->getSettings();
-
 		$cache = $applicationFactory->getCache();
 
 		if ( $articleID > 0 ) {
@@ -51,21 +50,8 @@ class ArticlePurge {
 			);
 		}
 
-		$dispatchContext = EventHandler::getInstance()->newDispatchContext();
-		$dispatchContext->set( 'title', $title );
-		$dispatchContext->set( 'context', 'ArticlePurge' );
-
 		if ( $settings->get( 'smwgQueryResultCacheRefreshOnPurge' ) ) {
-
-			$dispatchContext->set( 'ask', $applicationFactory->getStore()->getPropertyValues(
-				DIWikiPage::newFromTitle( $title ),
-				new DIProperty( '_ASK') )
-			);
-
-			EventHandler::getInstance()->getEventDispatcher()->dispatch(
-				'cached.prefetcher.reset',
-				$dispatchContext
-			);
+			$this->invalidateResultCache( $applicationFactory->getStore(), $title );
 		}
 
 		$context = [
@@ -76,6 +62,22 @@ class ArticlePurge {
 		$this->eventDispatcher->dispatch( 'InvalidateEntityCache', $context );
 
 		return true;
+	}
+
+	private function invalidateResultCache( $store, $title ) {
+
+		$dependency_list = $store->getPropertyValues(
+			DIWikiPage::newFromTitle( $title ),
+			new DIProperty( '_ASK' )
+		);
+
+		$context = [
+			'context' => 'ArticlePurge',
+			'title' => $title,
+			'dependency_list' => $dependency_list
+		];
+
+		$this->eventDispatcher->dispatch( 'InvalidateResultCache', $context );
 	}
 
 }

--- a/src/MediaWiki/Hooks/NewRevisionFromEditComplete.php
+++ b/src/MediaWiki/Hooks/NewRevisionFromEditComplete.php
@@ -100,26 +100,19 @@ class NewRevisionFromEditComplete extends HookHandler {
 			$schema
 		);
 
-		$dispatchContext = EventHandler::getInstance()->newDispatchContext();
-		$dispatchContext->set( 'title', $this->title );
-		$dispatchContext->set( 'context', 'NewRevisionFromEditComplete' );
+		$context = [
+			'context' => 'NewRevisionFromEditComplete',
+			'title' => $this->title
+		];
 
-		EventHandler::getInstance()->getEventDispatcher()->dispatch(
-			'cached.prefetcher.reset',
-			$dispatchContext
-		);
+		$this->eventDispatcher->dispatch( 'InvalidateResultCache', $context );
 
 		// If the concept was altered make sure to delete the cache
 		if ( $this->title->getNamespace() === SMW_NS_CONCEPT ) {
 			$applicationFactory->getStore()->deleteConceptCache( $this->title );
 		}
 
-		$parserData->pushSemanticDataToParserOutput();
-
-		$context = [
-			'context' => 'NewRevisionFromEditComplete',
-			'title' => $this->title
-		];
+		$parserData->copyToParserOutput();
 
 		$this->eventDispatcher->dispatch( 'InvalidateEntityCache', $context );
 

--- a/src/MediaWiki/Hooks/TitleMoveComplete.php
+++ b/src/MediaWiki/Hooks/TitleMoveComplete.php
@@ -4,7 +4,6 @@ namespace SMW\MediaWiki\Hooks;
 
 use Onoi\EventDispatcher\EventDispatcherAwareTrait;
 use SMW\ApplicationFactory;
-use SMW\EventHandler;
 use SMW\NamespaceExaminer;
 
 /**
@@ -61,32 +60,14 @@ class TitleMoveComplete {
 			);
 		}
 
-		$eventHandler = EventHandler::getInstance();
-
-		$dispatchContext = $eventHandler->newDispatchContext();
-		$dispatchContext->set( 'title', $oldTitle );
-		$dispatchContext->set( 'context', 'ArticleMove' );
-
-		$eventHandler->getEventDispatcher()->dispatch(
-			'cached.prefetcher.reset',
-			$dispatchContext
-		);
-
-		$dispatchContext = $eventHandler->newDispatchContext();
-		$dispatchContext->set( 'title', $newTitle );
-		$dispatchContext->set( 'context', 'ArticleMove' );
-
-		$eventHandler->getEventDispatcher()->dispatch(
-			'cached.prefetcher.reset',
-			$dispatchContext
-		);
-
 		$context = [
 			'context' => 'TitleMoveComplete'
 		];
 
-		$this->eventDispatcher->dispatch( 'InvalidateEntityCache', $context + [ 'title' => $oldTitle ] );
-		$this->eventDispatcher->dispatch( 'InvalidateEntityCache', $context + [ 'title' => $newTitle ] );
+		foreach ( [ 'InvalidateResultCache', 'InvalidateEntityCache' ] as $event ) {
+			$this->eventDispatcher->dispatch( $event, $context + [ 'title' => $oldTitle ] );
+			$this->eventDispatcher->dispatch( $event, $context + [ 'title' => $newTitle ] );
+		}
 
 		return true;
 	}

--- a/src/SQLStore/PropertyTableIdReferenceDisposer.php
+++ b/src/SQLStore/PropertyTableIdReferenceDisposer.php
@@ -265,24 +265,13 @@ class PropertyTableIdReferenceDisposer {
 		$eventHandler = EventHandler::getInstance();
 		$eventDispatcher = $eventHandler->getEventDispatcher();
 
-		$dispatchContext = $eventHandler->newDispatchContext();
-		$dispatchContext->set( 'subject', $subject );
-		$dispatchContext->set( 'context', 'PropertyTableIdReferenceDisposal' );
-
-		$eventDispatcher->dispatch(
-			'cached.prefetcher.reset',
-			$dispatchContext
-		);
-
 		$context = [
 			'context' => 'PropertyTableIdReferenceDisposal',
 			'title' => $subject->getTitle()
 		];
 
-		$eventDispatcher->dispatch(
-			'InvalidateEntityCache',
-			$context
-		);
+		$eventDispatcher->dispatch( 'InvalidateResultCache', $context );
+		$eventDispatcher->dispatch( 'InvalidateEntityCache', $context );
 	}
 
 }

--- a/tests/phpunit/Unit/EventListenerRegistryTest.php
+++ b/tests/phpunit/Unit/EventListenerRegistryTest.php
@@ -66,8 +66,6 @@ class EventListenerRegistryTest extends \PHPUnit_Framework_TestCase {
 		);
 
 		$this->verifyExporterResetEvent( $instance );
-		$this->verifyCachedPrefetcherResetEvent( $instance );
-		$this->verifyCachedUpdateMarkerDeleteEvent( $instance );
 	}
 
 	public function verifyExporterResetEvent( EventListenerCollection $instance ) {
@@ -76,53 +74,6 @@ class EventListenerRegistryTest extends \PHPUnit_Framework_TestCase {
 
 	public function verifyQueryComparatorResetEvent( EventListenerCollection $instance ) {
 		$this->assertListenerExecuteFor( 'query.comparator.reset', $instance, null );
-	}
-
-	public function verifyCachedPrefetcherResetEvent( EventListenerCollection $instance ) {
-
-		$dispatchContext = $this->eventDispatcherFactory->newDispatchContext();
-
-		$title = $this->getMockBuilder( '\Title' )
-			->disableOriginalConstructor()
-			->getMock();
-
-		$title->expects( $this->atLeastOnce() )
-			->method( 'getNamespace' )
-			->will( $this->returnValue( NS_MAIN ) );
-
-		$dispatchContext->set(
-			'title',
-			$title
-		);
-
-		$this->assertListenerExecuteFor(
-			'cached.prefetcher.reset',
-			$instance,
-			$dispatchContext
-		);
-	}
-
-	public function verifyCachedUpdateMarkerDeleteEvent( EventListenerCollection $instance ) {
-
-		$dispatchContext = $this->eventDispatcherFactory->newDispatchContext();
-
-		$subject = $this->getMockBuilder( '\SMW\DIWikiPage' )
-			->disableOriginalConstructor()
-			->getMock();
-
-		$subject->expects( $this->atLeastOnce() )
-			->method( 'getHash' );
-
-		$dispatchContext->set(
-			'subject',
-			$subject
-		);
-
-		$this->assertListenerExecuteFor(
-			'cached.update.marker.delete',
-			$instance,
-			$dispatchContext
-		);
 	}
 
 	private function assertListenerExecuteFor( $eventName, $instance, $dispatchContext = null ) {

--- a/tests/phpunit/Unit/MediaWiki/Hooks/ArticleDeleteTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Hooks/ArticleDeleteTest.php
@@ -108,7 +108,9 @@ class ArticleDeleteTest extends \PHPUnit_Framework_TestCase {
 
 		$this->eventDispatcher->expects( $this->atLeastOnce() )
 			->method( 'dispatch' )
-			->with( $this->equalTo( 'InvalidateEntityCache' ) );
+			->withConsecutive(
+				[ $this->equalTo( 'InvalidateResultCache' ) ],
+				[ $this->equalTo( 'InvalidateEntityCache' ) ] );
 
 		$instance = new ArticleDelete(
 			$store

--- a/tests/phpunit/Unit/MediaWiki/Hooks/NewRevisionFromEditCompleteTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Hooks/NewRevisionFromEditCompleteTest.php
@@ -75,7 +75,9 @@ class NewRevisionFromEditCompleteTest extends \PHPUnit_Framework_TestCase {
 
 		$this->eventDispatcher->expects( $expected ? $this->atLeastOnce() : $this->never() )
 			->method( 'dispatch' )
-			->with( $this->equalTo( 'InvalidateEntityCache' ) );
+			->withConsecutive(
+				[ $this->equalTo( 'InvalidateResultCache' ) ],
+				[ $this->equalTo( 'InvalidateEntityCache' ) ] );
 
 		$this->testEnvironment->withConfiguration( $settings );
 

--- a/tests/phpunit/Unit/MediaWiki/Hooks/TitleMoveCompleteTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Hooks/TitleMoveCompleteTest.php
@@ -66,6 +66,8 @@ class TitleMoveCompleteTest extends \PHPUnit_Framework_TestCase {
 		$this->eventDispatcher->expects( $this->atLeastOnce() )
 			->method( 'dispatch' )
 			->withConsecutive(
+				[ $this->equalTo( 'InvalidateResultCache' ) ],
+				[ $this->equalTo( 'InvalidateResultCache' ) ],
 				[ $this->equalTo( 'InvalidateEntityCache' ) ],
 				[ $this->equalTo( 'InvalidateEntityCache' ) ] );
 
@@ -99,6 +101,8 @@ class TitleMoveCompleteTest extends \PHPUnit_Framework_TestCase {
 		$this->eventDispatcher->expects( $this->atLeastOnce() )
 			->method( 'dispatch' )
 			->withConsecutive(
+				[ $this->equalTo( 'InvalidateResultCache' ) ],
+				[ $this->equalTo( 'InvalidateResultCache' ) ],
 				[ $this->equalTo( 'InvalidateEntityCache' ) ],
 				[ $this->equalTo( 'InvalidateEntityCache' ) ] );
 


### PR DESCRIPTION
This PR is made in reference to: #3667

This PR addresses or contains:

- Simplifies event handling when an entity is altered

This PR includes:
- [ ] Tests (unit/integration)
- [x] CI build passed
