### PR TITLE
Use different hook to add primary keys, refs 3559, 3683

### DIFF
--- a/docs/RELEASE-NOTES.md
+++ b/docs/RELEASE-NOTES.md
@@ -108,7 +108,6 @@ Changes to the DB are triggered by [#3644](https://github.com/SemanticMediaWiki/
 * [#3666](https://github.com/SemanticMediaWiki/SemanticMediaWiki/pull/3666) Uses HTML instead of JS for the SMWSearch namespace buttons
 * [#3675](https://github.com/SemanticMediaWiki/SemanticMediaWiki/pull/3675) Support definition of field index type
 * [#3682](https://github.com/SemanticMediaWiki/SemanticMediaWiki/pull/3682) Removed `IsFileCacheable` hook usage
-* [#3683](https://github.com/SemanticMediaWiki/SemanticMediaWiki/pull/3683) Added the `SMW::SQLStore::Installer::AddAuxiliaryIndicesBeforeCreateTablesComplete` hook
 * [#3685](https://github.com/SemanticMediaWiki/SemanticMediaWiki/pull/3685) Replaced qTip with tippy.js (3.4+) (#3811, #3812, #3813)
 * [#3712](https://github.com/SemanticMediaWiki/SemanticMediaWiki/pull/3712) Uses `smw_rev` field to check if an update is skippable
 * [#3721](https://github.com/SemanticMediaWiki/SemanticMediaWiki/pull/3721) Added index hint for page types

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -28,7 +28,6 @@ The general policy of the `Semantic MediaWiki` software and the development ther
 - No MediaWiki classes are modified, patched, or otherwise changed
 - Semantic MediaWiki tries to depend only on a selected pool of MediaWiki core classes (`Title`, `Wikipage`, `ParserOutput`, `Revision`, `Language` ... ) to minimize the potential for breakage during release changes
 - Use publicly available `Hooks` and `API` interfaces to extend MediaWiki with Semantic MediaWiki functions
-- Object interaction with MediaWiki objects should be done using accessors in the `SMW\MediaWiki` namespace
 
 ### Conventions
 
@@ -37,6 +36,7 @@ Some simple rules that developers and the project tries to follow (of course the
 - A `class` has a defined responsibility and boundary
 - Dependency injection goes before inheritance, meaning that all objects used in a class should be injected.
 - Instance creation (e.g. `new Foo( ... )`) is delegated to a factory service
+- Object interaction with MediaWiki objects should be done using accessors in the `SMW\MediaWiki` namespace
 - A factory service should avoid using conditionals (`if ... then ...`) to create an instance
 - Instance creation and dependency injection are done using a service locator or dependency builder
 - The top-level namespace is `SMW` and each component should be placed in a namespace that represents the main responsibility of the component
@@ -72,8 +72,9 @@ The project uses [Travis-CI](https://travis-ci.org/SemanticMediaWiki/SemanticMed
 - [Developing an extension](https://github.com/SemanticMediaWiki/SemanticMediaWiki/blob/master/docs/architecture/developing.extension.md)
 - [Register a custom datatype][datatype]
 - [Extending consistency checks on a property page](https://github.com/SemanticMediaWiki/SemanticMediaWiki/blob/master/docs/architecture/extending.declarationexaminer.md)
-- [Extending property annotators](https://github.com/SemanticMediaWiki/SemanticMediaWiki/blob/master/docs/architecture/extending.propertyannotator.md) for a core predefined property, also the [Semantic Extra Special Properties](https://github.com/SemanticMediaWiki/SemanticExtraSpecialProperties) extension provides a development space for deploying other predefined (special) property annotations
-- [Extending constraints and checks](https://github.com/SemanticMediaWiki/SemanticMediaWiki/blob/master/docs/architecture/extending.constraint.md)
+- [Extending property annotators](https://github.com/SemanticMediaWiki/SemanticMediaWiki/blob/master/docs/architecture/extending.propertyannotator.md) for core predefined properties, see also the [Semantic Extra Special Properties](https://github.com/SemanticMediaWiki/SemanticExtraSpecialProperties) extension that provides a development space for deploying other predefined (special) properties
+- [Extending constraints](https://github.com/SemanticMediaWiki/SemanticMediaWiki/blob/master/docs/architecture/extending.constraint.md) and their checks
+- Working with and [changing the table schema](https://github.com/SemanticMediaWiki/SemanticMediaWiki/blob/master/docs/architecture/changing.tableschema.md) of Semantic MediaWiki
 
 ## See also
 

--- a/docs/architecture/changing.tableschema.md
+++ b/docs/architecture/changing.tableschema.md
@@ -1,0 +1,22 @@
+### `src/SQLStore`
+
+- `TableSchemaManager` handles all table definitions used by Semantic MediaWiki in a RDBMS agnostic way
+- `Installer` takes the `TableSchemaManager` (holding the table definitions), `TableBuilder` (creates/updates/removes an individual table), and `TableBuildExaminer` (carries out some pre/post examination after tables have been added or removed) to perform the setup or removal of database tables used by Semantic MediaWiki
+
+### `src/SQLStore/TableBuilder`
+
+- Contains all classes that implement RDBMS specific execution commands and auxiliary classes to hold table definitions
+
+### `src/SQLStore/TableBuilder/Examiner`
+
+- Contains individual classes used by the `TableBuildExaminer`
+
+## Related hooks
+
+- `SMW::SQLStore::Installer::BeforeCreateTablesComplete`
+- `SMW::SQLStore::Installer::AfterCreateTablesComplete`
+- `SMW::SQLStore::Installer::AfterDropTablesComplete`
+
+## See also
+
+- [`hook.sqlstore.installer.beforecreatetablescomplete`](https://github.com/SemanticMediaWiki/SemanticMediaWiki/blob/master/docs/technical/code-snippets/hook.sqlstore.installer.beforecreatetablescomplete.md) contains an example how to modify table definitions (e.g. adding additional indices)

--- a/docs/technical/README.md
+++ b/docs/technical/README.md
@@ -25,7 +25,7 @@ This document collects technical resources to help improve the understanding of 
     - [API](api.md) provides an overview for available API modules
     - [Hooks](hooks.md) provided by Semantic MediaWiki
     - [Search](https://github.com/SemanticMediaWiki/SemanticMediaWiki/blob/master/src/MediaWiki/Search/README.md) `Special:Search` integration
-  - SQLStore ( [Overview](https://github.com/SemanticMediaWiki/SemanticMediaWiki/blob/master/src/SQLStore/README.md), [QueryEngine](https://github.com/SemanticMediaWiki/SemanticMediaWiki/blob/master/src/SQLStore/QueryEngine/README.md), [Installer](https://github.com/SemanticMediaWiki/SemanticMediaWiki/blob/master/docs/technical/doc.installer.md))
+  - SQLStore ( [Overview](https://github.com/SemanticMediaWiki/SemanticMediaWiki/blob/master/src/SQLStore/README.md), [QueryEngine](https://github.com/SemanticMediaWiki/SemanticMediaWiki/blob/master/src/SQLStore/QueryEngine/README.md))
   - SPARQLStore ([Overview](https://github.com/SemanticMediaWiki/SemanticMediaWiki/blob/master/src/SPARQLStore/README.md))
   - ElasticStore ([Overview](https://github.com/SemanticMediaWiki/SemanticMediaWiki/blob/master/src/Elastic/README.md))
 - tests

--- a/docs/technical/code-snippets/hook.sqlstore.installer.beforecreatetablescomplete.md
+++ b/docs/technical/code-snippets/hook.sqlstore.installer.beforecreatetablescomplete.md
@@ -1,0 +1,47 @@
+## SMW::SQLStore::Installer::BeforeCreateTablesComplete
+
+### Adding primary keys
+
+[#3559][issue-3559], Demonstrate how to add primary keys to existing table definitions in Semantic MediaWiki.
+
+```php
+use Hooks;
+
+Hooks::register( 'SMW::SQLStore::Installer::BeforeCreateTablesComplete', function( array $tables, $messageReporter ) {
+
+	// #3559
+	// Incomplete list to only showcase how to modify the table definition
+	$primaryKeys = [
+		'smw_di_blob'     => 'p_id,s_id,o_hash',
+		'smw_di_bool'     => 'p_id,s_id,o_value',
+		'smw_di_uri'      => 'p_id,s_id,o_serialized',
+		'smw_di_coords'   => 'p_id,s_id,o_serialized',
+		'smw_di_wikipage' => 'p_id,s_id,o_id',
+		'smw_di_number'   => 'p_id,s_id,o_serialized',
+
+		// smw_fpt ...
+
+		'smw_prop_stats'  => 'p_id',
+		'smw_query_links' => 's_id,o_id'
+	];
+
+	/**
+	 * @var \Onoi\MessageReporter\MessageReporter
+	 */
+	$messageReporter->reportMessage( "Setting primary indices.\n" );
+
+	/**
+	 * @var \SMW\SQLStore\TableBuilder\Table[]
+	 */
+	foreach ( $tables as $table ) {
+		if ( isset( $primaryKeys[$table->getName()] ) ) {
+			$table->setPrimaryKey( $primaryKeys[$table->getName()] );
+		}
+	}
+
+	$messageReporter->reportMessage( "\ndone.\n" );
+
+} );
+```
+
+[issue-3559]:https://github.com/SemanticMediaWiki/SemanticMediaWiki/issues/3559

--- a/docs/technical/doc.installer.md
+++ b/docs/technical/doc.installer.md
@@ -1,1 +1,0 @@
-![image](https://cloud.githubusercontent.com/assets/1245473/20027799/8a8e06b4-a31e-11e6-8b03-aaa1859e6937.png)

--- a/docs/technical/hooks.md
+++ b/docs/technical/hooks.md
@@ -372,27 +372,24 @@ Hooks::register( 'SMW::Admin::TaskHandlerFactory', function( &$taskHandlers, $st
 } );
 </pre>
 
-
-### SMW::SQLStore::Installer::AddAuxiliaryIndicesBeforeCreateTablesComplete
+### SMW::SQLStore::Installer::BeforeCreateTablesComplete
 
 * Version: 3.1
 * Description: Hook allows to add additional indices
 * Reference class: `SMW\SQLStore\Installer`
 
-When using this hook, please make sure you understand the implications adding auxiliary indices which are not part of the core declaration and may alter performance expectations.
+When using this hook, please make sure you understand the implications of modifying the standard table definition (e.g add auxiliary indices) which are not part of the core declaration and may alter performance expectations.
 
 <pre>
 use Hooks;
 
-Hooks::register( 'SMW::SQLStore::Installer::AddAuxiliaryIndicesBeforeCreateTablesComplete', function( &$auxiliaryIndices ) {
+Hooks::register( 'SMW::SQLStore::Installer::BeforeCreateTablesComplete', function( array $tables, $messageReporter ) {
 
-	$auxiliaryIndices = [
-		// SMW table name => index declaration
-		'smw_query_links' => [ "s_id,o_id", "PRIMARY KEY" ],
-	];
-
+	// Modify the table definitions
 } );
 </pre>
+
+[`hook.sqlstore.installer.beforecreatetablescomplete`](https://github.com/SemanticMediaWiki/SemanticMediaWiki/blob/master/docs/technical/code-snippets/hook.sqlstore.installer.beforecreatetablescomplete.md)
 
 ### SMW::Factbox::OverrideRevisionID
 

--- a/src/SQLStore/Installer.php
+++ b/src/SQLStore/Installer.php
@@ -148,20 +148,17 @@ class Installer implements MessageReporter {
 		);
 
 		// #3559
-		$auxiliaryIndices = [];
+		$tables = $this->tableSchemaManager->getTables();
 
 		Hooks::run(
-			'SMW::SQLStore::Installer::AddAuxiliaryIndicesBeforeCreateTablesComplete',
+			'SMW::SQLStore::Installer::BeforeCreateTablesComplete',
 			[
-				&$auxiliaryIndices
+				$tables,
+				$messageReporter
 			]
 		);
 
-		$this->tableSchemaManager->addAuxiliaryIndices(
-			$auxiliaryIndices
-		);
-
-		foreach ( $this->tableSchemaManager->getTables() as $table ) {
+		foreach ( $tables as $table ) {
 			$this->tableBuilder->create( $table );
 		}
 

--- a/src/SQLStore/TableBuilder/Table.php
+++ b/src/SQLStore/TableBuilder/Table.php
@@ -14,6 +14,10 @@ use RuntimeException;
  */
 class Table {
 
+	const TYPE_FIELDS = 'fields';
+	const TYPE_INDICES = 'indices';
+	const TYPE_DEFAULTS = 'defaults';
+
 	/**
 	 * @var string
 	 */
@@ -83,7 +87,16 @@ class Table {
 	 * @param string|array $fieldType
 	 */
 	public function addColumn( $fieldName, $fieldType ) {
-		$this->attributes['fields'][$fieldName] = $fieldType;
+		$this->attributes[self::TYPE_FIELDS][$fieldName] = $fieldType;
+	}
+
+	/**
+	 * @since 3.1
+	 *
+	 * @param string $key
+	 */
+	public function setPrimaryKey( $key ) {
+		$this->addIndex( [ $key, "PRIMARY KEY" ], 'pri' );
 	}
 
 	/**
@@ -101,9 +114,9 @@ class Table {
 		}
 
 		if ( $key !== null ) {
-			$this->attributes['indices'][$key] = $index;
+			$this->attributes[self::TYPE_INDICES][$key] = $index;
 		} else {
-			$this->attributes['indices'][] = $index;
+			$this->attributes[self::TYPE_INDICES][] = $index;
 		}
 	}
 
@@ -114,7 +127,7 @@ class Table {
 	 * @param string|int $default
 	 */
 	public function addDefault( $fieldName, $default ) {
-		$this->attributes['defaults'][$fieldName] = $default;
+		$this->attributes[self::TYPE_DEFAULTS][$fieldName] = $default;
 	}
 
 	/**
@@ -127,7 +140,7 @@ class Table {
 	 */
 	public function addOption( $key, $option ) {
 
-		if ( $key === 'fields' || $key === 'indices' || $key === 'defaults' ) {
+		if ( in_array( $key, [ self::TYPE_FIELDS, self::TYPE_INDICES, self::TYPE_DEFAULTS ] ) ) {
 			throw new RuntimeException( "$key is a reserved option key." );
 		}
 

--- a/src/SQLStore/TableSchemaManager.php
+++ b/src/SQLStore/TableSchemaManager.php
@@ -38,11 +38,6 @@ class TableSchemaManager {
 	/**
 	 * @var []
 	 */
-	private $auxiliaryIndices = [];
-
-	/**
-	 * @var []
-	 */
 	private $options = [];
 
 	/**
@@ -140,15 +135,6 @@ class TableSchemaManager {
 		}
 
 		return null;
-	}
-
-	/**
-	 * @since 3.1
-	 *
-	 * @param array $auxiliaryIndices
-	 */
-	public function addAuxiliaryIndices( array $auxiliaryIndices ) {
-		$this->auxiliaryIndices = $auxiliaryIndices;
 	}
 
 	/**
@@ -416,13 +402,7 @@ class TableSchemaManager {
 			return;
 		}
 
-		$name = $table->getName();
-
-		if ( isset( $this->auxiliaryIndices[$name] ) ) {
-			$table->addIndex( $this->auxiliaryIndices[$name] );
-		}
-
-		$this->tables[] = $table;
+		$this->tables[$table->getName()] = $table;
 	}
 
 }

--- a/tests/phpunit/Unit/SQLStore/TableBuilder/TableTest.php
+++ b/tests/phpunit/Unit/SQLStore/TableBuilder/TableTest.php
@@ -85,6 +85,23 @@ class TableTest extends \PHPUnit_Framework_TestCase {
 		);
 	}
 
+	public function testSetPrimaryKey() {
+
+		$instance = new Table( 'Foo' );
+		$instance->setPrimaryKey( 'abc,def' );
+
+		$expected = [
+			'indices' => [
+				'pri' => [ 'abc,def', 'PRIMARY KEY' ]
+			]
+		];
+
+		$this->assertEquals(
+			$expected,
+			$instance->getAttributes()
+		);
+	}
+
 	public function testAddIndexWithSpaceThrowsException() {
 
 		$instance = new Table( 'Foo' );


### PR DESCRIPTION
This PR is made in reference to: #3559, #3683

This PR addresses or contains:

- I wasn't so happy about how the `SMW::SQLStore::Installer::AddAuxiliaryIndicesBeforeCreateTablesComplete` (#3683) hook turned out and is replaced by this PR with `SMW::SQLStore::Installer::BeforeCreateTablesComplete`
- `hook.sqlstore.installer.beforecreatetablescomplete.md` demonstrates how to use the hook and provides an answer to #3559
- `Table` adds a `setPrimaryKey` method

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed
