### PR TITLE
Allow to use a callable to construct a DV instance

### DIFF
--- a/src/DataTypeRegistry.php
+++ b/src/DataTypeRegistry.php
@@ -477,7 +477,16 @@ class DataTypeRegistry {
 	 * @return boolean
 	 */
 	public function hasDataTypeClassById( $typeId ) {
-		return isset( $this->typeClasses[$typeId] ) && class_exists( $this->typeClasses[$typeId] );
+
+		if ( !isset( $this->typeClasses[$typeId] ) ) {
+			return false;
+		}
+
+		if ( is_callable( $this->typeClasses[$typeId] ) ) {
+			return true;
+		}
+
+		return class_exists( $this->typeClasses[$typeId] );
 	}
 
 	/**

--- a/src/Services/DataValueServiceFactory.php
+++ b/src/Services/DataValueServiceFactory.php
@@ -135,6 +135,10 @@ class DataValueServiceFactory {
 			return $this->containerBuilder->create( self::TYPE_INSTANCE . $typeId );
 		}
 
+		if ( is_callable( $class ) ) {
+			return $class( $typeId );
+		}
+
 		// Legacy invocation, for those that have not been defined yet!s
 		return new $class( $typeId );
 	}

--- a/tests/phpunit/Unit/DataTypeRegistryTest.php
+++ b/tests/phpunit/Unit/DataTypeRegistryTest.php
@@ -61,6 +61,26 @@ class DataTypeRegistryTest extends \PHPUnit_Framework_TestCase {
 		);
 	}
 
+	public function testRegisterDatatypeWithCallable() {
+
+		$callback = function() {
+			return new FooValue();
+		};
+
+		$this->dataTypeRegistry->registerDataType(
+			'_foo', $callback, DataItem::TYPE_NOTYPE, 'FooValue'
+		);
+
+		$this->assertTrue(
+			$this->dataTypeRegistry->hasDataTypeClassById( '_foo' )
+		);
+
+		$this->assertInstanceOf(
+			'\Closure',
+			$this->dataTypeRegistry->getDataTypeClassById( '_foo' )
+		);
+	}
+
 	public function testRegisterDatatype() {
 
 		$this->assertNull(


### PR DESCRIPTION
This PR is made in reference to: #

This PR addresses or contains:

- Preparation for allowing the `PluggableType` interface (soon to be introduced) to define callables so that the DV factory can create an instance from a callable instead of using static class strings

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed
