### PR TITLE
DV, add `callable` function, refs 3899

### DIFF
--- a/includes/datavalues/SMW_DataValue.php
+++ b/includes/datavalues/SMW_DataValue.php
@@ -187,6 +187,11 @@ abstract class SMWDataValue {
 	private $descriptionBuilderRegistry;
 
 	/**
+	 * @var []
+	 */
+	private $callables = [];
+
+	/**
 	 * Constructor.
 	 *
 	 * @param string $typeid
@@ -799,42 +804,46 @@ abstract class SMWDataValue {
 	}
 
 	/**
-	 * @since 2.3
+	 * @since 3.1
 	 *
-	 * @param string $name
-	 * @param array $parameters
+	 * @param string $key
+	 * @param callable $callable
 	 *
-	 * @return mixed
 	 * @throws RuntimeException
 	 */
-	public function getExtraneousFunctionFor( $name, array $parameters = [] ) {
-		return $this->dataValueServiceFactory->newExtraneousFunctionByName( $name, $parameters );
-	}
+	public function addCallable( $key, callable $callable ) {
 
-	/**
-	 * @since 3.0
-	 *
-	 * @param string $key
-	 * @param mixed $data
-	 */
-	public function setExtensionData( $key, $data ) {
-		$this->extenstionData[$key] = $data;
-	}
-
-	/**
-	 * @since 3.0
-	 *
-	 * @param string $key
-	 *
-	 * @return mixed
-	 */
-	public function getExtensionData( $key ) {
-
-		if ( isset( $this->extenstionData[$key] ) ) {
-			return $this->extenstionData[$key];
+		if ( isset( $this->callables[$key] ) ) {
+			throw new RuntimeException( "`$key` is alread in use, please clear the callable first!" );
 		}
 
-		return null;
+		$this->callables[$key] = $callable;
+	}
+
+	/**
+	 * @since 3.1
+	 *
+	 * @param string $key
+	 *
+	 * @return callable
+	 * @throws RuntimeException
+	 */
+	public function getCallable( $key ) {
+
+		if ( !isset( $this->callables[$key] ) ) {
+			throw new RuntimeException( "`$key` as callable is unknown or not registered!" );
+		}
+
+		return $this->callables[$key];
+	}
+
+	/**
+	 * @since 3.1
+	 *
+	 * @param string $key
+	 */
+	public function clearCallable( $key ) {
+		unset( $this->callables[$key] );
 	}
 
 	/**
@@ -965,6 +974,10 @@ abstract class SMWDataValue {
 		}
 
 		$this->dataValueServiceFactory->getConstraintValueValidator()->validate( $this );
+	}
+
+	function __destruct() {
+		$this->callables = [];
 	}
 
 }

--- a/src/Services/DataValueServiceFactory.php
+++ b/src/Services/DataValueServiceFactory.php
@@ -56,11 +56,6 @@ class DataValueServiceFactory {
 	const TYPE_VALIDATOR = '__dv.validator.';
 
 	/**
-	 * Extraneous service
-	 */
-	const TYPE_EXT_FUNCTION = '__dv.ext.func.';
-
-	/**
 	 * @var ContainerBuilder
 	 */
 	private $containerBuilder;
@@ -95,30 +90,6 @@ class DataValueServiceFactory {
 	 */
 	public function getDataValueFactory() {
 		return DataValueFactory::getInstance();
-	}
-
-	/**
-	 * Imported functions registered with DataTypeRegistry::registerExtraneousFunction
-	 *
-	 * @since 2.5
-	 *
-	 * @param array $extraneousFunctions
-	 */
-	public function importExtraneousFunctions( array $extraneousFunctions ) {
-		foreach ( $extraneousFunctions as $serviceName => $calllback ) {
-			$this->containerBuilder->registerCallback( self::TYPE_EXT_FUNCTION . $serviceName, $calllback );
-		}
-	}
-
-	/**
-	 * @since 2.5
-	 *
-	 * @param string $serviceName
-	 *
-	 * @return mixed
-	 */
-	public function newExtraneousFunctionByName( $serviceName ) {
-		return $this->containerBuilder->create( self::TYPE_EXT_FUNCTION . $serviceName );
 	}
 
 	/**

--- a/tests/phpunit/Unit/DataTypeRegistryTest.php
+++ b/tests/phpunit/Unit/DataTypeRegistryTest.php
@@ -223,40 +223,6 @@ class DataTypeRegistryTest extends \PHPUnit_Framework_TestCase {
 		);
 	}
 
-	public function testExtraneousCallbackFunction() {
-
-		$lang = $this->getMockBuilder( '\SMW\Lang\Lang' )
-			->disableOriginalConstructor()
-			->getMock();
-
-		$lang->expects( $this->once() )
-			->method( 'getDatatypeLabels' )
-			->will( $this->returnValue( [] ) );
-
-		$lang->expects( $this->once() )
-			->method( 'getDatatypeAliases' )
-			->will( $this->returnValue( [] ) );
-
-		$lang->expects( $this->once() )
-			->method( 'getCanonicalDatatypeLabels' )
-			->will( $this->returnValue( [] ) );
-
-		$instance = new DataTypeRegistry( $lang );
-		$arg = 'foo';
-
-		$instance->registerExtraneousFunction(
-			'foo',
-			function ( $arg ) {
-				return 'bar' . $arg;
-			}
-		);
-
-		$this->assertInternalType(
-			'array',
-			$instance->getExtraneousFunctions()
-		);
-	}
-
 	public function testLookupByLabelIsCaseInsensitive() {
 		$caseVariants = [
 			'page',
@@ -434,7 +400,11 @@ class DataTypeRegistryTest extends \PHPUnit_Framework_TestCase {
 		}
 	}
 
-	public function testExtensionData() {
+	public function testRegisterCallableGetCallablesByTypeId() {
+
+		$callback = function() {
+			return 'foo';
+		};
 
 		$lang = $this->getMockBuilder( '\SMW\Lang\Lang' )
 			->disableOriginalConstructor()
@@ -460,11 +430,13 @@ class DataTypeRegistryTest extends \PHPUnit_Framework_TestCase {
 			'__foo', '\SMW\Tests\FooValue', DataItem::TYPE_NOTYPE, 'FooValue'
 		);
 
-		$instance->setExtensionData( '__foo', [ 'ext.test' => 'test' ] );
+		$instance->registerCallable(
+			'__foo', 'ext.test', $callback
+		);
 
 		$this->assertEquals(
-			[ 'ext.test' => 'test' ],
-			$instance->getExtensionData( '__foo' )
+			[ 'ext.test' => $callback ],
+			$instance->getCallablesByTypeId( '__foo' )
 		);
 	}
 

--- a/tests/phpunit/Unit/Services/DataValueServiceFactoryTest.php
+++ b/tests/phpunit/Unit/Services/DataValueServiceFactoryTest.php
@@ -140,34 +140,6 @@ class DataValueServiceFactoryTest extends \PHPUnit_Framework_TestCase {
 		$instance->getValueFormatter( $dataValue );
 	}
 
-	public function testImportExtraneousFunctions() {
-
-		$this->containerBuilder->expects( $this->atLeastOnce() )
-			->method( 'registerCallback' )
-			->with( $this->stringContains( DataValueServiceFactory::TYPE_EXT_FUNCTION . 'Foo' ) );
-
-		$instance = new DataValueServiceFactory(
-			$this->containerBuilder
-		);
-
-		$instance->importExtraneousFunctions( [
-			'Foo' => function() { return 'Foo'; }
-		] );
-	}
-
-	public function testNewExtraneousFunctionByName() {
-
-		$this->containerBuilder->expects( $this->atLeastOnce() )
-			->method( 'create' )
-			->with( $this->stringContains( DataValueServiceFactory::TYPE_EXT_FUNCTION . 'Foo' ) );
-
-		$instance = new DataValueServiceFactory(
-			$this->containerBuilder
-		);
-
-		$instance->newExtraneousFunctionByName( 'Foo' );
-	}
-
 	public function testGetPropertyRestrictionExaminer() {
 
 		$propertyRestrictionExaminer = $this->getMockBuilder( '\SMW\PropertyRestrictionExaminer' )


### PR DESCRIPTION
This PR is made in reference to: #3899

This PR addresses or contains:

- Removes `DataValue::getExtraneousFunctionFor` (only used by `CitationReferenceValue`) to simplify invocations
- Adds `DataValue::addCallable` as replacement

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed
