### PR TITLE
DV, provide `semantic.data` as callable context, refs 3900

### DIFF
--- a/src/Parser/InTextAnnotationParser.php
+++ b/src/Parser/InTextAnnotationParser.php
@@ -130,6 +130,15 @@ class InTextAnnotationParser {
 	}
 
 	/**
+	 * @since 3.1
+	 *
+	 * @return SemanticData
+	 */
+	public function getSemanticData() {
+		return $this->parserData->getSemanticData();
+	}
+
+	/**
 	 * Parsing text before an article is displayed or previewed, strip out
 	 * semantic properties and add them to the ParserOutput object
 	 *
@@ -152,6 +161,9 @@ class InTextAnnotationParser {
 		$this->addRedirectTargetAnnotationFromText(
 			$text
 		);
+
+		// Set context
+		$this->dataValueFactory->addCallable( 'semantic.data', [ $this, 'getSemanticData' ] );
 
 		// Obscure [/] to find a set of [[ :: ... ]] while those in-between are left for
 		// decoding in a post-processing so that the regex can split the text
@@ -177,7 +189,10 @@ class InTextAnnotationParser {
 			$this->parserData->addExtraParserKey( 'userlang' );
 		}
 
-		$this->parserData->pushSemanticDataToParserOutput();
+		$this->parserData->copyToParserOutput();
+
+		// Remove context
+		$this->dataValueFactory->clearCallable( 'semantic.data' );
 
 		$this->parserData->addLimitReport(
 			'intext-parsertime',

--- a/src/ParserFunctions/SetParserFunction.php
+++ b/src/ParserFunctions/SetParserFunction.php
@@ -68,6 +68,15 @@ class SetParserFunction {
 	}
 
 	/**
+	 * @since 3.1
+	 *
+	 * @return SemanticData
+	 */
+	public function getSemanticData() {
+		return $this->parserData->getSemanticData();
+	}
+
+	/**
 	 * @since  1.9
 	 *
 	 * @param ParserParameterProcessor $parameters
@@ -87,6 +96,11 @@ class SetParserFunction {
 			unset( $parametersToArray['template'] );
 		}
 
+		$dataValueFactory = DataValueFactory::getInstance();
+
+		// Set context
+		$dataValueFactory->addCallable( 'semantic.data', [ $this, 'getSemanticData' ] );
+
 		foreach ( $parametersToArray as $property => $values ) {
 
 			$last = count( $values ) - 1; // -1 because the key starts with 0
@@ -97,7 +111,7 @@ class SetParserFunction {
 					$value = $this->stripMarkerDecoder->decode( $value );
 				}
 
-				$dataValue = DataValueFactory::getInstance()->newDataValueByText(
+				$dataValue = $dataValueFactory->newDataValueByText(
 						$property,
 						$value,
 						false,
@@ -121,7 +135,10 @@ class SetParserFunction {
 			}
 		}
 
-		$this->parserData->pushSemanticDataToParserOutput();
+		$this->parserData->copyToParserOutput();
+
+		// Remove context
+		$dataValueFactory->clearCallable( 'semantic.data' );
 
 		$html = $this->templateRenderer->render() . $this->messageFormatter
 			->addFromArray( $parameters->getErrors() )

--- a/src/ParserFunctions/SubobjectParserFunction.php
+++ b/src/ParserFunctions/SubobjectParserFunction.php
@@ -142,6 +142,15 @@ class SubobjectParserFunction {
 	}
 
 	/**
+	 * @since 3.1
+	 *
+	 * @return SemanticData
+	 */
+	public function getSemanticData() {
+		return $this->parserData->getSemanticData();
+	}
+
+	/**
 	 * @since 1.9
 	 *
 	 * @param ParserParameterProcessor $params
@@ -157,7 +166,7 @@ class SubobjectParserFunction {
 			$this->parserData->getSemanticData()->addSubobject( $this->subobject );
 		}
 
-		$this->parserData->pushSemanticDataToParserOutput();
+		$this->parserData->copyToParserOutput();
 
 		$html = $this->messageFormatter->addFromArray( $this->subobject->getErrors() )
 			->addFromArray( $this->parserData->getErrors() )
@@ -193,6 +202,10 @@ class SubobjectParserFunction {
 		);
 
 		$subject = $this->subobject->getSubject();
+		$dataValueFactory = DataValueFactory::getInstance();
+
+		// Set context
+		$dataValueFactory->addCallable( 'semantic.data', [ $this, 'getSemanticData' ] );
 
 		foreach ( $parameters as $property => $values ) {
 
@@ -206,7 +219,7 @@ class SubobjectParserFunction {
 
 			foreach ( $values as $value ) {
 
-				$dataValue = DataValueFactory::getInstance()->newDataValueByText(
+				$dataValue = $dataValueFactory->newDataValueByText(
 						$property,
 						$value,
 						false,
@@ -214,10 +227,14 @@ class SubobjectParserFunction {
 					);
 
 				$this->subobject->addDataValue( $dataValue );
+
 			}
 		}
 
 		$this->augment( $this->subobject->getSemanticData() );
+
+		// Remove context
+		$dataValueFactory->clearCallable( 'semantic.data' );
 
 		return true;
 	}


### PR DESCRIPTION
This PR is made in reference to: #3900

This PR addresses or contains:

- Provides a possibility for a `Constraint` to access the in-memory `SemanticData` as context of an individual `DataValue`

This PR includes:
- [ ] Tests (unit/integration)
- [x] CI build passed
