### PR TITLE
TableBuilder, move predefined properties check to own class, refs 3801

### DIFF
--- a/src/SQLStore/SQLStoreFactory.php
+++ b/src/SQLStore/SQLStoreFactory.php
@@ -40,10 +40,7 @@ use SMW\SQLStore\Lookup\MonolingualTextLookup;
 use SMW\SQLStore\TableBuilder\TableBuilder;
 use SMW\SQLStore\TableBuilder\TableSchemaManager;
 use SMW\SQLStore\TableBuilder\TableBuildExaminer;
-use SMW\SQLStore\TableBuilder\Examiner\HashField;
-use SMW\SQLStore\TableBuilder\Examiner\FixedProperties;
-use SMW\SQLStore\TableBuilder\Examiner\TouchedField;
-use SMW\SQLStore\TableBuilder\Examiner\IdBorder;
+use SMW\SQLStore\TableBuilder\TableBuildExaminerFactory;
 use SMW\SQLStore\Rebuilder\EntityValidator;
 use SMW\SQLStore\Rebuilder\Rebuilder;
 use SMW\Utils\CircularReferenceGuard;
@@ -404,10 +401,7 @@ class SQLStoreFactory {
 
 		$tableBuildExaminer = new TableBuildExaminer(
 			$this->store,
-			new HashField( $this->store ),
-			new FixedProperties( $this->store ),
-			new TouchedField( $this->store ),
-			new IdBorder( $this->store )
+			new TableBuildExaminerFactory()
 		);
 
 		$tableSchemaManager = new TableSchemaManager(

--- a/src/SQLStore/TableBuilder/Examiner/PredefinedProperties.php
+++ b/src/SQLStore/TableBuilder/Examiner/PredefinedProperties.php
@@ -1,0 +1,180 @@
+<?php
+
+namespace SMW\SQLStore\TableBuilder\Examiner;
+
+use Onoi\MessageReporter\MessageReporterAwareTrait;
+use SMW\Exception\PredefinedPropertyLabelMismatchException;
+use SMW\SQLStore\SQLStore;
+use SMW\DIProperty;
+use SMW\MediaWiki\Collator;
+
+/**
+ * @license GNU GPL v2+
+ * @since 3.1
+ *
+ * @author mwjames
+ */
+class PredefinedProperties {
+
+	use MessageReporterAwareTrait;
+
+	/**
+	 * @var SQLStore
+	 */
+	private $store;
+
+	/**
+	 * @var []
+	 */
+	private $predefinedPropertyList = [];
+
+	/**
+	 * @since 3.1
+	 *
+	 * @param SQLStore $store
+	 */
+	public function __construct( SQLStore $store ) {
+		$this->store = $store;
+	}
+
+	/**
+	 * @since 3.1
+	 *
+	 * @param array $predefinedPropertyList
+	 */
+	public function setPredefinedPropertyList( array $predefinedPropertyList ) {
+		$this->predefinedPropertyList = $predefinedPropertyList;
+	}
+
+	/**
+	 * Create some initial DB entries for important built-in properties. Having
+	 * the DB contents predefined allows us to safe DB calls when certain data
+	 * is needed. At the same time, the entries in the DB make sure that DB-based
+	 * functions work as with all other properties.
+	 *
+	 * @since 3.1
+	 *
+	 * @param array $opts
+	 */
+	public function check( array $opts = [] ) {
+
+		// now write actual properties; do that each time, it is cheap enough
+		// and we can update sortkeys by current language
+		$this->messageReporter->reportMessage( "Checking predefined properties ...\n" );
+		$this->messageReporter->reportMessage( "   ... initialize predefined properties ...\n" );
+
+		foreach ( $this->predefinedPropertyList as $prop => $id ) {
+
+			try{
+				$property = new DIProperty( $prop );
+			} catch ( PredefinedPropertyLabelMismatchException $e ) {
+				$property = null;
+				$this->messageReporter->reportMessage( "   ... skipping {$prop} due to invalid registration ...\n" );
+			}
+
+			if ( $property === null ) {
+				continue;
+			}
+
+			$this->doUpdate( $property, $id );
+		}
+
+		$this->messageReporter->reportMessage( "   ... done.\n" );
+	}
+
+	private function doUpdate( $property, $id ) {
+
+		$connection = $this->store->getConnection( DB_MASTER );
+
+		// Try to find the ID for a non-fixed predefined property
+		if ( $id === null ) {
+			$row = $connection->selectRow(
+				SQLStore::ID_TABLE,
+				[
+					'smw_id'
+				],
+				[
+					'smw_title' => $property->getKey(),
+					'smw_namespace' => SMW_NS_PROPERTY,
+					'smw_subobject' => ''
+				],
+				__METHOD__
+			);
+
+			if ( $row !== false ) {
+				$id = $row->smw_id;
+			}
+		}
+
+		if ( $id === null ) {
+			return;
+		}
+
+		$label = $property->getCanonicalLabel();
+
+		$iw = $this->store->getObjectIds()->getPropertyInterwiki(
+			$property
+		);
+
+		$row = $connection->selectRow(
+			SQLStore::ID_TABLE,
+			[
+				'smw_proptable_hash',
+				'smw_hash'
+			],
+			[
+				'smw_id' => $id
+			],
+			__METHOD__
+		);
+
+		if ( $row === false ) {
+			$row = (object)[ 'smw_proptable_hash' => null, 'smw_hash' => null ];
+		}
+
+		$connection->replace(
+			SQLStore::ID_TABLE,
+			[ 'smw_id' ],
+			[
+				'smw_id' => $id,
+				'smw_title' => $property->getKey(),
+				'smw_namespace' => SMW_NS_PROPERTY,
+				'smw_iw' =>  $iw,
+				'smw_subobject' => '',
+				'smw_sortkey' => $label,
+				'smw_sort' => Collator::singleton()->getSortKey( $label ),
+				'smw_proptable_hash' => $row->smw_proptable_hash,
+				'smw_hash' => $row->smw_hash
+			],
+			__METHOD__
+		);
+
+		if ( $id === null ) {
+			return;
+		}
+
+		$row = $connection->selectRow(
+			SQLStore::PROPERTY_STATISTICS_TABLE,
+			[ 'p_id' ],
+			[ 'p_id' => $id ],
+			__METHOD__
+		);
+
+		// Entry is available therefore don't try to override the count
+		// value
+		if ( $row !== false ) {
+			return;
+		}
+
+		$connection->insert(
+			SQLStore::PROPERTY_STATISTICS_TABLE,
+			[
+				'p_id' => $id,
+				'usage_count' => 0,
+				'null_count' => 0
+			],
+			__METHOD__
+		);
+	}
+
+}

--- a/src/SQLStore/TableBuilder/TableBuildExaminerFactory.php
+++ b/src/SQLStore/TableBuilder/TableBuildExaminerFactory.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace SMW\SQLStore\TableBuilder;
+
+use SMW\SQLStore\SQLStore;
+use SMW\SQLStore\TableBuilder\Examiner\HashField;
+use SMW\SQLStore\TableBuilder\Examiner\FixedProperties;
+use SMW\SQLStore\TableBuilder\Examiner\TouchedField;
+use SMW\SQLStore\TableBuilder\Examiner\IdBorder;
+use SMW\SQLStore\TableBuilder\Examiner\PredefinedProperties;
+
+/**
+ * @private
+ *
+ * @license GNU GPL v2+
+ * @since 3.1
+ *
+ * @author mwjames
+ */
+class TableBuildExaminerFactory {
+
+	/**
+	 * @since 3.1
+	 *
+	 * @return HashField
+	 */
+	public function newHashField( SQLStore $store ) {
+		return new HashField( $store );
+	}
+
+	/**
+	 * @since 3.1
+	 *
+	 * @return FixedProperties
+	 */
+	public function newFixedProperties( SQLStore $store ) {
+		return new FixedProperties( $store );
+	}
+
+	/**
+	 * @since 3.1
+	 *
+	 * @return TouchedField
+	 */
+	public function newTouchedField( SQLStore $store ) {
+		return new TouchedField( $store );
+	}
+
+	/**
+	 * @since 3.1
+	 *
+	 * @return HashField
+	 */
+	public function newIdBorder( SQLStore $store ) {
+		return new IdBorder( $store );
+	}
+
+	/**
+	 * @since 3.1
+	 *
+	 * @return PredefinedProperties
+	 */
+	public function newPredefinedProperties( SQLStore $store ) {
+		return new PredefinedProperties( $store );
+	}
+
+}

--- a/tests/phpunit/Unit/SQLStore/TableBuilder/Examiner/PredefinedPropertiesTest.php
+++ b/tests/phpunit/Unit/SQLStore/TableBuilder/Examiner/PredefinedPropertiesTest.php
@@ -1,0 +1,192 @@
+<?php
+
+namespace SMW\Tests\SQLStore\TableBuilder\Examiner;
+
+use SMW\SQLStore\TableBuilder\Examiner\PredefinedProperties;
+use SMW\Tests\TestEnvironment;
+
+/**
+ * @covers \SMW\SQLStore\TableBuilder\Examiner\PredefinedProperties
+ * @group semantic-mediawiki
+ *
+ * @license GNU GPL v2+
+ * @since 3.1
+ *
+ * @author mwjames
+ */
+class PredefinedPropertiesTest extends \PHPUnit_Framework_TestCase {
+
+	private $spyMessageReporter;
+	private $store;
+
+	protected function setUp() {
+		parent::setUp();
+		$this->spyMessageReporter = TestEnvironment::getUtilityFactory()->newSpyMessageReporter();
+
+		$this->store = $this->getMockBuilder( '\SMW\SQLStore\SQLStore' )
+			->disableOriginalConstructor()
+			->getMock();
+	}
+
+	public function testCanConstruct() {
+
+		$this->assertInstanceOf(
+			PredefinedProperties::class,
+			new PredefinedProperties( $this->store )
+		);
+	}
+
+	public function testCheckOnValidProperty() {
+
+		$row = [
+			'smw_id' => 42,
+			'smw_iw' => '',
+			'smw_proptable_hash' => '',
+			'smw_hash' => ''
+		];
+
+		$idTable = $this->getMockBuilder( '\stdClass' )
+			->setMethods( [ 'getPropertyInterwiki', 'moveSMWPageID', 'getPropertyTableHashes' ] )
+			->getMock();
+
+		$idTable->expects( $this->atLeastOnce() )
+			->method( 'getPropertyInterwiki' )
+			->will( $this->returnValue( 'Foo' ) );
+
+		$connection = $this->getMockBuilder( '\SMW\MediaWiki\Database' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$connection->expects( $this->atLeastOnce() )
+			->method( 'selectRow' )
+			->will( $this->returnValue( (object)$row ) );
+
+		$connection->expects( $this->atLeastOnce() )
+			->method( 'replace' );
+
+		$store = $this->getMockBuilder( '\SMW\SQLStore\SQLStore' )
+			->disableOriginalConstructor()
+			->setMethods( [ 'getObjectIds', 'getConnection' ] )
+			->getMock();
+
+		$store->expects( $this->any() )
+			->method( 'getConnection' )
+			->will( $this->returnValue( $connection ) );
+
+		$store->expects( $this->any() )
+			->method( 'getObjectIds' )
+			->will( $this->returnValue( $idTable ) );
+
+		$instance = new PredefinedProperties(
+			$store
+		);
+
+		$instance->setPredefinedPropertyList( [
+			'Foo' => 42
+		] );
+
+		$instance->setMessageReporter( $this->spyMessageReporter );
+		$instance->check();
+	}
+
+	public function testCheckOnValidProperty_NotFixed() {
+
+		$row = [
+			'smw_id' => 42,
+			'smw_iw' => '',
+			'smw_proptable_hash' => '',
+			'smw_hash' => ''
+		];
+
+		$idTable = $this->getMockBuilder( '\stdClass' )
+			->setMethods( [ 'moveSMWPageID', 'getPropertyInterwiki' ] )
+			->getMock();
+
+		$connection = $this->getMockBuilder( '\SMW\MediaWiki\Database' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$connection->expects( $this->at( 0 ) )
+			->method( 'selectRow' )
+			->with(
+				$this->anything(),
+				$this->anything(),
+				$this->equalTo( [
+					'smw_title' => 'Foo',
+					'smw_namespace' => SMW_NS_PROPERTY,
+					'smw_subobject' => '' ] ) )
+			->will( $this->returnValue( (object)$row ) );
+
+		$connection->expects( $this->at( 1 ) )
+			->method( 'selectRow' )
+			->will( $this->returnValue( (object)$row ) );
+
+		$store = $this->getMockBuilder( '\SMW\SQLStore\SQLStore' )
+			->disableOriginalConstructor()
+			->setMethods( [ 'getObjectIds', 'getConnection' ] )
+			->getMock();
+
+		$store->expects( $this->any() )
+			->method( 'getConnection' )
+			->will( $this->returnValue( $connection ) );
+
+		$store->expects( $this->any() )
+			->method( 'getObjectIds' )
+			->will( $this->returnValue( $idTable ) );
+
+		$instance = new PredefinedProperties(
+			$store
+		);
+
+		$instance->setPredefinedPropertyList( [
+			'Foo' => null
+		] );
+
+		$instance->setMessageReporter( $this->spyMessageReporter );
+		$instance->check();
+	}
+
+	public function testCheckOnInvalidProperty() {
+
+		$idTable = $this->getMockBuilder( '\stdClass' )
+			->setMethods( [ 'getPropertyInterwiki', 'moveSMWPageID' ] )
+			->getMock();
+
+		$idTable->expects( $this->never() )
+			->method( 'getPropertyInterwiki' );
+
+		$connection = $this->getMockBuilder( '\SMW\MediaWiki\Database' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$store = $this->getMockBuilder( '\SMW\SQLStore\SQLStore' )
+			->disableOriginalConstructor()
+			->setMethods( [ 'getObjectIds', 'getConnection' ] )
+			->getMock();
+
+		$store->expects( $this->any() )
+			->method( 'getConnection' )
+			->will( $this->returnValue( $connection ) );
+
+		$store->expects( $this->any() )
+			->method( 'getObjectIds' )
+			->will( $this->returnValue( $idTable ) );
+
+		$instance = new PredefinedProperties(
+			$store
+		);
+
+		$instance->setPredefinedPropertyList( [
+			'_FOO' => 42
+		] );
+
+		$instance->setMessageReporter( $this->spyMessageReporter );
+		$instance->check();
+
+		$this->assertContains(
+			'invalid registration',
+			$this->spyMessageReporter->getMessagesAsString()
+		);
+	}
+
+}

--- a/tests/phpunit/Unit/SQLStore/TableBuilder/TableBuildExaminerFactoryTest.php
+++ b/tests/phpunit/Unit/SQLStore/TableBuilder/TableBuildExaminerFactoryTest.php
@@ -1,0 +1,88 @@
+<?php
+
+namespace SMW\Tests\SQLStore\TableBuildExaminerFactory;
+
+use SMW\SQLStore\TableBuilder\TableBuildExaminerFactory;
+
+/**
+ * @covers \SMW\SQLStore\TableBuilder\TableBuildExaminerFactory
+ * @group semantic-mediawiki
+ *
+ * @license GNU GPL v2+
+ * @since 3.1
+ *
+ * @author mwjames
+ */
+class TableBuildExaminerFactoryTest extends \PHPUnit_Framework_TestCase {
+
+	public function testCanConstructHashField() {
+
+		$store = $this->getMockBuilder( '\SMW\SQLStore\SQLStore' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$instance = new TableBuildExaminerFactory();
+
+		$this->assertInstanceOf(
+			'\SMW\SQLStore\TableBuilder\Examiner\HashField',
+			$instance->newHashField( $store )
+		);
+	}
+
+	public function testCanConstructFixedProperties() {
+
+		$store = $this->getMockBuilder( '\SMW\SQLStore\SQLStore' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$instance = new TableBuildExaminerFactory();
+
+		$this->assertInstanceOf(
+			'\SMW\SQLStore\TableBuilder\Examiner\FixedProperties',
+			$instance->newFixedProperties( $store )
+		);
+	}
+
+	public function testCanConstructTouchedField() {
+
+		$store = $this->getMockBuilder( '\SMW\SQLStore\SQLStore' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$instance = new TableBuildExaminerFactory();
+
+		$this->assertInstanceOf(
+			'\SMW\SQLStore\TableBuilder\Examiner\TouchedField',
+			$instance->newTouchedField( $store )
+		);
+	}
+
+	public function testCanConstructIdBorder() {
+
+		$store = $this->getMockBuilder( '\SMW\SQLStore\SQLStore' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$instance = new TableBuildExaminerFactory();
+
+		$this->assertInstanceOf(
+			'\SMW\SQLStore\TableBuilder\Examiner\IdBorder',
+			$instance->newIdBorder( $store )
+		);
+	}
+
+	public function testCanConstructPredefinedProperties() {
+
+		$store = $this->getMockBuilder( '\SMW\SQLStore\SQLStore' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$instance = new TableBuildExaminerFactory();
+
+		$this->assertInstanceOf(
+			'\SMW\SQLStore\TableBuilder\Examiner\PredefinedProperties',
+			$instance->newPredefinedProperties( $store )
+		);
+	}
+
+}


### PR DESCRIPTION
This PR is made in reference to: #3801

This PR addresses or contains:

- Moving the predefined properties check from `TableBuildExaminer` to its own `PredefinedProperties` class
- Adds `TableBuildExaminerFactory` to isolate registered examiners

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed
