### PR TITLE
Add `PluggableDataType`

### DIFF
--- a/docs/technical/code-snippets/register.custom.datatype.md
+++ b/docs/technical/code-snippets/register.custom.datatype.md
@@ -1,8 +1,132 @@
-## Register new datatype
+The following examples demonstrate how to register a new [data type][datatype] using the `SMW::DataType::initTypes` hook in Semantic MediaWiki. The convention is for custom datatypes that the key uses `___` as leading identifier to distinguish them from those defined by Semantic MediaWiki itself.
 
-This example shows how to register a new dataType/dataValue in Semantic MediaWiki and the convention for the datatype key is to use `___` as leading identifer to distinguish them from those defined by Semantic MediaWiki itself.
+## Register a new datatype
 
-### SMW::DataType::initTypes
+To register a new data type, two methods are provided:
+
+- Implement the `PluggableDataType` interface or
+- Use the provided `DataTypeRegistry::registerDatatype` methods
+
+### Using the `PluggableDataType` interface
+
+The `PluggableDataType` interface is provided with beginning of SMW 3.1 as means to register pluggable data types.
+
+```php
+namespace Foo\DataTypes;
+
+use SMW\PluggableDataType;
+use Foo\DataValues\FooValue;
+use SMWDataItem as DataItem;
+
+/**
+ * @license GNU GPL v2+
+ * @since 0.1
+ *
+ * @author mwjames
+ */
+class FooPluggableType implements PluggableDataType {
+
+	/**
+	 * @since 0.1
+	 *
+	 * {@inheritDoc}
+	 */
+	public function getTypeId() {
+		return FooValue::TYPE_ID;
+	}
+
+	/**
+	 * Can return a string or callable (using a factory)
+	 *
+	 * @since 0.1
+	 *
+	 * {@inheritDoc}
+	 */
+	public function getClass() {
+		return [ $this, 'newFooValue' ];
+	}
+
+	/**
+	 * @since 0.1
+	 *
+	 * {@inheritDoc}
+	 */
+	public function getItemType() {
+		return DataItem::TYPE_BLOB;
+	}
+
+	/**
+	 * @since 0.1
+	 *
+	 * {@inheritDoc}
+	 */
+	public function getLabel() {
+		return false;
+	}
+
+	/**
+	 * @since 0.1
+	 *
+	 * {@inheritDoc}
+	 */
+	public function getAliases() {
+		return [];
+	}
+
+	/**
+	 * @since 0.1
+	 *
+	 * {@inheritDoc}
+	 */
+	public function isSubType() {
+		return false;
+	}
+
+	/**
+	 * @since 0.1
+	 *
+	 * {@inheritDoc}
+	 */
+	public function isBrowsableType() {
+		return false;
+	}
+
+	/**
+	 * @since 0.1
+	 *
+	 * {@inheritDoc}
+	 */
+	public function getCallables() {
+		return [];
+	}
+
+	/**
+	 * @since 0.1
+	 *
+	 * @return FooValue
+	 */
+	public function newFooValue( $typeId ) {
+		return new FooValue( $typeId );
+	}
+
+}
+```
+
+```php
+use Hooks;
+use Foo\DataTypes\FooPluggableType
+
+Hooks::register( 'SMW::DataType::initTypes', function ( $dataTypeRegistry ) {
+
+	$dataTypeRegistry->registerPluggableDataType(
+		new FooPluggableType()
+	);
+
+	return true;
+};
+```
+
+### Using `DataTypeRegistry::registerDatatype`
 
 ```php
 use Hooks;
@@ -16,11 +140,6 @@ Hooks::register( 'SMW::DataType::initTypes', function ( $dataTypeRegistry ) {
 		DataItem::TYPE_BLOB
 	);
 
-	$dataTypeRegistry->setOption(
-		'foovalue.SomeSetting',
-		42
-	);
-
 	return true;
 };
 ```
@@ -28,6 +147,8 @@ Hooks::register( 'SMW::DataType::initTypes', function ( $dataTypeRegistry ) {
 ### DataValue representation
 
 ```php
+namespace Foo\DataValues;
+
 class FooValue extends DataValue {
 
 	/**
@@ -50,10 +171,12 @@ class FooValue extends DataValue {
 ### Usage
 
 ```php
-$fooValue = DataValueFactory::getInstance()->newTypeIdValue(
+$dataValue = DataValueFactory::getInstance()->newDataValueByType(
 	'___foo_bar',
 	'Bar'
 )
 
-$fooValue->getShortWikiText();
+$dataValue->getShortWikiText();
 ```
+
+[datatype]:https://github.com/SemanticMediaWiki/SemanticMediaWiki/blob/master/docs/architecture/datamodel.datatype.md

--- a/src/DataTypeRegistry.php
+++ b/src/DataTypeRegistry.php
@@ -501,6 +501,33 @@ class DataTypeRegistry {
 	}
 
 	/**
+	 * @since 3.1
+	 *
+	 * @param PluggableDataType $pluggableDataType
+	 */
+	public function registerPluggableDataType( PluggableDataType $pluggableDataType ) {
+
+		$typeId = $pluggableDataType->getTypeId();
+
+		$this->registerDataType(
+			$typeId,
+			$pluggableDataType->getClass(),
+			$pluggableDataType->getItemType(),
+			$pluggableDataType->getLabel(),
+			$pluggableDataType->isSubType(),
+			$pluggableDataType->isBrowsableType()
+		);
+
+		foreach ( $pluggableDataType->getAliases() as $alias ) {
+			$this->registerDataTypeAlias( $typeId, $alias );
+		}
+
+		foreach ( $pluggableDataType->getCallables() as $key => $callable ) {
+			$this->registerCallable( $typeId, $key, $callable );
+		}
+	}
+
+	/**
 	 * This function allows for registered types to add additional data or functions
 	 * required by an individual DataValue of that type.
 	 *

--- a/src/PluggableDataType.php
+++ b/src/PluggableDataType.php
@@ -1,0 +1,90 @@
+<?php
+
+namespace SMW;
+
+/**
+ * @license GNU GPL v2+
+ * @since 3.1
+ *
+ * @author mwjames
+ */
+interface PluggableDataType {
+
+	/**
+	 * Returns the type_id and is by convention for an third-party extension
+	 * indicated by two underscores such as `__some_type`.
+	 *
+	 * @since 3.1
+	 *
+	 * @return string
+	 */
+	public function getTypeId();
+
+	/**
+	 * Returns the class name or callable associated with the type_id.
+	 *
+	 * @since 3.1
+	 *
+	 * @return string|callable
+	 */
+	public function getClass();
+
+	/**
+	 * Returns the DataItem::TYPE_...
+	 *
+	 * @since 3.1
+	 *
+	 * @return string
+	 */
+	public function getItemType();
+
+	/**
+	 * Returns a label or false for types that cannot be accessed by users.
+	 *
+	 * @since 3.1
+	 *
+	 * @return string
+	 */
+	public function getLabel();
+
+	/**
+	 * Returns possible aliases for a type
+	 *
+	 * @since 3.1
+	 *
+	 * @return []
+	 */
+	public function getAliases();
+
+	/**
+	 * Returns whether it is a sub type (container, subobject etc.) or not
+	 *
+	 * @since 3.1
+	 *
+	 * @return boolean
+	 */
+	public function isSubType();
+
+	/**
+	 * Returns whether the type is browseable or not
+	 *
+	 * @since 3.1
+	 *
+	 * @return boolean
+	 */
+	public function isBrowsableType();
+
+	/**
+	 * Allows to return additional callable and accessible callbacks on an
+	 * individual DataVaue of that type.
+	 *
+	 * The expected form is:
+	 * [ 'some.key' => callable ]
+	 *
+	 * @since 3.1
+	 *
+	 * @return []
+	 */
+	public function getCallables();
+
+}

--- a/tests/phpunit/Unit/DataTypeRegistryTest.php
+++ b/tests/phpunit/Unit/DataTypeRegistryTest.php
@@ -81,6 +81,25 @@ class DataTypeRegistryTest extends \PHPUnit_Framework_TestCase {
 		);
 	}
 
+	public function testRegisterPluggableDataType() {
+
+		$pluggableDataType = $this->getMockBuilder( '\SMW\PluggableDataType' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$pluggableDataType->expects( $this->once() )
+			->method( 'getAliases' )
+			->will( $this->returnValue( [] ) );
+
+		$pluggableDataType->expects( $this->once() )
+			->method( 'getCallables' )
+			->will( $this->returnValue( [] ) );
+
+		$this->dataTypeRegistry->registerPluggableDataType(
+			$pluggableDataType
+		);
+	}
+
 	public function testRegisterDatatype() {
 
 		$this->assertNull(


### PR DESCRIPTION
This PR is made in reference to: #

This PR addresses or contains:

- Until recently (#3899) it was not possible for custom types to control the construction of corresonding DV instances leaving out any possibility for dependency injection or the necessity to rely on global state.  The new `PluggableDataType` allows for custom types to define relevant fields together with how a DV instance should be constructed.

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed
