### PR TITLE
Add `purgeEntityCache.php`

### DIFF
--- a/i18n/en.json
+++ b/i18n/en.json
@@ -561,6 +561,7 @@
 	"smw-admin-maintenance-script-description-setupstore": "Sets up the storage backend selected in <code>LocalSettings.php</code>.",
 	"smw-admin-maintenance-script-description-updateentitycollation": "Updates the <code>smw_sort</code> field in the <code>SQLStore</code> (in accordance with the [https://www.semantic-mediawiki.org/wiki/Help:$smwgEntityCollation $smwgEntityCollation] setting).",
 	"smw-admin-maintenance-script-description-populatehashfield": "Populates the <code>smw_hash</code> field for rows missing the value.",
+	"smw-admin-maintenance-script-description-purgeentitycache": "Purge cache entries for known entities and their associated data.",
 	"smw-livepreview-loading": "Loading...",
 	"smw-sp-searchbyproperty-description": "This page provides a simple [https://www.semantic-mediawiki.org/wiki/Help:Browsing_interfaces browsing interface] for finding entities described by a property and a named value. Other available search interfaces include the [[Special:PageProperty|page property search]], and the [[Special:Ask|ask query builder]].",
 	"smw-sp-searchbyproperty-resultlist-header": "List of results",

--- a/maintenance/purgeEntityCache.php
+++ b/maintenance/purgeEntityCache.php
@@ -1,0 +1,166 @@
+<?php
+
+namespace SMW\Maintenance;
+
+use Onoi\MessageReporter\MessageReporter;
+use SMW\ApplicationFactory;
+use SMW\SQLStore\SQLStore;
+use SMW\Setup;
+use SMW\Store;
+use SMW\DIWikiPage;
+use SMW\DIProperty;
+
+$basePath = getenv( 'MW_INSTALL_PATH' ) !== false ? getenv('MW_INSTALL_PATH' ) : __DIR__ . '/../../..';
+
+require_once $basePath . '/maintenance/Maintenance.php';
+
+/**
+ * @license GNU GPL v2+
+ * @since 3.1
+ *
+ * @author mwjames
+ */
+class PurgeEntityCache extends \Maintenance {
+
+	/**
+	 * @var Store
+	 */
+	private $store;
+
+	/**
+	 * @var MessageReporter
+	 */
+	private $messageReporter;
+
+	/**
+	 * @since 3.1
+	 */
+	public function __construct() {
+		$this->mDescription = "Purge cache entries for known entities and their associated data.";
+		parent::__construct();
+	}
+
+	/**
+	 * @since 3.1
+	 *
+	 * @param MessageReporter $messageReporter
+	 */
+	public function setMessageReporter( MessageReporter $messageReporter ) {
+		$this->messageReporter = $messageReporter;
+	}
+
+	/**
+	 * @since 3.1
+	 *
+	 * @param string $message
+	 */
+	public function reportMessage( $message ) {
+
+		if ( $this->messageReporter !== null ) {
+			return $this->messageReporter->reportMessage( $message );
+		}
+
+		$this->output( $message );
+	}
+
+	/**
+	 * @see Maintenance::execute
+	 */
+	public function execute() {
+
+		if ( !Setup::isEnabled() ) {
+			$this->reportMessage( "\nYou need to have Semantic MediaWiki enabled in order to run the maintenance script!\n" );
+			exit;
+		}
+
+		$this->store = ApplicationFactory::getInstance()->getStore();
+
+		$this->reportMessage(
+			"\nThe script purges cache entries and their associate data for actively\n" .
+			"used entities.\n"
+		);
+
+		$this->reportMessage( "\nSelecting entities ...\n" );
+		$this->doPurge( $this->fetchRows() );
+
+		$this->reportMessage( "   ... done.\n" );
+
+		return true;
+	}
+
+	private function fetchRows() {
+
+		$connection = $this->store->getConnection( 'mw.db' );
+
+		return $connection->select(
+			SQLStore::ID_TABLE,
+			[
+				'smw_id',
+				'smw_title',
+				'smw_namespace',
+				'smw_iw',
+				'smw_subobject'
+			],
+			[
+				"smw_subobject=''",
+				'smw_iw != ' . $connection->addQuotes( SMW_SQL3_SMWDELETEIW )
+			],
+			__METHOD__,
+			[ 'ORDER BY' => 'smw_id' ]
+		);
+	}
+
+	private function doPurge( \Iterator $rows ) {
+
+		$entityCache = ApplicationFactory::getInstance()->getEntityCache();
+		$connection = $this->store->getConnection( 'mw.db' );
+
+		$count = $rows->numRows();
+		$i = 0;
+
+		if ( $count == 0 ) {
+			return $this->reportMessage( "   ... no entities selected ...\n"  );
+		}
+
+		$this->reportMessage( "   ... counting $count rows ...\n"  );
+
+		foreach ( $rows as $row ) {
+			$namespace = (int)$row->smw_namespace;
+
+			if (  $namespace === SMW_NS_PROPERTY ) {
+				$property = DIProperty::newFromUserLabel( $row->smw_title );
+				$subject = $property->getCanonicalDiWikiPage();
+			} else {
+				$subject = new DIWikiPage(
+					$row->smw_title,
+					$namespace,
+					$row->smw_iw,
+					$row->smw_subobject
+				);
+			}
+
+			$this->reportMessage(
+				$this->progress( $row->smw_id, $i++, $count )
+			);
+
+			$entityCache->invalidate( $subject );
+		}
+
+		$this->reportMessage( "\n"  );
+	}
+
+	/**
+	 * @see Maintenance::addDefaultParams
+	 */
+	protected function addDefaultParams() {
+		parent::addDefaultParams();
+	}
+
+	private function progress( $id, $i, $count ) {
+		return "\r". sprintf( "%-35s%s", "   ... purging document no.", sprintf( "%s (%1.0f%%)", $id, round( ( $i / $count ) * 100 ) ) );
+	}
+
+}
+
+$maintClass = 'SMW\Maintenance\PurgeEntityCache';
+require_once( RUN_MAINTENANCE_IF_MAIN );

--- a/src/EntityCache.php
+++ b/src/EntityCache.php
@@ -224,6 +224,9 @@ class EntityCache {
 			return;
 		}
 
+		// Associate only with the main subject (given that a Title can be injected)
+		$subject = $subject->asBase();
+
 		$k = $this->makeCacheKey( $subject );
 		$res = $this->cache->fetch( $k );
 
@@ -261,6 +264,8 @@ class EntityCache {
 		if ( !$subject instanceof DIWikiPage ) {
 			return;
 		}
+
+		$subject = $subject->asBase();
 
 		$k = $this->makeCacheKey( $subject );
 		$res = $this->cache->fetch( $k );

--- a/tests/phpunit/Unit/Maintenance/PurgeEntityCacheTest.php
+++ b/tests/phpunit/Unit/Maintenance/PurgeEntityCacheTest.php
@@ -1,0 +1,106 @@
+<?php
+
+namespace SMW\Tests\Maintenance;
+
+use SMW\Maintenance\PurgeEntityCache;
+use FakeResultWrapper;
+use SMW\Tests\TestEnvironment;
+use SMW\DIWikiPage;
+
+/**
+ * @covers \SMW\Maintenance\PurgeEntityCache
+ * @group semantic-mediawiki
+ *
+ * @license GNU GPL v2+
+ * @since 3.1
+ *
+ * @author mwjames
+ */
+class PurgeEntityCacheTest extends \PHPUnit_Framework_TestCase {
+
+	private $testEnvironment;
+	private $messageReporter;
+	private $store;
+	private $connection;
+	private $entityCache;
+
+	protected function setUp() {
+
+		$this->testEnvironment =  new TestEnvironment();
+
+		$this->messageReporter = $this->getMockBuilder( '\Onoi\MessageReporter\MessageReporter' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$this->store = $this->getMockBuilder( '\SMW\SQLStore\SQLStore' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$this->connection = $this->getMockBuilder( '\SMW\MediaWiki\Database' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$this->entityCache = $this->getMockBuilder( '\SMW\EntityCache' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$this->testEnvironment->registerObject( 'Store', $this->store );
+		$this->testEnvironment->registerObject( 'EntityCache', $this->entityCache );
+	}
+
+	protected function tearDown() {
+		$this->testEnvironment->tearDown();
+		parent::tearDown();
+	}
+
+	public function testCanConstruct() {
+
+		$this->assertInstanceOf(
+			PurgeEntityCache::class,
+			new PurgeEntityCache()
+		);
+	}
+
+	public function testExecute() {
+
+		$fields = [
+			"smw_subobject=''",
+			'smw_iw != '
+		];
+
+		$row = new \stdClass;
+		$row->smw_id = 42;
+		$row->smw_title = 'Foo';
+		$row->smw_namespace = '0';
+		$row->smw_iw = '';
+		$row->smw_subobject = '';
+
+		$subject = new DIWikiPage( 'Foo', 0 );
+
+		$this->connection->expects( $this->atLeastOnce() )
+			->method( 'select' )
+			->with(
+				$this->anything(),
+				$this->anything(),
+				$this->equalTo( $fields ),
+				$this->anything() )
+			->will( $this->returnValue( new FakeResultWrapper( [ $row ] ) ) );
+
+		$this->store->expects( $this->atLeastOnce() )
+			->method( 'getConnection' )
+			->will( $this->returnValue( $this->connection ) );
+
+		$this->entityCache->expects( $this->atLeastOnce() )
+			->method( 'invalidate' )
+			->with( $this->equalTo( $subject ) );
+
+		$instance = new PurgeEntityCache();
+
+		$instance->setMessageReporter(
+			$this->messageReporter
+		);
+
+		$instance->execute();
+	}
+
+}


### PR DESCRIPTION
This PR is made in reference to: #

This PR addresses or contains:

- Adds `purgeEntityCache.php` to purge all cache entries (including associates) that used the `EntityCache` interface 

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed

Fixes #