### PR TITLE
`DisplayTitleFinder` avoid false on empty, refs 3876

### DIFF
--- a/src/DisplayTitleFinder.php
+++ b/src/DisplayTitleFinder.php
@@ -46,7 +46,7 @@ class DisplayTitleFinder {
 		$key = $this->entityCache->makeKey( 'displaytitle', $subject->getHash() );
 
 		if ( ( $displayTitle = $this->entityCache->fetch( $key ) ) !== false && $displayTitle !== null ) {
-			return $displayTitle;
+			return trim( $displayTitle );
 		}
 
 		$displayTitle = $this->findDisplayTitleFor( $subject );
@@ -56,12 +56,14 @@ class DisplayTitleFinder {
 		// the time the subject gets altered
 		$this->entityCache->associate( $base, $key );
 
-		return $displayTitle;
+		return trim( $displayTitle );
 	}
 
 	private function findDisplayTitleFor( $subject ) {
 
-		$displayTitle = '';
+		// Avoid issues in case of `false` or empty to store
+		// a space
+		$displayTitle = ' ';
 
 		$dataItems = $this->store->getPropertyValues(
 			$subject,
@@ -77,6 +79,5 @@ class DisplayTitleFinder {
 
 		return $displayTitle;
 	}
-
 
 }

--- a/tests/phpunit/Unit/DisplayTitleFinderTest.php
+++ b/tests/phpunit/Unit/DisplayTitleFinderTest.php
@@ -98,7 +98,10 @@ class DisplayTitleFinderTest extends \PHPUnit_Framework_TestCase {
 			->will( $this->returnValue( false ) );
 
 		$this->entityCache->expects( $this->once() )
-			->method( 'save' );
+			->method( 'save' )
+			->with(
+				$this->anything(),
+				$this->equalTo( 'foobar' ) );
 
 		$this->entityCache->expects( $this->once() )
 			->method( 'associate' );
@@ -110,6 +113,49 @@ class DisplayTitleFinderTest extends \PHPUnit_Framework_TestCase {
 
 		$this->assertSame(
 			'foobar',
+			$instance->findDisplayTitle( $subject )
+		);
+	}
+
+	public function testNoDisplayTitle_Empty() {
+
+		$subject = new DIWikiPage( 'Foo', NS_MAIN, '', 'abc' );
+
+		$this->store->expects( $this->any() )
+			->method( 'getPropertyValues' )
+			->withConsecutive(
+				[ $this->equalTo( $subject ) ],
+				[ $this->equalTo( $subject->asBase() ) ] )
+			->will( $this->onConsecutiveCalls( [], [] ) );
+
+		$this->entityCache->expects( $this->once() )
+			->method( 'makeKey' )
+			->with(
+				$this->equalTo( 'displaytitle' ),
+				$this->equalTo( $subject->getHash() ) );
+
+		$this->entityCache->expects( $this->once() )
+			->method( 'fetch' )
+			->will( $this->returnValue( false ) );
+
+		// Stored with a space
+		$this->entityCache->expects( $this->once() )
+			->method( 'save' )
+			->with(
+				$this->anything(),
+				$this->equalTo( ' ' ) );
+
+		$this->entityCache->expects( $this->once() )
+			->method( 'associate' );
+
+		$instance = new DisplayTitleFinder(
+			$this->store,
+			$this->entityCache
+		);
+
+		// Trimmed on the output
+		$this->assertSame(
+			'',
 			$instance->findDisplayTitle( $subject )
 		);
 	}


### PR DESCRIPTION
This PR is made in reference to: #3876

This PR addresses or contains:

- Keep an ` ` (empty space) entry to avoid having the cache to return false when no title is available to avoid hitting the DB when it is known that no display title is available (the whole idea of caching is to avoid hitting the DB)

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed
