### PR TITLE
Move `LinkBatch` from `StubSemanticData` to `CacheWarmer`, refs 3836

### DIFF
--- a/src/SQLStore/EntityStore/StubSemanticData.php
+++ b/src/SQLStore/EntityStore/StubSemanticData.php
@@ -11,7 +11,6 @@ use SMW\SQLStore\SQLStore;
 use SMW\StoreFactory;
 use SMWDataItem as DataItem;
 use SMWSemanticData as SemanticData;
-use SMW\MediaWiki\LinkBatch;
 
 /**
  * This class provides a subclass of SemanticData that can store prefetched values
@@ -175,15 +174,6 @@ class StubSemanticData extends SemanticData {
 			}
 
 			unset( $this->mStubPropVals[$property->getKey()] );
-			$linkBatch = LinkBatch::singleton();
-			$linkBatch->setCaller( __METHOD__ );
-
-			if ( $propertyDiId === DataItem::TYPE_WIKIPAGE ) {
-				$linkBatch->addFromList( $this->mPropVals[$property->getKey()] );
-			}
-
-			$linkBatch->add( $property->getDIWikiPage() );
-			$linkBatch->execute();
 		}
 
 		return parent::getPropertyValues( $property );


### PR DESCRIPTION
This PR is made in reference to: #3836

This PR addresses or contains:

-  `CacheWarmer` provides a better inception point to prefetch and collect those entities that will represent a link in MediaWiki

This PR includes:
- [ ] Tests (unit/integration)
- [x] CI build passed
