### PR TITLE
[ES] Check for maintenance lock, refs 3697

### DIFF
--- a/i18n/en.json
+++ b/i18n/en.json
@@ -922,7 +922,11 @@
 	"smw-es-replication-error-divergent-date-detail": "*$1 (Elasticsearch)\n*$2 (SQLStore)",
 	"smw-es-replication-error-divergent-revision": "The replication monitoring has found that for the \"$1\" article (ID: $2) the <b>associated revision</b> shows a discrepancy.",
 	"smw-es-replication-error-divergent-revision-detail": "*$1 (Elasticsearch)\n*$2 (SQLStore)",
+	"smw-es-replication-error-maintenance-mode": "The replication and search engine are in [https://www.semantic-mediawiki.org/wiki/Help:ElasticStore/Maintenance_mode <b>maintenance mode</b>] making changes to entities and pages not immediately visible or to appear in query results.",
+	"smw-es-replication-error-bad-request-exception": "The Elasticsearch connection handler has thrown a bad request exception (\"400 conflict http error\") indicating a continuing issue during replication and search requests.",
 	"smw-es-replication-error-suggestions": "It is suggested to edit or purge the page to remove the discrepancy. If the issue remains then check the Elasticsearch cluster itself (allocator, exceptions, disk space etc.).",
+	"smw-es-replication-error-suggestions-maintenance-mode": "It is suggested to contact the wiki administrator to check whether an [https://www.semantic-mediawiki.org/wiki/Help:ElasticStore/Index_rebuild index rebuild] is currently in progress or the <code>refresh_interval</code> hasn't been set to the expected default value.",
+	"smw-es-replication-error-suggestions-exception": "Please check the logs for information about the status of Elasticsearch, their indices, and possible misconfiguration issues.",
 	"smw-es-replication-error-file-ingest-missing-file-attachment": "The replication monitoring has found that \"$1\" is missing a [[Property:File attachment|File attachment]] annotation indicating that the file ingest processor hasn't started or isn't finished.",
 	"smw-es-replication-error-file-ingest-missing-file-attachment-suggestions": "Please ensure that the [https://www.semantic-mediawiki.org/wiki/Help:ElasticStore/File_ingestion file ingest] job is scheduled and executed before the annotation and file index can be made available."
 }

--- a/src/Elastic/Connection/Client.php
+++ b/src/Elastic/Connection/Client.php
@@ -801,6 +801,22 @@ class Client {
 	}
 
 	/**
+	 * @since 3.1
+	 *
+	 * @return boolean
+	 */
+	public function hasMaintenanceLock() {
+		return $this->lockManager->hasMaintenanceLock();
+	}
+
+	/**
+	 * @since 3.1
+	 */
+	public function setMaintenanceLock() {
+		$this->lockManager->setMaintenanceLock();
+	}
+
+	/**
 	 * @since 3.0
 	 *
 	 * @param string $type

--- a/src/Elastic/Connection/DummyClient.php
+++ b/src/Elastic/Connection/DummyClient.php
@@ -240,6 +240,18 @@ class DummyClient extends Client {
 	}
 
 	/**
+	 * @see Client::hasMaintenanceLock
+	 */
+	public function hasMaintenanceLock() {
+		return false;
+	}
+
+	/**
+	 * @see Client::setMaintenanceLock
+	 */
+	public function setMaintenanceLock() {}
+
+	/**
 	 * @see Client::setLock
 	 */
 	public function setLock( $type, $version ) {}

--- a/src/Elastic/Connection/LockManager.php
+++ b/src/Elastic/Connection/LockManager.php
@@ -16,6 +16,8 @@ class LockManager {
 	 * Identifies the cache namespace
 	 */
 	const CACHE_NAMESPACE = 'smw:elastic';
+	const TYPE_LOCK = 'lock';
+	const TYPE_MAINTENANCE = 'maintenance';
 
 	/**
 	 * @var Cache
@@ -29,6 +31,32 @@ class LockManager {
 	 */
 	public function __construct( Cache $cache ) {
 		$this->cache = $cache;
+	}
+
+	/**
+	 * @since 3.1
+	 */
+	public function hasMaintenanceLock() {
+
+		$key = smwfCacheKey(
+			self::CACHE_NAMESPACE,
+			self::TYPE_MAINTENANCE
+		);
+
+		return $this->cache->fetch( $key ) !== false;
+	}
+
+	/**
+	 * @since 3.1
+	 */
+	public function setMaintenanceLock() {
+
+		$key = smwfCacheKey(
+			self::CACHE_NAMESPACE,
+			self::TYPE_MAINTENANCE
+		);
+
+		$this->cache->save( $key, true );
 	}
 
 	/**
@@ -91,6 +119,13 @@ class LockManager {
 		$key = smwfCacheKey(
 			self::CACHE_NAMESPACE,
 			[ 'lock', $type ]
+		);
+
+		$this->cache->delete( $key );
+
+		$key = smwfCacheKey(
+			self::CACHE_NAMESPACE,
+			self::TYPE_MAINTENANCE
 		);
 
 		$this->cache->delete( $key );

--- a/src/Elastic/Indexer/IndicatorProvider.php
+++ b/src/Elastic/Indexer/IndicatorProvider.php
@@ -124,7 +124,11 @@ class IndicatorProvider implements IIndicatorProvider {
 			}
 		}
 
-		if ( $this->entityCache->fetch( CheckReplicationTask::makeCacheKey( $subject ) ) === 'success' ) {
+		$connection = $this->store->getConnection( 'elastic' );
+
+		if (
+			$connection->hasMaintenanceLock() === false &&
+			$this->entityCache->fetch( CheckReplicationTask::makeCacheKey( $subject ) ) === CheckReplicationTask::TYPE_SUCCESS ) {
 			return;
 		}
 

--- a/src/Elastic/Indexer/Rebuilder.php
+++ b/src/Elastic/Indexer/Rebuilder.php
@@ -156,6 +156,8 @@ class Rebuilder {
 	 * @since 3.0
 	 */
 	public function prepare() {
+		$this->client->setMaintenanceLock();
+
 		$this->prepare_index( ElasticClient::TYPE_DATA );
 		$this->prepare_index( ElasticClient::TYPE_LOOKUP );
 	}

--- a/tests/phpunit/Unit/Elastic/Connection/ClientTest.php
+++ b/tests/phpunit/Unit/Elastic/Connection/ClientTest.php
@@ -45,6 +45,32 @@ class ClientTest extends \PHPUnit_Framework_TestCase {
 		);
 	}
 
+	public function testHasMaintenanceLock() {
+
+		$this->lockManager->expects( $this->once() )
+			->method( 'hasMaintenanceLock' );
+
+		$instance = new Client(
+			$this->elasticClient,
+			$this->lockManager
+		);
+
+		$instance->hasMaintenanceLock();
+	}
+
+	public function testSetMaintenanceLock() {
+
+		$this->lockManager->expects( $this->once() )
+			->method( 'setMaintenanceLock' );
+
+		$instance = new Client(
+			$this->elasticClient,
+			$this->lockManager
+		);
+
+		$instance->setMaintenanceLock();
+	}
+
 	public function testBulkOnIllegalArgumentErrorThrowsReplicationException() {
 
 		$options = new Options (

--- a/tests/phpunit/Unit/Elastic/Connection/LockManagerTest.php
+++ b/tests/phpunit/Unit/Elastic/Connection/LockManagerTest.php
@@ -36,11 +36,40 @@ class LockManagerTest extends \PHPUnit_Framework_TestCase {
 		);
 	}
 
+	public function testHasMaintenanceLock() {
+
+		$this->cache->expects( $this->once() )
+			->method( 'fetch' )
+			->with( $this->stringContains( 'smw:elastic:57cb773ae7a82c8c8aae12fa8f8d7abd' ) )
+			->will( $this->returnValue( true ) );
+
+		$instance = new LockManager(
+			$this->cache
+		);
+
+		$instance->hasMaintenanceLock();
+	}
+
+	public function testSetMaintenanceLock() {
+
+		$this->cache->expects( $this->once() )
+			->method( 'save' )
+			->with( $this->stringContains( 'smw:elastic:57cb773ae7a82c8c8aae12fa8f8d7abd' ) );
+
+		$instance = new LockManager(
+			$this->cache
+		);
+
+		$instance->setMaintenanceLock();
+	}
+
 	public function testSetLock() {
 
 		$this->cache->expects( $this->once() )
 			->method( 'save' )
-			->will( $this->returnValue( '' ) );
+			->with(
+				$this->anything(),
+				$this->equalTo( 2 ) );
 
 		$instance = new LockManager(
 			$this->cache
@@ -82,9 +111,12 @@ class LockManagerTest extends \PHPUnit_Framework_TestCase {
 
 	public function testReleaseLock() {
 
-		$this->cache->expects( $this->once() )
+		$this->cache->expects( $this->at( 0 ) )
+			->method( 'delete' );
+
+		$this->cache->expects( $this->at( 1 ) )
 			->method( 'delete' )
-			->will( $this->returnValue( 2 ) );
+			->with( $this->stringContains( 'smw:elastic:57cb773ae7a82c8c8aae12fa8f8d7abd' ) );
 
 		$instance = new LockManager(
 			$this->cache

--- a/tests/phpunit/Unit/Elastic/Indexer/Replication/CheckReplicationTaskTest.php
+++ b/tests/phpunit/Unit/Elastic/Indexer/Replication/CheckReplicationTaskTest.php
@@ -46,7 +46,7 @@ class CheckReplicationTaskTest extends \PHPUnit_Framework_TestCase {
 			->disableOriginalConstructor()
 			->getMock();
 
-		$this->elasticClient = $this->getMockBuilder( '\SMW\Elastic\Connection\Client' )
+		$this->elasticClient = $this->getMockBuilder( '\SMW\Elastic\Connection\DummyClient' )
 			->disableOriginalConstructor()
 			->getMock();
 
@@ -65,6 +65,10 @@ class CheckReplicationTaskTest extends \PHPUnit_Framework_TestCase {
 
 	public function testCheckReplication_NotExists() {
 
+		$this->elasticClient->expects( $this->any() )
+			->method( 'hasMaintenanceLock' )
+			->will( $this->returnValue( false ) );
+
 		$replicationStatus = [
 			'modification_date' => false
 		];
@@ -77,6 +81,10 @@ class CheckReplicationTaskTest extends \PHPUnit_Framework_TestCase {
 		$this->store->expects( $this->once() )
 			->method( 'getPropertyValues' )
 			->will( $this->returnValue( [] ) );
+
+		$this->store->expects( $this->any() )
+			->method( 'getConnection' )
+			->will( $this->returnValue( $this->elasticClient ) );
 
 		$instance = new CheckReplicationTask(
 			$this->store,
@@ -104,6 +112,10 @@ class CheckReplicationTaskTest extends \PHPUnit_Framework_TestCase {
 			->will( $this->returnValue( true ) );
 
 		$this->elasticClient->expects( $this->any() )
+			->method( 'hasMaintenanceLock' )
+			->will( $this->returnValue( false ) );
+
+		$this->elasticClient->expects( $this->any() )
 			->method( 'getConfig' )
 			->will( $this->returnValue( $config ) );
 
@@ -120,7 +132,7 @@ class CheckReplicationTaskTest extends \PHPUnit_Framework_TestCase {
 			->with(	$this->equalTo( 'modification_date_associated_revision' ) )
 			->will( $this->returnValue( $replicationStatus ) );
 
-		$this->store->expects( $this->at( 2 ) )
+		$this->store->expects( $this->at( 3 ) )
 			->method( 'getPropertyValues' )
 			->will( $this->returnValue( [ $time_store ] ) );
 
@@ -159,6 +171,10 @@ class CheckReplicationTaskTest extends \PHPUnit_Framework_TestCase {
 			->will( $this->returnValue( true ) );
 
 		$this->elasticClient->expects( $this->any() )
+			->method( 'hasMaintenanceLock' )
+			->will( $this->returnValue( false ) );
+
+		$this->elasticClient->expects( $this->any() )
 			->method( 'getConfig' )
 			->will( $this->returnValue( $config ) );
 
@@ -179,7 +195,7 @@ class CheckReplicationTaskTest extends \PHPUnit_Framework_TestCase {
 			->method( 'findAssociatedRev' )
 			->will( $this->returnValue( 42 ) );
 
-		$this->store->expects( $this->at( 2 ) )
+		$this->store->expects( $this->at( 3 ) )
 			->method( 'getPropertyValues' )
 			->will( $this->returnValue( [ $time ] ) );
 
@@ -218,6 +234,10 @@ class CheckReplicationTaskTest extends \PHPUnit_Framework_TestCase {
 			->will( $this->returnValue( true ) );
 
 		$this->elasticClient->expects( $this->any() )
+			->method( 'hasMaintenanceLock' )
+			->will( $this->returnValue( false ) );
+
+		$this->elasticClient->expects( $this->any() )
 			->method( 'getConfig' )
 			->will( $this->returnValue( $config ) );
 
@@ -238,11 +258,11 @@ class CheckReplicationTaskTest extends \PHPUnit_Framework_TestCase {
 			->method( 'findAssociatedRev' )
 			->will( $this->returnValue( 9999 ) );
 
-		$this->store->expects( $this->at( 2 ) )
+		$this->store->expects( $this->at( 3 ) )
 			->method( 'getPropertyValues' )
 			->will( $this->returnValue( [ $time ] ) );
 
-		$this->store->expects( $this->at( 4 ) )
+		$this->store->expects( $this->at( 5 ) )
 			->method( 'getPropertyValues' )
 			->with(
 				$this->equalTo( $subject ),


### PR DESCRIPTION
This PR is made in reference to: #3697

This PR addresses or contains:

- https://www.semantic-mediawiki.org/wiki/Help:ElasticStore/Maintenance_mode

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed
