### PR TITLE
`DisplayTitleFinder` add prefetch lookup, refs 3722, 3876

### DIFF
--- a/src/SQLStore/EntityStore/CacheWarmer.php
+++ b/src/SQLStore/EntityStore/CacheWarmer.php
@@ -9,6 +9,7 @@ use SMW\SQLStore\SQLStore;
 use SMWQueryResult as QueryResult;
 use Iterator;
 use SMW\MediaWiki\LinkBatch;
+use SMW\DisplayTitleFinder;
 
 /**
  * @license GNU GPL v2+
@@ -24,6 +25,16 @@ class CacheWarmer {
 	private $store;
 
 	/**
+	 * @var IdCacheManager
+	 */
+	private $idCacheManager;
+
+	/**
+	 * @var DisplayTitleFinder
+	 */
+	private $displayTitleFinder;
+
+	/**
 	 * @var integer
 	 */
 	private $thresholdLimit = 3;
@@ -37,6 +48,15 @@ class CacheWarmer {
 	public function __construct( SQLStore $store, IdCacheManager $idCacheManager ) {
 		$this->store = $store;
 		$this->idCacheManager = $idCacheManager;
+	}
+
+	/**
+	 * @since 3.1
+	 *
+	 * @param DisplayTitleFinder $displayTitleFinder
+	 */
+	public function setDisplayTitleFinder( DisplayTitleFinder $displayTitleFinder ) {
+		$this->displayTitleFinder = $displayTitleFinder;
 	}
 
 	/**
@@ -101,6 +121,10 @@ class CacheWarmer {
 
 		$linkBatch->execute();
 		$this->fillFromTableByHash( array_keys( $hashList ) );
+
+		if ( $this->displayTitleFinder !== null ) {
+			$this->displayTitleFinder->prefetchFromList( $list );
+		}
 	}
 
 	/**

--- a/src/SQLStore/Lookup/DisplayTitleLookup.php
+++ b/src/SQLStore/Lookup/DisplayTitleLookup.php
@@ -1,0 +1,115 @@
+<?php
+
+namespace SMW\SQLStore\Lookup;
+
+use SMW\SQLStore\SQLStore;
+use SMW\Store;
+use SMW\DIProperty;
+use RuntimeException;
+
+/**
+ * @license GNU GPL v2+
+ * @since 3.1
+ *
+ * @author mwjames
+ */
+class DisplayTitleLookup {
+
+	/**
+	 * @var Store
+	 */
+	private $store;
+
+	/**
+	 * @since 3.1
+	 *
+	 * @param Store $store
+	 */
+	public function __construct( Store $store ) {
+		$this->store = $store;
+	}
+
+	/**
+	 * @since 3.1
+	 *
+	 * @param Iterator|array $dataItems
+	 *
+	 * @return Iterator|array
+	 */
+	public function prefetchFromList( array $dataItems ) {
+
+		$list = [];
+		$prefetch = [];
+
+		foreach ( $dataItems as $dataItem ) {
+			$id = $subject = $this->store->getObjectIds()->getId(
+				$dataItem
+			);
+
+			$list[$id] = $dataItem;
+		}
+
+		list( $rows, $unescape_bytea ) = $this->fetchFromTable( $list );
+
+		foreach ( $rows as $row ) {
+
+			if ( !isset( $list[$row->s_id] ) ) {
+				continue;
+			}
+
+			$dataItem = $list[$row->s_id];
+
+			if ( $row->o_blob !== null ) {
+				$displayTitle = $unescape_bytea ? pg_unescape_bytea( $row->o_blob ) : $row->o_blob;
+			} else {
+				$displayTitle = $row->o_hash;
+			}
+
+			unset( $list[$row->s_id] );
+			$prefetch[$dataItem->getSha1()] = $displayTitle;
+		}
+
+		// Those that don't have a DisplayTitle are marked with a NULL
+		foreach ( $list as $id => $dataItem ) {
+			$prefetch[$dataItem->getSha1()] = null;
+		}
+
+		return $prefetch;
+	}
+
+	private function fetchFromTable( $list ) {
+
+		$property = new DIProperty( '_DTITLE' );
+		$connection = $this->store->getConnection( 'mw.db' );
+
+		$propTableId = $this->store->findPropertyTableID(
+			$property
+		);
+
+		$propTables = $this->store->getPropertyTables();
+
+		if ( !isset( $propTables[$propTableId] ) ) {
+			throw new RuntimeException( "Missing $propTableId!" );
+		}
+
+		$propTable = $propTables[$propTableId];
+
+		$rows = $connection->select(
+			$connection->tablename( $propTable->getName() ),
+			[
+				's_id',
+				'o_hash',
+				'o_blob'
+			],
+			[
+				's_id' => array_keys( $list )
+			],
+			__METHOD__
+		);
+
+		$unescape_bytea = $connection->isType( 'postgres' );
+
+		return [ $rows, $unescape_bytea ];
+	}
+
+}

--- a/src/SQLStore/SQLStoreFactory.php
+++ b/src/SQLStore/SQLStoreFactory.php
@@ -37,6 +37,7 @@ use SMW\SQLStore\Lookup\UsageStatisticsListLookup;
 use SMW\SQLStore\Lookup\ProximityPropertyValueLookup;
 use SMW\SQLStore\Lookup\MissingRedirectLookup;
 use SMW\SQLStore\Lookup\MonolingualTextLookup;
+use SMW\SQLStore\Lookup\DisplayTitleLookup;
 use SMW\SQLStore\TableBuilder\TableBuilder;
 use SMW\SQLStore\TableBuilder\TableSchemaManager;
 use SMW\SQLStore\TableBuilder\TableBuildExaminer;
@@ -599,9 +600,15 @@ class SQLStoreFactory {
 	 */
 	public function newCacheWarmer( IdCacheManager $idCacheManager ) {
 
+		$applicationFactory = ApplicationFactory::getInstance();
+
 		$cacheWarmer = new CacheWarmer(
 			$this->store,
 			$idCacheManager
+		);
+
+		$cacheWarmer->setDisplayTitleFinder(
+			$applicationFactory->singleton( 'DisplayTitleFinder', $this->store )
 		);
 
 		return $cacheWarmer;
@@ -811,6 +818,15 @@ class SQLStoreFactory {
 	/**
 	 * @since 3.1
 	 *
+	 * @return DisplayTitleLookup
+	 */
+	public function newDisplayTitleLookup() {
+		return new DisplayTitleLookup( $this->store );
+	}
+
+	/**
+	 * @since 3.1
+	 *
 	 * @return PrefetchItemLookup
 	 */
 	public function newPrefetchItemLookup() {
@@ -865,6 +881,10 @@ class SQLStoreFactory {
 				'MonolingualTextLookup' => [
 					'_service' => [ $this, 'newMonolingualTextLookup' ],
 					'_type'    => MonolingualTextLookup::class
+				],
+				'DisplayTitleLookup' => [
+					'_service' => [ $this, 'newDisplayTitleLookup' ],
+					'_type'    => DisplayTitleLookup::class
 				],
 				'PropertyTypeFinder' => [
 					'_service' => [ $this, 'newPropertyTypeFinder' ],

--- a/src/Services/SharedServicesContainer.php
+++ b/src/Services/SharedServicesContainer.php
@@ -736,17 +736,22 @@ class SharedServicesContainer implements CallbackContainer {
 		/**
 		 * @var DisplayTitleFinder
 		 */
-		$containerBuilder->registerCallback( 'DisplayTitleFinder', function( $containerBuilder ) {
+		$containerBuilder->registerCallback( 'DisplayTitleFinder', function( $containerBuilder, $store = null ) {
 			$containerBuilder->registerExpectedReturnType( 'DisplayTitleFinder', '\SMW\DisplayTitleFinder' );
 
-			$lang = Localizer::getInstance()->getLang();
+			$store = $store === null ? $containerBuilder->singleton( 'Store', null ) : $store;
+			$settings = $containerBuilder->singleton( 'Settings' );
 
-			$propertyLabelFinder = new DisplayTitleFinder(
-				$containerBuilder->singleton( 'Store', null ),
+			$displayTitleFinder = new DisplayTitleFinder(
+				$store,
 				$containerBuilder->singleton( 'EntityCache' )
 			);
 
-			return $propertyLabelFinder;
+			$displayTitleFinder->setCanUse(
+				$settings->isFlagSet( 'smwgDVFeatures', SMW_DV_WPV_DTITLE )
+			);
+
+			return $displayTitleFinder;
 		} );
 	}
 

--- a/tests/phpunit/Unit/DisplayTitleFinderTest.php
+++ b/tests/phpunit/Unit/DisplayTitleFinderTest.php
@@ -24,7 +24,7 @@ class DisplayTitleFinderTest extends \PHPUnit_Framework_TestCase {
 
 		$this->store = $this->getMockBuilder( '\SMW\Store' )
 			->disableOriginalConstructor()
-			->setMethods( [ 'getWikiPageSortKey' ] )
+			->setMethods( [ 'getWikiPageSortKey', 'service' ] )
 			->getMockForAbstractClass();
 
 		$this->entityCache = $this->getMockBuilder( '\SMW\EntityCache' )
@@ -158,6 +158,56 @@ class DisplayTitleFinderTest extends \PHPUnit_Framework_TestCase {
 			'',
 			$instance->findDisplayTitle( $subject )
 		);
+	}
+
+	public function testPrefetchFromList() {
+
+		$subjects = [
+			DIWikiPage::newFromText( 'Foo' ),
+			DIWikiPage::doUnserialize( 'Foo#0##abc' ),
+			DIWikiPage::doUnserialize( 'Foo#0##123' )
+		];
+
+		$prefetch = [
+			$subjects[2]->getSha1() => 'Bar',
+			$subjects[0]->getSha1() => 'Foobar',
+			$subjects[1]->getSha1() => null,
+		];
+
+		$displayTitleLookup = $this->getMockBuilder( '\SMW\SQLStore\Lookup\DisplayTitleLookup' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$displayTitleLookup->expects( $this->any() )
+			->method( 'prefetchFromList' )
+			->will( $this->returnValue( $prefetch ) );
+
+		$this->store->expects( $this->any() )
+			->method( 'service' )
+			->with( $this->equalTo( 'DisplayTitleLookup' ) )
+			->will( $this->returnValue( $displayTitleLookup ) );
+
+		$this->entityCache->expects( $this->any() )
+			->method( 'fetch' )
+			->will( $this->returnValue( false ) );
+
+		// Stored with a space
+		$this->entityCache->expects( $this->any() )
+			->method( 'save' )
+			->withConsecutive(
+				[ $this->anything(), $this->equalTo( 'Foobar' ) ],
+				[ $this->anything(), $this->equalTo( 'Foobar' ) ],
+				[ $this->anything(), $this->equalTo( 'Bar' ) ] );
+
+		$this->entityCache->expects( $this->exactly( 3 ) )
+			->method( 'associate' );
+
+		$instance = new DisplayTitleFinder(
+			$this->store,
+			$this->entityCache
+		);
+
+		$instance->prefetchFromList( $subjects );
 	}
 
 }

--- a/tests/phpunit/Unit/Elastic/Indexer/FileIndexerTest.php
+++ b/tests/phpunit/Unit/Elastic/Indexer/FileIndexerTest.php
@@ -39,7 +39,7 @@ class FileIndexerTest extends \PHPUnit_Framework_TestCase {
 
 		$this->entityCache = $this->getMockBuilder( '\SMW\EntityCache' )
 			->disableOriginalConstructor()
-			->setMethods( [ 'save', 'associate' ] )
+			->setMethods( [ 'save', 'associate', 'fetch' ] )
 			->getMock();
 
 		$this->testEnvironment->registerObject( 'EntityCache', $this->entityCache );

--- a/tests/phpunit/Unit/SQLStore/EntityStore/CacheWarmerTest.php
+++ b/tests/phpunit/Unit/SQLStore/EntityStore/CacheWarmerTest.php
@@ -95,6 +95,26 @@ class CacheWarmerTest extends \PHPUnit_Framework_TestCase {
 		$instance->fillFromList( $list );
 	}
 
+	public function testFillFromList_DisplayTitleFinder() {
+
+		$displayTitleFinder = $this->getMockBuilder( '\SMW\DisplayTitleFinder' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$displayTitleFinder->expects( $this->once() )
+			->method( 'prefetchFromList' );
+
+		$instance = new CacheWarmer(
+			$this->store,
+			$this->idCacheManager
+		);
+
+		$instance->setDisplayTitleFinder( $displayTitleFinder );
+		$instance->setThresholdLimit( 1 );
+
+		$instance->fillFromList( [] );
+	}
+
 	public function testFillFromList_Property() {
 
 		$list = [

--- a/tests/phpunit/Unit/SQLStore/Lookup/DisplayTitleLookupTest.php
+++ b/tests/phpunit/Unit/SQLStore/Lookup/DisplayTitleLookupTest.php
@@ -1,0 +1,115 @@
+<?php
+
+namespace SMW\Tests\SQLStore\Lookup;
+
+use SMW\SQLStore\Lookup\DisplayTitleLookup;
+use SMW\MediaWiki\Connection\Query;
+use SMW\DIWikiPage;
+use SMW\DIProperty;
+
+/**
+ * @covers \SMW\SQLStore\Lookup\DisplayTitleLookup
+ * @group semantic-mediawiki
+ *
+ * @license GNU GPL v2+
+ * @since   3.1
+ *
+ * @author mwjames
+ */
+class DisplayTitleLookupTest extends \PHPUnit_Framework_TestCase {
+
+	private $store;
+
+	protected function setUp() {
+
+		$this->store = $this->getMockBuilder( '\SMW\SQLStore\SQLStore' )
+			->disableOriginalConstructor()
+			->getMock();
+	}
+
+	public function testCanConstruct() {
+
+		$this->assertInstanceOf(
+			DisplayTitleLookup::class,
+			new DisplayTitleLookup( $this->store )
+		);
+	}
+
+	public function testPrefetchFromList() {
+
+		$subjects = [
+			DIWikiPage::newFromText( 'Foo' ),
+			DIWikiPage::newFromText( 'Bar' )
+		];
+
+		$rows = [
+			(object)[ 's_id' => 42, 'o_blob' => null, 'o_hash' => '123' ],
+			(object)[ 's_id' => 1001, 'o_blob' => 'abc_blob', 'o_hash' => 'abc_hash' ]
+		];
+
+		$connection = $this->getMockBuilder( '\SMW\MediaWiki\Database' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$idTable = $this->getMockBuilder( '\SMWSql3SmwIds' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$idTable->expects( $this->any() )
+			->method( 'getId' )
+			->will( $this->onConsecutiveCalls( 42, 1001 ) );
+
+		$connection = $this->getMockBuilder( '\SMW\MediaWiki\Database' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$connection->expects( $this->once() )
+			->method( 'tablename' )
+			->will( $this->returnArgument( 0 ) );
+
+		$connection->expects( $this->once() )
+			->method( 'select' )
+			->with(
+				$this->equalTo( 'foo_table' ),
+				$this->equalTo(  [ 's_id', 'o_hash', 'o_blob' ] ),
+				$this->equalTo(  [ 's_id' => [ 42, 1001 ] ] ) )
+			->will( $this->returnValue( $rows ) );
+
+		$tableDefinition = $this->getMockBuilder( '\SMW\SQLStore\TableDefinition' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$tableDefinition->expects( $this->any() )
+			->method( 'getName' )
+			->will( $this->returnValue( 'foo_table' ) );
+
+		$this->store->expects( $this->any() )
+			->method( 'getObjectIds' )
+			->will( $this->returnValue( $idTable ) );
+
+		$this->store->expects( $this->any() )
+			->method( 'getConnection' )
+			->will( $this->returnValue( $connection ) );
+
+		$this->store->expects( $this->any() )
+			->method( 'findPropertyTableID' )
+			->will( $this->returnValue( 'Foo' ) );
+
+		$this->store->expects( $this->any() )
+			->method( 'getPropertyTables' )
+			->will( $this->returnValue( [ 'Foo' => $tableDefinition ] ) );
+
+		$instance = new DisplayTitleLookup(
+			$this->store
+		);
+
+		$this->assertEquals(
+			[
+				$subjects[0]->getSha1() => '123',
+				$subjects[1]->getSha1() => 'abc_blob'
+			],
+			$instance->prefetchFromList( $subjects )
+		);
+	}
+
+}

--- a/tests/phpunit/Unit/SQLStore/SQLStoreFactoryTest.php
+++ b/tests/phpunit/Unit/SQLStore/SQLStoreFactoryTest.php
@@ -488,6 +488,16 @@ class SQLStoreFactoryTest extends \PHPUnit_Framework_TestCase {
 		);
 	}
 
+	public function testCanConstructDisplayTitleLookup() {
+
+		$instance = new SQLStoreFactory( $this->store );
+
+		$this->assertInstanceOf(
+			'\SMW\SQLStore\Lookup\DisplayTitleLookup',
+			$instance->newDisplayTitleLookup()
+		);
+	}
+
 	public function testCanConstructPrefetchItemLookup() {
 
 		$instance = new SQLStoreFactory( $this->store );


### PR DESCRIPTION
This PR is made in reference to: #3722, #3876

This PR addresses or contains:

- `DisplayTitleFinder` already services individual lookups from cache and to improve the lookup on unknown or evicted entities this PR adds a prefetch `DisplayTitleLookup` so that titles can be fetched and cached in bulk to minimize the required DB selects on a per request basis. 

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed
