### PR TITLE
Add `auto-recovery` option to `rebuildElasticIndex.php`, `rebuildData.php`, refs 3509

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ composer.lock
 !.*
 .idea/
 .smw.json
+.smw.maintenance.json

--- a/DefaultSettings.php
+++ b/DefaultSettings.php
@@ -47,6 +47,10 @@ return [
 	# $smwgConfigFileDir = $wgUploadDirectory;) or select an entire different
 	# location. The default location is the Semantic MediaWiki extension root.
 	#
+	# During its operation it may contain:
+	#  - `.smw.json`
+	#  - `.smw.maintenance.json`
+	#
 	# @since 3.0
 	##
 	'smwgConfigFileDir' => __DIR__,

--- a/maintenance/rebuildData.php
+++ b/maintenance/rebuildData.php
@@ -156,12 +156,23 @@ class RebuildData extends \Maintenance {
 			$maintenanceHelper->setGlobalToValue( 'wgDebugLogGroups', [] );
 		}
 
+		$autoRecovery = $maintenanceFactory->newAutoRecovery( 'rebuildData.php' );
+		$autoRecovery->safeMargin( 2 );
+
+		$autoRecovery->enable(
+			$this->hasOption( 'auto-recovery' )
+		);
+
 		$store = StoreFactory::getStore( $this->hasOption( 'b' ) ? $this->getOption( 'b' ) : null );
 		$store->setOption( Store::OPT_CREATE_UPDATE_JOB, false );
 
 		$dataRebuilder = $maintenanceFactory->newDataRebuilder(
 			$store,
 			[ $this, 'reportMessage' ]
+		);
+
+		$dataRebuilder->setAutoRecovery(
+			$autoRecovery
 		);
 
 		$dataRebuilder->setOptions(

--- a/src/Maintenance/AutoRecovery.php
+++ b/src/Maintenance/AutoRecovery.php
@@ -1,0 +1,192 @@
+<?php
+
+namespace SMW\Maintenance;
+
+use SMW\Utils\File;
+use RuntimeException;
+use SMW\Site;
+
+/**
+ * @license GNU GPL v2+
+ * @since 3.1
+ *
+ * @author mwjames
+ */
+class AutoRecovery {
+
+	const FILE_NAME = '.smw.maintenance.json';
+
+	/**
+	 * @var string
+	 */
+	private $identifier = '';
+
+	/**
+	 * @var string
+	 */
+	private $site = '';
+
+	/**
+	 * @var File
+	 */
+	private $file;
+
+	/**
+	 * @var boolean
+	 */
+	private $enabled = false;
+
+	/**
+	 * @var integer
+	 */
+	private $safeMargin = 0;
+
+	/**
+	 * @var array
+	 */
+	private $contents;
+
+	/**
+	 * @since 3.1
+	 *
+	 * @param string $identifier
+	 * @param File|null $file
+	 */
+	public function __construct( $identifier, File $file = null ) {
+		$this->identifier = $identifier;
+		$this->file = $file;
+		$this->site = Site::id();
+
+		if ( $this->file === null ) {
+			$this->file = new File();
+		}
+
+		$this->dir = $GLOBALS['smwgConfigFileDir'];
+	}
+
+	/**
+	 * @since 3.1
+	 *
+	 * @param boolean $enabled
+	 */
+	public function enable( $enabled ) {
+		$this->enabled = $enabled;
+	}
+
+	/**
+	 * @since 3.1
+	 *
+	 * @param string $dir
+	 */
+	public function setDir( $dir ) {
+		$this->dir = $dir;
+	}
+
+	/**
+	 * @since 3.1
+	 *
+	 * @param integer $safeMargin
+	 */
+	public function safeMargin( $safeMargin ) {
+		$this->safeMargin = $safeMargin;
+	}
+
+	/**
+	 * @since 3.1
+	 *
+	 * @return string
+	 */
+	public function getLocation() {
+		return $this->dir . "/" . self::FILE_NAME;
+	}
+
+	/**
+	 * @since 3.1
+	 *
+	 * @param string $key
+	 * @param mixed $value
+	 */
+	public function set( $key, $value ) {
+
+		if ( $this->contents === null ) {
+			$this->initContents( $key );
+		}
+
+		$this->contents[$this->site][$this->identifier][$key] = $value;
+
+		$this->file->write(
+			$this->getLocation(),
+			json_encode( $this->contents )
+		);
+	}
+
+	/**
+	 * @since 3.1
+	 *
+	 * @param string $key
+	 *
+	 * @return mixed
+	 */
+	public function get( $key ) {
+
+		if ( !$this->enabled ) {
+			return false;
+		}
+
+		if ( $this->contents === null ) {
+			$this->initContents( $key );
+		}
+
+		$value = $this->contents[$this->site][$this->identifier][$key];
+
+		if ( is_int( $value ) ) {
+			return max( 0, $value - $this->safeMargin );
+		}
+
+		return $value;
+	}
+
+	/**
+	 * @since 3.1
+	 *
+	 * @param string $key
+	 *
+	 * @return boolean
+	 */
+	public function has( $key ) {
+
+		if ( !$this->enabled ) {
+			return false;
+		}
+
+		if ( $this->contents === null ) {
+			$this->initContents( $key );
+		}
+
+		if ( !isset( $this->contents[$this->site][$this->identifier][$key] ) ) {
+			return false;
+		}
+
+		return $this->contents[$this->site][$this->identifier][$key] !== false;
+	}
+
+	private function initContents( $key ) {
+
+		$file = $this->getLocation();
+
+		$this->contents = [
+			$this->site => [ $this->identifier => [ $key => false ] ]
+		];
+
+		if ( !$this->file->exists( $file ) ) {
+			$this->file->write( $file, json_encode( $this->contents ) );
+		} else {
+			$this->contents = json_decode( $this->file->read( $file ), true );
+		}
+
+		if ( !isset( $this->contents[$this->site][$this->identifier][$key] ) ) {
+			$this->contents[$this->site][$this->identifier][$key] = false;
+		}
+	}
+
+}

--- a/src/Maintenance/MaintenanceFactory.php
+++ b/src/Maintenance/MaintenanceFactory.php
@@ -153,4 +153,15 @@ class MaintenanceFactory {
 		return $messageReporter;
 	}
 
+	/**
+	 * @since 3.1
+	 *
+	 * @param string $identifier
+	 *
+	 * @return AutoRecovery
+	 */
+	public function newAutoRecovery( $identifier ) {
+		return new AutoRecovery( $identifier );
+	}
+
 }

--- a/src/Utils/File.php
+++ b/src/Utils/File.php
@@ -50,7 +50,7 @@ class File {
 	 * @return boolean
 	 */
 	public function exists( $file ) {
-		return file_exists( $file );
+		return file_exists( self::dir( $file ) );
 	}
 
 	/**
@@ -63,6 +63,8 @@ class File {
 	 * @throws RuntimeException
 	 */
 	public function read( $file, $checkSum = null ) {
+
+		$file = self::dir( $file );
 
 		if ( !is_readable( $file ) ) {
 			throw new RuntimeException( "$file is not readable." );
@@ -81,7 +83,7 @@ class File {
 	 * @param string $file
 	 */
 	public function delete( $file ) {
-		@unlink( $file );
+		@unlink( self::dir( $file ) );
 	}
 
 	/**

--- a/tests/phpunit/Unit/Maintenance/AutoRecoveryTest.php
+++ b/tests/phpunit/Unit/Maintenance/AutoRecoveryTest.php
@@ -1,0 +1,177 @@
+<?php
+
+namespace SMW\Tests\Maintenance;
+
+use SMW\Maintenance\AutoRecovery;
+use FakeResultWrapper;
+use SMW\Tests\TestEnvironment;
+use SMW\DIWikiPage;
+
+/**
+ * @covers \SMW\Maintenance\AutoRecovery
+ * @group semantic-mediawiki
+ *
+ * @license GNU GPL v2+
+ * @since 3.1
+ *
+ * @author mwjames
+ */
+class AutoRecoveryTest extends \PHPUnit_Framework_TestCase {
+
+	private $testEnvironment;
+	private $file;
+	private $site;
+
+	protected function setUp() {
+
+		$this->testEnvironment =  new TestEnvironment();
+		$this->site = \SMW\Site::id();
+
+		$this->file = $this->getMockBuilder( '\SMW\Utils\File' )
+			->disableOriginalConstructor()
+			->getMock();
+	}
+
+	protected function tearDown() {
+		$this->testEnvironment->tearDown();
+		parent::tearDown();
+	}
+
+	public function testCanConstruct() {
+
+		$this->assertInstanceOf(
+			AutoRecovery::class,
+			new AutoRecovery( 'Foo' )
+		);
+	}
+
+	public function testCheckForID() {
+
+		$contents = [
+			$this->site => [ 'foo' => [ 'ar_id' => false ] ]
+		];
+
+		$this->file->expects( $this->atLeastOnce() )
+			->method( 'write' )
+			->with(
+				$this->anything(),
+				$this->equalTo( json_encode( $contents ) ) );
+
+		$this->file->expects( $this->atLeastOnce() )
+			->method( 'exists' )
+			->will( $this->returnValue( false ) );
+
+		$instance = new AutoRecovery( 'foo', $this->file );
+		$instance->enable( true );
+
+		$this->assertFalse(
+			$instance->has( 'ar_id' )
+		);
+	}
+
+	public function testGetSet() {
+
+		$init = [
+			$this->site => [ 'foo' => [ 'ar_id' => false ] ]
+		];
+
+		$this->file->expects( $this->atLeastOnce() )
+			->method( 'read' )
+			->will( $this->returnValue( json_encode( $init ) ) );
+
+		$contents = [
+			$this->site => [ 'foo' => [ 'ar_id' => 1001 ] ]
+		];
+
+		$this->file->expects( $this->atLeastOnce() )
+			->method( 'write' )
+			->with(
+				$this->anything(),
+				$this->equalTo( json_encode( $contents ) ) );
+
+		$this->file->expects( $this->atLeastOnce() )
+			->method( 'exists' )
+			->will( $this->returnValue( true ) );
+
+		$instance = new AutoRecovery( 'foo', $this->file );
+		$instance->enable( true );
+		$instance->safeMargin( 101 );
+
+		$this->assertEquals(
+			0,
+			$instance->get( 'ar_id' )
+		);
+
+		$instance->set( 'ar_id', 1001 );
+
+		$this->assertEquals(
+			900, // @see safeMargin
+			$instance->get( 'ar_id' )
+		);
+	}
+
+	public function testSetClosed() {
+
+		$init = [
+			$this->site => [ 'foo' => [ 'ar_id' => 42 ] ]
+		];
+
+		$this->file->expects( $this->atLeastOnce() )
+			->method( 'read' )
+			->will( $this->returnValue( json_encode( $init ) ) );
+
+		$contents = [
+			$this->site => [ 'foo' => [ 'ar_id' => false ] ]
+		];
+
+		$this->file->expects( $this->atLeastOnce() )
+			->method( 'write' )
+			->with(
+				$this->anything(),
+				$this->equalTo( json_encode( $contents ) ) );
+
+		$this->file->expects( $this->atLeastOnce() )
+			->method( 'exists' )
+			->will( $this->returnValue( true ) );
+
+		$instance = new AutoRecovery( 'foo', $this->file );
+		$instance->enable( true );
+
+		$this->assertEquals(
+			42,
+			$instance->get( 'ar_id' )
+		);
+
+		$instance->set( 'ar_id', false );
+
+		$this->assertEquals(
+			false,
+			$instance->get( 'ar_id' )
+		);
+	}
+
+	public function testGetSafeMargin() {
+
+		$init = [
+			$this->site => [ 'foo' => [ 'ar_id' => 42 ] ]
+		];
+
+		$this->file->expects( $this->atLeastOnce() )
+			->method( 'read' )
+			->will( $this->returnValue( json_encode( $init ) ) );
+
+		$this->file->expects( $this->atLeastOnce() )
+			->method( 'exists' )
+			->will( $this->returnValue( true ) );
+
+		$instance = new AutoRecovery( 'foo', $this->file );
+		$instance->enable( true );
+		$instance->safeMargin( 9999 );
+
+		$this->assertEquals(
+			0,
+			$instance->get( 'ar_id' )
+		);
+	}
+
+}

--- a/tests/phpunit/Unit/Maintenance/MaintenanceFactoryTest.php
+++ b/tests/phpunit/Unit/Maintenance/MaintenanceFactoryTest.php
@@ -103,4 +103,14 @@ class MaintenanceFactoryTest extends \PHPUnit_Framework_TestCase {
 		);
 	}
 
+	public function testCanConstructAutoRecovery() {
+
+		$instance = new MaintenanceFactory();
+
+		$this->assertInstanceOf(
+			'\SMW\Maintenance\AutoRecovery',
+			$instance->newAutoRecovery( 'Foo' )
+		);
+	}
+
 }


### PR DESCRIPTION
This PR is made in reference to: #3509

This PR addresses or contains:

- Adds the `auto-recovery` option to  `rebuildElasticIndex.php`, `rebuildData.php` and should provide a better handling as `startidfile` in `rebuildData.php`
- The `.smw.maintenance.json` file which is holding the auto recovery information is by default placed in the `smwgConfigFileDir` (since the location should be writable and persistently available for Semantic MediaWiki) location.

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed

Fixes #3509