### PR TITLE
[SMWSearch] Allow `callable` in `$smwgFallbackSearchType`, refs 3937, 3939

### DIFF
--- a/tests/phpunit/Unit/MediaWiki/Search/SearchTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Search/SearchTest.php
@@ -119,6 +119,40 @@ class SearchTest extends \PHPUnit_Framework_TestCase {
 		);
 	}
 
+	public function testGetFallbackSearchEngine_ConstructFromCallable() {
+
+		$searchEngine = $this->getMockBuilder( 'SearchEngine' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$callback = function() use( $searchEngine ) {
+			return $searchEngine;
+		};
+
+		$this->testEnvironment->addConfiguration( 'smwgFallbackSearchType', $callback );
+
+		$search = new Search();
+
+		$this->assertEquals(
+			$searchEngine,
+			$search->getFallbackSearchEngine()
+		);
+	}
+
+	public function testGetFallbackSearchEngine_ConstructFromInvalidCallableThrowsException() {
+
+		$callback = function() {
+			return new \stdClass;
+		};
+
+		$this->testEnvironment->addConfiguration( 'smwgFallbackSearchType', $callback );
+
+		$search = new Search();
+
+		$this->setExpectedException( 'RuntimeException' );
+		$search->getFallbackSearchEngine();
+	}
+
 	public function testSearchTitle_withNonsemanticQuery() {
 
 		$term = 'Some string that can not be interpreted as a semantic query';


### PR DESCRIPTION
This PR is made in reference to: #3937, #3939

This PR addresses or contains:

- Support `callable` in `$smwgFallbackSearchType`

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed

Fixes #3939

### Examples

```
$smwgFallbackSearchType = function( $connection ) {
	return new \SearchMySQL( $connection );
};
```
```
$smwgFallbackSearchType = function() {
	return new \CirrusSearch();
};
```