### PR TITLE
Have WikiPage datavalue getShortCaptionText do the full pipe trick

### DIFF
--- a/includes/datavalues/SMW_DV_WikiPage.php
+++ b/includes/datavalues/SMW_DV_WikiPage.php
@@ -673,10 +673,10 @@ class SMWWikiPageValue extends SMWDataValue {
 		}
 
 		# Remove (context) as per pipe trick.
-		if ( $this->getOption( 'smwgDVFeatures' ) & SMW_DV_WPV_PIPETRICK != 0) {
-			$tc = '[' . Title::legalChars() . ']';
-			$pt = "/($tc+?)( ?\\($tc+\\))/";
-			$displayTitle = preg_replace($pt, '\\1', $displayTitle);
+		if ( ($this->getOption( 'smwgDVFeatures' ) & SMW_DV_WPV_PIPETRICK) != 0 ) {
+			$titleChars = '[' . Title::legalChars() . ']';
+			$pattern = "/($titleChars+?)( ?\\($titleChars+\\))/";
+			$displayTitle = preg_replace($pattern, '\\1', $displayTitle);
 		}
 
 		return $displayTitle . $fragmentText;

--- a/includes/datavalues/SMW_DV_WikiPage.php
+++ b/includes/datavalues/SMW_DV_WikiPage.php
@@ -672,6 +672,13 @@ class SMWWikiPageValue extends SMWDataValue {
 			$displayTitle = $this->getText();
 		}
 
+		# Remove (context) as per pipe trick.
+		if ( $this->getOption( 'smwgDVFeatures' ) & SMW_DV_WPV_PIPETRICK != 0) {
+			$tc = '[' . Title::legalChars() . ']';
+			$pt = "/($tc+?)( ?\\($tc+\\))/";
+			$displayTitle = preg_replace($pt, '\\1', $displayTitle);
+		}
+
 		return $displayTitle . $fragmentText;
 	}
 

--- a/includes/datavalues/SMW_DV_WikiPage.php
+++ b/includes/datavalues/SMW_DV_WikiPage.php
@@ -4,6 +4,7 @@ use SMW\ApplicationFactory;
 use SMW\DIProperty;
 use SMW\Localizer;
 use SMW\Message;
+use SMW\MediaWiki\Pipetrick;
 use SMW\Utils\Image;
 
 /**
@@ -674,9 +675,7 @@ class SMWWikiPageValue extends SMWDataValue {
 
 		# Remove (context) as per pipe trick.
 		if ( ($this->getOption( 'smwgDVFeatures' ) & SMW_DV_WPV_PIPETRICK) != 0 ) {
-			$titleChars = '[' . Title::legalChars() . ']';
-			$pattern = "/($titleChars+?)( ?\\($titleChars+\\))/";
-			$displayTitle = preg_replace($pattern, '\\1', $displayTitle);
+			$displayTitle = Pipetrick::apply($displayTitle);
 		}
 
 		return $displayTitle . $fragmentText;

--- a/src/Defines.php
+++ b/src/Defines.php
@@ -165,6 +165,7 @@ define( 'SMW_DV_PVUC', 128 );  // Declares a uniqueness constraint
 define( 'SMW_DV_TIMEV_CM', 256 );  // TimeValue to indicate calendar model
 define( 'SMW_DV_PPLB', 512 );  // Preferred property label
 define( 'SMW_DV_PROV_LHNT', 1024 );  // PropertyValue to output a hint in case of a preferred label usage
+define( 'SMW_DV_WPV_PIPETRICK', 2048 );  // Have WikiPageValue use a full pipe trick when rendering its caption.
 /**@}*/
 
 /**@{

--- a/src/MediaWiki/Pipetrick.php
+++ b/src/MediaWiki/Pipetrick.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace SMW\MediaWiki;
+
+class Pipetrick {
+	/**
+ 	 * Apply the pipe trick to a page name (not a complete link).
+	 *
+	 * See MediaWiki includes/parser/Parser.php pstPass2() for details. Removed
+	 * the opening/closing of links ([[A|b]]), instead it considers the start
+	 * and close of the string. Maybe one day MediaWiki will refactor this into
+	 * its own function!
+	 *
+	 * Doesn't attempt to apply the reverse pipe trick.
+	 *
+	 * @since 3.0
+	 *
+	 * @param $title string
+	 *
+	 * @return string
+	 */
+	public static function apply( $title ) {
+		# Turn it into a link so we can use the MediaWiki regexes un-changed.
+		$link = '[[' . $title . '|]]';
+
+		# Regexes taken from MediaWiki parser.php. Maybe some day they'll factor it
+		# into its own function!
+
+		$tc = '[' . \Title::legalChars() . ']';
+		$nc = '[ _0-9A-Za-z\x80-\xff-]'; # Namespaces can use non-ascii!
+		// [[ns:page (context)|]]
+		$p1 = "/\[\[(:?$nc+:|:|)($tc+?)( ?\\($tc+\\))\\|]]/";
+		// [[ns:page  ^ context  ^ |]] (double-width brackets, added in r40257)
+		$p4 = "/\[\[(:?$nc+:|:|)($tc+?)( ?  ^ $tc+  ^ )\\|]]/";
+		// [[ns:page (context), context|]] (using either single or double-width comma)
+		$p3 = "/\[\[(:?$nc+:|:|)($tc+?)( ?\\($tc+\\)|)((?:, |  ^ )$tc+|)\\|]]/";
+
+		# try $p1 first, to turn "[[A, B (C)|]]" into "[[A, B (C)|A, B]]"
+		$link = preg_replace( $p1, '[[\\1\\2\\3|\\2]]', $link );
+		$link = preg_replace( $p4, '[[\\1\\2\\3|\\2]]', $link );
+		$link = preg_replace( $p3, '[[\\1\\2\\3\\4|\\2]]', $link );
+
+		# Now take the caption text.
+		$caption = "^.*/\\|([^\]]*)]]$/";
+		$link = preg_replace( $caption, '\\1', $link );
+
+		return $link;
+	}
+}

--- a/src/MediaWiki/Pipetrick.php
+++ b/src/MediaWiki/Pipetrick.php
@@ -41,7 +41,7 @@ class Pipetrick {
 		$link = preg_replace( $p3, '[[\\1\\2\\3\\4|\\2]]', $link );
 
 		# Now take the caption text.
-		$caption = "^.*/\\|([^\]]*)]]$/";
+		$caption = "/^.*?\|(.*)]]$/";
 		$link = preg_replace( $caption, '\\1', $link );
 
 		return $link;

--- a/tests/phpunit/Integration/JSONScript/TestCases/p-0918.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/p-0918.json
@@ -1,90 +1,24 @@
 {
-	"description": "Test `_eid` with multiple substitutes",
+	"description": "Test #ask with pipe trick output.",
 	"setup": [
 		{
-			"namespace": "SMW_NS_PROPERTY",
-			"page": "wikipedia",
-			"contents": "[[Has type::External identifier]][[External formatter uri::https://en.wikipedia.org/w/index.php?title=$1&oldid=$2]]"
+			"page": "Page0 (parens)",
+			"namespace": "NS_MAIN",
+			"contents": "[[Category:cat]]"
 		},
 		{
-			"namespace": "SMW_NS_PROPERTY",
-			"page": "wikipedia:diff",
-			"contents": "[[Has type::External identifier]][[External formatter uri::https://en.wikipedia.org/w/index.php?title=$1&oldid=$2&diff=$3]]"
+			"page": "P0918/Q.1",
+			"namespace": "NS_MAIN",
+			"contents": "{{#ask: [[Category:cat]]}}"
 		},
-		{
-			"page": "Test:P0918/1",
-			"contents": "[[wikipedia::Truid Aagesen{837787373,90}]]"
-		},
-		{
-			"page": "Test:P0918/2",
-			"contents": "[[wikipedia:diff::The Good, the Bad and the Ugly{886770575,887548148}]]"
-		},
-		{
-			"page": "Test:P0918/3",
-			"contents": "[[wikipedia:diff::The Good, the Bad and the Ugly{886770575,887548148\\,comma}]]"
-		}
-	],
 	"tests": [
 		{
 			"type": "parser",
-			"about": "#0 (multiple substitutes)",
-			"subject": "Test:P0918/1",
-			"assert-store": {
-				"semantic-data": {
-					"strict-mode-valuematch": false,
-					"propertyCount": 3,
-					"propertyKeys": [
-						"_MDAT",
-						"_SKEY",
-						"Wikipedia"
-					]
-				}
-			},
+			"about": "#0 (parenthetical page titles stripped as per pipe trick)",
+			"subject": "P0918/Q.1",
 			"assert-output": {
 				"to-contain": [
-					"<span class=\"plainlinks smw-eid\"><a rel=\"nofollow\" class=\"external text\" href=\"https://en.wikipedia.org/w/index.php?title=Truid_Aagesen&amp;oldid=837787373\">Truid Aagesen</a></span>"
-				]
-			}
-		},
-		{
-			"type": "parser",
-			"about": "#1 (multiple substitutes, different commas)",
-			"subject": "Test:P0918/2",
-			"assert-store": {
-				"semantic-data": {
-					"strict-mode-valuematch": false,
-					"propertyCount": 3,
-					"propertyKeys": [
-						"_MDAT",
-						"_SKEY",
-						"Wikipedia:diff"
-					]
-				}
-			},
-			"assert-output": {
-				"to-contain": [
-					"<span class=\"plainlinks smw-eid\"><a rel=\"nofollow\" class=\"external text\" href=\"https://en.wikipedia.org/w/index.php?title=The_Good,_the_Bad_and_the_Ugly&amp;oldid=886770575&amp;diff=887548148\">The Good, the Bad and the Ugly</a></span>"
-				]
-			}
-		},
-		{
-			"type": "parser",
-			"about": "#2 (multiple substitutes, different commas)",
-			"subject": "Test:P0918/3",
-			"assert-store": {
-				"semantic-data": {
-					"strict-mode-valuematch": false,
-					"propertyCount": 3,
-					"propertyKeys": [
-						"_MDAT",
-						"_SKEY",
-						"Wikipedia:diff"
-					]
-				}
-			},
-			"assert-output": {
-				"to-contain": [
-					"<span class=\"plainlinks smw-eid\"><a rel=\"nofollow\" class=\"external text\" href=\"https://en.wikipedia.org/w/index.php?title=The_Good,_the_Bad_and_the_Ugly&amp;oldid=886770575&amp;diff=887548148,comma\">The Good, the Bad and the Ugly</a></span>"
+					"Page0"
 				]
 			}
 		}
@@ -95,9 +29,8 @@
 		"smwgPageSpecialProperties": [
 			"_MDAT"
 		],
-		"smwgNamespacesWithSemanticLinks": {
-			"NS_MAIN": true,
-			"SMW_NS_PROPERTY": true
+		"smwgDVFeatures": {
+			"SMW_DV_WPV_PIPETRICK"
 		}
 	},
 	"meta": {

--- a/tests/phpunit/Integration/JSONScript/TestCases/p-0918.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/p-0918.json
@@ -1,24 +1,90 @@
 {
-	"description": "Test #ask with pipe trick output.",
+	"description": "Test `_eid` with multiple substitutes",
 	"setup": [
 		{
-			"page": "Page0 (parens)",
-			"namespace": "NS_MAIN",
-			"contents": "[[Category:cat]]"
+			"namespace": "SMW_NS_PROPERTY",
+			"page": "wikipedia",
+			"contents": "[[Has type::External identifier]][[External formatter uri::https://en.wikipedia.org/w/index.php?title=$1&oldid=$2]]"
 		},
 		{
-			"page": "P0918/Q.1",
-			"namespace": "NS_MAIN",
-			"contents": "{{#ask: [[Category:cat]]}}"
+			"namespace": "SMW_NS_PROPERTY",
+			"page": "wikipedia:diff",
+			"contents": "[[Has type::External identifier]][[External formatter uri::https://en.wikipedia.org/w/index.php?title=$1&oldid=$2&diff=$3]]"
 		},
+		{
+			"page": "Test:P0918/1",
+			"contents": "[[wikipedia::Truid Aagesen{837787373,90}]]"
+		},
+		{
+			"page": "Test:P0918/2",
+			"contents": "[[wikipedia:diff::The Good, the Bad and the Ugly{886770575,887548148}]]"
+		},
+		{
+			"page": "Test:P0918/3",
+			"contents": "[[wikipedia:diff::The Good, the Bad and the Ugly{886770575,887548148\\,comma}]]"
+		}
+	],
 	"tests": [
 		{
 			"type": "parser",
-			"about": "#0 (parenthetical page titles stripped as per pipe trick)",
-			"subject": "P0918/Q.1",
+			"about": "#0 (multiple substitutes)",
+			"subject": "Test:P0918/1",
+			"assert-store": {
+				"semantic-data": {
+					"strict-mode-valuematch": false,
+					"propertyCount": 3,
+					"propertyKeys": [
+						"_MDAT",
+						"_SKEY",
+						"Wikipedia"
+					]
+				}
+			},
 			"assert-output": {
 				"to-contain": [
-					"Page0"
+					"<span class=\"plainlinks smw-eid\"><a rel=\"nofollow\" class=\"external text\" href=\"https://en.wikipedia.org/w/index.php?title=Truid_Aagesen&amp;oldid=837787373\">Truid Aagesen</a></span>"
+				]
+			}
+		},
+		{
+			"type": "parser",
+			"about": "#1 (multiple substitutes, different commas)",
+			"subject": "Test:P0918/2",
+			"assert-store": {
+				"semantic-data": {
+					"strict-mode-valuematch": false,
+					"propertyCount": 3,
+					"propertyKeys": [
+						"_MDAT",
+						"_SKEY",
+						"Wikipedia:diff"
+					]
+				}
+			},
+			"assert-output": {
+				"to-contain": [
+					"<span class=\"plainlinks smw-eid\"><a rel=\"nofollow\" class=\"external text\" href=\"https://en.wikipedia.org/w/index.php?title=The_Good,_the_Bad_and_the_Ugly&amp;oldid=886770575&amp;diff=887548148\">The Good, the Bad and the Ugly</a></span>"
+				]
+			}
+		},
+		{
+			"type": "parser",
+			"about": "#2 (multiple substitutes, different commas)",
+			"subject": "Test:P0918/3",
+			"assert-store": {
+				"semantic-data": {
+					"strict-mode-valuematch": false,
+					"propertyCount": 3,
+					"propertyKeys": [
+						"_MDAT",
+						"_SKEY",
+						"Wikipedia:diff"
+					]
+				}
+			},
+			"assert-output": {
+				"to-contain": [
+					"<span class=\"plainlinks smw-eid\"><a rel=\"nofollow\" class=\"external text\" href=\"https://en.wikipedia.org/w/index.php?title=The_Good,_the_Bad_and_the_Ugly&amp;oldid=886770575&amp;diff=887548148,comma\">The Good, the Bad and the Ugly</a></span>"
 				]
 			}
 		}
@@ -29,8 +95,9 @@
 		"smwgPageSpecialProperties": [
 			"_MDAT"
 		],
-		"smwgDVFeatures": {
-			"SMW_DV_WPV_PIPETRICK"
+		"smwgNamespacesWithSemanticLinks": {
+			"NS_MAIN": true,
+			"SMW_NS_PROPERTY": true
 		}
 	},
 	"meta": {

--- a/tests/phpunit/Integration/JSONScript/TestCases/p-0921.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/p-0921.json
@@ -1,0 +1,41 @@
+{
+	"description": "Test #ask with pipe trick output.",
+	"setup": [
+		{
+			"page": "Page0 (parens)",
+			"namespace": "NS_MAIN",
+			"contents": "[[Category:cat]]"
+		},
+		{
+			"page": "P0918/Q.1",
+			"namespace": "NS_MAIN",
+			"contents": "{{#ask: [[Category:cat]]}}"
+		},
+	"tests": [
+		{
+			"type": "parser",
+			"about": "#0 (parenthetical page titles stripped as per pipe trick)",
+			"subject": "P0918/Q.1",
+			"assert-output": {
+				"to-contain": [
+					"Page0"
+				]
+			}
+		}
+	],
+	"settings": {
+		"wgContLang": "en",
+		"wgLang": "en",
+		"smwgPageSpecialProperties": [
+			"_MDAT"
+		],
+		"smwgDVFeatures": {
+			"SMW_DV_WPV_PIPETRICK"
+		}
+	},
+	"meta": {
+		"version": "2",
+		"is-incomplete": false,
+		"debug": false
+	}
+}

--- a/tests/phpunit/Integration/JSONScript/TestCases/p-0921.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/p-0921.json
@@ -10,7 +10,8 @@
 			"page": "P0918/Q.1",
 			"namespace": "NS_MAIN",
 			"contents": "{{#ask: [[Category:cat]]}}"
-		},
+		}
+	],
 	"tests": [
 		{
 			"type": "parser",
@@ -29,9 +30,9 @@
 		"smwgPageSpecialProperties": [
 			"_MDAT"
 		],
-		"smwgDVFeatures": {
+		"smwgDVFeatures": [
 			"SMW_DV_WPV_PIPETRICK"
-		}
+		]
 	},
 	"meta": {
 		"version": "2",

--- a/tests/phpunit/Unit/MediaWiki/PipetrickTest.php
+++ b/tests/phpunit/Unit/MediaWiki/PipetrickTest.php
@@ -5,15 +5,41 @@ namespace SMW\Tests\MediaWiki;
 use SMW\MediaWiki\Pipetrick;
 
 /**
- * @covers \SMW\MediaWiki\Pipetrick
- * @group semantic-mediawiki
- */
+* @covers \SMW\MediaWiki\Pipetrick
+* @group semantic-mediawiki
+*/
 class PipetrickTest extends \PHPUnit_Framework_TestCase {
-	public function testPipetrick() {
-		$in = 'Yours, Mine and Ours (1968 film)';
-		$this->assertEquals('Yours, Mine and Ours', Pipetrick::apply($in));
+	/**
+	 * @dataProvider textProvider
+	 */
+	public function testPipetrick( $text, $expected ) {
+		$this->assertEquals(
+			$expected,
+			Pipetrick::apply( $text )
+		);
+	}
 
-		$in = 'Il Buono, il Brutto, il Cattivo';
-		$this->assertEquals('Il Buono', Pipetrick::apply($in));
+	public function textProvider() {
+		// https://en.wikipedia.org/wiki/Help:Pipe_trick
+
+		yield [
+			'Yours, Mine and Ours (1968 film)',
+			'Yours, Mine and Ours'
+		];
+
+		yield [
+			'Il Buono, il Brutto, il Cattivo',
+			'Il Buono'
+		];
+
+		yield [
+			':es:Wikipedia:Políticas',
+			'Wikipedia:Políticas'
+		];
+
+		yield [
+			'Wikipedia:Manual of Style (Persian)',
+			'Manual of Style'
+		];
 	}
 }

--- a/tests/phpunit/Unit/MediaWiki/PipetrickTest.php
+++ b/tests/phpunit/Unit/MediaWiki/PipetrickTest.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace SMW\Tests\MediaWiki;
+
+use SMW\MediaWiki\Pipetrick;
+
+/**
+ * @covers \SMW\MediaWiki\Pipetrick
+ * @group semantic-mediawiki
+ */
+class PipetrickTest extends \PHPUnit_Framework_TestCase {
+	public function testPipetrick() {
+		$in = 'Yours, Mine and Ours (1968 film)';
+		$this->assertEquals('Yours, Mine and Ours', Pipetrick::apply($in));
+
+		$in = 'Il Buono, il Brutto, il Cattivo';
+		$this->assertEquals('Il Buono', Pipetrick::apply($in));
+	}
+}


### PR DESCRIPTION
This PR is made in reference to: #875

This PR addresses or contains:
- Ask queries returning only a partial pipe trick, rather than the full pipe trick (unexpected behavior)
- Adds `SMW_DV_WPV_PIPETRICK` as flag to the `smwgDVFeatures` setting to use the newly introduced `Pipetrick ` (off by default)
- Adds unit and integration tests with examples from https://en.wikipedia.org/wiki/Help:Pipe_trick

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed

Fixes #875 