### PR TITLE
Streamline hooks, refs 3141

### DIFF
--- a/includes/Settings.php
+++ b/includes/Settings.php
@@ -185,7 +185,11 @@ class Settings extends Options {
 
 		self::initLegacyMapping( $configuration );
 
+		// Deprecated since 3.1
 		\Hooks::run( 'SMW::Config::BeforeCompletion', [ &$configuration ] );
+
+		// Since 3.1
+		\Hooks::run( 'SMW::Settings::BeforeInitializationComplete', [ &$configuration ] );
 
 		if ( self::$instance === null ) {
 			self::$instance = self::newFromArray( $configuration );

--- a/includes/storage/SQLStore/SMW_SQLStore3_Writers.php
+++ b/includes/storage/SQLStore/SMW_SQLStore3_Writers.php
@@ -174,7 +174,14 @@ class SMWSQLStore3Writers {
 	 * @param SMWSemanticData $data
 	 */
 	public function doDataUpdate( SMWSemanticData $semanticData ) {
+
+		// Deprecated since 3.1, use SMW::SQLStore::BeforeDataUpdateComplete
 		\Hooks::run( 'SMWSQLStore3::updateDataBefore', [ $this->store, $semanticData ] );
+
+		\Hooks::run( 'SMW::SQLStore::BeforeDataUpdateComplete', [
+			$this->store,
+			$semanticData
+		] );
 
 		$subject = $semanticData->getSubject();
 

--- a/src/Store.php
+++ b/src/Store.php
@@ -229,17 +229,17 @@ abstract class Store implements QueryEngine {
 		$subject = $semanticData->getSubject();
 		$hash = $subject->getHash();
 
-		/**
-		 * @since 1.6
-		 */
+		// Deprecated since 3.1, use SMW::Store::BeforeDataUpdateComplete
 		\Hooks::run( 'SMWStore::updateDataBefore', [ $this, $semanticData ] );
+
+		\Hooks::run( 'SMW::Store::BeforeDataUpdateComplete', [ $this, $semanticData ] );
 
 		$this->doDataUpdate( $semanticData );
 
-		/**
-		 * @since 1.6
-		 */
+		// Deprecated since 3.1, use SMW::Store::AfterDataUpdateComplete
 		\Hooks::run( 'SMWStore::updateDataAfter', [ $this, $semanticData ] );
+
+		\Hooks::run( 'SMW::Store::AfterDataUpdateComplete', [ $this, $semanticData ] );
 
 		$rev = $semanticData->getExtensionData( 'revision_id' );
 		$procTime = Timer::getElapsedTime( __METHOD__, 5 );

--- a/tests/phpunit/Utils/MwHooksHandler.php
+++ b/tests/phpunit/Utils/MwHooksHandler.php
@@ -23,6 +23,9 @@ class MwHooksHandler {
 
 	private $listOfSmwHooks = [
 		'SMWStore::updateDataBefore',
+		'SMW::Store::BeforeDataUpdateComplete',
+		'SMWStore::updateDataAfter',
+		'SMW::Store::AfterDataUpdateComplete',
 
 		// Those shoudl not be disabled so that extension used
 		// by a test will run the registration in case an instance
@@ -44,7 +47,10 @@ class MwHooksHandler {
 		'SMW::SQLStore::AddCustomFixedPropertyTables',
 		'SMW::SQLStore::AfterDataUpdateComplete',
 		'SMW::Browse::AfterIncomingPropertiesLookupComplete',
-		'SMW::Browse::BeforeIncomingPropertyValuesFurtherLinkCreate'
+		'SMW::Browse::BeforeIncomingPropertyValuesFurtherLinkCreate',
+
+		'SMWSQLStore3::updateDataBefore',
+		'SMW::SQLStore::BeforeDataUpdateComplete'
 	];
 
 	/**


### PR DESCRIPTION
This PR is made in reference to: #3141

This PR addresses or contains:

- Deprecates `SMWSQLStore3::updateDataBefore` and be replaced by `SMW::SQLStore::BeforeDataUpdateComplete`
- Deprecates `SMWStore::updateDataBefore` and be replaced by `SMW::Store::BeforeDataUpdateComplete`
- Deprecates `SMWStore::updateDataAfter` and be replaced by `SMW::Store::AfterDataUpdateComplete`

This PR includes:
- [ ] Tests (unit/integration)
- [x] CI build passed
