### PR TITLE
[ES] Add `TestClient` to isolate in-test connection

### DIFF
--- a/src/Elastic/Connection/Client.php
+++ b/src/Elastic/Connection/Client.php
@@ -69,11 +69,6 @@ class Client {
 	/**
 	 * @var boolean
 	 */
-	private $inTest = false;
-
-	/**
-	 * @var boolean
-	 */
 	private static $hasIndex = [];
 
 	/**
@@ -87,7 +82,6 @@ class Client {
 		$this->client = $client;
 		$this->lockManager = $lockManager;
 		$this->options = $options;
-		$this->inTest = defined( 'MW_PHPUNIT_TEST' );
 
 		if ( $this->options === null ) {
 			$this->options = new Options();
@@ -638,10 +632,6 @@ class Client {
 			'response' => ''
 		];
 
-		if ( $this->inTest ) {
-			$params = $params + [ 'refresh' => true ];
-		}
-
 		try {
 			$response = $this->client->bulk( $params );
 
@@ -696,12 +686,6 @@ class Client {
 		$results = [];
 		$time = -microtime( true );
 
-		// https://discuss.elastic.co/t/es-5-2-refresh-interval-doesnt-work-if-set-to-0/79248/2
-		// Make sure the replication/index lag doesn't hinder the search
-		if ( $this->inTest ) {
-			$this->client->indices()->refresh( [ 'index' => $params['index'] ] );
-		}
-
 		// ... "_source", "from", "profile", "query", "size", "sort" are not valid parameters.
 		unset( $params['body']['sort'] );
 		unset( $params['body']['_source'] );
@@ -748,12 +732,6 @@ class Client {
 
 		$time = -microtime( true );
 
-		// https://discuss.elastic.co/t/es-5-2-refresh-interval-doesnt-work-if-set-to-0/79248/2
-		// Make sure the replication/index lag doesn't hinder the search
-		if ( $this->inTest ) {
-			$this->client->indices()->refresh( [ 'index' => $params['index'] ] );
-		}
-
 		try {
 			$results = $this->client->search( $params );
 		} catch ( NoNodesAvailableException $e ) {
@@ -792,12 +770,6 @@ class Client {
 
 		if ( $params === [] ) {
 			return [];
-		}
-
-		// https://discuss.elastic.co/t/es-5-2-refresh-interval-doesnt-work-if-set-to-0/79248/2
-		// Make sure the replication/index lag doesn't hinder the search
-		if ( $this->inTest ) {
-			$this->client->indices()->refresh( [ 'index' => $params['index'] ] );
 		}
 
 		return $this->client->explain( $params );

--- a/src/Elastic/Connection/TestClient.php
+++ b/src/Elastic/Connection/TestClient.php
@@ -1,0 +1,96 @@
+<?php
+
+namespace SMW\Elastic\Connection;
+
+/**
+ * @private
+ *
+ * !! Only used during integration testing!!
+ *
+ * @license GNU GPL v2+
+ * @since 3.1
+ *
+ * @author mwjames
+ */
+class TestClient extends Client {
+
+	/**
+	 * @see Client::bulk
+	 * @since 3.0
+	 *
+	 * @param array $params
+	 */
+	public function bulk( array $params ) {
+
+		if ( $params === [] ) {
+			return;
+		}
+
+		$params = $params + [ 'refresh' => true ];
+
+		return parent::bulk( $params );
+	}
+
+	/**
+	 * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/search-count.html
+	 * @see Client::count
+	 * @since 3.0
+	 *
+	 * @param array $params
+	 *
+	 * @return mixed
+	 */
+	public function count( array $params ) {
+
+		if ( $params === [] ) {
+			return [];
+		}
+
+		// https://discuss.elastic.co/t/es-5-2-refresh-interval-doesnt-work-if-set-to-0/79248/2
+		// Make sure the replication/index lag doesn't hinder the search
+		$this->indices()->refresh( [ 'index' => $params['index'] ] );
+
+		return parent::count( $params );
+	}
+
+	/**
+	 * @see Client::search
+	 * @since 3.0
+	 *
+	 * @param array $params
+	 *
+	 * @return array
+	 */
+	public function search( array $params ) {
+
+		if ( $params === [] ) {
+			return [];
+		}
+
+		$this->indices()->refresh( [ 'index' => $params['index'] ] );
+
+		return parent::search( $params );
+	}
+
+	/**
+	 * @see Client::explain
+	 * @since 3.0
+	 *
+	 * @param array $params
+	 *
+	 * @return mixed
+	 */
+	public function explain( array $params ) {
+
+		if ( $params === [] ) {
+			return [];
+		}
+
+		// https://discuss.elastic.co/t/es-5-2-refresh-interval-doesnt-work-if-set-to-0/79248/2
+		// Make sure the replication/index lag doesn't hinder the search
+		$this->indices()->refresh( [ 'index' => $params['index'] ] );
+
+		return parent::explain( $params );
+	}
+
+}


### PR DESCRIPTION
This PR is made in reference to: #

This PR addresses or contains:

- Removes the `MW_PHPUNIT_TEST` dependency from `Client` and isolates those methods that need special treatment during testing into the `TestClient`

This PR includes:
- [ ] Tests (unit/integration)
- [x] CI build passed
