### PR TITLE
Rem `wgVersion` usage, refs 3635

### DIFF
--- a/tests/phpunit/Unit/MediaWiki/HooksTest.php
+++ b/tests/phpunit/Unit/MediaWiki/HooksTest.php
@@ -174,7 +174,6 @@ class HooksTest extends \PHPUnit_Framework_TestCase {
 
 		$vars = [
 			'IP' => 'bar',
-		//	'wgVersion' => '1.24',
 			'wgLang' => $language,
 			'smwgEnabledDeferredUpdate' => false
 		];
@@ -201,7 +200,6 @@ class HooksTest extends \PHPUnit_Framework_TestCase {
 
 		$vars = [
 			'IP' => 'bar',
-		//	'wgVersion' => '1.24',
 			'wgLang' => $language,
 			'smwgEnabledDeferredUpdate' => false
 		];

--- a/tests/phpunit/Unit/SQLStore/TableBuilder/MySQLTableBuilderTest.php
+++ b/tests/phpunit/Unit/SQLStore/TableBuilder/MySQLTableBuilderTest.php
@@ -65,7 +65,7 @@ class MySQLTableBuilderTest extends \PHPUnit_Framework_TestCase {
 
 	public function testCreateNewTable() {
 
-		if ( version_compare( $GLOBALS['wgVersion'], '1.32', '>=' ) ) {
+		if ( version_compare( MW_VERSION, '1.32', '>=' ) ) {
 			$this->markTestSkipped( 'MediaWiki changed the Database signature!' );
 		}
 
@@ -98,7 +98,7 @@ class MySQLTableBuilderTest extends \PHPUnit_Framework_TestCase {
 
 	public function testCreateNewTable_132() {
 
-		if ( version_compare( $GLOBALS['wgVersion'], '1.32', '<' ) ) {
+		if ( version_compare( MW_VERSION, '1.32', '<' ) ) {
 			$this->markTestSkipped( 'MediaWiki changed the Database signature!' );
 		}
 
@@ -122,7 +122,7 @@ class MySQLTableBuilderTest extends \PHPUnit_Framework_TestCase {
 
 	public function testUpdateExistingTableWithNewField() {
 
-		if ( version_compare( $GLOBALS['wgVersion'], '1.32', '>=' ) ) {
+		if ( version_compare( MW_VERSION, '1.32', '>=' ) ) {
 			$this->markTestSkipped( 'MediaWiki changed the Database signature!' );
 		}
 
@@ -158,7 +158,7 @@ class MySQLTableBuilderTest extends \PHPUnit_Framework_TestCase {
 
 	public function testUpdateExistingTableWithNewField_132() {
 
-		if ( version_compare( $GLOBALS['wgVersion'], '1.32', '<' ) ) {
+		if ( version_compare( MW_VERSION, '1.32', '<' ) ) {
 			$this->markTestSkipped( 'MediaWiki changed the Database signature!' );
 		}
 
@@ -185,7 +185,7 @@ class MySQLTableBuilderTest extends \PHPUnit_Framework_TestCase {
 
 	public function testUpdateExistingTableWithNewFieldAndDefault() {
 
-		if ( version_compare( $GLOBALS['wgVersion'], '1.32', '>=' ) ) {
+		if ( version_compare( MW_VERSION, '1.32', '>=' ) ) {
 			$this->markTestSkipped( 'MediaWiki changed the Database signature!' );
 		}
 
@@ -222,7 +222,7 @@ class MySQLTableBuilderTest extends \PHPUnit_Framework_TestCase {
 
 	public function testUpdateExistingTableWithNewFieldAndDefault_132() {
 
-		if ( version_compare( $GLOBALS['wgVersion'], '1.32', '<' ) ) {
+		if ( version_compare( MW_VERSION, '1.32', '<' ) ) {
 			$this->markTestSkipped( 'MediaWiki changed the Database signature!' );
 		}
 
@@ -250,7 +250,7 @@ class MySQLTableBuilderTest extends \PHPUnit_Framework_TestCase {
 
 	public function testCreateIndex() {
 
-		if ( version_compare( $GLOBALS['wgVersion'], '1.32', '>=' ) ) {
+		if ( version_compare( MW_VERSION, '1.32', '>=' ) ) {
 			$this->markTestSkipped( 'MediaWiki changed the Database signature!' );
 		}
 
@@ -287,7 +287,7 @@ class MySQLTableBuilderTest extends \PHPUnit_Framework_TestCase {
 
 	public function testCreateIndex_132() {
 
-		if ( version_compare( $GLOBALS['wgVersion'], '1.32', '<' ) ) {
+		if ( version_compare( MW_VERSION, '1.32', '<' ) ) {
 			$this->markTestSkipped( 'MediaWiki changed the Database signature!' );
 		}
 
@@ -315,7 +315,7 @@ class MySQLTableBuilderTest extends \PHPUnit_Framework_TestCase {
 
 	public function testDropTable() {
 
-		if ( version_compare( $GLOBALS['wgVersion'], '1.32', '>=' ) ) {
+		if ( version_compare( MW_VERSION, '1.32', '>=' ) ) {
 			$this->markTestSkipped( 'MediaWiki changed the Database signature!' );
 		}
 
@@ -344,7 +344,7 @@ class MySQLTableBuilderTest extends \PHPUnit_Framework_TestCase {
 
 	public function testDropTable_132() {
 
-		if ( version_compare( $GLOBALS['wgVersion'], '1.32', '<' ) ) {
+		if ( version_compare( MW_VERSION, '1.32', '<' ) ) {
 			$this->markTestSkipped( 'MediaWiki changed the Database signature!' );
 		}
 
@@ -364,7 +364,7 @@ class MySQLTableBuilderTest extends \PHPUnit_Framework_TestCase {
 
 	public function testOptimizeTable() {
 
-		if ( version_compare( $GLOBALS['wgVersion'], '1.32', '>=' ) ) {
+		if ( version_compare( MW_VERSION, '1.32', '>=' ) ) {
 			$this->markTestSkipped( 'MediaWiki changed the Database signature!' );
 		}
 
@@ -393,7 +393,7 @@ class MySQLTableBuilderTest extends \PHPUnit_Framework_TestCase {
 
 	public function testOptimizeTable_132() {
 
-		if ( version_compare( $GLOBALS['wgVersion'], '1.32', '<' ) ) {
+		if ( version_compare( MW_VERSION, '1.32', '<' ) ) {
 			$this->markTestSkipped( 'MediaWiki changed the Database signature!' );
 		}
 

--- a/tests/phpunit/Unit/SQLStore/TableBuilder/PostgresTableBuilderTest.php
+++ b/tests/phpunit/Unit/SQLStore/TableBuilder/PostgresTableBuilderTest.php
@@ -48,7 +48,7 @@ class PostgresTableBuilderTest extends \PHPUnit_Framework_TestCase {
 
 	public function testCreateTableOnNewTable() {
 
-		if ( version_compare( $GLOBALS['wgVersion'], '1.32', '>=' ) ) {
+		if ( version_compare( MW_VERSION, '1.32', '>=' ) ) {
 			$this->markTestSkipped( 'MediaWiki changed the Database signature!' );
 		}
 
@@ -70,7 +70,7 @@ class PostgresTableBuilderTest extends \PHPUnit_Framework_TestCase {
 
 	public function testCreateTableOnNewTable_132() {
 
-		if ( version_compare( $GLOBALS['wgVersion'], '1.32', '<' ) ) {
+		if ( version_compare( MW_VERSION, '1.32', '<' ) ) {
 			$this->markTestSkipped( 'MediaWiki changed the Database signature!' );
 		}
 
@@ -92,7 +92,7 @@ class PostgresTableBuilderTest extends \PHPUnit_Framework_TestCase {
 
 	public function testUpdateTableWithNewField() {
 
-		if ( version_compare( $GLOBALS['wgVersion'], '1.32', '>=' ) ) {
+		if ( version_compare( MW_VERSION, '1.32', '>=' ) ) {
 			$this->markTestSkipped( 'MediaWiki changed the Database signature!' );
 		}
 
@@ -119,7 +119,7 @@ class PostgresTableBuilderTest extends \PHPUnit_Framework_TestCase {
 
 	public function testUpdateTableWithNewField_132() {
 
-		if ( version_compare( $GLOBALS['wgVersion'], '1.32', '<' ) ) {
+		if ( version_compare( MW_VERSION, '1.32', '<' ) ) {
 			$this->markTestSkipped( 'MediaWiki changed the Database signature!' );
 		}
 
@@ -146,7 +146,7 @@ class PostgresTableBuilderTest extends \PHPUnit_Framework_TestCase {
 
 	public function testUpdateTableWithNewFieldAndDefault() {
 
-		if ( version_compare( $GLOBALS['wgVersion'], '1.32', '>=' ) ) {
+		if ( version_compare( MW_VERSION, '1.32', '>=' ) ) {
 			$this->markTestSkipped( 'MediaWiki changed the Database signature!' );
 		}
 
@@ -174,7 +174,7 @@ class PostgresTableBuilderTest extends \PHPUnit_Framework_TestCase {
 
 	public function testUpdateTableWithNewFieldAndDefault_132() {
 
-		if ( version_compare( $GLOBALS['wgVersion'], '1.32', '<' ) ) {
+		if ( version_compare( MW_VERSION, '1.32', '<' ) ) {
 			$this->markTestSkipped( 'MediaWiki changed the Database signature!' );
 		}
 
@@ -202,7 +202,7 @@ class PostgresTableBuilderTest extends \PHPUnit_Framework_TestCase {
 
 	public function testCreateIndex() {
 
-		if ( version_compare( $GLOBALS['wgVersion'], '1.32', '>=' ) ) {
+		if ( version_compare( MW_VERSION, '1.32', '>=' ) ) {
 			$this->markTestSkipped( 'MediaWiki changed the Database signature!' );
 		}
 
@@ -234,7 +234,7 @@ class PostgresTableBuilderTest extends \PHPUnit_Framework_TestCase {
 
 	public function testCreateIndex_132() {
 
-		if ( version_compare( $GLOBALS['wgVersion'], '1.32', '<' ) ) {
+		if ( version_compare( MW_VERSION, '1.32', '<' ) ) {
 			$this->markTestSkipped( 'MediaWiki changed the Database signature!' );
 		}
 
@@ -266,7 +266,7 @@ class PostgresTableBuilderTest extends \PHPUnit_Framework_TestCase {
 
 	public function testDropTable() {
 
-		if ( version_compare( $GLOBALS['wgVersion'], '1.32', '>=' ) ) {
+		if ( version_compare( MW_VERSION, '1.32', '>=' ) ) {
 			$this->markTestSkipped( 'MediaWiki changed the Database signature!' );
 		}
 
@@ -286,7 +286,7 @@ class PostgresTableBuilderTest extends \PHPUnit_Framework_TestCase {
 
 	public function testDropTable_132() {
 
-		if ( version_compare( $GLOBALS['wgVersion'], '1.32', '<' ) ) {
+		if ( version_compare( MW_VERSION, '1.32', '<' ) ) {
 			$this->markTestSkipped( 'MediaWiki changed the Database signature!' );
 		}
 
@@ -306,7 +306,7 @@ class PostgresTableBuilderTest extends \PHPUnit_Framework_TestCase {
 
 	public function testDoCheckOnAfterCreate() {
 
-		if ( version_compare( $GLOBALS['wgVersion'], '1.32', '>=' ) ) {
+		if ( version_compare( MW_VERSION, '1.32', '>=' ) ) {
 			$this->markTestSkipped( 'MediaWiki changed the Database signature!' );
 		}
 
@@ -325,7 +325,7 @@ class PostgresTableBuilderTest extends \PHPUnit_Framework_TestCase {
 
 	public function testDoCheckOnAfterCreate_132() {
 
-		if ( version_compare( $GLOBALS['wgVersion'], '1.32', '<' ) ) {
+		if ( version_compare( MW_VERSION, '1.32', '<' ) ) {
 			$this->markTestSkipped( 'MediaWiki changed the Database signature!' );
 		}
 
@@ -344,7 +344,7 @@ class PostgresTableBuilderTest extends \PHPUnit_Framework_TestCase {
 
 	public function testOptimizeTable() {
 
-		if ( version_compare( $GLOBALS['wgVersion'], '1.32', '>=' ) ) {
+		if ( version_compare( MW_VERSION, '1.32', '>=' ) ) {
 			$this->markTestSkipped( 'MediaWiki changed the Database signature!' );
 		}
 
@@ -364,7 +364,7 @@ class PostgresTableBuilderTest extends \PHPUnit_Framework_TestCase {
 
 	public function testOptimizeTable_132() {
 
-		if ( version_compare( $GLOBALS['wgVersion'], '1.32', '<' ) ) {
+		if ( version_compare( MW_VERSION, '1.32', '<' ) ) {
 			$this->markTestSkipped( 'MediaWiki changed the Database signature!' );
 		}
 

--- a/tests/phpunit/Unit/SQLStore/TableBuilder/SQLiteTableBuilderTest.php
+++ b/tests/phpunit/Unit/SQLStore/TableBuilder/SQLiteTableBuilderTest.php
@@ -48,7 +48,7 @@ class SQLiteTableBuilderTest extends \PHPUnit_Framework_TestCase {
 
 	public function testCreateTableOnNewTable() {
 
-		if ( version_compare( $GLOBALS['wgVersion'], '1.32', '>=' ) ) {
+		if ( version_compare( MW_VERSION, '1.32', '>=' ) ) {
 			$this->markTestSkipped( 'MediaWiki changed the Database signature!' );
 		}
 
@@ -70,7 +70,7 @@ class SQLiteTableBuilderTest extends \PHPUnit_Framework_TestCase {
 
 	public function testCreateTableOnNewTable_132() {
 
-		if ( version_compare( $GLOBALS['wgVersion'], '1.32', '<' ) ) {
+		if ( version_compare( MW_VERSION, '1.32', '<' ) ) {
 			$this->markTestSkipped( 'MediaWiki changed the Database signature!' );
 		}
 
@@ -92,7 +92,7 @@ class SQLiteTableBuilderTest extends \PHPUnit_Framework_TestCase {
 
 	public function testUpdateTableWithNewField() {
 
-		if ( version_compare( $GLOBALS['wgVersion'], '1.32', '>=' ) ) {
+		if ( version_compare( MW_VERSION, '1.32', '>=' ) ) {
 			$this->markTestSkipped( 'MediaWiki changed the Database signature!' );
 		}
 
@@ -119,7 +119,7 @@ class SQLiteTableBuilderTest extends \PHPUnit_Framework_TestCase {
 
 	public function testUpdateTableWithNewField_132() {
 
-		if ( version_compare( $GLOBALS['wgVersion'], '1.32', '<' ) ) {
+		if ( version_compare( MW_VERSION, '1.32', '<' ) ) {
 			$this->markTestSkipped( 'MediaWiki changed the Database signature!' );
 		}
 
@@ -146,7 +146,7 @@ class SQLiteTableBuilderTest extends \PHPUnit_Framework_TestCase {
 
 	public function testUpdateTableWithNewFieldAndDefault() {
 
-		if ( version_compare( $GLOBALS['wgVersion'], '1.32', '>=' ) ) {
+		if ( version_compare( MW_VERSION, '1.32', '>=' ) ) {
 			$this->markTestSkipped( 'MediaWiki changed the Database signature!' );
 		}
 
@@ -174,7 +174,7 @@ class SQLiteTableBuilderTest extends \PHPUnit_Framework_TestCase {
 
 	public function testUpdateTableWithNewFieldAndDefault_132() {
 
-		if ( version_compare( $GLOBALS['wgVersion'], '1.32', '<' ) ) {
+		if ( version_compare( MW_VERSION, '1.32', '<' ) ) {
 			$this->markTestSkipped( 'MediaWiki changed the Database signature!' );
 		}
 
@@ -202,7 +202,7 @@ class SQLiteTableBuilderTest extends \PHPUnit_Framework_TestCase {
 
 	public function testCreateIndex() {
 
-		if ( version_compare( $GLOBALS['wgVersion'], '1.32', '>=' ) ) {
+		if ( version_compare( MW_VERSION, '1.32', '>=' ) ) {
 			$this->markTestSkipped( 'MediaWiki changed the Database signature!' );
 		}
 
@@ -230,7 +230,7 @@ class SQLiteTableBuilderTest extends \PHPUnit_Framework_TestCase {
 
 	public function testCreateIndex_132() {
 
-		if ( version_compare( $GLOBALS['wgVersion'], '1.32', '<' ) ) {
+		if ( version_compare( MW_VERSION, '1.32', '<' ) ) {
 			$this->markTestSkipped( 'MediaWiki changed the Database signature!' );
 		}
 
@@ -258,7 +258,7 @@ class SQLiteTableBuilderTest extends \PHPUnit_Framework_TestCase {
 
 	public function testDropTable() {
 
-		if ( version_compare( $GLOBALS['wgVersion'], '1.32', '>=' ) ) {
+		if ( version_compare( MW_VERSION, '1.32', '>=' ) ) {
 			$this->markTestSkipped( 'MediaWiki changed the Database signature!' );
 		}
 
@@ -278,7 +278,7 @@ class SQLiteTableBuilderTest extends \PHPUnit_Framework_TestCase {
 
 	public function testDropTable_132() {
 
-		if ( version_compare( $GLOBALS['wgVersion'], '1.32', '<' ) ) {
+		if ( version_compare( MW_VERSION, '1.32', '<' ) ) {
 			$this->markTestSkipped( 'MediaWiki changed the Database signature!' );
 		}
 
@@ -298,7 +298,7 @@ class SQLiteTableBuilderTest extends \PHPUnit_Framework_TestCase {
 
 	public function testOptimizeTable() {
 
-		if ( version_compare( $GLOBALS['wgVersion'], '1.32', '>=' ) ) {
+		if ( version_compare( MW_VERSION, '1.32', '>=' ) ) {
 			$this->markTestSkipped( 'MediaWiki changed the Database signature!' );
 		}
 
@@ -314,7 +314,7 @@ class SQLiteTableBuilderTest extends \PHPUnit_Framework_TestCase {
 
 	public function testOptimizeTable_132() {
 
-		if ( version_compare( $GLOBALS['wgVersion'], '1.32', '<' ) ) {
+		if ( version_compare( MW_VERSION, '1.32', '<' ) ) {
 			$this->markTestSkipped( 'MediaWiki changed the Database signature!' );
 		}
 

--- a/tests/phpunit/includes/SetupTest.php
+++ b/tests/phpunit/includes/SetupTest.php
@@ -49,7 +49,6 @@ class SetupTest extends \PHPUnit_Framework_TestCase {
 			'wgResourceModules' => [],
 			'wgScriptPath'      => '/Foo',
 			'wgServer'          => 'http://example.org',
-			//'wgVersion'         => '1.21',
 			'wgLanguageCode'    => 'en',
 			'wgLang'            => $language,
 			'IP'                => 'Foo',


### PR DESCRIPTION
This PR is made in reference to: #3635

This PR addresses or contains:

- Follow-up to #3635

This PR includes:
- [ ] Tests (unit/integration)
- [x] CI build passed
