### PR TITLE
`DisplayTitleFinder` prefetch base, refs 3920

### DIFF
--- a/src/DisplayTitleFinder.php
+++ b/src/DisplayTitleFinder.php
@@ -75,9 +75,19 @@ class DisplayTitleFinder {
 
 			$key = $this->entityCache->makeKey( 'displaytitle', $dataItem->getHash() );
 
-			if ( $this->entityCache->fetch( $key ) === false ) {
-				$unCachedList[] = $dataItem;
+			if ( $this->entityCache->fetch( $key ) !== false ) {
+				continue;
 			}
+
+			$unCachedList[$dataItem->getSha1()] = $dataItem;
+
+			if ( $dataItem->getSubobjectName() === '' ) {
+				continue;
+			}
+
+			// Fetch the base in case the subobject has no assignment
+			$dataItem = $dataItem->asBase();
+			$unCachedList[$dataItem->getSha1()] = $dataItem;
 		}
 
 		if ( $unCachedList === [] ) {
@@ -90,9 +100,9 @@ class DisplayTitleFinder {
 			$unCachedList
 		);
 
-		foreach ( $unCachedList as $dataItem ) {
-			$sha1 = $dataItem->getSha1();
+		foreach ( $unCachedList as $sha1 => $dataItem ) {
 
+			// Can be NULL therefore use `array_key_exists` as well
 			if ( !isset( $prefetch[$sha1] ) && !array_key_exists( $sha1, $prefetch ) ) {
 				continue;
 			}
@@ -101,8 +111,7 @@ class DisplayTitleFinder {
 
 			// Nothing found, use the base!
 			if ( $prefetchTitle === null && $dataItem->getSubobjectName() !== '' ) {
-				$base = $dataItem->asBase();
-				$sha1 = $base->getSha1();
+				$sha1 = $dataItem->asBase()->getSha1();
 
 				if ( !isset( $prefetch[$sha1] ) && !array_key_exists( $sha1, $prefetch ) ) {
 					continue;

--- a/tests/phpunit/Unit/DisplayTitleFinderTest.php
+++ b/tests/phpunit/Unit/DisplayTitleFinderTest.php
@@ -210,4 +210,49 @@ class DisplayTitleFinderTest extends \PHPUnit_Framework_TestCase {
 		$instance->prefetchFromList( $subjects );
 	}
 
+	public function testPrefetchFromList_Subobject_Base() {
+
+		$subjects = [
+			DIWikiPage::doUnserialize( 'Foo#0##abc' ),
+		];
+
+		$prefetch = [
+			$subjects[0]->getSha1() => null,
+			$subjects[0]->asBase()->getSha1() => 'Bar',
+		];
+
+		$displayTitleLookup = $this->getMockBuilder( '\SMW\SQLStore\Lookup\DisplayTitleLookup' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$displayTitleLookup->expects( $this->any() )
+			->method( 'prefetchFromList' )
+			->will( $this->returnValue( $prefetch ) );
+
+		$this->store->expects( $this->any() )
+			->method( 'service' )
+			->with( $this->equalTo( 'DisplayTitleLookup' ) )
+			->will( $this->returnValue( $displayTitleLookup ) );
+
+		$this->entityCache->expects( $this->any() )
+			->method( 'fetch' )
+			->will( $this->returnValue( false ) );
+
+		// Stored with a space
+		$this->entityCache->expects( $this->any() )
+			->method( 'save' )
+			->withConsecutive(
+				[ $this->anything(), $this->equalTo( 'Bar' ) ] );
+
+		$this->entityCache->expects( $this->exactly( 2 ) )
+			->method( 'associate' );
+
+		$instance = new DisplayTitleFinder(
+			$this->store,
+			$this->entityCache
+		);
+
+		$instance->prefetchFromList( $subjects );
+	}
+
 }


### PR DESCRIPTION
This PR is made in reference to: #3920

This PR addresses or contains:

- Prefetch the base as well to avoid extra queries when building the display cache entries

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed
