### PR TITLE
Avoid dependency tracking on blocked annotations

### DIFF
--- a/src/ParserData.php
+++ b/src/ParserData.php
@@ -214,6 +214,15 @@ class ParserData {
 	 * @return boolean
 	 */
 	public function isBlocked() {
+		return $this->hasAnnotationBlock();
+	}
+
+	/**
+	 * @since 3.1
+	 *
+	 * @return boolean
+	 */
+	public function hasAnnotationBlock() {
 
 		// ParserOutput::getExtensionData returns null if no value was set for this key
 		if ( $this->parserOutput->getExtensionData( self::ANNOTATION_BLOCK ) !== null &&
@@ -230,7 +239,7 @@ class ParserData {
 	 * @return boolean
 	 */
 	public function canUse() {
-		return !$this->isBlocked();
+		return !$this->hasAnnotationBlock();
 	}
 
 	/**

--- a/src/ParserFunctionFactory.php
+++ b/src/ParserFunctionFactory.php
@@ -118,6 +118,10 @@ class ParserFunctionFactory {
 			$parserData->setOption( $parserData::NO_QUERY_DEPENDENCY_TRACE, $parser->getOptions()->smwAskNoDependencyTracking );
 		}
 
+		if ( $parserData->hasAnnotationBlock() ) {
+			$parserData->setOption( $parserData::NO_QUERY_DEPENDENCY_TRACE, true );
+		}
+
 		// Avoid possible actions during for example stashedit etc.
 		$parserData->setOption( 'request.action', $GLOBALS['wgRequest']->getVal( 'action' ) );
 


### PR DESCRIPTION
This PR is made in reference to: #

This PR addresses or contains:

- Make sure we don't track queries that are embedded through a `format=embedded`

This PR includes:
- [ ] Tests (unit/integration)
- [x] CI build passed
