### PR TITLE
[DOCS] Add example `hook.store.afterqueryresultlookupcomplete.md`, refs 3934

### DIFF
--- a/docs/examples/README.md
+++ b/docs/examples/README.md
@@ -5,3 +5,4 @@
 * [register.custom.datatype.md](register.custom.datatype.md) Shows how to register a new dataType/dataValue using the the `SMW::DataType::initTypes` hook
 * [approve.update.md](approve.update.md) Shows how to alter the data representation in Semantic MediaWiki with the help of selected hooks in connection with the `ApprovedRevs` extension
 * [hook.pagecontentsavecomplete.md](hook.pagecontentsavecomplete.md) Creating subobjects using the `PageContentSaveComplete` hook (see [#2974](https://github.com/SemanticMediaWiki/SemanticMediaWiki/issues/2974))
+* [hook.store.afterqueryresultlookupcomplete.md](hook.store.afterqueryresultlookupcomplete.md) Extending the query result

--- a/docs/examples/hook.store.afterqueryresultlookupcomplete.md
+++ b/docs/examples/hook.store.afterqueryresultlookupcomplete.md
@@ -1,0 +1,70 @@
+This document contains examples on how the [`SMW::Store::AfterQueryResultLookupComplete`](https://github.com/SemanticMediaWiki/SemanticMediaWiki/blob/master/docs/technical/hooks/hook.store.afterqueryresultlookupcomplete.md) hook can be used.
+
+### Match unknown entities
+
+Demonstrates how the `SMW::Store::AfterQueryResultLookupComplete` hook can be used to add unknown entities (not matched by the `QueryEngine`) derived from the query description (see [#3934][issue-3934]).
+
+```php
+use Hooks;
+use SMW\Store;
+use SMW\Query\Language\Disjunction;
+use SMW\Query\Language\ValueDescription;
+use SMWQueryResult as QueryResult;
+
+Hooks::register( 'SMW::Store::AfterQueryResultLookupComplete', function( Store $store, QueryResult &$queryResult ) {
+
+	// Contains matched results from the `QueryEngine`
+	$results = $queryResult->getResults();
+	$map = [];
+
+	// Build a hash map to quickly perform a search on members of the
+	// result set
+	foreach ( $results as $result ) {
+		$map[$result->getSha1()] = true;
+	}
+
+	// Inspect the query ...
+	$query = $queryResult->getQuery();
+	$description = $query->getDescription();
+
+	// #3934
+	// Check query pattern: [[Foo||Bar||Foobar]]
+	if ( $description instanceof Disjunction ) {
+		$descriptions = $description->getDescriptions();
+
+		foreach ( $descriptions as $desc ) {
+			if ( $desc instanceof ValueDescription ) {
+				$dataItem = $desc->getDataItem();
+				$sha1 = $dataItem->getSha1();
+
+				// Already part of the result set?
+				if ( isset( $map[$sha1]) ) {
+					continue;
+				}
+
+				// Extend the result set!!, unordered
+				$results[] = $dataItem;
+				$map[$sha1] = true;
+			}
+		}
+	}
+
+	// Build a new query result object
+	$queryResult = new QueryResult(
+		$queryResult->getPrintRequests(),
+		$query,
+		$results,
+		$store,
+		$queryResult->hasFurtherResults()
+	);
+
+} );
+
+```
+
+## See also
+
+- [query.description.md](https://github.com/SemanticMediaWiki/SemanticMediaWiki/blob/master/docs/technical/code-snippets/query.description.md)
+
+[issue-3934]:https://github.com/SemanticMediaWiki/SemanticMediaWiki/issues/3934
+[doc-about]: # (Examples implementing the `SMW::Store::AfterQueryResultLookupComplete`)

--- a/docs/technical/hooks/hook.store.afterqueryresultlookupcomplete.md
+++ b/docs/technical/hooks/hook.store.afterqueryresultlookupcomplete.md
@@ -12,3 +12,7 @@ Hooks::register( 'SMW::Store::AfterQueryResultLookupComplete', function( $store,
 	return true;
 } );
 ```
+
+## See also
+
+- [`hook.store.afterqueryresultlookupcomplete.md`](https://github.com/SemanticMediaWiki/SemanticMediaWiki/blob/master/docs/examples/hook.store.afterqueryresultlookupcomplete.md)


### PR DESCRIPTION
This PR is made in reference to: #3934

This PR addresses or contains:

This PR includes:
- [ ] Tests (unit/integration)
- [ ] CI build passed
