### PR TITLE
[SMWSearch] Tidy (Profile form)

### DIFF
--- a/src/Defines.php
+++ b/src/Defines.php
@@ -10,6 +10,12 @@
  */
 
 /**@{
+  * Constants for the search type
+  */
+define( 'SMW_SPECIAL_SEARCHTYPE', 'SMWSearch' );
+/**@}*/
+
+/**@{
  * SMW\ResultPrinter related constants that define
  * how/if headers should be displayed
  */

--- a/src/MediaWiki/Hooks/GetPreferences.php
+++ b/src/MediaWiki/Hooks/GetPreferences.php
@@ -72,7 +72,7 @@ class GetPreferences extends HookHandler {
 			'type' => 'toggle',
 			'label-message' => 'smw-prefs-general-options-disable-search-info',
 			'section' => 'smw/general-options',
-			'disabled' => $this->getOption( 'wgSearchType' ) !== 'SMWSearch'
+			'disabled' => $this->getOption( 'wgSearchType' ) !== SMW_SPECIAL_SEARCHTYPE
 		];
 
 		$preferences['smw-prefs-general-options-jobqueue-watchlist'] = [

--- a/src/MediaWiki/Search/ProfileForm/Forms/CustomForm.php
+++ b/src/MediaWiki/Search/ProfileForm/Forms/CustomForm.php
@@ -1,11 +1,12 @@
 <?php
 
-namespace SMW\MediaWiki\Search\Form;
+namespace SMW\MediaWiki\Search\ProfileForm\Forms;
 
 use Html;
 use SMW\DIProperty;
 use Title;
 use WebRequest;
+use SMW\MediaWiki\Search\ProfileForm\FormsBuilder;
 
 /**
  * @private

--- a/src/MediaWiki/Search/ProfileForm/Forms/Field.php
+++ b/src/MediaWiki/Search/ProfileForm/Forms/Field.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace SMW\MediaWiki\Search\Form;
+namespace SMW\MediaWiki\Search\ProfileForm\Forms;
 
 use Html;
 use SMW\Highlighter;

--- a/src/MediaWiki/Search/ProfileForm/Forms/NamespaceForm.php
+++ b/src/MediaWiki/Search/ProfileForm/Forms/NamespaceForm.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace SMW\MediaWiki\Search\Form;
+namespace SMW\MediaWiki\Search\ProfileForm\Forms;
 
 use Html;
 use MWNamespace;

--- a/src/MediaWiki/Search/ProfileForm/Forms/OpenForm.php
+++ b/src/MediaWiki/Search/ProfileForm/Forms/OpenForm.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace SMW\MediaWiki\Search\Form;
+namespace SMW\MediaWiki\Search\ProfileForm\Forms;
 
 use Html;
 use Title;

--- a/src/MediaWiki/Search/ProfileForm/Forms/SortForm.php
+++ b/src/MediaWiki/Search/ProfileForm/Forms/SortForm.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace SMW\MediaWiki\Search\Form;
+namespace SMW\MediaWiki\Search\ProfileForm\Forms;
 
 use Html;
 use WebRequest;

--- a/src/MediaWiki/Search/ProfileForm/FormsBuilder.php
+++ b/src/MediaWiki/Search/ProfileForm/FormsBuilder.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace SMW\MediaWiki\Search\Form;
+namespace SMW\MediaWiki\Search\ProfileForm;
 
 use Html;
 use RuntimeException;

--- a/src/MediaWiki/Search/ProfileForm/FormsFactory.php
+++ b/src/MediaWiki/Search/ProfileForm/FormsFactory.php
@@ -1,7 +1,11 @@
 <?php
 
-namespace SMW\MediaWiki\Search\Form;
+namespace SMW\MediaWiki\Search\ProfileForm;
 
+use SMW\MediaWiki\Search\ProfileForm\Forms\OpenForm;
+use SMW\MediaWiki\Search\ProfileForm\Forms\CustomForm;
+use SMW\MediaWiki\Search\ProfileForm\Forms\SortForm;
+use SMW\MediaWiki\Search\ProfileForm\Forms\NamespaceForm;
 use WebRequest;
 
 /**

--- a/src/MediaWiki/Search/ProfileForm/ProfileForm.php
+++ b/src/MediaWiki/Search/ProfileForm/ProfileForm.php
@@ -1,12 +1,10 @@
 <?php
 
-namespace SMW\MediaWiki\Search;
+namespace SMW\MediaWiki\Search\ProfileForm;
 
 use Html;
 use MWNamespace;
 use SMW;
-use SMW\MediaWiki\Search\Form\FormsBuilder;
-use SMW\MediaWiki\Search\Form\FormsFactory;
 use SMW\Schema\SchemaFactory;
 use SMW\ProcessingErrorMsgHandler;
 use SMW\Utils\HtmlModal;
@@ -23,7 +21,7 @@ use Xml;
  *
  * @author mwjames
  */
-class SearchProfileForm {
+class ProfileForm {
 
 	const PROFILE_NAME = 'smw';
 
@@ -65,21 +63,32 @@ class SearchProfileForm {
 	}
 
 	/**
+	 * @since 3.1
+	 *
+	 * @param string $profile
+	 *
+	 * @return boolean
+	 */
+	public static function isValidProfile( $profile ) {
+		return $profile === ProfileForm::PROFILE_NAME;
+	}
+
+	/**
 	 * @since 3.0
 	 *
 	 * @param string $type
 	 * @param array &$profiles
 	 */
-	public static function addProfile( $type, array &$profiles ) {
+	public static function addProfile( $type, array &$profiles, array $options ) {
 
-		if ( $type !== 'SMWSearch' ) {
+		if ( $type !== SMW_SPECIAL_SEARCHTYPE ) {
 			return;
 		}
 
 		$profiles[self::PROFILE_NAME] = [
 			'message' => 'smw-search-profile',
 			'tooltip' => 'smw-search-profile-tooltip',
-			'namespaces' => \SearchEngine::defaultNamespaces()
+			'namespaces' => $options['default_namespaces']
 		];
 	}
 
@@ -126,7 +135,7 @@ class SearchProfileForm {
 	 * @param string &$form
 	 * @param array $opts
 	 */
-	public function getForm( &$form, array $opts = [] ) {
+	public function buildForm( &$form, array $opts = [] ) {
 
 		$hidden = '';
 		$html = '';

--- a/src/MediaWiki/Search/QueryBuilder.php
+++ b/src/MediaWiki/Search/QueryBuilder.php
@@ -2,7 +2,8 @@
 
 namespace SMW\MediaWiki\Search;
 
-use SMW\MediaWiki\Search\Form\FormsBuilder;
+use SMW\MediaWiki\Search\ProfileForm\FormsBuilder;
+use SMW\MediaWiki\Search\ProfileForm\ProfileForm;
 use SMW\Query\Language\Conjunction;
 use SMW\Query\Language\Disjunction;
 use SMW\Query\Language\NamespaceDescription;
@@ -154,7 +155,7 @@ class QueryBuilder {
 		$prefix_map = [];
 
 		if ( $this->data === [] ) {
-			$data = SearchProfileForm::getFormDefinitions( $store );
+			$data = ProfileForm::getFormDefinitions( $store );
 		} else {
 			$data = $this->data;
 		}
@@ -284,7 +285,5 @@ class QueryBuilder {
 
 		return $fieldValues;
 	}
-
-
 
 }

--- a/src/MediaWiki/Search/README.md
+++ b/src/MediaWiki/Search/README.md
@@ -2,160 +2,36 @@
 
 [SMWSearch](https://www.semantic-mediawiki.org/wiki/Help:SMWSearch) is the `SearchEngine` interface to provide classes and functions to integrate Semantic MediaWiki with `Special:Search`.
 
-It adds support for using #ask queries in the search input field and provides an extended search profile where user defined forms can empower users to find and match entities using property and value input fields.
+It adds support for using `#ask` queries in the `Special:Search` context and provides an extended search profile where user defined forms can empower users to find and match entities using property and value input fields.
 
 ## Extended search profile
 
+In cases where the systems detects forms maintained using the `SEARCH_FORM_SCHEMA`, an extended profile will be visible on the `Special:Search` page allowing users to match and search subjects with help of Semantic MediaWiki.
+
+Details on how to create and maintain forms can be found in the [search.form.md](https://github.com/SemanticMediaWiki/SemanticMediaWiki/blob/master/src/Schema/docs/search.form.md) document.
+
+### Example
+
 ![image](https://user-images.githubusercontent.com/1245473/43684698-7748fd76-9894-11e8-971f-3125892dc9ed.png)
 
-### Defining forms and form fields
-
-Form definitions are expected be created in the [rule namespace](https://www.semantic-mediawiki.org/wiki/Help:Rule) with the [`SEARCH_FORM_DEFINITION_RULE`](https://www.semantic-mediawiki.org/wiki/Help:Rule/Type/SEARCH_FORM_DEFINITION_RULE) as mandatory type to declare field constraints and validation checkpoints (see the `$smwgRuleTypes` setting) required by the type.
-
-Definitions are structured using the JSON format and in the following example represent:
-
-- `"type"` requires `SEARCH_FORM_DEFINITION_RULE`
-- `"forms"` defines a collection of forms
-  - `"Books and journals"` as title of a form
-    - `"Has title"` is a simple input field without any constraints
-    - `"Publication type"` is a input field with additional attributes
-
-<pre>
-{
-    "type": "SEARCH_FORM_DEFINITION_RULE",
-    "forms": {
-        "Books and journals": [
-            "Has title",
-            "Has author",
-            "Has year",
-            {
-                "Publication type": {
-                    "autocomplete": true,
-                    "tooltip": "Some context to be shown ...",
-                    "required": true
-                }
-            },
-            {
-                "Publisher": {
-                    "autocomplete": true
-                    "tooltip": "message-can-be-a-msg-key"
-                }
-            }
-        ],
-        "Media and files": [ ]
-    }
-}
-</pre>
-
-| Attributes | Values | Description |
-|--------------|-----------------|-----------------------------------|
-| autocomplete | true, false | whether the field should add an autocomplete function or not |
-| tooltip | text or msg key | shows a tooltip with either a text or retrieves information from a message key |
-| placeholder | text | shown instead of the property name |
-| required | true, false | whether the field input is required before submitting or not |
-| type | HTML5 | preselect a specific type field |
-
-`default_form` can define a default form that is displayed when no other form was preselected.
-
-<pre>
-{
-    "type": "SEARCH_FORM_DEFINITION_RULE",
-    "default_form": "Books and journals",
-    ...
-}
-</pre>
-
-### Term parser
-
-The `term_parser` prefix can be used to shorten the input cycle and summarize frequent properties so that a user can write:
- - `(in:foobar || phrase:foo bar) lang:fr` instead of
- - `<q>[[in:foobar]] || [[phrase:foo bar]]</q><q>[[Language code::fr]] OR [[Document language::fr]] OR [[File attachment.Content language::fr]] OR [[Has interlanguage link.Page content language::fr]]</q>`
-
-<pre>
-{
-    "type": "SEARCH_FORM_DEFINITION_RULE",
-    "term_parser": {
-        "prefix": {
-            "lang": [
-                "Language code",
-                "Document language",
-                "File attachment.Content language",
-                "Has interlanguage link.Page content language"
-            ]
-        }
-    }
-}
-</pre>
-
-Prefixes are only applicable (and usable as means the shorten the search term) from within the extended search form.
-
-### Namespaces
-
-- ` "namespaces"`
-  - `default_hide` hides the namespace box by default on the extended profile form
-  - `"hide"` identify namespaces that should be hidden from appearing in any SMW related form
-  - `"preselect"` assign a pre-selection of namespaces to a specific form
-    - `"Books and journals"` specific form the pre-selection should be enacted
-
-<pre>
-{
-    "type": "SEARCH_FORM_DEFINITION_RULE",
-    "namespaces": {
-        "default_hide": true,
-        "hide": [
-           "NS_PROJECT",
-           "NS_PROJECT_TALK"
-        ],
-        "preselect": {
-           "Books and journals": [
-                "NS_CUSTOM_BOOKS",
-                "NS_FILE"
-            ],
-           "Media and files": [
-                "NS_FILE"
-            ]
-        }
-    }
-}
-</pre>
-
-
-### Descriptions
-
-Describes a form and is shown at the top of the form fields to inform users about the intent of
-the form.
-
-<pre>
-{
-    "descriptions": {
-        "Books and journals": "Short description to be shown on top of a selected form"
-    }
-}
-</pre>
-
 ## Technical notes
-
-### Search engine
 
 Classes that provide an interface to support MW's `SearchEngine` by transforming a search term into a SMW equivalent expression of query elements.
 
 <pre>
 SMW\MediaWiki\Search
-┃
-┠━ QueryBuilder
-┠━ Search           # Implements the `SearchEngine`
-┠━ SearchResult     # Individual result representation
-┕━ SearchResultSet  # Contains a set of results return from the `QueryEngine`
+   │
+   ├─ QueryBuilder
+   ├─ Search           # Implements the `SearchEngine`
+   ├─ SearchResult     # Individual result representation
+   └─ SearchResultSet  # Contains a set of results return from the `QueryEngine`
 </pre>
-
-### Search profile and form builder
 
 Classes that provide an additional search form to support structured searches in `Special:Search` with the help of the [`SpecialSearchProfileForm`](https://www.mediawiki.org/wiki/Manual:Hooks/SpecialSearchProfileForm) hook.
 
 <pre>
-SMW\MediaWiki\Search
-┃     ┃
-┃     ┕━ Form               # Classes to generate a HTML from a JSON definition
-┃
-┕━ SearchProfileForm        # Interface to the `SpecialSearchProfileForm` hook
+SMW\MediaWiki\Search\ProfileForm
+   │
+   └─ ProfileForm      # Interface to the `SpecialSearchProfileForm` hook
+         └─ Forms      # Classes to generate a HTML from a JSON definition
 </pre>

--- a/src/Schema/docs/search.form.md
+++ b/src/Schema/docs/search.form.md
@@ -1,0 +1,150 @@
+## Objective
+
+The `SEARCH_FORM_SCHEMA` schema type defines forms used in the extended `Special:Search` profile.
+
+## Properties
+
+- `type`
+- `tags` simple tags to categorize a schema
+- `forms` defines the forms and fields to be displayed
+
+### Example
+
+<pre>
+{
+    "type": "SEARCH_FORM_SCHEMA",
+    "forms": {
+        "Foo": [],
+    }
+    "tags": [
+        "search form"
+    ]
+}
+</pre>
+
+#### Form definition
+
+- `type` requires `SEARCH_FORM_SCHEMA`
+- `forms` defines a collection of forms
+  - `Books and journals` as title of a form
+    - `Has title` is a simple input field without any constraints
+    - `Publication type` is a input field with additional attributes
+
+<pre>
+{
+    "type": "SEARCH_FORM_SCHEMA",
+    "forms": {
+        "Books and journals": [
+            "Has title",
+            "Has author",
+            "Has year",
+            {
+                "Publication type": {
+                    "autocomplete": true,
+                    "tooltip": "Some context to be shown ...",
+                    "required": true
+                }
+            },
+            {
+                "Publisher": {
+                    "autocomplete": true
+                    "tooltip": "message-can-be-a-msg-key"
+                }
+            }
+        ],
+        "Media and files": [ ]
+    }
+}
+</pre>
+
+Fields can define attributes such as:
+
+- `autocomplete` (true, false) whether the field should add an autocomplete function or not
+- `tooltip` (text or msg key) shows a tooltip with either a text or retrieves information from a message key
+- `placeholder` (text) shown instead of the property name
+- `required` (true, false) whether the field input is required before submitting or not
+- `type` (HTML5) preselect a specific type field
+
+#### Default form
+
+`default_form` to define a default form that is displayed when no other form was preselected.
+
+<pre>
+{
+    "type": "SEARCH_FORM_SCHEMA",
+    "default_form": "Books and journals",
+    ...
+}
+</pre>
+
+#### Term parser
+
+The `term_parser` prefix can be used to shorten the input cycle and summarize frequent properties so that a user can write:
+ - `(in:foobar || phrase:foo bar) lang:fr` instead of
+ - `<q>[[in:foobar]] || [[phrase:foo bar]]</q><q>[[Language code::fr]] OR [[Document language::fr]] OR [[File attachment.Content language::fr]] OR [[Has interlanguage link.Page content language::fr]]</q>`
+
+<pre>
+{
+    "type": "SEARCH_FORM_SCHEMA",
+    "term_parser": {
+        "prefix": {
+            "lang": [
+                "Language code",
+                "Document language",
+                "File attachment.Content language",
+                "Has interlanguage link.Page content language"
+            ]
+        }
+    }
+}
+</pre>
+
+Prefixes are only applicable (and usable as means the shorten the search term) from within the extended search form.
+
+#### Namespaces
+
+`namespaces` section defines namespaces to be preslected or hidden.
+
+- `default_hide` hides the namespace box by default on the extended profile form
+- `hidden` identifies namespaces that should be hidden from appearing in any SMW related form
+- `preselect` assign a pre-selection of namespaces to a specific form
+
+<pre>
+{
+    "type": "SEARCH_FORM_SCHEMA",
+    "namespaces": {
+        "default_hide": true,
+        "hidden": [
+           "NS_PROJECT",
+           "NS_PROJECT_TALK"
+        ],
+        "preselect": {
+           "Books and journals": [
+                "NS_CUSTOM_BOOKS",
+                "NS_FILE"
+            ],
+           "Media and files": [
+                "NS_FILE"
+            ]
+        }
+    }
+}
+</pre>
+
+#### Descriptions
+
+Describes a form and is shown at the top of the form fields to inform users about the intent of
+the form.
+
+<pre>
+{
+    "type": "SEARCH_FORM_SCHEMA",
+    "descriptions": {
+        "Books and journals": "Short description to be shown on top of a selected form"
+    }
+}
+</pre>
+
+## Validation
+
+`/data/schema/search-form-schema.v1.json`

--- a/src/Services/MediaWikiServices.php
+++ b/src/Services/MediaWikiServices.php
@@ -81,6 +81,21 @@ return [
 	},
 
 	/**
+	 * SearchEngineConfig
+	 *
+	 * @return callable
+	 */
+	'SearchEngineConfig' => function( $containerBuilder ) {
+
+		// > MW 1.27
+		if ( class_exists( '\MediaWiki\MediaWikiServices' ) && method_exists( '\MediaWiki\MediaWikiServices', 'getSearchEngineConfig' ) ) {
+			return MediaWikiServices::getInstance()->getSearchEngineConfig();
+		}
+
+		return null;
+	},
+
+	/**
 	 * LBFactory
 	 *
 	 * @return callable

--- a/src/Site.php
+++ b/src/Site.php
@@ -51,6 +51,15 @@ class Site {
 	}
 
 	/**
+	 * @since 3.1
+	 *
+	 * @return string
+	 */
+	public static function searchType() {
+		return $GLOBALS['wgSearchType'];
+	}
+
+	/**
 	 * @since 3.0
 	 *
 	 * @return string

--- a/tests/phpunit/Unit/MediaWiki/Search/ProfileForm/Forms/CustomFormTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Search/ProfileForm/Forms/CustomFormTest.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace SMW\Tests\MediaWiki\Search\Form;
+namespace SMW\Tests\MediaWiki\Search\ProfileForm\Forms;
 
-use SMW\MediaWiki\Search\Form\CustomForm;
+use SMW\MediaWiki\Search\ProfileForm\Forms\CustomForm;
 
 /**
- * @covers \SMW\MediaWiki\Search\Form\CustomForm
+ * @covers \SMW\MediaWiki\Search\ProfileForm\Forms\CustomForm
  * @group semantic-mediawiki
  *
  * @license GNU GPL v2+

--- a/tests/phpunit/Unit/MediaWiki/Search/ProfileForm/Forms/FieldTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Search/ProfileForm/Forms/FieldTest.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace SMW\Tests\MediaWiki\Search\Form;
+namespace SMW\Tests\MediaWiki\Search\ProfileForm\Forms;
 
-use SMW\MediaWiki\Search\Form\Field;
+use SMW\MediaWiki\Search\ProfileForm\Forms\Field;
 
 /**
- * @covers \SMW\MediaWiki\Search\Form\Field
+ * @covers \SMW\MediaWiki\Search\ProfileForm\Forms\Field
  * @group semantic-mediawiki
  *
  * @license GNU GPL v2+

--- a/tests/phpunit/Unit/MediaWiki/Search/ProfileForm/Forms/NamespaceFormTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Search/ProfileForm/Forms/NamespaceFormTest.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace SMW\Tests\MediaWiki\Search\Form;
+namespace SMW\Tests\MediaWiki\Search\ProfileForm\Forms;
 
-use SMW\MediaWiki\Search\Form\NamespaceForm;
+use SMW\MediaWiki\Search\ProfileForm\Forms\NamespaceForm;
 
 /**
- * @covers \SMW\MediaWiki\Search\Form\NamespaceForm
+ * @covers \SMW\MediaWiki\Search\ProfileForm\Forms\NamespaceForm
  * @group semantic-mediawiki
  *
  * @license GNU GPL v2+

--- a/tests/phpunit/Unit/MediaWiki/Search/ProfileForm/Forms/OpenFormTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Search/ProfileForm/Forms/OpenFormTest.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace SMW\Tests\MediaWiki\Search\Form;
+namespace SMW\Tests\MediaWiki\Search\ProfileForm\Forms;
 
-use SMW\MediaWiki\Search\Form\OpenForm;
+use SMW\MediaWiki\Search\ProfileForm\Forms\OpenForm;
 
 /**
- * @covers \SMW\MediaWiki\Search\Form\OpenForm
+ * @covers \SMW\MediaWiki\Search\ProfileForm\Forms\OpenForm
  * @group semantic-mediawiki
  *
  * @license GNU GPL v2+

--- a/tests/phpunit/Unit/MediaWiki/Search/ProfileForm/Forms/SortFormTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Search/ProfileForm/Forms/SortFormTest.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace SMW\Tests\MediaWiki\Search\Form;
+namespace SMW\Tests\MediaWiki\Search\ProfileForm\Forms;
 
-use SMW\MediaWiki\Search\Form\SortForm;
+use SMW\MediaWiki\Search\ProfileForm\Forms\SortForm;
 
 /**
- * @covers \SMW\MediaWiki\Search\Form\SortForm
+ * @covers \SMW\MediaWiki\Search\ProfileForm\Forms\SortForm
  * @group semantic-mediawiki
  *
  * @license GNU GPL v2+

--- a/tests/phpunit/Unit/MediaWiki/Search/ProfileForm/FormsBuilderTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Search/ProfileForm/FormsBuilderTest.php
@@ -1,12 +1,12 @@
 <?php
 
-namespace SMW\Tests\MediaWiki\Search\Form;
+namespace SMW\Tests\MediaWiki\Search\ProfileForm;
 
-use SMW\MediaWiki\Search\Form\FormsBuilder;
+use SMW\MediaWiki\Search\ProfileForm\FormsBuilder;
 use SMW\Tests\TestEnvironment;
 
 /**
- * @covers \SMW\MediaWiki\Search\Form\FormsBuilder
+ * @covers \SMW\MediaWiki\Search\ProfileForm\FormsBuilder
  * @group semantic-mediawiki
  *
  * @license GNU GPL v2+
@@ -16,16 +16,19 @@ use SMW\Tests\TestEnvironment;
  */
 class FormsBuilderTest extends \PHPUnit_Framework_TestCase {
 
+	private $stringValidator;
 	private $webRequest;
 	private $formsFactory;
 
 	protected function setUp() {
 
+		$this->stringValidator = TestEnvironment::newValidatorFactory()->newStringValidator();
+
 		$this->webRequest = $this->getMockBuilder( '\WebRequest' )
 			->disableOriginalConstructor()
 			->getMock();
 
-		$this->formsFactory = $this->getMockBuilder( '\SMW\MediaWiki\Search\Form\FormsFactory' )
+		$this->formsFactory = $this->getMockBuilder( '\SMW\MediaWiki\Search\ProfileForm\FormsFactory' )
 			->disableOriginalConstructor()
 			->getMock();
 	}
@@ -44,11 +47,11 @@ class FormsBuilderTest extends \PHPUnit_Framework_TestCase {
 			->disableOriginalConstructor()
 			->getMock();
 
-		$openForm = $this->getMockBuilder( '\SMW\MediaWiki\Search\Form\OpenForm' )
+		$openForm = $this->getMockBuilder( '\SMW\MediaWiki\Search\ProfileForm\Forms\OpenForm' )
 			->disableOriginalConstructor()
 			->getMock();
 
-		$customForm = $this->getMockBuilder( '\SMW\MediaWiki\Search\Form\CustomForm' )
+		$customForm = $this->getMockBuilder( '\SMW\MediaWiki\Search\ProfileForm\Forms\CustomForm' )
 			->disableOriginalConstructor()
 			->getMock();
 
@@ -92,15 +95,13 @@ class FormsBuilderTest extends \PHPUnit_Framework_TestCase {
 			$instance->buildForm( $data )
 		);
 
-		$stringValidator = TestEnvironment::newValidatorFactory()->newStringValidator();
-
 		$expected = [
 			'<button type="button" id="smw-search-forms" class="smw-selectmenu-button is-disabled".*',
 			'name="smw-form" value="".*',
 			'data-list="[{&quot;id&quot;:&quot;bar&quot;,&quot;name&quot;:&quot;Bar&quot;,&quot;desc&quot;:&quot;Bar&quot;},{&quot;id&quot;:&quot;foo&quot;,&quot;name&quot;:&quot;Foo&quot;,&quot;desc&quot;:&quot;Foo&quot;}]" data-nslist="[]">Form</button><input type="hidden" name="smw-form"/>'
 		];
 
-		$stringValidator->assertThatStringContains(
+		$this->stringValidator->assertThatStringContains(
 			$expected,
 			$instance->buildFormList( $title )
 		);

--- a/tests/phpunit/Unit/MediaWiki/Search/ProfileForm/FormsFactoryTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Search/ProfileForm/FormsFactoryTest.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace SMW\Tests\MediaWiki\Search\Form;
+namespace SMW\Tests\MediaWiki\Search\ProfileForm;
 
-use SMW\MediaWiki\Search\Form\FormsFactory;
+use SMW\MediaWiki\Search\ProfileForm\FormsFactory;
 
 /**
- * @covers \SMW\MediaWiki\Search\Form\FormsFactory
+ * @covers \SMW\MediaWiki\Search\ProfileForm\FormsFactory
  * @group semantic-mediawiki
  *
  * @license GNU GPL v2+
@@ -37,7 +37,7 @@ class FormsFactoryTest extends \PHPUnit_Framework_TestCase {
 		$instance = new FormsFactory();
 
 		$this->assertInstanceOf(
-			'\SMW\MediaWiki\Search\Form\OpenForm',
+			'\SMW\MediaWiki\Search\ProfileForm\Forms\OpenForm',
 			$instance->newOpenForm( $this->webRequest )
 		);
 	}
@@ -47,7 +47,7 @@ class FormsFactoryTest extends \PHPUnit_Framework_TestCase {
 		$instance = new FormsFactory();
 
 		$this->assertInstanceOf(
-			'\SMW\MediaWiki\Search\Form\CustomForm',
+			'\SMW\MediaWiki\Search\ProfileForm\Forms\CustomForm',
 			$instance->newCustomForm( $this->webRequest )
 		);
 	}
@@ -57,7 +57,7 @@ class FormsFactoryTest extends \PHPUnit_Framework_TestCase {
 		$instance = new FormsFactory();
 
 		$this->assertInstanceOf(
-			'\SMW\MediaWiki\Search\Form\SortForm',
+			'\SMW\MediaWiki\Search\ProfileForm\Forms\SortForm',
 			$instance->newSortForm( $this->webRequest )
 		);
 	}
@@ -67,7 +67,7 @@ class FormsFactoryTest extends \PHPUnit_Framework_TestCase {
 		$instance = new FormsFactory();
 
 		$this->assertInstanceOf(
-			'\SMW\MediaWiki\Search\Form\NamespaceForm',
+			'\SMW\MediaWiki\Search\ProfileForm\Forms\NamespaceForm',
 			$instance->newNamespaceForm()
 		);
 	}

--- a/tests/phpunit/Unit/MediaWiki/Search/ProfileForm/ProfileFormTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Search/ProfileForm/ProfileFormTest.php
@@ -1,12 +1,12 @@
 <?php
 
-namespace SMW\Tests\MediaWiki\Search;
+namespace SMW\Tests\MediaWiki\Search\ProfileForm;
 
-use SMW\MediaWiki\Search\SearchProfileForm;
+use SMW\MediaWiki\Search\ProfileForm\ProfileForm;
 use SMW\Tests\TestEnvironment;
 
 /**
- * @covers \SMW\MediaWiki\Search\SearchProfileForm
+ * @covers \SMW\MediaWiki\Search\ProfileForm\ProfileForm
  * @group semantic-mediawiki
  *
  * @license GNU GPL v2+
@@ -14,7 +14,7 @@ use SMW\Tests\TestEnvironment;
  *
  * @author mwjames
  */
-class SearchProfileFormTest extends \PHPUnit_Framework_TestCase {
+class ProfileFormTest extends \PHPUnit_Framework_TestCase {
 
 	private $store;
 	private $specialSearch;
@@ -68,16 +68,26 @@ class SearchProfileFormTest extends \PHPUnit_Framework_TestCase {
 	public function testCanConstruct() {
 
 		$this->assertInstanceOf(
-			SearchProfileForm::class,
-			new SearchProfileForm( $this->store, $this->specialSearch )
+			ProfileForm::class,
+			new ProfileForm( $this->store, $this->specialSearch )
+		);
+	}
+
+	public function testIsValidProfile() {
+
+		$this->assertFalse(
+			ProfileForm::isValidProfile( 'foo' )
 		);
 	}
 
 	public function testAddProfile() {
 
 		$profile = [];
+		$options = [
+			'default_namespaces' => []
+		];
 
-		SearchProfileForm::addProfile( 'SMWSearch', $profile );
+		ProfileForm::addProfile( SMW_SPECIAL_SEARCHTYPE, $profile, $options );
 
 		$this->assertArrayHasKey(
 			'smw',
@@ -85,7 +95,7 @@ class SearchProfileFormTest extends \PHPUnit_Framework_TestCase {
 		);
 	}
 
-	public function testGetForm() {
+	public function testBuildForm() {
 
 		$form = '';
 		$opts = [];
@@ -118,12 +128,12 @@ class SearchProfileFormTest extends \PHPUnit_Framework_TestCase {
 			->method( 'getContext' )
 			->will( $this->returnValue( $this->requestContext ) );
 
-		$instance = new SearchProfileForm(
+		$instance = new ProfileForm(
 			$this->store,
 			$this->specialSearch
 		);
 
-		$instance->getForm( $form, $opts );
+		$instance->buildForm( $form, $opts );
 
 		$expected = [
 			'<fieldset id="smw-searchoptions">',

--- a/tests/phpunit/Unit/Services/MediaWikiServicesContainerBuildTest.php
+++ b/tests/phpunit/Unit/Services/MediaWikiServicesContainerBuildTest.php
@@ -82,6 +82,12 @@ class MediaWikiServicesContainerBuildTest extends \PHPUnit_Framework_TestCase {
 			'\JobQueueGroup'
 		];
 
+		$provider[] = [
+			'SearchEngineConfig',
+			[],
+			'\SearchEngineConfig'
+		];
+
 		return $provider;
 	}
 }


### PR DESCRIPTION
This PR is made in reference to: #

This PR addresses or contains:

- Moves it to a sub namespace `\SMW\MediaWiki\Search\ProfileForm`

This PR includes:
- [ ] Tests (unit/integration)
- [x] CI build passed
