### PR TITLE
Add `--namespace` filter to `rebuildData.php`

### DIFF
--- a/maintenance/rebuildData.php
+++ b/maintenance/rebuildData.php
@@ -7,6 +7,7 @@ use SMW\StoreFactory;
 use SMW\Store;
 use SMW\Setup;
 use SMW\Options;
+use InvalidArgumentException;
 
 $basePath = getenv( 'MW_INSTALL_PATH' ) !== false ? getenv( 'MW_INSTALL_PATH' ) : __DIR__ . '/../../..';
 
@@ -86,6 +87,7 @@ class RebuildData extends \Maintenance {
 		$this->addOption( 'v', 'Be verbose about the progress', false );
 		$this->addOption( 'p', 'Only refresh property pages (and other explicitly named namespaces)', false );
 		$this->addOption( 'categories', 'Only refresh category pages (and other explicitly named namespaces)', false, false, 'c' );
+		$this->addOption( 'namespace', 'Only refresh pages in the selected namespace', false, false );
 		$this->addOption( 'redirects', 'Only refresh redirect pages', false );
 		$this->addOption( 'dispose-outdated', 'Only Remove outdated marked entities (including pending references).', false );
 		$this->addOption( 'check-remnantentities', 'Check and remove remnant entities (ghosts) from tables without a corresponding hash field entry', false );
@@ -137,13 +139,18 @@ class RebuildData extends \Maintenance {
 		$maintenanceHelper = $maintenanceFactory->newMaintenanceHelper();
 		$maintenanceHelper->initRuntimeValues();
 
+		if ( $this->hasOption( 'namespace' ) && !defined( $this->getOption( 'namespace' ) ) ) {
+			throw new InvalidArgumentException(
+				"Expected a namespace constant, `". $this->getOption( 'namespace' ) . "` is unkown!"
+			);
+		}
+
 		if ( $this->hasOption( 'check-remnantentities' ) ) {
 			$maintenanceHelper->setGlobalToValue( 'smwgCheckForRemnantEntities', true );
 		}
 
 		if ( $this->hasOption( 'no-cache' ) ) {
 			$maintenanceHelper->setGlobalToValue( 'wgMainCacheType', CACHE_NONE );
-			$maintenanceHelper->setGlobalToValue( 'smwgEntityLookupCacheType', CACHE_NONE );
 			$maintenanceHelper->setGlobalToValue( 'smwgQueryResultCacheType', CACHE_NONE );
 		}
 

--- a/src/Maintenance/DataRebuilder.php
+++ b/src/Maintenance/DataRebuilder.php
@@ -529,6 +529,10 @@ class DataRebuilder {
 			$this->filters[] = NS_CATEGORY;
 		}
 
+		if ( $options->has( 'namespace' ) ) {
+			$this->filters[] = constant( $options->get( 'namespace' ) );
+		}
+
 		if ( $options->has( 'p' ) ) {
 			$this->filters[] = SMW_NS_PROPERTY;
 		}

--- a/src/Maintenance/DistinctEntityDataRebuilder.php
+++ b/src/Maintenance/DistinctEntityDataRebuilder.php
@@ -115,6 +115,7 @@ class DistinctEntityDataRebuilder {
 
 		$type = ( $this->options->has( 'redirects' ) ? 'redirect' : '' ) .
 		( $this->options->has( 'categories' ) ? 'category' : '' ) .
+		( $this->options->has( 'namespace' ) ? $this->options->get( 'namespace' ) : '' ) .
 		( $this->options->has( 'query' ) ? 'query (' . $this->options->get( 'query' ) .')' : '' ) .
 		( $this->options->has( 'p' ) ? 'property' : '' );
 
@@ -151,7 +152,7 @@ class DistinctEntityDataRebuilder {
 				);
 			} else {
 				$this->reportMessage(
-					sprintf( "%-16s%s\n", "   ... ($this->rebuildCount/$total $progress)", "Page " . $key ),
+					sprintf( "%-25s%s\n", "   ... ($this->rebuildCount/$total $progress%)", $key ),
 					$this->options->has( 'v' )
 				);
 			}
@@ -190,6 +191,10 @@ class DistinctEntityDataRebuilder {
 
 		if ( $this->options->has( 'categories' ) ) {
 			$this->filters[] = NS_CATEGORY;
+		}
+
+		if ( $this->options->has( 'namespace' ) ) {
+			$this->filters[] = constant( $this->options->get( 'namespace' ) );
 		}
 
 		if ( $this->options->has( 'p' ) ) {


### PR DESCRIPTION
This PR is made in reference to: #

This PR addresses or contains:

- Adds `--namespace` filter as option, the expected value is the namespace constant such as `NS_HELP` and any literal value (for example `Help`) will cause an exception.

This PR includes:
- [ ] Tests (unit/integration)
- [x] CI build passed
