### PR TITLE
Isolate `pg_..._bytea` usage

### DIFF
--- a/includes/storage/SQLStore/SMW_Sql3SmwIds.php
+++ b/includes/storage/SQLStore/SMW_Sql3SmwIds.php
@@ -1094,8 +1094,8 @@ class SMWSql3SmwIds {
 			$hash = $row->smw_proptable_hash;
 		}
 
-		if ( $hash !== null && $hash !== false && $connection->isType( 'postgres' ) ) {
-			$hash = pg_unescape_bytea( $hash );
+		if ( $hash !== null && $hash !== false ) {
+			$hash = $connection->unescape_bytea( $hash );
 		}
 
 		$hash = $hash === null || $hash === false ? [] : unserialize( $hash );

--- a/src/MediaWiki/Connection/Database.php
+++ b/src/MediaWiki/Connection/Database.php
@@ -87,6 +87,11 @@ class Database {
 	private $insertId = null;
 
 	/**
+	 * @var string
+	 */
+	private $type = '';
+
+	/**
 	 * @since 1.9
 	 *
 	 * @param ConnRef $connRef
@@ -148,7 +153,7 @@ class Database {
 			$this->initConnection();
 		}
 
-		return $this->connections['read']->getType() === $type;
+		return $this->type === $type;
 	}
 
 	/**
@@ -180,7 +185,7 @@ class Database {
 			$this->initConnection();
 		}
 
-		return $this->connections['read']->getType();
+		return $this->type;
 	}
 
 	/**
@@ -963,6 +968,46 @@ class Database {
 		$this->connections['write']->onTransactionIdle( $callback );
 	}
 
+	/**
+	 * @since 3.1
+	 *
+	 * @param string $text
+	 *
+	 * @return string
+	 */
+	public function escape_bytea( $text ) {
+
+		if ( $this->initConnection === false ) {
+			$this->initConnection();
+		}
+
+		if ( $this->type === 'postgres' ) {
+			$text = pg_escape_bytea( $text );
+		}
+
+		return $text;
+	}
+
+	/**
+	 * @since 3.1
+	 *
+	 * @param string $text
+	 *
+	 * @return string
+	 */
+	public function unescape_bytea( $text ) {
+
+		if ( $this->initConnection === false ) {
+			$this->initConnection();
+		}
+
+		if ( $this->type === 'postgres' ) {
+			$text = pg_unescape_bytea( $text );
+		}
+
+		return $text;
+	}
+
 	private function initConnection() {
 
 		if ( $this->connections['read'] === null ) {
@@ -972,6 +1017,8 @@ class Database {
 		if ( $this->connections['write'] === null && $this->connRef->hasConnection( 'write' ) ) {
 			$this->connections['write'] = $this->connRef->getConnection( 'write' );
 		}
+
+		$this->type = $this->connections['read']->getType();
 
 		$this->initConnection = true;
 	}

--- a/src/SQLStore/Lookup/DisplayTitleLookup.php
+++ b/src/SQLStore/Lookup/DisplayTitleLookup.php
@@ -49,7 +49,8 @@ class DisplayTitleLookup {
 			$list[$id] = $dataItem;
 		}
 
-		list( $rows, $unescape_bytea ) = $this->fetchFromTable( $list );
+		$rows = $this->fetchFromTable( $list );
+		$connection = $this->store->getConnection( 'mw.db' );
 
 		foreach ( $rows as $row ) {
 
@@ -60,7 +61,7 @@ class DisplayTitleLookup {
 			$dataItem = $list[$row->s_id];
 
 			if ( $row->o_blob !== null ) {
-				$displayTitle = $unescape_bytea ? pg_unescape_bytea( $row->o_blob ) : $row->o_blob;
+				$displayTitle = $connection->unescape_bytea( $row->o_blob );
 			} else {
 				$displayTitle = $row->o_hash;
 			}
@@ -107,9 +108,7 @@ class DisplayTitleLookup {
 			__METHOD__
 		);
 
-		$unescape_bytea = $connection->isType( 'postgres' );
-
-		return [ $rows, $unescape_bytea ];
+		return $rows;
 	}
 
 }

--- a/src/SQLStore/Lookup/MonolingualTextLookup.php
+++ b/src/SQLStore/Lookup/MonolingualTextLookup.php
@@ -54,10 +54,10 @@ class MonolingualTextLookup {
 				$row
 			);
 
-			$text = $row->text_long === null ? $row->text_short : $row->text_long;
+			$text = $row->text_short;
 
-			if ( $row->text_long !== null && $connection->isType( 'postgres' ) ) {
-				$text = pg_unescape_bytea( $text );
+			if ( $row->text_long !== null ) {
+				$text = $connection->unescape_bytea( $row->text_long );
 			}
 
 			$containerSemanticData->addPropertyObjectValue(

--- a/tests/phpunit/Unit/MediaWiki/Connection/DatabaseTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Connection/DatabaseTest.php
@@ -478,6 +478,14 @@ class DatabaseTest extends \PHPUnit_Framework_TestCase {
 			->disableOriginalConstructor()
 			->getMock();
 
+		$read = $this->getMockBuilder( '\IDatabase' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$readConnectionProvider->expects( $this->any() )
+			->method( 'getConnection' )
+			->will( $this->returnValue( $read ) );
+
 		$write = $this->getMockBuilder( '\IDatabase' )
 			->disableOriginalConstructor()
 			->getMock();
@@ -518,6 +526,14 @@ class DatabaseTest extends \PHPUnit_Framework_TestCase {
 			->disableOriginalConstructor()
 			->getMock();
 
+		$read = $this->getMockBuilder( '\IDatabase' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$readConnectionProvider->expects( $this->any() )
+			->method( 'getConnection' )
+			->will( $this->returnValue( $read ) );
+
 		$write = $this->getMockBuilder( '\IDatabase' )
 			->disableOriginalConstructor()
 			->getMock();
@@ -553,6 +569,14 @@ class DatabaseTest extends \PHPUnit_Framework_TestCase {
 		$readConnectionProvider = $this->getMockBuilder( '\SMW\Connection\ConnectionProvider' )
 			->disableOriginalConstructor()
 			->getMock();
+
+		$read = $this->getMockBuilder( '\IDatabase' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$readConnectionProvider->expects( $this->any() )
+			->method( 'getConnection' )
+			->will( $this->returnValue( $read ) );
 
 		$write = $this->getMockBuilder( '\IDatabase' )
 			->disableOriginalConstructor()
@@ -618,6 +642,14 @@ class DatabaseTest extends \PHPUnit_Framework_TestCase {
 		$readConnectionProvider = $this->getMockBuilder( '\SMW\Connection\ConnectionProvider' )
 			->disableOriginalConstructor()
 			->getMock();
+
+		$read = $this->getMockBuilder( '\IDatabase' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$readConnectionProvider->expects( $this->any() )
+			->method( 'getConnection' )
+			->will( $this->returnValue( $read ) );
 
 		$write = $this->getMockBuilder( '\IDatabase' )
 			->disableOriginalConstructor()

--- a/tests/phpunit/Unit/SQLStore/Lookup/DisplayTitleLookupTest.php
+++ b/tests/phpunit/Unit/SQLStore/Lookup/DisplayTitleLookupTest.php
@@ -67,6 +67,10 @@ class DisplayTitleLookupTest extends \PHPUnit_Framework_TestCase {
 			->method( 'tablename' )
 			->will( $this->returnArgument( 0 ) );
 
+		$connection->expects( $this->any() )
+			->method( 'unescape_bytea' )
+			->will( $this->returnArgument( 0 ) );
+
 		$connection->expects( $this->once() )
 			->method( 'select' )
 			->with(


### PR DESCRIPTION
This PR is made in reference to: #

This PR addresses or contains:

- Isolate `pg_unescape_bytea`/`pg_escape_bytea` usage

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed
