### PR TITLE
Support `custom_constraint`

### DIFF
--- a/data/schema/property-constraint-schema.v1.json
+++ b/data/schema/property-constraint-schema.v1.json
@@ -44,6 +44,9 @@
 				},
 				"unique_value_constraint": {
 					"$ref": "#/definitions/unique_value_constraint"
+				},
+				"custom_constraint": {
+					"$ref": "#/definitions/custom_constraint"
 				}
 			},
 			"additionalProperties": false
@@ -67,6 +70,11 @@
 			"type": "boolean",
 			"title": "Specifies that values should be unique across the wiki, that the value is likely to be different (distinct) from all other items",
 			"default": false
+		},
+		"custom_constraint": {
+			"$id": "#/definitions/custom_constraint",
+			"type": "object",
+			"title": "Specifies custom constraints to be implemented by a user"
 		}
 	}
 }

--- a/docs/architecture/extending.constraint.md
+++ b/docs/architecture/extending.constraint.md
@@ -18,6 +18,10 @@ When adding new constraints, please ensure that:
 
 When a constraint is expected to be expensive (in terms of performance, runtime) it should be postponed and be derived from the `DeferrableConstraint` class to ensure that those checks are run using the `DeferredConstraintCheckUpdateJob` hereby avoiding unnecessary resource hogging during a page view/GET process.
 
+## See also
+
+- How to register a [custom constraint](https://github.com/SemanticMediaWiki/SemanticMediaWiki/blob/master/docs/examples/register.custom.constraint.md)
+
 [constraint]:https://github.com/SemanticMediaWiki/SemanticMediaWiki/blob/master/src/Constraint/Constraint.php
 [constraint-registry]:https://github.com/SemanticMediaWiki/SemanticMediaWiki/blob/master/src/Constraint/ConstraintRegistry.php
 [constraint-factory]:https://github.com/SemanticMediaWiki/SemanticMediaWiki/blob/master/src/ConstraintFactory.php

--- a/docs/examples/register.custom.constraint.md
+++ b/docs/examples/register.custom.constraint.md
@@ -1,0 +1,81 @@
+## Register new constraint
+
+This example shows how to register a custom constraint.
+
+### SMW::Constraint::initConstraints
+
+```php
+use Hooks;
+use Foo\FooConstraint;
+
+Hooks::register( 'SMW::Constraint::initConstraints', function ( $constraintRegistry ) {
+
+	$constraintRegistry->registerConstraint(
+		'foo_constraint',
+		FooConstraint::class
+	);
+
+	return true;
+};
+```
+
+### Constraint representation
+
+```php
+class FooConstraint implements Constraint {
+
+	private $hasViolation = false;
+
+	public function hasViolation() {
+		return $this->hasViolation;
+	}
+
+	public function getType( $type ) {
+		return Constraint::TYPE_INSTANT;
+	}
+
+	public function checkConstraint( array $constraint, $dataValue ) {
+
+		$this->hasViolation = false;
+
+		// Do the necessary checks
+
+		...
+
+		// Found a violation
+		$this->hasViolation = true
+
+		$dataValue->addErrorMsg(
+			new ConstraintError( [
+				'foo-violation-message-key'
+			] )
+		);
+
+	}
+}
+```
+
+### Usage
+
+The `custom_constraint` property in the schema is reserved for custom defined constraints.
+
+```
+{
+    "type": "PROPERTY_CONSTRAINT_SCHEMA",
+    "constraints": {
+        "custom_constraint": {
+            "foo_constraint": true
+        }
+    },
+    "tags": [
+        "property constraint",
+        "custom constraint"
+    ]
+}
+```
+
+## See also
+
+- [hook.constraint.initconstraints.md][hook.constraint.initconstraints]
+
+[hook.constraint.initconstraints]:https://github.com/SemanticMediaWiki/SemanticMediaWiki/blob/master/docs/technical/hooks/hook.constraint.initconstraints.md

--- a/docs/technical/hooks.md
+++ b/docs/technical/hooks.md
@@ -8,6 +8,7 @@ Implementing a hook should be made in consideration of the expected performance 
 
 - [`SMW::DataType::initTypes`][hook.datatype.inittypes] to add additional [DataType][datamodel.datatype] support
 - [`SMW::Property::initProperties`][hook.property.initproperties] to add additional predefined properties
+- [`SMW::Constraint::initConstraints`][hook.constraint.initconstraints] to add custom constraints
 - [`SMW::GetPreferences`][hook.getpreferences] to add extra preferences that are ordered on the Semantic MediaWiki user preference tab
 - [`SMW::Setup::AfterInitializationComplete`][hook.setup.afterinitializationcomplete] to modify global configuration after initialization of Semantic MediaWiki is completed
 - `SMW::Settings::BeforeInitializationComplete` to modify the Semantic MediaWiki configuration before the initialization is completed
@@ -110,3 +111,4 @@ Implementing a hook should be made in consideration of the expected performance 
 [hook.revisionguard.changefile]:https://github.com/SemanticMediaWiki/SemanticMediaWiki/blob/master/docs/technical/hooks/hook.revisionguard.changefile.md
 [hook.event.registereventlisteners]:https://github.com/SemanticMediaWiki/SemanticMediaWiki/blob/master/docs/technical/hooks/hook.event.registereventlisteners.md
 [hook.resultformat.overridedefaultformat]:https://github.com/SemanticMediaWiki/SemanticMediaWiki/blob/master/docs/technical/hooks/hook.resultformat.overridedefaultformat.md
+[hook.constraint.initconstraints]:https://github.com/SemanticMediaWiki/SemanticMediaWiki/blob/master/docs/technical/hooks/hook.constraint.initconstraints.md

--- a/docs/technical/hooks/hook.constraint.initconstraints.md
+++ b/docs/technical/hooks/hook.constraint.initconstraints.md
@@ -1,0 +1,16 @@
+* Since: 3.1
+* Description: Hook to allow adding custom constraint checks for a `custom_constraint`.
+* Reference class: [`ConstraintRegistry.php`][ConstraintRegistry.php]
+
+### Signature
+
+```php
+use Hooks;
+
+Hooks::register( 'SMW::Constraint::initConstraints', function( $constraintRegistry ) {
+
+	return true;
+} );
+```
+
+[ConstraintRegistry.php]:https://github.com/SemanticMediaWiki/SemanticMediaWiki/blob/master/src/Constraint/ConstraintRegistry.php

--- a/src/Constraint/ConstraintCheckRunner.php
+++ b/src/Constraint/ConstraintCheckRunner.php
@@ -125,7 +125,13 @@ class ConstraintCheckRunner {
 				break;
 			}
 
-			$this->checkConstraint( $key, $value, $dataValue );
+			if ( $key === 'custom_constraint' ) {
+				foreach ( $value as $k => $v ) {
+					$this->checkConstraint( $k, $v, $dataValue );
+				}
+			} else {
+				$this->checkConstraint( $key, $value, $dataValue );
+			}
 		}
 	}
 

--- a/src/Constraint/ConstraintRegistry.php
+++ b/src/Constraint/ConstraintRegistry.php
@@ -87,6 +87,8 @@ class ConstraintRegistry {
 			'allowed_namespaces' => CommonConstraint::class,
 			'unique_value_constraint' => UniqueValueConstraint::class
 		];
+
+		\Hooks::run( 'SMW::Constraint::initConstraints', [ $this ] );
 	}
 
 	private function loadInstance( $class ) {

--- a/src/Schema/docs/property.constraint.md
+++ b/src/Schema/docs/property.constraint.md
@@ -34,10 +34,12 @@ To easily identify pages that contain a constraint schema it is suggested to use
 
 - `allowed_namespaces` (array) specifies allowed namespaces
 - `unique_value_constraint` (boolean) specifies that values should be unique across the wiki, that the value is likely to be different (distinct) from all other items
+- `custom_constraint` (object) to be used to specify non-schema specific constraints that requrie an implementation using the `SMW::Constraint::initConstraints` hook
 
-### Extending constraint properties
+### Extending constraints
 
-For details, please see the [extending.constraint.md](https://github.com/SemanticMediaWiki/SemanticMediaWiki/blob/master/docs/architecture/extending.constraint.md) document.
+- General introduction in how to extend a [constraint](https://github.com/SemanticMediaWiki/SemanticMediaWiki/blob/master/docs/architecture/extending.constraint.md)
+- How to register a [custom constraint](https://github.com/SemanticMediaWiki/SemanticMediaWiki/blob/master/docs/examples/register.custom.constraint.md) using the `custom_constraint` property
 
 ## Validation
 


### PR DESCRIPTION
This PR is made in reference to: #3746

This PR addresses or contains:

- Using the `custom_constraint` attribute and the newly introduced `SMW::Constraint::initConstraints` hook to extend the schema and enable users to define custom constraints via a `Constraint` implementation using the provided hook.
- https://github.com/SemanticMediaWiki/SemanticMediaWiki/blob/master/docs/examples/register.custom.constraint.md

This PR includes:
- [ ] Tests (unit/integration)
- [x] CI build passed

## Example

```
{
    "type": "PROPERTY_CONSTRAINT_SCHEMA",
    "constraints": {
        "custom_constraint": {
            "here_we_define_a_custom_constraint": "some_value_to_compare_with"
        }
    },
    "tags": [
        "custom constraint"
    ]
}
```