### PR TITLE
Add `non_negative_integer` constraint, refs 3746

### DIFF
--- a/data/schema/property-constraint-schema.v1.json
+++ b/data/schema/property-constraint-schema.v1.json
@@ -47,6 +47,9 @@
 				},
 				"custom_constraint": {
 					"$ref": "#/definitions/custom_constraint"
+				},
+				"non_negative_integer": {
+					"$ref": "#/definitions/non_negative_integer"
 				}
 			},
 			"additionalProperties": false
@@ -75,6 +78,12 @@
 			"$id": "#/definitions/custom_constraint",
 			"type": "object",
 			"title": "Specifies custom constraints to be implemented by a user"
+		},
+		"non_negative_integer": {
+			"$id": "#/definitions/non_negative_integer",
+			"type": "boolean",
+			"title": "Specifies that values are derived from integer with the minimum inclusive to be 0",
+			"default": false
 		}
 	}
 }

--- a/docs/examples/constraint.schema.nonnegativeinteger.md
+++ b/docs/examples/constraint.schema.nonnegativeinteger.md
@@ -1,0 +1,16 @@
+```json
+{
+    "type": "PROPERTY_CONSTRAINT_SCHEMA",
+    "constraints": {
+        "non_negative_integer": true
+    },
+    "tags": [
+        "property constraint",
+        "integer",
+        "number"
+    ]
+}
+```
+## See also
+
+- [`property.constraint.md`](https://github.com/SemanticMediaWiki/SemanticMediaWiki/blob/master/src/Schema/docs/property.constraint.md)

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -729,6 +729,7 @@
 	"smw-property-predefined-long-pvuc": "Uniqueness is established when two values are not equal in their literal representation and any violation of that constraint will be categorized as error.",
 	"smw-datavalue-constraint-uniqueness-violation": "Property \"$1\" only permits unique value assignments and ''$2'' was already annotated in subject \"$3\".",
 	"smw-datavalue-constraint-uniqueness-violation-isknown": "Property \"$1\" only permits unique value annotations, ''$2'' already contains an assigned value. \"$3\" violates the uniqueness constraint.",
+	"smw-datavalue-constraint-violation-non-negative-integer": "Property \"$1\" has a \"non negative integer\" constraint and value ''$2'' is violating that requirement.",
 	"smw-property-predefined-boo": "\"$1\" is a [[Special:Types/Boolean|type]] and predefined property provided by [https://www.semantic-mediawiki.org/wiki/Help:Special_properties Semantic MediaWiki] to represent boolean values.",
 	"smw-property-predefined-num": "\"$1\" is a [[Special:Types/Number|type]] and predefined property provided by [https://www.semantic-mediawiki.org/wiki/Help:Special_properties Semantic MediaWiki] to represent numeric values.",
 	"smw-property-predefined-dat": "\"$1\" is a [[Special:Types/Date|type]] and predefined property provided by [https://www.semantic-mediawiki.org/wiki/Help:Special_properties Semantic MediaWiki] to represent date values.",

--- a/src/Constraint/ConstraintRegistry.php
+++ b/src/Constraint/ConstraintRegistry.php
@@ -7,6 +7,8 @@ use SMW\ConstraintFactory;
 use SMW\Constraint\Constraints\NullConstraint;
 use SMW\Constraint\Constraints\CommonConstraint;
 use SMW\Constraint\Constraints\UniqueValueConstraint;
+use SMW\Constraint\Constraints\NonNegativeIntegerConstraint;
+
 
 /**
  * @license GNU GPL v2+
@@ -85,7 +87,8 @@ class ConstraintRegistry {
 		$this->constraints = [
 			'null' => NullConstraint::class,
 			'allowed_namespaces' => CommonConstraint::class,
-			'unique_value_constraint' => UniqueValueConstraint::class
+			'unique_value_constraint' => UniqueValueConstraint::class,
+			'non_negative_integer' => NonNegativeIntegerConstraint::class
 		];
 
 		\Hooks::run( 'SMW::Constraint::initConstraints', [ $this ] );

--- a/src/Constraint/Constraints/NonNegativeIntegerConstraint.php
+++ b/src/Constraint/Constraints/NonNegativeIntegerConstraint.php
@@ -1,0 +1,85 @@
+<?php
+
+namespace SMW\Constraint\Constraints;
+
+use SMW\Constraint\Constraint;
+use SMW\Constraint\ConstraintError;
+use SMWDataValue as DataValue;
+use SMWDataItem as DataItem;
+use RuntimeException;
+
+/**
+ * @license GNU GPL v2+
+ * @since 3.1
+ *
+ * @author mwjames
+ */
+class NonNegativeIntegerConstraint implements Constraint {
+
+	/**
+	 * @var boolean
+	 */
+	private $hasViolation = false;
+
+	/**
+	 * @since 3.1
+	 *
+	 * {@inheritDoc}
+	 */
+	public function hasViolation() {
+		return $this->hasViolation;
+	}
+
+	/**
+	 * @since 3.1
+	 *
+	 * {@inheritDoc}
+	 */
+	public function getType() {
+		return Constraint::TYPE_INSTANT;
+	}
+
+	/**
+	 * @since 3.1
+	 *
+	 * {@inheritDoc}
+	 */
+	public function checkConstraint( array $constraint, $dataValue ) {
+
+		$this->hasViolation = false;
+
+		if ( !$dataValue instanceof DataValue ) {
+			throw new RuntimeException( "Expected a DataValue instance!" );
+		}
+
+		$key = key( $constraint );
+
+		if ( isset( $constraint['non_negative_integer'] ) && $constraint['non_negative_integer'] ) {
+			$this->non_negative_integer( $dataValue );
+		}
+	}
+
+	private function non_negative_integer( $dataValue ) {
+
+		$dataItem = $dataValue->getDataItem();
+
+		if ( $dataItem->getDIType() !== DataItem::TYPE_NUMBER ) {
+			return;
+		}
+
+		// https://www.w3.org/TR/xmlschema11-2/#nonNegativeInteger
+		if ( ( $number = $dataItem->getNumber() ) >= 0 ) {
+			return;
+		}
+
+		$dataValue->addErrorMsg( new ConstraintError( [
+				'smw-datavalue-constraint-violation-non-negative-integer',
+				$dataValue->getProperty()->getLabel(),
+				$number
+			] )
+		);
+
+		$this->hasViolation = true;
+	}
+
+}

--- a/src/ConstraintFactory.php
+++ b/src/ConstraintFactory.php
@@ -9,6 +9,7 @@ use SMW\Constraint\Constraints\NullConstraint;
 use SMW\Constraint\ConstraintSchemaCompiler;
 use SMW\Constraint\Constraints\CommonConstraint;
 use SMW\Constraint\Constraints\UniqueValueConstraint;
+use SMW\Constraint\Constraints\NonNegativeIntegerConstraint;
 
 /**
  * @license GNU GPL v2+
@@ -52,6 +53,9 @@ class ConstraintFactory {
 			case UniqueValueConstraint::class:
 				$constraint = $this->newUniqueValueConstraint();
 				break;
+			case NonNegativeIntegerConstraint::class:
+				$constraint = $this->newNonNegativeIntegerConstraint();
+				break;
 			default:
 				$constraint = $this->newNullConstraint();
 				break;
@@ -84,6 +88,15 @@ class ConstraintFactory {
 		);
 
 		return $uniqueValueConstraint;
+	}
+
+	/**
+	 * @since 3.1
+	 *
+	 * @return NonNegativeIntegerConstraint
+	 */
+	public function newNonNegativeIntegerConstraint() {
+		return new NonNegativeIntegerConstraint();
 	}
 
 	/**

--- a/src/SQLStore/Lookup/ErrorLookup.php
+++ b/src/SQLStore/Lookup/ErrorLookup.php
@@ -62,6 +62,15 @@ class ErrorLookup {
 		$connection = $this->store->getConnection( 'mw.db' );
 		$idTable = $this->store->getObjectIds();
 
+		$idTable->warmUpCache(
+			[
+				$subject,
+				new DIProperty( '_ERR_TYPE' ),
+				new DIProperty( '_ERRT' ),
+				new DIProperty( '_ERRC' )
+			]
+		);
+
 		$pid = $idTable->getSMWPropertyID(
 			new DIProperty( '_ERRC' )
 		);

--- a/src/Schema/docs/property.constraint.md
+++ b/src/Schema/docs/property.constraint.md
@@ -19,13 +19,11 @@ To easily identify pages that contain a constraint schema it is suggested to use
 {
     "type": "PROPERTY_CONSTRAINT_SCHEMA",
     "constraints": {
-        "allowed_namespaces": [
-            "NS_USER"
-        ]
+        ...
     },
     "tags": [
-        "constraint",
-        "user namespace"
+        "property constraint",
+        "..."
     ]
 }
 </pre>
@@ -34,13 +32,18 @@ To easily identify pages that contain a constraint schema it is suggested to use
 
 - `allowed_namespaces` (array) specifies allowed namespaces
 - `unique_value_constraint` (boolean) specifies that values should be unique across the wiki, that the value is likely to be different (distinct) from all other items
-- `custom_constraint` (object) to be used to specify non-schema specific constraints that requrie an implementation using the `SMW::Constraint::initConstraints` hook
+- [`custom_constraint`][custom.constraint] (object) to be used to specify non-schema specific constraints that requrie an implementation using the `SMW::Constraint::initConstraints` hook
+- [`non_negative_integer`][non_negative_integer] (boolean) specifies that values are derived from integer with the minimum inclusive to be 0
 
 ### Extending constraints
 
-- General introduction in how to extend a [constraint](https://github.com/SemanticMediaWiki/SemanticMediaWiki/blob/master/docs/architecture/extending.constraint.md)
-- How to register a [custom constraint](https://github.com/SemanticMediaWiki/SemanticMediaWiki/blob/master/docs/examples/register.custom.constraint.md) using the `custom_constraint` property
+- General introduction on how to extend a [constraint][extending.constraint]
+- How to register a [custom constraint][custom.constraint] using the `custom_constraint` property
 
 ## Validation
 
-`/data/schema/constraint-schema.v1.json`
+`/data/schema/property-constraint-schema.v1.json`
+
+[non_negative_integer]:https://github.com/SemanticMediaWiki/SemanticMediaWiki/blob/master/docs/examples/constraint.schema.nonnegativeinteger.md
+[custom.constraint]:https://github.com/SemanticMediaWiki/SemanticMediaWiki/blob/master/docs/examples/register.custom.constraint.md
+[extending.constraint]: https://github.com/SemanticMediaWiki/SemanticMediaWiki/blob/master/docs/architecture/extending.constraint.md

--- a/tests/phpunit/Integration/JSONScript/Fixtures/p-1101-constraint-non-negative.json
+++ b/tests/phpunit/Integration/JSONScript/Fixtures/p-1101-constraint-non-negative.json
@@ -1,0 +1,11 @@
+{
+    "type": "PROPERTY_CONSTRAINT_SCHEMA",
+    "constraints": {
+        "non_negative_integer": true
+    },
+    "tags": [
+        "property constraint",
+        "integer",
+        "number"
+    ]
+}

--- a/tests/phpunit/Integration/JSONScript/TestCases/p-1101.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/p-1101.json
@@ -1,0 +1,89 @@
+{
+	"description": "Test `smw/schema` on `PROPERTY_CONSTRAINT_SCHEMA` with `non_negative_integer` and `Constraint schema`",
+	"setup": [
+		{
+			"namespace": "SMW_NS_SCHEMA",
+			"page": "Constraint:NonNegative",
+			"contents": {
+				"import-from": "/../Fixtures/p-1101-constraint-non-negative.json"
+			}
+		},
+		{
+			"namespace": "SMW_NS_PROPERTY",
+			"page": "Has int",
+			"contents": "[[Has type::Number]] [[Constraint schema::Constraint:NonNegative]]"
+		},
+		{
+			"page": "Test:P1101/1",
+			"contents": "[[Has int::-1]]"
+		},
+		{
+			"page": "Test:P1101/2",
+			"contents": "[[Has int::1001]]"
+		},
+		{
+			"page": "Test:P1101/3",
+			"contents": "[[Has int::0]]"
+		}
+	],
+	"tests": [
+		{
+			"type": "parser",
+			"about": "#0 (invalid assignment on `non_negative_integer`)",
+			"subject": "Test:P1101/1",
+			"assert-store": {
+				"semantic-data": {
+					"strict-mode-valuematch": false,
+					"propertyCount": 3,
+					"propertyKeys": [
+						"_MDAT",
+						"_SKEY",
+						"_ERRC"
+					]
+				}
+			},
+			"assert-output": {
+				"to-contain": [
+					"<span class=\"smwttcontent\">Property \"Has int\" has a \"non negative integer\" constraint and value <i>-1</i> is violating that requirement.</span>"
+				]
+			}
+		},
+		{
+			"type": "parser",
+			"about": "#1 (valid assignment on `non_negative_integer`)",
+			"subject": "Test:P1101/2",
+			"assert-output": {
+				"to-contain": [
+					"1001"
+				]
+			}
+		},
+		{
+			"type": "parser",
+			"about": "#2 (valid assignment on `non_negative_integer`)",
+			"subject": "Test:P1101/3",
+			"assert-output": {
+				"to-contain": [
+					"0"
+				]
+			}
+		}
+	],
+	"settings": {
+		"wgContLang": "en",
+		"wgLang": "en",
+		"smwgPageSpecialProperties": [
+			"_MDAT"
+		],
+		"smwgNamespacesWithSemanticLinks": {
+			"NS_MAIN": true,
+			"SMW_NS_PROPERTY": true,
+			"SMW_NS_SCHEMA": true
+		}
+	},
+	"meta": {
+		"version": "2",
+		"is-incomplete": false,
+		"debug": false
+	}
+}

--- a/tests/phpunit/Unit/Constraint/Constraints/NonNegativeIntegerConstraintTest.php
+++ b/tests/phpunit/Unit/Constraint/Constraints/NonNegativeIntegerConstraintTest.php
@@ -1,0 +1,112 @@
+<?php
+
+namespace SMW\Tests\Constraint\Constraints;
+
+use SMW\Constraint\Constraints\NonNegativeIntegerConstraint;
+use SMW\Tests\PHPUnitCompat;
+use SMW\DataItemFactory;
+
+/**
+ * @covers \SMW\Constraint\Constraints\NonNegativeIntegerConstraint
+ * @group semantic-mediawiki
+ *
+ * @license GNU GPL v2+
+ * @since 3.1
+ *
+ * @author mwjames
+ */
+class NonNegativeIntegerConstraintTest extends \PHPUnit_Framework_TestCase {
+
+	use PHPUnitCompat;
+
+	private $dataItemFactory;
+
+	protected function setUp() {
+		$this->dataItemFactory = new DataItemFactory();
+	}
+
+	public function testCanConstruct() {
+
+		$this->assertInstanceOf(
+			NonNegativeIntegerConstraint::class,
+			new NonNegativeIntegerConstraint()
+		);
+	}
+
+	public function testGetType() {
+
+		$instance = new NonNegativeIntegerConstraint();
+
+		$this->assertEquals(
+			NonNegativeIntegerConstraint::TYPE_INSTANT,
+			$instance->getType()
+		);
+	}
+
+	public function testHasViolation() {
+
+		$instance = new NonNegativeIntegerConstraint();
+
+		$this->assertFalse(
+			$instance->hasViolation()
+		);
+	}
+
+	public function testCheckConstraint_non_negative_integer() {
+
+		$constraint = [
+			'non_negative_integer' => true
+		];
+
+		$expectedErrMsg = 'smw-datavalue-constraint-violation-non-negative-integer';
+
+		$dataValue = $this->getMockBuilder( '\SMWDataValue' )
+			->disableOriginalConstructor()
+			->setMethods( [ 'getProperty', 'getDataItem', 'addErrorMsg' ] )
+			->getMockForAbstractClass();
+
+		$dataValue->expects( $this->atLeastOnce() )
+			->method( 'addErrorMsg' )
+			->with( $this->callback( function( $error ) use ( $expectedErrMsg ) {
+				return $this->checkConstraintError( $error, $expectedErrMsg );
+			} ) );
+
+		$dataValue->expects( $this->atLeastOnce() )
+			->method( 'getProperty' )
+			->will( $this->returnValue( $this->dataItemFactory->newDIProperty( 'Bar' ) ) );
+
+		$dataValue->expects( $this->atLeastOnce() )
+			->method( 'getDataItem' )
+			->will( $this->returnValue( $this->dataItemFactory->newDINumber( -1 ) ) );
+
+		$instance = new NonNegativeIntegerConstraint();
+
+		$instance->checkConstraint( $constraint, $dataValue );
+
+		$this->assertTrue(
+			$instance->hasViolation()
+		);
+	}
+
+	public function testCheckConstraint_non_negative_integer_ThrowsException() {
+
+		$constraint = [
+			'non_negative_integer' => true
+		];
+
+		$instance = new NonNegativeIntegerConstraint();
+
+		$this->setExpectedException( '\RuntimeException' );
+		$instance->checkConstraint( $constraint, 'Foo' );
+	}
+
+	public function checkConstraintError( $error, $expectedErrMsg ) {
+
+		if ( strpos( $error->__toString(), $expectedErrMsg ) !== false ) {
+			return true;
+		}
+
+		return false;
+	}
+
+}


### PR DESCRIPTION
This PR is made in reference to: #3746

This PR addresses or contains:

- Adds `non_negative_integer` as constraint requirement

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed

## Example
```json
{
    "type": "PROPERTY_CONSTRAINT_SCHEMA",
    "constraints": {
        "non_negative_integer": true
    },
    "tags": [
        "property constraint",
        "integer",
        "number"
    ]
}
```