### PR TITLE
Add `must_exists` constraint, refs 3746

### DIFF
--- a/data/schema/property-constraint-schema.v1.json
+++ b/data/schema/property-constraint-schema.v1.json
@@ -50,6 +50,9 @@
 				},
 				"non_negative_integer": {
 					"$ref": "#/definitions/non_negative_integer"
+				},
+				"must_exists": {
+					"$ref": "#/definitions/must_exists"
 				}
 			},
 			"additionalProperties": false
@@ -83,6 +86,12 @@
 			"$id": "#/definitions/non_negative_integer",
 			"type": "boolean",
 			"title": "Specifies that values are derived from integer with the minimum inclusive to be 0",
+			"default": false
+		},
+		"must_exists": {
+			"$id": "#/definitions/must_exists",
+			"type": "boolean",
+			"title": "Specifies that the annotated value must exists to be valid",
 			"default": false
 		}
 	}

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -730,6 +730,7 @@
 	"smw-datavalue-constraint-uniqueness-violation": "Property \"$1\" only permits unique value assignments and ''$2'' was already annotated in subject \"$3\".",
 	"smw-datavalue-constraint-uniqueness-violation-isknown": "Property \"$1\" only permits unique value annotations, ''$2'' already contains an assigned value. \"$3\" violates the uniqueness constraint.",
 	"smw-datavalue-constraint-violation-non-negative-integer": "Property \"$1\" has a \"non negative integer\" constraint and value ''$2'' is violating that requirement.",
+	"smw-datavalue-constraint-violation-must-exists": "Property \"$1\" has a <code>must_exists</code> constraint and value ''$2'' is violating that requirement.",
 	"smw-property-predefined-boo": "\"$1\" is a [[Special:Types/Boolean|type]] and predefined property provided by [https://www.semantic-mediawiki.org/wiki/Help:Special_properties Semantic MediaWiki] to represent boolean values.",
 	"smw-property-predefined-num": "\"$1\" is a [[Special:Types/Number|type]] and predefined property provided by [https://www.semantic-mediawiki.org/wiki/Help:Special_properties Semantic MediaWiki] to represent numeric values.",
 	"smw-property-predefined-dat": "\"$1\" is a [[Special:Types/Date|type]] and predefined property provided by [https://www.semantic-mediawiki.org/wiki/Help:Special_properties Semantic MediaWiki] to represent date values.",

--- a/src/Constraint/ConstraintRegistry.php
+++ b/src/Constraint/ConstraintRegistry.php
@@ -8,6 +8,7 @@ use SMW\Constraint\Constraints\NullConstraint;
 use SMW\Constraint\Constraints\NamespaceConstraint;
 use SMW\Constraint\Constraints\UniqueValueConstraint;
 use SMW\Constraint\Constraints\NonNegativeIntegerConstraint;
+use SMW\Constraint\Constraints\MustExistsConstraint;
 
 
 /**
@@ -65,6 +66,20 @@ class ConstraintRegistry {
 	/**
 	 * @since 3.1
 	 *
+	 * @return []
+	 */
+	public function getConstraintKeys() {
+
+		if ( $this->constraints === [] ) {
+			$this->initConstraints();
+		}
+
+		return array_keys( $this->constraints );
+	}
+
+	/**
+	 * @since 3.1
+	 *
 	 * @param string $key
 	 *
 	 * @return Constraint
@@ -88,7 +103,8 @@ class ConstraintRegistry {
 			'null' => NullConstraint::class,
 			'allowed_namespaces' => NamespaceConstraint::class,
 			'unique_value_constraint' => UniqueValueConstraint::class,
-			'non_negative_integer' => NonNegativeIntegerConstraint::class
+			'non_negative_integer' => NonNegativeIntegerConstraint::class,
+			'must_exists' => MustExistsConstraint::class
 		];
 
 		\Hooks::run( 'SMW::Constraint::initConstraints', [ $this ] );

--- a/src/Constraint/Constraints/MustExistsConstraint.php
+++ b/src/Constraint/Constraints/MustExistsConstraint.php
@@ -1,0 +1,85 @@
+<?php
+
+namespace SMW\Constraint\Constraints;
+
+use SMW\Constraint\Constraint;
+use SMW\Constraint\ConstraintError;
+use SMWDataValue as DataValue;
+use SMWDataItem as DataItem;
+use RuntimeException;
+
+/**
+ * @license GNU GPL v2+
+ * @since 3.1
+ *
+ * @author mwjames
+ */
+class MustExistsConstraint implements Constraint {
+
+	/**
+	 * @var boolean
+	 */
+	private $hasViolation = false;
+
+	/**
+	 * @since 3.1
+	 *
+	 * {@inheritDoc}
+	 */
+	public function hasViolation() {
+		return $this->hasViolation;
+	}
+
+	/**
+	 * @since 3.1
+	 *
+	 * {@inheritDoc}
+	 */
+	public function getType() {
+		return Constraint::TYPE_INSTANT;
+	}
+
+	/**
+	 * @since 3.1
+	 *
+	 * {@inheritDoc}
+	 */
+	public function checkConstraint( array $constraint, $dataValue ) {
+
+		$this->hasViolation = false;
+
+		if ( !$dataValue instanceof DataValue ) {
+			throw new RuntimeException( "Expected a DataValue instance!" );
+		}
+
+		$key = key( $constraint );
+
+		if ( $key === 'must_exists' ) {
+			return $this->check( $constraint[$key], $dataValue );
+		}
+	}
+
+	private function check( $must_exists, $dataValue ) {
+
+		$dataItem = $dataValue->getDataItem();
+
+		if ( $must_exists === false || $dataItem->getDIType() !== DataItem::TYPE_WIKIPAGE ) {
+			return;
+		}
+
+		if ( $dataItem->getTitle()->exists() ) {
+			return;
+		}
+
+		$this->hasViolation = true;
+
+		$dataValue->addErrorMsg(
+			new ConstraintError( [
+				'smw-datavalue-constraint-violation-must-exists',
+				$dataValue->getProperty()->getLabel(),
+				$dataValue->getWikiValue()
+			] )
+		);
+	}
+
+}

--- a/src/ConstraintFactory.php
+++ b/src/ConstraintFactory.php
@@ -10,6 +10,7 @@ use SMW\Constraint\ConstraintSchemaCompiler;
 use SMW\Constraint\Constraints\NamespaceConstraint;
 use SMW\Constraint\Constraints\UniqueValueConstraint;
 use SMW\Constraint\Constraints\NonNegativeIntegerConstraint;
+use SMW\Constraint\Constraints\MustExistsConstraint;
 
 /**
  * @license GNU GPL v2+
@@ -56,6 +57,9 @@ class ConstraintFactory {
 			case NonNegativeIntegerConstraint::class:
 				$constraint = $this->newNonNegativeIntegerConstraint();
 				break;
+			case MustExistsConstraint::class:
+				$constraint = $this->newMustExistsConstraint();
+				break;
 			default:
 				$constraint = $this->newNullConstraint();
 				break;
@@ -97,6 +101,15 @@ class ConstraintFactory {
 	 */
 	public function newNonNegativeIntegerConstraint() {
 		return new NonNegativeIntegerConstraint();
+	}
+
+	/**
+	 * @since 3.1
+	 *
+	 * @return MustExistsConstraint
+	 */
+	public function newMustExistsConstraint() {
+		return new MustExistsConstraint();
 	}
 
 	/**

--- a/tests/phpunit/Integration/Constraint/ConstraintRegistryFactoryTest.php
+++ b/tests/phpunit/Integration/Constraint/ConstraintRegistryFactoryTest.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace SMW\Tests\Integration\Constraint;
+
+use SMW\ApplicationFactory;
+use SMW\Constraint\ConstraintRegistry;
+
+/**
+ * @group semantic-mediawiki
+ *
+ * @license GNU GPL v2+
+ * @since 3.1
+ *
+ * @author mwjames
+ */
+class ConstraintRegistryFactoryTest extends \PHPUnit_Framework_TestCase {
+
+	/**
+	 * @dataProvider constraintKeyProvider
+	 */
+	public function testGetConstraint( $key ) {
+
+		$instance = new ConstraintRegistry(
+			ApplicationFactory::getInstance()->create( 'ConstraintFactory' )
+		);
+
+		$this->assertInstanceOf(
+			'\SMW\Constraint\Constraint',
+			$instance->getConstraintByKey( $key )
+		);
+	}
+
+	public function constraintKeyProvider() {
+
+		$instance = new ConstraintRegistry(
+			ApplicationFactory::getInstance()->create( 'ConstraintFactory' )
+		);
+
+		foreach ( $instance->getConstraintKeys() as $key ) {
+			yield [ $key ];
+		}
+	}
+
+}

--- a/tests/phpunit/Integration/JSONScript/Fixtures/p-1102-constraint-must-exists.json
+++ b/tests/phpunit/Integration/JSONScript/Fixtures/p-1102-constraint-must-exists.json
@@ -1,0 +1,11 @@
+{
+    "type": "PROPERTY_CONSTRAINT_SCHEMA",
+    "constraints": {
+        "must_exists": true
+    },
+    "tags": [
+        "property constraint",
+        "integer",
+        "number"
+    ]
+}

--- a/tests/phpunit/Integration/JSONScript/TestCases/p-1102.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/p-1102.json
@@ -1,0 +1,75 @@
+{
+	"description": "Test `smw/schema` on `PROPERTY_CONSTRAINT_SCHEMA` with `must_exists` and `Constraint schema`",
+	"setup": [
+		{
+			"namespace": "SMW_NS_SCHEMA",
+			"page": "Constraint:MustExists",
+			"contents": {
+				"import-from": "/../Fixtures/p-1102-constraint-must-exists.json"
+			}
+		},
+		{
+			"namespace": "SMW_NS_PROPERTY",
+			"page": "Has page",
+			"contents": "[[Has type::Page]] [[Constraint schema::Constraint:MustExists]]"
+		},
+		{
+			"page": "Test:P1102/1",
+			"contents": "[[Has page::DoesNotExist]]"
+		},
+		{
+			"page": "Test:P1102/2",
+			"contents": "[[Has page::Test:P1102/1]]"
+		}
+	],
+	"tests": [
+		{
+			"type": "parser",
+			"about": "#0 (invalid assignment on `must_exists`)",
+			"subject": "Test:P1102/1",
+			"assert-store": {
+				"semantic-data": {
+					"strict-mode-valuematch": false,
+					"propertyCount": 3,
+					"propertyKeys": [
+						"_MDAT",
+						"_SKEY",
+						"_ERRC"
+					]
+				}
+			},
+			"assert-output": {
+				"to-contain": [
+					"<span class=\"smwttcontent\">Property \"Has page\" has a &lt;code&gt;must_exists&lt;/code&gt; constraint and value <i>DoesNotExist</i> is violating that requirement.</span>"
+				]
+			}
+		},
+		{
+			"type": "parser",
+			"about": "#1 (valid assignment on `must_exists`)",
+			"subject": "Test:P1102/2",
+			"assert-output": {
+				"to-contain": [
+					"P1102/1"
+				]
+			}
+		}
+	],
+	"settings": {
+		"wgContLang": "en",
+		"wgLang": "en",
+		"smwgPageSpecialProperties": [
+			"_MDAT"
+		],
+		"smwgNamespacesWithSemanticLinks": {
+			"NS_MAIN": true,
+			"SMW_NS_PROPERTY": true,
+			"SMW_NS_SCHEMA": true
+		}
+	},
+	"meta": {
+		"version": "2",
+		"is-incomplete": false,
+		"debug": false
+	}
+}

--- a/tests/phpunit/Unit/Constraint/ConstraintRegistryTest.php
+++ b/tests/phpunit/Unit/Constraint/ConstraintRegistryTest.php
@@ -33,6 +33,18 @@ class ConstraintRegistryTest extends \PHPUnit_Framework_TestCase {
 		);
 	}
 
+	public function testGetConstraintKeys() {
+
+		$instance = new ConstraintRegistry(
+			$this->constraintFactory
+		);
+
+		$this->assertInternaltype(
+			'array',
+			$instance->getConstraintKeys()
+		);
+	}
+
 	public function testGetConstraintByUnkownKey() {
 
 		$constraint = $this->getMockBuilder( '\SMW\Constraint\Constraint' )
@@ -133,6 +145,21 @@ class ConstraintRegistryTest extends \PHPUnit_Framework_TestCase {
 		yield[
 			'allowed_namespaces',
 			'SMW\Constraint\Constraints\NamespaceConstraint'
+		];
+
+		yield[
+			'unique_value_constraint',
+			'SMW\Constraint\Constraints\UniqueValueConstraint'
+		];
+
+		yield[
+			'non_negative_integer',
+			'SMW\Constraint\Constraints\NonNegativeIntegerConstraint'
+		];
+
+		yield[
+			'must_exists',
+			'SMW\Constraint\Constraints\MustExistsConstraint'
 		];
 	}
 

--- a/tests/phpunit/Unit/Constraint/Constraints/MustExistsConstraintTest.php
+++ b/tests/phpunit/Unit/Constraint/Constraints/MustExistsConstraintTest.php
@@ -1,0 +1,132 @@
+<?php
+
+namespace SMW\Tests\Constraint\Constraints;
+
+use SMW\Constraint\Constraints\MustExistsConstraint;
+use SMW\Tests\PHPUnitCompat;
+use SMW\DataItemFactory;
+
+/**
+ * @covers \SMW\Constraint\Constraints\MustExistsConstraint
+ * @group semantic-mediawiki
+ *
+ * @license GNU GPL v2+
+ * @since 3.1
+ *
+ * @author mwjames
+ */
+class MustExistsConstraintTest extends \PHPUnit_Framework_TestCase {
+
+	use PHPUnitCompat;
+
+	private $dataItemFactory;
+
+	protected function setUp() {
+		$this->dataItemFactory = new DataItemFactory();
+	}
+
+	public function testCanConstruct() {
+
+		$this->assertInstanceOf(
+			MustExistsConstraint::class,
+			new MustExistsConstraint()
+		);
+	}
+
+	public function testGetType() {
+
+		$instance = new MustExistsConstraint();
+
+		$this->assertEquals(
+			MustExistsConstraint::TYPE_INSTANT,
+			$instance->getType()
+		);
+	}
+
+	public function testHasViolation() {
+
+		$instance = new MustExistsConstraint();
+
+		$this->assertFalse(
+			$instance->hasViolation()
+		);
+	}
+
+	public function testCheckConstraint_must_exists() {
+
+		$constraint = [
+			'must_exists' => true
+		];
+
+		$expectedErrMsg = 'smw-datavalue-constraint-violation-must-exists';
+
+		$title = $this->getMockBuilder( '\Title' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$title->expects( $this->atLeastOnce() )
+			->method( 'exists' )
+			->will( $this->returnValue( false ) );
+
+		$dataItem = $this->getMockBuilder( '\SMW\DIWikiPage' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$dataItem->expects( $this->atLeastOnce() )
+			->method( 'getDIType' )
+			->will( $this->returnValue( \SMWDataItem::TYPE_WIKIPAGE ) );
+
+		$dataItem->expects( $this->atLeastOnce() )
+			->method( 'getTitle' )
+			->will( $this->returnValue( $title ) );
+
+		$dataValue = $this->getMockBuilder( '\SMWDataValue' )
+			->disableOriginalConstructor()
+			->setMethods( [ 'getProperty', 'getDataItem', 'addErrorMsg' ] )
+			->getMockForAbstractClass();
+
+		$dataValue->expects( $this->atLeastOnce() )
+			->method( 'addErrorMsg' )
+			->with( $this->callback( function( $error ) use ( $expectedErrMsg ) {
+				return $this->checkConstraintError( $error, $expectedErrMsg );
+			} ) );
+
+		$dataValue->expects( $this->atLeastOnce() )
+			->method( 'getProperty' )
+			->will( $this->returnValue( $this->dataItemFactory->newDIProperty( 'Bar' ) ) );
+
+		$dataValue->expects( $this->atLeastOnce() )
+			->method( 'getDataItem' )
+			->will( $this->returnValue( $dataItem ) );
+
+		$instance = new MustExistsConstraint();
+
+		$instance->checkConstraint( $constraint, $dataValue );
+
+		$this->assertTrue(
+			$instance->hasViolation()
+		);
+	}
+
+	public function testCheckConstraint_must_exists_ThrowsException() {
+
+		$constraint = [
+			'must_exists' => true
+		];
+
+		$instance = new MustExistsConstraint();
+
+		$this->setExpectedException( '\RuntimeException' );
+		$instance->checkConstraint( $constraint, 'Foo' );
+	}
+
+	public function checkConstraintError( $error, $expectedErrMsg ) {
+
+		if ( strpos( $error->__toString(), $expectedErrMsg ) !== false ) {
+			return true;
+		}
+
+		return false;
+	}
+
+}


### PR DESCRIPTION
This PR is made in reference to: #3746

This PR addresses or contains:

- Adds the `must_exists` constraint and is only relevant to the `Page` type where its checks whether the value exists or not before it can be used as annotation element for a property that has the constraint attached.

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed

## Example

```json
{
    "type": "PROPERTY_CONSTRAINT_SCHEMA",
    "constraints": {
        "must_exists": true
    },
    "tags": [
        "property constraint",
        "must exists"
    ]
}
```