### PR TITLE
Fix "Call to a member function getLabel() on null", refs 3979, 3730

### DIFF
--- a/src/Property/DeclarationExaminer/CommonExaminer.php
+++ b/src/Property/DeclarationExaminer/CommonExaminer.php
@@ -150,7 +150,7 @@ class CommonExaminer extends DeclarationExaminer {
 	private function checkCommonMessage( $propertyName ) {
 
 		if ( Message::exists( 'smw-property-introductory-message' ) ) {
-			$this->messages[] = [ 'info', 'smw-property-introductory-message', $property->getLabel() ];
+			$this->messages[] = [ 'info', 'smw-property-introductory-message', $propertyName ];
 		}
 
 		$label = mb_strtolower( str_replace( ' ', '-', $propertyName ) );


### PR DESCRIPTION
This PR is made in reference to: #3979, #3730

This PR addresses or contains:

This PR includes:
- [ ] Tests (unit/integration)
- [ ] CI build passed

Fixes #3979