### PR TITLE
Remove SMW\MediaWiki\Job::getTitle()

### DIFF
--- a/src/MediaWiki/Job.php
+++ b/src/MediaWiki/Job.php
@@ -91,17 +91,6 @@ abstract class Job extends MediaWikiJob {
 	}
 
 	/**
-	 * @note Job::getTitle() in MW 1.19 does not exist
-	 *
-	 * @since  1.9
-	 *
-	 * @return Title
-	 */
-	public function getTitle() {
-		return $this->title;
-	}
-
-	/**
 	 * @since  1.9
 	 *
 	 * @param mixed $key


### PR DESCRIPTION
This function was added in SMW 1.9 because it was missing from
MW 1.19; it was added in MW 1.21 hence it is in all MW versions
supported by SMW 3.0+. It is mandatory to remove this function
for compatibility with MW 1.34 because the method was declared
final. The implementation was always be the same.

This PR includes:
- [ ] Tests (unit/integration)
- [x] CI build passed

Fixes #3914