### PR TITLE
Track errors as unique entity in subobjects

### DIFF
--- a/src/ProcessingErrorMsgHandler.php
+++ b/src/ProcessingErrorMsgHandler.php
@@ -196,11 +196,12 @@ class ProcessingErrorMsgHandler {
 		}
 
 		$property = $dataValue->getProperty();
+		$contextPage = $dataValue->getContextPage();
 
-		if ( $property !== null ) {
-			$hash = $property->getKey();
-		} else {
+		if ( $property === null || ( $contextPage !== null && $contextPage->getSubobjectName() !== '' ) ) {
 			$hash = $dataValue->getDataItem()->getHash();
+		} else {
+			$hash = $property->getKey();
 		}
 
 		$errorsByType = $this->flip( $dataValue->getErrorsByType() );

--- a/tests/phpunit/Integration/JSONScript/TestCases/p-0462.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/p-0462.json
@@ -1,0 +1,122 @@
+{
+	"description": "Test `#subobject` and error handling",
+	"setup": [
+		{
+			"namespace": "SMW_NS_PROPERTY",
+			"page": "Has number",
+			"contents": "[[Has type::Number]]"
+		},
+		{
+			"page": "Example/P0462/1",
+			"contents": "{{#subobject: Has number=abc}}{{#subobject: Has number=abcd|Has number=abc}} {{#subobject:Test |Has number=abcd|Has number=abc}}"
+		}
+	],
+	"tests": [
+		{
+			"type": "parser",
+			"about": "#0",
+			"subject": "Example/P0462/1#_ERR94964c120bceb578838ce0b62394aa2d",
+			"assert-store": {
+				"semantic-data": {
+					"strictPropertyValueMatch": false,
+					"propertyCount": 3,
+					"propertyKeys": [
+						"_SKEY",
+						"_ERRP",
+						"_ERRT"
+					],
+					"propertyValues": [
+						"[2,\"smw_nofloat\",\"abc\"]"
+					]
+				}
+			}
+		},
+		{
+			"type": "parser",
+			"about": "#1",
+			"subject": "Example/P0462/1#_ERR4744c471aa3515bcba21a12a9b387f78",
+			"assert-store": {
+				"semantic-data": {
+					"strictPropertyValueMatch": false,
+					"propertyCount": 3,
+					"propertyKeys": [
+						"_SKEY",
+						"_ERRP",
+						"_ERRT"
+					],
+					"propertyValues": [
+						"[2,\"smw_nofloat\",\"abcd\"]"
+					]
+				}
+			}
+		},
+		{
+			"type": "parser",
+			"about": "#2",
+			"subject": "Example/P0462/1#_c71be766a73df58730d12de08322a103",
+			"assert-store": {
+				"semantic-data": {
+					"strictPropertyValueMatch": false,
+					"propertyCount": 2,
+					"propertyKeys": [
+						"_SKEY",
+						"_ERRC"
+					],
+					"propertyValues": [
+						"Example/P0462/1#_ERR94964c120bceb578838ce0b62394aa2d"
+					]
+				}
+			}
+		},
+		{
+			"type": "parser",
+			"about": "#3",
+			"subject": "Example/P0462/1#_8e3bf5d37464a8fe3a6b0fd220e47d2c",
+			"assert-store": {
+				"semantic-data": {
+					"strictPropertyValueMatch": false,
+					"propertyCount": 2,
+					"propertyKeys": [
+						"_SKEY",
+						"_ERRC"
+					],
+					"propertyValues": [
+						"Example/P0462/1#_ERR4744c471aa3515bcba21a12a9b387f78",
+						"Example/P0462/1#_ERR94964c120bceb578838ce0b62394aa2d"
+					]
+				}
+			}
+		},
+		{
+			"type": "parser",
+			"about": "#4",
+			"subject": "Example/P0462/1#Test",
+			"assert-store": {
+				"semantic-data": {
+					"strictPropertyValueMatch": false,
+					"propertyCount": 2,
+					"propertyKeys": [
+						"_SKEY",
+						"_ERRC"
+					],
+					"propertyValues": [
+						"Example/P0462/1#_ERR4744c471aa3515bcba21a12a9b387f78",
+						"Example/P0462/1#_ERR94964c120bceb578838ce0b62394aa2d"
+					]
+				}
+			}
+		}
+	],
+	"settings": {
+		"wgContLang": "ru",
+		"wgLang": "en",
+		"smwgPageSpecialProperties": [
+			"_MDAT"
+		]
+	},
+	"meta": {
+		"version": "2",
+		"is-incomplete": false,
+		"debug": false
+	}
+}

--- a/tests/phpunit/Integration/JSONScript/TestCases/r-0016.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/r-0016.json
@@ -33,7 +33,7 @@
 					"<swivt:Subject rdf:about=\"http://example.org/id/Example/R0016/1/-E7-89-B9-E6-AE-8A-E5-AD-97-E7-AC-A6\">",
 					"<rdfs:label>Example/R0016/1/特殊字符</rdfs:label>",
 					"<property:Has_subobject rdf:resource=\"&wiki;Example/R0016/1/-E7-89-B9-E6-AE-8A-E5-AD-97-E7-AC-A6-23-5E-5B0-2D9-5D-2A-24\"/>",
-					"<swivt:Subject rdf:about=\"http://example.org/id/Example/R0016/1/-E7-89-B9-E6-AE-8A-E5-AD-97-E7-AC-A6-23_ERRb4cc1ce66e816f93b716adeeddb0fa46\">",
+					"<swivt:Subject rdf:about=\"http://example.org/id/Example/R0016/1/-E7-89-B9-E6-AE-8A-E5-AD-97-E7-AC-A6-23_ERR1fd3f66738f13f376474b81b9af53d31\">",
 					"<property:Has_improper_value_for rdf:resource=\"&wiki;Property-3A-E7-89-B9-E6-AE-8A-E5-AD-97-E7-AC-A6\"/>",
 					"<swivt:wikiPageSortKey rdf:datatype=\"http://www.w3.org/2001/XMLSchema#string\">Example/R0016/1/特殊字符</swivt:wikiPageSortKey>"
 				]
@@ -57,7 +57,7 @@
 					"<swivt:Subject rdf:about=\"http://example.org/id/Example/R0016/2/-E7-89-B9-E6-AE-8A-E5-AD-97-E7-AC-A6\">",
 					"<rdfs:label>Example/R0016/2/特殊字符</rdfs:label>",
 					"<property:Has_subobject rdf:resource=\"&wiki;Example/R0016/2/-E7-89-B9-E6-AE-8A-E5-AD-97-E7-AC-A6-23-7B-28-7B-5B-5B-26-2C-2C-3B-2D.-5D-5D-7D-29-7D\"/>",
-					"<swivt:Subject rdf:about=\"http://example.org/id/Example/R0016/2/-E7-89-B9-E6-AE-8A-E5-AD-97-E7-AC-A6-23_ERRb4cc1ce66e816f93b716adeeddb0fa46\">",
+					"<swivt:Subject rdf:about=\"http://example.org/id/Example/R0016/2/-E7-89-B9-E6-AE-8A-E5-AD-97-E7-AC-A6-23_ERR112b24958a8154ac2a0147433b74f2b1\">",
 					"<property:Has_improper_value_for rdf:resource=\"&wiki;Property-3A-E7-89-B9-E6-AE-8A-E5-AD-97-E7-AC-A6\"/>"
 				]
 			}
@@ -80,7 +80,7 @@
 					"<swivt:Subject rdf:about=\"http://example.org/id/Example/R0016/3/-E7-89-B9-E6-AE-8A_-E5-AD-97-E7-AC-A6\">",
 					"<rdfs:label>Example/R0016/3/特殊 字符</rdfs:label>",
 					"<property:Has_subobject rdf:resource=\"&wiki;Example/R0016/3/-E7-89-B9-E6-AE-8A_-E5-AD-97-E7-AC-A6-23-3C-3E\"/>",
-					"<swivt:Subject rdf:about=\"http://example.org/id/Example/R0016/3/-E7-89-B9-E6-AE-8A_-E5-AD-97-E7-AC-A6-23_ERRb4cc1ce66e816f93b716adeeddb0fa46\">",
+					"<swivt:Subject rdf:about=\"http://example.org/id/Example/R0016/3/-E7-89-B9-E6-AE-8A_-E5-AD-97-E7-AC-A6-23_ERRa38d176f3646438a004d712cca6a78fd\">",
 					"<property:Has_improper_value_for rdf:resource=\"&wiki;Property-3A-E7-89-B9-E6-AE-8A-E5-AD-97-E7-AC-A6\"/>"
 				]
 			}

--- a/tests/phpunit/Integration/JSONScript/TestCases/r-0017.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/r-0017.json
@@ -33,7 +33,7 @@
 					"<swivt:Subject rdf:about=\"http://example.org/id/Example/R0017/1/特殊字符\">",
 					"<rdfs:label>Example/R0017/1/特殊字符</rdfs:label>",
 					"<property:Has_subobject rdf:resource=\"&wiki;Example/R0017/1/特殊字符-23-5E-5B0-2D9-5D-2A-24\"/>",
-					"<swivt:Subject rdf:about=\"http://example.org/id/Example/R0017/1/特殊字符-23_ERRb4cc1ce66e816f93b716adeeddb0fa46\">",
+					"<swivt:Subject rdf:about=\"http://example.org/id/Example/R0017/1/特殊字符-23_ERR1fd3f66738f13f376474b81b9af53d31\">",
 					"<swivt:Subject rdf:about=\"http://example.org/id/Example/R0017/1/特殊字符-23-5E-5B0-2D9-5D-2A-24\">"
 				]
 			}
@@ -56,7 +56,7 @@
 					"<swivt:Subject rdf:about=\"http://example.org/id/Example/R0017/2/特殊字符\">",
 					"<rdfs:label>Example/R0017/2/特殊字符</rdfs:label>",
 					"<property:Has_subobject rdf:resource=\"&wiki;Example/R0017/2/特殊字符-23-7B-28-7B-5B-5B-26-2C-2C-3B-2D.-5D-5D-7D-29-7D\"/>",
-					"<swivt:Subject rdf:about=\"http://example.org/id/Example/R0017/2/特殊字符-23_ERRb4cc1ce66e816f93b716adeeddb0fa46\">",
+					"<swivt:Subject rdf:about=\"http://example.org/id/Example/R0017/2/特殊字符-23_ERR112b24958a8154ac2a0147433b74f2b1\">",
 					"<swivt:Subject rdf:about=\"http://example.org/id/Example/R0017/2/特殊字符-23-7B-28-7B-5B-5B-26-2C-2C-3B-2D.-5D-5D-7D-29-7D\">"
 				]
 			}
@@ -79,7 +79,7 @@
 					"<swivt:Subject rdf:about=\"http://example.org/id/Example/R0017/3/特殊_字符\">",
 					"<rdfs:label>Example/R0017/3/特殊 字符</rdfs:label>",
 					"<property:Has_subobject rdf:resource=\"&wiki;Example/R0017/3/特殊_字符-23-3C-3E\"/>",
-					"<swivt:Subject rdf:about=\"http://example.org/id/Example/R0017/3/特殊_字符-23_ERRb4cc1ce66e816f93b716adeeddb0fa46\">",
+					"<swivt:Subject rdf:about=\"http://example.org/id/Example/R0017/3/特殊_字符-23_ERRa38d176f3646438a004d712cca6a78fd\">",
 					"<swivt:Subject rdf:about=\"http://example.org/id/Example/R0017/3/特殊_字符-23-3C-3E\">"
 				]
 			}


### PR DESCRIPTION
This PR is made in reference to: #

This PR addresses or contains:

- Uses a different hash basis for an error container to ensure that those errors (e.g. `{{#subobject: Has number=abcd|Has number=abc}}`) can be tracked uniquely within a subobject

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed
