### PR TITLE
Disable `wpg` Title related methods, refs 3801

### DIFF
--- a/includes/datavalues/SMW_DV_WikiPage.php
+++ b/includes/datavalues/SMW_DV_WikiPage.php
@@ -486,6 +486,8 @@ class SMWWikiPageValue extends SMWDataValue {
 ///// special interface for wiki page values
 
 	/**
+	 * @deprecated since 3.1
+	 *
 	 * Return according Title object or null if no valid value was set.
 	 * null can be returned even if this object returns true for isValid(),
 	 * since the latter function does not check whether MediaWiki can really
@@ -495,7 +497,7 @@ class SMWWikiPageValue extends SMWDataValue {
 	 *
 	 * @return Title
 	 */
-	public function getTitle() {
+	private function getTitle() {
 
 		if ( $this->m_title !== null ) {
 			return $this->m_title;
@@ -538,11 +540,13 @@ class SMWWikiPageValue extends SMWDataValue {
 	}
 
 	/**
+	 * @deprecated since 3.1
+	 *
 	 * Get MediaWiki's ID for this value or 0 if not available.
 	 *
 	 * @return integer
 	 */
-	public function getArticleID() {
+	private function getArticleID() {
 		if ( $this->m_id === false ) {
 			$this->m_id = !is_null( $this->getTitle() ) ? $this->m_title->getArticleID() : 0;
 		}
@@ -551,15 +555,19 @@ class SMWWikiPageValue extends SMWDataValue {
 	}
 
 	/**
+	 * @deprecated since 3.1
+	 *
 	 * Get namespace constant for this value.
 	 *
 	 * @return integer
 	 */
-	public function getNamespace() {
+	private function getNamespace() {
 		return $this->m_dataitem->getNamespace();
 	}
 
 	/**
+	 * @deprecated since 3.1
+	 *
 	 * Get DBKey for this value. Subclasses that allow for values that do not
 	 * correspond to wiki pages may choose a DB key that is not a legal title
 	 * DB key but rather another suitable internal ID. Thus it is not suitable
@@ -567,7 +575,7 @@ class SMWWikiPageValue extends SMWDataValue {
 	 *
 	 * @return string
 	 */
-	public function getDBkey() {
+	private function getDBkey() {
 		return $this->m_dataitem->getDBkey();
 	}
 
@@ -616,11 +624,13 @@ class SMWWikiPageValue extends SMWDataValue {
 	}
 
 	/**
+	 * @deprecated since 3.1
+	 *
 	 * Get interwiki prefix or empty string.
 	 *
 	 * @return string
 	 */
-	public function getInterwiki() {
+	private function getInterwiki() {
 		return $this->m_dataitem->getInterwiki();
 	}
 
@@ -733,7 +743,7 @@ class SMWWikiPageValue extends SMWDataValue {
 	 *
 	 * @return string sortkey
 	 */
-	public function getSortKey() {
+	private function getSortKey() {
 		return ApplicationFactory::getInstance()->getStore()->getWikiPageSortKey( $this->m_dataitem );
 	}
 
@@ -744,7 +754,7 @@ class SMWWikiPageValue extends SMWDataValue {
 	 */
 	public function getDisplayTitle() {
 
-		if ( $this->m_dataitem === null || !$this->isEnabledFeature( SMW_DV_WPV_DTITLE ) ) {
+		if ( $this->m_dataitem === null || !$this->hasFeature( SMW_DV_WPV_DTITLE ) ) {
 			return '';
 		}
 

--- a/src/MediaWiki/Specials/SpecialBrowse.php
+++ b/src/MediaWiki/Specials/SpecialBrowse.php
@@ -72,7 +72,7 @@ class SpecialBrowse extends SpecialPage {
 		);
 
 		$out = $this->getOutput();
-		$out->setHTMLTitle( $dataValue->getTitle() );
+		$out->setHTMLTitle( $dataValue->getWikiValue() );
 
 		$out->addModuleStyles( [
 			'mediawiki.ui',
@@ -196,7 +196,9 @@ class SpecialBrowse extends SpecialPage {
 		}
 
 		if ( $dataValue->isValid() ) {
-			$link = SpecialPage::getTitleFor( 'ExportRDF', $dataValue->getTitle()->getPrefixedText() );
+			$dataItem = $dataValue->getDataItem();
+
+			$title = SpecialPage::getTitleFor( 'ExportRDF', $dataItem->getTitle()->getPrefixedText() );
 
 			$this->getOutput()->setIndicators( [
 				'browse' => Html::rawElement(
@@ -207,7 +209,7 @@ class SpecialBrowse extends SpecialPage {
 					Html::rawElement(
 						'a',
 						[
-							'href' => $link->getLocalUrl( 'syntax=rdf' )
+							'href' => $title->getLocalUrl( 'syntax=rdf' )
 						],
 						'RDF'
 					)

--- a/tests/phpunit/includes/DataValues/WikiPageValueTest.php
+++ b/tests/phpunit/includes/DataValues/WikiPageValueTest.php
@@ -57,12 +57,6 @@ class WikiPageValueTest extends \PHPUnit_Framework_TestCase {
 		$instance->setDataItem(
 			$this->dataItemFactory->newDIWikiPage( '>Foo', NS_USER )
 		);
-
-		$instance->getTitle();
-
-		$this->assertTrue(
-			$instance->getOption( WikiPageValue::OPT_DISABLE_INFOLINKS )
-		);
 	}
 
 }


### PR DESCRIPTION
This PR is made in reference to: #3801

This PR addresses or contains:

- Sets all `Title` related methods in `WikiPageValue` to be private hereby axe any external access
- If a consumer needs access to a `Title` object then s(he) should use `DataValue::getDataItem` and access a `Title` instance via the `DataItem`.

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed
