### PR TITLE
Rem `prepareTextForEdit`, refs 3943

### DIFF
--- a/tests/phpunit/Integration/JSONScript/QueryTestCaseInterpreter.php
+++ b/tests/phpunit/Integration/JSONScript/QueryTestCaseInterpreter.php
@@ -264,7 +264,7 @@ class QueryTestCaseInterpreter {
 		}
 
 		$title = \Title::newFromText( $this->contents['subject'] );
-		$parserOutput = UtilityFactory::getInstance()->newPageReader()->getEditInfo( $title )->output;
+		$parserOutput = UtilityFactory::getInstance()->newPageReader()->getEditInfo( $title )->getOutput();
 
 		return $parserOutput->getText();
 	}

--- a/tests/phpunit/Integration/MediaWiki/LinksUpdateTest.php
+++ b/tests/phpunit/Integration/MediaWiki/LinksUpdateTest.php
@@ -88,7 +88,7 @@ class LinksUpdateTest extends MwDBaseUnitTestCase {
 
 		$parserData = $this->applicationFactory->newParserData(
 			$this->title,
-			$this->pageCreator->getEditInfo()->output
+			$this->pageCreator->getEditInfo()->getOutput()
 		);
 
 		$contentParser = $this->applicationFactory->newContentParser( $this->title );

--- a/tests/phpunit/Integration/MediaWiki/MediaWikiIntegrationForRegisteredHookTest.php
+++ b/tests/phpunit/Integration/MediaWiki/MediaWikiIntegrationForRegisteredHookTest.php
@@ -123,7 +123,7 @@ class MediaWikiIntegrationForRegisteredHookTest extends MwDBaseUnitTestCase {
 			->createPage( $this->title )
 			->doEdit( '[[EditPageToGetNewRevisionHookTest::Foo]]' );
 
-		$parserOutput = $pageCreator->getEditInfo()->output;
+		$parserOutput = $pageCreator->getEditInfo()->getOutput();
 
 		$this->assertInstanceOf(
 			'ParserOutput',
@@ -155,7 +155,7 @@ class MediaWikiIntegrationForRegisteredHookTest extends MwDBaseUnitTestCase {
 			->createPage( $this->title )
 			->doEdit( '[[Has function hook test::output page]]' );
 
-		$parserOutput = $pageCreator->getEditInfo()->output;
+		$parserOutput = $pageCreator->getEditInfo()->getOutput();
 
 		$this->assertInstanceOf(
 			'ParserOutput',

--- a/tests/phpunit/Integration/Query/ResultPrinters/ResultPrinterIntegrationTest.php
+++ b/tests/phpunit/Integration/Query/ResultPrinters/ResultPrinterIntegrationTest.php
@@ -66,7 +66,7 @@ class ResultPrinterIntegrationTest extends MwDBaseUnitTestCase {
 
 		$this->subjects[] = $this->pageCreator->getPage();
 
-		$parserOutput = $this->pageCreator->getEditInfo()->output;
+		$parserOutput = $this->pageCreator->getEditInfo()->getOutput();
 
 		$this->assertNotContains(
 			'[[Special:Ask/-5B-5BModification-20date::+-5D-5D-5B-5BCategory:LimitNullForEmptySearchlabel-5D-5D/searchlabel=/offset=0|]]',
@@ -102,7 +102,7 @@ class ResultPrinterIntegrationTest extends MwDBaseUnitTestCase {
 
 		$this->subjects[] = $this->pageCreator->getPage();
 
-		$parserOutput = $this->pageCreator->getEditInfo()->output;
+		$parserOutput = $this->pageCreator->getEditInfo()->getOutput();
 
 		$this->assertContains(
 			'do something',

--- a/tests/phpunit/Unit/MediaWiki/EditInfoProviderTest.php
+++ b/tests/phpunit/Unit/MediaWiki/EditInfoProviderTest.php
@@ -86,10 +86,6 @@ class EditInfoProviderTest extends \PHPUnit_Framework_TestCase {
 	 */
 	public function testFetchContentInfoWithDisabledContentHandler( $parameters, $expected ) {
 
-		if ( !method_exists( '\WikiPage', 'prepareTextForEdit' ) ) {
-			$this->markTestSkipped( 'WikiPage::prepareTextForEdit is no longer accessible (MW 1.29+)' );
-		}
-
 		$instance = $this->getMockBuilder( '\SMW\MediaWiki\EditInfoProvider' )
 			->setConstructorArgs( [
 				$parameters['wikiPage'],
@@ -111,9 +107,6 @@ class EditInfoProviderTest extends \PHPUnit_Framework_TestCase {
 
 	public function wikiPageDataProvider() {
 
-		// 'WikiPage::prepareTextForEdit is no longer accessible (MW 1.29+)'
-		$prepareTextForEditExists = method_exists( '\WikiPage', 'prepareTextForEdit' );
-
 		$title = $this->getMockBuilder( '\Title' )
 			->disableOriginalConstructor()
 			->getMock();
@@ -129,12 +122,6 @@ class EditInfoProviderTest extends \PHPUnit_Framework_TestCase {
 		$wikiPage->expects( $this->any() )
 			->method( 'prepareContentForEdit' )
 			->will( $this->returnValue( $editInfo ) );
-
-		if ( $prepareTextForEditExists ) {
-			$wikiPage->expects( $this->any() )
-				->method( 'prepareTextForEdit' )
-				->will( $this->returnValue( $editInfo ) );
-		}
 
 		$provider[] = [
 			[
@@ -153,12 +140,6 @@ class EditInfoProviderTest extends \PHPUnit_Framework_TestCase {
 		$wikiPage->expects( $this->any() )
 			->method( 'prepareContentForEdit' )
 			->will( $this->returnValue( false ) );
-
-		if ( $prepareTextForEditExists ) {
-			$wikiPage->expects( $this->any() )
-				->method( 'prepareTextForEdit' )
-				->will( $this->returnValue( false ) );
-		}
 
 		$provider[] = [
 			[
@@ -181,12 +162,6 @@ class EditInfoProviderTest extends \PHPUnit_Framework_TestCase {
 			->method( 'prepareContentForEdit' )
 			->will( $this->returnValue( $editInfo ) );
 
-		if ( $prepareTextForEditExists ) {
-			$wikiPage->expects( $this->any() )
-				->method( 'prepareTextForEdit' )
-				->will( $this->returnValue( $editInfo ) );
-		}
-
 		$provider[] = [
 			[
 				'editInfo' => $editInfo,
@@ -206,12 +181,6 @@ class EditInfoProviderTest extends \PHPUnit_Framework_TestCase {
 		$wikiPage->expects( $this->any() )
 			->method( 'prepareContentForEdit' )
 			->will( $this->returnValue( $editInfo ) );
-
-		if ( $prepareTextForEditExists ) {
-			$wikiPage->expects( $this->any() )
-				->method( 'prepareTextForEdit' )
-				->will( $this->returnValue( $editInfo ) );
-		}
 
 		$provider[] = [
 			[

--- a/tests/phpunit/Utils/Page/PageEditor.php
+++ b/tests/phpunit/Utils/Page/PageEditor.php
@@ -6,6 +6,7 @@ use Revision;
 use RuntimeException;
 use Title;
 use WikiPage;
+use SMW\MediaWiki\EditInfoProvider as EditInfo;
 
 /**
  * @group SMW
@@ -19,7 +20,7 @@ class PageEditor {
 	/**
 	 * @var WikiPage|null
 	 */
-	private $page = null;
+	private $page;
 
 	/**
 	 * @since 2.1
@@ -58,17 +59,12 @@ class PageEditor {
 	 */
 	public function doEdit( $pageContent = '', $editMessage = '' ) {
 
-		if ( class_exists( 'WikitextContent' ) ) {
-			$content = new \WikitextContent( $pageContent );
+		$content = new \WikitextContent( $pageContent );
 
-			$this->getPage()->doEditContent(
-				$content,
-				$editMessage
-			);
-
-		} else {
-			$this->getPage()->doEdit( $pageContent, $editMessage );
-		}
+		$this->getPage()->doEditContent(
+			$content,
+			$editMessage
+		);
 
 		return $this;
 	}
@@ -78,29 +74,11 @@ class PageEditor {
 	 */
 	public function getEditInfo() {
 
-		if ( class_exists( 'WikitextContent' ) ) {
-
-			$content = $this->getPage()->getRevision()->getContent();
-			$format  = $content->getContentHandler()->getDefaultFormat();
-
-			return $this->getPage()->prepareContentForEdit(
-				$content,
-				null,
-				null,
-				$format
-			);
-		}
-
-		if ( method_exists( $this->getPage()->getRevision(), 'getContent' ) ) {
-			$text = $this->getPage()->getRevision()->getContent( Revision::RAW );
-		} else {
-			$text = $this->getPage()->getRevision()->getRawText();
-		}
-		return $this->getPage()->prepareTextForEdit(
-			$text,
-			null,
-			null
+		$editInfo = new EditInfo(
+			$this->getPage()
 		);
+
+		return $editInfo->fetchEditInfo();
 	}
 
 }

--- a/tests/phpunit/Utils/PageCreator.php
+++ b/tests/phpunit/Utils/PageCreator.php
@@ -7,6 +7,7 @@ use SMW\Tests\TestEnvironment;
 use SMW\Tests\Utils\Mock\MockSuperUser;
 use Title;
 use UnexpectedValueException;
+use SMW\MediaWiki\EditInfoProvider as EditInfo;
 
 /**
  * @license GNU GPL v2+
@@ -81,20 +82,15 @@ class PageCreator {
 	 */
 	public function doEdit( $pageContent = '', $editMessage = '' ) {
 
-		if ( class_exists( 'ContentHandler' ) ) {
-			$content = \ContentHandler::makeContent(
-				$pageContent,
-				$this->getPage()->getTitle()
-			);
+		$content = \ContentHandler::makeContent(
+			$pageContent,
+			$this->getPage()->getTitle()
+		);
 
-			$this->getPage()->doEditContent(
-				$content,
-				$editMessage
-			);
-
-		} else {
-			$this->getPage()->doEdit( $pageContent, $editMessage );
-		}
+		$this->getPage()->doEditContent(
+			$content,
+			$editMessage
+		);
 
 		TestEnvironment::executePendingDeferredUpdates();
 
@@ -134,28 +130,11 @@ class PageCreator {
 	 */
 	public function getEditInfo() {
 
-		$revision = $this->getPage()->getRevision();
-
-		if ( class_exists( 'ContentHandler' ) ) {
-
-			$content = $revision->getContent();
-			$format  = $content->getContentHandler()->getDefaultFormat();
-
-			return $this->getPage()->prepareContentForEdit(
-				$content,
-				null,
-				null,
-				$format
-			);
-		}
-
-		$text = method_exists( $revision, 'getContent' ) ? $revision->getContent( Revision::RAW ) : $revision->getRawText();
-
-		return $this->getPage()->prepareTextForEdit(
-			$text,
-			null,
-			null
+		$editInfo = new EditInfo(
+			$this->getPage()
 		);
+
+		return $editInfo->fetchEditInfo();
 	}
 
 }

--- a/tests/phpunit/Utils/PageReader.php
+++ b/tests/phpunit/Utils/PageReader.php
@@ -6,6 +6,7 @@ use Revision;
 use TextContent;
 use Title;
 use UnexpectedValueException;
+use SMW\MediaWiki\EditInfoProvider as EditInfo;
 
 /**
  * @license GNU GPL v2+
@@ -45,18 +46,9 @@ class PageReader {
 	public function getContentAsText( Title $title ) {
 
 		$this->page = new \WikiPage( $title );
+		$content = $this->page->getContent();
 
-		if ( method_exists( $this->page, 'getContent' ) ) {
-			$content = $this->page->getContent();
-
-			if ( $content instanceof TextContent ) {
-				return $content->getNativeData();
-			} else {
-				return '';
-			}
-		}
-
-		return $this->page->getText();
+		return $content->getNativeData();
 	}
 
 	/**
@@ -66,29 +58,11 @@ class PageReader {
 
 		$this->page = new \WikiPage( $title );
 
-		if ( class_exists( 'WikitextContent' ) ) {
-
-			$content = $this->page->getRevision()->getContent();
-			$format  = $content->getContentHandler()->getDefaultFormat();
-
-			return $this->page->prepareContentForEdit(
-				$content,
-				null,
-				null,
-				$format
-			);
-		}
-
-		if ( method_exists( $this->getPage()->getRevision(), 'getContent' ) ) {
-			$text = $this->getPage()->getRevision()->getContent( Revision::RAW );
-		} else {
-			$text = $this->getPage()->getRevision()->getRawText();
-		}
-		return $this->page->prepareTextForEdit(
-			$text,
-			null,
-			null
+		$editInfo = new EditInfo(
+			$this->getPage()
 		);
+
+		return $editInfo->fetchEditInfo();
 	}
 
 	/**
@@ -99,7 +73,7 @@ class PageReader {
 	 * @return ParserOutput|null
 	 */
 	public function getParserOutputFromEdit( Title $title ) {
-		return $this->getEditInfo( $title )->output;
+		return $this->getEditInfo( $title )->getOutput();
 	}
 
 }


### PR DESCRIPTION
This PR is made in reference to: #3943, #3801

This PR addresses or contains:

- `prepareTextForEdit` as been deprecated since MW 1.21 and removed in MW 1.29

This PR includes:
- [ ] Tests (unit/integration)
- [x] CI build passed
