### PR TITLE
[SMWSearch] Add `ExtendedSearch`, isolate query construction, refs 3992

### DIFF
--- a/src/MediaWiki/Search/ExtendedSearch.php
+++ b/src/MediaWiki/Search/ExtendedSearch.php
@@ -1,0 +1,357 @@
+<?php
+
+namespace SMW\MediaWiki\Search;
+
+use SMW\Store;
+use RuntimeException;
+use SearchEngine;
+use SMWQuery;
+use SMWQueryResult as QueryResult;
+use Title;
+
+/**
+ * Search engine that will try to find wiki pages by interpreting the search
+ * term as an SMW query.
+ *
+ * If successful, the pages according to the query will be returned.
+ * If not it falls back to the default search engine.
+ *
+ * @license GNU GPL v2+
+ * @since   2.1
+ *
+ * @author  Stephan Gambke
+ */
+class ExtendedSearch {
+
+	/**
+	 * @var Store
+	 */
+	private $store;
+
+	/**
+	 * @var SearchEngine
+	 */
+	private $fallbackSearchEngine;
+
+	/**
+	 * @var array
+	 */
+	private $errors = [];
+
+	/**
+	 * @var QueryBuilder
+	 */
+	private $queryBuilder;
+
+	/**
+	 * @var string
+	 */
+	private $queryString = '';
+
+	/**
+	 * @var InfoLink
+	 */
+	private $queryLink;
+
+	/**
+	 * @var
+	 */
+	private $prefix;
+
+	/**
+	 * @var []
+	 */
+	private $namespaces = [];
+
+	/**
+	 * @var []
+	 */
+	private $searchableNamespaces = [];
+
+	/**
+	 * @var integer
+	 */
+	private $limit = 10;
+
+	/**
+	 * @var integer
+	 */
+	private $offset = 0;
+
+	/**
+	 * @since 3.1
+	 *
+	 * @param Store $store
+	 * @param SearchEngine $fallbackSearchEngine
+	 */
+	public function __construct( Store $store, SearchEngine $fallbackSearchEngine ) {
+		$this->store = $store;
+		$this->fallbackSearchEngine = $fallbackSearchEngine;
+	}
+
+	/**
+	 * @since 3.1
+	 *
+	 * @param QueryBuilder $queryBuilder
+	 */
+	public function setQueryBuilder( QueryBuilder $queryBuilder ) {
+		$this->queryBuilder = $queryBuilder;
+	}
+
+	/**
+	 * @since 3.1
+	 *
+	 * @param string $prefix
+	 */
+	public function setPrefix( $prefix ) {
+		$this->prefix = $prefix;
+	}
+
+	/**
+	 * @since 3.1
+	 *
+	 * @param array $namespaces
+	 */
+	public function setNamespaces( array $namespaces ) {
+		$this->namespaces = $namespaces;
+	}
+
+	/**
+	 * @since 3.1
+	 *
+	 * @param array $searchableNamespaces
+	 */
+	public function setSearchableNamespaces( array $searchableNamespaces ) {
+		$this->searchableNamespaces = $searchableNamespaces;
+	}
+
+	/**
+	 * @since 3.1
+	 *
+	 * @param integer $limit
+	 * @param integer $offset
+	 */
+	public function setLimitOffset( $limit, $offset = 0 ) {
+		$this->limit = $limit;
+		$this->offset = $offset;
+	}
+
+	/**
+	 * @since 3.0
+	 *
+	 * @return []
+	 */
+	public function getErrors() {
+		return $this->errors;
+	}
+
+	/**
+	 * @since 3.0
+	 *
+	 * @return string
+	 */
+	public function getQueryString() {
+		return $this->queryString;
+	}
+
+	/**
+	 * @since 3.0
+	 *
+	 * @return string
+	 */
+	public function getQueryLink() {
+		return $this->queryLink;
+	}
+
+	/**
+	 * @since 3.0
+	 *
+	 * @return array
+	 */
+	public function getValidSorts() {
+		return [
+
+			// SemanticMediaWiki supported
+			'title', 'recent', 'best',
+
+			// MediaWiki default
+			'relevance'
+		];
+	}
+
+	/**
+	 * Perform a title-only search query and return a result set.
+	 *
+	 * This method will try to find wiki pages by interpreting the search term as an SMW query.
+	 *
+	 * If successful, the pages according to the query will be returned.
+	 * If not, it falls back to the default search engine.
+	 *
+	 * @param string $term Raw search term
+	 *
+	 * @return SearchResultSet|null
+	 */
+	public function searchTitle( $term ) {
+
+		if ( $this->getSearchQuery( $term ) !== null ) {
+			return null;
+		}
+
+		return $this->searchFallbackSearchEngine( $term, false );
+	}
+
+	/**
+	 * Perform a full text search query and return a result set.
+	 * If title searches are not supported or disabled, return null.
+	 *
+	 * @param string $term Raw search term
+	 *
+	 * @return SearchResultSet|\Status|null
+	 */
+	public function searchText( $term ) {
+
+		if ( $this->getSearchQuery( $term ) !== null ) {
+			return $this->newSearchResultSet( $term );
+		}
+
+		return $this->searchFallbackSearchEngine( $term, true );
+	}
+
+	/**
+	 * Perform a completion search.
+	 *
+	 * @param string $search
+	 *
+	 * @return SearchSuggestionSet
+	 */
+	public function completionSearch( $search ) {
+
+		$searchResultSet = null;
+
+		// Avoid MW's auto formatting of title entities
+		if ( $search !== '' ) {
+			$search{0} = strtolower( $search{0} );
+		}
+
+		if ( !$this->hasPrefixAndMinLenForCompletionSearch( $search, 3 ) ) {
+			return $this->fallbackSearchEngine->completionSearch( $search );
+		}
+
+		if ( $this->getSearchQuery( $search ) !== null ) {
+			$searchResultSet = $this->newSearchResultSet( $search, false, false );
+		}
+
+		if ( $searchResultSet instanceof SearchResultSet ) {
+			return $searchResultSet->newSearchSuggestionSet();
+		}
+
+		return $this->fallbackSearchEngine->completionSearch( $search );
+	}
+
+	private function hasPrefixAndMinLenForCompletionSearch( $term, $minLen ) {
+
+		// Only act on when `in:foo`, `has:SomeProperty`, or `phrase:some text`
+		// is actively used as prefix
+
+		if ( strpos( $term, 'in:' ) !== false && mb_strlen( $term ) >= ( 3 + $minLen ) ) {
+			return true;
+		}
+
+		if ( strpos( $term, 'has:' ) !== false && mb_strlen( $term ) >= ( 4 + $minLen ) ) {
+			return true;
+		}
+
+		if ( strpos( $term, 'phrase:' ) !== false && mb_strlen( $term ) >= ( 7 + $minLen ) ) {
+			return true;
+		}
+
+		return false;
+	}
+
+	private function newSearchResultSet( $term, $count = true, $highlight = true ) {
+
+		$query = $this->getSearchQuery( $term );
+
+		if ( $query === null ) {
+			return null;
+		}
+
+		$query->setOffset( $this->offset );
+		$query->setLimit( $this->limit, false );
+		$this->queryString = $query->getQueryString();
+
+		$query->clearErrors();
+		$query->setOption( 'highlight.fragment', $highlight );
+		$query->setOption( SMWQuery::PROC_CONTEXT, 'SpecialSearch' );
+
+		$result = $this->store->getQueryResult( $query );
+		$this->errors = $query->getErrors();
+
+		$this->queryLink = $result->getQueryLink();
+		$this->queryLink->setParameter( $this->offset, 'offset' );
+		$this->queryLink->setParameter( $this->limit, 'limit' );
+
+		if ( $count ) {
+			$query->querymode = SMWQuery::MODE_COUNT;
+			$query->setOffset( 0 );
+
+			$queryResult = $this->store->getQueryResult( $query );
+			$count = $queryResult instanceof QueryResult ? $queryResult->getCountValue() : $queryResult;
+		} else {
+			$count = 0;
+		}
+
+		return new SearchResultSet( $result, $count );
+	}
+
+	/**
+	 * @param String $term
+	 *
+	 * @return SMWQuery | null
+	 */
+	private function getSearchQuery( $term ) {
+
+		if ( $this->queryBuilder === null ) {
+			$this->queryBuilder = new QueryBuilder();
+		}
+
+		$this->queryString = $this->queryBuilder->getQueryString(
+			$this->store,
+			$term
+		);
+
+		$query = $this->queryBuilder->getQuery(
+			$this->queryString
+		);
+
+		$this->queryBuilder->addSort( $query );
+
+		$this->queryBuilder->addNamespaceCondition(
+			$query,
+			$this->searchableNamespaces
+		);
+
+		return $query;
+	}
+
+	private function searchFallbackSearchEngine( $term, $fulltext ) {
+
+		$this->fallbackSearchEngine->prefix = $this->prefix;
+		$this->fallbackSearchEngine->namespaces = $this->namespaces;
+
+		$term = $this->fallbackSearchEngine->transformSearchTerm(
+			$term
+		);
+
+		$term = $this->fallbackSearchEngine->replacePrefixes(
+			$term
+		);
+
+		if ( $fulltext ) {
+			return $this->fallbackSearchEngine->searchText( $term );
+		}
+
+		return $this->fallbackSearchEngine->searchTitle( $term );
+	}
+
+}

--- a/src/MediaWiki/Search/ExtendedSearchEngine.php
+++ b/src/MediaWiki/Search/ExtendedSearchEngine.php
@@ -4,24 +4,12 @@ namespace SMW\MediaWiki\Search;
 
 use Content;
 use DatabaseBase;
-use RuntimeException;
-use SearchEngine;
-use SMW\ApplicationFactory;
-use SMWQuery;
-use SMWQueryResult as QueryResult;
 use Title;
-use SMW\MediaWiki\Search\Exception\SearchDatabaseInvalidTypeException;
-use SMW\MediaWiki\Search\Exception\SearchEngineInvalidTypeException;
-use SMW\Exception\ClassNotFoundException;
+use SearchEngine;
 
 /**
- * Search engine that will try to find wiki pages by interpreting the search
- * term as an SMW query.
- *
- * If successful, the pages according to the query will be returned.
- * If not it falls back to the default search engine.
- *
- * @ingroup SMW
+ * Facade to the MediaWiki `SearchEngine` which doesn't allow any factory
+ * or callable to construct an instance.
  *
  * @license GNU GPL v2+
  * @since   2.1
@@ -31,180 +19,173 @@ use SMW\Exception\ClassNotFoundException;
 class ExtendedSearchEngine extends SearchEngine {
 
 	/**
+	 * @var ExtendedSearch
+	 */
+	private $extendedSearch;
+
+	/**
 	 * @var SearchEngine
 	 */
-	private $fallbackSearch;
+	private $fallbackSearchEngine;
 
 	/**
-	 * @var Database
+	 * @see SearchEngineFactory::create
+	 *
+	 * @since 3.1
 	 */
-	private $connection;
+	public function __construct( DatabaseBase $connection = null ) {
+		// It is common practice to avoid construction work in the constructor
+		// but we are unable to define a factory or callable and this is the only
+		// place to create an instance.
+		$searchEngineFactory = new SearchEngineFactory();
+
+		$this->fallbackSearchEngine = $searchEngineFactory->newFallbackSearchEngine(
+			$connection
+		);
+
+		$this->extendedSearch = $searchEngineFactory->newExtendedSearch(
+			$this->fallbackSearchEngine
+		);
+
+		$this->extendedSearch->setPrefix( $this->prefix );
+		$this->extendedSearch->setNamespaces( $this->namespaces );
+	}
 
 	/**
-	 * @var array
+	 * @since 3.1
+	 *
+	 * @param ExtendedSearch $extendedSearch
 	 */
-	private $errors = [];
+	public function setExtendedSearch( ExtendedSearch $extendedSearch ) {
+		$this->extendedSearch = $extendedSearch;
+	}
 
 	/**
-	 * @var QueryBuilder
+	 * @since 2.1
+	 *
+	 * @param null|SearchEngine $fallbackSearch
 	 */
-	private $queryBuilder;
+	public function setFallbackSearchEngine( SearchEngine $fallbackSearchEngine = null ) {
+		$this->fallbackSearchEngine = $fallbackSearchEngine;
+	}
 
 	/**
-	 * @var string
+	 * @since 2.1
+	 *
+	 * @return SearchEngine
 	 */
-	private $queryString = '';
-
-	/**
-	 * @var InfoLink
-	 */
-	private $queryLink;
+	public function getFallbackSearchEngine() {
+		return $this->fallbackSearchEngine;
+	}
 
 	/**
 	 * @see SearchEngine::getValidSorts
 	 *
-	 * @since 3.0
-	 *
-	 * @return array
+	 * {@inheritDoc}
 	 */
 	public function getValidSorts() {
-		return [
-
-			// SemanticMediaWiki supported
-			'title', 'recent', 'best',
-
-			// MediaWiki default
-			'relevance'
-		];
+		return $this->extendedSearch->getValidSorts();
 	}
 
 	/**
 	 * @see SearchEngine::searchTitle
 	 *
-	 * Perform a title-only search query and return a result set.
-	 *
-	 * This method will try to find wiki pages by interpreting the search term as an SMW query.
-	 *
-	 * If successful, the pages according to the query will be returned.
-	 * If not, it falls back to the default search engine.
-	 *
-	 * @param string $term Raw search term
-	 *
-	 * @return SearchResultSet|null
+	 * {@inheritDoc}
 	 */
 	public function searchTitle( $term ) {
 
-		if ( $this->getSearchQuery( $term ) !== null ) {
-			return null;
-		}
+		$this->extendedSearch->setNamespaces(
+			$this->namespaces
+		);
 
-		return $this->searchFallbackSearchEngine( $term, false );
+		return $this->extendedSearch->searchTitle( $term );
 	}
 
 	/**
 	 * @see SearchEngine::searchText
 	 *
-	 * Perform a full text search query and return a result set.
-	 * If title searches are not supported or disabled, return null.
-	 *
-	 * @param string $term Raw search term
-	 *
-	 * @return SearchResultSet|\Status|null
+	 * {@inheritDoc}
 	 */
 	public function searchText( $term ) {
 
-		if ( $this->getSearchQuery( $term ) !== null ) {
-			return $this->newSearchResultSet( $term );
-		}
+		$this->extendedSearch->setNamespaces(
+			$this->namespaces
+		);
 
-		return $this->searchFallbackSearchEngine( $term, true );
+		return $this->extendedSearch->searchText( $term );
 	}
 
 	/**
 	 * @see SearchEngine::supports
 	 *
-	 * @param string $feature
-	 *
-	 * @return bool
+	 * {@inheritDoc}
 	 */
 	public function supports( $feature ) {
-		return $this->getFallbackSearchEngine()->supports( $feature );
+		return $this->fallbackSearchEngine->supports( $feature );
 	}
 
 	/**
 	 * @see SearchEngine::normalizeText
 	 *
-	 * May performs database-specific conversions on text to be used for
-	 * searching or updating search index.
-	 *
-	 * @param string $string String to process
-	 *
-	 * @return string
+	 * {@inheritDoc}
 	 */
 	public function normalizeText( $string ) {
-		return $this->getFallbackSearchEngine()->normalizeText( $string );
+		return $this->fallbackSearchEngine->normalizeText( $string );
 	}
 
 	/**
 	 * @see SearchEngine::getTextFromContent
+	 *
+	 * {@inheritDoc}
 	 */
 	public function getTextFromContent( Title $t, Content $c = null ) {
-		return $this->getFallbackSearchEngine()->getTextFromContent( $t, $c );
+		return $this->fallbackSearchEngine->getTextFromContent( $t, $c );
 	}
 
 	/**
 	 * @see SearchEngine::textAlreadyUpdatedForIndex
+	 *
+	 * {@inheritDoc}
 	 */
 	public function textAlreadyUpdatedForIndex() {
-		return $this->getFallbackSearchEngine()->textAlreadyUpdatedForIndex();
+		return $this->fallbackSearchEngine->textAlreadyUpdatedForIndex();
 	}
 
 	/**
 	 * @see SearchEngine::update
 	 *
-	 * Create or update the search index record for the given page.
-	 * Title and text should be pre-processed.
-	 *
-	 * @param int    $id
-	 * @param string $title
-	 * @param string $text
+	 * {@inheritDoc}
 	 */
 	public function update( $id, $title, $text ) {
-		$this->getFallbackSearchEngine()->update( $id, $title, $text );
+		$this->fallbackSearchEngine->update( $id, $title, $text );
 	}
 
 	/**
 	 * @see SearchEngine::updateTitle
 	 *
-	 * Update a search index record's title only.
-	 * Title should be pre-processed.
-	 *
-	 * @param int    $id
-	 * @param string $title
+	 * {@inheritDoc}
 	 */
 	public function updateTitle( $id, $title ) {
-		$this->getFallbackSearchEngine()->updateTitle( $id, $title );
+		$this->fallbackSearchEngine->updateTitle( $id, $title );
 	}
 
 	/**
 	 * @see SearchEngine::delete
 	 *
-	 * Delete an indexed page
-	 * Title should be pre-processed.
-	 *
-	 * @param int    $id    Page id that was deleted
-	 * @param string $title Title of page that was deleted
+	 * {@inheritDoc}
 	 */
 	public function delete( $id, $title ) {
-		$this->getFallbackSearchEngine()->delete( $id, $title );
+		$this->fallbackSearchEngine->delete( $id, $title );
 	}
 
 	/**
 	 * @see SearchEngine::setFeatureData
+	 *
+	 * {@inheritDoc}
 	 */
 	public function setFeatureData( $feature, $data ) {
 		parent::setFeatureData( $feature, $data );
-		$this->getFallbackSearchEngine()->setFeatureData( $feature, $data );
+		$this->fallbackSearchEngine->setFeatureData( $feature, $data );
 	}
 
 	/**
@@ -226,11 +207,7 @@ class ExtendedSearchEngine extends SearchEngine {
 	/**
 	 * @see SearchEngine::replacePrefixes
 	 *
-	 * SMW queries do not have prefixes. Returns query as is.
-	 *
-	 * @param string $query
-	 *
-	 * @return string
+	 * {@inheritDoc}
 	 */
 	public function replacePrefixes( $query ) {
 		return $query;
@@ -239,9 +216,7 @@ class ExtendedSearchEngine extends SearchEngine {
 	/**
 	 * @see SearchEngine::transformSearchTerm
 	 *
-	 * No Transformation needed. Returns term as is.
-	 * @param $term
-	 * @return mixed
+	 * {@inheritDoc}
 	 */
 	public function transformSearchTerm( $term ) {
 		return $term;
@@ -249,84 +224,57 @@ class ExtendedSearchEngine extends SearchEngine {
 
 	/**
 	 * @see SearchEngine::setLimitOffset
+	 *
+	 * {@inheritDoc}
 	 */
 	public function setLimitOffset( $limit, $offset = 0 ) {
 		parent::setLimitOffset( $limit, $offset );
-		$this->getFallbackSearchEngine()->setLimitOffset( $limit, $offset );
+		$this->extendedSearch->setLimitOffset( $limit, $offset );
+		$this->fallbackSearchEngine->setLimitOffset( $limit, $offset );
 	}
 
 	/**
 	 * @see SearchEngine::setNamespaces
+	 *
+	 * {@inheritDoc}
 	 */
 	public function setNamespaces( $namespaces ) {
 		parent::setNamespaces( $namespaces );
-		$this->getFallbackSearchEngine()->setNamespaces( $namespaces );
+
+		$this->extendedSearch->setNamespaces(
+			$this->namespaces
+		);
+
+		$this->fallbackSearchEngine->setNamespaces( $namespaces );
 	}
 
 	/**
 	 * @see SearchEngine::setShowSuggestion
+	 *
+	 * {@inheritDoc}
 	 */
 	public function setShowSuggestion( $showSuggestion ) {
 		parent::setShowSuggestion( $showSuggestion );
-		$this->getFallbackSearchEngine()->setShowSuggestion( $showSuggestion );
+		$this->fallbackSearchEngine->setShowSuggestion( $showSuggestion );
 	}
 
 	/**
 	 * @see SearchEngine::completionSearchBackend
 	 *
-	 * Perform a completion search.
-	 *
-	 * @param string $search
-	 *
-	 * @return SearchSuggestionSet
+	 * {@inheritDoc}
 	 */
 	protected function completionSearchBackend( $search ) {
 
-		$searchResultSet = null;
+		$this->extendedSearch->setNamespaces(
+			$this->namespaces
+		);
 
 		// Avoid MW's auto formatting of title entities
 		if ( $search !== '' ) {
 			$search{0} = strtolower( $search{0} );
 		}
 
-		$searchEngine = $this->getFallbackSearchEngine();
-
-		if ( !$this->hasPrefixAndMinLenForCompletionSearch( $search, 3 ) ) {
-			return $searchEngine->completionSearch( $search );
-		}
-
-		if ( $this->getSearchQuery( $search ) !== null ) {
-			$searchResultSet = $this->newSearchResultSet( $search, false, false );
-		}
-
-		if ( $searchResultSet instanceof SearchResultSet ) {
-			return $searchResultSet->newSearchSuggestionSet();
-		}
-
-		return $searchEngine->completionSearch( $search );
-	}
-
-	/**
-	 * @since 2.1
-	 *
-	 * @param null|SearchEngine $fallbackSearch
-	 */
-	public function setFallbackSearchEngine( SearchEngine $fallbackSearch = null ) {
-		$this->fallbackSearch = $fallbackSearch;
-	}
-
-	/**
-	 * @since 2.1
-	 *
-	 * @return SearchEngine
-	 */
-	public function getFallbackSearchEngine() {
-
-		if ( $this->fallbackSearch === null ) {
-			$this->fallbackSearch = $this->newFallbackSearchEngine();
-		}
-
-		return $this->fallbackSearch;
+		return $this->extendedSearch->completionSearch( $search );
 	}
 
 	/**
@@ -335,7 +283,7 @@ class ExtendedSearchEngine extends SearchEngine {
 	 * @return []
 	 */
 	public function getErrors() {
-		return $this->errors;
+		return $this->extendedSearch->getErrors();
 	}
 
 	/**
@@ -344,7 +292,7 @@ class ExtendedSearchEngine extends SearchEngine {
 	 * @return string
 	 */
 	public function getQueryString() {
-		return $this->queryString;
+		return $this->extendedSearch->getQueryString();
 	}
 
 	/**
@@ -353,7 +301,7 @@ class ExtendedSearchEngine extends SearchEngine {
 	 * @return string
 	 */
 	public function getQueryLink() {
-		return $this->queryLink;
+		return $this->extendedSearch->getQueryLink();
 	}
 
 	/**
@@ -364,13 +312,6 @@ class ExtendedSearchEngine extends SearchEngine {
 	}
 
 	/**
-	 * @return boolean
-	 */
-	public function getShowSuggestion() {
-		return $this->showSuggestion;
-	}
-
-	/**
 	 * @return int
 	 */
 	public function getOffset() {
@@ -378,174 +319,10 @@ class ExtendedSearchEngine extends SearchEngine {
 	}
 
 	/**
-	 * @param DatabaseBase $connection
+	 * @return boolean
 	 */
-	public function setDB( DatabaseBase $connection ) {
-		$this->connection = $connection;
-		$this->fallbackSearch = null;
-	}
-
-	/**
-	 * @return \IDatabase
-	 */
-	public function getDB() {
-
-		if ( $this->connection !== null ) {
-			return $this->connection;
-		}
-
-		$loadBalancer = ApplicationFactory::getInstance()->getLoadBalancer();
-
-		$this->connection = $loadBalancer->getConnection(
-			defined( 'DB_REPLICA' ) ? DB_REPLICA : DB_SLAVE
-		);
-
-		return $this->connection;
-	}
-
-	private function hasPrefixAndMinLenForCompletionSearch( $term, $minLen ) {
-
-		// Only act on when `in:foo`, `has:SomeProperty`, or `phrase:some text`
-		// is actively used as prefix
-
-		if ( strpos( $term, 'in:' ) !== false && mb_strlen( $term ) >= ( 3 + $minLen ) ) {
-			return true;
-		}
-
-		if ( strpos( $term, 'has:' ) !== false && mb_strlen( $term ) >= ( 4 + $minLen ) ) {
-			return true;
-		}
-
-		if ( strpos( $term, 'phrase:' ) !== false && mb_strlen( $term ) >= ( 7 + $minLen ) ) {
-			return true;
-		}
-
-		return false;
-	}
-
-	private function newSearchResultSet( $term, $count = true, $highlight = true ) {
-
-		$query = $this->getSearchQuery( $term );
-
-		if ( $query === null ) {
-			return null;
-		}
-
-		$query->setOffset( $this->offset );
-		$query->setLimit( $this->limit, false );
-		$this->queryString = $query->getQueryString();
-
-		$store = ApplicationFactory::getInstance()->getStore();
-		$query->clearErrors();
-		$query->setOption( 'highlight.fragment', $highlight );
-		$query->setOption( SMWQuery::PROC_CONTEXT, 'SpecialSearch' );
-
-		$result = $store->getQueryResult( $query );
-		$this->errors = $query->getErrors();
-		$this->queryLink = $result->getQueryLink();
-		$this->queryLink->setParameter( $this->offset, 'offset' );
-		$this->queryLink->setParameter( $this->limit, 'limit' );
-
-		if ( $count ) {
-			$query->querymode = SMWQuery::MODE_COUNT;
-			$query->setOffset( 0 );
-
-			$queryResult = $store->getQueryResult( $query );
-			$count = $queryResult instanceof QueryResult ? $queryResult->getCountValue() : $queryResult;
-		} else {
-			$count = 0;
-		}
-
-		return new SearchResultSet( $result, $count );
-	}
-
-	/**
-	 * @param String $term
-	 *
-	 * @return SMWQuery | null
-	 */
-	private function getSearchQuery( $term ) {
-
-		if ( $this->queryBuilder === null ) {
-			$this->queryBuilder = new QueryBuilder();
-		}
-
-		$this->queryString = $this->queryBuilder->getQueryString(
-			ApplicationFactory::getInstance()->getStore(),
-			$term
-		);
-
-		$query = $this->queryBuilder->getQuery(
-			$this->queryString
-		);
-
-		$this->queryBuilder->addSort( $query );
-
-		$this->queryBuilder->addNamespaceCondition(
-			$query,
-			$this->searchableNamespaces()
-		);
-
-		return $query;
-	}
-
-	private function searchFallbackSearchEngine( $term, $fulltext ) {
-
-		$f = $this->getFallbackSearchEngine();
-		$f->prefix = $this->prefix;
-		$f->namespaces = $this->namespaces;
-
-		$term = $f->transformSearchTerm( $term );
-		$term = $f->replacePrefixes( $term );
-
-		return $fulltext ? $f->searchText( $term ) : $f->searchTitle( $term );
-	}
-
-	/**
-	 * @return SearchEngine
-	 */
-	private function newFallbackSearchEngine() {
-
-		$applicationFactory = ApplicationFactory::getInstance();
-		$type = $applicationFactory->getSettings()->get( 'smwgFallbackSearchType' );
-
-		$connection = $this->getDB();
-
-		if ( is_callable( $type ) ) {
-			// #3939
-			$fallbackSearch = $type( $connection );
-		} elseif ( $type !== null && $this->isValidFallbackSearchEngineDatabaseType( $type ) ) {
-			$fallbackSearch = new $type( $connection );
-		} else {
-			$type = $applicationFactory->create( 'DefaultSearchEngineTypeForDB', $connection );
-			$fallbackSearch = new $type( $connection );
-		}
-
-		if ( !$fallbackSearch instanceof SearchEngine ) {
-			throw new SearchEngineInvalidTypeException( "The fallback is not a valid search engine type." );
-		}
-
-		return $fallbackSearch;
-	}
-
-	/**
-	 * @param $type
-	 */
-	private function isValidFallbackSearchEngineDatabaseType( $type ) {
-
-		if ( !class_exists( $type ) ) {
-			throw new ClassNotFoundException( "$type does not exist." );
-		}
-
-		if ( $type === 'SMWSearch' ) {
-			throw new SearchEngineInvalidTypeException( 'SMWSearch is not a valid fallback search engine type.' );
-		}
-
-		if ( $type !== 'SearchEngine' && !is_subclass_of( $type, 'SearchDatabase' ) ) {
-			throw new SearchDatabaseInvalidTypeException( $type );
-		}
-
-		return true;
+	public function getShowSuggestion() {
+		return $this->showSuggestion;
 	}
 
 }

--- a/src/MediaWiki/Search/README.md
+++ b/src/MediaWiki/Search/README.md
@@ -1,5 +1,3 @@
-# SMWSearch
-
 [SMWSearch](https://www.semantic-mediawiki.org/wiki/Help:SMWSearch) is the `SearchEngine` interface to provide classes and functions to integrate Semantic MediaWiki with `Special:Search`.
 
 It adds support for using `#ask` queries in the `Special:Search` context and provides an extended search profile where user defined forms can empower users to find and match entities using property and value input fields.
@@ -7,8 +5,6 @@ It adds support for using `#ask` queries in the `Special:Search` context and pro
 ## Extended search profile
 
 In cases where the systems detects forms maintained using the `SEARCH_FORM_SCHEMA`, an extended profile will be visible on the `Special:Search` page allowing users to match and search subjects with help of Semantic MediaWiki.
-
-Details on how to create and maintain forms can be found in the [search.form.md](https://github.com/SemanticMediaWiki/SemanticMediaWiki/blob/master/src/Schema/docs/search.form.md) document.
 
 ### Example
 
@@ -22,9 +18,11 @@ Classes that provide an interface to support MW's `SearchEngine` by transforming
 SMW\MediaWiki\Search
    │
    ├─ QueryBuilder
-   ├─ Search           # Implements the `SearchEngine`
-   ├─ SearchResult     # Individual result representation
-   └─ SearchResultSet  # Contains a set of results return from the `QueryEngine`
+   ├─ SearchEngineFactory
+   ├─ ExtendedSearchEngine     # Implements the `SearchEngine`
+   │     └─ ExtendedSearch
+   ├─ SearchResult             # Individual result representation
+   └─ SearchResultSet          # Contains a set of results return from the `QueryEngine`
 </pre>
 
 Classes that provide an additional search form to support structured searches in `Special:Search` with the help of the [`SpecialSearchProfileForm`](https://www.mediawiki.org/wiki/Manual:Hooks/SpecialSearchProfileForm) hook.
@@ -35,3 +33,7 @@ SMW\MediaWiki\Search\ProfileForm
    └─ ProfileForm      # Interface to the `SpecialSearchProfileForm` hook
          └─ Forms      # Classes to generate a HTML from a JSON definition
 </pre>
+
+## See also
+
+- [`search.form.md`](https://github.com/SemanticMediaWiki/SemanticMediaWiki/blob/master/src/Schema/docs/search.form.md) describes the `SEARCH_FORM_SCHEMA` schema to define forms to be used in the extended `Special:Search` profile

--- a/src/MediaWiki/Search/SearchEngineFactory.php
+++ b/src/MediaWiki/Search/SearchEngineFactory.php
@@ -1,0 +1,101 @@
+<?php
+
+namespace SMW\MediaWiki\Search;
+
+use DatabaseBase;
+use RuntimeException;
+use SearchEngine;
+use SMW\ApplicationFactory;
+use SMW\MediaWiki\Search\Exception\SearchDatabaseInvalidTypeException;
+use SMW\MediaWiki\Search\Exception\SearchEngineInvalidTypeException;
+use SMW\Exception\ClassNotFoundException;
+
+/**
+ * @license GNU GPL v2+
+ * @since   3.1
+ *
+ * @author  mwjames
+ */
+class SearchEngineFactory {
+
+	/**
+	 * @since 3.1
+	 *
+	 * @param \DatabaseBase $connection
+	 *
+	 * @return SearchEngine
+	 * @throws SearchEngineInvalidTypeException
+	 */
+	public function newFallbackSearchEngine( DatabaseBase $connection = null ) {
+
+		$applicationFactory = ApplicationFactory::getInstance();
+		$settings = $applicationFactory->getSettings();
+
+		if ( $connection === null ) {
+			$connection = $applicationFactory->getConnectionManager()->getConnection( DB_SLAVE );
+		}
+
+		$type = $settings->get( 'smwgFallbackSearchType' );
+		$defaultSearchEngine = $applicationFactory->create( 'DefaultSearchEngineTypeForDB', $connection );
+
+		if ( is_callable( $type ) ) {
+			// #3939
+			$fallbackSearchEngine = $type( $connection );
+		} elseif ( $type !== null && $this->isValidSearchDatabaseType( $type ) ) {
+			$fallbackSearchEngine = new $type( $connection );
+		} else {
+			$fallbackSearchEngine = new $defaultSearchEngine( $connection );
+		}
+
+		if ( !$fallbackSearchEngine instanceof SearchEngine ) {
+			throw new SearchEngineInvalidTypeException( "The fallback is not a valid search engine type." );
+		}
+
+		return $fallbackSearchEngine;
+	}
+
+	/**
+	 * @since 3.1
+	 *
+	 * @param SearchEngine $fallbackSearchEngine
+	 *
+	 * @return ExtendedSearch
+	 */
+	public function newExtendedSearch( \SearchEngine $fallbackSearchEngine ) {
+
+		$applicationFactory = ApplicationFactory::getInstance();
+		$searchEngineConfig = $applicationFactory->create( 'SearchEngineConfig' );
+
+		$extendedSearch = new ExtendedSearch(
+			$applicationFactory->getStore(),
+			$fallbackSearchEngine
+		);
+
+		$extendedSearch->setSearchableNamespaces(
+			$searchEngineConfig->searchableNamespaces()
+		);
+
+		return $extendedSearch;
+	}
+
+	/**
+	 * @param $type
+	 */
+	private function isValidSearchDatabaseType( $type ) {
+
+		if ( !class_exists( $type ) ) {
+			throw new ClassNotFoundException( "$type does not exist." );
+		}
+
+		if ( $type === 'SMWSearch' ) {
+			throw new SearchEngineInvalidTypeException( 'SMWSearch is not a valid fallback search engine type.' );
+		}
+
+		if ( $type !== 'SearchEngine' && !is_subclass_of( $type, 'SearchDatabase' ) ) {
+			throw new SearchDatabaseInvalidTypeException( $type );
+		}
+
+		return true;
+	}
+
+}

--- a/tests/phpunit/Unit/MediaWiki/Search/ExtendedSearchTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Search/ExtendedSearchTest.php
@@ -1,0 +1,304 @@
+<?php
+
+namespace SMW\Tests\MediaWiki\Search;
+
+use SMW\MediaWiki\Search\ExtendedSearch;
+use SMW\Tests\TestEnvironment;
+use SMWQuery;
+
+/**
+ * @covers \SMW\MediaWiki\Search\ExtendedSearch
+ * @group semantic-mediawiki
+ *
+ * @license GNU GPL v2+
+ * @since 2.1
+ *
+ * @author Stephan Gambke
+ */
+class ExtendedSearchTest extends \PHPUnit_Framework_TestCase {
+
+	private $testEnvironment;
+	private $store;
+	private $fallbackSearchEngine;
+
+	protected function setUp() {
+		$this->testEnvironment = new TestEnvironment();
+
+		$this->store = $this->getMockBuilder( 'SMW\Store' )
+			->disableOriginalConstructor()
+			->getMockForAbstractClass();
+
+		$this->fallbackSearchEngine = $this->getMockBuilder( 'SearchEngine' )
+			->disableOriginalConstructor()
+			->getMock();
+	}
+
+	protected function tearDown() {
+		$this->testEnvironment->tearDown();
+		parent::tearDown();
+	}
+
+	public function testCanConstruct() {
+
+		$this->assertInstanceOf(
+			ExtendedSearch::class,
+			new ExtendedSearch( $this->store, $this->fallbackSearchEngine )
+		);
+	}
+
+	public function testSearchTitle_withNonsemanticQuery() {
+
+		$term = 'Some string that can not be interpreted as a semantic query';
+
+		$searchResultSet = $this->getMockBuilder( 'SearchResultSet' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$this->fallbackSearchEngine->expects( $this->once() )
+			->method( 'transformSearchTerm' )
+			->will( $this->returnArgument( 0 ) );
+
+		$this->fallbackSearchEngine->expects( $this->once() )
+			->method( 'replacePrefixes' )
+			->will( $this->returnArgument( 0 ) );
+
+		$this->fallbackSearchEngine->expects( $this->once() )
+			->method( 'searchTitle')
+			->will( $this->returnValueMap( [ [ $term, $searchResultSet ] ] ) );
+
+		$this->store->expects( $this->any() )
+			->method( 'getPropertySubjects' )
+			->will( $this->returnValue( [] ) );
+
+		$instance = new ExtendedSearch(
+			$this->store,
+			$this->fallbackSearchEngine
+		);
+
+		$this->assertEquals(
+			$searchResultSet,
+			$instance->searchTitle( $term )
+		);
+	}
+
+	public function testSearchTitle_withEmptyQuery() {
+
+		$term = '   ';
+
+		$searchResultSet = $this->getMockBuilder( 'SearchResultSet' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$this->fallbackSearchEngine->expects( $this->once() )
+			->method( 'transformSearchTerm' )
+			->will( $this->returnArgument( 0 ) );
+
+		$this->fallbackSearchEngine->expects( $this->once() )
+			->method( 'replacePrefixes' )
+			->will( $this->returnArgument( 0 ) );
+
+		$this->fallbackSearchEngine->expects( $this->once() )
+			->method( 'searchTitle')
+			->will( $this->returnValueMap( [ [ $term, $searchResultSet ] ] ) );
+
+		$this->store->expects( $this->any() )
+			->method( 'getPropertySubjects' )
+			->will( $this->returnValue( [] ) );
+
+		$instance = new ExtendedSearch(
+			$this->store,
+			$this->fallbackSearchEngine
+		);
+
+		$this->assertEquals(
+			$searchResultSet,
+			$instance->searchTitle( $term )
+		);
+	}
+
+	public function testSearchText_withSemanticQuery() {
+
+		$term = '[[Some string that can be interpreted as a semantic query]]';
+
+		$infoLink = $this->getMockBuilder( '\SMWInfolink' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$query = $this->getMockBuilder( '\SMWQuery' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$queryResult = $this->getMockBuilder( '\SMWQueryResult' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$queryResult->expects( $this->any() )
+			->method( 'getQuery' )
+			->will( $this->returnValue( $query ) );
+
+		$queryResult->expects( $this->any() )
+			->method( 'getQueryLink' )
+			->will( $this->returnValue( $infoLink ) );
+
+		$this->store->expects( $this->any() )
+			->method( 'getPropertySubjects' )
+			->will( $this->returnValue( [] ) );
+
+		$this->store->expects( $this->exactly( 2 ) )
+			->method( 'getQueryResult' )
+			->will( $this->returnCallback( function ( SMWQuery $query ) use ( $queryResult ) {
+				return $query->querymode === SMWQuery::MODE_COUNT ? 9001 : $queryResult;
+			} ) );
+
+		$instance = new ExtendedSearch(
+			$this->store,
+			$this->fallbackSearchEngine
+		);
+
+		$result = $instance->searchText( $term );
+
+		$this->assertInstanceOf(
+			'SMW\MediaWiki\Search\SearchResultSet',
+			$result
+		);
+
+		$this->assertEquals(
+			9001,
+			$result->getTotalHits()
+		);
+	}
+
+	public function testSearchText_withNonsemanticQuery() {
+
+		$term = 'Some string that can not be interpreted as a semantic query';
+
+		$searchResultSet = $this->getMockBuilder( 'SearchResultSet' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$this->fallbackSearchEngine->expects( $this->once() )
+			->method( 'transformSearchTerm' )
+			->will( $this->returnArgument( 0 ) );
+
+		$this->fallbackSearchEngine->expects( $this->once() )
+			->method( 'replacePrefixes' )
+			->will( $this->returnArgument( 0 ) );
+
+		$this->fallbackSearchEngine->expects( $this->once() )
+			->method( 'searchText')
+			->will( $this->returnValueMap( [ [ $term, $searchResultSet ] ] ) );
+
+		$instance = new ExtendedSearch(
+			$this->store,
+			$this->fallbackSearchEngine
+		);
+
+		$this->assertEquals(
+			$searchResultSet,
+			$instance->searchText( $term )
+		);
+	}
+
+	public function testSearchTitle_withSemanticQuery() {
+
+		$term = '[[Some string that can be interpreted as a semantic query]]';
+
+		$instance = new ExtendedSearch(
+			$this->store,
+			$this->fallbackSearchEngine
+		);
+
+		$this->assertNull(
+			$instance->searchTitle( $term )
+		);
+	}
+
+	public function testCompletionSearch_OnEligiblePrefix() {
+
+		$infoLink = $this->getMockBuilder( '\SMWInfolink' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$query = $this->getMockBuilder( '\SMWQuery' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$queryBuilder = $this->getMockBuilder( '\SMW\MediaWiki\Search\QueryBuilder' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$queryBuilder->expects( $this->any() )
+			->method( 'getQuery')
+			->will( $this->returnValue( $query ) );
+
+		$queryResult = $this->getMockBuilder( '\SMWQueryResult' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$queryResult->expects( $this->any() )
+			->method( 'getQuery' )
+			->will( $this->returnValue( $query ) );
+
+		$queryResult->expects( $this->any() )
+			->method( 'getResults' )
+			->will( $this->returnValue( [] ) );
+
+		$queryResult->expects( $this->any() )
+			->method( 'getQueryLink' )
+			->will( $this->returnValue( $infoLink ) );
+
+		$this->store->expects( $this->any() )
+			->method( 'getQueryResult' )
+			->will( $this->returnCallback( function ( SMWQuery $query ) use ( $queryResult ) {
+				return $query->querymode === \SMWQuery::MODE_COUNT ? 9001 : $queryResult;
+			} ) );
+
+		$instance = new ExtendedSearch(
+			$this->store,
+			$this->fallbackSearchEngine
+		);
+
+		$instance->setQueryBuilder(
+			$queryBuilder
+		);
+
+		$this->assertInstanceof(
+			'\SearchSuggestionSet',
+			$instance->completionSearch( 'in:Foo' )
+		);
+	}
+
+	public function tesCompletionSearch_NoRelevantPrefix() {
+
+		$searchSuggestionSet = $this->getMockBuilder( '\SearchSuggestionSet' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$searchSuggestionSet->expects( $this->any() )
+			->method( 'map')
+			->will( $this->returnValue( [] ) );
+
+		$fallbackSearchEngine = $this->getMockBuilder( 'SearchEngine' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$fallbackSearchEngine->expects( $this->once() )
+			->method( 'setShowSuggestion')
+			->with( $this->equalTo( true ) );
+
+		$fallbackSearchEngine->expects( $this->once() )
+			->method( 'completionSearch' )
+			->will( $this->returnValue( $searchSuggestionSet ) );
+
+		$instance = new ExtendedSearch(
+			$this->store,
+			$fallbackSearchEngine
+		);
+
+		$this->assertInstanceof(
+			'\SearchSuggestionSet',
+			$instance->completionSearch( 'Foo' )
+		);
+	}
+
+}

--- a/tests/phpunit/Unit/MediaWiki/Search/SearchEngineFactoryTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Search/SearchEngineFactoryTest.php
@@ -1,0 +1,169 @@
+<?php
+
+namespace SMW\Tests\MediaWiki\Search;
+
+use SMW\MediaWiki\Search\SearchEngineFactory;
+use SMW\Tests\TestEnvironment;
+use SMW\Tests\PHPUnitCompat;
+use SMWQuery;
+
+/**
+ * @covers \SMW\MediaWiki\Search\SearchEngineFactory
+ * @group semantic-mediawiki
+ *
+ * @license GNU GPL v2+
+ * @since 3.1
+ *
+ * @author Stephan Gambke
+ */
+class SearchEngineFactoryTest extends \PHPUnit_Framework_TestCase {
+
+	use PHPUnitCompat;
+
+	private $testEnvironment;
+	private $connection;
+
+	protected function setUp() {
+		$this->testEnvironment = new TestEnvironment();
+
+		$this->connection = $this->getMockBuilder( 'DatabaseBase' )
+			->disableOriginalConstructor()
+			->getMockForAbstractClass();
+	}
+
+	protected function tearDown() {
+		$this->testEnvironment->tearDown();
+		parent::tearDown();
+	}
+
+	public function testCanConstruct() {
+
+		$this->assertInstanceOf(
+			SearchEngineFactory::class,
+			new SearchEngineFactory()
+		);
+	}
+
+	public function testGetFallbackSearchEngine_ConstructFromCallable() {
+
+		$searchEngine = $this->getMockBuilder( 'SearchEngine' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$searchEngineFactory = new SearchEngineFactory();
+
+		$this->assertInstanceOf(
+			'\SMW\MediaWiki\Search\ExtendedSearch',
+			$searchEngineFactory->newExtendedSearch( $searchEngine )
+		);
+	}
+
+	public function testNewDefaultFallbackSearchEngineForNullFallbackSearchType() {
+
+		$searchEngine = 'SearchDatabase';
+
+		if ( class_exists( 'SearchEngine' ) ) {
+
+			$reflection = new \ReflectionClass( 'SearchEngine' );
+
+			if ( $reflection->isInstantiable() ) {
+				$searchEngine = 'SearchEngine';
+			}
+		}
+
+		$connection = $this->getMockBuilder( '\DatabaseBase' )
+			->disableOriginalConstructor()
+			->setMethods( [ 'getSearchEngine' ] )
+			->getMockForAbstractClass();
+
+		$connection->expects( $this->any() )
+			->method( 'getSearchEngine' )
+			->will( $this->returnValue( $searchEngine ) );
+
+		$this->testEnvironment->addConfiguration( 'smwgFallbackSearchType', null );
+
+		$searchEngineFactory = new SearchEngineFactory();
+
+		$this->assertInstanceOf(
+			'SearchEngine',
+			$searchEngineFactory->newFallbackSearchEngine( $connection )
+		);
+	}
+
+	public function testInvalidFallbackSearchEngineThrowsException() {
+
+		$this->testEnvironment->addConfiguration( 'smwgFallbackSearchType', 'InvalidFallbackSearchEngine' );
+
+		$searchEngineFactory = new SearchEngineFactory();
+
+		$this->setExpectedException( 'RuntimeException' );
+		$searchEngineFactory->newFallbackSearchEngine( $this->connection );
+	}
+
+	public function testNewFallbackSearchEngine_ConstructFromCallable() {
+
+		$fallbackSearchEngine = $this->getMockBuilder( 'SearchEngine' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$callback = function() use( $fallbackSearchEngine ) {
+			return $fallbackSearchEngine;
+		};
+
+		$this->testEnvironment->addConfiguration( 'smwgFallbackSearchType', $callback );
+
+		$searchEngineFactory = new SearchEngineFactory();
+
+		$this->assertEquals(
+			$fallbackSearchEngine,
+			$searchEngineFactory->newFallbackSearchEngine( $this->connection )
+		);
+	}
+
+	public function testNewFallbackSearchEngine_ConstructFromInvalidCallableThrowsException() {
+
+		$callback = function() {
+			return new \stdClass;
+		};
+
+		$this->testEnvironment->addConfiguration( 'smwgFallbackSearchType', $callback );
+
+		$searchEngineFactory = new SearchEngineFactory();
+
+		$this->setExpectedException( '\SMW\MediaWiki\Search\Exception\SearchEngineInvalidTypeException' );
+		$searchEngineFactory->newFallbackSearchEngine( $this->connection );
+	}
+
+	public function testNewFallbackSearchEngine_ConstructFromString() {
+
+		$this->testEnvironment->addConfiguration( 'smwgFallbackSearchType', '\SMW\Tests\Fixtures\MediaWiki\Search\DummySearchDatabase' );
+
+		$searchEngineFactory = new SearchEngineFactory();
+
+		$this->assertInstanceOf(
+			'\SearchDatabase',
+			$searchEngineFactory->newFallbackSearchEngine( $this->connection )
+		);
+	}
+
+	public function testNewFallbackSearchEngine_ConstructFromStringNonSearchDatabaseThrowsException() {
+
+		$this->testEnvironment->addConfiguration( 'smwgFallbackSearchType', '\SMW\Tests\Fixtures\MediaWiki\Search\DummySearchEngine' );
+
+		$searchEngineFactory = new SearchEngineFactory();
+
+		$this->setExpectedException( '\SMW\MediaWiki\Search\Exception\SearchDatabaseInvalidTypeException' );
+		$searchEngineFactory->newFallbackSearchEngine( $this->connection );
+	}
+
+	public function testNewFallbackSearchEngine_ConstructFromStringInvalidClassThrowsException() {
+
+		$this->testEnvironment->addConfiguration( 'smwgFallbackSearchType', 'ClassDoesntExist' );
+
+		$searchEngineFactory = new SearchEngineFactory();
+
+		$this->setExpectedException( '\SMW\Exception\ClassNotFoundException' );
+		$searchEngineFactory->newFallbackSearchEngine( $this->connection );
+	}
+
+}


### PR DESCRIPTION
This PR is made in reference to: #3992, #3993, #3801

This PR addresses or contains:

- The changes to the `SearchEngine` interface are disruptive (it may be the 3rd or 4th time the interface/tests broke) and not really helpful for extension developers, so to minimize any further disturbance the following changes are made:
  - Remove any SMW specific instance construction from `ExtendedSearchEngine` and delegate the work to the `SearchEngineFactory`
  - Isolate any SMW specific query building to a new component called `ExtendedSearch` (which is injected and has no `SearchEngine` dependency hereby avoids breakage in future), defines a loose dependency in `ExtendedSearchEngine`
  - As for #3992, inject the `SearchEngineConfig::searchableNamespaces` via the `SearchEngineFactory` into `ExtendedSearch` to avoid any direct dependency on `MediaWikiServices::getInstance()->getSearchEngineConfig()->searchableNamespaces`
  - `SearchEngineFactory` will construct the fallback search engine and provide a loose dependency to `ExtendedSearch` and `ExtendedSearchEngine`

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed

Fixes #3992