### PR TITLE
Add `NamespaceInfo` and isolate `MWNamespace` usage, refs 3801

### DIFF
--- a/src/Localizer.php
+++ b/src/Localizer.php
@@ -6,6 +6,7 @@ use DateTime;
 use Language;
 use SMW\Lang\Lang;
 use SMW\MediaWiki\LocalTime;
+use SMW\MediaWiki\NamespaceInfo;
 use Title;
 use User;
 
@@ -31,9 +32,11 @@ class Localizer {
 	 * @since 2.1
 	 *
 	 * @param Language $contentLanguage
+	 * @param NamespaceInfo $namespaceInfo
 	 */
-	public function __construct( Language $contentLanguage ) {
+	public function __construct( Language $contentLanguage, NamespaceInfo $namespaceInfo ) {
 		$this->contentLanguage = $contentLanguage;
+		$this->namespaceInfo = $namespaceInfo;
 	}
 
 	/**
@@ -43,9 +46,14 @@ class Localizer {
 	 */
 	public static function getInstance() {
 
-		if ( self::$instance === null ) {
-			self::$instance = new self( $GLOBALS['wgContLang'] );
+		if ( self::$instance !== null ) {
+			return self::$instance;
 		}
+
+		self::$instance = new self(
+			$GLOBALS['wgContLang'],
+			ApplicationFactory::getInstance()->singleton( 'NamespaceInfo' )
+		);
 
 		return self::$instance;
 	}
@@ -226,7 +234,7 @@ class Localizer {
 			return $canonicalNames[$index];
 		}
 
-		return \MWNamespace::getCanonicalName( $index );
+		return $this->namespaceInfo->getCanonicalName( $index );
 	}
 
 	/**

--- a/src/MediaWiki/Hooks.php
+++ b/src/MediaWiki/Hooks.php
@@ -819,7 +819,16 @@ class Hooks {
 	 */
 	public function onResourceLoaderGetConfigVars( &$vars ) {
 
-		$resourceLoaderGetConfigVars = new ResourceLoaderGetConfigVars();
+		$applicationFactory = ApplicationFactory::getInstance();
+		$settings = ApplicationFactory::getInstance()->getSettings();
+
+		$resourceLoaderGetConfigVars = new ResourceLoaderGetConfigVars(
+			$applicationFactory->singleton( 'NamespaceInfo' )
+		);
+
+		$resourceLoaderGetConfigVars->setOptions(
+			$settings->filter( ResourceLoaderGetConfigVars::OPTION_KEYS )
+		);
 
 		return $resourceLoaderGetConfigVars->process( $vars );
 	}

--- a/src/MediaWiki/Hooks/HookHandler.php
+++ b/src/MediaWiki/Hooks/HookHandler.php
@@ -38,6 +38,21 @@ class HookHandler {
 	}
 
 	/**
+	 * @since 3.1
+	 *
+	 * @param string $key
+	 * @param mixed $value
+	 */
+	public function setOption( $key, $value ) {
+
+		if ( $this->options === null ) {
+			$this->setOptions( [] );
+		}
+
+		$this->options->set( $key, $value );
+	}
+
+	/**
 	 * @since 3.0
 	 *
 	 * @param string $key

--- a/src/MediaWiki/Hooks/ResourceLoaderGetConfigVars.php
+++ b/src/MediaWiki/Hooks/ResourceLoaderGetConfigVars.php
@@ -2,8 +2,8 @@
 
 namespace SMW\MediaWiki\Hooks;
 
-use MWNamespace;
 use SMW\Localizer;
+use SMW\MediaWiki\NamespaceInfo;
 
 /**
  * Hook: ResourceLoaderGetConfigVars called right before
@@ -20,6 +20,27 @@ use SMW\Localizer;
  */
 class ResourceLoaderGetConfigVars extends HookHandler {
 
+	const OPTION_KEYS = [
+		'smwgQMaxLimit',
+		'smwgQMaxInlineLimit',
+		'smwgNamespacesWithSemanticLinks',
+		'smwgResultFormats'
+	];
+
+	/**
+	 * @var NamespaceInfo
+	 */
+	private $namespaceInfo;
+
+	/**
+	 * @since 3.1
+	 *
+	 * @param NamespaceInfo $namespaceInfo
+	 */
+	public function __construct( NamespaceInfo $namespaceInfo ) {
+		$this->namespaceInfo = $namespaceInfo;
+	}
+
 	/**
 	 * @since 1.9
 	 *
@@ -33,22 +54,22 @@ class ResourceLoaderGetConfigVars extends HookHandler {
 			'version' => SMW_VERSION,
 			'namespaces' => [],
 			'settings' => [
-				'smwgQMaxLimit' => $GLOBALS['smwgQMaxLimit'],
-				'smwgQMaxInlineLimit' => $GLOBALS['smwgQMaxInlineLimit'],
+				'smwgQMaxLimit' => $this->getOption( 'smwgQMaxLimit' ),
+				'smwgQMaxInlineLimit' => $this->getOption( 'smwgQMaxInlineLimit' ),
 			]
 		];
 
 		$localizer = Localizer::getInstance();
 
 		// Available semantic namespaces
-		foreach ( array_keys( $GLOBALS['smwgNamespacesWithSemanticLinks'] ) as $ns ) {
-			$name = MWNamespace::getCanonicalName( $ns );
+		foreach ( array_keys( $this->getOption( 'smwgNamespacesWithSemanticLinks' ) ) as $ns ) {
+			$name = $this->namespaceInfo->getCanonicalName( $ns );
 			$vars['smw-config']['settings']['namespace'][$name] = $ns;
 			$vars['smw-config']['namespaces']['canonicalName'][$ns] = $name;
 			$vars['smw-config']['namespaces']['localizedName'][$ns] = $localizer->getNamespaceTextById( $ns );
 		}
 
-		foreach ( array_keys( $GLOBALS['smwgResultFormats'] ) as $format ) {
+		foreach ( array_keys( $this->getOption( 'smwgResultFormats' ) ) as $format ) {
 			$vars['smw-config']['formats'][$format] = htmlspecialchars( $format );
 		}
 

--- a/src/MediaWiki/NamespaceInfo.php
+++ b/src/MediaWiki/NamespaceInfo.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace SMW\MediaWiki;
+
+use MWNamespace;
+
+/**
+ * @license GNU GPL v2+
+ * @since   3.1
+ *
+ * @author mwjames
+ */
+class NamespaceInfo {
+
+	/**
+	 * @var
+	 */
+	private $nsInfo;
+
+	/**
+	 * @since 3.1
+	 *
+	 * @param NamespaceInfo|null $nsInfo
+	 */
+	public function __construct( $nsInfo = null ) {
+		$this->nsInfo = $nsInfo;
+	}
+
+	/**
+	 * @since 3.1
+	 *
+	 * @param integer $index
+	 *
+	 * @return string
+	 */
+	public function getCanonicalName( $index ) {
+
+		if ( $this->nsInfo === null ) {
+			return MWNamespace::getCanonicalName( $index );
+		}
+
+		return $this->nsInfo->getCanonicalName( $index );
+	}
+
+	/**
+	 * @since 3.1
+	 *
+	 * @return []
+	 */
+	public function getValidNamespaces() {
+
+		if ( $this->nsInfo === null ) {
+			return MWNamespace::getValidNamespaces();
+		}
+
+		return $this->nsInfo->getValidNamespaces();
+	}
+
+	/**
+	 * @since 3.1
+	 *
+	 * @param $index
+	 *
+	 * @return int
+	 */
+	public function getSubject( $index ) {
+
+		if ( $this->nsInfo === null ) {
+			return MWNamespace::getSubject( $index );
+		}
+
+		return $this->nsInfo->getSubject( $index );
+	}
+
+}

--- a/src/MediaWiki/Search/ProfileForm/Forms/NamespaceForm.php
+++ b/src/MediaWiki/Search/ProfileForm/Forms/NamespaceForm.php
@@ -3,7 +3,7 @@
 namespace SMW\MediaWiki\Search\ProfileForm\Forms;
 
 use Html;
-use MWNamespace;
+use SMW\MediaWiki\NamespaceInfo;
 use SMW\Message;
 use SpecialSearch;
 use Xml;
@@ -18,6 +18,11 @@ use Xml;
  * @author mwjames
  */
 class NamespaceForm {
+
+	/**
+	 * @var NamespaceInfo
+	 */
+	private $namespaceInfo;
 
 	/**
 	 * @var []
@@ -43,6 +48,15 @@ class NamespaceForm {
 	 * @var null|string
 	 */
 	private $hideList = false;
+
+	/**
+	 * @since 3.1
+	 *
+	 * @param NamespaceInfo $namespaceInfo
+	 */
+	public function __construct( NamespaceInfo $namespaceInfo ) {
+		$this->namespaceInfo = $namespaceInfo;
+	}
 
 	/**
 	 * @since 3.0
@@ -113,11 +127,7 @@ class NamespaceForm {
 		$hiddenNamespaces = array_flip( $this->hiddenNamespaces );
 
 		foreach ( $this->searchableNamespaces as $namespace => $name ) {
-			$subject = MWNamespace::getSubject( $namespace );
-
-			if ( MWNamespace::isTalk( $namespace ) ) {
-			//	continue;
-			}
+			$subject = $this->namespaceInfo->getSubject( $namespace );
 
 			if ( isset( $hiddenNamespaces[$namespace] ) ) {
 				continue;

--- a/src/MediaWiki/Search/ProfileForm/FormsFactory.php
+++ b/src/MediaWiki/Search/ProfileForm/FormsFactory.php
@@ -7,6 +7,7 @@ use SMW\MediaWiki\Search\ProfileForm\Forms\CustomForm;
 use SMW\MediaWiki\Search\ProfileForm\Forms\SortForm;
 use SMW\MediaWiki\Search\ProfileForm\Forms\NamespaceForm;
 use WebRequest;
+use SMW\ApplicationFactory;
 
 /**
  * @private
@@ -57,7 +58,9 @@ class FormsFactory {
 	 * @return NamespaceForm
 	 */
 	public function newNamespaceForm() {
-		return new NamespaceForm();
+		return new NamespaceForm(
+			ApplicationFactory::getInstance()->singleton( 'NamespaceInfo' )
+		);
 	}
 
 }

--- a/src/Services/MediaWikiServices.php
+++ b/src/Services/MediaWikiServices.php
@@ -10,6 +10,7 @@ use MediaWiki\Logger\LoggerFactory;
 use MediaWiki\MediaWikiServices;
 use Psr\Log\NullLogger;
 use SMW\Utils\Logger;
+use SMW\MediaWiki\NamespaceInfo;
 use WikiImporter;
 
 /**
@@ -163,6 +164,25 @@ return [
 		}
 
 		return new Logger( $logger, $role );
+	},
+
+	/**
+	 * NamespaceInfo
+	 *
+	 * @return callable
+	 */
+	'NamespaceInfo' => function( $containerBuilder ) {
+
+		$containerBuilder->registerExpectedReturnType( 'NamespaceInfo', '\SMW\MediaWiki\NamespaceInfo' );
+		$namespaceInfo = null;
+
+		// MW > 1.33
+		// https://github.com/wikimedia/mediawiki/commit/76661cf129e0dea40edefbd7d35a3f09130572a1
+		if ( class_exists( '\MediaWiki\MediaWikiServices' ) && method_exists( '\MediaWiki\MediaWikiServices', 'getNamespaceInfo' ) ) {
+			$namespaceInfo = MediaWikiServices::getInstance()->getNamespaceInfo();
+		}
+
+		return new NamespaceInfo( $namespaceInfo );
 	},
 
 	/**

--- a/tests/phpunit/Integration/MediaWiki/NamespaceInfoCanonicalNameMatchTest.php
+++ b/tests/phpunit/Integration/MediaWiki/NamespaceInfoCanonicalNameMatchTest.php
@@ -2,8 +2,8 @@
 
 namespace SMW\Tests\Integration\MediaWiki;
 
-use MWNamespace;
 use SMW\NamespaceManager;
+use SMW\ApplicationFactory;
 use SMW\Settings;
 use SMW\Tests\Utils\MwHooksHandler;
 
@@ -15,7 +15,7 @@ use SMW\Tests\Utils\MwHooksHandler;
  *
  * @author mwjames
  */
-class MWNamespaceCanonicalNameMatchTest extends \PHPUnit_Framework_TestCase {
+class NamespaceInfoCanonicalNameMatchTest extends \PHPUnit_Framework_TestCase {
 
 	private $mwHooksHandler;
 
@@ -59,6 +59,7 @@ class MWNamespaceCanonicalNameMatchTest extends \PHPUnit_Framework_TestCase {
 	public function testCanonicalNames() {
 
 		$this->mwHooksHandler->deregisterListedHooks();
+		$namespaceInfo = ApplicationFactory::getInstance()->singleton( 'NamespaceInfo' );
 
 		$count = 0;
 		$index = NamespaceManager::buildNamespaceIndex( Settings::newFromGlobals()->get( 'smwgNamespaceIndex' ) );
@@ -69,7 +70,7 @@ class MWNamespaceCanonicalNameMatchTest extends \PHPUnit_Framework_TestCase {
 
 		foreach ( $index as $ns => $idx ) {
 
-			$mwNamespace = MWNamespace::getCanonicalName( $idx );
+			$mwNamespace = $namespaceInfo->getCanonicalName( $idx );
 
 			if ( $mwNamespace && isset( $names[$idx] ) ) {
 				$this->assertEquals( $mwNamespace, $names[$idx] );

--- a/tests/phpunit/Unit/LocalizerTest.php
+++ b/tests/phpunit/Unit/LocalizerTest.php
@@ -16,37 +16,47 @@ use SMW\Localizer;
  */
 class LocalizerTest extends \PHPUnit_Framework_TestCase {
 
+	private $language;
+	private $namespaceInfo;
+
+	protected function setUp() {
+		parent::setUp();
+
+		$this->language = $this->getMockBuilder( '\Language' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$this->namespaceInfo = $this->getMockBuilder( '\SMW\MediaWiki\NamespaceInfo' )
+			->disableOriginalConstructor()
+			->getMock();
+	}
+
 	protected function tearDown() {
 		Localizer::clear();
 	}
 
 	public function testCanConstruct() {
 
-		$language = $this->getMockBuilder( '\Language' )
-			->disableOriginalConstructor()
-			->getMock();
-
 		$this->assertInstanceOf(
-			'\SMW\Localizer',
-			new Localizer( $language )
+			Localizer::class,
+			new Localizer( $this->language, $this->namespaceInfo )
 		);
 
 		$this->assertInstanceOf(
-			'\SMW\Localizer',
+			Localizer::class,
 			Localizer::getInstance()
 		);
 	}
 
 	public function testGetContentLanguage() {
 
-		$language = $this->getMockBuilder( '\Language' )
-			->disableOriginalConstructor()
-			->getMock();
-
-		$instance = new Localizer( $language );
+		$instance = new Localizer(
+			$this->language,
+			$this->namespaceInfo
+		);
 
 		$this->assertSame(
-			$language,
+			$this->language,
 			$instance->getContentLanguage()
 		);
 
@@ -58,7 +68,10 @@ class LocalizerTest extends \PHPUnit_Framework_TestCase {
 
 	public function testNamespaceTextById() {
 
-		$instance = new Localizer( Language::factory( 'en') );
+		$instance = new Localizer(
+			Language::factory( 'en' ),
+			$this->namespaceInfo
+		);
 
 		$this->assertEquals(
 			'Property',
@@ -68,7 +81,10 @@ class LocalizerTest extends \PHPUnit_Framework_TestCase {
 
 	public function testNamespaceIndexByName() {
 
-		$instance = new Localizer( Language::factory( 'en') );
+		$instance = new Localizer(
+			Language::factory( 'en'),
+			$this->namespaceInfo
+		);
 
 		$this->assertEquals(
 			SMW_NS_PROPERTY,
@@ -181,11 +197,10 @@ class LocalizerTest extends \PHPUnit_Framework_TestCase {
 
 	public function testGetLanguageCodeByRule_OnTitleExpectedToPageLanguage() {
 
-		$contentLanguage = $this->getMockBuilder( '\Language' )
-			->disableOriginalConstructor()
-			->getMock();
-
-		$instance = new Localizer( $contentLanguage );
+		$instance = new Localizer(
+			$this->language,
+			$this->namespaceInfo
+		);
 
 		$pageLanguage = $this->getMockBuilder( '\Language' )
 			->disableOriginalConstructor()
@@ -207,11 +222,10 @@ class LocalizerTest extends \PHPUnit_Framework_TestCase {
 
 	public function testGetLanguageCodeByRule_OnNotProvidedTitlePageLanguageExpectedToReturnUserLanguage() {
 
-		$contentLanguage = $this->getMockBuilder( '\Language' )
-			->disableOriginalConstructor()
-			->getMock();
-
-		$instance = new Localizer( $contentLanguage );
+		$instance = new Localizer(
+			$this->language,
+			$this->namespaceInfo
+		);
 
 		$this->assertEquals(
 			$instance->getContentLanguage(),
@@ -262,7 +276,10 @@ class LocalizerTest extends \PHPUnit_Framework_TestCase {
 
 	public function testCreateTextWithNamespacePrefix() {
 
-		$instance = new Localizer( Language::factory( 'en') );
+		$instance = new Localizer(
+			Language::factory( 'en'),
+			$this->namespaceInfo
+		);
 
 		$this->assertEquals(
 			'Property:foo bar',
@@ -272,15 +289,18 @@ class LocalizerTest extends \PHPUnit_Framework_TestCase {
 
 	public function testGetCanonicalizedUrlByNamespace() {
 
-		$language = $this->getMockBuilder( '\Language' )
-			->disableOriginalConstructor()
-			->getMock();
-
-		$language->expects( $this->exactly( 3 ) )
+		$this->language->expects( $this->exactly( 3 ) )
 			->method( 'getNsText' )
 			->will( $this->returnValue( 'Spécial' ) );
 
-		$instance = new Localizer( $language );
+		$this->namespaceInfo->expects( $this->exactly( 3 ) )
+			->method( 'getCanonicalName' )
+			->will( $this->returnValue( 'Special' ) );
+
+		$instance = new Localizer(
+			$this->language,
+			$this->namespaceInfo
+		);
 
 		$this->assertEquals(
 			'http://example.org/wiki/Special:URIResolver/Property-3AHas_query',
@@ -300,11 +320,14 @@ class LocalizerTest extends \PHPUnit_Framework_TestCase {
 
 	public function testGetCanonicalName() {
 
-		$language = $this->getMockBuilder( '\Language' )
-			->disableOriginalConstructor()
-			->getMock();
+		$this->namespaceInfo->expects( $this->once() )
+			->method( 'getCanonicalName' )
+			->will( $this->returnValue( 'Help' ) );
 
-		$instance = new Localizer( $language );
+		$instance = new Localizer(
+			$this->language,
+			$this->namespaceInfo
+		);
 
 		$this->assertEquals(
 			'Property',
@@ -328,11 +351,10 @@ class LocalizerTest extends \PHPUnit_Framework_TestCase {
 			->with( $this->equalTo( 'smw-prefs-general-options-time-correction' ) )
 			->will( $this->returnValue( true ) );
 
-		$language = $this->getMockBuilder( '\Language' )
-			->disableOriginalConstructor()
-			->getMock();
-
-		$instance = new Localizer( $language );
+		$instance = new Localizer(
+			$this->language,
+			$this->namespaceInfo
+		);
 
 		$this->assertTrue(
 			$instance->hasLocalTimeOffsetPreference( $user )
@@ -349,11 +371,10 @@ class LocalizerTest extends \PHPUnit_Framework_TestCase {
 			->disableOriginalConstructor()
 			->getMock();
 
-		$language = $this->getMockBuilder( '\Language' )
-			->disableOriginalConstructor()
-			->getMock();
-
-		$instance = new Localizer( $language );
+		$instance = new Localizer(
+			$this->language,
+			$this->namespaceInfo
+		);
 
 		$this->assertInstanceOf(
 			'DateTime',

--- a/tests/phpunit/Unit/MediaWiki/Hooks/ResourceLoaderGetConfigVarsTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Hooks/ResourceLoaderGetConfigVarsTest.php
@@ -15,11 +15,20 @@ use SMW\MediaWiki\Hooks\ResourceLoaderGetConfigVars;
  */
 class ResourceLoaderGetConfigVarsTest extends \PHPUnit_Framework_TestCase {
 
+	private $namespaceInfo;
+
+	protected function setUp() {
+
+		$this->namespaceInfo = $this->getMockBuilder( '\SMW\MediaWiki\NamespaceInfo' )
+			->disableOriginalConstructor()
+			->getMock();
+	}
+
 	public function testCanConstruct() {
 
 		$this->assertInstanceOf(
 			ResourceLoaderGetConfigVars::class,
-			new ResourceLoaderGetConfigVars()
+			new ResourceLoaderGetConfigVars( $this->namespaceInfo )
 		);
 	}
 
@@ -27,7 +36,18 @@ class ResourceLoaderGetConfigVarsTest extends \PHPUnit_Framework_TestCase {
 
 		$vars = [];
 
-		$instance = new ResourceLoaderGetConfigVars();
+		$instance = new ResourceLoaderGetConfigVars(
+			$this->namespaceInfo
+		);
+
+		$optionKeys = ResourceLoaderGetConfigVars::OPTION_KEYS;
+
+		foreach ( $optionKeys as $key ) {
+			$instance->setOption( $key, [] );
+		}
+
+		$instance->setOption( 'smwgNamespacesWithSemanticLinks', [ NS_MAIN ] );
+
 		$instance->process( $vars );
 
 		$this->assertArrayHasKey(

--- a/tests/phpunit/Unit/MediaWiki/NamespaceInfoTest.php
+++ b/tests/phpunit/Unit/MediaWiki/NamespaceInfoTest.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace SMW\Tests\MediaWiki;
+
+use ParserOutput;
+use SMW\MediaWiki\NamespaceInfo;
+
+/**
+ * @covers \SMW\MediaWiki\NamespaceInfo
+ * @group semantic-mediawiki
+ *
+ * @license GNU GPL v2+
+ * @since   3.1
+ *
+ * @author mwjames
+ */
+class NamespaceInfoTest extends \PHPUnit_Framework_TestCase {
+
+	public function testCanConstruct() {
+
+		$this->assertInstanceOf(
+			NamespaceInfo::class,
+			new NamespaceInfo()
+		);
+	}
+
+	public function testGetCanonicalName() {
+
+		$instance = new NamespaceInfo();
+
+		$this->assertInternalType(
+			'string',
+			$instance->getCanonicalName( NS_MAIN )
+		);
+	}
+
+	public function testGetValidNamespaces() {
+
+		$instance = new NamespaceInfo();
+
+		$this->assertInternalType(
+			'array',
+			$instance->getValidNamespaces()
+		);
+	}
+
+	public function testGetSubject() {
+
+		$instance = new NamespaceInfo();
+
+		$this->assertInternalType(
+			'integer',
+			$instance->getSubject( NS_MAIN )
+		);
+	}
+
+}

--- a/tests/phpunit/Unit/MediaWiki/Search/ProfileForm/Forms/NamespaceFormTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Search/ProfileForm/Forms/NamespaceFormTest.php
@@ -15,17 +15,28 @@ use SMW\MediaWiki\Search\ProfileForm\Forms\NamespaceForm;
  */
 class NamespaceFormTest extends \PHPUnit_Framework_TestCase {
 
+	private $namespaceInfo;
+
+	protected function setUp() {
+
+		$this->namespaceInfo = $this->getMockBuilder( '\SMW\MediaWiki\NamespaceInfo' )
+			->disableOriginalConstructor()
+			->getMock();
+	}
+
 	public function testCanConstruct() {
 
 		$this->assertInstanceOf(
 			NamespaceForm::class,
-			new NamespaceForm()
+			new NamespaceForm( $this->namespaceInfo )
 		);
 	}
 
 	public function testMakeFields() {
 
-		$instance = new NamespaceForm();
+		$instance = new NamespaceForm(
+			$this->namespaceInfo
+		);
 
 		$instance->setSearchableNamespaces( [ 0 => 'Foo '] );
 
@@ -56,7 +67,9 @@ class NamespaceFormTest extends \PHPUnit_Framework_TestCase {
 			->method( 'getUser' )
 			->will( $this->returnValue( $user ) );
 
-		$instance = new NamespaceForm();
+		$instance = new NamespaceForm(
+			$this->namespaceInfo
+		);
 
 		$instance->checkNamespaceEditToken( $specialSearch );
 	}


### PR DESCRIPTION
This PR is made in reference to: #3801

This PR addresses or contains:

- Removes the use of `MWNamespace` and replaces it by a narrow `NamespaceInfo` interface in the `SMW\MediaWiki` namespace

This PR includes:
- [ ] Tests (unit/integration)
- [x] CI build passed
