### PR TITLE
[CI] Use `clearInstanceCache`, refs 3916

### DIFF
--- a/tests/phpunit/DatabaseTestCase.php
+++ b/tests/phpunit/DatabaseTestCase.php
@@ -84,6 +84,12 @@ abstract class DatabaseTestCase extends \PHPUnit_Framework_TestCase {
 		$this->testEnvironment->resetMediaWikiService( 'MainWANObjectCache' );
 
 		$this->testEnvironment->clearPendingDeferredUpdates();
+
+		// #3916
+		// Reset $wgUser, which is probably 127.0.0.1, as its loaded data is probably not valid
+		// @todo Should we start setting $wgUser to something nondeterministic
+		//  to encourage tests to be updated to not depend on it?
+		$GLOBALS['wgUser']->clearInstanceCache( $GLOBALS['wgUser']->mFrom );
 	}
 
 	protected function tearDown() {


### PR DESCRIPTION
This PR is made in reference to: #3916

This PR addresses or contains:

- As noted in #3916, adding `$GLOBALS['wgUser']->clearInstanceCache` is counter intuitive and the explanation and dependency are unclear 

This PR includes:
- [ ] Tests (unit/integration)
- [x] CI build passed

Fixes #3916