### PR TITLE
Use `intval` to guard against non integer limit/offset, refs 3998

### DIFF
--- a/src/MediaWiki/Search/ExtendedSearch.php
+++ b/src/MediaWiki/Search/ExtendedSearch.php
@@ -132,8 +132,26 @@ class ExtendedSearch {
 	 * @param integer $offset
 	 */
 	public function setLimitOffset( $limit, $offset = 0 ) {
-		$this->limit = $limit;
-		$this->offset = $offset;
+		$this->limit = intval( $limit );
+		$this->offset = intval( $offset );
+	}
+
+	/**
+	 * @since 3.1
+	 *
+	 * @return integer
+	 */
+	public function getLimit() {
+		return $this->limit;
+	}
+
+	/**
+	 * @since 3.1
+	 *
+	 * @return integer
+	 */
+	public function getOffset() {
+		return $this->offset;
 	}
 
 	/**

--- a/tests/phpunit/Unit/MediaWiki/Search/ExtendedSearchTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Search/ExtendedSearchTest.php
@@ -46,6 +46,26 @@ class ExtendedSearchTest extends \PHPUnit_Framework_TestCase {
 		);
 	}
 
+	public function testSetLimitOffset() {
+
+		$instance = new ExtendedSearch(
+			$this->store,
+			$this->fallbackSearchEngine
+		);
+
+		$instance->setLimitOffset( 10, false );
+
+		$this->assertEquals(
+			10,
+			$instance->getLimit()
+		);
+
+		$this->assertEquals(
+			0,
+			$instance->getOffset()
+		);
+	}
+
 	public function testSearchTitle_withNonsemanticQuery() {
 
 		$term = 'Some string that can not be interpreted as a semantic query';


### PR DESCRIPTION
This PR is made in reference to: #3998

This PR addresses or contains:

This PR includes:
- [ ] Tests (unit/integration)
- [ ] CI build passed
