### PR TITLE
[ES] Show "no connection" message, refs 4019

### DIFF
--- a/i18n/en.json
+++ b/i18n/en.json
@@ -470,6 +470,8 @@
 	"smw-admin-supplementary-elastic-replication-files-docu": "It should be noted that for the list of files, the [https://www.semantic-mediawiki.org/wiki/Help:ElasticStore/File_ingestion file ingest] job is required to be executed first and has to finish its processing.",
 	"smw-admin-supplementary-elastic-replication-files":"Files",
 	"smw-admin-supplementary-elastic-replication-pages":"Pages",
+	"smw-admin-supplementary-elastic-endpoints": "Endpoints",
+	"smw-admin-supplementary-elastic-no-connection":"The wiki is currently '''unable''' to establish a connection to the Elasticsearch cluster, please contact the wiki administrator to investigate the issue as it incapacitates the index and query ability of the system.",
 	"smw-list-count": "The list contains $1 {{PLURAL:$1|entry|entries}}.",
 	"smw-property-label-uniqueness" : "The \"$1\" label was matched to at least one other property representation. Please consult the [https://www.semantic-mediawiki.org/wiki/Help:Property_uniqueness help page] on how to resolve this issue.",
 	"smw-property-label-similarity-title": "Property label similarity report",

--- a/src/Elastic/Admin/ElasticClientTaskHandler.php
+++ b/src/Elastic/Admin/ElasticClientTaskHandler.php
@@ -84,12 +84,6 @@ class ElasticClientTaskHandler extends TaskHandler {
 	 */
 	public function getHtml() {
 
-		$connection = $this->getStore()->getConnection( 'elastic' );
-
-		if ( !$connection->ping() ) {
-			return '';
-		}
-
 		$link = $this->outputFormatter->createSpecialPageLink(
 			$this->msg( 'smw-admin-supplementary-elastic-title' ),
 			[ 'action' => 'elastic' ]
@@ -130,7 +124,7 @@ class ElasticClientTaskHandler extends TaskHandler {
 		$action = $webRequest->getText( 'action' );
 
 		if ( !$connection->ping() ) {
-			return $this->outputNoNodesAvailable();
+			return $this->outputNoNodesAvailable( $connection );
 		} elseif ( $action === 'elastic' ) {
 			$this->outputHead();
 		} else {
@@ -149,14 +143,26 @@ class ElasticClientTaskHandler extends TaskHandler {
 		$this->outputInfo();
 	}
 
-	private function outputNoNodesAvailable() {
+	private function outputNoNodesAvailable( $connection ) {
 
 		$this->outputHead();
 
-		$html = Html::element(
-			'div',
-			[ 'class' => 'smw-callout smw-callout-error' ],
-			'Elasticsearch has no active nodes available.'
+		$html = Html::rawElement(
+			'h3',
+			[],
+			$this->msg( [ 'smw-admin-supplementary-elastic-replication-header-title' ] )
+		) . Html::rawElement(
+			'p',
+			[],
+			$this->msg( [ 'smw-admin-supplementary-elastic-no-connection' ], Message::PARSE )
+		). Html::rawElement(
+			'h4',
+			[],
+			$this->msg( [ 'smw-admin-supplementary-elastic-endpoints' ] )
+		) . Html::rawElement(
+			'pre',
+			[],
+			json_encode( $connection->getConfig()->safeGet( 'endpoints', [] ), JSON_PRETTY_PRINT )
 		);
 
 		$this->outputFormatter->addHTML( $html );

--- a/tests/phpunit/Unit/Elastic/Admin/ElasticClientTaskHandlerTest.php
+++ b/tests/phpunit/Unit/Elastic/Admin/ElasticClientTaskHandlerTest.php
@@ -71,22 +71,6 @@ class ElasticClientTaskHandlerTest extends \PHPUnit_Framework_TestCase {
 		);
 	}
 
-	public function testGetHtml_OnNoAvailableNodes() {
-
-		$this->outputFormatter->expects( $this->never() )
-			->method( 'createSpecialPageLink' );
-
-		$instance = new ElasticClientTaskHandler(
-			$this->outputFormatter
-		);
-
-		$instance->setStore( $this->store );
-
-		$this->assertEmpty(
-			$instance->getHtml()
-		);
-	}
-
 	public function testGetHtml_OnAvailableNodes() {
 
 		$this->outputFormatter->expects( $this->once() )


### PR DESCRIPTION
This PR is made in reference to: #4019 

This PR addresses or contains:

- Shows a message in the case of "no connection", other functions will be disabled as those require an active ES connection

This PR includes:
- [ ] Tests (unit/integration)
- [x] CI build passed

Fixes #4019

### Example

![image](https://user-images.githubusercontent.com/1245473/57970009-553c7d80-796b-11e9-81d8-ebb88ba03519.png)
