### PR TITLE
Fix "ProtectionValidator must be an instance of Title, null given ..."

### DIFF
--- a/src/Protection/ProtectionValidator.php
+++ b/src/Protection/ProtectionValidator.php
@@ -160,11 +160,15 @@ class ProtectionValidator {
 	 * @since 3.0
 	 *
 	 * @param Title $title
-	 * @param Title $title
 	 *
 	 * @return boolean
 	 */
-	public function hasCreateProtection( Title $title ) {
+	public function hasCreateProtection( Title $title = null ) {
+
+		if ( $title === null ) {
+			return false;
+		}
+
 		return $this->createProtectionRight && !$title->userCan( 'edit' );
 	}
 
@@ -180,7 +184,11 @@ class ProtectionValidator {
 	 *
 	 * @return boolean
 	 */
-	public function hasEditProtection( Title $title ) {
+	public function hasEditProtection( Title $title = null ) {
+
+		if ( $title === null ) {
+			return false;
+		}
 
 		$subject = DIWikiPage::newFromTitle(
 			$title

--- a/tests/phpunit/Unit/Protection/ProtectionValidatorTest.php
+++ b/tests/phpunit/Unit/Protection/ProtectionValidatorTest.php
@@ -265,4 +265,28 @@ class ProtectionValidatorTest extends \PHPUnit_Framework_TestCase {
 		);
 	}
 
+	public function testHasCreateProtection_NullTitle() {
+
+		$instance = new ProtectionValidator(
+			$this->store,
+			$this->entityCache
+		);
+
+		$this->assertFalse(
+			$instance->hasCreateProtection( null )
+		);
+	}
+
+	public function testHasEditProtection_NullTitle() {
+
+		$instance = new ProtectionValidator(
+			$this->store,
+			$this->entityCache
+		);
+
+		$this->assertFalse(
+			$instance->hasEditProtection( null )
+		);
+	}
+
 }


### PR DESCRIPTION
This PR is made in reference to: #

This PR addresses or contains:

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed

## Stack trace 

```
[5eeaa2d8e9573507809a7b82] /mw-30-00-elastic/index.php?title=Property:Rating TypeError from line 188 of ...\extensions\SemanticMediaWiki\src\Protection\ProtectionValidator.php: Argument 1 passed to SMW\Protection\ProtectionValidator::hasEditProtection() must be an instance of Title, null given, called in ...\extensions\SemanticMediaWiki\src\Property\DeclarationExaminer\ProtectionExaminer.php on line 71

Backtrace:

#0 ...\extensions\SemanticMediaWiki\src\Property\DeclarationExaminer\ProtectionExaminer.php(71): SMW\Protection\ProtectionValidator->hasEditProtection(NULL)
#1 ...\extensions\SemanticMediaWiki\src\Property\DeclarationExaminer\ProtectionExaminer.php(48): SMW\Property\DeclarationExaminer\ProtectionExaminer->checkEditProtectionRight(NULL, SMW\DIProperty)
#2 ...\extensions\SemanticMediaWiki\src\Property\DeclarationExaminer\DeclarationExaminer.php(80): SMW\Property\DeclarationExaminer\ProtectionExaminer->validate(SMW\DIProperty)
#3 ...\extensions\SemanticMediaWiki\src\Property\DeclarationExaminer\DeclarationExaminer.php(78): SMW\Property\DeclarationExaminer\DeclarationExaminer->check(SMW\DIProperty)
#4 ...\extensions\SemanticMediaWiki\src\Property\DeclarationExaminer\DeclarationExaminer.php(78): SMW\Property\DeclarationExaminer\DeclarationExaminer->check(SMW\DIProperty)
#5 ...\extensions\SemanticMediaWiki\src\MediaWiki\Page\PropertyPage.php(109): SMW\Property\DeclarationExaminer\DeclarationExaminer->check(SMW\DIProperty)
#6 ...\extensions\SemanticMediaWiki\src\MediaWiki\Page\Page.php(92): SMW\MediaWiki\Page\PropertyPage->initHtml()
#7 ...\includes\actions\ViewAction.php(68): SMW\MediaWiki\Page\Page->view()
#8 ...\includes\MediaWiki.php(499): ViewAction->show()
#9 ...\includes\MediaWiki.php(293): MediaWiki->performAction(SMW\MediaWiki\Page\PropertyPage, Title)
#10 ...\includes\MediaWiki.php(851): MediaWiki->performRequest()
#11 ...\includes\MediaWiki.php(523): MediaWiki->main()
#12 ...\index.php(43): MediaWiki->run()
#13 {main}
```