### PR TITLE
Add `CLASS_CONSTRAINT_SCHEMA`, refs 3746, 3829

### DIFF
--- a/DefaultSettings.php
+++ b/DefaultSettings.php
@@ -2109,6 +2109,13 @@ return [
 			'type_description' => 'smw-schema-description-property-constraint-schema',
 			'change_propagation' => [ '_CONSTRAINT_SCHEMA' ],
 			'usage_lookup' => '_CONSTRAINT_SCHEMA'
+		],
+		'CLASS_CONSTRAINT_SCHEMA' => [
+			'group' => SMW_SCHEMA_GROUP_CONSTRAINT,
+			'validation_schema' => __DIR__ . '/data/schema/class-constraint-schema.v1.json',
+			'type_description' => 'smw-schema-description-class-constraint-schema',
+			'change_propagation' => [ '_CONSTRAINT_SCHEMA' ],
+			'usage_lookup' => '_CONSTRAINT_SCHEMA'
 		]
 	],
 	##

--- a/data/schema/class-constraint-schema.v1.json
+++ b/data/schema/class-constraint-schema.v1.json
@@ -1,0 +1,77 @@
+{
+	"$schema": "http://json-schema.org/draft-07/schema#",
+	"$id": "https://www.semantic-mediawiki.org/wiki/Help:Schema/Type/CLASS_CONSTRAINT_SCHEMA",
+	"type": "object",
+	"title": "Class constraint validation schema",
+	"required": [
+		"type",
+		"constraints"
+	],
+	"properties": {
+		"type": {
+			"$id": "#/properties/type",
+			"type": "string",
+			"enum": [
+				"CLASS_CONSTRAINT_SCHEMA"
+			],
+			"title": "Schema type",
+			"default": "CLASS_CONSTRAINT_SCHEMA"
+		},
+		"tags": {
+			"$id": "#/properties/tags",
+			"type": "array",
+			"title": "tags",
+			"default": null,
+			"items": {
+				"$id": "#/properties/tags/items",
+				"type": "string",
+				"title": "tags, keywords etc.",
+				"default": "",
+				"pattern": "^(.*)$"
+			}
+		},
+		"constraints": {
+			"$id": "#/properties/constraints",
+			"type": "object",
+			"title": "constraint rules",
+			"minProperties": 1,
+			"propertyNames": {
+				"pattern": "^[A-Za-z_][A-Za-z0-9_]*$"
+			},
+			"properties": {
+				"mandatory_properties": {
+					"$ref": "#/definitions/mandatory_properties"
+				},
+				"custom_constraint": {
+					"$ref": "#/definitions/custom_constraint"
+				}
+			},
+			"additionalProperties": false
+		}
+	},
+	"definitions": {
+		"mandatory_properties": {
+			"$id": "#/definitions/mandatory_properties",
+			"type": "array",
+			"title": "Specifies required properties",
+			"minItems": 1,
+			"items": {
+				"type": "string"
+			}
+		},
+		"shape_constraint": {
+			"$id": "#/definitions/shape_constraint",
+			"type": "array",
+			"title": "Specifies required properties",
+			"minItems": 1,
+			"items": {
+				"$ref": "#/definitions/shape_item"
+			}
+		},
+		"custom_constraint": {
+			"$id": "#/definitions/custom_constraint",
+			"type": "object",
+			"title": "Specifies custom constraints to be implemented by a user"
+		}
+	}
+}

--- a/docs/examples/register.custom.constraint.md
+++ b/docs/examples/register.custom.constraint.md
@@ -1,8 +1,26 @@
-## Register new constraint
+The following example shows how to register a custom constraint using the `custom_constraint` property.
 
-This example shows how to register a custom constraint.
+## Register a custom constraint
 
-### SMW::Constraint::initConstraints
+The `custom_constraint` property is an `object` in the schema and is reserved for custom defined constraints using above outlined invocation and hook. The interpretation of what `custom_constraint` should contain and how those values of the schema are interpret are in the solely hand of the implementor.
+
+```json
+{
+	"type": "PROPERTY_CONSTRAINT_SCHEMA",
+	"constraints": {
+		"custom_constraint": {
+			"foo_constraint": true
+		}
+	},
+	"tags": [
+		"property constraint",
+		"custom constraint"
+	]
+}
+```
+The validation schema only checks whether `custom_constraint` is an object or not, any further validation of what and how the object is structured is not part of the schema validation, the assigned `Constraint` class should handle any inconsistencies with an invalid constraint definition.
+
+### Hook registration
 
 ```php
 use Hooks;
@@ -10,7 +28,7 @@ use Foo\FooConstraint;
 
 Hooks::register( 'SMW::Constraint::initConstraints', function ( $constraintRegistry ) {
 
-	// Defined the constraint name and assign a class that interprets the
+	// Declares the constraint identifier and assigns a class that interprets the
 	// content of it
 	$constraintRegistry->registerConstraint( 'foo_constraint', FooConstraint::class );
 
@@ -77,25 +95,94 @@ class FooConstraint implements Constraint {
 }
 ```
 
-### Usage
+## Other examples
 
-The `custom_constraint` property is an `object` in the schema and is reserved for custom defined constraints using above outlined invocation and hook. The interpretation of what `custom_constraint` should contain and how those values of the schema are interpret are in the solely hand of the implementor.
+For example, when implementing a `start_end_constraint` with an identifier `greater_than`, the `greater_than` property may expect an array with the registered class being responsible for interpreting what `greater_than` means in the context of the given array such as "the first element (e.g. property `Event end`) needs to be greater than the second element (e.g. property `Event start`)".
 
-The validation schema only checks whether `custom_constraint` is an object or not, any further validation of what how the object is structured or should contain needs to be implemented using the assigned `Constraint` class.
 
 ```json
 {
-	"type": "PROPERTY_CONSTRAINT_SCHEMA",
+	"type": "CLASS_CONSTRAINT_SCHEMA",
 	"constraints": {
 		"custom_constraint": {
-			"foo_constraint": true
+			"start_end_constraint": {
+				"greater_than": ["Event end", "Event start"]
+			}
 		}
 	},
 	"tags": [
-		"property constraint",
+		"class constraint",
 		"custom constraint"
 	]
 }
+```
+
+```php
+use SMW\Constraint\Constraint;
+use SMW\SemanticData;
+
+class StartEndConstraint implements Constraint {
+
+	private $hasViolation;
+
+	/**
+	 * @since 3.1
+	 *
+	 * {@inheritDoc}
+	 */
+	public function hasViolation() {
+		return $this->hasViolation;
+	}
+
+	/**
+	 * @since 3.1
+	 *
+	 * {@inheritDoc}
+	 */
+	public function getType() {
+		return Constraint::TYPE_INSTANT;
+	}
+
+	/**
+	 * @since 3.1
+	 *
+	 * {@inheritDoc}
+	 */
+	public function checkConstraint( array $constraint, $dataValue ) {
+
+		$this->hasViolation = false;
+
+		if ( !$dataValue instanceof \SMWDataValue ) {
+			throw new RuntimeException( "Expected a DataValue instance!" );
+		}
+
+		foreach ( $constraint as $key => $v ) {
+			if ( $key === 'start_end_constraint' ) {
+				$this->start_end_constraint( $v, $dataValue );
+			}
+		}
+	}
+
+	private function start_end_constraint( $constraint, $dataValue ) {
+
+		if ( !isset( $constraint['greater_than'] ) ) {
+			return;
+		}
+
+		// Interpret the array structure
+		$end = $constraint['greater_than'][0];
+		$start = $constraint['greater_than'][1];
+
+		$semanticData = $dataValue->getCallable( SemanticData::class )();
+
+		$s = $semanticData->getPropertyValues(
+			\SMW\DIProperty::newFromUserLabel( $start )
+		);
+
+		$e = $semanticData->getPropertyValues(
+			\SMW\DIProperty::newFromUserLabel( $end )
+		);
+	}
 ```
 
 ## See also

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -147,6 +147,7 @@
 	"smw-constraint-error": "Constraint issue",
 	"smw-constraint-error-suggestions": "Please check listed violations and properties together with their annotated values to ensure that all constraint requirements are met.",
 	"smw-constraint-error-limit":"The list will contain a maximum of $1 violations.",
+	"smw-constraint-violation-class-mandatory-properties-constraint": "Category \"[[:Category:$1|$1]]\" has a <code>mandatory_properties</code> constraint assigned and requires the following mandatory properties: $2",
 	"smw_noboolean": "\"$1\" is not recognized as a Boolean (true/false) value.",
 	"smw_true_words": "true,t,yes,y",
 	"smw_false_words": "false,f,no,n",
@@ -920,6 +921,7 @@
 	"smw-schema-description-search-form-schema": "The <code>$1</code> schema type is expected to be used to define input forms and characteristics for the [https://www.semantic-mediawiki.org/wiki/Help:SMWSearch extended search] profile where it contains instructions on how to generate input fields, define default namespaces, or declare prefix expressions for a search request.",
 	"smw-schema-description-property-group-schema": "The <code>$1</code> schema type defines [https://www.semantic-mediawiki.org/wiki/Help:Property_group property groups] to help structure the [https://www.semantic-mediawiki.org/wiki/Help:Special:Browse browsing] interface.",
 	"smw-schema-description-property-constraint-schema": "The <code>$1</code> schema type is expected to be used to define constraint rules for a property instance as well as those values assigned to it.",
+	"smw-schema-description-class-constraint-schema": "The <code>$1</code> schema type is expected to be used to define constraint rules for a class instance (a.k.a. category).",
 	"smw-schema-tag": "{{PLURAL:$1|Tag|Tags}}",
 	"smw-property-predefined-constraint-schema": "\"$1\" is a predefined property that defines a constraint schema and is provided by [https://www.semantic-mediawiki.org/wiki/Help:Special_properties Semantic MediaWiki].",
 	"smw-property-predefined-schema-desc": "\"$1\" is a predefined property that stores a schema description and is provided by [https://www.semantic-mediawiki.org/wiki/Help:Special_properties Semantic MediaWiki].",
@@ -973,5 +975,6 @@
 	"smw-es-replication-error-file-ingest-missing-file-attachment-suggestions": "Please ensure that the [https://www.semantic-mediawiki.org/wiki/Help:ElasticStore/File_ingestion file ingest] job is scheduled and executed before the annotation and file index can be made available.",
 	"smw-report": "Report",
 	"smw-legend": "Legend",
-	"smw-datavalue-constraint-schema-category-wrong-type": "The annotated \"$1\" schema requires to be a \"$2\" type for a category."
+	"smw-datavalue-constraint-schema-category-invalid-type": "The annotated \"$1\" schema is invalid for a category, it requires a \"$2\" type.",
+	"smw-datavalue-constraint-schema-property-invalid-type": "The annotated \"$1\" schema is invalid for a property, it requires a \"$2\" type."
 }

--- a/src/Constraint/ConstraintRegistry.php
+++ b/src/Constraint/ConstraintRegistry.php
@@ -9,6 +9,7 @@ use SMW\Constraint\Constraints\UniqueValueConstraint;
 use SMW\Constraint\Constraints\NonNegativeIntegerConstraint;
 use SMW\Constraint\Constraints\MustExistsConstraint;
 use SMW\Constraint\Constraints\SingleValueConstraint;
+use SMW\Constraint\Constraints\MandatoryPropertiesConstraint;
 
 /**
  * @license GNU GPL v2+
@@ -105,6 +106,7 @@ class ConstraintRegistry {
 			'single_value_constraint' => SingleValueConstraint::class,
 			'non_negative_integer' => NonNegativeIntegerConstraint::class,
 			'must_exists' => MustExistsConstraint::class,
+			'mandatory_properties' => MandatoryPropertiesConstraint::class
 		];
 
 		\Hooks::run( 'SMW::Constraint::initConstraints', [ $this ] );

--- a/src/Constraint/Constraints/MandatoryPropertiesConstraint.php
+++ b/src/Constraint/Constraints/MandatoryPropertiesConstraint.php
@@ -1,0 +1,104 @@
+<?php
+
+namespace SMW\Constraint\Constraints;
+
+use SMW\Constraint\Constraint;
+use SMW\Constraint\ConstraintError;
+use SMW\SemanticData;
+use SMW\Message;
+use SMWDataValue as DataValue;
+use SMWDataItem as DataItem;
+use RuntimeException;
+
+/**
+ * @license GNU GPL v2+
+ * @since 3.1
+ *
+ * @author mwjames
+ */
+class MandatoryPropertiesConstraint implements Constraint {
+
+	/**
+	 * Defines the expected key in the JSON
+	 */
+	const CONSTRAINT_KEY = 'mandatory_properties';
+
+	/**
+	 * @var boolean
+	 */
+	private $hasViolation = false;
+
+	/**
+	 * @since 3.1
+	 *
+	 * {@inheritDoc}
+	 */
+	public function hasViolation() {
+		return $this->hasViolation;
+	}
+
+	/**
+	 * @since 3.1
+	 *
+	 * {@inheritDoc}
+	 */
+	public function getType() {
+		return Constraint::TYPE_INSTANT;
+	}
+
+	/**
+	 * @since 3.1
+	 *
+	 * {@inheritDoc}
+	 */
+	public function checkConstraint( array $constraint, $dataValue ) {
+
+		$this->hasViolation = false;
+
+		if ( !$dataValue instanceof DataValue ) {
+			throw new RuntimeException( "Expected a DataValue instance!" );
+		}
+
+		$key = key( $constraint );
+
+		if ( $key === self::CONSTRAINT_KEY ) {
+			return $this->check( $constraint[$key], $dataValue );
+		}
+	}
+
+	private function check( $properties, $dataValue ) {
+
+		$dataItem = $dataValue->getDataItem();
+		$properties = array_flip( $properties );
+
+		//PHP 7.0+ $semanticData = $dataValue->getCallable( SemanticData::class )();
+		$semanticData = $dataValue->getCallable( SemanticData::class );
+		$semanticData = $semanticData();
+
+		foreach ( $semanticData->getProperties() as $property ) {
+			unset( $properties[$property->getLabel()] );
+		}
+
+		if ( $properties === [] ) {
+			return;
+		}
+
+		$this->reportError( $dataValue, $properties );
+	}
+
+	private function reportError( $dataValue, $properties ) {
+
+		$this->hasViolation = true;
+
+		$error = [
+			'smw-constraint-violation-class-mandatory-properties-constraint',
+			$dataValue->getWikiValue(),
+			implode(', ', array_keys( $properties ) )
+		];
+
+		$dataValue->addErrorMsg(
+			new ConstraintError( $error, Message::PARSE )
+		);
+	}
+
+}

--- a/src/ConstraintFactory.php
+++ b/src/ConstraintFactory.php
@@ -15,6 +15,7 @@ use SMW\Constraint\Constraints\UniqueValueConstraint;
 use SMW\Constraint\Constraints\NonNegativeIntegerConstraint;
 use SMW\Constraint\Constraints\MustExistsConstraint;
 use SMW\Constraint\Constraints\SingleValueConstraint;
+use SMW\Constraint\Constraints\MandatoryPropertiesConstraint;
 
 /**
  * @license GNU GPL v2+
@@ -71,6 +72,9 @@ class ConstraintFactory {
 				break;
 			case SingleValueConstraint::class:
 				$constraint = $this->newSingleValueConstraint();
+				break;
+			case MandatoryPropertiesConstraint::class:
+				$constraint = $this->newMandatoryPropertiesConstraint();
 				break;
 			case NullConstraint::class:
 				$constraint = $this->newNullConstraint();
@@ -138,6 +142,15 @@ class ConstraintFactory {
 	 */
 	public function newSingleValueConstraint() {
 		return new SingleValueConstraint();
+	}
+
+	/**
+	 * @since 3.1
+	 *
+	 * @return MandatoryPropertiesConstraint
+	 */
+	public function newMandatoryPropertiesConstraint() {
+		return new MandatoryPropertiesConstraint();
 	}
 
 	/**

--- a/src/DataValues/ConstraintSchemaValue.php
+++ b/src/DataValues/ConstraintSchemaValue.php
@@ -45,6 +45,8 @@ class ConstraintSchemaValue extends WikiPageValue {
 
 		$dataItem = $this->getDataItem();
 		$contextPage = $this->getContextPage();
+		$schema = null;
+		$error = [];
 
 		if ( !$dataItem instanceof DIWikiPage || $contextPage === null ) {
 			return;
@@ -59,8 +61,20 @@ class ConstraintSchemaValue extends WikiPageValue {
 			$schema = json_decode( $definition->getString(), true );
 		}
 
-		if ( $contextPage->getNamespace() === NS_CATEGORY && $schema['type'] !== 'CLASS_CONSTRAINT_SCHEMA' ) {
-			$this->addErrorMsg( [ 'smw-datavalue-constraint-schema-category-wrong-type', $value, 'CLASS_CONSTRAINT_SCHEMA' ] );
+		if ( $schema === null ) {
+			return;
+		}
+
+		$ns = $contextPage->getNamespace();
+
+		if ( $ns === NS_CATEGORY && $schema['type'] !== 'CLASS_CONSTRAINT_SCHEMA' ) {
+			$error = [ 'smw-datavalue-constraint-schema-category-invalid-type', $value, 'CLASS_CONSTRAINT_SCHEMA' ];
+		} elseif ( $ns === SMW_NS_PROPERTY && $schema['type'] !== 'PROPERTY_CONSTRAINT_SCHEMA' ) {
+			$error = [ 'smw-datavalue-constraint-schema-property-invalid-type', $value, 'PROPERTY_CONSTRAINT_SCHEMA' ];
+		}
+
+		if ( $error !== [] ) {
+			$this->addErrorMsg( $error );
 		}
 	}
 

--- a/src/DataValues/ValueValidators/ConstraintSchemaValueValidator.php
+++ b/src/DataValues/ValueValidators/ConstraintSchemaValueValidator.php
@@ -98,12 +98,30 @@ class ConstraintSchemaValueValidator implements ConstraintValueValidator {
 		}
 
 		$schemaList = null;
+		$dataItems = [];
 
 		$property = $dataValue->getProperty();
-		$key = $property->getSerialization();
+
+		if ( $property->getKey() === '_INST' ) {
+			$dataItem = $dataValue->getDataItem();
+		} else {
+			$dataItem = $property;
+		}
+
+		$key = $dataItem->getSerialization();
 
 		if ( !isset( $this->schemaLists[$key] ) ) {
-			$this->schemaLists[$key] = $this->schemaFinder->getConstraintSchema( $property );
+			$schemaList = $this->schemaFinder->getConstraintSchema( $dataItem );
+
+			if ( !$schemaList instanceof SchemaList && $dataItems !== [] ) {
+				$schemaList = new SchemaList();
+			}
+
+			foreach ( $dataItems as $di ) {
+				$schemaList->add( $this->schemaFinder->getConstraintSchema( $di ) );
+			}
+
+			$this->schemaLists[$key] = $schemaList;
 		}
 
 		$schemaList = $this->schemaLists[$key];

--- a/src/ProcessingErrorMsgHandler.php
+++ b/src/ProcessingErrorMsgHandler.php
@@ -225,7 +225,9 @@ class ProcessingErrorMsgHandler {
 
 	private function publishError( $containerSemanticData, $property, $error, $type ) {
 
-		if ( $property !== null ) {
+		// `_INST` is not a real (visible) property to create a reference from
+		// and link to
+		if ( $property !== null && $property->getKey() !== '_INST' ) {
 			$containerSemanticData->addPropertyObjectValue(
 				new DIProperty( '_ERRP' ),
 				new DIWikiPage( $property->getKey(), SMW_NS_PROPERTY )

--- a/src/Schema/README.md
+++ b/src/Schema/README.md
@@ -31,7 +31,7 @@ $GLOBALS['smwgSchemaTypes'] = [
 - [`SEARCH_FORM_SCHEMA`](https://github.com/SemanticMediaWiki/SemanticMediaWiki/blob/master/src/Schema/docs/search.form.md)
 - [`PROPERTY_GROUP_SCHEMA`](https://github.com/SemanticMediaWiki/SemanticMediaWiki/blob/master/src/Schema/docs/property.group.md)
 - [`PROPERTY_CONSTRAINT_SCHEMA`](https://github.com/SemanticMediaWiki/SemanticMediaWiki/blob/master/src/Schema/docs/property.constraint.md)
-- `CLASS_CONSTRAINT_SCHEMA`
+- [`CLASS_CONSTRAINT_SCHEMA`](https://github.com/SemanticMediaWiki/SemanticMediaWiki/blob/master/src/Schema/docs/class.constraint.md)
 
 [json:schema]: http://json-schema.org/
 

--- a/src/Schema/docs/class.constraint.md
+++ b/src/Schema/docs/class.constraint.md
@@ -1,6 +1,6 @@
 ## Objective
 
-The `PROPERTY_CONSTRAINT_SCHEMA` schema type defines constraint definitions that can be assigned to a property using the `Constraint schema` property.
+The `CLASS_CONSTRAINT_SCHEMA` schema type defines constraint definitions that can be assigned to a class (aka. category) using the `Constraint schema` property.
 
 ### Naming convention
 
@@ -8,7 +8,7 @@ To easily identify pages that contain a constraint schema it is suggested to use
 
 ## Properties
 
-- `type` defines the type and is fixed to `PROPERTY_CONSTRAINT_SCHEMA`
+- `type` defines the type and is fixed to `CLASS_CONSTRAINT_SCHEMA`
 - `constraints` the section that contains constraints definitions
 - `tags` simple tags to categorize a schema
 
@@ -16,7 +16,7 @@ To easily identify pages that contain a constraint schema it is suggested to use
 
 <pre>
 {
-    "type": "PROPERTY_CONSTRAINT_SCHEMA",
+    "type": "CLASS_CONSTRAINT_SCHEMA",
     "constraints": {
         ...
     },
@@ -29,12 +29,8 @@ To easily identify pages that contain a constraint schema it is suggested to use
 
 ### Constraint properties
 
-- `allowed_namespaces` (array) specifies allowed namespaces
-- `unique_value_constraint` (boolean) specifies that values should be unique across the wiki, that the value is likely to be different (distinct) from all other items
-- [`single_value_constraint`][example.schema] (boolean) specifies that the property expects only a single value per assigned entity
+- `mandatory_properties` (array) specifies mandatory properties
 - [`custom_constraint`][custom.constraint] (object) specifies non-schema specific custom constraints implementations
-- [`non_negative_integer`][example.schema] (boolean) specifies that values are derived from integer with the minimum inclusive to be 0
-- [`must_exists`][example.schema] (boolean) specifies that the annotated value must exists to be valid
 
 ### Extending constraints
 
@@ -43,7 +39,7 @@ To easily identify pages that contain a constraint schema it is suggested to use
 
 ## Validation
 
-`/data/schema/property-constraint-schema.v1.json`
+`/data/schema/class-constraint-schema.v1.json`
 
 [example.schema]:https://github.com/SemanticMediaWiki/SemanticMediaWiki/blob/master/docs/examples/constraint.schema.md
 [custom.constraint]:https://github.com/SemanticMediaWiki/SemanticMediaWiki/blob/master/docs/examples/register.custom.constraint.md

--- a/tests/phpunit/Integration/JSONScript/Fixtures/p-1110-constraint-mandatory-properties.json
+++ b/tests/phpunit/Integration/JSONScript/Fixtures/p-1110-constraint-mandatory-properties.json
@@ -1,0 +1,10 @@
+{
+    "type": "CLASS_CONSTRAINT_SCHEMA",
+    "constraints": {
+        "mandatory_properties": [ "Mandatory 1", "Mandatory 2" ]
+    },
+    "tags": [
+        "class constraint",
+        "mandatory properties"
+    ]
+}

--- a/tests/phpunit/Integration/JSONScript/TestCases/p-1110.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/p-1110.json
@@ -1,0 +1,139 @@
+{
+	"description": "Test `smw/schema` on `CLASS_CONSTRAINT_SCHEMA` with `mandatory_properties` and `Constraint schema`",
+	"setup": [
+		{
+			"namespace": "SMW_NS_SCHEMA",
+			"page": "Constraint:MandatoryProperties",
+			"contents": {
+				"import-from": "/../Fixtures/p-1110-constraint-mandatory-properties.json"
+			}
+		},
+		{
+			"namespace": "NS_CATEGORY",
+			"page": "P1110",
+			"contents": "[[Constraint schema::Constraint:MandatoryProperties]]"
+		},
+		{
+			"page": "Test:P1110/1",
+			"contents": "[[Category:P1110]]"
+		},
+		{
+			"page": "Test:P1110/2",
+			"contents": "[[Mandatory 1::abc]] [[Category:P1110]]"
+		},
+		{
+			"page": "Test:P1110/3",
+			"contents": "{{#subobject: |@category=P1110}}"
+		}
+	],
+	"tests": [
+		{
+			"type": "parser",
+			"about": "#0",
+			"namespace": "NS_CATEGORY",
+			"subject": "P1110",
+			"assert-store": {
+				"semantic-data": {
+					"strict-mode-valuematch": false,
+					"propertyCount": 3,
+					"propertyKeys": [
+						"_CONSTRAINT_SCHEMA",
+						"_SKEY",
+						"_MDAT"
+					]
+				}
+			}
+		},
+		{
+			"type": "parser",
+			"about": "#1 (violation of `mandatory_properties`)",
+			"subject": "Test:P1110/1",
+			"assert-store": {
+				"semantic-data": {
+					"strict-mode-valuematch": false,
+					"propertyCount": 3,
+					"propertyKeys": [
+						"_SKEY",
+						"_MDAT",
+						"_ERRC"
+					]
+				}
+			}
+		},
+		{
+			"type": "parser",
+			"about": "#2 (violation of `mandatory_properties`, missing two properties)",
+			"subject": "Test:P1110/1#_ERR080b0f4484ac85bb6dc711fe6befad5a",
+			"assert-store": {
+				"semantic-data": {
+					"strict-mode-valuematch": false,
+					"propertyCount": 3,
+					"propertyKeys": [
+						"_SKEY",
+						"_ERRT",
+						"_ERR_TYPE"
+					],
+					"propertyValues": [
+						{ "serialization": "[8,\"smw-constraint-violation-class-mandatory-properties-constraint\",\"P1110\",\"Mandatory 1, Mandatory 2\"]" }
+					]
+				}
+			}
+		},
+		{
+			"type": "parser",
+			"about": "#3 (violation of `mandatory_properties`, missing one property)",
+			"subject": "Test:P1110/2#_ERR080b0f4484ac85bb6dc711fe6befad5a",
+			"assert-store": {
+				"semantic-data": {
+					"strict-mode-valuematch": false,
+					"propertyCount": 3,
+					"propertyKeys": [
+						"_SKEY",
+						"_ERRT",
+						"_ERR_TYPE"
+					],
+					"propertyValues": [
+						{ "serialization": "[8,\"smw-constraint-violation-class-mandatory-properties-constraint\",\"P1110\",\"Mandatory 2\"]" }
+					]
+				}
+			}
+		},
+		{
+			"type": "parser",
+			"about": "#4 (violation of `mandatory_properties`, missing two properties, subobject)",
+			"subject": "Test:P1110/3#_ERR1b9c6b99283108386b4f864721b2e8b7",
+			"assert-store": {
+				"semantic-data": {
+					"strict-mode-valuematch": false,
+					"propertyCount": 3,
+					"propertyKeys": [
+						"_SKEY",
+						"_ERRT",
+						"_ERR_TYPE"
+					],
+					"propertyValues": [
+						{ "serialization": "[8,\"smw-constraint-violation-class-mandatory-properties-constraint\",\"P1110\",\"Mandatory 1, Mandatory 2\"]" }
+					]
+				}
+			}
+		}
+	],
+	"settings": {
+		"wgContLang": "en",
+		"wgLang": "en",
+		"smwgPageSpecialProperties": [
+			"_MDAT"
+		],
+		"smwgNamespacesWithSemanticLinks": {
+			"NS_MAIN": true,
+			"NS_CATEGORY": true,
+			"SMW_NS_PROPERTY": true,
+			"SMW_NS_SCHEMA": true
+		}
+	},
+	"meta": {
+		"version": "2",
+		"is-incomplete": false,
+		"debug": false
+	}
+}

--- a/tests/phpunit/Unit/Constraint/ConstraintRegistryTest.php
+++ b/tests/phpunit/Unit/Constraint/ConstraintRegistryTest.php
@@ -166,6 +166,11 @@ class ConstraintRegistryTest extends \PHPUnit_Framework_TestCase {
 			'must_exists',
 			'SMW\Constraint\Constraints\MustExistsConstraint'
 		];
+
+		yield[
+			'mandatory_properties',
+			'SMW\Constraint\Constraints\MandatoryPropertiesConstraint'
+		];
 	}
 
 }

--- a/tests/phpunit/Unit/Constraint/Constraints/MandatoryPropertiesConstraintTest.php
+++ b/tests/phpunit/Unit/Constraint/Constraints/MandatoryPropertiesConstraintTest.php
@@ -1,0 +1,116 @@
+<?php
+
+namespace SMW\Tests\Constraint\Constraints;
+
+use SMW\Constraint\Constraints\MandatoryPropertiesConstraint;
+use SMW\Tests\PHPUnitCompat;
+use SMW\DataItemFactory;
+
+/**
+ * @covers \SMW\Constraint\Constraints\MandatoryPropertiesConstraint
+ * @group semantic-mediawiki
+ *
+ * @license GNU GPL v2+
+ * @since 3.1
+ *
+ * @author mwjames
+ */
+class MandatoryPropertiesConstraintTest extends \PHPUnit_Framework_TestCase {
+
+	use PHPUnitCompat;
+
+	private $dataItemFactory;
+
+	protected function setUp() {
+		$this->dataItemFactory = new DataItemFactory();
+	}
+
+	public function testCanConstruct() {
+
+		$this->assertInstanceOf(
+			MandatoryPropertiesConstraint::class,
+			new MandatoryPropertiesConstraint()
+		);
+	}
+
+	public function testGetType() {
+
+		$instance = new MandatoryPropertiesConstraint();
+
+		$this->assertEquals(
+			MandatoryPropertiesConstraint::TYPE_INSTANT,
+			$instance->getType()
+		);
+	}
+
+	public function testHasViolation() {
+
+		$instance = new MandatoryPropertiesConstraint();
+
+		$this->assertFalse(
+			$instance->hasViolation()
+		);
+	}
+
+	public function testCheckConstraint_mandatory_properties() {
+
+		$constraint = [
+			'mandatory_properties' => [ 'Foo' ]
+		];
+
+		$expectedErrMsg = 'smw-constraint-violation-class-mandatory-properties-constraint';
+
+		$semanticData = $this->getMockBuilder( '\SMW\SemanticData' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$semanticData->expects( $this->atLeastOnce() )
+			->method( 'getProperties' )
+			->will( $this->returnValue( [ $this->dataItemFactory->newDIProperty( 'Foobar' ) ] ) );
+
+		$dataValue = $this->getMockBuilder( '\SMWDataValue' )
+			->disableOriginalConstructor()
+			->setMethods( [ 'addErrorMsg', 'getCallable' ] )
+			->getMockForAbstractClass();
+
+		$dataValue->expects( $this->once() )
+			->method( 'getCallable' )
+			->will( $this->returnValue( function() use( $semanticData ) { return $semanticData; } ) );
+
+		$dataValue->expects( $this->atLeastOnce() )
+			->method( 'addErrorMsg' )
+			->with( $this->callback( function( $error ) use ( $expectedErrMsg ) {
+				return $this->checkConstraintError( $error, $expectedErrMsg );
+			} ) );
+
+		$instance = new MandatoryPropertiesConstraint();
+
+		$instance->checkConstraint( $constraint, $dataValue );
+
+		$this->assertTrue(
+			$instance->hasViolation()
+		);
+	}
+
+	public function testCheckConstraint_mandatory_properties_ThrowsException() {
+
+		$constraint = [
+			'mandatory_properties' => true
+		];
+
+		$instance = new MandatoryPropertiesConstraint();
+
+		$this->setExpectedException( '\RuntimeException' );
+		$instance->checkConstraint( $constraint, 'Foo' );
+	}
+
+	public function checkConstraintError( $error, $expectedErrMsg ) {
+
+		if ( strpos( $error->__toString(), $expectedErrMsg ) !== false ) {
+			return true;
+		}
+
+		return false;
+	}
+
+}

--- a/tests/phpunit/Unit/ConstraintFactoryTest.php
+++ b/tests/phpunit/Unit/ConstraintFactoryTest.php
@@ -142,6 +142,21 @@ class ConstraintFactoryTest extends \PHPUnit_Framework_TestCase {
 			'SMW\Constraint\Constraints\NonNegativeIntegerConstraint',
 			'\SMW\Constraint\Constraints\NonNegativeIntegerConstraint'
 		];
+
+		yield[
+			'SMW\Constraint\Constraints\SingleValueConstraint',
+			'\SMW\Constraint\Constraints\SingleValueConstraint'
+		];
+
+		yield[
+			'SMW\Constraint\Constraints\MustExistsConstraint',
+			'\SMW\Constraint\Constraints\MustExistsConstraint'
+		];
+
+		yield[
+			'SMW\Constraint\Constraints\MandatoryPropertiesConstraint',
+			'\SMW\Constraint\Constraints\MandatoryPropertiesConstraint'
+		];
 	}
 
 }

--- a/tests/phpunit/Unit/DataValues/ConstraintSchemaValueTest.php
+++ b/tests/phpunit/Unit/DataValues/ConstraintSchemaValueTest.php
@@ -1,0 +1,139 @@
+<?php
+
+namespace SMW\Tests\DataValues;
+
+use SMW\DataItemFactory;
+use SMW\DataValueFactory;
+use SMW\DataValues\ConstraintSchemaValue;
+use SMW\PropertySpecificationLookup;
+use SMW\DIWikiPage;
+use SMW\Tests\TestEnvironment;
+
+/**
+ * @covers \SMW\DataValues\ConstraintSchemaValue
+ * @group semantic-mediawiki
+ *
+ * @license GNU GPL v2+
+ * @since 3.1
+ *
+ * @author mwjames
+ */
+class ConstraintSchemaValueTest extends \PHPUnit_Framework_TestCase {
+
+	private $testEnvironment;
+	private $dataItemFactory;
+	private $propertySpecificationLookup;
+
+	protected function setUp() {
+		parent::setUp();
+
+		$this->testEnvironment = new TestEnvironment();
+		$this->dataItemFactory = new DataItemFactory();
+
+		$this->propertySpecificationLookup = $this->getMockBuilder( PropertySpecificationLookup::class )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$this->testEnvironment->registerObject( 'PropertySpecificationLookup', $this->propertySpecificationLookup );
+	}
+
+	protected function tearDown() {
+		$this->testEnvironment->tearDown();
+	}
+
+	public function testCanConstruct() {
+
+		$this->assertInstanceOf(
+			ConstraintSchemaValue::class,
+			new ConstraintSchemaValue( ConstraintSchemaValue::TYPE_ID, $this->propertySpecificationLookup )
+		);
+	}
+
+	public function testNoSchema() {
+
+		$this->propertySpecificationLookup->expects( $this->any() )
+			->method( 'getSpecification' )
+			->will( $this->returnValue( [] ) );
+
+		$instance = new ConstraintSchemaValue(
+			ConstraintSchemaValue::TYPE_ID,
+			$this->propertySpecificationLookup
+		);
+
+		$instance->setContextPage(
+			DIWikiPage::newFromText( 'Foo', SMW_NS_PROPERTY )
+		);
+
+		$instance->setProperty( $this->dataItemFactory->newDIProperty( 'Bar' ) );
+		$instance->setUserValue( 'Foo' );
+
+		$this->assertEmpty(
+			$instance->getErrors()
+		);
+	}
+
+	public function testInvalidSchemaType_PropertyNamespace() {
+
+		$data = json_encode(
+			[
+				'type' => 'CLASS_CONSTRAINT_SCHEMA'
+			]
+		);
+
+		$this->propertySpecificationLookup->expects( $this->once() )
+			->method( 'getSpecification' )
+			->with(
+				$this->anything(),
+				$this->equalTo( $this->dataItemFactory->newDIProperty( '_SCHEMA_DEF' ) ) )
+			->will( $this->returnValue( [ $this->dataItemFactory->newDIBlob( $data ) ] ) );
+
+		$instance = new ConstraintSchemaValue(
+			ConstraintSchemaValue::TYPE_ID,
+			$this->propertySpecificationLookup
+		);
+
+		$instance->setContextPage(
+			DIWikiPage::newFromText( 'Foo', SMW_NS_PROPERTY )
+		);
+
+		$instance->setUserValue( 'Foo' );
+
+		$this->assertContains(
+			'[2,"smw-datavalue-constraint-schema-property-invalid-type","Foo","PROPERTY_CONSTRAINT_SCHEMA"]',
+			implode(',', $instance->getErrors() )
+		);
+	}
+
+	public function testInvalidSchemaType_CategoryNamespace() {
+
+		$data = json_encode(
+			[
+				'type' => 'PROPERTY_CONSTRAINT_SCHEMA'
+			]
+		);
+
+		$this->propertySpecificationLookup->expects( $this->once() )
+			->method( 'getSpecification' )
+			->with(
+				$this->anything(),
+				$this->equalTo( $this->dataItemFactory->newDIProperty( '_SCHEMA_DEF' ) ) )
+			->will( $this->returnValue( [ $this->dataItemFactory->newDIBlob( $data ) ] ) );
+
+		$instance = new ConstraintSchemaValue(
+			ConstraintSchemaValue::TYPE_ID,
+			$this->propertySpecificationLookup
+		);
+
+		$instance->setContextPage(
+			DIWikiPage::newFromText( 'Foo', NS_CATEGORY )
+		);
+
+		$instance->setUserValue( 'Foo' );
+
+		$this->assertContains(
+			'[2,"smw-datavalue-constraint-schema-category-invalid-type","Foo","CLASS_CONSTRAINT_SCHEMA"]',
+			implode(',', $instance->getErrors() )
+		);
+	}
+
+}

--- a/tests/phpunit/Unit/ProcessingErrorMsgHandlerTest.php
+++ b/tests/phpunit/Unit/ProcessingErrorMsgHandlerTest.php
@@ -207,6 +207,43 @@ class ProcessingErrorMsgHandlerTest extends \PHPUnit_Framework_TestCase {
 		);
 	}
 
+	public function testGetErrorContainerFromDataValue_CategoryProperty() {
+
+		$instance = new ProcessingErrorMsgHandler(
+			DIWikiPage::newFromText( __METHOD__ )
+		);
+
+		$dataValue = $this->getMockBuilder( '\SMWDataValue' )
+			->disableOriginalConstructor()
+			->setMethods( [ 'getErrors', 'getProperty' ] )
+			->getMockForAbstractClass();
+
+		$dataValue->expects( $this->atLeastOnce() )
+			->method( 'getErrors' )
+			->will( $this->returnValue( [ 'Foo' ] ) );
+
+		$dataValue->expects( $this->atLeastOnce() )
+			->method( 'getProperty' )
+			->will( $this->returnValue( $this->dataItemFactory->newDIProperty( '_INST' ) ) );
+
+		$container = $instance->newErrorContainerFromDataValue( $dataValue );
+
+		$this->assertInstanceOf(
+			'\SMWDIContainer',
+			$container
+		);
+
+		$expected = [
+			'propertyCount' => 1,
+			'propertyKeys'  => [ '_ERRT' ],
+		];
+
+		$this->semanticDataValidator->assertThatPropertiesAreSet(
+			$expected,
+			$container->getSemanticData()
+		);
+	}
+
 	public function testGetErrorContainerFromDataValue_TypedError() {
 
 		$instance = new ProcessingErrorMsgHandler(

--- a/tests/phpunit/Utils/Validators/SemanticDataValidator.php
+++ b/tests/phpunit/Utils/Validators/SemanticDataValidator.php
@@ -406,6 +406,14 @@ class SemanticDataValidator extends \PHPUnit_Framework_Assert {
 		// Be more lenient towards value comparison by just eliminating a matched pair
 		foreach ( $expected['propertyValues'] as $key => $propertyValue ) {
 
+			if ( is_array( $propertyValue ) && isset( $propertyValue['serialization'] ) ) {
+				if ( $propertyValue['serialization'] === $valueSerialization ) {
+					unset( $expected['propertyValues'][$key] );
+				}
+
+				continue;
+			}
+
 			if ( is_bool( $value ) && $value === $propertyValue ) {
 				unset( $expected['propertyValues'][$key] );
 				continue;


### PR DESCRIPTION
This PR is made in reference to: #3746, #3829, #4032 

This PR addresses or contains:

- Adds the `CLASS_CONSTRAINT_SCHEMA` type and `mandatory_properties` constraint
- `p-1110.json` contains the integration test for `mandatory_properties`

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed
