### PR TITLE
Support `#` as formatting directive for no link, refs 1855, 4037

### DIFF
--- a/includes/datavalues/SMW_DV_WikiPage.php
+++ b/includes/datavalues/SMW_DV_WikiPage.php
@@ -274,7 +274,18 @@ class SMWWikiPageValue extends SMWDataValue {
 		if ( is_null( $linked ) || $linked === false ||
 			$this->m_outformat == '-' || !$this->isValid() ||
 			$this->m_caption === '' ) {
-			return $this->m_caption !== false ? $this->m_caption : $this->getWikiValue();
+			$text = $this->m_caption !== false ? $this->m_caption : $this->getWikiValue();
+
+			// #4037
+			if ( $this->linkAttributes !== [] ) {
+				$text = \Html::rawElement(
+					'span',
+					$this->linkAttributes,
+					$text
+				);
+			}
+
+			return $text;
 		}
 
 		$noImage = $this->getOption( self::NO_IMAGE, false );

--- a/src/MediaWiki/Hooks/InternalParseBeforeLinks.php
+++ b/src/MediaWiki/Hooks/InternalParseBeforeLinks.php
@@ -73,7 +73,7 @@ class InternalParseBeforeLinks extends HookHandler {
 
 		// #2209, #2370 Allow content to be parsed that contain [[SMW::off]]/[[SMW::on]]
 		// even in case of MediaWiki messages
-		if ( InTextAnnotationParser::hasMarker( $text ) ) {
+		if ( InTextAnnotationParser::hasMarker( $text ) || InTextAnnotationParser::hasPropertyLink( $text ) ) {
 			return true;
 		}
 

--- a/src/Query/PrintRequest/Formatter.php
+++ b/src/Query/PrintRequest/Formatter.php
@@ -42,6 +42,12 @@ class Formatter {
 
 	private static function getHTMLText( $printRequest, $linker = null ) {
 
+		$label = $printRequest->getLabel();
+
+		if ( \SMW\Parser\InTextAnnotationParser::hasPropertyLink( $label ) ) {
+			return \SMW\Message::get( [ 'smw-parse', $label ], \SMW\Message::PARSE );
+		}
+
 		$label = htmlspecialchars( $printRequest->getLabel() );
 
 		if ( $linker === null || $linker === false || $label === '' ) {

--- a/tests/phpunit/Integration/JSONScript/TestCases/p-0212.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/p-0212.json
@@ -26,6 +26,10 @@
 		{
 			"page": "Example/P0212/4",
 			"contents": "[[P106::@@@ko|WithCaption]]"
+		},
+		{
+			"page": "Example/P0212/5",
+			"contents": "[[P106::@@@ko|#]]"
 		}
 	],
 	"tests": [
@@ -62,7 +66,7 @@
 			"subject": "Example/P0212/3",
 			"assert-output": {
 				"to-contain": [
-					"title=\"Property:P106\">職業</a></span><span class=\"smwttcontent\">人物の職業。「専門分野」</span></span>&#160;<span title=\"P106\"><sup>ᵖ</sup>"
+					"<span class=\"smw-property\">.*title=\"Property:P106\">職業</a></span></span><span class=\"smwttcontent\">人物の職業。「専門分野」</span></span>&#160;<span title=\"P106\"><sup>ᵖ</sup>"
 				]
 			}
 		},
@@ -75,7 +79,7 @@
 			"subject": "Example/P0212/3",
 			"assert-output": {
 				"to-contain": [
-					"title=\"Property:P106\">職業</a></span><span class=\"smwttcontent\">人物の職業。「専門分野」</span></span>&#160;<span title=\"P106\"><sup>ᵖ</sup>"
+					"<span class=\"smw-property\">.*title=\"Property:P106\">職業</a></span></span><span class=\"smwttcontent\">人物の職業。「専門分野」</span></span>&#160;<span title=\"P106\"><sup>ᵖ</sup>"
 				]
 			}
 		},
@@ -85,7 +89,17 @@
 			"subject": "Example/P0212/4",
 			"assert-output": {
 				"to-contain": [
-					"title=\"Property:P106\">WithCaption</a></span><span class=\"smwttcontent\">대상 인물의 직업</span></span>"
+					"<span class=\"smw-property\">.*title=\"Property:P106\">WithCaption</a></span></span><span class=\"smwttcontent\">대상 인물의 직업</span></span>"
+				]
+			}
+		},
+		{
+			"type": "parser",
+			"about": "#4 (no link)",
+			"subject": "Example/P0212/5",
+			"assert-output": {
+				"to-contain": [
+					"<span class=\"smw-highlighter\" .* title=\"대상 인물의 직업\"><span class=\"smwtext\"><span class=\"smw-property nolink\">직업</span></span><span class=\"smwttcontent\">대상 인물의 직업</span></span>&#160;<span title=\"P106\"><sup>ᵖ</sup></span>"
 				]
 			}
 		}

--- a/tests/phpunit/Unit/Parser/InTextAnnotationParserTest.php
+++ b/tests/phpunit/Unit/Parser/InTextAnnotationParserTest.php
@@ -631,12 +631,26 @@ class InTextAnnotationParserTest extends \PHPUnit_Framework_TestCase {
 			],
 			'[[Foo::@@@]] [[Bar::@@@en|Foobar]]',
 			[
-				'resultText'     => $testEnvironment->replaceNamespaceWithLocalizedText( SMW_NS_PROPERTY, '[[:Property:Foo|Foo]] [[:Property:Bar|Foobar]]' ),
+				'resultText'     => $testEnvironment->replaceNamespaceWithLocalizedText( SMW_NS_PROPERTY, '<span class="smw-property">[[:Property:Foo|Foo]]</span> <span class="smw-property">[[:Property:Bar|Foobar]]</span>' ),
 				'propertyCount'  => 0
 			]
 		];
 
-		#14 [ ... ] in-text link
+		#14 @@@|# syntax (#4037)
+		$provider[] = [
+			NS_MAIN,
+			[
+				'smwgNamespacesWithSemanticLinks' => [ NS_MAIN => true ],
+				'smwgParserFeatures' => SMW_PARSER_INL_ERROR | SMW_PARSER_STRICT
+			],
+			'[[Foo::@@@|#]] [[Bar::@@@en|#]]',
+			[
+				'resultText'     => '<span class="smw-property nolink">Foo</span> <span class="smw-property nolink">Bar</span>',
+				'propertyCount'  => 0
+			]
+		];
+
+		#15 [ ... ] in-text link
 		$provider[] = [
 			NS_MAIN,
 			[
@@ -652,7 +666,7 @@ class InTextAnnotationParserTest extends \PHPUnit_Framework_TestCase {
 			]
 		];
 
-		#15 (#2671) external [] decode use
+		#16 (#2671) external [] decode use
 		$provider[] = [
 			NS_MAIN,
 			[


### PR DESCRIPTION
This PR is made in reference to: #4037

This PR addresses or contains:

- Defines `#` to describe a no link state in connection with `@@@` as in `[[Foo::@@@|#]`

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed

Fixes #4037