### PR TITLE
Add new `smwtable-clean` table CSS

### DIFF
--- a/res/smw/ext.smw.css
+++ b/res/smw/ext.smw.css
@@ -187,6 +187,7 @@ span.smwtlcomment {
 	font-style: italic;
 	padding: 5px;
 }
+
 .smwtable-striped tbody > tr:nth-child(even) {
    background-color: #f5f5f5;
 }
@@ -197,6 +198,50 @@ span.smwtlcomment {
 
 .smwtable-striped tbody > tr:hover {
 	background-color: #eee;
+}
+
+.smwtable-clean {
+	width: 100%;
+	max-width: 100%;
+	margin-bottom: 20px;
+	background-color: transparent;
+	border-spacing: 0px;
+}
+
+.smwtable-clean tr {
+border-top: 1px solid #dddddd;
+}
+
+.smwtable-clean th {
+	text-align: left;
+}
+
+.smwtable-clean td, .smwtable-clean th {
+	padding: 0;
+}
+
+.smwtable-clean tr > th {
+	padding: 8px !important;
+	line-height: 1.42857143;
+	vertical-align: top;
+	border-top: 1px solid #dddddd;
+	border-collapse: collapse;
+	border-spacing: 0;
+	text-align: center;
+	vertical-align: middle;
+}
+
+.smwtable-clean tr > td {
+	padding: 8px !important;
+	line-height: 1.42857143;
+	vertical-align: top;
+	border-top: 1px solid #dddddd;
+	border-collapse: collapse;
+	border-spacing: 0;
+}
+
+.smwtable-clean tbody > tr:nth-child(even) {
+	background-color: #f5f5f5;
 }
 
 div.smwhr hr {


### PR DESCRIPTION
This PR is made in reference to: #

This PR addresses or contains:

This PR includes:
- [ ] Tests (unit/integration)
- [ ] CI build passed

### Example

default (`sortable wikitable smwtable`)

![image](https://user-images.githubusercontent.com/1245473/58375649-40518280-7f47-11e9-948e-3d41588b7d2d.png)

`sortable smwtable-clean`

![image](https://user-images.githubusercontent.com/1245473/58375650-49daea80-7f47-11e9-9d73-707b1b71bd33.png)
