### PR TITLE
Add option to request as prefixed form

### DIFF
--- a/includes/datavalues/SMW_DV_WikiPage.php
+++ b/includes/datavalues/SMW_DV_WikiPage.php
@@ -47,7 +47,12 @@ class SMWWikiPageValue extends SMWDataValue {
 	/**
 	 * Whether to use the short form or not.
 	 */
-	const SHORT_FORM = 'short.form';
+	const SHORT_FORM = 'form/short';
+
+	/**
+	 * Whether to use the prefixed form or not.
+	 */
+	const PREFIXED_FORM = 'form/prefixed';
 
 	/**
 	 * Fragment text for user-specified title. Not stored, but kept for
@@ -466,6 +471,8 @@ class SMWWikiPageValue extends SMWDataValue {
 
 		if ( $this->getOption( self::SHORT_FORM, false ) ) {
 			$text = $this->getText();
+		} elseif ( $this->getOption( self::PREFIXED_FORM, false ) ) {
+			$text = $this->getPrefixedText();
 		} elseif ( in_array( $this->getTypeID(), [ '_wpp', '_wps' ] ) || $this->m_fixNamespace == NS_MAIN ) {
 			$text = $this->getPrefixedText();
 		} else {

--- a/src/DataValues/InfoLinksProvider.php
+++ b/src/DataValues/InfoLinksProvider.php
@@ -11,6 +11,7 @@ use SMWDataValue as DataValue;
 use SMWDataItem as DataItem;
 use SMWDIBlob as DIBlob;
 use SMWInfolink as Infolink;
+use SMWWikiPageValue as WikiPageValue;
 
 /**
  * @license GNU GPL v2+
@@ -152,6 +153,12 @@ class InfoLinksProvider {
 		// Avoid any localization when generating the value
 		$this->dataValue->setOutputFormat( '' );
 		$dataItem = $this->dataValue->getDataItem();
+
+		// For a subcategory we need the full prefixed form when
+		// generating a browse link
+		if ( $this->dataValue->getTypeID() === '__suc' ) {
+			$this->dataValue->setOption( WikiPageValue::PREFIXED_FORM, true );
+		}
 
 		$value = $this->dataValue->getWikiValue();
 		$property = $this->dataValue->getProperty();

--- a/tests/phpunit/Integration/JSONScript/ParserTestCaseProcessor.php
+++ b/tests/phpunit/Integration/JSONScript/ParserTestCaseProcessor.php
@@ -244,6 +244,10 @@ class ParserTestCaseProcessor extends \PHPUnit_Framework_TestCase {
 
 		$title = $subject->getTitle();
 
+		if ( $subject->getNamespace() === SMW_NS_PROPERTY ) {
+			$checkExists = false;
+		}
+
 		if ( $title === null ) {
 			throw new RuntimeException( 'Could not create Title object for subject page "' . $case['subject'] . '".' );
 		}

--- a/tests/phpunit/Integration/JSONScript/TestCases/p-1009.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/p-1009.json
@@ -1,0 +1,76 @@
+{
+	"description": "Test property page, subcategory of",
+	"setup": [
+		{
+			"namespace": "NS_CATEGORY",
+			"page": "P1009",
+			"contents": ""
+		},
+		{
+			"namespace": "NS_CATEGORY",
+			"page": "P1009/1",
+			"contents": "[[Category:P1009]]"
+		}
+	],
+	"beforeTest": {
+		"job-run": [
+			"smw.changePropagationDispatch",
+			"smw.changePropagationClassUpdate",
+			"smw.changePropagationUpdate"
+		]
+	},
+	"tests": [
+		{
+			"type": "parser",
+			"about": "#0 (using predefined property, forced type URL)",
+			"namespace": "NS_CATEGORY",
+			"subject": "P1009/1",
+			"store": {
+				"clear-cache": true
+			},
+			"assert-store": {
+				"semantic-data": {
+					"strictPropertyValueMatch": false,
+					"propertyCount": 3,
+					"propertyKeys": [
+						"_SUBC",
+						"_MDAT",
+						"_SKEY"
+					]
+				}
+			}
+		},
+		{
+			"type": "parser",
+			"about": "#0 (shows prefixed browse links to a category)",
+			"namespace": "SMW_NS_PROPERTY",
+			"subject": "Subcategory of",
+			"assert-output": {
+				"onPageView": {
+					"parameters": {}
+				},
+				"to-contain": [
+					"<span class=\"smwbrowse\"><a href=\".*Special:Browse/:Category:P1009\" title=\"Special:Browse/:Category:P1009\">+</a></span>"
+				]
+			}
+		}
+	],
+	"settings": {
+		"wgContLang": "en",
+		"wgLang": "en",
+		"smwgPageSpecialProperties": [
+			"_MDAT"
+		],
+		"smwgQSubcategoryDepth": 10,
+		"smwgNamespacesWithSemanticLinks": {
+			"NS_MAIN": true,
+			"SMW_NS_PROPERTY": true,
+			"NS_CATEGORY": true
+		}
+	},
+	"meta": {
+		"version": "2",
+		"is-incomplete": false,
+		"debug": false
+	}
+}


### PR DESCRIPTION
This PR is made in reference to: #

This PR addresses or contains:

- Makes sure that the browsing link for a `Subcategory of` uses the prefixed form (== including the namespace)

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed
