### PR TITLE
Isolate `ItemFetcher`, refs 3722

### DIFF
--- a/includes/storage/SMW_QueryResult.php
+++ b/includes/storage/SMW_QueryResult.php
@@ -4,6 +4,8 @@ use SMW\Query\Excerpts;
 use SMW\Query\PrintRequest;
 use SMW\Query\QueryLinker;
 use SMW\Query\Result\ResolverJournal;
+use SMW\Query\Result\ResultFieldMatchFinder;
+use SMW\Query\Result\ItemFetcher;
 use SMW\Query\ScoreSet;
 use SMW\SerializerFactory;
 
@@ -78,6 +80,11 @@ class SMWQueryResult {
 	private $resolverJournal;
 
 	/**
+	 * @var ResultFieldMatchFinder
+	 */
+	private $resultFieldMatchFinder;
+
+	/**
 	 * @var integer
 	 */
 	private $serializer_version = 2;
@@ -112,6 +119,24 @@ class SMWQueryResult {
 		$this->mQuery = $query;
 		$this->mStore = $store;
 		$this->resolverJournal = new ResolverJournal();
+
+		$itemFetcher = new ItemFetcher( $store, $this->mResults );
+
+		// Init the instance here so the value cache is shared and hereby avoids
+		// a static declaration
+		$this->resultFieldMatchFinder = new ResultFieldMatchFinder(
+			$store,
+			$itemFetcher
+		);
+	}
+
+	/**
+	 * @since 3.1
+	 *
+	 * @return ResultFieldMatchFinder
+	 */
+	public function getResultFieldMatchFinder() {
+		return $this->resultFieldMatchFinder;
 	}
 
 	/**

--- a/includes/storage/SMW_ResultArray.php
+++ b/includes/storage/SMW_ResultArray.php
@@ -75,7 +75,8 @@ class SMWResultArray {
 		$resultArray = new self(
 			$resultPage,
 			$printRequest,
-			$queryResult->getStore()
+			$queryResult->getStore(),
+			$queryResult->getResultFieldMatchFinder()
 		);
 
 		$query = $queryResult->getQuery();
@@ -92,15 +93,20 @@ class SMWResultArray {
 	 * @param SMWDIWikiPage $resultPage
 	 * @param PrintRequest $printRequest
 	 * @param SMWStore $store
+	 * @param ResultFieldMatchFinder|null $resultFieldMatchFinde
 	 */
-	public function __construct( SMWDIWikiPage $resultPage, PrintRequest $printRequest, SMWStore $store ) {
+	public function __construct( SMWDIWikiPage $resultPage, PrintRequest $printRequest, SMWStore $store, ResultFieldMatchFinder $resultFieldMatchFinder = null ) {
 		$this->mResult = $resultPage;
 		$this->mPrintRequest = $printRequest;
 		$this->mStore = $store;
 		$this->mContent = false;
 
 		// FIXME 3.0; Inject the object
-		$this->resultFieldMatchFinder = new ResultFieldMatchFinder( $store, $printRequest );
+		$this->resultFieldMatchFinder = $resultFieldMatchFinder;
+
+		if ( $this->resultFieldMatchFinder === null ) {
+			$this->resultFieldMatchFinder = new ResultFieldMatchFinder( $store );
+		}
 	}
 
 	/**
@@ -303,6 +309,10 @@ class SMWResultArray {
 		if ( $this->mContent !== false ) {
 			return;
 		}
+
+		$this->resultFieldMatchFinder->setPrintRequest(
+			$this->mPrintRequest
+		);
 
 		$this->resultFieldMatchFinder->setQueryToken(
 			$this->queryToken

--- a/src/Query/Result/ItemFetcher.php
+++ b/src/Query/Result/ItemFetcher.php
@@ -1,0 +1,172 @@
+<?php
+
+namespace SMW\Query\Result;
+
+use SMW\DataValueFactory;
+use SMW\DataValues\MonolingualTextValue;
+use SMW\DIProperty;
+use SMW\DIWikiPage;
+use SMW\Parser\InTextAnnotationParser;
+use SMW\Query\PrintRequest;
+use SMW\Query\QueryToken;
+use SMW\RequestOptions;
+use SMW\Store;
+use SMWDataItem as DataItem;
+use SMWDIBlob as DIBlob;
+use SMWDIBoolean as DIBoolean;
+
+/**
+ * @license GNU GPL v2+
+ * @since 3.1
+ *
+ * @author mwjames
+ */
+class ItemFetcher {
+
+	/**
+	 * @var Store
+	 */
+	private $store;
+
+	/**
+	 * @var prefetchCache
+	 */
+	private $prefetchCache;
+
+	/**
+	 * @var PrintRequest
+	 */
+	private $printRequest;
+
+	/**
+	 * @var QueryToken
+	 */
+	private $queryToken;
+
+	/**
+	 * @var DIWikiPage[]
+	 */
+	private $dataItems = [];
+
+	/**
+	 * @var boolean
+	 */
+	private $prefetch = false;
+
+	/**
+	 * @since 3.1
+	 *
+	 * @param Store $store
+	 */
+	public function __construct( Store $store, array $dataItems = [] ) {
+		$this->store = $store;
+		$this->dataItems = $dataItems;
+	}
+
+	/**
+	 * @since 3.1
+	 *
+	 * @param PrintRequest $printRequest
+	 */
+	public function setPrintRequest( PrintRequest $printRequest ) {
+		$this->printRequest = $printRequest;
+	}
+
+	/**
+	 * @since 3.1
+	 *
+	 * @param QueryToken|null $queryToken
+	 */
+	public function setQueryToken( QueryToken $queryToken = null ) {
+		$this->queryToken = $queryToken;
+	}
+
+	/**
+	 * @since 3.1
+	 *
+	 * @param DataItem|null|false $dataItem
+	 */
+	public function highlightTokens( $dataItem ) {
+
+		if ( !$dataItem instanceof DIBlob || !$this->printRequest instanceof PrintRequest ) {
+			return $dataItem;
+		}
+
+		$type = $this->printRequest->getTypeID();
+
+		// Avoid `_cod`, `_eid` or similar types that use the DIBlob as storage
+		// object
+		if ( $type !== '_txt' && strpos( $type, '_rec' ) === false ) {
+			return $dataItem;
+		}
+
+		$outputFormat = $this->printRequest->getOutputFormat();
+
+		// #2325
+		// Output format marked with -raw are allowed to retain a possible [[ :: ]]
+		// annotation
+		// '-ia' is deprecated use `-raw`
+		if ( strpos( $outputFormat, '-raw' ) !== false || strpos( $outputFormat, '-ia' ) !== false ) {
+			return $dataItem;
+		}
+
+		// #1314
+		$string = InTextAnnotationParser::removeAnnotation(
+			$dataItem->getString()
+		);
+
+		// #2253
+		if ( $this->queryToken !== null ) {
+			$string = $this->queryToken->highlight( $string );
+		}
+
+		return new DIBlob( $string );
+	}
+
+	/**
+	 * @since 3.1
+	 *
+	 * @param array $dataItems
+	 * @param DIProperty $property
+	 * @param RequestOptions $requestOptions
+	 *
+	 * @return array
+	 */
+	public function fetch( array $dataItems, DIProperty $property, RequestOptions $requestOptions ) {
+		return $this->legacyFetch( $dataItems, $property, $requestOptions );
+	}
+
+	private function legacyFetch( $dataItems, $property, $requestOptions ) {
+
+		$propertyValues = [];
+		$requestOptions->setOption( RequestOptions::CONDITION_CONSTRAINT_RESULT, false );
+		$requestOptions->setCaller( __METHOD__ );
+
+		foreach ( $dataItems as $dataItem ) {
+
+			if ( !$dataItem instanceof DIWikiPage ) {
+				continue;
+			}
+
+			$pv = $this->store->getPropertyValues(
+				$dataItem,
+				$property,
+				$requestOptions
+			);
+
+			if ( $pv instanceof \Iterator ) {
+				$pv = iterator_to_array( $pv );
+			}
+
+			$propertyValues = array_merge( $propertyValues, $pv );
+			unset( $pv );
+		}
+
+		array_walk( $propertyValues, function( &$dataItem ) {
+			$dataItem = $this->highlightTokens( $dataItem );
+		} );
+
+		return $propertyValues;
+	}
+
+}

--- a/src/Query/Result/Restrictions.php
+++ b/src/Query/Result/Restrictions.php
@@ -1,0 +1,91 @@
+<?php
+
+namespace SMW\Query\Result;
+
+use SMW\Query\PrintRequest;
+use SMW\DataTypeRegistry;
+use SMWDataItem as DataItem;
+
+/**
+ * @license GNU GPL v2+
+ * @since 3.1
+ *
+ * @author mwjames
+ */
+class Restrictions {
+
+	/**
+	 * @since 3.1
+	 *
+	 * @param  PrintRequest $printRequest
+	 * @param  DataItem[] $content
+	 *
+	 * @return []
+	 */
+	public static function applySortRestriction( PrintRequest $printRequest, array $content ) {
+
+		if ( $content === [] ) {
+			return $content;
+		}
+
+		$order = strtolower( $printRequest->getParameter( 'order' ) );
+
+		$dataItemType = DataTypeRegistry::getInstance()->getDataItemByType(
+			$printRequest->getTypeID()
+		);
+
+		$flag = SORT_LOCALE_STRING;
+
+		if ( $dataItemType === DataItem::TYPE_NUMBER ) {
+			$flag = SORT_NUMERIC;
+		}
+
+		// SORT_NATURAL is selected on n-asc, n-desc
+		if ( strpos( $order, 'n-' ) !== false ) {
+			$flag = SORT_NATURAL;
+		}
+
+		$sortres = [];
+
+		foreach ( $content as $di ) {
+			$sortres[] = $di->getSortKey();
+		}
+
+		if ( $order === 'asc' || $order === 'n-asc' ) {
+			asort( $sortres, $flag );
+		} else {
+			arsort( $sortres, $flag );
+		}
+
+		$newres = [];
+		$i = 0;
+
+		foreach ( $sortres as $key => $value ) {
+			$newres[] = $content[$key];
+			$i++;
+		}
+
+		return $newres;
+	}
+
+	/**
+	 * @since 3.1
+	 *
+	 * @param  PrintRequest $printRequest
+	 * @param  DataItem[] $content
+	 *
+	 * @return []
+	 */
+	public static function applyLimitRestriction( PrintRequest $printRequest, array $content ) {
+
+		$limit = (int)$printRequest->getParameter( 'limit' );
+		$offset = (int)$printRequest->getParameter( 'offset' );
+
+		if ( $printRequest->getParameter( 'limit' ) !== false ) {
+			$content = array_slice( $content, $offset, $limit );
+		}
+
+		return $content;
+	}
+
+}

--- a/src/Query/Result/ResultFieldMatchFinder.php
+++ b/src/Query/Result/ResultFieldMatchFinder.php
@@ -44,6 +44,16 @@ class ResultFieldMatchFinder {
 	private $queryToken;
 
 	/**
+	 * @var DIWikiPage[]
+	 */
+	private $dataItems = [];
+
+	/**
+	 * @var ItemFetcher
+	 */
+	private $itemFetcher;
+
+	/**
 	 * @var boolean|array
 	 */
 	private static $catCacheObj = false;
@@ -59,9 +69,24 @@ class ResultFieldMatchFinder {
 	 * @param Store $store
 	 * @param PrintRequest $printRequest
 	 */
-	public function __construct( Store $store, PrintRequest $printRequest ) {
-		$this->printRequest = $printRequest;
+	public function __construct( Store $store, ItemFetcher $itemFetcher = null, PrintRequest $printRequest = null ) {
 		$this->store = $store;
+		$this->printRequest = $printRequest;
+		$this->itemFetcher = $itemFetcher;
+
+		if ( $this->itemFetcher === null ) {
+			$this->itemFetcher = new ItemFetcher( $store );
+		}
+	}
+
+	/**
+	 * @since 3.1
+	 *
+	 * @param PrintRequest $printRequest
+	 */
+	public function setPrintRequest( PrintRequest $printRequest ) {
+		$this->printRequest = $printRequest;
+		$this->itemFetcher->setPrintRequest( $this->printRequest );
 	}
 
 	/**
@@ -80,6 +105,8 @@ class ResultFieldMatchFinder {
 		$this->queryToken->setOutputFormat(
 			$this->printRequest->getOutputFormat()
 		);
+
+		$this->itemFetcher->setQueryToken( $this->queryToken );
 	}
 
 	/**
@@ -92,6 +119,10 @@ class ResultFieldMatchFinder {
 	public function findAndMatch( DataItem $dataItem ) {
 
 		$content = [];
+
+		if ( $this->printRequest === null ) {
+			throw new RuntimeException( "Missing a `PrintRequest` instance!" );
+		}
 
 		// Request the current element (page in result set).
 		// The limit is ignored here.
@@ -162,7 +193,8 @@ class ResultFieldMatchFinder {
 		$order = trim( $this->printRequest->getParameter( 'order' ) );
 		$options = null;
 
-		// Important: use "!=" for order, since trim() above does never return "false", use "!==" for limit since "0" is meaningful here.
+		// Important: use "!=" for order, since trim() above does never return
+		// "false", use "!==" for limit since "0" is meaningful here.
 		if ( ( $limit !== false ) || ( $order != false ) ) {
 			$options = new RequestOptions();
 
@@ -190,7 +222,7 @@ class ResultFieldMatchFinder {
 
 	private function getResultsForProperty( $dataItem ) {
 
-		$content = $this->getResultContent(
+		$content = $this->fetchContent(
 			$dataItem
 		);
 
@@ -229,15 +261,25 @@ class ResultFieldMatchFinder {
 				// Return the text representation without a language reference
 				// (tag) since the value has been filtered hence only matches
 				// that language
-				$newcontent[] = $this->applyContentManipulation( $textValue->getDataItem() );
+				$newcontent[] = $this->itemFetcher->highlightTokens( $textValue->getDataItem() );
 
 				// Set the index so ResultArray::getNextDataValue can
 				// find the correct PropertyDataItem (_TEXT;_LCODE) position
 				// to match the DI
 				$this->printRequest->setParameter( 'index', 1 );
 			} elseif ( $lang === false && $index !== false && ( $dataItemByRecord = $multiValue->getDataItemByIndex( $index ) ) !== null ) {
-				$newcontent[] = $this->applyContentManipulation( $dataItemByRecord );
+				$newcontent[] = $this->itemFetcher->highlightTokens( $dataItemByRecord );
 			}
+		}
+
+		// Reorder since only here it is possible to get the value according to
+		// the index
+		if ( $this->printRequest->getParameter( 'order' ) !== false ) {
+			$newcontent = Restrictions::applySortRestriction( $this->printRequest, $newcontent );
+		}
+
+		if ( $this->printRequest->getParameter( 'limit' ) !== false ) {
+			$newcontent = Restrictions::applyLimitRestriction( $this->printRequest, $newcontent );
 		}
 
 		$content = $newcontent;
@@ -250,7 +292,7 @@ class ResultFieldMatchFinder {
 		return strpos( $this->printRequest->getTypeID(), '_rec' ) !== false && $this->printRequest->getParameter( $parameter ) !== false;
 	}
 
-	private function getResultContent( DataItem $dataItem ) {
+	private function fetchContent( DataItem $dataItem ) {
 
 		$dataValue = $this->printRequest->getData();
 		$dataItems = [ $dataItem ];
@@ -258,6 +300,17 @@ class ResultFieldMatchFinder {
 		if ( !$dataValue->isValid() ) {
 			return [];
 		}
+
+		$requestOptions = $this->getRequestOptions();
+
+		if ( $requestOptions === null ) {
+			$requestOptions = new RequestOptions();
+			$requestOptions->conditionConstraint = true;
+		} else {
+			$requestOptions->setOption( RequestOptions::CONDITION_CONSTRAINT_RESULT, true );
+		}
+
+		$requestOptions->isChain = false;
 
 		// If it is a chain then try to find a connected DIWikiPage subject that
 		// matches the property on the chained PrintRequest.
@@ -268,10 +321,11 @@ class ResultFieldMatchFinder {
 		// for `Has page` and try to match a Number annotation on the results
 		// retrieved from `Has page`.
 		if ( $this->printRequest->isMode( PrintRequest::PRINT_CHAIN ) ) {
+			$requestOptions->isChain = $dataValue->getDataItem()->getString();
 
 			// Output of the previous iteration is the input for the next iteration
 			foreach ( $dataValue->getPropertyChainValues() as $pv ) {
-				$dataItems = $this->doFetchPropertyValues( $dataItems, $pv );
+				$dataItems = $this->itemFetcher->fetch( $dataItems, $pv->getDataItem(), $requestOptions );
 
 				// If the results return empty then it means that for this element
 				// the chain has no matchable items hence we stop
@@ -283,75 +337,26 @@ class ResultFieldMatchFinder {
 			$dataValue = $dataValue->getLastPropertyChainValue();
 		}
 
-		return $this->doFetchPropertyValues( $dataItems, $dataValue );
-	}
-
-	private function doFetchPropertyValues( $dataItems, $dataValue ) {
-
-		$propertyValues = [];
-
-		foreach ( $dataItems as $dataItem ) {
-
-			if ( !$dataItem instanceof DIWikiPage ) {
-				continue;
-			}
-
-			$pv = $this->store->getPropertyValues(
-				$dataItem,
-				$dataValue->getDataItem(),
-				$this->getRequestOptions()
-			);
-
-			if ( $pv instanceof \Iterator ) {
-				$pv = iterator_to_array( $pv );
-			}
-
-			$propertyValues = array_merge( $propertyValues, $pv );
-			unset( $pv );
-		}
-
-		array_walk( $propertyValues, function( &$dataItem ) {
-			$dataItem = $this->applyContentManipulation( $dataItem );
-		} );
-
-		return $propertyValues;
-	}
-
-	private function applyContentManipulation( $dataItem ) {
-
-		if ( !$dataItem instanceof DIBlob ) {
-			return $dataItem;
-		}
-
-		$type = $this->printRequest->getTypeID();
-
-		// Avoid `_cod`, `_eid` or similar types that use the DIBlob as storage
-		// object
-		if ( $type !== '_txt' && strpos( $type, '_rec' ) === false ) {
-			return $dataItem;
-		}
-
-		$outputFormat = $this->printRequest->getOutputFormat();
-
-		// #2325
-		// Output format marked with -raw are allowed to retain a possible [[ :: ]]
-		// annotation
-		// '-ia' is deprecated use `-raw`
-		if ( strpos( $outputFormat, '-raw' ) !== false || strpos( $outputFormat, '-ia' ) !== false ) {
-			return $dataItem;
-		}
-
-		// #1314
-		$string = InTextAnnotationParser::removeAnnotation(
-			$dataItem->getString()
+		$content = $this->itemFetcher->fetch(
+			$dataItems,
+			$dataValue->getDataItem(),
+			$requestOptions
 		);
 
-		// #2253
-		if ( $this->queryToken !== null ) {
-			$string = $this->queryToken->highlight( $string );
+		$isRecord = strpos( $this->printRequest->getTypeID(), '_rec' ) !== false;
+
+		if ( $this->printRequest->getParameter( 'order' ) !== false ) {
+			$content = Restrictions::applySortRestriction( $this->printRequest, $content );
 		}
 
-		return new DIBlob( $string );
+		// Limit for records are applied later as it requires to find the value
+		// representation first (and sort on those values instead of the record/subobject
+		// reference)
+		if ( $this->printRequest->getParameter( 'limit' ) !== false && !$isRecord ) {
+			$content = Restrictions::applyLimitRestriction( $this->printRequest, $content );
+		}
+
+		return $content;
 	}
 
 }

--- a/tests/phpunit/Integration/JSONScript/TestCases/q-0604.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/q-0604.json
@@ -75,7 +75,7 @@
 					},
 					{
 						"property": "PropertyToBeRedirected",
-						"value": "PageValueToBeRedirected"
+						"value": "PageRedirectTarget"
 					}
 				]
 			}
@@ -99,11 +99,11 @@
 				"datavalues": [
 					{
 						"property": "Has secondPage",
-						"value": "PageValueToBeRedirected"
+						"value": "PageRedirectTarget"
 					},
 					{
 						"property": "Has secondPage",
-						"value": "PageValueToBeRedirected"
+						"value": "PageRedirectTarget"
 					}
 				]
 			}

--- a/tests/phpunit/Integration/JSONScript/TestCases/q-0701.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/q-0701.json
@@ -61,7 +61,7 @@
 				"datavalues": [
 					{
 						"property": "Has url",
-						"value": "http://acme.test/api?query=%21_:%3B@%2A_#Foo&=_-3DBar"
+						"value": "http://acme.test/api?query=!_:;@*_#Foo&=_-3DBar"
 					}
 				]
 			}
@@ -154,7 +154,7 @@
 				"datavalues": [
 					{
 						"property": "Has url",
-						"value": "http://example.org/%E3%82%88%E3%81%86%E3%81%93%E3%81%9D#-%7B%7D"
+						"value": "http://example.org/ようこそ#-{}"
 					}
 				]
 			}

--- a/tests/phpunit/Integration/JSONScript/TestCases/q-0704.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/q-0704.json
@@ -34,7 +34,7 @@
 				"datavalues": [
 					{
 						"property": "Has url",
-						"value": "http://example.org/TBgcHiQBTvpV3XkFiRpMcV1KQoZvQXFyiQUQMM2RoYUyJaRoSyKnsQTWwia3HATd4YVmd8BZgkL2LfL0Q6rP5E90A4IuV6uKdYjL3nxZvx0pbc3tbxwa6jMW1JDNxusaKQ52ftRS7DCEY1IPTRZnuRMLPgWYwLOsEAebOsxD7BBL9IK3Z2Osfh9s0FC1SUwCVdKcLkBgurXKGi99s61qnAU2zWFXBUCEzID6533LeaHCBKW8%5C/%5Ci2BgTK2tv65LHO6zB-larger%&%60%5EThan255%C3%B6/%C3%A4/%C3%BC/%C3%A8/%C3%A9"
+						"value": "http://example.org/TBgcHiQBTvpV3XkFiRpMcV1KQoZvQXFyiQUQMM2RoYUyJaRoSyKnsQTWwia3HATd4YVmd8BZgkL2LfL0Q6rP5E90A4IuV6uKdYjL3nxZvx0pbc3tbxwa6jMW1JDNxusaKQ52ftRS7DCEY1IPTRZnuRMLPgWYwLOsEAebOsxD7BBL9IK3Z2Osfh9s0FC1SUwCVdKcLkBgurXKGi99s61qnAU2zWFXBUCEzID6533LeaHCBKW8\\/\\i2BgTK2tv65LHO6zB-larger%&`^Than255ö/ä/ü/è/é"
 					}
 				]
 			}

--- a/tests/phpunit/Unit/Query/Result/ItemFetcherTest.php
+++ b/tests/phpunit/Unit/Query/Result/ItemFetcherTest.php
@@ -1,0 +1,84 @@
+<?php
+
+namespace SMW\Tests\Query\Result;
+
+use SMW\DataItemFactory;
+use SMW\Query\Result\ItemFetcher;
+
+/**
+ * @covers SMW\Query\Result\ItemFetcher
+ * @group semantic-mediawiki
+ *
+ * @license GNU GPL v2+
+ * @since 3.1
+ *
+ * @author mwjames
+ */
+class ItemFetcherTest extends \PHPUnit_Framework_TestCase {
+
+	private $dataItemFactory;
+	private $store;
+	private $requestOptions;
+
+	protected function setUp() {
+		parent::setUp();
+		$this->dataItemFactory = new DataItemFactory();
+
+		$this->store = $this->getMockBuilder( '\SMW\Store' )
+			->disableOriginalConstructor()
+			->getMockForAbstractClass();
+
+		$this->requestOptions = $this->getMockBuilder( '\SMW\RequestOptions' )
+			->disableOriginalConstructor()
+			->getMock();
+	}
+
+	public function testCanConstruct() {
+
+		$this->assertInstanceOf(
+			ItemFetcher::class,
+			new ItemFetcher( $this->store )
+		);
+	}
+
+	public function testHighlightTokens() {
+
+		$dataItem = $this->dataItemFactory->newDIWikiPage( 'Foo' );
+
+		$instance = new ItemFetcher(
+			$this->store
+		);
+
+		$this->assertEquals(
+			$dataItem,
+			$instance->highlightTokens( $dataItem )
+		);
+	}
+
+	public function testFetchFromLegacy() {
+
+		$dataItem = $this->dataItemFactory->newDIWikiPage( 'Foo' );
+		$property = $this->dataItemFactory->newDIProperty( 'Bar' );
+
+		$expected = [
+			$this->dataItemFactory->newDIWikiPage( 'Foobar' )
+		];
+
+		$this->store->expects( $this->once() )
+			->method( 'getPropertyValues' )
+			->with(
+				$this->equalTo( $dataItem ),
+				$this->equalTo( $property ) )
+			->will( $this->returnValue( $expected ) );
+
+		$instance = new ItemFetcher(
+			$this->store
+		);
+
+		$this->assertEquals(
+			$expected,
+			$instance->fetch( [ $dataItem ], $property, $this->requestOptions )
+		);
+	}
+
+}

--- a/tests/phpunit/Unit/Query/Result/RestrictionsTest.php
+++ b/tests/phpunit/Unit/Query/Result/RestrictionsTest.php
@@ -1,0 +1,98 @@
+<?php
+
+namespace SMW\Tests\Query\Result;
+
+use SMW\DataItemFactory;
+use SMW\Query\Result\Restrictions;
+
+/**
+ * @covers SMW\Query\Result\Restrictions
+ * @group semantic-mediawiki
+ *
+ * @license GNU GPL v2+
+ * @since 3.1
+ *
+ * @author mwjames
+ */
+class RestrictionsTest extends \PHPUnit_Framework_TestCase {
+
+	private $dataItemFactory;
+	private $store;
+	private $printRequest;
+
+	protected function setUp() {
+		parent::setUp();
+		$this->dataItemFactory = new DataItemFactory();
+
+		$this->printRequest = $this->getMockBuilder( '\SMW\Query\PrintRequest' )
+			->disableOriginalConstructor()
+			->getMock();
+	}
+
+	public function testCanConstruct() {
+
+		$this->assertInstanceOf(
+			Restrictions::class,
+			new Restrictions()
+		);
+	}
+
+	public function testApplyLimitRestriction() {
+
+		$this->printRequest->expects( $this->at( 0 ) )
+			->method( 'getParameter' )
+			->with( $this->equalTo( 'limit' ) )
+			->will( $this->returnValue( 2 ) );
+
+		$this->printRequest->expects( $this->at( 1 ) )
+			->method( 'getParameter' )
+			->with( $this->equalTo( 'offset' ) )
+			->will( $this->returnValue( 1 ) );
+
+		$content = [
+			$this->dataItemFactory->newDIWikiPage( 'Foo' ),
+			$this->dataItemFactory->newDIWikiPage( 'Bar' ),
+			$this->dataItemFactory->newDIWikiPage( 'Foobar' )
+		];
+
+		$expected = [
+			$this->dataItemFactory->newDIWikiPage( 'Bar' ),
+			$this->dataItemFactory->newDIWikiPage( 'Foobar' )
+		];
+
+		$this->assertEquals(
+			$expected,
+			Restrictions::applyLimitRestriction( $this->printRequest, $content )
+		);
+	}
+
+	public function testApplySortRestriction() {
+
+		$this->printRequest->expects( $this->at( 0 ) )
+			->method( 'getParameter' )
+			->with( $this->equalTo( 'order' ) )
+			->will( $this->returnValue( 'desc' ) );
+
+		$content = [
+			$this->dataItemFactory->newDIWikiPage( 'Foo' ),
+			$this->dataItemFactory->newDIWikiPage( 'Bar' ),
+			$this->dataItemFactory->newDIWikiPage( 'Yoobar' )
+		];
+
+		$expected = [
+			$this->dataItemFactory->newDIWikiPage( 'Yoobar' ),
+			$this->dataItemFactory->newDIWikiPage( 'Foo' ),
+			$this->dataItemFactory->newDIWikiPage( 'Bar' ),
+		];
+
+		foreach ( $expected as $di ) {
+			$di->getSortKey();
+		}
+
+		$this->assertEquals(
+			$expected,
+			Restrictions::applySortRestriction( $this->printRequest, $content )
+		);
+	}
+
+}

--- a/tests/phpunit/Unit/Query/Result/ResultFieldMatchFinderTest.php
+++ b/tests/phpunit/Unit/Query/Result/ResultFieldMatchFinderTest.php
@@ -20,46 +20,46 @@ class ResultFieldMatchFinderTest extends \PHPUnit_Framework_TestCase {
 
 	private $dataItemFactory;
 	private $dataValueFactory;
+	private $store;
+	private $itemFetcher;
+	private $printRequest;
 
 	protected function setUp() {
 		parent::setUp();
 		$this->dataItemFactory = new DataItemFactory();
 		$this->dataValueFactory = DataValueFactory::getInstance();
+
+		$this->store = $this->getMockBuilder( '\SMW\Store' )
+			->disableOriginalConstructor()
+			->getMockForAbstractClass();
+
+		$this->itemFetcher = $this->getMockBuilder( '\SMW\Query\Result\ItemFetcher' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$this->printRequest = $this->getMockBuilder( '\SMW\Query\PrintRequest' )
+			->disableOriginalConstructor()
+			->getMock();
 	}
 
 	public function testCanConstruct() {
 
-		$store = $this->getMockBuilder( '\SMW\Store' )
-			->disableOriginalConstructor()
-			->getMockForAbstractClass();
-
-		$printRequest = $this->getMockBuilder( '\SMW\Query\PrintRequest' )
-			->disableOriginalConstructor()
-			->getMock();
-
 		$this->assertInstanceOf(
-			'SMW\Query\Result\ResultFieldMatchFinder',
-			new ResultFieldMatchFinder( $store, $printRequest )
+			ResultFieldMatchFinder::class,
+			new ResultFieldMatchFinder( $this->store, $this->itemFetcher, $this->printRequest )
 		);
 	}
 
 	public function testGetRequestOptions() {
 
-		$store = $this->getMockBuilder( '\SMW\Store' )
-			->disableOriginalConstructor()
-			->getMockForAbstractClass();
-
-		$printRequest = $this->getMockBuilder( '\SMW\Query\PrintRequest' )
-			->disableOriginalConstructor()
-			->getMock();
-
-		$printRequest->expects( $this->any() )
+		$this->printRequest->expects( $this->any() )
 			->method( 'getParameter' )
 			->will( $this->returnValue( 42 ) );
 
 		$instance = new ResultFieldMatchFinder(
-			$store,
-			$printRequest
+			$this->store,
+			$this->itemFetcher,
+			$this->printRequest
 		);
 
 		$this->assertInstanceOf(
@@ -72,22 +72,15 @@ class ResultFieldMatchFinderTest extends \PHPUnit_Framework_TestCase {
 
 		$dataItem = $this->dataItemFactory->newDIWikiPage( 'Foo' );
 
-		$store = $this->getMockBuilder( '\SMW\Store' )
-			->disableOriginalConstructor()
-			->getMockForAbstractClass();
-
-		$printRequest = $this->getMockBuilder( '\SMW\Query\PrintRequest' )
-			->disableOriginalConstructor()
-			->getMock();
-
-		$printRequest->expects( $this->any() )
+		$this->printRequest->expects( $this->any() )
 			->method( 'isMode' )
 			->with($this->equalTo( PrintRequest::PRINT_THIS ) )
 			->will( $this->returnValue( true ) );
 
 		$instance = new ResultFieldMatchFinder(
-			$store,
-			$printRequest
+			$this->store,
+			$this->itemFetcher,
+			$this->printRequest
 		);
 
 		$this->assertEquals(
@@ -101,29 +94,22 @@ class ResultFieldMatchFinderTest extends \PHPUnit_Framework_TestCase {
 		$dataItem = $this->dataItemFactory->newDIWikiPage( 'Foo' );
 		$expected = $this->dataItemFactory->newDIWikiPage( __METHOD__ );
 
-		$store = $this->getMockBuilder( '\SMW\Store' )
-			->disableOriginalConstructor()
-			->getMockForAbstractClass();
-
-		$store->expects( $this->once() )
+		$this->store->expects( $this->once() )
 			->method( 'getPropertyValues' )
 			->with(
 				$this->equalTo( $dataItem ),
 				$this->equalTo( $this->dataItemFactory->newDIProperty( '_INST' ) ) )
 			->will( $this->returnValue( [ $expected ] ) );
 
-		$printRequest = $this->getMockBuilder( '\SMW\Query\PrintRequest' )
-			->disableOriginalConstructor()
-			->getMock();
-
-		$printRequest->expects( $this->at( 1 ) )
+		$this->printRequest->expects( $this->at( 1 ) )
 			->method( 'isMode' )
 			->with($this->equalTo( PrintRequest::PRINT_CATS ) )
 			->will( $this->returnValue( true ) );
 
 		$instance = new ResultFieldMatchFinder(
-			$store,
-			$printRequest
+			$this->store,
+			$this->itemFetcher,
+			$this->printRequest
 		);
 
 		$this->assertEquals(
@@ -137,33 +123,26 @@ class ResultFieldMatchFinderTest extends \PHPUnit_Framework_TestCase {
 		$dataItem = $this->dataItemFactory->newDIWikiPage( 'Bar' );
 		$expected = $this->dataItemFactory->newDIWikiPage( __METHOD__ );
 
-		$store = $this->getMockBuilder( '\SMW\Store' )
-			->disableOriginalConstructor()
-			->getMockForAbstractClass();
-
-		$store->expects( $this->once() )
+		$this->store->expects( $this->once() )
 			->method( 'getPropertyValues' )
 			->with(
 				$this->equalTo( $dataItem ),
 				$this->equalTo( $this->dataItemFactory->newDIProperty( '_INST' ) ) )
 			->will( $this->returnValue( [ $expected ] ) );
 
-		$printRequest = $this->getMockBuilder( '\SMW\Query\PrintRequest' )
-			->disableOriginalConstructor()
-			->getMock();
-
-		$printRequest->expects( $this->at( 2 ) )
+		$this->printRequest->expects( $this->at( 2 ) )
 			->method( 'isMode' )
 			->with($this->equalTo( PrintRequest::PRINT_CCAT ) )
 			->will( $this->returnValue( true ) );
 
-		$printRequest->expects( $this->once() )
+		$this->printRequest->expects( $this->once() )
 			->method( 'getData' )
 			->will( $this->returnValue( $expected ) );
 
 		$instance = new ResultFieldMatchFinder(
-			$store,
-			$printRequest
+			$this->store,
+			$this->itemFetcher,
+			$this->printRequest
 		);
 
 		$this->assertEquals(
@@ -177,37 +156,31 @@ class ResultFieldMatchFinderTest extends \PHPUnit_Framework_TestCase {
 		$dataItem = $this->dataItemFactory->newDIWikiPage( 'Bar' );
 		$expected = $this->dataItemFactory->newDIWikiPage( __METHOD__ );
 
-		$store = $this->getMockBuilder( '\SMW\Store' )
-			->disableOriginalConstructor()
-			->getMockForAbstractClass();
-
-		$store->expects( $this->once() )
-			->method( 'getPropertyValues' )
+		$this->itemFetcher->expects( $this->once() )
+			->method( 'fetch' )
 			->with(
-				$this->equalTo( $dataItem ),
-				$this->equalTo( $this->dataItemFactory->newDIProperty( 'Prop' ) ) )
+				$this->equalTo( [ $dataItem ] ),
+				$this->equalTo( $this->dataItemFactory->newDIProperty( 'Prop' ) ),
+				$this->anything() )
 			->will( $this->returnValue( [ $expected ] ) );
 
-		$printRequest = $this->getMockBuilder( '\SMW\Query\PrintRequest' )
-			->disableOriginalConstructor()
-			->getMock();
-
-		$printRequest->expects( $this->at( 3 ) )
+		$this->printRequest->expects( $this->at( 3 ) )
 			->method( 'isMode' )
 			->with($this->equalTo( PrintRequest::PRINT_PROP ) )
 			->will( $this->returnValue( true ) );
 
-		$printRequest->expects( $this->any() )
+		$this->printRequest->expects( $this->any() )
 			->method( 'getParameter' )
 			->will( $this->returnValue( false ) );
 
-		$printRequest->expects( $this->once() )
+		$this->printRequest->expects( $this->once() )
 			->method( 'getData' )
 			->will( $this->returnValue( $this->dataValueFactory->newPropertyValueByLabel( 'Prop' ) ) );
 
 		$instance = new ResultFieldMatchFinder(
-			$store,
-			$printRequest
+			$this->store,
+			$this->itemFetcher,
+			$this->printRequest
 		);
 
 		$this->assertEquals(
@@ -221,39 +194,32 @@ class ResultFieldMatchFinderTest extends \PHPUnit_Framework_TestCase {
 		$dataItem = $this->dataItemFactory->newDIWikiPage( 'Bar' );
 		$expected = $this->dataItemFactory->newDIWikiPage( __METHOD__ );
 
-		$store = $this->getMockBuilder( '\SMW\Store' )
-			->disableOriginalConstructor()
-			->getMockForAbstractClass();
-
-		// #2541, return an iterator
-		$store->expects( $this->once() )
-			->method( 'getPropertyValues' )
+		$this->itemFetcher->expects( $this->once() )
+			->method( 'fetch' )
 			->with(
-				$this->equalTo( $dataItem ),
-				$this->equalTo( $this->dataItemFactory->newDIProperty( 'Prop' ) ) )
-			->will( $this->returnValue( new \ArrayIterator( [ $expected ] ) ) );
+				$this->equalTo( [ $dataItem ] ),
+				$this->equalTo( $this->dataItemFactory->newDIProperty( 'Prop' ) ),
+				$this->anything() )
+			->will( $this->returnValue( [ $expected ] ) );
 
-		$printRequest = $this->getMockBuilder( '\SMW\Query\PrintRequest' )
-			->disableOriginalConstructor()
-			->getMock();
-
-		$printRequest->expects( $this->at( 3 ) )
+		$this->printRequest->expects( $this->at( 3 ) )
 			->method( 'isMode' )
 			->with($this->equalTo( PrintRequest::PRINT_PROP ) )
 			->will( $this->returnValue( true ) );
 
-		$printRequest->expects( $this->any() )
+		$this->printRequest->expects( $this->any() )
 			->method( 'getParameter' )
 			->will( $this->returnValue( false ) );
 
-		$printRequest->expects( $this->once() )
+		$this->printRequest->expects( $this->once() )
 			->method( 'getData' )
 			->will( $this->returnValue(
 				$this->dataValueFactory->newPropertyValueByLabel( 'Prop' ) ) );
 
 		$instance = new ResultFieldMatchFinder(
-			$store,
-			$printRequest
+			$this->store,
+			$this->itemFetcher,
+			$this->printRequest
 		);
 
 		$this->assertEquals(
@@ -265,47 +231,39 @@ class ResultFieldMatchFinderTest extends \PHPUnit_Framework_TestCase {
 	public function testFindAndMatchWithBlobValueResultAndRemovedLink() {
 
 		$dataItem = $this->dataItemFactory->newDIWikiPage( 'Bar' );
-		$text = $this->dataItemFactory->newDIBlob( '[[Foo::bar]]' );
 		$expected = $this->dataItemFactory->newDIBlob( 'bar' );
 
 		$propertyValue = $this->dataValueFactory->newPropertyValueByLabel( 'Prop' );
 
-		$store = $this->getMockBuilder( '\SMW\Store' )
-			->disableOriginalConstructor()
-			->getMockForAbstractClass();
-
-		// #2541, return an iterator
-		$store->expects( $this->once() )
-			->method( 'getPropertyValues' )
+		$this->itemFetcher->expects( $this->once() )
+			->method( 'fetch' )
 			->with(
-				$this->equalTo( $dataItem ),
-				$this->equalTo( $this->dataItemFactory->newDIProperty( 'Prop' ) ) )
-			->will( $this->returnValue( new \ArrayIterator( [ $text ] ) ) );
+				$this->equalTo( [ $dataItem ] ),
+				$this->equalTo( $this->dataItemFactory->newDIProperty( 'Prop' ) ),
+				$this->anything() )
+			->will( $this->returnValue( [ $expected ] ) );
 
-		$printRequest = $this->getMockBuilder( '\SMW\Query\PrintRequest' )
-			->disableOriginalConstructor()
-			->getMock();
-
-		$printRequest->expects( $this->at( 3 ) )
+		$this->printRequest->expects( $this->at( 3 ) )
 			->method( 'isMode' )
 			->with($this->equalTo( PrintRequest::PRINT_PROP ) )
 			->will( $this->returnValue( true ) );
 
-		$printRequest->expects( $this->any() )
+		$this->printRequest->expects( $this->any() )
 			->method( 'getTypeID' )
 			->will( $this->returnValue( '_txt' ) );
 
-		$printRequest->expects( $this->any() )
+		$this->printRequest->expects( $this->any() )
 			->method( 'getParameter' )
 			->will( $this->returnValue( false ) );
 
-		$printRequest->expects( $this->once() )
+		$this->printRequest->expects( $this->once() )
 			->method( 'getData' )
 			->will( $this->returnValue( $propertyValue ) );
 
 		$instance = new ResultFieldMatchFinder(
-			$store,
-			$printRequest
+			$this->store,
+			$this->itemFetcher,
+			$this->printRequest
 		);
 
 		$this->assertEquals(
@@ -322,46 +280,39 @@ class ResultFieldMatchFinderTest extends \PHPUnit_Framework_TestCase {
 
 		$propertyValue = $this->dataValueFactory->newPropertyValueByLabel( 'Prop' );
 
-		$store = $this->getMockBuilder( '\SMW\Store' )
-			->disableOriginalConstructor()
-			->getMockForAbstractClass();
-
-		// #2541, return an iterator
-		$store->expects( $this->once() )
-			->method( 'getPropertyValues' )
+		$this->itemFetcher->expects( $this->once() )
+			->method( 'fetch' )
 			->with(
-				$this->equalTo( $dataItem ),
-				$this->equalTo( $this->dataItemFactory->newDIProperty( 'Prop' ) ) )
-			->will( $this->returnValue( new \ArrayIterator( [ $text ] ) ) );
+				$this->equalTo( [ $dataItem ] ),
+				$this->equalTo( $this->dataItemFactory->newDIProperty( 'Prop' ) ),
+				$this->anything() )
+			->will( $this->returnValue( [ $text ] ) );
 
-		$printRequest = $this->getMockBuilder( '\SMW\Query\PrintRequest' )
-			->disableOriginalConstructor()
-			->getMock();
-
-		$printRequest->expects( $this->at( 3 ) )
+		$this->printRequest->expects( $this->at( 3 ) )
 			->method( 'isMode' )
 			->with($this->equalTo( PrintRequest::PRINT_PROP ) )
 			->will( $this->returnValue( true ) );
 
-		$printRequest->expects( $this->any() )
+		$this->printRequest->expects( $this->any() )
 			->method( 'getOutputFormat' )
 			->will( $this->returnValue( '-raw' ) );
 
-		$printRequest->expects( $this->any() )
+		$this->printRequest->expects( $this->any() )
 			->method( 'getTypeID' )
 			->will( $this->returnValue( '_txt' ) );
 
-		$printRequest->expects( $this->any() )
+		$this->printRequest->expects( $this->any() )
 			->method( 'getParameter' )
 			->will( $this->returnValue( false ) );
 
-		$printRequest->expects( $this->once() )
+		$this->printRequest->expects( $this->once() )
 			->method( 'getData' )
 			->will( $this->returnValue( $propertyValue ) );
 
 		$instance = new ResultFieldMatchFinder(
-			$store,
-			$printRequest
+			$this->store,
+			$this->itemFetcher,
+			$this->printRequest
 		);
 
 		$this->assertEquals(


### PR DESCRIPTION
This PR is made in reference to: #3722

This PR addresses or contains:

- Isolates the specific part that returns `DataItem`s as `LegacyFetch` so it can be switched back and forth when adding the preftech lookup

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed
