### PR TITLE
Add prefetch cache and lookup, refs 3722

### DIFF
--- a/DefaultSettings.php
+++ b/DefaultSettings.php
@@ -1873,9 +1873,12 @@ return [
 	# to the desired target state and hereby automatically retires the related
 	# setting.
 	#
+	# - SMW_QUERYRESULT_PREFETCH to use the prefetch method to retrieve row
+	# related items for a `QueryResult`.
+	#
 	# @since 3.0
 	##
-	'smwgExperimentalFeatures' => false,
+	'smwgExperimentalFeatures' => SMW_QUERYRESULT_PREFETCH,
 	##
 
 	##

--- a/includes/storage/SMW_QueryResult.php
+++ b/includes/storage/SMW_QueryResult.php
@@ -122,6 +122,9 @@ class SMWQueryResult {
 
 		$itemFetcher = new ItemFetcher( $store, $this->mResults );
 
+		// Used temporarily to allow switching back while testing
+		$itemFetcher->setPrefetchFlag( $GLOBALS['smwgExperimentalFeatures'] );
+
 		// Init the instance here so the value cache is shared and hereby avoids
 		// a static declaration
 		$this->resultFieldMatchFinder = new ResultFieldMatchFinder(

--- a/src/Defines.php
+++ b/src/Defines.php
@@ -204,6 +204,7 @@ define( 'SMW_RF_TEMPLATE_OUTSEP', 2 ); // #2022 Enable 2.5 behaviour for templat
 /**@{
   * Constants for $smwgExperimentalFeatures
   */
+define( 'SMW_QUERYRESULT_PREFETCH', 2 );
 /**@}*/
 
 /**@{

--- a/src/MediaWiki/Connection/Query.php
+++ b/src/MediaWiki/Connection/Query.php
@@ -294,7 +294,11 @@ class Query {
 	 * @param string $value
 	 */
 	public function option( $key, $value ) {
-		$this->options[$key] = $value;
+		if ( $value === null ) {
+			unset( $this->options[$key] );
+		} else {
+			$this->options[$key] = $value;
+		}
 	}
 
 	/**

--- a/src/SQLStore/EntityStore/PrefetchCache.php
+++ b/src/SQLStore/EntityStore/PrefetchCache.php
@@ -1,0 +1,145 @@
+<?php
+
+namespace SMW\SQLStore\EntityStore;
+
+use SMW\SQLStore\SQLStore;
+use SMW\SQLStore\PropertyTableDefinition as TableDefinition;
+use SMWDataItem as DataItem;
+use SMW\DIWikiPage;
+use SMW\DIProperty;
+use SMW\RequestOptions;
+use SMW\DataTypeRegistry;
+use RuntimeException;
+use SMW\MediaWiki\LinkBatch;
+
+/**
+ * @license GNU GPL v2
+ * @since 3.1
+ *
+ * @author mwjames
+ */
+class PrefetchCache {
+
+	/**
+	 * @var SQLStore
+	 */
+	private $store;
+
+	/**
+	 * @var PrefetchItemLookup
+	 */
+	private $prefetchItemLookup;
+
+	/**
+	 * @var []
+	 */
+	private $cache = [];
+
+	/**
+	 * @since 3.1
+	 *
+	 * @param SQLStore $store
+	 * @param PrefetchItemLookup $prefetchItemLookup
+	 */
+	public function __construct( SQLStore $store, PrefetchItemLookup $prefetchItemLookup ) {
+		$this->store = $store;
+		$this->prefetchItemLookup = $prefetchItemLookup;
+	}
+
+	/**
+	 * @since 3.1
+	 *
+	 * @param DIProperty $property
+	 *
+	 * @return boolean
+	 */
+	public function isCached( DIProperty $property ) {
+		return isset( $this->cache[$property->getKey()] );
+	}
+
+	/**
+	 * @since 3.1
+	 */
+	public function clear() {
+		$this->cache = [];
+	}
+
+	/**
+	 * @since 3.1
+	 *
+	 * @param DIProperty $property
+	 * @param RequestOptions $requestOptions
+	 */
+	public static function makeCacheKey( DIProperty $property, RequestOptions $requestOptions ) {
+
+		$key = $property->getKey();
+
+		// Use the .dot notation to distingish it from other prrintouts that
+		// use the same property
+		if ( isset( $requestOptions->isChain ) && $requestOptions->isChain ) {
+			$key .= $requestOptions->isChain;
+		}
+
+		return $key;
+	}
+
+	/**
+	 * Prefetch related data into the cache in order for the `LookupCache::get`
+	 * to return the individual data.
+	 *
+	 * @since 3.1
+	 *
+	 * @param DIWikiPage[] $subjects
+	 * @param DIProperty $property
+	 * @param RequestOptions $requestOptions
+	 */
+	public function prefetch( array $subjects, DIProperty $property, RequestOptions $requestOptions ) {
+
+		$fingerprint = '';
+		$this->store->getObjectIds()->warmUpCache( $subjects );
+
+		foreach ( $subjects as $subject ) {
+			$fingerprint .= $subject->getHash();
+		}
+
+		$requestOptions->setOption( RequestOptions::PREFETCH_FINGERPRINT, md5( $fingerprint ) );
+
+		$result = $this->prefetchItemLookup->getPropertyValues(
+			$subjects,
+			$property,
+			$requestOptions
+		);
+
+		$key = $this->makeCacheKey( $property, $requestOptions );
+		$this->cache[$key] = $result;
+	}
+
+	/**
+	 * @since 3.1
+	 *
+	 * @param DIWikiPage $subject
+	 * @param DIProperty $property
+	 * @param RequestOptions $requestOptions
+	 *
+	 * @return []
+	 */
+	public function getPropertyValues( DIWikiPage $subject, DIProperty $property, RequestOptions $requestOptions ) {
+
+		$key = $this->makeCacheKey( $property, $requestOptions );
+
+		$sid = $this->store->getObjectIds()->getSMWPageID(
+			$subject->getDBkey(),
+			$subject->getNamespace(),
+			$subject->getInterwiki(),
+			$subject->getSubobjectName(),
+			true
+		);
+
+		if ( !isset( $this->cache[$key][$sid] ) ) {
+			return [];
+		}
+
+		return array_values( $this->cache[$key][$sid] );
+	}
+
+}

--- a/src/SQLStore/SQLStoreFactory.php
+++ b/src/SQLStore/SQLStoreFactory.php
@@ -27,6 +27,7 @@ use SMW\SQLStore\EntityStore\SubobjectListFinder;
 use SMW\SQLStore\EntityStore\TraversalPropertyLookup;
 use SMW\SQLStore\EntityStore\PropertySubjectsLookup;
 use SMW\SQLStore\EntityStore\PropertiesLookup;
+use SMW\SQLStore\EntityStore\PrefetchCache;
 use SMW\SQLStore\Lookup\CachedListLookup;
 use SMW\SQLStore\Lookup\ListLookup;
 use SMW\SQLStore\Lookup\PropertyUsageListLookup;
@@ -868,6 +869,18 @@ class SQLStoreFactory {
 	/**
 	 * @since 3.1
 	 *
+	 * @return PrefetchCache
+	 */
+	public function newPrefetchCache() {
+		return new PrefetchCache(
+			$this->store,
+			$this->newPrefetchItemLookup()
+		);
+	}
+
+	/**
+	 * @since 3.1
+	 *
 	 * @return PropertyTypeFinder
 	 */
 	public function newPropertyTypeFinder() {
@@ -951,6 +964,10 @@ class SQLStoreFactory {
 					static $singleton;
 					return $singleton = $singleton === null ? $this->newPropertyTableIdReferenceFinder() : $singleton;
 				},
+				'PrefetchCache' => [
+					'_service' => [ $this, 'newPrefetchCache' ],
+					'_type'    => PrefetchCache::class
+				],
 				'PrefetchItemLookup' => [
 					'_service' => [ $this, 'newPrefetchItemLookup' ],
 					'_type'    => PrefetchItemLookup::class

--- a/tests/phpunit/Integration/JSONScript/TestCases/q-0624.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/q-0624.json
@@ -169,6 +169,49 @@
 		},
 		{
 			"type": "query",
+			"about": "#2.1 (Q0624.-Q0624, limit)",
+			"condition": "[[Q0624::+]]",
+			"printouts": [
+				[ "Q0624.-Q0624", { "limit": 2 } ]
+			],
+			"parameters": {
+				"limit": "10",
+				"sort": { "": "asc" }
+			},
+			"assert-queryresult": {
+				"count": "3",
+				"results": [
+					"Q0624#0##",
+					"Q0624/1#0##",
+					"Q0624/1/1#0##"
+				],
+				"check-sorting": true,
+				"dataitems": [
+					{
+						"type": "_wpg",
+						"value": "Q0624#0##"
+					},
+					{
+						"type": "_wpg",
+						"value": "Q0624#0##"
+					},
+					{
+						"type": "_wpg",
+						"value": "Q0624/1#0##"
+					},
+					{
+						"type": "_wpg",
+						"value": "Q0624/1/1#0##"
+					},
+					{
+						"type": "_wpg",
+						"value": "Q0624/1/1#0##"
+					}
+				]
+			}
+		},
+		{
+			"type": "query",
 			"about": "#3 (Q0624.-Q0624.Has number)",
 			"condition": "[[Q0624::+]]",
 			"printouts": [
@@ -191,6 +234,33 @@
 						"type": "_num",
 						"value": "123"
 					},
+					{
+						"type": "_num",
+						"value": "789"
+					}
+				]
+			}
+		},
+		{
+			"type": "query",
+			"about": "#3.1 (Q0624.-Q0624.Has number, offset/limit)",
+			"condition": "[[Q0624::+]]",
+			"printouts": [
+				[ "Q0624.-Q0624.Has number", { "offset": 1, "limit": 1 } ]
+			],
+			"parameters": {
+				"limit": "10",
+				"sort": { "": "asc" }
+			},
+			"assert-queryresult": {
+				"count": "3",
+				"results": [
+					"Q0624#0##",
+					"Q0624/1#0##",
+					"Q0624/1/1#0##"
+				],
+				"check-sorting": true,
+				"dataitems": [
 					{
 						"type": "_num",
 						"value": "789"

--- a/tests/phpunit/Unit/SQLStore/EntityStore/PrefetchCacheTest.php
+++ b/tests/phpunit/Unit/SQLStore/EntityStore/PrefetchCacheTest.php
@@ -1,0 +1,89 @@
+<?php
+
+namespace SMW\Tests\SQLStore\EntityStore;
+
+use SMW\DIWikiPage;
+use SMW\DIProperty;
+use SMW\SQLStore\EntityStore\PrefetchCache;
+use SMW\Tests\PHPUnitCompat;
+
+/**
+ * @covers \SMW\SQLStore\EntityStore\PrefetchCache
+ * @group semantic-mediawiki
+ *
+ * @license GNU GPL v2+
+ * @since 3.1
+ *
+ * @author mwjames
+ */
+class PrefetchCacheTest extends \PHPUnit_Framework_TestCase {
+
+	use PHPUnitCompat;
+
+	private $store;
+	private $prefetchItemLookup;
+	private $requestOptions;
+
+	protected function setUp() {
+
+		$this->store = $this->getMockBuilder( '\SMW\SQLStore\SQLStore' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$this->prefetchItemLookup = $this->getMockBuilder( '\SMW\SQLStore\EntityStore\PrefetchItemLookup' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$this->requestOptions = $this->getMockBuilder( '\SMW\RequestOptions' )
+			->disableOriginalConstructor()
+			->getMock();
+	}
+
+	public function testCanConstruct() {
+
+		$this->assertInstanceOf(
+			PrefetchCache::class,
+			new PrefetchCache( $this->store, $this->prefetchItemLookup )
+		);
+	}
+
+	public function testCacheAndFetch() {
+
+		$property = new DIProperty( 'Foo' );
+		$subject = DIWikiPage::newFromText( __METHOD__ );
+
+		$expected = [
+			DIWikiPage::newFromText( 'Bar' )
+		];
+
+		$idTable = $this->getMockBuilder( '\SMWSql3SmwIds' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$idTable->expects( $this->atLeastOnce() )
+			->method( 'getSMWPageID' )
+			->with( $this->equalTo( __METHOD__ ) )
+			->will( $this->returnValue( 42 ) );
+
+		$this->store->expects( $this->atLeastOnce() )
+			->method( 'getObjectIds' )
+			->will( $this->returnValue( $idTable ) );
+
+		$this->prefetchItemLookup->expects( $this->atLeastOnce() )
+			->method( 'getPropertyValues' )
+			->will( $this->returnValue( [ 42 => [ DIWikiPage::newFromText( 'Bar' ) ] ] ) );
+
+		$instance = new PrefetchCache(
+			$this->store,
+			$this->prefetchItemLookup
+		);
+
+		$instance->prefetch( [ $subject ], $property, $this->requestOptions );
+
+		$this->assertEquals(
+			$expected,
+			$instance->getPropertyValues( $subject, $property, $this->requestOptions )
+		);
+	}
+
+}


### PR DESCRIPTION
This PR is made in reference to: #3722

This PR addresses or contains:

- As outline in #3722 the prefetch mode is assumed to significantly reduce DB queries when retrieving values for #ask printouts
- Adds the `SMW_QUERYRESULT_PREFETCH` flag to `smwgExperimentalFeatures` in order to make the prefetch lookup the default mode and in case some issues occurs allow to easily remove the flag hereby switches back to the legacy mode (#4056, i.e. the mode that was used until now)

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed

Fixes #3722