### PR TITLE
Test printout offset/limit

### DIFF
--- a/src/Query/Result/ResultFieldMatchFinder.php
+++ b/src/Query/Result/ResultFieldMatchFinder.php
@@ -190,6 +190,7 @@ class ResultFieldMatchFinder {
 	 */
 	public function getRequestOptions( $useLimit = true ) {
 		$limit = $useLimit ? $this->printRequest->getParameter( 'limit' ) : false;
+		$offset = $useLimit ? $this->printRequest->getParameter( 'offset' ) : false;
 		$order = trim( $this->printRequest->getParameter( 'order' ) );
 		$options = null;
 
@@ -200,6 +201,10 @@ class ResultFieldMatchFinder {
 
 			if ( $limit !== false ) {
 				$options->limit = trim( $limit );
+			}
+
+			if ( $offset !== false ) {
+				$options->offset = trim( $offset );
 			}
 
 			// Expecting a natural sort behaviour (n-asc, n-desc)?

--- a/src/SQLStore/EntityStore/PrefetchItemLookup.php
+++ b/src/SQLStore/EntityStore/PrefetchItemLookup.php
@@ -154,9 +154,11 @@ class PrefetchItemLookup {
 				$result[$hash] = [];
 			}
 
+			$limit = $requestOptions->limit + $requestOptions->offset;
+
 			foreach ( $dbkeys as $k => $v ) {
 
-				if ( $requestOptions->limit > 0 && $i > $requestOptions->limit ) {
+				if ( $requestOptions->limit > 0 && $i > $limit ) {
 					break;
 				}
 
@@ -223,7 +225,10 @@ class PrefetchItemLookup {
 			$ids[] = $sid;
 		}
 
+		// In prefetch mode avoid restricting the result due to use of WHERE IN
+		$requestOptions->exclude_limit = true;
 		$requestOptions->setCaller( __METHOD__ );
+
 		$propTable = $proptables[$tableid];
 
 		$result = $this->propertySubjectsLookup->prefetchFromTable(

--- a/src/SQLStore/EntityStore/PropertySubjectsLookup.php
+++ b/src/SQLStore/EntityStore/PropertySubjectsLookup.php
@@ -302,6 +302,11 @@ class PropertySubjectsLookup {
 
 		$query->options( $opts );
 
+		if ( $requestOptions->exclude_limit ) {
+			$query->option( 'LIMIT', null );
+			$query->option( 'OFFSET', null );
+		}
+
 		$caller = $this->caller;
 
 		if ( strval( $requestOptions->getCaller() ) !== '' ) {

--- a/src/SQLStore/EntityStore/SemanticDataLookup.php
+++ b/src/SQLStore/EntityStore/SemanticDataLookup.php
@@ -486,6 +486,7 @@ class SemanticDataLookup {
 
 		if ( $requestOptions->exclude_limit ) {
 			$query->option( 'LIMIT', null );
+			$query->option( 'OFFSET', null );
 		}
 
 		$caller = $this->caller;

--- a/tests/phpunit/Integration/JSONScript/TestCases/q-0625.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/q-0625.json
@@ -1,0 +1,442 @@
+{
+	"description": "Test printout offset/limit",
+	"setup": [
+		{
+			"namespace": "SMW_NS_PROPERTY",
+			"page": "Has number",
+			"contents": "[[Has type::Number]]"
+		},
+		{
+			"page": "Q0625",
+			"contents": "[[Category:Q0625]] [[Has number::123]] [[Has number::456]] [[Has number::1001]] [[Has number::9999]]"
+		},
+		{
+			"page": "Q0625/1",
+			"contents": "{{#subobject: |@category=Q0625/1 |Has number=123,456,1001,9999|+sep=, }}"
+		}
+	],
+	"tests": [
+		{
+			"type": "query",
+			"about": "#0",
+			"condition": "[[Category:Q0625]]",
+			"printouts": [
+				[ "Has number", { "order": "desc" } ]
+			],
+			"parameters": {
+				"limit": "10",
+				"sort": { "": "asc" }
+			},
+			"assert-queryresult": {
+				"count": "1",
+				"results": [
+					"Q0625#0##"
+				],
+				"check-sorting": true,
+				"dataitems": [
+					{
+						"type": "_num",
+						"value": "9999"
+					},
+					{
+						"type": "_num",
+						"value": "1001"
+					},
+					{
+						"type": "_num",
+						"value": "456"
+					},
+					{
+						"type": "_num",
+						"value": "123"
+					}
+				]
+			}
+		},
+		{
+			"type": "query",
+			"about": "#1",
+			"condition": "[[Category:Q0625]]",
+			"printouts": [
+				[ "Has number", { "order": "desc", "limit": 2 } ]
+			],
+			"parameters": {
+				"limit": "10",
+				"sort": { "": "asc" }
+			},
+			"assert-queryresult": {
+				"count": "1",
+				"results": [
+					"Q0625#0##"
+				],
+				"check-sorting": true,
+				"dataitems": [
+					{
+						"type": "_num",
+						"value": "9999"
+					},
+					{
+						"type": "_num",
+						"value": "1001"
+					}
+				]
+			}
+		},
+		{
+			"type": "query",
+			"about": "#1.1",
+			"condition": "[[Category:Q0625]]",
+			"printouts": [
+				[ "Has number", { "order": "desc", "limit": 2, "offset": 2 } ]
+			],
+			"parameters": {
+				"limit": "10",
+				"sort": { "": "asc" }
+			},
+			"assert-queryresult": {
+				"count": "1",
+				"results": [
+					"Q0625#0##"
+				],
+				"check-sorting": true,
+				"dataitems": [
+					{
+						"type": "_num",
+						"value": "456"
+					},
+					{
+						"type": "_num",
+						"value": "123"
+					}
+				]
+			}
+		},
+		{
+			"type": "query",
+			"about": "#1.2",
+			"condition": "[[Category:Q0625]]",
+			"printouts": [
+				[ "Has number", { "order": "desc", "limit": 2, "offset": 3 } ]
+			],
+			"parameters": {
+				"limit": "10",
+				"sort": { "": "asc" }
+			},
+			"assert-queryresult": {
+				"count": "1",
+				"results": [
+					"Q0625#0##"
+				],
+				"check-sorting": true,
+				"dataitems": [
+					{
+						"type": "_num",
+						"value": "123"
+					}
+				]
+			}
+		},
+		{
+			"type": "query",
+			"about": "#2",
+			"condition": "[[Category:Q0625]]",
+			"printouts": [
+				[ "Has number", { "order": "asc", "limit": 2 } ]
+			],
+			"parameters": {
+				"limit": "10",
+				"sort": { "": "asc" }
+			},
+			"assert-queryresult": {
+				"count": "1",
+				"results": [
+					"Q0625#0##"
+				],
+				"check-sorting": true,
+				"dataitems": [
+					{
+						"type": "_num",
+						"value": "123"
+					},
+					{
+						"type": "_num",
+						"value": "456"
+					}
+				]
+			}
+		},
+		{
+			"type": "query",
+			"about": "#2.1",
+			"condition": "[[Category:Q0625]]",
+			"printouts": [
+				[ "Has number", { "order": "asc", "limit": 2, "offset": 2 } ]
+			],
+			"parameters": {
+				"limit": "10",
+				"sort": { "": "asc" }
+			},
+			"assert-queryresult": {
+				"count": "1",
+				"results": [
+					"Q0625#0##"
+				],
+				"check-sorting": true,
+				"dataitems": [
+					{
+						"type": "_num",
+						"value": "1001"
+					},
+					{
+						"type": "_num",
+						"value": "9999"
+					}
+				]
+			}
+		},
+		{
+			"type": "query",
+			"about": "#2.2",
+			"condition": "[[Category:Q0625]]",
+			"printouts": [
+				[ "Has number", { "order": "asc", "limit": 2, "offset": 3 } ]
+			],
+			"parameters": {
+				"limit": "10",
+				"sort": { "": "asc" }
+			},
+			"assert-queryresult": {
+				"count": "1",
+				"results": [
+					"Q0625#0##"
+				],
+				"check-sorting": true,
+				"dataitems": [
+					{
+						"type": "_num",
+						"value": "9999"
+					}
+				]
+			}
+		},
+		{
+			"type": "query",
+			"about": "#3",
+			"condition": "[[Category:Q0625/1]]",
+			"printouts": [
+				[ "-Has subobject.Has subobject.Has number", { "order": "desc" } ]
+			],
+			"parameters": {
+				"limit": "10",
+				"sort": { "": "asc" }
+			},
+			"assert-queryresult": {
+				"count": "1",
+				"results": [
+					"Q0625/1#0##_01f5f1816fe22509901fd7722f8da53d"
+				],
+				"check-sorting": true,
+				"dataitems": [
+					{
+						"type": "_num",
+						"value": "9999"
+					},
+					{
+						"type": "_num",
+						"value": "1001"
+					},
+					{
+						"type": "_num",
+						"value": "456"
+					},
+					{
+						"type": "_num",
+						"value": "123"
+					}
+				]
+			}
+		},
+		{
+			"type": "query",
+			"about": "#3.1",
+			"condition": "[[Category:Q0625/1]]",
+			"printouts": [
+				[ "-Has subobject.Has subobject.Has number", { "order": "desc", "limit": 2 } ]
+			],
+			"parameters": {
+				"limit": "10",
+				"sort": { "": "asc" }
+			},
+			"assert-queryresult": {
+				"count": "1",
+				"results": [
+					"Q0625/1#0##_01f5f1816fe22509901fd7722f8da53d"
+				],
+				"check-sorting": true,
+				"dataitems": [
+					{
+						"type": "_num",
+						"value": "9999"
+					},
+					{
+						"type": "_num",
+						"value": "1001"
+					}
+				]
+			}
+		},
+		{
+			"type": "query",
+			"about": "#3.2",
+			"condition": "[[Category:Q0625/1]]",
+			"printouts": [
+				[ "-Has subobject.Has subobject.Has number", { "order": "desc", "limit": 2, "offset": 2 } ]
+			],
+			"parameters": {
+				"limit": "10",
+				"sort": { "": "asc" }
+			},
+			"assert-queryresult": {
+				"count": "1",
+				"results": [
+					"Q0625/1#0##_01f5f1816fe22509901fd7722f8da53d"
+				],
+				"check-sorting": true,
+				"dataitems": [
+					{
+						"type": "_num",
+						"value": "456"
+					},
+					{
+						"type": "_num",
+						"value": "123"
+					}
+				]
+			}
+		},
+		{
+			"type": "query",
+			"about": "#3.3",
+			"condition": "[[Category:Q0625/1]]",
+			"printouts": [
+				[ "-Has subobject.Has subobject.Has number", { "order": "desc", "limit": 2, "offset": 3 } ]
+			],
+			"parameters": {
+				"limit": "10",
+				"sort": { "": "asc" }
+			},
+			"assert-queryresult": {
+				"count": "1",
+				"results": [
+					"Q0625/1#0##_01f5f1816fe22509901fd7722f8da53d"
+				],
+				"check-sorting": true,
+				"dataitems": [
+					{
+						"type": "_num",
+						"value": "123"
+					}
+				]
+			}
+		},
+		{
+			"type": "query",
+			"about": "#4.1",
+			"condition": "[[Category:Q0625/1]]",
+			"printouts": [
+				[ "-Has subobject.Has subobject.Has number", { "order": "asc", "limit": 2 } ]
+			],
+			"parameters": {
+				"limit": "10",
+				"sort": { "": "asc" }
+			},
+			"assert-queryresult": {
+				"count": "1",
+				"results": [
+					"Q0625/1#0##_01f5f1816fe22509901fd7722f8da53d"
+				],
+				"check-sorting": true,
+				"dataitems": [
+					{
+						"type": "_num",
+						"value": "123"
+					},
+					{
+						"type": "_num",
+						"value": "456"
+					}
+				]
+			}
+		},
+		{
+			"type": "query",
+			"about": "#4.2",
+			"condition": "[[Category:Q0625/1]]",
+			"printouts": [
+				[ "-Has subobject.Has subobject.Has number", { "order": "asc", "limit": 2, "offset": 2 } ]
+			],
+			"parameters": {
+				"limit": "10",
+				"sort": { "": "asc" }
+			},
+			"assert-queryresult": {
+				"count": "1",
+				"results": [
+					"Q0625/1#0##_01f5f1816fe22509901fd7722f8da53d"
+				],
+				"check-sorting": true,
+				"dataitems": [
+					{
+						"type": "_num",
+						"value": "1001"
+					},
+					{
+						"type": "_num",
+						"value": "9999"
+					}
+				]
+			}
+		},
+		{
+			"type": "query",
+			"about": "#4.3",
+			"condition": "[[Category:Q0625/1]]",
+			"printouts": [
+				[ "-Has subobject.Has subobject.Has number", { "order": "asc", "limit": 2, "offset": 3 } ]
+			],
+			"parameters": {
+				"limit": "10",
+				"sort": { "": "asc" }
+			},
+			"assert-queryresult": {
+				"count": "1",
+				"results": [
+					"Q0625/1#0##_01f5f1816fe22509901fd7722f8da53d"
+				],
+				"check-sorting": true,
+				"dataitems": [
+					{
+						"type": "_num",
+						"value": "9999"
+					}
+				]
+			}
+		}
+	],
+	"settings": {
+		"wgContLang": "en",
+		"wgLang": "en",
+		"smwgNamespacesWithSemanticLinks": {
+			"NS_MAIN": true,
+			"SMW_NS_PROPERTY": true
+		},
+		"smwgPageSpecialProperties": [
+			"_MDAT"
+		]
+	},
+	"meta": {
+		"version": "2",
+		"is-incomplete": false,
+		"debug": false
+	}
+}


### PR DESCRIPTION
This PR is made in reference to: #4063 

This PR addresses or contains:

- The `|+offset=...` never worked in the legacy fetch mode, the prefetch mode will apply to correct restrictions
- `q-0625` adds corresponding tests

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed
