### PR TITLE
Move QueryResult, ResultArray, refs 3801

### DIFF
--- a/src/Aliases.php
+++ b/src/Aliases.php
@@ -12,6 +12,8 @@ class_alias( \SMW\Query\ResultPrinters\AggregatablePrinter::class, 'SMWAggregata
 class_alias( \SMW\Property\Annotator::class, 'SMW\PropertyAnnotator' );
 class_alias( \SMW\Property\SpecificationLookup::class, 'SMW\PropertySpecificationLookup' );
 class_alias( \SMW\Property\RestrictionExaminer::class, 'SMW\PropertyRestrictionExaminer' );
+class_alias( \SMW\Query\Result\ResultArray::class, 'SMWResultArray' );
+class_alias( \SMW\Query\QueryResult::class, 'SMWQueryResult' );
 
 // 3.0
 class_alias( \SMW\MediaWiki\Deferred\CallableUpdate::class, 'SMW\DeferredCallableUpdate' );

--- a/src/Query/Cache/ResultCache.php
+++ b/src/Query/Cache/ResultCache.php
@@ -317,7 +317,7 @@ class ResultCache implements QueryEngine, LoggerAwareInterface {
 
 		$results = [];
 		$incrStats = 'hits.Undefined';
-		$resolverJournal = null;
+		$itemJournal = null;
 
 		if ( ( $context = $query->getOption( Query::PROC_CONTEXT ) ) === false ) {
 			$context = 'Undefined';
@@ -340,7 +340,7 @@ class ResultCache implements QueryEngine, LoggerAwareInterface {
 			$hasFurtherResults = $queryResult->hasFurtherResults();
 			$countValue = $queryResult->getCountValue();
 			$excerpts = $queryResult->getExcerpts();
-			$resolverJournal = $queryResult->getResolverJournal();
+			$itemJournal = $queryResult->getItemJournal();
 		} else {
 
 			$incrStats = ( $query->getContextPage() !== null ? 'hits.embedded.' : 'hits.nonEmbedded.' ) . $context;
@@ -368,8 +368,8 @@ class ResultCache implements QueryEngine, LoggerAwareInterface {
 		$queryResult->setCountValue( $countValue );
 		$queryResult->setFromCache( true );
 
-		if ( $resolverJournal !== null ) {
-			$queryResult->setResolverJournal( $resolverJournal );
+		if ( $itemJournal !== null ) {
+			$queryResult->setItemJournal( $itemJournal );
 		}
 
 		$time = Timer::getElapsedTime( __CLASS__, 5 );

--- a/src/Query/Result/FieldItemFinder.php
+++ b/src/Query/Result/FieldItemFinder.php
@@ -26,7 +26,7 @@ use SMWDIBoolean as DIBoolean;
  * @author Jeroen De Dauw < jeroendedauw@gmail.com >
  * @author mwjames
  */
-class ResultFieldMatchFinder {
+class FieldItemFinder {
 
 	/**
 	 * @var Store
@@ -116,7 +116,7 @@ class ResultFieldMatchFinder {
 	 *
 	 * @param DataItem[]|[]
 	 */
-	public function findAndMatch( DataItem $dataItem ) {
+	public function findFor( DataItem $dataItem ) {
 
 		$content = [];
 

--- a/src/Query/Result/ItemJournal.php
+++ b/src/Query/Result/ItemJournal.php
@@ -18,7 +18,7 @@ use SMWDataItem as DataItem;
  *
  * @author mwjames
  */
-class ResolverJournal {
+class ItemJournal {
 
 	/**
 	 * @var array

--- a/src/SQLStore/QueryDependency/QueryResultDependencyListResolver.php
+++ b/src/SQLStore/QueryDependency/QueryResultDependencyListResolver.php
@@ -80,10 +80,10 @@ class QueryResultDependencyListResolver {
 			return [];
 		}
 
-		$resolverJournal = $queryResult->getResolverJournal();
+		$itemJournal = $queryResult->getItemJournal();
 
-		$dependencyList = $resolverJournal->getEntityList();
-		$resolverJournal->prune();
+		$dependencyList = $itemJournal->getEntityList();
+		$itemJournal->prune();
 
 		return $dependencyList;
 	}

--- a/tests/phpunit/Unit/Query/QueryResultTest.php
+++ b/tests/phpunit/Unit/Query/QueryResultTest.php
@@ -1,15 +1,12 @@
 <?php
 
-namespace SMW\Tests;
+namespace SMW\Tests\Query;
 
 use SMW\DIWikiPage;
-use SMWQueryResult as QueryResult;
+use SMW\Query\QueryResult;
 
 /**
- * @covers \SMWQueryResult
- *
- * @group SMW
- * @group SMWExtension
+ * @covers \SMW\Query\QueryResult
  *
  * @license GNU GPL v2+
  * @since 2.1
@@ -32,7 +29,7 @@ class QueryResultTest extends \PHPUnit_Framework_TestCase {
 		$results = [];
 
 		$this->assertInstanceOf(
-			'\SMWQueryResult',
+			QueryResult::class,
 			new QueryResult( $printRequests, $query, $results, $store )
 		);
 	}

--- a/tests/phpunit/Unit/Query/Result/FieldItemFinderTest.php
+++ b/tests/phpunit/Unit/Query/Result/FieldItemFinderTest.php
@@ -5,10 +5,10 @@ namespace SMW\Tests\Query\Result;
 use SMW\DataItemFactory;
 use SMW\DataValueFactory;
 use SMW\Query\PrintRequest;
-use SMW\Query\Result\ResultFieldMatchFinder;
+use SMW\Query\Result\FieldItemFinder;
 
 /**
- * @covers SMW\Query\Result\ResultFieldMatchFinder
+ * @covers SMW\Query\Result\FieldItemFinder
  * @group semantic-mediawiki
  *
  * @license GNU GPL v2+
@@ -16,7 +16,7 @@ use SMW\Query\Result\ResultFieldMatchFinder;
  *
  * @author mwjames
  */
-class ResultFieldMatchFinderTest extends \PHPUnit_Framework_TestCase {
+class FieldItemFinderTest extends \PHPUnit_Framework_TestCase {
 
 	private $dataItemFactory;
 	private $dataValueFactory;
@@ -45,8 +45,8 @@ class ResultFieldMatchFinderTest extends \PHPUnit_Framework_TestCase {
 	public function testCanConstruct() {
 
 		$this->assertInstanceOf(
-			ResultFieldMatchFinder::class,
-			new ResultFieldMatchFinder( $this->store, $this->itemFetcher, $this->printRequest )
+			FieldItemFinder::class,
+			new FieldItemFinder( $this->store, $this->itemFetcher, $this->printRequest )
 		);
 	}
 
@@ -56,7 +56,7 @@ class ResultFieldMatchFinderTest extends \PHPUnit_Framework_TestCase {
 			->method( 'getParameter' )
 			->will( $this->returnValue( 42 ) );
 
-		$instance = new ResultFieldMatchFinder(
+		$instance = new FieldItemFinder(
 			$this->store,
 			$this->itemFetcher,
 			$this->printRequest
@@ -68,7 +68,7 @@ class ResultFieldMatchFinderTest extends \PHPUnit_Framework_TestCase {
 		);
 	}
 
-	public function testFindAndMatch_THIS() {
+	public function testFindFor_THIS() {
 
 		$dataItem = $this->dataItemFactory->newDIWikiPage( 'Foo' );
 
@@ -77,7 +77,7 @@ class ResultFieldMatchFinderTest extends \PHPUnit_Framework_TestCase {
 			->with($this->equalTo( PrintRequest::PRINT_THIS ) )
 			->will( $this->returnValue( true ) );
 
-		$instance = new ResultFieldMatchFinder(
+		$instance = new FieldItemFinder(
 			$this->store,
 			$this->itemFetcher,
 			$this->printRequest
@@ -85,11 +85,11 @@ class ResultFieldMatchFinderTest extends \PHPUnit_Framework_TestCase {
 
 		$this->assertEquals(
 			[ $dataItem ],
-			$instance->findAndMatch( $dataItem )
+			$instance->findFor( $dataItem )
 		);
 	}
 
-	public function testFindAndMatch_CATS() {
+	public function testFindFor_CATS() {
 
 		$dataItem = $this->dataItemFactory->newDIWikiPage( 'Foo' );
 		$expected = $this->dataItemFactory->newDIWikiPage( __METHOD__ );
@@ -106,7 +106,7 @@ class ResultFieldMatchFinderTest extends \PHPUnit_Framework_TestCase {
 			->with($this->equalTo( PrintRequest::PRINT_CATS ) )
 			->will( $this->returnValue( true ) );
 
-		$instance = new ResultFieldMatchFinder(
+		$instance = new FieldItemFinder(
 			$this->store,
 			$this->itemFetcher,
 			$this->printRequest
@@ -114,11 +114,11 @@ class ResultFieldMatchFinderTest extends \PHPUnit_Framework_TestCase {
 
 		$this->assertEquals(
 			[ $expected ],
-			$instance->findAndMatch( $dataItem )
+			$instance->findFor( $dataItem )
 		);
 	}
 
-	public function testFindAndMatch_CCAT() {
+	public function testFindFor_CCAT() {
 
 		$dataItem = $this->dataItemFactory->newDIWikiPage( 'Bar' );
 		$expected = $this->dataItemFactory->newDIWikiPage( __METHOD__ );
@@ -139,7 +139,7 @@ class ResultFieldMatchFinderTest extends \PHPUnit_Framework_TestCase {
 			->method( 'getData' )
 			->will( $this->returnValue( $expected ) );
 
-		$instance = new ResultFieldMatchFinder(
+		$instance = new FieldItemFinder(
 			$this->store,
 			$this->itemFetcher,
 			$this->printRequest
@@ -147,11 +147,11 @@ class ResultFieldMatchFinderTest extends \PHPUnit_Framework_TestCase {
 
 		$this->assertEquals(
 			[ $this->dataItemFactory->newDIBoolean( true ) ],
-			$instance->findAndMatch( $dataItem )
+			$instance->findFor( $dataItem )
 		);
 	}
 
-	public function testFindAndMatch_PROP() {
+	public function testFindFor_PROP() {
 
 		$dataItem = $this->dataItemFactory->newDIWikiPage( 'Bar' );
 		$expected = $this->dataItemFactory->newDIWikiPage( __METHOD__ );
@@ -177,7 +177,7 @@ class ResultFieldMatchFinderTest extends \PHPUnit_Framework_TestCase {
 			->method( 'getData' )
 			->will( $this->returnValue( $this->dataValueFactory->newPropertyValueByLabel( 'Prop' ) ) );
 
-		$instance = new ResultFieldMatchFinder(
+		$instance = new FieldItemFinder(
 			$this->store,
 			$this->itemFetcher,
 			$this->printRequest
@@ -185,11 +185,11 @@ class ResultFieldMatchFinderTest extends \PHPUnit_Framework_TestCase {
 
 		$this->assertEquals(
 			[ $expected ],
-			$instance->findAndMatch( $dataItem )
+			$instance->findFor( $dataItem )
 		);
 	}
 
-	public function testFindAndMatchWithIteratorAsValueResultOnPRINT_PROP() {
+	public function testFindForWithIteratorAsValueResultOnPRINT_PROP() {
 
 		$dataItem = $this->dataItemFactory->newDIWikiPage( 'Bar' );
 		$expected = $this->dataItemFactory->newDIWikiPage( __METHOD__ );
@@ -216,7 +216,7 @@ class ResultFieldMatchFinderTest extends \PHPUnit_Framework_TestCase {
 			->will( $this->returnValue(
 				$this->dataValueFactory->newPropertyValueByLabel( 'Prop' ) ) );
 
-		$instance = new ResultFieldMatchFinder(
+		$instance = new FieldItemFinder(
 			$this->store,
 			$this->itemFetcher,
 			$this->printRequest
@@ -224,11 +224,11 @@ class ResultFieldMatchFinderTest extends \PHPUnit_Framework_TestCase {
 
 		$this->assertEquals(
 			[ $expected ],
-			$instance->findAndMatch( $dataItem )
+			$instance->findFor( $dataItem )
 		);
 	}
 
-	public function testFindAndMatchWithBlobValueResultAndRemovedLink() {
+	public function testFindForWithBlobValueResultAndRemovedLink() {
 
 		$dataItem = $this->dataItemFactory->newDIWikiPage( 'Bar' );
 		$expected = $this->dataItemFactory->newDIBlob( 'bar' );
@@ -260,7 +260,7 @@ class ResultFieldMatchFinderTest extends \PHPUnit_Framework_TestCase {
 			->method( 'getData' )
 			->will( $this->returnValue( $propertyValue ) );
 
-		$instance = new ResultFieldMatchFinder(
+		$instance = new FieldItemFinder(
 			$this->store,
 			$this->itemFetcher,
 			$this->printRequest
@@ -268,11 +268,11 @@ class ResultFieldMatchFinderTest extends \PHPUnit_Framework_TestCase {
 
 		$this->assertEquals(
 			[ $expected ],
-			$instance->findAndMatch( $dataItem )
+			$instance->findFor( $dataItem )
 		);
 	}
 
-	public function testFindAndMatchWithBlobValueResultAndRetainedLink() {
+	public function testFindForWithBlobValueResultAndRetainedLink() {
 
 		$dataItem = $this->dataItemFactory->newDIWikiPage( 'Bar' );
 		$text = $this->dataItemFactory->newDIBlob( '[[Foo::bar]]' );
@@ -309,7 +309,7 @@ class ResultFieldMatchFinderTest extends \PHPUnit_Framework_TestCase {
 			->method( 'getData' )
 			->will( $this->returnValue( $propertyValue ) );
 
-		$instance = new ResultFieldMatchFinder(
+		$instance = new FieldItemFinder(
 			$this->store,
 			$this->itemFetcher,
 			$this->printRequest
@@ -317,7 +317,7 @@ class ResultFieldMatchFinderTest extends \PHPUnit_Framework_TestCase {
 
 		$this->assertEquals(
 			[ $expected ],
-			$instance->findAndMatch( $dataItem )
+			$instance->findFor( $dataItem )
 		);
 	}
 

--- a/tests/phpunit/Unit/Query/Result/ItemJournalTest.php
+++ b/tests/phpunit/Unit/Query/Result/ItemJournalTest.php
@@ -4,10 +4,10 @@ namespace SMW\Tests\Query\Result;
 
 use SMW\DIProperty;
 use SMW\DIWikiPage;
-use SMW\Query\Result\ResolverJournal;
+use SMW\Query\Result\ItemJournal;
 
 /**
- * @covers \SMW\Query\Result\ResolverJournal
+ * @covers \SMW\Query\Result\ItemJournal
  * @group semantic-mediawiki
  *
  * @license GNU GPL v2+
@@ -15,20 +15,20 @@ use SMW\Query\Result\ResolverJournal;
  *
  * @author mwjames
  */
-class ResolverJournalTest extends \PHPUnit_Framework_TestCase {
+class ItemJournalTest extends \PHPUnit_Framework_TestCase {
 
 	public function testCanConstruct() {
 
 		$this->assertInstanceOf(
-			ResolverJournal::class,
-			new ResolverJournal()
+			ItemJournal::class,
+			new ItemJournal()
 		);
 	}
 
 	public function testRecordItem() {
 
 		$dataItem = DIWikiPage::newFromText( 'Foo' );
-		$instance = new ResolverJournal();
+		$instance = new ItemJournal();
 
 		$instance->prune();
 		$instance->recordItem( $dataItem );
@@ -48,7 +48,7 @@ class ResolverJournalTest extends \PHPUnit_Framework_TestCase {
 	public function testRecordProperty() {
 
 		$property = new DIProperty( 'Bar' );
-		$instance = new ResolverJournal();
+		$instance = new ItemJournal();
 
 		$instance->recordProperty( $property );
 

--- a/tests/phpunit/Unit/SQLStore/QueryDependency/QueryResultDependencyListResolverTest.php
+++ b/tests/phpunit/Unit/SQLStore/QueryDependency/QueryResultDependencyListResolverTest.php
@@ -224,11 +224,11 @@ class QueryResultDependencyListResolverTest extends \PHPUnit_Framework_TestCase 
 		$query = new Query( $description );
 		$query->setContextPage( DIWikiPage::newFromText( 'Foo' ) );
 
-		$resolverJournal = $this->getMockBuilder( '\SMW\Query\Result\ResolverJournal' )
+		$itemJournal = $this->getMockBuilder( '\SMW\Query\Result\ItemJournal' )
 			->disableOriginalConstructor()
 			->getMock();
 
-		$resolverJournal->expects( $this->once() )
+		$itemJournal->expects( $this->once() )
 			->method( 'getEntityList' )
 			->will( $this->returnValue( [ $subject ] ) );
 
@@ -237,8 +237,8 @@ class QueryResultDependencyListResolverTest extends \PHPUnit_Framework_TestCase 
 			->getMock();
 
 		$queryResult->expects( $this->once() )
-			->method( 'getResolverJournal' )
-			->will( $this->returnValue( $resolverJournal ) );
+			->method( 'getItemJournal' )
+			->will( $this->returnValue( $itemJournal ) );
 
 		$queryResult->expects( $this->any() )
 			->method( 'getQuery' )


### PR DESCRIPTION
This PR is made in reference to: #3801

This PR addresses or contains:

- Moves `SMWQueryResult` to `\SMW\Query\QueryResult` and `SMWResultArray` to `SMW\Query\Result\ResultArray`
- We keep an alias for both `SMWQueryResult` and `SMWResultArray` therefore there shouldn't be any immediate BC

This PR includes:
- [ ] Tests (unit/integration)
- [x] CI build passed
