### PR TITLE
Add `shape_constraint`, refs 4033

### DIFF
--- a/data/schema/class-constraint-schema.v1.json
+++ b/data/schema/class-constraint-schema.v1.json
@@ -42,6 +42,9 @@
 				"mandatory_properties": {
 					"$ref": "#/definitions/mandatory_properties"
 				},
+				"shape_constraint": {
+					"$ref": "#/definitions/shape_constraint"
+				},
 				"custom_constraint": {
 					"$ref": "#/definitions/custom_constraint"
 				}
@@ -68,10 +71,56 @@
 				"$ref": "#/definitions/shape_item"
 			}
 		},
+		"shape_item": {
+			"$id": "#/definitions/shape_item",
+			"type": "object",
+			"title": "shape item rules",
+			"minProperties": 1,
+			"propertyNames": {
+				"pattern": "^[A-Za-z_][A-Za-z0-9_]*$"
+			},
+			"required": [ "property" ],
+			"properties": {
+				"property": {
+					"$ref": "#/definitions/property"
+				},
+				"property_type": {
+					"$ref": "#/definitions/property_type"
+				},
+				"max_cardinality": {
+					"$ref": "#/definitions/max_cardinality"
+				},
+				"min_textlength": {
+					"$ref": "#/definitions/min_textlength"
+				}
+			},
+			"additionalProperties": false
+		},
 		"custom_constraint": {
 			"$id": "#/definitions/custom_constraint",
 			"type": "object",
 			"title": "Specifies custom constraints to be implemented by a user"
+		},
+		"property": {
+			"$id": "#/definitions/property",
+			"type": "string",
+			"title": "Specifies the related property"
+		},
+		"property_type": {
+			"$id": "#/definitions/property_type",
+			"type": "string",
+			"title": "Specifies ...",
+			"enum": [ "Date", "Boolean", "Text", "Geo", "Page", "Number", "URI" ]
+		},
+		"max_cardinality": {
+			"$id": "#/definitions/max_cardinality",
+			"type": "number",
+			"title": "Specifies ..."
+		},
+		"min_textlength": {
+			"$id": "#/definitions/min_textlength",
+			"type": "number",
+			"title": "Specifies ..."
 		}
 	}
 }

--- a/src/Constraint/ConstraintRegistry.php
+++ b/src/Constraint/ConstraintRegistry.php
@@ -10,6 +10,7 @@ use SMW\Constraint\Constraints\NonNegativeIntegerConstraint;
 use SMW\Constraint\Constraints\MustExistsConstraint;
 use SMW\Constraint\Constraints\SingleValueConstraint;
 use SMW\Constraint\Constraints\MandatoryPropertiesConstraint;
+use SMW\Constraint\Constraints\ShapeConstraint;
 
 /**
  * @license GNU GPL v2+
@@ -106,7 +107,8 @@ class ConstraintRegistry {
 			'single_value_constraint' => SingleValueConstraint::class,
 			'non_negative_integer' => NonNegativeIntegerConstraint::class,
 			'must_exists' => MustExistsConstraint::class,
-			'mandatory_properties' => MandatoryPropertiesConstraint::class
+			'mandatory_properties' => MandatoryPropertiesConstraint::class,
+			'shape_constraint' => ShapeConstraint::class
 		];
 
 		\Hooks::run( 'SMW::Constraint::initConstraints', [ $this ] );

--- a/src/Constraint/Constraints/ShapeConstraint.php
+++ b/src/Constraint/Constraints/ShapeConstraint.php
@@ -1,0 +1,222 @@
+<?php
+
+namespace SMW\Constraint\Constraints;
+
+use SMW\Constraint\Constraint;
+use SMW\Constraint\ConstraintError;
+use SMWDataValue as DataValue;
+use SMWDataItem as DataItem;
+use SMW\DIProperty;
+use SMW\DataTypeRegistry;
+use SMW\SemanticData;
+use RuntimeException;
+use SMWDIBlob as DIBlob;
+
+/**
+ * @license GNU GPL v2+
+ * @since 3.1
+ *
+ * @author mwjames
+ */
+class ShapeConstraint implements Constraint {
+
+	/**
+	 * Defines the expected key in the JSON
+	 */
+	const CONSTRAINT_KEY = 'shape_constraint';
+
+	/**
+	 * @var boolean
+	 */
+	private $hasViolation = false;
+
+	/**
+	 * @var SemanticData
+	 */
+	private $semanticData;
+
+	/**
+	 * @since 3.1
+	 *
+	 * {@inheritDoc}
+	 */
+	public function hasViolation() {
+		return $this->hasViolation;
+	}
+
+	/**
+	 * @since 3.1
+	 *
+	 * {@inheritDoc}
+	 */
+	public function getType() {
+		return Constraint::TYPE_INSTANT;
+	}
+
+	/**
+	 * @since 3.1
+	 *
+	 * {@inheritDoc}
+	 */
+	public function checkConstraint( array $constraints, $dataValue ) {
+
+		$this->hasViolation = false;
+
+		if ( !$dataValue instanceof DataValue ) {
+			throw new RuntimeException( "Expected a DataValue instance!" );
+		}
+
+		if ( !isset( $constraints[self::CONSTRAINT_KEY] ) ) {
+			return;
+		}
+
+		// PHP 7.0+ $this->semanticData = $dataValue->getCallable( SemanticData::class )();
+		$semanticData = $dataValue->getCallable( SemanticData::class );
+		$this->semanticData = $semanticData();
+
+		foreach ( $constraints[self::CONSTRAINT_KEY] as $constraint ) {
+			$this->check( $constraint, $dataValue );
+		}
+	}
+
+	private function check( $constraint, $dataValue ) {
+
+		$errors = [];
+
+		if ( !isset( $constraint['property'] ) ) {
+			return;
+		}
+
+		$property = DIProperty::newFromUserLabel(
+			$constraint['property']
+		);
+
+		if ( !$this->semanticData->hasProperty( $property ) ) {
+			$errors[] = [
+				'smw-constraint-violation-class-shape-constraint-missing-property',
+				$dataValue->getWikiValue(),
+				$property->getLabel()
+			];
+		}
+
+		if ( isset( $constraint['property_type'] ) && !$this->isType( $constraint['property_type'], $property ) ) {
+			$errors[] = [
+				'smw-constraint-violation-class-shape-constraint-wrong-type',
+				$dataValue->getWikiValue(),
+				$property->getLabel(),
+				$constraint['property_type']
+			];
+		}
+
+		if ( isset( $constraint['max_cardinality'] ) && !$this->hasMaxCardinality( $constraint['max_cardinality'], $property ) ) {
+			$errors[] = [
+				'smw-constraint-violation-class-shape-constraint-invalid-max-cardinality',
+				$dataValue->getWikiValue(),
+				$property->getLabel(),
+				$constraint['max_cardinality']
+			];
+		}
+
+		if ( isset( $constraint['min_textlength'] ) && !$this->hasMinLength( $constraint['min_textlength'], $property ) ) {
+			$errors[] = [
+				'smw-constraint-violation-class-shape-constraint-invalid-min-length',
+				$dataValue->getWikiValue(),
+				$property->getLabel(),
+				$constraint['min_textlength']
+			];
+		}
+
+		$this->reportError( $errors, $dataValue );
+	}
+
+	private function reportError( array $errors, $dataValue ) {
+
+		if ( $errors === [] ) {
+			return;
+		}
+
+		$this->hasViolation = true;
+
+		foreach ( $errors as $error ) {
+			$dataValue->addErrorMsg( $this->newConstraintError( $error ) );
+		}
+	}
+
+	private function newConstraintError( array $error ) {
+		return new ConstraintError( $error );
+	}
+
+	private function isType( $type, $property ) {
+
+		$diType = DataTypeRegistry::getInstance()->getDataItemByType(
+			$property->findPropertyTypeId()
+		);
+
+		switch ( $type ) {
+			case 'Text':
+				$type = DataItem::TYPE_BLOB;
+				break;
+			case 'Date':
+				$type = DataItem::TYPE_TIME;
+				break;
+			case 'Boolean':
+				$type = DataItem::TYPE_BOOLEAN;
+				break;
+			case 'Geo':
+				$type = DataItem::TYPE_GEO;
+				break;
+			case 'Page':
+				$type = DataItem::TYPE_WIKIPAGE;
+				break;
+			case 'Number':
+				$type = DataItem::TYPE_NUMBER;
+				break;
+			case 'URI':
+				$type = DataItem::TYPE_URI;
+				break;
+			default:
+				$type = DataItem::TYPE_NONE;
+				break;
+		}
+
+		return $diType === $type;
+	}
+
+	private function hasMinLength( $minLength, $property ) {
+
+		$dataItems = $this->semanticData->getPropertyValues(
+			$property
+		);
+
+		if ( $dataItems === [] ) {
+			return false;
+		}
+
+		foreach ( $dataItems as $dataItem ) {
+
+			if ( !$dataItem instanceof DIBlob ) {
+				continue;
+			}
+
+			if ( mb_strlen( $dataItem->getString() < $minLength ) ) {
+				return false;
+			}
+		}
+
+		return true;
+	}
+
+	private function hasMaxCardinality( $maxCardinality, $property ) {
+
+		$dataItems = $this->semanticData->getPropertyValues(
+			$property
+		);
+
+		if ( count( $dataItems ) > $maxCardinality ) {
+			return false;
+		}
+
+		return true;
+	}
+
+}

--- a/src/ConstraintFactory.php
+++ b/src/ConstraintFactory.php
@@ -16,6 +16,7 @@ use SMW\Constraint\Constraints\NonNegativeIntegerConstraint;
 use SMW\Constraint\Constraints\MustExistsConstraint;
 use SMW\Constraint\Constraints\SingleValueConstraint;
 use SMW\Constraint\Constraints\MandatoryPropertiesConstraint;
+use SMW\Constraint\Constraints\ShapeConstraint;
 use SMW\Options;
 
 /**
@@ -83,6 +84,9 @@ class ConstraintFactory {
 			case MandatoryPropertiesConstraint::class:
 				$constraint = $this->newMandatoryPropertiesConstraint();
 				break;
+			case ShapeConstraint::class:
+				$constraint = $this->newShapeConstraint();
+				break;
 			case UniqueValueConstraint::class:
 				$constraint = $this->newUniqueValueConstraint();
 				break;
@@ -126,6 +130,15 @@ class ConstraintFactory {
 	 */
 	public function newMandatoryPropertiesConstraint() {
 		return new MandatoryPropertiesConstraint();
+	}
+
+	/**
+	 * @since 3.1
+	 *
+	 * @return ShapeConstraint
+	 */
+	public function newShapeConstraint() {
+		return new ShapeConstraint();
 	}
 
 	/**

--- a/src/Schema/docs/class.constraint.md
+++ b/src/Schema/docs/class.constraint.md
@@ -29,7 +29,8 @@ To easily identify pages that contain a constraint schema it is suggested to use
 
 ### Constraint properties
 
-- `mandatory_properties` (array) specifies mandatory properties
+- [`mandatory_properties`][example.schema] (array) specifies mandatory properties
+- [`shape_constraint`][example.schema] (array) specifies shapes of properties and dependent characteristics
 - [`custom_constraint`][custom.constraint] (object) specifies non-schema specific custom constraints implementations
 
 ### Extending constraints

--- a/tests/phpunit/Integration/JSONScript/Fixtures/p-1110-constraint-shape-constraint-max-cardinality.json
+++ b/tests/phpunit/Integration/JSONScript/Fixtures/p-1110-constraint-shape-constraint-max-cardinality.json
@@ -1,0 +1,16 @@
+{
+    "type": "CLASS_CONSTRAINT_SCHEMA",
+    "description": "Constraint that describes a person or human being",
+    "constraints": {
+        "shape_constraint": [
+            {
+                "property": "Gender",
+                "max_cardinality": 1
+            }
+        ]
+    },
+    "tags": [
+        "class constraint",
+        "shape"
+    ]
+}

--- a/tests/phpunit/Integration/JSONScript/Fixtures/p-1110-constraint-shape-constraint-property-type.json
+++ b/tests/phpunit/Integration/JSONScript/Fixtures/p-1110-constraint-shape-constraint-property-type.json
@@ -1,0 +1,16 @@
+{
+    "type": "CLASS_CONSTRAINT_SCHEMA",
+    "description": "Constraint that describes a person or human being",
+    "constraints": {
+        "shape_constraint": [
+            {
+                "property": "Gender",
+                "property_type": "Number"
+            }
+        ]
+    },
+    "tags": [
+        "class constraint",
+        "shape"
+    ]
+}

--- a/tests/phpunit/Integration/JSONScript/TestCases/p-1111.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/p-1111.json
@@ -1,0 +1,218 @@
+{
+	"description": "Test `smw/schema` on `CLASS_CONSTRAINT_SCHEMA` with `shape_constraint` and `Constraint schema`",
+	"setup": [
+		{
+			"namespace": "SMW_NS_SCHEMA",
+			"page": "Constraint:ShapeConstraint/MaxCardinality",
+			"contents": {
+				"import-from": "/../Fixtures/p-1110-constraint-shape-constraint-max-cardinality.json"
+			}
+		},
+		{
+			"namespace": "SMW_NS_SCHEMA",
+			"page": "Constraint:ShapeConstraint/PropertyType",
+			"contents": {
+				"import-from": "/../Fixtures/p-1110-constraint-shape-constraint-property-type.json"
+			}
+		},
+		{
+			"namespace": "SMW_NS_PROPERTY",
+			"page": "Gender",
+			"contents": "[[Has type::Text]]"
+		},
+		{
+			"namespace": "NS_CATEGORY",
+			"page": "P1111/1",
+			"contents": "[[Constraint schema::Constraint:ShapeConstraint/MaxCardinality]]"
+		},
+		{
+			"namespace": "NS_CATEGORY",
+			"page": "P1111/2",
+			"contents": "[[Constraint schema::Constraint:ShapeConstraint/PropertyType]]"
+		},
+		{
+			"page": "P1111/1",
+			"contents": "[[Category:P1111/1]] [[Gender::male]] [[Gender::female]]"
+		},
+		{
+			"page": "P1111/2",
+			"contents": "[[Category:P1111/2]] [[Gender::male]]"
+		},
+		{
+			"page": "P1111/12",
+			"contents": "[[Category:P1111/1]] [[Category:P1111/2]] [[Gender::male]] [[Gender::female]]"
+		}
+	],
+	"tests": [
+		{
+			"type": "parser",
+			"about": "#0.1",
+			"namespace": "NS_CATEGORY",
+			"subject": "P1111/1",
+			"assert-store": {
+				"semantic-data": {
+					"strict-mode-valuematch": false,
+					"propertyCount": 3,
+					"propertyKeys": [
+						"_CONSTRAINT_SCHEMA",
+						"_SKEY",
+						"_MDAT"
+					]
+				}
+			}
+		},
+		{
+			"type": "parser",
+			"about": "#0.2",
+			"namespace": "NS_CATEGORY",
+			"subject": "P1111/2",
+			"assert-store": {
+				"semantic-data": {
+					"strict-mode-valuematch": false,
+					"propertyCount": 3,
+					"propertyKeys": [
+						"_CONSTRAINT_SCHEMA",
+						"_SKEY",
+						"_MDAT"
+					]
+				}
+			}
+		},
+		{
+			"type": "parser",
+			"about": "#1.1 (violation of `shape_constraint`)",
+			"namespace": "NS_MAIN",
+			"subject": "P1111/1",
+			"assert-store": {
+				"semantic-data": {
+					"strict-mode-valuematch": false,
+					"propertyCount": 5,
+					"propertyKeys": [
+						"_SKEY",
+						"_MDAT",
+						"_ERRC",
+						"_INST",
+						"Gender"
+					]
+				}
+			}
+		},
+		{
+			"type": "parser",
+			"about": "#1.2 (violation of `shape_constraint`, `max_cardinality` violation)",
+			"namespace": "NS_MAIN",
+			"subject": "P1111/1#_ERR080b0f4484ac85bb6dc711fe6befad5a",
+			"assert-store": {
+				"semantic-data": {
+					"strict-mode-valuematch": false,
+					"propertyCount": 3,
+					"propertyKeys": [
+						"_SKEY",
+						"_ERRT",
+						"_ERR_TYPE"
+					],
+					"propertyValues": [
+						{ "serialization": "[2,\"smw-constraint-violation-class-shape-constraint-invalid-max-cardinality\",\"P1111\\/1\",\"Gender\",\"1\"]" }
+					]
+				}
+			}
+		},
+		{
+			"type": "parser",
+			"about": "#2.1 (violation of `shape_constraint`)",
+			"namespace": "NS_MAIN",
+			"subject": "P1111/2",
+			"assert-store": {
+				"semantic-data": {
+					"strict-mode-valuematch": false,
+					"propertyCount": 5,
+					"propertyKeys": [
+						"_SKEY",
+						"_MDAT",
+						"_ERRC",
+						"_INST",
+						"Gender"
+					]
+				}
+			}
+		},
+		{
+			"type": "parser",
+			"about": "#2.2 (violation of `shape_constraint`, `property_type` violation)",
+			"namespace": "NS_MAIN",
+			"subject": "P1111/2#_ERR080b0f4484ac85bb6dc711fe6befad5a",
+			"assert-store": {
+				"semantic-data": {
+					"strict-mode-valuematch": false,
+					"propertyCount": 3,
+					"propertyKeys": [
+						"_SKEY",
+						"_ERRT",
+						"_ERR_TYPE"
+					],
+					"propertyValues": [
+						{ "serialization": "[2,\"smw-constraint-violation-class-shape-constraint-wrong-type\",\"P1111\\/2\",\"Gender\",\"Number\"]" }
+					]
+				}
+			}
+		},
+		{
+			"type": "parser",
+			"about": "#12.1 (violation of `shape_constraint`)",
+			"namespace": "NS_MAIN",
+			"subject": "P1111/12",
+			"assert-store": {
+				"semantic-data": {
+					"strict-mode-valuematch": false,
+					"propertyCount": 5,
+					"propertyKeys": [
+						"_SKEY",
+						"_MDAT",
+						"_ERRC",
+						"_INST",
+						"Gender"
+					]
+				}
+			}
+		},
+		{
+			"type": "parser",
+			"about": "#12.2 (violation of `shape_constraint`, `max_cardinality` + `property_type` violation)",
+			"namespace": "NS_MAIN",
+			"subject": "P1111/12#_ERR080b0f4484ac85bb6dc711fe6befad5a",
+			"assert-store": {
+				"semantic-data": {
+					"strict-mode-valuematch": false,
+					"propertyCount": 3,
+					"propertyKeys": [
+						"_SKEY",
+						"_ERRT",
+						"_ERR_TYPE"
+					],
+					"propertyValues": [
+						{ "serialization": "[2,\"smw-constraint-violation-class-shape-constraint-wrong-type\",\"P1111\\/2\",\"Gender\",\"Number\"]" },
+						{ "serialization": "[2,\"smw-constraint-violation-class-shape-constraint-invalid-max-cardinality\",\"P1111\\/1\",\"Gender\",\"1\"]" }
+					]
+				}
+			}
+		}
+	],
+	"settings": {
+		"wgContLang": "en",
+		"wgLang": "en",
+		"smwgPageSpecialProperties": [
+			"_MDAT"
+		],
+		"smwgNamespacesWithSemanticLinks": {
+			"NS_MAIN": true,
+			"NS_CATEGORY": true,
+			"SMW_NS_PROPERTY": true,
+			"SMW_NS_SCHEMA": true
+		}
+	},
+	"meta": {
+		"version": "2",
+		"is-incomplete": false,
+		"debug": false
+	}
+}

--- a/tests/phpunit/Unit/Constraint/ConstraintRegistryTest.php
+++ b/tests/phpunit/Unit/Constraint/ConstraintRegistryTest.php
@@ -147,29 +147,34 @@ class ConstraintRegistryTest extends \PHPUnit_Framework_TestCase {
 
 	public function constraintKeyProvider() {
 
-		yield[
+		yield [
 			'allowed_namespaces',
 			'SMW\Constraint\Constraints\NamespaceConstraint'
 		];
 
-		yield[
+		yield [
 			'unique_value_constraint',
 			'SMW\Constraint\Constraints\UniqueValueConstraint'
 		];
 
-		yield[
+		yield [
 			'non_negative_integer',
 			'SMW\Constraint\Constraints\NonNegativeIntegerConstraint'
 		];
 
-		yield[
+		yield [
 			'must_exists',
 			'SMW\Constraint\Constraints\MustExistsConstraint'
 		];
 
-		yield[
+		yield [
 			'mandatory_properties',
 			'SMW\Constraint\Constraints\MandatoryPropertiesConstraint'
+		];
+
+		yield [
+			'shape_constraint',
+			'SMW\Constraint\Constraints\ShapeConstraint'
 		];
 	}
 

--- a/tests/phpunit/Unit/Constraint/Constraints/ShapeConstraintTest.php
+++ b/tests/phpunit/Unit/Constraint/Constraints/ShapeConstraintTest.php
@@ -1,0 +1,260 @@
+<?php
+
+namespace SMW\Tests\Constraint\Constraints;
+
+use SMW\Constraint\Constraints\ShapeConstraint;
+use SMW\Tests\PHPUnitCompat;
+use SMW\DataItemFactory;
+
+/**
+ * @covers \SMW\Constraint\Constraints\ShapeConstraint
+ * @group semantic-mediawiki
+ *
+ * @license GNU GPL v2+
+ * @since 3.1
+ *
+ * @author mwjames
+ */
+class ShapeConstraintTest extends \PHPUnit_Framework_TestCase {
+
+	use PHPUnitCompat;
+
+	private $dataItemFactory;
+
+	protected function setUp() {
+		$this->dataItemFactory = new DataItemFactory();
+	}
+
+	public function testCanConstruct() {
+
+		$this->assertInstanceOf(
+			ShapeConstraint::class,
+			new ShapeConstraint()
+		);
+	}
+
+	public function testGetType() {
+
+		$instance = new ShapeConstraint();
+
+		$this->assertEquals(
+			ShapeConstraint::TYPE_INSTANT,
+			$instance->getType()
+		);
+	}
+
+	public function testHasViolation() {
+
+		$instance = new ShapeConstraint();
+
+		$this->assertFalse(
+			$instance->hasViolation()
+		);
+	}
+
+	public function testCheckConstraint_shape_constraint_missing_property() {
+
+		$constraint = [
+			'shape_constraint' => [ [ 'property' => 'Foo' ] ]
+		];
+
+		$expectedErrMsg = 'smw-constraint-violation-class-shape-constraint-missing-property';
+
+		$semanticData = $this->getMockBuilder( '\SMW\SemanticData' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$semanticData->expects( $this->atLeastOnce() )
+			->method( 'hasProperty' )
+			->with( $this->equalTo( 'Foo' ) )
+			->will( $this->returnValue( false ) );
+
+		$dataValue = $this->getMockBuilder( '\SMWDataValue' )
+			->disableOriginalConstructor()
+			->setMethods( [ 'addErrorMsg', 'getCallable' ] )
+			->getMockForAbstractClass();
+
+		$dataValue->expects( $this->once() )
+			->method( 'getCallable' )
+			->will( $this->returnValue( function() use( $semanticData ) { return $semanticData; } ) );
+
+		$dataValue->expects( $this->atLeastOnce() )
+			->method( 'addErrorMsg' )
+			->with( $this->callback( function( $error ) use ( $expectedErrMsg ) {
+				return $this->checkConstraintError( $error, $expectedErrMsg );
+			} ) );
+
+		$instance = new ShapeConstraint();
+
+		$instance->checkConstraint( $constraint, $dataValue );
+
+		$this->assertTrue(
+			$instance->hasViolation()
+		);
+	}
+
+	public function testCheckConstraint_shape_constraint_wrong_type() {
+
+		$constraint = [
+			'shape_constraint' => [ [ 'property' => 'Foo', 'property_type' => 'Text' ] ]
+		];
+
+		$expectedErrMsg = 'smw-constraint-violation-class-shape-constraint-wrong-type';
+
+		$semanticData = $this->getMockBuilder( '\SMW\SemanticData' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$semanticData->expects( $this->atLeastOnce() )
+			->method( 'hasProperty' )
+			->with( $this->equalTo( 'Foo' ) )
+			->will( $this->returnValue( true ) );
+
+		$dataValue = $this->getMockBuilder( '\SMWDataValue' )
+			->disableOriginalConstructor()
+			->setMethods( [ 'addErrorMsg', 'getCallable' ] )
+			->getMockForAbstractClass();
+
+		$dataValue->expects( $this->once() )
+			->method( 'getCallable' )
+			->will( $this->returnValue( function() use( $semanticData ) { return $semanticData; } ) );
+
+		$dataValue->expects( $this->atLeastOnce() )
+			->method( 'addErrorMsg' )
+			->with( $this->callback( function( $error ) use ( $expectedErrMsg ) {
+				return $this->checkConstraintError( $error, $expectedErrMsg );
+			} ) );
+
+		$instance = new ShapeConstraint();
+
+		$instance->checkConstraint( $constraint, $dataValue );
+
+		$this->assertTrue(
+			$instance->hasViolation()
+		);
+	}
+
+	public function testCheckConstraint_shape_constraint_invalid_max_cardinality() {
+
+		$constraint = [
+			'shape_constraint' => [ [ 'property' => 'Foo', 'max_cardinality' => 1 ] ]
+		];
+
+		$expectedErrMsg = 'smw-constraint-violation-class-shape-constraint-invalid-max-cardinality';
+
+		$dataItem = $this->getMockBuilder( '\SMWDataItem' )
+			->disableOriginalConstructor()
+			->getMockForAbstractClass();
+
+		$semanticData = $this->getMockBuilder( '\SMW\SemanticData' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$semanticData->expects( $this->atLeastOnce() )
+			->method( 'hasProperty' )
+			->with( $this->equalTo( 'Foo' ) )
+			->will( $this->returnValue( true ) );
+
+		$semanticData->expects( $this->atLeastOnce() )
+			->method( 'getPropertyValues' )
+			->will( $this->returnValue( [ $dataItem, $dataItem ] ) );
+
+		$dataValue = $this->getMockBuilder( '\SMWDataValue' )
+			->disableOriginalConstructor()
+			->setMethods( [ 'addErrorMsg', 'getCallable' ] )
+			->getMockForAbstractClass();
+
+		$dataValue->expects( $this->once() )
+			->method( 'getCallable' )
+			->will( $this->returnValue( function() use( $semanticData ) { return $semanticData; } ) );
+
+		$dataValue->expects( $this->atLeastOnce() )
+			->method( 'addErrorMsg' )
+			->with( $this->callback( function( $error ) use ( $expectedErrMsg ) {
+				return $this->checkConstraintError( $error, $expectedErrMsg );
+			} ) );
+
+		$instance = new ShapeConstraint();
+
+		$instance->checkConstraint( $constraint, $dataValue );
+
+		$this->assertTrue(
+			$instance->hasViolation()
+		);
+	}
+
+	public function testCheckConstraint_shape_constraint_invalid_min_textlength() {
+
+		$constraint = [
+			'shape_constraint' => [ [ 'property' => 'Foo', 'min_textlength' => 100 ] ]
+		];
+
+		$expectedErrMsg = 'smw-constraint-violation-class-shape-constraint-invalid-min-length';
+
+		$dataItem = $this->getMockBuilder( '\SMWDIBlob' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$dataItem->expects( $this->atLeastOnce() )
+			->method( 'getString' )
+			->will( $this->returnValue( 'Bar' ) );
+
+		$semanticData = $this->getMockBuilder( '\SMW\SemanticData' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$semanticData->expects( $this->atLeastOnce() )
+			->method( 'hasProperty' )
+			->with( $this->equalTo( 'Foo' ) )
+			->will( $this->returnValue( true ) );
+
+		$semanticData->expects( $this->atLeastOnce() )
+			->method( 'getPropertyValues' )
+			->will( $this->returnValue( [ $dataItem ] ) );
+
+		$dataValue = $this->getMockBuilder( '\SMWDataValue' )
+			->disableOriginalConstructor()
+			->setMethods( [ 'addErrorMsg', 'getCallable' ] )
+			->getMockForAbstractClass();
+
+		$dataValue->expects( $this->once() )
+			->method( 'getCallable' )
+			->will( $this->returnValue( function() use( $semanticData ) { return $semanticData; } ) );
+
+		$dataValue->expects( $this->atLeastOnce() )
+			->method( 'addErrorMsg' )
+			->with( $this->callback( function( $error ) use ( $expectedErrMsg ) {
+				return $this->checkConstraintError( $error, $expectedErrMsg );
+			} ) );
+
+		$instance = new ShapeConstraint();
+
+		$instance->checkConstraint( $constraint, $dataValue );
+
+		$this->assertTrue(
+			$instance->hasViolation()
+		);
+	}
+
+	public function testCheckConstraint_mandatory_properties_ThrowsException() {
+
+		$constraint = [
+			'mandatory_properties' => true
+		];
+
+		$instance = new ShapeConstraint();
+
+		$this->setExpectedException( '\RuntimeException' );
+		$instance->checkConstraint( $constraint, 'Foo' );
+	}
+
+	public function checkConstraintError( $error, $expectedErrMsg ) {
+
+		if ( strpos( $error->__toString(), $expectedErrMsg ) !== false ) {
+			return true;
+		}
+
+		return false;
+	}
+
+}

--- a/tests/phpunit/Unit/ConstraintFactoryTest.php
+++ b/tests/phpunit/Unit/ConstraintFactoryTest.php
@@ -29,6 +29,16 @@ class ConstraintFactoryTest extends \PHPUnit_Framework_TestCase {
 		);
 	}
 
+	public function testCanConstructConstraintOptions() {
+
+		$instance = new ConstraintFactory();
+
+		$this->assertInstanceOf(
+			'\SMW\Options',
+			$instance->newConstraintOptions()
+		);
+	}
+
 	public function testCanConstructConstraintRegistry() {
 
 		$instance = new ConstraintFactory();
@@ -109,39 +119,44 @@ class ConstraintFactoryTest extends \PHPUnit_Framework_TestCase {
 
 	public function constraintByClass() {
 
-		yield[
+		yield [
 			'\SMW\Constraint\Constraints\NullConstraint',
 			'\SMW\Constraint\Constraints\NullConstraint'
 		];
 
-		yield[
+		yield [
 			'SMW\Constraint\Constraints\NamespaceConstraint',
 			'\SMW\Constraint\Constraints\NamespaceConstraint'
 		];
 
-		yield[
+		yield [
 			'SMW\Constraint\Constraints\UniqueValueConstraint',
 			'\SMW\Constraint\Constraints\UniqueValueConstraint'
 		];
 
-		yield[
+		yield [
 			'SMW\Constraint\Constraints\NonNegativeIntegerConstraint',
 			'\SMW\Constraint\Constraints\NonNegativeIntegerConstraint'
 		];
 
-		yield[
+		yield [
 			'SMW\Constraint\Constraints\SingleValueConstraint',
 			'\SMW\Constraint\Constraints\SingleValueConstraint'
 		];
 
-		yield[
+		yield [
 			'SMW\Constraint\Constraints\MustExistsConstraint',
 			'\SMW\Constraint\Constraints\MustExistsConstraint'
 		];
 
-		yield[
+		yield [
 			'SMW\Constraint\Constraints\MandatoryPropertiesConstraint',
 			'\SMW\Constraint\Constraints\MandatoryPropertiesConstraint'
+		];
+
+		yield [
+			'SMW\Constraint\Constraints\ShapeConstraint',
+			'\SMW\Constraint\Constraints\ShapeConstraint'
 		];
 	}
 


### PR DESCRIPTION
This PR is made in reference to: #4033, #4032 

This PR addresses or contains:

- Adds the `shape_constraint` as outlined in #4032 that allows to check
  - `property_type`
  - `max_cardinality`
  - `min_textlength`

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed

Fixes #4032 