### PR TITLE
`auto-recovery` to use `.smw.json`, refs 3922

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,4 +12,3 @@ composer.lock
 !.*
 .idea/
 .smw.json
-.smw.maintenance.json

--- a/src/Maintenance/DataRebuilder.php
+++ b/src/Maintenance/DataRebuilder.php
@@ -291,17 +291,16 @@ class DataRebuilder {
 			$this->reportMessage( "\n" );
 		}
 
-		if ( $this->options->has( 'auto-recovery' ) && $this->autoRecovery !== null ) {
-			if ( $this->autoRecovery->has( 'ar_id' ) ) {
-				$this->start = $this->autoRecovery->get( 'ar_id' );
+		if ( $this->autoRecovery !== null && $this->autoRecovery->has( 'ar_id' ) ) {
+			$this->start = $this->autoRecovery->get( 'ar_id' );
 
-				$this->reportMessage(
-					"The auto recovery mode is enabled and has detected an unfinished\n" .
-					"rebuild run therefore the run is started with: " . $this->start . "\n"
-				);
+			$this->reportMessage( "Incomplete rebuild run detected (auto recovery) ...\n"  );
 
-				$this->reportMessage( "\n" );
-			}
+			$this->reportMessage(
+				sprintf( "%-50s%s\n", "   ... starting with", sprintf( "%s", $this->start ) )
+			);
+
+			$this->reportMessage( "\n" );
 		}
 
 		$this->store->clear();
@@ -326,6 +325,7 @@ class DataRebuilder {
 		$progress = 0;
 		$estimatedProgress = 0;
 		$skipped_update = 0;
+		$current_id = 0;
 
 		while ( ( ( !$this->end ) || ( $id <= $this->end ) ) && ( $id > 0 ) ) {
 
@@ -361,14 +361,14 @@ class DataRebuilder {
 
 			if ( !$this->options->has( 'v' ) && $id > 0 ) {
 				$this->reportMessage(
-					"\r". sprintf( "%-50s%s", "   ... updating document no.", sprintf( "%s (%1.0f%%)", $current_id, min( 100, $progress ) ) )
+					"\r". sprintf( "%-50s%s", "   ... updating", sprintf( "%s (%1.0f%%)", $current_id, min( 100, $progress ) ) )
 				);
 			}
 		}
 
 		if ( !$this->options->has( 'v' ) ) {
 			$this->reportMessage(
-				"\r". sprintf( "%-50s%s", "   ... updating document no.", sprintf( "%s (%1.0f%%)", $current_id, 100 ) )
+				"\r". sprintf( "%-50s%s", "   ... updating", sprintf( "%s (%1.0f%%)", $current_id, 100 ) )
 			);
 		}
 
@@ -378,8 +378,14 @@ class DataRebuilder {
 
 		$this->write_to_file( $id );
 
-		$this->reportMessage( "\n   ... $this->rebuildCount IDs checked or refreshed ..." );
-		$this->reportMessage( "\n   ... $skipped_update IDs skipped ..." );
+		$this->reportMessage(
+			"\n". sprintf( "%-50s%s", "   ... IDs checked or refreshed", sprintf( "%s", $this->rebuildCount ) )
+		);
+
+		$this->reportMessage(
+			"\n". sprintf( "%-50s%s", "   ... IDs skipped", sprintf( "%s", $skipped_update ) )
+		);
+
 		$this->reportMessage( "\n   ... done.\n" );
 
 		if ( $this->options->has( 'ignore-exceptions' ) && $this->exceptionFileLogger->getExceptionCount() > 0 ) {

--- a/src/Maintenance/DataRebuilder/OutdatedDisposer.php
+++ b/src/Maintenance/DataRebuilder/OutdatedDisposer.php
@@ -52,9 +52,11 @@ class OutdatedDisposer {
 
 		if ( ( $count = $resultIterator->count() ) > 0 ) {
 			$this->disposeOutdatedEntities( $resultIterator, $count );
+			$this->messageReporter->reportMessage( "\n   ... done." );
+		} else {
+			$this->messageReporter->reportMessage( " done." );
 		}
 
-		$this->messageReporter->reportMessage( "\n   ... done." );
 		$this->messageReporter->reportMessage( "\n   ... checking query links ..." );
 
 		$resultIterator = $this->entityIdDisposerJob->newOutdatedQueryLinksResultIterator();
@@ -67,9 +69,10 @@ class OutdatedDisposer {
 
 		if ( ( $count = $resultIterator->count() ) > 0 ) {
 			$this->disposeOutdatedQueryLinks( $resultIterator, $count, 'query links (unassigned)' );
+			$this->messageReporter->reportMessage( "\n   ... done.\n" );
+		} else {
+			$this->messageReporter->reportMessage( " done.\n" );
 		}
-
-		$this->messageReporter->reportMessage( "\n   ... done.\n" );
 	}
 
 	private function disposeOutdatedEntities( $resultIterator, $count ) {

--- a/src/SetupFile.php
+++ b/src/SetupFile.php
@@ -30,6 +30,11 @@ class SetupFile {
 	const UPGRADE_KEY = 'upgrade_key';
 
 	/**
+	 * Describes the file name
+	 */
+	const FILE_NAME = '.smw.json';
+
+	/**
 	 * @var File
 	 */
 	private $file;
@@ -55,7 +60,7 @@ class SetupFile {
 	public static function loadSchema( &$vars ) {
 
 		// @see #3506
-		$file = File::dir( $vars['smwgConfigFileDir'] . '/.smw.json' );
+		$file = File::dir( $vars['smwgConfigFileDir'] . '/' . self::FILE_NAME );
 
 		// Doesn't exist? The `Setup::init` will take care of it by trying to create
 		// a new file and if it fails or unable to do so wail raise an exception
@@ -249,7 +254,7 @@ class SetupFile {
 	 */
 	public function write( $vars, $args = [] ) {
 
-		$configFile = File::dir( $vars['smwgConfigFileDir'] . '/.smw.json' );
+		$configFile = File::dir( $vars['smwgConfigFileDir'] . '/' . self::FILE_NAME );
 		$id = Site::id();
 
 		if ( !isset( $vars['smw.json'] ) ) {

--- a/tests/phpunit/Unit/Maintenance/AutoRecoveryTest.php
+++ b/tests/phpunit/Unit/Maintenance/AutoRecoveryTest.php
@@ -48,14 +48,14 @@ class AutoRecoveryTest extends \PHPUnit_Framework_TestCase {
 	public function testCheckForID() {
 
 		$contents = [
-			$this->site => [ 'foo' => [ 'ar_id' => false ] ]
+			$this->site => [ 'auto_recovery_mode' => [ 'foo' => [ 'ar_id' => false ] ] ]
 		];
 
 		$this->file->expects( $this->atLeastOnce() )
 			->method( 'write' )
 			->with(
 				$this->anything(),
-				$this->equalTo( json_encode( $contents ) ) );
+				$this->equalTo( json_encode( $contents, JSON_PRETTY_PRINT ) ) );
 
 		$this->file->expects( $this->atLeastOnce() )
 			->method( 'exists' )
@@ -72,7 +72,7 @@ class AutoRecoveryTest extends \PHPUnit_Framework_TestCase {
 	public function testGetSet() {
 
 		$init = [
-			$this->site => [ 'foo' => [ 'ar_id' => false ] ]
+			$this->site => [ 'auto_recovery_mode' => [ 'foo' => [ 'ar_id' => false ] ] ]
 		];
 
 		$this->file->expects( $this->atLeastOnce() )
@@ -80,14 +80,14 @@ class AutoRecoveryTest extends \PHPUnit_Framework_TestCase {
 			->will( $this->returnValue( json_encode( $init ) ) );
 
 		$contents = [
-			$this->site => [ 'foo' => [ 'ar_id' => 1001 ] ]
+			$this->site => [ 'auto_recovery_mode' => [ 'foo' => [ 'ar_id' => 1001 ] ] ]
 		];
 
 		$this->file->expects( $this->atLeastOnce() )
 			->method( 'write' )
 			->with(
 				$this->anything(),
-				$this->equalTo( json_encode( $contents ) ) );
+				$this->equalTo( json_encode( $contents, JSON_PRETTY_PRINT ) ) );
 
 		$this->file->expects( $this->atLeastOnce() )
 			->method( 'exists' )
@@ -113,7 +113,7 @@ class AutoRecoveryTest extends \PHPUnit_Framework_TestCase {
 	public function testSetClosed() {
 
 		$init = [
-			$this->site => [ 'foo' => [ 'ar_id' => 42 ] ]
+			$this->site => [ 'auto_recovery_mode' => [ 'foo' => [ 'ar_id' => 42 ] ] ]
 		];
 
 		$this->file->expects( $this->atLeastOnce() )
@@ -121,14 +121,14 @@ class AutoRecoveryTest extends \PHPUnit_Framework_TestCase {
 			->will( $this->returnValue( json_encode( $init ) ) );
 
 		$contents = [
-			$this->site => [ 'foo' => [ 'ar_id' => false ] ]
+			$this->site => [ 'auto_recovery_mode' => [ 'foo' => [ 'ar_id' => false ] ] ]
 		];
 
 		$this->file->expects( $this->atLeastOnce() )
 			->method( 'write' )
 			->with(
 				$this->anything(),
-				$this->equalTo( json_encode( $contents ) ) );
+				$this->equalTo( json_encode( $contents, JSON_PRETTY_PRINT ) ) );
 
 		$this->file->expects( $this->atLeastOnce() )
 			->method( 'exists' )
@@ -153,12 +153,12 @@ class AutoRecoveryTest extends \PHPUnit_Framework_TestCase {
 	public function testGetSafeMargin() {
 
 		$init = [
-			$this->site => [ 'foo' => [ 'ar_id' => 42 ] ]
+			$this->site => [ 'auto_recovery_mode' => [ 'foo' => [ 'ar_id' => 42 ] ] ]
 		];
 
 		$this->file->expects( $this->atLeastOnce() )
 			->method( 'read' )
-			->will( $this->returnValue( json_encode( $init ) ) );
+			->will( $this->returnValue( json_encode( $init, JSON_PRETTY_PRINT ) ) );
 
 		$this->file->expects( $this->atLeastOnce() )
 			->method( 'exists' )


### PR DESCRIPTION
This PR is made in reference to: #3922

This PR addresses or contains:

- Instead of using `.smw.maintenance.json` as introduced in #3922, use `.smw.json` to store the auto-recovery information

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed

Fixes #