### PR TITLE
Optimize #show to use specialized query lookup, refs 3588

### DIFF
--- a/DefaultSettings.php
+++ b/DefaultSettings.php
@@ -1876,9 +1876,13 @@ return [
 	# - SMW_QUERYRESULT_PREFETCH to use the prefetch method to retrieve row
 	# related items for a `QueryResult`.
 	#
+	# - SMW_SHOWPARSER_USE_CURTAILMENT to use a short cut and circumventing the
+	# `QueryEngine` and directly access the DB since `#show` will always only
+	# request an output for one particular entity.
+	#
 	# @since 3.0
 	##
-	'smwgExperimentalFeatures' => SMW_QUERYRESULT_PREFETCH,
+	'smwgExperimentalFeatures' => SMW_QUERYRESULT_PREFETCH | SMW_SHOWPARSER_USE_CURTAILMENT,
 	##
 
 	##

--- a/includes/query/SMW_QueryProcessor.php
+++ b/includes/query/SMW_QueryProcessor.php
@@ -376,11 +376,20 @@ class SMWQueryProcessor implements QueryContext {
 			$query->setLimit( 0 );
 		}
 
-		$res = self::getStoreFromParams( $params )->getQueryResult( $query );
+		$querySourceFactory = ApplicationFactory::getInstance()->getQuerySourceFactory();
+		$source = $params['source']->getValue();
+
+		if ( $source === '' && $context === self::CURTAILMENT_MODE ) {
+			$querySource = $querySourceFactory->newSingleEntityQueryLookup();
+		} else {
+			$querySource = $querySourceFactory->get( $source );
+		}
+
+		$res = $querySource->getQueryResult( $query );
 		$start = microtime( true );
 
 		if ( $res instanceof SMWQueryResult && $query->getOption( 'calc.result_hash' ) ) {
-			$query->setOption( 'result_hash', $res->getHash( 'quick' ) );
+			$query->setOption( 'result_hash', $res->getHash( SMWQueryResult::QUICK_HASH ) );
 		}
 
 		if ( ( $query->querymode == SMWQuery::MODE_INSTANCES ) ||
@@ -414,10 +423,6 @@ class SMWQueryProcessor implements QueryContext {
 
 			return $result;
 		}
-	}
-
-	private static function getStoreFromParams( array $params ) {
-		return ApplicationFactory::getInstance()->getQuerySourceFactory()->get( $params['source']->getValue() );
 	}
 
 	/**

--- a/includes/storage/SQLStore/SMW_Sql3SmwIds.php
+++ b/includes/storage/SQLStore/SMW_Sql3SmwIds.php
@@ -780,22 +780,30 @@ class SMWSql3SmwIds {
 	/**
 	 * @since 3.0
 	 *
-	 * @param string $title
+	 * @param DIWikiPage|string $title
 	 * @param integer $namespace
 	 * @param string $iw
 	 */
-	public function findAssociatedRev( $title, $namespace, $iw = '' ) {
+	public function findAssociatedRev( $title, $namespace = '', $iw = '' ) {
 		$connection = $this->store->getConnection( 'mw.db' );
 
-		$row = $connection->selectRow(
-			self::TABLE_NAME,
-			'smw_rev',
-			[
+		if ( $title instanceof DIWikiPage ) {
+			$cond = [
+				"smw_hash" => $title->getSha1()
+			];
+		} else {
+			$cond = [
 				"smw_title =" . $connection->addQuotes( $title ),
 				"smw_namespace =" . $connection->addQuotes( $namespace ),
 				"smw_iw =" . $connection->addQuotes( $iw ),
 				"smw_subobject =''"
-			],
+			];
+		}
+
+		$row = $connection->selectRow(
+			self::TABLE_NAME,
+			'smw_rev',
+			$cond,
 			__METHOD__
 		);
 

--- a/src/Defines.php
+++ b/src/Defines.php
@@ -205,6 +205,7 @@ define( 'SMW_RF_TEMPLATE_OUTSEP', 2 ); // #2022 Enable 2.5 behaviour for templat
   * Constants for $smwgExperimentalFeatures
   */
 define( 'SMW_QUERYRESULT_PREFETCH', 2 );
+define( 'SMW_SHOWPARSER_USE_CURTAILMENT', 4 );
 /**@}*/
 
 /**@{

--- a/src/ParserFunctionFactory.php
+++ b/src/ParserFunctionFactory.php
@@ -172,8 +172,18 @@ class ParserFunctionFactory {
 	 */
 	public function newShowParserFunction( Parser $parser ) {
 
+		$settings = ApplicationFactory::getInstance()->getSettings();
+
+		$askParserFunction = $this->newAskParserFunction(
+			$parser
+		);
+
+		$askParserFunction->setCurtailmentMode(
+			$settings->isFlagSet( 'smwgExperimentalFeatures', SMW_SHOWPARSER_USE_CURTAILMENT )
+		);
+
 		$showParserFunction = new ShowParserFunction(
-			$this->newAskParserFunction( $parser )
+			$askParserFunction
 		);
 
 		return $showParserFunction;

--- a/src/ParserFunctions/AskParserFunction.php
+++ b/src/ParserFunctions/AskParserFunction.php
@@ -71,6 +71,11 @@ class AskParserFunction {
 	private $showMode = false;
 
 	/**
+	 * @var boolean
+	 */
+	private $curtailmentMode = false;
+
+	/**
 	 * @var integer
 	 */
 	private $context = QueryProcessor::INLINE_QUERY;
@@ -128,6 +133,15 @@ class AskParserFunction {
 	public function setShowMode( $mode ) {
 		$this->showMode = $mode;
 		return $this;
+	}
+
+	/**
+	 * @since 3.1
+	 *
+	 * @param boolean $curtailmentMode
+	 */
+	public function setCurtailmentMode( $curtailmentMode ) {
+		$this->curtailmentMode = (bool)$curtailmentMode;
 	}
 
 	/**
@@ -337,11 +351,17 @@ class AskParserFunction {
 			$query->setOption( 'calc.result_hash', $this->postProcHandler->getOption( 'check-query' ) );
 		}
 
+		$context = $this->context;
+
+		if ( $this->showMode && $this->curtailmentMode ) {
+			$context = QueryProcessor::CURTAILMENT_MODE;
+		}
+
 		$result = QueryProcessor::getResultFromQuery(
 			$query,
 			$this->params,
 			SMW_OUTPUT_WIKI,
-			$this->context
+			$context
 		);
 
 		if ( $this->postProcHandler !== null && $this->context !== QueryProcessor::DEFERRED_QUERY ) {

--- a/src/Query/QueryContext.php
+++ b/src/Query/QueryContext.php
@@ -35,6 +35,11 @@ interface QueryContext {
 	const CONCEPT_DESC = 1003;
 
 	/**
+	 * #show query using the curtailment
+	 */
+	const CURTAILMENT_MODE = 1004;
+
+	/**
 	 * normal instance retrieval
 	 */
 	const MODE_INSTANCES = 1;

--- a/src/Query/QuerySourceFactory.php
+++ b/src/Query/QuerySourceFactory.php
@@ -6,6 +6,7 @@ use RuntimeException;
 use SMW\QueryEngine;
 use SMW\Store;
 use SMW\StoreAware;
+use SMW\ApplicationFactory;
 
 /**
  * @private
@@ -39,6 +40,15 @@ class QuerySourceFactory {
 
 		// Standard store
 		$this->querySources['sql_store'] = 'SMW\SQLStore\SQLStore';
+	}
+
+	/**
+	 * @since 3.1
+	 *
+	 * @return SingleEntityQueryLookup
+	 */
+	public function newSingleEntityQueryLookup() {
+		return $this->store->service( 'SingleEntityQueryLookup' );
 	}
 
 	/**

--- a/src/SQLStore/Lookup/SingleEntityQueryLookup.php
+++ b/src/SQLStore/Lookup/SingleEntityQueryLookup.php
@@ -1,0 +1,91 @@
+<?php
+
+namespace SMW\SQLStore\Lookup;
+
+use SMW\Store;
+use SMW\QueryEngine;
+use SMWQuery as Query;
+use SMW\Query\QueryResult;
+use SMW\ApplicationFactory;
+use SMW\Query\Language\ValueDescription;
+use SMW\SQLStore\QueryDependency\QueryDependencyLinksStore;
+use SMW\DIWikiPage;
+use RuntimeException;
+
+/**
+ * `#show` will only make a request to one particular entity therefore instead of
+ * generating a generalized query, identify the entity and create a corresponding
+ * `QueryResult` hereby by behave as any other `QueryEngine` implementation but
+ * without the query footprint.
+ *
+ * @license GNU GPL v2+
+ * @since 3.1
+ *
+ * @author mwjames
+ */
+class SingleEntityQueryLookup implements QueryEngine {
+
+	/**
+	 * @var Store
+	 */
+	private $store;
+
+	/**
+	 * @since 3.1
+	 *
+	 * @param Store $store
+	 */
+	public function __construct( Store $store ) {
+		$this->store = $store;
+	}
+
+	/**
+	 * @since 3.1
+	 *
+	 * @param Query $query
+	 *
+	 * @return QueryResult
+	 */
+	public function getQueryResult( Query $query ) {
+
+		$description = $query->getDescription();
+		$results = [];
+		$furtherResults = false;
+
+		if (
+			!$description instanceof ValueDescription ||
+			!( $dataItem = $description->getDataItem() ) instanceof DIWikiPage ) {
+			throw new RuntimeException( "Expected a ValueDescription instance!" );
+		}
+
+		if ( $query->getLimit() == 0 ) {
+			$results = [];
+			$furtherResults = true;
+		} else {
+			// Instead of relying on Title::exists, find an associated revision
+			// ID to see whether it is a known page in MW or not
+			$associatedRev = $this->store->getObjectIds()->findAssociatedRev(
+				$dataItem
+			);
+
+			// #3588
+			// Does the entity exists or not?
+			if ( $associatedRev > 0 ) {
+				$results = [ $dataItem ];
+			}
+		}
+
+		$queryResult =  new QueryResult(
+			$description->getPrintrequests(),
+			$query,
+			$results,
+			$this->store,
+			$furtherResults
+		);
+
+		\Hooks::run( 'SMW::Store::AfterQueryResultLookupComplete', [ $this->store, &$queryResult ] );
+
+		return $queryResult;
+	}
+
+}

--- a/src/SQLStore/SQLStoreFactory.php
+++ b/src/SQLStore/SQLStoreFactory.php
@@ -42,6 +42,7 @@ use SMW\SQLStore\Lookup\DisplayTitleLookup;
 use SMW\SQLStore\Lookup\ErrorLookup;
 use SMW\SQLStore\Lookup\EntityUniquenessLookup;
 use SMW\SQLStore\Lookup\TableStatisticsLookup;
+use SMW\SQLStore\Lookup\SingleEntityQueryLookup;
 use SMW\SQLStore\TableBuilder\TableBuilder;
 use SMW\SQLStore\TableBuilder\TableSchemaManager;
 use SMW\SQLStore\TableBuilder\TableBuildExaminer;
@@ -905,6 +906,20 @@ class SQLStoreFactory {
 	/**
 	 * @since 3.1
 	 *
+	 * @return SingleEntityQueryLookup
+	 */
+	public function newSingleEntityQueryLookup() {
+
+		$singleEntityQueryLookup = new SingleEntityQueryLookup(
+			$this->store
+		);
+
+		return $singleEntityQueryLookup;
+	}
+
+	/**
+	 * @since 3.1
+	 *
 	 * @return ErrorLookup
 	 */
 	public function newErrorLookup() {
@@ -980,6 +995,10 @@ class SQLStoreFactory {
 				'TableStatisticsLookup' => [
 					'_service' => [ $this, 'newTableStatisticsLookup' ],
 					'_type'    => TableStatisticsLookup::class
+				],
+				'SingleEntityQueryLookup' => [
+					'_service' => [ $this, 'newSingleEntityQueryLookup' ],
+					'_type'    => SingleEntityQueryLookup::class
 				],
 			]
 		);

--- a/tests/phpunit/Unit/SQLStore/Lookup/SingleEntityQueryLookupTest.php
+++ b/tests/phpunit/Unit/SQLStore/Lookup/SingleEntityQueryLookupTest.php
@@ -1,0 +1,195 @@
+<?php
+
+namespace SMW\Tests\SQLStore\Lookup;
+
+use SMW\SQLStore\Lookup\SingleEntityQueryLookup;
+use SMW\Tests\PHPUnitCompat;
+
+/**
+ * @covers \SMW\SQLStore\Lookup\SingleEntityQueryLookup
+ * @group semantic-mediawiki
+ *
+ * @license GNU GPL v2+
+ * @since   3.1
+ *
+ * @author mwjames
+ */
+class SingleEntityQueryLookupTest extends \PHPUnit_Framework_TestCase {
+
+	use PHPUnitCompat;
+
+	private $store;
+	private $idTable;
+
+	protected function setUp() {
+
+		$this->idTable = $this->getMockBuilder( '\SMWSql3SmwIds' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$this->store = $this->getMockBuilder( '\SMW\SQLStore\SQLStore' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$this->store->expects( $this->any() )
+			->method( 'getObjectIds' )
+			->will( $this->returnValue( $this->idTable ) );
+	}
+
+	public function testCanConstruct() {
+
+		$this->assertInstanceOf(
+			SingleEntityQueryLookup::class,
+			new SingleEntityQueryLookup( $this->store )
+		);
+
+		$this->assertInstanceOf(
+			'\SMW\QueryEngine',
+			new SingleEntityQueryLookup( $this->store )
+		);
+	}
+
+	public function testNotAValueDescription_ThrowsException() {
+
+		$query = $this->getMockBuilder( '\SMWQuery' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$query->expects( $this->any() )
+			->method( 'getDescription' )
+			->will( $this->returnValue( 'Foo' ) );
+
+		$instance = new SingleEntityQueryLookup(
+			$this->store
+		);
+
+		$this->setExpectedException( '\RuntimeException' );
+		$instance->getQueryResult( $query );
+	}
+
+	public function testNotADIWikiPage_ThrowsException() {
+
+		$valueDescription = $this->getMockBuilder( '\SMW\Query\Language\ValueDescription' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$valueDescription->expects( $this->any() )
+			->method( 'getDataItem' )
+			->will( $this->returnValue( 'Foo' ) );
+
+		$query = $this->getMockBuilder( '\SMWQuery' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$query->expects( $this->any() )
+			->method( 'getDescription' )
+			->will( $this->returnValue( $valueDescription ) );
+
+		$instance = new SingleEntityQueryLookup(
+			$this->store
+		);
+
+		$this->setExpectedException( '\RuntimeException' );
+		$instance->getQueryResult( $query );
+	}
+
+	public function testGetQueryResult() {
+
+		$this->idTable->expects( $this->any() )
+			->method( 'findAssociatedRev' )
+			->will( $this->returnValue( 1001 ) );
+
+		$dataItem = $this->getMockBuilder( '\SMW\DIWikiPage' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$valueDescription = $this->getMockBuilder( '\SMW\Query\Language\ValueDescription' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$valueDescription->expects( $this->any() )
+			->method( 'getPrintrequests' )
+			->will( $this->returnValue( [] ) );
+
+		$valueDescription->expects( $this->any() )
+			->method( 'getDataItem' )
+			->will( $this->returnValue( $dataItem ) );
+
+		$query = $this->getMockBuilder( '\SMWQuery' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$query->expects( $this->any() )
+			->method( 'getLimit' )
+			->will( $this->returnValue( 42 ) );
+
+		$query->expects( $this->any() )
+			->method( 'getDescription' )
+			->will( $this->returnValue( $valueDescription ) );
+
+		$instance = new SingleEntityQueryLookup(
+			$this->store
+		);
+
+		$res = $instance->getQueryResult( $query );
+
+		$this->assertInstanceOf(
+			'\SMW\Query\QueryResult',
+			$res
+		);
+
+		$this->assertNotEmpty(
+			$res->getResults()
+		);
+	}
+
+	public function testGetQueryResult_LimitNull() {
+
+		$this->idTable->expects( $this->never() )
+			->method( 'findAssociatedRev' );
+
+		$dataItem = $this->getMockBuilder( '\SMW\DIWikiPage' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$valueDescription = $this->getMockBuilder( '\SMW\Query\Language\ValueDescription' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$valueDescription->expects( $this->any() )
+			->method( 'getPrintrequests' )
+			->will( $this->returnValue( [] ) );
+
+		$valueDescription->expects( $this->any() )
+			->method( 'getDataItem' )
+			->will( $this->returnValue( $dataItem ) );
+
+		$query = $this->getMockBuilder( '\SMWQuery' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$query->expects( $this->any() )
+			->method( 'getLimit' )
+			->will( $this->returnValue( 0 ) );
+
+		$query->expects( $this->any() )
+			->method( 'getDescription' )
+			->will( $this->returnValue( $valueDescription ) );
+
+		$instance = new SingleEntityQueryLookup(
+			$this->store
+		);
+
+		$res = $instance->getQueryResult( $query );
+
+		$this->assertInstanceOf(
+			'\SMW\Query\QueryResult',
+			$res
+		);
+
+		$this->assertEmpty(
+			$res->getResults()
+		);
+	}
+
+}


### PR DESCRIPTION
This PR is made in reference to: #3588

This PR addresses or contains:

- `#show` always expects a single entity (subject) as condition and instead of building a specific SQL (or any other query related DSL) condition and run it through the `QueryEngine`, use the fact that it is a single subject, circumvent the query building (via the `QueryEngine`), and immediately return a `QueryResult` object
- `#show` may be used to make a judgement about whether the requested entity "exists" or not (#3588), the `SingleEntityQueryLookup` will check if an associated revision exists and in case it does not it will return an empty `QueryResult` making the assumption (and so the `default=...` printout) about an existential statement always to apply (this will only be done for `#show`)
- Using `#show` in connection with `SMW_SHOWPARSER_USE_CURTAILMENT` should reduce the amount of queries required now that the `QueryEngine` is no longer used to resolve the query condition
- Adds `SMW_SHOWPARSER_USE_CURTAILMENT` as `smwgExperimentalFeatures` flag (== default) to curtail on how `#show` query results are retrieved
  - The flag is added to revert to the previous behaviour state in case of some unforeseen behaviour change that hasn't been tested
  - The flag should be removed by the next release given that the feature has been declared as stable and the functionality as been promoted to be the default behaviour

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed

Fixes #3588