### PR TITLE
CSS switching tabs on `max-width: 800px` from horizontal to vertical

### DIFF
--- a/res/smw/content/smw.schema.css
+++ b/res/smw/content/smw.schema.css
@@ -172,3 +172,8 @@
 .smw-schema input.nav-tab:checked + label.nav-label.error-label {
 	border-top: 2px solid #cc0000;
 }
+
+.skin-chameleon .content-no-highlight {
+    border-radius: 0px;
+    margin: 1em 0px;
+}

--- a/res/smw/ext.smw.page.css
+++ b/res/smw/ext.smw.page.css
@@ -242,17 +242,23 @@
 	font-weight: normal;
 }
 
+/**
+ * Use !important to avoid that any other default CSS
+ * for input fields disrupt the design
+ */
 .smw-ui-input-filter input {
-	border :0px solid #ddd;
-    padding: .42em .55em .35em .55em;
-    border-top-left-radius: .0em;
-    border-bottom-left-radius: .0em;
-    outline: none;
-    border-left: 0.1em solid #ddd;
-    /* border-left: 0; */
-    margin-left: 0.45em;
-    font-weight: normal;
-    color: #333333;
+	all: initial !important;
+	border :0px solid #ddd !important;
+	padding: .42em .55em .35em .55em !important;
+	border-top-left-radius: .0em !important;
+	border-bottom-left-radius: .0em !important;
+	outline: none !important;
+	border-left: 1px solid #ddd !important;
+	/* border-left: 0; */
+	margin-left: 0.45em !important;
+	font-weight: normal !important;
+	color: #333333 !important;
+	width: 150px !important;
 }
 
 .smw-property-page-results .value-row:nth-child(odd) {
@@ -387,6 +393,11 @@
  * Responsive settings (@see ext.smw.table)
  */
 @media screen and (max-width: 800px) {
+
+	.smw-page-nav-container {
+	    display: flex;
+	    flex-direction: column;
+	 }
 
 	.smw-page-nav-right {
 		float: left;

--- a/res/smw/ext.smw.skin.css
+++ b/res/smw/ext.smw.skin.css
@@ -63,8 +63,12 @@
 	line-height: 1.8;
 }
 
+.skin-chameleon .smw-tabs section pre {
+	margin-top: 10px;
+}
+
 .smw-ui-input-filter input {
-	padding: .33em .55em .33em .55em;
+	padding: .25em .55em .25em .55em !important;
 }
 
 /**

--- a/res/smw/ext.smw.tabs.css
+++ b/res/smw/ext.smw.tabs.css
@@ -78,6 +78,28 @@
 }
 
 /**
+ * Responsive settings
+ */
+@media screen and (max-width: 800px) {
+	.smw-tabs {
+		display: flex;
+		flex-direction: column;
+	}
+
+	.smw-tabs label.nav-label {
+		text-align: unset;
+		padding: 5px 25px;
+		border-top: 1px solid;
+	}
+
+	.smw-tabs input.nav-tab:checked + label.nav-label {
+		border-left: 0px !important;
+		border-right: 0px !important;
+		background-color: #f9f9f9a8;
+	}
+}
+
+/**
  * Requires to be adjusted by each set that uses the rules
  * to assign a tab to a content section.
  */

--- a/res/smw/factbox/smw.factbox.css
+++ b/res/smw/factbox/smw.factbox.css
@@ -156,7 +156,7 @@
 }
 
 .smw-factbox label.nav-label {
-	padding: 5px 25px 3px 25px;
+	padding: 3px 25px 3px 25px;
 }
 
 .smw-factbox input.nav-tab:checked + label.nav-label {
@@ -210,6 +210,10 @@
 	.smwfact .smwpropname, .smwfact .smwspecname {
 		width: auto;
 		font-weight: bold;
+	}
+
+	.smw-factbox label.nav-label {
+		padding: 5px 25px 5px 5px;
 	}
 }
 

--- a/res/smw/special/ext.smw.special.ask.css
+++ b/res/smw/special/ext.smw.special.ask.css
@@ -197,7 +197,7 @@ div#query legend {
 display: inline-block;
     padding: .30em .55em;
     margin-left: -1px;
-    margin-right: 10px;
+    margin-right: 0px;
     line-height: 1.25;
     color: #007bff;
     background-color: #fff;
@@ -652,6 +652,10 @@ display: inline-block;
 	.smw-ask-format-selector {
 		display: inline-block;
 		margin-bottom: 0;
+	}
+
+	.smw-tabs label.nav-label.smw-tab-right {
+		display: none;
 	}
 }
 

--- a/res/smw/special/ext.smw.special.css
+++ b/res/smw/special/ext.smw.special.css
@@ -123,10 +123,6 @@
 	padding: 5px 0 0 0 !important;
 }
 
-.smw-tabs.smw-admin label.nav-label {
-	padding: 8px 20px;
-}
-
 .smw-admin input.nav-tab:checked + label.nav-label {
 	border: 1px solid #aaa;
 	border-top: 2px solid orange;
@@ -158,5 +154,20 @@
 		display: flex;
 		flex-direction: column;
 		flex-wrap: wrap;
+	}
+
+	.smw-tabs.smw-admin {
+		display: flex;
+		flex-direction: column;
+	}
+
+	.smw-tabs.smw-admin label.nav-label {
+		text-align: unset;
+		border-top: 1px solid;
+	}
+
+	.smw-tabs.smw-admin input.nav-tab:checked + label.nav-label {
+		border-left: 0px;
+		border-right: 0px;
 	}
 }


### PR DESCRIPTION
This PR is made in reference to: #

This PR addresses or contains:

- If the screen size fall beyond the 800px threshold then tabs move from horizontal to a vertical display which should allow for a better users experience on mobile devices.

This PR includes:
- [ ] Tests (unit/integration)
- [ ] CI build passed

### Examples

![2019-06-09_1-41-26](https://user-images.githubusercontent.com/1245473/59150029-adb3e780-8a0c-11e9-8179-59d54f1a133f.jpg)
![2019-06-09_1-41-53](https://user-images.githubusercontent.com/1245473/59150030-adb3e780-8a0c-11e9-85e0-8fb7f0473ccd.jpg)
![2019-06-09_1-42-34](https://user-images.githubusercontent.com/1245473/59150031-ae4c7e00-8a0c-11e9-8ad8-ffa598a6a4d7.jpg)
![2019-06-09_1-42-51](https://user-images.githubusercontent.com/1245473/59150028-adb3e780-8a0c-11e9-8009-323dc5968575.jpg)
