### PR TITLE
`RedirectStore` to check active section transaction before invoking an update job

### DIFF
--- a/src/MediaWiki/Connection/Database.php
+++ b/src/MediaWiki/Connection/Database.php
@@ -880,6 +880,16 @@ class Database {
 	/**
 	 * @since 3.1
 	 *
+	 * @param  string $fname
+	 * @return boolean
+	 */
+	public function inSectionTransaction( $fname = __METHOD__ ) {
+		return $this->sectionTransaction === $fname;
+	}
+
+	/**
+	 * @since 3.1
+	 *
 	 * @param string $fname
 	 */
 	public function endSectionTransaction( $fname = __METHOD__ ) {

--- a/src/SQLStore/RedirectStore.php
+++ b/src/SQLStore/RedirectStore.php
@@ -193,8 +193,11 @@ class RedirectStore {
 			}
 		}
 
+
+		$canRun = $this->isCommandLineMode && !$connection->inSectionTransaction( 'SMWSQLStore3Writers::doDataUpdate' );
+
 		foreach ( $jobs as $job ) {
-			if ( $this->isCommandLineMode ) {
+			if ( $canRun ) {
 				$job->run();
 			} else {
 				$job->lazyPush();

--- a/tests/phpunit/Unit/MediaWiki/Connection/DatabaseTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Connection/DatabaseTest.php
@@ -606,6 +606,11 @@ class DatabaseTest extends \PHPUnit_Framework_TestCase {
 		);
 
 		$instance->beginSectionTransaction( __METHOD__ );
+
+		$this->assertTrue(
+			$instance->inSectionTransaction( __METHOD__ )
+		);
+
 		$instance->endSectionTransaction( __METHOD__ );
 	}
 


### PR DESCRIPTION
This PR is made in reference to: #

This PR addresses or contains:

- Avoid running an update from within an active section transaction as seen by the `RedirectStore` when running from the command line an defer the update to `lazyPush` instead of `run`

This PR includes:
- [ ] Tests (unit/integration)
- [x] CI build passed

### Stack

```
Trying to begin a new section transaction while SMWSQLStore3Writers::doDataUpdate is still active!##0 ...\extensions\SemanticMediaWiki\includes\storage\SQLStore\SMW_SQLStore3_Writers.php(196): SMW\MediaWiki\Connection\Database->beginSectionTransaction('SMWSQLStore3Wri...')
#1 ...\extensions\SemanticMediaWiki\includes\storage\SQLStore\SMW_SQLStore3.php(273): SMWSQLStore3Writers->doDataUpdate(Object(SMW\SemanticData))
#2 ...\extensions\SemanticMediaWiki\src\Store.php(237): SMWSQLStore3->doDataUpdate(Object(SMW\SemanticData))
#3 ...\extensions\SemanticMediaWiki\src\DataUpdater.php(396): SMW\Store->updateData(Object(SMW\SemanticData))
#4 ...\extensions\SemanticMediaWiki\src\DataUpdater.php(282): SMW\DataUpdater->updateData()
#5 ...\extensions\SemanticMediaWiki\src\DataUpdater.php(193): SMW\DataUpdater->performUpdate()
#6 ...\extensions\SemanticMediaWiki\src\ParserData.php(453): SMW\DataUpdater->doUpdate()
#7 ...\extensions\SemanticMediaWiki\src\MediaWiki\Jobs\UpdateJob.php(296): SMW\ParserData->updateStore()
#8 ...\extensions\SemanticMediaWiki\src\MediaWiki\Jobs\UpdateJob.php(216): SMW\MediaWiki\Jobs\UpdateJob->updateStore(Object(SMW\ParserData))
#9 ...\extensions\SemanticMediaWiki\src\MediaWiki\Jobs\UpdateJob.php(137): SMW\MediaWiki\Jobs\UpdateJob->parse_content()
#10 ...\extensions\SemanticMediaWiki\src\MediaWiki\Jobs\UpdateJob.php(94): SMW\MediaWiki\Jobs\UpdateJob->doUpdate()
#11 ...\extensions\SemanticMediaWiki\src\SQLStore\RedirectStore.php(199): SMW\MediaWiki\Jobs\UpdateJob->run()
#12 ...\extensions\SemanticMediaWiki\includes\storage\SQLStore\SMW_Sql3SmwIds.php(215): SMW\SQLStore\RedirectStore->updateRedirect(517, 'Lorem_Ipsum', 0)
#13 ...\extensions\SemanticMediaWiki\src\SQLStore\RedirectUpdater.php(293): SMWSql3SmwIds->updateRedirect(517, 'Lorem_Ipsum', 0)
#14 ...\extensions\SemanticMediaWiki\includes\storage\SQLStore\SMW_SQLStore3_Writers.php(300): SMW\SQLStore\RedirectUpdater->updateRedirects(Object(SMW\DIWikiPage))
#15 ...\extensions\SemanticMediaWiki\includes\storage\SQLStore\SMW_SQLStore3_Writers.php(225): SMWSQLStore3Writers->doFlatDataUpdate(Object(SMW\SemanticData))
#16 ...\extensions\SemanticMediaWiki\includes\storage\SQLStore\SMW_SQLStore3.php(273): SMWSQLStore3Writers->doDataUpdate(Object(SMW\SemanticData))
#17 ...\extensions\SemanticMediaWiki\src\Store.php(237): SMWSQLStore3->doDataUpdate(Object(SMW\SemanticData))
#18 ...\extensions\SemanticMediaWiki\src\Store.php(274): SMW\Store->updateData(Object(SMW\SemanticData))
#19 ...\extensions\SemanticMediaWiki\src\SQLStore\RedirectUpdater.php(498): SMW\Store->clearData(Object(SMW\DIWikiPage))
#20 ...\extensions\SemanticMediaWiki\src\SQLStore\RedirectUpdater.php(160): SMW\SQLStore\RedirectUpdater->moveAsRedirect(Object(SMW\DIWikiPage), Object(SMW\DIWikiPage), 524, 517, Array)
#21 ...\extensions\SemanticMediaWiki\includes\storage\SQLStore\SMW_SQLStore3_Writers.php(426): SMW\SQLStore\RedirectUpdater->doUpdate(Object(SMW\DIWikiPage), Object(SMW\DIWikiPage), Array)
#22 ...\extensions\SemanticMediaWiki\includes\storage\SQLStore\SMW_SQLStore3.php(287): SMWSQLStore3Writers->changeTitle(Object(Title), Object(Title), 17, 16)
#23 ...\extensions\SemanticMediaWiki\src\DataUpdater.php(450): SMWSQLStore3->changeTitle(Object(Title), Object(Title), 17, 16)
#24 ...\extensions\SemanticMediaWiki\src\DataUpdater.php(421): SMW\DataUpdater->doUpdateUnknownRedirectTarget(Object(SMW\SemanticData), Object(Title))
#25 ...\extensions\SemanticMediaWiki\src\DataUpdater.php(390): SMW\DataUpdater->checkOnRequiredRedirectUpdate(Object(SMW\SemanticData))
#26 ...\extensions\SemanticMediaWiki\src\DataUpdater.php(282): SMW\DataUpdater->updateData()
#27 ...\extensions\SemanticMediaWiki\src\DataUpdater.php(193): SMW\DataUpdater->performUpdate()
#28 ...\extensions\SemanticMediaWiki\src\ParserData.php(453): SMW\DataUpdater->doUpdate()
#29 ...\extensions\SemanticMediaWiki\src\MediaWiki\Hooks\LinksUpdateConstructed.php(120): SMW\ParserData->updateStore(Array)
#30 ...\extensions\SemanticMediaWiki\src\MediaWiki\Hooks.php(757): SMW\MediaWiki\Hooks\LinksUpdateConstructed->process(Object(LinksUpdate))
#31 ...\Hooks.php(174): SMW\MediaWiki\Hooks->onLinksUpdateConstructed(Object(LinksUpdate))
#32 ...\Hooks.php(202): Hooks::callHook('LinksUpdateCons...', Array, Array, NULL)
#33 ...\deferred\LinksUpdate.php(154): Hooks::run('LinksUpdateCons...', Array)
#34 ...\content\AbstractContent.php(238): LinksUpdate->__construct(Object(Title), Object(ParserOutput), true)
#35 ...\Storage\DerivedPageDataUpdater.php(1322): AbstractContent->getSecondaryDataUpdates(Object(Title), NULL, true, Object(ParserOutput))
#36 ...\Storage\DerivedPageDataUpdater.php(1559): MediaWiki\Storage\DerivedPageDataUpdater->getSecondaryDataUpdates(true)
#37 ...\Storage\DerivedPageDataUpdater.php(1401): MediaWiki\Storage\DerivedPageDataUpdater->doSecondaryDataUpdates(Array)
#38 ...\page\WikiPage.php(2036): MediaWiki\Storage\DerivedPageDataUpdater->doUpdates()
#39 ...\import\ImportableOldRevisionImporter.php(138): WikiPage->doEditUpdates(Object(MediaWiki\Revision\RevisionStoreRecord), Object(User), Array)
#40 ...\import\WikiRevision.php(602): ImportableOldRevisionImporter->import(Object(WikiRevision))
#41 ...\import\WikiImporter.php(367): WikiRevision->importOldRevision()
#42 ...\import\WikiImporter.php(504): WikiImporter->importRevision(Object(WikiRevision), Object(WikiImporter))
#43 ...\import\WikiImporter.php(944): WikiImporter->revisionCallback(Object(WikiRevision))
#44 ...\import\WikiImporter.php(860): WikiImporter->processRevision(Array, Array)
#45 ...\import\WikiImporter.php(802): WikiImporter->handleRevision(Array)
#46 ...\import\WikiImporter.php(609): WikiImporter->handlePage()
#47 ...\extensions\SemanticMediaWiki\tests\phpunit\Utils\Runners\XmlImportRunner.php(101): WikiImporter->doImport()
#48 ...\extensions\SemanticMediaWiki\tests\phpunit\Benchmark\PageImportBenchmarkRunner.php(106): SMW\Tests\Utils\Runners\XmlImportRunner->run()
#49 ...\extensions\SemanticMediaWiki\tests\phpunit\Benchmark\PageImportBenchmarkRunner.php(91): SMW\Tests\Benchmark\PageImportBenchmarkRunner->doXmlImport('C:\\xampp\\htdocs...', Array)
#50 ...\extensions\SemanticMediaWiki\tests\phpunit\Benchmark\BenchmarkJsonScriptRunnerTest.php(172): SMW\Tests\Benchmark\PageImportBenchmarkRunner->run(Array)
#51 ...\extensions\SemanticMediaWiki\tests\phpunit\Benchmark\BenchmarkJsonScriptRunnerTest.php(145): SMW\Tests\Benchmark\BenchmarkJsonScriptRunnerTest->doRunImportBenchmarks(Object(SMW\Tests\JsonTestCaseFileHandler))
#52 ...\extensions\SemanticMediaWiki\tests\phpunit\JsonTestCaseScriptRunner.php(215): SMW\Tests\Benchmark\BenchmarkJsonScriptRunnerTest->runTestCaseFile(Object(SMW\Tests\JsonTestCaseFileHandler))
#53 [internal function]: SMW\Tests\JsonTestCaseScriptRunner->testCaseFile('C:\\xampp\\htdocs...')
#54 ...\vendor\phpunit\phpunit\src\Framework\TestCase.php(1071): ReflectionMethod->invokeArgs(Object(SMW\Tests\Benchmark\BenchmarkJsonScriptRunnerTest), Array)
#55 ...\vendor\phpunit\phpunit\src\Framework\TestCase.php(939): PHPUnit\Framework\TestCase->runTest()
#56 ...\vendor\phpunit\phpunit\src\Framework\TestResult.php(698): PHPUnit\Framework\TestCase->runBare()
#57 ...\vendor\phpunit\phpunit\src\Framework\TestCase.php(894): PHPUnit\Framework\TestResult->run(Object(SMW\Tests\Benchmark\BenchmarkJsonScriptRunnerTest))
#58 ...\extensions\SemanticMediaWiki\tests\phpunit\DatabaseTestCase.php(138): PHPUnit\Framework\TestCase->run(Object(MediaWikiTestResult))
#59 ...\vendor\phpunit\phpunit\src\Framework\TestSuite.php(755): SMW\Tests\DatabaseTestCase->run(Object(MediaWikiTestResult))
#60 ...\vendor\phpunit\phpunit\src\Framework\TestSuite.php(755): PHPUnit\Framework\TestSuite->run(Object(MediaWikiTestResult))
#61 ...\vendor\phpunit\phpunit\src\Framework\TestSuite.php(755): PHPUnit\Framework\TestSuite->run(Object(MediaWikiTestResult))
#62 ...\vendor\phpunit\phpunit\src\TextUI\TestRunner.php(545): PHPUnit\Framework\TestSuite->run(Object(MediaWikiTestResult))
#63 ...\vendor\phpunit\phpunit\src\TextUI\Command.php(195): PHPUnit\TextUI\TestRunner->doRun(Object(PHPUnit\Framework\TestSuite), Array, true)
#64 ...\tests\phpunit\phpunit.php(90): PHPUnit\TextUI\Command->run(Array, true)
#65 ...\maintenance\doMaintenance.php(94): PHPUnitMaintClass->execute()
#66 ...\tests\phpunit\phpunit.php(129): require('C:\\xampp\\htdocs...')
```