### PR TITLE
Fix "InvalidateEntityCacheEventListener ... title is unknown", refs 4083

### DIFF
--- a/src/Events/InvalidateEntityCacheEventListener.php
+++ b/src/Events/InvalidateEntityCacheEventListener.php
@@ -36,15 +36,20 @@ class InvalidateEntityCacheEventListener implements EventListener {
 	 */
 	public function execute( DispatchContext $dispatchContext = null ) {
 
-		$title = $dispatchContext->get( 'title' );
-		$context = $dispatchContext->get( 'context' );
+		if ( $dispatchContext->has( 'subject' ) ) {
+			$subject = $dispatchContext->get( 'subject' );
+			$id = $subject->getHash();
+		} else {
+			$subject = $dispatchContext->get( 'title' );
+			$id = $subject->getPrefixedDBKey();
+		}
 
-		$this->entityCache->invalidate( $title );
-		$subject = $title->getPrefixedDBKey();
+		$context = $dispatchContext->get( 'context' );
+		$this->entityCache->invalidate( $subject );
 
 		$this->logger->info(
-			[ 'Event', 'InvalidateEntityCache', "{caused_by}", "{subject}" ],
-			[ 'role' => 'user', 'caused_by' => $context, 'subject' => $subject ]
+			[ 'Event', 'InvalidateEntityCache', "{caused_by}", "{id}" ],
+			[ 'role' => 'user', 'caused_by' => $context, 'id' => $id ]
 		);
 	}
 

--- a/tests/phpunit/Unit/Events/InvalidateEntityCacheEventListenerTest.php
+++ b/tests/phpunit/Unit/Events/InvalidateEntityCacheEventListenerTest.php
@@ -1,0 +1,96 @@
+<?php
+
+namespace SMW\Tests\Events;
+
+use SMW\DIWikiPage;
+use SMW\Events\InvalidateEntityCacheEventListener;
+use Onoi\EventDispatcher\DispatchContext;
+use SMW\Tests\TestEnvironment;
+
+/**
+ * @covers \SMW\Events\InvalidateEntityCacheEventListener
+ * @group semantic-mediawiki
+ *
+ * @license GNU GPL v2+
+ * @since 3.1
+ *
+ * @author mwjames
+ */
+class InvalidateEntityCacheEventListenerTest extends \PHPUnit_Framework_TestCase {
+
+	private $entityCache;
+	private $spyLogger;
+
+	protected function setUp() {
+		parent::setUp();
+
+		$this->spyLogger = TestEnvironment::newSpyLogger();
+
+		$this->entityCache = $this->getMockBuilder( '\SMW\EntityCache' )
+			->disableOriginalConstructor()
+			->getMock();
+	}
+
+	protected function tearDown() {
+		parent::tearDown();
+	}
+
+	public function testCanConstruct() {
+
+		$this->assertInstanceOf(
+			InvalidateEntityCacheEventListener::class,
+			new InvalidateEntityCacheEventListener( $this->entityCache )
+		);
+	}
+
+	public function testExecute_OnSubject() {
+
+		$context = DispatchContext::newFromArray(
+			[
+				'subject' => DIWikiPage::newFromText( __METHOD__ ),
+				'context' => 'Bar'
+			]
+		);
+
+		$this->entityCache->expects( $this->once() )
+			->method( 'invalidate' );
+
+		$instance = new InvalidateEntityCacheEventListener(
+			$this->entityCache
+		);
+
+		$instance->setLogger(
+			$this->spyLogger
+		);
+
+		$instance->execute( $context );
+	}
+
+	public function testExecute_OnTitle() {
+
+		$title = $this->getMockBuilder( '\Title' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$context = DispatchContext::newFromArray(
+			[
+				'title' => $title,
+				'context' => 'Bar'
+			]
+		);
+
+		$this->entityCache->expects( $this->once() )
+			->method( 'invalidate' );
+
+		$instance = new InvalidateEntityCacheEventListener(
+			$this->entityCache
+		);
+
+		$instance->setLogger(
+			$this->spyLogger
+		);
+
+		$instance->execute( $context );
+	}
+
+}


### PR DESCRIPTION
This PR is made in reference to: #4083

This PR addresses or contains:

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed

Fixes #4083