### PR TITLE
Handle predefined properties DBKey, refs 4080

### DIFF
--- a/src/Elastic/QueryEngine/QueryEngine.php
+++ b/src/Elastic/QueryEngine/QueryEngine.php
@@ -10,6 +10,7 @@ use SMW\Query\Language\ThingDescription;
 use SMW\Query\ScoreSet;
 use SMW\QueryEngine as IQueryEngine;
 use SMW\Store;
+use SMW\DIProperty;
 use SMWQuery as Query;
 use SMWQueryResult as QueryResult;
 
@@ -318,6 +319,15 @@ class QueryEngine implements IQueryEngine {
 			}
 
 			$id = $dataItem->getId();
+			$subobjectName = $dataItem->getSubobjectName();
+
+			// Handle predefined properties
+			if ( $dataItem->getNamespace() === SMW_NS_PROPERTY && ( $dbKey = $dataItem->getDBKEY() ) && $dbKey{0} === '_' ) {
+				$dataItem = DIProperty::newFromUserLabel( $dbKey )->getDIWikiPage(
+					$subobjectName
+				);
+			}
+
 			$results[$listPos[$id]] = $dataItem;
 
 			if ( isset( $scores[$id] ) ) {

--- a/src/SQLStore/Lookup/MonolingualTextLookup.php
+++ b/src/SQLStore/Lookup/MonolingualTextLookup.php
@@ -89,7 +89,17 @@ class MonolingualTextLookup {
 				$row
 			);
 
-			$h = $containerSemanticData->getSubject()->getHash();
+			$subject = $containerSemanticData->getSubject();
+			$subobjectName = $subject->getSubobjectName();
+
+			// Handle predefined properties
+			if ( $subject->getNamespace() === SMW_NS_PROPERTY && ( $dbKey = $subject->getDBKey() ) && $dbKey{0} === '_' ) {
+				$subject = DIProperty::newFromUserLabel( $dbKey )->getCanonicalDIWikiPage(
+					$subobjectName
+				);
+			}
+
+			$h = $subject->getHash();
 			$text = $row->text_short;
 
 			if ( $row->text_long !== null ) {

--- a/tests/phpunit/Integration/JSONScript/TestCases/f-0206.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/f-0206.json
@@ -7,12 +7,21 @@
 			"contents": "[[Has type::Number]] [[Has property description::A number to display ....@en]]"
 		},
 		{
+			"namespace": "SMW_NS_PROPERTY",
+			"page": "Modification date",
+			"contents": "[[Property description::Some description@en]]"
+		},
+		{
 			"page": "Example/F0206/1/1",
 			"contents": "[[Has number::1001]]"
 		},
 		{
 			"page": "Example/F0206/1a",
 			"contents": "{{#ask: [[~Example/F0206/1/*]] |?Has number |format=table }}"
+		},
+		{
+			"page": "F0206/Q2",
+			"contents": "{{#ask: [[Property:Modification date]] |?Property description |format=table }}"
 		}
 	],
 	"tests": [
@@ -24,6 +33,17 @@
 				"to-contain": [
 					"<span class=\"smwttcontent\">A number to display ....</span>",
 					"<td class=\"Has-number smwtype_num\" data-sort-value=\"1001\">1,001</td>"
+				]
+			}
+		},
+		{
+			"type": "format",
+			"about": "#1",
+			"subject": "F0206/Q2",
+			"assert-output": {
+				"to-contain": [
+					"<a href=\".*Property:Modification_date\" title=\"Property:Modification date\">Modification date</a>",
+					"<td class=\"Property-description smwtype_mlt_rec\">Some description (en)</td>"
 				]
 			}
 		}


### PR DESCRIPTION
This PR is made in reference to: #4080

This PR addresses or contains:

- Ensures that any predefined property key (e.g. `_MDAT`) is transformed into its canonical representation

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed
