### PR TITLE
Fix requirement of registered account for maintenance loggers

### DIFF
--- a/src/MediaWiki/ManualEntryLogger.php
+++ b/src/MediaWiki/ManualEntryLogger.php
@@ -63,7 +63,7 @@ class ManualEntryLogger {
 		$logEntry->setTarget( Title::newFromText( $target ) );
 
 		if ( is_string( $performer) ) {
-			$performer = User::newFromName( $performer );
+			$performer = User::newSystemUser( $performer, [ 'steal' => true ] );
 		}
 
 		$logEntry->setPerformer( $performer );


### PR DESCRIPTION
This PR is made in reference to: #4077 

This PR addresses or contains:
- Fixes requirement for registered account to be used for logging. Code change as suggested by @mwjames https://github.com/SemanticMediaWiki/SemanticMediaWiki/issues/4077#issuecomment-500544388

This PR includes:
- [ ] Tests (unit/integration)
- [x] CI build passed

Fixes #4077 