### PR TITLE
 [first pr] Use PrevNextNavigationRenderer::buildPrevNextNavigation

### DIFF
--- a/includes/querypages/QueryPage.php
+++ b/includes/querypages/QueryPage.php
@@ -3,6 +3,7 @@
 namespace SMW;
 
 use Html;
+use SMW\MediaWiki\MessageBuilder;
 use SMWRequestOptions;
 use SMWStringCondition;
 use Xml;
@@ -136,10 +137,11 @@ abstract class QueryPage extends \QueryPage {
 		// during doQuery() which is processed before this form is generated
 		$resultCount = wfShowingResults( $this->selectOptions['offset'], $this->selectOptions['count'] );
 
-		$selection = $this->getLanguage()->viewPrevNext(
+		$msgBuilder =  new MessageBuilder( $this->getLanguage() );
+		$selection = $msgBuilder->prevNextToText(
 			$this->getContext()->getTitle(),
-			$this->selectOptions['offset'],
 			$this->selectOptions['limit'],
+			$this->selectOptions['offset'],
 			$this->linkParameters(),
 			$this->selectOptions['end']
 		);

--- a/src/MediaWiki/MessageBuilder.php
+++ b/src/MediaWiki/MessageBuilder.php
@@ -4,6 +4,7 @@ namespace SMW\MediaWiki;
 
 use IContextSource;
 use Language;
+use MediaWiki\Navigation\PrevNextNavigationRenderer;
 use Message;
 use RuntimeException;
 use Title;
@@ -93,7 +94,12 @@ class MessageBuilder {
 	 * @return string
 	 */
 	public function prevNextToText( Title $title, $limit, $offset, array $query, $isAtTheEnd ) {
-		return $this->getLanguage()->viewPrevNext( $title, $offset, $limit, $query, $isAtTheEnd );
+		if ( class_exists( 'MediaWiki\Navigation\PrevNextNavigationRenderer' ) ) {
+			$prevNext =  new PrevNextNavigationRenderer( \RequestContext::getMain() );
+			return $prevNext->buildPrevNextNavigation( $title, $offset, $limit, $query, $isAtTheEnd );
+		} else {
+			return $this->getLanguage()->viewPrevNext( $title, $offset, $limit, $query, $isAtTheEnd );
+		}
 	}
 
 	/**

--- a/src/MediaWiki/Specials/Admin/OutputFormatter.php
+++ b/src/MediaWiki/Specials/Admin/OutputFormatter.php
@@ -99,7 +99,11 @@ class OutputFormatter {
 	 * @param string $text
 	 */
 	public function addWikiText( $text ) {
-		$this->outputPage->addWikiText( $text );
+		if ( method_exists( $this->outputPage, 'addWikiTextAsInterface' ) ) {
+			$this->outputPage->addWikiTextAsInterface( $text );
+		} else {
+			$this->outputPage->addWikiText( $text );
+		}
 	}
 
 	/**

--- a/tests/phpunit/Unit/MediaWiki/Specials/Admin/OutputFormatterTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Specials/Admin/OutputFormatterTest.php
@@ -91,8 +91,13 @@ class OutputFormatterTest extends \PHPUnit_Framework_TestCase {
 
 	public function testAddWikiText() {
 
-		$this->outputPage->expects( $this->once() )
-			->method( 'addWikiText' );
+		if ( method_exists( $this->outputPage, 'addWikiTextAsInterface' ) ) {
+			$this->outputPage->expects( $this->once() )
+				->method( 'addWikiTextAsInterface' );
+		} else {
+			$this->outputPage->expects( $this->once() )
+				->method( 'addWikiText' );
+		}
 
 		$instance = new OutputFormatter( $this->outputPage );
 		$instance->addWikiText( 'Foo' );


### PR DESCRIPTION
This PR is made in reference to: #4092 

This PR addresses or contains:
- Deprecate WebInstallerOutput::addWikiText
- Use new buildPrevNextNavigation

This PR includes:
- [x] Tests (unit/integration)
- [ ] CI build passed

Fixes #