### PR TITLE
Change constant name from DB_SLAVE to DB_REPLICA

### DIFF
--- a/DefaultSettings.php
+++ b/DefaultSettings.php
@@ -153,18 +153,18 @@ return [
 	#
 	# Available DB index as provided by MediaWiki:
 	#
-	# - DB_SLAVE or DB_REPLICA (1.28+)
+	# - DB_REPLICA (1.28+)
 	# - DB_MASTER
 	#
 	# @since 2.5.3
 	##
 	'smwgLocalConnectionConf' => [
 		'mw.db' => [
-			'read'  => DB_SLAVE,
+			'read'  => DB_REPLICA,
 			'write' => DB_MASTER
 		],
 		'mw.db.queryengine' => [
-			'read'  => DB_SLAVE,
+			'read'  => DB_REPLICA,
 			'write' => DB_MASTER
 		]
 	],

--- a/includes/export/SMW_ExportController.php
+++ b/includes/export/SMW_ExportController.php
@@ -537,7 +537,7 @@ class SMWExportController {
 	 */
 	protected function printAll( $ns_restriction = false, $delay, $delayeach ) {
 		$linkCache = LinkCache::singleton();
-		$db = wfGetDB( DB_SLAVE );
+		$db = wfGetDB( DB_REPLICA );
 
 		$this->delay_flush = 10;
 
@@ -602,7 +602,7 @@ class SMWExportController {
 	public function printPageList( $offset = 0, $limit = 30 ) {
 		global $smwgNamespacesWithSemanticLinks;
 
-		$db = wfGetDB( DB_SLAVE );
+		$db = wfGetDB( DB_REPLICA );
 		$this->prepareSerialization();
 		$this->delay_flush = 35; // don't do intermediate flushes with default parameters
 		$linkCache = LinkCache::singleton();

--- a/src/MediaWiki/Connection/ConnectionProvider.php
+++ b/src/MediaWiki/Connection/ConnectionProvider.php
@@ -68,7 +68,7 @@ class ConnectionProvider implements IConnectionProvider {
 
 		// Default configuration
 		$conf = [
-			'read'  => DB_SLAVE,
+			'read'  => DB_REPLICA,
 			'write' => DB_MASTER
 		];
 
@@ -144,8 +144,8 @@ class ConnectionProvider implements IConnectionProvider {
 				'role' => 'developer',
 				'provider' => $this->provider,
 				'conf' => [
-					'read'  => $conf['read'] === DB_SLAVE ? 'DB_SLAVE' : 'DB_MASTER',
-					'write' => $conf['write'] === DB_SLAVE ? 'DB_SLAVE' : 'DB_MASTER',
+					'read'  => $conf['read'] === DB_REPLICA ? 'DB_REPLICA' : 'DB_MASTER',
+					'write' => $conf['write'] === DB_REPLICA ? 'DB_REPLICA' : 'DB_MASTER',
 				]
 			]
 		);

--- a/src/MediaWiki/Search/SearchEngineFactory.php
+++ b/src/MediaWiki/Search/SearchEngineFactory.php
@@ -32,7 +32,7 @@ class SearchEngineFactory {
 		$settings = $applicationFactory->getSettings();
 
 		if ( $connection === null ) {
-			$connection = $applicationFactory->getConnectionManager()->getConnection( DB_SLAVE );
+			$connection = $applicationFactory->getConnectionManager()->getConnection( DB_REPLICA );
 		}
 
 		$type = $settings->get( 'smwgFallbackSearchType' );

--- a/src/SQLStore/QueryEngine/DescriptionInterpreters/SomePropertyInterpreter.php
+++ b/src/SQLStore/QueryEngine/DescriptionInterpreters/SomePropertyInterpreter.php
@@ -295,7 +295,7 @@ class SomePropertyInterpreter implements DescriptionInterpreter {
 			$where = $description->getSQLCondition(
 				$query->alias,
 				array_keys( $fields ),
-				$this->store->getConnection( DB_SLAVE )
+				$this->store->getConnection( DB_REPLICA )
 			);
 		}
 

--- a/src/Setup.php
+++ b/src/Setup.php
@@ -121,8 +121,8 @@ final class Setup {
 		);
 
 		$connectionManager->registerConnectionProvider(
-			DB_SLAVE,
-			$mwCollaboratorFactory->newLoadBalancerConnectionProvider( DB_SLAVE )
+			DB_REPLICA,
+			$mwCollaboratorFactory->newLoadBalancerConnectionProvider( DB_REPLICA )
 		);
 
 		$connectionManager->registerConnectionProvider(

--- a/tests/phpunit/Unit/MediaWiki/Connection/LoadBalancerConnectionProviderTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Connection/LoadBalancerConnectionProviderTest.php
@@ -24,14 +24,14 @@ class LoadBalancerConnectionProviderTest extends \PHPUnit_Framework_TestCase {
 
 		$this->assertInstanceOf(
 			LoadBalancerConnectionProvider::class,
-			new LoadBalancerConnectionProvider( DB_SLAVE )
+			new LoadBalancerConnectionProvider( DB_REPLICA )
 		);
 	}
 
 	public function testGetAndReleaseConnection() {
 
 		$instance = new LoadBalancerConnectionProvider(
-			DB_SLAVE
+			DB_REPLICA
 		);
 
 		$connection = $instance->getConnection();
@@ -53,7 +53,7 @@ class LoadBalancerConnectionProviderTest extends \PHPUnit_Framework_TestCase {
 		$this->setExpectedException( 'RuntimeException' );
 
 		$instance = new LoadBalancerConnectionProvider(
-			DB_SLAVE
+			DB_REPLICA
 		);
 
 		$reflector = new ReflectionClass(

--- a/tests/phpunit/Unit/MediaWiki/MwCollaboratorFactoryTest.php
+++ b/tests/phpunit/Unit/MediaWiki/MwCollaboratorFactoryTest.php
@@ -148,7 +148,7 @@ class MwCollaboratorFactoryTest extends \PHPUnit_Framework_TestCase {
 
 		$this->assertInstanceOf(
 			'\SMW\MediaWiki\Connection\LoadBalancerConnectionProvider',
-			$instance->newLoadBalancerConnectionProvider( DB_SLAVE )
+			$instance->newLoadBalancerConnectionProvider( DB_REPLICA )
 		);
 	}
 


### PR DESCRIPTION
Refs: https://github.com/SemanticMediaWiki/SemanticMediaWiki/issues/4093

This PR is made in reference to: #4093 

This PR addresses or contains:
- Renames constant to DB_REPLICA

This PR includes:
- [ ] Tests (unit/integration)
- [ ] CI build passed

Fixes #