### PR TITLE
Ensure enableSemantics is in use before newFromGlobals() continues

### DIFF
--- a/includes/Settings.php
+++ b/includes/Settings.php
@@ -43,6 +43,11 @@ class Settings extends Options {
 	 */
 	public static function newFromGlobals() {
 
+		if ( !isset( $GLOBALS['smwgNamespace'] ) ) {
+			throw new RuntimeException(
+				"Please add enableSemantics to your LocalSettings.php!"
+			);
+		}
 		$configuration = [
 			'smwgIP' => $GLOBALS['smwgIP'],
 			'smwgExtraneousLanguageFileDir' => $GLOBALS['smwgExtraneousLanguageFileDir'],
@@ -474,7 +479,7 @@ class Settings extends Options {
 
 		if ( isset( $GLOBALS['smwgSparqlDataEndpoint'] ) ) {
 			$configuration['smwgSparqlEndpoint']['data'] = $GLOBALS['smwgSparqlDataEndpoint'];
-    }
+		}
 
 		if ( isset( $GLOBALS['smwgCacheType'] ) ) {
 			$configuration['smwgMainCacheType'] = $GLOBALS['smwgCacheType'];


### PR DESCRIPTION
This PR is made in reference to: #

This PR addresses or contains:
- Without this the “Upgrade and maintenance (Semantic MediaWiki)” page has E_NOTICE when $GLOBALS['smwgNamespace'] hasn't been set.

This PR includes:
- [ ] Tests (unit/integration)
- [ ] CI build passed

Fixes #