### PR TITLE
Remove `jetbrains/phpstorm-stubs` to avoid "... jetbrains/phpstorm-stubs/PhpStormStubsMap.php): failed to open stream: No such file or directory ..."

### DIFF
--- a/tests/travis/install-mediawiki.sh
+++ b/tests/travis/install-mediawiki.sh
@@ -25,6 +25,10 @@ cd mw
 ## MW 1.25 requires Psr\Logger
 if [ -f composer.json ]
 then
+  # Hack to fix "... jetbrains/phpstorm-stubs/PhpStormStubsMap.php): failed to open stream: No such file or directory ..."
+  # https://phabricator.wikimedia.org/T226766
+  composer remove jetbrains/phpstorm-stubs --no-interaction
+
   composer install
 fi
 


### PR DESCRIPTION
This PR is made in reference to: #4108

This PR addresses or contains:

This PR includes:
- [ ] Tests (unit/integration)
- [x] CI build passed

Fixes #4108