### PR TITLE
[SMWSearch] Inject `LoadBalancer` (MW 1.34+), refs 4111

### DIFF
--- a/src/MediaWiki/Search/SearchEngineFactory.php
+++ b/src/MediaWiki/Search/SearchEngineFactory.php
@@ -38,6 +38,11 @@ class SearchEngineFactory {
 		$type = $settings->get( 'smwgFallbackSearchType' );
 		$defaultSearchEngine = $applicationFactory->create( 'DefaultSearchEngineTypeForDB', $connection );
 
+		// https://github.com/wikimedia/mediawiki/commit/f92a1a6db3b659d9943ca66eacff99b5e4133c7b
+		if ( version_compare( MW_VERSION, '1.34', '>=' ) ) {
+			$connection = $applicationFactory->create( 'DBLoadBalancer' );
+		}
+
 		if ( is_callable( $type ) ) {
 			// #3939
 			$fallbackSearchEngine = $type( $connection );


### PR DESCRIPTION
This PR is made in reference to: #4111

This PR addresses or contains:

- This just fixes the "TypeError SearchDatabase.php: Argument 1 ..."

This PR includes:
- [ ] Tests (unit/integration)
- [x] CI build passed

Fixes #4111