### PR TITLE
[ES] Add `rebuildElasticMissingDocuments.php`, refs 3697

### DIFF
--- a/DefaultSettings.php
+++ b/DefaultSettings.php
@@ -2195,7 +2195,7 @@ return [
 			// possible discrepancy between the stored on-wiki data and the data
 			// replicated to Elasticsearch.
 			'monitor.entity.replication' => true,
-			'monitor.entity.replication.cache.lifetime' => 3660,
+			'monitor.entity.replication.cache_lifetime' => 3660,
 		],
 		'query' => [
 

--- a/docs/RELEASE-NOTES.md
+++ b/docs/RELEASE-NOTES.md
@@ -38,7 +38,7 @@ Changes to the DB are triggered by [#3644](https://github.com/SemanticMediaWiki/
 * [#3637](https://github.com/SemanticMediaWiki/SemanticMediaWiki/pull/3637) Uses `keyword` as type for the `P:*.geoField` mapping
 * [#3638](https://github.com/SemanticMediaWiki/SemanticMediaWiki/pull/3638) Added minimal index document for an empty bulk request
 * [#3693](https://github.com/SemanticMediaWiki/SemanticMediaWiki/pull/3693) Relaxed link removal in raw text
-* [#3697](https://github.com/SemanticMediaWiki/SemanticMediaWiki/pull/3697) Added replication monitoring (`indexer.monitor.entity.replication`) on per entity base and [#3713](https://github.com/SemanticMediaWiki/SemanticMediaWiki/pull/3713) (`indexer.monitor.entity.replication.cache.lifetime`)
+* [#3697](https://github.com/SemanticMediaWiki/SemanticMediaWiki/pull/3697) Added replication monitoring (`indexer.monitor.entity.replication`) on per entity base and [#3713](https://github.com/SemanticMediaWiki/SemanticMediaWiki/pull/3713) (`indexer.monitor.entity.replication.cache_lifetime`)
 * [#3699](https://github.com/SemanticMediaWiki/SemanticMediaWiki/pull/3699) Added length restriction to value inputs for a query construct  (`query.maximum.value.length`)
 * [#3763](https://github.com/SemanticMediaWiki/SemanticMediaWiki/pull/3763) Forced `FileIngestJob` to wait on the command line before executing the file indexing
 * [#3777](https://github.com/SemanticMediaWiki/SemanticMediaWiki/pull/3777) Added `rev_id` as field for indexing to extend the [replication monitoring](https://www.semantic-mediawiki.org/wiki/Help:Replication_monitoring)

--- a/includes/storage/SQLStore/SMW_Sql3SmwIds.php
+++ b/includes/storage/SQLStore/SMW_Sql3SmwIds.php
@@ -791,6 +791,10 @@ class SMWSql3SmwIds {
 			$cond = [
 				"smw_hash" => $title->getSha1()
 			];
+		} elseif( is_int( $title ) ) {
+			$cond = [
+				"smw_id" => $title
+			];
 		} else {
 			$cond = [
 				"smw_title =" . $connection->addQuotes( $title ),

--- a/maintenance/rebuildElasticMissingDocuments.php
+++ b/maintenance/rebuildElasticMissingDocuments.php
@@ -1,0 +1,243 @@
+<?php
+
+namespace SMW\Maintenance;
+
+use Onoi\MessageReporter\MessageReporter;
+use SMW\ApplicationFactory;
+use SMW\SQLStore\SQLStore;
+use SMW\Setup;
+use SMW\Store;
+use SMW\DIWikiPage;
+use SMW\DIProperty;
+
+$basePath = getenv( 'MW_INSTALL_PATH' ) !== false ? getenv('MW_INSTALL_PATH' ) : __DIR__ . '/../../..';
+
+require_once $basePath . '/maintenance/Maintenance.php';
+
+/**
+ * @license GNU GPL v2+
+ * @since 3.1
+ *
+ * @author mwjames
+ */
+class RebuildElasticMissingDocuments extends \Maintenance {
+
+	/**
+	 * @var Store
+	 */
+	private $store;
+
+	/**
+	 * @var DocumentReplicationExaminer
+	 */
+	private $documentReplicationExaminer;
+
+	/**
+	 * @var JobFactory
+	 */
+	private $jobFactory;
+
+	/**
+	 * @var MessageReporter
+	 */
+	private $messageReporter;
+
+	/**
+	 * @since 3.1
+	 */
+	public function __construct() {
+		$this->mDescription = "Find missing entities in Elasticsearch and schedule appropriate update jobs.";
+		parent::__construct();
+	}
+
+	/**
+	 * @since 3.1
+	 *
+	 * @param MessageReporter $messageReporter
+	 */
+	public function setMessageReporter( MessageReporter $messageReporter ) {
+		$this->messageReporter = $messageReporter;
+	}
+
+	/**
+	 * @since 3.1
+	 *
+	 * @param string $message
+	 */
+	public function reportMessage( $message ) {
+
+		if ( $this->messageReporter !== null ) {
+			return $this->messageReporter->reportMessage( $message );
+		}
+
+		$this->output( $message );
+	}
+
+	/**
+	 * @see Maintenance::execute
+	 */
+	public function execute() {
+
+		if ( !Setup::isEnabled() ) {
+			$this->reportMessage( "\nYou need to have Semantic MediaWiki enabled in order to run the maintenance script!\n" );
+			exit;
+		}
+
+		$applicationFactory = ApplicationFactory::getInstance();
+		$this->store = $applicationFactory->getStore();
+		$this->jobFactory = $applicationFactory->newJobFactory();
+
+		$elasticFactory = $applicationFactory->create( 'ElasticFactory' );
+		$maintenanceFactory = $applicationFactory->newMaintenanceFactory();
+
+		$this->documentReplicationExaminer = $elasticFactory->newDocumentReplicationExaminer(
+			$this->store
+		);
+
+		if ( !$this->store->getConnection( 'elastic' )->ping() ) {
+
+			$this->reportMessage(
+				"\n" . 'Elasticsearch endpoint(s) are not available!' . "\n"
+			);
+
+			return true;
+		}
+
+		$this->reportMessage(
+			"\nThe script checks for missing entities (aka. documents) in\n" .
+			"Elasticsearch. It will schedule update jobs for those documents\n" .
+			"that have been classified as missing or showed a divergent meta\n" .
+			"data (e.g. modification date or associated revision) record.\n"
+		);
+
+		$this->reportMessage( "\nSelecting entities ...\n" );
+		$this->checkAndRebuild( $this->fetchRows() );
+
+		$this->reportMessage( "   ... removing replication trail ...\n"  );
+
+		$checkReplicationTask = $elasticFactory->newCheckReplicationTask(
+			$this->store
+		);
+
+		$checkReplicationTask->deleteEntireReplicationTrail();
+
+		$this->reportMessage( "   ... done.\n" );
+
+		return true;
+	}
+
+	private function fetchRows() {
+
+		$connection = $this->store->getConnection( 'mw.db' );
+
+		return $connection->select(
+			SQLStore::ID_TABLE,
+			[
+				'smw_id',
+				'smw_title',
+				'smw_namespace',
+				'smw_iw',
+				'smw_subobject'
+			],
+			[
+				"smw_subobject=''",
+				'smw_iw != ' . $connection->addQuotes( SMW_SQL3_SMWDELETEIW ),
+				'smw_iw != ' . $connection->addQuotes( SMW_SQL3_SMWREDIIW )
+			],
+			__METHOD__,
+			[ 'ORDER BY' => 'smw_id' ]
+		);
+	}
+
+	private function checkAndRebuild( \Iterator $rows ) {
+
+		$connection = $this->store->getConnection( 'mw.db' );
+
+		$count = $rows->numRows();
+		$i = 0;
+		$notExists_count = 0;
+		$dataDiff_count = 0;
+
+		if ( $count == 0 ) {
+			return $this->reportMessage( "   ... no entities selected ...\n"  );
+		}
+
+		$this->reportMessage( "   ... counting $count rows ...\n"  );
+		$this->reportMessage( "   ... done.\n" );
+
+		$this->reportMessage( "\nChecking and updating ...\n" );
+
+		foreach ( $rows as $row ) {
+
+			if ( $row->smw_title === '_INST' ) {
+				continue;
+			}
+
+			$namespace = (int)$row->smw_namespace;
+
+			if ( $namespace === SMW_NS_PROPERTY ) {
+				try {
+					$property = DIProperty::newFromUserLabel( $row->smw_title );
+				} catch( \SMW\Exception\PropertyLabelNotResolvedException $e ) {
+					continue;
+				}
+				$subject = $property->getCanonicalDiWikiPage();
+			} else {
+				$subject = new DIWikiPage(
+					$row->smw_title,
+					$namespace,
+					$row->smw_iw,
+					$row->smw_subobject
+				);
+			}
+
+			$this->reportMessage(
+				$this->progress( $row->smw_id, $i++, $count )
+			);
+
+			$title = $subject->getTitle();
+
+			if ( $title === null ) {
+				continue;
+			}
+
+			if ( !$this->documentReplicationExaminer->documentExistsById( $row->smw_id ) ) {
+				$notExists_count++;
+				$this->runJob( $title );
+			} elseif ( $title->exists() && ( $res = $this->documentReplicationExaminer->check( $subject ) ) !== [] ) {
+				$dataDiff_count++;
+				$this->runJob( $title );
+			}
+		}
+
+		$this->reportMessage( "\n   ... found document(s) ..." );
+		$this->reportMessage( "\n" . sprintf( "%-50s%s", "       ... missing ...", $notExists_count ) );
+		$this->reportMessage( "\n" . sprintf( "%-50s%s", "       ... divergent revision/date ...", $dataDiff_count ) );
+		$this->reportMessage( "\n" . sprintf( "%-50s%s", "   ... added update job(s) ...", ( $notExists_count + $dataDiff_count ) ) );
+		$this->reportMessage( "\n" );
+	}
+
+	private function runJob( $title ) {
+
+		$job = $this->jobFactory->newUpdateJob(
+			$title
+		);
+
+		$job->run();
+	}
+
+	/**
+	 * @see Maintenance::addDefaultParams
+	 */
+	protected function addDefaultParams() {
+		parent::addDefaultParams();
+	}
+
+	private function progress( $id, $i, $count ) {
+		return "\r". sprintf( "%-50s%s", "   ... checking entity", sprintf( "%s (%1.0f%%)", $id, round( ( $i / $count ) * 100 ) ) );
+	}
+
+}
+
+$maintClass = 'SMW\Maintenance\RebuildElasticMissingDocuments';
+require_once( RUN_MAINTENANCE_IF_MAIN );

--- a/src/Elastic/Indexer/Indexer.php
+++ b/src/Elastic/Indexer/Indexer.php
@@ -780,8 +780,15 @@ class Indexer {
 	}
 
 	private function makeSubject( DIWikiPage $subject ) {
+
+		$title = $subject->getDBKey();
+
+		if ( $subject->getNamespace() !== SMW_NS_PROPERTY || $title{0} !== '_' ) {
+			$title = str_replace( '_', ' ', $title );
+		}
+
 		return [
-			'title'     => str_replace( '_', ' ', $subject->getDBKey() ),
+			'title'     => $title,
 			'subobject' => $subject->getSubobjectName(),
 			'namespace' => $subject->getNamespace(),
 			'interwiki' => $subject->getInterwiki(),

--- a/src/Elastic/Indexer/Replication/DocumentReplicationExaminer.php
+++ b/src/Elastic/Indexer/Replication/DocumentReplicationExaminer.php
@@ -1,0 +1,111 @@
+<?php
+
+namespace SMW\Elastic\Indexer\Replication;
+
+use Onoi\Cache\Cache;
+use SMW\Store;
+use SMW\DIWikiPage;
+use SMW\DIProperty;
+use SMW\MediaWiki\Api\Tasks\Task;
+use SMW\Message;
+use SMW\EntityCache;
+use Html;
+use SMW\Utils\TemplateEngine;
+use SMW\Elastic\Connection\Client as ElasticClient;
+use Title;
+
+/**
+ * @license GNU GPL v2+
+ * @since 3.1
+ *
+ * @author mwjames
+ */
+class DocumentReplicationExaminer {
+
+	/**
+	 * @var Store
+	 */
+	private $store;
+
+	/**
+	 * @since 3.1
+	 *
+	 * @param Store $store
+	 * @param ReplicationStatus $replicationStatus
+	 */
+	public function __construct( Store $store, ReplicationStatus $replicationStatus ) {
+		$this->store = $store;
+		$this->replicationStatus = $replicationStatus;
+	}
+
+	/**
+	 * @since 3.1
+	 *
+	 * @param integer $id
+	 *
+	 * @return boolean
+	 */
+	public function documentExistsById( $id ) {
+		return $this->replicationStatus->get( 'documentExistsById', $id );
+	}
+
+	/**
+	 * @since 3.1
+	 *
+	 * @param DIWikiPage $subject
+	 *
+	 * @return []
+	 */
+	public function check( DIWikiPage $subject ) {
+
+		$idTable = $this->store->getObjectIds();
+		$exceptionError = null;
+
+		$id = $idTable->getSMWPageID(
+			$subject->getDBKey(),
+			$subject->getNamespace(),
+			$subject->getInterwiki(),
+			$subject->getSubobjectname(),
+			'',
+			true
+		);
+
+		$subject->setId( $id );
+		$rev_store = $idTable->findAssociatedRev( $id );
+
+		try {
+			$replicationStatus = $this->replicationStatus->get( 'modification_date_associated_revision', $id );
+		} catch ( \Elasticsearch\Common\Exceptions\BadRequest400Exception $e ) {
+			$exceptionError = 'BadRequest400Exception';
+		}
+
+		if ( $exceptionError !== null ) {
+			return [ 'exception' => $exceptionError ];
+		}
+
+		// What is stored in the DB
+		$pv = $this->store->getPropertyValues(
+			$subject,
+			new DIProperty( '_MDAT' )
+		);
+
+		if ( $replicationStatus['modification_date'] === false || $pv === [] ) {
+			return [ 'modification_date_missing' => $id ];
+		} elseif ( !end( $pv )->equals( $replicationStatus['modification_date'] ) ) {
+			$dates = [
+				'time_es' => $replicationStatus['modification_date']->asDateTime()->format( 'Y-m-d H:i:s' ),
+				'time_store' => end( $pv )->asDateTime()->format( 'Y-m-d H:i:s' )
+			];
+			return [ 'modification_date_diff' => $dates ];
+		} elseif ( $replicationStatus['associated_revision'] != $rev_store ) {
+			$revs = [
+				'rev_es' => $replicationStatus['associated_revision'],
+				'rev_store' => $rev_store
+			];
+			return [ 'associated_revision_diff' => $revs ];
+		}
+
+		return [];
+	}
+
+}

--- a/src/Elastic/Indexer/Replication/ReplicationStatus.php
+++ b/src/Elastic/Indexer/Replication/ReplicationStatus.php
@@ -61,6 +61,24 @@ class ReplicationStatus {
 	/**
 	 * @since 3.0
 	 *
+	 * @param integer $id
+	 *
+	 * @return boolean
+	 */
+	private function documentExistsById( $id ) {
+
+		$params = [
+			'index' => $this->connection->getIndexName( ElasticClient::TYPE_DATA ),
+			'type'  => ElasticClient::TYPE_DATA,
+			'id'    => $id,
+		];
+
+		return $this->connection->exists( $params );
+	}
+
+	/**
+	 * @since 3.0
+	 *
 	 * @param string $id
 	 *
 	 * @return []

--- a/tests/phpunit/Integration/Maintenance/RebuildElasticMissingDocumentsTest.php
+++ b/tests/phpunit/Integration/Maintenance/RebuildElasticMissingDocumentsTest.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace SMW\Tests\Integration\Maintenance;
+
+use SMW\Tests\MwDBaseUnitTestCase;
+use SMW\Tests\TestEnvironment;
+use SMW\ApplicationFactory;
+
+/**
+ * @group semantic-mediawiki
+ * @group medium
+ *
+ * @license GNU GPL v2+
+ * @since 3.1
+ *
+ * @author mwjames
+ */
+class RebuildElasticMissingDocuments extends MwDBaseUnitTestCase {
+
+	protected $destroyDatabaseTablesAfterRun = true;
+	private $runnerFactory;
+	private $spyMessageReporter;
+
+	protected function setUp() {
+		parent::setUp();
+
+		$store = ApplicationFactory::getInstance()->getStore();
+
+		if ( !$store instanceof \SMW\Elastic\ElasticStore ) {
+			$this->markTestSkipped( "Skipping test because a ElasticStore instance is required." );
+		}
+
+		$utilityFactory = TestEnvironment::getUtilityFactory();
+
+		$this->runnerFactory  = $utilityFactory->newRunnerFactory();
+		$this->spyMessageReporter = $utilityFactory->newSpyMessageReporter();
+	}
+
+	protected function tearDown() {
+		parent::tearDown();
+	}
+
+	public function testRun() {
+
+		$maintenanceRunner = $this->runnerFactory->newMaintenanceRunner(
+			'SMW\Maintenance\RebuildElasticMissingDocuments'
+		);
+
+		$maintenanceRunner->setMessageReporter( $this->spyMessageReporter );
+		$maintenanceRunner->setQuiet();
+
+		$this->assertTrue(
+			$maintenanceRunner->run()
+		);
+
+		$this->assertContains(
+			'removing replication trail',
+			$this->spyMessageReporter->getMessagesAsString()
+		);
+	}
+
+}

--- a/tests/phpunit/Unit/Elastic/Indexer/Replication/DocumentReplicationExaminerTest.php
+++ b/tests/phpunit/Unit/Elastic/Indexer/Replication/DocumentReplicationExaminerTest.php
@@ -1,0 +1,196 @@
+<?php
+
+namespace SMW\Tests\Elastic\Indexer\Replication;
+
+use SMW\Elastic\Indexer\Replication\DocumentReplicationExaminer;
+use SMW\Tests\PHPUnitCompat;
+use SMW\DIWikiPage;
+use SMW\DIProperty;
+use SMWDITime as DITime;
+
+/**
+ * @covers \SMW\Elastic\Indexer\Replication\DocumentReplicationExaminer
+ * @group semantic-mediawiki
+ *
+ * @license GNU GPL v2+
+ * @since 3.1
+ *
+ * @author mwjames
+ */
+class DocumentReplicationExaminerTest extends \PHPUnit_Framework_TestCase {
+
+	use PHPUnitCompat;
+
+	private $store;
+	private $replicationStatus;
+	private $elasticClient;
+	private $idTable;
+
+	protected function setUp() {
+
+		$this->idTable = $this->getMockBuilder( '\SMWSql3SmwIds' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$this->store = $this->getMockBuilder( '\SMW\Store' )
+			->disableOriginalConstructor()
+			->setMethods( [ 'getObjectIds', 'getConnection' ] )
+			->getMockForAbstractClass();
+
+		$this->store->expects( $this->any() )
+			->method( 'getObjectIds' )
+			->will( $this->returnValue( $this->idTable ) );
+
+		$this->replicationStatus = $this->getMockBuilder( '\SMW\Elastic\Indexer\Replication\ReplicationStatus' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$this->elasticClient = $this->getMockBuilder( '\SMW\Elastic\Connection\DummyClient' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$this->elasticClient->expects( $this->any() )
+			->method( 'ping' )
+			->will( $this->returnValue( true ) );
+	}
+
+	public function testCanConstruct() {
+
+		$this->assertInstanceOf(
+			DocumentReplicationExaminer::class,
+			new DocumentReplicationExaminer( $this->store, $this->replicationStatus )
+		);
+	}
+
+	public function testCheck_NotExists() {
+
+		$this->elasticClient->expects( $this->any() )
+			->method( 'hasMaintenanceLock' )
+			->will( $this->returnValue( false ) );
+
+		$replicationStatus = [
+			'modification_date' => false
+		];
+
+		$this->replicationStatus->expects( $this->once() )
+			->method( 'get' )
+			->with(	$this->equalTo( 'modification_date_associated_revision' ) )
+			->will( $this->returnValue( $replicationStatus ) );
+
+		$this->store->expects( $this->once() )
+			->method( 'getPropertyValues' )
+			->will( $this->returnValue( [] ) );
+
+		$this->store->expects( $this->any() )
+			->method( 'getConnection' )
+			->will( $this->returnValue( $this->elasticClient ) );
+
+		$instance = new DocumentReplicationExaminer(
+			$this->store,
+			$this->replicationStatus
+		);
+
+		$result = $instance->check( DIWikiPage::newFromText( 'Foo' ) );
+
+		$this->assertEquals(
+			[
+				'modification_date_missing' => null
+			],
+			$result
+		);
+	}
+
+	public function testCheck_ModificationDate() {
+
+		$this->elasticClient->expects( $this->any() )
+			->method( 'hasMaintenanceLock' )
+			->will( $this->returnValue( false ) );
+
+		$time_es = DITime::newFromTimestamp( 1272508900 );
+		$time_store = DITime::newFromTimestamp( 1272508903 );
+
+		$replicationStatus = [
+			'modification_date' => $time_es
+		];
+
+		$this->replicationStatus->expects( $this->once() )
+			->method( 'get' )
+			->with(	$this->equalTo( 'modification_date_associated_revision' ) )
+			->will( $this->returnValue( $replicationStatus ) );
+
+		$this->store->expects( $this->once() )
+			->method( 'getPropertyValues' )
+			->will( $this->returnValue( [ $time_store ] ) );
+
+		$this->store->expects( $this->any() )
+			->method( 'getConnection' )
+			->will( $this->returnValue( $this->elasticClient ) );
+
+		$instance = new DocumentReplicationExaminer(
+			$this->store,
+			$this->replicationStatus
+		);
+
+		$result = $instance->check( DIWikiPage::newFromText( 'Foo' ) );
+
+		$this->assertEquals(
+			[
+				'modification_date_diff' => [
+					'time_es' => '2010-04-29 02:41:40',
+					'time_store' => '2010-04-29 02:41:43'
+				]
+			],
+			$result
+		);
+	}
+
+	public function testCheck_AssociateRev() {
+
+		$this->elasticClient->expects( $this->any() )
+			->method( 'hasMaintenanceLock' )
+			->will( $this->returnValue( false ) );
+
+		$subject = DIWikiPage::newFromText( 'Foo' );
+		$time = DITime::newFromTimestamp( 1272508903 );
+
+		$replicationStatus = [
+			'modification_date' => $time,
+			'associated_revision' => 99999
+		];
+
+		$this->replicationStatus->expects( $this->once() )
+			->method( 'get' )
+			->with(	$this->equalTo( 'modification_date_associated_revision' ) )
+			->will( $this->returnValue( $replicationStatus ) );
+
+		$this->idTable->expects( $this->at( 1 ) )
+			->method( 'findAssociatedRev' )
+			->will( $this->returnValue( 42 ) );
+
+		$this->store->expects( $this->at( 1 ) )
+			->method( 'getPropertyValues' )
+			->will( $this->returnValue( [ $time ] ) );
+
+		$this->store->expects( $this->any() )
+			->method( 'getConnection' )
+			->will( $this->returnValue( $this->elasticClient ) );
+
+		$instance = new DocumentReplicationExaminer(
+			$this->store,
+			$this->replicationStatus
+		);
+
+		$result = $instance->check( DIWikiPage::newFromText( 'Foo' ) );
+
+		$this->assertEquals(
+			[
+				'associated_revision_diff' => [
+					'rev_es' => 99999,
+					'rev_store' => 42
+				]
+			],
+			$result
+		);
+	}
+
+}


### PR DESCRIPTION
This PR is made in reference to: #3697

This PR addresses or contains:

- Adds `rebuildElasticMissingDocuments` script to find missing entities (aka documents) from Elasticsearch and schedule `smw.update` jobs for those identified subjects

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed
