### PR TITLE
Add `smwgDefaultStore` to upgrade key matrix, refs 3095

### DIFF
--- a/i18n/en.json
+++ b/i18n/en.json
@@ -20,7 +20,7 @@
 	"smw-upgrade-progress-supplement-jobs": "Adding supplement jobs ...",
 	"smw-upgrade-error-title": "Error (Semantic MediaWiki)",
 	"smw-upgrade-error-why-title": "Why Do I see this page?",
-	"smw-upgrade-error-why-explain": "Semantic MediaWiki's internal database structure has changed and requires some adjustments to be fully functional. There can be several reasons including:\n* Additional fixed properties (requires additional table setup) were added \n* An upgrade contains some changes to tables or indices making an interception obligatory before accessing the data",
+	"smw-upgrade-error-why-explain": "Semantic MediaWiki's internal database structure has changed and requires some adjustments to be fully functional. There can be several reasons including:\n* Additional fixed properties (requires additional table setup) were added \n* An upgrade contains some changes to tables or indices making an interception obligatory before accessing the data \n* Changes to the storage or query engine",
 	"smw-upgrade-error-how-title": "How Do I fix this error?",
 	"smw-upgrade-error-how-explain-admin": "An administrator (or any person with administrator rights) has to run either MediaWiki's [https://www.mediawiki.org/wiki/Manual:Update.php update.php] or Semantic MediaWiki's [https://www.semantic-mediawiki.org/wiki/Help:SetupStore.php setupStore.php] maintenance script.",
 	"smw-upgrade-error-how-explain-links": "You may also consult the following pages for further assistance:\n* [https://www.semantic-mediawiki.org/wiki/Help:Installation Installation] instructions\n* [https://www.semantic-mediawiki.org/wiki/Help:Installation/Troubleshooting Troubleshooting] help page",

--- a/src/SetupFile.php
+++ b/src/SetupFile.php
@@ -377,6 +377,7 @@ class SetupFile {
 		// changes to them
 		$components = [
 			$vars['smwgUpgradeKey'],
+			$vars['smwgDefaultStore'],
 			$vars['smwgFixedProperties'],
 			$vars['smwgEnabledFulltextSearch'],
 			$pageSpecialProperties

--- a/tests/phpunit/Unit/SetupFileTest.php
+++ b/tests/phpunit/Unit/SetupFileTest.php
@@ -28,6 +28,7 @@ class SetupFileTest extends \PHPUnit_Framework_TestCase {
 
 		$var1 = [
 			'smwgUpgradeKey' => '',
+			'smwgDefaultStore' => '',
 			'smwgEnabledFulltextSearch' => '',
 			'smwgFixedProperties' => [ 'Foo', 'Bar' ],
 			'smwgPageSpecialProperties' => [ 'Foo', 'Bar' ]
@@ -35,6 +36,7 @@ class SetupFileTest extends \PHPUnit_Framework_TestCase {
 
 		$var2 = [
 			'smwgUpgradeKey' => '',
+			'smwgDefaultStore' => '',
 			'smwgEnabledFulltextSearch' => '',
 			'smwgFixedProperties' => [ 'Bar', 'Foo' ],
 			'smwgPageSpecialProperties' => [ 'Bar', 'Foo' ]
@@ -50,6 +52,7 @@ class SetupFileTest extends \PHPUnit_Framework_TestCase {
 
 		$var1 = [
 			'smwgUpgradeKey' => '',
+			'smwgDefaultStore' => '',
 			'smwgEnabledFulltextSearch' => '',
 			'smwgFixedProperties' => [ 'Foo', 'Bar' ],
 			'smwgPageSpecialProperties' => [ 'Foo', 'Bar' ]
@@ -57,6 +60,7 @@ class SetupFileTest extends \PHPUnit_Framework_TestCase {
 
 		$var2 = [
 			'smwgUpgradeKey' => '',
+			'smwgDefaultStore' => '',
 			'smwgEnabledFulltextSearch' => '',
 			'smwgFixedProperties' => [ 'Bar', 'Foo' ],
 			'smwgPageSpecialProperties' => [ 'Bar', '_MDAT' ]
@@ -85,6 +89,7 @@ class SetupFileTest extends \PHPUnit_Framework_TestCase {
 			'smwgConfigFileDir' => 'Foo/',
 			'smwgIP' => '',
 			'smwgUpgradeKey' => '',
+			'smwgDefaultStore' => '',
 			'smwgEnabledFulltextSearch' => '',
 			'smwgFixedProperties' => [],
 			'smwgPageSpecialProperties' => []
@@ -96,7 +101,7 @@ class SetupFileTest extends \PHPUnit_Framework_TestCase {
 	public function testSetMaintenanceMode() {
 
 		$fields = [
-			'upgrade_key' => 'abede9f6b2c43db901f6255e26b8d951f84f5d7c',
+			'upgrade_key' => '7540cc7b594b305fa2525c33d8963acb0c2d7b29',
 			SetupFile::MAINTENANCE_MODE => true,
 			// "upgrade_key_base" => '["",[],"",[]]'
 		];
@@ -121,6 +126,7 @@ class SetupFileTest extends \PHPUnit_Framework_TestCase {
 			'smwgConfigFileDir' => 'Foo/',
 			'smwgIP' => '',
 			'smwgUpgradeKey' => '',
+			'smwgDefaultStore' => '',
 			'smwgEnabledFulltextSearch' => '',
 			'smwgFixedProperties' => [],
 			'smwgPageSpecialProperties' => []
@@ -158,6 +164,7 @@ class SetupFileTest extends \PHPUnit_Framework_TestCase {
 			'smwgConfigFileDir' => 'Foo_dir',
 			'smwgIP' => '',
 			'smwgUpgradeKey' => '',
+			'smwgDefaultStore' => '',
 			'smwgEnabledFulltextSearch' => '',
 			'smwgFixedProperties' => [],
 			'smwgPageSpecialProperties' => []


### PR DESCRIPTION
This PR is made in reference to: #

This PR addresses or contains:

- Adds `smwgDefaultStore` to the upgrade key matrix to detect changes when users switch the store

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed
