### PR TITLE
LoadBalancerConnectionProvider to use `getConnectionRef`

### DIFF
--- a/src/MediaWiki/Connection/CleanUpTables.php
+++ b/src/MediaWiki/Connection/CleanUpTables.php
@@ -24,7 +24,7 @@ class CleanUpTables {
 	 */
 	public function __construct( $connection ) {
 
-		if ( !$connection instanceof Database && !$connection instanceof \DatabaseBase ) {
+		if ( !$connection instanceof \Wikimedia\Rdbms\IDatabase && !$connection instanceof \IDatabase && !$connection instanceof \DatabaseBase ) {
 			throw new RuntimeException( "Invalid connection instance!" );
 		}
 

--- a/src/MediaWiki/Connection/Sequence.php
+++ b/src/MediaWiki/Connection/Sequence.php
@@ -28,7 +28,11 @@ class Sequence {
 	 */
 	public function __construct( $connection ) {
 
-		if ( !$connection instanceof Database && !$connection instanceof \DatabaseBase ) {
+		if (
+			!$connection instanceof Database &&
+			!$connection instanceof DatabaseBase &&
+			!$connection instanceof \IDatabase &&
+			!$connection instanceof \Wikimedia\Rdbms\IDatabase ) {
 			throw new RuntimeException( "Invalid connection instance!" );
 		}
 

--- a/src/MediaWiki/MwCollaboratorFactory.php
+++ b/src/MediaWiki/MwCollaboratorFactory.php
@@ -120,8 +120,17 @@ class MwCollaboratorFactory {
 	 *
 	 * @return LoadBalancerConnectionProvider
 	 */
-	public function newLoadBalancerConnectionProvider( $connectionType ) {
-		return new LoadBalancerConnectionProvider( $connectionType );
+	public function newLoadBalancerConnectionProvider( $connectionType, $asConnectionRef = true ) {
+
+		$loadBalancerConnectionProvider = new LoadBalancerConnectionProvider(
+			$connectionType
+		);
+
+		$loadBalancerConnectionProvider->asConnectionRef(
+			$asConnectionRef
+		);
+
+		return $loadBalancerConnectionProvider;
 	}
 
 	/**

--- a/src/SQLStore/TableBuilder/TableBuilder.php
+++ b/src/SQLStore/TableBuilder/TableBuilder.php
@@ -41,7 +41,7 @@ abstract class TableBuilder implements TableBuilderInterface, MessageReporterAwa
 	 *
 	 * @param DatabaseBase $connection
 	 */
-	protected function __construct( DatabaseBase $connection ) {
+	protected function __construct( $connection ) {
 		$this->connection = $connection;
 	}
 
@@ -53,7 +53,14 @@ abstract class TableBuilder implements TableBuilderInterface, MessageReporterAwa
 	 * @return TableBuilder
 	 * @throws RuntimeException
 	 */
-	public static function factory( DatabaseBase $connection ) {
+	public static function factory( $connection ) {
+
+		if (
+			!$connection instanceof \Wikimedia\Rdbms\IDatabase &&
+			!$connection instanceof \IDatabase &&
+			!$connection instanceof \DatabaseBase ) {
+			throw new RuntimeException( "Invalid connection instance!" );
+		}
 
 		$instance = null;
 

--- a/src/Setup.php
+++ b/src/Setup.php
@@ -117,7 +117,7 @@ final class Setup {
 
 		$connectionManager->registerConnectionProvider(
 			DB_REPLICA,
-			$mwCollaboratorFactory->newLoadBalancerConnectionProvider( DB_REPLICA )
+			$mwCollaboratorFactory->newLoadBalancerConnectionProvider( DB_REPLICA, false )
 		);
 
 		$connectionManager->registerConnectionProvider(

--- a/tests/phpunit/Unit/MediaWiki/Connection/CleanUpTablesTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Connection/CleanUpTablesTest.php
@@ -22,7 +22,7 @@ class CleanUpTablesTest extends \PHPUnit_Framework_TestCase {
 
 	protected function setUp() {
 
-		$this->connection = $this->getMockBuilder( '\SMW\MediaWiki\Database' )
+		$this->connection = $this->getMockBuilder( '\DatabaseBase' )
 			->disableOriginalConstructor()
 			->getMock();
 	}

--- a/tests/phpunit/Unit/SQLStore/TableBuilder/TableBuilderTest.php
+++ b/tests/phpunit/Unit/SQLStore/TableBuilder/TableBuilderTest.php
@@ -80,4 +80,9 @@ class TableBuilderTest extends \PHPUnit_Framework_TestCase {
 		TableBuilder::factory( $connection );
 	}
 
+	public function testConstructWithInvalidInstanceThrowsException() {
+		$this->setExpectedException( 'RuntimeException' );
+		TableBuilder::factory( 'foo' );
+	}
+
 }


### PR DESCRIPTION
This PR is made in reference to: #

This PR addresses or contains:

- Allows to use `getConnectionRef` instead `getConnection`
- https://github.com/wikimedia/mediawiki/search?q=getConnectionRef&type=Commits

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed
