### PR TITLE
Add `updateQueryDependencies.php`, refs 1117

### DIFF
--- a/maintenance/updateQueryDependencies.php
+++ b/maintenance/updateQueryDependencies.php
@@ -1,0 +1,186 @@
+<?php
+
+namespace SMW\Maintenance;
+
+use Onoi\MessageReporter\MessageReporter;
+use SMW\ApplicationFactory;
+use SMW\SQLStore\SQLStore;
+use SMW\DIWikiPage;
+use SMW\DIProperty;
+use SMW\Setup;
+use Title;
+
+$basePath = getenv( 'MW_INSTALL_PATH' ) !== false ? getenv( 'MW_INSTALL_PATH' ) : __DIR__ . '/../../..';
+
+require_once $basePath . '/maintenance/Maintenance.php';
+
+/**
+ * @license GNU GPL v2+
+ * @since 3.1
+ *
+ * @author mwjames
+ */
+class UpdateQueryDependencies extends \Maintenance {
+
+	/**
+	 * @var MessageReporter
+	 */
+	private $messageReporter;
+
+	/**
+	 * @since 3.1
+	 */
+	public function __construct() {
+		$this->mDescription = 'Update queries and query dependencies.';
+		parent::__construct();
+	}
+
+	/**
+	 * @since 3.1
+	 *
+	 * @param MessageReporter $messageReporter
+	 */
+	public function setMessageReporter( MessageReporter $messageReporter ) {
+		$this->messageReporter = $messageReporter;
+	}
+
+	/**
+	 * @since 3.1
+	 *
+	 * @param string $message
+	 */
+	public function reportMessage( $message ) {
+
+		if ( $this->messageReporter !== null ) {
+			return $this->messageReporter->reportMessage( $message );
+		}
+
+		$this->output( $message );
+	}
+
+	/**
+	 * @see Maintenance::execute
+	 */
+	public function execute() {
+
+		if ( !Setup::isEnabled() ) {
+			$this->dieMessage(
+				"\nYou need to have SMW enabled in order to run the maintenance script!\n"
+			);
+		}
+
+		if ( !Setup::isValid( true ) ) {
+			$this->dieMessage(
+				"\nYou need to run `update.php` or `setupStore.php` first before continuing" .
+				"\nwith any maintenance tasks!\n"
+			);
+		}
+
+		$this->reportMessage(
+			"\nThe script schedules updates for entities known to contain queries." .
+			"\nA re-parse of the entity content will ensure to find new or missing" .
+			"\nquery dependencies and trigger updates to the `smw_query_links`" .
+			"\ntable.\n"
+		);
+
+		$settings = ApplicationFactory::getInstance()->getSettings();
+
+		if ( $settings->get( 'smwgQueryProfiler' ) === false ) {
+			return $this->reportMessage(
+				"\nThe `smwgQueryProfiler` has been disabled therefore making it impossible" .
+				"\nto track embedded queries.\n"
+			);
+		}
+
+		if ( $settings->get( 'smwgEnabledQueryDependencyLinksStore' ) === false ) {
+			$this->reportMessage(
+				"\nThe `smwgEnabledQueryDependencyLinksStore` is disabled therefore" .
+				"\nno query dependency updates (see `smw_query_links` table) will occur.\n"
+			);
+		}
+
+		return $this->runUpdate();
+	}
+
+	/**
+	 * @see Maintenance::addDefaultParams
+	 *
+	 * @since 3.0
+	 */
+	protected function addDefaultParams() {
+		parent::addDefaultParams();
+	}
+
+	private function dieMessage( $message ) {
+		$this->reportMessage( $message );
+		exit;
+	}
+
+	private function runUpdate() {
+
+		$applicationFactory = ApplicationFactory::getInstance();
+		$store = $applicationFactory->getStore( SQLStore::class );
+
+		$jobFactory = $applicationFactory->newJobFactory();
+		$connection = $store->getConnection( 'mw.db' );
+
+		$tableName = $store->getPropertyTableInfoFetcher()->findTableIdForProperty(
+			new DIProperty( '_ASK' )
+		);
+
+		$res = $connection->select(
+			[ SQLStore::ID_TABLE, $tableName . ' AS p' ],
+			[
+				'smw_id',
+				'smw_title',
+				'smw_namespace'
+			],
+			[
+				'smw_iw!=' . $connection->addQuotes( SMW_SQL3_SMWIW_OUTDATED ),
+				'smw_iw!=' . $connection->addQuotes( SMW_SQL3_SMWDELETEIW ),
+			],
+			__METHOD__,
+			[
+				'GROUP BY' => 'smw_id'
+			],
+			[
+				$tableName . ' AS p' => [ 'INNER JOIN', [ 'p.s_id=smw_id' ] ],
+			]
+		);
+
+		$expected = $res->numRows();
+		$i = 0;
+
+		$this->reportMessage(
+			"\nPerforming the update ..."
+		);
+
+		$this->reportMessage( "\n   ... found $expected entities ..." );
+		$this->reportMessage( "\n" );
+
+		foreach ( $res as $row ) {
+			$i++;
+
+			$this->reportMessage(
+				"\r". sprintf( "%-55s%s", "   ... update ...", sprintf( "%4.0f%% (%s/%s)", ( $i / $expected ) * 100, $i, $expected ) )
+			);
+
+			$updateJob = $jobFactory->newUpdateJob(
+				Title::makeTitleSafe( $row->smw_namespace, $row->smw_title ),
+				[
+					'origin' => 'updateQueryDependencies.php'
+				]
+			);
+
+			$updateJob->run();
+		}
+
+		$this->reportMessage( "\n" );
+
+		return true;
+	}
+
+}
+
+$maintClass = 'SMW\Maintenance\UpdateQueryDependencies';
+require_once( RUN_MAINTENANCE_IF_MAIN );

--- a/tests/phpunit/Unit/Maintenance/UpdateQueryDependenciesTest.php
+++ b/tests/phpunit/Unit/Maintenance/UpdateQueryDependenciesTest.php
@@ -1,0 +1,124 @@
+<?php
+
+namespace SMW\Tests\Maintenance;
+
+use SMW\Maintenance\UpdateQueryDependencies;
+use FakeResultWrapper;
+use SMW\Tests\TestEnvironment;
+use SMW\DIWikiPage;
+
+/**
+ * @covers \SMW\Maintenance\UpdateQueryDependencies
+ * @group semantic-mediawiki
+ *
+ * @license GNU GPL v2+
+ * @since 3.1
+ *
+ * @author mwjames
+ */
+class UpdateQueryDependenciesTest extends \PHPUnit_Framework_TestCase {
+
+	private $testEnvironment;
+	private $messageReporter;
+	private $store;
+	private $connection;
+	private $entityCache;
+
+	protected function setUp() {
+
+		$this->testEnvironment =  new TestEnvironment();
+
+		$this->messageReporter = $this->getMockBuilder( '\Onoi\MessageReporter\MessageReporter' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$this->store = $this->getMockBuilder( '\SMW\SQLStore\SQLStore' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$this->connection = $this->getMockBuilder( '\SMW\MediaWiki\Database' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$this->entityCache = $this->getMockBuilder( '\SMW\EntityCache' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$this->testEnvironment->registerObject( 'Store', $this->store );
+		$this->testEnvironment->registerObject( 'EntityCache', $this->entityCache );
+	}
+
+	protected function tearDown() {
+		$this->testEnvironment->tearDown();
+		parent::tearDown();
+	}
+
+	public function testCanConstruct() {
+
+		$this->assertInstanceOf(
+			UpdateQueryDependencies::class,
+			new UpdateQueryDependencies()
+		);
+	}
+
+	public function testExecute() {
+
+		$updateJob = $this->getMockBuilder( '\SMW\MediaWiki\Jobs\UpdateJob' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$jobFactory = $this->getMockBuilder( '\SMW\MediaWiki\JobFactory' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$jobFactory->expects( $this->atLeastOnce() )
+			->method( 'newUpdateJob' )
+			->will( $this->returnValue( $updateJob ) );
+
+		$this->testEnvironment->registerObject( 'JobFactory', $jobFactory );
+
+		$propertyTableInfoFetcher = $this->getMockBuilder( '\SMW\SQLStore\PropertyTableInfoFetcher' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$fields = [
+			"smw_subobject=''",
+			'smw_iw != '
+		];
+
+		$row = new \stdClass;
+		$row->smw_id = 42;
+		$row->smw_title = 'Foo';
+		$row->smw_namespace = '0';
+		$row->smw_iw = '';
+		$row->smw_subobject = '';
+
+		$subject = new DIWikiPage( 'Foo', 0 );
+
+		$this->connection->expects( $this->atLeastOnce() )
+			->method( 'select' )
+			->with(
+				$this->anything(),
+				$this->anything(),
+				$this->anything(),
+				$this->anything() )
+			->will( $this->returnValue( new FakeResultWrapper( [ $row ] ) ) );
+
+		$this->store->expects( $this->atLeastOnce() )
+			->method( 'getPropertyTableInfoFetcher' )
+			->will( $this->returnValue( $propertyTableInfoFetcher ) );
+
+		$this->store->expects( $this->atLeastOnce() )
+			->method( 'getConnection' )
+			->will( $this->returnValue( $this->connection ) );
+
+		$instance = new UpdateQueryDependencies();
+
+		$instance->setMessageReporter(
+			$this->messageReporter
+		);
+
+		$instance->execute();
+	}
+
+}


### PR DESCRIPTION
This PR is made in reference to: #1117

This PR addresses or contains:

- Adds the `updateQueryDependencies.php` script to run updates on all entities that embedded queries hereby allows to fill (or update) the query links table especially when enabling `smwgEnabledQueryDependencyLinksStore`
- https://www.semantic-mediawiki.org/wiki/Help:UpdateQueryDependencies.php

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed
