### PR TITLE
[CI] Skip tests on site language, refs 4135

### DIFF
--- a/tests/phpunit/Integration/JSONScript/TestCases/f-0208.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/f-0208.json
@@ -173,6 +173,9 @@
 		}
 	},
 	"meta": {
+		"skip-on": {
+			"sitelanguage": [ "ja", "Some issues with NS_SPECIAL when 'ja' is used as sitelanguage." ]
+		},
 		"version": "2",
 		"is-incomplete": false,
 		"debug": false

--- a/tests/phpunit/Integration/JSONScript/TestCases/f-0211.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/f-0211.json
@@ -223,6 +223,9 @@
 		}
 	},
 	"meta": {
+		"skip-on": {
+			"sitelanguage": [ "ja", "Some issues with NS_SPECIAL when 'ja' is used as sitelanguage." ]
+		},
 		"version": "2",
 		"is-incomplete": false,
 		"debug": false

--- a/tests/phpunit/Integration/JSONScript/TestCases/f-0301.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/f-0301.json
@@ -203,7 +203,9 @@
 	},
 	"meta": {
 		"skip-on": {
-			"postgres": "Unicode needs special treatment in postgres"
+			"postgres": "Unicode needs special treatment in postgres",
+			"sitelanguage": [ "ja", "Some issues with NS_SPECIAL when 'ja' is used as sitelanguage." ]
+
 		},
 		"version": "2",
 		"is-incomplete": false,

--- a/tests/phpunit/Integration/JSONScript/TestCases/f-0302.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/f-0302.json
@@ -101,6 +101,9 @@
 		}
 	},
 	"meta": {
+		"skip-on": {
+			"sitelanguage": [ "ja", "Some issues with NS_SPECIAL when 'ja' is used as sitelanguage." ]
+		},
 		"version": "2",
 		"is-incomplete": false,
 		"debug": false

--- a/tests/phpunit/Integration/JSONScript/TestCases/p-0202.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/p-0202.json
@@ -77,6 +77,9 @@
 		]
 	},
 	"meta": {
+		"skip-on": {
+			"sitelanguage": [ "ja", "Some issues with NS_SPECIAL when 'ja' is used as sitelanguage." ]
+		},
 		"version": "2",
 		"is-incomplete": false,
 		"debug": false

--- a/tests/phpunit/Integration/JSONScript/TestCases/p-0424.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/p-0424.json
@@ -106,7 +106,7 @@
 	},
 	"meta": {
 		"skip-on": {
-			"mw-1.25.6": "Somehow the content lang is not set correctly on Travis (locally works fine)."
+			"sitelanguage": [ "ja", "Some issues with NS_SPECIAL when 'ja' is used as sitelanguage." ]
 		},
 		"version": "2",
 		"is-incomplete": false,

--- a/tests/phpunit/Integration/JSONScript/TestCases/p-0433.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/p-0433.json
@@ -80,6 +80,9 @@
 		]
 	},
 	"meta": {
+		"skip-on": {
+			"sitelanguage": [ "ja", "Some issues with NS_SPECIAL when 'ja' is used as sitelanguage." ]
+		},
 		"version": "2",
 		"is-incomplete": false,
 		"debug": false

--- a/tests/phpunit/Integration/JSONScript/TestCases/p-0438.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/p-0438.json
@@ -54,6 +54,9 @@
 		"wgRestrictDisplayTitle": false
 	},
 	"meta": {
+		"skip-on": {
+			"sitelanguage": [ "ja", "Some issues with NS_SPECIAL when 'ja' is used as sitelanguage." ]
+		},
 		"version": "2",
 		"is-incomplete": false,
 		"debug": false

--- a/tests/phpunit/Integration/JSONScript/TestCases/p-0459.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/p-0459.json
@@ -112,6 +112,9 @@
 		}
 	},
 	"meta": {
+		"skip-on": {
+			"sitelanguage": [ "ja", "Some issues with NS_SPECIAL when 'ja' is used as sitelanguage." ]
+		},
 		"version": "2",
 		"is-incomplete": false,
 		"debug": false

--- a/tests/phpunit/Integration/JSONScript/TestCases/p-0703.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/p-0703.json
@@ -57,6 +57,9 @@
 		]
 	},
 	"meta": {
+		"skip-on": {
+			"sitelanguage": [ "ja", "Some issues with NS_SPECIAL when 'ja' is used as sitelanguage." ]
+		},
 		"version": "2",
 		"is-incomplete": false,
 		"debug": false

--- a/tests/phpunit/Integration/JSONScript/TestCases/p-0705.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/p-0705.json
@@ -122,6 +122,9 @@
 		}
 	},
 	"meta": {
+		"skip-on": {
+			"sitelanguage": [ "ja", "Some issues with the thumb output when 'ja' is used as sitelanguage." ]
+		},
 		"version": "2",
 		"is-incomplete": false,
 		"debug": false

--- a/tests/phpunit/Integration/JSONScript/TestCases/p-0708.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/p-0708.json
@@ -54,6 +54,9 @@
 		}
 	},
 	"meta": {
+		"skip-on": {
+			"sitelanguage": [ "ja", "Some issues with NS_SPECIAL when 'ja' is used as sitelanguage." ]
+		},
 		"version": "2",
 		"is-incomplete": false,
 		"debug": false

--- a/tests/phpunit/Integration/JSONScript/TestCases/p-0917.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/p-0917.json
@@ -68,6 +68,9 @@
 		}
 	},
 	"meta": {
+		"skip-on": {
+			"sitelanguage": [ "ja", "Some issues with NS_SPECIAL when 'ja' is used as sitelanguage." ]
+		},
 		"version": "2",
 		"is-incomplete": false,
 		"debug": false

--- a/tests/phpunit/Integration/JSONScript/TestCases/p-1002.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/p-1002.json
@@ -37,6 +37,9 @@
 		}
 	},
 	"meta": {
+		"skip-on": {
+			"sitelanguage": [ "ja", "Some issues with NS_SPECIAL when 'ja' is used as sitelanguage." ]
+		},
 		"version": "2",
 		"is-incomplete": false,
 		"debug": false

--- a/tests/phpunit/Integration/JSONScript/TestCases/p-1009.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/p-1009.json
@@ -69,6 +69,9 @@
 		}
 	},
 	"meta": {
+		"skip-on": {
+			"sitelanguage": [ "ja", "Some issues with NS_SPECIAL when 'ja' is used as sitelanguage." ]
+		},
 		"version": "2",
 		"is-incomplete": false,
 		"debug": false

--- a/tests/phpunit/Integration/JSONScript/TestCases/r-0010.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/r-0010.json
@@ -97,6 +97,9 @@
 		"smwgNamespace": "http://example.org/id/"
 	},
 	"meta": {
+		"skip-on": {
+			"sitelanguage": [ "ja", "Some issues with canonical NS_SPECIAL output when 'ja' is used as sitelanguage." ]
+		},
 		"version": "2",
 		"is-incomplete": false,
 		"debug": false

--- a/tests/phpunit/Integration/JSONScript/TestCases/s-0003.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/s-0003.json
@@ -124,6 +124,9 @@
 		}
 	},
 	"meta": {
+		"skip-on": {
+			"sitelanguage": [ "ja", "Some issues with <swivt:type rdf:resource=\"http://example.org/id/Category-3AS0003\"/> when 'ja' is used as sitelanguage." ]
+		},
 		"version": "2",
 		"is-incomplete": false,
 		"debug": false

--- a/tests/phpunit/Integration/JSONScript/TestCases/s-0004.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/s-0004.json
@@ -42,6 +42,9 @@
 		}
 	},
 	"meta": {
+		"skip-on": {
+			"sitelanguage": [ "ja", "Some issues with NS_SPECIAL when 'ja' is used as sitelanguage." ]
+		},
 		"version": "2",
 		"is-incomplete": false,
 		"debug": false

--- a/tests/phpunit/Integration/JSONScript/TestCases/s-0005.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/s-0005.json
@@ -76,6 +76,9 @@
 		]
 	},
 	"meta": {
+		"skip-on": {
+			"sitelanguage": [ "ja", "Some issues with NS_SPECIAL when 'ja' is used as sitelanguage." ]
+		},
 		"version": "2",
 		"is-incomplete": false,
 		"debug": false

--- a/tests/phpunit/Integration/JSONScript/TestCases/s-0008.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/s-0008.json
@@ -152,7 +152,8 @@
 	},
 	"meta": {
 		"skip-on": {
-			"mw-1.25.6": "Somehow the content lang is not set correctly on Travis (locally works fine)."
+			"mw-1.25.6": "Somehow the content lang is not set correctly on Travis (locally works fine).",
+			"sitelanguage": [ "ja", "Some issues with NS_SPECIAL when 'ja' is used as sitelanguage." ]
 		},
 		"version": "2",
 		"is-incomplete": false,

--- a/tests/phpunit/Integration/JSONScript/TestCases/s-0012.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/s-0012.json
@@ -59,6 +59,9 @@
 		}
 	},
 	"meta": {
+		"skip-on": {
+			"sitelanguage": [ "ja", "Some issues with thumb output when 'ja' is used as sitelanguage." ]
+		},
 		"version": "2",
 		"is-incomplete": false,
 		"debug": false

--- a/tests/phpunit/Integration/JSONScript/TestCases/s-0024.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/s-0024.json
@@ -42,6 +42,9 @@
 		}
 	},
 	"meta": {
+		"skip-on": {
+			"sitelanguage": [ "ja", "Some issues with NS_SPECIAL when 'ja' is used as sitelanguage." ]
+		},
 		"version": "2",
 		"is-incomplete": false,
 		"debug": false

--- a/tests/phpunit/Integration/Query/ConjunctionQueryDBIntegrationTest.php
+++ b/tests/phpunit/Integration/Query/ConjunctionQueryDBIntegrationTest.php
@@ -38,6 +38,10 @@ class ConjunctionQueryDBIntegrationTest extends MwDBaseUnitTestCase {
 	protected function setUp() {
 		parent::setUp();
 
+		if ( $GLOBALS['wgLanguageCode'] !== 'en' ) {
+			return $this->markTestSkipped( 'Category title produces different fingerprint!' );
+		}
+
 		$utilityFactory = UtilityFactory::getInstance();
 
 		$this->semanticDataFactory  = $utilityFactory->newSemanticDataFactory();

--- a/tests/phpunit/Integration/Query/DisjunctionQueryDBIntegrationTest.php
+++ b/tests/phpunit/Integration/Query/DisjunctionQueryDBIntegrationTest.php
@@ -37,6 +37,10 @@ class DisjunctionQueryDBIntegrationTest extends MwDBaseUnitTestCase {
 	protected function setUp() {
 		parent::setUp();
 
+		if ( $GLOBALS['wgLanguageCode'] !== 'en' ) {
+			return $this->markTestSkipped( 'Category title produces different fingerprint!' );
+		}
+
 		$this->queryResultValidator = UtilityFactory::getInstance()->newValidatorFactory()->newQueryResultValidator();
 		$this->semanticDataFactory = UtilityFactory::getInstance()->newSemanticDataFactory();
 		$this->queryParser = ApplicationFactory::getInstance()->getQueryFactory()->newQueryParser();

--- a/tests/phpunit/Integration/Query/ProfileAnnotators/ProfileAnnotatorWithQueryProcessorIntegrationTest.php
+++ b/tests/phpunit/Integration/Query/ProfileAnnotators/ProfileAnnotatorWithQueryProcessorIntegrationTest.php
@@ -24,6 +24,10 @@ class ProfileAnnotatorWithQueryProcessorIntegrationTest extends \PHPUnit_Framewo
 	protected function setUp() {
 		parent::setUp();
 
+		if ( $GLOBALS['wgLanguageCode'] !== 'en' ) {
+			return $this->markTestSkipped( 'Category title produces different fingerprint!' );
+		}
+
 		$testEnvironment = new TestEnvironment();
 		$this->semanticDataValidator = $testEnvironment->getUtilityFactory()->newValidatorFactory()->newSemanticDataValidator();
 	}

--- a/tests/phpunit/Integration/RdfFileResourceTest.php
+++ b/tests/phpunit/Integration/RdfFileResourceTest.php
@@ -26,6 +26,10 @@ class RdfFileResourceTest extends MwDBaseUnitTestCase {
 	protected function setUp() {
 		parent::setUp();
 
+		if ( $GLOBALS['wgLanguageCode'] !== 'en' ) {
+			return $this->markTestSkipped( 'Property title produces different representation!' );
+		}
+
 		$utilityFactory = $this->testEnvironment->getUtilityFactory();
 
 		$this->fixturesFileProvider = $utilityFactory->newFixturesFactory()->newFixturesFileProvider();

--- a/tests/phpunit/Integration/System/I18nExtraneousLanguageFileIntegrityTest.php
+++ b/tests/phpunit/Integration/System/I18nExtraneousLanguageFileIntegrityTest.php
@@ -26,7 +26,7 @@ class I18nExtraneousLanguageFileIntegrityTest extends \PHPUnit_Framework_TestCas
 		$missedLabelPair = [];
 
 		if ( !isset( $contents['property']['labels'] ) ) {
-			return $this->markTestIncomplete( 'No property label for ' . basename( $file ) . ' available.' );
+			return $this->markTestSkipped( 'No property label for ' . basename( $file ) . ' available.' );
 		}
 
 		foreach ( $contents['property']['labels'] as $key => $label ) {
@@ -53,7 +53,7 @@ class I18nExtraneousLanguageFileIntegrityTest extends \PHPUnit_Framework_TestCas
 		$missedAliasPair = [];
 
 		if ( !isset( $contents['property']['aliases'] ) ) {
-			return $this->markTestIncomplete( 'No property aliases for ' . basename( $file ) . ' available.' );
+			return $this->markTestSkipped( 'No property aliases for ' . basename( $file ) . ' available.' );
 		}
 
 		foreach ( $contents['property']['aliases'] as $label => $key ) {

--- a/tests/phpunit/JsonTestCaseFileHandler.php
+++ b/tests/phpunit/JsonTestCaseFileHandler.php
@@ -233,6 +233,31 @@ class JsonTestCaseFileHandler {
 	 *
 	 * @return boolean
 	 */
+	public function requiredToSkipOnSiteLanguage( $siteLanguage ) {
+
+		$meta = $this->getFileContentsFor( 'meta' );
+		$skipOn = isset( $meta['skip-on'] ) ? $meta['skip-on'] : [];
+
+		foreach ( $skipOn as $id => $reason ) {
+
+			if ( $id !== 'sitelanguage') {
+				continue;
+			}
+
+			if ( $reason[0] === $siteLanguage ) {
+				$this->reasonToSkip = $reason[1];
+				break;
+			}
+		}
+
+		return $this->reasonToSkip !== '';
+	}
+
+	/**
+	 * @since 2.2
+	 *
+	 * @return boolean
+	 */
 	public function requiredToSkipForMwVersion( $mwVersion ) {
 
 		$meta = $this->getFileContentsFor( 'meta' );

--- a/tests/phpunit/JsonTestCaseScriptRunner.php
+++ b/tests/phpunit/JsonTestCaseScriptRunner.php
@@ -277,6 +277,10 @@ abstract class JsonTestCaseScriptRunner extends MwDBaseUnitTestCase {
 			$this->markTestSkipped( $jsonTestCaseFileHandler->getReasonForSkip() );
 		}
 
+		if ( $jsonTestCaseFileHandler->requiredToSkipOnSiteLanguage( $GLOBALS['wgLanguageCode'] ) ) {
+			$this->markTestSkipped( $jsonTestCaseFileHandler->getReasonForSkip() );
+		}
+
 		if ( $jsonTestCaseFileHandler->requiredToSkipForConnector( $this->getDBConnection()->getType() ) ) {
 			$this->markTestSkipped( $jsonTestCaseFileHandler->getReasonForSkip() );
 		}

--- a/tests/phpunit/Unit/Parser/InTextAnnotationParserTest.php
+++ b/tests/phpunit/Unit/Parser/InTextAnnotationParserTest.php
@@ -25,6 +25,7 @@ use Title;
 class InTextAnnotationParserTest extends \PHPUnit_Framework_TestCase {
 
 	private $semanticDataValidator;
+	private $stringValidator;
 	private $testEnvironment;
 	private $linksProcessor;
 	private $magicWordsFinder;
@@ -34,6 +35,7 @@ class InTextAnnotationParserTest extends \PHPUnit_Framework_TestCase {
 
 		$this->testEnvironment = new TestEnvironment();
 		$this->semanticDataValidator = $this->testEnvironment->getUtilityFactory()->newValidatorFactory()->newSemanticDataValidator();
+		$this->stringValidator = $this->testEnvironment->getUtilityFactory()->newValidatorFactory()->newStringValidator();
 
 		$store = $this->getMockBuilder( '\SMW\Store' )
 			->disableOriginalConstructor()
@@ -158,7 +160,7 @@ class InTextAnnotationParserTest extends \PHPUnit_Framework_TestCase {
 
 		$instance->parse( $text );
 
-		$this->assertContains(
+		$this->stringValidator->assertThatStringContains(
 			$expected['resultText'],
 			$text
 		);
@@ -527,8 +529,6 @@ class InTextAnnotationParserTest extends \PHPUnit_Framework_TestCase {
 		#7 673
 
 		// Special:Types/Number
-		$specialTypeName = \SpecialPage::getTitleFor( 'Types', 'Number' )->getPrefixedText();
-
 		$provider[] = [
 			SMW_NS_PROPERTY,
 			[
@@ -537,7 +537,8 @@ class InTextAnnotationParserTest extends \PHPUnit_Framework_TestCase {
 			],
 			'[[has type::number]], [[has Type::page]] ',
 			[
-				'resultText'     => "[[$specialTypeName|number]], [[:Page|page]]",
+				//                     Special:Types/Number -> .*/Number
+				'resultText'     => "[[.*/Number|number]], [[:Page|page]]",
 				'propertyCount'  => 2,
 				'propertyLabels' => [ 'Has type', 'Has Type' ],
 				'propertyValues' => [ 'Number', 'Page' ]

--- a/tests/phpunit/includes/InfolinkTest.php
+++ b/tests/phpunit/includes/InfolinkTest.php
@@ -60,6 +60,10 @@ class InfolinkTest extends \PHPUnit_Framework_TestCase {
 
 	public function testNewPropertySearchLink_GetText() {
 
+		if ( $GLOBALS['wgLanguageCode'] !== 'en' ) {
+			return $this->markTestSkipped( 'NS_SPECIAL produces different representation!' );
+		}
+
 		$instance = Infolink::newPropertySearchLink( 'Foo', 'Bar', 'Foobar' );
 
 		$instance->setCompactLink( false );


### PR DESCRIPTION
This PR is made in reference to: #4135

This PR addresses or contains:

- Skip tests where the sitelanguage is `ja` or not `en` due to changes in MW 1.31+ to the `Title`, `Parser` MediaWiki services (outputting `NS_SPECIAL` related titles in the `wgLanguage` instead of the set `wgContLang` as it was the case for MW 1.27)

This PR includes:
- [ ] Tests (unit/integration)
- [x] CI build passed
