### PR TITLE
Adds `--report-runtime` and `--with-maintenance-log` options

### DIFF
--- a/docs/RELEASE-NOTES.md
+++ b/docs/RELEASE-NOTES.md
@@ -124,6 +124,7 @@ Changes to the DB are triggered by [#3644](https://github.com/SemanticMediaWiki/
 * [#4048](https://github.com/SemanticMediaWiki/SemanticMediaWiki/pull/4048)
 * [#4047](https://github.com/SemanticMediaWiki/SemanticMediaWiki/pull/4047)
 * [#4069](https://github.com/SemanticMediaWiki/SemanticMediaWiki/pull/4069)
+* [#4151](https://github.com/SemanticMediaWiki/SemanticMediaWiki/pull/4151) Added `--report-runtime` and `--with-maintenance-log` options to the "removeDuplicateEntities.php" maintenance script
 
 ## Bug fixes
 

--- a/maintenance/removeDuplicateEntities.php
+++ b/maintenance/removeDuplicateEntities.php
@@ -24,6 +24,8 @@ class RemoveDuplicateEntities extends \Maintenance {
 	public function __construct() {
 		$this->mDescription = 'Remove duplicate entities without active references.';
 		$this->addOption( 's', 'ID starting point', false, true );
+		$this->addOption( 'report-runtime', 'Report execution time and memory usage', false );		
+		$this->addOption( 'with-maintenance-log', 'Add log entry to `Special:Log` about the maintenance run.', false );
 
 		parent::__construct();
 	}
@@ -69,6 +71,16 @@ class RemoveDuplicateEntities extends \Maintenance {
 
 		$duplicateEntityRecords = $duplicateEntitiesDisposer->findDuplicates();
 		$duplicateEntitiesDisposer->verifyAndDispose( $duplicateEntityRecords );
+		
+		if ( $result && $this->hasOption( 'report-runtime' ) ) {
+			$this->reportMessage( "\n" . "Runtime report ..." . "\n" );
+			$this->reportMessage( $maintenanceHelper->getFormattedRuntimeValues( '   ...' ) . "\n" );
+		}
+		
+		if ( $this->hasOption( 'with-maintenance-log' ) ) {
+			$maintenanceLogger = $maintenanceFactory->newMaintenanceLogger( 'RemoveDuplicateEntitiesLogger' );
+			$maintenanceLogger->log( $maintenanceHelper->transformRuntimeValuesForOutput() );
+		}
 
 		return true;
 	}

--- a/maintenance/removeDuplicateEntities.php
+++ b/maintenance/removeDuplicateEntities.php
@@ -72,7 +72,7 @@ class RemoveDuplicateEntities extends \Maintenance {
 		$duplicateEntityRecords = $duplicateEntitiesDisposer->findDuplicates();
 		$duplicateEntitiesDisposer->verifyAndDispose( $duplicateEntityRecords );
 		
-		if ( $result && $this->hasOption( 'report-runtime' ) ) {
+		if ( $this->hasOption( 'report-runtime' ) ) {
 			$this->reportMessage( "\n" . "Runtime report ..." . "\n" );
 			$this->reportMessage( $maintenanceHelper->getFormattedRuntimeValues( '   ...' ) . "\n" );
 		}


### PR DESCRIPTION
This PR is made in reference to: #4149

This PR addresses or contains:
- Adds `--report-runtime` option to "removeDuplicateEntities.php"
- Adds  `--with-maintenance-log` option to "removeDuplicateEntities.php"

This PR includes:
- [ ] Tests (unit/integration)
- [x] CI build passed

Fixes #4149