### PR TITLE
Adds `--with-maintenance-log` option

### DIFF
--- a/docs/RELEASE-NOTES.md
+++ b/docs/RELEASE-NOTES.md
@@ -124,6 +124,7 @@ Changes to the DB are triggered by [#3644](https://github.com/SemanticMediaWiki/
 * [#4048](https://github.com/SemanticMediaWiki/SemanticMediaWiki/pull/4048)
 * [#4047](https://github.com/SemanticMediaWiki/SemanticMediaWiki/pull/4047)
 * [#4069](https://github.com/SemanticMediaWiki/SemanticMediaWiki/pull/4069)
+* [#4069](https://github.com/SemanticMediaWiki/SemanticMediaWiki/pull/4152) Added `--with-maintenance-log` option to the "rebuildElasticIndex.php" maintenance script
 
 ## Bug fixes
 

--- a/maintenance/rebuildElasticIndex.php
+++ b/maintenance/rebuildElasticIndex.php
@@ -60,6 +60,7 @@ class RebuildElasticIndex extends \Maintenance {
 
 		$this->addOption( 'debug', 'Sets global variables to support debug ouput while running the script', false );
 		$this->addOption( 'report-runtime', 'Report execution time and memory usage', false );
+		$this->addOption( 'with-maintenance-log', 'Add log entry to `Special:Log` about the maintenance run.', false );
 
 		parent::__construct();
 	}
@@ -158,6 +159,11 @@ class RebuildElasticIndex extends \Maintenance {
 
 		if ( $this->hasOption( 'report-runtime' ) ) {
 			$this->reportMessage( "\n" . $maintenanceHelper->getFormattedRuntimeValues() . "\n" );
+		}
+		
+		if ( $this->hasOption( 'with-maintenance-log' ) ) {
+			$maintenanceLogger = $maintenanceFactory->newMaintenanceLogger( 'RebuildElasticIndexLogger' );
+			$maintenanceLogger->log( $maintenanceHelper->transformRuntimeValuesForOutput() );
 		}
 
 		$maintenanceHelper->reset();


### PR DESCRIPTION
This PR is made in reference to: #3706 

This PR addresses or contains:
- Adds `--with-maintenance-log` option

This PR includes:
- [ ] Tests (unit/integration)
- [x] CI build passed

Fixes #3706 