### PR TITLE
[ES] Catch invalid predefined property match

### DIFF
--- a/src/Elastic/Connection/DummyClient.php
+++ b/src/Elastic/Connection/DummyClient.php
@@ -64,6 +64,13 @@ class DummyClient extends Client {
 	}
 
 	/**
+	 * @see Client::getIndexNameByType
+	 */
+	public function getIndexNameByType( $type ) {
+		return $this->getIndexName( $type );
+	}
+
+	/**
 	 * @see Client::getIndexName
 	 */
 	public function getIndexName( $type ) {

--- a/src/Elastic/QueryEngine/QueryEngine.php
+++ b/src/Elastic/QueryEngine/QueryEngine.php
@@ -4,6 +4,7 @@ namespace SMW\Elastic\QueryEngine;
 
 use Psr\Log\LoggerAwareTrait;
 use SMW\ApplicationFactory;
+use SMW\Exception\PredefinedPropertyLabelMismatchException;
 use SMW\Elastic\Connection\Client as ElasticClient;
 use SMW\Options;
 use SMW\Query\Language\ThingDescription;
@@ -320,12 +321,24 @@ class QueryEngine implements IQueryEngine {
 
 			$id = $dataItem->getId();
 			$subobjectName = $dataItem->getSubobjectName();
+			$property = null;
 
 			// Handle predefined properties
-			if ( $dataItem->getNamespace() === SMW_NS_PROPERTY && ( $dbKey = $dataItem->getDBKEY() ) && $dbKey{0} === '_' ) {
-				$dataItem = DIProperty::newFromUserLabel( $dbKey )->getDIWikiPage(
-					$subobjectName
-				);
+			if (
+				$dataItem->getNamespace() === SMW_NS_PROPERTY &&
+				( $dbKey = $dataItem->getDBKey() ) &&
+				$dbKey{0} === '_' ) {
+
+				try {
+					$property = DIProperty::newFromUserLabel( $dbKey );
+				} catch ( PredefinedPropertyLabelMismatchException $e ) {
+					// Keep the dataItem as-is, this may hint to an outdated
+					// predefined property
+				}
+			}
+
+			if ( $property !== null ) {
+				$dataItem = $property->getDIWikiPage( $subobjectName );
 			}
 
 			$results[$listPos[$id]] = $dataItem;

--- a/src/Elastic/QueryEngine/SearchResult.php
+++ b/src/Elastic/QueryEngine/SearchResult.php
@@ -89,7 +89,7 @@ class SearchResult {
 	public function getResults( $cutoff = null ) {
 
 		if ( $this->results === null ) {
-			$this->filter_results( $this->raw, $cutoff );
+			$this->doFilterResults( $this->raw, $cutoff );
 		}
 
 		return $this->results;
@@ -116,7 +116,7 @@ class SearchResult {
 	 *
 	 * @return []
 	 */
-	public function filter_results( array $results, $cutoff = null ) {
+	public function doFilterResults( array $results, $cutoff = null ) {
 
 		$this->results = [];
 
@@ -133,7 +133,7 @@ class SearchResult {
 		}
 
 		$info = $results;
-		$res = $this->filter_field( $results, $cutoff );
+		$res = $this->filterByField( $results, $cutoff, $this->filterField );
 
 		unset( $info['hits'] );
 		unset( $info['_shards'] );
@@ -151,16 +151,15 @@ class SearchResult {
 	/**
 	 * @see https://www.elastic.co/guide/en/elasticsearch/client/php-api/6.0/_search_operations.html
 	 */
-	private function filter_field( $results, $cutoff ) {
+	private function filterByField( $results, $cutoff, $field ) {
 
 		$res = [];
 		$continue = false;
 
 		$scores = [];
 		$excerpts = [];
-		$i = 0;
 
-		$field = $this->filterField;
+		$i = 0;
 		$pid = null;
 
 		if ( strpos( $field, '.' ) !== false ) {

--- a/tests/phpunit/Unit/Elastic/QueryEngine/QueryEngineTest.php
+++ b/tests/phpunit/Unit/Elastic/QueryEngine/QueryEngineTest.php
@@ -1,0 +1,177 @@
+<?php
+
+namespace SMW\Tests\Elastic\QueryEngine;
+
+use SMW\Elastic\QueryEngine\QueryEngine;
+use SMW\Query\QueryResult;
+use SMW\DIWikiPage;
+use SMWQuery as Query;
+
+/**
+ * @covers \SMW\Elastic\QueryEngine\QueryEngine
+ * @group semantic-mediawiki
+ *
+ * @license GNU GPL v2+
+ * @since 3.1
+ *
+ * @author mwjames
+ */
+class QueryEngineTest extends \PHPUnit_Framework_TestCase {
+
+	private $store;
+	private $conditionBuilder;
+	private $elasticClient;
+	private $idTable;
+
+	protected function setUp() {
+		parent::setUp();
+
+		$this->idTable = $this->getMockBuilder( '\SMWSql3SmwIds' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$database = $this->getMockBuilder( '\SMW\MediaWiki\Database' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$this->elasticClient = $this->getMockBuilder( '\SMW\Elastic\Connection\DummyClient' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$callback = function( $type ) use( $database ) {
+
+			if ( $type === 'mw.db' ) {
+				return $connection;
+			};
+
+			return $this->elasticClient;
+		};
+
+		$this->store = $this->getMockBuilder( '\SMW\SQLStore\SQLStore' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$this->store->expects( $this->any() )
+			->method( 'getConnection' )
+			->will( $this->returnCallback( $callback ) );
+
+		$this->store->expects( $this->any() )
+			->method( 'getObjectIds' )
+			->will( $this->returnValue( $this->idTable ) );
+
+		$this->conditionBuilder = $this->getMockBuilder( '\SMW\Elastic\QueryEngine\ConditionBuilder' )
+			->disableOriginalConstructor()
+			->getMock();
+
+	}
+
+	public function testCanConstruct() {
+
+		$this->assertInstanceOf(
+			QueryEngine::class,
+			new QueryEngine( $this->store, $this->conditionBuilder )
+		);
+	}
+
+	public function testgetQueryResult_MODE_NONE() {
+
+		$description = $this->getMockBuilder( '\SMW\Query\Language\Description' )
+			->disableOriginalConstructor()
+			->getMockForAbstractClass();
+
+		$query = $this->getMockBuilder( '\SMWQuery' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$query->expects( $this->any() )
+			->method( 'getDescription' )
+			->will( $this->returnValue( $description ) );
+
+		$query->expects( $this->any() )
+			->method( 'getLimit' )
+			->will( $this->returnValue( 0 ) );
+
+		$query->querymode = Query::MODE_NONE;
+
+		$instance = new QueryEngine(
+			$this->store,
+			$this->conditionBuilder
+		);
+
+		$this->assertInstanceOf(
+			QueryResult::class,
+			$instance->getQueryResult( $query )
+		);
+	}
+
+	public function testgetQueryResult_MODE_INSTANCES() {
+
+		$subject = DIWikiPage::newFromText( 'Foo' );
+		$subject->setId( 42 );
+
+		// Unknown predefined property
+		$subject_predef_prop = DIWikiPage::newFromText( '_FOO', SMW_NS_PROPERTY );
+		$subject_predef_prop->setId( 1001 );
+
+		$res = [
+			'hits' => [
+				'hits' => [
+					[ '_id' => 42 ],
+					[ '_id' => 1001 ]
+				],
+				'max_score' => 0
+			],
+		];
+
+		$list = [
+			$subject,
+			$subject_predef_prop
+		];
+
+		$errors = [];
+
+		$description = $this->getMockBuilder( '\SMW\Query\Language\Description' )
+			->disableOriginalConstructor()
+			->getMockForAbstractClass();
+
+		$query = $this->getMockBuilder( '\SMWQuery' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$query->expects( $this->any() )
+			->method( 'getDescription' )
+			->will( $this->returnValue( $description ) );
+
+		$query->expects( $this->any() )
+			->method( 'getLimit' )
+			->will( $this->returnValue( 42 ) );
+
+		$query->expects( $this->any() )
+			->method( 'getSortKeys' )
+			->will( $this->returnValue( [] ) );
+
+		$this->elasticClient->expects( $this->any() )
+			->method( 'search' )
+			->will( $this->returnValue( [ $res , $errors ] ) );
+
+		$this->idTable->expects( $this->any() )
+			->method( 'getDataItemsFromList' )
+			->will( $this->returnValue( $list ) );
+
+		$this->conditionBuilder->expects( $this->once() )
+			->method( 'makeFromDescription' );
+
+		$query->querymode = Query::MODE_INSTANCES;
+
+		$instance = new QueryEngine(
+			$this->store,
+			$this->conditionBuilder
+		);
+
+		$this->assertInstanceOf(
+			QueryResult::class,
+			$instance->getQueryResult( $query )
+		);
+	}
+
+}


### PR DESCRIPTION
This PR is made in reference to: #

This PR addresses or contains:

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed

### Stack trace

```
[c11ba41d9efee34acff7d29f] /w/index.php?search=in%3Aattachment&title=Sp%C3%A9cial%3ARecherche&go=Continuer SMW\Exception\PredefinedPropertyLabelMismatchException from line 94 of /var/www/html/sbxsmw/w/extensions/SemanticMediaWiki/includes/dataitems/SMW_DI_Property.php: There is no predefined property with "_FILE_AT".

Backtrace:

#0 /var/www/html/sbxsmw/w/extensions/SemanticMediaWiki/includes/dataitems/SMW_DI_Property.php(497): SMW\DIProperty->__construct(string, boolean)
#1 /var/www/html/sbxsmw/w/extensions/SemanticMediaWiki/src/Elastic/QueryEngine/QueryEngine.php(326): SMW\DIProperty::newFromUserLabel(string)
#2 /var/www/html/sbxsmw/w/extensions/SemanticMediaWiki/src/Elastic/QueryEngine/QueryEngine.php(214): SMW\Elastic\QueryEngine\QueryEngine->newInstanceQueryResult(SMWQuery, array)
#3 /var/www/html/sbxsmw/w/extensions/SemanticMediaWiki/src/Query/Cache/ResultCache.php(250): SMW\Elastic\QueryEngine\QueryEngine->getQueryResult(SMWQuery)
#4 /var/www/html/sbxsmw/w/extensions/SemanticMediaWiki/src/MediaWiki/Hooks.php(1211): SMW\Query\Cache\ResultCache->getQueryResult(SMWQuery)
#5 /var/www/html/sbxsmw/w/includes/Hooks.php(174): SMW\MediaWiki\Hooks->onBeforeQueryResultLookupComplete(SMW\Elastic\ElasticStore, SMWQuery, NULL, SMW\Elastic\QueryEngine\QueryEngine)
#6 /var/www/html/sbxsmw/w/includes/Hooks.php(202): Hooks::callHook(string, array, array, NULL)
#7 /var/www/html/sbxsmw/w/extensions/SemanticMediaWiki/src/Elastic/ElasticStore.php(209): Hooks::run(string, array)
#8 /var/www/html/sbxsmw/w/extensions/SemanticMediaWiki/src/MediaWiki/Search/ExtendedSearch.php(305): SMW\Elastic\ElasticStore->getQueryResult(SMWQuery)
#9 /var/www/html/sbxsmw/w/extensions/SemanticMediaWiki/src/MediaWiki/Search/ExtendedSearch.php(232): SMW\MediaWiki\Search\ExtendedSearch->newSearchResultSet(string)
#10 /var/www/html/sbxsmw/w/extensions/SemanticMediaWiki/src/MediaWiki/Search/ExtendedSearchEngine.php(115): SMW\MediaWiki\Search\ExtendedSearch->searchText(string)
#11 /var/www/html/sbxsmw/w/includes/specials/SpecialSearch.php(348): SMW\MediaWiki\Search\ExtendedSearchEngine->searchText(string)
#12 /var/www/html/sbxsmw/w/includes/specials/SpecialSearch.php(173): SpecialSearch->showResults(string)
#13 /var/www/html/sbxsmw/w/includes/specialpage/SpecialPage.php(569): SpecialSearch->execute(NULL)
#14 /var/www/html/sbxsmw/w/includes/specialpage/SpecialPageFactory.php(558): SpecialPage->run(NULL)
#15 /var/www/html/sbxsmw/w/includes/MediaWiki.php(288): MediaWiki\Special\SpecialPageFactory->executePath(Title, RequestContext)
#16 /var/www/html/sbxsmw/w/includes/MediaWiki.php(865): MediaWiki->performRequest()
#17 /var/www/html/sbxsmw/w/includes/MediaWiki.php(515): MediaWiki->main()
#18 /var/www/html/sbxsmw/w/index.php(42): MediaWiki->run()
#19 {main}
```