### PR TITLE
Check for `PredefinedPropertyLabelMismatchException` in `CacheWarmer`

### DIFF
--- a/src/SQLStore/EntityStore/CacheWarmer.php
+++ b/src/SQLStore/EntityStore/CacheWarmer.php
@@ -10,6 +10,7 @@ use SMWQueryResult as QueryResult;
 use Iterator;
 use SMW\MediaWiki\LinkBatch;
 use SMW\DisplayTitleFinder;
+use SMW\Exception\PredefinedPropertyLabelMismatchException;
 
 /**
  * @license GNU GPL v2+
@@ -95,7 +96,11 @@ class CacheWarmer {
 				$linkBatch->add( $item );
 
 				if ( $item->getNamespace() === SMW_NS_PROPERTY ) {
-					$property = DIProperty::newFromUserLabel( $item->getDBKey() );
+					try {
+						$property = DIProperty::newFromUserLabel( $item->getDBKey() );
+					} catch ( PredefinedPropertyLabelMismatchException $e ) {
+						continue;
+					}
 					$hash = $item->getSha1();
 				} else {
 					$hash = $item->getSha1();

--- a/tests/phpunit/Unit/SQLStore/EntityStore/CacheWarmerTest.php
+++ b/tests/phpunit/Unit/SQLStore/EntityStore/CacheWarmerTest.php
@@ -169,4 +169,34 @@ class CacheWarmerTest extends \PHPUnit_Framework_TestCase {
 		$instance->fillFromList( $list );
 	}
 
+	public function testFillFromList_UnknownPredefinedProperty() {
+
+		$list = [
+			new DIWikiPage( '_Foo', SMW_NS_PROPERTY )
+		];
+
+		$this->idCacheManager->expects( $this->never() )
+			->method( 'setCache' );
+
+		$connection = $this->getMockBuilder( '\SMW\MediaWiki\Database' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$this->store = $this->getMockBuilder( '\SMW\SQLStore\SQLStore' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$this->store->expects( $this->any() )
+			->method( 'getConnection' )
+			->will( $this->returnValue( $connection ) );
+
+		$instance = new CacheWarmer(
+			$this->store,
+			$this->idCacheManager
+		);
+
+		$instance->setThresholdLimit( 1 );
+		$instance->fillFromList( $list );
+	}
+
 }


### PR DESCRIPTION
This PR is made in reference to: #

This PR addresses or contains:

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed

### Stack trace

```
   ... update ...                                        66% (1035/1561)[17d60292300b86f7319a828b] [no req]   SMW\Exception\PropertyLabelNotResolvedException from line 89 of ...\extensions\SemanticMediaWiki\includes\dataitems\SMW_DI_Property.php: Illegal property key "".
Backtrace:
#0 ...\extensions\SemanticMediaWiki\includes\dataitems\SMW_DI_Property.php(497): SMW\DIProperty->__construct(string, boolean)
#1 ...\extensions\SemanticMediaWiki\src\SQLStore\EntityStore\CacheWarmer.php(98): SMW\DIProperty::newFromUserLabel(string)
#2 ...\extensions\SemanticMediaWiki\includes\storage\SQLStore\SMW_Sql3SmwIds.php(983): SMW\SQLStore\EntityStore\CacheWarmer->fillFromList(array)
#3 ...\extensions\SemanticMediaWiki\src\MediaWiki\Hooks.php(1232): SMWSql3SmwIds->warmUpCache(SMW\Query\QueryResult)
#4 ...\includes\Hooks.php(177): SMW\MediaWiki\Hooks->onAfterQueryResultLookupComplete(SMW\Elastic\ElasticStore, SMW\Query\QueryResult)
#5 ...\includes\Hooks.php(205): Hooks::callHook(string, array, array, NULL)
#6 ...\extensions\SemanticMediaWiki\src\Elastic\ElasticStore.php(219): Hooks::run(string, array)
#7 ...\extensions\SemanticMediaWiki\includes\query\SMW_QueryProcessor.php(388): SMW\Elastic\ElasticStore->getQueryResult(SMWQuery)
#8 ...\extensions\SemanticMediaWiki\src\ParserFunctions\AskParserFunction.php(363): SMWQueryProcessor::getResultFromQuery(SMWQuery, array, integer, integer)
#9 ...\extensions\SemanticMediaWiki\src\ParserFunctions\AskParserFunction.php(195): SMW\ParserFunctions\AskParserFunction->doFetchResultsFromFunctionParameters(array, array)
#10 ...\extensions\SemanticMediaWiki\src\ParserFunctionFactory.php(402): SMW\ParserFunctions\AskParserFunction->parse(array)
#11 ...\includes\parser\Parser.php(3383): SMW\ParserFunctionFactory->SMW\{closure}(Parser, string, string, string, string, string, string, string, string, string, string, string, string, string)
#12 ...\includes\parser\Parser.php(3106): Parser->callParserFunction(PPFrame_DOM, string, array)
#13 ...\includes\parser\Preprocessor_DOM.php(1229): Parser->braceSubstitution(array, PPFrame_DOM)
#14 ...\includes\parser\Parser.php(2921): PPFrame_DOM->expand(DOMElement, integer)
#15 ...\includes\parser\Parser.php(1277): Parser->replaceVariables(string)
#16 ...\includes\parser\Parser.php(451): Parser->internalParse(string)
#17 ...\includes\content\WikitextContent.php(329): Parser->parse(string, Title, ParserOptions, boolean, boolean, integer)
#18 ...\includes\content\AbstractContent.php(516): WikitextContent->fillParserOutput(Title, integer, ParserOptions, boolean, ParserOutput)
#19 ...\extensions\SemanticMediaWiki\includes\ContentParser.php(186): AbstractContent->getParserOutput(Title, integer, ParserOptions, boolean)
#20 ...\extensions\SemanticMediaWiki\includes\ContentParser.php(145): SMW\ContentParser->fetchFromContent()
#21 ...\extensions\SemanticMediaWiki\src\MediaWiki\Jobs\UpdateJob.php(197): SMW\ContentParser->parse()
#22 ...\extensions\SemanticMediaWiki\src\MediaWiki\Jobs\UpdateJob.php(137): SMW\MediaWiki\Jobs\UpdateJob->parse_content()
#23 ...\extensions\SemanticMediaWiki\src\MediaWiki\Jobs\UpdateJob.php(94): SMW\MediaWiki\Jobs\UpdateJob->doUpdate()
#24 ...\extensions\SemanticMediaWiki\maintenance\updateQueryDependencies.php(175): SMW\MediaWiki\Jobs\UpdateJob->run()
#25 ...\extensions\SemanticMediaWiki\maintenance\updateQueryDependencies.php(102): SMW\Maintenance\UpdateQueryDependencies->runUpdate()
#26 ...\maintenance\doMaintenance.php(92): SMW\Maintenance\UpdateQueryDependencies->execute()
#27 ...\extensions\SemanticMediaWiki\maintenance\updateQueryDependencies.php(186): require_once(string)
#28 {main}
```