### PR TITLE
`SemanticDataLookup` to support sorting via `smw_sort`, refs 2429, 4161

### DIFF
--- a/src/SQLStore/RequestOptionsProc.php
+++ b/src/SQLStore/RequestOptionsProc.php
@@ -48,6 +48,10 @@ class RequestOptionsProc {
 			$sqlConds['ORDER BY'] = $requestOptions->ascending ? $valueCol : $valueCol . ' DESC';
 		}
 
+		if ( $requestOptions->getOption( 'ORDER BY', false ) !== false ) {
+			$sqlConds['ORDER BY'] = $requestOptions->getOption( 'ORDER BY' );
+		}
+
 		if ( $requestOptions->getOption( 'GROUP BY' ) ) {
 			$sqlConds['GROUP BY'] = $requestOptions->getOption( 'GROUP BY' );
 		}

--- a/tests/phpunit/Unit/SQLStore/EntityStore/DataItemHandlers/DIWikiPageHandlerTest.php
+++ b/tests/phpunit/Unit/SQLStore/EntityStore/DataItemHandlers/DIWikiPageHandlerTest.php
@@ -118,6 +118,23 @@ class DIWikiPageHandlerTest extends \PHPUnit_Framework_TestCase {
 		);
 	}
 
+	public function testDataItemFromDBKeys_Sort() {
+
+		$store = $this->getMockBuilder( '\SMW\SQLStore\SQLStore' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$instance = new DIWikiPageHandler( $store );
+
+		$dbKeys = [ 'Foo', NS_MAIN, 'iw', 'sort', 'subobject' ];
+		$dataItem = $instance->dataItemFromDBKeys( $dbKeys );
+
+		$this->assertSame(
+			'sort',
+			$dataItem->getSortKey()
+		);
+	}
+
 	/**
 	 * @dataProvider dbKeysExceptionProvider
 	 */
@@ -150,6 +167,10 @@ class DIWikiPageHandlerTest extends \PHPUnit_Framework_TestCase {
 			[ '_Foo', SMW_NS_PROPERTY, '', '', '' ]
 		];
 
+		$provider[] = [
+			[ 'Foo', NS_MAIN, 'iw', 'sort', 'subobject' ]
+		];
+
 		return $provider;
 	}
 
@@ -157,6 +178,10 @@ class DIWikiPageHandlerTest extends \PHPUnit_Framework_TestCase {
 
 		$provider[] = [
 			[ 'Foo' ]
+		];
+
+		$provider[] = [
+			[ 'Foo', '', '', '', '', '', '' ]
 		];
 
 		return $provider;


### PR DESCRIPTION
This PR is made in reference to: #2429, #4161

This PR addresses or contains:

- Ensures that sorting happens on `smw_sort` for `TYPE_WIKIPAGE` to conform with the #2429 introduced collation setting

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed
