### PR TITLE
Check extension registration is complete, refs 1732

### DIFF
--- a/DefaultSettings.php
+++ b/DefaultSettings.php
@@ -104,6 +104,18 @@ return [
 	##
 
 	###
+	# Allows to ignore the check for whether the extension was correctly enabled
+	# or not. It will display a error message on `Special:Version` in case it was
+	# not.
+	#
+	# To ignore the check and suppress the error, set the value to `true`.
+	#
+	# @since 3.1
+	##
+	'smwgIgnoreExtensionRegistrationCheck' => false,
+	##
+
+	###
 	# CompatibilityMode is to force SMW to work with other extensions that may impact
 	# performance in an unanticipated way or may contain potential incompatibilities.
 	#

--- a/SemanticMediaWiki.php
+++ b/SemanticMediaWiki.php
@@ -53,6 +53,10 @@ class SemanticMediaWiki {
 				$GLOBALS[$key] = $value;
 			}
 		}
+
+		// Registration point before any `extension.json` invocation
+		// takes place
+		Setup::checkExtensionRegistration( $GLOBALS );
 	}
 
 	/**

--- a/includes/Settings.php
+++ b/includes/Settings.php
@@ -62,6 +62,7 @@ class Settings extends Options {
 			'smwgImportFileDirs' => $GLOBALS['smwgImportFileDirs'],
 			'smwgImportReqVersion' => $GLOBALS['smwgImportReqVersion'],
 			'smwgSemanticsEnabled' => $GLOBALS['smwgSemanticsEnabled'],
+			'smwgIgnoreExtensionRegistrationCheck' => $GLOBALS['smwgIgnoreExtensionRegistrationCheck'],
 			'smwgUpgradeKey' => $GLOBALS['smwgUpgradeKey'],
 			'smwgJobQueueWatchlist' => $GLOBALS['smwgJobQueueWatchlist'],
 			'smwgEnabledCompatibilityMode' => $GLOBALS['smwgEnabledCompatibilityMode'],

--- a/src/MediaWiki/Hooks.php
+++ b/src/MediaWiki/Hooks.php
@@ -135,11 +135,44 @@ class Hooks {
 	}
 
 	/**
+	 * Allow to show a message on `Special:Version` when it is clear that the
+	 * extension was loaded but not enabled.
+	 *
+	 * @since 3.1
+	 *
+	 * @param array &$vars
+	 */
+	public static function registerExtensionCheck( array &$vars ) {
+
+		$vars['wgHooks']['BeforePageDisplay']['smw-extension-check'] = function( $outputPage ) {
+
+			$beforePageDisplay = new BeforePageDisplay();
+
+			$beforePageDisplay->setOptions(
+				[
+					'SMW_EXTENSION_LOADED' => defined( 'SMW_EXTENSION_LOADED' )
+				]
+			);
+
+			$beforePageDisplay->informAboutExtensionAvailability( $outputPage );
+
+			return true;
+		};
+	}
+
+	/**
 	 * @since 3.0
 	 *
 	 * @param array &$vars
 	 */
 	public static function registerEarly( array &$vars ) {
+
+		// Remove the hook registered via `Hook::registerExtensionCheck` given
+		// that at this point we know the extension was loaded and hereby is
+		// available.
+		if ( defined( 'SMW_EXTENSION_LOADED' ) ) {
+			unset( $vars['wgHooks']['BeforePageDisplay']['smw-extension-check'] );
+		}
 
 		$vars['wgContentHandlers'][CONTENT_MODEL_SMW_SCHEMA] = 'SMW\MediaWiki\Content\SchemaContentHandler';
 

--- a/src/MediaWiki/Hooks/BeforePageDisplay.php
+++ b/src/MediaWiki/Hooks/BeforePageDisplay.php
@@ -23,6 +23,31 @@ use Html;
 class BeforePageDisplay extends HookHandler {
 
 	/**
+	 * @since 3.1
+	 *
+	 * @param OutputPage $outputPage
+	 */
+	public function informAboutExtensionAvailability( OutputPage $outputPage ) {
+
+		if ( $this->getOption( 'SMW_EXTENSION_LOADED' ) ) {
+			return;
+		}
+
+		$title = $outputPage->getTitle();
+
+		if ( $title === null || !$title->isSpecial( 'Version' ) ) {
+			return;
+		}
+
+		$outputPage->prependHTML(
+			'<div class="errorbox" style="display:block;">Semantic MediaWiki '.
+			'was installed but not enabled on this wiki. Please consult the ' .
+			'<a href="https://www.semantic-mediawiki.org/wiki/Extension_not_enabled">help page</a> for '.
+			'instructions and further assistances.</div>'
+		);
+	}
+
+	/**
 	 * @since 1.9
 	 *
 	 * @param OutputPage $outputPage,

--- a/src/Setup.php
+++ b/src/Setup.php
@@ -16,6 +16,23 @@ use SMW\MediaWiki\Hooks;
 final class Setup {
 
 	/**
+	 * Registers a hook even before the "early" registration to allow checking
+	 * whether the extension is loaded and enabled.
+	 *
+	 * @since 3.1
+	 *
+	 * @param array $vars
+	 */
+	public static function checkExtensionRegistration( &$vars ) {
+
+		if ( $vars['smwgIgnoreExtensionRegistrationCheck'] ) {
+			return;
+		}
+
+		Hooks::registerExtensionCheck( $vars );
+	}
+
+	/**
 	 * Runs at the earliest possible event to initialize functions or hooks that
 	 * are otherwise too late for the hook system to be recognized.
 	 *

--- a/tests/phpunit/Unit/MediaWiki/Hooks/BeforePageDisplayTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Hooks/BeforePageDisplayTest.php
@@ -18,10 +18,11 @@ class BeforePageDisplayTest extends \PHPUnit_Framework_TestCase {
 	private $outputPage;
 	private $request;
 	private $skin;
+	private $title;
 
 	protected function setUp() {
 
-		$title = $this->getMockBuilder( '\Title' )
+		$this->title = $this->getMockBuilder( '\Title' )
 			->disableOriginalConstructor()
 			->getMock();
 
@@ -43,7 +44,7 @@ class BeforePageDisplayTest extends \PHPUnit_Framework_TestCase {
 
 		$this->outputPage->expects( $this->any() )
 			->method( 'getTitle' )
-			->will( $this->returnValue( $title ) );
+			->will( $this->returnValue( $this->title ) );
 
 		$this->skin = $this->getMockBuilder( '\Skin' )
 			->disableOriginalConstructor()
@@ -60,6 +61,27 @@ class BeforePageDisplayTest extends \PHPUnit_Framework_TestCase {
 			BeforePageDisplay::class,
 			new BeforePageDisplay()
 		);
+	}
+
+	public function testInformAboutExtensionAvailability() {
+
+		$this->title->expects( $this->once() )
+			->method( 'isSpecial' )
+			->with( $this->equalTo( 'Version' ) )
+			->will( $this->returnValue( true ) );
+
+		$this->outputPage->expects( $this->once() )
+			->method( 'prependHTML' );
+
+		$instance = new BeforePageDisplay();
+
+		$instance->setOptions(
+			[
+				'SMW_EXTENSION_LOADED' => false
+			]
+		);
+
+		$instance->informAboutExtensionAvailability( $this->outputPage );
 	}
 
 	public function testModules() {

--- a/tests/phpunit/Unit/MediaWiki/HooksTest.php
+++ b/tests/phpunit/Unit/MediaWiki/HooksTest.php
@@ -126,6 +126,25 @@ class HooksTest extends \PHPUnit_Framework_TestCase {
 		);
 	}
 
+	public function testRegisterExtensionCheck() {
+
+		$vars = [];
+
+		Hooks::registerExtensionCheck( $vars );
+
+		// BeforePageDisplay
+		$callback = end( $vars['wgHooks']['BeforePageDisplay'] );
+
+		$outputPage = $this->getMockBuilder( '\OutputPage' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$this->assertThatHookIsExcutable(
+			$callback,
+			[ $outputPage ]
+		);
+	}
+
 	public function testInitExtension() {
 
 		$vars = [

--- a/tests/phpunit/Unit/SetupTest.php
+++ b/tests/phpunit/Unit/SetupTest.php
@@ -74,6 +74,31 @@ class SetupTest extends \PHPUnit_Framework_TestCase {
 		);
 	}
 
+	public function testCheckExtensionRegistration() {
+
+		$vars = [
+			'smwgIgnoreExtensionRegistrationCheck' => true
+		];
+
+		Setup::checkExtensionRegistration( $vars );
+
+		$this->assertCount(
+			1,
+			$vars
+		);
+
+		$vars = [
+			'smwgIgnoreExtensionRegistrationCheck' => false
+		];
+
+		Setup::checkExtensionRegistration( $vars );
+
+		$this->assertCount(
+			2,
+			$vars
+		);
+	}
+
 	public function testResourceModules() {
 
 		$config = $this->defaultConfig;


### PR DESCRIPTION
This PR is made in reference to: #1732

This PR addresses or contains:

- #1732 introduced `extension.json` has method to register SMW with MW
- Users maybe unfamiliar with it or misinterpreting the installation instruction and forgetting to add `enableSemantics` to `LocalSettings.php` therefore this PR will inform users on `Special:Version` about the discrepancy of having SMW installed but not enabled
- `smwgIgnoreExtensionRegistrationCheck` (default `false`) is provided so wiki-farm admins can disable the check (e.g. only selected wikis are allowed to have SMW enabled etc.)

This PR includes:
- [ ] Tests (unit/integration)
- [x] CI build passed

## Example

![extension-not-loaded](https://user-images.githubusercontent.com/1245473/62000386-543f6f00-b0c5-11e9-9a47-972ee677d819.png)
