### PR TITLE
Providing missing semicolon

### DIFF
--- a/res/smw/ext.smw.css
+++ b/res/smw/ext.smw.css
@@ -140,7 +140,7 @@ span.smwttactiveinline span.smwbuiltin {
 .smw-debug-box {
 	border: 5px dotted #ffcc00;
 	background: #FFF0BD;
-	padding: 15px
+	padding: 15px;
 	margin-bottom: 10px;
 }
 


### PR DESCRIPTION
According to css-validator: https://jigsaw.w3.org/css-validator/