### PR TITLE
Isolate `smw_proptable_hash` handling, refs 3801

### DIFF
--- a/src/SQLStore/EntityStore/IdCacheManager.php
+++ b/src/SQLStore/EntityStore/IdCacheManager.php
@@ -39,8 +39,8 @@ class IdCacheManager {
 			throw new RuntimeException( "Missing 'entity.lookup' instance.");
 		}
 
-		if ( !isset( $this->caches['table.hash'] ) ) {
-			throw new RuntimeException( "Missing 'table.hash' instance.");
+		if ( !isset( $this->caches['propertytable.hash'] ) ) {
+			throw new RuntimeException( "Missing 'propertytable.hash' instance.");
 		}
 	}
 

--- a/src/SQLStore/PropertyTable/PropertyTableHashes.php
+++ b/src/SQLStore/PropertyTable/PropertyTableHashes.php
@@ -1,0 +1,149 @@
+<?php
+
+namespace SMW\SQLStore\PropertyTable;
+
+use RuntimeException;
+use SMW\DIProperty;
+use SMW\MediaWiki\Database;
+use SMW\SQLStore\SQLStore;
+use SMW\SQLStore\EntityStore\IdCacheManager;
+
+/**
+ * @private
+ *
+ * @license GNU GPL v2+
+ * @since 3.1
+ *
+ * @author mwjames
+ */
+class PropertyTableHashes {
+
+	/**
+	 * @var Database
+	 */
+	private $connection;
+
+	/**
+	 * @var IdCacheManager
+	 */
+	private $idCacheManager;
+
+	/**
+	* @since 3.1
+	*
+	* @param Database $connection
+	* @param IdCacheManager $idCacheManager
+	*/
+	public function __construct( Database $connection, IdCacheManager $idCacheManager ) {
+		$this->connection = $connection;
+		$this->idCacheManager = $idCacheManager;
+	}
+
+	/**
+	 * Update the proptable_hash for a given page.
+	 *
+	 * @since 3.1
+	 *
+	 * @param integer $id ID of the page as stored in SMW IDs table
+	 * @param string[] of hash values with table names as keys
+	*/
+	public function setPropertyTableHashes( $id, $hash = null ) {
+
+		$update = [];
+
+		if ( $hash === null ) {
+			$update = [ 'smw_proptable_hash' => $hash, 'smw_rev' => null ];
+		} elseif ( is_array( $hash ) ) {
+			$update = [ 'smw_proptable_hash' => serialize( $hash ) ];
+		} else {
+			throw new RuntimeException( "Expected a null or an array as value!");
+		}
+
+		$this->connection->update(
+			SQLStore::ID_TABLE,
+			$update,
+			[
+				'smw_id' => $id
+			],
+			__METHOD__
+		);
+
+		$this->setPropertyTableHashesCache( $id, $hash );
+
+		if ( $hash === null ) {
+			$this->idCacheManager->deleteCacheById( $id );
+		}
+	}
+
+	/**
+	 * Return an array of hashes with table names as keys. These
+	 * hashes are used to compare new data with old data for each
+	 * property-value table when updating data
+	 *
+	 * @since 1.8
+	 *
+	 * @param integer $id ID of the page as stored in the SMW IDs table
+	 *
+	 * @return array
+	 */
+	public function getPropertyTableHashesById( $id ) {
+
+		if ( $id == 0 ) {
+			return [];
+		}
+
+		$hash = null;
+		$cache = $this->idCacheManager->get( 'propertytable.hash' );
+
+		if ( ( $hash = $cache->fetch( $id ) ) !== false ) {
+			return $hash;
+		}
+
+		$row = $this->connection->selectRow(
+			SQLStore::ID_TABLE,
+			[
+				'smw_proptable_hash'
+			],
+			[
+				'smw_id' => $id
+			],
+			__METHOD__
+		);
+
+		if ( $row !== false ) {
+			$hash = $row->smw_proptable_hash;
+		}
+
+		if ( $hash !== null && $hash !== false ) {
+			$hash = $this->connection->unescape_bytea( $hash );
+		}
+
+		$hash = $hash === null || $hash === false ? [] : unserialize( $hash );
+		$cache->save( $id, $hash );
+
+		return $hash;
+	}
+
+	/**
+	 * @since 3.1
+	 *
+	 * @param $id integer
+	 * @param string|null $hash
+	 */
+	public function setPropertyTableHashesCache( $id, $hash = null ) {
+
+		// never cache 0
+		if ( $id == 0 ) {
+			return;
+		}
+
+		if ( $hash === null ) {
+			$hash = [];
+		} elseif ( is_string( $hash ) ) {
+			$hash = unserialize( $hash );
+		}
+
+		$this->idCacheManager->get( 'propertytable.hash' )->save( $id, $hash );
+	}
+
+}

--- a/src/SQLStore/SQLStoreFactory.php
+++ b/src/SQLStore/SQLStoreFactory.php
@@ -28,6 +28,7 @@ use SMW\SQLStore\EntityStore\TraversalPropertyLookup;
 use SMW\SQLStore\EntityStore\PropertySubjectsLookup;
 use SMW\SQLStore\EntityStore\PropertiesLookup;
 use SMW\SQLStore\EntityStore\PrefetchCache;
+use SMW\SQLStore\PropertyTable\PropertyTableHashes;
 use SMW\SQLStore\Lookup\CachedListLookup;
 use SMW\SQLStore\Lookup\ListLookup;
 use SMW\SQLStore\Lookup\PropertyUsageListLookup;
@@ -385,6 +386,23 @@ class SQLStoreFactory {
 		);
 
 		return $propertyTableIdReferenceFinder;
+	}
+
+	/**
+	 * @since 3.1
+	 *
+	 * @param IdCacheManager $idCacheManager
+	 *
+	 * @return PropertyTableHashes
+	 */
+	public function newPropertyTableHashes( IdCacheManager $idCacheManager ) {
+
+		$propertyTableHashes = new PropertyTableHashes(
+			$this->store->getConnection( 'mw.db' ),
+			$idCacheManager
+		);
+
+		return $propertyTableHashes;
 	}
 
 	/**

--- a/tests/phpunit/Unit/SQLStore/EntityStore/IdCacheManagerTest.php
+++ b/tests/phpunit/Unit/SQLStore/EntityStore/IdCacheManagerTest.php
@@ -27,7 +27,7 @@ class IdCacheManagerTest extends \PHPUnit_Framework_TestCase {
 			'entity.id' => new FixedInMemoryLruCache(),
 			'entity.sort' => new FixedInMemoryLruCache(),
 			'entity.lookup' => new FixedInMemoryLruCache(),
-			'table.hash' => new FixedInMemoryLruCache()
+			'propertytable.hash' => new FixedInMemoryLruCache()
 		];
  	}
 

--- a/tests/phpunit/Unit/SQLStore/PropertyTable/PropertyTableHashesTest.php
+++ b/tests/phpunit/Unit/SQLStore/PropertyTable/PropertyTableHashesTest.php
@@ -1,0 +1,163 @@
+<?php
+
+namespace SMW\Tests\SQLStore\PropertyTable;
+
+use SMW\SQLStore\PropertyTable\PropertyTableHashes;
+use SMW\StoreFactory;
+use SMWDataItem;
+use SMW\Tests\PHPUnitCompat;
+
+/**
+ * @covers \SMW\SQLStore\PropertyTable\PropertyTableHashes
+ * @group semantic-mediawiki
+ *
+ * @license GNU GPL v2+
+ * @since 3.1
+ *
+ * @author mwjames
+ */
+class PropertyTableHashesTest extends \PHPUnit_Framework_TestCase {
+
+	private $connection;
+	private $idCacheManager;
+	private $cache;
+
+	protected function setUp() {
+
+		$this->connection = $this->getMockBuilder( '\SMW\MediaWiki\Database' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$this->idCacheManager = $this->getMockBuilder( '\SMW\SQLStore\EntityStore\IdCacheManager' )
+			->disableOriginalConstructor()
+			->getMock();
+
+
+		$this->cache = $this->getMockBuilder( '\Onoi\Cache\Cache' )
+			->disableOriginalConstructor()
+			->getMock();
+	}
+
+	public function testCanConstruct() {
+
+		$this->assertInstanceOf(
+			PropertyTableHashes::class,
+			new PropertyTableHashes( $this->connection, $this->idCacheManager )
+		);
+	}
+
+	public function testSetPropertyTableHashes() {
+
+		$this->cache->expects( $this->once() )
+			->method( 'save' );
+
+		$this->idCacheManager->expects( $this->once() )
+			->method( 'get' )
+			->will( $this->returnValue( $this->cache ) );
+
+		$rows = [
+			'smw_proptable_hash' => 'a:1:{i:0;s:3:"foo";}'
+		];
+
+		$expected = [
+			'smw_id' => 42
+		];
+
+		$this->connection->expects( $this->once() )
+			->method( 'update' )
+			->with(
+				$this->anything(),
+				$this->equalTo( $rows ),
+				$this->equalTo( $expected ) );
+
+		$instance = new PropertyTableHashes(
+			$this->connection,
+			$this->idCacheManager
+		);
+
+		$instance->setPropertyTableHashes( 42, [ 'foo' ] );
+	}
+
+	public function testGetPropertyTableHashes() {
+
+		$this->cache->expects( $this->once() )
+			->method( 'save' );
+
+		$this->cache->expects( $this->once() )
+			->method( 'fetch' )
+			->will( $this->returnValue( false ) );
+
+		$this->idCacheManager->expects( $this->once() )
+			->method( 'get' )
+			->will( $this->returnValue( $this->cache ) );
+
+		$fields = [
+			'smw_proptable_hash'
+		];
+
+		$expected = [
+			'smw_id' => 42
+		];
+
+		$row = [
+			'smw_proptable_hash' => 'a:1:{i:0;s:3:"foo";}'
+		];
+
+		$this->connection->expects( $this->once() )
+			->method( 'unescape_bytea' )
+			->will($this->returnArgument( 0 ) );
+
+		$this->connection->expects( $this->once() )
+			->method( 'selectRow' )
+			->with(
+				$this->anything(),
+				$this->equalTo( $fields ),
+				$this->equalTo( $expected ) )
+			->will( $this->returnValue( (object)$row ) );
+
+		$instance = new PropertyTableHashes(
+			$this->connection,
+			$this->idCacheManager
+		);
+
+		$this->assertEquals(
+			[ 'foo' ],
+			$instance->getPropertyTableHashesById( 42 )
+		);
+	}
+
+	public function testSetPropertyTableHashesCache() {
+
+		$this->cache->expects( $this->once() )
+			->method( 'save' )
+			->with(
+				$this->equalTo( 42 ),
+				$this->equalTo( [ 'foo' ] ) );
+
+		$this->idCacheManager->expects( $this->once() )
+			->method( 'get' )
+			->will( $this->returnValue( $this->cache ) );
+
+		$instance = new PropertyTableHashes(
+			$this->connection,
+			$this->idCacheManager
+		);
+
+		$instance->setPropertyTableHashesCache( 42, 'a:1:{i:0;s:3:"foo";}' );
+	}
+
+	public function testSetPropertyTableHashesCache_Zero() {
+
+		$this->idCacheManager->expects( $this->never() )
+			->method( 'get' )
+			->will( $this->returnValue( $this->cache ) );
+
+		$instance = new PropertyTableHashes(
+			$this->connection,
+			$this->idCacheManager
+		);
+
+		$instance->setPropertyTableHashesCache( 0 );
+	}
+
+}

--- a/tests/phpunit/Unit/SQLStore/SQLStoreFactoryTest.php
+++ b/tests/phpunit/Unit/SQLStore/SQLStoreFactoryTest.php
@@ -265,7 +265,7 @@ class SQLStoreFactoryTest extends \PHPUnit_Framework_TestCase {
 			'entity.id' => '',
 			'entity.sort' => '',
 			'entity.lookup' => '',
-			'table.hash' => ''
+			'propertytable.hash' => ''
 		];
 
 		$this->assertInstanceOf(
@@ -461,6 +461,28 @@ class SQLStoreFactoryTest extends \PHPUnit_Framework_TestCase {
 		$this->assertInstanceOf(
 			'\SMW\SQLStore\PropertyTableIdReferenceDisposer',
 			$instance->newPropertyTableIdReferenceDisposer()
+		);
+	}
+
+	public function testCanConstructPropertyTableHashes() {
+
+		$connection = $this->getMockBuilder( '\SMW\MediaWiki\Database' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$this->store->expects( $this->once() )
+			->method( 'getConnection' )
+			->will( $this->returnValue( $connection ) );
+
+		$idCacheManager = $this->getMockBuilder( '\SMW\SQLStore\EntityStore\IdCacheManager' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$instance = new SQLStoreFactory( $this->store );
+
+		$this->assertInstanceOf(
+			'\SMW\SQLStore\PropertyTable\PropertyTableHashes',
+			$instance->newPropertyTableHashes( $idCacheManager )
 		);
 	}
 

--- a/tests/phpunit/includes/storage/sqlstore/SQLStoreSmwIdsTest.php
+++ b/tests/phpunit/includes/storage/sqlstore/SQLStoreSmwIdsTest.php
@@ -34,7 +34,7 @@ class SQLStoreSmwIdsTest extends \PHPUnit_Framework_TestCase {
 				'entity.id' => new FixedInMemoryLruCache(),
 				'entity.sort' => new FixedInMemoryLruCache(),
 				'entity.lookup' => new FixedInMemoryLruCache(),
-				'table.hash' => new FixedInMemoryLruCache()
+				'propertytable.hash' => new FixedInMemoryLruCache()
 			]
 		);
 
@@ -59,6 +59,10 @@ class SQLStoreSmwIdsTest extends \PHPUnit_Framework_TestCase {
 			->getMock();
 
 		$this->tableFieldUpdater = $this->getMockBuilder( '\SMW\SQLStore\TableFieldUpdater' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$this->propertyTableHashes = $this->getMockBuilder( '\SMW\SQLStore\PropertyTable\PropertyTableHashes' )
 			->disableOriginalConstructor()
 			->getMock();
 
@@ -107,6 +111,10 @@ class SQLStoreSmwIdsTest extends \PHPUnit_Framework_TestCase {
 		$this->factory->expects( $this->any() )
 			->method( 'newCacheWarmer' )
 			->will( $this->returnValue( $this->cacheWarmer ) );
+
+		$this->factory->expects( $this->any() )
+			->method( 'newPropertyTableHashes' )
+			->will( $this->returnValue( $this->propertyTableHashes ) );
 	}
 
 	public function testCanConstruct() {


### PR DESCRIPTION
This PR is made in reference to: #3801

This PR addresses or contains:

- Isolates access to and from `smw_proptable_hash` field to `PropertyTableHashes`

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed
