### PR TITLE
Avoid "Uncaught Exception: It was attempted to load SemanticMediaWiki twice", refs 1732

### DIFF
--- a/src/GlobalFunctions.php
+++ b/src/GlobalFunctions.php
@@ -244,8 +244,13 @@ function swfCountDown( $seconds ) {
 function enableSemantics( $namespace = null, $complete = false ) {
 	global $smwgNamespace;
 
-	// #1732 + #2813
-	wfLoadExtension( 'SemanticMediaWiki', dirname( __DIR__ ) . '/extension.json' );
+	// Avoid "Uncaught Exception: It was attempted to load SemanticMediaWiki
+	// twice" in case users added `wfLoadExtension` manually to the
+	// `LocalSettings.php`
+	if ( !ExtensionRegistry::getInstance()->isLoaded( 'SemanticMediaWiki' ) ) {
+		// #1732 + #2813
+		wfLoadExtension( 'SemanticMediaWiki', dirname( __DIR__ ) . '/extension.json' );
+	}
 
 	// #4107
 	define( 'SMW_EXTENSION_LOADED', true );


### PR DESCRIPTION
This PR is made in reference to: #1732

This PR addresses or contains:

- Despite the fact that the documentation explicitly states not to invoke `wfLoadExtension( 'SemanitcMediaWiki' )` in `LocalSettings.php` users will be tempted to add this line anyway. So, in order to avoid "Uncaught Exception: It was attempted to load SemanticMediaWiki twice" shown to a user, check via `ExtensionRegistry` whether it was registered or not and in case it was ignore the call in `enableSemantics`. 
- `enableSemantics` remains required in `LocalSettings.php`

This PR includes:
- [ ] Tests (unit/integration)
- [x] CI build passed
