### PR TITLE
Introduce `EntityIdFinder`, refs 3801

### DIFF
--- a/src/SQLStore/EntityStore/EntityIdFinder.php
+++ b/src/SQLStore/EntityStore/EntityIdFinder.php
@@ -1,0 +1,309 @@
+<?php
+
+namespace SMW\SQLStore\EntityStore;
+
+use SMW\DIWikiPage;
+use SMW\IteratorFactory;
+use SMW\RequestOptions;
+use SMW\SQLStore\SQLStore;
+use SMW\DIProperty;
+use SMW\TypesRegistry;
+use SMW\PropertyRegistry;
+use SMW\SQLStore\RedirectStore;
+use SMW\MediaWiki\Database;
+use SMW\MediaWiki\Deferred\HashFieldUpdate;
+use SMW\SQLStore\propertyTable\propertyTableHashes;
+
+/**
+ * @private
+ *
+ * @license GNU GPL v2+
+ * @since 3.1
+ *
+ * @author mwjames
+ */
+class EntityIdFinder {
+
+	/**
+	 * @var Database
+	 */
+	private $connection;
+
+	/**
+	 * @var PropertyTableHashes
+	 */
+	private $propertyTableHashes;
+
+	/**
+	 * @var IdCacheManager
+	 */
+	private $idCacheManager;
+
+	/**
+	 * @var boolean
+	 */
+	private $fetchPropertyTableHashes = false;
+
+	/**
+	 * @since 3.1
+	 *
+	 * @param Database $connection
+	 * @param RedirectStore $redirectStore
+	 * @param IdCacheManager $idCacheManager
+	 */
+	public function __construct( Database $connection, PropertyTableHashes $propertyTableHashes, IdCacheManager $idCacheManager ) {
+		$this->connection = $connection;
+		$this->propertyTableHashes = $propertyTableHashes;
+		$this->idCacheManager = $idCacheManager;
+	}
+
+	/**
+	 * @since 3.1
+	 *
+	 * @param boolean $fetchPropertyTableHashes
+	 */
+	public function setFetchPropertyTableHashes( $fetchPropertyTableHashes ) {
+		$this->fetchPropertyTableHashes = $fetchPropertyTableHashes;
+	}
+
+	/**
+	 * @since 3.1
+	 *
+	 * @param DIWikiPage $dataItem
+	 *
+	 * @return integer
+	 */
+	public function findIdByItem( DIWikiPage $dataItem ) {
+
+		if ( ( $id = $this->idCacheManager->getId( $dataItem ) ) !== false ) {
+			return $id;
+		}
+
+		$id = 0;
+
+		$row = $this->connection->selectRow(
+			SQLStore::ID_TABLE,
+			[
+				'smw_id'
+			],
+			[
+				'smw_title' => $dataItem->getDBKey(),
+				'smw_namespace' => $dataItem->getNamespace(),
+				'smw_iw' => $dataItem->getInterWiki(),
+				'smw_subobject' => $dataItem->getSubobjectName()
+			],
+			__METHOD__
+		);
+
+		if ( $row !== false ) {
+			$id = $row->smw_id;
+
+			$this->idCacheManager->setCache(
+				$dataItem->getDBKey(),
+				$dataItem->getNamespace(),
+				$dataItem->getInterWiki(),
+				$dataItem->getSubobjectName(),
+				$id,
+				$dataItem->getSortKey()
+			);
+		}
+
+		return $id;
+	}
+
+	/**
+	 * @since 3.1
+	 *
+	 * @param integer $id
+	 * @param string $title
+	 * @param string|integer $namespace
+	 * @param string $iw
+	 * @param string $subobjectName
+	 * @param string &$sortkey
+	 *
+	 * @return array
+	 */
+	public function fetchFieldsFromTableById( $id, $title, $namespace, $iw, $subobjectName, &$sortkey ) {
+
+		if ( $id == 0 ) {
+			return [ $id, '' ];
+		}
+
+		$sha1 = IdCacheManager::computeSha1(
+			[
+				$title,
+				(int)$namespace,
+				$iw,
+				$subobjectName
+			]
+		);
+
+		if ( $this->fetchPropertyTableHashes ) {
+			$fields = [ 'smw_sortkey', 'smw_sort', 'smw_proptable_hash', 'smw_hash' ];
+		} else {
+			$fields = [ 'smw_sortkey', 'smw_sort', 'smw_hash' ];
+		}
+
+		$row = $this->connection->selectRow(
+			SQLStore::ID_TABLE,
+			$fields,
+			[
+				'smw_id' => $id
+			],
+			__METHOD__
+		);
+
+		if ( $row !== false ) {
+			// Make sure that smw_sort is being re-computed in case it is null
+			$sortkey = $row->smw_sort === null ? '' : $row->smw_sortkey;
+
+			if ( $this->fetchPropertyTableHashes ) {
+				$this->propertyTableHashes->setPropertyTableHashesCache( $id, $row->smw_proptable_hash );
+			}
+
+			// Prevent any irregularities caused by a delayed, or redirect update
+			if ( $row->smw_hash !== $sha1 && $iw !== SMW_SQL3_SMWREDIIW ) {
+				HashFieldUpdate::addUpdate( $this->connection, $id, $sha1 );
+			}
+		} else { // inconsistent DB; just recover somehow
+			$sortkey = str_replace( '_', ' ', $title );
+		}
+
+		$this->idCacheManager->setCache(
+			$title,
+			$namespace,
+			$iw,
+			$subobjectName,
+			$id,
+			$sortkey
+		);
+
+		return [ (int)$id, $sortkey ];
+	}
+
+	/**
+	 * @since 3.1
+	 *
+	 * @param string $title
+	 * @param string|integer $namespace
+	 * @param string $iw
+	 * @param string $subobjectName
+	 * @param string &$sortkey
+	 *
+	 * @return array
+	 */
+	public function fetchFromTableByTitle( $title, $namespace, $iw, $subobjectName, &$sortkey ) {
+
+		$sha1 = IdCacheManager::computeSha1(
+			[
+				$title,
+				(int)$namespace,
+				$iw,
+				$subobjectName
+			]
+		);
+
+		if ( $this->fetchPropertyTableHashes ) {
+			$fields = [ 'smw_id', 'smw_sortkey', 'smw_sort', 'smw_proptable_hash', 'smw_hash' ];
+		} else {
+			$fields = [ 'smw_id', 'smw_sortkey', 'smw_sort', 'smw_hash' ];
+		}
+
+		// #2001
+		// In cases where title components are excessively long (beyond the
+		// field limit) it has been observed that at least on MySQL/MariaDB no
+		// appropriate matches are found even though a row with a truncated
+		// representation exists in the table.
+		//
+		// `postgres` has no field limit and a divergent behaviour has not
+		// been observed
+		if ( $subobjectName !== '' && !$this->connection->isType( 'postgres' ) ) {
+			$subobjectName = mb_substr( $subobjectName, 0, 255 );
+		}
+
+		$row = $this->connection->selectRow(
+			SQLStore::ID_TABLE,
+			$fields,
+			[
+				'smw_title' => $title,
+				'smw_namespace' => $namespace,
+				'smw_iw' => $iw,
+				'smw_subobject' => $subobjectName
+			],
+			__METHOD__
+		);
+
+		if ( $row !== false ) {
+			$id = $row->smw_id;
+			// Make sure that smw_sort is being re-computed in case it is null
+			$sortkey = $row->smw_sort === null ? '' : $row->smw_sortkey;
+
+			if ( $this->fetchPropertyTableHashes ) {
+				$this->propertyTableHashes->setPropertyTableHashesCache( $id, $row->smw_proptable_hash );
+			}
+
+			// Prevent any irregularities caused by a delayed, or redirect update
+			if ( $row->smw_hash !== $sha1 && $iw !== SMW_SQL3_SMWREDIIW ) {
+				HashFieldUpdate::addUpdate( $this->connection, $id, $sha1 );
+			}
+		} else {
+			$id = 0;
+			$sortkey = '';
+		}
+
+		$this->idCacheManager->setCache(
+			$title,
+			$namespace,
+			$iw,
+			$subobjectName,
+			$id,
+			$sortkey
+		);
+
+		return [ (int)$id, $sortkey ];
+	}
+
+	/**
+	 * @since 3.1
+	 *
+	 * @param string $title
+	 * @param string|integer $namespace
+	 * @param string $iw
+	 * @param string $subobjectName
+	 *
+	 * @return array
+	 */
+	public function findIdsByTitle( $title, $namespace, $iw = null, $subobjectName = '' ) {
+
+		$matches = [];
+
+		$conditions = [
+			'smw_title' => $title,
+			'smw_namespace' => $namespace,
+			'smw_iw' => $iw,
+			'smw_subobject' => $subobjectName
+		];
+
+		// Null means select all (incl. those marked delete, redi etc.)
+		if ( $iw === null ) {
+			unset( $conditions['smw_iw'] );
+		}
+
+		$rows = $this->connection->select(
+			// This should be necessary but somehow `SQLite` fails here
+			$this->connection->tableName( SQLStore::ID_TABLE ),
+			[
+				'smw_id'
+			],
+			$conditions,
+			__METHOD__
+		);
+
+		foreach ( $rows as $row ) {
+			$matches[] = (int)$row->smw_id;
+		}
+
+		return $matches;
+	}
+
+}

--- a/src/SQLStore/EntityStore/IdCacheManager.php
+++ b/src/SQLStore/EntityStore/IdCacheManager.php
@@ -191,7 +191,11 @@ class IdCacheManager {
 			];
 		}
 
-		$hash = $this->computeSha1( $args );
+		if ( is_array( $args ) ) {
+			$hash = $this->computeSha1( $args );
+		} else {
+			$hash = $args;
+		}
 
 		if ( ( $id = $this->caches['entity.id']->fetch( $hash ) ) !== false ) {
 			return (int)$id;
@@ -214,7 +218,11 @@ class IdCacheManager {
 	 */
 	public function getSort( $args ) {
 
-		$hash = $this->computeSha1( $args );
+		if ( is_array( $args ) ) {
+			$hash = $this->computeSha1( $args );
+		} else {
+			$hash = $args;
+		}
 
 		if ( ( $sort = $this->caches['entity.sort']->fetch( $hash ) ) !== false ) {
 			return $sort;

--- a/src/SQLStore/SQLStore.php
+++ b/src/SQLStore/SQLStore.php
@@ -164,6 +164,15 @@ class SQLStore extends Store {
 	}
 
 	/**
+	 * @since 3.1
+	 *
+	 * @param SQLStoreFactory $factory
+	 */
+	public function setFactory( SQLStoreFactory $factory ) {
+		$this->factory = $factory;
+	}
+
+	/**
 	 * Get an object of the dataitem handler from the dataitem provided.
 	 *
 	 * @since 1.8

--- a/src/SQLStore/SQLStoreFactory.php
+++ b/src/SQLStore/SQLStoreFactory.php
@@ -19,6 +19,7 @@ use SMW\SQLStore\EntityStore\PrefetchItemLookup;
 use SMW\SQLStore\EntityStore\IdCacheManager;
 use SMW\SQLStore\EntityStore\CacheWarmer;
 use SMW\SQLStore\EntityStore\IdEntityFinder;
+use SMW\SQLStore\EntityStore\EntityIdFinder;
 use SMW\SQLStore\EntityStore\IdChanger;
 use SMW\SQLStore\EntityStore\DuplicateFinder;
 use SMW\SQLStore\EntityStore\EntityLookup;
@@ -600,6 +601,29 @@ class SQLStoreFactory {
 		);
 
 		return $idMatchFinder;
+	}
+
+	/**
+	 * @since 3.1
+	 *
+	 * @param IdCacheManager $idCacheManager
+	 * @param PropertyTableHashes|null $propertyTableHashes
+	 *
+	 * @return IdEntityFinder
+	 */
+	public function newEntityIdFinder( IdCacheManager $idCacheManager, PropertyTableHashes $propertyTableHashes = null ) {
+
+		if ( $propertyTableHashes === null ) {
+			$propertyTableHashes = $this->newPropertyTableHashes( $idCacheManager );
+		}
+
+		$entityIdFinder = new EntityIdFinder(
+			$this->store->getConnection( 'mw.db' ),
+			$propertyTableHashes,
+			$idCacheManager
+		);
+
+		return $entityIdFinder;
 	}
 
 	/**

--- a/tests/phpunit/Integration/SemanticMediaWikiProvidedHookInterfaceIntegrationTest.php
+++ b/tests/phpunit/Integration/SemanticMediaWikiProvidedHookInterfaceIntegrationTest.php
@@ -290,6 +290,26 @@ class SemanticMediaWikiProvidedHookInterfaceIntegrationTest extends \PHPUnit_Fra
 
 		$title = \Title::newFromText( __METHOD__ );
 
+		$redirectUpdater = $this->getMockBuilder( '\SMW\SQLStore\RedirectUpdater' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$factory = $this->getMockBuilder( '\SMW\SQLStore\SQLStoreFactory' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$semanticDataLookup = $this->getMockBuilder( '\SMW\SQLStore\EntityStore\CachingSemanticDataLookup' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$factory->expects( $this->any() )
+			->method( 'newRedirectUpdater' )
+			->will( $this->returnValue( $redirectUpdater ) );
+
+		$factory->expects( $this->any() )
+			->method( 'newSemanticDataLookup' )
+			->will( $this->returnValue( $semanticDataLookup ) );
+
 		$idGenerator = $this->getMockBuilder( '\SMWSql3SmwIds' )
 			->disableOriginalConstructor()
 			->getMock();
@@ -299,8 +319,11 @@ class SemanticMediaWikiProvidedHookInterfaceIntegrationTest extends \PHPUnit_Fra
 			->will( $this->returnValue( 42 ) );
 
 		$store = $this->getMockBuilder( $storeClass )
+			->disableOriginalConstructor()
 			->setMethods( [ 'getObjectIds', 'getPropertyTables', 'getConnection' ] )
 			->getMock();
+
+		$store->setFactory( $factory );
 
 		$store->expects( $this->any() )
 			->method( 'getObjectIds' )

--- a/tests/phpunit/Unit/SQLStore/EntityStore/EntityIdFinderTest.php
+++ b/tests/phpunit/Unit/SQLStore/EntityStore/EntityIdFinderTest.php
@@ -1,0 +1,190 @@
+<?php
+
+namespace SMW\Tests\SQLStore\EntityStore;
+
+use SMW\DIWikiPage;
+use SMW\IteratorFactory;
+use SMW\SQLStore\EntityStore\EntityIdFinder;
+use SMW\MediaWiki\Connection\Query;
+use SMW\Tests\TestEnvironment;
+
+/**
+ * @covers \SMW\SQLStore\EntityStore\EntityIdFinder
+ * @group semantic-mediawiki
+ *
+ * @license GNU GPL v2+
+ * @since   3.1
+ *
+ * @author mwjames
+ */
+class EntityIdFinderTest extends \PHPUnit_Framework_TestCase {
+
+	private $testEnvironment;
+	private $cache;
+	private $propertyTableHashes;
+	private $idCacheManager;
+	private $conection;
+
+	protected function setUp() {
+		$this->testEnvironment = new TestEnvironment();
+
+		$this->cache = $this->getMockBuilder( '\Onoi\Cache\Cache' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$this->idCacheManager = $this->getMockBuilder( '\SMW\SQLStore\EntityStore\IdCacheManager' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$this->idCacheManager->expects( $this->any() )
+			->method( 'get' )
+			->will( $this->returnValue( $this->cache ) );
+
+		$this->connection = $this->getMockBuilder( '\SMW\MediaWiki\Database' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$this->propertyTableHashes = $this->getMockBuilder( '\SMW\SQLStore\PropertyTable\PropertyTableHashes' )
+			->disableOriginalConstructor()
+			->getMock();
+	}
+
+	public function testCanConstruct() {
+
+		$this->assertInstanceOf(
+			EntityIdFinder::class,
+			new EntityIdFinder( $this->connection, $this->propertyTableHashes, $this->idCacheManager )
+		);
+	}
+
+	public function testFindIdByItem() {
+
+		$row = [
+			'smw_id' => 42
+		];
+
+		$dataItem = $this->getMockBuilder( '\SMW\DIWikiPage' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$this->idCacheManager->expects( $this->once() )
+			->method( 'getId' )
+			->will( $this->returnValue( false ) );
+
+		$this->idCacheManager->expects( $this->once() )
+			->method( 'setCache' );
+
+		$this->connection->expects( $this->once() )
+			->method( 'selectRow' )
+			->will( $this->returnValue( (object)$row ) );
+
+		$instance = new EntityIdFinder(
+			$this->connection,
+			$this->propertyTableHashes,
+			$this->idCacheManager
+		);
+
+		$this->assertEquals(
+			42,
+			$instance->findIdByItem( $dataItem )
+		);
+	}
+
+	public function testFetchFieldsFromTableById() {
+
+		$row = [
+			'smw_id' => 42,
+			'smw_hash' => '00000000000',
+			'smw_sort' => 'sort_a',
+			'smw_sortkey' => 'sort_b'
+		];
+
+		$dataItem = $this->getMockBuilder( '\SMW\DIWikiPage' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$this->idCacheManager->expects( $this->once() )
+			->method( 'setCache' );
+
+		$this->connection->expects( $this->once() )
+			->method( 'selectRow' )
+			->will( $this->returnValue( (object)$row ) );
+
+		$instance = new EntityIdFinder(
+			$this->connection,
+			$this->propertyTableHashes,
+			$this->idCacheManager
+		);
+
+		$sortkey = '';
+
+		$this->assertEquals(
+			[ 42, 'sort_b' ],
+			$instance->fetchFieldsFromTableById( 42, 'foo', 0, '', '', $sortkey )
+		);
+	}
+
+	public function testFetchFromTableByTitle() {
+
+		$row = [
+			'smw_id' => 42,
+			'smw_hash' => '00000000000',
+			'smw_sort' => 'sort_a',
+			'smw_sortkey' => 'sort_b'
+		];
+
+		$dataItem = $this->getMockBuilder( '\SMW\DIWikiPage' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$this->idCacheManager->expects( $this->once() )
+			->method( 'setCache' );
+
+		$this->connection->expects( $this->once() )
+			->method( 'selectRow' )
+			->will( $this->returnValue( (object)$row ) );
+
+		$instance = new EntityIdFinder(
+			$this->connection,
+			$this->propertyTableHashes,
+			$this->idCacheManager
+		);
+
+		$sortkey = '';
+
+		$this->assertEquals(
+			[ 42, 'sort_b' ],
+			$instance->fetchFromTableByTitle( 'foo', 0, '', '', $sortkey )
+		);
+	}
+
+	public function testFindIdsByTitle() {
+
+		$rows = [
+			(object)[ 'smw_id' => 42 ],
+			(object)[ 'smw_id' => 1001 ],
+		];
+
+		$dataItem = $this->getMockBuilder( '\SMW\DIWikiPage' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$this->connection->expects( $this->once() )
+			->method( 'select' )
+			->will( $this->returnValue( $rows ) );
+
+		$instance = new EntityIdFinder(
+			$this->connection,
+			$this->propertyTableHashes,
+			$this->idCacheManager
+		);
+
+		$sortkey = '';
+
+		$this->assertEquals(
+			[ 42, 1001 ],
+			$instance->findIdsByTitle( 'foo', 0, '', '' )
+		);
+	}
+
+}

--- a/tests/phpunit/Unit/SQLStore/EntityStore/IdCacheManagerTest.php
+++ b/tests/phpunit/Unit/SQLStore/EntityStore/IdCacheManagerTest.php
@@ -65,11 +65,16 @@ class IdCacheManagerTest extends \PHPUnit_Framework_TestCase {
 		$instance->get( 'foo' );
 	}
 
-	public function testSetCache() {
+	public function testGetId() {
 
 		$instance = new IdCacheManager( $this->caches );
 
 		$instance->setCache( 'foo', 0, '', '', 42, 'bar' );
+
+		$this->assertEquals(
+			42,
+			$instance->getId( new \SMW\DIWikiPage( 'foo', NS_MAIN ) )
+		);
 
 		$this->assertEquals(
 			42,
@@ -79,6 +84,23 @@ class IdCacheManagerTest extends \PHPUnit_Framework_TestCase {
 		$this->assertEquals(
 			false,
 			$instance->getId( [ 'foo', '0', '', '' ] )
+		);
+
+		$this->assertEquals(
+			42,
+			$instance->getId( $instance->computeSha1( [ 'foo', 0, '', '' ] ) )
+		);
+	}
+
+	public function testGetSort() {
+
+		$instance = new IdCacheManager( $this->caches );
+
+		$instance->setCache( 'foo', 0, '', '', 42, 'bar' );
+
+		$this->assertEquals(
+			'bar',
+			$instance->getSort( $instance->computeSha1( [ 'foo', 0, '', '' ] ) )
 		);
 
 		$this->assertEquals(

--- a/tests/phpunit/includes/storage/sqlstore/SQLStoreSmwIdsTest.php
+++ b/tests/phpunit/includes/storage/sqlstore/SQLStoreSmwIdsTest.php
@@ -66,7 +66,7 @@ class SQLStoreSmwIdsTest extends \PHPUnit_Framework_TestCase {
 			->disableOriginalConstructor()
 			->getMock();
 
-		$connection = $this->getMockBuilder( '\SMW\MediaWiki\Database' )
+		$this->connection = $this->getMockBuilder( '\SMW\MediaWiki\Database' )
 			->disableOriginalConstructor()
 			->getMock();
 
@@ -76,7 +76,7 @@ class SQLStoreSmwIdsTest extends \PHPUnit_Framework_TestCase {
 
 		$this->store->expects( $this->any() )
 			->method( 'getConnection' )
-			->will( $this->returnValue( $connection ) );
+			->will( $this->returnValue( $this->connection ) );
 
 		$redirectStore = new RedirectStore( $this->store );
 
@@ -115,6 +115,15 @@ class SQLStoreSmwIdsTest extends \PHPUnit_Framework_TestCase {
 		$this->factory->expects( $this->any() )
 			->method( 'newPropertyTableHashes' )
 			->will( $this->returnValue( $this->propertyTableHashes ) );
+
+		$this->entityIdFinder = $this->getMockBuilder( '\SMW\SQLStore\EntityStore\EntityIdFinder' )
+			->setConstructorArgs( [ $this->connection, $this->propertyTableHashes, $idCacheManager ] )
+			->setMethods( null )
+			->getMock();
+
+		$this->factory->expects( $this->any() )
+			->method( 'newEntityIdFinder' )
+			->will( $this->returnValue( $this->entityIdFinder ) );
 	}
 
 	public function testCanConstruct() {
@@ -169,11 +178,7 @@ class SQLStoreSmwIdsTest extends \PHPUnit_Framework_TestCase {
 		$selectRow->smw_sortkey = 'Foo';
 		$selectRow->smw_hash = '___hash___';
 
-		$connection = $this->getMockBuilder( '\SMW\MediaWiki\Database' )
-			->disableOriginalConstructor()
-			->getMock();
-
-		$connection->expects( $this->once() )
+		$this->connection->expects( $this->once() )
 			->method( 'selectRow' )
 			->will( $this->returnValue( $selectRow ) );
 
@@ -181,9 +186,9 @@ class SQLStoreSmwIdsTest extends \PHPUnit_Framework_TestCase {
 			->disableOriginalConstructor()
 			->getMock();
 
-		$store->expects( $this->atLeastOnce() )
+		$store->expects( $this->any() )
 			->method( 'getConnection' )
-			->will( $this->returnValue( $connection ) );
+			->will( $this->returnValue( $this->connection ) );
 
 		$instance = new SMWSql3SmwIds(
 			$store,
@@ -207,11 +212,7 @@ class SQLStoreSmwIdsTest extends \PHPUnit_Framework_TestCase {
 		$selectRow->smw_proptable_hash = serialize( 'Foo' );
 		$selectRow->smw_hash = '___hash___';
 
-		$connection = $this->getMockBuilder( '\SMW\MediaWiki\Database' )
-			->disableOriginalConstructor()
-			->getMock();
-
-		$connection->expects( $this->once() )
+		$this->connection->expects( $this->once() )
 			->method( 'selectRow' )
 			->will( $this->returnValue( $selectRow ) );
 
@@ -219,9 +220,9 @@ class SQLStoreSmwIdsTest extends \PHPUnit_Framework_TestCase {
 			->disableOriginalConstructor()
 			->getMock();
 
-		$store->expects( $this->atLeastOnce() )
+		$store->expects( $this->any() )
 			->method( 'getConnection' )
-			->will( $this->returnValue( $connection ) );
+			->will( $this->returnValue( $this->connection ) );
 
 		$instance = new SMWSql3SmwIds(
 			$store,
@@ -256,15 +257,11 @@ class SQLStoreSmwIdsTest extends \PHPUnit_Framework_TestCase {
 		$selectRow->smw_proptable_hash = serialize( 'Foo' );
 		$selectRow->smw_hash = '___hash___';
 
-		$connection = $this->getMockBuilder( '\SMW\MediaWiki\Database' )
-			->disableOriginalConstructor()
-			->getMock();
-
-		$connection->expects( $this->any() )
+		$this->connection->expects( $this->any() )
 			->method( 'selectRow' )
 			->will( $this->returnValue( $selectRow ) );
 
-		$connection->expects( $this->once() )
+		$this->connection->expects( $this->once() )
 			->method( 'insertId' )
 			->will( $this->returnValue( 9999 ) );
 
@@ -272,9 +269,9 @@ class SQLStoreSmwIdsTest extends \PHPUnit_Framework_TestCase {
 			->disableOriginalConstructor()
 			->getMock();
 
-		$store->expects( $this->atLeastOnce() )
+		$store->expects( $this->any() )
 			->method( 'getConnection' )
-			->will( $this->returnValue( $connection ) );
+			->will( $this->returnValue( $this->connection ) );
 
 		$instance = new SMWSql3SmwIds(
 			$store,
@@ -387,13 +384,13 @@ class SQLStoreSmwIdsTest extends \PHPUnit_Framework_TestCase {
 			->disableOriginalConstructor()
 			->getMock();
 
-		$connection->expects( $this->once() )
+		$this->connection->expects( $this->once() )
 			->method( 'selectRow' )
 			->will( $this->returnValue( $row ) );
 
-		$store->expects( $this->atLeastOnce() )
+		$store->expects( $this->any() )
 			->method( 'getConnection' )
-			->will( $this->returnValue( $connection ) );
+			->will( $this->returnValue( $this->connection ) );
 
 		$instance = new SMWSql3SmwIds(
 			$store,


### PR DESCRIPTION
This PR is made in reference to: #3801

This PR addresses or contains:

- Adds `EntityIdFinder` to isolate read access to the `ID_TABLE` before moving the `SMWSql3SmwIds` class

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed
