### PR TITLE
Register connection providers early, refs 4170

### DIFF
--- a/src/Setup.php
+++ b/src/Setup.php
@@ -40,6 +40,13 @@ final class Setup {
 	 */
 	public static function initExtension( &$vars ) {
 		Hooks::registerEarly( $vars );
+
+		// Register connection providers early to ensure the invocation of SMW
+		// related extensions such as `wfLoadExtension( 'SemanticCite' );` can
+		// happen before or after `enableSemantics` so that the check by the
+		// `ConnectionManager` (#4170) doesn't throw an error when an extension
+		// access the `Store` during `onExtensionFunction`
+		self::initConnectionProviders();
 	}
 
 	/**
@@ -88,8 +95,6 @@ final class Setup {
 			CompatibilityMode::disableSemantics();
 		}
 
-		$this->initConnectionProviders( );
-
 		$this->registerJobClasses( $vars );
 		$this->registerPermissions( $vars );
 
@@ -119,7 +124,7 @@ final class Setup {
 		}
 	}
 
-	private function initConnectionProviders() {
+	private static function initConnectionProviders() {
 
 		$applicationFactory = ApplicationFactory::getInstance();
 


### PR DESCRIPTION
This PR is made in reference to: #4170

This PR addresses or contains:

- Due to #4170 the check in `ConnectionManager` may happen to late due to how the `ExtensionRegistry` resolves the queue therefore register connection providers as soon as possible

This PR includes:
- [ ] Tests (unit/integration)
- [x] CI build passed

## Analysis

Due to `SemanticCite` being registered before `SemanticMediaWiki` it caused:

```
wfLoadExtension( 'SemanticCite' );
enableSemantics( 'example.org' );
```
```
[70c83752cac7731351c6966d] .../index.php/Main_Page RuntimeException from line 49 of ...\extensions\SemanticMediaWiki\src\Connection\ConnectionManager.php: mw.db is not registered as connection provider

Backtrace:

#0 ...\extensions\SemanticMediaWiki\src\Store.php(598): SMW\Connection\ConnectionManager->getConnection(string)
#1 ...\extensions\SemanticMediaWiki\src\SQLStore\SQLStore.php(656): SMW\Store->getConnection(string)
#2 ...\extensions\SemanticMediaWiki\src\SQLStore\SQLStoreFactory.php(409): SMW\SQLStore\SQLStore->getConnection(string)
#3 ...\extensions\SemanticMediaWiki\includes\storage\SQLStore\SMW_Sql3SmwIds.php(956): SMW\SQLStore\SQLStoreFactory->newPropertyTableHashes(SMW\SQLStore\EntityStore\IdCacheManager)
#4 ...\extensions\SemanticMediaWiki\includes\storage\SQLStore\SMW_Sql3SmwIds.php(152): SMWSql3SmwIds->initCache()
#5 ...\extensions\SemanticMediaWiki\src\SQLStore\SQLStoreFactory.php(133): SMWSql3SmwIds->__construct(SMW\Elastic\ElasticStore, SMW\SQLStore\SQLStoreFactory)
#6 ...\extensions\SemanticMediaWiki\src\SQLStore\SQLStore.php(158): SMW\SQLStore\SQLStoreFactory->newEntityTable()
#7 ...\extensions\SemanticMediaWiki\src\Elastic\ElasticStore.php(60): SMW\SQLStore\SQLStore->__construct()
#8 ...\extensions\SemanticMediaWiki\src\StoreFactory.php(61): SMW\Elastic\ElasticStore->__construct()
#9 ...\extensions\SemanticMediaWiki\src\StoreFactory.php(42): SMW\StoreFactory::newFromClass(string)
#10 ...\extensions\SemanticMediaWiki\src\Services\SharedServicesContainer.php(100): SMW\StoreFactory::getStore(string)
#11 [internal function]: SMW\Services\SharedServicesContainer->newStore(Onoi\CallbackContainer\CallbackContainerBuilder, string)
#12 ...\vendor\onoi\callback-container\src\CallbackContainerBuilder.php(260): call_user_func_array(array, array)
#13 ...\vendor\onoi\callback-container\src\CallbackContainerBuilder.php(288): Onoi\CallbackContainer\CallbackContainerBuilder->getReturnValueFromCallbackHandlerFor(string, array)
#14 ...\vendor\onoi\callback-container\src\CallbackContainerBuilder.php(195): Onoi\CallbackContainer\CallbackContainerBuilder->getReturnValueFromSingletonFor(string, array)
#15 ...\extensions\SemanticMediaWiki\src\Services\ServicesFactory.php(228): Onoi\CallbackContainer\CallbackContainerBuilder->singleton(string, NULL)
#16 ...\extensions\SemanticCite\SemanticCite.php(154): SMW\Services\ServicesFactory->getStore()
#17 ...\includes\Setup.php(938): SemanticCite::onExtensionFunction()
#18 ...\includes\WebStart.php(77): require_once(string)
#19 ...\index.php(39): require(string)
#20 {main}
```

The reason is that `SemanticCite::onExtensionFunction` is called before `SemanticMediaWiki::onExtensionFunction`. Use `SemanticMediaWiki::initExtension` which runs before the `onExtensionFunction` execution.