### PR TITLE
Remove `SQLStore::getStatisticsTable`

### DIFF
--- a/src/Maintenance/PropertyStatisticsRebuilder.php
+++ b/src/Maintenance/PropertyStatisticsRebuilder.php
@@ -6,6 +6,7 @@ use Onoi\MessageReporter\MessageReporter;
 use Onoi\MessageReporter\MessageReporterFactory;
 use SMW\SQLStore\PropertyStatisticsStore;
 use SMW\Store;
+use SMW\SQLStore\SQLStore;
 
 /**
  * Simple class for rebuilding property usage statistics.
@@ -59,7 +60,7 @@ class PropertyStatisticsRebuilder {
 	 */
 	public function rebuild() {
 		$this->reportMessage( "\nRebulding property statistics (this may take a while) ..." );
-		$table = $this->propertyStatisticsStore->getStatisticsTable();
+		$table = SQLStore::PROPERTY_STATISTICS_TABLE;
 
 		$this->reportMessage( "\n   ... deleting `$table` content ..." );
 		$this->propertyStatisticsStore->deleteAll();
@@ -67,7 +68,7 @@ class PropertyStatisticsRebuilder {
 		$connection = $this->store->getConnection( 'mw.db' );
 
 		$res = $connection->select(
-			\SMWSql3SmwIds::TABLE_NAME,
+			SQLStore::ID_TABLE,
 			[ 'smw_id', 'smw_title' ],
 			[
 				'smw_namespace' => SMW_NS_PROPERTY,

--- a/src/SQLStore/Lookup/UnusedPropertyListLookup.php
+++ b/src/SQLStore/Lookup/UnusedPropertyListLookup.php
@@ -115,15 +115,13 @@ class UnusedPropertyListLookup implements ListLookup {
 			$conditions[] = $this->store->getSQLConditions( $this->requestOptions, '', 'smw_sortkey', false );
 		}
 
-		$idTable = $this->store->getObjectIds()->getIdTable();
-
 		$res = $this->store->getConnection( 'mw.db' )->select(
-			[ $idTable ,$this->propertyStatisticsStore->getStatisticsTable() ],
+			[ SQLStore::ID_TABLE, SQLStore::PROPERTY_STATISTICS_TABLE ],
 			[ 'smw_title', 'usage_count' ],
 			$conditions,
 			__METHOD__,
 			$options,
-			[ $idTable => [ 'INNER JOIN', [ 'smw_id=p_id' ] ] ]
+			[  SQLStore::ID_TABLE => [ 'INNER JOIN', [ 'smw_id=p_id' ] ] ]
 		);
 
 		return $res;

--- a/src/SQLStore/Lookup/UsageStatisticsListLookup.php
+++ b/src/SQLStore/Lookup/UsageStatisticsListLookup.php
@@ -233,7 +233,7 @@ class UsageStatisticsListLookup implements ListLookup {
 		$count = 0;
 
 		$row = $this->store->getConnection()->selectRow(
-			[ $this->store->getStatisticsTable() ],
+			[ SQLStore::PROPERTY_STATISTICS_TABLE ],
 			'SUM( usage_count ) AS count',
 			[],
 			__METHOD__

--- a/src/SQLStore/PropertyStatisticsStore.php
+++ b/src/SQLStore/PropertyStatisticsStore.php
@@ -65,15 +65,6 @@ class PropertyStatisticsStore {
 	}
 
 	/**
-	 * @since 2.2
-	 *
-	 * @return string
-	 */
-	public function getStatisticsTable() {
-		return SQLStore::PROPERTY_STATISTICS_TABLE;
-	}
-
-	/**
 	 * Change the usage count for the property of the given ID by the given
 	 * value. The method does nothing if the count is 0.
 	 *

--- a/src/SQLStore/SQLStore.php
+++ b/src/SQLStore/SQLStore.php
@@ -598,17 +598,6 @@ class SQLStore extends Store {
 	}
 
 	/**
-	 * Returns the statics table
-	 *
-	 * @since 1.9
-	 *
-	 * @return string
-	 */
-	public function getStatisticsTable() {
-		return self::PROPERTY_STATISTICS_TABLE;
-	}
-
-	/**
 	 * Resets internal objects
 	 *
 	 * @since 1.9.1.1

--- a/tests/phpunit/includes/storage/sqlstore/SQLStoreTest.php
+++ b/tests/phpunit/includes/storage/sqlstore/SQLStoreTest.php
@@ -146,14 +146,6 @@ class SQLStoreTest extends \PHPUnit_Framework_TestCase {
 		);
 	}
 
-	public function testGetStatisticsTable() {
-
-		$this->assertInternalType(
-			'string',
-			$this->store->getStatisticsTable()
-		);
-	}
-
 	public function testGetObjectIds() {
 
 		$this->assertInternalType(


### PR DESCRIPTION
This PR is made in reference to: #

This PR addresses or contains:

- Removes `SQLStore::getStatisticsTable` from `SQLStore` and is replaced by `SQLStore::PROPERTY_STATISTICS_TABLE`

This PR includes:
- [ ] Tests (unit/integration)
- [x] CI build passed
