### PR TITLE
Add `include-head-items` to `ParserTestCaseProcessor`

### DIFF
--- a/tests/phpunit/Integration/JSONScript/docs/design.md
+++ b/tests/phpunit/Integration/JSONScript/docs/design.md
@@ -73,6 +73,7 @@ The test result assertion provides simplified string comparison methods (mostly 
 		"about": "#1 test output of #ask query",
 		"subject": "Example/Test/Q.1",
 		"assert-output": {
+			"include-head-items": true,
 			"to-contain": [
 				"Some text to search"
 			],
@@ -83,6 +84,8 @@ The test result assertion provides simplified string comparison methods (mostly 
 	}
 ]
 </pre>
+
+- `include-head-items` is an option that fetches the information stored in `ParserOutput::getHeadItems` and appends it to the validation output
 
 #### Type `parser-html`
 

--- a/tests/phpunit/Utils/JSONScript/ParserTestCaseProcessor.php
+++ b/tests/phpunit/Utils/JSONScript/ParserTestCaseProcessor.php
@@ -186,6 +186,10 @@ class ParserTestCaseProcessor extends \PHPUnit_Framework_TestCase {
 			$output = $parserOutput->getText();
 		}
 
+		if ( isset( $case['assert-output']['include-head-items'] ) && $case['assert-output']['include-head-items'] ) {
+			$output .= '<include-head-items>' . implode( '', $parserOutput->getHeadItems() ) . '</include-head-items>';
+		}
+
 		// Strip HTML comments
 		$output = preg_replace('/<!--(.*)-->/Uis', '', $output );
 


### PR DESCRIPTION
This PR is made in reference to: https://github.com/ProfessionalWiki/ModernTimeline/pull/1#issuecomment-517957869

This PR addresses or contains:

This PR includes:
- [ ] Tests (unit/integration)
- [ ] CI build passed

## Example

When option `include-head-items` is added to a test it will produce something like:

```
<include-head-items>              <script>(window.RLQ=window.RLQ||[]).push(function(){mw.config.set({"foooooo":"[\"abc\"]"});});</script>
</include-head-items>
```