### PR TITLE
Move SMWSql3SmwIds, refs 3801

### DIFF
--- a/src/Aliases.php
+++ b/src/Aliases.php
@@ -15,6 +15,7 @@ class_alias( \SMW\Property\RestrictionExaminer::class, 'SMW\PropertyRestrictionE
 class_alias( \SMW\Query\Result\ResultArray::class, 'SMWResultArray' );
 class_alias( \SMW\Query\QueryResult::class, 'SMWQueryResult' );
 class_alias( \SMW\Services\ServicesFactory::class, '\SMW\ApplicationFactory' );
+class_alias( \SMW\SQLStore\EntityStore\EntityIdManager::class, '\SMWSql3SmwIds' );
 
 // 3.0
 class_alias( \SMW\MediaWiki\Deferred\CallableUpdate::class, 'SMW\DeferredCallableUpdate' );

--- a/src/SQLStore/EntityStore/EntityIdManager.php
+++ b/src/SQLStore/EntityStore/EntityIdManager.php
@@ -1,5 +1,7 @@
 <?php
 
+namespace SMW\SQLStore\EntityStore;
+
 use SMW\DIProperty;
 use SMW\DIWikiPage;
 use SMW\MediaWiki\Collator;
@@ -60,13 +62,13 @@ use SMW\MediaWiki\Deferred\HashFieldUpdate;
  *
  * @ingroup SMWStore
  */
-class SMWSql3SmwIds {
+class EntityIdManager {
 
 	/**
 	 * Specifies the border limit for pre-defined properties declared
 	 * in SMWSql3SmwIds::special_ids
 	 */
-	const FXD_PROP_BORDER_ID = SMWSQLStore3::FIXED_PROPERTY_ID_UPPERBOUND;
+	const FXD_PROP_BORDER_ID = SQLStore::FIXED_PROPERTY_ID_UPPERBOUND;
 
 	/**
 	 * Name of the table to store IDs in.
@@ -74,16 +76,16 @@ class SMWSql3SmwIds {
 	 * @note This should never change. Existing wikis will have to drop and
 	 * rebuild their SMW tables completely to recover from any change here.
 	 */
-	const TABLE_NAME = SMWSQLStore3::ID_TABLE;
+	const TABLE_NAME = SQLStore::ID_TABLE;
 
 	const MAX_CACHE_SIZE = 1000;
 	const POOLCACHE_ID = 'smw.sqlstore';
 
 	/**
-	 * Parent SMWSQLStore3.
+	 * Parent SQLStore.
 	 *
 	 * @since 1.8
-	 * @var SMWSQLStore3
+	 * @var SQLStore
 	 */
 	public $store;
 
@@ -144,9 +146,9 @@ class SMWSql3SmwIds {
 
 	/**
 	 * @since 1.8
-	 * @param SMWSQLStore3 $store
+	 * @param SQLStore $store
 	 */
-	public function __construct( SMWSQLStore3 $store, SQLStoreFactory $factory ) {
+	public function __construct( SQLStore $store, SQLStoreFactory $factory ) {
 		$this->store = $store;
 		$this->factory = $factory;
 		$this->initCache();
@@ -618,10 +620,10 @@ class SMWSql3SmwIds {
 	 * the code.
 	 *
 	 * @since 1.8
-	 * @param SMWDIProperty $property
+	 * @param DIProperty $property
 	 * @return string
 	 */
-	public function getPropertyInterwiki( SMWDIProperty $property ) {
+	public function getPropertyInterwiki( DIProperty $property ) {
 		return ( $property->getLabel() !== '' ) ? '' : SMW_SQL3_SMWINTDEFIW;
 	}
 
@@ -709,18 +711,18 @@ class SMWSql3SmwIds {
 	}
 
 	/**
-	 * Fetch the ID for an SMWDIProperty object. This method achieves the
+	 * Fetch the ID for an DIProperty object. This method achieves the
 	 * same as getSMWPageID(), but avoids additional normalization steps
-	 * that have already been performed when creating an SMWDIProperty
+	 * that have already been performed when creating an DIProperty
 	 * object.
 	 *
 	 * @note There is no distinction between properties and inverse
 	 * properties here. A property and its inverse have the same ID in SMW.
 	 *
-	 * @param SMWDIProperty $property
+	 * @param DIProperty $property
 	 * @return integer
 	 */
-	public function getSMWPropertyID( SMWDIProperty $property ) {
+	public function getSMWPropertyID( DIProperty $property ) {
 		$key = $property->getKey();
 		$sortkey = '';
 
@@ -740,16 +742,16 @@ class SMWSql3SmwIds {
 	}
 
 	/**
-	 * Fetch and possibly create the ID for an SMWDIProperty object. The
+	 * Fetch and possibly create the ID for an DIProperty object. The
 	 * method achieves the same as getSMWPageID() but avoids additional
 	 * normalization steps that have already been performed when creating
-	 * an SMWDIProperty object.
+	 * an DIProperty object.
 	 *
 	 * @see getSMWPropertyID
-	 * @param SMWDIProperty $property
+	 * @param DIProperty $property
 	 * @return integer
 	 */
-	public function makeSMWPropertyID( SMWDIProperty $property ) {
+	public function makeSMWPropertyID( DIProperty $property ) {
 
 		$key = $property->getKey();
 

--- a/src/SQLStore/SQLStore.php
+++ b/src/SQLStore/SQLStore.php
@@ -155,7 +155,7 @@ class SQLStore extends Store {
 	 */
 	public function __construct() {
 		$this->factory = new SQLStoreFactory( $this, $this->messageReporter );
-		$this->smwIds = $this->factory->newEntityTable();
+		$this->smwIds = $this->factory->newEntityIdManager();
 	}
 
 	/**

--- a/src/SQLStore/SQLStoreFactory.php
+++ b/src/SQLStore/SQLStoreFactory.php
@@ -29,6 +29,7 @@ use SMW\SQLStore\EntityStore\TraversalPropertyLookup;
 use SMW\SQLStore\EntityStore\PropertySubjectsLookup;
 use SMW\SQLStore\EntityStore\PropertiesLookup;
 use SMW\SQLStore\EntityStore\PrefetchCache;
+use SMW\SQLStore\EntityStore\EntityIdManager;
 use SMW\SQLStore\PropertyTable\PropertyTableHashes;
 use SMW\SQLStore\Lookup\CachedListLookup;
 use SMW\SQLStore\Lookup\ListLookup;
@@ -53,7 +54,6 @@ use SMW\SQLStore\Rebuilder\EntityValidator;
 use SMW\SQLStore\Rebuilder\Rebuilder;
 use SMW\Utils\CircularReferenceGuard;
 use SMWRequestOptions as RequestOptions;
-use SMWSql3SmwIds as EntityIdManager;
 use SMW\Services\ServicesContainer;
 
 /**
@@ -129,7 +129,7 @@ class SQLStoreFactory {
 	 *
 	 * @return EntityIdManager
 	 */
-	public function newEntityTable() {
+	public function newEntityIdManager() {
 		return new EntityIdManager( $this->store, $this );
 	}
 

--- a/tests/phpunit/Unit/SQLStore/SQLStoreFactoryTest.php
+++ b/tests/phpunit/Unit/SQLStore/SQLStoreFactoryTest.php
@@ -95,7 +95,12 @@ class SQLStoreFactoryTest extends \PHPUnit_Framework_TestCase {
 
 		$this->assertInstanceOf(
 			'SMWSql3SmwIds',
-			$instance->newEntityTable()
+			$instance->newEntityIdManager()
+		);
+
+		$this->assertInstanceOf(
+			'\SMW\SQLStore\EntityStore\EntityIdManager',
+			$instance->newEntityIdManager()
 		);
 	}
 


### PR DESCRIPTION
This PR is made in reference to: #3801

This PR addresses or contains:

- Moves `SMWSql3SmwIds` to `SMW\SQLStore\EntityStore\EntityIdManager`

This PR includes:
- [ ] Tests (unit/integration)
- [x] CI build passed
