### PR TITLE
Fix for non-numeric values if offset option is empty

### DIFF
--- a/src/MediaWiki/Specials/Ask/ParametersProcessor.php
+++ b/src/MediaWiki/Specials/Ask/ParametersProcessor.php
@@ -145,11 +145,11 @@ class ParametersProcessor {
 		}
 
 		if ( !array_key_exists( 'offset', $parameters ) ) {
-			$parameters['offset'] = $request->getVal( 'offset', 0 );
+			$parameters['offset'] = $request->getInt( 'offset', 0 );
 		}
 
 		if ( !array_key_exists( 'limit', $parameters ) ) {
-			$parameters['limit'] = $request->getVal( 'limit', self::$defaultLimit );
+			$parameters['limit'] = $request->getInt( 'limit', self::$defaultLimit );
 		}
 
 		$parameters['limit'] = min( $parameters['limit'], self::$maxInlineLimit );

--- a/tests/phpunit/Unit/MediaWiki/Specials/Ask/ParametersProcessorTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Specials/Ask/ParametersProcessorTest.php
@@ -110,13 +110,13 @@ class ParametersProcessorTest extends \PHPUnit_Framework_TestCase {
 			->getMock();
 
 		$request->expects( $this->at( 5 ) )
-			->method( 'getVal' )
+			->method( 'getInt' )
 			->with(
 				$this->equalTo( 'offset' ),
 				$this->equalTo( 0 ) );
 
 		$request->expects( $this->at( 6 ) )
-			->method( 'getVal' )
+			->method( 'getInt' )
 			->with(
 				$this->equalTo( 'limit' ),
 				$this->equalTo( 42 ) );


### PR DESCRIPTION
This PR is made in reference to: #4205 

This PR addresses or contains:
- Fixes issue with non-numeric values if offset option is empty / as suggested by @mwjames https://github.com/SemanticMediaWiki/SemanticMediaWiki/issues/4205#issuecomment-518626418

This PR includes:
- [ ] Tests (unit/integration)
- [x] CI build passed

Fixes #4205 