### PR TITLE
Stop using mediawiki.api.parse

### DIFF
--- a/res/Resources.php
+++ b/res/Resources.php
@@ -635,7 +635,6 @@ return [
 		'scripts'  => [ 'smw/deferred/ext.smw.deferred.js' ],
 		'dependencies'  => [
 			'mediawiki.api',
-			'mediawiki.api.parse',
 			'onoi.rangeslider'
 		],
 		'messages' => [
@@ -665,7 +664,6 @@ return [
 		'scripts'  => [ 'smw/util/smw.property.page.js' ],
 		'dependencies'  => [
 			'mediawiki.api',
-			'mediawiki.api.parse',
 			'ext.smw.tooltip',
 		],
 		'messages' => [


### PR DESCRIPTION
To address https://github.com/SemanticMediaWiki/SemanticMediaWiki/issues/3626

I could not find any usages of the API module. Then again I do not know
the involved code so maybe I missed something.
