### PR TITLE
SQLite, Remove special `wgDBprefix` handling, refs 621

### DIFF
--- a/src/MediaWiki/Connection/ConnectionProvider.php
+++ b/src/MediaWiki/Connection/ConnectionProvider.php
@@ -132,9 +132,6 @@ class ConnectionProvider implements IConnectionProvider {
 			$silenceableTransactionProfiler
 		);
 
-		// Only required because of SQlite
-		$connection->setDBPrefix( $GLOBALS['wgDBprefix'] );
-
 		$this->logger->info(
 			[
 				'Connection',

--- a/src/MediaWiki/Connection/Database.php
+++ b/src/MediaWiki/Connection/Database.php
@@ -49,11 +49,6 @@ class Database {
 	private $loadBalancerFactory;
 
 	/**
-	 * @var string
-	 */
-	private $dbPrefix = '';
-
-	/**
 	 * @var SilenceableTransactionProfiler
 	 */
 	private $silenceableTransactionProfiler;
@@ -173,15 +168,6 @@ class Database {
 	}
 
 	/**
-	 * @since 2.1
-	 *
-	 * @param string $dbPrefix
-	 */
-	public function setDBPrefix( $dbPrefix ) {
-		$this->dbPrefix = $dbPrefix;
-	}
-
-	/**
 	 * @see DatabaseBase::tableName
 	 *
 	 * @since 1.9
@@ -191,11 +177,6 @@ class Database {
 	 * @return string
 	 */
 	public function tableName( $tableName ) {
-
-		if ( $this->getType() === 'sqlite' ) {
-			return $this->dbPrefix . $tableName;
-		}
-
 		return $this->connRef->getConnection( 'read' )->tableName( $tableName );
 	}
 

--- a/tests/phpunit/Unit/MediaWiki/Connection/DatabaseTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Connection/DatabaseTest.php
@@ -129,17 +129,12 @@ class DatabaseTest extends \PHPUnit_Framework_TestCase {
 
 		$database = $this->getMockBuilder( '\DatabaseBase' )
 			->disableOriginalConstructor()
-			->setMethods( [ 'tableName', 'getType' ] )
+			->setMethods( [ 'tableName' ] )
 			->getMockForAbstractClass();
 
 		$database->expects( $this->any() )
 			->method( 'tableName' )
-			->with( $this->equalTo( 'Foo' ) )
-			->will( $this->returnValue( 'Foo' ) );
-
-		$database->expects( $this->once() )
-			->method( 'getType' )
-			->will( $this->returnValue( $type ) );
+			->will( $this->returnArgument( 0 ) );
 
 		$connectionProvider = $this->getMockBuilder( '\SMW\Connection\ConnectionProvider' )
 			->disableOriginalConstructor()
@@ -157,12 +152,8 @@ class DatabaseTest extends \PHPUnit_Framework_TestCase {
 			)
 		);
 
-		$instance->setDBPrefix( 'bar_' );
-
-		$expected = $type === 'sqlite' ? 'bar_Foo' : 'Foo';
-
 		$this->assertEquals(
-			$expected,
+			'Foo',
 			$instance->tableName( 'Foo' )
 		);
 	}


### PR DESCRIPTION
This PR is made in reference to: #621

This PR addresses or contains:

- In the "old" days we needed to introduce a "hack" (#621) to have SQLite use the correct prefix during unit testing
- This PR removes the special handling for `wgDBprefix` which should resolve the https://github.com/SemanticMediaWiki/SemanticResultFormats/pull/525#issuecomment-518838469 issue caused by an early invocation of the database instance where `wgDBprefix` isn't set to the unit test prefix and is the reason why the test fails due to queries using the "real" database instead of the unit test cloned one

This PR includes:
- [ ] Tests (unit/integration)
- [x] CI build passed
