### PR TITLE
Replace wfGetLB, refs 4166

### DIFF
--- a/tests/phpunit/Utils/Connection/ConnectionProvider.php
+++ b/tests/phpunit/Utils/Connection/ConnectionProvider.php
@@ -3,7 +3,7 @@
 namespace SMW\Tests\Utils\Connection;
 
 use DatabaseBase;
-use MediaWiki\MediaWikiServices;
+use SMW\Services\ServicesFactory;
 use SMW\Connection\ConnectionProvider as IConnectionProvider;
 
 /**
@@ -37,15 +37,18 @@ class ConnectionProvider implements IConnectionProvider {
 	 */
 	public function getConnection() {
 
-		if ( $this->connection === null ) {
-			$this->connection = MediaWikiServices::getInstance()
-				->getDBLoadBalancer()->getConnection( $this->id );
+		if ( $this->connection !== null ) {
+			return $this->connection;
 		}
 
-		return $this->connection;
+		return $this->connection = $this->getLoadBalancer()->getConnection( $this->id );
 	}
 
 	public function releaseConnection() {
+	}
+
+	private function getLoadBalancer() {
+		return ServicesFactory::getInstance()->create( 'DBLoadBalancer' );
 	}
 
 }


### PR DESCRIPTION
This PR is made in reference to: #4166

This PR addresses or contains:

- Quoting `wfGetLB` which states "`@deprecated since 1.27, use MediaWikiServices::getInstance()->getDBLoadBalancer() or MediaWikiServices::getInstance()->getDBLoadBalancerFactory() instead.`"

This PR includes:
- [ ] Tests (unit/integration)
- [x] CI build passed
