### PR TITLE
Guard against "Serialization of 'Closure' is not allowed", refs 4210

### DIFF
--- a/src/MediaWiki/Content/SchemaContent.php
+++ b/src/MediaWiki/Content/SchemaContent.php
@@ -77,6 +77,18 @@ class SchemaContent extends JsonContent {
 	}
 
 	/**
+	 * This class doesn't own the properties but needs to guard against
+	 * a possible serialization attempt. (@see #4210)
+	 *
+	 * @since 3.1
+	 *
+	 * @return array
+	 */
+	public function __sleep() {
+		return [ 'model_id', 'mText' ];
+	}
+
+	/**
 	 * `Content::getNativeData` will return the "native" text representation which
 	 * in case of YAML is just the text and not a JSON string. Therefore
 	 * `getNativeData` preserves the original user input.

--- a/tests/phpunit/Unit/MediaWiki/Content/SchemaContentTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Content/SchemaContentTest.php
@@ -115,6 +115,52 @@ class SchemaContentTest extends \PHPUnit_Framework_TestCase {
 		);
 	}
 
+	public function testSerializationOfClassInstance() {
+
+		$title = $this->getMockBuilder( '\Title' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$title->expects( $this->any() )
+			->method( 'getDBKey' )
+			->will( $this->returnValue( 'Foo' ) );
+
+		$page = $this->getMockBuilder( '\wikiPage' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$page->expects( $this->any() )
+			->method( 'getTitle' )
+			->will( $this->returnValue( $title ) );
+
+		$user = $this->getMockBuilder( '\User' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$parserOptions = $this->getMockBuilder( '\ParserOptions' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$instance = new SchemaContent(
+			json_encode( [ 'Foo' => 42 ] )
+		);
+
+		// Use an actual factory instance to ensure a "real" DB instance is
+		// invoked and would force a "RuntimeException: Database serialization
+		// may cause problems, since the connection is not restored on wakeup."
+		$instance->setServices( new \SMW\Schema\SchemaFactory() );
+
+		$flags = '';
+		$parentRevId = '';
+
+		$instance->prepareSave( $page, $flags, $parentRevId, $user );
+
+		$this->assertInternalType(
+			'string',
+			serialize( $instance )
+		);
+	}
+
 	public function testPreSaveTransform() {
 
 		$title = $this->getMockBuilder( '\Title' )


### PR DESCRIPTION
This PR is made in reference to: #4210

This PR addresses or contains:

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed

Fixes #4210