### PR TITLE
Add support for `order_map`, refs

### DIFF
--- a/DefaultSettings.php
+++ b/DefaultSettings.php
@@ -71,7 +71,7 @@ return [
 	#
 	# @since 3.0
 	##
-	'smwgUpgradeKey' => 'smw:2019-01-19',
+	'smwgUpgradeKey' => 'smw:2019-08-18',
 	##
 
 	###
@@ -2144,7 +2144,14 @@ return [
 			'type_description' => 'smw-schema-description-class-constraint-schema',
 			'change_propagation' => [ '_CONSTRAINT_SCHEMA' ],
 			'usage_lookup' => '_CONSTRAINT_SCHEMA'
-		]
+		],
+		'PROPERTY_PROFILE_SCHEMA' => [
+			'group' => SMW_SCHEMA_GROUP_PROFILE,
+			'validation_schema' => __DIR__ . '/data/schema/property-profile-schema.v1.json',
+			'type_description' => 'smw-schema-description-property-profile-schema',
+			'change_propagation' => '_PROFILE_SCHEMA',
+			'usage_lookup' => '_PROFILE_SCHEMA'
+		],
 	],
 	##
 

--- a/data/import/groups/schema.json
+++ b/data/import/groups/schema.json
@@ -11,7 +11,8 @@
                 "_SCHEMA_TAG",
                 "_SCHEMA_LINK",
                 "_FORMAT_SCHEMA",
-                "_CONSTRAINT_SCHEMA"
+                "_CONSTRAINT_SCHEMA",
+                "_PROFILE_SCHEMA"
             ]
         }
     ],

--- a/data/schema/property-profile-schema.v1.json
+++ b/data/schema/property-profile-schema.v1.json
@@ -1,0 +1,68 @@
+{
+	"$schema": "http://json-schema.org/draft-07/schema#",
+	"$id": "https://www.semantic-mediawiki.org/wiki/Help:Schema/Type/PROPERTY_PROFILE_SCHEMA",
+	"type": "object",
+	"title": "Property profile validation schema",
+	"required": [
+		"type",
+		"profile"
+	],
+	"properties": {
+		"type": {
+			"$id": "#/properties/type",
+			"type": "string",
+			"enum": [
+				"PROPERTY_PROFILE_SCHEMA"
+			],
+			"title": "Schema type",
+			"default": "PROPERTY_PROFILE_SCHEMA"
+		},
+		"title_prefix": {
+			"$id": "#/properties/title_prefix",
+			"type": "string",
+			"enum": [
+				"Profile"
+			],
+			"title": "Title prefix"
+		},
+		"manifest_version": {
+			"$id": "#/properties/manifest_version",
+			"type": "number",
+			"title": "Manifest version",
+			"default": 1
+		},
+		"tags": {
+			"$id": "#/properties/tags",
+			"type": "array",
+			"title": "tags",
+			"default": null,
+			"items": {
+				"$id": "#/properties/tags/items",
+				"type": "string",
+				"title": "tags, keywords etc.",
+				"default": "",
+				"pattern": "^(.*)$"
+			}
+		},
+		"profile": {
+			"$id": "#/properties/profile",
+			"type": "object",
+			"title": "Available profile options",
+			"minProperties": 1,
+			"properties": {
+				"sequence_map": {
+					"$ref": "#/definitions/sequence_map"
+				}
+			},
+			"additionalProperties": false
+		}
+	},
+	"definitions": {
+		"sequence_map": {
+			"$id": "#/definitions/sequence_map",
+			"type": "boolean",
+			"default": false,
+			"title": "Whether to store annotation values in the order of the input or not"
+		}
+	}
+}

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -943,6 +943,7 @@
 	"smw-schema-description": "Schema description",
 	"smw-schema-description-link-format-schema": "This schema type supports the definition of characteristics for creating context sensitive links in connection with a [[Property:Formatter schema|formatter schema]] assigned property.",
 	"smw-schema-description-search-form-schema": "This schema type supports the definition of input forms and characteristics for the [https://www.semantic-mediawiki.org/wiki/Help:SMWSearch extended search] profile where it contains instructions on how to generate input fields, define default namespaces, or declare prefix expressions for a search request.",
+	"smw-schema-description-property-profile-schema": "This schema type supports the definition of a profile to declare characteristics to the assigned property and its annotation values.",
 	"smw-schema-description-property-group-schema": "This schema type supports the definition of [https://www.semantic-mediawiki.org/wiki/Help:Property_group property groups] to help structure the [https://www.semantic-mediawiki.org/wiki/Help:Special:Browse browsing] interface.",
 	"smw-schema-description-property-constraint-schema": "This supports the definition of constraint rules for a property instance as well as those values assigned to it.",
 	"smw-schema-description-class-constraint-schema": "This schema type supports the definition of constraint rules for a class instance (a.k.a. category).",

--- a/i18n/extra/en.json
+++ b/i18n/extra/en.json
@@ -125,6 +125,7 @@
             "_SCHEMA_LINK": "Schema link",
             "_FORMAT_SCHEMA": "Formatter schema",
             "_CONSTRAINT_SCHEMA": "Constraint schema",
+            "_PROFILE_SCHEMA": "Profile schema",
             "_ATTCH_LINK": "Attachment link",
             "_FILE_ATTCH": "File attachment",
             "_CONT_TYPE": "Content type",
@@ -201,6 +202,8 @@
             "Formatter schema": "_FORMAT_SCHEMA",
             "Constraint schema": "_CONSTRAINT_SCHEMA",
             "Property constraint schema": "_CONSTRAINT_SCHEMA",
+            "Profile schema": "_PROFILE_SCHEMA",
+            "Property profile schema": "_PROFILE_SCHEMA",
             "File attachment": "_FILE_ATTCH",
             "Has file attachment": "_FILE_ATTCH",
             "Has translation":"_TRANS"

--- a/src/DataModel/ContainerSemanticData.php
+++ b/src/DataModel/ContainerSemanticData.php
@@ -71,7 +71,8 @@ class ContainerSemanticData extends SemanticData {
 			'skipAnonymousCheck',
 			'subSemanticData',
 			'options',
-			'extensionData'
+			'extensionData',
+			'sequenceMap'
 		];
 	}
 
@@ -138,8 +139,8 @@ class ContainerSemanticData extends SemanticData {
 
 		if ( $semanticData === null ) {
 			return;
-		}		
-		
+		}
+
 		$this->mSubject = $semanticData->getSubject();
 		$this->mProperties = $semanticData->getProperties();
 		$this->mPropVals = [];
@@ -150,6 +151,7 @@ class ContainerSemanticData extends SemanticData {
 
 		$this->mHasVisibleProps = $semanticData->hasVisibleProperties();
 		$this->mHasVisibleSpecs = $semanticData->hasVisibleSpecialProperties();
+		$this->sequenceMap = $semanticData->getSequenceMap();
 		$this->mNoDuplicates = $semanticData->mNoDuplicates;
 	}
 

--- a/src/DataModel/SequenceMap.php
+++ b/src/DataModel/SequenceMap.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace SMW\DataModel;
+
+use SMW\DIProperty;
+use SMW\Services\ServicesFactory;
+
+/**
+ * Holds the annotation value input order by property.
+ *
+ * @license GNU GPL v2+
+ * @since 3.1
+ *
+ * @author mwjames
+ */
+class SequenceMap {
+
+	/**
+	 * @var []
+	 */
+	private static $canMap = [];
+
+	/**
+	 * @since 3.1
+	 *
+	 * @param boolean
+	 */
+	public static function canMap( DIProperty $property ) {
+
+		$key = $property->getKey();
+
+		if ( isset( self::$canMap[$key] ) ) {
+			return self::$canMap[$key];
+		}
+
+		$schemaFactory = ServicesFactory::getInstance()->singleton( 'SchemaFactory' );
+		$schemaFinder = $schemaFactory->newSchemaFinder();
+
+		$schemaList = $schemaFinder->newSchemaList(
+			$property,
+			new DIProperty( '_PROFILE_SCHEMA' )
+		);
+
+		if ( $schemaList === [] ) {
+			return self::$canMap[$key] = false;
+		}
+
+		$profile = $schemaList->get( 'profile' );
+
+		return self::$canMap[$key] = $profile['sequence_map'] ?? false;
+	}
+
+
+}

--- a/src/Defines.php
+++ b/src/Defines.php
@@ -287,6 +287,7 @@ define( 'SMW_SCHEMA_GROUP_FORMAT', 'schema/group/format' );
 define( 'SMW_SCHEMA_GROUP_SEARCH_FORM', 'schema/group/searchform' );
 define( 'SMW_SCHEMA_GROUP_PROPERTY', 'schema/group/property' );
 define( 'SMW_SCHEMA_GROUP_CONSTRAINT', 'schema/group/constraint' );
+define( 'SMW_SCHEMA_GROUP_PROFILE', 'schema/group/profile' );
 
 /**@{
   * Constants for Special:Ask submit method

--- a/src/MediaWiki/Specials/SpecialPageProperty.php
+++ b/src/MediaWiki/Specials/SpecialPageProperty.php
@@ -4,6 +4,7 @@ namespace SMW\MediaWiki\Specials;
 
 use SMW\ApplicationFactory;
 use SMW\DataValueFactory;
+use SMW\DataModel\SequenceMap;
 use SMW\Encoder;
 use SMW\MediaWiki\Specials\PageProperty\PageBuilder;
 use SMW\Options;
@@ -144,7 +145,7 @@ class SpecialPageProperty extends SpecialPage {
 			$requestOptions = new RequestOptions();
 			$requestOptions->setLimit( $options->get( 'limit' ) + 1 );
 			$requestOptions->setOffset( $options->get( 'offset' ) );
-			$requestOptions->sort = true;
+			$requestOptions->sort = !SequenceMap::canMap( $propertyValue->getDataItem() );
 
 			// Restrict the request otherwise the entire SemanticData record
 			// is fetched which can in case of a subject with a large

--- a/src/SQLStore/EntityStore/EntityIdManager.php
+++ b/src/SQLStore/EntityStore/EntityIdManager.php
@@ -114,6 +114,11 @@ class EntityIdManager {
 	 */
 	private $entityIdFinder;
 
+	/*
+	 * @var SequenceMapFinder
+	 */
+	private $sequenceMapFinder;
+
 	/**
 	 * @var DuplicateFinder
 	 */
@@ -134,6 +139,10 @@ class EntityIdManager {
 		$this->initCache();
 
 		$this->idEntityFinder = $this->factory->newIdEntityFinder(
+			$this->idCacheManager
+		);
+
+		$this->sequenceMapFinder = $this->factory->newSequenceMapFinder(
 			$this->idCacheManager
 		);
 
@@ -958,6 +967,7 @@ class EntityIdManager {
 				'entity.lookup' => 2000,
 				'propertytable.hash' => self::MAX_CACHE_SIZE,
 				'warmup.byid' => self::MAX_CACHE_SIZE,
+				'sequence.map' => self::MAX_CACHE_SIZE,
 			]
 		);
 
@@ -1001,6 +1011,48 @@ class EntityIdManager {
 	 */
 	public function setPropertyTableHashes( $sid, $hash = null ) {
 		$this->propertyTableHashes->setPropertyTableHashes( $sid, $hash );
+	}
+
+	/**
+	 * @since 3.1
+	 *
+	 * @param integer $sid
+	 * @param array $dataMap
+	 */
+	public function setSequenceMap( $sid, array $map = null ) {
+		$this->sequenceMapFinder->setMap( $sid, $map );
+	}
+
+	/**
+	 * @since 3.1
+	 *
+	 * @param integer $sid
+	 * @param string|null $key
+	 *
+	 * @return array
+	 */
+	public function getSequenceMap( $sid, $key = null ) {
+
+		$sequenceMap = $this->sequenceMapFinder->findMapById( $sid );
+
+		if ( $key === null ) {
+			return $sequenceMap;
+		}
+
+		if ( isset( $sequenceMap[$key] ) ) {
+			return $sequenceMap[$key];
+		}
+
+		return [];
+	}
+
+	/**
+	 * @since 3.1
+	 *
+	 * @param array $ids
+	 */
+	public function loadSequenceMap( array $ids ) {
+		$this->sequenceMapFinder->prefetchSequenceMap( $ids );
 	}
 
 }

--- a/src/SQLStore/EntityStore/EntityLookup.php
+++ b/src/SQLStore/EntityStore/EntityLookup.php
@@ -150,6 +150,13 @@ class EntityLookup implements IEntityLookup {
 			$this->semanticDataLookup->unlockCache();
 		}
 
+		if ( $semanticData->getSequenceMap() === [] ) {
+			$semanticData->setSequenceMap(
+				$sid,
+				$this->store->getObjectIds()->getSequenceMap( $sid )
+			);
+		}
+
 		// Avoid adding a sortkey for an already extended stub
 		if ( !$semanticData->hasProperty( new DIProperty( '_SKEY' ) ) ) {
 			$semanticData->addPropertyStubValue( '_SKEY', [ '', $sortKey ] );

--- a/src/SQLStore/EntityStore/IdChanger.php
+++ b/src/SQLStore/EntityStore/IdChanger.php
@@ -105,6 +105,14 @@ class IdChanger {
 		$targetid = $targetid == 0 ? $connection->insertId() : $targetid;
 
 		$connection->delete(
+			SQLStore::ID_AUXILIARY_TABLE,
+			[
+				'smw_id' => $curid
+			],
+			__METHOD__
+		);
+
+		$connection->delete(
 			SQLStore::ID_TABLE,
 			[
 				'smw_id' => $curid

--- a/src/SQLStore/EntityStore/SemanticDataLookup.php
+++ b/src/SQLStore/EntityStore/SemanticDataLookup.php
@@ -182,6 +182,11 @@ class SemanticDataLookup {
 			}
 		}
 
+		$stubSemanticData->setSequenceMap(
+			$id,
+			$this->store->getObjectIds()->getSequenceMap( $id )
+		);
+
 		return $stubSemanticData;
 	}
 
@@ -199,6 +204,7 @@ class SemanticDataLookup {
 
 		$ids = [];
 		$isSubject = true;
+		$entityIdManager = $this->store->getObjectIds();
 
 		foreach ( $subjects as $k => $subject ) {
 
@@ -206,7 +212,7 @@ class SemanticDataLookup {
 				continue;
 			}
 
-			$id = $this->store->getObjectIds()->getSMWPageID(
+			$id = $entityIdManager->getSMWPageID(
 				$subject->getDBkey(),
 				$subject->getNamespace(),
 				$subject->getInterwiki(),
@@ -222,7 +228,7 @@ class SemanticDataLookup {
 			return [];
 		}
 
-		$pid = $this->store->getObjectIds()->getSMWPropertyID( $property );
+		$pid = $entityIdManager->getSMWPropertyID( $property );
 		$this->caller = __METHOD__;
 
 		$connection = $this->store->getConnection( 'mw.db' );
@@ -271,6 +277,8 @@ class SemanticDataLookup {
 
 			$result[$sid]["$i#$h"] = $data[1];
 		}
+
+		$entityIdManager->loadSequenceMap( array_keys( $ids ) );
 
 		return $result;
 	}

--- a/src/SQLStore/EntityStore/SequenceMapFinder.php
+++ b/src/SQLStore/EntityStore/SequenceMapFinder.php
@@ -1,0 +1,186 @@
+<?php
+
+namespace SMW\SQLStore\EntityStore;
+
+use SMW\MediaWiki\Database;
+use SMW\Utils\HmacSerializer;
+use SMW\SQLStore\SQLStore;
+
+/**
+ * @private
+ *
+ * @license GNU GPL v2
+ * @since 3.1
+ *
+ * @author mwjames
+ */
+class SequenceMapFinder {
+
+	/**
+	 * @var Database
+	 */
+	private $connection;
+
+	/**
+	 * @var IdCacheManager
+	 */
+	private $idCacheManager;
+
+	/**
+	 * @var []
+	 */
+	private $preloaded = [];
+
+	/**
+	 * @since 3.1
+	 *
+	 * @param Database $connection
+	 * @param IdCacheManager $idCacheManager
+	 */
+	public function __construct( Database $connection, IdCacheManager $idCacheManager ) {
+		$this->connection = $connection;
+		$this->idCacheManager = $idCacheManager;
+	}
+
+	/**
+	 * Update the sequence.map (smw_seqmap) for a given entity ID
+	 *
+	 * @since 3.1
+	 *
+	 * @param integer $sid
+	 * @param array $map
+	 */
+	public function setMap( $sid, array $map = null ) {
+
+		if ( $map === null ) {
+			return;
+		}
+
+		if ( $map !== [] ) {
+			$map = $this->connection->escape_bytea( HmacSerializer::compress( $map ) );
+		} else {
+			$map = null;
+		}
+
+		$rows = [
+			'smw_id' => $sid,
+			'smw_seqmap' => $map
+		];
+
+		$this->connection->upsert(
+			SQLStore::ID_AUXILIARY_TABLE,
+			$rows,
+			[
+				'smw_id'
+			],
+			$rows,
+			__METHOD__
+		);
+	}
+
+	/**
+	 * @since 3.1
+	 *
+	 * @param integer $sid
+	 *
+	 * @return array
+	 */
+	public function findMapById( $sid ) {
+
+		$omap = [];
+		$cache = $this->idCacheManager->get( 'sequence.map' );
+
+		if ( ( $map = $cache->fetch( $sid ) ) !== false ) {
+			return $map;
+		}
+
+		$row = $this->connection->selectRow(
+			SQLStore::ID_AUXILIARY_TABLE,
+			[
+				'smw_seqmap'
+			],
+			[
+				'smw_id' => $sid
+			],
+			__METHOD__
+		);
+
+		if ( $row !== false ) {
+			$omap = $row->smw_seqmap;
+		}
+
+		if ( $omap !== null && is_string( $omap ) ) {
+			$omap = $this->connection->unescape_bytea( $omap );
+		}
+
+		if ( $omap === [] || $omap === null ) {
+			$map = [];
+		} else {
+			$map = HmacSerializer::uncompress( $omap );
+		}
+
+		$cache->save( $sid, $map );
+
+		return $map;
+	}
+
+	/**
+	 * @since 3.1
+	 *
+	 * @param array $ids
+	 */
+	public function prefetchSequenceMap( array $ids ) {
+
+		sort( $ids );
+		$hash = md5( json_encode( $ids ) );
+
+		if ( isset( $this->preloaded[$hash] ) ) {
+			return;
+		}
+
+		$cache = $this->idCacheManager->get( 'sequence.map' );
+
+		$rows = $this->connection->select(
+			SQLStore::ID_AUXILIARY_TABLE,
+			[
+				'smw_id',
+				'smw_seqmap'
+			],
+			[
+				'smw_id' => $ids
+			],
+			__METHOD__
+		);
+
+		$inverted_ids = array_flip( $ids );
+
+		foreach ( $rows as $row ) {
+			$id = (int)$row->smw_id;
+			$omap = $row->smw_seqmap;
+
+			if ( $omap !== null && is_string( $omap ) ) {
+				$omap = $this->connection->unescape_bytea( $omap );
+			}
+
+			if ( $omap !== null && $omap !== false ) {
+				$map = HmacSerializer::uncompress( $omap );
+			} else {
+				$map = [];
+			}
+
+			// Removes those that found a matching pair
+			unset( $inverted_ids[$id] );
+
+			$cache->save( $id, $map );
+		}
+
+		// For all leftovers, store them as empty to avoid
+		// running individual SELECTS
+		foreach ( $inverted_ids as $id => $pos ) {
+			$cache->save( $id, [] );
+		}
+
+		$this->preloaded[$hash] = true;
+	}
+
+}

--- a/src/SQLStore/EntityStore/StubSemanticData.php
+++ b/src/SQLStore/EntityStore/StubSemanticData.php
@@ -110,7 +110,18 @@ class StubSemanticData extends SemanticData {
 		$result->mHasVisibleProps = $semanticData->mHasVisibleProps;
 		$result->mHasVisibleSpecs = $semanticData->mHasVisibleSpecs;
 		$result->stubObject = $semanticData->stubObject;
+		$result->sequenceMap = $semanticData->sequenceMap;
 		return $result;
+	}
+
+	/**
+	 * @since 3.1
+	 *
+	 * @param integer $sid
+	 * @param [] $sequenceMap
+	 */
+	public function setSequenceMap( $sid, $sequenceMap ) {
+		$this->sequenceMap = is_array( $sequenceMap ) ? $sequenceMap : [];
 	}
 
 	/**
@@ -370,7 +381,7 @@ class StubSemanticData extends SemanticData {
 			}
 
 			if ( $this->mNoDuplicates ) {
-				$this->mPropVals[$property->getKey()][$dataItem->getHash()] = $dataItem;
+				$this->mPropVals[$property->getKey()][md5( $dataItem->getHash() )] = $dataItem;
 			} else {
 				$this->mPropVals[$property->getKey()][] = $dataItem;
 			}

--- a/src/SQLStore/PropertyTable/PropertyTableHashes.php
+++ b/src/SQLStore/PropertyTable/PropertyTableHashes.php
@@ -68,6 +68,23 @@ class PropertyTableHashes {
 			__METHOD__
 		);
 
+/*
+		$smw_proptable = $hash === null ? null : serialize( $hash );
+
+		$this->connection->upsert(
+			SQLStore::ID_AUXILIARY_TABLE,
+			[
+				'smw_id' => $id,
+				'smw_proptable' => $smw_proptable
+			],
+			[ 'smw_id' ],
+			[
+				'smw_id' => $id,
+				'smw_proptable' => $smw_proptable
+			],
+			__METHOD__
+		);
+*/
 		$this->setPropertyTableHashesCache( $id, $hash );
 
 		if ( $hash === null ) {

--- a/src/SQLStore/PropertyTableIdReferenceDisposer.php
+++ b/src/SQLStore/PropertyTableIdReferenceDisposer.php
@@ -222,6 +222,12 @@ class PropertyTableIdReferenceDisposer {
 		}
 
 		$this->connection->delete(
+			SQLStore::ID_AUXILIARY_TABLE,
+			[ 'smw_id' => $id ],
+			__METHOD__
+		);
+
+		$this->connection->delete(
 			SQLStore::PROPERTY_STATISTICS_TABLE,
 			[ 'p_id' => $id ],
 			__METHOD__

--- a/src/SQLStore/SQLStore.php
+++ b/src/SQLStore/SQLStore.php
@@ -108,6 +108,11 @@ class SQLStore extends Store {
 	const ID_TABLE = 'smw_object_ids';
 
 	/**
+	 * Name of the ID auxiliary table
+	 */
+	const ID_AUXILIARY_TABLE = 'smw_object_aux';
+
+	/**
 	 * @var SQLStoreFactory
 	 */
 	private $factory;

--- a/src/SQLStore/SQLStoreFactory.php
+++ b/src/SQLStore/SQLStoreFactory.php
@@ -20,6 +20,7 @@ use SMW\SQLStore\EntityStore\IdCacheManager;
 use SMW\SQLStore\EntityStore\CacheWarmer;
 use SMW\SQLStore\EntityStore\IdEntityFinder;
 use SMW\SQLStore\EntityStore\EntityIdFinder;
+use SMW\SQLStore\EntityStore\SequenceMapFinder;
 use SMW\SQLStore\EntityStore\IdChanger;
 use SMW\SQLStore\EntityStore\DuplicateFinder;
 use SMW\SQLStore\EntityStore\EntityLookup;
@@ -631,6 +632,23 @@ class SQLStoreFactory {
 		);
 
 		return $entityIdFinder;
+	}
+
+	/**
+	 * @since 3.1
+	 *
+	 * @param IdCacheManager $idCacheManager
+	 *
+	 * @return SequenceMapFinder
+	 */
+	public function newSequenceMapFinder( IdCacheManager $idCacheManager ) {
+
+		$sequenceMapFinder = new SequenceMapFinder(
+			$this->store->getConnection( 'mw.db'),
+			$idCacheManager
+		);
+
+		return $sequenceMapFinder;
 	}
 
 	/**

--- a/src/SQLStore/SQLStoreUpdater.php
+++ b/src/SQLStore/SQLStoreUpdater.php
@@ -368,6 +368,11 @@ class SQLStoreUpdater {
 
 		// Update caches (may be important if jobs are directly following this call)
 		$this->semanticDataLookup->setLookupCache( $sid, $data );
+
+		$this->store->getObjectIds()->setSequenceMap(
+			$sid,
+			$data->getSequenceMap()
+		);
 	}
 
 	private function makeSortKey( $subject, $data ) {

--- a/src/SQLStore/TableBuilder/TableSchemaManager.php
+++ b/src/SQLStore/TableBuilder/TableSchemaManager.php
@@ -148,6 +148,8 @@ class TableSchemaManager {
 		}
 
 		$this->addTable( $this->newEntityIdTable() );
+		$this->addTable( $this->newEntityAuxiliaryTable() );
+
 		$this->addTable( $this->newConceptCacheTable() );
 		$this->addTable( $this->newQueryLinksTable() );
 		$this->addTable( $this->newFulltextSearchTable() );
@@ -228,6 +230,21 @@ class TableSchemaManager {
 
 		$table->addIndex( 'smw_rev,smw_id' );
 		$table->addIndex( 'smw_touched,smw_id' );
+
+		return $table;
+	}
+
+	private function newEntityAuxiliaryTable() {
+
+		// ID_AUXILIARY_TABLE
+		$table = new Table( SQLStore::ID_AUXILIARY_TABLE );
+
+		$table->addColumn( 'smw_id', [ FieldType::FIELD_ID, 'NOT NULL' ] );
+		$table->addColumn( 'smw_seqmap', FieldType::TYPE_BLOB );
+
+		// $table->addColumn( 'smw_proptable', FieldType::TYPE_BLOB );
+
+		$table->addIndex( [ 'smw_id', 'UNIQUE INDEX' ] );
 
 		return $table;
 	}

--- a/src/Schema/README.md
+++ b/src/Schema/README.md
@@ -36,6 +36,7 @@ In the example above, `FOO_SCHEMA` refers to the type name and any attributes as
 - [`PROPERTY_GROUP_SCHEMA`](https://github.com/SemanticMediaWiki/SemanticMediaWiki/blob/master/src/Schema/docs/property.group.md)
 - [`PROPERTY_CONSTRAINT_SCHEMA`](https://github.com/SemanticMediaWiki/SemanticMediaWiki/blob/master/src/Schema/docs/property.constraint.md)
 - [`CLASS_CONSTRAINT_SCHEMA`](https://github.com/SemanticMediaWiki/SemanticMediaWiki/blob/master/src/Schema/docs/class.constraint.md)
+- [`PROPERTY_PROFILE_SCHEMA`](https://github.com/SemanticMediaWiki/SemanticMediaWiki/blob/master/src/Schema/docs/property.profile.md)
 
 [json:schema]: http://json-schema.org/
 

--- a/src/Schema/SchemaFinder.php
+++ b/src/Schema/SchemaFinder.php
@@ -50,10 +50,22 @@ class SchemaFinder {
 	 * @return SchemaList|[]
 	 */
 	public function getConstraintSchema( DataItem $dataItem ) {
+		return $this->newSchemaList( $dataItem, new DIProperty( '_CONSTRAINT_SCHEMA' ) );
+	}
+
+	/**
+	 * @since 3.1
+	 *
+	 * @param DataItem $dataItem
+	 * @param DIProperty $property
+	 *
+	 * @return SchemaList|[]
+	 */
+	public function newSchemaList( DataItem $dataItem, DIProperty $property ) {
 
 		$dataItems = $this->propertySpecificationLookup->getSpecification(
 			$dataItem,
-			new DIProperty( '_CONSTRAINT_SCHEMA' )
+			$property
 		);
 
 		if ( $dataItems === null || $dataItems === false ) {

--- a/src/Schema/docs/property.profile.md
+++ b/src/Schema/docs/property.profile.md
@@ -1,0 +1,30 @@
+## Objective
+
+The `PROPERTY_PROFILE_SCHEMA` schema type defines low level features sets for a property that assigns the schema using the declarative `Profile schema` property.
+
+## Properties
+
+- `type`
+- `profile` identifies the section that contains option definitions
+    - `sequence_map` to record the sequence of values (an ordered list of values) for the property that has the schema assigned
+- `tags` simple tags to categorize a schema
+
+### Example
+
+<pre>
+{
+    "type": "PROPERTY_PROFILE_SCHEMA",
+    "profile": {
+        "sequence_map": true
+    },
+    "tags": [
+        "option",
+        "property option",
+        "property profile"
+    ]
+}
+</pre>
+
+## Validation
+
+`/data/schema/property-profile-schema.v1.json`

--- a/src/TypesRegistry.php
+++ b/src/TypesRegistry.php
@@ -223,6 +223,7 @@ class TypesRegistry {
 			//
 			'_FORMAT_SCHEMA' => [ '_wps', true, true, false ], // "Formatter schema"
 			'_CONSTRAINT_SCHEMA' => [ ConstraintSchemaValue::TYPE_ID, true, true, true ], // "Constraint schema"
+			'_PROFILE_SCHEMA' => [ '_wps', true, true, true ], // "Profile schema"
 
 			// File attachment
 			'_ATTCH_LINK'  => [ '_wpg', true, false, false ], // "Attachment link"

--- a/tests/phpunit/Integration/JSONScript/Fixtures/p-1120-annotation-sequence-map.json
+++ b/tests/phpunit/Integration/JSONScript/Fixtures/p-1120-annotation-sequence-map.json
@@ -1,0 +1,9 @@
+{
+    "type": "PROPERTY_PROFILE_SCHEMA",
+    "profile": {
+        "sequence_map": true
+    },
+    "tags": [
+        "property profile"
+    ]
+}

--- a/tests/phpunit/Integration/JSONScript/TestCases/p-1120.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/p-1120.json
@@ -1,0 +1,91 @@
+{
+	"description": "Test `smw/schema` on `PROPERTY_PROFILE_SCHEMA` with `sequence_map`",
+	"setup": [
+		{
+			"namespace": "SMW_NS_SCHEMA",
+			"page": "Profile:AnnotationSequenceMap",
+			"contents": {
+				"import-from": "/../Fixtures/p-1120-annotation-sequence-map.json"
+			}
+		},
+		{
+			"namespace": "SMW_NS_PROPERTY",
+			"page": "Has authors",
+			"contents": "[[Has type::Text]] [[Profile schema::Profile:AnnotationSequenceMap]]"
+		},
+		{
+			"page": "P1120/1",
+			"contents": "[[Has authors::Zoe K.]] [[Has authors::Charlotte B.]] [[Has authors::Yui B.]] [[Category:P1120:1]] [[Has authors::Charlotte B.]]"
+		},
+		{
+			"page": "P1120/2",
+			"contents": "{{#subobject: |Has authors=Zoe K.,Charlotte B.,Yui B.,Charlotte B.|+sep=, |@category=P1120:2 }}"
+		},
+		{
+			"page": "P1120/3",
+			"contents": "{{#subobject: |Has authors=Charlotte B.,Zoe K.,Charlotte B.,Yui B.|+sep=, |@category=P1120:3 }}"
+		},
+		{
+			"page": "P1120/Q.1",
+			"contents": "{{#ask: [[Category:P1120:1]] [[Has authors::+]] |?Has authors |format=table |headers=plain }}"
+		},
+		{
+			"page": "P1120/Q.2",
+			"contents": "{{#ask: [[Category:P1120:2]] [[Has authors::+]] |?Has authors |format=table |headers=plain }}"
+		},
+		{
+			"page": "P1120/Q.3",
+			"contents": "{{#ask: [[Category:P1120:3]] [[Has authors::+]] |?Has authors |format=table |headers=plain }}"
+		}
+	],
+	"tests": [
+		{
+			"type": "parser",
+			"about": "#0",
+			"subject": "P1120/Q.1",
+			"assert-output": {
+				"to-contain": [
+					"<td class=\"Has-authors smwtype_txt\">Zoe K.<br />Charlotte B.<br />Yui B.</td>"
+				]
+			}
+		},
+		{
+			"type": "parser",
+			"about": "#1",
+			"subject": "P1120/Q.2",
+			"assert-output": {
+				"to-contain": [
+					"<td class=\"Has-authors smwtype_txt\">Zoe K.<br />Charlotte B.<br />Yui B.</td>"
+				]
+			}
+		},
+		{
+			"type": "parser",
+			"about": "#2",
+			"subject": "P1120/Q.3",
+			"assert-output": {
+				"to-contain": [
+					"<td class=\"Has-authors smwtype_txt\">Charlotte B.<br />Zoe K.<br />Yui B.</td>"
+				]
+			}
+		}
+	],
+	"settings": {
+		"wgContLang": "en",
+		"wgLang": "en",
+		"smwgPageSpecialProperties": [
+			"_MDAT"
+		],
+		"smwgNamespacesWithSemanticLinks": {
+			"NS_MAIN": true,
+			"NS_CATEGORY": true,
+			"SMW_NS_PROPERTY": true,
+			"SMW_NS_SCHEMA": true
+		}
+	},
+	"meta": {
+		"version": "2",
+		"is-incomplete": false,
+		"debug": false
+	}
+}

--- a/tests/phpunit/Unit/DataModel/SequenceMapTest.php
+++ b/tests/phpunit/Unit/DataModel/SequenceMapTest.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace SMW\Tests\DataModel;
+
+use SMW\DataModel\SequenceMap;
+use SMW\Tests\TestEnvironment;
+
+/**
+ * @covers \SMW\DataModel\SequenceMap
+ * @group semantic-mediawiki
+ *
+ * @license GNU GPL v2+
+ * @since 3.1
+ *
+ * @author mwjames
+ */
+class SequenceMapTest extends \PHPUnit_Framework_TestCase {
+
+	private $testEnvironment;
+	private $schemaFactory;
+
+	protected function setUp() {
+		parent::setUp();
+
+		$this->testEnvironment = new TestEnvironment();
+
+		$this->schemaFactory = $this->getMockBuilder( '\SMW\Schema\SchemaFactory' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$this->testEnvironment->registerObject( 'SchemaFactory', $this->schemaFactory );
+	}
+
+	public function testCanConstruct() {
+
+		$this->assertInstanceOf(
+			SequenceMap::class,
+			new SequenceMap()
+		);
+	}
+
+	public function testCanMap() {
+
+		$schemaList = $this->getMockBuilder( '\SMW\Schema\SchemaList' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$schemaList->expects( $this->atLeastOnce() )
+			->method( 'get' )
+			->with( $this->equalTo( 'profile' ) )
+			->will( $this->returnValue( [ 'sequence_map' => true ] ) );
+
+		$schemaFinder = $this->getMockBuilder( '\SMW\Schema\SchemaFinder' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$schemaFinder->expects( $this->atLeastOnce() )
+			->method( 'newSchemaList' )
+			->will( $this->returnValue( $schemaList ) );
+
+		$this->schemaFactory->expects( $this->atLeastOnce() )
+			->method( 'newSchemaFinder' )
+			->will( $this->returnValue( $schemaFinder ) );
+
+		$property = $this->getMockBuilder( '\SMW\DIProperty' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$this->assertTrue(
+			SequenceMap::canMap( $property )
+		);
+	}
+
+}

--- a/tests/phpunit/Unit/MediaWiki/Hooks/ArticleProtectCompleteTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Hooks/ArticleProtectCompleteTest.php
@@ -33,6 +33,10 @@ class ArticleProtectCompleteTest extends \PHPUnit_Framework_TestCase {
 		$this->spyLogger = $this->testEnvironment->getUtilityFactory()->newSpyLogger();
 		$this->semanticDataFactory = $this->testEnvironment->getUtilityFactory()->newSemanticDataFactory();
 
+		$propertySpecificationLookup = $this->getMockBuilder( '\SMW\Property\SpecificationLookup' )
+			->disableOriginalConstructor()
+			->getMock();
+
 		$store = $this->getMockBuilder( '\SMW\Store' )
 			->disableOriginalConstructor()
 			->getMockForAbstractClass();
@@ -51,6 +55,7 @@ class ArticleProtectCompleteTest extends \PHPUnit_Framework_TestCase {
 			->will( $this->returnValue( $idTable ) );
 
 		$this->testEnvironment->registerObject( 'Store', $store );
+		$this->testEnvironment->registerObject( 'PropertySpecificationLookup', $propertySpecificationLookup );
 
 		$this->editInfo = $this->getMockBuilder( '\SMW\MediaWiki\EditInfo' )
 			->disableOriginalConstructor()

--- a/tests/phpunit/Unit/SQLStore/EntityStore/EntityIdManagerTest.php
+++ b/tests/phpunit/Unit/SQLStore/EntityStore/EntityIdManagerTest.php
@@ -66,6 +66,10 @@ class EntityIdManagerTest extends \PHPUnit_Framework_TestCase {
 			->disableOriginalConstructor()
 			->getMock();
 
+		$this->sequenceMapFinder = $this->getMockBuilder( '\SMW\SQLStore\EntityStore\SequenceMapFinder' )
+			->disableOriginalConstructor()
+			->getMock();
+
 		$this->connection = $this->getMockBuilder( '\SMW\MediaWiki\Database' )
 			->disableOriginalConstructor()
 			->getMock();
@@ -115,6 +119,10 @@ class EntityIdManagerTest extends \PHPUnit_Framework_TestCase {
 		$this->factory->expects( $this->any() )
 			->method( 'newPropertyTableHashes' )
 			->will( $this->returnValue( $this->propertyTableHashes ) );
+
+		$this->factory->expects( $this->any() )
+			->method( 'newSequenceMapFinder' )
+			->will( $this->returnValue( $this->sequenceMapFinder ) );
 
 		$this->entityIdFinder = $this->getMockBuilder( '\SMW\SQLStore\EntityStore\EntityIdFinder' )
 			->setConstructorArgs( [ $this->connection, $this->propertyTableHashes, $idCacheManager ] )
@@ -508,6 +516,50 @@ class EntityIdManagerTest extends \PHPUnit_Framework_TestCase {
 			1001,
 			$instance->findAssociatedRev( 'Foo', NS_MAIN, '', '' )
 		);
+	}
+
+	public function testSetSequenceMap() {
+
+		$this->sequenceMapFinder->expects( $this->once() )
+			->method( 'setMap' )
+			->with(
+				$this->equalTo( 42 ),
+				$this->equalTo( [ 'Foo' ] ) );
+
+		$instance = new EntityIdManager(
+			$this->store,
+			$this->factory
+		);
+
+		$instance->setSequenceMap( 42, [ 'Foo' ] );
+	}
+
+	public function testGetSequenceMap() {
+
+		$this->sequenceMapFinder->expects( $this->once() )
+			->method( 'findMapById' )
+			->with( $this->equalTo( 1001 ) );
+
+		$instance = new EntityIdManager(
+			$this->store,
+			$this->factory
+		);
+
+		$instance->getSequenceMap( 1001 );
+	}
+
+	public function testLoadSequenceMap() {
+
+		$this->sequenceMapFinder->expects( $this->once() )
+			->method( 'prefetchSequenceMap' )
+			->with( $this->equalTo( [ 42, 1001 ] ) );
+
+		$instance = new EntityIdManager(
+			$this->store,
+			$this->factory
+		);
+
+		$instance->loadSequenceMap( [ 42, 1001 ] );
 	}
 
 	public function pageIdandSortProvider() {

--- a/tests/phpunit/Unit/SQLStore/EntityStore/IdChangerTest.php
+++ b/tests/phpunit/Unit/SQLStore/EntityStore/IdChangerTest.php
@@ -75,6 +75,10 @@ class IdChangerTest extends \PHPUnit_Framework_TestCase {
 
 	public function testMove_ZeroTarget() {
 
+		if ( !method_exists( '\PHPUnit_Framework_MockObject_Builder_InvocationMocker', 'withConsecutive' ) ) {
+			$this->markTestSkipped( 'PHPUnit_Framework_MockObject_Builder_InvocationMocker::withConsecutive requires PHPUnit 5.7+.' );
+		}
+
 		$row = [
 			'smw_id' => 42,
 			'smw_title' => 'Foo',
@@ -108,11 +112,11 @@ class IdChangerTest extends \PHPUnit_Framework_TestCase {
 			->method( 'insertId' )
 			->will( $this->returnValue( 9999 ) );
 
-		$this->connection->expects( $this->once() )
+		$this->connection->expects( $this->any() )
 			->method( 'delete' )
-			->with(
-				$this->anything(),
-				$this->equalTo( [ 'smw_id' => 42 ] ) );
+			->withConsecutive(
+				[ $this->equalTo( 'smw_object_aux' ), $this->equalTo( [ 'smw_id' => 42 ] ) ],
+				[ $this->equalTo( 'smw_object_ids' ), $this->equalTo( [ 'smw_id' => 42 ] ) ] );
 
 		$this->store->expects( $this->any() )
 			->method( 'getPropertyTables' )
@@ -136,6 +140,10 @@ class IdChangerTest extends \PHPUnit_Framework_TestCase {
 	}
 
 	public function testMove_Target() {
+
+		if ( !method_exists( '\PHPUnit_Framework_MockObject_Builder_InvocationMocker', 'withConsecutive' ) ) {
+			$this->markTestSkipped( 'PHPUnit_Framework_MockObject_Builder_InvocationMocker::withConsecutive requires PHPUnit 5.7+.' );
+		}
 
 		$row = [
 			'smw_id' => 42,
@@ -162,11 +170,11 @@ class IdChangerTest extends \PHPUnit_Framework_TestCase {
 				$this->anything(),
 				$this->equalTo( [ 'smw_id' => 1001 ] + $row ) );
 
-		$this->connection->expects( $this->once() )
+		$this->connection->expects( $this->any() )
 			->method( 'delete' )
-			->with(
-				$this->anything(),
-				$this->equalTo( [ 'smw_id' => 42 ] ) );
+			->withConsecutive(
+				[ $this->equalTo( 'smw_object_aux' ), $this->equalTo( [ 'smw_id' => 42 ] ) ],
+				[ $this->equalTo( 'smw_object_ids' ), $this->equalTo( [ 'smw_id' => 42 ] ) ] );
 
 		$this->store->expects( $this->any() )
 			->method( 'getPropertyTables' )

--- a/tests/phpunit/Unit/SQLStore/EntityStore/PrefetchItemLookupTest.php
+++ b/tests/phpunit/Unit/SQLStore/EntityStore/PrefetchItemLookupTest.php
@@ -58,9 +58,13 @@ class PrefetchItemLookupTest extends \PHPUnit_Framework_TestCase {
 			DIWikiPage::newFromText( __METHOD__ ),
 		];
 
-		$idTable = $this->getMockBuilder( '\SMW\SQLStore\EntityStore\EntityIdManager' )
+		$entityIdManager = $this->getMockBuilder( '\SMW\SQLStore\EntityStore\EntityIdManager' )
 			->disableOriginalConstructor()
 			->getMock();
+
+		$entityIdManager->expects( $this->atLeastOnce() )
+			->method( 'getSequenceMap' )
+			->will( $this->returnValue( [] ) );
 
 		$diHandler = $this->getMockBuilder( '\SMW\SQLStore\EntityStore\DataItemHandler' )
 			->disableOriginalConstructor()
@@ -88,7 +92,7 @@ class PrefetchItemLookupTest extends \PHPUnit_Framework_TestCase {
 
 		$this->store->expects( $this->atLeastOnce() )
 			->method( 'getObjectIds' )
-			->will( $this->returnValue( $idTable ) );
+			->will( $this->returnValue( $entityIdManager ) );
 
 		$this->semanticDataLookup->expects( $this->atLeastOnce() )
 			->method( 'prefetchDataFromTable' )

--- a/tests/phpunit/Unit/SQLStore/EntityStore/SequenceMapFinderTest.php
+++ b/tests/phpunit/Unit/SQLStore/EntityStore/SequenceMapFinderTest.php
@@ -1,0 +1,141 @@
+<?php
+
+namespace SMW\Tests\SQLStore\EntityStore;
+
+use SMW\SQLStore\EntityStore\SequenceMapFinder;
+
+/**
+ * @covers \SMW\SQLStore\EntityStore\SequenceMapFinder
+ * @group semantic-mediawiki
+ *
+ * @license GNU GPL v2+
+ * @since   3.1
+ *
+ * @author mwjames
+ */
+class SequenceMapFinderTest extends \PHPUnit_Framework_TestCase {
+
+	private $cache;
+	private $idCacheManager;
+	private $conection;
+
+	protected function setUp() {
+
+		$this->cache = $this->getMockBuilder( '\Onoi\Cache\Cache' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$this->idCacheManager = $this->getMockBuilder( '\SMW\SQLStore\EntityStore\IdCacheManager' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$this->idCacheManager->expects( $this->any() )
+			->method( 'get' )
+			->will( $this->returnValue( $this->cache ) );
+
+		$this->connection = $this->getMockBuilder( '\SMW\MediaWiki\Database' )
+			->disableOriginalConstructor()
+			->getMock();
+	}
+
+	public function testCanConstruct() {
+
+		$this->assertInstanceOf(
+			SequenceMapFinder::class,
+			new SequenceMapFinder( $this->connection, $this->idCacheManager )
+		);
+	}
+
+	public function testSetMap() {
+
+		$row = [
+			'smw_id' => 42,
+			'smw_seqmap' => null
+		];
+
+		$this->connection->expects( $this->once() )
+			->method( 'upsert' )
+			->with(
+				$this->anything(),
+				$this->equalTo( $row ),
+				$this->equalTo( [ 'smw_id' ] ),
+				$this->equalTo( $row ) );
+
+		$instance = new SequenceMapFinder(
+			$this->connection,
+			$this->idCacheManager
+		);
+
+		$instance->setMap( 42, [ 'Foo' ] );
+	}
+
+	public function testFindMapById() {
+
+		$map = \SMW\Utils\HmacSerializer::compress( [ 'Foo' ] );
+
+		$row = [
+			'smw_id' => 1001,
+			'smw_seqmap' => $map
+		];
+
+		$this->cache->expects( $this->once() )
+			->method( 'fetch' )
+			->will( $this->returnValue( false ) );
+
+		$this->connection->expects( $this->once() )
+			->method( 'selectRow' )
+			->will( $this->returnValue( (object)$row ) );
+
+		$this->connection->expects( $this->once() )
+			->method( 'unescape_bytea' )
+			->will( $this->returnArgument( 0 ) );
+
+		$instance = new SequenceMapFinder(
+			$this->connection,
+			$this->idCacheManager
+		);
+
+		$sortkey = '';
+
+		$this->assertEquals(
+			[ 'Foo' ],
+			$instance->findMapById( 1001 )
+		);
+	}
+
+	public function testPrefetchSequenceMap() {
+
+		$map = \SMW\Utils\HmacSerializer::compress( [ 'Foo' ] );
+
+		$row = [
+			'smw_id' => 1001,
+			'smw_seqmap' => $map
+		];
+
+		$this->cache->expects( $this->at( 0 ) )
+			->method( 'save' )
+			->with(
+				$this->equalTo( 1001 ),
+				$this->equalTo( [ 'Foo' ] ) );
+
+		$this->connection->expects( $this->once() )
+			->method( 'select' )
+			->with(
+				$this->anything(),
+				$this->equalTo( [ 'smw_id', 'smw_seqmap'] ),
+				$this->equalTo( [ 'smw_id' => [ 42, 1001 ] ] ) )
+			->will( $this->returnValue( [ (object)$row ] ) );
+
+		$this->connection->expects( $this->once() )
+			->method( 'unescape_bytea' )
+			->will( $this->returnArgument( 0 ) );
+
+		$instance = new SequenceMapFinder(
+			$this->connection,
+			$this->idCacheManager
+		);
+
+		$instance->prefetchSequenceMap( [ 42, 1001 ] );
+	}
+
+}

--- a/tests/phpunit/Unit/SQLStore/PropertyTableIdReferenceDisposerTest.php
+++ b/tests/phpunit/Unit/SQLStore/PropertyTableIdReferenceDisposerTest.php
@@ -286,6 +286,7 @@ class PropertyTableIdReferenceDisposerTest extends \PHPUnit_Framework_TestCase {
 			->method( 'delete' )
 			->withConsecutive(
 				[ $this->equalTo( SQLStore::ID_TABLE ) ],
+				[ $this->equalTo( SQLStore::ID_AUXILIARY_TABLE ) ],
 				[ $this->equalTo( SQLStore::PROPERTY_STATISTICS_TABLE ) ],
 				[ $this->equalTo( SQLStore::QUERY_LINKS_TABLE ) ],
 				[ $this->equalTo( SQLStore::QUERY_LINKS_TABLE ) ],
@@ -338,6 +339,7 @@ class PropertyTableIdReferenceDisposerTest extends \PHPUnit_Framework_TestCase {
 		$connection->expects( $this->atLeastOnce() )
 			->method( 'delete' )
 			->withConsecutive(
+				[ $this->equalTo( SQLStore::ID_AUXILIARY_TABLE ) ],
 				[ $this->equalTo( SQLStore::PROPERTY_STATISTICS_TABLE ) ],
 				[ $this->equalTo( SQLStore::QUERY_LINKS_TABLE ) ],
 				[ $this->equalTo( SQLStore::QUERY_LINKS_TABLE ) ],

--- a/tests/phpunit/Unit/SQLStore/SQLStoreFactoryTest.php
+++ b/tests/phpunit/Unit/SQLStore/SQLStoreFactoryTest.php
@@ -313,6 +313,28 @@ class SQLStoreFactoryTest extends \PHPUnit_Framework_TestCase {
 		);
 	}
 
+	public function testCanConstructSequenceMapFinder() {
+
+		$connection = $this->getMockBuilder( '\SMW\MediaWiki\Database' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$this->store->expects( $this->once() )
+			->method( 'getConnection' )
+			->will( $this->returnValue( $connection ) );
+
+		$idCacheManager = $this->getMockBuilder( '\SMW\SQLStore\EntityStore\IdCacheManager' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$instance = new SQLStoreFactory( $this->store );
+
+		$this->assertInstanceOf(
+			'\SMW\SQLStore\EntityStore\SequenceMapFinder',
+			$instance->newSequenceMapFinder( $idCacheManager )
+		);
+	}
+
 	public function testCanConstructCacheWarmer() {
 
 		$idCacheManager = $this->getMockBuilder( '\SMW\SQLStore\EntityStore\IdCacheManager' )

--- a/tests/phpunit/Unit/Schema/SchemaFinderTest.php
+++ b/tests/phpunit/Unit/Schema/SchemaFinderTest.php
@@ -101,4 +101,35 @@ class SchemaFinderTest extends \PHPUnit_Framework_TestCase {
 		);
 	}
 
+	public function testNewSchemaList() {
+
+		$subject = DIWikiPage::newFromText( 'Bar', SMW_NS_PROPERTY );
+
+		$data[] = new DIBlob( json_encode( [ 'Foo' => [ 'Bar' => 42 ], 1001 ] ) );
+
+		$this->propertySpecificationLookup->expects( $this->at( 0 ) )
+			->method( 'getSpecification' )
+			->with(
+				$this->equalTo( new DIProperty( 'Foo' ) ),
+				$this->equalTo( new DIProperty( 'BAR' ) ) )
+			->will( $this->onConsecutiveCalls( [ $subject ] ) );
+
+		$this->propertySpecificationLookup->expects( $this->at( 1 ) )
+			->method( 'getSpecification' )
+			->with(
+				$this->equalTo( $subject ),
+				$this->equalTo( new DIProperty( '_SCHEMA_DEF' ) ) )
+			->will( $this->onConsecutiveCalls( [ $data[0] ] ) );
+
+		$instance = new SchemaFinder(
+			$this->store,
+			$this->propertySpecificationLookup
+		);
+
+		$this->assertInstanceOf(
+			'\SMW\Schema\SchemaList',
+			$instance->newSchemaList( new DIProperty( 'Foo' ), new DIProperty( 'BAR' ) )
+		);
+	}
+
 }

--- a/tests/phpunit/includes/SubobjectTest.php
+++ b/tests/phpunit/includes/SubobjectTest.php
@@ -4,7 +4,7 @@ namespace SMW\Tests;
 
 use SMW\DataValueFactory;
 use SMW\Subobject;
-use SMW\Tests\Utils\UtilityFactory;
+use SMW\Tests\TestEnvironment;
 use SMWDIBlob;
 use Title;
 
@@ -28,7 +28,15 @@ class SubobjectTest extends \PHPUnit_Framework_TestCase {
 	protected function setUp() {
 		parent::setUp();
 
-		$this->semanticDataValidator = UtilityFactory::getInstance()->newValidatorFactory()->newSemanticDataValidator();
+		$this->testEnvironment = new TestEnvironment();
+
+		$propertySpecificationLookup = $this->getMockBuilder( '\SMW\Property\SpecificationLookup' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$this->semanticDataValidator = $this->testEnvironment->getUtilityFactory()->newValidatorFactory()->newSemanticDataValidator();
+
+		$this->testEnvironment->registerObject( 'PropertySpecificationLookup', $propertySpecificationLookup );
 	}
 
 	public function testCanConstruct() {


### PR DESCRIPTION
This PR is made in reference to: #4226

This PR addresses or contains:

- ~~Unit tests are missing~~, integration test added to ensure DB related queries do work and pass on all systems
- An order map isn't available by default, a property that requires an order map has to assign a `Profile schema` with something like `[[Profile schema::MyProfileSchema]]` where the `MyProfileSchema` schema defines that `sequence_map` is enabled
- Any existing properties that want to use this feature need to run `rebuildData.php` as it requires to build up the new table (`smw_object_aux`) and field (`smw_seqmap`) from the ground

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed

Fixes #4226