### PR TITLE
Avoid overriding `smw_rev`, `smw_touched` during setup, refs 3390, 3644

### DIFF
--- a/src/SQLStore/TableBuilder/Examiner/PredefinedProperties.php
+++ b/src/SQLStore/TableBuilder/Examiner/PredefinedProperties.php
@@ -120,7 +120,9 @@ class PredefinedProperties {
 			SQLStore::ID_TABLE,
 			[
 				'smw_proptable_hash',
-				'smw_hash'
+				'smw_hash',
+				'smw_rev',
+				'smw_touched'
 			],
 			[
 				'smw_id' => $id
@@ -129,7 +131,12 @@ class PredefinedProperties {
 		);
 
 		if ( $row === false ) {
-			$row = (object)[ 'smw_proptable_hash' => null, 'smw_hash' => null ];
+			$row = (object)[
+				'smw_proptable_hash' => null,
+				'smw_hash' => null,
+				'smw_rev' => null,
+				'smw_touched' => $connection->timestamp( '1970-01-01 00:00:00' )
+			];
 		}
 
 		$connection->replace(
@@ -144,7 +151,9 @@ class PredefinedProperties {
 				'smw_sortkey' => $label,
 				'smw_sort' => Collator::singleton()->getSortKey( $label ),
 				'smw_proptable_hash' => $row->smw_proptable_hash,
-				'smw_hash' => $row->smw_hash
+				'smw_hash' => $row->smw_hash,
+				'smw_rev' => $row->smw_rev,
+				'smw_touched' => $row->smw_touched
 			],
 			__METHOD__
 		);

--- a/tests/phpunit/Unit/Elastic/ElasticStoreTest.php
+++ b/tests/phpunit/Unit/Elastic/ElasticStoreTest.php
@@ -46,6 +46,8 @@ class ElasticStoreTest extends \PHPUnit_Framework_TestCase {
 		$row->smw_id = \SMW\SQLStore\SQLStore::FIXED_PROPERTY_ID_UPPERBOUND;
 		$row->smw_proptable_hash = 'foo';
 		$row->smw_hash = 42;
+		$row->smw_rev = null;
+		$row->smw_touched = null;
 		$row->count = 0;
 
 		$connection = $this->getMockBuilder( '\SMW\MediaWiki\Database' )

--- a/tests/phpunit/Unit/SQLStore/TableBuilder/Examiner/PredefinedPropertiesTest.php
+++ b/tests/phpunit/Unit/SQLStore/TableBuilder/Examiner/PredefinedPropertiesTest.php
@@ -42,7 +42,9 @@ class PredefinedPropertiesTest extends \PHPUnit_Framework_TestCase {
 			'smw_id' => 42,
 			'smw_iw' => '',
 			'smw_proptable_hash' => '',
-			'smw_hash' => ''
+			'smw_hash' => '',
+			'smw_rev' => null,
+			'smw_touched' => ''
 		];
 
 		$idTable = $this->getMockBuilder( '\stdClass' )
@@ -95,7 +97,9 @@ class PredefinedPropertiesTest extends \PHPUnit_Framework_TestCase {
 			'smw_id' => 42,
 			'smw_iw' => '',
 			'smw_proptable_hash' => '',
-			'smw_hash' => ''
+			'smw_hash' => '',
+			'smw_rev' => null,
+			'smw_touched' => ''
 		];
 
 		$idTable = $this->getMockBuilder( '\stdClass' )


### PR DESCRIPTION
This PR is made in reference to: #3390, #3644

This PR addresses or contains:

- If a predefined property exists then also check for `smw_rev`, `smw_touched`.

This PR includes:
- [ ] Tests (unit/integration)
- [x] CI build passed

Replication monitoring in ES would show a revision in ES but not in SMW after running `setupStore.php` and the reason is that those fields were overridden.

![image](https://user-images.githubusercontent.com/1245473/62839495-1d975600-bc7a-11e9-831f-e5ba524624fc.png)
