### PR TITLE
[ES] Show user readable property label, refs 3837

### DIFF
--- a/src/Elastic/Indexer/Replication/CheckReplicationTask.php
+++ b/src/Elastic/Indexer/Replication/CheckReplicationTask.php
@@ -198,6 +198,13 @@ class CheckReplicationTask extends Task {
 		$title = $subject->getTitle();
 		$html = '';
 
+		// Show a user readable representation especially when referring
+		// to a predefined property
+		if ( $subject->getNamespace() === SMW_NS_PROPERTY ) {
+			$property = DIProperty::newFromUserLabel( $subject->getDBKey() );
+			$title = $property->getDiWikiPage()->getTitle();
+		}
+
 		if ( $result !== [] && isset( $result['exception'] ) ) {
 			$html = $this->exceptionErrorMsg( $result['exception'] );
 		} elseif ( $result !== [] && isset( $result['modification_date_missing'] ) ) {


### PR DESCRIPTION
This PR is made in reference to: #3837

This PR addresses or contains:

This PR includes:
- [ ] Tests (unit/integration)
- [x] CI build passed

### Example

The issue that caught my eye which should show a readable property label.

![image](https://user-images.githubusercontent.com/1245473/62839260-6699db00-bc77-11e9-970e-c05d4ab265bb.png)
