### PR TITLE
Support subtabs, refs 3308

### DIFF
--- a/res/smw/ext.smw.js
+++ b/res/smw/ext.smw.js
@@ -31,6 +31,16 @@
 var smw = ( function ( $, undefined ) {
 	'use strict';
 
+	/**
+	 * Start as early as possible to attach any registered subtabs
+	 */
+	var x = document.getElementsByClassName( "smw-subtab" );
+	var i;
+
+	for ( i = 0; i < x.length; i++ ) {
+		x[i].innerHTML = JSON.parse( x[i].dataset.subtab ) + x[i].innerHTML;
+	}
+
 	/*global console:true message:true */
 
 	/**

--- a/res/smw/ext.smw.tabs.css
+++ b/res/smw/ext.smw.tabs.css
@@ -31,7 +31,7 @@
 	clear: both;
 }
 
-.smw-tabs section {
+.smw-tabs section, .smw-tabs .subtab-content {
 	display: none;
 	padding: 0 0 0 0;
 	border-top: 1px solid #ddd;

--- a/tests/phpunit/Unit/Utils/HtmlTabsTest.php
+++ b/tests/phpunit/Unit/Utils/HtmlTabsTest.php
@@ -32,6 +32,27 @@ class HtmlTabsTest extends \PHPUnit_Framework_TestCase {
 		);
 	}
 
+	public function testTab_Contents_Subtab() {
+
+		$instance = new HtmlTabs();
+		$instance->setActiveTab( 'foo' );
+		$instance->isSubTab();
+
+		$instance->tab( 'foo', 'FOO' );
+		$instance->content( 'foo', '< ... bar ... >' );
+
+		$this->assertContains(
+			'<div class="smw-tabs smw-subtab foo-bar" ' .
+			'data-subtab="&quot;&lt;input id=\&quot;tab-foo\&quot; ' .
+			'class=\&quot;nav-tab\&quot; type=\&quot;radio\&quot; ' .
+			'name=\&quot;tabs\&quot; checked=\&quot;\&quot;\/&gt;&lt;label ' .
+			'id=\&quot;tab-label-foo\&quot; for=\&quot;tab-foo\&quot; ' .
+			'class=\&quot;nav-label\&quot;&gt;FOO&lt;\/label&gt;&quot;">' .
+			'<div id="tab-content-foo" class="subtab-content">< ... bar ... ></div></div>',
+			$instance->buildHTML( [ 'class' => 'foo-bar' ] )
+		);
+	}
+
 	public function testTab_Contents_AutoChecked() {
 
 		$instance = new HtmlTabs();


### PR DESCRIPTION
This PR is made in reference to: #3308

This PR addresses or contains:

- The MW Parser messes up section elements when part of a hierarchy or sub level therefore work around this issue by using JS to inject the specific HTML after the parser as finalized the page build

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed
