### PR TITLE
Add `_wpu` internal type to represent NS_USER

### DIFF
--- a/includes/datavalues/SMW_DV_WikiPage.php
+++ b/includes/datavalues/SMW_DV_WikiPage.php
@@ -113,6 +113,9 @@ class SMWWikiPageValue extends SMWDataValue {
 			case '_wps' :
 				$this->m_fixNamespace = SMW_NS_SCHEMA;
 			break;
+			case '_wpu' :
+				$this->m_fixNamespace = NS_USER;
+			break;
 			default: // case '_wpg':
 				$this->m_fixNamespace = NS_MAIN;
 		}
@@ -473,7 +476,7 @@ class SMWWikiPageValue extends SMWDataValue {
 			$text = $this->getText();
 		} elseif ( $this->getOption( self::PREFIXED_FORM, false ) ) {
 			$text = $this->getPrefixedText();
-		} elseif ( in_array( $this->getTypeID(), [ '_wpp', '_wps' ] ) || $this->m_fixNamespace == NS_MAIN ) {
+		} elseif ( in_array( $this->getTypeID(), [ '_wpp', '_wps', '_wpu' ] ) || $this->m_fixNamespace == NS_MAIN ) {
 			$text = $this->getPrefixedText();
 		} else {
 			$text = $this->getText();

--- a/src/TypesRegistry.php
+++ b/src/TypesRegistry.php
@@ -82,6 +82,8 @@ class TypesRegistry {
 			'_wpf' => [ 'SMWWikiPageValue', DataItem::TYPE_WIKIPAGE, false, true ],
 			 // smw/schema page
 			'_wps'  => [ 'SMWWikiPageValue', DataItem::TYPE_WIKIPAGE, false, true ],
+			 // User page
+			'_wpu'  => [ 'SMWWikiPageValue', DataItem::TYPE_WIKIPAGE, false, true ],
 			// __cschema
 			ConstraintSchemaValue::TYPE_ID => [ ConstraintSchemaValue::class, DataItem::TYPE_WIKIPAGE, false, true ],
 			 // Number type


### PR DESCRIPTION
This PR is made in reference to: #

This PR addresses or contains:

- Adds `_wpu` as internal type, only predefined properties can make use this type when it is clear that the input should always contain a reference to something in the NS_USER namespace

This PR includes:
- [ ] Tests (unit/integration)
- [x] CI build passed
