### PR TITLE
Register property alias from key with content language immediately

### DIFF
--- a/src/PropertyAliasFinder.php
+++ b/src/PropertyAliasFinder.php
@@ -45,6 +45,11 @@ class PropertyAliasFinder {
 	private $canonicalPropertyAliases = [];
 
 	/**
+	 * @var string
+	 */
+	private $contentLanguageCode = 'en';
+
+	/**
 	 * @since 2.4
 	 *
 	 * @param Cache $cache
@@ -58,6 +63,15 @@ class PropertyAliasFinder {
 		foreach ( $propertyAliases as $alias => $id ) {
 			$this->registerAliasByFixedLabel( $id, $alias );
 		}
+	}
+
+	/**
+	 * @since 3.1
+	 *
+	 * @param string $contentLanguageCode
+	 */
+	public function setContentLanguageCode( $contentLanguageCode ) {
+		$this->contentLanguageCode = $contentLanguageCode;
 	}
 
 	/**
@@ -144,6 +158,13 @@ class PropertyAliasFinder {
 	 */
 	public function registerAliasByMsgKey( $id, $msgKey ) {
 		$this->propertyAliasesByMsgKey[$msgKey] = $id;
+
+		// Make sure the label is resolved and registered immediately
+		// for the content language
+		$this->registerAliasByFixedLabel(
+			$id,
+			Message::get( $msgKey, Message::TEXT, $this->contentLanguageCode )
+		);
 	}
 
 	/**

--- a/src/PropertyRegistry.php
+++ b/src/PropertyRegistry.php
@@ -70,13 +70,18 @@ class PropertyRegistry {
 			return self::$instance;
 		}
 
+		$localizer = Localizer::getInstance();
 		$applicationFactory = ApplicationFactory::getInstance();
-		$lang = Localizer::getInstance()->getLang();
+		$lang = $localizer->getLang();
 
 		$propertyAliasFinder = new PropertyAliasFinder(
 			$applicationFactory->getCache(),
 			$lang->getPropertyAliases(),
 			$lang->getCanonicalPropertyAliases()
+		);
+
+		$propertyAliasFinder->setContentLanguageCode(
+			$localizer->getContentLanguage()->getCode()
 		);
 
 		$settings = $applicationFactory->getSettings();

--- a/tests/phpunit/Unit/PropertyAliasFinderTest.php
+++ b/tests/phpunit/Unit/PropertyAliasFinderTest.php
@@ -90,6 +90,22 @@ class PropertyAliasFinderTest extends \PHPUnit_Framework_TestCase {
 		);
 	}
 
+	public function testRegisterAliasByFixedLabel_withContentLanguage() {
+
+		$instance = new PropertyAliasFinder(
+			$this->cache
+		);
+
+		$instance->setContentLanguageCode( 'en' );
+
+		$instance->registerAliasByMsgKey( '_Foo', 'smw-bar' );
+
+		$this->assertEquals(
+			[ '⧼smw-bar⧽' => '_Foo' ],
+			$instance->getKnownPropertyAliases()
+		);
+	}
+
 	public function testGetKnownPropertyAliasesByLanguageCodeCached() {
 
 		$this->cache->expects( $this->once() )
@@ -100,11 +116,17 @@ class PropertyAliasFinderTest extends \PHPUnit_Framework_TestCase {
 			$this->cache
 		);
 
+		$instance->setContentLanguageCode( 'en' );
 		$instance->registerAliasByMsgKey( '_Foo', 'smw-bar' );
 
 		$this->assertEquals(
 			[ '⧼smw-bar⧽' => '_Foo' ],
 			$instance->getKnownPropertyAliasesByLanguageCode( 'en' )
+		);
+
+		$this->assertEquals(
+			[ '⧼smw-bar⧽' => '_Foo' ],
+			$instance->getKnownPropertyAliases()
 		);
 	}
 


### PR DESCRIPTION
This PR is made in reference to: #

This PR addresses or contains:

- Ensures that matching happens on the content language and resolves an alias on all instances not only when `getKnownPropertyAliasesByLanguageCode` is called

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed
