### PR TITLE
Add `SMW::Maintenance::AfterUpdateEntityCollationComplete` hook

### DIFF
--- a/docs/technical/hooks.md
+++ b/docs/technical/hooks.md
@@ -62,6 +62,7 @@ Implementing a hook should be made in consideration of the expected performance 
 - [`SMW::ResultFormat::OverrideDefaultFormat`][hook.resultformat.overridedefaultformat] to override the default result format handling
 - [`SMW::Job::AfterUpdateDispatcherJobComplete`][hook.job.afterupdatedispatcherjobcomplete] to add additional update jobs for a property and related subjects
 - [`SMW::Exporter::Controller::AddExpData`][hook.exporter.controller.addexpdata] to add additional RDF data for a selected subject
+- [`SMW::Maintenance::AfterUpdateEntityCollationComplete`][hook.maintenance.afterupdateentitycollationcomplete] runs after the `updateEntityCollection.php` script has finished processing the update of entity collation changes
 
 ## Deprecated hooks
 
@@ -114,3 +115,4 @@ Implementing a hook should be made in consideration of the expected performance 
 [hook.event.registereventlisteners]:https://github.com/SemanticMediaWiki/SemanticMediaWiki/blob/master/docs/technical/hooks/hook.event.registereventlisteners.md
 [hook.resultformat.overridedefaultformat]:https://github.com/SemanticMediaWiki/SemanticMediaWiki/blob/master/docs/technical/hooks/hook.resultformat.overridedefaultformat.md
 [hook.constraint.initconstraints]:https://github.com/SemanticMediaWiki/SemanticMediaWiki/blob/master/docs/technical/hooks/hook.constraint.initconstraints.md
+[hook.maintenance.afterupdateentitycollationcomplete]:https://github.com/SemanticMediaWiki/SemanticMediaWiki/blob/master/docs/technical/hooks/hook.maintenance.afterupdateentitycollationcomplete.md

--- a/docs/technical/hooks/hook.maintenance.afterupdateentitycollationcomplete.md.md
+++ b/docs/technical/hooks/hook.maintenance.afterupdateentitycollationcomplete.md.md
@@ -1,0 +1,25 @@
+## SMW::Maintenance::AfterUpdateEntityCollationComplete
+
+* Since: 3.1
+* Description: Hook to allow to run other updates after the `updateEntityCollection.php` script has finished processing the update of entity collation changes
+* Reference class: [`updateEntityCollation.php`][updateEntityCollation.php]
+
+### Signature
+
+```php
+use Hooks;
+use SMW\Store;
+use Onoi\MessageReporter\MessageReporter;
+
+Hooks::register( 'SMW::Maintenance::AfterUpdateEntityCollationComplete', function( Store $store, MessageReporter $messageReporter ) {
+
+	return true;
+} );
+```
+
+## See also
+
+- See the [`ElasticFactory.php`][ElasticFactory.php] for an implementation example
+
+[updateEntityCollation.php]:https://github.com/SemanticMediaWiki/SemanticMediaWiki/blob/master/maintenance/updateEntityCollation.php
+[ElasticFactory.php]:https://github.com/SemanticMediaWiki/SemanticMediaWiki/blob/master/src/Elastic/ElasticFactory.php

--- a/src/Elastic/Hooks/UpdateEntityCollationComplete.php
+++ b/src/Elastic/Hooks/UpdateEntityCollationComplete.php
@@ -1,0 +1,140 @@
+<?php
+
+namespace SMW\Elastic\Hooks;
+
+use Onoi\MessageReporter\MessageReporter;
+use SMW\Store;
+use SMW\Elastic\Indexer\Rebuilder;
+
+/**
+ * @license GNU GPL v2+
+ * @since 3.1
+ *
+ * @author mwjames
+ */
+class UpdateEntityCollationComplete {
+
+	/**
+	 * @var Store
+	 */
+	private $store;
+
+	/**
+	 * @var MessageReporter
+	 */
+	private $messageReporter;
+
+	/**
+	 * @since 3.1
+	 *
+	 * @param Store $store
+	 * @param MessageReporter $messageReporter
+	 */
+	public function __construct( Store $store, MessageReporter $messageReporter ) {
+		$this->store = $store;
+		$this->messageReporter = $messageReporter;
+	}
+
+	/**
+	 * @since 3.1
+	 *
+	 * @param Rebuilder $rebuilder
+	 */
+	public function runUpdate( Rebuilder $rebuilder ) {
+
+		$this->messageReporter->reportMessage(
+			"\nThe entity collation was updated which requires to rebuild\n" .
+			"the Elasticsearch indicies as well to reflect those changes\n" .
+			"therefore a rebuild is planned to run shortly.\n"
+		);
+
+		$this->messageReporter->reportMessage(
+			"\nAbort the rebuild with control-c in the next five seconds ...  "
+		);
+
+		swfCountDown( 5 );
+
+		$this->messageReporter->reportMessage(
+			"\nRunning an index rebuild ..."
+		);
+
+		$rebuilder->setMessageReporter(
+			$this->messageReporter
+		);
+
+		if ( !$rebuilder->ping() ) {
+			return $this->messageReporter->reportMessage(
+				"\nElasticsearch endpoint(s) are not available!\n"
+			);
+		}
+
+		if ( !$rebuilder->hasIndices() ) {
+			$this->messageReporter->reportMessage( "\n   ... creating required indices and aliases ..." );
+			$rebuilder->createIndices();
+		}
+
+		$connection = $this->store->getConnection( 'mw.db' );
+
+		$conditions = [
+			"smw_iw!=" . $connection->addQuotes( SMW_SQL3_SMWIW_OUTDATED )
+		];
+
+		$rebuilder->prepare();
+
+		list( $res, $last ) = $rebuilder->select(
+			$this->store,
+			$conditions
+		);
+
+		if ( $res->numRows() > 0 ) {
+			$this->messageReporter->reportMessage( "\n" );
+		} else {
+			$this->messageReporter->reportMessage( "\n" . '   ... no documents to process ...' );
+		}
+
+		$this->rebuild( $rebuilder, $res, $last );
+
+		$this->messageReporter->reportMessage( "\n   ... done.\n" );
+
+		return true;
+	}
+
+	private function rebuild( $rebuilder, $res, $last ) {
+
+		$rebuilder->set( 'skip-fileindex', true );
+
+		$i = 0;
+		$last = $res->numRows();
+		$entityIdManager = $this->store->getObjectIds();
+
+		foreach ( $res as $row ) {
+			$i++;
+
+			$this->messageReporter->reportMessage(
+				"\r". sprintf( "%-50s%s", "   ... updating document", sprintf( "%4.0f%% (%s/%s)", ( $i / $last ) * 100, $i, $last ) )
+			);
+
+			if ( $row->smw_iw === SMW_SQL3_SMWDELETEIW || $row->smw_iw === SMW_SQL3_SMWREDIIW ) {
+				$rebuilder->delete( $row->smw_id );
+				continue;
+			}
+
+			$dataItem = $entityIdManager->getDataItemById(
+				$row->smw_id
+			);
+
+			if ( $dataItem === null ) {
+				continue;
+			}
+
+			$semanticData = $this->store->getSemanticData( $dataItem );
+			$semanticData->setExtensionData( 'revision_id', $row->smw_rev );
+
+			$rebuilder->rebuild( $row->smw_id, $semanticData );
+		}
+
+		$rebuilder->setDefaults();
+		$rebuilder->refresh();
+	}
+
+}

--- a/src/Elastic/Indexer/Rebuilder.php
+++ b/src/Elastic/Indexer/Rebuilder.php
@@ -357,13 +357,13 @@ class Rebuilder {
 			$type
 		);
 
-		$this->messageReporter->reportMessage( "\n   ... '$type' index ... " );
+		$this->messageReporter->reportMessage( "\n   ... *$type* index ... " );
 
 		if ( $this->client->hasLock( $type ) ) {
 			$this->rolloverByTypeAndVersion( $type, $this->client->getLock( $type ) );
 		}
 
-		$this->messageReporter->reportMessage( "\n      ... closing" );
+		$this->messageReporter->reportMessage( "\n       ... closing" );
 
 		// Certain changes ( ... to define new analyzers ...) requires to close
 		// and reopen an index

--- a/src/MediaWiki/Hooks.php
+++ b/src/MediaWiki/Hooks.php
@@ -312,6 +312,7 @@ class Hooks {
 			'SMW::Admin::TaskHandlerFactory' => [ $elasticFactory, 'onTaskHandlerFactory' ],
 			'SMW::Api::AddTasks' => [ $elasticFactory, 'onApiTasks' ],
 			'SMW::Event::RegisterEventListeners' => [ $elasticFactory, 'onRegisterEventListeners' ],
+			'SMW::Maintenance::AfterUpdateEntityCollationComplete' => [ $elasticFactory, 'onAfterUpdateEntityCollationComplete' ],
 
 			'AdminLinks' => [ $this, 'onAdminLinks' ],
 			'PageSchemasRegisterHandlers' => [ $this, 'onPageSchemasRegisterHandlers' ]

--- a/tests/phpunit/Integration/MediaWiki/Import/Maintenance/UpdateEntityCollationTest.php
+++ b/tests/phpunit/Integration/MediaWiki/Import/Maintenance/UpdateEntityCollationTest.php
@@ -48,6 +48,18 @@ class UpdateEntityCollationTest extends MwDBaseUnitTestCase {
 
 	public function testSortFieldUpdate() {
 
+		$version = $this->getStore()->getInfo( 'es' );
+
+		// Testing against ES 5.6 may cause a "Can't update
+		// [index.number_of_replicas] on closed indices" see
+		// https://github.com/elastic/elasticsearch/issues/22993
+		//
+		// Should be fixed with ES 6.4
+		// https://github.com/elastic/elasticsearch/pull/30423
+		if ( !is_array( $version ) && version_compare( $version, '6.4.0', '<' ) ) {
+			$this->markTestSkipped( "Skipping test because it requires at least ES 6.4.0." );
+		}
+
 		$this->importedTitles = [
 			'Category:Lorem ipsum',
 			'Lorem ipsum',

--- a/tests/phpunit/Unit/Elastic/Hooks/UpdateEntityCollationCompleteTest.php
+++ b/tests/phpunit/Unit/Elastic/Hooks/UpdateEntityCollationCompleteTest.php
@@ -1,0 +1,132 @@
+<?php
+
+namespace SMW\Tests\Elastic\Hooks;
+
+use SMW\Elastic\Hooks\UpdateEntityCollationComplete;
+use SMW\Tests\PHPUnitCompat;
+use SMW\Tests\TestEnvironment;
+use FakeResultWrapper;
+
+/**
+ * @covers \SMW\Elastic\Config
+ * @group semantic-mediawiki
+ *
+ * @license GNU GPL v2+
+ * @since 3.1
+ *
+ * @author mwjames
+ */
+class UpdateEntityCollationCompleteTest extends \PHPUnit_Framework_TestCase {
+
+	use PHPUnitCompat;
+
+	private $store;
+	private $messageReporter;
+	private $rebuilder;
+	private $entityIdManager;
+
+	protected function setUp() {
+
+		$this->testEnvironment = new TestEnvironment();
+
+		$this->messageReporter = $this->testEnvironment->getUtilityFactory()->newSpyMessageReporter();
+
+		$this->entityIdManager = $this->getMockBuilder( '\SMW\SQLStore\EntityStore\EntityIdManager' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$this->semanticData = $this->getMockBuilder( '\SMW\SemanticData' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$this->store = $this->getMockBuilder( '\SMW\SQLStore\SQLStore' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$this->store->expects( $this->any() )
+			->method( 'getObjectIds' )
+			->will( $this->returnValue( $this->entityIdManager ) );
+
+		$this->store->expects( $this->any() )
+			->method( 'getSemanticData' )
+			->will( $this->returnValue( $this->semanticData ) );
+
+		$this->rebuilder = $this->getMockBuilder( '\SMW\Elastic\Indexer\Rebuilder' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$this->connection = $this->getMockBuilder( '\SMW\Elastic\Connection\Client' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$this->database = $this->getMockBuilder( '\SMW\MediaWiki\Database' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$callback = function( $type ) {
+
+			if ( $type === 'mw.db' ) {
+				return $this->database;
+			};
+
+			return $this->connection;
+		};
+
+		$this->store->expects( $this->any() )
+			->method( 'getConnection' )
+			->will( $this->returnCallback( $callback ) );
+
+		$this->testEnvironment->registerObject( 'Store', $this->store );
+	}
+
+	protected function tearDown() {
+		$this->testEnvironment->tearDown();
+		parent::tearDown();
+	}
+
+	public function testCanConstruct() {
+
+		$this->assertInstanceof(
+			UpdateEntityCollationComplete::class,
+			new UpdateEntityCollationComplete( $this->store, $this->messageReporter )
+		);
+	}
+
+	public function testRunUpdate() {
+
+		$dataItem = $this->getMockBuilder( '\SMW\DIWikiPage' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$row = [
+			'smw_id'  => 42,
+			'smw_iw'  => '',
+			'smw_rev' => 9999
+		];
+
+		$this->rebuilder->expects( $this->any() )
+			->method( 'ping' )
+			->will( $this->returnValue( true ) );
+
+		$this->rebuilder->expects( $this->any() )
+			->method( 'select' )
+			->will( $this->returnValue( [ new FakeResultWrapper( [ (object)$row ] ), 2 ] ) );
+
+		$this->entityIdManager->expects( $this->any() )
+			->method( 'getDataItemById' )
+			->will( $this->returnValue( $dataItem ) );
+
+		$instance = new UpdateEntityCollationComplete(
+			$this->store,
+			$this->messageReporter
+		);
+
+		$instance->runUpdate( $this->rebuilder );
+
+		$this->assertContains(
+			'updating document                           100% (1/1)',
+			$this->messageReporter->getMessagesAsString()
+		);
+	}
+
+}

--- a/tests/phpunit/Unit/MediaWiki/HooksTest.php
+++ b/tests/phpunit/Unit/MediaWiki/HooksTest.php
@@ -297,9 +297,12 @@ class HooksTest extends \PHPUnit_Framework_TestCase {
 			[ 'callSMWBrowseAfterIncomingPropertiesLookupComplete' ],
 			[ 'callSMWBrowseBeforeIncomingPropertyValuesFurtherLinkCreate' ],
 			[ 'callSMWSQLStoreInstallerAfterCreateTablesComplete' ],
+			[ 'callSMWMaintenanceAfterUpdateEntityCollationComplete' ],
+
 		];
 	}
 
+//SMW::Maintenance::AfterUpdateEntityCollationComplete
 	public function callParserAfterTidy( $instance ) {
 
 		$handler = 'ParserAfterTidy';
@@ -1803,6 +1806,32 @@ class HooksTest extends \PHPUnit_Framework_TestCase {
 		$this->assertThatHookIsExcutable(
 			$instance->getHandlerFor( $handler ),
 			[ $tableBuilder, $messageReporter, $options ]
+		);
+
+		return $handler;
+	}
+
+	public function callSMWMaintenanceAfterUpdateEntityCollationComplete( $instance ) {
+
+		$handler = 'SMW::Maintenance::AfterUpdateEntityCollationComplete';
+
+		$result = '';
+
+		$this->assertTrue(
+			$instance->isRegistered( $handler )
+		);
+
+		$store = $this->getMockBuilder( '\SMW\SQLStore\SQLStore' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$messageReporter = $this->getMockBuilder( '\Onoi\MessageReporter\MessageReporter' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$this->assertThatHookIsExcutable(
+			$instance->getHandlerFor( $handler ),
+			[ $store, $messageReporter ]
 		);
 
 		return $handler;


### PR DESCRIPTION
This PR is made in reference to: #2429

This PR addresses or contains:

- When running `updateEntityCollation.php` the database table with `smw_sort` is directly modified to avoid the MW parser but it also means that the `ElasticStore` is unable to replicate possible changes without running `rebuildElasticIndex.php` manually and since users may forget about this step and wonder why changes are not applied (well, it had me fooled), `updateEntityCollation.php` emits a `SMW::Maintenance::AfterUpdateEntityCollationComplete` event so that `ElasticStore` can hook in and run the rebuild as part of `updateEntityCollation.php`
- Adds  the `SMW::Maintenance::AfterUpdateEntityCollationComplete` hook
- Adds an implementation for `SMW::Maintenance::AfterUpdateEntityCollationComplete` in the `ElasticStore`

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed
