### PR TITLE
Avoid "Creating default object from empty value", refs 4140

### DIFF
--- a/src/MediaWiki/Content/SchemaContent.php
+++ b/src/MediaWiki/Content/SchemaContent.php
@@ -406,6 +406,12 @@ class SchemaContent extends JsonContent {
 			$this->decodeJSONContent();
 		}
 
+		// The decode could return with a JSON syntax error therefore
+		// double check the parse state before trying to continue
+		if ( !is_object( $this->parse ) ) {
+			return;
+		}
+
 		$schemaName = $title->getDBKey();
 		$title_prefix = '';
 

--- a/tests/phpunit/Unit/MediaWiki/Content/SchemaContentTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Content/SchemaContentTest.php
@@ -115,6 +115,71 @@ class SchemaContentTest extends \PHPUnit_Framework_TestCase {
 		);
 	}
 
+	public function testPrepareSave_InvalidJSON() {
+
+		$schema = $this->getMockBuilder( '\SMW\Schema\SchemaDefinition' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$schemaValidator = $this->getMockBuilder( '\SMW\Schema\SchemaValidator' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$schemaValidator->expects( $this->once() )
+			->method( 'validate' )
+			->will( $this->returnValue( [] ) );
+
+		$schemaFactory = $this->getMockBuilder( '\SMW\Schema\SchemaFactory' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$schemaFactory->expects( $this->any() )
+			->method( 'newSchema' )
+			->will( $this->returnValue( $schema ) );
+
+		$schemaFactory->expects( $this->any() )
+			->method( 'newSchemaValidator' )
+			->will( $this->returnValue( $schemaValidator ) );
+
+		$title = $this->getMockBuilder( '\Title' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$title->expects( $this->any() )
+			->method( 'getDBKey' )
+			->will( $this->returnValue( 'Foo' ) );
+
+		$page = $this->getMockBuilder( '\wikiPage' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$page->expects( $this->any() )
+			->method( 'getTitle' )
+			->will( $this->returnValue( $title ) );
+
+		$user = $this->getMockBuilder( '\User' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$parserOptions = $this->getMockBuilder( '\ParserOptions' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$instance = new SchemaContent(
+			'Foo'
+		);
+
+		$instance->setServices( $schemaFactory );
+
+		$flags = '';
+		$parentRevId = '';
+
+		$this->assertInstanceof(
+			'\Status',
+			$instance->prepareSave( $page, $flags, $parentRevId, $user )
+		);
+	}
+
 	public function testSerializationOfClassInstance() {
 
 		$title = $this->getMockBuilder( '\Title' )


### PR DESCRIPTION
This PR is made in reference to: #4140

This PR addresses or contains:

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed
