### PR TITLE
[smw/schema] `usage_lookup` to allow multiple properties, refs 3965

### DIFF
--- a/src/MediaWiki/Content/SchemaContentFormatter.php
+++ b/src/MediaWiki/Content/SchemaContentFormatter.php
@@ -173,14 +173,27 @@ class SchemaContentFormatter {
 		}
 
 		$usage = '';
+		$dataItems = [];
 
-		$dataItems = $this->store->getPropertySubjects(
-			new DIProperty( $this->type['usage_lookup'] ),
-			new DIWikiPage( str_replace(' ', '_', $schema->getName() ), SMW_NS_SCHEMA )
+		$usage_lookup = (array)$this->type['usage_lookup'];
+
+		$subject = new DIWikiPage(
+			str_replace(' ', '_', $schema->getName() ),
+			SMW_NS_SCHEMA
 		);
 
-		if ( $dataItems instanceof \Traversable ) {
-			$dataItems = iterator_to_array( $dataItems );
+		foreach ( $usage_lookup as $property ) {
+			$property = new DIProperty(
+				$property
+			);
+
+			$ps = $this->store->getPropertySubjects( $property, $subject );
+
+			if ( $ps instanceof \Traversable ) {
+				$ps = iterator_to_array( $ps );
+			}
+
+			$dataItems = array_merge( $dataItems, $ps );
 		}
 
 		if ( $dataItems !== [] ) {

--- a/tests/phpunit/Unit/MediaWiki/Content/SchemaContentFormatterTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Content/SchemaContentFormatterTest.php
@@ -23,6 +23,7 @@ class SchemaContentFormatterTest extends \PHPUnit_Framework_TestCase {
 
 		$this->store = $this->getMockBuilder( '\SMW\Store' )
 			->disableOriginalConstructor()
+			->setMethods( [ 'service' ] )
 			->getMockForAbstractClass();
 	}
 
@@ -100,6 +101,101 @@ class SchemaContentFormatterTest extends \PHPUnit_Framework_TestCase {
 			$instance->getText( $text, $schema, $errors )
 		);
 	}
+
+	public function testGetUsage_Empty() {
+
+		$schema = $this->getMockBuilder( '\SMW\Schema\Schema' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$this->store->expects( $this->any() )
+			->method( 'getPropertySubjects' )
+			->will( $this->returnValue( [] ) );
+
+		$instance = new SchemaContentFormatter(
+			$this->store
+		);
+
+		$instance->setType( [ 'usage_lookup' => 'Foo' ] );
+
+		$this->assertEquals(
+			[ '', 0 ],
+			$instance->getUsage( $schema )
+		);
+	}
+
+	public function testGetUsage() {
+
+		$sortLetter = $this->getMockBuilder( '\SMW\SortLetter' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$dataItem = $this->getMockBuilder( '\SMW\DIWikiPage' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$schema = $this->getMockBuilder( '\SMW\Schema\Schema' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$this->store->expects( $this->any() )
+			->method( 'getPropertySubjects' )
+			->will( $this->returnValue( [ $dataItem ] ) );
+
+		$this->store->expects( $this->any() )
+			->method( 'service' )
+			->will( $this->returnValue( $sortLetter ) );
+
+		$instance = new SchemaContentFormatter(
+			$this->store
+		);
+
+		$instance->setType( [ 'usage_lookup' => 'Foo' ] );
+
+		list( $usage, $count ) = $instance->getUsage( $schema );
+
+		$this->assertContains(
+			'smw-columnlist-container',
+			$usage
+		);
+	}
+
+	public function testGetUsage_MultipleProperties() {
+
+		$sortLetter = $this->getMockBuilder( '\SMW\SortLetter' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$dataItem = $this->getMockBuilder( '\SMW\DIWikiPage' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$schema = $this->getMockBuilder( '\SMW\Schema\Schema' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$this->store->expects( $this->any() )
+			->method( 'getPropertySubjects' )
+			->will( $this->returnValue( [ $dataItem ] ) );
+
+		$this->store->expects( $this->any() )
+			->method( 'service' )
+			->will( $this->returnValue( $sortLetter ) );
+
+		$instance = new SchemaContentFormatter(
+			$this->store
+		);
+
+		$instance->setType( [ 'usage_lookup' => [ 'Foo', 'Bar' ] ] );
+
+		list( $usage, $count ) = $instance->getUsage( $schema );
+
+		$this->assertContains(
+			'smw-columnlist-container',
+			$usage
+		);
+	}
+
 
 	public function schema_get( $key ) {
 		return $key === Schema::SCHEMA_TAG ? [] : '';


### PR DESCRIPTION
This PR is made in reference to: #3965

This PR addresses or contains:

- Allows `usage_lookup` (see `smwgSchemaTypes`) to be defined as array of properties

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed
