### PR TITLE
Special:Browse, sort properties by label

### DIFF
--- a/src/MediaWiki/Specials/Browse/HtmlBuilder.php
+++ b/src/MediaWiki/Specials/Browse/HtmlBuilder.php
@@ -495,6 +495,12 @@ class HtmlBuilder {
 
 		$dataValueFactory = DataValueFactory::getInstance();
 
+		// Sort by label instead of the key which may start with `_` or `__`
+		// and thereby distorts the lexicographical order
+		usort ( $properties, function( $a, $b ) {
+			return strnatcmp( $a->getLabel(), $b->getLabel() );
+		} );
+
 		foreach ( $properties as $diProperty ) {
 
 			$dvProperty = $dataValueFactory->newDataValueByItem(


### PR DESCRIPTION
This PR is made in reference to: #

This PR addresses or contains:

- Fixes the display order of properties (all or within groups) to be of a lexicographical order by using the label instead of the key 

This PR includes:
- [ ] Tests (unit/integration)
- [x] CI build passed
