### PR TITLE
Allow to set a thumb image, refs 4212

### DIFF
--- a/res/smw/smw.summarytable.css
+++ b/res/smw/smw.summarytable.css
@@ -40,11 +40,12 @@
 }
 
 .smw-summarytable .smw-table-row .smwpropname, .smw-table-row .smwpropname, .smw-table-row .smwspecname {
-	width: 20%;
+	width: 25%;
 }
 
 .smw-summarytable-columns {
 	display: flex;
+	justify-content: center;
 }
 
 .smw-summarytable-columns .smw-summarytable-columns-2 {
@@ -65,6 +66,46 @@
 
 .smw-summarytable-columns .smw-summarytable-columns-2:last-child .smw-table .smw-table-row .smwpropname {
 	width: 30%;
+}
+
+.smw-summarytable .smwbuiltin {
+	font-style: normal;
+}
+
+.smw-summarytable-columns .smwpropname, .smw-table-row {
+	line-height: 25px;
+}
+
+.smw-summarytable-imagecolumn {
+	display: flex;
+}
+
+.smw-summarytable-imagecolumn .smw-summarytable-facts {
+	flex: 70%;
+}
+
+.smw-summarytable-facts .smw-table .smw-table-row .smwpropname {
+	width: 40%;
+}
+
+.smw-summarytable-imagecolumn .smw-summarytable-image {
+	flex: 30%;
+	margin-left:30px;
+}
+
+.smw-summarytable-item-center {
+	display: flex;
+	justify-content:center;
+	align-items:center;
+	height: 100%;
+}
+
+.smw-summarytable-noimage {
+	background: url('data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAMgAAADICAMAAACahl6sAAAAYFBMVEVHcEyqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqo+SBS7AAAAH3RSTlMA7nYFvqtUw4jGzJcPZ98hujMY9UXS+jvYL+goo11+hVrzMAAACiNJREFUeNrtndmCo6wSgANGm4i4xaya+P5vecImqphGM0H6/NTFTGYiLR9QRVEU9G7nxYsXL168ePHixYsXL16ckwvKD/OS4+pvYGRh+5vsb3+hO+7t7wIu7nOAtv1/IBEcx595AX+BRHDcizfP1HcHSMqLkCJ5x/Fel7cnuYVKAVJcruTY7QpBUmw1bo4Dfb2OSQpDjs1JfkaWB63l2JjkNjah94GeVAs4FMkWk/xjMhnU6svkef7dXmlIzs/ENkcVT0DyTHol8Nou4+hI2ivMbPlOD9SEYRjrfKaQyUFagesSH+qWilLHQ/hWGvT4B6xRfmxNJSyXTUqh8U8+5tFnGHVu/K72+liudlfzH5/Xn+gFMH7PgazR2oTExm/4wMLVkuN+HcupL3EI108IBQzj01gG70rPgmRtnwR8BjyiWxLMy+u5jxWR/pB5SW6I6+kh+GTiSF1YzQkL91jXTGz4pvXOBckYSbyqS4qPxuW/Fq6vq1QR0pLQmTXb+uo0VNFLZ0BKqvDNmpJ7OigdWkZTld2vKXhYW/BLQhv28DFI8EADMZzHyyIiT4TQk0RF6QQInDiIv9sZ0pz6Lg44NaTeHGTiqKbvTXr9jM8af+kcP2vXQN6NrSqc9/2PYfVXQKr9sOYAgCHXvtoOJDcGqRXz+dTAqKjLsqyLCDZXNdjC2vkegVK/z3tSD/UoqOFesgDoNkgmew5gvVtUYAmalw4PrUrEE454PlqQYdEraeWs+X0Inc7fL2FuolWOjw1ATCZEIur3+/CHgphs4KIQPBBYzkUiU5PdgosYgw/rIAZ1460cm+lwyaMnx4tzICVv4x/ToFDCIxtp6RpIvoyjI8kdA+HGIF4SpEv46IJOgWTHheNEjUaQuQQSLtVcbh/OZisbeyBVuy7EwQfkxR0Q5revWd//tMte8mWQC/N2tX5JFqHwcIpzrN+ruZ3Nu8QCCNMQ/MtKUb8yxOZa8n0QZrKO2axzqPZqbsZlNwGB+g4h03X7kei7BLoBQh88T9ZRqHP4f/K93Pec8hZUS36cAGGj4zDn0+MLXbgEFzznuR9Mx9bXQR66wXHj9d6rIEPNYyvHm25gPlwAwTrby2vd9JeRQdPqZg1mgbELINT3uwa6qb4ZRVE4ycgKB1fDqP+3QRKgmQmY4d2Pl/XBXue4h5P8nG1AbhoVmZsdtP/PlOS2PQgbRZFG//HcRD7S7Egz3rYAIRpvCc/5XjrNvhiarW+D0JFxrqcqot13YJo9UpL6bDa3fxvkqdkzjWcX4/nURLFdzqebIKdZl5aaqNPfAvlzPcJ0JJu+8zqrI3s3dYRoUiuwxgCoSo+sVmEYBf42SKSZRxjcc2YcjivtyjxSaGZ21vD3aZSrvGvGITTMlvk2SAk0OSJ7/VI81Lm/1JUE5fYgzESddONtnHMuFo2RQflNQBqNZvOktREJ5xgnj7Fh2LgAQnRW58IXto0aMiVfjUyCWMR06+rrIKxJ9zOxh1QkjGdQxB+euvqdaxdAmGc1rUrYJYw3uOmSzkNtMxilhX0f5KlT7F48aP7IiXzq6QYIa1SNAa1OI4xTpTfeRiPLRuw31zf2LiCHQdK5xvtC5ttvFkDYalcbZAtownh6T+eSzvlOV+UKCJ81ZmPqSTIbI2EWwbB2NjZ6opUJ30Q71W8Iwn2rxVnbPLs63zkEwneeTsuOkCSn+Z2urUDEpJEvScIP8tZ4DrEHEnBDG5qTBOHCMyGWUjjE6R9jEsGxQK9sZQdFYp/QTE8Ssb+44DCbLRCZmxabtHEtzogtyTGwBiK9xPvvrfy4z/mQToB0+YLN+xW4XGItzPmwCNJlZ97hvKYkUHQHWOgJ2ATZFdJzT6G+V0q5UmzjpafprILsAtydsmiiMUsZqbsW8OKDpHZBdrtKrUFAjqKipKcxk7KIUK5OkxxWpPnbBtkFZHCU+HhPr+l9kM5xJWvOE1oHoSjvjhLHZN1J1Q1A6ADDqZYixatvQ9kG5GVmK7Qf3od036PqgxsetgJhMLcIItw0DUYwun14TcWWIP9UVoOsLvglWd2woeG+hSUpwYIc4YE8F5/w+KqQRevivrCdgbsrXcJ27dpVtpttJbcHN0hK5vhcg/Wd6QYJ51g50APeJe2dbI1SEj6zXtfe93GRF5LEP1tKLLzm8/q73si5dUfOn1jQy8kZjtNnd+8F0A2UK/n4Ppzg8gz3m+rIPnxegp0XL168ePHixYsXL168/DmJ1LkCKDMUIrZDCFA/WS5kX0a9XFGaLQ/4R3q2r9tMzxCLIqBClpM7dN8HEfWXIOrdUAci8zGQqhzdeU8HYbKutF0QfmeTAGHdgRAehsp6ICLEDFTlUsXHEh9DXrri5UJ+wyC0AMLT2zhIIccaTYgBOpA2k70gvn9VHsgUubht40yUDrtydnQkF03PQXCnBXTkkwmIVIeYfgTyO5Jyvqw7JJJwFbMJgiC/f4WDxKr2uKfCHUjO1aFq21iAJPRvyHUiUsrSL2cJhKYmxxIEiKHD9TacgKCQkb7+hAIE0rFYcAI4PlullD2yAJIB2p4dSKK+04BElJr1ggCJmVrH7AHIO1GkQiW2QZjNrDhIqlKm+82rQOgTBaswB6n616MRrvQDEGG1Mhsg9H0xB8mVYsS9maQHQvkojADBaqZImAF7VT9CCKUSxKKOvBQ2ZfYoEp3TTW2ZBoSd0adKxUFA22La4hw77Xox3gREDJBIzG6v/0rwYHu1B7KTcyUDgdJOEfaBTi/5ywCTvN0GhNeOvrNQaUq9G8H6IIXwSBiIGn+AdWU+vFKwd2FiZAeEHT1i7+ruxcQ6pxHxR5EAKbhSiKbAStHblOxsgmQIiRcUyrIkU9+IsC/F0wVCtPLw9UymHnx95FMp7Bkpoq5ztvULSLx48eLFixcv/y2JZVwCdIuvULhqkfKlQhmMibVlu+MngLk5A/fYUhCs6u7RwJ1DKZFy5fNrQVTZ3r3bLJy2AQjujhlV8k1ELEYysUCcBVFlKUiOEMrbbm3aB7ERzQMtkJGsVEVXoagckOsSLUivrIhPUHc/nIJYWIXRpToWQS8ZlpCxIxqxkCtFHcioLOoFm+yD0KhPJSKjGR9bImbC4nZUTao5kH5ZARKlvAutg/AInIiM7rooHen+JXtJAzIoC4e36+uV/Ys8iDUgUuY2lGEUHq1jfyZ6kEFZOPzVl9ZBupBEKtQd0JGFhwYV6kEGZYXVottBaTJntb63LCajIAJqWxIKrVCnemItyLCsVHYRf7GtI7loR7HtQSuaA947dFZBoo0LHciwLOwFoJB1kEJGHTP5Ie7vruFePGgCMiorQWC7RY+gzgPJ1RzI65cA6XzwCb8DkXozKtv71SCgH64HVoJgafejpVeSADUvxOopMgUZlVUgcbGzDoIQUh+hDMOxjoi6EB/9WIhQXtLF5YpR2aL7YhjBgz6a58WLFy9evHjx4sWLFy825H8kSjVhBINVCwAAAABJRU5ErkJggg==');
+	background-size: 100px 100px;
+	background-repeat: no-repeat;
+	height: 100px;
+	width: 100px;
 }
 
 /**
@@ -93,14 +134,20 @@
 		width: unset;
 	}
 
-	.smw-summarytable-columns {
+	.smw-summarytable-columns, .smw-summarytable-imagecolumn {
 		display: block;
 	}
 
 	.smw-summarytable-columns .smw-summarytable-columns-2:first-child,
-	.smw-summarytable-columns .smw-summarytable-columns-2:last-child {
+	.smw-summarytable-columns .smw-summarytable-columns-2:last-child,
+	.smw-summarytable-imagecolumn .smw-summarytable-image {
 		margin-right: 0px;
 		margin-left: 0px;
+	}
+
+	.smw-summarytable-imagecolumn .smw-summarytable-image {
+		padding-top: 10px;
+		border-top: 1px solid #ddd;
 	}
 
 	.smw-summarytable-columns .smw-summarytable-columns-2:first-child {

--- a/src/Utils/Html/SummaryTable.php
+++ b/src/Utils/Html/SummaryTable.php
@@ -24,6 +24,16 @@ class SummaryTable {
 	private $attributes = [];
 
 	/**
+	 * @var integer
+	 */
+	private $columnThreshold = 4;
+
+	/**
+	 * @var string
+	 */
+	private $thumbImage = '';
+
+	/**
 	 * @since 3.1
 	 *
 	 * @param array $parameters
@@ -53,6 +63,44 @@ class SummaryTable {
 	/**
 	 * @since 3.1
 	 *
+	 * @param integer $ColumnThreshold
+	 */
+	public function setColumnThreshold( $columnThreshold ) {
+		$this->columnThreshold = $columnThreshold;
+	}
+
+	/**
+	 * @since 3.1
+	 *
+	 * @param string $thumbImage
+	 */
+	public function noImage() {
+		$this->thumbImage = Html::rawElement(
+			'div',
+			[
+				'class' => "smw-summarytable-item-center"
+			],
+			Html::rawElement(
+				'div',
+				[
+					'class' => "smw-summarytable-noimage"
+				]
+			)
+		);
+	}
+
+	/**
+	 * @since 3.1
+	 *
+	 * @param string $thumbImage
+	 */
+	public function setThumbImage( $thumbImage ) {
+		$this->thumbImage = $thumbImage;
+	}
+
+	/**
+	 * @since 3.1
+	 *
 	 * @return string
 	 */
 	public function buildHTML( array $opts = [] ) {
@@ -60,15 +108,24 @@ class SummaryTable {
 		$html = '';
 		$tables = [];
 
+		if ( $this->thumbImage !== '' ) {
+			return $this->tableAndImage( $this->parameters );
+		}
+
 		$count = count( $this->parameters );
 
-		if ( !isset( $opts['columns'] ) || $count < 4 ) {
+		if ( !isset( $opts['columns'] ) || $count < $this->columnThreshold ) {
 			return $this->table( $this->parameters );
 		}
 
 		$size = round( $count / $opts['columns'] );
 
-		$chunks = array_chunk( $this->parameters, $size, true );
+		if ( $this->thumbImage !== '' ) {
+			$chunks[] = $this->parameters;
+			$chunks[] = [ '' => $this->thumbImage ];
+		} else {
+			$chunks = array_chunk( $this->parameters, $size, true );
+		}
 
 		foreach ( $chunks as $params ) {
 			$tables[] = $this->table( $params );
@@ -90,6 +147,33 @@ class SummaryTable {
 			'div',
 			[
 				'class' => "smw-summarytable-columns"
+			],
+			$html
+		);
+	}
+
+	private function tableAndImage( $params ) {
+
+		$html = Html::rawElement(
+			'div',
+			[
+				'class' => "smw-summarytable-facts"
+			],
+			$this->table( $params )
+		);
+
+		$html .= Html::rawElement(
+			'div',
+			[
+				'class' => "smw-summarytable-image"
+			],
+			$this->thumbImage
+		);
+
+		return Html::rawElement(
+			'div',
+			[
+				'class' => "smw-summarytable-imagecolumn"
 			],
 			$html
 		);

--- a/tests/phpunit/Unit/Utils/Html/SummaryTableTest.php
+++ b/tests/phpunit/Unit/Utils/Html/SummaryTableTest.php
@@ -62,4 +62,47 @@ class SummaryTableTest extends \PHPUnit_Framework_TestCase {
 		);
 	}
 
+	public function testBuildHTML_ColumnThreshold() {
+
+		$instance = new SummaryTable(
+			[ 'Foo' => 'Bar', 'Foobar' => 'Bar' ]
+		);
+
+		$instance->setColumnThreshold( 1 );
+
+		$this->stringValidator->assertThatStringContains(
+			[
+				'<div class="smw-summarytable-columns"><div class="smw-summarytable-columns-2">',
+				'<div class="smw-summarytable"><div class="smw-table smwfacttable">',
+				'<div class="smw-table-row"><div class="smw-table-cell smwpropname">Foo</div>',
+				'<div class="smw-table-cell smwprops">Bar</div></div></div></div></div>',
+				'<div class="smw-summarytable-columns-2"><div class="smw-summarytable"><div class="smw-table smwfacttable">',
+				'<div class="smw-table-row"><div class="smw-table-cell smwpropname">Foobar</div>',
+				'<div class="smw-table-cell smwprops">Bar</div></div></div></div></div></div>'
+			],
+			$instance->buildHTML( ['columns' => 2 ] )
+		);
+	}
+
+	public function testBuildHTML_ColumnThreshold_NoImage() {
+
+		$instance = new SummaryTable(
+			[ 'Foo' => 'Bar', 'Foobar' => 'Bar' ]
+		);
+
+		$instance->noImage();
+		$instance->setColumnThreshold( 1 );
+
+		$this->stringValidator->assertThatStringContains(
+			[
+				'<div class="smw-summarytable-imagecolumn"><div class="smw-summarytable-facts">',
+				'<div class="smw-summarytable"><div class="smw-table smwfacttable">',
+				'<div class="smw-table-row"><div class="smw-table-cell smwpropname">Foo</div><div class="smw-table-cell smwprops">Bar</div></div>',
+				'<div class="smw-table-row"><div class="smw-table-cell smwpropname">Foobar</div><div class="smw-table-cell smwprops">Bar</div></div></div></div></div>',
+				'<div class="smw-summarytable-image"><div class="smw-summarytable-item-center"><div class="smw-summarytable-noimage"></div></div></div></div>'
+			],
+			$instance->buildHTML( ['columns' => 2 ] )
+		);
+	}
+
 }


### PR DESCRIPTION
This PR is made in reference to: #4212

This PR addresses or contains:

- Allows to add a thumb image and have to columns to fit nicely to provide a consistent user experience 

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed

## Example

PS: We won't have any image on the schema page but since it uses the `SummaryTable` to build the HTML, it helps to demonstrate the objective.

![image](https://user-images.githubusercontent.com/1245473/63214482-3b483d80-c108-11e9-90e7-5f22af5c74e6.png)

![image](https://user-images.githubusercontent.com/1245473/63214559-1607ff00-c109-11e9-936d-a38223dc0e4e.png)


