### PR TITLE
Add `DataValueFactory::newPropertyValueByItem`

### DIFF
--- a/src/DataValueFactory.php
+++ b/src/DataValueFactory.php
@@ -403,6 +403,34 @@ class DataValueFactory {
 	}
 
 	/**
+	 * @since 3.1
+	 *
+	 * @param DIProperty $property
+	 * @param string|false $caption
+	 * @param DIWikiPage|null $contextPage
+	 *
+	 * @return DataValue
+	 */
+	public function newPropertyValueByItem( DIProperty $property, $caption = false, DIWikiPage $contextPage = null ) {
+
+		$dataValue = $this->newDataValueByType(
+			PropertyValue::TYPE_ID,
+			false,
+			$caption,
+			null,
+			$contextPage
+		);
+
+		$dataValue->setDataItem( $property );
+
+		if ( $caption !== false ) {
+			$dataValue->setCaption( $caption );
+		}
+
+		return $dataValue;
+	}
+
+	/**
 	 * @since 2.5
 	 *
 	 * @param string $typeid

--- a/tests/phpunit/Unit/DataValueFactoryTest.php
+++ b/tests/phpunit/Unit/DataValueFactoryTest.php
@@ -241,6 +241,25 @@ class DataValueFactoryTest extends \PHPUnit_Framework_TestCase {
 		);
 	}
 
+	public function testNewPropertyValueByItem() {
+
+		$dataValue = DataValueFactory::getInstance()->newPropertyValueByItem(
+			DIProperty::newFromUserLabel( __METHOD__ ),
+			'Bar',
+			new DIWikiPage( 'Foobar', SMW_NS_PROPERTY )
+		);
+
+		$this->assertInstanceOf(
+			'\SMWPropertyValue',
+			$dataValue
+		);
+
+		$this->assertSame(
+			'Bar',
+			$dataValue->getCaption()
+		);
+	}
+
 	/**
 	 * @dataProvider newDataValueByItemDataProvider
 	 */


### PR DESCRIPTION
This PR is made in reference to: #

This PR addresses or contains:

- Adds `DataValueFactory::newPropertyValueByItem` as convenient function to create a `PropertyValue` instance from a `DIProperty` object

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed
