### PR TITLE
[ES] Improve ICU related collation sorting, refs 2429

### DIFF
--- a/tests/phpunit/Integration/JSONScript/JsonTestCaseScriptRunnerTest.php
+++ b/tests/phpunit/Integration/JSONScript/JsonTestCaseScriptRunnerTest.php
@@ -37,7 +37,7 @@ class JsonTestCaseScriptRunnerTest extends ExtendedJsonTestCaseScriptRunner {
 			'Maps' => function( $val, &$reason ) {
 
 				if ( !defined( 'SM_VERSION' ) ) {
-					$reason = "Dependency: Maps (or Semantic Maps) as requirement is not available!";
+					$reason = "Dependency: Maps (or Semantic Maps) as requirement for the test is not available!";
 					return false;
 				}
 
@@ -46,6 +46,32 @@ class JsonTestCaseScriptRunnerTest extends ExtendedJsonTestCaseScriptRunner {
 
 				if ( !version_compare( $version, $requiredVersion, $compare ) ) {
 					$reason = "Dependency: Required version of Maps ($requiredVersion $compare $version) is not available!";
+					return false;
+				}
+
+				return true;
+			},
+			'ext-intl' => function( $val, &$reason ) {
+
+				if ( !extension_loaded( 'intl' ) ) {
+					$reason = "Dependency: ext-intl (PHP extension, ICU collation) as requirement for the test is not available!";
+					return false;
+				}
+
+				return true;
+			},
+			'ICU' => function( $val, &$reason ) {
+
+				if ( !extension_loaded( 'intl' ) ) {
+					$reason = "Dependency: ext-intl (PHP extension, ICU collation) as requirement for the test is not available!";
+					return false;
+				}
+
+				list( $compare, $requiredVersion ) = explode( ' ', $val );
+				$version = INTL_ICU_VERSION;
+
+				if ( !version_compare( $version, $requiredVersion, $compare ) ) {
+					$reason = "Dependency: Requires at least ICU version {$requiredVersion} but only {$version} is available!";
 					return false;
 				}
 

--- a/tests/phpunit/Integration/JSONScript/TestCases/f-0306.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/f-0306.json
@@ -69,7 +69,7 @@
 			"subject": "Example/F0306/Q.1.1",
 			"assert-output": {
 				"to-contain": [
-					"<div class=\"smw-column-header\">B</div><ul><li>B1000.*<li>B9.*"
+					"<div class=\"smw-column-header\">B</div><ul><li>B9.*<li>B1000"
 				]
 			}
 		},
@@ -97,7 +97,7 @@
 			"subject": "Example/F0306/Q.1.2",
 			"assert-output": {
 				"to-contain": [
-					"<div class=\"smw-column-header\">B</div><ul><li>B9.*<li>B1000"
+					"<div class=\"smw-column-header\">B</div><ul><li>B1000.*<li>B9"
 				]
 			}
 		},

--- a/tests/phpunit/Integration/JSONScript/TestCases/f-0309.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/f-0309.json
@@ -1,0 +1,236 @@
+{
+	"description": "Test `format=category` DEFAULTSORT with numeric collation sort (`uca-default-u-kn` same as uca-default (== Unicode collation algorithm) with numeric sorting) (#2065, `smwgEntityCollation=uca-default-u-kn`, `smwgSparqlQFeatures=SMW_SPARQL_QF_COLLATION`)",
+	"requires": {
+		"ext-intl": "*",
+		"ICU":">= 57.1"
+	},
+	"setup": [
+		{
+			"namespace": "SMW_NS_PROPERTY",
+			"page": "Has page",
+			"contents": "[[Has type::Page]]"
+		},
+		{
+			"page": "F0309/1",
+			"contents": "{{DEFAULTSORT:T1.3}} [[Category:F0309-1]]"
+		},
+		{
+			"page": "F0309/2",
+			"contents": "{{DEFAULTSORT:T1.2}} [[Category:F0309-1]]"
+		},
+		{
+			"page": "F0309/3",
+			"contents": "{{DEFAULTSORT:T1.1}} [[Category:F0309-1]]"
+		},
+		{
+			"page": "F0309/A",
+			"contents": "{{DEFAULTSORT:T1.11}} [[Category:F0309-1]]"
+		},
+		{
+			"page": "F0309/B",
+			"contents": "{{DEFAULTSORT:T1.10}} [[Category:F0309-1]]"
+		},
+		{
+			"page": "F0309/Q.1",
+			"contents": "{{#ask: [[Category:F0309-1]] |format=category |order=asc |link=none |columns=1 }}"
+		},
+		{
+			"page": "F0309/Q.2",
+			"contents": "{{#ask: [[Category:F0309-1]] |format=category |order=desc |link=none |columns=1 }}"
+		},
+		{
+			"page": "F0309/AA1",
+			"contents": "{{DEFAULTSORT:ABC}} [[Category:F0309-2]]"
+		},
+		{
+			"page": "F0309/AA2",
+			"contents": "{{DEFAULTSORT:123}} [[Category:F0309-2]]"
+		},
+		{
+			"page": "F0309/AA3",
+			"contents": "{{DEFAULTSORT:こんにちは}} [[Category:F0309-2]]"
+		},
+		{
+			"page": "F0309/AA4",
+			"contents": "{{DEFAULTSORT:你好}} [[Category:F0309-2]]"
+		},
+		{
+			"page": "F0309/AA5",
+			"contents": "{{DEFAULTSORT:здравствуйте}} [[Category:F0309-2]]"
+		},
+		{
+			"page": "F0309/Q.3",
+			"contents": "{{#ask: [[Category:F0309-2]] |format=category |order=asc |link=none |columns=1 }}"
+		},
+		{
+			"page": "F0309/Q.4",
+			"contents": "{{#ask: [[Category:F0309-2]] |format=category |order=desc |link=none |columns=1 }}"
+		},
+		{
+			"page": "F0309/6",
+			"contents": "{{#subobject: |Has page=a15 |@sortkey=a15 |@category=F0309-3}} {{#subobject: |Has page=a142 |@sortkey=a142 |@category=F0309-3}} {{#subobject: |Has page=abc/bar |@sortkey=abc/bar |@category=F0309-3}} {{#subobject: |Has page=abc/bar/1 |@sortkey=abc/bar/1 |@category=F0309-3}} {{#subobject: |Has page=abc/bar/2 |@sortkey=abc/bar/2 |@category=F0309-3}} {{#subobject: |Has page=abc/bar/10/letters |@sortkey=abc/bar/10/letters |@category=F0309-3}} {{#subobject: |Has page=abc/bar/10/letters/1 |@sortkey=abc/bar/10/letters/1 |@category=F0309-3}} {{#subobject: |Has page=abc/bar/10/letters/2 |@sortkey=abc/bar/10/letters/2 |@category=F0309-3}} {{#subobject: |Has page=abc/foobar/ |@sortkey=abc/foobar/ |@category=F0309-3}}"
+		},
+		{
+			"page": "F0309/Q.5",
+			"contents": "{{#ask: [[Category:F0309-3]] |?Has page |format=category |order=asc |link=none |columns=1 }}"
+		},
+		{
+			"page": "F0309/Q.6",
+			"contents": "{{#ask: [[Category:F0309-3]] |?Has page |format=category |order=desc |link=none |columns=1 }}"
+		}
+	],
+	"tests": [
+		{
+			"type": "format",
+			"about": "#0 (asc sort, expected by DEFAULTSORT: 3 (T1.1), 2 (T1.2), 1 (T1.3), B (T1.10), A (T1.11))",
+			"subject": "F0309/Q.1",
+			"assert-output": {
+				"to-contain": [
+					"<ul><li>F0309/3 </li><li>F0309/2 </li><li>F0309/1 </li><li>F0309/B </li><li>F0309/A </li></ul>"
+				]
+			}
+		},
+		{
+			"type": "format",
+			"about": "#1 (desc sort, expected by DEFAULTSORT: A (T1.11), B (T1.10), 1 (T1.3), 2 (T1.2), 3 (T1.1) )",
+			"subject": "F0309/Q.2",
+			"assert-output": {
+				"to-contain": [
+					"<ul><li>F0309/A </li><li>F0309/B </li><li>F0309/1 </li><li>F0309/2 </li><li>F0309/3 </li></ul>"
+				]
+			}
+		},
+		{
+			"type": "format",
+			"about": "#2.1 (asc sort, expected by DEFAULTSORT: ... )",
+			"subject": "F0309/Q.3",
+			"skip-except":{
+				"elastic": "Only relevant when used in connection with ES, see comment in regards to UTF-8/collator in the Indexer"
+			},
+			"assert-output": {
+				"in-sequence": true,
+				"to-contain": [
+					"<div class=\"smw-column-header\">0–9</div><ul><li>F0309/AA2 </li></ul>",
+					"<div class=\"smw-column-header\">A</div><ul><li>F0309/AA1 </li></ul>",
+					"<div class=\"smw-column-header\">你</div><ul><li>F0309/AA4 </li></ul>",
+					"<div class=\"smw-column-header\">З</div><ul><li>F0309/AA5 </li></ul>",
+					"<div class=\"smw-column-header\">こ</div><ul><li>F0309/AA3 </li></ul>"
+				]
+			}
+		},
+		{
+			"type": "format",
+			"about": "#2.2 (asc sort, expected by DEFAULTSORT: ... )",
+			"subject": "F0309/Q.3",
+			"skip-on":{
+				"elastic": "Different sorting behaviour on UTF-8",
+				"postgres": "Different sorting behaviour on UTF-8"
+			},
+			"assert-output": {
+				"in-sequence": true,
+				"to-contain": [
+					"<div class=\"smw-column-header\">0–9</div><ul><li>F0309/AA2 </li></ul>",
+					"<div class=\"smw-column-header\">A</div><ul><li>F0309/AA1 </li></ul>",
+					"<div class=\"smw-column-header\">З</div><ul><li>F0309/AA5 </li></ul>",
+					"<div class=\"smw-column-header\">こ</div><ul><li>F0309/AA3 </li></ul>",
+					"<div class=\"smw-column-header\">你</div><ul><li>F0309/AA4 </li></ul>"
+				]
+			}
+		},
+		{
+			"type": "format",
+			"about": "#3.1 (desc sort, expected by DEFAULTSORT: ... )",
+			"subject": "F0309/Q.4",
+			"skip-except":{
+				"elastic": "Only relevant when used in connection with ES, see comment in regards to UTF-8/collator in the Indexer"
+			},
+			"assert-output": {
+				"in-sequence": true,
+				"to-contain": [
+					"<div class=\"smw-column-header\">こ</div><ul><li>F0309/AA3 </li></ul>",
+					"<div class=\"smw-column-header\">З</div><ul><li>F0309/AA5 </li></ul>",
+					"<div class=\"smw-column-header\">你</div><ul><li>F0309/AA4 </li></ul>",
+					"<div class=\"smw-column-header\">A</div><ul><li>F0309/AA1 </li></ul>",
+					"<div class=\"smw-column-header\">0–9</div><ul><li>F0309/AA2 </li></ul>"
+				]
+			}
+		},
+		{
+			"type": "format",
+			"about": "#3.2 (desc sort, expected by DEFAULTSORT: ... )",
+			"subject": "F0309/Q.4",
+			"skip-on":{
+				"elastic": "Different sorting behaviour on UTF-8",
+				"postgres": "Different sorting behaviour on UTF-8"
+			},
+			"assert-output": {
+				"in-sequence": true,
+				"to-contain": [
+					"<div class=\"smw-column-header\">你</div><ul><li>F0309/AA4 </li></ul>",
+					"<div class=\"smw-column-header\">こ</div><ul><li>F0309/AA3 </li></ul>",
+					"<div class=\"smw-column-header\">З</div><ul><li>F0309/AA5 </li></ul>",
+					"<div class=\"smw-column-header\">A</div><ul><li>F0309/AA1 </li></ul>",
+					"<div class=\"smw-column-header\">0–9</div><ul><li>F0309/AA2 </li></ul>"
+				]
+			}
+		},
+		{
+			"type": "format",
+			"about": "#4 (asc sort, subobject, expected by DEFAULTSORT: ... )",
+			"subject": "F0309/Q.5",
+			"assert-output": {
+				"in-sequence": true,
+				"to-contain": [
+					"A15",
+					"A142",
+					"Abc/bar",
+					"Abc/bar/1",
+					"Abc/bar/2",
+					"Abc/bar/10/letters",
+					"Abc/bar/10/letters/1",
+					"Abc/bar/10/letters/2",
+					"Abc/foobar/"
+				]
+			}
+		},
+		{
+			"type": "format",
+			"about": "#4 (desc sort, subobject, expected by DEFAULTSORT: ... )",
+			"subject": "F0309/Q.6",
+			"assert-output": {
+				"in-sequence": true,
+				"to-contain": [
+					"Abc/foobar/",
+					"Abc/bar/10/letters/2",
+					"Abc/bar/10/letters/1",
+					"Abc/bar/10/letters",
+					"Abc/bar/2",
+					"Abc/bar/1",
+					"Abc/bar",
+					"A142",
+					"A15"
+				]
+			}
+		}
+	],
+	"settings": {
+		"smwgEntityCollation": "uca-default-u-kn",
+		"smwgSparqlQFeatures": [
+			"SMW_SPARQL_QF_REDI",
+			"SMW_SPARQL_QF_SUBP",
+			"SMW_SPARQL_QF_SUBC",
+			"SMW_SPARQL_QF_COLLATION"
+		],
+		"wgContLang": "en",
+		"wgLang": "en",
+		"smwgNamespacesWithSemanticLinks": {
+			"NS_MAIN": true,
+			"SMW_NS_PROPERTY": true
+		}
+	},
+	"meta": {
+		"version": "2",
+		"is-incomplete": false,
+		"debug": false
+	}
+}


### PR DESCRIPTION
This PR is made in reference to: #2429

This PR addresses or contains:

- Adds a couple of integration tests especially for `uca-default-u-kn`, now the issue is that Travis-CI only runs with ICU 52.1 which means that sorting is somewhat dated (for example version 57.1 would order A15 before A142 but version 52.1 produces the opposite) therefore the `F0309` test case requires at least 57.1 to run the tests (otherwise there are skipped).
- ES only understands valid UTF-8 characters but the ICU collator can pick from different ICU collections (e.g. non UTF-8) which is why we need to enforce `mb_convert_encoding` otherwise the ES serializer would throw an exception but it means that some characters are replaced by ? which can lead to different sorting positions especially for Asian languages (see the test) compared to SQL (which hasn't an issue since it store the collated sorting string as byte representation).

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed

### Notes

We expect for `uca-default-u-kn` [0] to produce the sequence of:

```
"A15",
"A142",
"Abc/bar",
"Abc/bar/1",
"Abc/bar/2",
"Abc/bar/10/letters",
"Abc/bar/10/letters/1",
"Abc/bar/10/letters/2",
"Abc/foobar/"
```
[0] https://www.mediawiki.org/wiki/Manual:$wgCategoryCollation#Details