### PR TITLE
QueryProcessor, offset, limit to yield a correct ProcessedParam representation, refs 4260

### DIFF
--- a/includes/query/SMW_QueryProcessor.php
+++ b/includes/query/SMW_QueryProcessor.php
@@ -54,6 +54,23 @@ class SMWQueryProcessor implements QueryContext {
 	 * @return ProcessedParam[]
 	 */
 	public static function getProcessedParams( array $params, array $printRequests = [], $unknownInvalid = true, $context = null, $showMode = false ) {
+
+		// #4261
+		// The `ProcessedParam` library creates inconsistent results pending the
+		// input types especially between conversion of string to integer, so to
+		// ensure that method outputs a consistent behaviour independent of the
+		// type, we recast offset/limit as string.
+		//
+		// We remove the string casts tests would start to fail!
+
+		if ( isset( $params['offset'] ) ) {
+			$params['offset'] = (string)$params['offset'];
+		}
+
+		if ( isset( $params['limit'] ) ) {
+			$params['limit'] = (string)$params['limit'];
+		}
+
 		$validator = self::getProcessorForParams( $params, $printRequests, $unknownInvalid, $context, $showMode );
 		$processingResult = $validator->processParameters();
 

--- a/tests/phpunit/Integration/JSONScript/TestCases/s-0038.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/s-0038.json
@@ -1,0 +1,78 @@
+{
+	"description": "Test output via `Special:Ask` to verify limit, offset",
+	"setup": [
+		{
+			"namespace": "SMW_NS_PROPERTY",
+			"page": "Has number",
+			"contents": "[[Has type::Number]]"
+		},
+		{
+			"namespace": "NS_MAIN",
+			"page": "S0038/1",
+			"contents": "[[Has number::11]] [[Category:S0038]]"
+		},
+		{
+			"namespace": "NS_MAIN",
+			"page": "S0038/2",
+			"contents": "[[Has number::12]] [[Category:S0038]]"
+		},
+		{
+			"namespace": "NS_MAIN",
+			"page": "S0038/3",
+			"contents": "[[Has number::42]] [[Category:S0038]]"
+		},
+		{
+			"namespace": "NS_MAIN",
+			"page": "S0038/4",
+			"contents": "[[Has number::1001]] [[Category:S0038]]"
+		}
+	],
+	"tests": [
+		{
+			"type": "special",
+			"about": "#0",
+			"description": "Verifies that the offset is set and only two results are returned",
+			"special-page": {
+				"page": "Ask",
+				"request-parameters": {
+					"p": {
+						"link": "none",
+						"mainlabel": "",
+						"format": "table"
+					},
+					"q": "[[Category:S0038]]",
+					"po": "?Has number",
+					"offset": 2,
+					"limit": 20
+				}
+			},
+			"assert-output": {
+				"to-contain": [
+					"<td class=\"smwtype_wpg\">S0038/3</td><td class=\"Has-number smwtype_num\" data-sort-value=\"42\">42</td>",
+					"<td class=\"smwtype_wpg\">S0038/4</td><td class=\"Has-number smwtype_num\" data-sort-value=\"1001\">1,001</td>"
+				],
+				"not-contain": [
+					"<td class=\"smwtype_wpg\">S0038/1</td><td class=\"Has-number smwtype_num\" data-sort-value=\"11\">11</td>",
+					"<td class=\"smwtype_wpg\">S0038/2</td><td class=\"Has-number smwtype_num\" data-sort-value=\"12\">12</td>"
+				]
+			}
+		}
+	],
+	"settings": {
+		"wgContLang": "en",
+		"wgLang": "en",
+		"wgLanguageCode": "en",
+		"smwgPageSpecialProperties": [
+			"_MDAT"
+		],
+		"smwgNamespacesWithSemanticLinks": {
+			"NS_MAIN": true,
+			"SMW_NS_PROPERTY": true
+		}
+	},
+	"meta": {
+		"version": "2",
+		"is-incomplete": false,
+		"debug": false
+	}
+}

--- a/tests/phpunit/Unit/Query/Processor/QueryProcessorTest.php
+++ b/tests/phpunit/Unit/Query/Processor/QueryProcessorTest.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace SMW\Tests\Query\Processor;
+
+use SMWQueryProcessor as QueryProcessor;
+
+/**
+ * @covers SMWQueryProcessor
+ * @group semantic-mediawiki
+ *
+ * @license GNU GPL v2+
+ * @since 3.1
+ *
+ * @author mwjames
+ */
+class QueryProcessorTest extends \PHPUnit_Framework_TestCase {
+
+	/**
+	 * @dataProvider limitOffsetParamsProvider
+	 */
+	public function testGetProcessedParams_YieldCorrectProcessedParamValue( $params, $key, $expected ) {
+
+		$processedParam = QueryProcessor::getProcessedParams(
+			$params
+		);
+
+		$this->assertEquals(
+			$expected,
+			$processedParam[$key]->getValue()
+		);
+	}
+
+	public function limitOffsetParamsProvider() {
+
+		yield 'limit-string' => [
+			[ 'limit' => '12' ],
+			'limit',
+			12
+		];
+
+		yield 'limit-integer' => [
+			[ 'limit' => 12 ],
+			'limit',
+			12
+		];
+
+		yield 'offset-string' => [
+			[ 'offset' => '42' ],
+			'offset',
+			42
+		];
+
+		yield 'offset-integer' => [
+			[ 'offset' => 42 ],
+			'offset',
+			42
+		];
+	}
+
+}


### PR DESCRIPTION
This PR is made in reference to: #4172, #4260

This PR addresses or contains:

- Adds tests for the #4260 issue which introduced an inconsistency about how limit/offset produces different results depending on the value type (string vs. integer).
- It adds a unit test for `QueryProcessor::getProcessedParams` and an integration test with `Special:Ask` where the issue was uncovered.

This PR includes:
- [ ] Tests (unit/integration)
- [ ] CI build passed

Fixes #