### PR TITLE
Fix integer lower bounds

### DIFF
--- a/src/Query/Processor/DefaultParamDefinition.php
+++ b/src/Query/Processor/DefaultParamDefinition.php
@@ -74,13 +74,13 @@ class DefaultParamDefinition {
 		$params['limit'] = [
 			'type' => 'integer',
 			'default' => $vars['smwgQDefaultLimit'],
-			'negatives' => false,
+			'lowerbound' => 0,
 		];
 
 		$params['offset'] = [
 			'type' => 'integer',
 			'default' => 0,
-			'negatives' => false,
+			'lowerbound' => 0,
 			'upperbound' => $vars['smwgQUpperbound'],
 		];
 

--- a/src/Query/ResultPrinters/CategoryResultPrinter.php
+++ b/src/Query/ResultPrinters/CategoryResultPrinter.php
@@ -83,7 +83,7 @@ class CategoryResultPrinter extends ResultPrinter {
 			'name' => 'columns',
 			'type' => 'integer',
 			'message' => 'smw-paramdesc-columns',
-			'negatives' => false,
+			'lowerbound' => 0,
 			'default' => 3,
 		];
 


### PR DESCRIPTION
I noticed these negatives flags and looked for them in the documentation and ParamProcessor code. Maybe these existed in the distant past (2012 or before)... They certainly have not for a long time. Replacing them with something that does exist.

Might make sense to have different lower bounds in some cases (like 1). Something for a follow up