### PR TITLE
`SearchResult` use constructor, refs 4270

### DIFF
--- a/src/MediaWiki/Search/SearchResult.php
+++ b/src/MediaWiki/Search/SearchResult.php
@@ -4,6 +4,7 @@ namespace SMW\MediaWiki\Search;
 
 use SMW\DataValueFactory;
 use SMW\DIWikiPage;
+use Title;
 
 /**
  * @ingroup SMW
@@ -19,6 +20,15 @@ class SearchResult extends \SearchResult {
 	 * @var boolean
 	 */
 	private $hasHighlight = false;
+
+	/**
+	 * @since 3.1
+	 *
+	 * @param Title|null $title
+	 */
+	public function __construct( $title ) {
+		$this->initFromTitle( $title );
+	}
 
 	/**
 	 * @see SearchResult::getTextSnippet

--- a/src/MediaWiki/Search/SearchResultSet.php
+++ b/src/MediaWiki/Search/SearchResultSet.php
@@ -68,7 +68,7 @@ class SearchResultSet extends \SearchResultSet {
 		$searchResult = false;
 
 		if ( $page instanceof DIWikiPage ) {
-			$searchResult = SearchResult::newFromTitle( $page->getTitle() );
+			$searchResult = new SearchResult( $page->getTitle() );
 		}
 
 		// Attempt to use excerpts available from a different back-end
@@ -125,7 +125,7 @@ class SearchResultSet extends \SearchResultSet {
 		foreach ( $this->pages as $page ) {
 
 			if ( $page instanceof DIWikiPage ) {
-				$searchResult = SearchResult::newFromTitle( $page->getTitle() );
+				$searchResult = new SearchResult( $page->getTitle() );
 			}
 
 			// Attempt to use excerpts available from a different back-end

--- a/tests/phpunit/Unit/MediaWiki/Search/SearchResultTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Search/SearchResultTest.php
@@ -25,7 +25,7 @@ class SearchResultTest extends \PHPUnit_Framework_TestCase {
 			->method( 'getFragment' )
 			->will( $this->returnValue( 'Foo' ) );
 
-		$instance = SearchResult::newFromTitle( $title );
+		$instance = new SearchResult( $title );
 
 		$this->assertInstanceOf(
 			'\Title',
@@ -43,7 +43,7 @@ class SearchResultTest extends \PHPUnit_Framework_TestCase {
 			->method( 'getFragment' )
 			->will( $this->returnValue( '' ) );
 
-		$instance = SearchResult::newFromTitle( $title );
+		$instance = new SearchResult( $title );
 
 		$this->assertNull(
 			$instance->getSectionTitle()
@@ -60,7 +60,7 @@ class SearchResultTest extends \PHPUnit_Framework_TestCase {
 			->method( 'getFragment' )
 			->will( $this->returnValue( '' ) );
 
-		$instance = SearchResult::newFromTitle( $title );
+		$instance = new SearchResult( $title );
 		$instance->setExcerpt( 'Foo ...' );
 
 		$this->assertEquals(
@@ -87,7 +87,7 @@ class SearchResultTest extends \PHPUnit_Framework_TestCase {
 			->method( 'getFragment' )
 			->will( $this->returnValue( '' ) );
 
-		$instance = SearchResult::newFromTitle( $title );
+		$instance = new SearchResult( $title );
 
 		$this->assertEquals(
 			'Foo',
@@ -101,7 +101,7 @@ class SearchResultTest extends \PHPUnit_Framework_TestCase {
 			->disableOriginalConstructor()
 			->getMock();
 
-		$instance = SearchResult::newFromTitle( $title );
+		$instance = new SearchResult( $title );
 
 		$instance->setExcerpt( '<em>Foo</em>bar', true );
 
@@ -117,7 +117,7 @@ class SearchResultTest extends \PHPUnit_Framework_TestCase {
 			->disableOriginalConstructor()
 			->getMock();
 
-		$instance = SearchResult::newFromTitle( $title );
+		$instance = new SearchResult( $title );
 
 		$instance->setExcerpt( 'Foobar' );
 


### PR DESCRIPTION
This PR is made in reference to: #4270

This PR addresses or contains:

- Avoid using `SearchResult::newFromTitle` as MW 1.34+ forces a `new RevisionSearchResult( $title );` instead of a `new static();`

This PR includes:
- [ ] Tests (unit/integration)
- [x] CI build passed

Fixes #4270