### PR TITLE
Add `ResultPrinterDependency` interface

### DIFF
--- a/includes/query/SMW_QueryProcessor.php
+++ b/includes/query/SMW_QueryProcessor.php
@@ -15,6 +15,7 @@ use SMW\Query\Exception\ResultFormatNotFoundException;
 use SMW\Query\ResultFormat;
 use SMW\Query\ResultPrinter;
 use SMW\Query\ResultPrinters\NullResultPrinter;
+use SMW\Query\ResultPrinterDependency;
 
 /**
  * Static class for accessing functions to generate and execute semantic queries
@@ -280,6 +281,10 @@ class SMWQueryProcessor implements QueryContext {
 			$params['format']->getValue(),
 			$context
 		);
+
+		if ( $printer instanceof ResultPrinterDependency && $printer->hasMissingDependency() ) {
+			return $printer->getDependencyError();
+		}
 
 		if ( $printer->isDeferrable() && $context === self::DEFERRED_QUERY && $query->getLimit() > 0 ) {
 

--- a/src/Query/ResultPrinterDependency.php
+++ b/src/Query/ResultPrinterDependency.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace SMW\Query;
+
+use SMWQuery as Query;
+
+/**
+ * Interface for result printers that require some dependency to be fully
+ * functional.
+ *
+ * @license GNU GPL v2+
+ * @since 3.1
+ *
+ * @author mwjames
+ */
+interface ResultPrinterDependency {
+
+	/**
+	 * For result printers that implement this interface, return whether the
+	 * dependency contract is fulfilled or is missing something and would
+	 * impair the functionality of the result printer.
+	 *
+	 * This function will be called before any query execution ensuring that no
+	 * system resources are depleted while the printer is missing required
+	 * dependencies.
+	 *
+	 * @since 3.1
+	 *
+	 * @return boolean
+	 */
+	public function hasMissingDependency();
+
+	/**
+	 * Returns a desriptive error message in case of an unfulfilled dependency
+	 * contract to help users to understand as to why the result printer doesn't
+	 * return any results.
+	 *
+	 * @since 3.1
+	 *
+	 * @return string
+	 */
+	public function getDependencyError();
+
+}


### PR DESCRIPTION
This PR is made in reference to: #

This PR addresses or contains:

- `Resultprinter` that depend on an external service should implement `ResultPrinterDependency` to ensure that the check for those required services happens before any query execution.

This PR includes:
- [ ] Tests (unit/integration)
- [x] CI build passed
