### PR TITLE
`SearchResult` add `isBrokenTitle`, `isMissingRevision`

### DIFF
--- a/src/MediaWiki/Search/SearchResult.php
+++ b/src/MediaWiki/Search/SearchResult.php
@@ -4,6 +4,7 @@ namespace SMW\MediaWiki\Search;
 
 use SMW\DataValueFactory;
 use SMW\DIWikiPage;
+use SMW\DIProperty;
 use Title;
 
 /**
@@ -52,6 +53,36 @@ class SearchResult extends \SearchResult {
 		}
 
 		return $this->mTitle;
+	}
+
+	/**
+	 * @see SearchResult::isBrokenTitle
+	 */
+	function isBrokenTitle() {
+		return $this->mTitle === null;
+	}
+
+	/**
+	 * @see SearchResult::isMissingRevision
+	 */
+	function isMissingRevision() {
+
+		if ( $this->mTitle == null ) {
+			return true;
+		}
+
+		if ( $this->mTitle->getNamespace() === SMW_NS_PROPERTY ) {
+			$property = DIProperty::newFromUserLabel( $this->mTitle->getDBKey() );
+
+			// Predefined properties do not necessarily have a page and hereby a
+			// a revision in MediaWiki, anyway the page exists so allow it
+			// to be displayed
+			if ( !$property->isUserDefined() ) {
+				return false;
+			}
+		}
+
+		return !$this->mTitle->exists();
 	}
 
 	/**

--- a/src/MediaWiki/Search/SearchResultSet.php
+++ b/src/MediaWiki/Search/SearchResultSet.php
@@ -4,6 +4,9 @@ namespace SMW\MediaWiki\Search;
 
 use SMW\DIWikiPage;
 use SMW\Utils\CharExaminer;
+use SearchSuggestion;
+use SearchSuggestionSet;
+use SMW\Query\QueryResult;
 
 /**
  * @ingroup SMW
@@ -32,7 +35,7 @@ class SearchResultSet extends \SearchResultSet {
 
 	private $count = null;
 
-	public function __construct( \SMWQueryResult $result, $count = null ) {
+	public function __construct( QueryResult $result, $count = null ) {
 		$this->pages = $result->getResults();
 		$this->queryToken = $result->getQuery()->getQueryToken();
 		$this->excerpts = $result->getExcerpts();
@@ -95,12 +98,12 @@ class SearchResultSet extends \SearchResultSet {
 		$score = count( $this->pages );
 
 		foreach ( $this->pages as $page ) {
-			if ( ( $title = $page->getTitle() ) && $title->exists() ) {
-				$suggestions[] = \SearchSuggestion::fromTitle( $score--, $title );
+			if ( ( $title = $page->getTitle() ) ) {
+				$suggestions[] = SearchSuggestion::fromTitle( $score--, $title );
 			}
 		}
 
-		return new \SearchSuggestionSet( $suggestions, $hasMoreResults );
+		return new SearchSuggestionSet( $suggestions, $hasMoreResults );
 	}
 
 	/**


### PR DESCRIPTION
This PR is made in reference to: #

This PR addresses or contains:

- Adds `isBrokenTitle`, `isMissingRevision` so that the completion search can return matches to property pages that have no MediaWiki revision as in case of predefined properties

This PR includes:
- [ ] Tests (unit/integration)
- [x] CI build passed
