### PR TITLE
[SMWSearch] Widen search radius for `completionSearch`, refs 4280

### DIFF
--- a/src/MediaWiki/Search/ExtendedSearch.php
+++ b/src/MediaWiki/Search/ExtendedSearch.php
@@ -24,6 +24,11 @@ use Title;
 class ExtendedSearch {
 
 	/**
+	 * To provide a wider search radius for the completion search
+	 */
+	const COMPLETION_SEARCH_EXTRA_SEARCH_SIZE = 10;
+
+	/**
 	 * @var Store
 	 */
 	private $store;
@@ -274,6 +279,8 @@ class ExtendedSearch {
 
 		if ( $this->hasPrefixAndMinLenForCompletionSearch( $search, $minLen ) ) {
 			if ( $this->getSearchQuery( $search ) !== null ) {
+				// Lets widen the search in case we fetch subobjects
+				$this->limit = $this->limit + self::COMPLETION_SEARCH_EXTRA_SEARCH_SIZE;
 				$searchResultSet = $this->newSearchResultSet( $search, false, false );
 			}
 

--- a/src/MediaWiki/Search/SearchResultSet.php
+++ b/src/MediaWiki/Search/SearchResultSet.php
@@ -94,11 +94,25 @@ class SearchResultSet extends \SearchResultSet {
 	public function newSearchSuggestionSet() {
 
 		$suggestions = [];
+		$filter = [];
+
 		$hasMoreResults = false;
 		$score = count( $this->pages );
 
 		foreach ( $this->pages as $page ) {
-			if ( ( $title = $page->getTitle() ) ) {
+			if ( ( $title = $page->getTitle() ) !== null ) {
+				$key = $title->getPrefixedDBKey();
+
+				if ( $title->getNamespace() !== SMW_NS_PROPERTY && !$title->exists() ) {
+					continue;
+				}
+
+				if ( isset( $filter[$key] ) ) {
+					continue;
+				}
+
+				// Filter subobjects which are not distinguishable in MW
+				$filter[$key] = true;
 				$suggestions[] = SearchSuggestion::fromTitle( $score--, $title );
 			}
 		}

--- a/tests/phpunit/Unit/MediaWiki/Search/SearchResultSetTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Search/SearchResultSetTest.php
@@ -3,6 +3,7 @@
 namespace SMW\Tests\MediaWiki\Search;
 
 use SMW\MediaWiki\Search\SearchResultSet;
+use SMW\DIWikiPage;
 
 /**
  * @covers \SMW\MediaWiki\Search\SearchResultSet
@@ -216,6 +217,66 @@ class SearchResultSetTest extends \PHPUnit_Framework_TestCase {
 		$this->assertInstanceOf(
 			'\SearchSuggestionSet',
 			$resultSet->newSearchSuggestionSet()
+		);
+	}
+
+	public function testNewSearchSuggestionSet_FilterSameTitle() {
+
+		$title = $this->getMockBuilder( '\Title' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$title->expects( $this->any() )
+			->method( 'exists' )
+			->will( $this->returnValue( true ) );
+
+		$title->expects( $this->any() )
+			->method( 'getPrefixedDBKey' )
+			->will( $this->returnValue( 'Foo' ) );
+
+		$page_1 = $this->getMockBuilder( '\SMW\DIWikiPage' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$page_1->expects( $this->any() )
+			->method( 'getTitle' )
+			->will( $this->returnValue( $title ) );
+
+		$page_2 = $this->getMockBuilder( '\SMW\DIWikiPage' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$page_2->expects( $this->any() )
+			->method( 'getTitle' )
+			->will( $this->returnValue( $title ) );
+
+		$page_3 = $this->getMockBuilder( '\SMW\DIWikiPage' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$query = $this->getMockBuilder( '\SMWQuery' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$queryResult = $this->getMockBuilder( 'SMWQueryResult' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$queryResult->expects( $this->any() )
+			->method( 'getResults' )
+			->will( $this->returnValue( [ $page_1, $page_2, $page_3 ] ) );
+
+		$queryResult->expects( $this->any() )
+			->method( 'getQuery' )
+			->will( $this->returnValue( $query ) );
+
+		$resultSet = new SearchResultSet( $queryResult, 42 );
+
+		$searchSuggestionSet = $resultSet->newSearchSuggestionSet();
+
+		$this->assertCount(
+			1,
+			$searchSuggestionSet->getSuggestions()
 		);
 	}
 


### PR DESCRIPTION
This PR is made in reference to: #4280

This PR addresses or contains:

- MediaWiki's completion search cannot deal with subobjects (it is Semantic MediaWiki concept not a MediaWiki one) therefore widen the search radius a bit so we have some air to filter objects while filling the completion max size.

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed
