### PR TITLE
Rem `template arguments`, add `named args` to `templatefile` result printer, refs 3760

### DIFF
--- a/src/Query/ResultPrinters/TemplateFileExportPrinter.php
+++ b/src/Query/ResultPrinters/TemplateFileExportPrinter.php
@@ -74,10 +74,9 @@ class TemplateFileExportPrinter extends FileExportPrinter {
 
 		$params['searchlabel']->setDefault( 'templateFile' );
 
-		$params['template arguments'] = [
-			'message' => 'smw-paramdesc-template-arguments',
-			'default' => 'legacy',
-			'values' => [ 'numbered', 'named', 'legacy' ],
+		$params['valuesep'] = [
+			'message' => 'smw-paramdesc-sep',
+			'default' => ',',
 		];
 
 		$params['template'] = [
@@ -86,9 +85,10 @@ class TemplateFileExportPrinter extends FileExportPrinter {
 			'message' => 'smw-paramdesc-template',
 		];
 
-		$params['valuesep'] = [
-			'message' => 'smw-paramdesc-sep',
-			'default' => ',',
+		$params['named args'] =  [
+			'type' => 'boolean',
+			'message' => 'smw-paramdesc-named_args',
+			'default' => false,
 		];
 
 		$params['userparam'] = [
@@ -169,17 +169,13 @@ class TemplateFileExportPrinter extends FileExportPrinter {
 
 		$link = $link->getText( SMW_OUTPUT_RAW, $this->mLinker );
 
-		// Extra fields include:
-		// - {{{userparam}}}
-		// - {{{querylink}}}
-
 		if ( $this->params['introtemplate'] !== '' ) {
 			$template = new Template(
 				$this->params['introtemplate']
 			);
 
-			$template->field( 'userparam', $this->params['userparam'] );
-			$template->field( 'querylink', $link );
+			$template->field( '#userparam', $this->params['userparam'] );
+			$template->field( '#querylink', $link );
 			$templateSet->addTemplate( $template );
 		}
 
@@ -188,21 +184,18 @@ class TemplateFileExportPrinter extends FileExportPrinter {
 				$this->params['template']
 			);
 
+			$template->field( '#userparam', $this->params['userparam'] );
 			$this->addFields( $template, $row );
 			$templateSet->addTemplate( $template );
 		}
-
-		// Extra fields include:
-		// - {{{userparam}}}
-		// - {{{querylink}}}
 
 		if ( $this->params['outrotemplate'] !== '' ) {
 			$template = new Template(
 				$this->params['outrotemplate']
 			);
 
-			$template->field( 'userparam', $this->params['userparam'] );
-			$template->field( 'querylink', $link );
+			$template->field( '#userparam', $this->params['userparam'] );
+			$template->field( '#querylink', $link );
 			$templateSet->addTemplate( $template );
 		}
 
@@ -217,18 +210,13 @@ class TemplateFileExportPrinter extends FileExportPrinter {
 			$value = '';
 			$fieldName = '';
 
-			// {{{?Foo}}}
-			if ( $this->params['template arguments'] === 'legacy'  ) {
-				$fieldName = '?' . $field->getPrintRequest()->getLabel();
-			}
-
 			// {{{Foo}}}
-			if ( $this->params['template arguments'] === 'named' ) {
+			if ( $this->params['named args'] === true ) {
 				$fieldName = $field->getPrintRequest()->getLabel();
 			}
 
 			// {{{1}}}
-			if ( $fieldName === '' || $fieldName === '?' || $this->params['template arguments'] === 'numbered' ) {
+			if ( $fieldName === '' || $fieldName === '?' ) {
 				$fieldName = intval( $i + 1 );
 			}
 

--- a/tests/phpunit/Integration/JSONScript/Fixtures/res.s-0025.2.txt
+++ b/tests/phpunit/Integration/JSONScript/Fixtures/res.s-0025.2.txt
@@ -1,11 +1,13 @@
-<includeonly>#FORMAT: BEACON
+#FORMAT: BEACON
 #PREFIX: http://d-nb.info/gnd/
-#TARGET: {{{#querylink}}}
+#TARGET:.*
 #VERSION: 0.1
 #HOMEPAGE: https://www.semantic-mediawiki.org/w/index.php?title=Help:BEACON
 #FEED: https://www.semantic-mediawiki.org/w/index.php?title=BEACON&action=render
 #LINK: http://www.w3.org/2000/01/rdf-schema#seeAlso
 #INSTITUTION: Semantic MediaWiki
 #MESSAGE: Person test data in Semantic MediaWiki
-#TIMESTAMP: {{CURRENTTIMESTAMP}}
-#UPDATE: always</includeonly>
+#TIMESTAMP: .*
+#UPDATE: always
+123456789||John Doe
+987654321||Jane Doe

--- a/tests/phpunit/Integration/JSONScript/Fixtures/s-0025-beacon-named-template-args.txt
+++ b/tests/phpunit/Integration/JSONScript/Fixtures/s-0025-beacon-named-template-args.txt
@@ -1,0 +1,2 @@
+<includeonly>
+{{{GND|}}}||{{{Name|}}}</includeonly>

--- a/tests/phpunit/Integration/JSONScript/Fixtures/s-0025-beacon-numeric-template-args.txt
+++ b/tests/phpunit/Integration/JSONScript/Fixtures/s-0025-beacon-numeric-template-args.txt
@@ -1,0 +1,2 @@
+<includeonly>
+{{{2|}}}||{{{3|}}}</includeonly>

--- a/tests/phpunit/Integration/JSONScript/Fixtures/s-0025-beacon.txt
+++ b/tests/phpunit/Integration/JSONScript/Fixtures/s-0025-beacon.txt
@@ -1,2 +1,0 @@
-<includeonly>
-{{{?GND|}}}||{{{?Name|}}}</includeonly>

--- a/tests/phpunit/Integration/JSONScript/TestCases/s-0025.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/s-0025.json
@@ -13,9 +13,16 @@
 		},
 		{
 			"namespace": "NS_TEMPLATE",
-			"page": "BEACON",
+			"page": "BEACON (named)",
 			"contents": {
-				"import-from": "/../Fixtures/s-0025-beacon.txt"
+				"import-from": "/../Fixtures/s-0025-beacon-named-template-args.txt"
+			}
+		},
+		{
+			"namespace": "NS_TEMPLATE",
+			"page": "BEACON (numeric)",
+			"contents": {
+				"import-from": "/../Fixtures/s-0025-beacon-numeric-template-args.txt"
 			}
 		},
 		{
@@ -37,7 +44,7 @@
 	"tests": [
 		{
 			"type": "special",
-			"about": "#0",
+			"about": "#0 (named args)",
 			"special-page": {
 				"page": "Ask",
 				"request-parameters": {
@@ -46,8 +53,9 @@
 						"limit": "10",
 						"offset": "0",
 						"mainlabel": "",
+						"named args": true,
 						"format": "templatefile",
-						"template": "BEACON",
+						"template": "BEACON (named)",
 						"introtemplate": "BEACON-INTRO"
 					},
 					"q": "[[Has GND::123456789]]",
@@ -62,7 +70,7 @@
 		},
 		{
 			"type": "special",
-			"about": "#0",
+			"about": "#1 (named template args, multiple rows)",
 			"special-page": {
 				"page": "Ask",
 				"request-parameters": {
@@ -71,8 +79,9 @@
 						"limit": "10",
 						"offset": "0",
 						"mainlabel": "",
+						"named args": true,
 						"format": "templatefile",
-						"template": "BEACON",
+						"template": "BEACON (named)",
 						"introtemplate": "BEACON-INTRO"
 					},
 					"q": "[[Has GND::123456789]] OR [[Has GND::987654321]]",
@@ -82,6 +91,32 @@
 			"assert-output": {
 				"to-contain": {
 					"contents-file" : "/../Fixtures/res.s-0025.1.txt"
+				}
+			}
+		},
+		{
+			"type": "special",
+			"about": "#2 (numeric template args, multiple rows)",
+			"special-page": {
+				"page": "Ask",
+				"request-parameters": {
+					"p": {
+						"link": "none",
+						"limit": "10",
+						"offset": "0",
+						"mainlabel": "",
+						"named args": false,
+						"format": "templatefile",
+						"template": "BEACON (numeric)",
+						"introtemplate": "BEACON-INTRO"
+					},
+					"q": "[[Has GND::123456789]] OR [[Has GND::987654321]]",
+					"po": "?Has GND=GND|?Has name=Name"
+				}
+			},
+			"assert-output": {
+				"to-contain": {
+					"contents-file" : "/../Fixtures/res.s-0025.2.txt"
 				}
 			}
 		}


### PR DESCRIPTION
This PR is made in reference to: #3760

This PR addresses or contains:

- Removes the `template argument` parameter
- Adds the `named args` parameter
- Changes to common parameter fields
  - `userparam` becomes `#userparam`
  - `querylink` becomes `#querylink`

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed

Fixes #3760