### PR TITLE
Fix parameter warning

### DIFF
--- a/src/MediaWiki/Search/ProfileForm/FormsBuilder.php
+++ b/src/MediaWiki/Search/ProfileForm/FormsBuilder.php
@@ -246,7 +246,7 @@ class FormsBuilder {
 			$this->preselect_namespaces( $data['namespaces']['preselect'] );
 		}
 
-		if ( isset( $data['namespaces']['hidden'] ) && is_array(  ) ) {
+		if ( isset( $data['namespaces']['hidden'] ) && is_array( $data['namespaces']['hidden'] ) ) {
 			$this->hidden_namespaces( $data['namespaces']['hidden'] );
 		}
 


### PR DESCRIPTION
This PR is made in reference to: #4283 

This PR addresses or contains:
- Fix for warning "is_array() expects exactly 1 parameter, 0 given" as suggested by @mwjames in https://github.com/SemanticMediaWiki/SemanticMediaWiki/issues/4283#issuecomment-526957799

This PR includes:
- [ ] Tests (unit/integration)
- [x] CI build passed

Fixes #4283 