### PR TITLE
Mass replace deprecated curly brace syntax for array offset access

### DIFF
--- a/includes/dataitems/SMW_DI_Property.php
+++ b/includes/dataitems/SMW_DI_Property.php
@@ -85,11 +85,11 @@ class DIProperty extends SMWDataItem {
 	 */
 	public function __construct( $key, $inverse = false ) {
 
-		if ( ( $key === '' ) || ( $key{0} == '-' ) ) {
+		if ( ( $key === '' ) || ( $key[0] == '-' ) ) {
 			throw new PropertyLabelNotResolvedException( "Illegal property key \"$key\"." );
 		}
 
-		if ( $key{0} == '_' ) {
+		if ( $key[0] == '_' ) {
 			if ( !PropertyRegistry::getInstance()->isRegistered( $key ) ) {
 				throw new PredefinedPropertyLabelMismatchException( "There is no predefined property with \"$key\"." );
 			}
@@ -169,7 +169,7 @@ class DIProperty extends SMWDataItem {
 	 * @return boolean
 	 */
 	public function isUserDefined() {
-		return $this->m_key{0} != '_';
+		return $this->m_key[0] != '_';
 	}
 
 	/**
@@ -428,7 +428,7 @@ class DIProperty extends SMWDataItem {
 	public static function doUnserialize( $serialization ) {
 		$inverse = false;
 
-		if ( $serialization{0} == '-' ) {
+		if ( $serialization[0] == '-' ) {
 			$serialization = substr( $serialization, 1 );
 			$inverse = true;
 		}
@@ -465,7 +465,7 @@ class DIProperty extends SMWDataItem {
 	 */
 	public static function newFromUserLabel( $label, $inverse = false, $languageCode = false ) {
 
-		if ( $label !== '' && $label{0} == '-' ) {
+		if ( $label !== '' && $label[0] == '-' ) {
 			$label = substr( $label, 1 );
 			$inverse = true;
 		}
@@ -504,7 +504,7 @@ class DIProperty extends SMWDataItem {
 
 		// If an inverse marker is present just omit the marker so a normal
 		// property page link can be produced independent of its directionality
-		if ( $dbkey !== '' && $dbkey{0} == '-'  ) {
+		if ( $dbkey !== '' && $dbkey[0] == '-'  ) {
 			$dbkey = substr( $dbkey, 1 );
 		}
 

--- a/includes/dataitems/SMW_DI_Time.php
+++ b/includes/dataitems/SMW_DI_Time.php
@@ -141,7 +141,7 @@ class SMWDITime extends SMWDataItem implements CalendarModel {
 
 		$this->timezone = $timezone !== false ? $timezone : 0;
 		$year = strval( $year );
-		$this->era      = $year{0} === '+' ? 1 : ( $year{0} === '-' ? -1 : 0 );
+		$this->era      = $year[0] === '+' ? 1 : ( $year[0] === '-' ? -1 : 0 );
 
 		if ( $this->isOutOfBoundsBySome() ) {
 			throw new DataItemException( "Part of the date is out of bounds." );
@@ -496,7 +496,7 @@ class SMWDITime extends SMWDataItem implements CalendarModel {
 
 				// Find out whether the input contained an explicit AD/CE era marker
 				if ( $i == 1 ) {
-					$values[$i] = ( $parts[1]{0} === '+' ? '+' : '' ) . $values[$i];
+					$values[$i] = ( $parts[1][0] === '+' ? '+' : '' ) . $values[$i];
 				}
 			}
 		}

--- a/includes/datavalues/SMW_DV_Number.php
+++ b/includes/datavalues/SMW_DV_Number.php
@@ -181,7 +181,7 @@ class SMWNumberValue extends SMWDataValue {
 			$this->m_caption = $value;
 		}
 
-		if ( $value !== '' && $value{0} === ':' ) {
+		if ( $value !== '' && $value[0] === ':' ) {
 			$this->addErrorMsg( [ 'smw-datavalue-invalid-number', $value ] );
 			return;
 		}

--- a/includes/datavalues/SMW_DV_Record.php
+++ b/includes/datavalues/SMW_DV_Record.php
@@ -104,7 +104,7 @@ class SMWRecordValue extends AbstractMultiValue {
 				// then the wiki parser would interpret it as list element
 				// and format it accordingly eventhough it is not suppose to
 				// be an ul/ol list item.
-				if ( $val !== '' && $val{0} === '#' ) {
+				if ( $val !== '' && $val[0] === '#' ) {
 					$val = str_replace( "#", '&#x23;', $val );
 				}
 

--- a/includes/datavalues/SMW_DV_Time.php
+++ b/includes/datavalues/SMW_DV_Time.php
@@ -420,7 +420,7 @@ class SMWTimeValue extends SMWDataValue {
 			} else { // number can just be a year
 				return SMW_YEAR;
 			}
-		} elseif ( $component { 0 } == 'd' ) { // already marked as day
+		} elseif ( $component [0] == 'd' ) { // already marked as day
 			if ( is_numeric( substr( $component, 1 ) ) ) {
 				$numvalue = intval( substr( $component, 1 ) );
 				return ( ( $numvalue >= 1 ) && ( $numvalue <= 31 ) ) ? SMW_DAY : 0;

--- a/maintenance/updateEntityCollation.php
+++ b/maintenance/updateEntityCollation.php
@@ -147,7 +147,7 @@ class UpdateEntityCollation extends \Maintenance {
 			return end( $pv )->getString();
 		}
 
-		if ( $row->smw_title{0} !== '_' ) {
+		if ( $row->smw_title[0] !== '_' ) {
 			return $row->smw_sortkey;
 		}
 

--- a/src/DataValueFactory.php
+++ b/src/DataValueFactory.php
@@ -159,7 +159,7 @@ class DataValueFactory {
 
 			$type = str_replace( ' ' , '_', $type );
 
-			if ( $type{0} !== '_' && ( $dType = $this->dataTypeRegistry->findTypeByLabel( $type ) ) !== '' ) {
+			if ( $type[0] !== '_' && ( $dType = $this->dataTypeRegistry->findTypeByLabel( $type ) ) !== '' ) {
 				$type = $dType;
 			}
 

--- a/src/DataValues/TypesValue.php
+++ b/src/DataValues/TypesValue.php
@@ -196,7 +196,7 @@ class TypesValue extends DataValue {
 		$valueParts = explode( ':', $value, 2 );
 		$contentLanguage = $this->getOption( self::OPT_CONTENT_LANGUAGE );
 
-		if ( $value !== '' && $value{0} === '_' ) {
+		if ( $value !== '' && $value[0] === '_' ) {
 			$this->m_typeId = $value;
 		} else {
 			$this->givenLabel = smwfNormalTitleText( $value );

--- a/src/DataValues/ValueFormatters/StringValueFormatter.php
+++ b/src/DataValues/ValueFormatters/StringValueFormatter.php
@@ -79,7 +79,7 @@ class StringValueFormatter extends DataValueFormatter {
 
 		// Appease the MW parser to correctly apply formatting on the
 		// first indent
-		if ( $text !== '' && ( $text{0} === '*' || $text{0} === '#' || $text{0} === ':' ) ) {
+		if ( $text !== '' && ( $text[0] === '*' || $text[0] === '#' || $text[0] === ':' ) ) {
 			$text = "\n" . $text . "\n";
 		}
 

--- a/src/DataValues/ValueParsers/AllowsListValueParser.php
+++ b/src/DataValues/ValueParsers/AllowsListValueParser.php
@@ -85,7 +85,7 @@ class AllowsListValueParser implements ValueParser {
 			return $this->errors[] = [ 'smw-datavalue-allows-value-list-unknown', $userValue ];
 		}
 
-		if ( $contents{0} === '{' && ( $list = json_decode( $contents, true ) ) && is_array( $list ) ) {
+		if ( $contents[0] === '{' && ( $list = json_decode( $contents, true ) ) && is_array( $list ) ) {
 			return $list;
 		}
 

--- a/src/DataValues/ValueParsers/PropertyValueParser.php
+++ b/src/DataValues/ValueParsers/PropertyValueParser.php
@@ -176,7 +176,7 @@ class PropertyValueParser implements ValueParser {
 		}
 
 		// property refers to an inverse
-		if ( ( $propertyName !== '' ) && ( $propertyName { 0 } == '-' ) ) {
+		if ( ( $propertyName !== '' ) && ( $propertyName [0] == '-' ) ) {
 			$propertyName = $this->doNormalize( (string)substr( $value, 1 ), $this->isCapitalLinks );
 			/// NOTE The cast is necessary at least in PHP 5.3.3 to get string '' instead of boolean false.
 			/// NOTE It is necessary to normalize again here, since normalization may uppercase the first letter.

--- a/src/DataValues/ValueValidators/AllowsListConstraintValueValidator.php
+++ b/src/DataValues/ValueValidators/AllowsListConstraintValueValidator.php
@@ -227,7 +227,7 @@ class AllowsListConstraintValueValidator implements ConstraintValueValidator {
 		$v = $allowedValue->getString();
 
 		// If a previous range comparison failed then bail-out!
-		if ( $v{0} === $exp && ( $range === null || $range ) ) {
+		if ( $v[0] === $exp && ( $range === null || $range ) ) {
 			$v = intval( trim( substr( $v, 1 ) ) );
 
 			if ( $exp === '>' && $value > $v ) {

--- a/src/DataValues/ValueValidators/PatternConstraintValueValidator.php
+++ b/src/DataValues/ValueValidators/PatternConstraintValueValidator.php
@@ -90,7 +90,7 @@ class PatternConstraintValueValidator implements ConstraintValueValidator {
 		$pattern = str_replace( "/\\", "\\", $pattern );
 
 		// Add a mandatory backslash
-		if ( $pattern !== '' && $pattern{0} !== '/' ) {
+		if ( $pattern !== '' && $pattern[0] !== '/' ) {
 			$pattern = '/' . $pattern;
 		}
 

--- a/src/Elastic/Indexer/Indexer.php
+++ b/src/Elastic/Indexer/Indexer.php
@@ -773,7 +773,7 @@ class Indexer {
 
 		$title = $subject->getDBKey();
 
-		if ( $subject->getNamespace() !== SMW_NS_PROPERTY || $title{0} !== '_' ) {
+		if ( $subject->getNamespace() !== SMW_NS_PROPERTY || $title[0] !== '_' ) {
 			$title = str_replace( '_', ' ', $title );
 		}
 

--- a/src/Elastic/QueryEngine/DescriptionInterpreters/SomeValueInterpreter.php
+++ b/src/Elastic/QueryEngine/DescriptionInterpreters/SomeValueInterpreter.php
@@ -162,7 +162,7 @@ class SomeValueInterpreter {
 			// the standard analyzer splits CJK terms into single characters
 			if ( $this->conditionBuilder->getOption( 'cjk.best.effort.proximity.match', false ) && CharExaminer::isCJK( $value ) ) {
 
-				if ( $value{0} === '*' ) {
+				if ( $value[0] === '*' ) {
 					$value = substr( $value, 1 );
 				}
 
@@ -187,12 +187,12 @@ class SomeValueInterpreter {
 			// https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-query-string-query.html#_boolean_operators
 			if ( $this->conditionBuilder->getOption( 'query_string.boolean.operators' ) && ( strpos( $value, '+' ) !== false || strpos( $value, '-' ) !== false ) ) {
 				$match = $this->fieldMapper->query_string( "$pid.$field", $value );
-			} elseif ( ( $hasWildcard && $value{0} === '*' ) && $this->conditionBuilder->getOption( 'cjk.best.effort.proximity.match', false ) && CharExaminer::isCJK( $value ) ) {
+			} elseif ( ( $hasWildcard && $value[0] === '*' ) && $this->conditionBuilder->getOption( 'cjk.best.effort.proximity.match', false ) && CharExaminer::isCJK( $value ) ) {
 
 				// Avoid *...* on CJK related terms so that something like
 				// [[Has page::in:名古屋]] returns a better match accuracy given that
 				// the standard analyzer splits CJK terms into single characters
-				if ( $value{0} === '*' ) {
+				if ( $value[0] === '*' ) {
 					$value = mb_substr( $value, 1 );
 				}
 
@@ -204,7 +204,7 @@ class SomeValueInterpreter {
 				// matching single chars
 				$match = $this->fieldMapper->match( "$pid.$field", "\"$value\"" );
 
-			} elseif ( ( $hasWildcard && $value{0} === '*' ) || ( strpos( $value, '~?' ) !== false && $value{0} === '?' ) ) {
+			} elseif ( ( $hasWildcard && $value[0] === '*' ) || ( strpos( $value, '~?' ) !== false && $value[0] === '?' ) ) {
 				// ES notes "... In order to prevent extremely slow wildcard queries,
 				// a wildcard term should not start with one of the wildcards
 				// * or ? ..." therefore use `query_string` instead of a

--- a/src/Elastic/QueryEngine/DescriptionInterpreters/ValueDescriptionInterpreter.php
+++ b/src/Elastic/QueryEngine/DescriptionInterpreters/ValueDescriptionInterpreter.php
@@ -166,7 +166,7 @@ class ValueDescriptionInterpreter {
 
 		// Wide proximity uses ~~ as identifier as in [[~~ ... ]] or
 		// [[in:fox jumps]]
-		if ( $value{0} === '~' ) {
+		if ( $value[0] === '~' ) {
 			$isWide = true;
 
 			// Remove the ~ to avoid a `QueryShardException[Failed to parse query ...`
@@ -231,7 +231,7 @@ class ValueDescriptionInterpreter {
 			return false;
 		}
 
-		if ( $text{0} === '*' ) {
+		if ( $text[0] === '*' ) {
 			$text = mb_substr( $text, 1 );
 		}
 

--- a/src/Elastic/QueryEngine/FieldMapper.php
+++ b/src/Elastic/QueryEngine/FieldMapper.php
@@ -76,7 +76,7 @@ class FieldMapper {
 	 * @return boolean
 	 */
 	public static function isPhrase( $value = '' ) {
-		return $value{0} === '"' && substr( $value, -1 ) === '"';
+		return $value[0] === '"' && substr( $value, -1 ) === '"';
 	}
 
 	/**
@@ -272,7 +272,7 @@ class FieldMapper {
 		}
 
 		// Is it a phrase match as in "Foo bar"?
-		if ( $value !=='' && $value{0} === '"' && substr( $value, -1 ) === '"' ) {
+		if ( $value !=='' && $value[0] === '"' && substr( $value, -1 ) === '"' ) {
 			return $this->match_phrase( $field, trim( $value, '"' ) );
 		}
 
@@ -426,7 +426,7 @@ class FieldMapper {
 
 			// Use case: `[[Has text::~foo*]]`, `[[Has text::~foo]]`
 			// - add Boolean + which translates into "must be present"
-			if ( $value{0} !== '*' ) {
+			if ( $value[0] !== '*' ) {
 				$value = "+$value";
 			}
 

--- a/src/Elastic/QueryEngine/QueryEngine.php
+++ b/src/Elastic/QueryEngine/QueryEngine.php
@@ -327,7 +327,7 @@ class QueryEngine implements IQueryEngine {
 			if (
 				$dataItem->getNamespace() === SMW_NS_PROPERTY &&
 				( $dbKey = $dataItem->getDBKey() ) &&
-				$dbKey{0} === '_' ) {
+				$dbKey[0] === '_' ) {
 
 				try {
 					$property = DIProperty::newFromUserLabel( $dbKey );

--- a/src/Exporter/Element/ExpResource.php
+++ b/src/Exporter/Element/ExpResource.php
@@ -62,7 +62,7 @@ class ExpResource extends ExpElement {
 	 * @return boolean
 	 */
 	public function isBlankNode() {
-		return $this->uri === '' || $this->uri{0} == '_';
+		return $this->uri === '' || $this->uri[0] == '_';
 	}
 
 	/**

--- a/src/Exporter/ExpResourceMapper.php
+++ b/src/Exporter/ExpResourceMapper.php
@@ -205,7 +205,7 @@ class ExpResourceMapper {
 		$resource->isImported = $importDataItem instanceof DataItem;
 		$dbKey = $diWikiPage->getDBkey();
 
-		if ( $diWikiPage->getNamespace() === SMW_NS_PROPERTY && $dbKey !== '' && $dbKey{0} !== '-' ) {
+		if ( $diWikiPage->getNamespace() === SMW_NS_PROPERTY && $dbKey !== '' && $dbKey[0] !== '-' ) {
 			$resource->isUserDefined = DIProperty::newFromUserLabel( $diWikiPage->getDBkey() )->isUserDefined();
 		}
 
@@ -246,7 +246,7 @@ class ExpResourceMapper {
 		}
 
 		if ( ( $localName === '' ) ||
-		     ( in_array( $localName{0}, [ '-', '0', '1', '2', '3', '4', '5', '6', '7', '8', '9' ] ) ) ||
+		     ( in_array( $localName[0], [ '-', '0', '1', '2', '3', '4', '5', '6', '7', '8', '9' ] ) ) ||
 		     ( $hasFixedNamespace && strpos( $localName, '/' ) !== false )
 		     ) {
 			$namespace = Exporter::getInstance()->getNamespaceUri( 'wiki' );

--- a/src/GlobalFunctions.php
+++ b/src/GlobalFunctions.php
@@ -170,7 +170,7 @@ function smwfCacheKey( $namespace, $key ) {
 
 	$cachePrefix = $GLOBALS['wgCachePrefix'] === false ? wfWikiID() : $GLOBALS['wgCachePrefix'];
 
-	if ( $namespace{0} !== ':' ) {
+	if ( $namespace[0] !== ':' ) {
 		$namespace = ':' . $namespace;
 	}
 

--- a/src/HashBuilder.php
+++ b/src/HashBuilder.php
@@ -156,7 +156,7 @@ class HashBuilder {
 
 		// A leading underscore is an internal SMW convention to describe predefined
 		// properties and as such need to be transformed into a valid representation
-		if ( $title{0} === '_' ) {
+		if ( $title[0] === '_' ) {
 			$title = str_replace( ' ', '_', PropertyRegistry::getInstance()->findPropertyLabelById( $title ) );
 		}
 

--- a/src/Importer/ContentModeller.php
+++ b/src/Importer/ContentModeller.php
@@ -107,7 +107,7 @@ class ContentModeller {
 	}
 
 	private function normalizeFile( $fileDir, $file ) {
-		return str_replace( [ '\\', '/' ], DIRECTORY_SEPARATOR, $fileDir . ( $file{0} === '/' ? '' : '/' ) . $file );
+		return str_replace( [ '\\', '/' ], DIRECTORY_SEPARATOR, $fileDir . ( $file[0] === '/' ? '' : '/' ) . $file );
 	}
 
 }

--- a/src/MediaWiki/Api/Browse.php
+++ b/src/MediaWiki/Api/Browse.php
@@ -83,7 +83,7 @@ class Browse extends ApiBase {
 				// https://www.mediawiki.org/wiki/API:JSON_version_2
 				// " ... can indicate that a property beginning with an underscore ..."
 				foreach ( $value as $k => $v ) {
-					if ( $k{0} === '_' ) {
+					if ( $k[0] === '_' ) {
 						$result->addPreserveKeysList( 'query', $k );
 					}
 				}

--- a/src/MediaWiki/Api/Browse/ListLookup.php
+++ b/src/MediaWiki/Api/Browse/ListLookup.php
@@ -130,7 +130,7 @@ class ListLookup extends Lookup {
 		if ( isset( $parameters['search'] ) && isset( $parameters['strict'] ) ) {
 			$search = $parameters['search'];
 
-			if ( $search !== '' && $search{0} !== '_' ) {
+			if ( $search !== '' && $search[0] !== '_' ) {
 				$search = str_replace( "_", " ", $search );
 			}
 
@@ -142,7 +142,7 @@ class ListLookup extends Lookup {
 		} elseif ( isset( $parameters['search'] ) ) {
 			$search = $parameters['search'];
 
-			if ( $search !== '' && $search{0} !== '_' ) {
+			if ( $search !== '' && $search[0] !== '_' ) {
 				$search = str_replace( "_", " ", $search );
 			}
 

--- a/src/MediaWiki/Api/Browse/PSubjectLookup.php
+++ b/src/MediaWiki/Api/Browse/PSubjectLookup.php
@@ -179,7 +179,7 @@ class PSubjectLookup extends Lookup {
 		if ( isset( $parameters['search'] ) && $parameters['search'] !== '' ) {
 			$search = $parameters['search'];
 
-			if ( $search !== '' && $search{0} !== '_' ) {
+			if ( $search !== '' && $search[0] !== '_' ) {
 				$search = str_replace( "_", " ", $search );
 			}
 

--- a/src/MediaWiki/Api/PropertyListByApiRequest.php
+++ b/src/MediaWiki/Api/PropertyListByApiRequest.php
@@ -200,7 +200,7 @@ class PropertyListByApiRequest {
 			return $requestOptions;
 		}
 
-		if ( $property{0} !== '_' ) {
+		if ( $property[0] !== '_' ) {
 			$property = str_replace( "_", " ", $property );
 		}
 

--- a/src/MediaWiki/Connection/Query.php
+++ b/src/MediaWiki/Connection/Query.php
@@ -173,7 +173,7 @@ class Query {
 			foreach ( $join[1] as $table => $value ) {
 
 				if ( is_string( $table ) ) {
-					$value = $value{0} . $value{1} === 'ON' ? "$value" : "AS $value";
+					$value = $value[0] . $value[1] === 'ON' ? "$value" : "AS $value";
 					$value = $this->connection->tableName( $table ) . " $value";
 				}
 

--- a/src/MediaWiki/LinkBatch.php
+++ b/src/MediaWiki/LinkBatch.php
@@ -97,12 +97,12 @@ class LinkBatch {
 			return;
 		}
 
-		// PHP 5.6! -> PHP 7 $dataItem->getDBKey(){0}
+		// PHP 5.6! -> PHP 7 $dataItem->getDBKey()[0]
 		$dbkey = $dataItem->getDBKey();
 
 		// Avoid "... ParameterAssertionException: Bad value for parameter
 		// $dbkey: invalid DB key '_ASK'"
-		if ( $dbkey !== '' && $dbkey{0} === '_' ) {
+		if ( $dbkey !== '' && $dbkey[0] === '_' ) {
 			return;
 		}
 

--- a/src/MediaWiki/Search/ExtendedSearch.php
+++ b/src/MediaWiki/Search/ExtendedSearch.php
@@ -274,7 +274,7 @@ class ExtendedSearch {
 
 		// Avoid MW's auto formatting of title entities
 		if ( $search !== '' ) {
-			$search{0} = strtolower( $search{0} );
+			$search[0] = strtolower( $search[0] );
 		}
 
 		if ( $this->hasPrefixAndMinLenForCompletionSearch( $search, $minLen ) ) {

--- a/src/MediaWiki/Search/ExtendedSearchEngine.php
+++ b/src/MediaWiki/Search/ExtendedSearchEngine.php
@@ -271,7 +271,7 @@ class ExtendedSearchEngine extends SearchEngine {
 
 		// Avoid MW's auto formatting of title entities
 		if ( $search !== '' ) {
-			$search{0} = strtolower( $search{0} );
+			$search[0] = strtolower( $search[0] );
 		}
 
 		return $this->extendedSearch->completionSearch( $search );

--- a/src/MediaWiki/Specials/Ask/ParametersProcessor.php
+++ b/src/MediaWiki/Specials/Ask/ParametersProcessor.php
@@ -201,7 +201,7 @@ class ParametersProcessor {
 		foreach ( $printouts as $param ) {
 			$param = trim( $param );
 
-			if ( ( $param !== '' ) && ( $param { 0 } != '?' ) ) {
+			if ( ( $param !== '' ) && ( $param [0] != '?' ) ) {
 				$param = '?' . $param;
 			}
 
@@ -231,7 +231,7 @@ class ParametersProcessor {
 						$val = self::replace( '0x7C', '|', $val );
 					}
 
-					$parameters[] = $k == 0 && $key{0} == '?' ? $key . '=' . $val : $val;
+					$parameters[] = $k == 0 && $key[0] == '?' ? $key . '=' . $val : $val;
 				}
 			} elseif ( is_string( $key ) ) {
 				$parameters[$key] = $value;
@@ -245,11 +245,11 @@ class ParametersProcessor {
 
 	private static function hasPipe( $key, $value ) {
 
-		if ( $key !== '' && $key{0} == '?' && strpos( $value, '|' ) !== false ) {
+		if ( $key !== '' && $key[0] == '?' && strpos( $value, '|' ) !== false ) {
 			return true;
 		}
 
-		if ( is_string( $value ) && $value !== '' && $value{0} == '?' && strpos( $value, '|' ) !== false ) {
+		if ( is_string( $value ) && $value !== '' && $value[0] == '?' && strpos( $value, '|' ) !== false ) {
 			return true;
 		}
 

--- a/src/MediaWiki/Specials/SearchByProperty/PageRequestOptions.php
+++ b/src/MediaWiki/Specials/SearchByProperty/PageRequestOptions.php
@@ -93,7 +93,7 @@ class PageRequestOptions {
 		$value = isset( $this->requestOptions['value'] ) ? $this->requestOptions['value'] : next( $params );
 
 		// Auto-generated link is marked with a leading :
-		if ( $property !== '' && $property{0} === ':' ) {
+		if ( $property !== '' && $property[0] === ':' ) {
 			$escaped = true;
 			$property = $this->urlEncoder->unescape( ltrim( $property, ':' ) );
 		}

--- a/src/MediaWiki/Specials/SpecialBrowse.php
+++ b/src/MediaWiki/Specials/SpecialBrowse.php
@@ -56,7 +56,7 @@ class SpecialBrowse extends SpecialPage {
 		}
 
 		// Auto-generated link is marked with a leading :
-		if ( $query !== '' && $query{0} === ':' ) {
+		if ( $query !== '' && $query[0] === ':' ) {
 			$articletext = Encoder::unescape( $query );
 		} elseif ( $articletext === null ) {
 			$articletext = $query;

--- a/src/ParserFunctions/AskParserFunction.php
+++ b/src/ParserFunctions/AskParserFunction.php
@@ -250,7 +250,7 @@ class AskParserFunction {
 
 			// Skip the first (being the condition) and other marked
 			// printrequests
-			if ( $key == 0 || ( $value !== '' && $value{0} === '?' ) ) {
+			if ( $key == 0 || ( $value !== '' && $value[0] === '?' ) ) {
 				continue;
 			}
 

--- a/src/ParserFunctions/SubobjectParserFunction.php
+++ b/src/ParserFunctions/SubobjectParserFunction.php
@@ -298,7 +298,7 @@ class SubobjectParserFunction {
 
 			// Normalize property names to generate the same hash for when
 			// CapitalLinks is enabled (has foo === Has foo)
-			if ( $property !== '' && $property{0} !== '@' && $this->isCapitalLinks ) {
+			if ( $property !== '' && $property[0] !== '@' && $this->isCapitalLinks ) {
 				$property = mb_strtoupper( mb_substr( $property, 0, 1 ) ) . mb_substr( $property, 1 );
 			}
 

--- a/src/PostProcHandler.php
+++ b/src/PostProcHandler.php
@@ -364,7 +364,7 @@ class PostProcHandler {
 				// framework and without further computation) anticipate whether
 				// this influences a query or not, it is a good enough heuristic
 				// to allow to continue the postProc.
-				if ( $propertyList[$pid]{0} !== '_' ) {
+				if ( $propertyList[$pid][0] !== '_' ) {
 					return true;
 				}
 

--- a/src/PropertyAliasFinder.php
+++ b/src/PropertyAliasFinder.php
@@ -140,7 +140,7 @@ class PropertyAliasFinder {
 		}
 
 		// Indicates an untranslated MW message key
-		if ( $label !== '' && $label{0} === '<' ) {
+		if ( $label !== '' && $label[0] === '<' ) {
 			return null;
 		}
 

--- a/src/Query/Parser/LegacyParser.php
+++ b/src/Query/Parser/LegacyParser.php
@@ -436,7 +436,7 @@ class LegacyParser implements Parser {
 		$sep = $this->readChunk( '', false );
 
 		if ( ( $sep == '::' ) || ( $sep == ':=' ) ) {
-			if ( $chunk{0} != ':' ) { // property statement
+			if ( $chunk[0] != ':' ) { // property statement
 				return $this->getPropertyDescription( $chunk, $setNS );
 			} else { // escaped article description, read part after :: to get full contents
 				$chunk .= $this->readChunk( '\[\[|\]\]|\|\||\|' );
@@ -471,7 +471,7 @@ class LegacyParser implements Parser {
 
 				// [[Category:!Foo]]
 				// Only the ElasticStore does actively support this construct
-				if ( $chunk{0} === '!' ) {
+				if ( $chunk[0] === '!' ) {
 					$chunk = substr( $chunk, 1 );
 					$isNegation = true;
 				}
@@ -532,7 +532,7 @@ class LegacyParser implements Parser {
 
 		// First process property chain syntax (e.g. "property1.property2::value"),
 		// escaped by initial " ":
-		$propertynames = ( $propertyName{0} == ' ' ) ? [ $propertyName ] : explode( '.', $propertyName );
+		$propertynames = ( $propertyName[0] == ' ' ) ? [ $propertyName ] : explode( '.', $propertyName );
 		$propertyValueList = [];
 
 		$typeid = '_wpg';

--- a/src/Query/Parser/TermParser.php
+++ b/src/Query/Parser/TermParser.php
@@ -114,7 +114,7 @@ class TermParser {
 			$new = trim( $t_term );
 
 			$continue = true;
-			$space = $t_term{0} == ' ' ? ' ' : '';
+			$space = $t_term[0] == ' ' ? ' ' : '';
 
 			// Look ahead
 			$next = next( $terms );

--- a/src/Query/PrintRequest.php
+++ b/src/Query/PrintRequest.php
@@ -133,7 +133,7 @@ class PrintRequest {
 			return;
 		}
 
-		$this->labelMarker = $text !== '' && $text{0} === '#';
+		$this->labelMarker = $text !== '' && $text[0] === '#';
 	}
 
 	/**

--- a/src/Query/QueryLinker.php
+++ b/src/Query/QueryLinker.php
@@ -99,7 +99,7 @@ class QueryLinker {
 			}
 
 			// Avoid predefined properties to appear as key as in _MDAT
-			if ( $key !== '' && $key{0} === '_' ) {
+			if ( $key !== '' && $key[0] === '_' ) {
 				$key = DIProperty::newFromUserLabel( $key )->getLabel();
 			} else {
 				$key = str_replace( '_', ' ', $key );

--- a/src/SQLStore/EntityStore/DataItemHandlers/DIWikiPageHandler.php
+++ b/src/SQLStore/EntityStore/DataItemHandlers/DIWikiPageHandler.php
@@ -193,7 +193,7 @@ class DIWikiPageHandler extends DataItemHandler {
 
 		// Correctly interpret internal property keys
 		if ( $namespace == SMW_NS_PROPERTY && $dbkeys[0] != '' &&
-			$dbkeys[0]{0} == '_' && $dbkeys[2] == '' ) {
+			$dbkeys[0][0] == '_' && $dbkeys[2] == '' ) {
 
 			try {
 				$property = new DIProperty( $dbkeys[0] );

--- a/src/SQLStore/EntityStore/EntityIdManager.php
+++ b/src/SQLStore/EntityStore/EntityIdManager.php
@@ -817,7 +817,7 @@ class EntityIdManager {
 			( $iw === '' || $iw == SMW_SQL3_SMWINTDEFIW ) && $title != '' ) {
 
 			// Check if this is a predefined property:
-			if ( $title{0} != '_' ) {
+			if ( $title[0] != '_' ) {
 				// This normalization also applies to
 				// subobjects of predefined properties.
 				$newTitle = PropertyRegistry::getInstance()->findPropertyIdByLabel( str_replace( '_', ' ', $title ) );

--- a/src/SQLStore/EntityStore/PrefetchItemLookup.php
+++ b/src/SQLStore/EntityStore/PrefetchItemLookup.php
@@ -143,7 +143,7 @@ class PrefetchItemLookup {
 				$hash = $subject->getHash();
 
 				// Avoid reference to something like `__foo_bar#102##` (predefined property)
-				if ( $subject->getNamespace() === SMW_NS_PROPERTY && $hash{0} === '_' ) {
+				if ( $subject->getNamespace() === SMW_NS_PROPERTY && $hash[0] === '_' ) {
 					$property = DIProperty::newFromUserLabel(
 						$subject->getDBKey()
 					);

--- a/src/SQLStore/EntityStore/PropertySubjectsLookup.php
+++ b/src/SQLStore/EntityStore/PropertySubjectsLookup.php
@@ -341,7 +341,7 @@ class PropertySubjectsLookup {
 	public function newFromRow( $row ) {
 
 		try {
-			if ( $row->smw_iw === '' || $row->smw_iw{0} != ':' ) { // filter special objects
+			if ( $row->smw_iw === '' || $row->smw_iw[0] != ':' ) { // filter special objects
 
 				$keys = [
 					$row->smw_title,

--- a/src/SQLStore/EntityStore/SemanticDataLookup.php
+++ b/src/SQLStore/EntityStore/SemanticDataLookup.php
@@ -722,7 +722,7 @@ class SemanticDataLookup {
 		if ( $valueCount < 3 ||
 			implode( '', $fields ) !== FieldType::FIELD_ID ||
 			$valueKeys[2] === '' ||
-			$valueKeys[2]{0} != ':' ) {
+			$valueKeys[2][0] != ':' ) {
 
 			if ( isset( $result[$hash] ) ) {
 				$this->reportDuplicate( $propertykey, $valueKeys );

--- a/src/SQLStore/Lookup/MonolingualTextLookup.php
+++ b/src/SQLStore/Lookup/MonolingualTextLookup.php
@@ -110,7 +110,7 @@ class MonolingualTextLookup {
 			$subobjectName = $subject->getSubobjectName();
 
 			// Handle predefined properties
-			if ( $subject->getNamespace() === SMW_NS_PROPERTY && ( $dbKey = $subject->getDBKey() ) && $dbKey{0} === '_' ) {
+			if ( $subject->getNamespace() === SMW_NS_PROPERTY && ( $dbKey = $subject->getDBKey() ) && $dbKey[0] === '_' ) {
 				$subject = DIProperty::newFromUserLabel( $dbKey )->getCanonicalDIWikiPage(
 					$subobjectName
 				);

--- a/src/SQLStore/QueryEngine/QueryEngine.php
+++ b/src/SQLStore/QueryEngine/QueryEngine.php
@@ -433,7 +433,7 @@ class QueryEngine implements QueryEngineInterface, LoggerAwareInterface {
 		);
 
 		while ( ( $count < $query->getLimit() ) && ( $row = $connection->fetchObject( $res ) ) ) {
-			if ( $row->iw === '' || $row->iw{0} != ':' )  {
+			if ( $row->iw === '' || $row->iw[0] != ':' )  {
 
 				// Catch exception for non-existing predefined properties that
 				// still registered within non-updated pages (@see bug 48711)
@@ -445,7 +445,7 @@ class QueryEngine implements QueryEngineInterface, LoggerAwareInterface {
 						'',
 						$row->so
 					] );
-					
+
 					// Register the ID in an event the post-proceesing
 					// fails (namespace no longer valid etc.)
 					$dataItem->setId( $row->id );

--- a/src/SQLStore/Rebuilder/EntityValidator.php
+++ b/src/SQLStore/Rebuilder/EntityValidator.php
@@ -202,7 +202,7 @@ class EntityValidator {
 			$row->smw_iw != SMW_SQL3_SMWIW_OUTDATED &&
 			// Leave any pre-defined property (_...) untouched
 			$row->smw_title != '' &&
-			$row->smw_title{0} != '_' &&
+			$row->smw_title[0] != '_' &&
 			// smw_proptable_hash === null means it is not a subject but an object value
 			$row->smw_proptable_hash === null;
 	}
@@ -246,7 +246,7 @@ class EntityValidator {
 
 			// Check if both make a reference to a predefined representation
 			// and if not, skip
-			if ( $v{0} === '_' && $row->smw_title{0} !== '_' ) {
+			if ( $v[0] === '_' && $row->smw_title[0] !== '_' ) {
 				continue;
 			}
 

--- a/src/SQLStore/Rebuilder/Rebuilder.php
+++ b/src/SQLStore/Rebuilder/Rebuilder.php
@@ -324,7 +324,7 @@ class Rebuilder {
 	private function checkRow( $row ) {
 
 		// Find page to refresh, even for special properties:
-		if ( $row->smw_title != '' && $row->smw_title{0} != '_' ) {
+		if ( $row->smw_title != '' && $row->smw_title[0] != '_' ) {
 			$titleKey = $row->smw_title;
 		} elseif ( $this->entityValidator->isProperty( $row ) ) {
 			$titleKey = str_replace( ' ', '_', PropertyRegistry::getInstance()->findCanonicalPropertyLabelById( $row->smw_title ) );

--- a/src/Site.php
+++ b/src/Site.php
@@ -124,7 +124,7 @@ class Site {
 	 */
 	public static function id( $affix = '' ) {
 
-		if ( $affix !== '' && $affix{0} !== ':' ) {
+		if ( $affix !== '' && $affix[0] !== ':' ) {
 			$affix = ':' . $affix;
 		}
 

--- a/src/Utils/Csv.php
+++ b/src/Utils/Csv.php
@@ -47,7 +47,7 @@ class Csv {
 		$handle = fopen( 'php://temp', 'r+' );
 
 		// fputcsv(): delimiter must be a single character
-		$sep = $sep !== '' ? $sep{0} : self::DEFAULT_SEP;
+		$sep = $sep !== '' ? $sep[0] : self::DEFAULT_SEP;
 
 		// https://en.wikipedia.org/wiki/Comma-separated_values#Standardization
 		// http://php.net/manual/en/function.fputcsv.php

--- a/tests/phpunit/Integration/JSONScript/readmeContentsBuilder.php
+++ b/tests/phpunit/Integration/JSONScript/readmeContentsBuilder.php
@@ -60,8 +60,8 @@ class ReadmeContentsBuilder {
 
 		foreach ( $this->findFilesFor( $path, 'json' ) as $key => $location ) {
 
-			if ( $previousFirstKey !== $key{0} ) {
-				$list .= "\n" . '### ' . ucfirst( $key{0} ). "\n";
+			if ( $previousFirstKey !== $key[0] ) {
+				$list .= "\n" . '### ' . ucfirst( $key[0] ). "\n";
 			}
 
 			$list .= '* [' . $key .'](' . $urlLocation . '/' . $key . ')';
@@ -82,7 +82,7 @@ class ReadmeContentsBuilder {
 
 			$list .= "\n";
 			$counter++;
-			$previousFirstKey = $key{0};
+			$previousFirstKey = $key[0];
 		}
 
 		$head = "## $title\n\n";

--- a/tests/phpunit/Unit/ParserFunctions/SubobjectParserFunctionTest.php
+++ b/tests/phpunit/Unit/ParserFunctions/SubobjectParserFunctionTest.php
@@ -106,7 +106,7 @@ class SubobjectParserFunctionTest extends \PHPUnit_Framework_TestCase {
 		// If it is enabled only check for the first character {0} that should
 		// contain '_' as the rest is going to be an unknown hash value
 		$id = $subobject->getSubobjectId();
-		$this->assertEquals( $expected['identifier'], $isEnabled ? $id{0} : $id );
+		$this->assertEquals( $expected['identifier'], $isEnabled ? $id[0] : $id );
 
 		$parserData = new ParserData( $title, $parserOutput );
 

--- a/tests/phpunit/Unit/TypesRegistryTest.php
+++ b/tests/phpunit/Unit/TypesRegistryTest.php
@@ -73,7 +73,7 @@ class TypesRegistryTest extends \PHPUnit_Framework_TestCase {
 	 * @dataProvider typeList
 	 */
 	public function testTypeList_FirstCharUnderscore( $key, $def ) {
-		$this->assertTrue( $key{0} === '_' );
+		$this->assertTrue( $key[0] === '_' );
 	}
 
 	/**
@@ -94,7 +94,7 @@ class TypesRegistryTest extends \PHPUnit_Framework_TestCase {
 	 * @dataProvider propertyList
 	 */
 	public function testPropertyList_FirstCharUnderscore( $key, $def ) {
-		$this->assertTrue( $key{0} === '_' );
+		$this->assertTrue( $key[0] === '_' );
 	}
 
 	public function typeList() {

--- a/tests/phpunit/Utils/JSONScript/JsonTestCaseFileHandler.php
+++ b/tests/phpunit/Utils/JSONScript/JsonTestCaseFileHandler.php
@@ -164,8 +164,8 @@ class JsonTestCaseFileHandler {
 				$version = defined( 'PHP_VERSION' ) ? PHP_VERSION : 0;
  			}
 
-			if ( $versionToSkip !== '' && ( $versionToSkip{0} === '<' || $versionToSkip{0} === '>' ) ) {
-				$compare = $versionToSkip{0};
+			if ( $versionToSkip !== '' && ( $versionToSkip[0] === '<' || $versionToSkip[0] === '>' ) ) {
+				$compare = $versionToSkip[0];
 				$versionToSkip = substr( $versionToSkip, 1 );
 			}
 

--- a/tests/phpunit/Utils/JSONScript/QueryTestCaseInterpreter.php
+++ b/tests/phpunit/Utils/JSONScript/QueryTestCaseInterpreter.php
@@ -136,7 +136,7 @@ class QueryTestCaseInterpreter {
 				$parameters = $printout;
 			}
 
-			if ( $label{0} === '_' ) {
+			if ( $label[0] === '_' ) {
 				$printRequest = new PrintRequest(
 					PrintRequest::PRINT_PROP,
 					null,

--- a/tests/phpunit/includes/dataitems/DIPropertyTest.php
+++ b/tests/phpunit/includes/dataitems/DIPropertyTest.php
@@ -131,7 +131,7 @@ class DIPropertyTest extends \PHPUnit_Framework_TestCase {
 
 		$this->assertEquals(
 			'-',
-			$label{0}
+			$label[0]
 		);
 	}
 


### PR DESCRIPTION
This PR is made in reference to: #4294 

This PR addresses or contains:
- Replace deprecated[1] curly brace syntax for array offset access with square bracket syntax.

This PR includes:
- [x] CI build passed

---
[1] https://wiki.php.net/rfc/deprecate_curly_braces_array_access