### PR TITLE
Avoid offset access warnings in DIProperty

### DIFF
--- a/includes/dataitems/SMW_DI_Property.php
+++ b/includes/dataitems/SMW_DI_Property.php
@@ -464,6 +464,9 @@ class DIProperty extends SMWDataItem {
 	 * @return DIProperty object
 	 */
 	public static function newFromUserLabel( $label, $inverse = false, $languageCode = false ) {
+		// [#4294] Convert the passed-in label to a string value
+		// Avoids warning "Trying to access array offset on value of type X" on PHP 7.4+
+		$label = strval( $label );
 
 		if ( $label !== '' && $label{0} == '-' ) {
 			$label = substr( $label, 1 );
@@ -501,6 +504,9 @@ class DIProperty extends SMWDataItem {
 	}
 
 	private function newDIWikiPage( $dbkey, $subobjectName ) {
+		// [#4294] Convert the passed-in dbkey to a string value
+		// Avoids warning "Trying to access array offset on value of type X" on PHP 7.4+
+		$dbkey = strval( $dbkey );
 
 		// If an inverse marker is present just omit the marker so a normal
 		// property page link can be produced independent of its directionality


### PR DESCRIPTION
This PR is made in reference to: #4294

This PR addresses or contains:
- Avoid offset access warnings (`Trying to access array offset on value of type int`)[1] on PHP 7.4+ in `DIProperty` by casting the corresponding parameters to strings.

---
[1] https://github.com/php/php-src/blob/PHP-7.4/UPGRADING#L362

This PR includes:
- [ ] CI build passed
