### PR TITLE
Add parentheses to ternary operator in JsonTestCaseFileHandler

### DIFF
--- a/tests/phpunit/Utils/JSONScript/JsonTestCaseFileHandler.php
+++ b/tests/phpunit/Utils/JSONScript/JsonTestCaseFileHandler.php
@@ -377,7 +377,7 @@ class JsonTestCaseFileHandler {
 
 		// Needs special attention due to constant usage
 		if ( strpos( $key, 'CacheType' ) !== false && isset( $settings[$key] ) ) {
-			return $settings[$key] === false ? CACHE_NONE : defined( $settings[$key] ) ? constant( $settings[$key] ) : $settings[$key];
+			return $settings[$key] === false ? CACHE_NONE : ( defined( $settings[$key] ) ? constant( $settings[$key] ) : $settings[$key] );
 		}
 
 		if ( isset( $settings[$key] ) ) {


### PR DESCRIPTION
This PR is made in reference to: #4294 

This PR addresses or contains:
- Wrap a nested ternary operator in `JsonTestCaseFileHandler` with parentheses to avoid warning[1] in PHP 7.4: `Deprecated: Unparenthesized a ? b : c ? d : e is deprecated. Use either (a ? b : c) ? d : e or a ? b : (c ? d : e) in /usr/src/myapp/extensions/SemanticMediaWiki/tests/phpunit/Utils/JSONScript/JsonTestCaseFileHandler.php on line 380`

---
[1] https://github.com/php/php-src/blob/PHP-7.4/UPGRADING#L350

This PR includes:
- [ ] CI build passed

Fixes #