### PR TITLE
Fix missing use declaration; minor clean-up

### DIFF
--- a/src/Query/ResultPrinters/FileExportPrinter.php
+++ b/src/Query/ResultPrinters/FileExportPrinter.php
@@ -49,24 +49,21 @@ abstract class FileExportPrinter extends ResultPrinter implements ExportPrinter 
 	 * @param array $params
 	 */
 	public function outputAsFile( SMWQueryResult $queryResult, array $params ) {
-		$result = $this->getResult( $queryResult, $params, SMW_OUTPUT_FILE );
 
 		if ( $this->httpHeader ) {
 			header( 'Content-type: ' . $this->getMimeType( $queryResult ) . '; charset=UTF-8' );
-		}
 
-		$fileName = $this->getFileName( $queryResult );
+			$fileName = $this->getFileName( $queryResult );
 
-		if ( $fileName !== false ) {
-			$utf8Name = rawurlencode( $fileName );
-			$fileName = iconv( "UTF-8", "ASCII//TRANSLIT", $fileName );
+			if ( $fileName !== false ) {
+				$utf8Name = rawurlencode( $fileName );
+				$fileName = iconv( "UTF-8", "ASCII//TRANSLIT", $fileName );
 
-			if ( $this->httpHeader ) {
 				header( "content-disposition: attachment; filename=\"$fileName\"; filename*=UTF-8''$utf8Name;" );
 			}
 		}
 
-		echo $result;
+		echo $this->getResult( $queryResult, $params, SMW_OUTPUT_FILE );
 	}
 
 	/**

--- a/src/Query/ResultPrinters/ResultPrinter.php
+++ b/src/Query/ResultPrinters/ResultPrinter.php
@@ -8,6 +8,7 @@ use ParamProcessor\ParamDefinition;
 use Sanitizer;
 use SMW\Message;
 use SMW\Parser\RecursiveTextProcessor;
+use SMW\Query\QueryContext;
 use SMW\Query\Result\StringResult;
 use SMW\Query\ResultPrinter as IResultPrinter;
 use SMWInfolink;
@@ -196,7 +197,7 @@ abstract class ResultPrinter implements IResultPrinter {
 	 *
 	 * @since 3.0
 	 *
-	 * @return Message
+	 * @return \Message
 	 */
 	public function msg() {
 		return wfMessage( func_get_args() );


### PR DESCRIPTION
This PR is made in reference to: #

This PR addresses or contains:
- SMW\Query\QueryContext was used but not pulled in in ResultPrinter.
- minor clean-up and optimization.

This PR includes:
- [ ] Tests (unit/integration)
- [x] CI build passed

Fixes #