### PR TITLE
Remove unused method ResultPrinter::setQueryContext()

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,15 +15,15 @@ matrix:
     - env: DB=sqlite; MW=REL1_33; PHPUNIT=6.5.*
       php: 7.3
     - env: DB=sqlite; MW=REL1_31; SITELANG=ja; PHPUNIT=5.7.*
-      php: 7.0
+      php: 7.1
     - env: DB=mysql; MW=REL1_31; BLAZEGRAPH=1.5.2; PHPUNIT=5.7.*
-      php: 7.0
+      php: 7.1
     - env: DB=mysql; MW=REL1_32; FUSEKI=2.4.0; PHPUNIT=5.7.*
       php: 7.1
     - env: DB=mysql; MW=REL1_31; VIRTUOSO=6.1; PHPUNIT=5.7.*
-      php: 7.0
+      php: 7.1
     - env: DB=mysql; MW=REL1_31; SESAME=2.8.7; PHPUNIT=5.7.*
-      php: 7.0
+      php: 7.1
     - env: DB=mysql; MW=master; PHPUNIT=6.5.*
       php: 7.3
     - env: DB=mysql; MW=REL1_33; ES=5.6.6; PHPUNIT=5.7.*

--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,7 @@
 		"source": "https://github.com/SemanticMediaWiki/SemanticMediaWiki"
 	},
 	"require": {
-		"php": ">=7.0",
+		"php": ">=7.1",
 		"ext-mbstring": "*",
 		"composer/installers": "1.*,>=1.0.1",
 		"psr/log": "~1.0",

--- a/src/Query/ResultPrinters/ResultPrinter.php
+++ b/src/Query/ResultPrinters/ResultPrinter.php
@@ -8,7 +8,6 @@ use ParamProcessor\ParamDefinition;
 use Sanitizer;
 use SMW\Message;
 use SMW\Parser\RecursiveTextProcessor;
-use SMW\Query\QueryContext;
 use SMW\Query\Result\StringResult;
 use SMW\Query\ResultPrinter as IResultPrinter;
 use SMWInfolink;
@@ -183,15 +182,6 @@ abstract class ResultPrinter implements IResultPrinter {
 	}
 
 	/**
-	 * @since 3.0
-	 *
-	 * @param integer $queryContext
-	 */
-	public function setQueryContext( $queryContext ) {
-		$this->mInline = $queryContext != QueryContext::SPECIAL_PAGE;
-	}
-
-	/**
 	 * This method is added temporary measures to avoid breaking those that relied
 	 * on the removed ContextSource interface.
 	 *
@@ -226,7 +216,7 @@ abstract class ResultPrinter implements IResultPrinter {
 	/**
 	 * @since 3.1
 	 *
-	 * @return Parser
+	 * @return \Parser
 	 */
 	public function copyParser() {
 
@@ -513,6 +503,7 @@ abstract class ResultPrinter implements IResultPrinter {
 	 * @param string $classAffix
 	 *
 	 * @return SMWInfolink
+	 * @throws \Exception
 	 */
 	protected function getLink( QueryResult $res, $outputMode, $classAffix = '' ) {
 		$link = $res->getQueryLink( $this->getSearchLabel( $outputMode ) );
@@ -543,6 +534,7 @@ abstract class ResultPrinter implements IResultPrinter {
 	 * @param $outputMode
 	 *
 	 * @return SMWInfolink
+	 * @throws \Exception
 	 */
 	protected function getFurtherResultsLink( QueryResult $res, $outputMode ) {
 		$link = $this->getLink( $res, $outputMode, 'furtherresults' );
@@ -602,7 +594,7 @@ abstract class ResultPrinter implements IResultPrinter {
 	 *
 	 * @since 3.0
 	 *
-	 * @return []
+	 * @return array[]
 	 */
 	protected function getResources() {
 		return [ 'modules' => [], 'styles' => [] ];

--- a/src/SQLStore/QueryEngine/HierarchyTempTableBuilder.php
+++ b/src/SQLStore/QueryEngine/HierarchyTempTableBuilder.php
@@ -180,7 +180,7 @@ class HierarchyTempTableBuilder {
 
 			// empty "new" table
 			$db->query(
-				'DELETE FROM ' . $tmpnew,
+				'TRUNCATE TABLE ' . $tmpnew,
 				__METHOD__
 			);
 

--- a/src/SQLStore/QueryEngine/HierarchyTempTableBuilder.php
+++ b/src/SQLStore/QueryEngine/HierarchyTempTableBuilder.php
@@ -180,7 +180,7 @@ class HierarchyTempTableBuilder {
 
 			// empty "new" table
 			$db->query(
-				'TRUNCATE TABLE ' . $tmpnew,
+				'DELETE FROM ' . $tmpnew,
 				__METHOD__
 			);
 


### PR DESCRIPTION
This PR is made in reference to: #4322 (https://github.com/SemanticMediaWiki/SemanticMediaWiki/pull/4322#issuecomment-540658354)

This PR addresses or contains:
* Remove unused method ResultPrinter::setQueryContext()

Text search for "setQueryContext" over all extensions I use did not turn up anything. This includes in particular SRF. I think it is safe to remove the method.

This PR includes:
- [ ] Tests (unit/integration)
- [ ] CI build passed

Fixes #