### PR TITLE
Use `DELETE FROM` instead of `TRUNCATE TABLE`

### DIFF
--- a/src/SQLStore/QueryEngine/HierarchyTempTableBuilder.php
+++ b/src/SQLStore/QueryEngine/HierarchyTempTableBuilder.php
@@ -180,7 +180,7 @@ class HierarchyTempTableBuilder {
 
 			// empty "new" table
 			$db->query(
-				'TRUNCATE TABLE ' . $tmpnew,
+				'DELETE FROM ' . $tmpnew,
 				__METHOD__
 			);
 


### PR DESCRIPTION
As of https://github.com/SemanticMediaWiki/SemanticMediaWiki/issues/4319#issuecomment-542713250 this can go forward, trying to fix that bug.

This PR is made in reference to: #4319

This PR addresses or contains:
- avoid committing open transactions

This PR includes:
- [ ] Tests (unit/integration)
- [ ] CI build passed

Fixes #4319