### PR TITLE
newEditInfo() change @since doc to 3.1

### DIFF
--- a/src/MediaWiki/MwCollaboratorFactory.php
+++ b/src/MediaWiki/MwCollaboratorFactory.php
@@ -185,7 +185,7 @@ class MwCollaboratorFactory {
 	}
 
 	/**
-	 * @since 2.5
+	 * @since 3.1
 	 *
 	 * @param WikiPage $wkiPage
 	 * @param Revision $revision


### PR DESCRIPTION
`newEditInfo` does not exist in version 3.0 version