### PR TITLE
Allow restoring behavior for format=list

### DIFF
--- a/DefaultSettings.php
+++ b/DefaultSettings.php
@@ -775,7 +775,7 @@ return [
 	'smwgResultFormats' => [
 		'table'      => 'SMW\Query\ResultPrinters\TableResultPrinter',
 		'broadtable' => 'SMW\Query\ResultPrinters\TableResultPrinter',
-		'list'       => 'SMW\Query\ResultPrinters\ListResultPrinter',
+		'richlist'   => 'SMW\Query\ResultPrinters\ListResultPrinter',
 		'plainlist'  => 'SMW\Query\ResultPrinters\ListResultPrinter',
 		'ol'         => 'SMW\Query\ResultPrinters\ListResultPrinter',
 		'ul'         => 'SMW\Query\ResultPrinters\ListResultPrinter',
@@ -806,7 +806,8 @@ return [
 	'smwgResultAliases' => [
 		'feed' => [ 'rss' ],
 		'templatefile' => [ 'template file' ],
-		'plainlist' => [ 'plain' ]
+		'plainlist' => [ 'plain' ],
+		'richlist' => [ 'list' ]
 	],
 	##
 

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -66,7 +66,7 @@
 	"smw_printername_debug": "Debug query (for experts)",
 	"smw_printername_embedded": "Embed page contents",
 	"smw_printername_json": "JSON export",
-	"smw_printername_list": "List",
+	"smw_printername_richlist": "List",
 	"smw_printername_plainlist": "Plain list",
 	"smw_printername_ol": "Enumeration",
 	"smw_printername_ul": "Itemization",

--- a/src/Query/ResultPrinters/ListResultPrinter/ListResultBuilder.php
+++ b/src/Query/ResultPrinters/ListResultPrinter/ListResultBuilder.php
@@ -28,7 +28,7 @@ class ListResultBuilder {
 			'other-fields-open' => ' (',
 			'other-fields-close' => ')',
 		],
-		'list' => [
+		'richlist' => [
 			'row-open-tag' => '<span class="smw-row">',
 			'row-close-tag' => '</span>',
 			'result-open-tag' => '<span class="smw-format list-format $CLASS$">',
@@ -127,7 +127,7 @@ class ListResultBuilder {
 
 		$format = $this->get( 'format' );
 
-		if ( in_array( $format, [ 'ol', 'ul', 'plainlist' ] ) ) {
+		if ( in_array( $format, [ 'ol', 'ul', 'plainlist', 'richlist' ] ) ) {
 			return $format;
 		}
 
@@ -135,7 +135,7 @@ class ListResultBuilder {
 			return 'plainlist';
 		}
 
-		return 'list';
+		return 'richlist';
 	}
 
 	/**


### PR DESCRIPTION
SMW <3.0 wikis that make extensive use of format=list cannot easily
be upgraded due to the breaking changes SMW 3.0 brings in the form
of added HTML in the list output. In big wikis switching over to
plainlist can be an inpractical amount of work (even with search and replace)
and be very error prone.

This change renames list to richlist and adds list as an alias to richlist.
It thus does not change SMW 3.1 behavior. It however does allow the user
to restore pre-3.0 behavior via the $smwgResultAliases setting:

```php
$smwgResultAliases['richlist'] = [];
$smwgResultAliases['plainlist'][] = ['list'];
```