### PR TITLE
Query test on pages with numeric titles

### DIFF
--- a/tests/phpunit/Integration/JSONScript/TestCases/p-1010.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/p-1010.json
@@ -1,0 +1,55 @@
+{
+	"description": "Query test on pages with numberic titles (T239877)",
+	"setup": [
+		{
+			"namespace": "SMW_NS_PROPERTY",
+			"page": "Has text property",
+			"contents": "[[Has type::Text]]"
+		},
+		{
+			"page": "143434343434",
+			"contents": "{{#set: Has text property=Query test on pages with numeric titles. }}"
+		},
+		{
+			"page": "243434343434",
+			"contents": "{{#ask: [[143434343434]] |?Has text property= |mainlabel=- }}"
+		},
+		{
+			"page": "343434343434",
+			"contents": "{{#show: 143434343434 |?Has text property }}"
+		}
+	],
+	"tests": [
+		{
+			"type": "parser",
+			"about": "#0 ask on numeric title",
+			"subject": "ask-numeric-title",
+			"assert-output": {
+				"to-contain": [
+					"Test on pages with numeric titles."
+				]
+			}
+		},
+		{
+			"type": "parser",
+			"about": "#1 show on numeric title",
+			"subject": "show-numeric-title",
+			"assert-output": {
+				"to-contain": [
+					"Test on pages with numeric titles."
+				]
+			}
+		}
+	],
+	"settings": {
+		"smwgNamespacesWithSemanticLinks": {
+			"NS_MAIN": true,
+			"SMW_NS_PROPERTY": true
+		}
+	},
+	"meta": {
+		"version": "2",
+		"is-incomplete": false,
+		"debug": false
+	}
+}

--- a/tests/phpunit/Integration/JSONScript/TestCases/p-1010.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/p-1010.json
@@ -26,7 +26,7 @@
 			"subject": "243434343434",
 			"assert-output": {
 				"to-contain": [
-					"Test on pages with numeric titles."
+					"Query test on pages with numeric titles."
 				]
 			}
 		},
@@ -36,7 +36,7 @@
 			"subject": "343434343434",
 			"assert-output": {
 				"to-contain": [
-					"Test on pages with numeric titles."
+					"Query test on pages with numeric titles."
 				]
 			}
 		}

--- a/tests/phpunit/Integration/JSONScript/TestCases/p-1010.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/p-1010.json
@@ -23,7 +23,7 @@
 		{
 			"type": "parser",
 			"about": "#0 ask on numeric title",
-			"subject": "ask-numeric-title",
+			"subject": "243434343434",
 			"assert-output": {
 				"to-contain": [
 					"Test on pages with numeric titles."
@@ -33,7 +33,7 @@
 		{
 			"type": "parser",
 			"about": "#1 show on numeric title",
-			"subject": "show-numeric-title",
+			"subject": "343434343434",
 			"assert-output": {
 				"to-contain": [
 					"Test on pages with numeric titles."


### PR DESCRIPTION
This PR is made in reference to: [T239877](https://phabricator.wikimedia.org/T239877)

This PR addresses or contains:
- Test to verify that we have no issues with numeric titles

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed