### PR TITLE
Add smwgPlainList setting

### DIFF
--- a/DefaultSettings.php
+++ b/DefaultSettings.php
@@ -810,6 +810,19 @@ return [
 	],
 	##
 
+	/**
+	 * Affects format=list.
+	 *
+	 * When set to false (the default), format=list will result in lists with HTML markup.
+	 * In this case you can get a plain list via format=plainlist.
+	 *
+	 * To also get plain lists (without HTML markup) when using format=list, set this setting to true.
+	 * In SMW versions older than 3.0 format=list always resulted in a plain list, so this setting allows restoring old behavior.
+	 *
+	 * @since 3.1.2
+	 */
+	'smwgPlainList' => false,
+
 	##
 	# Result printer features
 	#

--- a/includes/Settings.php
+++ b/includes/Settings.php
@@ -190,6 +190,7 @@ class Settings extends Options {
 			'smwgMandatorySubpropertyParentTypeInheritance' => $GLOBALS['smwgMandatorySubpropertyParentTypeInheritance'],
 			'smwgCheckForRemnantEntities' => $GLOBALS['smwgCheckForRemnantEntities'],
 			'smwgCheckForConstraintErrors' => $GLOBALS['smwgCheckForConstraintErrors'],
+			'smwgPlainList' => $GLOBALS['smwgPlainList'],
 		];
 
 		self::initLegacyMapping( $configuration );

--- a/src/Query/ResultPrinters/ListResultPrinter.php
+++ b/src/Query/ResultPrinters/ListResultPrinter.php
@@ -75,7 +75,7 @@ class ListResultPrinter extends ResultPrinter {
 	 */
 	private function getBuilder( SMWQueryResult $queryResult ) {
 
-		$builder = new ListResultBuilder( $queryResult, $this->mLinker );
+		$builder = new ListResultBuilder( $queryResult, $this->mLinker, $GLOBALS['smwgPlainList'] );
 
 		$builder->set( $this->params );
 

--- a/src/Query/ResultPrinters/ListResultPrinter/ListResultBuilder.php
+++ b/src/Query/ResultPrinters/ListResultPrinter/ListResultBuilder.php
@@ -68,19 +68,14 @@ class ListResultBuilder {
 
 	/** @var ParameterDictionary */
 	private $configuration;
-
 	private $templateRendererFactory;
+	private $listPlainByDefault;
 
-	/**
-	 * ListResultBuilder constructor.
-	 *
-	 * @param SMWQueryResult $queryResult
-	 * @param Linker $linker
-	 */
-	public function __construct( SMWQueryResult $queryResult, Linker $linker ) {
+	public function __construct( SMWQueryResult $queryResult, Linker $linker, bool $listPlainByDefault ) {
 		$this->linker = $linker;
 		$this->queryResult = $queryResult;
 		$this->configuration = new ParameterDictionary();
+		$this->listPlainByDefault = $listPlainByDefault;
 	}
 
 	/**
@@ -135,7 +130,7 @@ class ListResultBuilder {
 			return 'plainlist';
 		}
 
-		return 'list';
+		return $this->listPlainByDefault ? 'plainlist' : 'list';
 	}
 
 	/**

--- a/tests/phpunit/Integration/JSONScript/TestCases/f-0403.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/f-0403.json
@@ -1,0 +1,42 @@
+{
+	"description": "Test smwgPlainList setting",
+	"meta": {
+		"version": "2",
+		"is-incomplete": false,
+		"debug": true
+	},
+	"setup": [
+		{
+			"namespace": "SMW_NS_PROPERTY",
+			"page": "Version",
+			"contents": "[[Has type::Text]]"
+		},
+		{
+			"page": "f-0403/Data",
+			"contents": "[[Version::VeryVersion]]"
+		},
+		{
+			"page": "f-0403/Test-1",
+			"contents": "{{#ask:[[f-0403/Data]]|?Version|format=list}}"
+		}
+
+	],
+	"tests": [
+		{
+			"type": "format",
+			"about": "#1 format=list outputs plain list",
+			"subject": "f-0403/Test-1",
+			"assert-output": {
+				"to-contain": [
+						"VeryVersion"
+				],
+				"not-contain": [
+					"<span class=\"smw-format list-format"
+				]
+			}
+		}
+	],
+	"settings": {
+		"smwgPlainList": true
+	}
+}


### PR DESCRIPTION
SMW <3.0 wikis that make extensive use of format=list cannot easily
be upgraded due to the breaking changes SMW 3.0 brings in the form
of added HTML in the list output. In big wikis switching over to
plainlist can be an impractical amount of work (even with search and replace)
and be very error prone.

This change allows restoring old behavior.