### PR TITLE
Adapts integration test of pr 4367

### DIFF
--- a/tests/phpunit/Integration/JSONScript/TestCases/f-0403.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/f-0403.json
@@ -1,5 +1,5 @@
 {
-	"description": "Test smwgPlainList setting",
+	"description": "Test `smwgPlainList` configuration parameter (#4367)",
 	"meta": {
 		"version": "2",
 		"is-incomplete": false,
@@ -17,14 +17,14 @@
 		},
 		{
 			"page": "f-0403/Test-1",
-			"contents": "{{#ask:[[f-0403/Data]]|?Version|format=list}}"
+			"contents": "{{#ask: [[f-0403/Data]] |?Version |format=list }}"
 		}
 
 	],
 	"tests": [
 		{
-			"type": "format",
-			"about": "#1 format=list outputs plain list",
+			"type": "parser",
+			"about": "#0 format=list outputs plain list",
 			"subject": "f-0403/Test-1",
 			"assert-output": {
 				"to-contain": [

--- a/tests/phpunit/LightweightJsonTestCaseScriptRunner.php
+++ b/tests/phpunit/LightweightJsonTestCaseScriptRunner.php
@@ -191,7 +191,7 @@ abstract class LightweightJsonTestCaseScriptRunner extends JsonTestCaseScriptRun
 			'smwgElasticsearchConfig',
 			'smwgDefaultNumRecurringEvents',
 			'smwgMandatorySubpropertyParentTypeInheritance',
-			'smwgPlainList'
+			'smwgPlainList',
 
 			// MW related
 			'wgLanguageCode',

--- a/tests/phpunit/LightweightJsonTestCaseScriptRunner.php
+++ b/tests/phpunit/LightweightJsonTestCaseScriptRunner.php
@@ -191,6 +191,7 @@ abstract class LightweightJsonTestCaseScriptRunner extends JsonTestCaseScriptRun
 			'smwgElasticsearchConfig',
 			'smwgDefaultNumRecurringEvents',
 			'smwgMandatorySubpropertyParentTypeInheritance',
+			'smwgPlainList'
 
 			// MW related
 			'wgLanguageCode',


### PR DESCRIPTION
This PR is made in reference to: #4367 

This PR addresses or contains:
- Adapts integration test, by registering the new configuration parameter and switch to test type parser

This PR includes:
- [x] Tests (unit/integration)
- [ ] CI build passed