### PR TITLE
Make new constrictor argument optional

### DIFF
--- a/src/Query/ResultPrinters/ListResultPrinter/ListResultBuilder.php
+++ b/src/Query/ResultPrinters/ListResultPrinter/ListResultBuilder.php
@@ -71,11 +71,11 @@ class ListResultBuilder {
 	private $templateRendererFactory;
 	private $listPlainByDefault;
 
-	public function __construct( SMWQueryResult $queryResult, Linker $linker, bool $listPlainByDefault ) {
+	public function __construct( SMWQueryResult $queryResult, Linker $linker, bool $listPlainByDefault = null ) {
 		$this->linker = $linker;
 		$this->queryResult = $queryResult;
 		$this->configuration = new ParameterDictionary();
-		$this->listPlainByDefault = $listPlainByDefault;
+		$this->listPlainByDefault = $listPlainByDefault ?? $GLOBALS['smwgPlainList'];
 	}
 
 	/**


### PR DESCRIPTION
Since some SRF code is using this constructor

Fixes part of the failure seen at https://github.com/SemanticMediaWiki/SemanticResultFormats/pull/563
