### PR TITLE
Fix `filename` and method access sequence, refs 4375

### DIFF
--- a/tests/phpunit/Unit/Query/ResultPrinters/FileExportPrinterTest.php
+++ b/tests/phpunit/Unit/Query/ResultPrinters/FileExportPrinterTest.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace SMW\Tests\Query\ResultPrinters;
+
+/**
+ * @covers \SMW\Query\ResultPrinters\FileExportPrinter
+ * @group semantic-mediawiki
+ *
+ * @license GNU GPL v2+
+ * @since 3.2
+ *
+ * @author mwjames
+ */
+class FileExportPrinterTest extends \PHPUnit_Framework_TestCase {
+
+	public function testOutputAsFile_AccessSequence() {
+
+		$queryResult = $this->getMockBuilder( '\SMWQueryResult' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$fileExportPrinter = $this->getMockBuilder( '\SMW\Query\ResultPrinters\FileExportPrinter' )
+			->disableOriginalConstructor()
+			->setMethods( [ 'getFileResult', 'getMimeType', 'getFileName' ] )
+			->getMockForAbstractClass();
+
+		// #4375 (needs to be accessed first)
+		$fileExportPrinter->expects( $this->at( 0 ) )
+			->method( 'getFileResult' )
+			->with(
+				$this->equalTo( $queryResult ),
+				$this->anything() )
+			->will( $this->returnValue( __METHOD__ ) );
+
+		$fileExportPrinter->expects( $this->at( 1 ) )
+			->method( 'getMimeType' );
+
+		$fileExportPrinter->expects( $this->at( 2 ) )
+			->method( 'getFileName' );
+
+		$fileExportPrinter->disableHttpHeader();
+
+		$this->expectOutputString( __METHOD__ );
+
+		$fileExportPrinter->outputAsFile( $queryResult, [] );
+	}
+
+}


### PR DESCRIPTION
This PR is made in reference to: #4375, https://github.com/SemanticMediaWiki/SemanticResultFormats/issues/560

This PR addresses or contains:

- Access sequence is of importance so that `ResultPrinter::getResult` is called before accessing some parameters (incl. the filename parameter) 

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed

Fixes #4375