### PR TITLE
Match canonical representation for a predefined property, refs 4356

### DIFF
--- a/src/SQLStore/EntityStore/StubSemanticData.php
+++ b/src/SQLStore/EntityStore/StubSemanticData.php
@@ -397,6 +397,19 @@ class StubSemanticData extends SemanticData {
 				continue;
 			}
 
+			// Ensure to hold a DBKEY reference to avoid something like:
+			// "... SMW\Exception\SubSemanticDataException from line 206 of
+			// SubSemanticData.php: Data for a subobject of Display_precision_of
+			// cannot be added to _PREC ..."
+			if ( $value->getNamespace() === SMW_NS_PROPERTY ) {
+				$value = new DIWikiPage(
+					$this->mSubject->getDBKey(),
+					SMW_NS_PROPERTY,
+					$value->getInterwiki(),
+					$value->getSubobjectName()
+				);
+			}
+
 			if ( $this->hasSubSemanticData( $value->getSubobjectName() ) ) {
 				continue;
 			}

--- a/tests/phpunit/Integration/JSONScript/TestCases/r-0021.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/r-0021.json
@@ -1,0 +1,62 @@
+{
+	"description": "Test RDF output for predefined property with alias (#4356)",
+	"setup": [
+		{
+			"namespace": "SMW_NS_PROPERTY",
+			"page": "Display precision of",
+			"contents": "[[Property description::Is described as ...@en]]"
+		}
+	],
+	"tests": [
+		{
+			"type": "rdf",
+			"about": "#0 (canonical `Display precision of` representation)",
+			"dumpRDF": {
+				"parameters": {
+					"page": "Property:Display precision of"
+				}
+			},
+			"assert-output": {
+				"to-contain": [
+					"<owl:Ontology rdf:about=\".*/Property-3ADisplay-2Bprecision-2Bof\">",
+					"<owl:ObjectProperty rdf:about=\"http://example.org/id/Property-3ADisplay_precision_of\">",
+					"<rdfs:isDefinedBy rdf:resource=\".*/Property-3ADisplay_precision_of\"/>",
+					"<property:Property_description rdf:resource=\"http://example.org/id/Property-3ADisplay_precision_of-23_ML9d90cf2e5874b99bebfab30b76c15a67\"/>",
+					"<skos:scopeNote xml:lang=\"en\">Is described as ...</skos:scopeNote>"
+				]
+			}
+		},
+		{
+			"type": "rdf",
+			"about": "#1 (using the alias to produce a RDF output, should represent the canonical `Display precision of` content)",
+			"dumpRDF": {
+				"parameters": {
+					"page": "Property:Display precision"
+				}
+			},
+			"assert-output": {
+				"to-contain": [
+					"<owl:Ontology rdf:about=\".*/Property-3ADisplay-2Bprecision\">",
+					"<owl:ObjectProperty rdf:about=\"http://example.org/id/Property-3ADisplay_precision_of\">",
+					"<rdfs:isDefinedBy rdf:resource=\".*/Property-3ADisplay_precision_of\"/>",
+					"<property:Property_description rdf:resource=\"http://example.org/id/Property-3ADisplay_precision_of-23_ML9d90cf2e5874b99bebfab30b76c15a67\"/>",
+					"<skos:scopeNote xml:lang=\"en\">Is described as ...</skos:scopeNote>"
+				]
+			}
+		}
+	],
+	"settings": {
+		"wgContLang": "en",
+		"wgLang": "en",
+		"smwgNamespacesWithSemanticLinks": {
+			"NS_MAIN": true,
+			"SMW_NS_PROPERTY": true
+		},
+		"smwgNamespace": "http://example.org/id/"
+	},
+	"meta": {
+		"version": "2",
+		"is-incomplete": false,
+		"debug": false
+	}
+}

--- a/tests/phpunit/Integration/SQLStore/SubSemanticDataDBIntegrationTest.php
+++ b/tests/phpunit/Integration/SQLStore/SubSemanticDataDBIntegrationTest.php
@@ -78,4 +78,97 @@ class SubSemanticDataDBIntegrationTest extends MwDBaseUnitTestCase {
 		}
 	}
 
+	public function testPredefinedProperty_Canonical_MonolingualText() {
+
+		$this->title = Title::newFromText( 'Display_precision_of', SMW_NS_PROPERTY );
+
+		$pageCreator = new PageCreator();
+
+		$pageCreator
+			->createPage( $this->title )
+			->doEdit(
+				'[[Property description::Simple monolingual test@en]]'
+			);
+
+		$semanticData = $this->getStore()->getSemanticData(
+			DIWikiPage::newFromTitle( $this->title )
+		);
+
+		$expected = [
+			'propertyCount'  => 3,
+			'properties' => [
+				new DIProperty( '_TEXT' ),
+				new DIProperty( '_LCODE' ),
+				new DIProperty( '_SKEY' )
+			],
+			'propertyValues' => [
+				'en',
+				'Simple monolingual test',
+				'Display precision of',
+				'Display precision of#Simple monolingual test;en'
+			]
+		];
+
+		$semanticDataValidator = new SemanticDataValidator();
+
+		foreach ( $semanticData->getSubSemanticData() as $subSemanticData ) {
+			$semanticDataValidator->assertThatPropertiesAreSet(
+				$expected,
+				$subSemanticData
+			);
+		}
+	}
+
+	public function testPredefinedProperty_Key_MonolingualText() {
+
+		$this->title = Title::newFromText( 'Display_precision_of', SMW_NS_PROPERTY );
+
+		$pageCreator = new PageCreator();
+
+		$pageCreator
+			->createPage( $this->title )
+			->doEdit(
+				'[[Property description::Simple monolingual test@en]]'
+			);
+
+		// 1) SMW\Tests\Integration\SQLStore\SubSemanticDataDBIntegrationTest::testPredefinedProperty_Key_MonolingualText
+		// SMW\Exception\SubSemanticDataException: Data for a subobject of Display_precision_of cannot be added to _PREC.
+		//
+		// ...\SemanticMediaWiki\src\DataModel\SubSemanticData.php:206
+		// ...\SemanticMediaWiki\includes\SemanticData.php:814
+		// ...\SemanticMediaWiki\src\SQLStore\EntityStore\StubSemanticData.php:417
+		// ...\SemanticMediaWiki\src\SQLStore\EntityStore\StubSemanticData.php:202
+		// ...\SemanticMediaWiki\tests\phpunit\Integration\SQLStore\SubSemanticDataDBIntegrationTest.php:153
+		// ...\SemanticMediaWiki\tests\phpunit\DatabaseTestCase.php:155
+		// ...\doMaintenance.php:94
+
+		$semanticData = $this->getStore()->getSemanticData(
+			DIWikiPage::newFromText( '_PREC', SMW_NS_PROPERTY )
+		);
+
+		$expected = [
+			'propertyCount'  => 3,
+			'properties' => [
+				new DIProperty( '_TEXT' ),
+				new DIProperty( '_LCODE' ),
+				new DIProperty( '_SKEY' )
+			],
+			'propertyValues' => [
+				'en',
+				'Simple monolingual test',
+				'Display precision of',
+				'Display precision of#Simple monolingual test;en'
+			]
+		];
+
+		$semanticDataValidator = new SemanticDataValidator();
+
+		foreach ( $semanticData->getSubSemanticData() as $subSemanticData ) {
+			$semanticDataValidator->assertThatPropertiesAreSet(
+				$expected,
+				$subSemanticData
+			);
+		}
+	}
+
 }


### PR DESCRIPTION
This PR is made in reference to: #4356

This PR addresses or contains:

- Make sure to resolve a predefined property with the correct canonical representation (which is `_...`, not the label or alias of it) as DBKEY when fetching data (especially sub-entity) from the database (the `smw_title` holds the property key reference which in case of a predefined property is `_...`)

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed

Fixes #4356