### PR TITLE
[SMWSearch] Resurrect completion search term, refs 4342

### DIFF
--- a/src/MediaWiki/Search/ExtendedSearch.php
+++ b/src/MediaWiki/Search/ExtendedSearch.php
@@ -89,6 +89,11 @@ class ExtendedSearch {
 	private $offset = 0;
 
 	/**
+	 * @var string
+	 */
+	private $completionSearchTerm = '';
+
+	/**
 	 * @since 3.1
 	 *
 	 * @param Store $store
@@ -159,6 +164,15 @@ class ExtendedSearch {
 	public function setLimitOffset( $limit, $offset = 0 ) {
 		$this->limit = intval( $limit );
 		$this->offset = intval( $offset );
+	}
+
+	/**
+	 * @since 3.2
+	 *
+	 * @param string $completionSearchTerm
+	 */
+	public function setCompletionSearchTerm( $completionSearchTerm ) {
+		$this->completionSearchTerm = $completionSearchTerm;
 	}
 
 	/**
@@ -287,6 +301,13 @@ class ExtendedSearch {
 			if ( $searchResultSet instanceof SearchResultSet ) {
 				return $searchResultSet->newSearchSuggestionSet();
 			}
+		}
+
+		// #4342
+		//
+		// Allow the fallback to work with the "raw" (not normalized) search term
+		if ( trim( $search ) === '' ) {
+			$search = $this->completionSearchTerm;
 		}
 
 		return $this->fallbackSearchEngine->completionSearch( $search );

--- a/src/MediaWiki/Search/ExtendedSearchEngine.php
+++ b/src/MediaWiki/Search/ExtendedSearchEngine.php
@@ -259,6 +259,33 @@ class ExtendedSearchEngine extends SearchEngine {
 	}
 
 	/**
+	 * @see SearchEngine::completionSearchWithVariants
+	 *
+	 * Called by `ApiQueryPrefixSearch.php`, `ApiOpenSearch.php`
+	 *
+	 * {@inheritDoc}
+	 */
+	public function completionSearchWithVariants( $search ) {
+
+		// #4342
+		//
+		// This method runs before `SearchEngine::completionSearchBackend`.
+		//
+		// Hold on to the original search term because `SearchEngine::completionSearch`
+		// and `SearchEngine::completionSearchWithVariants` do normalize the string
+		// and remove any namespace prefix they encounter.
+		//
+		// We may need the orginal search term when it is required to run the
+		// fallbacksearch to complete the search request and no SMW specific query
+		// component was detected.
+		$this->extendedSearch->setCompletionSearchTerm(
+			$search
+		);
+
+		return parent::completionSearchWithVariants( $search );
+	}
+
+	/**
 	 * @see SearchEngine::completionSearchBackend
 	 *
 	 * {@inheritDoc}
@@ -268,11 +295,6 @@ class ExtendedSearchEngine extends SearchEngine {
 		$this->extendedSearch->setNamespaces(
 			$this->namespaces
 		);
-
-		// Avoid MW's auto formatting of title entities
-		if ( $search !== '' ) {
-			$search[0] = strtolower( $search[0] );
-		}
 
 		return $this->extendedSearch->completionSearch( $search );
 	}

--- a/tests/phpunit/Unit/MediaWiki/Search/ExtendedSearchEngineTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Search/ExtendedSearchEngineTest.php
@@ -442,11 +442,7 @@ class ExtendedSearchEngineTest extends \PHPUnit_Framework_TestCase {
 		);
 	}
 
-	public function tesCompletionSearch_NoRelevantPrefix() {
-
-		$title = $this->getMockBuilder( '\Title' )
-			->disableOriginalConstructor()
-			->getMock();
+	public function testCompletionSearch_NoRelevantPrefix() {
 
 		$searchSuggestionSet = $this->getMockBuilder( '\SearchSuggestionSet' )
 			->disableOriginalConstructor()
@@ -456,36 +452,56 @@ class ExtendedSearchEngineTest extends \PHPUnit_Framework_TestCase {
 			->method( 'map')
 			->will( $this->returnValue( [] ) );
 
-		$fallbackSearchEngine = $this->getMockBuilder( 'SearchEngine' )
-			->disableOriginalConstructor()
-			->getMock();
-
-		$fallbackSearchEngine->expects( $this->once() )
-			->method( 'setShowSuggestion')
-			->with( $this->equalTo( true ) );
-
-		$fallbackSearchEngine->expects( $this->once() )
-			->method( 'completionSearch' )
-			->will( $this->returnValue( $searchSuggestionSet ) );
-
 		$extendedSearch = $this->getMockBuilder( '\SMW\MediaWiki\Search\ExtendedSearch' )
 			->disableOriginalConstructor()
 			->getMock();
 
-		$extendedSearch->setFallbackSearchEngine( $fallbackSearchEngine );
+		$extendedSearch->expects( $this->once() )
+			->method( 'completionSearch' )
+			->will( $this->returnValue( $searchSuggestionSet ) );
 
 		$searchEngine = new ExtendedSearchEngine(
 			$this->connection
 		);
 
 		$searchEngine->setExtendedSearch( $extendedSearch );
-		$searchEngine->setFallbackSearchEngine( $fallbackSearchEngine );
 		$searchEngine->setShowSuggestion( true );
 
 		$this->assertInstanceof(
 			'\SearchSuggestionSet',
 			$searchEngine->completionSearch( 'Foo' )
 		);
+	}
+
+	public function testCompletionSearchWithVariants() {
+
+		$searchSuggestionSet = $this->getMockBuilder( '\SearchSuggestionSet' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$searchSuggestionSet->expects( $this->any() )
+			->method( 'map')
+			->will( $this->returnValue( [] ) );
+
+		$extendedSearch = $this->getMockBuilder( '\SMW\MediaWiki\Search\ExtendedSearch' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$extendedSearch->expects( $this->once() )
+			->method( 'completionSearch' )
+			->will( $this->returnValue( $searchSuggestionSet ) );
+
+		$extendedSearch->expects( $this->once() )
+			->method( 'setCompletionSearchTerm' )
+			->with( $this->equalTo( 'Foo_Variants' ) );
+
+		$searchEngine = new ExtendedSearchEngine(
+			$this->connection
+		);
+
+		$searchEngine->setExtendedSearch( $extendedSearch );
+
+		$searchEngine->completionSearchWithVariants( 'Foo_Variants' );
 	}
 
 }

--- a/tests/phpunit/Unit/MediaWiki/Search/ExtendedSearchTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Search/ExtendedSearchTest.php
@@ -313,7 +313,7 @@ class ExtendedSearchTest extends \PHPUnit_Framework_TestCase {
 		$instance->completionSearch( 'fcat:Foo' );
 	}
 
-	public function tesCompletionSearch_NoRelevantPrefix() {
+	public function testCompletionSearch_NoRelevantPrefix() {
 
 		$searchSuggestionSet = $this->getMockBuilder( '\SearchSuggestionSet' )
 			->disableOriginalConstructor()
@@ -328,10 +328,6 @@ class ExtendedSearchTest extends \PHPUnit_Framework_TestCase {
 			->getMock();
 
 		$fallbackSearchEngine->expects( $this->once() )
-			->method( 'setShowSuggestion')
-			->with( $this->equalTo( true ) );
-
-		$fallbackSearchEngine->expects( $this->once() )
 			->method( 'completionSearch' )
 			->will( $this->returnValue( $searchSuggestionSet ) );
 
@@ -344,6 +340,25 @@ class ExtendedSearchTest extends \PHPUnit_Framework_TestCase {
 			'\SearchSuggestionSet',
 			$instance->completionSearch( 'Foo' )
 		);
+	}
+
+	public function testCompletionSearch_NoRelevantPrefix_ReplaceEmptySearchTermWithInfusedTerm() {
+
+		$fallbackSearchEngine = $this->getMockBuilder( 'SearchEngine' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$fallbackSearchEngine->expects( $this->once() )
+			->method( 'completionSearch' )
+			->with( $this->equalTo( 'origTerm' ) );
+
+		$instance = new ExtendedSearch(
+			$this->store,
+			$fallbackSearchEngine
+		);
+
+		$instance->setCompletionSearchTerm( 'origTerm' );
+		$instance->completionSearch( '' );
 	}
 
 }


### PR DESCRIPTION
This PR is made in reference to: #4342

This PR addresses or contains:

- Hold on to the original search term because `SearchEngine::completionSearch` and `SearchEngine::completionSearchWithVariants` do normalize the string and remove any namespace prefix they encounter and when relayed to the fallbacksearch (without the namespace) will cause #4342.

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed

Fixes #4342