### PR TITLE
[CI] Add MW 1.34

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,6 +30,8 @@ matrix:
       php: 7.1
     - env: DB=mysql; MW=REL1_31; TYPE=benchmark; PHPUNIT=6.5.*
       php: 7.2
+    - env: DB=mysql; MW=REL1_34; PHPUNIT=6.5.*
+      php: 7.2
     - env: DB=sqlite; MW=REL1_31; TYPE=composer; PHPUNIT=5.7.*
       php: 7.1
     - env: DB=mysql; MW=REL1_31; TYPE=relbuild; PHPUNIT=5.7.*
@@ -45,7 +47,7 @@ matrix:
     - env: DB=mysql; MW=REL1_31; TYPE=benchmark; PHPUNIT=6.5.*
     #- env: DB=mysql; MW=REL1_31; SESAME=2.8.7; PHPUNIT=5.7.*
     - env: DB=mysql; MW=REL1_33; ES=5.6.6; PHPUNIT=5.7.*
-
+    - env: DB=mysql; MW=REL1_34; PHPUNIT=6.5.*
 
 # Dec 16, 2015 (GCE switch): Travis support wrote (Tomcat + Java):
 # bug in the JDK: http://bugs.java.com/bugdatabase/view_bug.do?bug_id=7089443.


### PR DESCRIPTION
This PR is made in reference to: https://github.com/SemanticMediaWiki/SemanticMediaWiki/issues/4382#issuecomment-570825763

This PR addresses or contains:

- Adds MW 1.34 to the CI as non-voting because it breaks the test suite with 8 errors and 28 failures [0] as predicted in the referenced comment

This PR includes:
- [ ] Tests (unit/integration)
- [x] CI build passed

[0] https://travis-ci.org/SemanticMediaWiki/SemanticMediaWiki/jobs/635751414