### PR TITLE
Identify core, custom table

### DIFF
--- a/src/SQLStore/PropertyTableDefinition.php
+++ b/src/SQLStore/PropertyTableDefinition.php
@@ -22,6 +22,16 @@ use OutOfBoundsException;
 class PropertyTableDefinition {
 
 	/**
+	 * A table that is part of Semantic MediaWiki core.
+	 */
+	const TYPE_CORE = 'type/core';
+
+	/**
+	 * A custom table added for example by an extension.
+	 */
+	const TYPE_CUSTOM = 'type/custom';
+
+	/**
 	 * Name of the table in the DB.
 	 *
 	 * @since 1.8
@@ -63,6 +73,11 @@ class PropertyTableDefinition {
 	 * @var boolean
 	 */
 	protected $idSubject = true;
+
+	/**
+	 * @var string
+	 */
+	private $tableType = '';
 
 	/**
 	* Factory method to create an instance for a given
@@ -114,6 +129,26 @@ class PropertyTableDefinition {
 	 */
 	public function setUsesIdSubject( $usesIdSubject ) {
 		$this->idSubject = $usesIdSubject;
+	}
+
+	/**
+	 * @since 3.2
+	 *
+	 * @param string $tableType
+	 *
+	 * @return boolean
+	 */
+	public function isTableType( string $tableType ) : bool {
+		return $this->tableType === $tableType;
+	}
+
+	/**
+	 * @since 3.2
+	 *
+	 * @param string $tableType
+	 */
+	public function setTableType( string $tableType ) {
+		$this->tableType = $tableType;
 	}
 
 	/**

--- a/src/SQLStore/TableBuilder/Table.php
+++ b/src/SQLStore/TableBuilder/Table.php
@@ -24,6 +24,11 @@ class Table {
 	private $name;
 
 	/**
+	 * @var boolean
+	 */
+	private $isCoreTable = true;
+
+	/**
 	 * @var array
 	 */
 	private $attributes = [];
@@ -32,9 +37,11 @@ class Table {
 	 * @since 2.5
 	 *
 	 * @param string $name
+	 * @param boolean $isCoreTable
 	 */
-	public function __construct( $name ) {
+	public function __construct( $name, bool $isCoreTable = true ) {
 		$this->name = $name;
+		$this->isCoreTable = $isCoreTable;
 	}
 
 	/**
@@ -44,6 +51,15 @@ class Table {
 	 */
 	public function getName() {
 		return $this->name;
+	}
+
+	/**
+	 * @since 3.2
+	 *
+	 * @return boolean
+	 */
+	public function isCoreTable() : bool {
+		return $this->isCoreTable;
 	}
 
 	/**

--- a/src/SQLStore/TableBuilder/TableSchemaManager.php
+++ b/src/SQLStore/TableBuilder/TableSchemaManager.php
@@ -399,7 +399,10 @@ class TableSchemaManager {
 			$fieldarray[$fieldname] = $fieldType;
 		}
 
-		$table = new Table( $propertyTable->getName() );
+		$table = new Table(
+			$propertyTable->getName(),
+			$propertyTable->isTableType( $propertyTable::TYPE_CORE )
+		);
 
 		foreach ( $fieldarray as $fieldName => $fieldType ) {
 			$table->addColumn( $fieldName, $fieldType );

--- a/tests/phpunit/Unit/SQLStore/PropertyTableDefinitionBuilderTest.php
+++ b/tests/phpunit/Unit/SQLStore/PropertyTableDefinitionBuilderTest.php
@@ -3,6 +3,7 @@
 namespace SMW\Tests\SQLStore;
 
 use SMW\SQLStore\PropertyTableDefinitionBuilder;
+use SMW\SQLStore\TableDefinition;
 use SMW\Tests\Utils\MwHooksHandler;
 use SMWDataItem as DataItem;
 
@@ -45,7 +46,7 @@ class PropertyTableDefinitionBuilderTest extends \PHPUnit_Framework_TestCase {
 		$fixed = [];
 
 		$this->assertInstanceOf(
-			'\SMW\SQLStore\PropertyTableDefinitionBuilder',
+			PropertyTableDefinitionBuilder::class,
 			new PropertyTableDefinitionBuilder( $this->propertyTypeFinder )
 		);
 	}
@@ -69,6 +70,8 @@ class PropertyTableDefinitionBuilderTest extends \PHPUnit_Framework_TestCase {
 		$definition = $instance->newTableDefinition(
 			DataItem::TYPE_NUMBER, 'smw_di_number'
 		);
+
+		$definition->setTableType( TableDefinition::TYPE_CORE );
 
 		$expected = [
 			'smw_di_number' => $definition
@@ -106,6 +109,8 @@ class PropertyTableDefinitionBuilderTest extends \PHPUnit_Framework_TestCase {
 		$tableName = $instance->createHashedTableNameFrom( $expectedKey );
 		$definition = $instance->newTableDefinition( DataItem::TYPE_NUMBER, $tableName, $expectedKey );
 
+		$definition->setTableType( TableDefinition::TYPE_CORE );
+
 		$expected = [
 			'definition' => [ $tableName => $definition ],
 			'tableId' => [ $expectedKey => $tableName, '_SKEY' => null ]
@@ -141,7 +146,10 @@ class PropertyTableDefinitionBuilderTest extends \PHPUnit_Framework_TestCase {
 		);
 
 		$tableName = $instance->getTablePrefix() . strtolower( $propertyKey );
+
 		$definition = $instance->newTableDefinition( DataItem::TYPE_TIME, $tableName, $propertyKey );
+		$definition->setTableType( TableDefinition::TYPE_CORE );
+
 		$expected = [ $tableName => $definition ];
 
 		$this->assertEquals(
@@ -173,6 +181,10 @@ class PropertyTableDefinitionBuilderTest extends \PHPUnit_Framework_TestCase {
 
 		$expected = [ $tableName => $definition ];
 		$tableDefinitions = $instance->getTableDefinitions();
+
+		$this->assertTrue(
+			$tableDefinitions[$tableName]->isTableType( TableDefinition::TYPE_CORE )
+		);
 
 		$this->assertFalse(
 			$tableDefinitions[$tableName]->usesIdSubject()

--- a/tests/phpunit/Unit/SQLStore/PropertyTableDefinitionTest.php
+++ b/tests/phpunit/Unit/SQLStore/PropertyTableDefinitionTest.php
@@ -23,7 +23,7 @@ class PropertyTableDefinitionTest extends \PHPUnit_Framework_TestCase {
 	public function testCanConstruct() {
 
 		$this->assertInstanceOf(
-			'\SMW\SQLStore\PropertyTableDefinition',
+			PropertyTableDefinition::class,
 			new PropertyTableDefinition( 'foo', 'bar' )
 		);
 	}
@@ -67,6 +67,16 @@ class PropertyTableDefinitionTest extends \PHPUnit_Framework_TestCase {
 
 		$this->setExpectedException( 'OutOfBoundsException' );
 		$instance->getFixedProperty();
+	}
+
+	public function testTableType() {
+
+		$instance = new PropertyTableDefinition( 'foo', 'bar' );
+		$instance->setTableType( PropertyTableDefinition::TYPE_CORE );
+
+		$this->assertFalse(
+			$instance->isTableType( PropertyTableDefinition::TYPE_CUSTOM )
+		);
 	}
 
 }

--- a/tests/phpunit/Unit/SQLStore/TableBuilder/TableTest.php
+++ b/tests/phpunit/Unit/SQLStore/TableBuilder/TableTest.php
@@ -26,6 +26,21 @@ class TableTest extends \PHPUnit_Framework_TestCase {
 		);
 	}
 
+	public function testIsCoreTable() {
+
+		$instance = new Table( 'Foo' );
+
+		$this->assertTrue(
+			$instance->isCoreTable()
+		);
+
+		$instance = new Table( 'Bar', false );
+
+		$this->assertFalse(
+			$instance->isCoreTable()
+		);
+	}
+
 	public function testAddColumn() {
 
 		$instance = new Table( 'Foo' );


### PR DESCRIPTION
This PR is made in reference to: #

This PR addresses or contains:

- Allows to distinguish between core tables (provided by SMW itself) and tables added by an extension (mostly predefined property tables)

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed
