### PR TITLE
Invalidate `PropertySpecificationLookupCache` on update event

### DIFF
--- a/src/DataUpdater.php
+++ b/src/DataUpdater.php
@@ -10,6 +10,7 @@ use Psr\Log\LoggerAwareTrait;
 use SMW\Property\ChangePropagationNotifier;
 use Revision;
 use SMW\MediaWiki\RevisionGuard;
+use Onoi\EventDispatcher\EventDispatcherAwareTrait;
 
 /**
  * This function takes care of storing the collected semantic data and
@@ -31,6 +32,7 @@ use SMW\MediaWiki\RevisionGuard;
 class DataUpdater {
 
 	use LoggerAwareTrait;
+	use EventDispatcherAwareTrait;
 
 	/**
 	 * @var Store
@@ -287,6 +289,13 @@ class DataUpdater {
 
 		$this->checkChangePropagation();
 		$this->updateData();
+
+		$context = [
+			'context' => 'DataUpdater',
+			'subject' => $this->getSubject()
+		];
+
+		$this->eventDispatcher->dispatch( 'InvalidatePropertySpecificationLookupCache', $context );
 
 		return true;
 	}

--- a/src/EntityCache.php
+++ b/src/EntityCache.php
@@ -19,9 +19,15 @@ use Title;
  */
 class EntityCache {
 
+	/**
+	 * Repository specific namespace
+	 */
 	const CACHE_NAMESPACE = 'smw:entity';
 	const VERSION = 1;
 
+	/**
+	 * TTLs
+	 */
 	const TTL_SECOND = 1;
 	const TTL_MINUTE = 60;
 	const TTL_HOUR = 3600;
@@ -53,6 +59,12 @@ class EntityCache {
 	 */
 	public static function makeCacheKey( ...$params ) {
 
+		$namespace = self::CACHE_NAMESPACE;
+
+		if ( is_string( $params[0] ) && $params[0][0] === ':' ) {
+			$namespace .= array_shift( $params );
+		}
+
 		if ( $params[0] instanceof Title ) {
 			$params[0] = DIWikiPage::newFromTitle( $params[0] );
 		}
@@ -61,7 +73,7 @@ class EntityCache {
 			$params[0] = $params[0]->getHash();
 		}
 
-		return smwfCacheKey( self::CACHE_NAMESPACE, $params + [ 'version' => self::VERSION ] );
+		return smwfCacheKey( $namespace, $params + [ 'version' => self::VERSION ] );
 	}
 
 	/**

--- a/src/EventListenerRegistry.php
+++ b/src/EventListenerRegistry.php
@@ -5,6 +5,7 @@ namespace SMW;
 use Onoi\EventDispatcher\EventListenerCollection;
 use SMW\Query\QueryComparator;
 use SMWExporter as Exporter;
+use SMW\Events\InvalidatePropertySpecificationLookupCacheEventListener;
 
 /**
  * @license GNU GPL v2+
@@ -41,7 +42,9 @@ class EventListenerRegistry implements EventListenerCollection {
 	public function getCollection() {
 
 		$applicationFactory = ApplicationFactory::getInstance();
-		$invalidateResultCacheEventListener = $applicationFactory->create( 'InvalidateResultCacheEventListener' );
+		$invalidateResultCacheEventListener = $applicationFactory->create(
+			'InvalidateResultCacheEventListener'
+		);
 
 		$invalidateResultCacheEventListener->setLogger(
 			$applicationFactory->getMediaWikiLogger()
@@ -49,13 +52,28 @@ class EventListenerRegistry implements EventListenerCollection {
 
 		$this->eventListenerCollection->registerListener( 'InvalidateResultCache', $invalidateResultCacheEventListener );
 
-		$invalidateEntityCacheEventListener = $applicationFactory->create( 'InvalidateEntityCacheEventListener' );
+		$invalidateEntityCacheEventListener = $applicationFactory->create(
+			'InvalidateEntityCacheEventListener'
+		);
 
 		$invalidateEntityCacheEventListener->setLogger(
 			$applicationFactory->getMediaWikiLogger()
 		);
 
 		$this->eventListenerCollection->registerListener( 'InvalidateEntityCache', $invalidateEntityCacheEventListener );
+
+		$invalidatePropertySpecificationLookupCacheEventListener = $applicationFactory->create(
+			'InvalidatePropertySpecificationLookupCacheEventListener'
+		);
+
+		$invalidatePropertySpecificationLookupCacheEventListener->setLogger(
+			$applicationFactory->getMediaWikiLogger()
+		);
+
+		$this->eventListenerCollection->registerListener(
+			InvalidatePropertySpecificationLookupCacheEventListener::EVENT_ID,
+			$invalidatePropertySpecificationLookupCacheEventListener
+		);
 
 		$this->addListenersToCollection();
 

--- a/src/Events/InvalidatePropertySpecificationLookupCacheEventListener.php
+++ b/src/Events/InvalidatePropertySpecificationLookupCacheEventListener.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace SMW\Events;
+
+use Onoi\EventDispatcher\EventListener;
+use Onoi\EventDispatcher\DispatchContext;
+use SMW\PropertySpecificationLookup;
+use Psr\Log\LoggerAwareTrait;
+
+/**
+ * @license GNU GPL v2+
+ * @since 3.2
+ *
+ * @author mwjames
+ */
+class InvalidatePropertySpecificationLookupCacheEventListener implements EventListener {
+
+	use LoggerAwareTrait;
+
+	const EVENT_ID = 'InvalidatePropertySpecificationLookupCache';
+
+	/**
+	 * @var PropertySpecificationLookup
+	 */
+	private $propertySpecificationLookup;
+
+	/**
+	 * @since 3.2
+	 *
+	 * @param PropertySpecificationLookup $propertySpecificationLookup
+	 */
+	public function __construct( PropertySpecificationLookup $propertySpecificationLookup ) {
+		$this->propertySpecificationLookup = $propertySpecificationLookup;
+	}
+
+	/**
+	 * @since 3.2
+	 *
+	 * {@inheritDoc}
+	 */
+	public function execute( DispatchContext $dispatchContext = null ) {
+
+		$subject = $dispatchContext->get( 'subject' );
+		$context = $dispatchContext->get( 'context' );
+
+		$this->propertySpecificationLookup->invalidateCache(
+			$subject
+		);
+
+		$this->logger->info(
+			[ 'Event', 'InvalidatePropertySpecificationLookupCache', "{triggered_by}", "{id}" ],
+			[ 'role' => 'user', 'triggered_by' => $context, 'id' => $subject->getHash() ]
+		);
+	}
+
+	/**
+	 * @since 3.2
+	 *
+	 * {@inheritDoc}
+	 */
+	public function isPropagationStopped() {
+		return false;
+	}
+
+}

--- a/src/MediaWiki/Jobs/ChangePropagationDispatchJob.php
+++ b/src/MediaWiki/Jobs/ChangePropagationDispatchJob.php
@@ -74,7 +74,7 @@ class ChangePropagationDispatchJob extends Job {
 	public static function planAsJob( DIWikiPage $subject, $params = [] ) {
 
 		Exporter::getInstance()->resetCacheBy( $subject );
-		ApplicationFactory::getInstance()->getPropertySpecificationLookup()->resetCacheBy(
+		ApplicationFactory::getInstance()->getPropertySpecificationLookup()->invalidateCache(
 			$subject
 		);
 
@@ -443,7 +443,7 @@ class ChangePropagationDispatchJob extends Job {
 			60 * 60 * 24
 		);
 
-		$applicationFactory->getPropertySpecificationLookup()->resetCacheBy( $subject );
+		$applicationFactory->getPropertySpecificationLookup()->invalidateCache( $subject );
 
 		// Make sure the cache is reset in case runJobs.php --wait is used to avoid
 		// reusing outdated type assignments

--- a/src/Services/ServicesFactory.php
+++ b/src/Services/ServicesFactory.php
@@ -426,6 +426,10 @@ class ServicesFactory {
 			$this->getMediaWikiLogger()
 		);
 
+		$dataUpdater->setEventDispatcher(
+			$this->getEventDispatcher()
+		);
+
 		return $dataUpdater;
 	}
 

--- a/src/Services/events.php
+++ b/src/Services/events.php
@@ -4,6 +4,7 @@ namespace SMW\Services;
 
 use SMW\Events\InvalidateResultCacheEventListener;
 use SMW\Events\InvalidateEntityCacheEventListener;
+use SMW\Events\InvalidatePropertySpecificationLookupCacheEventListener;
 
 /**
  * @codeCoverageIgnore
@@ -44,6 +45,20 @@ return [
 		);
 
 		return $invalidateEntityCacheEventListener;
+	},
+
+	/**
+	 * InvalidatePropertySpecificationLookupCacheEventListener
+	 *
+	 * @return callable
+	 */
+	'InvalidatePropertySpecificationLookupCacheEventListener' => function( $containerBuilder ) {
+
+		$invalidatePropertySpecificationLookupCacheEventListener = new InvalidatePropertySpecificationLookupCacheEventListener(
+			$containerBuilder->singleton( 'PropertySpecificationLookup' )
+		);
+
+		return $invalidatePropertySpecificationLookupCacheEventListener;
 	}
 
 ];

--- a/tests/phpunit/Unit/DataUpdaterTest.php
+++ b/tests/phpunit/Unit/DataUpdaterTest.php
@@ -25,6 +25,7 @@ class DataUpdaterTest  extends \PHPUnit_Framework_TestCase {
 	private $spyLogger;
 	private $store;
 	private $changePropagationNotifier;
+	private $eventDispatcher;
 
 	protected function setUp() {
 		parent::setUp();
@@ -36,6 +37,10 @@ class DataUpdaterTest  extends \PHPUnit_Framework_TestCase {
 		] );
 
 		$this->spyLogger = $this->testEnvironment->newSpyLogger();
+
+		$this->eventDispatcher = $this->getMockBuilder( '\Onoi\EventDispatcher\EventDispatcher' )
+			->disableOriginalConstructor()
+			->getMock();
 
 		$this->changePropagationNotifier = $this->getMockBuilder( '\SMW\Property\ChangePropagationNotifier' )
 			->disableOriginalConstructor()
@@ -93,12 +98,20 @@ class DataUpdaterTest  extends \PHPUnit_Framework_TestCase {
 
 	public function testDoUpdateForDefaultSettings() {
 
+		$this->eventDispatcher->expects( $this->once() )
+			->method( 'dispatch' )
+			->with( $this->equalTo( \SMW\Events\InvalidatePropertySpecificationLookupCacheEventListener::EVENT_ID ) );
+
 		$semanticData = $this->semanticDataFactory->newEmptySemanticData( __METHOD__ );
 
 		$instance = new DataUpdater(
 			$this->store,
 			$semanticData,
 			$this->changePropagationNotifier
+		);
+
+		$instance->setEventDispatcher(
+			$this->eventDispatcher
 		);
 
 		$this->assertTrue(
@@ -114,6 +127,10 @@ class DataUpdaterTest  extends \PHPUnit_Framework_TestCase {
 			$this->store,
 			$semanticData,
 			$this->changePropagationNotifier
+		);
+
+		$instance->setEventDispatcher(
+			$this->eventDispatcher
 		);
 
 		$instance->setLogger( $this->spyLogger );
@@ -177,6 +194,10 @@ class DataUpdaterTest  extends \PHPUnit_Framework_TestCase {
 			$this->changePropagationNotifier
 		);
 
+		$instance->setEventDispatcher(
+			$this->eventDispatcher
+		);
+
 		$instance->canCreateUpdateJob(
 			$updateJobStatus
 		);
@@ -238,6 +259,10 @@ class DataUpdaterTest  extends \PHPUnit_Framework_TestCase {
 			$updateJobStatus
 		);
 
+		$instance->setEventDispatcher(
+			$this->eventDispatcher
+		);
+
 		$this->assertTrue(
 			$instance->doUpdate()
 		);
@@ -257,6 +282,10 @@ class DataUpdaterTest  extends \PHPUnit_Framework_TestCase {
 			$this->store,
 			$semanticData,
 			$this->changePropagationNotifier
+		);
+
+		$instance->setEventDispatcher(
+			$this->eventDispatcher
 		);
 
 		$this->assertInternalType(
@@ -279,6 +308,10 @@ class DataUpdaterTest  extends \PHPUnit_Framework_TestCase {
 			$this->store,
 			$semanticData,
 			$this->changePropagationNotifier
+		);
+
+		$instance->setEventDispatcher(
+			$this->eventDispatcher
 		);
 
 		$this->assertFalse(
@@ -348,6 +381,10 @@ class DataUpdaterTest  extends \PHPUnit_Framework_TestCase {
 			$this->changePropagationNotifier
 		);
 
+		$instance->setEventDispatcher(
+			$this->eventDispatcher
+		);
+
 		$instance->canCreateUpdateJob(
 			true
 		);
@@ -387,7 +424,12 @@ class DataUpdaterTest  extends \PHPUnit_Framework_TestCase {
 			->method( 'createPage' )
 			->will( $this->returnValue( $wikiPage ) );
 
+		$propertySpecificationLookup = $this->getMockBuilder( '\SMW\Property\SpecificationLookup' )
+			->disableOriginalConstructor()
+			->getMock();
+
 		$this->testEnvironment->registerObject( 'PageCreator', $pageCreator );
+		$this->testEnvironment->registerObject( 'PropertySpecificationLookup', $propertySpecificationLookup );
 
 		$source = $this->getMockBuilder( '\SMW\DIWikiPage' )
 			->disableOriginalConstructor()
@@ -426,6 +468,10 @@ class DataUpdaterTest  extends \PHPUnit_Framework_TestCase {
 			$store,
 			$semanticData,
 			$this->changePropagationNotifier
+		);
+
+		$instance->setEventDispatcher(
+			$this->eventDispatcher
 		);
 
 		$instance->canCreateUpdateJob( true );

--- a/tests/phpunit/Unit/EntityCacheTest.php
+++ b/tests/phpunit/Unit/EntityCacheTest.php
@@ -62,6 +62,25 @@ class EntityCacheTest extends \PHPUnit_Framework_TestCase {
 		);
 	}
 
+	public function testMakeCacheKey_SubNamespace() {
+
+		$instance = new EntityCache(
+			$this->cache
+		);
+
+		$subject = DIWikiPage::newFromText( 'Foo' );
+
+		$this->assertContains(
+			'smw:entity:44ab375ee7ebac04b8e4471a70180dc5',
+			EntityCache::makeCacheKey( $subject )
+		);
+
+		$this->assertContains(
+			'smw:entity:foo:44ab375ee7ebac04b8e4471a70180dc5',
+			EntityCache::makeCacheKey( ':foo', $subject )
+		);
+	}
+
 	public function testContains() {
 
 		$this->cache->expects( $this->once() )

--- a/tests/phpunit/Unit/Events/InvalidatePropertySpecificationLookupCacheEventListenerTest.php
+++ b/tests/phpunit/Unit/Events/InvalidatePropertySpecificationLookupCacheEventListenerTest.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace SMW\Tests\Events;
+
+use SMW\DIWikiPage;
+use SMW\Events\InvalidatePropertySpecificationLookupCacheEventListener;
+use Onoi\EventDispatcher\DispatchContext;
+use SMW\Tests\TestEnvironment;
+
+/**
+ * @covers \SMW\Events\InvalidatePropertySpecificationLookupCacheEventListener
+ * @group semantic-mediawiki
+ *
+ * @license GNU GPL v2+
+ * @since 3.2
+ *
+ * @author mwjames
+ */
+class InvalidatePropertySpecificationLookupCacheEventListenerTest extends \PHPUnit_Framework_TestCase {
+
+	private $specificationLookup;
+	private $spyLogger;
+
+	protected function setUp() {
+		parent::setUp();
+
+		$this->spyLogger = TestEnvironment::newSpyLogger();
+
+		$this->specificationLookup = $this->getMockBuilder( '\SMW\Property\SpecificationLookup' )
+			->disableOriginalConstructor()
+			->getMock();
+	}
+
+	protected function tearDown() {
+		parent::tearDown();
+	}
+
+	public function testCanConstruct() {
+
+		$this->assertInstanceOf(
+			InvalidatePropertySpecificationLookupCacheEventListener::class,
+			new InvalidatePropertySpecificationLookupCacheEventListener( $this->specificationLookup )
+		);
+	}
+
+	public function testExecute_OnSubject() {
+
+		$context = DispatchContext::newFromArray(
+			[
+				'subject' => DIWikiPage::newFromText( __METHOD__ ),
+				'context' => 'Bar'
+			]
+		);
+
+		$this->specificationLookup->expects( $this->once() )
+			->method( 'invalidateCache' );
+
+		$instance = new InvalidatePropertySpecificationLookupCacheEventListener(
+			$this->specificationLookup
+		);
+
+		$instance->setLogger(
+			$this->spyLogger
+		);
+
+		$instance->execute( $context );
+	}
+
+}

--- a/tests/phpunit/Unit/Property/SpecificationLookupTest.php
+++ b/tests/phpunit/Unit/Property/SpecificationLookupTest.php
@@ -35,7 +35,7 @@ class SpecificationLookupTest extends \PHPUnit_Framework_TestCase {
 
 		$this->entityCache = $this->getMockBuilder( '\SMW\EntityCache' )
 			->disableOriginalConstructor()
-			->setMethods( [ 'save', 'fetch', 'associate', 'fetchSub', 'saveSub' ] )
+			->setMethods( [ 'save', 'fetch', 'associate', 'fetchSub', 'saveSub', 'delete', 'invalidate' ] )
 			->getMock();
 
 		$this->monolingualTextLookup = $this->getMockBuilder( '\SMW\SQLStore\Lookup\MonolingualTextLookup' )
@@ -403,7 +403,7 @@ class SpecificationLookupTest extends \PHPUnit_Framework_TestCase {
 		$this->entityCache->expects( $this->once() )
 			->method( 'fetchSub' )
 			->with(
-				$this->stringContains( 'd98036d8042105fe312e09b61d7ef136' ),
+				$this->stringContains( 'smw:entity:propertyspecificationlookup:description:1313b81bb6a61a4661f7b91408659f86' ),
 				$this->equalTo( 'en:0' ) )
 			->will( $this->returnValue( 1001 ) );
 
@@ -499,6 +499,34 @@ class SpecificationLookupTest extends \PHPUnit_Framework_TestCase {
 			$dataItem,
 			$instance->getPropertyGroup( $property )
 		);
+	}
+
+	public function testInvalidateCache() {
+
+		$subject = $this->dataItemFactory->newDIWikiPage( 'Foo' );
+
+		$this->entityCache->expects( $this->at( 0 ) )
+			->method( 'invalidate' )
+			->with( $this->equalTo( $subject ) );
+
+		$this->entityCache->expects( $this->at( 1 ) )
+			->method( 'delete' )
+			->with( $this->stringContains( 'smw:entity:propertyspecificationlookup:44ab375ee7ebac04b8e4471a70180dc5' ) );
+
+		$this->entityCache->expects( $this->at( 2 ) )
+			->method( 'delete' )
+			->with( $this->stringContains( 'smw:entity:propertyspecificationlookup:preferredlabel:44ab375ee7ebac04b8e4471a70180dc5' ) );
+
+		$this->entityCache->expects( $this->at( 3 ) )
+			->method( 'delete' )
+			->with( $this->stringContains( 'smw:entity:propertyspecificationlookup:description:44ab375ee7ebac04b8e4471a70180dc5' ) );
+
+		$instance = new SpecificationLookup(
+			$this->store,
+			$this->entityCache
+		);
+
+		$instance->invalidateCache( $subject );
 	}
 
 }

--- a/tests/phpunit/Unit/Services/EventsServicesContainerBuildTest.php
+++ b/tests/phpunit/Unit/Services/EventsServicesContainerBuildTest.php
@@ -1,0 +1,85 @@
+<?php
+
+namespace SMW\Tests\Services;
+
+use Onoi\CallbackContainer\CallbackContainerFactory;
+
+/**
+ * @group semantic-mediawiki
+ *
+ * @license GNU GPL v2+
+ * @since 3.2
+ *
+ * @author mwjames
+ */
+class EventsServicesContainerBuildTest extends \PHPUnit_Framework_TestCase {
+
+	private $callbackContainerFactory;
+	private $servicesFileDir;
+	private $propertySpecificationLookup;
+	private $resultCache;
+	private $entityCache;
+
+	protected function setUp() {
+		parent::setUp();
+
+		$this->propertySpecificationLookup = $this->getMockBuilder( '\SMW\PropertySpecificationLookup' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$this->resultCache = $this->getMockBuilder( '\SMW\Query\Cache\ResultCache' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$this->entityCache = $this->getMockBuilder( '\SMW\EntityCache' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$this->callbackContainerFactory = new CallbackContainerFactory();
+		$this->servicesFileDir = $GLOBALS['smwgServicesFileDir'];
+	}
+
+	/**
+	 * @dataProvider servicesProvider
+	 */
+	public function testCanConstruct( $service, $parameters, $expected ) {
+
+		array_unshift( $parameters, $service );
+
+		$containerBuilder = $this->callbackContainerFactory->newCallbackContainerBuilder();
+
+		$containerBuilder->registerObject( 'ResultCache', $this->resultCache );
+		$containerBuilder->registerObject( 'EntityCache', $this->entityCache );
+		$containerBuilder->registerObject( 'PropertySpecificationLookup', $this->propertySpecificationLookup );
+
+		$containerBuilder->registerFromFile( $this->servicesFileDir . '/' . 'events.php' );
+
+		$this->assertInstanceOf(
+			$expected,
+			call_user_func_array( [ $containerBuilder, 'create' ], $parameters )
+		);
+	}
+
+	public function servicesProvider() {
+
+		$provider[] = [
+			'InvalidateResultCacheEventListener',
+			[],
+			'\SMW\Events\InvalidateResultCacheEventListener'
+		];
+
+		$provider[] = [
+			'InvalidateEntityCacheEventListener',
+			[],
+			'\SMW\Events\InvalidateEntityCacheEventListener'
+		];
+
+		$provider[] = [
+			'InvalidatePropertySpecificationLookupCacheEventListener',
+			[],
+			'\SMW\Events\InvalidatePropertySpecificationLookupCacheEventListener'
+		];
+
+		return $provider;
+	}
+}


### PR DESCRIPTION
This PR is made in reference to: #

This PR addresses or contains:

- Ensure that the specification cache is invalidated on every update event

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed
