### PR TITLE
Check for `wgFullyInitialised`, `MW_NO_SESSION`

### DIFF
--- a/src/MediaWiki/Hooks.php
+++ b/src/MediaWiki/Hooks.php
@@ -340,11 +340,8 @@ class Hooks {
 			Site::isCommandLineMode()
 		);
 
-		// #3341
-		// When running as part of the install don't try to access the DB
-		// or update the Store
-		$parserAfterTidy->isReadOnly(
-			Site::isBlocked()
+		$parserAfterTidy->isReady(
+			Site::isReady()
 		);
 
 		$parserAfterTidy->setLogger(
@@ -806,11 +803,8 @@ class Hooks {
 			 $applicationFactory->getMediaWikiLogger()
 		);
 
-		// #3341
-		// When running as part of the install don't try to access the DB
-		// or update the Store
-		$linksUpdateConstructed->isReadOnly(
-			Site::isBlocked()
+		$linksUpdateConstructed->isReady(
+			Site::isReady()
 		);
 
 		$linksUpdateConstructed->process( $linksUpdate );

--- a/src/MediaWiki/Hooks/LinksUpdateConstructed.php
+++ b/src/MediaWiki/Hooks/LinksUpdateConstructed.php
@@ -33,7 +33,7 @@ class LinksUpdateConstructed extends HookHandler {
 	/**
 	 * @var boolean
 	 */
-	private $isReadOnly = false;
+	private $isReady = true;
 
 	/**
 	 * @since 3.0
@@ -47,10 +47,10 @@ class LinksUpdateConstructed extends HookHandler {
 	/**
 	 * @since 3.0
 	 *
-	 * @param boolean $isReadOnly
+	 * @param boolean $isReady
 	 */
-	public function isReadOnly( $isReadOnly ) {
-		$this->isReadOnly = (bool)$isReadOnly;
+	public function isReady( $isReady ) {
+		$this->isReady = (bool)$isReady;
 	}
 
 	/**
@@ -69,8 +69,8 @@ class LinksUpdateConstructed extends HookHandler {
 	 */
 	public function process( LinksUpdate $linksUpdate ) {
 
-		if ( $this->isReadOnly ) {
-			return false;
+		if ( $this->isReady === false ) {
+			return $this->doAbort();
 		}
 
 		$title = $linksUpdate->getTitle();
@@ -156,6 +156,15 @@ class LinksUpdateConstructed extends HookHandler {
 		}
 
 		return $parserOutput->mSMWData;
+	}
+
+	private function doAbort() {
+
+		$this->logger->info(
+			"LinksUpdateConstructed was invoked but the site isn't ready yet, aborting the processing."
+		);
+
+		return false;
 	}
 
 }

--- a/src/MediaWiki/Hooks/ParserAfterTidy.php
+++ b/src/MediaWiki/Hooks/ParserAfterTidy.php
@@ -48,7 +48,7 @@ class ParserAfterTidy extends HookHandler {
 	/**
 	 * @var boolean
 	 */
-	private $isReadOnly = false;
+	private $isReady = true;
 
 	/**
 	 * @since  1.9
@@ -77,10 +77,10 @@ class ParserAfterTidy extends HookHandler {
 	/**
 	 * @since 3.0
 	 *
-	 * @param boolean $isReadOnly
+	 * @param boolean $isReady
 	 */
-	public function isReadOnly( $isReadOnly ) {
-		$this->isReadOnly = (bool)$isReadOnly;
+	public function isReady( $isReady ) {
+		$this->isReady = (bool)$isReady;
 	}
 
 	/**
@@ -103,8 +103,8 @@ class ParserAfterTidy extends HookHandler {
 
 		// #2432 avoid access to the DBLoadBalancer while being in readOnly mode
 		// when for example Title::isProtected is accessed
-		if ( $this->isReadOnly ) {
-			return false;
+		if ( $this->isReady === false ) {
+			return $this->doAbort();
 		}
 
 		$title = $this->parser->getTitle();
@@ -288,6 +288,15 @@ class ParserAfterTidy extends HookHandler {
 				number_format( ( microtime( true ) - $start ), 3 )
 			);
 		}
+	}
+
+	private function doAbort() {
+
+		$this->logger->info(
+			"ParserAfterTidy was invoked but the site isn't ready yet, aborting the processing."
+		);
+
+		return false;
 	}
 
 }

--- a/src/Site.php
+++ b/src/Site.php
@@ -33,12 +33,25 @@ class Site {
 	}
 
 	/**
-	 * @since 3.0
+	 * @since 3.2
 	 *
 	 * @return boolean
 	 */
-	public static function isBlocked() {
-		return defined( 'MEDIAWIKI_INSTALL' ) && MEDIAWIKI_INSTALL;
+	public static function isReady() {
+
+		// #3341
+		// When running as part of the install don't try to access the DB
+		// or update the Store
+		if ( defined( 'MEDIAWIKI_INSTALL' ) && MEDIAWIKI_INSTALL ) {
+			return false;
+		}
+
+		// Don't run any parsing or registration when the system isn't full
+		// initialized also prevent issues like "... BadMethodCallException from
+		// ... SessionManager.php Sessions are disabled for this entry point ..."
+		//
+		// https://github.com/wikimedia/mediawiki/blob/cdb7d53dcbb5af884d0d475e255730e35760489b/includes/user/User.php#L293-L317
+		return !defined( 'MW_NO_SESSION' ) && $GLOBALS['wgFullyInitialised'];
 	}
 
 	/**

--- a/tests/phpunit/Unit/MediaWiki/Hooks/LinksUpdateConstructedTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Hooks/LinksUpdateConstructedTest.php
@@ -21,11 +21,13 @@ class LinksUpdateConstructedTest extends \PHPUnit_Framework_TestCase {
 
 	private $testEnvironment;
 	private $namespaceExaminer;
+	private $spyLogger;
 
 	protected function setUp() {
 		parent::setUp();
 
 		$this->testEnvironment = new TestEnvironment();
+		$this->spyLogger = $this->testEnvironment->newSpyLogger();
 
 		$this->namespaceExaminer = $this->getMockBuilder( '\SMW\NamespaceExaminer' )
 			->disableOriginalConstructor()
@@ -119,7 +121,7 @@ class LinksUpdateConstructedTest extends \PHPUnit_Framework_TestCase {
 			$this->namespaceExaminer
 		);
 
-		$instance->setLogger( $this->testEnvironment->newSpyLogger() );
+		$instance->setLogger( $this->spyLogger );
 		$instance->disableDeferredUpdate();
 
 		$this->assertTrue(
@@ -219,7 +221,7 @@ class LinksUpdateConstructedTest extends \PHPUnit_Framework_TestCase {
 		);
 	}
 
-	public function testIsReadOnly_DoNothing() {
+	public function testIsNotReady_DoNothing() {
 
 		$linksUpdate = $this->getMockBuilder( '\LinksUpdate' )
 			->disableOriginalConstructor()
@@ -232,7 +234,9 @@ class LinksUpdateConstructedTest extends \PHPUnit_Framework_TestCase {
 			$this->namespaceExaminer
 		);
 
-		$instance->isReadOnly( true );
+		$instance->setLogger( $this->spyLogger );
+
+		$instance->isReady( false );
 
 		$this->assertFalse(
 			$instance->process( $linksUpdate )

--- a/tests/phpunit/Unit/MediaWiki/Hooks/ParserAfterTidyTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Hooks/ParserAfterTidyTest.php
@@ -79,7 +79,7 @@ class ParserAfterTidyTest extends \PHPUnit_Framework_TestCase {
 		);
 	}
 
-	public function testIsReadOnly() {
+	public function testIsNotReady_DoNothing() {
 
 		$this->parser->expects( $this->never() )
 			->method( 'getTitle' );
@@ -90,7 +90,9 @@ class ParserAfterTidyTest extends \PHPUnit_Framework_TestCase {
 			$this->cache
 		);
 
-		$instance->isReadOnly( true );
+		$instance->setLogger( $this->spyLogger );
+
+		$instance->isReady( false );
 
 		$text = '';
 		$instance->process( $text );

--- a/tests/phpunit/Unit/SiteTest.php
+++ b/tests/phpunit/Unit/SiteTest.php
@@ -23,11 +23,11 @@ class SiteTest extends \PHPUnit_Framework_TestCase {
 		);
 	}
 
-	public function testIsBlocked() {
+	public function testIsReady() {
 
 		$this->assertInternalType(
 			'boolean',
-			Site::isBlocked()
+			Site::isReady()
 		);
 	}
 


### PR DESCRIPTION
This PR is made in reference to: https://github.com/SemanticMediaWiki/SemanticExtraSpecialProperties/issues/129

This PR addresses or contains:

- I'm unable to replicate the referenced issue but one can see from the stack trace that it is invoked from `MessageCache.php(1162): Parser->parse` therefore as cautionary measurement we will now check  `wgFullyInitialised`, `MW_NO_SESSION` and avoid any possible "BadMethodCallException ... SessionManager.php: Sessions are disabled for this entry point" when called via the `ParserAfterTidy` or `LinksUpdateConstructed` hook.
- Relying on the same check as in https://github.com/wikimedia/mediawiki/blob/cdb7d53dcbb5af884d0d475e255730e35760489b/includes/user/User.php#L293-L317

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed

```
#12 /var/www/wiki/w/extensions/SemanticExtraSpecialProperties/src/PropertyRegistry.php(43): SESP\AppFactory->getPropertyDefinitions()
#13 /var/www/wiki/w/extensions/SemanticExtraSpecialProperties/src/HookRegistry.php(144): SESP\PropertyRegistry->register(SMW\PropertyRegistry)
#14 /var/www/wiki/w/includes/Hooks.php(177): SESP\HookRegistry->SESP\{closure}(SMW\PropertyRegistry)
#15 /var/www/wiki/w/includes/Hooks.php(205): Hooks::callHook(string, array, array, NULL)
#16 /var/www/wiki/w/extensions/SemanticMediaWiki/src/PropertyRegistry.php(507): Hooks::run(string, array)
#17 /var/www/wiki/w/extensions/SemanticMediaWiki/src/PropertyRegistry.php(98): SMW\PropertyRegistry->initProperties(array)
#18 /var/www/wiki/w/extensions/SemanticMediaWiki/includes/dataitems/SMW_DI_Property.php(94): SMW\PropertyRegistry::getInstance()
#19 /var/www/wiki/w/extensions/SemanticMediaWiki/src/DataItemFactory.php(45): SMW\DIProperty->__construct(string, boolean)
#20 /var/www/wiki/w/extensions/SemanticMediaWiki/src/Property/Annotators/EditProtectedPropertyAnnotator.php(71): SMW\DataItemFactory->newDIProperty(string)
#21 /var/www/wiki/w/extensions/SemanticMediaWiki/src/MediaWiki/Hooks/ParserAfterTidy.php(208): SMW\Property\Annotators\EditProtectedPropertyAnnotator->addTopIndicatorTo(ParserOutput)
#23 /var/www/wiki/w/extensions/SemanticMediaWiki/src/MediaWiki/Hooks/ParserAfterTidy.php(96): SMW\MediaWiki\Hooks\ParserAfterTidy->performUpdate(string)
#24 /var/www/wiki/w/extensions/SemanticMediaWiki/src/MediaWiki/Hooks.php(359): SMW\MediaWiki\Hooks\ParserAfterTidy->process(string)
#25 /var/www/wiki/w/includes/Hooks.php(177): SMW\MediaWiki\Hooks->onParserAfterTidy(Parser, string)
#26 /var/www/wiki/w/includes/Hooks.php(205): Hooks::callHook(string, array, array, NULL)
#27 /var/www/wiki/w/includes/parser/Parser.php(1428): Hooks::run(string, array)
#28 /var/www/wiki/w/includes/parser/Parser.php(446): Parser->internalParseHalfParsed(string, boolean, boolean)
#29 /var/www/wiki/w/includes/cache/MessageCache.php(1162): Parser->parse(string, Title, ParserOptions, boolean)
#30 /var/www/wiki/w/includes/Message.php(1244): MessageCache->parse(string, Title, boolean, boolean, Language)
#31 /var/www/wiki/w/includes/Message.php(869): Message->parseText(string)
#32 /var/www/wiki/w/includes/Message.php(922): Message->toString(string)
```