### PR TITLE
Avoid "Error: Class 'SMW\Maintenance\*' not found", refs 4394

### DIFF
--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -26,7 +26,9 @@ $autoloader->addClassMap( [
 	'SMW\Maintenance\DumpRdf'                    => __DIR__ . '/../maintenance/dumpRDF.php',
 	'SMW\Maintenance\SetupStore'                 => __DIR__ . '/../maintenance/setupStore.php',
 	'SMW\Maintenance\UpdateEntityCollation'      => __DIR__ . '/../maintenance/updateEntityCollation.php',
-	'SMW\Maintenance\RemoveDuplicateEntities'    => __DIR__ . '/../maintenance/removeDuplicateEntities.php'
+	'SMW\Maintenance\RemoveDuplicateEntities'    => __DIR__ . '/../maintenance/removeDuplicateEntities.php',
+	'SMW\Maintenance\PurgeEntityCache'           => __DIR__ . '/../maintenance/purgeEntityCache.php',
+	'SMW\Maintenance\UpdateQueryDependencies'    => __DIR__ . '/../maintenance/updateQueryDependencies.php'
 ] );
 
 define( 'SMW_PHPUNIT_DIR', __DIR__ . '/phpunit' );


### PR DESCRIPTION
This PR is made in reference to: #4394

This PR addresses or contains:

- Fixes 4 errors from [0].

```
There were 8 errors:

1) SMW\Tests\Maintenance\PurgeEntityCacheTest::testCanConstruct
Error: Class 'SMW\Maintenance\PurgeEntityCache' not found

/home/travis/build/SemanticMediaWiki/mw/extensions/SemanticMediaWiki/tests/phpunit/Unit/Maintenance/PurgeEntityCacheTest.php:53
/home/travis/build/SemanticMediaWiki/mw/maintenance/doMaintenance.php:99

2) SMW\Tests\Maintenance\PurgeEntityCacheTest::testExecute
Error: Class 'SMW\Maintenance\PurgeEntityCache' not found

/home/travis/build/SemanticMediaWiki/mw/extensions/SemanticMediaWiki/tests/phpunit/Unit/Maintenance/PurgeEntityCacheTest.php:90
/home/travis/build/SemanticMediaWiki/mw/maintenance/doMaintenance.php:99

3) SMW\Tests\Maintenance\UpdateQueryDependenciesTest::testCanConstruct
Error: Class 'SMW\Maintenance\UpdateQueryDependencies' not found

/home/travis/build/SemanticMediaWiki/mw/extensions/SemanticMediaWiki/tests/phpunit/Unit/Maintenance/UpdateQueryDependenciesTest.php:60
/home/travis/build/SemanticMediaWiki/mw/maintenance/doMaintenance.php:99

4) SMW\Tests\Maintenance\UpdateQueryDependenciesTest::testExecute
Error: Class 'SMW\Maintenance\UpdateQueryDependencies' not found

/home/travis/build/SemanticMediaWiki/mw/extensions/SemanticMediaWiki/tests/phpunit/Unit/Maintenance/UpdateQueryDependenciesTest.php:115
/home/travis/build/SemanticMediaWiki/mw/maintenance/doMaintenance.php:99
```

This PR includes:
- [ ] Tests (unit/integration)
- [ ] CI build passed

[0] https://travis-ci.org/SemanticMediaWiki/SemanticMediaWiki/jobs/635751414