### PR TITLE
[ES] Remove `number_of_replicas` from settings update for ES < 6.4, refs 4341

### DIFF
--- a/src/Elastic/Indexer/Rebuilder.php
+++ b/src/Elastic/Indexer/Rebuilder.php
@@ -379,6 +379,13 @@ class Rebuilder {
 		// rebuild
 		unset( $indexDef['settings']['number_of_shards'] );
 
+		// #4341
+		// ES 5.6 may cause a "Can't update [index.number_of_replicas] on closed
+		// indices" see elastic/elasticsearch#22993 and should be fixed with ES 6.4.
+		if ( version_compare( $this->client->getVersion(), '6.4.0', '<' ) ) {
+			unset( $indexDef['settings']['number_of_replicas'] );
+		}
+
 		$params = [
 			'index' => $index,
 			'body' => [

--- a/tests/phpunit/Integration/Maintenance/RebuildElasticIndexTest.php
+++ b/tests/phpunit/Integration/Maintenance/RebuildElasticIndexTest.php
@@ -43,18 +43,6 @@ class RebuildElasticIndexTest extends MwDBaseUnitTestCase {
 
 	public function testRun() {
 
-		$version = $this->store->getInfo( 'es' );
-
-		// Testing against ES 5.6 may cause a "Can't update
-		// [index.number_of_replicas] on closed indices" see
-		// https://github.com/elastic/elasticsearch/issues/22993
-		//
-		// Should be fixed with ES 6.4
-		// https://github.com/elastic/elasticsearch/pull/30423
-		if ( version_compare( $version, '6.4.0', '<' ) ) {
-			$this->markTestSkipped( "Skipping test because it requires at least ES 6.4.0." );
-		}
-
 		$maintenanceRunner = $this->runnerFactory->newMaintenanceRunner(
 			'SMW\Maintenance\RebuildElasticIndex'
 		);


### PR DESCRIPTION
This PR is made in reference to: #4341

This PR addresses or contains:

- Fixes "ES 5.6 may cause a "Can't update [index.number_of_replicas] on closed indices" see elastic/elasticsearch#22993 and should be fixed with ES 6.4."

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed
