### PR TITLE
[ES] Tidy (Config)

### DIFF
--- a/DefaultSettings.php
+++ b/DefaultSettings.php
@@ -2188,6 +2188,7 @@ return [
 		],
 		'connection' =>[
 			'quick_ping' => true,
+
 			// Number of times the client tries to reconnect before throwing an
 			// exception
 			'retries' => 2,
@@ -2236,13 +2237,13 @@ return [
 			// possible discrepancy between the stored on-wiki data and the data
 			// replicated to Elasticsearch.
 			'monitor.entity.replication' => true,
-			'monitor.entity.replication.cache_lifetime' => 3660,
+			'monitor.entity.replication.cache_lifetime' => 3600,
 		],
 		'query' => [
 
 			// If for some reason no connection to the ES cluster could be
 			// established, use the SQLStore QueryEngine as fallback.
-			'fallback.no.connection' => false,
+			'fallback.no_connection' => false,
 
 			// @see https://www.elastic.co/guide/en/elasticsearch/reference/6.1/_profiling_queries.html
 			'profiling' => false,

--- a/data/elastic/default-profile.json
+++ b/data/elastic/default-profile.json
@@ -3,8 +3,7 @@
 		"retries": 2,
 		"timeout": 30,
 		"connect_timeout": 30,
-		"quick_ping": true,
-		"retries": 2
+		"quick_ping": true
 	},
 	"settings": {
 		"data": {
@@ -19,16 +18,17 @@
 		"job.recovery.retries": 5,
 		"job.file.ingest.retries": 3,
 		"monitor.entity.replication": true,
-		"monitor.entity.replication.cache.lifetime": 3600,
+		"monitor.entity.replication.cache_lifetime": 3600
 	},
 	"query": {
-		"fallback.no.connection": false,
+		"fallback.no_connection": false,
 		"profiling": false,
 		"debug.explain": true,
 		"debug.description.log": true,
+		"maximum.value.length": 500,
 		"must_not.property.exists": true,
 		"sort.property.must.exists": true,
-		"score.sortfield": "elastic.score",
+		"score.sortfield": "es.score",
 		"query_string.boolean.operators": true,
 		"compat.mode": true,
 		"subquery.size":10000,
@@ -44,12 +44,12 @@
 			"subject.title^8",
 			"text_copy^5",
 			"text_raw",
-			"attachment.title^3"
+			"attachment.title^3",
 			"attachment.content"
 		],
 		"uri.field.case.insensitive": false,
 		"text.field.case.insensitive.eq.match": false,
 		"page.field.case.insensitive.proximity.match": true,
-		"highlight.fragment.type": false
+		"highlight.fragment": { "number" : 1, "size" : 250, "type" : false }
 	}
 }

--- a/src/Elastic/Admin/ElasticClientTaskHandler.php
+++ b/src/Elastic/Admin/ElasticClientTaskHandler.php
@@ -10,6 +10,7 @@ use SMW\ApplicationFactory;
 use WebRequest;
 use SMW\Elastic\Indexer\ReplicationStatus;
 use SMW\Elastic\Connection\Client as ElasticClient;
+use SMW\Elastic\Config;
 
 /**
  * @license GNU GPL v2+
@@ -146,6 +147,7 @@ class ElasticClientTaskHandler extends TaskHandler {
 	private function outputNoNodesAvailable( $connection ) {
 
 		$this->outputHead();
+		$config = $connection->getConfig();
 
 		$html = Html::rawElement(
 			'h3',
@@ -162,7 +164,7 @@ class ElasticClientTaskHandler extends TaskHandler {
 		) . Html::rawElement(
 			'pre',
 			[],
-			json_encode( $connection->getConfig()->safeGet( 'endpoints', [] ), JSON_PRETTY_PRINT )
+			json_encode( $config->safeGet( Config::ELASTIC_ENDPOINTS, [] ), JSON_PRETTY_PRINT )
 		);
 
 		$this->outputFormatter->addHTML( $html );

--- a/src/Elastic/Config.php
+++ b/src/Elastic/Config.php
@@ -14,6 +14,74 @@ use RuntimeException;
 class Config extends Options {
 
 	/**
+	 * Whether `EalsticStore` was selected as default store or not
+	 */
+	const DEFAULT_STORE = 'elastic/defaultstore';
+
+	/**
+	 * Describes registered endpoints
+	 */
+	const ELASTIC_ENDPOINTS = 'elastic/endpoints';
+
+	/**
+	 * Contains deprecated or renamed settings.
+	 *
+	 * @var array
+	 */
+	private $deprecatedKeys = [
+		'query' => [
+			// 3.2
+			'fallback.no.connection' => 'fallback.no_connection'
+		]
+	];
+
+	/**
+	 * @since 3.2
+	 *
+	 * @return boolean
+	 */
+	public function isDefaultStore() : bool {
+
+		$defaultStore = $this->get(
+			Config::DEFAULT_STORE
+		);
+
+		return $defaultStore === ElasticStore::class || $defaultStore === 'SMWElasticStore';
+	}
+
+	/**
+	 * @note Can only be used during testing
+	 *
+	 * @since 3.2
+	 *
+	 * @param array $deprecatedKeys
+	 */
+	public function setDeprectedKeys( array $deprecatedKeys ) {
+
+		if ( !defined( 'MW_PHPUNIT_TEST' ) ) {
+			return;
+		}
+
+		$this->deprecatedKeys = $deprecatedKeys;
+	}
+
+	/**
+	 * @since 3.2
+	 */
+	public function reassignDeprectedKeys() {
+		foreach ( $this->deprecatedKeys as $k => $keys ) {
+			foreach ( $keys as $deprected => $new ) {
+
+				if ( isset( $this->options[$k][$deprected] ) ) {
+					$this->options[$k][$new] = $this->options[$k][$deprected];
+				}
+
+				unset( $this->options[$k][$deprected] );
+			}
+		}
+	}
+
+	/**
 	 * @since 3.0
 	 *
 	 * @param string $data

--- a/src/Elastic/Connection/Client.php
+++ b/src/Elastic/Connection/Client.php
@@ -11,6 +11,7 @@ use Psr\Log\LoggerAwareTrait;
 use Psr\Log\NullLogger;
 use SMW\Elastic\Exception\InvalidJSONException;
 use SMW\Elastic\Exception\ReplicationException;
+use SMW\Elastic\Config;
 use SMW\Options;
 use SMW\Site;
 
@@ -78,7 +79,7 @@ class Client {
 	 * @param LockManager $lockManager
 	 * @param Options|null $options
 	 */
-	public function __construct( ElasticClient $client, LockManager $lockManager, Options $options = null ) {
+	public function __construct( ElasticClient $client, LockManager $lockManager, Config $options = null ) {
 		$this->client = $client;
 		$this->lockManager = $lockManager;
 		$this->options = $options;
@@ -187,7 +188,9 @@ class Client {
 
 		$info = $this->info();
 
-		if ( $this->options->safeGet( 'elastic.enabled' ) && isset( $info['version']['number'] ) ) {
+		if (
+			$this->options->isDefaultStore() &&
+			isset( $info['version']['number'] ) ) {
 			return $info['version']['number'];
 		}
 
@@ -504,7 +507,7 @@ class Client {
 	 */
 	public function quick_ping( $timeout = 2 ) {
 
-		$hosts = $this->options->get( 'endpoints' );
+		$hosts = $this->options->get( Config::ELASTIC_ENDPOINTS );
 
 		foreach ( $hosts as $host ) {
 

--- a/src/Elastic/Connection/DummyClient.php
+++ b/src/Elastic/Connection/DummyClient.php
@@ -6,7 +6,7 @@ use Onoi\Cache\Cache;
 use Onoi\Cache\NullCache;
 use Psr\Log\NullLogger;
 use RuntimeException;
-use SMW\Options;
+use SMW\Elastic\Config;
 
 /**
  * @private
@@ -29,28 +29,28 @@ class DummyClient extends Client {
 	private $cache;
 
 	/**
-	 * @var Options
+	 * @var Config
 	 */
-	private $options;
+	private $config;
 
 	/**
 	 * @since 3.0
 	 *
 	 * @param ElasticClient $client
 	 * @param Cache|null $cache
-	 * @param Options|null $options
+	 * @param Config|null $config
 	 */
-	public function __construct( $client = null, Cache $cache = null, Options $options = null ) {
+	public function __construct( $client = null, Cache $cache = null, Config $config = null ) {
 		$this->client = $client;
 		$this->cache = $cache;
-		$this->options = $options;
+		$this->config = $config;
 
 		if ( $this->cache === null ) {
 			$this->cache = new NullCache();
 		}
 
-		if ( $this->options === null ) {
-			$this->options = new Options();
+		if ( $this->config === null ) {
+			$this->config = new Config();
 		}
 
 		$this->logger = new NullLogger();
@@ -60,7 +60,7 @@ class DummyClient extends Client {
 	 * @see Client::getConfig
 	 */
 	public function getConfig() {
-		return $this->options;
+		return $this->config;
 	}
 
 	/**

--- a/src/Elastic/ElasticStore.php
+++ b/src/Elastic/ElasticStore.php
@@ -196,7 +196,7 @@ class ElasticStore extends SQLStore {
 			$this->queryEngine = $this->elasticFactory->newQueryEngine( $this );
 		}
 
-		if ( $connection->getConfig()->dotGet( 'query.fallback.no.connection' ) && !$connection->ping() ) {
+		if ( $connection->getConfig()->dotGet( 'query.fallback.no_connection' ) && !$connection->ping() ) {
 			return parent::getQueryResult( $query );
 		}
 

--- a/tests/phpunit/Integration/Elastic/DefaultConfigTest.php
+++ b/tests/phpunit/Integration/Elastic/DefaultConfigTest.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace SMW\Tests\Integration\Elastic;
+
+/**
+ * @license GNU GPL v2+
+ * @since 3.2
+ *
+ * @author mwjames
+ */
+class DefaultConfigTest extends \PHPUnit_Framework_TestCase {
+
+	private $contents;
+
+	protected function setUp() {
+		parent::setUp();
+		$this->contents = file_get_contents( $GLOBALS['smwgIP'] . 'data/elastic/default-profile.json' );
+	}
+
+	public function testJSONFile() {
+
+		$this->assertInternalType(
+			'string',
+			json_encode( json_decode( $this->contents ) )
+		);
+	}
+
+	/**
+	 * @dataProvider defaultSettingsProvider
+	 */
+	public function testComparePHP_JSONConfigKeys( $key, $k, $expected ) {
+
+		$contents = json_decode( $this->contents, true );
+
+		$this->assertEquals(
+			$expected,
+			$contents[$key][$k]
+		);
+	}
+
+	public function defaultSettingsProvider() {
+
+		$defaultSettings = include $GLOBALS['smwgIP'] . 'DefaultSettings.php';
+
+		foreach ( $defaultSettings['smwgElasticsearchConfig'] as $key => $configs ) {
+
+			if ( $key === 'index_def' ) {
+				continue;
+			}
+
+			foreach ( $configs as $k => $v ) {
+				yield $key => [ $key, $k, $v ];
+			}
+		}
+	}
+
+}

--- a/tests/phpunit/Unit/Elastic/ConfigTest.php
+++ b/tests/phpunit/Unit/Elastic/ConfigTest.php
@@ -26,6 +26,59 @@ class ConfigTest extends \PHPUnit_Framework_TestCase {
 		);
 	}
 
+	public function testIsDefaultStore_False() {
+
+		$instance = new Config(
+			[ Config::DEFAULT_STORE => 'Foo' ]
+		);
+
+		$this->assertFalse(
+			$instance->isDefaultStore()
+		);
+	}
+
+	public function testIsDefaultStore_True() {
+
+		$instance = new Config(
+			[ Config::DEFAULT_STORE => 'SMWElasticStore' ]
+		);
+
+		$this->assertTrue(
+			$instance->isDefaultStore()
+		);
+	}
+
+	public function testReassignDeprectedKeys() {
+
+		$instance = new Config(
+			[
+				'foo' => [
+					'foo.bar' => 42
+				]
+			]
+		);
+
+		$instance->setDeprectedKeys(
+			[
+				'foo' => [
+					'foo.bar' => 'foo_bar'
+				]
+			]
+		);
+
+		$instance->reassignDeprectedKeys();
+
+		$this->assertEquals(
+			42,
+			$instance->dotGet( 'foo.foo_bar' )
+		);
+
+		$this->assertEquals(
+			false,
+			$instance->dotGet( 'foo.foo.bar' )
+		);
+	}
+
 	public function testLoadFromJSON() {
 
 		$instance = new Config();

--- a/tests/phpunit/Unit/Elastic/Connection/ClientTest.php
+++ b/tests/phpunit/Unit/Elastic/Connection/ClientTest.php
@@ -3,7 +3,7 @@
 namespace SMW\Tests\Elastic\Connection;
 
 use SMW\Elastic\Connection\Client;
-use SMW\Options;
+use SMW\Elastic\Config;
 use SMW\Tests\PHPUnitCompat;
 
 /**
@@ -73,7 +73,7 @@ class ClientTest extends \PHPUnit_Framework_TestCase {
 
 	public function testBulkOnIllegalArgumentErrorThrowsReplicationException() {
 
-		$options = new Options (
+		$options = new Config (
 			[
 				'replication' => [
 					'throw.exception.on.illegal.argument.error' => true

--- a/tests/phpunit/Unit/Elastic/Connection/ConnectionProviderTest.php
+++ b/tests/phpunit/Unit/Elastic/Connection/ConnectionProviderTest.php
@@ -5,7 +5,7 @@ namespace SMW\Tests\Elastic\Connection;
 use SMW\Elastic\Connection\ConnectionProvider;
 use SMW\Elastic\Connection\DummyClient;
 use SMW\Elastic\Connection\Client;
-use SMW\Options;
+use SMW\Elastic\Config;
 use SMW\Tests\PHPUnitCompat;
 
 /**
@@ -34,28 +34,28 @@ class ConnectionProviderTest extends \PHPUnit_Framework_TestCase {
 			->disableOriginalConstructor()
 			->getMock();
 
-		$this->options = new Options();
+		$this->config = new Config();
 	}
 
 	public function testCanConstruct() {
 
 		$this->assertInstanceOf(
 			ConnectionProvider::class,
-			new ConnectionProvider( $this->lockManager, $this->options )
+			new ConnectionProvider( $this->lockManager, $this->config )
 		);
 	}
 
 	public function testGetConnection_MissingEndpointsThrowsException() {
 
-		$options = new Options (
+		$config = new Config (
 			[
-				'is.elasticstore' => true
+				Config::DEFAULT_STORE => 'SMWElasticStore'
 			]
 		);
 
 		$instance = new ConnectionProvider(
 			$this->lockManager,
-			$options
+			$config
 		);
 
 		$this->setExpectedException( '\SMW\Elastic\Exception\MissingEndpointConfigException' );
@@ -64,16 +64,16 @@ class ConnectionProviderTest extends \PHPUnit_Framework_TestCase {
 
 	public function testGetConnection_DummyClient() {
 
-		$options = new Options (
+		$config = new Config (
 			[
-				'is.elasticstore' => false,
-				'endpoints' => [ 'foo' ]
+				Config::DEFAULT_STORE => 'SMWSQLStore',
+				Config::ELASTIC_ENDPOINTS => [ 'foo' ]
 			]
 		);
 
 		$instance = new ConnectionProvider(
 			$this->lockManager,
-			$options
+			$config
 		);
 
 		$instance->setLogger( $this->logger );
@@ -90,16 +90,16 @@ class ConnectionProviderTest extends \PHPUnit_Framework_TestCase {
 			$this->markTestSkipped( "elasticsearch-php dependency is not available." );
 		}
 
-		$options = new Options (
+		$config = new Config (
 			[
-				'is.elasticstore' => true,
-				'endpoints' => [ 'foo' ]
+				Config::DEFAULT_STORE => 'SMWElasticStore',
+				Config::ELASTIC_ENDPOINTS => [ 'foo' ]
 			]
 		);
 
 		$instance = new ConnectionProvider(
 			$this->lockManager,
-			$options
+			$config
 		);
 
 		$instance->setLogger( $this->logger );
@@ -116,16 +116,16 @@ class ConnectionProviderTest extends \PHPUnit_Framework_TestCase {
 			$this->markTestSkipped( "\Elasticsearch\ClientBuilder is available, no exception is thrown" );
 		}
 
-		$options = new Options (
+		$config = new Config (
 			[
-				'is.elasticstore' => true,
-				'endpoints' => [ 'foo' ]
+				Config::DEFAULT_STORE => 'SMWElasticStore',
+				Config::ELASTIC_ENDPOINTS => [ 'foo' ]
 			]
 		);
 
 		$instance = new ConnectionProvider(
 			$this->lockManager,
-			$options
+			$config
 		);
 
 		$this->setExpectedException( '\SMW\Elastic\Exception\ClientBuilderNotFoundException' );


### PR DESCRIPTION
This PR is made in reference to: #

This PR addresses or contains:

- Use explicit type hinting against `SMW\Elastic\Config`
- Add support for `deprecatedKeys` in `SMW\Elastic\Config`

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed

Fixes #