### PR TITLE
Integration test for `Store::drop` via `setupStore.php`

### DIFF
--- a/maintenance/setupStore.php
+++ b/maintenance/setupStore.php
@@ -142,10 +142,10 @@ class SetupStore extends \Maintenance {
 			$connectionManager
 		);
 
-		$messageReporter = $this->getMessageReporter();
+		$this->initMessageReporter();
 
 		$store->setMessageReporter(
-			$messageReporter
+			$this->messageReporter
 		);
 
 		$options = new Options(
@@ -159,7 +159,7 @@ class SetupStore extends \Maintenance {
 
 		$cliMsgFormatter = new CliMsgFormatter();
 
-		$messageReporter->reportMessage(
+		$this->messageReporter->reportMessage(
 			"\n" . $cliMsgFormatter->head()
 		);
 
@@ -173,7 +173,7 @@ class SetupStore extends \Maintenance {
 		StoreFactory::clear();
 	}
 
-	protected function getMessageReporter() {
+	protected function initMessageReporter() {
 
 		$messageReporterFactory = MessageReporterFactory::getInstance();
 
@@ -222,17 +222,12 @@ class SetupStore extends \Maintenance {
 
 		$store->drop( !$this->isQuiet() );
 
-		// be sure to have some buffer, otherwise some PHPs complain
-		while ( ob_get_level() > 0 ) {
-			ob_end_flush();
-		}
-
 		$text = [
 			"You can recreate them with this script followed by the use",
 			"of the rebuildData.php script to rebuild their contents."
 		];
 
-		$this->output(
+		$this->messageReporter->reportMessage(
 			"\n" . $cliMsgFormatter->wordwrap( $text ) . "\n"
 		);
 	}
@@ -246,7 +241,7 @@ class SetupStore extends \Maintenance {
 
 		$cliMsgFormatter = new CliMsgFormatter();
 
-		$this->output(
+		$this->messageReporter->reportMessage(
 			$cliMsgFormatter->section( 'Notice' )
 		);
 
@@ -255,7 +250,7 @@ class SetupStore extends \Maintenance {
 			"this operation later on, a complete refresh of the data will be needed."
 		];
 
-		$this->output(
+		$this->messageReporter->reportMessage(
 			"\n" . $cliMsgFormatter->wordwrap( $text ) . "\n\n"
 		);
 

--- a/src/SPARQLStore/SPARQLStore.php
+++ b/src/SPARQLStore/SPARQLStore.php
@@ -63,6 +63,8 @@ class SPARQLStore extends Store {
 		if ( $this->baseStore === null ) {
 			$this->baseStore = $this->factory->getBaseStore( self::$baseStoreClass );
 		}
+
+		$this->connectionManager = $this->factory->getConnectionManager();
 	}
 
 	/**
@@ -373,6 +375,7 @@ class SPARQLStore extends Store {
 	 * @since 1.6
 	 */
 	public function drop( $verbose = true ) {
+		$this->baseStore->setMessageReporter( $this->messageReporter );
 		$this->baseStore->drop( $verbose );
 		$this->getConnection()->deleteAll();
 	}
@@ -456,11 +459,6 @@ class SPARQLStore extends Store {
 	 * @return mixed
 	 */
 	public function getConnection( $type = 'sparql' ) {
-
-		if ( $this->connectionManager === null ) {
-			$this->setConnectionManager( $this->factory->getConnectionManager() );
-		}
-
 		return parent::getConnection( $type );
 	}
 

--- a/tests/phpunit/Integration/Maintenance/SetupStoreMaintenanceTest.php
+++ b/tests/phpunit/Integration/Maintenance/SetupStoreMaintenanceTest.php
@@ -44,6 +44,31 @@ class SetupStoreMaintenanceTest extends MwDBaseUnitTestCase {
 		parent::tearDown();
 	}
 
+	public function testSetupStore_Delete() {
+
+		$maintenanceRunner = $this->runnerFactory->newMaintenanceRunner( 'SMW\Maintenance\SetupStore' );
+
+		$maintenanceRunner->setQuiet();
+
+		$maintenanceRunner->setOptions(
+			[
+				'delete' => true,
+				'nochecks' => true
+			]
+		);
+
+		$maintenanceRunner->setMessageReporter(
+			$this->spyMessageReporter
+		);
+
+		$maintenanceRunner->run();
+
+		$this->assertContains(
+			'Database table cleanup',
+			$this->spyMessageReporter->getMessagesAsString()
+		);
+	}
+
 	public function testSetupStore() {
 
 		$this->importedTitles = [


### PR DESCRIPTION
This PR is made in reference to: #

This PR addresses or contains:

- Adds an integration test for `Store::drop`
- Invokes the connection manager earlier in the `SPARQLStore` to avoid a "ConnectionManager.php: sparql is not registered as connection provider" encountered while testing `Store::drop` in connection with a rdf store

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed

## Stack trace

```
   ... smw_fpt_sobj (not found) ...                                 SKIPPED
   ... smw_fpt_askdu (not found) ...                                SKIPPED
   ... smw_fpt_mdat (not found) ...                                 SKIPPED
   ... done.

Standard and auxiliary tables with all corresponding data have been removed
successfully.
[156979eb86a2d94a51e9d2ab] [no req]   RuntimeException from line 49 of ...\extensions\SemanticMediaWiki\src\Connection\ConnectionManager.php: sparql is not registered as connection provider
Backtrace:
#0 ...\extensions\SemanticMediaWiki\src\Store.php(598): SMW\Connection\ConnectionManager->getConnection(string)
#1 ...\extensions\SemanticMediaWiki\src\SPARQLStore\SPARQLStore.php(465): SMW\Store->getConnection(string)
#2 ...\extensions\SemanticMediaWiki\src\SPARQLStore\SPARQLStore.php(378): SMW\SPARQLStore\SPARQLStore->getConnection()
#3 ...\extensions\SemanticMediaWiki\maintenance\setupStore.php(223): SMW\SPARQLStore\SPARQLStore->drop(boolean)
#4 ...\extensions\SemanticMediaWiki\maintenance\setupStore.php(167): SMW\Maintenance\SetupStore->dropStore(SMW\SPARQLStore\SPARQLStore)
#5 ...\maintenance\doMaintenance.php(96): SMW\Maintenance\SetupStore->execute()
#6 ...\extensions\SemanticMediaWiki\maintenance\setupStore.php(280): require_once(string)
#7 {main}
```