### PR TITLE
[API] Fix offset, add wildcard support in `smwbrowse`, refs 2696

### DIFF
--- a/src/MediaWiki/Api/Browse.php
+++ b/src/MediaWiki/Api/Browse.php
@@ -14,6 +14,7 @@ use SMW\MediaWiki\Api\Browse\ListAugmentor;
 use SMW\MediaWiki\Api\Browse\ListLookup;
 use SMW\MediaWiki\Api\Browse\PValueLookup;
 use SMW\MediaWiki\Api\Browse\PSubjectLookup;
+use SMW\Exception\JSONParseException;
 
 /**
  * Module to support selected browse activties including:
@@ -36,12 +37,13 @@ class Browse extends ApiBase {
 		$res = [];
 
 		if ( json_last_error() !== JSON_ERROR_NONE || !is_array( $parameters ) ) {
+			$error = new JSONParseException( $params['params'] );
 
 			// 1.29+
 			if ( method_exists($this, 'dieWithError' ) ) {
-				$this->dieWithError( [ 'smw-api-invalid-parameters', 'JSON: '. json_last_error_msg() ] );
+				$this->dieWithError( [ 'smw-api-invalid-parameters', 'JSON: '. $error->getMessage() ] );
 			} else {
-				$this->dieUsage( 'JSON: '. json_last_error_msg(), 'smw-api-invalid-parameters' );
+				$this->dieUsage( 'JSON: '. $error->getMessage(), 'smw-api-invalid-parameters' );
 			}
 		}
 
@@ -357,6 +359,8 @@ class Browse extends ApiBase {
 	 */
 	protected function getExamples() {
 		return [
+			'api.php?action=smwbrowse&browse=property&params={ "limit": 10, "offset": 0, "search": "*" }',
+			'api.php?action=smwbrowse&browse=property&params={ "limit": 10, "offset": 10, "search": "*", "sort": "desc" }',
 			'api.php?action=smwbrowse&browse=property&params={ "limit": 10, "offset": 0, "search": "Date" }',
 			'api.php?action=smwbrowse&browse=property&params={ "limit": 10, "offset": 0, "search": "Date", "description": true }',
 			'api.php?action=smwbrowse&browse=property&params={ "limit": 10, "offset": 0, "search": "Date", "description": true, "prefLabel": true }',

--- a/src/MediaWiki/Api/Browse/ListLookup.php
+++ b/src/MediaWiki/Api/Browse/ListLookup.php
@@ -62,7 +62,7 @@ class ListLookup extends Lookup {
 		);
 
 		$limit = $requestOptions->getLimit();
-		$list = [];
+		$res = [];
 		$continueOffset = 0;
 
 		// Increase by one to look ahead
@@ -127,8 +127,14 @@ class ListLookup extends Lookup {
 		$requestOptions->setLimit( $limit );
 		$requestOptions->setOffset( $offset );
 
-		if ( isset( $parameters['search'] ) && isset( $parameters['strict'] ) ) {
-			$search = $parameters['search'];
+		if ( isset( $parameters['sort'] ) && strtolower( $parameters['sort'] ) !== 'asc' ) {
+			$requestOptions->ascending = false;
+		}
+
+		if ( isset( $parameters['search'] ) && $parameters['search'] === '*' ) {
+			// wildcard
+		} elseif ( isset( $parameters['search'] ) && isset( $parameters['strict'] ) ) {
+			$search = str_replace( "*", "", $parameters['search'] );
 
 			if ( $search !== '' && $search[0] !== '_' ) {
 				$search = str_replace( "_", " ", $search );
@@ -140,7 +146,7 @@ class ListLookup extends Lookup {
 			);
 
 		} elseif ( isset( $parameters['search'] ) ) {
-			$search = $parameters['search'];
+			$search = str_replace( "*", "", $parameters['search'] );
 
 			if ( $search !== '' && $search[0] !== '_' ) {
 				$search = str_replace( "_", " ", $search );
@@ -186,10 +192,13 @@ class ListLookup extends Lookup {
 			'smw_title'
 		];
 
-		// the query needs to do the filtering of internal properties, else LIMIT is wrong
+		// The query needs to do the filtering for internal properties, else
+		// LIMIT is wrong
 		if ( isset( $parameters['sort'] ) ) {
 			$options = $this->store->getSQLOptions( $requestOptions, 'smw_sort' );
 			$fields[] = 'smw_sort';
+		} elseif ( isset( $parameters['offset'] ) ) {
+			$options = $this->store->getSQLOptions( $requestOptions, '' );
 		}
 
 		$conditions = [

--- a/tests/phpunit/Integration/JSONScript/Fixtures/res.a-0004.1.json
+++ b/tests/phpunit/Integration/JSONScript/Fixtures/res.a-0004.1.json
@@ -1,0 +1,1 @@
+"query":{"A0004\/3":{"label":"A0004\/3","key":"A0004\/3"},"A0004\/4":{"label":"A0004\/4","key":"A0004\/4"},"A0004\/5":{"label":"A0004\/5","key":"A0004\/5"}},"query-continue-offset":5,"version":1,"meta":{"type":"property","limit":3,"count":3,"isFromCache":false,"queryTime":.*}

--- a/tests/phpunit/Integration/JSONScript/Fixtures/res.a-0004.2.json
+++ b/tests/phpunit/Integration/JSONScript/Fixtures/res.a-0004.2.json
@@ -1,0 +1,1 @@
+{"query":{"A0004\/4":{"label":"A0004\/4","key":"A0004\/4"},"A0004\/3":{"label":"A0004\/3","key":"A0004\/3"},"A0004\/2":{"label":"A0004\/2","key":"A0004\/2"}},"query-continue-offset":5,"version":1,"meta":{"type":"property","limit":3,"count":3,"isFromCache":false,"queryTime":.*}

--- a/tests/phpunit/Integration/JSONScript/Fixtures/res.a-0004.3.json
+++ b/tests/phpunit/Integration/JSONScript/Fixtures/res.a-0004.3.json
@@ -1,0 +1,1 @@
+{"query":{"A0004\/6":{"label":"A0004\/6","key":"A0004\/6"}},"query-continue-offset":0,"version":1,"meta":{"type":"property","limit":1,"count":1,"isFromCache":false,"queryTime":.*}

--- a/tests/phpunit/Integration/JSONScript/TestCases/a-0004.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/a-0004.json
@@ -1,0 +1,106 @@
+{
+	"description": "Test API `action=smwbrowse` + `type=property` with limit/offset, sort",
+	"setup": [
+		{
+			"namespace": "SMW_NS_PROPERTY",
+			"page": "A0004/1",
+			"contents": "[[Has type::Page]]"
+		},
+		{
+			"namespace": "SMW_NS_PROPERTY",
+			"page": "A0004/2",
+			"contents": "[[Has type::Page]]"
+		},
+		{
+			"namespace": "SMW_NS_PROPERTY",
+			"page": "A0004/3",
+			"contents": "[[Has type::Page]]"
+		},
+		{
+			"namespace": "SMW_NS_PROPERTY",
+			"page": "A0004/4",
+			"contents": "[[Has type::Page]]"
+		},
+		{
+			"namespace": "SMW_NS_PROPERTY",
+			"page": "A0004/5",
+			"contents": "[[Has type::Page]]"
+		},
+		{
+			"namespace": "SMW_NS_PROPERTY",
+			"page": "A0004/6",
+			"contents": "[[Has type::Page]]"
+		}
+	],
+	"tests": [
+		{
+			"type": "api",
+			"about": "#0 `smwbrowse` property search (limit=3, offset=2, sort=asc)",
+			"api": {
+				"parameters": {
+					"action": "smwbrowse",
+					"format": "json",
+					"browse": "property",
+					"params": "{ \"limit\": 3, \"offset\": 2, \"search\": \"A0004\", \"sort\": \"asc\" }"
+				}
+			},
+			"assert-output": {
+				"to-contain": {
+					"contents-file" : "/../Fixtures/res.a-0004.1.json"
+				}
+			}
+		},
+		{
+			"type": "api",
+			"about": "#0 `smwbrowse` property search (limit=3, offset=2, sort=desc)",
+			"api": {
+				"parameters": {
+					"action": "smwbrowse",
+					"format": "json",
+					"browse": "property",
+					"params": "{ \"limit\": 3, \"offset\": 2, \"search\": \"A0004\", \"sort\": \"desc\" }"
+				}
+			},
+			"assert-output": {
+				"to-contain": {
+					"contents-file" : "/../Fixtures/res.a-0004.2.json"
+				}
+			}
+		},
+		{
+			"type": "api",
+			"about": "#0 `smwbrowse` property search (limit=1, offset=5)",
+			"api": {
+				"parameters": {
+					"action": "smwbrowse",
+					"format": "json",
+					"browse": "property",
+					"params": "{ \"limit\": 1, \"offset\": 5, \"search\": \"A0004\" }"
+				}
+			},
+			"assert-output": {
+				"to-contain": {
+					"contents-file" : "/../Fixtures/res.a-0004.3.json"
+				}
+			}
+		}
+	],
+	"settings": {
+		"wgContLang": "en",
+		"wgLang": "en",
+		"smwgCacheUsage": {
+			"api.browse": false
+		},
+		"smwgNamespacesWithSemanticLinks": {
+			"NS_MAIN": true,
+			"SMW_NS_PROPERTY": true,
+			"SMW_NS_CONCEPT": true,
+			"NS_CATEGORY": true
+		}
+	},
+	"meta": {
+		"version": "2",
+		"is-incomplete": false,
+		"debug": false
+	}
+}


### PR DESCRIPTION
This PR is made in reference to: #2696, https://sourceforge.net/p/semediawiki/mailman/message/36902989/

This PR addresses or contains:

- Allows `search` to use `*` as wildcard identifier as in `'api.php?action=smwbrowse&browse=property&params={ "limit": 10, "search": "*" }`
- Fixes the use of offset/limit as in `'api.php?action=smwbrowse&browse=property&params={ "limit": 10, "offset": 10, "search": "*", "sort": "desc" }'`

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed
