### PR TITLE
Fix "TypeError from line 32 of ...\SchemaDefinition.php: Argument 2 passed to ... must be of the type array, null given"

### DIFF
--- a/src/Schema/SchemaFinder.php
+++ b/src/Schema/SchemaFinder.php
@@ -119,9 +119,15 @@ class SchemaFinder {
 		$name = str_replace( '_', ' ', $subject->getDBKey() );
 
 		foreach ( $definitions as $definition ) {
+			$content = [];
+
+			if ( $definition->getString() !== '' ) {
+				$content = json_decode( $definition->getString(), true );
+			}
+
 			$schemaList[] = new SchemaDefinition(
 				$name,
-				json_decode( $definition->getString(), true )
+				$content
 			);
 		}
 	}

--- a/tests/phpunit/Unit/Schema/SchemaFinderTest.php
+++ b/tests/phpunit/Unit/Schema/SchemaFinderTest.php
@@ -132,4 +132,34 @@ class SchemaFinderTest extends \PHPUnit_Framework_TestCase {
 		);
 	}
 
+	public function testNewSchemaList_EmptyDefinition() {
+
+		$subject = DIWikiPage::newFromText( 'Bar', SMW_NS_PROPERTY );
+		$data[] = new DIBlob( '' );
+
+		$this->propertySpecificationLookup->expects( $this->at( 0 ) )
+			->method( 'getSpecification' )
+			->with(
+				$this->equalTo( new DIProperty( 'Foo' ) ),
+				$this->equalTo( new DIProperty( 'BAR' ) ) )
+			->will( $this->onConsecutiveCalls( [ $subject ] ) );
+
+		$this->propertySpecificationLookup->expects( $this->at( 1 ) )
+			->method( 'getSpecification' )
+			->with(
+				$this->equalTo( $subject ),
+				$this->equalTo( new DIProperty( '_SCHEMA_DEF' ) ) )
+			->will( $this->onConsecutiveCalls( [ $data[0] ] ) );
+
+		$instance = new SchemaFinder(
+			$this->store,
+			$this->propertySpecificationLookup
+		);
+
+		$this->assertInstanceOf(
+			'\SMW\Schema\SchemaList',
+			$instance->newSchemaList( new DIProperty( 'Foo' ), new DIProperty( 'BAR' ) )
+		);
+	}
+
 }


### PR DESCRIPTION
This PR is made in reference to: #

This PR addresses or contains:

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed

## Stack trace

```
Rebuilding semantic data ...
   ... selecting 24465 to 25572 IDs ...
   ... updating                                     96% (24529/25576)[b735da37633f9c78ab2c91db] [no req]
   TypeError from line 32 of ...\extensions\SemanticMediaWiki\src\Schema\SchemaDefinition.php: Argument 2 passed to SMW\Schema\SchemaDefinition::__construct() must be of the type array, null given, called in ...\extensions\SemanticMediaWiki\src\Schema\SchemaFinder.php on line 124
Backtrace:
#0 ...\extensions\SemanticMediaWiki\src\Schema\SchemaFinder.php(124): SMW\Schema\SchemaDefinition->__construct(string, NULL)
#1 ...\extensions\SemanticMediaWiki\src\Schema\SchemaFinder.php(78): SMW\Schema\SchemaFinder->findSchemaDefinition(SMW\DIWikiPage, array)
#2 ...\extensions\SemanticMediaWiki\src\Schema\SchemaFinder.php(53): SMW\Schema\SchemaFinder->newSchemaList(SMW\DIProperty, SMW\DIProperty)
#3 ...\extensions\SemanticMediaWiki\src\DataValues\ValueValidators\ConstraintSchemaValueValidator.php(114): SMW\Schema\SchemaFinder->getConstraintSchema(SMW\DIProperty)
#4 ...\extensions\SemanticMediaWiki\src\DataValues\ValueValidators\CompoundConstraintValueValidator.php(79): SMW\DataValues\ValueValidators\ConstraintSchemaValueValidator->validate(SMWNumberValue)
#5 ...\extensions\SemanticMediaWiki\includes\datavalues\SMW_DataValue.php(981): SMW\DataValues\ValueValidators\CompoundConstraintValueValidator->validate(SMWNumberValue)
#6 ...\extensions\SemanticMediaWiki\includes\datavalues\SMW_DataValue.php(248): SMWDataValue->checkConstraints()
#7 ...\extensions\SemanticMediaWiki\src\DataValueFactory.php(246): SMWDataValue->setUserValue(string, boolean)
#8 ...\extensions\SemanticMediaWiki\src\DataValueFactory.php(303): SMW\DataValueFactory->newDataValueByType(string, string, boolean, SMW\DIProperty, SMW\DIWikiPage)
#9 ...\extensions\SemanticMediaWiki\src\DataValueFactory.php(351): SMW\DataValueFactory->newDataValueByProperty(SMW\DIProperty, string, boolean, SMW\DIWikiPage)
#10 ...\extensions\SemanticMediaWiki\src\Parser\AnnotationProcessor.php(98): SMW\DataValueFactory->newDataValueByText(string, string, boolean, SMW\DIWikiPage)
#11 ...\extensions\SemanticMediaWiki\src\Parser\InTextAnnotationParser.php(414): SMW\Parser\AnnotationProcessor->newDataValueByText(string, string, boolean, SMW\DIWikiPage)
#12 ...\extensions\SemanticMediaWiki\src\Parser\InTextAnnotationParser.php(391): SMW\Parser\InTextAnnotationParser->addPropertyValue(SMW\DIWikiPage, array, string, boolean)
#13 ...\extensions\SemanticMediaWiki\src\Parser\InTextAnnotationParser.php(355): SMW\Parser\InTextAnnotationParser->process(array)
#14 [internal function]: SMW\Parser\InTextAnnotationParser->preprocess(array)
#15 ...\extensions\SemanticMediaWiki\src\Parser\InTextAnnotationParser.php(181): preg_replace_callback(string, string, string)
#16 ...\extensions\SemanticMediaWiki\src\MediaWiki\Hooks\InternalParseBeforeLinks.php(134): SMW\Parser\InTextAnnotationParser->parse(string)
#17 ...\extensions\SemanticMediaWiki\src\MediaWiki\Hooks\InternalParseBeforeLinks.php(65): SMW\MediaWiki\Hooks\InternalParseBeforeLinks->performUpdate(string)
#18 ...\extensions\SemanticMediaWiki\src\MediaWiki\Hooks.php(556): SMW\MediaWiki\Hooks\InternalParseBeforeLinks->process(string)
#19 ...\includes\Hooks.php(174): SMW\MediaWiki\Hooks->onInternalParseBeforeLinks(Parser, string, StripState)
#20 ...\includes\Hooks.php(202): Hooks::callHook(string, array, array, NULL)
#21 ...\includes\parser\Parser.php(1362): Hooks::run(string, array)
#22 ...\includes\parser\Parser.php(476): Parser->internalParse(string)
#23 ...\includes\content\WikitextContent.php(341): Parser->parse(string, Title, ParserOptions, boolean, boolean, integer)
#24 ...\includes\content\AbstractContent.php(517): WikitextContent->fillParserOutput(Title, integer, ParserOptions, boolean, ParserOutput)
#25 ...\extensions\SemanticMediaWiki\includes\ContentParser.php(186): AbstractContent->getParserOutput(Title, integer, ParserOptions, boolean)
#26 ...\extensions\SemanticMediaWiki\includes\ContentParser.php(145): SMW\ContentParser->fetchFromContent()
#27 ...\extensions\SemanticMediaWiki\src\MediaWiki\Jobs\UpdateJob.php(197): SMW\ContentParser->parse()
#28 ...\extensions\SemanticMediaWiki\src\MediaWiki\Jobs\UpdateJob.php(137): SMW\MediaWiki\Jobs\UpdateJob->parse_content()
#29 ...\extensions\SemanticMediaWiki\src\MediaWiki\Jobs\UpdateJob.php(94): SMW\MediaWiki\Jobs\UpdateJob->doUpdate()
#30 ...\extensions\SemanticMediaWiki\src\SQLStore\Rebuilder\Rebuilder.php(237): SMW\MediaWiki\Jobs\UpdateJob->run()
#31 ...\extensions\SemanticMediaWiki\src\Maintenance\DataRebuilder.php(423): SMW\SQLStore\Rebuilder\Rebuilder->rebuild(integer)
#32 ...\extensions\SemanticMediaWiki\src\Maintenance\DataRebuilder.php(349): SMW\Maintenance\DataRebuilder->do_update(integer)
#33 ...\extensions\SemanticMediaWiki\src\Maintenance\DataRebuilder.php(200): SMW\Maintenance\DataRebuilder->rebuild_all()
#34 ...\extensions\SemanticMediaWiki\maintenance\rebuildData.php(202): SMW\Maintenance\DataRebuilder->rebuild()
#35 ...\maintenance\doMaintenance.php(94): SMW\Maintenance\RebuildData->execute()
#36 ...\extensions\SemanticMediaWiki\maintenance\rebuildData.php(261): require_once
(string)
#37 {main}
```