### PR TITLE
Cache schema list lookup by type

### DIFF
--- a/src/SQLStore/SQLStoreFactory.php
+++ b/src/SQLStore/SQLStoreFactory.php
@@ -820,6 +820,13 @@ class SQLStoreFactory {
 			$propertyChangeListener
 		);
 
+		$schemaFactory = $applicationFactory->singleton( 'SchemaFactory' );
+		$schemaFinder = $schemaFactory->newSchemaFinder();
+
+		$schemaFinder->registerPropertyChangeListener(
+			$propertyChangeListener
+		);
+
 		return $propertyChangeListener;
 	}
 

--- a/src/Schema/SchemaFactory.php
+++ b/src/Schema/SchemaFactory.php
@@ -189,7 +189,8 @@ class SchemaFactory {
 
 		return new SchemaFinder(
 			$store,
-			$applicationFactory->getPropertySpecificationLookup()
+			$applicationFactory->getPropertySpecificationLookup(),
+			$applicationFactory->getCache()
 		);
 	}
 

--- a/src/Schema/SchemaFinder.php
+++ b/src/Schema/SchemaFinder.php
@@ -10,6 +10,9 @@ use SMWDataItem as DataItem;
 use Title;
 use SMW\DIWikiPage;
 use SMW\PropertySpecificationLookup;
+use Onoi\Cache\Cache;
+use SMW\Listener\ChangeListener\ChangeListeners\PropertyChangeListener;
+use SMW\Listener\ChangeListener\ChangeRecord;
 
 /**
  * @private
@@ -22,6 +25,16 @@ use SMW\PropertySpecificationLookup;
 class SchemaFinder {
 
 	/**
+	 * Persistent cache namespace
+	 */
+	const CACHE_NAMESPACE = 'smw:schema';
+
+	/**
+	 * List by types
+	 */
+	const TYPE_LIST = 'type/list';
+
+	/**
 	 * @var Store
 	 */
 	private $store;
@@ -32,14 +45,60 @@ class SchemaFinder {
 	private $propertySpecificationLookup;
 
 	/**
+	 * @var Cache
+	 */
+	private $cache;
+
+	/**
+	 * @var integer
+	 */
+	private $cacheTTL;
+
+	/**
 	 * @since 3.1
 	 *
 	 * @param Store $store
 	 * @param PropertySpecificationLookup $propertySpecificationLookup
+	 * @param Cache $cache
 	 */
-	public function __construct( Store $store, PropertySpecificationLookup $propertySpecificationLookup ) {
+	public function __construct( Store $store, PropertySpecificationLookup $propertySpecificationLookup, Cache $cache ) {
 		$this->store = $store;
 		$this->propertySpecificationLookup = $propertySpecificationLookup;
+		$this->cache = $cache;
+		$this->cacheTTL = 60 * 60 * 24 * 7;
+	}
+
+	/**
+	 * @since 3.2
+	 *
+	 * @param PropertyChangeListener $propertyChangeListener
+	 */
+	public function registerPropertyChangeListener( PropertyChangeListener $propertyChangeListener ) {
+		$propertyChangeListener->addListenerCallback( new DIProperty( '_SCHEMA_TYPE' ), [ $this, 'invalidateCache' ] );
+	}
+
+	/**
+	 * @since 3.2
+	 *
+	 * @param DIProperty $property
+	 * @param ChangeRecord $changeRecord
+	 */
+	public function invalidateCache( DIProperty $property, ChangeRecord $changeRecord ) {
+
+		if ( $property->getKey() !== '_SCHEMA_TYPE' ) {
+			return;
+		}
+
+		foreach ( $changeRecord as $record ) {
+
+			if ( !$record->has( 'row.o_hash' ) ) {
+				continue;
+			}
+
+			$this->cache->delete(
+				smwfCacheKey( self::CACHE_NAMESPACE, [ self::TYPE_LIST, $record->get( 'row.o_hash' ) ] )
+			);
+		}
 	}
 
 	/**
@@ -90,16 +149,26 @@ class SchemaFinder {
 	 */
 	public function getSchemaListByType( $type ) {
 
-		$data = [];
 		$schemaList = [];
+		$key = smwfCacheKey( self::CACHE_NAMESPACE, [ self::TYPE_LIST, $type ] );
 
-		$subjects = $this->store->getPropertySubjects(
-			new DIProperty( '_SCHEMA_TYPE' ),
-			new DIBlob( $type )
-		);
+		if ( ( $subjects = $this->cache->fetch( $key ) ) === false ) {
+			$subjects = [];
+
+			$dataItems = $this->store->getPropertySubjects(
+				new DIProperty( '_SCHEMA_TYPE' ),
+				new DIBlob( $type )
+			);
+
+			foreach ( $dataItems as $dataItem ) {
+				$subjects[] = $dataItem->getSerialization();
+			}
+
+			$this->cache->save( $key, $subjects, $this->cacheTTL );
+		}
 
 		foreach ( $subjects as $subject ) {
-			$this->findSchemaDefinition( $subject, $schemaList );
+			$this->findSchemaDefinition( DIWikiPage::doUnserialize( $subject ), $schemaList );
 		}
 
 		return new SchemaList( $schemaList );

--- a/tests/phpunit/Unit/Listener/ChangeListener/ChangeListeners/PropertyChangeListenerTest.php
+++ b/tests/phpunit/Unit/Listener/ChangeListener/ChangeListeners/PropertyChangeListenerTest.php
@@ -3,7 +3,6 @@
 namespace SMW\Tests\Listener\ChangeListener\ChangeListeners;
 
 use SMW\Listener\ChangeListener\ChangeListeners\PropertyChangeListener;
-use SMW\Listener\ChangeListener\ChangeRecord;
 use SMW\DIProperty;
 use SMW\Tests\PHPUnitCompat;
 
@@ -97,7 +96,7 @@ class PropertyChangeListenerTest extends \PHPUnit_Framework_TestCase {
 			$this->logger
 		);
 
-		$instance->recordChange( 42, [ 'foo' => 'bar' ] );
+		$instance->recordChange( 42, [ 'row' => [ 's_id' => 1000, 'o_hash' => 'foobar' ] ] );
 		$instance->matchAndTriggerChangeListeners();
 
 		$this->assertEquals(
@@ -105,13 +104,9 @@ class PropertyChangeListenerTest extends \PHPUnit_Framework_TestCase {
 			$this->property
 		);
 
-		$records = [
-			new ChangeRecord( [ 'foo' => 'bar' ] )
-		];
-
 		$this->assertEquals(
-			new ChangeRecord( $records ),
-			$this->changeRecord
+			'foobar',
+			$this->changeRecord->get( 0 )->get( 'row.o_hash' )
 		);
 	}
 

--- a/tests/phpunit/Unit/SQLStore/SQLStoreFactoryTest.php
+++ b/tests/phpunit/Unit/SQLStore/SQLStoreFactoryTest.php
@@ -377,6 +377,14 @@ class SQLStoreFactoryTest extends \PHPUnit_Framework_TestCase {
 
 	public function testCanConstructPropertyChangeListener() {
 
+		$entityIdManager = $this->getMockBuilder( '\SMW\SQLStore\EntityStore\EntityIdManager' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$this->store->expects( $this->any() )
+			->method( 'getObjectIds' )
+			->will( $this->returnValue( $entityIdManager ) );
+
 		$instance = new SQLStoreFactory( $this->store );
 
 		$this->assertInstanceOf(


### PR DESCRIPTION
This PR is made in reference to: #

This PR addresses or contains:

- Caches the lookup by type and uses the `PropertyChangeListener` (#4432) to invalidate the cache as soon as some changes to the `_SCHEMA_TYPE` property is recorded

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed
