### PR TITLE
Fix @annotation behavior when used with Page Forms

### DIFF
--- a/src/MediaWiki/Hooks/OutputPageParserOutput.php
+++ b/src/MediaWiki/Hooks/OutputPageParserOutput.php
@@ -95,7 +95,7 @@ class OutputPageParserOutput extends HookHandler {
 
 		$request = $outputPage->getContext()->getRequest();
 
-		if ( in_array( $request->getVal( 'action' ), [ 'delete', 'purge', 'protect', 'unprotect', 'history', 'edit' ] ) ) {
+		if ( in_array( $request->getVal( 'action' ), [ 'delete', 'purge', 'protect', 'unprotect', 'history', 'edit', 'formedit' ] ) ) {
 			return '';
 		}
 


### PR DESCRIPTION
Manually verified and not sure how to write a non-browser
automated test for this.

Ideally this code would be further refactored so it does
not break whenever it is used together with an extension
that adds an action. Might currently also be broken with
some visual editor stuff, did not check.