### PR TITLE
Prefetch lookup to correctly apply a "look ahead", refs 3722

### DIFF
--- a/src/MediaWiki/Page/ListBuilder/ValueListBuilder.php
+++ b/src/MediaWiki/Page/ListBuilder/ValueListBuilder.php
@@ -286,7 +286,8 @@ class ValueListBuilder {
 		$dataValueFactory = DataValueFactory::getInstance();
 
 		$requestOptions = new RequestOptions();
-		$requestOptions->limit = $this->maxPropertyValues;
+		$requestOptions->setLimit( $this->maxPropertyValues );
+		$requestOptions->setLookahead( 1 );
 
 		$prefetchItemLookup = $this->store->service( 'PrefetchItemLookup' );
 

--- a/src/RequestOptions.php
+++ b/src/RequestOptions.php
@@ -34,6 +34,9 @@ class RequestOptions {
 	 */
 	const PREFETCH_FINGERPRINT = 'prefetch.fingerprint';
 
+	/**
+	 * Defines an individual search field
+	 */
 	const SEARCH_FIELD = 'search_field';
 
 	/**
@@ -55,6 +58,12 @@ class RequestOptions {
 	 * (see SMWRequestOptions->$sort below).
 	 */
 	public $offset = 0;
+
+	/**
+	 * A numerical size to indicate a "look ahead" beyond the defined
+	 * limit.
+	 */
+	public $lookahead = 0;
 
 	/**
 	 * Should the result be ordered? The employed order is defined
@@ -249,6 +258,24 @@ class RequestOptions {
 	}
 
 	/**
+	 * @since 3.2
+	 *
+	 * @param integer $lookahead
+	 */
+	public function setLookahead( int $lookahead ) {
+		$this->lookahead = $lookahead;
+	}
+
+	/**
+	 * @since 3.2
+	 *
+	 * @return integer
+	 */
+	public function getLookahead() : int {
+		return $this->lookahead;
+	}
+
+	/**
 	 * @since 2.4
 	 *
 	 * @return string
@@ -264,6 +291,7 @@ class RequestOptions {
 		return json_encode( [
 			$this->limit,
 			$this->offset,
+			$this->lookahead,
 			$this->sort,
 			$this->ascending,
 			$this->boundary,

--- a/tests/phpunit/Integration/JSONScript/TestCases/p-1011.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/p-1011.json
@@ -1,0 +1,52 @@
+{
+	"description": "Test property page, '...' more than (`smwgMaxPropertyValues`)",
+	"setup": [
+		{
+			"namespace": "SMW_NS_PROPERTY",
+			"page": "P1011",
+			"contents": "[[Has type::Number]]"
+		},
+		{
+			"namespace": "NS_MAIN",
+			"page": "P1011/1",
+			"contents": "[[P1011::1]] [[P1011::2]] [[P1011::3]] [[P1011::4]] [[P1011::5]]"
+		}
+	],
+	"tests": [
+		{
+			"type": "parser",
+			"about": "#0 (ensure only one `…` appears when more than 3 (see `smwgMaxPropertyValues`) annotations are available)",
+			"namespace": "SMW_NS_PROPERTY",
+			"subject": "P1011",
+			"assert-output": {
+				"onPageView": {
+					"parameters": {}
+				},
+				"to-contain": [
+					"<a href=\".*/P1011-2F1::P1011\" title=\".*/P1011-2F1::P1011\">…</a></div>"
+				],
+				"not-contain": [
+					"<a href=\".*/P1011-2F1::P1011\" title=\".*/P1011-2F1::P1011\">…</a>, <a href=\".*/P1011-2F1::P1011\" title=\".*/P1011-2F1::P1011\">…</a></div>"
+				]
+			}
+		}
+	],
+	"settings": {
+		"wgContLang": "en",
+		"wgLang": "en",
+		"smwgPageSpecialProperties": [
+			"_MDAT"
+		],
+		"smwgMaxPropertyValues": 3,
+		"smwgNamespacesWithSemanticLinks": {
+			"NS_MAIN": true,
+			"SMW_NS_PROPERTY": true,
+			"NS_CATEGORY": true
+		}
+	},
+	"meta": {
+		"version": "2",
+		"is-incomplete": false,
+		"debug": false
+	}
+}

--- a/tests/phpunit/LightweightJsonTestCaseScriptRunner.php
+++ b/tests/phpunit/LightweightJsonTestCaseScriptRunner.php
@@ -192,6 +192,7 @@ abstract class LightweightJsonTestCaseScriptRunner extends JsonTestCaseScriptRun
 			'smwgDefaultNumRecurringEvents',
 			'smwgMandatorySubpropertyParentTypeInheritance',
 			'smwgPlainList',
+			'smwgMaxPropertyValues',
 
 			// MW related
 			'wgLanguageCode',

--- a/tests/phpunit/Unit/RequestOptionsTest.php
+++ b/tests/phpunit/Unit/RequestOptionsTest.php
@@ -41,7 +41,7 @@ class RequestOptionsTest extends \PHPUnit_Framework_TestCase {
 		}
 
 		$this->assertEquals(
-			'[-1,0,false,true,null,true,false,"Foo#0##",[],[]]',
+			'[-1,0,0,false,true,null,true,false,"Foo#0##",[],[]]',
 			$instance->getHash()
 		);
 	}
@@ -61,7 +61,7 @@ class RequestOptionsTest extends \PHPUnit_Framework_TestCase {
 		);
 
 		$this->assertEquals(
-			'[-1,0,false,true,null,true,false,"",["Foo",{"Bar":"Foobar"}],[]]',
+			'[-1,0,0,false,true,null,true,false,"",["Foo",{"Bar":"Foobar"}],[]]',
 			$instance->getHash()
 		);
 	}


### PR DESCRIPTION
This PR is made in reference to: #3722

This PR addresses or contains:

- Explicitly  indicate a "look ahead" beyond the defined limit
- Adds an integration test to verify that only one `…` appears next to property values on the property page when more than 3 (see `smwgMaxPropertyValues`) annotations are available

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed
