### PR TITLE
[CI] Check CLI status

### DIFF
--- a/src/SetupCheck.php
+++ b/src/SetupCheck.php
@@ -247,7 +247,7 @@ class SetupCheck {
 
 		// When it is not a test run or run from the command line we expect that
 		// the extension is registered using `enableSemantics`
-		if ( !defined( 'SMW_EXTENSION_LOADED' ) ) {
+		if ( !defined( 'SMW_EXTENSION_LOADED' ) && !$this->isCli() ) {
 			$this->errorType = self::ERROR_EXTENSION_LOAD;
 		} elseif ( $this->setupFile->inMaintenanceMode() ) {
 			$this->errorType = self::MAINTENANCE_MODE;

--- a/tests/phpunit/Unit/UncaughtExceptionHandlerTest.php
+++ b/tests/phpunit/Unit/UncaughtExceptionHandlerTest.php
@@ -86,7 +86,7 @@ class UncaughtExceptionHandlerTest extends \PHPUnit_Framework_TestCase {
 
 		yield[
 			[ 'msg' => 'SemanticFoobar', 'type' => 'incompatible-php' ],
-			\SMW\SetupCheck::ERROR_EXTENSION_INCOMPATIBLE
+			( version_compare( MW_VERSION, '1.32', '<' ) ? \SMW\SetupCheck::ERROR_EXTENSION_DEPENDENCY : \SMW\SetupCheck::ERROR_EXTENSION_INCOMPATIBLE )
 		];
 
 		yield[


### PR DESCRIPTION
This PR is made in reference to: #4440, #4438

This PR addresses or contains:

- Ensures that we can continue to use `wfLoadExtension` in connection with Travis

This PR includes:
- [ ] Tests (unit/integration)
- [x] CI build passed
