### PR TITLE
Make 3.1.3 release

### DIFF
--- a/docs/RELEASE-NOTES.md
+++ b/docs/RELEASE-NOTES.md
@@ -1,16 +1,21 @@
-# Semantic MediaWiki 3.1.2
+# Semantic MediaWiki 3.1.3
 
-Released on January 12, 2020.
+Released on January 24, 2020.
 
-## Enhancement
+## Bug fixes and internal code changes
 
-* [#4367](https://github.com/SemanticMediaWiki/SemanticMediaWiki/pull/4367) as `c2fa49d`: Added the [`$smwgPlainList` configuration parameter](https://www.semantic-mediawiki.org/wiki/Help:$smwgPlainList) for convenience allowing to set whether the list format should provide class attributes to HTML elements 
-
-## Bug fix and internal code changes
-
-* [#4364](https://github.com/SemanticMediaWiki/SemanticMediaWiki/pull/4364) as `1884b1d`: Fixed the `default` parameter of queries not being considered by the "list" format
+* [#4390](https://github.com/SemanticMediaWiki/SemanticMediaWiki/pull/4390) as `a9fdd77`: Fixes the `filename` parameter for export formats providing it
+* [#4393](https://github.com/SemanticMediaWiki/SemanticMediaWiki/pull/4393) as `3a007b5`: Fixes title preview for namespaces in the standard search field when using `SMWSearch`
+* [#4405](https://github.com/SemanticMediaWiki/SemanticMediaWiki/pull/4407) as `c0e3ae9`: Fixes using `SMWElasticStore` as the default store for Elasticsearch lower than 6.4.0
+* [#4407](https://github.com/SemanticMediaWiki/SemanticMediaWiki/pull/4407) as `c18aad4`: Fixes the `#show` parser function no longer being able to query subobjects
+* [#4419](https://github.com/SemanticMediaWiki/SemanticMediaWiki/pull/4419) as `9460d09`: Fixes the `#show` parser function no longer following redirect targets
+* [#4420](https://github.com/SemanticMediaWiki/SemanticMediaWiki/pull/4420) as `2047e6f`: Removes overriding instance construction when using `SMWSparqlStore` as the default store
+* [#4430](https://github.com/SemanticMediaWiki/SemanticMediaWiki/pull/4430) as `620fd40`: Fixes a "TypeError" in "SchemaDefinition.php"
+* `20ce009`: Makes a new constrictor argument optional for result formats provided by the "Semantic Result Formats" extension
+* `fcd9d5f`: Fixes the `@annotation` query marker when used in conjuction with the "Page Forms" extension 
 * Localisation updates from the translatewiki.net community of translators
 
 ## See also
+* [RELEASE NOTES](https://github.com/SemanticMediaWiki/SemanticMediaWiki/blob/3.1.x/docs/releasenotes/RELEASE-NOTES-3.1.2.md) for Semantic MediaWiki 3.1.2
 * [RELEASE NOTES](https://github.com/SemanticMediaWiki/SemanticMediaWiki/blob/3.1.x/docs/releasenotes/RELEASE-NOTES-3.1.1.md) for Semantic MediaWiki 3.1.1
 * [RELEASE NOTES](https://github.com/SemanticMediaWiki/SemanticMediaWiki/blob/3.1.x/docs/releasenotes/RELEASE-NOTES-3.1.0.md) for Semantic MediaWiki 3.1.0

--- a/docs/releasenotes/README.md
+++ b/docs/releasenotes/README.md
@@ -1,6 +1,7 @@
 ## Release notes
 
 ### Semantic MediaWiki 3.1.x
+* [SMW 3.1.3 release notes](RELEASE-NOTES-3.1.3.md)
 * [SMW 3.1.2 release notes](RELEASE-NOTES-3.1.2.md)
 * [SMW 3.1.1 release notes](RELEASE-NOTES-3.1.1.md)
 * [SMW 3.1.0 release notes](RELEASE-NOTES-3.1.0.md)

--- a/docs/releasenotes/RELEASE-NOTES-3.1.3.md
+++ b/docs/releasenotes/RELEASE-NOTES-3.1.3.md
@@ -1,0 +1,21 @@
+# Semantic MediaWiki 3.1.3
+
+Released on January 24, 2020.
+
+## Bug fixes and internal code changes
+
+* [#4390](https://github.com/SemanticMediaWiki/SemanticMediaWiki/pull/4390) as `a9fdd77`: Fixes the `filename` parameter for export formats providing it
+* [#4393](https://github.com/SemanticMediaWiki/SemanticMediaWiki/pull/4393) as `3a007b5`: Fixes title preview for namespaces in the standard search field when using `SMWSearch`
+* [#4405](https://github.com/SemanticMediaWiki/SemanticMediaWiki/pull/4407) as `c0e3ae9`: Fixes using `SMWElasticStore` as the default store for Elasticsearch lower than 6.4.0
+* [#4407](https://github.com/SemanticMediaWiki/SemanticMediaWiki/pull/4407) as `c18aad4`: Fixes the `#show` parser function no longer being able to query subobjects
+* [#4419](https://github.com/SemanticMediaWiki/SemanticMediaWiki/pull/4419) as `9460d09`: Fixes the `#show` parser function no longer following redirect targets
+* [#4420](https://github.com/SemanticMediaWiki/SemanticMediaWiki/pull/4420) as `2047e6f`: Removes overriding instance construction when using `SMWSparqlStore` as the default store
+* [#4430](https://github.com/SemanticMediaWiki/SemanticMediaWiki/pull/4430) as `620fd40`: Fixes a "TypeError" in "SchemaDefinition.php"
+* `20ce009`: Makes a new constrictor argument optional for result formats provided by the "Semantic Result Formats" extension
+* `fcd9d5f`: Fixes the `@annotation` query marker when used in conjuction with the "Page Forms" extension 
+* Localisation updates from the translatewiki.net community of translators
+
+## See also
+* [RELEASE NOTES](https://github.com/SemanticMediaWiki/SemanticMediaWiki/blob/3.1.x/docs/releasenotes/RELEASE-NOTES-3.1.2.md) for Semantic MediaWiki 3.1.2
+* [RELEASE NOTES](https://github.com/SemanticMediaWiki/SemanticMediaWiki/blob/3.1.x/docs/releasenotes/RELEASE-NOTES-3.1.1.md) for Semantic MediaWiki 3.1.1
+* [RELEASE NOTES](https://github.com/SemanticMediaWiki/SemanticMediaWiki/blob/3.1.x/docs/releasenotes/RELEASE-NOTES-3.1.0.md) for Semantic MediaWiki 3.1.0

--- a/extension.json
+++ b/extension.json
@@ -1,13 +1,13 @@
 {
 	"name": "SemanticMediaWiki",
-	"version": "3.1.3-alpha",
+	"version": "3.1.3",
 	"author": [
-		"[https://korrekt.org/ Markus Krötzsch]",
+		"[https://www.korrekt.org/ Markus Krötzsch]",
 		"[https://www.entropywins.wtf/ Jeroen De Dauw]",
 		"James Hong Kong",
 		"[https://www.semantic-mediawiki.org/wiki/Contributors ...]"
 	],
-	"url": "https://www.semantic-mediawiki.org",
+	"url": "https://www.semantic-mediawiki.org/",
 	"descriptionmsg": "smw-desc",
 	"namemsg": "smw-title",
 	"license-name": "GPL-2.0-or-later",


### PR DESCRIPTION
This PR is made in reference to: #4443 

This PR addresses or contains:
- RELEASE-NOTES for 3.1.3
- Bumps version to 3.1.3

This PR includes:
- [ ] Tests (unit/integration)
- [ ] CI build passed