### PR TITLE
Add `SemanticData::isStub`

### DIFF
--- a/includes/SemanticData.php
+++ b/includes/SemanticData.php
@@ -205,7 +205,7 @@ class SemanticData {
 	 *
 	 * @return boolean
 	 */
-	public function isStub() {
+	public function isStub() : bool {
 		return false;
 	}
 

--- a/src/SQLStore/EntityStore/StubSemanticData.php
+++ b/src/SQLStore/EntityStore/StubSemanticData.php
@@ -76,7 +76,7 @@ class StubSemanticData extends SemanticData {
 	 *
 	 * @return boolean
 	 */
-	public function isStub() {
+	public function isStub() : bool {
 		return true;
 	}
 

--- a/src/SQLStore/EntityStore/StubSemanticData.php
+++ b/src/SQLStore/EntityStore/StubSemanticData.php
@@ -72,6 +72,15 @@ class StubSemanticData extends SemanticData {
 	}
 
 	/**
+	 * @since 3.2
+	 *
+	 * @return boolean
+	 */
+	public function isStub() {
+		return true;
+	}
+
+	/**
 	 * Required to support php-serialization
 	 *
 	 * @since 2.3


### PR DESCRIPTION
This PR is made in reference to: #

This PR addresses or contains:

- Adds `SemanticData::isStub` to check whether resolving the `SemanticData::getSubSemanticData` can be done lazily  

This PR includes:
- [ ] Tests (unit/integration)
- [x] CI build passed
