### PR TITLE
Special:Browse use structured array instead of hash

### DIFF
--- a/res/smw/special/ext.smw.special.browse.js
+++ b/res/smw/special/ext.smw.special.browse.js
@@ -49,25 +49,14 @@
 		var self = this,
 			subject = self.context.data( 'subject' );
 
-		// Expect a serialization format (see DIWikiPage::getHash)
-		if ( subject.indexOf( "#" ) == -1 ) {
-			return this.context.find( '.smwb-status' )
-				.append(
-					mw.msg( 'smw-browse-api-subject-serialization-invalid' )
-				)
-				.addClass( 'smw-callout smw-callout-error' );
-		}
-
-		subject = subject.split( "#" );
-
 		self.api.post( {
 			action: "smwbrowse",
 			browse: "subject",
 			params: JSON.stringify( {
-				subject: subject[0],
-				ns: subject[1],
-				iw: subject[2],
-				subobject: subject[3],
+				subject: subject.dbkey,
+				ns: subject.ns,
+				iw: subject.iw,
+				subobject: subject.subobject,
 				options: self.options,
 				type: 'html'
 			} )

--- a/src/MediaWiki/Specials/Browse/HtmlBuilder.php
+++ b/src/MediaWiki/Specials/Browse/HtmlBuilder.php
@@ -140,10 +140,18 @@ class HtmlBuilder {
 	 * @return string
 	 */
 	public function legacy() {
+
+		$subject = [
+			'dbkey' => $this->subject->getDBKey(),
+			'ns' => $this->subject->getNamespace(),
+			'iw' => $this->subject->getInterwiki(),
+			'subobject' => $this->subject->getSubobjectName(),
+		];
+
 		return Html::rawElement(
 			'div',
 			[
-				'data-subject' => $this->subject->getHash(),
+				'data-subject' => json_encode( $subject, JSON_UNESCAPED_UNICODE ),
 				'data-options' => json_encode( $this->options )
 			],
 			$this->buildHTML()
@@ -156,11 +164,19 @@ class HtmlBuilder {
 	 * @return string
 	 */
 	public function placeholder() {
+
+		$subject = [
+			'dbkey' => $this->subject->getDBKey(),
+			'ns' => $this->subject->getNamespace(),
+			'iw' => $this->subject->getInterwiki(),
+			'subobject' => $this->subject->getSubobjectName(),
+		];
+
 		return Html::rawElement(
 			'div',
 			[
 				'class' => 'smwb-container',
-				'data-subject' => $this->subject->getHash(),
+				'data-subject' => json_encode( $subject, JSON_UNESCAPED_UNICODE ),
 				'data-options' => json_encode( $this->options )
 			],
 			Html::rawElement(

--- a/tests/phpunit/Unit/MediaWiki/Specials/SpecialBrowseTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Specials/SpecialBrowseTest.php
@@ -81,7 +81,7 @@ class SpecialBrowseTest extends \PHPUnit_Framework_TestCase {
 		$provider[] = [
 			'Foo/Bar',
 			[
-				'data-subject="Foo/Bar#0##"',
+				'data-subject="{&quot;dbkey&quot;:&quot;Foo\/Bar&quot;,&quot;ns&quot;:0,&quot;iw&quot;:&quot;&quot;,&quot;subobject&quot;:&quot;&quot;}"',
 				'data-options="{&quot;dir&quot;:null,&quot;group&quot;:null,&quot;printable&quot;:null,&quot;offset&quot;:null,&quot;including&quot;:null,&quot;showInverse&quot;:false,&quot;showAll&quot;:true,&quot;showGroup&quot;:false,&quot;showSort&quot;:false,&quot;api&quot;:true,&quot;valuelistlimit.out&quot;:&quot;30&quot;,&quot;valuelistlimit.in&quot;:&quot;20&quot;}"'
 			]
 		];
@@ -90,7 +90,7 @@ class SpecialBrowseTest extends \PHPUnit_Framework_TestCase {
 		$provider[] = [
 			':Main-20Page-23_QUERY140d50d705e9566904fc4a877c755964',
 			[
-				'data-subject="Main_Page#0##_QUERY140d50d705e9566904fc4a877c755964"',
+				'data-subject="{&quot;dbkey&quot;:&quot;Main_Page&quot;,&quot;ns&quot;:0,&quot;iw&quot;:&quot;&quot;,&quot;subobject&quot;:&quot;_QUERY140d50d705e9566904fc4a877c755964&quot;}"',
 				'data-options="{&quot;dir&quot;:null,&quot;group&quot;:null,&quot;printable&quot;:null,&quot;offset&quot;:null,&quot;including&quot;:null,&quot;showInverse&quot;:false,&quot;showAll&quot;:true,&quot;showGroup&quot;:false,&quot;showSort&quot;:false,&quot;api&quot;:true,&quot;valuelistlimit.out&quot;:&quot;30&quot;,&quot;valuelistlimit.in&quot;:&quot;20&quot;}"'
 			]
 		];


### PR DESCRIPTION
This PR is made in reference to: https://twitter.com/48pedia/status/1220697188948303873

This PR addresses or contains:

- Uses a structured array instead of a simple hash to make sure the API request uses the correct key hereby fixes an edge case (see link) where the subobject name contains `#` as part of the name (not as part of the identifier)

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed
