### PR TITLE
Move events to listener NS, refs 4432

### DIFF
--- a/src/Listener/EventListener/EventHandler.php
+++ b/src/Listener/EventListener/EventHandler.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace SMW;
+namespace SMW\Listener\EventListener;
 
 use Onoi\EventDispatcher\EventDispatcher;
 use Onoi\EventDispatcher\EventDispatcherFactory;

--- a/src/Listener/EventListener/EventListenerRegistry.php
+++ b/src/Listener/EventListener/EventListenerRegistry.php
@@ -1,11 +1,14 @@
 <?php
 
-namespace SMW;
+namespace SMW\Listener\EventListener;
 
 use Onoi\EventDispatcher\EventListenerCollection;
 use SMW\Query\QueryComparator;
 use SMWExporter as Exporter;
-use SMW\Events\InvalidatePropertySpecificationLookupCacheEventListener;
+use SMW\ApplicationFactory;
+use SMW\Listener\EventListener\EventListeners\InvalidatePropertySpecificationLookupCacheEventListener;
+use SMW\Listener\EventListener\EventListeners\InvalidateEntityCacheEventListener;
+use SMW\Listener\EventListener\EventListeners\InvalidateResultCacheEventListener;
 
 /**
  * @license GNU GPL v2+
@@ -42,32 +45,40 @@ class EventListenerRegistry implements EventListenerCollection {
 	public function getCollection() {
 
 		$applicationFactory = ApplicationFactory::getInstance();
+		$logger = $applicationFactory->getMediaWikiLogger();
+
 		$invalidateResultCacheEventListener = $applicationFactory->create(
 			'InvalidateResultCacheEventListener'
 		);
 
 		$invalidateResultCacheEventListener->setLogger(
-			$applicationFactory->getMediaWikiLogger()
+			$logger
 		);
 
-		$this->eventListenerCollection->registerListener( 'InvalidateResultCache', $invalidateResultCacheEventListener );
+		$this->eventListenerCollection->registerListener(
+			InvalidateResultCacheEventListener::EVENT_ID,
+			$invalidateResultCacheEventListener
+		);
 
 		$invalidateEntityCacheEventListener = $applicationFactory->create(
 			'InvalidateEntityCacheEventListener'
 		);
 
 		$invalidateEntityCacheEventListener->setLogger(
-			$applicationFactory->getMediaWikiLogger()
+			$logger
 		);
 
-		$this->eventListenerCollection->registerListener( 'InvalidateEntityCache', $invalidateEntityCacheEventListener );
+		$this->eventListenerCollection->registerListener(
+			InvalidateEntityCacheEventListener::EVENT_ID,
+			$invalidateEntityCacheEventListener
+		);
 
 		$invalidatePropertySpecificationLookupCacheEventListener = $applicationFactory->create(
 			'InvalidatePropertySpecificationLookupCacheEventListener'
 		);
 
 		$invalidatePropertySpecificationLookupCacheEventListener->setLogger(
-			$applicationFactory->getMediaWikiLogger()
+			$logger
 		);
 
 		$this->eventListenerCollection->registerListener(

--- a/src/Listener/EventListener/EventListeners/InvalidateEntityCacheEventListener.php
+++ b/src/Listener/EventListener/EventListeners/InvalidateEntityCacheEventListener.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace SMW\Events;
+namespace SMW\Listener\EventListener\EventListeners;
 
 use Onoi\EventDispatcher\EventListener;
 use Onoi\EventDispatcher\DispatchContext;
@@ -17,6 +17,8 @@ class InvalidateEntityCacheEventListener implements EventListener {
 
 	use LoggerAwareTrait;
 
+	const EVENT_ID = 'InvalidateEntityCache';
+
 	/**
 	 * @var EntityCache
 	 */
@@ -24,6 +26,8 @@ class InvalidateEntityCacheEventListener implements EventListener {
 
 	/**
 	 * @since 3.1
+	 *
+	 * @param EntityCache $entityCache
 	 */
 	public function __construct( EntityCache $entityCache ) {
 		$this->entityCache = $entityCache;

--- a/src/Listener/EventListener/EventListeners/InvalidatePropertySpecificationLookupCacheEventListener.php
+++ b/src/Listener/EventListener/EventListeners/InvalidatePropertySpecificationLookupCacheEventListener.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace SMW\Events;
+namespace SMW\Listener\EventListener\EventListeners;
 
 use Onoi\EventDispatcher\EventListener;
 use Onoi\EventDispatcher\DispatchContext;

--- a/src/Listener/EventListener/EventListeners/InvalidateResultCacheEventListener.php
+++ b/src/Listener/EventListener/EventListeners/InvalidateResultCacheEventListener.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace SMW\Events;
+namespace SMW\Listener\EventListener\EventListeners;
 
 use Onoi\EventDispatcher\EventListener;
 use Onoi\EventDispatcher\DispatchContext;
@@ -17,6 +17,8 @@ use Psr\Log\LoggerAwareTrait;
 class InvalidateResultCacheEventListener implements EventListener {
 
 	use LoggerAwareTrait;
+
+	const EVENT_ID = 'InvalidateResultCache';
 
 	/**
 	 * @var ResultCache

--- a/src/Maintenance/DuplicateEntitiesDisposer.php
+++ b/src/Maintenance/DuplicateEntitiesDisposer.php
@@ -198,10 +198,7 @@ class DuplicateEntitiesDisposer {
 
 	private function id_table( $table, $duplicates, &$log ) {
 
-		$propertyTableIdReferenceDisposer = new PropertyTableIdReferenceDisposer(
-			$this->store
-		);
-
+		$propertyTableIdReferenceDisposer = $this->store->service( 'PropertyTableIdReferenceDisposer' );
 		$propertyTableIdReferenceDisposer->setRedirectRemoval( true );
 
 		$connection = $this->store->getConnection( 'mw.db' );

--- a/src/MediaWiki/Hooks/ArticleDelete.php
+++ b/src/MediaWiki/Hooks/ArticleDelete.php
@@ -5,7 +5,6 @@ namespace SMW\MediaWiki\Hooks;
 use Onoi\EventDispatcher\EventDispatcherAwareTrait;
 use SMW\ApplicationFactory;
 use SMW\DIWikiPage;
-use SMW\EventHandler;
 use SMW\MediaWiki\Jobs\UpdateDispatcherJob;
 use SMW\SemanticData;
 use SMW\Store;

--- a/src/MediaWiki/Hooks/ArticlePurge.php
+++ b/src/MediaWiki/Hooks/ArticlePurge.php
@@ -6,7 +6,6 @@ use Onoi\EventDispatcher\EventDispatcherAwareTrait;
 use SMW\ApplicationFactory;
 use SMW\DIProperty;
 use SMW\DIWikiPage;
-use SMW\EventHandler;
 use WikiPage;
 
 /**

--- a/src/MediaWiki/Hooks/NewRevisionFromEditComplete.php
+++ b/src/MediaWiki/Hooks/NewRevisionFromEditComplete.php
@@ -5,7 +5,6 @@ namespace SMW\MediaWiki\Hooks;
 use Onoi\EventDispatcher\EventDispatcherAwareTrait;
 use ParserOutput;
 use SMW\ApplicationFactory;
-use SMW\EventHandler;
 use SMW\MediaWiki\EditInfo;
 use SMW\MediaWiki\PageInfoProvider;
 use Title;

--- a/src/MediaWiki/Jobs/UpdateJob.php
+++ b/src/MediaWiki/Jobs/UpdateJob.php
@@ -9,7 +9,7 @@ use SMW\ApplicationFactory;
 use SMW\DIProperty;
 use SMW\DIWikiPage;
 use SMW\Enum;
-use SMW\EventHandler;
+use SMW\Listener\EventListener\EventHandler;
 use Title;
 
 /**

--- a/src/SQLStore/PropertyTableIdReferenceDisposer.php
+++ b/src/SQLStore/PropertyTableIdReferenceDisposer.php
@@ -4,7 +4,7 @@ namespace SMW\SQLStore;
 
 use SMW\ApplicationFactory;
 use SMW\DIWikiPage;
-use SMW\EventHandler;
+use Onoi\EventDispatcher\EventDispatcherAwareTrait;
 use SMW\Iterators\ResultIterator;
 
 /**
@@ -20,6 +20,8 @@ use SMW\Iterators\ResultIterator;
  * @author mwjames
  */
 class PropertyTableIdReferenceDisposer {
+
+	use EventDispatcherAwareTrait;
 
 	/**
 	 * @var SQLStore
@@ -268,17 +270,14 @@ class PropertyTableIdReferenceDisposer {
 			return;
 		}
 
-		$eventHandler = EventHandler::getInstance();
-		$eventDispatcher = $eventHandler->getEventDispatcher();
-
 		$context = [
 			'context' => 'PropertyTableIdReferenceDisposal',
 			'title' => $subject->getTitle(),
 			'subject' => $subject
 		];
 
-		$eventDispatcher->dispatch( 'InvalidateResultCache', $context );
-		$eventDispatcher->dispatch( 'InvalidateEntityCache', $context );
+		$this->eventDispatcher->dispatch( 'InvalidateResultCache', $context );
+		$this->eventDispatcher->dispatch( 'InvalidateEntityCache', $context );
 	}
 
 }

--- a/src/SQLStore/Rebuilder/Rebuilder.php
+++ b/src/SQLStore/Rebuilder/Rebuilder.php
@@ -96,12 +96,14 @@ class Rebuilder {
 	 *
 	 * @param SQLStore $store
 	 * @param TitleFactory $titleFactory
+	 * @param EntityValidator $entityValidator
+	 * @param PropertyTableIdReferenceDisposer $propertyTableIdReferenceDisposer
 	 */
-	public function __construct( SQLStore $store, TitleFactory $titleFactory, EntityValidator $entityValidator ) {
+	public function __construct( SQLStore $store, TitleFactory $titleFactory, EntityValidator $entityValidator, PropertyTableIdReferenceDisposer $propertyTableIdReferenceDisposer ) {
 		$this->store = $store;
 		$this->titleFactory = $titleFactory;
 		$this->entityValidator = $entityValidator;
-		$this->propertyTableIdReferenceDisposer = new PropertyTableIdReferenceDisposer( $store );
+		$this->propertyTableIdReferenceDisposer = $propertyTableIdReferenceDisposer;
 		$this->jobFactory = ApplicationFactory::getInstance()->newJobFactory();
 		$this->lru = new Lru( 10000 );
 	}

--- a/src/SQLStore/SQLStoreFactory.php
+++ b/src/SQLStore/SQLStoreFactory.php
@@ -340,7 +340,8 @@ class SQLStoreFactory {
 		$rebuilder = new Rebuilder(
 			$this->store,
 			$applicationFactory->newTitleFactory(),
-			$entityValidator
+			$entityValidator,
+			$this->newPropertyTableIdReferenceDisposer()
 		);
 
 		return $rebuilder;
@@ -894,10 +895,17 @@ class SQLStoreFactory {
 	 * @return PropertyTableIdReferenceDisposer
 	 */
 	public function newPropertyTableIdReferenceDisposer() {
-		return new PropertyTableIdReferenceDisposer(
+
+		$propertyTableIdReferenceDisposer = new PropertyTableIdReferenceDisposer(
 			$this->store,
 			$this->getIteratorFactory()
 		);
+
+		$propertyTableIdReferenceDisposer->setEventDispatcher(
+			ApplicationFactory::getInstance()->getEventDispatcher()
+		);
+
+		return $propertyTableIdReferenceDisposer;
 	}
 
 	/**

--- a/src/Services/ServicesFactory.php
+++ b/src/Services/ServicesFactory.php
@@ -16,7 +16,7 @@ use SMW\DataValueFactory;
 use SMW\DeferredCallableUpdate;
 use SMW\DeferredTransactionalCallableUpdate;
 use SMW\EntityCache;
-use SMW\EventHandler;
+use SMW\Listener\EventListener\EventHandler;
 use SMW\HierarchyLookup;
 use SMW\InMemoryPoolCache;
 use SMW\InTextAnnotationParser;

--- a/src/Services/events.php
+++ b/src/Services/events.php
@@ -2,9 +2,9 @@
 
 namespace SMW\Services;
 
-use SMW\Events\InvalidateResultCacheEventListener;
-use SMW\Events\InvalidateEntityCacheEventListener;
-use SMW\Events\InvalidatePropertySpecificationLookupCacheEventListener;
+use SMW\Listener\EventListener\EventListeners\InvalidatePropertySpecificationLookupCacheEventListener;
+use SMW\Listener\EventListener\EventListeners\InvalidateEntityCacheEventListener;
+use SMW\Listener\EventListener\EventListeners\InvalidateResultCacheEventListener;
 
 /**
  * @codeCoverageIgnore

--- a/tests/phpunit/Integration/MediaWiki/Import/Maintenance/DumpRdfMaintenanceTest.php
+++ b/tests/phpunit/Integration/MediaWiki/Import/Maintenance/DumpRdfMaintenanceTest.php
@@ -3,7 +3,7 @@
 namespace SMW\Tests\Integration\MediaWiki\Import\Maintenance;
 
 use SMW\ApplicationFactory;
-use SMW\EventHandler;
+use SMW\Listener\EventListener\EventHandler;
 use SMW\Tests\MwDBaseUnitTestCase;
 use SMW\Tests\Utils\UtilityFactory;
 

--- a/tests/phpunit/LightweightJsonTestCaseScriptRunner.php
+++ b/tests/phpunit/LightweightJsonTestCaseScriptRunner.php
@@ -4,7 +4,7 @@ namespace SMW\Tests;
 
 use SMW\ApplicationFactory;
 use SMW\DataValueFactory;
-use SMW\EventHandler;
+use SMW\Listener\EventListener\EventHandler;
 use SMW\SPARQLStore\TurtleTriplesBuilder;
 use SMW\Tests\Utils\JSONScript\ParserTestCaseProcessor;
 use SMW\Tests\Utils\JSONScript\ParserHtmlTestCaseProcessor;

--- a/tests/phpunit/Unit/DataUpdaterTest.php
+++ b/tests/phpunit/Unit/DataUpdaterTest.php
@@ -100,7 +100,7 @@ class DataUpdaterTest  extends \PHPUnit_Framework_TestCase {
 
 		$this->eventDispatcher->expects( $this->once() )
 			->method( 'dispatch' )
-			->with( $this->equalTo( \SMW\Events\InvalidatePropertySpecificationLookupCacheEventListener::EVENT_ID ) );
+			->with( $this->equalTo( \SMW\Listener\EventListener\EventListeners\InvalidatePropertySpecificationLookupCacheEventListener::EVENT_ID ) );
 
 		$semanticData = $this->semanticDataFactory->newEmptySemanticData( __METHOD__ );
 

--- a/tests/phpunit/Unit/Listener/EventListener/EventHandlerTest.php
+++ b/tests/phpunit/Unit/Listener/EventListener/EventHandlerTest.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace SMW\Tests;
+namespace SMW\Tests\Listener\EventListener;
 
-use SMW\EventHandler;
+use SMW\Listener\EventListener\EventHandler;
 
 /**
- * @covers \SMW\EventHandler
+ * @covers \SMW\Listener\EventListener\EventHandler
  * @group semantic-mediawiki
  *
  * @license GNU GPL v2+
@@ -28,12 +28,12 @@ class EventHandlerTest extends \PHPUnit_Framework_TestCase {
 			->getMock();
 
 		$this->assertInstanceOf(
-			'\SMW\EventHandler',
+			EventHandler::class,
 			new EventHandler( $eventDispatcher )
 		);
 
 		$this->assertInstanceOf(
-			'\SMW\EventHandler',
+			EventHandler::class,
 			EventHandler::getInstance()
 		);
 	}

--- a/tests/phpunit/Unit/Listener/EventListener/EventListenerRegistryTest.php
+++ b/tests/phpunit/Unit/Listener/EventListener/EventListenerRegistryTest.php
@@ -1,13 +1,14 @@
 <?php
 
-namespace SMW\Tests;
+namespace SMW\Tests\Listener\EventListener;
 
 use Onoi\EventDispatcher\EventDispatcherFactory;
 use Onoi\EventDispatcher\EventListenerCollection;
-use SMW\EventListenerRegistry;
+use SMW\Listener\EventListener\EventListenerRegistry;
+use SMW\Tests\TestEnvironment;
 
 /**
- * @covers \SMW\EventListenerRegistry
+ * @covers \SMW\Listener\EventListener\EventListenerRegistry
  * @group semantic-mediawiki
  *
  * @license GNU GPL v2+

--- a/tests/phpunit/Unit/Listener/EventListener/EventListeners/InvalidateEntityCacheEventListenerTest.php
+++ b/tests/phpunit/Unit/Listener/EventListener/EventListeners/InvalidateEntityCacheEventListenerTest.php
@@ -1,14 +1,14 @@
 <?php
 
-namespace SMW\Tests\Events;
+namespace SMW\Tests\Listener\EventListener\EventListeners;
 
 use SMW\DIWikiPage;
-use SMW\Events\InvalidateEntityCacheEventListener;
+use SMW\Listener\EventListener\EventListeners\InvalidateEntityCacheEventListener;
 use Onoi\EventDispatcher\DispatchContext;
 use SMW\Tests\TestEnvironment;
 
 /**
- * @covers \SMW\Events\InvalidateEntityCacheEventListener
+ * @covers \SMW\Listener\EventListener\EventListeners\InvalidateEntityCacheEventListener
  * @group semantic-mediawiki
  *
  * @license GNU GPL v2+

--- a/tests/phpunit/Unit/Listener/EventListener/EventListeners/InvalidatePropertySpecificationLookupCacheEventListenerTest.php
+++ b/tests/phpunit/Unit/Listener/EventListener/EventListeners/InvalidatePropertySpecificationLookupCacheEventListenerTest.php
@@ -1,14 +1,14 @@
 <?php
 
-namespace SMW\Tests\Events;
+namespace SMW\Tests\Listener\EventListener\EventListeners;
 
 use SMW\DIWikiPage;
-use SMW\Events\InvalidatePropertySpecificationLookupCacheEventListener;
+use SMW\Listener\EventListener\EventListeners\InvalidatePropertySpecificationLookupCacheEventListener;
 use Onoi\EventDispatcher\DispatchContext;
 use SMW\Tests\TestEnvironment;
 
 /**
- * @covers \SMW\Events\InvalidatePropertySpecificationLookupCacheEventListener
+ * @covers \SMW\Listener\EventListener\EventListeners\InvalidatePropertySpecificationLookupCacheEventListener
  * @group semantic-mediawiki
  *
  * @license GNU GPL v2+

--- a/tests/phpunit/Unit/Listener/EventListener/EventListeners/InvalidateResultCacheEventListenerTest.php
+++ b/tests/phpunit/Unit/Listener/EventListener/EventListeners/InvalidateResultCacheEventListenerTest.php
@@ -1,14 +1,14 @@
 <?php
 
-namespace SMW\Tests\Events;
+namespace SMW\Tests\Listener\EventListener\EventListeners;
 
 use SMW\DIWikiPage;
-use SMW\Events\InvalidateResultCacheEventListener;
+use SMW\Listener\EventListener\EventListeners\InvalidateResultCacheEventListener;
 use Onoi\EventDispatcher\DispatchContext;
 use SMW\Tests\TestEnvironment;
 
 /**
- * @covers \SMW\Events\InvalidateResultCacheEventListener
+ * @covers \SMW\Listener\EventListener\EventListeners\InvalidateResultCacheEventListener
  * @group semantic-mediawiki
  *
  * @license GNU GPL v2+

--- a/tests/phpunit/Unit/Maintenance/DuplicateEntitiesDisposerTest.php
+++ b/tests/phpunit/Unit/Maintenance/DuplicateEntitiesDisposerTest.php
@@ -20,21 +20,21 @@ class DuplicateEntitiesDisposerTest extends \PHPUnit_Framework_TestCase {
 	private $cache;
 	private $messageReporter;
 	private $connection;
-	private $propertyTableIdReferenceFinder;
 
 	protected function setUp() {
+
+		$propertyTableIdReferenceDisposer = $this->getMockBuilder( '\SMW\SQLStore\PropertyTableIdReferenceDisposer' )
+			->disableOriginalConstructor()
+			->getMock();
 
 		$this->store = $this->getMockBuilder( '\SMW\SQLStore\SQLStore' )
 			->disableOriginalConstructor()
 			->getMock();
 
-		$this->propertyTableIdReferenceFinder = $this->getMockBuilder( '\SMW\SQLStore\PropertyTableIdReferenceFinder' )
-			->disableOriginalConstructor()
-			->getMock();
-
 		$this->store->expects( $this->any() )
-			->method( 'getPropertyTableIdReferenceFinder' )
-			->will( $this->returnValue( $this->propertyTableIdReferenceFinder ) );
+			->method( 'service' )
+			->with( $this->equalTo( 'PropertyTableIdReferenceDisposer' ) )
+			->will( $this->returnValue( $propertyTableIdReferenceDisposer ) );
 
 		$this->messageReporter = $this->getMockBuilder( '\Onoi\MessageReporter\MessageReporter' )
 			->disableOriginalConstructor()
@@ -152,22 +152,9 @@ class DuplicateEntitiesDisposerTest extends \PHPUnit_Framework_TestCase {
 			->method( 'getConnection' )
 			->will( $this->returnValue( $this->connection ) );
 
-		$idTable = $this->getMockBuilder( '\stdClss' )
-			->disableOriginalConstructor()
-			->setMethods( [ 'getDataItemById' ] )
-			->getMock();
-
-		$this->store->expects( $this->atLeastOnce() )
-			->method( 'getObjectIds' )
-			->will( $this->returnValue( $idTable ) );
-
 		$this->store->expects( $this->any() )
 			->method( 'getPropertyTables' )
 			->will( $this->returnValue( [] ) );
-
-		$this->propertyTableIdReferenceFinder->expects( $this->atLeastOnce() )
-			->method( 'hasResidualReferenceForId' )
-			->will( $this->returnValue( false ) );
 
 		$instance = new DuplicateEntitiesDisposer(
 			$this->store

--- a/tests/phpunit/Unit/SQLStore/PropertyTableIdReferenceDisposerTest.php
+++ b/tests/phpunit/Unit/SQLStore/PropertyTableIdReferenceDisposerTest.php
@@ -20,11 +20,16 @@ class PropertyTableIdReferenceDisposerTest extends \PHPUnit_Framework_TestCase {
 
 	private $store;
 	private $testEnvironment;
+	private $eventDispatcher;
 
 	protected function setUp() {
 		parent::setUp();
 
 		$this->testEnvironment = new TestEnvironment();
+
+		$this->eventDispatcher = $this->getMockBuilder( '\Onoi\EventDispatcher\EventDispatcher' )
+			->disableOriginalConstructor()
+			->getMock();
 
 		$idTable = $this->getMockBuilder( '\stdClass' )
 			->setMethods( [ 'getDataItemById' ] )
@@ -84,6 +89,10 @@ class PropertyTableIdReferenceDisposerTest extends \PHPUnit_Framework_TestCase {
 			$this->store
 		);
 
+		$instance->setEventDispatcher(
+			$this->eventDispatcher
+		);
+
 		$this->assertTrue(
 			$instance->isDisposable( 42 )
 		);
@@ -127,6 +136,10 @@ class PropertyTableIdReferenceDisposerTest extends \PHPUnit_Framework_TestCase {
 			$this->store
 		);
 
+		$instance->setEventDispatcher(
+			$this->eventDispatcher
+		);
+
 		$instance->removeOutdatedEntityReferencesById( 42 );
 	}
 
@@ -164,6 +177,10 @@ class PropertyTableIdReferenceDisposerTest extends \PHPUnit_Framework_TestCase {
 			$this->store
 		);
 
+		$instance->setEventDispatcher(
+			$this->eventDispatcher
+		);
+
 		$instance->cleanUpTableEntriesById( 42 );
 	}
 
@@ -183,6 +200,10 @@ class PropertyTableIdReferenceDisposerTest extends \PHPUnit_Framework_TestCase {
 
 		$instance = new PropertyTableIdReferenceDisposer(
 			$this->store
+		);
+
+		$instance->setEventDispatcher(
+			$this->eventDispatcher
 		);
 
 		$this->assertInstanceOf(
@@ -215,6 +236,10 @@ class PropertyTableIdReferenceDisposerTest extends \PHPUnit_Framework_TestCase {
 			$this->store
 		);
 
+		$instance->setEventDispatcher(
+			$this->eventDispatcher
+		);
+
 		$instance->cleanUpTableEntriesByRow( $row );
 	}
 
@@ -244,6 +269,10 @@ class PropertyTableIdReferenceDisposerTest extends \PHPUnit_Framework_TestCase {
 
 		$instance = new PropertyTableIdReferenceDisposer(
 			$this->store
+		);
+
+		$instance->setEventDispatcher(
+			$this->eventDispatcher
 		);
 
 		$instance->waitOnTransactionIdle();
@@ -356,6 +385,10 @@ class PropertyTableIdReferenceDisposerTest extends \PHPUnit_Framework_TestCase {
 
 		$instance = new PropertyTableIdReferenceDisposer(
 			$store
+		);
+
+		$instance->setEventDispatcher(
+			$this->eventDispatcher
 		);
 
 		$instance->cleanUpTableEntriesById( 42 );

--- a/tests/phpunit/Unit/SQLStore/Rebuilder/RebuilderTest.php
+++ b/tests/phpunit/Unit/SQLStore/Rebuilder/RebuilderTest.php
@@ -21,6 +21,7 @@ class RebuilderTest extends \PHPUnit_Framework_TestCase {
 	private $testEnvironment;
 	private $titleFactory;
 	private $entityValidator;
+	private $propertyTableIdReferenceDisposer;
 
 	protected function setUp() {
 		parent::setUp();
@@ -43,6 +44,10 @@ class RebuilderTest extends \PHPUnit_Framework_TestCase {
 			->getMock();
 
 		$this->entityValidator = $this->getMockBuilder( '\SMW\SQLStore\Rebuilder\EntityValidator' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$this->propertyTableIdReferenceDisposer = $this->getMockBuilder( '\SMW\SQLStore\PropertyTableIdReferenceDisposer' )
 			->disableOriginalConstructor()
 			->getMock();
 
@@ -86,7 +91,7 @@ class RebuilderTest extends \PHPUnit_Framework_TestCase {
 
 		$this->assertInstanceOf(
 			Rebuilder::class,
-			new Rebuilder( $store, $this->titleFactory, $this->entityValidator )
+			new Rebuilder( $store, $this->titleFactory, $this->entityValidator, $this->propertyTableIdReferenceDisposer )
 		);
 	}
 
@@ -123,7 +128,8 @@ class RebuilderTest extends \PHPUnit_Framework_TestCase {
 		$instance = new Rebuilder(
 			$store,
 			$this->titleFactory,
-			$this->entityValidator
+			$this->entityValidator,
+			$this->propertyTableIdReferenceDisposer
 		);
 
 		$instance->setDispatchRangeLimit( 1 );
@@ -211,7 +217,8 @@ class RebuilderTest extends \PHPUnit_Framework_TestCase {
 		$instance = new Rebuilder(
 			$store,
 			$this->titleFactory,
-			$this->entityValidator
+			$this->entityValidator,
+			$this->propertyTableIdReferenceDisposer
 		);
 
 		$instance->setDispatchRangeLimit( 1 );

--- a/tests/phpunit/Unit/Services/EventsServicesContainerBuildTest.php
+++ b/tests/phpunit/Unit/Services/EventsServicesContainerBuildTest.php
@@ -65,19 +65,19 @@ class EventsServicesContainerBuildTest extends \PHPUnit_Framework_TestCase {
 		$provider[] = [
 			'InvalidateResultCacheEventListener',
 			[],
-			'\SMW\Events\InvalidateResultCacheEventListener'
+			'\SMW\Listener\EventListener\EventListeners\InvalidateResultCacheEventListener'
 		];
 
 		$provider[] = [
 			'InvalidateEntityCacheEventListener',
 			[],
-			'\SMW\Events\InvalidateEntityCacheEventListener'
+			'\SMW\Listener\EventListener\EventListeners\InvalidateEntityCacheEventListener'
 		];
 
 		$provider[] = [
 			'InvalidatePropertySpecificationLookupCacheEventListener',
 			[],
-			'\SMW\Events\InvalidatePropertySpecificationLookupCacheEventListener'
+			'\SMW\Listener\EventListener\EventListeners\InvalidatePropertySpecificationLookupCacheEventListener'
 		];
 
 		return $provider;


### PR DESCRIPTION
This PR is made in reference to: #4432

This PR addresses or contains:

- Moves event listener specific classes to the `Listener` NS as follow-up to #4432

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed
