### PR TITLE
Optimize `exclude_limit`, refs 4063, 4064

### DIFF
--- a/src/SQLStore/EntityStore/PropertySubjectsLookup.php
+++ b/src/SQLStore/EntityStore/PropertySubjectsLookup.php
@@ -123,11 +123,19 @@ class PropertySubjectsLookup {
 		}
 
 		$res = $this->doFetch( $pid, $proptable, $ids, $requestOptions );
+
+		$resultLimiter = new ResultLimiter();
+		$resultLimiter->calcSize( $requestOptions );
+
 		$result = [];
 		$warmupCache = [];
 
 		// Reassign per ID
 		foreach ( $res as $row ) {
+
+			if ( $resultLimiter->canSkip( $row->id ) ) {
+				continue;
+			}
 
 			if ( !isset( $result[$row->id] ) ) {
 				$result[$row->id] = [];

--- a/src/SQLStore/EntityStore/ResultLimiter.php
+++ b/src/SQLStore/EntityStore/ResultLimiter.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace SMW\SQLStore\EntityStore;
+
+use SMW\RequestOptions;
+
+/**
+ * @license GNU GPL v2
+ * @since 3.2
+ *
+ * @author mwjames
+ */
+class ResultLimiter {
+
+	/**
+	 * @var integer
+	 */
+	private $size = -1;
+
+	/**
+	 * @var []
+	 */
+	private $counter = [];
+
+	/**
+	 * @since 3.2
+	 *
+	 * @param RequestOptions $requestOptions
+	 */
+	public function calcSize( RequestOptions $requestOptions ) {
+
+		$this->size = -1;
+		$this->counter = [];
+
+		// `exclude_limit` indicates an unrestricted query due to use of `WHERE IN`
+		// that is required by the prefetch mode
+		if ( $requestOptions->exclude_limit ) {
+			$this->size = $requestOptions->getLimit();
+
+			if ( $this->size > 0 ) {
+				$this->size += $requestOptions->getLookahead();
+			}
+
+			if ( $requestOptions->getOffset() > 0 ) {
+				$this->size += $requestOptions->getOffset();
+			}
+		}
+	}
+
+	/**
+	 * For cases where `exclude_limit` was used to run an unrestricted query, allow
+	 * to skip the result set to restrict the size of the set to avoid creating
+	 * instances for non-requested data.
+	 *
+	 * @since 3.2
+	 *
+	 * @param integer $id
+	 *
+	 * @return boolean
+	 */
+	public function canSkip( $id ) {
+
+		if ( $this->size < 0 ) {
+			return false;
+		}
+
+		$id = (int)$id;
+
+		if ( !isset( $this->counter[$id] ) ) {
+			$this->counter[$id] = 0;
+		} elseif ( $this->counter[$id] >= $this->size ) {
+			return true;
+		}
+
+		$this->counter[$id]++;
+
+		return false;
+	}
+
+}

--- a/src/SQLStore/EntityStore/SemanticDataLookup.php
+++ b/src/SQLStore/EntityStore/SemanticDataLookup.php
@@ -556,8 +556,15 @@ class SemanticDataLookup {
 			'propertyKey' => ''
 		];
 
+		$resultLimiter = new ResultLimiter();
+		$resultLimiter->calcSize( $requestOptions );
+
 		foreach ( $res as $row ) {
 			$params['propertyKey'] = '';
+
+			if ( isset( $row->s_id ) && $resultLimiter->canSkip( $row->s_id ) ) {
+				continue;
+			}
 
 			// use joined or predefined property name
 			if ( $isSubject && $propTable->isFixedPropertyTable() ) {

--- a/tests/phpunit/Integration/JSONScript/TestCases/q-0626.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/q-0626.json
@@ -1,0 +1,183 @@
+{
+	"description": "Test inverted printout offset/limit/order",
+	"setup": [
+		{
+			"namespace": "SMW_NS_PROPERTY",
+			"page": "Has page",
+			"contents": "[[Has type::Page]]"
+		},
+		{
+			"page": "Q0626",
+			"contents": "[[Category:Q0626]]"
+		},
+		{
+			"page": "Q0626/1",
+			"contents": "[[Has page::Q0626]]"
+		},
+		{
+			"page": "Q0626/2",
+			"contents": "[[Has page::Q0626]]"
+		},
+		{
+			"page": "Q0626/3",
+			"contents": "[[Has page::Q0626]]"
+		},
+		{
+			"page": "Q0626/A",
+			"contents": "[[Has page::Q0626]]"
+		},
+		{
+			"page": "Q0626/B",
+			"contents": "[[Has page::Q0626]]"
+		},
+		{
+			"page": "Q0626/C",
+			"contents": "[[Has page::Q0626]]"
+		},
+		{
+			"page": "Q0626/D",
+			"contents": "[[Has page::Q0626]]"
+		},
+		{
+			"page": "Q0626/E",
+			"contents": "[[Has page::Q0626]]"
+		}
+	],
+	"tests": [
+		{
+			"type": "query",
+			"about": "#0 (entire list)",
+			"condition": "[[Category:Q0626]]",
+			"printouts": [
+				[ "-Has page", { "order": "desc" } ]
+			],
+			"parameters": {
+				"limit": "10",
+				"sort": { "": "asc" }
+			},
+			"assert-queryresult": {
+				"count": "1",
+				"results": [
+					"Q0626#0##"
+				],
+				"check-sorting": true,
+				"dataitems": [
+					{
+						"type": "_wpg",
+						"value": "Q0626/E#0##"
+					},
+					{
+						"type": "_wpg",
+						"value": "Q0626/D#0##"
+					},
+					{
+						"type": "_wpg",
+						"value": "Q0626/C#0##"
+					},
+					{
+						"type": "_wpg",
+						"value": "Q0626/B#0##"
+					},
+					{
+						"type": "_wpg",
+						"value": "Q0626/A#0##"
+					},
+					{
+						"type": "_wpg",
+						"value": "Q0626/3#0##"
+					},
+					{
+						"type": "_wpg",
+						"value": "Q0626/2#0##"
+					},
+					{
+						"type": "_wpg",
+						"value": "Q0626/1#0##"
+					}
+				]
+			}
+		},
+		{
+			"type": "query",
+			"about": "#1 (limit, offset, desc)",
+			"condition": "[[Category:Q0626]]",
+			"printouts": [
+				[ "-Has page", { "order": "desc", "limit": 3, "offset": 2 } ]
+			],
+			"parameters": {
+				"limit": "10",
+				"sort": { "": "asc" }
+			},
+			"assert-queryresult": {
+				"count": "1",
+				"results": [
+					"Q0626#0##"
+				],
+				"check-sorting": true,
+				"dataitems": [
+					{
+						"type": "_wpg",
+						"value": "Q0626/C#0##"
+					},
+					{
+						"type": "_wpg",
+						"value": "Q0626/B#0##"
+					},
+					{
+						"type": "_wpg",
+						"value": "Q0626/A#0##"
+					}
+				]
+			}
+		},
+		{
+			"type": "query",
+			"about": "#2 (limit, offset, asc)",
+			"condition": "[[Category:Q0626]]",
+			"printouts": [
+				[ "-Has page", { "order": "asc", "limit": 3, "offset": 2 } ]
+			],
+			"parameters": {
+				"limit": "10",
+				"sort": { "": "asc" }
+			},
+			"assert-queryresult": {
+				"count": "1",
+				"results": [
+					"Q0626#0##"
+				],
+				"check-sorting": true,
+				"dataitems": [
+					{
+						"type": "_wpg",
+						"value": "Q0626/3#0##"
+					},
+					{
+						"type": "_wpg",
+						"value": "Q0626/A#0##"
+					},
+					{
+						"type": "_wpg",
+						"value": "Q0626/B#0##"
+					}
+				]
+			}
+		}
+	],
+	"settings": {
+		"wgContLang": "en",
+		"wgLang": "en",
+		"smwgNamespacesWithSemanticLinks": {
+			"NS_MAIN": true,
+			"SMW_NS_PROPERTY": true
+		},
+		"smwgPageSpecialProperties": [
+			"_MDAT"
+		]
+	},
+	"meta": {
+		"version": "2",
+		"is-incomplete": false,
+		"debug": false
+	}
+}

--- a/tests/phpunit/Unit/SQLStore/EntityStore/ResultLimiterTest.php
+++ b/tests/phpunit/Unit/SQLStore/EntityStore/ResultLimiterTest.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace SMW\Tests\SQLStore\EntityStore;
+
+use SMW\SQLStore\EntityStore\ResultLimiter;
+use SMW\RequestOptions;
+
+/**
+ * @covers \SMW\SQLStore\EntityStore\ResultLimiter
+ * @group semantic-mediawiki
+ *
+ * @license GNU GPL v2+
+ * @since   3.2
+ *
+ * @author mwjames
+ */
+class ResultLimiterTest extends \PHPUnit_Framework_TestCase {
+
+	public function testCanConstruct() {
+
+		$this->assertInstanceOf(
+			ResultLimiter::class,
+			new ResultLimiter()
+		);
+	}
+
+	public function testCalcAndSkip() {
+
+		$requestOptions = new RequestOptions();
+		$requestOptions->exclude_limit = true;
+		$requestOptions->setLimit( 2 );
+		$requestOptions->setOffset( 1 );
+
+		$instance = new ResultLimiter();
+		$instance->calcSize( $requestOptions );
+
+		$res = [];
+
+		foreach ( [ '1', '2', '3', '4' ] as $value ) {
+
+			if ( $instance->canSkip( 'foo' ) ) {
+				continue;
+			}
+
+			$res[] = $value;
+		}
+
+		$this->assertEquals(
+			[ '1', '2', '3' ],
+			$res
+		);
+	}
+
+	public function testNoSkip() {
+
+		$requestOptions = new RequestOptions();
+
+		$instance = new ResultLimiter();
+		$instance->calcSize( $requestOptions );
+
+		$res = [];
+
+		foreach ( [ '1', '2', '3', '4' ] as $value ) {
+
+			if ( $instance->canSkip( 'foo' ) ) {
+				continue;
+			}
+
+			$res[] = $value;
+		}
+
+		$this->assertEquals(
+			[ '1', '2', '3', '4' ],
+			$res
+		);
+	}
+
+}


### PR DESCRIPTION
This PR is made in reference to: #4063, #4064

This PR addresses or contains:

- If `exclude_limit` is used as part of the prefetch then allow results to be skipped early in case the `ResultLimiter` finds a request limit/offset
- In prefetch mode (see #4063) we rely on `WHERE IN` to make SELECT requests but those queries cannot be limited therefore a post-processing is necessary to ensure to have the correct limit/offset and this PR should optimize the post-processing

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed
