### PR TITLE
Check `Setup::MINIMUM_DB_VERSION`, refs 4439, 4438

### DIFF
--- a/src/SQLStore/TableBuilder/TableBuildExaminer.php
+++ b/src/SQLStore/TableBuilder/TableBuildExaminer.php
@@ -84,6 +84,36 @@ class TableBuildExaminer {
 	}
 
 	/**
+	 * @since 3.2
+	 *
+	 * @param array $requirements
+	 *
+	 * @return array
+	 */
+	public function defineDatabaseRequirements( array $requirements ) : array {
+
+		$connection = $this->store->getConnection( DB_MASTER );
+		$type = $connection->getType();
+
+		return [
+			'type' => $type,
+			'latest_version' => $connection->getServerInfo(),
+			'minimum_version' => $requirements[$type]
+		];
+	}
+
+	/**
+	 * @since 3.2
+	 *
+	 * @param array $requirements
+	 *
+	 * @return boolean
+	 */
+	public function meetsMinimumRequirement( array $requirements ) : bool {
+		return version_compare( $requirements['latest_version'], $requirements['minimum_version'], 'ge' );
+	}
+
+	/**
 	 * @since 2.5
 	 *
 	 * @param TableBuilder $tableBuilder

--- a/src/Setup.php
+++ b/src/Setup.php
@@ -17,6 +17,22 @@ use SMW\Utils\Logo;
 final class Setup {
 
 	/**
+	 * Describes the minimum requirements for the database version that Semantic
+	 * MediaWiki expects and may differ from what is defined in:
+	 *
+	 * - `MysqlInstaller`
+	 * - `PostgresInstaller`
+	 * - `SqliteInstaller`
+	 *
+	 * Any change to a version will modify the key computed by `SetupFile::makeKey`.
+	 */
+	const MINIMUM_DB_VERSION = [
+		'postgres' => '9.2',
+		'sqlite' => '3.3.7',
+		'mysql' => '5.5.8'
+	];
+
+	/**
 	 * Registers a hook even before the "early" registration to allow checking
 	 * whether the extension is loaded and enabled.
 	 *

--- a/src/SetupCheck.php
+++ b/src/SetupCheck.php
@@ -256,7 +256,7 @@ class SetupCheck {
 			$this->errorType = self::ERROR_EXTENSION_LOAD;
 		} elseif ( $this->setupFile->inMaintenanceMode() ) {
 			$this->errorType = self::MAINTENANCE_MODE;
-		} elseif ( $this->setupFile->hasDatabaseMinRequirement() === false ) {
+		} elseif ( !$this->isCli() && !$this->setupFile->hasDatabaseMinRequirement() ) {
 			$this->errorType = self::ERROR_DB_REQUIREMENT_INCOMPATIBLE;
 		} elseif ( $this->setupFile->isGoodSchema() === false ) {
 			$this->errorType = self::ERROR_SCHEMA_INVALID_KEY;

--- a/src/SetupFile.php
+++ b/src/SetupFile.php
@@ -528,6 +528,10 @@ class SetupFile {
 			$components += [ 'smwgFieldTypeFeatures' => $vars['smwgFieldTypeFeatures'] ];
 		}
 
+		// Recognize when the version requirements change and force
+		// an update to be able to check the requirements
+		$components += Setup::MINIMUM_DB_VERSION;
+
 		return json_encode( $components );
 	}
 

--- a/tests/phpunit/Unit/SetupFileTest.php
+++ b/tests/phpunit/Unit/SetupFileTest.php
@@ -106,7 +106,7 @@ class SetupFileTest extends \PHPUnit_Framework_TestCase {
 	public function testSetMaintenanceMode() {
 
 		$fields = [
-			'upgrade_key' => '7540cc7b594b305fa2525c33d8963acb0c2d7b29',
+			'upgrade_key' => 'e230d2baae635d8af7f20be34b2de36f23b6d610',
 			SetupFile::MAINTENANCE_MODE => true,
 			// "upgrade_key_base" => '["",[],"",[]]'
 		];


### PR DESCRIPTION
This PR is made in reference to: #4439, #4438

This PR addresses or contains:

- `Setup::MINIMUM_DB_VERSION` contains the min requirement definition
- `SetupCheck`/`Installer` will examine the `MINIMUM_DB_VERSION`  (is required for a different PR that needs to raise the minimum for postgres/sqlite) 
- `Setup::MINIMUM_DB_VERSION` has been added to the upgrade key (see `SetupFile::makeKey`) which means anytime the definition is altered, a new upgrade key will be necessary and ensures that `update.php`/`setupStore.php` is run first to check and inform users in case the requirement isn't met hereby blocks SMW (as below)

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed

## Example

### Command line

```
$ php maintenance/setupStore.php

Semantic MediaWiki:                                             3.2.0-alpha
MediaWiki:                                                           1.33.1

--- Database setup --------------------------------------------------------

Storage engine:                                                SMWSQLStore3

--- Compatibility notice --------------------------------------------------

The postgres database version of 9.6.16 doesn't meet the minimum
requirement of 19.2 for Semantic MediaWiki.

The installation of Semantic MediaWiki was aborted!

```

### Web

![image](https://user-images.githubusercontent.com/1245473/73118887-43779500-3f52-11ea-9e33-81c5b56c3626.png)
