### PR TITLE
Improve cli output (rebuildConceptCache), refs 4403

### DIFF
--- a/tests/phpunit/Integration/Maintenance/RebuildConceptCacheTest.php
+++ b/tests/phpunit/Integration/Maintenance/RebuildConceptCacheTest.php
@@ -10,11 +10,11 @@ use SMW\Tests\TestEnvironment;
  * @group medium
  *
  * @license GNU GPL v2+
- * @since 3.1
+ * @since 3.2
  *
  * @author mwjames
  */
-class PopulateHashFieldTest extends MwDBaseUnitTestCase {
+class RebuildConceptCacheTest extends MwDBaseUnitTestCase {
 
 	protected $destroyDatabaseTablesAfterRun = true;
 	private $runnerFactory;
@@ -32,10 +32,14 @@ class PopulateHashFieldTest extends MwDBaseUnitTestCase {
 	public function testRun() {
 
 		$maintenanceRunner = $this->runnerFactory->newMaintenanceRunner(
-			'SMW\Maintenance\PopulateHashField'
+			'SMW\Maintenance\RebuildConceptCache'
 		);
 
 		$maintenanceRunner->setQuiet();
+
+		$maintenanceRunner->setOptions(
+			[ 'create' => true ]
+		);
 
 		$this->assertTrue(
 			$maintenanceRunner->run()


### PR DESCRIPTION
This PR is made in reference to: #4403

This PR addresses or contains:

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed

## Example

```
$ php maintenance/rebuildConceptCache.php --status

Semantic MediaWiki:                                             3.2.0-alpha
MediaWiki:                                                           1.32.3

--- About -----------------------------------------------------------------

This script is used to manage concept caches for Semantic MediaWiki.
Concepts are semantic queries stored on Concept: pages. The elements of
concepts can be computed online, or they can come from a pre-computed
cache. The wiki may even be configured to display certain concepts only if
they are available cached.

This script can create, delete and update these caches, or merely show
their status.

--- Concept(s) ------------------------------------------------------------

Cache status information ...
   ... Concept:QDep ...
       ... created at                 2020-01-25 11:16:26 (543 minutes old)
       ... elements count .............................................. 16
   ... Concept:MassTitle ...
       ... created at                 2020-01-25 11:16:26 (543 minutes old)
       ... elements count ........................................... 10000
   ... done.
```