### PR TITLE
Improve cli output (purgeEntityCache), refs 4403

### DIFF
--- a/tests/phpunit/Integration/Maintenance/PurgeEntityCacheTest.php
+++ b/tests/phpunit/Integration/Maintenance/PurgeEntityCacheTest.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace SMW\Tests\Integration\Maintenance;
+
+use SMW\Tests\MwDBaseUnitTestCase;
+use SMW\Tests\TestEnvironment;
+
+/**
+ * @group semantic-mediawiki
+ * @group medium
+ *
+ * @license GNU GPL v2+
+ * @since 3.2
+ *
+ * @author mwjames
+ */
+class PurgeEntityCacheTest extends MwDBaseUnitTestCase {
+
+	protected $destroyDatabaseTablesAfterRun = true;
+	private $runnerFactory;
+
+	protected function setUp() {
+		parent::setUp();
+
+		$this->runnerFactory  = TestEnvironment::getUtilityFactory()->newRunnerFactory();
+	}
+
+	protected function tearDown() {
+		parent::tearDown();
+	}
+
+	public function testRun() {
+
+		$maintenanceRunner = $this->runnerFactory->newMaintenanceRunner(
+			'SMW\Maintenance\PurgeEntityCache'
+		);
+
+		$maintenanceRunner->setQuiet();
+
+		$this->assertTrue(
+			$maintenanceRunner->run()
+		);
+	}
+
+}


### PR DESCRIPTION
This PR is made in reference to: #4403

This PR addresses or contains:

This PR includes:
- [ ] Tests (unit/integration)
- [x] CI build passed

## Example

```
$ php maintenance/purgeEntityCache.php

Semantic MediaWiki:                                             3.2.0-alpha
MediaWiki:                                                           1.32.3

--- About -----------------------------------------------------------------

The script purges cache entries and their associate data for actively used
entities.

--- Cache purge -----------------------------------------------------------

Selecting entities ...
   ... fetching rows from table ...                                       ✓
   ... entities matched ...                                    (rows) 32756
   ... invalidating cache for ...                     19123 / 163160 ( 57%)
```