### PR TITLE
Act on `DeleteAccount` event from UserMerge extension

### DIFF
--- a/src/MediaWiki/Hooks.php
+++ b/src/MediaWiki/Hooks.php
@@ -52,6 +52,7 @@ use SMW\MediaWiki\Hooks\TitleIsMovable;
 use SMW\MediaWiki\Hooks\TitleMoveComplete;
 use SMW\MediaWiki\Hooks\TitleQuickPermissions;
 use SMW\MediaWiki\Hooks\UserChange;
+use SMW\MediaWiki\Hooks\DeleteAccount;
 use SMW\MediaWiki\Hooks\AdminLinks;
 use SMW\MediaWiki\Hooks\SpecialPageList;
 use SMW\MediaWiki\Hooks\ApiModuleManager;
@@ -300,6 +301,7 @@ class Hooks {
 			'BlockIpComplete' => [ $this, 'onBlockIpComplete' ],
 			'UnblockUserComplete' => [ $this, 'onUnblockUserComplete' ],
 			'UserGroupsChanged' => [ $this, 'onUserGroupsChanged' ],
+			'DeleteAccount' => [ $this, 'onDeleteAccount' ],
 
 			'SMW::SQLStore::AfterDataUpdateComplete' => [ $this, 'onAfterDataUpdateComplete'],
 			'SMW::SQLStore::Installer::AfterCreateTablesComplete' => [ $this, 'onAfterCreateTablesComplete' ],
@@ -779,7 +781,7 @@ class Hooks {
 			$applicationFactory->getEventDispatcher()
 		);
 
-		return $articleDelete->process( $wikiPage );
+		return $articleDelete->process( $wikiPage->getTitle() );
 	}
 
 	/**
@@ -1132,6 +1134,33 @@ class Hooks {
 			$parser,
 			$applicationFactory->getSettings()->get( 'smwgSupportSectionTag' )
 		);
+
+		return true;
+	}
+
+	/**
+	 * @see https://github.com/wikimedia/mediawiki-extensions-UserMerge/blob/master/includes/MergeUser.php#L654
+	 * @provided by Extension:UserMerge
+	 *
+	 */
+	public function onDeleteAccount( $user ) {
+
+		$applicationFactory = ApplicationFactory::getInstance();
+
+		$articleDelete = new ArticleDelete(
+			$applicationFactory->getStore()
+		);
+
+		$articleDelete->setEventDispatcher(
+			$applicationFactory->getEventDispatcher()
+		);
+
+		$deleteAccount = new DeleteAccount(
+			$applicationFactory->getNamespaceExaminer(),
+			$articleDelete
+		);
+
+		$deleteAccount->process( $user );
 
 		return true;
 	}

--- a/src/MediaWiki/Hooks/ArticleDelete.php
+++ b/src/MediaWiki/Hooks/ArticleDelete.php
@@ -25,9 +25,14 @@ class ArticleDelete implements HookListener {
 	use EventDispatcherAwareTrait;
 
 	/**
-	 * @var
+	 * @var Store
 	 */
 	private $store;
+
+	/**
+	 * @var string
+	 */
+	private $origin = 'ArticleDelete';
 
 	/**
 	 * @since 3.0
@@ -39,16 +44,25 @@ class ArticleDelete implements HookListener {
 	}
 
 	/**
+	 * @since 3.2
+	 *
+	 * @param string $origin
+	 */
+	public function setOrigin( string $origin ) {
+		$this->origin = $origin;
+	}
+
+	/**
 	 * @since 2.0
 	 *
-	 * @param Wikipage $wikiPage
+	 * @param Title $title
 	 *
 	 * @return true
 	 */
-	public function process( Wikipage $wikiPage ) {
+	public function process( Title $title ) {
 
-		$deferredCallableUpdate = ApplicationFactory::getInstance()->newDeferredCallableUpdate( function() use( $wikiPage ) {
-			$this->doDelete( $wikiPage->getTitle() );
+		$deferredCallableUpdate = ApplicationFactory::getInstance()->newDeferredCallableUpdate( function() use( $title ) {
+			$this->doDelete( $title );
 		} );
 
 		$deferredCallableUpdate->setOrigin( __METHOD__ );
@@ -92,7 +106,7 @@ class ArticleDelete implements HookListener {
 			$semanticData
 		);
 
-		$parameters['origin'] = 'ArticleDelete';
+		$parameters['origin'] = $this->origin;
 
 		// Fetch the ID before the delete process marks it as outdated to help
 		// run a dispatch process on secondary tables
@@ -109,7 +123,7 @@ class ArticleDelete implements HookListener {
 		$this->store->deleteSubject( $title );
 
 		$context = [
-			'context' => 'ArticleDelete',
+			'context' => $this->origin,
 			'title' => $title,
 			'subject' => $subject
 		];

--- a/src/MediaWiki/Hooks/DeleteAccount.php
+++ b/src/MediaWiki/Hooks/DeleteAccount.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace SMW\MediaWiki\Hooks;
+
+use SMW\Store;
+use SMW\NamespaceExaminer;
+use SMW\MediaWiki\HookListener;
+use SMW\DIWikiPage;
+use Title;
+use User;
+
+/**
+ * @see https://github.com/wikimedia/mediawiki-extensions-UserMerge/blob/master/includes/MergeUser.php#L654
+ *
+ * @license GNU GPL v2+
+ * @since 3.2
+ *
+ * @author mwjames
+ */
+class DeleteAccount implements HookListener {
+
+	/**
+	 * @var NamespaceExaminer
+	 */
+	private $namespaceExaminer;
+
+	/**
+	 * @var ArticleDelete
+	 */
+	private $articleDelete;
+
+	/**
+	 * @since 3.2
+	 *
+	 * @param NamespaceExaminer $namespaceExaminer
+	 * @param ArticleDelete $articleDelete
+	 */
+	public function __construct( NamespaceExaminer $namespaceExaminer, ArticleDelete $articleDelete ) {
+		$this->namespaceExaminer = $namespaceExaminer;
+		$this->articleDelete = $articleDelete;
+	}
+
+	/**
+	 * @since 3.2
+	 *
+	 * @param User|string $user
+	 */
+	public function process( $user ) {
+
+		if ( !$this->namespaceExaminer->isSemanticEnabled( NS_USER ) ) {
+			return false;
+		}
+
+		if ( $user instanceof User ) {
+			$user = $user->getName();
+		}
+
+		$this->articleDelete->setOrigin( 'DeleteAccount' );
+
+		$this->articleDelete->process(
+			Title::newFromText( $user, NS_USER )
+		);
+
+		return true;
+	}
+
+}

--- a/src/MediaWiki/Hooks/UserChange.php
+++ b/src/MediaWiki/Hooks/UserChange.php
@@ -75,7 +75,7 @@ class UserChange implements HookListener {
 			]
 		);
 
-		$updateJob->insert();
+		$updateJob->lazyPush();
 
 		return true;
 	}

--- a/tests/phpunit/Unit/MediaWiki/Hooks/ArticleDeleteTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Hooks/ArticleDeleteTest.php
@@ -98,14 +98,6 @@ class ArticleDeleteTest extends \PHPUnit_Framework_TestCase {
 			->method( 'getObjectIds' )
 			->will( $this->returnValue( $idTable ) );
 
-		$wikiPage = $this->getMockBuilder( '\WikiPage' )
-			->disableOriginalConstructor()
-			->getMock();
-
-		$wikiPage->expects( $this->atLeastOnce() )
-			->method( 'getTitle' )
-			->will( $this->returnValue( $subject->getTitle() ) );
-
 		$this->eventDispatcher->expects( $this->atLeastOnce() )
 			->method( 'dispatch' )
 			->withConsecutive(
@@ -121,7 +113,7 @@ class ArticleDeleteTest extends \PHPUnit_Framework_TestCase {
 		);
 
 		$this->assertTrue(
-			$instance->process( $wikiPage )
+			$instance->process( $subject->getTitle() )
 		);
 	}
 

--- a/tests/phpunit/Unit/MediaWiki/Hooks/DeleteAccountTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Hooks/DeleteAccountTest.php
@@ -1,0 +1,92 @@
+<?php
+
+namespace SMW\Tests\MediaWiki\Hooks;
+
+use SMW\DIProperty;
+use SMW\DIWikiPage;
+use SMW\MediaWiki\Hooks\DeleteAccount;
+use SMW\Tests\TestEnvironment;
+
+/**
+ * @covers \SMW\MediaWiki\Hooks\DeleteAccount
+ * @group semantic-mediawiki
+ *
+ * @license GNU GPL v2+
+ * @since 3.2
+ *
+ * @author mwjames
+ */
+class DeleteAccountTest extends \PHPUnit_Framework_TestCase {
+
+	private $namespaceExaminer;
+	private $articleDelete;
+
+	protected function setUp() {
+		parent::setUp();
+
+		$this->namespaceExaminer = $this->getMockBuilder( '\SMW\NamespaceExaminer' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$this->articleDelete = $this->getMockBuilder( '\SMW\MediaWiki\Hooks\ArticleDelete' )
+			->disableOriginalConstructor()
+			->getMock();
+	}
+
+	public function testCanConstruct() {
+
+		$this->assertInstanceOf(
+			DeleteAccount::class,
+			new DeleteAccount( $this->namespaceExaminer, $this->articleDelete )
+		);
+	}
+
+	public function testProcess() {
+
+		$this->namespaceExaminer->expects( $this->any() )
+			->method( 'isSemanticEnabled' )
+			->with( $this->equalTo( NS_USER ) )
+			->will( $this->returnValue( true ) );
+
+		$this->articleDelete->expects( $this->atLeastOnce() )
+			->method( 'process' );
+
+		$instance = new DeleteAccount(
+			$this->namespaceExaminer,
+			$this->articleDelete
+		);
+
+		$this->assertTrue(
+			$instance->process( 'Foo' )
+		);
+	}
+
+	public function testProcess_User() {
+
+		$this->namespaceExaminer->expects( $this->any() )
+			->method( 'isSemanticEnabled' )
+			->with( $this->equalTo( NS_USER ) )
+			->will( $this->returnValue( true ) );
+
+		$this->articleDelete->expects( $this->atLeastOnce() )
+			->method( 'process' );
+
+		$user = $this->getMockBuilder( '\User' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$user->expects( $this->once() )
+			->method( 'getName' )
+			->will( $this->returnValue( 'Foo' ) );
+
+		$instance = new DeleteAccount(
+			$this->namespaceExaminer,
+			$this->articleDelete
+		);
+
+		$this->assertTrue(
+			$instance->process( $user )
+		);
+	}
+
+}

--- a/tests/phpunit/Unit/MediaWiki/HooksTest.php
+++ b/tests/phpunit/Unit/MediaWiki/HooksTest.php
@@ -293,6 +293,7 @@ class HooksTest extends \PHPUnit_Framework_TestCase {
 			[ 'callBlockIpComplete' ],
 			[ 'callUnblockUserComplete' ],
 			[ 'callUserGroupsChanged' ],
+			[ 'callDeleteAccount' ],
 			[ 'callSMWSQLStoreEntityReferenceCleanUpComplete' ],
 			[ 'callSMWAdminTaskHandlerFactory' ],
 			[ 'callSMWApiAddTasks' ],
@@ -1513,6 +1514,30 @@ class HooksTest extends \PHPUnit_Framework_TestCase {
 		$user->expects( $this->any() )
 			->method( 'getName' )
 			->will( $this->returnValue( 'Foo' ) );
+
+		$this->assertTrue(
+			$instance->isRegistered( $handler )
+		);
+
+		$this->assertThatHookIsExcutable(
+			$instance->getHandlerFor( $handler ),
+			[ $user ]
+		);
+
+		return $handler;
+	}
+
+	public function callDeleteAccount( $instance ) {
+
+		$handler = 'DeleteAccount';
+
+		$user = $this->getMockBuilder( '\User' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$user->expects( $this->any() )
+			->method( 'getName' )
+			->will( $this->returnValue( 'foo_user' ) );
 
 		$this->assertTrue(
 			$instance->isRegistered( $handler )


### PR DESCRIPTION
This PR is made in reference to: #

This PR addresses or contains:

- Act on https://github.com/wikimedia/mediawiki-extensions-UserMerge/blob/master/includes/MergeUser.php#L654 as it doesn't run through the "default" article delete, especially when spam users accounts are deleted

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed
