### PR TITLE
Add `BATCH_ROW_SIZE` to `EntityIdDisposerJob`

### DIFF
--- a/src/SQLStore/PropertyTableIdReferenceDisposer.php
+++ b/src/SQLStore/PropertyTableIdReferenceDisposer.php
@@ -6,6 +6,7 @@ use SMW\ApplicationFactory;
 use SMW\DIWikiPage;
 use Onoi\EventDispatcher\EventDispatcherAwareTrait;
 use SMW\Iterators\ResultIterator;
+use SMW\RequestOptions;
 
 /**
  * @private
@@ -106,15 +107,27 @@ class PropertyTableIdReferenceDisposer {
 	/**
 	 * @since 2.5
 	 *
+	 * @param RequestOptions|null $requestOptions
+	 *
 	 * @return ResultIterator
 	 */
-	public function newOutdatedEntitiesResultIterator() {
+	public function newOutdatedEntitiesResultIterator( RequestOptions $requestOptions = null ) {
+
+		$options = [];
+
+		if ( $requestOptions !== null ) {
+			$options = [
+				'LIMIT'  => $requestOptions->getLimit(),
+				'OFFSET' => $requestOptions->getOffset()
+			];
+		}
 
 		$res = $this->connection->select(
 			SQLStore::ID_TABLE,
 			[ 'smw_id' ],
 			[ 'smw_iw' => SMW_SQL3_SMWDELETEIW ],
-			__METHOD__
+			__METHOD__,
+			$options
 		);
 
 		return new ResultIterator( $res );


### PR DESCRIPTION
This PR is made in reference to: https://sourceforge.net/p/semediawiki/mailman/message/36885152/

This PR addresses or contains:

- Run the `EntityIdDisposerJob` in cycles of `BATCH_ROW_SIZE = 5000` to avoid a potential OOM with jobs being rescheduled on each 5000 row select
- The job scheduler can pick those jobs one at a time and slowly work through the back log

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed
