### PR TITLE
[CI] Add `overrideUserPermissions` due to "Replace usages of deprecated User::isAllowed" (MW 1.34+)

### DIFF
--- a/tests/phpunit/TestEnvironment.php
+++ b/tests/phpunit/TestEnvironment.php
@@ -172,8 +172,26 @@ class TestEnvironment {
 		} else {
 			$lbFactory->setDomainPrefix( $prefix );
 		}
-		
+
 		$GLOBALS['wgDBprefix'] = $prefix;
+	}
+	/**
+	 * @see https://github.com/wikimedia/mediawiki/commit/7b4eafda0d986180d20f37f2489b70e8eca00df4
+	 * @since 3.2
+	 */
+	public static function overrideUserPermissions( $user, $permissions = [] ) {
+
+		if ( !class_exists( '\MediaWiki\MediaWikiServices' ) || !method_exists( \MediaWiki\MediaWikiServices::getInstance(), 'getPermissionManager' ) ) {
+			return;
+		}
+
+		$permissionManager = \MediaWiki\MediaWikiServices::getInstance()->getPermissionManager();
+
+		if ( !method_exists( $permissionManager, 'overrideUserRightsForTesting' ) ) {
+			return;
+		}
+
+		$permissionManager->overrideUserRightsForTesting( $user, $permissions );
 	}
 
 	/**

--- a/tests/phpunit/Unit/MediaWiki/Specials/SpecialAdminTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Specials/SpecialAdminTest.php
@@ -50,6 +50,9 @@ class SpecialAdminTest extends \PHPUnit_Framework_TestCase {
 
 	public function testExecuteWithValidUser() {
 
+		$user = new MockSuperUser();
+		$this->testEnvironment->overrideUserPermissions( $user, [ 'smw-admin' ] );
+
 		$outputPage = $this->getMockBuilder( '\OutputPage' )
 			->disableOriginalConstructor()
 			->getMock();
@@ -67,7 +70,7 @@ class SpecialAdminTest extends \PHPUnit_Framework_TestCase {
 		$oldOutput = $instance->getOutput();
 
 		$instance->getContext()->setOutput( $outputPage );
-		$instance->getContext()->setUser( new MockSuperUser() );
+		$instance->getContext()->setUser( $user );
 
 		$instance->execute( $query );
 
@@ -80,6 +83,8 @@ class SpecialAdminTest extends \PHPUnit_Framework_TestCase {
 		$user = $this->getMockBuilder( '\User' )
 			->disableOriginalConstructor()
 			->getMock();
+
+		$this->testEnvironment->overrideUserPermissions( $user, [] );
 
 		$query = '';
 		$instance = new SpecialAdmin();


### PR DESCRIPTION
This PR is made in reference to: #

This PR addresses or contains:

- Caused by https://github.com/wikimedia/mediawiki/commit/7b4eafda0d986180d20f37f2489b70e8eca00df4
- Final patch to pass MW 1.34

This PR includes:
- [ ] Tests (unit/integration)
- [x] CI build passed

Fixes #