### PR TITLE
Check `last_optimization_run`, add maintenance alert

### DIFF
--- a/DefaultSettings.php
+++ b/DefaultSettings.php
@@ -1080,9 +1080,16 @@ return [
 	# - SMW_ADM_PSTATS: Property statistics update
 	# - SMW_ADM_FULLT:
 	#
+	#   Maintenance alerts
+	#
+	# - SMW_ADM_ALERT_LAST_OPTIMIZATION_RUN: Alerts when table optimization is
+	#   overdue
+	#
 	# @since 2.5
 	##
-	'smwgAdminFeatures' => SMW_ADM_REFRESH | SMW_ADM_SETUP | SMW_ADM_DISPOSAL | SMW_ADM_PSTATS | SMW_ADM_FULLT,
+	'smwgAdminFeatures' =>
+		SMW_ADM_REFRESH | SMW_ADM_SETUP | SMW_ADM_DISPOSAL | SMW_ADM_PSTATS | SMW_ADM_FULLT |
+		SMW_ADM_ALERT_LAST_OPTIMIZATION_RUN,
 	##
 
 	###

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -599,6 +599,8 @@
 	"smw-admin-alerts-tab-maintenancealerts": "Maintenance alerts",
 	"smw-admin-alerts-section-intro": "This section shows alerts and notices related to settings, operations, and other activities that have been classified to require attention from an administrator or user with appropriated rights.",
 	"smw-admin-maintenancealerts-section-intro": "The following alerts and notices should be resolved and while not essential it is expected to help improve system and operational maintainability.",
+	"smw-admin-maintenancealerts-lastoptimizationrun-alert-title": "Table optimization",
+	"smw-admin-maintenancealerts-lastoptimizationrun-alert": "The system has found that the last [https://www.semantic-mediawiki.org/wiki/Table_optimization table optimization] was run $2 days ago (record from $1) which exceeds the $3 days maintenance threshold. As mentioned in the documentation, running optimizations will allow the query planner to make better decisions about queries therefore it is suggested to run the table optimization on a regular basis.",
 	"smw-admin-deprecation-notice-section":"Semantic MediaWiki",
 	"smw-admin-configutation-tab-settings": "Settings",
 	"smw-admin-configutation-tab-namespaces": "Namespaces",

--- a/src/Defines.php
+++ b/src/Defines.php
@@ -199,6 +199,7 @@ define( 'SMW_ADM_DISPOSAL', 4 ); // IDDisposal
 define( 'SMW_ADM_SETUP', 8 ); // SetupStore
 define( 'SMW_ADM_PSTATS', 16 ); // Property statistics update
 define( 'SMW_ADM_FULLT', 32 ); // Fulltext update
+define( 'SMW_ADM_ALERT_LAST_OPTIMIZATION_RUN', 2048 ); // Table optimization alert
 /**@}*/
 
 /**@{

--- a/src/MediaWiki/Specials/Admin/Alerts/LastOptimizationRunMaintenanceAlertTaskHandler.php
+++ b/src/MediaWiki/Specials/Admin/Alerts/LastOptimizationRunMaintenanceAlertTaskHandler.php
@@ -1,0 +1,96 @@
+<?php
+
+namespace SMW\MediaWiki\Specials\Admin\Alerts;
+
+use Html;
+use DateTime;
+use SMW\Message;
+use SMW\SetupFile;
+use SMW\MediaWiki\Specials\Admin\TaskHandler;
+use SMW\MediaWiki\Specials\Admin\OutputFormatter;
+
+/**
+ * @license GNU GPL v2+
+ * @since   3.2
+ *
+ * @author mwjames
+ */
+class LastOptimizationRunMaintenanceAlertTaskHandler extends TaskHandler {
+
+	/**
+	 * Defines the threshold in days, exceeding the threholds will trigger the
+	 * alert.
+	 */
+	const DAYS_THRESHOLD = 90; // 3 Month;
+
+	/**
+	 * @var SetupFile
+	 */
+	private $setupFile;
+
+	/**
+	 * @since 3.2
+	 *
+	 * @param SetupFile $setupFile
+	 */
+	public function __construct( SetupFile $setupFile ) {
+		$this->setupFile = $setupFile;
+	}
+
+	/**
+	 * @since 3.2
+	 *
+	 * {@inheritDoc}
+	 */
+	public function getHtml() : string {
+
+		if ( !$this->hasFeature( SMW_ADM_ALERT_LAST_OPTIMIZATION_RUN ) ) {
+			return '';
+		}
+
+		$lastRun = $this->setupFile->get( SetupFile::LAST_OPTIMIZATION_RUN );
+
+		if ( $lastRun === null ) {
+			return '';
+		}
+
+		$dateTime = new DateTime( $lastRun );
+		$daysDiff = (int)$dateTime->diff( new DateTime( 'now' ) )->format( '%R%a' );
+
+		return $this->buildHTML( $lastRun, $daysDiff );
+	}
+
+	private function buildHTML( $lastRun, $daysDiff ) {
+
+		if ( $daysDiff < self::DAYS_THRESHOLD ) {
+			return '';
+		}
+
+		$html = Html::rawElement(
+			'fieldset',
+			[
+				'class' => "smw-admin-alerts-section-legend-info"
+			],
+			Html::rawElement(
+				'legend',
+				[
+					'class' => "smw-admin-alerts-section-legend-info"
+				],
+				$this->msg( "smw-admin-maintenancealerts-lastoptimizationrun-alert-title" )
+			) .	Html::rawElement(
+				'p',
+				[],
+				$this->msg( ['smw-admin-maintenancealerts-lastoptimizationrun-alert', $lastRun, $daysDiff, self::DAYS_THRESHOLD ], Message::PARSE )
+			)
+		);
+
+		return Html::rawElement(
+			'div',
+			[
+				'class' => 'smw-admin-alerts smw-admin-alerts-last-optimization-run'
+			],
+			$html
+		);
+	}
+
+}

--- a/src/MediaWiki/Specials/Admin/Alerts/MaintenanceAlertsTaskHandler.php
+++ b/src/MediaWiki/Specials/Admin/Alerts/MaintenanceAlertsTaskHandler.php
@@ -59,6 +59,11 @@ class MaintenanceAlertsTaskHandler extends TaskHandler {
 		$contents = '';
 
 		foreach ( $this->taskHandlers as $taskHandler ) {
+
+			$taskHandler->setFeatureSet(
+				$this->featureSet
+			);
+
 			$contents .= $taskHandler->getHtml();
 		}
 

--- a/src/MediaWiki/Specials/Admin/TaskHandler.php
+++ b/src/MediaWiki/Specials/Admin/TaskHandler.php
@@ -27,7 +27,7 @@ abstract class TaskHandler {
 	/**
 	 * @var integer
 	 */
-	private $featureSet = 0;
+	protected $featureSet = 0;
 
 	/**
 	 * @var Store

--- a/src/MediaWiki/Specials/Admin/TaskHandlerFactory.php
+++ b/src/MediaWiki/Specials/Admin/TaskHandlerFactory.php
@@ -16,6 +16,7 @@ use SMW\MediaWiki\Specials\Admin\Supplement\OperationalStatisticsListTaskHandler
 use SMW\MediaWiki\Specials\Admin\Supplement\TableStatisticsTaskHandler;
 use SMW\MediaWiki\Specials\Admin\Alerts\DeprecationNoticeTaskHandler;
 use SMW\MediaWiki\Specials\Admin\Alerts\MaintenanceAlertsTaskHandler;
+use SMW\MediaWiki\Specials\Admin\Alerts\LastOptimizationRunMaintenanceAlertTaskHandler;
 use SMW\Store;
 use SMW\SetupFile;
 use SMw\ApplicationFactory;
@@ -69,7 +70,7 @@ class TaskHandlerFactory {
 			$this->newMaintenanceTaskHandler( $adminFeatures ),
 
 			// TaskHandler::SECTION_ALERTS
-			$this->newAlertsTaskHandler(),
+			$this->newAlertsTaskHandler( $adminFeatures ),
 
 			// TaskHandler::SECTION_SUPPLEMENT
 			$this->newSupplementTaskHandler( $adminFeatures, $user ),
@@ -291,15 +292,24 @@ class TaskHandlerFactory {
 	/**
 	 * @since 3.2
 	 *
+	 * @param integer $adminFeatures
+	 *
 	 * @return AlertsTaskHandler
 	 */
-	public function newAlertsTaskHandler() {
+	public function newAlertsTaskHandler( $adminFeatures = 0 ) {
 
 		$maintenanceAlertsTaskHandlers = [
+			new LastOptimizationRunMaintenanceAlertTaskHandler(
+				new SetupFile()
+			)
 		];
 
 		$maintenanceAlertsTaskHandler = new MaintenanceAlertsTaskHandler(
 			$maintenanceAlertsTaskHandlers
+		);
+
+		$maintenanceAlertsTaskHandler->setFeatureSet(
+			$adminFeatures
 		);
 
 		$taskHandlers = [

--- a/src/SQLStore/Installer.php
+++ b/src/SQLStore/Installer.php
@@ -390,6 +390,9 @@ class Installer implements MessageReporter {
 		}
 
 		$messageReporter->reportMessage( "   ... done.\n" );
+
+		$dateTimeUtc = new \DateTime( 'now', new \DateTimeZone( 'UTC' ) );
+		$this->setupFile->set( [ SetupFile::LAST_OPTIMIZATION_RUN => $dateTimeUtc->format( 'Y-m-d h:i' ) ] );
 	}
 
 	private function addSupplementJobs( $messageReporter ) {

--- a/src/SetupFile.php
+++ b/src/SetupFile.php
@@ -32,6 +32,11 @@ class SetupFile {
 	const DB_REQUIREMENTS = 'db_requirements';
 
 	/**
+	 * Key that describes the date of the last table optimization run.
+	 */
+	const LAST_OPTIMIZATION_RUN = 'last_optimization_run';
+
+	/**
 	 * Describes the file name
 	 */
 	const FILE_NAME = '.smw.json';

--- a/tests/phpunit/Unit/MediaWiki/Specials/Admin/Alerts/LastOptimizationRunMaintenanceAlertTaskHandlerTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Specials/Admin/Alerts/LastOptimizationRunMaintenanceAlertTaskHandlerTest.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace SMW\Tests\MediaWiki\Specials\Admin\Alerts;
+
+use SMW\MediaWiki\Specials\Admin\Alerts\LastOptimizationRunMaintenanceAlertTaskHandler;
+
+/**
+ * @covers \SMW\MediaWiki\Specials\Admin\Alerts\LastOptimizationRunMaintenanceAlertTaskHandler
+ * @group semantic-mediawiki
+ *
+ * @license GNU GPL v2+
+ * @since 3.2
+ *
+ * @author mwjames
+ */
+class LastOptimizationRunMaintenanceAlertTaskHandlerTest extends \PHPUnit_Framework_TestCase {
+
+	private $setupFile;
+
+	protected function setUp() {
+		parent::setUp();
+
+		$this->setupFile = $this->getMockBuilder( '\SMW\SetupFile' )
+			->disableOriginalConstructor()
+			->getMock();
+	}
+
+	public function testCanConstruct() {
+
+		$this->assertInstanceOf(
+			LastOptimizationRunMaintenanceAlertTaskHandler::class,
+			new LastOptimizationRunMaintenanceAlertTaskHandler( $this->setupFile )
+		);
+	}
+
+	public function testGetHtml() {
+
+		$this->setupFile->expects( $this->once() )
+			->method( 'get' )
+			->with( $this->equalTo( 'last_optimization_run' ) )
+			->will( $this->returnValue( '1970-01-01' ) );
+
+		$instance = new LastOptimizationRunMaintenanceAlertTaskHandler(
+			$this->setupFile
+		);
+
+		$instance->setFeatureSet( SMW_ADM_ALERT_LAST_OPTIMIZATION_RUN );
+
+		$this->assertContains(
+			'smw-admin-alerts-last-optimization-run',
+			$instance->getHtml()
+		);
+	}
+
+}


### PR DESCRIPTION
This PR is made in reference to: #4468

This PR addresses or contains:

- Records the `last_optimization_run` in the setup file (`.smw.json`) and when overdue will create an alter via `LastOptimizationRunMaintenanceAlertTaskHandler`
- Adds `SMW_ADM_ALERT_LAST_OPTIMIZATION_RUN` as option (enabled by default) to `smwgAdminFeatures`

This PR includes:
- [ ] Tests (unit/integration)
- [ ] CI build passed

## Example

![image](https://user-images.githubusercontent.com/1245473/73131111-04eae480-3ffd-11ea-86a2-561c7b21b8ee.png)
