### PR TITLE
Introduce `HookDispatcher`, isolate static `Hooks::run`

### DIFF
--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -1,4 +1,4 @@
-[Development policies and practices](#development-policies-and-practices) | [Architecture guide](#architecture-guide) | [Hacking by examples](#hacking-by-examples) | [Testing](#testing) | [Getting started](#getting-started)
+[Development policies and practices](#development-policies-and-practices) | [Architecture guide](#architecture-guide) | [Technical insights](#technical-insights) | [Testing](#testing) | [Pull request](#create-a-pull-request)
 
 ## Objective
 
@@ -19,6 +19,7 @@ The general policy of the `Semantic MediaWiki` software and the development ther
 - No MediaWiki tables are modified or altered, any data that needs to be stored persistently is relying on the Semantic MediaWiki's own [`database schema`][db-schema] (writing to the cache is an exception)
 - No MediaWiki classes are modified, patched, or otherwise changed
 - Only publicly available `Hooks` and `API` interfaces are used to extend MediaWiki with Semantic MediaWiki functions
+- Classes and methods (i.e. declared using the `public` visibility attribute) marked as `@private` are not considered for public consumption or API hence a users should not relied upon its availability and can change their signature anytime without prio notice
 
 ### Conventions
 
@@ -42,33 +43,37 @@ Some conventions to help developers and the project to maintain a consistent pro
 - Trying to follow [`Single responsibility principle`](https://en.wikipedia.org/wiki/Single_responsibility_principle) and applying [`inversion of control`](https://en.wikipedia.org/wiki/Inversion_of_control) (i.e dependency injection, factory pattern, service locator pattern) is a best practice approach
 - Newly added functionality is expected to be accompanied by unit and integration test to ensure that its operation is verifiable and doesn't interfere with existing services
 - Newly introduced features (or enhancements) that alter existing behaviour need to be guarded by a behaviour switch (or flag) allowing to restore any previous behaviour and need to be accompanied by [integration tests](#testing)
-- To improve the readability of classes in terms of what is public and what are internals (not to be exposed outside of the class boundary), functions are ordered by its visibility where `public` comes before `protected` which comes before `private` defined functions
+- To improve the readability of classes in terms of what is public and what are internals (not to be exposed outside of the class boundary), class methods are ordered by its visibility where `public` comes before `protected` which comes before `private` defined functions
 
 ## Architecture guide
 
-- [`Datamodel`][datamodel] contains the most essential architectural choice of Semantic MediaWiki for the management of its data including [`DataItem`][dataitem], [`SemanticData`][semanticdata], [`DataValue`][datavalue], and [`DataTypes`][datatype]
-- [`Database schema`][db-schema] and table definitions in Semantic MediaWiki
-- [`Glossary`][glossary]
+- [Datamodel][datamodel] contains the most essential architectural choice of Semantic MediaWiki for the management of its data including:
+  - [DataItem][dataitem]
+  - [SemanticData][semanticdata]
+  - [DataValue][datavalue]
+  - [DataTypes][datatype]
+- [Database schema][db-schema] and table definitions in Semantic MediaWiki
+- [Glossary][glossary]
 
-## Hacking by examples
+## Technical insights
 
 - Creating [annotations and storing data](https://github.com/SemanticMediaWiki/SemanticMediaWiki/blob/master/docs/architecture/storing.annotations.md)
-- [Querying data](https://github.com/SemanticMediaWiki/SemanticMediaWiki/blob/master/docs/architecture/querying.data.md)
+- Querying and displaying [data](https://github.com/SemanticMediaWiki/SemanticMediaWiki/blob/master/docs/architecture/querying.data.md)
 - Writing a [result printer](https://github.com/SemanticMediaWiki/SemanticMediaWiki/blob/master/docs/architecture/writing.resultprinter.md)
-- Best practices for [developing an extension](https://github.com/SemanticMediaWiki/SemanticMediaWiki/blob/master/docs/architecture/developing.extension.md) and a [list of hooks](https://github.com/SemanticMediaWiki/SemanticMediaWiki/blob/master/docs/technical/hooks.md) to extend the functionality of Semantic MediaWiki
 - Register a custom [datatype][datatype] or [predefined property][hook.property.initproperties.md]
 - Extending [consistency checks](https://github.com/SemanticMediaWiki/SemanticMediaWiki/blob/master/docs/architecture/extending.declarationexaminer.md) on a property page
 - Extending [property annotators](https://github.com/SemanticMediaWiki/SemanticMediaWiki/blob/master/docs/architecture/extending.propertyannotator.md) for core predefined properties, see also the [Semantic Extra Special Properties](https://github.com/SemanticMediaWiki/SemanticExtraSpecialProperties) extension that provides a development space for deploying other predefined (special) properties
 - [Extending constraints](https://github.com/SemanticMediaWiki/SemanticMediaWiki/blob/master/docs/architecture/extending.constraint.md) and their checks
 - Working with and [changing the table schema](https://github.com/SemanticMediaWiki/SemanticMediaWiki/blob/master/docs/architecture/changing.tableschema.md) of Semantic MediaWiki
+- Managing [hook events][hooks], best practices for [developing an extension](https://github.com/SemanticMediaWiki/SemanticMediaWiki/blob/master/docs/architecture/developing.extension.md), and a [list of hooks][hook-list] provided by Semantic MediaWiki to extend its core functionality
 
 ## Testing
 
 The `Semantic MediaWiki` software alone deploys ~7400 tests (as of July 2019) which are __required to pass__ before changes can be merged into the repository.
 
-Tests are commonly divided into [unit][glossary] and [integration tests][glossary] where unit tests represent an isolated unit (or component) to be tested and normally doesn't require a database or repository connection. The integration test on the other hand is as test that requires other components and directly interacts with MediaWiki and its services which is why nearly 80% of the CI time for a test run is spend on executing integration test as they will a run a full integration cycle (parsing, storing, reading, HTML generating etc.).
+Tests are commonly divided into [unit][glossary] and [integration tests][glossary] where unit tests represent an isolated unit (or component) to be tested and normally doesn't require a database or other repository connection (e.g. triple store etc.). Integration tests on the other hand provide the means to test the interplay with other components by directly interacting with MediaWiki and its services. For example, about 80% of the CI running time is spend on executing integration tests as they normally run a full integration cycle (parsing, storing, reading, HTML generating etc.).
 
-For an introduction on "How to use `PHPUnit`" and "How to write integration tests using [`JSONScript`][glossary]" this [document](https://github.com/SemanticMediaWiki/SemanticMediaWiki/blob/master/tests/README.md) contains relevant details.
+For an introduction on "How to use `PHPUnit`" and "How to write integration tests using `JSONScript`" see the relevant section in this [document](https://github.com/SemanticMediaWiki/SemanticMediaWiki/blob/master/tests/README.md).
 
 ### Continues integration (CI)
 
@@ -77,21 +82,21 @@ The project uses [Travis-CI](https://travis-ci.org/SemanticMediaWiki/SemanticMed
 - [`.travis.yml`](https://github.com/SemanticMediaWiki/SemanticMediaWiki/blob/master/.travis.yml) testing matrix
 - Settings and [configurations](https://github.com/SemanticMediaWiki/SemanticMediaWiki/blob/master/tests/travis/README.md) to tune the Travis-CI setup
 
-## Getting started
+## Create a pull request
+
+Before creating a pull request it is recommended to:
 
 - Read this document
 - Install [git](https://www.semantic-mediawiki.org/wiki/Help:Using_Git)
 - Install/clone `Semantic MediaWiki` with `@dev` (with development happening against the master branch)
-- Run `composer test` locally (see the test section) and verify that your installation and test environment are setup correctly so that you would find something like "_OK, but incomplete, skipped, or risky tests! Tests ..._" at the end as output (after the test run)
+- Run `composer test` locally (see the test section) and verify that your installation and test environment are setup correctly
 
-### Creating a pull request
-
-#### First PR
+### First PR
 
 - Send a PR with subject [first pr] to the [`Semantic MediaWiki`](https://github.com/SemanticMediaWiki/SemanticMediaWiki/) repository and verify that your git setup works and you are able to replicate changes against the master branch
 - Get yourself familiar with the [Travis-CI](https://travis-ci.org/SemanticMediaWiki/SemanticMediaWiki) environment and observe how a PR triggers CI jobs and review the output of those jobs (important when a job doesn't pass and you need to find the cause for a failure)
 
-#### Preparing a PR
+### Preparing a PR
 
 - Create a PR with your changes and send it to the `Semantic MediaWiki` repository
 - Observe whether tests are failing or not, and when there are failing identify what caused them to fail
@@ -113,5 +118,7 @@ In an event that you encountered a problem, ask or create a [ticket](https://git
 [datavalue]:https://github.com/SemanticMediaWiki/SemanticMediaWiki/blob/master/docs/architecture/datamodel.datavalue.md
 [datatype]:https://github.com/SemanticMediaWiki/SemanticMediaWiki/blob/master/docs/architecture/datamodel.datatype.md
 [db-schema]:https://github.com/SemanticMediaWiki/SemanticMediaWiki/blob/master/docs/architecture/database.schema.md
+[hooks]:https://github.com/SemanticMediaWiki/SemanticMediaWiki/blob/master/docs/architecture/managing.hooks.md
 [hook.property.initproperties.md]:https://github.com/SemanticMediaWiki/SemanticMediaWiki/blob/master/docs/examples/hook.property.initproperties.md
+[hook-list]: https://github.com/SemanticMediaWiki/SemanticMediaWiki/blob/master/docs/technical/hooks.md
 [glossary]: https://github.com/SemanticMediaWiki/SemanticMediaWiki/blob/master/docs/technical/glossary.md

--- a/docs/architecture/managing.hooks.md
+++ b/docs/architecture/managing.hooks.md
@@ -1,0 +1,68 @@
+The [`HookDispatcher`][dispatcher] is provided to inject a hook event handler into a class that triggers a specific hook event with the objective to isolate the MediaWiki `Hooks::run` static caller from a class instance.
+
+The removal of the `Hooks::run` static caller from an individual class follows mainly the problem of leaking global state into an instance which would persist during testing and hereby may alter results in a manner unpredictable based on hooks enabled at the time of the test run.
+
+### Register and trigger a hook event
+
+#### HookDispatcher
+
+Extend the [`HookDispatcher`][dispatcher] class with a particular method that is considered the public interface to trigger a hook event.
+
+```php
+class HookDispatcher {
+
+	/**
+	 * @see ...
+	 * @since 3.2
+	 *
+	 * @param $bar
+	 */
+	public function onChangingSomething( $bar ) {
+		Hooks::run( 'SMW::Fake::ChangingSomething', [ $bar ] );
+	}
+
+}
+```
+
+#### HookDispatcherAwareTrait
+
+The [`HookDispatcherAwareTrait`][trait] has been introduced to help extend a class that is expected to trigger a specific hook event.
+
+It requires to inject the `HookDispatcher` upon creation of an instance of that class (which should be done using a factory) hereby removes global state that would otherwise be leaking into the instance via `Hooks::run`.
+
+```php
+use SMW\MediaWiki\HookDispatcherAwareTrait;
+
+class Foo {
+
+	use HookDispatcherAwareTrait;
+
+	public function doSomethingAndTriggerAnEvent( $bar ) {
+
+		// Trigger the hook event
+		$this->hookDispatcher->onChangingSomething( $bar );
+	}
+
+}
+```
+```php
+use SMW\Services\ServicesFactory;
+
+$servicesFactory = ServicesFactory::getInstance();
+
+$foo = new Foo();
+
+$foo->setHookDispatcher(
+	$servicesFactory->getHookDispatcher()
+);
+
+$foo->doSomethingAndTriggerAnEvent( 'abc' );
+```
+
+## List of hooks
+
+A list of [hook events][hook-list] provided by Semantic MediaWiki to help users to extend its core functionality.
+
+[hook-list]:https://github.com/SemanticMediaWiki/SemanticMediaWiki/blob/master/docs/technical/hooks.md
+[dispatcher]: https://github.com/SemanticMediaWiki/SemanticMediaWiki/blob/master/src/MediaWiki/HookDispatcher.php
+[trait]: https://github.com/SemanticMediaWiki/SemanticMediaWiki/blob/master/src/MediaWiki/HookDispatcherAwareTrait.php

--- a/src/DataUpdater.php
+++ b/src/DataUpdater.php
@@ -9,6 +9,7 @@ use SMW\DeferredTransactionalCallableUpdate as DeferredUpdate;
 use Psr\Log\LoggerAwareTrait;
 use SMW\Property\ChangePropagationNotifier;
 use Revision;
+use SMW\MediaWiki\RevisionGuardAwareTrait;
 use SMW\MediaWiki\RevisionGuard;
 use Onoi\EventDispatcher\EventDispatcherAwareTrait;
 
@@ -31,6 +32,7 @@ use Onoi\EventDispatcher\EventDispatcherAwareTrait;
  */
 class DataUpdater {
 
+	use RevisionGuardAwareTrait;
 	use LoggerAwareTrait;
 	use EventDispatcherAwareTrait;
 
@@ -165,7 +167,7 @@ class DataUpdater {
 
 		$latestRevID = null;
 
-		if ( RevisionGuard::isSkippableUpdate( $title, $latestRevID ) ) {
+		if ( $this->revisionGuard->isSkippableUpdate( $title, $latestRevID ) ) {
 			return true;
 		}
 

--- a/src/MediaWiki/HookDispatcher.php
+++ b/src/MediaWiki/HookDispatcher.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace SMW\MediaWiki;
+
+use Hooks;
+use SMW\Parser\AnnotationProcessor;
+
+/**
+ * @private
+ *
+ * This class is to provide a single point of entry for hooks defined by Semantic
+ * MediaWiki. The `HookDispatcherAwareTrait` is deployed to simplify the removal
+ * of the `Hooks` static caller from a class and allows the injection of the
+ * `HookDispatcher` instead to invoke the appropriate method.
+ *
+ * The removal of the `Hooks` static caller follows mainly the problem of removing
+ * global state from a class which would persists during testing and hereby can
+ * alter results in a manner unpredictable based on hooks enabled by the time of
+ * the test run.
+ *
+ * @license GNU GPL v2+
+ * @since 3.2
+ *
+ * @author mwjames
+ */
+class HookDispatcher {
+
+	/**
+	 * @see https://github.com/SemanticMediaWiki/SemanticMediaWiki/blob/master/docs/technical/hooks/hook.getpreferences.md
+	 * @since 3.2
+	 *
+	 * @param User $user
+	 * @param array &$preferences
+	 */
+	public function onGetPreferences( \User $user, array &$preferences ) {
+		Hooks::run( 'SMW::GetPreferences', [ $user, &$preferences ] );
+	}
+
+	/**
+	 * @see https://github.com/SemanticMediaWiki/SemanticMediaWiki/blob/master/docs/technical/hooks/hook.parser.beforemagicwordsfinder.md
+	 * @since 3.2
+	 *
+	 * @param array &$magicWords
+	 */
+	public function onBeforeMagicWordsFinder( array &$magicWords ) {
+		Hooks::run( 'SMW::Parser::BeforeMagicWordsFinder', [ &$magicWords ] );
+	}
+
+	/**
+	 * @see https://github.com/SemanticMediaWiki/SemanticMediaWiki/blob/master/docs/technical/hooks/hook.parser.afterlinksprocessingcomplete.md
+	 * @since 3.2
+	 *
+	 * @param string &$text
+	 * @param AnnotationProcessor $annotationProcessor
+	 */
+	public function onAfterLinksProcessingComplete( string &$text, AnnotationProcessor $annotationProcessor ) {
+		Hooks::run( 'SMW::Parser::AfterLinksProcessingComplete', [ &$text, $annotationProcessor ] );
+	}
+
+	/**
+	 * @see https://github.com/SemanticMediaWiki/SemanticMediaWiki/blob/master/docs/technical/hooks/hook.revisionguard.isapprovedrevision.md
+	 *
+	 * Hooks to define whether the latest used revision is approved or not, and
+	 * when it is not approved the hook should return `false`.
+	 *
+	 * @note This hook is only to be called from the `RevisionGuard` class.
+	 *
+	 * @since 3.2
+	 *
+	 * @param Title $title
+	 * @param int $latestRevID
+	 *
+	 * @return bool
+	 */
+	public function onIsApprovedRevision( \Title $title, int $latestRevID ) : bool {
+		return Hooks::run( 'SMW::RevisionGuard::IsApprovedRevision', [ $title, $latestRevID ] );
+	}
+
+}

--- a/src/MediaWiki/HookDispatcherAwareTrait.php
+++ b/src/MediaWiki/HookDispatcherAwareTrait.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace SMW\MediaWiki;
+
+/**
+ * @license GNU GPL v2+
+ * @since 3.2
+ *
+ * @author mwjames
+ */
+trait HookDispatcherAwareTrait {
+
+	/**
+	 * @var HookDispatcher
+	 */
+	private $hookDispatcher;
+
+	/**
+	 * @since 3.2
+	 *
+	 * @param HookDispatcher $hookDispatcher
+	 */
+	public function setHookDispatcher( HookDispatcher $hookDispatcher ) {
+		$this->hookDispatcher = $hookDispatcher;
+	}
+
+}

--- a/src/MediaWiki/Hooks.php
+++ b/src/MediaWiki/Hooks.php
@@ -802,11 +802,18 @@ class Hooks {
 		);
 
 		$linksUpdateConstructed->setLogger(
-			 $applicationFactory->getMediaWikiLogger()
+			$applicationFactory->getMediaWikiLogger()
 		);
 
+		// #3341
+		// When running as part of the install don't try to access the DB
+		// or update the Store
 		$linksUpdateConstructed->isReady(
 			Site::isReady()
+		);
+
+		$linksUpdateConstructed->setRevisionGuard(
+			 $applicationFactory->singleton( 'RevisionGuard' )
 		);
 
 		$linksUpdateConstructed->process( $linksUpdate );
@@ -910,10 +917,15 @@ class Hooks {
 	 */
 	public function onGetPreferences( $user, &$preferences ) {
 
-		$settings = ApplicationFactory::getInstance()->getSettings();
+		$applicationFactory = ApplicationFactory::getInstance();
+		$settings = $applicationFactory->getSettings();
 
 		$getPreferences = new GetPreferences(
 			$user
+		);
+
+		$getPreferences->setHookDispatcher(
+			$applicationFactory->getHookDispatcher()
 		);
 
 		$getPreferences->setOptions(

--- a/src/MediaWiki/Hooks/GetPreferences.php
+++ b/src/MediaWiki/Hooks/GetPreferences.php
@@ -7,6 +7,7 @@ use User;
 use Xml;
 use SMW\Utils\Logo;
 use SMW\MediaWiki\HookListener;
+use SMW\MediaWiki\HookDispatcherAwareTrait;
 use SMW\OptionsAwareTrait;
 
 /**
@@ -22,6 +23,7 @@ use SMW\OptionsAwareTrait;
 class GetPreferences implements HookListener {
 
 	use OptionsAwareTrait;
+	use HookDispatcherAwareTrait;
 
 	/**
 	 * @var User
@@ -47,8 +49,7 @@ class GetPreferences implements HookListener {
 	public function process( array &$preferences ) {
 
 		$otherPreferences = [];
-
-		Hooks::run( 'SMW::GetPreferences', [ $this->user, &$otherPreferences ] );
+		$this->hookDispatcher->onGetPreferences( $this->user, $otherPreferences );
 
 		$html = $this->makeImage( Logo::get( '100x90' ) );
 		$html .= wfMessage( 'smw-prefs-intro-text' )->parseAsBlock();

--- a/src/MediaWiki/Hooks/LinksUpdateConstructed.php
+++ b/src/MediaWiki/Hooks/LinksUpdateConstructed.php
@@ -4,7 +4,7 @@ namespace SMW\MediaWiki\Hooks;
 
 use LinksUpdate;
 use SMW\ApplicationFactory;
-use SMW\MediaWiki\RevisionGuard;
+use SMW\MediaWiki\RevisionGuardAwareTrait;
 use SMW\NamespaceExaminer;
 use SMW\SemanticData;
 use SMW\MediaWiki\HookListener;
@@ -22,6 +22,7 @@ use Psr\Log\LoggerAwareTrait;
  */
 class LinksUpdateConstructed implements HookListener {
 
+	use RevisionGuardAwareTrait;
 	use LoggerAwareTrait;
 
 	/**
@@ -79,7 +80,7 @@ class LinksUpdateConstructed implements HookListener {
 
 		$title = $linksUpdate->getTitle();
 
-		if ( RevisionGuard::isSkippableUpdate( $title ) ) {
+		if ( $this->revisionGuard->isSkippableUpdate( $title ) ) {
 			return true;
 		}
 

--- a/src/MediaWiki/RevisionGuard.php
+++ b/src/MediaWiki/RevisionGuard.php
@@ -7,6 +7,7 @@ use Title;
 use File;
 use User;
 use WikiPage;
+use SMW\MediaWiki\HookDispatcherAwareTrait;
 
 /**
  * @private
@@ -23,6 +24,8 @@ use WikiPage;
  */
 class RevisionGuard {
 
+	use HookDispatcherAwareTrait;
+
 	/**
 	 * @since 3.1
 	 *
@@ -31,7 +34,7 @@ class RevisionGuard {
 	 *
 	 * @return boolean
 	 */
-	public static function isSkippableUpdate( Title $title, &$latestRevID = null ) {
+	public function isSkippableUpdate( Title $title, &$latestRevID = null ) {
 
 		// MW 1.34+
 		// https://github.com/wikimedia/mediawiki/commit/b65e77a385c7423ce03a4d21c141d96c28291a60
@@ -47,7 +50,7 @@ class RevisionGuard {
 
 		// If for some reason an extension decides that the current used revision
 		// isn't approved then the hook should return `false`
-		if ( \Hooks::run( 'SMW::RevisionGuard::IsApprovedRevision', [ $title, $latestRevID ] ) === false ) {
+		if ( $this->hookDispatcher->onIsApprovedRevision( $title, $latestRevID ) === false ) {
 			return true;
 		}
 

--- a/src/MediaWiki/RevisionGuardAwareTrait.php
+++ b/src/MediaWiki/RevisionGuardAwareTrait.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace SMW\MediaWiki;
+
+/**
+ * @license GNU GPL v2+
+ * @since 3.2
+ *
+ * @author mwjames
+ */
+trait RevisionGuardAwareTrait {
+
+	/**
+	 * @var RevisionGuard
+	 */
+	private $revisionGuard;
+
+	/**
+	 * @since 3.2
+	 *
+	 * @param RevisionGuard $revisionGuard
+	 */
+	public function setRevisionGuard( RevisionGuard $revisionGuard ) {
+		$this->revisionGuard = $revisionGuard;
+	}
+
+}

--- a/src/Parser/InTextAnnotationParser.php
+++ b/src/Parser/InTextAnnotationParser.php
@@ -10,6 +10,7 @@ use SMW\SemanticData;
 use SMW\MediaWiki\MagicWordsFinder;
 use SMW\MediaWiki\RedirectTargetFinder;
 use SMW\MediaWiki\StripMarkerDecoder;
+use SMW\MediaWiki\HookDispatcherAwareTrait;
 use SMW\ParserData;
 use SMW\Utils\Timer;
 use SMWOutputs;
@@ -30,6 +31,8 @@ use Title;
  * @author mwjames
  */
 class InTextAnnotationParser {
+
+	use HookDispatcherAwareTrait;
 
 	/**
 	 * Internal state for switching SMW link annotations off/on during parsing
@@ -186,12 +189,7 @@ class InTextAnnotationParser {
 			$this->parserData->canUse()
 		);
 
-		Hooks::run( 'SMW::Parser::AfterLinksProcessingComplete',
-			[
-				&$text,
-				$this->annotationProcessor
-			]
-		);
+		$this->hookDispatcher->onAfterLinksProcessingComplete( $text, $this->annotationProcessor );
 
 		// Ensure remaining encoded entities are decoded again
 		$text = LinksEncoder::removeLinkObfuscation( $text );
@@ -456,7 +454,7 @@ class InTextAnnotationParser {
 			'SMW_SHOWFACTBOX'
 		];
 
-		Hooks::run( 'SMW::Parser::BeforeMagicWordsFinder', [ &$magicWords ] );
+		$this->hookDispatcher->onBeforeMagicWordsFinder( $magicWords );
 
 		foreach ( $magicWords as $magicWord ) {
 			$words[] = $this->magicWordsFinder->findMagicWordInText( $magicWord, $text );

--- a/src/Services/ServicesFactory.php
+++ b/src/Services/ServicesFactory.php
@@ -29,6 +29,7 @@ use SMW\MediaWiki\MwCollaboratorFactory;
 use SMW\MediaWiki\PageCreator;
 use SMW\MediaWiki\PageUpdater;
 use SMW\MediaWiki\TitleFactory;
+use SMW\MediaWiki\HookDispatcher;
 use SMW\NamespaceExaminer;
 use SMW\ParserData;
 use SMW\ParserFunctionFactory;
@@ -228,30 +229,47 @@ class ServicesFactory {
 
 	/**
 	 * @since 2.0
+	 *
+	 * @return Store
 	 */
-	public function getStore( $store = null ): Store {
+	public function getStore( $store = null ) : Store {
 		return $this->containerBuilder->singleton( 'Store', $store );
 	}
 
 	/**
 	 * @since 2.0
+	 *
+	 * @return Settings
 	 */
-	public function getSettings(): Settings {
+	public function getSettings() : Settings {
 		return $this->containerBuilder->singleton( 'Settings' );
 	}
 
 	/**
 	 * @since 3.0
+	 *
+	 * @return ConnectionManager
 	 */
-	public function getConnectionManager(): ConnectionManager {
+	public function getConnectionManager() : ConnectionManager {
 		return $this->containerBuilder->singleton( 'ConnectionManager' );
 	}
 
 	/**
 	 * @since 3.1
+	 *
+	 * @return EventDispatcher
 	 */
-	public function getEventDispatcher(): EventDispatcher {
+	public function getEventDispatcher() : EventDispatcher {
 		return EventHandler::getInstance()->getEventDispatcher();
+	}
+
+	/**
+	 * @since 3.2
+	 *
+	 * @return HookDispatcher
+	 */
+	public function getHookDispatcher() : HookDispatcher {
+		return $this->containerBuilder->singleton( 'HookDispatcher' );
 	}
 
 	/**
@@ -360,6 +378,10 @@ class ServicesFactory {
 			$settings->isFlagSet( 'smwgParserFeatures', SMW_PARSER_INL_ERROR )
 		);
 
+		$inTextAnnotationParser->setHookDispatcher(
+			$this->getHookDispatcher()
+		);
+
 		return $inTextAnnotationParser;
 	}
 
@@ -417,6 +439,10 @@ class ServicesFactory {
 
 		$dataUpdater->setEventDispatcher(
 			$this->getEventDispatcher()
+		);
+
+		$dataUpdater->setRevisionGuard(
+			$this->singleton( 'RevisionGuard' )
 		);
 
 		return $dataUpdater;

--- a/src/Services/SharedServicesContainer.php
+++ b/src/Services/SharedServicesContainer.php
@@ -34,6 +34,8 @@ use SMW\MediaWiki\PageCreator;
 use SMW\MediaWiki\PageUpdater;
 use SMW\MediaWiki\PermissionManager;
 use SMW\MediaWiki\TitleFactory;
+use SMW\MediaWiki\HookDispatcher;
+use SMW\MediaWiki\RevisionGuard;
 use SMW\MessageFormatter;
 use SMW\NamespaceExaminer;
 use SMW\Parser\LinksProcessor;
@@ -262,6 +264,22 @@ class SharedServicesContainer implements CallbackContainer {
 		$containerBuilder->registerCallback( 'TitleFactory', function( $containerBuilder ) {
 			$containerBuilder->registerExpectedReturnType( 'TitleFactory', '\SMW\MediaWiki\TitleFactory' );
 			return new TitleFactory();
+		} );
+
+		$containerBuilder->registerCallback( 'HookDispatcher', function( $containerBuilder ) {
+			$containerBuilder->registerExpectedReturnType( 'HookDispatcher', HookDispatcher::class );
+			return new HookDispatcher();
+		} );
+
+		$containerBuilder->registerCallback( 'RevisionGuard', function( $containerBuilder ) {
+			$containerBuilder->registerExpectedReturnType( 'RevisionGuard', RevisionGuard::class );
+			$revisionGuard = new RevisionGuard();
+
+			$revisionGuard->setHookDispatcher(
+				$containerBuilder->singleton( 'HookDispatcher' )
+			);
+
+			return $revisionGuard;
 		} );
 
 		$containerBuilder->registerCallback( 'ContentParser', function( $containerBuilder, \Title $title ) {

--- a/tests/phpunit/Integration/MediaWiki/HookDispatcherTest.php
+++ b/tests/phpunit/Integration/MediaWiki/HookDispatcherTest.php
@@ -1,0 +1,132 @@
+<?php
+
+namespace SMW\Tests\Integration;
+
+use RuntimeException;
+use SMW\MediaWiki\HookDispatcher;
+use SMW\Tests\TestEnvironment;
+
+/**
+ * @group semantic-mediawiki
+ *
+ * @license GNU GPL v2+
+ * @since 3.2
+ *
+ * @author mwjames
+ */
+class HookDispatcherTest extends \PHPUnit_Framework_TestCase {
+
+	private $mwHooksHandler;
+
+	protected function setUp() {
+		parent::setUp();
+
+		$this->testEnvironment = new TestEnvironment();
+
+		$this->mwHooksHandler = $this->testEnvironment->getUtilityFactory()->newMwHooksHandler();
+		$this->mwHooksHandler->deregisterListedHooks();
+	}
+
+	protected function tearDown() {
+		$this->mwHooksHandler->restoreListedHooks();
+		$this->testEnvironment->tearDown();
+		parent::tearDown();
+	}
+
+	public function testOnGetPreferences() {
+
+		$preferences = [];
+
+		$hookDispatcher = new HookDispatcher();
+
+		$user = $this->getMockBuilder( '\User' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$this->mwHooksHandler->register( 'SMW::GetPreferences', function( $user, &$preferences ) {
+			$preferences = [ 'Foo' ];
+		} );
+
+		$hookDispatcher->onGetPreferences( $user, $preferences );
+
+		$this->assertEquals(
+			[ 'Foo' ],
+			$preferences
+		);
+	}
+
+	public function testOnBeforeMagicWordsFinder() {
+
+		$magicWords = [];
+
+		$hookDispatcher = new HookDispatcher();
+
+		$this->mwHooksHandler->register( 'SMW::Parser::BeforeMagicWordsFinder', function( &$magicWords ) {
+			$magicWords = [ 'Foo' ];
+		} );
+
+		$hookDispatcher->onBeforeMagicWordsFinder( $magicWords );
+
+		$this->assertEquals(
+			[ 'Foo' ],
+			$magicWords
+		);
+	}
+
+	public function testOnAfterLinksProcessingComplete() {
+
+		$text = '';
+
+		$hookDispatcher = new HookDispatcher();
+
+		$annotationProcessor = $this->getMockBuilder( '\SMW\Parser\AnnotationProcessor' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$this->mwHooksHandler->register( 'SMW::Parser::AfterLinksProcessingComplete', function( &$text, $annotationProcessor ) {
+			$text = 'Foo';
+		} );
+
+		$hookDispatcher->onAfterLinksProcessingComplete( $text, $annotationProcessor );
+
+		$this->assertEquals(
+			'Foo',
+			$text
+		);
+	}
+
+	public function testOnIsApprovedRevision() {
+
+		$hookDispatcher = new HookDispatcher();
+
+		$title = $this->getMockBuilder( '\Title' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$this->mwHooksHandler->register( 'SMW::RevisionGuard::IsApprovedRevision', function( $title, $latestRevID ) {
+			return $latestRevID == 9999 ? false : true ;
+		} );
+
+		$this->assertFalse(
+			$hookDispatcher->onIsApprovedRevision( $title, 9999 )
+		);
+	}
+
+	public function testConfirmAllOnMethodsWereCalled() {
+
+		// Expected class methods to be tested
+		$classMethods = get_class_methods( HookDispatcher::class );
+
+		// Match all "testOn" to the expected set of methods
+		$testMethods = preg_grep('/^testOn/', get_class_methods( $this ) );
+
+		$testMethods = array_flip(
+			str_replace( 'testOn', 'on', $testMethods )
+		);
+
+		foreach ( $classMethods as $name ) {
+			$this->assertArrayHasKey( $name, $testMethods );
+		}
+	}
+
+}

--- a/tests/phpunit/Integration/SemanticMediaWikiProvidedHookInterfaceIntegrationTest.php
+++ b/tests/phpunit/Integration/SemanticMediaWikiProvidedHookInterfaceIntegrationTest.php
@@ -487,12 +487,19 @@ class SemanticMediaWikiProvidedHookInterfaceIntegrationTest extends \PHPUnit_Fra
 			->setMethods( null )
 			->getMock();
 
-		$this->mwHooksHandler->register( 'SMW::Parser::BeforeMagicWordsFinder', function( &$magicWords ) {
-			$magicWords = [ 'Foo' ];
+		$hookDispatcher = $this->getMockBuilder( '\SMW\MediaWiki\HookDispatcher' )
+			->disableOriginalConstructor()
+			->getMock();
 
-			// Just to make MW 1.19 happy, otherwise it is not really needed
-			return true;
-		} );
+		$hookDispatcher->expects( $this->once() )
+			->method( 'onBeforeMagicWordsFinder' )
+			->will($this->returnCallback( function( &$magicWords ) {
+				$magicWords = [ 'Foo' ];
+			} ) );
+
+		$inTextAnnotationParser->setHookDispatcher(
+			$hookDispatcher
+		);
 
 		$text = '';
 

--- a/tests/phpunit/Unit/DataUpdaterTest.php
+++ b/tests/phpunit/Unit/DataUpdaterTest.php
@@ -26,6 +26,7 @@ class DataUpdaterTest  extends \PHPUnit_Framework_TestCase {
 	private $store;
 	private $changePropagationNotifier;
 	private $eventDispatcher;
+	private $revisionGuard;
 
 	protected function setUp() {
 		parent::setUp();
@@ -39,6 +40,14 @@ class DataUpdaterTest  extends \PHPUnit_Framework_TestCase {
 		$this->spyLogger = $this->testEnvironment->newSpyLogger();
 
 		$this->eventDispatcher = $this->getMockBuilder( '\Onoi\EventDispatcher\EventDispatcher' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$this->revisionGuard = $this->getMockBuilder( '\SMW\MediaWiki\RevisionGuard' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$this->propertySpecificationLookup = $this->getMockBuilder( '\SMW\Property\SpecificationLookup' )
 			->disableOriginalConstructor()
 			->getMock();
 
@@ -75,6 +84,8 @@ class DataUpdaterTest  extends \PHPUnit_Framework_TestCase {
 
 		$this->testEnvironment->registerObject( 'JobQueue', $jobQueue );
 		$this->testEnvironment->registerObject( 'Store', $this->store );
+		$this->testEnvironment->registerObject( 'RevisionGuard', $this->revisionGuard );
+		$this->testEnvironment->registerObject( 'PropertySpecificationLookup', $this->propertySpecificationLookup );
 
 		$this->semanticDataFactory = $this->testEnvironment->getUtilityFactory()->newSemanticDataFactory();
 	}
@@ -114,6 +125,10 @@ class DataUpdaterTest  extends \PHPUnit_Framework_TestCase {
 			$this->eventDispatcher
 		);
 
+		$instance->setRevisionGuard(
+			$this->revisionGuard
+		);
+
 		$this->assertTrue(
 			$instance->doUpdate()
 		);
@@ -131,6 +146,10 @@ class DataUpdaterTest  extends \PHPUnit_Framework_TestCase {
 
 		$instance->setEventDispatcher(
 			$this->eventDispatcher
+		);
+
+		$instance->setRevisionGuard(
+			$this->revisionGuard
 		);
 
 		$instance->setLogger( $this->spyLogger );
@@ -472,6 +491,10 @@ class DataUpdaterTest  extends \PHPUnit_Framework_TestCase {
 
 		$instance->setEventDispatcher(
 			$this->eventDispatcher
+		);
+
+		$instance->setRevisionGuard(
+			$this->revisionGuard
 		);
 
 		$instance->canCreateUpdateJob( true );

--- a/tests/phpunit/Unit/MediaWiki/HookDispatcherAwareTraitTest.php
+++ b/tests/phpunit/Unit/MediaWiki/HookDispatcherAwareTraitTest.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace SMW\Tests\MediaWiki;
+
+use SMW\MediaWiki\HookDispatcherAwareTrait;
+
+/**
+ * @covers \SMW\MediaWiki\HookDispatcherAwareTrait
+ * @group semantic-mediawiki
+ *
+ * @license GNU GPL v2+
+ * @since 3.2
+ *
+ * @author mwjames
+ */
+class HookDispatcherAwareTraitTest extends \PHPUnit_Framework_TestCase {
+
+	public function testSetHookDispatcher() {
+
+		$user = $this->getMockBuilder( '\User' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$hookDispatcher = $this->getMockBuilder( '\SMW\MediaWiki\HookDispatcher' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$hookDispatcher->expects( $this->once() )
+			->method( 'onGetPreferences' );
+
+		$instance = $this->newHookDispatcherAware();
+
+		$instance->setHookDispatcher(
+			$hookDispatcher
+		);
+
+		$instance->callOnGetPreferences( $user, [] );
+	}
+
+	private function newHookDispatcherAware() {
+		return new class() {
+
+			use HookDispatcherAwareTrait;
+
+			public function callOnGetPreferences( $user, $parameters ) {
+				$this->hookDispatcher->onGetPreferences( $user, $parameters );
+			}
+		};
+	}
+
+}

--- a/tests/phpunit/Unit/MediaWiki/Hooks/ArticleProtectCompleteTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Hooks/ArticleProtectCompleteTest.php
@@ -121,6 +121,10 @@ class ArticleProtectCompleteTest extends \PHPUnit_Framework_TestCase {
 			->method( 'getNamespace' )
 			->will( $this->returnValue( NS_SPECIAL ) );
 
+		$title->expects( $this->any() )
+			->method( 'getLatestRevID' )
+			->will( $this->returnValue( 9900 ) );
+
 		$this->editInfo->expects( $this->once() )
 			->method( 'getOutput' )
 			->will( $this->returnValue( $parserOutput ) );
@@ -178,6 +182,10 @@ class ArticleProtectCompleteTest extends \PHPUnit_Framework_TestCase {
 		$title->expects( $this->any() )
 			->method( 'getDBKey' )
 			->will( $this->returnValue( 'Foo' ) );
+
+		$title->expects( $this->any() )
+			->method( 'getLatestRevID' )
+			->will( $this->returnValue( 9901 ) );
 
 		$title->expects( $this->any() )
 			->method( 'getNamespace' )

--- a/tests/phpunit/Unit/MediaWiki/Hooks/GetPreferencesTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Hooks/GetPreferencesTest.php
@@ -15,6 +15,16 @@ use SMW\MediaWiki\Hooks\GetPreferences;
  */
 class GetPreferencesTest extends \PHPUnit_Framework_TestCase {
 
+	private $hookDispatcher;
+
+	protected function setUp() {
+		parent::setUp();
+
+		$this->hookDispatcher = $this->getMockBuilder( '\SMW\MediaWiki\HookDispatcher' )
+			->disableOriginalConstructor()
+			->getMock();
+	}
+
 	public function testCanConstruct() {
 
 		$user = $this->getMockBuilder( '\User' )
@@ -41,6 +51,10 @@ class GetPreferencesTest extends \PHPUnit_Framework_TestCase {
 		$preferences = [];
 
 		$instance = new GetPreferences( $user );
+
+		$instance->setHookDispatcher(
+			$this->hookDispatcher
+		);
 
 		$instance->setOptions(
 			[

--- a/tests/phpunit/Unit/MediaWiki/Hooks/LinksUpdateConstructedTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Hooks/LinksUpdateConstructedTest.php
@@ -22,12 +22,22 @@ class LinksUpdateConstructedTest extends \PHPUnit_Framework_TestCase {
 	private $testEnvironment;
 	private $namespaceExaminer;
 	private $spyLogger;
+	private $revisionGuard;
+
 
 	protected function setUp() {
 		parent::setUp();
 
 		$this->testEnvironment = new TestEnvironment();
 		$this->spyLogger = $this->testEnvironment->newSpyLogger();
+
+		$this->revisionGuard = $this->getMockBuilder( '\SMW\MediaWiki\RevisionGuard' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$this->revisionGuard->expects( $this->any() )
+			->method( 'isSkippableUpdate' )
+			->will( $this->returnValue( false ) );
 
 		$this->namespaceExaminer = $this->getMockBuilder( '\SMW\NamespaceExaminer' )
 			->disableOriginalConstructor()
@@ -47,6 +57,7 @@ class LinksUpdateConstructedTest extends \PHPUnit_Framework_TestCase {
 			->will( $this->returnValue( $idTable ) );
 
 		$this->testEnvironment->registerObject( 'Store', $store );
+		$this->testEnvironment->registerObject( 'RevisionGuard', $this->revisionGuard );
 	}
 
 	protected function tearDown() {
@@ -71,6 +82,10 @@ class LinksUpdateConstructedTest extends \PHPUnit_Framework_TestCase {
 		$title->expects( $this->any() )
 			->method( 'getArticleID' )
 			->will( $this->returnValue( 11001 ) );
+
+		$title->expects( $this->any() )
+			->method( 'getLatestRevID' )
+			->will( $this->returnValue( 9999 ) );
 
 		$title->expects( $this->any() )
 			->method( 'getDBKey' )
@@ -122,6 +137,11 @@ class LinksUpdateConstructedTest extends \PHPUnit_Framework_TestCase {
 		);
 
 		$instance->setLogger( $this->spyLogger );
+
+		$instance->setRevisionGuard(
+			$this->revisionGuard
+		);
+
 		$instance->disableDeferredUpdate();
 
 		$this->assertTrue(
@@ -165,6 +185,10 @@ class LinksUpdateConstructedTest extends \PHPUnit_Framework_TestCase {
 
 		$instance = new LinksUpdateConstructed(
 			$this->namespaceExaminer
+		);
+
+		$instance->setRevisionGuard(
+			$this->revisionGuard
 		);
 
 		$this->assertTrue(
@@ -212,6 +236,10 @@ class LinksUpdateConstructedTest extends \PHPUnit_Framework_TestCase {
 
 		$instance = new LinksUpdateConstructed(
 			$this->namespaceExaminer
+		);
+
+		$instance->setRevisionGuard(
+			$this->revisionGuard
 		);
 
 		$instance->process( $linksUpdate );

--- a/tests/phpunit/Unit/MediaWiki/HooksTest.php
+++ b/tests/phpunit/Unit/MediaWiki/HooksTest.php
@@ -55,6 +55,10 @@ class HooksTest extends \PHPUnit_Framework_TestCase {
 			->method( 'getNamespace' )
 			->will( $this->returnValue( NS_MAIN ) );
 
+		$this->title->expects( $this->any() )
+			->method( 'getLatestRevID' )
+			->will( $this->returnValue( 9900 ) );
+
 		$this->outputPage = $this->getMockBuilder( '\OutputPage' )
 			->disableOriginalConstructor()
 			->getMock();

--- a/tests/phpunit/Unit/MediaWiki/RevisionGuardAwareTraitTest.php
+++ b/tests/phpunit/Unit/MediaWiki/RevisionGuardAwareTraitTest.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace SMW\Tests\MediaWiki;
+
+use SMW\MediaWiki\RevisionGuardAwareTrait;
+
+/**
+ * @covers \SMW\MediaWiki\RevisionGuardAwareTrait
+ * @group semantic-mediawiki
+ *
+ * @license GNU GPL v2+
+ * @since 3.2
+ *
+ * @author mwjames
+ */
+class RevisionGuardAwareTraitTest extends \PHPUnit_Framework_TestCase {
+
+	public function testSetRevisionGuard() {
+
+		$title = $this->getMockBuilder( '\Title' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$revisionGuard = $this->getMockBuilder( '\SMW\MediaWiki\RevisionGuard' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$revisionGuard->expects( $this->once() )
+			->method( 'isSkippableUpdate' );
+
+		$instance = $this->newRevisionGuardAware();
+
+		$instance->setRevisionGuard(
+			$revisionGuard
+		);
+
+		$instance->callIsSkippableUpdate( $title );
+	}
+
+	private function newRevisionGuardAware() {
+		return new class() {
+
+			use RevisionGuardAwareTrait;
+
+			public function callIsSkippableUpdate( $title ) {
+				$this->revisionGuard->isSkippableUpdate( $title );
+			}
+		};
+	}
+
+}

--- a/tests/phpunit/Unit/MediaWiki/RevisionGuardTest.php
+++ b/tests/phpunit/Unit/MediaWiki/RevisionGuardTest.php
@@ -16,6 +16,16 @@ use SMW\DIWikiPage;
  */
 class RevisionGuardTest extends \PHPUnit_Framework_TestCase {
 
+	private $hookDispatcher;
+
+	protected function setUp() {
+		parent::setUp();
+
+		$this->hookDispatcher = $this->getMockBuilder( '\SMW\MediaWiki\HookDispatcher' )
+			->disableOriginalConstructor()
+			->getMock();
+	}
+
 	public function testCanConstruct() {
 
 		$this->assertInstanceOf(
@@ -34,9 +44,15 @@ class RevisionGuardTest extends \PHPUnit_Framework_TestCase {
 			->method( 'getLatestRevID' )
 			->will( $this->returnValue( 42 ) );
 
+		$instance = new RevisionGuard();
+
+		$instance->setHookDispatcher(
+			$this->hookDispatcher
+		);
+
 		$this->assertInternalType(
 			'boolean',
-			RevisionGuard::isSkippableUpdate( $title )
+			$instance->isSkippableUpdate( $title )
 		);
 	}
 
@@ -51,9 +67,15 @@ class RevisionGuardTest extends \PHPUnit_Framework_TestCase {
 
 		$latestRevID = 1001;
 
+		$instance = new RevisionGuard();
+
+		$instance->setHookDispatcher(
+			$this->hookDispatcher
+		);
+
 		$this->assertInternalType(
 			'boolean',
-			RevisionGuard::isSkippableUpdate( $title, $latestRevID )
+			$instance->isSkippableUpdate( $title, $latestRevID )
 		);
 	}
 

--- a/tests/phpunit/Unit/Parser/InTextAnnotationParserTest.php
+++ b/tests/phpunit/Unit/Parser/InTextAnnotationParserTest.php
@@ -29,6 +29,7 @@ class InTextAnnotationParserTest extends \PHPUnit_Framework_TestCase {
 	private $testEnvironment;
 	private $linksProcessor;
 	private $magicWordsFinder;
+	private $hookDispatcher;
 
 	protected function setUp() {
 		parent::setUp();
@@ -46,6 +47,10 @@ class InTextAnnotationParserTest extends \PHPUnit_Framework_TestCase {
 		$this->linksProcessor = new LinksProcessor();
 
 		$this->magicWordsFinder = $this->getMockBuilder( '\SMW\MediaWiki\MagicWordsFinder' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$this->hookDispatcher = $this->getMockBuilder( '\SMW\MediaWiki\HookDispatcher' )
 			->disableOriginalConstructor()
 			->getMock();
 	}
@@ -117,6 +122,10 @@ class InTextAnnotationParserTest extends \PHPUnit_Framework_TestCase {
 			new RedirectTargetFinder()
 		);
 
+		$instance->setHookDispatcher(
+			$this->hookDispatcher
+		);
+
 		$instance->parse( $text );
 
 		$this->assertEquals(
@@ -144,6 +153,10 @@ class InTextAnnotationParserTest extends \PHPUnit_Framework_TestCase {
 			$this->linksProcessor,
 			$this->magicWordsFinder,
 			new RedirectTargetFinder()
+		);
+
+		$instance->setHookDispatcher(
+			$this->hookDispatcher
 		);
 
 		$instance->showErrors(
@@ -205,6 +218,10 @@ class InTextAnnotationParserTest extends \PHPUnit_Framework_TestCase {
 			$redirectTargetFinder
 		);
 
+		$instance->setHookDispatcher(
+			$this->hookDispatcher
+		);
+
 		$instance->parse( $text );
 
 		$this->semanticDataValidator->assertThatPropertiesAreSet(
@@ -246,6 +263,10 @@ class InTextAnnotationParserTest extends \PHPUnit_Framework_TestCase {
 			$this->linksProcessor,
 			$this->magicWordsFinder,
 			$redirectTargetFinder
+		);
+
+		$instance->setHookDispatcher(
+			$this->hookDispatcher
 		);
 
 		$instance->setRedirectTarget( $redirectTarget );
@@ -294,6 +315,10 @@ class InTextAnnotationParserTest extends \PHPUnit_Framework_TestCase {
 		);
 
 		$text = '[[Foo::<nowiki>Bar</nowiki>]]';
+
+		$instance->setHookDispatcher(
+			$this->hookDispatcher
+		);
 
 		$instance->setStripMarkerDecoder( $stripMarkerDecoder );
 		$instance->parse( $text );

--- a/tests/phpunit/Unit/ParserDataTest.php
+++ b/tests/phpunit/Unit/ParserDataTest.php
@@ -31,6 +31,12 @@ class ParserDataTest extends \PHPUnit_Framework_TestCase {
 
 		$this->semanticDataValidator = $this->testEnvironment->getUtilityFactory()->newValidatorFactory()->newSemanticDataValidator();
 		$this->dataValueFactory = DataValueFactory::getInstance();
+
+		$this->revisionGuard = $this->getMockBuilder( '\SMW\MediaWiki\RevisionGuard' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$this->testEnvironment->registerObject( 'RevisionGuard', $this->revisionGuard );
 	}
 
 	protected function tearDown() {
@@ -265,24 +271,11 @@ class ParserDataTest extends \PHPUnit_Framework_TestCase {
 
 	public function testSkipUpdateOnMatchedMarker() {
 
-		$idTable = $this->getMockBuilder( '\stdClass' )
-			->setMethods( [ 'findAssociatedRev' ] )
-			->getMock();
+		$this->revisionGuard->expects( $this->once() )
+			->method( 'isSkippableUpdate' )
+			->will( $this->returnValue( true ) );
 
-		$idTable->expects( $this->once() )
-			->method( 'findAssociatedRev' )
-			->will( $this->returnValue( 42 ) );
-
-		$store = $this->getMockBuilder( '\SMW\SQLStore\SQLStore' )
-			->disableOriginalConstructor()
-			->setMethods( [ 'getObjectIds' ] )
-			->getMock();
-
-		$store->expects( $this->any() )
-			->method( 'getObjectIds' )
-			->will( $this->returnValue( $idTable ) );
-
-		$this->testEnvironment->registerObject( 'Store', $store );
+		$this->testEnvironment->registerObject( 'RevisionGuard', $this->revisionGuard );
 
 		$title = $this->getMockBuilder( '\Title' )
 			->disableOriginalConstructor()

--- a/tests/phpunit/Utils/MwHooksHandler.php
+++ b/tests/phpunit/Utils/MwHooksHandler.php
@@ -49,6 +49,10 @@ class MwHooksHandler {
 		'SMW::Browse::AfterIncomingPropertiesLookupComplete',
 		'SMW::Browse::BeforeIncomingPropertyValuesFurtherLinkCreate',
 
+		'SMW::GetPreferences',
+		'SMW::Parser::AfterLinksProcessingComplete',
+		'SMW::RevisionGuard::IsApprovedRevision',
+
 		'SMWSQLStore3::updateDataBefore',
 		'SMW::SQLStore::BeforeDataUpdateComplete'
 	];


### PR DESCRIPTION
This PR is made in reference to: #

This PR addresses or contains:

- Actively remove reference of the static `Hooks::run` from the SMW code base to avoid global state that leaks into an instance
- `managing.hooks.md` contains more information
- This PR moves the following hooks into the `HookDispatcher`:
  - `Hooks::run( 'SMW::GetPreferences', [ $user, &$preferences ] );`
  - `Hooks::run( 'SMW::Parser::BeforeMagicWordsFinder', [ &$magicWords ] );`
  - `Hooks::run( 'SMW::Parser::AfterLinksProcessingComplete', [ &$text, $annotationProcessor ] );`
  - `Hooks::run( 'SMW::RevisionGuard::IsApprovedRevision', [ $title, $latestRevID ] );`
- This is also done to prepare for changes and avoid interruptions due to thinks like https://phabricator.wikimedia.org/T240307
- Injecting `HookDispatcher` into an instance ensures that we can mock the call and avoid other extensions to manipulate test results while those extensions are active during a test run


This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed

Fixes #