### PR TITLE
Add `SchemaFilter` (`CategoryFilter`, `NamespaceFilter`), refs 4280

### DIFF
--- a/src/Schema/CompartmentIterator.php
+++ b/src/Schema/CompartmentIterator.php
@@ -38,6 +38,10 @@ class CompartmentIterator implements Iterator, Countable, SeekableIterator {
 
 		$data = current( $this->container );
 
+		if ( $data instanceof Compartment ) {
+			return $data;
+		}
+
 		if ( !is_array( $data ) ) {
 			$data = [ $this->position => $data ];
 		}
@@ -66,21 +70,22 @@ class CompartmentIterator implements Iterator, Countable, SeekableIterator {
 
 		foreach ( $data as $section => $value ) {
 
-			if ( is_string( $value ) ) {
-				continue;
+			if ( $value instanceof Compartment && $value->has( $key ) ) {
+				$result[] = $value;
+			} elseif ( is_array( $value ) ) {
+
+				if ( isset( $data[Compartment::ASSOCIATED_SCHEMA] ) ) {
+					$meta[Compartment::ASSOCIATED_SCHEMA] = $data[Compartment::ASSOCIATED_SCHEMA];
+				}
+
+				$meta[Compartment::ASSOCIATED_SECTION] = $section;
+
+				if ( isset( $value[$key] ) ) {
+					$result[] = $value + $meta;
+				}
+
+				$this->search( $key, $value, $meta, $result );
 			}
-
-			if ( isset( $data[Compartment::ASSOCIATED_SCHEMA] ) ) {
-				$meta[Compartment::ASSOCIATED_SCHEMA] = $data[Compartment::ASSOCIATED_SCHEMA];
-			}
-
-			$meta[Compartment::ASSOCIATED_SECTION] = $section;
-
-			if ( isset( $value[$key] ) ) {
-				$result[] = $value + $meta;
-			}
-
-			$this->search( $key, $value, $meta, $result );
 		}
 
 		return $result;

--- a/src/Schema/Filters/CategoryFilter.php
+++ b/src/Schema/Filters/CategoryFilter.php
@@ -1,0 +1,203 @@
+<?php
+
+namespace SMW\Schema\Filters;
+
+use SMW\Schema\SchemaList;
+use SMW\Schema\SchemaFilter;
+use SMW\Schema\CompartmentIterator;
+use SMW\Schema\Compartment;
+use RuntimeException;
+
+/**
+ * @license GNU GPL v2+
+ * @since 3.2
+ *
+ * @author mwjames
+ */
+class CategoryFilter implements SchemaFilter {
+
+	use FilterTrait;
+
+	/**
+	 * @var []
+	 */
+	private $categories = [];
+
+	/**
+	 * @since 3.2
+	 *
+	 * @param string|array|callable $categories
+	 */
+	public function __construct( $categories = '' ) {
+
+		if ( is_array( $categories ) || is_string( $categories ) ) {
+			$this->categories = array_flip( str_replace( ' ', '_', (array)$categories ) );
+		} elseif ( is_callable( $categories ) ) {
+			// Allow categories to be lazy loaded when for example those are
+			// fetched from the DB
+			$this->categories = $categories;
+		} else {
+			throw new RuntimeException( "Requires a string, array, or callable as constructor argument!" );
+		}
+	}
+
+	/**
+	 * @since 3.2
+	 *
+	 * {@inheritDoc}
+	 */
+	public function getName() : string {
+		return 'category';
+	}
+
+	private function match( Compartment $compartment ) {
+
+		if ( is_callable( $this->categories ) ) {
+			$this->categories = array_flip( str_replace( ' ', '_', ( $this->categories )() ) );
+		}
+
+		$conditions = $compartment->get( 'if.category' );
+
+		// No condition to test means it is allowed to remain in the pool
+		// of matches
+		if ( $this->categories === [] && $conditions === null ) {
+			return $this->matches[] = $compartment;
+		}
+
+		$matchedCondition = false;
+
+		if ( is_string( $conditions ) || (is_array( $conditions ) && isset( $conditions[0] ) ) ) {
+			$matchedCondition = $this->matchOneOf( (array)$conditions );
+		} elseif ( isset( $conditions['oneOf'] ) ) {
+			 /**
+			 * `oneOf` matches against only one category
+			 *
+			 *```
+			 * {
+			 *	"if": {
+			 *		"category": { "anyOf": [ "Foo", "Bar" ] }
+			 *	},
+			 *	"then": {
+			 *		...
+			 *	}
+			 *}
+			 *```
+			 */
+			$matchedCondition = $this->matchOneOf( (array)$conditions['oneOf'] );
+		} elseif ( isset( $conditions['anyOf'] ) ) {
+			 /**
+			 * `anyOf` matches against any (one or more) category
+			 *
+			 *```
+			 * {
+			 *	"if": {
+			 *		"category": { "anyOf": [ "Foo", "Bar" ] }
+			 *	},
+			 *	"then": {
+			 *		...
+			 *	}
+			 *}
+			 *```
+			 */
+			$matchedCondition = $this->matchAnyOf( (array)$conditions['anyOf'] );
+		} elseif ( isset( $conditions['allOf'] ) ) {
+			 /**
+			 * `allOf` matches against all categories
+			 *
+			 *```
+			 * {
+			 *	"if": {
+			 *		"category": { "allOf": [ "Foo", "Bar" ] }
+			 *	},
+			 *	"then": {
+			 *		...
+			 *	}
+			 *}
+			 *```
+			 */
+			$matchedCondition = $this->matchAllOf( (array)$conditions['allOf'] );
+		} elseif ( isset( $conditions['not'] ) ) {
+			 /**
+			 * `not` on multiple categories means if "any of" them is validated then
+			 * the condition is fullfilled.
+			 *
+			 *```
+			 * {
+			 *	"if": {
+			 *		"category": { "not": [ "Foo", "Bar" ] }
+			 *	},
+			 *	"then": {
+			 *		...
+			 *	}
+			 *}
+			 *```
+			 */
+			$matchedCondition = !$this->matchAnyOf( (array)$conditions['not'] );
+			unset( $conditions['not'] );
+		}
+
+		if ( $matchedCondition && isset( $conditions['not'] ) ) {
+			 /**
+			 *```
+			 * {
+			 *	"if": {
+			 *		"category": { "not": [ "Foobar" ], "oneOf": [ "Foo", "Bar" ] }
+			 *	},
+			 *	"then": {
+			 *		...
+			 *	}
+			 *}
+			 *```
+			 */
+			$matchedCondition = !$this->matchAnyOf( (array)$conditions['not'] );
+		}
+
+		if ( $matchedCondition === true ) {
+			$this->matches[] = $compartment;
+		}
+	}
+
+	private function matchAllOf( array $categories ) : bool {
+
+		$count = count( $categories );
+
+		foreach ( $categories as $category ) {
+			$category = str_replace( ' ', '_', $category );
+
+			if ( isset( $this->categories[$category] ) ) {
+				$count--;
+			}
+		}
+
+		return $count == 0;
+	}
+
+	private function matchOneOf( array $categories ) : bool {
+
+		$count = 0;
+
+		foreach ( $categories as $category ) {
+			$category = str_replace( ' ', '_', $category );
+
+			if ( isset( $this->categories[$category] ) ) {
+				$count++;
+			}
+		}
+
+		return $count == 1;
+	}
+
+	private function matchAnyOf( array $categories ) : bool {
+
+		foreach ( $categories as $category ) {
+			$category = str_replace( ' ', '_', $category );
+
+			if ( isset( $this->categories[$category] ) ) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+}

--- a/src/Schema/Filters/FilterTrait.php
+++ b/src/Schema/Filters/FilterTrait.php
@@ -1,0 +1,111 @@
+<?php
+
+namespace SMW\Schema\Filters;
+
+use SMW\Schema\SchemaList;
+use SMW\Schema\SchemaFilter;
+use SMW\Schema\CompartmentIterator;
+use SMW\Schema\Compartment;
+
+/**
+ * @private
+ *
+ * @license GNU GPL v2+
+ * @since 3.2
+ *
+ * @author mwjames
+ */
+trait FilterTrait {
+
+	/**
+	 * @var iterable
+	 */
+	private $matches = [];
+
+	/**
+	 * @var SchemaFilter
+	 */
+	private $nodeFilter;
+
+	/**
+	 * @since 3.2
+	 *
+	 * {@inheritDoc}
+	 */
+	public function hasMatches() : bool {
+		return $this->matches !== [];
+	}
+
+	/**
+	 * @since 3.2
+	 *
+	 * {@inheritDoc}
+	 */
+	public function getMatches() : iterable {
+		return $this->matches;
+	}
+
+	/**
+	 * Returns information about which filter was used and how many matches where
+	 * found as part of the filtering process.
+	 *
+	 * @since 3.2
+	 */
+	public function getLog() : iterable {
+
+		$log = [
+			$this->getName() => count( $this->getMatches() )
+		];
+
+		if ( $this->nodeFilter instanceof SchemaFilter ) {
+			$log += $this->nodeFilter->getLog();
+		}
+
+		return $log;
+	}
+
+	/**
+	 * @since 3.2
+	 *
+	 * {@inheritDoc}
+	 */
+	public function setNodeFilter( SchemaFilter $nodeFilter ) {
+		$this->nodeFilter = $nodeFilter;
+	}
+
+	/**
+	 * @since 3.2
+	 *
+	 * {@inheritDoc}
+	 */
+	public function filter( iterable $compartments ) {
+
+		$this->matches = [];
+
+		if ( $compartments instanceof CompartmentIterator ) {
+			foreach ( $compartments->find( 'if' ) as $compartment ) {
+				$this->match( $compartment );
+			}
+		} else {
+			$this->match( $compartments );
+		}
+
+		if ( !$this->nodeFilter instanceof SchemaFilter ) {
+			return;
+		}
+
+		$this->nodeFilter->filter(
+			new CompartmentIterator( $this->matches )
+		);
+
+		$this->matches = $this->nodeFilter->getMatches();
+	}
+
+	/**
+	 * @since 3.2
+	 *
+	 * @param Compartment $compartment
+	 */
+	abstract protected function match( Compartment $compartment );
+
+}

--- a/src/Schema/Filters/NamespaceFilter.php
+++ b/src/Schema/Filters/NamespaceFilter.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace SMW\Schema\Filters;
+
+use SMW\Schema\SchemaList;
+use SMW\Schema\SchemaFilter;
+use SMW\Schema\CompartmentIterator;
+use SMW\Schema\Compartment;
+
+/**
+ * @license GNU GPL v2+
+ * @since 3.2
+ *
+ * @author mwjames
+ */
+class NamespaceFilter implements SchemaFilter {
+
+	use FilterTrait;
+
+	/**
+	 * @var integer
+	 */
+	private $namespace;
+
+	/**
+	 * @since 3.2
+	 *
+	 * @param int|null $namespace
+	 */
+	public function __construct( ?int $namespace ) {
+		$this->namespace = $namespace;
+	}
+
+	/**
+	 * @since 3.2
+	 *
+	 * {@inheritDoc}
+	 */
+	public function getName() : string {
+		return 'namespace';
+	}
+
+	private function match( Compartment $compartment ) {
+
+		$namespaces = $compartment->get( 'if.namespace' );
+
+		if ( $namespaces === null && $this->namespace === null ) {
+			return $this->matches[] = $compartment;
+		}
+
+		if ( $this->matchOneOf( (array)$namespaces ) ) {
+			$this->matches[] = $compartment;
+		}
+	}
+
+	private function matchOneOf( array $namespaces ) {
+
+		if ( $this->namespace === null ) {
+			return false;
+		}
+
+		foreach ( $namespaces as $ns ) {
+
+			if ( is_int( $ns ) && $ns == $this->namespace ) {
+				return true;
+			}
+
+			if ( is_string( $ns ) && defined( $ns ) && ( constant( $ns ) == $this->namespace ) ) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+}

--- a/src/Schema/README.md
+++ b/src/Schema/README.md
@@ -1,8 +1,8 @@
 ## Objective
 
-The objective of the `SMW_NS_SCHEMA` (aka [`smw/schema`][ns:schema]) namespace is to allow for a structured definition of different schemata where types define the interpreter, syntax elements, and constraints.
+The objective of the `SMW_NS_SCHEMA` (aka [`smw/schema`][ns:schema]) namespace provides a structured definition space where different schemata  types can be defined and that independently use a type specific interpreter, syntax elements, and possible constraints.
 
-The namespace expects a JSON format (or if available, YAML as superset of JSON) as input format to ensure that content elements are structured and a `validation_schema` (see [JSON schema][json:schema]) may be assigned to a type to help enforce requirements and constraints for a specific type.
+The namespace expects a JSON format (or if available, YAML as superset of JSON) as input format to ensure that content elements are structured and a `validation_schema` (see [JSON schema][json:schema]) can be assigned to help and enforce requirements and constraints for a specific type.
 
 The following annotation properties are provided to make elements of a schema and its definition discoverable.
 
@@ -38,23 +38,38 @@ In the example above, `FOO_SCHEMA` refers to the type name and any attributes as
 - [`CLASS_CONSTRAINT_SCHEMA`](https://github.com/SemanticMediaWiki/SemanticMediaWiki/blob/master/src/Schema/docs/class.constraint.md)
 - [`PROPERTY_PROFILE_SCHEMA`](https://github.com/SemanticMediaWiki/SemanticMediaWiki/blob/master/src/Schema/docs/property.profile.md)
 
-[json:schema]: http://json-schema.org/
 
 ## Technical notes
 
 <pre>
-SMW\Schema
-│	│
+/src/Schema (SMW\Schema)
+│	├─ Compartment
+│	├─ CompartmentIterator
 │	├─ Schema
 │	├─ SchemaDefinition
 │	├─ SchemaFactory
-│	└─ SchemaValidator
+│	├─ SchemaValidator
+│	├─ SchemaFilterFactory
+│	└─ SchemaFilter
+│		│
+│		/src/Schema/Filters (SMW\Schema\Filters)
+│		├─ CategoryFilter
+│		├─ NamespaceFilter
 │
-SMW\MediaWiki
+/src/MediaWiki (SMW\MediaWiki)
 	└─ Content
 		├─ SchemaContent
 		├─ SchemaContentFormatter
 		└─ SchemaContentHandler
 </pre>
 
+### Filters
+
+[Filter](https://github.com/SemanticMediaWiki/SemanticMediaWiki/blob/master/src/Schema/docs/filter.md) conditions can be defined as aprt of a type to provide means to create conditional requirements.
+
+### Validation
+
+As outlined above, the use of a [JSON schema][json:schema] is an important part of a provided type to ensure that only specific data in an appropriate format can be stored and is validated against a normed vocabulary.
+
 [ns:schema]: https://www.semantic-mediawiki.org/wiki/Help:Schema
+[json:schema]: http://json-schema.org/

--- a/src/Schema/SchemaFactory.php
+++ b/src/Schema/SchemaFactory.php
@@ -205,4 +205,13 @@ class SchemaFactory {
 		);
 	}
 
+	/**
+	 * @since 3.2
+	 *
+	 * @return SchemaFilterFactory
+	 */
+	public function newSchemaFilterFactory() : SchemaFilterFactory {
+		return new SchemaFilterFactory();
+	}
+
 }

--- a/src/Schema/SchemaFilter.php
+++ b/src/Schema/SchemaFilter.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace SMW\Schema;
+
+/**
+ * @license GNU GPL v2+
+ * @since 3.2
+ *
+ * @author mwjames
+ */
+interface SchemaFilter {
+
+	/**
+	 * @since 3.2
+	 *
+	 * @return string
+	 */
+	public function getName() : string;
+
+	/**
+	 * @since 3.2
+	 *
+	 * @return bool
+	 */
+	public function hasMatches() : bool;
+
+	/**
+	 * @since 3.2
+	 *
+	 * @return iterable
+	 */
+	public function getMatches() : iterable;
+
+	/**
+	 * Inject a filter as a node to build a decision tree by chaining together
+	 * different filters so that each "root" returns matches for next node to
+	 * continue.
+	 *
+	 * @since 3.2
+	 *
+	 * @param SchemaFilter $nodeFilter
+	 */
+	public function setNodeFilter( SchemaFilter $nodeFilter );
+
+	/**
+	 * @since 3.2
+	 *
+	 * @param iterable $comparators
+	 */
+	public function filter( iterable $comparators );
+
+}

--- a/src/Schema/SchemaFilterFactory.php
+++ b/src/Schema/SchemaFilterFactory.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace SMW\Schema;
+
+use SMW\Schema\Filters\NamespaceFilter;
+use SMW\Schema\Filters\CategoryFilter;
+use SMW\DIWikiPage;
+
+/**
+ * @license GNU GPL v2+
+ * @since 3.2
+ *
+ * @author mwjames
+ */
+class SchemaFilterFactory {
+
+	/**
+	 * @since 3.2
+	 *
+	 * @param int|null $namespace
+	 *
+	 * @return NamespaceFilter
+	 */
+	public function newNamespaceFilter( ?int $namespace ) : NamespaceFilter {
+		return new NamespaceFilter( $namespace );
+	}
+
+	/**
+	 * @since 3.2
+	 *
+	 * @param string|array|callable $categories
+	 *
+	 * @return CategoryFilter
+	 */
+	public function newCategoryFilter( $categories ) : CategoryFilter {
+		return new CategoryFilter( $categories );
+	}
+
+}

--- a/src/Schema/SchemaList.php
+++ b/src/Schema/SchemaList.php
@@ -101,18 +101,20 @@ class SchemaList implements JsonSerializable {
 	 *
 	 * @return CompartmentIterator
 	 */
-	public function newCompartmentIteratorByKey( $key ) {
+	public function newCompartmentIteratorByKey( string $key ) : CompartmentIterator {
 
 		$list = [];
 
 		foreach ( $this->getList() as $schema ) {
-			if ( $schema instanceof SchemaDefinition && $schema->has( $key ) ) {
-				$list[] = $schema->get( $key ) + [ Compartment::ASSOCIATED_SCHEMA => $schema->getName() ];
-			}
-		}
 
-		if ( $list === [] ) {
-			return new CompartmentIterator();
+			if ( !$schema instanceof SchemaDefinition || !$schema->has( $key ) ) {
+				continue;
+			}
+
+			// Keep the reference to the original schema
+			$list[] = $schema->get( $key ) + [
+				Compartment::ASSOCIATED_SCHEMA => $schema->getName()
+			];
 		}
 
 		return new CompartmentIterator( $list );

--- a/src/Schema/docs/filter.md
+++ b/src/Schema/docs/filter.md
@@ -1,0 +1,115 @@
+Semantic MediaWiki provides a `SchemaFilter` to help developers define specific conditional aspects of a schema.
+
+## Format
+
+The following examples show the expected format for how to define a condition which is tested and hereby permits the code to decide whether it is a true statement or not for those tested values. Aside from the `if` + `keyword` notation, some statements allow the clarify the requirements when more than one value is given or required by using the following expressions `oneOf`, `anyOf`, and `allOf` (borrowing the semantics from  [swagger.io][swagger.io] and [json-schema.org][json-schema.org]).
+
+```
+{
+	"if": {
+		"category": { "oneOf" : [ "Foo", "Bar", "Foobar" ] }
+	},
+	"then": {
+		"follow": "step_1"
+	}
+}
+```
+
+Building compsite filters is possible as well by combining different condition statements as the next example shows where the first condition expects a specific `namespace` while the `category` condition requires "allOf" its conditions to be met so that the entire composite block (which each individual filter) is to be true only when all requirements are fulfilled.
+
+```
+{
+	"if": {
+		"namespace": "NS_HELP",
+		"category": { "allOf" : [ "Foo", "Bar", "Foobar" ] }
+	},
+	"then": {
+		"follow": "step_1"
+	}
+}
+```
+
+## Filters
+
+ The following filter conditionals are provided by default:
+
+- The `category` conditional is implemented in `CategoryFilter`
+- The `namespace` conditional is implemented in `NamespaceFilter`
+
+To be able to use above filters without modifications the following format is expected from a schema that relies on those conditionals. A single filter should be declared with something like:
+
+```
+"rule_name_x": {
+	"if": {
+		"conditional_x": "conditional_value_z"
+	}
+}
+```
+
+While expressing a composite filter should follow:
+
+```
+"rule_name_x": {
+	"if": {
+		"conditional_x_1": "conditional_value_z_1",
+		"conditional_x_2": "conditional_value_z_2"
+	}
+}
+```
+
+It should be noted that it is possible to define a schema without a specific "rule_name_x" but it will create a disadvantage when trying to identify which rule was applied later in a production system when there are dozen of possible rules to be filtered.
+
+Some conditionals (category, namespace, property) can clarify their intention for testing a condition by using extra attributes such as `oneOf`, `anyOf`, `allOf`. For an understanding of the semantics, please consult the [swagger.io][swagger.io] and [json-schema.org][json-schema.org].
+
+## Technical notes
+
+The [`SchemaFilter`](https://github.com/SemanticMediaWiki/SemanticMediaWiki/blob/master/src/Schema/SchemaFilter.php) describes an interface for a specific filter implementation.
+
+As with the example above, different filters can be combined to narrow the match pool of values to be tested against. To support composite filters any filter can be attached to another as a so called "node" filter to build something similar to a [decision tree][decision-tree] that is recursively traversed hereby tests on matches left from the previous filter.
+
+```php
+// Requirements to be tested against
+$namespace = NS_MAIN;
+$subject = '';
+
+$schemaFactory = new SchemaFactory();
+$schemaFilterFactory = $schemaFactory->newSchemaFilterFactory();
+
+// Find a schema/list by type and which can included different pages
+// from MediaWiki where the type is used
+$schemaList = $schemaFactory->newSchemaFinder()->getSchemaListByType( 'SOME_SCHEMA' );
+
+$callback = function() use( $subject ) {
+	return $this->categoryLookup->findCategories(
+		$subject
+	);
+};
+
+$categoryFilter = $schemaFilterFactory->newCategoryFilter(
+	// Expensive fetch, lazy-load when required due to DB lookup
+	$callback
+);
+
+$namespaceFilter = $schemaFilterFactory->newNamespaceFilter(
+	$namespace
+);
+
+// As with a decision tree attach an additional filter as "Node" filter
+// so that matches can be further restricted by the node filter
+$namespaceFilter->setNodeFilter(
+	$categoryFilter
+);
+
+$namespaceFilter->filter(
+	$schemaList->newCompartmentIteratorByKey( 'some_rules' )
+);
+
+if ( $namespaceFilter->hasMatches() ) {
+	// Act on those compartments that matched the condition(s)
+	$matches = $namespaceFilter->getMatches();
+}
+```
+
+[swagger.io]: https://swagger.io/docs/specification/data-models/oneof-anyof-allof-not
+[json-schema.org]: https://json-schema.org/understanding-json-schema/reference/combining.html
+[decision-tree]: https://en.wikipedia.org/wiki/Decision_tree

--- a/tests/phpunit/Fixtures/Schema/fake_namespace_category_action_rule_schema_4.json
+++ b/tests/phpunit/Fixtures/Schema/fake_namespace_category_action_rule_schema_4.json
@@ -1,0 +1,42 @@
+{
+	"type": "FAKE_TYPE",
+	"filter_rules": {
+		"rule_4_1": {
+			"if": {
+				"action": [ "edit", "view" ],
+				"namespace": "NS_HELP",
+				"category": [ "action-4-a", "action-4-b" ]
+			},
+			"then": {
+				"action": "4_1"
+			}
+		},
+		"rule_4_2": {
+			"if": {
+				"action": [ "edit" ],
+				"namespace": [ "NS_MAIN", "NS_HELP" ],
+				"category": { "oneOf" : [ "action-4-a", "action-4-b" ] }
+			},
+			"then": {
+				"action": "4_2"
+			}
+		},
+		"rule_4_3": {
+			"if": {
+				"action": [ "view", "delete" ],
+				"category": "action-4-a"
+			},
+			"then": {
+				"action": "4_3"
+			}
+		},
+		"rule_4_4": {
+			"if": {
+				"action": "delete"
+			},
+			"then": {
+				"action": "4_4"
+			}
+		}
+	}
+}

--- a/tests/phpunit/Fixtures/Schema/fake_namespace_category_rule_schema_1.json
+++ b/tests/phpunit/Fixtures/Schema/fake_namespace_category_rule_schema_1.json
@@ -1,0 +1,30 @@
+{
+	"type": "FAKE_TYPE",
+	"filter_rules": {
+		"rule_1_1": {
+			"if": {
+				"namespace": "NS_MAIN"
+			},
+			"then": {
+				"action": "1_1"
+			}
+		},
+		"rule_1_2": {
+			"if": {
+				"namespace": [ "NS_MAIN", "NS_FILE" ]
+			},
+			"then": {
+				"action": "1_2"
+			}
+		},
+		"rule_1_3": {
+			"if": {
+				"namespace": [ "NS_MAIN", "NS_FILE" ],
+				"category": "Foo"
+			},
+			"then": {
+				"action": "1_3"
+			}
+		}
+	}
+}

--- a/tests/phpunit/Fixtures/Schema/fake_namespace_category_rule_schema_2.json
+++ b/tests/phpunit/Fixtures/Schema/fake_namespace_category_rule_schema_2.json
@@ -1,0 +1,39 @@
+{
+	"type": "FAKE_TYPE",
+	"filter_rules": {
+		"rule_2_1": {
+			"if": {
+				"namespace": "NS_HELP",
+				"category": [ "Foo", "Bar" ]
+			},
+			"then": {
+				"action": "2_1"
+			}
+		},
+		"rule_2_2": {
+			"if": {
+				"namespace": [ "NS_MAIN", "NS_HELP" ],
+				"category": { "oneOf" : [ "Foo", "Bar" ] }
+			},
+			"then": {
+				"action": "2_2"
+			}
+		},
+		"rule_2_3": {
+			"if": {
+				"category": "Foo"
+			},
+			"then": {
+				"action": "2_3"
+			}
+		},
+		"rule_2_4": {
+			"if": {
+				"category": "Brown fox"
+			},
+			"then": {
+				"action": "2_4"
+			}
+		}
+	}
+}

--- a/tests/phpunit/Fixtures/Schema/fake_namespace_category_unnamed_rule_schema_3.json
+++ b/tests/phpunit/Fixtures/Schema/fake_namespace_category_unnamed_rule_schema_3.json
@@ -1,0 +1,49 @@
+{
+	"type": "FAKE_TYPE",
+	"filter_rules": [
+		{
+			"if": {
+				"namespace": "NS_HELP",
+				"category": [ "Foo", "Bar" ]
+			},
+			"then": {
+				"action": "3_1"
+			}
+		},
+		{
+			"if": {
+				"namespace": [ "NS_MAIN", "NS_HELP" ],
+				"category": [ "Foo", "Bar" ]
+			},
+			"then": {
+				"action": "3_2"
+			}
+		},
+		{
+			"if": {
+				"category": "Foo"
+			},
+			"then": {
+				"action": "3_3"
+			}
+		},
+		{
+			"if": {
+				"namespace": "NS_TEMPLATE",
+				"category": { "allOf" : [ "Foo", "Bar", "Foobar-1" ] }
+			},
+			"then": {
+				"action": "3_4"
+			}
+		},
+		{
+			"if": {
+				"namespace": "NS_TEMPLATE",
+				"category": { "allOf" : [ "Foo", "Bar", "Foobar-2" ] }
+			},
+			"then": {
+				"action": "3_5"
+			}
+		}
+	]
+}

--- a/tests/phpunit/Integration/Schema/FilteredSchemaListTest.php
+++ b/tests/phpunit/Integration/Schema/FilteredSchemaListTest.php
@@ -1,0 +1,212 @@
+<?php
+
+namespace SMW\Tests\Integration\Schema;
+
+use SMW\Schema\SchemaDefinition;
+use SMW\Schema\Compartment;
+use SMW\Schema\SchemaList;
+use SMW\Schema\SchemaFilterFactory;
+use SMW\Schema\Filters\CategoryFilter;
+use SMW\DIWikiPage;
+use SMW\DIProperty;
+
+/**
+ * @group semantic-mediawiki-integration
+ * @group medium
+ *
+ * @license GNU GPL v2+
+ * @since 3.2
+ *
+ * @author mwjames
+ */
+class FilteredSchemaListTest extends \PHPUnit_Framework_TestCase {
+
+	private $schemaList;
+
+	protected function setUp() {
+		parent::setUp();
+
+		$this->schemaList = new SchemaList( [] );
+
+		$schemata = [
+			'fake_namespace_category_rule_schema_1',
+			'fake_namespace_category_rule_schema_2',
+			'fake_namespace_category_unnamed_rule_schema_3',
+			'fake_namespace_category_action_rule_schema_4'
+
+		];
+
+		foreach ( $schemata as $name ) {
+
+			$schema = new SchemaDefinition(
+				$name,
+				json_decode( file_get_contents( SMW_PHPUNIT_DIR . "/Fixtures/Schema/$name.json" ), true )
+			);
+
+			$this->schemaList->add( $schema );
+		}
+	}
+
+	/**
+	 * @dataProvider namespaceCategoryFilterProvider
+	 */
+	public function testNamespaceCategoryFilter( $ns, $categories, $expected ) {
+
+		$compartments = $this->schemaList->newCompartmentIteratorByKey(
+			'filter_rules'
+		);
+
+		$schemaFilterFactory = new SchemaFilterFactory();
+
+		$categoryFilter = $schemaFilterFactory->newCategoryFilter(
+			$categories
+		);
+
+		$namespaceFilter = $schemaFilterFactory->newNamespaceFilter(
+			$ns
+		);
+
+		$namespaceFilter->setNodeFilter(
+			$categoryFilter
+		);
+
+		$namespaceFilter->filter( $compartments );
+		$sections = [];
+
+		foreach ( $namespaceFilter->getMatches() as $compartment ) {
+			$sections[] = $compartment->get( Compartment::ASSOCIATED_SECTION );
+		}
+
+		$this->assertEquals(
+			$expected,
+			$sections
+		);
+	}
+
+	public function testCategoryFilter() {
+
+		$expected = [
+			"if" => [ "category" => "Brown fox" ], "then" => [ "action" => "2_4" ],
+			'___assoc_schema'  => 'fake namespace category rule schema 2',
+			'___assoc_section' => 'rule_2_4'
+		];
+
+		$compartments = $this->schemaList->newCompartmentIteratorByKey(
+			'filter_rules'
+		);
+
+		$schemaFilterFactory = new SchemaFilterFactory();
+
+		$categoryFilter = $schemaFilterFactory->newCategoryFilter(
+			[ "Brown fox" ]
+		);
+
+		$categoryFilter->filter( $compartments );
+		$matches = $categoryFilter->getMatches();
+
+		$this->assertEquals(
+			$expected,
+			json_decode( $matches[0], true )
+		);
+	}
+
+	public function namespaceCategoryFilterProvider() {
+
+		yield "NS_MAIN" => [
+			NS_MAIN,
+			[],
+			[ 'rule_1_1', 'rule_1_2' ]
+		];
+
+		yield "NS_MAIN, category Foo" => [
+			NS_MAIN,
+			[ 'Foo' ],
+			[ 'rule_1_3', 'rule_2_2', 1 ]
+		];
+
+		/**
+		 * {
+		 *	"if": {
+		 *		"category": "Foo"
+		 *	},
+		 *	"then": {
+		 *		"action": "2_3"
+		 *	}
+		 *},
+		 */
+		yield "category Foo" => [
+			null,
+			[ 'Foo' ],
+			[ 'rule_2_3', 2 ]
+		];
+
+		yield "category Foo, Bar" => [
+			null,
+			[ 'Foo', 'Bar' ],
+			[ 'rule_2_3', 2 /* unnamed_rule_schema_3 */ ]
+		];
+
+		/**
+		 * {
+		 *	"if": {
+		 *		"namespace": "NS_TEMPLATE",
+		 *		"category": { "allOf" : [ "Foo", "Bar", "Foobar-1" ] }
+		 *	},
+		 *	"then": {
+		 *		"action": "3_4"
+		 *	}
+		 *},
+		 */
+		yield "category Foo, Bar, Foobar-1" => [
+			NS_TEMPLATE,
+			[ 'Foo', 'Bar', 'Foobar-1' ],
+			[ 3 /* unnamed_rule_schema_3 */ ]
+		];
+
+	}
+
+	public function multi2ChainFilterProvider() {
+
+		yield "NS_MAIN" => [
+			NS_MAIN,
+			[],
+			2
+		];
+
+		yield "NS_MAIN, category Foo" => [
+			NS_MAIN,
+			[ 'Foo' ],
+			6
+		];
+
+		/**
+		 * {
+		 *	"if": {
+		 *		"category": "Foo"
+		 *	},
+		 *	"then": {
+		 *		"action": "3_3"
+		 *	}
+		 *},
+		 */
+		yield "category Foo" => [
+			null,
+			[ 'Foo' ],
+			2
+		];
+
+		yield "category Foo, Bar" => [
+			null,
+			[ 'Foo', 'Bar' ],
+			2
+		];
+
+
+		yield "category Foo, Bar, Foobar" => [
+			NS_TEMPLATE,
+			[ 'Foo', 'Bar', 'Foobar-1' ],
+			3
+		];
+	}
+
+}

--- a/tests/phpunit/Unit/Schema/Filters/CategoryFilterTest.php
+++ b/tests/phpunit/Unit/Schema/Filters/CategoryFilterTest.php
@@ -1,0 +1,381 @@
+<?php
+
+namespace SMW\Tests\Schema\Filters;
+
+use SMW\Schema\Filters\CategoryFilter;
+use SMW\Schema\Compartment;
+use SMW\Schema\CompartmentIterator;
+
+/**
+ * @covers \SMW\Schema\Filters\CategoryFilter
+ * @group semantic-mediawiki
+ *
+ * @license GNU GPL v2+
+ * @since 3.2
+ *
+ * @author mwjames
+ */
+class CategoryFilterTest extends \PHPUnit_Framework_TestCase {
+
+	public function testCanConstruct() {
+
+		$this->assertInstanceOf(
+			CategoryFilter::class,
+			new CategoryFilter()
+		);
+	}
+
+	public function testGetName() {
+
+		$instance = new CategoryFilter();
+
+		$this->assertEquals(
+			'category',
+			$instance->getName()
+		);
+	}
+
+	public function testIfCondition() {
+
+		$compartment = $this->getMockBuilder( '\SMW\Schema\Compartment' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$compartment->expects( $this->once() )
+			->method( 'get' )
+			->with(	$this->equalTo( 'if.category' ) );
+
+		$instance = new CategoryFilter();
+		$instance->filter( $compartment );
+	}
+
+	/**
+	 * @dataProvider categoryFilterProvider
+	 */
+	public function testHasMatches_Compartment( $categories, $compartment, $expected ) {
+
+		$instance = new CategoryFilter(
+			$categories
+		);
+
+		$instance->filter(
+			new Compartment( $compartment )
+		);
+
+		$this->assertEquals(
+			$expected,
+			$instance->hasMatches()
+		);
+	}
+
+	/**
+	 * @dataProvider categoryFilterProvider
+	 */
+	public function testHasMatches_CompartmentIterator( $categories, $compartment, $expected ) {
+
+		$instance = new CategoryFilter(
+			$categories
+		);
+
+		$instance->filter(
+			new CompartmentIterator( [ $compartment ] )
+		);
+
+		$this->assertEquals(
+			$expected,
+			$instance->hasMatches()
+		);
+	}
+
+	public function categoryFilterProvider() {
+
+		yield 'oneOf.1: single one_of' => [
+			[ 'Foo', 'Bar' ],
+			[
+				'if' => [
+					'category' => 'Foo'
+				]
+			],
+			true
+		];
+
+		yield 'oneOf.2: single one_of, underscore condition' => [
+			[ 'Foo bar', 'Bar' ],
+			[
+				'if' => [
+					'category' => 'Foo_bar'
+				]
+			],
+			true
+		];
+
+		yield 'oneOf.3: single one_of, underscore validation value' => [
+			[ 'Foo_bar', 'Bar' ],
+			[
+				'if' => [
+					'category' => 'Foo bar'
+				]
+			],
+			true
+		];
+
+		yield 'oneOf.4: empty categories' => [
+			[],
+			[
+				'if' => [
+					'category' => 'Foo'
+				]
+			],
+			false
+		];
+
+		yield 'oneOf.5: single no_match' => [
+			[ 'Foo', 'Bar' ],
+			[
+				'if' => [
+					'category' => 'no_match'
+				]
+			],
+			false
+		];
+
+		yield 'oneOf.6: one_of matches' => [
+			[ 'Foo', 'Bar' ],
+			[
+				'if' => [
+					'category' => [ 'oneOf' => [ 'Foo', 'Foobar' ] ]
+				]
+			],
+			true
+		];
+
+		yield 'oneOf.7: one_of fails because more than one matches' => [
+			[ 'Foo', 'Bar' ],
+			[
+				'if' => [
+					'category' => [ 'oneOf' => [ 'Foo', 'Bar' ] ]
+				]
+			],
+			false
+		];
+
+		yield 'oneOf.8: one_of fails because both match (onyl one is allowed to match)' => [
+			[ 'Foo', 'Bar' ],
+			[
+				'if' => [
+					'category' => [ 'oneOf' => [ 'Foo', 'Bar', 'Foobar' ] ]
+				]
+			],
+			false
+		];
+
+		// anyOf
+
+		yield 'anyOf.1: anyOf does match because one or more match' => [
+			[ 'Foo', 'Bar' ],
+			[
+				'if' => [
+					'category' => [ 'anyOf' => [ 'Foo', 'Bar', 'Foobar' ] ]
+				]
+			],
+			true
+		];
+
+		// allOf
+
+		yield 'allOf.1: all_of matched' => [
+			[ 'Foo', 'Bar' ],
+			[
+				'if' => [
+					'category' => [ 'allOf' => [ 'Foo', 'Bar' ] ]
+				]
+			],
+			true
+		];
+
+		yield 'allOf.2: all_of failed' => [
+			[ 'Foo', 'Bar' ],
+			[
+				'if' => [
+					'category' => [ 'allOf' => [ 'Foo', 'Foobar' ] ]
+				]
+			],
+			false
+		];
+
+		// not
+
+		yield 'not.1: not single, matches `not` condition' => [
+			[ 'Foo' ],
+			[
+				'if' => [
+					'category' => [ 'not' => [ 'Foo1', 'Foo2' ] ]
+				]
+			],
+			true
+		];
+
+		yield 'not.2: not multiple, matches `not` condition' => [
+			[ 'Foo', 'Bar' ],
+			[
+				'if' => [
+					'category' => [ 'not' => [ 'Foo1', 'Foo2' ] ]
+				]
+			],
+			true
+		];
+
+		yield 'not.3: not single, matches `not` condition' => [
+			[ 'Foo', 'Bar' ],
+			[
+				'if' => [
+					'category' => [ 'not' => [ 'Foo1' ] ]
+				]
+			],
+			true
+		];
+
+		yield 'not.4: not multiple, fails because `not` matches one' => [
+			[ 'Foo', 'Bar' ],
+			[
+				'if' => [
+					'category' => [ 'not' => [ 'Foo1', 'Bar' ] ]
+				]
+			],
+			false
+		];
+
+		yield 'not.5: not multiple, fails because `not` matches both' => [
+			[ 'Foo', 'Bar' ],
+			[
+				'if' => [
+					'category' => [ 'not' => [ 'Foo', 'Bar' ] ]
+				]
+			],
+			false
+		];
+
+		yield 'not.6: not single, fails because `not` matches one' => [
+			[ 'Foo', 'Bar' ],
+			[
+				'if' => [
+					'category' => [ 'not' => 'Foo' ]
+				]
+			],
+			false
+		];
+
+		// combined
+
+		yield 'not.oneOf.1: not, oneOf combined, false because `not` is matched' => [
+			[ 'Foo', 'Bar', 'Foobar' ],
+			[
+				'if' => [
+					'category' => [ 'not' => 'Foobar', 'oneOf' => [ 'Foo', 'Bar' ] ]
+				]
+			],
+			false
+		];
+
+		yield 'not.oneOf.2: not, oneOf combined, false because `oneOf` does not match' => [
+			[ 'Foo', 'Bar', 'Foobar' ],
+			[
+				'if' => [
+					'category' => [ 'not' => 'Foobar', 'oneOf' => [ 'Foo_1', 'Bar_2' ] ]
+				]
+			],
+			false
+		];
+
+		yield 'not.oneOf.3: not, oneOf combined, false because `oneOf` does not match' => [
+			[ 'Foo', 'Bar', 'Foobar_1' ],
+			[
+				'if' => [
+					'category' => [ 'not' => 'Foobar', 'oneOf' => [ 'Foo_1', 'Bar_2' ] ]
+				]
+			],
+			false
+		];
+
+		yield 'not.oneOf.4: not, oneOf combined, truthy because `oneOf` matches one and is not `Foobar`' => [
+			[ 'Foo', 'Bar', 'Foobar_1' ],
+			[
+				'if' => [
+					'category' => [ 'not' => 'Foobar', 'oneOf' => [ 'Foo', 'Bar_2' ] ]
+				]
+			],
+			true
+		];
+
+		yield 'not.oneOf.5: not, oneOf combined, truthy because `oneOf` matches one and is not `Foobar`' => [
+			[ 'Foo', 'Bar', 'Foobar_1' ],
+			[
+				'if' => [
+					'category' => [ 'oneOf' => [ 'Foo', 'Bar_2' ], 'not' => 'Foobar' ]
+				]
+			],
+			true
+		];
+
+		yield 'not.allOf.1: not, allOf combined, false because `allOf` fails' => [
+			[ 'Foo', 'Bar', 'Foobar_1' ],
+			[
+				'if' => [
+					'category' => [ 'not' => 'Foobar', 'allOf' => [ 'Foo', 'Bar_2' ] ]
+				]
+			],
+			false
+		];
+
+		yield 'not.allOf.2: not, allOf combined, false because `allOf` fails' => [
+			[ 'Foo', 'Bar', 'Foobar_1' ],
+			[
+				'if' => [
+					'category' => [ 'allOf' => [ 'Foo', 'Bar_2' ], 'not' => 'Foobar' ]
+				]
+			],
+			false
+		];
+
+		yield 'not.allOf.3: not, allOf combined, true' => [
+			[ 'Foo', 'Bar', 'Foobar_1' ],
+			[
+				'if' => [
+					'category' => [ 'allOf' => [ 'Foo', 'Bar', 'Foobar_1' ], 'not' => 'Foobar' ]
+				]
+			],
+			true
+		];
+
+		yield 'not.anyOf.1: not, oneOf combined, truthy because `not` is not matched' => [
+			[ 'Foo', 'Bar', 'Foobar' ],
+			[
+				'if' => [
+					'category' => [ 'not' => 'Foobar_1', 'anyOf' => [ 'Foo', 'Bar' ] ]
+				]
+			],
+			true
+		];
+
+		yield 'not.anyOf.2: not, oneOf combined, truthy because `not` is not matched' => [
+			[ 'Foo', 'Bar', 'Foobar' ],
+			[
+				'if' => [
+					'category' => [ 'anyOf' => [ 'Foo', 'Bar' ], 'not' => 'Foobar_1' ]
+				]
+			],
+			true
+		];
+
+		yield 'not.anyOf.3: not, oneOf combined, fails because `not` is not matched' => [
+			[ 'Foo', 'Bar', 'Foobar' ],
+			[
+				'if' => [
+					'category' => [ 'anyOf' => [ 'Foo', 'Bar' ], 'not' => 'Foobar' ]
+				]
+			],
+			false
+		];
+	}
+
+}

--- a/tests/phpunit/Unit/Schema/Filters/FilterTraitTest.php
+++ b/tests/phpunit/Unit/Schema/Filters/FilterTraitTest.php
@@ -1,0 +1,85 @@
+<?php
+
+namespace SMW\Tests\Schema\Filters;
+
+use SMW\Schema\Filters\FilterTrait;
+
+/**
+ * @covers \SMW\Schema\Filters\FilterTrait
+ * @group semantic-mediawiki
+ *
+ * @license GNU GPL v2+
+ * @since 3.2
+ *
+ * @author mwjames
+ */
+class FilterTraitTest extends \PHPUnit_Framework_TestCase {
+
+	public function testHasMatches() {
+
+		$instance = $this->newFilterTrait();
+
+		$this->assertInternalType(
+			'bool',
+			$instance->hasMatches()
+		);
+	}
+
+	public function testGetMatches() {
+
+		$instance = $this->newFilterTrait();
+
+		$this->assertInternalType(
+			'array',
+			$instance->getMatches()
+		);
+	}
+
+	public function testGetLog() {
+
+		$instance = $this->newFilterTrait();
+
+		$this->assertInternalType(
+			'array',
+			$instance->getLog()
+		);
+	}
+
+	public function testSetNodeFilter() {
+
+		$compartment = $this->getMockBuilder( '\SMW\Schema\Compartment' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$schemaFilter = $this->getMockBuilder( '\SMW\Schema\SchemaFilter' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$schemaFilter->expects( $this->once() )
+			->method( 'filter' );
+
+		$instance = $this->newFilterTrait();
+
+		$instance->setNodeFilter(
+			$schemaFilter
+		);
+
+		$instance->filter( $compartment );
+	}
+
+	private function newFilterTrait() {
+		return new class() {
+
+			use FilterTrait;
+
+			public function getName() {
+				return 'Foo';
+			}
+
+			protected function match( \SMW\Schema\Compartment $compartment ) {
+
+			}
+		};
+	}
+
+}

--- a/tests/phpunit/Unit/Schema/Filters/NamespaceFilterTest.php
+++ b/tests/phpunit/Unit/Schema/Filters/NamespaceFilterTest.php
@@ -1,0 +1,144 @@
+<?php
+
+namespace SMW\Tests\Schema\Filters;
+
+use SMW\Schema\Filters\NamespaceFilter;
+use SMW\Schema\Compartment;
+use SMW\Schema\CompartmentIterator;
+
+/**
+ * @covers \SMW\Schema\Filters\NamespaceFilter
+ * @group semantic-mediawiki
+ *
+ * @license GNU GPL v2+
+ * @since 3.2
+ *
+ * @author mwjames
+ */
+class NamespaceFilterTest extends \PHPUnit_Framework_TestCase {
+
+	public function testCanConstruct() {
+
+		$this->assertInstanceOf(
+			NamespaceFilter::class,
+			new NamespaceFilter( null )
+		);
+	}
+
+	public function testGetName() {
+
+		$instance = new NamespaceFilter( null );
+
+		$this->assertEquals(
+			'namespace',
+			$instance->getName()
+		);
+	}
+
+	public function testIfCondition() {
+
+		$compartment = $this->getMockBuilder( '\SMW\Schema\Compartment' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$compartment->expects( $this->once() )
+			->method( 'get' )
+			->with(	$this->equalTo( 'if.namespace' ) );
+
+		$instance = new NamespaceFilter( null );
+		$instance->filter( $compartment );
+	}
+
+	/**
+	 * @dataProvider namespaceFilterProvider
+	 */
+	public function testHasMatches_Compartment( $ns, $compartment, $expected ) {
+
+		$instance = new NamespaceFilter(
+			$ns
+		);
+
+		$instance->filter(
+			new Compartment( $compartment )
+		);
+
+		$this->assertEquals(
+			$expected,
+			$instance->hasMatches()
+		);
+	}
+
+	/**
+	 * @dataProvider namespaceFilterProvider
+	 */
+	public function testHasMatches_CompartmentIterator( $ns, $compartment, $expected ) {
+
+		$instance = new NamespaceFilter(
+			$ns
+		);
+
+		$instance->filter(
+			new CompartmentIterator( [ $compartment ] )
+		);
+
+		$this->assertEquals(
+			$expected,
+			$instance->hasMatches()
+		);
+	}
+
+	public function namespaceFilterProvider() {
+
+		yield 'oneOf.1: single one_of' => [
+			NS_MAIN,
+			[
+				'if' => [
+					'namespace' => 'NS_MAIN'
+				]
+			],
+			true
+		];
+
+		yield 'oneOf.2: single one_of no_match' => [
+			NS_HELP,
+			[
+				'if' => [
+					'namespace' => 'NS_MAIN'
+				]
+			],
+			false
+		];
+
+		yield 'oneOf.3: multiple one_of' => [
+			NS_HELP,
+			[
+				'if' => [
+					'namespace' => [ 'NS_MAIN', 'NS_HELP' ]
+				]
+			],
+			true
+		];
+
+		yield 'oneOf.4: multiple one_of no_match' => [
+			NS_FILE,
+			[
+				'if' => [
+					'namespace' => [ 'NS_MAIN', 'NS_HELP' ]
+				]
+			],
+			false
+		];
+
+		yield 'oneOf.5: multiple one_of match, mixed with integer' => [
+			NS_FILE,
+			[
+				'if' => [
+					'namespace' => [ 'NS_MAIN', NS_FILE ]
+				]
+			],
+			true
+		];
+
+	}
+
+}

--- a/tests/phpunit/Unit/Schema/SchemaFactoryTest.php
+++ b/tests/phpunit/Unit/Schema/SchemaFactoryTest.php
@@ -78,6 +78,16 @@ class SchemaFactoryTest extends \PHPUnit_Framework_TestCase {
 		);
 	}
 
+	public function testCanConstructSchemaFilterFactory() {
+
+		$instance = new SchemaFactory();
+
+		$this->assertInstanceof(
+			'\SMW\Schema\SchemaFilterFactory',
+			$instance->newSchemaFilterFactory()
+		);
+	}
+
 	public function testIsRegisteredType() {
 
 		$instance = new SchemaFactory(

--- a/tests/phpunit/Unit/Schema/SchemaFilterFactoryTest.php
+++ b/tests/phpunit/Unit/Schema/SchemaFilterFactoryTest.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace SMW\Tests\Schema;
+
+use SMW\Schema\SchemaFilterFactory;
+use SMW\Tests\PHPUnitCompat;
+use SMW\Tests\TestEnvironment;
+
+/**
+ * @covers \SMW\Schema\SchemaFilterFactory
+ * @group semantic-mediawiki
+ *
+ * @license GNU GPL v2+
+ * @since 3.2
+ *
+ * @author mwjames
+ */
+class SchemaFilterFactoryTest extends \PHPUnit_Framework_TestCase {
+
+	public function testCanConstructNamespaceFilter() {
+
+		$instance = new SchemaFilterFactory();
+
+		$this->assertInstanceof(
+			'\SMW\Schema\Filters\NamespaceFilter',
+			$instance->newNamespaceFilter( NS_MAIN )
+		);
+	}
+
+	public function testCanConstructCategoryFilter() {
+
+		$instance = new SchemaFilterFactory();
+
+		$this->assertInstanceof(
+			'\SMW\Schema\Filters\CategoryFilter',
+			$instance->newCategoryFilter( 'Foo' )
+		);
+	}
+
+}


### PR DESCRIPTION
This PR is made in reference to: #4280

This PR addresses or contains:

- Ground work for #4280 to allow to define filter conditions (see below) in a schema and case it supports the filter notation
- Implements `CategoryFilter` and `NamespaceFilter`
- `filter.md` contains details about the use those filters 

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed

## Example

```
{
	"if": {
		"namespace": "NS_HELP",
		"category": { "allOf" : [ "Foo", "Bar", "Foobar" ] }
	},
	"then": {
		"follow": "step_1"
	}
}
```
```
$compartments = $this->schemaList->newCompartmentIteratorByKey(
	'filter_rules'
);

$schemaFilterFactory = new SchemaFilterFactory();

$categoryFilter = $schemaFilterFactory->newCategoryFilter(
	$categories
);

$namespaceFilter = $schemaFilterFactory->newNamespaceFilter(
	$ns
);

$namespaceFilter->setNodeFilter(
	$categoryFilter
);

$namespaceFilter->filter( $compartments );
```