### PR TITLE
Hook `ParserAfterTidyPropertyAnnotationComplete`

### DIFF
--- a/docs/technical/hooks.md
+++ b/docs/technical/hooks.md
@@ -47,6 +47,7 @@ Implementing a hook should be made in consideration of the expected performance 
 
 - [`SMW::Parser::BeforeMagicWordsFinder`][hook.parser.beforemagicwordsfinder] to extend the magic words list that the `InTextAnnotationParser` should inspect on a given text section
 - [`SMW::Parser::AfterLinksProcessingComplete`][hook.parser.afterlinksprocessingcomplete] to add additional annotation parsing after `InTextAnnotationParser` has finished the processing of standard annotation links (e.g. `[[...::...]]`)
+- [`SMW::Parser::ParserAfterTidyPropertyAnnotationComplete`][hook.parser.parseraftertidypropertyannotationcomplete] allows to add additional `PropertyAnnotator` as part of the `ParserAfterTidy` after default annotators have been executed
 - [`SMW::FileUpload::BeforeUpdate`][hook.fileupload.beforeupdate] to add extra annotations on a `FileUpload` event before the `Store` update is triggered
 - [`SMW::RevisionGuard::ChangeRevision`][hook.revisionguard.changerevision] to forcibly change a revision used during content parsing
 - [`SMW::RevisionGuard::ChangeRevisionID`][hook.revisionguard.changerevisionid] to forcibly change the revision ID as in case of the `Factbox` when building the content.
@@ -90,6 +91,7 @@ Implementing a hook should be made in consideration of the expected performance 
 [hook.sqlstore.beforechangetitlecomplete]:https://github.com/SemanticMediaWiki/SemanticMediaWiki/blob/master/docs/technical/hooks/hook.sqlstore.beforechangetitlecomplete.md
 [hook.parser.beforemagicwordsfinder]:https://github.com/SemanticMediaWiki/SemanticMediaWiki/blob/master/docs/technical/hooks/hook.parser.beforemagicwordsfinder.md
 [hook.parser.afterlinksprocessingcomplete]:https://github.com/SemanticMediaWiki/SemanticMediaWiki/blob/master/docs/technical/hooks/hook.parser.afterlinksprocessingcomplete.md
+[hook.parser.parseraftertidypropertyannotationcomplete]:https://github.com/SemanticMediaWiki/SemanticMediaWiki/blob/master/docs/technical/hooks/hook.parser.parseraftertidypropertyannotationcomplete.md
 [hook.sqlstore.beforedatarebuildjobinserts]:https://github.com/SemanticMediaWiki/SemanticMediaWiki/blob/master/docs/technical/hooks/hook.sqlstore.beforedatarebuildjobinserts.md
 [hook.sqlstore.addcustomfixedpropertytables]:https://github.com/SemanticMediaWiki/SemanticMediaWiki/blob/master/docs/technical/hooks/hook.sqlstore.addcustomfixedpropertytables.md
 [hook.browse.afterincomingpropertieslookupcomplete]:https://github.com/SemanticMediaWiki/SemanticMediaWiki/blob/master/docs/technical/hooks/hook.browse.afterincomingpropertieslookupcomplete.md

--- a/docs/technical/hooks/hook.parser.parseraftertidypropertyannotationcomplete.md
+++ b/docs/technical/hooks/hook.parser.parseraftertidypropertyannotationcomplete.md
@@ -1,0 +1,24 @@
+## SMW::Parser::ParserAfterTidyPropertyAnnotationComplete
+
+* Since: 3.2
+* Description: Provides a method to add additional `PropertyAnnotator` as part of the `ParserAfterTidy` after default annotators have been executed
+* Reference class: [`ParserAfterTidy.php`][ParserAfterTidy.php]
+
+### Signature
+
+```php
+use Hooks;
+
+Hooks::register( 'SMW::Parser::ParserAfterTidyPropertyAnnotationComplete', function( $propertyAnnotator, $parserOutput ) {
+
+	$fooAnnotator = new FooAnnotator(
+		$propertyAnnotator
+	);
+
+	$fooAnnotator->addAnnotation();
+
+	return true;
+} );
+```
+
+[ParserAfterTidy.php]:https://github.com/SemanticMediaWiki/SemanticMediaWiki/blob/master/src/MediaWiki/Hooks/ParserAfterTidy.php

--- a/src/MediaWiki/HookDispatcher.php
+++ b/src/MediaWiki/HookDispatcher.php
@@ -4,6 +4,7 @@ namespace SMW\MediaWiki;
 
 use Hooks;
 use SMW\Parser\AnnotationProcessor;
+use SMW\Property\Annotator as PropertyAnnotator;
 
 /**
  * @private
@@ -55,6 +56,17 @@ class HookDispatcher {
 	 */
 	public function onAfterLinksProcessingComplete( string &$text, AnnotationProcessor $annotationProcessor ) {
 		Hooks::run( 'SMW::Parser::AfterLinksProcessingComplete', [ &$text, $annotationProcessor ] );
+	}
+
+	/**
+	 * @see https://github.com/SemanticMediaWiki/SemanticMediaWiki/blob/master/docs/technical/hooks/hook.parser.parseraftertidypropertyannotationcomplete.md
+	 * @since 3.2
+	 *
+	 * @param PropertyAnnotator $propertyAnnotator
+	 * @param ParserOutput $parserOutput
+	 */
+	public function onParserAfterTidyPropertyAnnotationComplete( PropertyAnnotator $propertyAnnotator, \ParserOutput $parserOutput ) {
+		\Hooks::run( 'SMW::Parser::ParserAfterTidyPropertyAnnotationComplete', [ $propertyAnnotator, $parserOutput ] );
 	}
 
 	/**

--- a/src/MediaWiki/Hooks.php
+++ b/src/MediaWiki/Hooks.php
@@ -343,6 +343,10 @@ class Hooks {
 			$applicationFactory->getMediaWikiLogger()
 		);
 
+		$parserAfterTidy->setHookDispatcher(
+			$applicationFactory->getHookDispatcher()
+		);
+
 		$parserAfterTidy->isCommandLineMode(
 			Site::isCommandLineMode()
 		);

--- a/src/MediaWiki/Hooks/ParserAfterTidy.php
+++ b/src/MediaWiki/Hooks/ParserAfterTidy.php
@@ -11,6 +11,7 @@ use Onoi\Cache\Cache;
 use SMW\NamespaceExaminer;
 use SMW\MediaWiki\HookListener;
 use SMW\OptionsAwareTrait;
+use SMW\MediaWiki\HookDispatcherAwareTrait;
 use Psr\Log\LoggerAwareTrait;
 
 /**
@@ -28,6 +29,7 @@ class ParserAfterTidy implements HookListener {
 
 	use OptionsAwareTrait;
 	use LoggerAwareTrait;
+	use HookDispatcherAwareTrait;
 
 	const CACHE_NAMESPACE = 'smw:parseraftertidy';
 
@@ -238,6 +240,8 @@ class ParserAfterTidy implements HookListener {
 		);
 
 		$propertyAnnotator->addAnnotation();
+
+		$this->hookDispatcher->onParserAfterTidyPropertyAnnotationComplete( $propertyAnnotator, $parserOutput );
 	}
 
 	/**

--- a/tests/phpunit/Integration/MediaWiki/HookDispatcherTest.php
+++ b/tests/phpunit/Integration/MediaWiki/HookDispatcherTest.php
@@ -95,6 +95,28 @@ class HookDispatcherTest extends \PHPUnit_Framework_TestCase {
 		);
 	}
 
+	public function testOnParserAfterTidyPropertyAnnotationComplete() {
+
+		$hookDispatcher = new HookDispatcher();
+
+		$propertyAnnotator = $this->getMockBuilder( '\SMW\Property\Annotator' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$propertyAnnotator->expects( $this->once() )
+			->method( 'addAnnotation' );
+
+		$parserOutput = $this->getMockBuilder( '\ParserOutput' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$this->mwHooksHandler->register( 'SMW::Parser::ParserAfterTidyPropertyAnnotationComplete', function( $propertyAnnotator, $parserOutput ) {
+			$propertyAnnotator->addAnnotation();
+		} );
+
+		$hookDispatcher->onParserAfterTidyPropertyAnnotationComplete( $propertyAnnotator, $parserOutput );
+	}
+
 	public function testOnIsApprovedRevision() {
 
 		$hookDispatcher = new HookDispatcher();

--- a/tests/phpunit/Unit/MediaWiki/Hooks/ParserAfterTidyTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Hooks/ParserAfterTidyTest.php
@@ -27,6 +27,7 @@ class ParserAfterTidyTest extends \PHPUnit_Framework_TestCase {
 	private $testEnvironment;
 	private $parser;
 	private $namespaceExaminer;
+	private $hookDispatcher;
 	private $cache;
 
 	protected function setUp() {
@@ -58,6 +59,10 @@ class ParserAfterTidyTest extends \PHPUnit_Framework_TestCase {
 			->getMock();
 
 		$this->namespaceExaminer = $this->getMockBuilder( '\SMW\NamespaceExaminer' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$this->hookDispatcher = $this->getMockBuilder( '\SMW\MediaWiki\HookDispatcher' )
 			->disableOriginalConstructor()
 			->getMock();
 
@@ -213,6 +218,10 @@ class ParserAfterTidyTest extends \PHPUnit_Framework_TestCase {
 			$cache
 		);
 
+		$instance->setHookDispatcher(
+			$this->hookDispatcher
+		);
+
 		$this->assertTrue(
 			$instance->process( $text )
 		);
@@ -266,6 +275,10 @@ class ParserAfterTidyTest extends \PHPUnit_Framework_TestCase {
 			$this->cache
 		);
 
+		$instance->setHookDispatcher(
+			$this->hookDispatcher
+		);
+
 		$instance->process( $text );
 	}
 
@@ -297,6 +310,10 @@ class ParserAfterTidyTest extends \PHPUnit_Framework_TestCase {
 			$parser,
 			$this->namespaceExaminer,
 			$this->cache
+		);
+
+		$instance->setHookDispatcher(
+			$this->hookDispatcher
 		);
 
 		$this->assertTrue(

--- a/tests/phpunit/Utils/MwHooksHandler.php
+++ b/tests/phpunit/Utils/MwHooksHandler.php
@@ -51,6 +51,7 @@ class MwHooksHandler {
 
 		'SMW::GetPreferences',
 		'SMW::Parser::AfterLinksProcessingComplete',
+		'SMW::Parser::ParserAfterTidyPropertyAnnotationComplete',
 		'SMW::RevisionGuard::IsApprovedRevision',
 
 		'SMWSQLStore3::updateDataBefore',


### PR DESCRIPTION
This PR is made in reference to: #4478 

This PR addresses or contains:

- Adds `SMW::Parser::ParserAfterTidyPropertyAnnotationComplete` (details see document)

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed
