### PR TITLE
[ES] Refactor `FileIndexer`

### DIFF
--- a/src/Elastic/ElasticStore.php
+++ b/src/Elastic/ElasticStore.php
@@ -12,6 +12,7 @@ use SMW\Options;
 use Title;
 use SMW\SetupFile;
 use SMW\Utils\CliMsgFormatter;
+use SMW\Elastic\Jobs\FileIngestJob;
 
 /**
  * @private
@@ -279,8 +280,10 @@ class ElasticStore extends SQLStore {
 			]
 		);
 
-		if ( $config->dotGet( 'indexer.experimental.file.ingest', false ) && $semanticData->getOption( 'is.fileupload' ) ) {
-			$this->ingestFile( $subject->getTitle() );
+		if (
+			$config->dotGet( 'indexer.experimental.file.ingest', false ) &&
+			$semanticData->getOption( 'is_fileupload' ) ) {
+			FileIngestJob::pushIngestJob( $subject->getTitle() );
  		}
 
 		return $status;
@@ -454,15 +457,6 @@ class ElasticStore extends SQLStore {
 		return [
 			'SMWElasticStore' => $database->getInfo() + [ 'es' => $client->getVersion() ]
 		];
-	}
-
-	private function ingestFile( $title, array $params = [] ) {
-
-		if ( $title->getNamespace() !== NS_FILE ) {
-			return;
-		}
-
-		$this->indexer->getFileIndexer()->pushIngestJob( $title, $params );
 	}
 
 }

--- a/src/Elastic/Indexer/Attachment/AttachmentAnnotator.php
+++ b/src/Elastic/Indexer/Attachment/AttachmentAnnotator.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace SMW\Elastic\Indexer;
+namespace SMW\Elastic\Indexer\Attachment;
 
 use SMW\DataItemFactory;
 use SMW\DIProperty;
@@ -33,7 +33,7 @@ class AttachmentAnnotator implements PropertyAnnotator {
 	 * @param ContainerSemanticData $containerSemanticData
 	 * @param array $doc
 	 */
-	public function __construct( ContainerSemanticData $containerSemanticData, array $doc ) {
+	public function __construct( ContainerSemanticData $containerSemanticData, array $doc = [] ) {
 		$this->containerSemanticData = $containerSemanticData;
 		$this->doc = $doc;
 	}
@@ -124,7 +124,7 @@ class AttachmentAnnotator implements PropertyAnnotator {
 		if ( isset( $this->doc['_source']['attachment']['keywords'] ) ) {
 			$this->containerSemanticData->addPropertyObjectValue(
 				$dataItemFactory->newDIProperty( '_CONT_KEYW' ),
-				$dataItemFactory->newDINumber( intval( $this->doc['_source']['attachment']['keywords'] ) )
+				$dataItemFactory->newDIBlob( $this->doc['_source']['attachment']['keywords'] )
 			);
 		}
 

--- a/src/Elastic/Indexer/Attachment/FileAttachment.php
+++ b/src/Elastic/Indexer/Attachment/FileAttachment.php
@@ -1,0 +1,312 @@
+<?php
+
+namespace SMW\Elastic\Indexer\Attachment;
+
+use Onoi\MessageReporter\MessageReporterAwareTrait;
+use Psr\Log\LoggerAwareTrait;
+use RuntimeException;
+use SMW\ApplicationFactory;
+use SMW\DIWikiPage;
+use SMW\DIProperty;
+use SMW\Elastic\Connection\Client as ElasticClient;
+use SMW\Elastic\Indexer\Indexer;
+use SMW\Elastic\QueryEngine\FieldMapper;
+use SMW\Store;
+use SMWContainerSemanticData as ContainerSemanticData;
+use Title;
+use File;
+
+/**
+ * @license GNU GPL v2+
+ * @since 3.2
+ *
+ * @author mwjames
+ */
+class FileAttachment {
+
+	use MessageReporterAwareTrait;
+	use LoggerAwareTrait;
+
+	/**
+	 * @var Store
+	 */
+	private $store;
+
+	/**
+	 * @var Indexer
+	 */
+	private $indexer;
+
+	/**
+	 * @var string
+	 */
+	private $origin = '';
+
+	/**
+	 * @since 3.2
+	 *
+	 * @param Store $store
+	 * @param Indexer $indexer
+	 */
+	public function __construct( Store $store, Indexer $indexer ) {
+		$this->store = $store;
+		$this->indexer = $indexer;
+	}
+
+	/**
+	 * @since 3.2
+	 *
+	 * @param string $origin
+	 */
+	public function setOrigin( $origin ) {
+		$this->origin = $origin;
+	}
+
+	/**
+	 * @since 3.2
+	 *
+	 * @param DIWikiPage $dataItem
+	 */
+	public function createAttachment( DIWikiPage $dataItem ) {
+
+		$time = -microtime( true );
+
+		if ( $dataItem->getId() == 0 ) {
+			$dataItem->setId( $this->indexer->getId( $dataItem ) );
+		}
+
+		if ( $dataItem->getId() == 0 ) {
+			throw new RuntimeException( "Missing ID: " . $dataItem );
+		}
+
+		$context = [
+			'method' => __METHOD__,
+			'role' => 'production',
+			'origin' => $this->origin,
+			'subject' => $dataItem->getHash()
+		];
+
+		$semanticData = $this->store->getSemanticData( $dataItem );
+		$connection = $this->indexer->getConnection();
+
+		$index = $this->indexer->getIndexName( ElasticClient::TYPE_DATA );
+		$doc = [ '_source' => [] ];
+
+		$params = [
+			'index' => $index,
+			'type'  => ElasticClient::TYPE_DATA,
+			'id'    => $dataItem->getId(),
+		];
+
+		if ( !$connection->exists( $params ) ) {
+
+			$msg = [
+				'File indexer',
+				'Abort annotation update',
+				'Missing {id} document!'
+			];
+
+			return $this->logger->info( $msg, $context + [ 'id' => $dataItem->getId() ] );
+		}
+
+		// Available properties
+		// @see https://www.elastic.co/guide/en/elasticsearch/plugins/master/using-ingest-attachment.html
+		$params = $params + [
+			'_source_include' => [
+				'file_sha1',
+				'attachment.date',
+				'attachment.content_type',
+				'attachment.author',
+				'attachment.language',
+				'attachment.title',
+				'attachment.content_length',
+				'attachment.keywords',
+				'attachment.name'
+			]
+		];
+
+		$doc = $connection->get( $params );
+
+		if ( !isset( $doc['_source']['file_sha1'] ) ) {
+
+			$msg = [
+				'File indexer',
+				'No annotation update',
+				'Missing file_sha1!'
+			];
+
+			return $this->logger->info( $msg, $context );
+		}
+
+		$containerSemanticData = $this->newContainerSemanticData(
+			$dataItem,
+			$doc
+		);
+
+		$attachmentAnnotator = new AttachmentAnnotator(
+			$containerSemanticData,
+			$doc
+		);
+
+		$attachmentAnnotator->addAnnotation();
+		$property = $attachmentAnnotator->getProperty();
+
+		// Remove any existing `_FILE_ATTCH` in case it was a reupload with a different
+		// content sha1
+		foreach ( $semanticData->getPropertyValues( $property ) as $pv ) {
+			$semanticData->removePropertyObjectValue( $property, $pv );
+		}
+
+		$semanticData->addPropertyObjectValue(
+			$property,
+			$attachmentAnnotator->getContainer()
+		);
+
+		$callableUpdate = ApplicationFactory::getInstance()->newDeferredTransactionalCallableUpdate( function() use( $semanticData, $attachmentAnnotator ) {
+
+			// Update the SQLStore with the annotated information which will NOT
+			// trigger another ES index update BUT ...
+			$this->store->updateData( $semanticData );
+
+			// ... we need to replicate the container data (subobject) in order to
+			// make them usable via query engine therefore ...
+			$this->indexAttachmentInfo( $attachmentAnnotator );
+		} );
+
+		$callableUpdate->setOrigin( __METHOD__ );
+		$callableUpdate->waitOnTransactionIdle();
+		$callableUpdate->pushUpdate();
+
+		$context['procTime'] = microtime( true ) + $time;
+
+		$msg = [
+			'File indexer',
+			'Attachment annotation update completed ({subject})',
+			'procTime (in sec): {procTime}'
+		];
+
+		$this->logger->info( $msg, $context );
+	}
+
+	/**
+	 * Meta assignments from a file ingest need to be republished in a SMW conform
+	 * manner so that property path `[[File attachment.Content title::..]]` work
+	 * as expected.
+	 *
+	 * @since 3.2
+	 *
+	 * @param AttachmentAnnotator $attachmentAnnotator
+	 */
+	public function indexAttachmentInfo( AttachmentAnnotator $attachmentAnnotator ) {
+
+		$data = [];
+		$time = -microtime( true );
+
+		$semanticData = $attachmentAnnotator->getSemanticData();
+		$subject = $semanticData->getSubject();
+
+		// Find base document ID
+		$baseDocId = $this->indexer->getId( $subject->asBase() );
+
+		if ( $baseDocId == 0 ) {
+			throw new RuntimeException( "Missing ID: " . $subject );
+		}
+
+		$subject->setId( $this->indexer->getId( $subject ) );
+
+		if ( $subject->getId() == 0 ) {
+			throw new RuntimeException( "Missing ID: " . $subject );
+		}
+
+		$context = [
+			'method' => __METHOD__,
+			'role' => 'production',
+			'origin' => $this->origin,
+			'subject' => $subject->getHash()
+		];
+
+		foreach ( $semanticData->getProperties() as $property ) {
+
+			$pid = $this->indexer->getId(
+				$property->getCanonicalDiWikiPage()
+			);
+
+			$pid = FieldMapper::getPID( $pid );
+			$data[$pid] = [];
+			$field = FieldMapper::getField( $property );
+
+			$data[$pid][$field] = [];
+
+			foreach ( $semanticData->getPropertyValues( $property ) as $dataItem ) {
+				$data[$pid][$field][] = $dataItem->getSortKey();
+			}
+		}
+
+		$this->indexer->create( $subject, $data );
+
+		// Attach the subobject to the base subject
+		$response = $this->upsertDoc(
+			$baseDocId,
+			$subject,
+			$attachmentAnnotator->getProperty()
+		);
+
+		$context['time'] = microtime( true ) + $time;
+		$context['response'] = $response;
+
+		$msg = [
+			'File indexer',
+			'Pushed attachment information to ES ({subject})',
+			'procTime (in sec): {procTime}',
+			'Response: {response}'
+		];
+
+		$this->logger->info( $msg, $context );
+	}
+
+	private function upsertDoc( $baseDocId, $subject, $property ) {
+
+		$params = [
+			'_index' => $this->indexer->getIndexName( ElasticClient::TYPE_DATA ),
+			'_type'  => ElasticClient::TYPE_DATA
+		];
+
+		$bulk = $this->indexer->newBulk( $params );
+		$data = [];
+
+		$pid = $this->indexer->getId(
+			$property->getCanonicalDiWikiPage()
+		);
+
+		$pid = FieldMapper::getPID( $pid );
+		$data[$pid] = [];
+
+		// It is the ID field we want not any type related field!
+		$field = 'wpgID';
+
+		$data[$pid][$field] = [];
+		$data[$pid][$field][] = $subject->getId();
+
+		// Upsert of the base document to link subject -> subobject otherwise
+		// a property path like `File attachment.Content length`) is not going
+		// to work
+		$bulk->upsert( [ '_id' => $baseDocId ], $data );
+
+		return $bulk->execute();
+	}
+
+	private function newContainerSemanticData( $dataItem, $doc ) {
+
+		$subobjectName = '_FILE' . $doc['_source']['file_sha1'];
+
+		$subject = new DIWikiPage(
+			$dataItem->getDBkey(),
+			$dataItem->getNamespace(),
+			$dataItem->getInterwiki(),
+			$subobjectName
+		);
+
+		return new ContainerSemanticData( $subject );
+	}
+
+}

--- a/src/Elastic/Indexer/Attachment/FileHandler.php
+++ b/src/Elastic/Indexer/Attachment/FileHandler.php
@@ -1,0 +1,117 @@
+<?php
+
+namespace SMW\Elastic\Indexer\Attachment;
+
+use Psr\Log\LoggerAwareTrait;
+use SMW\MediaWiki\FileRepoFinder;
+use Title;
+use RuntimeException;
+
+/**
+ * @license GNU GPL v2+
+ * @since 3.2
+ *
+ * @author mwjames
+ */
+class FileHandler {
+
+	use LoggerAwareTrait;
+
+	/**
+	 * Transform the content to base64
+	 */
+	const FORMAT_BASE64 = 'format/base64';
+
+	/**
+	 * @var FileRepoFinder
+	 */
+	private $fileRepoFinder;
+
+	/**
+	 * @var callable
+	 */
+	private $readCallback;
+
+	/**
+	 * @since 3.2
+	 *
+	 * @param FileRepoFinder $fileRepoFinder
+	 */
+	public function __construct( FileRepoFinder $fileRepoFinder ) {
+		$this->fileRepoFinder = $fileRepoFinder;
+	}
+
+	/**
+	 * @since 3.2
+	 *
+	 * @param callable $readCallback
+	 */
+	public function setReadCallback( callable $readCallback ) {
+		$this->readCallback = $readCallback;
+	}
+
+	/**
+	 * @since 3.2
+	 *
+	 * @param Title $title
+	 *
+	 * @return string
+	 */
+	public function findFileByTitle( Title $title ) {
+		return $this->fileRepoFinder->findFile( $title );
+	}
+
+	/**
+	 * @since 3.2
+	 *
+	 * @param string $url
+	 *
+	 * @return string
+	 */
+	public function fetchContentFromURL( string $url ) : string {
+
+		//PHP 7.1+
+		$readCallback = $this->readCallback;
+
+		if ( $this->readCallback !== null ) {
+			return $readCallback( $url );
+		}
+
+		$contents = '';
+
+		// Avoid a "failed to open stream: HTTP request failed! HTTP/1.1 404 Not Found"
+		$file_headers = @get_headers( $url );
+
+		if (
+			$file_headers !== false &&
+			$file_headers[0] !== 'HTTP/1.1 404 Not Found' &&
+			$file_headers[0] !== 'HTTP/1.0 404 Not Found' ) {
+			return file_get_contents( $url );
+		}
+
+		$this->logger->info(
+			[ 'File indexer', 'HTTP/1.1 404 Not Found', '{url}' ],
+			[ 'method' => __METHOD__, 'role' => 'production', 'url' => $url ]
+		);
+
+		return $contents;
+	}
+
+	/**
+	 * @since 3.2
+	 *
+	 * @param string $contents
+	 * @param string $type
+	 *
+	 * @return string
+	 */
+	public function format( string $contents, string $type = '' ) : string {
+
+		if ( $type === self::FORMAT_BASE64 ) {
+			return base64_encode( $contents );
+		}
+
+		return $contents;
+	}
+
+}

--- a/src/Elastic/Indexer/Attachment/ScopeMemoryLimiter.php
+++ b/src/Elastic/Indexer/Attachment/ScopeMemoryLimiter.php
@@ -1,0 +1,90 @@
+<?php
+
+namespace SMW\Elastic\Indexer\Attachment;
+
+/**
+ * It has been observed that when large files are processed the job runner can
+ * return with "Fatal error: Allowed memory size of ..." therefore temporary lift
+ * and scope the memory limitation!
+ *
+ * @license GNU GPL v2+
+ * @since 3.2
+ *
+ * @author mwjames
+ */
+class ScopeMemoryLimiter {
+
+	/**
+	 * @var string
+	 */
+	private $memoryLimit = '1024M';
+
+	/**
+	 * @since 3.2
+	 *
+	 * @param string $url
+	 *
+	 * @return string
+	 */
+	public function __construct( $memoryLimit = '1024M' ) {
+		$this->memoryLimit = $memoryLimit;
+	}
+
+	/**
+	 * @since 3.2
+	 *
+	 * @return int
+	 */
+	public function getMemoryLimit() : int {
+		return ini_get( 'memory_limit' );
+	}
+
+	/**
+	 * @since 3.2
+	 *
+	 * @param callable $callable
+	 */
+	public function execute( callable $callable ) {
+
+		$memory_limit = ini_get( 'memory_limit' );
+
+		if ( $this->toInt( $memory_limit ) < $this->toInt( $this->memoryLimit ) ) {
+			ini_set( 'memory_limit', $this->memoryLimit );
+		}
+
+		( $callable )();
+
+		ini_set( 'memory_limit', $memory_limit );
+	}
+
+	/**
+	 * @see wfShorthandToInteger
+	 */
+	public function toInt( $string = '', $default = -1 ) {
+		$string = trim( $string );
+
+		if ( $string === '' ) {
+			return $default;
+		}
+
+		$last = $string[strlen( $string ) - 1];
+		$val = intval( $string );
+
+		switch ( $last ) {
+			case 'g':
+			case 'G':
+				$val *= 1024;
+				// break intentionally missing
+			case 'm':
+			case 'M':
+				$val *= 1024;
+				// break intentionally missing
+			case 'k':
+			case 'K':
+				$val *= 1024;
+		}
+
+		return $val;
+	}
+
+}

--- a/src/Elastic/Indexer/FileIndexer.php
+++ b/src/Elastic/Indexer/FileIndexer.php
@@ -6,20 +6,24 @@ use File;
 use Onoi\MessageReporter\MessageReporterAwareTrait;
 use Psr\Log\LoggerAwareTrait;
 use RuntimeException;
-use SMW\ApplicationFactory;
+use SMW\EntityCache;
 use SMW\DIWikiPage;
 use SMW\DIProperty;
 use SMW\Elastic\Connection\Client as ElasticClient;
+use SMW\Elastic\Indexer\Indexer;
 use SMW\Elastic\QueryEngine\FieldMapper;
 use SMW\Store;
 use SMWContainerSemanticData as ContainerSemanticData;
-use SMW\MediaWiki\RevisionGuard;
+use SMW\MediaWiki\RevisionGuardAwareTrait;
+use SMW\Elastic\Indexer\Attachment\FileHandler;
+use SMW\Elastic\Indexer\Attachment\FileAttachment;
 use Title;
 
 /**
- * Experimental file indexer that uses the ES ingest pipeline to ingest and retrieve
- * data from an attachment and make file content searchable outside of a normal
- * wiki content.
+ * File indexer to use the Elasticsearch ingest pipeline to index and retrieve
+ * data from an file (aka. attachment) and make the file content searchable
+ * outside of a normal wiki content (i.e. the indexed data is only stored in
+ * Elasticsearch).
  *
  * @license GNU GPL v2+
  * @since 3.0
@@ -29,14 +33,30 @@ use Title;
 class FileIndexer {
 
 	use MessageReporterAwareTrait;
+	use RevisionGuardAwareTrait;
 	use LoggerAwareTrait;
 
 	const INGEST_RESPONSE = 'es.ingest.response';
 
 	/**
-	 * @var Indexer
+	 * @var Store
 	 */
-	private $indexer;
+	private $store;
+
+	/**
+	 * @var EntityCache
+	 */
+	private $entityCache;
+
+	/**
+	 * @var FileHandler
+	 */
+	private $fileHandler;
+
+	/**
+	 * @var FileAttachment
+	 */
+	private $fileAttachment;
 
 	/**
 	 * @var string
@@ -49,17 +69,23 @@ class FileIndexer {
 	private $sha1Check = true;
 
 	/**
-	 * @var callable
+	 * @var []
 	 */
-	private $readCallback;
+	private $versions = [];
 
 	/**
 	 * @since 3.0
 	 *
 	 * @param Indexer $indexer
+	 * @param EntityCache $entityCache
+	 * @param FileHandler $fileHandler
+	 * @param FileAttachment $fileAttachment
 	 */
-	public function __construct( Indexer $indexer ) {
-		$this->indexer = $indexer;
+	public function __construct( Store $store, EntityCache $entityCache, FileHandler $fileHandler, FileAttachment $fileAttachment ) {
+		$this->store = $store;
+		$this->entityCache = $entityCache;
+		$this->fileHandler = $fileHandler;
+		$this->fileAttachment = $fileAttachment;
 	}
 
 	/**
@@ -73,68 +99,51 @@ class FileIndexer {
 
 	/**
 	 * @since 3.0
+	 *
+	 * @param [] $versions
+	 */
+	public function setVersions( array $versions ) {
+		$this->versions = $versions;
+	}
+
+	/**
+	 * @since 3.0
+	 *
+	 * @param string $type
+	 *
+	 * @return string
+	 */
+	public function getIndexName( $type ) {
+
+		$index = $this->store->getConnection( 'elastic' )->getIndexNameByType(
+			$type
+		);
+
+		// If the rebuilder has set a specific version, use it to avoid writing to
+		// the alias of the index when running a rebuild.
+		if ( isset( $this->versions[$type] ) ) {
+			$index = "$index-" . $this->versions[$type];
+		}
+
+		return $index;
+	}
+
+	/**
+	 * @since 3.0
 	 */
 	public function noSha1Check() {
 		$this->sha1Check = false;
 	}
 
 	/**
-	 * @since 3.0
-	 *
-	 * @param File|null $file
-	 */
-	public function pushIngestJob( Title $title, array $params = [] ) {
-
-		$params = $params + [ 'waitOnCommandLine' => true ];
-
-		$fileIngestJob = new FileIngestJob(
-			$title,
-			array_merge( $params, FileIngestJob::newRootJobParams( 'smw.fileIngestJob', $title ) )
-		);
-
-		$fileIngestJob->lazyPush();
-	}
-
-	/**
 	 * @since 3.1
 	 *
-	 * @param callable $readCallback
-	 */
-	public function setReadCallback( callable $readCallback ) {
-		$this->readCallback = $readCallback;
-	}
-
-	/**
-	 * @since 3.1
+	 * @param Title $title
 	 *
-	 * @param string $url
-	 *
-	 * @return string
+	 * @return File
 	 */
-	public function readURL( $url ) {
-
-		//PHP 7.1+
-		$readCallback = $this->readCallback;
-
-		if ( $this->readCallback !== null ) {
-			return $readCallback( $url );
-		}
-
-		$contents = '';
-
-		// Avoid a "failed to open stream: HTTP request failed! HTTP/1.1 404 Not Found"
-		$file_headers = @get_headers( $url );
-
-		if ( $file_headers !== false && $file_headers[0] !== 'HTTP/1.1 404 Not Found' && $file_headers[0] !== 'HTTP/1.0 404 Not Found' ) {
-			return file_get_contents( $url );
-		}
-
-		$this->logger->info(
-			[ 'File indexer', 'HTTP/1.1 404 Not Found', '{url}' ],
-			[ 'method' => __METHOD__, 'role' => 'production', 'origin' => $this->origin, 'url' => $url ]
-		);
-
-		return $contents;
+	public function findFile( Title $title ) {
+		return $this->fileHandler->findFileByTitle( $title );
 	}
 
 	/**
@@ -165,7 +174,7 @@ class FileIndexer {
 
 		// Allow any third-party extension to modify the file used as base for
 		// the index process
-		$file = RevisionGuard::getFile( $title, $file );
+		$file = $this->revisionGuard->getFile( $title, $file );
 
 		if ( $file !== null && isset( $file->file_sha1 ) ) {
 			$this->logger->info(
@@ -175,10 +184,13 @@ class FileIndexer {
 		}
 
 		if ( $dataItem->getId() == 0 ) {
-			$dataItem->setId( $this->indexer->getId( $dataItem ) );
+			$dataItem->setId( $this->store->getObjectIds()->getId( $dataItem ) );
 		}
 
-		if ( $dataItem->getId() == 0 || $dataItem->getNamespace() !== NS_FILE || $dataItem->getSubobjectName() !== '' ) {
+		if (
+			$dataItem->getId() == 0 ||
+			$dataItem->getNamespace() !== NS_FILE ||
+			$dataItem->getSubobjectName() !== '' ) {
 			return;
 		}
 
@@ -204,11 +216,11 @@ class FileIndexer {
 			],
 		];
 
-		$connection = $this->indexer->getConnection();
+		$connection = $this->store->getConnection( 'elastic' );
 		$connection->ingest()->putPipeline( $params );
 
 		if ( $file === null ) {
-			$file = wfFindFile( $title );
+			$file = $this->findFile( $title );
 		}
 
 		if ( $file === false || $file === null ) {
@@ -221,7 +233,7 @@ class FileIndexer {
 		$sha1 = $file->getSha1();
 		$ingest = true;
 
-		$index = $this->indexer->getIndexName( ElasticClient::TYPE_DATA );
+		$index = $this->getIndexName( ElasticClient::TYPE_DATA );
 		$doc = [ '_source' => [] ];
 
 		$params = [
@@ -250,22 +262,26 @@ class FileIndexer {
 		];
 
 		if ( $ingest === false ) {
+			$this->logger->info(
+				[ 'File indexer', 'Skipping the ingest process', 'Found identical file_sha1 ({subject})' ],
+				$context
+			);
 
-			$msg = [
-				'File indexer',
-				'Skipping the ingest process',
-				'Found identical file_sha1 ({subject})'
-			];
-
-			return $this->logger->info( $msg, $context );
+			return;
 		}
 
-		$contents = $this->readURL( $url );
+		// https://www.elastic.co/guide/en/elasticsearch/plugins/master/ingest-attachment.html
+		// "... The source field must be a base64 encoded binary or ... the
+		// CBOR format ..."
+		$content = $this->fileHandler->format(
+			$this->fileHandler->fetchContentFromURL( $url ),
+			FileHandler::FORMAT_BASE64
+		);
 
 		$params += [
 			'pipeline' => 'attachment',
 			'body' => [
-				'file_content' => base64_encode( $contents ),
+				'file_content' => $content,
 				'file_path' => $url,
 				'file_sha1' => $sha1,
 			] + $doc['_source']
@@ -285,268 +301,15 @@ class FileIndexer {
 
 		$this->logger->info( $msg, $context );
 
-		// Store the response temporary to allow the `replication status` board
+		// Store the response temporarily to allow the `replication status` board
 		// to show whether some files had issues during the indexing and need
 		// intervention from a user
-		$entityCache = ApplicationFactory::getInstance()->getEntityCache();
-		$key = $entityCache->makeCacheKey( $title, self::INGEST_RESPONSE );
+		$key = $this->entityCache->makeCacheKey( $title, self::INGEST_RESPONSE );
 
-		$entityCache->save( $key, $context['response'] );
-		$entityCache->associate( $title, $key );
+		$this->entityCache->save( $key, $context['response'] );
+		$this->entityCache->associate( $title, $key );
 
-		// Don't use the ElasticStore otherwise we index the added fields once more
-		// and hereby remove the content from the attachment! and start a circle
-		// since the annotation update can only happen after the information is
-		// retrieved from ES.
-		$store = ApplicationFactory::getInstance()->getStore(
-			'\SMW\SQLStore\SQLStore'
-		);
-
-		$this->addAnnotation( $store, $dataItem );
-	}
-
-	/**
-	 * @since 3.0
-	 *
-	 * @param Store $store
-	 * @param DIWikiPage $dataItem
-	 */
-	public function addAnnotation( Store $store, DIWikiPage $dataItem ) {
-
-		$time = -microtime( true );
-
-		if ( $dataItem->getId() == 0 ) {
-			$dataItem->setId( $this->indexer->getId( $dataItem ) );
-		}
-
-		if ( $dataItem->getId() == 0 ) {
-			throw new RuntimException( "Missing ID: " . $dataItem );
-		}
-
-		$context = [
-			'method' => __METHOD__,
-			'role' => 'production',
-			'origin' => $this->origin,
-			'subject' => $dataItem->getHash()
-		];
-
-		$semanticData = $store->getSemanticData( $dataItem );
-		$connection = $this->indexer->getConnection();
-
-		$index = $this->indexer->getIndexName( ElasticClient::TYPE_DATA );
-		$doc = [ '_source' => [] ];
-
-		$params = [
-			'index' => $index,
-			'type'  => ElasticClient::TYPE_DATA,
-			'id'    => $dataItem->getId(),
-		];
-
-		if ( !$connection->exists( $params ) ) {
-
-			$msg = [
-				'File indexer',
-				'Abort annotation update',
-				'Missing {id} document!'
-			];
-
-			return $this->logger->info( $msg, $context + [ 'id' => $dataItem->getId() ] );
-		}
-
-		$params = $params + [
-			'_source_include' => [
-				'file_sha1',
-				'attachment.date',
-				'attachment.content_type',
-				'attachment.author',
-				'attachment.language',
-				'attachment.title',
-				'attachment.content_length'
-			]
-		];
-
-		$doc = $connection->get( $params );
-
-		if ( !isset( $doc['_source']['file_sha1'] ) ) {
-
-			$msg = [
-				'File indexer',
-				'No annotation update',
-				'Missing file_sha1!'
-			];
-
-			return $this->logger->info( $msg, $context );
-		}
-
-		$containerSemanticData = $this->newContainerSemanticData(
-			$dataItem,
-			$doc
-		);
-
-		$attachmentAnnotator = new AttachmentAnnotator(
-			$containerSemanticData,
-			$doc
-		);
-
-		$attachmentAnnotator->addAnnotation();
-		$property = $attachmentAnnotator->getProperty();
-
-		// Remove any existing `_FILE_ATTCH` in case it was a reupload with a different
-		// content sha1
-		foreach ( $semanticData->getPropertyValues( $property ) as $pv ) {
-			$semanticData->removePropertyObjectValue( $property, $pv );
-		}
-
-		$semanticData->addPropertyObjectValue(
-			$property,
-			$attachmentAnnotator->getContainer()
-		);
-
-		$callableUpdate = ApplicationFactory::getInstance()->newDeferredTransactionalCallableUpdate( function() use( $store, $semanticData, $attachmentAnnotator ) {
-
-			// Update the SQLStore with the annotated information which will NOT
-			// trigger another ES index update BUT ...
-			$store->updateData( $semanticData );
-
-			// ... we need to replicate the container data (subobject) in order to
-			// make them usable via query engine therefore ...
-			$this->indexAttachmentInfo( $attachmentAnnotator );
-		} );
-
-		$callableUpdate->setOrigin( __METHOD__ );
-		$callableUpdate->waitOnTransactionIdle();
-		$callableUpdate->pushUpdate();
-
-		$context['procTime'] = microtime( true ) + $time;
-
-		$msg = [
-			'File indexer',
-			'Attachment annotation update completed ({subject})',
-			'procTime (in sec): {procTime}'
-		];
-
-		$this->logger->info( $msg, $context );
-	}
-
-	/**
-	 * Meta assignments from a file ingest need to be republished in a SMW conform
-	 * manner so that property path `[[File attachment.Content title::..]]` work
-	 * as expected.
-	 *
-	 * @since 3.0
-	 *
-	 * @param AttachmentAnnotator $attachmentAnnotator
-	 */
-	public function indexAttachmentInfo( AttachmentAnnotator $attachmentAnnotator ) {
-
-		$data = [];
-		$time = -microtime( true );
-
-		$semanticData = $attachmentAnnotator->getSemanticData();
-		$subject = $semanticData->getSubject();
-
-		// Find base document ID
-		$baseDocId = $this->indexer->getId( $subject->asBase() );
-
-		if ( $baseDocId == 0 ) {
-			throw new RuntimeException( "Missing ID: " . $subject );
-		}
-
-		$subject->setId( $this->indexer->getId( $subject ) );
-
-		if ( $subject->getId() == 0 ) {
-			throw new RuntimeException( "Missing ID: " . $subject );
-		}
-
-		$context = [
-			'method' => __METHOD__,
-			'role' => 'production',
-			'origin' => $this->origin,
-			'subject' => $subject->getHash()
-		];
-
-		foreach ( $semanticData->getProperties() as $property ) {
-
-			$pid = $this->indexer->getId(
-				$property->getCanonicalDiWikiPage()
-			);
-
-			$pid = FieldMapper::getPID( $pid );
-			$data[$pid] = [];
-			$field = FieldMapper::getField( $property );
-
-			$data[$pid][$field] = [];
-
-			foreach ( $semanticData->getPropertyValues( $property ) as $dataItem ) {
-				$data[$pid][$field][] = $dataItem->getSortKey();
-			}
-		}
-
-		$this->indexer->create( $subject, $data );
-
-		// Attach the subobject to the base subject
-		$response = $this->upsertDoc(
-			$baseDocId,
-			$subject,
-			$attachmentAnnotator->getProperty()
-		);
-
-		$context['time'] = microtime( true ) + $time;
-		$context['response'] = $response;
-
-		$msg = [
-			'File indexer',
-			'Pushed attachment information to ES ({subject})',
-			'procTime (in sec): {procTime}',
-			'Response: {response}'
-		];
-
-		$this->logger->info( $msg, $context );
-	}
-
-	private function upsertDoc( $baseDocId, $subject, $property ) {
-
-		$params = [
-			'_index' => $this->indexer->getIndexName( ElasticClient::TYPE_DATA ),
-			'_type'  => ElasticClient::TYPE_DATA
-		];
-
-		$bulk = $this->indexer->newBulk( $params );
-		$data = [];
-
-		$pid = $this->indexer->getId(
-			$property->getCanonicalDiWikiPage()
-		);
-
-		$pid = FieldMapper::getPID( $pid );
-		$data[$pid] = [];
-
-		// It is the ID field we want not any type related field!
-		$field = 'wpgID';
-
-		$data[$pid][$field] = [];
-		$data[$pid][$field][] = $subject->getId();
-
-		// Upsert of the base document to link subject -> subobject otherwise
-		// a property path like `File attachment.Content length`) is not going
-		// to work
-		$bulk->upsert( [ '_id' => $baseDocId ], $data );
-
-		return $bulk->execute();
-	}
-
-	private function newContainerSemanticData( $dataItem, $doc ) {
-
-		$subobjectName = '_FILE' . md5( $doc['_source']['file_sha1'] );
-
-		$subject = new DIWikiPage(
-			$dataItem->getDBkey(),
-			$dataItem->getNamespace(),
-			$dataItem->getInterwiki(),
-			$subobjectName
-		);
-
-		return new ContainerSemanticData( $subject );
+		$this->fileAttachment->createAttachment( $dataItem );
 	}
 
 }

--- a/src/Elastic/Indexer/Indexer.php
+++ b/src/Elastic/Indexer/Indexer.php
@@ -10,6 +10,7 @@ use SMW\DIWikiPage;
 use SMW\Elastic\Connection\Client as ElasticClient;
 use SMW\SQLStore\ChangeOp\ChangeDiff;
 use SMW\SQLStore\ChangeOp\ChangeOp;
+use SMW\Elastic\Jobs\FileIngestJob;
 use SMW\Store;
 use SMW\Utils\CharArmor;
 use SMW\MediaWiki\RevisionGuard;
@@ -86,24 +87,6 @@ class Indexer {
 	 */
 	public function setOrigin( $origin ) {
 		$this->origin = $origin;
-	}
-
-	/**
-	 * @since 3.0
-	 *
-	 * @return FileIndexer
-	 */
-	public function getFileIndexer() {
-
-		if ( $this->fileIndexer === null ) {
-			$this->fileIndexer = $this->servicesContainer->get( 'FileIndexer', $this );
-		}
-
-		$this->fileIndexer->setLogger(
-			$this->logger
-		);
-
-		return $this->fileIndexer;
 	}
 
 	/**
@@ -440,7 +423,7 @@ class Indexer {
 		// Of course, this will cause a delay for the file content being searchable
 		// but that should be acceptable to avoid blocking any online transaction.
 		if ( !$this->isRebuild && $subject->getNamespace() === NS_FILE ) {
-			$this->getFileIndexer()->pushIngestJob( $subject->getTitle() );
+			FileIngestJob::pushIngestJob( $subject->getTitle() );
 		}
 
 		$this->logger->info(

--- a/src/MediaWiki/FileRepoFinder.php
+++ b/src/MediaWiki/FileRepoFinder.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace SMW\MediaWiki;
+
+use Title;
+use RepoGroup;
+use OldLocalFile;
+
+/**
+ * @license GNU GPL v2+
+ * @since   3.2
+ *
+ * @author mwjames
+ */
+class FileRepoFinder {
+
+	/**
+	 * @var RepoGroup
+	 */
+	private $repoGroup;
+
+	/**
+	 * @since 3.2
+	 *
+	 * @param RepoGroup $repoGroup
+	 */
+	public function __construct( RepoGroup $repoGroup ) {
+		$this->repoGroup = $repoGroup;
+	}
+
+	/**
+	 * @since 3.2
+	 *
+	 * @param Title $title
+	 * @param array $options
+	 *
+	 * @return File|bool File, or false if the file does not exist
+	 */
+	public function findFile( Title $title, array $options = [] ) {
+		return $this->repoGroup->findFile( $title, $options );
+	}
+
+	/**
+	 * @since 3.2
+	 *
+	 * @param string $sha1
+	 * @param string $timestamp
+	 *
+	 * @return File|bool File, or false if the file does not exist
+	 */
+	public function findFromArchive( $sha1, $timestamp ) {
+		$localRepo = $this->repoGroup->getLocalRepo();
+
+		$file = OldLocalFile::newFromKey(
+			$sha1,
+			$localRepo,
+			$timestamp
+		);
+
+		// Try the local repo!
+		if ( $file === false ) {
+			$files = $localRepo->findBySha1( $sha1 );
+			$file = end( $files );
+		}
+
+		return $file;
+	}
+
+}

--- a/src/MediaWiki/HookDispatcher.php
+++ b/src/MediaWiki/HookDispatcher.php
@@ -76,4 +76,18 @@ class HookDispatcher {
 		return Hooks::run( 'SMW::RevisionGuard::IsApprovedRevision', [ $title, $latestRevID ] );
 	}
 
+	/**
+	 * @see https://github.com/SemanticMediaWiki/SemanticMediaWiki/blob/master/docs/technical/hooks/hook.revisionguard.changeFile.md
+	 *
+	 * @note This hook is only to be called from the `RevisionGuard` class.
+	 *
+	 * @since 3.2
+	 *
+	 * @param Title $title
+	 * @param File|null $file
+	 */
+	public function onChangeFile( \Title $title, &$file ) {
+		Hooks::run( 'SMW::RevisionGuard::ChangeFile', [ $title, &$file ] );
+	}
+
 }

--- a/src/MediaWiki/Hooks/FileUpload.php
+++ b/src/MediaWiki/Hooks/FileUpload.php
@@ -80,7 +80,7 @@ class FileUpload implements HookListener {
 		$propertyAnnotatorFactory = $applicationFactory->singleton( 'PropertyAnnotatorFactory' );
 
 		$semanticData = $parserData->getSemanticData();
-		$semanticData->setOption( 'is.fileupload', true );
+		$semanticData->setOption( 'is_fileupload', true );
 
 		$propertyAnnotator = $propertyAnnotatorFactory->newNullPropertyAnnotator(
 			$semanticData

--- a/src/MediaWiki/Job.php
+++ b/src/MediaWiki/Job.php
@@ -2,6 +2,7 @@
 
 namespace SMW\MediaWiki;
 
+use Psr\Log\LoggerAwareTrait;
 use Job as MediaWikiJob;
 use JobQueueGroup;
 use SMW\ApplicationFactory;
@@ -18,6 +19,8 @@ use Title;
  * @author mwjames
  */
 abstract class Job extends MediaWikiJob {
+
+	use LoggerAwareTrait;
 
 	/**
 	 * @var boolean

--- a/src/MediaWiki/RevisionGuard.php
+++ b/src/MediaWiki/RevisionGuard.php
@@ -115,11 +115,11 @@ class RevisionGuard {
 	 *
 	 * @return File|null
 	 */
-	public static function getFile( Title $title, File $file = null ) {
+	public function getFile( Title $title, File $file = null ) {
 
 		$origFile = $file;
 
-		\Hooks::run( 'SMW::RevisionGuard::ChangeFile', [ $title, &$file ] );
+		$this->hookDispatcher->onChangeFile( $title, $file );
 
 		if ( $file instanceof File ) {
 			return $file;

--- a/src/Services/mediawiki.php
+++ b/src/Services/mediawiki.php
@@ -11,7 +11,9 @@ use MediaWiki\MediaWikiServices;
 use Psr\Log\NullLogger;
 use SMW\Utils\Logger;
 use SMW\MediaWiki\NamespaceInfo;
+use SMW\MediaWiki\FileRepoFinder;
 use WikiImporter;
+use RepoGroup;
 
 /**
  * @codeCoverageIgnore
@@ -214,6 +216,26 @@ return [
 		}
 
 		return new NamespaceInfo( $namespaceInfo );
+	},
+
+	/**
+	 * RepoGroup
+	 *
+	 * @return callable
+	 */
+	'FileRepoFinder' => function( $containerBuilder ) {
+
+		$repoGroup = null;
+
+		// MW > 1.34
+		// https://github.com/wikimedia/mediawiki/commit/21e2d71560cb87191dd80ae0750d0190b45063c1
+		if ( class_exists( '\MediaWiki\MediaWikiServices' ) && method_exists( '\MediaWiki\MediaWikiServices', 'getRepoGroup' ) ) {
+			$repoGroup = MediaWikiServices::getInstance()->getRepoGroup();
+		} else {
+			$repoGroup = RepoGroup::singleton();
+		}
+
+		return new FileRepoFinder( $repoGroup );
 	},
 
 	/**

--- a/src/Setup.php
+++ b/src/Setup.php
@@ -300,7 +300,7 @@ final class Setup {
 			'smw.changePropagationClassUpdate' => 'SMW\MediaWiki\Jobs\ChangePropagationClassUpdateJob',
 			'smw.deferredConstraintCheckUpdateJob' => 'SMW\MediaWiki\Jobs\DeferredConstraintCheckUpdateJob',
 			'smw.elasticIndexerRecovery' => 'SMW\Elastic\Indexer\IndexerRecoveryJob',
-			'smw.elasticFileIngest' => 'SMW\Elastic\Indexer\FileIngestJob',
+			'smw.elasticFileIngest' => 'SMW\Elastic\Jobs\FileIngestJob',
 			'smw.parserCachePurgeJob' => 'SMW\MediaWiki\Jobs\ParserCachePurgeJob',
 
 			// Legacy 3.0-

--- a/tests/phpunit/Integration/MediaWiki/HookDispatcherTest.php
+++ b/tests/phpunit/Integration/MediaWiki/HookDispatcherTest.php
@@ -112,6 +112,41 @@ class HookDispatcherTest extends \PHPUnit_Framework_TestCase {
 		);
 	}
 
+	public function testOnChangeFile() {
+
+		$hookDispatcher = new HookDispatcher();
+
+		$title = $this->getMockBuilder( '\Title' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$file = $this->getMockBuilder( '\File' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$anotherFile = $this->getMockBuilder( '\File' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$anotherFile->extraProperty = 'Foo';
+
+		$this->assertNotEquals(
+			$anotherFile,
+			$file
+		);
+
+		$this->mwHooksHandler->register( 'SMW::RevisionGuard::ChangeFile', function( $title, &$file ) use ( $anotherFile ) {
+			$file = $anotherFile;
+		} );
+
+		$hookDispatcher->onChangeFile( $title, $file );
+
+		$this->assertEquals(
+			$anotherFile,
+			$file
+		);
+	}
+
 	public function testConfirmAllOnMethodsWereCalled() {
 
 		// Expected class methods to be tested

--- a/tests/phpunit/Unit/Elastic/ElasticFactoryTest.php
+++ b/tests/phpunit/Unit/Elastic/ElasticFactoryTest.php
@@ -116,7 +116,7 @@ class ElasticFactoryTest extends \PHPUnit_Framework_TestCase {
 
 		$this->assertInstanceOf(
 			'\SMW\Elastic\Indexer\FileIndexer',
-			$instance->newFileIndexer( $indexer )
+			$instance->newFileIndexer( $this->store, $indexer )
 		);
 	}
 

--- a/tests/phpunit/Unit/Elastic/Indexer/Attachment/AttachmentAnnotatorTest.php
+++ b/tests/phpunit/Unit/Elastic/Indexer/Attachment/AttachmentAnnotatorTest.php
@@ -1,0 +1,130 @@
+<?php
+
+namespace SMW\Tests\Elastic\Indexer\Attachment;
+
+use SMW\Elastic\Indexer\Attachment\AttachmentAnnotator;
+
+/**
+ * @covers \SMW\Elastic\Indexer\Attachment\AttachmentAnnotator
+ * @group semantic-mediawiki
+ *
+ * @license GNU GPL v2+
+ * @since 3.2
+ *
+ * @author mwjames
+ */
+class AttachmentAnnotatorTest extends \PHPUnit_Framework_TestCase {
+
+	private $containerSemanticData;
+
+	protected function setUp() {
+
+		$this->containerSemanticData = $this->getMockBuilder( '\SMWContainerSemanticData' )
+			->disableOriginalConstructor()
+			->getMock();
+	}
+
+	public function testCanConstruct() {
+
+		$this->assertInstanceOf(
+			AttachmentAnnotator::class,
+			new AttachmentAnnotator( $this->containerSemanticData )
+		);
+	}
+
+	public function testGetProperty() {
+
+		$instance = new AttachmentAnnotator(
+			$this->containerSemanticData
+		);
+
+		$this->assertInstanceOf(
+			'\SMW\DIProperty',
+			$instance->getProperty()
+		);
+	}
+
+	public function testGetContainer() {
+
+		$instance = new AttachmentAnnotator(
+			$this->containerSemanticData
+		);
+
+		$this->assertInstanceOf(
+			'\SMWDIContainer',
+			$instance->getContainer()
+		);
+	}
+
+	public function testGetSemanticData() {
+
+		$instance = new AttachmentAnnotator(
+			$this->containerSemanticData
+		);
+
+		$this->assertEquals(
+			$this->containerSemanticData,
+			$instance->getSemanticData()
+		);
+	}
+
+	/**
+	 * @dataProvider documentProvider
+	 */
+	public function testAddAnnotation( $document, $expected ) {
+
+		$this->containerSemanticData->expects( $this->once() )
+			->method( 'addPropertyObjectValue' )
+			->with( $this->equalTo( new \SMW\DIProperty( $expected ) ) );
+
+		$instance = new AttachmentAnnotator(
+			$this->containerSemanticData,
+			$document
+		);
+
+		$this->assertEquals(
+			$instance,
+			$instance->addAnnotation()
+		);
+	}
+
+	public function documentProvider() {
+
+		yield 'date' => [
+			[ '_source' => [ 'attachment' => [ 'date' => '1362200400' ] ] ],
+			'_CONT_DATE'
+		];
+
+		yield 'content_type' => [
+			[ '_source' => [ 'attachment' => [ 'content_type' => 'Foo' ] ] ],
+			'_CONT_TYPE'
+		];
+
+		yield 'author' => [
+			[ '_source' => [ 'attachment' => [ 'author' => 'Bar' ] ] ],
+			'_CONT_AUTHOR'
+		];
+
+		yield 'title' => [
+			[ '_source' => [ 'attachment' => [ 'title' => 'Foobar' ] ] ],
+			'_CONT_TITLE'
+		];
+
+		yield 'language' => [
+			[ '_source' => [ 'attachment' => [ 'language' => 'en' ] ] ],
+			'_CONT_LANG'
+		];
+
+		yield 'content_length' => [
+			[ '_source' => [ 'attachment' => [ 'content_length' => '1001' ] ] ],
+			'_CONT_LEN'
+		];
+
+		yield 'keywords' => [
+			[ '_source' => [ 'attachment' => [ 'keywords' => '1001' ] ] ],
+			'_CONT_KEYW'
+		];
+
+	}
+
+}

--- a/tests/phpunit/Unit/Elastic/Indexer/Attachment/FileAttachmentTest.php
+++ b/tests/phpunit/Unit/Elastic/Indexer/Attachment/FileAttachmentTest.php
@@ -1,0 +1,314 @@
+<?php
+
+namespace SMW\Tests\Elastic\Indexer\Attachment;
+
+use SMW\Elastic\Indexer\Attachment\FileAttachment;
+use SMW\DIWikiPage;
+use SMW\Tests\PHPUnitCompat;
+
+/**
+ * @covers \SMW\Elastic\Indexer\Attachment\FileAttachment
+ * @group semantic-mediawiki
+ *
+ * @license GNU GPL v2+
+ * @since 3.2
+ *
+ * @author mwjames
+ */
+class FileAttachmentTest extends \PHPUnit_Framework_TestCase {
+
+	use PHPUnitCompat;
+
+	private $store;
+	private $indexer;
+	private $bulk;
+	private $client;
+	private $logger;
+
+	protected function setUp() {
+
+		$this->store = $this->getMockBuilder( '\SMW\Store' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$this->indexer = $this->getMockBuilder( '\SMW\Elastic\Indexer\Indexer' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$this->bulk = $this->getMockBuilder( '\SMW\Elastic\Indexer\Bulk' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$this->client = $this->getMockBuilder( '\SMW\Elastic\Connection\Client' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$this->logger = $this->getMockBuilder( '\Psr\Log\NullLogger' )
+			->disableOriginalConstructor()
+			->getMock();
+	}
+
+	public function testCanConstruct() {
+
+		$this->assertInstanceOf(
+			FileAttachment::class,
+			new FileAttachment( $this->store, $this->indexer )
+		);
+	}
+
+	public function testCreateAttachment() {
+
+		$dataItem = DIWikiPage::newFromText( __METHOD__ );
+
+		$document = [
+			'_source' => [
+				'file_sha1' => '0123456789'
+			]
+		];
+
+		$semanticData = $this->getMockBuilder( '\SMW\SemanticData' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$semanticData->expects( $this->once() )
+			->method( 'getPropertyValues' )
+			->will( $this->returnValue( [ DIWikiPage::newFromText( 'Foo' ) ] ) );
+
+		$semanticData->expects( $this->once() )
+			->method( 'addPropertyObjectValue' );
+
+		$this->store->expects( $this->once() )
+			->method( 'getSemanticData' )
+			->will( $this->returnValue( $semanticData ) );
+
+		$this->client->expects( $this->once() )
+			->method( 'exists' )
+			->will( $this->returnValue( true ) );
+
+		$this->client->expects( $this->once() )
+			->method( 'get' )
+			->will( $this->returnValue( $document ) );
+
+		$this->bulk->expects( $this->once() )
+			->method( 'upsert' );
+
+		$this->indexer->expects( $this->atLeastOnce() )
+			->method( 'getId' )
+			->will( $this->returnValue( 42 ) );
+
+		$this->indexer->expects( $this->once() )
+			->method( 'getConnection' )
+			->will( $this->returnValue( $this->client ) );
+
+		$this->indexer->expects( $this->once() )
+			->method( 'newBulk' )
+			->will( $this->returnValue( $this->bulk ) );
+
+		$instance = new FileAttachment(
+			$this->store,
+			$this->indexer
+		);
+
+		$instance->setOrigin( __METHOD__ );
+		$instance->setLogger( $this->logger );
+
+		$instance->createAttachment( $dataItem );
+	}
+
+	public function testCreateAttachment_NoFileSha1() {
+
+		$dataItem = DIWikiPage::newFromText( __METHOD__ );
+		$document = [];
+
+		$this->client->expects( $this->once() )
+			->method( 'exists' )
+			->will( $this->returnValue( true ) );
+
+		$this->client->expects( $this->once() )
+			->method( 'get' )
+			->will( $this->returnValue( $document ) );
+
+		$this->indexer->expects( $this->once() )
+			->method( 'getId' )
+			->will( $this->returnValue( 42 ) );
+
+		$this->indexer->expects( $this->once() )
+			->method( 'getConnection' )
+			->will( $this->returnValue( $this->client ) );
+
+		$instance = new FileAttachment(
+			$this->store,
+			$this->indexer
+		);
+
+		$instance->setLogger( $this->logger );
+
+		$instance->createAttachment( $dataItem );
+	}
+
+	public function testCreateAttachment_NotExists() {
+
+		$dataItem = DIWikiPage::newFromText( __METHOD__ );
+
+		$this->client->expects( $this->once() )
+			->method( 'exists' )
+			->will( $this->returnValue( false ) );
+
+		$this->client->expects( $this->never() )
+			->method( 'get' );
+
+		$this->indexer->expects( $this->once() )
+			->method( 'getId' )
+			->will( $this->returnValue( 42 ) );
+
+		$this->indexer->expects( $this->once() )
+			->method( 'getConnection' )
+			->will( $this->returnValue( $this->client ) );
+
+		$instance = new FileAttachment(
+			$this->store,
+			$this->indexer
+		);
+
+		$instance->setLogger( $this->logger );
+
+		$instance->createAttachment( $dataItem );
+	}
+
+	public function testIndexAttachmentInfo() {
+
+		$property = $this->getMockBuilder( '\SMW\DIProperty' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$property->expects( $this->atLeastOnce() )
+			->method( 'getCanonicalDiWikiPage' )
+			->will( $this->returnValue( DIWikiPage::newFromText( 'Bar', SMW_NS_PROPERTY ) ) );
+
+		$attachmentAnnotator = $this->getMockBuilder( '\SMW\Elastic\Indexer\Attachment\AttachmentAnnotator' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$attachmentAnnotator->expects( $this->once() )
+			->method( 'getProperty' )
+			->will( $this->returnValue( $property ) );
+
+		$semanticData = $this->getMockBuilder( '\SMW\SemanticData' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$semanticData->expects( $this->once() )
+			->method( 'getSubject' )
+			->will( $this->returnValue( DIWikiPage::newFromText( 'Foo' ) ) );
+
+		$semanticData->expects( $this->once() )
+			->method( 'getProperties' )
+			->will( $this->returnValue( [ $property ] ) );
+
+		$semanticData->expects( $this->once() )
+			->method( 'getPropertyValues' )
+			->will( $this->returnValue( [ DIWikiPage::newFromText( 'Foobar' ) ] ) );
+
+		$attachmentAnnotator->expects( $this->once() )
+			->method( 'getSemanticData' )
+			->will( $this->returnValue( $semanticData ) );
+
+		$this->bulk->expects( $this->once() )
+			->method( 'upsert' );
+
+		$this->indexer->expects( $this->atLeastOnce() )
+			->method( 'getId' )
+			->will( $this->returnValue( 42 ) );
+
+		$this->indexer->expects( $this->once() )
+			->method( 'newBulk' )
+			->will( $this->returnValue( $this->bulk ) );
+
+		$instance = new FileAttachment(
+			$this->store,
+			$this->indexer
+		);
+
+		$instance->setLogger( $this->logger );
+
+		$instance->indexAttachmentInfo( $attachmentAnnotator );
+	}
+
+	public function testIndexAttachmentInfo_MissingId_ThrowsException() {
+
+		$attachmentAnnotator = $this->getMockBuilder( '\SMW\Elastic\Indexer\Attachment\AttachmentAnnotator' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$semanticData = $this->getMockBuilder( '\SMW\SemanticData' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$semanticData->expects( $this->once() )
+			->method( 'getSubject' )
+			->will( $this->returnValue( DIWikiPage::newFromText( 'Foo' ) ) );
+
+		$attachmentAnnotator->expects( $this->once() )
+			->method( 'getSemanticData' )
+			->will( $this->returnValue( $semanticData ) );
+
+		$this->indexer->expects( $this->once() )
+			->method( 'getId' )
+			->will( $this->returnValue( 0 ) );
+
+		$instance = new FileAttachment(
+			$this->store,
+			$this->indexer
+		);
+
+		$this->setExpectedException( '\RuntimeException' );
+		$instance->indexAttachmentInfo( $attachmentAnnotator );
+	}
+
+	public function testIndexAttachmentInfo_MissingIdOnConsecutiveCalls_ThrowsException() {
+
+		$attachmentAnnotator = $this->getMockBuilder( '\SMW\Elastic\Indexer\Attachment\AttachmentAnnotator' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$semanticData = $this->getMockBuilder( '\SMW\SemanticData' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$semanticData->expects( $this->once() )
+			->method( 'getSubject' )
+			->will( $this->returnValue( DIWikiPage::newFromText( 'Foo' ) ) );
+
+		$attachmentAnnotator->expects( $this->once() )
+			->method( 'getSemanticData' )
+			->will( $this->returnValue( $semanticData ) );
+
+		$this->indexer->expects( $this->atLeastOnce() )
+			->method( 'getId' )
+			->will( $this->onConsecutiveCalls( 42, 0 ) );
+
+		$instance = new FileAttachment(
+			$this->store,
+			$this->indexer
+		);
+
+		$this->setExpectedException( '\RuntimeException' );
+		$instance->indexAttachmentInfo( $attachmentAnnotator );
+	}
+
+	public function testCreateAttachment_MissingId_ThrowsException() {
+
+		$dataItem = $this->getMockBuilder( '\SMW\DIWikiPage' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$instance = new FileAttachment(
+			$this->store,
+			$this->indexer
+		);
+
+		$this->setExpectedException( '\RuntimeException' );
+		$instance->createAttachment( $dataItem );
+	}
+
+}

--- a/tests/phpunit/Unit/Elastic/Indexer/Attachment/FileHandlerTest.php
+++ b/tests/phpunit/Unit/Elastic/Indexer/Attachment/FileHandlerTest.php
@@ -1,0 +1,98 @@
+<?php
+
+namespace SMW\Tests\Elastic\Indexer\Attachment;
+
+use SMW\Elastic\Indexer\Attachment\FileHandler;
+
+/**
+ * @covers \SMW\Elastic\Indexer\Attachment\FileHandler
+ * @group semantic-mediawiki
+ *
+ * @license GNU GPL v2+
+ * @since 3.2
+ *
+ * @author mwjames
+ */
+class FileHandlerTest extends \PHPUnit_Framework_TestCase {
+
+	private $fileRepoFinder;
+
+	protected function setUp() {
+
+		$this->fileRepoFinder = $this->getMockBuilder( '\SMW\MediaWiki\FileRepoFinder' )
+			->disableOriginalConstructor()
+			->getMock();
+	}
+
+	public function testCanConstruct() {
+
+		$this->assertInstanceOf(
+			FileHandler::class,
+			new FileHandler( $this->fileRepoFinder )
+		);
+	}
+
+	public function testFindFileByTitle() {
+
+		$title = $this->getMockBuilder( '\Title' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$this->fileRepoFinder->expects( $this->once() )
+			->method( 'findFile' );
+
+		$instance = new FileHandler(
+			$this->fileRepoFinder
+		);
+
+		$instance->findFileByTitle( $title );
+	}
+
+	public function testBase64FromURI() {
+
+		$url = 'http://example.org/Foo.txt';
+
+		$instance = new FileHandler(
+			$this->fileRepoFinder
+		);
+
+		$instance->setReadCallback( function( $read_url ) use( $url ) {
+
+			if ( $read_url !== $url ) {
+				throw new \RuntimeException( "Invalid read URL!" );
+			}
+
+			return 'FooUrl';
+		} );
+
+		$this->assertEquals(
+			'FooUrl',
+			$instance->fetchContentFromURL( $url )
+		);
+	}
+
+	public function testFormat() {
+
+		$instance = new FileHandler(
+			$this->fileRepoFinder
+		);
+
+		$this->assertEquals(
+			'Foo',
+			$instance->format( 'Foo' )
+		);
+	}
+
+	public function testFormat_base64() {
+
+		$instance = new FileHandler(
+			$this->fileRepoFinder
+		);
+
+		$this->assertEquals(
+			base64_encode( 'Foo' ),
+			$instance->format( 'Foo', FileHandler::FORMAT_BASE64 )
+		);
+	}
+
+}

--- a/tests/phpunit/Unit/Elastic/Indexer/Attachment/ScopeMemoryLimiterTest.php
+++ b/tests/phpunit/Unit/Elastic/Indexer/Attachment/ScopeMemoryLimiterTest.php
@@ -1,0 +1,129 @@
+<?php
+
+namespace SMW\Tests\Elastic\Indexer\Attachment;
+
+use SMW\Elastic\Indexer\Attachment\ScopeMemoryLimiter;
+
+/**
+ * @covers \SMW\Elastic\Indexer\Attachment\ScopeMemoryLimiter
+ * @group semantic-mediawiki
+ *
+ * @license GNU GPL v2+
+ * @since 3.2
+ *
+ * @author mwjames
+ */
+class ScopeMemoryLimiterTest extends \PHPUnit_Framework_TestCase {
+
+	private $testCaller;
+	private $memoryLimitFromCallable;
+
+	public function testCanConstruct() {
+
+		$this->assertInstanceOf(
+			ScopeMemoryLimiter::class,
+			new ScopeMemoryLimiter()
+		);
+	}
+
+	public function testExecute() {
+
+		$this->testCaller = $this->getMockBuilder( '\stdClass' )
+			->disableOriginalConstructor()
+			->setMethods( [ 'calledFromCallable' ] )
+			->getMock();
+
+		$this->testCaller->expects( $this->once() )
+			->method( 'calledFromCallable' );
+
+		$memoryLimitBefore = ini_get( 'memory_limit' );
+		$memoryLimit = '1M';
+
+		// Establish that the limits are different
+		$this->assertNotEquals(
+			$memoryLimitBefore,
+			$memoryLimit
+		);
+
+		$instance = new ScopeMemoryLimiter(
+			$memoryLimit
+		);
+
+		$instance->execute( [ $this, 'runCallable' ] );
+
+		// Establish that the limit is equal to what we have expected
+		// to be set
+		$this->assertEquals(
+			$memoryLimit,
+			$this->memoryLimitFromCallable
+		);
+
+		// Establish that the initial limit has been reset
+		$this->assertEquals(
+			$memoryLimitBefore,
+			$instance->getMemoryLimit()
+		);
+	}
+
+	public function runCallable() {
+		$this->memoryLimitFromCallable = ini_get( 'memory_limit' );
+		$this->testCaller->calledFromCallable();
+	}
+
+	/**
+	 * @dataProvider toIntProvider
+	 */
+	public function testToInt( $string, $expected ) {
+
+		$instance = new ScopeMemoryLimiter();
+
+		$this->assertEquals(
+			$expected,
+			$instance->toInt( $string )
+		);
+	}
+
+	public static function toIntProvider() {
+
+		yield 'Empty string' => [
+			'',
+			-1,
+		];
+
+		yield 'String of spaces' => [
+			'     ',
+			-1,
+		];
+
+		yield 'One kb uppercased' => [
+			'1K',
+			1024
+		];
+
+		yield 'One kb lowercased' => [
+			'1k',
+			1024
+		];
+
+		yield 'One meg uppercased' => [
+			'1M',
+			1024 * 1024
+		];
+
+		yield 'One meg lowercased' => [
+			'1m',
+			1024 * 1024
+		];
+
+		yield 'One gig uppercased' => [
+			'1G',
+			1024 * 1024 * 1024
+		];
+
+		yield 'One gig lowercased' => [
+			'1g',
+			1024 * 1024 * 1024
+		];
+	}
+
+}

--- a/tests/phpunit/Unit/Elastic/Indexer/Rebuilder/RebuilderTest.php
+++ b/tests/phpunit/Unit/Elastic/Indexer/Rebuilder/RebuilderTest.php
@@ -19,6 +19,7 @@ class RebuilderTest extends \PHPUnit_Framework_TestCase {
 	use PHPUnitCompat;
 
 	private $connection;
+	private $fileIndexer;
 	private $indexer;
 	private $propertyTableRowMapper;
 	private $rollover;
@@ -31,6 +32,10 @@ class RebuilderTest extends \PHPUnit_Framework_TestCase {
 			->getMock();
 
 		$this->indexer = $this->getMockBuilder( '\SMW\Elastic\Indexer\Indexer' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$this->fileIndexer = $this->getMockBuilder( '\SMW\Elastic\Indexer\FileIndexer' )
 			->disableOriginalConstructor()
 			->getMock();
 
@@ -51,7 +56,7 @@ class RebuilderTest extends \PHPUnit_Framework_TestCase {
 
 		$this->assertInstanceOf(
 			Rebuilder::class,
-			new Rebuilder( $this->connection, $this->indexer, $this->propertyTableRowMapper, $this->rollover )
+			new Rebuilder( $this->connection, $this->indexer, $this->fileIndexer, $this->propertyTableRowMapper, $this->rollover )
 		);
 	}
 
@@ -73,6 +78,7 @@ class RebuilderTest extends \PHPUnit_Framework_TestCase {
 		$instance = new Rebuilder(
 			$this->connection,
 			$this->indexer,
+			$this->fileIndexer,
 			$this->propertyTableRowMapper,
 			$this->rollover
 		);
@@ -94,6 +100,7 @@ class RebuilderTest extends \PHPUnit_Framework_TestCase {
 		$instance = new Rebuilder(
 			$this->connection,
 			$this->indexer,
+			$this->fileIndexer,
 			$this->propertyTableRowMapper,
 			$this->rollover
 		);
@@ -114,6 +121,7 @@ class RebuilderTest extends \PHPUnit_Framework_TestCase {
 		$instance = new Rebuilder(
 			$this->connection,
 			$this->indexer,
+			$this->fileIndexer,
 			$this->propertyTableRowMapper,
 			$this->rollover
 		);
@@ -142,6 +150,7 @@ class RebuilderTest extends \PHPUnit_Framework_TestCase {
 		$instance = new Rebuilder(
 			$this->connection,
 			$this->indexer,
+			$this->fileIndexer,
 			$this->propertyTableRowMapper,
 			$this->rollover
 		);
@@ -179,6 +188,7 @@ class RebuilderTest extends \PHPUnit_Framework_TestCase {
 		$instance = new Rebuilder(
 			$this->connection,
 			$this->indexer,
+			$this->fileIndexer,
 			$this->propertyTableRowMapper,
 			$this->rollover
 		);
@@ -198,6 +208,7 @@ class RebuilderTest extends \PHPUnit_Framework_TestCase {
 		$instance = new Rebuilder(
 			$this->connection,
 			$this->indexer,
+			$this->fileIndexer,
 			$this->propertyTableRowMapper,
 			$this->rollover
 		);
@@ -249,6 +260,7 @@ class RebuilderTest extends \PHPUnit_Framework_TestCase {
 		$instance = new Rebuilder(
 			$this->connection,
 			$this->indexer,
+			$this->fileIndexer,
 			$this->propertyTableRowMapper,
 			$this->rollover
 		);
@@ -268,6 +280,7 @@ class RebuilderTest extends \PHPUnit_Framework_TestCase {
 		$instance = new Rebuilder(
 			$this->connection,
 			$this->indexer,
+			$this->fileIndexer,
 			$this->propertyTableRowMapper,
 			$this->rollover
 		);

--- a/tests/phpunit/Unit/Elastic/Jobs/FileIngestJobTest.php
+++ b/tests/phpunit/Unit/Elastic/Jobs/FileIngestJobTest.php
@@ -1,0 +1,199 @@
+<?php
+
+namespace SMW\Tests\Elastic\Jobs;
+
+use SMW\Elastic\Jobs\FileIngestJob;
+use SMW\DIWikiPage;
+use SMW\Tests\PHPUnitCompat;
+use SMW\Tests\TestEnvironment;
+
+/**
+ * @covers \SMW\Elastic\Jobs\FileIngestJob
+ * @group semantic-mediawiki
+ *
+ * @license GNU GPL v2+
+ * @since 3.0
+ *
+ * @author mwjames
+ */
+class FileIngestJobTest extends \PHPUnit_Framework_TestCase {
+
+	use PHPUnitCompat;
+
+	private $testEnvironment;
+	private $fileIndexer;
+	private $title;
+	private $logger;
+	private $elasticFactory;
+	private $jobQueue;
+
+	protected function setUp() {
+		parent::setUp();
+
+		$this->testEnvironment =  new TestEnvironment();
+
+		$this->title = $this->getMockBuilder( '\Title' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$indexer = $this->getMockBuilder( '\SMW\Elastic\Indexer\Indexer' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$this->fileIndexer = $this->getMockBuilder( '\SMW\Elastic\Indexer\FileIndexer' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$this->elasticFactory = $this->getMockBuilder( '\SMW\Elastic\ElasticFactory' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$this->elasticFactory->expects( $this->any() )
+			->method( 'newIndexer' )
+			->will( $this->returnValue( $indexer ) );
+
+		$this->logger = $this->getMockBuilder( '\Psr\Log\NullLogger' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$this->jobQueue = $this->getMockBuilder( '\SMW\MediaWiki\JobQueue' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$this->testEnvironment->registerObject( 'ElasticFactory', $this->elasticFactory );
+		$this->testEnvironment->registerObject( 'JobQueue', $this->jobQueue );
+	}
+
+	protected function tearDown() {
+		$this->testEnvironment->tearDown();
+		parent::tearDown();
+	}
+
+	public function testCanConstruct() {
+
+		$this->assertInstanceOf(
+			FileIngestJob::class,
+			new FileIngestJob( $this->title )
+		);
+	}
+
+	public function testPushIngestJob() {
+
+		$subject = DIWikiPage::newFromText( __METHOD__, NS_FILE );
+
+		$checkJobParameterCallback = function( $job ) use( $subject ) {
+			return DIWikiPage::newFromTitle( $job->getTitle() )->equals( $subject );
+		};
+
+		$this->jobQueue->expects( $this->once() )
+			->method( 'lazyPush' )
+			->with( $this->callback( $checkJobParameterCallback ) );
+
+		FileIngestJob::pushIngestJob( $subject->getTitle() );
+	}
+
+	public function testRunFileIndexer() {
+
+		$file = $this->getMockBuilder( '\File' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$this->fileIndexer->expects( $this->once() )
+			->method( 'findFile' )
+			->will( $this->returnValue( $file ) );
+
+		$this->elasticFactory->expects( $this->once() )
+			->method( 'newFileIndexer' )
+			->will( $this->returnValue( $this->fileIndexer ) );
+
+		$config = $this->getMockBuilder( '\SMW\Elastic\Config' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$client = $this->getMockBuilder( '\SMW\Elastic\Connection\Client' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$store = $this->getMockBuilder( '\SMW\SQLStore\SQLStore' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$store->expects( $this->atLeastOnce() )
+			->method( 'getConnection' )
+			->will( $this->returnValue( $client ) );
+
+		$this->testEnvironment->registerObject( 'Store', $store );
+
+		$this->title->expects( $this->any() )
+			->method( 'getDBKey' )
+			->will( $this->returnValue( 'Foo' ) );
+
+		$this->title->expects( $this->any() )
+			->method( 'getNamespace' )
+			->will( $this->returnValue( NS_FILE ) );
+
+		$instance = new FileIngestJob(
+			$this->title
+		);
+
+		$instance->setLogger( $this->logger );
+		$instance->runFileIndexer();
+	}
+
+	public function testRunFileIndexer_NoFile_RequeueRetry() {
+
+		$this->fileIndexer->expects( $this->once() )
+			->method( 'findFile' )
+			->will( $this->returnValue( null ) );
+
+		$this->elasticFactory->expects( $this->once() )
+			->method( 'newFileIndexer' )
+			->will( $this->returnValue( $this->fileIndexer ) );
+
+		$config = $this->getMockBuilder( '\SMW\Elastic\Config' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$config->expects( $this->once() )
+			->method( 'dotGet' )
+			->with( $this->equalTo( 'indexer.job.file.ingest.retries' ) )
+			->will( $this->returnValue( 1 ) );
+
+		$client = $this->getMockBuilder( '\SMW\Elastic\Connection\Client' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$client->expects( $this->atLeastOnce() )
+			->method( 'getConfig' )
+			->will( $this->returnValue( $config ) );
+
+		$store = $this->getMockBuilder( '\SMW\SQLStore\SQLStore' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$store->expects( $this->atLeastOnce() )
+			->method( 'getConnection' )
+			->will( $this->returnValue( $client ) );
+
+		$this->testEnvironment->registerObject( 'Store', $store );
+
+		$this->title->expects( $this->any() )
+			->method( 'getDBKey' )
+			->will( $this->returnValue( 'Foo' ) );
+
+		$this->title->expects( $this->any() )
+			->method( 'getNamespace' )
+			->will( $this->returnValue( NS_FILE ) );
+
+		$this->jobQueue->expects( $this->once() )
+			->method( 'push' );
+
+		$instance = new FileIngestJob(
+			$this->title
+		);
+
+		$instance->setLogger( $this->logger );
+		$instance->runFileIndexer();
+	}
+
+}

--- a/tests/phpunit/Unit/MediaWiki/FileRepoFinderTest.php
+++ b/tests/phpunit/Unit/MediaWiki/FileRepoFinderTest.php
@@ -1,0 +1,100 @@
+<?php
+
+namespace SMW\Tests\MediaWiki;
+
+use ParserOutput;
+use SMW\MediaWiki\FileRepoFinder;
+
+/**
+ * @covers \SMW\MediaWiki\FileRepoFinder
+ * @group semantic-mediawiki
+ *
+ * @license GNU GPL v2+
+ * @since   3.2
+ *
+ * @author mwjames
+ */
+class FileRepoFinderTest extends \PHPUnit_Framework_TestCase {
+
+	private $repoGroup;
+
+	protected function setUp() {
+
+		$this->repoGroup = $this->getMockBuilder( '\RepoGroup' )
+			->disableOriginalConstructor()
+			->getMock();
+	}
+
+	public function testCanConstruct() {
+
+		$this->assertInstanceOf(
+			FileRepoFinder::class,
+			new FileRepoFinder( $this->repoGroup )
+		);
+	}
+
+	public function testFindFile() {
+
+		$file = $this->getMockBuilder( '\File' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$this->repoGroup->expects( $this->once() )
+			->method( 'findFile' )
+			->will( $this->returnValue( $file ) );
+
+		$title = $this->getMockBuilder( '\Title' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$instance = new FileRepoFinder(
+			$this->repoGroup
+		);
+
+		$this->assertInstanceOf(
+			'\File',
+			$instance->findFile( $title )
+		);
+	}
+
+	public function testFindFromArchive() {
+
+		$file = $this->getMockBuilder( '\File' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$db = $this->getMockBuilder( '\Database' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$localRepo = $this->getMockBuilder( '\LocalRepo' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$localRepo->expects( $this->any() )
+			->method( 'getReplicaDB' )
+			->will( $this->returnValue( $db ) );
+
+		$this->repoGroup->expects( $this->any() )
+			->method( 'getLocalRepo' )
+			->will( $this->returnValue( $localRepo ) );
+
+		$localRepo->expects( $this->once() )
+			->method( 'findBySha1' )
+			->will( $this->returnValue( [ $file ] ) );
+
+		$title = $this->getMockBuilder( '\Title' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$instance = new FileRepoFinder(
+			$this->repoGroup
+		);
+
+		$this->assertInstanceOf(
+			'\File',
+			$instance->findFromArchive( '42', '1970010101010' )
+		);
+	}
+
+}

--- a/tests/phpunit/Unit/MediaWiki/RevisionGuardTest.php
+++ b/tests/phpunit/Unit/MediaWiki/RevisionGuardTest.php
@@ -121,9 +121,21 @@ class RevisionGuardTest extends \PHPUnit_Framework_TestCase {
 			->disableOriginalConstructor()
 			->getMock();
 
+		$this->hookDispatcher->expects( $this->once() )
+			->method( 'onChangeFile' )
+			->with(
+				$this->equalTo( $title ),
+				$this->equalTo( $file ) );
+
+		$instance = new RevisionGuard();
+
+		$instance->setHookDispatcher(
+			$this->hookDispatcher
+		);
+
 		$this->assertInstanceOf(
 			'\File',
-			RevisionGuard::getFile( $title, $file )
+			$instance->getFile( $title, $file )
 		);
 	}
 

--- a/tests/phpunit/Utils/MwHooksHandler.php
+++ b/tests/phpunit/Utils/MwHooksHandler.php
@@ -52,6 +52,7 @@ class MwHooksHandler {
 		'SMW::GetPreferences',
 		'SMW::Parser::AfterLinksProcessingComplete',
 		'SMW::RevisionGuard::IsApprovedRevision',
+		'SMW::RevisionGuard::ChangeFile',
 
 		'SMWSQLStore3::updateDataBefore',
 		'SMW::SQLStore::BeforeDataUpdateComplete'


### PR DESCRIPTION
This PR is made in reference to: #

This PR addresses or contains:

- Removes the circular dependency from `Indexer` and `FileIndexer`
- Splits `FileIndexer` into components (`ScopeMemoryLimiter`, `FileHandler`, `FileAttachment`, `AttachmentAnnotator` ) for easier maintainence 
- Adds a couple of extra unit tests (#3165)
- Isolates access of MediaWikis `RepoGroup` via `FileRepoFinder`

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed
