### PR TITLE
Fixes issue on "Special:SemanticMediaWiki" with debug logging enabled

### DIFF
--- a/src/MediaWiki/Specials/Admin/MaintenanceTaskHandler.php
+++ b/src/MediaWiki/Specials/Admin/MaintenanceTaskHandler.php
@@ -176,9 +176,11 @@ class MaintenanceTaskHandler extends TaskHandler implements ActionableTask {
 			$classes = get_declared_classes();
 			$class = end( $classes );
 
-			$mainClass = new $class;
+			$reflectionClass = new \ReflectionClass( $class );
 
-			if ( !$mainClass instanceof \Maintenance ) {
+			if (
+				!$reflectionClass->getParentClass() ||
+				$reflectionClass->getParentClass()->getName() !== 'Maintenance' ) {
 				continue;
 			}
 


### PR DESCRIPTION
This PR is made in reference to: #4500 

This PR addresses or contains:
- Fixes issue on "Special:SemanticMediaWiki" with debug logging enabled (`$wgDebugLogFile`) as suggested by @mwjames 

This PR includes:
- [ ] Tests (unit/integration)
- [x] CI build passed

Fixes #4500 