### PR TITLE
Raise `postgres` minimum requirement to 9.5, refs 4461

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,9 @@ sudo: required
 # https://docs.travis-ci.com/user/trusty-ci-environment/
 dist: trusty
 
+addons:
+  postgresql: "9.5"
+
 matrix:
   fast_finish: true
   include:

--- a/src/Setup.php
+++ b/src/Setup.php
@@ -27,7 +27,7 @@ final class Setup {
 	 * Any change to a version will modify the key computed by `SetupFile::makeKey`.
 	 */
 	const MINIMUM_DB_VERSION = [
-		'postgres' => '9.2',
+		'postgres' => '9.5',
 		'sqlite' => '3.3.7',
 		'mysql' => '5.5.8'
 	];

--- a/tests/phpunit/Unit/SetupFileTest.php
+++ b/tests/phpunit/Unit/SetupFileTest.php
@@ -106,7 +106,7 @@ class SetupFileTest extends \PHPUnit_Framework_TestCase {
 	public function testSetMaintenanceMode() {
 
 		$fields = [
-			'upgrade_key' => 'e230d2baae635d8af7f20be34b2de36f23b6d610',
+			'upgrade_key' => '2fefe0755c8b2d1b13b22a0a0c0677a24982ad3e',
 			SetupFile::MAINTENANCE_MODE => true,
 			// "upgrade_key_base" => '["",[],"",[]]'
 		];

--- a/tests/travis/install-mediawiki.sh
+++ b/tests/travis/install-mediawiki.sh
@@ -41,7 +41,7 @@ then
   # and the first command that accesses PostgreSQL
   sleep 3
 
-  sudo /etc/init.d/postgresql start
+  sudo /etc/init.d/postgresql start 9.5
   sleep 3
 
   psql -c 'create database its_a_mw;' -U postgres


### PR DESCRIPTION
This PR is made in reference to: #4461

This PR addresses or contains:

- PostgreSQL 9.4 becomes EOL on February 13, 2020 [0]
- Raise minimum requirement to 9.5 because it only starts to support "ON CONFLICT DO NOTHING" [1] avoiding issues with UNIQUE INDEX on inserts which is required for an upcoming change
- Changes `Setup::MINIMUM_DB_VERSION` which creates a new upgrade key hereby forces an update and version check

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed

[0] https://www.postgresql.org/about/news/1994/
[1] https://www.postgresql.org/docs/9.5/sql-insert.html
