### PR TITLE
Fix {{#info}} parserfunction for integer parameter

### DIFF
--- a/src/Message.php
+++ b/src/Message.php
@@ -35,6 +35,7 @@ class Message {
 	const TEXT = 0x2;
 	const ESCAPED = 0x4;
 	const PARSE = 0x8;
+	const RAW = 0x16;
 
 	/**
 	 * Predefined language mode
@@ -203,6 +204,10 @@ class Message {
 
 		if ( $type === null ) {
 			$type = self::TEXT;
+		}
+
+		if ( is_int( $parameters[0] ) ) {
+			$type = self::RAW;
 		}
 
 		if ( $language === null || !$language ) {

--- a/src/Setup.php
+++ b/src/Setup.php
@@ -5,6 +5,7 @@ namespace SMW;
 use SMW\Connection\ConnectionManager;
 use SMW\MediaWiki\Hooks;
 use SMW\Utils\Logo;
+use RawMessage;
 
 /**
  * Extension setup and registration
@@ -232,6 +233,12 @@ final class Setup {
 	}
 
 	private function initMessageCallbackHandler() {
+
+		Message::registerCallbackHandler( Message::RAW, function( $arguments, $language ) {
+			$rawtext = array_shift( $arguments );
+			$rawmessage = new RawMessage( "$rawtext", $arguments );
+			return $rawmessage->text();
+		} );
 
 		Message::registerCallbackHandler( Message::TEXT, function( $arguments, $language ) {
 


### PR DESCRIPTION
When called with just an integer as parameter the `{{#info}}`
parserfunction will produce an `InvalidArgumentException` with message
"$key must be a string or an array".

To avoid this, the `RawMessage` object can be used.

e.g.
`{{#info:7}}`

This PR is made in reference to: #4532

Fixes #4532