### PR TITLE
Fix {{#info}} parserfunction for integer parameter

### DIFF
--- a/src/Message.php
+++ b/src/Message.php
@@ -173,6 +173,10 @@ class Message {
 			return false;
 		}
 
+		if ( !is_array( $message ) && is_numeric( $message ) ) {
+			return $message;
+		}
+
 		// If the first element is numeric then its signals the expected message
 		// formatter type
 		if ( isset( $message[0] ) && is_numeric( $message[0] ) ) {

--- a/tests/phpunit/Integration/JSONScript/TestCases/p-0106.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/p-0106.json
@@ -15,7 +15,13 @@
 			"message-cache": "clear",
 			"page": "P0106/Note",
 			"contents": "{{#info: an info note | note }}"
+		},
+		{
+			"message-cache": "clear",
+			"page": "P0106/Numeric_value",
+			"contents": "{{#info: 1 }}"
 		}
+
 	],
 	"tests": [
 		{
@@ -53,7 +59,20 @@
 					"<span class=\"smwttcontent\">an info note</span>"
 				]
 			}
+		},
+		{
+			"type": "parser",
+			"about": "#3",
+			"subject": "P0106/Numeric_value",
+			"assert-output": {
+				"to-contain": [
+					"<span class=\"smw-highlighter\" data-type=\"6\" data-state=\"persistent\" data-title=\"Information\" title>",
+					"<span class=\"smwtticon info\">",
+					"<span class=\"smwttcontent\">1</span>"
+				]
+			}
 		}
+
 	],
 	"settings": {
 		"wgContLang": "en",

--- a/tests/phpunit/Integration/JSONScript/TestCases/p-0106.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/p-0106.json
@@ -66,7 +66,7 @@
 			"subject": "P0106/Numeric_value",
 			"assert-output": {
 				"to-contain": [
-					"<span class=\"smw-highlighter\" data-type=\"6\" data-state=\"persistent\" data-title=\"Information\" title>",
+					"<span class=\"smw-highlighter\" data-type=\"6\" data-state=\"persistent\" data-title=\"Information\" title=\"1\">",
 					"<span class=\"smwtticon info\">",
 					"<span class=\"smwttcontent\">1</span>"
 				]


### PR DESCRIPTION
When called with just an integer as parameter the `{{#info}}`
parserfunction will produce an `InvalidArgumentException` with message
"$key must be a string or an array".

To avoid this, the MediaWiki message system can be bypassed.

e.g.
`{{#info:7}}`

This PR is made in reference to: #4532

Fixes #4532