### PR TITLE
Fix table alias usage in select

### DIFF
--- a/maintenance/updateQueryDependencies.php
+++ b/maintenance/updateQueryDependencies.php
@@ -129,7 +129,7 @@ class UpdateQueryDependencies extends \Maintenance {
 		);
 
 		$res = $connection->select(
-			[ SQLStore::ID_TABLE, $tableName . ' AS p' ],
+			[ SQLStore::ID_TABLE, 'p' => $tableName ],
 			[
 				'smw_id',
 				'smw_title',
@@ -144,7 +144,7 @@ class UpdateQueryDependencies extends \Maintenance {
 				'GROUP BY' => 'smw_id'
 			],
 			[
-				$tableName . ' AS p' => [ 'INNER JOIN', [ 'p.s_id=smw_id' ] ],
+				'p' => [ 'INNER JOIN', [ 'p.s_id=smw_id' ] ],
 			]
 		);
 


### PR DESCRIPTION
This PR is made in reference to: #4423 

This PR addresses or contains:
- Fix select in runUpdate() using table alias as described in [SpecialOrphanedTalkPages.php](
https://gerrit.wikimedia.org/r/plugins/gitiles/mediawiki/extensions/OrphanedTalkPages/+/master/includes/specials/SpecialOrphanedTalkPages.php)
(from [Manual:Database_access](https://www.mediawiki.org/wiki/Manual:Database_access))

This PR includes:
- [ ] Tests (unit/integration)
- [x] CI build passed

Fixes #4423