### PR TITLE
[ES] Remove redirect from index, refs 4498

### DIFF
--- a/src/Elastic/Indexer/DocumentCreator.php
+++ b/src/Elastic/Indexer/DocumentCreator.php
@@ -4,6 +4,7 @@ namespace SMW\Elastic\Indexer;
 
 use SMW\Store;
 use SMW\DIWikiPage;
+use SMW\DIProperty;
 use SMW\SemanticData;
 use SMW\DataTypeRegistry;
 use SMW\MediaWiki\Collator;
@@ -161,9 +162,19 @@ class DocumentCreator {
 			$data['subject']['parent_id'] = $parent_id;
 		}
 
+		$type = Document::TYPE_INSERT;
+
+		// Remove any document that has been identified as redirect to avoid
+		// having Elasticsearch to match those documents and create a subject
+		// match similar to `[[::smw-redi:Issue/1286|Issue/1286]]` (#P0904)
+		if ( $semanticData->hasProperty( new DIProperty( '_REDI' ) ) ) {
+			$type = Document::TYPE_DELETE;
+		}
+
 		$document = new Document(
 			$id,
-			$data
+			$data,
+			$type
 		);
 
 		$properties = $semanticData->getProperties();

--- a/tests/phpunit/Integration/JSONScript/TestCases/p-0904.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/p-0904.json
@@ -28,6 +28,10 @@
 			"contents": "{{#ask: [[~Example/P0904*]] |?Has page |format=table |link=none }}"
 		},
 		{
+			"page": "P0904/Q.3",
+			"contents": "{{#ask: [[~Example/P0904*]] |?Has page |format=category |link=none }}"
+		},
+		{
 			"page": "Example/P0904/4",
 			"contents": "{{#show: Example/P0904/1 |?Has page |format=table |link=none }}"
 		}
@@ -86,7 +90,24 @@
 		},
 		{
 			"type": "parser",
-			"about": "#3 (#show with redirected subject, redirect target is: `Help:Example/P0904/1`)",
+			"about": "#3 (same as #2, indirect test that ES removes any redirects and no `smw-redi` reference remains)",
+			"subject": "P0904/Q.3",
+			"assert-output": {
+				"to-contain": [
+					"<li>.*Example/P0904/1.*</li>",
+					"<li>Example/P0904/2  </li>",
+					"<li>Example/P0904/2#_QUERY37a5a96c1ca51601b7eb2d79de6573f2  </li>",
+					"<li>Example/P0904/4  </li>",
+					"<li>Example/P0904/4#_QUERY214c3e831228139be58b2f0db16e18c1  </li>"
+				],
+				"not-contain": [
+					"<li>:smw-redi:Example/P0904/1.*</li>"
+				]
+			}
+		},
+		{
+			"type": "parser",
+			"about": "#4 (#show with redirected subject, redirect target is: `Help:Example/P0904/1`)",
 			"subject": "Example/P0904/4",
 			"assert-output": {
 				"to-contain": [


### PR DESCRIPTION
This PR is made in reference to: #4498

This PR addresses or contains:

- Before the #4498, the diff would have marked any `redi` related change as to be deleted, with a `Document` instance created from a `SemanticData` object the check for a redirect (`_REDI`) as to be explicit

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed

## Issue 

https://sandbox.semantic-mediawiki.org/wiki/Issue

![image](https://user-images.githubusercontent.com/1245473/74584663-c4afce00-4fcc-11ea-9f59-0c150885cf89.png)
