### PR TITLE
Check for `false`, refs 4308

### DIFF
--- a/src/MediaWiki/Page/PropertyPage.php
+++ b/src/MediaWiki/Page/PropertyPage.php
@@ -136,8 +136,12 @@ class PropertyPage extends Page {
 
 		$label = $this->getTitle()->getText();
 
+		if ( ( $key = PropertyRegistry::getInstance()->findPropertyIdByLabel( $label ) ) === false ) {
+			return false;
+		}
+
 		$property = new DIProperty(
-			PropertyRegistry::getInstance()->findPropertyIdByLabel( $label )
+			$key
 		);
 
 		// Ensure to redirect to `Property:Modification date` and not using


### PR DESCRIPTION
This PR is made in reference to: #4308, #4547 

This PR addresses or contains:

- Going to be explicit here, and yes, `PropertyRegistry::getInstance()->findPropertyIdByLabel( $label )` is allowed to return `false`

This PR includes:
- [ ] Tests (unit/integration)
- [x] CI build passed
