### PR TITLE
Tidy (Redirect), refs 4336, 4343

### DIFF
--- a/DefaultSettings.php
+++ b/DefaultSettings.php
@@ -584,13 +584,27 @@ return [
 	'smwgQSubcategoryDepth' => 10, // Restrict level of sub-category inclusion (steps within category hierarchy)
 	'smwgQSubpropertyDepth' => 10, // Restrict level of sub-property inclusion (steps within property hierarchy)
 					// (Use 0 to disable hierarchy-inferencing in queries)
-	'smwgQEqualitySupport' => SMW_EQ_SOME, // Evaluate #redirects as equality between page names, with possible
-						// performance-relevant restrictions depending on the storage engine
-	// 'smwgQEqualitySupport' => SMW_EQ_FULL, // Evaluate #redirects as equality between page names in all cases
-	// 'smwgQEqualitySupport' => SMW_EQ_NONE, // Never evaluate #redirects as equality between page names
 	'smwgQDefaultNamespaces' => null, // Which namespaces should be searched by default?
 						// (value NULL switches off default restrictions on searching -- this is faster)
 						// Example with namespaces: 'smwgQDefaultNamespaces' => array(NS_MAIN, NS_FILE)
+
+	##
+	# Evaluate #redirects
+	#
+	# - SMW_EQ_NONE: Never evaluate #redirects as equality between page names
+	#
+	# - SMW_EQ_SOME: Evaluate #redirects as equality between page names, with
+	#   possible performance-relevant restrictions depending on the storage
+	#   engine
+	#
+	# - SMW_EQ_FULL: Evaluate #redirects as equality between page names in all
+	#   cases
+	#
+	# @since 1.0
+	# @default: SMW_EQ_SOME
+	##
+	'smwgQEqualitySupport' => SMW_EQ_SOME,
+	##
 
 	###
 	# Sort features

--- a/src/Defines.php
+++ b/src/Defines.php
@@ -61,9 +61,9 @@ define( 'SMW_FACTBOX_DISPLAY_ATTACHMENT', 128 );
 /**@{
  * Constants for regulating equality reasoning
  */
-define( 'SMW_EQ_NONE', 0 );
-define( 'SMW_EQ_SOME', 1 );
-define( 'SMW_EQ_FULL', 2 );
+define( 'SMW_EQ_NONE', 1 );
+define( 'SMW_EQ_SOME', 2 );
+define( 'SMW_EQ_FULL', 4 );
 /**@}*/
 
 /**@{

--- a/src/SQLStore/SQLStoreUpdater.php
+++ b/src/SQLStore/SQLStoreUpdater.php
@@ -293,16 +293,17 @@ class SQLStoreUpdater {
 		// Take care of redirects
 		$redirects = $data->getPropertyValues( new DIProperty( '_REDI' ) );
 
-		if ( count( $redirects ) > 0 ) {
-			$redirect = end( $redirects ); // at most one redirect per page
-			$this->redirectUpdater->updateRedirects( $subject, $redirect );
-			// Stop here:
-			// * no support for annotations on redirect pages
-			// * updateRedirects takes care of deleting any previous data
-			return;
-		} else {
-			$this->redirectUpdater->updateRedirects( $subject );
+		// Redirects:
+		// * Generally, there is no support for annotations on redirect pages
+		// * Any data on a redirect page will be removed where the subject is
+		//   classified as redirect
+		// * If the redirect equality support was disabled (=== SMW_EQ_NONE) then
+		//   under certain circumstances, annotations are allowed to remain
+		if ( $this->redirectUpdater->shouldCleanUpAnnotationsAndRedirects( $redirects ) ) {
+			return $this->redirectUpdater->cleanUpAnnotationsAndRedirects( $subject, $redirects );
 		}
+
+		$this->redirectUpdater->discardRemnantRedirects( $subject );
 
 		// Find an approriate sortkey, the field is influenced by various
 		// elements incl. DEFAULTSORT and can be altered without modifying

--- a/src/Services/ServicesFactory.php
+++ b/src/Services/ServicesFactory.php
@@ -31,6 +31,7 @@ use SMW\MediaWiki\PageUpdater;
 use SMW\MediaWiki\TitleFactory;
 use SMW\MediaWiki\HookDispatcher;
 use SMW\NamespaceExaminer;
+use SMW\SQLStore\RedirectStore;
 use SMW\ParserData;
 use SMW\ParserFunctionFactory;
 use SMW\PostProcHandler;
@@ -412,13 +413,15 @@ class ServicesFactory {
 	 */
 	public function newDataUpdater( SemanticData $semanticData ) {
 
+		$settings = $this->getSettings();
+
 		$changePropagationNotifier = new \SMW\Property\ChangePropagationNotifier(
 			$this->getStore(),
 			$this->newSerializerFactory()
 		);
 
 		$changePropagationNotifier->setPropertyList(
-			$this->getSettings()->get( 'smwgChangePropagationWatchlist' )
+			$settings->get( 'smwgChangePropagationWatchlist' )
 		);
 
 		$changePropagationNotifier->isCommandLineMode(

--- a/src/Utils/Flag.php
+++ b/src/Utils/Flag.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace SMW\Utils;
+
+/**
+ * @license GNU GPL v2+
+ * @since 3.2
+ *
+ * @author mwjames
+ */
+class Flag {
+
+	/**
+	 * @var int
+	 */
+	private $flag = 0;
+
+	/**
+	 * @since 3.2
+	 *
+	 * @param int $flag
+	 */
+	public function __construct( int $flag ) {
+		$this->flag = $flag;
+	}
+
+	/**
+	 * @since 3.2
+	 *
+	 * @param integer $flag
+	 *
+	 * @return boolean
+	 */
+	public function is( $flag ) : bool {
+		return ( ( (int)$this->flag & $flag ) == $flag );
+	}
+
+	/**
+	 * @since 3.2
+	 *
+	 * @param integer $flag
+	 *
+	 * @return boolean
+	 */
+	public function not( $flag ) : bool {
+		return !$this->is( $flag );
+	}
+
+}

--- a/tests/phpunit/Unit/DataUpdaterTest.php
+++ b/tests/phpunit/Unit/DataUpdaterTest.php
@@ -65,7 +65,7 @@ class DataUpdaterTest  extends \PHPUnit_Framework_TestCase {
 
 		$this->store = $this->getMockBuilder( '\SMW\SQLStore\SQLStore' )
 			->disableOriginalConstructor()
-			->setMethods( [ 'getObjectIds', 'getConnection' ] )
+			->setMethods( [ 'getObjectIds', 'getConnection', 'getPropertyValues' ] )
 			->getMock();
 
 		$this->store->expects( $this->any() )

--- a/tests/phpunit/Unit/SQLStore/EntityStore/EntityIdManagerTest.php
+++ b/tests/phpunit/Unit/SQLStore/EntityStore/EntityIdManagerTest.php
@@ -286,6 +286,8 @@ class EntityIdManagerTest extends \PHPUnit_Framework_TestCase {
 			$this->factory
 		);
 
+		$instance->setEqualitySupport( SMW_EQ_SOME );
+
 		$sortkey = $parameters['sortkey'];
 
 		$result  = $instance->makeSMWPageID(

--- a/tests/phpunit/Unit/SQLStore/RedirectStoreTest.php
+++ b/tests/phpunit/Unit/SQLStore/RedirectStoreTest.php
@@ -240,7 +240,7 @@ class RedirectStoreTest extends \PHPUnit_Framework_TestCase {
 		);
 
 		$instance->setCommandLineMode( false );
-		$instance->setEqualitySupportFlag( SMW_EQ_FULL );
+		$instance->setEqualitySupport( SMW_EQ_FULL );
 
 		$instance->updateRedirect( 42, 'Foo', NS_MAIN );
 	}
@@ -302,7 +302,7 @@ class RedirectStoreTest extends \PHPUnit_Framework_TestCase {
 		);
 
 		$instance->setCommandLineMode( true );
-		$instance->setEqualitySupportFlag( SMW_EQ_FULL );
+		$instance->setEqualitySupport( SMW_EQ_FULL );
 
 		$instance->updateRedirect( 42, 'Foo', NS_MAIN );
 	}
@@ -326,7 +326,7 @@ class RedirectStoreTest extends \PHPUnit_Framework_TestCase {
 			$store
 		);
 
-		$instance->setEqualitySupportFlag( SMW_EQ_NONE );
+		$instance->setEqualitySupport( SMW_EQ_NONE );
 		$instance->updateRedirect( 42, 'Foo', NS_MAIN );
 	}
 

--- a/tests/phpunit/Unit/SQLStore/RedirectUpdaterTest.php
+++ b/tests/phpunit/Unit/SQLStore/RedirectUpdaterTest.php
@@ -123,6 +123,8 @@ class RedirectUpdaterTest extends \PHPUnit_Framework_TestCase {
 			$this->propertyStatisticsStore
 		);
 
+		$instance->setEqualitySupport( SMW_EQ_NONE );
+
 		$instance->updateRedirects(
 			DIWikiPage::newFromText( __METHOD__ . '-old', NS_MAIN )
 		);

--- a/tests/phpunit/Unit/SQLStore/SQLStoreUpdaterTest.php
+++ b/tests/phpunit/Unit/SQLStore/SQLStoreUpdaterTest.php
@@ -21,6 +21,7 @@ class SQLStoreUpdaterTest extends \PHPUnit_Framework_TestCase {
 	private $store;
 	private $factory;
 	private $idTable;
+	private $redirectUpdater;
 
 	protected function setUp() {
 
@@ -60,7 +61,7 @@ class SQLStoreUpdaterTest extends \PHPUnit_Framework_TestCase {
 			->disableOriginalConstructor()
 			->getMock();
 
-		$redirectUpdater = $this->getMockBuilder( '\SMW\SQLStore\RedirectUpdater' )
+		$this->redirectUpdater = $this->getMockBuilder( '\SMW\SQLStore\RedirectUpdater' )
 			->disableOriginalConstructor()
 			->getMock();
 
@@ -118,7 +119,7 @@ class SQLStoreUpdaterTest extends \PHPUnit_Framework_TestCase {
 
 		$this->factory->expects( $this->any() )
 			->method( 'newRedirectUpdater' )
-			->will( $this->returnValue( $redirectUpdater ) );
+			->will( $this->returnValue( $this->redirectUpdater ) );
 
 		$this->factory->expects( $this->any() )
 			->method( 'newPropertyStatisticsStore' )
@@ -272,6 +273,10 @@ class SQLStoreUpdaterTest extends \PHPUnit_Framework_TestCase {
 
 	public function testDoDataUpdateForMainNamespaceWithRedirect() {
 
+		$this->redirectUpdater->expects( $this->any() )
+			->method( 'shouldCleanUpAnnotationsAndRedirects' )
+			->will( $this->returnValue( true ) );
+
 		$title = Title::newFromText( __METHOD__, NS_MAIN );
 
 		$semanticData = $this->getMockBuilder( '\SMW\SemanticData' )
@@ -320,6 +325,10 @@ class SQLStoreUpdaterTest extends \PHPUnit_Framework_TestCase {
 	}
 
 	public function testAtomicTransactionOnDataUpdate() {
+
+		$this->redirectUpdater->expects( $this->any() )
+			->method( 'shouldCleanUpAnnotationsAndRedirects' )
+			->will( $this->returnValue( true ) );
 
 		$title = Title::newFromText( __METHOD__, NS_MAIN );
 

--- a/tests/phpunit/Unit/Utils/FlagTest.php
+++ b/tests/phpunit/Unit/Utils/FlagTest.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace SMW\Tests\Utils;
+
+use SMW\Utils\Flag;
+
+/**
+ * @covers \SMW\Utils\Flag
+ * @group semantic-mediawiki
+ *
+ * @license GNU GPL v2+
+ * @since 3.2
+ *
+ * @author mwjames
+ */
+class FlagTest extends \PHPUnit_Framework_TestCase {
+
+	public function testIs() {
+
+		$instance = new Flag( 2 | 4 | 16 );
+
+		$this->assertTrue(
+			$instance->is( 0 )
+		);
+
+		$this->assertTrue(
+			$instance->is( 2 )
+		);
+
+		$this->assertTrue(
+			$instance->is( 16 )
+		);
+
+		$this->assertTrue(
+			$instance->is( 2 | 16 )
+		);
+
+		$this->assertFalse(
+			$instance->is( 3 )
+		);
+	}
+
+	public function testNot() {
+
+		$instance = new Flag( 2 | 4 | 16 );
+
+		$this->assertFalse(
+			$instance->not( 0 )
+		);
+
+		$this->assertFalse(
+			$instance->not( 2 | 16 )
+		);
+
+		$this->assertTrue(
+			$instance->not( 2 | 32 )
+		);
+	}
+
+}

--- a/tests/phpunit/Utils/JSONScript/JsonTestCaseFileHandler.php
+++ b/tests/phpunit/Utils/JSONScript/JsonTestCaseFileHandler.php
@@ -350,7 +350,8 @@ class JsonTestCaseFileHandler {
 			'smwgQueryProfiler',
 			'smwgParserFeatures',
 			'smwgCategoryFeatures',
-			'smwgQSortFeatures'
+			'smwgQSortFeatures',
+			'smwgQEqualitySupport'
 		];
 
 		foreach ( $constantFeaturesList as $constantFeatures ) {


### PR DESCRIPTION
This PR is made in reference to: #4343, #4336

This PR addresses or contains:

- Isolates the access of `smwgQEqualitySupport` and avoids GLOBALS leakage into an active instance

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed

Fixes #4343