### PR TITLE
Make clear that Settings::override is package private

### DIFF
--- a/includes/Settings.php
+++ b/includes/Settings.php
@@ -219,9 +219,7 @@ class Settings extends Options {
 	}
 
 	/**
-	 * @since 3.2
-	 *
-	 * @param array $vars
+	 * Package private. Should not be used from outside SMW.
 	 */
 	public function override( array $vars ) {
 


### PR DESCRIPTION
PR into https://github.com/SemanticMediaWiki/SemanticMediaWiki/pull/4558

`@since` deliberately removed, since it implies package public.