### PR TITLE
Optimize `MonolingualTextLookup` to avoid ID lookup, refs 3870

### DIFF
--- a/includes/dataitems/SMW_DI_WikiPage.php
+++ b/includes/dataitems/SMW_DI_WikiPage.php
@@ -114,6 +114,36 @@ class DIWikiPage extends SMWDataItem {
 	}
 
 	/**
+	 * @since 3.2
+	 *
+	 * @param string $prefix
+	 *
+	 * @return boolean
+	 */
+	public function isSubEntityOf( string $prefix ) : bool {
+
+		if (
+			$this->m_dbkey === '' ||
+			$this->m_subobjectname ===  '' ||
+			$prefix ===  '' ) {
+			return false;
+		}
+
+		return substr( $this->m_subobjectname, 0, strlen( $prefix ) ) === $prefix;
+	}
+
+	/**
+	 * @since 3.2
+	 *
+	 * @param int $namespace
+	 *
+	 * @return boolean
+	 */
+	public function inNamespace( int $namespace ) : bool {
+		return $this->m_dbkey !== '' && $this->m_namespace === $namespace;
+	}
+
+	/**
 	 * @since 3.1
 	 *
 	 * @return string

--- a/src/DataValues/MonolingualTextValue.php
+++ b/src/DataValues/MonolingualTextValue.php
@@ -331,7 +331,7 @@ class MonolingualTextValue extends AbstractMultiValue {
 			$containerSemanticData = ContainerSemanticData::makeAnonymousContainer();
 			$containerSemanticData->skipAnonymousCheck();
 		} else {
-			$subobjectName = '_ML' . md5( $value );
+			$subobjectName = SMW_SUBENTITY_MONOLINGUAL . md5( $value );
 
 			$subject = new DIWikiPage(
 				$this->m_contextPage->getDBkey(),

--- a/src/Defines.php
+++ b/src/Defines.php
@@ -67,6 +67,15 @@ define( 'SMW_EQ_FULL', 4 );
 /**@}*/
 
 /**@{
+ * Constants for internal entity types
+ */
+define( 'SMW_SUBENTITY_MONOLINGUAL', '_ML' );
+define( 'SMW_SUBENTITY_REFERENCE', '_REF' );
+define( 'SMW_SUBENTITY_QUERY', '_QUERY' );
+define( 'SMW_SUBENTITY_ERROR', '_ERR' );
+/**@}*/
+
+/**@{
  * Flags to classify available query descriptions,
  * used to enable/disable certain features
  */

--- a/src/SQLStore/EntityStore/EntityIdFinder.php
+++ b/src/SQLStore/EntityStore/EntityIdFinder.php
@@ -96,7 +96,7 @@ class EntityIdFinder {
 		);
 
 		if ( $row !== false ) {
-			$id = $row->smw_id;
+			$id = (int)$row->smw_id;
 
 			$this->idCacheManager->setCache(
 				$dataItem->getDBKey(),

--- a/src/SQLStore/TableBuilder/Examiner/PredefinedProperties.php
+++ b/src/SQLStore/TableBuilder/Examiner/PredefinedProperties.php
@@ -133,7 +133,7 @@ class PredefinedProperties {
 		if ( $row === false ) {
 			$row = (object)[
 				'smw_proptable_hash' => null,
-				'smw_hash' => null,
+				'smw_hash' => $property->getSha1(),
 				'smw_rev' => null,
 				'smw_touched' => $connection->timestamp( '1970-01-01 00:00:00' )
 			];

--- a/tests/phpunit/includes/dataitems/DIWikiPageTest.php
+++ b/tests/phpunit/includes/dataitems/DIWikiPageTest.php
@@ -65,6 +65,41 @@ class DIWikiPageTest extends DataItemTest {
 		);
 	}
 
+	/**
+	 * @dataProvider subEntityProvider
+	 */
+	public function testIsSubEntityOf( $dbKey, $subobjectName, $subEntity, $expected ) {
+
+		$instance = new DIWikiPage( $dbKey, NS_MAIN, '', $subobjectName );
+
+		$this->assertEquals(
+			$expected,
+			$instance->isSubEntityOf( $subEntity )
+		);
+	}
+
+	public function testInNamespace() {
+
+		$instance = new DIWikiPage( 'Foo', NS_HELP );
+
+		$this->assertFalse(
+			$instance->inNamespace( SMW_NS_PROPERTY )
+		);
+
+		$this->assertTrue(
+			$instance->inNamespace( NS_HELP )
+		);
+	}
+
+	public function testInNamespace_EmptyDBKey() {
+
+		$instance = new DIWikiPage( '', NS_HELP );
+
+		$this->assertFalse(
+			$instance->inNamespace( NS_HELP )
+		);
+	}
+
 	public function testDoUnserialize() {
 
 		$expected = new DIWikiPage( 'Foo', 0 , '', '' );
@@ -107,6 +142,51 @@ class DIWikiPageTest extends DataItemTest {
 		];
 
 		return $provider;
+	}
+
+	public function subEntityProvider() {
+
+		yield 'empty dbkey' => [
+			'',
+			'_ML-foo',
+			SMW_SUBENTITY_MONOLINGUAL,
+			false
+		];
+
+		yield 'empty prefix' => [
+			'FOO',
+			'_ML-foo',
+			'',
+			false
+		];
+
+		yield SMW_SUBENTITY_MONOLINGUAL => [
+			'FOO',
+			'_ML-foo',
+			SMW_SUBENTITY_MONOLINGUAL,
+			true
+		];
+
+		yield SMW_SUBENTITY_REFERENCE => [
+			'FOO',
+			'_REF-foo',
+			SMW_SUBENTITY_REFERENCE,
+			true
+		];
+
+		yield SMW_SUBENTITY_QUERY => [
+			'FOO',
+			'_QUERY-foo',
+			SMW_SUBENTITY_QUERY,
+			true
+		];
+
+		yield SMW_SUBENTITY_ERROR => [
+			'FOO',
+			'_ERR-foo',
+			SMW_SUBENTITY_ERROR,
+			true
+		];
 	}
 
 }


### PR DESCRIPTION
This PR is made in reference to: #3870

This PR addresses or contains:

- Removes the need for an entity ID lookup hereby reduces required queries to match a monolingual text representation.

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed

## Example

`o0.smw_hash` as join condition that removes the need for the mentioned extra ID lookup.

```
SELECT t0.o_id AS id, o0.smw_title AS v0, o0.smw_namespace AS v1, o0.smw_iw AS v2, o0.smw_subobject AS v3, t2.o_hash AS text_short, t2.o_blob AS text_long, t3.o_hash AS lcode FROM `smw_di_wikipage` AS t0 INNER JOIN `smw_object_ids` AS o0 ON t0.o_id=o0.smw_id INNER JOIN `smw_object_ids` AS t1 ON t0.p_id=t1.smw_id INNER JOIN `smw_fpt_text` AS t2 ON t2.s_id=o0.smw_id INNER JOIN `smw_fpt_lcode` AS t3 ON t3.s_id=o0.smw_id WHERE (o0.smw_hash='d08d32b2ab554828a6de7e270a4cfc158d69c268') AND (o0.smw_iw!=':smw') AND (o0.smw_iw!=':smw-delete') AND (t0.p_id='10')
```


id | select_type | table | partitions | type | possible_keys | key | key_len | ref | rows | filtered | Extra |  
-- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | --
1 | SIMPLE | t1 | NULL | const | PRIMARY,smw_id | PRIMARY | 4 | const | 1 | 100.00 | Using index
1 | SIMPLE | o0 | NULL | ref | PRIMARY,smw_id,smw_iw,smw_hash,smw_iw_2 | smw_hash | 43 | const | 1 | 50.02 | Using index condition; Using where
1 | SIMPLE | t0 | NULL | ref | o_id,p_id,o_id_2,o_id_3 | o_id_3 | 9 | mw3203.o0.smw_id,const | 1 | 100.00 | Using where; Using index
1 | SIMPLE | t2 | NULL | ref | s_id_2,s_id | s_id_2 | 4 | mw3203.o0.smw_id | 1 | 100.00 | NULL
1 | SIMPLE | t3 | NULL | ref | s_id,s_id_2 | s_id_2 | 4 | mw3203.o0.smw_id | 1 | 100.00 | Using index


