### PR TITLE
Optimize chain lookup in prefetch mode, refs 3722

### DIFF
--- a/src/Query/Result/FieldItemFinder.php
+++ b/src/Query/Result/FieldItemFinder.php
@@ -316,6 +316,7 @@ class FieldItemFinder {
 		}
 
 		$requestOptions->isChain = false;
+		$requestOptions->isFirstChain = false;
 
 		// If it is a chain then try to find a connected DIWikiPage subject that
 		// matches the property on the chained PrintRequest.
@@ -327,9 +328,11 @@ class FieldItemFinder {
 		// retrieved from `Has page`.
 		if ( $this->printRequest->isMode( PrintRequest::PRINT_CHAIN ) ) {
 			$requestOptions->isChain = $dataValue->getDataItem()->getString();
+			$isFirstChain = true;
 
 			// Output of the previous iteration is the input for the next iteration
 			foreach ( $dataValue->getPropertyChainValues() as $pv ) {
+				$requestOptions->isFirstChain = $isFirstChain;
 				$dataItems = $this->itemFetcher->fetch( $dataItems, $pv->getDataItem(), $requestOptions );
 
 				// If the results return empty then it means that for this element
@@ -337,9 +340,12 @@ class FieldItemFinder {
 				if ( $dataItems === [] ) {
 					return [];
 				}
+
+				$isFirstChain = false;
 			}
 
 			$dataValue = $dataValue->getLastPropertyChainValue();
+			$requestOptions->isFirstChain = false;
 		}
 
 		$content = $this->itemFetcher->fetch(

--- a/src/Query/Result/ItemFetcher.php
+++ b/src/Query/Result/ItemFetcher.php
@@ -164,6 +164,12 @@ class ItemFetcher {
 
 			if ( $requestOptions->isChain ) {
 				$list = $dataItems;
+
+				// Allow the first chain element to use the entire result list
+				// to filter members as early as possible from the chain
+				if ( $requestOptions->isFirstChain ?? false ) {
+					$list = $this->dataItems;
+				}
 			}
 
 			$this->prefetchCache->prefetch( $list, $property, $requestOptions );

--- a/src/SQLStore/EntityStore/SemanticDataLookup.php
+++ b/src/SQLStore/EntityStore/SemanticDataLookup.php
@@ -265,7 +265,11 @@ class SemanticDataLookup {
 			$result[$sid]["$i#$hash"] = $data[1];
 		}
 
-		$entityIdManager->loadSequenceMap( $list );
+		// Only try to load a sequence map when it is kown that results
+		// are available for the list of selected IDs
+		if ( $result !== [] ) {
+			$entityIdManager->loadSequenceMap( $list );
+		}
 
 		return $result;
 	}

--- a/tests/phpunit/Integration/JSONScript/TestCases/p-0467.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/p-0467.json
@@ -1,0 +1,77 @@
+{
+	"description": "Test use case for lookup prefetch cache strategy in connection with printrequest chain filtering",
+	"setup": [
+		{
+			"namespace": "SMW_NS_PROPERTY",
+			"page": "Has Page",
+			"contents": "[[Has type::Page]]"
+		},
+		{
+			"namespace": "SMW_NS_PROPERTY",
+			"page": "Has number",
+			"contents": "[[Has type::Number]]"
+		},
+		{
+			"page": "P0467/1",
+			"contents": "[[Has page::P0467/1/A]] {{#subobject: Has page=P0467/1/A |@category=P0467 }} [[Category:P0467]]"
+		},
+		{
+			"page": "P0467/1/A",
+			"contents": "[[Has page::P0467/2]] [[Has number::1001]]"
+		},
+		{
+			"page": "P0467/2",
+			"contents": "[[Has number::123]]"
+		},
+		{
+			"page": "P0467/Q.1",
+			"contents": "{{#ask: [[Category:P0467]] |?Has page.Has page.Has number#- |format=table |link=none }}"
+		},
+		{
+			"page": "P0467/Q.2",
+			"contents": "{{#ask: [[Category:P0467]] |?Has page.Has page.-Has page.Has number#- |format=table |link=none }}"
+		}
+	],
+	"tests": [
+		{
+			"type": "parser",
+			"about": "#0 (Verifies that the prefetch cache correctly tracks lookup queries and returns a number for both subjects)",
+			"subject": "P0467/Q.1",
+			"assert-output": {
+				"to-contain": [
+					"<td class=\"smwtype_wpg\">P0467/1</td><td class=\"Has-number smwtype_num\" data-sort-value=\"123\">123</td>",
+					"<td class=\"smwtype_wpg\">P0467/1#_e242c306cd92f5de7da4528c9e2987f6</td><td class=\"Has-number smwtype_num\" data-sort-value=\"123\">123</td>"
+				],
+				"not-contain": [
+					"<td class=\"smwtype_wpg\">P0467/1#_e242c306cd92f5de7da4528c9e2987f6</td><td class=\"Has-number smwtype_num\"></td>"
+				]
+			}
+		},
+		{
+			"type": "parser",
+			"about": "#1 (Verifies that the prefetch cache correctly tracks lookup queries, incl. inverted request)",
+			"subject": "P0467/Q.2",
+			"assert-output": {
+				"to-contain": [
+					"<td class=\"smwtype_wpg\">P0467/1</td><td class=\"Has-number smwtype_num\" data-sort-value=\"1001\">1001</td>",
+					"<td class=\"smwtype_wpg\">P0467/1#_e242c306cd92f5de7da4528c9e2987f6</td><td class=\"Has-number smwtype_num\" data-sort-value=\"1001\">1001</td>"
+				],
+				"not-contain": [
+					"<td class=\"smwtype_wpg\">P0467/1#_e242c306cd92f5de7da4528c9e2987f6</td><td class=\"Has-number smwtype_num\"></td>"
+				]
+			}
+		}
+	],
+	"settings": {
+		"wgContLang": "en",
+		"wgLang": "en",
+		"smwgPageSpecialProperties": [
+			"_MDAT"
+		]
+	},
+	"meta": {
+		"version": "2",
+		"is-incomplete": false,
+		"debug": false
+	}
+}


### PR DESCRIPTION
This PR is made in reference to: #3722

This PR addresses or contains:

- Optimizes the lookup for indirection (Has page.Has page ...) so that queries for chain members are cached early hereby provide a potential to reduce the lookup by up to 50% on the first chain request.

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed
