### PR TITLE
Isolate `Hooks::run` in Settings, refs 4478

### DIFF
--- a/includes/specials/SpecialPage.php
+++ b/includes/specials/SpecialPage.php
@@ -2,6 +2,8 @@
 
 namespace SMW;
 
+use SMW\Services\ServicesFactory;
+
 /**
  * Semantic MediaWiki SpecialPage base class
  *
@@ -84,7 +86,7 @@ class SpecialPage extends \SpecialPage {
 	public function getSettings() {
 
 		if ( $this->settings === null ) {
-			$this->settings = Settings::newFromGlobals();
+			$this->settings = ServicesFactory::getInstance()->getSettings();
 		}
 
 		return $this->settings;

--- a/src/ConfigLegacyTrait.php
+++ b/src/ConfigLegacyTrait.php
@@ -24,7 +24,7 @@ trait ConfigLegacyTrait {
 	 * @since 3.2
 	 *
 	 */
-	public static function loadLegacyMappings( &$configuration ) {
+	public function loadLegacyMappings( &$configuration ) {
 		self::setLegacyMappings( $configuration );
 		self::fillDeprecationNotices();
 	}

--- a/src/Exception/SettingsAlreadyLoadedException.php
+++ b/src/Exception/SettingsAlreadyLoadedException.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace SMW\Exception;
+
+use RuntimeException;
+
+/**
+ * @license GNU GPL v2+
+ * @since 3.2
+ *
+ * @author mwjames
+ */
+class SettingsAlreadyLoadedException extends RuntimeException {
+
+}

--- a/src/MediaWiki/HookDispatcher.php
+++ b/src/MediaWiki/HookDispatcher.php
@@ -32,6 +32,21 @@ class HookDispatcher {
 	 * @see https://github.com/SemanticMediaWiki/SemanticMediaWiki/blob/master/docs/technical/hooks/hook.getpreferences.md
 	 * @since 3.2
 	 *
+	 * @param array &$configuration
+	 */
+	public function onSettingsBeforeInitializationComplete( array &$configuration ) {
+
+		// Deprecated since 3.1
+		\Hooks::run( 'SMW::Config::BeforeCompletion', [ &$configuration ] );
+
+
+		Hooks::run( 'SMW::Settings::BeforeInitializationComplete', [ &$configuration ] );
+	}
+
+	/**
+	 * @see https://github.com/SemanticMediaWiki/SemanticMediaWiki/blob/master/docs/technical/hooks/hook.getpreferences.md
+	 * @since 3.2
+	 *
 	 * @param User $user
 	 * @param array &$preferences
 	 */

--- a/src/Services/ServicesFactory.php
+++ b/src/Services/ServicesFactory.php
@@ -119,11 +119,6 @@ class ServicesFactory {
 	 * @since 2.0
 	 */
 	public static function clear() {
-
-		if ( self::$instance !== null ) {
-			self::$instance->getSettings()->clear();
-		}
-
 		self::$instance = null;
 	}
 

--- a/src/Services/SharedServicesContainer.php
+++ b/src/Services/SharedServicesContainer.php
@@ -149,7 +149,16 @@ class SharedServicesContainer implements CallbackContainer {
 
 		$containerBuilder->registerCallback( 'Settings', function( $containerBuilder ) {
 			$containerBuilder->registerExpectedReturnType( 'Settings', '\SMW\Settings' );
-			return Settings::newFromGlobals();
+
+			$settings = new Settings();
+
+			$settings->setHookDispatcher(
+				$containerBuilder->singleton( 'HookDispatcher' )
+			);
+
+			$settings->loadFromGlobals();
+
+			return $settings;
 		} );
 
 		/**

--- a/tests/phpunit/DatabaseTestCase.php
+++ b/tests/phpunit/DatabaseTestCase.php
@@ -137,7 +137,6 @@ abstract class DatabaseTestCase extends \PHPUnit_Framework_TestCase {
 
 		ServicesFactory::clear();
 		PropertyRegistry::clear();
-		Settings::clear();
 		Exporter::getInstance()->clear();
 
 		parent::tearDown();

--- a/tests/phpunit/Integration/MediaWiki/HookDispatcherTest.php
+++ b/tests/phpunit/Integration/MediaWiki/HookDispatcherTest.php
@@ -33,6 +33,28 @@ class HookDispatcherTest extends \PHPUnit_Framework_TestCase {
 		parent::tearDown();
 	}
 
+	public function testOnSettingsBeforeInitializationComplete() {
+
+		$configuration = [];
+
+		$hookDispatcher = new HookDispatcher();
+
+		$user = $this->getMockBuilder( '\User' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$this->mwHooksHandler->register( 'SMW::Settings::BeforeInitializationComplete', function( &$configuration ) {
+			$configuration = [ 'Foo' ];
+		} );
+
+		$hookDispatcher->onSettingsBeforeInitializationComplete( $configuration );
+
+		$this->assertEquals(
+			[ 'Foo' ],
+			$configuration
+		);
+	}
+
 	public function testOnGetPreferences() {
 
 		$preferences = [];

--- a/tests/phpunit/Integration/MediaWiki/NamespaceInfoCanonicalNameMatchTest.php
+++ b/tests/phpunit/Integration/MediaWiki/NamespaceInfoCanonicalNameMatchTest.php
@@ -62,10 +62,11 @@ class NamespaceInfoCanonicalNameMatchTest extends \PHPUnit_Framework_TestCase {
 	public function testCanonicalNames() {
 
 		$this->mwHooksHandler->deregisterListedHooks();
-		$namespaceInfo = ApplicationFactory::getInstance()->singleton( 'NamespaceInfo' );
+		$applicationFactory = ApplicationFactory::getInstance();
+		$namespaceInfo = $applicationFactory->singleton( 'NamespaceInfo' );
 
 		$count = 0;
-		$index = NamespaceManager::buildNamespaceIndex( Settings::newFromGlobals()->get( 'smwgNamespaceIndex' ) );
+		$index = NamespaceManager::buildNamespaceIndex( $applicationFactory->getSettings()->get( 'smwgNamespaceIndex' ) );
 		$names = NamespaceManager::getCanonicalNames();
 
 		$this->assertInternalType( 'array', $names );

--- a/tests/phpunit/Unit/Exception/SettingsAlreadyLoadedExceptionTest.php
+++ b/tests/phpunit/Unit/Exception/SettingsAlreadyLoadedExceptionTest.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace SMW\Tests\Exception;
+
+use SMW\Exception\SettingsAlreadyLoadedException;
+
+/**
+ * @covers \SMW\Exception\SettingsAlreadyLoadedException
+ * @group semantic-mediawiki
+ *
+ * @license GNU GPL v2+
+ * @since 3.2
+ *
+ * @author mwjames
+ */
+class SettingsAlreadyLoadedExceptionTest extends \PHPUnit_Framework_TestCase {
+
+	public function testCanConstruct() {
+
+		$instance = new SettingsAlreadyLoadedException();
+
+		$this->assertInstanceof(
+			SettingsAlreadyLoadedException::class,
+			$instance
+		);
+
+		$this->assertInstanceof(
+			'\RuntimeException',
+			$instance
+		);
+	}
+
+}

--- a/tests/phpunit/Unit/StoreFactoryTest.php
+++ b/tests/phpunit/Unit/StoreFactoryTest.php
@@ -2,15 +2,11 @@
 
 namespace SMW\Tests;
 
-use SMW\Settings;
 use SMW\StoreFactory;
 
 /**
  * @covers \SMW\StoreFactory
- *
- *
- * @group SMW
- * @group SMWExtension
+ * @group semantic-mediawiki
  *
  * @license GNU GPL v2+
  * @since 1.9
@@ -23,7 +19,6 @@ class StoreFactoryTest extends \PHPUnit_Framework_TestCase {
 
 	protected function tearDown() : void {
 		StoreFactory::clear();
-
 		parent::tearDown();
 	}
 
@@ -32,7 +27,7 @@ class StoreFactoryTest extends \PHPUnit_Framework_TestCase {
 		$instance = StoreFactory::getStore();
 
 		$this->assertInstanceOf(
-			Settings::newFromGlobals()->get( 'smwgDefaultStore' ),
+			$GLOBALS['smwgDefaultStore'],
 			$instance
 		);
 

--- a/tests/phpunit/Utils/MwHooksHandler.php
+++ b/tests/phpunit/Utils/MwHooksHandler.php
@@ -33,6 +33,8 @@ class MwHooksHandler {
 		//	'smwInitDatatypes',
 		//	'SMW::DataType::initTypes',
 
+		'SMW::Settings::BeforeInitializationComplete',
+
 		'smwInitProperties',
 		'SMW::Property::initProperties',
 		'SMW::Factbox::BeforeContentGeneration',


### PR DESCRIPTION
This PR is made in reference to: #4478

This PR addresses or contains:

- Moves `Hooks::run` out of `Settings` into `HookDispatcher::onSettingsBeforeInitializationComplete`
- Removes `Settings::newFromGlobals` and throws a `SettingsAlreadyLoadedException` if someone tries to reload the settings

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed
