### PR TITLE
CSS (`smw-factbox-view`, smw.factbox.css), refs 4146

### DIFF
--- a/res/smw/factbox/smw.factbox.css
+++ b/res/smw/factbox/smw.factbox.css
@@ -196,8 +196,51 @@
 }
 
 /**
+ * #4146
+ *
+ * `#mw-data-after-content` defines when the content is outside of the
+ * `#bodyContent`
+ *
+ * `#bodyContent #mw-data-after-content` negates previous CSS when it is part of
+ * the #bodyContent (being inside)
+ */
+.smw-factbox-view.skin-vector #mw-data-after-content .smw-factbox {
+	background: #fff;
+	padding: 0px 25px 25px 25px;
+	border-left: 1px solid #a7d7f9;
+	/*border-top: 1px solid #a7d7f9;*/
+	border-bottom: 1px solid #a7d7f9;
+	font-size: 0.875em;
+	line-height: 1.6;
+	margin-top: -10px;
+}
+
+.smw-factbox-view.skin-vector #bodyContent #mw-data-after-content .smw-factbox {
+	background: unset;
+	padding: unset;
+	border-left: 0px solid #a7d7f9;
+	/* border-top: 0px solid #a7d7f9; */
+	border-bottom: 0px solid #a7d7f9;
+	font-size: unset;
+	line-height: unset;
+	margin-top: 15px;
+}
+
+/**
  * Responsive settings (#see smw.table.css)
  */
+@media screen and (max-width: 980px) {
+	.smw-factbox-view.skin-vector #mw-data-after-content .smw-factbox {
+		padding: 16px;
+		margin-top: -16px;
+	}
+
+	.smw-factbox-view.skin-vector #bodyContent #mw-data-after-content .smw-factbox {
+		padding: unset;
+		margin-top: 16px;
+	}
+}
+
 @media screen and (max-width: 800px) {
 	.smw-factbox .smwfactboxhead {
 		padding: 1px 5px 1px 5px;

--- a/res/smw/util/smw.tippy.js
+++ b/res/smw/util/smw.tippy.js
@@ -315,6 +315,7 @@
 	// Running in default mode which would be on
 	// $( document ).ready( function() { ... } ); when relying on jQuery
 	tippy( '#bodyContent', options )
+	tippy( '#mw-data-after-content', options )
 	tippy( '.mw-indicators', options )
 
 	/**

--- a/src/MediaWiki/Hooks/OutputPageParserOutput.php
+++ b/src/MediaWiki/Hooks/OutputPageParserOutput.php
@@ -132,6 +132,15 @@ class OutputPageParserOutput implements HookListener {
 			$this->getParserOutput( $outputPage, $parserOutput )
 		);
 
+		// #4146
+		//
+		// Due to how MW started to move the `mw-data-after-content` out of the
+		// `bodyContent` we need a way to distinguish content from a top level
+		// to apply additional CSS rules
+		if ( isset( $outputPage->mSMWFactboxText ) && $outputPage->mSMWFactboxText !== '' ) {
+			$outputPage->addBodyClasses( 'smw-factbox-view' );
+		}
+
 		return true;
 	}
 


### PR DESCRIPTION
This PR is made in reference to: #4146

This PR addresses or contains:

- This tries to mend the factbox display on the `.skin-vector` by using some extra CSS rules to make the factbox content to appear as part of the overall `bodyContent` and not as dismembered snippet of the content as shown in the example.

This PR includes:
- [ ] Tests (unit/integration)
- [x] CI build passed

## Example

MW 1.34+

![image](https://user-images.githubusercontent.com/1245473/75090740-e45f6d00-555d-11ea-81d6-6aab96c17f8c.png)
