### PR TITLE
Add max-width, theme parameter to #info

### DIFF
--- a/includes/Highlighter.php
+++ b/includes/Highlighter.php
@@ -241,10 +241,18 @@ class Highlighter {
 		}
 
 		$language = is_string( $this->language ) ? $this->language : Message::USER_LANGUAGE;
-		$style = [];
+		$attribs = [];
 
 		if ( isset( $this->options['style'] ) ) {
-			$style = [ 'style' => $this->options['style'] ];
+			$attribs['style'] = $this->options['style'];
+		}
+
+		if ( isset( $this->options['maxwidth'] ) && $this->options['maxwidth'] !== '' ) {
+			$attribs['data-maxwidth'] = $this->options['maxwidth'];
+		}
+
+		if ( isset( $this->options['themeclass'] ) && $this->options['themeclass'] !== '' ) {
+			$attribs['data-tooltipclass'] = $this->options['themeclass'];
 		}
 
 		// In case the text contains HTML, remove trailing line feeds to avoid breaking
@@ -268,7 +276,7 @@ class Highlighter {
 				'data-state'   => $this->options['state'],
 				'data-title'   => Message::get( $this->options['title'], Message::TEXT, $language ),
 				'title'        => $title
-			] + $style,
+			] + $attribs,
 			Html::rawElement(
 				'span',
 				[

--- a/res/smw/util/smw.tippy.css
+++ b/res/smw/util/smw.tippy.css
@@ -57,15 +57,13 @@
 }
 
 .tippy-content-container {
-    padding: .3em .8em;
-    margin-bottom: 0.2em;
-    margin-top: 0.2em;
+    padding: .5em .8em;
     text-align: initial;
     word-break: break-word;
-   /* max-width: 260px; */
-   font-size: 14px;
-   max-height: 250px;
-   overflow-y: auto;
+    /* max-width: 260px; */
+    font-size: 14px;
+    max-height: 250px;
+    overflow-y: auto;
 }
 
 .tippy-content-container ul {
@@ -95,15 +93,24 @@
 }
 
 .tippy-tooltip.light-border-theme.square-border-transparent-arrow[x-placement^=bottom] .tippy-arrow,
+.tippy-tooltip.light-border-theme.square-border-light[x-placement^=bottom] .tippy-arrow,
 .tippy-tooltip.light-theme.square-border-transparent-arrow[x-placement^=bottom] .tippy-arrow,
+.tippy-tooltip.light-theme.square-border-light[x-placement^=bottom] .tippy-arrow,
 .tippy-tooltip.light-border-theme.square-border-transparent-arrow[x-placement^=bottom] .tippy-arrow:after,
-.tippy-tooltip.light-theme.square-border-transparent-arrow[x-placement^=bottom] .tippy-arrow:after {
+.tippy-tooltip.light-border-theme.square-border-light[x-placement^=bottom] .tippy-arrow:after,
+.tippy-tooltip.light-theme.square-border-transparent-arrow[x-placement^=bottom] .tippy-arrow:after,
+.tippy-tooltip.light-theme.square-border-light[x-placement^=bottom] .tippy-arrow:after {
      border-bottom-color: #fff;
 }
 
 .tippy-tooltip.light-border-theme.square-border,
+.tippy-tooltip.light-border-theme.square-border-light,
 .tippy-tooltip.light-border-theme.square-border-transparent-arrow {
     border-radius: 0;
+}
+
+.square-border-light .tippy-header {
+    background-color: #fff
 }
 
 .tippy-cancel {

--- a/res/smw/util/smw.tippy.js
+++ b/res/smw/util/smw.tippy.js
@@ -65,6 +65,11 @@
 
 			var isRTL = document.documentElement.dir === "rtl";
 
+			// Set a possinle maxwidth before accessing the props
+			if ( tip.reference.getAttribute( "data-maxwidth" ) ) {
+				tip.set( { maxWidth: parseInt( tip.reference.getAttribute( "data-maxwidth" ) ) } );
+			}
+
 			// Move away from the `bodyContent` border
 			if ( tip.reference.offsetWidth < tip.props.maxWidth ) {
 
@@ -101,10 +106,6 @@
 
 				if ( tip.reference.getAttribute( "data-state" ) ) {
 					tip.smw.isPersistent = tip.reference.getAttribute( "data-state" ) === 'persistent';
-				}
-
-				if ( tip.reference.getAttribute( "data-maxwidth" ) ) {
-					tip.set( { maxWidth: parseInt( tip.reference.getAttribute( "data-maxwidth" ) ) } );
 				}
 
 				if ( tip.reference.getAttribute( "data-tooltipclass" ) ) {

--- a/tests/phpunit/Integration/JSONScript/TestCases/p-0106.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/p-0106.json
@@ -20,8 +20,12 @@
 			"message-cache": "clear",
 			"page": "P0106/Numeric_value",
 			"contents": "{{#info: 1 }}"
+		},
+		{
+			"message-cache": "clear",
+			"page": "P0106/maxwidth_theme",
+			"contents": "{{#info: some text |max-width=300 |theme=square-border}}"
 		}
-
 	],
 	"tests": [
 		{
@@ -71,8 +75,19 @@
 					"<span class=\"smwttcontent\">1</span>"
 				]
 			}
+		},
+		{
+			"type": "parser",
+			"about": "#4 (adding max-width, theme parameters)",
+			"subject": "P0106/maxwidth_theme",
+			"assert-output": {
+				"to-contain": [
+					"<span class=\"smw-highlighter\" data-type=\"6\" data-state=\"persistent\" data-title=\"Information\" title=\"some text\" data-maxwidth=\"300\" data-tooltipclass=\"square-border\">",
+					"<span class=\"smwtticon info\">",
+					"<span class=\"smwttcontent\">some text</span>"
+				]
+			}
 		}
-
 	],
 	"settings": {
 		"wgContLang": "en",

--- a/tests/phpunit/Integration/JSONScript/TestCases/p-0109.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/p-0109.json
@@ -2,42 +2,36 @@
 	"description": "Test `#info`, `#ask`/`#show` with error output (`wgContLang=en`, `wgLang=en`)",
 	"setup": [
 		{
-			"page": "Test/P0109/1",
-			"contents": "Info: {{#info: message=Test some error {{#show: [[Test/P0109/2]] |?Has text }} }}"
+			"page": "P0109/1",
+			"contents": "Info: {{#info: message=Test some error {{#show: [[P0109/2]] |?Has text }} }}"
+		},
+		{
+			"page": "P0109/2",
+			"contents": "Info: {{#info: message=Test some <span style='color:red;'>error</span> }}"
 		}
 	],
 	"tests": [
 		{
 			"type": "parser",
-			"about": "#0 (1.31-) switch #info to error display",
-			"skip-on": {
-				"mediawiki": [ ">1.30.x", "MediaWiki changed the HTML Tidy" ]
-			},
-			"subject": "Test/P0109/1",
+			"about": "#0 switch #info to error display, inner `smw-highlighter` is removed",
+			"subject": "P0109/1",
 			"assert-output": {
+				"n-sequence": true,
 				"to-contain": [
-					"Info: Test some error <span class=\"smw-highlighter\" data-type=\"4\""
-				],
-				"not-contain": [
-					"Info: <span class=\"smw-highlighter\" data-type=\"5\"",
-					"<div class=\"smwttcontent\">Test some error <span class=\"smw-highlighter\" data-type=\"4\""
+					"Info: <span class=\"smw-highlighter\" data-type=\"6\" data-state=\"persistent\"",
+					"title=\"Test some error "
 				]
 			}
 		},
 		{
 			"type": "parser",
-			"about": "#0 (1.31+) switch #info to error display",
-			"skip-on": {
-				"mediawiki": [ "<1.30.x", "MediaWiki changed the HTML Tidy" ]
-			},
-			"subject": "Test/P0109/1",
+			"about": "#1 inner <span> remains",
+			"subject": "P0109/2",
 			"assert-output": {
+				"n-sequence": true,
 				"to-contain": [
-					"Info: Test some error <span class=\"smw-highlighter\" data-type=\"4\""
-				],
-				"not-contain": [
-					"Info: <span class=\"smw-highlighter\" data-type=\"5\"",
-					"<div class=\"smwttcontent\">Test some error <span class=\"smw-highlighter\" data-type=\"4\""
+					"Info: <span class=\"smw-highlighter\" data-type=\"6\" data-state=\"persistent\"",
+					"Test some &lt;span style='color:red;'&gt;error&lt;/span&gt;"
 				]
 			}
 		}

--- a/tests/phpunit/Unit/ParserFunctions/InfoParserFunctionTest.php
+++ b/tests/phpunit/Unit/ParserFunctions/InfoParserFunctionTest.php
@@ -46,6 +46,8 @@ class InfoParserFunctionTest extends \PHPUnit_Framework_TestCase {
 			->method( 'getParameters' )
 			->will( $this->returnValue( [
 				'message'  => $processedParam,
+				'max-width'  => $processedParam,
+				'theme'  => $processedParam,
 				'icon'     => $processedParam ] ) );
 
 		$this->assertInternalType(


### PR DESCRIPTION
This PR is made in reference to: https://www.semantic-mediawiki.org/wiki/Thread:Help_talk:Special_characters_in_tooltips/Adding_a_tooltip

This PR addresses or contains:

- This doesn't answer the question of "what if I would like to add a custom tooltip (i.e. hacking SMW)" (which I don't recommend otherwise any modifications to the smw.tippy.js will be made invalid by the next upgrade) anyway:
  - The `Highlighter` class creates the HTML code in PHP while
  - `smw.tippy.js` is the corresponding tandem on the JS side to create and invoke the `tippy` instance (see atomiks/tippyjs) 
- This PR adds two new parameters to #info:
  - max-width: to define the maximum width with a tooltip, allowing it to be wider than the default to display more information at once
  - theme (square-border, square-border-light) to use a slightly different theme for the tooltip appearance

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed

## Example
```
{{#info: message=Integer eu ... |max-width=350 |theme=square-border }}
```

![image](https://user-images.githubusercontent.com/1245473/75093684-e7695600-557b-11ea-883e-06ad865fa76f.png)

![image](https://user-images.githubusercontent.com/1245473/75093690-edf7cd80-557b-11ea-849d-285c38026d43.png)
