### PR TITLE
Introduce class "smwbroadtable-clean"

### DIFF
--- a/res/smw/ext.smw.css
+++ b/res/smw/ext.smw.css
@@ -205,6 +205,13 @@ span.smwtlcomment {
 }
 
 .smwtable-clean {
+	max-width: 100%;
+	margin-bottom: 20px;
+	background-color: transparent;
+	border-spacing: 0px;
+}
+
+.smwbroadtable-clean {
 	width: 100%;
 	max-width: 100%;
 	margin-bottom: 20px;
@@ -212,19 +219,25 @@ span.smwtlcomment {
 	border-spacing: 0px;
 }
 
-.smwtable-clean tr {
-border-top: 1px solid #dddddd;
+.smwtable-clean tr,
+.smwbroadtable-clean tr {
+	border-top: 1px solid #dddddd;
 }
 
-.smwtable-clean th {
+.smwtable-clean th,
+.smwbroadtable-clean th {
 	text-align: left;
 }
 
-.smwtable-clean td, .smwtable-clean th {
+.smwtable-clean td,
+.smwbroadtable-clean td,
+.smwtable-clean th,
+.smwbroadtable-clean th {
 	padding: 0;
 }
 
-.smwtable-clean tr > th {
+.smwtable-clean tr > th,
+.smwbroadtable-clean tr > th {
 	padding: 8px !important;
 	line-height: 1.42857143;
 	vertical-align: top;
@@ -235,7 +248,8 @@ border-top: 1px solid #dddddd;
 	vertical-align: middle;
 }
 
-.smwtable-clean tr > td {
+.smwtable-clean tr > td,
+.smwbroadtable-clean tr > td {
 	padding: 8px !important;
 	line-height: 1.42857143;
 	vertical-align: top;
@@ -244,11 +258,13 @@ border-top: 1px solid #dddddd;
 	border-spacing: 0;
 }
 
-.smwtable-clean tbody > tr:nth-child(even) {
+.smwtable-clean tbody > tr:nth-child(even),
+.smwbroadtable-clean tbody > tr:nth-child(even) {
 	background-color: #f5f5f5;
 }
 
-.smwtable-clean tr > th.headerSort {
+.smwtable-clean tr > th.headerSort,
+.smwbroadtable-clean tr > th.headerSort {
 	padding-right: 21px !important;
 }
 

--- a/src/MediaWiki/Specials/SpecialConstraintErrorList.php
+++ b/src/MediaWiki/Specials/SpecialConstraintErrorList.php
@@ -50,7 +50,7 @@ class SpecialConstraintErrorList extends SpecialPage {
 			[
 				'q'      => '[[Has processing error text::+]] [[Processing error type::constraint]]',
 				'po'     => '?Has improper value for|?Has processing error text',
-				'p'      => 'class=sortable-20smwtable-2Dstriped-20smwtable-2Dclean/sep=ul',
+				'p'      => 'class=sortable-20smwbroadtable-2Dstriped-20smwbroadtable-2Dclean/sep=ul',
 				'eq'     => 'no',
 				'limit'  =>  $limit,
 				'bTitle' => 'constrainterrorlist',

--- a/src/MediaWiki/Specials/SpecialProcessingErrorList.php
+++ b/src/MediaWiki/Specials/SpecialProcessingErrorList.php
@@ -49,7 +49,7 @@ class SpecialProcessingErrorList extends SpecialPage {
 			[
 				'q'      => '[[Has processing error text::+]]',
 				'po'     => '?Has improper value for|?Has processing error text',
-				'p'      => 'class=sortable-20smwtable-2Dstriped-20smwtable-2Dclean/sep=ul',
+				'p'      => 'class=sortable-20smwbroadtable-2Dstriped-20smwbroadtable-2Dclean/sep=ul',
 				'eq'     => 'no',
 				'limit'  =>  $limit,
 				'bTitle' => 'processingerrorlist',

--- a/tests/phpunit/Unit/MediaWiki/Specials/SpecialConstraintErrorListTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Specials/SpecialConstraintErrorListTest.php
@@ -62,7 +62,7 @@ class SpecialConstraintErrorListTest extends \PHPUnit_Framework_TestCase {
 		$expected = [
 			'%5D%5D+%5B%5BProcessing+error+type%3A%3Aconstraint%5D%5D',
 			'&po=%3FHas+improper+value+for%7C%3FHas+processing+error+text',
-			'&p=class%3Dsortable-20smwtable-2Dstriped-20smwtable-2Dclean%2Fsep%3Dul',
+			'&p=class%3Dsortable-20smwbroadtable-2Dstriped-20smwtable-2Dclean%2Fsep%3Dul',
 			'&eq=no&limit=5',
 			'&bTitle=constrainterrorlist',
 			'&bHelp=smw-constrainterrorlist-helplink',

--- a/tests/phpunit/Unit/MediaWiki/Specials/SpecialProcessingErrorListTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Specials/SpecialProcessingErrorListTest.php
@@ -62,7 +62,7 @@ class SpecialProcessingErrorListTest extends \PHPUnit_Framework_TestCase {
 		$expected = [
 			'%5B%5BHas+processing+error+text%3A%3A%2B%5D%5D',
 			'&po=%3FHas+improper+value+for%7C%3FHas+processing+error+text',
-			'&p=class%3Dsortable-20smwtable-2Dstriped-20smwtable-2Dclean%2Fsep%3Dul',
+			'&p=class%3Dsortable-20smwtable-2Dstriped-20smwbroadtable-2Dclean%2Fsep%3Dul',
 			'&eq=no&limit=5',
 			'&bTitle=processingerrorlist',
 			'&bHelp=smw-processingerrorlist-helplink',


### PR DESCRIPTION
This PR is made in reference to: #4048 

This PR addresses or contains:
- Fixes the `smwtable-clean` class producing a broadtable
- Introduces the `smwbroadtable-clean` class to provide the same styling as the former `smwtable-clean` class

This PR includes:
- [ ] Tests (unit/integration)
- [ ] CI build passed

Fixes #