### PR TITLE
Fix "smwtable-clean" class being broad by default

### DIFF
--- a/res/smw/ext.smw.css
+++ b/res/smw/ext.smw.css
@@ -205,7 +205,7 @@ span.smwtlcomment {
 }
 
 .smwtable-clean {
-	width: 100%;
+	width: auto;
 	max-width: 100%;
 	margin-bottom: 20px;
 	background-color: transparent;


### PR DESCRIPTION
This PR is made in reference to: #4048 

This PR addresses or contains:
- Fix "smwtable-clean" class being broad by default

This PR includes:
- [ ] Tests (unit/integration)
- [ ] CI build passed

Fixes #