### PR TITLE
Add `SMW::Schema::RegisterSchemaTypes` hook, refs 3431

### DIFF
--- a/DefaultSettings.php
+++ b/DefaultSettings.php
@@ -32,7 +32,7 @@ return [
 	'smwgServicesFileDir' => __DIR__ . '/src/Services',
 	'smwgResourceLoaderDefFiles' => [ 'smw' => __DIR__ . '/res/Resources.php' ],
 	'smwgMaintenanceDir' => __DIR__ . '/maintenance',
-	'smwgTemplateDir' => __DIR__ . '/data/template',
+	'smwgDir' => __DIR__,
 	##
 
 	###

--- a/docs/technical/hooks.md
+++ b/docs/technical/hooks.md
@@ -14,6 +14,7 @@ Implementing a hook should be made in consideration of the expected performance 
 - `SMW::Settings::BeforeInitializationComplete` to modify the Semantic MediaWiki configuration before the initialization is completed
 - [`SMW::Event::RegisterEventListeners`][hook.event.registereventlisteners] to register additional event listeners
 - [`SMW::Listener::ChangeListener::RegisterPropertyChangeListeners`][hook.listener.registerpropertychangelisteners] allows to register and listen to individual property changes
+- [`SMW::Schema::RegisterSchemaTypes`][hook.schema.registerschematypes] allows to register additional schema types
 
 ### Store
 
@@ -120,3 +121,4 @@ Implementing a hook should be made in consideration of the expected performance 
 [hook.constraint.initconstraints]:https://github.com/SemanticMediaWiki/SemanticMediaWiki/blob/master/docs/technical/hooks/hook.constraint.initconstraints.md
 [hook.maintenance.afterupdateentitycollationcomplete]:https://github.com/SemanticMediaWiki/SemanticMediaWiki/blob/master/docs/technical/hooks/hook.maintenance.afterupdateentitycollationcomplete.md
 [hook.listener.registerpropertychangelistener]:https://github.com/SemanticMediaWiki/SemanticMediaWiki/blob/master/docs/technical/hooks/hook.listener.registerpropertychangelistener.md
+[hook.schema.registerschematypes]:https://github.com/SemanticMediaWiki/SemanticMediaWiki/blob/master/docs/technical/hooks/hook.schema.registerschematypes.md

--- a/docs/technical/hooks/hook.schema.registerschematypes.md
+++ b/docs/technical/hooks/hook.schema.registerschematypes.md
@@ -1,0 +1,27 @@
+* Since: 3.2
+* Description: Hook allows to register schema types
+* Reference class: [`SchemaTypes.php`][SchemaTypes.php]
+
+### Signature
+
+```php
+use Hooks;
+use SMW\Schema\SchemaTypes;
+
+Hooks::register( 'SMW::Schema::RegisterSchemaTypes', function( SchemaTypes $schemaTypes ) {
+
+	$params = [
+		'group' => FOO_GROUP,
+		'validation_schema' => $schemaTypes->withDir( 'foo-schema.v1.json' ),
+		'type_description' => 'smw-schema-description-foo-schema',
+		'change_propagation' => [ '_FOO_SCHEMA' ],
+		'usage_lookup' => '_FOO_SCHEMA'
+	];
+
+	$schemaTypes->registerSchemaType( 'FOO_SCHEMA', $params );
+
+	return true;
+} );
+```
+
+[RevisionGuard.php]:https://github.com/SemanticMediaWiki/SemanticMediaWiki/blob/master/src/Schema/SchemaTypes.php

--- a/includes/Settings.php
+++ b/includes/Settings.php
@@ -6,6 +6,7 @@ use SMW\Exception\SettingNotFoundException;
 use SMW\Exception\SettingsAlreadyLoadedException;
 use SMW\Listener\ChangeListener\ChangeListenerAwareTrait;
 use SMW\MediaWiki\HookDispatcherAwareTrait;
+use RuntimeException;
 
 /**
  * @private
@@ -71,7 +72,7 @@ class Settings extends Options {
 			'smwgServicesFileDir' => $GLOBALS['smwgServicesFileDir'],
 			'smwgResourceLoaderDefFiles' => $GLOBALS['smwgResourceLoaderDefFiles'],
 			'smwgMaintenanceDir' => $GLOBALS['smwgMaintenanceDir'],
-			'smwgTemplateDir' => $GLOBALS['smwgTemplateDir'],
+			'smwgDir' => $GLOBALS['smwgDir'],
 			'smwgConfigFileDir' => $GLOBALS['smwgConfigFileDir'],
 			'smwgImportFileDirs' => $GLOBALS['smwgImportFileDirs'],
 			'smwgImportReqVersion' => $GLOBALS['smwgImportReqVersion'],
@@ -292,6 +293,24 @@ class Settings extends Options {
 		}
 
 		return $r;
+	}
+
+	/**
+	 * @since 3.2
+	 *
+	 * @param string $key
+	 * @param mixed $key
+	 *
+	 * @return mixed
+	 * @throws RuntimeException
+	 */
+	public function mung( string $key, $mung ) {
+
+		if ( is_string( $mung ) ) {
+			return (string)$this->get( $key ) . $mung;
+		}
+
+		throw new RuntimeException( "Operation for the current type is not supported!" );
 	}
 
 }

--- a/src/MediaWiki/HookDispatcher.php
+++ b/src/MediaWiki/HookDispatcher.php
@@ -7,6 +7,7 @@ use SMW\Store;
 use SMW\Parser\AnnotationProcessor;
 use SMW\Property\Annotator as PropertyAnnotator;
 use Onoi\MessageReporter\MessageReporter;
+use SMW\Schema\SchemaTypes;
 
 /**
  * @private
@@ -27,6 +28,16 @@ use Onoi\MessageReporter\MessageReporter;
  * @author mwjames
  */
 class HookDispatcher {
+
+	/**
+	 * @see https://github.com/SemanticMediaWiki/SemanticMediaWiki/blob/master/docs/technical/hooks/hook.schema.registerschematypes.md
+	 * @since 3.2
+	 *
+	 * @param SchemaTypes $schemaTypes
+	 */
+	public function onRegisterSchemaTypes( SchemaTypes $schemaTypes ) {
+		Hooks::run( 'SMW::Schema::RegisterSchemaTypes', [ $schemaTypes ] );
+	}
 
 	/**
 	 * @see https://github.com/SemanticMediaWiki/SemanticMediaWiki/blob/master/docs/technical/hooks/hook.getpreferences.md

--- a/src/Schema/Exception/SchemaTypeAlreadyExistsException.php
+++ b/src/Schema/Exception/SchemaTypeAlreadyExistsException.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace SMW\Schema\Exception;
+
+use RuntimeException;
+
+/**
+ * @license GNU GPL v2+
+ * @since 3.2
+ *
+ * @author mwjames
+ */
+class SchemaTypeAlreadyExistsException extends RuntimeException {
+
+	/**
+	 * @since 3.2
+	 *
+	 * @param string $type
+	 */
+	public function __construct( $type ) {
+		parent::__construct( "$type is already registered as schema type." );
+	}
+
+}

--- a/src/Schema/SchemaTypes.php
+++ b/src/Schema/SchemaTypes.php
@@ -1,0 +1,144 @@
+<?php
+
+namespace SMW\Schema;
+
+use SMW\Schema\Exception\SchemaTypeAlreadyExistsException;
+use SMW\MediaWiki\HookDispatcherAwareTrait;
+
+/**
+ * @license GNU GPL v2+
+ * @since 3.2
+ *
+ * @author mwjames
+ */
+class SchemaTypes {
+
+	use HookDispatcherAwareTrait;
+
+	/**
+	 * @var array
+	 */
+	private $schemaTypes = [];
+
+	/**
+	 * @var string
+	 */
+	private $dir = '';
+
+	/**
+	 * @var bool
+	 */
+	private $onRegisterSchemaTypes = false;
+
+	/**
+	 * @since 3.2
+	 *
+	 * @param array $schemaTypes
+	 * @param string $dir
+	 */
+	public function __construct( array $schemaTypes = [], string $dir = '' ) {
+		$this->schemaTypes = $schemaTypes;
+		$this->dir = $dir;
+	}
+
+	/**
+	 * @since 3.2
+	 *
+	 * @param string $dir
+	 *
+	 * @return string
+	 */
+	public function withDir( string $dir = '' ) : string {
+		return "{$this->dir}/$dir";
+	}
+
+	/**
+	 * @since 3.2
+	 *
+	 * @param array $schemaTypes
+	 */
+	public function registerSchemaTypes( array $schemaTypes ) {
+
+		if ( $this->onRegisterSchemaTypes ) {
+			return;
+		}
+
+		$this->onRegisterSchemaTypes = true;
+		$this->schemaTypes = $schemaTypes;
+
+		$this->hookDispatcher->onRegisterSchemaTypes( $this );
+	}
+
+	/**
+	 * This method is provided for hook handlers to register a new schema type
+	 * via the `SMW::Schema::RegisterSchemaTypes` hook.
+	 *
+	 * @since 3.2
+	 *
+	 * @param string $type
+	 * @param array $params
+	 *
+	 * @throws SchemaTypeAlreadyExistsException
+	 */
+	public function registerSchemaType( string $type, array $params ) {
+
+		if ( isset( $this->schemaTypes[$type] ) ) {
+			throw new SchemaTypeAlreadyExistsException( $type );
+		}
+
+		$this->schemaTypes[$type] = $params;
+	}
+
+	/**
+	 * @since 3.2
+	 *
+	 * @param string $type
+	 *
+	 * @return []
+	 */
+	public function getType( string $type ) : array {
+		return $this->schemaTypes[$type] ?? [];
+	}
+
+	/**
+	 * @since 3.2
+	 *
+	 * @param string|null $type
+	 *
+	 * @return boolean
+	 */
+	public function isRegisteredType( ?string $type ) : bool {
+		return isset( $this->schemaTypes[$type] );
+	}
+
+	/**
+	 * @since 3.2
+	 *
+	 * @return []
+	 */
+	public function getRegisteredTypes() : array {
+		return array_keys( $this->schemaTypes );
+	}
+
+	/**
+	 * @since 3.2
+	 *
+	 * @param string $group
+	 *
+	 * @return []
+	 */
+	public function getRegisteredTypesByGroup( string $group ) : array {
+
+		$registeredTypes = [];
+		$groups = (array)$group;
+
+		foreach ( $this->schemaTypes as $type => $val ) {
+			if ( isset( $val['group'] ) && in_array( $val['group'], $groups ) ) {
+				$registeredTypes[] = $type;
+			}
+		}
+
+		return $registeredTypes;
+	}
+
+}

--- a/src/SetupCheck.php
+++ b/src/SetupCheck.php
@@ -296,7 +296,7 @@ class SetupCheck {
 
 		// Output forms for different error types are registered with a JSON file.
 		$this->definitions = $this->readFromFile(
-			$GLOBALS['smwgTemplateDir'] . '/setupcheck/setupcheck.json'
+			$GLOBALS['smwgDir'] . '/data/template/setupcheck/setupcheck.json'
 		);
 
 		// Error messages are specified in a special i18n JSON file to avoid relying

--- a/src/Utils/TemplateEngine.php
+++ b/src/Utils/TemplateEngine.php
@@ -42,7 +42,7 @@ class TemplateEngine {
 		$this->templateDir = $templateDir;
 
 		if ( $this->templateDir === null ) {
-			$this->templateDir = $GLOBALS['smwgTemplateDir'];
+			$this->templateDir = $GLOBALS['smwgDir'] . '/data/template';
 		}
 	}
 

--- a/tests/phpunit/Integration/MediaWiki/HookDispatcherTest.php
+++ b/tests/phpunit/Integration/MediaWiki/HookDispatcherTest.php
@@ -55,6 +55,24 @@ class HookDispatcherTest extends \PHPUnit_Framework_TestCase {
 		);
 	}
 
+	public function testOnRegisterSchemaTypes() {
+
+		$hookDispatcher = new HookDispatcher();
+
+		$schemaTypes = $this->getMockBuilder( '\SMW\Schema\SchemaTypes' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$schemaTypes->expects( $this->once() )
+			->method( 'registerSchemaType' );
+
+		$this->mwHooksHandler->register( 'SMW::Schema::RegisterSchemaTypes', function( $schemaTypes ) {
+			$schemaTypes->registerSchemaType( 'Foo', [] );
+		} );
+
+		$hookDispatcher->onRegisterSchemaTypes( $schemaTypes );
+	}
+
 	public function testOnGetPreferences() {
 
 		$preferences = [];

--- a/tests/phpunit/Unit/Schema/Exception/SchemaTypeAlreadyExistsExceptionTest.php
+++ b/tests/phpunit/Unit/Schema/Exception/SchemaTypeAlreadyExistsExceptionTest.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace SMW\Tests\Schema\Exception;
+
+use SMW\Schema\Exception\SchemaTypeAlreadyExistsException;
+
+/**
+ * @covers \SMW\Schema\Exception\SchemaTypeAlreadyExistsException
+ * @group semantic-mediawiki
+ *
+ * @license GNU GPL v2+
+ * @since 3.2
+ *
+ * @author mwjames
+ */
+class SchemaTypeAlreadyExistsExceptionTest extends \PHPUnit_Framework_TestCase {
+
+	public function testCanConstruct() {
+
+		$instance = new SchemaTypeAlreadyExistsException( 'foo' );
+
+		$this->assertInstanceof(
+			SchemaTypeAlreadyExistsException::class,
+			$instance
+		);
+
+		$this->assertInstanceof(
+			'\RuntimeException',
+			$instance
+		);
+	}
+
+}

--- a/tests/phpunit/Unit/Schema/SchemaFactoryTest.php
+++ b/tests/phpunit/Unit/Schema/SchemaFactoryTest.php
@@ -88,49 +88,6 @@ class SchemaFactoryTest extends \PHPUnit_Framework_TestCase {
 		);
 	}
 
-	public function testIsRegisteredType() {
-
-		$instance = new SchemaFactory(
-			[
-				'foo' => []
-			]
-		);
-
-		$this->assertTrue(
-			$instance->isRegisteredType( 'foo' )
-		);
-	}
-
-	public function testGetRegisteredTypes() {
-
-		$instance = new SchemaFactory(
-			[
-				'foo' => [],
-				'bar' => []
-			]
-		);
-
-		$this->assertEquals(
-			[ 'foo', 'bar' ],
-			$instance->getRegisteredTypes()
-		);
-	}
-
-	public function testGetRegisteredTypesByGroup() {
-
-		$instance = new SchemaFactory(
-			[
-				'foo' => [ 'group' => 'f_group' ],
-				'bar' => [ 'group' => 'b_group' ]
-			]
-		);
-
-		$this->assertEquals(
-			[ 'foo' ],
-			$instance->getRegisteredTypesByGroup( 'f_group' )
-		);
-	}
-
 	public function testNewSchemaDefinition() {
 
 		$instance = new SchemaFactory(

--- a/tests/phpunit/Unit/Schema/SchemaTypesTest.php
+++ b/tests/phpunit/Unit/Schema/SchemaTypesTest.php
@@ -1,0 +1,135 @@
+<?php
+
+namespace SMW\Tests\Schema;
+
+use SMW\Schema\SchemaTypes;
+use SMW\Tests\PHPUnitCompat;
+use SMW\Tests\TestEnvironment;
+
+/**
+ * @covers \SMW\Schema\SchemaTypes
+ * @group semantic-mediawiki
+ *
+ * @license GNU GPL v2+
+ * @since 3.2
+ *
+ * @author mwjames
+ */
+class SchemaTypesTest extends \PHPUnit_Framework_TestCase {
+
+	use PHPUnitCompat;
+
+	private $testEnvironment;
+	private $hookDispatcher;
+
+	protected function setUp() : void {
+		parent::setUp();
+
+		$this->testEnvironment = new TestEnvironment();
+
+		$this->hookDispatcher = $this->getMockBuilder( '\SMW\MediaWiki\HookDispatcher' )
+			->disableOriginalConstructor()
+			->getMock();
+	}
+
+	protected function tearDown() : void {
+		$this->testEnvironment->tearDown();
+		parent::tearDown();
+	}
+
+	public function testCanConstruct() {
+
+		$instance = new SchemaTypes();
+
+		$this->assertInstanceof(
+			SchemaTypes::class,
+			$instance
+		);
+	}
+
+	public function testRegisterSchemaTypes() {
+
+		$this->hookDispatcher->expects( $this->once() )
+			->method( 'onRegisterSchemaTypes' );
+
+		$instance = new SchemaTypes();
+		$instance->setHookDispatcher( $this->hookDispatcher );
+
+		$instance->registerSchemaTypes( [] );
+	}
+
+	public function testRegisterSchemaType() {
+
+		$instance = new SchemaTypes();
+
+		$instance->registerSchemaType( 'Foo', [] );
+
+		$this->assertTrue(
+			$instance->isRegisteredType( 'Foo' )
+		);
+	}
+
+	public function testGetRegisteredTypes() {
+
+		$instance = new SchemaTypes();
+
+		$instance->registerSchemaType( 'Foo', [] );
+		$instance->registerSchemaType( 'Bar', [ 'bar' => 123 ] );
+
+		$this->assertEquals(
+			[ 'Foo', 'Bar' ],
+			$instance->getRegisteredTypes()
+		);
+	}
+
+	public function testGetRegisteredTypesByGroup() {
+
+		$instance = new SchemaTypes();
+
+		$instance->registerSchemaType( 'Foo', [ 'group' => 'foo_bar' ] );
+		$instance->registerSchemaType( 'Bar', [ 'bar' => 123, 'group' => 'foobar' ] );
+
+		$this->assertEquals(
+			[ 'Bar' ],
+			$instance->getRegisteredTypesByGroup( 'foobar' )
+		);
+	}
+
+	public function testGetType() {
+
+		$instance = new SchemaTypes();
+
+		$this->assertEquals(
+			[],
+			$instance->getType( 'Foo' )
+		);
+
+		$instance->registerSchemaType( 'Foo', [ 'bar' => 123 ] );
+
+		$this->assertEquals(
+			[ 'bar' => 123 ],
+			$instance->getType( 'Foo' )
+		);
+	}
+
+	public function testWithDir() {
+
+		$instance = new SchemaTypes( [], __DIR__ );
+
+		$this->assertEquals(
+			__DIR__ . '/Foo',
+			$instance->withDir( 'Foo' )
+		);
+	}
+
+	public function testRegisterKnownSchemaType_ThrowsException() {
+
+		$instance = new SchemaTypes();
+
+		$instance->registerSchemaType( 'Foo', [] );
+
+		$this->expectException( '\SMW\Schema\Exception\SchemaTypeAlreadyExistsException' );
+		$instance->registerSchemaType( 'Foo', [] );
+	}
+
+}

--- a/tests/phpunit/Utils/MwHooksHandler.php
+++ b/tests/phpunit/Utils/MwHooksHandler.php
@@ -51,6 +51,8 @@ class MwHooksHandler {
 		'SMW::Browse::AfterIncomingPropertiesLookupComplete',
 		'SMW::Browse::BeforeIncomingPropertyValuesFurtherLinkCreate',
 
+		'SMW::Schema::RegisterSchemaTypes',
+
 		'SMW::GetPreferences',
 		'SMW::Parser::AfterLinksProcessingComplete',
 		'SMW::Parser::ParserAfterTidyPropertyAnnotationComplete',

--- a/tests/phpunit/includes/SettingsTest.php
+++ b/tests/phpunit/includes/SettingsTest.php
@@ -157,6 +157,24 @@ class SettingsTest extends \PHPUnit_Framework_TestCase {
 		$instance->loadFromGlobals();
 	}
 
+	public function testMung() {
+
+		$instance = Settings::newFromArray( [ 'Foo' => 123 ] );
+
+		$this->assertEquals(
+			'123bar',
+			$instance->mung( 'Foo', 'bar' )
+		);
+	}
+
+	public function testMungOnUnknownTypeThrowsException() {
+
+		$instance = Settings::newFromArray( [ 'Foo' => 123 ] );
+
+		$this->expectException( '\RuntimeException' );
+		$instance->mung( 'Foo', 456 );
+	}
+
 	/**
 	 * Provides sample data to be tested
 	 *


### PR DESCRIPTION
This PR is made in reference to: #

This PR addresses or contains:

- Adds `SMW::Schema::RegisterSchemaTypes` as replacement for `$smwgSchemaTypes` which becomes deprecated as of 3.2 (it isn't a config setting)
- Description can be found in https://github.com/SemanticMediaWiki/SemanticMediaWiki/blob/master/docs/technical/hooks/hook.schema.registerschematypes.md

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed

Fixes #