### PR TITLE
Add predefined properties group, refs 3749

### DIFF
--- a/data/import/groups/predefined.properties.json
+++ b/data/import/groups/predefined.properties.json
@@ -1,0 +1,76 @@
+{
+    "type": "PROPERTY_GROUP_SCHEMA",
+    "groups": {
+        "adminstrative_group": {
+            "canonical_name": "Adminstrative properties",
+            "message_key": "smw-property-group-label-adminstrative-properties",
+            "property_keys": [
+                "_MDAT",
+                "_CDAT",
+                "_NEWP",
+                "_LEDT",
+                "_DTITLE",
+                "_CHGPRO",
+                "_EDIP",
+                "_ERRC"
+            ]
+        },
+        "classification_group": {
+            "canonical_name": "Classification properties",
+            "message_key": "smw-property-group-label-classification-properties",
+            "property_keys": [
+                "_INST",
+                "_PPGR",
+                "_SUBP",
+                "_SUBC"
+            ]
+        },
+        "content_group": {
+            "canonical_name": "Content properties",
+            "message_key": "smw-property-group-label-content-properties",
+            "property_keys": [
+                "_SOBJ",
+                "_ASK",
+                "_MEDIA",
+                "_MIME",
+                "_ATTCH_LINK",
+                "_FILE_ATTCH",
+                "_CONT_TYPE",
+                "_CONT_AUTHOR",
+                "_CONT_LEN",
+                "_CONT_LANG",
+                "_CONT_TITLE",
+                "_CONT_DATE",
+                "_CONT_KEYW",
+                "_TRANS",
+                "_TRANS_SOURCE",
+                "_TRANS_GROUP"
+            ]
+        },
+        "declarative_group": {
+            "canonical_name": "Declarative properties",
+            "message_key" : "smw-property-group-label-declarative-properties",
+            "property_keys": [
+                "_TYPE",
+                "_UNIT",
+                "_IMPO",
+                "_CONV",
+                "_SERV",
+                "_PVAL",
+                "_LIST",
+                "_PREC",
+                "_PDESC",
+                "_PPLB",
+                "_PVAP",
+                "_PVALI",
+                "_PVUC",
+                "_PEID",
+                "_PEFU"
+            ]
+        }
+    },
+    "tags": [
+        "group",
+        "property group"
+    ]
+}

--- a/data/import/groups/schema.json
+++ b/data/import/groups/schema.json
@@ -1,10 +1,10 @@
 {
     "type": "PROPERTY_GROUP_SCHEMA",
-    "groups": [
-        {
-            "group_name": "Schema properties",
+    "groups": {
+        "schema_group": {
+            "canonical_name": "Schema properties",
             "message_key": "smw-property-group-label-schema-group",
-            "properties": [
+            "property_keys": [
                 "_SCHEMA_TYPE",
                 "_SCHEMA_DEF",
                 "_SCHEMA_DESC",
@@ -15,7 +15,7 @@
                 "_PROFILE_SCHEMA"
             ]
         }
-    ],
+    },
     "tags": [
         "group",
         "property group"

--- a/data/import/smw.groups.json
+++ b/data/import/smw.groups.json
@@ -10,6 +10,16 @@
 			"options": {
 				"replaceable": { "LAST_EDITOR": "IS_IMPORTER" }
 			}
+		},
+		{
+			"page": "Group:Predefined properties",
+			"namespace": "SMW_NS_SCHEMA",
+			"contents": {
+				"importFrom": "/groups/predefined.properties.json"
+			},
+			"options": {
+				"replaceable": { "LAST_EDITOR": "IS_IMPORTER" }
+			}
 		}
 	],
 	"meta": {

--- a/data/schema/property-group-schema.v1.json
+++ b/data/schema/property-group-schema.v1.json
@@ -45,16 +45,22 @@
 			}
 		},
 		"groups": {
-			"$id": "#/properties/groups",
-			"type": "array",
-			"title": "group list",
-			"minItems": 1,
-			"items": {
-				"$ref": "#/definitions/group"
-			}
+			"$ref": "#/definitions/groups"
 		}
 	},
 	"definitions": {
+		"groups": {
+			"$id": "#/definitions/groups",
+			"type": "object",
+			"title": "Definition of groups",
+			"minProperties": 1,
+			"patternProperties": {
+				"^(.*)_group": {
+					"$ref": "#/definitions/group"
+				}
+			},
+			"additionalProperties": false
+		},
 		"group": {
 			"$id": "#/definitions/group",
 			"type": "object",
@@ -63,44 +69,41 @@
 			"propertyNames": {
 				"pattern": "^[A-Za-z_][A-Za-z0-9_]*$"
 			},
-			"required": [ "properties", "group_name" ],
+			"required": [ "property_keys", "canonical_name" ],
 			"properties": {
 				"message_key": {
 					"$ref": "#/definitions/message_key"
 				},
-				"group_name": {
-					"$ref": "#/definitions/group_name"
+				"canonical_name": {
+					"$ref": "#/definitions/canonical_name"
 				},
-				"properties": {
-					"$ref": "#/definitions/properties"
+				"property_keys": {
+					"$ref": "#/definitions/property_keys"
 				}
 			},
-			"additionalProperties": false,
-			"required": [
-				"properties"
-			]
+			"additionalProperties": false
 		},
 		"message_key": {
 			"$id": "#/definitions/message_key",
 			"type": "string",
-			"title": "message key/label",
+			"title": "Group name as message key",
 			"default": "",
 			"examples": [
 				"smw-property-group-label-schema-group"
 			],
 			"pattern": "^(smw|sar|sesp|sbl|scite|sg)-property-group-label-(.*)$"
 		},
-		"group_name": {
-			"$id": "#/definitions/group_name",
+		"canonical_name": {
+			"$id": "#/definitions/canonical_name",
 			"type": "string",
-			"title": "Simple group label",
+			"title": "Canonical group name",
 			"default": "",
 			"pattern": "^(.*)$"
 		},
-		"properties": {
-			"$id": "#/definitions/properties",
+		"property_keys": {
+			"$id": "#/definitions/property_keys",
 			"type": "array",
-			"title": "property list",
+			"title": "List of properties keys",
 			"minItems": 1,
 			"items": {
 				"type": "string",

--- a/src/MediaWiki/Specials/Browse/GroupFormatter.php
+++ b/src/MediaWiki/Specials/Browse/GroupFormatter.php
@@ -257,19 +257,34 @@ class GroupFormatter {
 		foreach ( $schemaList->getList() as $schemaDefinition ) {
 			foreach ( $schemaDefinition->get( 'groups' ) as $data ) {
 
-				if ( !isset( $data['properties'] ) || !isset( $data['group_name'] ) ) {
+				$message_key = '';
+
+				if ( isset( $data['properties'] ) ) {
+					$property_keys = $data['properties'];
+				} elseif ( isset( $data['property_keys'] ) ) {
+					$property_keys = $data['property_keys'];
+				} else {
 					continue;
 				}
 
-				$group = str_replace( '_', ' ', $data['group_name'] );
-				$message_key = isset( $data['message_key'] ) ? $data['message_key'] : '';
+				if( isset( $data['message_key'] ) ) {
+					$message_key = $data['message_key'];
+				}
 
-				if ( $message_key !== '' && !Message::exists( $message_key ) && isset( $data['group_name'] ) ) {
+				if ( isset( $data['canonical_name'] ) ) {
+					$group = $data['canonical_name'];
+				} elseif ( isset( $data['group_name'] ) ) {
 					$group = $data['group_name'];
+				} elseif( $message_key === '' ) {
+					continue;
+				}
+
+				if ( $message_key !== '' && !Message::exists( $message_key ) ) {
+					$message_key = $group;
 				}
 
 				$list[$group] = [
-					'properties' => array_flip( $data['properties'] ),
+					'properties' => array_flip( $property_keys ),
 					'msg_key' => $message_key,
 					'item' => DIWikiPage::newFromText( $schemaDefinition->getName(), SMW_NS_SCHEMA )
 				];

--- a/src/Setup.php
+++ b/src/Setup.php
@@ -277,7 +277,9 @@ final class Setup {
 			//
 			// Message::setInterfaceMessageFlag "... used to restore the flag
 			// after setting a language"
-			return $message->setInterfaceMessageFlag( true )->title( $GLOBALS['wgTitle'] )->parse();
+			$title = $GLOBALS['wgTitle'] ?? \Title::newFromText( 'Blank', NS_SPECIAL );
+
+			return $message->setInterfaceMessageFlag( true )->title( $title )->parse();
 		} );
 	}
 


### PR DESCRIPTION
This PR is made in reference to: #3749

This PR addresses or contains:

- Adds an import for a group definition of some SMW core predefined properties and as before, if the wiki defines an individual group for a property then this has priority before the pre-deployed group assignment
- Slightly changes the `PROPERTY_GROUP_SCHEMA` schema to make the content more readable

This PR includes:
- [ ] Tests (unit/integration)
- [x] CI build passed
