### PR TITLE
Tweak the fix of "smwtable-clean" class being broad by default

### DIFF
--- a/res/smw/ext.smw.css
+++ b/res/smw/ext.smw.css
@@ -193,11 +193,11 @@ span.smwtlcomment {
 }
 
 .smwtable-striped tbody > tr:nth-child(even) {
-   background-color: #f5f5f5;
+	background-color: #f5f5f5;
 }
 
 .smwtable-striped tbody > tr:nth-child(odd) {
-   background-color: #fff;
+	background-color: #fff;
 }
 
 .smwtable-striped tbody > tr:hover {
@@ -213,7 +213,7 @@ span.smwtlcomment {
 }
 
 .smwtable-clean tr {
-border-top: 1px solid #dddddd;
+	border-top: 1px solid #dddddd;
 }
 
 .smwtable-clean th {
@@ -250,6 +250,11 @@ border-top: 1px solid #dddddd;
 
 .smwtable-clean tr > th.headerSort {
 	padding-right: 21px !important;
+}
+
+/* Make it work for inline broadtable */
+.smwtable-clean.broadtable {
+	width: 100%;
 }
 
 div.smwhr hr {


### PR DESCRIPTION
This PR is made in reference to: #4589 

This PR addresses or contains:
- Tweak the fix of "smwtable-clean" class being broad by default

This PR includes:
- [ ] Tests (unit/integration)
- [ ] CI build passed

Fixes #