### PR TITLE
Support to define `import_performer`

### DIFF
--- a/src/Importer/ContentCreators/TextContentCreator.php
+++ b/src/Importer/ContentCreators/TextContentCreator.php
@@ -10,6 +10,7 @@ use SMW\MediaWiki\Database;
 use SMW\MediaWiki\TitleFactory;
 use SMW\Utils\CliMsgFormatter;
 use Title;
+use User;
 
 /**
  * @license GNU GPL v2+
@@ -145,10 +146,18 @@ class TextContentCreator implements ContentCreator {
 			$title
 		);
 
+		$user = null;
+
+		if ( $importContents->getImportPerformer() !== '' ) {
+			$user = User::newSystemUser( $importContents->getImportPerformer(), [ 'steal' => true ] );
+		}
+
 		$status = $page->doEditContent(
 			$content,
 			$importContents->getDescription(),
-			EDIT_FORCE_BOT
+			EDIT_FORCE_BOT,
+			false,
+			$user
 		);
 
 		if ( !$status->isOk() ) {
@@ -188,17 +197,17 @@ class TextContentCreator implements ContentCreator {
 
 	private function isCreatorLastEditor( $page ) {
 
-		$lastEditor = \User::newFromID(
+		$lastEditor = User::newFromID(
 			$page->getUser()
 		);
 
-		if ( !$lastEditor instanceof \User ) {
+		if ( !$lastEditor instanceof User ) {
 			return false;
 		}
 
 		$creator = $page->getCreator();
 
-		if ( !$creator instanceof \User ) {
+		if ( !$creator instanceof User ) {
 			return false;
 		}
 

--- a/src/Importer/ContentModeller.php
+++ b/src/Importer/ContentModeller.php
@@ -40,6 +40,10 @@ class ContentModeller {
 				$importContents->setName( $value['page'] );
 			}
 
+			if ( isset( $value['import_performer'] ) ) {
+				$importContents->setImportPerformer( $value['import_performer'] );
+			}
+
 			if ( isset( $value['description'] ) ) {
 				$importContents->setDescription( $value['description'] );
 			} elseif ( isset( $fileContents['description'] ) ) {
@@ -54,11 +58,7 @@ class ContentModeller {
 				$importContents->setVersion( 0 );
 			}
 
-			if ( isset( $value['contents']['type'] ) && $value['contents']['type'] === 'xml' ) {
-				$contents[] = $this->newImportContents( $importContents, $fileDir, $value );
-			} else {
-				$contents[] = $this->newImportContents( $importContents, $fileDir, $value );
-			}
+			$contents[] = $this->newImportContents( $importContents, $fileDir, $value );
 		}
 
 		return $contents;

--- a/src/Importer/ImportContents.php
+++ b/src/Importer/ImportContents.php
@@ -29,6 +29,11 @@ class ImportContents {
 	private $name = '';
 
 	/**
+	 * @var string
+	 */
+	private $importPerformer = '';
+
+	/**
 	 * @var integer
 	 */
 	private $namespace = 0;
@@ -128,6 +133,24 @@ class ImportContents {
 	 */
 	public function getName() {
 		return $this->name;
+	}
+
+	/**
+	 * @since 3.2
+	 *
+	 * @param string $importPerformer
+	 */
+	public function setImportPerformer( string $importPerformer ) {
+		$this->importPerformer = $importPerformer;
+	}
+
+	/**
+	 * @since 2.5
+	 *
+	 * @return string
+	 */
+	public function getImportPerformer() : string {
+		return $this->importPerformer;
 	}
 
 	/**

--- a/tests/phpunit/Unit/Importer/ContentModellerTest.php
+++ b/tests/phpunit/Unit/Importer/ContentModellerTest.php
@@ -18,7 +18,6 @@ class ContentModellerTest extends \PHPUnit_Framework_TestCase {
 
 	private $contentModeller;
 	private $testEnvironment;
-	private $fixtures;
 
 	protected function setUp() : void {
 		parent::setUp();
@@ -26,7 +25,6 @@ class ContentModellerTest extends \PHPUnit_Framework_TestCase {
 		$this->contentModeller = new ContentModeller();
 
 		$this->testEnvironment = new TestEnvironment();
-		$this->fixtures = __DIR__ . '/Fixtures';
 	}
 
 	public function testCanConstruct() {

--- a/tests/phpunit/Unit/Importer/ImportContentsTest.php
+++ b/tests/phpunit/Unit/Importer/ImportContentsTest.php
@@ -59,6 +59,18 @@ class ImportContentsTest extends \PHPUnit_Framework_TestCase {
 		);
 	}
 
+	public function testImportPerformer() {
+
+		$instance = new ImportContents();
+
+		$instance->setImportPerformer( 'Foo' );
+
+		$this->assertSame(
+			'Foo',
+			$instance->getImportPerformer()
+		);
+	}
+
 	public function testNamespace() {
 
 		$instance = new ImportContents();


### PR DESCRIPTION
This PR is made in reference to: #

This PR addresses or contains:

- Allows to define `import_performer` in the JSON definition for imports which then relies on `User::newSystemUser`

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed
