### PR TITLE
Isolate `Hooks::run` in `PropertyChangeListener`, refs 4478

### DIFF
--- a/src/MediaWiki/HookDispatcher.php
+++ b/src/MediaWiki/HookDispatcher.php
@@ -8,6 +8,7 @@ use SMW\Parser\AnnotationProcessor;
 use SMW\Property\Annotator as PropertyAnnotator;
 use Onoi\MessageReporter\MessageReporter;
 use SMW\Schema\SchemaTypes;
+use SMW\Listener\ChangeListener\ChangeListeners\PropertyChangeListener;
 
 /**
  * @private
@@ -28,6 +29,16 @@ use SMW\Schema\SchemaTypes;
  * @author mwjames
  */
 class HookDispatcher {
+
+	/**
+	 * @see https://github.com/SemanticMediaWiki/SemanticMediaWiki/blob/master/docs/technical/hooks/hook.listener.registerpropertychangelisteners.md
+	 * @since 3.2
+	 *
+	 * @param PropertyChangeListener $propertyChangeListener
+	 */
+	public function onRegisterPropertyChangeListeners( PropertyChangeListener $propertyChangeListener ) {
+		Hooks::run( 'SMW::Listener::ChangeListener::RegisterPropertyChangeListeners', [ $propertyChangeListener ] );
+	}
 
 	/**
 	 * @see https://github.com/SemanticMediaWiki/SemanticMediaWiki/blob/master/docs/technical/hooks/hook.schema.registerschematypes.md

--- a/src/SQLStore/SQLStoreFactory.php
+++ b/src/SQLStore/SQLStoreFactory.php
@@ -890,6 +890,12 @@ class SQLStoreFactory {
 			$this->getLogger()
 		);
 
+		$propertyChangeListener->setHookDispatcher(
+			$applicationFactory->getHookDispatcher()
+		);
+
+		$propertyChangeListener->loadListeners();
+
 		$hierarchyLookup = $applicationFactory->newHierarchyLookup();
 
 		// #2698

--- a/tests/phpunit/Integration/MediaWiki/HookDispatcherTest.php
+++ b/tests/phpunit/Integration/MediaWiki/HookDispatcherTest.php
@@ -55,6 +55,28 @@ class HookDispatcherTest extends \PHPUnit_Framework_TestCase {
 		);
 	}
 
+	public function testOnRegisterPropertyChangeListeners() {
+
+		$hookDispatcher = new HookDispatcher();
+
+		$property = $this->getMockBuilder( '\SMW\DIProperty' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$propertyChangeListener = $this->getMockBuilder( '\SMW\Listener\ChangeListener\ChangeListeners\PropertyChangeListener' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$propertyChangeListener->expects( $this->once() )
+			->method( 'addListenerCallback' );
+
+		$this->mwHooksHandler->register( 'SMW::Listener::ChangeListener::RegisterPropertyChangeListeners', function( $propertyChangeListener ) use ( $property ) {
+			$propertyChangeListener->addListenerCallback( $property, function(){} );
+		} );
+
+		$hookDispatcher->onRegisterPropertyChangeListeners( $propertyChangeListener );
+	}
+
 	public function testOnRegisterSchemaTypes() {
 
 		$hookDispatcher = new HookDispatcher();

--- a/tests/phpunit/Utils/MwHooksHandler.php
+++ b/tests/phpunit/Utils/MwHooksHandler.php
@@ -51,6 +51,8 @@ class MwHooksHandler {
 		'SMW::Browse::AfterIncomingPropertiesLookupComplete',
 		'SMW::Browse::BeforeIncomingPropertyValuesFurtherLinkCreate',
 
+		'SMW::Listener::ChangeListener::RegisterPropertyChangeListeners',
+
 		'SMW::Schema::RegisterSchemaTypes',
 
 		'SMW::GetPreferences',


### PR DESCRIPTION
This PR is made in reference to: #4478

This PR addresses or contains:

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed
