### PR TITLE
Special:Browse recognize `lang` parameter

### DIFF
--- a/src/MediaWiki/Specials/Browse/FieldBuilder.php
+++ b/src/MediaWiki/Specials/Browse/FieldBuilder.php
@@ -5,6 +5,7 @@ namespace SMW\MediaWiki\Specials\Browse;
 use Html;
 use SMW\Message;
 use SpecialPage;
+use SMW\Localizer;
 
 /**
  * @private
@@ -27,10 +28,15 @@ class FieldBuilder {
 	 *
 	 * @return string
 	 */
-	public static function createQueryForm( $articletext = '' ) {
+	public static function createQueryForm( $articletext = '', $lang = Message::USER_LANGUAGE ) {
 
 		$title = SpecialPage::getTitleFor( 'Browse' );
-		$dir = $title->getPageLanguage()->isRTL() ? 'rtl' : 'ltr';
+
+		if ( $lang !== Message::USER_LANGUAGE ) {
+			$dir = Localizer::getInstance()->getLanguage( $lang )->isRTL() ? 'rtl' : 'ltr';
+		} else {
+			$dir = $title->getPageLanguage()->isRTL() ? 'rtl' : 'ltr';
+		}
 
 		$html = "<div class=\"smwb-form\">". Html::rawElement(
 			'div',
@@ -52,7 +58,7 @@ class FieldBuilder {
 					'name'  => 'title',
 					'value' => $title->getPrefixedText()
 				],
-				 Message::get( 'smw_browse_article', Message::ESCAPED, Message::USER_LANGUAGE )
+				 Message::get( 'smw_browse_article', Message::ESCAPED, $lang )
 			) .
 			Html::rawElement(
 				'div',
@@ -87,7 +93,7 @@ class FieldBuilder {
 						[
 							'type'  => 'submit',
 							'class' => 'input-button mw-ui-button',
-							'value' => Message::get( 'smw_browse_go', Message::ESCAPED, Message::USER_LANGUAGE )
+							'value' => Message::get( 'smw_browse_go', Message::ESCAPED, $lang )
 						]
 					)
 				)
@@ -107,7 +113,7 @@ class FieldBuilder {
 	 *
 	 * @return string
 	 */
-	public static function createLink( $linkMsg, array $parameters ) {
+	public static function createLink( $linkMsg, array $parameters, $lang = Message::USER_LANGUAGE ) {
 
 		$title = SpecialPage::getSafeTitleFor( 'Browse' );
 		$fragment = $linkMsg === 'smw_browse_show_incoming' ? '#smw_browse_incoming' : '';
@@ -118,7 +124,7 @@ class FieldBuilder {
 				'href' => $title->getLocalURL( $parameters ) . $fragment,
 				'class' => $linkMsg
 			],
-			Message::get( $linkMsg, Message::TEXT, Message::USER_LANGUAGE )
+			Message::get( $linkMsg, Message::TEXT, $lang )
 		);
 	}
 

--- a/src/MediaWiki/Specials/Browse/HtmlBuilder.php
+++ b/src/MediaWiki/Specials/Browse/HtmlBuilder.php
@@ -80,6 +80,11 @@ class HtmlBuilder {
 	private $options = [];
 
 	/**
+	 * @var array
+	 */
+	private $language = 'en';
+
+	/**
 	 * @since 2.5
 	 *
 	 * @param Store $store
@@ -172,6 +177,8 @@ class HtmlBuilder {
 			'subobject' => $this->subject->getSubobjectName(),
 		];
 
+		$this->language = $this->getOption( 'lang' ) !== null ? $this->getOption( 'lang' ) : Message::USER_LANGUAGE;
+
 		return Html::rawElement(
 			'div',
 			[
@@ -192,7 +199,7 @@ class HtmlBuilder {
 						[
 							'class' => 'smw-callout smw-callout-error',
 						],
-						Message::get( 'smw-noscript', Message::PARSE )
+						Message::get( 'smw-noscript', Message::PARSE, $this->language )
 					)
 				)
 			) . Html::rawElement(
@@ -220,6 +227,8 @@ class HtmlBuilder {
 		if ( ( $offset = $this->getOption( 'offset' ) ) ) {
 			$this->offset = $offset;
 		}
+
+		$this->language = $this->getOption( 'lang' ) !== null ? $this->getOption( 'lang' ) : Message::USER_LANGUAGE;
 
 		$this->outgoingValuesCount = $this->getOption( 'valuelistlimit.out', 200 );
 
@@ -273,7 +282,7 @@ class HtmlBuilder {
 		$html .= $this->displayBottom( false );
 
 		if ( $this->getOption( 'printable' ) !== 'yes' && !$this->getOption( 'including' ) ) {
-			$form = FieldBuilder::createQueryForm( $this->articletext );
+			$form = FieldBuilder::createQueryForm( $this->articletext, $this->language );
 		}
 
 		return Html::rawElement(
@@ -306,6 +315,8 @@ class HtmlBuilder {
 		$semanticData = new SemanticData(
 			$this->dataValue->getDataItem()
 		);
+
+		$this->dataValue->setOption( $this->dataValue::OPT_USER_LANGUAGE, $this->language );
 
 		$html .= $this->displayHead();
 		$html .= $this->displayActions();
@@ -356,7 +367,7 @@ class HtmlBuilder {
 		);
 
 		if ( $this->getOption( 'printable' ) !== 'yes' && !$this->getOption( 'including' ) ) {
-			$html .= FieldBuilder::createQueryForm( $this->articletext ) ;
+			$html .= FieldBuilder::createQueryForm( $this->articletext, $this->language ) ;
 		}
 
 		$html .= Html::element(
@@ -465,7 +476,7 @@ class HtmlBuilder {
 			);
 
 			$lColumn = HtmlDivTable::cell(
-				wfMessage( $isLoading ? 'smw-browse-from-backend' : $noMsgKey )->escaped(),
+				 Message::get( $isLoading ? 'smw-browse-from-backend' : $noMsgKey, Message::ESCAPED, $this->language ),
 				[
 					"class" => 'smwb-cell smwb-propval'
 				]
@@ -500,13 +511,13 @@ class HtmlBuilder {
 		$comma = Message::get(
 			'comma-separator',
 			Message::ESCAPED,
-			Message::USER_LANGUAGE
+			$this->language
 		);
 
 		$and = Message::get(
 			'and',
 			Message::ESCAPED,
-			Message::USER_LANGUAGE
+			$this->language
 		);
 
 		$dataValueFactory = DataValueFactory::getInstance();
@@ -524,6 +535,8 @@ class HtmlBuilder {
 				null
 			);
 
+			$dvProperty->setOption( $this->dataValue::OPT_USER_LANGUAGE, $this->language );
+
 			$dvProperty->setContextPage(
 				$contextPage
 			);
@@ -536,7 +549,7 @@ class HtmlBuilder {
 
 			// Make the sortkey visible which is otherwise hidden from the user
 			if ( $showSort && $diProperty->getKey() === '_SKEY' ) {
-				$propertyLabel = Message::get( 'smw-property-predefined-label-skey', Message::TEXT, Message::USER_LANGUAGE );
+				$propertyLabel = Message::get( 'smw-property-predefined-label-skey', Message::TEXT, $this->language );
 			}
 
 			if ( $propertyLabel === null ) {
@@ -707,7 +720,7 @@ class HtmlBuilder {
 				$linkMsg = 'smw-browse-hide-group';
 			}
 
-			$html .= FieldBuilder::createLink( $linkMsg, $parameters );
+			$html .= FieldBuilder::createLink( $linkMsg, $parameters, $this->language );
 			$html .= '<span class="smwb-action-separator">&nbsp;</span>';
 		}
 
@@ -733,7 +746,7 @@ class HtmlBuilder {
 				$linkMsg = 'smw_browse_show_incoming';
 			}
 
-			$html .= FieldBuilder::createLink( $linkMsg, $parameters );
+			$html .= FieldBuilder::createLink( $linkMsg, $parameters, $this->language );
 		}
 
 		return HtmlDivTable::table(
@@ -801,7 +814,7 @@ class HtmlBuilder {
 
 			$linkMsg = 'smw_result_prev';
 
-			$html .= ( $this->offset == 0 ) ? wfMessage( $linkMsg )->escaped() : FieldBuilder::createLink( $linkMsg, $parameters );
+			$html .= ( $this->offset == 0 ) ? wfMessage( $linkMsg )->escaped() : FieldBuilder::createLink( $linkMsg, $parameters, $this->language );
 
 			$offset = $this->offset + $this->incomingPropertiesCount - 1;
 
@@ -815,7 +828,7 @@ class HtmlBuilder {
 
 			$html .= " &#160;&#160;&#160;  <strong>" . wfMessage( 'smw_result_results' )->escaped() . " " . ( $this->offset + 1 ) .
 					 " – " . ( $offset ) . "</strong>  &#160;&#160;&#160; ";
-			$html .= $more ? FieldBuilder::createLink( $linkMsg, $parameters ) : wfMessage( $linkMsg )->escaped();
+			$html .= $more ? FieldBuilder::createLink( $linkMsg, $parameters, $this->language ) : wfMessage( $linkMsg )->escaped();
 
 			$html = HtmlDivTable::row(
 				$html,

--- a/src/MediaWiki/Specials/SpecialBrowse.php
+++ b/src/MediaWiki/Specials/SpecialBrowse.php
@@ -162,6 +162,7 @@ class SpecialBrowse extends SpecialPage {
 		$htmlBuilder->setOptions(
 			[
 				'dir' => $webRequest->getVal( 'dir' ),
+				'lang' => $webRequest->getVal( 'lang', $this->getLanguage()->getCode() ),
 				'group' => $webRequest->getVal( 'group' ),
 				'printable' => $webRequest->getVal( 'printable' ),
 				'offset' => $webRequest->getVal( 'offset' ),

--- a/tests/phpunit/Integration/JSONScript/TestCases/a-0001.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/a-0001.json
@@ -217,7 +217,7 @@
 					"action": "smwbrowse",
 					"format": "json",
 					"browse": "subject",
-					"params": "{ \"subject\": \"A0001/1\" , \"ns\": 0 , \"type\": \"html\", \"options\": {} }"
+					"params": "{ \"subject\": \"A0001/1\" , \"ns\": 0 , \"type\": \"html\", \"options\": { \"lang\" : \"en\" } }"
 				}
 			},
 			"assert-output": {

--- a/tests/phpunit/Integration/JSONScript/TestCases/s-0013.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/s-0013.json
@@ -19,7 +19,8 @@
 				"page": "Browse",
 				"query-parameters": "Example/S0013/1",
 				"request-parameters": {
-					"output": "legacy"
+					"output": "legacy",
+					"lang": "es"
 				}
 			},
 			"assert-output": {

--- a/tests/phpunit/Unit/MediaWiki/Specials/SpecialBrowseTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Specials/SpecialBrowseTest.php
@@ -55,6 +55,10 @@ class SpecialBrowseTest extends \PHPUnit_Framework_TestCase {
 			Title::newFromText( 'SpecialBrowse' )
 		);
 
+		$instance->getContext()->setLanguage(
+			\Language::factory( 'en' )
+		);
+
 		$instance->execute( $query );
 
 		$this->stringValidator->assertThatStringContains(
@@ -82,7 +86,7 @@ class SpecialBrowseTest extends \PHPUnit_Framework_TestCase {
 			'Foo/Bar',
 			[
 				'data-subject="{&quot;dbkey&quot;:&quot;Foo\/Bar&quot;,&quot;ns&quot;:0,&quot;iw&quot;:&quot;&quot;,&quot;subobject&quot;:&quot;&quot;}"',
-				'data-options="{&quot;dir&quot;:null,&quot;group&quot;:null,&quot;printable&quot;:null,&quot;offset&quot;:null,&quot;including&quot;:null,&quot;showInverse&quot;:false,&quot;showAll&quot;:true,&quot;showGroup&quot;:false,&quot;showSort&quot;:false,&quot;api&quot;:true,&quot;valuelistlimit.out&quot;:&quot;30&quot;,&quot;valuelistlimit.in&quot;:&quot;20&quot;}"'
+				'data-options="{&quot;dir&quot;:null,&quot;lang&quot;:&quot;en&quot;,&quot;group&quot;:null,&quot;printable&quot;:null,&quot;offset&quot;:null,&quot;including&quot;:null,&quot;showInverse&quot;:false,&quot;showAll&quot;:true,&quot;showGroup&quot;:false,&quot;showSort&quot;:false,&quot;api&quot;:true,&quot;valuelistlimit.out&quot;:&quot;30&quot;,&quot;valuelistlimit.in&quot;:&quot;20&quot;}"'
 			]
 		];
 
@@ -91,7 +95,7 @@ class SpecialBrowseTest extends \PHPUnit_Framework_TestCase {
 			':Main-20Page-23_QUERY140d50d705e9566904fc4a877c755964',
 			[
 				'data-subject="{&quot;dbkey&quot;:&quot;Main_Page&quot;,&quot;ns&quot;:0,&quot;iw&quot;:&quot;&quot;,&quot;subobject&quot;:&quot;_QUERY140d50d705e9566904fc4a877c755964&quot;}"',
-				'data-options="{&quot;dir&quot;:null,&quot;group&quot;:null,&quot;printable&quot;:null,&quot;offset&quot;:null,&quot;including&quot;:null,&quot;showInverse&quot;:false,&quot;showAll&quot;:true,&quot;showGroup&quot;:false,&quot;showSort&quot;:false,&quot;api&quot;:true,&quot;valuelistlimit.out&quot;:&quot;30&quot;,&quot;valuelistlimit.in&quot;:&quot;20&quot;}"'
+				'data-options="{&quot;dir&quot;:null,&quot;lang&quot;:&quot;en&quot;,&quot;group&quot;:null,&quot;printable&quot;:null,&quot;offset&quot;:null,&quot;including&quot;:null,&quot;showInverse&quot;:false,&quot;showAll&quot;:true,&quot;showGroup&quot;:false,&quot;showSort&quot;:false,&quot;api&quot;:true,&quot;valuelistlimit.out&quot;:&quot;30&quot;,&quot;valuelistlimit.in&quot;:&quot;20&quot;}"'
 			]
 		];
 


### PR DESCRIPTION
This PR is made in reference to: #

This PR addresses or contains:

- `lang` parameter to allow switching the display appearance when used in connection with a `uselang`

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed
