### PR TITLE
Isolate access to `wgContLang`

### DIFF
--- a/includes/SMW_Infolink.php
+++ b/includes/SMW_Infolink.php
@@ -1,6 +1,7 @@
 <?php
 
 use SMW\Site;
+use SMW\Localizer\Localizer;
 
 /**
  * This class mainly is a container to store URLs for the factbox in a
@@ -145,12 +146,11 @@ class SMWInfolink {
 	 * @return SMWInfolink
 	 */
 	public static function newPropertySearchLink( $caption, $propertyName, $propertyValue, $style = 'smwsearch' ) {
-		global $wgContLang;
 
 		$infolink = new SMWInfolink(
 			true,
 			$caption,
-			$wgContLang->getNsText( NS_SPECIAL ) . ':SearchByProperty',
+			Localizer::getInstance()->getNsText( NS_SPECIAL ) . ':SearchByProperty',
 			$style,
 			[ ':' . $propertyName, $propertyValue ] // `:` is marking that the link was auto-generated
 		);
@@ -175,11 +175,11 @@ class SMWInfolink {
 	 * @return SMWInfolink
 	 */
 	public static function newInversePropertySearchLink( $caption, $subject, $propertyname, $style = false ) {
-		global $wgContLang;
+
 		return new SMWInfolink(
 			true,
 			$caption,
-			$wgContLang->getNsText( NS_SPECIAL ) . ':PageProperty',
+			Localizer::getInstance()->getNsText( NS_SPECIAL ) . ':PageProperty',
 			$style,
 			[ $subject . '::' . $propertyname ]
 		);
@@ -195,11 +195,11 @@ class SMWInfolink {
 	 * @return SMWInfolink
 	 */
 	public static function newBrowsingLink( $caption, $titleText, $style = 'smwbrowse' ) {
-		global $wgContLang;
+
 		return new SMWInfolink(
 			true,
 			$caption,
-			$wgContLang->getNsText( NS_SPECIAL ) . ':Browse',
+			Localizer::getInstance()->getNsText( NS_SPECIAL ) . ':Browse',
 			$style,
 			[ ':' . $titleText ]
 		);

--- a/includes/SMW_PageLister.php
+++ b/includes/SMW_PageLister.php
@@ -1,6 +1,9 @@
 <?php
 
 use SMW\Query\PrintRequest;
+use SMW\Localizer\Localizer;
+use SMW\StoreFactory;
+use SMW\DataValueFactory;
 
 /**
  * Helper class to generate HTML lists of wiki pages, with support for paged
@@ -55,16 +58,15 @@ class SMWPageLister {
 	 * @return string
 	 */
 	public function getNavigationLinks( Title $title, $query = [] ) {
-		global $wgLang;
 
-		$limitText = $wgLang->formatNum( $this->mLimit );
+		$limitText = Localizer::getInstance()->getUserLanguage()->formatNum( $this->mLimit );
 
 		$resultCount = count( $this->mDiWikiPages );
 		$beyondLimit = ( $resultCount > $this->mLimit );
 
 		if ( !is_null( $this->mUntil ) && $this->mUntil !== '' ) {
 			if ( $beyondLimit ) {
-				$first = \SMW\StoreFactory::getStore()->getWikiPageSortKey( $this->mDiWikiPages[1] );
+				$first = StoreFactory::getStore()->getWikiPageSortKey( $this->mDiWikiPages[1] );
 			} else {
 				$first = '';
 			}
@@ -74,7 +76,7 @@ class SMWPageLister {
 			$first = $this->mFrom;
 
 			if ( $beyondLimit ) {
-				$last = \SMW\StoreFactory::getStore()->getWikiPageSortKey( $this->mDiWikiPages[$resultCount - 1] );
+				$last = StoreFactory::getStore()->getWikiPageSortKey( $this->mDiWikiPages[$resultCount - 1] );
 			} else {
 				$last = '';
 			}
@@ -209,7 +211,6 @@ class SMWPageLister {
 	 * @return string
 	 */
 	public static function getColumnList( $start, $end, $diWikiPages, $diProperty, $moreCallback = null ) {
-		global $wgContLang;
 
 		if ( $diWikiPages instanceof \Iterator ) {
 			$diWikiPages = iterator_to_array( $diWikiPages );
@@ -237,12 +238,12 @@ class SMWPageLister {
 					continue;
 				}
 
-				$dataValue = \SMW\DataValueFactory::getInstance()->newDataValueByItem( $diWikiPages[$index], $diProperty );
+				$dataValue = DataValueFactory::getInstance()->newDataValueByItem( $diWikiPages[$index], $diProperty );
 				$searchlink = \SMWInfolink::newBrowsingLink( '+', $dataValue->getWikiValue() );
 
 				// check for change of starting letter or beginning of chunk
-				$sortkey = \SMW\StoreFactory::getStore()->getWikiPageSortKey( $diWikiPages[$index] );
-				$startChar = $wgContLang->convert( $wgContLang->firstChar( $sortkey ) );
+				$sortkey = StoreFactory::getStore()->getWikiPageSortKey( $diWikiPages[$index] );
+				$startChar = self::getFirstChar( $sortkey );
 
 				if ( ( $index == $startChunk ) ||
 					 ( $startChar != $prevStartChar ) ) {
@@ -298,7 +299,7 @@ class SMWPageLister {
 			$diWikiPages = iterator_to_array( $diWikiPages );
 		}
 
-		$startDv = \SMW\DataValueFactory::getInstance()->newDataValueByItem( $diWikiPages[$start], $diProperty );
+		$startDv = DataValueFactory::getInstance()->newDataValueByItem( $diWikiPages[$start], $diProperty );
 		$searchlink = \SMWInfolink::newBrowsingLink( '+', $startDv->getWikiValue() );
 
 		// For a redirect, disable the DisplayTitle to show the original (aka source) page
@@ -313,7 +314,7 @@ class SMWPageLister {
 
 		$prevStartChar = $startChar;
 		for ( $index = $start + 1; $index < $end; $index++ ) {
-			$dataValue = \SMW\DataValueFactory::getInstance()->newDataValueByItem( $diWikiPages[$index], $diProperty );
+			$dataValue = DataValueFactory::getInstance()->newDataValueByItem( $diWikiPages[$index], $diProperty );
 			$searchlink = \SMWInfolink::newBrowsingLink( '+', $dataValue->getWikiValue() );
 
 			// For a redirect, disable the DisplayTitle to show the original (aka source) page
@@ -341,15 +342,15 @@ class SMWPageLister {
 	}
 
 	private static function getFirstChar( $dataItem ) {
-		global $wgContLang;
+		$contentLanguage = Localizer::getInstance()->getContentLanguage();
 
-		$sortkey = \SMW\StoreFactory::getStore()->getWikiPageSortKey( $dataItem );
+		$sortkey = StoreFactory::getStore()->getWikiPageSortKey( $dataItem );
 
 		if ( $sortkey === '' ) {
 			$sortkey = $dataItem->getDBKey();
 		}
 
-		return $wgContLang->convert( $wgContLang->firstChar( $sortkey ) );
+		return $contentLanguage->convert( $contentLanguage->firstChar( $sortkey ) );
 	}
 
 }

--- a/includes/SemanticData.php
+++ b/includes/SemanticData.php
@@ -2,9 +2,9 @@
 
 namespace SMW;
 
-use MWException;
 use SMW\DataModel\SubSemanticData;
 use SMW\DataModel\SequenceMap;
+use SMW\Localizer\Localizer;
 use SMW\Exception\SemanticDataImportException;
 use SMWContainerSemanticData;
 use SMWDataItem;
@@ -523,8 +523,7 @@ class SemanticData {
 			$property = $this->mProperties[$propertyKey];
 		} else {
 			if ( self::$mPropertyPrefix === '' ) {
-				global $wgContLang;
-				self::$mPropertyPrefix = $wgContLang->getNsText( SMW_NS_PROPERTY ) . ':';
+				self::$mPropertyPrefix = Localizer::getInstance()->getNsText( SMW_NS_PROPERTY ) . ':';
 			} // explicitly use prefix to cope with things like [[Property:User:Stupid::somevalue]]
 
 			$propertyDV = DataValueFactory::getInstance()->newPropertyValueByLabel( self::$mPropertyPrefix . $propertyName );

--- a/includes/datavalues/SMW_DV_PropertyList.php
+++ b/includes/datavalues/SMW_DV_PropertyList.php
@@ -26,20 +26,21 @@ class SMWPropertyListValue extends SMWDataValue {
 
 		$this->m_diProperties = [];
 		$stringValue = '';
+		$localizer = Localizer::getInstance();
 
 		$valueList = preg_split( '/[\s]*;[\s]*/u', trim( $value ) );
-		$propertyNamespace = Localizer::getInstance()->getNamespaceTextById(
+		$propertyNamespace = $localizer->getNsText(
 			SMW_NS_PROPERTY
 		);
 
 		foreach ( $valueList as $propertyName ) {
 			$propertyNameParts = explode( ':', $propertyName, 2 );
 			if ( count( $propertyNameParts ) > 1 ) {
-				$namespace = smwfNormalTitleText( $propertyNameParts[0] );
+				$namespace = $localizer->normalizeTitleText( $propertyNameParts[0] );
 
 				// Is it a registered namespace? Or just a property with a `:`
 				// divider such as `foaf:name`?
-				if ( Localizer::getInstance()->getNamespaceIndexByName( $namespace ) ) {
+				if ( $localizer->getNsIndex( $namespace ) ) {
 					$propertyName = $propertyNameParts[1];
 
 					if ( $namespace != $propertyNamespace ) {
@@ -48,7 +49,7 @@ class SMWPropertyListValue extends SMWDataValue {
 				}
 			}
 
-			$propertyName = smwfNormalTitleText( $propertyName );
+			$propertyName = $localizer->normalizeTitleText( $propertyName );
 
 			try {
 				$diProperty = SMW\DIProperty::newFromUserLabel( $propertyName );

--- a/includes/datavalues/SMW_DV_WikiPage.php
+++ b/includes/datavalues/SMW_DV_WikiPage.php
@@ -162,7 +162,7 @@ class SMWWikiPageValue extends SMWDataValue {
 			// T:P0902 (`[[Help:]]`)
 			} elseif ( $title !== null ) {
 				return $this->m_dataitem = SMWDIWikiPage::newFromTitle( $title );
-			} elseif ( !$localizer->getNamespaceIndexByName( substr( $value, 0, -1 ) ) ) {
+			} elseif ( !$localizer->getNsIndex( substr( $value, 0, -1 ) ) ) {
 				return $this->m_dataitem = new SMWDIWikiPage( $value, NS_MAIN );
 			}
 		}
@@ -189,7 +189,7 @@ class SMWWikiPageValue extends SMWDataValue {
 			$this->addErrorMsg( [ 'smw-datavalue-wikipage-invalid-title', $value ] );
 		} elseif ( ( $this->m_fixNamespace != NS_MAIN ) &&
 			 ( $this->m_fixNamespace != $this->m_title->getNamespace() ) ) {
-			$this->addErrorMsg( [ 'smw_wrong_namespace', $localizer->getNamespaceTextById( $this->m_fixNamespace ) ] );
+			$this->addErrorMsg( [ 'smw_wrong_namespace', $localizer->getNsText( $this->m_fixNamespace ) ] );
 		} else {
 			$this->m_fragment = str_replace( ' ', '_', $this->m_title->getFragment() );
 			$this->m_prefixedtext = '';
@@ -227,7 +227,7 @@ class SMWWikiPageValue extends SMWDataValue {
 				$this->addErrorMsg(
 					[
 						'smw_wrong_namespace',
-						Localizer::getInstance()->getNamespaceTextById( $this->m_fixNamespace )
+						Localizer::getInstance()->getNsText( $this->m_fixNamespace )
 					]
 				);
 		}
@@ -549,7 +549,7 @@ class SMWWikiPageValue extends SMWDataValue {
 		$errArg = $this->m_caption;
 
 		if ( $this->isValid() ) {
-			$ns = Localizer::getInstance()->getNamespaceTextById(
+			$ns = Localizer::getInstance()->getNsText(
 				$this->m_dataitem->getNamespace()
 			);
 
@@ -635,7 +635,7 @@ class SMWWikiPageValue extends SMWDataValue {
 		}
 
 		if ( $this->isValid() ) {
-			$nstext = Localizer::getInstance()->getNamespaceTextById( $this->m_dataitem->getNamespace() );
+			$nstext = Localizer::getInstance()->getNsText( $this->m_dataitem->getNamespace() );
 			$this->m_prefixedtext =
 				( $this->m_dataitem->getInterwiki() !== '' ? $this->m_dataitem->getInterwiki() . ':' : '' ) .
 				( $nstext !== '' ? "$nstext:" : '' ) . $this->getText();

--- a/includes/export/SMW_Exporter.php
+++ b/includes/export/SMW_Exporter.php
@@ -16,7 +16,7 @@ use SMW\Exporter\ElementFactory;
 use SMW\Exporter\Escaper;
 use SMW\Exporter\ExpResourceMapper;
 use SMW\Exporter\ResourceBuilders\DispatchingResourceBuilder;
-use SMW\Localizer;
+use SMW\Localizer\Localizer;
 use SMW\NamespaceUriFinder;
 use SMW\TypesRegistry;
 
@@ -148,7 +148,8 @@ class SMWExporter {
 		if ( self::$m_exporturl !== false ) {
 			return;
 		}
-		global $wgContLang;
+
+		$localizer = Localizer::getInstance();
 
 		global $smwgNamespace; // complete namespace for URIs (with protocol, usually http://)
 
@@ -164,20 +165,23 @@ class SMWExporter {
 		self::$m_ent_wikiurl  = Site::wikiurl();
 		self::$m_ent_wiki     = $smwgNamespace;
 
-		$property = $GLOBALS['smwgExportBCNonCanonicalFormUse'] ? urlencode( str_replace( ' ', '_', $wgContLang->getNsText( SMW_NS_PROPERTY ) ) ) : 'Property';
-		$category = $GLOBALS['smwgExportBCNonCanonicalFormUse'] ? urlencode( str_replace( ' ', '_', $wgContLang->getNsText( NS_CATEGORY ) ) ) : 'Category';
+		$property = 'Property';
+		$category = 'Category';
+
+		if ( $GLOBALS['smwgExportBCNonCanonicalFormUse'] ) {
+			$property = urlencode( str_replace( ' ', '_', $localizer->getNsText( SMW_NS_PROPERTY ) ) );
+			$category = urlencode( str_replace( ' ', '_', $localizer->getNsText( NS_CATEGORY ) ) );
+		}
 
 		self::$m_ent_property = self::$m_ent_wiki . Escaper::encodeUri( $property . ':' );
 		self::$m_ent_category = self::$m_ent_wiki . Escaper::encodeUri( $category . ':' );
 
 		$title = Title::makeTitle( NS_SPECIAL, 'ExportRDF' );
-		self::$m_exporturl    = self::$m_ent_wikiurl . $title->getPrefixedURL();
+		self::$m_exporturl = self::$m_ent_wikiurl . $title->getPrefixedURL();
 
 		// Canonical form, the title object always contains a wgContLang reference
 		// therefore replace it
 		if ( !$GLOBALS['smwgExportBCNonCanonicalFormUse'] ) {
-			$localizer = Localizer::getInstance();
-
 			self::$m_ent_property = $localizer->getCanonicalizedUrlByNamespace( NS_SPECIAL, self::$m_ent_property );
 			self::$m_ent_category = $localizer->getCanonicalizedUrlByNamespace( NS_SPECIAL, self::$m_ent_category );
 			self::$m_ent_wiki = $localizer->getCanonicalizedUrlByNamespace( NS_SPECIAL, self::$m_ent_wiki );
@@ -306,7 +310,7 @@ class SMWExporter {
 
 			$pageTitle = str_replace( '_', ' ', $subject->getDBkey() );
 			if ( $subject->getNamespace() !== 0 ) {
-				$prefixedSubjectTitle = Localizer::getInstance()->getNamespaceTextById( $subject->getNamespace() ) . ":" . $pageTitle;
+				$prefixedSubjectTitle = Localizer::getInstance()->getNsText( $subject->getNamespace() ) . ":" . $pageTitle;
 			} else {
 				$prefixedSubjectTitle = $pageTitle;
 			}

--- a/src/Aliases.php
+++ b/src/Aliases.php
@@ -4,6 +4,10 @@
  * SemanticMediaWiki compatibility aliases for classes that got moved into the SMW namespace
  */
 
+// 3.2
+class_alias( \SMW\Localizer\Localizer::class, '\SMW\Localizer' );
+class_alias( \SMW\Localizer\Message::class, '\SMW\Message' );
+
 // 3.1
 class_alias( \SMW\Query\ResultPrinters\RdfResultPrinter::class, 'SMWRDFResultPrinter' );
 class_alias( \SMW\Query\ResultPrinters\EmbeddedResultPrinter::class, 'SMWEmbeddedResultPrinter' );

--- a/src/DataValues/AllowsListValue.php
+++ b/src/DataValues/AllowsListValue.php
@@ -68,7 +68,7 @@ class AllowsListValue extends StringValue {
 
 		$id = $this->getDataItem()->getString();
 
-		return '[['. Localizer::getInstance()->getNamespaceTextById( NS_MEDIAWIKI ) . ':' . self::LIST_PREFIX . $id . '|' . $id .']]';
+		return '[['. Localizer::getInstance()->getNsText( NS_MEDIAWIKI ) . ':' . self::LIST_PREFIX . $id . '|' . $id .']]';
 	}
 
 	/**

--- a/src/DataValues/AllowsPatternValue.php
+++ b/src/DataValues/AllowsPatternValue.php
@@ -74,7 +74,7 @@ class AllowsPatternValue extends StringValue {
 
 		$id = $this->getDataItem()->getString();
 
-		return '[['. Localizer::getInstance()->getNamespaceTextById( NS_MEDIAWIKI ) . ':' . self::REFERENCE_PAGE_ID . '|' . $id .']]';
+		return '[['. Localizer::getInstance()->getNsText( NS_MEDIAWIKI ) . ':' . self::REFERENCE_PAGE_ID . '|' . $id .']]';
 	}
 
 	/**

--- a/src/DataValues/TypesValue.php
+++ b/src/DataValues/TypesValue.php
@@ -3,7 +3,7 @@
 namespace SMW\DataValues;
 
 use SMW\DataTypeRegistry;
-use SMW\Localizer;
+use SMW\Localizer\Localizer;
 use SMWDataItem as DataItem;
 use SMWDataItemException as DataItemException;
 use SMWDataValue as DataValue;
@@ -201,7 +201,7 @@ class TypesValue extends DataValue {
 		if ( $value !== '' && $value[0] === '_' ) {
 			$this->m_typeId = $value;
 		} else {
-			$this->givenLabel = smwfNormalTitleText( $value );
+			$this->givenLabel = Localizer::getInstance()->normalizeTitleText( $value );
 			$this->m_typeId = DataTypeRegistry::getInstance()->findTypeByLabelAndLanguage( $this->givenLabel, $contentLanguage );
 		}
 

--- a/src/Exporter/DataItemMatchFinder.php
+++ b/src/Exporter/DataItemMatchFinder.php
@@ -110,12 +110,12 @@ class DataItemMatchFinder {
 		// try the by far most common cases directly before using Title
 		$namespaceName = str_replace( '_', ' ', $name );
 
-		if ( ( $namespaceId = Localizer::getInstance()->getNamespaceIndexByName( $name ) ) !== false ) {
+		if ( ( $namespaceId = Localizer::getInstance()->getNsIndex( $name ) ) !== false ) {
 			return $namespaceId;
 		}
 
 		foreach ( [ SMW_NS_PROPERTY, NS_CATEGORY, NS_USER, NS_HELP ] as $nsId ) {
-			if ( $namespaceName == Localizer::getInstance()->getNamespaceTextById( $nsId ) ) {
+			if ( $namespaceName == Localizer::getInstance()->getNsText( $nsId ) ) {
 				$namespaceId = $nsId;
 				break;
 			}

--- a/src/Exporter/Escaper.php
+++ b/src/Exporter/Escaper.php
@@ -3,6 +3,7 @@
 namespace SMW\Exporter;
 
 use SMW\DIWikiPage;
+use SMW\Localizer\Localizer;
 
 /**
  * @license GNU GPL v2+
@@ -32,7 +33,7 @@ class Escaper {
 		} elseif ( $diWikiPage->getNamespace() === NS_CATEGORY ) {
 			$localName .= 'Category' . ':' . $diWikiPage->getDBkey();
 		} elseif ( $diWikiPage->getNamespace() !== NS_MAIN ) {
-			$localName .= str_replace( ' ', '_', $GLOBALS['wgContLang']->getNSText( $diWikiPage->getNamespace() ) ) . ':' . $diWikiPage->getDBkey();
+			$localName .= str_replace( ' ', '_', Localizer::getInstance()->getNSText( $diWikiPage->getNamespace() ) ) . ':' . $diWikiPage->getDBkey();
 		} else {
 			$localName .= $diWikiPage->getDBkey();
 		}

--- a/src/Factbox/Factbox.php
+++ b/src/Factbox/Factbox.php
@@ -389,7 +389,7 @@ class Factbox {
 
 		$rdflink = SMWInfolink::newInternalLink(
 			Message::get( 'smw_viewasrdf', Message::TEXT, Message::USER_LANGUAGE ),
-			Localizer::getInstance()->getNamespaceTextById( NS_SPECIAL ) . ':ExportRDF/' . $dataValue->getWikiValue(),
+			Localizer::getInstance()->getNsText( NS_SPECIAL ) . ':ExportRDF/' . $dataValue->getWikiValue(),
 			'rdflink'
 		);
 

--- a/src/GlobalFunctions.php
+++ b/src/GlobalFunctions.php
@@ -36,26 +36,10 @@ function smwfNormalTitleDBKey( $text ) {
 }
 
 /**
- * Takes a text and turns it into a normalised version. This function
- * reimplements the title normalization as done in Title.php in order to
- * achieve conversion with less overhead. The official code could be called
- * here if more advanced normalization is needed.
- *
- * @param string $text
+ * @deprecated since 3.2, use `Localizer::normalizeTitleText`
  */
 function smwfNormalTitleText( $text ) {
-	global $wgCapitalLinks, $wgContLang;
-
-	$text = trim( $text );
-
-	if ( $wgCapitalLinks ) {
-		$text = $wgContLang->ucfirst( $text );
-	}
-
-	// https://www.mediawiki.org/wiki/Manual:Page_title
-	// Titles beginning or ending with a space (underscore), or containing two
-	// or more consecutive spaces (underscores).
-	return str_replace( [ '__', '_', '  ' ], ' ', $text );
+	return Localizer::getInstance()->normalizeTitleText( $text );
 }
 
 /**

--- a/src/Localizer/Message.php
+++ b/src/Localizer/Message.php
@@ -1,9 +1,10 @@
 <?php
 
-namespace SMW;
+namespace SMW\Localizer;
 
 use Closure;
 use Language;
+use SMW\InMemoryPoolCache;
 
 /**
  * @private

--- a/src/MediaWiki/Api/Browse/ArticleLookup.php
+++ b/src/MediaWiki/Api/Browse/ArticleLookup.php
@@ -180,7 +180,7 @@ class ArticleLookup extends Lookup {
 		if ( strpos( $search, ':' ) !== false ) {
 			list( $ns, $term ) = explode( ':', $search );
 
-			if ( ( $namespace = Localizer::getInstance()->getNamespaceIndexByName( $ns ) ) !== false ) {
+			if ( ( $namespace = Localizer::getInstance()->getNsIndex( $ns ) ) !== false ) {
 				$search = $term;
 			} else {
 				$namespace = null;

--- a/src/MediaWiki/Hooks/ResourceLoaderGetConfigVars.php
+++ b/src/MediaWiki/Hooks/ResourceLoaderGetConfigVars.php
@@ -70,7 +70,7 @@ class ResourceLoaderGetConfigVars implements HookListener {
 			$name = $this->namespaceInfo->getCanonicalName( $ns );
 			$vars['smw-config']['settings']['namespace'][$name] = $ns;
 			$vars['smw-config']['namespaces']['canonicalName'][$ns] = $name;
-			$vars['smw-config']['namespaces']['localizedName'][$ns] = $localizer->getNamespaceTextById( $ns );
+			$vars['smw-config']['namespaces']['localizedName'][$ns] = $localizer->getNsText( $ns );
 		}
 
 		foreach ( array_keys( $this->getOption( 'smwgResultFormats' ) ) as $format ) {

--- a/src/MediaWiki/Search/ProfileForm/Forms/NamespaceForm.php
+++ b/src/MediaWiki/Search/ProfileForm/Forms/NamespaceForm.php
@@ -4,6 +4,8 @@ namespace SMW\MediaWiki\Search\ProfileForm\Forms;
 
 use Html;
 use SMW\MediaWiki\NamespaceInfo;
+use SMW\Localizer\Localizer;
+use SMW\Localizer\MessageLocalizerTrait;
 use SMW\Message;
 use SpecialSearch;
 use Xml;
@@ -19,10 +21,17 @@ use Xml;
  */
 class NamespaceForm {
 
+	use MessageLocalizerTrait;
+
 	/**
 	 * @var NamespaceInfo
 	 */
 	private $namespaceInfo;
+
+	/**
+	 * @var Localizer
+	 */
+	private $localizer;
 
 	/**
 	 * @var []
@@ -53,9 +62,11 @@ class NamespaceForm {
 	 * @since 3.1
 	 *
 	 * @param NamespaceInfo $namespaceInfo
+	 * @param Localizer $localizer
 	 */
-	public function __construct( NamespaceInfo $namespaceInfo ) {
+	public function __construct( NamespaceInfo $namespaceInfo, Localizer $localizer ) {
 		$this->namespaceInfo = $namespaceInfo;
+		$this->localizer = $localizer;
 	}
 
 	/**
@@ -118,7 +129,6 @@ class NamespaceForm {
 	 * @return string
 	 */
 	public function makeFields() {
-		global $wgContLang;
 
 		$divider = "<div class='divider'></div>";
 		$rows = [];
@@ -137,10 +147,10 @@ class NamespaceForm {
 				$rows[$subject] = "";
 			}
 
-			$name = $wgContLang->getConverter()->convertNamespace( $namespace );
+			$name = $this->localizer->convertNamespace( $namespace );
 
 			if ( $name === '' ) {
-				$name = Message::get( 'blanknamespace', Message::TEXT, Message::USER_LANGUAGE );
+				$name = $this->msg( 'blanknamespace', Message::TEXT, Message::USER_LANGUAGE );
 			}
 
 			$isChecked = in_array( $namespace, $this->activeNamespaces );
@@ -174,7 +184,7 @@ class NamespaceForm {
 
 		if ( $this->token ) {
 			$remember = $divider . Xml::checkLabel(
-				Message::get( 'powersearch-remember', Message::TEXT, Message::USER_LANGUAGE ),
+				$this->msg( 'powersearch-remember', Message::TEXT, Message::USER_LANGUAGE ),
 				'nsRemember',
 				'mw-search-powersearch-remember',
 				false,
@@ -191,8 +201,8 @@ class NamespaceForm {
 		}
 
 		return "<fieldset id='mw-searchoptions'>" .
-			"<legend>" . Message::get( 'powersearch-legend', Message::ESCAPED, Message::USER_LANGUAGE ) . '</legend>' .
-			"<h4>" . Message::get( 'powersearch-ns', Message::PARSE, Message::USER_LANGUAGE ) . '</h4>' .
+			"<legend>" . $this->msg( 'powersearch-legend', Message::ESCAPED, Message::USER_LANGUAGE ) . '</legend>' .
+			"<h4>" . $this->msg( 'powersearch-ns', Message::PARSE, Message::USER_LANGUAGE ) . '</h4>' .
 			// populated by js if available
 			"<div id='smw-search-togglensview'>" .
 			'<input type="button" id="smw-togglensview" value="' . $val . '">' .
@@ -214,10 +224,6 @@ class NamespaceForm {
 			) .
 			$remember . "</div>" .
 		"</fieldset>";
-	}
-
-	private function msg( $key, $type = Message::PARSE, $lang = Message::USER_LANGUAGE ) {
-		return Message::get( $key, $type, $lang );
 	}
 
 }

--- a/src/MediaWiki/Search/ProfileForm/FormsFactory.php
+++ b/src/MediaWiki/Search/ProfileForm/FormsFactory.php
@@ -8,6 +8,7 @@ use SMW\MediaWiki\Search\ProfileForm\Forms\SortForm;
 use SMW\MediaWiki\Search\ProfileForm\Forms\NamespaceForm;
 use WebRequest;
 use SMW\ApplicationFactory;
+use SMW\Localizer\Localizer;
 
 /**
  * @private
@@ -57,9 +58,10 @@ class FormsFactory {
 	 *
 	 * @return NamespaceForm
 	 */
-	public function newNamespaceForm() {
+	public function newNamespaceForm() : NamespaceForm {
 		return new NamespaceForm(
-			ApplicationFactory::getInstance()->singleton( 'NamespaceInfo' )
+			ApplicationFactory::getInstance()->singleton( 'NamespaceInfo' ),
+			Localizer::getInstance()
 		);
 	}
 

--- a/src/Parser/RecursiveTextProcessor.php
+++ b/src/Parser/RecursiveTextProcessor.php
@@ -316,7 +316,7 @@ class RecursiveTextProcessor {
 		}
 
 		// Content language dep. category name
-		$category = Localizer::getInstance()->getNamespaceTextById(
+		$category = Localizer::getInstance()->getNsText(
 			NS_CATEGORY
 		);
 

--- a/src/Query/Language/ClassDescription.php
+++ b/src/Query/Language/ClassDescription.php
@@ -135,7 +135,7 @@ class ClassDescription extends Description {
 	public function getQueryString( $asValue = false ) {
 
 		$first = true;
-		$namespaceText = Localizer::getInstance()->getNamespaceTextById( NS_CATEGORY );
+		$namespaceText = Localizer::getInstance()->getNsText( NS_CATEGORY );
 
 		foreach ( $this->m_diWikiPages as $wikiPage ) {
 			$wikiValue = DataValueFactory::getInstance()->newDataValueByItem( $wikiPage, null );

--- a/src/Query/Language/NamespaceDescription.php
+++ b/src/Query/Language/NamespaceDescription.php
@@ -50,7 +50,7 @@ class NamespaceDescription extends Description {
 
 	public function getQueryString( $asValue = false ) {
 
-		$localizedNamespaceText = Localizer::getInstance()->getNamespaceTextById( $this->namespace );
+		$localizedNamespaceText = Localizer::getInstance()->getNsText( $this->namespace );
 
 		$prefix = $this->namespace == NS_CATEGORY ? ':' : '';
 

--- a/src/Query/Parser/LegacyParser.php
+++ b/src/Query/Parser/LegacyParser.php
@@ -6,7 +6,7 @@ use SMW\DataTypeRegistry;
 use SMW\DataValueFactory;
 use SMW\DIProperty;
 use SMW\DIWikiPage;
-use SMW\Localizer;
+use SMW\Localizer\Localizer;
 use SMW\Query\DescriptionFactory;
 use SMW\Query\Language\ClassDescription;
 use SMW\Query\Language\Disjunction;
@@ -711,7 +711,7 @@ class LegacyParser implements Parser {
 			// try namespace restriction
 			if ( ( count( $list ) == 2 ) && ( $list[1] == '+' ) ) {
 
-				$idx = $localizer->getNamespaceIndexByName( $list[0] );
+				$idx = $localizer->getNsIndex( $list[0] );
 
 				if ( $idx !== false ) {
 					$description = $this->descriptionProcessor->asOr(
@@ -836,11 +836,32 @@ class LegacyParser implements Parser {
 	}
 
 	private function hasClassPrefix( $chunk ) {
-		return in_array( smwfNormalTitleText( $chunk ), [ $this->categoryPrefix, $this->conceptPrefix, $this->categoryPrefixCannonical, $this->conceptPrefixCannonical ] );
+
+		$prefix = [
+			$this->categoryPrefix,
+			$this->conceptPrefix,
+			$this->categoryPrefixCannonical,
+			$this->conceptPrefixCannonical
+		];
+
+		return in_array( $this->normalizeTitleText( $chunk ), $prefix );
 	}
 
 	private function isClass( $chunk ) {
-		return smwfNormalTitleText( $chunk ) == $this->categoryPrefix || smwfNormalTitleText( $chunk ) == $this->categoryPrefixCannonical;
+
+		$chunk = $this->normalizeTitleText( $chunk );
+
+		if (
+			$chunk == $this->categoryPrefix ||
+			$chunk == $this->categoryPrefixCannonical ) {
+			return true;
+		}
+
+		return false;
+	}
+
+	private function normalizeTitleText( string $text ) : string {
+		return Localizer::getInstance()->normalizeTitleText( $text );
 	}
 
 }

--- a/src/Query/PrintRequest.php
+++ b/src/Query/PrintRequest.php
@@ -178,7 +178,7 @@ class PrintRequest {
 		} elseif ( $this->m_mode === self::PRINT_CHAIN ) {
 			return $this->m_data->getDataItem()->getString();
 		} elseif ( $this->m_mode === self::PRINT_CATS ) {
-			return Localizer::getInstance()->getNamespaceTextById( NS_CATEGORY );
+			return Localizer::getInstance()->getNsText( NS_CATEGORY );
 		} elseif ( $this->m_mode === self::PRINT_CCAT ) {
 			return $this->m_data->getPrefixedText();
 		}

--- a/src/Query/PrintRequest/Deserializer.php
+++ b/src/Query/PrintRequest/Deserializer.php
@@ -6,7 +6,7 @@ use InvalidArgumentException;
 use SMW\DataValueFactory;
 use SMW\DataValues\PropertyChainValue;
 use SMW\DataValues\PropertyValue;
-use SMW\Localizer;
+use SMW\Localizer\Localizer;
 use SMW\Query\PrintRequest;
 use Title;
 
@@ -66,7 +66,7 @@ class Deserializer {
 			$printmode = PrintRequest::PRINT_CATS;
 
 			if ( $showMode === false ) {
-				$label = Localizer::getInstance()->getNamespaceTextById( NS_CATEGORY );
+				$label = Localizer::getInstance()->getNsText( NS_CATEGORY );
 			}
 		} elseif ( PropertyChainValue::isChained( $printRequestLabel ) ) {
 			$printmode = PrintRequest::PRINT_CHAIN;
@@ -162,7 +162,7 @@ class Deserializer {
 			return true;
 		}
 
-		return Localizer::getInstance()->getNamespaceTextById( NS_CATEGORY ) == $text;
+		return Localizer::getInstance()->getNsText( NS_CATEGORY ) == $text;
 	}
 
 	private static function getPartsFromText( $text ) {
@@ -188,7 +188,7 @@ class Deserializer {
 		$printRequestLabel = trim( $propparts[0] );
 		$outputFormat = isset( $propparts[1] ) ? trim( $propparts[1] ) : false;
 
-		return [ $parts, $outputFormat, smwfNormalTitleText( $printRequestLabel ) ];
+		return [ $parts, $outputFormat, Localizer::getInstance()->normalizeTitleText( $printRequestLabel ) ];
 	}
 
 }

--- a/src/Query/PrintRequest/Serializer.php
+++ b/src/Query/PrintRequest/Serializer.php
@@ -56,7 +56,7 @@ class Serializer {
 
 	private static function doSerializeCat( $printRequest, $parameters ) {
 
-		$catlabel = Localizer::getInstance()->getNamespaceTextById( NS_CATEGORY );
+		$catlabel = Localizer::getInstance()->getNsText( NS_CATEGORY );
 		$result = '?' . $catlabel;
 
 		if ( $printRequest->getLabel() != $catlabel ) {

--- a/src/Query/Processor/QueryCreator.php
+++ b/src/Query/Processor/QueryCreator.php
@@ -242,7 +242,7 @@ class QueryCreator implements QueryContext {
 	}
 
 	private function normalize_sort( $sort ) {
-		return Localizer::getInstance()->getNamespaceTextById( NS_CATEGORY ) == mb_convert_case( $sort, MB_CASE_TITLE ) ? '_INST' : $sort;
+		return Localizer::getInstance()->getNsText( NS_CATEGORY ) == mb_convert_case( $sort, MB_CASE_TITLE ) ? '_INST' : $sort;
 	}
 
 	private function getParam( $key, $default ) {

--- a/src/Services/mediawiki.php
+++ b/src/Services/mediawiki.php
@@ -282,6 +282,22 @@ return [
 	},
 
 	/**
+	 * ContentLanguage
+	 *
+	 * @return callable
+	 */
+	'ContentLanguage' => function( $containerBuilder ) {
+
+		// MW 1.35+
+		// https://phabricator.wikimedia.org/T245940
+		if ( class_exists( '\MediaWiki\MediaWikiServices' ) && method_exists( '\MediaWiki\MediaWikiServices', 'getContentLanguage' ) ) {
+			return MediaWikiServices::getInstance()->getContentLanguage();
+		}
+
+		return $GLOBALS['wgContLang'];
+	},
+
+	/**
 	 * ParserCache
 	 *
 	 * @return callable

--- a/tests/phpunit/Integration/MediaWiki/Hooks/FileUploadIntegrationTest.php
+++ b/tests/phpunit/Integration/MediaWiki/Hooks/FileUploadIntegrationTest.php
@@ -81,7 +81,7 @@ class FileUploadIntegrationTest extends MwDBaseUnitTestCase {
 		Localizer::getInstance()->clear();
 
 		$subject = new DIWikiPage( 'Foo.txt', NS_FILE );
-		$fileNS = Localizer::getInstance()->getNamespaceTextById( NS_FILE );
+		$fileNS = Localizer::getInstance()->getNsText( NS_FILE );
 
 		$dummyTextFile = $this->fixturesFileProvider->newUploadForDummyTextFile( 'Foo.txt' );
 

--- a/tests/phpunit/Integration/Query/ProfileAnnotators/ProfileAnnotatorWithQueryProcessorIntegrationTest.php
+++ b/tests/phpunit/Integration/Query/ProfileAnnotators/ProfileAnnotatorWithQueryProcessorIntegrationTest.php
@@ -70,7 +70,7 @@ class ProfileAnnotatorWithQueryProcessorIntegrationTest extends \PHPUnit_Framewo
 
 	public function queryDataProvider() {
 
-		$categoryNS = Localizer::getInstance()->getNamespaceTextById( NS_CATEGORY );
+		$categoryNS = Localizer::getInstance()->getNsText( NS_CATEGORY );
 
 		$provider = [];
 

--- a/tests/phpunit/Integration/RdfFileResourceTest.php
+++ b/tests/phpunit/Integration/RdfFileResourceTest.php
@@ -65,7 +65,7 @@ class RdfFileResourceTest extends MwDBaseUnitTestCase {
 		Localizer::getInstance()->clear();
 
 		$subject = new DIWikiPage( 'RdfLinkedFile.txt', NS_FILE );
-		$fileNS = Localizer::getInstance()->getNamespaceTextById( NS_FILE );
+		$fileNS = Localizer::getInstance()->getNsText( NS_FILE );
 
 		$dummyTextFile = $this->fixturesFileProvider->newUploadForDummyTextFile(
 			'RdfLinkedFile.txt'

--- a/tests/phpunit/TestEnvironment.php
+++ b/tests/phpunit/TestEnvironment.php
@@ -297,7 +297,7 @@ class TestEnvironment {
 	 */
 	public function replaceNamespaceWithLocalizedText( $index, $text ) {
 
-		$namespace = Localizer::getInstance()->getNamespaceTextById( $index );
+		$namespace = Localizer::getInstance()->getNsText( $index );
 
 		return str_replace(
 			Localizer::getInstance()->getCanonicalNamespaceTextById( $index ) . ':',

--- a/tests/phpunit/Unit/Localizer/LocalizerTest.php
+++ b/tests/phpunit/Unit/Localizer/LocalizerTest.php
@@ -1,12 +1,12 @@
 <?php
 
-namespace SMW\Tests;
+namespace SMW\Tests\Localizer;
 
 use Language;
-use SMW\Localizer;
+use SMW\Localizer\Localizer;
 
 /**
- * @covers \SMW\Localizer
+ * @covers \SMW\Localizer\Localizer
  * @group semantic-mediawiki
  *
  * @license GNU GPL v2+
@@ -59,11 +59,6 @@ class LocalizerTest extends \PHPUnit_Framework_TestCase {
 			$this->language,
 			$instance->getContentLanguage()
 		);
-
-		$this->assertSame(
-			$GLOBALS['wgContLang'],
-			Localizer::getInstance()->getContentLanguage()
-		);
 	}
 
 	public function testNamespaceTextById() {
@@ -75,7 +70,7 @@ class LocalizerTest extends \PHPUnit_Framework_TestCase {
 
 		$this->assertEquals(
 			'Property',
-			$instance->getNamespaceTextById( SMW_NS_PROPERTY )
+			$instance->getNsText( SMW_NS_PROPERTY )
 		);
 	}
 
@@ -88,7 +83,7 @@ class LocalizerTest extends \PHPUnit_Framework_TestCase {
 
 		$this->assertEquals(
 			SMW_NS_PROPERTY,
-			$instance->getNamespaceIndexByName( 'property' )
+			$instance->getNsIndex( 'property' )
 		);
 	}
 
@@ -284,6 +279,23 @@ class LocalizerTest extends \PHPUnit_Framework_TestCase {
 		$this->assertEquals(
 			'Property:foo bar',
 			$instance->createTextWithNamespacePrefix( SMW_NS_PROPERTY, 'foo bar' )
+		);
+	}
+
+	public function testNormalizeTitleText() {
+
+		$this->language->expects( $this->once() )
+			->method( 'ucfirst' )
+			->will( $this->returnValue( 'Fo_o' ) );
+
+		$instance = new Localizer(
+			$this->language,
+			$this->namespaceInfo
+		);
+
+		$this->assertEquals(
+			'Fo o',
+			$instance->normalizeTitleText( 'fo_o' )
 		);
 	}
 

--- a/tests/phpunit/Unit/Localizer/MessageTest.php
+++ b/tests/phpunit/Unit/Localizer/MessageTest.php
@@ -1,11 +1,12 @@
 <?php
 
-namespace SMW\Tests;
+namespace SMW\Tests\Localizer;
 
-use SMW\Message;
+use SMW\Localizer\Message;
+use SMW\Tests\TestEnvironment;
 
 /**
- * @covers \SMW\Message
+ * @covers \SMW\Localizer\Message
  * @group semantic-mediawiki
  *
  * @license GNU GPL v2+
@@ -25,7 +26,7 @@ class MessageTest extends \PHPUnit_Framework_TestCase {
 	public function testCanConstruct() {
 
 		$this->assertInstanceOf(
-			'\SMW\Message',
+			Message::class,
 			new Message()
 		);
 	}

--- a/tests/phpunit/Unit/MediaWiki/Search/ProfileForm/Forms/NamespaceFormTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Search/ProfileForm/Forms/NamespaceFormTest.php
@@ -19,10 +19,20 @@ class NamespaceFormTest extends \PHPUnit_Framework_TestCase {
 	use PHPUnitCompat;
 
 	private $namespaceInfo;
+	private $localizer;
+	private $messageLocalizer;
 
 	protected function setUp() : void {
 
 		$this->namespaceInfo = $this->getMockBuilder( '\SMW\MediaWiki\NamespaceInfo' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$this->localizer = $this->getMockBuilder( '\SMW\Localizer\Localizer' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$this->messageLocalizer = $this->getMockBuilder( '\SMW\Localizer\MessageLocalizer' )
 			->disableOriginalConstructor()
 			->getMock();
 	}
@@ -31,14 +41,19 @@ class NamespaceFormTest extends \PHPUnit_Framework_TestCase {
 
 		$this->assertInstanceOf(
 			NamespaceForm::class,
-			new NamespaceForm( $this->namespaceInfo )
+			new NamespaceForm( $this->namespaceInfo, $this->localizer )
 		);
 	}
 
 	public function testMakeFields() {
 
 		$instance = new NamespaceForm(
-			$this->namespaceInfo
+			$this->namespaceInfo,
+			$this->localizer
+		);
+
+		$instance->setMessageLocalizer(
+			$this->messageLocalizer
 		);
 
 		$instance->setSearchableNamespaces( [ 0 => 'Foo '] );
@@ -71,7 +86,12 @@ class NamespaceFormTest extends \PHPUnit_Framework_TestCase {
 			->will( $this->returnValue( $user ) );
 
 		$instance = new NamespaceForm(
-			$this->namespaceInfo
+			$this->namespaceInfo,
+			$this->localizer
+		);
+
+		$instance->setMessageLocalizer(
+			$this->messageLocalizer
 		);
 
 		$instance->checkNamespaceEditToken( $specialSearch );

--- a/tests/phpunit/Unit/MediaWiki/Specials/SearchByProperty/PageBuilderTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Specials/SearchByProperty/PageBuilderTest.php
@@ -93,7 +93,7 @@ class PageBuilderTest extends \PHPUnit_Framework_TestCase {
 			'value="Foo"',
 			'value="Bar"',
 			'title="ResultOne',
-			'title="' . $this->localizer->getNamespaceTextById( NS_HELP ) . ':ResultTwo'
+			'title="' . $this->localizer->getNsText( NS_HELP ) . ':ResultTwo'
 		];
 
 		$this->stringValidator->assertThatStringContains(
@@ -166,7 +166,7 @@ class PageBuilderTest extends \PHPUnit_Framework_TestCase {
 			'value="Foo"',
 			'value="Bar"',
 			'title="ResultOne',
-			'title="' . $this->localizer->getNamespaceTextById( NS_HELP ) . ':ResultTwo'
+			'title="' . $this->localizer->getNsText( NS_HELP ) . ':ResultTwo'
 		];
 
 		$this->stringValidator->assertThatStringContains(

--- a/tests/phpunit/Unit/ParserFunctions/AskParserFunctionTest.php
+++ b/tests/phpunit/Unit/ParserFunctions/AskParserFunctionTest.php
@@ -436,8 +436,8 @@ class AskParserFunctionTest extends \PHPUnit_Framework_TestCase {
 
 	public function queryDataProvider() {
 
-		$categoryNS = Localizer::getInstance()->getNamespaceTextById( NS_CATEGORY );
-		$fileNS = Localizer::getInstance()->getNamespaceTextById( NS_FILE );
+		$categoryNS = Localizer::getInstance()->getNsText( NS_CATEGORY );
+		$fileNS = Localizer::getInstance()->getNsText( NS_FILE );
 
 		$provider = [];
 

--- a/tests/phpunit/Unit/ParserFunctions/SubobjectParserFunctionTest.php
+++ b/tests/phpunit/Unit/ParserFunctions/SubobjectParserFunctionTest.php
@@ -339,7 +339,7 @@ class SubobjectParserFunctionTest extends \PHPUnit_Framework_TestCase {
 
 	public function parameterDataProvider() {
 
-		$helpNS = Localizer::getInstance()->getNamespaceTextById( NS_HELP );
+		$helpNS = Localizer::getInstance()->getNsText( NS_HELP );
 
 		$provider = [];
 

--- a/tests/phpunit/Unit/Property/Annotators/AttachmentLinkPropertyAnnotatorTest.php
+++ b/tests/phpunit/Unit/Property/Annotators/AttachmentLinkPropertyAnnotatorTest.php
@@ -29,7 +29,7 @@ class AttachmentLinkPropertyAnnotatorTest extends \PHPUnit_Framework_TestCase {
 
 		$this->semanticDataValidator = TestEnvironment::newValidatorFactory()->newSemanticDataValidator();
 		$this->dataItemFactory = new DataItemFactory();
-		$this->fileNS = Localizer::getInstance()->getNamespaceTextById( NS_FILE );
+		$this->fileNS = Localizer::getInstance()->getNsText( NS_FILE );
 	}
 
 	public function testCanConstruct() {

--- a/tests/phpunit/Unit/Property/Annotators/PredefinedPropertyAnnotatorTest.php
+++ b/tests/phpunit/Unit/Property/Annotators/PredefinedPropertyAnnotatorTest.php
@@ -173,7 +173,7 @@ class PredefinedPropertyAnnotatorTest extends \PHPUnit_Framework_TestCase {
 
 		#5 TYPE_LAST_EDITOR
 		$userPage = MockTitle::buildMock( 'Lula' );
-		$userNS = Localizer::getInstance()->getNamespaceTextById( NS_USER );
+		$userNS = Localizer::getInstance()->getNsText( NS_USER );
 
 		$userPage->expects( $this->any() )
 			->method( 'getNamespace' )
@@ -196,7 +196,7 @@ class PredefinedPropertyAnnotatorTest extends \PHPUnit_Framework_TestCase {
 
 		#6 Combined entries
 		$userPage = MockTitle::buildMock( 'Lula' );
-		$userNS = Localizer::getInstance()->getNamespaceTextById( NS_USER );
+		$userNS = Localizer::getInstance()->getNsText( NS_USER );
 
 		$userPage->expects( $this->any() )
 			->method( 'getNamespace' )

--- a/tests/phpunit/Unit/Query/Language/ClassDescriptionTest.php
+++ b/tests/phpunit/Unit/Query/Language/ClassDescriptionTest.php
@@ -25,7 +25,7 @@ class ClassDescriptionTest extends \PHPUnit_Framework_TestCase {
 
 	protected function setUp() : void {
 		parent::setUp();
-		$this->cat_name = Localizer::getInstance()->getNamespaceTextById( NS_CATEGORY );
+		$this->cat_name = Localizer::getInstance()->getNsText( NS_CATEGORY );
 	}
 
 	public function testCanConstruct() {
@@ -55,7 +55,7 @@ class ClassDescriptionTest extends \PHPUnit_Framework_TestCase {
 
 	public function testCommonMethods() {
 
-		$ns = Localizer::getInstance()->getNamespaceTextById( NS_CATEGORY );
+		$ns = Localizer::getInstance()->getNsText( NS_CATEGORY );
 
 		$class = new DIWikiPage( 'Foo', NS_CATEGORY );
 		$instance = new ClassDescription( $class );
@@ -75,7 +75,7 @@ class ClassDescriptionTest extends \PHPUnit_Framework_TestCase {
 
 	public function testAddDescription() {
 
-		$ns = Localizer::getInstance()->getNamespaceTextById( NS_CATEGORY );
+		$ns = Localizer::getInstance()->getNsText( NS_CATEGORY );
 
 		$instance = new ClassDescription( new DIWikiPage( 'Foo', NS_CATEGORY ) );
 		$instance->addDescription( new ClassDescription( new DIWikiPage( 'Bar', NS_CATEGORY ) ) );
@@ -93,7 +93,7 @@ class ClassDescriptionTest extends \PHPUnit_Framework_TestCase {
 
 	public function testAddClass() {
 
-		$ns = Localizer::getInstance()->getNamespaceTextById( NS_CATEGORY );
+		$ns = Localizer::getInstance()->getNsText( NS_CATEGORY );
 
 		$instance = new ClassDescription( new DIWikiPage( 'Foo', NS_CATEGORY ) );
 		$instance->addClass( new DIWikiPage( 'Bar', NS_CATEGORY ) );
@@ -244,7 +244,7 @@ class ClassDescriptionTest extends \PHPUnit_Framework_TestCase {
 
 	public function testGetQueryStringWithHierarchyDepth() {
 
-		$ns = Localizer::getInstance()->getNamespaceTextById( NS_CATEGORY );
+		$ns = Localizer::getInstance()->getNsText( NS_CATEGORY );
 
 		$instance = new ClassDescription(
 			new DIWikiPage( 'Foo', NS_CATEGORY )

--- a/tests/phpunit/Unit/Query/Language/ConceptDescriptionTest.php
+++ b/tests/phpunit/Unit/Query/Language/ConceptDescriptionTest.php
@@ -38,7 +38,7 @@ class ConceptDescriptionTest extends \PHPUnit_Framework_TestCase {
 
 	public function testCommonMethods() {
 
-		$ns = Localizer::getInstance()->getNamespaceTextById( SMW_NS_CONCEPT );
+		$ns = Localizer::getInstance()->getNsText( SMW_NS_CONCEPT );
 
 		$concept = new DIWikiPage( 'Foo', SMW_NS_CONCEPT );
 		$instance = new ConceptDescription( $concept );

--- a/tests/phpunit/Unit/Query/Language/ConjunctionTest.php
+++ b/tests/phpunit/Unit/Query/Language/ConjunctionTest.php
@@ -99,7 +99,7 @@ class ConjunctionTest extends \PHPUnit_Framework_TestCase {
 
 	public function conjunctionProvider() {
 
-		$nsHelp = Localizer::getInstance()->getNamespaceTextById( NS_HELP );
+		$nsHelp = Localizer::getInstance()->getNsText( NS_HELP );
 
 		$descriptions = [
 			'N:cfcd208495d565ef66e7dff9f98764da' => new NamespaceDescription( NS_MAIN ),

--- a/tests/phpunit/Unit/Query/Language/DisjunctionTest.php
+++ b/tests/phpunit/Unit/Query/Language/DisjunctionTest.php
@@ -101,7 +101,7 @@ class DisjunctionTest extends \PHPUnit_Framework_TestCase {
 
 	public function disjunctionProvider() {
 
-		$nsHelp = Localizer::getInstance()->getNamespaceTextById( NS_HELP );
+		$nsHelp = Localizer::getInstance()->getNsText( NS_HELP );
 
 		$descriptions = [
 			'N:cfcd208495d565ef66e7dff9f98764da' => new NamespaceDescription( NS_MAIN ),

--- a/tests/phpunit/Unit/Query/Language/NamespaceDescriptionTest.php
+++ b/tests/phpunit/Unit/Query/Language/NamespaceDescriptionTest.php
@@ -56,7 +56,7 @@ class NamespaceDescriptionTest extends \PHPUnit_Framework_TestCase {
 
 		$namespace = NS_CATEGORY;
 
-		$ns = Localizer::getInstance()->getNamespaceTextById( $namespace );
+		$ns = Localizer::getInstance()->getNsText( $namespace );
 		$instance = new NamespaceDescription( $namespace );
 
 		$this->assertEquals(

--- a/tests/phpunit/Unit/Query/PrintRequest/DeserializerTest.php
+++ b/tests/phpunit/Unit/Query/PrintRequest/DeserializerTest.php
@@ -87,7 +87,7 @@ class DeserializerTest extends \PHPUnit_Framework_TestCase {
 
 		#3
 		// Category
-		$categoryName = Localizer::getInstance()->getNamespaceTextById(
+		$categoryName = Localizer::getInstance()->getNsText(
 			NS_CATEGORY
 		);
 
@@ -102,7 +102,7 @@ class DeserializerTest extends \PHPUnit_Framework_TestCase {
 
 		#4
 		// Category
-		$categoryName = Localizer::getInstance()->getNamespaceTextById(
+		$categoryName = Localizer::getInstance()->getNsText(
 			NS_CATEGORY
 		);
 

--- a/tests/phpunit/Unit/Query/PrintRequest/SerializerTest.php
+++ b/tests/phpunit/Unit/Query/PrintRequest/SerializerTest.php
@@ -32,7 +32,7 @@ class SerializerTest extends \PHPUnit_Framework_TestCase {
 
 	public function textProvider() {
 
-		$category = Localizer::getInstance()->getNamespaceTextById( NS_CATEGORY );
+		$category = Localizer::getInstance()->getNsText( NS_CATEGORY );
 
 		$provider['print-cats'] = [
 			new PrintRequest( PrintRequest::PRINT_CATS, 'Foo' ),

--- a/tests/phpunit/includes/InfolinkTest.php
+++ b/tests/phpunit/includes/InfolinkTest.php
@@ -23,11 +23,13 @@ class InfolinkTest extends \PHPUnit_Framework_TestCase {
 
 	protected function setUp() : void {
 
-		$this->testEnvironment = new TestEnvironment(
-			[
-				'wgContLang' => \Language::factory( 'en' )
-			]
-		);
+		$this->testEnvironment = new TestEnvironment();
+
+		$language = $this->getMockBuilder( '\Language' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$this->testEnvironment->registerObject( 'ContentLanguage', $language );
 	}
 
 	protected function tearDown() : void {

--- a/tests/phpunit/includes/SemanticDataTest.php
+++ b/tests/phpunit/includes/SemanticDataTest.php
@@ -95,7 +95,7 @@ class SemanticDataTest extends \PHPUnit_Framework_TestCase {
 			DIWikiPage::doUnserialize( 'Foo#0##' )
 		);
 
-		$key = Localizer::getInstance()->getNamespaceTextById( SMW_NS_PROPERTY ) . ':' . 'addPropertyValue';
+		$key = Localizer::getInstance()->getNsText( SMW_NS_PROPERTY ) . ':' . 'addPropertyValue';
 
 		$expected = [
 			'propertyCount'  => 1,


### PR DESCRIPTION
This PR is made in reference to: #

This PR addresses or contains:

- Only the `Localizer::getContentLanguage` is allowed to carry the content language reference 
- Removes/replaces all known `$GLOBALS['wgContLang']` usages
- https://phabricator.wikimedia.org/T245940

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed
