### PR TITLE
SQLite `EXPLAIN QUERY PLAN`

### DIFF
--- a/src/Query/DebugFormatter.php
+++ b/src/Query/DebugFormatter.php
@@ -115,7 +115,7 @@ class DebugFormatter {
 	 *
 	 * @return string
 	 */
-	public static function prettifyExplain( $type, $res ) {
+	public static function prettifyExplain( string $type, iterable $res ) {
 
 		$output = '';
 
@@ -167,9 +167,28 @@ class DebugFormatter {
 			$output .= '</div>';
 		}
 
-		// SQlite doesn't support this
 		if ( $type === 'sqlite' ) {
-			$output .= 'Not supported.';
+			$output .= 'QUERY PLAN' . "<br>";
+			$plan = '';
+			$last = count( $res ) - 1;
+
+			foreach ( $res as $k => $row ) {
+
+				// https://www.sqlite.org/eqp.html notes "... output format did change
+				// substantially with the version 3.24.0 release ..."
+				if ( !isset( $row->id ) ) {
+					continue;
+				}
+
+				$marker = $k === $last ? '└──' : '├──';
+				$plan .= "<div style='margin-left:15px;'>$marker [" . $row->id . '] `' . $row->detail . "`</div>";
+			}
+
+			if ( $plan === '' ) {
+				$plan = 'The SQLite version doesn\'t support a query plan.';
+			}
+
+			$output .= $plan;
 		}
 
 		return $output;

--- a/tests/phpunit/Unit/Query/DebugFormatterTest.php
+++ b/tests/phpunit/Unit/Query/DebugFormatterTest.php
@@ -134,7 +134,7 @@ class DebugFormatterTest extends \PHPUnit_Framework_TestCase {
 
 		$provider[] = [
 			'sqlite',
-			''
+			[ ]
 		];
 
 		$row = [


### PR DESCRIPTION
This PR is made in reference to: #

This PR addresses or contains:

- If supported "... the EXPLAIN QUERY PLAN output format did change substantially with the version 3.24.0 release (2018-06-04). Further changes are possible in subsequent releases." as noted by https://www.sqlite.org/eqp.html.

This PR includes:
- [ ] Tests (unit/integration)
- [x] CI build passed

## Explain

```
SQL Explain
QUERY PLAN
├── [9] `SCAN TABLE t1 AS t1`
├── [11] `SEARCH TABLE smw_object_ids AS t0 USING INTEGER PRIMARY KEY (rowid=?)`
├── [39] `USE TEMP B-TREE FOR DISTINCT`
└── [40] `USE TEMP B-TREE FOR ORDER BY`
```