### PR TITLE
Remove `smwgContLang`

### DIFF
--- a/includes/SMW_PageSchemas.php
+++ b/includes/SMW_PageSchemas.php
@@ -199,7 +199,8 @@ class SMWPageSchemas extends PSExtensionHandler {
 	 * semantic property within the Page Schemas 'editschema' page.
 	 */
 	public static function getFieldEditingHTML( $psTemplateField ) {
-		global $smwgContLang;
+
+		$smwgContLang = smwfContLang();
 
 		$prop_array = [];
 		$hasExistingValues = false;
@@ -258,9 +259,9 @@ class SMWPageSchemas extends PSExtensionHandler {
 	 * passed-in Page Schemas XML object.
 	 */
 	public static function generatePages( $pageSchemaObj, $selectedPages ) {
-		global $smwgContLang, $wgUser;
+		global $wgUser;
 
-		$datatypeLabels = $smwgContLang->getDatatypeLabels();
+		$datatypeLabels = smwfContLang()->getDatatypeLabels();
 		$pageTypeLabel = $datatypeLabels['_wpg'];
 
 		$jobs = [];
@@ -308,10 +309,8 @@ class SMWPageSchemas extends PSExtensionHandler {
 	 * Creates the text for a property page.
 	 */
 	static public function createPropertyText( $propertyType, $allowedValues, $linkedForm = null ) {
-		/**
-		 * @var SMWLanguage $smwgContLang
-		 */
-		global $smwgContLang, $wgContLang;
+
+		$smwgContLang = smwfContLang();
 
 		$propLabels = $smwgContLang->getPropertyLabels();
 		$hasTypeLabel = $propLabels['_TYPE'];
@@ -326,7 +325,7 @@ class SMWPageSchemas extends PSExtensionHandler {
 		}
 
 		if ( $allowedValues != null) {
-			$text .= "\n\n" . wfMessage( 'smw-createproperty-allowedvals', $wgContLang->formatNum( count( $allowedValues ) ) )->inContentLanguage()->text();
+			$text .= "\n\n" . wfMessage( 'smw-createproperty-allowedvals', $GLOBALS['wgContLang']->formatNum( count( $allowedValues ) ) )->inContentLanguage()->text();
 
 			foreach ( $allowedValues as $value ) {
 				$prop_labels = $smwgContLang->getPropertyLabels();

--- a/src/ConfigLegacyTrait.php
+++ b/src/ConfigLegacyTrait.php
@@ -318,6 +318,8 @@ trait ConfigLegacyTrait {
 				'smwgFactboxUseCache' => 'smwgFactboxFeatures',
 				'smwgFactboxCacheRefreshOnPurge' => 'smwgFactboxFeatures',
 
+				'smwgContLang' => 'smwfContLang()',
+
 				// Identifies options of settings planned to be replaced
 				'options' => [
 					'smwgCacheUsage' => [
@@ -346,6 +348,7 @@ trait ConfigLegacyTrait {
 				'smwgEntityLookupCacheType' => '3.1.0',
 				'smwgEntityLookupCacheLifetime' => '3.1.0',
 				'smwgEntityLookupFeatures' => '3.1.0',
+				'smwgContLang' => '3.2.0'
 			]
 		];
 	}

--- a/src/GlobalFunctions.php
+++ b/src/GlobalFunctions.php
@@ -5,6 +5,7 @@ use SMW\DataValues\Number\IntlNumberFormatter;
 use SMW\Highlighter;
 use SMW\NamespaceManager;
 use SMW\ProcessingErrorMsgHandler;
+use SMW\Localizer\LocalLanguage\LocalLanguage;
 
 /**
  * Global functions specified and used by Semantic MediaWiki. In general, it is
@@ -14,6 +15,17 @@ use SMW\ProcessingErrorMsgHandler;
  * yet.
  * @ingroup SMW
  */
+
+/**
+ * Convenience function for external users. Replaces the `smwgContLang` setting.
+ *
+ * @since 3.2
+ *
+ * @return LocalLanguage
+ */
+function smwfContLang() : LocalLanguage {
+	return LocalLanguage::getInstance()->fetch( $GLOBALS['wgLanguageCode'] );
+}
 
 /**
  * Takes a title text and turns it safely into its DBKey. This function

--- a/src/NamespaceManager.php
+++ b/src/NamespaceManager.php
@@ -42,11 +42,6 @@ class NamespaceManager {
 			$this->initCustomNamespace( $vars );
 		}
 
-		// Legacy seeting in case some extension request a `smwgContLang` reference
-		if ( empty( $vars['smwgContLang'] ) ) {
-			$vars['smwgContLang'] = $this->localLanguage->fetch( $vars['wgLanguageCode'] );
-		}
-
 		$this->addNamespaceSettings( $vars );
 		$this->addExtraNamespaceSettings( $vars );
 	}
@@ -177,13 +172,12 @@ class NamespaceManager {
 			};
 		}
 
-		$extraNamespaces = $instance->getNamespacesByLanguageCode(
+		$localLanguage = $instance->getLocalLanguage(
 			$vars['wgLanguageCode']
 		);
 
-		$namespaceAliases = $instance->getNamespaceAliasesByLanguageCode(
-			$vars['wgLanguageCode']
-		);
+		$extraNamespaces = $localLanguage->getNamespaces();
+		$namespaceAliases = $localLanguage->getNamespaceAliases();
 
 		$vars['wgCanonicalNamespaceNames'] += $instance->getCanonicalNames();
 		$vars['wgExtraNamespaces'] += $extraNamespaces + $instance->getCanonicalNames();
@@ -256,13 +250,8 @@ class NamespaceManager {
 		return defined( $constant );
 	}
 
-	protected function getNamespacesByLanguageCode( $languageCode ) {
-		$GLOBALS['smwgContLang'] = $this->localLanguage->fetch( $languageCode );
-		return $GLOBALS['smwgContLang']->getNamespaces();
-	}
-
-	private function getNamespaceAliasesByLanguageCode( $languageCode ) {
-		return $this->localLanguage->fetch( $languageCode )->getNamespaceAliases();
+	protected function getLocalLanguage( $languageCode ) {
+		return $this->localLanguage->fetch( $languageCode );
 	}
 
 }

--- a/src/Settings.php
+++ b/src/Settings.php
@@ -151,7 +151,6 @@ class Settings extends Options {
 			'smwgAdminFeatures' => $GLOBALS['smwgAdminFeatures'],
 			'smwgAutoRefreshOnPurge' => $GLOBALS['smwgAutoRefreshOnPurge'],
 			'smwgAutoRefreshOnPageMove' => $GLOBALS['smwgAutoRefreshOnPageMove'],
-			'smwgContLang' => isset( $GLOBALS['smwgContLang'] ) ? $GLOBALS['smwgContLang'] : '',
 			'smwgMaxPropertyValues' => $GLOBALS['smwgMaxPropertyValues'],
 			'smwgNamespace' => $GLOBALS['smwgNamespace'],
 			'smwgMasterStore' => isset( $GLOBALS['smwgMasterStore'] ) ? $GLOBALS['smwgMasterStore'] : '',

--- a/tests/phpunit/Unit/GlobalFunctionsTest.php
+++ b/tests/phpunit/Unit/GlobalFunctionsTest.php
@@ -101,6 +101,13 @@ class GlobalFunctionsTest extends \PHPUnit_Framework_TestCase {
 		);
 	}
 
+	public function testSmwfContLang() {
+		$this->assertInstanceOf(
+			'\SMW\Localizer\LocalLanguage\LocalLanguage',
+			smwfContLang()
+		);
+	}
+
 	/**
 	 * Provides available global functions
 	 *


### PR DESCRIPTION
This PR is made in reference to: #1848, #1896, #1941

This PR addresses or contains:

- Removes `smwgContLang` which was never a configuration setting but got used as is, we have removed any reference of it in SMW with (#1896, #1941) and now it is time to remove remaining references from the code base
- If for some reason some external user made use of it then the `smwfContLang()` function is provided as convenience 

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed
