### PR TITLE
Use prefetch lookup for categories, refs 3722, 4611

### DIFF
--- a/src/Query/Result/FieldItemFinder.php
+++ b/src/Query/Result/FieldItemFinder.php
@@ -133,10 +133,15 @@ class FieldItemFinder {
 		// Request all direct categories of the current element
 		// Always recompute cache here to ensure output format is respected.
 		if ( $this->printRequest->isMode( PrintRequest::PRINT_CATS ) ) {
-			self::$catCache = $this->store->getPropertyValues(
-				$dataItem,
+			$options = new RequestOptions();
+			$options->isChain = false;
+			$options->isFirstChain = false;
+
+			// Rely on the prefetch
+			self::$catCache = $this->itemFetcher->fetch(
+				[ $dataItem ],
 				new DIProperty( '_INST' ),
-				$this->getRequestOptions( false )
+				$options
 			);
 
 			self::$catCacheObj = $dataItem->getHash();

--- a/tests/phpunit/Unit/Query/Result/FieldItemFinderTest.php
+++ b/tests/phpunit/Unit/Query/Result/FieldItemFinderTest.php
@@ -94,10 +94,10 @@ class FieldItemFinderTest extends \PHPUnit_Framework_TestCase {
 		$dataItem = $this->dataItemFactory->newDIWikiPage( 'Foo' );
 		$expected = $this->dataItemFactory->newDIWikiPage( __METHOD__ );
 
-		$this->store->expects( $this->once() )
-			->method( 'getPropertyValues' )
+		$this->itemFetcher->expects( $this->once() )
+			->method( 'fetch' )
 			->with(
-				$this->equalTo( $dataItem ),
+				$this->equalTo( [ $dataItem ] ),
 				$this->equalTo( $this->dataItemFactory->newDIProperty( '_INST' ) ) )
 			->will( $this->returnValue( [ $expected ] ) );
 


### PR DESCRIPTION
This PR is made in reference to: #3722, #4611

This PR addresses or contains:

- While working on #4611 I could see that categories are fetch in a non prefetch fashion creating a lot of SQL queries hence switching in using the same approach as introduced in #3722.

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed
