### PR TITLE
Improve `SemanticData` access in multi-value instance, refs 3900, 3901

### DIFF
--- a/includes/datavalues/SMW_DataValue.php
+++ b/includes/datavalues/SMW_DataValue.php
@@ -820,6 +820,17 @@ abstract class SMWDataValue {
 	}
 
 	/**
+	 * @since 3.2
+	 *
+	 * @param string $key
+	 *
+	 * @return bool
+	 */
+	public function hasCallable( $key ) : bool {
+		return isset( $this->callables[$key] );
+	}
+
+	/**
 	 * @since 3.1
 	 *
 	 * @param string $key
@@ -827,7 +838,7 @@ abstract class SMWDataValue {
 	 * @return callable
 	 * @throws RuntimeException
 	 */
-	public function getCallable( $key ) {
+	public function getCallable( $key ) : callable {
 
 		if ( !isset( $this->callables[$key] ) ) {
 			throw new RuntimeException( "`$key` as callable is unknown or not registered!" );

--- a/src/DataValues/MonolingualTextValue.php
+++ b/src/DataValues/MonolingualTextValue.php
@@ -4,6 +4,7 @@ namespace SMW\DataValues;
 
 use SMW\ApplicationFactory;
 use SMW\DataValueFactory;
+use SMW\SemanticData;
 use SMW\DataValues\ValueFormatters\DataValueFormatter;
 use SMW\DIProperty;
 use SMW\DIWikiPage;
@@ -174,8 +175,25 @@ class MonolingualTextValue extends AbstractMultiValue {
 			$this->m_dataitem = $dataItem;
 			return true;
 		} elseif ( $dataItem->getDIType() === DataItem::TYPE_WIKIPAGE ) {
-			$monolingualTextLookup = ApplicationFactory::getInstance()->getStore()->service( 'MonolingualTextLookup' );
-			$this->m_dataitem = $monolingualTextLookup->newDIContainer( $dataItem, $this->getProperty() );
+
+			$semanticData = null;
+			$subobjectName = $dataItem->getSubobjectName();
+
+			if ( $this->hasCallable( SemanticData::class ) ) {
+				$semanticData = $this->getCallable( SemanticData::class )();
+			}
+
+			if (
+				$semanticData instanceof SemanticData &&
+				$semanticData->hasSubSemanticData( $subobjectName ) ) {
+				$this->m_dataitem = new DIContainer(
+					$semanticData->findSubSemanticData( $subobjectName )
+				);
+			} else {
+				$monolingualTextLookup = ApplicationFactory::getInstance()->getStore()->service( 'MonolingualTextLookup' );
+				$this->m_dataitem = $monolingualTextLookup->newDIContainer( $dataItem, $this->getProperty() );
+			}
+
 			return true;
 		}
 


### PR DESCRIPTION
This PR is made in reference to: #3900, #3901

This PR addresses or contains:

- The issue of delayed value display is due to the required store access and can become visible when different multi-values as in case of  [0] depend on a store connection
- This PR attempts to avoid access to the store when a `SemanticData` instance is temporary available as part of the parsing process

This PR includes:
- [ ] Tests (unit/integration)
- [x] CI build passed

## Example

[0] https://sandbox.semantic-mediawiki.org/wiki/ReferenceAndRecord

![image](https://user-images.githubusercontent.com/1245473/76144949-06d4a880-607d-11ea-8f0a-901fca3c7a83.png)
