### PR TITLE
[SPARQLStore] `SMW_SPARQL_CONNECTION_PING` to ping before update

### DIFF
--- a/DefaultSettings.php
+++ b/DefaultSettings.php
@@ -291,6 +291,20 @@ return [
 	##
 
 	##
+	# SPARQL respository specific features
+	#
+	# - SMW_SPARQL_NONE does not support any features
+	#
+	# - SMW_SPARQL_CONNECTION_PING to support the verifcation that a connection
+	#   can be established and allows for an uninterruppted update and query
+	#   process
+	#
+	# @since 3.2
+	##
+	'smwgSparqlRepositoryFeatures' => SMW_SPARQL_NONE,
+	##
+
+	##
 	# @see https://github.com/SemanticMediaWiki/SemanticMediaWiki/issues/1306
 	#
 	# Setting to explicitly force a CURLOPT_HTTP_VERSION for the endpoint communication

--- a/src/Defines.php
+++ b/src/Defines.php
@@ -154,7 +154,7 @@ define( 'SMW_PREC_YMDTZ', 4 ); // with time zone
 /**@}*/
 
 /**@{
- * Constants for SPARQL supported features (mostly SPARQL 1.1) because we are unable
+ * Constants for SPARQL supported query features (mostly SPARQL 1.1) because we are unable
  * to verify against the REST API whether a feature is supported or not
  */
 define( 'SMW_SPARQL_QF_NONE', 0 ); // does not support any features
@@ -163,6 +163,13 @@ define( 'SMW_SPARQL_QF_SUBP', 4 ); // support for rdfs:subPropertyOf*
 define( 'SMW_SPARQL_QF_SUBC', 8 ); // support for rdfs:subClassOf*
 define( 'SMW_SPARQL_QF_COLLATION', 16 ); // support for use of $smwgEntityCollation
 define( 'SMW_SPARQL_QF_NOCASE', 32 ); // support case insensitive pattern matches
+/**@}*/
+
+/**@{
+ * Constants for SPARQL repository sepcific features
+ */
+define( 'SMW_SPARQL_NONE', 0 ); // does not support any features
+define( 'SMW_SPARQL_CONNECTION_PING', 2 ); // ping connection before update
 /**@}*/
 
 /**@{

--- a/src/SPARQLStore/Exception/HttpEndpointConnectionException.php
+++ b/src/SPARQLStore/Exception/HttpEndpointConnectionException.php
@@ -19,8 +19,11 @@ class HttpEndpointConnectionException extends \Exception {
 	 * @param integer $errorCode
 	 * @param string $errorText
 	 */
-	public function __construct( $endpoint, $errorCode, $errorText ) {
-		parent::__construct( "Failed to communicate to Endpoint: $endpoint\n" . "due to curl error: $errorCode ($errorText).\n" );
+	public function __construct( $endpoint, $errorCode, $errorText = '' ) {
+		parent::__construct(
+			"Failed to communicate with $endpoint (endpoint), due to cURL error: $errorCode" .
+			( $errorText !== '' ? " ($errorText)" : '' ) . "\n"
+		);
 	}
 
 }

--- a/src/SPARQLStore/RepositoryClient.php
+++ b/src/SPARQLStore/RepositoryClient.php
@@ -2,6 +2,8 @@
 
 namespace SMW\SPARQLStore;
 
+use SMW\Utils\Flag;
+
 /**
  * Provides information about the client and how to communicate with
  * its services
@@ -51,6 +53,11 @@ class RepositoryClient {
 	private $name = '';
 
 	/**
+	 * @var Flag|null
+	 */
+	private $featureSet;
+
+	/**
 	 * @since 2.2
 	 *
 	 * @param string $defaultGraph
@@ -63,6 +70,24 @@ class RepositoryClient {
 		$this->queryEndpoint = $queryEndpoint;
 		$this->updateEndpoint = $updateEndpoint;
 		$this->dataEndpoint = $dataEndpoint;
+	}
+
+	/**
+	 * @since 3.2
+	 *
+	 * @param int $featureSet
+	 */
+	public function setFeatureSet( int $featureSet ) {
+		$this->featureSet = new Flag( $featureSet );
+	}
+
+	/**
+	 * @since 3.2
+	 *
+	 * @param int $key
+	 */
+	public function isFlagSet( int $key ) : bool {
+		return $this->featureSet !== null && $this->featureSet->is( $key );
 	}
 
 	/**

--- a/src/SPARQLStore/RepositoryConnection.php
+++ b/src/SPARQLStore/RepositoryConnection.php
@@ -12,6 +12,21 @@ namespace SMW\SPARQLStore;
 interface RepositoryConnection {
 
 	/**
+	 * Flag denoting endpoints being capable of querying
+	 */
+	const QUERY_ENDPOINT = 1;
+
+	/**
+	 * Flag denoting endpoints being capable of updating
+	 */
+	const UPDATE_ENDPOINT = 2;
+
+	/**
+	 * Flag denoting endpoints being capable of SPARQL HTTP graph management
+	 */
+	const DATA_ENDPOINT = 4;
+
+	/**
 	 * The function returns connection details required for establishing an active
 	 * repository connection.
 	 *

--- a/src/SPARQLStore/RepositoryConnectionProvider.php
+++ b/src/SPARQLStore/RepositoryConnectionProvider.php
@@ -77,6 +77,11 @@ class RepositoryConnectionProvider implements ConnectionProvider {
 	private $httpVersion = false;
 
 	/**
+	 * @var integer
+	 */
+	private $featureSet = 0;
+
+	/**
 	 * @since 2.0
 	 *
 	 * @param string|null $connectorId
@@ -132,6 +137,15 @@ class RepositoryConnectionProvider implements ConnectionProvider {
 	}
 
 	/**
+	 * @since 3.2
+	 *
+	 * @return integer $featureSet
+	 */
+	public function setFeatureSet( int $featureSet ) {
+		$this->featureSet = $featureSet;
+	}
+
+	/**
 	 * @see ConnectionProvider::getConnection
 	 *
 	 * @since 2.0
@@ -175,6 +189,7 @@ class RepositoryConnectionProvider implements ConnectionProvider {
 			$this->dataEndpoint
 		);
 
+		$repositoryClient->setFeatureSet( $this->featureSet );
 		$repositoryClient->setName( $id );
 
 		$repositoryConnector = $this->createRepositoryConnector(

--- a/src/SPARQLStore/RepositoryConnectors/GenericRepositoryConnector.php
+++ b/src/SPARQLStore/RepositoryConnectors/GenericRepositoryConnector.php
@@ -24,17 +24,17 @@ class GenericRepositoryConnector implements RepositoryConnection {
 	/**
 	 * Flag denoting endpoints being capable of querying
 	 */
-	const ENDP_QUERY = 1;
+	const ENDP_QUERY = RepositoryConnection::QUERY_ENDPOINT;
 
 	/**
 	 * Flag denoting endpoints being capable of updating
 	 */
-	const ENDP_UPDATE = 2;
+	const ENDP_UPDATE = RepositoryConnection::UPDATE_ENDPOINT;
 
 	/**
 	 * Flag denoting endpoints being capable of SPARQL HTTP graph management
 	 */
-	const ENDP_DATA = 4;
+	const ENDP_DATA = RepositoryConnection::DATA_ENDPOINT;
 
 	/**
 	 * @var RepositoryClient
@@ -85,6 +85,39 @@ class GenericRepositoryConnector implements RepositoryConnection {
 	}
 
 	/**
+	 * @since 3.2
+	 *
+	 * @param string|int $type
+	 *
+	 * @return string
+	 */
+	public function getEndpoint( $type ) : ?string {
+
+		if ( $type === RepositoryConnection::QUERY_ENDPOINT ) {
+			return $this->repositoryClient->getQueryEndpoint();
+		}
+
+		if ( $type === RepositoryConnection::UPDATE_ENDPOINT ) {
+			return $this->repositoryClient->getUpdateEndpoint();
+		}
+
+		if ( $type === RepositoryConnection::DATA_ENDPOINT ) {
+			return $this->repositoryClient->getDataEndpoint();
+		}
+
+		return null;
+	}
+
+	/**
+	 * @since 3.2
+	 *
+	 * @return string
+	 */
+	public function getLastErrorCode() {
+		return $this->httpRequest->getLastErrorCode();
+	}
+
+	/**
 	 * Get the URI of the default graph that this database connector is
 	 * using, or the empty string if none is used (no graph related
 	 * statements in queries/updates).
@@ -102,6 +135,15 @@ class GenericRepositoryConnector implements RepositoryConnection {
 	 */
 	public function setConnectionTimeout( $timeout = 10 ) {
 		$this->httpRequest->setOption( CURLOPT_CONNECTTIMEOUT, $timeout );
+	}
+
+	/**
+	 * @since 3.2
+	 *
+	 * @return boolean
+	 */
+	public function shouldPing() : bool {
+		return $this->repositoryClient->isFlagSet( SMW_SPARQL_CONNECTION_PING );
 	}
 
 	/**

--- a/src/SPARQLStore/SPARQLStore.php
+++ b/src/SPARQLStore/SPARQLStore.php
@@ -5,6 +5,7 @@ namespace SMW\SPARQLStore;
 use SMW\DIProperty;
 use SMW\DIWikiPage;
 use SMW\SemanticData;
+use SMW\SPARQLStore\Exception\HttpEndpointConnectionException;
 use SMW\Store;
 use SMWDataItem as DataItem;
 use SMWExpNsResource as ExpNsResource;
@@ -180,6 +181,17 @@ class SPARQLStore extends Store {
 	 * @param SemanticData $semanticData
 	 */
 	public function doSparqlDataUpdate( SemanticData $semanticData ) {
+
+		$connection = $this->getConnection( 'sparql' );
+
+		if (
+			$connection->shouldPing() &&
+			$connection->ping( RepositoryConnection::UPDATE_ENDPOINT ) === false ) {
+			throw new HttpEndpointConnectionException(
+				$connection->getEndpoint( RepositoryConnection::UPDATE_ENDPOINT ),
+				$connection->getLastErrorCode()
+			);
+		}
 
 		$replicationDataTruncator = $this->factory->newReplicationDataTruncator();
 		$semanticData = $replicationDataTruncator->doTruncate( $semanticData );

--- a/src/SPARQLStore/SPARQLStoreFactory.php
+++ b/src/SPARQLStore/SPARQLStoreFactory.php
@@ -147,6 +147,10 @@ class SPARQLStoreFactory {
 			$settings->get( 'smwgSparqlRepositoryConnectorForcedHttpVersion' )
 		);
 
+		$repositoryConnectionProvider->setFeatureSet(
+			$settings->get( 'smwgSparqlRepositoryFeatures' )
+		);
+
 		$connectionManager = $applicationFactory->getConnectionManager();
 		$connectionManager->registerConnectionProvider(
 			'sparql',

--- a/src/Settings.php
+++ b/src/Settings.php
@@ -87,6 +87,7 @@ class Settings extends Options {
 			'smwgSparqlCustomConnector' => $GLOBALS['smwgSparqlCustomConnector'],
 			'smwgSparqlEndpoint' => $GLOBALS['smwgSparqlEndpoint'],
 			'smwgSparqlDefaultGraph' => $GLOBALS['smwgSparqlDefaultGraph'],
+			'smwgSparqlRepositoryFeatures' => $GLOBALS['smwgSparqlRepositoryFeatures'],
 			'smwgSparqlRepositoryConnectorForcedHttpVersion' => $GLOBALS['smwgSparqlRepositoryConnectorForcedHttpVersion'],
 			'smwgSparqlReplicationPropertyExemptionList' => $GLOBALS['smwgSparqlReplicationPropertyExemptionList'],
 			'smwgSparqlQFeatures' => $GLOBALS['smwgSparqlQFeatures'],

--- a/tests/phpunit/Unit/SPARQLStore/RepositoryClientTest.php
+++ b/tests/phpunit/Unit/SPARQLStore/RepositoryClientTest.php
@@ -18,8 +18,22 @@ class RepositoryClientTest extends \PHPUnit_Framework_TestCase {
 	public function testCanConstruct() {
 
 		$this->assertInstanceOf(
-			'\SMW\SPARQLStore\RepositoryClient',
+			RepositoryClient::class,
 			new RepositoryClient( '', '', '', '' )
+		);
+	}
+
+	public function testFeatureFlag() {
+
+		$instance = new RepositoryClient( 'Foo', 'Bar', 'Nu', 'Vim' );
+		$instance->setFeatureSet( 2 | 4 | 8 );
+
+		$this->assertTrue(
+			$instance->isFlagSet( 8 )
+		);
+
+		$this->assertFalse(
+			$instance->isFlagSet( 16 )
 		);
 	}
 

--- a/tests/phpunit/Unit/SPARQLStore/RepositoryConnectors/GenericRepositoryConnectorTest.php
+++ b/tests/phpunit/Unit/SPARQLStore/RepositoryConnectors/GenericRepositoryConnectorTest.php
@@ -3,6 +3,7 @@
 namespace SMW\Tests\SPARQLStore\RepositoryConnectors;
 
 use SMW\SPARQLStore\RepositoryConnectors\GenericRepositoryConnector;
+use SMW\SPARQLStore\RepositoryClient;
 
 /**
  * @covers \SMW\SPARQLStore\RepositoryConnectors\GenericRepositoryConnector
@@ -18,6 +19,104 @@ class GenericRepositoryConnectorTest extends ElementaryRepositoryConnectorTest {
 	public function getRepositoryConnectors() {
 		return [
 			GenericRepositoryConnector::class
+		];
+	}
+
+	public function testShouldPing() {
+
+		$httpRequest = $this->getMockBuilder( '\Onoi\HttpRequest\HttpRequest' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$repositoryClient = new RepositoryClient(
+			'http://foo/myDefaultGraph',
+			'http://localhost:9999/query',
+			'http://localhost:9999/update',
+			'http://localhost:9999/data'
+		);
+
+		$repositoryClient->setFeatureSet( SMW_SPARQL_CONNECTION_PING );
+
+		$instance = new GenericRepositoryConnector(
+			$repositoryClient,
+			$httpRequest
+		);
+
+		$this->assertTrue(
+			$instance->shouldPing()
+		);
+	}
+
+	/**
+	 * @dataProvider endpointProvider
+	 */
+	public function testGetEndpoint( $endpoint, $expected ) {
+
+		$httpRequest = $this->getMockBuilder( '\Onoi\HttpRequest\HttpRequest' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$instance = new GenericRepositoryConnector (
+			new RepositoryClient(
+				'http://foo/myDefaultGraph',
+				'http://localhost:9999/query',
+				'http://localhost:9999/update',
+				'http://localhost:9999/data'
+			),
+			$httpRequest
+		);
+
+		$this->assertEquals(
+			$expected,
+			$instance->getEndpoint( $endpoint )
+		);
+	}
+
+	public function testGetLastErrorCode() {
+
+		$httpRequest = $this->getMockBuilder( '\Onoi\HttpRequest\HttpRequest' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$httpRequest->expects( $this->once() )
+			->method( 'getLastErrorCode' )
+			->will( $this->returnValue( 42 ) );
+
+		$instance = new GenericRepositoryConnector(
+			new RepositoryClient(
+				'http://foo/myDefaultGraph',
+				'http://localhost:9999/query',
+				'http://localhost:9999/update'
+			),
+			$httpRequest
+		);
+
+		$this->assertEquals(
+			42,
+			$instance->getLastErrorCode()
+		);
+	}
+
+	public function endpointProvider() {
+
+		yield GenericRepositoryConnector::UPDATE_ENDPOINT => [
+			GenericRepositoryConnector::UPDATE_ENDPOINT,
+			'http://localhost:9999/update'
+		];
+
+		yield GenericRepositoryConnector::QUERY_ENDPOINT => [
+			GenericRepositoryConnector::QUERY_ENDPOINT,
+			'http://localhost:9999/query'
+		];
+
+		yield GenericRepositoryConnector::DATA_ENDPOINT => [
+			GenericRepositoryConnector::DATA_ENDPOINT,
+			'http://localhost:9999/data'
+		];
+
+		yield 'unknown' => [
+			'foo',
+			null
 		];
 	}
 

--- a/tests/phpunit/Unit/SPARQLStore/SPARQLStoreTest.php
+++ b/tests/phpunit/Unit/SPARQLStore/SPARQLStoreTest.php
@@ -242,6 +242,44 @@ class SPARQLStoreTest extends \PHPUnit_Framework_TestCase {
 		$instance->doSparqlDataUpdate( $semanticData );
 	}
 
+	public function testDoSparqlDataUpdate_FailedPingThrowsException() {
+
+		$semanticData = $this->getMockBuilder( '\SMW\SemanticData' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$repositoryResult = $this->getMockBuilder( '\SMW\SPARQLStore\QueryEngine\RepositoryResult' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$connection = $this->getMockBuilder( '\SMW\SPARQLStore\RepositoryConnectors\GenericRepositoryConnector' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$connection->expects( $this->once() )
+			->method( 'shouldPing' )
+			->will( $this->returnValue( true ) );
+
+		$connection->expects( $this->once() )
+			->method( 'ping' )
+			->will( $this->returnValue( false ) );
+
+		$connection->expects( $this->never() )
+			->method( 'insertData' );
+
+		$instance = $this->getMockBuilder( '\SMW\SPARQLStore\SPARQLStore' )
+			->setMethods( [ 'getConnection' ] )
+			->getMock();
+
+		$instance->expects( $this->atLeastOnce() )
+			->method( 'getConnection' )
+			->will( $this->returnValue( $connection ) );
+
+		$this->expectException( '\SMW\SPARQLStore\Exception\HttpEndpointConnectionException' );
+
+		$instance->doSparqlDataUpdate( $semanticData );
+	}
+
 	public function testGetQueryResult() {
 
 		$description = $this->getMockBuilder( '\SMW\Query\Language\Description' )

--- a/tests/travis/update-configuration-settings.sh
+++ b/tests/travis/update-configuration-settings.sh
@@ -24,38 +24,38 @@ if [ "$FOURSTORE" != "" ]
 then
 	echo '$smwgDefaultStore = "SMWSparqlStore";' >> LocalSettings.php
 	echo '$smwgSparqlRepositoryConnector = "4Store";' >> LocalSettings.php
-	echo '$smwgSparqlEndpoint["query"] = "http://localhost:8088/sparql/";' >> LocalSettings.php
-	echo '$smwgSparqlEndpoint["update"] = "http://localhost:8088/update/";' >> LocalSettings.php
+	echo '$smwgSparqlEndpoint["query"] = "http://127.0.0.1:8088/sparql/";' >> LocalSettings.php
+	echo '$smwgSparqlEndpoint["update"] = "http://127.0.0.1:8088/update/";' >> LocalSettings.php
 	echo '$smwgSparqlEndpoint["data"] = "";' >> LocalSettings.php
 	echo '$smwgSparqlDefaultGraph = "http://example.org/mydefaultgraphname";' >> LocalSettings.php
 elif [ "$FUSEKI" != "" ]
 then
 	echo '$smwgDefaultStore = "SMWSparqlStore";' >> LocalSettings.php
 	echo '$smwgSparqlRepositoryConnector = "Fuseki";' >> LocalSettings.php
-	echo '$smwgSparqlEndpoint["query"] = "http://localhost:3030/db/query";' >> LocalSettings.php
-	echo '$smwgSparqlEndpoint["update"] = "http://localhost:3030/db/update";' >> LocalSettings.php
+	echo '$smwgSparqlEndpoint["query"] = "http://127.0.0.1:3030/db/query";' >> LocalSettings.php
+	echo '$smwgSparqlEndpoint["update"] = "http://127.0.0.1:3030/db/update";' >> LocalSettings.php
 	echo '$smwgSparqlEndpoint["data"] = "";' >> LocalSettings.php
 elif [ "$SESAME" != "" ]
 then
 	echo '$smwgDefaultStore = "SMWSparqlStore";' >> LocalSettings.php
 	echo '$smwgSparqlRepositoryConnector = "Sesame";' >> LocalSettings.php
-	echo '$smwgSparqlEndpoint["query"] = "http://localhost:8080/openrdf-sesame/repositories/test-smw";' >> LocalSettings.php
-	echo '$smwgSparqlEndpoint["update"] = "http://localhost:8080/openrdf-sesame/repositories/test-smw/statements";' >> LocalSettings.php
+	echo '$smwgSparqlEndpoint["query"] = "http://127.0.0.1:8080/openrdf-sesame/repositories/test-smw";' >> LocalSettings.php
+	echo '$smwgSparqlEndpoint["update"] = "http://127.0.0.1:8080/openrdf-sesame/repositories/test-smw/statements";' >> LocalSettings.php
 	echo '$smwgSparqlEndpoint["data"] = "";' >> LocalSettings.php
 elif [ "$BLAZEGRAPH" != "" ]
 then
 	echo '$smwgDefaultStore = "SMWSparqlStore";' >> LocalSettings.php
 	echo '$smwgSparqlRepositoryConnector = "Blazegraph";' >> LocalSettings.php
-	echo '$smwgSparqlEndpoint["query"] = "http://localhost:9999/bigdata/namespace/kb/sparql";' >> LocalSettings.php
-	echo '$smwgSparqlEndpoint["update"] = "http://localhost:9999/bigdata/namespace/kb/sparql";' >> LocalSettings.php
+	echo '$smwgSparqlEndpoint["query"] = "http://127.0.0.1:9999/bigdata/namespace/kb/sparql";' >> LocalSettings.php
+	echo '$smwgSparqlEndpoint["update"] = "http://127.0.0.1:9999/bigdata/namespace/kb/sparql";' >> LocalSettings.php
 	echo '$smwgSparqlEndpoint["data"] = "";' >> LocalSettings.php
 	echo '$smwgSparqlDefaultGraph = "";' >> LocalSettings.php
 elif [ "$VIRTUOSO" != "" ]
 then
 	echo '$smwgDefaultStore = "SMWSparqlStore";' >> LocalSettings.php
 	echo '$smwgSparqlRepositoryConnector = "Virtuoso";' >> LocalSettings.php
-	echo '$smwgSparqlEndpoint["query"] = "http://localhost:8890/sparql";' >> LocalSettings.php
-	echo '$smwgSparqlEndpoint["update"] = "http://localhost:8890/sparql";' >> LocalSettings.php
+	echo '$smwgSparqlEndpoint["query"] = "http://127.0.0.1:8890/sparql";' >> LocalSettings.php
+	echo '$smwgSparqlEndpoint["update"] = "http://127.0.0.1:8890/sparql";' >> LocalSettings.php
 	echo '$smwgSparqlEndpoint["data"] = "";' >> LocalSettings.php
 	echo '$smwgSparqlDefaultGraph = "http://example.org/travisGraph";' >> LocalSettings.php
 elif [ "$ES" != "" ]


### PR DESCRIPTION
This PR is made in reference to: #

This PR addresses or contains:

- While working with some SPARQL endpoint it happened that the server went away and some cURL error occurred but SMW didn't report any issue and as a consequence no data where saved for neither SQL nor the SPARQL endpoint. Only some minor log message could be found similar to `[fatal] [1d67d62748381c5cdc9a6ca2] /mw-master/index.php?title=Foo&action=submit   PHP Fatal Error from line 135 of ...\mw-master\vendor\onoi\http-request\src\CurlRequest.php: Maximum execution time of 120 seconds exceeded #0 [internal function]: MWExceptionHandler::handleFatalError()`
- This PR introduces `SMW_SPARQL_CONNECTION_PING` for the newly added `smwgSparqlRepositoryFeatures` setting so that users can enable the feature in order to ping before trying to run an update and if it cannot connect then it will produce a visible exception.
- `SMW_SPARQL_CONNECTION_PING` is disabled by default as feature because it depends on the selected repository connector (and version) whether the update endpoint returns a correct cURL code or not

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed

## Example

```
2020-03-06 05:35:54 PROMETHEUS mwmaster: Deferred update ["SMW\\DataUpdater::doUpdate","LinksUpdateConstructed","Foo#0##"] failed: Failed to communicate with the http://192.168.99.101:32768/smw/update (endpoint), due to cURL error: 7

#0 ...\mw-master\extensions\SemanticMediaWiki\src\SPARQLStore\SPARQLStore.php(242): SMW\SPARQLStore\SPARQLStore->doSparqlDataUpdate(Object(SMW\SemanticData))
#1 ...\mw-master\extensions\SemanticMediaWiki\src\Store.php(238): SMW\SPARQLStore\SPARQLStore->doDataUpdate(Object(SMW\SemanticData))
#2 ...\mw-master\extensions\SemanticMediaWiki\src\DataUpdater.php(415): SMW\Store->updateData(Object(SMW\SemanticData))
#3 ...\mw-master\extensions\SemanticMediaWiki\src\DataUpdater.php(294): SMW\DataUpdater->updateData()
#4 ...\mw-master\extensions\SemanticMediaWiki\src\MediaWiki\Deferred\CallableUpdate.php(349): SMW\DataUpdater->runUpdate()
#5 ...\mw-master\extensions\SemanticMediaWiki\src\MediaWiki\Deferred\CallableUpdate.php(324): SMW\MediaWiki\Deferred\CallableUpdate->runUpdate()
#6 ...\mw-master\extensions\SemanticMediaWiki\src\MediaWiki\Deferred\CallableUpdate.php(245): SMW\MediaWiki\Deferred\CallableUpdate->attemptUpdate()
#7 ...\mw-master\extensions\SemanticMediaWiki\src\MediaWiki\Deferred\TransactionalCallableUpdate.php(168): SMW\MediaWiki\Deferred\CallableUpdate->doUpdate()
#8 ...\mw-master\includes\deferred\DeferredUpdates.php(417): SMW\MediaWiki\Deferred\TransactionalCallableUpdate->doUpdate()
#9 ...\mw-master\includes\deferred\DeferredUpdates.php(296): DeferredUpdates::attemptUpdate(Object(SMW\MediaWiki\Deferred\TransactionalCallableUpdate), Object(Wikimedia\Rdbms\LBFactorySimple))
#10 ...\mw-master\includes\deferred\DeferredUpdates.php(242): DeferredUpdates::run(Object(SMW\MediaWiki\Deferred\TransactionalCallableUpdate), Object(Wikimedia\Rdbms\LBFactorySimple), Object(MediaWiki\Logger\LegacyLogger), Object(BufferingStatsdDataFactory), 'post')
#11 ...\mw-master\includes\deferred\DeferredUpdates.php(150): DeferredUpdates::handleUpdateQueue(Array, 'run', 2)
#12 ...\mw-master\includes\MediaWiki.php(1057): DeferredUpdates::doUpdates('run')
#13 ...\mw-master\includes\MediaWiki.php(837): MediaWiki->restInPeace()
#14 ...\mw-master\includes\MediaWiki.php(857): MediaWiki->{closure}()
#15 ...\mw-master\includes\MediaWiki.php(573): MediaWiki->doPostOutputShutdown()
#16 ...\mw-master\index.php(47): MediaWiki->run()
#17 {main}: []
```

Information about the error code can be found at https://curl.haxx.se/libcurl/c/libcurl-errors.html.