### PR TITLE
[SPARQLStore] Fetch server info (Fuseki)

### DIFF
--- a/src/SPARQLStore/RepositoryConnectors/FusekiRepositoryConnector.php
+++ b/src/SPARQLStore/RepositoryConnectors/FusekiRepositoryConnector.php
@@ -5,6 +5,7 @@ namespace SMW\SPARQLStore\RepositoryConnectors;
 use SMW\SPARQLStore\Exception\BadHttpEndpointResponseException;
 use SMW\SPARQLStore\QueryEngine\RepositoryResult;
 use SMW\SPARQLStore\QueryEngine\XmlResponseParser;
+use SMW\Utils\Url;
 
 /**
  * @see https://jena.apache.org/documentation/serving_data/index.html
@@ -54,6 +55,30 @@ class FusekiRepositoryConnector extends GenericRepositoryConnector {
 		$repositoryResult->setErrorCode( RepositoryResult::ERROR_UNREACHABLE );
 
 		return $repositoryResult;
+	}
+
+	/**
+	 * @since 3.2
+	 *
+	 * @see GenericRepositoryConnector::getVersion
+	 */
+	public function getVersion() {
+
+		$url = new Url(
+			$this->repositoryClient->getQueryEndpoint()
+		);
+
+		// https://jena.apache.org/documentation/fuseki2/fuseki-server-protocol.html
+		$this->httpRequest->setOption( CURLOPT_URL, $url->path( '/$/server' ) );
+		$httpResponse = $this->httpRequest->execute();
+
+		if ( is_string( $httpResponse ) ) {
+			$httpResponse = json_decode( $httpResponse, true );
+
+			return $httpResponse['version'] ?? '/na';
+		}
+
+		return 'n/a';
 	}
 
 }

--- a/src/SPARQLStore/RepositoryConnectors/GenericRepositoryConnector.php
+++ b/src/SPARQLStore/RepositoryConnectors/GenericRepositoryConnector.php
@@ -621,6 +621,15 @@ class GenericRepositoryConnector implements RepositoryConnection {
 	}
 
 	/**
+	 * @since 3.2
+	 *
+	 * @return string|int
+	 */
+	public function getVersion() {
+		return 'n/a';
+	}
+
+	/**
 	 * @param $endpoint string URL of endpoint that was used
 	 * @param $sparql string query that caused the problem
 	 */

--- a/src/SPARQLStore/SPARQLStore.php
+++ b/src/SPARQLStore/SPARQLStore.php
@@ -446,10 +446,11 @@ class SPARQLStore extends Store {
 	 */
 	public function getInfo( $type = null ) {
 
-		$client = $this->getConnection( 'sparql' )->getRepositoryClient();
+		$respositoryConnetion = $this->getConnection( 'sparql' );
+		$repositoryClient = $respositoryConnetion->getRepositoryClient();
 
 		if ( $type === 'store' ) {
-			return [ 'SMWSPARQLStore', $client->getName() ];
+			return [ 'SMWSPARQLStore', $repositoryClient->getName() ];
 		}
 
 		$connection = $this->getConnection( 'mw.db' );
@@ -459,7 +460,7 @@ class SPARQLStore extends Store {
 		}
 
 		return [
-			'SMWSPARQLStore' => $connection->getInfo() + [ $client->getName() => 'n/a' ]
+			'SMWSPARQLStore' => $connection->getInfo() + [ $repositoryClient->getName() => $respositoryConnetion->getVersion() ]
 		];
 	}
 

--- a/src/Utils/Url.php
+++ b/src/Utils/Url.php
@@ -1,0 +1,111 @@
+<?php
+
+namespace SMW\Utils;
+
+/**
+ * @license GNU GPL v2+
+ * @since 3.2
+ *
+ * @author mwjames
+ */
+class Url {
+
+	/**
+	 * @var []
+	 */
+	private $info = [];
+
+	/**
+	 * @var []
+	 */
+	private $flag = [];
+
+	/**
+	 * @since 3.2
+	 *
+	 * @param string $url
+	 */
+	public function __construct( string $url ) {
+		$this->info = parse_url( $url );
+	}
+
+	/**
+	 * @since 3.2
+	 *
+	 * @param string $path
+	 *
+	 * @return string
+	 */
+	public function path( string $path = '' ) : string {
+
+		if ( $path === '' ) {
+			return $this->get( PHP_URL_SCHEME, PHP_URL_HOST, PHP_URL_PORT, PHP_URL_USER, PHP_URL_PASS, PHP_URL_PATH );
+		}
+
+		return $this->get( PHP_URL_SCHEME, PHP_URL_HOST, PHP_URL_PORT, PHP_URL_USER, PHP_URL_PASS ) . "$path";
+	}
+
+	/**
+	 * @since 3.2
+	 *
+	 * @param ...$args
+	 *
+	 * @return string
+	 */
+	public function get( ...$args ) : string {
+		// PHP_URL_* aren't bit fields !!!!!
+		$this->flag = $args;
+
+		$text = '';
+
+		// https://www.php.net/manual/en/function.parse-url.php#106731
+		$scheme = isset( $this->info['scheme'] ) ? $this->info['scheme'] . '://' : '';
+		$host = isset( $this->info['host'] ) ? $this->info['host'] : '';
+		$port = isset( $this->info['port'] ) ? ':' . $this->info['port'] : '';
+		$user = isset( $this->info['user'] ) ? $this->info['user'] : '';
+		$pass = isset( $this->info['pass'] ) ? ':' . $this->info['pass']  : '';
+		$pass = ( $user || $pass ) ? "$pass@" : '';
+		$path     = isset( $this->info['path'] ) ? $this->info['path'] : '';
+		$query    = isset( $this->info['query'] ) ? '?' . $this->info['query'] : '';
+		$fragment = isset( $this->info['fragment'] ) ? '#' . $this->info['fragment'] : '';
+
+		if ( $this->is( PHP_URL_SCHEME ) ) {
+			$text .= $scheme;
+		}
+
+		if ( $this->is( PHP_URL_USER ) ) {
+			$text .= $user;
+		}
+
+		if ( $this->is( PHP_URL_PASS ) ) {
+			$text .= $pass;
+		}
+
+		if ( $this->is( PHP_URL_HOST ) ) {
+			$text .= $host;
+		}
+
+		if ( $this->is( PHP_URL_PORT ) ) {
+			$text .= $port;
+		}
+
+		if ( $this->is( PHP_URL_PATH ) ) {
+			$text .= $path;
+		}
+
+		if ( $this->is( PHP_URL_QUERY ) ) {
+			$text .= $query;
+		}
+
+		if ( $this->is( PHP_URL_FRAGMENT ) ) {
+			$text .= $fragment;
+		}
+
+		return $text;
+	}
+
+	private function is( $flag ) : bool {
+		return in_array( $flag, $this->flag );
+	}
+
+}

--- a/tests/phpunit/Unit/SPARQLStore/RepositoryConnectors/FusekiRepositoryConnectorTest.php
+++ b/tests/phpunit/Unit/SPARQLStore/RepositoryConnectors/FusekiRepositoryConnectorTest.php
@@ -3,6 +3,7 @@
 namespace SMW\Tests\SPARQLStore\RepositoryConnectors;
 
 use SMW\SPARQLStore\RepositoryConnectors\FusekiRepositoryConnector;
+use SMW\SPARQLStore\RepositoryClient;
 
 /**
  * @covers \SMW\SPARQLStore\RepositoryConnectors\FusekiRepositoryConnector
@@ -19,6 +20,40 @@ class FusekiRepositoryConnectorTest extends ElementaryRepositoryConnectorTest {
 		return [
 			FusekiRepositoryConnector::class
 		];
+	}
+
+	public function testGetVersion() {
+
+		$data = json_encode( [ 'version' => '3.2' ] );
+
+		$httpRequest = $this->getMockBuilder( '\Onoi\HttpRequest\HttpRequest' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$httpRequest->expects( $this->at( 5 ) )
+			->method( 'setOption' )
+			->with(
+				$this->equalTo( CURLOPT_URL ),
+				$this->stringContains( 'http://usr:pass@localhost:9999/$/server' ) )
+			->will( $this->returnValue( true ) );
+
+		$httpRequest->expects( $this->once() )
+			->method( 'execute' )
+			->will( $this->returnValue( $data ) );
+
+		$instance = new FusekiRepositoryConnector(
+			new RepositoryClient(
+				'http://foo/myDefaultGraph',
+				'http://usr:pass@localhost:9999/query',
+				'http://localhost:9999/update'
+			),
+			$httpRequest
+		);
+
+		$this->assertEquals(
+			'3.2',
+			$instance->getVersion()
+		);
 	}
 
 }

--- a/tests/phpunit/Unit/Utils/UrlTest.php
+++ b/tests/phpunit/Unit/Utils/UrlTest.php
@@ -1,0 +1,86 @@
+<?php
+
+namespace SMW\Tests\Utils;
+
+use SMW\Utils\Url;
+
+/**
+ * @covers \SMW\Utils\Url
+ * @group semantic-mediawiki
+ *
+ * @license GNU GPL v2+
+ * @since 3.2
+ *
+ * @author mwjames
+ */
+class UrlTest extends \PHPUnit_Framework_TestCase {
+
+	/**
+	 * @dataProvider urlProvider
+	 */
+	public function testGet( $url, $flags, $expected ) {
+
+		$instance = new Url( $url );
+
+		$this->assertEquals(
+			$expected,
+			$instance->get( ...$flags )
+		);
+	}
+
+	/**
+	 * @dataProvider pathProvider
+	 */
+	public function testPath( $url, $path, $expected ) {
+
+		$instance = new Url( $url );
+
+		$this->assertEquals(
+			$expected,
+			$instance->path( $path )
+		);
+	}
+
+	public function urlProvider() {
+
+		yield [
+			'http://usr:pss@example.com:81/mypath/myfile.html?a=b&b[]=2&b[]=3#myfragment',
+			[ PHP_URL_SCHEME, PHP_URL_HOST ],
+			'http://example.com'
+		];
+
+		yield [
+			'http://usr:pss@example.com:81/mypath/myfile.html?a=b&b[]=2&b[]=3#myfragment',
+			[ PHP_URL_SCHEME, PHP_URL_HOST, PHP_URL_USER, PHP_URL_PASS, PHP_URL_PORT ],
+			'http://usr:pss@example.com:81'
+		];
+
+		yield [
+			'http://usr:pss@example.com:81/mypath/myfile.html?a=b&b[]=2&b[]=3#myfragment',
+			[ PHP_URL_QUERY ],
+			'?a=b&b[]=2&b[]=3'
+		];
+
+		yield 'invalid' => [
+			'http://:80',
+			[ PHP_URL_SCHEME, PHP_URL_HOST ],
+			''
+		];
+	}
+
+	public function pathProvider() {
+
+		yield [
+			'http://usr:pss@example.com:81/mypath/myfile.html?a=b&b[]=2&b[]=3#myfragment',
+			'',
+			'http://usr:pss@example.com:81/mypath/myfile.html'
+		];
+
+		yield [
+			'http://usr:pss@example.com:81/mypath/myfile.html?a=b&b[]=2&b[]=3#myfragment',
+			'/foo/bar',
+			'http://usr:pss@example.com:81/foo/bar'
+		];
+	}
+
+}


### PR DESCRIPTION
This PR is made in reference to: #

This PR addresses or contains:

- Getting the version number of the triple store software depends solely on the implementation details of the selected triple store and currently only Fuseki [0] provides an interface (REST) where such information can be fetched from.

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed

[0] https://jena.apache.org/documentation/fuseki2/fuseki-server-protocol.html