### PR TITLE
Use `JSONParseException` instead of `json_last_error_msg`, refs 4404

### DIFF
--- a/src/Exception/JSONParseException.php
+++ b/src/Exception/JSONParseException.php
@@ -23,6 +23,13 @@ class JSONParseException extends RuntimeException {
 	}
 
 	/**
+	 * @since 3.2
+	 */
+	public function getTidyMessage() : string {
+		return str_replace( "\n", '', $this->getMessage() );
+	}
+
+	/**
 	 * PHP has no built-in functionality to find errors in a JSON therefore we rely
 	 * on `JsonLint` to help us find a more meaningful message other than
 	 * "Syntax error".

--- a/src/MediaWiki/Content/SchemaContent.php
+++ b/src/MediaWiki/Content/SchemaContent.php
@@ -4,6 +4,7 @@ namespace SMW\MediaWiki\Content;
 
 use SMW\Schema\SchemaFactory;
 use SMW\Schema\Exception\SchemaTypeNotFoundException;
+use SMW\Exception\JSONParseException;
 use SMW\Schema\Schema;
 use SMW\ParserData;
 use SMW\Message;
@@ -393,9 +394,18 @@ class SchemaContent extends JsonContent {
 			// Objects and arrays are kept as distinguishable types in the PHP values.
 			$this->parse = json_decode( $this->mText );
 			$this->isValid = json_last_error() === JSON_ERROR_NONE;
-			$this->errorMsg = json_last_error_msg();
 
-			return $this->isValid;
+			if ( $this->isValid ) {
+				return true;
+			}
+
+			$jsonParseException = new JSONParseException(
+				$this->mText
+			);
+
+			$this->errorMsg = $jsonParseException->getTidyMessage();
+
+			return false;
 		}
 	}
 

--- a/tests/phpunit/Unit/Exception/JSONParseExceptionTest.php
+++ b/tests/phpunit/Unit/Exception/JSONParseExceptionTest.php
@@ -18,7 +18,7 @@ class JSONParseExceptionTest extends \PHPUnit_Framework_TestCase {
 
 	use PHPUnitCompat;
 
-	public function testCanConstruct() {
+	public function testGetMessage() {
 
 		$json = '{ "test": 123, }';
 
@@ -29,6 +29,20 @@ class JSONParseExceptionTest extends \PHPUnit_Framework_TestCase {
 		$this->assertContains(
 			"Expected: 'STRING' - It appears you have an extra trailing comma",
 			$instance->getMessage()
+		);
+	}
+
+	public function testGetTidyMessage() {
+
+		$json = '{ "test": 123, }';
+
+		$instance = new JSONParseException(
+			$json
+		);
+
+		$this->assertInternalType(
+			'string',
+			$instance->getTidyMessage()
 		);
 	}
 


### PR DESCRIPTION
This PR is made in reference to: #4404

This PR addresses or contains:

- `json_last_error_msg` isn't really helpful therefore we use `JSONParseException` to show better information about the error that causes a syntax error.

This PR includes:
- [ ] Tests (unit/integration)
- [x] CI build passed

## Example

### Before

![image](https://user-images.githubusercontent.com/1245473/76151192-1b7b6580-60aa-11ea-9e89-5165fa2c1eac.png)

### After
![image](https://user-images.githubusercontent.com/1245473/76150601-39de6280-60a4-11ea-8789-b5e882f317bb.png)
