### PR TITLE
[SPARQLStore] Show detail during setup, refs 4631

### DIFF
--- a/src/SQLStore/Installer.php
+++ b/src/SQLStore/Installer.php
@@ -184,7 +184,7 @@ class Installer implements MessageReporter {
 		);
 
 		$this->messageReporter->reportMessage(
-			$this->cliMsgFormatter->twoCols( 'Database:', $this->tableBuildExaminer->getDatabaseInfo() )
+			$this->cliMsgFormatter->twoCols( 'Database (type/version):', $this->tableBuildExaminer->getDatabaseInfo() )
 		);
 
 		$this->tableBuilder->setMessageReporter(


### PR DESCRIPTION
This PR is made in reference to: #4631

This PR addresses or contains:

- If the information is available then it shows as "RDF store setup" in the output  (see below)

This PR includes:
- [ ] Tests (unit/integration)
- [x] CI build passed

## Example

```
=== Sematic MediaWiki =====================================================

Semantic MediaWiki:                                             3.2.0-alpha
MediaWiki:                                                           1.32.6

--- RDF store setup -------------------------------------------------------

Query engine:                                                SMWSPARQLStore
Repository connector (type/version):                         fuseki (2.4.0)

--- Database setup --------------------------------------------------------

Storage engine:                                                SMWSQLStore3
Database (type/version):                    mysql (5.6.33-0ubuntu0.14.04.1)

Checking database version requirement ...
   ... done.

------------------------------------------------------ Core table(s) ------
```