### PR TITLE
Handle other types of deprecation notices, refs 2357

### DIFF
--- a/i18n/en.json
+++ b/i18n/en.json
@@ -392,6 +392,7 @@
 	"smw-admin-deprecation-notice-config-notice-option": "<code>[https://www.semantic-mediawiki.org/wiki/Help:$1 $1]</code> will remove (or replace) the following {{PLURAL:$2|option|options}}:",
 	"smw-admin-deprecation-notice-config-notice-option-list": "<code>$1</code> is deprecated and will be removed in $2",
 	"smw-admin-deprecation-notice-config-replacement": "<code>[https://www.semantic-mediawiki.org/wiki/Help:$1 $1]</code> was replaced by <code>[https://www.semantic-mediawiki.org/wiki/Help:$2 $2]</code>",
+	"smw-admin-deprecation-notice-config-replacement-other": "<code>[https://www.semantic-mediawiki.org/wiki/Help:$1 $1]</code> was replaced by <code>$2</code>",
 	"smw-admin-deprecation-notice-config-replacement-option": "<code>[https://www.semantic-mediawiki.org/wiki/Help:$1 $1]</code> {{PLURAL:$2|option|options}}:",
 	"smw-admin-deprecation-notice-config-replacement-option-list": "<code>$1</code> is being replaced by <code>$2</code>",
 	"smw-admin-deprecation-notice-config-removal": "<code>[https://www.semantic-mediawiki.org/wiki/Help:$1 $1]</code> was removed in $2",

--- a/src/MediaWiki/Specials/Admin/Alerts/DeprecationNoticeTaskHandler.php
+++ b/src/MediaWiki/Specials/Admin/Alerts/DeprecationNoticeTaskHandler.php
@@ -163,8 +163,10 @@ class DeprecationNoticeTaskHandler extends TaskHandler {
 		foreach ( $replacementConfigList as $setting => $value ) {
 			if ( $setting === 'options' ) {
 				$list[] = $this->createItems( "$section-admin-deprecation-notice-config-replacement", $value );
-			} elseif ( isset( $GLOBALS[$setting] ) ) {
+			} elseif ( isset( $GLOBALS[$setting] ) && strpos( $value, 'smwg' ) !== false ) {
 				$list[] = $this->createItem( [ "$section-admin-deprecation-notice-config-replacement", '$' . $setting, '$' . $value ] );
+			} elseif ( isset( $GLOBALS[$setting] ) ) {
+				$list[] = $this->createItem( [ "$section-admin-deprecation-notice-config-replacement-other", '$' . $setting, $value ] );
 			}
 		}
 

--- a/src/MediaWiki/Specials/Admin/TaskHandler.php
+++ b/src/MediaWiki/Specials/Admin/TaskHandler.php
@@ -5,6 +5,7 @@ namespace SMW\MediaWiki\Specials\Admin;
 use SMW\Message;
 use SMW\Store;
 use WebRequest;
+use SMW\Localizer\MessageLocalizerTrait;
 
 /**
  * @license GNU GPL v2+
@@ -13,6 +14,8 @@ use WebRequest;
  * @author mwjames
  */
 abstract class TaskHandler {
+
+	use MessageLocalizerTrait;
 
 	/**
 	 * Identifies an individual section to where the task is associated with.
@@ -133,9 +136,5 @@ abstract class TaskHandler {
 	 * @return string
 	 */
 	abstract public function getHtml();
-
-	protected function msg( $key, $type = Message::TEXT ) {
-		return Message::get( $key, $type, Message::USER_LANGUAGE );
-	}
 
 }

--- a/tests/phpunit/Unit/MediaWiki/Specials/Admin/Alerts/DeprecationNoticeTaskHandlerTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Specials/Admin/Alerts/DeprecationNoticeTaskHandlerTest.php
@@ -21,6 +21,7 @@ class DeprecationNoticeTaskHandlerTest extends \PHPUnit_Framework_TestCase {
 
 	private $testEnvironment;
 	private $outputFormatter;
+	private $messageLocalizer;
 
 	protected function setUp() : void {
 		parent::setUp();
@@ -28,6 +29,10 @@ class DeprecationNoticeTaskHandlerTest extends \PHPUnit_Framework_TestCase {
 		$this->testEnvironment = new TestEnvironment();
 
 		$this->outputFormatter = $this->getMockBuilder( '\SMW\MediaWiki\Specials\Admin\OutputFormatter' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$this->messageLocalizer = $this->getMockBuilder( '\SMW\Localizer\MessageLocalizer' )
 			->disableOriginalConstructor()
 			->getMock();
 	}
@@ -49,6 +54,10 @@ class DeprecationNoticeTaskHandlerTest extends \PHPUnit_Framework_TestCase {
 
 		$instance = new DeprecationNoticeTaskHandler(
 			$this->outputFormatter
+		);
+
+		$instance->setMessageLocalizer(
+			$this->messageLocalizer
 		);
 
 		$this->assertInternalType(
@@ -92,6 +101,10 @@ class DeprecationNoticeTaskHandlerTest extends \PHPUnit_Framework_TestCase {
 			$deprecationNotice
 		);
 
+		$instance->setMessageLocalizer(
+			$this->messageLocalizer
+		);
+
 		$this->assertInternalType(
 			'string',
 			$instance->getHtml()
@@ -131,6 +144,10 @@ class DeprecationNoticeTaskHandlerTest extends \PHPUnit_Framework_TestCase {
 		$instance = new DeprecationNoticeTaskHandler(
 			$this->outputFormatter,
 			$deprecationNotice
+		);
+
+		$instance->setMessageLocalizer(
+			$this->messageLocalizer
 		);
 
 		$this->assertContains(


### PR DESCRIPTION
This PR is made in reference to: #2357

This PR addresses or contains:

- Not all messages will point to a replacement setting hence check for that and select a different message type for those cases.

This PR includes:
- [ ] Tests (unit/integration)
- [x] CI build passed
