### PR TITLE
Deprecate `smwgSchemaTypes`, refs 4591

### DIFF
--- a/DefaultSettings.php
+++ b/DefaultSettings.php
@@ -2156,6 +2156,9 @@ return [
 	##
 
 	##
+	# @deprecated since 3.2, use `SchemaTypes` or the
+	# `SMW::Schema::RegisterSchemaTypes` hook.
+	#
 	# Schema types
 	#
 	# The mapping defines the relation between a specific type, group and
@@ -2166,45 +2169,7 @@ return [
 	#
 	# @since 3.0
 	##
-	'smwgSchemaTypes' => [
-		'LINK_FORMAT_SCHEMA' => [
-			'group' => SMW_SCHEMA_GROUP_FORMAT,
-			'validation_schema' => __DIR__ . '/data/schema/link-format-schema.v1.json',
-			'type_description' => 'smw-schema-description-link-format-schema',
-			// 'class' => [ 'SMW\Schema\SchemaFactory', 'newTest' ]
-		],
-		'SEARCH_FORM_SCHEMA' => [
-			'group' => SMW_SCHEMA_GROUP_SEARCH_FORM,
-			'validation_schema' => __DIR__ . '/data/schema/search-form-schema.v1.json',
-			'type_description' => 'smw-schema-description-search-form-schema'
-		],
-		'PROPERTY_GROUP_SCHEMA' => [
-			'group' => SMW_SCHEMA_GROUP_PROPERTY,
-			'validation_schema' => __DIR__ . '/data/schema/property-group-schema.v1.json',
-			'type_description' => 'smw-schema-description-property-group-schema'
-		],
-		'PROPERTY_CONSTRAINT_SCHEMA' => [
-			'group' => SMW_SCHEMA_GROUP_CONSTRAINT,
-			'validation_schema' => __DIR__ . '/data/schema/property-constraint-schema.v1.json',
-			'type_description' => 'smw-schema-description-property-constraint-schema',
-			'change_propagation' => [ '_CONSTRAINT_SCHEMA' ],
-			'usage_lookup' => '_CONSTRAINT_SCHEMA'
-		],
-		'CLASS_CONSTRAINT_SCHEMA' => [
-			'group' => SMW_SCHEMA_GROUP_CONSTRAINT,
-			'validation_schema' => __DIR__ . '/data/schema/class-constraint-schema.v1.json',
-			'type_description' => 'smw-schema-description-class-constraint-schema',
-			'change_propagation' => [ '_CONSTRAINT_SCHEMA' ],
-			'usage_lookup' => '_CONSTRAINT_SCHEMA'
-		],
-		'PROPERTY_PROFILE_SCHEMA' => [
-			'group' => SMW_SCHEMA_GROUP_PROFILE,
-			'validation_schema' => __DIR__ . '/data/schema/property-profile-schema.v1.json',
-			'type_description' => 'smw-schema-description-property-profile-schema',
-			'change_propagation' => '_PROFILE_SCHEMA',
-			'usage_lookup' => '_PROFILE_SCHEMA'
-		],
-	],
+	'smwgSchemaTypes' => [],
 	##
 
 	##

--- a/src/ConfigLegacyTrait.php
+++ b/src/ConfigLegacyTrait.php
@@ -213,6 +213,10 @@ trait ConfigLegacyTrait {
 		if ( isset( $GLOBALS['smwgCacheType'] ) ) {
 			$configuration['smwgMainCacheType'] = $GLOBALS['smwgCacheType'];
 		}
+
+		if ( isset( $GLOBALS['smwgSchemaTypes'] ) && $GLOBALS['smwgSchemaTypes'] === [] ) {
+			unset( $GLOBALS['smwgSchemaTypes'] );
+		}
 	}
 
 	/**
@@ -266,6 +270,9 @@ trait ConfigLegacyTrait {
 				'smwgFactboxUseCache' => '3.1.0',
 				'smwgFactboxCacheRefreshOnPurge' => '3.1.0',
 
+				// 3.2
+				'smwgSchemaTypes' => '3.3.0',
+
 				// Identifies options of settings planned to be removed
 				'options' => [
 					'smwgCacheUsage' =>  [
@@ -318,7 +325,9 @@ trait ConfigLegacyTrait {
 				'smwgFactboxUseCache' => 'smwgFactboxFeatures',
 				'smwgFactboxCacheRefreshOnPurge' => 'smwgFactboxFeatures',
 
-				'smwgContLang' => 'smwfContLang()',
+				// 3.2
+				'smwgContLang' => 'smwfContLang() (#4618)',
+				'smwgSchemaTypes' => 'SchemaTypes (#4591)',
 
 				// Identifies options of settings planned to be replaced
 				'options' => [

--- a/src/Schema/README.md
+++ b/src/Schema/README.md
@@ -14,10 +14,10 @@ The following annotation properties are provided to make elements of a schema an
 
 ## Registration
 
-Extensibility for new schema types and interpreters is provided by adding a new type to the `$smwgSchemaTypes` setting.
+Extensibility for new schema types and interpreters is provided by adding a new type to the `SchemaTypes::defaultTypes` setting or via the [`SMW::Schema::RegisterSchemaTypes`][SMW::Schema::RegisterSchemaTypes] hook.
 
 <pre>
-$GLOBALS['smwgSchemaTypes'] = [
+$schemaTypes = [
 	'FOO_SCHEMA' => [
 		'group' => SMW_SCHEMA_FOO_GROUP,
 		'validation_schema => __DIR__ . '/data/schema/foo-schema.v1.json',
@@ -73,3 +73,4 @@ As outlined above, the use of a [JSON schema][json:schema] is an important part 
 
 [ns:schema]: https://www.semantic-mediawiki.org/wiki/Help:Schema
 [json:schema]: http://json-schema.org/
+[SMW::Schema::RegisterSchemaTypes]: https://github.com/SemanticMediaWiki/SemanticMediaWiki/blob/master/docs/technical/hooks/hook.schema.registerschematypes.md

--- a/src/Schema/SchemaFactory.php
+++ b/src/Schema/SchemaFactory.php
@@ -198,7 +198,6 @@ class SchemaFactory {
 		}
 
 		$schemaTypes = new SchemaTypes(
-			$types,
 			$settings->mung( 'smwgDir', '/data/schema' )
 		);
 

--- a/src/Schema/SchemaTypes.php
+++ b/src/Schema/SchemaTypes.php
@@ -31,13 +31,55 @@ class SchemaTypes {
 	private $onRegisterSchemaTypes = false;
 
 	/**
+	 * Default types
+	 *
+	 * @var []
+	 */
+	private static $defaultTypes = [
+		'LINK_FORMAT_SCHEMA' => [
+			'group' => SMW_SCHEMA_GROUP_FORMAT,
+			'validation_schema' => 'link-format-schema.v1.json',
+			'type_description' => 'smw-schema-description-link-format-schema'
+		],
+		'SEARCH_FORM_SCHEMA' => [
+			'group' => SMW_SCHEMA_GROUP_SEARCH_FORM,
+			'validation_schema' => 'search-form-schema.v1.json',
+			'type_description' => 'smw-schema-description-search-form-schema'
+		],
+		'PROPERTY_GROUP_SCHEMA' => [
+			'group' => SMW_SCHEMA_GROUP_PROPERTY,
+			'validation_schema' => 'property-group-schema.v1.json',
+			'type_description' => 'smw-schema-description-property-group-schema'
+		],
+		'PROPERTY_CONSTRAINT_SCHEMA' => [
+			'group' => SMW_SCHEMA_GROUP_CONSTRAINT,
+			'validation_schema' => 'property-constraint-schema.v1.json',
+			'type_description' => 'smw-schema-description-property-constraint-schema',
+			'change_propagation' => [ '_CONSTRAINT_SCHEMA' ],
+			'usage_lookup' => '_CONSTRAINT_SCHEMA'
+		],
+		'CLASS_CONSTRAINT_SCHEMA' => [
+			'group' => SMW_SCHEMA_GROUP_CONSTRAINT,
+			'validation_schema' => 'class-constraint-schema.v1.json',
+			'type_description' => 'smw-schema-description-class-constraint-schema',
+			'change_propagation' => [ '_CONSTRAINT_SCHEMA' ],
+			'usage_lookup' => '_CONSTRAINT_SCHEMA'
+		],
+		'PROPERTY_PROFILE_SCHEMA' => [
+			'group' => SMW_SCHEMA_GROUP_PROFILE,
+			'validation_schema' => 'property-profile-schema.v1.json',
+			'type_description' => 'smw-schema-description-property-profile-schema',
+			'change_propagation' => '_PROFILE_SCHEMA',
+			'usage_lookup' => '_PROFILE_SCHEMA'
+		]
+	];
+
+	/**
 	 * @since 3.2
 	 *
-	 * @param array $schemaTypes
 	 * @param string $dir
 	 */
-	public function __construct( array $schemaTypes = [], string $dir = '' ) {
-		$this->schemaTypes = $schemaTypes;
+	public function __construct( string $dir = '' ) {
 		$this->dir = $dir;
 	}
 
@@ -49,7 +91,7 @@ class SchemaTypes {
 	 * @return string
 	 */
 	public function withDir( string $dir = '' ) : string {
-		return "{$this->dir}/$dir";
+		return str_replace( [ '\\', '//', '/', '\\\\' ], DIRECTORY_SEPARATOR, "{$this->dir}/$dir" );
 	}
 
 	/**
@@ -57,14 +99,22 @@ class SchemaTypes {
 	 *
 	 * @param array $schemaTypes
 	 */
-	public function registerSchemaTypes( array $schemaTypes ) {
+	public function registerSchemaTypes( array $schemaTypes = [] ) {
 
 		if ( $this->onRegisterSchemaTypes ) {
 			return;
 		}
 
 		$this->onRegisterSchemaTypes = true;
-		$this->schemaTypes = $schemaTypes;
+
+		foreach ( self::$defaultTypes + $schemaTypes as $key => $value ) {
+
+			if ( isset( $value['validation_schema'] ) ) {
+				$value['validation_schema'] = $this->withDir( $value['validation_schema'] );
+			}
+
+			$this->registerSchemaType( $key, $value );
+		}
 
 		$this->hookDispatcher->onRegisterSchemaTypes( $this );
 	}

--- a/src/Settings.php
+++ b/src/Settings.php
@@ -195,7 +195,7 @@ class Settings extends Options {
 			'smwgBrowseFeatures' => $GLOBALS['smwgBrowseFeatures'],
 			'smwgCategoryFeatures' => $GLOBALS['smwgCategoryFeatures'],
 			'smwgURITypeSchemeList' => $GLOBALS['smwgURITypeSchemeList'],
-			'smwgSchemaTypes' => $GLOBALS['smwgSchemaTypes'],
+			'smwgSchemaTypes' => $GLOBALS['smwgSchemaTypes'] ?? [],
 			'smwgElasticsearchConfig' => $GLOBALS['smwgElasticsearchConfig'],
 			'smwgElasticsearchProfile' => $GLOBALS['smwgElasticsearchProfile'],
 			'smwgElasticsearchEndpoints' => $GLOBALS['smwgElasticsearchEndpoints'],

--- a/tests/phpunit/Unit/Schema/SchemaFactoryTest.php
+++ b/tests/phpunit/Unit/Schema/SchemaFactoryTest.php
@@ -31,7 +31,12 @@ class SchemaFactoryTest extends \PHPUnit_Framework_TestCase {
 			->disableOriginalConstructor()
 			->getMock();
 
+		$hookDispatcher = $this->getMockBuilder( '\SMW\MediaWiki\HookDispatcher' )
+			->disableOriginalConstructor()
+			->getMock();
+
 		$this->testEnvironment->registerObject( 'JobQueue', $this->jobQueue );
+		$this->testEnvironment->registerObject( 'HookDispatcher', $hookDispatcher );
 	}
 
 	protected function tearDown() : void {

--- a/tests/phpunit/Unit/Schema/SchemaTypesTest.php
+++ b/tests/phpunit/Unit/Schema/SchemaTypesTest.php
@@ -114,11 +114,26 @@ class SchemaTypesTest extends \PHPUnit_Framework_TestCase {
 
 	public function testWithDir() {
 
-		$instance = new SchemaTypes( [], __DIR__ );
+		$instance = new SchemaTypes( __DIR__ );
 
 		$this->assertEquals(
-			__DIR__ . '/Foo',
+			str_replace( [ '\\', '//', '/', '\\\\' ], DIRECTORY_SEPARATOR, __DIR__ . '/Foo' ),
 			$instance->withDir( 'Foo' )
+		);
+	}
+
+	/**
+	 * @dataProvider defaultTypeProvider
+	 */
+	public function testRegisterDefaultTypes( $type ) {
+
+		$instance = new SchemaTypes( __DIR__ );
+		$instance->setHookDispatcher( $this->hookDispatcher );
+
+		$instance->registerSchemaTypes();
+
+		$this->assertTrue(
+			$instance->isRegisteredType( $type )
 		);
 	}
 
@@ -130,6 +145,33 @@ class SchemaTypesTest extends \PHPUnit_Framework_TestCase {
 
 		$this->expectException( '\SMW\Schema\Exception\SchemaTypeAlreadyExistsException' );
 		$instance->registerSchemaType( 'Foo', [] );
+	}
+
+	public function defaultTypeProvider() {
+
+		yield [
+			'LINK_FORMAT_SCHEMA'
+		];
+
+		yield [
+			'SEARCH_FORM_SCHEMA'
+		];
+
+		yield [
+			'PROPERTY_GROUP_SCHEMA'
+		];
+
+		yield [
+			'PROPERTY_CONSTRAINT_SCHEMA'
+		];
+
+		yield [
+			'CLASS_CONSTRAINT_SCHEMA'
+		];
+
+		yield [
+			'PROPERTY_PROFILE_SCHEMA'
+		];
 	}
 
 }


### PR DESCRIPTION
This PR is made in reference to: #4591

This PR addresses or contains:

- Deprecates `smwgSchemaTypes` setting now that a proper hook (#4591) exists that allows external users to define extra schema types while internally the `SchemaTypes` class is holding the definition of default types.

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed
