### PR TITLE
Add edit protection for imported content, refs 4595

### DIFF
--- a/DefaultSettings.php
+++ b/DefaultSettings.php
@@ -93,6 +93,22 @@ return [
 	##
 
 	###
+	# List of users for import activities
+	#
+	# Users listed here are to be used exclusively for the import task and can
+	# depending on the specific protection level lock certain content from being
+	# altered by any other user.
+	#
+	# The protection is only enabled when a specific import content has defined
+	# the `import_performer` with a listed user.
+	#
+	# @since 3.2
+	# @default []
+	##
+	'smwgImportPerformers' => [ 'SemanticMediaWikiImporter' ],
+	##
+
+	###
 	# Semantic MediaWiki's operational state
 	#
 	# It is expected that enableSemantics() is used to enable SMW otherwise it is

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -990,6 +990,7 @@
 	"smw-types-title": "Type: $1",
 	"smw-schema-namespace-editcontentmodel-disallowed": "Changing the content model of a [https://www.semantic-mediawiki.org/wiki/Help:Schema schema page] is not permitted.",
 	"smw-schema-namespace-edit-protection": "This page is protected and can only be edited by users with the appropriate <code>smw-schemaedit</code> [https://www.semantic-mediawiki.org/wiki/Help:Permissions permission].",
+	"smw-schema-namespace-edit-protection-by-import-performer": "This page was imported by a listed [https://www.semantic-mediawiki.org/wiki/Import_performer import performer] and means that changing the content of this page is restricted to only those listed users.",
 	"smw-schema-error-title": "Validation {{PLURAL:$1|error|errors}}",
 	"smw-schema-error-schema": "The validation schema '''$1''' found the following inconsistencies:",
 	"smw-schema-error-validation-file-inaccessible": "The validation file \"$1\" is inaccessible.",

--- a/src/MediaWiki/PermissionManager.php
+++ b/src/MediaWiki/PermissionManager.php
@@ -148,6 +148,11 @@ class PermissionManager {
 			return false;
 		}
 
+		if ( $action === 'edit' && $this->protectionValidator->isClassifiedAsImportPerformerProtected( $title, $user ) ) {
+			$this->errors[] = [ 'smw-schema-namespace-edit-protection-by-import-performer' ];
+			return false;
+		}
+
 		return true;
 	}
 

--- a/src/Services/SharedServicesContainer.php
+++ b/src/Services/SharedServicesContainer.php
@@ -692,22 +692,28 @@ class SharedServicesContainer implements CallbackContainer {
 		$containerBuilder->registerCallback( 'ProtectionValidator', function( $containerBuilder ) {
 			$containerBuilder->registerExpectedReturnType( 'ProtectionValidator', '\SMW\Protection\ProtectionValidator' );
 
+			$settings = $containerBuilder->singleton( 'Settings' );
+
 			$protectionValidator = new ProtectionValidator(
 				$containerBuilder->singleton( 'Store', null ),
 				$containerBuilder->singleton( 'EntityCache' ),
 				$containerBuilder->singleton( 'PermissionExaminer' )
 			);
 
+			$protectionValidator->setImportPerformers(
+				$settings->get( 'smwgImportPerformers' )
+			);
+
 			$protectionValidator->setEditProtectionRight(
-				$containerBuilder->singleton( 'Settings' )->get( 'smwgEditProtectionRight' )
+				$settings->get( 'smwgEditProtectionRight' )
 			);
 
 			$protectionValidator->setCreateProtectionRight(
-				$containerBuilder->singleton( 'Settings' )->get( 'smwgCreateProtectionRight' )
+				$settings->get( 'smwgCreateProtectionRight' )
 			);
 
 			$protectionValidator->setChangePropagationProtection(
-				$containerBuilder->singleton( 'Settings' )->get( 'smwgChangePropagationProtection' )
+				$settings->get( 'smwgChangePropagationProtection' )
 			);
 
 			return $protectionValidator;

--- a/src/Settings.php
+++ b/src/Settings.php
@@ -76,6 +76,7 @@ class Settings extends Options {
 			'smwgConfigFileDir' => $GLOBALS['smwgConfigFileDir'],
 			'smwgImportFileDirs' => $GLOBALS['smwgImportFileDirs'],
 			'smwgImportReqVersion' => $GLOBALS['smwgImportReqVersion'],
+			'smwgImportPerformers' => $GLOBALS['smwgImportPerformers'],
 			'smwgSemanticsEnabled' => $GLOBALS['smwgSemanticsEnabled'],
 			'smwgIgnoreExtensionRegistrationCheck' => $GLOBALS['smwgIgnoreExtensionRegistrationCheck'],
 			'smwgUpgradeKey' => $GLOBALS['smwgUpgradeKey'],

--- a/tests/phpunit/Unit/MediaWiki/PermissionManagerTest.php
+++ b/tests/phpunit/Unit/MediaWiki/PermissionManagerTest.php
@@ -412,6 +412,56 @@ class PermissionManagerTest extends \PHPUnit_Framework_TestCase {
 		);
 	}
 
+	public function testEditPermissionOnImportPerformer_SchemaNamespace() {
+
+		$title = $this->getMockBuilder( '\Title' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$title->expects( $this->any() )
+			->method( 'getDBKey' )
+			->will( $this->returnValue( 'PermissionTest' ) );
+
+		$title->expects( $this->any() )
+			->method( 'exists' )
+			->will( $this->returnValue( true ) );
+
+		$title->expects( $this->any() )
+			->method( 'getNamespace' )
+			->will( $this->returnValue( SMW_NS_SCHEMA ) );
+
+		$user = $this->getMockBuilder( '\User' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$this->permissionExaminer->expects( $this->once() )
+			->method( 'userHasRight' )
+			->with(
+				$this->equalTo( $user ),
+				$this->equalTo( 'smw-schemaedit' ) )
+			->will( $this->returnValue( true ) );
+
+		$this->protectionValidator->expects( $this->once() )
+			->method( 'isClassifiedAsImportPerformerProtected' )
+			->will( $this->returnValue( true ) );
+
+		$instance = new PermissionManager(
+			$this->protectionValidator,
+			$this->permissionExaminer
+		);
+
+		$this->assertFalse(
+			$instance->hasUserPermission( $title, $user, 'edit' )
+		);
+
+		$this->assertEquals(
+			[
+				[ 'smw-schema-namespace-edit-protection-by-import-performer' ]
+			],
+			$instance->getErrors()
+		);
+	}
+
 	public function testNoEditcontentmodelPermissionForAnyUser_SchemaNamespace() {
 
 		$editProtectionRight = 'Foo';

--- a/tests/phpunit/Unit/Protection/ProtectionValidatorTest.php
+++ b/tests/phpunit/Unit/Protection/ProtectionValidatorTest.php
@@ -310,4 +310,119 @@ class ProtectionValidatorTest extends \PHPUnit_Framework_TestCase {
 		);
 	}
 
+	public function testIsClassifiedAsImportPerformerProtected_NoImportersNoProtection() {
+
+		$title = $this->getMockBuilder( '\Title' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$user = $this->getMockBuilder( '\User' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$instance = new ProtectionValidator(
+			$this->store,
+			$this->entityCache,
+			$this->permissionExaminer
+		);
+
+		$this->assertFalse(
+			$instance->isClassifiedAsImportPerformerProtected( $title, $user )
+		);
+	}
+
+	public function testIsClassifiedAsImportPerformerProtected_CreatorAndCurrentUserDontMatch() {
+
+		$revision = $this->getMockBuilder( '\Revision' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$revision->expects( $this->any() )
+			->method( 'getUserText' )
+			->will( $this->returnValue( 'FooImporter' ) );
+
+		$title = $this->getMockBuilder( '\Title' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$title->expects( $this->any() )
+			->method( 'getNamespace' )
+			->will( $this->returnValue( SMW_NS_SCHEMA ) );
+
+		$title->expects( $this->any() )
+			->method( 'getDBKey' )
+			->will( $this->returnValue( 'FooSchema' ) );
+
+		$title->expects( $this->any() )
+			->method( 'getFirstRevision' )
+			->will( $this->returnValue( $revision ) );
+
+		$user = $this->getMockBuilder( '\User' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$instance = new ProtectionValidator(
+			$this->store,
+			$this->entityCache,
+			$this->permissionExaminer
+		);
+
+		$instance->setImportPerformers(
+			[ 'FooImporter' ]
+		);
+
+		$this->assertTrue(
+			$instance->isClassifiedAsImportPerformerProtected( $title, $user )
+		);
+	}
+
+	public function testIsClassifiedAsNotImportPerformerProtected_CreatorAndCurrentUserDoMatch() {
+
+		$revision = $this->getMockBuilder( '\Revision' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$revision->expects( $this->any() )
+			->method( 'getUserText' )
+			->will( $this->returnValue( 'FooImporter' ) );
+
+		$title = $this->getMockBuilder( '\Title' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$title->expects( $this->any() )
+			->method( 'getNamespace' )
+			->will( $this->returnValue( SMW_NS_SCHEMA ) );
+
+		$title->expects( $this->any() )
+			->method( 'getDBKey' )
+			->will( $this->returnValue( 'FooSchema' ) );
+
+		$title->expects( $this->any() )
+			->method( 'getFirstRevision' )
+			->will( $this->returnValue( $revision ) );
+
+		$user = $this->getMockBuilder( '\User' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$user->expects( $this->any() )
+			->method( 'getName' )
+			->will( $this->returnValue( 'FooImporter' ) );
+
+		$instance = new ProtectionValidator(
+			$this->store,
+			$this->entityCache,
+			$this->permissionExaminer
+		);
+
+		$instance->setImportPerformers(
+			[ 'FooImporter' ]
+		);
+
+		$this->assertFalse(
+			$instance->isClassifiedAsImportPerformerProtected( $title, $user )
+		);
+	}
+
 }


### PR DESCRIPTION
This PR is made in reference to: #4595

This PR addresses or contains:

- #4595 added support for defining a dedicated import performer (user which cannot be hijacked because it is classified as system user) and this PR will introduce an edit protection for SMW_NS_SCHEMA (for now) on content where the `import_performer` was defined to ensure no other users besides the importer can alter the content (users can delete the page but not edit).
- In general, the importer is only allowed to replace content of imported pages if there was no edit to the content by any other users which is the reason why a mechanisms is needed to lock content so that it can be replaced without fear that some other user modified the content and may loose that information on the next import.
- Adds `smwgImportPerformers` to list those users classified as import performers which should be used in `import_performer` 

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed
