### PR TITLE
Check `justinrainbow/json-schema` is available

### DIFF
--- a/i18n/en.json
+++ b/i18n/en.json
@@ -993,6 +993,8 @@
 	"smw-schema-namespace-edit-protection-by-import-performer": "This page was imported by a listed [https://www.semantic-mediawiki.org/wiki/Import_performer import performer] and means that changing the content of this page is restricted to only those listed users.",
 	"smw-schema-error-title": "Validation {{PLURAL:$1|error|errors}}",
 	"smw-schema-error-schema": "The validation schema '''$1''' found the following inconsistencies:",
+	"smw-schema-error-miscellaneous": "Miscellaneous error ($1)",
+	"smw-schema-error-validation-json-validator-inaccessible": "The JSON validator \"<b>$1</b>\" is not accessible (or installed) and is the reason why the \"$2\" file cannot be examined which prevents the current page from being saved or altered.",
 	"smw-schema-error-validation-file-inaccessible": "The validation file \"$1\" is inaccessible.",
 	"smw-schema-error-violation": "[\"$1\", \"$2\"]",
 	"smw-schema-error-type-missing": "The content is missing a type in order for it to be recognized and usable in the [https://www.semantic-mediawiki.org/wiki/Help:Schema schema namespace].",

--- a/src/MediaWiki/Content/SchemaContent.php
+++ b/src/MediaWiki/Content/SchemaContent.php
@@ -221,6 +221,8 @@ class SchemaContent extends JsonContent {
 				$parserData->addError(
 					[ ['smw-schema-error-violation', $error['property'], $error['message'] ] ]
 				);
+			} else {
+				$parserData->addError( (array)$error );
 			}
 		}
 

--- a/src/MediaWiki/Content/SchemaContentFormatter.php
+++ b/src/MediaWiki/Content/SchemaContentFormatter.php
@@ -341,16 +341,11 @@ class SchemaContentFormatter {
 
 		foreach ( $errors as $error ) {
 
-			if ( !isset( $error['property'] ) ) {
-				continue;
+			if ( isset( $error['property'] ) ) {
+				$list[$error['property']] = $error['message'];
+			} elseif ( is_array( $error ) ) {
+				$list[ $this->msg( [ 'smw-schema-error-miscellaneous', $error[0] ?? 'n/a' ])] = $this->msg( $error );
 			}
-
-			$params = [
-				'msg' => $error['message'],
-				'text' => $error['property']
-			];
-
-			$list[$error['property']] = $error['message'];
 		}
 
 		if ( $list === [] ) {

--- a/src/Utils/JsonSchemaValidator.php
+++ b/src/Utils/JsonSchemaValidator.php
@@ -46,9 +46,21 @@ class JsonSchemaValidator {
 	 */
 	public function validate( JsonSerializable $data, $schemaLink = null ) {
 
-		if ( $this->schemaValidator === null || $schemaLink === null ) {
-			return;
+		// Raise an error because we expect the validator to be available
+		// when at the same time a schema link is present
+		if ( $this->schemaValidator === null && $schemaLink !== null ) {
+			$this->isValid = false;
+			$this->errors[] = [
+				'smw-schema-error-validation-json-validator-inaccessible',
+				'justinrainbow/json-schema',
+				pathinfo( $schemaLink, PATHINFO_BASENAME )
+			];
+		} elseif ( $this->schemaValidator !== null && $schemaLink !== null ) {
+			$this->runValidation( $data, $schemaLink );
 		}
+	}
+
+	private function runValidation( $data, $schemaLink ) {
 
 		// https://github.com/justinrainbow/json-schema/issues/203
 		$data = json_decode( $data->jsonSerialize() );

--- a/tests/phpunit/Unit/Utils/JsonSchemaValidatorTest.php
+++ b/tests/phpunit/Unit/Utils/JsonSchemaValidatorTest.php
@@ -118,4 +118,33 @@ class JsonSchemaValidatorTest extends \PHPUnit_Framework_TestCase {
 		);
 	}
 
+	public function testNoJSONValidatorButSchemaLink() {
+
+		$instance = new JsonSchemaValidator();
+
+		$instance->validate( $this->newJsonSerializable( [] ), 'Foo' );
+
+		$this->assertFalse(
+			$instance->isValid()
+		);
+
+		$this->assertNotEmpty(
+			$instance->getErrors()
+		);
+	}
+
+	public function newJsonSerializable( $data ) {
+		return new class( $data ) implements \JsonSerializable {
+
+			private $data;
+
+			public function __construct( $data ) {
+				$this->data = $data;
+			}
+
+			public function jsonSerialize() {
+				return json_encode( $this->data );
+			}
+		};
+	}
 }


### PR DESCRIPTION
This PR is made in reference to: https://github.com/SemanticMediaWiki/SemanticMediaWiki/pull/3749#issuecomment-599029003

This PR addresses or contains:

- Schema validation happens to ensure input data conforms with the requirements set forth so checking that the validator is available is paramount otherwise we produce schemata with incorrect data.

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed

## Example

![image](https://user-images.githubusercontent.com/1245473/76681001-ddb89880-65e5-11ea-9783-31fc11d0a51f.png)
