### PR TITLE
Migrate maintenance scripts to psr-4 compliant autoloading standard

### DIFF
--- a/maintenance/README.md
+++ b/maintenance/README.md
@@ -20,6 +20,8 @@ required to specify the location of "LocalSettings.php" explicitly, too:
 export MW_INSTALL_PATH="/path/to/mediawiki" && php setupStore.php --conf=/path/to/mediawiki/LocalSettings.php
 ```
 
+## Scripts
+
 ### dumpRDF.php
 
 Complete RDF export of existing triples.

--- a/maintenance/disposeOutdatedEntities.php
+++ b/maintenance/disposeOutdatedEntities.php
@@ -25,7 +25,7 @@ if ( getenv( 'MW_INSTALL_PATH' ) !== false ) {
  *
  * @author mwjames
  */
-class DisposeOutdatedEntities extends \Maintenance {
+class disposeOutdatedEntities extends \Maintenance {
 
 	/**
 	 * @var MessageReporter
@@ -129,5 +129,5 @@ class DisposeOutdatedEntities extends \Maintenance {
 
 }
 
-$maintClass = DisposeOutdatedEntities::class;
+$maintClass = disposeOutdatedEntities::class;
 require_once( RUN_MAINTENANCE_IF_MAIN );

--- a/maintenance/dumpRDF.php
+++ b/maintenance/dumpRDF.php
@@ -38,7 +38,7 @@ require_once $basePath . '/maintenance/Maintenance.php';
  * @author Markus Krötzsch
  * @author mwjames
  */
-class DumpRdf extends \Maintenance {
+class dumpRDF extends \Maintenance {
 
 	private $delay = 0;
 	private $delayeach = 0;
@@ -184,5 +184,5 @@ class DumpRdf extends \Maintenance {
 
 }
 
-$maintClass = 'SMW\Maintenance\DumpRdf';
+$maintClass = 'SMW\Maintenance\dumpRDF';
 require_once ( RUN_MAINTENANCE_IF_MAIN );

--- a/maintenance/populateHashField.php
+++ b/maintenance/populateHashField.php
@@ -27,7 +27,7 @@ if ( getenv( 'MW_INSTALL_PATH' ) !== false ) {
  *
  * @author mwjames
  */
-class PopulateHashField extends \Maintenance {
+class populateHashField extends \Maintenance {
 
 	/**
 	 * Threshold as the when the `populateHashField.php` should be used by an

--- a/maintenance/populateHashField.php
+++ b/maintenance/populateHashField.php
@@ -290,5 +290,5 @@ class PopulateHashField extends \Maintenance {
 
 }
 
-$maintClass = PopulateHashField::class;
+$maintClass = populateHashField::class;
 require_once( RUN_MAINTENANCE_IF_MAIN );

--- a/maintenance/purgeEntityCache.php
+++ b/maintenance/purgeEntityCache.php
@@ -27,7 +27,7 @@ if ( getenv( 'MW_INSTALL_PATH' ) !== false ) {
  *
  * @author mwjames
  */
-class PurgeEntityCache extends \Maintenance {
+class purgeEntityCache extends \Maintenance {
 
 	/**
 	 * @var Store
@@ -240,5 +240,5 @@ class PurgeEntityCache extends \Maintenance {
 
 }
 
-$maintClass = PurgeEntityCache::class;
+$maintClass = purgeEntityCache::class;
 require_once( RUN_MAINTENANCE_IF_MAIN );

--- a/maintenance/rebuildConceptCache.php
+++ b/maintenance/rebuildConceptCache.php
@@ -69,7 +69,7 @@ if ( getenv( 'MW_INSTALL_PATH' ) !== false ) {
  * @author Markus Krötzsch
  * @author mwjames
  */
-class RebuildConceptCache extends \Maintenance {
+class rebuildConceptCache extends \Maintenance {
 
 	public function __construct() {
 		parent::__construct();
@@ -218,5 +218,5 @@ class RebuildConceptCache extends \Maintenance {
 
 }
 
-$maintClass = RebuildConceptCache::class;
+$maintClass = rebuildConceptCache::class;
 require_once ( RUN_MAINTENANCE_IF_MAIN );

--- a/maintenance/rebuildData.php
+++ b/maintenance/rebuildData.php
@@ -56,7 +56,7 @@ if ( getenv( 'MW_INSTALL_PATH' ) !== false ) {
  * @author Yaron Koren
  * @author Markus Krötzsch
  */
-class RebuildData extends \Maintenance {
+class rebuildData extends \Maintenance {
 
 	public function __construct() {
 		parent::__construct();
@@ -290,5 +290,5 @@ class RebuildData extends \Maintenance {
 
 }
 
-$maintClass = 'SMW\Maintenance\RebuildData';
+$maintClass = 'SMW\Maintenance\rebuildData';
 require_once ( RUN_MAINTENANCE_IF_MAIN );

--- a/maintenance/rebuildElasticIndex.php
+++ b/maintenance/rebuildElasticIndex.php
@@ -25,7 +25,7 @@ if ( getenv( 'MW_INSTALL_PATH' ) !== false ) {
  *
  * @author mwjames
  */
-class RebuildElasticIndex extends \Maintenance {
+class rebuildElasticIndex extends \Maintenance {
 
 	/**
 	 * @var Store
@@ -548,5 +548,5 @@ class RebuildElasticIndex extends \Maintenance {
 
 }
 
-$maintClass = 'SMW\Maintenance\RebuildElasticIndex';
+$maintClass = 'SMW\Maintenance\rebuildElasticIndex';
 require_once( RUN_MAINTENANCE_IF_MAIN );

--- a/maintenance/rebuildElasticMissingDocuments.php
+++ b/maintenance/rebuildElasticMissingDocuments.php
@@ -31,7 +31,7 @@ if ( getenv( 'MW_INSTALL_PATH' ) !== false ) {
  *
  * @author mwjames
  */
-class RebuildElasticMissingDocuments extends \Maintenance {
+class rebuildElasticMissingDocuments extends \Maintenance {
 
 	/**
 	 * @var Store
@@ -413,5 +413,5 @@ class RebuildElasticMissingDocuments extends \Maintenance {
 
 }
 
-$maintClass = RebuildElasticMissingDocuments::class;
+$maintClass = rebuildElasticMissingDocuments::class;
 require_once( RUN_MAINTENANCE_IF_MAIN );

--- a/maintenance/rebuildFulltextSearchTable.php
+++ b/maintenance/rebuildFulltextSearchTable.php
@@ -25,7 +25,7 @@ if ( getenv( 'MW_INSTALL_PATH' ) !== false ) {
  *
  * @author mwjames
  */
-class RebuildFulltextSearchTable extends \Maintenance {
+class rebuildFulltextSearchTable extends \Maintenance {
 
 	/**
 	 * @var MessageReporter
@@ -248,5 +248,5 @@ class RebuildFulltextSearchTable extends \Maintenance {
 
 }
 
-$maintClass = RebuildFulltextSearchTable::class;
+$maintClass = rebuildFulltextSearchTable::class;
 require_once ( RUN_MAINTENANCE_IF_MAIN );

--- a/maintenance/rebuildPropertyStatistics.php
+++ b/maintenance/rebuildPropertyStatistics.php
@@ -22,7 +22,7 @@ if ( getenv( 'MW_INSTALL_PATH' ) !== false ) {
  *
  * @author Jeroen De Dauw < jeroendedauw@gmail.com >
  */
-class RebuildPropertyStatistics extends \Maintenance {
+class rebuildPropertyStatistics extends \Maintenance {
 
 	public function __construct() {
 		parent::__construct();
@@ -96,5 +96,5 @@ class RebuildPropertyStatistics extends \Maintenance {
 
 }
 
-$maintClass = RebuildPropertyStatistics::class;
+$maintClass = rebuildPropertyStatistics::class;
 require_once ( RUN_MAINTENANCE_IF_MAIN );

--- a/maintenance/removeDuplicateEntities.php
+++ b/maintenance/removeDuplicateEntities.php
@@ -21,7 +21,7 @@ if ( getenv( 'MW_INSTALL_PATH' ) !== false ) {
  *
  * @author mwjames
  */
-class RemoveDuplicateEntities extends \Maintenance {
+class removeDuplicateEntities extends \Maintenance {
 
 	/**
 	 * @since 3.0
@@ -147,5 +147,5 @@ class RemoveDuplicateEntities extends \Maintenance {
 
 }
 
-$maintClass = RemoveDuplicateEntities::class;
+$maintClass = removeDuplicateEntities::class;
 require_once( RUN_MAINTENANCE_IF_MAIN );

--- a/maintenance/runImport.php
+++ b/maintenance/runImport.php
@@ -24,7 +24,7 @@ if ( getenv( 'MW_INSTALL_PATH' ) !== false ) {
  *
  * @author mwjames
  */
-class RunImport extends \Maintenance {
+class runImport extends \Maintenance {
 
 	/**
 	 * @var MessageReporter
@@ -127,5 +127,5 @@ class RunImport extends \Maintenance {
 
 }
 
-$maintClass = RunImport::class;
+$maintClass = runImport::class;
 require_once( RUN_MAINTENANCE_IF_MAIN );

--- a/maintenance/runLocalMessageCopy.php
+++ b/maintenance/runLocalMessageCopy.php
@@ -25,7 +25,7 @@ if ( getenv( 'MW_INSTALL_PATH' ) !== false ) {
  *
  * @author mwjames
  */
-class RunLocalMessageCopy extends \Maintenance {
+class runLocalMessageCopy extends \Maintenance {
 
 	/**
 	 * @var MessageReporter
@@ -178,5 +178,5 @@ class RunLocalMessageCopy extends \Maintenance {
 
 }
 
-$maintClass = RunLocalMessageCopy::class;
+$maintClass = runLocalMessageCopy::class;
 require_once( RUN_MAINTENANCE_IF_MAIN );

--- a/maintenance/setupStore.php
+++ b/maintenance/setupStore.php
@@ -55,7 +55,7 @@ if ( getenv( 'MW_INSTALL_PATH' ) !== false ) {
  * @author Jeroen De Dauw < jeroendedauw@gmail.com >
  * @author James Hong Kong
  */
-class SetupStore extends \Maintenance {
+class setupStore extends \Maintenance {
 
 	/**
 	 * Name of the store class configured in the "LocalSettings.php" file. Stored to
@@ -273,5 +273,5 @@ class SetupStore extends \Maintenance {
 
 }
 
-$maintClass = SetupStore::class;
+$maintClass = setupStore::class;
 require_once ( RUN_MAINTENANCE_IF_MAIN );

--- a/maintenance/updateEntityCollation.php
+++ b/maintenance/updateEntityCollation.php
@@ -29,7 +29,7 @@ if ( getenv( 'MW_INSTALL_PATH' ) !== false ) {
  *
  * @author mwjames
  */
-class UpdateEntityCollation extends \Maintenance {
+class updateEntityCollation extends \Maintenance {
 
 	/**
 	 * @var Store
@@ -300,5 +300,5 @@ class UpdateEntityCollation extends \Maintenance {
 
 }
 
-$maintClass = UpdateEntityCollation::class;
+$maintClass = updateEntityCollation::class;
 require_once( RUN_MAINTENANCE_IF_MAIN );

--- a/maintenance/updateEntityCountMap.php
+++ b/maintenance/updateEntityCountMap.php
@@ -25,7 +25,7 @@ if ( getenv( 'MW_INSTALL_PATH' ) !== false ) {
  *
  * @author mwjames
  */
-class UpdateEntityCountMap extends \Maintenance {
+class updateEntityCountMap extends \Maintenance {
 
 	/**
 	 * Incomplete task message
@@ -275,5 +275,5 @@ class UpdateEntityCountMap extends \Maintenance {
 
 }
 
-$maintClass = UpdateEntityCountMap::class;
+$maintClass = updateEntityCountMap::class;
 require_once( RUN_MAINTENANCE_IF_MAIN );

--- a/maintenance/updateQueryDependencies.php
+++ b/maintenance/updateQueryDependencies.php
@@ -20,7 +20,7 @@ require_once $basePath . '/maintenance/Maintenance.php';
  *
  * @author mwjames
  */
-class UpdateQueryDependencies extends \Maintenance {
+class updateQueryDependencies extends \Maintenance {
 
 	/**
 	 * @var MessageReporter
@@ -182,5 +182,5 @@ class UpdateQueryDependencies extends \Maintenance {
 
 }
 
-$maintClass = 'SMW\Maintenance\UpdateQueryDependencies';
+$maintClass = 'SMW\Maintenance\updateQueryDependencies';
 require_once( RUN_MAINTENANCE_IF_MAIN );


### PR DESCRIPTION
This PR is made in reference to: #4650

This PR addresses or contains:
- Migrate maintenance scripts to psr-4 compliant autoloading standard by renaming the class names to match the file names (Note: renaming the file names rather than the class names is a NOGO for us)

This PR includes:
- [ ] Tests (unit/integration)
- [x] CI build passed

Fixes #4650 