### PR TITLE
Add `CompartmentIterator::has`

### DIFF
--- a/src/Schema/CompartmentIterator.php
+++ b/src/Schema/CompartmentIterator.php
@@ -7,6 +7,7 @@ use Iterator;
 use Countable;
 use OutOfBoundsException;
 use RuntimeException;
+use SMW\Utils\DotArray;
 use SMW\Iterators\SeekableIteratorTrait;
 
 /**
@@ -44,6 +45,24 @@ class CompartmentIterator implements Iterator, Countable, SeekableIterator {
 	public function __construct( array $compartments = [], ?string $type = null ) {
 		$this->container = $compartments;
 		$this->type = $type;
+	}
+
+	/**
+	 * @since 3.2
+	 *
+	 * @param string $key
+	 *
+	 * @return bool
+	 */
+	public function has( string $key ) : bool {
+
+		foreach ( $this->container as $data ) {
+			if ( DotArray::get( $data, $key, false ) !== false ) {
+				return true;
+			}
+		}
+
+		return false;
 	}
 
 	/**

--- a/tests/phpunit/Unit/Schema/CompartmentIteratorTest.php
+++ b/tests/phpunit/Unit/Schema/CompartmentIteratorTest.php
@@ -136,6 +136,36 @@ class CompartmentIteratorTest extends \PHPUnit_Framework_TestCase {
 		}
 	}
 
+	public function testHas() {
+
+		$data = [
+			[ 'Foo_1' => [ 'Foo2' ] ],
+			[ 'Foo' => [ 'Foobar' => [] ] ],
+			[ 'Bar' => [] ],
+		];
+
+		$instance = new CompartmentIterator(
+			$data
+		);
+
+		$this->assertTrue(
+			$instance->has( 'Foo.Foobar' )
+		);
+
+		$this->assertTrue(
+			$instance->has( 'Foo_1' )
+		);
+
+		$this->assertTrue(
+			$instance->has( 'Bar' )
+		);
+
+		// Foo_2 is not iterable
+		$this->assertFalse(
+			$instance->has( 'Foo_1.Foo_2' )
+		);
+	}
+
 	public function testIterate_Associatve() {
 
 		$data = [


### PR DESCRIPTION
This PR is made in reference to: #

This PR addresses or contains:

- Is needed for #4611 to quickly see whether something like a `range_group` is part of a schema without having to iterate through entire container.

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed
