### PR TITLE
PrefetchItemLookup to support HASH_INDEX for inverse lookup, refs 3723

### DIFF
--- a/src/SQLStore/EntityStore/PrefetchItemLookup.php
+++ b/src/SQLStore/EntityStore/PrefetchItemLookup.php
@@ -227,6 +227,31 @@ class PrefetchItemLookup {
 			$requestOptions
 		);
 
+		if ( $requestOptions->getOption( self::HASH_INDEX ) ) {
+			foreach ( $result as $sid => $values ) {
+				$subject = $idTable->getDataItemById(
+					$sid
+				);
+
+				// Subject hash is used as identifying hash to split
+				// the collected set of values
+				$hash = $subject->getHash();
+
+				// Avoid reference to something like `__foo_bar#102##` (predefined property)
+				if ( $subject->getNamespace() === SMW_NS_PROPERTY && $hash[0] === '_' ) {
+
+					$property = DIProperty::newFromUserLabel(
+						$subject->getDBKey()
+					);
+
+					$hash = $property->getCanonicalDIWikiPage()->getHash();
+				}
+
+				$result[$hash] = $values;
+				unset( $result[$sid] );
+			}
+		}
+
 		return $result;
 	}
 


### PR DESCRIPTION
This PR is made in reference to: #3723

This PR addresses or contains:

- Not always is it required for `PrefetchItemLookup` to return an ID based result set, `HASH_INDEX` as option allows to return the serialized format of a subject making it possible to construct an object instance at a convenient time without having to lookup the DB to match an ID

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed
