### PR TITLE
Add namedargs alias to templatefile result format

### DIFF
--- a/src/Query/ResultPrinters/TemplateFileExportPrinter.php
+++ b/src/Query/ResultPrinters/TemplateFileExportPrinter.php
@@ -89,6 +89,7 @@ class TemplateFileExportPrinter extends FileExportPrinter {
 			'type' => 'boolean',
 			'message' => 'smw-paramdesc-named_args',
 			'default' => false,
+			'aliases' => [ 'namedargs' ]
 		];
 
 		$params['userparam'] = [

--- a/tests/phpunit/Integration/JSONScript/TestCases/s-0025.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/s-0025.json
@@ -44,7 +44,7 @@
 	"tests": [
 		{
 			"type": "special",
-			"about": "#0 (named args)",
+			"about": "#0a (named args)",
 			"special-page": {
 				"page": "Ask",
 				"request-parameters": {
@@ -54,6 +54,32 @@
 						"offset": "0",
 						"mainlabel": "",
 						"named args": true,
+						"format": "templatefile",
+						"template": "BEACON (named)",
+						"introtemplate": "BEACON-INTRO"
+					},
+					"q": "[[Has GND::123456789]]",
+					"po": "?Has GND=GND|?Has name=Name"
+				}
+			},
+			"assert-output": {
+				"to-contain": {
+					"contents-file" : "/../Fixtures/res.s-0025.0.txt"
+				}
+			}
+		},
+		{
+			"type": "special",
+			"about": "#0b (namedargs)",
+			"special-page": {
+				"page": "Ask",
+				"request-parameters": {
+					"p": {
+						"link": "none",
+						"limit": "10",
+						"offset": "0",
+						"mainlabel": "",
+						"namedargs": true,
 						"format": "templatefile",
 						"template": "BEACON (named)",
 						"introtemplate": "BEACON-INTRO"


### PR DESCRIPTION
This PR is made in reference to: #4655

This PR addresses or contains:
- "namedargs" alias for "named args" to the templatefile format including a test

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed