### PR TITLE
Change styling of `#smwdoc` tables

### DIFF
--- a/src/ParameterListDocBuilder.php
+++ b/src/ParameterListDocBuilder.php
@@ -53,7 +53,7 @@ class ParameterListDocBuilder {
 			'!' . $this->msg( 'validator-describe-header-description' )
 		], $tableRows );
 
-		return '{| class="wikitable sortable"' . "\n" .
+		return '{| class="smwtable-clean doctable sortable"' . "\n" .
 			implode( "\n|-\n", $tableRows ) .
 			"\n|}";
 	}

--- a/tests/phpunit/Integration/JSONScript/TestCases/p-0107.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/p-0107.json
@@ -25,82 +25,29 @@
 	"tests": [
 		{
 			"type": "parser",
-			"about": "#0 (1.31-) (#1019)",
-			"skip-on": {
-				"mediawiki": [ ">1.30.x", "MediaWiki changed the HTML Tidy" ]
-			},
-			"subject": "smwdoc-table",
-			"assert-output": {
-				"to-contain": [
-					"<table class=\"wikitable sortable\">",
-					"</td></tr></table>"
-				]
-			}
-		},
-		{
-			"type": "parser",
 			"about": "#0 (1.31+) (#1019)",
-			"skip-on": {
-				"mediawiki": [ "<1.30.x", "MediaWiki changed the HTML Tidy" ]
-			},
 			"subject": "smwdoc-table",
 			"assert-output": {
 				"to-contain": [
-					"<table class=\"wikitable sortable\">",
+					"<table class=\"smwtable-clean doctable sortable\">",
 					"</td></tr></tbody></table>"
-				]
-			}
-		},
-		{
-			"type": "parser",
-			"about": "#1 (1.31-) (#1019)",
-			"skip-on": {
-				"mediawiki": [ ">1.30.x", "MediaWiki changed the HTML Tidy" ]
-			},
-			"subject": "smwdoc-csv",
-			"assert-output": {
-				"to-contain": [
-					"<table class=\"wikitable sortable\">",
-					"</td></tr></table>"
 				]
 			}
 		},
 		{
 			"type": "parser",
 			"about": "#1 (1.31+) (#1019)",
-			"skip-on": {
-				"mediawiki": [ "<1.30.x", "MediaWiki changed the HTML Tidy" ]
-			},
 			"subject": "smwdoc-csv",
 			"assert-output": {
 				"to-contain": [
-					"<table class=\"wikitable sortable\">",
+					"<table class=\"smwtable-clean doctable sortable\">",
 					"</td></tr></tbody></table>"
 				]
 			}
 		},
 		{
 			"type": "parser",
-			"about": "#2 (1.31-) (#1019)",
-			"skip-on": {
-				"mediawiki": [ ">1.30.x", "MediaWiki changed the HTML Tidy" ]
-			},
-			"subject": "smwdoc-list",
-			"assert-output": {
-				"to-contain": [
-					"</td>",
-					"<td>Legt fest, welche zusätzliche CSS-Klasse genutzt werden soll",
-					"</td></tr>",
-					"</td></tr></table>"
-				]
-			}
-		},
-		{
-			"type": "parser",
 			"about": "#2 (1.31+) (#1019)",
-			"skip-on": {
-				"mediawiki": [ "<1.30.x", "MediaWiki changed the HTML Tidy" ]
-			},
 			"subject": "smwdoc-list",
 			"assert-output": {
 				"to-contain": [

--- a/tests/phpunit/Unit/ParameterListDocBuilderTest.php
+++ b/tests/phpunit/Unit/ParameterListDocBuilderTest.php
@@ -51,7 +51,7 @@ class ParameterListDocBuilderTest extends \PHPUnit_Framework_TestCase {
 		] );
 
 		$expected = [
-			'{| class="wikitable sortable"',
+			'{| class="smwtable-clean doctable sortable"',
 			'!validator-describe-header-parameter',
 			'!validator-describe-header-type',
 			'!validator-describe-header-default',
@@ -76,7 +76,7 @@ class ParameterListDocBuilderTest extends \PHPUnit_Framework_TestCase {
 		] );
 
 		$expected = [
-			'{| class="wikitable sortable"',
+			'{| class="smwtable-clean doctable sortable"',
 			'!validator-describe-header-parameter',
 			'!validator-describe-header-type',
 			'!validator-describe-header-default',
@@ -104,7 +104,7 @@ class ParameterListDocBuilderTest extends \PHPUnit_Framework_TestCase {
 		$wikiText = $this->builder->getParameterTable( [ $paramWithAliases, $paramWithoutAliases ] );
 
 		$expected = [
-			'{| class="wikitable sortable"',
+			'{| class="smwtable-clean doctable sortable"',
 			'!validator-describe-header-parameter',
 			'!validator-describe-header-type',
 			'!validator-describe-header-default',
@@ -136,7 +136,7 @@ class ParameterListDocBuilderTest extends \PHPUnit_Framework_TestCase {
 		] );
 
 		$expected = [
-			'{| class="wikitable sortable"',
+			'{| class="smwtable-clean doctable sortable"',
 			'!validator-describe-header-parameter',
 			'!validator-describe-header-type',
 			'!validator-describe-header-default',


### PR DESCRIPTION
This PR is made in reference to: #

This PR addresses or contains:
- Changes standard class for tables of `#smwdoc` parser function from "wikitable" to "smwtable-clean" as a more modern alternative
- Provides extra class identifier "doctable" allowing for custom formatting. I deliberately chose a generic name to allow also other extension to adopt it, e.g. Maps for the `#mapsdoc` parser function
- Adapts existing test accordingly

This PR includes:
- [x] Tests (unit/integration)
- [ ] CI build passed

Fixes #