### PR TITLE
[CI] Fix warnings and notices

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,9 @@
 # https://docs.travis-ci.com/user/languages/php
 language: php
 
+os:
+  - linux
+
 # https://docs.travis-ci.com/user/trusty-ci-environment/
 dist: trusty
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 # https://docs.travis-ci.com/user/languages/php
 language: php
-sudo: required
 
 # https://docs.travis-ci.com/user/trusty-ci-environment/
 dist: trusty
@@ -8,7 +7,7 @@ dist: trusty
 addons:
   postgresql: "9.5"
 
-matrix:
+jobs:
   fast_finish: true
   include:
     - env: DB=mysql; MW=REL1_32; PHPUNIT=6.5.*


### PR DESCRIPTION
This PR is made in reference to: #

This PR addresses or contains:
- root: deprecated key sudo (The key `sudo` has no effect anymore.) 
- root: key matrix is an alias for jobs, using jobs
- root: missing os, using the default linux

This PR includes:
- [ ] Tests (unit/integration)
- [x] CI build passed