### PR TITLE
Migrate maintenance scripts to psr-4 compliant autoloading standard

### DIFF
--- a/maintenance/dumpRDF.php
+++ b/maintenance/dumpRDF.php
@@ -38,7 +38,7 @@ require_once $basePath . '/maintenance/Maintenance.php';
  * @author Markus Krötzsch
  * @author mwjames
  */
-class DumpRdf extends \Maintenance {
+class dumpRDF extends \Maintenance {
 
 	private $delay = 0;
 	private $delayeach = 0;
@@ -184,5 +184,5 @@ class DumpRdf extends \Maintenance {
 
 }
 
-$maintClass = 'SMW\Maintenance\DumpRdf';
+$maintClass = 'SMW\Maintenance\dumpRDF';
 require_once ( RUN_MAINTENANCE_IF_MAIN );

--- a/maintenance/populateHashField.php
+++ b/maintenance/populateHashField.php
@@ -20,7 +20,7 @@ require_once $basePath . '/maintenance/Maintenance.php';
  *
  * @author mwjames
  */
-class PopulateHashField extends \Maintenance {
+class populateHashField extends \Maintenance {
 
 	/**
 	 * Threshold as the when the `populateHashField.php` should be used by an
@@ -220,5 +220,5 @@ class PopulateHashField extends \Maintenance {
 
 }
 
-$maintClass = 'SMW\Maintenance\PopulateHashField';
+$maintClass = 'SMW\Maintenance\populateHashField';
 require_once( RUN_MAINTENANCE_IF_MAIN );

--- a/maintenance/purgeEntityCache.php
+++ b/maintenance/purgeEntityCache.php
@@ -20,7 +20,7 @@ require_once $basePath . '/maintenance/Maintenance.php';
  *
  * @author mwjames
  */
-class PurgeEntityCache extends \Maintenance {
+class purgeEntityCache extends \Maintenance {
 
 	/**
 	 * @var Store
@@ -162,5 +162,5 @@ class PurgeEntityCache extends \Maintenance {
 
 }
 
-$maintClass = 'SMW\Maintenance\PurgeEntityCache';
+$maintClass = 'SMW\Maintenance\purgeEntityCache';
 require_once( RUN_MAINTENANCE_IF_MAIN );

--- a/maintenance/rebuildConceptCache.php
+++ b/maintenance/rebuildConceptCache.php
@@ -63,7 +63,7 @@ require_once $basePath . '/maintenance/Maintenance.php';
  * @author Markus Krötzsch
  * @author mwjames
  */
-class RebuildConceptCache extends \Maintenance {
+class rebuildConceptCache extends \Maintenance {
 
 	public function __construct() {
 		parent::__construct();
@@ -191,5 +191,5 @@ class RebuildConceptCache extends \Maintenance {
 
 }
 
-$maintClass = 'SMW\Maintenance\RebuildConceptCache';
+$maintClass = 'SMW\Maintenance\rebuildConceptCache';
 require_once ( RUN_MAINTENANCE_IF_MAIN );

--- a/maintenance/rebuildData.php
+++ b/maintenance/rebuildData.php
@@ -50,7 +50,7 @@ require_once $basePath . '/maintenance/Maintenance.php';
  * @author Yaron Koren
  * @author Markus Krötzsch
  */
-class RebuildData extends \Maintenance {
+class rebuildData extends \Maintenance {
 
 	public function __construct() {
 		parent::__construct();
@@ -257,5 +257,5 @@ class RebuildData extends \Maintenance {
 
 }
 
-$maintClass = 'SMW\Maintenance\RebuildData';
+$maintClass = 'SMW\Maintenance\rebuildData';
 require_once ( RUN_MAINTENANCE_IF_MAIN );

--- a/maintenance/rebuildElasticIndex.php
+++ b/maintenance/rebuildElasticIndex.php
@@ -19,7 +19,7 @@ require_once $basePath . '/maintenance/Maintenance.php';
  *
  * @author mwjames
  */
-class RebuildElasticIndex extends \Maintenance {
+class rebuildElasticIndex extends \Maintenance {
 
 	/**
 	 * @var Store
@@ -433,5 +433,5 @@ class RebuildElasticIndex extends \Maintenance {
 
 }
 
-$maintClass = 'SMW\Maintenance\RebuildElasticIndex';
+$maintClass = 'SMW\Maintenance\rebuildElasticIndex';
 require_once( RUN_MAINTENANCE_IF_MAIN );

--- a/maintenance/rebuildElasticMissingDocuments.php
+++ b/maintenance/rebuildElasticMissingDocuments.php
@@ -20,7 +20,7 @@ require_once $basePath . '/maintenance/Maintenance.php';
  *
  * @author mwjames
  */
-class RebuildElasticMissingDocuments extends \Maintenance {
+class rebuildElasticMissingDocuments extends \Maintenance {
 
 	/**
 	 * @var Store
@@ -252,5 +252,5 @@ class RebuildElasticMissingDocuments extends \Maintenance {
 
 }
 
-$maintClass = 'SMW\Maintenance\RebuildElasticMissingDocuments';
+$maintClass = 'SMW\Maintenance\rebuildElasticMissingDocuments';
 require_once( RUN_MAINTENANCE_IF_MAIN );

--- a/maintenance/rebuildFulltextSearchTable.php
+++ b/maintenance/rebuildFulltextSearchTable.php
@@ -18,7 +18,7 @@ require_once $basePath . '/maintenance/Maintenance.php';
  *
  * @author mwjames
  */
-class RebuildFulltextSearchTable extends \Maintenance {
+class rebuildFulltextSearchTable extends \Maintenance {
 
 	public function __construct() {
 		$this->mDescription = 'Rebuild the fulltext search index (only works with SQLStore)';
@@ -180,5 +180,5 @@ class RebuildFulltextSearchTable extends \Maintenance {
 
 }
 
-$maintClass = 'SMW\Maintenance\RebuildFulltextSearchTable';
+$maintClass = 'SMW\Maintenance\rebuildFulltextSearchTable';
 require_once ( RUN_MAINTENANCE_IF_MAIN );

--- a/maintenance/rebuildPropertyStatistics.php
+++ b/maintenance/rebuildPropertyStatistics.php
@@ -17,7 +17,7 @@ require_once $basePath . '/maintenance/Maintenance.php';
  *
  * @author Jeroen De Dauw < jeroendedauw@gmail.com >
  */
-class RebuildPropertyStatistics extends \Maintenance {
+class rebuildPropertyStatistics extends \Maintenance {
 
 	public function __construct() {
 		$this->mDescription = 'Rebuild the property usage statistics (only works with SQLStore3 for now)';
@@ -89,5 +89,5 @@ class RebuildPropertyStatistics extends \Maintenance {
 
 }
 
-$maintClass = 'SMW\Maintenance\RebuildPropertyStatistics';
+$maintClass = 'SMW\Maintenance\rebuildPropertyStatistics';
 require_once ( RUN_MAINTENANCE_IF_MAIN );

--- a/maintenance/removeDuplicateEntities.php
+++ b/maintenance/removeDuplicateEntities.php
@@ -16,7 +16,7 @@ require_once $basePath . '/maintenance/Maintenance.php';
  *
  * @author mwjames
  */
-class RemoveDuplicateEntities extends \Maintenance {
+class removeDuplicateEntities extends \Maintenance {
 
 	/**
 	 * @since 3.0
@@ -108,5 +108,5 @@ class RemoveDuplicateEntities extends \Maintenance {
 
 }
 
-$maintClass = 'SMW\Maintenance\RemoveDuplicateEntities';
+$maintClass = 'SMW\Maintenance\removeDuplicateEntities';
 require_once( RUN_MAINTENANCE_IF_MAIN );

--- a/maintenance/setupStore.php
+++ b/maintenance/setupStore.php
@@ -52,7 +52,7 @@ require_once $basePath . '/maintenance/Maintenance.php';
  * @author Markus Krötzsch
  * @author Jeroen De Dauw < jeroendedauw@gmail.com >
  */
-class SetupStore extends \Maintenance {
+class setupStore extends \Maintenance {
 
 	/**
 	 * Name of the store class configured in LocalSettings.php. Stored to
@@ -267,5 +267,5 @@ class SetupStore extends \Maintenance {
 
 }
 
-$maintClass = 'SMW\Maintenance\SetupStore';
+$maintClass = 'SMW\Maintenance\setupStore';
 require_once ( RUN_MAINTENANCE_IF_MAIN );

--- a/maintenance/updateEntityCollation.php
+++ b/maintenance/updateEntityCollation.php
@@ -21,7 +21,7 @@ require_once $basePath . '/maintenance/Maintenance.php';
  *
  * @author mwjames
  */
-class UpdateEntityCollation extends \Maintenance {
+class updateEntityCollation extends \Maintenance {
 
 	public function __construct() {
 		$this->mDescription = 'Update the smw_sort field (relying on the $smwgEntityCollation setting)';
@@ -173,5 +173,5 @@ class UpdateEntityCollation extends \Maintenance {
 
 }
 
-$maintClass = 'SMW\Maintenance\UpdateEntityCollation';
+$maintClass = 'SMW\Maintenance\updateEntityCollation';
 require_once( RUN_MAINTENANCE_IF_MAIN );

--- a/maintenance/updateQueryDependencies.php
+++ b/maintenance/updateQueryDependencies.php
@@ -20,7 +20,7 @@ require_once $basePath . '/maintenance/Maintenance.php';
  *
  * @author mwjames
  */
-class UpdateQueryDependencies extends \Maintenance {
+class updateQueryDependencies extends \Maintenance {
 
 	/**
 	 * @var MessageReporter
@@ -182,5 +182,5 @@ class UpdateQueryDependencies extends \Maintenance {
 
 }
 
-$maintClass = 'SMW\Maintenance\UpdateQueryDependencies';
+$maintClass = 'SMW\Maintenance\updateQueryDependencies';
 require_once( RUN_MAINTENANCE_IF_MAIN );


### PR DESCRIPTION
This PR is made in reference to: #4650 

This PR addresses or contains:
- Migrate maintenance scripts to psr-4 compliant autoloading standard by renaming the class names to match the file names

Back-port to 3.1.x

This PR includes:
- [ ] Tests (unit/integration)
- [x] CI build passed

Fixes #4650 