### PR TITLE
Find and match redirect source for `sequence_map`, refs 4669, 4227

### DIFF
--- a/DefaultSettings.php
+++ b/DefaultSettings.php
@@ -71,7 +71,7 @@ return [
 	#
 	# @since 3.0
 	##
-	'smwgUpgradeKey' => 'smw:2020-02-29',
+	'smwgUpgradeKey' => 'smw:2020-03-28',
 	##
 
 	###

--- a/src/SQLStore/EntityStore/IdCacheManager.php
+++ b/src/SQLStore/EntityStore/IdCacheManager.php
@@ -14,6 +14,14 @@ use SMW\SQLStore\SQLStore;
  */
 class IdCacheManager {
 
+	// InMemoryCacheManager
+
+	/**
+	 * Caching redirects, especially from prefetch
+	 */
+	const REDIRECT_SOURCE = 'redirect.source.lookup';
+	const REDIRECT_TARGET = 'redirect.target.lookup';
+
 	/**
 	 * @var []
 	 */

--- a/src/SQLStore/EntityStore/SemanticDataLookup.php
+++ b/src/SQLStore/EntityStore/SemanticDataLookup.php
@@ -11,6 +11,7 @@ use SMW\SemanticData;
 use SMW\SQLStore\PropertyTableDefinition;
 use SMW\SQLStore\SQLStore;
 use SMW\SQLStore\TableBuilder\FieldType;
+use SMW\SQLStore\Lookup\RedirectTargetLookup;
 use SMWDataItem as DataItem;
 
 /**
@@ -591,7 +592,7 @@ class SemanticDataLookup {
 
 			// Using a short-cut to warmup the cache/linkbatch instance
 			if ( $propTable->getDiType() === DataItem::TYPE_WIKIPAGE ) {
-				$warmupCache[] = DIWikiPage::newFromText( $row->v0, $row->v1 );
+				$warmupCache[$row->id0] = DIWikiPage::newFromText( $row->v0, $row->v1 );
 			}
 		}
 
@@ -605,7 +606,7 @@ class SemanticDataLookup {
 		}
 
 		if ( $warmupCache !== [] ) {
-			$this->store->getObjectIds()->warmupCache( $warmupCache );
+			$this->store->getObjectIds()->warmupCache( $warmupCache, RedirectTargetLookup::PREPARE_CACHE );
 		}
 
 		return $result;

--- a/src/SQLStore/EntityStore/SequenceMapFinder.php
+++ b/src/SQLStore/EntityStore/SequenceMapFinder.php
@@ -141,7 +141,7 @@ class SequenceMapFinder {
 		$cache = $this->idCacheManager->get( 'sequence.map' );
 
 		$rows = $this->connection->select(
-			SQLStore::ID_AUXILIARY_TABLE,
+			$this->connection->tablename( SQLStore::ID_AUXILIARY_TABLE ),
 			[
 				'smw_id',
 				'smw_seqmap'

--- a/src/SQLStore/Lookup/RedirectTargetLookup.php
+++ b/src/SQLStore/Lookup/RedirectTargetLookup.php
@@ -5,7 +5,8 @@ namespace SMW\SQLStore\Lookup;
 use SMW\DIProperty;
 use SMW\DIWikiPage;
 use SMW\Store;
-use SMW\Utils\CircularReferenceGuard;
+use SMW\SQLStore\EntityStore\IdCacheManager;
+use SMW\SQLStore\RedirectStore;
 
 /**
  * @license GNU GPL v2+
@@ -16,51 +17,106 @@ use SMW\Utils\CircularReferenceGuard;
 class RedirectTargetLookup {
 
 	/**
+	 * Only attempt to lookup from cache
+	 */
+	const PREPARE_CACHE = 'redirect/cache';
+
+	/**
+	 * Only attempt to lookup from cache
+	 */
+	const CACHE_ONLY = 'cache/only';
+
+	/**
 	 * @var Store
 	 */
 	private $store;
 
 	/**
-	 * @var CircularReferenceGuard
+	 * @var InMemoryCacheManager
 	 */
-	private $circularReferenceGuard;
+	private $inMemoryCacheManager;
 
 	/**
 	 * @since 2.5
 	 *
 	 * @param Store $store
-	 * @param CircularReferenceGuard $circularReferenceGuard
+	 * @param IdCacheManager $inMemoryCacheManager
 	 */
-	public function __construct( Store $store, CircularReferenceGuard $circularReferenceGuard ) {
+	public function __construct( Store $store, IdCacheManager $inMemoryCacheManager ) {
 		$this->store = $store;
-		$this->circularReferenceGuard = $circularReferenceGuard;
+		$this->inMemoryCacheManager = $inMemoryCacheManager;
 	}
 
 	/**
-	 * @since 2.5
+	 * @since 3.2
 	 *
-	 * @param $dataItem
-	 *
-	 * @return DataItem
+	 * @param array $list
 	 */
-	public function findRedirectTarget( $dataItem ) {
+	public function prepareCache( array $list ) {
 
-		if ( !$dataItem instanceof DIWikiPage && !$dataItem instanceof DIProperty ) {
-			return $dataItem;
+		$ids = array_keys( $list );
+
+		if ( $ids === [] ) {
+			return;
 		}
 
-		$hash = $dataItem->getSerialization();
+		$source = $this->inMemoryCacheManager->get( IdCacheManager::REDIRECT_SOURCE );
+		$target = $this->inMemoryCacheManager->get( IdCacheManager::REDIRECT_TARGET );
 
-		// Guard against a dataItem that points to itself
-		$this->circularReferenceGuard->mark( $hash );
+		$connection = $this->store->getConnection( 'mw.db' );
 
-		if ( !$this->circularReferenceGuard->isCircular( $hash ) ) {
-			$dataItem = $this->store->getRedirectTarget( $dataItem );
+		$rows = $connection->select(
+			$connection->tableName( RedirectStore::TABLE_NAME ),
+			[
+				'o_id',
+				's_title',
+				's_namespace',
+			],
+			[
+				'o_id' => $ids
+			],
+			__METHOD__
+		);
+
+		foreach ( $rows as $row ) {
+
+			// Matching target to source
+			[ $title, $namespace, $interwiki, $subobject ] = explode( "#", $list[$row->o_id] );
+
+			$hash = IdCacheManager::computeSha1(
+				[ $title, (int)$namespace, $interwiki, $subobject ]
+			);
+
+			$source->save( $hash, "$row->s_title#$row->s_namespace##" );
+
+			// Matching source to target
+			$hash = IdCacheManager::computeSha1(
+				[ $row->s_title, (int)$row->s_namespace, '', '' ]
+			);
+
+			$target->save( $hash, "$title#$namespace##" );
+		}
+	}
+
+	/**
+	 * @since 3.2
+	 *
+	 * @param DIWikiPage $target
+	 * @param string $flag
+	 *
+	 * @return DIWikiPage|false
+	 */
+	public function findRedirectSource( DIWikiPage $target, ?string $flag = null ) {
+
+		$cache = $this->inMemoryCacheManager->get(
+			IdCacheManager::REDIRECT_SOURCE
+		);
+
+		if ( $flag === self::CACHE_ONLY && $cache->fetch( $target->getSha1() ) !== false ) {
+			return DIWikiPage::doUnserialize( $cache->fetch( $target->getSha1() ) );
 		}
 
-		$this->circularReferenceGuard->unmark( $hash );
-
-		return $dataItem;
+		return false;
 	}
 
 }

--- a/src/SQLStore/SQLStoreFactory.php
+++ b/src/SQLStore/SQLStoreFactory.php
@@ -745,7 +745,26 @@ class SQLStoreFactory {
 			$applicationFactory->singleton( 'DisplayTitleFinder', $this->store )
 		);
 
+		$cacheWarmer->setThresholdLimit( 1 );
+
 		return $cacheWarmer;
+	}
+
+	/**
+	 * @since 3.2
+	 *
+	 * @param IdCacheManager $idCacheManager
+	 *
+	 * @return redirectTargetLookup
+	 */
+	public function newRedirectTargetLookup( IdCacheManager $idCacheManager ) : RedirectTargetLookup {
+
+		$redirectTargetLookup = new RedirectTargetLookup(
+			$this->store,
+			$idCacheManager
+		);
+
+		return $redirectTargetLookup;
 	}
 
 	/**

--- a/src/SQLStore/TableBuilder/TableSchemaManager.php
+++ b/src/SQLStore/TableBuilder/TableSchemaManager.php
@@ -352,7 +352,7 @@ class TableSchemaManager {
 				's_namespace' => [ FieldType::FIELD_NAMESPACE, 'NOT NULL' ]
 			];
 
-			$indexes['sp'] = 's_title,s_namespace';
+			$indexes['sp'] = 's_title,s_namespace,o_id';
 		}
 
 		$indexes['po'] = $diHandler->getIndexField();

--- a/tests/phpunit/Integration/JSONScript/TestCases/p-1121.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/p-1121.json
@@ -1,0 +1,77 @@
+{
+	"description": "Test `smw/schema` on `PROPERTY_PROFILE_SCHEMA` with `sequence_map` and redirects",
+	"setup": [
+		{
+			"namespace": "SMW_NS_SCHEMA",
+			"page": "Profile:AnnotationSequenceMap",
+			"contents": {
+				"import-from": "/../Fixtures/p-1120-annotation-sequence-map.json"
+			}
+		},
+		{
+			"namespace": "SMW_NS_PROPERTY",
+			"page": "Has city",
+			"contents": "[[Has type::Page]] [[Profile schema::Profile:AnnotationSequenceMap]]"
+		},
+		{
+			"page": "City A",
+			"contents": "#REDIRECT [[City AA]]"
+		},
+		{
+			"page": "P1121/1",
+			"contents": "[[Has city::City A]] [[Has city::City B]] [[Has city::City C]] [[Category:P1121:1]]"
+		},
+		{
+			"page": "P1121/2",
+			"contents": "[[Has city::City B]] [[Has city::City A]] [[Has city::City C]] [[Category:P1121:2]]"
+		},
+		{
+			"page": "P1121/Q.1",
+			"contents": "{{#ask: [[Category:P1121:1]] [[Has city::+]] |?Has city |format=table |headers=plain |link=none }}"
+		},
+		{
+			"page": "P1121/Q.2",
+			"contents": "{{#ask: [[Category:P1121:2]] [[Has city::+]] |?Has city |format=table |headers=plain |link=none }}"
+		}
+	],
+	"tests": [
+		{
+			"type": "parser",
+			"about": "#0 (object value with redirect)",
+			"subject": "P1121/Q.1",
+			"assert-output": {
+				"to-contain": [
+					"<td class=\"Has-city smwtype_wpg\">City AA<br />City B<br />City C</td>"
+				]
+			}
+		},
+		{
+			"type": "parser",
+			"about": "#1 (object value with redirect)",
+			"subject": "P1121/Q.2",
+			"assert-output": {
+				"to-contain": [
+					"<td class=\"Has-city smwtype_wpg\">City B<br />City AA<br />City C</td>"
+				]
+			}
+		}
+	],
+	"settings": {
+		"wgContLang": "en",
+		"wgLang": "en",
+		"smwgPageSpecialProperties": [
+			"_MDAT"
+		],
+		"smwgNamespacesWithSemanticLinks": {
+			"NS_MAIN": true,
+			"NS_CATEGORY": true,
+			"SMW_NS_PROPERTY": true,
+			"SMW_NS_SCHEMA": true
+		}
+	},
+	"meta": {
+		"version": "2",
+		"is-incomplete": false,
+		"debug": false
+	}
+}

--- a/tests/phpunit/Unit/SQLStore/Lookup/RedirectTargetLookupTest.php
+++ b/tests/phpunit/Unit/SQLStore/Lookup/RedirectTargetLookupTest.php
@@ -16,97 +16,135 @@ use SMW\SQLStore\Lookup\RedirectTargetLookup;
  */
 class RedirectTargetLookupTest extends \PHPUnit_Framework_TestCase {
 
+	private $store;
+	private $idCacheManager;
+	private $cache;
+	private $connection;
+
+	protected function setUp() : void {
+
+		$this->connection = $this->getMockBuilder( '\SMW\MediaWiki\Database' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$this->store = $this->getMockBuilder( '\SMW\Store' )
+			->disableOriginalConstructor()
+			->setMethods( [ 'getConnection' ] )
+			->getMockForAbstractClass();
+
+		$this->store->expects( $this->any() )
+			->method( 'getConnection' )
+			->will( $this->returnValue( $this->connection ) );
+
+		$this->idCacheManager = $this->getMockBuilder( '\SMW\SQLStore\EntityStore\IdCacheManager' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$this->cache = $this->getMockBuilder( '\Onoi\Cache\Cache' )
+			->disableOriginalConstructor()
+			->getMock();
+	}
+
 	public function testCanConstruct() {
 
-		$store = $this->getMockBuilder( '\SMW\Store' )
-			->disableOriginalConstructor()
-			->getMockForAbstractClass();
+		$this->assertInstanceOf(
+			RedirectTargetLookup::class,
+			new RedirectTargetLookup( $this->store, $this->idCacheManager )
+		);
+	}
 
-		$circularReferenceGuard = $this->getMockBuilder( '\SMW\Utils\CircularReferenceGuard' )
-			->disableOriginalConstructor()
-			->getMock();
+	public function testPrepareCache_FromHash() {
+
+		$rows = [
+			(object)[ 's_title' => 'Bar', 's_namespace' => 0, 'o_id' => 42 ]
+		];
+
+		$this->connection->expects( $this->once() )
+			->method( 'select' )
+			->will( $this->returnValue( $rows ) );
+
+		$this->idCacheManager->expects( $this->any() )
+			->method( 'get' )
+			->will( $this->returnValue( $this->cache ) );
+
+		$this->cache->expects( $this->at( 0 ) )
+			->method( 'save' )
+			->with(
+				$this->equalTo( 'ebb1b47f7cf43a5a58d3c6cc58f3c3bb8b9246e6' ),
+				$this->equalTo( 'Bar#0##' ) );
+
+		$this->cache->expects( $this->at( 1 ) )
+			->method( 'save' )
+			->with(
+				$this->equalTo( '7b6b944694382bfab461675f40a2bda7e71e68e3' ),
+				$this->equalTo( 'Foo#0##' ) );
+
+		$instance = new RedirectTargetLookup(
+			$this->store,
+			$this->idCacheManager
+		);
+
+		$instance->prepareCache( [ 42 => 'Foo#0##' ] );
+	}
+
+	public function testPrepareCache_FromInstance() {
+
+		$rows = [
+			(object)[ 's_title' => 'Bar', 's_namespace' => 0, 'o_id' => 42 ]
+		];
+
+		$this->connection->expects( $this->once() )
+			->method( 'select' )
+			->will( $this->returnValue( $rows ) );
+
+		$this->idCacheManager->expects( $this->any() )
+			->method( 'get' )
+			->will( $this->returnValue( $this->cache ) );
+
+		$this->cache->expects( $this->at( 0 ) )
+			->method( 'save' )
+			->with(
+				$this->equalTo( 'ebb1b47f7cf43a5a58d3c6cc58f3c3bb8b9246e6' ),
+				$this->equalTo( 'Bar#0##' ) );
+
+		$this->cache->expects( $this->at( 1 ) )
+			->method( 'save' )
+			->with(
+				$this->equalTo( '7b6b944694382bfab461675f40a2bda7e71e68e3' ),
+				$this->equalTo( 'Foo#0##' ) );
+
+		$instance = new RedirectTargetLookup(
+			$this->store,
+			$this->idCacheManager
+		);
+
+		$instance->prepareCache( [ 42 => DIWikiPage::newFromText( 'Foo' ) ] );
+	}
+
+	public function testFindRedirectSource() {
+
+		$flag = RedirectTargetLookup::CACHE_ONLY;
+		$target = DIWikiPage::newFromText( 'Foo' );
+
+		$this->idCacheManager->expects( $this->any() )
+			->method( 'get' )
+			->with( $this->equalTo( \SMW\SQLStore\EntityStore\IdCacheManager::REDIRECT_SOURCE ) )
+			->will( $this->returnValue( $this->cache ) );
+
+		$this->cache->expects( $this->atLeastOnce() )
+			->method( 'fetch' )
+			->with( $this->equalTo( 'ebb1b47f7cf43a5a58d3c6cc58f3c3bb8b9246e6' ) )
+			->will( $this->returnValue( 'Bar#0##' ) );
+
+		$instance = new RedirectTargetLookup(
+			$this->store,
+			$this->idCacheManager
+		);
 
 		$this->assertInstanceOf(
-			'\SMW\SQLStore\Lookup\RedirectTargetLookup',
-			new RedirectTargetLookup( $store, $circularReferenceGuard )
+			'\SMW\DIWikiPage',
+			$instance->findRedirectSource( $target, $flag )
 		);
-	}
-
-	public function testFindRedirectTargetOnValidDataItem() {
-
-		$store = $this->getMockBuilder( '\SMW\Store' )
-			->disableOriginalConstructor()
-			->setMethods( [ 'getRedirectTarget' ] )
-			->getMockForAbstractClass();
-
-		$store->expects( $this->atLeastOnce() )
-			->method( 'getRedirectTarget' );
-
-		$circularReferenceGuard = $this->getMockBuilder( '\SMW\Utils\CircularReferenceGuard' )
-			->disableOriginalConstructor()
-			->getMock();
-
-		$circularReferenceGuard->expects( $this->atLeastOnce() )
-			->method( 'isCircular' )
-			->will( $this->returnValue( false ) );
-
-		$instance = new RedirectTargetLookup(
-			$store,
-			$circularReferenceGuard
-		);
-
-		$instance->findRedirectTarget( DIWikiPage::newFromText( 'Foo' ) );
-	}
-
-	public function testFindRedirectTargetOnInvalidDataItem() {
-
-		$store = $this->getMockBuilder( '\SMW\Store' )
-			->disableOriginalConstructor()
-			->setMethods( [ 'getRedirectTarget' ] )
-			->getMockForAbstractClass();
-
-		$store->expects( $this->never() )
-			->method( 'getRedirectTarget' );
-
-		$circularReferenceGuard = $this->getMockBuilder( '\SMW\Utils\CircularReferenceGuard' )
-			->disableOriginalConstructor()
-			->getMock();
-
-		$circularReferenceGuard->expects( $this->never() )
-			->method( 'isCircular' );
-
-		$instance = new RedirectTargetLookup(
-			$store,
-			$circularReferenceGuard
-		);
-
-		$instance->findRedirectTarget( 'foo' );
-	}
-
-	public function testFindRedirectTargetOnSelfReferencedDataItem() {
-
-		$store = $this->getMockBuilder( '\SMW\Store' )
-			->disableOriginalConstructor()
-			->setMethods( [ 'getRedirectTarget' ] )
-			->getMockForAbstractClass();
-
-		$store->expects( $this->never() )
-			->method( 'getRedirectTarget' );
-
-		$circularReferenceGuard = $this->getMockBuilder( '\SMW\Utils\CircularReferenceGuard' )
-			->disableOriginalConstructor()
-			->getMock();
-
-		$circularReferenceGuard->expects( $this->atLeastOnce() )
-			->method( 'isCircular' )
-			->will( $this->returnValue( true ) );
-
-		$instance = new RedirectTargetLookup(
-			$store,
-			$circularReferenceGuard
-		);
-
-		$instance->findRedirectTarget( DIWikiPage::newFromText( 'Foo' ) );
 	}
 
 }

--- a/tests/phpunit/Unit/SQLStore/SQLStoreFactoryTest.php
+++ b/tests/phpunit/Unit/SQLStore/SQLStoreFactoryTest.php
@@ -793,6 +793,20 @@ class SQLStoreFactoryTest extends \PHPUnit_Framework_TestCase {
 		);
 	}
 
+	public function testCanConstructRedirectTargetLookup() {
+
+		$idCacheManager = $this->getMockBuilder( '\SMW\SQLStore\EntityStore\IdCacheManager' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$instance = new SQLStoreFactory( $this->store );
+
+		$this->assertInstanceOf(
+			'\SMW\SQLStore\Lookup\RedirectTargetLookup',
+			$instance->newRedirectTargetLookup( $idCacheManager )
+		);
+	}
+
 	public function testCanConstructByGroupPropertyValuesLookup() {
 
 		$instance = new SQLStoreFactory( $this->store );


### PR DESCRIPTION
This PR is made in reference to: #4669, #4227

This PR addresses or contains:

- It changes `'smwgUpgradeKey' => 'smw:2020-03-28',` because we need an additional index on the redirect table to make the read more efficient

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed

Fixes #4669