### PR TITLE
Use label as hover context, refs 4499

### DIFF
--- a/src/Utils/Pager.php
+++ b/src/Utils/Pager.php
@@ -65,11 +65,25 @@ class Pager {
 		);
 
 		$label = Message::get( 'smw-filter', Message::TEXT, Message::USER_LANGUAGE );
+		$content = Message::get( 'smw-property-page-filter-note', Message::PARSE, Message::USER_LANGUAGE );
+
+		$highlighter = Highlighter::factory(
+			Highlighter::TYPE_TEXT
+		);
+
+		$highlighter->setContent(
+			[
+				'caption' => $label,
+				'content' => $content,
+				'state'   => 'inline',
+				'style'   => 'text-decoration: underline dotted;text-underline-offset: 3px;'
+			]
+		);
 
 		$form .= Html::rawElement(
 			'label',
 			[],
-			$label .
+			$highlighter->getHtml() .
 			Html::rawElement(
 				'input',
 				[
@@ -83,30 +97,12 @@ class Pager {
 			)
 		);
 
-		$highlighter = Highlighter::factory( Highlighter::TYPE_NOTE );
-		$content = Message::get( 'smw-property-page-filter-note', Message::PARSE, Message::USER_LANGUAGE );
-
-		$highlighter->setContent(
-			[
-				'content' => $content,
-				'style' => 'margin-left: 5px;'
-			]
-		);
-
-		$tooltip = Html::rawElement(
-			'span',
-			[
-				'class' => 'smw-ui-input-filter-tooltip'
-			],
-			$highlighter->getHtml()
-		);
-
 		return Html::rawElement(
 			'div',
 			[
 				'class' => 'smw-ui-input-filter'
 			],
-			$form . $tooltip
+			$form
 		);
 	}
 

--- a/tests/phpunit/Unit/Utils/PagerTest.php
+++ b/tests/phpunit/Unit/Utils/PagerTest.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace SMW\Tests\Utils;
+
+use SMW\Utils\Pager;
+use SMW\Tests\PHPUnitCompat;
+
+/**
+ * @covers \SMW\Utils\Pager
+ * @group semantic-mediawiki
+ *
+ * @license GNU GPL v2+
+ * @since 3.2
+ *
+ * @author mwjames
+ */
+class PagerTest extends \PHPUnit_Framework_TestCase {
+
+	use PHPUnitCompat;
+
+	public function testFilter() {
+
+		$title = $this->getMockBuilder( '\Title' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$this->assertInternalType(
+			'string',
+			Pager::filter( $title )
+		);
+	}
+
+}


### PR DESCRIPTION
This PR is made in reference to: #4499

This PR addresses or contains:

- Instead of a special icon, use the filter label as context to provide a tooltip info

This PR includes:
- [ ] Tests (unit/integration)
- [ ] CI build passed

## Example

![image](https://user-images.githubusercontent.com/1245473/77845642-0755f000-71a0-11ea-9598-1a1cccdf2f43.png)
