### PR TITLE
Add `ConfigPreloader`

### DIFF
--- a/data/config/developer.php
+++ b/data/config/developer.php
@@ -1,0 +1,62 @@
+<?php
+
+/**
+ * Default settings mostly used in connection with a development environment and
+ * it not meant to be used in production.
+ *
+ * @since 3.2
+ */
+
+error_reporting(E_STRICT|E_ALL);
+ini_set("display_errors", 1);
+
+return [
+
+	/**
+	 *  MediaWiki specific settings to be used within a development environment
+	 */
+	'wgShowExceptionDetails' => true,
+	'wgDevelopmentWarnings' => true,
+	'wgShowSQLErrors' => true,
+	'wgDebugDumpSql' => true,
+	'wgShowDBErrorBacktrace' => true,
+
+	/**
+	 * @see https://www.mediawiki.org/wiki/Debugging_toolbar
+	 *
+	 * A utility for developers that displays debug information about a MediaWiki
+	 * page at the bottom of the browser window.
+	 */
+	'wgDebugToolbar' => true,
+
+	/**
+	 * Semantic MediaWiki related
+	 */
+
+	/**
+	 * @see $smwgIgnoreExtensionRegistrationCheck
+	 */
+	'smwgIgnoreExtensionRegistrationCheck' => true,
+
+	/**
+	 * @see $smwgDefaultLoggerRole
+	 *
+	 * You never want this role to be enabled in production because it will create
+	 * large log files while monitoring SMW related activities in detail.
+	 */
+	'smwgDefaultLoggerRole' => 'developer',
+
+	/**
+	 * @see $smwgJobQueueWatchlist
+	 */
+	'smwgJobQueueWatchlist' => [
+	    'smw.update',
+	    'smw.fulltextSearchTableUpdate',
+	    'smw.changePropagationUpdate',
+	    'smw.changePropagationClassUpdate',
+	    'smw.changePropagationDispatch',
+	    'smw.elasticIndexerRecovery',
+	    'smw.elasticFileIngest'
+	]
+
+];

--- a/data/config/elastic-fileingest.php
+++ b/data/config/elastic-fileingest.php
@@ -1,0 +1,35 @@
+<?php
+
+/**
+ * Convenience settings to extend Semantic MediaWiki and support file ingestion
+ * in connection with the ElasticStore.
+ *
+ * @since 3.2
+ */
+
+$extraSettings = [
+	'settings' => [
+		'data' => [ "index.mapping.total_fields.limit" => 12000 ]
+	],
+	'indexer' => [
+		"raw.text" => true,
+		"experimental.file.ingest" => true,
+		"throw.exception.on.illegal.argument.error" => false
+	],
+	"query" => [
+		"highlight.fragment" => [ "type" => "unified" ]
+	]
+];
+
+return [
+
+	/**
+	 * @see $smwgDefaultStore
+	 */
+	'smwgDefaultStore' => 'SMWElasticStore',
+
+	/**
+	 * @see $smwgElasticsearchConfig
+	 */
+	'smwgElasticsearchConfig' => array_replace_recursive( $GLOBALS['smwgElasticsearchConfig'], $extraSettings ),
+];

--- a/data/config/media.php
+++ b/data/config/media.php
@@ -1,0 +1,17 @@
+<?php
+
+/**
+ * Convenience settings to extend Semantic MediaWiki with media related functionality.
+ *
+ * @since 3.2
+ */
+
+$properties = [ '_MIME', '_MEDIA', '_ATTCH_LINK' ];
+
+return [
+
+	/**
+	 * @see $smwgPageSpecialProperties
+	 */
+	'smwgPageSpecialProperties' => array_merge( $GLOBALS['smwgPageSpecialProperties'], $properties )
+];

--- a/src/ConfigPreloader.php
+++ b/src/ConfigPreloader.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace SMW;
+
+use SMW\Exception\FileNotReadableException;
+
+/**
+ * @private
+ *
+ * Convenience class to allow users to inject some default settings from
+ * individual files directly from `enableSemantics`.
+ *
+ * @license GNU GPL v2+
+ * @since 3.2
+ *
+ * @author mwjames
+ */
+class ConfigPreloader {
+
+	/**
+	 * Loading files from the internal `config` directory that provides some
+	 * predeployed default settings.
+	 *
+	 * ```
+	 * enableSemantics( 'example.org' )->loadDefaultConfigFrom( 'media.php', 'xxx.php' );
+	 * ```
+	 *
+	 * @since 3.2
+	 *
+	 * @param array $files
+	 *
+	 * @return self
+	 */
+	public function loadDefaultConfigFrom( ...$files ) : ConfigPreloader {
+
+		$dir = $GLOBALS['smwgDir'] . '/data/config/';
+
+		foreach ( $files as $file ) {
+			$this->load( "$dir/$file" );
+		}
+
+		return $this;
+	}
+
+	/**
+	 * Loading some custom config from "any" location and is provided for
+	 * convenience to be used directly as in:
+	 *
+	 * ```
+	 * enableSemantics( 'example.org' )->loadConfigFrom( __DIR__ . '/locationX/foo.php' );
+	 * ```
+	 *
+	 * @since 3.2
+	 *
+	 * @param array $files
+	 *
+	 * @return self
+	 */
+	public function loadConfigFrom( ...$files ) : ConfigPreloader {
+
+		foreach ( $files as $file ) {
+			$this->load( $file );
+		}
+
+		return $this;
+	}
+
+	private function load( $file ) {
+
+		$file = str_replace( [ '\\', '//', '/' ], DIRECTORY_SEPARATOR, $file );
+
+		if ( !is_readable( $file ) ) {
+			throw new FileNotReadableException( $file );
+		}
+
+		$config = require $file;
+
+		foreach ( $config as $key => $value ) {
+			$GLOBALS[$key] = $value;
+		}
+	}
+
+}

--- a/src/GlobalFunctions.php
+++ b/src/GlobalFunctions.php
@@ -6,6 +6,7 @@ use SMW\Highlighter;
 use SMW\NamespaceManager;
 use SMW\ProcessingErrorMsgHandler;
 use SMW\Localizer\LocalLanguage\LocalLanguage;
+use SMW\ConfigPreloader;
 
 /**
  * Global functions specified and used by Semantic MediaWiki. In general, it is
@@ -233,7 +234,7 @@ function swfCountDown( $seconds ) {
  * @param mixed $namespace
  * @param boolean $complete
  *
- * @return true
+ * @return ConfigPreloader
  *
  * @codeCoverageIgnore
  */
@@ -264,7 +265,7 @@ function enableSemantics( $namespace = null, $complete = false ) {
 
 	$GLOBALS['smwgSemanticsEnabled'] = true;
 
-	return true;
+	return new ConfigPreloader();
 }
 
 /**

--- a/src/SetupFile.php
+++ b/src/SetupFile.php
@@ -514,6 +514,8 @@ class SetupFile {
 			TypesRegistry::getFixedProperties( 'custom_fixed' )
 		);
 
+		$pageSpecialProperties = array_unique( $pageSpecialProperties );
+
 		// Sort to ensure the key contains the same order
 		sort( $vars['smwgFixedProperties'] );
 		sort( $pageSpecialProperties );

--- a/tests/phpunit/Integration/ConfigPreloaderTest.php
+++ b/tests/phpunit/Integration/ConfigPreloaderTest.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace SMW\Tests\Integration;
+
+use SMW\ConfigPreloader;
+use SMW\Utils\FileFetcher;
+use SMW\Tests\PHPUnitCompat;
+
+/**
+ * @covers \SMW\ConfigPreloader
+ * @group semantic-mediawiki
+ *
+ * @license GNU GPL v2+
+ * @since 3.2
+ *
+ * @author mwjames
+ */
+class ConfigPreloaderTest extends \PHPUnit_Framework_TestCase {
+
+	use PHPUnitCompat;
+
+	private $gl = [];
+
+	protected function setUp() : void {
+
+		foreach ( $GLOBALS as $key => $value ) {
+			if ( is_callable( $value ) ) {
+				continue;
+			}
+
+			$this->gl[$key] = $value;
+		}
+	}
+
+	protected function tearDown() : void {
+		foreach ( $this->gl as $key => $value ) {
+			$GLOBALS[$key] = $value;
+		}
+	}
+
+	/**
+	 *@dataProvider configFileProvider
+	 */
+	public function testLoadDefaultConfigFrom( $file ) {
+
+		$instance = new ConfigPreloader();
+
+		$this->assertInstanceOf(
+			ConfigPreloader::class,
+			$instance->loadDefaultConfigFrom( pathinfo( $file, PATHINFO_BASENAME ) )
+		);
+	}
+
+	/**
+	 *@dataProvider configFileProvider
+	 */
+	public function testLoadConfigFrom( $file ) {
+
+		$instance = new ConfigPreloader();
+
+		$this->assertInstanceOf(
+			ConfigPreloader::class,
+			$instance->loadConfigFrom( $file )
+		);
+	}
+
+	public function testLoadingInvalidConfigFile_ThrowsException() {
+
+		$instance = new ConfigPreloader();
+
+		$this->expectException( '\SMW\Exception\FileNotReadableException' );
+		$instance->loadConfigFrom( 'foo.php' );
+	}
+
+	public function configFileProvider() {
+
+		$fileFetcher = new FileFetcher( $GLOBALS['smwgDir'] . '/data/config/' );
+		$iterator = $fileFetcher->findByExtension( 'php' );
+
+		yield from $iterator;
+	}
+
+}


### PR DESCRIPTION
This PR is made in reference to: #

This PR addresses or contains:

- `loadDefaultConfigFrom` allows to load some pre-deployed settings that are not used by default and bound to context and can directly be invoked after `enableSemantics`
  - `developer.php` mostly relevant to develop with SMW
  - `media.php` common media specific settings
  - `elastic-fileingest.php`
- `loadConfigFrom` to load a local bound set of configurations 

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed

## Example

```
enableSemantics( 'example.org' )->loadDefaultConfigFrom( 'developer.php', 'media.php' );
```
```
enableSemantics( 'example.org' )->loadConfigFrom( __DIR__ . '/locationX/foo.php' );
```