### PR TITLE
Check `smwgNamespaceIndex` and raise exception, refs 4682

### DIFF
--- a/src/Exception/NamespaceIndexChangeException.php
+++ b/src/Exception/NamespaceIndexChangeException.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace SMW\Exception;
+
+use RuntimeException;
+
+/**
+ * @license GNU GPL v2+
+ * @since 3.2
+ *
+ * @author mwjames
+ */
+class NamespaceIndexChangeException extends RuntimeException {
+
+	/**
+	 * @since 3.2
+	 *
+	 * @param string $old
+	 * @param string $new
+	 */
+	public function __construct( string $old, string $new ) {
+		parent::__construct(
+			"A change to the `smwgNamespaceIndex` was detected showing a discrepancy ($old, $new) and " .
+			"is preventing Semantic MediaWiki from modifying related namespace settings.\n\n" .
+			"LocalSettings.php should only contain one `smwgNamespaceIndex` definition and the declaration should ".
+			"happen before `enableSemantics`."
+		);
+	}
+
+}

--- a/tests/phpunit/Unit/Exception/NamespaceIndexChangeExceptionTest.php
+++ b/tests/phpunit/Unit/Exception/NamespaceIndexChangeExceptionTest.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace SMW\Tests\Exception;
+
+use SMW\Exception\NamespaceIndexChangeException;
+
+/**
+ * @covers \SMW\Exception\NamespaceIndexChangeException
+ * @group semantic-mediawiki
+ *
+ * @license GNU GPL v2+
+ * @since 3.2
+ *
+ * @author mwjames
+ */
+class NamespaceIndexChangeExceptionTest extends \PHPUnit_Framework_TestCase {
+
+	public function testCanConstruct() {
+
+		$instance = new NamespaceIndexChangeException( 'Foo', 'Bar' );
+
+		$this->assertInstanceof(
+			NamespaceIndexChangeException::class,
+			$instance
+		);
+
+		$this->assertInstanceof(
+			'\RuntimeException',
+			$instance
+		);
+	}
+
+}

--- a/tests/phpunit/Unit/NamespaceManagerTest.php
+++ b/tests/phpunit/Unit/NamespaceManagerTest.php
@@ -166,6 +166,45 @@ class NamespaceManagerTest extends \PHPUnit_Framework_TestCase {
 		NamespaceManager::initCustomNamespace( $vars );
 	}
 
+	public function testInitCustomNamespaceWithDefaultDifferentNamespaceIndex_ThrowsException() {
+
+		$vars = [
+			'wgLanguageCode' => 'en',
+			'wgContentNamespaces' => []
+		];
+
+		NamespaceManager::initCustomNamespace( $vars );
+
+		$vars = [
+			'wgLanguageCode' => 'en',
+			'wgContentNamespaces' => [],
+			'smwgNamespaceIndex' => 2001
+		];
+
+		$this->expectException( '\SMW\Exception\NamespaceIndexChangeException' );
+		NamespaceManager::initCustomNamespace( $vars );
+	}
+
+	public function testInitCustomNamespaceWithPresetDifferentNamespaceIndex_ThrowsException() {
+
+		$vars = [
+			'wgLanguageCode' => 'en',
+			'wgContentNamespaces' => [],
+			'smwgNamespaceIndex' => 2000
+		];
+
+		NamespaceManager::initCustomNamespace( $vars );
+
+		$vars = [
+			'wgLanguageCode' => 'en',
+			'wgContentNamespaces' => [],
+			'smwgNamespaceIndex' => 2001
+		];
+
+		$this->expectException( '\SMW\Exception\NamespaceIndexChangeException' );
+		NamespaceManager::initCustomNamespace( $vars );
+	}
+
 	public function testNamespacesInitWithEmptySettings() {
 
 		$vars = $this->default + [


### PR DESCRIPTION
This PR is made in reference to: #4682

This PR addresses or contains:

- Hardening the check to avoid any misunderstandings on the use of `smwgNamespaceIndex

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed
