### PR TITLE
Recognize date with UTC offset, refs 3532

### DIFF
--- a/tests/phpunit/Integration/JSONScript/TestCases/p-0451.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/p-0451.json
@@ -45,6 +45,14 @@
 		{
 			"page": "Example/P0451/9",
 			"contents": "[[Has date::2458119.500000]]"
+		},
+		{
+			"page": "Example/P0451/10",
+			"contents": "[[Has date::2002-11-01T00:00:00.000-0800]]"
+		},
+		{
+			"page": "Example/P0451/11",
+			"contents": "[[Has date::2018-10-11 18:23:59 +0200]]"
 		}
 	],
 	"tests": [
@@ -86,6 +94,54 @@
 			"assert-output": {
 				"to-contain": [
 					"2458119.500000"
+				]
+			}
+		},
+		{
+			"type": "parser",
+			"about": "#2 (recognized +/- offset from UTC)",
+			"subject": "Example/P0451/10",
+			"assert-store": {
+				"semantic-data": {
+					"strictPropertyValueMatch": false,
+					"propertyCount": 3,
+					"propertyKeys": [
+						"_SKEY",
+						"_MDAT",
+						"Has date"
+					],
+					"propertyValues": [
+						"2002-11-01T08:00:00"
+					]
+				}
+			},
+			"assert-output": {
+				"to-contain": [
+					"2002-11-01T00:00:00.000-0800"
+				]
+			}
+		},
+		{
+			"type": "parser",
+			"about": "#3 (recognized +/- offset from UTC)",
+			"subject": "Example/P0451/11",
+			"assert-store": {
+				"semantic-data": {
+					"strictPropertyValueMatch": false,
+					"propertyCount": 3,
+					"propertyKeys": [
+						"_SKEY",
+						"_MDAT",
+						"Has date"
+					],
+					"propertyValues": [
+						"2018-10-11T16:23:59"
+					]
+				}
+			},
+			"assert-output": {
+				"to-contain": [
+					"2018-10-11 18:23:59 +0200"
 				]
 			}
 		}

--- a/tests/phpunit/Unit/DataValues/ValueParsers/TimeValueParserTest.php
+++ b/tests/phpunit/Unit/DataValues/ValueParsers/TimeValueParserTest.php
@@ -83,6 +83,43 @@ class TimeValueParserTest extends \PHPUnit_Framework_TestCase {
 			[]
 		];
 
+		yield '2002-11-01T00:00:00.000-0800' => [
+			'2002-11-01T00:00:00.000-0800',
+			[
+				'value' => '2002-11-01T00:00:00.000-0800',
+				'datecomponents' => [
+					'2002', '-', '11', '-', '01'
+				],
+				'calendarmodel' => false,
+				'era' => false,
+				'hours' => 8,
+				'minutes' => 0,
+				'seconds' => 0,
+				'microseconds' => false,
+				'timeoffset' => 0,
+				'timezone' => false
+			],
+			[]
+		];
+
+		yield '2018-10-11 18:23:59 +0200' => [
+			'2018-10-11 18:23:59 +0200',
+			[
+				'value' => '2018-10-11 18:23:59 +0200',
+				'datecomponents' => [
+					'2018', '-', '10', '-', '11'
+				],
+				'calendarmodel' => false,
+				'era' => false,
+				'hours' => 16,
+				'minutes' => 23,
+				'seconds' => 59,
+				'microseconds' => false,
+				'timeoffset' => 0,
+				'timezone' => false
+			],
+			[]
+		];
 	}
 
 }


### PR DESCRIPTION
This PR is made in reference to: #3532

This PR addresses or contains:

- While importing some data I came across the `2002-11-01T00:00:00.000-0800` date format which requires special treatment due to the some UTC offset (see http://www.faqs.org/rfcs/rfc2822.html)
- PR also solves the issue of #3532 with a format like `2018-10-11 18:23:59 +0200`

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed
