### PR TITLE
Fix functions with required parameters after optional ones

### DIFF
--- a/includes/export/SMW_ExportController.php
+++ b/includes/export/SMW_ExportController.php
@@ -507,7 +507,7 @@ class SMWExportController {
 	 * export to reduce server load in long-running operations
 	 * @param integer $delayeach number of pages to process between two sleeps
 	 */
-	public function printAllToFile( $outfile, $ns_restriction = false, $delay, $delayeach ) {
+	public function printAllToFile( $outfile, $ns_restriction, $delay, $delayeach ) {
 
 		if ( !$this->prepareSerialization( $outfile ) ) {
 			return;
@@ -527,7 +527,7 @@ class SMWExportController {
 	 * export to reduce server load in long-running operations
 	 * @param integer $delayeach number of pages to process between two sleeps
 	 */
-	public function printAllToOutput( $ns_restriction = false, $delay, $delayeach ) {
+	public function printAllToOutput( $ns_restriction, $delay, $delayeach ) {
 		$this->prepareSerialization();
 		$this->printAll( $ns_restriction, $delay, $delayeach );
 	}
@@ -535,7 +535,7 @@ class SMWExportController {
 	/**
 	 * @since 2.0 made protected; use printAllToFile or printAllToOutput
 	 */
-	protected function printAll( $ns_restriction = false, $delay, $delayeach ) {
+	protected function printAll( $ns_restriction, $delay, $delayeach ) {
 		$linkCache = LinkCache::singleton();
 		$db = wfGetDB( DB_REPLICA );
 

--- a/src/DataValues/ConstraintSchemaValue.php
+++ b/src/DataValues/ConstraintSchemaValue.php
@@ -30,7 +30,7 @@ class ConstraintSchemaValue extends WikiPageValue {
 	/**
 	 * @param string $typeid
 	 */
-	public function __construct( $typeid = '', SpecificationLookup $specificationLookup ) {
+	public function __construct( $typeid, SpecificationLookup $specificationLookup ) {
 		parent::__construct( self::TYPE_ID );
 		$this->specificationLookup = $specificationLookup;
 		$this->m_fixNamespace = SMW_NS_SCHEMA;

--- a/src/DataValues/Number/IntlNumberFormatter.php
+++ b/src/DataValues/Number/IntlNumberFormatter.php
@@ -305,7 +305,7 @@ class IntlNumberFormatter {
 		);
 	}
 
-	private function doFormatWithPrecision( $value, $precision = false, $decimal, $thousand ) {
+	private function doFormatWithPrecision( $value, $precision, $decimal, $thousand ) {
 
 		$replacement = 0;
 

--- a/src/DataValues/Time/JulianDay.php
+++ b/src/DataValues/Time/JulianDay.php
@@ -44,7 +44,7 @@ class JulianDay implements CalendarModel {
 	 *
 	 * @return float
 	 */
-	public static function getJD( $calendarModel = self::CM_GREGORIAN, $year, $month, $day, $hour, $minute, $second ) {
+	public static function getJD( $calendarModel, $year, $month, $day, $hour, $minute, $second ) {
 		return self::format( self::date2JD( $calendarModel, $year, $month, $day ) + self::time2JDoffset( $hour, $minute, $second ) );
 	}
 

--- a/src/Elastic/Lookup/ProximityPropertyValueLookup.php
+++ b/src/Elastic/Lookup/ProximityPropertyValueLookup.php
@@ -51,7 +51,7 @@ class ProximityPropertyValueLookup {
 	 *
 	 * @return array
 	 */
-	public function lookup( DIProperty $property, $value = '', RequestOptions $opts ) {
+	public function lookup( DIProperty $property, $value, RequestOptions $opts ) {
 
 		$connection = $this->store->getConnection( 'elastic' );
 		$continueOffset = 0;

--- a/src/EntityCache.php
+++ b/src/EntityCache.php
@@ -222,7 +222,7 @@ class EntityCache {
 	 *
 	 * @param DIWikiPage|Title $subject
 	 */
-	public function associate( $subject = null, $key ) {
+	public function associate( $subject, $key ) {
 
 		if ( $subject === null ) {
 			return;

--- a/src/MediaWiki/Connection/Database.php
+++ b/src/MediaWiki/Connection/Database.php
@@ -254,14 +254,14 @@ class Database {
 	 *
 	 * @param string $tableName
 	 * @param $fields
-	 * @param $conditions
+	 * @param array|string $conditions
 	 * @param array $options
 	 * @param array $joinConditions
 	 *
 	 * @return ResultWrapper
 	 * @throws UnexpectedValueException
 	 */
-	public function select( $tableName, $fields, $conditions = '', $fname, array $options = [], $joinConditions = [] ) {
+	public function select( $tableName, $fields, $conditions, $fname, array $options = [], $joinConditions = [] ) {
 
 		$tablePrefix = null;
 		$connection = $this->connRef->getConnection( 'read' );

--- a/src/Property/ChangePropagationNotifier.php
+++ b/src/Property/ChangePropagationNotifier.php
@@ -182,7 +182,7 @@ class ChangePropagationNotifier {
 		$this->setDiff( !$this->isEqual( $oldValues, $newValues ), $key );
 	}
 
-	private function setDiff( $hasDiff = true, $key ) {
+	private function setDiff( $hasDiff, $key ) {
 
 		if ( !$hasDiff || $this->hasDiff ) {
 			return;

--- a/src/Query/Result/StringResult.php
+++ b/src/Query/Result/StringResult.php
@@ -51,7 +51,7 @@ class StringResult extends QueryResult {
 	 *
 	 * @param string $result
 	 */
-	public function __construct( $result = '', Query $query, $hasFurtherResults = false ) {
+	public function __construct( $result, Query $query, $hasFurtherResults = false ) {
 		$this->result = $result;
 		$this->query = $query;
 		$this->hasFurtherResults = $hasFurtherResults;

--- a/src/SetupFile.php
+++ b/src/SetupFile.php
@@ -455,7 +455,7 @@ class SetupFile {
 	 * @param array $vars
 	 * @param array $args
 	 */
-	public function write( $args = [], array $vars ) {
+	public function write( array $args, array $vars ) {
 
 		$configFile = File::dir( $vars['smwgConfigFileDir'] . '/' . self::FILE_NAME );
 		$id = Site::id();

--- a/src/Utils/HtmlTable.php
+++ b/src/Utils/HtmlTable.php
@@ -130,7 +130,7 @@ class HtmlTable {
 		return $this->concatenateRows( $rows, $htmlContext );
 	}
 
-	private function createRow( $content = '', $attributes = [], $count ) {
+	private function createRow( $content, $attributes = [], $count ) {
 
 		$alternate = $count % 2 == 0 ? 'row-odd' : 'row-even';
 

--- a/tests/phpunit/Utils/Validators/StringValidator.php
+++ b/tests/phpunit/Utils/Validators/StringValidator.php
@@ -53,7 +53,7 @@ class StringValidator extends \PHPUnit_Framework_Assert {
 		$this->doAssertWith( $expected, (string)$actual, $message, 'StringNotContains', $callback );
 	}
 
-	private function doAssertWith( $expected, $actual, $message = '', $method = '', $callback ) {
+	private function doAssertWith( $expected, $actual, $message, $method, $callback ) {
 
 		if ( !is_array( $expected ) ) {
 			$expected = [ $expected ];

--- a/tests/phpunit/includes/DataValues/UriValueTest.php
+++ b/tests/phpunit/includes/DataValues/UriValueTest.php
@@ -28,7 +28,7 @@ class UriValueTest extends \PHPUnit_Framework_TestCase {
 	/**
 	 * @dataProvider uriProvider
 	 */
-	public function testUriOutputFormatting( $uri, $caption = false, $linker = null, $expected ) {
+	public function testUriOutputFormatting( $uri, $caption, $linker, $expected ) {
 
 		$instance = new UriValue( '_uri' );
 		$instance->setUserValue( $uri, $caption );
@@ -43,7 +43,7 @@ class UriValueTest extends \PHPUnit_Framework_TestCase {
 	/**
 	 * @dataProvider uriProvider
 	 */
-	public function testAnuOutputFormatting( $uri, $caption = false, $linker = null, $expected ) {
+	public function testAnuOutputFormatting( $uri, $caption, $linker, $expected ) {
 
 		$instance = new UriValue( '_anu' );
 		$instance->setUserValue( $uri, $caption );
@@ -58,7 +58,7 @@ class UriValueTest extends \PHPUnit_Framework_TestCase {
 	/**
 	 * @dataProvider telProvider
 	 */
-	public function testTelOutputFormatting( $uri, $caption = false, $linker = null, $expected ) {
+	public function testTelOutputFormatting( $uri, $caption, $linker, $expected ) {
 
 		$instance = new UriValue( '_tel' );
 		$instance->setUserValue( $uri, $caption );
@@ -73,7 +73,7 @@ class UriValueTest extends \PHPUnit_Framework_TestCase {
 	/**
 	 * @dataProvider emaProvider
 	 */
-	public function testEmaOutputFormatting( $uri, $caption = false, $linker = null, $expected ) {
+	public function testEmaOutputFormatting( $uri, $caption, $linker, $expected ) {
 
 		$instance = new UriValue( '_ema' );
 		$instance->setUserValue( $uri, $caption );


### PR DESCRIPTION
This PR is made in reference to: #4701

This PR addresses or contains:

PHP 8 is stricter about functions that have required parameters after optional
ones and will generate an `E_DEPRECATED` for such functions. This patch changes
such optional parameters in SMW to required ones; it seems that all callers are
already passing them in at all times anyways, especially since several times,
the required parameters following these "optional" ones have a type hint and
would have caused the code to fail were they not provided.

With this change, there are still two deprecation warnings logged during tests
by dependencies, namely the elasticsearch client and the json-schema lib. For
the former, the latest version seems to have already resolved the issue, while
for the latter, the issue is fixed on master but no new release with the fix has
been published yet.

This PR includes:
- [x] Tests (unit/integration)
- [ ] CI build passed
