### PR TITLE
Check for `PropertyLabelNotResolvedException`, refs 4157

### DIFF
--- a/src/SQLStore/EntityStore/CacheWarmer.php
+++ b/src/SQLStore/EntityStore/CacheWarmer.php
@@ -11,6 +11,7 @@ use Iterator;
 use SMW\MediaWiki\LinkBatch;
 use SMW\DisplayTitleFinder;
 use SMW\Exception\PredefinedPropertyLabelMismatchException;
+use SMW\Exception\PropertyLabelNotResolvedException;
 
 /**
  * @license GNU GPL v2+
@@ -99,6 +100,8 @@ class CacheWarmer {
 					try {
 						$property = DIProperty::newFromUserLabel( $item->getDBKey() );
 					} catch ( PredefinedPropertyLabelMismatchException $e ) {
+						continue;
+					} catch ( PropertyLabelNotResolvedException $e ) {
 						continue;
 					}
 					$hash = $item->getSha1();

--- a/src/SQLStore/EntityStore/EntityIdManager.php
+++ b/src/SQLStore/EntityStore/EntityIdManager.php
@@ -529,6 +529,8 @@ class EntityIdManager {
 				$property = DIProperty::newFromUserLabel( $subject->getDBKey() );
 			} catch( \SMW\Exception\PredefinedPropertyLabelMismatchException $e ) {
 				return 0;
+			} catch( \SMW\Exception\PropertyLabelNotResolvedException $e ) {
+				return 0;
 			}
 
 			$key = $property->getKey();


### PR DESCRIPTION
This PR is made in reference to: #4157

This PR addresses or contains:

- Catch `PropertyLabelNotResolvedException` for a predefined property no longer in existence 

This PR includes:
- [ ] Tests (unit/integration)
- [x] CI build passed

```
exception] [a492df26262acd221e29bc58] /mw-master/index.php?title=Special:Ask&   SMW\Exception\PropertyLabelNotResolvedException from line 92 of ...\extensions\SemanticMediaWiki\includes\dataitems\SMW_DI_Property.php: Illegal property key "".
#0 ...\extensions\SemanticMediaWiki\includes\dataitems\SMW_DI_Property.php(539): SMW\DIProperty->__construct(string, boolean)
#1 ...\extensions\SemanticMediaWiki\src\SQLStore\EntityStore\CacheWarmer.php(100): SMW\DIProperty::newFromUserLabel(string)
#2 ...\extensions\SemanticMediaWiki\src\SQLStore\EntityStore\EntityIdManager.php(953): SMW\SQLStore\EntityStore\CacheWarmer->prepareCache(array)
#3 ...\extensions\SemanticMediaWiki\src\SQLStore\EntityStore\PrefetchCache.php(112): SMW\SQLStore\EntityStore\EntityIdManager->warmUpCache(array)
#4 ...\extensions\SemanticMediaWiki\src\Query\Result\ItemFetcher.php(178): SMW\SQLStore\EntityStore\PrefetchCache->prefetch(array, SMW\DIProperty, SMW\RequestOptions)
#5 ...\extensions\SemanticMediaWiki\src\Query\Result\FieldItemFinder.php(359): SMW\Query\Result\ItemFetcher->fetch(array, SMW\DIProperty, SMW\RequestOptions)
#6 ...\extensions\SemanticMediaWiki\src\Query\Result\FieldItemFinder.php(237): SMW\Query\Result\FieldItemFinder->fetchContent(SMW\DIWikiPage)
#7 ...\extensions\SemanticMediaWiki\src\Query\Result\FieldItemFinder.php(181): SMW\Query\Result\FieldItemFinder->getResultsForProperty(SMW\DIWikiPage)
#8 ...\extensions\SemanticMediaWiki\src\Query\Result\ResultArray.php(330): SMW\Query\Result\FieldItemFinder->findFor(SMW\DIWikiPage)
#9 ...\extensions\SemanticMediaWiki\src\Query\Result\ResultArray.php(195): SMW\Query\Result\ResultArray->loadContent()
#10 ...\extensions\SemanticMediaWiki\src\Query\Result\ResultArray.php(230): SMW\Query\Result\ResultArray->getNextDataItem()
#11 ...\extensions\SemanticMediaWiki\src\Query\ResultPrinters\TableResultPrinter.php(241): SMW\Query\Result\ResultArray->getNextDataValue()
#12 ...\extensions\SemanticMediaWiki\src\Query\ResultPrinters\TableResultPrinter.php(222): SMW\Query\ResultPrinters\TableResultPrinter->getCellForPropVals(SMW\Query\Result\ResultArray, integer, string)
#13 ...\extensions\SemanticMediaWiki\src\Query\ResultPrinters\TableResultPrinter.php(130): SMW\Query\ResultPrinters\TableResultPrinter->getRowForSubject(array, integer, array)
#14 ...\extensions\SemanticMediaWiki\src\Query\ResultPrinters\ResultPrinter.php(337): SMW\Query\ResultPrinters\TableResultPrinter->getResultText(SMW\Query\QueryResult, integer)
#15 ...\extensions\SemanticMediaWiki\src\Query\ResultPrinters\ResultPrinter.php(302): SMW\Query\ResultPrinters\ResultPrinter->buildResult(SMW\Query\QueryResult)
#16 ...\extensions\SemanticMediaWiki\src\MediaWiki\Specials\SpecialAsk.php(501): SMW\Query\ResultPrinters\ResultPrinter->getResult(SMW\Query\QueryResult, array, integer)
#17 ...\extensions\SemanticMediaWiki\src\MediaWiki\Specials\SpecialAsk.php(315): SMW\MediaWiki\Specials\SpecialAsk->fetchResults(SMW\Query\ResultPrinters\TableResultPrinter, SMWQuery, SMW\Utils\UrlArgs)
#18 ...\extensions\SemanticMediaWiki\src\MediaWiki\Specials\SpecialAsk.php(170): SMW\MediaWiki\Specials\SpecialAsk->makeHTMLResult()
#19 ...\includes\specialpage\SpecialPage.php(575): SMW\MediaWiki\Specials\SpecialAsk->execute(NULL)
#20 ...\includes\specialpage\SpecialPageFactory.php(621): SpecialPage->run(NULL)
#21 ...\includes\MediaWiki.php(298): MediaWiki\Special\SpecialPageFactory->executePath(Title, RequestContext)
#22 ...\includes\MediaWiki.php(971): MediaWiki->performRequest()
#23 ...\includes\MediaWiki.php(534): MediaWiki->main()
#24 ...\index.php(47): MediaWiki->run()
```