### PR TITLE
Isolate `Hooks::run` in `Setup`, refs 4478

### DIFF
--- a/docs/technical/hooks/hook.grouppermissions.beforeinitializationcomplete.md
+++ b/docs/technical/hooks/hook.grouppermissions.beforeinitializationcomplete.md
@@ -11,6 +11,12 @@ use Hooks;
 
 Hooks::register( 'SMW::GroupPermissions::BeforeInitializationComplete', function( &$permissions ) {
 
+	// Assignments have the form of:
+	// $permissions['smw_group_x'] = [ 'right_x' => true, 'right_y' => true ];
+
+	// Rights added by Semantic MediaWiki are listed in the
+	// `GroupPermissions` class
+
 	return true;
 } );
 ```

--- a/docs/technical/hooks/hook.setup.afterinitializationcomplete.md
+++ b/docs/technical/hooks/hook.setup.afterinitializationcomplete.md
@@ -1,3 +1,5 @@
+## SMW::Setup::AfterInitializationComplete
+
 * Since: 3.0
 * Description: Hook allows to modify global configuration after initialization of Semantic MediaWiki is completed.
 * Reference class: [`Setup.php`][Setup.php]
@@ -10,6 +12,8 @@ use Hooks;
 Hooks::register( 'SMW::Setup::AfterInitializationComplete', function( &$vars ) {
 
 	// #2565
+	// It is suggested to use `SMW::GroupPermissions::BeforeInitializationComplete` for
+	// the following case:
 	unset( $vars['wgGroupPermissions']['smwcurator'] );
 
 	return true;

--- a/src/MediaWiki/HookDispatcher.php
+++ b/src/MediaWiki/HookDispatcher.php
@@ -82,6 +82,16 @@ class HookDispatcher {
 	}
 
 	/**
+	 * @see https://github.com/SemanticMediaWiki/SemanticMediaWiki/blob/master/docs/technical/hookshook.setup.afterinitializationcomplete.md
+	 * @since 3.2
+	 *
+	 * @param array &$vars
+	 */
+	public function onSetupAfterInitializationComplete( array &$vars ) {
+		Hooks::run( 'SMW::Setup::AfterInitializationComplete', [ &$vars ] );
+	}
+
+	/**
 	 * @see https://github.com/SemanticMediaWiki/SemanticMediaWiki/blob/master/docs/technical/hooks/hook.grouppermissions.beforeinitializationcomplete.md
 	 * @since 3.2
 	 *

--- a/src/Setup.php
+++ b/src/Setup.php
@@ -157,7 +157,7 @@ final class Setup {
 		$this->registerFooterIcon( $vars, $rootDir );
 		$this->registerHooks( $vars, $rootDir );
 
-		\Hooks::run( 'SMW::Setup::AfterInitializationComplete', [ &$vars ] );
+		$this->hookDispatcher->onSetupAfterInitializationComplete( $vars );
 	}
 
 	private function addDefaultConfigurations( &$vars, $rootDir ) {

--- a/tests/phpunit/Integration/MediaWiki/HookDispatcherTest.php
+++ b/tests/phpunit/Integration/MediaWiki/HookDispatcherTest.php
@@ -51,6 +51,24 @@ class HookDispatcherTest extends \PHPUnit_Framework_TestCase {
 		);
 	}
 
+	public function testOnSetupAfterInitializationComplete() {
+
+		$vars = [];
+
+		$hookDispatcher = new HookDispatcher();
+
+		$this->mwHooksHandler->register( 'SMW::Setup::AfterInitializationComplete', function( &$vars ) {
+			$vars = [ 'Foo' ];
+		} );
+
+		$hookDispatcher->onSetupAfterInitializationComplete( $vars );
+
+		$this->assertEquals(
+			[ 'Foo' ],
+			$vars
+		);
+	}
+
 	public function testOnGroupPermissionsBeforeInitializationComplete() {
 
 		$permissions = [];

--- a/tests/phpunit/Unit/SetupTest.php
+++ b/tests/phpunit/Unit/SetupTest.php
@@ -120,6 +120,22 @@ class SetupTest extends \PHPUnit_Framework_TestCase {
 		);
 	}
 
+	public function testHookRunOnSetupAfterInitializationComplete() {
+
+		$this->hookDispatcher->expects( $this->once() )
+			->method( 'onSetupAfterInitializationComplete' );
+
+		$config = $this->defaultConfig;
+
+		$instance = new Setup();
+
+		$instance->setHookDispatcher(
+			$this->hookDispatcher
+		);
+
+		$instance->init( $config, '' );
+	}
+
 	/**
 	 * @dataProvider jobClassesDataProvider
 	 */

--- a/tests/phpunit/Utils/MwHooksHandler.php
+++ b/tests/phpunit/Utils/MwHooksHandler.php
@@ -34,6 +34,7 @@ class MwHooksHandler {
 		//	'SMW::DataType::initTypes',
 
 		'SMW::Settings::BeforeInitializationComplete',
+		'SMW::Setup::AfterInitializationComplete',
 		'SMW::GroupPermissions::BeforeInitializationComplete',
 
 		'smwInitProperties',


### PR DESCRIPTION
This PR is made in reference to: #4478

This PR addresses or contains:

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed
