### PR TITLE
Tidy (Exporter/Serializer)

### DIFF
--- a/src/Aliases.php
+++ b/src/Aliases.php
@@ -8,6 +8,9 @@
 class_alias( \SMW\Localizer\Localizer::class, '\SMW\Localizer' );
 class_alias( \SMW\Localizer\Message::class, '\SMW\Message' );
 class_alias( \SMW\Localizer\LocalLanguage\LocalLanguage::class, '\SMW\Lang\Lang' );
+class_alias( \SMW\Exporter\Serializer\Serializer::class, '\SMWSerializer' );
+class_alias( \SMW\Exporter\Serializer\TurtleSerializer::class, '\SMWTurtleSerializer' );
+class_alias( \SMW\Exporter\Serializer\RDFXMLSerializer::class, '\SMWRDFXMLSerializer' );
 
 // 3.1
 class_alias( \SMW\Query\ResultPrinters\RdfResultPrinter::class, 'SMWRDFResultPrinter' );

--- a/src/Defines.php
+++ b/src/Defines.php
@@ -16,6 +16,14 @@ define( 'SMW_SPECIAL_SEARCHTYPE', 'SMWSearch' );
 /**@}*/
 
 /**@{
+  * Constants for the exporter/OWL serializer
+  */
+define( 'SMW_SERIALIZER_DECL_CLASS', 1 );
+define( 'SMW_SERIALIZER_DECL_OPROP', 2 );
+define( 'SMW_SERIALIZER_DECL_APROP', 4 );
+/**@}*/
+
+/**@{
   * Constants to indicate that the installer is called from the `ExtensionSchemaUpdates`
   * hook.
   */

--- a/tests/phpunit/Unit/Exporter/Serializer/RDFXMLSerializerTest.php
+++ b/tests/phpunit/Unit/Exporter/Serializer/RDFXMLSerializerTest.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace SMW\Tests\Exporter\Serializer;
+
+use SMW\DIProperty;
+use SMW\DIWikiPage;
+use SMW\Exporter\Serializer\RDFXMLSerializer;
+use SMW\Tests\PHPUnitCompat;
+use SMWExpData as ExpData;
+use SMW\Exporter\Element\ExpNsResource;
+use SMW\Exporter\Element\ExpLiteral;
+
+/**
+ * @covers \SMW\Exporter\Serializer\RDFXMLSerializer
+ * @group semantic-mediawiki
+ *
+ * @license GNU GPL v2+
+ * @since 3.2
+ *
+ * @author mwjames
+ */
+class RDFXMLSerializerTest extends \PHPUnit_Framework_TestCase {
+
+	use PHPUnitCompat;
+
+	public function testFlushContent_Empty() {
+
+		$instance = new RDFXMLSerializer();
+		$instance->startSerialization();
+		$instance->finishSerialization();
+
+		$this->assertContains(
+			'<?xml version="1.0" encoding="UTF-8"?>',
+			$instance->flushContent()
+		);
+	}
+
+	public function testFlushContent_EmptyElement() {
+
+		$expData = new ExpData(
+			new ExpNsResource( 'Foobar', 'Bar', 'Mo', null )
+		);
+
+		$instance = new RDFXMLSerializer();
+
+		$instance->startSerialization();
+		$instance->serializeExpData( $expData );
+		$instance->finishSerialization();
+
+		$this->assertContains(
+			'<rdf:Resource rdf:about="BarFoobar" />',
+			$instance->flushContent()
+		);
+	}
+
+	public function testFlushContent_SingleElement() {
+
+		$expData = new ExpData(
+			new ExpNsResource( 'Foobar', 'Bar', 'ns:Mo', null )
+		);
+
+		$expData->addPropertyObjectValue(
+			new ExpNsResource( 'Li', 'La', 'ns:Lu', null ),
+			new ExpLiteral( 'Foo', 'Bar' )
+		);
+
+		$instance = new RDFXMLSerializer();
+
+		$instance->startSerialization();
+		$instance->serializeExpData( $expData );
+		$instance->finishSerialization();
+
+		$this->assertContains(
+			"	<rdf:Resource rdf:about=\"BarFoobar\">\n" .
+			"		<ns:Lu:Li rdf:datatype=\"Bar\">Foo</ns:Lu:Li>\n" .
+			"	</rdf:Resource>\n" .
+			"	<owl:DatatypeProperty rdf:about=\"LaLi\" />\n",
+			$instance->flushContent()
+		);
+	}
+
+}

--- a/tests/phpunit/Unit/Exporter/Serializer/TurtleSerializerTest.php
+++ b/tests/phpunit/Unit/Exporter/Serializer/TurtleSerializerTest.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace SMW\Tests\Exporter\Serializer;
+
+use SMW\DIProperty;
+use SMW\DIWikiPage;
+use SMW\Exporter\Serializer\TurtleSerializer;
+use SMW\Tests\PHPUnitCompat;
+use SMWExpData as ExpData;
+use SMW\Exporter\Element\ExpNsResource;
+use SMW\Exporter\Element\ExpLiteral;
+
+/**
+ * @covers \SMW\Exporter\Serializer\TurtleSerializer
+ * @group semantic-mediawiki
+ *
+ * @license GNU GPL v2+
+ * @since 3.2
+ *
+ * @author mwjames
+ */
+class TurtleSerializerTest extends \PHPUnit_Framework_TestCase {
+
+	use PHPUnitCompat;
+
+	public function testFlushContent_Empty() {
+
+		$instance = new TurtleSerializer();
+		$instance->startSerialization();
+		$instance->finishSerialization();
+
+		$this->assertContains(
+			'@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>',
+			$instance->flushContent()
+		);
+	}
+
+	public function testFlushContent_SingleElement() {
+
+		$expData = new ExpData(
+			new ExpNsResource( 'Foobar', 'Bar', 'ns:Mo', null )
+		);
+
+		$expData->addPropertyObjectValue(
+			new ExpNsResource( 'Li', 'La', 'ns:Lu', null ),
+			new ExpLiteral( 'Foo', 'Bar' )
+		);
+
+		$instance = new TurtleSerializer();
+
+		$instance->startSerialization();
+		$instance->serializeExpData( $expData );
+		$instance->finishSerialization();
+
+		$this->assertContains(
+			"ns:Mo:Foobar\n" .
+			" 	ns:Lu:Li  \"Foo\"^^<Bar> .\n",
+			$instance->flushContent()
+		);
+	}
+
+}


### PR DESCRIPTION
This PR is made in reference to: #

This PR addresses or contains:

- Moves `SMWSerializer` to `\SMW\Exporter\Serializer\Serializer`
- Moves `SMWTurtleSerializer` to `\SMW\Exporter\Serializer\TurtleSerializer`
- Moves `SMWRDFXMLSerializer` to `\SMW\Exporter\Serializer\RDFXMLSerializer`


This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed
