### PR TITLE
Isolate `Hooks::run` in `ConstraintRegistry`, refs 4478

### DIFF
--- a/src/Constraint/ConstraintRegistry.php
+++ b/src/Constraint/ConstraintRegistry.php
@@ -11,6 +11,7 @@ use SMW\Constraint\Constraints\MustExistsConstraint;
 use SMW\Constraint\Constraints\SingleValueConstraint;
 use SMW\Constraint\Constraints\MandatoryPropertiesConstraint;
 use SMW\Constraint\Constraints\ShapeConstraint;
+use SMW\MediaWiki\HookDispatcherAwareTrait;
 
 /**
  * @license GNU GPL v2+
@@ -19,6 +20,8 @@ use SMW\Constraint\Constraints\ShapeConstraint;
  * @author mwjames
  */
 class ConstraintRegistry {
+
+	use HookDispatcherAwareTrait;
 
 	/**
 	 * @var ConstraintFactory
@@ -111,7 +114,7 @@ class ConstraintRegistry {
 			'shape_constraint' => ShapeConstraint::class
 		];
 
-		\Hooks::run( 'SMW::Constraint::initConstraints', [ $this ] );
+		$this->hookDispatcher->onInitConstraints( $this );
 	}
 
 	private function loadInstance( $class ) {

--- a/src/ConstraintFactory.php
+++ b/src/ConstraintFactory.php
@@ -33,7 +33,18 @@ class ConstraintFactory {
 	 * @return ConstraintRegistry
 	 */
 	public function newConstraintRegistry() {
-		return new ConstraintRegistry( $this );
+
+		$applicationFactory = ApplicationFactory::getInstance();
+
+		$constraintRegistry = new ConstraintRegistry(
+			$this
+		);
+
+		$constraintRegistry->setHookDispatcher(
+			$applicationFactory->getHookDispatcher()
+		);
+
+		return $constraintRegistry;
 	}
 
 	/**

--- a/src/MediaWiki/HookDispatcher.php
+++ b/src/MediaWiki/HookDispatcher.php
@@ -11,6 +11,7 @@ use SMW\Parser\AnnotationProcessor;
 use SMW\Property\Annotator as PropertyAnnotator;
 use Onoi\MessageReporter\MessageReporter;
 use SMW\Schema\SchemaTypes;
+use SMW\Constraint\ConstraintRegistry;
 use SMW\Listener\ChangeListener\ChangeListeners\PropertyChangeListener;
 use SMW\MediaWiki\Specials\Admin\OutputFormatter;
 use SMW\MediaWiki\Specials\Admin\TaskHandlerRegistry;
@@ -56,6 +57,16 @@ class HookDispatcher {
 	 */
 	public function onRegisterPropertyChangeListeners( PropertyChangeListener $propertyChangeListener ) {
 		Hooks::run( 'SMW::Listener::ChangeListener::RegisterPropertyChangeListeners', [ $propertyChangeListener ] );
+	}
+
+	/**
+	 * @see https://github.com/SemanticMediaWiki/SemanticMediaWiki/blob/master/docs/technical/hooks/hook.constraint.initconstraints.md
+	 * @since 3.2
+	 *
+	 * @param ConstraintRegistry $constraintRegistry
+	 */
+	public function onInitConstraints( ConstraintRegistry $constraintRegistry ) {
+		Hooks::run( 'SMW::Constraint::initConstraints', [ $constraintRegistry ] );
 	}
 
 	/**

--- a/tests/phpunit/Integration/Constraint/ConstraintRegistryFactoryTest.php
+++ b/tests/phpunit/Integration/Constraint/ConstraintRegistryFactoryTest.php
@@ -20,8 +20,16 @@ class ConstraintRegistryFactoryTest extends \PHPUnit_Framework_TestCase {
 	 */
 	public function testGetConstraint( $key ) {
 
+		$hookDispatcher = $this->getMockBuilder( '\SMW\MediaWiki\HookDispatcher' )
+			->disableOriginalConstructor()
+			->getMock();
+
 		$instance = new ConstraintRegistry(
 			ApplicationFactory::getInstance()->create( 'ConstraintFactory' )
+		);
+
+		$instance->setHookDispatcher(
+			$hookDispatcher
 		);
 
 		$this->assertInstanceOf(
@@ -32,8 +40,16 @@ class ConstraintRegistryFactoryTest extends \PHPUnit_Framework_TestCase {
 
 	public function constraintKeyProvider() {
 
+		$hookDispatcher = $this->getMockBuilder( '\SMW\MediaWiki\HookDispatcher' )
+			->disableOriginalConstructor()
+			->getMock();
+
 		$instance = new ConstraintRegistry(
 			ApplicationFactory::getInstance()->create( 'ConstraintFactory' )
+		);
+
+		$instance->setHookDispatcher(
+			$hookDispatcher
 		);
 
 		foreach ( $instance->getConstraintKeys() as $key ) {

--- a/tests/phpunit/Integration/MediaWiki/HookDispatcherTest.php
+++ b/tests/phpunit/Integration/MediaWiki/HookDispatcherTest.php
@@ -143,6 +143,24 @@ class HookDispatcherTest extends \PHPUnit_Framework_TestCase {
 		$hookDispatcher->onRegisterPropertyChangeListeners( $propertyChangeListener );
 	}
 
+	public function testOnInitConstraints() {
+
+		$hookDispatcher = new HookDispatcher();
+
+		$constraintRegistry = $this->getMockBuilder( '\SMW\Constraint\ConstraintRegistry' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$constraintRegistry->expects( $this->once() )
+			->method( 'registerConstraint' );
+
+		$this->mwHooksHandler->register( 'SMW::Constraint::initConstraints', function( $constraintRegistry ) {
+			$constraintRegistry->registerConstraint( 'foo', 'bar' );
+		} );
+
+		$hookDispatcher->onInitConstraints( $constraintRegistry );
+	}
+
 	public function testOnRegisterSchemaTypes() {
 
 		$hookDispatcher = new HookDispatcher();

--- a/tests/phpunit/Unit/Constraint/ConstraintRegistryTest.php
+++ b/tests/phpunit/Unit/Constraint/ConstraintRegistryTest.php
@@ -20,10 +20,15 @@ class ConstraintRegistryTest extends \PHPUnit_Framework_TestCase {
 	use PHPUnitCompat;
 
 	private $constraintFactory;
+	private $hookDispatcher;
 
 	protected function setUp() : void {
 
 		$this->constraintFactory = $this->getMockBuilder( '\SMW\ConstraintFactory' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$this->hookDispatcher = $this->getMockBuilder( '\SMW\MediaWiki\HookDispatcher' )
 			->disableOriginalConstructor()
 			->getMock();
 	}
@@ -42,10 +47,30 @@ class ConstraintRegistryTest extends \PHPUnit_Framework_TestCase {
 			$this->constraintFactory
 		);
 
+		$instance->setHookDispatcher(
+			$this->hookDispatcher
+		);
+
 		$this->assertInternalType(
 			'array',
 			$instance->getConstraintKeys()
 		);
+	}
+
+	public function testRunHookOnInitConstraints() {
+
+		$this->hookDispatcher->expects( $this->once() )
+			->method( 'onInitConstraints' );
+
+		$instance = new ConstraintRegistry(
+			$this->constraintFactory
+		);
+
+		$instance->setHookDispatcher(
+			$this->hookDispatcher
+		);
+
+		$instance->getConstraintKeys();
 	}
 
 	public function testGetConstraintByUnkownKey() {
@@ -63,6 +88,10 @@ class ConstraintRegistryTest extends \PHPUnit_Framework_TestCase {
 			$this->constraintFactory
 		);
 
+		$instance->setHookDispatcher(
+			$this->hookDispatcher
+		);
+
 		$instance->getConstraintByKey( '__unknown__' );
 	}
 
@@ -74,6 +103,10 @@ class ConstraintRegistryTest extends \PHPUnit_Framework_TestCase {
 
 		$instance = new ConstraintRegistry(
 			$this->constraintFactory
+		);
+
+		$instance->setHookDispatcher(
+			$this->hookDispatcher
 		);
 
 		$instance->registerConstraint( 'foo', $constraint );
@@ -92,6 +125,10 @@ class ConstraintRegistryTest extends \PHPUnit_Framework_TestCase {
 
 		$instance = new ConstraintRegistry(
 			$this->constraintFactory
+		);
+
+		$instance->setHookDispatcher(
+			$this->hookDispatcher
 		);
 
 		$instance->registerConstraint( 'foo', function() use( $constraint ) {
@@ -119,6 +156,10 @@ class ConstraintRegistryTest extends \PHPUnit_Framework_TestCase {
 			$this->constraintFactory
 		);
 
+		$instance->setHookDispatcher(
+			$this->hookDispatcher
+		);
+
 		$instance->registerConstraint( 'foo', '__class__' );
 
 		$this->assertInstanceOf(
@@ -143,6 +184,10 @@ class ConstraintRegistryTest extends \PHPUnit_Framework_TestCase {
 
 		$instance = new ConstraintRegistry(
 			$this->constraintFactory
+		);
+
+		$instance->setHookDispatcher(
+			$this->hookDispatcher
 		);
 
 		$instance->getConstraintByKey( $key );

--- a/tests/phpunit/Utils/MwHooksHandler.php
+++ b/tests/phpunit/Utils/MwHooksHandler.php
@@ -39,6 +39,7 @@ class MwHooksHandler {
 
 		'smwInitProperties',
 		'SMW::Property::initProperties',
+		'SMW::Constraint::initConstraints',
 		'SMW::Factbox::BeforeContentGeneration',
 		'SMW::SQLStore::updatePropertyTableDefinitions',
 		'SMW::Store::BeforeQueryResultLookupComplete',


### PR DESCRIPTION
This PR is made in reference to: #4478

This PR addresses or contains:

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed
