### PR TITLE
Make `AssociatedRevisionMismatch` a deferred examiner, refs 4698

### DIFF
--- a/i18n/en.json
+++ b/i18n/en.json
@@ -1100,6 +1100,7 @@
 	"smw-entity-examiner-deferred-check-awaiting-response": "The \"$1\" examiner is currently awaiting a response from the backend.",
 	"smw-entity-examiner-deferred-elastic-replication": "Elastic",
 	"smw-entity-examiner-deferred-constraint-error": "Constraint",
+	"smw-entity-examiner-associated-revision-mismatch": "Revision",
 	"smw-entity-examiner-deferred-fake": "Fake",
 	"smw-entity-examiner-indicator-suggestions": "As part of the entity examination, the following {{PLURAL:$1|issue was|issues were}} found and it is suggested to carefully review {{PLURAL:$1|the issue|them}} and take appropriate {{PLURAL:$1|action|actions}}.",
 	"smw-indicator-constraint-violation": "{{PLURAL:$1|Constraint|Constraints}}",

--- a/src/Indicator/EntityExaminerIndicatorsFactory.php
+++ b/src/Indicator/EntityExaminerIndicatorsFactory.php
@@ -37,7 +37,6 @@ class EntityExaminerIndicatorsFactory {
 		$servicesFactory = ServicesFactory::getInstance();
 
 		$indicatorProviders = [
-			$this->newAssociatedRevisionMismatchEntityExaminerIndicatorProvider( $store ),
 			$this->newEntityExaminerDeferrableCompositeIndicatorProvider( $store )
 		];
 
@@ -114,6 +113,7 @@ class EntityExaminerIndicatorsFactory {
 		);
 
 		$indicatorProviders = [
+			$this->newAssociatedRevisionMismatchEntityExaminerIndicatorProvider( $store ),
 			$constraintErrorEntityExaminerIndicatorProvider,
 
 			// Example of how to a add deferreable indicator; the `blank` can

--- a/src/MediaWiki/Api/Task.php
+++ b/src/MediaWiki/Api/Task.php
@@ -50,10 +50,10 @@ class Task extends ApiBase {
 		}
 
 		$this->taskFactory = new TaskFactory();
-		$task = $this->taskFactory->newByType( $params['task'] );
+		$task = $this->taskFactory->newByType( $params['task'], $this->getUser() );
 
 		// If the `uselang` isn't set then inject the language from the
-		// user logged-on
+		// logged-in user
 		if ( !isset( $parameters['uselang'] ) || $parameters['uselang'] === '' ) {
 			$parameters['uselang'] = $this->getLanguage()->getCode();
 		}

--- a/src/MediaWiki/Api/TaskFactory.php
+++ b/src/MediaWiki/Api/TaskFactory.php
@@ -13,6 +13,7 @@ use SMW\MediaWiki\Api\Tasks\TableStatisticsTask;
 use SMW\MediaWiki\Api\Tasks\EntityExaminerTask;
 use SMW\Indicator\EntityExaminerIndicatorsFactory;
 use RuntimeException;
+use User;
 
 /**
  * @license GNU GPL v2+
@@ -75,7 +76,7 @@ class TaskFactory {
 	 *
 	 * @throws RuntimeException
 	 */
-	public function newByType( $type ) {
+	public function newByType( $type, User $user = null ) {
 
 		$applicationFactory = ApplicationFactory::getInstance();
 		$service = null;
@@ -88,7 +89,7 @@ class TaskFactory {
 				return new CheckQueryTask( $applicationFactory->getStore() );
 				break;
 			case 'run-entity-examiner':
-				return $this->newEntityExaminerTask();
+				return $this->newEntityExaminerTask( $user );
 				break;
 			case 'duplicate-lookup':
 				return $this->newDuplicateLookupTask();
@@ -162,13 +163,17 @@ class TaskFactory {
 	 *
 	 * @return EntityExaminerTask
 	 */
-	public function newEntityExaminerTask() : EntityExaminerTask {
+	public function newEntityExaminerTask( User $user = null ) : EntityExaminerTask {
 
 		$applicationFactory = ApplicationFactory::getInstance();
 
 		$entityExaminerTask = new EntityExaminerTask(
 			$applicationFactory->getStore(),
 			new EntityExaminerIndicatorsFactory()
+		);
+
+		$entityExaminerTask->setPermissionExaminer(
+			$applicationFactory->newPermissionExaminer( $user )
 		);
 
 		return $entityExaminerTask;

--- a/src/MediaWiki/Api/Tasks/EntityExaminerTask.php
+++ b/src/MediaWiki/Api/Tasks/EntityExaminerTask.php
@@ -4,6 +4,8 @@ namespace SMW\MediaWiki\Api\Tasks;
 
 use SMW\Store;
 use SMW\DIWikiPage;
+use SMW\MediaWiki\Permission\PermissionExaminer;
+use SMW\MediaWiki\Permission\PermissionExaminerAware;
 use SMW\Services\ServicesFactory;
 use SMW\Indicator\EntityExaminerIndicatorsFactory;
 
@@ -13,7 +15,7 @@ use SMW\Indicator\EntityExaminerIndicatorsFactory;
  *
  * @author mwjames
  */
-class EntityExaminerTask extends Task {
+class EntityExaminerTask extends Task implements PermissionExaminerAware {
 
 	/**
 	 * @var Store
@@ -26,6 +28,11 @@ class EntityExaminerTask extends Task {
 	private $entityExaminerIndicatorsFactory;
 
 	/**
+	 * @var PermissionExaminer
+	 */
+	private $permissionExaminer;
+
+	/**
 	 * @since 3.2
 	 *
 	 * @param Store $store
@@ -34,6 +41,16 @@ class EntityExaminerTask extends Task {
 	public function __construct( Store $store, EntityExaminerIndicatorsFactory $entityExaminerIndicatorsFactory ) {
 		$this->store = $store;
 		$this->entityExaminerIndicatorsFactory = $entityExaminerIndicatorsFactory;
+	}
+
+	/**
+	 * @see PermissionExaminerAware::setPermissionExaminer
+	 * @since 3.2
+	 *
+	 * @param PermissionExaminer $permissionExaminer
+	 */
+	public function setPermissionExaminer( PermissionExaminer $permissionExaminer ) {
+		$this->permissionExaminer = $permissionExaminer;
 	}
 
 	/**
@@ -87,6 +104,12 @@ class EntityExaminerTask extends Task {
 			$this->store
 		);
 
+		if ( $this->permissionExaminer instanceof PermissionExaminer ) {
+			$entityExaminerDeferrableCompositeIndicatorProvider->setPermissionExaminer(
+				$this->permissionExaminer
+			);
+		}
+
 		$entityExaminerDeferrableCompositeIndicatorProvider->setDeferredMode(
 			true
 		);
@@ -103,6 +126,12 @@ class EntityExaminerTask extends Task {
 				$entityExaminerDeferrableCompositeIndicatorProvider
 			]
 		);
+
+		if ( $this->permissionExaminer instanceof PermissionExaminer ) {
+			$entityExaminerCompositeIndicatorProvider->setPermissionExaminer(
+				$this->permissionExaminer
+			);
+		}
 
 		return $entityExaminerCompositeIndicatorProvider;
 	}

--- a/src/MediaWiki/IndicatorRegistry.php
+++ b/src/MediaWiki/IndicatorRegistry.php
@@ -8,6 +8,7 @@ use SMW\DIWikiPage;
 use SMW\Indicator\IndicatorProvider;
 use SMW\MediaWiki\Permission\PermissionExaminer;
 use SMW\MediaWiki\Permission\PermissionAware;
+use SMW\MediaWiki\Permission\PermissionExaminerAware;
 
 /**
  * @license GNU GPL v2+
@@ -67,6 +68,10 @@ class IndicatorRegistry {
 		);
 
 		foreach ( $this->indicatorProviders as $indicatorProvider ) {
+
+			if ( $indicatorProvider instanceof PermissionExaminerAware ) {
+				$indicatorProvider->setPermissionExaminer( $permissionExaminer );
+			}
 
 			if (
 				$indicatorProvider instanceof PermissionAware &&

--- a/src/MediaWiki/Permission/PermissionExaminerAware.php
+++ b/src/MediaWiki/Permission/PermissionExaminerAware.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace SMW\MediaWiki\Permission;
+
+/**
+ * @license GNU GPL v2
+ * @since 3.2
+ *
+ * @author mwjames
+ */
+interface PermissionExaminerAware {
+
+	/**
+	 * @since 3.2
+	 *
+	 * @param PermissionExaminer $permissionExaminer
+	 */
+	public function setPermissionExaminer( PermissionExaminer $permissionExaminer );
+
+}

--- a/tests/phpunit/Unit/Indicator/EntityExaminerIndicators/AssociatedRevisionMismatchEntityExaminerIndicatorProviderTest.php
+++ b/tests/phpunit/Unit/Indicator/EntityExaminerIndicators/AssociatedRevisionMismatchEntityExaminerIndicatorProviderTest.php
@@ -177,6 +177,10 @@ class AssociatedRevisionMismatchEntityExaminerIndicatorProviderTest extends \PHP
 			$this->store
 		);
 
+		$instance->setDeferredMode(
+			true
+		);
+
 		$instance->setRevisionGuard(
 			$this->revisionGuard
 		);
@@ -204,6 +208,10 @@ class AssociatedRevisionMismatchEntityExaminerIndicatorProviderTest extends \PHP
 
 		$instance = new AssociatedRevisionMismatchEntityExaminerIndicatorProvider(
 			$this->store
+		);
+
+		$instance->setDeferredMode(
+			true
 		);
 
 		$instance->setRevisionGuard(
@@ -241,6 +249,10 @@ class AssociatedRevisionMismatchEntityExaminerIndicatorProviderTest extends \PHP
 
 		$instance = new AssociatedRevisionMismatchEntityExaminerIndicatorProvider(
 			$this->store
+		);
+
+		$instance->setDeferredMode(
+			true
 		);
 
 		$instance->setRevisionGuard(

--- a/tests/phpunit/Unit/MediaWiki/Api/Tasks/EntityExaminerTaskTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Api/Tasks/EntityExaminerTaskTest.php
@@ -18,6 +18,7 @@ class EntityExaminerTaskTest extends \PHPUnit_Framework_TestCase {
 
 	private $store;
 	private $entityExaminerIndicatorsFactory;
+	private $permissionExaminer;
 	private $testEnvironment;
 
 	protected function setUp() : void {
@@ -28,6 +29,10 @@ class EntityExaminerTaskTest extends \PHPUnit_Framework_TestCase {
 		$this->store = $this->getMockBuilder( '\SMW\Store' )
 			->disableOriginalConstructor()
 			->getMockForAbstractClass();
+
+		$this->permissionExaminer = $this->getMockBuilder( '\SMW\MediaWiki\Permission\PermissionExaminer' )
+			->disableOriginalConstructor()
+			->getMock();
 
 		$this->entityExaminerIndicatorsFactory = $this->getMockBuilder( '\SMW\Indicator\EntityExaminerIndicatorsFactory' )
 			->disableOriginalConstructor()
@@ -66,6 +71,9 @@ class EntityExaminerTaskTest extends \PHPUnit_Framework_TestCase {
 			->disableOriginalConstructor()
 			->getMock();
 
+		$entityExaminerDeferrableCompositeIndicatorProvider->expects( $this->atLeastOnce() )
+			->method( 'setPermissionExaminer' );
+
 		$this->entityExaminerIndicatorsFactory->expects( $this->atLeastOnce() )
 			->method( 'newEntityExaminerDeferrableCompositeIndicatorProvider' )
 			->will( $this->returnValue( $entityExaminerDeferrableCompositeIndicatorProvider ) );
@@ -73,6 +81,10 @@ class EntityExaminerTaskTest extends \PHPUnit_Framework_TestCase {
 		$instance = new EntityExaminerTask(
 			$this->store,
 			$this->entityExaminerIndicatorsFactory
+		);
+
+		$instance->setPermissionExaminer(
+			$this->permissionExaminer
 		);
 
 		$this->assertEquals(
@@ -87,9 +99,15 @@ class EntityExaminerTaskTest extends \PHPUnit_Framework_TestCase {
 			->disableOriginalConstructor()
 			->getMock();
 
+		$entityExaminerDeferrableCompositeIndicatorProvider->expects( $this->atLeastOnce() )
+			->method( 'setPermissionExaminer' );
+
 		$compositeIndicatorProvider = $this->getMockBuilder( '\SMW\Indicator\EntityExaminerIndicators\EntityExaminerCompositeIndicatorProvider' )
 			->disableOriginalConstructor()
 			->getMock();
+
+		$compositeIndicatorProvider->expects( $this->atLeastOnce() )
+			->method( 'setPermissionExaminer' );
 
 		$this->entityExaminerIndicatorsFactory->expects( $this->atLeastOnce() )
 			->method( 'newEntityExaminerDeferrableCompositeIndicatorProvider' )
@@ -102,6 +120,10 @@ class EntityExaminerTaskTest extends \PHPUnit_Framework_TestCase {
 		$instance = new EntityExaminerTask(
 			$this->store,
 			$this->entityExaminerIndicatorsFactory
+		);
+
+		$instance->setPermissionExaminer(
+			$this->permissionExaminer
 		);
 
 		$this->assertEquals(

--- a/tests/phpunit/Unit/MediaWiki/IndicatorRegistryTest.php
+++ b/tests/phpunit/Unit/MediaWiki/IndicatorRegistryTest.php
@@ -99,6 +99,26 @@ class IndicatorRegistryTest extends \PHPUnit_Framework_TestCase {
 		$instance->hasIndicator( $title, $this->permissionExaminer, [] );
 	}
 
+	public function testPermissionAwareIndicatorProvider() {
+
+		$title = $this->getMockBuilder( '\Title' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$title->expects( $this->once() )
+			->method( 'getNamespace' )
+			->will( $this->returnValue( NS_MAIN ) );
+
+		$this->permissionExaminer->expects( $this->once() )
+			->method( 'hasPermissionOf' )
+			->will( $this->returnValue( false ) );
+
+		$instance = new IndicatorRegistry();
+		$instance->addIndicatorProvider( $this->newPermissionExaminerAwareIndicatorProvider() );
+
+		$instance->hasIndicator( $title, $this->permissionExaminer, [] );
+	}
+
 	private function newPermissionAwareIndicatorProvider() {
 		return new class() implements \SMW\Indicator\IndicatorProvider, \SMW\MediaWiki\Permission\PermissionAware {
 
@@ -124,6 +144,36 @@ class IndicatorRegistryTest extends \PHPUnit_Framework_TestCase {
 
 			public function hasPermission( \SMW\MediaWiki\Permission\PermissionExaminer $permissionExaminer ) : bool {
 				return $permissionExaminer->hasPermissionOf( 'Foo' );
+			}
+		};
+	}
+
+	private function newPermissionExaminerAwareIndicatorProvider() {
+		return new class() implements \SMW\Indicator\IndicatorProvider, \SMW\MediaWiki\Permission\PermissionExaminerAware {
+
+			public function getName() : string {
+				return '';
+			}
+
+			public function getInlineStyle() {
+				return '';
+			}
+
+			public function hasIndicator( \SMW\DIWikiPage $subject, array $options) {
+				return false;
+			}
+
+			public function getModules() {
+				return [];
+			}
+
+			public function getIndicators() {
+				return [];
+			}
+
+			public function setPermissionExaminer( \SMW\MediaWiki\Permission\PermissionExaminer $permissionExaminer ) {
+				// Just used as an example to check that the setter is run
+				$permissionExaminer->hasPermissionOf( 'Foo' );
 			}
 		};
 	}


### PR DESCRIPTION
This PR is made in reference to: #4698

This PR addresses or contains:

- In MW 1.34+ the deferred update is showing more lag than in any other MW release making it possible that revision examination (which runs on a GET request) is executed before the actual storage has been completed and is creating false positives hence the `AssociatedRevisionMismatch` examiner is moved to a `DeferrableIndicatorProvider`
- #4698 missed to forward the `PermissionExaminer` for registered composite entity examiners which has been corrected as well

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed
