### PR TITLE
Add `ExporterFactory` and `ExpDataFactory`

### DIFF
--- a/includes/export/SMW_Exporter.php
+++ b/includes/export/SMW_Exporter.php
@@ -514,8 +514,28 @@ class SMWExporter {
 		}
 	}
 
+	/**
+	 * Create an ExpNsResource for some special element that belongs to
+	 * a known vocabulary. An exception is generated when given parameters
+	 * that do not fit any known vocabulary.
+	 *
+	 * @param $namespaceId string (e.g. "rdf")
+	 * @param $localName string (e.g. "type")
+	 *
+	 * @return ExpNsResource
+	 */
+	public function newExpNsResourceById( $namespaceId, $localName ) {
+		$namespace = self::getNamespaceUri( $namespaceId );
+
+		if ( $namespace !== '' ) {
+			return new ExpNsResource( $localName, $namespace, $namespaceId );
+		}
+
+		throw new InvalidArgumentException( "The vocabulary '$namespaceId' is not a known special vocabulary." );
+	}
 
 	/**
+	 * @deprecated since 3.2, use
 	 * Create an ExpNsResource for some special element that belongs to
 	 * a known vocabulary. An exception is generated when given parameters
 	 * that do not fit any known vocabulary.
@@ -544,7 +564,7 @@ class SMWExporter {
 	 * @param $uri string of the URI to be expanded
 	 * @return string of the expanded URI
 	 */
-	static public function expandURI( $uri ) {
+	public function expandURI( $uri ) {
 		self::initBaseURIs();
 		$uri = str_replace( [ '&wiki;', '&wikiurl;', '&property;', '&category;', '&owl;', '&rdf;', '&rdfs;', '&swivt;', '&export;' ],
 		                    [ self::$m_ent_wiki, self::$m_ent_wikiurl, self::$m_ent_property, self::$m_ent_category, 'http://www.w3.org/2002/07/owl#', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#', 'http://www.w3.org/2000/01/rdf-schema#', 'http://semantic-mediawiki.org/swivt/1.0#',
@@ -598,44 +618,6 @@ class SMWExporter {
 			default:
 			return '';
 		}
-	}
-
-	/**
-	 * @since 3.1
-	 *
-	 * @param string $syntax
-	 *
-	 * @return ExportSerializer
-	 */
-	public function newExportSerializer( $syntax = '' ) {
-		return $syntax === 'turtle' ? new SMWTurtleSerializer() : new SMWRDFXMLSerializer();
-	}
-
-	/**
-	 * Create an SMWExpData container that encodes the ontology header for an
-	 * SMW exported OWL file.
-	 *
-	 * @param string $ontologyuri specifying the URI of the ontology, possibly
-	 * empty
-	 *
-	 * @return SMWExpData
-	 */
-	public function newOntologyExpData( $ontologyuri ) {
-
-		$expData = new SMWExpData(
-			new SMWExpResource( $ontologyuri )
-		);
-
-		$ed = self::getSpecialNsResource( 'owl', 'Ontology' );
-		$expData->addPropertyObjectValue( self::getSpecialNsResource( 'rdf', 'type' ), $ed );
-
-		$ed = new ExpLiteral( date( DATE_W3C ), 'http://www.w3.org/2001/XMLSchema#dateTime' );
-		$expData->addPropertyObjectValue( self::getSpecialNsResource( 'swivt', 'creationDate' ), $ed );
-
-		$ed = new SMWExpResource( 'http://semantic-mediawiki.org/swivt/1.0' );
-		$expData->addPropertyObjectValue( self::getSpecialNsResource( 'owl', 'imports' ), $ed );
-
-		return $expData;
 	}
 
 	/**

--- a/includes/specials/SMW_SpecialOWLExport.php
+++ b/includes/specials/SMW_SpecialOWLExport.php
@@ -1,5 +1,7 @@
 <?php
 
+use SMW\Exporter\ExporterFactory;
+
 /**
  * This special page (Special:ExportRDF) for MediaWiki implements an OWL-export of semantic data,
  * gathered both from the annotations in articles, and from metadata already
@@ -106,6 +108,8 @@ class SMWSpecialOWLExport extends SpecialPage {
 	protected function startRDFExport() {
 		global $wgOut, $wgRequest;
 
+		$exporterFactory = new ExporterFactory();
+
 		$syntax = $wgRequest->getText( 'syntax' );
 
 		if ( $syntax === '' ) {
@@ -117,7 +121,7 @@ class SMWSpecialOWLExport extends SpecialPage {
 
 		if ( $syntax == 'turtle' ) {
 			$mimetype = 'application/x-turtle'; // may change to 'text/turtle' at some time, watch Turtle development
-			$serializer = new SMWTurtleSerializer();
+			$serializer = $exporterFactory->newTurtleSerializer();
 		} else { // rdfxml as default
 			// Only use rdf+xml mimetype if explicitly requested (browsers do
 			// not support it by default).
@@ -125,12 +129,12 @@ class SMWSpecialOWLExport extends SpecialPage {
 			// though; it is only meant to help some tools to see that HTML
 			// included resources are RDF (from there on they should be fine).
 			$mimetype = ( $wgRequest->getVal( 'xmlmime' ) == 'rdf' ) ? 'application/rdf+xml' : 'application/xml';
-			$serializer = new SMWRDFXMLSerializer();
+			$serializer = $exporterFactory->newRDFXMLSerializer();
 		}
 
 		header( "Content-type: $mimetype; charset=UTF-8" );
 
-		$this->export_controller = new SMWExportController( $serializer );
+		$this->export_controller = $exporterFactory->newExportController( $serializer );
 	}
 
 	/**

--- a/maintenance/dumpRDF.php
+++ b/maintenance/dumpRDF.php
@@ -2,8 +2,7 @@
 
 namespace SMW\Maintenance;
 
-use SMWExportController as ExportController;
-use SMWRDFXMLSerializer as RDFXMLSerializer;
+use SMW\Exporter\ExporterFactory;
 
 $basePath = getenv( 'MW_INSTALL_PATH' ) !== false ? getenv( 'MW_INSTALL_PATH' ) : __DIR__ . '/../../..';
 
@@ -158,7 +157,11 @@ class dumpRDF extends \Maintenance {
 
 	private function exportRdfToOutputChannel() {
 
-		$exportController = new ExportController( new RDFXMLSerializer() );
+		$exporterFactory = new ExporterFactory();
+
+		$exportController = $exporterFactory->newExportController(
+			$exporterFactory->newRDFXMLSerializer()
+		);
 
 		if ( $this->pages !== [] ) {
 			return $exportController->printPages(

--- a/src/Exporter/ExpDataFactory.php
+++ b/src/Exporter/ExpDataFactory.php
@@ -1,0 +1,150 @@
+<?php
+
+namespace SMW\Exporter;
+
+use SMWExpData as ExpData;
+use SMWExporter as Exporter;
+use SMW\Exporter\Element\ExpResource;
+use SMW\Exporter\Element\ExpLiteral;
+use SMW\Exporter\Element\ExpNsResource;
+use SMW\Site;
+use Title;
+
+/**
+ * @license GNU GPL v2+
+ * @since 3.2
+ *
+ * @author mwjames
+ */
+class ExpDataFactory {
+
+	/**
+	 * @var Exporter
+	 */
+	private $exporter;
+
+	/**
+	 * @since 3.2
+	 *
+	 * @param Exporter $exporter
+	 */
+	public function __construct( Exporter $exporter ) {
+		$this->exporter = $exporter;
+	}
+
+	/**
+	 * @since 3.2
+	 *
+	 * @return ExpData
+	 */
+	public function newSiteExpData() : ExpData {
+
+		// assemble export data:
+		$expData = new ExpData( new ExpResource( '&wiki;#wiki' ) );
+
+		$expData->addPropertyObjectValue(
+			$this->exporter->newExpNsResourceById( 'rdf', 'type' ),
+			new ExpData( $this->exporter->newExpNsResourceById( 'swivt', 'Wikisite' ) )
+		);
+
+		// basic wiki information
+		$expData->addPropertyObjectValue(
+			$this->exporter->newExpNsResourceById( 'rdfs', 'label' ),
+			new ExpLiteral( Site::name() )
+		);
+
+		$expData->addPropertyObjectValue(
+			$this->exporter->newExpNsResourceById( 'swivt', 'siteName' ),
+			new ExpLiteral( Site::name(), 'http://www.w3.org/2001/XMLSchema#string' )
+		);
+
+		$expData->addPropertyObjectValue(
+			$this->exporter->newExpNsResourceById( 'swivt', 'pagePrefix' ),
+			new ExpLiteral( $this->exporter->expandURI( '&wikiurl;' ), 'http://www.w3.org/2001/XMLSchema#string' )
+		);
+
+		$expData->addPropertyObjectValue(
+			$this->exporter->newExpNsResourceById( 'swivt', 'smwVersion' ),
+			new ExpLiteral( SMW_VERSION, 'http://www.w3.org/2001/XMLSchema#string' )
+		);
+
+		$expData->addPropertyObjectValue(
+			$this->exporter->newExpNsResourceById( 'swivt', 'langCode' ),
+			new ExpLiteral( Site::languageCode(), 'http://www.w3.org/2001/XMLSchema#string' )
+		);
+
+		$mainpage = Title::newMainPage();
+
+		if ( $mainpage !== null ) {
+			$ed = new ExpData( new ExpResource( $mainpage->getFullURL() ) );
+			$expData->addPropertyObjectValue( $this->exporter->newExpNsResourceById( 'swivt', 'mainPage' ), $ed );
+		}
+
+		// statistical information
+		foreach ( Site::stats() as $key => $value ) {
+			$expData->addPropertyObjectValue(
+				$this->exporter->newExpNsResourceById( 'swivt', $key ),
+				new ExpLiteral( (string)$value, 'http://www.w3.org/2001/XMLSchema#int' )
+			);
+		}
+
+		return $expData;
+	}
+
+	/**
+	 * @since 3.2
+	 *
+	 * @return ExpData
+	 */
+	public function newDefinedExpData() : ExpData {
+
+		// link to list of existing pages:
+		 // check whether we have title as a first parameter or in URL
+		if ( strpos( $this->exporter->expandURI( '&wikiurl;' ), '?' ) === false ) {
+			$nexturl = $this->exporter->expandURI( '&export;?offset=0' );
+		} else {
+			$nexturl = $this->exporter->expandURI( '&export;&amp;offset=0' );
+		}
+
+		$expData = new ExpData(
+			new ExpResource( $nexturl )
+		);
+
+		$ed = new ExpData( $this->exporter->newExpNsResourceById( 'owl', 'Thing' ) );
+		$expData->addPropertyObjectValue( $this->exporter->newExpNsResourceById( 'rdf', 'type' ), $ed );
+
+		$ed = new ExpData( new ExpResource( $nexturl ) );
+		$expData->addPropertyObjectValue( $this->exporter->newExpNsResourceById( 'rdfs', 'isDefinedBy' ), $ed );
+
+		return $expData;
+	}
+
+	/**
+	 * Create an SMWExpData container that encodes the ontology header for an
+	 * SMW exported OWL file.
+	 *
+	 * @param string $ontologyuri specifying the URI of the ontology, possibly
+	 * empty
+	 *
+	 * @return ExpData
+	 */
+	public function newOntologyExpData( string $ontologyuri ) : ExpData {
+
+		$expData = new ExpData(
+			new ExpResource( $ontologyuri )
+		);
+
+		$ed = $this->exporter->newExpNsResourceById( 'owl', 'Ontology' );
+		$expData->addPropertyObjectValue( $this->exporter->newExpNsResourceById( 'rdf', 'type' ), $ed );
+
+		$ed = new ExpLiteral( date( DATE_W3C ), 'http://www.w3.org/2001/XMLSchema#dateTime' );
+		$expData->addPropertyObjectValue( $this->exporter->newExpNsResourceById( 'swivt', 'creationDate' ), $ed );
+
+		$ed = new ExpResource( 'http://semantic-mediawiki.org/swivt/1.0' );
+		$expData->addPropertyObjectValue( $this->exporter->newExpNsResourceById( 'owl', 'imports' ), $ed );
+
+		return $expData;
+	}
+
+
+}

--- a/src/Exporter/ExporterFactory.php
+++ b/src/Exporter/ExporterFactory.php
@@ -1,0 +1,99 @@
+<?php
+
+namespace SMW\Exporter;
+
+use SMW\Exporter\Serializer\Serializer;
+use SMW\Exporter\Serializer\RDFXMLSerializer;
+use SMW\Exporter\Serializer\TurtleSerializer;
+use SMWExportController as ExportController;
+use SMWExporter as Exporter;
+use InvalidArgumentException;
+
+/**
+ * @license GNU GPL v2+
+ * @since 3.2
+ *
+ * @author mwjames
+ */
+class ExporterFactory {
+
+	/**
+	 * @since 3.2
+	 *
+	 * @return Exporter
+	 */
+	public function getExporter() : Exporter {
+		return Exporter::getInstance();
+	}
+
+	/**
+	 * @since 3.2
+	 *
+	 * @param Serializer $serializer
+	 *
+	 * @return ExportController
+	 */
+	public function newExportController( Serializer $serializer ) : ExportController {
+
+		$exportController = new ExportController(
+			$serializer,
+			$this->newExpDataFactory( $this->getExporter() )
+		);
+
+		return $exportController;
+	}
+
+	/**
+	 * @since 3.2
+	 *
+	 * @param string $type
+	 *
+	 * @return Serializer
+	 * @throws InvalidArgumentException
+	 */
+	public function newSerializerByType( string $type ) : Serializer {
+
+		switch ( $type ) {
+			case 'application/x-turtle':
+			case 'turtle':
+				return $this->newTurtleSerializer();
+				break;
+			case 'application/rdf+xml':
+			case 'rdfxml':
+				return $this->newRDFXMLSerializer();
+				break;
+		}
+
+		throw new InvalidArgumentException( "$type is not matchable to a registered serializer!" );
+	}
+
+	/**
+	 * @since 3.2
+	 *
+	 * @return RDFXMLSerializer
+	 */
+	public function newRDFXMLSerializer() : RDFXMLSerializer {
+		return new RDFXMLSerializer();
+	}
+
+	/**
+	 * @since 3.2
+	 *
+	 * @return TurtleSerializer
+	 */
+	public function newTurtleSerializer() : TurtleSerializer {
+		return new TurtleSerializer();
+	}
+
+	/**
+	 * @since 3.2
+	 *
+	 * @param Exporter $exporter
+	 *
+	 * @return ExpDataFactory
+	 */
+	public function newExpDataFactory( Exporter $exporter ) : ExpDataFactory {
+		return new ExpDataFactory( $exporter );
+	}
+
+}

--- a/src/Query/ResultPrinters/RdfResultPrinter.php
+++ b/src/Query/ResultPrinters/RdfResultPrinter.php
@@ -6,8 +6,7 @@ use SMW\Query\PrintRequest;
 use SMW\DIProperty;
 use SMWExporter as Exporter;
 use SMWQueryResult as QueryResult;
-use SMWRDFXMLSerializer;
-use SMWTurtleSerializer;
+use SMW\Exporter\ExporterFactory;
 
 /**
  * Printer class for generating RDF output
@@ -108,11 +107,22 @@ class RdfResultPrinter extends FileExportPrinter {
 
 	private function makeExport( QueryResult $res, $outputMode ) {
 
-		$exporter = Exporter::getInstance();
-		$serializer = $exporter->newExportSerializer( $this->params['syntax'] );
+		$exporterFactory = new ExporterFactory();
+		$exporter = $exporterFactory->getExporter();
+
+		$expDataFactory = $exporterFactory->newExpDataFactory(
+			$exporter
+		);
+
+		$serializer = $exporterFactory->newSerializerByType(
+			$this->params['syntax']
+		);
 
 		$serializer->startSerialization();
-		$serializer->serializeExpData( $exporter->newOntologyExpData( '' ) );
+
+		$serializer->serializeExpData(
+			$expDataFactory->newOntologyExpData( '' )
+		);
 
 		while ( $row = $res->getNext() ) {
 			$serializer->serializeExpData( $this->makeExportData( $exporter, $row ) );

--- a/tests/phpunit/Integration/InterwikiDBIntegrationTest.php
+++ b/tests/phpunit/Integration/InterwikiDBIntegrationTest.php
@@ -6,9 +6,8 @@ use SMW\ApplicationFactory;
 use SMW\DIWikiPage;
 use SMW\Tests\MwDBaseUnitTestCase;
 use SMW\Tests\Utils\UtilityFactory;
-use SMWExportController as ExportController;
+use SMW\Exporter\ExporterFactory;
 use SMWQuery as Query;
-use SMWRDFXMLSerializer as RDFXMLSerializer;
 use Title;
 
 /**
@@ -147,8 +146,11 @@ class InterwikiDBIntegrationTest extends MwDBaseUnitTestCase {
 	private function fetchSerializedRdfOutputFor( array $pages ) {
 
 		$this->subjects = $pages;
+		$exporterFactory = new ExporterFactory();
 
-		$instance = new ExportController( new RDFXMLSerializer() );
+		$instance = $exporterFactory->newExportController(
+			$exporterFactory->newRDFXMLSerializer()
+		);
 
 		ob_start();
 		$instance->printPages( $pages );

--- a/tests/phpunit/Integration/RdfFileResourceTest.php
+++ b/tests/phpunit/Integration/RdfFileResourceTest.php
@@ -5,8 +5,7 @@ namespace SMW\Tests\Integration;
 use SMW\DIWikiPage;
 use SMW\Localizer;
 use SMW\Tests\MwDBaseUnitTestCase;
-use SMWExportController as ExportController;
-use SMWRDFXMLSerializer as RDFXMLSerializer;
+use SMW\Exporter\ExporterFactory;
 use Title;
 
 /**
@@ -77,7 +76,12 @@ class RdfFileResourceTest extends MwDBaseUnitTestCase {
 
 		$this->testEnvironment->executePendingDeferredUpdates();
 
-		$exportController = new ExportController( new RDFXMLSerializer() );
+		$exporterFactory = new ExporterFactory();
+
+		$exportController = $exporterFactory->newExportController(
+			$exporterFactory->newRDFXMLSerializer()
+		);
+
 		$exportController->enableBacklinks( false );
 
 		ob_start();

--- a/tests/phpunit/Unit/Exporter/ExpDataFactoryTest.php
+++ b/tests/phpunit/Unit/Exporter/ExpDataFactoryTest.php
@@ -1,0 +1,107 @@
+<?php
+
+namespace SMW\Tests\Exporter;
+
+use SMW\DIWikiPage;
+use SMW\Exporter\ExpDataFactory;
+use SMW\Tests\TestEnvironment;
+use SMW\Serializers\ExpDataSerializer;
+
+/**
+ * @covers \SMW\Exporter\ExpDataFactory
+ * @group semantic-mediawiki
+ *
+ * @license GNU GPL v2+
+ * @since 3.2
+ *
+ * @author mwjames
+ */
+class ExpDataFactoryTest extends \PHPUnit_Framework_TestCase {
+
+	private $exporter;
+
+	protected function setUp() : void {
+		parent::setUp();
+
+		$this->exporter = $this->getMockBuilder( '\SMWExporter' )
+			->disableOriginalConstructor()
+			->getMock();
+	}
+
+	public function testCanConstruct() {
+
+		$this->assertInstanceOf(
+			ExpDataFactory::class,
+			new ExpDataFactory( $this->exporter )
+		);
+	}
+
+	public function testNewSiteExpData() {
+
+		$expNsResource = $this->getMockBuilder( '\SMW\Exporter\Element\ExpNsResource' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$this->exporter->expects( $this->atLeastOnce() )
+			->method( 'newExpNsResourceById' )
+			->will( $this->returnValue( $expNsResource ) );
+
+		$this->exporter->expects( $this->atLeastOnce() )
+			->method( 'expandURI' )
+			->will( $this->returnValue( '' ) );
+
+		$instance = new ExpDataFactory(
+			$this->exporter
+		);
+
+		$this->assertInstanceOf(
+			'\SMWExpData',
+			$instance->newSiteExpData()
+		);
+	}
+
+	public function testNewDefinedExpData() {
+
+		$expNsResource = $this->getMockBuilder( '\SMW\Exporter\Element\ExpNsResource' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$this->exporter->expects( $this->atLeastOnce() )
+			->method( 'newExpNsResourceById' )
+			->will( $this->returnValue( $expNsResource ) );
+
+		$this->exporter->expects( $this->atLeastOnce() )
+			->method( 'expandURI' )
+			->will( $this->returnValue( '' ) );
+
+		$instance = new ExpDataFactory(
+			$this->exporter
+		);
+
+		$this->assertInstanceOf(
+			'\SMWExpData',
+			$instance->newDefinedExpData()
+		);
+	}
+
+	public function testNewOntologyExpData() {
+
+		$expNsResource = $this->getMockBuilder( '\SMW\Exporter\Element\ExpNsResource' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$this->exporter->expects( $this->atLeastOnce() )
+			->method( 'newExpNsResourceById' )
+			->will( $this->returnValue( $expNsResource ) );
+
+		$instance = new ExpDataFactory(
+			$this->exporter
+		);
+
+		$this->assertInstanceOf(
+			'\SMWExpData',
+			$instance->newOntologyExpData( '' )
+		);
+	}
+
+}

--- a/tests/phpunit/Unit/Exporter/ExporterFactoryTest.php
+++ b/tests/phpunit/Unit/Exporter/ExporterFactoryTest.php
@@ -1,0 +1,150 @@
+<?php
+
+namespace SMW\Tests\Exporter;
+
+use SMW\DataItemFactory;
+use SMW\Exporter\ExporterFactory;
+use SMW\Tests\PHPUnitCompat;
+
+/**
+ * @covers \SMW\Exporter\ExporterFactory
+ * @group semantic-mediawiki
+ *
+ * @license GNU GPL v2+
+ * @since 3.2
+ *
+ * @author mwjames
+ */
+class ExporterFactoryTest extends \PHPUnit_Framework_TestCase {
+
+	use PHPUnitCompat;
+
+	public function testCanConstruct() {
+
+		$this->assertInstanceOf(
+			ExporterFactory::class,
+			new ExporterFactory()
+		);
+	}
+
+	public function testGetExporter() {
+
+		$instance = new ExporterFactory();
+
+		$this->assertInstanceOf(
+			'\SMWExporter',
+			$instance->getExporter()
+		);
+	}
+
+	public function testCanConstructExportController() {
+
+		$serializer = $this->getMockBuilder( '\SMW\Exporter\Serializer\Serializer' )
+			->disableOriginalConstructor()
+			->getMockForAbstractClass();
+
+		$instance = new ExporterFactory();
+
+		$this->assertInstanceOf(
+			'\SMWExportController',
+			$instance->newExportController( $serializer )
+		);
+	}
+
+	/**
+	 * @dataProvider serializerByTypeProvider
+	 */
+	public function testCanConstructSerializerByType( $type ) {
+
+		$instance = new ExporterFactory();
+
+		$this->assertInstanceOf(
+			'\SMW\Exporter\Serializer\Serializer',
+			$instance->newSerializerByType( $type )
+		);
+	}
+
+	public function testSerializerByInvalidType_ThrowsException() {
+
+		$instance = new ExporterFactory();
+
+		$this->expectException( '\InvalidArgumentException' );
+		$instance->newSerializerByType( 'foo' );
+	}
+
+	public function testCanConstructRDFXMLSerializer() {
+
+		$instance = new ExporterFactory();
+
+		$this->assertInstanceOf(
+			'\SMW\Exporter\Serializer\RDFXMLSerializer',
+			$instance->newRDFXMLSerializer()
+		);
+	}
+
+	public function testCanConstructTurtleSerializer() {
+
+		$instance = new ExporterFactory();
+
+		$this->assertInstanceOf(
+			'\SMW\Exporter\Serializer\TurtleSerializer',
+			$instance->newTurtleSerializer()
+		);
+	}
+
+	public function testCanConstructExpDataFactory() {
+
+		$exporter = $this->getMockBuilder( '\SMWExporter' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$instance = new ExporterFactory();
+
+		$this->assertInstanceOf(
+			'\SMW\Exporter\ExpDataFactory',
+			$instance->newExpDataFactory( $exporter )
+		);
+	}
+
+	public function testConfirmAllCanConstructMethodsWereCalled() {
+
+		// Available class methods to be tested
+		$classMethods = get_class_methods( ExporterFactory::class );
+
+		// Match all "testCanConstruct" to define the expected set of methods
+		$testMethods = preg_grep('/^testCanConstruct/', get_class_methods( $this ) );
+
+		$testMethods = array_flip(
+			str_replace( 'testCanConstruct', 'new', $testMethods )
+		);
+
+		foreach ( $classMethods as $name ) {
+
+			if ( substr( $name, 0, 3 ) !== 'new' ) {
+				continue;
+			}
+
+			$this->assertArrayHasKey( $name, $testMethods );
+		}
+	}
+
+	public function serializerByTypeProvider() {
+
+		yield [
+			'turtle'
+		];
+
+		yield [
+			'application/x-turtle'
+		];
+
+		yield [
+			'rdfxml'
+		];
+
+		yield [
+			'application/rdf+xml'
+		];
+	}
+
+}

--- a/tests/phpunit/Utils/JSONScript/RdfTestCaseProcessor.php
+++ b/tests/phpunit/Utils/JSONScript/RdfTestCaseProcessor.php
@@ -2,9 +2,7 @@
 
 namespace SMW\Tests\Utils\JSONScript;
 
-use SMWExportController as ExportController;
-use SMWRDFXMLSerializer as RDFXMLSerializer;
-use SMWTurtleSerializer as TurtleSerializer;
+use SMW\Exporter\ExporterFactory;
 
 /**
  * @group semantic-mediawiki
@@ -87,13 +85,15 @@ class RdfTestCaseProcessor extends \PHPUnit_Framework_TestCase {
 
 	private function assertExportControllerOutputForCase( $case ) {
 
+		$exporterFactory = new ExporterFactory();
+
 		if ( isset( $case['exportcontroller']['syntax'] ) && $case['exportcontroller']['syntax'] === 'turtle' ) {
-			$serializer = new TurtleSerializer();
+			$serializer = $exporterFactory->newTurtleSerializer();
 		} else {
-			$serializer = new RDFXMLSerializer();
+			$serializer = $exporterFactory->newRDFXMLSerializer();
 		}
 
-		$exportController = new ExportController( $serializer );
+		$exportController = $exporterFactory->newExportController( $serializer );
 		$exportController->enableBacklinks( $case['exportcontroller']['parameters']['backlinks'] );
 
 		ob_start();


### PR DESCRIPTION
This PR is made in reference to: #4711 

This PR addresses or contains:

- In light of #4714 add a couple of clean-ups, isolating factoring of `ExpData` instances using the newly added `ExpDataFactory`
- Isolate instantiation of the `TurtleSerializer` and `RDFXMLSerializer` via `ExporterFactory`

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed
