### PR TITLE
Run `PropertyChangeListener` after commit, refs 4432

### DIFF
--- a/src/Listener/ChangeListener/CallableChangeListenerTrait.php
+++ b/src/Listener/ChangeListener/CallableChangeListenerTrait.php
@@ -63,13 +63,13 @@ trait CallableChangeListenerTrait {
 			return;
 		}
 
-		$changeRecord = new ChangeRecord( $this->attrs );
-		$this->triggerByKey( $key, $changeRecord );
-
 		$this->logger->info(
 			[ 'Listener', 'ChangeListener', "{key}" ],
 			[ 'role' => 'developer', 'key' => $key ]
 		);
+
+		$changeRecord = new ChangeRecord( $this->attrs );
+		$this->triggerByKey( $key, $changeRecord );
 	}
 
 	protected function triggerByKey( string $key, ChangeRecord $changeRecord ) {

--- a/src/Listener/ChangeListener/ChangeListeners/PropertyChangeListener.php
+++ b/src/Listener/ChangeListener/ChangeListeners/PropertyChangeListener.php
@@ -118,8 +118,7 @@ class PropertyChangeListener implements ChangeListener {
 	/**
 	 * @since 3.2
 	 */
-	public function matchAndTriggerChangeListeners() {
-
+	public function triggerChangeListeners() {
 		$keyIdMap = array_flip( $this->propertyIdKeyMap );
 
 		foreach ( $this->changeListeners as $key => $changeListeners ) {
@@ -139,6 +138,13 @@ class PropertyChangeListener implements ChangeListener {
 			$this->setAttrs( $attrs );
 			$this->trigger( $key );
 		}
+	}
+
+	/**
+	 * @since 3.2
+	 */
+	public function runChangeListeners() {
+		$this->store->getConnection( 'mw.db' )->onTransactionIdle( [ $this, 'triggerChangeListeners' ] );
 	}
 
 	/**

--- a/src/SQLStore/SQLStoreUpdater.php
+++ b/src/SQLStore/SQLStoreUpdater.php
@@ -266,8 +266,6 @@ class SQLStoreUpdater {
 		$changeDiff = $changeOp->newChangeDiff();
 		$changeDiff->save( ApplicationFactory::getInstance()->getCache() );
 
-		$propertyChangeListener->matchAndTriggerChangeListeners();
-
 		$status = new Status(
 			[
 				'delete_list' => $deleteList,
@@ -285,6 +283,8 @@ class SQLStoreUpdater {
 		] );
 
 		$connection->endSectionTransaction( SQLStore::UPDATE_TRANSACTION );
+
+		$propertyChangeListener->runChangeListeners();
 
 		return $status;
 	}

--- a/tests/phpunit/Unit/Listener/ChangeListener/ChangeListeners/PropertyChangeListenerTest.php
+++ b/tests/phpunit/Unit/Listener/ChangeListener/ChangeListeners/PropertyChangeListenerTest.php
@@ -108,7 +108,7 @@ class PropertyChangeListenerTest extends \PHPUnit_Framework_TestCase {
 		);
 
 		$instance->recordChange( 42, [ 'row' => [ 's_id' => 1000, 'o_hash' => 'foobar' ] ] );
-		$instance->matchAndTriggerChangeListeners();
+		$instance->triggerChangeListeners();
 
 		$this->assertEquals(
 			$property,
@@ -119,6 +119,26 @@ class PropertyChangeListenerTest extends \PHPUnit_Framework_TestCase {
 			'foobar',
 			$this->changeRecord->get( 0 )->get( 'row.o_hash' )
 		);
+	}
+
+	public function testRunChangeListeners() {
+
+		$connection = $this->getMockBuilder( '\SMW\MediaWiki\Database' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$connection->expects( $this->once() )
+			->method( 'onTransactionIdle' );
+
+		$this->store->expects( $this->atLeastOnce() )
+			->method( 'getConnection' )
+			->will( $this->returnValue( $connection ) );
+
+		$instance = new PropertyChangeListener(
+			$this->store
+		);
+
+		$instance->runChangeListeners();
 	}
 
 	public function testLoadListeners() {


### PR DESCRIPTION
This PR is made in reference to: #4432

This PR addresses or contains:

- Ensures that any listener registered is triggered only after the data has been written to the repository

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed
