### PR TITLE
Register `ProtectionValidator` with `PropertyChangeListener`

### DIFF
--- a/src/SQLStore/SQLStoreFactory.php
+++ b/src/SQLStore/SQLStoreFactory.php
@@ -952,6 +952,12 @@ class SQLStoreFactory {
 			$propertyChangeListener
 		);
 
+		$protectionValidator = $applicationFactory->singleton( 'ProtectionValidator' );
+
+		$protectionValidator->registerPropertyChangeListener(
+			$propertyChangeListener
+		);
+
 		return $propertyChangeListener;
 	}
 


### PR DESCRIPTION
This PR is made in reference to: #4432

This PR addresses or contains:

- Register the `ProtectionValidator` with the `PropertyChangeListener` which allows to quickly see whether a change happened to the `_CHGPRO` (Change propagation) property hereby provides means to quickly invalidate the cache so that a possible lock request (protection check) has the latest possible information available based on the update event the `PropertyChangeListener` is listen to.

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed
