### PR TITLE
Avoid using deprecated $wgParserConf configuration variable

### DIFF
--- a/includes/ContentParser.php
+++ b/includes/ContentParser.php
@@ -7,6 +7,7 @@ use ParserOptions;
 use Revision;
 use Title;
 use User;
+use MediaWiki\MediaWikiServices;
 use SMW\MediaWiki\RevisionGuard;
 
 /**
@@ -49,10 +50,6 @@ class ContentParser {
 	private $skipInTextAnnotationParser = false;
 
 	/**
-	 * @note Injecting new Parser() alone will not yield an expected result and
-	 * doing new Parser( $GLOBALS['wgParserConf'] brings no benefits therefore
-	 * we stick to the GLOBAL as fallback if no parser is injected.
-	 *
 	 * @since 1.9
 	 *
 	 * @param Title $title
@@ -63,7 +60,7 @@ class ContentParser {
 		$this->parser = $parser;
 
 		if ( $this->parser === null ) {
-			$this->parser = $GLOBALS['wgParser'];
+			$this->parser = MediaWikiServices::getInstance()->getParser();
 		}
 	}
 

--- a/tests/phpunit/Utils/ParserFactory.php
+++ b/tests/phpunit/Utils/ParserFactory.php
@@ -2,6 +2,7 @@
 
 namespace SMW\Tests\Utils;
 
+use MediaWiki\MediaWikiServices;
 use Parser;
 use ParserOptions;
 use SMW\DIWikiPage;
@@ -41,7 +42,7 @@ class ParserFactory {
 		// $wikiPage = new \WikiPage( $title );
 		// $wikiPage->makeParserOptions( $user );
 
-		$parser = new Parser( $GLOBALS['wgParserConf'] );
+		$parser = MediaWikiServices::getInstance()->getParserFactory()->create();
 		$parser->setTitle( $title );
 		$parser->setUser( $user );
 		$parser->Options( new ParserOptions( $user ) );


### PR DESCRIPTION
Modern code should use the Parser or ParserFactory service.
See I787f22ea9bf59a049b13631ba6974866a1300988.
