### PR TITLE
Isolate `Hooks::run` in `RevisionGuard`, refs 4478

### DIFF
--- a/src/DataUpdater.php
+++ b/src/DataUpdater.php
@@ -272,7 +272,7 @@ class DataUpdater {
 		// that the revision reference is the same that lead to an update during
 		// a content parse, the revision for the parsed text and the `smw_rev`
 		// reference field should both point to the same revision
-		$revision = RevisionGuard::getRevision(
+		$revision = $this->revisionGuard->getRevision(
 			$title,
 			$wikiPage->getRevision()
 		);

--- a/src/MediaWiki/HookDispatcher.php
+++ b/src/MediaWiki/HookDispatcher.php
@@ -238,6 +238,20 @@ class HookDispatcher {
 	}
 
 	/**
+	 * @see https://github.com/SemanticMediaWiki/SemanticMediaWiki/blob/master/docs/technical/hooks/hook.revisionguard.changerevision.md
+	 *
+	 * @note This hook is only to be called from the `RevisionGuard` class.
+	 *
+	 * @since 3.2
+	 *
+	 * @param Title $title
+	 * @param Revision|null $revision
+	 */
+	public function onChangeRevision( \Title $title, ?\Revision &$revision ) {
+		Hooks::run( 'SMW::RevisionGuard::ChangeRevision', [ $title, &$revision ] );
+	}
+
+	/**
 	 * @see https://github.com/SemanticMediaWiki/SemanticMediaWiki/blob/master/docs/technical/hooks/hook.sqlstore.installer.beforecreatetablescomplete.md
 	 * @since 3.2
 	 *

--- a/src/MediaWiki/RevisionGuard.php
+++ b/src/MediaWiki/RevisionGuard.php
@@ -90,15 +90,19 @@ class RevisionGuard {
 	 * @since 3.1
 	 *
 	 * @param Title $title
-	 * @param Revision $revision
+	 * @param Revision|null $revision
 	 *
-	 * @return integer
+	 * @return Revision|null
 	 */
-	public static function getRevision( Title $title, $revision ) {
+	public function getRevision( Title $title, ?Revision $revision ) : ?Revision {
+
+		if ( $revision === null ) {
+			$revision = Revision::newFromTitle( $title, false, Revision::READ_NORMAL );
+		}
 
 		$origRevision = $revision;
 
-		\Hooks::run( 'SMW::RevisionGuard::ChangeRevision', [ $title, &$revision ] );
+		$this->hookDispatcher->onChangeRevision( $title, $revision );
 
 		if ( $revision instanceof Revision ) {
 			return $revision;

--- a/src/Services/ServicesFactory.php
+++ b/src/Services/ServicesFactory.php
@@ -418,8 +418,12 @@ class ServicesFactory {
 
 	/**
 	 * @since 2.0
+	 *
+	 * @param Title $title
+	 *
+	 * @return ContentParser
 	 */
-	public function newContentParser( Title $title ): ContentParser {
+	public function newContentParser( Title $title ) : ContentParser {
 		return $this->containerBuilder->create( 'ContentParser', $title );
 	}
 

--- a/src/Services/SharedServicesContainer.php
+++ b/src/Services/SharedServicesContainer.php
@@ -289,7 +289,17 @@ class SharedServicesContainer implements CallbackContainer {
 
 		$containerBuilder->registerCallback( 'ContentParser', function( $containerBuilder, \Title $title ) {
 			$containerBuilder->registerExpectedReturnType( 'ContentParser', '\SMW\ContentParser' );
-			return new ContentParser( $title );
+
+			$contentParser = new ContentParser(
+				$title,
+				$containerBuilder->create( 'Parser' )
+			);
+
+			$contentParser->setRevisionGuard(
+				$containerBuilder->singleton( 'RevisionGuard' )
+			);
+
+			return $contentParser;
 		} );
 
 		$containerBuilder->registerCallback( 'DeferredCallableUpdate', function( $containerBuilder, callable $callback = null ) {

--- a/tests/phpunit/Integration/MediaWiki/HookDispatcherTest.php
+++ b/tests/phpunit/Integration/MediaWiki/HookDispatcherTest.php
@@ -403,6 +403,41 @@ class HookDispatcherTest extends \PHPUnit_Framework_TestCase {
 		);
 	}
 
+	public function testOnChangeRevision() {
+
+		$hookDispatcher = new HookDispatcher();
+
+		$title = $this->getMockBuilder( '\Title' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$revision = $this->getMockBuilder( '\Revision' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$anotherRevision = $this->getMockBuilder( '\Revision' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$anotherRevision->extraProperty = 'Foo';
+
+		$this->assertNotEquals(
+			$revision,
+			$anotherRevision
+		);
+
+		$this->mwHooksHandler->register( 'SMW::RevisionGuard::ChangeRevision', function( $title, &$revision ) use ( $anotherRevision ) {
+			$revision = $anotherRevision;
+		} );
+
+		$hookDispatcher->onChangeRevision( $title, $revision );
+
+		$this->assertEquals(
+			$anotherRevision,
+			$revision
+		);
+	}
+
 	public function testOnInstallerBeforeCreateTablesComplete() {
 
 		$hookDispatcher = new HookDispatcher();

--- a/tests/phpunit/Integration/MediaWiki/Hooks/ParserFirstCallInitIntegrationTest.php
+++ b/tests/phpunit/Integration/MediaWiki/Hooks/ParserFirstCallInitIntegrationTest.php
@@ -2,7 +2,7 @@
 
 namespace SMW\Tests\Integration\MediaWiki\Hooks;
 
-use SMW\ContentParser;
+use SMW\Services\ServicesFactory;
 use SMW\Tests\TestEnvironment;
 use Title;
 
@@ -18,7 +18,6 @@ use Title;
 class ParserFirstCallInitIntegrationTest extends \PHPUnit_Framework_TestCase {
 
 	private $mwHooksHandler;
-	private $parserFactory;
 	private $testEnvironment;
 	private $store;
 	private $queryResult;
@@ -32,8 +31,6 @@ class ParserFirstCallInitIntegrationTest extends \PHPUnit_Framework_TestCase {
 
 		$this->mwHooksHandler = $this->testEnvironment->getUtilityFactory()->newMwHooksHandler();
 		$this->mwHooksHandler->deregisterListedHooks();
-
-		$this->parserFactory = $this->testEnvironment->getUtilityFactory()->newParserFactory();
 
 		$idTable = $this->getMockBuilder( '\SMW\SQLStore\EntityStore\EntityIdManager' )
 			->disableOriginalConstructor()
@@ -111,11 +108,9 @@ class ParserFirstCallInitIntegrationTest extends \PHPUnit_Framework_TestCase {
 		];
 
 		$title = Title::newFromText( __METHOD__ );
-		$parser = $this->parserFactory->newFromTitle( $title );
-
 		$this->testEnvironment->addConfiguration( 'smwgQEnabled', true );
 
-		$instance = new ContentParser( $title, $parser );
+		$instance = ServicesFactory::getInstance()->newContentParser( $title );
 		$instance->parse( $text );
 
 		if ( in_array( $parserName, $expectedNullOutputFor ) ) {
@@ -143,11 +138,9 @@ class ParserFirstCallInitIntegrationTest extends \PHPUnit_Framework_TestCase {
 		];
 
 		$title = Title::newFromText( __METHOD__ );
-		$parser = $this->parserFactory->newFromTitle( $title );
-
 		$this->testEnvironment->addConfiguration( 'smwgQEnabled', false );
 
-		$instance = new ContentParser( $title, $parser );
+		$instance = ServicesFactory::getInstance()->newContentParser( $title );
 		$instance->parse( $text );
 
 		if ( in_array( $parserName, $expectedNullOutputFor ) ) {

--- a/tests/phpunit/Integration/MediaWiki/LinksUpdateSQLStoreDBIntegrationTest.php
+++ b/tests/phpunit/Integration/MediaWiki/LinksUpdateSQLStoreDBIntegrationTest.php
@@ -5,7 +5,7 @@ namespace SMW\Tests\Integration\MediaWiki;
 use LinksUpdate;
 use ParserOutput;
 use Revision;
-use SMW\ContentParser;
+use SMW\Services\ServicesFactory;
 use SMW\DIWikiPage;
 use SMW\ParserData;
 use SMW\Tests\MwDBaseUnitTestCase;
@@ -186,8 +186,13 @@ class LinksUpdateSQLStoreDBIntegrationTest extends MwDBaseUnitTestCase {
 
 		$revision = $revId ? Revision::newFromId( $revId ) : null;
 
-		$contentParser = new ContentParser( $this->title );
-		$parserOutput =	$contentParser->setRevision( $revision )->parse()->getOutput();
+		$contentParser = ServicesFactory::getInstance()->newContentParser(
+			$this->title
+		);
+
+		$contentParser->setRevision( $revision );
+
+		$parserOutput =	$contentParser->parse()->getOutput();
 		$parserOutput->setExtensionData( ParserData::OPT_FORCED_UPDATE, true );
 
 		if ( $parserOutput instanceof ParserOutput ) {

--- a/tests/phpunit/Unit/MediaWiki/RevisionGuardTest.php
+++ b/tests/phpunit/Unit/MediaWiki/RevisionGuardTest.php
@@ -106,6 +106,9 @@ class RevisionGuardTest extends \PHPUnit_Framework_TestCase {
 
 	public function testGetRevision() {
 
+		$this->hookDispatcher->expects( $this->once() )
+			->method( 'onChangeRevision' );
+
 		$title = $this->getMockBuilder( '\Title' )
 			->disableOriginalConstructor()
 			->getMock();
@@ -114,9 +117,15 @@ class RevisionGuardTest extends \PHPUnit_Framework_TestCase {
 			->disableOriginalConstructor()
 			->getMock();
 
+		$instance = new RevisionGuard();
+
+		$instance->setHookDispatcher(
+			$this->hookDispatcher
+		);
+
 		$this->assertInstanceOf(
 			'\Revision',
-			RevisionGuard::getRevision( $title, $revision )
+			$instance->getRevision( $title, $revision )
 		);
 	}
 

--- a/tests/phpunit/Utils/MwHooksHandler.php
+++ b/tests/phpunit/Utils/MwHooksHandler.php
@@ -70,6 +70,7 @@ class MwHooksHandler {
 		'SMW::RevisionGuard::IsApprovedRevision',
 		'SMW::RevisionGuard::ChangeRevisionID',
 		'SMW::RevisionGuard::ChangeFile',
+		'SMW::RevisionGuard::ChangeRevision',
 
 		'SMWSQLStore3::updateDataBefore',
 		'SMW::SQLStore::BeforeDataUpdateComplete',

--- a/tests/phpunit/Utils/PageRefresher.php
+++ b/tests/phpunit/Utils/PageRefresher.php
@@ -37,9 +37,13 @@ class PageRefresher {
 			throw new RuntimeException( 'Expected a title instance' );
 		}
 
-		$contentParser = new ContentParser( $title );
+		$applicationFactory = ApplicationFactory::getInstance();
 
-		$parserData = ApplicationFactory::getInstance()->newParserData(
+		$contentParser = $applicationFactory->newContentParser(
+			$title
+		);
+
+		$parserData = $applicationFactory->newParserData(
 			$title,
 			$contentParser->parse()->getOutput()
 		);

--- a/tests/phpunit/includes/ContentParserTest.php
+++ b/tests/phpunit/includes/ContentParserTest.php
@@ -2,332 +2,126 @@
 
 namespace SMW\Test;
 
-use ContentHandler;
-use Parser;
-use Revision;
 use SMW\ContentParser;
-use SMW\Tests\Utils\Mock\MockTitle;
-use TextContent;
-use TextContentHandler;
-use Title;
 use SMW\Tests\PHPUnitCompat;
 
 /**
  * @covers \SMW\ContentParser
- *
- *
- * @group SMW
- * @group SMWExtension
+ * @group semantic-mediawiki
  *
  * @license GNU GPL v2+
  * @since   1.9
  *
  * @author mwjames
  */
-class ContentParserTest extends SemanticMediaWikiTestCase {
+class ContentParserTest extends \PHPUnit_Framework_TestCase {
 
 	use PHPUnitCompat;
 
-	public function getClass() {
-		return '\SMW\ContentParser';
+	private $revisionGuard;
+	private $title;
+	private $parser;
+	private $parserOutput;
+
+	protected function setUp() : void {
+		parent::setUp();
+
+		$this->revisionGuard = $this->getMockBuilder( '\SMW\MediaWiki\RevisionGuard' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$this->title = $this->getMockBuilder( '\Title' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$this->parser = $this->getMockBuilder( '\Parser' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$this->parserOutput = $this->getMockBuilder( '\ParserOutput' )
+			->disableOriginalConstructor()
+			->getMock();
 	}
 
-	private function newInstance( Title $title = null, $parser = null ) {
-
-		if ( $title === null ) {
-			$title = Title::newFromText( __METHOD__ );
-		}
-
-		return new ContentParser( $title, $parser );
+	protected function tearDown() : void {
+		parent::tearDown();
 	}
 
 	public function testCanConstruct() {
-		$this->assertInstanceOf( $this->getClass(), $this->newInstance() );
-	}
 
-	/**
-	 * @depends testCanConstruct
-	 */
-	public function testCanParseOnInstance() {
-		$this->assertInstanceOf( $this->getClass(), $this->newInstance()->parse() );
-	}
-
-	/**
-	 * @depends testCanParseOnInstance
-	 */
-	public function testRunParseOnText() {
-
-		$text     = 'Foo-1-' . __METHOD__;
-		$expected = '<p>' . $text . "\n" . '</p>';
-
-		$this->assertParserOutput( $expected, $this->newInstance()->parse( $text ) );
-	}
-
-	/**
-	 * @dataProvider titleRevisionDataProvider
-	 */
-	public function testRunParseOnTitle( $setup, $expected, $withContentHandler = false ) {
-
-		$instance = $this->getMockBuilder( '\SMW\ContentParser' )
-			->setConstructorArgs( [ $setup['title'], new Parser() ] )
-			->setMethods( [ 'hasContentHandler' ] )
+		$semanticData = $this->getMockBuilder( '\SMW\SemanticData' )
+			->disableOriginalConstructor()
 			->getMock();
 
-		$instance->expects( $this->any() )
-			->method( 'hasContentHandler' )
-			->will( $this->returnValue( $withContentHandler ) );
-
-		$instance->setRevision( $setup['revision'] );
-
-		$this->assertInstanceAfterParse( $expected, $instance->parse() );
-
+		$this->assertInstanceOf(
+			ContentParser::class,
+			new ContentParser( $this->title, $this->parser )
+		);
 	}
 
-	/**
-	 * @dataProvider contentDataProvider
-	 *
-	 * @since 1.9
-	 */
-	public function testRunParseOnTitleWithContentHandler( $setup, $expected ) {
+	public function testRunParseOnText() {
 
-		if ( !class_exists( 'ContentHandler') ) {
-			$this->markTestSkipped(
-				'Skipping test due to missing class (probably MW 1.21 or lower).'
-			);
-		}
+		$text = __METHOD__;
 
-		$this->testRunParseOnTitle( $setup, $expected, true );
-	}
+		$this->parser->expects( $this->any() )
+			->method( 'parse' )
+			->with( $this->stringContains( $text ) )
+			->will( $this->returnValue( $this->parserOutput ) );
 
-	protected function assertInstanceAfterParse( $expected, $instance ) {
-
-		$this->assertInstanceOf( $this->getClass(), $instance );
-
-		if ( $expected['error'] ) {
-			return $this->assertError( $instance );
-		}
-
-		$this->assertParserOutput( $expected['text'], $instance );
-	}
-
-	protected function assertError( $instance ) {
-		$this->assertInternalType( 'array', $instance->getErrors() );
-		$this->assertNotEmpty( $instance->getErrors() );
-	}
-
-	protected function assertParserOutput( $text, $instance ) {
-
-		$this->assertInstanceOf( 'ParserOutput', $instance->getOutput() );
-
-		if ( $text !== '' ) {
-
-			return $this->assertContains(
-				$text,
-				$instance->getOutput()->getText(),
-				'Asserts that getText() returns expected text component'
-			);
-
-		}
-
-		$this->assertEmpty( $instance->getOutput()->getText() );
-	}
-
-	/**
-	 * @return array
-	 */
-	public function titleRevisionDataProvider() {
-
-		$provider = [];
-
-		$text     = 'Foo-2-' . __METHOD__;
-		$expected ='<p>' . $text . "\n" . '</p>';
-
-		// #0 Title does not exists
-		$title = $this->newMockBuilder()->newObject( 'Title', [
-			'getDBkey'        => 'Lila',
-			'exists'          => false,
-			'getText'         => null,
-			'getPageLanguage' => $this->getLanguage()
-		] );
-
-		$provider[] = [
-			[
-				'title'    => $title,
-				'revision' => null,
-			],
-			[
-				'error'    => true,
-				'text'     => ''
-			]
-		];
-
-		// #1 Valid revision
-		// Required by MW 1.29, method got removed
-		if ( method_exists( 'Revision', 'getText' ) ) {
-			$title = $this->newMockBuilder()->newObject( 'Title', [
-				'getDBkey'        => 'Lula',
-				'exists'          => true,
-				'getPageLanguage' => $this->getLanguage()
-			] );
-
-			$revision = $this->newMockBuilder()->newObject( 'Revision', [
-				'getId'   => 9001,
-				'getUser' => 'Lala',
-				'getText' => $text,
-			] );
-
-			$provider[] = [
-				[
-					'title'    => $title,
-					'revision' => $revision,
-				],
-				[
-					'error'    => false,
-					'text'     => $expected
-				]
-			];
-		}
-
-		// #2 Null revision
-		$title = $this->newMockBuilder()->newObject( 'Title', [
-			'getDBkey'        => 'Lula',
-			'exists'          => true,
-			'getPageLanguage' => $this->getLanguage()
-		] );
-
-		$revision = null;
-
-		$provider[] = [
-			[
-				'title'    => $title,
-				'revision' => $revision,
-			],
-			[
-				'error'    => true,
-				'text'     => ''
-			]
-		];
-
-		return $provider;
-	}
-
-	/**
-	 * @return array
-	 */
-	public function contentDataProvider() {
-
-		$provider = [];
-
-		if ( !class_exists( 'ContentHandler') ) {
-			$provider[] = [ [], [] ];
-			return $provider;
-		}
-
-		$text     = 'Foo-3-' . __METHOD__;
-
-		// #0 Title does not exists
-		$title = MockTitle::buildMock( 'Lila' );
-
-		$title->expects( $this->any() )
-			->method( 'exists' )
-			->will( $this->returnValue( false ) );
-
-		$title->expects( $this->any() )
-			->method( 'getPageLanguage' )
-			->will( $this->returnValue( $this->getLanguage() ) );
-
-		$provider[] = [
-			[
-				'title'    => $title,
-				'revision' => null,
-			],
-			[
-				'error'    => true,
-				'text'     => ''
-			]
-		];
-
-		// #1 Valid revision
-		$title = $this->newMockBuilder()->newObject( 'Title', [
-			'getDBkey'        => 'Lula',
-			'exists'          => true,
-			'getPageLanguage' => $this->getLanguage()
-		] );
-
-		$revision = $this->newMockBuilder()->newObject( 'Revision', [
-			'getId'   => 9001,
-			'getUser' => 'Lala',
-			'getContent' => new TextContent( $text )
-		] );
-
-		$provider[] = [
-			[
-				'title'    => $title,
-				'revision' => $revision,
-			],
-			[
-				'error'    => false,
-				'text'     => $text
-			]
-		];
-
-		// #1 Empty content
-		$title = $this->newMockBuilder()->newObject( 'Title', [
-			'getDBkey'        => 'Lula',
-			'exists'          => true,
-			'getPageLanguage' => $this->getLanguage(),
-			'getContentModel' => CONTENT_MODEL_WIKITEXT
-		] );
-
-		$revision = $this->newMockBuilder()->newObject( 'Revision', [
-			'getId'             => 9001,
-			'getUser'           => 'Lala',
-			'getContent'        => false,
-			'getContentHandler' => new TextContentHandler()
-		] );
-
-		$provider[] = [
-			[
-				'title'    => $title,
-				'revision' => $revision,
-			],
-			[
-				'error'    => false,
-				'text'     => ''
-			]
-		];
-
-		// #2 "real" revision and content
-		$title    = $this->newTitle();
-		$content  = ContentHandler::makeContent( $text, $title, CONTENT_MODEL_WIKITEXT, null );
-
-		$revision = new Revision(
-			[
-				'id'         => 42,
-				'page'       => 23,
-				'title'      => $title,
-
-				'content'    => $content,
-				'length'     => $content->getSize(),
-				'comment'    => "testing",
-				'minor_edit' => false,
-
-				'content_format' => null,
-			]
+		$instance = new ContentParser(
+			$this->title,
+			$this->parser
 		);
 
-		$provider[] = [
-			[
-				'title'    => $title,
-				'revision' => $revision,
-			],
-			[
-				'error'    => false,
-				'text'     => $text
-			]
-		];
+		$instance->setRevisionGuard(
+			$this->revisionGuard
+		);
 
-		return $provider;
+		$instance->parse( $text );
+
+		$this->assertInstanceOf(
+			'\ParserOutput',
+			$instance->getOutput()
+		);
+	}
+
+	public function testRunParseFromRevision() {
+
+		$content = $this->getMockBuilder( '\Content' )
+			->disableOriginalConstructor()
+			->getMockForAbstractClass();
+
+		$content->expects( $this->any() )
+			->method( 'getParserOutput' )
+			->will( $this->returnValue( $this->parserOutput ) );
+
+		$revision = $this->getMockBuilder( '\Revision' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$revision->expects( $this->any() )
+			->method( 'getContent' )
+			->will( $this->returnValue( $content ) );
+
+		$this->revisionGuard->expects( $this->any() )
+			->method( 'getRevision' )
+			->will( $this->returnValue( $revision ) );
+
+		$instance = new ContentParser(
+			$this->title,
+			$this->parser
+		);
+
+		$instance->setRevisionGuard(
+			$this->revisionGuard
+		);
+
+		$instance->parse();
+
+		$this->assertInstanceOf(
+			'\ParserOutput',
+			$instance->getOutput()
+		);
 	}
 
 }


### PR DESCRIPTION
This PR is made in reference to: #4478, #4725 

This PR addresses or contains:

- Aside from isolating `Hooks::run` in `RevisionGuard` it also clean-ups `ContentParser` to address part of #4725

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed
