### PR TITLE
Nicify output for unknown config profile, refs 4684, 4438

### DIFF
--- a/data/template/setupcheck/setupcheck.json
+++ b/data/template/setupcheck/setupcheck.json
@@ -252,6 +252,28 @@
 				}
 			]
 		},
+		"ERROR_CONFIG_PROFILE_UNKNOWN":{
+			"indicator_title":"smw-setupcheck-error",
+			"indicator_color":"#dd3d31",
+			"output_form":[
+				{
+					"type":"paragraph",
+					"text":"ERROR_TEXT"
+				},
+				{
+					"type":"version",
+					"text":"smw-setupcheck-release"
+				},
+				{
+					"type":"section",
+					"text":"smw-setupcheck-how-to-fix-error"
+				},
+				{
+					"type":"paragraph",
+					"text":"smw-setupcheck-config-profile"
+				}
+			]
+		},
 		"MAINTENANCE_MODE":{
 			"indicator_title":"smw-setupcheck-maintenance",
 			"indicator_color":"#ffc107",

--- a/i18n/local/setupcheck.i18n.json
+++ b/i18n/local/setupcheck.i18n.json
@@ -96,6 +96,9 @@
 	"smw-setupcheck-registry-requires-enablesemantics": {
 		"en": "To use Semantic MediaWiki or functions of it, it is necessary to add <code>enableSemantics</code> to your <code>LocalSettings.php</code> which will ensure required variables and parameters are setup before programs can continue to work and make use of it."
 	},
+	"smw-setupcheck-config-profile": {
+		"en": "Please check the spelling and location of available <a href='https://www.semantic-mediawiki.org/wiki/Config_preloading'>default profiles</a> used as part of the <code>enableSemantics</code> declaration in your <code>LocalSettings.php</code>."
+	},
 	"smw-setupcheck-in-maintenance-mode": {
 		"en": "The system is currently undergoing an <a href='https://www.semantic-mediawiki.org/wiki/Help:Upgrade'>upgrade</a> of the <a href='https://www.semantic-mediawiki.org/'>Semantic MediaWiki</a> extension together with its data repository and we would like to ask you for your patience and allow the maintenance to continue before the wiki can be made accessible again."
 	},

--- a/src/ConfigPreloader.php
+++ b/src/ConfigPreloader.php
@@ -2,7 +2,7 @@
 
 namespace SMW;
 
-use SMW\Exception\FileNotReadableException;
+use SMW\Exception\ConfigPreloadFileNotReadableException;
 
 /**
  * @private
@@ -70,7 +70,7 @@ class ConfigPreloader {
 		$file = str_replace( [ '\\', '//', '/' ], DIRECTORY_SEPARATOR, $file );
 
 		if ( !is_readable( $file ) ) {
-			throw new FileNotReadableException( $file );
+			throw new ConfigPreloadFileNotReadableException( $file );
 		}
 
 		$config = require $file;

--- a/src/Exception/ConfigPreloadFileNotReadableException.php
+++ b/src/Exception/ConfigPreloadFileNotReadableException.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace SMW\Exception;
+
+use RuntimeException;
+
+/**
+ * @license GNU GPL v2+
+ * @since 3.2
+ *
+ * @author mwjames
+ */
+class ConfigPreloadFileNotReadableException extends RuntimeException {
+
+	/**
+	 * @since  3.2
+	 *
+	 * @param string $file
+	 */
+	public function __construct( string $file ) {
+
+		$profile = pathinfo( $file, PATHINFO_BASENAME );
+
+		parent::__construct(
+			"The \"$profile\" profile is unknown, missing, or might contain a misspelling.\n\n".
+			"Semantic MediaWiki is currently unable to locate and load the profile from $file."
+		);
+	}
+
+}

--- a/src/SetupCheck.php
+++ b/src/SetupCheck.php
@@ -62,6 +62,11 @@ class SetupCheck {
 	const ERROR_SCHEMA_INVALID_KEY = 'ERROR_SCHEMA_INVALID_KEY';
 
 	/**
+	 * A selected default profile could not be loaded or is unknown.
+	 */
+	const ERROR_CONFIG_PROFILE_UNKNOWN = 'ERROR_CONFIG_PROFILE_UNKNOWN';
+
+	/**
 	 * The system is currently in a maintenance window
 	 */
 	const MAINTENANCE_MODE = 'MAINTENANCE_MODE';
@@ -439,7 +444,7 @@ class SetupCheck {
 	private function createContent( $value, $type ) {
 
 		if ( $value['text'] === 'ERROR_TEXT' ) {
-			$text = $this->errorMessage;
+			$text = str_replace( "\n", '<br>', $this->errorMessage );
 		} elseif ( $value['text'] === 'ERROR_TEXT_MULTIPLE' ) {
 			$errors = explode( "\n", $this->errorMessage );
 			$text = '<ul><li>' . implode( '</li><li>', array_filter( $errors ) ) . '</li></ul>';

--- a/src/UncaughtExceptionHandler.php
+++ b/src/UncaughtExceptionHandler.php
@@ -3,6 +3,7 @@
 namespace SMW;
 
 use ExtensionDependencyError;
+use SMW\Exception\ConfigPreloadFileNotReadableException;
 
 /**
  * @private
@@ -37,6 +38,10 @@ class UncaughtExceptionHandler {
 
 		$message = $e->getMessage();
 
+		if ( $e instanceof ConfigPreloadFileNotReadableException ) {
+			return $this->reportConfigPreloadError( $e );
+		}
+
 		// There is no better way to fetch the specific info other then comparing
 		// a string because there is no dedicated exception thrown by the
 		// `ExtensionRegistry`.
@@ -55,6 +60,21 @@ class UncaughtExceptionHandler {
 		}
 
 		throw $e;
+	}
+
+	private function reportConfigPreloadError( $e ) {
+
+		$this->setupCheck->setErrorMessage(
+			$e->getMessage()
+		);
+
+		$this->setupCheck->setErrorType(
+			SetupCheck::ERROR_CONFIG_PROFILE_UNKNOWN
+		);
+
+		$this->setupCheck->showErrorAndAbort(
+			$this->setupCheck->isCli()
+		);
 	}
 
 	private function reportExtensionRegistryError( $e ) {

--- a/tests/phpunit/Integration/ConfigPreloaderTest.php
+++ b/tests/phpunit/Integration/ConfigPreloaderTest.php
@@ -68,7 +68,7 @@ class ConfigPreloaderTest extends \PHPUnit_Framework_TestCase {
 
 		$instance = new ConfigPreloader();
 
-		$this->expectException( '\SMW\Exception\FileNotReadableException' );
+		$this->expectException( '\SMW\Exception\ConfigPreloadFileNotReadableException' );
 		$instance->loadConfigFrom( 'foo.php' );
 	}
 

--- a/tests/phpunit/Unit/Exception/ConfigPreloadFileNotReadableExceptionTest.php
+++ b/tests/phpunit/Unit/Exception/ConfigPreloadFileNotReadableExceptionTest.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace SMW\Tests\Exception;
+
+use SMW\Exception\ConfigPreloadFileNotReadableException;
+
+/**
+ * @covers \SMW\Exception\ConfigPreloadFileNotReadableException
+ * @group semantic-mediawiki
+ *
+ * @license GNU GPL v2+
+ * @since 3.2
+ *
+ * @author mwjames
+ */
+class ConfigPreloadFileNotReadableExceptionTest extends \PHPUnit_Framework_TestCase {
+
+	public function testCanConstruct() {
+
+		$instance = new ConfigPreloadFileNotReadableException( 'Foo' );
+
+		$this->assertInstanceof(
+			ConfigPreloadFileNotReadableException::class,
+			$instance
+		);
+
+		$this->assertInstanceof(
+			'\RuntimeException',
+			$instance
+		);
+	}
+
+}

--- a/tests/phpunit/Unit/UncaughtExceptionHandlerTest.php
+++ b/tests/phpunit/Unit/UncaughtExceptionHandlerTest.php
@@ -33,6 +33,26 @@ class UncaughtExceptionHandlerTest extends \PHPUnit_Framework_TestCase {
 		);
 	}
 
+	public function testConfigPreloadError() {
+
+		$this->setupCheck->expects( $this->once() )
+			->method( 'showErrorAndAbort' );
+
+		$this->setupCheck->expects( $this->once() )
+			->method( 'setErrorType' )
+			->with( $this->equalTo( \SMW\SetupCheck::ERROR_CONFIG_PROFILE_UNKNOWN ) );
+
+		$instance = new UncaughtExceptionHandler(
+			$this->setupCheck
+		);
+
+		$exception = new \SMW\Exception\ConfigPreloadFileNotReadableException(
+			'Foo'
+		);
+
+		$instance->registerHandler( $exception );
+	}
+
 	public function testExtensionRegistryError() {
 
 		$this->setupCheck->expects( $this->once() )


### PR DESCRIPTION
This PR is made in reference to: #4684, #4438

This PR addresses or contains:

- If someone tries to load a profile #4684 that doesn't exist then we show a "nice" error page to inform and instruct about the issue.
- Adds `ERROR_CONFIG_PROFILE_UNKNOWN`

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed

## Example

### Before

![image](https://user-images.githubusercontent.com/1245473/79641521-8cbd3680-8187-11ea-8379-a54611cb64c4.png)

### After
![image](https://user-images.githubusercontent.com/1245473/79641175-5e3e5c00-8185-11ea-9bce-ca9d9e395873.png)
