### PR TITLE
Add `db-primary-keys` config profile, refs 4684

### DIFF
--- a/data/config/db-primary-keys.php
+++ b/data/config/db-primary-keys.php
@@ -1,0 +1,152 @@
+<?php
+
+use Onoi\MessageReporter\MessageReporter;
+use SMW\Utils\CliMsgFormatter;
+
+/**
+ * This profile adds primary keys to Semantic MediaWiki owned tables to help DB
+ * environments like `Percona XtraDB Cluster` (#4724, #4507) that require those
+ * keys.
+ *
+ * Beware that while the profile is provided as part of the Semantic MediaWiki
+ * software it does NOT imply that systems like `Percona` are officially
+ * supported as there is no test setup that runs the required test suite.
+ *
+ * @see https://www.semantic-mediawiki.org/wiki/Config_preloading
+ *
+ * @since 3.2
+ */
+
+class ConfigPreloadPrimaryKeyTableMutator {
+
+	// #3559
+	const PRIMARY_KEYS = [
+
+		// Common property value tables
+		'smw_di_blob'     => 's_id,p_id,o_hash',
+		'smw_di_bool'     => 's_id,p_id,o_value',
+		'smw_di_coords'   => 's_id,p_id,o_serialized',
+		'smw_di_number'   => 's_id,p_id,o_serialized',
+		'smw_di_time'     => 's_id,p_id,o_serialized',
+		'smw_di_uri'      => 's_id,p_id,o_serialized',
+		'smw_di_wikipage' => 's_id,p_id,o_id',
+
+		// Fixed property value tables
+		'smw_fpt_ask'     => 's_id,o_id',
+		'smw_fpt_askde'   => 's_id,o_serialized',
+		'smw_fpt_askfo'   => 's_id,o_hash',
+		'smw_fpt_askdu'   => 's_id,o_serialized',
+		'smw_fpt_asksi'   => 's_id,o_serialized',
+		'smw_fpt_askst'   => 's_id,o_hash',
+		'smw_fpt_askpa'   => 's_id,o_hash',
+		'smw_fpt_cdat'    => 's_id,o_serialized',
+		'smw_fpt_conc'    => 's_id',
+		'smw_fpt_conv'    => 's_id,o_hash',
+		'smw_fpt_dtitle'  => 's_id,o_hash',
+		'smw_fpt_impo'    => 's_id,o_hash',
+		'smw_fpt_inst'    => 's_id,o_id',
+		'smw_fpt_lcode'   => 's_id,o_hash',
+		'smw_fpt_ledt'    => 's_id,o_id',
+		'smw_fpt_list'    => 's_id,o_hash',
+		'smw_fpt_mdat'    => 's_id,o_serialized',
+		'smw_fpt_media'   => 's_id,o_hash',
+		'smw_fpt_mime'    => 's_id,o_hash',
+		'smw_fpt_newp'    => 's_id,o_value',
+		'smw_fpt_pplb'    => 's_id,o_id',
+		'smw_fpt_prec'    => 's_id,o_serialized',
+		'smw_fpt_pval'    => 's_id,o_hash',
+		'smw_fpt_redi'    => 's_title,s_namespace',
+		'smw_fpt_serv'    => 's_id,o_hash',
+		'smw_fpt_sobj'    => 's_id,o_id',
+		'smw_fpt_subc'    => 's_id,o_id',
+		'smw_fpt_subp'    => 's_id,o_id',
+		'smw_fpt_text'    => 's_id,o_hash',
+		'smw_fpt_type'    => 's_id,o_serialized',
+		'smw_fpt_unit'    => 's_id,o_hash',
+		'smw_fpt_uri'     => 's_id,o_serialized',
+
+		// Other data tables
+		'smw_object_ids'  => 'smw_id',
+		'smw_object_aux'  => 'smw_id',
+		'smw_prop_stats'  => 'p_id',
+		'smw_query_links' => 's_id,o_id',
+		'smw_ft_search'   => 's_id,p_id',
+		'smw_concept_cache' => 's_id,o_id'
+	];
+
+	/**
+	 * @param string $tableName
+	 */
+	public function hasKey( string $tableName ) : bool {
+		return self::PRIMARY_KEYS[$tableName] ?? false;
+	}
+
+	/**
+	 * @param string $tableName
+	 */
+	public function getKey( string $tableName ) : string {
+		return self::PRIMARY_KEYS[$tableName];
+	}
+}
+
+/**
+ * @see https://github.com/SemanticMediaWiki/SemanticMediaWiki/master/docs/technical/code-snippets/hook.sqlstore.installer.beforecreatetablescomplete.md
+ */
+Hooks::register( 'SMW::SQLStore::Installer::BeforeCreateTablesComplete', function( array $tables, MessageReporter $messageReporter ) {
+
+	$cliMsgFormatter = new CliMsgFormatter();
+	$configPreloadPrimaryKeyTableMutator = new ConfigPreloadPrimaryKeyTableMutator();
+
+	$messageReporter->reportMessage(
+		$cliMsgFormatter->section( 'Primary key(s)', 3, '-', true )
+	);
+
+	$i = 0;
+
+	$text = [
+		'The following updates adds primary key information for the tables',
+		'owned by Semantic MediaWiki.'
+	];
+
+	$messageReporter->reportMessage(
+		"\n" . $cliMsgFormatter->wordwrap( $text ) . "\n"
+	);
+
+	$messageReporter->reportMessage(
+		"\n" . $cliMsgFormatter->oneCol( "Checking table definitions ..." )
+	);
+
+	/**
+	 * @var \SMW\SQLStore\TableBuilder\Table[]
+	 */
+	foreach ( $tables as $table ) {
+
+		$tableName = $table->getName();
+
+		if ( !$configPreloadPrimaryKeyTableMutator->hasKey( $tableName ) ) {
+			continue;
+		}
+
+		$i++;
+
+		$table->setPrimaryKey(
+			$configPreloadPrimaryKeyTableMutator->getKey( $tableName )
+		);
+	}
+
+	$messageReporter->reportMessage(
+		$cliMsgFormatter->twoCols( "... run table definition update ...", "$i (tables)", 3 )
+	);
+
+	$messageReporter->reportMessage(
+		$cliMsgFormatter->oneCol( "... done.", 3 )
+	);
+
+} );
+
+return [
+
+	// Modify the upgrade key to make sure an update is forced in the event this
+	// profile is used (or removed).
+	'smwgUpgradeKey' => $GLOBALS['smwgUpgradeKey'] . ':primary'
+];

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -42,6 +42,9 @@
         <testsuite name="semantic-mediawiki-system">
             <directory>tests/phpunit/Integration/System</directory>
         </testsuite>
+        <testsuite name="semantic-mediawiki-structure">
+            <directory>tests/phpunit/Structure</directory>
+        </testsuite>
         <testsuite name="semantic-mediawiki-benchmark">
             <directory>tests/phpunit/Benchmark</directory>
         </testsuite>

--- a/src/ConfigPreloader.php
+++ b/src/ConfigPreloader.php
@@ -18,6 +18,11 @@ use SMW\Exception\ConfigPreloadFileNotReadableException;
 class ConfigPreloader {
 
 	/**
+	 * @var []
+	 */
+	private static $config = [];
+
+	/**
 	 * Loading files from the internal `config` directory that provides some
 	 * predeployed default settings.
 	 *
@@ -73,9 +78,11 @@ class ConfigPreloader {
 			throw new ConfigPreloadFileNotReadableException( $file );
 		}
 
-		$config = require $file;
+		if ( ( $config = require_once $file ) !== true ) {
+			self::$config[$file] = $config;
+		}
 
-		foreach ( $config as $key => $value ) {
+		foreach ( self::$config[$file] as $key => $value ) {
 			$GLOBALS[$key] = $value;
 		}
 	}

--- a/tests/phpunit/Structure/ConfigPreloadTableListPrimaryKeysCompleteTest.php
+++ b/tests/phpunit/Structure/ConfigPreloadTableListPrimaryKeysCompleteTest.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace SMW\Tests\Structure;
+
+use SMW\Services\ServicesFactory;
+use SMW\SQLStore\TableBuilder\TableSchemaManager;
+use SMW\SQLStore\SQLStore;
+use ReflectionClass;
+
+/**
+ * @group semantic-mediawiki
+ *
+ * @license GNU GPL v2+
+ * @since 3.2
+ *
+ * @author mwjames
+ */
+class ConfigPreloadTableListPrimaryKeysCompleteTest extends \PHPUnit_Framework_TestCase {
+
+	const FILENAME = 'db-primary-keys.php';
+
+	public function testCheckTableList() {
+
+		$store = ServicesFactory::getInstance()->getStore( SQLStore::class );
+		$file = $GLOBALS['smwgDir'] . '/data/config/' . self::FILENAME;
+
+		if ( !is_readable( $file ) ) {
+			throw new RuntimeException( "Unable to access $file." );
+		}
+
+		require_once $file;
+
+		$reflectionClass = new ReflectionClass( '\ConfigPreloadPrimaryKeyTableMutator' );
+		$tableKeys = $reflectionClass->getConstant( 'PRIMARY_KEYS' );
+
+		$unlistedTables = [];
+		$connection = $store->getConnection( DB_MASTER );
+
+		$tableSchemaManager = new TableSchemaManager(
+			$store
+		);
+
+		foreach ( $tableSchemaManager->getTables() as $table ) {
+			$tableName = $table->getName();
+
+			if ( isset( $tableKeys[$tableName] ) ) {
+				continue;
+			}
+
+			$unlistedTables[] = $tableName;
+		}
+
+		$this->assertEmpty(
+			$unlistedTables,
+			'Some table definition(s) are missing from the ' . self::FILENAME . ' list including: ' .
+			implode( ', ', $unlistedTables )
+		);
+	}
+
+}


### PR DESCRIPTION
This PR is made in reference to: #4684, #4724 

This PR addresses or contains:

- PR provides a `db-primary-keys.php` config profile that users can invoke in case they need support for primary keys as in #4724 and as outlined in #4507 we won't have them created by default so for those that need them can do `enableSemantics( 'example.org' )->loadDefaultConfigFrom( 'db-primary-keys.php' );` which should be sufficient 
- Providing the profile doesn't mean SMW is supporting the functionality it just provides the profile for convenience
- Also for convenience, the `ConfigPreloadTableListPrimaryKeysCompleteTest` will check whether all SMW owned tables are listed in `db-primary-keys.php` or not and otherwise fail in case a new table is added without being listed in `db-primary-keys.php`
- PR uses the information from #3559 to match the list of primary keys

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed

Fixes #4507 

## Example

Output of `setupStore.php` when the `db-primary-keys.php` is loaded.

```
--- Database setup --------------------------------------------------------

Storage engine:                                                SMWSQLStore3
Database (type/version):                            mysql (10.4.11-MariaDB)

Checking version requirement ...
   ... done.

-------------------------------------------------------- Primary key(s) ---

The following updates adds primary key information for the tables owned by
Semantic MediaWiki.

Checking table definitions ...
   ... run table definition update ...                          39 (tables)
   ... done.

------------------------------------------------------ Core table(s) ------

Checking table smw_object_ids ...
```