### PR TITLE
Dispose entities on unmaintained namespace, add maintenance alert, refs 4468

### DIFF
--- a/i18n/en.json
+++ b/i18n/en.json
@@ -611,6 +611,8 @@
 	"smw-admin-maintenancealerts-lastoptimizationrun-alert": "The system has found that the last [https://www.semantic-mediawiki.org/wiki/Table_optimization table optimization] was run $2 days ago (record from $1) which exceeds the $3 days maintenance threshold. As mentioned in the documentation, running optimizations will allow the query planner to make better decisions about queries therefore it is suggested to run the table optimization on a regular basis.",
 	"smw-admin-maintenancealerts-outdatedentitiesmaxcount-alert-title": "Outdated entities",
 	"smw-admin-maintenancealerts-outdatedentitiesmaxcount-alert": "The system has counted $1 [https://www.semantic-mediawiki.org/wiki/Outdated_entities outdated entities] and reached a critical level of unattended maintenance by exceeding the threshold of $2. It is recommended to run the [https://www.semantic-mediawiki.org/wiki/disposeOutdatedEntities.php <code>disposeOutdatedEntities.php</code>] maintenance script.",
+	"smw-admin-maintenancealerts-invalidentities-alert-title": "Invalid entities",
+	"smw-admin-maintenancealerts-invalidentities-alert": "The system matched $1 [https://www.semantic-mediawiki.org/wiki/Invalid_entities {{PLURAL:$1|entity|entities}}] to an [https://www.semantic-mediawiki.org/wiki/Unmaintained_namespace unmaintained namespace] and it is recommended to run the [https://www.semantic-mediawiki.org/wiki/disposeOutdatedEntities.php <code>disposeOutdatedEntities.php</code>] or [https://www.semantic-mediawiki.org/wiki/rebuildData.php <code>rebuildData.php</code>] maintenance script.",
 	"smw-admin-deprecation-notice-section": "Semantic MediaWiki",
 	"smw-admin-configutation-tab-settings": "Settings",
 	"smw-admin-configutation-tab-namespaces": "Namespaces",

--- a/maintenance/disposeOutdatedEntities.php
+++ b/maintenance/disposeOutdatedEntities.php
@@ -96,8 +96,9 @@ class disposeOutdatedEntities extends \Maintenance {
 		);
 
 		$text = [
-			"This script will remove outdated entities and query link entries from",
-			"tables that hold a reference to the ID marked as outdated",
+			"This script will remove outdated entities and entities rendered",
+			"invalid due to redeclared namespace settings. It will also dispose of",
+			"query link entries from tables that no longer hold a valid entity reference",
 			"in Semantic MediaWiki."
 		];
 

--- a/src/Maintenance/DataRebuilder/OutdatedDisposer.php
+++ b/src/Maintenance/DataRebuilder/OutdatedDisposer.php
@@ -53,7 +53,7 @@ class OutdatedDisposer {
 	public function run() {
 
 		$this->messageReporter->reportMessage(
-			"Removing outdated entities and query links ...\n"
+			"Removing outdated and invalid entities ...\n"
 		);
 
 		$this->messageReporter->reportMessage(
@@ -69,6 +69,26 @@ class OutdatedDisposer {
 				$this->cliMsgFormatter->secondCol( CliMsgFormatter::OK )
 			);
 		}
+
+		$this->messageReporter->reportMessage(
+			$this->cliMsgFormatter->firstCol( '   ... checking invalid entities by namespace ...' )
+		);
+
+		$resultIterator = $this->entityIdDisposerJob->newByNamespaceInvalidEntitiesResultIterator();
+
+		if ( ( $count = $resultIterator->count() ) > 0 ) {
+			$this->disposeOutdatedEntities( $resultIterator, $count );
+		} else {
+			$this->messageReporter->reportMessage(
+				$this->cliMsgFormatter->secondCol( CliMsgFormatter::OK )
+			);
+		}
+
+		$this->messageReporter->reportMessage( "   ... done.\n" );
+
+		$this->messageReporter->reportMessage(
+			"\nRemoving query links ...\n"
+		);
 
 		$this->messageReporter->reportMessage(
 			$this->cliMsgFormatter->firstCol( '   ... checking query links (invalid) ...' )

--- a/src/MediaWiki/Jobs/EntityIdDisposerJob.php
+++ b/src/MediaWiki/Jobs/EntityIdDisposerJob.php
@@ -67,6 +67,22 @@ class EntityIdDisposerJob extends Job {
 	}
 
 	/**
+	 * @since 3.2
+	 *
+	 * @param RequestOptions|null $requestOptions
+	 *
+	 * @return ResultIterator
+	 */
+	public function newByNamespaceInvalidEntitiesResultIterator( RequestOptions $requestOptions = null ) {
+
+		if ( $this->propertyTableIdReferenceDisposer === null ) {
+			$this->propertyTableIdReferenceDisposer = $this->newPropertyTableIdReferenceDisposer();
+		}
+
+		return $this->propertyTableIdReferenceDisposer->newByNamespaceInvalidEntitiesResultIterator( $requestOptions );
+	}
+
+	/**
 	 * @since 3.1
 	 *
 	 * @return ResultIterator

--- a/src/MediaWiki/Specials/Admin/Alerts/ByNamespaceInvalidEntitiesMaintenanceAlertTaskHandler.php
+++ b/src/MediaWiki/Specials/Admin/Alerts/ByNamespaceInvalidEntitiesMaintenanceAlertTaskHandler.php
@@ -1,0 +1,109 @@
+<?php
+
+namespace SMW\MediaWiki\Specials\Admin\Alerts;
+
+use Html;
+use SMW\Store;
+use SMW\Message;
+use SMW\SQLStore\SQLStore;
+use SMW\MediaWiki\Specials\Admin\TaskHandler;
+use SMW\MediaWiki\Specials\Admin\OutputFormatter;
+
+/**
+ * @license GNU GPL v2+
+ * @since   3.2
+ *
+ * @author mwjames
+ */
+class ByNamespaceInvalidEntitiesMaintenanceAlertTaskHandler extends TaskHandler {
+
+	/**
+	 * @var Store
+	 */
+	private $store;
+
+	/**
+	 * @var array
+	 */
+	private $namespacesWithSemanticLinks = [];
+
+	/**
+	 * @since 3.2
+	 *
+	 * @param Store $store
+	 */
+	public function __construct( Store $store ) {
+		$this->store = $store;
+	}
+
+	/**
+	 * @since 3.2
+	 *
+	 * @param array $namespacesWithSemanticLinks
+	 */
+	public function setNamespacesWithSemanticLinks( array $namespacesWithSemanticLinks ) {
+		$this->namespacesWithSemanticLinks = $namespacesWithSemanticLinks;
+	}
+
+	/**
+	 * @since 3.2
+	 *
+	 * {@inheritDoc}
+	 */
+	public function getHtml() {
+
+		$count = $this->fetchCount();
+
+		if ( $count == 0 ) {
+			return '';
+		}
+
+		return $this->buildHTML( $count );
+	}
+
+	private function fetchCount() {
+
+		$connection = $this->store->getConnection( 'mw.db' );
+
+		$row = $connection->selectRow(
+			SQLStore::ID_TABLE,
+			'COUNT(smw_id) AS count',
+			[
+				'smw_namespace NOT IN (' . $connection->makeList( array_keys( $this->namespacesWithSemanticLinks ) ) . ')'
+			],
+			__METHOD__
+		);
+
+		return $row !== false ? (int)$row->count : 0;
+	}
+
+	private function buildHTML( $count ) {
+
+		$html = Html::rawElement(
+			'fieldset',
+			[
+				'class' => "smw-admin-alerts-section-legend"
+			],
+			Html::rawElement(
+				'legend',
+				[
+					'class' => "smw-admin-alerts-section-legend"
+				],
+				$this->msg( "smw-admin-maintenancealerts-invalidentities-alert-title" )
+			) .	Html::rawElement(
+				'p',
+				[],
+				$this->msg( ['smw-admin-maintenancealerts-invalidentities-alert', $count ], Message::PARSE )
+			)
+		);
+
+		return Html::rawElement(
+			'div',
+			[
+				'class' => 'smw-admin-alerts smw-admin-alerts-invalid-entities'
+			],
+			$html
+		);
+	}
+
+}

--- a/src/MediaWiki/Specials/Admin/TaskHandlerFactory.php
+++ b/src/MediaWiki/Specials/Admin/TaskHandlerFactory.php
@@ -18,6 +18,7 @@ use SMW\MediaWiki\Specials\Admin\Alerts\DeprecationNoticeTaskHandler;
 use SMW\MediaWiki\Specials\Admin\Alerts\MaintenanceAlertsTaskHandler;
 use SMW\MediaWiki\Specials\Admin\Alerts\LastOptimizationRunMaintenanceAlertTaskHandler;
 use SMW\MediaWiki\Specials\Admin\Alerts\OutdatedEntitiesMaxCountThresholdMaintenanceAlertTaskHandler;
+use SMW\MediaWiki\Specials\Admin\Alerts\ByNamespaceInvalidEntitiesMaintenanceAlertTaskHandler;
 use SMW\MediaWiki\HookDispatcherAwareTrait;
 use SMW\Store;
 use SMW\SetupFile;
@@ -271,13 +272,24 @@ class TaskHandlerFactory {
 	 */
 	public function newAlertsTaskHandler( $adminFeatures = 0 ) {
 
+		$settings = ApplicationFactory::getInstance()->getSettings();
+
+		$byNamespaceInvalidEntitiesMaintenanceAlertTaskHandler = new ByNamespaceInvalidEntitiesMaintenanceAlertTaskHandler(
+			$this->store
+		);
+
+		$byNamespaceInvalidEntitiesMaintenanceAlertTaskHandler->setNamespacesWithSemanticLinks(
+			$settings->get( 'smwgNamespacesWithSemanticLinks' )
+		);
+
 		$maintenanceAlertsTaskHandlers = [
 			new LastOptimizationRunMaintenanceAlertTaskHandler(
 				new SetupFile()
 			),
 			new OutdatedEntitiesMaxCountThresholdMaintenanceAlertTaskHandler(
 				$this->store
-			)
+			),
+			$byNamespaceInvalidEntitiesMaintenanceAlertTaskHandler
 		];
 
 		$maintenanceAlertsTaskHandler = new MaintenanceAlertsTaskHandler(

--- a/src/SQLStore/PropertyTableIdReferenceDisposer.php
+++ b/src/SQLStore/PropertyTableIdReferenceDisposer.php
@@ -50,6 +50,11 @@ class PropertyTableIdReferenceDisposer {
 	private $fulltextTableUsage = false;
 
 	/**
+	 * @var array
+	 */
+	private $namespacesWithSemanticLinks = [];
+
+	/**
 	 * @since 2.4
 	 *
 	 * @param SQLStore $store
@@ -75,6 +80,15 @@ class PropertyTableIdReferenceDisposer {
 	 */
 	public function setFulltextTableUsage( bool $fulltextTableUsage ) {
 		$this->fulltextTableUsage = $fulltextTableUsage;
+	}
+
+	/**
+	 * @since 3.2
+	 *
+	 * @param array $namespacesWithSemanticLinks
+	 */
+	public function setNamespacesWithSemanticLinks( array $namespacesWithSemanticLinks ) {
+		$this->namespacesWithSemanticLinks = $namespacesWithSemanticLinks;
 	}
 
 	/**
@@ -140,6 +154,37 @@ class PropertyTableIdReferenceDisposer {
 			SQLStore::ID_TABLE,
 			[ 'smw_id' ],
 			[ 'smw_iw' => SMW_SQL3_SMWDELETEIW ],
+			__METHOD__,
+			$options
+		);
+
+		return new ResultIterator( $res );
+	}
+
+	/**
+	 * @since 3.2
+	 *
+	 * @param RequestOptions|null $requestOptions
+	 *
+	 * @return ResultIterator
+	 */
+	public function newByNamespaceInvalidEntitiesResultIterator( RequestOptions $requestOptions = null ) {
+
+		$options = [];
+
+		if ( $requestOptions !== null ) {
+			$options = [
+				'LIMIT'  => $requestOptions->getLimit(),
+				'OFFSET' => $requestOptions->getOffset()
+			];
+		}
+
+		$res = $this->connection->select(
+			SQLStore::ID_TABLE,
+			[ 'smw_id' ],
+			[
+				'smw_namespace NOT IN (' . $this->connection->makeList( array_keys( $this->namespacesWithSemanticLinks ) ) . ')'
+			],
 			__METHOD__,
 			$options
 		);

--- a/src/SQLStore/SQLStoreFactory.php
+++ b/src/SQLStore/SQLStoreFactory.php
@@ -1027,6 +1027,7 @@ class SQLStoreFactory {
 	public function newPropertyTableIdReferenceDisposer() {
 
 		$applicationFactory = ApplicationFactory::getInstance();
+		$settings = $applicationFactory->getSettings();
 
 		$propertyTableIdReferenceDisposer = new PropertyTableIdReferenceDisposer(
 			$this->store,
@@ -1038,7 +1039,11 @@ class SQLStoreFactory {
 		);
 
 		$propertyTableIdReferenceDisposer->setFulltextTableUsage(
-			$applicationFactory->getSettings()->get( 'smwgEnabledFulltextSearch' )
+			$settings->get( 'smwgEnabledFulltextSearch' )
+		);
+
+		$propertyTableIdReferenceDisposer->setNamespacesWithSemanticLinks(
+			$settings->get( 'smwgNamespacesWithSemanticLinks' )
 		);
 
 		return $propertyTableIdReferenceDisposer;

--- a/tests/phpunit/Integration/Maintenance/DisposeOutdatedEntitiesTest.php
+++ b/tests/phpunit/Integration/Maintenance/DisposeOutdatedEntitiesTest.php
@@ -52,7 +52,12 @@ class DisposeOutdatedEntitiesTest extends DatabaseTestCase {
 		);
 
 		$this->assertContains(
-			'Removing outdated entities and query links',
+			'Removing outdated and invalid entities',
+			$this->spyMessageReporter->getMessagesAsString()
+		);
+
+		$this->assertContains(
+			'Removing query links',
 			$this->spyMessageReporter->getMessagesAsString()
 		);
 	}

--- a/tests/phpunit/Unit/Maintenance/DataRebuilder/OutdatedDisposerTest.php
+++ b/tests/phpunit/Unit/Maintenance/DataRebuilder/OutdatedDisposerTest.php
@@ -66,12 +66,16 @@ class OutdatedDisposerTest extends \PHPUnit_Framework_TestCase {
 			->disableOriginalConstructor()
 			->getMock();
 
-		$resultIterator->expects( $this->once() )
+		$resultIterator->expects( $this->exactly( 2 ) )
 			->method( 'count' )
 			->will( $this->returnValue( 42 ) );
 
 		$this->entityIdDisposerJob->expects( $this->once() )
 			->method( 'newOutdatedEntitiesResultIterator' )
+			->will( $this->returnValue( $resultIterator ) );
+
+		$this->entityIdDisposerJob->expects( $this->once() )
+			->method( 'newByNamespaceInvalidEntitiesResultIterator' )
 			->will( $this->returnValue( $resultIterator ) );
 
 		$this->entityIdDisposerJob->expects( $this->once() )
@@ -85,7 +89,7 @@ class OutdatedDisposerTest extends \PHPUnit_Framework_TestCase {
 		$this->entityIdDisposerJob->expects( $this->once() )
 			->method( 'dispose' );
 
-		$this->iteratorFactory->expects( $this->once() )
+		$this->iteratorFactory->expects( $this->exactly( 2 ) )
 			->method( 'newChunkedIterator' )
 			->will( $this->returnValue( $chunkedIterator ) );
 
@@ -135,6 +139,10 @@ class OutdatedDisposerTest extends \PHPUnit_Framework_TestCase {
 
 		$this->entityIdDisposerJob->expects( $this->once() )
 			->method( 'newOutdatedEntitiesResultIterator' )
+			->will( $this->returnValue( $this->resultIterator ) );
+
+		$this->entityIdDisposerJob->expects( $this->once() )
+			->method( 'newByNamespaceInvalidEntitiesResultIterator' )
 			->will( $this->returnValue( $this->resultIterator ) );
 
 		$this->entityIdDisposerJob->expects( $this->once() )
@@ -195,6 +203,10 @@ class OutdatedDisposerTest extends \PHPUnit_Framework_TestCase {
 
 		$this->entityIdDisposerJob->expects( $this->once() )
 			->method( 'newOutdatedEntitiesResultIterator' )
+			->will( $this->returnValue( $this->resultIterator ) );
+
+		$this->entityIdDisposerJob->expects( $this->once() )
+			->method( 'newByNamespaceInvalidEntitiesResultIterator' )
 			->will( $this->returnValue( $this->resultIterator ) );
 
 		$this->entityIdDisposerJob->expects( $this->once() )

--- a/tests/phpunit/Unit/MediaWiki/Jobs/EntityIdDisposerJobTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Jobs/EntityIdDisposerJobTest.php
@@ -80,6 +80,20 @@ class EntityIdDisposerJobTest extends \PHPUnit_Framework_TestCase {
 		);
 	}
 
+	public function testCanConstructByNamespaceInvalidEntitiesResultIterator() {
+
+		$title = $this->getMockBuilder( 'Title' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$instance = new EntityIdDisposerJob( $title );
+
+		$this->assertInstanceOf(
+			'\SMW\Iterators\ResultIterator',
+			$instance->newByNamespaceInvalidEntitiesResultIterator()
+		);
+	}
+
 	public function testCanConstructOutdatedQueryLinksResultIterator() {
 
 		$title = $this->getMockBuilder( 'Title' )

--- a/tests/phpunit/Unit/MediaWiki/Specials/Admin/Alerts/ByNamespaceInvalidEntitiesMaintenanceAlertTaskHandlerTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Specials/Admin/Alerts/ByNamespaceInvalidEntitiesMaintenanceAlertTaskHandlerTest.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace SMW\Tests\MediaWiki\Specials\Admin\Alerts;
+
+use SMW\MediaWiki\Specials\Admin\Alerts\ByNamespaceInvalidEntitiesMaintenanceAlertTaskHandler;
+use SMW\Tests\PHPUnitCompat;
+
+/**
+ * @covers \SMW\MediaWiki\Specials\Admin\Alerts\ByNamespaceInvalidEntitiesMaintenanceAlertTaskHandler
+ * @group semantic-mediawiki
+ *
+ * @license GNU GPL v2+
+ * @since 3.2
+ *
+ * @author mwjames
+ */
+class ByNamespaceInvalidEntitiesMaintenanceAlertTaskHandlerTest extends \PHPUnit_Framework_TestCase {
+
+	use PHPUnitCompat;
+
+	private $store;
+
+	protected function setUp() : void {
+		parent::setUp();
+
+		$this->store = $this->getMockBuilder( '\SMW\SQLStore\SQLStore' )
+			->disableOriginalConstructor()
+			->getMock();
+	}
+
+	public function testCanConstruct() {
+
+		$this->assertInstanceOf(
+			ByNamespaceInvalidEntitiesMaintenanceAlertTaskHandler::class,
+			new ByNamespaceInvalidEntitiesMaintenanceAlertTaskHandler( $this->store )
+		);
+	}
+
+	public function testGetHtml() {
+
+		$connection = $this->getMockBuilder( '\SMW\MediaWiki\Database' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$connection->expects( $this->once() )
+			->method( 'selectRow' )
+			->will( $this->returnValue( (object)[ 'count' => 50000 ] ) );
+
+		$this->store->expects( $this->once() )
+			->method( 'getConnection' )
+			->will( $this->returnValue( $connection ) );
+
+		$instance = new ByNamespaceInvalidEntitiesMaintenanceAlertTaskHandler(
+			$this->store
+		);
+
+		$this->assertContains(
+			'smw-admin-alerts-invalid-entities',
+			$instance->getHtml()
+		);
+	}
+
+}

--- a/tests/phpunit/Unit/SQLStore/PropertyTableIdReferenceDisposerTest.php
+++ b/tests/phpunit/Unit/SQLStore/PropertyTableIdReferenceDisposerTest.php
@@ -212,6 +212,34 @@ class PropertyTableIdReferenceDisposerTest extends \PHPUnit_Framework_TestCase {
 		);
 	}
 
+	public function testCanConstructByNamespaceInvalidEntitiesResultIterator() {
+
+		$connection = $this->getMockBuilder( '\SMW\MediaWiki\Database' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$connection->expects( $this->atLeastOnce() )
+			->method( 'select' )
+			->will( $this->returnValue( [] ) );
+
+		$this->store->expects( $this->any() )
+			->method( 'getConnection' )
+			->will( $this->returnValue( $connection ) );
+
+		$instance = new PropertyTableIdReferenceDisposer(
+			$this->store
+		);
+
+		$instance->setEventDispatcher(
+			$this->eventDispatcher
+		);
+
+		$this->assertInstanceOf(
+			'\SMW\Iterators\ResultIterator',
+			$instance->newByNamespaceInvalidEntitiesResultIterator()
+		);
+	}
+
 	public function testCleanUpTableEntriesByRow() {
 
 		$row = new \stdClass;


### PR DESCRIPTION
This PR is made in reference to: #4468

This PR addresses or contains:

- The `disposeOutdatedEntities.php` script will check for "invalid entities" on unmaintained namespaces which may have been lingering in the object table due to a removed namespace setting where a user did not run a rebuild of the data as suggested by [0]
- Adds a maintenance alert for invalid entities by namespace

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed

[0] https://www.semantic-mediawiki.org/wiki/Help:Custom_namespaces

## Example

![image](https://user-images.githubusercontent.com/1245473/80277870-85df7800-86e1-11ea-9b40-72aafafdd6f9.png)

```
$ php maintenance/disposeOutdatedEntities.php

Semantic MediaWiki:                                             3.2.0-alpha
MediaWiki:                                                     1.35.0-alpha

--- About -----------------------------------------------------------------

This script will remove outdated entities and entities rendered invalid due
to redeclared namespace settings. It will also dispose of query link
entries from tables that no longer hold a valid entity reference in
Semantic MediaWiki.

--- Outdated entitie(s) ---------------------------------------------------

Removing outdated and invalid entities ...
   ... checking outdated entities ...                                     ✓
   ... checking invalid entities by namespace ...
       ... cleaning up entity                                   4836 (100%)
       ... removed (IDs) ...                                              1
   ... done.

Removing query links ...
   ... checking query links (invalid) ...                                 ✓
   ... checking query links (unassigned) ...                              ✓
   ... done.
```