### PR TITLE
WIP: Add class="" wrapper to attribute values for CSS styling

### DIFF
--- a/src/DataValues/ValueFormatters/CodeStringValueFormatter.php
+++ b/src/DataValues/ValueFormatters/CodeStringValueFormatter.php
@@ -23,6 +23,11 @@ class CodeStringValueFormatter extends StringValueFormatter {
 	}
 
 	/**
+	 * @param \SMW\DataValues\StringValue $dataValue
+	 * @param int $type
+	 * @param mixed $linker
+	 *
+	 * @return string
 	 * @see StringValueFormatter::doFormat
 	 */
 	protected function doFormat( $dataValue, $type, $linker ) {

--- a/src/DataValues/ValueFormatters/StringValueFormatter.php
+++ b/src/DataValues/ValueFormatters/StringValueFormatter.php
@@ -65,6 +65,13 @@ class StringValueFormatter extends DataValueFormatter {
 		return $this->doFormat( $dataValue, $type, $linker );
 	}
 
+	/**
+	 * @param \SMW\DataValues\StringValue $dataValue
+	 * @param int $type
+	 * @param mixed $linker
+	 *
+	 * @return string
+	 */
 	protected function doFormat( $dataValue, $type, $linker ) {
 
 		$text = (string)$dataValue->getDataItem()->getString();

--- a/src/DataValues/ValueFormatters/StringValueFormatter.php
+++ b/src/DataValues/ValueFormatters/StringValueFormatter.php
@@ -62,7 +62,14 @@ class StringValueFormatter extends DataValueFormatter {
 			return $dataValue->getDataItem()->getUserValue();
 		}
 
-		return $this->doFormat( $dataValue, $type, $linker );
+		$formatted = $this->doFormat( $dataValue, $type, $linker );
+
+		if ( $type === self::HTML_SHORT || $type === self::HTML_LONG ) {
+			$attribute_key = $dataValue->getProperty()->getKey();
+			return "<span class=\"smw-attribute smw-attribute-$attribute_key\">$formatted</span>";
+		}
+
+		return $formatted;
 	}
 
 	/**


### PR DESCRIPTION
This PR addresses or contains one new feature:
- Wrap HTML output of property values in CSS-able `<span />` tag.

    This will allow for custom styling such as an icon before the text
    added by wiki admins.

I couldn't get the PHPUnit tests to run locally yet. After 2 hours, I give up for today and let Travis do the work 😢 

<!--
This PR includes:
- [ ] Tests (unit/integration)
- [ ] CI build passed (

-->