### PR TITLE
Switch parser check, refs 4330

### DIFF
--- a/src/Parser/RecursiveTextProcessor.php
+++ b/src/Parser/RecursiveTextProcessor.php
@@ -228,7 +228,7 @@ class RecursiveTextProcessor {
 	public function recursivePreprocess( $text ) {
 
 		// not during parsing, no preprocessing needed, still protect the result
-		if ( $this->parser === null || !$this->parser->getTitle() instanceof Title || !$this->parser->getOptions() instanceof ParserOptions ) {
+		if ( $this->parser === null || !$this->parser->getOptions() instanceof ParserOptions || !$this->parser->getTitle() instanceof Title ) {
 			return $this->recursiveAnnotation ? $text : '[[SMW::off]]' . $text . '[[SMW::on]]';
 		}
 
@@ -269,7 +269,7 @@ class RecursiveTextProcessor {
 		}
 
 		$this->recursionDepth++;
-		$isValid = $this->parser->getTitle() instanceof Title && $this->parser->getOptions() instanceof ParserOptions;
+		$isValid = $this->parser->getOptions() instanceof ParserOptions && $this->parser->getTitle() instanceof Title;
 
 		if ( $this->recursionDepth <= $this->maxRecursionDepth && $isValid ) {
 				$text = $this->parser->recursiveTagParse( $text );


### PR DESCRIPTION
This PR is made in reference to: #4330

This PR addresses or contains:

- Switching the position of the check to avoid #4330

This PR includes:
- [ ] Tests (unit/integration)
- [x] CI build passed

```
[78c7599b4b827813955e1ccd] /mw-master/index.php?title=Special:Ask&q=%5B%5B%3A%2B%5D%5D+%5B%5BCategory%3ASample+pages%5D%5D&p=mainlabel%3D%2Fformat%3Dplainlist%2Fintro%3D-5B-5BMain-20Page-5D-5D-20-3Cspan-20class%3D%22smw-2Dhighlighter%22-20data-2Dtype%3D%226%22-20data-2Dstate%3D%22persistent%22-20data-2Dtitle%3D%22Information%22-20title%3D%22test%22-3E-3Cspan-20class%3D%22smwtticon-20info%22-3E-3C-2Fspan-3E-3Cspan-20class%3D%22smwttcontent%22-3Etest-3C-2Fspan-3E-3C-2Fspan-3E&sort=&order=asc&offset=2&limit=2&eq=yes TypeError from line 960 of ...\includes\parser\Parser.php: Return value of Parser::getTitle() must be an instance of Title, null returned

Backtrace:

#0 ...\includes\StubObject.php(112): Parser->getTitle()
#1 ...\includes\StubObject.php(138): StubObject->_call(string, array)
#2 ...\extensions\SemanticMediaWiki\src\Parser\RecursiveTextProcessor.php(231): StubObject->__call(string, array)
#3 ...\extensions\SemanticMediaWiki\src\Query\ResultPrinters\ResultPrinter.php(385): SMW\Parser\RecursiveTextProcessor->recursivePreprocess(string)
#4 ...\extensions\SemanticMediaWiki\src\Query\ResultPrinters\ResultPrinter.php(340): SMW\Query\ResultPrinters\ResultPrinter->handleNonFileResult(string, SMW\Query\QueryResult, integer)
#5 ...\extensions\SemanticMediaWiki\src\Query\ResultPrinters\ResultPrinter.php(302): SMW\Query\ResultPrinters\ResultPrinter->buildResult(SMW\Query\QueryResult)
#6 ...\extensions\SemanticMediaWiki\src\MediaWiki\Specials\SpecialAsk.php(501): SMW\Query\ResultPrinters\ResultPrinter->getResult(SMW\Query\QueryResult, array, integer)
#7 ...\extensions\SemanticMediaWiki\src\MediaWiki\Specials\SpecialAsk.php(315): SMW\MediaWiki\Specials\SpecialAsk->fetchResults(SMW\Query\ResultPrinters\ListResultPrinter, SMWQuery, SMW\Utils\UrlArgs)
#8 ...\extensions\SemanticMediaWiki\src\MediaWiki\Specials\SpecialAsk.php(170): SMW\MediaWiki\Specials\SpecialAsk->makeHTMLResult()
#9 ...\includes\specialpage\SpecialPage.php(575): SMW\MediaWiki\Specials\SpecialAsk->execute(NULL)
#10 ...\includes\specialpage\SpecialPageFactory.php(621): SpecialPage->run(NULL)
#11 ...\includes\MediaWiki.php(298): MediaWiki\Special\SpecialPageFactory->executePath(Title, RequestContext)
#12 ...\includes\MediaWiki.php(971): MediaWiki->performRequest()
#13 ...\includes\MediaWiki.php(534): MediaWiki->main()
#14 ...\index.php(47): MediaWiki->run()
#15 {main}
```
