### PR TITLE
Fix wikitext not parsed on "Special:Ask"

### DIFF
--- a/src/Query/ResultPrinters/ResultPrinter.php
+++ b/src/Query/ResultPrinters/ResultPrinter.php
@@ -382,19 +382,19 @@ abstract class ResultPrinter implements IResultPrinter {
 		// Apply intro parameter
 		if ( ( $this->mIntro ) && ( $results->getCount() > 0 ) ) {
 			if ( $outputmode == SMW_OUTPUT_HTML && $this->isHTML ) {
- 				$result = Message::get( [ 'smw-parse', $this->mIntro ], Message::PARSE ) . $result;
- 			} elseif ( $outputmode !== SMW_OUTPUT_RAW ) {
- 				$result = $this->mIntro . $result;
- 			}
+				$result = Message::get( [ 'smw-parse', $this->mIntro ], Message::PARSE ) . $result;
+			} elseif ( $outputmode !== SMW_OUTPUT_RAW ) {
+				$result = $this->mIntro . $result;
+			}
 		}
 
 		// Apply outro parameter
 		if ( ( $this->mOutro ) && ( $results->getCount() > 0 ) ) {
 			if ( $outputmode == SMW_OUTPUT_HTML && $this->isHTML ) {
- 				$result = $result . Message::get( [ 'smw-parse', $this->mOutro ], Message::PARSE );
- 			} elseif ( $outputmode !== SMW_OUTPUT_RAW ) {
- 				$result = $result . $this->mOutro;
- 			}
+				$result = $result . Message::get( [ 'smw-parse', $this->mOutro ], Message::PARSE );
+			} elseif ( $outputmode !== SMW_OUTPUT_RAW ) {
+				$result = $result . $this->mOutro;
+			}
 		}
 
 		// Preprocess embedded templates if needed

--- a/src/Query/ResultPrinters/ResultPrinter.php
+++ b/src/Query/ResultPrinters/ResultPrinter.php
@@ -381,20 +381,20 @@ abstract class ResultPrinter implements IResultPrinter {
 
 		// Apply intro parameter
 		if ( ( $this->mIntro ) && ( $results->getCount() > 0 ) ) {
-			if ( $outputmode == SMW_OUTPUT_HTML ) {
-				$result = Message::get( [ 'smw-parse', $this->mIntro ], Message::PARSE ) . $result;
-			} elseif ( $outputmode !== SMW_OUTPUT_RAW ) {
-				$result = $this->mIntro . $result;
-			}
+			if ( $outputmode == SMW_OUTPUT_HTML && $this->isHTML ) {
+ 				$result = Message::get( [ 'smw-parse', $this->mIntro ], Message::PARSE ) . $result;
+ 			} elseif ( $outputmode !== SMW_OUTPUT_RAW ) {
+ 				$result = $this->mIntro . $result;
+ 			}
 		}
 
 		// Apply outro parameter
 		if ( ( $this->mOutro ) && ( $results->getCount() > 0 ) ) {
-			if ( $outputmode == SMW_OUTPUT_HTML ) {
-				$result = $result . Message::get( [ 'smw-parse', $this->mOutro ], Message::PARSE );
-			} elseif ( $outputmode !== SMW_OUTPUT_RAW ) {
-				$result = $result . $this->mOutro;
-			}
+			if ( $outputmode == SMW_OUTPUT_HTML && $this->isHTML ) {
+ 				$result = $result . Message::get( [ 'smw-parse', $this->mOutro ], Message::PARSE );
+ 			} elseif ( $outputmode !== SMW_OUTPUT_RAW ) {
+ 				$result = $result . $this->mOutro;
+ 			}
 		}
 
 		// Preprocess embedded templates if needed


### PR DESCRIPTION
This PR is made in reference to: https://github.com/SemanticMediaWiki/SemanticMediaWiki/issues/4738 (Wikitext not parsed on "Special:Ask" when used with `intro`  and `outro` parameters)

This PR addresses or contains:
- Fix per James comment https://github.com/SemanticMediaWiki/SemanticMediaWiki/issues/4738#issuecomment-619439901

This PR includes:
- [ ] Tests (unit/integration)
- [ ] CI build passed

Fixes https://github.com/SemanticMediaWiki/SemanticMediaWiki/issues/4738