### PR TITLE
Check `smwgIgnoreExtensionRegistrationCheck` in hook, refs 4742

### DIFF
--- a/src/MediaWiki/Hooks.php
+++ b/src/MediaWiki/Hooks.php
@@ -153,7 +153,11 @@ class Hooks {
 
 			$beforePageDisplay->setOptions(
 				[
-					'SMW_EXTENSION_LOADED' => defined( 'SMW_EXTENSION_LOADED' )
+					'SMW_EXTENSION_LOADED' => defined( 'SMW_EXTENSION_LOADED' ),
+
+					// We might run out of the Semantic MediaWiki context hence
+					// rely on $GLOBALS to fetch the latest value
+					'smwgIgnoreExtensionRegistrationCheck' => $GLOBALS['smwgIgnoreExtensionRegistrationCheck']
 				]
 			);
 

--- a/src/MediaWiki/Hooks/BeforePageDisplay.php
+++ b/src/MediaWiki/Hooks/BeforePageDisplay.php
@@ -33,7 +33,9 @@ class BeforePageDisplay implements HookListener {
 	 */
 	public function informAboutExtensionAvailability( OutputPage $outputPage ) {
 
-		if ( $this->getOption( 'SMW_EXTENSION_LOADED' ) ) {
+		if (
+			$this->getOption( 'SMW_EXTENSION_LOADED' ) ||
+			$this->getOption( 'smwgIgnoreExtensionRegistrationCheck' ) ) {
 			return;
 		}
 

--- a/tests/phpunit/Unit/MediaWiki/Hooks/BeforePageDisplayTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Hooks/BeforePageDisplayTest.php
@@ -84,6 +84,23 @@ class BeforePageDisplayTest extends \PHPUnit_Framework_TestCase {
 		$instance->informAboutExtensionAvailability( $this->outputPage );
 	}
 
+	public function testIgnoreInformAboutExtensionAvailability() {
+
+		$this->outputPage->expects( $this->never() )
+			->method( 'prependHTML' );
+
+		$instance = new BeforePageDisplay();
+
+		$instance->setOptions(
+			[
+				'SMW_EXTENSION_LOADED' => false,
+				'smwgIgnoreExtensionRegistrationCheck' => true
+			]
+		);
+
+		$instance->informAboutExtensionAvailability( $this->outputPage );
+	}
+
 	public function testModules() {
 
 		$user = $this->getMockBuilder( '\User' )


### PR DESCRIPTION
This PR is made in reference to: #4742

This PR addresses or contains:

- Need to check `smwgIgnoreExtensionRegistrationCheck` directly when `enableSemantics` isn't used

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed

Fixes #4742