### PR TITLE
Exclude MonolingualText from `Has fields` examination, refs 4656

### DIFF
--- a/src/Property/DeclarationExaminer/UserdefinedPropertyExaminer.php
+++ b/src/Property/DeclarationExaminer/UserdefinedPropertyExaminer.php
@@ -6,6 +6,7 @@ use SMW\DIProperty;
 use SMW\Property\DeclarationExaminer as IDeclarationExaminer;
 use SMW\DataTypeRegistry;
 use SMW\Property\Annotators\MandatoryTypePropertyAnnotator;
+use SMW\DataValues\MonolingualTextValue;
 use SMWDataItem as DataItem;
 use SMW\Store;
 use SMW\Message;
@@ -75,8 +76,14 @@ class UserdefinedPropertyExaminer extends DeclarationExaminer {
 			return;
 		}
 
+		$type = $property->findPropertyTypeID();
+
+		if ( $type === MonolingualTextValue::TYPE_ID ) {
+			return;
+		}
+
 		$semanticData = $this->getSemanticData();
-		$prop = new DIProperty( $property->findPropertyTypeID() );
+		$prop = new DIProperty( $type );
 		$pv = $semanticData->getPropertyValues( new DIProperty( '_LIST' ) );
 
 		// #3522

--- a/tests/phpunit/Unit/Property/DeclarationExaminer/UserdefinedPropertyExaminerTest.php
+++ b/tests/phpunit/Unit/Property/DeclarationExaminer/UserdefinedPropertyExaminerTest.php
@@ -131,6 +131,28 @@ class UserdefinedPropertyExaminerTest extends \PHPUnit_Framework_TestCase {
 		);
 	}
 
+	public function testIgnoreRecordType_MonolingualText() {
+
+		$dataItemFactory = new DataItemFactory();
+
+		$instance = new UserdefinedPropertyExaminer(
+			$this->declarationExaminer,
+			$this->store
+		);
+
+		$property = $dataItemFactory->newDIProperty( 'Foo' );
+		$property->setPropertyValueType( '_mlt_rec' );
+
+		$instance->check(
+			$property
+		);
+
+		$this->assertNotContains(
+			'smw-property-req-violation-missing-fields',
+			$instance->getMessagesAsString()
+		);
+	}
+
 	/**
 	 * @dataProvider recordTypeProvider
 	 */


### PR DESCRIPTION
This PR is made in reference to: #4656

This PR addresses or contains:

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed
