### PR TITLE
Add `PropertyFilter`, refs 4479

### DIFF
--- a/src/Schema/README.md
+++ b/src/Schema/README.md
@@ -38,7 +38,6 @@ In the example above, `FOO_SCHEMA` refers to the type name and any attributes as
 - [`CLASS_CONSTRAINT_SCHEMA`](https://github.com/SemanticMediaWiki/SemanticMediaWiki/blob/master/src/Schema/docs/class.constraint.md)
 - [`PROPERTY_PROFILE_SCHEMA`](https://github.com/SemanticMediaWiki/SemanticMediaWiki/blob/master/src/Schema/docs/property.profile.md)
 
-
 ## Technical notes
 
 <pre>
@@ -55,6 +54,7 @@ In the example above, `FOO_SCHEMA` refers to the type name and any attributes as
 │		/src/Schema/Filters (SMW\Schema\Filters)
 │		├─ CategoryFilter
 │		├─ NamespaceFilter
+│		├─ PropertyFilter
 │
 /src/MediaWiki (SMW\MediaWiki)
 	└─ Content

--- a/src/Schema/SchemaFilterFactory.php
+++ b/src/Schema/SchemaFilterFactory.php
@@ -4,6 +4,7 @@ namespace SMW\Schema;
 
 use SMW\Schema\Filters\NamespaceFilter;
 use SMW\Schema\Filters\CategoryFilter;
+use SMW\Schema\Filters\PropertyFilter;
 use SMW\Schema\Filters\CompositeFilter;
 use SMW\DIWikiPage;
 
@@ -46,6 +47,17 @@ class SchemaFilterFactory {
 	 */
 	public function newCategoryFilter( $categories ) : CategoryFilter {
 		return new CategoryFilter( $categories );
+	}
+
+	/**
+	 * @since 3.2
+	 *
+	 * @param string|array|callable $properties
+	 *
+	 * @return PropertyFilter
+	 */
+	public function newPropertyFilter( $properties ) : PropertyFilter {
+		return new PropertyFilter( $properties );
 	}
 
 }

--- a/src/Schema/docs/filter.md
+++ b/src/Schema/docs/filter.md
@@ -35,6 +35,7 @@ Building compsite filters is possible as well by combining different condition s
 
 - The `category` conditional is implemented in `CategoryFilter`
 - The `namespace` conditional is implemented in `NamespaceFilter`
+- The `property` conditional is implemented in `PropertyFilter`
 
 To be able to use above filters without modifications the following format is expected from a schema that relies on those conditionals. A single filter should be declared with something like:
 

--- a/tests/phpunit/Fixtures/Schema/fake_namespace_category_property_action_rule_schema_6.json
+++ b/tests/phpunit/Fixtures/Schema/fake_namespace_category_property_action_rule_schema_6.json
@@ -1,0 +1,45 @@
+{
+	"type": "FAKE_TYPE",
+	"filter_rules": {
+		"rule_6_1": {
+			"if": {
+				"action": [ "edit", "view" ],
+				"property": "property-6-a",
+				"namespace": "NS_HELP",
+				"category": [ "category-6-a", "category-6-b" ]
+			},
+			"then": {
+				"action": "6_1"
+			}
+		},
+		"rule_6_2": {
+			"if": {
+				"action": [ "edit" ],
+				"property": { "allOf" : [ "property-6-a", "property-6-b" ] },
+				"namespace": [ "NS_MAIN", "NS_HELP" ],
+				"category": { "oneOf" : [ "category-6-a", "category-6-b" ] }
+			},
+			"then": {
+				"action": "6_2"
+			}
+		},
+		"rule_6_3": {
+			"if": {
+				"action": [ "view", "delete" ],
+				"property": "property-6-a"
+			},
+			"then": {
+				"action": "6_3"
+			}
+		},
+		"rule_6_4": {
+			"if": {
+				"action": "delete",
+				"property": "property-6-a"
+			},
+			"then": {
+				"action": "6_4"
+			}
+		}
+	}
+}

--- a/tests/phpunit/Unit/Schema/Filters/PropertyFilterTest.php
+++ b/tests/phpunit/Unit/Schema/Filters/PropertyFilterTest.php
@@ -1,0 +1,471 @@
+<?php
+
+namespace SMW\Tests\Schema\Filters;
+
+use SMW\Schema\Filters\PropertyFilter;
+use SMW\Schema\Compartment;
+use SMW\Schema\Rule;
+use SMW\Schema\CompartmentIterator;
+use SMW\Tests\PHPUnitCompat;
+
+/**
+ * @covers \SMW\Schema\Filters\PropertyFilter
+ * @group semantic-mediawiki
+ *
+ * @license GNU GPL v2+
+ * @since 3.2
+ *
+ * @author mwjames
+ */
+class PropertyFilterTest extends \PHPUnit_Framework_TestCase {
+
+	use PHPUnitCompat;
+
+	public function testCanConstruct() {
+
+		$this->assertInstanceOf(
+			PropertyFilter::class,
+			new PropertyFilter()
+		);
+	}
+
+	public function testGetName() {
+
+		$instance = new PropertyFilter();
+
+		$this->assertEquals(
+			'property',
+			$instance->getName()
+		);
+	}
+
+	public function testIfCondition() {
+
+		$compartment = $this->getMockBuilder( '\SMW\Schema\Compartment' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$compartment->expects( $this->once() )
+			->method( 'get' )
+			->with(	$this->equalTo( 'if.property' ) );
+
+		$instance = new PropertyFilter();
+		$instance->filter( $compartment );
+	}
+
+	public function testNoCondition_FilterNotRequired() {
+
+		$compartment = $this->getMockBuilder( '\SMW\Schema\Compartment' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$compartment->expects( $this->once() )
+			->method( 'get' )
+			->with(	$this->equalTo( 'if.property' ) );
+
+		$instance = new PropertyFilter();
+		$instance->addOption( PropertyFilter::FILTER_CONDITION_NOT_REQUIRED, true );
+
+		$instance->filter( $compartment );
+
+		$this->assertEquals(
+			[ $compartment ],
+			$instance->getMatches()
+		);
+	}
+
+	public function testFilterOnCallbackWhileFailingReturnFormat_ThrowsException() {
+
+		$compartment = $this->getMockBuilder( '\SMW\Schema\Compartment' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$callback = function() {
+			return null;
+		};
+
+		$instance = new PropertyFilter( $callback );
+
+		$this->expectException( '\RuntimeException' );
+		$instance->filter( $compartment );
+	}
+
+	/**
+	 * @dataProvider propertyFilterProvider
+	 */
+	public function testHasMatches_Compartment( $properties, $compartment, $expected ) {
+
+		$instance = new PropertyFilter(
+			$properties
+		);
+
+		$instance->filter(
+			new Compartment( $compartment )
+		);
+
+		$this->assertEquals(
+			$expected,
+			$instance->hasMatches()
+		);
+	}
+
+	/**
+	 * @dataProvider propertyFilterProvider
+	 */
+	public function testHasMatches_Callback_Compartment( $properties, $compartment, $expected ) {
+
+		$callback = function() use ( $properties ) {
+			return $properties;
+		};
+
+		$instance = new PropertyFilter(
+			$callback
+		);
+
+		$instance->filter(
+			new Compartment( $compartment )
+		);
+
+		$this->assertEquals(
+			$expected,
+			$instance->hasMatches()
+		);
+	}
+
+	/**
+	 * @dataProvider propertyFilterProvider
+	 */
+	public function testHasMatches_Rule( $properties, $compartment, $expected ) {
+
+		$instance = new PropertyFilter(
+			$properties
+		);
+
+		$rule = new Rule(
+			$compartment
+		);
+
+		$instance->filter( $rule );
+
+		$this->assertEquals(
+			$expected,
+			$instance->hasMatches()
+		);
+
+		$this->assertEquals(
+			$expected ? 1 : 0,
+			$rule->filterScore
+		);
+	}
+
+	/**
+	 * @dataProvider propertyFilterProvider
+	 */
+	public function testHasMatches_CompartmentIterator( $properties, $compartment, $expected ) {
+
+		$instance = new PropertyFilter(
+			$properties
+		);
+
+		$instance->filter(
+			new CompartmentIterator( [ $compartment ] )
+		);
+
+		$this->assertEquals(
+			$expected,
+			$instance->hasMatches()
+		);
+	}
+
+	public function propertyFilterProvider() {
+
+		yield 'oneOf.1: single one_of' => [
+			[ 'Foo', 'Bar' ],
+			[
+				'if' => [
+					'property' => 'Foo'
+				]
+			],
+			true
+		];
+
+		yield 'oneOf.2: single one_of, underscore condition' => [
+			[ 'Foo bar', 'Bar' ],
+			[
+				'if' => [
+					'property' => 'Foo_bar'
+				]
+			],
+			true
+		];
+
+		yield 'oneOf.3: single one_of, underscore validation value' => [
+			[ 'Foo_bar', 'Bar' ],
+			[
+				'if' => [
+					'property' => 'Foo bar'
+				]
+			],
+			true
+		];
+
+		yield 'oneOf.4: empty properties' => [
+			[],
+			[
+				'if' => [
+					'property' => 'Foo'
+				]
+			],
+			false
+		];
+
+		yield 'oneOf.5: single no_match' => [
+			[ 'Foo', 'Bar' ],
+			[
+				'if' => [
+					'property' => 'no_match'
+				]
+			],
+			false
+		];
+
+		yield 'oneOf.6: one_of matches' => [
+			[ 'Foo', 'Bar' ],
+			[
+				'if' => [
+					'property' => [ 'oneOf' => [ 'Foo', 'Foobar' ] ]
+				]
+			],
+			true
+		];
+
+		yield 'oneOf.7: one_of fails because more than one matches' => [
+			[ 'Foo', 'Bar' ],
+			[
+				'if' => [
+					'property' => [ 'oneOf' => [ 'Foo', 'Bar' ] ]
+				]
+			],
+			false
+		];
+
+		yield 'oneOf.8: one_of fails because both match (only one is allowed to match)' => [
+			[ 'Foo', 'Bar' ],
+			[
+				'if' => [
+					'property' => [ 'oneOf' => [ 'Foo', 'Bar', 'Foobar' ] ]
+				]
+			],
+			false
+		];
+
+		// anyOf
+
+		yield 'anyOf.1: anyOf does match because one or more match' => [
+			[ 'Foo', 'Bar' ],
+			[
+				'if' => [
+					'property' => [ 'anyOf' => [ 'Foo', 'Bar', 'Foobar' ] ]
+				]
+			],
+			true
+		];
+
+		// allOf
+
+		yield 'allOf.1: all_of matched' => [
+			[ 'Foo', 'Bar' ],
+			[
+				'if' => [
+					'property' => [ 'allOf' => [ 'Foo', 'Bar' ] ]
+				]
+			],
+			true
+		];
+
+		yield 'allOf.2: all_of failed' => [
+			[ 'Foo', 'Bar' ],
+			[
+				'if' => [
+					'property' => [ 'allOf' => [ 'Foo', 'Foobar' ] ]
+				]
+			],
+			false
+		];
+
+		// not
+
+		yield 'not.1: not single, matches `not` condition' => [
+			[ 'Foo' ],
+			[
+				'if' => [
+					'property' => [ 'not' => [ 'Foo1', 'Foo2' ] ]
+				]
+			],
+			true
+		];
+
+		yield 'not.2: not multiple, matches `not` condition' => [
+			[ 'Foo', 'Bar' ],
+			[
+				'if' => [
+					'property' => [ 'not' => [ 'Foo1', 'Foo2' ] ]
+				]
+			],
+			true
+		];
+
+		yield 'not.3: not single, matches `not` condition' => [
+			[ 'Foo', 'Bar' ],
+			[
+				'if' => [
+					'property' => [ 'not' => [ 'Foo1' ] ]
+				]
+			],
+			true
+		];
+
+		yield 'not.4: not multiple, fails because `not` matches one' => [
+			[ 'Foo', 'Bar' ],
+			[
+				'if' => [
+					'property' => [ 'not' => [ 'Foo1', 'Bar' ] ]
+				]
+			],
+			false
+		];
+
+		yield 'not.5: not multiple, fails because `not` matches both' => [
+			[ 'Foo', 'Bar' ],
+			[
+				'if' => [
+					'property' => [ 'not' => [ 'Foo', 'Bar' ] ]
+				]
+			],
+			false
+		];
+
+		yield 'not.6: not single, fails because `not` matches one' => [
+			[ 'Foo', 'Bar' ],
+			[
+				'if' => [
+					'property' => [ 'not' => 'Foo' ]
+				]
+			],
+			false
+		];
+
+		// combined
+
+		yield 'not.oneOf.1: not, oneOf combined, false because `not` is matched' => [
+			[ 'Foo', 'Bar', 'Foobar' ],
+			[
+				'if' => [
+					'property' => [ 'not' => 'Foobar', 'oneOf' => [ 'Foo', 'Bar' ] ]
+				]
+			],
+			false
+		];
+
+		yield 'not.oneOf.2: not, oneOf combined, false because `oneOf` does not match' => [
+			[ 'Foo', 'Bar', 'Foobar' ],
+			[
+				'if' => [
+					'property' => [ 'not' => 'Foobar', 'oneOf' => [ 'Foo_1', 'Bar_2' ] ]
+				]
+			],
+			false
+		];
+
+		yield 'not.oneOf.3: not, oneOf combined, false because `oneOf` does not match' => [
+			[ 'Foo', 'Bar', 'Foobar_1' ],
+			[
+				'if' => [
+					'property' => [ 'not' => 'Foobar', 'oneOf' => [ 'Foo_1', 'Bar_2' ] ]
+				]
+			],
+			false
+		];
+
+		yield 'not.oneOf.4: not, oneOf combined, truthy because `oneOf` matches one and is not `Foobar`' => [
+			[ 'Foo', 'Bar', 'Foobar_1' ],
+			[
+				'if' => [
+					'property' => [ 'not' => 'Foobar', 'oneOf' => [ 'Foo', 'Bar_2' ] ]
+				]
+			],
+			true
+		];
+
+		yield 'not.oneOf.5: not, oneOf combined, truthy because `oneOf` matches one and is not `Foobar`' => [
+			[ 'Foo', 'Bar', 'Foobar_1' ],
+			[
+				'if' => [
+					'property' => [ 'oneOf' => [ 'Foo', 'Bar_2' ], 'not' => 'Foobar' ]
+				]
+			],
+			true
+		];
+
+		yield 'not.allOf.1: not, allOf combined, false because `allOf` fails' => [
+			[ 'Foo', 'Bar', 'Foobar_1' ],
+			[
+				'if' => [
+					'property' => [ 'not' => 'Foobar', 'allOf' => [ 'Foo', 'Bar_2' ] ]
+				]
+			],
+			false
+		];
+
+		yield 'not.allOf.2: not, allOf combined, false because `allOf` fails' => [
+			[ 'Foo', 'Bar', 'Foobar_1' ],
+			[
+				'if' => [
+					'property' => [ 'allOf' => [ 'Foo', 'Bar_2' ], 'not' => 'Foobar' ]
+				]
+			],
+			false
+		];
+
+		yield 'not.allOf.3: not, allOf combined, true' => [
+			[ 'Foo', 'Bar', 'Foobar_1' ],
+			[
+				'if' => [
+					'property' => [ 'allOf' => [ 'Foo', 'Bar', 'Foobar_1' ], 'not' => 'Foobar' ]
+				]
+			],
+			true
+		];
+
+		yield 'not.anyOf.1: not, oneOf combined, truthy because `not` is not matched' => [
+			[ 'Foo', 'Bar', 'Foobar' ],
+			[
+				'if' => [
+					'property' => [ 'not' => 'Foobar_1', 'anyOf' => [ 'Foo', 'Bar' ] ]
+				]
+			],
+			true
+		];
+
+		yield 'not.anyOf.2: not, oneOf combined, truthy because `not` is not matched' => [
+			[ 'Foo', 'Bar', 'Foobar' ],
+			[
+				'if' => [
+					'property' => [ 'anyOf' => [ 'Foo', 'Bar' ], 'not' => 'Foobar_1' ]
+				]
+			],
+			true
+		];
+
+		yield 'not.anyOf.3: not, oneOf combined, fails because `not` is not matched' => [
+			[ 'Foo', 'Bar', 'Foobar' ],
+			[
+				'if' => [
+					'property' => [ 'anyOf' => [ 'Foo', 'Bar' ], 'not' => 'Foobar' ]
+				]
+			],
+			false
+		];
+	}
+
+}

--- a/tests/phpunit/Unit/Schema/SchemaFilterFactoryTest.php
+++ b/tests/phpunit/Unit/Schema/SchemaFilterFactoryTest.php
@@ -47,4 +47,14 @@ class SchemaFilterFactoryTest extends \PHPUnit_Framework_TestCase {
 		);
 	}
 
+	public function testCanConstructPropertyFilter() {
+
+		$instance = new SchemaFilterFactory();
+
+		$this->assertInstanceof(
+			'\SMW\Schema\Filters\PropertyFilter',
+			$instance->newPropertyFilter( 'Foo' )
+		);
+	}
+
 }


### PR DESCRIPTION
This PR is made in reference to: #4479

This PR addresses or contains:

- Extends #4479 to provide `property` as conditional filter and is equivalent to what the `category` filter does just that it uses properties as argument to match a rule or if combined with other filters can define more complex constructs such as shown in the example
- `PropertyFilter` only provides the ground work for the filtering, a schema type has to decide whether a `property` filter should be used or not and requires to provide an individual `RuleFinder` (or `RuleMatcher`) as seen in [0]
- Definitions of how conditionals are defined is bound to the schema type including what attributive filter arguments are supported (e.g `allOf`,`oneOf`) as in [1]

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed

## Example

```json
{
    "if":{
        "namespace":[
            "NS_MAIN",
            "NS_HELP"
        ],
        "category":{
            "oneOf":[
                "category-6-a",
                "category-6-b"
            ]
        },
        "property":{
            "allOf":[
                "property-6-a",
                "property-6-b"
            ]
        }
    },
    "then":"do_something"
}
```

[0] https://github.com/SemanticMediaWiki/SemanticImageCaption/blob/master/src/RuleFinder.php
[1] https://github.com/SemanticMediaWiki/SemanticImageCaption/blob/master/data/schema/imagecaption-rule-schema.v1.json#L51-L126