### PR TITLE
`SemanticDataLookup` forward caller

### DIFF
--- a/src/SQLStore/EntityStore/SemanticDataLookup.php
+++ b/src/SQLStore/EntityStore/SemanticDataLookup.php
@@ -55,7 +55,7 @@ class SemanticDataLookup {
 	public function newRequestOptions( PropertyTableDefinition $propertyTableDef, DIProperty $property, RequestOptions $requestOptions = null ) {
 
 		if ( $requestOptions === null || !isset( $requestOptions->conditionConstraint ) ) {
-			return null;
+			return $requestOptions;
 		}
 
 		$ropts = new RequestOptions();
@@ -63,6 +63,7 @@ class SemanticDataLookup {
 
 		$ropts->setLimit( $requestOptions->getLimit() );
 		$ropts->setOffset( $requestOptions->getOffset() );
+		$ropts->setCaller( $requestOptions->getCaller() );
 
 		if ( $propertyTableDef->isFixedPropertyTable() ) {
 			return $ropts;


### PR DESCRIPTION
This PR is made in reference to: #

This PR addresses or contains:

- Forwards the caller (if set) to better track which module/class called `SemanticDataLookup` methods during debug

This PR includes:
- [ ] Tests (unit/integration)
- [x] CI build passed
