### PR TITLE
Fix "Unrecognized value for parameter "api_version": 2", refs 4604

### DIFF
--- a/src/MediaWiki/Api/Ask.php
+++ b/src/MediaWiki/Api/Ask.php
@@ -41,7 +41,7 @@ class Ask extends Query {
 		}
 
 		if ( isset( $params['api_version'] ) ) {
-			$queryResult->setSerializerVersion( $params['api_version'] );
+			$queryResult->setSerializerVersion( (int)$params['api_version'] );
 		}
 
 		$this->addQueryResult( $queryResult, $outputFormat );
@@ -60,8 +60,8 @@ class Ask extends Query {
 				ApiBase::PARAM_REQUIRED => true,
 			],
 			'api_version' => [
-				ApiBase::PARAM_TYPE => [ 2, 3 ],
-				ApiBase::PARAM_DFLT => 2,
+				ApiBase::PARAM_TYPE => [ '2', '3' ],
+				ApiBase::PARAM_DFLT => '2',
 				ApiBase::PARAM_HELP_MSG => 'apihelp-ask-parameter-api-version',
 			],
 		];

--- a/src/MediaWiki/Api/AskArgs.php
+++ b/src/MediaWiki/Api/AskArgs.php
@@ -36,7 +36,7 @@ class AskArgs extends Query {
 		}
 
 		if ( isset( $params['api_version'] ) ) {
-			$queryResult->setSerializerVersion( $params['api_version'] );
+			$queryResult->setSerializerVersion( (int)$params['api_version'] );
 		}
 
 		$this->addQueryResult( $queryResult, $outputFormat );
@@ -66,8 +66,8 @@ class AskArgs extends Query {
 				ApiBase::PARAM_ISMULTI => true,
 			],
 			'api_version' => [
-				ApiBase::PARAM_TYPE => [ 2, 3 ],
-				ApiBase::PARAM_DFLT => 2,
+				ApiBase::PARAM_TYPE => [ '2', '3' ],
+				ApiBase::PARAM_DFLT => '2',
 				ApiBase::PARAM_HELP_MSG => 'apihelp-ask-parameter-api-version',
 			],
 		];


### PR DESCRIPTION
This PR is made in reference to: #4604

This PR addresses or contains:

- Apparently `ApiBase::PARAM_TYPE` no longer excepts integers (MW 1.35+) which is why we convert them to a string 

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed

Fixes #4604