### PR TITLE
Factbox prefetch display title, refs 3920

### DIFF
--- a/src/Factbox/Factbox.php
+++ b/src/Factbox/Factbox.php
@@ -5,8 +5,8 @@ namespace SMW\Factbox;
 use Html;
 use Sanitizer;
 use Title;
-use SMW\ApplicationFactory;
 use SMW\DataValueFactory;
+use SMW\DisplayTitleFinder;
 use SMW\DIProperty;
 use SMW\DIWikiPage;
 use SMW\Localizer;
@@ -44,9 +44,9 @@ class Factbox {
 	private $parserData;
 
 	/**
-	 * @var ApplicationFactory
+	 * @var DisplayTitleFinder
 	 */
-	private $applicationFactory;
+	private $displayTitleFinder;
 
 	/**
 	 * @var DataValueFactory
@@ -83,11 +83,12 @@ class Factbox {
 	 *
 	 * @param Store $store
 	 * @param ParserData $parserData
+	 * @param DisplayTitleFinder $displayTitleFinder
 	 */
-	public function __construct( Store $store, ParserData $parserData ) {
+	public function __construct( Store $store, ParserData $parserData, DisplayTitleFinder $displayTitleFinder ) {
 		$this->store = $store;
 		$this->parserData = $parserData;
-		$this->applicationFactory = ApplicationFactory::getInstance();
+		$this->displayTitleFinder = $displayTitleFinder;
 		$this->dataValueFactory = DataValueFactory::getInstance();
 		$this->attachmentFormatter = new AttachmentFormatter( $store );
 	}
@@ -339,6 +340,8 @@ class Factbox {
 	protected function createTable( SemanticData $semanticData ) {
 
 		$html = '';
+
+		$this->displayTitleFinder->prefetchFromSemanticData( $semanticData );
 
 		// Hook deprecated with SMW 1.9 and will vanish with SMW 1.11
 		\Hooks::run( 'smwShowFactbox', [ &$html, $semanticData ] );

--- a/src/Factbox/FactboxFactory.php
+++ b/src/Factbox/FactboxFactory.php
@@ -85,7 +85,8 @@ class FactboxFactory {
 
 		$factbox = new Factbox(
 			$applicationFactory->getStore(),
-			$applicationFactory->newParserData( $title, $parserOutput )
+			$applicationFactory->newParserData( $title, $parserOutput ),
+			$applicationFactory->singleton( 'DisplayTitleFinder' )
 		);
 
 		$factbox->setFeatureSet(

--- a/tests/phpunit/Integration/SemanticMediaWikiProvidedHookInterfaceIntegrationTest.php
+++ b/tests/phpunit/Integration/SemanticMediaWikiProvidedHookInterfaceIntegrationTest.php
@@ -226,7 +226,7 @@ class SemanticMediaWikiProvidedHookInterfaceIntegrationTest extends \PHPUnit_Fra
 			->disableOriginalConstructor()
 			->getMock();
 
-		$semanticData->expects( $this->once() )
+		$semanticData->expects( $this->atLeastOnce() )
 			->method( 'getSubject' )
 			->will( $this->returnValue( new DIWikiPage( 'Bar', NS_MAIN ) ) );
 
@@ -234,10 +234,22 @@ class SemanticMediaWikiProvidedHookInterfaceIntegrationTest extends \PHPUnit_Fra
 			->method( 'hasVisibleProperties' )
 			->will( $this->returnValue( true ) );
 
+		$semanticData->expects( $this->any() )
+			->method( 'getProperties' )
+			->will( $this->returnValue( [] ) );
+
+		$semanticData->expects( $this->any() )
+			->method( 'getSubSemanticData' )
+			->will( $this->returnValue( [] ) );
+
 		$store = $this->getMockBuilder( $storeClass )
 			->disableOriginalConstructor()
-			->setMethods( [ 'getSemanticData', 'getConnection' ] )
+			->setMethods( [ 'getSemanticData', 'getConnection', 'service' ] )
 			->getMock();
+
+		$store->expects( $this->any() )
+			->method( 'service' )
+			->will($this->throwException(new \SMW\Services\Exception\ServiceNotFoundException( 'foo' ) ));
 
 		$store->expects( $this->any() )
 			->method( 'getConnection' )

--- a/tests/phpunit/Unit/Factbox/CachedFactboxTest.php
+++ b/tests/phpunit/Unit/Factbox/CachedFactboxTest.php
@@ -231,6 +231,10 @@ class CachedFactboxTest extends \PHPUnit_Framework_TestCase {
 			->method( 'hasVisibleProperties' )
 			->will( $this->returnValue( true ) );
 
+		$semanticData->expects( $this->any() )
+			->method( 'getSubSemanticData' )
+			->will( $this->returnValue( [] ) );
+
 		$semanticData->expects( $this->atLeastOnce() )
 			->method( 'getPropertyValues' )
 			->will( $this->returnValue( [ DIWikiPage::newFromTitle( $title ) ] ) );

--- a/tests/phpunit/Unit/Factbox/FactboxMagicWordsTest.php
+++ b/tests/phpunit/Unit/Factbox/FactboxMagicWordsTest.php
@@ -26,6 +26,7 @@ class FactboxMagicWordsTest extends \PHPUnit_Framework_TestCase {
 	use PHPUnitCompat;
 
 	private $testEnvironment;
+	private $displayTitleFinder;
 
 	protected function setUp() : void {
 		parent::setUp();
@@ -37,6 +38,10 @@ class FactboxMagicWordsTest extends \PHPUnit_Framework_TestCase {
 			->getMockForAbstractClass();
 
 		$this->testEnvironment->registerObject( 'Store', $store );
+
+		$this->displayTitleFinder = $this->getMockBuilder( '\SMW\DisplayTitleFinder' )
+			->disableOriginalConstructor()
+			->getMock();
 	}
 
 	protected function tearDown() : void {
@@ -99,10 +104,6 @@ class FactboxMagicWordsTest extends \PHPUnit_Framework_TestCase {
 			->disableOriginalConstructor()
 			->getMockForAbstractClass();
 
-		$messageBuilder = $this->getMockBuilder( '\SMW\MediaWiki\MessageBuilder' )
-			->disableOriginalConstructor()
-			->getMock();
-
 		$checkMagicWords = new CheckMagicWords(
 			[
 				'preview' => isset( $expected['preview'] ) && $expected['preview'],
@@ -114,7 +115,7 @@ class FactboxMagicWordsTest extends \PHPUnit_Framework_TestCase {
 		$instance = new Factbox(
 			$store,
 			new ParserData( $title, $parserOutput ),
-			$messageBuilder
+			$this->displayTitleFinder
 		);
 
 		$instance->setCheckMagicWords(

--- a/tests/phpunit/Unit/Factbox/FactboxTest.php
+++ b/tests/phpunit/Unit/Factbox/FactboxTest.php
@@ -30,6 +30,7 @@ class FactboxTest extends \PHPUnit_Framework_TestCase {
 
 	private $stringValidator;
 	private $testEnvironment;
+	private $displayTitleFinder;
 
 	protected function setUp() : void {
 		parent::setUp();
@@ -38,6 +39,10 @@ class FactboxTest extends \PHPUnit_Framework_TestCase {
 		$this->stringValidator = $this->testEnvironment->getUtilityFactory()->newValidatorFactory()->newStringValidator();
 
 		$this->testEnvironment->addConfiguration( 'smwgShowFactbox', SMW_FACTBOX_NONEMPTY );
+
+		$this->displayTitleFinder = $this->getMockBuilder( '\SMW\DisplayTitleFinder' )
+			->disableOriginalConstructor()
+			->getMock();
 	}
 
 	protected function tearDown() : void {
@@ -65,7 +70,8 @@ class FactboxTest extends \PHPUnit_Framework_TestCase {
 
 		$instance = new Factbox(
 			$store,
-			$parserData
+			$parserData,
+			$this->displayTitleFinder
 		);
 
 		$instance->setCheckMagicWords(
@@ -111,7 +117,8 @@ class FactboxTest extends \PHPUnit_Framework_TestCase {
 
 		$instance = new Factbox(
 			$store,
-			$parserData
+			$parserData,
+			$this->displayTitleFinder
 		);
 
 		$reflector = new ReflectionClass( '\SMW\Factbox\Factbox' );
@@ -182,7 +189,8 @@ class FactboxTest extends \PHPUnit_Framework_TestCase {
 		$factbox = $this->getMockBuilder( '\SMW\Factbox\Factbox' )
 			->setConstructorArgs( [
 				$store,
-				$parserData
+				$parserData,
+				$this->displayTitleFinder
 			] )
 			->setMethods( [ 'createTable' ] )
 			->getMock();
@@ -307,7 +315,8 @@ class FactboxTest extends \PHPUnit_Framework_TestCase {
 
 		$instance = new Factbox(
 			$store,
-			$parserData
+			$parserData,
+			$this->displayTitleFinder
 		);
 
 		$instance->setCheckMagicWords(
@@ -382,7 +391,8 @@ class FactboxTest extends \PHPUnit_Framework_TestCase {
 
 		$instance = new Factbox(
 			$store,
-			$parserData
+			$parserData,
+			$this->displayTitleFinder
 		);
 
 		$instance->setCheckMagicWords(

--- a/tests/phpunit/Unit/MediaWiki/Hooks/OutputPageParserOutputTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Hooks/OutputPageParserOutputTest.php
@@ -183,6 +183,10 @@ class OutputPageParserOutputTest extends \PHPUnit_Framework_TestCase {
 			->method( 'hasVisibleProperties' )
 			->will( $this->returnValue( true ) );
 
+		$semanticData->expects( $this->any() )
+			->method( 'getSubSemanticData' )
+			->will( $this->returnValue( [] ) );
+
 		$semanticData->expects( $this->atLeastOnce() )
 			->method( 'getPropertyValues' )
 			->will( $this->returnValue( [ DIWikiPage::newFromTitle( $title ) ] ) );


### PR DESCRIPTION
This PR is made in reference to: #3920

This PR addresses or contains:

- Prefetch the display titles before any `SMWWikiPageValue->getDisplayTitle` tries to do that for any individual wikipage entity which saves time by doing it at the top and in bulk

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed

`
SMW\Factbox\CachedFactbox->rebuild/SMW\Factbox\Factbox->doBuild/SMW\Factbox\Factbox->fetchContent/SMW\Factbox\Factbox->createTable/SMW\Factbox\Factbox->createRows/SMWWikiPageValue->getLongWikiText/SMWWikiPageValue->getLongCaptionText/SMWWikiPageValue->getDisplayTitle/SMW\DisplayTitleFinder->findDisplayTitle/SMW\DisplayTitleFinder->findDisplayTitleFor
`