### PR TITLE
Avoid class_alias issue not loading tests

### DIFF
--- a/tests/autoloader.php
+++ b/tests/autoloader.php
@@ -84,14 +84,14 @@ $autoloader->addClassMap( [
 
 	// Reference needed for SRF as it inherits from this class (or better its alias)!!
 	// TODO: make sure to use `JSONScriptServicesTestCaseRunner`
-	'SMW\Tests\Integration\JSONScript\JSONScriptTestCaseRunnerTest'    => __DIR__ . '/phpunit/Integration/JSONScript/JSONScriptTestCaseRunnerTest.php'
+	'SMW\Tests\Integration\JSONScript\JSONScriptTestCaseRunnerTest' => __DIR__ . '/phpunit/Integration/JSONScript/JSONScriptTestCaseRunnerTest.php',
+	'SMW\Tests\Integration\JSONScript\JsonTestCaseScriptRunnerTest' => __DIR__ . '/phpunit/Integration/JSONScript/JSONScriptTestCaseRunnerTest.php'
 ] );
 
 // 3.2
 class_alias( '\SMW\Tests\JSONScriptTestCaseRunner', 'SMW\Tests\JsonTestCaseScriptRunner' );
 class_alias( '\SMW\Tests\JSONScriptServicesTestCaseRunner', 'SMW\Tests\LightweightJsonTestCaseScriptRunner' );
 class_alias( '\SMW\Tests\JSONScriptServicesTestCaseRunner', 'SMW\Tests\ExtendedJsonTestCaseScriptRunner' );
-class_alias( '\SMW\Tests\Integration\JSONScript\JSONScriptTestCaseRunnerTest', 'SMW\Tests\Integration\JSONScript\JsonTestCaseScriptRunnerTest' );
 
 // 3.1
 class_alias( '\SMW\Tests\Utils\JSONScript\JsonTestCaseFileHandler', 'SMW\Tests\JsonTestCaseFileHandler' );

--- a/tests/phpunit/Integration/JSONScript/JSONScriptTestCaseRunnerTest.php
+++ b/tests/phpunit/Integration/JSONScript/JSONScriptTestCaseRunnerTest.php
@@ -98,3 +98,5 @@ class JSONScriptTestCaseRunnerTest extends JSONScriptServicesTestCaseRunner {
 	}
 
 }
+
+class_alias( JSONScriptTestCaseRunnerTest::class, 'SMW\Tests\Integration\JSONScript\JsonTestCaseScriptRunnerTest' );


### PR DESCRIPTION
This PR is made in reference to: #

This PR addresses or contains:

- The way the `class_alias` was defined made the JSONScript tests disappear from running during the entire `phpunit` run, verified using option `phpunit --list-tests` 

This PR includes:
- [ ] Tests (unit/integration)
- [x] CI build passed
