### PR TITLE
Isolate `Hooks::clear`, refs 4779

### DIFF
--- a/src/MediaWiki/Hooks.php
+++ b/src/MediaWiki/Hooks.php
@@ -100,10 +100,31 @@ class Hooks {
 
 	/**
 	 * @since 2.3
+	 *
+	 * @param string $name
 	 */
-	public function clear() {
-		foreach ( $this->getHandlerList() as $name ) {
-			\Hooks::clear( $name );
+	public function clear( string $name = '' ) {
+
+		if ( !defined( 'MW_PHPUNIT_TEST' ) ) {
+			return;
+		}
+
+		if ( $name !== [] ) {
+			$handlers = [ $name ];
+		} else {
+			$handlers = $this->getHandlerList();
+		}
+
+		foreach ( $handlers as $name ) {
+
+			// #4779
+			if (
+				!class_exists( '\MediaWiki\MediaWikiServices' ) ||
+				!method_exists( \MediaWiki\MediaWikiServices::getInstance(), 'getHookContainer' ) ) {
+				\Hooks::clear( $name );
+			} else {
+				\MediaWiki\MediaWikiServices::getInstance()->getHookContainer()->clear( $name );
+			}
 		}
 	}
 

--- a/tests/phpunit/Utils/MwHooksHandler.php
+++ b/tests/phpunit/Utils/MwHooksHandler.php
@@ -96,7 +96,7 @@ class MwHooksHandler {
 
 			// MW 1.19
 			if ( method_exists( 'Hooks', 'clear' ) ) {
-				\Hooks::clear( $hook );
+				$this->getHookRegistry()->clear( $hook );
 			}
 
 			if ( !isset( $GLOBALS['wgHooks'][$hook] ) ) {


### PR DESCRIPTION
This PR is made in reference to: #4779

This PR addresses or contains:

This PR includes:
- [ ] Tests (unit/integration)
- [x] CI build passed

Fixes #4779