### PR TITLE
Escape separator in CSV printer

### DIFF
--- a/includes/queryprinters/CsvResultPrinter.php
+++ b/includes/queryprinters/CsvResultPrinter.php
@@ -87,7 +87,7 @@ class CsvResultPrinter extends FileExportPrinter {
 					$growing = array();
 
 					while ( ( $object = $field->getNextDataValue() ) !== false ) {
-						$growing[] = Sanitizer::decodeCharReferences( $object->getWikiValue() );
+						$growing[] = addcslashes( Sanitizer::decodeCharReferences( $object->getWikiValue() ), ',' );
 					}
 
 					$row_items[] = implode( ',', $growing );


### PR DESCRIPTION
This PR addresses or contains:
- When exporting a query result as CSV, the values can contain an unescaped `,` character, so it becomes impossible to properly parse the values from the CSV.

This PR includes:
- [ ] Tests (unit/integration)
- [ ] CI build passed

We are stuck on the 2.5 branch for now but I am not sure you still accept PR for this branch.
(If the 3.1 still has the same issue, I think a similar fix could be applied.)