### PR TITLE
Remove calls to ParserOptions::setTidy()

### DIFF
--- a/extension.json
+++ b/extension.json
@@ -13,7 +13,7 @@
 	"license-name": "GPL-2.0-or-later",
 	"type": "semantic",
 	"requires": {
-		"MediaWiki": ">= 1.31"
+		"MediaWiki": ">= 1.35"
 	},
 	"MessagesDirs": {
 		"SemanticMediaWiki": [

--- a/src/MediaWiki/Template/TemplateExpander.php
+++ b/src/MediaWiki/Template/TemplateExpander.php
@@ -72,7 +72,6 @@ class TemplateExpander {
 		if ( !$options instanceof ParserOptions ) {
 			$options = new ParserOptions();
 			$options->setRemoveComments( true );
-			$options->setTidy( true );
 			$options->setMaxIncludeSize( self::MAX_INCLUDE_SIZE );
 		}
 


### PR DESCRIPTION
ParserOptions::setTidy() was deprecated and made a no-op in MW 1.35, and will be removed in a future release.  Bump the minumum required MW version to >= 1.35.

Bug: T198214
