### PR TITLE
Add explicit testing for MW 1.35

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,7 +38,7 @@ jobs:
     - env: DB=mysql; MW=REL1_34; PHPUNIT=6.5.*
       php: 7.2
     - env: DB=mysql; MW=REL1_35; PHPUNIT=8.5.*
-      php: 7.4
+      php: 7.3
     - env: DB=sqlite; MW=REL1_35; PHPUNIT=8.5.*
       php: 7.4
     - env: DB=sqlite; MW=REL1_31; TYPE=composer; PHPUNIT=6.5.*
@@ -58,7 +58,7 @@ jobs:
     - env: DB=mysql; MW=REL1_33; ES=5.6.6; PHPUNIT=6.5.*
     - env: DB=mysql; MW=REL1_34; PHPUNIT=6.5.*
     - env: DB=mysql; MW=REL1_31; BLAZEGRAPH=1.5.2; PHPUNIT=6.5.*
-    - env: DB=mysql; MW=REL1_34; PHPUNIT=6.5.*
+    - env: DB=mysql; MW=REL1_35; PHPUNIT=8.5.*
     - env: DB=sqlite; MW=REL1_35; PHPUNIT=8.5.*
 
 # Dec 16, 2015 (GCE switch): Travis support wrote (Tomcat + Java):


### PR DESCRIPTION
This PR is made in reference to: #4825

This PR addresses or contains:
- Adds testing for PHP 7.4 and MW 1.35 for SQLite and MySQL

This PR includes:
- [ ] Tests (unit/integration)
- [ ] CI build passed

Fixes #