### PR TITLE
Use Language::formatNumNoSeparators where appropriate

### DIFF
--- a/src/DataValues/ValueFormatters/TimeValueFormatter.php
+++ b/src/DataValues/ValueFormatters/TimeValueFormatter.php
@@ -135,7 +135,7 @@ class TimeValueFormatter extends DataValueFormatter {
 		$year = str_pad( $year, 4, "0", STR_PAD_LEFT );
 
 		if ( $precision <= DITime::PREC_Y ) {
-			return $language->formatNum( $year, true );
+			return $language->formatNumNoSeparators( $year );
 		}
 
 		$month = str_pad( $dataItem->getMonth(), 2, "0", STR_PAD_LEFT );

--- a/src/MediaWiki/MessageBuilder.php
+++ b/src/MediaWiki/MessageBuilder.php
@@ -68,7 +68,11 @@ class MessageBuilder {
 	 * @return string
 	 */
 	public function formatNumberToText( $number, $useForSpecialNumbers = false ) {
-		return $this->getLanguage()->formatNum( $number, $useForSpecialNumbers );
+		if ( $useForSpecialNumbers ) {
+			return $this->getLanguage()->formatNumNoSeparators( $number );
+		} else {
+			return $this->getLanguage()->formatNum( $number );
+		}
 	}
 
 	/**


### PR DESCRIPTION
Avoids using the deprecated `$noSeparators` parameter to `Language::formatNum` in favor of `Language::formatNumNoSeparators`, which has been around since MW 1.21.