### PR TITLE
Fix typo: adminstrative > administrative

### DIFF
--- a/data/import/groups/predefined.properties.json
+++ b/data/import/groups/predefined.properties.json
@@ -1,7 +1,7 @@
 {
     "type": "PROPERTY_GROUP_SCHEMA",
     "groups": {
-        "adminstrative_group": {
+        "administrative_group": {
             "canonical_name": "Adminstrative properties",
             "message_key": "smw-property-group-label-adminstrative-properties",
             "property_keys": [

--- a/data/import/groups/predefined.properties.json
+++ b/data/import/groups/predefined.properties.json
@@ -3,7 +3,7 @@
     "groups": {
         "administrative_group": {
             "canonical_name": "Adminstrative properties",
-            "message_key": "smw-property-group-label-adminstrative-properties",
+            "message_key": "smw-property-group-label-administrative-properties",
             "property_keys": [
                 "_MDAT",
                 "_CDAT",


### PR DESCRIPTION
I have just realized there is a typo here (adminstrative > administrative)