### PR TITLE
Drop pre-mw-1.21 fallback to ParserOutput dynamic properties.

### DIFF
--- a/includes/SMW_Outputs.php
+++ b/includes/SMW_Outputs.php
@@ -142,8 +142,8 @@ class SMWOutputs {
 		self::$headItems = array_merge( (array)self::$headItems, $parserOutputHeadItems );
 
 		/// TODO Is the following needed?
-		if ( isset( $parserOutput->mModules ) ) {
-			foreach ( $parserOutput->mModules as $module ) {
+		if ( $parserOutput->getModules() ) {
+			foreach ( $parserOutput->getModules() as $module ) {
 				self::$resourceModules[$module] = $module;
 			}
 		}

--- a/src/MediaWiki/Hooks/LinksUpdateConstructed.php
+++ b/src/MediaWiki/Hooks/LinksUpdateConstructed.php
@@ -156,11 +156,7 @@ class LinksUpdateConstructed implements HookListener {
 			return null;
 		}
 
-		if ( method_exists( $parserOutput, 'getExtensionData' ) ) {
-			return $parserOutput->getExtensionData( 'smwdata' );
-		}
-
-		return $parserOutput->mSMWData;
+		return $parserOutput->getExtensionData( 'smwdata' );
 	}
 
 	private function doAbort() {

--- a/src/MediaWiki/MagicWordsFinder.php
+++ b/src/MediaWiki/MagicWordsFinder.php
@@ -84,12 +84,9 @@ class MagicWordsFinder {
 
 		// Filter empty lines
 		$words = array_values( array_filter( $words ) );
-
-		if ( $this->hasExtensionData() && $words !== [] ) {
+		if ( $words !== [] ) {
 			return $this->parserOutput->setExtensionData( 'smwmagicwords', $words );
 		}
-
-		return $this->parserOutput->mSMWMagicWords = $words;
 	}
 
 	/**
@@ -98,23 +95,6 @@ class MagicWordsFinder {
 	 * @return array
 	 */
 	public function getMagicWords() {
-
-		if ( $this->hasExtensionData() ) {
-			return $this->parserOutput->getExtensionData( 'smwmagicwords' );
-		}
-
-		if ( isset( $this->parserOutput->mSMWMagicWords ) ) {
-			return $this->parserOutput->mSMWMagicWords;
-		}
-
-		return [];
+		return $this->parserOutput->getExtensionData( 'smwmagicwords' );
 	}
-
-	/**
-	 * FIXME Remove when MW 1.21 becomes mandatory
-	 */
-	protected function hasExtensionData() {
-		return method_exists( $this->parserOutput, 'getExtensionData' );
-	}
-
 }

--- a/tests/phpunit/Integration/MediaWiki/Hooks/ParserFirstCallInitIntegrationTest.php
+++ b/tests/phpunit/Integration/MediaWiki/Hooks/ParserFirstCallInitIntegrationTest.php
@@ -208,12 +208,7 @@ class ParserFirstCallInitIntegrationTest extends \PHPUnit_Framework_TestCase {
 	}
 
 	private function findSemanticataFromOutput( $parserOutput ) {
-
-		if ( method_exists( $parserOutput, 'getExtensionData' ) ) {
-			return $parserOutput->getExtensionData( 'smwdata' );
-		}
-
-		return isset( $parserOutput->mSMWData ) ? $parserOutput->mSMWData : null;
+		return $parserOutput->getExtensionData( 'smwdata' );
 	}
 
 }

--- a/tests/phpunit/Unit/Factbox/CachedFactboxTest.php
+++ b/tests/phpunit/Unit/Factbox/CachedFactboxTest.php
@@ -550,15 +550,8 @@ class CachedFactboxTest extends \PHPUnit_Framework_TestCase {
 	}
 
 	protected function makeParserOutput( $semanticData ) {
-
 		$parserOutput = new ParserOutput();
-
-		if ( method_exists( $parserOutput, 'setExtensionData' ) ) {
-			$parserOutput->setExtensionData( 'smwdata', $semanticData );
-		} else {
-			$parserOutput->mSMWData = $semanticData;
-		}
-
+		$parserOutput->setExtensionData( 'smwdata', $semanticData );
 		return $parserOutput;
 
 	}

--- a/tests/phpunit/Unit/Factbox/FactboxMagicWordsTest.php
+++ b/tests/phpunit/Unit/Factbox/FactboxMagicWordsTest.php
@@ -97,9 +97,6 @@ class FactboxMagicWordsTest extends \PHPUnit_Framework_TestCase {
 			->method( 'getExtensionData' )
 			->will( $this->returnValue( $expected['magicWords'] ) );
 
-		// MW 1.19, 1.20
-		$parserOutput->mSMWMagicWords = $expected['magicWords'];
-
 		$store = $this->getMockBuilder( '\SMW\Store' )
 			->disableOriginalConstructor()
 			->getMockForAbstractClass();
@@ -198,12 +195,7 @@ class FactboxMagicWordsTest extends \PHPUnit_Framework_TestCase {
 	 * @return array
 	 */
 	protected function getMagicwords( $parserOutput ) {
-
-		if ( method_exists( $parserOutput, 'getExtensionData' ) ) {
-			return $parserOutput->getExtensionData( 'smwmagicwords' );
-		}
-
-		return $parserOutput->mSMWMagicWords;
+		return $parserOutput->getExtensionData( 'smwmagicwords' );
 	}
 
 }

--- a/tests/phpunit/Unit/Factbox/FactboxTest.php
+++ b/tests/phpunit/Unit/Factbox/FactboxTest.php
@@ -503,13 +503,7 @@ class FactboxTest extends \PHPUnit_Framework_TestCase {
 	protected function setupParserOutput( $semanticData ) {
 
 		$parserOutput = new ParserOutput();
-
-		if ( method_exists( $parserOutput, 'setExtensionData' ) ) {
-			$parserOutput->setExtensionData( 'smwdata', $semanticData );
-		} else {
-			$parserOutput->mSMWData = $semanticData;
-		}
-
+		$parserOutput->setExtensionData( 'smwdata', $semanticData );
 		return $parserOutput;
 	}
 

--- a/tests/phpunit/Unit/MediaWiki/Hooks/OutputPageParserOutputTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Hooks/OutputPageParserOutputTest.php
@@ -393,15 +393,8 @@ class OutputPageParserOutputTest extends \PHPUnit_Framework_TestCase {
 	}
 
 	protected function makeParserOutput( $data ) {
-
 		$parserOutput = new ParserOutput();
-
-		if ( method_exists( $parserOutput, 'setExtensionData' ) ) {
-			$parserOutput->setExtensionData( 'smwdata', $data );
-		} else {
-			$parserOutput->mSMWData = $data;
-		}
-
+		$parserOutput->setExtensionData( 'smwdata', $data );
 		return $parserOutput;
 	}
 


### PR DESCRIPTION
The extension requires 1.31, ParserOutput get/setExtensionData
was added in 1.21. We're going to completely prohibit dynamic
properties on ParserOutput object in core, see
https://phabricator.wikimedia.org/T263851