### PR TITLE
Fix AskArgs API UnitTests

### DIFF
--- a/src/MediaWiki/Api/ApiQueryResultFormatter.php
+++ b/src/MediaWiki/Api/ApiQueryResultFormatter.php
@@ -94,7 +94,7 @@ class ApiQueryResultFormatter {
 	public function getResult() {
 		$queryCountValue = $this->queryResult->getCountValue();
 		if ( $queryCountValue !== null ) {
-			return [ $queryCountValue ];
+			$this->result['results'] = $queryCountValue;
 		}
 
 		return $this->result;

--- a/tests/phpunit/Unit/MediaWiki/Api/AskArgsTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Api/AskArgsTest.php
@@ -267,6 +267,25 @@ class AskArgsTest extends \PHPUnit_Framework_TestCase {
 					]
 				]
 			],
+
+			// #6 Query producing a count result
+			[
+				[
+					'conditions' => 'Modification date::+',
+					'printouts'  => null,
+					'parameters' => 'format=count'
+				],
+				[
+					[
+						'label'=> '',
+						'typeid' => '_wpg',
+						'mode' => 2,
+						'format' => false,
+						'key' => '',
+						'redi' => ''
+					]
+				]
+			],
 		];
 	}
 }


### PR DESCRIPTION
Re-use standard result format

Follow up for https://github.com/SemanticMediaWiki/SemanticMediaWiki/pull/4858