### PR TITLE
Remove usage of hard-deprecated ParserCache::getETag.

### DIFF
--- a/src/MediaWiki/Hooks.php
+++ b/src/MediaWiki/Hooks.php
@@ -706,9 +706,21 @@ class Hooks {
 		// #4741
 		$wikiPage = $page->getPage();
 
-		$dependencyValidator->setETag(
-			$parserCache->getETag( $wikiPage, $wikiPage->makeParserOptions( 'canonical' ) )
-		);
+		if ( method_exists( $parserCache, 'makeParserOutputKey' ) ) {
+			// 1.36+
+			$dependencyValidator->setETag(
+				'W/"' .
+				$parserCache->makeParserOutputKey(
+					$wikiPage,
+					$wikiPage->makeParserOptions( 'canonical' )
+				) .
+				"--" . $wikiPage->getTouched() . '"'
+			);
+		} else {
+			$dependencyValidator->setETag(
+				$parserCache->getETag( $wikiPage, $wikiPage->makeParserOptions( 'canonical' ) )
+			);
+		}
 
 		$dependencyValidator->setCacheTTL(
 			Site::getCacheExpireTime( 'parser' )


### PR DESCRIPTION
See https://gerrit.wikimedia.org/r/c/mediawiki/core/+/634593

ParserCache::getETag is being removed from MW since it's not a ParserCache concern to build tags for the whole page. 