### PR TITLE
Make TranslationPropertyAnnotator compatible with new format.

### DIFF
--- a/src/Property/Annotators/TranslationPropertyAnnotator.php
+++ b/src/Property/Annotators/TranslationPropertyAnnotator.php
@@ -64,11 +64,22 @@ class TranslationPropertyAnnotator extends PropertyAnnotatorDecorator {
 			);
 		}
 
-		if ( isset( $this->translation['sourcepagetitle'] ) && $this->translation['sourcepagetitle'] instanceof Title ) {
+		if ( isset( $this->translation['sourcepagetitle'] ) ) {
+			if ( $this->translation['sourcepagetitle'] instanceof Title ) {
+				// Backwards-compatibility.
+				// After 2020-07-20 stores array [ dbkey, namespace ] in sourcepagetitle property
+				$title = $this->translation['sourcepagetitle'];
+			} else {
+				$title = Title::makeTitle(
+					$this->translation['sourcepagetitle']['namespace'],
+					$this->translation['sourcepagetitle']['dbkey']
+				);
+			}
+
 			// Translation.Translation source
 			$containerSemanticData->addPropertyObjectValue(
 				$this->dataItemFactory->newDIProperty( '_TRANS_SOURCE' ),
-				$this->dataItemFactory->newDIWikiPage( $this->translation['sourcepagetitle'] )
+				$this->dataItemFactory->newDIWikiPage( $title )
 			);
 		}
 


### PR DESCRIPTION
We are moving ParserCache from PHP serialization to JSON serialization,
thus instances of classes will no longer be supported in extension
data. https://gerrit.wikimedia.org/r/635901 changes the Translate
extension to write primitives instead of the Title.

See https://phabricator.wikimedia.org/T266268