### PR TITLE
Update COMPATIBILITY.md

### DIFF
--- a/docs/COMPATIBILITY.md
+++ b/docs/COMPATIBILITY.md
@@ -23,7 +23,7 @@ Semantic MediaWiki may also work with more recent versions of PHP and MediaWiki,
 	<tr>
 		<th>4.0.x</th>
 		<td>7.1.0 - 7.4.x</td>
-		<td>1.32.0+</td>
+		<td>1.36.0+</td>
 		<td>-</td>
 		<td>In development</td>
 	</tr>


### PR DESCRIPTION
Fixes a typo in mediawiki version for compatibility matrix ( 1.32.+ to 1.36.+ )