### PR TITLE
Re-enable the "Refresh" menu when JS is enabled

### DIFF
--- a/res/Resources.php
+++ b/res/Resources.php
@@ -273,6 +273,9 @@ return [
 			'smw-purge-update-dependencies'
 		],
 		'position' => 'top',
+		'dependencies' => array_merge( [
+			'mediawiki.api',
+		], version_compare( MW_VERSION, '1.35', '<' ) ? [ 'mediawiki.notify' ] : [] ),
 		'targets' => [
 			'mobile',
 			'desktop'
@@ -372,6 +375,9 @@ return [
 		'messages' => [
 			'smw-postproc-queryref'
 		],
+		'dependencies' => array_merge( [
+			'mediawiki.api',
+		], version_compare( MW_VERSION, '1.35', '<' ) ? [ 'mediawiki.notify' ] : [] ),
 		'targets' => [
 			'mobile',
 			'desktop'

--- a/res/smw/util/ext.smw.util.postproc.js
+++ b/res/smw/util/ext.smw.util.postproc.js
@@ -21,76 +21,72 @@
 	/**
 	 * @since 3.0
 	 */
-	mw.loader.using( [ 'mediawiki.api', 'mediawiki.notify' ] ).then( function () {
+	$( '.smw-postproc' ).each( function() {
 
-		$( '.smw-postproc' ).each( function() {
+		var api = new mw.Api();
+		var ref = $( this ).data( 'ref' );
+		var query = $( this ).data( 'query' );
 
-			var api = new mw.Api();
-			var ref = $( this ).data( 'ref' );
-			var query = $( this ).data( 'query' );
+		if ( ref !== undefined && ref !== '' ) {
+			mw.notify( mw.msg( 'smw-postproc-queryref' ), { type: 'info', autoHide: false } );
 
-			if ( ref !== undefined && ref !== '' ) {
-				mw.notify( mw.msg( 'smw-postproc-queryref' ), { type: 'info', autoHide: false } );
-
-				var params = {
-					'subject': $( this ).data( 'subject' ),
-					'origin': 'api-postproc',
-					'ref' : ref,
-					'cache-key': $( this ).data( 'cache-key' )
-				};
-
-				var postArgs = {
-					'action': 'smwtask',
-					'task': 'update',
-					'params': JSON.stringify( params )
-				};
-
-				api.postWithToken( 'csrf', postArgs ).then( function ( data ) {
-					location.reload( true );
-				} );
-			} else if ( query !== undefined ) {
-
-				var params = {
-					'subject': $( this ).data( 'subject' ),
-					'origin': 'api-postproc',
-					'query' : query,
-					'cache-key': $( this ).data( 'cache-key' )
-				};
-
-				var postArgs = {
-					'action': 'smwtask',
-					'task': 'check-query',
-					'params': JSON.stringify( params )
-				};
-
-				api.postWithToken( 'csrf', postArgs ).then( function ( data ) {
-					if ( data.task.hasOwnProperty( 'reload' ) ) {
-						mw.notify( mw.msg( 'smw-postproc-queryref' ), { type: 'info', autoHide: false } );
-						location.reload( true );
-					};
-				} );
-			}
-
-			var jobs = $( this ).data( 'jobs' );
-
-			if ( jobs !== '' ) {
-
-				var params = {
-					'subject': $( this ).data( 'subject' ),
-					'origin': 'api-postproc',
-					'jobs' : jobs
-				};
-
-				var postArgs = {
-					'action': 'smwtask',
-					'task': 'run-joblist',
-					'params': JSON.stringify( params )
-				};
-
-				api.postWithToken( 'csrf', postArgs );
+			var params = {
+				'subject': $( this ).data( 'subject' ),
+				'origin': 'api-postproc',
+				'ref' : ref,
+				'cache-key': $( this ).data( 'cache-key' )
 			};
 
-		} );
+			var postArgs = {
+				'action': 'smwtask',
+				'task': 'update',
+				'params': JSON.stringify( params )
+			};
+
+			api.postWithToken( 'csrf', postArgs ).then( function ( data ) {
+				location.reload( true );
+			} );
+		} else if ( query !== undefined ) {
+
+			var params = {
+				'subject': $( this ).data( 'subject' ),
+				'origin': 'api-postproc',
+				'query' : query,
+				'cache-key': $( this ).data( 'cache-key' )
+			};
+
+			var postArgs = {
+				'action': 'smwtask',
+				'task': 'check-query',
+				'params': JSON.stringify( params )
+			};
+
+			api.postWithToken( 'csrf', postArgs ).then( function ( data ) {
+				if ( data.task.hasOwnProperty( 'reload' ) ) {
+					mw.notify( mw.msg( 'smw-postproc-queryref' ), { type: 'info', autoHide: false } );
+					location.reload( true );
+				};
+			} );
+		}
+
+		var jobs = $( this ).data( 'jobs' );
+
+		if ( jobs !== '' ) {
+
+			var params = {
+				'subject': $( this ).data( 'subject' ),
+				'origin': 'api-postproc',
+				'jobs' : jobs
+			};
+
+			var postArgs = {
+				'action': 'smwtask',
+				'task': 'run-joblist',
+				'params': JSON.stringify( params )
+			};
+
+			api.postWithToken( 'csrf', postArgs );
+		};
 
 	} );
 

--- a/res/smw/util/ext.smw.util.purge.js
+++ b/res/smw/util/ext.smw.util.purge.js
@@ -46,23 +46,19 @@
 		} );
 	}
 
-	mw.loader.using( [ 'mediawiki.api', 'mediawiki.notify' ] ).then( function () {
+	// JS is loaded, now remove the "soft" disabled functionality
+	$( "#ca-purge" ).removeClass( 'is-disabled' );
 
-		// JS is loaded, now remove the "soft" disabled functionality
-		$( "#ca-purge" ).removeClass( 'is-disabled' );
+	// Observed on the chameleon skin
+	$( "#ca-purge a" ).removeClass( 'is-disabled' );
 
-		// Observed on the chameleon skin
-		$( "#ca-purge a" ).removeClass( 'is-disabled' );
+	$( "#ca-purge a, .purge" ).on( 'click', function ( e ) {
+		purge( $( this ) );
+		e.preventDefault();
+	} );
 
-		$( "#ca-purge a, .purge" ).on( 'click', function ( e ) {
-			purge( $( this ) );
-			e.preventDefault();
-		} );
-
-		$( ".page-purge" ).each( function () {
-			purge( $( this ) );
-		} );
-
+	$( ".page-purge" ).each( function () {
+		purge( $( this ) );
 	} );
 
 }( jQuery, mediaWiki ) );


### PR DESCRIPTION
MW 1.35 deleted the resource mediawiki.notify (included in mediawiki.base), resulting in avoiding the undisabling of the "Refresh" menu (removing of the class "is-disabled" when JS is enabled). See  #2631 for the mechanism to enable when JS is loaded.

In order to support MW < 1.35, I declared the dependencies on PHP side to benefit of version_compare, and consequently removed mw.loader.using on JS side.

In JS files, removed one initial tab; the diff rendering seems to be a bit lost.

Issue: #4833