### PR TITLE
Fix Travis build fails: incompatible with composer-plugin-api[2.0.0] (#4905)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -58,6 +58,8 @@ before_install:
   - sudo sysctl -w net.ipv6.conf.default.disable_ipv6=1
   - ip addr # for confirmation. can be skipped
   - cat /etc/hosts # optionally check the content *before*
+  # MW is not yet compatible with Composer 2.x, see https://phabricator.wikimedia.org/T266417
+  - composer self-update --1
 
 install:
   - travis_retry composer self-update


### PR DESCRIPTION
fixes #4905. @kghbln @JeroenDeDauw backport to 3.x branch to make a stable SMW available for CI in SRF?