### PR TITLE
Update i18n/extra/pl.json

### DIFF
--- a/i18n/extra/pl.json
+++ b/i18n/extra/pl.json
@@ -1,6 +1,8 @@
 {
     "@metadata": {
-        "authors": []
+        "authors": [
+            "Ostrzyciel"
+        ]
     },
     "fallback_language": "en",
     "namespace": {
@@ -25,12 +27,12 @@
             "_ema": "Email",
             "_uri": "URL",
             "_anu": "URI adnotacji",
-            "_tel": "Telephone number",
-            "_rec": "Record",
-            "_qty": "Quantity",
-            "_mlt_rec": "Monolingual text",
-            "_eid": "External identifier",
-            "_ref_rec": "Reference"
+            "_tel": "Numer telefonu",
+            "_rec": "Rekord",
+            "_qty": "Wielkość",
+            "_mlt_rec": "Tekst z tagiem języka",
+            "_eid": "Identyfikator zewnętrzny",
+            "_ref_rec": "Przypis"
         },
         "aliases": {
             "URI": "_uri",
@@ -87,87 +89,99 @@
         "months": [
             [
                 "styczeń",
-                "sty"
+                "sty",
+                "stycznia"
             ],
             [
                 "luty",
-                "lut"
+                "lut",
+                "lutego"
             ],
             [
-                "marsz",
-                "mar"
+                "marzec",
+                "mar",
+                "marca"
             ],
             [
                 "kwiecień",
-                "kwi"
+                "kwi",
+                "kwietnia"
             ],
             [
                 "maj",
-                "maj"
+                "maj",
+                "maja"
             ],
             [
                 "czerwiec",
-                "cze"
+                "cze",
+                "czerwca"
             ],
             [
                 "lipiec",
-                "lip"
+                "lip",
+                "lipca"
             ],
             [
                 "sierpień",
-                "sie"
+                "sie",
+                "sierpnia"
             ],
             [
                 "wrzesień",
-                "wrz"
+                "wrz",
+                "września"
             ],
             [
                 "październik",
-                "paź"
+                "paź",
+                "października"
             ],
             [
                 "listopad",
-                "lis"
+                "lis",
+                "listopada"
             ],
             [
                 "grudzień",
-                "gru"
+                "gru",
+                "grudnia"
             ]
         ],
         "days": [
             [
-                "Monday",
-                "Mon"
+                "poniedziałek",
+                "pon."
             ],
             [
-                "Tuesday",
-                "Tue"
+                "wtorek",
+                "wt."
             ],
             [
-                "Wednesday",
-                "Wed"
+                "środa",
+                "śr."
             ],
             [
-                "Thursday",
-                "Thu"
+                "czwartek",
+                "czw."
             ],
             [
-                "Friday",
-                "Fri"
+                "piątek",
+                "pt."
             ],
             [
-                "Saturday",
-                "Sat"
+                "sobota",
+                "sob."
             ],
             [
-                "Sunday",
-                "Sun"
+                "niedziela",
+                "niedz."
             ]
         ],
         "precision": {
             "SMW_PREC_Y": "Y",
             "SMW_PREC_YM": "F Y",
-            "SMW_PREC_YMD": "F j, Y",
+            "SMW_PREC_YMD": "j F Y",
             "SMW_PREC_YMDT": "H:i:s, j F Y"
         },
         "format": [
@@ -179,9 +193,9 @@
                 "SMW_YM"
             ],
             [
-                "SMW_MDY",
                 "SMW_DMY",
                 "SMW_YMD",
+                "SMW_MDY",
                 "SMW_YDM"
             ]
         ]

--- a/src/Localizer/LocalLanguage/LocalLanguage.php
+++ b/src/Localizer/LocalLanguage/LocalLanguage.php
@@ -503,8 +503,10 @@ class LocalLanguage {
 		}
 
 		foreach ( $this->months[$languageCode] as $key => $value ) {
-			if ( strcasecmp( $value[0], $label ) == 0 || strcasecmp( $value[1], $label ) == 0 ) {
-				return $key + 1; // array starts with 0
+			foreach ( $value as $variant ) {
+				if ( strcasecmp( $variant, $label ) == 0 ) {
+					return $key + 1; // array starts with 0
+				}
 			}
 		}
 


### PR DESCRIPTION
The `i18n/extra/pl.json` file is pretty bad in some ways, so I tried to fix the most glaring issues.

* I translated the datatype labels. "quantity" was tricky, I made it "wielkość" which is usually used in the physical context. I translated "monolingual text" as literally "text with a language tag" because a direct translation would be just confusing ("monolingual" is not really a word in Polish).
* I'm not touching property labels (yet). They are scary.
* I fixed the translation of March, someone did the previous version using an automatic translation tool. "marsz" is indeed "march", just **a** march, not the month :P
* I added a third form of each month's name, in the genitive case. In Polish genitive is used for months, when the month is preceded with a day number, so "stycz**eń** 2021" (nominative) and "12 stycz**nia** 2020" (genitive). To make SMW be able to interpret such dates at all, I changed LocalLanguage.php to look through any number of month name variants. There's no way for SMW to use these cases when outputting dates, sadly, but I may get back to it later :)
* Days of week were not translated at all, so I did that. As for the short versions, I used the recommendation from a renowned Polish linguist, Mirosław Bańko: https://sjp.pwn.pl/poradnia/haslo/skroty-dni-tygodnia;2315.html
* In Polish we only ever write dates in YMD or DMY order, so I changed the priorities in the "format" field. I think this is how this is supposed to work...

To make the above look more legit, [here's some translations I did on translatewiki.net](https://translatewiki.net/wiki/Special:Contributions/Ostrzyciel), including SMW. :) 