### PR TITLE
Use $1 in the messages on Special:Types

### DIFF
--- a/includes/specials/SMW_SpecialTypes.php
+++ b/includes/specials/SMW_SpecialTypes.php
@@ -421,22 +421,21 @@ class SMWSpecialTypes extends SpecialPage {
 			$typeValue = TypesValue::newFromTypeId( $typeId );
 			$msgKey = 'smw-type' . str_replace( '_', '-', strtolower( $typeId ) );
 
-			$text = $typeValue->getLongHTMLText( $linker );
-
 			if ( Message::exists( $msgKey ) ) {
-				$msg = Message::get( [ $msgKey, '' ], Message::PARSE, Message::USER_LANGUAGE );
-				$text .= Html::rawElement(
-					'span' ,
-					[
-						'class' => 'plainlinks',
-						'style' => 'font-size:85%'
-					],
-
-					// Remove the first two chars which are a localized
-					// diacritical, quotation mark
-					str_replace( mb_substr( $msg, 0, 2 ), '', $msg )
-				);
+				$text = $typeValue->getLongWikiText( $linker );
+				$text = Message::get( [ $msgKey, $text ], Message::PARSE, Message::USER_LANGUAGE );
+			} else {
+				$text = $typeValue->getLongHTMLText( $linker );
 			}
+
+			$text = Html::rawElement(
+				'span' ,
+				[
+					'class' => 'plainlinks',
+					'style' => 'font-size:85%'
+				],
+				$text
+			);
 
 			foreach ( $groups as $group => $types ) {
 


### PR DESCRIPTION
There is a small glitch on [Special:Types with French language](https://sandbox.semantic-mediawiki.org/wiki/Special:Types?uselang=fr) because the message is trimed of the two first characters, which are “” in other languages, but the French starts with «&amp;#​160; so the two first characters are «&amp; and the remaining #​160; is displayed.

Instead of modifying afterwards the message, use the $1 inside the message.

Also, uniformise the style (font-size: 85%) by using it for the fallback case when there is no help message for some specific type.