### PR TITLE
Replace use of Parser::$mOutput, deprecated in 1.35

### DIFF
--- a/includes/SMW_Outputs.php
+++ b/includes/SMW_Outputs.php
@@ -161,12 +161,7 @@ class SMWOutputs {
 	 * @param Parser $parser
 	 */
 	static public function commitToParser( Parser $parser ) {
-		/// TODO find out and document when this b/c code can go away
-		if ( method_exists( $parser, 'getOutput' ) ) {
-			$po = $parser->getOutput();
-		} else {
-			$po = $parser->mOutput;
-		}
+		$po = $parser->getOutput();
 
 		if ( isset( $po ) ) {
 			self::commitToParserOutput( $po );


### PR DESCRIPTION
The replacement, Parser::getOutput(), has been in MediaWiki for over a
decade (since 1.12.2 in 2008).  The current extension.json for SMW
requires MW >= 1.32.

Bug: T275160