### PR TITLE
Update Travis CI: MW 1.35, fix SITELANG=ja

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,24 +13,34 @@ addons:
 jobs:
   fast_finish: true
   include:
-    - env: DB=mysql; MW=REL1_32; PHPUNIT=6.5.*
+    # 1) SQLITE, MW min. supported version
+    - env: DB=sqlite; MW=REL1_32; PHPUNIT=6.5.*
       php: 7.1
-    - env: DB=sqlite; MW=REL1_33; PHPUNIT=6.5.* SITELANG=ja;
+    # 2) POSTGRES, current MW non-LTS stable, SITELANG=ja
+    - env: DB=postgres; MW=REL1_34; PHPUNIT=6.5.*; SITELANG=ja;
       php: 7.2
-    - env: DB=postgres; MW=REL1_34; PHPUNIT=6.5.*
+    # 3) MYSQL, current MW LTS stable, COVERAGE
+    - env: DB=mysql; MW=REL1_35; PHPUNIT=8.5.*; TYPE=coverage
       php: 7.3
+    # 4) mysql, MW master
     - env: DB=mysql; MW=master; PHPUNIT=8.5.*
       php: 7.4
+    # 5) BLAZEGRAPH
     - env: DB=mysql; MW=REL1_32; PHPUNIT=6.5.*; BLAZEGRAPH=1.5.2
       php: 7.1
+    # 6) FUSEKI
     - env: DB=mysql; MW=REL1_32; PHPUNIT=6.5.*; FUSEKI=2.4.0
       php: 7.1
+    # 7) VIRTUOSO
     - env: DB=mysql; MW=REL1_32; PHPUNIT=6.5.*; VIRTUOSO=6.1
       php: 7.1
+    # 8) SESAME
     - env: DB=mysql; MW=REL1_32; PHPUNIT=6.5.*; SESAME=2.8.7
       php: 7.1
+    # 9) ES
     - env: DB=mysql; MW=REL1_33; PHPUNIT=6.5.*; ES=5.6.6
       php: 7.1
+    # 10) Benchmark
     - env: DB=mysql; MW=REL1_32; PHPUNIT=6.5.*; TYPE=benchmark
       php: 7.2
   allow_failures:

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,8 +19,11 @@ jobs:
     # 2) POSTGRES, current MW non-LTS stable, SITELANG=ja
     - env: DB=postgres; MW=REL1_34; PHPUNIT=6.5.*; SITELANG=ja;
       php: 7.2
-    # 3) MYSQL, current MW LTS stable, COVERAGE
+    # 3a) MYSQL, current MW LTS stable, COVERAGE
     - env: DB=mysql; MW=REL1_35; PHPUNIT=8.5.*; TYPE=coverage
+      php: 7.3
+    # 3b) temp. stay with MW 1.34 for coverage
+    - env: DB=mysql; MW=REL1_34; PHPUNIT=6.5.*; TYPE=coverage
       php: 7.3
     # 4) mysql, MW master
     - env: DB=mysql; MW=master; PHPUNIT=8.5.*

--- a/.travis.yml
+++ b/.travis.yml
@@ -44,6 +44,11 @@ jobs:
     - env: DB=mysql; MW=REL1_32; PHPUNIT=6.5.*; TYPE=benchmark
       php: 7.2
   allow_failures:
+    # some tests fail for MW 1.35. temp. allow failures
+    - env: DB=mysql; MW=REL1_35; PHPUNIT=8.5.*; TYPE=coverage
+    # the test were never run before due to a syntax error in .travis.yml
+    # now, some test are failing. temp. allow_failures
+    - env: DB=postgres; MW=REL1_34; PHPUNIT=6.5.*; SITELANG=ja;
     # This is MW master, you never know what WMF developers have put in for easter eggs, same for PHP conversely
     - env: DB=mysql; MW=master; PHPUNIT=8.5.*
     # May take a moment and is non-critical therefore allow it to run without delaying the status


### PR DESCRIPTION
- added comments with job targets / expected configs
- added job for MW 1.35 (with temp. allowing failure)
- fix for SITELANG=ja: test was never run before due to a syntax error in .travis.yml (with temp. allowing failure)