### PR TITLE
Maintenance: replace deprecated static function

### DIFF
--- a/tests/phpunit/Utils/JSONScript/SpecialPageTestCaseProcessor.php
+++ b/tests/phpunit/Utils/JSONScript/SpecialPageTestCaseProcessor.php
@@ -4,12 +4,12 @@ namespace SMW\Tests\Utils\JSONScript;
 
 use FauxRequest;
 use Language;
+use MediaWiki\MediaWikiServices;
 use OutputPage;
 use RequestContext;
 use SMW\Tests\Utils\File\ContentsReader;
 use SMW\Tests\Utils\Mock\MockSuperUser;
 use SpecialPage;
-use SpecialPageFactory;
 
 /**
  * @group semantic-mediawiki
@@ -85,7 +85,7 @@ class SpecialPageTestCaseProcessor extends \PHPUnit_Framework_TestCase {
 		}
 
 		$text = $this->getTextForRequestBy(
-			SpecialPageFactory::getPage( $case['special-page']['page'] ),
+			MediaWikiServices::getInstance()->getSpecialPageFactory()->getPage( $case['special-page']['page'] ),
 			new FauxRequest( $case['special-page']['request-parameters'] ),
 			$queryParameters
 		);


### PR DESCRIPTION
The static calls to methods of SpecialPageFactory are replaced by an instance of the class.

The only other occurence of `SpecialPageFactory::` is in a comment in [tests/phpunit/includes/specials/SpecialsTest.php](https://github.com/SemanticMediaWiki/SemanticMediaWiki/blob/master/tests/phpunit/includes/specials/SpecialsTest.php), but given the class still exists I guess it’s correct.

Kept the old version for MediaWiki 1.31, although I’m not sure if it will be supported by SMW 4.0.

Fixes: #4603
Fixes: #4943