### PR TITLE
Maintenance: replace Revision by RevisionRecord

### DIFF
--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -29,7 +29,7 @@ Some conventions to help developers and the project to maintain a consistent pro
 - The top-level namespace is `SMW` and each component should be placed in a namespace that represents the main responsibility of the component
 - [`PSR-4`](https://www.php-fig.org/psr/psr-4/) is used for resolving classes and namespaces in the `src` directory (`includes` is the legacy folder that doesn't necessarily follow any of the policies or conventions mentioned in this document)
 - Development happens against the master branch (see also the [release process](https://www.semantic-mediawiki.org/wiki/Release_process)) and will be release according the the available release plan, backports should be cherry-picked and merged into the targeted branch
-- Semantic MediaWiki tries to depend only on a selected pool of MediaWiki core classes (`Title`, `Wikipage`, `ParserOutput`, `Revision`, `Language` ... ) to minimize the potential for breakage during release changes
+- Semantic MediaWiki tries to depend only on a selected pool of MediaWiki core classes (`Title`, `Wikipage`, `ParserOutput`, `RevisionRecord`, `Language` ... ) to minimize the potential for breakage during release changes
 - It is expected that each new class and functionality is covered by corresponding unit tests and if the functionality spans into different components integration tests are required as well to ensure that the behaviour is tested across components and produces deterministic and observable outputs.
 
 #### Best practices

--- a/docs/architecture/extending.propertyannotator.md
+++ b/docs/architecture/extending.propertyannotator.md
@@ -2,7 +2,7 @@
 
 - Add a new class that implements the [Annotator](https://github.com/SemanticMediaWiki/SemanticMediaWiki/blob/master/src/Property/Annotator.php) (alias `PropertyAnnotator`) interface via the `PropertyAnnotatorDecorator` base class
 - Register the implementation with the `AnnotatorFactory`
-- Use either the [`NewRevisionFromEditComplete`](https://github.com/SemanticMediaWiki/SemanticMediaWiki/blob/master/src/MediaWiki/Hooks/NewRevisionFromEditComplete.php) or [`ParserAfterTidy`](https://github.com/SemanticMediaWiki/SemanticMediaWiki/blob/master/src/MediaWiki/Hooks/ParserAfterTidy.php) hook to invoke the `AnnotatorFactory` method created and annotate values as demonstrated by existing `PropertyAnnotator`
+- Use either the [`RevisionFromEditComplete`](https://github.com/SemanticMediaWiki/SemanticMediaWiki/blob/master/src/MediaWiki/Hooks/RevisionFromEditComplete.php) or [`ParserAfterTidy`](https://github.com/SemanticMediaWiki/SemanticMediaWiki/blob/master/src/MediaWiki/Hooks/ParserAfterTidy.php) hook to invoke the `AnnotatorFactory` method created and annotate values as demonstrated by existing `PropertyAnnotator`
 
 ### See also
 

--- a/docs/technical/hooks/hook.revisionguard.changerevision.md
+++ b/docs/technical/hooks/hook.revisionguard.changerevision.md
@@ -12,7 +12,8 @@ use Hooks;
 Hooks::register( 'SMW::RevisionGuard::ChangeRevision', function( $title, &$revision ) {
 
 	// Set a revision
-	// $revision = \Revision::newFromId( $id );
+	// $revisionLookup = \MediaWiki\MediaWikiServices::getInstance()->getRevisionLookup();
+	// $revision = $revisionLookup->getRevisionById( $id );
 
 	return true;
 } );

--- a/includes/ContentParser.php
+++ b/includes/ContentParser.php
@@ -2,9 +2,10 @@
 
 namespace SMW;
 
+use MediaWiki\Revision\RevisionRecord;
+use MediaWiki\Revision\SlotRecord;
 use Parser;
 use ParserOptions;
-use Revision;
 use Title;
 use User;
 use SMW\MediaWiki\RevisionGuard;
@@ -35,7 +36,7 @@ class ContentParser {
 	/** @var ParserOutput */
 	protected $parserOutput = null;
 
-	/** @var Revision */
+	/** @var RevisionRecord */
 	protected $revision = null;
 
 	/** @var array */
@@ -71,7 +72,7 @@ class ContentParser {
 	 *
 	 * @return ContentParser
 	 */
-	public function setRevision( Revision $revision = null ) {
+	public function setRevision( RevisionRecord $revision = null ) {
 		$this->revision = $revision;
 		return $this;
 	}
@@ -146,9 +147,10 @@ class ContentParser {
 		}
 
 		$revision = $this->getRevision();
-		$content = $revision->getContent( Revision::RAW );
+		$content = $revision->getContent( SlotRecord::MAIN, RevisionRecord::RAW );
 
 		if ( !$content ) {
+			// TODO must be replaced by appropriate function for MCR (main slot)
 			$content = $revision->getContentHandler()->makeEmptyContent();
 		}
 
@@ -177,7 +179,10 @@ class ContentParser {
 		$user = null;
 
 		if ( $this->getRevision() !== null ) {
-			$user = User::newFromId( $this->getRevision()->getUser() );
+			$identity = $this->getRevision()->getUser();
+			if ( $identity ) {
+				$user = User::newFromIdentity( $identity );
+			}
 		}
 
 		$parserOptions = new ParserOptions( $user );
@@ -191,7 +196,7 @@ class ContentParser {
 
 	private function getRevision() {
 
-		if ( $this->revision instanceof Revision ) {
+		if ( $this->revision instanceof RevisionRecord ) {
 			return $this->revision;
 		}
 

--- a/includes/export/SMW_ExportController.php
+++ b/includes/export/SMW_ExportController.php
@@ -412,7 +412,9 @@ class SMWExportController {
 				continue; // invalid title name given
 			}
 			if ( $revisiondate !== '' ) { // filter page list by revision date
-				$rev = Revision::getTimeStampFromID( $title, $title->getLatestRevID() );
+				$revisionStore = \MediaWiki\MediaWikiServices::getInstance()->getRevisionStore();
+				# b/c The title can be dropped for 1.34+
+				$rev = $revisionStore->getTimestampFromId( $title, $title->getLatestRevID() );
 				if ( $rev < $revisiondate ) {
 					continue;
 				}

--- a/src/DataUpdater.php
+++ b/src/DataUpdater.php
@@ -2,13 +2,13 @@
 
 namespace SMW;
 
+use MediaWiki\Revision\RevisionRecord;
 use Title;
 use User;
 use WikiPage;
 use SMW\DeferredTransactionalCallableUpdate as DeferredUpdate;
 use Psr\Log\LoggerAwareTrait;
 use SMW\Property\ChangePropagationNotifier;
-use Revision;
 use SMW\MediaWiki\RevisionGuardAwareTrait;
 use SMW\MediaWiki\RevisionGuard;
 use Onoi\EventDispatcher\EventDispatcherAwareTrait;
@@ -277,8 +277,11 @@ class DataUpdater {
 			$this->revisionGuard->newRevisionFromPage( $wikiPage )
 		);
 
-		if ( $revision instanceof Revision ) {
-			$user = User::newFromId( $revision->getUser() );
+		if ( $revision instanceof RevisionRecord ) {
+			$identity = $revision->getUser();
+			if ( $identity ) {
+				$user = User::newFromIdentity( $identity );
+			}
 		}
 
 		$this->addAnnotations( $title, $wikiPage, $revision, $user );

--- a/src/Elastic/Indexer/Indexer.php
+++ b/src/Elastic/Indexer/Indexer.php
@@ -2,6 +2,8 @@
 
 namespace SMW\Elastic\Indexer;
 
+use MediaWiki\Revision\RevisionRecord;
+use MediaWiki\Revision\SlotRecord;
 use Onoi\MessageReporter\MessageReporterAwareTrait;
 use Psr\Log\LoggerAwareTrait;
 use SMW\Services\ServicesContainer;
@@ -19,7 +21,6 @@ use SMW\MediaWiki\Collator;
 use SMW\Utils\Timer;
 use SMWDIBlob as DIBlob;
 use Title;
-use Revision;
 
 /**
  * @license GNU GPL v2+
@@ -293,13 +294,15 @@ class Indexer {
 			return '';
 		}
 
-		$revision = Revision::newFromId( $id );
+		// TODO MCR use RevisionGuard ?
+		$revisionLookup = \MediaWiki\MediaWikiServices::getInstance()->getRevisionLookup();
+		$revision = $revisionLookup->getRevisionById( $id );
 
 		if ( $revision == null ) {
 			return '';
 		}
 
-		$content = $revision->getContent( Revision::RAW );
+		$content = $revision->getContent( SlotRecord::MAIN, RevisionRecord::RAW );
 
 		return $content->getNativeData();
 	}

--- a/src/MediaWiki/EditInfo.php
+++ b/src/MediaWiki/EditInfo.php
@@ -2,8 +2,9 @@
 
 namespace SMW\MediaWiki;
 
+use MediaWiki\Revision\RevisionRecord;
+use MediaWiki\Revision\SlotRecord;
 use ParserOutput;
-use Revision;
 use SMW\ParserData;
 use SMW\SemanticData;
 use User;
@@ -25,7 +26,7 @@ class EditInfo {
 	private $page;
 
 	/**
-	 * @var Revision
+	 * @var RevisionRecord
 	 */
 	private $revision;
 
@@ -43,10 +44,10 @@ class EditInfo {
 	 * @since 1.9
 	 *
 	 * @param WikiPage $page
-	 * @param Revision $revision
+	 * @param RevisionRecord|null $revision
 	 * @param User|null $user
 	 */
-	public function __construct( WikiPage $page, Revision $revision = null, User $user = null ) {
+	public function __construct( WikiPage $page, RevisionRecord $revision = null, User $user = null ) {
 		$this->page = $page;
 		$this->revision = $revision;
 		$this->user = $user;
@@ -86,11 +87,11 @@ class EditInfo {
 			$this->revision = $this->revisionGuard->newRevisionFromPage( $this->page );
 		}
 
-		if ( !$this->revision instanceof Revision ) {
+		if ( !$this->revision instanceof RevisionRecord ) {
 			return $this;
 		}
 
-		$content = $this->revision->getContent();
+		$content = $this->revision->getContent( SlotRecord::MAIN );
 
 		$prepareEdit = $this->page->prepareContentForEdit(
 			$content,

--- a/src/MediaWiki/HookDispatcher.php
+++ b/src/MediaWiki/HookDispatcher.php
@@ -4,6 +4,7 @@ namespace SMW\MediaWiki;
 
 use Hooks;
 use User;
+use MediaWiki\Revision\RevisionRecord;
 use SMW\Store;
 use SMW\SQLStore\TableBuilder;
 use SMW\Options;
@@ -245,9 +246,9 @@ class HookDispatcher {
 	 * @since 3.2
 	 *
 	 * @param Title $title
-	 * @param Revision|null $revision
+	 * @param RevisionRecord|null $revision
 	 */
-	public function onChangeRevision( \Title $title, ?\Revision &$revision ) {
+	public function onChangeRevision( \Title $title, ?RevisionRecord &$revision ) {
 		Hooks::run( 'SMW::RevisionGuard::ChangeRevision', [ $title, &$revision ] );
 	}
 

--- a/src/MediaWiki/Hooks.php
+++ b/src/MediaWiki/Hooks.php
@@ -36,7 +36,7 @@ use SMW\MediaWiki\Hooks\FileUpload;
 use SMW\MediaWiki\Hooks\GetPreferences;
 use SMW\MediaWiki\Hooks\InternalParseBeforeLinks;
 use SMW\MediaWiki\Hooks\LinksUpdateConstructed;
-use SMW\MediaWiki\Hooks\NewRevisionFromEditComplete;
+use SMW\MediaWiki\Hooks\RevisionFromEditComplete;
 use SMW\MediaWiki\Hooks\OutputPageParserOutput;
 use SMW\MediaWiki\Hooks\ParserAfterTidy;
 use SMW\MediaWiki\Hooks\PersonalUrls;
@@ -50,7 +50,7 @@ use SMW\MediaWiki\Hooks\SpecialSearchResultsPrepend;
 use SMW\MediaWiki\Hooks\SpecialStatsAddExtra;
 use SMW\MediaWiki\Hooks\TitleIsAlwaysKnown;
 use SMW\MediaWiki\Hooks\TitleIsMovable;
-use SMW\MediaWiki\Hooks\TitleMoveComplete;
+use SMW\MediaWiki\Hooks\PageMoveComplete;
 use SMW\MediaWiki\Hooks\TitleQuickPermissions;
 use SMW\MediaWiki\Hooks\UserChange;
 use SMW\MediaWiki\Hooks\DeleteAccount;
@@ -289,7 +289,7 @@ class Hooks {
 			'BeforeDisplayNoArticleText' => [ $this, 'onBeforeDisplayNoArticleText' ],
 			'EditPage::showEditForm:initial' => [ $this, 'onEditPageShowEditFormInitial' ],
 
-			'TitleMoveComplete' => [ $this, 'onTitleMoveComplete' ],
+			'PageMoveComplete' => [ $this, 'onPageMoveComplete' ],
 			'TitleIsAlwaysKnown' => [ $this, 'onTitleIsAlwaysKnown' ],
 			'TitleQuickPermissions' => [ $this, 'onTitleQuickPermissions' ],
 			'TitleIsMovable' => [ $this, 'onTitleIsMovable' ],
@@ -301,7 +301,7 @@ class Hooks {
 			'ArticleViewHeader' => [ $this, 'onArticleViewHeader' ],
 			'ContentHandlerForModelID' => [ $this, 'onContentHandlerForModelID' ],
 
-			'NewRevisionFromEditComplete' => [ $this, 'onNewRevisionFromEditComplete' ],
+			'RevisionFromEditComplete' => [ $this, 'onRevisionFromEditComplete' ],
 			'LinksUpdateConstructed' => [ $this, 'onLinksUpdateConstructed' ],
 			'FileUpload' => [ $this, 'onFileUpload' ],
 			'MaintenanceUpdateAddParams' => [ $this, 'onMaintenanceUpdateAddParams' ],
@@ -613,12 +613,12 @@ class Hooks {
 	}
 
 	/**
-	 * Hook: NewRevisionFromEditComplete called when a revision was inserted
+	 * Hook: RevisionFromEditComplete called when a revision was inserted
 	 * due to an edit
 	 *
-	 * @see https://www.mediawiki.org/wiki/Manual:Hooks/NewRevisionFromEditComplete
+	 * @see https://www.mediawiki.org/wiki/Manual:Hooks/RevisionFromEditComplete
 	 */
-	public function onNewRevisionFromEditComplete( $wikiPage, $revision, $baseId, $user ) {
+	public function onRevisionFromEditComplete( $wikiPage, $revision, $baseId, $user, &$tags ) {
 
 		$applicationFactory = ApplicationFactory::getInstance();
 		$mwCollaboratorFactory = $applicationFactory->newMwCollaboratorFactory();
@@ -635,18 +635,18 @@ class Hooks {
 			$user
 		);
 
-		$newRevisionFromEditComplete = new NewRevisionFromEditComplete(
+		$revisionFromEditComplete = new RevisionFromEditComplete(
 			$editInfo,
 			$pageInfoProvider,
 			$applicationFactory->singleton( 'PropertyAnnotatorFactory' ),
 			$applicationFactory->singleton( 'SchemaFactory' )
 		);
 
-		$newRevisionFromEditComplete->setEventDispatcher(
+		$revisionFromEditComplete->setEventDispatcher(
 			$applicationFactory->getEventDispatcher()
 		);
 
-		$newRevisionFromEditComplete->process( $wikiPage->getTitle() );
+		$revisionFromEditComplete->process( $wikiPage->getTitle() );
 
 		return true;
 	}
@@ -779,16 +779,16 @@ class Hooks {
 	}
 
 	/**
-	 * Hook: TitleMoveComplete occurs whenever a request to move an article
+	 * Hook: PageMoveComplete occurs whenever a request to move an article
 	 * is completed
 	 *
-	 * @see https://www.mediawiki.org/wiki/Manual:Hooks/TitleMoveComplete
+	 * @see https://www.mediawiki.org/wiki/Manual:Hooks/PageMoveComplete
 	 */
-	public function onTitleMoveComplete( $oldTitle, $newTitle, $user, $oldId, $newId ) {
+	public function onPageMoveComplete( $oldTitle, $newTitle, $user, $oldId, $newId ) {
 
 		$applicationFactory = ApplicationFactory::getInstance();
 
-		$titleMoveComplete = new TitleMoveComplete(
+		$titleMoveComplete = new PageMoveComplete(
 			$applicationFactory->getNamespaceExaminer()
 		);
 

--- a/src/MediaWiki/Hooks/PageMoveComplete.php
+++ b/src/MediaWiki/Hooks/PageMoveComplete.php
@@ -8,20 +8,20 @@ use SMW\NamespaceExaminer;
 use SMW\MediaWiki\HookListener;
 
 /**
- * TitleMoveComplete occurs whenever a request to move an article
+ * PageMoveComplete occurs whenever a request to move an article
  * is completed
  *
  * This method will be called whenever an article is moved so that
  * semantic properties are moved accordingly.
  *
- * @see https://www.mediawiki.org/wiki/Manual:Hooks/TitleMoveComplete
+ * @see https://www.mediawiki.org/wiki/Manual:Hooks/PageMoveComplete
  *
  * @license GNU GPL v2+
  * @since 1.9
  *
  * @author mwjames
  */
-class TitleMoveComplete implements HookListener {
+class PageMoveComplete implements HookListener {
 
 	use EventDispatcherAwareTrait;
 
@@ -62,7 +62,7 @@ class TitleMoveComplete implements HookListener {
 		}
 
 		$context = [
-			'context' => 'TitleMoveComplete'
+			'context' => 'PageMoveComplete'
 		];
 
 		foreach ( [ 'InvalidateResultCache', 'InvalidateEntityCache' ] as $event ) {

--- a/src/MediaWiki/Hooks/README.md
+++ b/src/MediaWiki/Hooks/README.md
@@ -12,8 +12,8 @@ InternalParseBeforeLinks is used to process and expand text content, and in case
 #### LinksUpdateConstructed
 LinksUpdateConstructed is called at the end of LinksUpdate and is being used to initiate a store update for data that were held by the ParserOutput object.
 
-#### NewRevisionFromEditComplete
-NewRevisionFromEditComplete called when a new revision was inserted due to an edit and used to update the ParserOuput with the latests special property annotation.
+#### RevisionFromEditComplete
+RevisionFromEditComplete called when a new revision was inserted due to an edit and used to update the ParserOuput with the latests special property annotation.
 
 #### ParserAfterTidy
 ParserAfterTidy is used to re-introduce content, update base annotations (e.g. special properties, categories etc.) and in case of a manual article purge initiates a store update (LinksUpdateConstructed wouldn't work because it acts only on link changes and therefore would not trigger a LinksUpdateConstructed event).
@@ -27,7 +27,7 @@ Extend the display with content from the Factbox.
 #### OutputPageParserOutput
 Rendering the Factbox and updating the FactboxCache.
 
-#### TitleMoveComplete
+#### PageMoveComplete
 Update the Store after an article has been deleted.
 
 #### ResourceLoaderGetConfigVars

--- a/src/MediaWiki/Hooks/RevisionFromEditComplete.php
+++ b/src/MediaWiki/Hooks/RevisionFromEditComplete.php
@@ -16,7 +16,7 @@ use SMW\Property\AnnotatorFactory as PropertyAnnotatorFactory;
 use SMW\Schema\SchemaFactory;
 
 /**
- * Hook: NewRevisionFromEditComplete called when a revision was inserted
+ * Hook: RevisionFromEditComplete called when a revision was inserted
  * due to an edit
  *
  * Fetch additional information that is related to the saving that has just happened,
@@ -25,14 +25,14 @@ use SMW\Schema\SchemaFactory;
  *
  * Called from LocalFile.php, SpecialImport.php, Article.php, Title.php
  *
- * @see https://www.mediawiki.org/wiki/Manual:Hooks/NewRevisionFromEditComplete
+ * @see https://www.mediawiki.org/wiki/Manual:Hooks/RevisionFromEditComplete
  *
  * @license GNU GPL v2+
  * @since 1.9
  *
  * @author mwjames
  */
-class NewRevisionFromEditComplete implements HookListener {
+class RevisionFromEditComplete implements HookListener {
 
 	use OptionsAwareTrait;
 	use EventDispatcherAwareTrait;
@@ -102,7 +102,7 @@ class NewRevisionFromEditComplete implements HookListener {
 		);
 
 		$context = [
-			'context' => NewRevisionFromEditComplete::class,
+			'context' => RevisionFromEditComplete::class,
 			'title' => $title
 		];
 

--- a/src/MediaWiki/Jobs/ParserCachePurgeJob.php
+++ b/src/MediaWiki/Jobs/ParserCachePurgeJob.php
@@ -2,6 +2,8 @@
 
 namespace SMW\MediaWiki\Jobs;
 
+use MediaWiki\Revision\RevisionRecord;
+use MediaWiki\Revision\SlotRecord;
 use SMW\MediaWiki\Job;
 use SMW\ApplicationFactory;
 use Title;
@@ -100,7 +102,7 @@ class ParserCachePurgeJob extends Job {
 		$enableParserCache = true;
 
 		$popts = $page->makeParserOptions( 'canonical' );
-		$content = $page->getContent( \Revision::RAW );
+		$content = $page->getContent( SlotRecord::MAIN, RevisionRecord::RAW );
 
 		if ( $content ) {
 			$p_result = $content->getParserOutput(

--- a/src/MediaWiki/MediaWikiNsContentReader.php
+++ b/src/MediaWiki/MediaWikiNsContentReader.php
@@ -2,7 +2,8 @@
 
 namespace SMW\MediaWiki;
 
-use Revision;
+use MediaWiki\Revision\SlotRecord;
+use IDBAccessObject;
 use Title;
 
 /**
@@ -57,21 +58,14 @@ class MediaWikiNsContentReader {
 			return '';
 		}
 
-		$revision = $this->revisionGuard->newRevisionFromTitle( $title, false, Revision::READ_LATEST );
+		$revision = $this->revisionGuard->newRevisionFromTitle( $title, false, IDBAccessObject::READ_LATEST );
 
 		if ( $revision === null ) {
 			return '';
 		}
 
-		if ( class_exists( 'WikitextContent' ) ) {
-			return $revision->getContent()->getNativeData();
-		}
-
-		if ( method_exists( $revision, 'getContent' ) ) {
-			return $revision->getContent( Revision::RAW );
-		}
-
-		return $revision->getRawText();
+		// MW 1.33+ use getText() instead
+		return $revision->getContent( SlotRecord::MAIN )->getNativeData();
 	}
 
 }

--- a/src/MediaWiki/MwCollaboratorFactory.php
+++ b/src/MediaWiki/MwCollaboratorFactory.php
@@ -2,9 +2,9 @@
 
 namespace SMW\MediaWiki;
 
+use MediaWiki\Revision\RevisionRecord;
 use Language;
 use Parser;
-use Revision;
 use SMW\ApplicationFactory;
 use SMW\MediaWiki\Connection\LoadBalancerConnectionProvider;
 use SMW\MediaWiki\Connection\ConnectionProvider;
@@ -160,14 +160,14 @@ class MwCollaboratorFactory {
 	/**
 	 * @since 2.0
 	 *
-	 * @param WikiPage $wkiPage
-	 * @param Revision|null $revision
+	 * @param WikiPage $wikiPage
+	 * @param RevisionRecord|null $revision
 	 * @param User|null $user
 	 *
 	 * @return PageInfoProvider
 	 */
-	public function newPageInfoProvider( WikiPage $wkiPage, Revision $revision = null, User $user = null ) {
-		$pageInfoProvider = new PageInfoProvider( $wkiPage, $revision, $user );
+	public function newPageInfoProvider( WikiPage $wikiPage, RevisionRecord $revision = null, User $user = null ) {
+		$pageInfoProvider = new PageInfoProvider( $wikiPage, $revision, $user );
 
 		$pageInfoProvider->setRevisionGuard(
 			$this->applicationFactory->singleton( 'RevisionGuard' )
@@ -180,28 +180,28 @@ class MwCollaboratorFactory {
 	 * @deprecated since 3.1
 	 * @since 2.5
 	 *
-	 * @param WikiPage $wkiPage
-	 * @param Revision $revision
+	 * @param WikiPage $wikiPage
+	 * @param RevisionRecord $revision
 	 * @param User|null $user
 	 *
 	 * @return EditInfo
 	 */
-	public function newEditInfoProvider( WikiPage $wkiPage, Revision $revision, User $user = null ) {
-		return $this->newEditInfo( $wkiPage, $revision, $user );
+	public function newEditInfoProvider( WikiPage $wikiPage, RevisionRecord $revision, User $user = null ) {
+		return $this->newEditInfo( $wikiPage, $revision, $user );
 	}
 
 	/**
 	 * @since 3.1
 	 *
-	 * @param WikiPage $wkiPage
-	 * @param Revision $revision
+	 * @param WikiPage $wikiPage
+	 * @param RevisionRecord $revision
 	 * @param User|null $user
 	 *
 	 * @return EditInfo
 	 */
-	public function newEditInfo( WikiPage $wkiPage, Revision $revision = null, User $user = null ) {
+	public function newEditInfo( WikiPage $wikiPage, RevisionRecord $revision = null, User $user = null ) {
 
-		$editInfo = new EditInfo( $wkiPage, $revision, $user );
+		$editInfo = new EditInfo( $wikiPage, $revision, $user );
 
 		$editInfo->setRevisionGuard(
 			$this->applicationFactory->singleton( 'RevisionGuard' )

--- a/src/MediaWiki/PageInfoProvider.php
+++ b/src/MediaWiki/PageInfoProvider.php
@@ -2,7 +2,7 @@
 
 namespace SMW\MediaWiki;
 
-use Revision;
+use MediaWiki\Revision\RevisionRecord;
 use SMW\PageInfo;
 use Title;
 use User;
@@ -29,7 +29,7 @@ class PageInfoProvider implements PageInfo {
 	private $wikiPage = null;
 
 	/**
-	 * @var Revision
+	 * @var RevisionRecord
 	 */
 	private $revision = null;
 
@@ -42,10 +42,10 @@ class PageInfoProvider implements PageInfo {
 	 * @since 1.9
 	 *
 	 * @param WikiPage $wikiPage
-	 * @param Revision|null $revision
+	 * @param RevisionRecord|null $revision
 	 * @param User|null $user
 	 */
-	public function __construct( WikiPage $wikiPage, Revision $revision = null, User $user = null ) {
+	public function __construct( WikiPage $wikiPage, RevisionRecord $revision = null, User $user = null ) {
 		$this->wikiPage = $wikiPage;
 		$this->revision = $revision;
 		$this->user = $user;

--- a/src/Parser/RecursiveTextProcessor.php
+++ b/src/Parser/RecursiveTextProcessor.php
@@ -5,6 +5,7 @@ namespace SMW\Parser;
 use Parser;
 use ParserOptions;
 use RuntimeException;
+use SMW\ApplicationFactory;
 use SMW\Localizer;
 use SMW\ParserData;
 use SMW\MediaWiki\Template\TemplateExpander;
@@ -71,7 +72,7 @@ class RecursiveTextProcessor {
 		$this->parser = $parser;
 
 		if ( $this->parser === null ) {
-			$this->parser = $GLOBALS['wgParser'];
+			$this->parser = ApplicationFactory::getInstance()->create( 'Parser' );
 		}
 	}
 

--- a/src/Query/ResultPrinters/FeedExportPrinter.php
+++ b/src/Query/ResultPrinters/FeedExportPrinter.php
@@ -5,6 +5,7 @@ namespace SMW\Query\ResultPrinters;
 use FeedItem;
 use ParserOptions;
 use Sanitizer;
+use SMW\ApplicationFactory;
 use SMW\DataValueFactory;
 use SMW\DIWikiPage;
 use SMW\Query\ExportPrinter;
@@ -434,7 +435,8 @@ final class FeedExportPrinter extends ResultPrinter implements ExportPrinter {
 			$parserOptions->setEditSection( false );
 		}
 
-		return $GLOBALS['wgParser']->parse( $text, $title, $parserOptions )->getText( [ 'enableSectionEditLinks' => false ] );
+		$parser = ApplicationFactory::getInstance()->create( 'Parser' );
+		return $parser->parse( $text, $title, $parserOptions )->getText( [ 'enableSectionEditLinks' => false ] );
 	}
 
 	private function getFeedLink( QueryResult $res, $outputMode ) {

--- a/tests/phpunit/Integration/MediaWiki/HookDispatcherTest.php
+++ b/tests/phpunit/Integration/MediaWiki/HookDispatcherTest.php
@@ -411,11 +411,11 @@ class HookDispatcherTest extends \PHPUnit_Framework_TestCase {
 			->disableOriginalConstructor()
 			->getMock();
 
-		$revision = $this->getMockBuilder( '\Revision' )
+		$revision = $this->getMockBuilder( '\MediaWiki\Revision\RevisionRecord' )
 			->disableOriginalConstructor()
 			->getMock();
 
-		$anotherRevision = $this->getMockBuilder( '\Revision' )
+		$anotherRevision = $this->getMockBuilder( '\MediaWiki\Revision\RevisionRecord' )
 			->disableOriginalConstructor()
 			->getMock();
 

--- a/tests/phpunit/Integration/MediaWiki/Hooks/PageMoveCompleteIntegrationTest.php
+++ b/tests/phpunit/Integration/MediaWiki/Hooks/PageMoveCompleteIntegrationTest.php
@@ -22,7 +22,7 @@ use WikiPage;
  *
  * @author mwjames
  */
-class TitleMoveCompleteIntegrationTest extends MwDBaseUnitTestCase {
+class PageMoveCompleteIntegrationTest extends MwDBaseUnitTestCase {
 
 	private $mwHooksHandler;
 	private $queryResultValidator;
@@ -43,8 +43,8 @@ class TitleMoveCompleteIntegrationTest extends MwDBaseUnitTestCase {
 		$this->mwHooksHandler->deregisterListedHooks();
 
 		$this->mwHooksHandler->register(
-			'TitleMoveComplete',
-			$this->mwHooksHandler->getHookRegistry()->getHandlerFor( 'TitleMoveComplete' )
+			'PageMoveComplete',
+			$this->mwHooksHandler->getHookRegistry()->getHandlerFor( 'PageMoveComplete' )
 		);
 
 		$this->pageCreator = $utilityFactory->newPageCreator();

--- a/tests/phpunit/Integration/MediaWiki/LinksUpdateSQLStoreDBIntegrationTest.php
+++ b/tests/phpunit/Integration/MediaWiki/LinksUpdateSQLStoreDBIntegrationTest.php
@@ -4,7 +4,6 @@ namespace SMW\Tests\Integration\MediaWiki;
 
 use LinksUpdate;
 use ParserOutput;
-use Revision;
 use SMW\Services\ServicesFactory;
 use SMW\DIWikiPage;
 use SMW\ParserData;
@@ -187,7 +186,9 @@ class LinksUpdateSQLStoreDBIntegrationTest extends MwDBaseUnitTestCase {
 
 	protected function retrieveAndLoadData( $revId = null ) {
 
-		$revision = $revId ? Revision::newFromId( $revId ) : null;
+		// TODO MCR use RevisionGuard ?
+		$revisionLookup = \MediaWiki\MediaWikiServices::getInstance()->getRevisionLookup();
+		$revision = $revId ? $revisionLookup->getRevisionById( $revId ) : null;
 
 		$contentParser = ServicesFactory::getInstance()->newContentParser(
 			$this->title

--- a/tests/phpunit/Integration/Parser/InTextAnnotationParserTemplateTransclusionTest.php
+++ b/tests/phpunit/Integration/Parser/InTextAnnotationParserTemplateTransclusionTest.php
@@ -55,7 +55,7 @@ class InTextAnnotationParserTemplateTransclusionTest extends \PHPUnit_Framework_
 	 */
 	private function runTemplateTransclusion( Title $title, $text, $return ) {
 
-		$parser  = new \Parser;
+		$parser  = $this->applicationFactory->create( 'Parser' );
 		$options = new \ParserOptions;
 		$options->setTemplateCallback( function ( $title, $parser = false ) use ( $return ) {
 

--- a/tests/phpunit/Unit/DataUpdaterTest.php
+++ b/tests/phpunit/Unit/DataUpdaterTest.php
@@ -43,7 +43,7 @@ class DataUpdaterTest extends \PHPUnit_Framework_TestCase {
 
 		$this->spyLogger = $this->testEnvironment->newSpyLogger();
 
-		$this->revision = $this->getMockBuilder( '\Revision' )
+		$this->revision = $this->getMockBuilder( '\MediaWiki\Revision\RevisionRecord' )
 			->disableOriginalConstructor()
 			->getMock();
 
@@ -193,7 +193,7 @@ class DataUpdaterTest extends \PHPUnit_Framework_TestCase {
 		$store->expects( $this->once() )
 			->method( 'updateData' );
 
-		$revision = $this->getMockBuilder( '\Revision' )
+		$revision = $this->getMockBuilder( '\MediaWiki\Revision\RevisionRecord' )
 			->disableOriginalConstructor()
 			->getMock();
 
@@ -396,7 +396,7 @@ class DataUpdaterTest extends \PHPUnit_Framework_TestCase {
 			->disableOriginalConstructor()
 			->getMock();
 
-		$revision = $this->getMockBuilder( '\Revision' )
+		$revision = $this->getMockBuilder( '\MediaWiki\Revision\RevisionRecord' )
 			->disableOriginalConstructor()
 			->getMock();
 
@@ -451,7 +451,7 @@ class DataUpdaterTest extends \PHPUnit_Framework_TestCase {
 
 	public function testForYetUnknownRedirectTarget() {
 
-		$revision = $this->getMockBuilder( '\Revision' )
+		$revision = $this->getMockBuilder( '\MediaWiki\Revision\RevisionRecord' )
 			->disableOriginalConstructor()
 			->getMock();
 

--- a/tests/phpunit/Unit/MediaWiki/EditInfoTest.php
+++ b/tests/phpunit/Unit/MediaWiki/EditInfoTest.php
@@ -22,7 +22,7 @@ class EditInfoTest extends \PHPUnit_Framework_TestCase {
 			->disableOriginalConstructor()
 			->getMock();
 
-		$revision = $this->getMockBuilder( '\Revision' )
+		$revision = $this->getMockBuilder( '\MediaWiki\Revision\RevisionRecord' )
 			->disableOriginalConstructor()
 			->getMock();
 
@@ -196,9 +196,9 @@ class EditInfoTest extends \PHPUnit_Framework_TestCase {
 
 	private function newRevisionStub() {
 
-		$revision = $this->getMockBuilder( '\Revision' )
+		$revision = $this->getMockBuilder( '\MediaWiki\Revision\RevisionRecord' )
 			->disableOriginalConstructor()
-			->setMethods( [ 'getRawText', 'getContent' ] )
+			->setMethods( [ 'getRawText', 'getContent', 'getSize', 'getSha1' ] )
 			->getMock();
 
 		$revision->expects( $this->any() )
@@ -208,9 +208,17 @@ class EditInfoTest extends \PHPUnit_Framework_TestCase {
 		$revision->expects( $this->any() )
 			->method( 'getContent' )
 			->will( $this->returnValueMap( [
-				[ \Revision::RAW, null, 'Foo' ],
-				[ \Revision::FOR_PUBLIC, null, $this->newContentStub() ],
+				[ \MediaWiki\Revision\SlotRecord::MAIN, \MediaWiki\Revision\RevisionRecord::RAW, null, 'Foo' ],
+				[ \MediaWiki\Revision\SlotRecord::MAIN, \MediaWiki\Revision\RevisionRecord::FOR_PUBLIC, null, $this->newContentStub() ],
 			] ) );
+
+		$revision->expects( $this->any() )
+			->method( 'getSize' )
+			->will( $this->returnValue( strlen( 'Foo' ) ) );
+
+		$revision->expects( $this->any() )
+			->method( 'getSha1' )
+			->will( $this->returnValue( \Wikimedia\base_convert( sha1( 'Foo' ), 16, 36 ) ) );
 
 		return $revision;
 	}

--- a/tests/phpunit/Unit/MediaWiki/Hooks/PageMoveCompleteTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Hooks/PageMoveCompleteTest.php
@@ -2,13 +2,13 @@
 
 namespace SMW\Tests\MediaWiki\Hooks;
 
-use SMW\MediaWiki\Hooks\TitleMoveComplete;
+use SMW\MediaWiki\Hooks\PageMoveComplete;
 use SMW\Tests\TestEnvironment;
 use SMW\Tests\Utils\Mock\MockSuperUser;
 use SMW\Tests\Utils\Mock\MockTitle;
 
 /**
- * @covers \SMW\MediaWiki\Hooks\TitleMoveComplete
+ * @covers \SMW\MediaWiki\Hooks\PageMoveComplete
  * @group semantic-mediawiki
  *
  * @license GNU GPL v2+
@@ -16,7 +16,7 @@ use SMW\Tests\Utils\Mock\MockTitle;
  *
  * @author mwjames
  */
-class TitleMoveCompleteTest extends \PHPUnit_Framework_TestCase {
+class PageMoveCompleteTest extends \PHPUnit_Framework_TestCase {
 
 	private $user;
 	private $testEnvironment;
@@ -56,8 +56,8 @@ class TitleMoveCompleteTest extends \PHPUnit_Framework_TestCase {
 	public function testCanConstruct() {
 
 		$this->assertInstanceOf(
-			TitleMoveComplete::class,
-			new TitleMoveComplete( $this->namespaceExaminer )
+			PageMoveComplete::class,
+			new PageMoveComplete( $this->namespaceExaminer )
 		);
 	}
 
@@ -83,7 +83,7 @@ class TitleMoveCompleteTest extends \PHPUnit_Framework_TestCase {
 
 		$this->testEnvironment->registerObject( 'Store', $store );
 
-		$instance = new TitleMoveComplete(
+		$instance = new PageMoveComplete(
 			$this->namespaceExaminer
 		);
 
@@ -119,7 +119,7 @@ class TitleMoveCompleteTest extends \PHPUnit_Framework_TestCase {
 
 		$this->testEnvironment->registerObject( 'Store', $store );
 
-		$instance = new TitleMoveComplete(
+		$instance = new PageMoveComplete(
 			$this->namespaceExaminer
 		);
 

--- a/tests/phpunit/Unit/MediaWiki/Hooks/ParserAfterTidyTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Hooks/ParserAfterTidyTest.php
@@ -446,7 +446,7 @@ class ParserAfterTidyTest extends \PHPUnit_Framework_TestCase {
 		$store->expects( $this->atLeastOnce() )
 			->method( 'updateData' );
 
-		$revision = $this->getMockBuilder( '\Revision' )
+		$revision = $this->getMockBuilder( '\MediaWiki\Revision\RevisionRecord' )
 			->disableOriginalConstructor()
 			->getMock();
 

--- a/tests/phpunit/Unit/MediaWiki/Hooks/RevisionFromEditCompleteTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Hooks/RevisionFromEditCompleteTest.php
@@ -2,11 +2,11 @@
 
 namespace SMW\Tests\MediaWiki\Hooks;
 
-use SMW\MediaWiki\Hooks\NewRevisionFromEditComplete;
+use SMW\MediaWiki\Hooks\RevisionFromEditComplete;
 use SMW\Tests\TestEnvironment;
 
 /**
- * @covers \SMW\MediaWiki\Hooks\NewRevisionFromEditComplete
+ * @covers \SMW\MediaWiki\Hooks\RevisionFromEditComplete
  * @group semantic-mediawiki
  *
  * @license GNU GPL v2+
@@ -14,7 +14,7 @@ use SMW\Tests\TestEnvironment;
  *
  * @author mwjames
  */
-class NewRevisionFromEditCompleteTest extends \PHPUnit_Framework_TestCase {
+class RevisionFromEditCompleteTest extends \PHPUnit_Framework_TestCase {
 
 	private $semanticDataValidator;
 	private $testEnvironment;
@@ -81,8 +81,8 @@ class NewRevisionFromEditCompleteTest extends \PHPUnit_Framework_TestCase {
 			->getMock();
 
 		$this->assertInstanceOf(
-			NewRevisionFromEditComplete::class,
-			new NewRevisionFromEditComplete( $this->editInfo, $pageInfoProvider, $this->propertyAnnotatorFactory, $this->schemaFactory )
+			RevisionFromEditComplete::class,
+			new RevisionFromEditComplete( $this->editInfo, $pageInfoProvider, $this->propertyAnnotatorFactory, $this->schemaFactory )
 		);
 	}
 
@@ -106,7 +106,7 @@ class NewRevisionFromEditCompleteTest extends \PHPUnit_Framework_TestCase {
 		$this->eventDispatcher->expects( $this->never() )
 			->method( 'dispatch' );
 
-		$instance = new NewRevisionFromEditComplete(
+		$instance = new RevisionFromEditComplete(
 			$this->editInfo,
 			$pageInfoProvider,
 			$this->propertyAnnotatorFactory,
@@ -155,7 +155,7 @@ class NewRevisionFromEditCompleteTest extends \PHPUnit_Framework_TestCase {
 				[ $this->equalTo( 'InvalidateResultCache' ) ],
 				[ $this->equalTo( 'InvalidateEntityCache' ) ] );
 
-		$instance = new NewRevisionFromEditComplete(
+		$instance = new RevisionFromEditComplete(
 			$this->editInfo,
 			$pageInfoProvider,
 			$this->propertyAnnotatorFactory,
@@ -205,7 +205,7 @@ class NewRevisionFromEditCompleteTest extends \PHPUnit_Framework_TestCase {
 				[ $this->equalTo( 'InvalidateResultCache' ) ],
 				[ $this->equalTo( 'InvalidateEntityCache' ) ] );
 
-		$instance = new NewRevisionFromEditComplete(
+		$instance = new RevisionFromEditComplete(
 			$this->editInfo,
 			$pageInfoProvider,
 			$this->propertyAnnotatorFactory,
@@ -263,7 +263,7 @@ class NewRevisionFromEditCompleteTest extends \PHPUnit_Framework_TestCase {
 				[ $this->equalTo( 'InvalidateResultCache' ) ],
 				[ $this->equalTo( 'InvalidateEntityCache' ) ] );
 
-		$instance = new NewRevisionFromEditComplete(
+		$instance = new RevisionFromEditComplete(
 			$this->editInfo,
 			$pageInfoProvider,
 			$this->propertyAnnotatorFactory,

--- a/tests/phpunit/Unit/MediaWiki/HooksTest.php
+++ b/tests/phpunit/Unit/MediaWiki/HooksTest.php
@@ -222,9 +222,9 @@ class HooksTest extends \PHPUnit_Framework_TestCase {
 		self::$handlers[] = call_user_func_array( [ $this, $method ], [ $instance ] );
 	}
 
-    /**
-     * @depends testRegister
-     */
+	/**
+	 * @depends testRegister
+	 */
 	public function testCheckOnMissingHandlers() {
 
 		$disabled = [
@@ -273,8 +273,8 @@ class HooksTest extends \PHPUnit_Framework_TestCase {
 			[ 'callSpecialSearchProfiles' ],
 			[ 'callSpecialSearchProfileForm' ],
 			[ 'callInternalParseBeforeLinks' ],
-			[ 'callNewRevisionFromEditComplete' ],
-			[ 'callTitleMoveComplete' ],
+			[ 'callRevisionFromEditComplete' ],
+			[ 'callPageMoveComplete' ],
 			[ 'callArticleProtectComplete' ],
 			[ 'callArticleViewHeader' ],
 			[ 'callArticlePurge' ],
@@ -615,9 +615,9 @@ class HooksTest extends \PHPUnit_Framework_TestCase {
 		return $handler;
 	}
 
-	public function callNewRevisionFromEditComplete( $instance ) {
+	public function callRevisionFromEditComplete( $instance ) {
 
-		$handler = 'NewRevisionFromEditComplete';
+		$handler = 'RevisionFromEditComplete';
 
 		$contentHandler = $this->getMockBuilder( '\ContentHandler' )
 			->disableOriginalConstructor()
@@ -643,7 +643,7 @@ class HooksTest extends \PHPUnit_Framework_TestCase {
 			->method( 'getTitle' )
 			->will( $this->returnValue( $title ) );
 
-		$revision = $this->getMockBuilder( '\Revision' )
+		$revision = $this->getMockBuilder( '\MediaWiki\Revision\RevisionRecord' )
 			->disableOriginalConstructor()
 			->getMock();
 
@@ -661,17 +661,19 @@ class HooksTest extends \PHPUnit_Framework_TestCase {
 			$instance->isRegistered( $handler )
 		);
 
+		$tags = [];
+
 		$this->assertThatHookIsExcutable(
 			$instance->getHandlerFor( $handler ),
-			[ $wikiPage, $revision, $baseId, $user ]
+			[ $wikiPage, $revision, $baseId, $user, &$tags ]
 		);
 
 		return $handler;
 	}
 
-	public function callTitleMoveComplete( $instance ) {
+	public function callPageMoveComplete( $instance ) {
 
-		$handler = 'TitleMoveComplete';
+		$handler = 'PageMoveComplete';
 
 		$store = $this->getMockBuilder( '\SMW\SQLStore\SQLStore' )
 			->disableOriginalConstructor()
@@ -736,7 +738,7 @@ class HooksTest extends \PHPUnit_Framework_TestCase {
 			->method( 'getContentHandler' )
 			->will( $this->returnValue( $contentHandler ) );
 
-		$revision = $this->getMockBuilder( '\Revision' )
+		$revision = $this->getMockBuilder( '\MediaWiki\Revision\RevisionRecord' )
 			->disableOriginalConstructor()
 			->getMock();
 

--- a/tests/phpunit/Unit/MediaWiki/MwCollaboratorFactoryTest.php
+++ b/tests/phpunit/Unit/MediaWiki/MwCollaboratorFactoryTest.php
@@ -215,7 +215,7 @@ class MwCollaboratorFactoryTest extends \PHPUnit_Framework_TestCase {
 			->disableOriginalConstructor()
 			->getMock();
 
-		$revision = $this->getMockBuilder( '\Revision' )
+		$revision = $this->getMockBuilder( '\MediaWiki\Revision\RevisionRecord' )
 			->disableOriginalConstructor()
 			->getMock();
 

--- a/tests/phpunit/Unit/MediaWiki/PageInfoProviderTest.php
+++ b/tests/phpunit/Unit/MediaWiki/PageInfoProviderTest.php
@@ -43,7 +43,7 @@ class PageInfoProviderTest extends \PHPUnit_Framework_TestCase {
 
 	public function testWikiPage_TYPE_CREATION_DATE() {
 
-		$revision = $this->getMockBuilder( '\Revision' )
+		$revision = $this->getMockBuilder( '\MediaWiki\Revision\RevisionRecord' )
 			->disableOriginalConstructor()
 			->getMock();
 
@@ -89,7 +89,7 @@ class PageInfoProviderTest extends \PHPUnit_Framework_TestCase {
 	 */
 	public function testWikiPage_TYPE_NEW_PAGE( $parentId, $expected ) {
 
-		$revision = $this->getMockBuilder( '\Revision' )
+		$revision = $this->getMockBuilder( '\MediaWiki\Revision\RevisionRecord' )
 			->disableOriginalConstructor()
 			->getMock();
 
@@ -161,7 +161,7 @@ class PageInfoProviderTest extends \PHPUnit_Framework_TestCase {
 				->will( $this->returnValue( $returnValue ) );
 		}
 
-		$revision = $this->getMockBuilder( '\Revision' )
+		$revision = $this->getMockBuilder( '\MediaWiki\Revision\RevisionRecord' )
 			->disableOriginalConstructor()
 			->getMock();
 

--- a/tests/phpunit/Unit/MediaWiki/RevisionGuardTest.php
+++ b/tests/phpunit/Unit/MediaWiki/RevisionGuardTest.php
@@ -110,7 +110,7 @@ class RevisionGuardTest extends \PHPUnit_Framework_TestCase {
 			->disableOriginalConstructor()
 			->getMock();
 
-		$revisionLookup = $this->getMockBuilder( '\MediaWiki\Storage\RevisionLookup' )
+		$revisionLookup = $this->getMockBuilder( '\MediaWiki\Revision\RevisionLookup' )
 			->disableOriginalConstructor()
 			->getMock();
 
@@ -135,7 +135,7 @@ class RevisionGuardTest extends \PHPUnit_Framework_TestCase {
 			->disableOriginalConstructor()
 			->getMock();
 
-		$revision = $this->getMockBuilder( '\Revision' )
+		$revision = $this->getMockBuilder( '\MediaWiki\Revision\RevisionRecord' )
 			->disableOriginalConstructor()
 			->getMock();
 
@@ -146,7 +146,7 @@ class RevisionGuardTest extends \PHPUnit_Framework_TestCase {
 		);
 
 		$this->assertInstanceOf(
-			'\Revision',
+			'\MediaWiki\Revision\RevisionRecord',
 			$instance->getRevision( $title, $revision )
 		);
 	}

--- a/tests/phpunit/Unit/Protection/ProtectionValidatorTest.php
+++ b/tests/phpunit/Unit/Protection/ProtectionValidatorTest.php
@@ -333,10 +333,11 @@ class ProtectionValidatorTest extends \PHPUnit_Framework_TestCase {
 
 	public function testIsClassifiedAsImportPerformerProtected_CreatorAndCurrentUserDontMatch() {
 
-		$revision = $this->getMockBuilder( '\Revision' )
+		$revision = $this->getMockBuilder( '\MediaWiki\Revision\RevisionRecord' )
 			->disableOriginalConstructor()
 			->getMock();
 
+		# TODO 1.35 adapt to code in WikiPage::factory()->getCreator
 		$revision->expects( $this->any() )
 			->method( 'getUserText' )
 			->will( $this->returnValue( 'FooImporter' ) );
@@ -378,10 +379,11 @@ class ProtectionValidatorTest extends \PHPUnit_Framework_TestCase {
 
 	public function testIsClassifiedAsNotImportPerformerProtected_CreatorAndCurrentUserDoMatch() {
 
-		$revision = $this->getMockBuilder( '\Revision' )
+		$revision = $this->getMockBuilder( '\MediaWiki\Revision\RevisionRecord' )
 			->disableOriginalConstructor()
 			->getMock();
 
+		# TODO 1.35 adapt to code in WikiPage::factory()->getCreator
 		$revision->expects( $this->any() )
 			->method( 'getUserText' )
 			->will( $this->returnValue( 'FooImporter' ) );

--- a/tests/phpunit/Unit/Serializers/QueryResultSerializerTest.php
+++ b/tests/phpunit/Unit/Serializers/QueryResultSerializerTest.php
@@ -202,7 +202,7 @@ class QueryResultSerializerTest extends \PHPUnit_Framework_TestCase {
 		$provider[] = [
 			[
 				'queryResult' => $this->buildMockQueryResult( $setup )
-				],
+			],
 			[
 				'printrequests' => [
 					[ 'label' => 'Foo-1', 'typeid' => '_num', 'mode' => 2, 'format' => false, 'key' => '', 'redi' => '' ],
@@ -237,7 +237,9 @@ class QueryResultSerializerTest extends \PHPUnit_Framework_TestCase {
 			] );
 
 			$printRequests[] = $printRequest;
-			$getResults[] = \SMW\DIWikiPage::newFromTitle( new \Title( NS_MAIN, $value['printRequest'] ) );
+			# TODO: Should be the following line, but the environment of the test should be adapted
+			# $getResults[] = \SMW\DIWikiPage::newFromTitle( \Title::makeTitle( NS_MAIN, $value['printRequest'] ) );
+			$getResults[] = \SMW\DIWikiPage::newFromTitle( \Title::makeTitle( NS_MAIN, '' ) );
 
 			$dataItem = $this->newMockBuilder()->newObject( 'DataItem', [
 				'getDIType' => DataItem::TYPE_NUMBER,

--- a/tests/phpunit/Utils/ByPageSemanticDataFinder.php
+++ b/tests/phpunit/Utils/ByPageSemanticDataFinder.php
@@ -110,11 +110,13 @@ class ByPageSemanticDataFinder {
 		$revision = $revisionGuard->newRevisionFromPage( $wikiPage );
 
 		if ( $revision === null ) {
-			throw new UnexpectedValueException( 'Expected a valid Revision' );
+			throw new UnexpectedValueException( 'Expected a valid MediaWiki\Revision\RevisionRecord' );
 		}
 
+		$identity = $revision->getUser();
+		$user = $identity ? User::newFromIdentity( $identity ) : null;
 		$parserOutput = $wikiPage->getParserOutput(
-			$wikiPage->makeParserOptions( User::newFromId( $revision->getUser() ) ),
+			$wikiPage->makeParserOptions( $user ),
 			$revision->getId()
 		);
 

--- a/tests/phpunit/Utils/Mock/MediaWikiMockObjectRepository.php
+++ b/tests/phpunit/Utils/Mock/MediaWikiMockObjectRepository.php
@@ -154,11 +154,11 @@ class MediaWikiMockObjectRepository extends \PHPUnit_Framework_TestCase implemen
 	/**
 	 * @since 1.9
 	 *
-	 * @return Revision
+	 * @return \MediaWiki\Revision\RevisionRecord
 	 */
-	public function Revision() {
+	public function RevisionRecord() {
 
-		$revision = $this->getMockBuilder( 'Revision' )
+		$revision = $this->getMockBuilder( '\MediaWiki\Revision\RevisionRecord' )
 			->disableOriginalConstructor()
 			->getMock();
 

--- a/tests/phpunit/Utils/Mock/MockSuperUser.php
+++ b/tests/phpunit/Utils/Mock/MockSuperUser.php
@@ -25,15 +25,22 @@ use User;
  * @codeCoverageIgnore
  */
 class MockSuperUser extends User {
-	public function getId() {
+	# The signature is "getId()" in MW 1.35-
+	# and "getId( $wikiId = self::LOCAL ) : int" in MW 1.36
+	# TODO: when SMW will only support MW 1.36+, the new signature can be fixed
+	public function getId( $wikiId = false ) : int {
 		return 666;
 	}
 
-	public function getName() {
+	public function getName() : string {
 		return 'SuperUser';
 	}
 
-	public function isAllowed( $right = '' ) {
+	# The signature is "isAllowed( $action = '' )" in MW 1.35-
+	# and "isAllowed( string $permission ) : bool" in MW 1.36
+	# The following signature does not emit warnings in any cases
+	# TODO: when SMW will only support MW 1.36+, the new signature can be fixed
+	public function isAllowed( $permission = '' ) : bool {
 		return true;
 	}
 }

--- a/tests/phpunit/Utils/Page/PageEditor.php
+++ b/tests/phpunit/Utils/Page/PageEditor.php
@@ -2,7 +2,6 @@
 
 namespace SMW\Tests\Utils\Page;
 
-use Revision;
 use RuntimeException;
 use Title;
 use WikiPage;

--- a/tests/phpunit/Utils/PageCreator.php
+++ b/tests/phpunit/Utils/PageCreator.php
@@ -2,7 +2,6 @@
 
 namespace SMW\Tests\Utils;
 
-use Revision;
 use SMW\Tests\TestEnvironment;
 use SMW\Tests\Utils\Mock\MockSuperUser;
 use Title;

--- a/tests/phpunit/Utils/PageReader.php
+++ b/tests/phpunit/Utils/PageReader.php
@@ -2,7 +2,6 @@
 
 namespace SMW\Tests\Utils;
 
-use Revision;
 use TextContent;
 use Title;
 use UnexpectedValueException;

--- a/tests/phpunit/includes/ContentParserTest.php
+++ b/tests/phpunit/includes/ContentParserTest.php
@@ -95,7 +95,7 @@ class ContentParserTest extends \PHPUnit_Framework_TestCase {
 			->method( 'getParserOutput' )
 			->will( $this->returnValue( $this->parserOutput ) );
 
-		$revision = $this->getMockBuilder( '\Revision' )
+		$revision = $this->getMockBuilder( '\MediaWiki\Revision\RevisionRecord' )
 			->disableOriginalConstructor()
 			->getMock();
 


### PR DESCRIPTION
This is a breaking change to follow Multi-Content Revisions from MediaWiki (i.e. a revision has multiple “slots”, each one is a content).

The previous Revision is replaced by MediaWiki\Revision\RevisionRecord, which is mostly similar (although not a subclass) except there are no static methods (newFromId, getTimestampFromId) and it must be specified in the method getContent the requested slot (MAIN, at least for now).

SMW has an almost-central management of revisions with RevisionGuard.

An upstream MediaWiki hook is replaced: NewRevisionFromEditComplete → RevisionFromEditComplete

A downstream Semantic MediaWiki hook has a modified signature: SMW::RevisionGuard::ChangeRevision( Title, ?RevisionRecord& )

Issue: #4944
Issue: #4941

---

**DRAFT - do not merge!**

> This first draft pull request replaced most of the deprecated class `Revision` and it seems to work with some smoke tests, but it remains details to be checked.

TODO from easiest to most difficult:
- [x] mock RevisionRecord: the two methods `getSize` and `getSha1` must be mocked else the class remains abstract, see Travis
- [ ] mock in ProtectionValidatorTest to fix the warnings?
- [ ] it seems there are issues in deleting the pages from the previous test case in `InterwikiDBIntegrationTest`, fix it
- [ ] `getContentHandler`: check/change the call to this method 
- [ ] `Revision::newFromId`: check/change the replacements - should it use RevisionGuard?
- [ ] should it be kept the `LogicException` added in RevisionGuard, or a fallback to the global `MediaWikiServices::getInstance()->getRevisionLookup()->getRevisionByTitle(…)`?
- [ ] `getTimestampFromId`: check/change the call to this method: the change in this commit is only to avoid the warning, but it should be assert if this use of RevisionStore (the only occurence in SMW) is the right way to do (see also #4714)
- [ ] use of downstream hook `SMW::RevisionGuard::ChangeRevision`: should a new hook be created or do we change signature of this existing one? - I only found SemanticApprovedRevs as public user of this hook in SMW + Gerrit repos
- [ ] keep the two old hooks? (depends on compatibility pre-1.35)