### PR TITLE
CachedFactbox: Avoid master DB connection on read requests

### DIFF
--- a/src/Factbox/CachedFactbox.php
+++ b/src/Factbox/CachedFactbox.php
@@ -10,7 +10,6 @@ use SMW\Parser\InTextAnnotationParser;
 use Title;
 use Psr\Log\LoggerAwareTrait;
 use SMW\Utils\HmacSerializer;
-use SMW\MediaWiki\RevisionGuardAwareTrait;
 
 /**
  * Factbox output caching
@@ -26,7 +25,6 @@ use SMW\MediaWiki\RevisionGuardAwareTrait;
 class CachedFactbox {
 
 	use LoggerAwareTrait;
-	use RevisionGuardAwareTrait;
 
 	/**
 	 * @var EntityCache
@@ -192,7 +190,7 @@ class CachedFactbox {
 		$outputPage->addModules( Factbox::getModules() );
 		$title = $outputPage->getTitle();
 
-		$rev_id = $this->findRevId( $title, $request );
+		$rev_id = $outputPage->getRevisionId();
 		$lang = $context->getLanguage()->getCode();
 		$content = '';
 
@@ -288,9 +286,7 @@ class CachedFactbox {
 			$context = $outputPage->getContext();
 			$lang = $context->getLanguage()->getCode();
 
-			$rev_id = $this->findRevId(
-				$title, $context->getRequest()
-			);
+			$rev_id = $outputPage->getRevisionId();
 
 			$sub = $this->makeSubCacheKey( $rev_id, $lang, $this->featureSet );
 
@@ -309,23 +305,6 @@ class CachedFactbox {
 		}
 
 		return $text;
-	}
-
-	/**
-	 * Return a revisionId either from the WebRequest object (display an old
-	 * revision or permalink etc.) or from the title object
-	 */
-	private function findRevId( Title $title, $request ) {
-
-		if ( $request->getInt( 'diff' ) > 0 ) {
-			return $request->getInt( 'diff' );
-		}
-
-		if ( $request->getInt( 'oldid' ) > 0 ) {
-			return $request->getInt( 'oldid' );
-		}
-
-		return $this->revisionGuard->getLatestRevID( $title );
 	}
 
 	/**

--- a/src/Factbox/FactboxFactory.php
+++ b/src/Factbox/FactboxFactory.php
@@ -64,10 +64,6 @@ class FactboxFactory {
 			$applicationFactory->getMediaWikiLogger()
 		);
 
-		$cachedFactbox->setRevisionGuard(
-			$applicationFactory->singleton( 'RevisionGuard' )
-		);
-
 		return $cachedFactbox;
 	}
 

--- a/tests/phpunit/Unit/Factbox/CachedFactboxTest.php
+++ b/tests/phpunit/Unit/Factbox/CachedFactboxTest.php
@@ -29,7 +29,6 @@ class CachedFactboxTest extends \PHPUnit_Framework_TestCase {
 
 	private $testEnvironment;
 	private $memoryCache;
-	private $revisionGuard;
 	private $entityCache;
 	private $spyLogger;
 
@@ -47,10 +46,6 @@ class CachedFactboxTest extends \PHPUnit_Framework_TestCase {
 		);
 
 		$this->spyLogger = $this->testEnvironment->newSpyLogger();
-
-		$this->revisionGuard = $this->getMockBuilder( '\SMW\MediaWiki\RevisionGuard' )
-			->disableOriginalConstructor()
-			->getMock();
 
 		$this->entityCache = $this->getMockBuilder( '\SMW\EntityCache' )
 			->disableOriginalConstructor()
@@ -82,16 +77,6 @@ class CachedFactboxTest extends \PHPUnit_Framework_TestCase {
 			->method( 'fetch' )
 			->will( $this->returnValue( false ) );
 
-		$this->revisionGuard->expects( $this->any() )
-			->method( 'getLatestRevID' )
-			->will( $this->returnValue( 10001 ) );
-
-		$this->revisionGuard->expects( $this->any() )
-			->method( 'newRevisionFromTitle' )
-			->will( $this->returnValue( null ) );
-
-		$this->testEnvironment->registerObject( 'RevisionGuard', $this->revisionGuard );
-
 		$this->testEnvironment->addConfiguration(
 			'smwgNamespacesWithSemanticLinks',
 			$parameters['smwgNamespacesWithSemanticLinks']
@@ -108,10 +93,6 @@ class CachedFactboxTest extends \PHPUnit_Framework_TestCase {
 
 		$instance = new CachedFactbox(
 			new EntityCache( $this->memoryCache )
-		);
-
-		$instance->setRevisionGuard(
-			$this->revisionGuard
 		);
 
 		$instance->isEnabled( true );
@@ -288,6 +269,10 @@ class CachedFactboxTest extends \PHPUnit_Framework_TestCase {
 			->method( 'getContext' )
 			->will( $this->returnValue( new \RequestContext() ) );
 
+		$outputPage->expects( $this->atLeastOnce() )
+			->method( 'getRevisionId' )
+			->will( $this->returnValue( 10001 ) );
+
 		$provider[] = [
 			[
 				'smwgNamespacesWithSemanticLinks' => [ NS_MAIN => true ],
@@ -332,6 +317,10 @@ class CachedFactboxTest extends \PHPUnit_Framework_TestCase {
 		$outputPage->expects( $this->atLeastOnce() )
 			->method( 'getTitle' )
 			->will( $this->returnValue( $title ) );
+
+		$outputPage->expects( $this->atLeastOnce() )
+			->method( 'getRevisionId' )
+			->will( $this->returnValue( 9001 ) );
 
 		$context = new \RequestContext( );
 		$context->setRequest( new \FauxRequest( [ 'oldid' => 9001 ], true ) );
@@ -428,6 +417,10 @@ class CachedFactboxTest extends \PHPUnit_Framework_TestCase {
 		$outputPage->expects( $this->atLeastOnce() )
 			->method( 'getContext' )
 			->will( $this->returnValue( new \RequestContext() ) );
+
+		$outputPage->expects( $this->atLeastOnce() )
+			->method( 'getRevisionId' )
+			->will( $this->returnValue( 10004 ) );
 
 		$semanticData = $this->getMockBuilder( '\SMW\SemanticData' )
 			->disableOriginalConstructor()

--- a/tests/phpunit/Unit/MediaWiki/Hooks/OutputPageParserOutputTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Hooks/OutputPageParserOutputTest.php
@@ -80,17 +80,6 @@ class OutputPageParserOutputTest extends \PHPUnit_Framework_TestCase {
 	 * @dataProvider outputDataProvider
 	 */
 	public function testProcess( $parameters, $expected ) {
-
-		$revisionGuard = $this->getMockBuilder( '\SMW\MediaWiki\RevisionGuard' )
-			->disableOriginalConstructor()
-			->getMock();
-
-		$revisionGuard->expects( $this->any() )
-			->method( 'newRevisionFromTitle' )
-			->will( $this->returnValue( $revisionGuard ) );
-
-		$this->testEnvironment->registerObject( 'RevisionGuard', $revisionGuard );
-
 		$this->namespaceExaminer->expects( $this->any() )
 			->method( 'isSemanticEnabled' )
 			->will( $this->returnValue( $parameters['smwgNamespacesWithSemanticLinks'] ) );
@@ -116,10 +105,6 @@ class OutputPageParserOutputTest extends \PHPUnit_Framework_TestCase {
 		);
 
 		$cachedFactbox = $this->applicationFactory->create( 'FactboxFactory' )->newCachedFactbox();
-
-		$cachedFactbox->setRevisionGuard(
-			$revisionGuard
-		);
 
 		$factboxFactory = $this->getMockBuilder( '\SMW\Factbox\FactboxFactory' )
 			->disableOriginalConstructor()

--- a/tests/phpunit/Unit/MediaWiki/Hooks/SkinAfterContentTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Hooks/SkinAfterContentTest.php
@@ -69,11 +69,6 @@ class SkinAfterContentTest extends \PHPUnit_Framework_TestCase {
 	 * @dataProvider outputDataProvider
 	 */
 	public function testperformUpdateFactboxPresenterIntegration( $parameters, $expected ) {
-
-		$revisionGuard = $this->getMockBuilder( '\SMW\MediaWiki\RevisionGuard' )
-			->disableOriginalConstructor()
-			->getMock();
-
 		$data = '';
 
 		$instance = new SkinAfterContent( $parameters['skin'] );
@@ -84,10 +79,6 @@ class SkinAfterContentTest extends \PHPUnit_Framework_TestCase {
 		if ( isset( $parameters['title'] ) ) {
 
 			$cachedFactbox = $this->applicationFactory->create( 'FactboxFactory' )->newCachedFactbox();
-
-			$cachedFactbox->setRevisionGuard(
-				$revisionGuard
-			);
 
 			$cachedFactbox->addContentToCache(
 				$cachedFactbox->makeCacheKey( $parameters['title'] ),


### PR DESCRIPTION
Currently, CachedFactbox fetches the revision ID of the current page via
RevisionGuard, which always uses the master DB, even on read requests. This
results in warnings from MediaWiki's TransactionProfiler ("Expectation
(masterConns <= 0) by MediaWiki::main not met (actual: 1)"), and can pose an
issue if the master DB is in a remote datacenter and so expensive (latency) to
access, or if it is down for maintenance or otherwise unavailable.

Instead, use OutputPage::getRevisionId to fetch the revision ID here, which
avoids this behavior.