### PR TITLE
Elastic: Replace use of depreacted _source_include

### DIFF
--- a/src/Elastic/Indexer/Attachment/FileAttachment.php
+++ b/src/Elastic/Indexer/Attachment/FileAttachment.php
@@ -120,7 +120,7 @@ class FileAttachment {
 		// Available properties
 		// @see https://www.elastic.co/guide/en/elasticsearch/plugins/master/using-ingest-attachment.html
 		$params = $params + [
-			'_source_include' => [
+			'_source_includes' => [
 				'file_sha1',
 				'attachment.date',
 				'attachment.content_type',

--- a/src/Elastic/Indexer/FileIndexer.php
+++ b/src/Elastic/Indexer/FileIndexer.php
@@ -245,7 +245,7 @@ class FileIndexer {
 		// Do we have any existing data? The ingest pipeline will override the
 		// entire document, so rescue any data before starting the ingest.
 		if ( $connection->exists( $params ) ) {
-			$doc = $connection->get( $params + [ '_source_include' => [ 'file_sha1', 'subject', 'text_raw', 'text_copy', 'P*' ] ] );
+			$doc = $connection->get( $params + [ '_source_includes' => [ 'file_sha1', 'subject', 'text_raw', 'text_copy', 'P*' ] ] );
 		}
 
 		// Is the sha1 the same? Don't do anything since the content is expected

--- a/src/Elastic/Indexer/Replication/ReplicationStatus.php
+++ b/src/Elastic/Indexer/Replication/ReplicationStatus.php
@@ -98,7 +98,7 @@ class ReplicationStatus {
 		$pid = $this->fieldMapper->getPID( \SMW\SQLStore\EntityStore\EntityIdManager::$special_ids['_MDAT'] );
 		$field = $this->fieldMapper->getField( new DIProperty( '_MDAT' ) );
 
-		$doc = $this->connection->get( $params + [ '_source_include' => [ "$pid.$field", "subject.rev_id" ] ] );
+		$doc = $this->connection->get( $params + [ '_source_includes' => [ "$pid.$field", "subject.rev_id" ] ] );
 
 		if ( isset( $doc['_source'][$pid][$field] ) ) {
 			$date = end( $doc['_source'][$pid][$field] );
@@ -139,7 +139,7 @@ class ReplicationStatus {
 		$pid = $this->fieldMapper->getPID( \SMW\SQLStore\EntityStore\EntityIdManager::$special_ids['_MDAT'] );
 		$field = $this->fieldMapper->getField( new DIProperty( '_MDAT' ) );
 
-		$doc = $this->connection->get( $params + [ '_source_include' => [ "$pid.$field" ] ] );
+		$doc = $this->connection->get( $params + [ '_source_includes' => [ "$pid.$field" ] ] );
 
 		if ( !isset( $doc['_source'][$pid][$field] ) ) {
 			return false;
@@ -173,7 +173,7 @@ class ReplicationStatus {
 			return 0;
 		}
 
-		$doc = $this->connection->get( $params + [ '_source_include' => [ "subject.rev_id" ] ] );
+		$doc = $this->connection->get( $params + [ '_source_includes' => [ "subject.rev_id" ] ] );
 
 		if ( !isset( $doc['_source']['subject']['rev_id'] ) ) {
 			return 0;

--- a/tests/phpunit/Unit/Elastic/Indexer/Replication/ReplicationStatusTest.php
+++ b/tests/phpunit/Unit/Elastic/Indexer/Replication/ReplicationStatusTest.php
@@ -142,7 +142,7 @@ class ReplicationStatusTest extends \PHPUnit_Framework_TestCase {
 			'index' => 'FOO',
 			'type' => 'data',
 			'id' => 42,
-			'_source_include' => [ 'subject.rev_id' ]
+			'_source_includes' => [ 'subject.rev_id' ]
 		];
 
 		$this->connection->expects( $this->once() )
@@ -214,7 +214,7 @@ class ReplicationStatusTest extends \PHPUnit_Framework_TestCase {
 			'index' => 'FOO',
 			'type' => 'data',
 			'id' => 42,
-			'_source_include' => [ 'subject.rev_id' ]
+			'_source_includes' => [ 'subject.rev_id' ]
 		];
 
 		$this->connection->expects( $this->once() )
@@ -257,7 +257,7 @@ class ReplicationStatusTest extends \PHPUnit_Framework_TestCase {
 			'index' => 'FOO',
 			'type' => 'data',
 			'id' => 42,
-			'_source_include' => [ 'P:29.datField', 'subject.rev_id' ]
+			'_source_includes' => [ 'P:29.datField', 'subject.rev_id' ]
 		];
 
 		$this->connection->expects( $this->once() )


### PR DESCRIPTION
**This PR may breaks older ES release**
====

It's breaking change introduced on ES 6.6 announcement.
Deprecated since ElasticSearch 6.6 and plan to drop support in 7.0


https://www.elastic.co/guide/en/elasticsearch/reference/6.8/breaking-changes-6.6.html#_deprecate_literal__source_exclude_literal_and_literal__source_include_literal_url_parameters

closes #4975

PS. Travis Errored on some cases during running `./tests/travis/install-services.sh` which not related this PR at all.