### PR TITLE
Use the services factory to create a parser object

### DIFF
--- a/src/Parser/RecursiveTextProcessor.php
+++ b/src/Parser/RecursiveTextProcessor.php
@@ -5,6 +5,7 @@ namespace SMW\Parser;
 use Parser;
 use ParserOptions;
 use RuntimeException;
+use SMW\ApplicationFactory;
 use SMW\Localizer;
 use SMW\ParserData;
 use SMW\MediaWiki\Template\TemplateExpander;
@@ -71,7 +72,7 @@ class RecursiveTextProcessor {
 		$this->parser = $parser;
 
 		if ( $this->parser === null ) {
-			$this->parser = $GLOBALS['wgParser'];
+			$this->parser = ApplicationFactory::getInstance()->create( 'Parser' );
 		}
 	}
 

--- a/src/Query/ResultPrinters/FeedExportPrinter.php
+++ b/src/Query/ResultPrinters/FeedExportPrinter.php
@@ -5,6 +5,7 @@ namespace SMW\Query\ResultPrinters;
 use FeedItem;
 use ParserOptions;
 use Sanitizer;
+use SMW\ApplicationFactory;
 use SMW\DataValueFactory;
 use SMW\DIWikiPage;
 use SMW\Query\ExportPrinter;
@@ -434,7 +435,8 @@ final class FeedExportPrinter extends ResultPrinter implements ExportPrinter {
 			$parserOptions->setEditSection( false );
 		}
 
-		return $GLOBALS['wgParser']->parse( $text, $title, $parserOptions )->getText( [ 'enableSectionEditLinks' => false ] );
+		$parser = ApplicationFactory::getInstance()->create( 'Parser' );
+		return $parser->parse( $text, $title, $parserOptions )->getText( [ 'enableSectionEditLinks' => false ] );
 	}
 
 	private function getFeedLink( QueryResult $res, $outputMode ) {

--- a/src/Query/ResultPrinters/ResultPrinter.php
+++ b/src/Query/ResultPrinters/ResultPrinter.php
@@ -224,8 +224,6 @@ abstract class ResultPrinter implements IResultPrinter {
 	 */
 	public function copyParser() {
 
-		// Should not happen, used as fallback which in case the parser state
-		// relies on the $GLOBALS['wgParser']
 		if ( $this->recursiveTextProcessor === null ) {
 			$this->recursiveTextProcessor = new RecursiveTextProcessor();
 		}
@@ -363,8 +361,6 @@ abstract class ResultPrinter implements IResultPrinter {
 		// append errors
 		$result .= $this->getErrorString( $results );
 
-		// Should not happen, used as fallback which in case the parser state
-		// relies on the $GLOBALS['wgParser']
 		if ( $this->recursiveTextProcessor === null ) {
 			$this->recursiveTextProcessor = new RecursiveTextProcessor();
 		}

--- a/tests/phpunit/Integration/Parser/InTextAnnotationParserTemplateTransclusionTest.php
+++ b/tests/phpunit/Integration/Parser/InTextAnnotationParserTemplateTransclusionTest.php
@@ -55,7 +55,7 @@ class InTextAnnotationParserTemplateTransclusionTest extends \PHPUnit_Framework_
 	 */
 	private function runTemplateTransclusion( Title $title, $text, $return ) {
 
-		$parser  = new \Parser;
+		$parser  = $this->applicationFactory->create( 'Parser' );
 		$options = new \ParserOptions;
 		$options->setTemplateCallback( function ( $title, $parser = false ) use ( $return ) {
 


### PR DESCRIPTION
Direct uses of global $wgParser is deprecated in MW 1.35. This removes the three last occurrences of it.

It is backward-compatible thanks to the services factory. It could be deleted the 1.34- compatibility by removing the line in /src/Services/mediawiki.php, but I think it should be done in a commit which clearly removes this compatibility (extension.json, CI).

Fixes: #4940
Fixes: #4945