### PR TITLE
Use replica DBs for high-volume queries, refs #4989

### DIFF
--- a/src/SQLStore/EntityStore/SemanticDataLookup.php
+++ b/src/SQLStore/EntityStore/SemanticDataLookup.php
@@ -552,7 +552,7 @@ class SemanticDataLookup {
 			$caller .= " (for " . $requestOptions->getCaller() . ")";
 		}
 
-		$res = $connection->query(
+		$res = $connection->readQuery(
 			$query,
 			$caller
 		);

--- a/tests/phpunit/Unit/SQLStore/EntityStore/SemanticDataLookupTest.php
+++ b/tests/phpunit/Unit/SQLStore/EntityStore/SemanticDataLookupTest.php
@@ -211,7 +211,7 @@ class SemanticDataLookupTest extends \PHPUnit_Framework_TestCase {
 			->will( $this->returnValue( 'Foo' ) );
 
 		$this->connection->expects( $this->once() )
-			->method( 'query' )
+			->method( 'readQuery' )
 			->will( $this->returnValue( [ $row ] ) );
 
 		$this->connection->expects( $this->any() )
@@ -275,7 +275,7 @@ class SemanticDataLookupTest extends \PHPUnit_Framework_TestCase {
 			->will( $this->returnCallback( function( $value ) { return "'$value'"; } ) );
 
 		$this->connection->expects( $this->once() )
-			->method( 'query' )
+			->method( 'readQuery' )
 			->will( $this->returnValue( [ $row ] ) );
 
 		$this->connection->expects( $this->any() )
@@ -336,7 +336,7 @@ class SemanticDataLookupTest extends \PHPUnit_Framework_TestCase {
 			->will( $this->returnCallback( function( $value ) { return "'$value'"; } ) );
 
 		$this->connection->expects( $this->once() )
-			->method( 'query' )
+			->method( 'readQuery' )
 			->will( $this->returnValue( [ $row ] ) );
 
 		$this->connection->expects( $this->any() )
@@ -388,7 +388,7 @@ class SemanticDataLookupTest extends \PHPUnit_Framework_TestCase {
 			->will( $this->returnCallback( function( $value ) { return "'$value'"; } ) );
 
 		$this->connection->expects( $this->once() )
-			->method( 'query' )
+			->method( 'readQuery' )
 			->will( $this->returnValue( [ $row ] ) );
 
 		$this->connection->expects( $this->any() )
@@ -498,7 +498,7 @@ class SemanticDataLookupTest extends \PHPUnit_Framework_TestCase {
 			->will( $this->returnCallback( function( $value ) { return "'$value'"; } ) );
 
 		$this->connection->expects( $this->once() )
-			->method( 'query' )
+			->method( 'readQuery' )
 			->will( $this->returnValue( [ $row ] ) );
 
 		$this->connection->expects( $this->any() )
@@ -570,6 +570,10 @@ class SemanticDataLookupTest extends \PHPUnit_Framework_TestCase {
 
 		$this->connection->expects( $this->atLeastOnce() )
 			->method( 'query' )
+			->will( $this->returnValue( [ $row ] ) );
+
+		$this->connection->expects( $this->atLeastOnce() )
+			->method( 'readQuery' )
 			->will( $this->returnValue( [ $row ] ) );
 
 		$this->connection->expects( $this->any() )


### PR DESCRIPTION
Introduce a new method readQuery() on SMW's Database helper class that uses a
replica DB for executing the query, and use it in
SemanticDataLookup::fetchFromTable, which is responsible for a large amount of
queries. This allows for other call sites to be gradually migrated to the new
method without breaking callers that might rely on query() using the primary DB.