### PR TITLE
Replace usage of deprecated ParserCache::getETag

### DIFF
--- a/src/MediaWiki/Hooks.php
+++ b/src/MediaWiki/Hooks.php
@@ -707,7 +707,7 @@ class Hooks {
 		$wikiPage = $page->getPage();
 
 		$dependencyValidator->setETag(
-			$parserCache->getETag( $wikiPage, $wikiPage->makeParserOptions( 'canonical' ) )
+			$this->getETag( $parserCache, $wikiPage, $wikiPage->makeParserOptions( 'canonical' ) )
 		);
 
 		$dependencyValidator->setCacheTTL(
@@ -738,6 +738,16 @@ class Hooks {
 		return true;
 	}
 
+	private function getETag( $parserCache, $page, $pOpts) {
+		if ( method_exists( $parserCache, 'makeParserOutputKey' ) ) {
+			// 1.36+
+			return 'W/"' . $parserCache->makeParserOutputKey( $page, $pOpts	) .
+				"--" . $page->getTouched() . '"';
+		} else {
+			return $parserCache->getETag( $page, $pOpts );
+		}
+	}
+
 	/**
 	 * @see https://www.mediawiki.org/wiki/Manual:Hooks/RejectParserCacheValue
 	 */
@@ -750,10 +760,7 @@ class Hooks {
 		$parserCache = $applicationFactory->create( 'ParserCache' );
 
 		$dependencyValidator = $applicationFactory->create( 'DependencyValidator' );
-
-		$dependencyValidator->setETag(
-			$parserCache->getETag( $page, $popts )
-		);
+		$dependencyValidator->setETag( $this->getETag( $parserCache, $page, $popts ) );
 
 		$dependencyValidator->setCacheTTL(
 			Site::getCacheExpireTime( 'parser' )


### PR DESCRIPTION
Caused by: https://gerrit.wikimedia.org/r/634593

Fallback taken from 1e758c750b3f0ff1ed15a786681863c544737f5f