### PR TITLE
Drop the deprecated SMWTypesValue and SMWImportValue aliases

### DIFF
--- a/includes/export/SMW_Exporter.php
+++ b/includes/export/SMW_Exporter.php
@@ -261,7 +261,7 @@ class SMWExporter {
 	 * Make an SMWExpData object for the given page, and include the basic
 	 * properties about this subject that are not directly represented by
 	 * SMW property values. The optional parameter $typevalueforproperty
-	 * can be used to pass a particular SMWTypesValue object that is used
+	 * can be used to pass a particular TypesValue object that is used
 	 * for determining the OWL type for property pages.
 	 *
 	 * @todo Take into account whether the wiki page belongs to a builtin property, and ensure URI alignment/type declaration in this case.
@@ -452,7 +452,7 @@ class SMWExporter {
 
 	/**
 	 * Determine what kind of OWL property some SMW property should be exported as.
-	 * The input is an SMWTypesValue object, a typeid string, or empty (use default)
+	 * The input is an TypesValue object, a typeid string, or empty (use default)
 	 *
 	 * @todo An improved mechanism for selecting property types here is needed.
 	 */

--- a/includes/querypages/PropertiesQueryPage.php
+++ b/includes/querypages/PropertiesQueryPage.php
@@ -4,12 +4,12 @@ namespace SMW;
 
 use Html;
 use Skin;
+use SMW\DataValues\TypesValue;
 use SMW\DataValues\ValueFormatters\DataValueFormatter;
 use SMW\Exception\PropertyNotFoundException;
 use SMW\SQLStore\Lookup\ListLookup;
 use SMWDIError;
 use SMWRequestOptions;
-use SMWTypesValue;
 use Title;
 
 /**
@@ -203,7 +203,7 @@ class PropertiesQueryPage extends QueryPage {
 		}
 
 		// User defined types default to Page
-		$typestring = SMWTypesValue::newFromTypeId( $this->settings->get( 'smwgPDefaultType' ) )->getLongHTMLText( $this->getLinker() );
+		$typestring = TypesValue::newFromTypeId( $this->settings->get( 'smwgPDefaultType' ) )->getLongHTMLText( $this->getLinker() );
 
 		$label = htmlspecialchars( $property->getLabel() );
 		$linkAttributes = [];
@@ -251,7 +251,8 @@ class PropertiesQueryPage extends QueryPage {
 		$dataValue = DataValueFactory::getInstance()->newDataValueByItem( $property, null );
 
 		$dataValue->setLinkAttributes( [
-			'title' => 'ID: ' . ( isset( $property->id ) ? $property->id : 'N/A' ) . ' (' . $property->getKey() . ')'
+			'title' => 'ID: ' . ( isset( $property->id ) ? $property->id : 'N/A' )
+					. ' (' . $property->getKey() . ')'
 		] );
 
 		$label = $dataValue->getFormattedLabel(
@@ -260,7 +261,7 @@ class PropertiesQueryPage extends QueryPage {
 		);
 
 		return [
-			SMWTypesValue::newFromTypeId( $property->findPropertyValueType() )->getLongHTMLText( $this->getLinker() ),
+			TypesValue::newFromTypeId( $property->findPropertyValueType() )->getLongHTMLText( $this->getLinker() ),
 			$label
 		];
 	}

--- a/includes/querypages/UnusedPropertiesQueryPage.php
+++ b/includes/querypages/UnusedPropertiesQueryPage.php
@@ -3,9 +3,9 @@
 namespace SMW;
 
 use Html;
+use SMW\DataValues\TypesValue;
 use SMW\Exception\PropertyNotFoundException;
 use SMWDIError;
-use SMWTypesValue;
 
 /**
  * Query page that provides content to Special:UnusedProperties
@@ -77,7 +77,10 @@ class UnusedPropertiesQueryPage extends QueryPage {
 	public function getCacheInfo() {
 
 		if ( $this->listLookup->isFromCache() ) {
-			return $this->msg( 'smw-sp-properties-cache-info', $this->getLanguage()->userTimeAndDate( $this->listLookup->getTimestamp(), $this->getUser() ) )->parse();
+			return $this->msg(
+				'smw-sp-properties-cache-info',
+				$this->getLanguage()->userTimeAndDate( $this->listLookup->getTimestamp(), $this->getUser() )
+			)->parse();
 		}
 
 		return '';
@@ -123,7 +126,9 @@ class UnusedPropertiesQueryPage extends QueryPage {
 				->getHtml();
 		}
 
-		throw new PropertyNotFoundException( 'UnusedPropertiesQueryPage expects results that are properties or errors.' );
+		throw new PropertyNotFoundException(
+			'UnusedPropertiesQueryPage expects results that are properties or errors.'
+		);
 	}
 
 	/**
@@ -155,22 +160,29 @@ class UnusedPropertiesQueryPage extends QueryPage {
 				$property->getLabel()
 			);
 
-			$types = $this->store->getPropertyValues( $property->getDiWikiPage(), new DIProperty( '_TYPE' ) );
+			$types = $this->store->getPropertyValues(
+				$property->getDiWikiPage(), new DIProperty( '_TYPE' )
+			);
 
 			if ( is_array( $types ) && count( $types ) >= 1 ) {
-				$typeDataValue = DataValueFactory::getInstance()->newDataValueByItem( current( $types ), new DIProperty( '_TYPE' ) );
+				$typeDataValue = DataValueFactory::getInstance()
+							   ->newDataValueByItem( current( $types ), new DIProperty( '_TYPE' ) );
 			} else {
-				$typeDataValue = SMWTypesValue::newFromTypeId( '_wpg' );
-				$this->getMessageFormatter()->addFromKey( 'smw_propertylackstype', $typeDataValue->getLongHTMLText() );
+				$typeDataValue = TypesValue::newFromTypeId( '_wpg' );
+				$this->getMessageFormatter()
+					 ->addFromKey( 'smw_propertylackstype', $typeDataValue->getLongHTMLText() );
 			}
 
 		} else {
-			$typeDataValue = SMWTypesValue::newFromTypeId( $property->findPropertyTypeID() );
-			$propertyLink  = DataValueFactory::getInstance()->newDataValueByItem( $property, null )->getShortHtmlText( $this->getLinker() );
+			$typeDataValue = TypesValue::newFromTypeId( $property->findPropertyTypeID() );
+			$propertyLink  = DataValueFactory::getInstance()
+						   ->newDataValueByItem( $property, null )->getShortHtmlText( $this->getLinker() );
 		}
 
-		return $this->msg( 'smw-unusedproperty-template', $propertyLink, $typeDataValue->getLongHTMLText( $this->getLinker() )	)->text() . ' ' .
-			$this->getMessageFormatter()->getHtml();
+		return $this->msg(
+			'smw-unusedproperty-template', $propertyLink,
+			$typeDataValue->getLongHTMLText( $this->getLinker() )
+		)->text() . ' ' . $this->getMessageFormatter()->getHtml();
 	}
 
 	/**

--- a/src/Aliases.php
+++ b/src/Aliases.php
@@ -40,7 +40,6 @@ class_alias( \SMW\Query\ResultPrinters\ListResultPrinter::class, 'SMW\ListResult
 class_alias( \SMW\Query\Parser::class, 'SMWQueryParser' );
 class_alias( \SMW\SQLStore\ChangeOp\ChangeOp::class, 'SMW\SQLStore\CompositePropertyTableDiffIterator' );
 class_alias( \SMW\Connection\ConnectionProvider::class, 'SMW\DBConnectionProvider' );
-class_alias( \SMW\DataValues\TypesValue::class, 'SMWTypesValue' );
 class_alias( \SMW\DataValues\PropertyValue::class, 'SMWPropertyValue' );
 class_alias( \SMW\DataValues\StringValue::class, 'SMWStringValue' );
 class_alias( \SMW\MediaWiki\Connection\Database::class, '\SMW\MediaWiki\Database' );
@@ -94,7 +93,6 @@ class_alias( \SMW\Exporter\Element\ExpElement::class, 'SMWExpElement' );
 class_alias( \SMW\Exporter\Element\ExpResource::class, 'SMWExpResource' );
 class_alias( \SMW\Exporter\Element\ExpNsResource::class, 'SMWExpNsResource' );
 class_alias( \SMW\Exporter\Element\ExpLiteral::class, 'SMWExpLiteral' );
-class_alias( \SMW\DataValues\ImportValue::class, 'SMWImportValue' );
 class_alias( \SMW\SQLStore\QueryEngine\QueryEngine::class, 'SMWSQLStore3QueryEngine' );
 
 // 2.3

--- a/src/Exporter/ResourceBuilders/ImportFromPropertyValueResourceBuilder.php
+++ b/src/Exporter/ResourceBuilders/ImportFromPropertyValueResourceBuilder.php
@@ -3,11 +3,11 @@
 namespace SMW\Exporter\ResourceBuilders;
 
 use SMW\DataValueFactory;
+use SMW\DataValues\ImportValue;
 use SMW\DIProperty;
 use SMWDataItem as DataItem;
 use SMWDIBlob as DIBlob;
 use SMWExpData as ExpData;
-use SMWImportValue as ImportValue;
 
 /**
  * @private

--- a/src/Property/DeclarationExaminer/PredefinedPropertyExaminer.php
+++ b/src/Property/DeclarationExaminer/PredefinedPropertyExaminer.php
@@ -4,11 +4,11 @@ namespace SMW\Property\DeclarationExaminer;
 
 use SMW\DIProperty;
 use SMW\Property\DeclarationExaminer as IDeclarationExaminer;
+use SMW\DataValues\TypesValue;
 use SMW\DataTypeRegistry;
 use SMW\DataValueFactory;
 use SMW\PropertyRegistry;
 use SMW\Message;
-use SMWTypesValue;
 
 /**
  * @license GNU GPL v2+
@@ -76,7 +76,7 @@ class PredefinedPropertyExaminer extends DeclarationExaminer {
 			$messages[] = [
 				'smw-property-predefined-default',
 				$propertyName,
-				SMWTypesValue::newFromTypeId( $property->findPropertyValueType() )->getLongHTMLText()
+				TypesValue::newFromTypeId( $property->findPropertyValueType() )->getLongHTMLText()
 			];
 		}
 

--- a/tests/phpunit/Unit/DataValues/ImportValueTest.php
+++ b/tests/phpunit/Unit/DataValues/ImportValueTest.php
@@ -40,12 +40,6 @@ class ImportValueTest extends \PHPUnit_Framework_TestCase {
 			'\SMW\DataValues\ImportValue',
 			new ImportValue()
 		);
-
-		// FIXME Legacy naming remove in 3.x
-		$this->assertInstanceOf(
-			'\SMWImportValue',
-			new ImportValue()
-		);
 	}
 
 	public function testErrorForInvalidUserValue() {

--- a/tests/phpunit/Unit/DataValues/TypesValueTest.php
+++ b/tests/phpunit/Unit/DataValues/TypesValueTest.php
@@ -23,11 +23,6 @@ class TypesValueTest extends \PHPUnit_Framework_TestCase {
 			new TypesValue()
 		);
 
-		// FIXME Legacy naming remove in 3.1.x
-		$this->assertInstanceOf(
-			'\SMWTypesValue',
-			new TypesValue()
-		);
 	}
 
 	public function testNewFromTypeId() {

--- a/tests/phpunit/Unit/Importer/ImporterTest.php
+++ b/tests/phpunit/Unit/Importer/ImporterTest.php
@@ -5,7 +5,7 @@ namespace SMW\Tests\Importer;
 use SMW\Importer\ContentIterator;
 use SMW\Importer\ImportContents;
 use SMW\Importer\Importer;
-use SMW\Importer\JsoncontentIterator;
+use SMW\Importer\JsonContentIterator;
 use SMW\Importer\JsonImportContentsFileDirReader;
 use SMW\Tests\TestEnvironment;
 use SMW\Tests\PHPUnitCompat;
@@ -61,7 +61,7 @@ class ImporterTest extends \PHPUnit_Framework_TestCase {
 	public function testDisabled() {
 
 		$instance = new Importer(
-			new JsoncontentIterator( $this->jsonImportContentsFileDirReader ),
+			new JsonContentIterator( $this->jsonImportContentsFileDirReader ),
 			$this->contentCreator
 		);
 
@@ -99,7 +99,7 @@ class ImporterTest extends \PHPUnit_Framework_TestCase {
 			->method( 'create' );
 
 		$instance = new Importer(
-			new JsoncontentIterator( $this->jsonImportContentsFileDirReader ),
+			new JsonContentIterator( $this->jsonImportContentsFileDirReader ),
 			$this->contentCreator
 		);
 
@@ -128,7 +128,7 @@ class ImporterTest extends \PHPUnit_Framework_TestCase {
 			->method( 'create' );
 
 		$instance = new Importer(
-			new JsoncontentIterator( $this->jsonImportContentsFileDirReader ),
+			new JsonContentIterator( $this->jsonImportContentsFileDirReader ),
 			$this->contentCreator
 		);
 
@@ -161,7 +161,7 @@ class ImporterTest extends \PHPUnit_Framework_TestCase {
 			) );
 
 		$instance = new Importer(
-			new JsoncontentIterator( $this->jsonImportContentsFileDirReader ),
+			new JsonContentIterator( $this->jsonImportContentsFileDirReader ),
 			$this->contentCreator
 		);
 


### PR DESCRIPTION
Comments in the tests indicated they should be removed in the 3.x cycle.