### PR TITLE
Remove usage of wfWikiId function as fallback

### DIFF
--- a/src/CacheFactory.php
+++ b/src/CacheFactory.php
@@ -51,13 +51,8 @@ class CacheFactory {
 	 * @return string
 	 */
 	public static function getCachePrefix() {
-		if ( class_exists( '\WikiMap' ) && method_exists( '\WikiMap', 'getCurrentWikiId' ) ) {
-			$wikiId = WikiMap::getCurrentWikiId();
-		} else {
-			$wikiId = wfWikiID();
-		}
-
-		return $GLOBALS['wgCachePrefix'] === false ? $wikiId : $GLOBALS['wgCachePrefix'];
+		return $GLOBALS['wgCachePrefix'] === false ?
+			WikiMap::getCurrentWikiId() : $GLOBALS['wgCachePrefix'];
 	}
 
 	/**

--- a/src/GlobalFunctions.php
+++ b/src/GlobalFunctions.php
@@ -164,13 +164,8 @@ function &smwfGetStore() {
  * @return string
  */
 function smwfCacheKey( $namespace, $key ) {
-	if ( class_exists( '\WikiMap' ) && method_exists( '\WikiMap', 'getCurrentWikiId' ) ) {
-		$wikiId = WikiMap::getCurrentWikiId();
-	} else {
-		$wikiId = wfWikiID();
-	}
-
-	$cachePrefix = $GLOBALS['wgCachePrefix'] === false ? $wikiId : $GLOBALS['wgCachePrefix'];
+	$cachePrefix = $GLOBALS['wgCachePrefix'] === false ?
+		WikiMap::getCurrentWikiId() : $GLOBALS['wgCachePrefix'];
 
 	if ( $namespace[0] !== ':' ) {
 		$namespace = ':' . $namespace;

--- a/src/Site.php
+++ b/src/Site.php
@@ -142,13 +142,7 @@ class Site {
 			$affix = ':' . $affix;
 		}
 
-		if ( class_exists( '\WikiMap' ) && method_exists( '\WikiMap', 'getCurrentWikiId' ) ) {
-			$wikiId = WikiMap::getCurrentWikiId();
-		} else {
-			$wikiId = wfWikiID();
-		}
-
-		return $wikiId . $affix;
+		return WikiMap::getCurrentWikiId() . $affix;
 	}
 
 	/**


### PR DESCRIPTION
WikiMap::getCurrentWikiId() has been available since MW 1.35