### PR TITLE
Type error in some requests when ElasticStore is used

### DIFF
--- a/src/Elastic/QueryEngine/DescriptionInterpreters/SomePropertyInterpreter.php
+++ b/src/Elastic/QueryEngine/DescriptionInterpreters/SomePropertyInterpreter.php
@@ -61,7 +61,7 @@ class SomePropertyInterpreter {
 	 *
 	 * @param SomeProperty $description
 	 *
-	 * @return array
+	 * @return Condition|array
 	 */
 	public function interpretDescription( SomeProperty $description, $isConjunction = false, $isChain = false ) {
 
@@ -406,6 +406,9 @@ class SomePropertyInterpreter {
 		}
 
 		if ( $property->isInverse() ) {
+			if ( $p instanceof Condition ) {
+				$p = $p->toArray();
+			}
 			$parameters = $this->termsLookup->newParameters(
 				[
 					'query.string' => $desc->getQueryString(),


### PR DESCRIPTION
Sometimes interpretDescription returns an array, so we have to convert it to an array only if it is a Condition.

This happened on a wiki where ElasticStore is activated and was solved with this patch -- well, in fact, a slightly different patch: I placed the conversion just after the call to interpretDescription (between lines 405 and 406), but I think it is better placed inside the `if ( $property->isInverse() )` to convert it to array only if needed.