### PR TITLE
Fix interface to ElasticStore parameters

### DIFF
--- a/src/Elastic/Connection/ConnectionProvider.php
+++ b/src/Elastic/Connection/ConnectionProvider.php
@@ -72,14 +72,16 @@ class ConnectionProvider implements IConnectionProvider {
 			'hosts' => $endpoints,
 			'retries' => $this->config->dotGet( 'connection.retries', 1 ),
 
-			'client' => [
+			'connectionParams' => [
+				'client' => [
 
-				// controls the request timeout
-				'timeout' => $this->config->dotGet( 'connection.timeout', 30 ),
+					// controls the request timeout
+					'timeout' => $this->config->dotGet( 'connection.timeout', 30 ),
 
-				// controls the original connection timeout duration
-				'connect_timeout' => $this->config->dotGet( 'connection.connect_timeout', 30 )
-			]
+					// controls the original connection timeout duration
+					'connect_timeout' => $this->config->dotGet( 'connection.connect_timeout', 30 )
+				]
+			],
 
 			// Use `singleHandler` if you know you will never need async capabilities,
 			// since it will save a small amount of overhead by reducing indirection


### PR DESCRIPTION
In SMW\Elastic\Connection\ConnectionProvider::getConnections(), the keys $k in $params [[1]](https://github.com/SemanticMediaWiki/SemanticMediaWiki/blob/master/src/Elastic/Connection/ConnectionProvider.php#L71-L87) are used to create method names "set$k" in Elasticsearch\ClientBuilder::fromConfig() [[2]](https://github.com/elastic/elasticsearch-php/blob/master/src/Elasticsearch/ClientBuilder.php#L200).
The connection parameters are set with setConnectionParams, this is this fix (see use in Elasticsearch\Connections\Connection, e.g. [[3]](https://github.com/elastic/elasticsearch-php/blob/master/src/Elasticsearch/Connections/Connection.php#L290)).

This issue can be seen by setting, in `SMW\Elastic\Connection\ConnectionProvider::getConnection()`, the second parameter of `ClientBuilder::fromConfig( $params, $quiet = true )` to `$quiet = false` like in the following diff: an exception is returned.
```diff
@@ -90 +90 @@ class ConnectionProvider implements IConnectionProvider {
-                       $clientBuilder = ClientBuilder::fromConfig( $params, true );
+                       $clientBuilder = ClientBuilder::fromConfig( $params, false );
```