### PR TITLE
Document that Elasticsearch really need resources

### DIFF
--- a/src/Elastic/README.md
+++ b/src/Elastic/README.md
@@ -22,6 +22,7 @@ It is recommended to:
 
 - Use Elasticsearch 6+ due to improvements to its [sparse field][es:6] handling
 - Consult the official hardware [guide][es:hardware] on specific Elasticsearch requirements
+  If Elasticsearch has not enough resources, it could defeat this whole feature ElasticStore; check Elasticsearch logs and other Elasticsearch mechanisms in case of issue, and add resources if needed.
 
 ## Features
 


### PR DESCRIPTION
To insist more on [Help:ElasticStore](https://www.semantic-mediawiki.org/wiki/Help:ElasticStore) that Elasticsearch really needs resources and if not enough it could defeat the whole ElasticStore feature, which what I experienced in #4990.

(Perhaps this documentation could be better worded.)