### PR TITLE
Optimise second-chained properties results, refs 3722

### DIFF
--- a/src/Query/Result/ItemFetcher.php
+++ b/src/Query/Result/ItemFetcher.php
@@ -162,20 +162,8 @@ class ItemFetcher {
 
 		// If its a chain we need to reload since the DataItem's use are traversed
 		// from each chain element
-		if ( !$this->prefetchCache->isCached( $property ) || $requestOptions->isChain ) {
-			$list = $this->dataItems;
-
-			if ( $requestOptions->isChain ) {
-				$list = $dataItems;
-
-				// Allow the first chain element to use the entire result list
-				// to filter members as early as possible from the chain
-				if ( $requestOptions->isFirstChain ?? false ) {
-					$list = $this->dataItems;
-				}
-			}
-
-			$this->prefetchCache->prefetch( $list, $property, $requestOptions );
+		if ( !$this->prefetchCache->isCached( $property, $requestOptions ) ) {
+			$this->prefetchCache->prefetch( $this->dataItems, $property, $requestOptions );
 		}
 
 		foreach ( $dataItems as $subject ) {

--- a/tests/phpunit/Integration/JSONScript/TestCases/p-0468.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/p-0468.json
@@ -1,0 +1,67 @@
+{
+	"description": "Test `_wpg` for property chain query queries",
+	"setup": [
+		{
+			"namespace": "SMW_NS_PROPERTY",
+			"page": "Located in",
+			"contents": "[[Has type::Page]]"
+		},
+		{
+			"namespace": "SMW_NS_PROPERTY",
+			"page": "Member of",
+			"contents": "[[Has type::Page]]"
+		},
+		{
+			"page": "Europe",
+			"contents": "[[Member of::European Union]] {{#subobject:Member of=NATO}}"
+		},
+		{
+			"page": "France",
+			"contents": "[[Located in::Europe]] [[Has surrounding sea::Mediterranean Sea]]"
+		},
+		{
+			"page": "Germany",
+			"contents": "{{#set:Located in=Europe|Has surrounding sea=North Sea}}"
+		},
+		{
+			"page": "Italy",
+			"contents": "{{#subobject:Located in=Europe|Has surrounding sea=Mediterranean Sea}}"
+		},
+		{
+			"page": "Mediterranean Sea",
+			"contents": "[[Located in::South Europe]]"
+		},
+		{
+			"page": "North Sea",
+			"contents": "[[Located in::North Europe]]"
+		},
+		{
+			"page": "Example/Q0601/Q2",
+			"contents": "{{#ask: [[Located in.Member of::European Union]] | ?Has surrounding sea.Located in | link=none }}"
+		}
+	],
+	"tests": [
+		{
+			"type": "parser",
+			"about": "#0 (see issue #4988)",
+			"subject": "Example/Q0601/Q2",
+			"assert-output": {
+				"to-contain": [
+					"<tr data-row-number=\"1\" class=\"row-odd\"><td class=\"smwtype_wpg\">France</td><td class=\"Located-in smwtype_wpg\">South Europe</td></tr>",
+					"<tr data-row-number=\"2\" class=\"row-even\"><td class=\"smwtype_wpg\">Germany</td><td class=\"Located-in smwtype_wpg\">North Europe</td></tr>",
+					"<tr data-row-number=\"3\" class=\"row-odd\"><td class=\"smwtype_wpg\">Italy#_7c13af61ab1eac49b09a02a9511dccb8</td><td class=\"Located-in smwtype_wpg\">South Europe</td></tr>"
+				]
+			}
+		}
+	],
+	"settings": {
+		"smwgPageSpecialProperties": [
+			"_MDAT"
+		]
+	},
+	"meta": {
+		"version": "2",
+		"is-incomplete": false,
+		"debug": false
+	}
+}


### PR DESCRIPTION
This PR is made in reference to: #3722

This PR addresses or contains:
* When a chained result is requested, there is already an optimisation for the first-chained property with a bulk request of this property accross all results (#4572); this optimises further the second-chained property (then third, etc) with a bulk request of this property accross all results (results from the first-chained property results).
* solves #4988

The “prefetch cache” operation is now global: all prefetching is done at the first execution of `PrefetchCache::prefetch()` for all lines of the result, instead of one prefetching on each line.

The real cache (PrefetchCache->cache) have keys "PropertyName" or "-PropertyName" and the values are arrays [ "semantic object ID" => [ list of WikiPages ] ] ; so that it is easy to pick values in PrefetchCache::getPropertyValues(). (I say WikiPages here and after, but it could be other data types.)

The second cache (PrefetchCache->lookupCache) is aligned with the first one; its keys are the whole property chain like "Prop1.-Prop2.Prop3…PropN-1" for the N-level chain (so that it is empty for first-level chain) and the values are the WikiPages of the result for this level N; this is mainly used to be able to compute the next level starting from this result.

Earlier versions of this PR failed on tests p-0434.json and p-0467.json due to the vicious repetition of a same property in the chain, which why the whole property chain must be cached somewhere (here in lookupCache) and not only the property.

On a request #ask with 999 results and two 2-levels chain properties (with no common property), it took 18.4 seconds before this patch and 3.7 seconds with this patch (mean over a sample of 5 reloads of the page; it is not impossible other factors influence the performance like MySQL internal cache, but the figures are anyway quite different). This was on SMW 3.2.2 + MW 1.33 + ElasticStore + PHP 7.3.

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed