### PR TITLE
Override ContentHandler::preSaveTransform instead of Content::preSaveTransform.

### DIFF
--- a/src/MediaWiki/Content/SchemaContentHandler.php
+++ b/src/MediaWiki/Content/SchemaContentHandler.php
@@ -2,6 +2,8 @@
 
 namespace SMW\MediaWiki\Content;
 
+use Content;
+use MediaWiki\Content\Transform\PreSaveTransformParams;
 use JsonContentHandler;
 
 /**
@@ -71,4 +73,15 @@ class SchemaContentHandler extends JsonContentHandler {
 		return false;
 	}
 
+	/**
+	 *
+	 * {@inheritDoc}
+	 */
+	public function preSaveTransform( Content $content, PreSaveTransformParams $pstParams ) {
+		return $content->preSaveTransform(
+			$pstParams->getPage(),
+			$pstParams->getUser(),
+			$pstParams->getParserOptions()
+		);
+	}
 }

--- a/src/MediaWiki/Content/SchemaContentHandler.php
+++ b/src/MediaWiki/Content/SchemaContentHandler.php
@@ -14,11 +14,6 @@ use JsonContentHandler;
  */
 class SchemaContentHandler extends JsonContentHandler {
 
-	/**
-	 * @since 3.0
-	 *
-	 * {@inheritDoc}
-	 */
 	public function __construct() {
 		parent::__construct( CONTENT_MODEL_SMW_SCHEMA, [ CONTENT_FORMAT_JSON ] );
 	}


### PR DESCRIPTION
Since starting with version 1.37 we move Content::preSaveTransform to ContentHandler we should also move it in SemanticMediaWiki (SchemaContent -> SchemaContentHandler). But as SemanticMediaWiki used in older version, we should leave the old SchemaContent::preSaveTransform and reuse it for the new one SchemaContentHandler::preSaveTransform.

More details in ticket description: https://phabricator.wikimedia.org/T287156