### PR TITLE
MwHooksHandler: Use MediaWiki\HookContainer to fix tests

### DIFF
--- a/src/MediaWiki/HookDispatcher.php
+++ b/src/MediaWiki/HookDispatcher.php
@@ -90,7 +90,7 @@ class HookDispatcher {
 	public function onSettingsBeforeInitializationComplete( array &$configuration ) {
 
 		// Deprecated since 3.1
-		\Hooks::run( 'SMW::Config::BeforeCompletion', [ &$configuration ] );
+		Hooks::run( 'SMW::Config::BeforeCompletion', [ &$configuration ] );
 
 
 		Hooks::run( 'SMW::Settings::BeforeInitializationComplete', [ &$configuration ] );

--- a/tests/phpunit/Utils/MwHooksHandler.php
+++ b/tests/phpunit/Utils/MwHooksHandler.php
@@ -2,6 +2,7 @@
 
 namespace SMW\Tests\Utils;
 
+use MediaWiki\MediaWikiServices;
 use RuntimeException;
 use SMW\MediaWiki\Hooks;
 
@@ -17,6 +18,7 @@ class MwHooksHandler {
 	 * @var HookRegistry
 	 */
 	private $hookRegistry = null;
+	private $hookContainer = null;
 
 	private $wgHooks = [];
 	private $inTestRegisteredHooks = [];
@@ -80,6 +82,11 @@ class MwHooksHandler {
 		'SMW::SQLStore::Installer::AfterDropTablesComplete'
 	];
 
+
+	public function __construct() {
+		$this->hookContainer = MediaWikiServices::getInstance()->getHookContainer();
+	}
+
 	/**
 	 * @since  2.0
 	 *
@@ -93,18 +100,9 @@ class MwHooksHandler {
 		);
 
 		foreach ( $listOfHooks as $hook ) {
-
-			// MW 1.19
-			if ( method_exists( 'Hooks', 'clear' ) ) {
-				$this->getHookRegistry()->clear( $hook );
+			if ( $this->hookContainer->isRegistered( $hook ) ) {
+				$this->hookContainer->clear( $hook );
 			}
-
-			if ( !isset( $GLOBALS['wgHooks'][$hook] ) ) {
-				continue;
-			}
-
-			$this->wgHooks[$hook] = $GLOBALS['wgHooks'][$hook];
-			$GLOBALS['wgHooks'][$hook] = [];
 		}
 
 		return $this;
@@ -118,11 +116,11 @@ class MwHooksHandler {
 	public function restoreListedHooks() {
 
 		foreach ( $this->inTestRegisteredHooks as $hook ) {
-			unset( $GLOBALS['wgHooks'][$hook] );
+			$this->hookContainer->clear( $hook );
 		}
 
 		foreach ( $this->wgHooks as $hook => $definition ) {
-			$GLOBALS['wgHooks'][$hook] = $definition;
+			$this->hookContainer->register( $hook, $definition );
 			unset( $this->wgHooks[$hook] );
 		}
 
@@ -146,18 +144,8 @@ class MwHooksHandler {
 		}
 
 		$this->inTestRegisteredHooks[] = $name;
-		$GLOBALS['wgHooks'][$name][] = $callback;
+		$this->hookContainer->register( $name, $callback );
 
-		return $this;
-	}
-
-	/**
-	 * @since  2.1
-	 *
-	 * @return MwHooksHandler
-	 */
-	public function invokeHooksFromRegistry() {
-		$this->getHookRegistry()->register( $GLOBALS );
 		return $this;
 	}
 


### PR DESCRIPTION
`MediaWiki\HookContainer` was introduced in MW 1.35.

Tested on MW 1.37.0-alpha (78a8e93)

**Before changes**:
![image](https://user-images.githubusercontent.com/1685517/130750177-259e39a5-30f4-4cfa-a440-cdec4fe576fe.png)

**After changes**:
![image](https://user-images.githubusercontent.com/1685517/130750062-eaae2d73-15f8-411a-952b-062f115f4da3.png)
