### PR TITLE
Fix deprecated argument format to IDatabase::upsert

### DIFF
--- a/src/SQLStore/EntityStore/AuxiliaryFields.php
+++ b/src/SQLStore/EntityStore/AuxiliaryFields.php
@@ -117,9 +117,7 @@ class AuxiliaryFields {
 		$this->connection->upsert(
 			SQLStore::ID_AUXILIARY_TABLE,
 			$rows,
-			[
-				'smw_id'
-			],
+			'smw_id',
 			$rows,
 			__METHOD__
 		);

--- a/src/SQLStore/EntityStore/SequenceMapFinder.php
+++ b/src/SQLStore/EntityStore/SequenceMapFinder.php
@@ -70,9 +70,7 @@ class SequenceMapFinder {
 		$this->connection->upsert(
 			SQLStore::ID_AUXILIARY_TABLE,
 			$rows,
-			[
-				'smw_id'
-			],
+			'smw_id',
 			$rows,
 			__METHOD__
 		);


### PR DESCRIPTION
Fixes: #5062

This should prevent warnings in Database::normalizeUpsertKeys from being emitted.