### PR TITLE
Remove usage of wfWaitForSlaves with LBFactory::waitForReplication

### DIFF
--- a/tests/phpunit/Utils/Runners/JobQueueRunner.php
+++ b/tests/phpunit/Utils/Runners/JobQueueRunner.php
@@ -4,6 +4,7 @@ namespace SMW\Tests\Utils\Runners;
 
 use Job;
 use JobQueueGroup;
+use MediaWiki\MediaWikiServices;
 use SMW\Connection\ConnectionProvider;
 use SMW\Tests\TestEnvironment;
 use SMW\Tests\Utils\Connection\TestDatabaseConnectionProvider;
@@ -22,6 +23,7 @@ class JobQueueRunner {
 	protected $type = null;
 	protected $status = [];
 	protected $connectionProvider = null;
+	private $lbFactory;
 
 	/**
 	 * @var TestEnvironment
@@ -37,6 +39,7 @@ class JobQueueRunner {
 	public function __construct( $type = null, ConnectionProvider $connectionProvider = null ) {
 		$this->type = $type;
 		$this->connectionProvider = $connectionProvider;
+		$this->lbFactory = MediaWikiServices::getInstance()->getDBLoadBalancerFactory();
 
 		if ( $this->connectionProvider === null ) {
 			$this->connectionProvider = new TestDatabaseConnectionProvider();
@@ -89,7 +92,7 @@ class JobQueueRunner {
 				break;
 			}
 
-			wfWaitForSlaves();
+			$this->lbFactory->waitForReplication();
 
 			$this->status[] = [
 				'type'   => $job->command,


### PR DESCRIPTION
LBFactory::waitForSlaves() was replaced with waitForReplication().
See: https://gerrit.wikimedia.org/g/mediawiki/core/+/71d9aa661b46aa20a42cea2387be3c0d51a72d1c/HISTORY#354

Fixes: #4789