### PR TITLE
Implements JsonUnserializable on SMW\SemanticData

### DIFF
--- a/includes/SemanticData.php
+++ b/includes/SemanticData.php
@@ -2,6 +2,8 @@
 
 namespace SMW;
 
+use MediaWiki\Json\JsonUnserializable;
+use MediaWiki\Json\JsonUnserializer;
 use SMW\DataModel\SubSemanticData;
 use SMW\DataModel\SequenceMap;
 use SMW\Exception\SubSemanticDataException;
@@ -30,7 +32,7 @@ use SMWDIContainer;
  * @author Markus Krötzsch
  * @author Jeroen De Dauw
  */
-class SemanticData {
+class SemanticData implements JsonUnserializable {
 
 	/**
 	 * Returns the last modified timestamp the data were stored to the Store or
@@ -74,7 +76,7 @@ class SemanticData {
 	 * Array mapping property keys (string) to arrays of SMWDataItem
 	 * objects.
 	 *
-	 * @var SMWDataItem[]
+	 * @var SMWDataItem[][]
 	 */
 	protected $mPropVals = [];
 
@@ -886,6 +888,69 @@ class SemanticData {
 	public function removeSubSemanticData( SemanticData $semanticData ) {
 		$this->hash = null;
 		$this->subSemanticData->removeSubSemanticData( $semanticData );
+	}
+
+	/**
+	 * Implements \JsonSerializable.
+	 * 
+	 * @since 4.0.0
+	 *
+	 * @return array
+	 */
+	public function jsonSerialize() {
+		$json = [
+			'stubObject' => $this->stubObject,
+			'mPropVals' => array_map( function( $x ) {
+					return array_map( function( $y ) {
+						return $y->jsonSerialize();
+					}, $x );
+				}, $this->mPropVals ),
+			'mProperties' => array_map( function( $x ) {
+					return $x->jsonSerialize();
+				}, $this->mProperties ),
+			'mHasVisibleProps' => $this->mHasVisibleProps,
+			'mHasVisibleSpecs' => $this->mHasVisibleSpecs,
+			'mNoDuplicates' => $this->mNoDuplicates,
+			'mSubject' => $this->mSubject ? $this->mSubject->jsonSerialize() : null,
+			'subSemanticData' => $this->subSemanticData ? $this->subSemanticData->jsonSerialize() : null,
+			'errors' => $this->errors,
+			'hash' => $this->hash,
+			'options' => $this->options ? $this->options->jsonSerialize() : null,
+			'extensionData' => $this->extensionData,
+			'sequenceMap' => $this->sequenceMap,
+			'countMap' => $this->countMap,
+			'_type_' => get_class( $this ),
+		];
+		return $json;
+	}
+
+	/**
+	 * Implements JsonUnserializable.
+	 * 
+	 * @since 4.0.0
+	 *
+	 * @param JsonUnserializer $unserializer Unserializer
+	 * @param array $json JSON to be unserialized
+	 *
+	 * @return self
+	 */
+	public static function newFromJsonArray( JsonUnserializer $unserializer, array $json ) {
+		$obj = new self( $unserializer->unserialize( $json['mSubject'] ), $json['mNoDuplicates'] );
+		$obj->stubObject = $json['stubObject'];
+		$obj->mPropVals = array_map( function( $x ) use( $unserializer ) {
+				return $unserializer->unserializeArray( $x );
+			}, $json['mPropVals'] );
+		$obj->mProperties = $unserializer->unserializeArray( $json['mProperties'] );
+		$obj->mHasVisibleProps = $json['mHasVisibleProps'];
+		$obj->mHasVisibleSpecs = $json['mHasVisibleSpecs'];
+		$obj->subSemanticData = $json['subSemanticData'] ? $unserializer->unserialize( $json['subSemanticData'] ) : null;
+		$obj->errors = $json['errors'];
+		$obj->hash = $json['hash'];
+		$obj->options = $json['options'] ? $unserializer->unserialize( $json['options'] ) : null;
+		$obj->extensionData = $json['extensionData'];
+		$obj->sequenceMap = $json['sequenceMap'];
+		$obj->countMap = $json['countMap'];
+		return $obj;
 	}
 
 }

--- a/includes/compat/JsonUnserializable.php
+++ b/includes/compat/JsonUnserializable.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace MediaWiki\Json;
+
+if( ! interface_exists( 'MediaWiki\Json\JsonUnserializable' ) ) {
+
+	/**
+	 * This interface was introduced in MediaWiki 1.36 and some classes need to implement it.
+	 * With this stub definition SMW can be used on MediaWiki 1.35-.
+	 *
+	 * @license GNU GPL v2+
+	 * @since 4.0.0
+	 * @todo Remove when SMW will only support MediaWiki 1.36+ (see #5055).
+	 *
+	 * @author Sébastien Beyou
+	 */
+	interface JsonUnserializable {};
+
+}

--- a/includes/dataitems/DIConcept.php
+++ b/includes/dataitems/DIConcept.php
@@ -2,6 +2,7 @@
 
 namespace SMW;
 
+use MediaWiki\Json\JsonUnserializer;
 use SMWDataItem;
 
 /**
@@ -195,6 +196,39 @@ class DIConcept extends \SMWDataItem {
 			return false;
 		}
 		return $di->getSerialization() === $this->getSerialization();
+	}
+
+	/**
+	 * Implements \JsonSerializable.
+	 * 
+	 * @since 4.0.0
+	 *
+	 * @return array
+	 */
+	public function jsonSerialize() {
+		$json = parent::jsonSerialize();
+		$json['cacheStatus'] = $this->cacheStatus;
+		$json['cacheDate'] = $this->cacheDate;
+		$json['cacheCount'] = $this->cacheCount;
+		return $json;
+	}
+
+	/**
+	 * Implements JsonUnserializable.
+	 * 
+	 * @since 4.0.0
+	 *
+	 * @param JsonUnserializer $unserializer Unserializer
+	 * @param array $json JSON to be unserialized
+	 *
+	 * @return self
+	 */
+	public static function newFromJsonArray( JsonUnserializer $unserializer, array $json ) {
+		$obj = parent::newFromJsonArray( $unserializer, $json );
+		$obj->cacheStatus = $json['cacheStatus'];
+		$obj->cacheDate = $json['cacheDate'];
+		$obj->cacheCount = $json['cacheCount'];
+		return $obj;
 	}
 
 }

--- a/includes/dataitems/SMW_DI_Error.php
+++ b/includes/dataitems/SMW_DI_Error.php
@@ -3,6 +3,8 @@
  * @ingroup SMWDataItems
  */
 
+use MediaWiki\Json\JsonUnserializer;
+
 /**
  * This class implements error list data items. These data items are used to
  * pass around lists of error messages within the application. They are not
@@ -77,4 +79,34 @@ class SMWDIError extends SMWDataItem {
 
 		return $di->getSerialization() === $this->getSerialization();
 	}
+
+	/**
+	 * Implements \JsonSerializable.
+	 * 
+	 * @since 4.0.0
+	 *
+	 * @return array
+	 */
+	public function jsonSerialize() {
+		$json = parent::jsonSerialize();
+		$json['userValue'] = $this->userValue;
+		return $json;
+	}
+
+	/**
+	 * Implements JsonUnserializable.
+	 * 
+	 * @since 4.0.0
+	 *
+	 * @param JsonUnserializer $unserializer Unserializer
+	 * @param array $json JSON to be unserialized
+	 *
+	 * @return self
+	 */
+	public static function newFromJsonArray( JsonUnserializer $unserializer, array $json ) {
+		$obj = parent::newFromJsonArray( $unserializer, $json );
+		$obj->userValue = $json['userValue'];
+		return $obj;
+	}
+
 }

--- a/includes/dataitems/SMW_DI_Property.php
+++ b/includes/dataitems/SMW_DI_Property.php
@@ -3,6 +3,7 @@
 namespace SMW;
 
 use RuntimeException;
+use MediaWiki\Json\JsonUnserializer;
 use SMW\Exception\DataItemException;
 use SMW\Exception\DataTypeLookupException;
 use SMW\Exception\PredefinedPropertyLabelMismatchException;
@@ -555,6 +556,37 @@ class DIProperty extends SMWDataItem {
 		} catch ( DataItemException $e ) {
 			return null;
 		}
+	}
+
+	/**
+	 * Implements \JsonSerializable.
+	 * 
+	 * @since 4.0.0
+	 *
+	 * @return array
+	 */
+	public function jsonSerialize() {
+		$json = parent::jsonSerialize();
+		$json['propertyValueType'] = $this->propertyValueType;
+		$json['interwiki'] = $this->interwiki;
+		return $json;
+	}
+
+	/**
+	 * Implements JsonUnserializable.
+	 * 
+	 * @since 4.0.0
+	 *
+	 * @param JsonUnserializer $unserializer Unserializer
+	 * @param array $json JSON to be unserialized
+	 *
+	 * @return self
+	 */
+	public static function newFromJsonArray( JsonUnserializer $unserializer, array $json ) {
+		$obj = parent::newFromJsonArray( $unserializer, $json );
+		$obj->propertyValueType = $json['propertyValueType'];
+		$obj->interwiki = $json['interwiki'];
+		return $obj;
 	}
 
 }

--- a/includes/dataitems/SMW_DI_Time.php
+++ b/includes/dataitems/SMW_DI_Time.php
@@ -1,5 +1,6 @@
 <?php
 
+use MediaWiki\Json\JsonUnserializer;
 use SMW\DataValues\Time\CalendarModel;
 use SMW\DataValues\Time\JulianDay;
 use SMW\Exception\DataItemException;
@@ -605,6 +606,35 @@ class SMWDITime extends SMWDataItem implements CalendarModel {
 		} else {
 			$this->m_precision = self::PREC_YMDT;
 		}
+	}
+
+	/**
+	 * Implements \JsonSerializable.
+	 * 
+	 * @since 4.0.0
+	 *
+	 * @return array
+	 */
+	public function jsonSerialize() {
+		$json = parent::jsonSerialize();
+		$json['julianDay'] = $this->julianDay;
+		return $json;
+	}
+
+	/**
+	 * Implements JsonUnserializable.
+	 * 
+	 * @since 4.0.0
+	 *
+	 * @param JsonUnserializer $unserializer Unserializer
+	 * @param array $json JSON to be unserialized
+	 *
+	 * @return self
+	 */
+	public static function newFromJsonArray( JsonUnserializer $unserializer, array $json ) {
+		$obj = parent::newFromJsonArray( $unserializer, $json );
+		$obj->julianDay = $json['julianDay'];
+		return $obj;
 	}
 
 }

--- a/includes/dataitems/SMW_DI_WikiPage.php
+++ b/includes/dataitems/SMW_DI_WikiPage.php
@@ -2,6 +2,7 @@
 
 namespace SMW;
 
+use MediaWiki\Json\JsonUnserializer;
 use SMW\Exception\DataItemDeserializationException;
 use SMW\Exception\DataItemException;
 use SMWDataItem;
@@ -335,4 +336,40 @@ class DIWikiPage extends SMWDataItem {
 
 		return $di->getSerialization() === $this->getSerialization();
 	}
+
+	/**
+	 * Implements \JsonSerializable.
+	 * 
+	 * @since 4.0.0
+	 *
+	 * @return array
+	 */
+	public function jsonSerialize() {
+		$json = parent::jsonSerialize();
+		$json['sortkey'] = $this->sortkey;
+		$json['contextReference'] = $this->contextReference;
+		$json['pageLanguage'] = $this->pageLanguage;
+		$json['id'] = $this->id;
+		return $json;
+	}
+
+	/**
+	 * Implements JsonUnserializable.
+	 * 
+	 * @since 4.0.0
+	 *
+	 * @param JsonUnserializer $unserializer Unserializer
+	 * @param array $json JSON to be unserialized
+	 *
+	 * @return self
+	 */
+	public static function newFromJsonArray( JsonUnserializer $unserializer, array $json ) {
+		$obj = parent::newFromJsonArray( $unserializer, $json );
+		$obj->sortkey = $json['sortkey'];
+		$obj->contextReference = $json['contextReference'];
+		$obj->pageLanguage = $json['pageLanguage'];
+		$obj->id = $json['id'];
+		return $obj;
+	}
+
 }

--- a/includes/dataitems/SMW_DataItem.php
+++ b/includes/dataitems/SMW_DataItem.php
@@ -1,5 +1,7 @@
 <?php
 
+use MediaWiki\Json\JsonUnserializable;
+use MediaWiki\Json\JsonUnserializer;
 use SMW\Options;
 
 /**
@@ -27,7 +29,7 @@ use SMW\Options;
  *
  * @ingroup SMWDataItems
  */
-abstract class SMWDataItem {
+abstract class SMWDataItem implements JsonUnserializable {
 
 	/// Data item ID that can be used to indicate that no data item class is appropriate
 	const TYPE_NOTYPE    = 0;
@@ -240,6 +242,37 @@ abstract class SMWDataItem {
 		}
 
 		return $default;
+	}
+
+	/**
+	 * Implements \JsonSerializable.
+	 * 
+	 * @since 4.0.0
+	 *
+	 * @return array
+	 */
+	public function jsonSerialize() {
+		return [
+			'options' => $this->options ? $this->options->jsonSerialize() : null,
+			'value' => $this->getSerialization(),
+			'_type_' => get_class( $this ),
+		];
+	}
+
+	/**
+	 * Implements JsonUnserializable.
+	 * 
+	 * @since 4.0.0
+	 *
+	 * @param JsonUnserializer $unserializer Unserializer
+	 * @param array $json JSON to be unserialized
+	 *
+	 * @return self
+	 */
+	public static function newFromJsonArray( JsonUnserializer $unserializer, array $json ) {
+		$obj = static::doUnserialize( $json['value'] );
+		$obj->options = $json['options'] ? $unserializer->unserialize( $json['options'] ) : null;
+		return $obj;
 	}
 
 }

--- a/src/DataModel/SubSemanticData.php
+++ b/src/DataModel/SubSemanticData.php
@@ -2,6 +2,8 @@
 
 namespace SMW\DataModel;
 
+use MediaWiki\Json\JsonUnserializable;
+use MediaWiki\Json\JsonUnserializer;
 use SMW\DIProperty;
 use SMW\DIWikiPage;
 use SMW\Exception\SubSemanticDataException;
@@ -20,7 +22,7 @@ use SMW\SemanticData;
  * @author Jeroen De Dauw
  * @author mwjames
  */
-class SubSemanticData {
+class SubSemanticData implements JsonUnserializable {
 
 	/**
 	 * States whether repeated values should be avoided. Not needing
@@ -266,6 +268,42 @@ class SubSemanticData {
 
 		$semanticData->clearSubSemanticData();
 		$this->subSemanticData[$subobjectName] = $semanticData;
+	}
+
+	/**
+	 * Implements \JsonSerializable.
+	 * 
+	 * @since 4.0.0
+	 *
+	 * @return array
+	 */
+	public function jsonSerialize() {
+		return [
+			'noDuplicates' => $this->noDuplicates,
+			'subject' => $this->subject->jsonSerialize(),
+			'subSemanticData' => array_map( function( $x ) {
+					return $x->jsonSerialize();
+				}, $this->subSemanticData ),
+			'subContainerMaxDepth' => $this->subContainerMaxDepth,
+			'_type_' => get_class( $this ),
+		];
+	}
+
+	/**
+	 * Implements JsonUnserializable.
+	 * 
+	 * @since 4.0.0
+	 *
+	 * @param JsonUnserializer $unserializer Unserializer
+	 * @param array $json JSON to be unserialized
+	 *
+	 * @return self
+	 */
+	public static function newFromJsonArray( JsonUnserializer $unserializer, array $json ) {
+		$obj = new self( $unserializer->unserialize( $json['subject'] ), $json['noDuplicates'] );
+		$obj->subSemanticData = $unserializer->unserializeArray( $json['subSemanticData'] );
+		$obj->subContainerMaxDepth = $json['subContainerMaxDepth'];
+		return $obj;
 	}
 
 }

--- a/src/Options.php
+++ b/src/Options.php
@@ -4,6 +4,8 @@ namespace SMW;
 
 use InvalidArgumentException;
 use RuntimeException;
+use MediaWiki\Json\JsonUnserializable;
+use MediaWiki\Json\JsonUnserializer;
 use SMW\Utils\DotArray;
 
 /**
@@ -12,7 +14,7 @@ use SMW\Utils\DotArray;
  *
  * @author mwjames
  */
-class Options {
+class Options implements JsonUnserializable {
 
 	/**
 	 * @var array
@@ -158,6 +160,34 @@ class Options {
 		}
 
 		return $options;
+	}
+
+	/**
+	 * Implements \JsonSerializable.
+	 * 
+	 * @since 4.0.0
+	 *
+	 * @return array
+	 */
+	public function jsonSerialize() {
+		return [
+			'options' => $this->options,
+			'_type_' => get_class( $this ),
+		];
+	}
+
+	/**
+	 * Implements JsonUnserializable.
+	 * 
+	 * @since 4.0.0
+	 *
+	 * @param JsonUnserializer $unserializer Unserializer
+	 * @param array $json JSON to be unserialized
+	 *
+	 * @return self
+	 */
+	public static function newFromJsonArray( JsonUnserializer $unserializer, array $json ) {
+		return new self( $json['options'] );
 	}
 
 }


### PR DESCRIPTION
To avoid the warning “Non-unserializable property set at $.ExtensionData.smwdata” on MediaWiki 1.36.

Closes: #5055

Notes:

1) **Stub interface for 1.35**: I added a stub interface MediaWiki\Json\JsonUnserializable if it does not exist (MW 1.35-) so that classes can implement it unconditionnally, but it is unused in MW 1.35-. It is loaded by Composer’s classmap. Given MediaWiki’s autoloader is loaded before Composer’s autoloader, the real interface from MW 1.36 is found before the stub interface from SMW. The stub interface can be removed when SMW will only support MW 1.36+.

2) **Isomorphic with PHP serialization**: I put in this serialization all properties of objects to stay isomorphic with previous (PHP) serialization. Possibly some properties could be removed if they are not needed in this serialization (currently used for ParserOutput, but I don’t know if it will be used elsewhere in the future).

3) **Issue in MW unserialization of objects**: If you observe the object ParserOutput obtained from cache, you will be surprised that it is the JSON array and not an object SMW\SemanticData. This comes from MediaWiki, precisely I5785596d68e ([link](https://gerrit.wikimedia.org/r/c/mediawiki/core/+/639609)). I put the remark on the Gerrit change, and I will open a Phabricator task.

4) **Alternative PR**: Just when I finished this PR, I remembered there is already a PR from Cindy #4874. It is an alternative to this PR, perhaps/probably in an easier way.

For reviewers:

1) JsonUnserializer->unserializeArray() and JsonUnserializer->unserialize() are not recursive, that’s why there is a loop in SemanticData::newFromJsonArray() for mPropVals. I added a precision in the definition of mPropVals that it is a two-dimensional array.

2) JsonUnserializer->unserialize() does not accept null as parameter, so that are some operators ? :
