### PR TITLE
PermissionManager: Replace $wgUser with RequestContext::getUser()

### DIFF
--- a/src/MediaWiki/PermissionManager.php
+++ b/src/MediaWiki/PermissionManager.php
@@ -2,6 +2,7 @@
 
 namespace SMW\MediaWiki;
 
+use RequestContext;
 use Title;
 use User;
 
@@ -40,7 +41,7 @@ class PermissionManager {
 
 		// @see Title::userCan
 		if ( !$user instanceof User ) {
-			$user = $GLOBALS['wgUser'];
+			$user = RequestContext::getMain()->getUser();
 		}
 
 		if ( $this->permissionManager !== null ) {


### PR DESCRIPTION
Getting the following error on page: Property:Modification_date:

Argument 2 passed to MediaWiki\Permissions\PermissionManager::userCan()
must be an instance of User, instance of StubGlobalUser given

Using MW version 1.38

Caused by: https://gerrit.wikimedia.org/r/c/mediawiki/core/+/721534