### PR TITLE
Replace fallbacks for MediaWiki\Permissions\PermissionManager

### DIFF
--- a/src/MediaWiki/PermissionManager.php
+++ b/src/MediaWiki/PermissionManager.php
@@ -2,6 +2,7 @@
 
 namespace SMW\MediaWiki;
 
+use MediaWiki\Permissions\PermissionManager as MwPermissionManager;
 use RequestContext;
 use Title;
 use User;
@@ -15,16 +16,16 @@ use User;
 class PermissionManager {
 
 	/**
-	 * @var PermissionManager|null
+	 * @var MwPermissionManager
 	 */
 	private $permissionManager;
 
 	/**
 	 * @since 3.2
 	 *
-	 * @param PermissionManager|null $permissionManager
+	 * @param MwPermissionManager $permissionManager
 	 */
-	public function __construct( \MediaWiki\Permissions\PermissionManager $permissionManager = null ) {
+	public function __construct( MwPermissionManager $permissionManager ) {
 		$this->permissionManager = $permissionManager;
 	}
 
@@ -38,17 +39,11 @@ class PermissionManager {
 	 * @return bool
 	 */
 	public function userCan( string $action, User $user = null, Title $title ) : bool {
-
-		// @see Title::userCan
 		if ( !$user instanceof User ) {
-			$user = RequestContext::getMain()->getUser();
+			$user = RequestContext::getMain()->getUser();			
 		}
 
-		if ( $this->permissionManager !== null ) {
-			return $this->permissionManager->userCan( $action, $user, $title );
-		}
-
-		return $title->userCan( $action, $user );
+		return $this->permissionManager->userCan( $action, $user, $title );
 	}
 
 	/**
@@ -60,12 +55,7 @@ class PermissionManager {
 	 * @return bool
 	 */
 	public function userHasRight( User $user, string $action = '' ) : bool {
-
-		if ( $this->permissionManager !== null && method_exists( $this->permissionManager, 'userHasRight' ) ) {
-			return $this->permissionManager->userHasRight( $user, $action );
-		}
-
-		return $user->isAllowed( $action );
+		return $this->permissionManager->userHasRight( $user, $action );
 	}
 
 }

--- a/src/Services/mediawiki.php
+++ b/src/Services/mediawiki.php
@@ -136,15 +136,7 @@ return [
 	 * @return callable
 	 */
 	'PermissionManager' => function( $containerBuilder ) {
-
-		$permissionManager = null;
-
-		// > MW 1.33
-		if ( class_exists( '\MediaWiki\MediaWikiServices' ) && method_exists( '\MediaWiki\MediaWikiServices', 'getPermissionManager' ) ) {
-			$permissionManager = MediaWikiServices::getInstance()->getPermissionManager();
-		}
-
-		return new PermissionManager( $permissionManager );
+		return new PermissionManager( MediaWikiServices::getInstance()->getPermissionManager() );
 	},
 
 	/**

--- a/tests/phpunit/MediaWiki/PermissionManagerTest.php
+++ b/tests/phpunit/MediaWiki/PermissionManagerTest.php
@@ -2,7 +2,6 @@
 
 namespace SMW\Tests\MediaWiki;
 
-use ParserOutput;
 use SMW\MediaWiki\PermissionManager;
 use SMW\Tests\PHPUnitCompat;
 
@@ -20,78 +19,39 @@ class PermissionManagerTest extends \PHPUnit_Framework_TestCase {
 	use PHPUnitCompat;
 
 	public function testCanConstruct() {
-
 		$this->assertInstanceOf(
 			PermissionManager::class,
-			new PermissionManager()
-		);
-	}
-
-	public function testUserCan_Title() {
-
-		if ( method_exists( 'MediaWiki\Permissions\PermissionManager', 'userCan' ) ) {
-			$this->markTestSkipped( 'Using the PermissionManager::userCan' );
-		}
-
-		$title = $this->getMockBuilder( '\Title' )
-			->disableOriginalConstructor()
-			->getMock();
-
-		$title->expects( $this->any() )
-			->method(  'userCan' )
-			->will( $this->returnValue( true ) );
-
-		$instance = new PermissionManager();
-
-		$this->assertInternalType(
-			'bool',
-			$instance->userCan( 'foo', null, $title )
+			new PermissionManager( $this->getMwPermissionManagerMock() )
 		);
 	}
 
 	public function testUserCan_PermissionManager() {
-
-		if ( !method_exists( 'MediaWiki\Permissions\PermissionManager', 'userCan' ) ) {
-			$this->markTestSkipped( 'PermissionManager::userCan is unknown' );
-		}
-
 		$title = $this->getMockBuilder( '\Title' )
 			->disableOriginalConstructor()
-			->getMock();
+			->getMock();		
 
-		$permissionManager = $this->getMockBuilder( '\MediaWiki\Permissions\PermissionManager' )
-			->disableOriginalConstructor()
-			->getMock();
-
-		$permissionManager->expects( $this->any() )
-			->method(  'userCan' )
-			->will( $this->returnValue( true ) );
-
-		$instance = new PermissionManager(
-			$permissionManager
+		$mwPermissionManager = $this->getMwPermissionManagerMock(
+			[ 'userCan' => true ]
 		);
+
+		$instance = new PermissionManager( $mwPermissionManager );
 
 		$this->assertInternalType(
 			'bool',
 			$instance->userCan( 'foo', null, $title )
 		);
-	}
+	}	
 
-	public function testUserHasRight_User() {
-
-		if ( method_exists( 'MediaWiki\Permissions\PermissionManager', 'userHasRight' ) ) {
-			$this->markTestSkipped( 'Using PermissionManager::userHasRight' );
-		}
-
+	public function testUserHasRight_PermissionManager() {
 		$user = $this->getMockBuilder( '\User' )
 			->disableOriginalConstructor()
 			->getMock();
 
-		$user->expects( $this->any() )
-			->method(  'isAllowed' )
-			->will( $this->returnValue( true ) );
+		$mwPermissionManager = $this->getMwPermissionManagerMock(
+			[ 'userHasRight' => true ]
+		);		
 
-		$instance = new PermissionManager();
+		$instance = new PermissionManager( $mwPermissionManager );
 
 		$this->assertInternalType(
 			'bool',
@@ -99,32 +59,18 @@ class PermissionManagerTest extends \PHPUnit_Framework_TestCase {
 		);
 	}
 
-	public function testUserHasRight_PermissionManager() {
-
-		if ( !method_exists( 'MediaWiki\Permissions\PermissionManager', 'userHasRight' ) ) {
-			$this->markTestSkipped( 'PermissionManager::userHasRight is unknown' );
-		}
-
-		$user = $this->getMockBuilder( '\User' )
-			->disableOriginalConstructor()
-			->getMock();
-
+	private function getMwPermissionManagerMock( array $methodMocks = [] ) {
 		$permissionManager = $this->getMockBuilder( '\MediaWiki\Permissions\PermissionManager' )
 			->disableOriginalConstructor()
 			->getMock();
 
-		$permissionManager->expects( $this->any() )
-			->method(  'userHasRight' )
-			->will( $this->returnValue( true ) );
+		foreach ( $methodMocks as $method => $returnValue ) {
+			$permissionManager->expects( $this->any() )
+				->method(  $method )
+				->will( $this->returnValue( $returnValue ) );
+		}
 
-		$instance = new PermissionManager(
-			$permissionManager
-		);
-
-		$this->assertInternalType(
-			'bool',
-			$instance->userHasRight( $user, 'foo' )
-		);
+		return $permissionManager;
 	}
 
 }


### PR DESCRIPTION
Class itself is available since MW 1.33 and methods that we use
are available since 1.34