### PR TITLE
Always pass user when creating instance of ParserOptions

### DIFF
--- a/src/MediaWiki/Template/TemplateExpander.php
+++ b/src/MediaWiki/Template/TemplateExpander.php
@@ -4,6 +4,7 @@ namespace SMW\MediaWiki\Template;
 
 use Parser;
 use ParserOptions;
+use RequestContext;
 use Title;
 use RuntimeException;
 
@@ -70,7 +71,8 @@ class TemplateExpander {
 		$options = $this->parser->getOptions();
 
 		if ( !$options instanceof ParserOptions ) {
-			$options = new ParserOptions();
+			$user = RequestContext::getMain()->getUser();
+			$options = new ParserOptions( $user );
 			$options->setRemoveComments( true );
 			$options->setTidy( true );
 			$options->setMaxIncludeSize( self::MAX_INCLUDE_SIZE );

--- a/src/Parser/RecursiveTextProcessor.php
+++ b/src/Parser/RecursiveTextProcessor.php
@@ -5,6 +5,7 @@ namespace SMW\Parser;
 use MediaWiki\MediaWikiServices;
 use Parser;
 use ParserOptions;
+use RequestContext;
 use RuntimeException;
 use SMW\Localizer;
 use SMW\ParserData;
@@ -281,7 +282,8 @@ class RecursiveTextProcessor {
 				$title = Title::newFromText( 'UNKNOWN_TITLE' );
 			}
 
-			$popt = new ParserOptions();
+			$user = RequestContext::getMain()->getUser();
+			$popt = new ParserOptions( $user );
 
 			// FIXME: Remove the if block once compatibility with MW <1.31 is dropped
 			if ( !defined( '\ParserOutput::SUPPORTS_STATELESS_TRANSFORMS' ) || \ParserOutput::SUPPORTS_STATELESS_TRANSFORMS !== 1 ) {

--- a/src/Query/ResultPrinters/FeedExportPrinter.php
+++ b/src/Query/ResultPrinters/FeedExportPrinter.php
@@ -5,6 +5,7 @@ namespace SMW\Query\ResultPrinters;
 use FeedItem;
 use MediaWiki\MediaWikiServices;
 use ParserOptions;
+use RequestContext;
 use Sanitizer;
 use SMW\DataValueFactory;
 use SMW\DIWikiPage;
@@ -428,7 +429,8 @@ final class FeedExportPrinter extends ResultPrinter implements ExportPrinter {
 			return $text;
 		}
 
-		$parserOptions = new ParserOptions();
+		$user = RequestContext::getMain()->getUser();
+		$parserOptions = new ParserOptions( $user );
 
 		// FIXME: Remove the if block once compatibility with MW <1.31 is dropped
 		if ( !defined( '\ParserOutput::SUPPORTS_STATELESS_TRANSFORMS' ) || \ParserOutput::SUPPORTS_STATELESS_TRANSFORMS !== 1 ) {


### PR DESCRIPTION
Fixes:
```
[2021-10-03T04:12:01.139474+00:00] error.WARNING: [abd1405ad654229e2a932430] /wiki/Special:Ask/-5B-5BSummary:%2B-5D-5D-20-5B-5BStatus::open-5D-5D-20-5B-5BProject::MediaWiki-5D-5D/-3FThread/mainlabel%3D-2D/limit%3D100/offset%3D100/format%3Dol/default%3DNo-20open-20support-20requests.-20This-20is-20good!   ErrorException: ParserOptions being created without a UserIdentity object [Called from SMW\Parser\RecursiveTextProcessor::recursiveTagParse] {"exception":"[object] (ErrorException(code: 0): ParserOptions being created without a UserIdentity object [Called from SMW\\Parser\\RecursiveTextProcessor::recursiveTagParse] at /srv/mediawiki/tags/2021-10-01_09:34:10/extensions/SemanticMediaWiki/src/Parser/RecursiveTextProcessor.php:284)
```