### PR TITLE
SchemaContentHandler::preSaveTransform specify Content return type

### DIFF
--- a/src/MediaWiki/Content/SchemaContentHandler.php
+++ b/src/MediaWiki/Content/SchemaContentHandler.php
@@ -72,7 +72,7 @@ class SchemaContentHandler extends JsonContentHandler {
 	 *
 	 * {@inheritDoc}
 	 */
-	public function preSaveTransform( Content $content, PreSaveTransformParams $pstParams ) {
+	public function preSaveTransform( Content $content, PreSaveTransformParams $pstParams ): Content {
 		return $content->preSaveTransform(
 			$pstParams->getPage(),
 			$pstParams->getUser(),


### PR DESCRIPTION
Fix: `PHP Fatal error: Declaration of SMW\MediaWiki\Content\SchemaContentHandler::preSaveTransform(Content $content, MediaWiki\Content\Transform\PreSaveTransformParams $pstParams) must be compatible with JsonContentHandler::preSaveTransform(Content $content, MediaWiki\Content\Transform\PreSaveTransformParams $pstParams): Content `

Bug: #5037