### PR TITLE
Rename deprecated ParserOutput::getCategoryLinks()

### DIFF
--- a/src/MediaWiki/Hooks/ParserAfterTidy.php
+++ b/src/MediaWiki/Hooks/ParserAfterTidy.php
@@ -138,7 +138,7 @@ class ParserAfterTidy implements HookListener {
 		if ( $parserOutput->getProperty( 'displaytitle' ) ||
 			$parserOutput->getImages() !== [] ||
 			$parserOutput->getExtensionData( 'translate-translation-page' ) ||
-			$parserOutput->getCategoryLinks() ) {
+			$parserOutput->getCategories() ) {
 			return true;
 		}
 
@@ -199,7 +199,7 @@ class ParserAfterTidy implements HookListener {
 
 		$propertyAnnotator = $propertyAnnotatorFactory->newCategoryPropertyAnnotator(
 			$propertyAnnotator,
-			$parserOutput->getCategoryLinks()
+			array_keys( $parserOutput->getCategories() )
 		);
 
 		$propertyAnnotator = $propertyAnnotatorFactory->newMandatoryTypePropertyAnnotator(


### PR DESCRIPTION
Bug: T287216
Depends-On: Idb383d3d9ef7b76f8a0208a057a3cb8c639465c9