### PR TITLE
Correctly generate boolean WHERE conditions for PostgreSQL (fixes #5093)

### DIFF
--- a/src/SQLStore/EntityStore/DataItemHandlers/DIBooleanHandler.php
+++ b/src/SQLStore/EntityStore/DataItemHandlers/DIBooleanHandler.php
@@ -45,8 +45,15 @@ class DIBooleanHandler extends DataItemHandler {
 	 * {@inheritDoc}
 	 */
 	public function getWhereConds( DataItem $dataItem ) {
+		//PgSQL returns as t and f and need special handling http://archives.postgresql.org/pgsql-php/2010-02/msg00005.php
+		if ( $this->isDbType( 'postgres' ) ) {
+			$value = $dataItem->getBoolean() ? 't' : 'f';
+		} else {
+			$value = $dataItem->getBoolean() ? 1 : 0;
+		}
+
 		return [
-			'o_value' => $dataItem->getBoolean() ? 1 : 0,
+			'o_value' => $value,
 		];
 	}
 


### PR DESCRIPTION
PostgreSQL is not willing to compare BOOLEAN column values to integers
(e.g., `1` or `0`, as used by MySQL or Sqlite).  But, it seems happy
with the strings 't' and 'f', which are also what it emits as the values
of BOOLEAN columns.