### PR TITLE
Treat values of special properties of the type 'Page' as other properties of this type in printouts

### DIFF
--- a/includes/datavalues/SMW_DV_WikiPage.php
+++ b/includes/datavalues/SMW_DV_WikiPage.php
@@ -476,7 +476,10 @@ class SMWWikiPageValue extends SMWDataValue {
 			$text = $this->getText();
 		} elseif ( $this->getOption( self::PREFIXED_FORM, false ) ) {
 			$text = $this->getPrefixedText();
-		} elseif ( in_array( $this->getTypeID(), [ '_wpp', '_wps', '_wpu' ] ) || $this->m_fixNamespace == NS_MAIN ) {
+		} elseif (
+			in_array( $this->getTypeID(), [ '_wpp', '_wps', '_wpu', '__sup', '__sin', '__suc', '__con' ] ) ||
+			$this->m_fixNamespace === NS_MAIN
+		) {
 			$text = $this->getPrefixedText();
 		} else {
 			$text = $this->getText();


### PR DESCRIPTION
Treat values of special properties of the type 'Page'
as other properties of this type in printouts

Now SMWWikiPageValue::getWikiValue() returns the values of the properties
'Subproperty of', 'Subcategory of', 'Instance of a category',
'Associated concept' in unprefixed form (without 'Property:'),
because $this->getTypeID() in these cases is not listed in the array
[ '_wpp', '_wps', '_wpu' ].

As a result, the output of queries like

{{#ask:[[Property:+]]
| ?Subproperty of
| format = graph
| parent = Subproperty of
| limit = 2000
}}

or

{{#ask:[[Category:+]]
| ?Subcategory of
| format = graph
| parent = Subcategory of
| limit = 2000
| rankdir = RL
| graphlink = yes
}}

is broken: the edges link not to the nodes 'Property:Some property'
or 'Category:Some category' but to the nodes 'Some property' or
'Some category' not present in the query results,
thus failing to display the existing hierarchy.

The solution is to add '__sup', '__sin', '__suc', '__con'
to the array [ '_wpp', '_wps', '_wpu' ].

Fixes https://github.com/SemanticMediaWiki/SemanticResultFormats/issues/668