### PR TITLE
ParserOutput: Remove usage of deprecated getProperty/setProperty

### DIFF
--- a/src/MediaWiki/Hooks/ParserAfterTidy.php
+++ b/src/MediaWiki/Hooks/ParserAfterTidy.php
@@ -135,7 +135,14 @@ class ParserAfterTidy implements HookListener {
 
 		$parserOutput = $this->parser->getOutput();
 
-		if ( $parserOutput->getProperty( 'displaytitle' ) ||
+		if ( method_exists( $parserOutput, 'getPageProperty' ) ) {
+			$displayTitle = $parserOutput->getPageProperty( 'displaytitle' );
+		} else {
+			// MW < 1.38
+			$displayTitle = $parserOutput->getProperty( 'displaytitle' );
+		}
+
+		if ( $displayTitle ||
 			$parserOutput->getImages() !== [] ||
 			$parserOutput->getExtensionData( 'translate-translation-page' ) ||
 			$parserOutput->getCategories() ) {
@@ -216,9 +223,16 @@ class ParserAfterTidy implements HookListener {
 			$parserOutput
 		);
 
+		if ( method_exists( $parserOutput, 'getPageProperty') ) {
+			$displayTitle = $parserOutput->getPageProperty( 'displaytitle' );
+		} else {
+			// MW < 1.38
+			$displayTitle = $parserOutput->getProperty( 'displaytitle' );
+		}
+
 		$propertyAnnotator = $propertyAnnotatorFactory->newDisplayTitlePropertyAnnotator(
 			$propertyAnnotator,
-			$parserOutput->getProperty( 'displaytitle' ),
+			$displayTitle,
 			$this->parser->getDefaultSort()
 		);
 

--- a/src/ParserData.php
+++ b/src/ParserData.php
@@ -355,10 +355,18 @@ class ParserData {
 
 		$this->parserOutput->setTimestamp( wfTimestampNow() );
 
-		$this->parserOutput->setProperty(
-			'smw-semanticdata-status',
-			$this->semanticData->getProperties() !== []
-		);
+		if ( method_exists( $this->parserOutput, 'setPageProperty' ) ) {
+			$this->parserOutput->setPageProperty(
+				'smw-semanticdata-status',
+				$this->semanticData->getProperties() !== []
+			);
+		} else {
+			// MW < 1.38
+			$this->parserOutput->setProperty(
+				'smw-semanticdata-status',
+				$this->semanticData->getProperties() !== []
+			);
+		}
 	}
 
 	/**
@@ -376,7 +384,13 @@ class ParserData {
 	 * @return boolean
 	 */
 	public static function hasSemanticData( ParserOutput $parserOutput ) {
-		return (bool)$parserOutput->getProperty( 'smw-semanticdata-status' );
+		if ( method_exists( $parserOutput, 'getPageProperty' ) ) {
+			return (bool)$parserOutput->getPageProperty( 'smw-semanticdata-status' );
+		} else {
+			// MW < 1.38
+			return (bool)$parserOutput->getProperty( 'smw-semanticdata-status' );
+		}
+
 	}
 
 	/**

--- a/tests/phpunit/MediaWiki/Hooks/ParserAfterTidyTest.php
+++ b/tests/phpunit/MediaWiki/Hooks/ParserAfterTidyTest.php
@@ -206,16 +206,18 @@ class ParserAfterTidyTest extends \PHPUnit_Framework_TestCase {
 		);
 
 		$parser = $this->parserFactory->newFromTitle( $parameters['title'] );
+		$parserOutput = $parser->getOutput();
 
-		$parser->getOutput()->setProperty(
-			'smw-semanticdata-status',
-			$parameters['data-status']
-		);
+		$displayTitle = isset( $parameters['displaytitle'] ) ? $parameters['displaytitle'] : false;
 
-		$parser->getOutput()->setProperty(
-			'displaytitle',
-			isset( $parameters['displaytitle'] ) ? $parameters['displaytitle'] : false
-		);
+		if ( method_exists( $parserOutput, 'setPageProperty' ) ) {
+			$parserOutput->setPageProperty( 'smw-semanticdata-status', $parameters['data-status'] );
+			$parserOutput->setPageProperty( 'displaytitle', $displayTitle );
+		} else {
+			// MW < 1.38
+			$parserOutput->setProperty( 'smw-semanticdata-status', $parameters['data-status'] );
+			$parserOutput->setProperty( 'displaytitle', $displayTitle );
+		}
 
 		$text   = '';
 
@@ -308,10 +310,17 @@ class ParserAfterTidyTest extends \PHPUnit_Framework_TestCase {
 		$title  = Title::newFromText( __METHOD__ );
 
 		$parser = $this->parserFactory->newFromTitle( $title );
+		$parserOutput = $parser->getOutput();
 
-		$parser->getOutput()->addCategory( 'Foo', 'Foo' );
-		$parser->getOutput()->addCategory( 'Bar', 'Bar' );
-		$parser->getOutput()->setProperty( 'smw-semanticdata-status', true );
+		$parserOutput->addCategory( 'Foo', 'Foo' );
+		$parserOutput->addCategory( 'Bar', 'Bar' );
+		if ( method_exists( $parserOutput, 'setPageProperty' ) ) {
+			$parserOutput->setPageProperty( 'smw-semanticdata-status', true );
+		} else {
+			// MW < 1.38
+			$parserOutput->setProperty( 'smw-semanticdata-status', true );
+		}
+
 
 		$instance = new ParserAfterTidy(
 			$parser,


### PR DESCRIPTION
Deprecated in MW 1.38. Tested on Translatewiki.net. 