### PR TITLE
Fix: AbstractContent::getParserOutput was deprecated in MW 1.38

### DIFF
--- a/includes/ContentParser.php
+++ b/includes/ContentParser.php
@@ -164,16 +164,12 @@ class ContentParser {
 				$this->parserOutput = $contentRenderer->getParserOutput(
 					$content,
 					$this->getTitle(),
-					$revision->getId(),
-					null,
-					true
+					$revision->getId()
 				);
 			} else {
 				$this->parserOutput = $content->getParserOutput(
 					$this->getTitle(),
-					$revision->getId(),
-					null,
-					true
+					$revision->getId()
 				);
 			}
 		} catch( \MWUnknownContentModelException $e ) {

--- a/includes/ContentParser.php
+++ b/includes/ContentParser.php
@@ -2,13 +2,13 @@
 
 namespace SMW;
 
+use MediaWiki\MediaWikiServices;
 use MediaWiki\Revision\RevisionRecord;
 use MediaWiki\Revision\SlotRecord;
 use Parser;
 use ParserOptions;
 use Title;
 use User;
-use SMW\MediaWiki\RevisionGuard;
 use SMW\MediaWiki\RevisionGuardAwareTrait;
 
 /**
@@ -150,17 +150,32 @@ class ContentParser {
 		$content = $revision->getContent( SlotRecord::MAIN, RevisionRecord::RAW );
 
 		if ( !$content ) {
-			$content = $revision->getContentHandler()->makeEmptyContent();
+			$mainSlot = $revision->getSlot( SlotRecord::MAIN, RevisionRecord::RAW );
+			$contentHandlerFactory = MediaWikiServices::getInstance()->getContentHandlerFactory();
+			$handler = $contentHandlerFactory->getContentHandler( $mainSlot->getModel() );
+			$content = $handler->makeEmptyContent();
 		}
 
 		// Avoid "The content model 'xyz' is not registered on this wiki."
 		try {
-			$this->parserOutput = $content->getParserOutput(
-				$this->getTitle(),
-				$revision->getId(),
-				null,
-				true
-			);
+			$services = MediaWikiServices::getInstance();
+			if ( method_exists( $services, 'getContentRenderer' ) ) {
+				$contentRenderer = $services->getContentRenderer();
+				$this->parserOutput = $contentRenderer->getParserOutput(
+					$content,
+					$this->getTitle(),
+					$revision->getId(),
+					null,
+					true
+				);
+			} else {
+				$this->parserOutput = $content->getParserOutput(
+					$this->getTitle(),
+					$revision->getId(),
+					null,
+					true
+				);
+			}
 		} catch( \MWUnknownContentModelException $e ) {
 			$this->parserOutput = null;
 		}


### PR DESCRIPTION
Also fix invalid usage of `$revision->getContentHandler()`

Error stack trace:
```
[2021-11-09T23:55:46.766710+00:00] error.WARNING: [facd9a01bf3e133e44d51dc0] /w/api.php   PHP Deprecated: Use of AbstractContent::getParserOutput was deprecated in MediaWiki 1.38. [Called from SMW\ContentParser::fetchFromContent] {"exception":"[object] (ErrorException(code: 0): PHP Deprecated: Use of AbstractContent::getParserOutput was deprecated in MediaWiki 1.38. [Called from SMW\\ContentParser::fetchFromContent] at /srv/mediawiki/tags/2021-11-04_08:34:43/extensions/SemanticMediaWiki/includes/ContentParser.php:162)
[stacktrace]
#0 [internal function]: MWExceptionHandler::handleError()
#1 /srv/mediawiki/tags/2021-11-04_08:34:43/includes/debug/MWDebug.php(375): trigger_error()
#2 /srv/mediawiki/tags/2021-11-04_08:34:43/includes/debug/MWDebug.php(349): MWDebug::sendRawDeprecated()
#3 /srv/mediawiki/tags/2021-11-04_08:34:43/includes/debug/MWDebug.php(230): MWDebug::deprecatedMsg()
#4 /srv/mediawiki/tags/2021-11-04_08:34:43/includes/GlobalFunctions.php(1005): MWDebug::deprecated()
#5 /srv/mediawiki/tags/2021-11-04_08:34:43/includes/content/AbstractContent.php(534): wfDeprecated()
#6 /srv/mediawiki/tags/2021-11-04_08:34:43/extensions/SemanticMediaWiki/includes/ContentParser.php(162): AbstractContent->getParserOutput()
#7 /srv/mediawiki/tags/2021-11-04_08:34:43/extensions/SemanticMediaWiki/includes/ContentParser.php(129): SMW\\ContentParser->fetchFromContent()
#8 /srv/mediawiki/tags/2021-11-04_08:34:43/extensions/SemanticMediaWiki/src/MediaWiki/Hooks/LinksUpdateConstructed.php(153): SMW\\ContentParser->parse()
#9 /srv/mediawiki/tags/2021-11-04_08:34:43/extensions/SemanticMediaWiki/src/MediaWiki/Hooks/LinksUpdateConstructed.php(143): SMW\\MediaWiki\\Hooks\\LinksUpdateConstructed->reparseAndFetchSemanticData()
#10 /srv/mediawiki/tags/2021-11-04_08:34:43/extensions/SemanticMediaWiki/src/MediaWiki/Hooks/LinksUpdateConstructed.php(97): SMW\\MediaWiki\\Hooks\\LinksUpdateConstructed->updateSemanticData()
#11 /srv/mediawiki/tags/2021-11-04_08:34:43/extensions/SemanticMediaWiki/src/MediaWiki/Hooks.php(876): SMW\\MediaWiki\\Hooks\\LinksUpdateConstructed->process()
#12 /srv/mediawiki/tags/2021-11-04_08:34:43/includes/HookContainer/HookContainer.php(338): SMW\\MediaWiki\\Hooks->onLinksUpdateConstructed()
#13 /srv/mediawiki/tags/2021-11-04_08:34:43/includes/HookContainer/HookContainer.php(137): MediaWiki\\HookContainer\\HookContainer->callLegacyHook()
#14 /srv/mediawiki/tags/2021-11-04_08:34:43/includes/HookContainer/HookRunner.php(2314): MediaWiki\\HookContainer\\HookContainer->run()
#15 /srv/mediawiki/tags/2021-11-04_08:34:43/includes/deferred/LinksUpdate.php(166): MediaWiki\\HookContainer\\HookRunner->onLinksUpdateConstructed()
#16 /srv/mediawiki/tags/2021-11-04_08:34:43/includes/Storage/DerivedPageDataUpdater.php(1414): LinksUpdate->__construct()
#17 /srv/mediawiki/tags/2021-11-04_08:34:43/includes/deferred/RefreshSecondaryDataUpdate.php(84): MediaWiki\\Storage\\DerivedPageDataUpdater->getSecondaryDataUpdates()
#18 /srv/mediawiki/tags/2021-11-04_08:34:43/includes/deferred/DeferredUpdates.php(515): RefreshSecondaryDataUpdate->doUpdate()
#19 /srv/mediawiki/tags/2021-11-04_08:34:43/includes/deferred/DeferredUpdates.php(391): DeferredUpdates::attemptUpdate()
#20 /srv/mediawiki/tags/2021-11-04_08:34:43/includes/deferred/DeferredUpdates.php(234): DeferredUpdates::run()
#21 /srv/mediawiki/tags/2021-11-04_08:34:43/includes/deferred/DeferredUpdatesScope.php(264): DeferredUpdates::{closure}()
#22 /srv/mediawiki/tags/2021-11-04_08:34:43/includes/deferred/DeferredUpdatesScope.php(196): DeferredUpdatesScope->processStageQueue()
#23 /srv/mediawiki/tags/2021-11-04_08:34:43/includes/deferred/DeferredUpdates.php(237): DeferredUpdatesScope->processUpdates()
#24 /srv/mediawiki/tags/2021-11-04_08:34:43/includes/deferred/DeferredUpdatesScope.php(267): DeferredUpdates::{closure}()
#25 /srv/mediawiki/tags/2021-11-04_08:34:43/includes/deferred/DeferredUpdatesScope.php(196): DeferredUpdatesScope->processStageQueue()
#26 /srv/mediawiki/tags/2021-11-04_08:34:43/includes/deferred/DeferredUpdates.php(242): DeferredUpdatesScope->processUpdates()
#27 /srv/mediawiki/tags/2021-11-04_08:34:43/includes/MediaWiki.php(1136): DeferredUpdates::doUpdates()
#28 /srv/mediawiki/tags/2021-11-04_08:34:43/includes/MediaWiki.php(846): MediaWiki->restInPeace()
#29 /srv/mediawiki/tags/2021-11-04_08:34:43/api.php(125): MediaWiki->doPostOutputShutdown()
#30 /srv/mediawiki/tags/2021-11-04_08:34:43/api.php(45): wfApiMain()
#31 {main}
","exception_url":"/w/api.php","reqId":"facd9a01bf3e133e44d51dc0","caught_by":"mwe_handler"} []
```