### PR TITLE
Move Content::fillParserOutput method that don't belong in Content to ContentHandler

### DIFF
--- a/src/MediaWiki/Content/SchemaContentHandler.php
+++ b/src/MediaWiki/Content/SchemaContentHandler.php
@@ -3,8 +3,11 @@
 namespace SMW\MediaWiki\Content;
 
 use Content;
+use MediaWiki\Content\Renderer\ContentParseParams;
 use MediaWiki\Content\Transform\PreSaveTransformParams;
 use JsonContentHandler;
+use Title;
+use ParserOutput;
 
 /**
  * @license GNU GPL v2+
@@ -77,6 +80,25 @@ class SchemaContentHandler extends JsonContentHandler {
 			$pstParams->getPage(),
 			$pstParams->getUser(),
 			$pstParams->getParserOptions()
+		);
+	}
+
+	/**
+	 *
+	 * {@inheritDoc}
+	 */
+	protected function fillParserOutput(
+		Content $content,
+		ContentParseParams $cpoParams,
+		ParserOutput &$output
+	) {
+		$title = Title::castFromPageReference( $cpoParams->getPage() );
+		$content->fillParserOutput(
+			$title,
+			$cpoParams->getRevId(),
+			$cpoParams->getParserOptions(),
+			$cpoParams->getGenerateHtml(),
+			$output
 		);
 	}
 }


### PR DESCRIPTION
Since starting with version 1.38 we move Content::getParserOutput and Content::fillParserOutput to ContentHandler we should also move it in SemanticMediaWiki (SchemaContent -> SchemaContentHandler). But as SemanticMediaWiki used in older version, we should leave the old SchemaContent::fillParserOutput and reuse it for the new one SchemaContentHandler::fillParserOutput.

Issue: https://github.com/SemanticMediaWiki/SemanticMediaWiki/issues/5129