### PR TITLE
Do not rely on MW initialization order when being autoloaded.

### DIFF
--- a/SemanticMediaWiki.php
+++ b/SemanticMediaWiki.php
@@ -61,6 +61,12 @@ class SemanticMediaWiki {
 		}
 
 		/**
+		 * These globals are specified too early and will be overridden by normal MediaWiki
+		 * setup. They will be initialized again from extension.json.
+		 *
+		 * They are here so that SetupCheck is capable of finding messages to show setup errors
+		 * to the user.
+		 * 
 		 * @see https://www.mediawiki.org/wiki/Localisation#Localising_namespaces_and_special_page_aliases
 		 */
 		$GLOBALS['wgMessagesDirs']['SemanticMediaWiki'] = __DIR__ . '/i18n';

--- a/SemanticMediaWiki.php
+++ b/SemanticMediaWiki.php
@@ -66,7 +66,7 @@ class SemanticMediaWiki {
 		 *
 		 * They are here so that SetupCheck is capable of finding messages to show setup errors
 		 * to the user.
-		 * 
+		 *
 		 * @see https://www.mediawiki.org/wiki/Localisation#Localising_namespaces_and_special_page_aliases
 		 */
 		$GLOBALS['wgMessagesDirs']['SemanticMediaWiki'] = __DIR__ . '/i18n';

--- a/extension.json
+++ b/extension.json
@@ -25,8 +25,8 @@
 		"SemanticMediaWiki::onExtensionFunction"
 	],
 	"ExtensionMessagesFiles": {
-		"SemanticMediaWikiAlias": "/i18n/extra/SemanticMediaWiki.alias.php",
-		"SemanticMediaWikiMagic": "/i18n/extra/SemanticMediaWiki.magic.php"
+		"SemanticMediaWikiAlias": "i18n/extra/SemanticMediaWiki.alias.php",
+		"SemanticMediaWikiMagic": "i18n/extra/SemanticMediaWiki.magic.php"
 	},
 	"QUnitTestModule": {
 		"ext.smw.tests": {

--- a/extension.json
+++ b/extension.json
@@ -24,6 +24,10 @@
 	"ExtensionFunctions": [
 		"SemanticMediaWiki::onExtensionFunction"
 	],
+	"ExtensionMessagesFiles": {
+		"SemanticMediaWikiAlias": "/i18n/extra/SemanticMediaWiki.alias.php",
+		"SemanticMediaWikiMagic": "/i18n/extra/SemanticMediaWiki.magic.php"
+	},
 	"QUnitTestModule": {
 		"ext.smw.tests": {
 			"scripts": [

--- a/src/SetupCheck.php
+++ b/src/SetupCheck.php
@@ -187,8 +187,7 @@ class SetupCheck {
 		$setupCheck = new SetupCheck(
 			[
 				'SMW_VERSION'    => $version,
-				'MW_VERSION'     => $GLOBALS['wgVersion'], // MW_VERSION may not yet be defined!!
-				'wgLanguageCode' => $GLOBALS['wgLanguageCode'],
+				'MW_VERSION'     => $GLOBALS['wgVersion'] ?? 'unknown', // MW_VERSION may not yet be defined!!
 				'smwgUpgradeKey' => $GLOBALS['smwgUpgradeKey']
 			],
 			$setupFile
@@ -298,7 +297,7 @@ class SetupCheck {
 			'content' => ''
 		];
 
-		$this->languageCode = $_GET['uselang'] ?? $this->options['wgLanguageCode'] ?? 'en';
+		$this->languageCode = $_GET['uselang'] ?? 'en';
 
 		// Output forms for different error types are registered with a JSON file.
 		$this->definitions = $this->readFromFile(


### PR DESCRIPTION
Currently SMW setup uses both composer and extension.json.
During the composer autoload it executes SemanticMediaWiki.php
to export it's own constants to be used in LocalSettings.php.
Additionally it does self-check to see if it's intalled correctly.

During autoloading you can't rely on ANY part of MediaWiki to be
initialized. In this case it relied on $wgVersion and $wgLanguageCode
to be present. They will not be anymore since core is moving
dependency autoloading earlier.

In general, this pattern will be prohibited in MW 1.38 and will
be broken intentionally - relying on MW to be partially initialized
during class autoloading is a bad, bad, bad idea.

This fix is a stop-gap to avoid breaking translatewiki entirely.

Bug: https://phabricator.wikimedia.org/T295883