### PR TITLE
Update instructions for SMW 4.0.0

### DIFF
--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -45,8 +45,9 @@ Note if you have Git installed on your system add the `--prefer-source` flag to 
 
 #### Step 3
 
-Add the following line to the end of your "LocalSettings.php" file:
+Add the following two lines to the end of your "LocalSettings.php" file:
 
+    wfLoadExtension( 'SemanticMediaWiki' );
     enableSemantics( 'example.org' );
 
 Note that "example.org" should be replaced by your wiki's domain.


### PR DESCRIPTION
Refs: https://github.com/SemanticMediaWiki/SemanticMediaWiki/issues/5148#issuecomment-980507917

Nowadays we obviously need `wtfLoadExtension( )` here, too.