### PR TITLE
Fix PHPUnit autoloader path

### DIFF
--- a/src/Setup.php
+++ b/src/Setup.php
@@ -159,9 +159,8 @@ final class Setup {
 		// Convenience function for extensions depending on a SMW specific
 		// test infrastructure
 		if ( !defined( 'SMW_PHPUNIT_AUTOLOADER_FILE' ) ) {
-			define(
-				'SMW_PHPUNIT_AUTOLOADER_FILE', getenv( "MW_INSTALL_PATH" ) . "/vendor/autoload.php"
-			);
+			$smwDir = dirname( $rootDir );
+			define( 'SMW_PHPUNIT_AUTOLOADER_FILE', "$smwDir/tests/autoloader.php" );
 		}
 
 		$vars['wgLogTypes'][] = 'smw';


### PR DESCRIPTION
It seems like this change (https://github.com/SemanticMediaWiki/SemanticMediaWiki/commit/ec4b490615e80c82d52a3c94afd9492f8c400e26#diff-9d91c4baf27794a2a1921841b0d1961dc88a7b463e81902878a7b2739134fbe5) causes other extensions, like Semantic Result Formats, to not load the test aliases which breaks unit tests.

I'm not sure if I missed a discussion about this, or if I'm simply misunderstanding this, but as far as I can tell that constant is supposed to point to the test autoloader file (as it was originally) and not the Composer autoloader file.

As per https://github.com/SemanticMediaWiki/SemanticMediaWiki/blob/master/tests/autoloader.php#L9 other extensions are supposed to use that constant (as opposed to hardcoding the path).
SRF uses the constant: https://github.com/SemanticMediaWiki/SemanticResultFormats/blob/master/tests/bootstrap.php#L11
SAR hardcodes the path: https://github.com/SemanticMediaWiki/SemanticApprovedRevs/blob/master/tests/bootstrap.php#L11
The end result is that SRF unit tests [fail](https://github.com/SemanticMediaWiki/SemanticResultFormats/runs/4622962554?check_suite_focus=true#step:8:10) due to missing classes, but SAR tests [pass](https://github.com/SemanticMediaWiki/SemanticApprovedRevs/actions/runs/1618484545).

As for this PR, the `$rootDir` path now contains the "includes" directory, so it is necessary to use the parent folder. Is there a preference for using `dirname` or `../`?