### PR TITLE
Test deprecations and errors (MW 1.36 and MW 1.37)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -65,7 +65,6 @@ jobs:
       - name: Checkout Extension
         uses: actions/checkout@v2
         with:
-          repository: SemanticMediaWiki/${{ env.EXT_NAME }}
           path: ${{ env.EXT_NAME }}
 
       # Setting actions/checkout@v2 path to env.MW_EXT_PATH fails with "Repository path '/var/www/html/extensions' is not under ..."

--- a/includes/ContentParser.php
+++ b/includes/ContentParser.php
@@ -7,6 +7,7 @@ use MediaWiki\Revision\RevisionRecord;
 use MediaWiki\Revision\SlotRecord;
 use Parser;
 use ParserOptions;
+use RequestContext;
 use Title;
 use User;
 use SMW\MediaWiki\RevisionGuardAwareTrait;
@@ -195,6 +196,7 @@ class ContentParser {
 			}
 		}
 
+		$user = $user ?? RequestContext::getMain()->getUser();
 		$parserOptions = new ParserOptions( $user );
 
 		// Use the InterfaceMessage marker to skip InTextAnnotationParser

--- a/includes/SMW_PageSchemas.php
+++ b/includes/SMW_PageSchemas.php
@@ -261,14 +261,12 @@ class SMWPageSchemas extends PSExtensionHandler {
 	 * passed-in Page Schemas XML object.
 	 */
 	public static function generatePages( $pageSchemaObj, $selectedPages ) {
-		global $wgUser;
-
 		$datatypeLabels = smwfContLang()->getDatatypeLabels();
 		$pageTypeLabel = $datatypeLabels['_wpg'];
 
 		$jobs = [];
 		$jobParams = [];
-		$jobParams['user_id'] = $wgUser->getId();
+		$jobParams['user_id'] = \RequestContext::getMain()->getUser()->getId();
 
 		// First, create jobs for all "connecting properties".
 		$psTemplates = $pageSchemaObj->getTemplates();

--- a/includes/SMW_PageSchemas.php
+++ b/includes/SMW_PageSchemas.php
@@ -266,7 +266,7 @@ class SMWPageSchemas extends PSExtensionHandler {
 
 		$jobs = [];
 		$jobParams = [];
-		$jobParams['user_id'] = \RequestContext::getMain()->getUser()->getId();
+		$jobParams['user_id'] = RequestContext::getMain()->getUser()->getId();
 
 		// First, create jobs for all "connecting properties".
 		$psTemplates = $pageSchemaObj->getTemplates();

--- a/src/Importer/ContentCreators/TextContentCreator.php
+++ b/src/Importer/ContentCreators/TextContentCreator.php
@@ -4,6 +4,7 @@ namespace SMW\Importer\ContentCreators;
 
 use ContentHandler;
 use Onoi\MessageReporter\MessageReporterAwareTrait;
+use RequestContext;
 use SMW\Importer\ContentCreator;
 use SMW\Importer\ImportContents;
 use SMW\MediaWiki\Database;
@@ -158,7 +159,7 @@ class TextContentCreator implements ContentCreator {
 		if ( method_exists( $page, 'doUserEditContent' ) ) {
 			// MW 1.36+
 			// Use the global user if necessary (same as doEditContent())
-			$user = $user ?? \RequestContext::getMain()->getUser();
+			$user = $user ?? RequestContext::getMain()->getUser();
 			$status = $page->doUserEditContent(
 				$content,
 				$user,

--- a/src/Importer/ContentCreators/TextContentCreator.php
+++ b/src/Importer/ContentCreators/TextContentCreator.php
@@ -157,6 +157,8 @@ class TextContentCreator implements ContentCreator {
 
 		if ( method_exists( $page, 'doUserEditContent' ) ) {
 			// MW 1.36+
+			// Use the global user if necessary (same as doEditContent())
+			$user = $user ?? \RequestContext::getMain()->getUser();
 			$status = $page->doUserEditContent(
 				$content,
 				$user,

--- a/src/MediaWiki/Jobs/ParserCachePurgeJob.php
+++ b/src/MediaWiki/Jobs/ParserCachePurgeJob.php
@@ -2,6 +2,7 @@
 
 namespace SMW\MediaWiki\Jobs;
 
+use RequestContext;
 use SMW\MediaWiki\Job;
 use SMW\ApplicationFactory;
 use Title;
@@ -45,7 +46,7 @@ class ParserCachePurgeJob extends Job {
 		if ( $this->hasParameter( 'user' ) ) {
 			$causeAgent = $this->getParameter( 'user' );
 		} else {
-			$causeAgent = \RequestContext::getMain()->getUser()->getName;
+			$causeAgent = RequestContext::getMain()->getUser()->getName;
 		}
 
 		if ( $page === null ) {

--- a/src/MediaWiki/Jobs/ParserCachePurgeJob.php
+++ b/src/MediaWiki/Jobs/ParserCachePurgeJob.php
@@ -45,7 +45,7 @@ class ParserCachePurgeJob extends Job {
 		if ( $this->hasParameter( 'user' ) ) {
 			$causeAgent = $this->getParameter( 'user' );
 		} else {
-			$causeAgent = $GLOBALS['wgUser']->getName();
+			$causeAgent = \RequestContext::getMain()->getUser()->getName;
 		}
 
 		if ( $page === null ) {

--- a/src/Protection/EditProtectionUpdater.php
+++ b/src/Protection/EditProtectionUpdater.php
@@ -4,6 +4,7 @@ namespace SMW\Protection;
 
 use Psr\Log\LoggerAwareInterface;
 use Psr\Log\LoggerInterface;
+use RequestContext;
 use SMW\DIProperty;
 use SMW\MediaWiki\Hooks\ArticleProtectComplete;
 use SMW\Message;
@@ -56,7 +57,7 @@ class EditProtectionUpdater implements LoggerAwareInterface {
 		$this->user = $user;
 
 		if ( $this->user === null ) {
-			$this->user = \RequestContext::getMain()->getUser();
+			$this->user = RequestContext::getMain()->getUser();
 		}
 	}
 

--- a/src/Protection/EditProtectionUpdater.php
+++ b/src/Protection/EditProtectionUpdater.php
@@ -56,7 +56,7 @@ class EditProtectionUpdater implements LoggerAwareInterface {
 		$this->user = $user;
 
 		if ( $this->user === null ) {
-			$this->user = $GLOBALS['wgUser'];
+			$this->user = \RequestContext::getMain()->getUser();
 		}
 	}
 

--- a/src/Services/mediawiki.php
+++ b/src/Services/mediawiki.php
@@ -56,7 +56,24 @@ return [
 	 */
 	'WikiImporter' => function( $containerBuilder, \ImportSource $importSource ) {
 		$containerBuilder->registerExpectedReturnType( 'WikiImporter', '\WikiImporter' );
-		return new WikiImporter( $importSource, $containerBuilder->create( 'MainConfig' ) );
+		if ( version_compare( MW_VERSION, '1.37', '<' ) ) {
+			return new WikiImporter( $importSource, $containerBuilder->create( 'MainConfig' ) );
+		} else {
+			$services = MediaWikiServices::getInstance();
+			return new WikiImporter(
+				$importSource,
+				$containerBuilder->create( 'MainConfig' ),
+				$services->getHookContainer(),
+				$services->getContentLanguage(),
+				$services->getNamespaceInfo(),
+				$services->getTitleFactory(),
+				$services->getWikiPageFactory(),
+				$services->getWikiRevisionUploadImporter(),
+				$services->getPermissionManager(),
+				$services->getContentHandlerFactory(),
+				$services->getSlotRoleRegistry()
+			);
+		}
 	},
 
 	/**

--- a/tests/phpunit/DatabaseTestCase.php
+++ b/tests/phpunit/DatabaseTestCase.php
@@ -112,7 +112,8 @@ abstract class DatabaseTestCase extends \PHPUnit_Framework_TestCase {
 		// Reset $wgUser, which is probably 127.0.0.1, as its loaded data is probably not valid
 		// @todo Should we start setting $wgUser to something nondeterministic
 		//  to encourage tests to be updated to not depend on it?
-		$GLOBALS['wgUser']->clearInstanceCache( $GLOBALS['wgUser']->mFrom );
+		$user = \RequestContext::getMain()->getUser();
+		$user->clearInstanceCache( $user->mFrom );
 
 		ObjectCache::$instances[CACHE_DB] = new HashBagOStuff();
 

--- a/tests/phpunit/DatabaseTestCase.php
+++ b/tests/phpunit/DatabaseTestCase.php
@@ -12,6 +12,7 @@ use SMW\Tests\Utils\Connection\TestDatabaseTableBuilder;
 use SMWExporter as Exporter;
 use HashBagOStuff;
 use ObjectCache;
+use RequestContext;
 
 /**
  * @group semantic-mediawiki
@@ -112,7 +113,7 @@ abstract class DatabaseTestCase extends \PHPUnit_Framework_TestCase {
 		// Reset $wgUser, which is probably 127.0.0.1, as its loaded data is probably not valid
 		// @todo Should we start setting $wgUser to something nondeterministic
 		//  to encourage tests to be updated to not depend on it?
-		$user = \RequestContext::getMain()->getUser();
+		$user = RequestContext::getMain()->getUser();
 		$user->clearInstanceCache( $user->mFrom );
 
 		ObjectCache::$instances[CACHE_DB] = new HashBagOStuff();

--- a/tests/phpunit/Integration/Elastic/DefaultConfigTest.php
+++ b/tests/phpunit/Integration/Elastic/DefaultConfigTest.php
@@ -50,7 +50,7 @@ class DefaultConfigTest extends \PHPUnit_Framework_TestCase {
 
 	public function defaultSettingsProvider() {
 
-		$defaultSettings = SemanticMediaWiki::getDefaultSettings();
+		$defaultSettings = \SemanticMediaWiki::getDefaultSettings();
 
 		foreach ( $defaultSettings['smwgElasticsearchConfig'] as $key => $configs ) {
 

--- a/tests/phpunit/Integration/Parser/InTextAnnotationParserTemplateTransclusionTest.php
+++ b/tests/phpunit/Integration/Parser/InTextAnnotationParserTemplateTransclusionTest.php
@@ -5,6 +5,7 @@ namespace SMW\Tests\Integration\Parser;
 use ParserOutput;
 use ParserOptions;
 use MediaWiki\MediaWikiServices;
+use RequestContext;
 use SMW\ApplicationFactory;
 use SMW\Tests\TestEnvironment;
 use Title;
@@ -58,7 +59,8 @@ class InTextAnnotationParserTemplateTransclusionTest extends \PHPUnit_Framework_
 	private function runTemplateTransclusion( Title $title, $text, $return ) {
 
 		$parser = MediaWikiServices::getInstance()->getParserFactory()->create();
-		$options = new ParserOptions;
+		$user = RequestContext::getMain()->getUser();
+		$options = new ParserOptions( $user );
 		$options->setTemplateCallback( function ( $title, $parser = false ) use ( $return ) {
 
 			$text = $return;

--- a/tests/phpunit/Integration/SQLStore/RefreshSQLStoreDBIntegrationTest.php
+++ b/tests/phpunit/Integration/SQLStore/RefreshSQLStoreDBIntegrationTest.php
@@ -98,8 +98,8 @@ class RefreshSQLStoreDBIntegrationTest extends DatabaseTestCase {
 		$provider = [];
 
 	//	$provider[] = array( NS_MAIN, 'withInterWiki', 'commons' );
-		$provider[] = [ NS_MAIN, 'normalTite', '' ];
-		$provider[] = [ NS_MAIN, 'useUpdateJobs', '' ];
+		$provider[] = [ NS_MAIN, 'NormalTite', '' ];
+		$provider[] = [ NS_MAIN, 'UseUpdateJobs', '' ];
 
 		return $provider;
 	}

--- a/tests/phpunit/JSONScriptServicesTestCaseRunner.php
+++ b/tests/phpunit/JSONScriptServicesTestCaseRunner.php
@@ -101,7 +101,9 @@ abstract class JSONScriptServicesTestCaseRunner extends JSONScriptTestCaseRunner
 				'smwgDVFeatures' => $GLOBALS['smwgDVFeatures'] & ~SMW_DV_NUMV_USPACE,
 				'smwgCacheUsage' => [
 					'api.browse' => false
-				] + $GLOBALS['smwgCacheUsage']
+				] + $GLOBALS['smwgCacheUsage'],
+				// MW 1.37 defaults to html5 fragment mode. Force legacy mode for consistency.
+				'wgFragmentMode' => [ 'legacy', 'html5' ],
 			]
 		);
 	}

--- a/tests/phpunit/Utils/Page/PageEditor.php
+++ b/tests/phpunit/Utils/Page/PageEditor.php
@@ -5,6 +5,7 @@ namespace SMW\Tests\Utils\Page;
 use CommentStoreComment;
 use MediaWiki\Revision\SlotRecord;
 use MediaWiki\Storage\RevisionSlotsUpdate;
+use RequestContext;
 use RuntimeException;
 use Title;
 use WikiPage;
@@ -64,7 +65,7 @@ class PageEditor {
 		$content = new \WikitextContent( $pageContent );
 
 		// Simplified implementation of WikiPage::doUserEditContent() from MW 1.36
-		$performer = \RequestContext::getMain()->getUser();
+		$performer = RequestContext::getMain()->getUser();
 		$summary = CommentStoreComment::newUnsavedComment( trim( $editMessage ) );
 
 		$slotsUpdate = new RevisionSlotsUpdate();

--- a/tests/phpunit/Utils/Page/PageEditor.php
+++ b/tests/phpunit/Utils/Page/PageEditor.php
@@ -70,9 +70,9 @@ class PageEditor {
 		$slotsUpdate = new RevisionSlotsUpdate();
 		$slotsUpdate->modifyContent( SlotRecord::MAIN, $content );
 
-		$this->getPage()->newPageUpdater( $performer, $slotsUpdate )
-			->setContent( SlotRecord::MAIN, $content )
-			->saveRevision( $summary );
+		$updater = $this->getPage()->newPageUpdater( $performer, $slotsUpdate );
+		$updater->setContent( SlotRecord::MAIN, $content );
+		$updater->saveRevision( $summary );
 
 		return $this;
 	}

--- a/tests/phpunit/Utils/Page/PageEditor.php
+++ b/tests/phpunit/Utils/Page/PageEditor.php
@@ -2,6 +2,9 @@
 
 namespace SMW\Tests\Utils\Page;
 
+use CommentStoreComment;
+use MediaWiki\Revision\SlotRecord;
+use MediaWiki\Storage\RevisionSlotsUpdate;
 use RuntimeException;
 use Title;
 use WikiPage;
@@ -60,10 +63,16 @@ class PageEditor {
 
 		$content = new \WikitextContent( $pageContent );
 
-		$this->getPage()->doEditContent(
-			$content,
-			$editMessage
-		);
+		// Simplified implementation of WikiPage::doUserEditContent() from MW 1.36
+		$performer = \RequestContext::getMain()->getUser();
+		$summary = CommentStoreComment::newUnsavedComment( trim( $editMessage ) );
+
+		$slotsUpdate = new RevisionSlotsUpdate();
+		$slotsUpdate->modifyContent( SlotRecord::MAIN, $content );
+
+		$this->getPage()->newPageUpdater( $performer, $slotsUpdate )
+			->setContent( SlotRecord::MAIN, $content )
+			->saveRevision( $summary );
 
 		return $this;
 	}

--- a/tests/phpunit/Utils/PageCreator.php
+++ b/tests/phpunit/Utils/PageCreator.php
@@ -106,9 +106,9 @@ class PageCreator {
 		$slotsUpdate = new RevisionSlotsUpdate();
 		$slotsUpdate->modifyContent( SlotRecord::MAIN, $content );
 
-		$this->getPage()->newPageUpdater( $performer, $slotsUpdate )
-			->setContent( SlotRecord::MAIN, $content )
-			->saveRevision( $summary );
+		$updater = $this->getPage()->newPageUpdater( $performer, $slotsUpdate );
+		$updater->setContent( SlotRecord::MAIN, $content );
+		$updater->saveRevision( $summary );
 
 		TestEnvironment::executePendingDeferredUpdates();
 

--- a/tests/phpunit/Utils/PageCreator.php
+++ b/tests/phpunit/Utils/PageCreator.php
@@ -6,6 +6,7 @@ use CommentStoreComment;
 use MediaWiki\MediaWikiServices;
 use MediaWiki\Revision\SlotRecord;
 use MediaWiki\Storage\RevisionSlotsUpdate;
+use RequestContext;
 use SMW\Tests\TestEnvironment;
 use SMW\Tests\Utils\Mock\MockSuperUser;
 use Title;
@@ -101,7 +102,7 @@ class PageCreator {
 		);
 
 		// Simplified implementation of WikiPage::doUserEditContent() from MW 1.36
-		$performer = \RequestContext::getMain()->getUser();
+		$performer = RequestContext::getMain()->getUser();
 		$summary = CommentStoreComment::newUnsavedComment( trim( $editMessage ) );
 
 		$slotsUpdate = new RevisionSlotsUpdate();

--- a/tests/phpunit/Utils/PageCreator.php
+++ b/tests/phpunit/Utils/PageCreator.php
@@ -3,6 +3,7 @@
 namespace SMW\Tests\Utils;
 
 use CommentStoreComment;
+use MediaWiki\MediaWikiServices;
 use MediaWiki\Revision\SlotRecord;
 use MediaWiki\Storage\RevisionSlotsUpdate;
 use SMW\Tests\TestEnvironment;
@@ -128,13 +129,8 @@ class PageCreator {
 		$reason = "integration test";
 		$source = $this->getPage()->getTitle();
 
-		if ( class_exists( '\MovePage' ) ) {
-			$mp = new \MovePage( $source, $target );
-			$status = $mp->move( new MockSuperUser(), $reason, $isRedirect );
-		} else {
-			// deprecated since 1.25, use the MovePage class instead
-			$status = $source->moveTo( $target, false, $reason, $isRedirect );
-		}
+		$mp = MediaWikiServices::getInstance()->getMovePageFactory()->newMovePage( $source, $target );
+		$status = $mp->move( new MockSuperUser(), $reason, $isRedirect );
 
 		TestEnvironment::executePendingDeferredUpdates();
 

--- a/tests/phpunit/Utils/Runners/XmlImportRunner.php
+++ b/tests/phpunit/Utils/Runners/XmlImportRunner.php
@@ -4,6 +4,7 @@ namespace SMW\Tests\Utils\Runners;
 
 use ImportReporter;
 use ImportStreamSource;
+use MediaWiki\MediaWikiServices;
 use RequestContext;
 use RuntimeException;
 use SMW\Tests\TestEnvironment;
@@ -83,7 +84,24 @@ class XmlImportRunner {
 			$config = \ConfigFactory::getDefaultInstance()->makeConfig( 'main' );
 		}
 
-		$importer = new WikiImporter( $source->value, $config );
+		if ( version_compare( MW_VERSION, '1.37', '<' ) ) {
+			$importer = new WikiImporter( $source->value, $config );
+		} else {
+			$services = MediaWikiServices::getInstance();
+			$importer = new WikiImporter(
+				$source->value,
+				$config,
+				$services->getHookContainer(),
+				$services->getContentLanguage(),
+				$services->getNamespaceInfo(),
+				$services->getTitleFactory(),
+				$services->getWikiPageFactory(),
+				$services->getWikiRevisionUploadImporter(),
+				$services->getPermissionManager(),
+				$services->getContentHandlerFactory(),
+				$services->getSlotRoleRegistry()
+			);
+		}
 		$importer->setDebug( $this->verbose );
 
 		$reporter = new ImportReporter(


### PR DESCRIPTION
This addresses various MW 1.36 and 1.37 deprecations and some test errors picked up during unit test runs (SMW and indirectly SRF).

I removed the repository reference in the CI action because it prevents checking out the forked repo when running from the forked repo.

I have not done much manual testing with these changes. I'm primarily looking at MW 1.37 and relying on the unit tests.