### PR TITLE
Move message listingcontinuesabbrev to SMW

### DIFF
--- a/i18n/ace.json
+++ b/i18n/ace.json
@@ -5,5 +5,6 @@
 		]
 	},
 	"browse": "Rawôn wiki",
-	"smw-livepreview-loading": "Pumasoë..."
+	"smw-livepreview-loading": "Pumasoë...",
+	"smw-listingcontinuesabbrev": "samb."
 }

--- a/i18n/ady-cyrl.json
+++ b/i18n/ady-cyrl.json
@@ -5,5 +5,6 @@
 			"SamGamgee"
 		]
 	},
-	"browse": "НэкIубгъомэ ашъхьырыплъ"
+	"browse": "НэкIубгъомэ ашъхьырыплъ",
+	"smw-listingcontinuesabbrev": "пэубл."
 }

--- a/i18n/af.json
+++ b/i18n/af.json
@@ -118,5 +118,6 @@
 	"smw-populatehashfield-incomplete": "Die <code> smw_hash </code> -populasie is tydens die opstelling oorgeslaan; die [https://www.semantic-mediawiki.org/wiki/Help:populateHashField.php populateHashField.php] -skrif is nodig om uitgevoer te word.",
 	"smw-elastic-rebuildelasticindex-run-incomplete": "Die <code> ElasticStore </code> is gekies as [https://www.semantic-mediawiki.org/wiki/Help:smwgDefaultStore standaardwinkel], maar die uitbreiding kon nog geen rekord vind dat die [https: / /www.semantic-mediawiki.org/wiki/Help:rebuildElasticIndex.php buildElasticIndex.php] script is uitgevoer, voer asseblief die script uit soos voorgeskryf.",
 	"smw-pendingtasks-setup-intro": "Die {{PLURAL:$1|installasie|opgradering}} van <b> Semantic MediaWiki </b> het die volgende take geklassifiseer as [https://www.semantic-mediawiki.org/wiki/Help:Upgrade/Incomplete_upgrade onvolledig] en daar word van 'n administrateur (of gebruiker met voldoende regte) verwag om hierdie take op te los voordat gebruikers voortgaan om inhoud te skep of te verander. Die {{PLURAL:$1|installasie|opgradering}} van <b> Semantic MediaWiki </b> het die die volgende take te volg as [https://www.semantic-mediawiki.org/wiki/Help:Upgrade/Incomplete_upgrade onvolledig] en daar word van 'n administrateur (of gebruiker met voldoende regte) verwag om hierdie take op te los voordat gebruikers voortgaan om inhoud te skep of te verander.",
-	"smw-pendingtasks-setup-tasks": "take"
+	"smw-pendingtasks-setup-tasks": "take",
+	"smw-listingcontinuesabbrev": "vervolg"
 }

--- a/i18n/aln.json
+++ b/i18n/aln.json
@@ -40,5 +40,6 @@
 	"smw_parseerror": "Vlera e dhënë nuk është kuptuar.",
 	"smw_notitle": "\"$1\" nuk mund të përdoret si një emër faqe në këtë wiki.",
 	"smw_wrong_namespace": "Vetëm faqet në hapësirën \"$1\" lejohen këtu.",
-	"smw_unknowntype": "Lloj i pasuportuar \"$1\" të përcaktuara për pronën."
+	"smw_unknowntype": "Lloj i pasuportuar \"$1\" të përcaktuara për pronën.",
+	"smw-listingcontinuesabbrev": "vazh."
 }

--- a/i18n/am.json
+++ b/i18n/am.json
@@ -5,5 +5,6 @@
 		]
 	},
 	"smw_result_next": "ቀጥሎ",
-	"smw-livepreview-loading": "በመጫን ላይ ነው..."
+	"smw-livepreview-loading": "በመጫን ላይ ነው...",
+	"smw-listingcontinuesabbrev": "(ተቀጥሏል)"
 }

--- a/i18n/an.json
+++ b/i18n/an.json
@@ -10,5 +10,6 @@
 	"smw_nodatetime": "No s'ha entendito a calendata \"$1\".",
 	"browse": "Explorar o wiki",
 	"smw-livepreview-loading": "Cargando…",
-	"smw-help": "Aduya"
+	"smw-help": "Aduya",
+	"smw-listingcontinuesabbrev": "cont."
 }

--- a/i18n/ang.json
+++ b/i18n/ang.json
@@ -13,5 +13,6 @@
 	"smw-expand": "Brǣde",
 	"smw-copy": "Biwrītan",
 	"smw-jsonview-expand-title": "Aþenaþ þe JSON ansyn",
-	"smw-jsonview-collapse-title": "Tofealleþ þa JSON ansyn"
+	"smw-jsonview-collapse-title": "Tofealleþ þa JSON ansyn",
+	"smw-listingcontinuesabbrev": "mā"
 }

--- a/i18n/anp.json
+++ b/i18n/anp.json
@@ -4,5 +4,6 @@
 			"Angpradesh"
 		]
 	},
-	"browse": "विकि देखऽ"
+	"browse": "विकि देखऽ",
+	"smw-listingcontinuesabbrev": "जारी"
 }

--- a/i18n/ar.json
+++ b/i18n/ar.json
@@ -1008,5 +1008,6 @@
 	"smw-datavalue-constraint-schema-category-invalid-type": "المخطط \"$1\" المشروح غير صالح لتصنيف؛ فهو يتطلب نوع \"$2\".",
 	"smw-datavalue-constraint-schema-property-invalid-type": "المخطط \"$1\" المشروح غير صالح لخاصية؛ فهو يتطلب نوع \"$2\".",
 	"smw-entity-examiner-associated-revision-mismatch": "مراجعة",
-	"smw-entity-examiner-deferred-fake": "مزيف"
+	"smw-entity-examiner-deferred-fake": "مزيف",
+	"smw-listingcontinuesabbrev": "(تابع)"
 }

--- a/i18n/arc.json
+++ b/i18n/arc.json
@@ -46,5 +46,6 @@
 	"smw_result_prev": "ܕܩܕܡ",
 	"smw_result_next": "ܕܒܬܪ",
 	"smw_result_results": "ܦܠܛ̈ܐ",
-	"smw_result_noresults": "ܠܝܬ ܦܠܛ̈ܐ."
+	"smw_result_noresults": "ܠܝܬ ܦܠܛ̈ܐ.",
+	"smw-listingcontinuesabbrev": "(ܫܘܠܡܐ)"
 }

--- a/i18n/arq.json
+++ b/i18n/arq.json
@@ -4,5 +4,6 @@
 			"Oldstoneage"
 		]
 	},
-	"browse": "صفّح فل ويكي"
+	"browse": "صفّح فل ويكي",
+	"smw-listingcontinuesabbrev": "يُتبع"
 }

--- a/i18n/ary.json
+++ b/i18n/ary.json
@@ -11,5 +11,6 @@
 	"smw-admin-supplementary-elastic-version-info": "نسخة",
 	"smw-admin-supplementary-elastic-config": "ريكلاج",
 	"smw-livepreview-loading": "tssna wa7d chwiya kaytcharja ....",
-	"smw-search-hide": "خبي"
+	"smw-search-hide": "خبي",
+	"smw-listingcontinuesabbrev": "لكمالة"
 }

--- a/i18n/arz.json
+++ b/i18n/arz.json
@@ -179,5 +179,6 @@
 	"smw_unknowntype": "نوع غير مدعوم \"$1\" لتعريف الممتلكات.",
 	"smw_concept_header": "صفحات المبدأ \"$1\"",
 	"smw_conceptarticlecount": "عرض {{PLURAL:$1||صفحه واحده تنتمي|صفحتين تنتميان|$1 صفحات تنتمي|$1 صفحه تنتمي}} إلى هذا المبدأ.",
-	"smw-livepreview-loading": "تحميل…"
+	"smw-livepreview-loading": "تحميل…",
+	"smw-listingcontinuesabbrev": "متابعه"
 }

--- a/i18n/as.json
+++ b/i18n/as.json
@@ -11,5 +11,6 @@
 	"smw-upgrade-maintenance-why-title": "মই এই পৃষ্ঠাখন কিয় দেখা পাওঁ?",
 	"browse": "ব্ৰাউজ ৱিকি",
 	"smw_result_results": "ফলাফল",
-	"smw-livepreview-loading": "ল'ড হৈ আছে…"
+	"smw-livepreview-loading": "ল'ড হৈ আছে…",
+	"smw-listingcontinuesabbrev": "আগলৈ"
 }

--- a/i18n/ast.json
+++ b/i18n/ast.json
@@ -651,5 +651,6 @@
 	"smw-ask-message-keyword-type": "Esta busca casa cola condición <code><nowiki>$1</nowiki></code>.",
 	"smw-remote-source-unavailable": "Nun pudo coneutase col destín remotu «$1».",
 	"smw-remote-source-disabled": "L'orixe '''$1''' desactivó l'encontu de solicitúes remotes.",
-	"smw-pendingtasks-setup-tasks": "Xeres"
+	"smw-pendingtasks-setup-tasks": "Xeres",
+	"smw-listingcontinuesabbrev": "cont."
 }

--- a/i18n/avk.json
+++ b/i18n/avk.json
@@ -5,5 +5,6 @@
 		]
 	},
 	"browse": "Exulera va wiki",
-	"smw-livepreview-loading": "Vajas…"
+	"smw-livepreview-loading": "Vajas…",
+	"smw-listingcontinuesabbrev": "loon"
 }

--- a/i18n/awa.json
+++ b/i18n/awa.json
@@ -7,5 +7,6 @@
 	"smw_purge": "रिफ्रेश",
 	"browse": "विकि देखा जाय",
 	"smw_browselink": "खाश जानकारी",
-	"prefs-smw": "शब्दार्थगत मीडियाविकी"
+	"prefs-smw": "शब्दार्थगत मीडियाविकी",
+	"smw-listingcontinuesabbrev": "आगे."
 }

--- a/i18n/az.json
+++ b/i18n/az.json
@@ -34,5 +34,6 @@
 	"smw-limitreport-pagepurge-storeupdatetime-value": "$1 {{PLURAL:$1|saniyə|saniyə}}",
 	"smw-help": "Kömək",
 	"smw-processing": "İşləyir ...",
-	"smw-redirect-target-unresolvable": "Hədəf \"$1\" səbəbindən həll olunmayacaq"
+	"smw-redirect-target-unresolvable": "Hədəf \"$1\" səbəbindən həll olunmayacaq",
+	"smw-listingcontinuesabbrev": "(davam)"
 }

--- a/i18n/azb.json
+++ b/i18n/azb.json
@@ -9,5 +9,6 @@
 	"browse": "ویکی یه باخیش",
 	"smw_browselink": "اوزللیکلری گؤزدن کئچیر",
 	"smw_browse_go": "گئت",
-	"smw-livepreview-loading": "یوکلنیر..."
+	"smw-livepreview-loading": "یوکلنیر...",
+	"smw-listingcontinuesabbrev": "(قالانی)"
 }

--- a/i18n/ba.json
+++ b/i18n/ba.json
@@ -14,5 +14,6 @@
 	"smw_browselink": "Үҙенсәлектәрҙе ҡарарға",
 	"smw-admin-setupsuccess": "Һаҡлау системаһы уңышлы ҡуйылды",
 	"smw-livepreview-loading": "Сығарыу...",
-	"smw-format-datatable-toolbar-export": "Экспорт"
+	"smw-format-datatable-toolbar-export": "Экспорт",
+	"smw-listingcontinuesabbrev": "дауамы"
 }

--- a/i18n/bar.json
+++ b/i18n/bar.json
@@ -6,5 +6,6 @@
 	},
 	"smw_purge": "Neich loon",
 	"smw_browselink": "D' Attributt åzoang",
-	"smw-livepreview-loading": "Loon ..."
+	"smw-livepreview-loading": "Loon ...",
+	"smw-listingcontinuesabbrev": "(Fortsetzung)"
 }

--- a/i18n/bcc.json
+++ b/i18n/bcc.json
@@ -8,5 +8,6 @@
 	"smw-upgrade-error-why-title": "من چۏن کُت کہ اے ارور پݔش آتک؟",
 	"smw-upgrade-error-how-title": "چۏن اے ارورءَ شرّ بکنوں؟",
 	"smw_printername_category": "تهر",
-	"smw-livepreview-loading": "...بار بیت"
+	"smw-livepreview-loading": "...بار بیت",
+	"smw-listingcontinuesabbrev": "دامدار."
 }

--- a/i18n/bcl.json
+++ b/i18n/bcl.json
@@ -13,5 +13,6 @@
 	"smw-upgrade-maintenance-why-title": "Tano ko nahihiling an pahina na ni?",
 	"smw-paramdesc-table-transpose": "Ipahiling an mga pamayuhan kan lamesa sa paaging patindog asin an mga resulta sa paaging pahigda",
 	"browse": "Browse wiki",
-	"smw-livepreview-loading": "Pigkakarga…"
+	"smw-livepreview-loading": "Pigkakarga…",
+	"smw-listingcontinuesabbrev": "kasumpay"
 }

--- a/i18n/be-tarask.json
+++ b/i18n/be-tarask.json
@@ -428,5 +428,6 @@
 	"smw-datavalue-external-formatter-invalid-uri": "«$1» зьяўляецца няправільным URL-адрасам.",
 	"smw-datavalue-parse-error": "Дадзенае значэньне «$1» не было распазнанае.",
 	"smw-no-data-available": "Няма даступных зьвестак.",
-	"smw-es-replication-error-no-connection": "Сачэньне за паўтарэньнем ня можа выканаць праверкі, бо ня можа ўсталяваць сувязь з клястэрам Elasticsearch."
+	"smw-es-replication-error-no-connection": "Сачэньне за паўтарэньнем ня можа выканаць праверкі, бо ня можа ўсталяваць сувязь з клястэрам Elasticsearch.",
+	"smw-listingcontinuesabbrev": " (працяг)"
 }

--- a/i18n/be.json
+++ b/i18n/be.json
@@ -28,5 +28,6 @@
 	"smw-admin-installfile": "Калі ў Вас узнікнуць праблемы з усталяваннем, пачніце з рэкамендацыяў у <a href=\"https://github.com/SemanticMediaWiki/SemanticMediaWiki/blob/master/docs/INSTALL.md\">файле INSTALL</a>.",
 	"smw-ui-tooltip-title-property": "Уласцівасць",
 	"smw-livepreview-loading": "Счытваем…",
-	"smw-help": "Даведка"
+	"smw-help": "Даведка",
+	"smw-listingcontinuesabbrev": "працяг"
 }

--- a/i18n/bg.json
+++ b/i18n/bg.json
@@ -165,5 +165,6 @@
 	"smw-format-datatable-processing": "Обработка...",
 	"smw-format-datatable-search": "Търсене:",
 	"smw-format-datatable-next": "Следваща",
-	"smw-help": "Помощ"
+	"smw-help": "Помощ",
+	"smw-listingcontinuesabbrev": "продълж."
 }

--- a/i18n/bgn.json
+++ b/i18n/bgn.json
@@ -4,5 +4,6 @@
 			"Baloch Afghanistan"
 		]
 	},
-	"browse": "ویکی بروز"
+	"browse": "ویکی بروز",
+	"smw-listingcontinuesabbrev": "(ادامه)"
 }

--- a/i18n/bho.json
+++ b/i18n/bho.json
@@ -5,5 +5,6 @@
 			"SatyamMishra"
 		]
 	},
-	"browse": "विकि ब्राउज करी"
+	"browse": "विकि ब्राउज करी",
+	"smw-listingcontinuesabbrev": "जारी..."
 }

--- a/i18n/bjn.json
+++ b/i18n/bjn.json
@@ -5,5 +5,6 @@
 		]
 	},
 	"browse": "Jalajahi wiki",
-	"smw-livepreview-loading": "Ma'unggah..."
+	"smw-livepreview-loading": "Ma'unggah...",
+	"smw-listingcontinuesabbrev": "samb."
 }

--- a/i18n/bn.json
+++ b/i18n/bn.json
@@ -207,5 +207,6 @@
 	"smw-ask-tab-extra": "অতিরিক্ত",
 	"smw-ask-tab-debug": "ডিবাগ",
 	"smw-ask-tab-code": "কোড",
-	"smw-legend": "ব্যাখ্যা"
+	"smw-legend": "ব্যাখ্যা",
+	"smw-listingcontinuesabbrev": "আরও আছে"
 }

--- a/i18n/br.json
+++ b/i18n/br.json
@@ -246,5 +246,6 @@
 	"smw-processing": "O tretañ...",
 	"smw-types-title": "Doare: $1",
 	"smw-updateentitycollation-incomplete": "NEvez zo eo bet kemmet an arventenn <code>[https://www.semantic-mediawiki.org/wiki/Help:$smwgEntityCollation $smwgEntityCollation]</code> ha rekis eo erounit ar skript <code>[https://www.semantic-mediawiki.org/wiki/Help:updateEntityCollation.php updateEntityCollation.php]</code> evit ma c'hallfe an entiteoù bezañ hizivaet ha bezañ enno talvoudoù dilenn reizh.",
-	"smw-entity-examiner-associated-revision-mismatch": "Adweladenn"
+	"smw-entity-examiner-associated-revision-mismatch": "Adweladenn",
+	"smw-listingcontinuesabbrev": "(war-lerc'h)"
 }

--- a/i18n/bs.json
+++ b/i18n/bs.json
@@ -74,5 +74,6 @@
 	"smw-clipboard-copy-link": "Kopiraj link u međuspremnik",
 	"smw-data-lookup": "Dobavljam podatke...",
 	"smw-format-datatable-loadingrecords": "Učitavam...",
-	"smw-format-datatable-processing": "Obrađujem..."
+	"smw-format-datatable-processing": "Obrađujem...",
+	"smw-listingcontinuesabbrev": "nast."
 }

--- a/i18n/ca.json
+++ b/i18n/ca.json
@@ -875,5 +875,6 @@
 	"smw-entity-examiner-associated-revision-mismatch": "Revisió",
 	"smw-entity-examiner-deferred-fake": "Simulació",
 	"smw-indicator-constraint-violation": "{{PLURAL:$1|Constricció|Constriccions}}",
-	"smw-indicator-revision-mismatch": "Revisió"
+	"smw-indicator-revision-mismatch": "Revisió",
+	"smw-listingcontinuesabbrev": " cont."
 }

--- a/i18n/cdo.json
+++ b/i18n/cdo.json
@@ -5,5 +5,6 @@
 		]
 	},
 	"browse": "Káng wiki",
-	"smw-livepreview-loading": "載入..."
+	"smw-livepreview-loading": "載入...",
+	"smw-listingcontinuesabbrev": "（繼續前斗）"
 }

--- a/i18n/ce.json
+++ b/i18n/ce.json
@@ -89,5 +89,6 @@
 	"smw-limitreport-intext-postproctime-value": "$1 {{PLURAL:$1|секунд}}",
 	"smw-format-datatable-previous": "Хьалхара",
 	"smw-category": "Категори",
-	"smw-help": "ГӀо"
+	"smw-help": "ГӀо",
+	"smw-listingcontinuesabbrev": "(кхин дlа)"
 }

--- a/i18n/ch.json
+++ b/i18n/ch.json
@@ -4,5 +4,6 @@
 			"Jatrobat"
 		]
 	},
-	"smw_browse_go": "Hånao"
+	"smw_browse_go": "Hånao",
+	"smw-listingcontinuesabbrev": "kont."
 }

--- a/i18n/ckb.json
+++ b/i18n/ckb.json
@@ -46,5 +46,6 @@
 	"smw-ui-tooltip-title-note": "تێبینی",
 	"smw-livepreview-loading": "باركردن‌...",
 	"smw-patternedit-protection": "ئەم پەڕەیە پارێزراوە و تەنھا دەتوانرێت دەستکاریان بکرێت لەلایەن بەکارھێنەرانی <code>smw-patternedit</code> [https://www.semantic-mediawiki.org/wiki/Help:Permissions permission].",
-	"smw-jsonview-search-label": "گەڕان:"
+	"smw-jsonview-search-label": "گەڕان:",
+	"smw-listingcontinuesabbrev": "(درێژە)"
 }

--- a/i18n/crh-cyrl.json
+++ b/i18n/crh-cyrl.json
@@ -5,5 +5,6 @@
 		]
 	},
 	"smw_purge": "Янъарт",
-	"smw-livepreview-loading": "Юкленмекте…"
+	"smw-livepreview-loading": "Юкленмекте…",
+	"smw-listingcontinuesabbrev": " (девам)"
 }

--- a/i18n/crh-latn.json
+++ b/i18n/crh-latn.json
@@ -5,5 +5,6 @@
 		]
 	},
 	"smw_purge": "Yañart",
-	"smw-livepreview-loading": "Yüklenmekte…"
+	"smw-livepreview-loading": "Yüklenmekte…",
+	"smw-listingcontinuesabbrev": " (devam)"
 }

--- a/i18n/cs.json
+++ b/i18n/cs.json
@@ -377,5 +377,6 @@
 	"smw-property-tab-usage": "Použití",
 	"smw-property-tab-redirects": "Synonyma",
 	"smw-concept-tab-list": "Seznam",
-	"smw-concept-tab-errors": "Chyby"
+	"smw-concept-tab-errors": "Chyby",
+	"smw-listingcontinuesabbrev": "pokrač."
 }

--- a/i18n/cu.json
+++ b/i18n/cu.json
@@ -4,5 +4,6 @@
 			"ОйЛ"
 		]
 	},
-	"smw-ui-tooltip-title-warning": "нарочито"
+	"smw-ui-tooltip-title-warning": "нарочито",
+	"smw-listingcontinuesabbrev": "· вѧщє"
 }

--- a/i18n/cv.json
+++ b/i18n/cv.json
@@ -7,5 +7,6 @@
 	"smw_printername_template": "Шаблон",
 	"smw_purge": "Çĕнĕлет",
 	"smw_browse_go": "Куç",
-	"smw-livepreview-loading": "Тултаратпăр…"
+	"smw-livepreview-loading": "Тултаратпăр…",
+	"smw-listingcontinuesabbrev": "(малалли)"
 }

--- a/i18n/cy.json
+++ b/i18n/cy.json
@@ -9,5 +9,6 @@
 	"smw_printername_category": "Categori",
 	"validator-type-class-SMWParamSource": "testun",
 	"browse": "Pori'r wici",
-	"smw-livepreview-loading": "Wrthi'n llwytho…"
+	"smw-livepreview-loading": "Wrthi'n llwytho…",
+	"smw-listingcontinuesabbrev": "parh."
 }

--- a/i18n/da.json
+++ b/i18n/da.json
@@ -228,5 +228,6 @@
 	"smw-concept-tab-errors": "Fejl",
 	"smw-ask-tab-result": "Resultat",
 	"smw-ask-tab-extra": "Ekstra",
-	"smw-ask-tab-code": "Kode"
+	"smw-ask-tab-code": "Kode",
+	"smw-listingcontinuesabbrev": "forts."
 }

--- a/i18n/de.json
+++ b/i18n/de.json
@@ -1120,5 +1120,6 @@
 	"smw-indicator-constraint-violation": "{{PLURAL:$1|Einschränkung|Einschränkungen}}",
 	"smw-indicator-revision-mismatch": "Revision",
 	"smw-indicator-revision-mismatch-error": "Der [https://www.semantic-mediawiki.org/wiki/Help:Associated_revision/Examiner Seitenversionsprüfung] hat beim Vergleich eine Abweichung der Seitenversionen zwischen den Datenbanken von MediaWiki und Semantic MediaWiki festgestellt.",
-	"smw-indicator-revision-mismatch-comment": "Eine Abweichung deutet normalerweise darauf hin, daß eine Softwareaufgabe zur Aktualisierung der Seitenversion, in der Datenbank von Semantic MediaWiki, unterbrochen wurde. Daher sollten die entsprechenden Logdateien des Servers auf Informationen zu möglichen Fehlern geprüft werden."
+	"smw-indicator-revision-mismatch-comment": "Eine Abweichung deutet normalerweise darauf hin, daß eine Softwareaufgabe zur Aktualisierung der Seitenversion, in der Datenbank von Semantic MediaWiki, unterbrochen wurde. Daher sollten die entsprechenden Logdateien des Servers auf Informationen zu möglichen Fehlern geprüft werden.",
+	"smw-listingcontinuesabbrev": "(Fortsetzung)"
 }

--- a/i18n/din.json
+++ b/i18n/din.json
@@ -4,5 +4,6 @@
 			"Dinkawiki"
 		]
 	},
-	"browse": "Cäärë wiki"
+	"browse": "Cäärë wiki",
+	"smw-listingcontinuesabbrev": "ɣäthtueŋ"
 }

--- a/i18n/diq.json
+++ b/i18n/diq.json
@@ -148,5 +148,6 @@
 	"smw-es-replication-error": "Problemê zêdekerdışi",
 	"smw-es-replication-error-divergent-date-detail": "*$1 (Cıgeyrayışo elastik)\n*$2 (Mığazaya SQLi)",
 	"smw-report": "Rapore",
-	"smw-legend": "Kıtabek"
+	"smw-legend": "Kıtabek",
+	"smw-listingcontinuesabbrev": "dewam..."
 }

--- a/i18n/dsb.json
+++ b/i18n/dsb.json
@@ -263,5 +263,6 @@
 	"action-smw-admin": "administraciske nadawki Semantic MediaWiki",
 	"smw-sp-properties-header-label": "Lisćina kakosćow",
 	"smw-sp-admin-settings-button": "Lisćinu nastajenjow napóraś",
-	"smw-livepreview-loading": "Lodowanje …"
+	"smw-livepreview-loading": "Lodowanje …",
+	"smw-listingcontinuesabbrev": "dalej"
 }

--- a/i18n/dty.json
+++ b/i18n/dty.json
@@ -18,5 +18,6 @@
 	"smw-format-datatable-first": "पैल्लो",
 	"smw-format-datatable-last": "छाड्डीबारको",
 	"smw-format-datatable-next": "अघबटाको",
-	"smw-format-datatable-previous": "पछबटाको"
+	"smw-format-datatable-previous": "पछबटाको",
+	"smw-listingcontinuesabbrev": "निरन्तरता..."
 }

--- a/i18n/ee.json
+++ b/i18n/ee.json
@@ -2,5 +2,6 @@
 	"@metadata": {
 		"authors": []
 	},
-	"smw_browse_go": "Yi"
+	"smw_browse_go": "Yi",
+	"smw-listingcontinuesabbrev": "yi edzi"
 }

--- a/i18n/el.json
+++ b/i18n/el.json
@@ -690,5 +690,6 @@
 	"smw-ask-tab-result": "Αποτέλεσμα",
 	"smw-pendingtasks-setup-tasks": "Εργασίες",
 	"smw-report": "Αναφορά",
-	"smw-legend": "Υπόμνημα"
+	"smw-legend": "Υπόμνημα",
+	"smw-listingcontinuesabbrev": "συνεχίζεται"
 }

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -1112,5 +1112,6 @@
 	"smw-indicator-constraint-violation": "{{PLURAL:$1|Constraint|Constraints}}",
 	"smw-indicator-revision-mismatch": "Revision",
 	"smw-indicator-revision-mismatch-error": "The [https://www.semantic-mediawiki.org/wiki/Help:Associated_revision/Examiner associated revision] check found a mismatch between the revision referenced in MediaWiki and the one being associated in Semantic MediaWiki for this entity.",
-	"smw-indicator-revision-mismatch-comment": "A mismatch normally indicates that some process interrupted the storage operation in Semantic MediaWiki. It is recommended to review the server logs and look for exceptions or other failures."
+	"smw-indicator-revision-mismatch-comment": "A mismatch normally indicates that some process interrupted the storage operation in Semantic MediaWiki. It is recommended to review the server logs and look for exceptions or other failures.",
+	"smw-listingcontinuesabbrev": "cont."
 }

--- a/i18n/eo.json
+++ b/i18n/eo.json
@@ -177,5 +177,6 @@
 	"smw-limitreport-intext-postproctime-value": "$1 {{PLURAL:$1|sekundo|sekundoj}}",
 	"smw-property-predefined-pvuc": "\"$1\" estas predifinita eco, provizita de [https://www.semantic-mediawiki.org/wiki/Help:Special_properties Semantika Mediavikio] por restrikti valorajn atribuojn por ke ĉiu ekzemplero estas unika (aŭ maksimume ekzemplerigita unufoje).",
 	"smw-datavalue-parse-error": "La donita valoro \"$1\" ne estis komprenita.",
-	"smw-format-datatable-next": "Sekva"
+	"smw-format-datatable-next": "Sekva",
+	"smw-listingcontinuesabbrev": "daŭrigo"
 }

--- a/i18n/es.json
+++ b/i18n/es.json
@@ -879,5 +879,6 @@
 	"smw-legend": "Leyenda",
 	"smw-entity-examiner-deferred-constraint-error": "Restricción",
 	"smw-entity-examiner-associated-revision-mismatch": "Revisión",
-	"smw-indicator-constraint-violation": "{{PLURAL:$1|Restricción|Restricciones}}"
+	"smw-indicator-constraint-violation": "{{PLURAL:$1|Restricción|Restricciones}}",
+	"smw-listingcontinuesabbrev": "cont."
 }

--- a/i18n/et.json
+++ b/i18n/et.json
@@ -47,5 +47,6 @@
 	"smw-ui-tooltip-title-event": "Sündmus",
 	"smw_unknowntype": "Selle omaduse tüüp \"$1\" on vigane.",
 	"smw-property-predefined-default": "\"$1\" on eelmääratletud omadus tüübiga $2.",
-	"smw-livepreview-loading": "Laadimine..."
+	"smw-livepreview-loading": "Laadimine...",
+	"smw-listingcontinuesabbrev": "jätk"
 }

--- a/i18n/eu.json
+++ b/i18n/eu.json
@@ -324,5 +324,6 @@
 	"smw-section-collapse": "Atala kolapsatu",
 	"smw-ask-format-help-link": "[https://www.semantic-mediawiki.org/wiki/Help:$1_format $1] formatua",
 	"smw-help": "Laguntza",
-	"smw-processing": "Prozesatzen..."
+	"smw-processing": "Prozesatzen...",
+	"smw-listingcontinuesabbrev": "jarr."
 }

--- a/i18n/ext.json
+++ b/i18n/ext.json
@@ -2,5 +2,6 @@
 	"@metadata": {
 		"authors": []
 	},
-	"smw-livepreview-loading": "Cargandu…"
+	"smw-livepreview-loading": "Cargandu…",
+	"smw-listingcontinuesabbrev": "acont."
 }

--- a/i18n/fa.json
+++ b/i18n/fa.json
@@ -395,5 +395,6 @@
 	"smw-fetching": "پی‌گیری...",
 	"smw-expand": "گسترش",
 	"smw-copy": "رونوشت",
-	"smw-entity-examiner-associated-revision-mismatch": "نسخه"
+	"smw-entity-examiner-associated-revision-mismatch": "نسخه",
+	"smw-listingcontinuesabbrev": "(ادامه)"
 }

--- a/i18n/fi.json
+++ b/i18n/fi.json
@@ -382,5 +382,6 @@
 	"smw-ask-tab-result": "Tulos",
 	"smw-ask-tab-extra": "Ekstra",
 	"smw-ask-tab-code": "Koodi",
-	"smw-legend": "Selite"
+	"smw-legend": "Selite",
+	"smw-listingcontinuesabbrev": "jatkuu"
 }

--- a/i18n/fo.json
+++ b/i18n/fo.json
@@ -5,5 +5,6 @@
 		]
 	},
 	"browse": "Leita í wikiini",
-	"smw-livepreview-loading": "Innlesur..."
+	"smw-livepreview-loading": "Innlesur...",
+	"smw-listingcontinuesabbrev": "frh."
 }

--- a/i18n/fr.json
+++ b/i18n/fr.json
@@ -1147,5 +1147,6 @@
 	"smw-indicator-constraint-violation": "{{PLURAL:$1|Contrainte|Contraintes}}",
 	"smw-indicator-revision-mismatch": "Révision",
 	"smw-indicator-revision-mismatch-error": "La vérification de la [https://www.semantic-mediawiki.org/wiki/Help:Associated_revision/Examiner révision associée] a mis en évidence une différence entre la révision référencée dans MediaWiki et celle associée dans Semantic MediaWiki pour cette entité.",
-	"smw-indicator-revision-mismatch-comment": "Une désynchronisation indique en général qu’un certain processus a interrompu l’opération de stockage dans MediaWiki Sémantique. Il est recommandé de vérifier les journaux du serveur et de rechercher les exceptions ou autres échecs."
+	"smw-indicator-revision-mismatch-comment": "Une désynchronisation indique en général qu’un certain processus a interrompu l’opération de stockage dans MediaWiki Sémantique. Il est recommandé de vérifier les journaux du serveur et de rechercher les exceptions ou autres échecs.",
+	"smw-listingcontinuesabbrev": "(suite)"
 }

--- a/i18n/frp.json
+++ b/i18n/frp.json
@@ -106,5 +106,6 @@
 	"smw-info-par-message": "Mèssâjo a fâre vêre.",
 	"smw_concept_header": "Pâges du concèpte « $1 »",
 	"smw_conceptarticlecount": "Fâre vêre l{{PLURAL:$1|a pâge que repôse|es $1 pâges que repôsont}} sur cél concèpte.",
-	"smw-livepreview-loading": "Chargement..."
+	"smw-livepreview-loading": "Chargement...",
+	"smw-listingcontinuesabbrev": "(suita)"
 }

--- a/i18n/frr.json
+++ b/i18n/frr.json
@@ -6,5 +6,6 @@
 	},
 	"browse": "Browse wiki",
 	"smw-livepreview-loading": "Loose ...",
-	"smw-search-show": "Wise"
+	"smw-search-show": "Wise",
+	"smw-listingcontinuesabbrev": "(gongt widjer)"
 }

--- a/i18n/fur.json
+++ b/i18n/fur.json
@@ -5,5 +5,6 @@
 		]
 	},
 	"browse": "Esplore il sît",
-	"smw-livepreview-loading": "Daûr a cjamâ…"
+	"smw-livepreview-loading": "Daûr a cjamâ…",
+	"smw-listingcontinuesabbrev": "cont."
 }

--- a/i18n/fy.json
+++ b/i18n/fy.json
@@ -68,5 +68,6 @@
 	"smw-ask-tab-result": "Resultaat",
 	"smw-ask-tab-code": "Koade",
 	"smw-pendingtasks-setup-tasks": "Taken",
-	"smw-legend": "Leginda"
+	"smw-legend": "Leginda",
+	"smw-listingcontinuesabbrev": "(ferfolch)"
 }

--- a/i18n/ga.json
+++ b/i18n/ga.json
@@ -22,5 +22,6 @@
 	"smw_pp_type": "Airí",
 	"smw_result_prev": "Siar",
 	"smw_result_next": "Ar aghaidh",
-	"smw-livepreview-loading": "Ag lódáil…"
+	"smw-livepreview-loading": "Ag lódáil…",
+	"smw-listingcontinuesabbrev": "ar lean."
 }

--- a/i18n/gan-hans.json
+++ b/i18n/gan-hans.json
@@ -2,5 +2,6 @@
 	"@metadata": {
 		"authors": []
 	},
-	"smw-livepreview-loading": "加载中…"
+	"smw-livepreview-loading": "加载中…",
+	"smw-listingcontinuesabbrev": "续"
 }

--- a/i18n/gan-hant.json
+++ b/i18n/gan-hant.json
@@ -2,5 +2,6 @@
 	"@metadata": {
 		"authors": []
 	},
-	"smw-livepreview-loading": "載入中…"
+	"smw-livepreview-loading": "載入中…",
+	"smw-listingcontinuesabbrev": "續"
 }

--- a/i18n/gd.json
+++ b/i18n/gd.json
@@ -4,5 +4,6 @@
 			"GunChleoc"
 		]
 	},
-	"browse": "Brabhsaich an uicidh"
+	"browse": "Brabhsaich an uicidh",
+	"smw-listingcontinuesabbrev": "(an corr)"
 }

--- a/i18n/gl.json
+++ b/i18n/gl.json
@@ -778,5 +778,6 @@
 	"smw-ask-tab-result": "Resultado",
 	"smw-ask-tab-extra": "Extras",
 	"smw-ask-tab-debug": "Depuración",
-	"smw-ask-tab-code": "Código"
+	"smw-ask-tab-code": "Código",
+	"smw-listingcontinuesabbrev": "cont."
 }

--- a/i18n/glk.json
+++ b/i18n/glk.json
@@ -5,5 +5,6 @@
 			"شیخ"
 		]
 	},
-	"browse": "ويکيه مٚتٚن"
+	"browse": "ويکيه مٚتٚن",
+	"smw-listingcontinuesabbrev": "(ايدامه)"
 }

--- a/i18n/gom-deva.json
+++ b/i18n/gom-deva.json
@@ -5,5 +5,6 @@
 			"The Discoverer"
 		]
 	},
-	"browse": "विकींत भोवडी मार"
+	"browse": "विकींत भोवडी मार",
+	"smw-listingcontinuesabbrev": "चालू."
 }

--- a/i18n/gom-latn.json
+++ b/i18n/gom-latn.json
@@ -4,5 +4,6 @@
 			"The Discoverer"
 		]
 	},
-	"browse": "Wikint bhovdi mar"
+	"browse": "Wikint bhovdi mar",
+	"smw-listingcontinuesabbrev": "chalu"
 }

--- a/i18n/grc.json
+++ b/i18n/grc.json
@@ -26,5 +26,6 @@
 	"smw_result_prev": "Προηγουμέναι",
 	"smw_result_next": "Ἑπόμεναι",
 	"smw_result_noresults": "Οὐδὲν ἀποτέλεσμα.",
-	"smw-livepreview-loading": "Φορτίζειν…"
+	"smw-livepreview-loading": "Φορτίζειν…",
+	"smw-listingcontinuesabbrev": "συνεχίζεται"
 }

--- a/i18n/gsw.json
+++ b/i18n/gsw.json
@@ -184,5 +184,6 @@
 	"smw_unknowntype": "Imn dr Eigeschaft isch dr nit bekannt Datetyp „$1“ zuegwise wore.",
 	"smw_concept_header": "Syte vum Konzäpt „$1“",
 	"smw_conceptarticlecount": "S {{PLURAL:$1|wird ei Syten|wäre $1 Syten}} aazeigt, wu zue däm Konzäpt {{PLURAL:$1|ghert|ghere}}:",
-	"smw-livepreview-loading": "Am Lade …"
+	"smw-livepreview-loading": "Am Lade …",
+	"smw-listingcontinuesabbrev": "(Forts.)"
 }

--- a/i18n/gu.json
+++ b/i18n/gu.json
@@ -5,5 +5,6 @@
 		]
 	},
 	"browse": "વિકિ વાંચો",
-	"smw-livepreview-loading": "લવાઇ રહ્યું છે..."
+	"smw-livepreview-loading": "લવાઇ રહ્યું છે...",
+	"smw-listingcontinuesabbrev": "ચાલુ.."
 }

--- a/i18n/hak.json
+++ b/i18n/hak.json
@@ -5,5 +5,6 @@
 		]
 	},
 	"browse": "Liù-lám Wiki",
-	"smw-livepreview-loading": "Chang-chhai chai-ngi̍p…"
+	"smw-livepreview-loading": "Chang-chhai chai-ngi̍p…",
+	"smw-listingcontinuesabbrev": "sa"
 }

--- a/i18n/haw.json
+++ b/i18n/haw.json
@@ -2,5 +2,6 @@
 	"@metadata": {
 		"authors": []
 	},
-	"smw-livepreview-loading": "Ke ho‘ouka nei…"
+	"smw-livepreview-loading": "Ke ho‘ouka nei…",
+	"smw-listingcontinuesabbrev": "(homaʻia)"
 }

--- a/i18n/he.json
+++ b/i18n/he.json
@@ -551,5 +551,6 @@
 	"smw-remote-request-note-cached": "התוצאה '''מוטמנת''' מהמקור החיצוני '''$1''', והתוכן המיוצר עלול להכיל מידע שאינו זמין מתוך אתר הוויקי הנוכחי.",
 	"smw-es-replication-check": "בדיקת שכפול (Elasticsearch)",
 	"smw-es-replication-error-missing-id": "ניטור שכפול מצא שהערך \"$1\" (מזהה: $2) חסר משרת Elasticsearch.",
-	"smw-es-replication-error-divergent-revision": "ניטור שכפול מצא שעבור הערך \"$1\" (מזהה: $2) <b>הגרסה המשויכת</b>מציגה חוסר־עקביות."
+	"smw-es-replication-error-divergent-revision": "ניטור שכפול מצא שעבור הערך \"$1\" (מזהה: $2) <b>הגרסה המשויכת</b>מציגה חוסר־עקביות.",
+	"smw-listingcontinuesabbrev": "(המשך)"
 }

--- a/i18n/hi.json
+++ b/i18n/hi.json
@@ -212,5 +212,6 @@
 	"smw-format-datatable-previous": "पिछला",
 	"smw-section-expand": "अंश का विस्तार करें",
 	"smw-section-collapse": "अंश को संक्षिप्त करें",
-	"smw-types-title": "प्रकार: $1"
+	"smw-types-title": "प्रकार: $1",
+	"smw-listingcontinuesabbrev": "जारी"
 }

--- a/i18n/hif-latn.json
+++ b/i18n/hif-latn.json
@@ -2,5 +2,6 @@
 	"@metadata": {
 		"authors": []
 	},
-	"smw-livepreview-loading": "load karaa jaae hae..."
+	"smw-livepreview-loading": "load karaa jaae hae...",
+	"smw-listingcontinuesabbrev": "aur"
 }

--- a/i18n/hil.json
+++ b/i18n/hil.json
@@ -6,5 +6,6 @@
 		]
 	},
 	"browse": "Maglagula sa wiki",
-	"smw_browse_go": "Lakat"
+	"smw_browse_go": "Lakat",
+	"smw-listingcontinuesabbrev": "pdyn"
 }

--- a/i18n/hr.json
+++ b/i18n/hr.json
@@ -228,5 +228,6 @@
 	"smw-type-tab-errors": "Pogreške",
 	"smw-type-primitive": "Temeljno",
 	"smw-install-incomplete-intro-note": "Ova će se poruka prestati prikazivati nakon što svi značajni zadaci budu riješeni.",
-	"smw-pendingtasks-setup-tasks": "Zadaci"
+	"smw-pendingtasks-setup-tasks": "Zadaci",
+	"smw-listingcontinuesabbrev": "nast."
 }

--- a/i18n/hrx.json
+++ b/i18n/hrx.json
@@ -5,5 +5,6 @@
 		]
 	},
 	"browse": "Semantisches Browse",
-	"smw-livepreview-loading": "Am loode …"
+	"smw-livepreview-loading": "Am loode …",
+	"smw-listingcontinuesabbrev": "(Fortsetzung)"
 }

--- a/i18n/hsb.json
+++ b/i18n/hsb.json
@@ -269,5 +269,6 @@
 	"smw-sp-properties-header-label": "Lisćina kajkosćow",
 	"smw-sp-admin-settings-button": "Lisćinu nastajenjow wutworić",
 	"smw-admin-objectid": "ID:",
-	"smw-livepreview-loading": "Čita so…"
+	"smw-livepreview-loading": "Čita so…",
+	"smw-listingcontinuesabbrev": "(pokročowanje)"
 }

--- a/i18n/ht.json
+++ b/i18n/ht.json
@@ -24,5 +24,6 @@
 	"smw_nofloat": "\"$1\" pa yon nimewo.",
 	"smw_infinite": "Nimewo ki gwo tankou \"$1\" pa sipòte.",
 	"browse": "Pran yon gade nan wiki sa a",
-	"smw_unknowntype": "Tip done \"$1\" yo ki pa sipòte retounen nan atribi a."
+	"smw_unknowntype": "Tip done \"$1\" yo ki pa sipòte retounen nan atribi a.",
+	"smw-listingcontinuesabbrev": "(kontinye)"
 }

--- a/i18n/hu.json
+++ b/i18n/hu.json
@@ -240,5 +240,6 @@
 	"smw-datavalue-allows-value-list-missing-marker": "A(z) „$1” lista tartalmában nincsenek elemek * listajelzővel.",
 	"smw-schema-error-violation": "[\"$1\", \"$2\"]",
 	"smw-schema-error-json": "JSON hiba: \"$1\"",
-	"smw-schema-usage": "Használat"
+	"smw-schema-usage": "Használat",
+	"smw-listingcontinuesabbrev": "folyt."
 }

--- a/i18n/hy.json
+++ b/i18n/hy.json
@@ -36,5 +36,6 @@
 	"smw-format-datatable-infothousands": ",",
 	"smw-format-datatable-search": "Որոնել.",
 	"smw-format-datatable-last": "Վերջին",
-	"smw-help": "Օգնություն"
+	"smw-help": "Օգնություն",
+	"smw-listingcontinuesabbrev": "շարունակելի"
 }

--- a/i18n/ia.json
+++ b/i18n/ia.json
@@ -315,5 +315,6 @@
 	"smw-es-replication-error-no-connection": "Le surveliantia de replication non pote exequer verificationes perque illo non pote establir un connexion al racemo Elasticsearch.",
 	"smw-es-replication-error-suggestions-no-connection": "Es suggerite contactar le administrator del wiki pro signalar le problema \"nulle connexion\".",
 	"smw-datavalue-constraint-schema-category-invalid-type": "Le schema annotate \"$1\" es invalide pro un categoria; illo require un typo \"$2\".",
-	"smw-datavalue-constraint-schema-property-invalid-type": "Le schema annotate \"$1\" es invalide pro un proprietate; illo require un typo \"$2\"."
+	"smw-datavalue-constraint-schema-property-invalid-type": "Le schema annotate \"$1\" es invalide pro un proprietate; illo require un typo \"$2\".",
+	"smw-listingcontinuesabbrev": "cont."
 }

--- a/i18n/id.json
+++ b/i18n/id.json
@@ -218,5 +218,6 @@
 	"smw_concept_header": "Halaman berkonsep \"$1\"",
 	"smw_conceptarticlecount": "Menampilkan $1 {{PLURAL:$1|halaman|halaman}} yang termasuk konsep ini.",
 	"smw-livepreview-loading": "Mengunggah...",
-	"smw-datavalue-number-nullnotallowed": "\"$1\" kembali dengan sebuah \"NULL\" yang tidak mengizinkan sebagai nomor."
+	"smw-datavalue-number-nullnotallowed": "\"$1\" kembali dengan sebuah \"NULL\" yang tidak mengizinkan sebagai nomor.",
+	"smw-listingcontinuesabbrev": "samb."
 }

--- a/i18n/ig.json
+++ b/i18n/ig.json
@@ -18,5 +18,6 @@
 	"smw-livepreview-loading": "Ọ biágó...",
 	"smw-format-datatable-search": "Tùwe:",
 	"smw-property-reserved-category": "Ụdàkọ",
-	"smw-category": "Ụdàkọ"
+	"smw-category": "Ụdàkọ",
+	"smw-listingcontinuesabbrev": "gàzi."
 }

--- a/i18n/ilo.json
+++ b/i18n/ilo.json
@@ -86,5 +86,6 @@
 	"smw-admin-objectid": "ID:",
 	"smw-livepreview-loading": "Maikarkarga…",
 	"smw-sp-searchbyproperty-resultlist-header": "Listaan dagiti resulta",
-	"smw-search-syntax": "Sintaksis"
+	"smw-search-syntax": "Sintaksis",
+	"smw-listingcontinuesabbrev": "tuloy."
 }

--- a/i18n/io.json
+++ b/i18n/io.json
@@ -37,5 +37,6 @@
 	"smw-fetching": "Surveyanta…",
 	"smw-preparing": "Kreado ...",
 	"smw-expand": "Montrar la listo",
-	"smw-copy": "Kopiar"
+	"smw-copy": "Kopiar",
+	"smw-listingcontinuesabbrev": "seq."
 }

--- a/i18n/is.json
+++ b/i18n/is.json
@@ -20,5 +20,6 @@
 	"smw-admin-supplementary-elastic-statistics-title": "Tölfræði",
 	"smw-livepreview-loading": "Framkalla…",
 	"log-name-smw": "Aðgerðaskrá yfir málskipan MediaWiki",
-	"smw-type-tab-types": "Tegundir"
+	"smw-type-tab-types": "Tegundir",
+	"smw-listingcontinuesabbrev": "frh."
 }

--- a/i18n/it.json
+++ b/i18n/it.json
@@ -491,5 +491,6 @@
 	"smw-concept-tab-errors": "Errori",
 	"smw-ask-tab-code": "Codice",
 	"smw-legend": "Legenda",
-	"smw-entity-examiner-associated-revision-mismatch": "Versione"
+	"smw-entity-examiner-associated-revision-mismatch": "Versione",
+	"smw-listingcontinuesabbrev": "cont."
 }

--- a/i18n/ja.json
+++ b/i18n/ja.json
@@ -578,5 +578,6 @@
 	"smw-es-replication-error-file-ingest-missing-file-attachment-suggestions": "注釈とファイル索引より以前に[https://www.semantic-mediawiki.org/wiki/Help:ElasticStore/File_ingestion ファイル取得]ジョブの予定が確立していて実行されるかどうか確認してください。",
 	"smw-report": "レポート",
 	"smw-legend": "凡例",
-	"smw-indicator-revision-mismatch-error": "[https://www.semantic-mediawiki.org/wiki/Help:Associated_revision/Examiner 関連する改版]検査により、このエントリに対して MediaWiki が引用する改版と Semantic MediaWiki に紐付けされたものに不一致が見つかりました。"
+	"smw-indicator-revision-mismatch-error": "[https://www.semantic-mediawiki.org/wiki/Help:Associated_revision/Examiner 関連する改版]検査により、このエントリに対して MediaWiki が引用する改版と Semantic MediaWiki に紐付けされたものに不一致が見つかりました。",
+	"smw-listingcontinuesabbrev": "の続き"
 }

--- a/i18n/jam.json
+++ b/i18n/jam.json
@@ -4,5 +4,6 @@
 			"Katxis"
 		]
 	},
-	"browse": "Brouz wiki"
+	"browse": "Brouz wiki",
+	"smw-listingcontinuesabbrev": "kant."
 }

--- a/i18n/jbo.json
+++ b/i18n/jbo.json
@@ -5,5 +5,6 @@
 		]
 	},
 	"smw_purge": "vifnygau",
-	"smw_browselink": "zgana lo se ckaji"
+	"smw_browselink": "zgana lo se ckaji",
+	"smw-listingcontinuesabbrev": "ranji"
 }

--- a/i18n/jut.json
+++ b/i18n/jut.json
@@ -4,5 +4,6 @@
 			"Jyllanj"
 		]
 	},
-	"browse": "Djennemsie wiki"
+	"browse": "Djennemsie wiki",
+	"smw-listingcontinuesabbrev": "forts."
 }

--- a/i18n/jv.json
+++ b/i18n/jv.json
@@ -97,5 +97,6 @@
 	"smw-livepreview-loading": "Ngunggahaké…",
 	"smw-type-tab-properties": "Properti",
 	"smw-type-tab-types": "Jinis",
-	"smw-type-tab-errors": "Masalah"
+	"smw-type-tab-errors": "Masalah",
+	"smw-listingcontinuesabbrev": "samb."
 }

--- a/i18n/ka.json
+++ b/i18n/ka.json
@@ -88,5 +88,6 @@
 	"smw-ui-tooltip-title-note": "შენიშვნა",
 	"smw-ui-tooltip-title-legend": "ლეგენდა",
 	"smw_unknowntype": "ამ თვისების ტიპი არასწორია",
-	"smw-livepreview-loading": "იტვირთება…"
+	"smw-livepreview-loading": "იტვირთება…",
+	"smw-listingcontinuesabbrev": "გაგრძ."
 }

--- a/i18n/kab.json
+++ b/i18n/kab.json
@@ -60,5 +60,6 @@
 	"smw-admin-idlookup-input": "Ḥuf",
 	"smw-livepreview-loading": "Asali…",
 	"protect-level-smw-pageedit": "Sirek iseqdacen yesɛan azref n usnifel n isebtar (Semantic MediaWiki)",
-	"smw-postproc-queryref": "Asebter yettwacreḍ d akken yessefk ad ittusmiren imi yesra asesfer uḍfiṛ."
+	"smw-postproc-queryref": "Asebter yettwacreḍ d akken yessefk ad ittusmiren imi yesra asesfer uḍfiṛ.",
+	"smw-listingcontinuesabbrev": "asartu"
 }

--- a/i18n/khw.json
+++ b/i18n/khw.json
@@ -4,5 +4,6 @@
 			"Rachitrali"
 		]
 	},
-	"browse": "ویکپیڈیا براوزر"
+	"browse": "ویکپیڈیا براوزر",
+	"smw-listingcontinuesabbrev": "جاری"
 }

--- a/i18n/kiu.json
+++ b/i18n/kiu.json
@@ -7,5 +7,6 @@
 	},
 	"smw-admin-supplementary-elastic-status-replication-monitoring": "Şêrkerdışê jêdekerdışi (aktif): $1",
 	"smw-es-replication-error": "Problemê jêdekerdışi",
-	"smw-es-replication-error-divergent-date": "*$1 (Cıcêrayışo elastik)\n*$2 (Mığazaya SQLi)"
+	"smw-es-replication-error-divergent-date": "*$1 (Cıcêrayışo elastik)\n*$2 (Mığazaya SQLi)",
+	"smw-listingcontinuesabbrev": "dewam"
 }

--- a/i18n/kk-arab.json
+++ b/i18n/kk-arab.json
@@ -2,5 +2,6 @@
 	"@metadata": {
 		"authors": []
 	},
-	"smw-livepreview-loading": "جۇكتەۋدە…"
+	"smw-livepreview-loading": "جۇكتەۋدە…",
+	"smw-listingcontinuesabbrev": "(جالع.)"
 }

--- a/i18n/kk-cyrl.json
+++ b/i18n/kk-cyrl.json
@@ -8,5 +8,6 @@
 	"smw-paramdesc-json-unescape": "Нәтижеде құтылмаған қиғаш сызықтармен көп байттылы Unicode белгілер болу керек.",
 	"smw_purge": "Жаңарту",
 	"browse": "Уикиді шолу",
-	"smw-livepreview-loading": "Жүктеуде…"
+	"smw-livepreview-loading": "Жүктеуде…",
+	"smw-listingcontinuesabbrev": "(жалғ.)"
 }

--- a/i18n/kk-latn.json
+++ b/i18n/kk-latn.json
@@ -2,5 +2,6 @@
 	"@metadata": {
 		"authors": []
 	},
-	"smw-livepreview-loading": "Jüktewde…"
+	"smw-livepreview-loading": "Jüktewde…",
+	"smw-listingcontinuesabbrev": "(jalğ.)"
 }

--- a/i18n/km.json
+++ b/i18n/km.json
@@ -81,5 +81,6 @@
 	"smw-createproperty-isproperty": "នេះ​គឺជា​លក្ខណៈសម្បត្តិមួយ​នៃ​គំរូ $1 ។",
 	"smw-createproperty-allowedvals": "តម្លៃ​ចំនួន$1 ​សម្រាប់​លក្ខណៈសម្បត្តិ​នេះគឺ​៖",
 	"smw-livepreview-loading": "កំពុងផ្ទុក…",
-	"smw-search-show": "បង្ហាញ"
+	"smw-search-show": "បង្ហាញ",
+	"smw-listingcontinuesabbrev": "បន្ត"
 }

--- a/i18n/kn.json
+++ b/i18n/kn.json
@@ -13,5 +13,6 @@
 	"browse": "ವಿಕಿ ಜಾಲಾಡಿ",
 	"smw_browse_go": "ಹೋಗು",
 	"smw-livepreview-loading": "ತುಂಬಿಸಲಾಗುತ್ತಿದೆ....",
-	"smw-processing": "ಸಂಸ್ಕರಿಸಲಾಗುತ್ತಿದೆ..."
+	"smw-processing": "ಸಂಸ್ಕರಿಸಲಾಗುತ್ತಿದೆ...",
+	"smw-listingcontinuesabbrev": "ಮುಂದು."
 }

--- a/i18n/ko.json
+++ b/i18n/ko.json
@@ -662,5 +662,6 @@
 	"smw-es-replication-error-divergent-revision-short": "다음의 관련 판 데이터는 비교를 위해 사용되었습니다:",
 	"smw-report": "보고서",
 	"smw-legend": "범례",
-	"smw-entity-examiner-associated-revision-mismatch": "판"
+	"smw-entity-examiner-associated-revision-mismatch": "판",
+	"smw-listingcontinuesabbrev": "(계속)"
 }

--- a/i18n/krc.json
+++ b/i18n/krc.json
@@ -7,5 +7,6 @@
 	},
 	"smw_purge": "Джангырт",
 	"browse": "Викиге кёз ат",
-	"smw-livepreview-loading": "Джюклениу..."
+	"smw-livepreview-loading": "Джюклениу...",
+	"smw-listingcontinuesabbrev": "(баргъаны)"
 }

--- a/i18n/kri.json
+++ b/i18n/kri.json
@@ -5,5 +5,6 @@
 			"Protostar"
 		]
 	},
-	"smw_browse_go": "Go"
+	"smw_browse_go": "Go",
+	"smw-listingcontinuesabbrev": "kònt."
 }

--- a/i18n/ksh.json
+++ b/i18n/ksh.json
@@ -230,5 +230,6 @@
 	"smw-limitreport-intext-parsertime": "[SMW] De Zigg di der Paaser för et Annotehre jebruch hät",
 	"smw-limitreport-intext-parsertime-value": "{{PLURAL:$1|eijn Sekond|$1 Sekonde|keijn Sekond}}",
 	"smw-limitreport-pagepurge-storeupdatetime": "[SMW] De Duur för et Ändere fum Zwescheschpeijscher beim Fottschmiiße",
-	"smw-limitreport-pagepurge-storeupdatetime-value": "{{PLURAL:$1|eijn Sekond|$1 Sekond|keijn Sekond}}"
+	"smw-limitreport-pagepurge-storeupdatetime-value": "{{PLURAL:$1|eijn Sekond|$1 Sekond|keijn Sekond}}",
+	"smw-listingcontinuesabbrev": "… (wigger)"
 }

--- a/i18n/ku-latn.json
+++ b/i18n/ku-latn.json
@@ -41,5 +41,6 @@
 	"smw-sp-searchbyproperty-resultlist-header": "Lîsteya encaman",
 	"smw-search-syntax": "Sentaks",
 	"smw-types-list": "Lîsteya cureyên daneyan",
-	"smw-format-datatable-next": "Pêşve"
+	"smw-format-datatable-next": "Pêşve",
+	"smw-listingcontinuesabbrev": "dewam"
 }

--- a/i18n/kw.json
+++ b/i18n/kw.json
@@ -5,5 +5,6 @@
 		]
 	},
 	"browse": "Peuri an wiki",
-	"smw-livepreview-loading": "Ow karga..."
+	"smw-livepreview-loading": "Ow karga...",
+	"smw-listingcontinuesabbrev": "pes."
 }

--- a/i18n/ky.json
+++ b/i18n/ky.json
@@ -18,5 +18,6 @@
 	"smw-ui-tooltip-title-info": "Маалымат",
 	"smw-ui-tooltip-title-warning": "Ката",
 	"smw-ui-tooltip-title-parameter": "Параметр",
-	"smw-livepreview-loading": "Жүктөлүүдө..."
+	"smw-livepreview-loading": "Жүктөлүүдө...",
+	"smw-listingcontinuesabbrev": "уланд."
 }

--- a/i18n/la.json
+++ b/i18n/la.json
@@ -5,5 +5,6 @@
 		]
 	},
 	"browse": "Percurrere",
-	"smw-livepreview-loading": "Depromens…"
+	"smw-livepreview-loading": "Depromens…",
+	"smw-listingcontinuesabbrev": "cont."
 }

--- a/i18n/lad.json
+++ b/i18n/lad.json
@@ -5,5 +5,6 @@
 		]
 	},
 	"browse": "Eksplorar viki",
-	"smw-livepreview-loading": "Cargando..."
+	"smw-livepreview-loading": "Cargando...",
+	"smw-listingcontinuesabbrev": "cont."
 }

--- a/i18n/lb.json
+++ b/i18n/lb.json
@@ -371,5 +371,6 @@
 	"smw-entity-examiner-deferred-constraint-error": "Limitatioun",
 	"smw-entity-examiner-associated-revision-mismatch": "Versioun",
 	"smw-entity-examiner-deferred-fake": "Fälschung",
-	"smw-indicator-revision-mismatch": "Revisioun"
+	"smw-indicator-revision-mismatch": "Revisioun",
+	"smw-listingcontinuesabbrev": "(Fortsetzung)"
 }

--- a/i18n/lez.json
+++ b/i18n/lez.json
@@ -5,5 +5,6 @@
 		]
 	},
 	"browse": "Чинрин обзор",
-	"smw-livepreview-loading": "Ппарзава..."
+	"smw-livepreview-loading": "Ппарзава...",
+	"smw-listingcontinuesabbrev": "(кьатӀ)"
 }

--- a/i18n/li.json
+++ b/i18n/li.json
@@ -43,5 +43,6 @@
 	"validator-type-class-SMWParamSource": "teks",
 	"smw_purge": "Vernuuj",
 	"browse": "Blajer door de wiki",
-	"smw-livepreview-loading": "Laje…"
+	"smw-livepreview-loading": "Laje…",
+	"smw-listingcontinuesabbrev": "wiejer"
 }

--- a/i18n/lij.json
+++ b/i18n/lij.json
@@ -6,5 +6,6 @@
 		]
 	},
 	"browse": "Esplóra o scîto",
-	"smw-livepreview-loading": "Camallando…"
+	"smw-livepreview-loading": "Camallando…",
+	"smw-listingcontinuesabbrev": "cont."
 }

--- a/i18n/lki.json
+++ b/i18n/lki.json
@@ -11,5 +11,6 @@
 	"smw-special-concept-docu": "[https://www.semantic-mediawiki.org/wiki/Help:Concepts concept] می‌تواند  به عنوان \"دسته پویا\" مشاهده شوند، یعنی به عنوان مجموعه‌ای از صفحاتی که به طور دستی ایجاد نمی‌شوند، اما آنهایی که توسط مدیاویکی معنایی از یک توصیف داده شده پرس‌وجو، محاسبه می‌شوند.",
 	"smw-ask-format-selection-help": "برای شرح مفصل، لطفاً صفحه راهنما $1 را مشاهده کنید.",
 	"browse": "مرور ویکی",
-	"smw-ui-tooltip-title-note": "ویرنۆیسة-یادداشت"
+	"smw-ui-tooltip-title-note": "ویرنۆیسة-یادداشت",
+	"smw-listingcontinuesabbrev": "(ادامه)"
 }

--- a/i18n/lrc.json
+++ b/i18n/lrc.json
@@ -5,5 +5,6 @@
 			"Mogoeilor"
 		]
 	},
-	"browse": "دوئارتٱ نری سی ڤیکی"
+	"browse": "دوئارتٱ نری سی ڤیکی",
+	"smw-listingcontinuesabbrev": "دۏمبالٱ"
 }

--- a/i18n/lt.json
+++ b/i18n/lt.json
@@ -197,5 +197,6 @@
 	"smw-section-collapse": "Suskleisti dalį",
 	"smw-help": "Pagalba",
 	"smw-es-replication-error-no-connection": "Replikacijos stebėjimas negali atlikti jokių patikrinimų, nes negali sukurti ryšio su Elasticsearch klusteriu.",
-	"smw-es-replication-error-suggestions-no-connection": "Siūloma kreiptis į „wiki“ administratorių ir pranešti apie „be ryšio“ problemą."
+	"smw-es-replication-error-suggestions-no-connection": "Siūloma kreiptis į „wiki“ administratorių ir pranešti apie „be ryšio“ problemą.",
+	"smw-listingcontinuesabbrev": "tęsti"
 }

--- a/i18n/luz.json
+++ b/i18n/luz.json
@@ -4,5 +4,6 @@
 			"علی ساکی لرستانی"
 		]
 	},
-	"browse": "مۉروٙر ڤیکی"
+	"browse": "مۉروٙر ڤیکی",
+	"smw-listingcontinuesabbrev": "دۉنبالە"
 }

--- a/i18n/lv.json
+++ b/i18n/lv.json
@@ -55,5 +55,6 @@
 	"smw-schema-error-json": "JSON kļūme:\"$1\"",
 	"smw-schema-summary-title": "Kopsavilkums",
 	"smw-schema-tag": "{{PLURAL:$1|Iezīmes|Iezīme|Iezīmes}}",
-	"smw-indicator-revision-mismatch": "Versija"
+	"smw-indicator-revision-mismatch": "Versija",
+	"smw-listingcontinuesabbrev": " (turpinājums)"
 }

--- a/i18n/lzh.json
+++ b/i18n/lzh.json
@@ -5,5 +5,6 @@
 		]
 	},
 	"browse": "覽共筆",
-	"smw-livepreview-loading": "遺藏…"
+	"smw-livepreview-loading": "遺藏…",
+	"smw-listingcontinuesabbrev": "續"
 }

--- a/i18n/mai.json
+++ b/i18n/mai.json
@@ -111,5 +111,6 @@
 	"smw-search-profile-link-caption-query": "देखी",
 	"smw-search-show": "देखाबी",
 	"smw-search-hide": "नुकाबी",
-	"log-name-smw": "सिमेंटिक मीडियाविकि"
+	"log-name-smw": "सिमेंटिक मीडियाविकि",
+	"smw-listingcontinuesabbrev": "शेष आगाँ।"
 }

--- a/i18n/mdf.json
+++ b/i18n/mdf.json
@@ -2,5 +2,6 @@
 	"@metadata": {
 		"authors": []
 	},
-	"smw-livepreview-loading": "Аноклакшни…"
+	"smw-livepreview-loading": "Аноклакшни…",
+	"smw-listingcontinuesabbrev": "полатксоц"
 }

--- a/i18n/mg.json
+++ b/i18n/mg.json
@@ -46,5 +46,6 @@
 	"smw_result_noresults": "Tsy nahitana valiny",
 	"smw-admin-statistics-job-title": "Statistikan'ny asa",
 	"smw_smwadmin_return": "Hiverina any amin'ny $1",
-	"smw-livepreview-loading": "Am-pakàna…"
+	"smw-livepreview-loading": "Am-pakàna…",
+	"smw-listingcontinuesabbrev": " manaraka."
 }

--- a/i18n/min.json
+++ b/i18n/min.json
@@ -10,5 +10,6 @@
 	"smw_propertylackspage": "Sado properti musti dideskripsikan jo suatu laman!",
 	"smw_purge": "Pabaharui",
 	"browse": "Jalajahi wiki",
-	"smw_browse_go": "Tuju"
+	"smw_browse_go": "Tuju",
+	"smw-listingcontinuesabbrev": "samb."
 }

--- a/i18n/mk.json
+++ b/i18n/mk.json
@@ -548,5 +548,6 @@
 	"smw-ask-tab-debug": "Исправки",
 	"smw-ask-tab-code": "Код",
 	"smw-report": "Извештај",
-	"smw-legend": "Легенда"
+	"smw-legend": "Легенда",
+	"smw-listingcontinuesabbrev": "продолжува"
 }

--- a/i18n/ml.json
+++ b/i18n/ml.json
@@ -35,5 +35,6 @@
 	"smw_result_noresults": "ക്ഷമിക്കുക, ഫലങ്ങൾ ഒന്നുമില്ല",
 	"smw-livepreview-loading": "ശേഖരിക്കുന്നു...",
 	"smw-data-lookup": "വിവരം ലഭ്യമാക്കുന്നു ...",
-	"smw-no-data-available": "വിവരങ്ങളൊന്നും ലഭ്യമല്ല."
+	"smw-no-data-available": "വിവരങ്ങളൊന്നും ലഭ്യമല്ല.",
+	"smw-listingcontinuesabbrev": "തുടർച്ച."
 }

--- a/i18n/mn.json
+++ b/i18n/mn.json
@@ -12,5 +12,6 @@
 	"smw-ui-tooltip-title-quantity": "Нэгжийн шилжүүлэг",
 	"smw-livepreview-loading": "Уншиж байна...",
 	"smw-limitreport-intext-parsertime-value": "$1 секунд",
-	"smw-limitreport-pagepurge-storeupdatetime-value": "$1 секунд"
+	"smw-limitreport-pagepurge-storeupdatetime-value": "$1 секунд",
+	"smw-listingcontinuesabbrev": "-н үргэлжлэл"
 }

--- a/i18n/mr.json
+++ b/i18n/mr.json
@@ -129,5 +129,6 @@
 	"smw-datavalue-reference-outputformat": "$1: $2",
 	"smw-property-preferred-title-format": "$1 ($2)",
 	"smw-ask-title-keyword-type": "मुख्यशब्दचा शोध",
-	"smw-ask-message-keyword-type": "ह्या शोधातून <code><nowiki>$1</nowiki></code> ही अट जुळली आहे"
+	"smw-ask-message-keyword-type": "ह्या शोधातून <code><nowiki>$1</nowiki></code> ही अट जुळली आहे",
+	"smw-listingcontinuesabbrev": "पुढे चला"
 }

--- a/i18n/ms.json
+++ b/i18n/ms.json
@@ -51,5 +51,6 @@
 	"smw_result_noresults": "Tiada hasil.",
 	"smwadmin": "Fungsi penyelia untuk Semantic MediaWiki",
 	"smw-concept-cache-text": "Konsep ini mempunyai sejumlah $1 laman, dan kali terakhir dikemaskinikan pada $3, $2.",
-	"smw-livepreview-loading": "Memuatkan..."
+	"smw-livepreview-loading": "Memuatkan...",
+	"smw-listingcontinuesabbrev": "samb."
 }

--- a/i18n/mt.json
+++ b/i18n/mt.json
@@ -16,5 +16,6 @@
 	"smw-admin-statistics": "Statistika",
 	"smw-livepreview-loading": "Tniżżil fil-progress…",
 	"smw-sp-searchbyproperty-resultlist-header": "Lista ta' riżultati",
-	"logeventslist-smw-log": "Semantic MediaWiki"
+	"logeventslist-smw-log": "Semantic MediaWiki",
+	"smw-listingcontinuesabbrev": "kompli"
 }

--- a/i18n/mwl.json
+++ b/i18n/mwl.json
@@ -8,5 +8,6 @@
 	"smw-ask-search": "Percurar",
 	"browse": "Nabegar pula wiki",
 	"prefs-general-options": "Oupçones girales",
-	"smw-livepreview-loading": "A cargar..."
+	"smw-livepreview-loading": "A cargar...",
+	"smw-listingcontinuesabbrev": "cunt."
 }

--- a/i18n/my.json
+++ b/i18n/my.json
@@ -123,5 +123,6 @@
 	"smw-pendingtasks-setup-tasks": "တာဝန်များ",
 	"smw-es-replication-error-divergent-date-short": "အောက်ပါ ရက်စွဲအချက်အလက်များကို နှိုင်းယှဉ်ခြင်းအတွက် အသုံးပြုပါသည်:",
 	"smw-report": "အစီရင်ခံရန်",
-	"smw-legend": "အညွှန်း"
+	"smw-legend": "အညွှန်း",
+	"smw-listingcontinuesabbrev": "ပံ့ပိုး"
 }

--- a/i18n/myv.json
+++ b/i18n/myv.json
@@ -27,5 +27,6 @@
 	"smw-ui-tooltip-title-error": "Ильведевкс",
 	"smw-ui-tooltip-title-parameter": "Параметра",
 	"smw-ui-tooltip-title-legend": "Легенда",
-	"smw-livepreview-loading": "Йоракшны…"
+	"smw-livepreview-loading": "Йоракшны…",
+	"smw-listingcontinuesabbrev": "поладксозо моли"
 }

--- a/i18n/mzn.json
+++ b/i18n/mzn.json
@@ -4,5 +4,6 @@
 			"محک"
 		]
 	},
-	"browse": "ویکی ره بگردستن"
+	"browse": "ویکی ره بگردستن",
+	"smw-listingcontinuesabbrev": "(دمباله)"
 }

--- a/i18n/nah.json
+++ b/i18n/nah.json
@@ -15,5 +15,6 @@
 	"smw_smwadmin_return": "Titocuepāz īhuīc $1",
 	"smw-admin-idlookup-input": "Tlatemoliztli",
 	"smw-livepreview-loading": "Tēmohua...",
-	"smw-format-datatable-search": "Tlatemoliztli:"
+	"smw-format-datatable-search": "Tlatemoliztli:",
+	"smw-listingcontinuesabbrev": "niman"
 }

--- a/i18n/nan.json
+++ b/i18n/nan.json
@@ -8,5 +8,6 @@
 	},
 	"browse": "Khoàⁿ wiki",
 	"smw-constraint-violation-class-mandatory-properties-constraint": "<code>mandatory_properties</code>hān-chè hō͘ hun-phuè kàu lūi-pia̍t\"[[:Category:$1|$1]]\", pīng-chhiánn su-iàu í-hā kiông-tsè sio̍k-sìng: $2",
-	"apihelp-smwtask-param-task": "Tēng-gī jīm-bū luī-hêng"
+	"apihelp-smwtask-param-task": "Tēng-gī jīm-bū luī-hêng",
+	"smw-listingcontinuesabbrev": "(chiap-sòa thâu-chêng)"
 }

--- a/i18n/nap.json
+++ b/i18n/nap.json
@@ -6,5 +6,6 @@
 	},
 	"smw-paramdesc-table-transpose": "Fà vedé 'e cap' 'e tabella n verticale e li risultate n orizzontale",
 	"browse": "Ascìa wiki",
-	"smw_smwadmin_datarefreshstopconfirm": "Si, so' {{GENDER:$1|sicuro|sicura}}."
+	"smw_smwadmin_datarefreshstopconfirm": "Si, so' {{GENDER:$1|sicuro|sicura}}.",
+	"smw-listingcontinuesabbrev": "cont."
 }

--- a/i18n/nb.json
+++ b/i18n/nb.json
@@ -1102,5 +1102,6 @@
 	"smw-indicator-constraint-violation": "{{PLURAL:$1|Begrensning|Begrensninger}}",
 	"smw-indicator-revision-mismatch": "Revisjon",
 	"smw-indicator-revision-mismatch-error": "Sjekken for [https://www.semantic-mediawiki.org/wiki/Help:Associated_revision/Examiner assosiert revisjon] fant manglende samsvar mellom revisjonen som refereres til i MediaWiki og den som er assosiert med Semantic MediaWiki for denne entiteten.",
-	"smw-indicator-revision-mismatch-comment": "Manglende samsvar indikerer vanligvis at en prosess forstyrret lagringsoperasjonen i Semantic MediaWiki. Det anbefales å gå gjennom tjenerloggene og se etter unntak eller andre feil."
+	"smw-indicator-revision-mismatch-comment": "Manglende samsvar indikerer vanligvis at en prosess forstyrret lagringsoperasjonen i Semantic MediaWiki. Det anbefales å gå gjennom tjenerloggene og se etter unntak eller andre feil.",
+	"smw-listingcontinuesabbrev": "forts."
 }

--- a/i18n/nds-nl.json
+++ b/i18n/nds-nl.json
@@ -10,5 +10,6 @@
 	"smw_browselink": "Eigenskappen bekyken",
 	"smw-ui-tooltip-title-reference": "Referensy",
 	"smw-livepreview-loading": "An t laojen…",
-	"smw-expand": "Uutklappen"
+	"smw-expand": "Uutklappen",
+	"smw-listingcontinuesabbrev": "(vervolg)"
 }

--- a/i18n/nds.json
+++ b/i18n/nds.json
@@ -24,5 +24,6 @@
 	"smw-livepreview-loading": "Läädt…",
 	"smw-sp-searchbyproperty-resultlist-header": "List vun Resultaten",
 	"smw-datavalue-reference-outputformat": "$1: $2",
-	"smw-help": "Hülp"
+	"smw-help": "Hülp",
+	"smw-listingcontinuesabbrev": "wieder"
 }

--- a/i18n/ne.json
+++ b/i18n/ne.json
@@ -51,5 +51,6 @@
 	"smw-entity-examiner-deferred-elastic-replication": "लचकता",
 	"smw-entity-examiner-deferred-fake": "नक्कली",
 	"smw-indicator-constraint-violation": "{{PLURAL:$1|बाधा|बाधाहरू}}",
-	"smw-indicator-revision-mismatch": "पुनरावलोकन"
+	"smw-indicator-revision-mismatch": "पुनरावलोकन",
+	"smw-listingcontinuesabbrev": "निरन्तरता..."
 }

--- a/i18n/nl.json
+++ b/i18n/nl.json
@@ -553,5 +553,6 @@
 	"smw-updateentitycollation-incomplete": "De <code>[https://www.semantic-mediawiki.org/wiki/Help:$smwgEntityCollation $smwgEntityCollation]</code> zetting werd recent gewijzigd en vereist dat het <code>[https://www.semantic-mediawiki.org/wiki/Help:updateEntityCollation.php updateEntityCollation.php]</code> script uitgevoerd wordt zodat entiteiten geüpdated worden en de juiste sorteerveldwaarde bevatten.",
 	"smw-es-replication-error-divergent-date-detail": "Wijzigingsdatum waarnaar wordt verwezen:\n*Elasticsearch: $1 \n*Database: $2",
 	"smw-report": "Verslag",
-	"smw-entity-examiner-associated-revision-mismatch": "Versie"
+	"smw-entity-examiner-associated-revision-mismatch": "Versie",
+	"smw-listingcontinuesabbrev": "meer"
 }

--- a/i18n/nn.json
+++ b/i18n/nn.json
@@ -172,5 +172,6 @@
 	"smw_concept_header": "Sider av konseptet «$1»",
 	"smw_conceptarticlecount": "Syner nedanfor {{PLURAL:$1|éi side|$1 sider}}",
 	"smw-livepreview-loading": "Lastar inn&nbsp;…",
-	"smw-type-tab-properties": "Eigenskapar"
+	"smw-type-tab-properties": "Eigenskapar",
+	"smw-listingcontinuesabbrev": "vidare"
 }

--- a/i18n/oc.json
+++ b/i18n/oc.json
@@ -225,5 +225,6 @@
 	"smw-datavalue-reference-outputformat": "$1 : $2",
 	"smw-parser-invalid-json-format": "L’analisador JSON a tornat un « $1 ».",
 	"smw-property-preferred-title-format": "$1 ($2)",
-	"smw-no-data-available": "Cap de donada pas disponibla."
+	"smw-no-data-available": "Cap de donada pas disponibla.",
+	"smw-listingcontinuesabbrev": "(seguida)"
 }

--- a/i18n/olo.json
+++ b/i18n/olo.json
@@ -4,5 +4,6 @@
 			"Mashoi7"
 		]
 	},
-	"browse": "Livua wikii"
+	"browse": "Livua wikii",
+	"smw-listingcontinuesabbrev": "(jatko)"
 }

--- a/i18n/or.json
+++ b/i18n/or.json
@@ -62,5 +62,6 @@
 	"smw_ask_show_embed": "ଅନ୍ତଃସ୍ଥାପିତ ସାଙ୍କେତିକ ଚିହ୍ନ ଦେଖାନ୍ତୁ",
 	"smw_ask_hide_embed": "ଅନ୍ତଃସ୍ଥାପିତ ସାଙ୍କେତିକ ଚିହ୍ନ ଲୁଚାନ୍ତୁ",
 	"browse": "ଉଇକି ଦେଖିବେ",
-	"smw-livepreview-loading": "ଖୋଲୁଅଛି..."
+	"smw-livepreview-loading": "ଖୋଲୁଅଛି...",
+	"smw-listingcontinuesabbrev": "ଆହୁରି ଅଛି.."
 }

--- a/i18n/os.json
+++ b/i18n/os.json
@@ -5,5 +5,6 @@
 		]
 	},
 	"smw_printername_template": "Шаблон",
-	"smw-livepreview-loading": "Æвгæд цæуы..."
+	"smw-livepreview-loading": "Æвгæд цæуы...",
+	"smw-listingcontinuesabbrev": "(дарддæргонд)"
 }

--- a/i18n/pa.json
+++ b/i18n/pa.json
@@ -8,5 +8,6 @@
 	"browse": "ਵਿਕੀ ਫਰੋਲੋ",
 	"smw-livepreview-loading": "ਲੋਡ ਕੀਤਾ ਜਾ ਰਿਹਾ ਹੈ...",
 	"smw-sp-searchbyproperty-resultlist-header": "ਨਤੀਜਿਆਂ ਦੀ ਸੂਚੀ",
-	"smw-copy": "ਰੀਸ ਕਰੋ"
+	"smw-copy": "ਰੀਸ ਕਰੋ",
+	"smw-listingcontinuesabbrev": "ਜਾਰੀ"
 }

--- a/i18n/pag.json
+++ b/i18n/pag.json
@@ -2,5 +2,6 @@
 	"@metadata": {
 		"authors": []
 	},
-	"smw-livepreview-loading": "Ilulugan…"
+	"smw-livepreview-loading": "Ilulugan…",
+	"smw-listingcontinuesabbrev": "tol."
 }

--- a/i18n/pam.json
+++ b/i18n/pam.json
@@ -2,5 +2,6 @@
 	"@metadata": {
 		"authors": []
 	},
-	"smw-livepreview-loading": "Máglulan…"
+	"smw-livepreview-loading": "Máglulan…",
+	"smw-listingcontinuesabbrev": "katuglung."
 }

--- a/i18n/pdc.json
+++ b/i18n/pdc.json
@@ -16,5 +16,6 @@
 	"smw_result_prev": "zerick",
 	"smw_result_next": "vaerschich",
 	"smw_smwadmin_return": "Zerick zu $1",
-	"smw-livepreview-loading": "Laade…"
+	"smw-livepreview-loading": "Laade…",
+	"smw-listingcontinuesabbrev": "(weider)"
 }

--- a/i18n/pfl.json
+++ b/i18n/pfl.json
@@ -7,5 +7,6 @@
 	"smw_true_words": "woah,w,ja,j",
 	"smw_false_words": "falsch,f,nä,n",
 	"browse": "Guggschd uff die Bedaidung",
-	"smw_smwadmin_datarefreshstopconfirm": "Ja, isch bin ma sischa"
+	"smw_smwadmin_datarefreshstopconfirm": "Ja, isch bin ma sischa",
+	"smw-listingcontinuesabbrev": "(Waida)"
 }

--- a/i18n/pl.json
+++ b/i18n/pl.json
@@ -601,5 +601,6 @@
 	"smw-property-tab-specification": "... więcej",
 	"smw-concept-tab-errors": "Błędy",
 	"smw-ask-tab-result": "Wynik",
-	"smw-ask-tab-code": "Kod"
+	"smw-ask-tab-code": "Kod",
+	"smw-listingcontinuesabbrev": "cd."
 }

--- a/i18n/pms.json
+++ b/i18n/pms.json
@@ -235,5 +235,6 @@
 	"smw_unknowntype": "La sòrt ëd costa propietà a l'é pa bon-a.",
 	"smw_concept_header": "Pàgine dël concet \"$1\"",
 	"smw_conceptarticlecount": "Smon-e $1 {{PLURAL:$1|pàgina|pàgine}} che a aparten-o a col concet.",
-	"smw-livepreview-loading": "Antramentr ch'as caria…"
+	"smw-livepreview-loading": "Antramentr ch'as caria…",
+	"smw-listingcontinuesabbrev": "anans"
 }

--- a/i18n/pnb.json
+++ b/i18n/pnb.json
@@ -22,5 +22,6 @@
 	"smw-no-data-available": "کوئی ڈیٹا دستیاب نئیں",
 	"smw-format-datatable-emptytable": "جدول وچ کوئی ڈیٹا دستیاب نئیں",
 	"smw-property-tab-specification": "... ہور",
-	"smw-legend": "کُنجی"
+	"smw-legend": "کُنجی",
+	"smw-listingcontinuesabbrev": "جاری"
 }

--- a/i18n/prg.json
+++ b/i18n/prg.json
@@ -5,5 +5,6 @@
 		]
 	},
 	"browse": "Lasāis artīkelins",
-	"smw-livepreview-loading": "Krausnā..."
+	"smw-livepreview-loading": "Krausnā...",
+	"smw-listingcontinuesabbrev": "ē.s."
 }

--- a/i18n/ps.json
+++ b/i18n/ps.json
@@ -44,5 +44,6 @@
 	"smw-limitreport-pagepurge-storeupdatetime-value": "$1 {{PLURAL:$1|ثانيه|ثانيې}}",
 	"smw-format-datatable-infoempty": "ښکارونه له ۰ تر ۰ له ۰ وتلو",
 	"smw-property-reserved-category": "وېشنيزه",
-	"smw-category": "وېشنيزه"
+	"smw-category": "وېشنيزه",
+	"smw-listingcontinuesabbrev": "پرله پسې"
 }

--- a/i18n/pt-br.json
+++ b/i18n/pt-br.json
@@ -1123,5 +1123,6 @@
 	"smw-indicator-constraint-violation": "{{PLURAL:$1|Restrição|Restrições}}",
 	"smw-indicator-revision-mismatch": "Revisão",
 	"smw-indicator-revision-mismatch-error": "A verificação da [https://www.semantic-mediawiki.org/wiki/Help:Associated_revision/Examiner revisão associada] encontrou uma incompatibilidade entre a revisão mencionada no MediaWiki e a que está sendo associada no Semantic MediaWiki para esta entidade.",
-	"smw-indicator-revision-mismatch-comment": "Uma incompatibilidade normalmente indica que algum processo interrompeu a operação de armazenamento do Semantic MediaWiki. É recomendado revisar os logs do servidor e procurar por erros ou outras falhas."
+	"smw-indicator-revision-mismatch-comment": "Uma incompatibilidade normalmente indica que algum processo interrompeu a operação de armazenamento do Semantic MediaWiki. É recomendado revisar os logs do servidor e procurar por erros ou outras falhas.",
+	"smw-listingcontinuesabbrev": "cont."
 }

--- a/i18n/pt.json
+++ b/i18n/pt.json
@@ -1001,5 +1001,6 @@
 	"smw-report": "Relatório",
 	"smw-legend": "Legenda",
 	"smw-datavalue-constraint-schema-category-invalid-type": "O esquema anotado \"$1\" é inválido para uma categoria; requer um tipo \"$2\".",
-	"smw-datavalue-constraint-schema-property-invalid-type": "O esquema anotado \"$1\" é inválido para uma propriedade; requer um tipo \"$2\"."
+	"smw-datavalue-constraint-schema-property-invalid-type": "O esquema anotado \"$1\" é inválido para uma propriedade; requer um tipo \"$2\".",
+	"smw-listingcontinuesabbrev": "cont."
 }

--- a/i18n/qqq.json
+++ b/i18n/qqq.json
@@ -1028,5 +1028,6 @@
 	"smw-entity-examiner-deferred-elastic-replication": "This is a label. Translate as noun. Elastic as Elasticsearch.",
 	"smw-entity-examiner-deferred-constraint-error": "This is a label.",
 	"smw-entity-examiner-deferred-fake": "This is a label.",
-	"smw-indicator-revision-mismatch": "This is a label."
+	"smw-indicator-revision-mismatch": "This is a label.",
+	"smw-listingcontinuesabbrev": "Shown in continuation of each first letter group. This message follows the first letter.\n\nThis is an abbreviation of the English word \"continued\". If the word is short in your language, the full stop in the end is not necessary."
 }

--- a/i18n/qu.json
+++ b/i18n/qu.json
@@ -7,5 +7,6 @@
 	"smw_purge": "Musuqchay",
 	"browse": "Wikipi wamp'uy",
 	"smw_browselink": "Kaqninkunapi wamp'uy",
-	"smw-livepreview-loading": "Chaqnamuspa…"
+	"smw-livepreview-loading": "Chaqnamuspa…",
+	"smw-listingcontinuesabbrev": "qatiy"
 }

--- a/i18n/rif.json
+++ b/i18n/rif.json
@@ -4,5 +4,6 @@
 			"Jose77"
 		]
 	},
-	"smw_browse_go": "Raḥ ɣa"
+	"smw_browse_go": "Raḥ ɣa",
+	"smw-listingcontinuesabbrev": "arni-d."
 }

--- a/i18n/rm.json
+++ b/i18n/rm.json
@@ -5,5 +5,6 @@
 		]
 	},
 	"smw-ui-tooltip-title-legend": "Legenda",
-	"smw-livepreview-loading": "Chargiar…"
+	"smw-livepreview-loading": "Chargiar…",
+	"smw-listingcontinuesabbrev": "cuntinuaziun"
 }

--- a/i18n/ro.json
+++ b/i18n/ro.json
@@ -144,5 +144,6 @@
 	"smw-concept-tab-list": "Listă",
 	"smw-concept-tab-errors": "Erori",
 	"smw-install-incomplete-intro": "Instalarea (sau actualizarea) aplicației <b>Semantic MediaWiki</b> nu a fost finalizată și un administrator ar trebui să execute următoarele activități pentru a preveni inconsecvențele de date înainte ca utilizatorii să continue să creeze sau să modifice conținut.",
-	"smw-install-incomplete-populate-hash-field": "Populația de câmp <code>smw_hash</code> a fost omisă în timpul configurării, este necesar să fie executat scriptul [https://www.semantic-mediawiki.org/wiki/Help:populateHashField.php populateHashField.php]."
+	"smw-install-incomplete-populate-hash-field": "Populația de câmp <code>smw_hash</code> a fost omisă în timpul configurării, este necesar să fie executat scriptul [https://www.semantic-mediawiki.org/wiki/Help:populateHashField.php populateHashField.php].",
+	"smw-listingcontinuesabbrev": "cont."
 }

--- a/i18n/roa-tara.json
+++ b/i18n/roa-tara.json
@@ -248,5 +248,6 @@
 	"smw-property-tab-errors": "Assegnazziune sbagliate",
 	"smw-property-tab-constraint-schema-title": "Vingole d'u scheme combilate",
 	"smw-concept-tab-list": "Elenghe",
-	"smw-concept-tab-errors": "Errore"
+	"smw-concept-tab-errors": "Errore",
+	"smw-listingcontinuesabbrev": "cond."
 }

--- a/i18n/ru.json
+++ b/i18n/ru.json
@@ -897,5 +897,6 @@
 	"smw-entity-examiner-deferred-constraint-error": "Ограничение",
 	"smw-entity-examiner-deferred-fake": "Не настоящие",
 	"smw-indicator-revision-mismatch": "Редакция",
-	"smw-indicator-revision-mismatch-error": "Проверка [https://www.semantic-mediawiki.org/wiki/Help:Associated_revision/Examiner связанной ревизии] обнаружила несоответствие между ревизией, на которую ссылается MediaWiki, и ревизией, ассоциированной в Semantic MediaWiki для этой сущности."
+	"smw-indicator-revision-mismatch-error": "Проверка [https://www.semantic-mediawiki.org/wiki/Help:Associated_revision/Examiner связанной ревизии] обнаружила несоответствие между ревизией, на которую ссылается MediaWiki, и ревизией, ассоциированной в Semantic MediaWiki для этой сущности.",
+	"smw-listingcontinuesabbrev": "(продолжение)"
 }

--- a/i18n/rue.json
+++ b/i18n/rue.json
@@ -10,5 +10,6 @@
 	"smw_result_results": "Резултаты",
 	"smw_result_noresults": "Жадны ресултаты",
 	"smw_smwadmin_return": "Навернутя до  «$1».",
-	"smw-livepreview-loading": "Наладовованя..."
+	"smw-livepreview-loading": "Наладовованя...",
+	"smw-listingcontinuesabbrev": "(дале)"
 }

--- a/i18n/sa.json
+++ b/i18n/sa.json
@@ -8,5 +8,6 @@
 	"browse": "विकि दृश्यताम्",
 	"smw-admin-supplementary-elastic-functions": "उपलब्धकार्याणि",
 	"smw-admin-supplementary-elastic-settings-title": "अभिविन्यासाः",
-	"smw-livepreview-loading": "आरोपयति..."
+	"smw-livepreview-loading": "आरोपयति...",
+	"smw-listingcontinuesabbrev": "अनुवर्तते"
 }

--- a/i18n/sah.json
+++ b/i18n/sah.json
@@ -8,5 +8,6 @@
 	"smw_purge": "Саҥарт",
 	"smw-ask-search": "Бул",
 	"browse": "Биикини көрүү",
-	"smw-livepreview-loading": "Киллэрии бара турар…"
+	"smw-livepreview-loading": "Киллэрии бара турар…",
+	"smw-listingcontinuesabbrev": "(салгыыта)"
 }

--- a/i18n/sc.json
+++ b/i18n/sc.json
@@ -5,5 +5,6 @@
 		]
 	},
 	"browse": "Esplora sa wiki",
-	"smw_smwadmin_datarefreshstopconfirm": "Eja, deo so {{GENDER:$1|seguru|segura}}"
+	"smw_smwadmin_datarefreshstopconfirm": "Eja, deo so {{GENDER:$1|seguru|segura}}",
+	"smw-listingcontinuesabbrev": "sighit"
 }

--- a/i18n/scn.json
+++ b/i18n/scn.json
@@ -66,5 +66,6 @@
 	"smw-concept-tab-list": "Elencu",
 	"smw-concept-tab-errors": "Errura",
 	"smw-ask-tab-result": "Risurtatu",
-	"smw-ask-tab-code": "Còdici"
+	"smw-ask-tab-code": "Còdici",
+	"smw-listingcontinuesabbrev": " cunt."
 }

--- a/i18n/sco.json
+++ b/i18n/sco.json
@@ -11,5 +11,6 @@
 	"smw-admin-idlookup-title": "Object ID leukup",
 	"smw-admin-idlookup-docu": "Displeys details aneat aen internal object Id that represents indeevidual entities (wikipage, subobject etc.) in Semantic MediaWiki.",
 	"smw-admin-objectid": "The Object Id:",
-	"smw-livepreview-loading": "Laidin..."
+	"smw-livepreview-loading": "Laidin...",
+	"smw-listingcontinuesabbrev": "cont."
 }

--- a/i18n/sd.json
+++ b/i18n/sd.json
@@ -39,5 +39,6 @@
 	"smw-format-datatable-previous": "پويون",
 	"smw-filter": "ڇاڻي",
 	"smw-concept-tab-list": "فھرست",
-	"smw-legend": "ڪنجي"
+	"smw-legend": "ڪنجي",
+	"smw-listingcontinuesabbrev": "جاري."
 }

--- a/i18n/sdc.json
+++ b/i18n/sdc.json
@@ -5,5 +5,6 @@
 		]
 	},
 	"browse": "Nabiggà vichi",
-	"smw-livepreview-loading": "Carrigghendi…"
+	"smw-livepreview-loading": "Carrigghendi…",
+	"smw-listingcontinuesabbrev": "(séguiddu)"
 }

--- a/i18n/sgs.json
+++ b/i18n/sgs.json
@@ -6,5 +6,6 @@
 	},
 	"smw_purge": "Atšvėižintė",
 	"browse": "Poslapiu apveiza",
-	"smw-livepreview-loading": "Kraunama īr…"
+	"smw-livepreview-loading": "Kraunama īr…",
+	"smw-listingcontinuesabbrev": "tes."
 }

--- a/i18n/sh.json
+++ b/i18n/sh.json
@@ -15,5 +15,6 @@
 	"action-smw-pageedit": "uređujete stranice s anotacijom <code>Is edit protected</code> (Semantic MediaWiki)",
 	"action-smw-admin": "pristupanje administratorskima zadacima Semantički MediaWiki",
 	"action-smw-ruleedit": "uređivanje odredbenih stranica (Semantički MediaWiki)",
-	"smw-livepreview-loading": "Učitavanje..."
+	"smw-livepreview-loading": "Učitavanje...",
+	"smw-listingcontinuesabbrev": "nast."
 }

--- a/i18n/shn.json
+++ b/i18n/shn.json
@@ -6,5 +6,6 @@
 	},
 	"smw_printername_category": "ပိူင်ထၢၼ်ႈ",
 	"browse": "ပိုတ်ႇႁႃ wiki",
-	"smw-property-reserved-category": "ပိူင်ထၢၼ်ႈ"
+	"smw-property-reserved-category": "ပိူင်ထၢၼ်ႈ",
+	"smw-listingcontinuesabbrev": "သိုပ်ႇ"
 }

--- a/i18n/si.json
+++ b/i18n/si.json
@@ -146,5 +146,6 @@
 	"smw-sp-searchbyproperty-description": "මෙම පිටුව [https://www.semantic-mediawiki.org/wiki/Help:Browsing_interfaces browsing interface] නාමික අගය හා හිමිකම් පැහැදිලි කිරීම් සෙවුම් සදහා විස්තර ලබා දේ.\nතවත් පවතින අතුරුමුහුණත් සෙවුම් ඇතුළත් කරනවා [[Special:PageProperty|page property search]], සහ [[Special:Ask|ask query builder]].",
 	"smw-sp-searchbyproperty-resultlist-header": "ප්‍රතිපල ලැයිස්තුව",
 	"smw-sp-searchbyproperty-nonvaluequery": "\"$1\" සදහා ඇති වටිනාකම් ලැයිස්තුව පවරන ලදී.",
-	"smw-sp-searchbyproperty-valuequery": "\"$2\"ක අගයේ \"$1\" හිමිකම් ඇති පිටු ලැයිස්තුව විස්තර කරන ලදී."
+	"smw-sp-searchbyproperty-valuequery": "\"$2\"ක අගයේ \"$1\" හිමිකම් ඇති පිටු ලැයිස්තුව විස්තර කරන ලදී.",
+	"smw-listingcontinuesabbrev": "ඉතිරිය."
 }

--- a/i18n/sk.json
+++ b/i18n/sk.json
@@ -178,5 +178,6 @@
 	"smw_concept_header": "Návrh „$1”",
 	"smw_conceptarticlecount": "Nižšie {{PLURAL:$1|zobrazená jedna stránka|zobrazené $1 stránky|zobrazených $1 stránkok}}.",
 	"smw-property-predefined-askpa": "„$1“ je predefinovaná vlastnosť popisujúca parametre, ktoré ovplyvňujú výsledok dopytu, a poskytuje ju [https://www.semantic-mediawiki.org/wiki/Help:Special_properties Semantic MediaWiki].",
-	"smw-livepreview-loading": "Načítava sa…"
+	"smw-livepreview-loading": "Načítava sa…",
+	"smw-listingcontinuesabbrev": "pokrač."
 }

--- a/i18n/sl.json
+++ b/i18n/sl.json
@@ -144,5 +144,6 @@
 	"smw-format-datatable-processing": "Obdelovanje ...",
 	"smw-format-datatable-search": "Iskanje:",
 	"smw-format-datatable-next": "Naprej",
-	"smw-format-datatable-toolbar-export": "Izvoz"
+	"smw-format-datatable-toolbar-export": "Izvoz",
+	"smw-listingcontinuesabbrev": "nadalj."
 }

--- a/i18n/sli.json
+++ b/i18n/sli.json
@@ -5,5 +5,6 @@
 		]
 	},
 	"browse": "Semantisches Browsen",
-	"smw-livepreview-loading": "Loada…"
+	"smw-livepreview-loading": "Loada…",
+	"smw-listingcontinuesabbrev": "(Furtsetzung)"
 }

--- a/i18n/sq.json
+++ b/i18n/sq.json
@@ -20,5 +20,6 @@
 	"smw_printername_dsv": "Eksport DSV",
 	"browse": "Shfletoni wiki",
 	"smw-admin-bugsreport": "Të metat mund të njoftohen te <a href=\"https://github.com/SemanticMediaWiki/SemanticMediaWiki/issues\">ndjekësi i problemeve</a>, faqja <a href=\"https://www.semantic-mediawiki.org/wiki/Help:Reporting_bugs\">e njoftimit të të metave</a> jep ca ndihmë mbi se si të shkruhet një raport efikas të mete.",
-	"smw-livepreview-loading": "Duke punuar…"
+	"smw-livepreview-loading": "Duke punuar…",
+	"smw-listingcontinuesabbrev": "vazh."
 }

--- a/i18n/sr-ec.json
+++ b/i18n/sr-ec.json
@@ -362,5 +362,6 @@
 	"smw-ask-tab-extra": "Додатно",
 	"smw-ask-tab-code": "Кôд",
 	"smw-pendingtasks-setup-tasks": "Задаци",
-	"smw-es-replication-error-divergent-date-short": "Следеће информације о датуму коришћене су ради поређења:"
+	"smw-es-replication-error-divergent-date-short": "Следеће информације о датуму коришћене су ради поређења:",
+	"smw-listingcontinuesabbrev": "наст."
 }

--- a/i18n/sr-el.json
+++ b/i18n/sr-el.json
@@ -259,5 +259,6 @@
 	"smw-concept-tab-list": "Spisak",
 	"smw-concept-tab-errors": "Greške",
 	"smw-ask-tab-extra": "Dodatno",
-	"smw-ask-tab-code": "Kôd"
+	"smw-ask-tab-code": "Kôd",
+	"smw-listingcontinuesabbrev": "nast."
 }

--- a/i18n/stq.json
+++ b/i18n/stq.json
@@ -2,5 +2,6 @@
 	"@metadata": {
 		"authors": []
 	},
-	"smw-livepreview-loading": "Leede …"
+	"smw-livepreview-loading": "Leede …",
+	"smw-listingcontinuesabbrev": "(Foutsättenge)"
 }

--- a/i18n/su.json
+++ b/i18n/su.json
@@ -34,5 +34,6 @@
 	"smw-format-datatable-search": "Paluruh",
 	"smw-format-datatable-first": "mimiti",
 	"smw-format-datatable-last": "Pamungkas",
-	"smw-format-datatable-next": "Saterusna"
+	"smw-format-datatable-next": "Saterusna",
+	"smw-listingcontinuesabbrev": "(samb.)"
 }

--- a/i18n/sv.json
+++ b/i18n/sv.json
@@ -674,5 +674,6 @@
 	"smw-ask-tab-code": "Kod",
 	"smw-pendingtasks-setup-tasks": "Uppgifter",
 	"smw-report": "Rapportera",
-	"smw-legend": "Teckenförklaring"
+	"smw-legend": "Teckenförklaring",
+	"smw-listingcontinuesabbrev": "forts."
 }

--- a/i18n/sw.json
+++ b/i18n/sw.json
@@ -8,5 +8,6 @@
 	"smw-ui-tooltip-title-legend": "Simulizi",
 	"smw-livepreview-loading": "Inapakizwa...",
 	"smw-filter": "Chuja",
-	"smw-property-tab-usage": "Matumizi"
+	"smw-property-tab-usage": "Matumizi",
+	"smw-listingcontinuesabbrev": "endelea"
 }

--- a/i18n/szl.json
+++ b/i18n/szl.json
@@ -6,5 +6,6 @@
 		]
 	},
 	"browse": "Przeglōndej wiki",
-	"smw-livepreview-loading": "Trwo uadowańy…"
+	"smw-livepreview-loading": "Trwo uadowańy…",
+	"smw-listingcontinuesabbrev": "cd."
 }

--- a/i18n/ta.json
+++ b/i18n/ta.json
@@ -64,5 +64,6 @@
 	"smw_unknowntype": "இந்த உடமையின் வகை செல்லாதது",
 	"smw-livepreview-loading": "ஏற்றப்படுகிறது…",
 	"smw-no-data-available": "தரவேதும் கிடைக்கப்பெறவில்லை",
-	"smw-property-req-violation-missing-fields": "விடுபட்ட சொத்து \"$1\" [https://www.semantic-mediawiki.org/wiki/Help:Special_property_Has_fields <code>Has fields</code>] இந்த \"$2\" வகைக்கான அறிவிப்பு தேவைப்படுகிறது."
+	"smw-property-req-violation-missing-fields": "விடுபட்ட சொத்து \"$1\" [https://www.semantic-mediawiki.org/wiki/Help:Special_property_Has_fields <code>Has fields</code>] இந்த \"$2\" வகைக்கான அறிவிப்பு தேவைப்படுகிறது.",
+	"smw-listingcontinuesabbrev": "தொடரும்."
 }

--- a/i18n/tcy.json
+++ b/i18n/tcy.json
@@ -39,5 +39,6 @@
 	"smw-copy": "ನಕಲ್ ಮಲ್ಪುಲೆ",
 	"smw-copy-clipboard-title": "ವಿಷಯಾಂಶೊನು ಪತಿಪಲಯಿಗ್ ನಕಲುಂಡು",
 	"smw-jsonview-expand-title": "JSON ನೋಟನು ವಿಸ್ತಾರ ಮಲ್ಪುಂಡು.",
-	"smw-jsonview-collapse-title": "JSON ನೋಟನು ಪತನ ಮಲ್ಪುಂಡು"
+	"smw-jsonview-collapse-title": "JSON ನೋಟನು ಪತನ ಮಲ್ಪುಂಡು",
+	"smw-listingcontinuesabbrev": "ದುಂಬು."
 }

--- a/i18n/te.json
+++ b/i18n/te.json
@@ -131,5 +131,6 @@
 	"smw-category": "వర్గం",
 	"smw-help": "సహాయం",
 	"smw-types-title": "రకం: $1",
-	"smw-schema-error-violation": "[\"$1\", \"$2\"]"
+	"smw-schema-error-violation": "[\"$1\", \"$2\"]",
+	"smw-listingcontinuesabbrev": "(కొనసాగింపు)"
 }

--- a/i18n/tet.json
+++ b/i18n/tet.json
@@ -7,5 +7,6 @@
 	"smw_true_words": "loos,l,sin,s",
 	"smw_false_words": "sala,s,lae,la",
 	"smw_result_prev": "Molok",
-	"smw_result_next": "Oinmai"
+	"smw_result_next": "Oinmai",
+	"smw-listingcontinuesabbrev": "kont."
 }

--- a/i18n/tg-cyrl.json
+++ b/i18n/tg-cyrl.json
@@ -56,5 +56,6 @@
 	"smw-type-tab-properties": "Хусусиятҳо",
 	"smw-format-datatable-search": "Ҷустуҷӯ:",
 	"smw-format-datatable-toolbar-export": "Берунбарӣ",
-	"smw-schema-summary-title": "Хулоса"
+	"smw-schema-summary-title": "Хулоса",
+	"smw-listingcontinuesabbrev": "идома"
 }

--- a/i18n/tg-latn.json
+++ b/i18n/tg-latn.json
@@ -3,5 +3,6 @@
 		"authors": []
 	},
 	"smw-createproperty-isproperty": "In jak viƶagī az nav'i $1 ast.",
-	"smw-livepreview-loading": "Dar holi bor şudan…"
+	"smw-livepreview-loading": "Dar holi bor şudan…",
+	"smw-listingcontinuesabbrev": "idoma"
 }

--- a/i18n/th.json
+++ b/i18n/th.json
@@ -73,5 +73,6 @@
 	"smw-ui-tooltip-title-note": "หมายเหตุ",
 	"smw-livepreview-loading": "กำลังค้นหา…",
 	"smw-install-incomplete-intro": "การติดตั้ง (หรืออัปเกรด) ของ <b>ความหมายมีเดียวิกิ</b> ยังไม่สิ้นสุดและผู้ดูแลระบบควรดำเนินงานต่อไปนี้เพื่อป้องกันข้อมูลที่ไม่สอดคล้องกันก่อนที่ผู้ใช้จะสร้างหรือแก้ไขเนื้อหาต่อไป",
-	"smw-install-incomplete-populate-hash-field": "<code>smw_hash</code> วงประชากรถูกข้ามไปในระหว่างการตั้งค่า สคริปต์ [https://www.semantic-mediawiki.org/wiki/Help:populateHashField.php populateHashField.php] จะต้องมีการดำเนินการ"
+	"smw-install-incomplete-populate-hash-field": "<code>smw_hash</code> วงประชากรถูกข้ามไปในระหว่างการตั้งค่า สคริปต์ [https://www.semantic-mediawiki.org/wiki/Help:populateHashField.php populateHashField.php] จะต้องมีการดำเนินการ",
+	"smw-listingcontinuesabbrev": "ต่อ"
 }

--- a/i18n/tk.json
+++ b/i18n/tk.json
@@ -6,5 +6,6 @@
 	},
 	"smw_browse_go": "Git",
 	"smw_result_prev": "Öňki",
-	"smw-livepreview-loading": "Ýüklenýär..."
+	"smw-livepreview-loading": "Ýüklenýär...",
+	"smw-listingcontinuesabbrev": "(dowamy)"
 }

--- a/i18n/tl.json
+++ b/i18n/tl.json
@@ -247,5 +247,6 @@
 	"smw-format-datatable-last": "Dulo",
 	"smw-filter": "Pansala",
 	"smw-help": "Makatulong",
-	"smw-remote-source-unavailable": "Hindi mai-'connect' sa 'remote \"$1\" target'."
+	"smw-remote-source-unavailable": "Hindi mai-'connect' sa 'remote \"$1\" target'.",
+	"smw-listingcontinuesabbrev": "karugtong"
 }

--- a/i18n/tly.json
+++ b/i18n/tly.json
@@ -12,5 +12,6 @@
 	"smw_printername_category": "Kateqoriya",
 	"smw_purge": "Тожә кардеј",
 	"browse": "Сәһифон дијәкә",
-	"smw-admin-supplementary-elastic-version-info": "Versiyə"
+	"smw-admin-supplementary-elastic-version-info": "Versiyə",
+	"smw-listingcontinuesabbrev": "dəvom"
 }

--- a/i18n/tr.json
+++ b/i18n/tr.json
@@ -1098,5 +1098,6 @@
 	"smw-indicator-constraint-violation": "{{PLURAL:$1|Kısıtlama|Kısıtlama}}",
 	"smw-indicator-revision-mismatch": "Revizyon",
 	"smw-indicator-revision-mismatch-error": "[https://www.semantic-mediawiki.org/wiki/Help:Associated_revision/Examiner İlişkilendirilmiş düzeltme] denetimi, MediaWiki'de başvurulan düzeltme ile bu varlık için Semantic MediaWiki'de ilişkilendirilen düzeltme arasında bir uyumsuzluk buldu.",
-	"smw-indicator-revision-mismatch-comment": "Uyumsuzluk normalde bazı işlemlerin Semantic MediaWiki'deki depolama işlemini kesintiye uğrattığını gösterir. Sunucu günlüklerini incelemeniz ve özel durumlar veya diğer hatalar olup olmadığına bakmanız önerilir."
+	"smw-indicator-revision-mismatch-comment": "Uyumsuzluk normalde bazı işlemlerin Semantic MediaWiki'deki depolama işlemini kesintiye uğrattığını gösterir. Sunucu günlüklerini incelemeniz ve özel durumlar veya diğer hatalar olup olmadığına bakmanız önerilir.",
+	"smw-listingcontinuesabbrev": "devam"
 }

--- a/i18n/tt-cyrl.json
+++ b/i18n/tt-cyrl.json
@@ -32,5 +32,6 @@
 	"group-smwadministrator": "Идарәчеләр (Semantic MediaWiki)",
 	"group-smwadministrator-member": "{{GENDER:$1|идәрәче (Semantic MediaWiki)}}",
 	"grouppage-smwadministrator": "{{ns:project}}:Идарәчеләр (Semantic MediaWiki)",
-	"smw-livepreview-loading": "Төяү бара…"
+	"smw-livepreview-loading": "Төяү бара…",
+	"smw-listingcontinuesabbrev": "дәвамы"
 }

--- a/i18n/tt-latn.json
+++ b/i18n/tt-latn.json
@@ -5,5 +5,6 @@
 		]
 	},
 	"browse": "Wiki eçtälegen qaraw",
-	"smw-livepreview-loading": "Yökläw..."
+	"smw-livepreview-loading": "Yökläw...",
+	"smw-listingcontinuesabbrev": "däwamı"
 }

--- a/i18n/tyv.json
+++ b/i18n/tyv.json
@@ -7,5 +7,6 @@
 	},
 	"browse": "Арыннарның ниити көрүлдези",
 	"smw-help": "Дуза",
-	"smw-schema-summary-title": "Түңнел"
+	"smw-schema-summary-title": "Түңнел",
+	"smw-listingcontinuesabbrev": "(уланчы)"
 }

--- a/i18n/ug-arab.json
+++ b/i18n/ug-arab.json
@@ -16,5 +16,6 @@
 	"smw-ask-format": "فورمات",
 	"browse": "ۋىكىنى زىيارەت قىلىش",
 	"smw_browse_go": "كۆچۈش",
-	"smw-livepreview-loading": "يۈكلەۋاتىدۇ…"
+	"smw-livepreview-loading": "يۈكلەۋاتىدۇ…",
+	"smw-listingcontinuesabbrev": "داۋاملاشتۇر"
 }

--- a/i18n/uk.json
+++ b/i18n/uk.json
@@ -1118,5 +1118,6 @@
 	"smw-indicator-constraint-violation": "{{PLURAL:$1|Обмеження}}",
 	"smw-indicator-revision-mismatch": "Версія",
 	"smw-indicator-revision-mismatch-error": "Перевірка [https://www.semantic-mediawiki.org/wiki/Help:Associated_revision/Examiner пов'язаної версії] виявила невідповідність між версією, на яку посилається MediaWiki, та тією, з якою здійснюється пов'язування в Семантичній MediaWiki для цієї сутності.",
-	"smw-indicator-revision-mismatch-comment": "Невідповідність зазвичай свідчить про те, що якийсь процес перервав операцію зі зберігання в Семантичній MediaWiki. Рекомендується переглянути журнали сервера та пошукати винятків чи інших невдач."
+	"smw-indicator-revision-mismatch-comment": "Невідповідність зазвичай свідчить про те, що якийсь процес перервав операцію зі зберігання в Семантичній MediaWiki. Рекомендується переглянути журнали сервера та пошукати винятків чи інших невдач.",
+	"smw-listingcontinuesabbrev": "(прод.)"
 }

--- a/i18n/ur.json
+++ b/i18n/ur.json
@@ -46,5 +46,6 @@
 	"smw-admin-support": "ہو رہی ہے کی حمایت",
 	"smw-admin-other-functions": "دیگر کردار",
 	"smw-property-reserved-category": "زمرہ",
-	"smw-datavalue-uri-invalid-scheme": "$1کوواجب URI سکیم میں ذیرِفہرست نہیں رکھا گیا۔"
+	"smw-datavalue-uri-invalid-scheme": "$1کوواجب URI سکیم میں ذیرِفہرست نہیں رکھا گیا۔",
+	"smw-listingcontinuesabbrev": "جاری۔"
 }

--- a/i18n/uz.json
+++ b/i18n/uz.json
@@ -12,5 +12,6 @@
 	"prefs-smw": "Semantik MediaWiki",
 	"prefs-ask-options": "Maʼnoviy qidiruv moslamalari",
 	"smw-prefs-ask-options-tooltip-display": "«Matn» koʻrsatkichini paydo boʻladigan yordamchi sifatida aks ettirish",
-	"smw_unknowntype": "Ushbu xossaning tipi noto'g'ri"
+	"smw_unknowntype": "Ushbu xossaning tipi noto'g'ri",
+	"smw-listingcontinuesabbrev": "davomi"
 }

--- a/i18n/vec.json
+++ b/i18n/vec.json
@@ -8,5 +8,6 @@
 	"browse": "Nàvega ła wiki",
 	"smw-ui-tooltip-title-legend": "Lejenda",
 	"smw-livepreview-loading": "Caricamento in corso…",
-	"smw-legend": "Lejenda"
+	"smw-legend": "Lejenda",
+	"smw-listingcontinuesabbrev": "cont."
 }

--- a/i18n/vep.json
+++ b/i18n/vep.json
@@ -24,5 +24,6 @@
 	"smw_result_results": "Rezul'tatad",
 	"smw_result_noresults": "Ei ole rezul'tatoid.",
 	"smwadmin": "Redaktiruida Semantic MediaWiki",
-	"smw-livepreview-loading": "Ozutase…"
+	"smw-livepreview-loading": "Ozutase…",
+	"smw-listingcontinuesabbrev": "jatktand"
 }

--- a/i18n/vi.json
+++ b/i18n/vi.json
@@ -192,5 +192,6 @@
 	"smw-livepreview-loading": "Đang tải…",
 	"smw-property-tab-usage": "Sử dụng",
 	"smw-concept-tab-list": "Danh sách",
-	"smw-concept-tab-errors": "Lỗi"
+	"smw-concept-tab-errors": "Lỗi",
+	"smw-listingcontinuesabbrev": "(tiếp theo)"
 }

--- a/i18n/vo.json
+++ b/i18n/vo.json
@@ -77,5 +77,6 @@
 	"smw_smwadmin_return": "Geikön lü pad: $1",
 	"smw_concept_header": "Pads suemoda: „$1“.",
 	"smw_conceptarticlecount": "{{PLURAL:$1|Pajonon pad $1, kel duton|Pajonons pads $1, kels dutons}} lü suemod at.",
-	"smw-livepreview-loading": "Pabelodon…"
+	"smw-livepreview-loading": "Pabelodon…",
+	"smw-listingcontinuesabbrev": "(fov.)"
 }

--- a/i18n/vro.json
+++ b/i18n/vro.json
@@ -5,5 +5,6 @@
 		]
 	},
 	"browse": "Viki kaeminõ",
-	"smw-livepreview-loading": "Laat…"
+	"smw-livepreview-loading": "Laat…",
+	"smw-listingcontinuesabbrev": "lätt edesi"
 }

--- a/i18n/wa.json
+++ b/i18n/wa.json
@@ -8,5 +8,6 @@
 	"smw_purge": "Rafrister",
 	"browse": "Naivyî el wiki",
 	"smw-ui-tooltip-title-legend": "Ledjinde",
-	"smw-livepreview-loading": "Tcherdjant..."
+	"smw-livepreview-loading": "Tcherdjant...",
+	"smw-listingcontinuesabbrev": "(shûte)"
 }

--- a/i18n/war.json
+++ b/i18n/war.json
@@ -5,5 +5,6 @@
 		]
 	},
 	"browse": "Browse wiki",
-	"smw-livepreview-loading": "Ginkakarga. . ."
+	"smw-livepreview-loading": "Ginkakarga. . .",
+	"smw-listingcontinuesabbrev": "pdyn."
 }

--- a/i18n/wo.json
+++ b/i18n/wo.json
@@ -4,5 +4,6 @@
 			"Ibou"
 		]
 	},
-	"browse": "Wër wiki bi"
+	"browse": "Wër wiki bi",
+	"smw-listingcontinuesabbrev": "(desit)"
 }

--- a/i18n/wuu.json
+++ b/i18n/wuu.json
@@ -4,5 +4,6 @@
 			"Poiuyt"
 		]
 	},
-	"browse": "浏览维基"
+	"browse": "浏览维基",
+	"smw-listingcontinuesabbrev": "续"
 }

--- a/i18n/xal.json
+++ b/i18n/xal.json
@@ -2,5 +2,6 @@
 	"@metadata": {
 		"authors": []
 	},
-	"smw-livepreview-loading": "Белднә..."
+	"smw-livepreview-loading": "Белднә...",
+	"smw-listingcontinuesabbrev": "(залһан)"
 }

--- a/i18n/xmf.json
+++ b/i18n/xmf.json
@@ -8,5 +8,6 @@
 	"browse": "ვიკიშ ძირაფა",
 	"smw-limitreport-intext-parsertime-value": "$1 მერქა",
 	"smw-limitreport-pagepurge-storeupdatetime-value": "$1 მერქა",
-	"smw-jsonview-search-label": "გორუა:"
+	"smw-jsonview-search-label": "გორუა:",
+	"smw-listingcontinuesabbrev": "გჷნძარ."
 }

--- a/i18n/yi.json
+++ b/i18n/yi.json
@@ -23,5 +23,6 @@
 	"smw-ui-tooltip-title-parameter": "פאַראַמעטער",
 	"smw-ui-tooltip-title-reference": "רעפערענץ",
 	"smw-livepreview-loading": "לאדנדיג…",
-	"smw-search-syntax": "סינטאקס"
+	"smw-search-syntax": "סינטאקס",
+	"smw-listingcontinuesabbrev": "(המשך)"
 }

--- a/i18n/yo.json
+++ b/i18n/yo.json
@@ -6,5 +6,6 @@
 	},
 	"browse": "Ìtúwò wiki",
 	"smw-livepreview-loading": "Óúnbọ̀wá...",
-	"smw-property-preferred-title-format": "$1 ($2)"
+	"smw-property-preferred-title-format": "$1 ($2)",
+	"smw-listingcontinuesabbrev": "tẹ̀síwájú"
 }

--- a/i18n/yue.json
+++ b/i18n/yue.json
@@ -62,5 +62,6 @@
 	"smw-livepreview-loading": "撈緊...",
 	"log-name-smw": "語意MediaWiki日誌",
 	"smw-datavalue-time-invalid-date-components-common": "“$1”包含一啲無法解釋嘅信息。",
-	"smw-datavalue-external-formatter-invalid-uri": "“$1”係無效連結。"
+	"smw-datavalue-external-formatter-invalid-uri": "“$1”係無效連結。",
+	"smw-listingcontinuesabbrev": "續"
 }

--- a/i18n/zh-hans.json
+++ b/i18n/zh-hans.json
@@ -953,5 +953,6 @@
 	"smw-entity-examiner-associated-revision-mismatch": "版本",
 	"smw-entity-examiner-deferred-fake": "假的",
 	"smw-indicator-constraint-violation": "{{PLURAL:$1|约束}}",
-	"smw-indicator-revision-mismatch": "版本"
+	"smw-indicator-revision-mismatch": "版本",
+	"smw-listingcontinuesabbrev": "续"
 }

--- a/i18n/zh-hant.json
+++ b/i18n/zh-hant.json
@@ -1123,5 +1123,6 @@
 	"smw-indicator-constraint-violation": "{{PLURAL:$1|限制}}",
 	"smw-indicator-revision-mismatch": "修訂",
 	"smw-indicator-revision-mismatch-error": "[https://www.semantic-mediawiki.org/wiki/Help:Associated_revision/Examiner 相關修訂]檢查發現在 MediaWiki 引用的修訂之間內容不符合，且關聯到用於此實體的 Semantic MediaWiki。",
-	"smw-indicator-revision-mismatch-comment": "不符合通常表示某些程序中斷了在 Semantic MediaWiki 的儲存操作。建議檢視伺服器日誌並查看例外或其它錯誤。"
+	"smw-indicator-revision-mismatch-comment": "不符合通常表示某些程序中斷了在 Semantic MediaWiki 的儲存操作。建議檢視伺服器日誌並查看例外或其它錯誤。",
+	"smw-listingcontinuesabbrev": "續"
 }

--- a/includes/SMW_PageLister.php
+++ b/includes/SMW_PageLister.php
@@ -254,7 +254,7 @@ class SMWPageLister {
 					}
 
 					if ( $startChar == $prevStartChar ) {
-						$cont_msg = ' ' . wfMessage( 'listingcontinuesabbrev' )->escaped();
+						$cont_msg = ' ' . wfMessage( 'smw-listingcontinuesabbrev' )->escaped();
 					} else {
 						$cont_msg = '';
 					}

--- a/src/MediaWiki/Page/ListBuilder.php
+++ b/src/MediaWiki/Page/ListBuilder.php
@@ -153,7 +153,7 @@ class ListBuilder {
 		$htmlColumns->isRTL( $this->isRTL );
 
 		$htmlColumns->setContinueAbbrev(
-			Message::get( 'listingcontinuesabbrev', Message::PARSE, Message::USER_LANGUAGE )
+			Message::get( 'smw-listingcontinuesabbrev', Message::PARSE, Message::USER_LANGUAGE )
 		);
 
 		$htmlColumns->setContents(

--- a/src/MediaWiki/Renderer/HtmlColumnListRenderer.php
+++ b/src/MediaWiki/Renderer/HtmlColumnListRenderer.php
@@ -209,7 +209,7 @@ class HtmlColumnListRenderer {
 		}
 
 		$this->rowsPerColumn = ceil( $this->numberOfResults / $this->numberOfColumns );
-		$listContinuesAbbrev = wfMessage( 'listingcontinuesabbrev' )->text();
+		$listContinuesAbbrev = wfMessage( 'smw-listingcontinuesabbrev' )->text();
 
 		foreach ( $this->contentsByIndex as $key => $resultItems ) {
 

--- a/src/Query/ResultPrinters/CategoryResultPrinter.php
+++ b/src/Query/ResultPrinters/CategoryResultPrinter.php
@@ -157,7 +157,7 @@ class CategoryResultPrinter extends ResultPrinter {
 
 		$language = Localizer::getInstance()->getUserLanguage();
 
-		$this->htmlColumns->setContinueAbbrev( wfMessage( 'listingcontinuesabbrev' )->text() );
+		$this->htmlColumns->setContinueAbbrev( wfMessage( 'smw-listingcontinuesabbrev' )->text() );
 		$this->htmlColumns->setColumns( $this->numColumns );
 		$this->htmlColumns->isRTL( $language->isRTL() );
 

--- a/tests/phpunit/MediaWiki/Renderer/HtmlColumnListRendererTest.php
+++ b/tests/phpunit/MediaWiki/Renderer/HtmlColumnListRendererTest.php
@@ -65,7 +65,7 @@ class HtmlColumnListRendererTest extends \PHPUnit_Framework_TestCase {
 			'B' => [ 'Baz', 'Fom', 'Fin', 'Fum' ]
 		] );
 
-		$listContinuesAbbrev = wfMessage( 'listingcontinuesabbrev' )->text();
+		$listContinuesAbbrev = wfMessage( 'smw-listingcontinuesabbrev' )->text();
 
 		$expected = [
 			'<div class="smw-columnlist-container" dir="ltr">',


### PR DESCRIPTION
SMW uses a MW message "listingcontinuesabbrev".
This was removed in MW 1.36: https://github.com/wikimedia/mediawiki/commit/14ab3d95986fd6b8e72eca352e224a9467d31ad0

This causes 2 tests to fail (for 1.36 and 1.37) and it will look weird on the UI as well:
1) SMW\Tests\Integration\JSONScript\JSONScriptTestCaseRunnerTest::testCaseFile with data set "f-0301.json"
https://github.com/SemanticMediaWiki/SemanticMediaWiki/runs/4633024053?check_suite_focus=true#step:10:6207

2) SMW\Tests\Integration\JSONScript\JSONScriptTestCaseRunnerTest::testCaseFile with data set "f-0303.json"
https://github.com/SemanticMediaWiki/SemanticMediaWiki/runs/4633024053?check_suite_focus=true#step:10:6226

The failure is caused by the original message no longer returning anything:
```<div class="smw-column-header">A ⧼listingcontinuesabbrev⧽</div>```

This PR simply moves the message translation into SMW for all languages where SMW has a language file and where MW 1.35 has a translation for the message.
Languages without the message translation in MW: [missing-translation-mw.txt](https://github.com/SemanticMediaWiki/SemanticMediaWiki/files/7776257/missing-translation-mw.txt)
Languages missing in SMW: [missing-language-smw.txt](https://github.com/SemanticMediaWiki/SemanticMediaWiki/files/7776256/missing-language-smw.txt)

There is no alternative core message with the same value as this one.

Not sure if something like this was done before and if this is the best way.

