### PR TITLE
Replace usage of deprecated global function wfReadOnly()

### DIFF
--- a/src/MediaWiki/PageUpdater.php
+++ b/src/MediaWiki/PageUpdater.php
@@ -4,6 +4,7 @@ namespace SMW\MediaWiki;
 
 use DeferrableUpdate;
 use DeferredpendingUpdates;
+use MediaWiki\MediaWikiServices;
 use Psr\Log\LoggerAwareTrait;
 use SMW\MediaWiki\Deferred\TransactionalCallableUpdate;
 use SMW\Utils\Timer;
@@ -171,7 +172,7 @@ class PageUpdater implements DeferrableUpdate {
 	 * @return boolean
 	 */
 	public function canUpdate() {
-		return !wfReadOnly();
+		return !MediaWikiServices::getInstance()->getReadOnlyMode()->isReadOnly();
 	}
 
 	/**

--- a/src/Site.php
+++ b/src/Site.php
@@ -2,6 +2,7 @@
 
 namespace SMW;
 
+use MediaWiki\MediaWikiServices;
 use SiteStats;
 use WikiMap;
 
@@ -25,7 +26,7 @@ class Site {
 		// MediaWiki\Services\ServiceDisabledException from line 340 of
 		// ...\ServiceContainer.php: Service disabled: DBLoadBalancer
 		try {
-			$isReadOnly = wfReadOnly();
+			$isReadOnly = MediaWikiServices::getInstance()->getReadOnlyMode()->isReadOnly();
 		} catch( \MediaWiki\Services\ServiceDisabledException $e ) {
 			$isReadOnly = true;
 		}


### PR DESCRIPTION
The global function wfReadOnly() has been deprecated in favor of the
new ReadOnlyMode service. Its usages should be replaced.