### PR TITLE
Fix missing parenthesis on a method call

### DIFF
--- a/src/MediaWiki/Jobs/ParserCachePurgeJob.php
+++ b/src/MediaWiki/Jobs/ParserCachePurgeJob.php
@@ -46,7 +46,7 @@ class ParserCachePurgeJob extends Job {
 		if ( $this->hasParameter( 'user' ) ) {
 			$causeAgent = $this->getParameter( 'user' );
 		} else {
-			$causeAgent = RequestContext::getMain()->getUser()->getName;
+			$causeAgent = RequestContext::getMain()->getUser()->getName();
 		}
 
 		if ( $page === null ) {


### PR DESCRIPTION
This causes non-existent property PHP warnings.