### PR TITLE
Return without processing if the context does not have a title set

### DIFF
--- a/src/MediaWiki/Hooks/OutputPageParserOutput.php
+++ b/src/MediaWiki/Hooks/OutputPageParserOutput.php
@@ -72,7 +72,7 @@ class OutputPageParserOutput implements HookListener {
 
 		$title = $outputPage->getTitle();
 
-		if ( $title->isSpecialPage() || $title->isRedirect() ) {
+		if ( $title === null || $title->isSpecialPage() || $title->isRedirect() ) {
 			return true;
 		}
 


### PR DESCRIPTION
Otherwise, we'll get method called on null.

Fixes #5077