### PR TITLE
Passing a string to ParserOutput::addModules()/addModuleStyles() is deprecated

### DIFF
--- a/src/Query/Deferred.php
+++ b/src/Query/Deferred.php
@@ -35,8 +35,8 @@ class Deferred {
 	 * @param ParserOutput $parserOutput
 	 */
 	public static function registerResources( ParserOutput $parserOutput ) {
-		$parserOutput->addModuleStyles( 'ext.smw.deferred.styles' );
-		$parserOutput->addModules( 'ext.smw.deferred' );
+		$parserOutput->addModuleStyles( [ 'ext.smw.deferred.styles' ] );
+		$parserOutput->addModules( [ 'ext.smw.deferred' ] );
 	}
 
 	/**


### PR DESCRIPTION
Bug: T296123