### PR TITLE
Fix html columns util

### DIFF
--- a/src/Utils/HtmlColumns.php
+++ b/src/Utils/HtmlColumns.php
@@ -273,7 +273,7 @@ class HtmlColumns {
 			);
 		}
 
-		if ( !$usedColumnCloser ) {
+		if ( !$usedColumnCloser && !empty( $result ) ) {
 			$result .= "</{$this->listType}></div> <!-- end column -->";
 		}
 


### PR DESCRIPTION
If `$this->contents` is empty closing tag would be created
even though no opening tag is in the buffer.