### PR TITLE
correct year

### DIFF
--- a/docs/COMPATIBILITY.md
+++ b/docs/COMPATIBILITY.md
@@ -32,7 +32,7 @@ Increases of minimum requirements are indicated in bold.
 		<th><a href="https://www.semantic-mediawiki.org/wiki/Semantic_MediaWiki_4.0.0">4.0.x</a></th>
 		<td><strong>7.3.0</strong> - 7.4.x</td>
 		<td><strong>1.35.0</strong> - 1.37.x</td>
-		<td>2021-01-18</td>
+		<td>2022-01-18</td>
 		<td><strong>Stable release</strong></td>
 	</tr>
 	<tr>


### PR DESCRIPTION
I get it, sometimes I still write 2021 myself... 😄 

Also, https://www.semantic-mediawiki.org/wiki/Semantic_MediaWiki_4.0.0 mentions "See the English language RELEASE NOTES below on this page for further information" but doesn't show or link to anything.