### PR TITLE
Move misplaced factbox resource loader module

### DIFF
--- a/src/MediaWiki/Content/SchemaContentFormatter.php
+++ b/src/MediaWiki/Content/SchemaContentFormatter.php
@@ -89,7 +89,6 @@ class SchemaContentFormatter {
 			'mediawiki.content.json',
 			'ext.smw.style',
 			'ext.smw.table.styles',
-			'smw.factbox',
 		], SummaryTable::getModuleStyles() );
 	}
 
@@ -99,7 +98,7 @@ class SchemaContentFormatter {
 	 * @return []
 	 */
 	public function getModules() {
-		return [ 'smw.content.schemaview' ];
+		return [ 'smw.content.schemaview', 'smw.factbox' ];
 	}
 
 	/**


### PR DESCRIPTION
Avoids this error:

{"message":"Unexpected general module \"{module}\" in styles queue.","context":{"module":"smw.factbox"