### PR TITLE
Update uses of ParserOutput::getPageProperty() to handle new return val

### DIFF
--- a/src/MediaWiki/Hooks/ParserAfterTidy.php
+++ b/src/MediaWiki/Hooks/ParserAfterTidy.php
@@ -136,7 +136,8 @@ class ParserAfterTidy implements HookListener {
 		$parserOutput = $this->parser->getOutput();
 
 		if ( method_exists( $parserOutput, 'getPageProperty' ) ) {
-			$displayTitle = $parserOutput->getPageProperty( 'displaytitle' );
+			// T301915
+			$displayTitle = $parserOutput->getPageProperty( 'displaytitle' ) ?? false;
 		} else {
 			// MW < 1.38
 			$displayTitle = $parserOutput->getProperty( 'displaytitle' );
@@ -224,7 +225,8 @@ class ParserAfterTidy implements HookListener {
 		);
 
 		if ( method_exists( $parserOutput, 'getPageProperty') ) {
-			$displayTitle = $parserOutput->getPageProperty( 'displaytitle' );
+			// T301915
+			$displayTitle = $parserOutput->getPageProperty( 'displaytitle' ) ?? false;
 		} else {
 			// MW < 1.38
 			$displayTitle = $parserOutput->getProperty( 'displaytitle' );

--- a/src/ParserData.php
+++ b/src/ParserData.php
@@ -385,7 +385,8 @@ class ParserData {
 	 */
 	public static function hasSemanticData( ParserOutput $parserOutput ) {
 		if ( method_exists( $parserOutput, 'getPageProperty' ) ) {
-			return (bool)$parserOutput->getPageProperty( 'smw-semanticdata-status' );
+			// T301915
+			return (bool)( $parserOutput->getPageProperty( 'smw-semanticdata-status' ) ?? false );
 		} else {
 			// MW < 1.38
 			return (bool)$parserOutput->getProperty( 'smw-semanticdata-status' );


### PR DESCRIPTION
The return value of ParserOutput::getPageProperty() will transition to
returning `null` instead of `false` when the page property is missing.

Bug: T301915