### PR TITLE
Fix special property Is_a_new_page

### DIFF
--- a/src/MediaWiki/PageInfoProvider.php
+++ b/src/MediaWiki/PageInfoProvider.php
@@ -96,20 +96,14 @@ class PageInfoProvider implements PageInfo {
 	 * @return boolean
 	 */
 	public function isNewPage() {
-
-		if ( $this->isFilePage() ) {
+		 if ( $this->isFilePage() ) {
 			return isset( $this->wikiPage->smwFileReUploadStatus ) ? !$this->wikiPage->smwFileReUploadStatus : false;
 		}
 
-		if ( $this->revision ) {
-			return $this->revision->getParentId() === null;
-		}
+		$revision = $this->revision ??
+			$this->revisionGuard->newRevisionFromPage( $this->wikiPage );
 
-		$revision = $this->revisionGuard->newRevisionFromPage(
-			$this->wikiPage
-		);
-
-		return $revision->getParentId() === null;
+		return $revision->getParentId() === 0;
 	}
 
 	/**

--- a/tests/phpunit/MediaWiki/PageInfoProviderTest.php
+++ b/tests/phpunit/MediaWiki/PageInfoProviderTest.php
@@ -132,7 +132,8 @@ class PageInfoProviderTest extends \PHPUnit_Framework_TestCase {
 
 		$provider = [
 			[ 90001, false ],
-			[ null , true ]
+			[ 0 , true ],
+			[ null, false ]
 		];
 
 		return $provider;


### PR DESCRIPTION
Check for revision's parent id to be 0 (instead of null) in
PageInfoProvider::isNewPage. (According to the documentation of
RevisionRecord::getParentId: "If there is no parent revision, this
returns 0. If the parent revision is undefined or unknown, this
returns null.")

fixes #5082