### PR TITLE
Replace LinksUpdateConstructed with LinksUpdateComplete hook

### DIFF
--- a/src/MediaWiki/Hooks.php
+++ b/src/MediaWiki/Hooks.php
@@ -39,7 +39,7 @@ use SMW\MediaWiki\Hooks\ExtensionTypes;
 use SMW\MediaWiki\Hooks\FileUpload;
 use SMW\MediaWiki\Hooks\GetPreferences;
 use SMW\MediaWiki\Hooks\InternalParseBeforeLinks;
-use SMW\MediaWiki\Hooks\LinksUpdateConstructed;
+use SMW\MediaWiki\Hooks\LinksUpdateComplete;
 use SMW\MediaWiki\Hooks\RevisionFromEditComplete;
 use SMW\MediaWiki\Hooks\OutputPageParserOutput;
 use SMW\MediaWiki\Hooks\ParserAfterTidy;
@@ -270,7 +270,7 @@ class Hooks {
 			'ContentHandlerForModelID' => [ $this, 'onContentHandlerForModelID' ],
 
 			'RevisionFromEditComplete' => [ $this, 'onRevisionFromEditComplete' ],
-			'LinksUpdateConstructed' => [ $this, 'onLinksUpdateConstructed' ],
+			'LinksUpdateComplete' => [ $this, 'onLinksUpdateComplete' ],
 			'FileUpload' => [ $this, 'onFileUpload' ],
 			'MaintenanceUpdateAddParams' => [ $this, 'onMaintenanceUpdateAddParams' ],
 
@@ -824,15 +824,15 @@ class Hooks {
 	}
 
 	/**
-	 * Hook: LinksUpdateConstructed called at the end of LinksUpdate() construction
+	 * Hook: LinksUpdateComplete called at the end of LinksUpdate() construction
 	 *
-	 * @see https://www.mediawiki.org/wiki/Manual:Hooks/LinksUpdateConstructed
+	 * @see https://www.mediawiki.org/wiki/Manual:Hooks/LinksUpdateComplete
 	 */
-	public function onLinksUpdateConstructed( $linksUpdate ) {
+	public function onLinksUpdateComplete( $linksUpdate ) {
 
 		$applicationFactory = ApplicationFactory::getInstance();
 
-		$linksUpdateConstructed = new LinksUpdateConstructed(
+		$linksUpdateConstructed = new LinksUpdateComplete(
 			$applicationFactory->getNamespaceExaminer()
 		);
 

--- a/src/MediaWiki/Hooks/LinksUpdateComplete.php
+++ b/src/MediaWiki/Hooks/LinksUpdateComplete.php
@@ -11,16 +11,16 @@ use SMW\MediaWiki\HookListener;
 use Psr\Log\LoggerAwareTrait;
 
 /**
- * LinksUpdateConstructed hook is called at the end of LinksUpdate()
+ * LinksUpdateComplete hook is called at the end of LinksUpdate()
  *
- * @see https://www.mediawiki.org/wiki/Manual:Hooks/LinksUpdateConstructed
+ * @see https://www.mediawiki.org/wiki/Manual:Hooks/LinksUpdateComplete
  *
  * @license GNU GPL v2+
  * @since 1.9
  *
  * @author mwjames
  */
-class LinksUpdateConstructed implements HookListener {
+class LinksUpdateComplete implements HookListener {
 
 	use RevisionGuardAwareTrait;
 	use LoggerAwareTrait;

--- a/src/MediaWiki/Hooks/ParserAfterTidy.php
+++ b/src/MediaWiki/Hooks/ParserAfterTidy.php
@@ -266,7 +266,7 @@ class ParserAfterTidy implements HookListener {
 
 	/**
 	 * @note Article purge: In case an article was manually purged/moved
-	 * the store is updated as well; for all other cases LinksUpdateConstructed
+	 * the store is updated as well; for all other cases LinksUpdateComplete
 	 * will handle the store update
 	 *
 	 * @note The purge action is isolated from any other request therefore using

--- a/src/MediaWiki/Hooks/README.md
+++ b/src/MediaWiki/Hooks/README.md
@@ -9,14 +9,14 @@ BeforePageDisplay allows last minute changes to the output page and is being use
 #### InternalParseBeforeLinks
 InternalParseBeforeLinks is used to process and expand text content, and in case of SMW it is used to identify and resolve the property annotation syntax ([[link::syntax]]), returning a modified content component and storing annotations within the ParserOutput object.
 
-#### LinksUpdateConstructed
-LinksUpdateConstructed is called at the end of LinksUpdate and is being used to initiate a store update for data that were held by the ParserOutput object.
+#### LinksUpdateComplete
+LinksUpdateComplete is called at the end of LinksUpdate and is being used to initiate a store update for data that were held by the ParserOutput object.
 
 #### RevisionFromEditComplete
 RevisionFromEditComplete called when a new revision was inserted due to an edit and used to update the ParserOuput with the latests special property annotation.
 
 #### ParserAfterTidy
-ParserAfterTidy is used to re-introduce content, update base annotations (e.g. special properties, categories etc.) and in case of a manual article purge initiates a store update (LinksUpdateConstructed wouldn't work because it acts only on link changes and therefore would not trigger a LinksUpdateConstructed event).
+ParserAfterTidy is used to re-introduce content, update base annotations (e.g. special properties, categories etc.) and in case of a manual article purge initiates a store update (LinksUpdateComplete wouldn't work because it acts only on link changes and therefore would not trigger a LinksUpdateComplete event).
 
 #### SpecialStatsAddExtra
 SpecialStatsAddExtra is used to add additional statistic being shown at Special:Statistics.

--- a/tests/phpunit/Integration/MediaWiki/Hooks/FileUploadIntegrationTest.php
+++ b/tests/phpunit/Integration/MediaWiki/Hooks/FileUploadIntegrationTest.php
@@ -63,8 +63,8 @@ class FileUploadIntegrationTest extends DatabaseTestCase {
 		);
 
 		$this->mwHooksHandler->register(
-			'LinksUpdateConstructed',
-			$this->mwHooksHandler->getHookRegistry()->getHandlerFor( 'LinksUpdateConstructed' )
+			'LinksUpdateComplete',
+			$this->mwHooksHandler->getHookRegistry()->getHandlerFor( 'LinksUpdateComplete' )
 		);
 
 		$this->getStore()->setup( false );

--- a/tests/phpunit/Integration/MediaWiki/Hooks/PageMoveCompleteIntegrationTest.php
+++ b/tests/phpunit/Integration/MediaWiki/Hooks/PageMoveCompleteIntegrationTest.php
@@ -104,8 +104,8 @@ class PageMoveCompleteIntegrationTest extends DatabaseTestCase {
 		);
 
 		$this->mwHooksHandler->register(
-			'LinksUpdateConstructed',
-			$this->mwHooksHandler->getHookRegistry()->getHandlerFor( 'LinksUpdateConstructed' )
+			'LinksUpdateComplete',
+			$this->mwHooksHandler->getHookRegistry()->getHandlerFor( 'LinksUpdateComplete' )
 		);
 
 		$title = Title::newFromText( __METHOD__ . '-old' );

--- a/tests/phpunit/Integration/MediaWiki/LinksUpdateEmptyParserOutputDBIntegrationTest.php
+++ b/tests/phpunit/Integration/MediaWiki/LinksUpdateEmptyParserOutputDBIntegrationTest.php
@@ -33,7 +33,7 @@ class LinksUpdateEmptyParserOutputDBIntegrationTest extends DatabaseTestCase {
 
 		$pageCreator
 			->createPage( $title )
-			->doEdit( '[[Has some property::LinksUpdateConstructedOnEmptyParserOutput]]' );
+			->doEdit( '[[Has some property::LinksUpdateCompleteOnEmptyParserOutput]]' );
 
 		$propertiesCountBeforeUpdate = count( $this->getStore()->getSemanticData( $subject )->getProperties() );
 

--- a/tests/phpunit/Integration/MediaWiki/LinksUpdateTest.php
+++ b/tests/phpunit/Integration/MediaWiki/LinksUpdateTest.php
@@ -113,7 +113,7 @@ class LinksUpdateTest extends DatabaseTestCase {
 		);
 
 		/**
-		 * See #347 and LinksUpdateConstructed
+		 * See #347 and LinksUpdateComplete
 		 */
 		$linksUpdate = new \LinksUpdate( $this->title, new \ParserOutput() );
 		$linksUpdate->doUpdate();

--- a/tests/phpunit/MediaWiki/Hooks/LinksUpdateCompleteTest.php
+++ b/tests/phpunit/MediaWiki/Hooks/LinksUpdateCompleteTest.php
@@ -4,12 +4,12 @@ namespace SMW\Tests\MediaWiki\Hooks;
 
 use LinksUpdate;
 use ParserOutput;
-use SMW\MediaWiki\Hooks\LinksUpdateConstructed;
+use SMW\MediaWiki\Hooks\LinksUpdateComplete;
 use SMW\Tests\TestEnvironment;
 use Title;
 
 /**
- * @covers \SMW\MediaWiki\Hooks\LinksUpdateConstructed
+ * @covers \SMW\MediaWiki\Hooks\LinksUpdateComplete
  * @group semantic-mediawiki
  *
  * @license GNU GPL v2+
@@ -17,7 +17,7 @@ use Title;
  *
  * @author mwjames
  */
-class LinksUpdateConstructedTest extends \PHPUnit_Framework_TestCase {
+class LinksUpdateCompleteTest extends \PHPUnit_Framework_TestCase {
 
 	private $testEnvironment;
 	private $namespaceExaminer;
@@ -68,8 +68,8 @@ class LinksUpdateConstructedTest extends \PHPUnit_Framework_TestCase {
 	public function testCanConstruct() {
 
 		$this->assertInstanceOf(
-			LinksUpdateConstructed::class,
-			new LinksUpdateConstructed( $this->namespaceExaminer )
+			LinksUpdateComplete::class,
+			new LinksUpdateComplete( $this->namespaceExaminer )
 		);
 	}
 
@@ -132,7 +132,7 @@ class LinksUpdateConstructedTest extends \PHPUnit_Framework_TestCase {
 
 		$this->testEnvironment->registerObject( 'Store', $store );
 
-		$instance = new LinksUpdateConstructed(
+		$instance = new LinksUpdateComplete(
 			$this->namespaceExaminer
 		);
 
@@ -183,7 +183,7 @@ class LinksUpdateConstructedTest extends \PHPUnit_Framework_TestCase {
 			->method( 'getParserOutput' )
 			->will( $this->returnValue( $parserOutput ) );
 
-		$instance = new LinksUpdateConstructed(
+		$instance = new LinksUpdateComplete(
 			$this->namespaceExaminer
 		);
 
@@ -234,7 +234,7 @@ class LinksUpdateConstructedTest extends \PHPUnit_Framework_TestCase {
 		$linksUpdate->mTemplates = [ 'Foo' ];
 		$linksUpdate->mRecursive = false;
 
-		$instance = new LinksUpdateConstructed(
+		$instance = new LinksUpdateComplete(
 			$this->namespaceExaminer
 		);
 
@@ -258,7 +258,7 @@ class LinksUpdateConstructedTest extends \PHPUnit_Framework_TestCase {
 		$linksUpdate->expects( $this->never() )
 			->method( 'getTitle' );
 
-		$instance = new LinksUpdateConstructed(
+		$instance = new LinksUpdateComplete(
 			$this->namespaceExaminer
 		);
 

--- a/tests/phpunit/MediaWiki/HooksTest.php
+++ b/tests/phpunit/MediaWiki/HooksTest.php
@@ -279,7 +279,7 @@ class HooksTest extends \PHPUnit_Framework_TestCase {
 			[ 'callArticleViewHeader' ],
 			[ 'callArticlePurge' ],
 			[ 'callArticleDelete' ],
-			[ 'callLinksUpdateConstructed' ],
+			[ 'callLinksUpdateComplete' ],
 			[ 'callSpecialStatsAddExtra' ],
 			[ 'callFileUpload' ],
 			[ 'callMaintenanceUpdateAddParams' ],
@@ -902,9 +902,9 @@ class HooksTest extends \PHPUnit_Framework_TestCase {
 		return $handler;
 	}
 
-	public function callLinksUpdateConstructed( $instance ) {
+	public function callLinksUpdateComplete( $instance ) {
 
-		$handler = 'LinksUpdateConstructed';
+		$handler = 'LinksUpdateComplete';
 
 		$idTable = $this->getMockBuilder( '\stdClass' )
 			->setMethods( [ 'exists', 'findAssociatedRev' ] )


### PR DESCRIPTION
LinksUpdateConstructed is deprecated in MW 1.38

Bug: T305136