### PR TITLE
Remove usage of LinksUpdate::mTemplate

### DIFF
--- a/src/MediaWiki/Hooks/LinksUpdateConstructed.php
+++ b/src/MediaWiki/Hooks/LinksUpdateConstructed.php
@@ -112,7 +112,7 @@ class LinksUpdateConstructed implements HookListener {
 
 		// Update incurred by a template change and is signaled through
 		// the following condition
-		if ( $linksUpdate->mTemplates !== [] && $linksUpdate->mRecursive === false ) {
+		if ( $linksUpdate->getParserOutput()->getTemplates() !== [] && $linksUpdate->mRecursive === false ) {
 			$parserData->setOption( $parserData::OPT_FORCED_UPDATE, true );
 		}
 


### PR DESCRIPTION
This is deprecated in MW 1.38. Use
LinksUpdate::getParserOutput()->getTemplates()

Bug: T305136