### PR TITLE
Replace deprecated use of LinksUpdate::mRecursive

### DIFF
--- a/src/MediaWiki/Hooks/LinksUpdateComplete.php
+++ b/src/MediaWiki/Hooks/LinksUpdateComplete.php
@@ -112,7 +112,7 @@ class LinksUpdateComplete implements HookListener {
 
 		// Update incurred by a template change and is signaled through
 		// the following condition
-		if ( $linksUpdate->getParserOutput()->getTemplates() !== [] && $linksUpdate->mRecursive === false ) {
+		if ( $linksUpdate->getParserOutput()->getTemplates() !== [] && $linksUpdate->isRecursive() === false ) {
 			$parserData->setOption( $parserData::OPT_FORCED_UPDATE, true );
 		}
 


### PR DESCRIPTION
Deprecated in 1.38, getter available since 1.34.

https://phabricator.wikimedia.org/T305136