### PR TITLE
Deprecate SkinTemplateNavigation in favor of SkinTemplateNavigation::Universal

### DIFF
--- a/src/MediaWiki/Hooks.php
+++ b/src/MediaWiki/Hooks.php
@@ -48,7 +48,7 @@ use SMW\MediaWiki\Hooks\RejectParserCacheValue;
 use SMW\MediaWiki\Hooks\ResourceLoaderGetConfigVars;
 use SMW\MediaWiki\Hooks\SidebarBeforeOutput;
 use SMW\MediaWiki\Hooks\SkinAfterContent;
-use SMW\MediaWiki\Hooks\SkinTemplateNavigation;
+use SMW\MediaWiki\Hooks\SkinTemplateNavigationUniversal;
 use SMW\MediaWiki\Hooks\SpecialSearchResultsPrepend;
 use SMW\MediaWiki\Hooks\SpecialStatsAddExtra;
 use SMW\MediaWiki\Hooks\TitleIsAlwaysKnown;
@@ -277,7 +277,7 @@ class Hooks {
 			'ResourceLoaderGetConfigVars' => [ $this, 'onResourceLoaderGetConfigVars' ],
 			'GetPreferences' => [ $this, 'onGetPreferences' ],
 			'PersonalUrls' => [ $this, 'onPersonalUrls' ],
-			'SkinTemplateNavigation' => [ $this, 'onSkinTemplateNavigation' ],
+			'SkinTemplateNavigation::Universal' => [ $this, 'onSkinTemplateNavigationUniversal' ],
 			'SidebarBeforeOutput' => [ $this, 'onSidebarBeforeOutput' ],
 			'LoadExtensionSchemaUpdates' => [ $this, 'onLoadExtensionSchemaUpdates' ],
 
@@ -1016,16 +1016,16 @@ class Hooks {
 	}
 
 	/**
-	 * @see https://www.mediawiki.org/wiki/Manual:Hooks/SkinTemplateNavigation
+	 * @see https://www.mediawiki.org/wiki/Manual:Hooks/SkinTemplateNavigation::Universal
 	 */
-	public function onSkinTemplateNavigation( &$skinTemplate, &$links ) {
+	public function onSkinTemplateNavigationUniversal( &$skinTemplate, &$links ) {
 
-		$skinTemplateNavigation = new SkinTemplateNavigation(
+		$skinTemplateNavigationUniversal = new SkinTemplateNavigationUniversal(
 			$skinTemplate,
 			$links
 		);
 
-		return $skinTemplateNavigation->process();
+		return $skinTemplateNavigationUniversal->process();
 	}
 
 	/**

--- a/src/MediaWiki/Hooks/README.md
+++ b/src/MediaWiki/Hooks/README.md
@@ -34,6 +34,6 @@ Update the Store after an article has been deleted.
 
 #### GetPreferences
 
-#### SkinTemplateNavigation
+#### SkinTemplateNavigation::Universal
 
 [hooks]: https://www.mediawiki.org/wiki/Hooks "Manual:Hooks"

--- a/src/MediaWiki/Hooks/SkinTemplateNavigationUniversal.php
+++ b/src/MediaWiki/Hooks/SkinTemplateNavigationUniversal.php
@@ -8,14 +8,14 @@ use SMW\MediaWiki\HookListener;
 /**
  * Alter the structured navigation links in SkinTemplates.
  *
- * @see https://www.mediawiki.org/wiki/Manual:Hooks/SkinTemplateNavigation
+ * @see https://www.mediawiki.org/wiki/Manual:Hooks/SkinTemplateNavigation::Universal
  *
  * @license GNU GPL v2+
  * @since 2.0
  *
  * @author mwjames
  */
-class SkinTemplateNavigation implements HookListener {
+class SkinTemplateNavigationUniversal implements HookListener {
 
 	/**
 	 * @var SkinTemplate

--- a/tests/phpunit/MediaWiki/Hooks/SkinTemplateNavigationUniversalTest.php
+++ b/tests/phpunit/MediaWiki/Hooks/SkinTemplateNavigationUniversalTest.php
@@ -2,10 +2,10 @@
 
 namespace SMW\Tests\MediaWiki\Hooks;
 
-use SMW\MediaWiki\Hooks\SkinTemplateNavigation;
+use SMW\MediaWiki\Hooks\SkinTemplateNavigationUniversal;
 
 /**
- * @covers \SMW\MediaWiki\Hooks\SkinTemplateNavigation
+ * @covers \SMW\MediaWiki\Hooks\SkinTemplateNavigationUniversal
  * @group semantic-mediawiki
  *
  * @license GNU GPL v2+
@@ -24,8 +24,8 @@ class SkinTemplateNavigationTest extends \PHPUnit_Framework_TestCase {
 		$links = [];
 
 		$this->assertInstanceOf(
-			'\SMW\MediaWiki\Hooks\SkinTemplateNavigation',
-			new SkinTemplateNavigation( $skinTemplate, $links )
+			'\SMW\MediaWiki\Hooks\SkinTemplateNavigationUniversal',
+			new SkinTemplateNavigationUniversal( $skinTemplate, $links )
 		);
 	}
 
@@ -46,7 +46,7 @@ class SkinTemplateNavigationTest extends \PHPUnit_Framework_TestCase {
 		$user->expects( $this->atLeastOnce() )
 			->method( 'isAllowed' )
 			->will( $this->returnValue( true ) );
-		
+
 		$output = $this->getMockBuilder( '\OutputPage' )
 			->disableOriginalConstructor()
 			->getMock();
@@ -58,7 +58,7 @@ class SkinTemplateNavigationTest extends \PHPUnit_Framework_TestCase {
 		$skinTemplate->expects( $this->atLeastOnce() )
 			->method( 'getOutput' )
 			->will( $this->returnValue( $output ) );
-			
+
 		$skinTemplate->expects( $this->atLeastOnce() )
 			->method( 'getUser' )
 			->will( $this->returnValue( $user ) );
@@ -73,7 +73,7 @@ class SkinTemplateNavigationTest extends \PHPUnit_Framework_TestCase {
 
 		$links = [];
 
-		$instance = new SkinTemplateNavigation( $skinTemplate, $links );
+		$instance = new SkinTemplateNavigationUniversal( $skinTemplate, $links );
 		$instance->process();
 
 		$this->assertArrayHasKey( 'purge', $links['actions'] );

--- a/tests/phpunit/MediaWiki/HooksTest.php
+++ b/tests/phpunit/MediaWiki/HooksTest.php
@@ -1098,7 +1098,7 @@ class HooksTest extends \PHPUnit_Framework_TestCase {
 
 	public function callSkinTemplateNavigation( $instance ) {
 
-		$handler = 'SkinTemplateNavigation';
+		$handler = 'SkinTemplateNavigationUniversal';
 
 		$user = $this->getMockBuilder( '\User' )
 			->disableOriginalConstructor()


### PR DESCRIPTION
SkinTemplateNavigation was deprecated in 1.39.

SkinTemplateNavigation::Universal is available since 1.18