### PR TITLE
Update to accomodate future changes to JsonCodec

### DIFF
--- a/includes/SemanticData.php
+++ b/includes/SemanticData.php
@@ -898,6 +898,8 @@ class SemanticData implements JsonUnserializable {
 	 * @return array
 	 */
 	public function jsonSerialize() {
+		# T312589 explicitly calling jsonSerialize() will be unnecessary
+		# in the future.
 		$json = [
 			'stubObject' => $this->stubObject,
 			'mPropVals' => array_map( function( $x ) {
@@ -924,6 +926,21 @@ class SemanticData implements JsonUnserializable {
 		return $json;
 	}
 
+	public static function maybeUnserialize( $unserializer, $value ) {
+		# Compatibility thunk for MW versions with T312589 fixed/unfixed
+		return is_object($value) ? $value :
+			$unserializer->unserialize( $value );
+	}
+
+	public static function maybeUnserializeArray( $unserializer, array $value ) {
+		# Compatibility thunk for MW versions with T312589 fixed/unfixed
+		$result = [];
+		foreach ($value as $k=>$v) {
+			$result[$k] = self::maybeUnserialize($unserializer, $v);
+		}
+		return $result;
+	}
+
 	/**
 	 * Implements JsonUnserializable.
 	 * 
@@ -935,18 +952,23 @@ class SemanticData implements JsonUnserializable {
 	 * @return self
 	 */
 	public static function newFromJsonArray( JsonUnserializer $unserializer, array $json ) {
-		$obj = new self( $unserializer->unserialize( $json['mSubject'] ), $json['mNoDuplicates'] );
+		# T312589: In the future JsonCodec will take care of unserializing
+		# the values in the $json array itself.
+		$obj = new self(
+			self::maybeUnserialize($unserializer, $json['mSubject']),
+			$json['mNoDuplicates']
+		);
 		$obj->stubObject = $json['stubObject'];
 		$obj->mPropVals = array_map( function( $x ) use( $unserializer ) {
-				return $unserializer->unserializeArray( $x );
-			}, $json['mPropVals'] );
-		$obj->mProperties = $unserializer->unserializeArray( $json['mProperties'] );
+			return self::maybeUnserializeArray( $unserializer, $x );
+		}, $json['mPropVals'] );
+		$obj->mProperties = self::maybeUnserializeArray($unserializer, $json['mProperties'] );
 		$obj->mHasVisibleProps = $json['mHasVisibleProps'];
 		$obj->mHasVisibleSpecs = $json['mHasVisibleSpecs'];
-		$obj->subSemanticData = $json['subSemanticData'] ? $unserializer->unserialize( $json['subSemanticData'] ) : null;
+		$obj->subSemanticData = $json['subSemanticData'] ? self::maybeUnserialize($unserializer, $json['subSemanticData'] ) : null;
 		$obj->errors = $json['errors'];
 		$obj->hash = $json['hash'];
-		$obj->options = $json['options'] ? $unserializer->unserialize( $json['options'] ) : null;
+		$obj->options = $json['options'] ? self::maybeUnserialize($unserializer, $json['options'] ) : null;
 		$obj->extensionData = $json['extensionData'];
 		$obj->sequenceMap = $json['sequenceMap'];
 		$obj->countMap = $json['countMap'];

--- a/includes/dataitems/SMW_DataItem.php
+++ b/includes/dataitems/SMW_DataItem.php
@@ -252,6 +252,8 @@ abstract class SMWDataItem implements JsonUnserializable {
 	 * @return array
 	 */
 	public function jsonSerialize() {
+		# T312589 explicitly calling jsonSerialize() will be unnecessary
+		# in the future.
 		return [
 			'options' => $this->options ? $this->options->jsonSerialize() : null,
 			'value' => $this->getSerialization(),
@@ -271,7 +273,7 @@ abstract class SMWDataItem implements JsonUnserializable {
 	 */
 	public static function newFromJsonArray( JsonUnserializer $unserializer, array $json ) {
 		$obj = static::doUnserialize( $json['value'] );
-		$obj->options = $json['options'] ? $unserializer->unserialize( $json['options'] ) : null;
+		$obj->options = $json['options'] ? SemanticData::maybeUnserialize($unserializer, $json['options'] ) : null;
 		return $obj;
 	}
 

--- a/src/DataModel/SubSemanticData.php
+++ b/src/DataModel/SubSemanticData.php
@@ -300,8 +300,8 @@ class SubSemanticData implements JsonUnserializable {
 	 * @return self
 	 */
 	public static function newFromJsonArray( JsonUnserializer $unserializer, array $json ) {
-		$obj = new self( $unserializer->unserialize( $json['subject'] ), $json['noDuplicates'] );
-		$obj->subSemanticData = $unserializer->unserializeArray( $json['subSemanticData'] );
+		$obj = new self( SemanticData::maybeUnserialize($unserializer, $json['subject'] ), $json['noDuplicates'] );
+		$obj->subSemanticData = SemanticData::maybeUnserializeArray($unserializer, $json['subSemanticData'] );
 		$obj->subContainerMaxDepth = $json['subContainerMaxDepth'];
 		return $obj;
 	}


### PR DESCRIPTION
JsonCodec will handle recursion itself in the future, so you can directly
include JsonSerializable objects as values in the array returned by
::toJsonArray(), and those objects will already be unserialized values
in the array given to ::newFromJsonArray().

This patch makes the code in SemanticMediaWiki agnostic about whether
unserialization occurs before or after ::newFromJsonArray() occurs,
in order to handle both the old and proposed new behavior of JsonCodec.
