### PR TITLE
Sanitize query log before output

### DIFF
--- a/src/MediaWiki/Specials/SpecialAsk.php
+++ b/src/MediaWiki/Specials/SpecialAsk.php
@@ -545,7 +545,7 @@ class SpecialAsk extends SpecialPage {
 		);
 
 		return [
-			'query_string' => $this->queryString,
+			'query_string' => htmlspecialchars( $this->queryString ),
 			'query_source' => str_replace( '"', '', $querySource ),
 			'query_time' => $duration,
 			'from_cache' => $isFromCache


### PR DESCRIPTION
The query log output was unsanitized. This is a potential security issue. Added sanitization in analogy to l. 557.
This commit fixes https://github.com/SemanticMediaWiki/SemanticMediaWiki/issues/5262