### PR TITLE
Update to accomodate future changes to JsonCodec

### DIFF
--- a/includes/dataitems/SMW_DataItem.php
+++ b/includes/dataitems/SMW_DataItem.php
@@ -252,6 +252,8 @@ abstract class SMWDataItem implements JsonUnserializable {
 	 * @return array
 	 */
 	public function jsonSerialize() {
+		# T312589 explicitly calling jsonSerialize() will be unnecessary
+		# in the future.
 		return [
 			'options' => $this->options ? $this->options->jsonSerialize() : null,
 			'value' => $this->getSerialization(),
@@ -271,7 +273,7 @@ abstract class SMWDataItem implements JsonUnserializable {
 	 */
 	public static function newFromJsonArray( JsonUnserializer $unserializer, array $json ) {
 		$obj = static::doUnserialize( $json['value'] );
-		$obj->options = $json['options'] ? $unserializer->unserialize( $json['options'] ) : null;
+		$obj->options = $json['options'] ? SemanticData::maybeUnserialize($unserializer, $json['options'] ) : null;
 		return $obj;
 	}
 

--- a/src/DataModel/SubSemanticData.php
+++ b/src/DataModel/SubSemanticData.php
@@ -278,12 +278,14 @@ class SubSemanticData implements JsonUnserializable {
 	 * @return array
 	 */
 	public function jsonSerialize() {
+		# T312589 explicitly calling jsonSerialize() will be unnecessary
+		# in the future.
 		return [
 			'noDuplicates' => $this->noDuplicates,
 			'subject' => $this->subject->jsonSerialize(),
 			'subSemanticData' => array_map( function( $x ) {
 					return $x->jsonSerialize();
-				}, $this->subSemanticData ),
+			}, $this->subSemanticData ),
 			'subContainerMaxDepth' => $this->subContainerMaxDepth,
 			'_type_' => get_class( $this ),
 		];
@@ -300,8 +302,8 @@ class SubSemanticData implements JsonUnserializable {
 	 * @return self
 	 */
 	public static function newFromJsonArray( JsonUnserializer $unserializer, array $json ) {
-		$obj = new self( $unserializer->unserialize( $json['subject'] ), $json['noDuplicates'] );
-		$obj->subSemanticData = $unserializer->unserializeArray( $json['subSemanticData'] );
+		$obj = new self( SemanticData::maybeUnserialize($unserializer, $json['subject'] ), $json['noDuplicates'] );
+		$obj->subSemanticData = SemanticData::maybeUnserializeArray($unserializer, $json['subSemanticData'] );
 		$obj->subContainerMaxDepth = $json['subContainerMaxDepth'];
 		return $obj;
 	}


### PR DESCRIPTION
JsonCodec will handle recursion itself in the future, so you can directly
include JsonSerializable objects as values in the array returned by
::toJsonArray(), and those objects will already be unserialized values
in the array given to ::newFromJsonArray().

This patch makes the code in SemanticMediaWiki agnostic about whether
unserialization occurs before or after ::newFromJsonArray() occurs,
in order to handle both the old and proposed new behavior of JsonCodec.

Bug: T312589