### PR TITLE
SMW_DataItem: Add necessary abstract function

### DIFF
--- a/includes/dataitems/SMW_DataItem.php
+++ b/includes/dataitems/SMW_DataItem.php
@@ -246,7 +246,7 @@ abstract class SMWDataItem implements JsonUnserializable {
 
 	/**
 	 * Implements \JsonSerializable.
-	 * 
+	 *
 	 * @since 4.0.0
 	 *
 	 * @return array
@@ -263,7 +263,7 @@ abstract class SMWDataItem implements JsonUnserializable {
 
 	/**
 	 * Implements JsonUnserializable.
-	 * 
+	 *
 	 * @since 4.0.0
 	 *
 	 * @param JsonUnserializer $unserializer Unserializer
@@ -277,4 +277,5 @@ abstract class SMWDataItem implements JsonUnserializable {
 		return $obj;
 	}
 
+	abstract public static function doUnserialize($serialization);
 }


### PR DESCRIPTION
The abstract class SMW_DataItem expects doUnserialize method to be
implemented. It uses it in multiple places so I went ahead and added
it as an abstract function.

I also checked and noticed that all the classes that extend this
class already implement this function.

*No other testing was done*