### PR TITLE
Fix upsert warnings

### DIFF
--- a/maintenance/updateEntityCountMap.php
+++ b/maintenance/updateEntityCountMap.php
@@ -240,18 +240,19 @@ class updateEntityCountMap extends \Maintenance {
 				HmacSerializer::compress( $countMap )
 			);
 
-			$rows = [
-				'smw_id' => $row->smw_id,
-				'smw_countmap' => $countMap
-			];
 
 			$connection->upsert(
 				SQLStore::ID_AUXILIARY_TABLE,
-				$rows,
+				[
+					'smw_id' => $row->smw_id,
+					'smw_countmap' => $countMap
+				],
 				[
 					'smw_id'
 				],
-				$rows,
+				[
+					'smw_countmap' => $countMap
+				],
 				__METHOD__
 			);
 

--- a/src/SQLStore/EntityStore/AuxiliaryFields.php
+++ b/src/SQLStore/EntityStore/AuxiliaryFields.php
@@ -108,17 +108,18 @@ class AuxiliaryFields {
 			$countmap = null;
 		}
 
-		$rows = [
-			'smw_id' => $sid,
-			'smw_seqmap' => $seqmap,
-			'smw_countmap' => $countmap
-		];
-
 		$this->connection->upsert(
 			SQLStore::ID_AUXILIARY_TABLE,
-			$rows,
+			[
+				'smw_id' => $sid,
+				'smw_seqmap' => $seqmap,
+				'smw_countmap' => $countmap
+			],
 			'smw_id',
-			$rows,
+			[
+				'smw_seqmap' => $seqmap,
+				'smw_countmap' => $countmap
+			],
 			__METHOD__
 		);
 

--- a/src/SQLStore/EntityStore/SequenceMapFinder.php
+++ b/src/SQLStore/EntityStore/SequenceMapFinder.php
@@ -62,16 +62,16 @@ class SequenceMapFinder {
 			$map = null;
 		}
 
-		$rows = [
-			'smw_id' => $sid,
-			'smw_seqmap' => $map
-		];
-
 		$this->connection->upsert(
 			SQLStore::ID_AUXILIARY_TABLE,
-			$rows,
+			[
+				'smw_id' => $sid,
+				'smw_seqmap' => $map
+			],
 			'smw_id',
-			$rows,
+			[
+				'smw_seqmap' => $map
+			],
 			__METHOD__
 		);
 	}

--- a/src/SQLStore/PropertyTable/PropertyTableHashes.php
+++ b/src/SQLStore/PropertyTable/PropertyTableHashes.php
@@ -79,7 +79,6 @@ class PropertyTableHashes {
 			],
 			[ 'smw_id' ],
 			[
-				'smw_id' => $id,
 				'smw_proptable' => $smw_proptable
 			],
 			__METHOD__


### PR DESCRIPTION
> Wikimedia\\Rdbms\\Database::assertValidUpsertSetArray called with redundant assignment to column 'smw_id'

This warning gets spammed a lot into logs