### PR TITLE
Remove usage of deprecated User::getOption methods

### DIFF
--- a/src/Localizer/Localizer.php
+++ b/src/Localizer/Localizer.php
@@ -5,6 +5,7 @@ namespace SMW\Localizer;
 use DateTime;
 use IContextSource;
 use Language;
+use MediaWiki\User\UserOptionsLookup;
 use RequestContext;
 use SMW\Localizer\LocalLanguage\LocalLanguage;
 use SMW\DIWikiPage;
@@ -37,6 +38,9 @@ class Localizer {
 	/** @var IContextSource */
 	private $context = null;
 
+	/** @var UserOptionsLookup */
+	private $userOptionsLookup = null;
+
 	/**
 	 * @since 2.1
 	 *
@@ -46,10 +50,12 @@ class Localizer {
 	public function __construct(
 		Language $contentLanguage,
 		NamespaceInfo $namespaceInfo,
+		UserOptionsLookup $userOptionsLookup,
 		IContextSource $context
 	) {
 		$this->contentLanguage = $contentLanguage;
 		$this->namespaceInfo = $namespaceInfo;
+		$this->userOptionsLookup = $userOptionsLookup;
 		$this->context = $context;
 	}
 
@@ -69,6 +75,7 @@ class Localizer {
 		self::$instance = new self(
 			$servicesFactory->singleton( 'ContentLanguage' ),
 			$servicesFactory->singleton( 'NamespaceInfo' ),
+			$servicesFactory->singleton( 'UserOptionsLookup' ),
 			RequestContext::getMain()
 		);
 
@@ -113,7 +120,7 @@ class Localizer {
 			$user = $this->context->getUser();
 		}
 
-		return $user->getOption( 'smw-prefs-general-options-time-correction' );
+		return $this->userOptionsLookup->getOption( $user, 'smw-prefs-general-options-time-correction' );
 	}
 
 	/**
@@ -134,7 +141,8 @@ class Localizer {
 			$GLOBALS['wgLocalTZoffset']
 		);
 
-		return LocalTime::getLocalizedTime( $dateTime, $user );
+		$timeCorrection = $this->userOptionsLookup->getOption( $user, 'timecorrection' );
+		return LocalTime::getLocalizedTime( $dateTime, $timeCorrection );
 	}
 
 	/**

--- a/src/MediaWiki/Hooks/BeforePageDisplay.php
+++ b/src/MediaWiki/Hooks/BeforePageDisplay.php
@@ -8,6 +8,7 @@ use SpecialPage;
 use Title;
 use SMW\Message;
 use Html;
+use MediaWiki\MediaWikiServices;
 use SMW\MediaWiki\HookListener;
 use SMW\OptionsAwareTrait;
 
@@ -83,7 +84,8 @@ class BeforePageDisplay implements HookListener {
 		}
 
 		// #2726
-		if ( $user->getOption( 'smw-prefs-general-options-suggester-textinput' ) ) {
+		$userOptionsLookup = MediaWikiServices::getInstance()->getUserOptionsLookup();
+		if ( $userOptionsLookup->getOption( $user, 'smw-prefs-general-options-suggester-textinput' ) ) {
 			$outputPage->addModules( 'ext.smw.suggester.textInput' );
 		}
 

--- a/src/MediaWiki/Hooks/BeforePageDisplay.php
+++ b/src/MediaWiki/Hooks/BeforePageDisplay.php
@@ -8,9 +8,9 @@ use SpecialPage;
 use Title;
 use SMW\Message;
 use Html;
-use MediaWiki\MediaWikiServices;
 use SMW\MediaWiki\HookListener;
 use SMW\OptionsAwareTrait;
+use SMW\Services\ServicesFactory;
 
 /**
  * BeforePageDisplay hook which allows last minute changes to the
@@ -84,7 +84,7 @@ class BeforePageDisplay implements HookListener {
 		}
 
 		// #2726
-		$userOptionsLookup = MediaWikiServices::getInstance()->getUserOptionsLookup();
+		$userOptionsLookup = ServicesFactory::getInstance()->singleton( 'UserOptionsLookup' );
 		if ( $userOptionsLookup->getOption( $user, 'smw-prefs-general-options-suggester-textinput' ) ) {
 			$outputPage->addModules( 'ext.smw.suggester.textInput' );
 		}

--- a/src/MediaWiki/LocalTime.php
+++ b/src/MediaWiki/LocalTime.php
@@ -40,13 +40,13 @@ class LocalTime {
 	 * @since 3.0
 	 *
 	 * @param DateTime $dateTime
-	 * @param User|null $user
+	 * @param string|null $user
 	 *
 	 * @return DateTime
 	 */
-	public static function getLocalizedTime( DateTime $dateTime, User $user = null ) {
+	public static function getLocalizedTime( DateTime $dateTime, string $timeCorrection = null ) {
 
-		$tz = $user instanceof User ? $user->getOption( 'timecorrection' ) : false;
+		$tz = $timeCorrection ?? false;
 		$data = explode( '|', $tz, 3 );
 
 		// DateTime is mutable, keep track of possible changes

--- a/src/MediaWiki/Page/Page.php
+++ b/src/MediaWiki/Page/Page.php
@@ -3,7 +3,6 @@
 namespace SMW\MediaWiki\Page;
 
 use Article;
-use MediaWiki\MediaWikiServices;
 use SMW\DIWikiPage;
 use SMW\Options;
 use SMW\Services\ServicesFactory;

--- a/src/MediaWiki/Page/Page.php
+++ b/src/MediaWiki/Page/Page.php
@@ -3,6 +3,7 @@
 namespace SMW\MediaWiki\Page;
 
 use Article;
+use MediaWiki\MediaWikiServices;
 use SMW\DIWikiPage;
 use SMW\Options;
 use SMWOutputs as Outputs;
@@ -81,7 +82,8 @@ abstract class Page extends Article {
 		$request = $this->getContext()->getRequest();
 
 		$diff = $request->getVal( 'diff' );
-		$diffOnly = $request->getBool( 'diffonly', $user->getOption( 'diffonly' ) );
+		$userOptionsLookup = MediaWikiServices::getInstance()->getUserOptionsLookup();
+		$diffOnly = $request->getBool( 'diffonly', $userOptionsLookup->getOption( $user, 'diffonly' ) );
 
 		if ( !isset( $diff ) || !$diffOnly ) {
 			// MW 1.25+

--- a/src/MediaWiki/Page/Page.php
+++ b/src/MediaWiki/Page/Page.php
@@ -6,6 +6,7 @@ use Article;
 use MediaWiki\MediaWikiServices;
 use SMW\DIWikiPage;
 use SMW\Options;
+use SMW\Services\ServicesFactory;
 use SMWOutputs as Outputs;
 
 /**
@@ -82,7 +83,7 @@ abstract class Page extends Article {
 		$request = $this->getContext()->getRequest();
 
 		$diff = $request->getVal( 'diff' );
-		$userOptionsLookup = MediaWikiServices::getInstance()->getUserOptionsLookup();
+		$userOptionsLookup = ServicesFactory::getInstance()->singleton( 'UserOptionsLookup' );
 		$diffOnly = $request->getBool( 'diffonly', $userOptionsLookup->getOption( $user, 'diffonly' ) );
 
 		if ( !isset( $diff ) || !$diffOnly ) {

--- a/src/MediaWiki/Preference/PreferenceExaminer.php
+++ b/src/MediaWiki/Preference/PreferenceExaminer.php
@@ -2,6 +2,7 @@
 
 namespace SMW\MediaWiki\Preference;
 
+use LogicException;
 use MediaWiki\User\UserOptionsLookup;
 use User;
 
@@ -19,7 +20,7 @@ class PreferenceExaminer {
 	private $user;
 
 	/**
-	 * @var UserOptionsLookup
+	 * @var ?UserOptionsLookup
 	 */
 	private $userOptionsLookup;
 
@@ -28,7 +29,7 @@ class PreferenceExaminer {
 	 *
 	 * @param User|null $user
 	 */
-	public function __construct( User $user = null, UserOptionsLookup $userOptionsLookup ) {
+	public function __construct( User $user = null, UserOptionsLookup $userOptionsLookup = null ) {
 		$this->user = $user;
 		$this->userOptionsLookup = $userOptionsLookup;
 	}
@@ -55,7 +56,11 @@ class PreferenceExaminer {
 			return false;
 		}
 
-		return $this->userOptionsLookup->getOption( $this->user, $key, false );
+		if ( $this->userOptionsLookup === null ) {
+			return $this->user->getOption( $key, false );
+		} else {
+			return $this->userOptionsLookup->getOption( $this->user, $key, false );
+		}
 	}
 
 }

--- a/src/MediaWiki/Preference/PreferenceExaminer.php
+++ b/src/MediaWiki/Preference/PreferenceExaminer.php
@@ -2,6 +2,7 @@
 
 namespace SMW\MediaWiki\Preference;
 
+use MediaWiki\User\UserOptionsLookup;
 use User;
 
 /**
@@ -18,12 +19,18 @@ class PreferenceExaminer {
 	private $user;
 
 	/**
+	 * @var UserOptionsLookup
+	 */
+	private $userOptionsLookup;
+
+	/**
 	 * @since 3.2
 	 *
 	 * @param User|null $user
 	 */
-	public function __construct( User $user = null ) {
+	public function __construct( User $user = null, UserOptionsLookup $userOptionsLookup ) {
 		$this->user = $user;
+		$this->userOptionsLookup = $userOptionsLookup;
 	}
 
 	/**
@@ -48,7 +55,7 @@ class PreferenceExaminer {
 			return false;
 		}
 
-		return $this->user->getOption( $key, false );
+		return $this->userOptionsLookup->getOption( $this->user, $key, false );
 	}
 
 }

--- a/src/MediaWiki/Preference/PreferenceExaminer.php
+++ b/src/MediaWiki/Preference/PreferenceExaminer.php
@@ -2,7 +2,6 @@
 
 namespace SMW\MediaWiki\Preference;
 
-use LogicException;
 use MediaWiki\User\UserOptionsLookup;
 use User;
 

--- a/src/MediaWiki/Specials/SpecialAsk.php
+++ b/src/MediaWiki/Specials/SpecialAsk.php
@@ -3,6 +3,7 @@
 namespace SMW\MediaWiki\Specials;
 
 use Html;
+use MediaWiki\MediaWikiServices;
 use ParamProcessor\Param;
 use SMW\Query\QuerySourceFactory;
 use SMW\Services\ServicesFactory as ApplicationFactory;
@@ -235,8 +236,9 @@ class SpecialAsk extends SpecialPage {
 			$GLOBALS['smwgResultFormats']
 		);
 
+		$userOptionsLookup = MediaWikiServices::getInstance()->getUserOptionsLookup();
 		ParametersWidget::setTooltipDisplay(
-			$this->getUser()->getOption( 'smw-prefs-ask-options-tooltip-display' )
+			$userOptionsLookup->getOption( $this->getUser(), 'smw-prefs-ask-options-tooltip-display' )
 		);
 
 		ParametersWidget::setDefaultLimit(

--- a/src/MediaWiki/Specials/SpecialAsk.php
+++ b/src/MediaWiki/Specials/SpecialAsk.php
@@ -28,6 +28,7 @@ use SMWQueryProcessor as QueryProcessor;
 use SMW\Query\QueryResult;
 use SpecialPage;
 use SMW\Utils\UrlArgs;
+use SMW\Services\ServicesFactory;
 
 /**
  * This special page for MediaWiki implements a customisable form for executing
@@ -236,7 +237,7 @@ class SpecialAsk extends SpecialPage {
 			$GLOBALS['smwgResultFormats']
 		);
 
-		$userOptionsLookup = MediaWikiServices::getInstance()->getUserOptionsLookup();
+		$userOptionsLookup = ServicesFactory::getInstance()->singleton( 'UserOptionsLookup' );
 		ParametersWidget::setTooltipDisplay(
 			$userOptionsLookup->getOption( $this->getUser(), 'smw-prefs-ask-options-tooltip-display' )
 		);

--- a/src/MediaWiki/Specials/SpecialAsk.php
+++ b/src/MediaWiki/Specials/SpecialAsk.php
@@ -3,7 +3,6 @@
 namespace SMW\MediaWiki\Specials;
 
 use Html;
-use MediaWiki\MediaWikiServices;
 use ParamProcessor\Param;
 use SMW\Query\QuerySourceFactory;
 use SMW\Services\ServicesFactory as ApplicationFactory;

--- a/src/Services/SharedServicesContainer.php
+++ b/src/Services/SharedServicesContainer.php
@@ -883,7 +883,7 @@ class SharedServicesContainer implements CallbackContainer {
 
 			$preferenceExaminer = new PreferenceExaminer(
 				$user,
-				MediaWikiServices::getInstance()->getUserOptionsLookup()
+				ServicesFactory::getInstance()->singleton( 'UserOptionsLookup' )
 			);
 
 			return $preferenceExaminer;

--- a/src/Services/SharedServicesContainer.php
+++ b/src/Services/SharedServicesContainer.php
@@ -3,6 +3,7 @@
 namespace SMW\Services;
 
 use JsonSchema\Validator as SchemaValidator;
+use MediaWiki\MediaWikiServices;
 use Onoi\BlobStore\BlobStore;
 use Onoi\CallbackContainer\CallbackContainer;
 use Onoi\CallbackContainer\ContainerBuilder;
@@ -881,7 +882,8 @@ class SharedServicesContainer implements CallbackContainer {
 			$containerBuilder->registerExpectedReturnType( 'PreferenceExaminer', '\SMW\MediaWiki\Preference\PreferenceExaminer' );
 
 			$preferenceExaminer = new PreferenceExaminer(
-				$user
+				$user,
+				MediaWikiServices::getInstance()->getUserOptionsLookup()
 			);
 
 			return $preferenceExaminer;

--- a/src/Services/SharedServicesContainer.php
+++ b/src/Services/SharedServicesContainer.php
@@ -3,7 +3,6 @@
 namespace SMW\Services;
 
 use JsonSchema\Validator as SchemaValidator;
-use MediaWiki\MediaWikiServices;
 use Onoi\BlobStore\BlobStore;
 use Onoi\CallbackContainer\CallbackContainer;
 use Onoi\CallbackContainer\ContainerBuilder;

--- a/src/Services/mediawiki.php
+++ b/src/Services/mediawiki.php
@@ -8,6 +8,7 @@ use JobQueueGroup;
 use LBFactory;
 use MediaWiki\Logger\LoggerFactory;
 use MediaWiki\MediaWikiServices;
+use MediaWiki\User\UserOptionsLookup;
 use Psr\Log\NullLogger;
 use SMW\Utils\Logger;
 use SMW\MediaWiki\NamespaceInfo;
@@ -336,5 +337,9 @@ return [
 	'ParserCache' => function( $containerBuilder ) {
 		return MediaWikiServices::getInstance()->getParserCache();
 	},
+
+	'UserOptionsLookup' => function( $containerBuilder ): UserOptionsLookup {
+		return MediaWikiServices::getInstance()->getUserOptionsLookup();
+	}
 
 ];

--- a/tests/phpunit/MediaWiki/LocalTimeTest.php
+++ b/tests/phpunit/MediaWiki/LocalTimeTest.php
@@ -63,19 +63,10 @@ class LocalTimeTest extends \PHPUnit_Framework_TestCase {
 
 	public function testModifiedTimeWithUserTimeCorrection() {
 
-		$user = $this->getMockBuilder( '\User' )
-			->disableOriginalConstructor()
-			->getMock();
-
-		$user->expects( $this->once() )
-			->method( 'getOption' )
-			->with( $this->equalTo( 'timecorrection' ) )
-			->will( $this->returnValue( 'ZoneInfo|+120|Europe/Berlin' ) );
-
 		$dti = new DateTime( '2017-08-01 10:00:00+00:00' );
 
 		LocalTime::setLocalTimeOffset( 0 );
-		$dateTime = LocalTime::getLocalizedTime( $dti, $user );
+		$dateTime = LocalTime::getLocalizedTime( $dti, 'ZoneInfo|+120|Europe/Berlin' );
 
 		$this->assertTrue(
 			$dateTime->hasLocalTimeCorrection
@@ -89,18 +80,9 @@ class LocalTimeTest extends \PHPUnit_Framework_TestCase {
 
 	public function testModifiedTimeWithUserTimeCorrectionOnInvalidZone() {
 
-		$user = $this->getMockBuilder( '\User' )
-			->disableOriginalConstructor()
-			->getMock();
-
-		$user->expects( $this->once() )
-			->method( 'getOption' )
-			->with( $this->equalTo( 'timecorrection' ) )
-			->will( $this->returnValue( 'ZoneInfo|+125|Foo' ) );
-
 		$dti = new DateTime( '2017-08-01 10:00:00+00:00' );
 
-		$dateTime = LocalTime::getLocalizedTime( $dti, $user );
+		$dateTime = LocalTime::getLocalizedTime( $dti, 'ZoneInfo|+125|Foo' );
 
 		$this->assertTrue(
 			$dateTime->hasLocalTimeCorrection


### PR DESCRIPTION
Method was deprecated in MW 1.35

Instead use `UserOptionsLookup` class available since MW 1.35