### PR TITLE
Allow rebuildData.php for smw_ftp_sesp_usereditcntns

### DIFF
--- a/src/SQLStore/PropertyTableIdReferenceFinder.php
+++ b/src/SQLStore/PropertyTableIdReferenceFinder.php
@@ -220,7 +220,7 @@ class PropertyTableIdReferenceFinder {
 		if ( isset( $fields['o_id'] ) ) {
 
 			// This next time someone ... I'm going to Alaska
-			$field = strpos( $proptable->getName(), 'redi' ) ? [ 's_title', 's_namespace' ] : [ 's_id' ];
+			$field = preg_match( '/redi$/', $proptable->getName() ) ? [ 's_title', 's_namespace' ] : [ 's_id' ];
 
 			$row = $this->connection->selectRow(
 				$proptable->getName(),


### PR DESCRIPTION
```
// This next time someone ... I'm going to Alaska
      $field = strpos( $proptable->getName(), 'redi' ) ? [ 's_title', 's_namespace' ] : [ 's_id' ];
```
This fragment returns wrong `$field` when `$proptable->getName() = 'smw_ftp_sesp_usereditcntns'` and crashes `rebuildData.php`, because 'smw_ftp_sesp_usereditcntns' contains `redi`. So, update the check, so that 'redi' is at the end of the table name.