### PR TITLE
HtmlTable: Fix optional parameter before required one

### DIFF
--- a/src/Utils/HtmlTable.php
+++ b/src/Utils/HtmlTable.php
@@ -130,7 +130,7 @@ class HtmlTable {
 		return $this->concatenateRows( $rows, $htmlContext );
 	}
 
-	private function createRow( $content, $attributes = [], $count ) {
+	private function createRow( $content, $attributes, $count ) {
 
 		$alternate = $count % 2 == 0 ? 'row-odd' : 'row-even';
 


### PR DESCRIPTION
It seems I missed some functions in e40c49d because on PHP 8, HtmlTable::createRow() reports an E_DEPRECATED due to an optional parameter preceding a required one.