### PR TITLE
Fix next() in ResultIterator

### DIFF
--- a/src/Iterators/ResultIterator.php
+++ b/src/Iterators/ResultIterator.php
@@ -108,8 +108,8 @@ class ResultIterator implements Iterator, Countable, SeekableIterator {
 	 * {@inheritDoc}
 	 */
 	public function next() {
-		$row = $this->res->next();
-		$this->setCurrent( $row );
+		$this->res->next();
+		$this->setCurrent( $this->res->current() );
 		$this->position++;
 	}
 
@@ -130,7 +130,7 @@ class ResultIterator implements Iterator, Countable, SeekableIterator {
 	 * {@inheritDoc}
 	 */
 	public function valid() {
-		return $this->current !== false;
+		return $this->current !== false && $this->position < $this->count();
 	}
 
 	protected function setCurrent( $row ) {

--- a/tests/phpunit/Iterators/ResultIteratorTest.php
+++ b/tests/phpunit/Iterators/ResultIteratorTest.php
@@ -51,6 +51,11 @@ class ResultIteratorTest extends \PHPUnit_Framework_TestCase {
 				$value
 			);
 		}
+
+		$this->assertEquals(
+			2,
+			$instance->key()
+		);
 	}
 
 	public function testdoSeekOnArray() {
@@ -74,7 +79,7 @@ class ResultIteratorTest extends \PHPUnit_Framework_TestCase {
 			->disableOriginalConstructor()
 			->getMock();
 
-		$resultWrapper->expects( $this->once() )
+		$resultWrapper->expects( $this->exactly( 3 ) )
 			->method( 'numRows' )
 			->will( $this->returnValue( 1 ) );
 


### PR DESCRIPTION
`ResultIterator` never reaches the second element because [`next()`](https://www.php.net/manual/en/iterator.next.php) always returns void, so `$row = parent::next()` is always `null`.

I observed this with the script `disposeOutdatedEntities.php` which only removed one entity at each execution.

The change in `valid()` is not strictly necessary, but, without it, the test `ResultIteratorTest::testdoIterateOnResultWrapper()` is an infinite recursion, and I guess it is harmless in the general case.