### PR TITLE
Don’t apply tests to i18n files with isLanguageRedirect

### DIFF
--- a/tests/phpunit/Structure/LocalLanguageFileIntegrityTest.php
+++ b/tests/phpunit/Structure/LocalLanguageFileIntegrityTest.php
@@ -18,7 +18,7 @@ class LocalLanguageFileIntegrityTest extends \PHPUnit_Framework_TestCase {
 	/**
 	 * @dataProvider i18nFileProvider
 	 */
-	public function testPropertyLabelTrailingSpaces( $file ) {
+	public function testPropertyLabelsTrailingSpaces( $file ) {
 
 		$jsonFileReader = UtilityFactory::getInstance()->newJsonFileReader( $file );
 		$contents = $jsonFileReader->read();
@@ -26,7 +26,7 @@ class LocalLanguageFileIntegrityTest extends \PHPUnit_Framework_TestCase {
 		$missedLabelPair = [];
 
 		if ( !isset( $contents['property']['labels'] ) ) {
-			return $this->markTestSkipped( 'No property label for ' . basename( $file ) . ' available.' );
+			return $this->markTestSkipped( 'No property labels for ' . basename( $file ) . ' available.' );
 		}
 
 		foreach ( $contents['property']['labels'] as $key => $label ) {
@@ -70,7 +70,15 @@ class LocalLanguageFileIntegrityTest extends \PHPUnit_Framework_TestCase {
 	}
 
 	public function i18nFileProvider() {
-		return $this->findFilesIn( $GLOBALS['smwgExtraneousLanguageFileDir'] );
+		return array_filter( $this->findFilesIn( $GLOBALS['smwgExtraneousLanguageFileDir'] ), function( $args ) {
+			$file = $args[0];
+			$jsonFileReader = UtilityFactory::getInstance()->newJsonFileReader( $file );
+			$contents = $jsonFileReader->read();
+			if ( isset( $contents['isLanguageRedirect'] ) && $contents['isLanguageRedirect'] ) {
+				return false;
+			}
+			return true;
+		} );
 	}
 
 	private function findFilesIn( $location ) {


### PR DESCRIPTION
All these tests are currently skipped and will always be skipped, so remove these 12 noisy messages: it will simplify a bit the reading of the CI logs.

Also, use plural for "labels" to be coherent with "aliases".