### PR TITLE
Clear ActorStore cache to fix some test results

### DIFF
--- a/tests/phpunit/DatabaseTestCase.php
+++ b/tests/phpunit/DatabaseTestCase.php
@@ -107,6 +107,11 @@ abstract class DatabaseTestCase extends \PHPUnit_Framework_TestCase {
 		$this->testEnvironment->resetMediaWikiService( 'LocalServerObjectCache' );
 		$this->testEnvironment->resetMediaWikiService( 'MainWANObjectCache' );
 
+		// HACK: clear ActorStore cache to avoid failures in tests
+		// https://github.com/SemanticMediaWiki/SemanticMediaWiki/issues/5199
+		$this->testEnvironment->resetMediaWikiService( 'ActorStore' );
+		$this->testEnvironment->resetMediaWikiService( 'ActorStoreFactory' );
+
 		$this->testEnvironment->clearPendingDeferredUpdates();
 
 		// #3916


### PR DESCRIPTION
This fixes most tests, although a few errors/failures remain. For these last ones, it is linked to the same root cause (ActorStore cache not cleared sufficiently often, since setting ActorStore::LOCAL_CACHE_SIZE = 1 fixes more tests), but more investigation is needed to understand when it should be cleared.

Issue: #5199