### PR TITLE
Unskip one test related to dates with microseconds precision

### DIFF
--- a/tests/phpunit/includes/dataitems/DITimeTest.php
+++ b/tests/phpunit/includes/dataitems/DITimeTest.php
@@ -80,15 +80,11 @@ class DITimeTest extends \PHPUnit_Framework_TestCase {
 
 	public function testDateTimeWithLargeMs() {
 
-		$dateTime = new \DateTime( '1300-11-02 12:03:25.888500' );
+		$dateTime = new \DateTime( '1300-11-02 12:03:25.888499' );
 
 		$instance = new DITime(
-			2, 1300, 11, 02, 12, 03, 25.888499949
+			2, 1300, 11, 02, 12, 03, 25.888499
 		);
-
-		if ( $instance->asDateTime() != $dateTime  ) {
-			$this->markTestSkipped( 'For some reason this started to fail on 5.6.19 (worked on 5.6.18)' );
-		}
 
 		$this->assertEquals(
 			$dateTime,


### PR DESCRIPTION
According to PHP release notes, there was a bug in PHP < 5.6.19 where microseconds were ignored when comparing dates (bug #68078). => Adapt this test with a precision up to microseconds as documented in PHP doc.

NB: on PHP 7.3, a precision of nanoseconds returns a warning in DateTime object. According to PHP bug #64814, there is no more warning in PHP 8.1, but extra precision is lost.