### PR TITLE
Update deprecated WikiPage::factory() method calls

### DIFF
--- a/src/MediaWiki/Jobs/ParserCachePurgeJob.php
+++ b/src/MediaWiki/Jobs/ParserCachePurgeJob.php
@@ -2,6 +2,7 @@
 
 namespace SMW\MediaWiki\Jobs;
 
+use MediaWiki\MediaWikiServices;
 use RequestContext;
 use SMW\MediaWiki\Job;
 use SMW\Services\ServicesFactory as ApplicationFactory;
@@ -83,6 +84,10 @@ class ParserCachePurgeJob extends Job {
 	}
 
 	protected function newWikiPage( $title ) {
+		if ( version_compare( MW_VERSION, '1.36', '>=' ) ) {
+			return MediaWikiServices::getInstance()->getWikiPageFactory()->newFromTitle( $title );
+		}
+
 		return WikiPage::factory( $title );
 	}
 }

--- a/src/MediaWiki/Jobs/UpdateJob.php
+++ b/src/MediaWiki/Jobs/UpdateJob.php
@@ -11,6 +11,7 @@ use SMW\Enum;
 use SMW\Listener\EventListener\EventHandler;
 use SMW\MediaWiki\Job;
 use Title;
+use WikiPage;
 
 /**
  * UpdateJob is responsible for the asynchronous update of semantic data
@@ -111,7 +112,13 @@ class UpdateJob extends Job {
 			DIWikiPage::newFromTitle( $title )
 		);
 
-		if ( $lastModified !== \WikiPage::factory( $title )->getTimestamp() ) {
+		if ( version_compare( MW_VERSION, '1.36', '>=' ) ) {
+			$currentVersion = MediaWikiServices::getInstance()->getWikiPageFactory()->newFromTitle( $title );
+		} else {
+			$currentVersion = WikiPage::factory( $title );
+		}
+
+		if ( $lastModified !== $currentVersion->getTimestamp() ) {
 			return false;
 		}
 

--- a/src/MediaWiki/PageCreator.php
+++ b/src/MediaWiki/PageCreator.php
@@ -2,6 +2,7 @@
 
 namespace SMW\MediaWiki;
 
+use MediaWiki\MediaWikiServices;
 use Title;
 use WikiFilePage;
 use WikiPage;
@@ -22,6 +23,10 @@ class PageCreator {
 	 * @return WikiPage
 	 */
 	public function createPage( Title $title ) {
+		if ( version_compare( MW_VERSION, '1.36', '>=' ) ) {
+			return MediaWikiServices::getInstance()->getWikiPageFactory()->newFromTitle( $title );
+		}
+
 		return WikiPage::factory( $title );
 	}
 

--- a/src/Protection/ProtectionValidator.php
+++ b/src/Protection/ProtectionValidator.php
@@ -2,6 +2,7 @@
 
 namespace SMW\Protection;
 
+use MediaWiki\MediaWikiServices;
 use Onoi\Cache\Cache;
 use SMW\DIProperty;
 use SMW\DIWikiPage;
@@ -13,6 +14,7 @@ use SMW\Listener\ChangeListener\ChangeListeners\PropertyChangeListener;
 use SMW\Listener\ChangeListener\ChangeRecord;
 use Title;
 use User;
+use WikiPage;
 
 /**
  * Handles protection validation.
@@ -222,7 +224,11 @@ class ProtectionValidator {
 			return $this->importPerformerProtectionLookupCache[$key];
 		}
 
-		$creator = \WikiPage::factory( $title )->getCreator();
+		if ( version_compare( MW_VERSION, '1.36', '>=' ) ) {
+			$creator = MediaWikiServices::getInstance()->getWikiPageFactory()->newFromTitle( $title )->getCreator();
+		} else {
+			$creator = WikiPage::factory( $title )->getCreator();
+		}
 
 		if ( !$creator instanceof User ) {
 			return $this->importPerformerProtectionLookupCache[$key] = false;

--- a/src/Services/mediawiki.php
+++ b/src/Services/mediawiki.php
@@ -16,6 +16,7 @@ use SMW\MediaWiki\FileRepoFinder;
 use SMW\MediaWiki\PermissionManager;
 use WikiImporter;
 use RepoGroup;
+use WikiPage;
 
 /**
  * @codeCoverageIgnore
@@ -84,8 +85,12 @@ return [
 	 */
 	'WikiPage' => function( $containerBuilder, \Title $title ) {
 		$containerBuilder->registerExpectedReturnType( 'WikiPage', '\WikiPage' );
-		return \WikiPage::factory( $title );
-	},
+		if ( version_compare( MW_VERSION, '1.36', '>=' ) ) {
+			return MediaWikiServices::getInstance()->getWikiPageFactory()->newFromTitle( $title );
+		}
+
+		return WikiPage::factory( $title );
+ },
 
 	/**
 	 * ResourceLoader

--- a/tests/phpunit/Integration/MediaWiki/Hooks/PageMoveCompleteIntegrationTest.php
+++ b/tests/phpunit/Integration/MediaWiki/Hooks/PageMoveCompleteIntegrationTest.php
@@ -2,6 +2,7 @@
 
 namespace SMW\Tests\Integration\MediaWiki\Hooks;
 
+use MediaWiki\MediaWikiServices;
 use SMW\Services\ServicesFactory as ApplicationFactory;
 use SMW\DIProperty;
 use SMW\DIWikiPage;
@@ -197,6 +198,11 @@ class PageMoveCompleteIntegrationTest extends DatabaseTestCase {
 	}
 
 	private function newRevisionFromTitle( $title ) {
+        if ( version_compare( MW_VERSION, '1.36', '>=' ) ) {
+            $title = MediaWikiServices::getInstance()->getWikiPageFactory()->newFromTitle( $title );
+            $this->revisionGuard->newRevisionFromPage( $title );
+        }
+
 		return $this->revisionGuard->newRevisionFromPage( WikiPage::factory( $title ) );
 	}
 }

--- a/tests/phpunit/Integration/MediaWiki/LinksUpdateSQLStoreDBIntegrationTest.php
+++ b/tests/phpunit/Integration/MediaWiki/LinksUpdateSQLStoreDBIntegrationTest.php
@@ -123,7 +123,12 @@ class LinksUpdateSQLStoreDBIntegrationTest extends DatabaseTestCase {
 
 	protected function assertSemanticDataBeforeContentAlteration() {
 
-		$wikiPage = WikiPage::factory( $this->title );
+        if ( version_compare( MW_VERSION, '1.36', '>=' ) ) {
+            $wikiPage = MediaWikiServices::getInstance()->getWikiPageFactory()->newFromTitle( $this->title );
+        } else {
+            $wikiPage = WikiPage::factory( $this->title );
+        }
+
 		$revision = $this->revisionGuard->newRevisionFromPage( $wikiPage );
 
 		$parserData = $this->retrieveAndLoadData();

--- a/tests/phpunit/Utils/ByPageSemanticDataFinder.php
+++ b/tests/phpunit/Utils/ByPageSemanticDataFinder.php
@@ -2,6 +2,7 @@
 
 namespace SMW\Tests\Utils;
 
+use MediaWiki\MediaWikiServices;
 use ParserOutput;
 use SMW\ParserData;
 use SMW\SemanticData;
@@ -100,8 +101,12 @@ class ByPageSemanticDataFinder {
 	}
 
 	protected function getPage() {
-		return WikiPage::factory( $this->getTitle() );
-	}
+        if ( version_compare( MW_VERSION, '1.36', '>=' ) ) {
+            return MediaWikiServices::getInstance()->getWikiPageFactory()->newFromTitle( $this->getTitle() );
+        }
+
+        return WikiPage::factory( $this->getTitle() );
+    }
 
 	protected function makeOutputFromPageRevision() {
 


### PR DESCRIPTION
* Replace WikiPage::factory() with WikiPageFactory()->newFromTitle() in 1.36+; #5324
* Replace Title::newFromIDs() with TitleArray::newFromResult() in 1.38+