### PR TITLE
Add show entity panel preference

### DIFF
--- a/extension.json
+++ b/extension.json
@@ -90,6 +90,9 @@
 		"UnusedProperties": "SMW\\SpecialUnusedProperties",
 		"WantedProperties": "SMW\\SpecialWantedProperties"
 	},
+	"DefaultUserOptions": {
+		"smw-prefs-general-options-show-entity-issue-panel": true
+	},
 	"load_composer_autoloader": true,
 	"manifest_version": 1
 }

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -535,6 +535,8 @@
 	"smw-prefs-general-options-disable-search-info": "Disable the syntax support information on the standard search page",
 	"smw-prefs-general-options-suggester-textinput": "Enable input assistance for semantic entities",
 	"smw-prefs-help-general-options-suggester-textinput": "If enabled, allows to use an [https://www.semantic-mediawiki.org/wiki/Help:Input_assistance input assistance] to find properties, concepts, and categorties from an input context.",
+	"smw-prefs-general-options-show-entity-issue-panel": "Show the entity issue panel",
+	"smw-prefs-help-general-options-show-entity-issue-panel": "If enabled, runs integrity checks on each page and shows the [https://www.semantic-mediawiki.org/wiki/Help:Entity_issue_panel Entity issue panel].",
 	"smw-ui-tooltip-title-property": "Property",
 	"smw-ui-tooltip-title-quantity": "Unit conversion",
 	"smw-ui-tooltip-title-info": "Information",

--- a/i18n/qqq.json
+++ b/i18n/qqq.json
@@ -551,6 +551,8 @@
 	"smw-prefs-general-options-disable-search-info": "This message describes a user preference option on special page \"Preferences\".",
 	"smw-prefs-general-options-suggester-textinput": "This is the description of a user preference option selectable on special page \"Preferences\".",
 	"smw-prefs-help-general-options-suggester-textinput": "This is an informative message explaining a preference option on special page \"Preferences\". Input context means accessible from respective input fields.",
+	"smw-prefs-general-options-show-entity-issue-panel": "This message describes a user preference option on special page \"Preferences\".",
+	"smw-prefs-help-general-options-show-entity-issue-panel": "This is a message describing a user preference option selectable via special page \"Preferences\". Relates to checks and information shown when viewing a page.",
 	"smw-ui-tooltip-title-property": "A label that is displayed on the info tooltip.\n{{Identical|Property}}",
 	"smw-ui-tooltip-title-quantity": "A label that is displayed on the info tooltip.",
 	"smw-ui-tooltip-title-info": "A label that is displayed on the info tooltip.\n{{Identical|Information}}",

--- a/src/MediaWiki/Hooks.php
+++ b/src/MediaWiki/Hooks.php
@@ -436,8 +436,13 @@ class Hooks {
 			$permissionExaminer
 		);
 
+		$preferenceExaminer = $applicationFactory->newPreferenceExaminer( $outputPage->getUser() );
+
 		$outputPageParserOutput->setIndicatorRegistry(
-			$applicationFactory->create( 'IndicatorRegistry' )
+			$applicationFactory->create(
+				'IndicatorRegistry',
+				$preferenceExaminer->hasPreferenceOf( GetPreferences::SHOW_ENTITY_ISSUE_PANEL )
+			)
 		);
 
 		$outputPageParserOutput->process( $outputPage, $parserOutput );

--- a/src/MediaWiki/Hooks/GetPreferences.php
+++ b/src/MediaWiki/Hooks/GetPreferences.php
@@ -52,6 +52,11 @@ class GetPreferences implements HookListener {
 	const DISABLE_SEARCH_INFO = 'smw-prefs-general-options-disable-search-info';
 
 	/**
+	 * Option to disable the entity issue indicator and panel on a wiki page
+	 */
+	const SHOW_ENTITY_ISSUE_PANEL = 'smw-prefs-general-options-show-entity-issue-panel';
+
+	/**
 	 * @var PermissionExaminer
 	 */
 	private $permissionExaminer;
@@ -120,6 +125,13 @@ class GetPreferences implements HookListener {
 			'type' => 'toggle',
 			'label-message' => 'smw-prefs-general-options-suggester-textinput',
 			'help-message' => 'smw-prefs-help-general-options-suggester-textinput',
+			'section' => 'smw/general-options',
+		];
+
+		$preferences[self::SHOW_ENTITY_ISSUE_PANEL] = [
+			'type' => 'toggle',
+			'label-message' => 'smw-prefs-general-options-show-entity-issue-panel',
+			'help-message' => 'smw-prefs-help-general-options-show-entity-issue-panel',
 			'section' => 'smw/general-options',
 		];
 

--- a/src/Services/SharedServicesContainer.php
+++ b/src/Services/SharedServicesContainer.php
@@ -129,9 +129,14 @@ class SharedServicesContainer implements CallbackContainer {
 	 *
 	 * @return IndicatorRegistry
 	 */
-	public function newIndicatorRegistry( ContainerBuilder $containerBuilder ) {
+	public function newIndicatorRegistry( ContainerBuilder $containerBuilder, bool $addEntityExaminer ) {
 
 		$indicatorRegistry = new IndicatorRegistry();
+
+		if ( !$addEntityExaminer ) {
+			return $indicatorRegistry;
+		}
+
 		$entityExaminerIndicatorsFactory = new EntityExaminerIndicatorsFactory();
 
 		$entityExaminerIndicatorProvider = $entityExaminerIndicatorsFactory->newEntityExaminerIndicatorProvider(


### PR DESCRIPTION
Refs #4674

I'm not very familiar with SMW architecture, so this might be totally in the wrong place.

In general the idea here is to allow completely disabling the entity examiner status indicator and panel (and the API call itself).

The user preference is `true` by default to maintain the current default behavior. This can be changed in LocalSettings:
```php
$wgDefaultUserOptions['smw-prefs-general-options-show-entity-issue-panel'] = false;
```

Or a user can set it on the Preferences UI:
![Screenshot_20221209_002240](https://user-images.githubusercontent.com/1428594/206579801-4bbe706a-afe9-44ac-9b09-71026ebc8a95.png)

Any test changes are still TODO.