### PR TITLE
Fix matching of pipe character in Ask API

### DIFF
--- a/src/MediaWiki/Api/ApiRequestParameterFormatter.php
+++ b/src/MediaWiki/Api/ApiRequestParameterFormatter.php
@@ -45,7 +45,7 @@ final class ApiRequestParameterFormatter {
 	public function getAskApiParameters() {
 
 		if ( $this->results === null ) {
-			$this->results = isset( $this->requestParameters['query'] ) ? preg_split( "/(?<=[^\|])\|(?=[^\|])/", $this->requestParameters['query'] ) : [];
+			$this->results = isset( $this->requestParameters['query'] ) ? preg_split( "/(?<=[^\|])\|(?=[^\|])(?=[^\+])/", $this->requestParameters['query'] ) : [];
 		}
 
 		return $this->results;


### PR DESCRIPTION
Update the regex to only match the pipe character `|` if the immediate next character is not a `+`.

Test Case: `[[Category:Portail|+depth=0]]|?=Page|?A des termes SEO=Description|limit=5000`
Old Regex: `/(?<=[^\|])\|(?=[^\|])/`  
Returns:
```
Array
(
    [0] => [[Category:Portail
    [1] => +depth=0]]
    [2] => ?=Page
    [3] => ?A des termes SEO=Description
    [4] => limit=5000
)
```

New Regex: `/(?<=[^\|])\|(?=[^\|])(?=[^\+])/`  
Returns:  
```
Array
(
    [0] => [[Category:Portail|+depth=0]]
    [1] => ?=Page
    [2] => ?A des termes SEO=Description
    [3] => limit=5000
)
```

Should fix #5316