### PR TITLE
Switch to mediawiki/http-request

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -47,7 +47,7 @@
 		"onoi/cache": "~1.2",
 		"onoi/event-dispatcher": "~1.0",
 		"onoi/blob-store": "~1.2",
-		"onoi/http-request": "~1.1",
+		"mediawiki/http-request": "~2.0|~1.1",
 		"onoi/callback-container": "~2.0",
 		"onoi/shared-resources": "~0.3",
 		"symfony/css-selector": "^5|^4|^3.3",


### PR DESCRIPTION
Should make the MW 1.35 + PHP 8 test failures in #5346 pass, although it does not address the PHP 7 issue there.

(Reason for forking here: https://github.com/onoi/http-request/pull/14)