### PR TITLE
refactor: Make `showingresults` message part of SMW

### DIFF
--- a/i18n/af.json
+++ b/i18n/af.json
@@ -119,5 +119,6 @@
 	"smw-elastic-rebuildelasticindex-run-incomplete": "Die <code> ElasticStore </code> is gekies as [https://www.semantic-mediawiki.org/wiki/Help:smwgDefaultStore standaardwinkel], maar die uitbreiding kon nog geen rekord vind dat die [https: / /www.semantic-mediawiki.org/wiki/Help:rebuildElasticIndex.php buildElasticIndex.php] script is uitgevoer, voer asseblief die script uit soos voorgeskryf.",
 	"smw-pendingtasks-setup-intro": "Die {{PLURAL:$1|installasie|opgradering}} van <b> Semantic MediaWiki </b> het die volgende take geklassifiseer as [https://www.semantic-mediawiki.org/wiki/Help:Upgrade/Incomplete_upgrade onvolledig] en daar word van 'n administrateur (of gebruiker met voldoende regte) verwag om hierdie take op te los voordat gebruikers voortgaan om inhoud te skep of te verander. Die {{PLURAL:$1|installasie|opgradering}} van <b> Semantic MediaWiki </b> het die die volgende take te volg as [https://www.semantic-mediawiki.org/wiki/Help:Upgrade/Incomplete_upgrade onvolledig] en daar word van 'n administrateur (of gebruiker met voldoende regte) verwag om hierdie take op te los voordat gebruikers voortgaan om inhoud te skep of te verander.",
 	"smw-pendingtasks-setup-tasks": "take",
-	"smw-listingcontinuesabbrev": "vervolg"
+	"smw-listingcontinuesabbrev": "vervolg",
+	"smw-showingresults": "Hier volg {{PLURAL:$1|'''1''' resultaat|'''$1''' resultate}} vanaf #'''$2'''."
 }

--- a/i18n/aln.json
+++ b/i18n/aln.json
@@ -41,5 +41,6 @@
 	"smw_notitle": "\"$1\" nuk mund të përdoret si një emër faqe në këtë wiki.",
 	"smw_wrong_namespace": "Vetëm faqet në hapësirën \"$1\" lejohen këtu.",
 	"smw_unknowntype": "Lloj i pasuportuar \"$1\" të përcaktuara për pronën.",
-	"smw-listingcontinuesabbrev": "vazh."
+	"smw-listingcontinuesabbrev": "vazh.",
+	"smw-showingresults": "Mâ poshtë {{PLURAL:$1|tregohet '''1''' rezultat|tregohen '''$1''' rezultate}} që nisin me #'''$2'''."
 }

--- a/i18n/am.json
+++ b/i18n/am.json
@@ -6,5 +6,6 @@
 	},
 	"smw_result_next": "ቀጥሎ",
 	"smw-livepreview-loading": "በመጫን ላይ ነው...",
-	"smw-listingcontinuesabbrev": "(ተቀጥሏል)"
+	"smw-listingcontinuesabbrev": "(ተቀጥሏል)",
+	"smw-showingresults": "ከ ቁ.#<b>$2</b> ጀምሮ እስከ <b>$1</b> ውጤቶች ድረስ ከዚህ በታች ይታያሉ።"
 }

--- a/i18n/an.json
+++ b/i18n/an.json
@@ -11,5 +11,6 @@
 	"browse": "Explorar o wiki",
 	"smw-livepreview-loading": "Cargando…",
 	"smw-help": "Aduya",
-	"smw-listingcontinuesabbrev": "cont."
+	"smw-listingcontinuesabbrev": "cont.",
+	"smw-showingresults": "Contino se bi {{PLURAL:$1|amuestra '''1''' resultau|amuestran '''$1''' resultaus}} prencipiando por o numero '''$2'''."
 }

--- a/i18n/ang.json
+++ b/i18n/ang.json
@@ -14,5 +14,6 @@
 	"smw-copy": "Biwrītan",
 	"smw-jsonview-expand-title": "Aþenaþ þe JSON ansyn",
 	"smw-jsonview-collapse-title": "Tofealleþ þa JSON ansyn",
-	"smw-listingcontinuesabbrev": "mā"
+	"smw-listingcontinuesabbrev": "mā",
+	"smw-showingresults": "Ywð herunder swa fela swa {{PLURAL:$1|<strong>1</strong> gefundennesse|<strong>$1</strong> gefundennessa}}, and #<strong>$2</strong> is seo forme."
 }

--- a/i18n/ar.json
+++ b/i18n/ar.json
@@ -1011,5 +1011,6 @@
 	"smw-datavalue-constraint-schema-property-invalid-type": "المخطط \"$1\" المشروح غير صالح لخاصية؛ فهو يتطلب نوع \"$2\".",
 	"smw-entity-examiner-associated-revision-mismatch": "مراجعة",
 	"smw-entity-examiner-deferred-fake": "مزيف",
-	"smw-listingcontinuesabbrev": "(تابع)"
+	"smw-listingcontinuesabbrev": "(تابع)",
+	"smw-showingresults": "معروض بالأسفل {{PLURAL:$1|<strong>1</strong> نتيجة}} بدءا من رقم <strong>$2</strong>."
 }

--- a/i18n/arc.json
+++ b/i18n/arc.json
@@ -47,5 +47,6 @@
 	"smw_result_next": "ܕܒܬܪ",
 	"smw_result_results": "ܦܠܛ̈ܐ",
 	"smw_result_noresults": "ܠܝܬ ܦܠܛ̈ܐ.",
-	"smw-listingcontinuesabbrev": "(ܫܘܠܡܐ)"
+	"smw-listingcontinuesabbrev": "(ܫܘܠܡܐ)",
+	"smw-showingresults": "ܚܘܘܝܐ ܠܬܚܬ {{PLURAL:$1|'''1''' ܦܠܛܐ|'''$1''' ܦܠܛ̈ܐ}} ܫܪܐ ܡܢ ܡܢܝܢܐ '''$2'''."
 }

--- a/i18n/ary.json
+++ b/i18n/ary.json
@@ -15,5 +15,6 @@
 	"smw-livepreview-loading": "tssna wa7d chwiya kaytcharja ....",
 	"smw-search-hide": "خبي",
 	"smw-help": "معاونة",
-	"smw-listingcontinuesabbrev": "لكمالة"
+	"smw-listingcontinuesabbrev": "لكمالة",
+	"smw-showingresults": "باينة لتحت {{PLURAL:$1|<strong>1</strong> نتائج}} بادية برقم <strong>$2</strong>."
 }

--- a/i18n/arz.json
+++ b/i18n/arz.json
@@ -180,5 +180,6 @@
 	"smw_concept_header": "صفحات المبدأ \"$1\"",
 	"smw_conceptarticlecount": "عرض {{PLURAL:$1||صفحه واحده تنتمي|صفحتين تنتميان|$1 صفحات تنتمي|$1 صفحه تنتمي}} إلى هذا المبدأ.",
 	"smw-livepreview-loading": "تحميل…",
-	"smw-listingcontinuesabbrev": "متابعه"
+	"smw-listingcontinuesabbrev": "متابعه",
+	"smw-showingresults": "الصفحه دى بتعرض {{PLURAL:$1|<strong>1</strong> نتيجه}} من اول رقم <strong>$2</strong>."
 }

--- a/i18n/as.json
+++ b/i18n/as.json
@@ -12,5 +12,6 @@
 	"browse": "ব্ৰাউজ ৱিকি",
 	"smw_result_results": "ফলাফল",
 	"smw-livepreview-loading": "ল'ড হৈ আছে…",
-	"smw-listingcontinuesabbrev": "আগলৈ"
+	"smw-listingcontinuesabbrev": "আগলৈ",
+	"smw-showingresults": "তলত #'''$2'''ৰ পৰা {{PLURAL:$1|'''1''' ফলাফল|'''$1''' ফলাফল}} দেখুওৱা হৈছে।"
 }

--- a/i18n/ast.json
+++ b/i18n/ast.json
@@ -652,5 +652,6 @@
 	"smw-remote-source-unavailable": "Nun pudo coneutase col destín remotu «$1».",
 	"smw-remote-source-disabled": "L'orixe '''$1''' desactivó l'encontu de solicitúes remotes.",
 	"smw-pendingtasks-setup-tasks": "Xeres",
-	"smw-listingcontinuesabbrev": "cont."
+	"smw-listingcontinuesabbrev": "cont.",
+	"smw-showingresults": "Abaxo s'{{PLURAL:$1|amuesa hasta <strong>un</strong> resultáu|amuesen <strong>$1</strong> resultaos}}, principando por #<strong>$2</strong>."
 }

--- a/i18n/avk.json
+++ b/i18n/avk.json
@@ -6,5 +6,6 @@
 	},
 	"browse": "Exulera va wiki",
 	"smw-livepreview-loading": "Vajas…",
-	"smw-listingcontinuesabbrev": "loon"
+	"smw-listingcontinuesabbrev": "loon",
+	"smw-showingresults": "Vlevefa nedira va {{PLURAL:$1|'''1''' trasiks|'''$1''' trasiks}} dem #'''$2''' toza."
 }

--- a/i18n/awa.json
+++ b/i18n/awa.json
@@ -8,5 +8,6 @@
 	"browse": "विकि देखा जाय",
 	"smw_browselink": "खाश जानकारी",
 	"prefs-smw": "शब्दार्थगत मीडियाविकी",
-	"smw-listingcontinuesabbrev": "आगे."
+	"smw-listingcontinuesabbrev": "आगे.",
+	"smw-showingresults": "नीचे क्रमांक '''$2''' से सुरु कै कय सबसे ढेर '''$1''' परिणाम {{PLURAL:$1|देखाइ गा है}}।"
 }

--- a/i18n/az.json
+++ b/i18n/az.json
@@ -35,5 +35,6 @@
 	"smw-help": "Kömək",
 	"smw-processing": "İşləyir ...",
 	"smw-redirect-target-unresolvable": "Hədəf \"$1\" səbəbindən həll olunmayacaq",
-	"smw-listingcontinuesabbrev": "(davam)"
+	"smw-listingcontinuesabbrev": "(davam)",
+	"smw-showingresults": "Aşağıda #<strong>$2</strong> ilə başlayan {{PLURAL:$1|<strong>$1</strong>-ə qədər}} nəticə göstərilib."
 }

--- a/i18n/azb.json
+++ b/i18n/azb.json
@@ -10,5 +10,6 @@
 	"smw_browselink": "اوزللیکلری گؤزدن کئچیر",
 	"smw_browse_go": "گئت",
 	"smw-livepreview-loading": "یوکلنیر...",
-	"smw-listingcontinuesabbrev": "(قالانی)"
+	"smw-listingcontinuesabbrev": "(قالانی)",
+	"smw-showingresults": "آشاغیدا نومره '''$2'''-دن باشلایان {{PLURAL:$1|'''بیر'''|'''$1'''}} سونوجا قدر گؤستریلیر."
 }

--- a/i18n/ba.json
+++ b/i18n/ba.json
@@ -15,5 +15,6 @@
 	"smw-admin-setupsuccess": "Һаҡлау системаһы уңышлы ҡуйылды",
 	"smw-livepreview-loading": "Сығарыу...",
 	"smw-format-datatable-toolbar-export": "Экспорт",
-	"smw-listingcontinuesabbrev": "дауамы"
+	"smw-listingcontinuesabbrev": "дауамы",
+	"smw-showingresults": "Түбәндә №&nbsp;<strong>$2</strong> һөҙөмтәнән башлап <strong>$1</strong> {{PLURAL:$1|һөҙөмтә}} күрһәтелгән."
 }

--- a/i18n/bcc.json
+++ b/i18n/bcc.json
@@ -9,5 +9,6 @@
 	"smw-upgrade-error-how-title": "چۏن اے ارورءَ شرّ بکنوں؟",
 	"smw_printername_category": "تهر",
 	"smw-livepreview-loading": "...بار بیت",
-	"smw-listingcontinuesabbrev": "دامدار."
+	"smw-listingcontinuesabbrev": "دامدار.",
+	"smw-showingresults": "جهل پیش دارگنت تا  {{PLURAL:$1|'''1'''نتیجه|'''$1''' نتایج}} شروع بنت گون #'''$2'''."
 }

--- a/i18n/bcl.json
+++ b/i18n/bcl.json
@@ -15,5 +15,6 @@
 	"smw-paramdesc-table-transpose": "Ipahiling an mga pamayuhan kan lamesa sa paaging patindog asin an mga resulta sa paaging pahigda",
 	"browse": "Mag-browse sa wiki",
 	"smw-livepreview-loading": "Pigkakarga…",
-	"smw-listingcontinuesabbrev": "kasumpay"
+	"smw-listingcontinuesabbrev": "kasumpay",
+	"smw-showingresults": "Pigpapahiling sa babâ sagkod sa {{PLURAL:$1|'''1''' resulta|'''$1''' mga resulta}} poon sa #'''$2'''."
 }

--- a/i18n/be-tarask.json
+++ b/i18n/be-tarask.json
@@ -429,5 +429,6 @@
 	"smw-datavalue-parse-error": "Дадзенае значэньне «$1» не было распазнанае.",
 	"smw-no-data-available": "Няма даступных зьвестак.",
 	"smw-es-replication-error-no-connection": "Сачэньне за паўтарэньнем ня можа выканаць праверкі, бо ня можа ўсталяваць сувязь з клястэрам Elasticsearch.",
-	"smw-listingcontinuesabbrev": " (працяг)"
+	"smw-listingcontinuesabbrev": " (працяг)",
+	"smw-showingresults": "Ніжэй {{PLURAL:$1|паданы|паданыя|паданыя}} да '''$1''' {{PLURAL:$1|выніку|вынікаў|вынікаў}}, пачынаючы з #<b>$2</b>."
 }

--- a/i18n/be.json
+++ b/i18n/be.json
@@ -31,5 +31,6 @@
 	"smw-ui-tooltip-title-property": "Уласцівасць",
 	"smw-livepreview-loading": "Счытваем…",
 	"smw-help": "Даведка",
-	"smw-listingcontinuesabbrev": "працяг"
+	"smw-listingcontinuesabbrev": "працяг",
+	"smw-showingresults": "Ніжэй паказаны да {{PLURAL:$1|'''$1''' выніку|'''$1''' вынікаў}}, пачынаючы з нумару '''$2'''."
 }

--- a/i18n/bg.json
+++ b/i18n/bg.json
@@ -166,5 +166,6 @@
 	"smw-format-datatable-search": "Търсене:",
 	"smw-format-datatable-next": "Следваща",
 	"smw-help": "Помощ",
-	"smw-listingcontinuesabbrev": "продълж."
+	"smw-listingcontinuesabbrev": "продълж.",
+	"smw-showingresults": "Показване на до {{PLURAL:$1|<strong>1</strong> резултат|<strong>$1</strong> резултата}}, като се започва от номер <strong>$2</strong>."
 }

--- a/i18n/bgn.json
+++ b/i18n/bgn.json
@@ -5,5 +5,6 @@
 		]
 	},
 	"browse": "ویکی بروز",
-	"smw-listingcontinuesabbrev": "(ادامه)"
+	"smw-listingcontinuesabbrev": "(ادامه)",
+	"smw-showingresults": "نشان داتین حداکثر {{PLURAL:$1|'''۱''' نتیجه|'''$1''' نتیجه}} بی جهلگا، شرو شه شماره ئی  '''$2'''."
 }

--- a/i18n/bho.json
+++ b/i18n/bho.json
@@ -6,5 +6,6 @@
 		]
 	},
 	"browse": "विकि ब्राउज करी",
-	"smw-listingcontinuesabbrev": "जारी..."
+	"smw-listingcontinuesabbrev": "जारी...",
+	"smw-showingresults": "नीचे  #'''$2''' से शुरु होखे वाला {{PLURAL:$1|'''1''' रिजल्ट देखावल जा रहल बा|'''$1''' रिजल्ट देखावल जा रहल बाड़ें}}।"
 }

--- a/i18n/bjn.json
+++ b/i18n/bjn.json
@@ -7,5 +7,6 @@
 	"version-semantic": "Éksténsi sémantik",
 	"browse": "Jalajahi wiki",
 	"smw-livepreview-loading": "Ma'unggah...",
-	"smw-listingcontinuesabbrev": "samb."
+	"smw-listingcontinuesabbrev": "samb.",
+	"smw-showingresults": "Di bawah ngini ditampaiakan hingga {{PLURAL:$1|'''1''' kulihan|'''$1''' kukulihan}}, dimulai matan #'''$2'''."
 }

--- a/i18n/bn.json
+++ b/i18n/bn.json
@@ -209,5 +209,6 @@
 	"smw-ask-tab-debug": "ডিবাগ",
 	"smw-ask-tab-code": "কোড",
 	"smw-legend": "ব্যাখ্যা",
-	"smw-listingcontinuesabbrev": "আরও আছে"
+	"smw-listingcontinuesabbrev": "আরও আছে",
+	"smw-showingresults": "<strong>$2</strong> নং থেকে শুরু করে {{PLURAL:$1|<strong>১টি</strong> ফলাফল|<strong>$1টি</strong> ফলাফল}} নিচে দেখানো হচ্ছে।"
 }

--- a/i18n/br.json
+++ b/i18n/br.json
@@ -248,5 +248,6 @@
 	"smw-types-title": "Doare: $1",
 	"smw-updateentitycollation-incomplete": "NEvez zo eo bet kemmet an arventenn <code>[https://www.semantic-mediawiki.org/wiki/Help:$smwgEntityCollation $smwgEntityCollation]</code> ha rekis eo erounit ar skript <code>[https://www.semantic-mediawiki.org/wiki/Help:updateEntityCollation.php updateEntityCollation.php]</code> evit ma c'hallfe an entiteoù bezañ hizivaet ha bezañ enno talvoudoù dilenn reizh.",
 	"smw-entity-examiner-associated-revision-mismatch": "Adweladenn",
-	"smw-listingcontinuesabbrev": "(war-lerc'h)"
+	"smw-listingcontinuesabbrev": "(war-lerc'h)",
+	"smw-showingresults": "Diskouez betek {{PLURAL:$1|'''1''' disoc'h|'''$1''' disoc'h}} o kregiñ gant #'''$2'''."
 }

--- a/i18n/bs.json
+++ b/i18n/bs.json
@@ -75,5 +75,6 @@
 	"smw-data-lookup": "Dobavljam podatke...",
 	"smw-format-datatable-loadingrecords": "Učitavam...",
 	"smw-format-datatable-processing": "Obrađujem...",
-	"smw-listingcontinuesabbrev": "nast."
+	"smw-listingcontinuesabbrev": "nast.",
+	"smw-showingresults": "Dolje {{PLURAL:$1|je prikazan <strong>1</strong> rezultat|su prikazana <strong>$1</strong> rezultata|je prikazano '''$1''' rezultata}} počev od #<strong>$2</strong>."
 }

--- a/i18n/ca.json
+++ b/i18n/ca.json
@@ -876,5 +876,6 @@
 	"smw-entity-examiner-deferred-fake": "Simulació",
 	"smw-indicator-constraint-violation": "{{PLURAL:$1|Constricció|Constriccions}}",
 	"smw-indicator-revision-mismatch": "Revisió",
-	"smw-listingcontinuesabbrev": " cont."
+	"smw-listingcontinuesabbrev": " cont.",
+	"smw-showingresults": "Tot seguit es {{PLURAL:$1|mostra el resultat|mostren els <b>$1</b> resultats començant pel número <b>$2</b>}}."
 }

--- a/i18n/cdo.json
+++ b/i18n/cdo.json
@@ -6,5 +6,6 @@
 	},
 	"browse": "Káng wiki",
 	"smw-livepreview-loading": "載入...",
-	"smw-listingcontinuesabbrev": "（繼續前斗）"
+	"smw-listingcontinuesabbrev": "（繼續前斗）",
+	"smw-showingresults": "顯示趁#<b>$2</b>開始其{{PLURAL:$1|'''$1'''萆結果}}。"
 }

--- a/i18n/ce.json
+++ b/i18n/ce.json
@@ -91,5 +91,6 @@
 	"smw-category": "Категори",
 	"smw-help": "ГӀо",
 	"smw-schema-error-json": "JSON гӀалат: \"$1\"",
-	"smw-listingcontinuesabbrev": "(кхин дlа)"
+	"smw-listingcontinuesabbrev": "(кхин дlа)",
+	"smw-showingresults": "Лахахьа {{PLURAL:$1|гойту}} <strong>$1</strong> {{PLURAL:$1|хилам}}, дӀаболало кху № <strong>$2</strong>."
 }

--- a/i18n/ch.json
+++ b/i18n/ch.json
@@ -5,5 +5,6 @@
 		]
 	},
 	"smw_browse_go": "Hånao",
-	"smw-listingcontinuesabbrev": "kont."
+	"smw-listingcontinuesabbrev": "kont.",
+	"smw-showingresults": "A'annok gi sampapa' asta {{PLURAL:$1|'''1''' na humuyongña|'''$1''' na humuyongña siha}} tumutuhon yan i #'''$2'''."
 }

--- a/i18n/ckb.json
+++ b/i18n/ckb.json
@@ -48,5 +48,6 @@
 	"smw-livepreview-loading": "باركردن‌...",
 	"smw-patternedit-protection": "ئەم پەڕەیە پارێزراوە و تەنھا دەتوانرێت دەستکاریان بکرێت لەلایەن بەکارھێنەرانی <code>smw-patternedit</code> [https://www.semantic-mediawiki.org/wiki/Help:Permissions permission].",
 	"smw-jsonview-search-label": "گەڕان:",
-	"smw-listingcontinuesabbrev": "(درێژە)"
+	"smw-listingcontinuesabbrev": "(درێژە)",
+	"smw-showingresults": "لە خوارەوە {{PLURAL:$1|'''یەک''' ئەنجام|'''$1''' ئەنجام}} نیشان دراوە، بە دەست پێ کردن لە ژمارەی '''$2'''ەوە."
 }

--- a/i18n/crh-cyrl.json
+++ b/i18n/crh-cyrl.json
@@ -6,5 +6,6 @@
 	},
 	"smw_purge": "Янъарт",
 	"smw-livepreview-loading": "Юкленмекте…",
-	"smw-listingcontinuesabbrev": " (девам)"
+	"smw-listingcontinuesabbrev": " (девам)",
+	"smw-showingresults": "Ашагъыда №&nbsp;<strong>$2</strong>ден башлап {{PLURAL:$1|1='''1''' нетидже|'''$1''' нетидже}} булуна."
 }

--- a/i18n/crh-latn.json
+++ b/i18n/crh-latn.json
@@ -8,5 +8,6 @@
 	"smw_purge": "Yañart",
 	"browse": "Vikini qıdırıñız",
 	"smw-livepreview-loading": "Yüklenmekte…",
-	"smw-listingcontinuesabbrev": " (devam)"
+	"smw-listingcontinuesabbrev": " (devam)",
+	"smw-showingresults": "Aşağıda №&nbsp;<strong>$2</strong>den başlap {{PLURAL:$1|'''1''' netice|'''$1''' netice}} buluna."
 }

--- a/i18n/cs.json
+++ b/i18n/cs.json
@@ -378,5 +378,6 @@
 	"smw-property-tab-redirects": "Synonyma",
 	"smw-concept-tab-list": "Seznam",
 	"smw-concept-tab-errors": "Chyby",
-	"smw-listingcontinuesabbrev": "pokrač."
+	"smw-listingcontinuesabbrev": "pokrač.",
+	"smw-showingresults": "Níže zobrazuji nejvýše <strong>$1</strong> {{PLURAL:$1|výsledek|výsledky|výsledků}} počínaje od <strong>$2</strong>."
 }

--- a/i18n/cv.json
+++ b/i18n/cv.json
@@ -8,5 +8,6 @@
 	"smw_purge": "Çĕнĕлет",
 	"smw_browse_go": "Куç",
 	"smw-livepreview-loading": "Тултаратпăр…",
-	"smw-listingcontinuesabbrev": "(малалли)"
+	"smw-listingcontinuesabbrev": "(малалли)",
+	"smw-showingresults": "Аяларах эсир <strong>$2</strong> пуçласа кăтартнă <strong>$1</strong> йĕркене куратăр."
 }

--- a/i18n/cy.json
+++ b/i18n/cy.json
@@ -10,5 +10,6 @@
 	"validator-type-class-SMWParamSource": "testun",
 	"browse": "Pori'r wici",
 	"smw-livepreview-loading": "Wrthi'n llwytho…",
-	"smw-listingcontinuesabbrev": "parh."
+	"smw-listingcontinuesabbrev": "parh.",
+	"smw-showingresults": "Yn dangos $1 {{PLURAL:$1|canlyniad|canlyniad|ganlyniad|chanlyniad|chanlyniad|canlyniad}} isod gan ddechrau gyda rhif '''$2'''."
 }

--- a/i18n/da.json
+++ b/i18n/da.json
@@ -229,5 +229,6 @@
 	"smw-ask-tab-result": "Resultat",
 	"smw-ask-tab-extra": "Ekstra",
 	"smw-ask-tab-code": "Kode",
-	"smw-listingcontinuesabbrev": "forts."
+	"smw-listingcontinuesabbrev": "forts.",
+	"smw-showingresults": "Nedenfor vises <b>$1</b> {{PLURAL:$1|resultat|resultater}} startende med nummer <b>$2</b>."
 }

--- a/i18n/de.json
+++ b/i18n/de.json
@@ -1125,5 +1125,6 @@
 	"smw-indicator-revision-mismatch": "Revision",
 	"smw-indicator-revision-mismatch-error": "Der [https://www.semantic-mediawiki.org/wiki/Help:Associated_revision/Examiner Seitenversionsprüfung] hat beim Vergleich eine Abweichung der Seitenversionen zwischen den Datenbanken von MediaWiki und Semantic MediaWiki festgestellt.",
 	"smw-indicator-revision-mismatch-comment": "Eine Abweichung deutet normalerweise darauf hin, daß eine Softwareaufgabe zur Aktualisierung der Seitenversion, in der Datenbank von Semantic MediaWiki, unterbrochen wurde. Daher sollten die entsprechenden Logdateien des Servers auf Informationen zu möglichen Fehlern geprüft werden.",
-	"smw-listingcontinuesabbrev": "Fortsetzung"
+	"smw-listingcontinuesabbrev": "Fortsetzung",
+	"smw-showingresults": "Hier {{PLURAL:$1|ist '''1''' Ergebnis|sind '''$1''' Ergebnisse}}, beginnend mit Nummer '''$2.'''"
 }

--- a/i18n/diq.json
+++ b/i18n/diq.json
@@ -149,5 +149,6 @@
 	"smw-es-replication-error-divergent-date-detail": "*$1 (Cıgeyrayışo elastik)\n*$2 (Mığazaya SQLi)",
 	"smw-report": "Rapore",
 	"smw-legend": "Kıtabek",
-	"smw-listingcontinuesabbrev": "dewam..."
+	"smw-listingcontinuesabbrev": "dewam...",
+	"smw-showingresults": "#<strong>$2</strong> netican ra {{PLURAL:$1|<strong>1</strong> netice cêr dero|<strong>$1</strong> neticey cêr derê}}."
 }

--- a/i18n/dsb.json
+++ b/i18n/dsb.json
@@ -264,5 +264,6 @@
 	"smw-sp-properties-header-label": "Lisćina kakosćow",
 	"smw-sp-admin-settings-button": "Lisćinu nastajenjow napóraś",
 	"smw-livepreview-loading": "Lodowanje …",
-	"smw-listingcontinuesabbrev": "dalej"
+	"smw-listingcontinuesabbrev": "dalej",
+	"smw-showingresults": "How {{PLURAL:|jo '''1''' wuslědk|stej '''$1''' wuslědka|su '''$1''' wuslědki}} wót cysła '''$2'''."
 }

--- a/i18n/dty.json
+++ b/i18n/dty.json
@@ -19,5 +19,6 @@
 	"smw-format-datatable-last": "छाड्डीबारको",
 	"smw-format-datatable-next": "अघबटाको",
 	"smw-format-datatable-previous": "पछबटाको",
-	"smw-listingcontinuesabbrev": "निरन्तरता..."
+	"smw-listingcontinuesabbrev": "निरन्तरता...",
+	"smw-showingresults": "धेखाउँदै  {{PLURAL:$1|'''१''' नतिजा|'''$1''' नतिजाहरू }} , #'''$2''' बठे सुरुहुन्या ।"
 }

--- a/i18n/el.json
+++ b/i18n/el.json
@@ -714,5 +714,6 @@
 	"smw-report": "Αναφορά",
 	"smw-legend": "Υπόμνημα",
 	"smw-entity-examiner-associated-revision-mismatch": "Αναθεώρηση",
-	"smw-listingcontinuesabbrev": "συνεχίζεται"
+	"smw-listingcontinuesabbrev": "συνεχίζεται",
+	"smw-showingresults": "Παρακάτω {{PLURAL:$1|εμφανίζεται μέχρι <strong>1</strong> αποτέλεσμα|εμφανίζονται μέχρι <strong>$1</strong> αποτελέσματα}} ξεκινώντας από το Νο <strong>$2</strong>."
 }

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -1115,5 +1115,6 @@
 	"smw-indicator-revision-mismatch": "Revision",
 	"smw-indicator-revision-mismatch-error": "The [https://www.semantic-mediawiki.org/wiki/Help:Associated_revision/Examiner associated revision] check found a mismatch between the revision referenced in MediaWiki and the one being associated in Semantic MediaWiki for this entity.",
 	"smw-indicator-revision-mismatch-comment": "A mismatch normally indicates that some process interrupted the storage operation in Semantic MediaWiki. It is recommended to review the server logs and look for exceptions or other failures.",
-	"smw-listingcontinuesabbrev": "cont."
+	"smw-listingcontinuesabbrev": "cont.",
+	"smw-showingresults": "Showing below up to {{PLURAL:$1|<strong>1</strong> result|<strong>$1</strong> results}} starting with #<strong>$2</strong>."
 }

--- a/i18n/eo.json
+++ b/i18n/eo.json
@@ -178,5 +178,6 @@
 	"smw-property-predefined-pvuc": "\"$1\" estas predifinita eco, provizita de [https://www.semantic-mediawiki.org/wiki/Help:Special_properties Semantika Mediavikio] por restrikti valorajn atribuojn por ke ĉiu ekzemplero estas unika (aŭ maksimume ekzemplerigita unufoje).",
 	"smw-datavalue-parse-error": "La donita valoro \"$1\" ne estis komprenita.",
 	"smw-format-datatable-next": "Sekva",
-	"smw-listingcontinuesabbrev": "daŭrigo"
+	"smw-listingcontinuesabbrev": "daŭrigo",
+	"smw-showingresults": "Montras {{PLURAL:$1|'''1''' trovitan|'''$1''' trovitajn}} ekde la #'''$2'''-a."
 }

--- a/i18n/es.json
+++ b/i18n/es.json
@@ -881,5 +881,6 @@
 	"smw-entity-examiner-deferred-constraint-error": "Restricción",
 	"smw-entity-examiner-associated-revision-mismatch": "Revisión",
 	"smw-indicator-constraint-violation": "{{PLURAL:$1|Restricción|Restricciones}}",
-	"smw-listingcontinuesabbrev": "cont."
+	"smw-listingcontinuesabbrev": "cont.",
+	"smw-showingresults": "Abajo se {{PLURAL:$1|muestra <strong>1</strong> resultado|muestran hasta <strong>$1</strong> resultados}} comenzando por el n.º <strong>$2</strong>."
 }

--- a/i18n/et.json
+++ b/i18n/et.json
@@ -48,5 +48,6 @@
 	"smw_unknowntype": "Selle omaduse tüüp \"$1\" on vigane.",
 	"smw-property-predefined-default": "\"$1\" on eelmääratletud omadus tüübiga $2.",
 	"smw-livepreview-loading": "Laadimine...",
-	"smw-listingcontinuesabbrev": "jätk"
+	"smw-listingcontinuesabbrev": "jätk",
+	"smw-showingresults": "Allpool näidatakse '''{{PLURAL:$1|ühte|$1}}''' tulemust alates '''$2'''. tulemusest."
 }

--- a/i18n/eu.json
+++ b/i18n/eu.json
@@ -325,5 +325,6 @@
 	"smw-ask-format-help-link": "[https://www.semantic-mediawiki.org/wiki/Help:$1_format $1] formatua",
 	"smw-help": "Laguntza",
 	"smw-processing": "Prozesatzen...",
-	"smw-listingcontinuesabbrev": "jarr."
+	"smw-listingcontinuesabbrev": "jarr.",
+	"smw-showingresults": "Jarraian {{PLURAL:$1|emaitza <strong>bat</strong> ageri da.|<strong>$1</strong> emaitza ageri dira, #'''$2'''.etik hasita.}}"
 }

--- a/i18n/ext.json
+++ b/i18n/ext.json
@@ -3,5 +3,6 @@
 		"authors": []
 	},
 	"smw-livepreview-loading": "Cargandu…",
-	"smw-listingcontinuesabbrev": "acont."
+	"smw-listingcontinuesabbrev": "acont.",
+	"smw-showingresults": "Embahu se {{PLURAL:$1|muestra '''1''' resurtau qu'esmiença|muestran hata '''$1''' resurtaus qu'esmiençan}} pol #'''$2'''."
 }

--- a/i18n/fa.json
+++ b/i18n/fa.json
@@ -473,5 +473,6 @@
 	"smw-entity-examiner-deferred-elastic-replication": "الاستیک‌سرچ",
 	"smw-entity-examiner-associated-revision-mismatch": "نسخه",
 	"smw-indicator-revision-mismatch": "نسخه",
-	"smw-listingcontinuesabbrev": "ادامه"
+	"smw-listingcontinuesabbrev": "ادامه",
+	"smw-showingresults": "نمایش حداکثر {{PLURAL:$1|'''۱''' نتیجه|'''$1''' نتیجه}} در پایین، آغاز از شماره '''$2'''."
 }

--- a/i18n/fi.json
+++ b/i18n/fi.json
@@ -385,5 +385,6 @@
 	"smw-ask-tab-extra": "Ekstra",
 	"smw-ask-tab-code": "Koodi",
 	"smw-legend": "Selite",
-	"smw-listingcontinuesabbrev": "jatkuu"
+	"smw-listingcontinuesabbrev": "jatkuu",
+	"smw-showingresults": "Alla on vain {{PLURAL:$1|<strong>1</strong> hakutulos|<strong>$1</strong> hakutulosta}} alkaen tuloksesta nro <strong>$2</strong>."
 }

--- a/i18n/fo.json
+++ b/i18n/fo.json
@@ -6,5 +6,6 @@
 	},
 	"browse": "Leita í wikiini",
 	"smw-livepreview-loading": "Innlesur...",
-	"smw-listingcontinuesabbrev": "frh."
+	"smw-listingcontinuesabbrev": "frh.",
+	"smw-showingresults": "Niðanfyri standa upp til {{PLURAL:$1|'''$1''' úrslit, sum byrjar|'''$1''' úrslit, sum byrja}} við #<b>$2</b>."
 }

--- a/i18n/fr.json
+++ b/i18n/fr.json
@@ -1150,5 +1150,6 @@
 	"smw-indicator-revision-mismatch": "Révision",
 	"smw-indicator-revision-mismatch-error": "La vérification de la [https://www.semantic-mediawiki.org/wiki/Help:Associated_revision/Examiner révision associée] a mis en évidence une différence entre la révision référencée dans MediaWiki et celle associée dans Semantic MediaWiki pour cette entité.",
 	"smw-indicator-revision-mismatch-comment": "Une désynchronisation indique en général qu’un certain processus a interrompu l’opération de stockage dans MediaWiki Sémantique. Il est recommandé de vérifier les journaux du serveur et de rechercher les exceptions ou autres échecs.",
-	"smw-listingcontinuesabbrev": "(suite)"
+	"smw-listingcontinuesabbrev": "(suite)",
+	"smw-showingresults": "Affichage de <strong>$1</strong> résultat{{PLURAL:$1||s}} à partir du nº <strong>$2</strong>."
 }

--- a/i18n/frp.json
+++ b/i18n/frp.json
@@ -107,5 +107,6 @@
 	"smw_concept_header": "Pâges du concèpte « $1 »",
 	"smw_conceptarticlecount": "Fâre vêre l{{PLURAL:$1|a pâge que repôse|es $1 pâges que repôsont}} sur cél concèpte.",
 	"smw-livepreview-loading": "Chargement...",
-	"smw-listingcontinuesabbrev": "(suita)"
+	"smw-listingcontinuesabbrev": "(suita)",
+	"smw-showingresults": "Afichâjo ce-desot de tant qu’a <strong>$1</strong> rèsultat{{PLURAL:$1||s}} dês lo nº <strong>$2</strong>."
 }

--- a/i18n/frr.json
+++ b/i18n/frr.json
@@ -8,5 +8,6 @@
 	"browse": "Browse wiki",
 	"smw-livepreview-loading": "Loose ...",
 	"smw-search-show": "Wise",
-	"smw-listingcontinuesabbrev": "(gongt widjer)"
+	"smw-listingcontinuesabbrev": "(gongt widjer)",
+	"smw-showingresults": "Heer {{PLURAL:$1|as '''1''' resultaat|san '''$1''' resultaaten}}, jo began mä numer '''$2.'''"
 }

--- a/i18n/fur.json
+++ b/i18n/fur.json
@@ -6,5 +6,6 @@
 	},
 	"browse": "Esplore il sît",
 	"smw-livepreview-loading": "Daûr a cjamâ…",
-	"smw-listingcontinuesabbrev": "cont."
+	"smw-listingcontinuesabbrev": "cont.",
+	"smw-showingresults": "Ca sot {{PLURAL:$1|al è fin a '''1''' risultât|a son fin a '''$1''' risultâts}} scomençant dal numar '''$2'''."
 }

--- a/i18n/fy.json
+++ b/i18n/fy.json
@@ -69,5 +69,6 @@
 	"smw-ask-tab-code": "Koade",
 	"smw-pendingtasks-setup-tasks": "Taken",
 	"smw-legend": "Leginda",
-	"smw-listingcontinuesabbrev": "(ferfolch)"
+	"smw-listingcontinuesabbrev": "(ferfolch)",
+	"smw-showingresults": "Hjirûnder {{PLURAL:$1|<strong>1</strong> resultaat|<strong>$1</strong> resultaten}}, werjûn fan nû. <strong>$2</strong> ôf."
 }

--- a/i18n/ga.json
+++ b/i18n/ga.json
@@ -23,5 +23,6 @@
 	"smw_result_prev": "Siar",
 	"smw_result_next": "Ar aghaidh",
 	"smw-livepreview-loading": "Ag lódáil…",
-	"smw-listingcontinuesabbrev": "ar lean."
+	"smw-listingcontinuesabbrev": "ar lean.",
+	"smw-showingresults": "Ag taispeáint thíos {{PLURAL:$1|'''toradh amháin'''|'''$1''' torthaí}}, ag tosú le #'''$2'''."
 }

--- a/i18n/gan-hans.json
+++ b/i18n/gan-hans.json
@@ -3,5 +3,6 @@
 		"authors": []
 	},
 	"smw-livepreview-loading": "加载中…",
-	"smw-listingcontinuesabbrev": "续"
+	"smw-listingcontinuesabbrev": "续",
+	"smw-showingresults": "底下从第<b>$2</b>条显示起先𠮶<b>$1</b>条结果:"
 }

--- a/i18n/gan-hant.json
+++ b/i18n/gan-hant.json
@@ -3,5 +3,6 @@
 		"authors": []
 	},
 	"smw-livepreview-loading": "載入中…",
-	"smw-listingcontinuesabbrev": "續"
+	"smw-listingcontinuesabbrev": "續",
+	"smw-showingresults": "底下從第<b>$2</b>條顯示起先嗰<b>$1</b>條結果:"
 }

--- a/i18n/gd.json
+++ b/i18n/gd.json
@@ -5,5 +5,6 @@
 		]
 	},
 	"browse": "Brabhsaich an uicidh",
-	"smw-listingcontinuesabbrev": "(an corr)"
+	"smw-listingcontinuesabbrev": "(an corr)",
+	"smw-showingresults": "A' sealltainn suas ri <strong>$1</strong> {{PLURAL:$1|toradh|thoradh|toraidhean|toradh}} gu h-ìosal a' tòiseachadh le àireamh <strong>$2</strong>."
 }

--- a/i18n/gl.json
+++ b/i18n/gl.json
@@ -779,5 +779,6 @@
 	"smw-ask-tab-extra": "Extras",
 	"smw-ask-tab-debug": "Depuración",
 	"smw-ask-tab-code": "Código",
-	"smw-listingcontinuesabbrev": "cont."
+	"smw-listingcontinuesabbrev": "cont.",
+	"smw-showingresults": "{{PLURAL:$1|Móstrase <strong>1</strong> resultado|Móstranse <strong>$1</strong> resultados}}, comezando polo número <strong>$2</strong>."
 }

--- a/i18n/grc.json
+++ b/i18n/grc.json
@@ -27,5 +27,6 @@
 	"smw_result_next": "Ἑπόμεναι",
 	"smw_result_noresults": "Οὐδὲν ἀποτέλεσμα.",
 	"smw-livepreview-loading": "Φορτίζειν…",
-	"smw-listingcontinuesabbrev": "συνεχίζεται"
+	"smw-listingcontinuesabbrev": "συνεχίζεται",
+	"smw-showingresults": "Δεικνύναι κατωτέρω μέχρι {{PLURAL:$1|'''1''' ἀποτέλεσμα|'''$1''' ἀποτελέσματα}}· ἐκκίνησις ἐκ τοῦ #'''$2'''."
 }

--- a/i18n/gsw.json
+++ b/i18n/gsw.json
@@ -185,5 +185,6 @@
 	"smw_concept_header": "Syte vum Konzäpt „$1“",
 	"smw_conceptarticlecount": "S {{PLURAL:$1|wird ei Syten|wäre $1 Syten}} aazeigt, wu zue däm Konzäpt {{PLURAL:$1|ghert|ghere}}:",
 	"smw-livepreview-loading": "Am Lade …",
-	"smw-listingcontinuesabbrev": "(Forts.)"
+	"smw-listingcontinuesabbrev": "(Forts.)",
+	"smw-showingresults": "Do {{PLURAL:$1|isch '''1''' Ergebnis|sin '''$1''' Ergebniss}}, s fangt aa mit dr Nummerer '''$2.'''"
 }

--- a/i18n/gu.json
+++ b/i18n/gu.json
@@ -6,5 +6,6 @@
 	},
 	"browse": "વિકિ વાંચો",
 	"smw-livepreview-loading": "લવાઇ રહ્યું છે...",
-	"smw-listingcontinuesabbrev": "ચાલુ.."
+	"smw-listingcontinuesabbrev": "ચાલુ..",
+	"smw-showingresults": " {{PLURAL:$1|'''1''' પરિણામ|'''$1''' પરિણામો}} સુધી #'''$2''' થી શરૂ  કરી"
 }

--- a/i18n/hak.json
+++ b/i18n/hak.json
@@ -6,5 +6,6 @@
 	},
 	"browse": "Liù-lám Wiki",
 	"smw-livepreview-loading": "Chang-chhai chai-ngi̍p…",
-	"smw-listingcontinuesabbrev": "sa"
+	"smw-listingcontinuesabbrev": "sa",
+	"smw-showingresults": "Ha-mien hién-sṳ chhiùng thi-'''$2'''-thiàu khôi-sṳ́ ke '''$1'''-thiàu kiet-kó:"
 }

--- a/i18n/he.json
+++ b/i18n/he.json
@@ -646,5 +646,6 @@
 	"smw-indicator-revision-mismatch": "גרסה",
 	"smw-indicator-revision-mismatch-error": "בדיקת [https://www.semantic-mediawiki.org/wiki/Help:Associated_revision/Examiner הגרסה המשויכת] מצאה חוסר־התאמה בין הגרסה שכתובה במדיה־ויקי לבין הגרסה שמשויכת במדיה־ויקי סמנטית עבור הישות הזאת.",
 	"smw-indicator-revision-mismatch-comment": "חוסר התאמה בדרך־כלל מצביע על כך שתהליך כלשהו הפסיק פעולת אחסון במדיה־ויקי סמנטית. מומלץ לסקור את יומני השרת ולחפש חריגים וכישלונות אחרים.",
-	"smw-listingcontinuesabbrev": "המשך"
+	"smw-listingcontinuesabbrev": "המשך",
+	"smw-showingresults": "{{PLURAL:$1|מוצגת תוצאה <strong>אחת</strong>|מוצגות עד <strong>$1</strong> תוצאות}} החל ממספר <strong>$2</strong>:"
 }

--- a/i18n/hi.json
+++ b/i18n/hi.json
@@ -268,5 +268,6 @@
 	"smw-section-expand": "अंश का विस्तार करें",
 	"smw-section-collapse": "अंश को संक्षिप्त करें",
 	"smw-types-title": "प्रकार: $1",
-	"smw-listingcontinuesabbrev": "जारी"
+	"smw-listingcontinuesabbrev": "जारी",
+	"smw-showingresults": "नीचे क्रमांक '''$2''' से प्रारंभ कर के अधिकतम '''$1''' परिणाम {{PLURAL:$1|दिखाया गया है|दिखाए गए हैं}}।"
 }

--- a/i18n/hif-latn.json
+++ b/i18n/hif-latn.json
@@ -3,5 +3,6 @@
 		"authors": []
 	},
 	"smw-livepreview-loading": "load karaa jaae hae...",
-	"smw-listingcontinuesabbrev": "aur"
+	"smw-listingcontinuesabbrev": "aur",
+	"smw-showingresults": "Niche dekhae hai {{PLURAL:$1|'''1''' result|'''$1''' results}} #'''$2''' se suruu hoe ke."
 }

--- a/i18n/hil.json
+++ b/i18n/hil.json
@@ -7,5 +7,6 @@
 	},
 	"browse": "Maglagula sa wiki",
 	"smw_browse_go": "Lakat",
-	"smw-listingcontinuesabbrev": "pdyn"
+	"smw-listingcontinuesabbrev": "pdyn",
+	"smw-showingresults": "Ginapakita sa dalom pakadto sa {{PLURAL:$1|'''1''' ka resulta|'''$1''' ka mga resulta}} umpisa ang #'''$2'''."
 }

--- a/i18n/hr.json
+++ b/i18n/hr.json
@@ -229,5 +229,6 @@
 	"smw-type-primitive": "Temeljno",
 	"smw-install-incomplete-intro-note": "Ova će se poruka prestati prikazivati nakon što svi značajni zadaci budu riješeni.",
 	"smw-pendingtasks-setup-tasks": "Zadaci",
-	"smw-listingcontinuesabbrev": "nast."
+	"smw-listingcontinuesabbrev": "nast.",
+	"smw-showingresults": "Dolje {{PLURAL:$1|je prikazan '''$1''' rezultat|su prikazana '''$1''' rezultata|je prikazano '''$1''' rezultata}}, počevši od '''$2'''."
 }

--- a/i18n/hrx.json
+++ b/i18n/hrx.json
@@ -6,5 +6,6 @@
 	},
 	"browse": "Semantisches Browse",
 	"smw-livepreview-loading": "Am loode …",
-	"smw-listingcontinuesabbrev": "(Fortsetzung)"
+	"smw-listingcontinuesabbrev": "(Fortsetzung)",
+	"smw-showingresults": "Hier {{PLURAL:$1|ist '''1''' Ergebnis|sind '''$1''' Ergebnisse}}, beginnend mit Nummer '''$2.'''"
 }

--- a/i18n/hsb.json
+++ b/i18n/hsb.json
@@ -270,5 +270,6 @@
 	"smw-sp-admin-settings-button": "Lisćinu nastajenjow wutworić",
 	"smw-admin-objectid": "ID:",
 	"smw-livepreview-loading": "Čita so…",
-	"smw-listingcontinuesabbrev": "(pokročowanje)"
+	"smw-listingcontinuesabbrev": "(pokročowanje)",
+	"smw-showingresults": "Deleka so hač {{PLURAL:$1|'''1''' wuslědk pokazuje|'''$1''' wuslědkaj pokazujetej|'''$1''' wuslědki pokazuja|'''$1''' wuslědkow pokazuje}}, započinajo z #'''$2'''."
 }

--- a/i18n/ht.json
+++ b/i18n/ht.json
@@ -26,5 +26,6 @@
 	"smw_infinite": "Nimewo ki gwo tankou \"$1\" pa sipòte.",
 	"browse": "Pran yon gade nan wiki sa a",
 	"smw_unknowntype": "Tip pwopriyete sa a « $1 » pa valab",
-	"smw-listingcontinuesabbrev": "(kontinye)"
+	"smw-listingcontinuesabbrev": "(kontinye)",
+	"smw-showingresults": "Men jiska {{PLURAL:$1|<strong>$1</strong> rezilta}}, premye se #<strong>$2</strong>."
 }

--- a/i18n/hu.json
+++ b/i18n/hu.json
@@ -241,5 +241,6 @@
 	"smw-schema-error-violation": "[\"$1\", \"$2\"]",
 	"smw-schema-error-json": "JSON hiba: \"$1\"",
 	"smw-schema-usage": "Használat",
-	"smw-listingcontinuesabbrev": "folyt."
+	"smw-listingcontinuesabbrev": "folyt.",
+	"smw-showingresults": "Lent '''{{PLURAL:$1|egy|$1}}''' találat látható, az eleje '''$2'''."
 }

--- a/i18n/hy.json
+++ b/i18n/hy.json
@@ -42,5 +42,6 @@
 	"smw-format-datatable-last": "Վերջին",
 	"smw-help": "Օգնություն",
 	"smw-loading": "Բեռնում ...",
-	"smw-listingcontinuesabbrev": "շարունակելի"
+	"smw-listingcontinuesabbrev": "շարունակելի",
+	"smw-showingresults": "Ստորև բերված է մինչև {{PLURAL:$1|'''1''' արդյունք|'''$1''' արդյունք}}՝ սկսած №&nbsp;<strong>$2</strong>-ից։"
 }

--- a/i18n/ia.json
+++ b/i18n/ia.json
@@ -316,5 +316,6 @@
 	"smw-es-replication-error-suggestions-no-connection": "Es suggerite contactar le administrator del wiki pro signalar le problema \"nulle connexion\".",
 	"smw-datavalue-constraint-schema-category-invalid-type": "Le schema annotate \"$1\" es invalide pro un categoria; illo require un typo \"$2\".",
 	"smw-datavalue-constraint-schema-property-invalid-type": "Le schema annotate \"$1\" es invalide pro un proprietate; illo require un typo \"$2\".",
-	"smw-listingcontinuesabbrev": "cont."
+	"smw-listingcontinuesabbrev": "cont.",
+	"smw-showingresults": "Infra se monstra non plus de {{PLURAL:$1|'''1''' resultato|'''$1''' resultatos}} a partir del numero '''$2'''."
 }

--- a/i18n/id.json
+++ b/i18n/id.json
@@ -256,5 +256,6 @@
 	"smw_conceptarticlecount": "Menampilkan $1 {{PLURAL:$1|halaman}} berikut.",
 	"smw-livepreview-loading": "Mengunggah...",
 	"smw-datavalue-number-nullnotallowed": "\"$1\" kembali dengan sebuah \"NULL\" yang tidak mengizinkan sebagai nomor.",
-	"smw-listingcontinuesabbrev": "samb."
+	"smw-listingcontinuesabbrev": "samb.",
+	"smw-showingresults": "Di bawah ini ditampilkan hingga {{PLURAL:$1|<strong>1</strong> hasil|<strong>$1</strong> hasil}}, dimulai dari #<strong>$2</strong>."
 }

--- a/i18n/ilo.json
+++ b/i18n/ilo.json
@@ -87,5 +87,6 @@
 	"smw-livepreview-loading": "Maikarkarga…",
 	"smw-sp-searchbyproperty-resultlist-header": "Listaan dagiti resulta",
 	"smw-search-syntax": "Sintaksis",
-	"smw-listingcontinuesabbrev": "tuloy."
+	"smw-listingcontinuesabbrev": "tuloy.",
+	"smw-showingresults": "Maiparang dita baba agingga {{PLURAL:$1|iti <strong>1</strong> a nagbanagan|dagiti <strong>$1</strong> a nagbanagan}} a mangrugi iti #<strong>$2</strong>."
 }

--- a/i18n/io.json
+++ b/i18n/io.json
@@ -47,5 +47,6 @@
 	"smw-preparing": "Kreado ...",
 	"smw-expand": "Montrar la listo",
 	"smw-copy": "Kopiar",
-	"smw-listingcontinuesabbrev": "seq."
+	"smw-listingcontinuesabbrev": "seq.",
+	"smw-showingresults": "Montrante infre {{PLURAL:$1|'''1''' rezulto|'''$1''' rezulti}}, qui komencas kun numero #'''$2'''."
 }

--- a/i18n/is.json
+++ b/i18n/is.json
@@ -23,5 +23,6 @@
 	"smw-livepreview-loading": "Framkalla…",
 	"log-name-smw": "Aðgerðaskrá yfir málskipan MediaWiki",
 	"smw-type-tab-types": "Tegundir",
-	"smw-listingcontinuesabbrev": "frh."
+	"smw-listingcontinuesabbrev": "frh.",
+	"smw-showingresults": "Sýni <strong>$1</strong> {{PLURAL:$1|niðurstöðu|niðurstöður}} frá og með #<strong>$2</strong>."
 }

--- a/i18n/it.json
+++ b/i18n/it.json
@@ -493,5 +493,6 @@
 	"smw-ask-tab-code": "Codice",
 	"smw-legend": "Legenda",
 	"smw-entity-examiner-associated-revision-mismatch": "Versione",
-	"smw-listingcontinuesabbrev": "cont."
+	"smw-listingcontinuesabbrev": "cont.",
+	"smw-showingresults": "Di seguito {{PLURAL:$1|viene presentato al massimo '''1''' risultato|vengono presentati al massimo '''$1''' risultati}} a partire dal numero '''$2'''."
 }

--- a/i18n/ja.json
+++ b/i18n/ja.json
@@ -580,5 +580,6 @@
 	"smw-report": "レポート",
 	"smw-legend": "凡例",
 	"smw-indicator-revision-mismatch-error": "[https://www.semantic-mediawiki.org/wiki/Help:Associated_revision/Examiner 関連する改版]検査により、このエントリに対して MediaWiki が引用する改版と Semantic MediaWiki に紐付けされたものに不一致が見つかりました。",
-	"smw-listingcontinuesabbrev": "の続き"
+	"smw-listingcontinuesabbrev": "の続き",
+	"smw-showingresults": "<strong>$2</strong> 件目以降の最大 {{PLURAL:$1|<strong>$1</strong> 件の結果}}を表示しています。"
 }

--- a/i18n/jv.json
+++ b/i18n/jv.json
@@ -98,5 +98,6 @@
 	"smw-type-tab-properties": "Properti",
 	"smw-type-tab-types": "Jinis",
 	"smw-type-tab-errors": "Masalah",
-	"smw-listingcontinuesabbrev": "samb."
+	"smw-listingcontinuesabbrev": "samb.",
+	"smw-showingresults": "Ing ngisor iki dituduhaké {{PLURAL:$1|'''1''' kasil|'''$1''' kasil}}, wiwitané saking #<strong>$2</strong>."
 }

--- a/i18n/ka.json
+++ b/i18n/ka.json
@@ -89,5 +89,6 @@
 	"smw-ui-tooltip-title-legend": "ლეგენდა",
 	"smw_unknowntype": "ამ თვისების ტიპი არასწორია",
 	"smw-livepreview-loading": "იტვირთება…",
-	"smw-listingcontinuesabbrev": "გაგრძ."
+	"smw-listingcontinuesabbrev": "გაგრძ.",
+	"smw-showingresults": "ქვემოთ იხილეთ <b>$1</b>-მდე შედეგი დაწყებული #<b>$2</b>-იდან."
 }

--- a/i18n/kab.json
+++ b/i18n/kab.json
@@ -61,5 +61,6 @@
 	"smw-livepreview-loading": "Asali…",
 	"protect-level-smw-pageedit": "Sirek iseqdacen yesɛan azref n usnifel n isebtar (Semantic MediaWiki)",
 	"smw-postproc-queryref": "Asebter yettwacreḍ d akken yessefk ad ittusmiren imi yesra asesfer uḍfiṛ.",
-	"smw-listingcontinuesabbrev": "asartu"
+	"smw-listingcontinuesabbrev": "asartu",
+	"smw-showingresults": "Tamuli n {{PLURAL:$1|'''Yiwen''' wegmud|'''$1''' n yigmad}} seg  #'''$2'''."
 }

--- a/i18n/kk-arab.json
+++ b/i18n/kk-arab.json
@@ -3,5 +3,6 @@
 		"authors": []
 	},
 	"smw-livepreview-loading": "جۇكتەۋدە…",
-	"smw-listingcontinuesabbrev": "(جالع.)"
+	"smw-listingcontinuesabbrev": "(جالع.)",
+	"smw-showingresults": "تومەندە ٴنومىر '''$2''' ورنىنان باستاپ بارىنشا '''$1''' ناتىيجە كورسەتىلەدى."
 }

--- a/i18n/kk-cyrl.json
+++ b/i18n/kk-cyrl.json
@@ -9,5 +9,6 @@
 	"smw_purge": "Жаңарту",
 	"browse": "Уикиді шолу",
 	"smw-livepreview-loading": "Жүктеуде…",
-	"smw-listingcontinuesabbrev": "(жалғ.)"
+	"smw-listingcontinuesabbrev": "(жалғ.)",
+	"smw-showingresults": "Төменде #<strong>$2</strong> нәтижеден бастап {{PLURAL:$1|<strong>1</strong> нәтиже|<strong>$1</strong> нәтиже}}ге дейін нәтижелер көрсетілуде."
 }

--- a/i18n/kk-latn.json
+++ b/i18n/kk-latn.json
@@ -3,5 +3,6 @@
 		"authors": []
 	},
 	"smw-livepreview-loading": "Jüktewde…",
-	"smw-listingcontinuesabbrev": "(jalğ.)"
+	"smw-listingcontinuesabbrev": "(jalğ.)",
+	"smw-showingresults": "Tömende nömir '''$2''' ornınan bastap barınşa '''$1''' nätïje körsetiledi."
 }

--- a/i18n/km.json
+++ b/i18n/km.json
@@ -82,5 +82,6 @@
 	"smw-createproperty-allowedvals": "តម្លៃ​ចំនួន$1 ​សម្រាប់​លក្ខណៈសម្បត្តិ​នេះគឺ​៖",
 	"smw-livepreview-loading": "កំពុងផ្ទុក…",
 	"smw-search-show": "បង្ហាញ",
-	"smw-listingcontinuesabbrev": "បន្ត"
+	"smw-listingcontinuesabbrev": "បន្ត",
+	"smw-showingresults": "ខាងក្រោមកំពុងបង្ហាញរហូតដល់ {{PLURAL:$1|'''១''' លទ្ឋផល|'''$1''' លទ្ឋផល}} ចាប់ផ្ដើមពីលេខ #'''$2'''។"
 }

--- a/i18n/kn.json
+++ b/i18n/kn.json
@@ -14,5 +14,6 @@
 	"smw_browse_go": "ಹೋಗು",
 	"smw-livepreview-loading": "ತುಂಬಿಸಲಾಗುತ್ತಿದೆ....",
 	"smw-processing": "ಸಂಸ್ಕರಿಸಲಾಗುತ್ತಿದೆ...",
-	"smw-listingcontinuesabbrev": "ಮುಂದು."
+	"smw-listingcontinuesabbrev": "ಮುಂದು.",
+	"smw-showingresults": "ಕೆಳಗೆ #<strong>$2</strong> ಇಂದ ಶುರುವಾದ {{PLURAL:$1|<strong>೧</strong> ಫಲಿತಾಂಶದ|<strong>$1</strong> ಫಲಿತಾಂಶಗಳ}}ವರೆಗೂ ತೋರಿಸಲಾಗುತ್ತಿದೆ."
 }

--- a/i18n/ko.json
+++ b/i18n/ko.json
@@ -664,5 +664,6 @@
 	"smw-report": "보고서",
 	"smw-legend": "범례",
 	"smw-entity-examiner-associated-revision-mismatch": "판",
-	"smw-listingcontinuesabbrev": "(계속)"
+	"smw-listingcontinuesabbrev": "(계속)",
+	"smw-showingresults": "'''$2'''번 부터의 {{PLURAL:$1|결과 '''1'''개|결과 '''$1'''개}}입니다."
 }

--- a/i18n/krc.json
+++ b/i18n/krc.json
@@ -11,5 +11,6 @@
 	"smw-prefs-general-options-show-entity-issue-panel": "Магъананы проблемасыны панелин кёргюзт",
 	"smw-prefs-help-general-options-show-entity-issue-panel": "Джандырылгъан эсе, хар бетде бютеулюкню тинтиуюн башлайды эмда [https://www.semantic-mediawiki.org/wiki/Help:Entity_issue_panel магананы проблемасыны панелин ачады].",
 	"smw-livepreview-loading": "Джюклениу...",
-	"smw-listingcontinuesabbrev": "(баргъаны)"
+	"smw-listingcontinuesabbrev": "(баргъаны)",
+	"smw-showingresults": "Тюбюрек №&nbsp;<strong>$2</strong> башлаб <strong>$1</strong> {{PLURAL:$1|1=эсеб|эсебле}} {{PLURAL:$1|1=кёргюзюлгенди|кёргюзюлгендиле}}."
 }

--- a/i18n/ksh.json
+++ b/i18n/ksh.json
@@ -231,5 +231,6 @@
 	"smw-limitreport-intext-parsertime-value": "{{PLURAL:$1|eijn Sekond|$1 Sekonde|keijn Sekond}}",
 	"smw-limitreport-pagepurge-storeupdatetime": "[SMW] De Duur för et Ändere fum Zwescheschpeijscher beim Fottschmiiße",
 	"smw-limitreport-pagepurge-storeupdatetime-value": "{{PLURAL:$1|eijn Sekond|$1 Sekond|keijn Sekond}}",
-	"smw-listingcontinuesabbrev": "… (wigger)"
+	"smw-listingcontinuesabbrev": "… (wigger)",
+	"smw-showingresults": "Onge {{PLURAL:$1|weed <strong>eine</strong>|wääde bes <strong>$1</strong>|weed <strong>keine</strong>}} vun de jefonge Endrähsch jezeisch, vun de Nommer <strong>$2</strong> av."
 }

--- a/i18n/ku-latn.json
+++ b/i18n/ku-latn.json
@@ -42,5 +42,6 @@
 	"smw-search-syntax": "Sentaks",
 	"smw-types-list": "Lîsteya cureyên daneyan",
 	"smw-format-datatable-next": "Pêşve",
-	"smw-listingcontinuesabbrev": "dewam"
+	"smw-listingcontinuesabbrev": "dewam",
+	"smw-showingresults": "{{PLURAL:$1|Encamek|'''$1''' encam}}, bi #'''$2''' dest pê dike."
 }

--- a/i18n/la.json
+++ b/i18n/la.json
@@ -6,5 +6,6 @@
 	},
 	"browse": "Percurrere",
 	"smw-livepreview-loading": "Depromens…",
-	"smw-listingcontinuesabbrev": "cont."
+	"smw-listingcontinuesabbrev": "cont.",
+	"smw-showingresults": "Subter monstrans {{PLURAL:$1|'''1''' eventu|'''$1''' eventibus}} tenus incipiens ab #'''$2'''."
 }

--- a/i18n/lb.json
+++ b/i18n/lb.json
@@ -372,5 +372,6 @@
 	"smw-entity-examiner-associated-revision-mismatch": "Versioun",
 	"smw-entity-examiner-deferred-fake": "Fälschung",
 	"smw-indicator-revision-mismatch": "Revisioun",
-	"smw-listingcontinuesabbrev": "(Fortsetzung)"
+	"smw-listingcontinuesabbrev": "(Fortsetzung)",
+	"smw-showingresults": "Hei gesitt der  {{PLURAL:$1| '''1''' Resultat|'''$1''' Resultater}}, ugefaange mat #'''$2'''."
 }

--- a/i18n/li.json
+++ b/i18n/li.json
@@ -44,5 +44,6 @@
 	"smw_purge": "Vernuuj",
 	"browse": "Blajer door de wiki",
 	"smw-livepreview-loading": "Laje…",
-	"smw-listingcontinuesabbrev": "wiejer"
+	"smw-listingcontinuesabbrev": "wiejer",
+	"smw-showingresults": "Hieonger staon de <b>$1</b> {{PLURAL:$1|resultaat|resultaat}}, vanaaf #<b>$2</b>."
 }

--- a/i18n/lij.json
+++ b/i18n/lij.json
@@ -7,5 +7,6 @@
 	},
 	"browse": "Esplóra o scîto",
 	"smw-livepreview-loading": "Camallando…",
-	"smw-listingcontinuesabbrev": "cont."
+	"smw-listingcontinuesabbrev": "cont.",
+	"smw-showingresults": "Chì appreuvo se mostra a-o mascimo {{PLURAL:$1|'''1''' risultou|'''$1''' risultæ}} a partî da-o nummero '''$2'''."
 }

--- a/i18n/lki.json
+++ b/i18n/lki.json
@@ -12,5 +12,6 @@
 	"smw-ask-format-selection-help": "برای شرح مفصل، لطفاً صفحه راهنما $1 را مشاهده کنید.",
 	"browse": "مرور ویکی",
 	"smw-ui-tooltip-title-note": "ویرنۆیسة-یادداشت",
-	"smw-listingcontinuesabbrev": "(ادامه)"
+	"smw-listingcontinuesabbrev": "(ادامه)",
+	"smw-showingresults": "نمایش حداکثر {{PLURAL:$1|'''۱''' نتیجه|'''$1''' نتیجه}} در پایین، آغاز از شماره '''$2'''."
 }

--- a/i18n/lrc.json
+++ b/i18n/lrc.json
@@ -6,5 +6,6 @@
 		]
 	},
 	"browse": "دوئارتٱ نری سی ڤیکی",
-	"smw-listingcontinuesabbrev": "دۏمبالٱ"
+	"smw-listingcontinuesabbrev": "دۏمبالٱ",
+	"smw-showingresults": "نمایش بؽشترونٱ {{PLURAL:$1|'''۱''' نتیجٱ|'''$1''' نتیجٱ}} د هار، شرۊ د شمارٱ'''$2'''."
 }

--- a/i18n/lt.json
+++ b/i18n/lt.json
@@ -198,5 +198,6 @@
 	"smw-help": "Pagalba",
 	"smw-es-replication-error-no-connection": "Replikacijos stebėjimas negali atlikti jokių patikrinimų, nes negali sukurti ryšio su Elasticsearch klusteriu.",
 	"smw-es-replication-error-suggestions-no-connection": "Siūloma kreiptis į „wiki“ administratorių ir pranešti apie „be ryšio“ problemą.",
-	"smw-listingcontinuesabbrev": "tęsti"
+	"smw-listingcontinuesabbrev": "tęsti",
+	"smw-showingresults": "Žemiau rodoma iki '''$1''' {{PLURAL:$1|rezultato|rezultatų|rezultatų}} pradedant #'''$2'''."
 }

--- a/i18n/lv.json
+++ b/i18n/lv.json
@@ -56,5 +56,6 @@
 	"smw-schema-summary-title": "Kopsavilkums",
 	"smw-schema-tag": "{{PLURAL:$1|Iezīmes|Iezīme|Iezīmes}}",
 	"smw-indicator-revision-mismatch": "Versija",
-	"smw-listingcontinuesabbrev": " (turpinājums)"
+	"smw-listingcontinuesabbrev": " (turpinājums)",
+	"smw-showingresults": "Šobrīd ir {{PLURAL:$1|redzamas|redzama|redzamas}} '''$1''' {{PLURAL:$1|lapas|lapa|lapas}}, sākot ar #'''$2'''."
 }

--- a/i18n/lzh.json
+++ b/i18n/lzh.json
@@ -6,5 +6,6 @@
 	},
 	"browse": "覽共筆",
 	"smw-livepreview-loading": "遺藏…",
-	"smw-listingcontinuesabbrev": "續"
+	"smw-listingcontinuesabbrev": "續",
+	"smw-showingresults": "見'''$1'''尋，自'''$2'''始："
 }

--- a/i18n/mai.json
+++ b/i18n/mai.json
@@ -112,5 +112,6 @@
 	"smw-search-show": "देखाबी",
 	"smw-search-hide": "नुकाबी",
 	"log-name-smw": "सिमेंटिक मीडियाविकि",
-	"smw-listingcontinuesabbrev": "शेष आगाँ।"
+	"smw-listingcontinuesabbrev": "शेष आगाँ।",
+	"smw-showingresults": "नीचाँ एतऽ धरि {{PLURAL:$1|'''1''' परिणाम|'''$1''' परिणाम सभ}}  #'''$2''' सँ प्रारम्भ भऽ कऽ।"
 }

--- a/i18n/mdf.json
+++ b/i18n/mdf.json
@@ -3,5 +3,6 @@
 		"authors": []
 	},
 	"smw-livepreview-loading": "Аноклакшни…",
-	"smw-listingcontinuesabbrev": "полатксоц"
+	"smw-listingcontinuesabbrev": "полатксоц",
+	"smw-showingresults": "Ала няфтеви {{PLURAL:$1|мувсь '''1'''|мувсть '''$1'''}} '''$2'''-ста ушедомс."
 }

--- a/i18n/mg.json
+++ b/i18n/mg.json
@@ -47,5 +47,6 @@
 	"smw-admin-statistics-job-title": "Statistikan'ny asa",
 	"smw_smwadmin_return": "Hiverina any amin'ny $1",
 	"smw-livepreview-loading": "Am-pakàna…",
-	"smw-listingcontinuesabbrev": " manaraka."
+	"smw-listingcontinuesabbrev": " manaraka.",
+	"smw-showingresults": "Omeo ny valiny{{PLURAL:$1||}} miisa hatramin'ny <b>$1</b> manomboka ny #<b>$2</b>."
 }

--- a/i18n/min.json
+++ b/i18n/min.json
@@ -11,5 +11,6 @@
 	"smw_purge": "Pabaharui",
 	"browse": "Jalajahi wiki",
 	"smw_browse_go": "Tuju",
-	"smw-listingcontinuesabbrev": "samb."
+	"smw-listingcontinuesabbrev": "samb.",
+	"smw-showingresults": "Di bawah ko dikaluaan sampai {{PLURAL:$1|'''$1''' hasil}}, dimulai dari #'''$2'''."
 }

--- a/i18n/mk.json
+++ b/i18n/mk.json
@@ -549,5 +549,6 @@
 	"smw-ask-tab-code": "Код",
 	"smw-report": "Извештај",
 	"smw-legend": "Легенда",
-	"smw-listingcontinuesabbrev": "продолжува"
+	"smw-listingcontinuesabbrev": "продолжува",
+	"smw-showingresults": "Подолу {{PLURAL:$1|е прикажана <strong>1</strong> ставка|се прикажани <strong>$1</strong> ставки}} почнувајќи од бр. <strong>$2</strong>."
 }

--- a/i18n/ml.json
+++ b/i18n/ml.json
@@ -36,5 +36,6 @@
 	"smw-livepreview-loading": "ശേഖരിക്കുന്നു...",
 	"smw-data-lookup": "വിവരം ലഭ്യമാക്കുന്നു ...",
 	"smw-no-data-available": "വിവരങ്ങളൊന്നും ലഭ്യമല്ല.",
-	"smw-listingcontinuesabbrev": "തുടർച്ച."
+	"smw-listingcontinuesabbrev": "തുടർച്ച.",
+	"smw-showingresults": "'''$2''' മുതലുള്ള {{PLURAL:$1|'''ഒരു''' ഫലം|'''$1''' ഫലങ്ങൾ}} താഴെ പ്രദർശിപ്പിക്കുന്നു."
 }

--- a/i18n/mn.json
+++ b/i18n/mn.json
@@ -13,5 +13,6 @@
 	"smw-livepreview-loading": "Уншиж байна...",
 	"smw-limitreport-intext-parsertime-value": "$1 секунд",
 	"smw-limitreport-pagepurge-storeupdatetime-value": "$1 секунд",
-	"smw-listingcontinuesabbrev": "-н үргэлжлэл"
+	"smw-listingcontinuesabbrev": "-н үргэлжлэл",
+	"smw-showingresults": "Доор #'''$2'''-с эхлэсэн '''$1''' илэрцийг үзүүлж байна."
 }

--- a/i18n/mr.json
+++ b/i18n/mr.json
@@ -130,5 +130,6 @@
 	"smw-property-preferred-title-format": "$1 ($2)",
 	"smw-ask-title-keyword-type": "मुख्यशब्दचा शोध",
 	"smw-ask-message-keyword-type": "ह्या शोधातून <code><nowiki>$1</nowiki></code> ही अट जुळली आहे",
-	"smw-listingcontinuesabbrev": "पुढे चला"
+	"smw-listingcontinuesabbrev": "पुढे चला",
+	"smw-showingresults": "#'''$2'''पासून {{PLURAL:$1|'''1'''पर्यंतचा निकाल|'''$1'''पर्यंतचे निकाल}} खाली दाखवले आहे."
 }

--- a/i18n/ms.json
+++ b/i18n/ms.json
@@ -52,5 +52,6 @@
 	"smwadmin": "Fungsi penyelia untuk Semantic MediaWiki",
 	"smw-concept-cache-text": "Konsep ini mempunyai sejumlah $1 laman, dan kali terakhir dikemaskinikan pada $3, $2.",
 	"smw-livepreview-loading": "Memuatkan...",
-	"smw-listingcontinuesabbrev": "samb."
+	"smw-listingcontinuesabbrev": "samb.",
+	"smw-showingresults": "Yang berikut ialah '''$1''' hasil bermula daripada yang {{PLURAL:$2|pertama|ke-'''$2'''}}."
 }

--- a/i18n/mt.json
+++ b/i18n/mt.json
@@ -17,5 +17,6 @@
 	"smw-livepreview-loading": "Tniżżil fil-progress…",
 	"smw-sp-searchbyproperty-resultlist-header": "Lista ta' riżultati",
 	"logeventslist-smw-log": "Semantic MediaWiki",
-	"smw-listingcontinuesabbrev": "kompli"
+	"smw-listingcontinuesabbrev": "kompli",
+	"smw-showingresults": "Hawn taħt ġie inkluż massimu ta' {{PLURAL:$1|riżultat '''1''' li jibda|'''$1''' riżultat li jibdew}} bin-numru '''$2'''."
 }

--- a/i18n/my.json
+++ b/i18n/my.json
@@ -125,5 +125,6 @@
 	"smw-es-replication-error-divergent-date-short": "အောက်ပါ ရက်စွဲအချက်အလက်များကို နှိုင်းယှဉ်ခြင်းအတွက် အသုံးပြုပါသည်:",
 	"smw-report": "အစီရင်ခံရန်",
 	"smw-legend": "အညွှန်း",
-	"smw-listingcontinuesabbrev": "ပံ့ပိုး"
+	"smw-listingcontinuesabbrev": "ပံ့ပိုး",
+	"smw-showingresults": "№<strong>$2</strong> နှင့်စသော ရလဒ် {{PLURAL:$1|<strong>1</strong> ခု|<strong>$1</strong> ခု}}ထိကို အောက်တွင် ပြထားသည်။"
 }

--- a/i18n/nan.json
+++ b/i18n/nan.json
@@ -9,5 +9,6 @@
 	"browse": "Khoàⁿ wiki",
 	"smw-constraint-violation-class-mandatory-properties-constraint": "<code>mandatory_properties</code>hān-chè hō͘ hun-phuè kàu lūi-pia̍t\"[[:Category:$1|$1]]\", pīng-chhiánn su-iàu í-hā kiông-tsè sio̍k-sìng: $2",
 	"apihelp-smwtask-param-task": "Tēng-gī jīm-bū luī-hêng",
-	"smw-listingcontinuesabbrev": "(chiap-sòa thâu-chêng)"
+	"smw-listingcontinuesabbrev": "(chiap-sòa thâu-chêng)",
+	"smw-showingresults": "Ē-kha tùi #<b>$2</b> khai-sí hián-sī <b>$1</b> hāng kiat-kó."
 }

--- a/i18n/nap.json
+++ b/i18n/nap.json
@@ -7,5 +7,6 @@
 	"smw-paramdesc-table-transpose": "Fà vedé 'e cap' 'e tabella n verticale e li risultate n orizzontale",
 	"browse": "Ascìa wiki",
 	"smw_smwadmin_datarefreshstopconfirm": "Si, so' {{GENDER:$1|sicuro|sicura}}.",
-	"smw-listingcontinuesabbrev": "cont."
+	"smw-listingcontinuesabbrev": "cont.",
+	"smw-showingresults": "Ccà abbascio {{PLURAL:$1|s'apprisentano 'o massimo '''1''' risultato|veneno apprisentate massimo '''$1''' risultate}} aropp' 'o nummero '''$2'''."
 }

--- a/i18n/nb.json
+++ b/i18n/nb.json
@@ -1103,5 +1103,6 @@
 	"smw-indicator-revision-mismatch": "Revisjon",
 	"smw-indicator-revision-mismatch-error": "Sjekken for [https://www.semantic-mediawiki.org/wiki/Help:Associated_revision/Examiner assosiert revisjon] fant manglende samsvar mellom revisjonen som refereres til i MediaWiki og den som er assosiert med Semantic MediaWiki for denne entiteten.",
 	"smw-indicator-revision-mismatch-comment": "Manglende samsvar indikerer vanligvis at en prosess forstyrret lagringsoperasjonen i Semantic MediaWiki. Det anbefales å gå gjennom tjenerloggene og se etter unntak eller andre feil.",
-	"smw-listingcontinuesabbrev": "forts."
+	"smw-listingcontinuesabbrev": "forts.",
+	"smw-showingresults": "Nedenfor vises opptil {{PLURAL:$1|'''ett''' resultat|'''$1''' resultater}} fra og med nummer <b>$2</b>."
 }

--- a/i18n/nds-nl.json
+++ b/i18n/nds-nl.json
@@ -11,5 +11,6 @@
 	"smw-ui-tooltip-title-reference": "Referensy",
 	"smw-livepreview-loading": "An t laojen…",
 	"smw-expand": "Uutklappen",
-	"smw-listingcontinuesabbrev": "(vervolg)"
+	"smw-listingcontinuesabbrev": "(vervolg)",
+	"smw-showingresults": "Hieronder {{PLURAL:$1|steet '''1''' resultaot|staon '''$1''' resultaoten}}  <b>$1</b> vanaof nummer <b>$2</b>."
 }

--- a/i18n/nds.json
+++ b/i18n/nds.json
@@ -25,5 +25,6 @@
 	"smw-sp-searchbyproperty-resultlist-header": "List vun Resultaten",
 	"smw-datavalue-reference-outputformat": "$1: $2",
 	"smw-help": "Hülp",
-	"smw-listingcontinuesabbrev": "wieder"
+	"smw-listingcontinuesabbrev": "wieder",
+	"smw-showingresults": "Hier {{PLURAL:$1|is een Resultat|sünd '''$1''' Resultaten}}, anfungen mit #'''$2'''."
 }

--- a/i18n/ne.json
+++ b/i18n/ne.json
@@ -56,5 +56,6 @@
 	"smw-entity-examiner-deferred-fake": "नक्कली",
 	"smw-indicator-constraint-violation": "{{PLURAL:$1|बाधा|बाधाहरू}}",
 	"smw-indicator-revision-mismatch": "पुनरावलोकन",
-	"smw-listingcontinuesabbrev": "निरन्तरता..."
+	"smw-listingcontinuesabbrev": "निरन्तरता...",
+	"smw-showingresults": "देखाउँदै  {{PLURAL:$1|'''१''' नतिजा|'''$1''' नतिजाहरू }} , #'''$2''' बाट सुरुहुने ।"
 }

--- a/i18n/nl.json
+++ b/i18n/nl.json
@@ -554,5 +554,6 @@
 	"smw-es-replication-error-divergent-date-detail": "Wijzigingsdatum waarnaar wordt verwezen:\n*Elasticsearch: $1 \n*Database: $2",
 	"smw-report": "Verslag",
 	"smw-entity-examiner-associated-revision-mismatch": "Versie",
-	"smw-listingcontinuesabbrev": "meer"
+	"smw-listingcontinuesabbrev": "meer",
+	"smw-showingresults": "Hieronder {{PLURAL:$1|staat '''1''' resultaat|staan '''$1''' resultaten}} vanaf #'''$2'''."
 }

--- a/i18n/nn.json
+++ b/i18n/nn.json
@@ -173,5 +173,6 @@
 	"smw_conceptarticlecount": "Syner nedanfor {{PLURAL:$1|éi side|$1 sider}}",
 	"smw-livepreview-loading": "Lastar inn&nbsp;…",
 	"smw-type-tab-properties": "Eigenskapar",
-	"smw-listingcontinuesabbrev": "vidare"
+	"smw-listingcontinuesabbrev": "vidare",
+	"smw-showingresults": "Nedanfor er opp til {{PLURAL:$1|<strong>eitt</strong>|<strong>$1</strong>}} resultat som byrjar med nummer <strong>$2</strong> vist{{PLURAL:$1||e}}."
 }

--- a/i18n/oc.json
+++ b/i18n/oc.json
@@ -227,5 +227,6 @@
 	"smw-parser-invalid-json-format": "L’analisador JSON a tornat un « $1 ».",
 	"smw-property-preferred-title-format": "$1 ($2)",
 	"smw-no-data-available": "Cap de donada pas disponibla.",
-	"smw-listingcontinuesabbrev": "(seguida)"
+	"smw-listingcontinuesabbrev": "(seguida)",
+	"smw-showingresults": "Afichatge de <b>$1</b> resultat{{PLURAL:$1||s}} a partir del n°<b>$2</b>."
 }

--- a/i18n/or.json
+++ b/i18n/or.json
@@ -63,5 +63,6 @@
 	"smw_ask_hide_embed": "ଅନ୍ତଃସ୍ଥାପିତ ସାଙ୍କେତିକ ଚିହ୍ନ ଲୁଚାନ୍ତୁ",
 	"browse": "ଉଇକି ଦେଖିବେ",
 	"smw-livepreview-loading": "ଖୋଲୁଅଛି...",
-	"smw-listingcontinuesabbrev": "ଆହୁରି ଅଛି.."
+	"smw-listingcontinuesabbrev": "ଆହୁରି ଅଛି..",
+	"smw-showingresults": "ତଳେ {{PLURAL:$1|'''ଗୋଟିଏ'''  ଫଳାଫଳ|'''$1'''ଟି ଫଳାଫଳ}} ଦେଖାଉଛୁ ଯାହା #'''$2'''ରେ ଆରମ୍ଭ ହୋଇଅଛି ।"
 }

--- a/i18n/pa.json
+++ b/i18n/pa.json
@@ -9,5 +9,6 @@
 	"smw-livepreview-loading": "ਲੋਡ ਕੀਤਾ ਜਾ ਰਿਹਾ ਹੈ...",
 	"smw-sp-searchbyproperty-resultlist-header": "ਨਤੀਜਿਆਂ ਦੀ ਸੂਚੀ",
 	"smw-copy": "ਰੀਸ ਕਰੋ",
-	"smw-listingcontinuesabbrev": "ਜਾਰੀ"
+	"smw-listingcontinuesabbrev": "ਜਾਰੀ",
+	"smw-showingresults": "ਹੇਠਾਂ #'''$2''' ਨਾਲ਼ ਸ਼ੁਰੂ ਹੋਣ ਵਾਲ਼ੇ {{PLURAL:\n$1|'''1''' ਨਤੀਜਾ|'''$1''' ਤੱਕ ਨਤੀਜੇ}} ਵਖਾਓ।"
 }

--- a/i18n/pam.json
+++ b/i18n/pam.json
@@ -3,5 +3,6 @@
 		"authors": []
 	},
 	"smw-livepreview-loading": "Máglulan…",
-	"smw-listingcontinuesabbrev": "katuglung."
+	"smw-listingcontinuesabbrev": "katuglung.",
+	"smw-showingresults": "Ing/ding {{PLURAL:$1|'''1''' a resulta|'''$1''' resulta}} manibatan king #'''$2'''."
 }

--- a/i18n/pl.json
+++ b/i18n/pl.json
@@ -602,5 +602,6 @@
 	"smw-concept-tab-errors": "Błędy",
 	"smw-ask-tab-result": "Wynik",
 	"smw-ask-tab-code": "Kod",
-	"smw-listingcontinuesabbrev": "cd."
+	"smw-listingcontinuesabbrev": "cd.",
+	"smw-showingresults": "Poniżej znajduje się lista {{PLURAL:$1|z '''1''' wynikiem|'''$1''' wyników}}, rozpoczynając od wyniku numer '''$2'''."
 }

--- a/i18n/pms.json
+++ b/i18n/pms.json
@@ -236,5 +236,6 @@
 	"smw_concept_header": "Pàgine dël concet \"$1\"",
 	"smw_conceptarticlecount": "Smon-e $1 {{PLURAL:$1|pàgina|pàgine}} che a aparten-o a col concet.",
 	"smw-livepreview-loading": "Antramentr ch'as caria…",
-	"smw-listingcontinuesabbrev": "anans"
+	"smw-listingcontinuesabbrev": "anans",
+	"smw-showingresults": "Ambelessì-sota a treuva fin a {{PLURAL:$1|'''1'''|'''$1'''}} arzultà, a parte dal nùmer #'''$2'''."
 }

--- a/i18n/pnb.json
+++ b/i18n/pnb.json
@@ -23,5 +23,6 @@
 	"smw-format-datatable-emptytable": "جدول وچ کوئی ڈیٹا دستیاب نئیں",
 	"smw-property-tab-specification": "... ہور",
 	"smw-legend": "کُنجی",
-	"smw-listingcontinuesabbrev": "جاری"
+	"smw-listingcontinuesabbrev": "جاری",
+	"smw-showingresults": "تھلیوں دسے گۓ  {{PLURAL:$1|'''1''' نتیجہ|'''$1''' نتیجے}}  شروع #'''$2'''."
 }

--- a/i18n/prg.json
+++ b/i18n/prg.json
@@ -6,5 +6,6 @@
 	},
 	"browse": "Lasāis artīkelins",
 	"smw-livepreview-loading": "Krausnā...",
-	"smw-listingcontinuesabbrev": "ē.s."
+	"smw-listingcontinuesabbrev": "ē.s.",
+	"smw-showingresults": "Zemmais ast listi {{PLURAL:$1|stēisan <strong>$1</strong> rezultātan|sen <strong>1</strong> rezultātan|stēisan <strong>$1</strong> rezultātan}}, pagaūnintei ezze <strong>$2</strong>-asmu rezutātan."
 }

--- a/i18n/ps.json
+++ b/i18n/ps.json
@@ -46,5 +46,6 @@
 	"smw-format-datatable-infoempty": "ښکارونه له ۰ تر ۰ له ۰ وتلو",
 	"smw-property-reserved-category": "وېشنيزه",
 	"smw-category": "وېشنيزه",
-	"smw-listingcontinuesabbrev": "پرله پسې"
+	"smw-listingcontinuesabbrev": "پرله پسې",
+	"smw-showingresults": "دلته لاندې تر {{PLURAL:$1|'''1''' پايله|'''$1''' پايلې}} ښکاره شوي پيل له #'''$2''' شوی."
 }

--- a/i18n/pt-br.json
+++ b/i18n/pt-br.json
@@ -1124,5 +1124,6 @@
 	"smw-indicator-revision-mismatch": "Revisão",
 	"smw-indicator-revision-mismatch-error": "A verificação da [https://www.semantic-mediawiki.org/wiki/Help:Associated_revision/Examiner revisão associada] encontrou uma incompatibilidade entre a revisão mencionada no MediaWiki e a que está sendo associada no Semantic MediaWiki para esta entidade.",
 	"smw-indicator-revision-mismatch-comment": "Uma incompatibilidade normalmente indica que algum processo interrompeu a operação de armazenamento do Semantic MediaWiki. É recomendado revisar os logs do servidor e procurar por erros ou outras falhas.",
-	"smw-listingcontinuesabbrev": "cont."
+	"smw-listingcontinuesabbrev": "cont.",
+	"smw-showingresults": "A seguir {{PLURAL:$1|é mostrado '''um''' resultado|são mostrados até '''$1''' resultados}}, iniciando no '''$2'''º."
 }

--- a/i18n/pt.json
+++ b/i18n/pt.json
@@ -1117,5 +1117,6 @@
 	"smw-indicator-revision-mismatch": "Revisão",
 	"smw-indicator-revision-mismatch-error": "A verificação [https://www.semantic-mediawiki.org/wiki/Help:Associated_revision/Examiner revisão associada] encontrou uma falta de correspondência para esta entidade entre a revisão referenciada no MediaWiki e a que está a ser associada no MediaWiki Semântico.",
 	"smw-indicator-revision-mismatch-comment": "Uma falta de correspondência normalmente indica que um qualquer processo interrompeu a operação de armazenamento no MediaWiki Semântico. É recomendado rever os registos do servidor e procurar exceções ou outras falhas.",
-	"smw-listingcontinuesabbrev": "cont."
+	"smw-listingcontinuesabbrev": "cont.",
+	"smw-showingresults": "{{PLURAL:$1|É apresentado <strong>um</strong> resultado|São apresentados até <strong>$1</strong> resultados}} abaixo{{PLURAL:$1||, começando pelo <strong>$2</strong>º}}."
 }

--- a/i18n/qqq.json
+++ b/i18n/qqq.json
@@ -1032,5 +1032,6 @@
 	"smw-entity-examiner-deferred-constraint-error": "This is a label.",
 	"smw-entity-examiner-deferred-fake": "This is a label.",
 	"smw-indicator-revision-mismatch": "This is a label.",
-	"smw-listingcontinuesabbrev": "Shown in continuation of each first letter group. This message follows the first letter.\n\nThis is an abbreviation of the English word \"continued\". If the word is short in your language, the full stop in the end is not necessary."
+	"smw-listingcontinuesabbrev": "Shown in continuation of each first letter group. This message follows the first letter.\n\nThis is an abbreviation of the English word \"continued\". If the word is short in your language, the full stop in the end is not necessary.",
+	"smw-showingresults": "This message is used on some special pages such as [[Special:WantedCategories]]. Parameters:\n* $1 ― the total number of results in the batch shown\n* $2 ― the number of the first item listed\n\nNote that numbers given in $1 and $2 are preformated (and may contain locale-specific group separators or digits), so they cannot be used in the 1st parameter for the <code><nowiki>{{</nowiki>PLURAL:''number''<nowiki>|</nowiki>''textual variants...''<nowiki>}}</nowiki></code> parser funtion, which only accepts raw numbers written with ASCII digits.\n\n{{Int:Seealso}}{{Colon}}\n* {{msg-mw|Showingresultsnum}}"
 }

--- a/i18n/qu.json
+++ b/i18n/qu.json
@@ -8,5 +8,6 @@
 	"browse": "Wikipi wamp'uy",
 	"smw_browselink": "Kaqninkunapi wamp'uy",
 	"smw-livepreview-loading": "Chaqnamuspa…",
-	"smw-listingcontinuesabbrev": "qatiy"
+	"smw-listingcontinuesabbrev": "qatiy",
+	"smw-showingresults": "Qhipanpiqa rikuchkanki {{PLURAL:$1|'''1''' tarisqatam|'''$1'''-kama tarisqakunatam}}, '''$2''' huchhawan qallarispa."
 }

--- a/i18n/rm.json
+++ b/i18n/rm.json
@@ -6,5 +6,6 @@
 	},
 	"smw-ui-tooltip-title-legend": "Legenda",
 	"smw-livepreview-loading": "Chargiar…",
-	"smw-listingcontinuesabbrev": "cuntinuaziun"
+	"smw-listingcontinuesabbrev": "cuntinuaziun",
+	"smw-showingresults": "Sutvart èn enfin {{PLURAL:$1|'''in''' resultat|'''$1''' resultats}} cumenzond cun il numer '''$2'''."
 }

--- a/i18n/ro.json
+++ b/i18n/ro.json
@@ -145,5 +145,6 @@
 	"smw-concept-tab-errors": "Erori",
 	"smw-install-incomplete-intro": "Instalarea (sau actualizarea) aplicației <b>Semantic MediaWiki</b> nu a fost finalizată și un administrator ar trebui să execute următoarele activități pentru a preveni inconsecvențele de date înainte ca utilizatorii să continue să creeze sau să modifice conținut.",
 	"smw-install-incomplete-populate-hash-field": "Populația de câmp <code>smw_hash</code> a fost omisă în timpul configurării, este necesar să fie executat scriptul [https://www.semantic-mediawiki.org/wiki/Help:populateHashField.php populateHashField.php].",
-	"smw-listingcontinuesabbrev": "cont."
+	"smw-listingcontinuesabbrev": "cont.",
+	"smw-showingresults": "Mai jos {{PLURAL:$1|apare '''1''' rezultat|apar '''$1''' rezultate|apar '''$1''' de rezultate}} începând cu nr. <b>$2</b>."
 }

--- a/i18n/roa-tara.json
+++ b/i18n/roa-tara.json
@@ -249,5 +249,6 @@
 	"smw-property-tab-constraint-schema-title": "Vingole d'u scheme combilate",
 	"smw-concept-tab-list": "Elenghe",
 	"smw-concept-tab-errors": "Errore",
-	"smw-listingcontinuesabbrev": "cond."
+	"smw-listingcontinuesabbrev": "cond.",
+	"smw-showingresults": "Stoche a fazze vedè aqquà sotte {{PLURAL:$1|'''1''' resultete|'''$1''' resultete}} ca accumenzene cu #'''$2'''."
 }

--- a/i18n/ru.json
+++ b/i18n/ru.json
@@ -899,5 +899,6 @@
 	"smw-entity-examiner-deferred-fake": "Не настоящие",
 	"smw-indicator-revision-mismatch": "Редакция",
 	"smw-indicator-revision-mismatch-error": "Проверка [https://www.semantic-mediawiki.org/wiki/Help:Associated_revision/Examiner связанной ревизии] обнаружила несоответствие между ревизией, на которую ссылается MediaWiki, и ревизией, ассоциированной в Semantic MediaWiki для этой сущности.",
-	"smw-listingcontinuesabbrev": "(продолжение)"
+	"smw-listingcontinuesabbrev": "(продолжение)",
+	"smw-showingresults": "Ниже {{PLURAL:$1|1=показан <strong>1</strong> результат|показан  <strong>$1</strong> результат|показано <strong>$1</strong> результата|показаны <strong>$1</strong> результатов}}, начиная с № <strong>$2</strong>."
 }

--- a/i18n/rue.json
+++ b/i18n/rue.json
@@ -11,5 +11,6 @@
 	"smw_result_noresults": "Жадны ресултаты",
 	"smw_smwadmin_return": "Навернутя до  «$1».",
 	"smw-livepreview-loading": "Наладовованя...",
-	"smw-listingcontinuesabbrev": "(дале)"
+	"smw-listingcontinuesabbrev": "(дале)",
+	"smw-showingresults": "Ниже {{PLURAL:$1|вказане|вказаны|вказаных}} '''$1''' {{PLURAL:$1|резултат|резултаты|резултатів}}, почінаючіх з №&nbsp;'''$2'''"
 }

--- a/i18n/sa.json
+++ b/i18n/sa.json
@@ -9,5 +9,6 @@
 	"smw-admin-supplementary-elastic-functions": "उपलब्धकार्याणि",
 	"smw-admin-supplementary-elastic-settings-title": "अभिविन्यासाः",
 	"smw-livepreview-loading": "आरोपयति...",
-	"smw-listingcontinuesabbrev": "अनुवर्तते"
+	"smw-listingcontinuesabbrev": "अनुवर्तते",
+	"smw-showingresults": "#'''$2''' क्रमाङ्कात् आरभ्य {{PLURAL:$1|'''$1''' परिणामः अधः प्रदर्शितः|'''$1''' परिणामाः अधः प्रदर्शिताः}}।"
 }

--- a/i18n/sah.json
+++ b/i18n/sah.json
@@ -9,5 +9,6 @@
 	"smw-ask-search": "Бул",
 	"browse": "Биикини көрүү",
 	"smw-livepreview-loading": "Киллэрии бара турар…",
-	"smw-listingcontinuesabbrev": "(салгыыта)"
+	"smw-listingcontinuesabbrev": "(салгыыта)",
+	"smw-showingresults": "Манна {{PLURAL:$1|түмүк|түмүктэр}} {{PLURAL:$1|көрдөрүлүннэ|көрдөрүлүннүлэр}} <strong>$1</strong> , мантан саҕалаан №&nbsp;<strong>$2</strong>."
 }

--- a/i18n/sc.json
+++ b/i18n/sc.json
@@ -6,5 +6,6 @@
 	},
 	"browse": "Esplora sa wiki",
 	"smw_smwadmin_datarefreshstopconfirm": "Eja, deo so {{GENDER:$1|seguru|segura}}",
-	"smw-listingcontinuesabbrev": "sighit"
+	"smw-listingcontinuesabbrev": "sighit",
+	"smw-showingresults": "Inoghe sighende {{PLURAL:$1|benit ammustradu '''1''' resurtadu|benint ammustrados '''$1''' resurtados}} incumentzende dae su nùmeru '''$2'''."
 }

--- a/i18n/scn.json
+++ b/i18n/scn.json
@@ -76,5 +76,6 @@
 	"smw-concept-tab-errors": "Errura",
 	"smw-ask-tab-result": "Risurtatu",
 	"smw-ask-tab-code": "Còdici",
-	"smw-listingcontinuesabbrev": "cunt."
+	"smw-listingcontinuesabbrev": "cunt.",
+	"smw-showingresults": "Ammustra nzinu a {{PLURAL:$1|'''1''' risurtatu|'''$1''' risurtati}} a pàrtiri dô nùmmuru '''$2'''."
 }

--- a/i18n/sco.json
+++ b/i18n/sco.json
@@ -12,5 +12,6 @@
 	"smw-admin-idlookup-docu": "Displeys details aneat aen internal object Id that represents indeevidual entities (wikipage, subobject etc.) in Semantic MediaWiki.",
 	"smw-admin-objectid": "The Object Id:",
 	"smw-livepreview-loading": "Laidin...",
-	"smw-listingcontinuesabbrev": "cont."
+	"smw-listingcontinuesabbrev": "cont.",
+	"smw-showingresults": "Shawin ablo up tae {{PLURAL:$1|'''1''' ootcome|'''$1''' ootcomes}} stertin wi #'''$2'''."
 }

--- a/i18n/sd.json
+++ b/i18n/sd.json
@@ -56,5 +56,6 @@
 	"smw-pendingtasks-setup-tasks": "ڪم",
 	"smw-legend": "ڪنجي",
 	"smw-indicator-revision-mismatch": "ورجاءُ",
-	"smw-listingcontinuesabbrev": "جاري."
+	"smw-listingcontinuesabbrev": "جاري.",
+	"smw-showingresults": "ھيٺ #<strong>$2</strong> سان شروع ٿيندڙ {{PLURAL:$1|<strong>1</strong> نتيجو|<strong>$1</strong> نتيجا}} تائين ڏيکاري ٿو."
 }

--- a/i18n/sdc.json
+++ b/i18n/sdc.json
@@ -6,5 +6,6 @@
 	},
 	"browse": "Nabiggà vichi",
 	"smw-livepreview-loading": "Carrigghendi…",
-	"smw-listingcontinuesabbrev": "(séguiddu)"
+	"smw-listingcontinuesabbrev": "(séguiddu)",
+	"smw-showingresults": "Accó {{PLURAL:$1|màssimu '''1''' risulthaddu|màssimu li '''$1''' risulthaddi}} à partì da lu nùmaru #'''$2'''."
 }

--- a/i18n/sgs.json
+++ b/i18n/sgs.json
@@ -7,5 +7,6 @@
 	"smw_purge": "Atšvėižintė",
 	"browse": "Poslapiu apveiza",
 	"smw-livepreview-loading": "Kraunama īr…",
-	"smw-listingcontinuesabbrev": "tes."
+	"smw-listingcontinuesabbrev": "tes.",
+	"smw-showingresults": "Žemiau ruodoma lėgė '''$1''' {{PLURAL:$1|rezoltata|rezoltatu|rezoltatu}} pradedont #'''$2'''."
 }

--- a/i18n/sh.json
+++ b/i18n/sh.json
@@ -17,5 +17,6 @@
 	"action-smw-admin": "pristupanje administratorskima zadacima Semantički MediaWiki",
 	"action-smw-ruleedit": "uređivanje odredbenih stranica (Semantički MediaWiki)",
 	"smw-livepreview-loading": "Učitavanje...",
-	"smw-listingcontinuesabbrev": "nast."
+	"smw-listingcontinuesabbrev": "nast.",
+	"smw-showingresults": "Dole {{PLURAL:$1|je prikazana <strong>1</strong> stavka|su prikazane <strong>$1</strong> stavke|je prikazano <strong>$1</strong> stavki}} počev od br. <strong>$2</strong>."
 }

--- a/i18n/si.json
+++ b/i18n/si.json
@@ -147,5 +147,6 @@
 	"smw-sp-searchbyproperty-resultlist-header": "ප්‍රතිපල ලැයිස්තුව",
 	"smw-sp-searchbyproperty-nonvaluequery": "\"$1\" සදහා ඇති වටිනාකම් ලැයිස්තුව පවරන ලදී.",
 	"smw-sp-searchbyproperty-valuequery": "\"$2\"ක අගයේ \"$1\" හිමිකම් ඇති පිටු ලැයිස්තුව විස්තර කරන ලදී.",
-	"smw-listingcontinuesabbrev": "ඉතිරිය."
+	"smw-listingcontinuesabbrev": "ඉතිරිය.",
+	"smw-showingresults": "#'''$2''' ගෙන් ආරම්භ කොට, {{PLURAL:$1|ප්‍රතිඵල '''1'''  ක් |ප්‍රතිඵල '''$1''' ක්}} දක්වා පහත පෙන්වා ඇත."
 }

--- a/i18n/sk.json
+++ b/i18n/sk.json
@@ -179,5 +179,6 @@
 	"smw_conceptarticlecount": "Nižšie {{PLURAL:$1|zobrazená jedna stránka|zobrazené $1 stránky|zobrazených $1 stránkok}}.",
 	"smw-property-predefined-askpa": "„$1“ je predefinovaná vlastnosť popisujúca parametre, ktoré ovplyvňujú výsledok dopytu, a poskytuje ju [https://www.semantic-mediawiki.org/wiki/Help:Special_properties Semantic MediaWiki].",
 	"smw-livepreview-loading": "Načítava sa…",
-	"smw-listingcontinuesabbrev": "pokrač."
+	"smw-listingcontinuesabbrev": "pokrač.",
+	"smw-showingresults": "Nižšie {{PLURAL:$1|je zobrazený jeden výsledok|sú zobrazené '''1''' výsledky|je zobrazených '''$1''' výsledkov}}, počnúc od  #<b>$2</b>."
 }

--- a/i18n/sl.json
+++ b/i18n/sl.json
@@ -222,5 +222,6 @@
 	"smw-remote-source-disabled": "Vir '''$1''' je onemogočil podporo za oddaljene zahtevke!",
 	"smw-es-replication-error-divergent-date": "Pri spremljanju replikacije je bilo ugotovljeno, da <b>datum modifikacije</b> pri članku »$1« (ID: $2) kaže neskladnost.",
 	"smw-es-replication-error-divergent-date-detail": "Referenčni datum spremembe:\n*Elasticsearch: $1 \n*Podatkovna zbirka: $2",
-	"smw-listingcontinuesabbrev": "nadalj."
+	"smw-listingcontinuesabbrev": "nadalj.",
+	"smw-showingresults": "Prikazujem do '''$1''' {{PLURAL:$1|zadetek|zadetka|zadetke|zadetkov}}, začenši s št. '''$2'''."
 }

--- a/i18n/sli.json
+++ b/i18n/sli.json
@@ -6,5 +6,6 @@
 	},
 	"browse": "Semantisches Browsen",
 	"smw-livepreview-loading": "Loada…",
-	"smw-listingcontinuesabbrev": "(Furtsetzung)"
+	"smw-listingcontinuesabbrev": "(Furtsetzung)",
+	"smw-showingresults": "Hier {{PLURAL:$1|ies '''1''' Ergebnis|sein '''$1''' Ergebnisse}}, beginnend miet Nummer '''$2.'''"
 }

--- a/i18n/sq.json
+++ b/i18n/sq.json
@@ -21,5 +21,6 @@
 	"browse": "Shfletoni wiki",
 	"smw-admin-bugsreport": "Të metat mund të njoftohen te <a href=\"https://github.com/SemanticMediaWiki/SemanticMediaWiki/issues\">ndjekësi i problemeve</a>, faqja <a href=\"https://www.semantic-mediawiki.org/wiki/Help:Reporting_bugs\">e njoftimit të të metave</a> jep ca ndihmë mbi se si të shkruhet një raport efikas të mete.",
 	"smw-livepreview-loading": "Duke punuar…",
-	"smw-listingcontinuesabbrev": "vazh."
+	"smw-listingcontinuesabbrev": "vazh.",
+	"smw-showingresults": "Më poshtë tregohen {{PLURAL:$1|'''1''' përfundim|'''$1''' përfundime}} duke filluar nga #'''$2'''."
 }

--- a/i18n/sr-ec.json
+++ b/i18n/sr-ec.json
@@ -363,5 +363,6 @@
 	"smw-ask-tab-code": "Кôд",
 	"smw-pendingtasks-setup-tasks": "Задаци",
 	"smw-es-replication-error-divergent-date-short": "Следеће информације о датуму коришћене су ради поређења:",
-	"smw-listingcontinuesabbrev": "наст."
+	"smw-listingcontinuesabbrev": "наст.",
+	"smw-showingresults": "{{PLURAL:$1|1=Приказан је <strong>један</strong> резултат|Приказан је <strong>$1</strong> резултат|Приказана су <strong>$1</strong> резултата|Приказано је <strong>$1</strong> резултата}}; број прве ставке: <strong>$2</strong>."
 }

--- a/i18n/sr-el.json
+++ b/i18n/sr-el.json
@@ -260,5 +260,6 @@
 	"smw-concept-tab-errors": "Greške",
 	"smw-ask-tab-extra": "Dodatno",
 	"smw-ask-tab-code": "Kôd",
-	"smw-listingcontinuesabbrev": "nast."
+	"smw-listingcontinuesabbrev": "nast.",
+	"smw-showingresults": "{{PLURAL:$1|1=Prikazan je <strong>jedan</strong> rezultat|Prikazan je <strong>$1</strong> rezultat|Prikazana su <strong>$1</strong> rezultata|Prikazano je <strong>$1</strong> rezultata}}; broj prve stavke: <strong>$2</strong>."
 }

--- a/i18n/stq.json
+++ b/i18n/stq.json
@@ -3,5 +3,6 @@
 		"authors": []
 	},
 	"smw-livepreview-loading": "Leede …",
-	"smw-listingcontinuesabbrev": "(Foutsättenge)"
+	"smw-listingcontinuesabbrev": "(Foutsättenge)",
+	"smw-showingresults": "Hier {{PLURAL:$1|is '''1''' Resultoat|sunt '''$1''' Resultoate}}, ounfangend mäd Nuumer '''$2'''."
 }

--- a/i18n/su.json
+++ b/i18n/su.json
@@ -35,5 +35,6 @@
 	"smw-format-datatable-first": "mimiti",
 	"smw-format-datatable-last": "Pamungkas",
 	"smw-format-datatable-next": "Saterusna",
-	"smw-listingcontinuesabbrev": "(samb.)"
+	"smw-listingcontinuesabbrev": "(samb.)",
+	"smw-showingresults": "Di handap ieu némbongkeun {{PLURAL:$1|'''1''' hasil|'''$1''' hasil}}, dimimitianku  #'''$2'''."
 }

--- a/i18n/sv.json
+++ b/i18n/sv.json
@@ -675,5 +675,6 @@
 	"smw-pendingtasks-setup-tasks": "Uppgifter",
 	"smw-report": "Rapportera",
 	"smw-legend": "Teckenförklaring",
-	"smw-listingcontinuesabbrev": "forts."
+	"smw-listingcontinuesabbrev": "forts.",
+	"smw-showingresults": "Nedan visas upp till {{PLURAL:$1|<strong>1</strong> resultat|<strong>$1</strong> resultat}} från och med nummer <strong>$2</strong>."
 }

--- a/i18n/sw.json
+++ b/i18n/sw.json
@@ -11,5 +11,6 @@
 	"smw-livepreview-loading": "Inapakizwa...",
 	"smw-filter": "Chuja",
 	"smw-property-tab-usage": "Matumizi",
-	"smw-listingcontinuesabbrev": "endelea"
+	"smw-listingcontinuesabbrev": "endelea",
+	"smw-showingresults": "{{PLURAL:$1|Tokeo '''1''' linaonyeshwa|matokeo '''$1''' yanaonyeshwa}} chini, kuanzia na namba '''$2'''."
 }

--- a/i18n/szl.json
+++ b/i18n/szl.json
@@ -7,5 +7,6 @@
 	},
 	"browse": "Przeglōndej wiki",
 	"smw-livepreview-loading": "Trwo uadowańy…",
-	"smw-listingcontinuesabbrev": "cd."
+	"smw-listingcontinuesabbrev": "cd.",
+	"smw-showingresults": "To lista na keryj je {{PLURAL:$1|'''1''' wyńik|'''$1''' wyńikůw}}, sztartujůnc uod nůmery '''$2'''."
 }

--- a/i18n/ta.json
+++ b/i18n/ta.json
@@ -65,5 +65,6 @@
 	"smw-livepreview-loading": "ஏற்றப்படுகிறது…",
 	"smw-no-data-available": "தரவேதும் கிடைக்கப்பெறவில்லை",
 	"smw-property-req-violation-missing-fields": "விடுபட்ட சொத்து \"$1\" [https://www.semantic-mediawiki.org/wiki/Help:Special_property_Has_fields <code>Has fields</code>] இந்த \"$2\" வகைக்கான அறிவிப்பு தேவைப்படுகிறது.",
-	"smw-listingcontinuesabbrev": "தொடரும்."
+	"smw-listingcontinuesabbrev": "தொடரும்.",
+	"smw-showingresults": "'''$2''' இலிருந்து தொடங்கும்  {{PLURAL:$1|'''1''' முடிவு கீழே காட்டப்பட்டுள்ளது|'''$1''' முடிவுகள் கீழே காட்டப்பட்டுள்ளன}}."
 }

--- a/i18n/tcy.json
+++ b/i18n/tcy.json
@@ -40,5 +40,6 @@
 	"smw-copy-clipboard-title": "ವಿಷಯಾಂಶೊನು ಪತಿಪಲಯಿಗ್ ನಕಲುಂಡು",
 	"smw-jsonview-expand-title": "JSON ನೋಟನು ವಿಸ್ತಾರ ಮಲ್ಪುಂಡು.",
 	"smw-jsonview-collapse-title": "JSON ನೋಟನು ಪತನ ಮಲ್ಪುಂಡು",
-	"smw-listingcontinuesabbrev": "ದುಂಬು."
+	"smw-listingcontinuesabbrev": "ದುಂಬು.",
+	"smw-showingresults": "#<strong>$2</strong>ರ್ದ್ ಸುರುವಾಪಿನ,  {{PLURAL:$1|<strong>1</strong> ಫಲಿತಾಂಶ|<strong>$1</strong>ಫಲಿತಾಂಶೊಲು}} ಮುಟ್ಟದವೆನ್ ಈ  ತಿರ್ತ್ ತೋಜಾವುಂಡು ."
 }

--- a/i18n/te.json
+++ b/i18n/te.json
@@ -156,5 +156,6 @@
 	"smw-help": "సహాయం",
 	"smw-types-title": "రకం: $1",
 	"smw-schema-error-violation": "[\"$1\", \"$2\"]",
-	"smw-listingcontinuesabbrev": "(కొనసాగింపు)"
+	"smw-listingcontinuesabbrev": "(కొనసాగింపు)",
+	"smw-showingresults": "#<strong>$2</strong> నుండి మొదలుకొని {{PLURAL:$1|</strong>ఒక్క</strong> ఫలితాన్ని|<strong>$1</strong> ఫలితాలను}} కింద చూపించాం."
 }

--- a/i18n/tg-cyrl.json
+++ b/i18n/tg-cyrl.json
@@ -57,5 +57,6 @@
 	"smw-format-datatable-search": "Ҷустуҷӯ:",
 	"smw-format-datatable-toolbar-export": "Берунбарӣ",
 	"smw-schema-summary-title": "Хулоса",
-	"smw-listingcontinuesabbrev": "идома"
+	"smw-listingcontinuesabbrev": "идома",
+	"smw-showingresults": "Намоиши {{PLURAL:$1|'''1''' натиҷа|'''$1''' натоиҷ}} дар зер оғоз аз #'''$2'''."
 }

--- a/i18n/tg-latn.json
+++ b/i18n/tg-latn.json
@@ -4,5 +4,6 @@
 	},
 	"smw-createproperty-isproperty": "In jak viƶagī az nav'i $1 ast.",
 	"smw-livepreview-loading": "Dar holi bor şudan…",
-	"smw-listingcontinuesabbrev": "idoma"
+	"smw-listingcontinuesabbrev": "idoma",
+	"smw-showingresults": "Namoişi {{PLURAL:$1|'''1''' natiça|'''$1''' natoiç}} dar zer oƣoz az #'''$2'''."
 }

--- a/i18n/th.json
+++ b/i18n/th.json
@@ -74,5 +74,6 @@
 	"smw-livepreview-loading": "กำลังค้นหา…",
 	"smw-install-incomplete-intro": "การติดตั้ง (หรืออัปเกรด) ของ <b>ความหมายมีเดียวิกิ</b> ยังไม่สิ้นสุดและผู้ดูแลระบบควรดำเนินงานต่อไปนี้เพื่อป้องกันข้อมูลที่ไม่สอดคล้องกันก่อนที่ผู้ใช้จะสร้างหรือแก้ไขเนื้อหาต่อไป",
 	"smw-install-incomplete-populate-hash-field": "<code>smw_hash</code> วงประชากรถูกข้ามไปในระหว่างการตั้งค่า สคริปต์ [https://www.semantic-mediawiki.org/wiki/Help:populateHashField.php populateHashField.php] จะต้องมีการดำเนินการ",
-	"smw-listingcontinuesabbrev": "ต่อ"
+	"smw-listingcontinuesabbrev": "ต่อ",
+	"smw-showingresults": "ด้านล่างแสดง <strong>1</strong> ผลลัพธ์ เริ่มตั้งแต่รายการที่ <strong>$2</strong>"
 }

--- a/i18n/tk.json
+++ b/i18n/tk.json
@@ -9,5 +9,6 @@
 	"smw_browse_go": "Git",
 	"smw_result_prev": "Öňki",
 	"smw-livepreview-loading": "Ýüklenýär...",
-	"smw-listingcontinuesabbrev": "(dowamy)"
+	"smw-listingcontinuesabbrev": "(dowamy)",
+	"smw-showingresults": "Aşakda №'''$2''' netijeden başlap, {{PLURAL:$1|'''1''' netije|'''$1''' netije}} görkezilýär."
 }

--- a/i18n/tl.json
+++ b/i18n/tl.json
@@ -248,5 +248,6 @@
 	"smw-filter": "Pansala",
 	"smw-help": "Makatulong",
 	"smw-remote-source-unavailable": "Hindi mai-'connect' sa 'remote \"$1\" target'.",
-	"smw-listingcontinuesabbrev": "karugtong"
+	"smw-listingcontinuesabbrev": "karugtong",
+	"smw-showingresults": "Ipinapakita sa ibaba ang magpahanggang sa {{PLURAL:$1|'''1''' resultang|'''$1''' mga resultang}} nagsisimula sa #'''$2'''."
 }

--- a/i18n/tr.json
+++ b/i18n/tr.json
@@ -1101,5 +1101,6 @@
 	"smw-indicator-revision-mismatch": "Revizyon",
 	"smw-indicator-revision-mismatch-error": "[https://www.semantic-mediawiki.org/wiki/Help:Associated_revision/Examiner İlişkilendirilmiş düzeltme] denetimi, MediaWiki'de başvurulan düzeltme ile bu varlık için Semantic MediaWiki'de ilişkilendirilen düzeltme arasında bir uyumsuzluk buldu.",
 	"smw-indicator-revision-mismatch-comment": "Uyumsuzluk normalde bazı işlemlerin Semantic MediaWiki'deki depolama işlemini kesintiye uğrattığını gösterir. Sunucu günlüklerini incelemeniz ve özel durumlar veya diğer hatalar olup olmadığına bakmanız önerilir.",
-	"smw-listingcontinuesabbrev": "devam"
+	"smw-listingcontinuesabbrev": "devam",
+	"smw-showingresults": "$2. sonuçtan başlayarak {{PLURAL:$1|<strong>1</strong> sonuç|<strong>$1</strong> sonuç}} aşağıdadır:"
 }

--- a/i18n/tt-cyrl.json
+++ b/i18n/tt-cyrl.json
@@ -33,5 +33,6 @@
 	"group-smwadministrator-member": "{{GENDER:$1|идәрәче (Semantic MediaWiki)}}",
 	"grouppage-smwadministrator": "{{ns:project}}:Идарәчеләр (Semantic MediaWiki)",
 	"smw-livepreview-loading": "Төяү бара…",
-	"smw-listingcontinuesabbrev": "дәвамы"
+	"smw-listingcontinuesabbrev": "дәвамы",
+	"smw-showingresults": "Түбәндә <strong>$2</strong>&nbsp;№ башлап {{PLURAL:$1|<strong>бер генә</strong> нәтиҗә|<strong>$1</strong> нәтиҗә}} күрсәтелгән."
 }

--- a/i18n/tt-latn.json
+++ b/i18n/tt-latn.json
@@ -6,5 +6,6 @@
 	},
 	"browse": "Wiki eçtälegen qaraw",
 	"smw-livepreview-loading": "Yökläw...",
-	"smw-listingcontinuesabbrev": "däwamı"
+	"smw-listingcontinuesabbrev": "däwamı",
+	"smw-showingresults": "Asta № '''$2''' {{PLURAL:$1|başlap}} '''$1''' {{PLURAL:$1|rezultat}} kürsätelgän."
 }

--- a/i18n/ug-arab.json
+++ b/i18n/ug-arab.json
@@ -17,5 +17,6 @@
 	"browse": "ۋىكىنى زىيارەت قىلىش",
 	"smw_browse_go": "كۆچۈش",
 	"smw-livepreview-loading": "يۈكلەۋاتىدۇ…",
-	"smw-listingcontinuesabbrev": "داۋاملاشتۇر"
+	"smw-listingcontinuesabbrev": "داۋاملاشتۇر",
+	"smw-showingresults": "تۆۋەندە '''$2''' - نەتىجىدىن باشلانغان {{PLURAL:$1|'''1''' نەتىجە|'''$1''' نەتىجە}} كۆرسىتىدۇ:"
 }

--- a/i18n/uk.json
+++ b/i18n/uk.json
@@ -1120,5 +1120,6 @@
 	"smw-indicator-revision-mismatch": "Версія",
 	"smw-indicator-revision-mismatch-error": "Перевірка [https://www.semantic-mediawiki.org/wiki/Help:Associated_revision/Examiner пов'язаної версії] виявила невідповідність між версією, на яку посилається MediaWiki, та тією, з якою здійснюється пов'язування в Семантичній MediaWiki для цієї сутності.",
 	"smw-indicator-revision-mismatch-comment": "Невідповідність зазвичай свідчить про те, що якийсь процес перервав операцію зі зберігання в Семантичній MediaWiki. Рекомендується переглянути журнали сервера та пошукати винятків чи інших невдач.",
-	"smw-listingcontinuesabbrev": "(прод.)"
+	"smw-listingcontinuesabbrev": "(прод.)",
+	"smw-showingresults": "Нижче {{PLURAL:$1|показане|показані|показані|}} <strong>$1</strong> {{PLURAL:$1|результат|результати|результатів|}}, починаючи з №&nbsp;<strong>$2</strong>"
 }

--- a/i18n/ur.json
+++ b/i18n/ur.json
@@ -47,5 +47,6 @@
 	"smw-admin-other-functions": "دیگر کردار",
 	"smw-property-reserved-category": "زمرہ",
 	"smw-datavalue-uri-invalid-scheme": "$1کوواجب URI سکیم میں ذیرِفہرست نہیں رکھا گیا۔",
-	"smw-listingcontinuesabbrev": "جاری۔"
+	"smw-listingcontinuesabbrev": "جاری۔",
+	"smw-showingresults": "ذیل میں #<strong>$2</strong> سے {{PLURAL:$1|<strong>1</strong> تک نتیجہ دکھایا گیا ہے|<strong>$1</strong> تک نتائج دکھائے گئے ہیں}}۔"
 }

--- a/i18n/uz.json
+++ b/i18n/uz.json
@@ -15,5 +15,6 @@
 	"prefs-ask-options": "Maʼnoviy qidiruv moslamalari",
 	"smw-prefs-ask-options-tooltip-display": "«Matn» koʻrsatkichini paydo boʻladigan yordamchi sifatida aks ettirish",
 	"smw_unknowntype": "Ushbu xossaning tipi noto'g'ri",
-	"smw-listingcontinuesabbrev": "davomi"
+	"smw-listingcontinuesabbrev": "davomi",
+	"smw-showingresults": "Quyida №'''$2'''dan boshlab {{PLURAL:$1|'''bitta''' natija|'''$1''' ta natija}} koʻrsatilgan."
 }

--- a/i18n/vec.json
+++ b/i18n/vec.json
@@ -9,5 +9,6 @@
 	"smw-ui-tooltip-title-legend": "Lejenda",
 	"smw-livepreview-loading": "Caricamento in corso…",
 	"smw-legend": "Lejenda",
-	"smw-listingcontinuesabbrev": "cont."
+	"smw-listingcontinuesabbrev": "cont.",
+	"smw-showingresults": "Qua de soto vien mostrà al massimo {{PLURAL:$1|'''1''' risultato|'''$1''' risultati}} a partir dal nùmaro '''$2'''."
 }

--- a/i18n/vep.json
+++ b/i18n/vep.json
@@ -25,5 +25,6 @@
 	"smw_result_noresults": "Ei ole rezul'tatoid.",
 	"smwadmin": "Redaktiruida Semantic MediaWiki",
 	"smw-livepreview-loading": "Ozutase…",
-	"smw-listingcontinuesabbrev": "jatktand"
+	"smw-listingcontinuesabbrev": "jatktand",
+	"smw-showingresults": "Alemba ozutadas {{PLURAL:$1|'''1''' rezul'tat|'''$1''' rezul'tatad}} nomeraspäi #'''$2''' augotaden."
 }

--- a/i18n/vi.json
+++ b/i18n/vi.json
@@ -193,5 +193,6 @@
 	"smw-property-tab-usage": "Sử dụng",
 	"smw-concept-tab-list": "Danh sách",
 	"smw-concept-tab-errors": "Lỗi",
-	"smw-listingcontinuesabbrev": "(tiếp theo)"
+	"smw-listingcontinuesabbrev": "(tiếp theo)",
+	"smw-showingresults": "Dưới đây là cho đến <strong>$1</strong> kết quả bắt đầu từ #<strong>$2</strong>."
 }

--- a/i18n/vo.json
+++ b/i18n/vo.json
@@ -78,5 +78,6 @@
 	"smw_concept_header": "Pads suemoda: „$1“.",
 	"smw_conceptarticlecount": "{{PLURAL:$1|Pajonon pad $1, kel duton|Pajonons pads $1, kels dutons}} lü suemod at.",
 	"smw-livepreview-loading": "Pabelodon…",
-	"smw-listingcontinuesabbrev": "(fov.)"
+	"smw-listingcontinuesabbrev": "(fov.)",
+	"smw-showingresults": "Pajonons dono jü {{PLURAL:$1|sukasek '''1'''|sukaseks '''$1'''}}, primölo me nüm #'''$2'''."
 }

--- a/i18n/vro.json
+++ b/i18n/vro.json
@@ -6,5 +6,6 @@
 	},
 	"browse": "Viki kaeminõ",
 	"smw-livepreview-loading": "Laat…",
-	"smw-listingcontinuesabbrev": "lätt edesi"
+	"smw-listingcontinuesabbrev": "lätt edesi",
+	"smw-showingresults": "{{PLURAL:$1|'''Üts''' tulõmus|'''$1''' tulõmust}} (tulõmusõst '''$2''' pääle)."
 }

--- a/i18n/wa.json
+++ b/i18n/wa.json
@@ -9,5 +9,6 @@
 	"browse": "Naivyî el wiki",
 	"smw-ui-tooltip-title-legend": "Ledjinde",
 	"smw-livepreview-loading": "Tcherdjant...",
-	"smw-listingcontinuesabbrev": "(shûte)"
+	"smw-listingcontinuesabbrev": "(shûte)",
+	"smw-showingresults": "Cial pa dzo {{PLURAL:$1|'''1''' rizultat|'''$1''' rizultats}} a pårti do limero '''$2'''."
 }

--- a/i18n/wo.json
+++ b/i18n/wo.json
@@ -5,5 +5,6 @@
 		]
 	},
 	"browse": "Wër wiki bi",
-	"smw-listingcontinuesabbrev": "(desit)"
+	"smw-listingcontinuesabbrev": "(desit)",
+	"smw-showingresults": "Woneg <b>$1</b> {{PLURAL:$1|ngérte|ciy ngérte}} doore ko ci #<b>$2</b>."
 }

--- a/i18n/wuu.json
+++ b/i18n/wuu.json
@@ -5,5 +5,6 @@
 		]
 	},
 	"browse": "浏览维基",
-	"smw-listingcontinuesabbrev": "续"
+	"smw-listingcontinuesabbrev": "续",
+	"smw-showingresults": "下头显示从第<b>$2</b>条开始个<b>$1</b>条结果："
 }

--- a/i18n/xmf.json
+++ b/i18n/xmf.json
@@ -9,5 +9,6 @@
 	"smw-limitreport-intext-parsertime-value": "$1 მერქა",
 	"smw-limitreport-pagepurge-storeupdatetime-value": "$1 მერქა",
 	"smw-jsonview-search-label": "გორუა:",
-	"smw-listingcontinuesabbrev": "გჷნძარ."
+	"smw-listingcontinuesabbrev": "გჷნძარ.",
+	"smw-showingresults": "გიმე ქოძირით {{PLURAL:$1|<strong>1</strong>}}</b>-შახ შედეგი დოწყაფილი #<strong>$2</strong>-შე."
 }

--- a/i18n/yi.json
+++ b/i18n/yi.json
@@ -24,5 +24,6 @@
 	"smw-ui-tooltip-title-reference": "רעפערענץ",
 	"smw-livepreview-loading": "לאדנדיג…",
 	"smw-search-syntax": "סינטאקס",
-	"smw-listingcontinuesabbrev": "(המשך)"
+	"smw-listingcontinuesabbrev": "(המשך)",
+	"smw-showingresults": "ווייזן ביז {{PLURAL:$1|רעזולטאט '''איינס'''|'''$1''' רעזולטאטן}} אנגעפאנגן פון נומער #'''$2''':"
 }

--- a/i18n/yo.json
+++ b/i18n/yo.json
@@ -7,5 +7,6 @@
 	"browse": "Ìtúwò wiki",
 	"smw-livepreview-loading": "Óúnbọ̀wá...",
 	"smw-property-preferred-title-format": "$1 ($2)",
-	"smw-listingcontinuesabbrev": "tẹ̀síwájú"
+	"smw-listingcontinuesabbrev": "tẹ̀síwájú",
+	"smw-showingresults": "Ìfihàn nísàlẹ̀ títí dé {{PLURAL:$1|èsì '''1'''|àwọn èsì '''$1'''}} láti ìbẹ̀rẹ̀ ní #'''$2'''."
 }

--- a/i18n/yue.json
+++ b/i18n/yue.json
@@ -63,5 +63,6 @@
 	"log-name-smw": "語意MediaWiki日誌",
 	"smw-datavalue-time-invalid-date-components-common": "“$1”包含一啲無法解釋嘅信息。",
 	"smw-datavalue-external-formatter-invalid-uri": "“$1”係無效連結。",
-	"smw-listingcontinuesabbrev": "續"
+	"smw-listingcontinuesabbrev": "續",
+	"smw-showingresults": "'自#'''$2'''起顯示最多'''$1'''個結果。"
 }

--- a/i18n/zh-hans.json
+++ b/i18n/zh-hans.json
@@ -963,5 +963,6 @@
 	"smw-entity-examiner-deferred-fake": "假的",
 	"smw-indicator-constraint-violation": "{{PLURAL:$1|约束}}",
 	"smw-indicator-revision-mismatch": "版本",
-	"smw-listingcontinuesabbrev": "续"
+	"smw-listingcontinuesabbrev": "续",
+	"smw-showingresults": "下面显示从第<strong>$2</strong>条结果开始的<strong>$1</strong>条结果。"
 }

--- a/i18n/zh-hant.json
+++ b/i18n/zh-hant.json
@@ -1127,5 +1127,6 @@
 	"smw-indicator-revision-mismatch": "修訂",
 	"smw-indicator-revision-mismatch-error": "[https://www.semantic-mediawiki.org/wiki/Help:Associated_revision/Examiner 相關修訂]檢查發現在 MediaWiki 引用的修訂之間內容不符合，且關聯到用於此實體的 Semantic MediaWiki。",
 	"smw-indicator-revision-mismatch-comment": "不符合通常表示某些程序中斷了在 Semantic MediaWiki 的儲存操作。建議檢視伺服器日誌並查看例外或其它錯誤。",
-	"smw-listingcontinuesabbrev": "續"
+	"smw-listingcontinuesabbrev": "續",
+	"smw-showingresults": "以下顯示從第 <strong>$2</strong> 筆開始，共 {{PLURAL:$1|<strong>1</strong> 筆結果|<strong>$1</strong> 筆結果}}："
 }

--- a/includes/querypages/QueryPage.php
+++ b/includes/querypages/QueryPage.php
@@ -137,7 +137,7 @@ abstract class QueryPage extends \QueryPage {
 		// during doQuery() which is processed before this form is generated
 		$limit = $this->selectOptions['limit'];
 		$offset = $this->selectOptions['offset'];
-		$resultCount = wfMessage( 'showingresults' )->numParams( $limit, $offset + 1 )->parse();
+		$resultCount = wfMessage( 'smw-showingresults' )->numParams( $limit, $offset + 1 )->parse();
 
 		$msgBuilder =  new MessageBuilder( $this->getLanguage() );
 		$selection = $msgBuilder->prevNextToText(


### PR DESCRIPTION
In reference to this comment: https://github.com/SemanticMediaWiki/SemanticMediaWiki/issues/5335#issuecomment-1359881744

I've copied the original MW messages verbatim, but prefixed them with `smw-`.