### PR TITLE
Fix PHP 8.1 deprecations (during install)

### DIFF
--- a/maintenance/populateHashField.php
+++ b/maintenance/populateHashField.php
@@ -225,7 +225,7 @@ class populateHashField extends \Maintenance {
 	public function populate( \Iterator $rows = null ) {
 
 		$this->cliMsgFormatter = new CliMsgFormatter();
-		$this->cliMsgFormatter->setStartTime( microtime( true ) );
+		$this->cliMsgFormatter->setStartTime( (int) microtime( true ) );
 
 		if ( $rows === null ) {
 			$rows = $this->fetchRows();

--- a/maintenance/rebuildElasticMissingDocuments.php
+++ b/maintenance/rebuildElasticMissingDocuments.php
@@ -302,7 +302,7 @@ class rebuildElasticMissingDocuments extends \Maintenance {
 		);
 
 		$this->reportMessage( "\nInspecting documents ...\n" );
-		$cliMsgFormatter->setStartTime( microtime( true ) );
+		$cliMsgFormatter->setStartTime( (int) microtime( true ) );
 
 		foreach ( $rows as $row ) {
 

--- a/src/SQLStore/PropertyTableRowDiffer.php
+++ b/src/SQLStore/PropertyTableRowDiffer.php
@@ -158,7 +158,7 @@ class PropertyTableRowDiffer {
 			}
 
 			$tableName = $propertyTable->getName();
-			$fixedProperty = false;
+			$fixedProperty = [];
 
 			// Fixed property tables have no p_id declared, the auxiliary
 			// information is provided to easily map fixed tables and
@@ -173,11 +173,11 @@ class PropertyTableRowDiffer {
 						$property
 					);
 				} catch ( DataItemException $e ) {
-					$fixedProperty = false;
+					$fixedProperty = [];
 				}
 			}
 
-			if ( $fixedProperty ) {
+			if ( $fixedProperty !== [] ) {
 				$this->changeOp->addFixedPropertyRecord( $tableName, $fixedProperty );
 			}
 


### PR DESCRIPTION
Refs #5369 

Fixes 2 notices:

> Deprecated: Implicit conversion from float 1671744632.67117 to int loses precision in /var/www/html/extensions/SemanticMediaWiki/src/Utils/CliMsgFormatter.php on line 137

> Deprecated: Automatic conversion of false to array is deprecated in /var/www/html/extensions/SemanticMediaWiki/src/SQLStore/PropertyTableRowDiffer.php on line 167

Separate fix is needed for #5278