### PR TITLE
Fix PHP 8.1 null string deprecations

### DIFF
--- a/includes/querypages/PropertiesQueryPage.php
+++ b/includes/querypages/PropertiesQueryPage.php
@@ -72,7 +72,7 @@ class PropertiesQueryPage extends QueryPage {
 			'p',
 			[ 'class' => 'smw-sp-properties-docu' ],
 			$this->msg( 'smw-sp-properties-docu' )->parse()
-		) . $this->getSearchForm( $this->getRequest()->getVal( 'property' ), $this->getCacheInfo() ) .
+		) . $this->getSearchForm( $this->getRequest()->getVal( 'property', '' ), $this->getCacheInfo() ) .
 		Html::element(
 			'h2',
 			[],

--- a/includes/querypages/UnusedPropertiesQueryPage.php
+++ b/includes/querypages/UnusedPropertiesQueryPage.php
@@ -96,7 +96,7 @@ class UnusedPropertiesQueryPage extends QueryPage {
 			'p',
 			[ 'class' => 'smw-unusedproperties-docu' ],
 			$this->msg( 'smw-unusedproperties-docu' )->parse()
-		) . $this->getSearchForm( $this->getRequest()->getVal( 'property' ), $this->getCacheInfo() ) .
+		) . $this->getSearchForm( $this->getRequest()->getVal( 'property', '' ), $this->getCacheInfo() ) .
 		Html::element(
 			'h2',
 			[],

--- a/includes/querypages/WantedPropertiesQueryPage.php
+++ b/includes/querypages/WantedPropertiesQueryPage.php
@@ -132,7 +132,7 @@ class WantedPropertiesQueryPage extends QueryPage {
 			'p',
 			[ 'class' => 'smw-wantedproperties-docu plainlinks' ],
 			$this->msg( 'smw-special-wantedproperties-docu' )->parse()
-		) . $this->getSearchForm( $this->getRequest()->getVal( 'property' ), $this->getCacheInfo(), false, $filter )  .
+		) . $this->getSearchForm( $this->getRequest()->getVal( 'property', '' ), $this->getCacheInfo(), false, $filter )  .
 		Html::element(
 			'h2',
 			[],

--- a/includes/specials/SMW_SpecialTypes.php
+++ b/includes/specials/SMW_SpecialTypes.php
@@ -47,7 +47,7 @@ class SMWSpecialTypes extends SpecialPage {
 		$out->addModuleStyles( 'ext.smw.page.styles' );
 		$out->addModules( 'smw.property.page' );
 
-		$params = Infolink::decodeParameters( $param, false );
+		$params = Infolink::decodeParameters( $param ?? '', false );
 		$typeLabel = reset( $params );
 
 		if ( $typeLabel == false ) {

--- a/src/MediaWiki/Specials/SpecialBrowse.php
+++ b/src/MediaWiki/Specials/SpecialBrowse.php
@@ -68,7 +68,7 @@ class SpecialBrowse extends SpecialPage {
 
 		$dataValue = DataValueFactory::getInstance()->newTypeIDValue(
 			'_wpg',
-			$articletext
+			$articletext ?? false
 		);
 
 		$out = $this->getOutput();

--- a/src/MediaWiki/Specials/SpecialSearchByProperty.php
+++ b/src/MediaWiki/Specials/SpecialSearchByProperty.php
@@ -74,7 +74,7 @@ class SpecialSearchByProperty extends SpecialPage {
 
 		$pageBuilder = new PageBuilder(
 			$htmlFormRenderer,
-			new PageRequestOptions( $query, $requestOptions ),
+			new PageRequestOptions( $query ?? '', $requestOptions ),
 			new QueryResultLookup( $applicationFactory->getStore() )
 		);
 


### PR DESCRIPTION
Refs #5369 

Various Special spages, when opened without parameters, were passing nulls where strings are expected.

This also fixes the 4 outstanding deprecations from #5373.