### PR TITLE
Make MW 1.39 database tests run

### DIFF
--- a/tests/phpunit/DatabaseTestCase.php
+++ b/tests/phpunit/DatabaseTestCase.php
@@ -2,6 +2,7 @@
 
 namespace SMW\Tests;
 
+use PHPUnit\Framework\TestResult;
 use RuntimeException;
 use SMW\Services\ServicesFactory;
 use SMW\NamespaceExaminer;
@@ -157,7 +158,7 @@ abstract class DatabaseTestCase extends \PHPUnit_Framework_TestCase {
 	 * request a trear down so that the next test can rebuild the tables from
 	 * scratch
 	 */
-	public function run( ?\PHPUnit_Framework_TestResult $result = null ) : \PHPUnit_Framework_TestResult {
+	public function run( ?TestResult $result = null ) : TestResult {
 
 		$this->getStore()->clear();
 

--- a/tests/phpunit/PHPUnitResultPrinter.php
+++ b/tests/phpunit/PHPUnitResultPrinter.php
@@ -10,7 +10,7 @@ class PHPUnitResultPrinter extends PHPUnit_TextUI_ResultPrinter {
 	/**
 	 * @see PHPUnit_TextUI_ResultPrinter::endTestSuite
 	 */
-	public function endTestSuite( PHPUnit_Framework_TestSuite $suite ) {
+	public function endTestSuite( PHPUnit_Framework_TestSuite $suite ): void {
 		parent::endTestSuite( $suite );
 
 		if ( !isset( $suite->_slowTestsReport ) ) {

--- a/tests/phpunit/Utils/Connection/TestDatabaseConnectionProvider.php
+++ b/tests/phpunit/Utils/Connection/TestDatabaseConnectionProvider.php
@@ -41,7 +41,14 @@ class TestDatabaseConnectionProvider implements ConnectionProvider {
 			return $this->connection;
 		}
 
-		return $this->connection = $this->getLoadBalancer()->getConnection( $this->id );
+		$loadBalancer = $this->getLoadBalancer();
+
+		// MW 1.39
+		if ( method_exists( $loadBalancer, 'getConnectionInternal' ) ) {
+			return $this->connection = $loadBalancer->getConnectionInternal( $this->id );
+		}
+
+		return $this->connection = $loadBalancer->getConnection( $this->id );
 	}
 
 	public function releaseConnection() {

--- a/tests/phpunit/Utils/File/JsonFileReader.php
+++ b/tests/phpunit/Utils/File/JsonFileReader.php
@@ -27,8 +27,8 @@ class JsonFileReader {
 	 *
 	 * @param string|null $file
 	 */
-	public function __construct( $file = null ) {
-		$this->setFile( $file );
+	public function __construct( ?string $file = null ) {
+		$this->setFile( $file ?? '' );
 	}
 
 	/**
@@ -36,7 +36,7 @@ class JsonFileReader {
 	 *
 	 * @param string $file
 	 */
-	public function setFile( $file ) {
+	public function setFile( string $file ) {
 		$this->file = str_replace( [ '\\', '/' ], DIRECTORY_SEPARATOR, $file );
 		$this->contents = null;
 	}


### PR DESCRIPTION
This is going to cause the 1.39 run to fail, although it ends up running a lot more tests. It was previously skipping all tests subclassing `DatabaseTestCase` due to a change in `getConnection()` vs `getConnectionInternal()`. 

Important to note is that this method is marked `@internal`, but it does what the previous method did before MW 1.39:
https://github.com/wikimedia/mediawiki/blob/a128b08c67bbe7b3b3c34172b404b8a1d2f36bd5/includes/libs/rdbms/loadbalancer/ILoadBalancer.php#L315-L323

Initial run:
https://github.com/SemanticMediaWiki/SemanticMediaWiki/actions/runs/3768185100/jobs/6406407733#step:11:3817
![Screenshot_20221223_230607](https://user-images.githubusercontent.com/1428594/209405501-4293f4d7-eed3-4eb5-8089-f8872a9fbc11.png)

Compared to MW 1.38:
![Screenshot_20221223_231334](https://user-images.githubusercontent.com/1428594/209406044-d27928cf-316b-4b8c-a199-7275ae838aa6.png)

----

This bigger execution reveals more deprecations to be followed up on separately.