### PR TITLE
Fix RDF Export null string deprecation

### DIFF
--- a/includes/specials/SMW_SpecialOWLExport.php
+++ b/includes/specials/SMW_SpecialOWLExport.php
@@ -178,7 +178,7 @@ class SMWSpecialOWLExport extends SpecialPage {
 
 		$date = $wgRequest->getText( 'date' );
 		if ( $date === '' ) {
-			$date = $wgRequest->getVal( 'date' );
+			$date = $wgRequest->getVal( 'date', '' );
 		}
 
 		if ( $date !== '' ) {


### PR DESCRIPTION
Refs #5369 

On PHP 8.1 a deprecation notice is shown when doing an RDF export using a page's "RDF" link: 
![Screenshot_20221227_140956](https://user-images.githubusercontent.com/1428594/209664776-7108b00a-55c2-4292-9461-7240584005a8.png)
Resulting URL: `/index.php?title=Special:ExportRDF/Foo_Bar&syntax=rdf`

This leads to an invalid XML document:
![Screenshot_20221227_141049](https://user-images.githubusercontent.com/1428594/209664867-9edde491-5df9-4d47-85f8-2918cc3a3cf2.png)

Due to the presence of this text:
> <b>Deprecated</b>:  strtotime(): Passing null to parameter 1 ($datetime) of type string is deprecated in <b>/var/www/html/extensions/SemanticMediaWiki/includes/specials/SMW_SpecialOWLExport.php</b> on line <b>185</b><br />



