### PR TITLE
Fix some PHP 8.2 deprecations

### DIFF
--- a/includes/dataitems/SMW_DI_Property.php
+++ b/includes/dataitems/SMW_DI_Property.php
@@ -75,6 +75,8 @@ class DIProperty extends SMWDataItem {
 	 */
 	private $interwiki = '';
 
+	public int $id;
+
 	/**
 	 * Initialise a property. This constructor checks that keys of
 	 * predefined properties do really exist (in the current configuration

--- a/includes/formatters/MessageFormatter.php
+++ b/includes/formatters/MessageFormatter.php
@@ -38,6 +38,8 @@ class MessageFormatter {
 	/** @var boolean */
 	protected $escape = true;
 
+	private Language $language;
+
 	/**
 	 * @since 1.9
 	 *

--- a/src/DataTypeRegistry.php
+++ b/src/DataTypeRegistry.php
@@ -27,10 +27,7 @@ class DataTypeRegistry {
 	 */
 	protected static $instance = null;
 
-	/**
-	 * @var LocalLanguage
-	 */
-	private $LocalLanguage;
+	private LocalLanguage $localLanguage;
 
 	/**
 	 * Array of type labels indexed by type ids. Used for datatype resolution.

--- a/src/Localizer/Localizer.php
+++ b/src/Localizer/Localizer.php
@@ -35,6 +35,8 @@ class Localizer {
 	 */
 	private $contentLanguage = null;
 
+	private NamespaceInfo $namespaceInfo;
+
 	/** @var IContextSource */
 	private $context = null;
 

--- a/src/MediaWiki/Connection/TransactionHandler.php
+++ b/src/MediaWiki/Connection/TransactionHandler.php
@@ -4,6 +4,7 @@ namespace SMW\MediaWiki\Connection;
 
 use RuntimeException;
 use Wikimedia\Rdbms\ILBFactory;
+use Wikimedia\Rdbms\TransactionProfiler;
 
 /**
  * @license GNU GPL v2+
@@ -28,6 +29,8 @@ class TransactionHandler {
 	 */
 	private $mutedTransactionProfiler;
 
+	private TransactionProfiler $transactionProfiler;
+
 	/**
 	 * @since 3.1
 	 */
@@ -41,11 +44,7 @@ class TransactionHandler {
 	 * @param TransactionProfiler $transactionProfiler
 	 */
 	public function setTransactionProfiler( $transactionProfiler ) {
-
-		// MW 1.28+
-		if ( method_exists( $transactionProfiler, 'setSilenced' ) ) {
-			$this->transactionProfiler = $transactionProfiler;
-		}
+		$this->transactionProfiler = $transactionProfiler;
 	}
 
 	/**

--- a/src/MediaWiki/Specials/Browse/HtmlBuilder.php
+++ b/src/MediaWiki/Specials/Browse/HtmlBuilder.php
@@ -12,6 +12,7 @@ use SMW\RequestOptions;
 use SMW\SemanticData;
 use SMW\Store;
 use SMW\Utils\HtmlDivTable;
+use SMWDataValue;
 
 /**
  * @license GNU GPL v2+
@@ -86,6 +87,10 @@ class HtmlBuilder {
 	 * @var array
 	 */
 	private $language = 'en';
+
+	private SMWDataValue $dataValue;
+
+	private string $articletext;
 
 	/**
 	 * @since 2.5

--- a/src/NamespaceManager.php
+++ b/src/NamespaceManager.php
@@ -22,9 +22,9 @@ class NamespaceManager {
 	const DEFAULT_NAMESPACEINDEX = 100;
 
 	/**
-	 * @var LocalLanguage
+	 * @var LocalLanguage|null
 	 */
-	private $LocalLanguage;
+	private $localLanguage;
 
 	/**
 	 * @var string

--- a/src/Parser/InTextAnnotationParser.php
+++ b/src/Parser/InTextAnnotationParser.php
@@ -182,7 +182,7 @@ class InTextAnnotationParser {
 
 		$text = preg_replace_callback(
 			$this->getRegexpPattern( $linksInValuesPcre ),
-			$linksInValuesPcre ? 'self::process' : 'self::preprocess',
+			$linksInValuesPcre ? self::class . '::process' : self::class . '::preprocess',
 			$text
 		);
 

--- a/src/ParserFunctions/AskParserFunction.php
+++ b/src/ParserFunctions/AskParserFunction.php
@@ -2,6 +2,7 @@
 
 namespace SMW\ParserFunctions;
 
+use ParamProcessor\ProcessedParam;
 use Parser;
 use SMW\Services\ServicesFactory as ApplicationFactory;
 use SMW\DIProperty;
@@ -89,6 +90,11 @@ class AskParserFunction {
 	 * @var RecursiveTextProcessor
 	 */
 	private $recursiveTextProcessor;
+
+	/**
+	 * @var ProcessedParam[]
+	 */
+	private array $params;
 
 	/**
 	 * @since 1.9

--- a/src/Property/Annotators/CategoryPropertyAnnotator.php
+++ b/src/Property/Annotators/CategoryPropertyAnnotator.php
@@ -53,6 +53,8 @@ class CategoryPropertyAnnotator extends PropertyAnnotatorDecorator {
 	 */
 	private $useCategoryRedirect = true;
 
+	private ProcessingErrorMsgHandler $processingErrorMsgHandler;
+
 	/**
 	 * @since 1.9
 	 *

--- a/src/RequestOptions.php
+++ b/src/RequestOptions.php
@@ -118,6 +118,12 @@ class RequestOptions {
 	 */
 	private $caller;
 
+	public bool $conditionConstraint;
+
+	public bool $isChain;
+
+	public bool $isFirstChain;
+
 	/**
 	 * @since 3.1
 	 *

--- a/src/Utils/Timer.php
+++ b/src/Utils/Timer.php
@@ -21,6 +21,11 @@ class Timer {
 	private $times = [];
 
 	/**
+	 * @var string[]
+	 */
+	public array $keys;
+
+	/**
 	 * @since 3.0
 	 *
 	 * @param integer $outputType


### PR DESCRIPTION
First round of fixing a bunch of PHP 8.2 deprecations. These are primarily due to dynamic property creation.

Some of these are `public` scope, which I suppose is bad practice, but this allows the current code to work as-is.