### PR TITLE
Refactor EditInfo constructor parameter order

### DIFF
--- a/src/MediaWiki/EditInfo.php
+++ b/src/MediaWiki/EditInfo.php
@@ -44,10 +44,10 @@ class EditInfo {
 	 * @since 1.9
 	 *
 	 * @param WikiPage $page
+	 * @param User $user
 	 * @param ?RevisionRecord $revision
-	 * @param ?User $user
 	 */
-	public function __construct( WikiPage $page, ?RevisionRecord $revision = null, User $user ) {
+	public function __construct( WikiPage $page, User $user, ?RevisionRecord $revision = null ) {
 		$this->page = $page;
 		$this->revision = $revision;
 		$this->user = $user;

--- a/src/MediaWiki/MwCollaboratorFactory.php
+++ b/src/MediaWiki/MwCollaboratorFactory.php
@@ -221,7 +221,7 @@ class MwCollaboratorFactory {
 			$user = RequestContext::getMain()->getUser();
 		}
 
-		$editInfo = new EditInfo( $wikiPage, $revision, $user );
+		$editInfo = new EditInfo( $wikiPage, $user, $revision );
 
 		$editInfo->setRevisionGuard(
 			$this->applicationFactory->singleton( 'RevisionGuard' )

--- a/tests/phpunit/MediaWiki/EditInfoTest.php
+++ b/tests/phpunit/MediaWiki/EditInfoTest.php
@@ -39,7 +39,7 @@ class EditInfoTest extends \PHPUnit_Framework_TestCase {
 
 		$this->assertInstanceOf(
 			EditInfo::class,
-			new EditInfo( $wikiPage, $revision, $user )
+			new EditInfo( $wikiPage, $user, $revision )
 		);
 	}
 
@@ -49,8 +49,8 @@ class EditInfoTest extends \PHPUnit_Framework_TestCase {
 	public function testFetchContentInfo( $parameters, $expected ) {
 		$instance = new EditInfo(
 			$parameters['wikiPage'],
-			$parameters['revision'],
-			$parameters['user']
+			$parameters['user'],
+			$parameters['revision']
 		);
 
 		$this->assertEquals(
@@ -82,8 +82,8 @@ class EditInfoTest extends \PHPUnit_Framework_TestCase {
 
 		$instance = new EditInfo(
 			$wikiPage,
-			$this->newRevisionStub(),
-			$user
+			$user,
+			$this->newRevisionStub()
 		);
 
 		$this->assertInstanceOf(


### PR DESCRIPTION
Fixes #5388

This fixes the constructor signature after #5091.

I don't know if this was ever meant to be part of a public API, so I'm not sure if this should be considered a breaking/major change. However, I cannot think of a different way to solve the issue, because there is still some logic where `revision` can be null.