### PR TITLE
Remove EditInfo optional parameter

### DIFF
--- a/src/MediaWiki/EditInfo.php
+++ b/src/MediaWiki/EditInfo.php
@@ -42,12 +42,8 @@ class EditInfo {
 
 	/**
 	 * @since 1.9
-	 *
-	 * @param WikiPage $page
-	 * @param ?RevisionRecord $revision
-	 * @param ?User $user
 	 */
-	public function __construct( WikiPage $page, ?RevisionRecord $revision = null, User $user ) {
+	public function __construct( WikiPage $page, ?RevisionRecord $revision, User $user ) {
 		$this->page = $page;
 		$this->revision = $revision;
 		$this->user = $user;


### PR DESCRIPTION
Fixes https://github.com/SemanticMediaWiki/SemanticMediaWiki/issues/5388

This fixes the constructor signature after #5091.

I don't know if this was ever meant to be part of a public API, so I'm not sure if this should be considered a breaking/major change. However, this is an almost similar change as in #5091, so if any downstream code was constructing `EditInfo` and expecting to have default values it would've broken in any case. The only difference is in this case it still needs to be nullable, since there is some logic based on that.

The alternative would be to rearrange the order, but I'm not sure if that is any better and would still raise the question of whether this is a breaking change.