### PR TITLE
Do not process UserChange if `$user` is null

### DIFF
--- a/src/MediaWiki/Hooks/UserChange.php
+++ b/src/MediaWiki/Hooks/UserChange.php
@@ -63,7 +63,7 @@ class UserChange implements HookListener {
 			return false;
 		}
 
-		// getTargetUserIdentity returns null if it isnot user(eg. CIDR) 
+		// getTargetUserIdentity returns null if it is not user(eg. CIDR) 
 		// https://github.com/SemanticMediaWiki/SemanticMediaWiki/issues/5263
 		if ( $user === null ) {
 			return false;

--- a/src/MediaWiki/Hooks/UserChange.php
+++ b/src/MediaWiki/Hooks/UserChange.php
@@ -55,7 +55,7 @@ class UserChange implements HookListener {
 	/**
 	 * @since 3.0
 	 *
-	 * @param UserIdentity|string $user
+	 * @param UserIdentity|string|null $user
 	 */
 	public function process( $user ) {
 

--- a/src/MediaWiki/Hooks/UserChange.php
+++ b/src/MediaWiki/Hooks/UserChange.php
@@ -63,6 +63,12 @@ class UserChange implements HookListener {
 			return false;
 		}
 
+		// getTargetUserIdentity returns null if it isnot user(eg. CIDR) 
+		// https://github.com/SemanticMediaWiki/SemanticMediaWiki/issues/5263
+		if ( $user === null ) {
+			return false;
+		}
+
 		if ( $user instanceof UserIdentity ) {
 			$user = $user->getName();
 		}


### PR DESCRIPTION
`$user` is null when CIDR block occurs because type of block is not `TYPE_USER`. Fix #5263

> Get the UserIdentity identifying the blocked user, if the target is indeed a user (that is, if [getType()](https://doc.wikimedia.org/mediawiki-core/master/php/interfaceMediaWiki_1_1Block_1_1Block.html#ae3fd2182e1e85dc056b0b6fe8f1f9a96) returns TYPE_USER).

CC: https://doc.wikimedia.org/mediawiki-core/master/php/interfaceMediaWiki_1_1Block_1_1Block.html#a4d6f365ad914e79b505af92084e18dc2

Note: `getTarget`(<1.37) returns `User|string|null`, `getTargetUserIdentity`(>=1.37) returns `?UserIdentity`