### PR TITLE
Replace deprecated usages

### DIFF
--- a/src/Localizer/Localizer.php
+++ b/src/Localizer/Localizer.php
@@ -5,6 +5,7 @@ namespace SMW\Localizer;
 use DateTime;
 use IContextSource;
 use Language;
+use MediaWiki\MediaWikiServices;
 use MediaWiki\User\UserOptionsLookup;
 use RequestContext;
 use SMW\Localizer\LocalLanguage\LocalLanguage;
@@ -210,7 +211,8 @@ class Localizer {
 			return $this->getContentLanguage();
 		}
 
-		return Language::factory( $languageCode );
+		$languageFactory = MediaWikiServices::getInstance()->getLanguageFactory();
+		return $languageFactory->getLanguage( $languageCode );
 	}
 
 	/**

--- a/src/Localizer/Localizer.php
+++ b/src/Localizer/Localizer.php
@@ -303,20 +303,16 @@ class Localizer {
 	public static function isKnownLanguageTag( $languageCode ) {
 
 		$languageCode = mb_strtolower( $languageCode );
+		$languageNameUtils = MediaWikiServices::getInstance()->getLanguageNameUtils();
 
-		// FIXME 1.19 doesn't know Language::isKnownLanguageTag
-		if ( !method_exists( '\Language', 'isKnownLanguageTag' ) ) {
-			return Language::isValidBuiltInCode( $languageCode );
-		}
-
-		return Language::isKnownLanguageTag( $languageCode );
+		return $languageNameUtils->isKnownLanguageTag( $languageCode );
 	}
 
 	/**
 	 * @see IETF language tag / BCP 47 standards
 	 *
 	 * @since 2.4
-	 *
+	 * 
 	 * @param string $languageCode
 	 *
 	 * @return string

--- a/src/Localizer/Localizer.php
+++ b/src/Localizer/Localizer.php
@@ -312,7 +312,7 @@ class Localizer {
 	 * @see IETF language tag / BCP 47 standards
 	 *
 	 * @since 2.4
-	 * 
+	 *
 	 * @param string $languageCode
 	 *
 	 * @return string

--- a/src/MediaWiki/Jobs/UpdateJob.php
+++ b/src/MediaWiki/Jobs/UpdateJob.php
@@ -111,7 +111,9 @@ class UpdateJob extends Job {
 			DIWikiPage::newFromTitle( $title )
 		);
 
-		if ( $lastModified !== \WikiPage::factory( $title )->getTimestamp() ) {
+		$wikiPage = $this->applicationFactory->newPageCreator()->createPage( $title );
+
+		if ( $lastModified !== $wikiPage->getTimestamp() ) {
 			return false;
 		}
 

--- a/tests/phpunit/Factbox/CachedFactboxTest.php
+++ b/tests/phpunit/Factbox/CachedFactboxTest.php
@@ -4,6 +4,7 @@ namespace SMW\Tests\Factbox;
 
 use Language;
 use ParserOutput;
+use MediaWiki\MediaWikiServices;
 use SMW\Services\ServicesFactory as ApplicationFactory;
 use SMW\DIProperty;
 use SMW\DIWikiPage;
@@ -178,7 +179,7 @@ class CachedFactboxTest extends \PHPUnit_Framework_TestCase {
 			'Asserts that content from the outputpage property and retrieveContent() is equal'
 		);
 
-		if ( isset( $expected['isCached'] ) &&  $expected['isCached'] ) {
+		if ( isset( $expected['isCached'] ) && $expected['isCached'] ) {
 
 			$this->assertTrue(
 				$instance->isCached(),
@@ -196,7 +197,8 @@ class CachedFactboxTest extends \PHPUnit_Framework_TestCase {
 
 	public function outputDataProvider() {
 
-		$language = Language::factory( 'en' );
+		$languageFactory = MediaWikiServices::getInstance()->getLanguageFactory();
+		$language = $languageFactory->getLanguage( 'en' );
 
 		$title = MockTitle::buildMockForMainNamespace( __METHOD__ . 'mock-subject' );
 

--- a/tests/phpunit/JSONScriptTestCaseRunner.php
+++ b/tests/phpunit/JSONScriptTestCaseRunner.php
@@ -2,6 +2,7 @@
 
 namespace SMW\Tests;
 
+use MediaWiki\MediaWikiServices;
 use SMW\Tests\Utils\JSONScript\JsonTestCaseContentHandler;
 use SMW\Tests\Utils\JSONScript\JsonTestCaseFileHandler;
 use SMW\Tests\Utils\UtilityFactory;
@@ -158,7 +159,8 @@ abstract class JSONScriptTestCaseRunner extends DatabaseTestCase {
 			\SMW\Localizer::getInstance()->clear();
 			// #4682, Avoid any surprises when the `wgLanguageCode` is changed during a test
 			\SMW\NamespaceManager::clear();
-			$lang = \Language::factory( $val );
+			$languageFactory = MediaWikiServices::getInstance()->getLanguageFactory();
+			$lang = $languageFactory->getLanguage( $val );
 
 			// https://github.com/wikimedia/mediawiki/commit/49ce67be93dfbb40d036703dad2278ea9843f1ad
 			$this->testEnvironment->redefineMediaWikiService( 'ContentLanguage', function () use ( $lang ) {
@@ -172,7 +174,9 @@ abstract class JSONScriptTestCaseRunner extends DatabaseTestCase {
 			\RequestContext::getMain()->setLanguage( $val );
 			\SMW\Localizer::getInstance()->clear();
 			\SMW\NamespaceManager::clear();
-			return \Language::factory( $val );
+			$languageFactory = MediaWikiServices::getInstance()->getLanguageFactory();
+			$lang = $languageFactory->getLanguage( $val );
+			return $lang;
 		} );
 
 		return [];

--- a/tests/phpunit/Localizer/LocalizerTest.php
+++ b/tests/phpunit/Localizer/LocalizerTest.php
@@ -3,6 +3,7 @@
 namespace SMW\Tests\Localizer;
 
 use Language;
+use MediaWiki\MediaWikiServices;
 use SMW\Localizer\Localizer;
 
 /**
@@ -63,8 +64,10 @@ class LocalizerTest extends \PHPUnit_Framework_TestCase {
 
 	public function testNamespaceTextById() {
 
+		$languageFactory = MediaWikiServices::getInstance()->getLanguageFactory();
+
 		$instance = new Localizer(
-			Language::factory( 'en' ),
+			$languageFactory->getLanguage( 'en' ),
 			$this->namespaceInfo
 		);
 
@@ -76,8 +79,10 @@ class LocalizerTest extends \PHPUnit_Framework_TestCase {
 
 	public function testNamespaceIndexByName() {
 
+		$languageFactory = MediaWikiServices::getInstance()->getLanguageFactory();
+
 		$instance = new Localizer(
-			Language::factory( 'en'),
+			$languageFactory->getLanguage( 'en' ),
 			$this->namespaceInfo
 		);
 
@@ -271,8 +276,10 @@ class LocalizerTest extends \PHPUnit_Framework_TestCase {
 
 	public function testCreateTextWithNamespacePrefix() {
 
+		$languageFactory = MediaWikiServices::getInstance()->getLanguageFactory();
+
 		$instance = new Localizer(
-			Language::factory( 'en'),
+			$languageFactory->getLanguage( 'en' ),
 			$this->namespaceInfo
 		);
 

--- a/tests/phpunit/MediaWiki/Hooks/OutputPageParserOutputTest.php
+++ b/tests/phpunit/MediaWiki/Hooks/OutputPageParserOutputTest.php
@@ -4,6 +4,7 @@ namespace SMW\Tests\MediaWiki\Hooks;
 
 use Language;
 use ParserOutput;
+use MediaWiki\MediaWikiServices;
 use SMW\Services\ServicesFactory as ApplicationFactory;
 use SMW\DIProperty;
 use SMW\DIWikiPage;
@@ -152,7 +153,8 @@ class OutputPageParserOutputTest extends \PHPUnit_Framework_TestCase {
 
 	public function outputDataProvider() {
 
-		$language = Language::factory( 'en' );
+		$languageFactory = MediaWikiServices::getInstance()->getLanguageFactory();
+		$language = $languageFactory->getLanguage( 'en' );
 
 		$title = MockTitle::buildMockForMainNamespace( __METHOD__ . 'mock-subject' );
 

--- a/tests/phpunit/MediaWiki/Specials/SpecialBrowseTest.php
+++ b/tests/phpunit/MediaWiki/Specials/SpecialBrowseTest.php
@@ -2,6 +2,7 @@
 
 namespace SMW\Tests\MediaWiki\Specials;
 
+use MediaWiki\MediaWikiServices;
 use SMW\MediaWiki\Specials\SpecialBrowse;
 use SMW\Tests\TestEnvironment;
 use Title;
@@ -55,8 +56,9 @@ class SpecialBrowseTest extends \PHPUnit_Framework_TestCase {
 			Title::newFromText( 'SpecialBrowse' )
 		);
 
+		$languageFactory = MediaWikiServices::getInstance()->getLanguageFactory();
 		$instance->getContext()->setLanguage(
-			\Language::factory( 'en' )
+			$languageFactory->getLanguage( 'en' )
 		);
 
 		$instance->execute( $query );

--- a/tests/phpunit/ParserFunctions/RecurringEventsParserFunctionTest.php
+++ b/tests/phpunit/ParserFunctions/RecurringEventsParserFunctionTest.php
@@ -4,6 +4,7 @@ namespace SMW\Tests\ParserFunctions;
 
 use ParserOutput;
 use ReflectionClass;
+use MediaWiki\MediaWikiServices;
 use SMW\MessageFormatter;
 use SMW\ParserData;
 use SMW\RecurringEvents;
@@ -57,10 +58,12 @@ class RecurringEventsParserFunctionTest extends \PHPUnit_Framework_TestCase {
 
 		$title = Title::newFromText( __METHOD__ );
 
+		$languageFactory = MediaWikiServices::getInstance()->getLanguageFactory();
+
 		$instance = new RecurringEventsParserFunction(
 			new ParserData( $title, new ParserOutput() ),
 			new Subobject( $title ),
-			new MessageFormatter( \Language::factory( 'en' ) ),
+			new MessageFormatter( $languageFactory->getLanguage( 'en' ) ),
 			$recurringEvents
 		);
 

--- a/tests/phpunit/SemanticMediaWikiTestCase.php
+++ b/tests/phpunit/SemanticMediaWikiTestCase.php
@@ -6,6 +6,7 @@ use FauxRequest;
 use Language;
 use ReflectionClass;
 use RequestContext;
+use MediaWiki\MediaWikiServices;
 use SMW\DependencyContainer;
 use SMW\DIWikiPage;
 use SMW\Settings;
@@ -130,7 +131,8 @@ abstract class SemanticMediaWikiTestCase extends \PHPUnit_Framework_TestCase {
 	 * @return Language
 	 */
 	protected function getLanguage( $langCode = 'en' ) {
-		return Language::factory( $langCode );
+		$languageFactory = MediaWikiServices::getInstance()->getLanguageFactory();
+		return $languageFactory->getLanguage( $langCode );
 	}
 
 	/**

--- a/tests/phpunit/SpecialPageTestCase.php
+++ b/tests/phpunit/SpecialPageTestCase.php
@@ -6,6 +6,7 @@ use FauxRequest;
 use Language;
 use OutputPage;
 use RequestContext;
+use MediaWiki\MediaWikiServices;
 use SMW\Tests\Utils\Mock\MockSuperUser;
 use SpecialPage;
 use WebRequest;
@@ -119,6 +120,8 @@ abstract class SpecialPageTestCase extends \PHPUnit_Framework_TestCase {
 	 */
 	private function makeRequestContext( WebRequest $request, $user, $title ) {
 
+		$languageFactory = MediaWikiServices::getInstance()->getLanguageFactory();
+
 		$context = new RequestContext();
 		$context->setRequest( $request );
 
@@ -126,7 +129,7 @@ abstract class SpecialPageTestCase extends \PHPUnit_Framework_TestCase {
 		$out->setTitle( $title );
 
 		$context->setOutput( $out );
-		$context->setLanguage( Language::factory( 'en' ) );
+		$context->setLanguage( $languageFactory->getLanguage( 'en' ) );
 
 		$user = $user === null ? new MockSuperUser() : $user;
 		$context->setUser( $user );

--- a/tests/phpunit/Utils/JSONScript/SpecialPageTestCaseProcessor.php
+++ b/tests/phpunit/Utils/JSONScript/SpecialPageTestCaseProcessor.php
@@ -179,6 +179,8 @@ class SpecialPageTestCaseProcessor extends \PHPUnit_Framework_TestCase {
 	 */
 	private function makeRequestContext( \WebRequest $request, $user, $title ) {
 
+		$languageFactory = MediaWikiServices::getInstance()->getLanguageFactory();
+
 		$context = new RequestContext();
 		$context->setRequest( $request );
 
@@ -186,7 +188,7 @@ class SpecialPageTestCaseProcessor extends \PHPUnit_Framework_TestCase {
 		$out->setTitle( $title );
 
 		$context->setOutput( $out );
-		$context->setLanguage( Language::factory( $GLOBALS['wgLanguageCode'] ) );
+		$context->setLanguage( $languageFactory->getLanguage( $GLOBALS['wgLanguageCode'] ));
 
 		$user = $user === null ? new MockSuperUser() : $user;
 		$context->setUser( $user );

--- a/tests/phpunit/includes/specials/SpecialsTest.php
+++ b/tests/phpunit/includes/specials/SpecialsTest.php
@@ -78,12 +78,15 @@ class SpecialsTest extends SemanticMediaWikiTestCase {
 	 */
 	public function testSpecialAliasesContLang( SpecialPage $specialPage ) {
 
+		$languageFactory = MediaWikiServices::getInstance()->getLanguageFactory();
+
 		// Test for languages
 		$langCodes = [ 'en', 'fr', 'de', 'es', 'zh', 'ja' ];
 
 		// Test aliases for a specific language
 		foreach ( $langCodes as $langCode ) {
-			$langObj = Language::factory( $langCode );
+			$langObj = $languageFactory->getLanguage( $langCode );
+
 			$aliases = $langObj->getSpecialPageAliases();
 			$found = false;
 			$name = $specialPage->getName();


### PR DESCRIPTION
`Language::factory` and `Language::isKnownLanguageTag` does not need to compat with older MW version as since both are available on 1.35+ and SMW 4.1 support range starts with 1.35.
(Plus, removed 1.19 leftover too)
`WikiPage::factory` is need to compat with 1.35 and there's implemented on d4d5137ee8c3b816c9cf6c446a34163137569906 (It's leftover by the way.)