### PR TITLE
Move Factbox text into a service

### DIFF
--- a/src/Factbox/CachedFactbox.php
+++ b/src/Factbox/CachedFactbox.php
@@ -66,13 +66,16 @@ class CachedFactbox {
 	 */
 	private $timestamp;
 
+	private FactboxText $factboxText;
+
 	/**
 	 * @since 1.9
 	 *
 	 * @param EntityCache $entityCache
 	 */
-	public function __construct( EntityCache $entityCache ) {
+	public function __construct( EntityCache $entityCache, FactboxText $factboxText ) {
 		$this->entityCache = $entityCache;
+		$this->factboxText = $factboxText;
 	}
 
 	/**
@@ -168,9 +171,7 @@ class CachedFactbox {
 	 */
 	public function prepare( OutputPage &$outputPage, ParserOutput $parserOutput ) {
 
-		$factboxText = ApplicationFactory::getInstance()->getFactboxText();
-
-		$factboxText->clear();
+		$this->factboxText->clear();
 		$time = -microtime( true );
 
 		$context = $outputPage->getContext();
@@ -210,7 +211,7 @@ class CachedFactbox {
 				[ 'rev_id' => $rev_id, 'lang' => $lang, 'procTime' => microtime( true ) + $time ]
 			);
 
-			$factboxText->setText( $content['text'] );
+			$this->factboxText->setText( $content['text'] );
 			return;
 		}
 
@@ -220,7 +221,7 @@ class CachedFactbox {
 			$checkMagicWords
 		);
 
-		$factboxText->setText( $text );
+		$this->factboxText->setText( $text );
 
 		if ( $isPreview ) {
 			return;
@@ -282,10 +283,8 @@ class CachedFactbox {
 			return $text;
 		}
 
-		$factboxText = ApplicationFactory::getInstance()->getFactboxText();
-
-		if ( $factboxText->hasText() ) {
-			$text = $factboxText->getText();
+		if ( $this->factboxText->hasText() ) {
+			$text = $this->factboxText->getText();
 		} elseif ( $title instanceof Title ) {
 
 			$context = $outputPage->getContext();

--- a/src/Factbox/CachedFactbox.php
+++ b/src/Factbox/CachedFactbox.php
@@ -168,7 +168,9 @@ class CachedFactbox {
 	 */
 	public function prepare( OutputPage &$outputPage, ParserOutput $parserOutput ) {
 
-		$outputPage->mSMWFactboxText = null;
+		$factboxText = ApplicationFactory::getInstance()->getFactboxText();
+
+		$factboxText->clear();
 		$time = -microtime( true );
 
 		$context = $outputPage->getContext();
@@ -208,7 +210,8 @@ class CachedFactbox {
 				[ 'rev_id' => $rev_id, 'lang' => $lang, 'procTime' => microtime( true ) + $time ]
 			);
 
-			return $outputPage->mSMWFactboxText = $content['text'];
+			$factboxText->setText( $content['text'] );
+			return;
 		}
 
 		$text = $this->rebuild(
@@ -217,7 +220,7 @@ class CachedFactbox {
 			$checkMagicWords
 		);
 
-		$outputPage->mSMWFactboxText = $text;
+		$factboxText->setText( $text );
 
 		if ( $isPreview ) {
 			return;
@@ -279,8 +282,10 @@ class CachedFactbox {
 			return $text;
 		}
 
-		if ( isset( $outputPage->mSMWFactboxText ) ) {
-			$text = $outputPage->mSMWFactboxText;
+		$factboxText = ApplicationFactory::getInstance()->getFactboxText();
+
+		if ( $factboxText->hasText() ) {
+			$text = $factboxText->getText();
 		} elseif ( $title instanceof Title ) {
 
 			$context = $outputPage->getContext();

--- a/src/Factbox/Factbox.php
+++ b/src/Factbox/Factbox.php
@@ -78,6 +78,8 @@ class Factbox {
 	 */
 	private $checkMagicWords;
 
+	private AttachmentFormatter $attachmentFormatter;
+
 	/**
 	 * @since 1.9
 	 *

--- a/src/Factbox/FactboxFactory.php
+++ b/src/Factbox/FactboxFactory.php
@@ -38,7 +38,8 @@ class FactboxFactory {
 		$settings = $applicationFactory->getSettings();
 
 		$cachedFactbox = new CachedFactbox(
-			$applicationFactory->getEntityCache()
+			$applicationFactory->getEntityCache(),
+			$applicationFactory->getFactboxText()
 		);
 
 		// Month = 30 * 24 * 3600

--- a/src/Factbox/FactboxText.php
+++ b/src/Factbox/FactboxText.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace SMW\Factbox;
+
+class FactboxText {
+
+	private ?string $text = null;
+
+	public function clear(): void {
+		$this->text = null;
+	}
+
+	public function setText( ?string $text ): void {
+		$this->text = $text;
+	}
+
+	public function getText(): ?string {
+		return $this->text;
+	}
+
+	public function hasText(): bool {
+		return $this->text !== null;
+	}
+
+}

--- a/src/Factbox/FactboxText.php
+++ b/src/Factbox/FactboxText.php
@@ -22,4 +22,8 @@ class FactboxText {
 		return $this->text !== null;
 	}
 
+	public function hasNonEmptyText(): bool {
+		return $this->text !== null && $this->text !== '';
+	}
+
 }

--- a/src/MediaWiki/Hooks.php
+++ b/src/MediaWiki/Hooks.php
@@ -433,7 +433,8 @@ class Hooks {
 
 		$outputPageParserOutput = new OutputPageParserOutput(
 			$applicationFactory->getNamespaceExaminer(),
-			$permissionExaminer
+			$permissionExaminer,
+			$applicationFactory->getFactboxText()
 		);
 
 		$preferenceExaminer = $applicationFactory->newPreferenceExaminer( $outputPage->getUser() );

--- a/src/MediaWiki/Hooks/OutputPageParserOutput.php
+++ b/src/MediaWiki/Hooks/OutputPageParserOutput.php
@@ -131,13 +131,13 @@ class OutputPageParserOutput implements HookListener {
 
 	protected function addFactbox( OutputPage $outputPage, ParserOutput $parserOutput ) {
 
-		$applicationFactory = ApplicationFactory::getInstance();
-
 		$request = $outputPage->getContext()->getRequest();
 
 		if ( $this->factboxText->hasText() && $request->getCheck( 'wpPreview' ) ) {
 			return '';
 		}
+
+		$applicationFactory = ApplicationFactory::getInstance();
 
 		$cachedFactbox = $applicationFactory->singleton( 'FactboxFactory' )->newCachedFactbox();
 

--- a/src/MediaWiki/Hooks/OutputPageParserOutput.php
+++ b/src/MediaWiki/Hooks/OutputPageParserOutput.php
@@ -4,6 +4,7 @@ namespace SMW\MediaWiki\Hooks;
 
 use OutputPage;
 use ParserOutput;
+use SMW\Factbox\FactboxText;
 use SMW\Services\ServicesFactory as ApplicationFactory;
 use SMW\MediaWiki\IndicatorRegistry;
 use SMW\NamespaceExaminer;
@@ -45,15 +46,19 @@ class OutputPageParserOutput implements HookListener {
 	 */
 	private $indicatorRegistry;
 
+	private FactboxText $factboxText;
+
 	/**
 	 * @since 1.9
-	 *
-	 * @param NamespaceExaminer $namespaceExaminer
-	 * @param PermissionExaminer $permissionExaminer
 	 */
-	public function __construct( NamespaceExaminer $namespaceExaminer, PermissionExaminer $permissionExaminer ) {
+	public function __construct(
+		NamespaceExaminer $namespaceExaminer,
+		PermissionExaminer $permissionExaminer,
+		FactboxText $factboxText
+	) {
 		$this->namespaceExaminer = $namespaceExaminer;
 		$this->permissionExaminer = $permissionExaminer;
+		$this->factboxText = $factboxText;
 	}
 
 	/**
@@ -128,11 +133,9 @@ class OutputPageParserOutput implements HookListener {
 
 		$applicationFactory = ApplicationFactory::getInstance();
 
-		$factboxText = $applicationFactory->getFactboxText();
-
 		$request = $outputPage->getContext()->getRequest();
 
-		if ( $factboxText->hasText() && $request->getCheck( 'wpPreview' ) ) {
+		if ( $this->factboxText->hasText() && $request->getCheck( 'wpPreview' ) ) {
 			return '';
 		}
 
@@ -148,7 +151,7 @@ class OutputPageParserOutput implements HookListener {
 		// Due to how MW started to move the `mw-data-after-content` out of the
 		// `bodyContent` we need a way to distinguish content from a top level
 		// to apply additional CSS rules
-		if ( $factboxText->hasText() && $factboxText->getText() !== '' ) {
+		if ( $this->factboxText->hasNonEmptyText() ) {
 			$outputPage->addBodyClasses( 'smw-factbox-view' );
 		}
 

--- a/src/MediaWiki/Hooks/OutputPageParserOutput.php
+++ b/src/MediaWiki/Hooks/OutputPageParserOutput.php
@@ -126,13 +126,15 @@ class OutputPageParserOutput implements HookListener {
 
 	protected function addFactbox( OutputPage $outputPage, ParserOutput $parserOutput ) {
 
+		$applicationFactory = ApplicationFactory::getInstance();
+
+		$factboxText = $applicationFactory->getFactboxText();
+
 		$request = $outputPage->getContext()->getRequest();
 
-		if ( isset( $outputPage->mSMWFactboxText ) && $request->getCheck( 'wpPreview' ) ) {
+		if ( $factboxText->hasText() && $request->getCheck( 'wpPreview' ) ) {
 			return '';
 		}
-
-		$applicationFactory = ApplicationFactory::getInstance();
 
 		$cachedFactbox = $applicationFactory->singleton( 'FactboxFactory' )->newCachedFactbox();
 
@@ -146,7 +148,7 @@ class OutputPageParserOutput implements HookListener {
 		// Due to how MW started to move the `mw-data-after-content` out of the
 		// `bodyContent` we need a way to distinguish content from a top level
 		// to apply additional CSS rules
-		if ( isset( $outputPage->mSMWFactboxText ) && $outputPage->mSMWFactboxText !== '' ) {
+		if ( $factboxText->hasText() && $factboxText->getText() !== '' ) {
 			$outputPage->addBodyClasses( 'smw-factbox-view' );
 		}
 

--- a/src/Services/ServicesFactory.php
+++ b/src/Services/ServicesFactory.php
@@ -16,6 +16,7 @@ use SMW\DataUpdater;
 use SMW\DataValueFactory;
 use SMW\DeferredTransactionalCallableUpdate;
 use SMW\EntityCache;
+use SMW\Factbox\FactboxText;
 use SMW\Listener\EventListener\EventHandler;
 use SMW\HierarchyLookup;
 use SMW\InMemoryPoolCache;
@@ -652,6 +653,13 @@ class ServicesFactory {
 
 	public function newPostProcHandler( ParserOutput $parserOutput ) : PostProcHandler {
 		return $this->create( 'PostProcHandler', $parserOutput );
+	}
+
+	/**
+	 * @since 4.1.1
+	 */
+	public function getFactboxText() : FactboxText {
+		return $this->containerBuilder->singleton( 'FactboxText' );
 	}
 
 }

--- a/src/Services/SharedServicesContainer.php
+++ b/src/Services/SharedServicesContainer.php
@@ -17,6 +17,7 @@ use SMW\DisplayTitleFinder;
 use SMW\Elastic\ElasticFactory;
 use SMW\EntityCache;
 use SMW\Factbox\FactboxFactory;
+use SMW\Factbox\FactboxText;
 use SMW\HierarchyLookup;
 use SMW\InMemoryPoolCache;
 use SMW\IteratorFactory;
@@ -482,6 +483,15 @@ class SharedServicesContainer implements CallbackContainer {
 			);
 
 			return $paramListProcessor;
+		} );
+
+		/**
+		 * @var FactboxText
+		 */
+		$containerBuilder->registerCallback( 'FactboxText', function( $containerBuilder ) {
+			$containerBuilder->registerExpectedReturnType( 'FactboxText', FactboxText::class );
+
+			return new FactboxText();
 		} );
 	}
 

--- a/tests/phpunit/Factbox/CachedFactboxTest.php
+++ b/tests/phpunit/Factbox/CachedFactboxTest.php
@@ -115,7 +115,7 @@ class CachedFactboxTest extends \PHPUnit_Framework_TestCase {
 			$parameters['parserOutput']
 		);
 
-		$result = $outputPage->mSMWFactboxText;
+		$result = ApplicationFactory::getInstance()->getFactboxText()->getText();
 
 		$this->assertPreProcess(
 			$expected,
@@ -148,9 +148,8 @@ class CachedFactboxTest extends \PHPUnit_Framework_TestCase {
 				'Asserts that content was altered as expected'
 			);
 
-			// Deliberately clear the outputPage property to force
-			// content to be retrieved from the cache
-			unset( $outputPage->mSMWFactboxText );
+			// Deliberately clear the text to force content to be retrieved from the cache
+			ApplicationFactory::getInstance()->getFactboxText()->clear();
 
 			$this->assertTrue(
 				$result === $instance->retrieveContent( $outputPage ),
@@ -175,8 +174,8 @@ class CachedFactboxTest extends \PHPUnit_Framework_TestCase {
 		);
 
 		$this->assertTrue(
-			$result === $outputPage->mSMWFactboxText,
-			'Asserts that content from the outputpage property and retrieveContent() is equal'
+			$result === ApplicationFactory::getInstance()->getFactboxText()->getText(),
+			'Asserts that content from the FactboxText text and retrieveContent() is equal'
 		);
 
 		if ( isset( $expected['isCached'] ) && $expected['isCached'] ) {

--- a/tests/phpunit/Factbox/CachedFactboxTest.php
+++ b/tests/phpunit/Factbox/CachedFactboxTest.php
@@ -5,6 +5,7 @@ namespace SMW\Tests\Factbox;
 use Language;
 use ParserOutput;
 use MediaWiki\MediaWikiServices;
+use SMW\Factbox\FactboxText;
 use SMW\Services\ServicesFactory as ApplicationFactory;
 use SMW\DIProperty;
 use SMW\DIWikiPage;
@@ -32,6 +33,7 @@ class CachedFactboxTest extends \PHPUnit_Framework_TestCase {
 	private $memoryCache;
 	private $entityCache;
 	private $spyLogger;
+	private FactboxText $factboxText;
 
 	protected function setUp() : void {
 		parent::setUp();
@@ -54,6 +56,8 @@ class CachedFactboxTest extends \PHPUnit_Framework_TestCase {
 			->getMock();
 
 		$this->testEnvironment->registerObject( 'EntityCache', $this->entityCache );
+
+		$this->factboxText = ApplicationFactory::getInstance()->getFactboxText();
 	}
 
 	protected function tearDown() : void {
@@ -65,7 +69,7 @@ class CachedFactboxTest extends \PHPUnit_Framework_TestCase {
 
 		$this->assertInstanceOf(
 			CachedFactbox::class,
-			new CachedFactbox( $this->entityCache )
+			new CachedFactbox( $this->entityCache, $this->factboxText )
 		);
 	}
 
@@ -93,7 +97,8 @@ class CachedFactboxTest extends \PHPUnit_Framework_TestCase {
 		$outputPage = $parameters['outputPage'];
 
 		$instance = new CachedFactbox(
-			new EntityCache( $this->memoryCache )
+			new EntityCache( $this->memoryCache ),
+			$this->factboxText
 		);
 
 		$instance->isEnabled( true );
@@ -115,7 +120,7 @@ class CachedFactboxTest extends \PHPUnit_Framework_TestCase {
 			$parameters['parserOutput']
 		);
 
-		$result = ApplicationFactory::getInstance()->getFactboxText()->getText();
+		$result = $this->factboxText->getText();
 
 		$this->assertPreProcess(
 			$expected,
@@ -149,7 +154,7 @@ class CachedFactboxTest extends \PHPUnit_Framework_TestCase {
 			);
 
 			// Deliberately clear the text to force content to be retrieved from the cache
-			ApplicationFactory::getInstance()->getFactboxText()->clear();
+			$this->factboxText->clear();
 
 			$this->assertTrue(
 				$result === $instance->retrieveContent( $outputPage ),
@@ -174,7 +179,7 @@ class CachedFactboxTest extends \PHPUnit_Framework_TestCase {
 		);
 
 		$this->assertTrue(
-			$result === ApplicationFactory::getInstance()->getFactboxText()->getText(),
+			$result === $this->factboxText->getText(),
 			'Asserts that content from the FactboxText text and retrieveContent() is equal'
 		);
 

--- a/tests/phpunit/Factbox/FactboxTextTest.php
+++ b/tests/phpunit/Factbox/FactboxTextTest.php
@@ -1,0 +1,92 @@
+<?php
+
+namespace SMW\Tests\Factbox;
+
+use SMW\Factbox\FactboxText;
+use SMW\Tests\PHPUnitCompat;
+
+/**
+ * @covers \SMW\Factbox\FactboxText
+ * @group semantic-mediawiki
+ *
+ * @license GNU GPL v2+
+ * @since 4.1.1
+ *
+ * @author Morne Alberts
+ */
+class FactboxTextTest extends \PHPUnit_Framework_TestCase {
+
+	use PHPUnitCompat;
+
+	public function testSetText(): void {
+		$factboxText = new FactboxText();
+
+		$factboxText->setText( 'Foo bar' );
+
+		$this->assertSame(
+			'Foo bar',
+			$factboxText->getText()
+		);
+	}
+
+	public function testHasText(): void {
+		$factboxText = new FactboxText();
+
+		$factboxText->setText( 'Foo bar' );
+
+		$this->assertTrue(
+			$factboxText->hasText()
+		);
+	}
+
+	public function testDefaultDoesNotHaveText(): void {
+		$factboxText = new FactboxText();
+
+		$this->assertFalse(
+			$factboxText->hasText()
+		);
+	}
+
+	public function testClearDoesNotHaveText(): void {
+		$factboxText = new FactboxText();
+
+		$factboxText->setText( 'Foo Bar' );
+		$factboxText->clear();
+
+		$this->assertFalse(
+			$factboxText->hasText()
+		);
+	}
+
+	public function testHasNonEmptyText(): void {
+		$factboxText = new FactboxText();
+
+		$factboxText->setText( 'Foo bar' );
+
+		$this->assertTrue(
+			$factboxText->hasNonEmptyText()
+		);
+	}
+
+	public function testClearDoesNotHaveNonEmptyText(): void {
+		$factboxText = new FactboxText();
+
+		$factboxText->setText( 'Foo Bar' );
+		$factboxText->clear();
+
+		$this->assertFalse(
+			$factboxText->hasNonEmptyText()
+		);
+	}
+
+	public function testEmptyStringDoesNotHaveNonEmptyText(): void {
+		$factboxText = new FactboxText();
+
+		$factboxText->setText( '' );
+
+		$this->assertFalse(
+			$factboxText->hasNonEmptyText()
+		);
+	}
+
+}

--- a/tests/phpunit/MediaWiki/Hooks/OutputPageParserOutputTest.php
+++ b/tests/phpunit/MediaWiki/Hooks/OutputPageParserOutputTest.php
@@ -125,12 +125,13 @@ class OutputPageParserOutputTest extends \PHPUnit_Framework_TestCase {
 		$instance->process( $outputPage, $parserOutput );
 
 		if ( $expected['text'] == '' ) {
-			return $this->assertFalse( isset( $outputPage->mSMWFactboxText ) );
+			$this->assertFalse( ApplicationFactory::getInstance()->getFactboxText()->hasText() );
+			return;
 		}
 
 		// For expected content continue to verify that the outputPage was amended and
 		// that the content is also available via the CacheStore
-		$text = $outputPage->mSMWFactboxText;
+		$text = ApplicationFactory::getInstance()->getFactboxText()->getText();
 
 		$this->assertContains( $expected['text'], $text );
 
@@ -140,9 +141,8 @@ class OutputPageParserOutputTest extends \PHPUnit_Framework_TestCase {
 			'Asserts that retrieveContent() returns an expected text'
 		);
 
-		// Deliberately clear the outputPage Property to retrieve
-		// content from the CacheStore
-		unset( $outputPage->mSMWFactboxText );
+		// Deliberately clear the text to retrieve content from the CacheStore
+		ApplicationFactory::getInstance()->getFactboxText()->clear();
 
 		$this->assertEquals(
 			$text,

--- a/tests/phpunit/MediaWiki/Hooks/SkinAfterContentTest.php
+++ b/tests/phpunit/MediaWiki/Hooks/SkinAfterContentTest.php
@@ -129,7 +129,7 @@ class SkinAfterContentTest extends \PHPUnit_Framework_TestCase {
 			->method( 'getTitle' )
 			->will( $this->returnValue( $title ) );
 
-		$outputPage->mSMWFactboxText = $text;
+		ApplicationFactory::getInstance()->getFactboxText()->setText( $text );
 
 		$skin = $this->getMockBuilder( '\Skin' )
 			->disableOriginalConstructor()
@@ -221,7 +221,7 @@ class SkinAfterContentTest extends \PHPUnit_Framework_TestCase {
 			->method( 'getTitle' )
 			->will( $this->returnValue( $title ) );
 
-		$outputPage->mSMWFactboxText = $text;
+		ApplicationFactory::getInstance()->getFactboxText()->setText( $text );
 
 		$skin = $this->getMockBuilder( '\Skin' )
 			->disableOriginalConstructor()
@@ -265,7 +265,7 @@ class SkinAfterContentTest extends \PHPUnit_Framework_TestCase {
 			->method( 'getTitle' )
 			->will( $this->returnValue( $title ) );
 
-		$outputPage->mSMWFactboxText = $text;
+		ApplicationFactory::getInstance()->getFactboxText()->setText( $text );
 
 		$skin = $this->getMockBuilder( '\Skin' )
 			->disableOriginalConstructor()

--- a/tests/phpunit/MediaWiki/Hooks/SkinAfterContentTest.php
+++ b/tests/phpunit/MediaWiki/Hooks/SkinAfterContentTest.php
@@ -2,6 +2,7 @@
 
 namespace SMW\Tests\MediaWiki\Hooks;
 
+use SMW\Factbox\FactboxText;
 use SMW\Services\ServicesFactory as ApplicationFactory;
 use SMW\MediaWiki\Hooks\SkinAfterContent;
 use SMW\Settings;
@@ -19,6 +20,7 @@ use SMW\Tests\Utils\Mock\MockTitle;
 class SkinAfterContentTest extends \PHPUnit_Framework_TestCase {
 
 	private $applicationFactory;
+	private FactboxText $factboxText;
 
 	protected function setUp() : void {
 		parent::setUp();
@@ -33,6 +35,8 @@ class SkinAfterContentTest extends \PHPUnit_Framework_TestCase {
 		] );
 
 		$this->applicationFactory->registerObject( 'Settings', $settings );
+
+		$this->factboxText = $this->applicationFactory->getFactboxText();
 	}
 
 	protected function tearDown() : void {
@@ -129,7 +133,7 @@ class SkinAfterContentTest extends \PHPUnit_Framework_TestCase {
 			->method( 'getTitle' )
 			->will( $this->returnValue( $title ) );
 
-		ApplicationFactory::getInstance()->getFactboxText()->setText( $text );
+		$this->factboxText->setText( $text );
 
 		$skin = $this->getMockBuilder( '\Skin' )
 			->disableOriginalConstructor()
@@ -221,7 +225,7 @@ class SkinAfterContentTest extends \PHPUnit_Framework_TestCase {
 			->method( 'getTitle' )
 			->will( $this->returnValue( $title ) );
 
-		ApplicationFactory::getInstance()->getFactboxText()->setText( $text );
+		$this->factboxText->setText( $text );
 
 		$skin = $this->getMockBuilder( '\Skin' )
 			->disableOriginalConstructor()
@@ -265,7 +269,7 @@ class SkinAfterContentTest extends \PHPUnit_Framework_TestCase {
 			->method( 'getTitle' )
 			->will( $this->returnValue( $title ) );
 
-		ApplicationFactory::getInstance()->getFactboxText()->setText( $text );
+		$this->factboxText->setText( $text );
 
 		$skin = $this->getMockBuilder( '\Skin' )
 			->disableOriginalConstructor()


### PR DESCRIPTION
Fixes #5387

This takes a very literal approach to replacing the dynamic property with a service. 

Is this the right approach, or is there a better way to do this? The FactboxText class is basically a glorified global string or singleton. I'm not sure if there is a similar example in SMW which I can follow.

Is it necessary to inject this new class into the affected classes? Or is this fine, since they already use ApplicationFactory internally?