### PR TITLE
Fix dynamic property creations

### DIFF
--- a/includes/dataitems/SMW_DI_WikiPage.php
+++ b/includes/dataitems/SMW_DI_WikiPage.php
@@ -63,6 +63,8 @@ class DIWikiPage extends SMWDataItem {
 	 */
 	private $id = 0;
 
+	public int $recdepth;
+
 	/**
 	 * Constructor. We do not bother with too much detailed validation here,
 	 * regarding the known namespaces, canonicity of the dbkey (namespace

--- a/includes/querypages/WantedPropertiesQueryPage.php
+++ b/includes/querypages/WantedPropertiesQueryPage.php
@@ -3,6 +3,7 @@
 namespace SMW;
 
 use Html;
+use Title;
 
 /**
  * Query class that provides content for the Special:WantedProperties page
@@ -27,6 +28,8 @@ class WantedPropertiesQueryPage extends QueryPage {
 	 * @var ListLookup
 	 */
 	private $listLookup;
+
+	private Title $title;
 
 	/**
 	 * @since 1.9

--- a/src/Elastic/Indexer/Replication/DocumentReplicationExaminer.php
+++ b/src/Elastic/Indexer/Replication/DocumentReplicationExaminer.php
@@ -43,6 +43,8 @@ class DocumentReplicationExaminer {
 	 */
 	private $replicationStatusResponse = [];
 
+	private ReplicationStatus $replicationStatus;
+
 	/**
 	 * @since 3.1
 	 *

--- a/src/Elastic/Indexer/Replication/ReplicationEntityExaminerDeferrableIndicatorProvider.php
+++ b/src/Elastic/Indexer/Replication/ReplicationEntityExaminerDeferrableIndicatorProvider.php
@@ -57,6 +57,8 @@ class ReplicationEntityExaminerDeferrableIndicatorProvider implements TypableSev
 	 */
 	private $severityType = '';
 
+	private TemplateEngine $templateEngine;
+
 	/**
 	 * @since 3.2
 	 *

--- a/src/Elastic/Indexer/Replication/ReplicationStatus.php
+++ b/src/Elastic/Indexer/Replication/ReplicationStatus.php
@@ -27,6 +27,8 @@ class ReplicationStatus {
 	 */
 	private $fieldMapper;
 
+	private ElasticClient $connection;
+
 	/**
 	 * @since 3.0
 	 *

--- a/src/Elastic/Jobs/IndexerRecoveryJob.php
+++ b/src/Elastic/Jobs/IndexerRecoveryJob.php
@@ -2,6 +2,7 @@
 
 namespace SMW\Elastic\Jobs;
 
+use SMW\Elastic\Indexer\Indexer;
 use SMW\Services\ServicesFactory as ApplicationFactory;
 use SMW\DIWikiPage;
 use SMW\Elastic\ElasticStore;
@@ -33,6 +34,8 @@ class IndexerRecoveryJob extends Job {
 
 	const TTL_DAY = 86400; // 24 * 3600
 	const TTL_WEEK = 604800; // 7 * 24 * 3600
+
+	private Indexer $indexer;
 
 	/**
 	 * @since 3.0

--- a/src/Elastic/Lookup/ProximityPropertyValueLookup.php
+++ b/src/Elastic/Lookup/ProximityPropertyValueLookup.php
@@ -32,6 +32,8 @@ class ProximityPropertyValueLookup {
 	 */
 	private $store;
 
+	private FieldMapper $fieldMapper;
+
 	/**
 	 * @since 3.0
 	 *

--- a/src/Exporter/Element/ExpNsResource.php
+++ b/src/Exporter/Element/ExpNsResource.php
@@ -39,6 +39,8 @@ class ExpNsResource extends ExpResource {
 	 */
 	private $namespaceId;
 
+	public bool $isUserDefined;
+
 	/**
 	 * @note The given URI must not contain serialization-specific
 	 * abbreviations or escapings, such as XML entities.

--- a/src/Exporter/Serializer/TurtleSerializer.php
+++ b/src/Exporter/Serializer/TurtleSerializer.php
@@ -48,6 +48,8 @@ class TurtleSerializer extends Serializer {
 	 */
 	protected $sparql_namespaces;
 
+	protected array $subExpData;
+
 	/**
 	 * @since 1.5.5
 	 *

--- a/src/Indicator/EntityExaminerIndicators/AssociatedRevisionMismatchEntityExaminerIndicatorProvider.php
+++ b/src/Indicator/EntityExaminerIndicators/AssociatedRevisionMismatchEntityExaminerIndicatorProvider.php
@@ -52,6 +52,8 @@ class AssociatedRevisionMismatchEntityExaminerIndicatorProvider implements Typab
 	 */
 	private $isDeferredMode = false;
 
+	private TemplateEngine $templateEngine;
+
 	/**
 	 * @since 3.2
 	 *

--- a/src/Indicator/EntityExaminerIndicators/ConstraintErrorEntityExaminerIndicatorProvider.php
+++ b/src/Indicator/EntityExaminerIndicators/ConstraintErrorEntityExaminerIndicatorProvider.php
@@ -55,6 +55,10 @@ class ConstraintErrorEntityExaminerIndicatorProvider implements TypableSeverityI
 	 */
 	private $languageCode = '';
 
+	private string $errorTitle;
+
+	private TemplateEngine $templateEngine;
+
 	/**
 	 * @since 3.2
 	 *

--- a/src/Indicator/EntityExaminerIndicators/EntityExaminerDeferrableCompositeIndicatorProvider.php
+++ b/src/Indicator/EntityExaminerIndicators/EntityExaminerDeferrableCompositeIndicatorProvider.php
@@ -53,6 +53,8 @@ class EntityExaminerDeferrableCompositeIndicatorProvider implements DeferrableIn
 	 */
 	private $languageCode = '';
 
+	private TemplateEngine $templateEngine;
+
 	/**
 	 * @since 3.2
 	 *

--- a/src/Localizer/CopyLocalMessages.php
+++ b/src/Localizer/CopyLocalMessages.php
@@ -24,6 +24,8 @@ class CopyLocalMessages {
 	 */
 	private $languageFileDir = '';
 
+	private array $contents;
+
 	/**
 	 * @since 3.2
 	 *

--- a/src/Maintenance/AutoRecovery.php
+++ b/src/Maintenance/AutoRecovery.php
@@ -47,6 +47,8 @@ class AutoRecovery {
 	 */
 	private $contents;
 
+	private string $dir;
+
 	/**
 	 * @since 3.1
 	 *

--- a/src/MediaWiki/Api/ApiQueryResultFormatter.php
+++ b/src/MediaWiki/Api/ApiQueryResultFormatter.php
@@ -39,6 +39,8 @@ class ApiQueryResultFormatter {
 	 */
 	protected $queryResult = null;
 
+	protected array $result;
+
 	/**
 	 * @since 1.9
 	 *
@@ -181,7 +183,7 @@ class ApiQueryResultFormatter {
 	 *
 	 * @return array
 	 */
-	protected function formatErrors( array $errors ) {
+	protected function formatErrors( array $errors ): array {
 
 		$this->type      = 'error';
 		$result['query'] = $errors;

--- a/src/MediaWiki/Api/Browse/CachingLookup.php
+++ b/src/MediaWiki/Api/Browse/CachingLookup.php
@@ -31,6 +31,8 @@ class CachingLookup {
 	 */
 	private $cacheTTL;
 
+	private Cache $cache;
+
 	/**
 	 * @since 3.0
 	 *

--- a/src/MediaWiki/Api/Task.php
+++ b/src/MediaWiki/Api/Task.php
@@ -16,6 +16,8 @@ class Task extends ApiBase {
 
 	const CACHE_NAMESPACE = 'smw:api:task';
 
+	private TaskFactory $taskFactory;
+
 	/**
 	 * @since 3.0
 	 *

--- a/src/MediaWiki/Api/Tasks/DuplicateLookupTask.php
+++ b/src/MediaWiki/Api/Tasks/DuplicateLookupTask.php
@@ -24,6 +24,8 @@ class DuplicateLookupTask extends Task {
 	 */
 	private $cacheUsage;
 
+	private Cache $cache;
+
 	/**
 	 * @since 3.1
 	 *

--- a/src/MediaWiki/Api/Tasks/TableStatisticsTask.php
+++ b/src/MediaWiki/Api/Tasks/TableStatisticsTask.php
@@ -26,6 +26,8 @@ class TableStatisticsTask extends Task {
 	 */
 	private $cacheUsage;
 
+	private Cache $cache;
+
 	/**
 	 * @since 3.1
 	 *

--- a/src/MediaWiki/Content/SchemaContent.php
+++ b/src/MediaWiki/Content/SchemaContent.php
@@ -433,6 +433,7 @@ class SchemaContent extends JsonContent {
 
 		// Allow to use the schema validation against a possible
 		// required naming convention (aka title prefix)
+		// TODO: Illegal dynamic property (#5421)
 		$this->parse->title_prefix = $title_prefix;
 	}
 

--- a/src/MediaWiki/Hooks/FileUpload.php
+++ b/src/MediaWiki/Hooks/FileUpload.php
@@ -111,6 +111,7 @@ class FileUpload implements HookListener {
 		);
 
 		$filePage->setFile( $file );
+		// TODO: Illegal dynamic property (#5421)
 		$filePage->smwFileReUploadStatus = $reUploadStatus;
 
 		return $filePage;

--- a/src/MediaWiki/Jobs/UpdateDispatcherJob.php
+++ b/src/MediaWiki/Jobs/UpdateDispatcherJob.php
@@ -4,6 +4,7 @@ namespace SMW\MediaWiki\Jobs;
 
 use Hooks;
 use SMW\MediaWiki\Job;
+use SMW\SerializerFactory;
 use SMW\Services\ServicesFactory as ApplicationFactory;
 use SMW\DIProperty;
 use SMW\DIWikiPage;
@@ -40,6 +41,8 @@ class UpdateDispatcherJob extends Job {
 	 * Size of chunks used when invoking the secondary dispatch run
 	 */
 	const CHUNK_SIZE = 500;
+
+	private SerializerFactory $serializerFactory;
 
 	/**
 	 * @since  1.9

--- a/src/MediaWiki/LocalTime.php
+++ b/src/MediaWiki/LocalTime.php
@@ -50,6 +50,7 @@ class LocalTime {
 		$data = explode( '|', $tz, 3 );
 
 		// DateTime is mutable, keep track of possible changes
+		// TODO: Illegal dynamic property (#5421)
 		$dateTime->hasLocalTimeCorrection = false;
 
 		if ( $data[0] == 'ZoneInfo' ) {

--- a/src/MediaWiki/Renderer/HtmlTableRenderer.php
+++ b/src/MediaWiki/Renderer/HtmlTableRenderer.php
@@ -47,6 +47,8 @@ class HtmlTableRenderer {
 	 */
 	private $transpose = false;
 
+	private bool $htmlContext;
+
 	/**
 	 * @par Example:
 	 * @code

--- a/src/Query/Language/Description.php
+++ b/src/Query/Language/Description.php
@@ -30,6 +30,9 @@ abstract class Description {
 	 */
 	private $membership = '';
 
+	public bool $isPartOfDisjunction;
+	public bool $isNegation;
+
 	/**
 	 * Get the (possibly empty) array of all print requests that
 	 * exist for the entities that fit this description.

--- a/src/Query/Language/SomeProperty.php
+++ b/src/Query/Language/SomeProperty.php
@@ -34,6 +34,9 @@ class SomeProperty extends Description {
 	 */
 	protected $hierarchyDepth;
 
+	public string $notConditionField;
+	public string $sourceChainMemberField;
+
 	/**
 	 * @since 1.6
 	 *

--- a/src/Query/ResultPrinters/CategoryResultPrinter.php
+++ b/src/Query/ResultPrinters/CategoryResultPrinter.php
@@ -3,6 +3,7 @@
 namespace SMW\Query\ResultPrinters;
 
 use SMW\MediaWiki\Collator;
+use SMW\MediaWiki\Renderer\WikitextTemplateRenderer;
 use SMWDataItem as DataItem;
 use SMWQueryResult as QueryResult;
 use SMW\Utils\HtmlColumns;
@@ -41,6 +42,10 @@ class CategoryResultPrinter extends ResultPrinter {
 	 * @var integer
 	 */
 	private $numColumns;
+
+	private HtmlColumns $htmlColumns;
+	private WikitextTemplateRenderer $templateRenderer;
+	private Collator $collator;
 
 	/**
 	 * @see ResultPrinter::getName

--- a/src/Query/ResultPrinters/TableResultPrinter.php
+++ b/src/Query/ResultPrinters/TableResultPrinter.php
@@ -30,6 +30,8 @@ class TableResultPrinter extends ResultPrinter {
 	 */
 	private $htmlTable;
 
+	private bool $isDataTable;
+
 	/**
 	 * @see ResultPrinter::getName
 	 *

--- a/src/RequestOptions.php
+++ b/src/RequestOptions.php
@@ -124,6 +124,8 @@ class RequestOptions {
 
 	public bool $isFirstChain;
 
+	public bool $natural;
+
 	/**
 	 * @since 3.1
 	 *

--- a/src/SQLStore/QueryEngine/ConditionBuilder.php
+++ b/src/SQLStore/QueryEngine/ConditionBuilder.php
@@ -68,6 +68,8 @@ class ConditionBuilder {
 	 */
 	private $lastQuerySegmentId = -1;
 
+	private CircularReferenceGuard $circularReferenceGuard;
+
 	/**
 	 * @since 2.2
 	 *

--- a/tests/phpunit/Integration/HookDispatcherTest.php
+++ b/tests/phpunit/Integration/HookDispatcherTest.php
@@ -384,6 +384,7 @@ class HookDispatcherTest extends \PHPUnit_Framework_TestCase {
 			->disableOriginalConstructor()
 			->getMock();
 
+		// TODO: Illegal dynamic property (#5421)
 		$anotherFile->extraProperty = 'Foo';
 
 		$this->assertNotEquals(
@@ -419,6 +420,7 @@ class HookDispatcherTest extends \PHPUnit_Framework_TestCase {
 			->disableOriginalConstructor()
 			->getMock();
 
+		// TODO: Illegal dynamic property (#5421)
 		$anotherRevision->extraProperty = 'Foo';
 
 		$this->assertNotEquals(

--- a/tests/phpunit/Integration/MediaWiki/Import/Maintenance/RebuildDataMaintenanceTest.php
+++ b/tests/phpunit/Integration/MediaWiki/Import/Maintenance/RebuildDataMaintenanceTest.php
@@ -5,6 +5,7 @@ namespace SMW\Tests\Integration\MediaWiki\Import\Maintenance;
 use SMW\DIProperty;
 use SMW\Tests\DatabaseTestCase;
 use SMW\Tests\Utils\ByPageSemanticDataFinder;
+use SMW\Tests\Utils\Runners\MaintenanceRunner;
 use SMW\Tests\Utils\UtilityFactory;
 use Title;
 
@@ -28,6 +29,8 @@ class RebuildDataMaintenanceTest extends DatabaseTestCase {
 	private $runnerFactory;
 	private $titleValidator;
 	private $semanticDataValidator;
+	private MaintenanceRunner $maintenanceRunner;
+	private ByPageSemanticDataFinder $semanticDataFinder;
 
 	protected function setUp() : void {
 		parent::setUp();

--- a/tests/phpunit/Integration/MediaWiki/Import/TimeDataTypeTest.php
+++ b/tests/phpunit/Integration/MediaWiki/Import/TimeDataTypeTest.php
@@ -31,6 +31,7 @@ class TimeDataTypeTest extends DatabaseTestCase {
 	private $runnerFactory;
 	private $titleValidator;
 	private $semanticDataValidator;
+	private ByPageSemanticDataFinder $semanticDataFinder;
 
 	protected function setUp() : void {
 		parent::setUp();

--- a/tests/phpunit/MediaWiki/Hooks/LinksUpdateCompleteTest.php
+++ b/tests/phpunit/MediaWiki/Hooks/LinksUpdateCompleteTest.php
@@ -231,6 +231,7 @@ class LinksUpdateCompleteTest extends \PHPUnit_Framework_TestCase {
 			->method( 'getParserOutput' )
 			->will( $this->returnValue( $parserOutput ) );
 
+		// TODO: Illegal dynamic property (#5421)
 		$linksUpdate->mTemplates = [ 'Foo' ];
 		$linksUpdate->mRecursive = false;
 

--- a/tests/phpunit/MediaWiki/PageInfoProviderTest.php
+++ b/tests/phpunit/MediaWiki/PageInfoProviderTest.php
@@ -223,6 +223,7 @@ class PageInfoProviderTest extends \PHPUnit_Framework_TestCase {
 			->getMock();
 
 		if ( $uploadStatus !== null ) {
+			// TODO: Illegal dynamic property (#5421)
 			$wikiFilePage->smwFileReUploadStatus = $uploadStatus;
 		}
 

--- a/tests/phpunit/ParserFunctionFactoryTest.php
+++ b/tests/phpunit/ParserFunctionFactoryTest.php
@@ -110,6 +110,7 @@ class ParserFunctionFactoryTest extends \PHPUnit_Framework_TestCase {
 				$this->anything() );
 
 		$parser = $this->parserFactory->create( __METHOD__ );
+		// TODO: Illegal dynamic property (#5421)
 		$parser->getOptions()->smwAskNoDependencyTracking = true;
 
 		$parserFunctionFactory = new ParserFunctionFactory();

--- a/tests/phpunit/SQLStore/Lookup/PropertyUsageListLookupTest.php
+++ b/tests/phpunit/SQLStore/Lookup/PropertyUsageListLookupTest.php
@@ -179,6 +179,7 @@ class PropertyUsageListLookupTest extends \PHPUnit_Framework_TestCase {
 			->method( 'getConnection' )
 			->will( $this->returnValue( $connection ) );
 
+		// TODO: Illegal dynamic property (#5421)
 		$this->requestOptions->limit = 1001;
 
 		$instance = new PropertyUsageListLookup(

--- a/tests/phpunit/SQLStore/Lookup/UnusedPropertyListLookupTest.php
+++ b/tests/phpunit/SQLStore/Lookup/UnusedPropertyListLookupTest.php
@@ -191,6 +191,7 @@ class UnusedPropertyListLookupTest extends \PHPUnit_Framework_TestCase {
 			->disableOriginalConstructor()
 			->getMock();
 
+		// TODO: Illegal dynamic property (#5421)
 		$this->requestOptions->limit = 1001;
 
 		$instance = new UnusedPropertyListLookup(

--- a/tests/phpunit/SpecialPageTestCase.php
+++ b/tests/phpunit/SpecialPageTestCase.php
@@ -10,6 +10,7 @@ use MediaWiki\MediaWikiServices;
 use SMW\Tests\Utils\Mock\MockSuperUser;
 use SpecialPage;
 use WebRequest;
+use WebResponse;
 
 /**
  *
@@ -26,6 +27,8 @@ abstract class SpecialPageTestCase extends \PHPUnit_Framework_TestCase {
 
 	protected $obLevel;
 	protected $store = null;
+	protected string $text;
+	protected WebResponse $response;
 
 	protected function setUp() : void {
 		parent::setUp();

--- a/tests/phpunit/Utils/JSONScript/ApiTestCaseProcessor.php
+++ b/tests/phpunit/Utils/JSONScript/ApiTestCaseProcessor.php
@@ -30,6 +30,8 @@ class ApiTestCaseProcessor extends \PHPUnit_Framework_TestCase {
 	 */
 	private $debug = false;
 
+	private string $testCaseLocation;
+
 	/**
 	 * @param MwApiFactory mwApiFactory
 	 * @param StringValidator
@@ -48,10 +50,8 @@ class ApiTestCaseProcessor extends \PHPUnit_Framework_TestCase {
 
 	/**
 	 * @since 3.0
-	 *
-	 * @param string $testCaseLocation
 	 */
-	public function setTestCaseLocation( $testCaseLocation ) {
+	public function setTestCaseLocation( string $testCaseLocation ) {
 		$this->testCaseLocation = $testCaseLocation;
 	}
 

--- a/tests/phpunit/Utils/JSONScript/JsonTestCaseContentHandler.php
+++ b/tests/phpunit/Utils/JSONScript/JsonTestCaseContentHandler.php
@@ -48,6 +48,8 @@ class JsonTestCaseContentHandler {
 	 */
 	private $testCaseLocation = '';
 
+	private LocalFileUpload $localFileUpload;
+
 	/**
 	 * @since 2.5
 	 *

--- a/tests/phpunit/Utils/JSONScript/QueryTestCaseProcessor.php
+++ b/tests/phpunit/Utils/JSONScript/QueryTestCaseProcessor.php
@@ -4,6 +4,8 @@ namespace SMW\Tests\Utils\JSONScript;
 
 use SMW\Query\Parser as QueryParser;
 use SMW\Store;
+use SMW\Tests\Utils\Validators\QueryResultValidator;
+use SMW\Tests\Utils\Validators\StringValidator;
 use SMWQuery as Query;
 use Title;
 
@@ -37,6 +39,10 @@ class QueryTestCaseProcessor extends \PHPUnit_Framework_TestCase {
 	 * @var boolean
 	 */
 	private $debug = false;
+
+	private QueryResultValidator $queryResultValidator;
+	private StringValidator $stringValidator;
+	private QueryParser $queryParser;
 
 	/**
 	 * @since 2.2

--- a/tests/phpunit/Utils/Mock/FakeQueryStore.php
+++ b/tests/phpunit/Utils/Mock/FakeQueryStore.php
@@ -2,11 +2,11 @@
 
 namespace SMW\Tests\Utils\Mock;
 
+use SMW\Query\QueryResult;
 use SMW\QueryEngine;
 use SMW\Store;
 use SMW\StoreAware;
 use SMWQuery;
-use SMWQueryResult;
 
 /**
  * FIXME One would wish to have a FakeStore but instead SMWSQLStore3 is used in
@@ -26,8 +26,9 @@ use SMWQueryResult;
 class FakeQueryStore implements QueryEngine, StoreAware {
 
 	protected $store;
+	protected QueryResult $queryResult;
 
-	public function setQueryResult( SMWQueryResult $queryResult ) {
+	public function setQueryResult( QueryResult $queryResult ) {
 		$this->queryResult = $queryResult;
 	}
 

--- a/tests/phpunit/Utils/Runners/XmlImportRunner.php
+++ b/tests/phpunit/Utils/Runners/XmlImportRunner.php
@@ -26,6 +26,7 @@ class XmlImportRunner {
 	protected $exception = false;
 	protected $result = null;
 	protected $verbose = false;
+	protected float $importTime;
 
 	/**
 	 * @var TestEnvironment


### PR DESCRIPTION
Refs #5421

This PR fixes dynamic property creation only for SMW objects.

Dynamic properties on non-SMW objects are marked with a `TODO` and the parent issue `#5421`.

There are some cases where a public property was added, since this is how the original code worked. However, these should eventually be replaced with functions.