### PR TITLE
Add refreshData() return type

### DIFF
--- a/src/Maintenance/DataRebuilder.php
+++ b/src/Maintenance/DataRebuilder.php
@@ -10,6 +10,7 @@ use SMW\Services\ServicesFactory as ApplicationFactory;
 use SMW\DIWikiPage;
 use SMW\MediaWiki\TitleFactory;
 use SMW\Maintenance\DataRebuilder\OutdatedDisposer;
+use SMW\SQLStore\Rebuilder\Rebuilder;
 use SMW\Utils\CliMsgFormatter;
 use SMW\Options;
 use SMW\Store;
@@ -92,6 +93,7 @@ class DataRebuilder {
 	private $filters = [];
 	private $verbose = false;
 	private $startIdFile = false;
+	private Rebuilder $entityRebuildDispatcher;
 
 	/**
 	 * @since 1.9.2

--- a/src/SPARQLStore/SPARQLStore.php
+++ b/src/SPARQLStore/SPARQLStore.php
@@ -6,6 +6,7 @@ use SMW\DIProperty;
 use SMW\DIWikiPage;
 use SMW\SemanticData;
 use SMW\SPARQLStore\Exception\HttpEndpointConnectionException;
+use SMW\SQLStore\Rebuilder\Rebuilder;
 use SMW\Store;
 use SMWDataItem as DataItem;
 use SMWExpNsResource as ExpNsResource;
@@ -433,7 +434,7 @@ class SPARQLStore extends Store {
 	 * @see Store::refreshData()
 	 * @since 1.8
 	 */
-	public function refreshData( &$index, $count, $namespaces = false, $usejobs = true ) {
+	public function refreshData( &$index, $count, $namespaces = false, $usejobs = true ): Rebuilder {
 		return $this->baseStore->refreshData( $index, $count, $namespaces, $usejobs );
 	}
 

--- a/src/SQLStore/SQLStore.php
+++ b/src/SQLStore/SQLStore.php
@@ -14,6 +14,7 @@ use SMW\SQLStore\EntityStore\DataItemHandler;
 use SMW\SQLStore\EntityStore\DataItemHandlerFactory;
 use SMW\SQLStore\EntityStore\EntityLookup;
 use SMW\SQLStore\Lookup\CachedListLookup;
+use SMW\SQLStore\Rebuilder\Rebuilder;
 use SMW\Store;
 use SMWDataItem as DataItem;
 use SMWQuery as Query;
@@ -464,7 +465,7 @@ class SQLStore extends Store {
 		return $installer->uninstall( $verbose );
 	}
 
-	public function refreshData( &$id, $count, $namespaces = false, $usejobs = true ) {
+	public function refreshData( &$id, $count, $namespaces = false, $usejobs = true ): Rebuilder {
 
 		$rebuilder = $this->factory->newRebuilder();
 

--- a/src/Store.php
+++ b/src/Store.php
@@ -7,6 +7,7 @@ use Onoi\MessageReporter\MessageReporterAwareTrait;
 use Psr\Log\LoggerAwareTrait;
 use SMW\Connection\ConnectionManager;
 use SMW\SQLStore\Lookup\ListLookup;
+use SMW\SQLStore\Rebuilder\Rebuilder;
 use SMW\Utils\Timer;
 use SMWDataItem as DataItem;
 use SMWQuery;
@@ -454,10 +455,8 @@ abstract class Store implements QueryEngine {
 	 * @param $count integer
 	 * @param $namespaces mixed array or false
 	 * @param $usejobs boolean
-	 *
-	 * @return float between 0 and 1 to indicate the overall progress of the refreshing
 	 */
-	public abstract function refreshData( &$index, $count, $namespaces = false, $usejobs = true );
+	public abstract function refreshData( &$index, $count, $namespaces = false, $usejobs = true ): Rebuilder;
 
 	/**
 	 * Setup the store.


### PR DESCRIPTION
Fixes #5325 

This seems to be the type that is currently being used.

Without knowing anything the class does: it seems a little strange that SPARQLStore is relying on a SQLStore Rebuilder, but maybe that's just the way it is. Perhaps a new interface (or moving it) might be more correct, but I'm not going to look at that right now since there is only one implementation.