### PR TITLE
Remove group from resources

### DIFF
--- a/res/Resources.php
+++ b/res/Resources.php
@@ -14,8 +14,7 @@ $pathParts = explode( '/', str_replace( DIRECTORY_SEPARATOR, '/', __DIR__ ) );
 
 $moduleTemplate = [
 	'localBasePath' => __DIR__,
-	'remoteExtPath' => implode( '/', array_slice( $pathParts, -2 ) ),
-	'group' => 'ext.smw'
+	'remoteExtPath' => implode( '/', array_slice( $pathParts, -2 ) )
 ];
 
 return [


### PR DESCRIPTION
AFAIK, a group is not necessary and it causes ResourceLoader to not merge the stylesheets with the others, causing an extra web request.

This inefficiency is reported by https://www.webpagetest.org/ as well as https://developers.google.com/speed and NewRelic