### PR TITLE
Upgrade to actions/checkout@v3

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -69,11 +69,11 @@ jobs:
           mv composer.phar /usr/local/bin/composer
 
       - name: Checkout Extension
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           path: ${{ env.EXT_NAME }}
 
-      # Setting actions/checkout@v2 path to env.MW_EXT_PATH fails with "Repository path '/var/www/html/extensions' is not under ..."
+      # Setting actions/checkout@v3 path to env.MW_EXT_PATH fails with "Repository path '/var/www/html/extensions' is not under ..."
       # See also open PR https://github.com/actions/checkout/pull/388
       - name: Move Extension
         run: |

--- a/.github/workflows/php-8.yml
+++ b/.github/workflows/php-8.yml
@@ -69,11 +69,11 @@ jobs:
           mv composer.phar /usr/local/bin/composer
 
       - name: Checkout Extension
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           path: ${{ env.EXT_NAME }}
 
-      # Setting actions/checkout@v2 path to env.MW_EXT_PATH fails with "Repository path '/var/www/html/extensions' is not under ..."
+      # Setting actions/checkout@v3 path to env.MW_EXT_PATH fails with "Repository path '/var/www/html/extensions' is not under ..."
       # See also open PR https://github.com/actions/checkout/pull/388
       - name: Move Extension
         run: |

--- a/.github/workflows/tesa.yml
+++ b/.github/workflows/tesa.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2


### PR DESCRIPTION
This removes the warnings in the Actions, [like here](https://github.com/SemanticMediaWiki/SemanticMediaWiki/actions/runs/4054206088). There is a [GitHub blog post about this](https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/).

It mainly changes node12 to node16 internally in the action ([changelog](https://github.com/actions/checkout/blob/main/CHANGELOG.md)), so there should be any side-effect.

Unfortunately the linked PR https://github.com/actions/checkout/pull/388 is still open, so no improvement possible on this workaround and it is still needed to move afterwards the files:
https://github.com/SemanticMediaWiki/SemanticMediaWiki/blob/812a19bd665ce9b44adf7736ca5ac2a5e514c7c8/.github/workflows/main.yml#L76-L81