### PR TITLE
MessageFormatter: construct can also be passed StubUserLang

### DIFF
--- a/includes/formatters/MessageFormatter.php
+++ b/includes/formatters/MessageFormatter.php
@@ -4,6 +4,7 @@ namespace SMW;
 
 use Html;
 use Language;
+use StubUserLang;
 
 /**
  * Class implementing message output formatting
@@ -38,14 +39,15 @@ class MessageFormatter {
 	/** @var boolean */
 	protected $escape = true;
 
-	private Language $language;
+	/** @var Language|StubUserLang */
+	private $language;
 
 	/**
 	 * @since 1.9
 	 *
-	 * @param Language $language
+	 * @param Language|StubUserLang $language
 	 */
-	public function __construct( Language $language ) {
+	public function __construct( $language ) {
 		$this->language = $language;
 	}
 


### PR DESCRIPTION
For example, `Parser::getTargetLanguage()` as passed to this numerous times in `ParserFunctionFactory.php`, may also return `StubUserLang`. There were probably other ways to instead ensure it is a Language object everywhere else it is called, but this seemed like a cleaner solution then all the other possible issues it might bring by trying that.

Just a note also, `StubUserLang` was namespaced in 1.40 as `MediaWiki\StubObject\StubUserLang` so for the @param doc, that can probably be changed for use statement when the time comes, but for now this should be fine, as `MediaWiki\StubObject\StubUserLang` is also aliased as `StubUserLang` still in 1.40 (currently anyway).

Fixes #5426