### PR TITLE
Pass '_index' suffix to tableName method (#5384)

### DIFF
--- a/src/SQLStore/TableBuilder/SQLiteTableBuilder.php
+++ b/src/SQLStore/TableBuilder/SQLiteTableBuilder.php
@@ -349,8 +349,7 @@ class SQLiteTableBuilder extends TableBuilder {
 			$indexType = 'UNIQUE INDEX';
 		}
 
-		$tableName = $this->connection->tableName( $tableName );
-		$indexName = "{$tableName}_index{$indexName}";
+		$indexName = $this->connection->tableName(  "{$tableName}_index{$indexName}" );
 
 		$this->reportMessage( "   ... creating new $indexType $columns ..." );
 		$this->connection->query( "CREATE $indexType $indexName ON $tableName ($columns)", __METHOD__ );


### PR DESCRIPTION
By passing the `_index{$indexName}` suffix in the `tableName` method, the entire table name gets correctly quoted. This fixes #5384.

When using SMW 4.1.0 without this change against SQLite, the following exception gets thrown upon running `maintenance/update.php`:

```
Checking index structures for table smw_object_ids ...
   ... creating new UNIQUE INDEX smw_id ...Wikimedia\Rdbms\DBQueryError from line 1618 of /Users/xxmarijnwwerk/Documents/Wikis/wikiguard/mediawiki-1.39.1/includes/libs/rdbms/database/Database.php: Error 1: near "(": syntax error
Function: SMW\SQLStore\TableBuilder\SQLiteTableBuilder::doCreateIndex
Query: CREATE UNIQUE INDEX _indexpri ON  (smw_id)

#0 /Users/xxmarijnwwerk/Documents/Wikis/wikiguard/mediawiki-1.39.1/includes/libs/rdbms/database/Database.php(1602): Wikimedia\Rdbms\Database->getQueryException('near "(": synta...', 1, 'CREATE UNIQUE I...', 'SMW\\SQLStore\\Ta...')
#1 /Users/xxmarijnwwerk/Documents/Wikis/wikiguard/mediawiki-1.39.1/includes/libs/rdbms/database/Database.php(1576): Wikimedia\Rdbms\Database->getQueryExceptionAndLog('near "(": synta...', 1, 'CREATE UNIQUE I...', 'SMW\\SQLStore\\Ta...')
#2 /Users/xxmarijnwwerk/Documents/Wikis/wikiguard/mediawiki-1.39.1/includes/libs/rdbms/database/Database.php(952): Wikimedia\Rdbms\Database->reportQueryError('near "(": synta...', 1, 'CREATE UNIQUE I...', 'SMW\\SQLStore\\Ta...', false)
#3 /Users/xxmarijnwwerk/Documents/Wikis/wikiguard/mediawiki-1.39.1/includes/libs/rdbms/database/DBConnRef.php(103): Wikimedia\Rdbms\Database->query('CREATE UNIQUE I...', 'SMW\\SQLStore\\Ta...', 0)
#4 /Users/xxmarijnwwerk/Documents/Wikis/wikiguard/mediawiki-1.39.1/includes/libs/rdbms/database/DBConnRef.php(293): Wikimedia\Rdbms\DBConnRef->__call('query', Array)
#5 /Users/xxmarijnwwerk/Documents/Wikis/wikiguard/mediawiki-1.39.1/extensions/SemanticMediaWiki/src/SQLStore/TableBuilder/SQLiteTableBuilder.php(356): Wikimedia\Rdbms\DBConnRef->query('CREATE UNIQUE I...', 'SMW\\SQLStore\\Ta...')
#6 /Users/xxmarijnwwerk/Documents/Wikis/wikiguard/mediawiki-1.39.1/extensions/SemanticMediaWiki/src/SQLStore/TableBuilder/SQLiteTableBuilder.php(294): SMW\SQLStore\TableBuilder\SQLiteTableBuilder->doCreateIndex('', 'UNIQUE INDEX', '_indexpri', 'smw_id', Array)
#7 /Users/xxmarijnwwerk/Documents/Wikis/wikiguard/mediawiki-1.39.1/extensions/SemanticMediaWiki/src/SQLStore/TableBuilder/TableBuilder.php(169): SMW\SQLStore\TableBuilder\SQLiteTableBuilder->doCreateIndices('smw_object_ids', Array)
#8 /Users/xxmarijnwwerk/Documents/Wikis/wikiguard/mediawiki-1.39.1/extensions/SemanticMediaWiki/src/SQLStore/Installer.php(229): SMW\SQLStore\TableBuilder\TableBuilder->create(Object(SMW\SQLStore\TableBuilder\Table))
#9 /Users/xxmarijnwwerk/Documents/Wikis/wikiguard/mediawiki-1.39.1/extensions/SemanticMediaWiki/src/SQLStore/SQLStore.php(452): SMW\SQLStore\Installer->install(Object(SMW\Options))
#10 /Users/xxmarijnwwerk/Documents/Wikis/wikiguard/mediawiki-1.39.1/extensions/SemanticMediaWiki/src/Store.php(488): SMW\SQLStore\SQLStore->setup(Object(SMW\Options))
#11 /Users/xxmarijnwwerk/Documents/Wikis/wikiguard/mediawiki-1.39.1/includes/installer/DatabaseUpdater.php(547): SMW\Store::setupStore(true, Object(SMW\Options))
#12 /Users/xxmarijnwwerk/Documents/Wikis/wikiguard/mediawiki-1.39.1/includes/installer/DatabaseUpdater.php(515): DatabaseUpdater->runUpdates(Array, true)
#13 /Users/xxmarijnwwerk/Documents/Wikis/wikiguard/mediawiki-1.39.1/maintenance/update.php(202): DatabaseUpdater->doUpdates(Array)
#14 /Users/xxmarijnwwerk/Documents/Wikis/wikiguard/mediawiki-1.39.1/maintenance/includes/MaintenanceRunner.php(309): UpdateMediaWiki->execute()
#15 /Users/xxmarijnwwerk/Documents/Wikis/wikiguard/mediawiki-1.39.1/maintenance/doMaintenance.php(85): MediaWiki\Maintenance\MaintenanceRunner->run()
#16 /Users/xxmarijnwwerk/Documents/Wikis/wikiguard/mediawiki-1.39.1/maintenance/update.php(312): require_once('/Users/xxmarijn...')
#17 {main}
```

With this change, the update script completes without any problems (besides some deprecation warnings).