### PR TITLE
Make SemanticMediaWiki compatible with new ElasticSearch

### DIFF
--- a/data/elastic/smw-data-standard.json
+++ b/data/elastic/smw-data-standard.json
@@ -57,218 +57,216 @@
 		}
 	},
 	"mappings": {
-		"data": {
-			"dynamic_templates": [
-				{
-					"text_fields": {
-						"path_match": "P:*.txtField",
-						"match_mapping_type": "*",
-						"mapping": {
-							"type": "text",
-							"copy_to": "text_copy",
-							"fields": {
-								"sort": {
-									"type": "keyword",
-									"normalizer": "standard_sort_normalizer",
-									"index": false,
-									"ignore_above": 256
-								},
-								"keyword": {
-									"type": "keyword",
-									"ignore_above": 2000
-								}
+		"dynamic_templates": [
+			{
+				"text_fields": {
+					"path_match": "P:*.txtField",
+					"match_mapping_type": "*",
+					"mapping": {
+						"type": "text",
+						"copy_to": "text_copy",
+						"fields": {
+							"sort": {
+								"type": "keyword",
+								"normalizer": "standard_sort_normalizer",
+								"index": false,
+								"ignore_above": 256
+							},
+							"keyword": {
+								"type": "keyword",
+								"ignore_above": 2000
 							}
-						}
-					}
-				},
-				{
-					"uri_fields": {
-						"path_match": "P:*.uriField",
-						"match_mapping_type": "*",
-						"mapping": {
-							"type": "text",
-							"copy_to": "text_copy",
-							"fields": {
-								"sort": {
-									"type": "keyword",
-									"normalizer": "standard_sort_normalizer",
-									"index": false,
-									"ignore_above": 256
-								},
-								"keyword": {
-									"type": "keyword",
-									"ignore_above": 2000
-								},
-								"lowercase": {
-									"type":     "text",
-									"analyzer": "uri_lowercase_with_stopwords"
-								}
-							}
-						}
-					}
-				},
-				{
-					"page_fields_text": {
-						"path_match": "P:*.wpgField",
-						"match_mapping_type": "*",
-						"mapping": {
-							"type": "text",
-							"copy_to": "text_copy",
-							"fields": {
-								"sort": {
-									"type": "keyword",
-									"normalizer": "standard_sort_normalizer",
-									"index": false,
-									"ignore_above": 256
-								},
-								"keyword": {
-									"type": "keyword",
-									"ignore_above": 500
-								},
-								"lowercase": {
-									"type": "keyword",
-									"normalizer": "lowercase_normalizer"
-								}
-							}
-						}
-					}
-				},
-				{
-					"page_fields_identifier": {
-						"path_match": "P:*.wpgID",
-						"match_mapping_type": "*",
-						"mapping": {
-							"type": "long"
-						}
-					}
-				},
-				{
-					"numeric_fields": {
-						"path_match": "P:*.numField",
-						"match_mapping_type": "*",
-						"mapping": {
-							"type": "double",
-							"fields": {
-								"keyword": {
-									"type": "keyword",
-									"ignore_above": 256
-								}
-							}
-						}
-					}
-				},
-				{
-					"date_fields": {
-						"path_match": "P:*.datField",
-						"match_mapping_type": "*",
-						"mapping": {
-							"type": "double",
-							"fields": {
-								"keyword": {
-									"type": "keyword",
-									"ignore_above": 256
-								}
-							}
-						}
-					}
-				},
-				{
-					"date_fields_raw": {
-						"path_match": "P:*.dat_raw",
-						"match_mapping_type": "*",
-						"mapping": {
-							"type": "keyword"
-						}
-					}
-				},
-				{
-					"geo_fields": {
-						"path_match": "P:*.geoField",
-						"match_mapping_type": "string",
-						"mapping": {
-							"type": "keyword",
-							"fields": {
-								"point": {
-									"type": "geo_point"
-								}
-							}
-						}
-					}
-				},
-				{
-					"boolean_fields": {
-						"path_match": "P:*.booField",
-						"match_mapping_type": "boolean",
-						"mapping": {
-							"type": "boolean"
 						}
 					}
 				}
-			],
-			"properties": {
-				"noop": {
-					"type": "integer"
-				},
-				"text_copy": {
-					"type": "text"
-				},
-				"text_raw": {
-					"type": "text"
-				},
-				"subject.title": {
-					"type": "text",
-					"fields": {
-						"sort": {
-							"type": "keyword",
-							"normalizer": "standard_sort_normalizer",
-							"index": false
-						},
-						"keyword": {
-							"type": "keyword",
-							"ignore_above": 256
+			},
+			{
+				"uri_fields": {
+					"path_match": "P:*.uriField",
+					"match_mapping_type": "*",
+					"mapping": {
+						"type": "text",
+						"copy_to": "text_copy",
+						"fields": {
+							"sort": {
+								"type": "keyword",
+								"normalizer": "standard_sort_normalizer",
+								"index": false,
+								"ignore_above": 256
+							},
+							"keyword": {
+								"type": "keyword",
+								"ignore_above": 2000
+							},
+							"lowercase": {
+								"type":     "text",
+								"analyzer": "uri_lowercase_with_stopwords"
+							}
 						}
 					}
-				},
-				"subject.interwiki": {
-					"type": "text",
-					"fields": {
-						"keyword": {
-							"type": "keyword",
-							"ignore_above": 256
-						}
-					}
-				},
-				"subject.subobject": {
-					"type": "text",
-					"fields": {
-						"keyword": {
-							"type": "keyword",
-							"ignore_above": 256
-						}
-					}
-				},
-				"subject.sortkey": {
-					"type": "text",
-					"copy_to": "text_copy",
-					"fields": {
-						"sort": {
-							"type": "keyword",
-							"normalizer": "standard_sort_normalizer",
-							"index": false
-						},
-						"keyword": {
-							"type": "keyword",
-							"ignore_above": 256
-						},
-						"lowercase": {
-							"type": "keyword",
-							"normalizer": "lowercase_normalizer"
-						}
-					}
-				},
-				"subject.rev_id": {
-					"type": "integer"
 				}
+			},
+			{
+				"page_fields_text": {
+					"path_match": "P:*.wpgField",
+					"match_mapping_type": "*",
+					"mapping": {
+						"type": "text",
+						"copy_to": "text_copy",
+						"fields": {
+							"sort": {
+								"type": "keyword",
+								"normalizer": "standard_sort_normalizer",
+								"index": false,
+								"ignore_above": 256
+							},
+							"keyword": {
+								"type": "keyword",
+								"ignore_above": 500
+							},
+							"lowercase": {
+								"type": "keyword",
+								"normalizer": "lowercase_normalizer"
+							}
+						}
+					}
+				}
+			},
+			{
+				"page_fields_identifier": {
+					"path_match": "P:*.wpgID",
+					"match_mapping_type": "*",
+					"mapping": {
+						"type": "long"
+					}
+				}
+			},
+			{
+				"numeric_fields": {
+					"path_match": "P:*.numField",
+					"match_mapping_type": "*",
+					"mapping": {
+						"type": "double",
+						"fields": {
+							"keyword": {
+								"type": "keyword",
+								"ignore_above": 256
+							}
+						}
+					}
+				}
+			},
+			{
+				"date_fields": {
+					"path_match": "P:*.datField",
+					"match_mapping_type": "*",
+					"mapping": {
+						"type": "double",
+						"fields": {
+							"keyword": {
+								"type": "keyword",
+								"ignore_above": 256
+							}
+						}
+					}
+				}
+			},
+			{
+				"date_fields_raw": {
+					"path_match": "P:*.dat_raw",
+					"match_mapping_type": "*",
+					"mapping": {
+						"type": "keyword"
+					}
+				}
+			},
+			{
+				"geo_fields": {
+					"path_match": "P:*.geoField",
+					"match_mapping_type": "string",
+					"mapping": {
+						"type": "keyword",
+						"fields": {
+							"point": {
+								"type": "geo_point"
+							}
+						}
+					}
+				}
+			},
+			{
+				"boolean_fields": {
+					"path_match": "P:*.booField",
+					"match_mapping_type": "boolean",
+					"mapping": {
+						"type": "boolean"
+					}
+				}
+			}
+		],
+		"properties": {
+			"noop": {
+				"type": "integer"
+			},
+			"text_copy": {
+				"type": "text"
+			},
+			"text_raw": {
+				"type": "text"
+			},
+			"subject.title": {
+				"type": "text",
+				"fields": {
+					"sort": {
+						"type": "keyword",
+						"normalizer": "standard_sort_normalizer",
+						"index": false
+					},
+					"keyword": {
+						"type": "keyword",
+						"ignore_above": 256
+					}
+				}
+			},
+			"subject.interwiki": {
+				"type": "text",
+				"fields": {
+					"keyword": {
+						"type": "keyword",
+						"ignore_above": 256
+					}
+				}
+			},
+			"subject.subobject": {
+				"type": "text",
+				"fields": {
+					"keyword": {
+						"type": "keyword",
+						"ignore_above": 256
+					}
+				}
+			},
+			"subject.sortkey": {
+				"type": "text",
+				"copy_to": "text_copy",
+				"fields": {
+					"sort": {
+						"type": "keyword",
+						"normalizer": "standard_sort_normalizer",
+						"index": false
+					},
+					"keyword": {
+						"type": "keyword",
+						"ignore_above": 256
+					},
+					"lowercase": {
+						"type": "keyword",
+						"normalizer": "lowercase_normalizer"
+					}
+				}
+			},
+			"subject.rev_id": {
+				"type": "integer"
 			}
 		}
 	}

--- a/data/elastic/smw-data-standard.json
+++ b/data/elastic/smw-data-standard.json
@@ -210,12 +210,10 @@
 					"type": "integer"
 				},
 				"text_copy": {
-					"type": "text",
-					"doc_values": false
+					"type": "text"
 				},
 				"text_raw": {
-					"type": "text",
-					"doc_values": false
+					"type": "text"
 				},
 				"subject.title": {
 					"type": "text",

--- a/data/elastic/smw-lookup.json
+++ b/data/elastic/smw-lookup.json
@@ -6,11 +6,9 @@
 		"index.max_result_window": "50000"
 	},
 	"mappings": {
-		"lookup": {
-			"properties": {
-				"id": {
-					"type": "long"
-				}
+		"properties": {
+			"id": {
+				"type": "long"
 			}
 		}
 	}

--- a/includes/DefaultSettings.php
+++ b/includes/DefaultSettings.php
@@ -2485,15 +2485,15 @@ return (function() {
 			// 'localhost:9200'
 		],
 
-        ##
-        # ElasticSearch basic authentication credentials
-        #
-        # @since 4.2
-        ##
-        'smwgElasticsearchCredentials' => [
-            // 'user' => 'foo', 'pass' => 'bar'
-            // 'foo', 'bar'
-        ],
+		##
+		# ElasticSearch basic authentication credentials
+		#
+		# @since 4.2
+		##
+		'smwgElasticsearchCredentials' => [
+			// 'user' => 'foo', 'pass' => 'bar'
+			// 'foo', 'bar'
+		],
 
 		/**
 		 * If SMW should verify that the semantic data is up to date with the latest revision of a

--- a/includes/DefaultSettings.php
+++ b/includes/DefaultSettings.php
@@ -2485,6 +2485,16 @@ return (function() {
 			// 'localhost:9200'
 		],
 
+        ##
+        # ElasticSearch basic authentication credentials
+        #
+        # @since 4.2
+        ##
+        'smwgElasticsearchCredentials' => [
+            // 'user' => 'foo', 'pass' => 'bar'
+            // 'foo', 'bar'
+        ],
+
 		/**
 		 * If SMW should verify that the semantic data is up to date with the latest revision of a
 		 * page whenever this page is loaded. If the semantic data is out of date this will be shown

--- a/src/Elastic/Admin/ElasticClientTaskHandler.php
+++ b/src/Elastic/Admin/ElasticClientTaskHandler.php
@@ -274,8 +274,11 @@ class ElasticClientTaskHandler extends TaskHandler implements ActionableTask {
 
 		// Do not show credentials through special page
 		unset( $config['elastic/credentials'] );
-		unset( $endpoints['user'] );
-		unset( $endpoints['pass'] );
+
+		foreach ( $endpoints as &$endpoint ) {
+			unset( $endpoint['user'] );
+			unset( $endpoint['pass'] );
+		}
 
 		$config = ( new JsonView() )->create(
 			'elastic-config',

--- a/src/Elastic/Admin/ElasticClientTaskHandler.php
+++ b/src/Elastic/Admin/ElasticClientTaskHandler.php
@@ -272,6 +272,11 @@ class ElasticClientTaskHandler extends TaskHandler implements ActionableTask {
 		unset( $config['elastic/defaultstore'] );
 		unset( $config['elastic/endpoints'] );
 
+		// Do not show credentials through special page
+		unset( $config['elastic/credentials'] );
+		unset( $endpoints['user'] );
+		unset( $endpoints['pass'] );
+
 		$config = ( new JsonView() )->create(
 			'elastic-config',
 			$this->outputFormatter->encodeAsJson( $config ),

--- a/src/Elastic/Admin/MappingsInfoProvider.php
+++ b/src/Elastic/Admin/MappingsInfoProvider.php
@@ -74,12 +74,12 @@ class MappingsInfoProvider extends InfoProviderHandler {
 		$mappings = [
 			ElasticClient::TYPE_DATA => $connection->getMapping(
 				[
-					'index' => $connection->getIndexNameByType( ElasticClient::TYPE_DATA )
+					'index' => $connection->getIndexName( ElasticClient::TYPE_DATA )
 				]
 			),
 			ElasticClient::TYPE_LOOKUP => $connection->getMapping(
 				[
-					'index' => $connection->getIndexNameByType( ElasticClient::TYPE_LOOKUP )
+					'index' => $connection->getIndexName( ElasticClient::TYPE_LOOKUP )
 				]
 			)
 		];

--- a/src/Elastic/Admin/MappingsInfoProvider.php
+++ b/src/Elastic/Admin/MappingsInfoProvider.php
@@ -3,6 +3,7 @@
 namespace SMW\Elastic\Admin;
 
 use Html;
+use SMW\Elastic\Connection\Client;
 use SMW\Elastic\Connection\Client as ElasticClient;
 use WebRequest;
 use SMW\Utils\HtmlTabs;
@@ -158,19 +159,16 @@ class MappingsInfoProvider extends InfoProviderHandler {
 			]
 		];
 
-        // TODO: See what the structure of $mappings is without types and change these functions
-        //       to work with that new structure.
-		foreach ( $mappings as $inx ) {
-			foreach ( $inx as $key => $value ) {
-				$this->countFields( $value, $summary );
-				$this->countFields( $value,  $summary );
+		foreach ( $mappings as $type => $mapping ) {
+			foreach ( $mapping as $inx ) {
+				$this->countFields( $inx['mappings'], $type, $summary );
 			}
 		}
 
 		return $summary;
 	}
 
-	private function countFields( $mapping, &$count ) {
+	private function countFields( $mapping, $type, &$count ) {
 
 		foreach ( $mapping['properties'] as $k => $val ) {
 			foreach ( $val as $p => $v ) {

--- a/src/Elastic/Admin/MappingsInfoProvider.php
+++ b/src/Elastic/Admin/MappingsInfoProvider.php
@@ -70,18 +70,18 @@ class MappingsInfoProvider extends InfoProviderHandler {
 
 		$connection = $this->getStore()->getConnection( 'elastic' );
 
-		$mappings = array_merge(
-			$connection->getMapping(
+		$mappings = [
+            ElasticClient::TYPE_DATA => $connection->getMapping(
 				[
 					'index' => $connection->getIndexNameByType( ElasticClient::TYPE_DATA )
 				]
 			),
-			$connection->getMapping(
+			ElasticClient::TYPE_LOOKUP => $connection->getMapping(
 				[
 					'index' => $connection->getIndexNameByType( ElasticClient::TYPE_LOOKUP )
 				]
 			)
-		);
+		];
 
 		$limits = [
 			ElasticClient::TYPE_DATA => [
@@ -158,23 +158,21 @@ class MappingsInfoProvider extends InfoProviderHandler {
 			]
 		];
 
+        // TODO: See what the structure of $mappings is without types and change these functions
+        //       to work with that new structure.
 		foreach ( $mappings as $inx ) {
 			foreach ( $inx as $key => $value ) {
-				$this->countFields( $value, ElasticClient::TYPE_DATA, $summary );
-				$this->countFields( $value, ElasticClient::TYPE_LOOKUP, $summary );
+				$this->countFields( $value, $summary );
+				$this->countFields( $value,  $summary );
 			}
 		}
 
 		return $summary;
 	}
 
-	private function countFields( $value, $type, &$count ) {
+	private function countFields( $mapping, &$count ) {
 
-		if ( !isset( $value[$type] ) ) {
-			return;
-		}
-
-		foreach ( $value[$type]['properties'] as $k => $val ) {
+		foreach ( $mapping['properties'] as $k => $val ) {
 			foreach ( $val as $p => $v ) {
 				if ( $p === 'properties' ) {
 					foreach ( $v as $field => $mappings ) {

--- a/src/Elastic/Admin/MappingsInfoProvider.php
+++ b/src/Elastic/Admin/MappingsInfoProvider.php
@@ -72,7 +72,7 @@ class MappingsInfoProvider extends InfoProviderHandler {
 		$connection = $this->getStore()->getConnection( 'elastic' );
 
 		$mappings = [
-            ElasticClient::TYPE_DATA => $connection->getMapping(
+			ElasticClient::TYPE_DATA => $connection->getMapping(
 				[
 					'index' => $connection->getIndexNameByType( ElasticClient::TYPE_DATA )
 				]

--- a/src/Elastic/Admin/SettingsInfoProvider.php
+++ b/src/Elastic/Admin/SettingsInfoProvider.php
@@ -69,17 +69,15 @@ class SettingsInfoProvider extends InfoProviderHandler {
 
 		$connection = $this->getStore()->getConnection( 'elastic' );
 
-		// TODO: See what the structure of $mappings is without types and change these functions
-		//	   to work with that new structure.
 		$settings = [
-			$connection->getSettings(
+			ElasticClient::TYPE_DATA => $connection->getSettings(
 				[
-					'index' => $connection->getIndexNameByType( ElasticClient::TYPE_DATA )
+					'index' => $connection->getIndexName( ElasticClient::TYPE_DATA )
 				]
 			),
-			$connection->getSettings(
+			ElasticClient::TYPE_LOOKUP => $connection->getSettings(
 				[
-					'index' => $connection->getIndexNameByType( ElasticClient::TYPE_LOOKUP )
+					'index' => $connection->getIndexName( ElasticClient::TYPE_LOOKUP )
 				]
 			)
 		];

--- a/src/Elastic/Admin/SettingsInfoProvider.php
+++ b/src/Elastic/Admin/SettingsInfoProvider.php
@@ -69,8 +69,8 @@ class SettingsInfoProvider extends InfoProviderHandler {
 
 		$connection = $this->getStore()->getConnection( 'elastic' );
 
-        // TODO: See what the structure of $mappings is without types and change these functions
-        //       to work with that new structure.
+		// TODO: See what the structure of $mappings is without types and change these functions
+		//	   to work with that new structure.
 		$settings = [
 			$connection->getSettings(
 				[

--- a/src/Elastic/Admin/SettingsInfoProvider.php
+++ b/src/Elastic/Admin/SettingsInfoProvider.php
@@ -69,6 +69,8 @@ class SettingsInfoProvider extends InfoProviderHandler {
 
 		$connection = $this->getStore()->getConnection( 'elastic' );
 
+        // TODO: See what the structure of $mappings is without types and change these functions
+        //       to work with that new structure.
 		$settings = [
 			$connection->getSettings(
 				[

--- a/src/Elastic/Config.php
+++ b/src/Elastic/Config.php
@@ -23,6 +23,11 @@ class Config extends Options {
 	 */
 	const ELASTIC_ENDPOINTS = 'elastic/endpoints';
 
+    /**
+     * Describes ElasticSearch credentials
+     */
+    const ELASTIC_CREDENTIALS = 'elastic/credentials';
+
 	/**
 	 * Contains deprecated or renamed settings.
 	 *

--- a/src/Elastic/Config.php
+++ b/src/Elastic/Config.php
@@ -23,10 +23,10 @@ class Config extends Options {
 	 */
 	const ELASTIC_ENDPOINTS = 'elastic/endpoints';
 
-    /**
-     * Describes ElasticSearch credentials
-     */
-    const ELASTIC_CREDENTIALS = 'elastic/credentials';
+	/**
+	 * Describes ElasticSearch credentials
+	 */
+	const ELASTIC_CREDENTIALS = 'elastic/credentials';
 
 	/**
 	 * Contains deprecated or renamed settings.

--- a/src/Elastic/Connection/Client.php
+++ b/src/Elastic/Connection/Client.php
@@ -749,7 +749,7 @@ class Client {
 	 * @return bool
 	 */
 	public function aliasExists( string $index ): bool {
-		return $this->client->indices()->existsAlias( [ 'index' => $index ] );
+		return $this->client->indices()->existsAlias( [ 'name' => $index ] );
 	}
 
 	/**

--- a/src/Elastic/Connection/Client.php
+++ b/src/Elastic/Connection/Client.php
@@ -361,7 +361,7 @@ class Client {
 			'body'  => $this->getIndexDefByType( $type )
 		];
 
-		$response = $indices->create( $params );
+		$response = $indices->create( $params )->asArray();
 
 		$context = [
 			'method' => __METHOD__,

--- a/src/Elastic/Connection/Client.php
+++ b/src/Elastic/Connection/Client.php
@@ -331,7 +331,7 @@ class Client {
 			[
 				'index' => $index
 			]
-		)->asArray();
+		)->asBool();
 
 		return self::$hasIndex[$type] = $ret;
 	}

--- a/src/Elastic/Connection/Client.php
+++ b/src/Elastic/Connection/Client.php
@@ -2,8 +2,8 @@
 
 namespace SMW\Elastic\Connection;
 
-use Elasticsearch\Client as ElasticClient;
-use Elasticsearch\Common\Exceptions\NoNodesAvailableException;
+use Elastic\Elasticsearch\Client as ElasticClient;
+use Elastic\Transport\Exception\NoNodeAvailableException;
 use Exception;
 use Onoi\Cache\Cache;
 use Onoi\Cache\NullCache;
@@ -43,7 +43,7 @@ class Client {
 	const TYPE_LOOKUP = 'lookup';
 
 	/**
-	 * @var Client
+	 * @var ElasticClient
 	 */
 	private $client;
 
@@ -222,7 +222,7 @@ class Client {
 
 		try {
 			$info = $this->client->info( [] );
-		} catch( NoNodesAvailableException $e ) {
+		} catch( NoNodeAvailableException $e ) {
 			$info = [];
 		}
 
@@ -737,7 +737,7 @@ class Client {
 
 		try {
 			$results = $this->client->search( $params );
-		} catch ( NoNodesAvailableException $e ) {
+		} catch ( NoNodeAvailableException $e ) {
 			$errors[] = 'Elasticsearch endpoint returned with "' . $e->getMessage() . '" .';
 		} catch ( Exception $e ) {
 			$context['exception'] = $e->getMessage();

--- a/src/Elastic/Connection/Client.php
+++ b/src/Elastic/Connection/Client.php
@@ -807,6 +807,15 @@ class Client {
 		$this->client->indices()->close( [ 'index' => $index ] );
 	}
 
+    /**
+     * @since 4.2.0
+     *
+     * @param array $params
+     */
+    public function ingestPutPipeline( array $params ) {
+        $this->client->ingest()->putPipeline( $params );
+    }
+
 	/**
 	 * @since 3.1
 	 *

--- a/src/Elastic/Connection/Client.php
+++ b/src/Elastic/Connection/Client.php
@@ -7,8 +7,6 @@ use Elastic\Elasticsearch\Endpoints\Indices;
 use Elastic\Elasticsearch\Endpoints\Ingest;
 use Elastic\Transport\Exception\NoNodeAvailableException;
 use Exception;
-use Onoi\Cache\Cache;
-use Onoi\Cache\NullCache;
 use Psr\Log\LoggerAwareTrait;
 use Psr\Log\NullLogger;
 use SMW\Elastic\Exception\InvalidJSONException;
@@ -30,11 +28,7 @@ class Client {
 	use LoggerAwareTrait;
 
 	/**
-	 * @see https://www.elastic.co/blog/index-vs-type
-	 * @see https://www.elastic.co/guide/en/elasticsearch/reference/master/removal-of-types.html
-	 *
-	 * " ... Indices created in Elasticsearch 6.0.0 or later may only contain a
-	 * single mapping type ..."
+	 * Type for main data storage.
 	 */
 	const TYPE_DATA = 'data';
 
@@ -281,6 +275,7 @@ class Client {
 		$res = [];
 
 		if ( $type === 'indices' ) {
+            $params += [ 'format' => 'json' ];
 			$indices = $this->client->cat()->indices( $params )->asArray();
 
 			foreach ( $indices as $key => $value ) {

--- a/src/Elastic/Connection/ConnectionProvider.php
+++ b/src/Elastic/Connection/ConnectionProvider.php
@@ -2,7 +2,7 @@
 
 namespace SMW\Elastic\Connection;
 
-use Elastic\Elasticsearch\ClientBuilder;
+use Elasticsearch\ClientBuilder;
 use SMW\Elastic\Exception\ClientBuilderNotFoundException;
 use SMW\Elastic\Exception\MissingEndpointConfigException;
 use SMW\Connection\ConnectionProvider as IConnectionProvider;
@@ -158,7 +158,7 @@ class ConnectionProvider implements IConnectionProvider {
 
 		// Fail hard because someone selected the ElasticStore but forgot to install
 		// the elastic interface!
-		if ( !class_exists( 'Elastic\Elasticsearch\ClientBuilder' ) ) {
+		if ( !class_exists( 'Elasticsearch\ClientBuilder' ) ) {
 			throw new ClientBuilderNotFoundException();
 		}
 

--- a/src/Elastic/Connection/ConnectionProvider.php
+++ b/src/Elastic/Connection/ConnectionProvider.php
@@ -180,11 +180,11 @@ class ConnectionProvider implements IConnectionProvider {
 			return $host;
 		}
 
-		$schema = $host['schema'] ?? 'https';
+		$scheme = $host['scheme'] ?? 'https';
 		$hostName = $host['host'] ?? 'localhost';
 		$port = $host['port'] ?? 9200;
 
-		return $schema . '://' . $hostName . ':' . $port;
+		return $scheme . '://' . $hostName . ':' . $port;
 	}
 
 }

--- a/src/Elastic/Connection/ConnectionProvider.php
+++ b/src/Elastic/Connection/ConnectionProvider.php
@@ -67,7 +67,7 @@ class ConnectionProvider implements IConnectionProvider {
 			throw new MissingEndpointConfigException();
 		}
 
-        $endpoints = array_map( [$this, 'buildHostString'], $endpoints );
+		$endpoints = array_map( [$this, 'buildHostString'], $endpoints );
 
 		$params = [
 			'hosts' => $endpoints,
@@ -89,14 +89,14 @@ class ConnectionProvider implements IConnectionProvider {
 			// 'handler' => ClientBuilder::singleHandler()
 		];
 
-        $authentication = $this->config->safeGet( Config::ELASTIC_CREDENTIALS );
+		$authentication = $this->config->safeGet( Config::ELASTIC_CREDENTIALS );
 
-        if ( $authentication ) {
-            $user = $authentication['user'] ?? $authentication[0];
-            $pass = $authentication['pass'] ?? $authentication[1];
+		if ( $authentication ) {
+			$user = $authentication['user'] ?? $authentication[0];
+			$pass = $authentication['pass'] ?? $authentication[1];
 
-            $params['basicAuthentication'] = [$user, $pass];
-        }
+			$params['basicAuthentication'] = [$user, $pass];
+		}
 
 		if ( $this->hasAvailableClientBuilder() ) {
 			$clientBuilder = ClientBuilder::fromConfig( $params, true );
@@ -165,22 +165,22 @@ class ConnectionProvider implements IConnectionProvider {
 		return true;
 	}
 
-    /**
-     * ElasticSearch client 8.0 no longer supports the associative array syntax for hosts. This function acts as a
-     * B/C adapter, that transform a host in the old syntax to a host in the new syntax.
-     *
-     * @see https://github.com/elastic/elasticsearch-php/issues/1214
-     *
-     * @param array|string $host
-     * @return string
-     */
-    private function buildHostString( $host ): string {
+	/**
+	 * ElasticSearch client 8.0 no longer supports the associative array syntax for hosts. This function acts as a
+	 * B/C adapter, that transform a host in the old syntax to a host in the new syntax.
+	 *
+	 * @see https://github.com/elastic/elasticsearch-php/issues/1214
+	 *
+	 * @param array|string $host
+	 * @return string
+	 */
+	private function buildHostString( $host ): string {
 
-        if ( is_string( $host ) ) {
-            return $host;
-        }
+		if ( is_string( $host ) ) {
+			return $host;
+		}
 
-        $schema = $host['schema'] ?? 'https';
+		$schema = $host['schema'] ?? 'https';
         $hostName = $host['host'] ?? 'localhost';
         $port = $host['port'] ?? 9200;
 

--- a/src/Elastic/Connection/ConnectionProvider.php
+++ b/src/Elastic/Connection/ConnectionProvider.php
@@ -148,7 +148,7 @@ class ConnectionProvider implements IConnectionProvider {
 
 		// Fail hard because someone selected the ElasticStore but forgot to install
 		// the elastic interface!
-		if ( !class_exists( '\Elasticsearch\ClientBuilder' ) ) {
+		if ( !class_exists( 'Elastic\Elasticsearch\ClientBuilder' ) ) {
 			throw new ClientBuilderNotFoundException();
 		}
 

--- a/src/Elastic/Connection/ConnectionProvider.php
+++ b/src/Elastic/Connection/ConnectionProvider.php
@@ -2,7 +2,7 @@
 
 namespace SMW\Elastic\Connection;
 
-use Elasticsearch\ClientBuilder;
+use Elastic\Elasticsearch\ClientBuilder;
 use SMW\Elastic\Exception\ClientBuilderNotFoundException;
 use SMW\Elastic\Exception\MissingEndpointConfigException;
 use SMW\Services\ServicesFactory as ApplicationFactory;

--- a/src/Elastic/Connection/ConnectionProvider.php
+++ b/src/Elastic/Connection/ConnectionProvider.php
@@ -176,9 +176,9 @@ class ConnectionProvider implements IConnectionProvider {
         $hostName = $host['host'] ?? 'localhost';
         $port = $host['port'] ?? 9200;
 
-        if ( isset( $host['username'] ) && isset( $host['password'] ) ) {
+        if ( isset( $host['user'] ) && isset( $host['pass'] ) ) {
             // Basic authentication should be used
-            return $schema . '://' . $host['username'] . ':' . $host['password'] . '@' . $hostName . ':' . $port;
+            return $schema . '://' . $host['user'] . ':' . $host['pass'] . '@' . $hostName . ':' . $port;
         } else {
             // No authentication
             return $schema . '://' . $hostName . ':' . $port;

--- a/src/Elastic/Connection/ConnectionProvider.php
+++ b/src/Elastic/Connection/ConnectionProvider.php
@@ -181,10 +181,10 @@ class ConnectionProvider implements IConnectionProvider {
 		}
 
 		$schema = $host['schema'] ?? 'https';
-        $hostName = $host['host'] ?? 'localhost';
-        $port = $host['port'] ?? 9200;
+		$hostName = $host['host'] ?? 'localhost';
+		$port = $host['port'] ?? 9200;
 
-        return $schema . '://' . $hostName . ':' . $port;
-    }
+		return $schema . '://' . $hostName . ':' . $port;
+	}
 
 }

--- a/src/Elastic/Connection/ConnectionProvider.php
+++ b/src/Elastic/Connection/ConnectionProvider.php
@@ -90,6 +90,15 @@ class ConnectionProvider implements IConnectionProvider {
 			// 'handler' => ClientBuilder::singleHandler()
 		];
 
+        $authentication = $this->config->safeGet( Config::ELASTIC_CREDENTIALS );
+
+        if ( $authentication ) {
+            $user = $authentication['user'] ?? $authentication[0];
+            $pass = $authentication['pass'] ?? $authentication[1];
+
+            $params['basicAuthentication'] = [$user, $pass];
+        }
+
 		if ( $this->hasAvailableClientBuilder() ) {
 			$clientBuilder = ClientBuilder::fromConfig( $params, true );
 		}
@@ -176,13 +185,7 @@ class ConnectionProvider implements IConnectionProvider {
         $hostName = $host['host'] ?? 'localhost';
         $port = $host['port'] ?? 9200;
 
-        if ( isset( $host['user'] ) && isset( $host['pass'] ) ) {
-            // Basic authentication should be used
-            return $schema . '://' . $host['user'] . ':' . $host['pass'] . '@' . $hostName . ':' . $port;
-        } else {
-            // No authentication
-            return $schema . '://' . $hostName . ':' . $port;
-        }
+        return $schema . '://' . $hostName . ':' . $port;
     }
 
 }

--- a/src/Elastic/Connection/ConnectionProvider.php
+++ b/src/Elastic/Connection/ConnectionProvider.php
@@ -5,7 +5,6 @@ namespace SMW\Elastic\Connection;
 use Elastic\Elasticsearch\ClientBuilder;
 use SMW\Elastic\Exception\ClientBuilderNotFoundException;
 use SMW\Elastic\Exception\MissingEndpointConfigException;
-use SMW\Services\ServicesFactory as ApplicationFactory;
 use SMW\Connection\ConnectionProvider as IConnectionProvider;
 use SMW\Elastic\Config;
 use Psr\Log\LoggerAwareTrait;
@@ -33,7 +32,7 @@ class ConnectionProvider implements IConnectionProvider {
 	private $config;
 
 	/**
-	 * @var ElasticClient
+	 * @var Client
 	 */
 	private $connection;
 
@@ -53,7 +52,7 @@ class ConnectionProvider implements IConnectionProvider {
 	 *
 	 * @since 3.0
 	 *
-	 * @return Connection
+	 * @return Client
 	 */
 	public function getConnection() {
 

--- a/src/Elastic/Connection/DummyClient.php
+++ b/src/Elastic/Connection/DummyClient.php
@@ -63,13 +63,6 @@ class DummyClient extends Client {
 	}
 
 	/**
-	 * @see Client::getIndexNameByType
-	 */
-	public function getIndexNameByType( $type ) {
-		return $this->getIndexName( $type );
-	}
-
-	/**
 	 * @see Client::getIndexName
 	 */
 	public function getIndexName( $type ) {
@@ -77,9 +70,9 @@ class DummyClient extends Client {
 	}
 
 	/**
-	 * @see Client::getIndexDefByType
+	 * @see Client::getIndexDefinition
 	 */
-	public function getIndexDefByType( $type ) {
+	public function getIndexDefinition($type ) {
 		return '';
 	}
 

--- a/src/Elastic/Connection/DummyClient.php
+++ b/src/Elastic/Connection/DummyClient.php
@@ -35,7 +35,7 @@ class DummyClient extends Client {
 	/**
 	 * @since 3.0
 	 *
-	 * @param \Elastic\Elasticsearch\Client $client
+	 * @param \Elasticsearch\Client $client
 	 * @param Cache|null $cache
 	 * @param Config|null $config
 	 */

--- a/src/Elastic/Connection/DummyClient.php
+++ b/src/Elastic/Connection/DummyClient.php
@@ -5,7 +5,6 @@ namespace SMW\Elastic\Connection;
 use Onoi\Cache\Cache;
 use Onoi\Cache\NullCache;
 use Psr\Log\NullLogger;
-use RuntimeException;
 use SMW\Elastic\Config;
 
 /**
@@ -21,7 +20,7 @@ class DummyClient extends Client {
 	/**
 	 * @var Client
 	 */
-	private $client;
+	protected $client;
 
 	/**
 	 * @var Cache
@@ -36,7 +35,7 @@ class DummyClient extends Client {
 	/**
 	 * @since 3.0
 	 *
-	 * @param ElasticClient $client
+	 * @param \Elastic\Elasticsearch\Client $client
 	 * @param Cache|null $cache
 	 * @param Config|null $config
 	 */
@@ -137,7 +136,7 @@ class DummyClient extends Client {
 	/**
 	 * @see Client::deleteIndex
 	 */
-	public function deleteIndex( $type ) {}
+	public function deleteIndex( $index ) {}
 
 	/**
 	 * @see Client::putSettings
@@ -245,6 +244,35 @@ class DummyClient extends Client {
 	public function explain( array $params ) {
 		return [];
 	}
+
+	/**
+	 * @see Client::updateAliases
+	 */
+	public function updateAliases( array $params ) {}
+
+	/**
+	 * @see Client::indexExists
+	 */
+	public function indexExists( string $index ): bool {
+		return true;
+	}
+
+	/**
+	 * @see Client::aliasExists
+	 */
+	public function aliasExists( string $index ): bool {
+		return true;
+	}
+
+	/**
+	 * @see Client::openIndex
+	 */
+	public function openIndex( string $index ) {}
+
+	/**
+	 * @see Client::closeIndex
+	 */
+	public function closeIndex( string $index ) {}
 
 	/**
 	 * @see Client::hasMaintenanceLock

--- a/src/Elastic/Connection/DummyClient.php
+++ b/src/Elastic/Connection/DummyClient.php
@@ -65,14 +65,14 @@ class DummyClient extends Client {
 	/**
 	 * @see Client::getIndexName
 	 */
-	public function getIndexName( $type ) {
+	public function getIndexName( string $type ): string {
 		return '';
 	}
 
 	/**
 	 * @see Client::getIndexDefinition
 	 */
-	public function getIndexDefinition($type ) {
+	public function getIndexDefinition( string $type ): string {
 		return '';
 	}
 
@@ -96,14 +96,14 @@ class DummyClient extends Client {
 	/**
 	 * @see Client::info
 	 */
-	public function info() {
+	public function info(): array {
 		return [];
 	}
 
 	/**
 	 * @see Client::stats
 	 */
-	public function stats( $type = 'indices', $params = [] ) {
+	public function stats( string $type = 'indices', array $params = [] ): array {
 		return [];
 	}
 

--- a/src/Elastic/Connection/TestClient.php
+++ b/src/Elastic/Connection/TestClient.php
@@ -48,7 +48,7 @@ class TestClient extends Client {
 
 		// https://discuss.elastic.co/t/es-5-2-refresh-interval-doesnt-work-if-set-to-0/79248/2
 		// Make sure the replication/index lag doesn't hinder the search
-		$this->indices()->refresh( [ 'index' => $params['index'] ] );
+		$this->client->indices()->refresh( [ 'index' => $params['index'] ] );
 
 		return parent::count( $params );
 	}
@@ -67,7 +67,7 @@ class TestClient extends Client {
 			return [];
 		}
 
-		$this->indices()->refresh( [ 'index' => $params['index'] ] );
+		$this->client->indices()->refresh( [ 'index' => $params['index'] ] );
 
 		return parent::search( $params );
 	}
@@ -88,7 +88,7 @@ class TestClient extends Client {
 
 		// https://discuss.elastic.co/t/es-5-2-refresh-interval-doesnt-work-if-set-to-0/79248/2
 		// Make sure the replication/index lag doesn't hinder the search
-		$this->indices()->refresh( [ 'index' => $params['index'] ] );
+		$this->client->indices()->refresh( [ 'index' => $params['index'] ] );
 
 		return parent::explain( $params );
 	}

--- a/src/Elastic/ElasticFactory.php
+++ b/src/Elastic/ElasticFactory.php
@@ -94,10 +94,10 @@ class ElasticFactory {
 			$settings->get( 'smwgElasticsearchEndpoints' )
 		);
 
-        $config->set(
-            Config::ELASTIC_CREDENTIALS,
-            $settings->get( 'smwgElasticsearchCredentials' )
-        );
+		$config->set(
+			Config::ELASTIC_CREDENTIALS,
+			$settings->get( 'smwgElasticsearchCredentials' )
+		);
 
 		$config->loadFromJSON(
 			$config->readFile( $settings->get( 'smwgElasticsearchProfile' ) )

--- a/src/Elastic/ElasticFactory.php
+++ b/src/Elastic/ElasticFactory.php
@@ -94,6 +94,11 @@ class ElasticFactory {
 			$settings->get( 'smwgElasticsearchEndpoints' )
 		);
 
+        $config->set(
+            Config::ELASTIC_CREDENTIALS,
+            $settings->get( 'smwgElasticsearchCredentials' )
+        );
+
 		$config->loadFromJSON(
 			$config->readFile( $settings->get( 'smwgElasticsearchProfile' ) )
 		);

--- a/src/Elastic/Indexer/Attachment/FileAttachment.php
+++ b/src/Elastic/Indexer/Attachment/FileAttachment.php
@@ -97,12 +97,8 @@ class FileAttachment {
 		$semanticData = $this->store->getSemanticData( $dataItem );
 		$connection = $this->indexer->getConnection();
 
-		$index = $this->indexer->getIndexName( ElasticClient::TYPE_DATA );
-		$doc = [ '_source' => [] ];
-
 		$params = [
-			'index' => $index,
-			'type'  => ElasticClient::TYPE_DATA,
+			'index' => $this->indexer->getIndexName( ElasticClient::TYPE_DATA ),
 			'id'    => $dataItem->getId(),
 		];
 
@@ -275,8 +271,7 @@ class FileAttachment {
 	private function upsertDoc( $baseDocId, $subject, $property ) {
 
 		$params = [
-			'_index' => $this->indexer->getIndexName( ElasticClient::TYPE_DATA ),
-			'_type'  => ElasticClient::TYPE_DATA
+			'_index' => $this->indexer->getIndexName( ElasticClient::TYPE_DATA )
 		];
 
 		$this->bulk->clear();

--- a/src/Elastic/Indexer/FileIndexer.php
+++ b/src/Elastic/Indexer/FileIndexer.php
@@ -115,9 +115,7 @@ class FileIndexer {
 	 */
 	public function getIndexName( $type ) {
 
-		$index = $this->store->getConnection( 'elastic' )->getIndexNameByType(
-			$type
-		);
+		$index = $this->store->getConnection( 'elastic' )->getIndexName( $type );
 
 		// If the rebuilder has set a specific version, use it to avoid writing to
 		// the alias of the index when running a rebuild.

--- a/src/Elastic/Indexer/FileIndexer.php
+++ b/src/Elastic/Indexer/FileIndexer.php
@@ -238,7 +238,6 @@ class FileIndexer {
 
 		$params = [
 			'index' => $index,
-			'type'  => ElasticClient::TYPE_DATA,
 			'id'    => $id,
 		];
 

--- a/src/Elastic/Indexer/FileIndexer.php
+++ b/src/Elastic/Indexer/FileIndexer.php
@@ -215,7 +215,7 @@ class FileIndexer {
 		];
 
 		$connection = $this->store->getConnection( 'elastic' );
-		$connection->ingest()->putPipeline( $params );
+		$connection->ingestPutPipeline( $params );
 
 		if ( $file === null ) {
 			$file = $this->findFile( $title );

--- a/src/Elastic/Indexer/Indexer.php
+++ b/src/Elastic/Indexer/Indexer.php
@@ -244,7 +244,7 @@ class Indexer {
 
 		$params = [
 			'index' => $this->getIndexName( ElasticClient::TYPE_DATA ),
-            'id'    => $dataItem->getId()
+			'id'	=> $dataItem->getId()
 		];
 
 		$data['subject'] = $this->makeSubject( $dataItem );

--- a/src/Elastic/Indexer/Indexer.php
+++ b/src/Elastic/Indexer/Indexer.php
@@ -176,13 +176,8 @@ class Indexer {
 			return IndexerRecoveryJob::pushFromParams( $title, [ 'delete' => $idList ] );
 		}
 
-		$index = $this->getIndexName(
-			ElasticClient::TYPE_DATA
-		);
-
 		$params = [
-			'_index' => $index,
-			'_type'  => ElasticClient::TYPE_DATA
+			'_index' => $this->getIndexName( ElasticClient::TYPE_DATA )
 		];
 
 		$this->bulk->clear();
@@ -198,7 +193,6 @@ class Indexer {
 				$this->bulk->delete(
 					[
 						'_index' => $this->getIndexName( ElasticClient::TYPE_LOOKUP ),
-						'_type' => ElasticClient::TYPE_LOOKUP,
 						'_id' => md5( $id )
 					]
 				);
@@ -250,8 +244,7 @@ class Indexer {
 
 		$params = [
 			'index' => $this->getIndexName( ElasticClient::TYPE_DATA ),
-			'type'  => ElasticClient::TYPE_DATA,
-			'id'    => $dataItem->getId()
+            'id'    => $dataItem->getId()
 		];
 
 		$data['subject'] = $this->makeSubject( $dataItem );
@@ -323,8 +316,7 @@ class Indexer {
 		}
 
 		$params = [
-			'_index' => $this->getIndexName( ElasticClient::TYPE_DATA ),
-			'_type'  => ElasticClient::TYPE_DATA
+			'_index' => $this->getIndexName( ElasticClient::TYPE_DATA )
 		];
 
 		$this->bulk->clear();

--- a/src/Elastic/Indexer/Indexer.php
+++ b/src/Elastic/Indexer/Indexer.php
@@ -146,9 +146,7 @@ class Indexer {
 	 */
 	public function getIndexName( $type ) {
 
-		$index = $this->store->getConnection( 'elastic' )->getIndexNameByType(
-			$type
-		);
+		$index = $this->store->getConnection( 'elastic' )->getIndexName( $type );
 
 		// If the rebuilder has set a specific version, use it to avoid writing to
 		// the alias of the index when running a rebuild.

--- a/src/Elastic/Indexer/Rebuilder/Rebuilder.php
+++ b/src/Elastic/Indexer/Rebuilder/Rebuilder.php
@@ -485,7 +485,7 @@ class Rebuilder {
 		$indices = $this->client->indices();
 
 		// No Alias available, create one before the rollover
-		if ( !$indices->exists( [ 'index' => "$index" ] ) ) {
+		if ( !$indices->exists( [ 'index' => "$index" ] )->asBool() ) {
 			$actions = [
 				[ 'add' => [ 'index' => "$index-$version", 'alias' => $index ] ]
 			];

--- a/src/Elastic/Indexer/Rebuilder/Rebuilder.php
+++ b/src/Elastic/Indexer/Rebuilder/Rebuilder.php
@@ -206,7 +206,7 @@ class Rebuilder {
 	public function hasIndices() {
 
 		return $this->client->hasIndex( ElasticClient::TYPE_DATA ) &&
-            $this->client->hasIndex( ElasticClient::TYPE_LOOKUP );
+			$this->client->hasIndex( ElasticClient::TYPE_LOOKUP );
 	}
 
 	/**
@@ -394,8 +394,6 @@ class Rebuilder {
 			$cliMsgFormatter->oneCol( "... $type index ...", 3 )
 		);
 
-		$indices = $this->client->indices();
-
 		$index = $this->client->getIndexName(
 			$type
 		);
@@ -410,11 +408,9 @@ class Rebuilder {
 
 		// Certain changes ( ... to define new analyzers ...) requires to close
 		// and reopen an index
-		$indices->close( [ 'index' => $index ] );
+		$this->client->closeIndex( $index );
 
-		$indexDef = $this->client->getIndexDefByType(
-			$type
-		);
+		$indexDef = $this->client->getIndexDefByType( $type );
 
 		$indexDef = json_decode( $indexDef, true );
 
@@ -447,8 +443,7 @@ class Rebuilder {
 		$this->client->putMapping( $params );
 
 		$this->messageReporter->reportMessage( ', reopening ...' );
-		$indices->open( [ 'index' => $index ] );
-
+		$this->client->openIndex( $index );
 
 		$this->client->releaseLock( $type );
 
@@ -474,7 +469,6 @@ class Rebuilder {
 		}
 
 		$index = $this->client->getIndexName( $type );
-		$indices = $this->client->indices();
 
 		// No Alias available, create one before the rollover
 		if ( !$this->client->indexExists( "$index" ) ) {
@@ -484,7 +478,7 @@ class Rebuilder {
 
 			$params['body'] = [ 'actions' => $actions ];
 
-			$indices->updateAliases( $params );
+			$this->client->updateAliases( $params );
 		}
 
 		$this->versions[$type] = $version;

--- a/src/Elastic/Indexer/Rebuilder/Rebuilder.php
+++ b/src/Elastic/Indexer/Rebuilder/Rebuilder.php
@@ -205,15 +205,8 @@ class Rebuilder {
 	 */
 	public function hasIndices() {
 
-		if ( !$this->client->hasIndex( ElasticClient::TYPE_DATA ) ) {
-			return false;
-		}
-
-		if ( !$this->client->hasIndex( ElasticClient::TYPE_LOOKUP ) ) {
-			return false;
-		}
-
-		return true;
+		return $this->client->hasIndex( ElasticClient::TYPE_DATA ) &&
+            $this->client->hasIndex( ElasticClient::TYPE_LOOKUP );
 	}
 
 	/**
@@ -269,7 +262,6 @@ class Rebuilder {
 
 		$params = [
 			'index' => $index,
-			'type' => ElasticClient::TYPE_DATA,
 			'id' => $id
 		];
 

--- a/src/Elastic/Indexer/Rebuilder/Rebuilder.php
+++ b/src/Elastic/Indexer/Rebuilder/Rebuilder.php
@@ -477,7 +477,7 @@ class Rebuilder {
 		$indices = $this->client->indices();
 
 		// No Alias available, create one before the rollover
-		if ( !$indices->exists( [ 'index' => "$index" ] )->asBool() ) {
+		if ( !$this->client->indexExists( "$index" ) ) {
 			$actions = [
 				[ 'add' => [ 'index' => "$index-$version", 'alias' => $index ] ]
 			];

--- a/src/Elastic/Indexer/Rebuilder/Rebuilder.php
+++ b/src/Elastic/Indexer/Rebuilder/Rebuilder.php
@@ -411,7 +411,6 @@ class Rebuilder {
 		$this->client->closeIndex( $index );
 
 		$indexDef = $this->client->getIndexDefinition( $type );
-
 		$indexDef = json_decode( $indexDef, true );
 
 		// Cannot be altered by a simple settings update and requires a complete
@@ -436,7 +435,6 @@ class Rebuilder {
 
 		$params = [
 			'index' => $index,
-			'type'  => $type,
 			'body'  => $indexDef['mappings'] ?? []
 		];
 

--- a/src/Elastic/Indexer/Rebuilder/Rebuilder.php
+++ b/src/Elastic/Indexer/Rebuilder/Rebuilder.php
@@ -410,7 +410,7 @@ class Rebuilder {
 		// and reopen an index
 		$this->client->closeIndex( $index );
 
-		$indexDef = $this->client->getIndexDefByType( $type );
+		$indexDef = $this->client->getIndexDefinition( $type );
 
 		$indexDef = json_decode( $indexDef, true );
 

--- a/src/Elastic/Indexer/Rebuilder/Rollover.php
+++ b/src/Elastic/Indexer/Rebuilder/Rollover.php
@@ -53,7 +53,7 @@ class Rollover {
 		$old = $version === 'v2' ? 'v1' : 'v2';
 		$check = false;
 
-		if ( $indices->exists( [ 'index' => "$index-$old" ] ) ) {
+		if ( $indices->exists( [ 'index' => "$index-$old" ] )->asBool() ) {
 			$actions = [
 				[ 'remove' => [ 'index' => "$index-$old", 'alias' => $index ] ],
 				[ 'add' => [ 'index' => "$index-$version", 'alias' => $index ] ]
@@ -73,7 +73,7 @@ class Rollover {
 
 		$indices->updateAliases( $params );
 
-		if ( $check && $indices->exists( [ 'index' => "$index-$old" ] ) ) {
+		if ( $check && $indices->exists( [ 'index' => "$index-$old" ] )->asBool() ) {
 			$indices->delete( [ "index" => "$index-$old" ] );
 		}
 
@@ -104,21 +104,21 @@ class Rollover {
 
 		// Shouldn't happen but just in case where the root index is
 		// used as index but not an alias
-		if ( $indices->exists( [ 'index' => "$index" ] ) && !$indices->existsAlias( [ 'name' => "$index" ] ) ) {
+		if ( $indices->exists( [ 'index' => "$index" ] )->asBool() && !$indices->existsAlias( [ 'name' => "$index" ] )->asBool() ) {
 			$indices->delete( [ 'index' => "$index" ] );
 		}
 
 		// Check v1/v2 and if both exists (which shouldn't happen but most likely
 		// caused by an unfinshed rebuilder run) then use v1 as master
-		if ( $indices->exists( [ 'index' => "$index-v1" ] ) ) {
+		if ( $indices->exists( [ 'index' => "$index-v1" ] )->asBool() ) {
 
 			// Just in case
-			if ( $indices->exists( [ 'index' => "$index-v2" ] ) ) {
+			if ( $indices->exists( [ 'index' => "$index-v2" ] )->asBool() ) {
 				$indices->delete( [ 'index' => "$index-v2" ] );
 			}
 
 			$actions[] = [ 'add' => [ 'index' => "$index-v1", 'alias' => $index ] ];
-		} elseif ( $indices->exists( [ 'index' => "$index-v2" ] ) ) {
+		} elseif ( $indices->exists( [ 'index' => "$index-v2" ] )->asBool() ) {
 			$actions[] = [ 'add' => [ 'index' => "$index-v2", 'alias' => $index ] ];
 		} else {
 			$version = $this->connection->createIndex( $type );
@@ -154,15 +154,15 @@ class Rollover {
 			$type
 		);
 
-		if ( $indices->exists( [ 'index' => "$index-v1" ] ) ) {
+		if ( $indices->exists( [ 'index' => "$index-v1" ] )->asBool() ) {
 			$indices->delete( [ 'index' => "$index-v1" ] );
 		}
 
-		if ( $indices->exists( [ 'index' => "$index-v2" ] ) ) {
+		if ( $indices->exists( [ 'index' => "$index-v2" ] )->asBool() ) {
 			$indices->delete( [ 'index' => "$index-v2" ] );
 		}
 
-		if ( $indices->exists( [ 'index' => "$index" ] ) && !$indices->existsAlias( [ 'name' => "$index" ] ) ) {
+		if ( $indices->exists( [ 'index' => "$index" ] )->asBool() && !$indices->existsAlias( [ 'name' => "$index" ] )->asBool() ) {
 			$indices->delete( [ 'index' => "$index" ] );
 		}
 

--- a/src/Elastic/Indexer/Rebuilder/Rollover.php
+++ b/src/Elastic/Indexer/Rebuilder/Rollover.php
@@ -44,7 +44,7 @@ class Rollover {
 	 */
 	public function rollover( $type, $version ) {
 
-		$index = $this->connection->getIndexNameByType( $type );
+		$index = $this->connection->getIndexName( $type );
 
 		$params = [];
 

--- a/src/Elastic/Indexer/Rebuilder/Rollover.php
+++ b/src/Elastic/Indexer/Rebuilder/Rollover.php
@@ -48,12 +48,11 @@ class Rollover {
 		$indices = $this->connection->indices();
 
 		$params = [];
-		$actions = [];
 
 		$old = $version === 'v2' ? 'v1' : 'v2';
 		$check = false;
 
-		if ( $indices->exists( [ 'index' => "$index-$old" ] )->asBool() ) {
+		if ( $this->connection->indexExists( "$index-$old" ) ) {
 			$actions = [
 				[ 'remove' => [ 'index' => "$index-$old", 'alias' => $index ] ],
 				[ 'add' => [ 'index' => "$index-$version", 'alias' => $index ] ]
@@ -73,7 +72,7 @@ class Rollover {
 
 		$indices->updateAliases( $params );
 
-		if ( $check && $indices->exists( [ 'index' => "$index-$old" ] )->asBool() ) {
+		if ( $check && $this->connection->indexExists( "$index-$old" ) ) {
 			$indices->delete( [ "index" => "$index-$old" ] );
 		}
 
@@ -104,21 +103,21 @@ class Rollover {
 
 		// Shouldn't happen but just in case where the root index is
 		// used as index but not an alias
-		if ( $indices->exists( [ 'index' => "$index" ] )->asBool() && !$indices->existsAlias( [ 'name' => "$index" ] )->asBool() ) {
+		if ( $this->connection->indexExists("$index" ) && !$indices->existsAlias( [ 'name' => "$index" ] )->asBool() ) {
 			$indices->delete( [ 'index' => "$index" ] );
 		}
 
 		// Check v1/v2 and if both exists (which shouldn't happen but most likely
 		// caused by an unfinshed rebuilder run) then use v1 as master
-		if ( $indices->exists( [ 'index' => "$index-v1" ] )->asBool() ) {
+		if ( $this->connection->indexExists( "$index-v1" ) ) {
 
 			// Just in case
-			if ( $indices->exists( [ 'index' => "$index-v2" ] )->asBool() ) {
+			if ( $this->connection->indexExists( "$index-v2" ) ) {
 				$indices->delete( [ 'index' => "$index-v2" ] );
 			}
 
 			$actions[] = [ 'add' => [ 'index' => "$index-v1", 'alias' => $index ] ];
-		} elseif ( $indices->exists( [ 'index' => "$index-v2" ] )->asBool() ) {
+		} elseif ( $this->connection->indexExists( "$index-v2" ) ) {
 			$actions[] = [ 'add' => [ 'index' => "$index-v2", 'alias' => $index ] ];
 		} else {
 			$version = $this->connection->createIndex( $type );
@@ -154,15 +153,15 @@ class Rollover {
 			$type
 		);
 
-		if ( $indices->exists( [ 'index' => "$index-v1" ] )->asBool() ) {
+		if ( $this->connection->indexExists( "$index-v1" ) ) {
 			$indices->delete( [ 'index' => "$index-v1" ] );
 		}
 
-		if ( $indices->exists( [ 'index' => "$index-v2" ] )->asBool() ) {
+		if ( $this->connection->indexExists( "$index-v2" ) ) {
 			$indices->delete( [ 'index' => "$index-v2" ] );
 		}
 
-		if ( $indices->exists( [ 'index' => "$index" ] )->asBool() && !$indices->existsAlias( [ 'name' => "$index" ] )->asBool() ) {
+		if ( $this->connection->indexExists( "$index" ) && !$indices->existsAlias( [ 'name' => "$index" ] )->asBool() ) {
 			$indices->delete( [ 'index' => "$index" ] );
 		}
 

--- a/src/Elastic/Indexer/Replication/ReplicationStatus.php
+++ b/src/Elastic/Indexer/Replication/ReplicationStatus.php
@@ -71,7 +71,6 @@ class ReplicationStatus {
 
 		$params = [
 			'index' => $this->connection->getIndexName( ElasticClient::TYPE_DATA ),
-			'type'  => ElasticClient::TYPE_DATA,
 			'id'    => $id,
 		];
 
@@ -89,7 +88,6 @@ class ReplicationStatus {
 
 		$params = [
 			'index' => $this->connection->getIndexName( ElasticClient::TYPE_DATA ),
-			'type'  => ElasticClient::TYPE_DATA,
 			'id'    => $id,
 		];
 
@@ -130,7 +128,6 @@ class ReplicationStatus {
 
 		$params = [
 			'index' => $this->connection->getIndexName( ElasticClient::TYPE_DATA ),
-			'type'  => ElasticClient::TYPE_DATA,
 			'id'    => $id,
 		];
 
@@ -167,7 +164,6 @@ class ReplicationStatus {
 
 		$params = [
 			'index' => $this->connection->getIndexName( ElasticClient::TYPE_DATA ),
-			'type'  => ElasticClient::TYPE_DATA,
 			'id'    => $id,
 		];
 
@@ -225,7 +221,6 @@ class ReplicationStatus {
 
 		$params = [
 			'index' => $this->connection->getIndexName( ElasticClient::TYPE_DATA ),
-			'type'  => ElasticClient::TYPE_DATA,
 			'body'  => $body
 		];
 

--- a/src/Elastic/Lookup/ProximityPropertyValueLookup.php
+++ b/src/Elastic/Lookup/ProximityPropertyValueLookup.php
@@ -138,7 +138,6 @@ class ProximityPropertyValueLookup {
 
 		$params = [
 			'index' => $connection->getIndexName( ElasticClient::TYPE_DATA ),
-			'type'  => ElasticClient::TYPE_DATA,
 			'body'  => $body
 		];
 

--- a/src/Elastic/QueryEngine/QueryEngine.php
+++ b/src/Elastic/QueryEngine/QueryEngine.php
@@ -184,7 +184,7 @@ class QueryEngine implements IQueryEngine {
 		$connection = $this->store->getConnection( 'elastic' );
 
 		$params = [
-			'index' => $connection->getIndexNameByType( ElasticClient::TYPE_DATA ),
+			'index' => $connection->getIndexName( ElasticClient::TYPE_DATA ),
 			'body'  => $body
 		];
 

--- a/src/Elastic/QueryEngine/QueryEngine.php
+++ b/src/Elastic/QueryEngine/QueryEngine.php
@@ -183,13 +183,8 @@ class QueryEngine implements IQueryEngine {
 
 		$connection = $this->store->getConnection( 'elastic' );
 
-		$index = $connection->getIndexNameByType(
-			ElasticClient::TYPE_DATA
-		);
-
 		$params = [
-			'index' => $index,
-			'type'  => ElasticClient::TYPE_DATA,
+			'index' => $connection->getIndexNameByType( ElasticClient::TYPE_DATA ),
 			'body'  => $body
 		];
 

--- a/src/Elastic/QueryEngine/TermsLookup/TermsLookup.php
+++ b/src/Elastic/QueryEngine/TermsLookup/TermsLookup.php
@@ -329,7 +329,6 @@ class TermsLookup implements ITermsLookup {
 
 		$params = [
 			'index' => $connection->getIndexName( ElasticClient::TYPE_LOOKUP ),
-			'type'  => ElasticClient::TYPE_LOOKUP,
 			'id'    => $id
 		];
 
@@ -344,12 +343,11 @@ class TermsLookup implements ITermsLookup {
 
 		$params = [
 			'index' => $connection->getIndexName( ElasticClient::TYPE_DATA ),
-			'type'  => ElasticClient::TYPE_DATA,
 			'body'  => $parameters->get( 'search.body' ),
 			'size'  => $this->options->safeGet( 'subquery.size', 100 )
 		];
 
-		$info = $info + [
+		$info += [
 			'query' => $params,
 			'search_info' => [ 'search_info' => [ 'total' => 0 ] ],
 			'isFromCache' => false
@@ -393,7 +391,6 @@ class TermsLookup implements ITermsLookup {
 
 		$params = [
 			'index' => $connection->getIndexName( ElasticClient::TYPE_LOOKUP ),
-			'type'  => ElasticClient::TYPE_LOOKUP,
 			'id'    => $id
 		];
 

--- a/src/Settings.php
+++ b/src/Settings.php
@@ -201,6 +201,7 @@ class Settings extends Options {
 			'smwgElasticsearchConfig' => $GLOBALS['smwgElasticsearchConfig'],
 			'smwgElasticsearchProfile' => $GLOBALS['smwgElasticsearchProfile'],
 			'smwgElasticsearchEndpoints' => $GLOBALS['smwgElasticsearchEndpoints'],
+            'smwgElasticsearchCredentials' => $GLOBALS['smwgElasticsearchCredentials'],
 			'smwgPostEditUpdate' => $GLOBALS['smwgPostEditUpdate'],
 			'smwgSpecialAskFormSubmitMethod' => $GLOBALS['smwgSpecialAskFormSubmitMethod'],
 			'smwgSupportSectionTag' => $GLOBALS['smwgSupportSectionTag'],

--- a/tests/phpunit/Elastic/Indexer/IndexerTest.php
+++ b/tests/phpunit/Elastic/Indexer/IndexerTest.php
@@ -100,7 +100,7 @@ class IndexerTest extends \PHPUnit_Framework_TestCase {
 			->will( $this->returnValue( true ) );
 
 		$this->connection->expects( $this->any() )
-			->method( 'getIndexNameByType' )
+			->method( 'getIndexName' )
 			->with( $this->equalTo( 'data' ) )
 			->will( $this->returnValue( '_index_abc' ) );
 


### PR DESCRIPTION
This pull request makes Semantic MediaWiki compatible with new ElasticSearch (8.x tested). It is currently still a draft, since I have not yet updated the tests. It is working in my personal testing environment.

There are a number of major changes in the ElasticSearch API, as well as some breaking changes in the ElasticSearch PHP package, that this pull request addresses. Most notably:

* Mapping types have been removed (https://www.elastic.co/guide/en/elasticsearch/reference/7.17/removal-of-types.html);
* Elasticsearch PHP methods now return `Promise` objects, which need to be explicitly converted to a type;
* The `cat` API no longer returns a JSON by default;
* The associative array syntax for hosts is no longer supported (https://github.com/elastic/elasticsearch-php/issues/1214). This required the addition of a configuration variable, `$wgElasticsearchCredentials`;
* `doc_values` is no longer supported on properties of type `text`.