### PR TITLE
Do not run PHPUnit with --testdox

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -101,7 +101,7 @@
 	},
 	"scripts": {
 		"test": "php ${MW_INSTALL_PATH}/tests/phpunit/phpunit.php -c phpunit.xml.dist",
-		"phpunit": "php ${MW_INSTALL_PATH}/tests/phpunit/phpunit.php -c phpunit.xml.dist --testdox ${composerScriptArg}",
+		"phpunit": "php ${MW_INSTALL_PATH}/tests/phpunit/phpunit.php -c phpunit.xml.dist",
 		"phpdbg": "phpdbg -qrr ${MW_INSTALL_PATH}/tests/phpunit/phpunit.php -c phpunit.xml.dist",
 		"unit": [
 			"composer dump-autoload",


### PR DESCRIPTION
That option is nice if you want to get a list of tests. It's not nice if you want to see what actually failed among the 2000 tests on GH Actions