### PR TITLE
Use Spaceship operator to sort numbers

### DIFF
--- a/src/SQLStore/Lookup/PropertyLabelSimilarityLookup.php
+++ b/src/SQLStore/Lookup/PropertyLabelSimilarityLookup.php
@@ -144,7 +144,7 @@ class PropertyLabelSimilarityLookup {
 		$similarities = $this->matchLabels( $propertyList, $withType );
 
 		usort( $similarities, function ( $a, $b ) {
-			return $a['similarity'] < $b['similarity'];
+			return $a['similarity'] <=> $b['similarity'];
 		} );
 
 		return $similarities;


### PR DESCRIPTION
Fix php 8 deprecation notice:
Deprecated: usort(): Returning bool from comparison function is deprecated, return an integer less than, equal to, or greater than zero in .../extensions/SemanticMediaWiki/src/SQLStore/Lookup/PropertyLabelSimilarityLookup.php on line 148