### PR TITLE
Fix sort order on Special:PropertyLabelSimilarity

### DIFF
--- a/src/SQLStore/Lookup/PropertyLabelSimilarityLookup.php
+++ b/src/SQLStore/Lookup/PropertyLabelSimilarityLookup.php
@@ -144,7 +144,7 @@ class PropertyLabelSimilarityLookup {
 		$similarities = $this->matchLabels( $propertyList, $withType );
 
 		usort( $similarities, function ( $a, $b ) {
-			return $a['similarity'] <=> $b['similarity'];
+			return $b['similarity'] <=> $a['similarity'];
 		} );
 
 		return $similarities;


### PR DESCRIPTION
Fix regression from https://github.com/SemanticMediaWiki/SemanticMediaWiki/pull/5464 that changed sorting order.