### PR TITLE
feat: Add webp to list of image types

### DIFF
--- a/src/Utils/Image.php
+++ b/src/Utils/Image.php
@@ -35,7 +35,8 @@ class Image {
 		'xbm' => 'image/xbm',
 		'tiff' => 'image/tiff',
 		'aiff' => 'image/iff',
-		'wbmp' => 'image/vnd.wap.wbmp'
+		'wbmp' => 'image/vnd.wap.wbmp',
+		'webp' => 'image/webp',
 	];
 
 	/**


### PR DESCRIPTION
This change lets images in the webp format show up as actual images in results instead of a link to the corresponding file page.