### PR TITLE
Remove usage of deprecated \Hooks::run

### DIFF
--- a/includes/export/SMW_ExportController.php
+++ b/includes/export/SMW_ExportController.php
@@ -178,15 +178,17 @@ class SMWExportController {
 		// let other extensions add additional RDF data for this page
 		$expDataList = [];
 
-		\Hooks::run(
-			'SMW::Exporter::Controller::AddExpData',
-			[
-				$diWikiPage,
-				&$expDataList,
-				( $recursiondepth != 0 ),
-				$this->add_backlinks
-			]
-		);
+		MediaWikiServices::getInstance()
+			->getHookContainer()
+			->run(
+				'SMW::Exporter::Controller::AddExpData',
+				[
+					$diWikiPage,
+					&$expDataList,
+					( $recursiondepth != 0 ),
+					$this->add_backlinks
+				]
+			);
 
 		foreach ( $expDataList as $data ) {
 

--- a/src/DataTypeRegistry.php
+++ b/src/DataTypeRegistry.php
@@ -2,6 +2,7 @@
 
 namespace SMW;
 
+use MediaWiki\MediaWikiServices;
 use SMW\DataValues\TypeList;
 use SMW\Localizer\LocalLanguage\LocalLanguage;
 use SMWDataItem as DataItem;
@@ -507,10 +508,11 @@ class DataTypeRegistry {
 		}
 
 		// Deprecated since 1.9
-		\Hooks::run( 'smwInitDatatypes' );
+		$hookContainer = MediaWikiServices::getInstance()->getHookContainer();
+		$hookContainer->run( 'smwInitDatatypes' );
 
 		// Since 1.9
-		\Hooks::run( 'SMW::DataType::initTypes', [ $this ] );
+		$hookContainer->run( 'SMW::DataType::initTypes' );
 	}
 
 	/**

--- a/src/DataUpdater.php
+++ b/src/DataUpdater.php
@@ -362,13 +362,15 @@ class DataUpdater {
 
 		$propertyAnnotator->addAnnotation();
 
-		\Hooks::run(
-			'SMW::DataUpdater::ContentProcessor',
-			[
-				$this->semanticData,
-				$wikiPage->getContent()
-			]
-		);
+		MediaWikiServices::getInstance()
+			->getHookContainer()
+			->run(
+				'SMW::DataUpdater::ContentProcessor',
+				[
+					$this->semanticData,
+					$wikiPage->getContent()
+				]
+			);
 	}
 
 	private function checkUpdateEditProtection( $wikiPage, $user ) {

--- a/src/Elastic/ElasticStore.php
+++ b/src/Elastic/ElasticStore.php
@@ -3,6 +3,7 @@
 namespace SMW\Elastic;
 
 use Hooks;
+use MediaWiki\MediaWikiServices;
 use RuntimeException;
 use SMW\DIWikiPage;
 use SMW\SemanticData;
@@ -213,7 +214,8 @@ class ElasticStore extends SQLStore {
 			$this->queryEngine
 		];
 
-		if ( Hooks::run( 'SMW::Store::BeforeQueryResultLookupComplete', $params ) ) {
+		$hookContainer = MediaWikiServices::getInstance()->getHookContainer();
+		if ( $hookContainer->run( 'SMW::Store::BeforeQueryResultLookupComplete', $params ) ) {
 			$result = $this->queryEngine->getQueryResult( $query );
 		}
 
@@ -222,8 +224,8 @@ class ElasticStore extends SQLStore {
 			&$result
 		];
 
-		Hooks::run( 'SMW::ElasticStore::AfterQueryResultLookupComplete', $params );
-		Hooks::run( 'SMW::Store::AfterQueryResultLookupComplete', $params );
+		$hookContainer->run( 'SMW::ElasticStore::AfterQueryResultLookupComplete', $params );
+		$hookContainer->run( 'SMW::Store::AfterQueryResultLookupComplete', $params );
 
 		$query->setOption( Query::PROC_QUERY_TIME, microtime( true ) + $time );
 

--- a/src/Factbox/Factbox.php
+++ b/src/Factbox/Factbox.php
@@ -3,6 +3,7 @@
 namespace SMW\Factbox;
 
 use Html;
+use MediaWiki\MediaWikiServices;
 use Sanitizer;
 use Title;
 use SMW\DataValueFactory;
@@ -345,11 +346,12 @@ class Factbox {
 
 		$this->displayTitleFinder->prefetchFromSemanticData( $semanticData );
 
+		$hookContainer = MediaWikiServices::getInstance()->getHookContainer();
 		// Hook deprecated with SMW 1.9 and will vanish with SMW 1.11
-		\Hooks::run( 'smwShowFactbox', [ &$html, $semanticData ] );
+		$hookContainer->run( 'smwShowFactbox', [ &$html, $semanticData ] );
 
 		// Hook since 1.9
-		if ( \Hooks::run( 'SMW::Factbox::BeforeContentGeneration', [ &$html, $semanticData ] ) ) {
+		if ( $hookContainer->run( 'SMW::Factbox::BeforeContentGeneration', [ &$html, $semanticData ] ) ) {
 
 			$header = $this->createHeader( $semanticData->getSubject() );
 			$rows = $this->createRows( $semanticData );

--- a/src/Listener/EventListener/EventListenerRegistry.php
+++ b/src/Listener/EventListener/EventListenerRegistry.php
@@ -2,6 +2,7 @@
 
 namespace SMW\Listener\EventListener;
 
+use MediaWiki\MediaWikiServices;
 use Onoi\EventDispatcher\EventListenerCollection;
 use SMW\Query\QueryComparator;
 use SMWExporter as Exporter;
@@ -88,7 +89,9 @@ class EventListenerRegistry implements EventListenerCollection {
 
 		$this->addListenersToCollection();
 
-		\Hooks::run( 'SMW::Event::RegisterEventListeners', [ $this->eventListenerCollection ] );
+		MediaWikiServices::getInstance()
+			->getHookContainer()
+			->run( 'SMW::Event::RegisterEventListeners', [ $this->eventListenerCollection ] );
 
 		return $this->eventListenerCollection->getCollection();
 	}

--- a/src/MediaWiki/Api/TaskFactory.php
+++ b/src/MediaWiki/Api/TaskFactory.php
@@ -2,6 +2,7 @@
 
 namespace SMW\MediaWiki\Api;
 
+use MediaWiki\MediaWikiServices;
 use SMW\Services\ServicesFactory as ApplicationFactory;
 use SMW\MediaWiki\Api\Tasks\Task;
 use SMW\MediaWiki\Api\Tasks\UpdateTask;
@@ -36,7 +37,9 @@ class TaskFactory {
 	public function getAllowedTypes() {
 
 		if ( self::$services === null ) {
-			\Hooks::run( 'SMW::Api::AddTasks', [ &self::$services ] );
+			MediaWikiServices::getInstance()
+				->getHookContainer()
+				->run( 'SMW::Api::AddTasks', [ &self::$services ] );
 		}
 
 		$types = [

--- a/src/MediaWiki/HookDispatcher.php
+++ b/src/MediaWiki/HookDispatcher.php
@@ -3,6 +3,8 @@
 namespace SMW\MediaWiki;
 
 use Hooks;
+use MediaWiki\HookContainer\HookContainer;
+use MediaWiki\MediaWikiServices;
 use MediaWiki\Revision\RevisionRecord;
 use SMW\Store;
 use SMW\SQLStore\TableBuilder;
@@ -38,6 +40,16 @@ use User;
  */
 class HookDispatcher {
 
+	private $hookContainer;
+
+	private function getHookContiner(): HookContainer {
+		if ( $this->hookContainer ) {
+			return $this->hookContainer;
+		}
+
+		$this->hookContainer = MediaWikiServices::getInstance()->getHookContainer();
+		return $this->hookContainer;
+	}
 	/**
 	 * @see https://github.com/SemanticMediaWiki/SemanticMediaWiki/blob/master/docs/technical/hooks/hook.admin.registertaskhandlers.md
 	 * @since 3.2
@@ -48,7 +60,8 @@ class HookDispatcher {
 	 * @param User $user
 	 */
 	public function onRegisterTaskHandlers( TaskHandlerRegistry $taskHandlerRegistry, Store $store, OutputFormatter $outputFormatter, User $user ) {
-		Hooks::run( 'SMW::Admin::RegisterTaskHandlers', [ $taskHandlerRegistry, $store, $outputFormatter, $user ] );
+		$this->getHookContiner()
+			->run( 'SMW::Admin::RegisterTaskHandlers', [ $taskHandlerRegistry, $store, $outputFormatter, $user ] );
 	}
 
 	/**
@@ -58,7 +71,8 @@ class HookDispatcher {
 	 * @param PropertyChangeListener $propertyChangeListener
 	 */
 	public function onRegisterPropertyChangeListeners( PropertyChangeListener $propertyChangeListener ) {
-		Hooks::run( 'SMW::Listener::ChangeListener::RegisterPropertyChangeListeners', [ $propertyChangeListener ] );
+		$this->getHookContiner()
+			->run( 'SMW::Listener::ChangeListener::RegisterPropertyChangeListeners', [ $propertyChangeListener ] );
 	}
 
 	/**
@@ -68,7 +82,8 @@ class HookDispatcher {
 	 * @param ConstraintRegistry $constraintRegistry
 	 */
 	public function onInitConstraints( ConstraintRegistry $constraintRegistry ) {
-		Hooks::run( 'SMW::Constraint::initConstraints', [ $constraintRegistry ] );
+		$this->getHookContiner()
+			->run( 'SMW::Constraint::initConstraints', [ $constraintRegistry ] );
 	}
 
 	/**
@@ -78,7 +93,8 @@ class HookDispatcher {
 	 * @param SchemaTypes $schemaTypes
 	 */
 	public function onRegisterSchemaTypes( SchemaTypes $schemaTypes ) {
-		Hooks::run( 'SMW::Schema::RegisterSchemaTypes', [ $schemaTypes ] );
+		$this->getHookContiner()
+			->run( 'SMW::Schema::RegisterSchemaTypes', [ $schemaTypes ] );
 	}
 
 	/**
@@ -90,10 +106,11 @@ class HookDispatcher {
 	public function onSettingsBeforeInitializationComplete( array &$configuration ) {
 
 		// Deprecated since 3.1
-		Hooks::run( 'SMW::Config::BeforeCompletion', [ &$configuration ] );
+		$this->getHookContiner()
+			->run( 'SMW::Config::BeforeCompletion', [ &$configuration ] );
 
-
-		Hooks::run( 'SMW::Settings::BeforeInitializationComplete', [ &$configuration ] );
+		$this->getHookContiner()
+			->run( 'SMW::Settings::BeforeInitializationComplete', [ &$configuration ] );
 	}
 
 	/**
@@ -103,7 +120,8 @@ class HookDispatcher {
 	 * @param array &$vars
 	 */
 	public function onSetupAfterInitializationComplete( array &$vars ) {
-		Hooks::run( 'SMW::Setup::AfterInitializationComplete', [ &$vars ] );
+		$this->getHookContiner()
+			->run( 'SMW::Setup::AfterInitializationComplete', [ &$vars ] );
 	}
 
 	/**
@@ -113,7 +131,8 @@ class HookDispatcher {
 	 * @param array &$grouppermissions
 	 */
 	public function onGroupPermissionsBeforeInitializationComplete( array &$grouppermissions ) {
-		Hooks::run( 'SMW::GroupPermissions::BeforeInitializationComplete', [ &$grouppermissions ] );
+		$this->getHookContiner()
+			->run( 'SMW::GroupPermissions::BeforeInitializationComplete', [ &$grouppermissions ] );
 	}
 
 	/**
@@ -124,7 +143,8 @@ class HookDispatcher {
 	 * @param array &$preferences
 	 */
 	public function onGetPreferences( \User $user, array &$preferences ) {
-		Hooks::run( 'SMW::GetPreferences', [ $user, &$preferences ] );
+		$this->getHookContiner()
+			->run( 'SMW::GetPreferences', [ $user, &$preferences ] );
 	}
 
 	/**
@@ -134,7 +154,8 @@ class HookDispatcher {
 	 * @param array &$magicWords
 	 */
 	public function onBeforeMagicWordsFinder( array &$magicWords ) {
-		Hooks::run( 'SMW::Parser::BeforeMagicWordsFinder', [ &$magicWords ] );
+		$this->getHookContiner()
+			->run( 'SMW::Parser::BeforeMagicWordsFinder', [ &$magicWords ] );
 	}
 
 	/**
@@ -145,7 +166,8 @@ class HookDispatcher {
 	 * @param AnnotationProcessor $annotationProcessor
 	 */
 	public function onAfterLinksProcessingComplete( string &$text, AnnotationProcessor $annotationProcessor ) {
-		Hooks::run( 'SMW::Parser::AfterLinksProcessingComplete', [ &$text, $annotationProcessor ] );
+		$this->getHookContiner()
+			->run( 'SMW::Parser::AfterLinksProcessingComplete', [ &$text, $annotationProcessor ] );
 	}
 
 	/**
@@ -156,7 +178,8 @@ class HookDispatcher {
 	 * @param ParserOutput $parserOutput
 	 */
 	public function onParserAfterTidyPropertyAnnotationComplete( PropertyAnnotator $propertyAnnotator, \ParserOutput $parserOutput ) {
-		\Hooks::run( 'SMW::Parser::ParserAfterTidyPropertyAnnotationComplete', [ $propertyAnnotator, $parserOutput ] );
+		$this->getHookContiner()
+			->run( 'SMW::Parser::ParserAfterTidyPropertyAnnotationComplete', [ $propertyAnnotator, $parserOutput ] );
 	}
 
 	/**
@@ -167,7 +190,8 @@ class HookDispatcher {
 	 * @param MessageReporter $messageReporter
 	 */
 	public function onAfterUpdateEntityCollationComplete( Store $store, MessageReporter $messageReporter ) {
-		\Hooks::run( 'SMW::Maintenance::AfterUpdateEntityCollationComplete', [ $store, $messageReporter ] );
+		$this->getHookContiner()
+			->run( 'SMW::Maintenance::AfterUpdateEntityCollationComplete', [ $store, $messageReporter ] );
 	}
 
 	/**
@@ -178,7 +202,8 @@ class HookDispatcher {
 	 * @param array &$indicatorProviders
 	 */
 	public function onRegisterEntityExaminerIndicatorProviders( Store $store, array &$indicatorProviders ) {
-		Hooks::run( 'SMW::Indicator::EntityExaminer::RegisterIndicatorProviders', [ $store, &$indicatorProviders ] );
+		$this->getHookContiner()
+			->run( 'SMW::Indicator::EntityExaminer::RegisterIndicatorProviders', [ $store, &$indicatorProviders ] );
 	}
 
 	/**
@@ -189,7 +214,8 @@ class HookDispatcher {
 	 * @param array &$indicatorProviders
 	 */
 	public function onRegisterEntityExaminerDeferrableIndicatorProviders( Store $store, array &$indicatorProviders ) {
-		Hooks::run( 'SMW::Indicator::EntityExaminer::RegisterDeferrableIndicatorProviders', [ $store, &$indicatorProviders ] );
+		$this->getHookContiner()
+			->run( 'SMW::Indicator::EntityExaminer::RegisterDeferrableIndicatorProviders', [ $store, &$indicatorProviders ] );
 	}
 
 	/**
@@ -208,7 +234,8 @@ class HookDispatcher {
 	 * @return bool
 	 */
 	public function onIsApprovedRevision( Title $title, int $latestRevID ) : bool {
-		return Hooks::run( 'SMW::RevisionGuard::IsApprovedRevision', [ $title, $latestRevID ] );
+		return $this->getHookContiner()
+			->run( 'SMW::RevisionGuard::IsApprovedRevision', [ $title, $latestRevID ] );
 	}
 
 	/**
@@ -222,7 +249,8 @@ class HookDispatcher {
 	 * @param int &$latestRevID
 	 */
 	public function onChangeRevisionID( Title $title, int &$latestRevID ) {
-		Hooks::run( 'SMW::RevisionGuard::ChangeRevisionID', [ $title, &$latestRevID ] );
+		$this->getHookContiner()
+			->run( 'SMW::RevisionGuard::ChangeRevisionID', [ $title, &$latestRevID ] );
 	}
 
 	/**
@@ -236,7 +264,8 @@ class HookDispatcher {
 	 * @param File|null $file
 	 */
 	public function onChangeFile( Title $title, &$file ) {
-		Hooks::run( 'SMW::RevisionGuard::ChangeFile', [ $title, &$file ] );
+		$this->getHookContiner()
+			->run( 'SMW::RevisionGuard::ChangeFile', [ $title, &$file ] );
 	}
 
 	/**
@@ -250,7 +279,8 @@ class HookDispatcher {
 	 * @param RevisionRecord|null $revision
 	 */
 	public function onChangeRevision( Title $title, ?RevisionRecord &$revision ) {
-		Hooks::run( 'SMW::RevisionGuard::ChangeRevision', [ $title, &$revision ] );
+		$this->getHookContiner()
+			->run( 'SMW::RevisionGuard::ChangeRevision', [ $title, &$revision ] );
 	}
 
 	/**
@@ -261,7 +291,8 @@ class HookDispatcher {
 	 * @param MessageReporter $messageReporter
 	 */
 	public function onInstallerBeforeCreateTablesComplete( array $tables, MessageReporter $messageReporter ) {
-		Hooks::run( 'SMW::SQLStore::Installer::BeforeCreateTablesComplete', [ $tables, $messageReporter ] );
+		$this->getHookContiner()
+			->run( 'SMW::SQLStore::Installer::BeforeCreateTablesComplete', [ $tables, $messageReporter ] );
 	}
 
 	/**
@@ -273,7 +304,8 @@ class HookDispatcher {
 	 * @param Options $options
 	 */
 	public function onInstallerAfterCreateTablesComplete( TableBuilder $tableBuilder, MessageReporter $messageReporter, Options $options ) {
-		Hooks::run( 'SMW::SQLStore::Installer::AfterCreateTablesComplete', [ $tableBuilder, $messageReporter, $options ] );
+		$this->getHookContiner()
+			->run( 'SMW::SQLStore::Installer::AfterCreateTablesComplete', [ $tableBuilder, $messageReporter, $options ] );
 	}
 
 	/**
@@ -285,7 +317,8 @@ class HookDispatcher {
 	 * @param Options $options
 	 */
 	public function onInstallerAfterDropTablesComplete( TableBuilder $tableBuilder, MessageReporter $messageReporter, Options $options ) {
-		Hooks::run( 'SMW::SQLStore::Installer::AfterDropTablesComplete', [ $tableBuilder, $messageReporter, $options ] );
+		$this->getHookContiner()
+			->run( 'SMW::SQLStore::Installer::AfterDropTablesComplete', [ $tableBuilder, $messageReporter, $options ] );
 	}
 
 }

--- a/src/MediaWiki/Hooks.php
+++ b/src/MediaWiki/Hooks.php
@@ -922,7 +922,8 @@ class Hooks {
 	public function onFileUpload( $file, $reupload ) {
 
 		$fileUpload = new FileUpload(
-			ApplicationFactory::getInstance()->getNamespaceExaminer()
+			ApplicationFactory::getInstance()->getNamespaceExaminer(),
+			MediaWikiServices::getInstance()->getHookContainer()
 		);
 
 		return $fileUpload->process( $file, $reupload );

--- a/src/MediaWiki/Hooks/FileUpload.php
+++ b/src/MediaWiki/Hooks/FileUpload.php
@@ -4,6 +4,7 @@ namespace SMW\MediaWiki\Hooks;
 
 use File;
 use Hooks;
+use MediaWiki\HookContainer\HookContainer;
 use ParserOptions;
 use SMW\Services\ServicesFactory as ApplicationFactory;
 use SMW\Localizer;
@@ -30,12 +31,16 @@ class FileUpload implements HookListener {
 	private $namespaceExaminer;
 
 	/**
-	 * @since 1.9
-	 *
-	 * @param NamespaceExaminer $namespaceExaminer
+	 * @var HookContainer
 	 */
-	public function __construct( NamespaceExaminer $namespaceExaminer ) {
+	private $hookContainer;
+
+	public function __construct(
+		NamespaceExaminer $namespaceExaminer,
+		HookContainer $hookContainer
+	) {
 		$this->namespaceExaminer = $namespaceExaminer;
+		$this->hookContainer = $hookContainer;
 	}
 
 	/**
@@ -94,7 +99,7 @@ class FileUpload implements HookListener {
 		$propertyAnnotator->addAnnotation();
 
 		// 2.4+
-		Hooks::run( 'SMW::FileUpload::BeforeUpdate', [ $filePage, $semanticData ] );
+		$this->hookContainer->run( 'SMW::FileUpload::BeforeUpdate', [ $filePage, $semanticData ] );
 
 		$parserData->setOrigin( 'FileUpload' );
 

--- a/src/MediaWiki/Jobs/FulltextSearchTableUpdateJob.php
+++ b/src/MediaWiki/Jobs/FulltextSearchTableUpdateJob.php
@@ -2,6 +2,7 @@
 
 namespace SMW\MediaWiki\Jobs;
 
+use MediaWiki\MediaWikiServices;
 use SMW\MediaWiki\Job;
 use Hooks;
 use SMW\Services\ServicesFactory as ApplicationFactory;
@@ -44,7 +45,9 @@ class FulltextSearchTableUpdateJob extends Job {
 			$this->params
 		);
 
-		Hooks::run( 'SMW::Job::AfterFulltextSearchTableUpdateComplete', [ $this ] );
+		MediaWikiServices::getInstance()
+			->getHookContainer()
+			->run( 'SMW::Job::AfterFulltextSearchTableUpdateComplete', [ $this ] );
 
 		return true;
 	}

--- a/src/MediaWiki/Jobs/UpdateDispatcherJob.php
+++ b/src/MediaWiki/Jobs/UpdateDispatcherJob.php
@@ -3,6 +3,7 @@
 namespace SMW\MediaWiki\Jobs;
 
 use Hooks;
+use MediaWiki\MediaWikiServices;
 use SMW\MediaWiki\Job;
 use SMW\SerializerFactory;
 use SMW\Services\ServicesFactory as ApplicationFactory;
@@ -104,7 +105,9 @@ class UpdateDispatcherJob extends Job {
 			$this->create_secondary_dispatch_run( $this->jobs );
 		}
 
-		Hooks::run( 'SMW::Job::AfterUpdateDispatcherJobComplete', [ $this ] );
+		MediaWikiServices::getInstance()
+			->getHookContainer()
+			->run( 'SMW::Job::AfterUpdateDispatcherJobComplete', [ $this ] );
 
 		return true;
 	}

--- a/src/MediaWiki/Specials/Browse/HtmlBuilder.php
+++ b/src/MediaWiki/Specials/Browse/HtmlBuilder.php
@@ -3,6 +3,7 @@
 namespace SMW\MediaWiki\Specials\Browse;
 
 use Html;
+use MediaWiki\MediaWikiServices;
 use SMW\Services\ServicesFactory as ApplicationFactory;
 use SMW\DataValueFactory;
 use SMW\DIProperty;
@@ -364,15 +365,17 @@ class HtmlBuilder {
 		$this->articletext = $this->dataValue->getWikiValue();
 		$html .= "</div>";
 
-		\Hooks::run(
-			'SMW::Browse::AfterDataLookupComplete',
-			[
-				$this->store,
-				$semanticData,
-				&$html,
-				&$this->extraModules
-			]
-		);
+		MediaWikiServices::getInstance()
+			->getHookContainer()
+			->run(
+				'SMW::Browse::AfterDataLookupComplete',
+				[
+					$this->store,
+					$semanticData,
+					&$html,
+					&$this->extraModules
+				]
+			);
 
 		if ( $this->getOption( 'printable' ) !== 'yes' && !$this->getOption( 'including' ) ) {
 			$html .= FieldBuilder::createQueryForm( $this->articletext, $this->language );
@@ -621,15 +624,17 @@ class HtmlBuilder {
 			if ( $moreIncoming ) {
 				// Added in 2.3
 				// link to the remaining incoming pages
-				$hook = \Hooks::run(
-					'SMW::Browse::BeforeIncomingPropertyValuesFurtherLinkCreate',
-					[
-						$diProperty,
-						$contextPage,
-						&$value_html,
-						$this->store
-					]
-				);
+				MediaWikiServices::getInstance()
+					->getHookContainer()
+					->run(
+						'SMW::Browse::BeforeIncomingPropertyValuesFurtherLinkCreate',
+						[
+							$diProperty,
+							$contextPage,
+							&$value_html,
+							$this->store
+						]
+					);
 			}
 
 			if ( $hook ) {
@@ -901,14 +906,16 @@ class HtmlBuilder {
 		// Added in 2.3
 		// Whether to show a more link or not can be set via
 		// SMW::Browse::BeforeIncomingPropertyValuesFurtherLinkCreate
-		\Hooks::run(
-			'SMW::Browse::AfterIncomingPropertiesLookupComplete',
-			[
-				$this->store,
-				$indata,
-				$valRequestOptions
-			]
-		);
+		MediaWikiServices::getInstance()
+			->getHookContainer()
+			->run(
+				'SMW::Browse::AfterIncomingPropertiesLookupComplete',
+				[
+					$this->store,
+					$indata,
+					$valRequestOptions
+				]
+			);
 
 		return [ $indata, $more ];
 	}

--- a/src/PropertyRegistry.php
+++ b/src/PropertyRegistry.php
@@ -2,6 +2,7 @@
 
 namespace SMW;
 
+use MediaWiki\MediaWikiServices;
 use RuntimeException;
 
 /**
@@ -502,9 +503,10 @@ class PropertyRegistry {
 		}
 
 		// @deprecated since 2.1
-		\Hooks::run( 'smwInitProperties' );
+		$hookContainer = MediaWikiServices::getInstance()->getHookContainer();
+		$hookContainer->run( 'smwInitProperties' );
 
-		\Hooks::run( 'SMW::Property::initProperties', [ $this ] );
+		$hookContainer->run( 'SMW::Property::initProperties', [ $this ] );
 	}
 
 	private function registerPropertyLabel( $id, $label, $asCanonical = true ) {

--- a/src/Query/ResultFormat.php
+++ b/src/Query/ResultFormat.php
@@ -2,6 +2,7 @@
 
 namespace SMW\Query;
 
+use MediaWiki\MediaWikiServices;
 use ParamProcessor\Definition\StringParam;
 use ParamProcessor\IParam;
 use ParamProcessor\IParamDefinition;
@@ -99,8 +100,10 @@ class ResultFormat extends StringParam {
 
 		$format = false;
 
+
+		$hookContainer = MediaWikiServices::getInstance()->getHookContainer();
 		// Deprecated since 3.1, use `SMW::ResultFormat::OverrideDefaultFormat`
-		\Hooks::run( 'SMWResultFormat', [ &$format, $this->printRequests, [] ] );
+		$hookContainer->run( 'SMWResultFormat', [ &$format, $this->printRequests, [] ] );
 
 		/**
 		 * This hook allows extensions to override SMWs implementation of default result
@@ -108,7 +111,7 @@ class ResultFormat extends StringParam {
 		 *
 		 * @since 3.1
 		 */
-		\Hooks::run( 'SMW::ResultFormat::OverrideDefaultFormat', [ &$format, $this->printRequests, [] ] );
+		$hookContainer->run( 'SMW::ResultFormat::OverrideDefaultFormat', [ &$format, $this->printRequests, [] ] );
 
 		if ( $format !== false ) {
 			return $format;

--- a/src/SPARQLStore/SPARQLStore.php
+++ b/src/SPARQLStore/SPARQLStore.php
@@ -2,6 +2,7 @@
 
 namespace SMW\SPARQLStore;
 
+use MediaWiki\MediaWikiServices;
 use SMW\DIProperty;
 use SMW\DIWikiPage;
 use SMW\SemanticData;
@@ -296,11 +297,17 @@ class SPARQLStore extends Store {
 		$result = null;
 		$start = microtime( true );
 
-		if ( \Hooks::run( 'SMW::Store::BeforeQueryResultLookupComplete', [ $this, $query, &$result, $this->factory->newMasterQueryEngine() ] ) ) {
+		$hookContainer = MediaWikiServices::getInstance()->getHookContainer();
+		if (
+			$hookContainer->run(
+				'SMW::Store::BeforeQueryResultLookupComplete',
+				[ $this, $query, &$result, $this->factory->newMasterQueryEngine() ]
+			)
+		) {
 			$result = $this->fetchQueryResult( $query );
 		}
 
-		\Hooks::run( 'SMW::Store::AfterQueryResultLookupComplete', [ $this, &$result ] );
+		$hookContainer->run( 'SMW::Store::AfterQueryResultLookupComplete', [ $this, &$result ] );
 
 		$query->setOption( Query::PROC_QUERY_TIME, microtime( true ) - $start );
 

--- a/src/SQLStore/Lookup/SingleEntityQueryLookup.php
+++ b/src/SQLStore/Lookup/SingleEntityQueryLookup.php
@@ -2,6 +2,7 @@
 
 namespace SMW\SQLStore\Lookup;
 
+use MediaWiki\MediaWikiServices;
 use SMW\Store;
 use SMW\QueryEngine;
 use SMWQuery as Query;
@@ -88,7 +89,9 @@ class SingleEntityQueryLookup implements QueryEngine {
 			$furtherResults
 		);
 
-		\Hooks::run( 'SMW::Store::AfterQueryResultLookupComplete', [ $this->store, &$queryResult ] );
+		MediaWikiServices::getInstance()
+			->getHookContainer()
+			->run( 'SMW::Store::AfterQueryResultLookupComplete', [ $this->store, &$queryResult ] );
 
 		return $queryResult;
 	}

--- a/src/SQLStore/PropertyTableDefinitionBuilder.php
+++ b/src/SQLStore/PropertyTableDefinitionBuilder.php
@@ -3,6 +3,7 @@
 namespace SMW\SQLStore;
 
 use Hooks;
+use MediaWiki\MediaWikiServices;
 use SMW\DataTypeRegistry;
 use SMW\DIProperty;
 use SMW\PropertyRegistry;
@@ -66,8 +67,9 @@ class PropertyTableDefinitionBuilder {
 		$customFixedProperties = [];
 		$fixedPropertyTablePrefix = [];
 
+		$hookContainer = MediaWikiServices::getInstance()->getHookContainer();
 		// Allow to alter the prefix by an extension
-		Hooks::run( 'SMW::SQLStore::AddCustomFixedPropertyTables', [ &$customFixedProperties, &$fixedPropertyTablePrefix ] );
+		$hookContainer->run( 'SMW::SQLStore::AddCustomFixedPropertyTables', [ &$customFixedProperties, &$fixedPropertyTablePrefix ] );
 
 		$this->addTableDefinitionForFixedProperties(
 			$customFixedProperties,
@@ -81,7 +83,7 @@ class PropertyTableDefinitionBuilder {
 			$userDefinedFixedProperties
 		);
 
-		Hooks::run( 'SMW::SQLStore::updatePropertyTableDefinitions', [ &$this->propertyTables ] );
+		$hookContainer->run( 'SMW::SQLStore::updatePropertyTableDefinitions', [ &$this->propertyTables ] );
 
 		$this->createFixedPropertyTableIdIndex();
 	}

--- a/src/SQLStore/PropertyTableIdReferenceDisposer.php
+++ b/src/SQLStore/PropertyTableIdReferenceDisposer.php
@@ -2,6 +2,7 @@
 
 namespace SMW\SQLStore;
 
+use MediaWiki\MediaWikiServices;
 use SMW\Services\ServicesFactory as ApplicationFactory;
 use SMW\DIWikiPage;
 use Onoi\EventDispatcher\EventDispatcherAwareTrait;
@@ -278,10 +279,12 @@ class PropertyTableIdReferenceDisposer {
 		$this->cleanUpSecondaryReferencesById( $id, $isRedirect );
 		$this->connection->endAtomicTransaction( __METHOD__ );
 
-		\Hooks::run(
-			'SMW::SQLStore::EntityReferenceCleanUpComplete',
-			[ $this->store, $id, $subject, $isRedirect ]
-		);
+		MediaWikiServices::getInstance()
+			->getHookContainer()
+			->run(
+				'SMW::SQLStore::EntityReferenceCleanUpComplete',
+				[ $this->store, $id, $subject, $isRedirect ]
+			);
 	}
 
 	private function cleanUpSecondaryReferencesById( $id, $isRedirect ) {

--- a/src/SQLStore/Rebuilder/Rebuilder.php
+++ b/src/SQLStore/Rebuilder/Rebuilder.php
@@ -3,6 +3,8 @@
 namespace SMW\SQLStore\Rebuilder;
 
 use Hooks;
+use MediaWiki\HookContainer\HookContainer;
+use MediaWiki\MediaWikiServices;
 use SMW\Services\ServicesFactory as ApplicationFactory;
 use SMW\DIWikiPage;
 use SMW\PropertyRegistry;
@@ -57,6 +59,11 @@ class Rebuilder {
 	private $namespaceExaminer;
 
 	/**
+	 * @var HookContainer
+	 */
+	private $hookContainer;
+
+	/**
 	 * @var array
 	 */
 	private $options;
@@ -105,6 +112,7 @@ class Rebuilder {
 		$this->entityValidator = $entityValidator;
 		$this->propertyTableIdReferenceDisposer = $propertyTableIdReferenceDisposer;
 		$this->jobFactory = ApplicationFactory::getInstance()->newJobFactory();
+		$this->hookContainer = MediaWikiServices::getInstance()->getHookContainer();
 		$this->lru = new Lru( 10000 );
 	}
 
@@ -228,9 +236,9 @@ class Rebuilder {
 		$this->matchAsSubject( $id, $emptyRange );
 
 		// Deprecated since 2.3, use 'SMW::SQLStore::BeforeDataRebuildJobInsert'
-		\Hooks::run( 'smwRefreshDataJobs', [ &$this->updateJobs ] );
+		$this->hookContainer->run( 'smwRefreshDataJobs', [ &$this->updateJobs ] );
 
-		Hooks::run( 'SMW::SQLStore::BeforeDataRebuildJobInsert', [ $this->store, &$this->updateJobs ] );
+		$this->hookContainer->run( 'SMW::SQLStore::BeforeDataRebuildJobInsert', [ $this->store, &$this->updateJobs ] );
 
 		if ( $this->getOption( 'use-job' ) ) {
 			$this->jobFactory->batchInsert( $this->updateJobs );

--- a/src/Store.php
+++ b/src/Store.php
@@ -3,6 +3,7 @@
 namespace SMW;
 
 use InvalidArgumentException;
+use MediaWiki\MediaWikiServices;
 use Onoi\MessageReporter\MessageReporterAwareTrait;
 use Psr\Log\LoggerAwareTrait;
 use SMW\Connection\ConnectionManager;
@@ -223,21 +224,22 @@ abstract class Store implements QueryEngine {
 		Timer::start( __METHOD__ );
 
 		$applicationFactory = ApplicationFactory::getInstance();
+		$hookContainer = MediaWikiServices::getInstance()->getHookContainer();
 
 		$subject = $semanticData->getSubject();
 		$hash = $subject->getHash();
 
 		// Deprecated since 3.1, use SMW::Store::BeforeDataUpdateComplete
-		\Hooks::run( 'SMWStore::updateDataBefore', [ $this, $semanticData ] );
+		$hookContainer->run( 'SMWStore::updateDataBefore', [ $this, $semanticData ] );
 
-		\Hooks::run( 'SMW::Store::BeforeDataUpdateComplete', [ $this, $semanticData ] );
+		$hookContainer->run( 'SMW::Store::BeforeDataUpdateComplete', [ $this, $semanticData ] );
 
 		$this->doDataUpdate( $semanticData );
 
 		// Deprecated since 3.1, use SMW::Store::AfterDataUpdateComplete
-		\Hooks::run( 'SMWStore::updateDataAfter', [ $this, $semanticData ] );
+		$hookContainer->run( 'SMWStore::updateDataAfter', [ $this, $semanticData ] );
 
-		\Hooks::run( 'SMW::Store::AfterDataUpdateComplete', [ $this, $semanticData ] );
+		$hookContainer->run( 'SMW::Store::AfterDataUpdateComplete', [ $this, $semanticData ] );
 
 		$rev = $semanticData->getExtensionData( 'revision_id' );
 		$procTime = Timer::getElapsedTime( __METHOD__, 5 );

--- a/tests/phpunit/MediaWiki/Hooks/FileUploadTest.php
+++ b/tests/phpunit/MediaWiki/Hooks/FileUploadTest.php
@@ -2,6 +2,7 @@
 
 namespace SMW\Tests\MediaWiki\Hooks;
 
+use MediaWiki\HookContainer\HookContainer;
 use ParserOutput;
 use SMW\MediaWiki\Hooks\FileUpload;
 use SMW\Tests\TestEnvironment;
@@ -62,10 +63,13 @@ class FileUploadTest extends \PHPUnit_Framework_TestCase {
 		$namespaceExaminer = $this->getMockBuilder( '\SMW\NamespaceExaminer' )
 			->disableOriginalConstructor()
 			->getMock();
+		$hookContainer = $this->getMockBuilder( HookContainer::class )
+			->disableOriginalConstructor()
+			->getMock();
 
 		$this->assertInstanceOf(
 			FileUpload::class,
-			new FileUpload( $namespaceExaminer )
+			new FileUpload( $namespaceExaminer, $hookContainer )
 		);
 	}
 
@@ -114,7 +118,10 @@ class FileUploadTest extends \PHPUnit_Framework_TestCase {
 		$this->testEnvironment->registerObject( 'PageCreator', $pageCreator );
 
 		$instance = new FileUpload(
-			$namespaceExaminer
+			$namespaceExaminer,
+			$this->getMockBuilder( HookContainer::class )
+				->disableOriginalConstructor()
+				->getMock()
 		);
 
 		$reUploadStatus = true;
@@ -159,7 +166,10 @@ class FileUploadTest extends \PHPUnit_Framework_TestCase {
 		$this->testEnvironment->registerObject( 'PageCreator', $pageCreator );
 
 		$instance = new FileUpload(
-			$namespaceExaminer
+			$namespaceExaminer,
+			$this->getMockBuilder( HookContainer::class )
+				->disableOriginalConstructor()
+				->getMock()
 		);
 
 		$instance->process( $file, false );


### PR DESCRIPTION
\Hooks::run was hard-deprecated in
https://gerrit.wikimedia.org/r/c/mediawiki/core/+/916810

Replace it with MediaWiki\HookContainer\HookContainer introduced in
MW 1.35