### PR TITLE
DuplicateFinder: Avoid primary DB query on pageview

### DIFF
--- a/src/SQLStore/EntityStore/DuplicateFinder.php
+++ b/src/SQLStore/EntityStore/DuplicateFinder.php
@@ -82,7 +82,7 @@ class DuplicateFinder {
 		$query->condition( $query->neq( 'smw_iw', SMW_SQL3_SMWDELETEIW ) );
 		$query->condition( $query->neq( 'smw_iw', SMW_SQL3_SMWREDIIW ) );
 
-		$res = $connection->query(
+		$res = $connection->readQuery(
 			$query,
 			__METHOD__
 		);


### PR DESCRIPTION
As far as I can tell, this only gets called via
DeclarationExaminer::check() when a Property: page is viewed. So, switch it to use a replica DB instead to avoid generating undue load on the primary.