### PR TITLE
fix SPARQL "data" protocol (GSP)

### DIFF
--- a/src/SPARQLStore/RepositoryConnectors/GenericRepositoryConnector.php
+++ b/src/SPARQLStore/RepositoryConnectors/GenericRepositoryConnector.php
@@ -573,16 +573,9 @@ class GenericRepositoryConnector implements RepositoryConnection {
 		$this->httpRequest->setOption( CURLOPT_URL, $this->repositoryClient->getDataEndpoint() .
 			( ( $defaultGraph !== '' ) ? '?graph=' . urlencode( $defaultGraph ) : '?default' ) );
 		$this->httpRequest->setOption( CURLOPT_POST, true );
-
-		// POST as file (fails in 4Store)
-		$payloadFile = tmpfile();
-		fwrite( $payloadFile, $payload );
-		fseek( $payloadFile, 0 );
-
-		$this->httpRequest->setOption( CURLOPT_INFILE, $payloadFile );
-		$this->httpRequest->setOption( CURLOPT_INFILESIZE, strlen( $payload ) );
 		$this->httpRequest->setOption( CURLOPT_HTTPHEADER, [ 'Content-Type: application/x-turtle' ] );
-
+		$this->httpRequest->setOption( CURLOPT_POSTFIELDS, $payload );
+		$this->httpRequest->setOption( CURLOPT_NOBODY, false );
 		$this->httpRequest->execute();
 
 		if ( $this->httpRequest->getLastErrorCode() == 0 ) {


### PR DESCRIPTION
This patch fixes SMW to send turtle content directly as SPARQL 1.1 GSP POST.
https://www.w3.org/TR/sparql11-http-rdf-update/#http-post

The problem was that internal curl_handler reused the curl options of previous call, and CURLOPT_INFILE did not set the HTTP content.

There was a comment about 4store in GenericRepositoryConnector, but FourstoreRepositoryConnector overrides this part.
4store POST /data/ endpoint only supports content-type of form-urlencoded. https://github.com/4store/4store/blob/fe348295e0e20e1b2192dd08e3ef380d9750ff77/src/http/httpd.c#L1397

In SPARQL 1.1 Graph Store HTTP Protocol (GSP) spec, POST with RDF graph content is the first class, and multipart/form-data may be used as well.

By the way, sending in multipart/form-data is performed by CURLOPT_POSTFIELDS with array of CURLFile instances.