### PR TITLE
Improve exception-log flag

### DIFF
--- a/src/Maintenance/ExceptionFileLogger.php
+++ b/src/Maintenance/ExceptionFileLogger.php
@@ -64,10 +64,13 @@ class ExceptionFileLogger {
 	public function setOptions( Options $options ) {
 
 		$dateTimeUtc = new \DateTime( 'now', new \DateTimeZone( 'UTC' ) );
-		$this->exceptionFile = __DIR__ . "../../../";
+		$this->exceptionFile = __DIR__ . "/../../../";
 
 		if ( $options->has( 'exception-log' ) ) {
 			$this->exceptionFile = $options->get( 'exception-log' );
+			if ( !str_ends_with( $this->exceptionFile, '/' ) ) {
+				$this->exceptionFile = $this->exceptionFile . '/';
+			}
 		}
 
 		$this->exceptionFile .= $this->namespace . "-exceptions-" . $dateTimeUtc->format( 'Y-m-d' ) . ".log";


### PR DESCRIPTION
If no exception-log flag was provided, the default was missing a / after the current directory. The patch adds the missing /.

If exception-log was provided, it needed to end with a '/'. The patch checks for the '/' and adds it if it is missing so the user does not need to.