### PR TITLE
fix(SubobjectParserFunction): Fix mb_substr logspam

### DIFF
--- a/src/ParserFunctions/SubobjectParserFunction.php
+++ b/src/ParserFunctions/SubobjectParserFunction.php
@@ -188,7 +188,7 @@ class SubobjectParserFunction {
 		// reserved to be used by extensions only in order to separate them from
 		// user land and avoid having them accidentally to refer to the same
 		// named ID (i.e. different access restrictions etc.)
-		if ( strpos( mb_substr( $parserParameterProcessor->getFirst(), 0, 5 ), '.' ) !== false ) {
+		if ( strpos( mb_substr( $parserParameterProcessor->getFirst() ?? '', 0, 5 ), '.' ) !== false ) {
 			return $this->parserData->addError(
 				Message::encode( [ 'smw-subobject-parser-invalid-naming-scheme', $parserParameterProcessor->getFirst() ] )
 			);


### PR DESCRIPTION
Fixes `Passing null to parameter #1 ($string) of type string is deprecated` messages.