### PR TITLE
fix(GenericRegExTokenizer): Fix preg_split logspam in Tesa

### DIFF
--- a/src/Tesa/src/Tokenizer/GenericRegExTokenizer.php
+++ b/src/Tesa/src/Tokenizer/GenericRegExTokenizer.php
@@ -75,7 +75,7 @@ class GenericRegExTokenizer implements Tokenizer {
 			'([\s\-_,:;?!%\'\|\/\(\)\[\]{}<>\r\n"]|(?<!\d)\.(?!\d)|(?<=\p{L})(?=\p{N}))'
 		);
 
-		$result = preg_split( '/' . $pattern . '/u', $string, null, PREG_SPLIT_NO_EMPTY );
+		$result = preg_split( '/' . $pattern . '/u', $string, -1, PREG_SPLIT_NO_EMPTY );
 
 		if ( $result === false ) {
 			$result = array();


### PR DESCRIPTION
Fixes `Passing null to parameter #3 ($limit) of type int is deprecated`messages by replacing `null` with `-1`, which is the default parameter for the $limit arg.

Taken from https://www.php.net/manual/en/function.preg-split.php