### PR TITLE
Fix 'pass by reference use'

### DIFF
--- a/src/SetupFile.php
+++ b/src/SetupFile.php
@@ -375,9 +375,11 @@ class SetupFile {
 		// Remove legacy
 		if ( isset( $vars[self::SMW_JSON]['upgradeKey'] ) ) {
 			unset( $vars[self::SMW_JSON]['upgradeKey'] );
+			unset( $GLOBALS[self::SMW_JSON]['upgradeKey'] );
 		}
 		if ( isset( $vars[self::SMW_JSON][$id]['in.maintenance_mode'] ) ) {
 			unset( $vars[self::SMW_JSON][$id]['in.maintenance_mode'] );
+			unset( $GLOBALS[self::SMW_JSON][$id]['in.maintenance_mode'] );
 		}
 
 		try {

--- a/src/SetupFile.php
+++ b/src/SetupFile.php
@@ -360,8 +360,10 @@ class SetupFile {
 			// NULL means that the key key is removed
 			if ( $value === null ) {
 				unset( $vars[self::SMW_JSON][$id][$key] );
+				unset( $GLOBALS[self::SMW_JSON][$id][$key] );
 			} else {
 				$vars[self::SMW_JSON][$id][$key] = $value;
+				$GLOBALS[self::SMW_JSON][$id][$key] = $value;
 			}
 		}
 


### PR DESCRIPTION
Fixes update.php must be run twice #5510

`SetupFile::remove` assigned `$vars = $GLOBALS` before calling `write( [ $key => null ], $vars )`

`PHP 8.1` passes `$GLOBALS` by value, so set set `$GLOBALS[$key]` explicitly in `write()`