### PR TITLE
Use proper namespace for ResultWrapper related classes

### DIFF
--- a/src/IteratorFactory.php
+++ b/src/IteratorFactory.php
@@ -19,7 +19,7 @@ class IteratorFactory {
 	/**
 	 * @since 2.5
 	 *
-	 * @param ResultWrapper|Iterator|array $res
+	 * @param \Wikimedia\Rdbms\ResultWrapper|Iterator|array $res
 	 *
 	 * @return ResultIterator
 	 */

--- a/src/Iterators/ResultIterator.php
+++ b/src/Iterators/ResultIterator.php
@@ -5,10 +5,9 @@ namespace SMW\Iterators;
 use ArrayIterator;
 use Countable;
 use Iterator;
-use ResultWrapper;
 use RuntimeException;
 use SeekableIterator;
-
+use Wikimedia\Rdbms\ResultWrapper;
 /**
  * @license GNU GPL v2+
  * @since 2.5

--- a/src/MediaWiki/Connection/Database.php
+++ b/src/MediaWiki/Connection/Database.php
@@ -4,11 +4,11 @@ namespace SMW\MediaWiki\Connection;
 
 use DBError;
 use Exception;
-use ResultWrapper;
 use RuntimeException;
 use SMW\Connection\ConnRef;
 use UnexpectedValueException;
 use Wikimedia\Rdbms\IDatabase;
+use Wikimedia\Rdbms\ResultWrapper;
 use Wikimedia\ScopedCallback;
 
 /**

--- a/tests/phpunit/Elastic/Hooks/UpdateEntityCollationCompleteTest.php
+++ b/tests/phpunit/Elastic/Hooks/UpdateEntityCollationCompleteTest.php
@@ -5,7 +5,7 @@ namespace SMW\Tests\Elastic\Hooks;
 use SMW\Elastic\Hooks\UpdateEntityCollationComplete;
 use SMW\Tests\PHPUnitCompat;
 use SMW\Tests\TestEnvironment;
-use FakeResultWrapper;
+use Wikimedia\Rdbms\FakeResultWrapper;
 
 /**
  * @covers \SMW\Elastic\Hooks\UpdateEntityCollationComplete

--- a/tests/phpunit/IteratorFactoryTest.php
+++ b/tests/phpunit/IteratorFactoryTest.php
@@ -21,7 +21,7 @@ class IteratorFactoryTest extends \PHPUnit_Framework_TestCase {
 
 		$instance = new IteratorFactory();
 
-		$result = $this->getMockBuilder( '\ResultWrapper' )
+		$result = $this->getMockBuilder( '\Wikimedia\Rdbms\ResultWrapper' )
 			->disableOriginalConstructor()
 			->getMock();
 

--- a/tests/phpunit/Iterators/ResultIteratorTest.php
+++ b/tests/phpunit/Iterators/ResultIteratorTest.php
@@ -75,7 +75,7 @@ class ResultIteratorTest extends \PHPUnit_Framework_TestCase {
 
 	public function testdoIterateOnResultWrapper() {
 
-		$resultWrapper = $this->getMockBuilder( '\ResultWrapper' )
+		$resultWrapper = $this->getMockBuilder( '\Wikimedia\Rdbms\ResultWrapper' )
 			->disableOriginalConstructor()
 			->getMock();
 

--- a/tests/phpunit/Maintenance/AutoRecoveryTest.php
+++ b/tests/phpunit/Maintenance/AutoRecoveryTest.php
@@ -3,9 +3,7 @@
 namespace SMW\Tests\Maintenance;
 
 use SMW\Maintenance\AutoRecovery;
-use FakeResultWrapper;
 use SMW\Tests\TestEnvironment;
-use SMW\DIWikiPage;
 
 /**
  * @covers \SMW\Maintenance\AutoRecovery

--- a/tests/phpunit/Maintenance/DuplicateEntitiesDisposerTest.php
+++ b/tests/phpunit/Maintenance/DuplicateEntitiesDisposerTest.php
@@ -2,7 +2,6 @@
 
 namespace SMW\Tests\Maintenance;
 
-use FakeResultWrapper;
 use SMW\Maintenance\DuplicateEntitiesDisposer;
 
 /**

--- a/tests/phpunit/Maintenance/PropertyStatisticsRebuilderTest.php
+++ b/tests/phpunit/Maintenance/PropertyStatisticsRebuilderTest.php
@@ -2,8 +2,8 @@
 
 namespace SMW\Tests\Maintenance;
 
-use FakeResultWrapper;
 use SMW\Maintenance\PropertyStatisticsRebuilder;
+use Wikimedia\Rdbms\FakeResultWrapper;
 
 /**
  * @covers \SMW\Maintenance\PropertyStatisticsRebuilder

--- a/tests/phpunit/Maintenance/PurgeEntityCacheTest.php
+++ b/tests/phpunit/Maintenance/PurgeEntityCacheTest.php
@@ -6,7 +6,7 @@ use Onoi\MessageReporter\MessageReporter;
 use PHPUnit\Framework\TestCase;
 use SMW\EntityCache;
 use SMW\Maintenance\PurgeEntityCache;
-use FakeResultWrapper;
+use Wikimedia\Rdbms\FakeResultWrapper;
 use SMW\SQLStore\SQLStore;
 use SMW\Tests\TestEnvironment;
 use SMW\DIWikiPage;

--- a/tests/phpunit/Maintenance/UpdateQueryDependenciesTest.php
+++ b/tests/phpunit/Maintenance/UpdateQueryDependenciesTest.php
@@ -3,9 +3,9 @@
 namespace SMW\Tests\Maintenance;
 
 use SMW\Maintenance\UpdateQueryDependencies;
-use FakeResultWrapper;
 use SMW\Tests\TestEnvironment;
 use SMW\DIWikiPage;
+use Wikimedia\Rdbms\FakeResultWrapper;
 
 /**
  * @covers \SMW\Maintenance\UpdateQueryDependencies

--- a/tests/phpunit/MediaWiki/Api/Browse/PValueLookupTest.php
+++ b/tests/phpunit/MediaWiki/Api/Browse/PValueLookupTest.php
@@ -5,9 +5,8 @@ namespace SMW\Tests\MediaWiki\Api\Browse;
 use SMW\DIProperty;
 use SMW\MediaWiki\Api\Browse\PValueLookup;
 use SMW\MediaWiki\Connection\Query;
-use SMW\Services\ServicesContainer;
-use FakeResultWrapper;
 use SMW\Tests\PHPUnitCompat;
+use Wikimedia\Rdbms\FakeResultWrapper;
 
 /**
  * @covers \SMW\MediaWiki\Api\Browse\PValueLookup

--- a/tests/phpunit/MediaWiki/Api/BrowseTest.php
+++ b/tests/phpunit/MediaWiki/Api/BrowseTest.php
@@ -85,7 +85,7 @@ class BrowseTest extends \PHPUnit_Framework_TestCase {
 			->method( 'fetch' )
 			->will( $this->returnValue( false ) );
 
-		$resultWrapper = $this->getMockBuilder( '\FakeResultWrapper' )
+		$resultWrapper = $this->getMockBuilder( '\Wikimedia\Rdbms\FakeResultWrapper' )
 			->disableOriginalConstructor()
 			->getMock();
 

--- a/tests/phpunit/MediaWiki/Connection/DatabaseTest.php
+++ b/tests/phpunit/MediaWiki/Connection/DatabaseTest.php
@@ -168,7 +168,7 @@ class DatabaseTest extends \PHPUnit_Framework_TestCase {
 
 	public function testSelectMethod() {
 
-		$resultWrapper = $this->getMockBuilder( 'ResultWrapper' )
+		$resultWrapper = $this->getMockBuilder( '\Wikimedia\Rdbms\ResultWrapper' )
 			->disableOriginalConstructor()
 			->getMock();
 
@@ -199,7 +199,7 @@ class DatabaseTest extends \PHPUnit_Framework_TestCase {
 		);
 
 		$this->assertInstanceOf(
-			'ResultWrapper',
+			'\Wikimedia\Rdbms\ResultWrapper',
 			$instance->select( 'Foo', 'Bar', '', __METHOD__ )
 		);
 	}
@@ -244,7 +244,7 @@ class DatabaseTest extends \PHPUnit_Framework_TestCase {
 	 */
 	public function testQueryOnSQLite( $query, $expected ) {
 
-		$resultWrapper = $this->getMockBuilder( 'ResultWrapper' )
+		$resultWrapper = $this->getMockBuilder( '\Wikimedia\Rdbms\ResultWrapper' )
 			->disableOriginalConstructor()
 			->getMock();
 
@@ -294,7 +294,7 @@ class DatabaseTest extends \PHPUnit_Framework_TestCase {
 		);
 
 		$this->assertInstanceOf(
-			'ResultWrapper',
+			'\Wikimedia\Rdbms\ResultWrapper',
 			$instance->query( $query )
 		);
 	}
@@ -341,7 +341,7 @@ class DatabaseTest extends \PHPUnit_Framework_TestCase {
 		$this->expectException( 'RuntimeException' );
 
 		$this->assertInstanceOf(
-			'ResultWrapper',
+			'\Wikimedia\Rdbms\ResultWrapper',
 			$instance->select( 'Foo', 'Bar', '', __METHOD__ )
 		);
 	}

--- a/tests/phpunit/MediaWiki/Jobs/PropertyStatisticsRebuildJobTest.php
+++ b/tests/phpunit/MediaWiki/Jobs/PropertyStatisticsRebuildJobTest.php
@@ -34,7 +34,7 @@ class PropertyStatisticsRebuildJobTest extends \PHPUnit_Framework_TestCase {
 
 		$connection->expects( $this->any() )
 			->method( 'select' )
-			->will( $this->returnValue( new \FakeResultWrapper( [ $row ] ) ) );
+			->will( $this->returnValue( new \Wikimedia\Rdbms\FakeResultWrapper( [ $row ] ) ) );
 
 		$store = $this->getMockBuilder( '\SMW\SQLStore\SQLStore' )
 			->disableOriginalConstructor()

--- a/tests/phpunit/MediaWiki/Specials/SpecialMissingRedirectAnnotationsTest.php
+++ b/tests/phpunit/MediaWiki/Specials/SpecialMissingRedirectAnnotationsTest.php
@@ -40,7 +40,7 @@ class SpecialMissingRedirectAnnotationsTest extends \PHPUnit_Framework_TestCase 
 
 	public function testCanExecute() {
 
-		$resultWrapper = $this->getMockBuilder( '\FakeResultWrapper' )
+		$resultWrapper = $this->getMockBuilder( '\Wikimedia\Rdbms\FakeResultWrapper' )
 			->disableOriginalConstructor()
 			->getMock();
 

--- a/tests/phpunit/SQLStore/EntityStore/DuplicateFinderTest.php
+++ b/tests/phpunit/SQLStore/EntityStore/DuplicateFinderTest.php
@@ -69,7 +69,7 @@ class DuplicateFinderTest extends \PHPUnit_Framework_TestCase {
 
 		$query = new \SMW\MediaWiki\Connection\Query( $connection );
 
-		$resultWrapper = $this->getMockBuilder( '\ResultWrapper' )
+		$resultWrapper = $this->getMockBuilder( '\Wikimedia\Rdbms\ResultWrapper' )
 			->disableOriginalConstructor()
 			->getMock();
 

--- a/tests/phpunit/SQLStore/EntityStore/PropertiesLookupTest.php
+++ b/tests/phpunit/SQLStore/EntityStore/PropertiesLookupTest.php
@@ -34,7 +34,7 @@ class PropertiesLookupTest extends \PHPUnit_Framework_TestCase {
 		$dataItem = DIWikiPage::newFromText( __METHOD__ );
 		$dataItem->setId( 42 );
 
-		$resultWrapper = $this->getMockBuilder( '\FakeResultWrapper' )
+		$resultWrapper = $this->getMockBuilder( '\Wikimedia\Rdbms\FakeResultWrapper' )
 			->disableOriginalConstructor()
 			->getMock();
 
@@ -91,7 +91,7 @@ class PropertiesLookupTest extends \PHPUnit_Framework_TestCase {
 		$dataItem = DIWikiPage::newFromText( __METHOD__ );
 		$dataItem->setId( 1001 );
 
-		$resultWrapper = $this->getMockBuilder( '\FakeResultWrapper' )
+		$resultWrapper = $this->getMockBuilder( '\Wikimedia\Rdbms\FakeResultWrapper' )
 			->disableOriginalConstructor()
 			->getMock();
 

--- a/tests/phpunit/SQLStore/EntityStore/PropertySubjectsLookupTest.php
+++ b/tests/phpunit/SQLStore/EntityStore/PropertySubjectsLookupTest.php
@@ -97,7 +97,7 @@ class PropertySubjectsLookupTest extends \PHPUnit_Framework_TestCase {
 
 		$dataItem = DIWikiPage::newFromText( __METHOD__ );
 
-		$resultWrapper = $this->getMockBuilder( '\FakeResultWrapper' )
+		$resultWrapper = $this->getMockBuilder( '\Wikimedia\Rdbms\FakeResultWrapper' )
 			->disableOriginalConstructor()
 			->getMock();
 

--- a/tests/phpunit/SQLStore/EntityStore/TraversalPropertyLookupTest.php
+++ b/tests/phpunit/SQLStore/EntityStore/TraversalPropertyLookupTest.php
@@ -89,7 +89,7 @@ class TraversalPropertyLookupTest extends \PHPUnit_Framework_TestCase {
 
 		$dataItem = DIWikiPage::newFromText( __METHOD__ );
 
-		$resultWrapper = $this->getMockBuilder( '\FakeResultWrapper' )
+		$resultWrapper = $this->getMockBuilder( '\Wikimedia\Rdbms\FakeResultWrapper' )
 			->disableOriginalConstructor()
 			->getMock();
 

--- a/tests/phpunit/SQLStore/Lookup/EntityUniquenessLookupTest.php
+++ b/tests/phpunit/SQLStore/Lookup/EntityUniquenessLookupTest.php
@@ -137,7 +137,7 @@ class EntityUniquenessLookupTest extends \PHPUnit_Framework_TestCase {
 
 		$query = new \SMW\MediaWiki\Connection\Query( $connection );
 
-		$resultWrapper = $this->getMockBuilder( '\ResultWrapper' )
+		$resultWrapper = $this->getMockBuilder( '\Wikimedia\Rdbms\ResultWrapper' )
 			->disableOriginalConstructor()
 			->getMock();
 

--- a/tests/phpunit/SQLStore/Lookup/ErrorLookupTest.php
+++ b/tests/phpunit/SQLStore/Lookup/ErrorLookupTest.php
@@ -110,7 +110,7 @@ class ErrorLookupTest extends \PHPUnit_Framework_TestCase {
 
 		$query = new \SMW\MediaWiki\Connection\Query( $this->connection );
 
-		$resultWrapper = $this->getMockBuilder( '\ResultWrapper' )
+		$resultWrapper = $this->getMockBuilder( '\Wikimedia\Rdbms\ResultWrapper' )
 			->disableOriginalConstructor()
 			->getMock();
 
@@ -184,7 +184,7 @@ class ErrorLookupTest extends \PHPUnit_Framework_TestCase {
 
 		$query = new \SMW\MediaWiki\Connection\Query( $this->connection );
 
-		$resultWrapper = $this->getMockBuilder( '\ResultWrapper' )
+		$resultWrapper = $this->getMockBuilder( '\Wikimedia\Rdbms\ResultWrapper' )
 			->disableOriginalConstructor()
 			->getMock();
 

--- a/tests/phpunit/SQLStore/Lookup/ProximityPropertyValueLookupTest.php
+++ b/tests/phpunit/SQLStore/Lookup/ProximityPropertyValueLookupTest.php
@@ -6,8 +6,8 @@ use SMW\DIProperty;
 use SMW\RequestOptions;
 use SMW\SQLStore\Lookup\ProximityPropertyValueLookup;
 use SMW\MediaWiki\Connection\Query;
-use FakeResultWrapper;
 use SMW\Tests\PHPUnitCompat;
+use \Wikimedia\Rdbms\FakeResultWrapper;
 
 /**
  * @covers \SMW\MediaWiki\Api\Browse\ProximityPropertyValueLookup

--- a/tests/phpunit/SQLStore/Lookup/UsageStatisticsListLookupTest.php
+++ b/tests/phpunit/SQLStore/Lookup/UsageStatisticsListLookupTest.php
@@ -4,6 +4,7 @@ namespace SMW\Tests\SQLStore\Lookup;
 
 use SMW\SQLStore\Lookup\UsageStatisticsListLookup;
 use SMW\Tests\PHPUnitCompat;
+use Wikimedia\Rdbms\FakeResultWrapper;
 
 /**
  * @covers \SMW\SQLStore\Lookup\UsageStatisticsListLookup
@@ -72,7 +73,7 @@ class UsageStatisticsListLookupTest extends \PHPUnit_Framework_TestCase {
 
 		$connection->expects( $this->any() )
 			->method( 'select' )
-			->will( $this->returnValue( new \FakeResultWrapper( [] ) ) );
+			->will( $this->returnValue( new FakeResultWrapper( [] ) ) );
 
 		$this->store->expects( $this->any() )
 			->method( 'findPropertyTableID' )
@@ -110,7 +111,7 @@ class UsageStatisticsListLookupTest extends \PHPUnit_Framework_TestCase {
 
 		$connection->expects( $this->any() )
 			->method( 'select' )
-			->will( $this->returnValue( new \FakeResultWrapper( [ $row ] ) ) );
+			->will( $this->returnValue( new FakeResultWrapper( [ $row ] ) ) );
 
 		$tableDefinition = $this->getMockBuilder( '\SMW\SQLStore\TableDefinition' )
 			->disableOriginalConstructor()

--- a/tests/phpunit/SQLStore/QueryEngine/Fulltext/SearchTableRebuilderTest.php
+++ b/tests/phpunit/SQLStore/QueryEngine/Fulltext/SearchTableRebuilderTest.php
@@ -113,7 +113,7 @@ class SearchTableRebuilderTest extends \PHPUnit_Framework_TestCase {
 		$row->o_blob = null;
 		$row->s_id = 42;
 
-		$resultWrapper = $this->iteratorMockBuilder->setClass( '\ResultWrapper' )
+		$resultWrapper = $this->iteratorMockBuilder->setClass( '\Wikimedia\Rdbms\ResultWrapper' )
 			->with( [ $row ] )
 			->incrementInvokedCounterBy( 1 )
 			->getMockForIterator();

--- a/tests/phpunit/SQLStore/TableBuilder/Examiner/HashFieldTest.php
+++ b/tests/phpunit/SQLStore/TableBuilder/Examiner/HashFieldTest.php
@@ -46,7 +46,7 @@ class HashFieldTest extends \PHPUnit_Framework_TestCase {
 
 	public function testCheck_Populate() {
 
-		$resultWrapper = $this->getMockBuilder( '\ResultWrapper' )
+		$resultWrapper = $this->getMockBuilder( '\Wikimedia\Rdbms\ResultWrapper' )
 			->disableOriginalConstructor()
 			->getMock();
 
@@ -77,7 +77,7 @@ class HashFieldTest extends \PHPUnit_Framework_TestCase {
 
 	public function testCheck_Incomplete() {
 
-		$resultWrapper = $this->getMockBuilder( '\ResultWrapper' )
+		$resultWrapper = $this->getMockBuilder( '\Wikimedia\Rdbms\ResultWrapper' )
 			->disableOriginalConstructor()
 			->getMock();
 


### PR DESCRIPTION
The ResultWrapper related classes exist under the \Wikimedia\Rdms namespace since MW 1.29. See:
https://gerrit.wikimedia.org/r/c/mediawiki/core/+/338613

The class_alias was removed recently. See:
https://gerrit.wikimedia.org/r/c/mediawiki/core/+/950227