### PR TITLE
Elastic/Indexer/Bulk::$response can also be a string

### DIFF
--- a/src/Elastic/Indexer/Bulk.php
+++ b/src/Elastic/Indexer/Bulk.php
@@ -35,7 +35,7 @@ class Bulk implements JsonSerializable {
 	private $head = [];
 
 	/**
-	 * @var array
+	 * @var array|string
 	 */
 	private $response = [];
 
@@ -133,9 +133,9 @@ class Bulk implements JsonSerializable {
 	/**
 	 * @since 3.2
 	 *
-	 * @return array
+	 * @return array|string
 	 */
-	public function getResponse() : array {
+	public function getResponse() : array|string {
 		return $this->response;
 	}
 

--- a/src/Elastic/Indexer/Bulk.php
+++ b/src/Elastic/Indexer/Bulk.php
@@ -135,7 +135,7 @@ class Bulk implements JsonSerializable {
 	 *
 	 * @return array|string
 	 */
-	public function getResponse() : array|string {
+	public function getResponse() {
 		return $this->response;
 	}
 


### PR DESCRIPTION
That is, if there was an error.

But you should not get a useless TypeError then, you should get a useful error.