### PR TITLE
ParserAfterTidy: Remove usage of deprecated ParserOutput::getCategories

### DIFF
--- a/src/MediaWiki/Hooks/ParserAfterTidy.php
+++ b/src/MediaWiki/Hooks/ParserAfterTidy.php
@@ -145,10 +145,22 @@ class ParserAfterTidy implements HookListener {
 			$parserDefaultSort = $this->parser->getDefaultSort();
 		}
 
+
+		$parserCategories = [];
+		// MW >= 1.40
+		if ( method_exists( $parserOutput, 'getCategorySortKey' ) ) {
+			$names = $parserOutput->getCategoryNames();
+			foreach ( $names as $name ) {
+				$parserCategories[$name] = $parserOutput->getCategorySortKey( $name );
+			}
+		} else {
+			$parserCategories = $parserOutput->getCategories();
+		}
+
 		if ( $displayTitle ||
 			$parserOutput->getImages() !== [] ||
 			$parserOutput->getExtensionData( 'translate-translation-page' ) ||
-			$parserOutput->getCategories() ) {
+			$parserCategories ) {
 			return true;
 		}
 
@@ -207,9 +219,16 @@ class ParserAfterTidy implements HookListener {
 			$semanticData
 		);
 
+		// MW >= 1.38
+		if ( method_exists( $parserOutput, 'getCategoryNames' ) ) {
+			$parserCategoryKeys = $parserOutput->getCategoryNames();
+		} else {
+			$parserCategoryKeys = array_keys( $parserOutput->getCategories() );
+		}
+
 		$propertyAnnotator = $propertyAnnotatorFactory->newCategoryPropertyAnnotator(
 			$propertyAnnotator,
-			array_keys( $parserOutput->getCategories() )
+			$parserCategoryKeys
 		);
 
 		$propertyAnnotator = $propertyAnnotatorFactory->newMandatoryTypePropertyAnnotator(


### PR DESCRIPTION
Deprecated in https://gerrit.wikimedia.org/r/c/mediawiki/core/+/959825