### PR TITLE
Do not use array in 'must' query when sorting

### DIFF
--- a/src/Elastic/QueryEngine/ConditionBuilder.php
+++ b/src/Elastic/QueryEngine/ConditionBuilder.php
@@ -348,13 +348,13 @@ class ConditionBuilder {
 		}
 
 		if ( $this->options->safeGet( 'sort.property.must.exists' ) && $this->sortFields !== [] ) {
-			$params = [];
+			$must = [ $query ];
 
 			foreach ( $this->sortFields as $field ) {
-				$params[] = $this->fieldMapper->exists( "$field" );
+				$must[] = $this->fieldMapper->exists( "$field" );
 			}
 
-			$query = $this->fieldMapper->bool( 'must', [ $query, $params ] );
+			$query = $this->fieldMapper->bool( 'must', $must );
 		}
 
 		// If we know we don't need any score we turn this into a `constant_score`


### PR DESCRIPTION
This fixes the sort issue reported in #5451 by @wgevaert (https://github.com/SemanticMediaWiki/SemanticMediaWiki/pull/5451#issuecomment-1706739395).