### PR TITLE
Update SemanticMediaWiki.magic.php

### DIFF
--- a/i18n/extra/SemanticMediaWiki.magic.php
+++ b/i18n/extra/SemanticMediaWiki.magic.php
@@ -342,9 +342,12 @@ $magicWords['sr-ec'] = [
 	'show' => [ 0, 'прикажи' ],
 	'info' => [ 0, 'подаци' ],
 	'concept' => [ 0, 'концепт' ],
+	'subobject' => [ 0, 'подобјекат' ],
 	'set' => [ 0, 'постави' ],
 	'set_recurring_event' => [ 0, 'постави_периодични_догађај' ],
 	'declare' => [ 0, 'одреди' ],
+	'SMW_NOFACTBOX' => [ 0, '__БЕЗЧИЊЕНИЦА__', '__БЕЗ_ЧИЊЕНИЦА__' ],
+	'SMW_SHOWFACTBOX' => [ 0, '__ПРИКАЖИЧИЊЕНИЦЕ__', '__ПРИКАЖИ_ЧИЊЕНИЦЕ__' ],
 ];
 
 /** Serbian (Latin script) (srpski (latinica)‎) */
@@ -353,6 +356,7 @@ $magicWords['sr-el'] = [
 	'show' => [ 0, 'prikaži' ],
 	'info' => [ 0, 'podaci' ],
 	'concept' => [ 0, 'koncept' ],
+	'subobject' => [ 0, 'podobjekat' ],
 	'set' => [ 0, 'postavi' ],
 	'set_recurring_event' => [ 0, 'postavi_periodični_događaj' ],
 	'declare' => [ 0, 'odredi' ],


### PR DESCRIPTION
Added one magic word for the Serbian language (both scripts) and two for Serbian (Cyrillic script) based on Serbian (Latin script).

Checkable via https://konvertor.co.rs (on the right side paste SMW_NOFACTBOX and SMW_NOFACTBOX from sr-el, and click on "KONVERTUJ U ĆIRILICU").

For "subobject" check Google Translate (https://translate.google.com/?sl=en&tl=sr&text=subobject&op=translate) and in https://konvertor.co.rs paste in the left side "подобјекат" and click on "KONVERTUJ U LATINICU".

PR is made to address https://phabricator.wikimedia.org/T349952