### PR TITLE
Improve compatibility with OpenSearch

### DIFF
--- a/src/Elastic/Admin/ElasticClientTaskHandler.php
+++ b/src/Elastic/Admin/ElasticClientTaskHandler.php
@@ -276,9 +276,9 @@ class ElasticClientTaskHandler extends TaskHandler implements ActionableTask {
 		unset( $config['elastic/credentials'] );
 
 		foreach ( $endpoints as &$endpoint ) {
-            if ( is_string( $endpoint ) ) {
-                continue;
-            }
+			if ( is_string( $endpoint ) ) {
+				continue;
+			}
 
 			unset( $endpoint['user'] );
 			unset( $endpoint['pass'] );

--- a/src/Elastic/Admin/ElasticClientTaskHandler.php
+++ b/src/Elastic/Admin/ElasticClientTaskHandler.php
@@ -276,6 +276,10 @@ class ElasticClientTaskHandler extends TaskHandler implements ActionableTask {
 		unset( $config['elastic/credentials'] );
 
 		foreach ( $endpoints as &$endpoint ) {
+            if ( is_string( $endpoint ) ) {
+                continue;
+            }
+
 			unset( $endpoint['user'] );
 			unset( $endpoint['pass'] );
 		}

--- a/src/Elastic/Admin/ElasticClientTaskHandler.php
+++ b/src/Elastic/Admin/ElasticClientTaskHandler.php
@@ -275,15 +275,6 @@ class ElasticClientTaskHandler extends TaskHandler implements ActionableTask {
 		// Do not show credentials through special page
 		unset( $config['elastic/credentials'] );
 
-		foreach ( $endpoints as &$endpoint ) {
-			if ( is_string( $endpoint ) ) {
-				continue;
-			}
-
-			unset( $endpoint['user'] );
-			unset( $endpoint['pass'] );
-		}
-
 		$config = ( new JsonView() )->create(
 			'elastic-config',
 			$this->outputFormatter->encodeAsJson( $config ),

--- a/src/Elastic/Connection/Client.php
+++ b/src/Elastic/Connection/Client.php
@@ -61,10 +61,10 @@ class Client {
 	 */
 	private $wikiid;
 
-    /**
-     * @var string
-     */
-    private $distribution;
+	/**
+	 * @var string
+	 */
+	private $distribution;
 
 	/**
 	 * @var boolean
@@ -193,8 +193,8 @@ class Client {
 	public function getSoftwareInfo() {
 		return [
 			'component' => $this->isOpenSearch() ?
-                "[https://opensearch.org OpenSearch]" :
-                "[https://www.elastic.co/elasticsearch/ Elasticsearch]",
+				"[https://opensearch.org OpenSearch]" :
+				"[https://www.elastic.co/elasticsearch/ Elasticsearch]",
 			'version' => $this->getVersion()
 		];
 	}
@@ -217,7 +217,7 @@ class Client {
 	 * @since 3.0
 	 *
 	 * @param string $type
-     * @param array $params
+	 * @param array $params
 	 */
 	public function stats( string $type = 'indices', array $params = [] ): array {
 
@@ -226,16 +226,16 @@ class Client {
 			$this->getIndexName( self::TYPE_LOOKUP )
 		];
 
-        switch ( $type ) {
-            case 'indices':
-                $res = $this->client->indices()->stats( [ 'index' => $indices ] + $params );
-                break;
-            case 'nodes':
-                $res = $this->client->nodes()->stats( $params );
-                break;
-            default:
-                return [];
-        }
+		switch ( $type ) {
+			case 'indices':
+				$res = $this->client->indices()->stats( [ 'index' => $indices ] + $params );
+				break;
+			case 'nodes':
+				$res = $this->client->nodes()->stats( $params );
+				break;
+			default:
+				return [];
+		}
 
 		if ( $type === 'indices' && isset( $res['indices'] ) ) {
 			unset( $res['_all'] );
@@ -266,7 +266,7 @@ class Client {
 		if ( $type === 'indices' ) {
 			$params += [ 'format' => 'json' ];
 
-            $indices = $this->client->cat()->indices( $params );
+			$indices = $this->client->cat()->indices( $params );
 
 			foreach ( $indices as $value ) {
 				$res[$value['index']] = $value;
@@ -319,14 +319,14 @@ class Client {
 			'body'  => $this->getIndexDefinition( $type )
 		];
 
-        $context = [
-            'method' => __METHOD__,
-            'role' => 'user',
-            'index' => $index
-        ];
+		$context = [
+			'method' => __METHOD__,
+			'role' => 'user',
+			'index' => $index
+		];
 
-        $context['response'] = $this->client->indices()->create( $params );
-        $this->logger->info( 'Created index {index} with: {response}', $context );
+		$context['response'] = $this->client->indices()->create( $params );
+		$this->logger->info( 'Created index {index} with: {response}', $context );
 
 		return $version;
 	}
@@ -342,14 +342,14 @@ class Client {
 			'index' => $index,
 		];
 
-        $context = [
-            'method' => __METHOD__,
-            'role' => 'user',
-            'index' => $index
-        ];
+		$context = [
+			'method' => __METHOD__,
+			'role' => 'user',
+			'index' => $index
+		];
 
-        $context['response'] = $this->client->indices()->delete( $params );
-        $this->logger->info( 'Deleted index {index} with: {response}', $context );
+		$context['response'] = $this->client->indices()->delete( $params );
+		$this->logger->info( 'Deleted index {index} with: {response}', $context );
 	}
 
 	/**
@@ -536,7 +536,7 @@ class Client {
 			$context['exception'] = $e->getMessage();
 			$this->logger->info( 'Updated failed for document {id} with: {exception}, DOC: {doc}', $context );
 
-            return $context['exception'];
+			return $context['exception'];
 		}
 	}
 
@@ -563,7 +563,7 @@ class Client {
 			$context['exception'] = $e->getMessage();
 			$this->logger->info( 'Index failed for document {id} with: {exception}', $context );
 
-            return $context['exception'];
+			return $context['exception'];
 		}
 	}
 
@@ -616,7 +616,7 @@ class Client {
 			$context['exception'] = $e->getMessage();
 			$this->logger->info( 'Bulk update failed with {exception}', $context );
 
-            return $context['exception'];
+			return $context['exception'];
 		}
 	}
 
@@ -777,14 +777,14 @@ class Client {
 		$this->client->indices()->close( [ 'index' => $index ] );
 	}
 
-    /**
-     * @since 4.2.0
-     *
-     * @param array $params
-     */
-    public function ingestPutPipeline( array $params ) {
-        $this->client->ingest()->putPipeline( $params );
-    }
+	/**
+	 * @since 4.2.0
+	 *
+	 * @param array $params
+	 */
+	public function ingestPutPipeline( array $params ) {
+		$this->client->ingest()->putPipeline( $params );
+	}
 
 	/**
 	 * @since 3.1
@@ -843,19 +843,19 @@ class Client {
 		$this->lockManager->releaseLock( $type );
 	}
 
-    /**
-     * @since 4.2
-     *
-     * @return bool
-     */
-    public function isOpenSearch(): bool {
+	/**
+	 * @since 4.2
+	 *
+	 * @return bool
+	 */
+	public function isOpenSearch(): bool {
 
-        if ( !isset( $this->distribution ) ) {
-            $info = $this->info();
-            $this->distribution = $info['version']['distribution'] ?? 'elasticsearch';
-        }
+		if ( !isset( $this->distribution ) ) {
+			$info = $this->info();
+			$this->distribution = $info['version']['distribution'] ?? 'elasticsearch';
+		}
 
-        return $this->distribution === 'opensearch';
-    }
+		return $this->distribution === 'opensearch';
+	}
 
 }

--- a/src/Elastic/Connection/Client.php
+++ b/src/Elastic/Connection/Client.php
@@ -61,6 +61,11 @@ class Client {
 	 */
 	private $wikiid;
 
+    /**
+     * @var string
+     */
+    private $distribution;
+
 	/**
 	 * @var boolean
 	 */
@@ -187,7 +192,9 @@ class Client {
 	 */
 	public function getSoftwareInfo() {
 		return [
-			'component' => "[https://www.elastic.co/elasticsearch/ Elasticsearch]",
+			'component' => $this->isOpenSearch() ?
+                "[https://opensearch.org OpenSearch]" :
+                "[https://www.elastic.co/elasticsearch/ Elasticsearch]",
 			'version' => $this->getVersion()
 		];
 	}
@@ -835,5 +842,20 @@ class Client {
 	public function releaseLock( $type ) {
 		$this->lockManager->releaseLock( $type );
 	}
+
+    /**
+     * @since 4.2
+     *
+     * @return bool
+     */
+    public function isOpenSearch(): bool {
+
+        if ( !isset( $this->distribution ) ) {
+            $info = $this->info();
+            $this->distribution = $info['version']['distribution'] ?? 'elasticsearch';
+        }
+
+        return $this->distribution === 'opensearch';
+    }
 
 }

--- a/src/Elastic/Indexer/Rebuilder/Rebuilder.php
+++ b/src/Elastic/Indexer/Rebuilder/Rebuilder.php
@@ -420,7 +420,7 @@ class Rebuilder {
 		// #4341
 		// ES 5.6 may cause a "Can't update [index.number_of_replicas] on closed
 		// indices" see elastic/elasticsearch#22993 and should be fixed with ES 6.4.
-		if ( version_compare( $this->client->getVersion(), '6.4.0', '<' ) ) {
+		if ( !$this->client->isOpenSearch() && version_compare( $this->client->getVersion(), '6.4.0', '<' ) ) {
 			unset( $indexDef['settings']['number_of_replicas'] );
 		}
 


### PR DESCRIPTION
This pull request improves compatibility with OpenSearch. I tested it using OpenSearch 1.3.13, which seems to work (i.e. passes `update.php`, `setupStore.php`, `rebuildData.php` and `rebuildElasticIndex.php` without fatalling).

<img width="676" alt="Screenshot 2023-10-31 at 13 01 41" src="https://github.com/SemanticMediaWiki/SemanticMediaWiki/assets/96489967/0f6419b5-8554-4eb0-be2d-3565fd5af078">
<img width="826" alt="Screenshot 2023-10-31 at 16 04 13" src="https://github.com/SemanticMediaWiki/SemanticMediaWiki/assets/96489967/3215ab4b-4266-420b-a37f-6c0abb952eb1">
<img width="587" alt="Screenshot 2023-10-31 at 16 03 47" src="https://github.com/SemanticMediaWiki/SemanticMediaWiki/assets/96489967/6b6a648d-c074-4a8e-91ba-f1298d03f26f">
