### PR TITLE
replace isLoggedIn()->isRegistered()

### DIFF
--- a/src/MediaWiki/Search/ProfileForm/Forms/NamespaceForm.php
+++ b/src/MediaWiki/Search/ProfileForm/Forms/NamespaceForm.php
@@ -116,7 +116,7 @@ class NamespaceForm {
 
 		$user = $specialSearch->getUser();
 
-		if ( !$user->isLoggedIn() ) {
+		if ( !$user->isRegistered() ) {
 			return;
 		}
 

--- a/src/MediaWiki/Search/ProfileForm/Forms/NamespaceForm.php
+++ b/src/MediaWiki/Search/ProfileForm/Forms/NamespaceForm.php
@@ -115,8 +115,8 @@ class NamespaceForm {
 	public function checkNamespaceEditToken( SpecialSearch $specialSearch ) {
 
 		$user = $specialSearch->getUser();
-
-		if ( !$user->isRegistered() ) {
+		$isRegistered = ( version_compare( $GLOBALS['wgVersion'], '1.34' ) !== -1 ) ? $user->isRegistered() : $user->isLoggedIn();
+		if ( !$isRegistered ) {
 			return;
 		}
 

--- a/tests/phpunit/MediaWiki/Search/ProfileForm/Forms/NamespaceFormTest.php
+++ b/tests/phpunit/MediaWiki/Search/ProfileForm/Forms/NamespaceFormTest.php
@@ -74,7 +74,7 @@ class NamespaceFormTest extends \PHPUnit_Framework_TestCase {
 			->method( 'getEditToken' );
 
 		$user->expects( $this->any() )
-			->method( 'isLoggedIn' )
+			->method( 'isRegistered' )
 			->will( $this->returnValue( true ) );
 
 		$specialSearch = $this->getMockBuilder( '\SpecialSearch' )

--- a/tests/phpunit/MediaWiki/Search/ProfileForm/Forms/NamespaceFormTest.php
+++ b/tests/phpunit/MediaWiki/Search/ProfileForm/Forms/NamespaceFormTest.php
@@ -73,8 +73,9 @@ class NamespaceFormTest extends \PHPUnit_Framework_TestCase {
 		$user->expects( $this->once() )
 			->method( 'getEditToken' );
 
+		$isRegisteredMethod = ( version_compare( $GLOBALS['wgVersion'], '1.34' ) !== -1 ) ? 'isRegistered' : 'isLoggedIn';
 		$user->expects( $this->any() )
-			->method( 'isRegistered' )
+			->method( $isRegisteredMethod )
 			->will( $this->returnValue( true ) );
 
 		$specialSearch = $this->getMockBuilder( '\SpecialSearch' )


### PR DESCRIPTION
isLogged() was deprecated in 1.36 and removed by 1.39.