### PR TITLE
eliminate one more MW1.38 deprecation warning

### DIFF
--- a/src/ParserFunctions/ConceptParserFunction.php
+++ b/src/ParserFunctions/ConceptParserFunction.php
@@ -43,7 +43,7 @@ class ConceptParserFunction {
 
 	/**
 	 * @since 1.9
-	 *
+	 * 
 	 * @param ParserData $parserData
 	 * @param MessageFormatter $messageFormatter
 	 */
@@ -72,7 +72,7 @@ class ConceptParserFunction {
 	 * @return string|null
 	 */
 	public function parse( array $rawParams ) {
-		$this->parserData->getOutput()->addModules( 'ext.smw.style' );
+		$this->parserData->getOutput()->addModules( ['ext.smw.style'] );
 
 		$title = $this->parserData->getTitle();
 		$property = new DIProperty( '_CONC' );


### PR DESCRIPTION
Fixes some cases from the deprecation messages reported in 
* https://github.com/SemanticMediaWiki/SemanticMediaWiki/issues/5553
namely:
```
Deprecated: Use of ParserOutput::addModules with non-array argument was deprecated in MediaWiki 1.38
```