### PR TITLE
Fix special page property issue 5536

### DIFF
--- a/src/MediaWiki/Specials/PageProperty/PageBuilder.php
+++ b/src/MediaWiki/Specials/PageProperty/PageBuilder.php
@@ -161,6 +161,7 @@ class PageBuilder {
 				$this->options->safeGet( 'from', '' ),
 				'smw-article-input',
 				30,
+				// [ 'class' => 'is-disabled' ]
 			)
 			->addNonBreakingSpace()
 			->addInputField(

--- a/src/MediaWiki/Specials/PageProperty/PageBuilder.php
+++ b/src/MediaWiki/Specials/PageProperty/PageBuilder.php
@@ -161,7 +161,7 @@ class PageBuilder {
 				$this->options->safeGet( 'from', '' ),
 				'smw-article-input',
 				30,
-				[ 'class' => 'is-disabled' ] )
+			)
 			->addNonBreakingSpace()
 			->addInputField(
 				Message::get( 'smw_sbv_property', Message::TEXT, Message::USER_LANGUAGE ),

--- a/src/MediaWiki/Specials/PageProperty/PageBuilder.php
+++ b/src/MediaWiki/Specials/PageProperty/PageBuilder.php
@@ -159,9 +159,9 @@ class PageBuilder {
 				Message::get( 'smw_pp_from', Message::TEXT, Message::USER_LANGUAGE ),
 				'from',
 				$this->options->safeGet( 'from', '' ),
-				'smw-article-input',
+				'smw-page-input',
 				30,
-				// [ 'class' => 'is-disabled' ]
+				[ 'class' => 'is-disabled' ]
 			)
 			->addNonBreakingSpace()
 			->addInputField(

--- a/src/MediaWiki/Specials/SpecialPageProperty.php
+++ b/src/MediaWiki/Specials/SpecialPageProperty.php
@@ -47,7 +47,7 @@ class SpecialPageProperty extends SpecialPage {
 		}
 
 		if ( $query !== '' ) {
-			$query = Encoder::unescape( $query );
+			$query = Encoder::unescape( (string)$query );
 		}
 
 		// Get parameters

--- a/src/MediaWiki/Specials/SpecialPageProperty.php
+++ b/src/MediaWiki/Specials/SpecialPageProperty.php
@@ -172,7 +172,7 @@ class SpecialPageProperty extends SpecialPage {
 		$output->addModules( 'ext.smw.tooltip' );
 
 		$output->addModules( 'ext.smw.autocomplete.property' );
-		$output->addModules( 'ext.smw.autocomplete.article' );
+		$output->addModules( 'ext.smw.autocomplete.page' );
 
 		$output->addHTML( $html );
 	}


### PR DESCRIPTION
fixes https://github.com/SemanticMediaWiki/SemanticMediaWiki/issues/5536

(the input "From page" in the special page `Special:PageProperty` was not working, due to a change in the class name and the module `ext.smw.autocomplete.page` (from `ext.smw.autocomplete.article` ) entitled to handle the input.

Also, is there a reason to not list this special page, `Special:PageProperty` , in `Special:SpecialPages` , which actually could be used independently ? 
