### PR TITLE
Introduce IDatabase::QUERY_CHANGE_* constants

### DIFF
--- a/src/MediaWiki/Connection/CleanUpTables.php
+++ b/src/MediaWiki/Connection/CleanUpTables.php
@@ -4,6 +4,7 @@ namespace SMW\MediaWiki\Connection;
 
 use RuntimeException;
 use Wikimedia\Rdbms\IDatabase;
+use Wikimedia\Rdbms\Platform\ISQLPlatform;
 
 /**
  * @private
@@ -54,9 +55,9 @@ class CleanUpTables {
 			}
 
 			if ( $this->connection->getType() === 'postgres' ) {
-				$this->connection->query( "DROP TABLE IF EXISTS $table CASCADE", __METHOD__ );
+				$this->connection->query( "DROP TABLE IF EXISTS $table CASCADE", __METHOD__, ISQLPlatform::QUERY_CHANGE_SCHEMA );
 			} else {
-				$this->connection->query( "DROP TABLE $table", __METHOD__ );
+				$this->connection->query( "DROP TABLE $table", __METHOD__, ISQLPlatform::QUERY_CHANGE_SCHEMA );
 			}
 		}
 	}

--- a/src/MediaWiki/Connection/Sequence.php
+++ b/src/MediaWiki/Connection/Sequence.php
@@ -5,6 +5,7 @@ namespace SMW\MediaWiki\Connection;
 use SMW\SQLStore\SQLStore;
 use RuntimeException;
 use Wikimedia\Rdbms\IDatabase;
+use Wikimedia\Rdbms\Platform\ISQLPlatform;
 
 /**
  * @license GNU GPL v2+
@@ -79,7 +80,7 @@ class Sequence {
 		$sequence = self::makeSequence( $table, $field );
 
 		$this->connection->onTransactionCommitOrIdle( function () use( $sequence, $seq_num ) {
-			$this->connection->query( "ALTER SEQUENCE {$sequence} RESTART WITH {$seq_num}", __METHOD__ );
+			$this->connection->query( "ALTER SEQUENCE {$sequence} RESTART WITH {$seq_num}", __METHOD__, ISQLPlatform::QUERY_CHANGE_SCHEMA );
 		} );
 
 		return $seq_num;

--- a/src/SQLStore/ConceptCache.php
+++ b/src/SQLStore/ConceptCache.php
@@ -10,6 +10,7 @@ use SMW\SQLStore\QueryEngine\ConceptQuerySegmentBuilder;
 use SMWSQLStore3;
 use SMWWikiPageValue;
 use Title;
+use Wikimedia\Rdbms\Platform\ISQLPlatform;
 
 /**
  * @license GNU GPL v2+
@@ -146,7 +147,8 @@ class ConceptCache {
 			$db->tableName( $querySegment->joinTable ) . " AS {$querySegment->alias}" .
 			$querySegment->from .
 			( $where ? ' WHERE ' : '' ) . $where . " LIMIT " . $this->upperLimit,
-			__METHOD__
+			__METHOD__,
+			ISQLPlatform::QUERY_CHANGE_ROWS
 		);
 
 		$db->update(

--- a/src/SQLStore/Lookup/EntityUniquenessLookup.php
+++ b/src/SQLStore/Lookup/EntityUniquenessLookup.php
@@ -12,6 +12,7 @@ use SMW\IteratorFactory;
 use InvalidArgumentException;
 use RuntimeException;
 use SMWDIContainer as DIContainer;
+use Wikimedia\Rdbms\Platform\ISQLPlatform;
 
 /**
  * @license GNU GPL v2+
@@ -96,7 +97,8 @@ class EntityUniquenessLookup {
 
 		$res = $connection->query(
 			$query,
-			__METHOD__
+			__METHOD__,
+			ISQLPlatform::QUERY_CHANGE_NONE
 		);
 
 		$result = $this->iteratorFactory->newMappingIterator(

--- a/src/SQLStore/Lookup/ProximityPropertyValueLookup.php
+++ b/src/SQLStore/Lookup/ProximityPropertyValueLookup.php
@@ -11,6 +11,7 @@ use SMW\RequestOptions;
 use SMW\SQLStore\SQLStore;
 use SMWDataItem as DataItem;
 use SMWDITime as DITime;
+use Wikimedia\Rdbms\Platform\ISQLPlatform;
 
 /**
  * @license GNU GPL v2+
@@ -118,7 +119,8 @@ class ProximityPropertyValueLookup {
 
 		$res = $connection->query(
 			$query,
-			__METHOD__
+			__METHOD__,
+			ISQLPlatform::QUERY_CHANGE_NONE
 		);
 
 		foreach ( $res as $row ) {
@@ -209,7 +211,8 @@ class ProximityPropertyValueLookup {
 
 		$res = $connection->query(
 			$query,
-			__METHOD__
+			__METHOD__,
+			ISQLPlatform::QUERY_CHANGE_NONE
 		);
 
 		$list = [];

--- a/src/SQLStore/QueryEngine/Fulltext/SearchTableUpdater.php
+++ b/src/SQLStore/QueryEngine/Fulltext/SearchTableUpdater.php
@@ -3,6 +3,7 @@
 namespace SMW\SQLStore\QueryEngine\Fulltext;
 
 use SMW\MediaWiki\Database;
+use Wikimedia\Rdbms\Platform\ISQLPlatform;
 
 /**
  * @license GNU GPL v2+
@@ -86,7 +87,8 @@ class SearchTableUpdater {
 
 		$this->connection->query(
 			"OPTIMIZE TABLE " . $this->searchTable->getTableName(),
-			__METHOD__
+			__METHOD__,
+			ISQLPlatform::QUERY_CHANGE_SCHEMA
 		);
 
 		return true;

--- a/src/SQLStore/QueryEngine/HierarchyTempTableBuilder.php
+++ b/src/SQLStore/QueryEngine/HierarchyTempTableBuilder.php
@@ -5,6 +5,7 @@ namespace SMW\SQLStore\QueryEngine;
 use RuntimeException;
 use SMW\MediaWiki\Database;
 use SMW\SQLStore\TableBuilder\TemporaryTableBuilder;
+use Wikimedia\Rdbms\Platform\ISQLPlatform;
 
 /**
  * @license GNU GPL v2+
@@ -118,7 +119,8 @@ class HierarchyTempTableBuilder {
 
 			$this->connection->query(
 				"INSERT INTO $tablename (id) SELECT id" . ' FROM ' . $this->hierarchyCache[$valueComposite],
-				__METHOD__
+				__METHOD__,
+				ISQLPlatform::QUERY_CHANGE_ROWS
 			);
 
 			return;
@@ -147,19 +149,22 @@ class HierarchyTempTableBuilder {
 
 			$db->query(
 				"INSERT " . "IGNORE" . " INTO $tablename (id) VALUES $value",
-				__METHOD__
+				__METHOD__,
+				ISQLPlatform::QUERY_CHANGE_ROWS
 			);
 
 			$db->query(
 				"INSERT " . "IGNORE" . " INTO $tmpnew (id) VALUES $value",
-				__METHOD__
+				__METHOD__,
+				ISQLPlatform::QUERY_CHANGE_ROWS
 			);
 		}
 
 		for ( $i = 0; $i < $depth; $i++ ) {
 			$db->query(
 				"INSERT " . 'IGNORE ' . "INTO $tmpres (id) SELECT s_id" . '@INT' . " FROM $smwtable, $tmpnew WHERE o_id=id",
-				__METHOD__
+				__METHOD__,
+				ISQLPlatform::QUERY_CHANGE_ROWS
 			);
 
 			if ( $db->affectedRows() == 0 ) { // no change, exit loop
@@ -168,7 +173,8 @@ class HierarchyTempTableBuilder {
 
 			$db->query(
 				"INSERT " . 'IGNORE ' . "INTO $tablename (id) SELECT $tmpres.id FROM $tmpres",
-				__METHOD__
+				__METHOD__,
+				ISQLPlatform::QUERY_CHANGE_ROWS
 			);
 
 			if ( $db->affectedRows() == 0 ) { // no change, exit loop
@@ -178,7 +184,8 @@ class HierarchyTempTableBuilder {
 			// empty "new" table
 			$db->query(
 				'DELETE FROM ' . $tmpnew,
-				__METHOD__
+				__METHOD__,
+				ISQLPlatform::QUERY_CHANGE_ROWS
 			);
 
 			$tmpname = $tmpnew;

--- a/src/SQLStore/QueryEngine/QueryEngine.php
+++ b/src/SQLStore/QueryEngine/QueryEngine.php
@@ -16,6 +16,7 @@ use SMWDataItem as DataItem;
 use SMWQuery as Query;
 use SMWQueryResult as QueryResult;
 use SMWSQLStore3 as SQLStore;
+use Wikimedia\Rdbms\Platform\ISQLPlatform;
 
 /**
  * Class that implements query answering for SQLStore.
@@ -307,7 +308,7 @@ class QueryEngine implements QueryEngineInterface, LoggerAwareInterface {
 			$query = "EXPLAIN $format $sql";
 		}
 
-		$res = $connection->query( $query, __METHOD__ );
+		$res = $connection->query( $query, __METHOD__, ISQLPlatform::QUERY_CHANGE_NONE );
 
 		$entries['SQL Explain'] = $debugFormatter->prettifyExplain( new ResultIterator( $res ) );
 		$entries['SQL Query'] = $debugFormatter->prettifySQL( $sql, $qobj->alias );

--- a/src/SQLStore/QueryEngine/QuerySegmentListProcessor.php
+++ b/src/SQLStore/QueryEngine/QuerySegmentListProcessor.php
@@ -6,6 +6,7 @@ use RuntimeException;
 use SMW\MediaWiki\Database;
 use SMW\SQLStore\TableBuilder\TemporaryTableBuilder;
 use SMWQuery as Query;
+use Wikimedia\Rdbms\Platform\ISQLPlatform;
 
 /**
  * @license GNU GPL v2+
@@ -280,7 +281,8 @@ class QuerySegmentListProcessor {
 				if ( $this->queryMode !== Query::MODE_NONE ) {
 					$this->connection->query(
 						$sql,
-						__METHOD__
+						__METHOD__,
+						ISQLPlatform::QUERY_CHANGE_ROWS
 					);
 				}
 			}

--- a/src/SQLStore/RedirectUpdater.php
+++ b/src/SQLStore/RedirectUpdater.php
@@ -15,6 +15,7 @@ use SMW\SQLStore\EntityStore\IdChanger;
 use SMW\SQLStore\EntityStore\CachingSemanticDataLookup;
 use SMW\Listener\ChangeListener\ChangeRecord;
 use Title;
+use Wikimedia\Rdbms\Platform\ISQLPlatform;
 
 /**
  * @license GNU GPL v2+
@@ -585,7 +586,7 @@ class RedirectUpdater {
 			'smw_iw = ' . $connection->addQuotes( '' ) . ' AND ' .
 			'smw_subobject != ' . $connection->addQuotes( '' ); // The "!=" is why we cannot use MW array syntax here
 
-		$connection->query( $sql, __METHOD__ );
+		$connection->query( $sql, __METHOD__, ISQLPlatform::QUERY_CHANGE_ROWS );
 
 		$this->moveSubobjects(
 			$source->getDBkey(),

--- a/src/SQLStore/TableBuilder/TableBuildExaminer.php
+++ b/src/SQLStore/TableBuilder/TableBuildExaminer.php
@@ -16,6 +16,7 @@ use SMW\SQLStore\TableBuilder\Examiner\FixedProperties;
 use SMW\SQLStore\TableBuilder\Examiner\TouchedField;
 use SMW\SQLStore\TableBuilder\Examiner\IdBorder;
 use SMWSql3SmwIds;
+use Wikimedia\Rdbms\Platform\ISQLPlatform;
 
 /**
  * @private
@@ -204,7 +205,7 @@ class TableBuildExaminer {
 
 			$this->messageReporter->reportMessage( "   Table " . SQLStore::ID_TABLE . " ...\n" );
 			$this->messageReporter->reportMessage( "   ... copying $copyField to $emptyField ... " );
-			$connection->query( "UPDATE $tableName SET $emptyField = $copyField", __METHOD__ );
+			$connection->query( "UPDATE $tableName SET $emptyField = $copyField", __METHOD__, ISQLPlatform::QUERY_CHANGE_ROWS );
 			$this->messageReporter->reportMessage( "done.\n" );
 		}
 

--- a/src/SQLStore/TableBuilder/TemporaryTableBuilder.php
+++ b/src/SQLStore/TableBuilder/TemporaryTableBuilder.php
@@ -3,6 +3,7 @@
 namespace SMW\SQLStore\TableBuilder;
 
 use SMW\MediaWiki\Database;
+use Wikimedia\Rdbms\Platform\ISQLPlatform;
 
 /**
  * @license GNU GPL v2+
@@ -55,7 +56,7 @@ class TemporaryTableBuilder {
 		$this->connection->query(
 			$this->getSQLCodeFor( $tableName ),
 			__METHOD__,
-			false
+			ISQLPlatform::QUERY_CHANGE_SCHEMA
 		);
 	}
 
@@ -72,7 +73,7 @@ class TemporaryTableBuilder {
 		$this->connection->query(
 			"DROP TEMPORARY TABLE " . $tableName,
 			__METHOD__,
-			false
+			ISQLPlatform::QUERY_CHANGE_SCHEMA
 		);
 	}
 


### PR DESCRIPTION
This is a classification of the SQL queries introduced by MediaWiki 1.35 and it becomes heavily-recommended in 1.40 (warnings emitted).

This uses intentionally IDatabase::QUERY_CHANGE_* constants and not ISQLPlatform::QUERY_CHANGE_* to be compatible with MW 1.35; and the interface ISQLPlatform is a parent interface of IDatabase from 1.39.

This commit is only a first step to introduce the parameter `$flags` in lieu of `$ignoreException` in the methods `query` (MediaWiki did a similar move in https://github.com/wikimedia/mediawiki/commit/108fd8b18c1084de7af0bf05831ee9360f595c96 and the previous parameters values remains compatible) and I replaced the most visible occurrences I saw when executed with MW 1.40, but it remains other occurrences.

Issue: #5568

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced query execution with `ISQLPlatform` integration across multiple classes, improving handling of schema changes and query types.
  
- **Bug Fixes**
	- Adjusted query parameters to ensure accurate execution context for various database operations.

- **Documentation**
	- Clarified handling of ENUM types in SQLite and improved comments regarding query changes in multiple classes.

- **Refactor**
	- Updated method signatures to include new parameters for better query context and execution handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->