### PR TITLE
Fix PHP deprecation warning in SemanticDataLookup.php

### DIFF
--- a/src/SQLStore/EntityStore/SemanticDataLookup.php
+++ b/src/SQLStore/EntityStore/SemanticDataLookup.php
@@ -729,7 +729,7 @@ class SemanticDataLookup {
 
 		// Avoid issues with `$row->$sortField` containing other `#` as for
 		// example in case of a subobject name
-		if ( $sortField !== '' ) {
+		if ( is_string( $softField ) && $sortField !== '' ) {
 			$hash = mb_substr( str_replace( '#', '|', $row->$sortField ), 0, 32 ) . '#' . $hash;
 		}
 

--- a/src/SQLStore/EntityStore/SemanticDataLookup.php
+++ b/src/SQLStore/EntityStore/SemanticDataLookup.php
@@ -729,7 +729,7 @@ class SemanticDataLookup {
 
 		// Avoid issues with `$row->$sortField` containing other `#` as for
 		// example in case of a subobject name
-		if ( is_string( $softField ) && $sortField !== '' ) {
+		if ( is_string( $sortField ) && $sortField !== '' ) {
 			$hash = mb_substr( str_replace( '#', '|', $row->$sortField ), 0, 32 ) . '#' . $hash;
 		}
 


### PR DESCRIPTION
```
PHP Deprecated: str_replace(): Passing null to parameter #3 ($subject) of type array|string
is deprecated at SemanticDataLookup.php:733

str_replace('#', '|', NULL)
```