### PR TITLE
Update extension.json manifest_version to 2

### DIFF
--- a/extension.json
+++ b/extension.json
@@ -122,5 +122,5 @@
 		"smw-prefs-general-options-show-entity-issue-panel": true
 	},
 	"load_composer_autoloader": true,
-	"manifest_version": 1
+	"manifest_version": 2
 }


### PR DESCRIPTION
> v2 is recommended if your extension already requires MediaWiki 1.29+.

As SemanticMediaWiki already require MediaWiki >= 1.35 and the extension.json already meet both manifest_version v1 and v2 specs, we could simply update the version number.