### PR TITLE
Fix assorted PHP deprecation notices

### DIFF
--- a/includes/dataitems/SMW_DI_WikiPage.php
+++ b/includes/dataitems/SMW_DI_WikiPage.php
@@ -161,7 +161,7 @@ class DIWikiPage extends SMWDataItem {
 	 * @param string $sortkey
 	 */
 	public function setSortKey( $sortkey ) {
-		$this->sortkey = str_replace( '_', ' ', $sortkey );
+		$this->sortkey = str_replace( '_', ' ', $sortkey ?? '' );
 	}
 
 	/**
@@ -341,7 +341,7 @@ class DIWikiPage extends SMWDataItem {
 
 	/**
 	 * Implements \JsonSerializable.
-	 * 
+	 *
 	 * @since 4.0.0
 	 *
 	 * @return array
@@ -357,7 +357,7 @@ class DIWikiPage extends SMWDataItem {
 
 	/**
 	 * Implements JsonUnserializable.
-	 * 
+	 *
 	 * @since 4.0.0
 	 *
 	 * @param JsonUnserializer $unserializer Unserializer

--- a/src/Iterators/ChunkedIterator.php
+++ b/src/Iterators/ChunkedIterator.php
@@ -57,6 +57,7 @@ class ChunkedIterator extends IteratorIterator {
 	 *
 	 * {@inheritDoc}
 	 */
+	#[\ReturnTypeWillChange]
 	public function rewind() {
 		parent::rewind();
 		$this->next();
@@ -67,6 +68,7 @@ class ChunkedIterator extends IteratorIterator {
 	 *
 	 * {@inheritDoc}
 	 */
+	#[\ReturnTypeWillChange]
 	public function next() {
 		$this->chunk = [];
 
@@ -81,6 +83,7 @@ class ChunkedIterator extends IteratorIterator {
 	 *
 	 * {@inheritDoc}
 	 */
+	#[\ReturnTypeWillChange]
 	public function current() {
 		return $this->chunk;
 	}
@@ -90,6 +93,7 @@ class ChunkedIterator extends IteratorIterator {
 	 *
 	 * {@inheritDoc}
 	 */
+	#[\ReturnTypeWillChange]
 	public function valid() {
 		return (bool)$this->chunk;
 	}

--- a/src/MediaWiki/Api/ApiRequestParameterFormatter.php
+++ b/src/MediaWiki/Api/ApiRequestParameterFormatter.php
@@ -88,11 +88,11 @@ final class ApiRequestParameterFormatter {
 		}
 
 		if ( isset( $this->requestParameters['conditions'] ) && is_array( $this->requestParameters['conditions'] ) ) {
-			$result->set( 'conditions', implode( ' ', array_map( 'self::formatConditions', $this->requestParameters['conditions'] ) ) );
+			$result->set( 'conditions', implode( ' ', array_map( [ $this, 'formatConditions' ], $this->requestParameters['conditions'] ) ) );
 		}
 
 		if ( isset( $this->requestParameters['printouts'] ) && is_array( $this->requestParameters['printouts'] ) ) {
-			$result->set( 'printouts', array_map( 'self::formatPrintouts', $this->requestParameters['printouts'] ) );
+			$result->set( 'printouts', array_map( [ $this, 'formatPrintouts' ], $this->requestParameters['printouts'] ) );
 		}
 
 		return $result;

--- a/src/Parser/RecursiveTextProcessor.php
+++ b/src/Parser/RecursiveTextProcessor.php
@@ -136,11 +136,7 @@ class RecursiveTextProcessor {
 		}
 
 		$parserOutput = $this->parser->getOutput();
-		$track = $parserOutput->getExtensionData( ParserData::ANNOTATION_BLOCK );
-
-		if ( $track === null ) {
-			$track = [];
-		}
+		$track = $parserOutput->getExtensionData( ParserData::ANNOTATION_BLOCK ) ?: [];
 
 		// Track each embedded #ask process to ensure to remove
 		// blocks on the correct recursive iteration (e.g Page A containing

--- a/src/Query/PrintRequest/Deserializer.php
+++ b/src/Query/PrintRequest/Deserializer.php
@@ -143,7 +143,7 @@ class Deserializer {
 		}
 
 		try {
-			$printRequest = new PrintRequest( $printmode, $label, $data, trim( $outputFormat ) );
+			$printRequest = new PrintRequest( $printmode, $label, $data, trim( $outputFormat ?? '' ) );
 			$printRequest->markThisLabel( $text );
 		} catch ( InvalidArgumentException $e ) {
 			// something still went wrong; give up

--- a/src/SQLStore/QueryEngine/QuerySegment.php
+++ b/src/SQLStore/QueryEngine/QuerySegment.php
@@ -120,6 +120,11 @@ class QuerySegment {
 	public $where = '';
 
 	/**
+	 * @var string
+	 */
+	public $sortIndexField;
+
+	/**
 	 * @var string[]
 	 */
 	public $components = [];


### PR DESCRIPTION
* setSortKey() may end up receiving nulls in some cases, so account for that to avoid warnings about nulls being passed to string functions on PHP 8.1 and newer. Do the same in Deserializer.
* Avoid using 'self' references in ApiRequestParameterFormatter callables.
* Annotate ChunkedIterator methods with #[ReturnTypeWillChange] to avoid method signature mismatch warnings until PHP 7.4 support can be dropped.
* Declare a missing property in QuerySegment.
* Account for annotation data being false (instead of null) in RecursiveTextProcessor, as array autovivification no longer works for `false` on newer PHP.