### PR TITLE
Stabilize tests on MW 1.39

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -14,6 +14,7 @@
          beStrictAboutTestsThatDoNotTestAnything="true"
          printerClass="SMW\Tests\PHPUnitResultPrinter"
          printerFile="tests/phpunit/PHPUnitResultPrinter.php"
+         stderr="true"
          verbose="true">
     <listeners>
         <listener file="tests/phpunit/ExecutionTimeTestListener.php" class="SMW\Tests\ExecutionTimeTestListener">

--- a/src/MediaWiki/Deferred/CallableUpdate.php
+++ b/src/MediaWiki/Deferred/CallableUpdate.php
@@ -7,6 +7,7 @@ use DeferrableUpdate;
 use DeferredUpdates;
 use Psr\Log\LoggerAwareTrait;
 use SMW\MediaWiki\Database;
+use Wikimedia\Assert\Assert;
 
 /**
  * @see MWCallableUpdate
@@ -223,6 +224,7 @@ class CallableUpdate implements DeferrableUpdate {
 	}
 
 	/**
+	 * Release all pending updates into MediaWiki's DeferredUpdates stack.
 	 * @since 2.4
 	 */
 	public static function releasePendingUpdates() {
@@ -230,6 +232,15 @@ class CallableUpdate implements DeferrableUpdate {
 			DeferredUpdates::addUpdate( $update );
 		}
 
+		self::$pendingUpdates = [];
+	}
+
+	/**
+	 * Clear all pending updates without executing them. Useful for tests.
+	 * @since 4.2
+	 */
+	public static function clearPendingUpdates() {
+		Assert::precondition( defined( 'MW_PHPUNIT_TEST' ), 'This method should only be called in tests' );
 		self::$pendingUpdates = [];
 	}
 

--- a/tests/phpUnitEnvironment.php
+++ b/tests/phpUnitEnvironment.php
@@ -182,26 +182,23 @@ class PHPUnitEnvironment {
 	/**
 	 * @param string $arg1
 	 * @param string|array $arg2
-	 *
-	 * @return string
 	 */
 	public function writeLn( $arg1, $arg2 ) {
-		return print sprintf( "%-{$this->firstColumnWidth}s%s\n", $arg1, $arg2 );
+		fwrite( STDERR, sprintf( "%-{$this->firstColumnWidth}s%s\n", $arg1, $arg2 ) );
 	}
 
 	/**
 	 * @param string $arg1
 	 * @param string|array $arg2
-	 *
-	 * @return string
 	 */
 	public function writeNewLn( $arg1 = '', $arg2 = '' ) {
 
 		if ( $arg1 === '' && $arg2 === '' ) {
-			return print "\n";
+			fwrite( STDERR, "\n" );
+			return;
 		}
 
-		return print sprintf( "\n%-{$this->firstColumnWidth}s%s\n", $arg1, $arg2 );
+		fwrite( STDERR, sprintf( "\n%-{$this->firstColumnWidth}s%s\n", $arg1, $arg2 ) );
 	}
 
 	private function command_exists( $command ) {

--- a/tests/phpunit/Integration/HookDispatcherTest.php
+++ b/tests/phpunit/Integration/HookDispatcherTest.php
@@ -18,6 +18,8 @@ class HookDispatcherTest extends \PHPUnit_Framework_TestCase {
 
 	private $mwHooksHandler;
 
+	private $testEnvironment;
+
 	protected function setUp() : void {
 		parent::setUp();
 
@@ -384,10 +386,7 @@ class HookDispatcherTest extends \PHPUnit_Framework_TestCase {
 			->disableOriginalConstructor()
 			->getMock();
 
-		// TODO: Illegal dynamic property (#5421)
-		$anotherFile->extraProperty = 'Foo';
-
-		$this->assertNotEquals(
+		$this->assertNotSame(
 			$anotherFile,
 			$file
 		);
@@ -398,7 +397,7 @@ class HookDispatcherTest extends \PHPUnit_Framework_TestCase {
 
 		$hookDispatcher->onChangeFile( $title, $file );
 
-		$this->assertEquals(
+		$this->assertSame(
 			$anotherFile,
 			$file
 		);
@@ -420,10 +419,7 @@ class HookDispatcherTest extends \PHPUnit_Framework_TestCase {
 			->disableOriginalConstructor()
 			->getMock();
 
-		// TODO: Illegal dynamic property (#5421)
-		$anotherRevision->extraProperty = 'Foo';
-
-		$this->assertNotEquals(
+		$this->assertNotSame(
 			$revision,
 			$anotherRevision
 		);
@@ -434,7 +430,7 @@ class HookDispatcherTest extends \PHPUnit_Framework_TestCase {
 
 		$hookDispatcher->onChangeRevision( $title, $revision );
 
-		$this->assertEquals(
+		$this->assertSame(
 			$anotherRevision,
 			$revision
 		);

--- a/tests/phpunit/Integration/InterwikiDBIntegrationTest.php
+++ b/tests/phpunit/Integration/InterwikiDBIntegrationTest.php
@@ -21,11 +21,15 @@ use Title;
  */
 class InterwikiDBIntegrationTest extends DatabaseTestCase {
 
+	private $semanticDataFactory;
 	private $stringValidator;
 	private $subjects = [];
 
 	private $pageCreator;
 	private $stringBuilder;
+
+	private $queryResultValidator;
+	private $queryParser;
 
 	protected function setUp() : void {
 		parent::setUp();
@@ -74,7 +78,6 @@ class InterwikiDBIntegrationTest extends DatabaseTestCase {
 	}
 
 	public function testRdfSerializationForInterwikiAnnotation() {
-
 		$this->stringBuilder
 			->addString( '[[Has type::Page]]' );
 
@@ -106,7 +109,6 @@ class InterwikiDBIntegrationTest extends DatabaseTestCase {
 	}
 
 	public function testQueryForInterwikiAnnotation() {
-		$this->markTestSkipped( "FIXME" );
 		$this->stringBuilder
 			->addString( '[[Has type::Page]]' );
 

--- a/tests/phpunit/Integration/Maintenance/RebuildFulltextSearchTableTest.php
+++ b/tests/phpunit/Integration/Maintenance/RebuildFulltextSearchTableTest.php
@@ -21,6 +21,7 @@ class RebuildFulltextSearchTableTest extends DatabaseTestCase {
 
 	protected $destroyDatabaseTablesAfterRun = true;
 	private $runnerFactory;
+	private $spyMessageReporter;
 
 	protected function setUp() : void {
 		parent::setUp();

--- a/tests/phpunit/Integration/MediaWiki/Hooks/ParserFirstCallInitIntegrationTest.php
+++ b/tests/phpunit/Integration/MediaWiki/Hooks/ParserFirstCallInitIntegrationTest.php
@@ -3,6 +3,7 @@
 namespace SMW\Tests\Integration\MediaWiki\Hooks;
 
 use SMW\Services\ServicesFactory;
+use SMW\Tests\DatabaseTestCase;
 use SMW\Tests\TestEnvironment;
 use Title;
 
@@ -15,20 +16,15 @@ use Title;
  *
  * @author mwjames
  */
-class ParserFirstCallInitIntegrationTest extends \PHPUnit_Framework_TestCase {
+class ParserFirstCallInitIntegrationTest extends DatabaseTestCase {
 
 	private $mwHooksHandler;
-	private $testEnvironment;
+
 	private $store;
 	private $queryResult;
 
 	protected function setUp() : void {
 		parent::setUp();
-
-		$this->testEnvironment = new TestEnvironment( [
-			'smwgMainCacheType' => CACHE_NONE
-		] );
-
 		$this->mwHooksHandler = $this->testEnvironment->getUtilityFactory()->newMwHooksHandler();
 		$this->mwHooksHandler->deregisterListedHooks();
 
@@ -67,7 +63,6 @@ class ParserFirstCallInitIntegrationTest extends \PHPUnit_Framework_TestCase {
 
 	protected function tearDown() : void {
 		$this->mwHooksHandler->restoreListedHooks();
-		$this->testEnvironment->tearDown();
 
 		parent::tearDown();
 	}
@@ -76,7 +71,6 @@ class ParserFirstCallInitIntegrationTest extends \PHPUnit_Framework_TestCase {
 	 * @dataProvider textToParseProvider
 	 */
 	public function testParseWithParserFunctionEnabled( $parserName, $text ) {
-		$this->markTestSkipped( "database connections" );
 		$singleEntityQueryLookup = $this->getMockBuilder( '\SMW\SQLStore\Lookup\SingleEntityQueryLookup' )
 			->disableOriginalConstructor()
 			->getMock();
@@ -129,7 +123,6 @@ class ParserFirstCallInitIntegrationTest extends \PHPUnit_Framework_TestCase {
 	 * @dataProvider textToParseProvider
 	 */
 	public function testParseWithParserFunctionDisabled( $parserName, $text ) {
-		$this->markTestSkipped( "database connections" );
 		$expectedNullOutputFor = [
 			'concept',
 			'declare',

--- a/tests/phpunit/Integration/MediaWiki/RedirectTargetFinderIntegrationTest.php
+++ b/tests/phpunit/Integration/MediaWiki/RedirectTargetFinderIntegrationTest.php
@@ -38,21 +38,22 @@ class RedirectTargetFinderIntegrationTest extends DatabaseTestCase {
 			false
 		);
 
-		$this->pageCreator = UtilityFactory::getInstance()->newPageCreator();
-		$this->semanticDataValidator = UtilityFactory::getInstance()->newValidatorFactory()->newSemanticDataValidator();
+		$utilityFactory = UtilityFactory::getInstance();
 
-		// #3414
-		// NameTableAccessException: Expected unused ID from database insert for
-		// 'mw-changed-redirect-target'  into 'change_tag_def',
-		$this->testEnvironment->resetMediaWikiService( 'NameTableStoreFactory' );
+		$this->pageCreator = $utilityFactory->newPageCreator();
+		$this->semanticDataValidator = $utilityFactory->newValidatorFactory()->newSemanticDataValidator();
+
+		$utilityFactory->newMwHooksHandler()->invokeHooksFromRegistry();
 	}
 
 	protected function tearDown() : void {
-
-		$pageDeleter = UtilityFactory::getInstance()->newPageDeleter();
+		$utilityFactory = UtilityFactory::getInstance();
+		$pageDeleter = $utilityFactory->newPageDeleter();
 
 		$pageDeleter
 			->doDeletePoolOfPages( $this->deletePoolOfPages );
+
+		$utilityFactory->newMwHooksHandler()->restoreListedHooks();
 
 		parent::tearDown();
 	}

--- a/tests/phpunit/Integration/MediaWiki/SearchInPageDBIntegrationTest.php
+++ b/tests/phpunit/Integration/MediaWiki/SearchInPageDBIntegrationTest.php
@@ -7,6 +7,7 @@ use SMW\MediaWiki\Search\ExtendedSearchEngine;
 use SMW\Tests\DatabaseTestCase;
 use SMW\Tests\Utils\PageCreator;
 use SMW\Tests\Utils\PageDeleter;
+use SMW\Tests\Utils\UtilityFactory;
 use Title;
 
 /**
@@ -24,6 +25,13 @@ use Title;
  * @author mwjames
  */
 class SearchInPageDBIntegrationTest extends DatabaseTestCase {
+
+	protected function setUp(): void {
+		parent::setUp();
+
+		$mwHooksHandler = UtilityFactory::getInstance()->newMwHooksHandler();
+		$mwHooksHandler->invokeHooksFromRegistry();
+	}
 
 	public function testSearchForPageValueAsTerm() {
 

--- a/tests/phpunit/Integration/Query/ConjunctionQueryDBIntegrationTest.php
+++ b/tests/phpunit/Integration/Query/ConjunctionQueryDBIntegrationTest.php
@@ -33,6 +33,7 @@ class ConjunctionQueryDBIntegrationTest extends DatabaseTestCase {
 	private $subjectsToBeCleared = [];
 	private $semanticDataFactory;
 	private $queryResultValidator;
+	private $fixturesProvider;
 	private $queryParser;
 
 	protected function setUp() : void {
@@ -51,6 +52,8 @@ class ConjunctionQueryDBIntegrationTest extends DatabaseTestCase {
 		$this->fixturesProvider->setupDependencies( $this->getStore() );
 
 		$this->queryParser = ApplicationFactory::getInstance()->getQueryFactory()->newQueryParser();
+
+		$utilityFactory->newMwHooksHandler()->invokeHooksFromRegistry();
 	}
 
 	protected function tearDown() : void {

--- a/tests/phpunit/Integration/Query/DatePropertyValueQueryDBIntegrationTest.php
+++ b/tests/phpunit/Integration/Query/DatePropertyValueQueryDBIntegrationTest.php
@@ -35,16 +35,20 @@ class DatePropertyValueQueryDBIntegrationTest extends DatabaseTestCase {
 	private $semanticDataFactory;
 	private $dataValueFactory;
 	private $queryResultValidator;
+	private $fixturesProvider;
 
 	protected function setUp() : void {
 		parent::setUp();
 
 		$this->dataValueFactory = DataValueFactory::getInstance();
 
-		$this->semanticDataFactory = UtilityFactory::getInstance()->newSemanticDataFactory();
-		$this->queryResultValidator = UtilityFactory::getInstance()->newValidatorFactory()->newQueryResultValidator();
+		$utilityFactory = UtilityFactory::getInstance();
+		$utilityFactory->newMwHooksHandler()->invokeHooksFromRegistry();
 
-		$this->fixturesProvider = UtilityFactory::getInstance()->newFixturesFactory()->newFixturesProvider();
+		$this->semanticDataFactory = $utilityFactory->newSemanticDataFactory();
+		$this->queryResultValidator = $utilityFactory->newValidatorFactory()->newQueryResultValidator();
+
+		$this->fixturesProvider = $utilityFactory->newFixturesFactory()->newFixturesProvider();
 		$this->fixturesProvider->setupDependencies( $this->getStore() );
 	}
 

--- a/tests/phpunit/Integration/Query/GeneralQueryDBIntegrationTest.php
+++ b/tests/phpunit/Integration/Query/GeneralQueryDBIntegrationTest.php
@@ -30,10 +30,10 @@ use SMWQuery as Query;
 class GeneralQueryDBIntegrationTest extends DatabaseTestCase {
 
 	private $subjectsToBeCleared = [];
-	private $subject;
 
 	private $dataValueFactory;
 	private $queryResultValidator;
+	private $semanticDataFactory;
 
 	protected function setUp() : void {
 		parent::setUp();

--- a/tests/phpunit/Integration/Query/NamespaceQueryDBIntegrationTest.php
+++ b/tests/phpunit/Integration/Query/NamespaceQueryDBIntegrationTest.php
@@ -36,10 +36,13 @@ class NamespaceQueryDBIntegrationTest extends DatabaseTestCase {
 	protected function setUp() : void {
 		parent::setUp();
 
-		$this->semanticDataFactory  = UtilityFactory::getInstance()->newSemanticDataFactory();
-		$this->queryResultValidator = UtilityFactory::getInstance()->newValidatorFactory()->newQueryResultValidator();
+		$utilityFactory = UtilityFactory::getInstance();
+		$utilityFactory->newMwHooksHandler()->invokeHooksFromRegistry();
 
-		$this->fixturesProvider = UtilityFactory::getInstance()->newFixturesFactory()->newFixturesProvider();
+		$this->semanticDataFactory  = $utilityFactory->newSemanticDataFactory();
+		$this->queryResultValidator = $utilityFactory->newValidatorFactory()->newQueryResultValidator();
+
+		$this->fixturesProvider = $utilityFactory->newFixturesFactory()->newFixturesProvider();
 		$this->fixturesProvider->setupDependencies( $this->getStore() );
 	}
 

--- a/tests/phpunit/Integration/Query/RandomQueryResultOrderIntegrationTest.php
+++ b/tests/phpunit/Integration/Query/RandomQueryResultOrderIntegrationTest.php
@@ -27,7 +27,10 @@ class RandomQueryResultOrderIntegrationTest extends DatabaseTestCase {
 	protected function setUp() : void {
 		parent::setUp();
 
-		$this->fixturesProvider = UtilityFactory::getInstance()->newFixturesFactory()->newFixturesProvider();
+		$utilityFactory = UtilityFactory::getInstance();
+		$utilityFactory->newMwHooksHandler()->invokeHooksFromRegistry();
+
+		$this->fixturesProvider = $utilityFactory->newFixturesFactory()->newFixturesProvider();
 		$this->fixturesProvider->setupDependencies( $this->getStore() );
 	}
 

--- a/tests/phpunit/Integration/Query/SemanticDataLookupTest.php
+++ b/tests/phpunit/Integration/Query/SemanticDataLookupTest.php
@@ -23,9 +23,9 @@ use SMW\Tests\DatabaseTestCase;
 class SemanticDataLookupTest extends DatabaseTestCase {
 
 	private $subjectsToBeCleared = [];
-	private $subject;
+
 	private $dataValueFactory;
-	private $queryResultValidator;
+	private $semanticDataFactory;
 
 	protected function setUp() : void {
 		parent::setUp();

--- a/tests/phpunit/Integration/RdfFileResourceTest.php
+++ b/tests/phpunit/Integration/RdfFileResourceTest.php
@@ -30,6 +30,7 @@ class RdfFileResourceTest extends DatabaseTestCase {
 		}
 
 		$utilityFactory = $this->testEnvironment->getUtilityFactory();
+		$utilityFactory->newMwHooksHandler()->invokeHooksFromRegistry();
 
 		$this->fixturesFileProvider = $utilityFactory->newFixturesFactory()->newFixturesFileProvider();
 		$this->stringValidator = $utilityFactory->newValidatorFactory()->newStringValidator();

--- a/tests/phpunit/Integration/SQLStore/Lookup/ByGroupPropertyValuesLookupIntegrationTest.php
+++ b/tests/phpunit/Integration/SQLStore/Lookup/ByGroupPropertyValuesLookupIntegrationTest.php
@@ -19,6 +19,8 @@ use SMW\DIWikiPage;
 class ByGroupPropertyValuesLookupIntegrationTest extends DatabaseTestCase {
 
 	private $semanticDataFactory;
+	private $mwHooksHandler;
+
 	private $subjects = [];
 
 	protected function setUp() : void {

--- a/tests/phpunit/Integration/SQLStore/TableBuilder/TableBuilderIntegrationTest.php
+++ b/tests/phpunit/Integration/SQLStore/TableBuilder/TableBuilderIntegrationTest.php
@@ -22,7 +22,7 @@ use SMW\Tests\DatabaseTestCase;
 class TableBuilderIntegrationTest extends DatabaseTestCase {
 
 	private $messageReporterFactory;
-	private $TableBuilder;
+	private $tableBuilder;
 	private $stringValidator;
 	private $tableName = 'rdbms_test';
 

--- a/tests/phpunit/Integration/SemanticDataCountMapIntegrationTest.php
+++ b/tests/phpunit/Integration/SemanticDataCountMapIntegrationTest.php
@@ -19,6 +19,7 @@ use SMW\DIWikiPage;
 class SemanticDataCountMapIntegrationTest extends DatabaseTestCase {
 
 	private $semanticDataFactory;
+	private $mwHooksHandler;
 	private $subjects = [];
 
 	protected function setUp() : void {

--- a/tests/phpunit/Integration/SemanticDataSortKeyUpdateDBIntegrationTest.php
+++ b/tests/phpunit/Integration/SemanticDataSortKeyUpdateDBIntegrationTest.php
@@ -25,6 +25,7 @@ use Title;
 class SemanticDataSortKeyUpdateDBIntegrationTest extends DatabaseTestCase {
 
 	private $semanticDataFactory;
+	private $mwHooksHandler;
 	private $subjects = [];
 
 	protected function setUp() : void {

--- a/tests/phpunit/Integration/SemanticMediaWikiProvidedHookInterfaceIntegrationTest.php
+++ b/tests/phpunit/Integration/SemanticMediaWikiProvidedHookInterfaceIntegrationTest.php
@@ -17,6 +17,7 @@ use SMW\Tests\TestEnvironment;
  */
 class SemanticMediaWikiProvidedHookInterfaceIntegrationTest extends \PHPUnit_Framework_TestCase {
 
+	private $testEnvironment;
 	private $mwHooksHandler;
 	private $applicationFactory;
 	private $spyLogger;
@@ -356,15 +357,14 @@ class SemanticMediaWikiProvidedHookInterfaceIntegrationTest extends \PHPUnit_Fra
 
 		$null = 0;
 
-		$this->mwHooksHandler->register( 'SMW::SQLStore::BeforeChangeTitleComplete', function( $store, $oldTitle, $newTitle, $pageId, $redirectId ) {
-			return $store->reachedTheBeforeChangeTitleCompleteHook = true;
+		$reachedTheBeforeChangeTitleCompleteHook = false;
+		$this->mwHooksHandler->register( 'SMW::SQLStore::BeforeChangeTitleComplete', function() use ( &$reachedTheBeforeChangeTitleCompleteHook ) {
+			$reachedTheBeforeChangeTitleCompleteHook = true;
 		} );
 
 		$store->changeTitle( $title, $title, $null, $null );
 
-		$this->assertTrue(
-			$store->reachedTheBeforeChangeTitleCompleteHook
-		);
+		$this->assertTrue( $reachedTheBeforeChangeTitleCompleteHook );
 	}
 
 	public function testRegisteredSQLStoreBeforeDeleteSubjectComplete() {
@@ -394,14 +394,15 @@ class SemanticMediaWikiProvidedHookInterfaceIntegrationTest extends \PHPUnit_Fra
 			->method( 'getPropertyTables' )
 			->will( $this->returnValue( [] ) );
 
-		$this->mwHooksHandler->register( 'SMW::SQLStore::BeforeDeleteSubjectComplete', function( $store, $title ) {
-			return $store->reachedTheBeforeDeleteSubjectCompleteHook = true;
+		$reachedTheBeforeDeleteSubjectCompleteHook = false;
+		$this->mwHooksHandler->register( 'SMW::SQLStore::BeforeDeleteSubjectComplete', function() use ( &$reachedTheBeforeDeleteSubjectCompleteHook) {
+			$reachedTheBeforeDeleteSubjectCompleteHook = true;
 		} );
 
 		$store->deleteSubject( $title );
 
 		$this->assertTrue(
-			$store->reachedTheBeforeDeleteSubjectCompleteHook
+			$reachedTheBeforeDeleteSubjectCompleteHook
 		);
 	}
 
@@ -432,15 +433,14 @@ class SemanticMediaWikiProvidedHookInterfaceIntegrationTest extends \PHPUnit_Fra
 			->method( 'getPropertyTables' )
 			->will( $this->returnValue( [] ) );
 
-		$this->mwHooksHandler->register( 'SMW::SQLStore::AfterDeleteSubjectComplete', function( $store, $title ) {
-			return $store->reachedTheAfterDeleteSubjectCompleteHook = true;
+		$reachedTheAfterDeleteSubjectCompleteHook = false;
+		$this->mwHooksHandler->register( 'SMW::SQLStore::AfterDeleteSubjectComplete', function() use ( &$reachedTheAfterDeleteSubjectCompleteHook ) {
+			$reachedTheAfterDeleteSubjectCompleteHook = true;
 		} );
 
 		$store->deleteSubject( $title );
 
-		$this->assertTrue(
-			$store->reachedTheAfterDeleteSubjectCompleteHook
-		);
+		$this->assertTrue( $reachedTheAfterDeleteSubjectCompleteHook );
 	}
 
 	public function testRegisteredParserBeforeMagicWordsFinder() {

--- a/tests/phpunit/JSONScriptServicesTestCaseRunner.php
+++ b/tests/phpunit/JSONScriptServicesTestCaseRunner.php
@@ -67,24 +67,6 @@ abstract class JSONScriptServicesTestCaseRunner extends JSONScriptTestCaseRunner
 		$this->validatorFactory = $utilityFactory->newValidatorFactory();
 		$this->apiFactory = $utilityFactory->newMwApiFactory();
 
-		// This ensures that if content is created in the NS_MEDIAWIKI namespace
-		// and an object relies on the MediaWikiNsContentReader then it uses the DB
-		ApplicationFactory::clear();
-		ApplicationFactory::getInstance()->getMediaWikiNsContentReader()->skipMessageCache();
-		DataValueFactory::getInstance()->clear();
-
-		// Reset the Title/TitleParser otherwise a singleton instance holds an outdated
-		// content language reference
-		$this->testEnvironment->resetMediaWikiService( '_MediaWikiTitleCodec' );
-		$this->testEnvironment->resetMediaWikiService( 'TitleParser' );
-
-		// #3414
-		// NameTableAccessException: Expected unused ID from database insert for
-		// 'mw-changed-redirect-target'  into 'change_tag_def',
-		$this->testEnvironment->resetMediaWikiService( 'NameTableStoreFactory' );
-
-		$this->testEnvironment->resetMediaWikiService( 'NamespaceInfo' );
-
 		$this->testEnvironment->resetPoolCacheById( TurtleTriplesBuilder::POOLCACHE_ID );
 
 		// Make sure LocalSettings don't interfere with the default settings
@@ -264,6 +246,12 @@ abstract class JSONScriptServicesTestCaseRunner extends JSONScriptTestCaseRunner
 				$jsonTestCaseFileHandler->getSettingsFor( $key, $this->getConfigValueCallback( $key ) )
 			);
 		}
+
+		// This ensures that if content is created in the NS_MEDIAWIKI namespace
+		// and an object relies on the MediaWikiNsContentReader then it uses the DB
+		ApplicationFactory::clear();
+		ApplicationFactory::getInstance()->getMediaWikiNsContentReader()->skipMessageCache();
+		DataValueFactory::getInstance()->clear();
 
 		if ( $jsonTestCaseFileHandler->hasSetting( 'smwgFieldTypeFeatures' ) ) {
 			$this->doRunTableSetupBeforeContentCreation();

--- a/tests/phpunit/JSONScriptTestCaseRunner.php
+++ b/tests/phpunit/JSONScriptTestCaseRunner.php
@@ -3,10 +3,10 @@
 namespace SMW\Tests;
 
 use MediaWiki\MediaWikiServices;
+use SMW\Localizer\Localizer;
 use SMW\Tests\Utils\JSONScript\JsonTestCaseContentHandler;
 use SMW\Tests\Utils\JSONScript\JsonTestCaseFileHandler;
 use SMW\Tests\Utils\UtilityFactory;
-use Title;
 
 /**
  * The `JSONScriptTestCaseRunner` is a convenience provider for `Json` formatted
@@ -31,11 +31,6 @@ abstract class JSONScriptTestCaseRunner extends DatabaseTestCase {
 	 * @var FileReader
 	 */
 	private $fileReader;
-
-	/**
-	 * @var JsonTestCaseFileHandler
-	 */
-	private $jsonTestCaseFileHandler;
 
 	/**
 	 * @var JsonTestCaseContentHandler
@@ -156,7 +151,7 @@ abstract class JSONScriptTestCaseRunner extends DatabaseTestCase {
 		// and dependent objects are reset
 		$this->registerConfigValueCallback( 'wgContLang', function( $val ) {
 			\RequestContext::getMain()->setLanguage( $val );
-			\SMW\Localizer::getInstance()->clear();
+			Localizer::clear();
 			// #4682, Avoid any surprises when the `wgLanguageCode` is changed during a test
 			\SMW\NamespaceManager::clear();
 			$languageFactory = MediaWikiServices::getInstance()->getLanguageFactory();
@@ -172,7 +167,7 @@ abstract class JSONScriptTestCaseRunner extends DatabaseTestCase {
 
 		$this->registerConfigValueCallback( 'wgLang', function( $val ) {
 			\RequestContext::getMain()->setLanguage( $val );
-			\SMW\Localizer::getInstance()->clear();
+			Localizer::clear();
 			\SMW\NamespaceManager::clear();
 			$languageFactory = MediaWikiServices::getInstance()->getLanguageFactory();
 			$lang = $languageFactory->getLanguage( $val );

--- a/tests/phpunit/PHPUnitResultPrinter.php
+++ b/tests/phpunit/PHPUnitResultPrinter.php
@@ -13,11 +13,11 @@ class PHPUnitResultPrinter extends PHPUnit_TextUI_ResultPrinter {
 	public function endTestSuite( PHPUnit_Framework_TestSuite $suite ): void {
 		parent::endTestSuite( $suite );
 
-		if ( !isset( $suite->_slowTestsReport ) ) {
+		$slowTestsReport = ExecutionTimeTestListener::getSlowTestsReport( $suite );
+		if ( $slowTestsReport === null ) {
 			return;
 		}
 
-		$slowTestsReport = $suite->_slowTestsReport;
 		$i = 0;
 
 		$this->write( "\n\n" );

--- a/tests/phpunit/TestEnvironment.php
+++ b/tests/phpunit/TestEnvironment.php
@@ -2,6 +2,7 @@
 
 namespace SMW\Tests;
 
+use DeferredUpdates;
 use SMW\Services\ServicesFactory as ApplicationFactory;
 use SMW\DataValueFactory;
 use SMW\Localizer;
@@ -56,7 +57,7 @@ class TestEnvironment {
 	 * @since 2.4
 	 */
 	public static function clearPendingDeferredUpdates() {
-		CallableUpdate::releasePendingUpdates();
+		CallableUpdate::clearPendingUpdates();
 		\DeferredUpdates::clearPendingUpdates();
 	}
 

--- a/tests/phpunit/Utils/PageCreator.php
+++ b/tests/phpunit/Utils/PageCreator.php
@@ -13,6 +13,7 @@ use Title;
 use UnexpectedValueException;
 use SMW\MediaWiki\EditInfo;
 use SMW\Services\ServicesFactory;
+use User;
 
 /**
  * @license GNU GPL v2+
@@ -63,7 +64,9 @@ class PageCreator {
 	public function createPage( Title $title, $editContent = '', $pageContentLanguage = '' ) {
 
 		if ( $pageContentLanguage !== '' ) {
-			MediaWikiServices::getInstance()->getHookContainer()->register( 'PageContentLanguage', function( $titleByHook, &$pageLang ) use( $title, $pageContentLanguage ) {
+			$services = MediaWikiServices::getInstance();
+			$pageContentLanguage = $services->getLanguageFactory()->getLanguage( $pageContentLanguage );
+			$services->getHookContainer()->register( 'PageContentLanguage', function( $titleByHook, &$pageLang ) use( $title, $pageContentLanguage ) {
 
 				// Only change the pageContentLanguage for the selected page
 				if ( $title->getPrefixedDBKey() === $titleByHook->getPrefixedDBKey() ) {
@@ -130,8 +133,9 @@ class PageCreator {
 		$reason = "integration test";
 		$source = $this->getPage()->getTitle();
 
+		$user = User::newSystemUser( 'Maintenance script', [ 'steal' => true ] );
 		$mp = MediaWikiServices::getInstance()->getMovePageFactory()->newMovePage( $source, $target );
-		$status = $mp->move( new MockSuperUser(), $reason, $isRedirect );
+		$status = $mp->move( $user, $reason, $isRedirect );
 
 		TestEnvironment::executePendingDeferredUpdates();
 

--- a/tests/phpunit/Utils/PageDeleter.php
+++ b/tests/phpunit/Utils/PageDeleter.php
@@ -6,6 +6,7 @@ use SMW\DIWikiPage;
 use SMW\Tests\TestEnvironment;
 use SMW\Tests\Utils\Mock\MockSuperUser;
 use Title;
+use User;
 use WikiPage;
 
 /**
@@ -36,7 +37,8 @@ class PageDeleter {
 		$page = new WikiPage( $title );
 
 		try {
-			$page->doDeleteArticleReal( 'SMW system test: delete page', new MockSuperUser() );
+			$user = User::newSystemUser( 'Maintenance script', [ 'steal' => true ] );
+			$page->doDeleteArticleReal( 'SMW system test: delete page', $user );
 		} catch( \Exception $e ) {
 			//
 		}

--- a/tests/phpunit/includes/DataValues/RecordValueTest.php
+++ b/tests/phpunit/includes/DataValues/RecordValueTest.php
@@ -23,6 +23,8 @@ class RecordValueTest extends \PHPUnit_Framework_TestCase {
 	private $testEnvironment;
 	private $dataItemFactory;
 
+	private $propertySpecificationLookup;
+
 	protected function setUp() : void {
 		parent::setUp();
 

--- a/tests/phpunit/includes/DataValues/WikiPageValueTest.php
+++ b/tests/phpunit/includes/DataValues/WikiPageValueTest.php
@@ -20,6 +20,8 @@ class WikiPageValueTest extends \PHPUnit_Framework_TestCase {
 	private $testEnvironment;
 	private $dataItemFactory;
 
+	private $propertySpecificationLookup;
+
 	protected function setUp() : void {
 		parent::setUp();
 

--- a/tests/phpunit/includes/SubobjectTest.php
+++ b/tests/phpunit/includes/SubobjectTest.php
@@ -23,6 +23,8 @@ class SubobjectTest extends \PHPUnit_Framework_TestCase {
 
 	use PHPUnitCompat;
 
+	private $testEnvironment;
+
 	private $semanticDataValidator;
 
 	protected function setUp() : void {


### PR DESCRIPTION
Most of the error spam in the 1.39 test run is ultimately due to services not being reset between tests, which (a) can cause errors in itself due to stale data as seen in #5199 and co. and (b) can cause resulting error states to propagate to other tests. Previous attempts at fixing this took the approach of selectively resetting services that were found to be problematic, such as ActorStore. However, this is not in itself sufficient: not only is the task of identifying services not safe for reuse between tests quite Sisyphean, resetting them won't reset services or static singletons that injected them as a dependency.

So, reset MW services, SMW services and assorted static singletons before each integration test. This conveniently allows for reenabling several tests that had been previously disabled due to running into exactly the kind of problems described above. Since resetting the MW service container also resets hook handlers, add appropriate hook registration logic to tests that previously implicitly relied on hook registrations "leaking" over from another test (mostly Query-related ones). As we're here, declare a bunch of missing properties in test classes that pollute the output on PHP > 8.2.

On MW 1.39 (and possibly older), the test output appears to be buffered by default, which is inconvenient because one cannot see the progress until the whole suite has concluded. Set stderr="true" in the config to rectify that (matching what core tests already do), and update the environment reporter to write to stderr as well.

This change does not yet make the suite green on MW 1.39 - there are various failures that need to be investigated. However, it should fix most issues that are purely test setup-related.