### PR TITLE
Fix DISPLAYTITLE sort behavior on MW 1.38+

### DIFF
--- a/src/MediaWiki/Hooks/ParserAfterTidy.php
+++ b/src/MediaWiki/Hooks/ParserAfterTidy.php
@@ -248,7 +248,7 @@ class ParserAfterTidy implements HookListener {
 		if ( method_exists( $parserOutput, 'getPageProperty') ) {
 			// T301915
 			$displayTitle = $parserOutput->getPageProperty( 'displaytitle' ) ?? false;
-			$parserDefaultSort = $parserOutput->getPageProperty( 'defaultsort' );
+			$parserDefaultSort = $parserOutput->getPageProperty( 'defaultsort' ) ?? '';
 		} else {
 			// MW < 1.38
 			$displayTitle = $parserOutput->getProperty( 'displaytitle' );


### PR DESCRIPTION
Parser::getDefaultSort would fall back to an empty string if no defaultsort was provided, but in newer MW we have to use a page property with a null default value to obtain the defaultsort value. DisplayTitlePropertyAnnotator however expects an empty string for the "no defaultsort" case.

The expectation here is that this should make p-0416.json pass on MW 1.38 and newer.

Closes #5585