### PR TITLE
Use User::isRegistered over User::isLoggedIn

### DIFF
--- a/src/MediaWiki/Search/ProfileForm/Forms/NamespaceForm.php
+++ b/src/MediaWiki/Search/ProfileForm/Forms/NamespaceForm.php
@@ -116,7 +116,7 @@ class NamespaceForm {
 
 		$user = $specialSearch->getUser();
 
-		if ( !$user->isLoggedIn() ) {
+		if ( !$user->isRegistered() ) {
 			return;
 		}
 

--- a/tests/phpunit/MediaWiki/Search/ProfileForm/Forms/NamespaceFormTest.php
+++ b/tests/phpunit/MediaWiki/Search/ProfileForm/Forms/NamespaceFormTest.php
@@ -74,7 +74,7 @@ class NamespaceFormTest extends \PHPUnit_Framework_TestCase {
 			->method( 'getEditToken' );
 
 		$user->expects( $this->any() )
-			->method( 'isLoggedIn' )
+			->method( 'isRegistered' )
 			->will( $this->returnValue( true ) );
 
 		$specialSearch = $this->getMockBuilder( '\SpecialSearch' )


### PR DESCRIPTION
This should get tests passing on 1.38 and 1.39. User::isRegistered is available since MW 1.34, so it should work on all supported MW versions.

Closes #5538