### PR TITLE
Fix P0110 on PHP 8.1 and newer

### DIFF
--- a/includes/Highlighter.php
+++ b/includes/Highlighter.php
@@ -382,7 +382,11 @@ class Highlighter {
 			$content = Message::get( [ 'smw-parse', $content ], Message::PARSE, $language );
 		}
 
-		return strip_tags( htmlspecialchars_decode( str_replace( [ "[", '&#160;', "&#10;", "\n" ], [ "&#91;", ' ', '', '' ], $content ) ) );
+		return strip_tags(
+			htmlspecialchars_decode(
+				str_replace( [ "[", '&#160;', "&#10;", "\n", "&#39;", "'" ], [ "&#91;", ' ', '', '', '' ], $content ),
+			)
+		);
 	}
 
 }


### PR DESCRIPTION
On PHP 8.1 and newer, the default flags of htmlspecialchars() and related functions were changed so that they no longer leave single quotes alone, causing escaped single quotes to show up in the title attribute of the error tested by P0110. The single quotes are not very useful in a title attribute context, so remove them instead.