### PR TITLE
Task: Fix missing RequestContext import

### DIFF
--- a/src/MediaWiki/Api/Task.php
+++ b/src/MediaWiki/Api/Task.php
@@ -3,6 +3,7 @@
 namespace SMW\MediaWiki\Api;
 
 use ApiBase;
+use RequestContext;
 
 /**
  * Module to support various tasks initiate using the API interface


### PR DESCRIPTION
Now that the unit tests are running again, they are failing as #5564 was missing an use statement.