### PR TITLE
Use read connection in makeList method

### DIFF
--- a/src/MediaWiki/Connection/Database.php
+++ b/src/MediaWiki/Connection/Database.php
@@ -601,7 +601,7 @@ class Database {
 	 * @since 1.9
 	 */
 	public function makeList( $data, $mode = self::LIST_COMMA ) {
-		return $this->connRef->getConnection( 'write' )->makeList( $data, $mode );
+		return $this->connRef->getConnection( 'read' )->makeList( $data, $mode );
 	}
 
 	/**


### PR DESCRIPTION
Currently, because makeList is using the `write` connection its causing transaction-profiler warnings. There shouldn't be any difference between write/read connection as this method doesn't do any actual actions in the database.