### PR TITLE
Use readQuery method in PropertySubjectsLookup

### DIFF
--- a/src/SQLStore/EntityStore/PropertySubjectsLookup.php
+++ b/src/SQLStore/EntityStore/PropertySubjectsLookup.php
@@ -327,7 +327,7 @@ class PropertySubjectsLookup {
 			$caller .= " (for " . $requestOptions->getCaller() . ")";
 		}
 
-		$res = $connection->query(
+		$res = $connection->readQuery(
 			$query,
 			$caller
 		);

--- a/tests/phpunit/SQLStore/EntityStore/PropertySubjectsLookupTest.php
+++ b/tests/phpunit/SQLStore/EntityStore/PropertySubjectsLookupTest.php
@@ -63,7 +63,7 @@ class PropertySubjectsLookupTest extends \PHPUnit_Framework_TestCase {
 			->will( $this->returnValue( $query ) );
 
 		$connection->expects( $this->atLeastOnce() )
-			->method( 'query' )
+			->method( 'readQuery' )
 			->will( $this->returnValue( [] ) );
 
 		$store = $this->getMockBuilder( '\SMW\SQLStore\SQLStore' )
@@ -129,7 +129,7 @@ class PropertySubjectsLookupTest extends \PHPUnit_Framework_TestCase {
 			->will( $this->returnValue( $query ) );
 
 		$connection->expects( $this->atLeastOnce() )
-			->method( 'query' )
+			->method( 'readQuery' )
 			->will( $this->returnValue( $resultWrapper ) );
 
 		$store = $this->getMockBuilder( '\SMW\SQLStore\SQLStore' )


### PR DESCRIPTION
PropertySubjectsLookup doesn't make any writes, so instead of using "write" connection it should query it through "read". This doesn't appear in the transaction-profiler as "query" method is silenced.

**NOTE**
I couldn't find any obvious "read for update" cases, but if there is one we probably could switch from "readQuery" to "query" depending on the context eg. requests is POST