### PR TITLE
Use RIGOR_QUICK for ProtectionValidator checks

### DIFF
--- a/src/MediaWiki/PermissionManager.php
+++ b/src/MediaWiki/PermissionManager.php
@@ -35,15 +35,21 @@ class PermissionManager {
 	 * @param string $action
 	 * @param User|null $user
 	 * @param Title $title
+	 * @param string $rigor One of the PermissionManager::RIGOR_* constants
 	 *
 	 * @return bool
 	 */
-	public function userCan( string $action, User $user = null, Title $title ) : bool {
+	public function userCan(
+		string $action,
+		?User $user,
+		Title $title,
+		string $rigor = MwPermissionManager::RIGOR_SECURE
+	) : bool {
 		if ( !$user instanceof User ) {
-			$user = RequestContext::getMain()->getUser();			
+			$user = RequestContext::getMain()->getUser();
 		}
 
-		return $this->permissionManager->userCan( $action, $user, $title );
+		return $this->permissionManager->userCan( $action, $user, $title, $rigor );
 	}
 
 	/**

--- a/src/Protection/ProtectionValidator.php
+++ b/src/Protection/ProtectionValidator.php
@@ -2,16 +2,15 @@
 
 namespace SMW\Protection;
 
-use Onoi\Cache\Cache;
+use MediaWiki\Permissions\PermissionManager as MwPermissionManager;
 use SMW\DIProperty;
 use SMW\DIWikiPage;
-use SMW\RequestOptions;
-use SMW\Store;
 use SMW\EntityCache;
-use SMW\MediaWiki\PermissionManager;
 use SMW\Listener\ChangeListener\ChangeListeners\PropertyChangeListener;
 use SMW\Listener\ChangeListener\ChangeRecord;
+use SMW\MediaWiki\PermissionManager;
 use SMW\Services\ServicesFactory;
+use SMW\Store;
 use Title;
 use User;
 
@@ -294,7 +293,9 @@ class ProtectionValidator {
 			return false;
 		}
 
-		return $this->createProtectionRight && !$this->permissionManager->userCan( 'edit', null, $title );
+		$rigor = MwPermissionManager::RIGOR_QUICK;
+		return $this->createProtectionRight &&
+			!$this->permissionManager->userCan( 'edit', null, $title, $rigor );
 	}
 
 	/**
@@ -319,7 +320,9 @@ class ProtectionValidator {
 			$title
 		);
 
-		return !$this->permissionManager->userCan( 'edit', null, $title ) && $this->checkProtection( $subject->asBase() );
+		$rigor = MwPermissionManager::RIGOR_QUICK;
+		return !$this->permissionManager->userCan( 'edit', null, $title, $rigor )
+			&& $this->checkProtection( $subject->asBase() );
 	}
 
 	private function checkProtection( $subject, $property = null ) {


### PR DESCRIPTION
The main purpose of this check is to check whether an user is blocked from creating or editing a page by page protection settings. Since this only hinges on the presence of said protection settings and the user's set of rights, and this check is meant to control the rendering of UI elements on read requests, RIGOR_QUICK is more appropriate for this than RIGOR_SECURE which would trigger a primary database connection.