### PR TITLE
Imported from property

### DIFF
--- a/src/DataValues/ImportValue.php
+++ b/src/DataValues/ImportValue.php
@@ -73,9 +73,8 @@ class ImportValue extends DataValue {
 	 * @var string
 	 */
 	private $declarativeName = '';
-	
-	/** @var array */
-	private $declarativeNames = [];
+
+	private array $declarativeNames = [];
 
 	private MediaWikiNsContentReader $mediaWikiNsContentReader;
 

--- a/src/DataValues/ImportValue.php
+++ b/src/DataValues/ImportValue.php
@@ -6,8 +6,8 @@ use SMW\Message;
 use SMWDataItem as DataItem;
 use SMWDataValue as DataValue;
 use SMWDIBlob as DIBlob;
-use SMW\MediaWiki\MediaWikiNsContentReader as MediaWikiNsContentReader;
-use SMW\Services\ServicesFactory as ApplicationFactory;
+use SMW\MediaWiki\MediaWikiNsContentReader;
+use SMW\Services\ServicesFactory;
 
 /**
  * This datavalue implements datavalues used by special property '_IMPO' used
@@ -83,7 +83,7 @@ class ImportValue extends DataValue {
 	 */
 	public function __construct( $typeid = self::TYPE_ID ) {
 		parent::__construct( $typeid );
-		$this->mediaWikiNsContentReader = ApplicationFactory::getInstance()->getMediaWikiNsContentReader();
+		$this->mediaWikiNsContentReader = ServicesFactory::getInstance()->getMediaWikiNsContentReader();
 	}
 
 	/**

--- a/src/DataValues/ImportValue.php
+++ b/src/DataValues/ImportValue.php
@@ -6,6 +6,7 @@ use SMW\Message;
 use SMWDataItem as DataItem;
 use SMWDataValue as DataValue;
 use SMWDIBlob as DIBlob;
+use SMW\MediaWiki\MediaWikiNsContentReader as MediaWikiNsContentReader;
 use SMW\Services\ServicesFactory as ApplicationFactory;
 
 /**
@@ -76,8 +77,7 @@ class ImportValue extends DataValue {
 	/** @var array */
 	private $declarativeNames = [];
 
-	/** @var mediaWikiNsContentReader */
-	private $mediaWikiNsContentReader;
+	private MediaWikiNsContentReader $mediaWikiNsContentReader;
 
 	/**
 	 * @param string $typeid
@@ -158,11 +158,7 @@ class ImportValue extends DataValue {
 		return true;
 	}
 
-	/**
-	 * @param string $namespace
-	 * @return string
-	 */
-	private function getDeclarativeName( $namespace ) {
+	private function getDeclarativeName( string $namespace ) : string {
 		if ( array_key_exists( $namespace, $this->declarativeNames ) ) {
 			return $this->declarativeNames[$namespace];
 		}

--- a/src/DataValues/ImportValue.php
+++ b/src/DataValues/ImportValue.php
@@ -6,6 +6,7 @@ use SMW\Message;
 use SMWDataItem as DataItem;
 use SMWDataValue as DataValue;
 use SMWDIBlob as DIBlob;
+use SMW\Services\ServicesFactory as ApplicationFactory;
 
 /**
  * This datavalue implements datavalues used by special property '_IMPO' used
@@ -16,6 +17,7 @@ use SMWDIBlob as DIBlob;
  *
  * @author Fabian Howahl
  * @author Markus Krötzsch
+ * @reviewer thomas-topway-it for KM-A
  */
 class ImportValue extends DataValue {
 
@@ -70,12 +72,19 @@ class ImportValue extends DataValue {
 	 * @var string
 	 */
 	private $declarativeName = '';
+	
+	/** @var array */
+	private $declarativeNames = [];
+
+	/** @var mediaWikiNsContentReader */
+	private $mediaWikiNsContentReader;
 
 	/**
 	 * @param string $typeid
 	 */
 	public function __construct( $typeid = self::TYPE_ID ) {
 		parent::__construct( $typeid );
+		$this->mediaWikiNsContentReader = ApplicationFactory::getInstance()->getMediaWikiNsContentReader();
 	}
 
 	/**
@@ -142,11 +151,43 @@ class ImportValue extends DataValue {
 			$this->uri = $parts[2];
 			$this->termType = $parts[3];
 			$this->qname = $this->namespace . ':' . $this->term;
-			$this->declarativeName = '';
+			$this->declarativeName = $this->getDeclarativeName( $this->namespace );
 			$this->m_caption = $this->createCaption( $this->namespace, $this->qname, $this->uri, $this->declarativeName );
 		}
 
 		return true;
+	}
+
+	/**
+	 * @param string $namespace
+	 * @return string
+	 */
+	private function getDeclarativeName( $namespace ) {
+		if ( array_key_exists( $namespace, $this->declarativeNames ) ) {
+			return $this->declarativeNames[$namespace];
+		}
+
+		// @see ImportValueParser
+		$controlledVocabulary = $this->mediaWikiNsContentReader->read(
+			ImportValue::IMPORT_PREFIX . $namespace
+		);
+
+		if ( $controlledVocabulary === '' ) {
+			return $this->declarativeNames[$namespace] = '';
+		}
+
+		$importDefintions = array_map( 'trim', preg_split( "([\n][\s]?)", $controlledVocabulary ) );
+
+		// Get definition from first line
+		$fristLine = array_shift( $importDefintions );
+
+		if ( strpos( $fristLine, '|' ) === false ) {
+			return $this->declarativeNames[$namespace] = '';
+		}
+
+		list( $uri, $name ) = explode( '|', $fristLine, 2 );
+
+		return $this->declarativeNames[$namespace] = $name;
 	}
 
 	/**
@@ -225,7 +266,7 @@ class ImportValue extends DataValue {
 	}
 
 	private function createCaption( $namespace, $qname, $uri, $declarativeName ) {
-		return "[[MediaWiki:" . self::IMPORT_PREFIX . $namespace . "|" . $qname . "]] " . Message::get( [ 'parentheses', "[$uri $namespace] | " . $declarativeName ], Message::PARSE );
+		return "[[MediaWiki:" . self::IMPORT_PREFIX . $namespace . "|" . $qname . "]] " . Message::get( [ 'parentheses', "[$uri $namespace] | " . $declarativeName ], Message::TEXT );
 	}
 
 }

--- a/tests/phpunit/Integration/JSONScript/TestCases/q-1301.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/q-1301.json
@@ -1,0 +1,42 @@
+{
+	"description": "imported-from query (@see issues/4971)",
+	"setup": [
+		{
+			"namespace": "NS_MEDIAWIKI",
+			"page": "Smw import foaf",
+			"contents": "http://xmlns.com/foaf/0.1/|[http://www.foaf-project.org/ Friend Of A Friend]\n name|Type:Text\n homepage|Type:URL\n"
+		},
+		{
+			"namespace": "SMW_NS_PROPERTY",
+			"page": "Foaf:homepage",
+			"contents": "[[Imported from::foaf:homepage]]"
+		},
+		{
+			"page": "Page1",
+			"contents": "{{#ask: [[Imported from::+]] |?Imported from |format=plainlist  }}"
+		}
+	],
+	"tests": [
+		{
+			"type": "parser",
+			"about": "#1 (output imported-from query)",
+			"subject": "Page1",
+			"assert-output": {
+				"to-contain": [
+					"<a href=\"/index.php/Property:Foaf:homepage\" title=\"Property:Foaf:homepage\">Foaf:homepage</a> (<span class=\"smw-highlighter\" data-type=\"1\" data-state=\"inline\" data-title=\"Property\" title=\"&quot;Imported from&quot; is a predefined property that describes a relation to an imported vocabulary and is provided by Semantic MediaWiki.\"><span class=\"smwbuiltin\"><a href=\"/index.php/Property:Imported_from\" title=\"Property:Imported from\">Imported from</a></span><span class=\"smwttcontent\">\"Imported from\" is a predefined property that describes a relation to an <a rel=\"nofollow\" class=\"external text\" href=\"https://www.semantic-mediawiki.org/wiki/Help:Import_vocabulary\">imported vocabulary</a> and is provided by <a rel=\"nofollow\" class=\"external text\" href=\"https://www.semantic-mediawiki.org/wiki/Help:Special_properties\">Semantic MediaWiki</a>.</span></span>: <a href=\"/index.php/MediaWiki:Smw_import_foaf\" title=\"MediaWiki:Smw import foaf\">foaf:homepage</a> (<a rel=\"nofollow\" class=\"external text\" href=\"http://xmlns.com/foaf/0.1/\">foaf</a> | <a rel=\"nofollow\" class=\"external text\" href=\"http://www.foaf-project.org/\">Friend Of A Friend</a>))"
+				]
+			}
+		}
+	],
+	"settings": {
+		"smwgNamespacesWithSemanticLinks": {
+			"NS_MAIN": true,
+			"SMW_NS_PROPERTY": true
+		}
+	},
+	"meta": {
+		"version": "2",
+		"is-incomplete": false,
+		"debug": false
+	}
+}


### PR DESCRIPTION
fixes issue https://github.com/SemanticMediaWiki/SemanticMediaWiki/issues/4971

- fixes mixed wikitext/html in Imported from printout caption
- fixes empty declarativeName (i.e. vocabulary name used as caption of the imported property between parenthesis) (see here https://www.semantic-mediawiki.org/wiki/User:Krabina_Bernhard/ontology)


supersedes https://github.com/SemanticMediaWiki/SemanticMediaWiki/pull/5492

added test `q-1301.json`

the test fails with the original class and succeeds with the updated class. (the original class returns a result like the following, https://www.semantic-mediawiki.org/wiki/User:Krabina_Bernhard/ontology, with escaped html and without captions)





