### PR TITLE
Fix #5579 by adding a workaround for MediaWiki 1.41 and above

### DIFF
--- a/src/MediaWiki/Template/TemplateExpander.php
+++ b/src/MediaWiki/Template/TemplateExpander.php
@@ -54,7 +54,7 @@ class TemplateExpander {
 	 * @see Special:ExpandTemplates
 	 * @since 3.1
 	 *
-	 * @param Template|TemplateSet|srting $template
+	 * @param Template|TemplateSet|string $template
 	 *
 	 * @return string
 	 */


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Bug Fixes**
    - Corrected a typo in a function parameter declaration.
- **New Features**
    - Enhanced error handling by changing the error data type and introducing safer parser output access methods.
- **Refactor**
    - Simplified and updated methods for improved efficiency and readability.
    - Removed outdated compatibility logic.
- **Chores**
    - Added necessary imports for error handling and parser output management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->