### PR TITLE
Fix footer sorting on table results

### DIFF
--- a/src/Query/ResultPrinters/TableResultPrinter.php
+++ b/src/Query/ResultPrinters/TableResultPrinter.php
@@ -156,10 +156,10 @@ class TableResultPrinter extends ResultPrinter {
 
 			$this->htmlTable->cell(
 					$link->getText( $outputMode, $this->mLinker ),
-					[ 'class' => 'sortbottom', 'colspan' => $res->getColumnCount() ]
+					[ 'colspan' => $res->getColumnCount() ]
 			);
 
-			$this->htmlTable->row( [ 'class' => 'smwfooter' ] );
+			$this->htmlTable->row( [ 'class' => 'smwfooter sortbottom' ] );
 		}
 
 		$tableAttrs = [ 'class' => $class ];


### PR DESCRIPTION
The `sortbottom` class needs to be on the row, not on a cell.

https://en.wikipedia.org/wiki/Help:Sortable_tables#Summation_footer

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Improved table rendering by adjusting attributes for better styling and functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->