### PR TITLE
fix SMW\SQLStore\EntityStore\PrefetchCache cache key overwrap

### DIFF
--- a/src/SQLStore/EntityStore/PrefetchCache.php
+++ b/src/SQLStore/EntityStore/PrefetchCache.php
@@ -115,7 +115,7 @@ class PrefetchCache {
 			$requestOptions
 		);
 
-		$this->cache[$key] = $result;
+		$this->cache[$key] = $result + ( $this->cache[$key] ?? [] );
 		$this->lookupCache[$lookupKey] = true;
 	}
 

--- a/tests/phpunit/Unit/SQLStore/EntityStore/PrefetchCacheTest.php
+++ b/tests/phpunit/Unit/SQLStore/EntityStore/PrefetchCacheTest.php
@@ -85,4 +85,44 @@ class PrefetchCacheTest extends TestCase {
 		);
 	}
 
+	public function testCacheMergeWithDifferentFingerprints() {
+		$property = new Property( 'Pm' );
+		$subject1 = WikiPage::newFromText( 'Subject1' );
+		$subject2 = WikiPage::newFromText( 'Subject2' );
+
+		$idTable = $this->getMockBuilder( EntityIdManager::class )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$idTable->method( 'getSMWPageID' )
+			->willReturnOnConsecutiveCalls( 101, 102 );
+
+		$this->store->method( 'getObjectIds' )
+			->willReturn( $idTable );
+
+		$this->prefetchItemLookup->method( 'getPropertyValues' )
+			->willReturnOnConsecutiveCalls(
+				[ 101 => [ WikiPage::newFromText( 'Result1' ) ] ],
+				[ 102 => [ WikiPage::newFromText( 'Result2' ) ] ]
+			);
+
+		$instance = new PrefetchCache(
+			$this->store,
+			$this->prefetchItemLookup
+		);
+
+		$instance->prefetch( [ $subject1 ], $property, $this->requestOptions );
+		$instance->prefetch( [ $subject2 ], $property, $this->requestOptions );
+
+		$this->assertEquals(
+			[ WikiPage::newFromText( 'Result1' ) ],
+			$instance->getPropertyValues( $subject1, $property, $this->requestOptions )
+		);
+
+		$this->assertEquals(
+			[ WikiPage::newFromText( 'Result2' ) ],
+			$instance->getPropertyValues( $subject2, $property, $this->requestOptions )
+		);
+	}
+
 }


### PR DESCRIPTION
There is a case that key from makeCacheKey is same, but fingerprint from subjects are different, typically with subobject property path resolution.
SemanticMediaWiki/SemanticResultFormats#825

Using same PrefetchCache, if there comes new prefetch call with same key but different fingerprint, then the old cache will be replaced with the new result.
I think we should merge the result here.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Refactor**
	- Improved cache merging in the prefetch functionality to enhance data retrieval efficiency.
- **Tests**
	- Added new test methods `testMultiCacheAndFetch` and `testCacheMergeWithDifferentFingerprints` to validate caching, fetching multiple items, and merging items with different fingerprints based on certain conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->