### PR TITLE
Assign array key and icon to "browse properties" in toolbox

### DIFF
--- a/src/MediaWiki/Hooks/SidebarBeforeOutput.php
+++ b/src/MediaWiki/Hooks/SidebarBeforeOutput.php
@@ -74,9 +74,10 @@ class SidebarBeforeOutput implements HookListener {
 			true
 		);
 
-		$sidebar["TOOLBOX"][] = [
+		$sidebar["TOOLBOX"]['smwbrowselink'] = [
 			'text' => $skin->msg( 'smw_browselink' )->text(),
 			'href' => SpecialPage::getTitleFor( 'Browse', ':' . $link )->getLocalUrl(),
+			'icon' => 'database',
 			'id'   => 't-smwbrowselink',
 			'rel'  => 'search'
 		];

--- a/tests/phpunit/Integration/EncodingIntegrationTest.php
+++ b/tests/phpunit/Integration/EncodingIntegrationTest.php
@@ -51,7 +51,7 @@ class EncodingIntegrationTest extends \PHPUnit_Framework_TestCase {
 
 		$this->assertContains(
 			$expected,
-			$sidebar['TOOLBOX'][0]['href']
+			$sidebar['TOOLBOX']['smwbrowselink']['href']
 		);
 
 		ApplicationFactory::clear();


### PR DESCRIPTION
The "browse property" link in sidebar should have an array key so that it can be targeted by other extensions or gadgets properly. The [OOUI database icon](https://doc.wikimedia.org/oojs-ui/master/demos/?page=icons&theme=wikimediaui&direction=ltr&platform=desktop) is added to give an icon for skins that might use it,

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced the toolbox in the sidebar with a new link for improved navigation and usability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->