### PR TITLE
Test with more MediaWiki versions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -30,6 +30,16 @@ jobs:
           - mediawiki_version: 1.39
             database_type: mysql
             experimental: true
+          - mediawiki_version: 1.40
+            database_type: mysql
+            experimental: true
+          - mediawiki_version: 1.41
+            database_type: mysql
+            experimental: true
+          - mediawiki_version: 1.42
+            database_type: mysql
+            experimental: true
+
 
     container:
       image: mediawiki:${{ matrix.mediawiki_version }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -30,7 +30,7 @@ jobs:
           - mediawiki_version: 1.39
             database_type: mysql
             experimental: true
-          - mediawiki_version: 1.40
+          - mediawiki_version: "1.40"
             database_type: mysql
             experimental: true
           - mediawiki_version: 1.41


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Added support for newer versions of MediaWiki (1.40, 1.41, 1.42) with MySQL as the database type in the workflow configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->