### PR TITLE
Docker compose ci

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,7 +22,7 @@ jobs:
             experimental: false
           - mediawiki_version: '1.39'
             database_type: mysql
-            coverage: true
+            coverage: false
             experimental: false
           - mediawiki_version: '1.39'
             database_type: sqlite

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,8 +8,7 @@ on:
   workflow_dispatch:
 
 jobs:
-
-  test:
+  build:
 
     runs-on: ubuntu-22.04
     continue-on-error: ${{ matrix.experimental }}
@@ -17,127 +16,65 @@ jobs:
     strategy:
       matrix:
         include:
-          - mediawiki_version: 1.35
+          - mediawiki_version: '1.35'
             database_type: mysql
             coverage: false
             experimental: false
-          - mediawiki_version: 1.39
+          - mediawiki_version: '1.39'
             database_type: mysql
             coverage: true
             experimental: false
-          - mediawiki_version: 1.39
+          - mediawiki_version: '1.39'
             database_type: sqlite
             coverage: false
             experimental: true
-          - mediawiki_version: 1.40
+          - mediawiki_version: '1.40'
             database_type: sqlite
             coverage: false
             experimental: true
 
-    container:
-      image: mediawiki:${{ matrix.mediawiki_version }}
-      options: --link some-${{ matrix.database_type }}:${{ matrix.database_type }}
+      env:
+        EXT_NAME: SemanticMediaWiki
+        COMPOSER_VERSION: 2.1.14
+        MW_INSTALL_PATH: /var/www/html
+        MW_EXT_PATH: /var/www/html/extensions
+        DB_ROOT_USER: root
+        DB_ROOT_PWD: database
+        MW_DB_TYPE: ${{ matrix.database_type }}
+        MW_DB_SERVER: ${{ matrix.database_type }}
+        MW_DB_PATH: /var/www/data
+        MW_DB_USER: wiki
+        MW_DB_PWD: wiki
+        MW_DB_NAME: wiki
 
-    env:
-      EXT_NAME: SemanticMediaWiki
-      COMPOSER_VERSION: 2.1.14
-      MW_INSTALL_PATH: /var/www/html
-      MW_EXT_PATH: /var/www/html/extensions
-      DB_ROOT_USER: root
-      DB_ROOT_PWD: database
-      MW_DB_TYPE: ${{ matrix.database_type }}
-      MW_DB_SERVER: ${{ matrix.database_type }}
-      MW_DB_PATH: /var/www/data
-      MW_DB_USER: wiki
-      MW_DB_PWD: wiki
-      MW_DB_NAME: wiki
+      steps:
+        - name: Checkout
+          uses: actions/checkout@v4
+          with:
+            submodules: recursive
+                    
+        - name: Update submodules
+          run: git submodule update --init --remote
 
-    services:
-      some-mysql:
-        image: mariadb:latest
-        env:
-          MARIADB_ROOT_PASSWORD: ${{ env.DB_ROOT_PWD }}
+        - name: Run unit tests
+          run: make ci COMPOSER_PARAMS="-- --testsuite=semantic-mediawiki-unit"
+          if: matrix.coverage == false
 
-    steps:
-      # https://getcomposer.org/download/
-      - name: Get Composer
-        run: |
-          apt update
-          apt install -y unzip
-          php -r "copy('https://getcomposer.org/installer', 'installer');"
-          php -r "copy('https://composer.github.io/installer.sig', 'expected');"
-          echo `cat expected` " installer" | sha384sum -c -
-          php installer --version=${{ env.COMPOSER_VERSION }}
-          rm -f installer expected
-          mv composer.phar /usr/local/bin/composer
+        - name: Run tests
+          run: make ci COMPOSER_PARAMS="-- --testsuite semantic-mediawiki-check,semantic-mediawiki-data-model,semantic-mediawiki-integration,semantic-mediawiki-import,semantic-mediawiki-structure"
+          if: matrix.coverage == false
 
-      - name: Checkout Extension
-        uses: actions/checkout@v3
-        with:
-          path: ${{ env.EXT_NAME }}
+        - name: Run unit tests with coverage
+          run: make ci-coverage COMPOSER_PARAMS="-- --testsuite=semantic-mediawiki-unit"
+          if: matrix.coverage == true
 
-      # Setting actions/checkout@v3 path to env.MW_EXT_PATH fails with "Repository path '/var/www/html/extensions' is not under ..."
-      # See also open PR https://github.com/actions/checkout/pull/388
-      - name: Move Extension
-        run: |
-          mkdir -p ${{ env.MW_EXT_PATH }}
-          mv ${{ env.EXT_NAME }} ${{ env.MW_EXT_PATH }}
+        - name: Run tests with coverage
+          run: make ci-coverage COMPOSER_PARAMS="-- --testsuite semantic-mediawiki-check,semantic-mediawiki-data-model,semantic-mediawiki-integration,semantic-mediawiki-import,semantic-mediawiki-structure"
+          if: matrix.coverage == true
 
-      - name: MediaWiki Composer Update
-        run: |
-          COMPOSER=composer.local.json composer require --no-update --working-dir ${{ env.MW_INSTALL_PATH }} mediawiki/semantic-media-wiki @dev
-          COMPOSER=composer.local.json composer config repositories.semantic-media-wiki '{"type": "path", "url": "extensions/SemanticMediaWiki"}' --working-dir ${{ env.MW_INSTALL_PATH }}
-          composer update --working-dir ${{ env.MW_INSTALL_PATH }}
-
-      - name: MediaWiki Install
-        run: >
-          php ${{ env.MW_INSTALL_PATH }}/maintenance/install.php
-          --pass=Password123456
-          --server="http://localhost:8000"
-          --scriptpath=""
-          --dbtype=${{ env.MW_DB_TYPE }}
-          --dbserver=${{ env.MW_DB_SERVER }}
-          --installdbuser=${{ env.DB_ROOT_USER }}
-          --installdbpass=${{ env.DB_ROOT_PWD }}
-          --dbname=${{ env.MW_DB_NAME }}
-          --dbuser=${{ env.MW_DB_USER }}
-          --dbpass=${{ env.MW_DB_PWD }}
-          --dbpath=${{ env.MW_DB_PATH }}
-          --extensions=SemanticMediaWiki
-          ${{ env.EXT_NAME }}-test WikiSysop
-
-      - name: Enable Debug Output
-        run: |
-          echo 'error_reporting(E_ALL| E_STRICT);' >> ${{ env.MW_INSTALL_PATH }}/LocalSettings.php
-          echo 'ini_set("display_errors", 1);' >> ${{ env.MW_INSTALL_PATH }}/LocalSettings.php
-          echo '$wgShowExceptionDetails = true;' >> ${{ env.MW_INSTALL_PATH }}/LocalSettings.php
-          echo '$wgDevelopmentWarnings = true;' >> ${{ env.MW_INSTALL_PATH }}/LocalSettings.php
-
-      - name: Install SemanticMediaWiki
-        run: |
-          echo "enableSemantics( 'localhost' );" >> ${{ env.MW_INSTALL_PATH }}/LocalSettings.php
-          tail -n5 ${{ env.MW_INSTALL_PATH }}/LocalSettings.php
-          php ${{ env.MW_INSTALL_PATH }}/maintenance/update.php --quick
-
-      - name: Run unit tests
-        run: make ci COMPOSER_PARAMS="-- --testsuite=semantic-mediawiki-unit"
-        if: matrix.coverage == false
-
-      - name: Run tests
-        run: make ci COMPOSER_PARAMS="-- --testsuite semantic-mediawiki-check,semantic-mediawiki-data-model,semantic-mediawiki-integration,semantic-mediawiki-import,semantic-mediawiki-structure"
-        if: matrix.coverage == false
-
-      - name: Run unit tests with coverage
-        run: make ci-coverage COMPOSER_PARAMS="-- --testsuite=semantic-mediawiki-unit"
-        if: matrix.coverage == true
-
-      - name: Run tests with coverage
-        run: make ci-coverage COMPOSER_PARAMS="-- --testsuite semantic-mediawiki-check,semantic-mediawiki-data-model,semantic-mediawiki-integration,semantic-mediawiki-import,semantic-mediawiki-structure"
-        if: matrix.coverage == true
-
-      - name: Upload code coverage
-        uses: codecov/codecov-action@v4
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}
-          files: coverage/php/coverage.xml
-        if: matrix.coverage == true
+        - name: Upload code coverage
+          uses: codecov/codecov-action@v4
+          with:
+            token: ${{ secrets.CODECOV_TOKEN }}
+            files: coverage/php/coverage.xml
+          if: matrix.coverage == true

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,7 +25,7 @@ jobs:
           - mediawiki_version: '1.39'
             php_version: 8.1
             database_type: mysql
-            database_image: "mysql:8"
+            database_image: "mariadb:latest"
             coverage: false
             experimental: false
           - mediawiki_version: '1.39'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,11 +19,13 @@ jobs:
           - mediawiki_version: '1.35'
             php_version: 7.4
             database_type: mysql
+            database_image: "mysql:5.7"
             coverage: false
             experimental: false
           - mediawiki_version: '1.39'
             php_version: 8.1
             database_type: mysql
+            database_image: "mysql:8"
             coverage: false
             experimental: false
           - mediawiki_version: '1.39'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -35,7 +35,8 @@ jobs:
             experimental: true
           - mediawiki_version: '1.41'
             php_version: 8.1
-            database_type: sqlite
+            database_type: mysql
+            database_image: "mysql:8"
             coverage: false
             experimental: true
             

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,4 +1,4 @@
-name: CI
+name: build
 
 on:
   push:
@@ -59,13 +59,65 @@ jobs:
           MARIADB_ROOT_PASSWORD: ${{ env.DB_ROOT_PWD }}
 
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
+      # https://getcomposer.org/download/
+      - name: Get Composer
+        run: |
+          apt update
+          apt install -y unzip
+          php -r "copy('https://getcomposer.org/installer', 'installer');"
+          php -r "copy('https://composer.github.io/installer.sig', 'expected');"
+          echo `cat expected` " installer" | sha384sum -c -
+          php installer --version=${{ env.COMPOSER_VERSION }}
+          rm -f installer expected
+          mv composer.phar /usr/local/bin/composer
+
+      - name: Checkout Extension
+        uses: actions/checkout@v3
         with:
-          submodules: recursive
-                   
-      - name: Update submodules
-        run: git submodule update --init --remote
+          path: ${{ env.EXT_NAME }}
+
+      # Setting actions/checkout@v3 path to env.MW_EXT_PATH fails with "Repository path '/var/www/html/extensions' is not under ..."
+      # See also open PR https://github.com/actions/checkout/pull/388
+      - name: Move Extension
+        run: |
+          mkdir -p ${{ env.MW_EXT_PATH }}
+          mv ${{ env.EXT_NAME }} ${{ env.MW_EXT_PATH }}
+
+      - name: MediaWiki Composer Update
+        run: |
+          COMPOSER=composer.local.json composer require --no-update --working-dir ${{ env.MW_INSTALL_PATH }} mediawiki/semantic-media-wiki @dev
+          COMPOSER=composer.local.json composer config repositories.semantic-media-wiki '{"type": "path", "url": "extensions/SemanticMediaWiki"}' --working-dir ${{ env.MW_INSTALL_PATH }}
+          composer update --working-dir ${{ env.MW_INSTALL_PATH }}
+
+      - name: MediaWiki Install
+        run: >
+          php ${{ env.MW_INSTALL_PATH }}/maintenance/install.php
+          --pass=Password123456
+          --server="http://localhost:8000"
+          --scriptpath=""
+          --dbtype=${{ env.MW_DB_TYPE }}
+          --dbserver=${{ env.MW_DB_SERVER }}
+          --installdbuser=${{ env.DB_ROOT_USER }}
+          --installdbpass=${{ env.DB_ROOT_PWD }}
+          --dbname=${{ env.MW_DB_NAME }}
+          --dbuser=${{ env.MW_DB_USER }}
+          --dbpass=${{ env.MW_DB_PWD }}
+          --dbpath=${{ env.MW_DB_PATH }}
+          --extensions=SemanticMediaWiki
+          ${{ env.EXT_NAME }}-test WikiSysop
+
+      - name: Enable Debug Output
+        run: |
+          echo 'error_reporting(E_ALL| E_STRICT);' >> ${{ env.MW_INSTALL_PATH }}/LocalSettings.php
+          echo 'ini_set("display_errors", 1);' >> ${{ env.MW_INSTALL_PATH }}/LocalSettings.php
+          echo '$wgShowExceptionDetails = true;' >> ${{ env.MW_INSTALL_PATH }}/LocalSettings.php
+          echo '$wgDevelopmentWarnings = true;' >> ${{ env.MW_INSTALL_PATH }}/LocalSettings.php
+
+      - name: Install SemanticMediaWiki
+        run: |
+          echo "enableSemantics( 'localhost' );" >> ${{ env.MW_INSTALL_PATH }}/LocalSettings.php
+          tail -n5 ${{ env.MW_INSTALL_PATH }}/LocalSettings.php
+          php ${{ env.MW_INSTALL_PATH }}/maintenance/update.php --quick
 
       - name: Run unit tests
         run: make ci COMPOSER_PARAMS="-- --testsuite=semantic-mediawiki-unit"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,4 +1,4 @@
-name: build
+name: CI
 
 on:
   push:
@@ -8,27 +8,31 @@ on:
   workflow_dispatch:
 
 jobs:
-  build:
+
+  test:
+
     runs-on: ubuntu-22.04
     continue-on-error: ${{ matrix.experimental }}
 
     strategy:
       matrix:
         include:
+          include:
           - mediawiki_version: 1.35
             database_type: mysql
+            coverage: false
             experimental: false
-          - mediawiki_version: 1.36
-            database_type: mysql
-            experimental: true
-          - mediawiki_version: 1.37
-            database_type: mysql
-            experimental: true
-          - mediawiki_version: 1.38
-            database_type: mysql
-            experimental: true
           - mediawiki_version: 1.39
             database_type: mysql
+            coverage: true
+            experimental: false
+          - mediawiki_version: 1.39
+            database_type: sqlite
+            coverage: false
+            experimental: true
+          - mediawiki_version: 1.40
+            database_type: sqlite
+            coverage: false
             experimental: true
 
     container:
@@ -56,74 +60,33 @@ jobs:
           MARIADB_ROOT_PASSWORD: ${{ env.DB_ROOT_PWD }}
 
     steps:
-      # https://getcomposer.org/download/
-      - name: Get Composer
-        run: |
-          apt update
-          apt install -y unzip
-          php -r "copy('https://getcomposer.org/installer', 'installer');"
-          php -r "copy('https://composer.github.io/installer.sig', 'expected');"
-          echo `cat expected` " installer" | sha384sum -c -
-          php installer --version=${{ env.COMPOSER_VERSION }}
-          rm -f installer expected
-          mv composer.phar /usr/local/bin/composer
-
-      - name: Checkout Extension
-        uses: actions/checkout@v3
+      - name: Checkout
+        uses: actions/checkout@v4
         with:
-          path: ${{ env.EXT_NAME }}
-
-      # Setting actions/checkout@v3 path to env.MW_EXT_PATH fails with "Repository path '/var/www/html/extensions' is not under ..."
-      # See also open PR https://github.com/actions/checkout/pull/388
-      - name: Move Extension
-        run: |
-          mkdir -p ${{ env.MW_EXT_PATH }}
-          mv ${{ env.EXT_NAME }} ${{ env.MW_EXT_PATH }}
-
-      - name: MediaWiki Composer Update
-        run: |
-          COMPOSER=composer.local.json composer require --no-update --working-dir ${{ env.MW_INSTALL_PATH }} mediawiki/semantic-media-wiki @dev
-          COMPOSER=composer.local.json composer config repositories.semantic-media-wiki '{"type": "path", "url": "extensions/SemanticMediaWiki"}' --working-dir ${{ env.MW_INSTALL_PATH }}
-          composer update --working-dir ${{ env.MW_INSTALL_PATH }}
-
-      - name: MediaWiki Install
-        run: >
-          php ${{ env.MW_INSTALL_PATH }}/maintenance/install.php
-          --pass=Password123456
-          --server="http://localhost:8000"
-          --scriptpath=""
-          --dbtype=${{ env.MW_DB_TYPE }}
-          --dbserver=${{ env.MW_DB_SERVER }}
-          --installdbuser=${{ env.DB_ROOT_USER }}
-          --installdbpass=${{ env.DB_ROOT_PWD }}
-          --dbname=${{ env.MW_DB_NAME }}
-          --dbuser=${{ env.MW_DB_USER }}
-          --dbpass=${{ env.MW_DB_PWD }}
-          --dbpath=${{ env.MW_DB_PATH }}
-          --extensions=SemanticMediaWiki
-          ${{ env.EXT_NAME }}-test WikiSysop
-
-      - name: Enable Debug Output
-        run: |
-          echo 'error_reporting(E_ALL| E_STRICT);' >> ${{ env.MW_INSTALL_PATH }}/LocalSettings.php
-          echo 'ini_set("display_errors", 1);' >> ${{ env.MW_INSTALL_PATH }}/LocalSettings.php
-          echo '$wgShowExceptionDetails = true;' >> ${{ env.MW_INSTALL_PATH }}/LocalSettings.php
-          echo '$wgDevelopmentWarnings = true;' >> ${{ env.MW_INSTALL_PATH }}/LocalSettings.php
-
-      - name: Install SemanticMediaWiki
-        run: |
-          echo "enableSemantics( 'localhost' );" >> ${{ env.MW_INSTALL_PATH }}/LocalSettings.php
-          tail -n5 ${{ env.MW_INSTALL_PATH }}/LocalSettings.php
-          php ${{ env.MW_INSTALL_PATH }}/maintenance/update.php --quick
+          submodules: recursive
+                   
+      - name: Update submodules
+        run: git submodule update --init --remote
 
       - name: Run unit tests
-        run: >
-          composer phpunit
-          --working-dir ${{ env.MW_INSTALL_PATH }}/extensions/SemanticMediaWiki
-          -- --testsuite semantic-mediawiki-unit
+        run: make ci COMPOSER_PARAMS="-- --testsuite=semantic-mediawiki-unit"
+        if: matrix.coverage == false
 
-      - name: Run Tests
-        run: >
-          composer phpunit
-          --working-dir ${{ env.MW_INSTALL_PATH }}/extensions/SemanticMediaWiki
-          -- --testsuite semantic-mediawiki-check,semantic-mediawiki-data-model,semantic-mediawiki-integration,semantic-mediawiki-import,semantic-mediawiki-structure
+      - name: Run tests
+        run: make ci COMPOSER_PARAMS="-- --testsuite semantic-mediawiki-check,semantic-mediawiki-data-model,semantic-mediawiki-integration,semantic-mediawiki-import,semantic-mediawiki-structure"
+        if: matrix.coverage == false
+
+      - name: Run unit tests with coverage
+        run: make ci-coverage COMPOSER_PARAMS="-- --testsuite=semantic-mediawiki-unit"
+        if: matrix.coverage == true
+
+      - name: Run tests with coverage
+        run: make ci-coverage COMPOSER_PARAMS="-- --testsuite semantic-mediawiki-check,semantic-mediawiki-data-model,semantic-mediawiki-integration,semantic-mediawiki-import,semantic-mediawiki-structure"
+        if: matrix.coverage == true
+
+      - name: Upload code coverage
+        uses: codecov/codecov-action@v4
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: coverage/php/coverage.xml
+        if: matrix.coverage == true

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,7 +17,6 @@ jobs:
     strategy:
       matrix:
         include:
-          include:
           - mediawiki_version: 1.35
             database_type: mysql
             coverage: false

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,35 +17,31 @@ jobs:
       matrix:
         include:
           - mediawiki_version: '1.35'
+            php_version: 7.4
             database_type: mysql
             coverage: false
             experimental: false
           - mediawiki_version: '1.39'
+            php_version: 8.1
             database_type: mysql
             coverage: false
             experimental: false
           - mediawiki_version: '1.39'
+            php_version: 8.1
             database_type: sqlite
             coverage: false
             experimental: true
-          - mediawiki_version: '1.40'
+          - mediawiki_version: '1.41'
+            php_version: 8.1
             database_type: sqlite
             coverage: false
             experimental: true
             
     env:
-      EXT_NAME: SemanticMediaWiki
-      COMPOSER_VERSION: 2.1.14
-      MW_INSTALL_PATH: /var/www/html
-      MW_EXT_PATH: /var/www/html/extensions
-      DB_ROOT_USER: root
-      DB_ROOT_PWD: database
-      MW_DB_TYPE: ${{ matrix.database_type }}
-      MW_DB_SERVER: ${{ matrix.database_type }}
-      MW_DB_PATH: /var/www/data
-      MW_DB_USER: wiki
-      MW_DB_PWD: wiki
-      MW_DB_NAME: wiki
+      MW_VERSION: ${{ matrix.mediawiki_version }}
+      PHP_VERSION: ${{ matrix.php_version }}
+      DB_TYPE: ${{ matrix.database_type }}
+      DB_IMAGE: ${{ matrix.database_image }}
 
     steps:
       - name: Checkout

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -32,49 +32,49 @@ jobs:
             database_type: sqlite
             coverage: false
             experimental: true
+            
+    env:
+      EXT_NAME: SemanticMediaWiki
+      COMPOSER_VERSION: 2.1.14
+      MW_INSTALL_PATH: /var/www/html
+      MW_EXT_PATH: /var/www/html/extensions
+      DB_ROOT_USER: root
+      DB_ROOT_PWD: database
+      MW_DB_TYPE: ${{ matrix.database_type }}
+      MW_DB_SERVER: ${{ matrix.database_type }}
+      MW_DB_PATH: /var/www/data
+      MW_DB_USER: wiki
+      MW_DB_PWD: wiki
+      MW_DB_NAME: wiki
 
-      env:
-        EXT_NAME: SemanticMediaWiki
-        COMPOSER_VERSION: 2.1.14
-        MW_INSTALL_PATH: /var/www/html
-        MW_EXT_PATH: /var/www/html/extensions
-        DB_ROOT_USER: root
-        DB_ROOT_PWD: database
-        MW_DB_TYPE: ${{ matrix.database_type }}
-        MW_DB_SERVER: ${{ matrix.database_type }}
-        MW_DB_PATH: /var/www/data
-        MW_DB_USER: wiki
-        MW_DB_PWD: wiki
-        MW_DB_NAME: wiki
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+                   
+      - name: Update submodules
+        run: git submodule update --init --remote
 
-      steps:
-        - name: Checkout
-          uses: actions/checkout@v4
-          with:
-            submodules: recursive
-                    
-        - name: Update submodules
-          run: git submodule update --init --remote
+      - name: Run unit tests
+        run: make ci COMPOSER_PARAMS="-- --testsuite=semantic-mediawiki-unit"
+        if: matrix.coverage == false
 
-        - name: Run unit tests
-          run: make ci COMPOSER_PARAMS="-- --testsuite=semantic-mediawiki-unit"
-          if: matrix.coverage == false
+      - name: Run tests
+        run: make ci COMPOSER_PARAMS="-- --testsuite semantic-mediawiki-check,semantic-mediawiki-data-model,semantic-mediawiki-integration,semantic-mediawiki-import,semantic-mediawiki-structure"
+        if: matrix.coverage == false
 
-        - name: Run tests
-          run: make ci COMPOSER_PARAMS="-- --testsuite semantic-mediawiki-check,semantic-mediawiki-data-model,semantic-mediawiki-integration,semantic-mediawiki-import,semantic-mediawiki-structure"
-          if: matrix.coverage == false
+      - name: Run unit tests with coverage
+        run: make ci-coverage COMPOSER_PARAMS="-- --testsuite=semantic-mediawiki-unit"
+        if: matrix.coverage == true
 
-        - name: Run unit tests with coverage
-          run: make ci-coverage COMPOSER_PARAMS="-- --testsuite=semantic-mediawiki-unit"
-          if: matrix.coverage == true
+      - name: Run tests with coverage
+        run: make ci-coverage COMPOSER_PARAMS="-- --testsuite semantic-mediawiki-check,semantic-mediawiki-data-model,semantic-mediawiki-integration,semantic-mediawiki-import,semantic-mediawiki-structure"
+        if: matrix.coverage == true
 
-        - name: Run tests with coverage
-          run: make ci-coverage COMPOSER_PARAMS="-- --testsuite semantic-mediawiki-check,semantic-mediawiki-data-model,semantic-mediawiki-integration,semantic-mediawiki-import,semantic-mediawiki-structure"
-          if: matrix.coverage == true
-
-        - name: Upload code coverage
-          uses: codecov/codecov-action@v4
-          with:
-            token: ${{ secrets.CODECOV_TOKEN }}
-            files: coverage/php/coverage.xml
-          if: matrix.coverage == true
+      - name: Upload code coverage
+        uses: codecov/codecov-action@v4
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: coverage/php/coverage.xml
+        if: matrix.coverage == true

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,7 +25,7 @@ jobs:
           - mediawiki_version: '1.39'
             php_version: 8.1
             database_type: mysql
-            database_image: "mariadb:latest"
+            database_image: "mariadb:11.2"
             coverage: false
             experimental: false
           - mediawiki_version: '1.39'
@@ -36,7 +36,7 @@ jobs:
           - mediawiki_version: '1.41'
             php_version: 8.1
             database_type: mysql
-            database_image: "mysql:8"
+            database_image: "mariadb:11.2"
             coverage: false
             experimental: true
             

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "build"]
+	path = build
+	url = https://github.com/gesinn-it-pub/docker-compose-ci.git

--- a/.phpcs.xml
+++ b/.phpcs.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0"?>
+<ruleset>
+	<rule ref="./vendor/mediawiki/mediawiki-codesniffer/MediaWiki">
+		<exclude name="Generic.Files.LineLength.TooLong" />
+		<exclude name="MediaWiki.Commenting.FunctionComment.MissingDocumentationPrivate" />
+		<exclude name="MediaWiki.Commenting.FunctionComment.MissingParamTag" />
+		<exclude name="MediaWiki.Commenting.FunctionComment.MissingReturn" />
+		<exclude name="MediaWiki.NamingConventions.LowerCamelFunctionsName.FunctionName" />
+		<exclude name="MediaWiki.Commenting.FunctionComment.NoParamType" />
+		<exclude name="MediaWiki.Files.ClassMatchesFilename.NotMatch" />
+		<exclude name="MediaWiki.Commenting.FunctionComment.MissingDocumentationPublic" />
+		<exclude name="MediaWiki.Commenting.FunctionComment.MissingDocumentationProtected" />
+		<exclude name="MediaWiki.Commenting.FunctionComment.MissingDocumentationPrivate" />
+		<exclude name="Generic.CodeAnalysis.AssignmentInCondition.FoundInWhileCondition" /> 
+		<exclude name="Squiz.Classes.ValidClassName.NotCamelCaps" />
+		<exclude name="Generic.CodeAnalysis.AssignmentInCondition.Found" />
+		<exclude name="MediaWiki.Commenting.PropertyDocumentation.MissingDocumentationPrivate" />
+		<exclude name="MediaWiki.Commenting.PropertyDocumentation.MissingDocumentationProtected" />
+		<exclude name="MediaWiki.Commenting.PropertyDocumentation.MissingDocumentationPublic" />
+		<exclude name="MediaWiki.PHPUnit.AssertEmpty.AssertEmptyUsed" />
+		<exclude name="Squiz.Operators.ValidLogicalOperators.NotAllowed" />
+		<exclude name="Generic.ControlStructures.DisallowYodaConditions.Found" />
+		<exclude name="MediaWiki.Commenting.PropertyDocumentation.WrongStyle" />
+		<exclude name="Generic.Files.OneObjectStructurePerFile.MultipleFound" />
+	</rule>
+	<rule ref="MediaWiki.NamingConventions.ValidGlobalName">
+		<properties>
+			<property name="allowedPrefixes" type="array" value="eg,wg" />
+		</properties>
+	</rule>
+	<rule ref="MediaWiki.Commenting.FunctionComment.ObjectTypeHintReturn">
+		<severity>0</severity>
+	</rule>
+	<file>.</file>
+	<exclude-pattern>/(vendor|conf)/</exclude-pattern>
+	<exclude-pattern type="relative">extensions/*</exclude-pattern>
+	<arg name="extensions" value="php"/>
+	<arg name="encoding" value="UTF-8"/>
+</ruleset>

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ EXTENSION=SemanticMediaWiki
 # docker images
 MW_VERSION?=1.39
 PHP_VERSION?=8.1
-DB_TYPE?=sqlite
+DB_TYPE?=mysql
 DB_IMAGE?=""
 
 # composer

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,28 @@
+-include .env
+export
+
+# setup for docker-compose-ci build directory
+# delete "build" directory to update docker-compose-ci
+
+ifeq (,$(wildcard ./build/))
+    $(shell git submodule update --init --remote)
+endif
+
+EXTENSION=SemanticMediaWiki
+
+# docker images
+MW_VERSION?=1.39
+PHP_VERSION?=8.1
+DB_TYPE?=sqlite
+DB_IMAGE?=""
+
+# composer
+# Enables "composer update" inside of extension
+COMPOSER_EXT?=true
+
+# nodejs
+# Enables node.js related tests and "npm install"
+# NODE_JS?=true
+
+# check for build dir and git submodule init if it does not exist
+include build/Makefile

--- a/__setup_extension__
+++ b/__setup_extension__
@@ -1,0 +1,6 @@
+error_reporting(E_ALL| E_STRICT);
+ini_set("display_errors", 1);
+$wgShowExceptionDetails = true;
+$wgDevelopmentWarnings = true;
+
+enableSemantics( $wgServer );

--- a/composer.json
+++ b/composer.json
@@ -63,8 +63,12 @@
 		"wikimedia/textcat": "^2|^1.1"
 	},
 	"require-dev": {
-		"squizlabs/php_codesniffer": "~3.5",
-		"phpmd/phpmd": "~2.1"
+		"mediawiki/mediawiki-codesniffer": "43.0.0",
+		"mediawiki/minus-x": "1.1.3",
+		"phpmd/phpmd": "~2.1",
+		"php-parallel-lint/php-console-highlighter": "1.0.0",
+		"php-parallel-lint/php-parallel-lint": "1.4.0",
+		"squizlabs/php_codesniffer": "~3.5"
 	},
 	"suggest": {
 		"mediawiki/semantic-result-formats": "Provides additional result formats for queries of structured data"
@@ -99,8 +103,18 @@
 		}
 	},
 	"scripts": {
-		"test": "php ${MW_INSTALL_PATH}/tests/phpunit/phpunit.php -c phpunit.xml.dist",
-		"phpunit": "php ${MW_INSTALL_PATH}/tests/phpunit/phpunit.php -c phpunit.xml.dist",
+		"analyze": [
+			"@lint",
+			"@phpcs",
+			"@minus-x"
+		],
+		"test": [
+			"@phpunit"
+		],
+		"lint": "parallel-lint . --exclude vendor --exclude node_modules --exclude extensions",
+		"minus-x": "minus-x check .",
+		"phpcs": "phpcs -ps -d memory_limit=2G",
+		"phpunit": "php ${MW_INSTALL_PATH:-../..}/tests/phpunit/phpunit.php -c phpunit.xml.dist",
 		"phpdbg": "phpdbg -qrr ${MW_INSTALL_PATH}/tests/phpunit/phpunit.php -c phpunit.xml.dist",
 		"unit": [
 			"composer dump-autoload",

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -36,7 +36,8 @@ $autoloader->addClassMap( [
 ] );
 
 define( 'SMW_PHPUNIT_DIR', __DIR__ . '/phpunit' );
-define( 'SMW_PHPUNIT_TABLE_PREFIX', 'sunittest_' );
+#define( 'SMW_PHPUNIT_TABLE_PREFIX', 'sunittest_' );
+define( 'SMW_PHPUNIT_TABLE_PREFIX', '' );
 
 /**
  * Register a shutdown function the invoke a final clean-up


### PR DESCRIPTION
The current CI setup updated to run the matrixes for **MW 1.35, 1.39 and 1.41**. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Updated workflow configurations to include new MediaWiki, PHP, and database versions.
  - Added new linting and analysis scripts in the `composer.json` file.
  - Introduced a new submodule for `build` setup.
  - Enhanced Makefile to support Docker Compose CI builds.

- **Chores**
  - Updated PHP CodeSniffer rules in `.phpcs.xml`.
  - Modified `tests/bootstrap.php` for PHPUnit configuration.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->