### PR TITLE
Issue 5667 - fix sniffs Squiz.Functions.FunctionDeclarationArgumentSpacing

### DIFF
--- a/.phpcs.xml
+++ b/.phpcs.xml
@@ -53,7 +53,6 @@
 		<exclude name="MediaWiki.Commenting.FunctionComment.WrongStyle" />
 		<exclude name="Squiz.WhiteSpace.OperatorSpacing.SpacingAfter" />
 		<exclude name="MediaWiki.PHPUnit.MockBoilerplate.returnCallback" />
-		<exclude name="Squiz.Functions.FunctionDeclarationArgumentSpacing.SpacingBeforeClose" />
 		<exclude name="MediaWiki.PHPUnit.AssertEquals.False" />
 		<exclude name="MediaWiki.Commenting.DocComment.SpacingDocStar" />
 		<exclude name="MediaWiki.Classes.UnusedUseStatement.UnnecessaryUse" />
@@ -111,7 +110,6 @@
 		<exclude name="MediaWiki.Commenting.PropertyDocumentation.NotShortBoolVar" />
 		<exclude name="MediaWiki.Commenting.FunctionComment.MissingParamName" />
 		<exclude name="MediaWiki.Commenting.PhpunitAnnotations.NotClass" />
-		<exclude name="Squiz.Functions.FunctionDeclarationArgumentSpacing.SpaceBeforeComma" />
 		<exclude name="Squiz.WhiteSpace.SemicolonSpacing.Incorrect" />
 		<exclude name="Squiz.PHP.NonExecutableCode.Unreachable" />
 		<exclude name="MediaWiki.Commenting.FunctionComment.NotShortIntParam" />
@@ -136,11 +134,9 @@
 		<exclude name="MediaWiki.PHPUnit.AssertEquals.NumericString" />
 		<exclude name="MediaWiki.PHPUnit.SpecificAssertions.assertIsArray" />
 		<exclude name="Universal.WhiteSpace.CommaSpacing.NoSpaceAfterInFunctionDeclaration" />
-		<exclude name="Squiz.Functions.FunctionDeclarationArgumentSpacing.NoSpaceBeforeArg" />
 		<exclude name="MediaWiki.Commenting.DocComment.SyntaxAlignedDocClose" />
 		<exclude name="MediaWiki.WhiteSpace.SpaceAfterClosure.NoWhitespaceAfterArrow" />
 		<exclude name="PSR2.Classes.ClassDeclaration.SpaceBeforeName" />
-		<exclude name="Squiz.Functions.FunctionDeclarationArgumentSpacing.SpacingAfterOpen" />
 		<exclude name="MediaWiki.PHPUnit.MockBoilerplate.returnValueMap" />
 		<exclude name="Generic.Formatting.SpaceAfterNot.Incorrect" />
 		<exclude name="PSR2.Files.EndFileNewline.TooMany" />
@@ -217,7 +213,6 @@
 		<exclude name="MediaWiki.Commenting.FunctionComment.UppercasePrimitiveStringReturn" />
 		<exclude name="MediaWiki.NamingConventions.PrefixedGlobalFunctions.allowedPrefix" />
 		<exclude name="MediaWiki.Commenting.LicenseComment.LicenseTagNonFileComment" />
-		<exclude name="Squiz.Functions.FunctionDeclarationArgumentSpacing.SpaceAfterEquals" />
 		<exclude name="MediaWiki.VariableAnalysis.MisleadingGlobalNames.Misleading$wgCategoryCollation" />
 		<exclude name="MediaWiki.Usage.DirUsage.FunctionFound" />
 	</rule>

--- a/data/config/db-primary-keys.php
+++ b/data/config/db-primary-keys.php
@@ -93,7 +93,7 @@ class ConfigPreloadPrimaryKeyTableMutator {
 /**
  * @see https://github.com/SemanticMediaWiki/SemanticMediaWiki/blob/master/docs/examples/hook.sqlstore.installer.beforecreatetablescomplete.md
  */
-MediaWikiServices::getInstance()->getHookContainer()->register( 'SMW::SQLStore::Installer::BeforeCreateTablesComplete', function(array $tables, MessageReporter $messageReporter ) {
+MediaWikiServices::getInstance()->getHookContainer()->register( 'SMW::SQLStore::Installer::BeforeCreateTablesComplete', function( array $tables, MessageReporter $messageReporter ) {
 	$cliMsgFormatter = new CliMsgFormatter();
 	$configPreloadPrimaryKeyTableMutator = new ConfigPreloadPrimaryKeyTableMutator();
 

--- a/includes/SMW_PageSchemas.php
+++ b/includes/SMW_PageSchemas.php
@@ -174,7 +174,7 @@ class SMWPageSchemas extends PSExtensionHandler {
 	 * Returns the HTML necessary for getting information about the
 	 * "connecting property" within the Page Schemas 'editschema' page.
 	 */
-	public static function getTemplateEditingHTML( $psTemplate) {
+	public static function getTemplateEditingHTML( $psTemplate ) {
 		// Only display this if the Semantic Internal Objects extension
 		// isn't displaying something similar.
 		if ( class_exists( 'SIOPageSchemas' ) ) {

--- a/includes/export/SMW_ExportController.php
+++ b/includes/export/SMW_ExportController.php
@@ -400,7 +400,7 @@ class SMWExportController {
 	 * @todo Consider dropping the $revisiondate filtering and all associated
 	 * functionality. Is anybody using this?
 	 */
-	public function printPages( $pages, $recursion = 1, $revisiondate = false  ) {
+	public function printPages( $pages, $recursion = 1, $revisiondate = false ) {
 		$mwServices = MediaWikiServices::getInstance();
 		$linkCache = $mwServices->getLinkCache();
 		$revisionStore = $mwServices->getRevisionStore();

--- a/includes/formatters/MessageFormatter.php
+++ b/includes/formatters/MessageFormatter.php
@@ -67,7 +67,7 @@ class MessageFormatter {
 	 *
 	 * @return MessageFormatter
 	 */
-	public static function newFromArray( Language $language, array $messages =  [] ) {
+	public static function newFromArray( Language $language, array $messages = [] ) {
 		$instance = new self( $language );
 		return $instance->addFromArray( $messages );
 	}

--- a/src/MediaWiki/Hooks.php
+++ b/src/MediaWiki/Hooks.php
@@ -688,7 +688,7 @@ class Hooks {
 		return true;
 	}
 
-	private function getETag( $parserCache, $page, $pOpts) {
+	private function getETag( $parserCache, $page, $pOpts ) {
 		if ( method_exists( $parserCache, 'makeParserOutputKey' ) ) {
 			// 1.36+
 			return 'W/"' . $parserCache->makeParserOutputKey( $page, $pOpts	) .

--- a/src/Services/importer.php
+++ b/src/Services/importer.php
@@ -69,7 +69,7 @@ return [
 	 *
 	 * @return callable
 	 */
-	'Importer' => function( $containerBuilder, ContentIterator $contentIterator  ) {
+	'Importer' => function( $containerBuilder, ContentIterator $contentIterator ) {
 		$containerBuilder->registerExpectedReturnType( 'Importer', '\SMW\Importer\Importer' );
 
 		$dispatchingContentCreator = new DispatchingContentCreator(

--- a/src/Tesa/tests/phpunit/Unit/StopwordAnalyzer/CdbStopwordAnalyzerTest.php
+++ b/src/Tesa/tests/phpunit/Unit/StopwordAnalyzer/CdbStopwordAnalyzerTest.php
@@ -60,7 +60,7 @@ class CdbStopwordAnalyzerTest extends TestCase {
 	/**
 	 * @dataProvider stopWordProvider
 	 */
-	public function testIsStopWord( $languageCode , $word, $expected ) {
+	public function testIsStopWord( $languageCode, $word, $expected ) {
 		$instane = new CdbStopwordAnalyzer(
 			CdbStopwordAnalyzer::getTargetByLanguage( $languageCode )
 		);

--- a/tests/phpunit/Benchmark/CliOutputFormatter.php
+++ b/tests/phpunit/Benchmark/CliOutputFormatter.php
@@ -32,7 +32,7 @@ class CliOutputFormatter {
 	 *
 	 * @param array $report
 	 */
-	public function format( array $report  ) {
+	public function format( array $report ) {
 		if ( $this->formatType === self::FORMAT_TREE ) {
 			return $this->doFormatAsTree( $report );
 		}

--- a/tests/phpunit/HashBuilderTest.php
+++ b/tests/phpunit/HashBuilderTest.php
@@ -26,7 +26,7 @@ class HashBuilderTest extends \PHPUnit_Framework_TestCase {
 	/**
 	 * @dataProvider segmentProvider
 	 */
-	public function testTitleRoundTrip( $namespace, $title, $interwiki , $fragment ) {
+	public function testTitleRoundTrip( $namespace, $title, $interwiki, $fragment ) {
 		$title = Title::makeTitle( $namespace, $title, $fragment, $interwiki );
 
 		$this->assertEquals(

--- a/tests/phpunit/IndicatorEntityExaminerIndicators/EntityExaminerCompositeIndicatorProviderTest.php
+++ b/tests/phpunit/IndicatorEntityExaminerIndicators/EntityExaminerCompositeIndicatorProviderTest.php
@@ -266,7 +266,7 @@ class EntityExaminerCompositeIndicatorProviderTest extends \PHPUnit_Framework_Te
 				return '';
 			}
 
-			public function hasIndicator( \SMW\DIWikiPage $subject, array $options) {
+			public function hasIndicator( \SMW\DIWikiPage $subject, array $options ) {
 				return false;
 			}
 

--- a/tests/phpunit/IndicatorEntityExaminerIndicators/EntityExaminerDeferrableCompositeIndicatorProviderTest.php
+++ b/tests/phpunit/IndicatorEntityExaminerIndicators/EntityExaminerDeferrableCompositeIndicatorProviderTest.php
@@ -250,7 +250,7 @@ class EntityExaminerDeferrableCompositeIndicatorProviderTest extends \PHPUnit_Fr
 				return '';
 			}
 
-			public function hasIndicator( \SMW\DIWikiPage $subject, array $options) {
+			public function hasIndicator( \SMW\DIWikiPage $subject, array $options ) {
 				return false;
 			}
 

--- a/tests/phpunit/Integration/SemanticMediaWikiProvidedHookInterfaceIntegrationTest.php
+++ b/tests/phpunit/Integration/SemanticMediaWikiProvidedHookInterfaceIntegrationTest.php
@@ -385,7 +385,7 @@ class SemanticMediaWikiProvidedHookInterfaceIntegrationTest extends \PHPUnit_Fra
 			->will( $this->returnValue( [] ) );
 
 		$reachedTheBeforeDeleteSubjectCompleteHook = false;
-		$this->mwHooksHandler->register( 'SMW::SQLStore::BeforeDeleteSubjectComplete', function() use ( &$reachedTheBeforeDeleteSubjectCompleteHook) {
+		$this->mwHooksHandler->register( 'SMW::SQLStore::BeforeDeleteSubjectComplete', function() use ( &$reachedTheBeforeDeleteSubjectCompleteHook ) {
 			$reachedTheBeforeDeleteSubjectCompleteHook = true;
 		} );
 

--- a/tests/phpunit/MediaWiki/IndicatorRegistryTest.php
+++ b/tests/phpunit/MediaWiki/IndicatorRegistryTest.php
@@ -124,7 +124,7 @@ class IndicatorRegistryTest extends \PHPUnit_Framework_TestCase {
 				return '';
 			}
 
-			public function hasIndicator( \SMW\DIWikiPage $subject, array $options) {
+			public function hasIndicator( \SMW\DIWikiPage $subject, array $options ) {
 				return false;
 			}
 
@@ -153,7 +153,7 @@ class IndicatorRegistryTest extends \PHPUnit_Framework_TestCase {
 				return '';
 			}
 
-			public function hasIndicator( \SMW\DIWikiPage $subject, array $options) {
+			public function hasIndicator( \SMW\DIWikiPage $subject, array $options ) {
 				return false;
 			}
 

--- a/tests/phpunit/MediaWiki/PageUpdaterTest.php
+++ b/tests/phpunit/MediaWiki/PageUpdaterTest.php
@@ -135,7 +135,7 @@ class PageUpdaterTest extends \PHPUnit_Framework_TestCase {
 	/**
 	 * @dataProvider purgeMethodProvider
 	 */
-	public function testPurgeWillNotWaitOnTransactionIdleForMissingConnection(  $purgeMethod, $titleMethod ) {
+	public function testPurgeWillNotWaitOnTransactionIdleForMissingConnection( $purgeMethod, $titleMethod ) {
 		$title = $this->getMockBuilder( '\Title' )
 			->disableOriginalConstructor()
 			->getMock();

--- a/tests/phpunit/ParserFunctions/SubobjectParserFunctionTest.php
+++ b/tests/phpunit/ParserFunctions/SubobjectParserFunctionTest.php
@@ -89,7 +89,7 @@ class SubobjectParserFunctionTest extends \PHPUnit_Framework_TestCase {
 	/**
 	 * @dataProvider firstElementDataProvider
 	 */
-	public function testFirstElementAsPropertyLabel( $isEnabled , array $parameters, array $expected ) {
+	public function testFirstElementAsPropertyLabel( $isEnabled, array $parameters, array $expected ) {
 		$parserOutput = new ParserOutput();
 		$title        = Title::newFromText( __METHOD__ );
 		$subobject    = new Subobject( $title );

--- a/tests/phpunit/includes/storage/StoreTest.php
+++ b/tests/phpunit/includes/storage/StoreTest.php
@@ -38,7 +38,7 @@ class StoreTest extends DatabaseTestCase {
 	/**
 	* @dataProvider getSemanticDataProvider
 	*/
-	public function testGetSemanticData( $titleText ,$filter = false) {
+	public function testGetSemanticData( $titleText, $filter = false ) {
 		$title = Title::newFromText( $titleText );
 		$subject = DIWikiPage::newFromTitle( $title );
 		$store = StoreFactory::getStore();


### PR DESCRIPTION
Clear and fix sniff **Squiz.Functions.FunctionDeclarationArgumentSpacing** reported by phpcs and improve code quality.
As a part of this PR we have cleared and fixed **5 subgroups** of Squiz.Functions.FunctionDeclarationArgumentSpacing like: 

- SpaceAfterEquals,
- SpacingAfterOpen,
- NoSpaceBeforeArg,
- SpaceBeforeComma,
- SpacingBeforeClose