### PR TITLE
Issue 5667 - fix sniffs MediaWiki.WhiteSpace.SpaceAfterClosure

### DIFF
--- a/.phpcs.xml
+++ b/.phpcs.xml
@@ -40,10 +40,8 @@
 		<exclude name="MediaWiki.Commenting.PropertyDocumentation.NotShortIntVar" />
 		<exclude name="MediaWiki.Commenting.MissingCovers.MissingCovers" />
 		<exclude name="PSR12.Properties.ConstantVisibility.NotFound" />
-		<exclude name="MediaWiki.WhiteSpace.SpaceAfterClosure.NoWhitespaceAfterClosure" />
 		<exclude name="Squiz.WhiteSpace.OperatorSpacing.NoSpaceAfter" />
 		<exclude name="Squiz.WhiteSpace.OperatorSpacing.NoSpaceBefore" />
-		<exclude name="MediaWiki.WhiteSpace.SpaceAfterClosure.NoWhitespaceAfterClosure" />
 		<exclude name="MediaWiki.WhiteSpace.SpaceBeforeSingleLineComment.NewLineComment" />
 		<exclude name="Generic.WhiteSpace.DisallowSpaceIndent.SpacesUsed" />
 		<exclude name="MediaWiki.WhiteSpace.MultipleEmptyLines.MultipleEmptyLines" />
@@ -135,7 +133,6 @@
 		<exclude name="MediaWiki.PHPUnit.SpecificAssertions.assertIsArray" />
 		<exclude name="Universal.WhiteSpace.CommaSpacing.NoSpaceAfterInFunctionDeclaration" />
 		<exclude name="MediaWiki.Commenting.DocComment.SyntaxAlignedDocClose" />
-		<exclude name="MediaWiki.WhiteSpace.SpaceAfterClosure.NoWhitespaceAfterArrow" />
 		<exclude name="PSR2.Classes.ClassDeclaration.SpaceBeforeName" />
 		<exclude name="MediaWiki.PHPUnit.MockBoilerplate.returnValueMap" />
 		<exclude name="Generic.Formatting.SpaceAfterNot.Incorrect" />

--- a/data/config/db-primary-keys.php
+++ b/data/config/db-primary-keys.php
@@ -93,7 +93,7 @@ class ConfigPreloadPrimaryKeyTableMutator {
 /**
  * @see https://github.com/SemanticMediaWiki/SemanticMediaWiki/blob/master/docs/examples/hook.sqlstore.installer.beforecreatetablescomplete.md
  */
-MediaWikiServices::getInstance()->getHookContainer()->register( 'SMW::SQLStore::Installer::BeforeCreateTablesComplete', function( array $tables, MessageReporter $messageReporter ) {
+MediaWikiServices::getInstance()->getHookContainer()->register( 'SMW::SQLStore::Installer::BeforeCreateTablesComplete', function ( array $tables, MessageReporter $messageReporter ) {
 	$cliMsgFormatter = new CliMsgFormatter();
 	$configPreloadPrimaryKeyTableMutator = new ConfigPreloadPrimaryKeyTableMutator();
 

--- a/includes/DefaultSettings.php
+++ b/includes/DefaultSettings.php
@@ -16,7 +16,7 @@ if ( !defined( 'MEDIAWIKI' ) ) {
   die( "This file is part of the Semantic MediaWiki extension. It is not a valid entry point.\n" );
 }
 
-return (function() {
+return (function () {
 	SemanticMediaWiki::setupDefines();
 	$smwgIP = dirname( __DIR__ ) . '/';
 	return [

--- a/includes/SemanticData.php
+++ b/includes/SemanticData.php
@@ -771,7 +771,7 @@ class SemanticData implements JsonUnserializable {
 				if ( isset( $this->sequenceMap[$key] ) && SequenceMap::canMap( $property ) ) {
 					$sequenceMap = array_flip( $this->sequenceMap[$key] );
 
-					usort ( $this->mPropVals[$key], function( $a, $b ) use( $sequenceMap ) {
+					usort ( $this->mPropVals[$key], function ( $a, $b ) use( $sequenceMap ) {
 						$pos_a = $sequenceMap[md5( $a->getHash() )];
 						$pos_b = $sequenceMap[md5( $b->getHash() )];
 
@@ -890,12 +890,12 @@ class SemanticData implements JsonUnserializable {
 		# in the future.
 		$json = [
 			'stubObject' => $this->stubObject,
-			'mPropVals' => array_map( function( $x ) {
-					return array_map( function( $y ) {
+			'mPropVals' => array_map( function ( $x ) {
+					return array_map( function ( $y ) {
 						return $y->jsonSerialize();
 					}, $x );
 			}, $this->mPropVals ),
-			'mProperties' => array_map( function( $x ) {
+			'mProperties' => array_map( function ( $x ) {
 					return $x->jsonSerialize();
 			}, $this->mProperties ),
 			'mHasVisibleProps' => $this->mHasVisibleProps,
@@ -947,7 +947,7 @@ class SemanticData implements JsonUnserializable {
 			$json['mNoDuplicates']
 		);
 		$obj->stubObject = $json['stubObject'];
-		$obj->mPropVals = array_map( static function( $x ) use( $unserializer ) {
+		$obj->mPropVals = array_map( static function ( $x ) use( $unserializer ) {
 			return self::maybeUnserializeArray( $unserializer, $x );
 		}, $json['mPropVals'] );
 		$obj->mProperties = self::maybeUnserializeArray($unserializer, $json['mProperties'] );

--- a/src/Constraint/Constraints/UniqueValueConstraint.php
+++ b/src/Constraint/Constraints/UniqueValueConstraint.php
@@ -112,7 +112,7 @@ class UniqueValueConstraint implements Constraint {
 		// Exclude the current page from the result match to check whether another
 		// page matches the condition and if so then the value can no longer be
 		// assigned and is not unique
-		$requestOptions->addExtraCondition( function( $store, $query, $alias ) use( $contextPage ) {
+		$requestOptions->addExtraCondition( function ( $store, $query, $alias ) use( $contextPage ) {
 				return $query->neq( "$alias.s_id", $store->getObjectIds()->getId( $contextPage ) );
 			}
 		);

--- a/src/DataModel/SubSemanticData.php
+++ b/src/DataModel/SubSemanticData.php
@@ -277,7 +277,7 @@ class SubSemanticData implements JsonUnserializable {
 		return [
 			'noDuplicates' => $this->noDuplicates,
 			'subject' => $this->subject->jsonSerialize(),
-			'subSemanticData' => array_map( function( $x ) {
+			'subSemanticData' => array_map( function ( $x ) {
 					return $x->jsonSerialize();
 			}, $this->subSemanticData ),
 			'subContainerMaxDepth' => $this->subContainerMaxDepth,

--- a/src/Elastic/Indexer/Attachment/FileAttachment.php
+++ b/src/Elastic/Indexer/Attachment/FileAttachment.php
@@ -165,7 +165,7 @@ class FileAttachment {
 			$attachmentAnnotator->getContainer()
 		);
 
-		$callableUpdate = ApplicationFactory::getInstance()->newDeferredTransactionalCallableUpdate( function() use( $semanticData, $attachmentAnnotator ) {
+		$callableUpdate = ApplicationFactory::getInstance()->newDeferredTransactionalCallableUpdate( function () use( $semanticData, $attachmentAnnotator ) {
 			// Update the SQLStore with the annotated information which will NOT
 			// trigger another ES index update BUT ...
 			$this->store->updateData( $semanticData );

--- a/src/Elastic/Indexer/Document.php
+++ b/src/Elastic/Indexer/Document.php
@@ -185,7 +185,7 @@ class Document implements JsonSerializable {
 			'type' => $this->type,
 			'data' => $this->data,
 			'sub_docs' => array_map(
-				function( $v ) { return $v->toArray(); },
+				function ( $v ) { return $v->toArray(); },
 				$this->subDocuments
 			)
 		];

--- a/src/Importer/ContentCreators/TextContentCreator.php
+++ b/src/Importer/ContentCreators/TextContentCreator.php
@@ -137,7 +137,7 @@ class TextContentCreator implements ContentCreator {
 		// Avoid a possible "Notice: WikiPage::doEditContent: Transaction already
 		// in progress (from DatabaseUpdater::doUpdates), performing implicit
 		// commit ..."
-		$this->connection->onTransactionCommitOrIdle( function() use ( $page, $title, $importContents, $action ) {
+		$this->connection->onTransactionCommitOrIdle( function () use ( $page, $title, $importContents, $action ) {
 			$this->doCreateContent( $page, $title, $importContents, $action );
 		} );
 	}

--- a/src/Listener/EventListener/EventListenerRegistry.php
+++ b/src/Listener/EventListener/EventListenerRegistry.php
@@ -99,13 +99,13 @@ class EventListenerRegistry implements EventListenerCollection {
 		$this->logger = ApplicationFactory::getInstance()->getMediaWikiLogger();
 
 		$this->eventListenerCollection->registerCallback(
-			'exporter.reset', function() {
+			'exporter.reset', function () {
 				Exporter::getInstance()->clear();
 			}
 		);
 
 		$this->eventListenerCollection->registerCallback(
-			'query.comparator.reset', function() {
+			'query.comparator.reset', function () {
 				QueryComparator::getInstance()->clear();
 			}
 		);

--- a/src/MediaWiki/Connection/Sequence.php
+++ b/src/MediaWiki/Connection/Sequence.php
@@ -79,7 +79,7 @@ class Sequence {
 
 		$sequence = self::makeSequence( $table, $field );
 
-		$this->connection->onTransactionCommitOrIdle( function() use( $sequence, $seq_num ) {
+		$this->connection->onTransactionCommitOrIdle( function () use( $sequence, $seq_num ) {
 			$this->connection->query( "ALTER SEQUENCE {$sequence} RESTART WITH {$seq_num}", __METHOD__ );
 		} );
 

--- a/src/MediaWiki/Deferred/TransactionalCallableUpdate.php
+++ b/src/MediaWiki/Deferred/TransactionalCallableUpdate.php
@@ -198,7 +198,7 @@ class TransactionalCallableUpdate extends CallableUpdate {
 				[ 'method' => __METHOD__, 'role' => 'developer', 'origin' => $this->getOrigin() ]
 			);
 
-			return $this->connection->onTransactionCommitOrIdle( function() use( $update ) {
+			return $this->connection->onTransactionCommitOrIdle( function () use( $update ) {
 				$update->onTransactionIdle = false;
 				parent::registerUpdate( $update );
 			} );
@@ -214,7 +214,7 @@ class TransactionalCallableUpdate extends CallableUpdate {
 	}
 
 	private function runOnTransactionIdle() {
-		$this->connection->onTransactionCommitOrIdle( function() {
+		$this->connection->onTransactionCommitOrIdle( function () {
 			$this->logger->info(
 				[ 'DeferrableUpdate', 'Transactional', 'Update: {origin} (onTransactionIdle)' ],
 				[ 'method' => __METHOD__, 'role' => 'developer', 'origin' => $this->getOrigin() ]

--- a/src/MediaWiki/Hooks.php
+++ b/src/MediaWiki/Hooks.php
@@ -159,7 +159,7 @@ class Hooks {
 	 * @param array &$vars
 	 */
 	public static function registerExtensionCheck( array &$vars ) {
-		$vars['wgHooks']['BeforePageDisplay']['smw-extension-check'] = function( $outputPage ) {
+		$vars['wgHooks']['BeforePageDisplay']['smw-extension-check'] = function ( $outputPage ) {
 			$beforePageDisplay = new BeforePageDisplay();
 
 			$beforePageDisplay->setOptions(

--- a/src/MediaWiki/Hooks/ArticleDelete.php
+++ b/src/MediaWiki/Hooks/ArticleDelete.php
@@ -60,7 +60,7 @@ class ArticleDelete implements HookListener {
 	 * @return true
 	 */
 	public function process( Title $title ) {
-		$deferredCallableUpdate = ApplicationFactory::getInstance()->newDeferredCallableUpdate( function() use( $title ) {
+		$deferredCallableUpdate = ApplicationFactory::getInstance()->newDeferredCallableUpdate( function () use( $title ) {
 			$this->doDelete( $title );
 		} );
 

--- a/src/MediaWiki/Page/ListBuilder/ItemListBuilder.php
+++ b/src/MediaWiki/Page/ListBuilder/ItemListBuilder.php
@@ -190,7 +190,7 @@ class ItemListBuilder {
 	}
 
 	private function getLastItemFormatter( $property, $dataItem ) {
-		return function() use ( $property, $dataItem ) {
+		return function () use ( $property, $dataItem ) {
 			return \Html::element(
 				'a',
 				[

--- a/src/MediaWiki/PageUpdater.php
+++ b/src/MediaWiki/PageUpdater.php
@@ -150,7 +150,7 @@ class PageUpdater implements DeferrableUpdate {
 	 */
 	public function doPurgeParserCacheAsPool() {
 		if ( $this->connection !== null ) {
-			$this->connection->onTransactionCommitOrIdle( function() {
+			$this->connection->onTransactionCommitOrIdle( function () {
 				 $this->doPoolPurge();
 			} );
 		} else {
@@ -185,7 +185,7 @@ class PageUpdater implements DeferrableUpdate {
 			return $this->log( __METHOD__ . ' it is not possible to push updates as DeferredTransactionalUpdate)' );
 		}
 
-		$this->transactionalCallableUpdate->setCallback( function(){
+		$this->transactionalCallableUpdate->setCallback( function (){
 			$this->doUpdate();
 		} );
 

--- a/src/MediaWiki/Renderer/HtmlFormRenderer.php
+++ b/src/MediaWiki/Renderer/HtmlFormRenderer.php
@@ -430,7 +430,7 @@ class HtmlFormRenderer {
 	public function addPaging( $limit, $offset, $count, $messageCount = null ) {
 		$title = $this->title;
 
-		$this->content[] = function( $instance ) use ( $title, $limit, $offset, $count, $messageCount ) {
+		$this->content[] = function ( $instance ) use ( $title, $limit, $offset, $count, $messageCount ) {
 			if ( $messageCount === null ) {
 				$messageCount = ( $count > $limit ? $count - 1 : $count );
 			}

--- a/src/MediaWiki/Specials/Admin/Alerts/DeprecationNoticeTaskHandler.php
+++ b/src/MediaWiki/Specials/Admin/Alerts/DeprecationNoticeTaskHandler.php
@@ -55,7 +55,7 @@ class DeprecationNoticeTaskHandler extends TaskHandler {
 		$html = '';
 
 		// Push `smw` to the top
-		uksort( $this->deprecationNoticeList, function( $a, $b ) {
+		uksort( $this->deprecationNoticeList, function ( $a, $b ) {
 			return $b === 'smw';
 		} );
 

--- a/src/MediaWiki/Specials/Ask/FormatListWidget.php
+++ b/src/MediaWiki/Specials/Ask/FormatListWidget.php
@@ -106,7 +106,7 @@ class FormatListWidget {
 			}
 		}
 
-		usort( $formats, function( $x, $y ) {
+		usort( $formats, function ( $x, $y ) {
 			return strcasecmp( $x['name'] , $y['name'] );
 		} );
 

--- a/src/MediaWiki/Specials/Ask/ParametersProcessor.php
+++ b/src/MediaWiki/Specials/Ask/ParametersProcessor.php
@@ -269,7 +269,7 @@ class ParametersProcessor {
 	private static function replace( $source, $target, $value ) {
 		return preg_replace_callback(
 			'/\[\[([^\[\]]*)\]\]/xu',
-			function( array $matches ) use ( $source, $target ) {
+			function ( array $matches ) use ( $source, $target ) {
 				return str_replace( [ $source ], [ $target ], $matches[0] );
 			},
 			$value

--- a/src/MediaWiki/Specials/Browse/HtmlBuilder.php
+++ b/src/MediaWiki/Specials/Browse/HtmlBuilder.php
@@ -527,7 +527,7 @@ class HtmlBuilder {
 
 		// Sort by label instead of the key which may start with `_` or `__`
 		// and thereby distorts the lexicographical order
-		usort ( $properties, function( $a, $b ) {
+		usort ( $properties, function ( $a, $b ) {
 			return strnatcmp( $a->getLabel(), $b->getLabel() );
 		} );
 

--- a/src/MediaWiki/Specials/SpecialAsk.php
+++ b/src/MediaWiki/Specials/SpecialAsk.php
@@ -375,7 +375,7 @@ class SpecialAsk extends SpecialPage {
 
 		$htmlForm->setCallbacks(
 			[
-				'code_handler' => function() {
+				'code_handler' => function () {
 					return $this->print_code();
 				}
 			]

--- a/src/Parser/LinksEncoder.php
+++ b/src/Parser/LinksEncoder.php
@@ -90,7 +90,7 @@ class LinksEncoder {
 	public static function obfuscateAnnotation( $text ) {
 		return preg_replace_callback(
 			LinksProcessor::getRegexpPattern( false ),
-			function( array $matches ) {
+			function ( array $matches ) {
 				return str_replace( '[', '&#91;', $matches[0] );
 			},
 			self::decodeSquareBracket( $text )

--- a/src/ParserFunctionFactory.php
+++ b/src/ParserFunctionFactory.php
@@ -377,7 +377,7 @@ class ParserFunctionFactory {
 	 * @return array
 	 */
 	public function getAskParserFunctionDefinition() {
-		$askParserFunctionDefinition = function( $parser ) {
+		$askParserFunctionDefinition = function ( $parser ) {
 			$applicationFactory = ApplicationFactory::getInstance();
 			$settings = $applicationFactory->getSettings();
 
@@ -401,7 +401,7 @@ class ParserFunctionFactory {
 	 * @return array
 	 */
 	public function getShowParserFunctionDefinition() {
-		$showParserFunctionDefinition = function( $parser ) {
+		$showParserFunctionDefinition = function ( $parser ) {
 			$applicationFactory = ApplicationFactory::getInstance();
 			$settings = $applicationFactory->getSettings();
 
@@ -425,7 +425,7 @@ class ParserFunctionFactory {
 	 * @return array
 	 */
 	public function getSubobjectParserFunctionDefinition() {
-		$subobjectParserFunctionDefinition = function( $parser ) {
+		$subobjectParserFunctionDefinition = function ( $parser ) {
 			$subobjectParserFunction = $this->newSubobjectParserFunction(
 				$parser
 			);
@@ -444,7 +444,7 @@ class ParserFunctionFactory {
 	 * @return array
 	 */
 	public function getSetRecurringEventParserFunctionDefinition() {
-		$recurringEventsParserFunctionDefinition = function( $parser ) {
+		$recurringEventsParserFunctionDefinition = function ( $parser ) {
 			$recurringEventsParserFunction = $this->newRecurringEventsParserFunction(
 				$parser
 			);
@@ -463,7 +463,7 @@ class ParserFunctionFactory {
 	 * @return array
 	 */
 	public function getSetParserFunctionDefinition() {
-		$setParserFunctionDefinition = function( $parser ) {
+		$setParserFunctionDefinition = function ( $parser ) {
 			$setParserFunction = $this->newSetParserFunction(
 				$parser
 			);
@@ -482,7 +482,7 @@ class ParserFunctionFactory {
 	 * @return array
 	 */
 	public function getConceptParserFunctionDefinition() {
-		$conceptParserFunctionDefinition = function( $parser ) {
+		$conceptParserFunctionDefinition = function ( $parser ) {
 			$conceptParserFunction = $this->newConceptParserFunction(
 				$parser
 			);
@@ -499,7 +499,7 @@ class ParserFunctionFactory {
 	 * @return array
 	 */
 	public function getDeclareParserFunctionDefinition() {
-		$declareParserFunctionDefinition = function( $parser, $frame, $args ) {
+		$declareParserFunctionDefinition = function ( $parser, $frame, $args ) {
 			$declareParserFunction = $this->newDeclareParserFunction(
 				$parser
 			);

--- a/src/ParserFunctions/InfoParserFunction.php
+++ b/src/ParserFunctions/InfoParserFunction.php
@@ -53,7 +53,7 @@ class InfoParserFunction implements HookHandler {
 		if ( strpos( $message, 'smw-highlighter' ) !== '' ) {
 			$message = preg_replace_callback(
 					"/" . "<span class=\"smw-highlighter\"(.*)?>(.*)?<\/span>" . "/m",
-					function( $matches ) {
+					function ( $matches ) {
 						return strip_tags( $matches[0] );
 					},
 					$message

--- a/src/ParserParameterProcessor.php
+++ b/src/ParserParameterProcessor.php
@@ -314,7 +314,7 @@ class ParserParameterProcessor {
 			return $results;
 		}
 
-		array_walk( $params, function( &$value, $key ) {
+		array_walk( $params, function ( &$value, $key ) {
 			if ( $value === '' ) {
 				$value = [];
 			}

--- a/src/Property/SpecificationLookup.php
+++ b/src/Property/SpecificationLookup.php
@@ -748,7 +748,7 @@ class SpecificationLookup {
 	 * @return DataValue|null
 	 */
 	private function tryOutFalldownAndInverse( $monolingualTextLookup, $subject, $property, &$languageCode ) {
-		$getDataValue = static function( $value ) use ( $monolingualTextLookup, $subject, $property, &$languageCode ) {
+		$getDataValue = static function ( $value ) use ( $monolingualTextLookup, $subject, $property, &$languageCode ) {
 			 $dataValue = $monolingualTextLookup->newDataValue(
 				$subject,
 				$property,

--- a/src/Query/Cache/ResultCache.php
+++ b/src/Query/Cache/ResultCache.php
@@ -395,7 +395,7 @@ class ResultCache implements QueryEngine, LoggerAwareInterface {
 			Timer::getElapsedTime( __CLASS__, 5 )
 		);
 
-		$callback = function() use( $queryResult, $queryId, $container, $query ) {
+		$callback = function () use( $queryResult, $queryId, $container, $query ) {
 			$this->doCacheQueryResult( $queryResult, $queryId, $container, $query );
 		};
 

--- a/src/Query/Processor/ParamListProcessor.php
+++ b/src/Query/Processor/ParamListProcessor.php
@@ -186,7 +186,7 @@ class ParamListProcessor {
 		// request that contains `-3D` string
 		return preg_replace_callback(
 			'/\[\[([^\[\]]*)\]\]/xu',
-			function( array $matches ) {
+			function ( array $matches ) {
 				return str_replace( [ '=' ], [ '0x003D' ], $matches[0] );
 			},
 			$param

--- a/src/Query/RemoteRequest.php
+++ b/src/Query/RemoteRequest.php
@@ -140,7 +140,7 @@ class RemoteRequest implements QueryEngine {
 		}
 
 		// Add an information note depending on the context before the actual output
-		$callback = function( $result, array $options ) use( $isFromCache, $isDisabled, $source ) {
+		$callback = function ( $result, array $options ) use( $isFromCache, $isDisabled, $source ) {
 			$options['source'] = $source;
 			$options['is.cached'] = $isFromCache;
 			$options['is.disabled'] = $isDisabled;

--- a/src/Query/Result/ItemFetcher.php
+++ b/src/Query/Result/ItemFetcher.php
@@ -200,7 +200,7 @@ class ItemFetcher {
 			unset( $pv );
 		}
 
-		array_walk( $propertyValues, function( &$dataItem ) {
+		array_walk( $propertyValues, function ( &$dataItem ) {
 			$dataItem = $this->highlightTokens( $dataItem );
 		} );
 
@@ -232,7 +232,7 @@ class ItemFetcher {
 			unset( $pv );
 		}
 
-		array_walk( $propertyValues, function( &$dataItem ) {
+		array_walk( $propertyValues, function ( &$dataItem ) {
 			$dataItem = $this->highlightTokens( $dataItem );
 		} );
 

--- a/src/Query/ScoreSet.php
+++ b/src/Query/ScoreSet.php
@@ -109,7 +109,7 @@ class ScoreSet {
 			return;
 		}
 
-		usort( $this->scores, function( $a, $b ) {
+		usort( $this->scores, function ( $a, $b ) {
 			if ( $a[1] == $b[1] ) {
 				return 0;
 			}

--- a/src/SQLStore/EntityStore/SubobjectListFinder.php
+++ b/src/SQLStore/EntityStore/SubobjectListFinder.php
@@ -81,7 +81,7 @@ class SubobjectListFinder {
 	 * @return MappingIterator
 	 */
 	private function newMappingIterator( DIWikiPage $subject ) {
-		$callback = function( $row ) use ( $subject ) {
+		$callback = function ( $row ) use ( $subject ) {
 			// #1955
 			if ( $subject->getNamespace() === SMW_NS_PROPERTY ) {
 				$property = new DIProperty( $subject->getDBkey() );

--- a/src/SQLStore/Lookup/EntityUniquenessLookup.php
+++ b/src/SQLStore/Lookup/EntityUniquenessLookup.php
@@ -101,7 +101,7 @@ class EntityUniquenessLookup {
 
 		$result = $this->iteratorFactory->newMappingIterator(
 			$this->iteratorFactory->newResultIterator( $res ),
-			function( $row ) {
+			function ( $row ) {
 				return $this->store->getObjectIds()->getDataItemById( $row->s_id );
 			}
 		);

--- a/src/SQLStore/Lookup/MissingRedirectLookup.php
+++ b/src/SQLStore/Lookup/MissingRedirectLookup.php
@@ -59,7 +59,7 @@ class MissingRedirectLookup {
 	 * @return Iterator/array
 	 */
 	public function findMissingRedirects() {
-		$namespaces = array_keys( array_filter( $this->namespaces, function( $v ) {
+		$namespaces = array_keys( array_filter( $this->namespaces, function ( $v ) {
 			return $v; }
 		) );
 

--- a/src/SQLStore/PropertyTableIdReferenceDisposer.php
+++ b/src/SQLStore/PropertyTableIdReferenceDisposer.php
@@ -213,7 +213,7 @@ class PropertyTableIdReferenceDisposer {
 	 */
 	public function cleanUpTableEntriesById( $id ) {
 		if ( $this->onTransactionIdle ) {
-			return $this->connection->onTransactionCommitOrIdle( function() use ( $id ) {
+			return $this->connection->onTransactionCommitOrIdle( function () use ( $id ) {
 				$this->cleanUpReferencesById( $id );
 			} );
 		} else {

--- a/src/SQLStore/QueryDependency/QueryDependencyLinksStore.php
+++ b/src/SQLStore/QueryDependency/QueryDependencyLinksStore.php
@@ -361,7 +361,7 @@ class QueryDependencyLinksStore {
 		}
 
 		// Executed as DeferredTransactionalUpdate
-		$callback = function() use( $queryResult, $subject, $sid, $hash ) {
+		$callback = function () use( $queryResult, $subject, $sid, $hash ) {
 			$this->doUpdate( $queryResult, $subject, $sid, $hash );
 		};
 

--- a/src/SQLStore/QueryDependency/QueryLinksTableDisposer.php
+++ b/src/SQLStore/QueryDependency/QueryLinksTableDisposer.php
@@ -129,7 +129,7 @@ class QueryLinksTableDisposer {
 		}
 
 		if ( $this->onTransactionIdle ) {
-			return $this->connection->onTransactionCommitOrIdle( function() use ( $id, $fname ) {
+			return $this->connection->onTransactionCommitOrIdle( function () use ( $id, $fname ) {
 				$this->connection->delete(
 					SQLStore::QUERY_LINKS_TABLE,
 					[

--- a/src/SQLStore/SQLStoreFactory.php
+++ b/src/SQLStore/SQLStoreFactory.php
@@ -321,7 +321,7 @@ class SQLStoreFactory {
 	 * @return DeferredCallableUpdate
 	 */
 	public function newDeferredCallableCachedListLookupUpdate() {
-		$deferredTransactionalUpdate = ApplicationFactory::getInstance()->newDeferredTransactionalCallableUpdate( function() {
+		$deferredTransactionalUpdate = ApplicationFactory::getInstance()->newDeferredTransactionalCallableUpdate( function () {
 			$this->newPropertyUsageCachedListLookup()->deleteCache();
 			$this->newUnusedPropertyCachedListLookup()->deleteCache();
 			$this->newUndeclaredPropertyCachedListLookup()->deleteCache();
@@ -1173,7 +1173,7 @@ class SQLStoreFactory {
 					'_service' => [ $this, 'newPropertyTypeFinder' ],
 					'_type'    => PropertyTypeFinder::class
 				],
-				'PropertyTableIdReferenceFinder' => function() {
+				'PropertyTableIdReferenceFinder' => function () {
 					static $singleton;
 					return $singleton = $singleton === null ? $this->newPropertyTableIdReferenceFinder() : $singleton;
 				},

--- a/src/Schema/Filters/CompositeFilter.php
+++ b/src/Schema/Filters/CompositeFilter.php
@@ -85,7 +85,7 @@ class CompositeFilter implements SchemaFilter {
 		$order = strtolower( $order );
 
 		if ( $type === self:: SORT_FILTER_SCORE ) {
-			usort( $this->matches, function( $a, $b ) use ( $order ) {
+			usort( $this->matches, function ( $a, $b ) use ( $order ) {
 				if ( $order === 'desc' ) {
 					return $b->filterScore <=> $a->filterScore;
 				}

--- a/src/Services/SharedServicesContainer.php
+++ b/src/Services/SharedServicesContainer.php
@@ -149,7 +149,7 @@ class SharedServicesContainer implements CallbackContainer {
 	}
 
 	private function registerCallbackHandlers( ContainerBuilder $containerBuilder ) {
-		$containerBuilder->registerCallback( 'Settings', function( $containerBuilder ) {
+		$containerBuilder->registerCallback( 'Settings', function ( $containerBuilder ) {
 			$containerBuilder->registerExpectedReturnType( 'Settings', '\SMW\Settings' );
 
 			$settings = new Settings();
@@ -168,7 +168,7 @@ class SharedServicesContainer implements CallbackContainer {
 		 *
 		 * @return callable
 		 */
-		$containerBuilder->registerCallback( 'ConnectionManager', function( $containerBuilder ) {
+		$containerBuilder->registerCallback( 'ConnectionManager', function ( $containerBuilder ) {
 			$containerBuilder->registerExpectedReturnType( 'ConnectionManager', ConnectionManager::class );
 			return new ConnectionManager();
 		} );
@@ -178,17 +178,17 @@ class SharedServicesContainer implements CallbackContainer {
 		 *
 		 * @return callable
 		 */
-		$containerBuilder->registerCallback( 'SetupFile', function( $containerBuilder ) {
+		$containerBuilder->registerCallback( 'SetupFile', function ( $containerBuilder ) {
 			$containerBuilder->registerExpectedReturnType( 'SetupFile', SetupFile::class );
 			return new SetupFile();
 		} );
 
-		$containerBuilder->registerCallback( 'Cache', function( $containerBuilder, $cacheType = null ) {
+		$containerBuilder->registerCallback( 'Cache', function ( $containerBuilder, $cacheType = null ) {
 			$containerBuilder->registerExpectedReturnType( 'Cache', '\Onoi\Cache\Cache' );
 			return $containerBuilder->create( 'CacheFactory' )->newMediaWikiCompositeCache( $cacheType );
 		} );
 
-		$containerBuilder->registerCallback( 'NamespaceExaminer', function() use ( $containerBuilder ) {
+		$containerBuilder->registerCallback( 'NamespaceExaminer', function () use ( $containerBuilder ) {
 			$settings = $containerBuilder->singleton( 'Settings' );
 			$namespaceInfo = $containerBuilder->singleton( 'NamespaceInfo' );
 
@@ -203,7 +203,7 @@ class SharedServicesContainer implements CallbackContainer {
 			return $namespaceExaminer;
 		} );
 
-		$containerBuilder->registerCallback( 'ParserData', function( $containerBuilder, \Title $title, \ParserOutput $parserOutput ) {
+		$containerBuilder->registerCallback( 'ParserData', function ( $containerBuilder, \Title $title, \ParserOutput $parserOutput ) {
 			$containerBuilder->registerExpectedReturnType( 'ParserData', ParserData::class );
 
 			$parserData = new ParserData( $title, $parserOutput );
@@ -215,17 +215,17 @@ class SharedServicesContainer implements CallbackContainer {
 			return $parserData;
 		} );
 
-		$containerBuilder->registerCallback( 'LinksProcessor', function( $containerBuilder ) {
+		$containerBuilder->registerCallback( 'LinksProcessor', function ( $containerBuilder ) {
 			$containerBuilder->registerExpectedReturnType( 'LinksProcessor', '\SMW\Parser\LinksProcessor' );
 			return new LinksProcessor();
 		} );
 
-		$containerBuilder->registerCallback( 'MessageFormatter', function( $containerBuilder, \Language $language ) {
+		$containerBuilder->registerCallback( 'MessageFormatter', function ( $containerBuilder, \Language $language ) {
 			$containerBuilder->registerExpectedReturnType( 'MessageFormatter', '\SMW\MessageFormatter' );
 			return new MessageFormatter( $language );
 		} );
 
-		$containerBuilder->registerCallback( 'MediaWikiNsContentReader', function() use ( $containerBuilder ) {
+		$containerBuilder->registerCallback( 'MediaWikiNsContentReader', function () use ( $containerBuilder ) {
 			$containerBuilder->registerExpectedReturnType( 'MediaWikiNsContentReader', '\SMW\MediaWiki\MediaWikiNsContentReader' );
 
 			$mediaWikiNsContentReader = new MediaWikiNsContentReader();
@@ -237,17 +237,17 @@ class SharedServicesContainer implements CallbackContainer {
 			return $mediaWikiNsContentReader;
 		} );
 
-		$containerBuilder->registerCallback( 'PageCreator', function( $containerBuilder ) {
+		$containerBuilder->registerCallback( 'PageCreator', function ( $containerBuilder ) {
 			$containerBuilder->registerExpectedReturnType( 'PageCreator', '\SMW\MediaWiki\PageCreator' );
 			return new PageCreator();
 		} );
 
-		$containerBuilder->registerCallback( 'PageUpdater', function( $containerBuilder, $connection, TransactionalCallableUpdate $transactionalCallableUpdate = null ) {
+		$containerBuilder->registerCallback( 'PageUpdater', function ( $containerBuilder, $connection, TransactionalCallableUpdate $transactionalCallableUpdate = null ) {
 			$containerBuilder->registerExpectedReturnType( 'PageUpdater', '\SMW\MediaWiki\PageUpdater' );
 			return new PageUpdater( $connection, $transactionalCallableUpdate );
 		} );
 
-		$containerBuilder->registerCallback( 'EntityCache', function( $containerBuilder ) {
+		$containerBuilder->registerCallback( 'EntityCache', function ( $containerBuilder ) {
 			$containerBuilder->registerExpectedReturnType( 'EntityCache', '\SMW\EntityCache' );
 			return new EntityCache( $containerBuilder->singleton( 'Cache', $GLOBALS['smwgMainCacheType'] ) );
 		} );
@@ -257,7 +257,7 @@ class SharedServicesContainer implements CallbackContainer {
 		 *
 		 * @return callable
 		 */
-		$containerBuilder->registerCallback( 'JobQueue', function( $containerBuilder ) {
+		$containerBuilder->registerCallback( 'JobQueue', function ( $containerBuilder ) {
 			$containerBuilder->registerExpectedReturnType(
 				'JobQueue',
 				'\SMW\MediaWiki\JobQueue'
@@ -268,22 +268,22 @@ class SharedServicesContainer implements CallbackContainer {
 			);
 		} );
 
-		$containerBuilder->registerCallback( 'ManualEntryLogger', function( $containerBuilder ) {
+		$containerBuilder->registerCallback( 'ManualEntryLogger', function ( $containerBuilder ) {
 			$containerBuilder->registerExpectedReturnType( 'ManualEntryLogger', '\SMW\MediaWiki\ManualEntryLogger' );
 			return new ManualEntryLogger();
 		} );
 
-		$containerBuilder->registerCallback( 'TitleFactory', function( $containerBuilder ) {
+		$containerBuilder->registerCallback( 'TitleFactory', function ( $containerBuilder ) {
 			$containerBuilder->registerExpectedReturnType( 'TitleFactory', '\SMW\MediaWiki\TitleFactory' );
 			return new TitleFactory();
 		} );
 
-		$containerBuilder->registerCallback( 'HookDispatcher', function( $containerBuilder ) {
+		$containerBuilder->registerCallback( 'HookDispatcher', function ( $containerBuilder ) {
 			$containerBuilder->registerExpectedReturnType( 'HookDispatcher', HookDispatcher::class );
 			return new HookDispatcher();
 		} );
 
-		$containerBuilder->registerCallback( 'RevisionGuard', function( $containerBuilder ) {
+		$containerBuilder->registerCallback( 'RevisionGuard', function ( $containerBuilder ) {
 			$containerBuilder->registerExpectedReturnType( 'RevisionGuard', RevisionGuard::class );
 
 			$revisionGuard = new RevisionGuard(
@@ -297,7 +297,7 @@ class SharedServicesContainer implements CallbackContainer {
 			return $revisionGuard;
 		} );
 
-		$containerBuilder->registerCallback( 'ContentParser', function( $containerBuilder, \Title $title ) {
+		$containerBuilder->registerCallback( 'ContentParser', function ( $containerBuilder, \Title $title ) {
 			$containerBuilder->registerExpectedReturnType( 'ContentParser', '\SMW\ContentParser' );
 
 			$contentParser = new ContentParser(
@@ -312,14 +312,14 @@ class SharedServicesContainer implements CallbackContainer {
 			return $contentParser;
 		} );
 
-		$containerBuilder->registerCallback( 'DeferredCallableUpdate', function( $containerBuilder, callable $callback = null ) {
+		$containerBuilder->registerCallback( 'DeferredCallableUpdate', function ( $containerBuilder, callable $callback = null ) {
 			$containerBuilder->registerExpectedReturnType( 'DeferredCallableUpdate', '\SMW\MediaWiki\Deferred\CallableUpdate' );
 			$containerBuilder->registerAlias( 'CallableUpdate', CallableUpdate::class );
 
 			return new CallableUpdate( $callback );
 		} );
 
-		$containerBuilder->registerCallback( 'DeferredTransactionalCallableUpdate', function( $containerBuilder, callable $callback = null, Database $connection = null ) {
+		$containerBuilder->registerCallback( 'DeferredTransactionalCallableUpdate', function ( $containerBuilder, callable $callback = null, Database $connection = null ) {
 			$containerBuilder->registerExpectedReturnType( 'DeferredTransactionalUpdate', '\SMW\MediaWiki\Deferred\TransactionalCallableUpdate' );
 			$containerBuilder->registerAlias( 'DeferredTransactionalUpdate', TransactionalCallableUpdate::class );
 
@@ -329,7 +329,7 @@ class SharedServicesContainer implements CallbackContainer {
 		/**
 		 * @var InMemoryPoolCache
 		 */
-		$containerBuilder->registerCallback( 'InMemoryPoolCache', function( $containerBuilder ) {
+		$containerBuilder->registerCallback( 'InMemoryPoolCache', function ( $containerBuilder ) {
 			$containerBuilder->registerExpectedReturnType( 'InMemoryPoolCache', '\SMW\InMemoryPoolCache' );
 			return InMemoryPoolCache::getInstance();
 		} );
@@ -337,7 +337,7 @@ class SharedServicesContainer implements CallbackContainer {
 		/**
 		 * @var AnnotatorFactory
 		 */
-		$containerBuilder->registerCallback( 'PropertyAnnotatorFactory', function( $containerBuilder ) {
+		$containerBuilder->registerCallback( 'PropertyAnnotatorFactory', function ( $containerBuilder ) {
 			$containerBuilder->registerExpectedReturnType( 'PropertyAnnotatorFactory', AnnotatorFactory::class );
 			return new AnnotatorFactory();
 		} );
@@ -347,7 +347,7 @@ class SharedServicesContainer implements CallbackContainer {
 		 */
 		$containerBuilder->registerAlias( 'ConnectionProvider', 'DBConnectionProvider' );
 
-		$containerBuilder->registerCallback( 'ConnectionProvider', function( $containerBuilder ) {
+		$containerBuilder->registerCallback( 'ConnectionProvider', function ( $containerBuilder ) {
 			$containerBuilder->registerExpectedReturnType( 'ConnectionProvider', ConnectionProvider::class );
 
 			$connectionProvider = new ConnectionProvider();
@@ -362,7 +362,7 @@ class SharedServicesContainer implements CallbackContainer {
 		/**
 		 * @var TempFile
 		 */
-		$containerBuilder->registerCallback( 'TempFile', function( $containerBuilder ) {
+		$containerBuilder->registerCallback( 'TempFile', function ( $containerBuilder ) {
 			$containerBuilder->registerExpectedReturnType( 'TempFile', '\SMW\Utils\TempFile' );
 			return new TempFile();
 		} );
@@ -370,7 +370,7 @@ class SharedServicesContainer implements CallbackContainer {
 		/**
 		 * @var PostProcHandler
 		 */
-		$containerBuilder->registerCallback( 'PostProcHandler', function( $containerBuilder, \ParserOutput $parserOutput ) {
+		$containerBuilder->registerCallback( 'PostProcHandler', function ( $containerBuilder, \ParserOutput $parserOutput ) {
 			$containerBuilder->registerExpectedReturnType( 'PostProcHandler', PostProcHandler::class );
 
 			$settings = $containerBuilder->singleton( 'Settings' );
@@ -392,7 +392,7 @@ class SharedServicesContainer implements CallbackContainer {
 		/**
 		 * @var JsonSchemaValidator
 		 */
-		$containerBuilder->registerCallback( 'JsonSchemaValidator', function( $containerBuilder ) {
+		$containerBuilder->registerCallback( 'JsonSchemaValidator', function ( $containerBuilder ) {
 			$containerBuilder->registerExpectedReturnType( 'JsonSchemaValidator', JsonSchemaValidator::class );
 			$containerBuilder->registerAlias( 'JsonSchemaValidator', JsonSchemaValidator::class );
 
@@ -413,7 +413,7 @@ class SharedServicesContainer implements CallbackContainer {
 		/**
 		 * @var SchemaFactory
 		 */
-		$containerBuilder->registerCallback( 'SchemaFactory', function( $containerBuilder ) {
+		$containerBuilder->registerCallback( 'SchemaFactory', function ( $containerBuilder ) {
 			$containerBuilder->registerExpectedReturnType( 'SchemaFactory', SchemaFactory::class );
 
 			$settings = $containerBuilder->singleton( 'Settings' );
@@ -428,7 +428,7 @@ class SharedServicesContainer implements CallbackContainer {
 		/**
 		 * @var ConstraintFactory
 		 */
-		$containerBuilder->registerCallback( 'ConstraintFactory', function( $containerBuilder ) {
+		$containerBuilder->registerCallback( 'ConstraintFactory', function ( $containerBuilder ) {
 			$containerBuilder->registerExpectedReturnType( 'ConstraintFactory', ConstraintFactory::class );
 			return new ConstraintFactory();
 		} );
@@ -436,7 +436,7 @@ class SharedServicesContainer implements CallbackContainer {
 		/**
 		 * @var ElasticFactory
 		 */
-		$containerBuilder->registerCallback( 'ElasticFactory', function( $containerBuilder ) {
+		$containerBuilder->registerCallback( 'ElasticFactory', function ( $containerBuilder ) {
 			$containerBuilder->registerExpectedReturnType( 'ElasticFactory', ElasticFactory::class );
 			return new ElasticFactory();
 		} );
@@ -444,7 +444,7 @@ class SharedServicesContainer implements CallbackContainer {
 		/**
 		 * @var QueryCreator
 		 */
-		$containerBuilder->registerCallback( 'QueryCreator', function( $containerBuilder ) {
+		$containerBuilder->registerCallback( 'QueryCreator', function ( $containerBuilder ) {
 			$containerBuilder->registerExpectedReturnType( 'QueryCreator', QueryCreator::class );
 
 			$settings = $containerBuilder->singleton( 'Settings' );
@@ -469,7 +469,7 @@ class SharedServicesContainer implements CallbackContainer {
 		/**
 		 * @var ParamListProcessor
 		 */
-		$containerBuilder->registerCallback( 'ParamListProcessor', function( $containerBuilder ) {
+		$containerBuilder->registerCallback( 'ParamListProcessor', function ( $containerBuilder ) {
 			$containerBuilder->registerExpectedReturnType( 'ParamListProcessor', ParamListProcessor::class );
 
 			$paramListProcessor = new ParamListProcessor(
@@ -482,7 +482,7 @@ class SharedServicesContainer implements CallbackContainer {
 		/**
 		 * @var FactboxText
 		 */
-		$containerBuilder->registerCallback( 'FactboxText', function( $containerBuilder ) {
+		$containerBuilder->registerCallback( 'FactboxText', function ( $containerBuilder ) {
 			$containerBuilder->registerExpectedReturnType( 'FactboxText', FactboxText::class );
 
 			return new FactboxText();
@@ -493,7 +493,7 @@ class SharedServicesContainer implements CallbackContainer {
 		/**
 		 * @var CacheFactory
 		 */
-		$containerBuilder->registerCallback( 'CacheFactory', function( $containerBuilder, $mainCacheType = null ) {
+		$containerBuilder->registerCallback( 'CacheFactory', function ( $containerBuilder, $mainCacheType = null ) {
 			$containerBuilder->registerExpectedReturnType( 'CacheFactory', '\SMW\CacheFactory' );
 			return new CacheFactory( $mainCacheType );
 		} );
@@ -501,7 +501,7 @@ class SharedServicesContainer implements CallbackContainer {
 		/**
 		 * @var IteratorFactory
 		 */
-		$containerBuilder->registerCallback( 'IteratorFactory', function( $containerBuilder ) {
+		$containerBuilder->registerCallback( 'IteratorFactory', function ( $containerBuilder ) {
 			$containerBuilder->registerExpectedReturnType( 'IteratorFactory', '\SMW\IteratorFactory' );
 			return new IteratorFactory();
 		} );
@@ -509,7 +509,7 @@ class SharedServicesContainer implements CallbackContainer {
 		/**
 		 * @var JobFactory
 		 */
-		$containerBuilder->registerCallback( 'JobFactory', function( $containerBuilder ) {
+		$containerBuilder->registerCallback( 'JobFactory', function ( $containerBuilder ) {
 			$containerBuilder->registerExpectedReturnType( 'JobFactory', '\SMW\MediaWiki\JobFactory' );
 			return new JobFactory();
 		} );
@@ -517,7 +517,7 @@ class SharedServicesContainer implements CallbackContainer {
 		/**
 		 * @var FactboxFactory
 		 */
-		$containerBuilder->registerCallback( 'FactboxFactory', function( $containerBuilder ) {
+		$containerBuilder->registerCallback( 'FactboxFactory', function ( $containerBuilder ) {
 			$containerBuilder->registerExpectedReturnType( 'FactboxFactory', '\SMW\Factbox\FactboxFactory' );
 			return new FactboxFactory();
 		} );
@@ -525,7 +525,7 @@ class SharedServicesContainer implements CallbackContainer {
 		/**
 		 * @var QuerySourceFactory
 		 */
-		$containerBuilder->registerCallback( 'QuerySourceFactory', function( $containerBuilder ) {
+		$containerBuilder->registerCallback( 'QuerySourceFactory', function ( $containerBuilder ) {
 			$containerBuilder->registerExpectedReturnType( 'QuerySourceFactory', '\SMW\Query\QuerySourceFactory' );
 
 			return new QuerySourceFactory(
@@ -537,7 +537,7 @@ class SharedServicesContainer implements CallbackContainer {
 		/**
 		 * @var QueryFactory
 		 */
-		$containerBuilder->registerCallback( 'QueryFactory', function( $containerBuilder ) {
+		$containerBuilder->registerCallback( 'QueryFactory', function ( $containerBuilder ) {
 			$containerBuilder->registerExpectedReturnType( 'QueryFactory', '\SMW\QueryFactory' );
 			return new QueryFactory();
 		} );
@@ -545,7 +545,7 @@ class SharedServicesContainer implements CallbackContainer {
 		/**
 		 * @var DataItemFactory
 		 */
-		$containerBuilder->registerCallback( 'DataItemFactory', function( $containerBuilder ) {
+		$containerBuilder->registerCallback( 'DataItemFactory', function ( $containerBuilder ) {
 			$containerBuilder->registerExpectedReturnType( 'DataItemFactory', '\SMW\DataItemFactory' );
 			return new DataItemFactory();
 		} );
@@ -553,7 +553,7 @@ class SharedServicesContainer implements CallbackContainer {
 		/**
 		 * @var DataValueServiceFactory
 		 */
-		$containerBuilder->registerCallback( 'DataValueServiceFactory', function( $containerBuilder ) {
+		$containerBuilder->registerCallback( 'DataValueServiceFactory', function ( $containerBuilder ) {
 			$containerBuilder->registerExpectedReturnType( 'DataValueServiceFactory', '\SMW\Services\DataValueServiceFactory' );
 
 			$containerBuilder->registerFromFile(
@@ -570,7 +570,7 @@ class SharedServicesContainer implements CallbackContainer {
 		/**
 		 * @var QueryDependencyLinksStoreFactory
 		 */
-		$containerBuilder->registerCallback( 'QueryDependencyLinksStoreFactory', function( $containerBuilder ) {
+		$containerBuilder->registerCallback( 'QueryDependencyLinksStoreFactory', function ( $containerBuilder ) {
 			$containerBuilder->registerExpectedReturnType( 'QueryDependencyLinksStoreFactory', '\SMW\SQLStore\QueryDependencyLinksStoreFactory' );
 			return new QueryDependencyLinksStoreFactory();
 		} );
@@ -581,7 +581,7 @@ class SharedServicesContainer implements CallbackContainer {
 		/**
 		 * @var BlobStore
 		 */
-		$containerBuilder->registerCallback( 'BlobStore', function( $containerBuilder, $namespace, $cacheType = null, $ttl = 0 ) {
+		$containerBuilder->registerCallback( 'BlobStore', function ( $containerBuilder, $namespace, $cacheType = null, $ttl = 0 ) {
 			$containerBuilder->registerExpectedReturnType( 'BlobStore', '\Onoi\BlobStore\BlobStore' );
 
 			$cacheFactory = $containerBuilder->create( 'CacheFactory' );
@@ -609,7 +609,7 @@ class SharedServicesContainer implements CallbackContainer {
 		/**
 		 * @var ResultCache
 		 */
-		$containerBuilder->registerCallback( 'ResultCache', function( $containerBuilder, $cacheType = null ) {
+		$containerBuilder->registerCallback( 'ResultCache', function ( $containerBuilder, $cacheType = null ) {
 			$containerBuilder->registerExpectedReturnType( 'ResultCache', '\SMW\Query\Cache\ResultCache' );
 
 			$cacheFactory = $containerBuilder->create( 'CacheFactory' );
@@ -664,7 +664,7 @@ class SharedServicesContainer implements CallbackContainer {
 		/**
 		 * @var Stats
 		 */
-		$containerBuilder->registerCallback( 'Stats', function( $containerBuilder, $id ) {
+		$containerBuilder->registerCallback( 'Stats', function ( $containerBuilder, $id ) {
 			$containerBuilder->registerExpectedReturnType( 'Stats', '\SMW\Utils\Stats' );
 
 			$cacheFactory = $containerBuilder->create( 'CacheFactory' );
@@ -681,7 +681,7 @@ class SharedServicesContainer implements CallbackContainer {
 		/**
 		 * @var PropertySpecificationLookup
 		 */
-		$containerBuilder->registerCallback( 'PropertySpecificationLookup', function( $containerBuilder ) {
+		$containerBuilder->registerCallback( 'PropertySpecificationLookup', function ( $containerBuilder ) {
 			$containerBuilder->registerExpectedReturnType( 'PropertySpecificationLookup', '\SMW\PropertySpecificationLookup' );
 
 			$contentLanguage = Localizer::getInstance()->getContentLanguage();
@@ -701,7 +701,7 @@ class SharedServicesContainer implements CallbackContainer {
 		/**
 		 * @var ProtectionValidator
 		 */
-		$containerBuilder->registerCallback( 'ProtectionValidator', function( $containerBuilder ) {
+		$containerBuilder->registerCallback( 'ProtectionValidator', function ( $containerBuilder ) {
 			$containerBuilder->registerExpectedReturnType( 'ProtectionValidator', '\SMW\Protection\ProtectionValidator' );
 
 			$settings = $containerBuilder->singleton( 'Settings' );
@@ -734,7 +734,7 @@ class SharedServicesContainer implements CallbackContainer {
 		/**
 		 * @var TitlePermissions
 		 */
-		$containerBuilder->registerCallback( 'TitlePermissions', function( $containerBuilder ) {
+		$containerBuilder->registerCallback( 'TitlePermissions', function ( $containerBuilder ) {
 			$containerBuilder->registerExpectedReturnType( 'TitlePermissions', '\SMW\MediaWiki\Permission\TitlePermissions' );
 
 			$titlePermissions = new TitlePermissions(
@@ -748,7 +748,7 @@ class SharedServicesContainer implements CallbackContainer {
 		/**
 		 * @var EditProtectionUpdater
 		 */
-		$containerBuilder->registerCallback( 'EditProtectionUpdater', function( $containerBuilder, \WikiPage $wikiPage, \User $user = null ) {
+		$containerBuilder->registerCallback( 'EditProtectionUpdater', function ( $containerBuilder, \WikiPage $wikiPage, \User $user = null ) {
 			$containerBuilder->registerExpectedReturnType( 'EditProtectionUpdater', '\SMW\Protection\EditProtectionUpdater' );
 
 			$editProtectionUpdater = new EditProtectionUpdater(
@@ -770,7 +770,7 @@ class SharedServicesContainer implements CallbackContainer {
 		/**
 		 * @var PropertyRestrictionExaminer
 		 */
-		$containerBuilder->registerCallback( 'PropertyRestrictionExaminer', function( $containerBuilder ) {
+		$containerBuilder->registerCallback( 'PropertyRestrictionExaminer', function ( $containerBuilder ) {
 			$containerBuilder->registerExpectedReturnType( 'PropertyRestrictionExaminer', '\SMW\PropertyRestrictionExaminer' );
 
 			$propertyRestrictionExaminer = new PropertyRestrictionExaminer();
@@ -785,7 +785,7 @@ class SharedServicesContainer implements CallbackContainer {
 		/**
 		 * @var HierarchyLookup
 		 */
-		$containerBuilder->registerCallback( 'HierarchyLookup', function( $containerBuilder, $store = null, $cacheType = null ) {
+		$containerBuilder->registerCallback( 'HierarchyLookup', function ( $containerBuilder, $store = null, $cacheType = null ) {
 			$containerBuilder->registerExpectedReturnType( 'HierarchyLookup', '\SMW\HierarchyLookup' );
 
 			$hierarchyLookup = new HierarchyLookup(
@@ -811,7 +811,7 @@ class SharedServicesContainer implements CallbackContainer {
 		/**
 		 * @var PropertyLabelFinder
 		 */
-		$containerBuilder->registerCallback( 'PropertyLabelFinder', function( $containerBuilder ) {
+		$containerBuilder->registerCallback( 'PropertyLabelFinder', function ( $containerBuilder ) {
 			$containerBuilder->registerExpectedReturnType( 'PropertyLabelFinder', '\SMW\PropertyLabelFinder' );
 
 			$lang = Localizer::getInstance()->getLang();
@@ -829,7 +829,7 @@ class SharedServicesContainer implements CallbackContainer {
 		/**
 		 * @var DisplayTitleFinder
 		 */
-		$containerBuilder->registerCallback( 'DisplayTitleFinder', function( $containerBuilder, $store = null ) {
+		$containerBuilder->registerCallback( 'DisplayTitleFinder', function ( $containerBuilder, $store = null ) {
 			$containerBuilder->registerExpectedReturnType( 'DisplayTitleFinder', '\SMW\DisplayTitleFinder' );
 
 			$store = $store === null ? $containerBuilder->singleton( 'Store', null ) : $store;
@@ -850,7 +850,7 @@ class SharedServicesContainer implements CallbackContainer {
 		/**
 		 * @var MagicWordsFinder
 		 */
-		$containerBuilder->registerCallback( 'MagicWordsFinder', function( $containerBuilder, $parserOutput = null ) {
+		$containerBuilder->registerCallback( 'MagicWordsFinder', function ( $containerBuilder, $parserOutput = null ) {
 			$containerBuilder->registerExpectedReturnType( 'MagicWordsFinder', '\SMW\MediaWiki\MagicWordsFinder' );
 
 			$magicWordsFinder = new \SMW\MediaWiki\MagicWordsFinder(
@@ -864,7 +864,7 @@ class SharedServicesContainer implements CallbackContainer {
 		/**
 		 * @var DependencyValidator
 		 */
-		$containerBuilder->registerCallback( 'DependencyValidator', function( $containerBuilder, $store = null ) {
+		$containerBuilder->registerCallback( 'DependencyValidator', function ( $containerBuilder, $store = null ) {
 			$containerBuilder->registerExpectedReturnType( 'DependencyValidator', '\SMW\DependencyValidator' );
 
 			$store = $store === null ? $containerBuilder->singleton( 'Store', null ) : $store;
@@ -884,7 +884,7 @@ class SharedServicesContainer implements CallbackContainer {
 		/**
 		 * @var PreferenceExaminer
 		 */
-		$containerBuilder->registerCallback( 'PreferenceExaminer', function( $containerBuilder, \User $user ) {
+		$containerBuilder->registerCallback( 'PreferenceExaminer', function ( $containerBuilder, \User $user ) {
 			$containerBuilder->registerExpectedReturnType( 'PreferenceExaminer', '\SMW\MediaWiki\Preference\PreferenceExaminer' );
 
 			$preferenceExaminer = new PreferenceExaminer(

--- a/src/Services/datavalues.php
+++ b/src/Services/datavalues.php
@@ -55,7 +55,7 @@ return [
 	 *
 	 * @return callable
 	 */
-	'UnitConverter' => function( $containerBuilder ) {
+	'UnitConverter' => function ( $containerBuilder ) {
 		$containerBuilder->registerExpectedReturnType(
 			'UnitConverter',
 			UnitConverter::class
@@ -74,7 +74,7 @@ return [
 	 *
 	 * @return callable
 	 */
-	ConstraintSchemaValue::class => function( $containerBuilder ) {
+	ConstraintSchemaValue::class => function ( $containerBuilder ) {
 		return new ConstraintSchemaValue(
 			ConstraintSchemaValue::TYPE_ID,
 			$containerBuilder->singleton( 'PropertySpecificationLookup' )
@@ -86,7 +86,7 @@ return [
 	 *
 	 * @return callable
 	 */
-	DataValueServiceFactory::TYPE_PARSER . PropertyValue::TYPE_ID => function( $containerBuilder ) {
+	DataValueServiceFactory::TYPE_PARSER . PropertyValue::TYPE_ID => function ( $containerBuilder ) {
 		$containerBuilder->registerExpectedReturnType(
 			DataValueServiceFactory::TYPE_PARSER . PropertyValue::TYPE_ID,
 			PropertyValueParser::class
@@ -110,7 +110,7 @@ return [
 	 *
 	 * @return callable
 	 */
-	DataValueServiceFactory::TYPE_FORMATTER . PropertyValue::TYPE_ID => function( $containerBuilder ) {
+	DataValueServiceFactory::TYPE_FORMATTER . PropertyValue::TYPE_ID => function ( $containerBuilder ) {
 		$containerBuilder->registerExpectedReturnType(
 			DataValueServiceFactory::TYPE_FORMATTER . PropertyValue::TYPE_ID,
 			PropertyValueFormatter::class
@@ -124,7 +124,7 @@ return [
 	 *
 	 * @return callable
 	 */
-	DataValueServiceFactory::TYPE_PARSER . AllowsPatternValue::TYPE_ID => function( $containerBuilder ) {
+	DataValueServiceFactory::TYPE_PARSER . AllowsPatternValue::TYPE_ID => function ( $containerBuilder ) {
 		$containerBuilder->registerExpectedReturnType(
 			DataValueServiceFactory::TYPE_PARSER . AllowsPatternValue::TYPE_ID,
 			AllowsPatternValueParser::class
@@ -138,7 +138,7 @@ return [
 	 *
 	 * @return callable
 	 */
-	DataValueServiceFactory::TYPE_PARSER . AllowsListValue::TYPE_ID => function( $containerBuilder ) {
+	DataValueServiceFactory::TYPE_PARSER . AllowsListValue::TYPE_ID => function ( $containerBuilder ) {
 		$containerBuilder->registerExpectedReturnType(
 			DataValueServiceFactory::TYPE_PARSER . AllowsListValue::TYPE_ID,
 			AllowsListValueParser::class
@@ -152,7 +152,7 @@ return [
 	 *
 	 * @return callable
 	 */
-	DataValueServiceFactory::TYPE_VALIDATOR . 'CompoundConstraintValueValidator' => function( $containerBuilder ) {
+	DataValueServiceFactory::TYPE_VALIDATOR . 'CompoundConstraintValueValidator' => function ( $containerBuilder ) {
 		$containerBuilder->registerExpectedReturnType(
 			DataValueServiceFactory::TYPE_VALIDATOR . 'CompoundConstraintValueValidator',
 			CompoundConstraintValueValidator::class
@@ -219,7 +219,7 @@ return [
 	 *
 	 * @return callable
 	 */
-	DataValueServiceFactory::TYPE_PARSER . ImportValue::TYPE_ID => function( $containerBuilder ) {
+	DataValueServiceFactory::TYPE_PARSER . ImportValue::TYPE_ID => function ( $containerBuilder ) {
 		$containerBuilder->registerExpectedReturnType(
 			DataValueServiceFactory::TYPE_PARSER . ImportValue::TYPE_ID,
 			ImportValueParser::class
@@ -233,7 +233,7 @@ return [
 	 *
 	 * @return callable
 	 */
-	DataValueServiceFactory::TYPE_FORMATTER . StringValue::TYPE_ID => function( $containerBuilder ) {
+	DataValueServiceFactory::TYPE_FORMATTER . StringValue::TYPE_ID => function ( $containerBuilder ) {
 		$containerBuilder->registerExpectedReturnType(
 			DataValueServiceFactory::TYPE_FORMATTER . StringValue::TYPE_ID,
 			StringValueFormatter::class
@@ -252,7 +252,7 @@ return [
 	 *
 	 * @return callable
 	 */
-	DataValueServiceFactory::TYPE_FORMATTER . StringValue::TYPE_COD_ID => function( $containerBuilder ) {
+	DataValueServiceFactory::TYPE_FORMATTER . StringValue::TYPE_COD_ID => function ( $containerBuilder ) {
 		$containerBuilder->registerExpectedReturnType(
 			DataValueServiceFactory::TYPE_FORMATTER . StringValue::TYPE_COD_ID,
 			CodeStringValueFormatter::class
@@ -266,7 +266,7 @@ return [
 	 *
 	 * @return callable
 	 */
-	DataValueServiceFactory::TYPE_FORMATTER . ReferenceValue::TYPE_ID => function( $containerBuilder ) {
+	DataValueServiceFactory::TYPE_FORMATTER . ReferenceValue::TYPE_ID => function ( $containerBuilder ) {
 		$containerBuilder->registerExpectedReturnType(
 			DataValueServiceFactory::TYPE_FORMATTER . ReferenceValue::TYPE_ID,
 			ReferenceValueFormatter::class
@@ -280,7 +280,7 @@ return [
 	 *
 	 * @return callable
 	 */
-	DataValueServiceFactory::TYPE_PARSER . MonolingualTextValue::TYPE_ID => function( $containerBuilder ) {
+	DataValueServiceFactory::TYPE_PARSER . MonolingualTextValue::TYPE_ID => function ( $containerBuilder ) {
 		$containerBuilder->registerExpectedReturnType(
 			DataValueServiceFactory::TYPE_PARSER . MonolingualTextValue::TYPE_ID,
 			MonolingualTextValueParser::class
@@ -294,7 +294,7 @@ return [
 	 *
 	 * @return callable
 	 */
-	DataValueServiceFactory::TYPE_FORMATTER . MonolingualTextValue::TYPE_ID => function( $containerBuilder ) {
+	DataValueServiceFactory::TYPE_FORMATTER . MonolingualTextValue::TYPE_ID => function ( $containerBuilder ) {
 		$containerBuilder->registerExpectedReturnType(
 			DataValueServiceFactory::TYPE_FORMATTER . MonolingualTextValue::TYPE_ID,
 			MonolingualTextValueFormatter::class
@@ -308,11 +308,11 @@ return [
 	 *
 	 * @return callable
 	 */
-	DataValueServiceFactory::TYPE_FORMATTER . QuantityValue::TYPE_ID => function( $containerBuilder ) {
+	DataValueServiceFactory::TYPE_FORMATTER . QuantityValue::TYPE_ID => function ( $containerBuilder ) {
 		return $containerBuilder->create( DataValueServiceFactory::TYPE_FORMATTER . NumberValue::TYPE_ID );
 	},
 
-	DataValueServiceFactory::TYPE_FORMATTER . NumberValue::TYPE_ID => function( $containerBuilder ) {
+	DataValueServiceFactory::TYPE_FORMATTER . NumberValue::TYPE_ID => function ( $containerBuilder ) {
 		$containerBuilder->registerExpectedReturnType(
 			DataValueServiceFactory::TYPE_FORMATTER . NumberValue::TYPE_ID,
 			NumberValueFormatter::class
@@ -326,7 +326,7 @@ return [
 	 *
 	 * @return callable
 	 */
-	DataValueServiceFactory::TYPE_FORMATTER . TimeValue::TYPE_ID => function( $containerBuilder ) {
+	DataValueServiceFactory::TYPE_FORMATTER . TimeValue::TYPE_ID => function ( $containerBuilder ) {
 		$containerBuilder->registerExpectedReturnType(
 			DataValueServiceFactory::TYPE_FORMATTER . TimeValue::TYPE_ID,
 			TimeValueFormatter::class
@@ -340,7 +340,7 @@ return [
 	 *
 	 * @return callable
 	 */
-	DataValueServiceFactory::TYPE_PARSER . TimeValue::TYPE_ID => function( $containerBuilder ) {
+	DataValueServiceFactory::TYPE_PARSER . TimeValue::TYPE_ID => function ( $containerBuilder ) {
 		$containerBuilder->registerExpectedReturnType(
 			DataValueServiceFactory::TYPE_PARSER . TimeValue::TYPE_ID,
 			TimeValueParser::class
@@ -354,7 +354,7 @@ return [
 	 *
 	 * @return callable
 	 */
-	'DescriptionBuilderRegistry' => function( $containerBuilder ) {
+	'DescriptionBuilderRegistry' => function ( $containerBuilder ) {
 		return new DescriptionBuilderRegistry();
 	},
 

--- a/src/Services/events.php
+++ b/src/Services/events.php
@@ -24,7 +24,7 @@ return [
 	 *
 	 * @return callable
 	 */
-	'InvalidateResultCacheEventListener' => function( $containerBuilder ) {
+	'InvalidateResultCacheEventListener' => function ( $containerBuilder ) {
 		$invalidateResultCacheEventListener = new InvalidateResultCacheEventListener(
 			$containerBuilder->singleton( 'ResultCache' )
 		);
@@ -37,7 +37,7 @@ return [
 	 *
 	 * @return callable
 	 */
-	'InvalidateEntityCacheEventListener' => function( $containerBuilder ) {
+	'InvalidateEntityCacheEventListener' => function ( $containerBuilder ) {
 		$invalidateEntityCacheEventListener = new InvalidateEntityCacheEventListener(
 			$containerBuilder->singleton( 'EntityCache' )
 		);
@@ -50,7 +50,7 @@ return [
 	 *
 	 * @return callable
 	 */
-	'InvalidatePropertySpecificationLookupCacheEventListener' => function( $containerBuilder ) {
+	'InvalidatePropertySpecificationLookupCacheEventListener' => function ( $containerBuilder ) {
 		$invalidatePropertySpecificationLookupCacheEventListener = new InvalidatePropertySpecificationLookupCacheEventListener(
 			$containerBuilder->singleton( 'PropertySpecificationLookup' )
 		);

--- a/src/Services/importer.php
+++ b/src/Services/importer.php
@@ -31,7 +31,7 @@ return [
 	 *
 	 * @return callable
 	 */
-	'ImporterServiceFactory' => function( $containerBuilder ) {
+	'ImporterServiceFactory' => function ( $containerBuilder ) {
 		$containerBuilder->registerExpectedReturnType( 'ImporterServiceFactory', '\SMW\Services\ImporterServiceFactory' );
 		return new ImporterServiceFactory( $containerBuilder );
 	},
@@ -41,7 +41,7 @@ return [
 	 *
 	 * @return callable
 	 */
-	'XmlContentCreator' => function( $containerBuilder ) {
+	'XmlContentCreator' => function ( $containerBuilder ) {
 		$containerBuilder->registerExpectedReturnType( 'XmlContentCreator', '\SMW\Importer\ContentCreators\XmlContentCreator' );
 		return new XmlContentCreator( $containerBuilder->create( 'ImporterServiceFactory' ) );
 	},
@@ -51,7 +51,7 @@ return [
 	 *
 	 * @return callable
 	 */
-	'TextContentCreator' => function( $containerBuilder ) {
+	'TextContentCreator' => function ( $containerBuilder ) {
 		$containerBuilder->registerExpectedReturnType( 'TextContentCreator', '\SMW\Importer\ContentCreators\TextContentCreator' );
 
 		$connectionManager = $containerBuilder->singleton( 'ConnectionManager' );
@@ -69,7 +69,7 @@ return [
 	 *
 	 * @return callable
 	 */
-	'Importer' => function( $containerBuilder, ContentIterator $contentIterator ) {
+	'Importer' => function ( $containerBuilder, ContentIterator $contentIterator ) {
 		$containerBuilder->registerExpectedReturnType( 'Importer', '\SMW\Importer\Importer' );
 
 		$dispatchingContentCreator = new DispatchingContentCreator(
@@ -96,7 +96,7 @@ return [
 	 *
 	 * @return callable
 	 */
-	'JsonContentIterator' => function( $containerBuilder, $importFileDirs ) {
+	'JsonContentIterator' => function ( $containerBuilder, $importFileDirs ) {
 		$containerBuilder->registerExpectedReturnType( 'JsonContentIterator', '\SMW\Importer\JsonContentIterator' );
 
 		$jsonImportContentsFileDirReader = new JsonImportContentsFileDirReader(

--- a/src/Services/mediawiki.php
+++ b/src/Services/mediawiki.php
@@ -33,7 +33,7 @@ return [
 	 *
 	 * @return callable
 	 */
-	'ImportStringSource' => function( $containerBuilder, $source ) {
+	'ImportStringSource' => function ( $containerBuilder, $source ) {
 		$containerBuilder->registerExpectedReturnType( 'ImportStringSource', '\ImportStringSource' );
 		return new ImportStringSource( $source );
 	},
@@ -43,7 +43,7 @@ return [
 	 *
 	 * @return callable
 	 */
-	'ImportStreamSource' => function( $containerBuilder, $source ) {
+	'ImportStreamSource' => function ( $containerBuilder, $source ) {
 		$containerBuilder->registerExpectedReturnType( 'ImportStreamSource', '\ImportStreamSource' );
 		return new ImportStreamSource( $source );
 	},
@@ -53,7 +53,7 @@ return [
 	 *
 	 * @return callable
 	 */
-	'WikiImporter' => function( $containerBuilder, \ImportSource $importSource ) {
+	'WikiImporter' => function ( $containerBuilder, \ImportSource $importSource ) {
 		$containerBuilder->registerExpectedReturnType( 'WikiImporter', '\WikiImporter' );
 		if ( version_compare( MW_VERSION, '1.37', '<' ) ) {
 			return new WikiImporter( $importSource, $containerBuilder->create( 'MainConfig' ) );
@@ -80,7 +80,7 @@ return [
 	 *
 	 * @return callable
 	 */
-	'WikiPage' => function( $containerBuilder, \Title $title ) {
+	'WikiPage' => function ( $containerBuilder, \Title $title ) {
 		$containerBuilder->registerExpectedReturnType( 'WikiPage', '\WikiPage' );
 		return ServicesFactory::getInstance()->newPageCreator()->createPage( $title );
 	},
@@ -90,7 +90,7 @@ return [
 	 *
 	 * @return callable
 	 */
-	'MainConfig' => function() {
+	'MainConfig' => function () {
 		return MediaWikiServices::getInstance()->getMainConfig();
 	},
 
@@ -99,7 +99,7 @@ return [
 	 *
 	 * @return callable
 	 */
-	'SearchEngineConfig' => function() {
+	'SearchEngineConfig' => function () {
 		return MediaWikiServices::getInstance()->getSearchEngineConfig();
 	},
 
@@ -108,7 +108,7 @@ return [
 	 *
 	 * @return callable
 	 */
-	'MagicWordFactory' => function() {
+	'MagicWordFactory' => function () {
 		return MediaWikiServices::getInstance()->getMagicWordFactory();
 	},
 
@@ -117,7 +117,7 @@ return [
 	 *
 	 * @return callable
 	 */
-	'PermissionManager' => function() {
+	'PermissionManager' => function () {
 		return new PermissionManager( MediaWikiServices::getInstance()->getPermissionManager() );
 	},
 
@@ -126,7 +126,7 @@ return [
 	 *
 	 * @return callable
 	 */
-	'DBLoadBalancerFactory' => function() {
+	'DBLoadBalancerFactory' => function () {
 		return MediaWikiServices::getInstance()->getDBLoadBalancerFactory();
 	},
 
@@ -135,7 +135,7 @@ return [
 	 *
 	 * @return callable
 	 */
-	'DBLoadBalancer' => function() {
+	'DBLoadBalancer' => function () {
 		return MediaWikiServices::getInstance()->getDBLoadBalancer();
 	},
 
@@ -144,7 +144,7 @@ return [
 	 *
 	 * @return callable
 	 */
-	'DefaultSearchEngineTypeForDB' => function( $containerBuilder, IDatabase $db ) {
+	'DefaultSearchEngineTypeForDB' => function ( $containerBuilder, IDatabase $db ) {
 		return MediaWikiServices::getInstance()->getSearchEngineFactory()->getSearchEngineClass( $db );
 	},
 
@@ -153,7 +153,7 @@ return [
 	 *
 	 * @return callable
 	 */
-	'MediaWikiLogger' => function( $containerBuilder, $channel = 'smw', $role = Logger::ROLE_DEVELOPER ) {
+	'MediaWikiLogger' => function ( $containerBuilder, $channel = 'smw', $role = Logger::ROLE_DEVELOPER ) {
 		$containerBuilder->registerExpectedReturnType( 'MediaWikiLogger', '\Psr\Log\LoggerInterface' );
 
 		$logger = LoggerFactory::getInstance( $channel );
@@ -166,7 +166,7 @@ return [
 	 *
 	 * @return callable
 	 */
-	'NamespaceInfo' => function( $containerBuilder ) {
+	'NamespaceInfo' => function ( $containerBuilder ) {
 		$containerBuilder->registerExpectedReturnType( 'NamespaceInfo', '\SMW\MediaWiki\NamespaceInfo' );
 		$namespaceInfo = MediaWikiServices::getInstance()->getNamespaceInfo();
 
@@ -178,7 +178,7 @@ return [
 	 *
 	 * @return callable
 	 */
-	'FileRepoFinder' => function() {
+	'FileRepoFinder' => function () {
 		$repoGroup = MediaWikiServices::getInstance()->getRepoGroup();
 
 		return new FileRepoFinder( $repoGroup );
@@ -189,7 +189,7 @@ return [
 	 *
 	 * @return callable
 	 */
-	'JobQueueGroup' => function( $containerBuilder ) {
+	'JobQueueGroup' => function ( $containerBuilder ) {
 		$containerBuilder->registerExpectedReturnType( 'JobQueueGroup', '\JobQueueGroup' );
 
 		if ( method_exists( MediaWikiServices::class, 'getJobQueueGroup' ) ) {
@@ -205,7 +205,7 @@ return [
 	 *
 	 * @return callable
 	 */
-	'Parser' => function() {
+	'Parser' => function () {
 		return MediaWikiServices::getInstance()->getParser();
 	},
 
@@ -214,7 +214,7 @@ return [
 	 *
 	 * @return callable
 	 */
-	'ContentLanguage' => function() {
+	'ContentLanguage' => function () {
 		return MediaWikiServices::getInstance()->getContentLanguage();
 	},
 
@@ -223,7 +223,7 @@ return [
 	 *
 	 * @return callable
 	 */
-	'RevisionLookup' => function() {
+	'RevisionLookup' => function () {
 		return MediaWikiServices::getInstance()->getRevisionLookup();
 	},
 
@@ -232,11 +232,11 @@ return [
 	 *
 	 * @return callable
 	 */
-	'ParserCache' => function() {
+	'ParserCache' => function () {
 		return MediaWikiServices::getInstance()->getParserCache();
 	},
 
-	'UserOptionsLookup' => function(): UserOptionsLookup {
+	'UserOptionsLookup' => function (): UserOptionsLookup {
 		return MediaWikiServices::getInstance()->getUserOptionsLookup();
 	}
 

--- a/src/SetupCheck.php
+++ b/src/SetupCheck.php
@@ -536,7 +536,7 @@ class SetupCheck {
 		// Minify CSS rules, we keep them readable in the template to allow for
 		// better adaption
 		// @see http://manas.tungare.name/software/css-compression-in-php/
-		$html = preg_replace_callback( "/<style\\b[^>]*>(.*?)<\\/style>/s", function( $matches ) {
+		$html = preg_replace_callback( "/<style\\b[^>]*>(.*?)<\\/style>/s", function ( $matches ) {
 				// Remove space after colons
 				$style = str_replace( ': ', ':', $matches[0] );
 

--- a/src/TypesRegistry.php
+++ b/src/TypesRegistry.php
@@ -359,13 +359,13 @@ class TypesRegistry {
 		];
 
 		if ( $key === 'id' ) {
-			array_walk( $fixedProperties, function( &$v, $k ) { $v = $v[0]; } );
+			array_walk( $fixedProperties, function ( &$v, $k ) { $v = $v[0]; } );
 		}
 
 		// Default fixed property table for selected special properties
 		if ( $key === 'default_fixed' ) {
 			$fixedProperties = array_keys(
-				array_filter( $fixedProperties, function( $v ) { return $v[1]; } )
+				array_filter( $fixedProperties, function ( $v ) { return $v[1]; } )
 			);
 		}
 
@@ -373,7 +373,7 @@ class TypesRegistry {
 		// special properties that can have their own fixed property table
 		if ( $key === 'custom_fixed' ) {
 			$fixedProperties = array_keys(
-				array_filter( $fixedProperties, function( $v ) { return $v[2]; } )
+				array_filter( $fixedProperties, function ( $v ) { return $v[2]; } )
 			);
 		}
 

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -42,7 +42,7 @@ define( 'SMW_PHPUNIT_TABLE_PREFIX', '' );
 /**
  * Register a shutdown function the invoke a final clean-up
  */
-register_shutdown_function( function() {
+register_shutdown_function( function () {
 	if ( !defined( 'MW_PHPUNIT_TEST' ) ) {
 		return;
 	}

--- a/tests/phpunit/Connection/CallbackConnectionProviderTest.php
+++ b/tests/phpunit/Connection/CallbackConnectionProviderTest.php
@@ -24,7 +24,7 @@ class CallbackConnectionProviderTest extends \PHPUnit_Framework_TestCase {
 	}
 
 	public function testCanConstruct() {
-		$callback = function() {};
+		$callback = function () {};
 
 		$this->assertInstanceOf(
 			CallbackConnectionProvider::class,
@@ -37,7 +37,7 @@ class CallbackConnectionProviderTest extends \PHPUnit_Framework_TestCase {
 	}
 
 	public function testGetConnectionFormCallback() {
-		$callback = function() {
+		$callback = function () {
 			return $this->connection;
 		};
 

--- a/tests/phpunit/Connection/ConnectionManagerTest.php
+++ b/tests/phpunit/Connection/ConnectionManagerTest.php
@@ -78,7 +78,7 @@ class ConnectionManagerTest extends \PHPUnit_Framework_TestCase {
 		$connectionProvider->expects( $this->once() )
 			->method( 'getConnection' );
 
-		$callback = function() use( $connectionProvider ) {
+		$callback = function () use( $connectionProvider ) {
 			return $connectionProvider->getConnection();
 		};
 

--- a/tests/phpunit/Constraint/ConstraintRegistryTest.php
+++ b/tests/phpunit/Constraint/ConstraintRegistryTest.php
@@ -124,7 +124,7 @@ class ConstraintRegistryTest extends \PHPUnit_Framework_TestCase {
 			$this->hookDispatcher
 		);
 
-		$instance->registerConstraint( 'foo', function() use( $constraint ) {
+		$instance->registerConstraint( 'foo', function () use( $constraint ) {
 			return $constraint; }
 		);
 

--- a/tests/phpunit/Constraint/Constraints/MandatoryPropertiesConstraintTest.php
+++ b/tests/phpunit/Constraint/Constraints/MandatoryPropertiesConstraintTest.php
@@ -71,11 +71,11 @@ class MandatoryPropertiesConstraintTest extends \PHPUnit_Framework_TestCase {
 
 		$dataValue->expects( $this->once() )
 			->method( 'getCallable' )
-			->will( $this->returnValue( function() use( $semanticData ) { return $semanticData; } ) );
+			->will( $this->returnValue( function () use( $semanticData ) { return $semanticData; } ) );
 
 		$dataValue->expects( $this->atLeastOnce() )
 			->method( 'addError' )
-			->with( $this->callback( function( $error ) use ( $expectedErrMsg ) {
+			->with( $this->callback( function ( $error ) use ( $expectedErrMsg ) {
 				return $this->checkConstraintError( $error, $expectedErrMsg );
 			} ) );
 

--- a/tests/phpunit/Constraint/Constraints/MustExistsConstraintTest.php
+++ b/tests/phpunit/Constraint/Constraints/MustExistsConstraintTest.php
@@ -83,7 +83,7 @@ class MustExistsConstraintTest extends \PHPUnit_Framework_TestCase {
 
 		$dataValue->expects( $this->atLeastOnce() )
 			->method( 'addError' )
-			->with( $this->callback( function( $error ) use ( $expectedErrMsg ) {
+			->with( $this->callback( function ( $error ) use ( $expectedErrMsg ) {
 				return $this->checkConstraintError( $error, $expectedErrMsg );
 			} ) );
 

--- a/tests/phpunit/Constraint/Constraints/NamespaceConstraintTest.php
+++ b/tests/phpunit/Constraint/Constraints/NamespaceConstraintTest.php
@@ -67,7 +67,7 @@ class NamespaceConstraintTest extends \PHPUnit_Framework_TestCase {
 
 		$dataValue->expects( $this->atLeastOnce() )
 			->method( 'addError' )
-			->with( $this->callback( function( $error ) use ( $expectedErrMsg ) {
+			->with( $this->callback( function ( $error ) use ( $expectedErrMsg ) {
 				return $this->checkConstraintError( $error, $expectedErrMsg );
 			} ) );
 

--- a/tests/phpunit/Constraint/Constraints/NonNegativeIntegerConstraintTest.php
+++ b/tests/phpunit/Constraint/Constraints/NonNegativeIntegerConstraintTest.php
@@ -63,7 +63,7 @@ class NonNegativeIntegerConstraintTest extends \PHPUnit_Framework_TestCase {
 
 		$dataValue->expects( $this->atLeastOnce() )
 			->method( 'addError' )
-			->with( $this->callback( function( $error ) use ( $expectedErrMsg ) {
+			->with( $this->callback( function ( $error ) use ( $expectedErrMsg ) {
 				return $this->checkConstraintError( $error, $expectedErrMsg );
 			} ) );
 

--- a/tests/phpunit/Constraint/Constraints/ShapeConstraintTest.php
+++ b/tests/phpunit/Constraint/Constraints/ShapeConstraintTest.php
@@ -73,11 +73,11 @@ class ShapeConstraintTest extends \PHPUnit_Framework_TestCase {
 
 		$dataValue->expects( $this->once() )
 			->method( 'getCallable' )
-			->will( $this->returnValue( function() use( $semanticData ) { return $semanticData; } ) );
+			->will( $this->returnValue( function () use( $semanticData ) { return $semanticData; } ) );
 
 		$dataValue->expects( $this->atLeastOnce() )
 			->method( 'addError' )
-			->with( $this->callback( function( $error ) use ( $expectedErrMsg ) {
+			->with( $this->callback( function ( $error ) use ( $expectedErrMsg ) {
 				return $this->checkConstraintError( $error, $expectedErrMsg );
 			} ) );
 
@@ -113,11 +113,11 @@ class ShapeConstraintTest extends \PHPUnit_Framework_TestCase {
 
 		$dataValue->expects( $this->once() )
 			->method( 'getCallable' )
-			->will( $this->returnValue( function() use( $semanticData ) { return $semanticData; } ) );
+			->will( $this->returnValue( function () use( $semanticData ) { return $semanticData; } ) );
 
 		$dataValue->expects( $this->atLeastOnce() )
 			->method( 'addError' )
-			->with( $this->callback( function( $error ) use ( $expectedErrMsg ) {
+			->with( $this->callback( function ( $error ) use ( $expectedErrMsg ) {
 				return $this->checkConstraintError( $error, $expectedErrMsg );
 			} ) );
 
@@ -161,11 +161,11 @@ class ShapeConstraintTest extends \PHPUnit_Framework_TestCase {
 
 		$dataValue->expects( $this->once() )
 			->method( 'getCallable' )
-			->will( $this->returnValue( function() use( $semanticData ) { return $semanticData; } ) );
+			->will( $this->returnValue( function () use( $semanticData ) { return $semanticData; } ) );
 
 		$dataValue->expects( $this->atLeastOnce() )
 			->method( 'addError' )
-			->with( $this->callback( function( $error ) use ( $expectedErrMsg ) {
+			->with( $this->callback( function ( $error ) use ( $expectedErrMsg ) {
 				return $this->checkConstraintError( $error, $expectedErrMsg );
 			} ) );
 
@@ -213,11 +213,11 @@ class ShapeConstraintTest extends \PHPUnit_Framework_TestCase {
 
 		$dataValue->expects( $this->once() )
 			->method( 'getCallable' )
-			->will( $this->returnValue( function() use( $semanticData ) { return $semanticData; } ) );
+			->will( $this->returnValue( function () use( $semanticData ) { return $semanticData; } ) );
 
 		$dataValue->expects( $this->atLeastOnce() )
 			->method( 'addError' )
-			->with( $this->callback( function( $error ) use ( $expectedErrMsg ) {
+			->with( $this->callback( function ( $error ) use ( $expectedErrMsg ) {
 				return $this->checkConstraintError( $error, $expectedErrMsg );
 			} ) );
 

--- a/tests/phpunit/Constraint/Constraints/SingleValueConstraintTest.php
+++ b/tests/phpunit/Constraint/Constraints/SingleValueConstraintTest.php
@@ -71,11 +71,11 @@ class SingleValueConstraintTest extends \PHPUnit_Framework_TestCase {
 
 		$dataValue->expects( $this->once() )
 			->method( 'getCallable' )
-			->will( $this->returnValue( function() use( $semanticData ) { return $semanticData; } ) );
+			->will( $this->returnValue( function () use( $semanticData ) { return $semanticData; } ) );
 
 		$dataValue->expects( $this->atLeastOnce() )
 			->method( 'addError' )
-			->with( $this->callback( function( $error ) use ( $expectedErrMsg ) {
+			->with( $this->callback( function ( $error ) use ( $expectedErrMsg ) {
 				return $this->checkConstraintError( $error, $expectedErrMsg );
 			} ) );
 

--- a/tests/phpunit/DataTypeRegistryTest.php
+++ b/tests/phpunit/DataTypeRegistryTest.php
@@ -63,7 +63,7 @@ class DataTypeRegistryTest extends \PHPUnit_Framework_TestCase {
 	}
 
 	public function testRegisterDatatypeWithCallable() {
-		$callback = function() {
+		$callback = function () {
 			return new FooValue();
 		};
 
@@ -464,7 +464,7 @@ class DataTypeRegistryTest extends \PHPUnit_Framework_TestCase {
 	}
 
 	public function testRegisterCallableGetCallablesByTypeId() {
-		$callback = function() {
+		$callback = function () {
 			return 'foo';
 		};
 

--- a/tests/phpunit/DataValueFactoryTest.php
+++ b/tests/phpunit/DataValueFactoryTest.php
@@ -36,7 +36,7 @@ class DataValueFactoryTest extends \PHPUnit_Framework_TestCase {
 		$test->expects( $this->once() )
 			->method( 'doRun' );
 
-		$callback = function() use( $test ) {
+		$callback = function () use( $test ) {
 			return $test;
 		};
 

--- a/tests/phpunit/Elastic/ElasticStoreTest.php
+++ b/tests/phpunit/Elastic/ElasticStoreTest.php
@@ -103,7 +103,7 @@ class ElasticStoreTest extends \PHPUnit_Framework_TestCase {
 			->disableOriginalConstructor()
 			->getMock();
 
-		$callback = function( $type ) use( $connection, $database, $client ) {
+		$callback = function ( $type ) use( $connection, $database, $client ) {
 			if ( $type === 'elastic' ) {
 				return $client;
 			};
@@ -179,7 +179,7 @@ class ElasticStoreTest extends \PHPUnit_Framework_TestCase {
 			->disableOriginalConstructor()
 			->getMock();
 
-		$callback = function( $type ) use( $connection, $database, $client ) {
+		$callback = function ( $type ) use( $connection, $database, $client ) {
 			if ( $type === 'elastic' ) {
 				return $client;
 			};
@@ -234,7 +234,7 @@ class ElasticStoreTest extends \PHPUnit_Framework_TestCase {
 		$subject = DIWikiPage::newFromText( __METHOD__, NS_FILE );
 
 		// Check that the IngestJob is referencing to the same subject instance
-		$checkJobParameterCallback = function( $job ) use( $subject ) {
+		$checkJobParameterCallback = function ( $job ) use( $subject ) {
 			return DIWikiPage::newFromTitle( $job->getTitle() )->equals( $subject );
 		};
 
@@ -295,7 +295,7 @@ class ElasticStoreTest extends \PHPUnit_Framework_TestCase {
 			->disableOriginalConstructor()
 			->getMock();
 
-		$callback = function( $type ) use( $connection, $client ) {
+		$callback = function ( $type ) use( $connection, $client ) {
 			if ( $type === 'mw.db' ) {
 				return $connection;
 			};

--- a/tests/phpunit/Elastic/Indexer/Attachment/FileHandlerTest.php
+++ b/tests/phpunit/Elastic/Indexer/Attachment/FileHandlerTest.php
@@ -52,7 +52,7 @@ class FileHandlerTest extends \PHPUnit_Framework_TestCase {
 			$this->fileRepoFinder
 		);
 
-		$instance->setReadCallback( function( $read_url ) use( $url ) {
+		$instance->setReadCallback( function ( $read_url ) use( $url ) {
 			if ( $read_url !== $url ) {
 				throw new \RuntimeException( "Invalid read URL!" );
 			}

--- a/tests/phpunit/Elastic/Jobs/FileIngestJobTest.php
+++ b/tests/phpunit/Elastic/Jobs/FileIngestJobTest.php
@@ -79,7 +79,7 @@ class FileIngestJobTest extends \PHPUnit_Framework_TestCase {
 	public function testPushIngestJob() {
 		$subject = DIWikiPage::newFromText( __METHOD__, NS_FILE );
 
-		$checkJobParameterCallback = function( $job ) use( $subject ) {
+		$checkJobParameterCallback = function ( $job ) use( $subject ) {
 			return DIWikiPage::newFromTitle( $job->getTitle() )->equals( $subject );
 		};
 

--- a/tests/phpunit/Elastic/QueryEngine/ConditionBuilderTest.php
+++ b/tests/phpunit/Elastic/QueryEngine/ConditionBuilderTest.php
@@ -40,7 +40,7 @@ class ConditionBuilderTest extends \PHPUnit_Framework_TestCase {
 			->disableOriginalConstructor()
 			->getMock();
 
-		$callback = function( $type ) use( $database ) {
+		$callback = function ( $type ) use( $database ) {
 			if ( $type === 'mw.db' ) {
 				return $connection;
 			};

--- a/tests/phpunit/Elastic/QueryEngine/QueryEngineTest.php
+++ b/tests/phpunit/Elastic/QueryEngine/QueryEngineTest.php
@@ -38,7 +38,7 @@ class QueryEngineTest extends \PHPUnit_Framework_TestCase {
 			->disableOriginalConstructor()
 			->getMock();
 
-		$callback = function( $type ) use( $database ) {
+		$callback = function ( $type ) use( $database ) {
 			if ( $type === 'mw.db' ) {
 				return $connection;
 			};

--- a/tests/phpunit/Exporter/ElementFactoryTest.php
+++ b/tests/phpunit/Exporter/ElementFactoryTest.php
@@ -46,7 +46,7 @@ class ElementFactoryTest extends \PHPUnit_Framework_TestCase {
 		$dataItemFactory = new DataItemFactory();
 		$instance = new ElementFactory();
 
-		$instance->registerCallableMapper( \SMWDataItem::TYPE_BLOB, function( $datatem ) {
+		$instance->registerCallableMapper( \SMWDataItem::TYPE_BLOB, function ( $datatem ) {
 			return new \stdclass;
 		} );
 

--- a/tests/phpunit/Importer/ContentCreators/TextContentCreatorTest.php
+++ b/tests/phpunit/Importer/ContentCreators/TextContentCreatorTest.php
@@ -61,7 +61,7 @@ class TextContentCreatorTest extends \PHPUnit_Framework_TestCase {
 	public function testCreate() {
 		$this->connection->expects( $this->once() )
 			->method( 'onTransactionCommitOrIdle' )
-			->will( $this->returnCallback( function( $callback ) {
+			->will( $this->returnCallback( function ( $callback ) {
 				return call_user_func( $callback ); }
 			) );
 
@@ -120,7 +120,7 @@ class TextContentCreatorTest extends \PHPUnit_Framework_TestCase {
 	public function testCreate_WithError() {
 		$this->connection->expects( $this->once() )
 			->method( 'onTransactionCommitOrIdle' )
-			->will( $this->returnCallback( function( $callback ) {
+			->will( $this->returnCallback( function ( $callback ) {
 				return call_user_func( $callback ); }
 			) );
 
@@ -232,7 +232,7 @@ class TextContentCreatorTest extends \PHPUnit_Framework_TestCase {
 	public function testCreate_ReplaceableOnCreator() {
 		$this->connection->expects( $this->once() )
 			->method( 'onTransactionCommitOrIdle' )
-			->will( $this->returnCallback( function( $callback ) {
+			->will( $this->returnCallback( function ( $callback ) {
 				return call_user_func( $callback ); }
 			) );
 
@@ -308,7 +308,7 @@ class TextContentCreatorTest extends \PHPUnit_Framework_TestCase {
 	public function testCreate_ReplaceableOnCreator_WithNoAvailableUser() {
 		$this->connection->expects( $this->once() )
 			->method( 'onTransactionCommitOrIdle' )
-			->will( $this->returnCallback( function( $callback ) {
+			->will( $this->returnCallback( function ( $callback ) {
 				return call_user_func( $callback ); }
 			) );
 

--- a/tests/phpunit/Importer/ImporterTest.php
+++ b/tests/phpunit/Importer/ImporterTest.php
@@ -148,7 +148,7 @@ class ImporterTest extends \PHPUnit_Framework_TestCase {
 
 		$this->contentCreator->expects( $this->once() )
 			->method( 'create' )
-			->with( $this->callback( function( $importContents ) {
+			->with( $this->callback( function ( $importContents ) {
 					$importContents->addError( 'BarError from create' );
 					$importContents->addError( [ 'Foo1', 'Foo2' ] );
 					return true;

--- a/tests/phpunit/Integration/HookDispatcherTest.php
+++ b/tests/phpunit/Integration/HookDispatcherTest.php
@@ -40,7 +40,7 @@ class HookDispatcherTest extends \PHPUnit_Framework_TestCase {
 
 		$hookDispatcher = new HookDispatcher();
 
-		$this->mwHooksHandler->register( 'SMW::Settings::BeforeInitializationComplete', function( &$configuration ) {
+		$this->mwHooksHandler->register( 'SMW::Settings::BeforeInitializationComplete', function ( &$configuration ) {
 			$configuration = [ 'Foo' ];
 		} );
 
@@ -57,7 +57,7 @@ class HookDispatcherTest extends \PHPUnit_Framework_TestCase {
 
 		$hookDispatcher = new HookDispatcher();
 
-		$this->mwHooksHandler->register( 'SMW::Setup::AfterInitializationComplete', function( &$vars ) {
+		$this->mwHooksHandler->register( 'SMW::Setup::AfterInitializationComplete', function ( &$vars ) {
 			$vars = [ 'Foo' ];
 		} );
 
@@ -74,7 +74,7 @@ class HookDispatcherTest extends \PHPUnit_Framework_TestCase {
 
 		$hookDispatcher = new HookDispatcher();
 
-		$this->mwHooksHandler->register( 'SMW::GroupPermissions::BeforeInitializationComplete', function( &$permissions ) {
+		$this->mwHooksHandler->register( 'SMW::GroupPermissions::BeforeInitializationComplete', function ( &$permissions ) {
 			$permissions = [ 'Foo' ];
 		} );
 
@@ -112,7 +112,7 @@ class HookDispatcherTest extends \PHPUnit_Framework_TestCase {
 			->disableOriginalConstructor()
 			->getMockForAbstractClass();
 
-		$this->mwHooksHandler->register( 'SMW::Admin::RegisterTaskHandlers', function( $taskHandlerRegistry, $store, $outputFormatter, $user ) use ( $taskHandler ) {
+		$this->mwHooksHandler->register( 'SMW::Admin::RegisterTaskHandlers', function ( $taskHandlerRegistry, $store, $outputFormatter, $user ) use ( $taskHandler ) {
 			$taskHandlerRegistry->registerTaskHandler( $taskHandler );
 		} );
 
@@ -133,8 +133,8 @@ class HookDispatcherTest extends \PHPUnit_Framework_TestCase {
 		$propertyChangeListener->expects( $this->once() )
 			->method( 'addListenerCallback' );
 
-		$this->mwHooksHandler->register( 'SMW::Listener::ChangeListener::RegisterPropertyChangeListeners', function( $propertyChangeListener ) use ( $property ) {
-			$propertyChangeListener->addListenerCallback( $property, function(){} );
+		$this->mwHooksHandler->register( 'SMW::Listener::ChangeListener::RegisterPropertyChangeListeners', function ( $propertyChangeListener ) use ( $property ) {
+			$propertyChangeListener->addListenerCallback( $property, function (){} );
 		} );
 
 		$hookDispatcher->onRegisterPropertyChangeListeners( $propertyChangeListener );
@@ -150,7 +150,7 @@ class HookDispatcherTest extends \PHPUnit_Framework_TestCase {
 		$constraintRegistry->expects( $this->once() )
 			->method( 'registerConstraint' );
 
-		$this->mwHooksHandler->register( 'SMW::Constraint::initConstraints', function( $constraintRegistry ) {
+		$this->mwHooksHandler->register( 'SMW::Constraint::initConstraints', function ( $constraintRegistry ) {
 			$constraintRegistry->registerConstraint( 'foo', 'bar' );
 		} );
 
@@ -167,7 +167,7 @@ class HookDispatcherTest extends \PHPUnit_Framework_TestCase {
 		$schemaTypes->expects( $this->once() )
 			->method( 'registerSchemaType' );
 
-		$this->mwHooksHandler->register( 'SMW::Schema::RegisterSchemaTypes', function( $schemaTypes ) {
+		$this->mwHooksHandler->register( 'SMW::Schema::RegisterSchemaTypes', function ( $schemaTypes ) {
 			$schemaTypes->registerSchemaType( 'Foo', [] );
 		} );
 
@@ -183,7 +183,7 @@ class HookDispatcherTest extends \PHPUnit_Framework_TestCase {
 			->disableOriginalConstructor()
 			->getMock();
 
-		$this->mwHooksHandler->register( 'SMW::GetPreferences', function( $user, &$preferences ) {
+		$this->mwHooksHandler->register( 'SMW::GetPreferences', function ( $user, &$preferences ) {
 			$preferences = [ 'Foo' ];
 		} );
 
@@ -200,7 +200,7 @@ class HookDispatcherTest extends \PHPUnit_Framework_TestCase {
 
 		$hookDispatcher = new HookDispatcher();
 
-		$this->mwHooksHandler->register( 'SMW::Parser::BeforeMagicWordsFinder', function( &$magicWords ) {
+		$this->mwHooksHandler->register( 'SMW::Parser::BeforeMagicWordsFinder', function ( &$magicWords ) {
 			$magicWords = [ 'Foo' ];
 		} );
 
@@ -221,7 +221,7 @@ class HookDispatcherTest extends \PHPUnit_Framework_TestCase {
 			->disableOriginalConstructor()
 			->getMock();
 
-		$this->mwHooksHandler->register( 'SMW::Parser::AfterLinksProcessingComplete', function( &$text, $annotationProcessor ) {
+		$this->mwHooksHandler->register( 'SMW::Parser::AfterLinksProcessingComplete', function ( &$text, $annotationProcessor ) {
 			$text = 'Foo';
 		} );
 
@@ -247,7 +247,7 @@ class HookDispatcherTest extends \PHPUnit_Framework_TestCase {
 			->disableOriginalConstructor()
 			->getMock();
 
-		$this->mwHooksHandler->register( 'SMW::Parser::ParserAfterTidyPropertyAnnotationComplete', function( $propertyAnnotator, $parserOutput ) {
+		$this->mwHooksHandler->register( 'SMW::Parser::ParserAfterTidyPropertyAnnotationComplete', function ( $propertyAnnotator, $parserOutput ) {
 			$propertyAnnotator->addAnnotation();
 		} );
 
@@ -268,7 +268,7 @@ class HookDispatcherTest extends \PHPUnit_Framework_TestCase {
 		$messageReporter->expects( $this->once() )
 			->method( 'reportMessage' );
 
-		$this->mwHooksHandler->register( 'SMW::Maintenance::AfterUpdateEntityCollationComplete', function( $store, $messageReporter ) {
+		$this->mwHooksHandler->register( 'SMW::Maintenance::AfterUpdateEntityCollationComplete', function ( $store, $messageReporter ) {
 			$messageReporter->reportMessage( 'foo' );
 		} );
 
@@ -284,7 +284,7 @@ class HookDispatcherTest extends \PHPUnit_Framework_TestCase {
 
 		$indicatorProviders = [];
 
-		$this->mwHooksHandler->register( 'SMW::Indicator::EntityExaminer::RegisterIndicatorProviders', function( $store, &$indicatorProviders ) {
+		$this->mwHooksHandler->register( 'SMW::Indicator::EntityExaminer::RegisterIndicatorProviders', function ( $store, &$indicatorProviders ) {
 			$indicatorProviders[] = 'Foo';
 		} );
 
@@ -305,7 +305,7 @@ class HookDispatcherTest extends \PHPUnit_Framework_TestCase {
 
 		$indicatorProviders = [];
 
-		$this->mwHooksHandler->register( 'SMW::Indicator::EntityExaminer::RegisterDeferrableIndicatorProviders', function( $store, &$indicatorProviders ) {
+		$this->mwHooksHandler->register( 'SMW::Indicator::EntityExaminer::RegisterDeferrableIndicatorProviders', function ( $store, &$indicatorProviders ) {
 			$indicatorProviders[] = 'Foo';
 		} );
 
@@ -324,7 +324,7 @@ class HookDispatcherTest extends \PHPUnit_Framework_TestCase {
 			->disableOriginalConstructor()
 			->getMock();
 
-		$this->mwHooksHandler->register( 'SMW::RevisionGuard::IsApprovedRevision', function( $title, $latestRevID ) {
+		$this->mwHooksHandler->register( 'SMW::RevisionGuard::IsApprovedRevision', function ( $title, $latestRevID ) {
 			return $latestRevID == 9999 ? false : true ;
 		} );
 
@@ -342,7 +342,7 @@ class HookDispatcherTest extends \PHPUnit_Framework_TestCase {
 
 		$latestRevID = 9999;
 
-		$this->mwHooksHandler->register( 'SMW::RevisionGuard::ChangeRevisionID', function( $title, &$latestRevID ) {
+		$this->mwHooksHandler->register( 'SMW::RevisionGuard::ChangeRevisionID', function ( $title, &$latestRevID ) {
 			$latestRevID = 1001;
 		} );
 
@@ -374,7 +374,7 @@ class HookDispatcherTest extends \PHPUnit_Framework_TestCase {
 			$file
 		);
 
-		$this->mwHooksHandler->register( 'SMW::RevisionGuard::ChangeFile', function( $title, &$file ) use ( $anotherFile ) {
+		$this->mwHooksHandler->register( 'SMW::RevisionGuard::ChangeFile', function ( $title, &$file ) use ( $anotherFile ) {
 			$file = $anotherFile;
 		} );
 
@@ -406,7 +406,7 @@ class HookDispatcherTest extends \PHPUnit_Framework_TestCase {
 			$anotherRevision
 		);
 
-		$this->mwHooksHandler->register( 'SMW::RevisionGuard::ChangeRevision', function( $title, &$revision ) use ( $anotherRevision ) {
+		$this->mwHooksHandler->register( 'SMW::RevisionGuard::ChangeRevision', function ( $title, &$revision ) use ( $anotherRevision ) {
 			$revision = $anotherRevision;
 		} );
 
@@ -430,7 +430,7 @@ class HookDispatcherTest extends \PHPUnit_Framework_TestCase {
 		$messageReporter->expects( $this->once() )
 			->method( 'reportMessage' );
 
-		$this->mwHooksHandler->register( 'SMW::SQLStore::Installer::BeforeCreateTablesComplete', function( $tables, $messageReporter ) {
+		$this->mwHooksHandler->register( 'SMW::SQLStore::Installer::BeforeCreateTablesComplete', function ( $tables, $messageReporter ) {
 			$messageReporter->reportMessage( 'foo' );
 		} );
 
@@ -455,7 +455,7 @@ class HookDispatcherTest extends \PHPUnit_Framework_TestCase {
 		$messageReporter->expects( $this->once() )
 			->method( 'reportMessage' );
 
-		$this->mwHooksHandler->register( 'SMW::SQLStore::Installer::AfterCreateTablesComplete', function( $tableBuilder, $messageReporter, $options ) {
+		$this->mwHooksHandler->register( 'SMW::SQLStore::Installer::AfterCreateTablesComplete', function ( $tableBuilder, $messageReporter, $options ) {
 			$messageReporter->reportMessage( 'foo' );
 		} );
 
@@ -480,7 +480,7 @@ class HookDispatcherTest extends \PHPUnit_Framework_TestCase {
 		$messageReporter->expects( $this->once() )
 			->method( 'reportMessage' );
 
-		$this->mwHooksHandler->register( 'SMW::SQLStore::Installer::AfterDropTablesComplete', function( $tableBuilder, $messageReporter, $options ) {
+		$this->mwHooksHandler->register( 'SMW::SQLStore::Installer::AfterDropTablesComplete', function ( $tableBuilder, $messageReporter, $options ) {
 			$messageReporter->reportMessage( 'foo' );
 		} );
 

--- a/tests/phpunit/Integration/InterwikiDBIntegrationTest.php
+++ b/tests/phpunit/Integration/InterwikiDBIntegrationTest.php
@@ -50,7 +50,7 @@ class InterwikiDBIntegrationTest extends DatabaseTestCase {
 			->invokeHooksFromRegistry();
 
 		// Manipulate the interwiki prefix on-the-fly
-		$GLOBALS['wgHooks']['InterwikiLoadPrefix'][] = function( $prefix, &$interwiki ) {
+		$GLOBALS['wgHooks']['InterwikiLoadPrefix'][] = function ( $prefix, &$interwiki ) {
 			if ( $prefix !== 'iw-test' ) {
 				return true;
 			}

--- a/tests/phpunit/Integration/JSONScript/JSONScriptTestCaseRunnerTest.php
+++ b/tests/phpunit/Integration/JSONScript/JSONScriptTestCaseRunnerTest.php
@@ -51,7 +51,7 @@ class JSONScriptTestCaseRunnerTest extends JSONScriptServicesTestCaseRunner {
 	 */
 	protected function getDependencyDefinitions() {
 		return [
-			'Maps' => function( $val, &$reason ) {
+			'Maps' => function ( $val, &$reason ) {
 				if ( !ExtensionRegistry::getInstance()->isLoaded( 'Maps' ) ) {
 					$reason = "Dependency: Maps (or Semantic Maps) as requirement for the test is not available!";
 					return false;
@@ -67,7 +67,7 @@ class JSONScriptTestCaseRunnerTest extends JSONScriptServicesTestCaseRunner {
 
 				return true;
 			},
-			'ext-intl' => function( $val, &$reason ) {
+			'ext-intl' => function ( $val, &$reason ) {
 				if ( !extension_loaded( 'intl' ) ) {
 					$reason = "Dependency: ext-intl (PHP extension, ICU collation) as requirement for the test is not available!";
 					return false;
@@ -75,7 +75,7 @@ class JSONScriptTestCaseRunnerTest extends JSONScriptServicesTestCaseRunner {
 
 				return true;
 			},
-			'ICU' => function( $val, &$reason ) {
+			'ICU' => function ( $val, &$reason ) {
 				if ( !extension_loaded( 'intl' ) ) {
 					$reason = "Dependency: ext-intl (PHP extension, ICU collation) as requirement for the test is not available!";
 					return false;

--- a/tests/phpunit/Integration/MediaWiki/Hooks/ParserFirstCallInitIntegrationTest.php
+++ b/tests/phpunit/Integration/MediaWiki/Hooks/ParserFirstCallInitIntegrationTest.php
@@ -85,7 +85,7 @@ class ParserFirstCallInitIntegrationTest extends DatabaseTestCase {
 
 		$this->store->expects( $this->any() )
 			->method( 'service' )
-			->will( $this->returnCallback( function( $service ) use( $singleEntityQueryLookup, $monolingualTextLookup ) {
+			->will( $this->returnCallback( function ( $service ) use( $singleEntityQueryLookup, $monolingualTextLookup ) {
 				if ( $service === 'SingleEntityQueryLookup' ) {
 					return $singleEntityQueryLookup;
 				}

--- a/tests/phpunit/Integration/MediaWiki/Import/TimeDataTypeTest.php
+++ b/tests/phpunit/Integration/MediaWiki/Import/TimeDataTypeTest.php
@@ -251,31 +251,31 @@ class TimeDataTypeTest extends DatabaseTestCase {
 	}
 
 	protected function setWikiValueDateValueFormatter() {
-		return function( $dataValue ) { return $dataValue->getWikiValue();
+		return function ( $dataValue ) { return $dataValue->getWikiValue();
 		};
 	}
 
 	protected function setWikiValueDateWithGRCalendarModelValueFormatter() {
-		return function( $dataValue ) {
+		return function ( $dataValue ) {
 			$dataValue->setOutputFormat( 'GR' );
 			return $dataValue->getWikiValue();
 		};
 	}
 
 	protected function setWikiValueDateWithJLCalendarModelValueFormatter() {
-		return function( $dataValue ) {
+		return function ( $dataValue ) {
 			$dataValue->setOutputFormat( 'JL' );
 			return $dataValue->getWikiValue();
 		};
 	}
 
 	protected function setISO8601DateValueFormatter() {
-		return function( $dataValue ) { return $dataValue->getISO8601Date();
+		return function ( $dataValue ) { return $dataValue->getISO8601Date();
 		};
 	}
 
 	protected function setMediaWikiDateValueFormatter() {
-		return function( $dataValue ) { return $dataValue->getMediaWikiDate();
+		return function ( $dataValue ) { return $dataValue->getMediaWikiDate();
 		};
 	}
 

--- a/tests/phpunit/Integration/Schema/FilteredSchemaListTest.php
+++ b/tests/phpunit/Integration/Schema/FilteredSchemaListTest.php
@@ -234,10 +234,10 @@ class FilteredSchemaListTest extends \PHPUnit_Framework_TestCase {
 
 		yield "'property-6-a', 'property-6-b' NS_MAIN" => [
 			NS_MAIN,
-			function() {
+			function () {
 				return [ 'category-6-a' ];
 			},
-			function(){
+			function (){
 				return [ new DIProperty( 'property-6-a' ), new DIProperty( 'property-6-b' ) ];
 			},
 			[ 'rule_6_2' ]

--- a/tests/phpunit/Integration/SemanticMediaWikiProvidedHookInterfaceIntegrationTest.php
+++ b/tests/phpunit/Integration/SemanticMediaWikiProvidedHookInterfaceIntegrationTest.php
@@ -128,7 +128,7 @@ class SemanticMediaWikiProvidedHookInterfaceIntegrationTest extends \PHPUnit_Fra
 		$store->expects( $this->once() )
 			->method( 'fetchQueryResult' );
 
-		$this->mwHooksHandler->register( 'SMW::Store::BeforeQueryResultLookupComplete', function( $store, $query, &$queryResult ) {
+		$this->mwHooksHandler->register( 'SMW::Store::BeforeQueryResultLookupComplete', function ( $store, $query, &$queryResult ) {
 			$queryResult = 'Foo';
 			return true;
 		} );
@@ -154,7 +154,7 @@ class SemanticMediaWikiProvidedHookInterfaceIntegrationTest extends \PHPUnit_Fra
 		$store->expects( $this->never() )
 			->method( 'fetchQueryResult' );
 
-		$this->mwHooksHandler->register( 'SMW::Store::BeforeQueryResultLookupComplete', function( $store, $query, &$queryResult ) {
+		$this->mwHooksHandler->register( 'SMW::Store::BeforeQueryResultLookupComplete', function ( $store, $query, &$queryResult ) {
 			$queryResult = 'Foo';
 
 			// Return false to suppress additional calls to fetchQueryResult
@@ -187,7 +187,7 @@ class SemanticMediaWikiProvidedHookInterfaceIntegrationTest extends \PHPUnit_Fra
 			->method( 'fetchQueryResult' )
 			->will( $this->returnValue( $queryResult ) );
 
-		$this->mwHooksHandler->register( 'SMW::Store::AfterQueryResultLookupComplete', function( $store, &$queryResult ) {
+		$this->mwHooksHandler->register( 'SMW::Store::AfterQueryResultLookupComplete', function ( $store, &$queryResult ) {
 			if ( !$queryResult instanceof \SMWQueryResult ) {
 				throw new RuntimeException( 'Expected a SMWQueryResult instance' );
 			}
@@ -254,7 +254,7 @@ class SemanticMediaWikiProvidedHookInterfaceIntegrationTest extends \PHPUnit_Fra
 
 		$this->applicationFactory->registerObject( 'Store', $store );
 
-		$this->mwHooksHandler->register( 'SMW::Factbox::BeforeContentGeneration', function( &$text, $semanticData ) {
+		$this->mwHooksHandler->register( 'SMW::Factbox::BeforeContentGeneration', function ( &$text, $semanticData ) {
 			$text = $semanticData->getSubject()->getTitle()->getText();
 			return false;
 		} );
@@ -349,7 +349,7 @@ class SemanticMediaWikiProvidedHookInterfaceIntegrationTest extends \PHPUnit_Fra
 		$null = 0;
 
 		$reachedTheBeforeChangeTitleCompleteHook = false;
-		$this->mwHooksHandler->register( 'SMW::SQLStore::BeforeChangeTitleComplete', function() use ( &$reachedTheBeforeChangeTitleCompleteHook ) {
+		$this->mwHooksHandler->register( 'SMW::SQLStore::BeforeChangeTitleComplete', function () use ( &$reachedTheBeforeChangeTitleCompleteHook ) {
 			$reachedTheBeforeChangeTitleCompleteHook = true;
 		} );
 
@@ -385,7 +385,7 @@ class SemanticMediaWikiProvidedHookInterfaceIntegrationTest extends \PHPUnit_Fra
 			->will( $this->returnValue( [] ) );
 
 		$reachedTheBeforeDeleteSubjectCompleteHook = false;
-		$this->mwHooksHandler->register( 'SMW::SQLStore::BeforeDeleteSubjectComplete', function() use ( &$reachedTheBeforeDeleteSubjectCompleteHook ) {
+		$this->mwHooksHandler->register( 'SMW::SQLStore::BeforeDeleteSubjectComplete', function () use ( &$reachedTheBeforeDeleteSubjectCompleteHook ) {
 			$reachedTheBeforeDeleteSubjectCompleteHook = true;
 		} );
 
@@ -423,7 +423,7 @@ class SemanticMediaWikiProvidedHookInterfaceIntegrationTest extends \PHPUnit_Fra
 			->will( $this->returnValue( [] ) );
 
 		$reachedTheAfterDeleteSubjectCompleteHook = false;
-		$this->mwHooksHandler->register( 'SMW::SQLStore::AfterDeleteSubjectComplete', function() use ( &$reachedTheAfterDeleteSubjectCompleteHook ) {
+		$this->mwHooksHandler->register( 'SMW::SQLStore::AfterDeleteSubjectComplete', function () use ( &$reachedTheAfterDeleteSubjectCompleteHook ) {
 			$reachedTheAfterDeleteSubjectCompleteHook = true;
 		} );
 
@@ -493,7 +493,7 @@ class SemanticMediaWikiProvidedHookInterfaceIntegrationTest extends \PHPUnit_Fra
 
 		$hookDispatcher->expects( $this->once() )
 			->method( 'onBeforeMagicWordsFinder' )
-			->will($this->returnCallback( function( &$magicWords ) {
+			->will($this->returnCallback( function ( &$magicWords ) {
 				$magicWords = [ 'Foo' ];
 			} ) );
 
@@ -511,7 +511,7 @@ class SemanticMediaWikiProvidedHookInterfaceIntegrationTest extends \PHPUnit_Fra
 			->setMethods( null )
 			->getMock();
 
-		$this->mwHooksHandler->register( 'SMW::SQLStore::AddCustomFixedPropertyTables', function( &$customFixedProperties, &$fixedPropertyTablePrefix ) {
+		$this->mwHooksHandler->register( 'SMW::SQLStore::AddCustomFixedPropertyTables', function ( &$customFixedProperties, &$fixedPropertyTablePrefix ) {
 			// Standard table prefix
 			$customFixedProperties['Foo'] = '_Bar';
 
@@ -554,7 +554,7 @@ class SemanticMediaWikiProvidedHookInterfaceIntegrationTest extends \PHPUnit_Fra
 
 		$store->setLogger( $this->spyLogger );
 
-		$this->mwHooksHandler->register( 'SMW::SQLStore::AfterDataUpdateComplete', function( $store, $semanticData, $changeOp ) use ( $test ){
+		$this->mwHooksHandler->register( 'SMW::SQLStore::AfterDataUpdateComplete', function ( $store, $semanticData, $changeOp ) use ( $test ){
 			$test->is( $changeOp->getChangedEntityIdSummaryList() );
 
 			return true;

--- a/tests/phpunit/Integration/SpecialsTest.php
+++ b/tests/phpunit/Integration/SpecialsTest.php
@@ -136,7 +136,7 @@ class SpecialsTest extends DatabaseTestCase {
 		foreach ( $specialPages as $special ) {
 			// Defer instantiating the special pages until the test runs
 			// to avoid prematurely capturing service references that may become stale later.
-			$specialPageCallable = static function() use ( $special, $request ): SpecialPage {
+			$specialPageCallable = static function () use ( $special, $request ): SpecialPage {
 				$specialPage = MediaWikiServices::getInstance()->getSpecialPageFactory()->getPage(
 					$special
 				);
@@ -148,7 +148,7 @@ class SpecialsTest extends DatabaseTestCase {
 				return $specialPage;
 			};
 
-			$specialPageWithSuperUserCallable = static function() use ( $special, $request ): SpecialPage {
+			$specialPageWithSuperUserCallable = static function () use ( $special, $request ): SpecialPage {
 				$specialPage = MediaWikiServices::getInstance()->getSpecialPageFactory()->getPage(
 					$special
 				);

--- a/tests/phpunit/IteratorFactoryTest.php
+++ b/tests/phpunit/IteratorFactoryTest.php
@@ -39,7 +39,7 @@ class IteratorFactoryTest extends \PHPUnit_Framework_TestCase {
 
 		$this->assertInstanceOf(
 			'\SMW\Iterators\MappingIterator',
-			$instance->newMappingIterator( $iterator, function(){
+			$instance->newMappingIterator( $iterator, function (){
 			} )
 		);
 	}

--- a/tests/phpunit/Iterators/MappingIteratorTest.php
+++ b/tests/phpunit/Iterators/MappingIteratorTest.php
@@ -22,14 +22,14 @@ class MappingIteratorTest extends \PHPUnit_Framework_TestCase {
 	public function testCanConstruct() {
 		$this->assertInstanceOf(
 			MappingIterator::class,
-			new MappingIterator( [], function() {
+			new MappingIterator( [], function () {
 			} )
 		);
 	}
 
 	public function testInvalidConstructorArgumentThrowsException() {
 		$this->expectException( 'RuntimeException' );
-		$instance = new MappingIterator( 2, function() {
+		$instance = new MappingIterator( 2, function () {
 		} );
 	}
 
@@ -38,7 +38,7 @@ class MappingIteratorTest extends \PHPUnit_Framework_TestCase {
 			1 , 42
 		];
 
-		$mappingIterator = new MappingIterator( $expected, function( $counter ) {
+		$mappingIterator = new MappingIterator( $expected, function ( $counter ) {
 			return $counter;
 		} );
 
@@ -55,7 +55,7 @@ class MappingIteratorTest extends \PHPUnit_Framework_TestCase {
 			1001 , 42
 		];
 
-		$mappingIterator = new MappingIterator( new ArrayIterator( $expected ), function( $counter ) {
+		$mappingIterator = new MappingIterator( new ArrayIterator( $expected ), function ( $counter ) {
 			return $counter;
 		} );
 

--- a/tests/phpunit/JSONScriptServicesTestCaseRunner.php
+++ b/tests/phpunit/JSONScriptServicesTestCaseRunner.php
@@ -153,7 +153,7 @@ abstract class JSONScriptServicesTestCaseRunner extends JSONScriptTestCaseRunner
 	protected function getPermittedSettings() {
 		parent::getPermittedSettings();
 
-		$elasticsearchConfig = function( $val ) {
+		$elasticsearchConfig = function ( $val ) {
 			if ( $this->getStore() instanceof \SMWElasticStore ) {
 				$config = $this->getStore()->getConnection( 'elastic' )->getConfig();
 
@@ -170,7 +170,7 @@ abstract class JSONScriptServicesTestCaseRunner extends JSONScriptTestCaseRunner
 		// Config isolation causes NamespaceInfo to not access the `MainConfig`
 		// therefore reset the services so that it copies the changed setting.
 		// https://github.com/wikimedia/mediawiki/commit/7ada64684e6477be44405dedbfdb0d96242f2e73
-		$capitalLinks = function( $val ) {
+		$capitalLinks = function ( $val ) {
 			$this->testEnvironment->resetMediaWikiService( 'NamespaceInfo' );
 			return $val;
 		};

--- a/tests/phpunit/JSONScriptTestCaseRunner.php
+++ b/tests/phpunit/JSONScriptTestCaseRunner.php
@@ -147,7 +147,7 @@ abstract class JSONScriptTestCaseRunner extends DatabaseTestCase {
 	protected function getPermittedSettings() {
 		// Ensure that the context is set for a selected language
 		// and dependent objects are reset
-		$this->registerConfigValueCallback( 'wgContLang', function( $val ) {
+		$this->registerConfigValueCallback( 'wgContLang', function ( $val ) {
 			\RequestContext::getMain()->setLanguage( $val );
 			Localizer::clear();
 			// #4682, Avoid any surprises when the `wgLanguageCode` is changed during a test
@@ -163,7 +163,7 @@ abstract class JSONScriptTestCaseRunner extends DatabaseTestCase {
 			return $lang;
 		} );
 
-		$this->registerConfigValueCallback( 'wgLang', function( $val ) {
+		$this->registerConfigValueCallback( 'wgLang', function ( $val ) {
 			\RequestContext::getMain()->setLanguage( $val );
 			Localizer::clear();
 			\SMW\NamespaceManager::clear();

--- a/tests/phpunit/Localizer/MessageTest.php
+++ b/tests/phpunit/Localizer/MessageTest.php
@@ -41,7 +41,7 @@ class MessageTest extends \PHPUnit_Framework_TestCase {
 	public function testRegisteredHandler() {
 		$instance = new Message();
 
-		$instance->registerCallbackHandler( 'Foo', function( $parameters, $language ) {
+		$instance->registerCallbackHandler( 'Foo', function ( $parameters, $language ) {
 			if ( $parameters[0] === 'Foo' && $language === Message::CONTENT_LANGUAGE ) {
 				return 'Foobar';
 			}
@@ -86,7 +86,7 @@ class MessageTest extends \PHPUnit_Framework_TestCase {
 		$instance = new Message();
 		$instance->clear();
 
-		$instance->registerCallbackHandler( 'Foo', function( $parameters, $language ) use ( $instanceSpy ){
+		$instance->registerCallbackHandler( 'Foo', function ( $parameters, $language ) use ( $instanceSpy ){
 			$instanceSpy->hasLanguage( $language );
 			return 'UNKNOWN';
 		} );
@@ -99,7 +99,7 @@ class MessageTest extends \PHPUnit_Framework_TestCase {
 		$instance = new Message();
 		$instance->clear();
 
-		$instance->registerCallbackHandler( 'SimpleText', function( $parameters, $language ) {
+		$instance->registerCallbackHandler( 'SimpleText', function ( $parameters, $language ) {
 			return 'Foo';
 		} );
 

--- a/tests/phpunit/MediaWiki/Api/BrowseBySubjectTest.php
+++ b/tests/phpunit/MediaWiki/Api/BrowseBySubjectTest.php
@@ -205,23 +205,23 @@ class BrowseBySubjectTest extends \PHPUnit_Framework_TestCase {
 
 	public function assertToContainArrayKeys( $setup, $result ) {
 		$this->assertInternalArrayStructure(
-			$setup, $result, 'error', 'array', function( $r ) { return $r['error'];
+			$setup, $result, 'error', 'array', function ( $r ) { return $r['error'];
 			} );
 
 		$this->assertInternalArrayStructure(
-			$setup, $result, 'result', 'array', function( $r ) { return $r['query'];
+			$setup, $result, 'result', 'array', function ( $r ) { return $r['query'];
 			} );
 
 		$this->assertInternalArrayStructure(
-			$setup, $result, 'subject', 'string', function( $r ) { return $r['query']['subject'];
+			$setup, $result, 'subject', 'string', function ( $r ) { return $r['query']['subject'];
 			} );
 
 		$this->assertInternalArrayStructure(
-			$setup, $result, 'data', 'array', function( $r ) { return $r['query']['data'];
+			$setup, $result, 'data', 'array', function ( $r ) { return $r['query']['data'];
 			} );
 
 		$this->assertInternalArrayStructure(
-			$setup, $result, 'sobj', 'array', function( $r ) { return $r['query']['sobj'];
+			$setup, $result, 'sobj', 'array', function ( $r ) { return $r['query']['sobj'];
 			} );
 	}
 

--- a/tests/phpunit/MediaWiki/Connection/ConnectionProviderTest.php
+++ b/tests/phpunit/MediaWiki/Connection/ConnectionProviderTest.php
@@ -101,7 +101,7 @@ class ConnectionProviderTest extends \PHPUnit_Framework_TestCase {
 
 		$conf = [
 			'foo' => [
-				'callback'  => function() use( $db ) {
+				'callback'  => function () use( $db ) {
 					return $db;
 				}
 			]

--- a/tests/phpunit/MediaWiki/Connection/SequenceTest.php
+++ b/tests/phpunit/MediaWiki/Connection/SequenceTest.php
@@ -67,7 +67,7 @@ class SequenceTest extends \PHPUnit_Framework_TestCase {
 
 		$this->connection->expects( $this->once() )
 			->method( 'onTransactionCommitOrIdle' )
-			->will( $this->returnCallback( function( $callback ) { return $callback(); } ) );
+			->will( $this->returnCallback( function ( $callback ) { return $callback(); } ) );
 
 		$this->connection->expects( $this->once() )
 			->method( 'query' )

--- a/tests/phpunit/MediaWiki/Deferred/CallableUpdateTest.php
+++ b/tests/phpunit/MediaWiki/Deferred/CallableUpdateTest.php
@@ -35,7 +35,7 @@ class CallableUpdateTest extends \PHPUnit_Framework_TestCase {
 	}
 
 	public function testCanConstruct() {
-		$callback = function() {
+		$callback = function () {
 			return null;
 		};
 
@@ -54,7 +54,7 @@ class CallableUpdateTest extends \PHPUnit_Framework_TestCase {
 		$test->expects( $this->once() )
 			->method( 'doTest' );
 
-		$callback = function() use ( $test ) {
+		$callback = function () use ( $test ) {
 			$test->doTest();
 		};
 
@@ -69,7 +69,7 @@ class CallableUpdateTest extends \PHPUnit_Framework_TestCase {
 	}
 
 	public function testUpdateThatThrowsExceptionToLogAndRethrow() {
-		$callback = function() {
+		$callback = function () {
 			throw new \Exception("Error Processing Request", 1);
 		};
 
@@ -114,7 +114,7 @@ class CallableUpdateTest extends \PHPUnit_Framework_TestCase {
 		$test->expects( $this->once() )
 			->method( 'doTest' );
 
-		$callback = function() use ( $test ) {
+		$callback = function () use ( $test ) {
 			$test->doTest();
 		};
 
@@ -140,7 +140,7 @@ class CallableUpdateTest extends \PHPUnit_Framework_TestCase {
 		$test->expects( $this->once() )
 			->method( 'doTest' );
 
-		$callback = function() use ( $test ) {
+		$callback = function () use ( $test ) {
 			$test->doTest();
 		};
 
@@ -167,7 +167,7 @@ class CallableUpdateTest extends \PHPUnit_Framework_TestCase {
 		$test->expects( $this->once() )
 			->method( 'doTest' );
 
-		$callback = function() use ( $test ) {
+		$callback = function () use ( $test ) {
 			$test->doTest();
 		};
 
@@ -182,7 +182,7 @@ class CallableUpdateTest extends \PHPUnit_Framework_TestCase {
 	}
 
 	public function testOrigin() {
-		$callback = function() {
+		$callback = function () {
 		};
 
 		$instance = new CallableUpdate(
@@ -206,7 +206,7 @@ class CallableUpdateTest extends \PHPUnit_Framework_TestCase {
 		$test->expects( $this->once() )
 			->method( 'doTest' );
 
-		$callback = function() use ( $test ) {
+		$callback = function () use ( $test ) {
 			$test->doTest();
 		};
 

--- a/tests/phpunit/MediaWiki/Deferred/TransactionalCallableUpdateTest.php
+++ b/tests/phpunit/MediaWiki/Deferred/TransactionalCallableUpdateTest.php
@@ -40,7 +40,7 @@ class TransactionalCallableUpdateTest extends \PHPUnit_Framework_TestCase {
 	}
 
 	public function testCanConstruct() {
-		$callback = function() {
+		$callback = function () {
 			return null;
 		};
 
@@ -64,7 +64,7 @@ class TransactionalCallableUpdateTest extends \PHPUnit_Framework_TestCase {
 		$test->expects( $this->once() )
 			->method( 'doTest' );
 
-		$callback = function() use ( $test ) {
+		$callback = function () use ( $test ) {
 			$test->doTest();
 		};
 
@@ -110,7 +110,7 @@ class TransactionalCallableUpdateTest extends \PHPUnit_Framework_TestCase {
 		$test->expects( $this->once() )
 			->method( 'doTest' );
 
-		$callback = function() use ( $test ) {
+		$callback = function () use ( $test ) {
 			$test->doTest();
 		};
 
@@ -136,7 +136,7 @@ class TransactionalCallableUpdateTest extends \PHPUnit_Framework_TestCase {
 		$test->expects( $this->once() )
 			->method( 'doTest' );
 
-		$callback = function() use ( $test ) {
+		$callback = function () use ( $test ) {
 			$test->doTest();
 		};
 
@@ -164,7 +164,7 @@ class TransactionalCallableUpdateTest extends \PHPUnit_Framework_TestCase {
 		$test->expects( $this->once() )
 			->method( 'doTest' );
 
-		$callback = function() use ( $test ) {
+		$callback = function () use ( $test ) {
 			$test->doTest();
 		};
 
@@ -180,7 +180,7 @@ class TransactionalCallableUpdateTest extends \PHPUnit_Framework_TestCase {
 	}
 
 	public function testOrigin() {
-		$callback = function() {
+		$callback = function () {
 		};
 
 		$instance = new TransactionalCallableUpdate(
@@ -207,7 +207,7 @@ class TransactionalCallableUpdateTest extends \PHPUnit_Framework_TestCase {
 		$test->expects( $this->once() )
 			->method( 'doTest' );
 
-		$callback = function() use ( $test ) {
+		$callback = function () use ( $test ) {
 			$test->doTest();
 		};
 
@@ -237,7 +237,7 @@ class TransactionalCallableUpdateTest extends \PHPUnit_Framework_TestCase {
 	}
 
 	public function testUpdateOnTransactionIdle() {
-		$callback = function( $callback ) {
+		$callback = function ( $callback ) {
 			return call_user_func( $callback );
 		};
 
@@ -259,7 +259,7 @@ class TransactionalCallableUpdateTest extends \PHPUnit_Framework_TestCase {
 		$test->expects( $this->once() )
 			->method( 'doTest' );
 
-		$callback = function() use ( $test ) {
+		$callback = function () use ( $test ) {
 			$test->doTest();
 		};
 
@@ -294,7 +294,7 @@ class TransactionalCallableUpdateTest extends \PHPUnit_Framework_TestCase {
 		$test->expects( $this->once() )
 			->method( 'doTest' );
 
-		$callback = function() use ( $test ) {
+		$callback = function () use ( $test ) {
 			$test->doTest();
 		};
 
@@ -330,7 +330,7 @@ class TransactionalCallableUpdateTest extends \PHPUnit_Framework_TestCase {
 		$test->expects( $this->once() )
 			->method( 'doTest' );
 
-		$callback = function() use ( $test ) {
+		$callback = function () use ( $test ) {
 			$test->doTest();
 		};
 
@@ -366,7 +366,7 @@ class TransactionalCallableUpdateTest extends \PHPUnit_Framework_TestCase {
 		$test->expects( $this->never() )
 			->method( 'doTest' );
 
-		$callback = function() use ( $test ) {
+		$callback = function () use ( $test ) {
 			$test->doTest();
 		};
 

--- a/tests/phpunit/MediaWiki/Jobs/ChangePropagationDispatchJobTest.php
+++ b/tests/phpunit/MediaWiki/Jobs/ChangePropagationDispatchJobTest.php
@@ -235,7 +235,7 @@ class ChangePropagationDispatchJobTest extends \PHPUnit_Framework_TestCase {
 		$subject = DIWikiPage::newFromText( 'Foo' );
 
 		// Check that it is the dataItem from `getPropertyValues`
-		$checkJobParameterCallback = function( $jobs ) use( $dataItem ) {
+		$checkJobParameterCallback = function ( $jobs ) use( $dataItem ) {
 			foreach ( $jobs as $job ) {
 				return DIWikiPage::newFromTitle( $job->getTitle() )->equals( $dataItem );
 			}

--- a/tests/phpunit/MediaWiki/Jobs/ParserCachePurgeJobTest.php
+++ b/tests/phpunit/MediaWiki/Jobs/ParserCachePurgeJobTest.php
@@ -29,7 +29,7 @@ class ParserCachePurgeJobTest extends \PHPUnit_Framework_TestCase {
 	public function testRun() {
 		$action = 'Foo';
 
-		$updateParserCacheCallback = function( $parameters ) use( $action ) {
+		$updateParserCacheCallback = function ( $parameters ) use( $action ) {
 			return $parameters['causeAction'] === $action;
 		};
 

--- a/tests/phpunit/MediaWiki/Page/ListBuilderTest.php
+++ b/tests/phpunit/MediaWiki/Page/ListBuilderTest.php
@@ -115,7 +115,7 @@ class ListBuilderTest extends \PHPUnit_Framework_TestCase {
 			$this->store
 		);
 
-		$instance->setItemFormatter( function( $dataValue, $linker ) {
+		$instance->setItemFormatter( function ( $dataValue, $linker ) {
 			return 'Bar';
 		} );
 

--- a/tests/phpunit/MediaWiki/PageUpdaterTest.php
+++ b/tests/phpunit/MediaWiki/PageUpdaterTest.php
@@ -256,7 +256,7 @@ class PageUpdaterTest extends \PHPUnit_Framework_TestCase {
 
 		$this->connection->expects( $this->once() )
 			->method( 'onTransactionCommitOrIdle' )
-			->will( $this->returnCallback( function( $callback ) {
+			->will( $this->returnCallback( function ( $callback ) {
 				return call_user_func( $callback ); }
 			) );
 

--- a/tests/phpunit/MediaWiki/Search/SearchEngineFactoryTest.php
+++ b/tests/phpunit/MediaWiki/Search/SearchEngineFactoryTest.php
@@ -101,7 +101,7 @@ class SearchEngineFactoryTest extends \PHPUnit_Framework_TestCase {
 			->disableOriginalConstructor()
 			->getMock();
 
-		$callback = function() use( $fallbackSearchEngine ) {
+		$callback = function () use( $fallbackSearchEngine ) {
 			return $fallbackSearchEngine;
 		};
 
@@ -116,7 +116,7 @@ class SearchEngineFactoryTest extends \PHPUnit_Framework_TestCase {
 	}
 
 	public function testNewFallbackSearchEngine_ConstructFromInvalidCallableThrowsException() {
-		$callback = function() {
+		$callback = function () {
 			return new \stdClass;
 		};
 

--- a/tests/phpunit/ParameterListDocBuilderTest.php
+++ b/tests/phpunit/ParameterListDocBuilderTest.php
@@ -31,7 +31,7 @@ class ParameterListDocBuilderTest extends \PHPUnit_Framework_TestCase {
 
 		$this->stringValidator = UtilityFactory::getInstance()->newValidatorFactory()->newStringValidator();
 
-		$this->builder = new ParameterListDocBuilder( function( $key ) {
+		$this->builder = new ParameterListDocBuilder( function ( $key ) {
 			return $key;
 		} );
 	}

--- a/tests/phpunit/Query/DescriptionBuilders/RecordValueDescriptionBuilderTest.php
+++ b/tests/phpunit/Query/DescriptionBuilders/RecordValueDescriptionBuilderTest.php
@@ -49,7 +49,7 @@ class RecordValueDescriptionBuilderTest extends \PHPUnit_Framework_TestCase {
 		$recordValue->expects( $this->any() )
 			->method( 'getValuesFromString' )
 			->with( $this->stringContains( $value ) )
-			->will( $this->returnCallback( function( $value ) {
+			->will( $this->returnCallback( function ( $value ) {
 				 return explode(';', $value );
 			} ) );
 

--- a/tests/phpunit/Query/Result/StringResultTest.php
+++ b/tests/phpunit/Query/Result/StringResultTest.php
@@ -60,7 +60,7 @@ class StringResultTest extends \PHPUnit_Framework_TestCase {
 	public function testGetResult_PreOutputCallback() {
 		$instance = new StringResult( 'Foobar', $this->query );
 
-		$instance->setPreOutputCallback( function( $result, $options ) {
+		$instance->setPreOutputCallback( function ( $result, $options ) {
 			return $result . ' Foo bar';
 		} );
 

--- a/tests/phpunit/QueryPrinterRegistryTestCase.php
+++ b/tests/phpunit/QueryPrinterRegistryTestCase.php
@@ -64,7 +64,7 @@ abstract class QueryPrinterRegistryTestCase extends QueryPrinterTestCase {
 		$phpFails = [ $this, 'newInstance' ];
 
 		return array_map(
-			function( array $args ) use ( $phpFails ) {
+			function ( array $args ) use ( $phpFails ) {
 				return call_user_func_array( $phpFails, $args );
 			},
 			$this->constructorProvider()

--- a/tests/phpunit/SQLStore/EntityStore/SemanticDataLookupTest.php
+++ b/tests/phpunit/SQLStore/EntityStore/SemanticDataLookupTest.php
@@ -264,7 +264,7 @@ class SemanticDataLookupTest extends \PHPUnit_Framework_TestCase {
 
 		$this->connection->expects( $this->any() )
 			->method( 'addQuotes' )
-			->will( $this->returnCallback( function( $value ) { return "'$value'"; } ) );
+			->will( $this->returnCallback( function ( $value ) { return "'$value'"; } ) );
 
 		$this->connection->expects( $this->once() )
 			->method( 'readQuery' )
@@ -324,7 +324,7 @@ class SemanticDataLookupTest extends \PHPUnit_Framework_TestCase {
 
 		$this->connection->expects( $this->any() )
 			->method( 'addQuotes' )
-			->will( $this->returnCallback( function( $value ) { return "'$value'"; } ) );
+			->will( $this->returnCallback( function ( $value ) { return "'$value'"; } ) );
 
 		$this->connection->expects( $this->once() )
 			->method( 'readQuery' )
@@ -375,7 +375,7 @@ class SemanticDataLookupTest extends \PHPUnit_Framework_TestCase {
 
 		$this->connection->expects( $this->any() )
 			->method( 'addQuotes' )
-			->will( $this->returnCallback( function( $value ) { return "'$value'"; } ) );
+			->will( $this->returnCallback( function ( $value ) { return "'$value'"; } ) );
 
 		$this->connection->expects( $this->once() )
 			->method( 'readQuery' )
@@ -481,7 +481,7 @@ class SemanticDataLookupTest extends \PHPUnit_Framework_TestCase {
 
 		$this->connection->expects( $this->any() )
 			->method( 'addQuotes' )
-			->will( $this->returnCallback( function( $value ) { return "'$value'"; } ) );
+			->will( $this->returnCallback( function ( $value ) { return "'$value'"; } ) );
 
 		$this->connection->expects( $this->once() )
 			->method( 'readQuery' )
@@ -551,7 +551,7 @@ class SemanticDataLookupTest extends \PHPUnit_Framework_TestCase {
 
 		$this->connection->expects( $this->any() )
 			->method( 'addQuotes' )
-			->will( $this->returnCallback( function( $value ) { return "'$value'"; } ) );
+			->will( $this->returnCallback( function ( $value ) { return "'$value'"; } ) );
 
 		$this->connection->expects( $this->atLeastOnce() )
 			->method( 'readQuery' )

--- a/tests/phpunit/SQLStore/InstallerTest.php
+++ b/tests/phpunit/SQLStore/InstallerTest.php
@@ -271,7 +271,7 @@ class InstallerTest extends \PHPUnit_Framework_TestCase {
 			$this->tableOptimizer
 		);
 
-		$callback = function() use( $instance ) {
+		$callback = function () use( $instance ) {
 			$instance->reportMessage( 'Foo' );
 		};
 

--- a/tests/phpunit/SQLStore/PropertyStatisticsStoreTest.php
+++ b/tests/phpunit/SQLStore/PropertyStatisticsStoreTest.php
@@ -194,7 +194,7 @@ class PropertyStatisticsStoreTest extends DatabaseTestCase {
 
 		$connection->expects( $this->once() )
 			->method( 'onTransactionCommitOrIdle' )
-			->will( $this->returnCallback( function( $callback ) {
+			->will( $this->returnCallback( function ( $callback ) {
 				return call_user_func( $callback );
 			}
 			) );

--- a/tests/phpunit/SQLStore/PropertyTableIdReferenceDisposerTest.php
+++ b/tests/phpunit/SQLStore/PropertyTableIdReferenceDisposerTest.php
@@ -271,7 +271,7 @@ class PropertyTableIdReferenceDisposerTest extends \PHPUnit_Framework_TestCase {
 
 		$connection->expects( $this->once() )
 			->method( 'onTransactionCommitOrIdle' )
-			->will( $this->returnCallback( function( $callback ) {
+			->will( $this->returnCallback( function ( $callback ) {
 				return call_user_func( $callback );
 			}
 			) );
@@ -322,7 +322,7 @@ class PropertyTableIdReferenceDisposerTest extends \PHPUnit_Framework_TestCase {
 
 		$connection->expects( $this->once() )
 			->method( 'onTransactionCommitOrIdle' )
-			->will( $this->returnCallback( function( $callback ) {
+			->will( $this->returnCallback( function ( $callback ) {
 				return $callback();
 			} ) );
 

--- a/tests/phpunit/Schema/Filters/CategoryFilterTest.php
+++ b/tests/phpunit/Schema/Filters/CategoryFilterTest.php
@@ -75,7 +75,7 @@ class CategoryFilterTest extends \PHPUnit_Framework_TestCase {
 			->disableOriginalConstructor()
 			->getMock();
 
-		$callback = function() {
+		$callback = function () {
 			return null;
 		};
 
@@ -107,7 +107,7 @@ class CategoryFilterTest extends \PHPUnit_Framework_TestCase {
 	 * @dataProvider categoryFilterProvider
 	 */
 	public function testHasMatches_Callback_Compartment( $categories, $compartment, $expected ) {
-		$callback = function() use ( $categories ) {
+		$callback = function () use ( $categories ) {
 			return $categories;
 		};
 

--- a/tests/phpunit/Schema/Filters/PropertyFilterTest.php
+++ b/tests/phpunit/Schema/Filters/PropertyFilterTest.php
@@ -75,7 +75,7 @@ class PropertyFilterTest extends \PHPUnit_Framework_TestCase {
 			->disableOriginalConstructor()
 			->getMock();
 
-		$callback = function() {
+		$callback = function () {
 			return null;
 		};
 
@@ -107,7 +107,7 @@ class PropertyFilterTest extends \PHPUnit_Framework_TestCase {
 	 * @dataProvider propertyFilterProvider
 	 */
 	public function testHasMatches_Callback_Compartment( $properties, $compartment, $expected ) {
-		$callback = function() use ( $properties ) {
+		$callback = function () use ( $properties ) {
 			return $properties;
 		};
 

--- a/tests/phpunit/Schema/SchemaFactoryTest.php
+++ b/tests/phpunit/Schema/SchemaFactoryTest.php
@@ -121,7 +121,7 @@ class SchemaFactoryTest extends \PHPUnit_Framework_TestCase {
 	}
 
 	public function testPushChangePropagationDispatchJob() {
-		$checkJobParameterCallback = function( $job ) {
+		$checkJobParameterCallback = function ( $job ) {
 			return $job->getParameter( 'property_key' ) === 'FOO' && $job->hasParameter( 'schema_change_propagation' );
 		};
 
@@ -144,7 +144,7 @@ class SchemaFactoryTest extends \PHPUnit_Framework_TestCase {
 	}
 
 	public function testPushChangePropagationDispatchJob_CastAsArray() {
-		$checkJobParameterCallback = function( $job ) {
+		$checkJobParameterCallback = function ( $job ) {
 			return $job->getParameter( 'property_key' ) === 'FOO' && $job->hasParameter( 'schema_change_propagation' );
 		};
 

--- a/tests/phpunit/Services/ServicesContainerTest.php
+++ b/tests/phpunit/Services/ServicesContainerTest.php
@@ -104,7 +104,7 @@ class ServicesContainerTest extends \PHPUnit_Framework_TestCase {
 
 		$instance = new ServicesContainer();
 
-		$closure = function( $arg ) use( $fake ) {
+		$closure = function ( $arg ) use( $fake ) {
 			$fake->runService( $arg );
 		};
 

--- a/tests/phpunit/Services/ServicesFactoryTest.php
+++ b/tests/phpunit/Services/ServicesFactoryTest.php
@@ -220,7 +220,7 @@ class ServicesFactoryTest extends \PHPUnit_Framework_TestCase {
 	}
 
 	public function testCanConstructDeferredCallableUpdate() {
-		$callback = function() {
+		$callback = function () {
 			return null;
 		};
 

--- a/tests/phpunit/Structure/LocalLanguageFileIntegrityTest.php
+++ b/tests/phpunit/Structure/LocalLanguageFileIntegrityTest.php
@@ -68,7 +68,7 @@ class LocalLanguageFileIntegrityTest extends \PHPUnit_Framework_TestCase {
 	}
 
 	public function i18nFileProvider() {
-		return array_filter( $this->findFilesIn( $GLOBALS['smwgExtraneousLanguageFileDir'] ), function( $args ) {
+		return array_filter( $this->findFilesIn( $GLOBALS['smwgExtraneousLanguageFileDir'] ), function ( $args ) {
 			$file = $args[0];
 			$jsonFileReader = UtilityFactory::getInstance()->newJsonFileReader( $file );
 			$contents = $jsonFileReader->read();

--- a/tests/phpunit/Utils/JSONScript/JsonTestCaseFileHandler.php
+++ b/tests/phpunit/Utils/JSONScript/JsonTestCaseFileHandler.php
@@ -470,7 +470,7 @@ class JsonTestCaseFileHandler {
 	 * @return array
 	 */
 	public function findTestCasesByType( $type ) {
-		return array_filter( $this->getContentsFor( 'tests' ), function( $contents ) use( $type ) {
+		return array_filter( $this->getContentsFor( 'tests' ), function ( $contents ) use( $type ) {
 			return isset( $contents['type'] ) && $contents['type'] === $type;
 		} );
 	}

--- a/tests/phpunit/Utils/PageCreator.php
+++ b/tests/phpunit/Utils/PageCreator.php
@@ -64,7 +64,7 @@ class PageCreator {
 		if ( $pageContentLanguage !== '' ) {
 			$services = MediaWikiServices::getInstance();
 			$pageContentLanguage = $services->getLanguageFactory()->getLanguage( $pageContentLanguage );
-			$services->getHookContainer()->register( 'PageContentLanguage', function( $titleByHook, &$pageLang ) use( $title, $pageContentLanguage ) {
+			$services->getHookContainer()->register( 'PageContentLanguage', function ( $titleByHook, &$pageLang ) use( $title, $pageContentLanguage ) {
 				// Only change the pageContentLanguage for the selected page
 				if ( $title->getPrefixedDBKey() === $titleByHook->getPrefixedDBKey() ) {
 					$pageLang = $pageContentLanguage;

--- a/tests/phpunit/Utils/Validators/QueryResultValidator.php
+++ b/tests/phpunit/Utils/Validators/QueryResultValidator.php
@@ -200,7 +200,7 @@ class QueryResultValidator extends \PHPUnit_Framework_Assert {
 	 * @return QueryResultValidator
 	 */
 	public function useWikiValueForDataValueValidation() {
-		$this->dataValueValidationMethod = function( DataValue $expectedDataValue, DataValue $dataValue ) {
+		$this->dataValueValidationMethod = function ( DataValue $expectedDataValue, DataValue $dataValue ) {
 			return $expectedDataValue->getWikiValue() === $dataValue->getWikiValue();
 		};
 

--- a/tests/phpunit/Utils/Validators/StringValidator.php
+++ b/tests/phpunit/Utils/Validators/StringValidator.php
@@ -20,7 +20,7 @@ class StringValidator extends \PHPUnit_Framework_Assert {
 	 * @param string $actual
 	 */
 	public function assertThatStringContains( $expected, $actual, $message = '' ) {
-		$callback = function( &$expected, $actual, &$actualCounted ) {
+		$callback = function ( &$expected, $actual, &$actualCounted ) {
 			foreach ( $expected as $key => $pattern ) {
 				if ( $this->isMatch( $pattern, $actual ) ) {
 					$actualCounted++;
@@ -39,7 +39,7 @@ class StringValidator extends \PHPUnit_Framework_Assert {
 	 * @param string $actual
 	 */
 	public function assertThatStringNotContains( $expected, $actual, $message = '' ) {
-		$callback = function( &$expected, $actual, &$actualCounted ) {
+		$callback = function ( &$expected, $actual, &$actualCounted ) {
 			foreach ( $expected as $key => $pattern ) {
 				if ( $this->isMatch( $pattern, $actual ) === false ) {
 					$actualCounted++;

--- a/tests/phpunit/includes/ContentParserTest.php
+++ b/tests/phpunit/includes/ContentParserTest.php
@@ -60,7 +60,7 @@ class ContentParserTest extends \PHPUnit_Framework_TestCase {
 
 	protected function tearDown(): void {
 		if ( $this->contentRenderer !== null ) {
-			$this->testEnvironment->redefineMediaWikiService( 'ContentRenderer', fn() => $this->contentRenderer );
+			$this->testEnvironment->redefineMediaWikiService( 'ContentRenderer', fn () => $this->contentRenderer );
 		}
 		$this->testEnvironment->tearDown();
 		parent::tearDown();

--- a/tests/phpunit/includes/SemanticDataTest.php
+++ b/tests/phpunit/includes/SemanticDataTest.php
@@ -554,7 +554,7 @@ class SemanticDataTest extends \PHPUnit_Framework_TestCase {
 			$instance->getExtensionData( 'Foo' )
 		);
 
-		$callback = function() { return 42; };
+		$callback = function () { return 42; };
 
 		$instance->setExtensionData( 'Bar', $callback );
 

--- a/tests/phpunit/includes/dataitems/DataItemTest.php
+++ b/tests/phpunit/includes/dataitems/DataItemTest.php
@@ -55,7 +55,7 @@ abstract class DataItemTest extends DatabaseTestCase {
 		$phpFails = [ $this, 'newInstance' ];
 
 		return array_map(
-			function( array $args ) use ( $phpFails ) {
+			function ( array $args ) use ( $phpFails ) {
 				return [ call_user_func_array( $phpFails, $args ) ];
 			},
 			$this->constructorProvider()


### PR DESCRIPTION
Clear and fix sniff **MediaWiki.WhiteSpace.SpaceAfterClosure** reported by phpcs and improve code quality.
As a part of this PR we have cleared and fixed 2 subgroups of **MediaWiki.WhiteSpace.SpaceAfterClosure** like:

- NoWhitespaceAfterClosure,
- NoWhitespaceAfterArrow