### PR TITLE
Issue 5667 - fix sniffs Squiz.WhiteSpace.ObjectOperatorSpacing:

### DIFF
--- a/.phpcs.xml
+++ b/.phpcs.xml
@@ -137,7 +137,6 @@
 		<exclude name="MediaWiki.PHPUnit.MockBoilerplate.returnValueMap" />
 		<exclude name="Generic.Formatting.SpaceAfterNot.Incorrect" />
 		<exclude name="PSR2.Files.EndFileNewline.TooMany" />
-		<exclude name="Squiz.WhiteSpace.ObjectOperatorSpacing.Before" />
 		<exclude name="MediaWiki.WhiteSpace.SpaceyParenthesis.SpaceBeforeOpeningParenthesis" />
 		<exclude name="Generic.Functions.OpeningFunctionBraceKernighanRitchie.SpaceBeforeBrace" />
 		<exclude name="MediaWiki.PHPUnit.MockBoilerplate.ExactlyOnce" />
@@ -177,7 +176,6 @@
 		<exclude name="PSR2.ControlStructures.ElseIfDeclaration.NotAllowed" />
 		<exclude name="MediaWiki.Usage.ForbiddenFunctions.assert" />
 		<exclude name="MediaWiki.Commenting.FunctionComment.NotParenthesisParamType" />
-		<exclude name="Squiz.WhiteSpace.ObjectOperatorSpacing.After" />
 		<exclude name="Squiz.Classes.SelfMemberReference.SpaceAfter" />
 		<exclude name="MediaWiki.Commenting.FunctionComment.SpacingBeforeReturnType" />
 		<exclude name="PSR2.ControlStructures.SwitchDeclaration.SpaceBeforeColonCASE" />

--- a/src/Schema/Filters/CompositeFilter.php
+++ b/src/Schema/Filters/CompositeFilter.php
@@ -84,7 +84,7 @@ class CompositeFilter implements SchemaFilter {
 
 		$order = strtolower( $order );
 
-		if ( $type === self:: SORT_FILTER_SCORE ) {
+		if ( $type === self::SORT_FILTER_SCORE ) {
 			usort( $this->matches, function ( $a, $b ) use ( $order ) {
 				if ( $order === 'desc' ) {
 					return $b->filterScore <=> $a->filterScore;

--- a/tests/phpunit/MediaWiki/Permission/TitlePermissionsTest.php
+++ b/tests/phpunit/MediaWiki/Permission/TitlePermissionsTest.php
@@ -63,7 +63,7 @@ class TitlePermissionsTest extends \PHPUnit_Framework_TestCase {
 	 * @dataProvider titleProvider
 	 */
 	public function testToReturnFalseOnMwNamespacePermissionCheck( $title, $permission, $action, $expected ) {
-		$this->protectionValidator ->expects( $this->any() )
+		$this->protectionValidator->expects( $this->any() )
 			->method( 'hasEditProtection' )
 			->will( $this->returnValue( true ) );
 


### PR DESCRIPTION
Clear and fix sniff **Squiz.WhiteSpace.ObjectOperatorSpacing** reported by phpcs and improve code quality.
As a part of this PR we have cleared and fixed 2 subgroups of **Squiz.WhiteSpace.ObjectOperatorSpacing** like:

- Squiz.WhiteSpace.ObjectOperatorSpacing.Before;
- Squiz.WhiteSpace.ObjectOperatorSpacing.After
