### PR TITLE
Issue 5667 - fix sniff Generic.Formatting.SpaceAfterNot.Incorrect

### DIFF
--- a/.phpcs.xml
+++ b/.phpcs.xml
@@ -135,7 +135,6 @@
 		<exclude name="MediaWiki.Commenting.DocComment.SyntaxAlignedDocClose" />
 		<exclude name="PSR2.Classes.ClassDeclaration.SpaceBeforeName" />
 		<exclude name="MediaWiki.PHPUnit.MockBoilerplate.returnValueMap" />
-		<exclude name="Generic.Formatting.SpaceAfterNot.Incorrect" />
 		<exclude name="PSR2.Files.EndFileNewline.TooMany" />
 		<exclude name="MediaWiki.WhiteSpace.SpaceyParenthesis.SpaceBeforeOpeningParenthesis" />
 		<exclude name="Generic.Functions.OpeningFunctionBraceKernighanRitchie.SpaceBeforeBrace" />

--- a/includes/RecurringEvents.php
+++ b/includes/RecurringEvents.php
@@ -236,7 +236,7 @@ class RecurringEvents {
 		}
 
 		// Handle 'week number', but only if it's of unit 'month'.
-		if ( $unit == 'month' && ! is_null( $week_num ) ) {
+		if ( $unit == 'month' && !is_null( $week_num ) ) {
 			$unit = 'dayofweekinmonth';
 
 			if ( $week_num < -4 || $week_num > 5 || $week_num == 0 ) {

--- a/includes/compat/JsonUnserializable.php
+++ b/includes/compat/JsonUnserializable.php
@@ -2,7 +2,7 @@
 
 namespace MediaWiki\Json;
 
-if( ! interface_exists( 'MediaWiki\Json\JsonUnserializable' ) ) {
+if( !interface_exists( 'MediaWiki\Json\JsonUnserializable' ) ) {
 
 	/**
 	 * This interface was introduced in MediaWiki 1.36 and some classes need to implement it.

--- a/includes/querypages/QueryPage.php
+++ b/includes/querypages/QueryPage.php
@@ -223,7 +223,7 @@ abstract class QueryPage extends \QueryPage {
 
 		if ( $num > 0 ) {
 			$s = [];
-			if ( ! $this->listoutput ) {
+			if ( !$this->listoutput ) {
 				$s[] = $this->openList( $offset );
 			}
 
@@ -234,7 +234,7 @@ abstract class QueryPage extends \QueryPage {
 				}
 			}
 
-			if ( ! $this->listoutput ) {
+			if ( !$this->listoutput ) {
 				$s[] = $this->closeList();
 			}
 			$str = $this->listoutput ? $this->getLanguage()->listToText( $s ) : implode( '', $s );

--- a/tests/phpunit/MediaWiki/Search/ExtendedSearchEngineTest.php
+++ b/tests/phpunit/MediaWiki/Search/ExtendedSearchEngineTest.php
@@ -137,7 +137,7 @@ class ExtendedSearchEngineTest extends \PHPUnit_Framework_TestCase {
 	}
 
 	public function testGetTextFromContent() {
-		if ( ! method_exists( 'SearchEngine', 'getTextFromContent' ) ) {
+		if ( !method_exists( 'SearchEngine', 'getTextFromContent' ) ) {
 			$this->markTestSkipped( 'SearchEngine::getTextFromContent() is undefined. Probably not yet present in the tested MW version.' );
 		}
 
@@ -173,7 +173,7 @@ class ExtendedSearchEngineTest extends \PHPUnit_Framework_TestCase {
 	}
 
 	public function testTextAlreadyUpdatedForIndex() {
-		if ( ! method_exists( 'SearchEngine', 'textAlreadyUpdatedForIndex' ) ) {
+		if ( !method_exists( 'SearchEngine', 'textAlreadyUpdatedForIndex' ) ) {
 			$this->markTestSkipped( 'SearchEngine::textAlreadyUpdatedForIndex() is undefined. Probably not yet present in the tested MW version.' );
 		}
 
@@ -237,7 +237,7 @@ class ExtendedSearchEngineTest extends \PHPUnit_Framework_TestCase {
 	}
 
 	public function testDelete() {
-		if ( ! method_exists( 'SearchEngine', 'delete' ) ) {
+		if ( !method_exists( 'SearchEngine', 'delete' ) ) {
 			$this->markTestSkipped( 'SearchEngine::delete() is undefined. Probably not yet present in the tested MW version.' );
 		}
 
@@ -260,7 +260,7 @@ class ExtendedSearchEngineTest extends \PHPUnit_Framework_TestCase {
 	}
 
 	public function testSetFeatureData() {
-		if ( ! method_exists( 'SearchEngine', 'delete' ) ) {
+		if ( !method_exists( 'SearchEngine', 'delete' ) ) {
 			$this->markTestSkipped( 'SearchEngine::delete() is undefined. Probably not yet present in the tested MW version.' );
 		}
 
@@ -366,7 +366,7 @@ class ExtendedSearchEngineTest extends \PHPUnit_Framework_TestCase {
 	}
 
 	public function testSetShowSuggestion() {
-		if ( ! method_exists( 'SearchEngine', 'setShowSuggestion' ) ) {
+		if ( !method_exists( 'SearchEngine', 'setShowSuggestion' ) ) {
 			$this->markTestSkipped( 'SearchEngine::setShowSuggestion() is undefined. Probably not yet present in the tested MW version.' );
 		}
 


### PR DESCRIPTION
Clear and fix sniff **Generic.Formatting.SpaceAfterNot.Incorrect** reported by phpcs and improve code quality.