### PR TITLE
Use IDBAccessObject::READ_LATEST on 1.42 onwards

### DIFF
--- a/src/MediaWiki/RevisionGuard.php
+++ b/src/MediaWiki/RevisionGuard.php
@@ -52,8 +52,12 @@ class RevisionGuard {
 	public function isSkippableUpdate( Title $title, &$latestRevID = null ) {
 		// MW 1.34+
 		// https://github.com/wikimedia/mediawiki/commit/b65e77a385c7423ce03a4d21c141d96c28291a60
-		if ( defined( 'Title::READ_LATEST' ) && Title::GAID_FOR_UPDATE == 512 ) {
+		if ( defined( 'Title::READ_LATEST' ) ) {
 			$flag = Title::READ_LATEST;
+		// MW 1.42+
+		// https://github.com/wikimedia/mediawiki/commit/5ca00251c607d2fd11e2df66336fcbb9925eea91
+		} else if ( version_compare( MW_VERSION, '1.42' , '>=' ) ) {
+			$flag = IDBAccessObject::READ_LATEST;
 		} else {
 			$flag = Title::GAID_FOR_UPDATE;
 		}
@@ -81,8 +85,12 @@ class RevisionGuard {
 	public function getLatestRevID( Title $title ) {
 		// MW 1.34+
 		// https://github.com/wikimedia/mediawiki/commit/b65e77a385c7423ce03a4d21c141d96c28291a60
-		if ( defined( 'Title::READ_LATEST' ) && Title::GAID_FOR_UPDATE == 512 ) {
+		if ( defined( 'Title::READ_LATEST' ) ) {
 			$flag = Title::READ_LATEST;
+		// MW 1.42+
+		// https://github.com/wikimedia/mediawiki/commit/5ca00251c607d2fd11e2df66336fcbb9925eea91
+		} else if ( version_compare( MW_VERSION, '1.42' , '>=' ) ) {
+			$flag = IDBAccessObject::READ_LATEST;
 		} else {
 			$flag = Title::GAID_FOR_UPDATE;
 		}


### PR DESCRIPTION
Fixes page protection on 1.42

Miraheze bug: https://issue-tracker.miraheze.org/T12379

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Enhanced compatibility for MediaWiki versions prior to 1.42, improving the handling of updates.
- **Bug Fixes**
	- Adjusted logic in the update process to ensure it operates correctly across different software versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->