### PR TITLE
Issue 5702 - clear deprecation warnings for PHP 8.1 and MW 1.39+ - null to param

### DIFF
--- a/includes/Highlighter.php
+++ b/includes/Highlighter.php
@@ -192,7 +192,7 @@ class Highlighter {
 	 */
 	public static function getTypeId( $type ) {
 		// TODO: why do we have a htmlspecialchars here?!
-		switch ( strtolower( htmlspecialchars( $type ) ) ) {
+		switch ( strtolower( htmlspecialchars( $type ?? '' ) ) ) {
 			case 'property':
 			return self::TYPE_PROPERTY;
 			case 'text':

--- a/includes/Highlighter.php
+++ b/includes/Highlighter.php
@@ -255,7 +255,7 @@ class Highlighter {
 
 		// In case the text contains HTML, remove trailing line feeds to avoid breaking
 		// the display
-		if ( $this->options['content'] != strip_tags( $this->options['content'] ) ) {
+		if ( $this->options['content'] != strip_tags( $this->options['content'] ?? '' ) ) {
 			$this->options['content'] = str_replace( [ "\n" ], [ '' ], $this->options['content'] );
 		}
 
@@ -290,7 +290,7 @@ class Highlighter {
 				// will make the parser go berserk (injecting <p> elements etc.)
 				// hence encode the identifying </> and decode it within the
 				// tooltip
-				str_replace( [ "\n", '<', '>' ], [ '</br>', '&lt;', '&gt;' ], htmlspecialchars_decode( $this->options['content'] ) )
+				str_replace( [ "\n", '<', '>' ], [ '</br>', '&lt;', '&gt;' ], htmlspecialchars_decode( $this->options['content'] ?? '' ) )
 			)
 		);
 
@@ -375,13 +375,14 @@ class Highlighter {
 	private function title( $content, $language ) {
 		// Pre-process the content when used as title to avoid breaking elements
 		// (URLs etc.)
+		$content = $content ?? '';
 		if ( strpos( $content, '[' ) !== false || strpos( $content, '//' ) !== false ) {
 			$content = Message::get( [ 'smw-parse', $content ], Message::PARSE, $language );
 		}
 
 		return strip_tags(
 			htmlspecialchars_decode(
-				str_replace( [ "[", '&#160;', "&#10;", "\n", "&#39;", "'" ], [ "&#91;", ' ', '', '', '' ], $content ),
+				str_replace( [ "[", '&#160;', "&#10;", "\n", "&#39;", "'" ], [ "&#91;", ' ', '', '', '' ], $content ?? '' ),
 			)
 		);
 	}

--- a/includes/SMW_Infolink.php
+++ b/includes/SMW_Infolink.php
@@ -497,7 +497,7 @@ class SMWInfolink {
 
 			foreach ( $params as $name => $value ) {
 				if ( is_string( $name ) && ( $name !== '' ) ) {
-					$value = rawurlencode( $name ) . '=' . rawurlencode( $value );
+					$value = rawurlencode( $name ?? '' ) . '=' . rawurlencode( $value ?? '' );
 
 					if ( $result !== '' ) {
 						$result .= '&';

--- a/src/CacheFactory.php
+++ b/src/CacheFactory.php
@@ -67,7 +67,7 @@ class CacheFactory {
 			$key = $key->getArticleID();
 		}
 
-		return self::getCachePrefix() . ':smw:arc:' . md5( $key );
+		return self::getCachePrefix() . ':smw:arc:' . md5( $key ?? '' );
 	}
 
 	/**

--- a/src/DataValues/Number/IntlNumberFormatter.php
+++ b/src/DataValues/Number/IntlNumberFormatter.php
@@ -312,6 +312,7 @@ class IntlNumberFormatter {
 		// Format to some level of precision; number_format does rounding and
 		// locale formatting, x and y are used temporarily since number_format
 		// supports only single characters for either
+		$precision = $precision ?? 0;
 		$value = number_format( $value, $precision, 'x', 'y' );
 
 		// Due to https://bugs.php.net/bug.php?id=76824

--- a/src/DataValues/ValueParsers/AllowsPatternValueParser.php
+++ b/src/DataValues/ValueParsers/AllowsPatternValueParser.php
@@ -71,6 +71,7 @@ class AllowsPatternValueParser implements ValueParser {
 			return null;
 		}
 
+		$contents = $contents ?? '';
 		$parts = array_map( 'trim', preg_split( "([\n][\s]?)", $contents ) );
 
 		// Get definition from first line

--- a/src/Localizer/Message.php
+++ b/src/Localizer/Message.php
@@ -119,6 +119,9 @@ class Message {
 		$encode[] = $type;
 
 		foreach ( $message as $value ) {
+			// Ensure $value is a string before using substr()
+			$value = $value ?? '';
+
 			// Check if the value is already encoded, and if decode to keep the
 			// structure intact
 			if ( substr( $value, 0, 1 ) === '[' && ( $dc = json_decode( $value, true ) ) && json_last_error() === JSON_ERROR_NONE ) {

--- a/src/MediaWiki/Connection/Query.php
+++ b/src/MediaWiki/Connection/Query.php
@@ -144,7 +144,7 @@ class Query {
 	 * @param string $table
 	 */
 	public function table( ...$table ) {
-		if ( strpos( $table[0], 'SELECT' ) !== false ) {
+		if ( strpos( $table[0] ?? '', 'SELECT' ) !== false ) {
 			$tableName = '(' . $table[0] . ')';
 		} else {
 			$tableName = $this->connection->tableName( $table[0] );

--- a/src/MediaWiki/Content/SchemaContent.php
+++ b/src/MediaWiki/Content/SchemaContent.php
@@ -269,7 +269,7 @@ class SchemaContent extends JsonContent {
 			);
 
 			$schema_link = pathinfo(
-				$schema->info( Schema::SCHEMA_VALIDATION_FILE ),
+				$schema->info( Schema::SCHEMA_VALIDATION_FILE ) ?? '',
 				PATHINFO_FILENAME
 			);
 		}

--- a/src/MediaWiki/Content/SchemaContentFormatter.php
+++ b/src/MediaWiki/Content/SchemaContentFormatter.php
@@ -174,7 +174,7 @@ class SchemaContentFormatter {
 		$usage_lookup = (array)$this->type['usage_lookup'];
 
 		$subject = new DIWikiPage(
-			str_replace( ' ', '_', $schema->getName() ),
+			str_replace( ' ', '_', $schema->getName() ?? '' ),
 			SMW_NS_SCHEMA
 		);
 
@@ -231,7 +231,7 @@ class SchemaContentFormatter {
 		$type = $schema->get( Schema::SCHEMA_TYPE );
 
 		$schema_link = pathinfo(
-			$schema->info( Schema::SCHEMA_VALIDATION_FILE ), PATHINFO_FILENAME
+			$schema->info( Schema::SCHEMA_VALIDATION_FILE ) ?? '', PATHINFO_FILENAME
 		);
 
 		if ( isset( $this->type['type_description'] ) ) {

--- a/src/MediaWiki/Renderer/HtmlFormRenderer.php
+++ b/src/MediaWiki/Renderer/HtmlFormRenderer.php
@@ -483,7 +483,7 @@ class HtmlFormRenderer {
 			'action' => htmlspecialchars( $this->actionUrl ? $this->actionUrl : $GLOBALS['wgScript'] )
 		], Html::hidden(
 			'title',
-			strtok( $this->title->getPrefixedText(), '/' )
+			strtok( $this->title->getPrefixedText() ?? '', '/' )
 		) . $content );
 
 		$this->clear();

--- a/src/MediaWiki/Specials/Admin/Supplement/EntityLookupTaskHandler.php
+++ b/src/MediaWiki/Specials/Admin/Supplement/EntityLookupTaskHandler.php
@@ -228,7 +228,7 @@ class EntityLookupTaskHandler extends TaskHandler implements ActionableTask {
 
 		$connection = $this->store->getConnection( 'mw.db' );
 
-		if ( ctype_digit( $id ) ) {
+		if ( ctype_digit( (string)$id ) ) {
 			$condition = 'smw_id=' . intval( $id );
 		} else {
 			$op = strpos( $id, '*' ) !== false ? ' LIKE ' : '=';

--- a/src/MediaWiki/Specials/Ask/NavigationLinksWidget.php
+++ b/src/MediaWiki/Specials/Ask/NavigationLinksWidget.php
@@ -164,7 +164,7 @@ class NavigationLinksWidget {
 		$offset = (int)$urlArgs->get( 'offset' );
 
 		// Remove any contents that is cruft
-		if ( strpos( $urlArgs->get( 'p' ), 'cl=' ) !== false ) {
+		if ( strpos( $urlArgs->get( 'p' ) ?? '', 'cl=' ) !== false ) {
 			$urlArgs->set( 'p', mb_substr( $urlArgs->get( 'p' ), stripos( $urlArgs->get( 'p' ), '/' ) + 1 ) );
 		}
 

--- a/src/MediaWiki/Specials/Ask/ParametersProcessor.php
+++ b/src/MediaWiki/Specials/Ask/ParametersProcessor.php
@@ -65,7 +65,7 @@ class ParametersProcessor {
 		// Parameters separated by newlines here (compatible with text-input for
 		// printouts)
 		if ( ( $po = $request->getText( 'po' ) ) !== '' ) {
-			$printouts = explode( "\n", $po );
+			$printouts = explode( "\n", $po ?? '' );
 		}
 
 		// Check for param strings in po (printouts), appears in some links

--- a/src/MediaWiki/Specials/Ask/QueryInputWidget.php
+++ b/src/MediaWiki/Specials/Ask/QueryInputWidget.php
@@ -39,7 +39,7 @@ class QueryInputWidget {
 			) . HtmlDivTable::cell(
 				"<fieldset><legend>" . Message::get( 'smw_ask_printhead', Message::TEXT, Message::USER_LANGUAGE ) . "</legend>" .
 				'<textarea id="smw-property-input" class="smw-ask-query-printout" name="po" rows="6" placeholder="...">' .
-				htmlspecialchars( $printoutString ) . '</textarea></fieldset>',
+				htmlspecialchars( $printoutString ?? '' ) . '</textarea></fieldset>',
 				[ 'class' => 'smw-ask-printhead slowfade' ]
 			)
 		);

--- a/src/MediaWiki/Specials/Browse/ValueFormatter.php
+++ b/src/MediaWiki/Specials/Browse/ValueFormatter.php
@@ -195,7 +195,7 @@ class ValueFormatter {
 	 */
 	public static function addNonBreakingSpace( $text ) {
 		$nonBreakingSpace = html_entity_decode( '&#160;', ENT_NOQUOTES, 'UTF-8' );
-		$text = preg_replace( '/[\s]/u', $nonBreakingSpace, $text, -1, $count );
+		$text = preg_replace( '/[\s]/u', $nonBreakingSpace, $text ?? '', -1, $count );
 
 		if ( $count > 2 ) {
 			return preg_replace( '/($nonBreakingSpace)/u', ' ', $text, max( 0, $count - 2 ) );

--- a/src/MediaWiki/Specials/FacetedSearch/Profile.php
+++ b/src/MediaWiki/Specials/FacetedSearch/Profile.php
@@ -124,7 +124,7 @@ class Profile {
 		$compartmentIterator = $schemaList->newCompartmentIteratorByKey( 'profiles' );
 
 		if ( $this->profileName === '' ) {
-			$this->profileName = str_replace( '_profile', '', $schemaList->get( 'default_profile', 'default' ) );
+			$this->profileName = str_replace( '_profile', '', $schemaList->get( 'default_profile', 'default' ) ?? '' );
 		}
 
 		foreach ( $compartmentIterator as $profiles ) {

--- a/src/MediaWiki/Specials/SearchByProperty/PageBuilder.php
+++ b/src/MediaWiki/Specials/SearchByProperty/PageBuilder.php
@@ -106,7 +106,7 @@ class PageBuilder {
 	private function getHtmlForm( $resultMessage, $resultCount ) {
 		// Precaution to avoid any inline breakage caused by a div element
 		// within a paragraph (e.g Highlighter content)
-		$resultMessage = str_replace( 'div', 'span', $resultMessage );
+		$resultMessage = str_replace( 'div', 'span', $resultMessage ?? '' );
 
 		$html = $this->htmlFormRenderer
 			->setName( 'searchbyproperty' )
@@ -182,7 +182,7 @@ class PageBuilder {
 			$resultList = $this->makeResultList( $exactResults, $this->pageRequestOptions->limit, true );
 		}
 
-		return [ str_replace( '_', ' ', $resultMessage ), $resultList, $exactCount ];
+		return [ str_replace( '_', ' ', $resultMessage ?? '' ), $resultList, $exactCount ];
 	}
 
 	private function getNearbyResults( $exactResults, $exactCount ) {

--- a/src/MediaWiki/StripMarkerDecoder.php
+++ b/src/MediaWiki/StripMarkerDecoder.php
@@ -58,7 +58,7 @@ class StripMarkerDecoder {
 	 * @return boolean
 	 */
 	public function hasStripMarker( $text ) {
-		return strpos( $text, Parser::MARKER_SUFFIX );
+		return strpos( $text ?? '', Parser::MARKER_SUFFIX );
 	}
 
 	/**
@@ -93,7 +93,7 @@ class StripMarkerDecoder {
 		return str_replace(
 			[ '<', '>', ' ', '[', '{', '=', "'", ':', "\n" ],
 			[ '&lt;', '&gt;', ' ', '&#x005B;', '&#x007B;', '&#x003D;', '&#x0027;', '&#58;', "<br />" ],
-			$this->doUnstrip( $text )
+			$this->doUnstrip( $text ) ?? ''
 		);
 	}
 

--- a/src/MediaWiki/Template/TemplateExpander.php
+++ b/src/MediaWiki/Template/TemplateExpander.php
@@ -96,7 +96,7 @@ class TemplateExpander {
 		$text = str_replace(
 			[ '_&lt;nowiki&gt;_', '_&lt;/nowiki&gt;_', '_&lt;nowiki */&gt;_', '<nowiki>', '</nowiki>' ],
 			'',
-			$text
+			$text ?? ''
 		);
 
 		return $text;

--- a/src/ParserFunctions/InfoParserFunction.php
+++ b/src/ParserFunctions/InfoParserFunction.php
@@ -50,13 +50,13 @@ class InfoParserFunction implements HookHandler {
 		// If the message contains another highlighter (caused by recursive
 		// parsing etc.) remove the tags to allow to show the text without making
 		// the JS go berserk due to having more than one `smw-highlighter`
-		if ( strpos( $message, 'smw-highlighter' ) !== '' ) {
+		if ( strpos( $message ?? '', 'smw-highlighter' ) !== '' ) {
 			$message = preg_replace_callback(
 					"/" . "<span class=\"smw-highlighter\"(.*)?>(.*)?<\/span>" . "/m",
 					function ( $matches ) {
 						return strip_tags( $matches[0] );
 					},
-					$message
+					$message ?? ''
 			);
 		}
 

--- a/src/Property/SpecificationLookup.php
+++ b/src/Property/SpecificationLookup.php
@@ -699,11 +699,11 @@ class SpecificationLookup {
 
 		// If a local property description wasn't available for a predefined property
 		// the try to find a system translation
-		if ( trim( $text ) === '' && !$property->isUserDefined() ) {
+		if ( trim( $text ?? '' ) === '' && !$property->isUserDefined() ) {
 			$text = $this->getPredefinedPropertyDescription( $property, $languageCode, $linker );
 		}
 
-		$text = trim( $text );
+		$text = trim( $text ?? '' );
 
 		$this->entityCache->saveSub( $key, $sub_key, $text );
 		$this->entityCache->associate( $subject, $key );

--- a/src/Query/DebugFormatter.php
+++ b/src/Query/DebugFormatter.php
@@ -82,7 +82,7 @@ class DebugFormatter {
 		if ( $query instanceof Query ) {
 			$preEntries = [];
 			$description = $query->getDescription();
-			$queryString = str_replace( '[', '&#91;', $description->getQueryString() );
+			$queryString = str_replace( '[', '&#91;', $description->getQueryString() ?? '' );
 
 			$preEntries['ASK Query'] = '<div class="smwpre">' . $queryString . '</div>';
 			$entries = array_merge( $preEntries, $entries );
@@ -243,7 +243,7 @@ class DebugFormatter {
 				'&#x3C;',
 				'&#x3E;'
 			],
-			$sparql
+			$sparql ?? ''
 		);
 
 		return '<div class="smwpre">' . $sparql . '</div>';

--- a/src/Query/DebugFormatter.php
+++ b/src/Query/DebugFormatter.php
@@ -161,7 +161,7 @@ class DebugFormatter {
 					$possible_keys = implode( ', ', explode( ',', $possible_keys ) );
 				}
 
-				if ( strpos( $ref, ',' ) !== false ) {
+				if ( strpos( $ref ?? '', ',' ) !== false ) {
 					$ref = implode( ', ', explode( ',', $ref ) );
 				}
 

--- a/src/Query/Deferred.php
+++ b/src/Query/Deferred.php
@@ -59,7 +59,7 @@ class Deferred {
 				'class' => 'smw-deferred-query' . ( isset( $params['class'] ) ? ' ' . $params['class'] : '' ),
 				'data-query' => json_encode(
 					[
-						'query'  => trim( $query->getOption( self::QUERY_PARAMETERS ) ),
+						'query'  => trim( $query->getOption( self::QUERY_PARAMETERS ) ?? '' ),
 						'params' => $params,
 						'limit'  => $query->getLimit(),
 						'offset' => $query->getOffset(),

--- a/src/Query/Processor/ParamListProcessor.php
+++ b/src/Query/Processor/ParamListProcessor.php
@@ -189,7 +189,7 @@ class ParamListProcessor {
 			function ( array $matches ) {
 				return str_replace( [ '=' ], [ '0x003D' ], $matches[0] );
 			},
-			$param
+			$param ?? ''
 		);
 	}
 

--- a/src/Query/QueryComparator.php
+++ b/src/Query/QueryComparator.php
@@ -116,7 +116,7 @@ class QueryComparator {
 		$comparator = SMW_CMP_EQ;
 
 		foreach ( $this->getComparatorStrings() as $string ) {
-			if ( strpos( $value, $string ) === 0 ) {
+			if ( strpos( $value ?? '', $string ) === 0 ) {
 				$comparator = $this->getComparatorFromString( substr( $value, 0, strlen( $string ) ) );
 				$value = substr( $value, strlen( $string ) );
 				break;

--- a/src/Query/QueryLinker.php
+++ b/src/Query/QueryLinker.php
@@ -51,7 +51,7 @@ class QueryLinker {
 	}
 
 	private static function getParameters( $query ) {
-		$params = [ trim( $query->getQueryString( true ) ) ];
+		$params = [ trim( $query->getQueryString( true ) ?? '' ) ];
 
 		foreach ( $query->getExtraPrintouts() as /* PrintRequest */ $printout ) {
 			if ( ( $serialisation = $printout->getSerialisation( true ) ) !== '' ) {

--- a/src/SPARQLStore/QueryEngine/RepositoryResult.php
+++ b/src/SPARQLStore/QueryEngine/RepositoryResult.php
@@ -164,7 +164,7 @@ class RepositoryResult implements Iterator {
 	/**
 	 * Reset iterator to position 0. Standard method of Iterator.
 	 */
-	public function rewind() {
+	public function rewind(): void {
 		reset( $this->data );
 	}
 
@@ -201,9 +201,9 @@ class RepositoryResult implements Iterator {
 	 * Return true if the internal pointer refers to a valid element.
 	 * Standard method of Iterator.
 	 *
-	 * @return boolean
+	 * @return bool
 	 */
-	public function valid() {
+	public function valid(): bool {
 		return ( current( $this->data ) !== false );
 	}
 

--- a/src/SQLStore/Lookup/CachedListLookup.php
+++ b/src/SQLStore/Lookup/CachedListLookup.php
@@ -174,7 +174,7 @@ class CachedListLookup implements ListLookup {
 		$this->isFromCache = false;
 
 		// Collect the options keys
-		$data = unserialize( $this->cache->fetch( $key ) );
+		$data = unserialize( $this->cache->fetch( $key ) ?? '' );
 		$data = $data === false ? [] : $data;
 		$data[$optionsKey] = true;
 		$this->cache->save( $key, serialize( $data ), $ttl );
@@ -190,7 +190,7 @@ class CachedListLookup implements ListLookup {
 	private function getCacheKey( $id ) {
 		$optionsKey = '';
 
-		if ( strpos( $id, '#' ) !== false ) {
+		if ( strpos( $id ?? '', '#' ) !== false ) {
 			list( $id, $optionsKey ) = explode( '#', $id, 2 );
 		}
 

--- a/src/SQLStore/PropertyTableIdReferenceFinder.php
+++ b/src/SQLStore/PropertyTableIdReferenceFinder.php
@@ -214,7 +214,7 @@ class PropertyTableIdReferenceFinder {
 		if ( isset( $fields['o_id'] ) ) {
 
 			// This next time someone ... I'm going to Alaska
-			$field = preg_match( '/redi$/', $proptable->getName() ) ? [ 's_title', 's_namespace' ] : [ 's_id' ];
+			$field = preg_match( '/redi$/', $proptable->getName() ?? '' ) ? [ 's_title', 's_namespace' ] : [ 's_id' ];
 
 			$row = $this->connection->selectRow(
 				$proptable->getName(),

--- a/src/SQLStore/QueryEngine/Fulltext/SearchTableRebuilder.php
+++ b/src/SQLStore/QueryEngine/Fulltext/SearchTableRebuilder.php
@@ -353,7 +353,7 @@ class SearchTableRebuilder {
 				$this->searchTableUpdater->insert( $sid, $pid );
 			}
 
-			$this->searchTableUpdater->update( $sid, $pid, trim( $text ) . ' ' . $indexableText );
+			$this->searchTableUpdater->update( $sid, $pid, trim( $text ?? '' ) . ' ' . $indexableText );
 		}
 
 		$this->reportMessage( "\n" );

--- a/src/SQLStore/TableBuilder/Table.php
+++ b/src/SQLStore/TableBuilder/Table.php
@@ -123,7 +123,7 @@ class Table {
 	public function addIndex( $index, $key = null ) {
 		$val = is_array( $index ) ? $index[0] : $index;
 
-		if ( count( explode( ' ', $val ) ) > 1 ) {
+		if ( count( explode( ' ', $val ?? '' ) ) > 1 ) {
 			throw new RuntimeException( "Index declaration `$val` contains a space!." );
 		}
 

--- a/src/Utils/CharArmor.php
+++ b/src/Utils/CharArmor.php
@@ -36,7 +36,7 @@ class CharArmor {
 		return str_replace(
 			[ '&shy;', '&lrm;', " ", " ", " " ],
 			[ '', '', ' ', ' ', ' ' ],
-			$text
+			$text ?? ''
 		);
 	}
 


### PR DESCRIPTION
**Null to param deprecation warnings** checked and fixed for MW 1.39+ and PHP 8.1.
There are still some other deprecation warnings that need to be checked how it can be updated not to change or break the workflow. (_maybe to open another issue and check_)
