### PR TITLE
Use table prefix in bootstrap, ignore key check during tests

### DIFF
--- a/__setup_extension__
+++ b/__setup_extension__
@@ -2,5 +2,6 @@ error_reporting(E_ALL| E_STRICT);
 ini_set("display_errors", 1);
 $wgShowExceptionDetails = true;
 $wgDevelopmentWarnings = true;
+$smwgIgnoreUpgradeKeyCheck = true;
 
 enableSemantics( $wgServer );

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -36,8 +36,8 @@ $autoloader->addClassMap( [
 ] );
 
 define( 'SMW_PHPUNIT_DIR', __DIR__ . '/phpunit' );
-#define( 'SMW_PHPUNIT_TABLE_PREFIX', 'sunittest_' );
-define( 'SMW_PHPUNIT_TABLE_PREFIX', '' );
+define( 'SMW_PHPUNIT_TABLE_PREFIX', 'sunittest_' );
+// define( 'SMW_PHPUNIT_TABLE_PREFIX', '' );
 
 /**
  * Register a shutdown function the invoke a final clean-up


### PR DESCRIPTION
Set $smwgIgnoreUpgradeKeyCheck to true to ignore verification that a correct upgrade path was selected. 
Define test table prefix used in tests. 
