### PR TITLE
Convert SQL select() to use only table names and join conditions

### DIFF
--- a/includes/ContentParser.php
+++ b/includes/ContentParser.php
@@ -157,12 +157,17 @@ class ContentParser {
 		// Avoid "The content model 'xyz' is not registered on this wiki."
 		try {
 			$services = MediaWikiServices::getInstance();
+			// MW 1.38+
 			if ( method_exists( $services, 'getContentRenderer' ) ) {
+				// MW 1.42+
+				if ( version_compare( MW_VERSION, '1.42', '<' ) ) {
+					$revision = $revision->getId();
+				}
 				$contentRenderer = $services->getContentRenderer();
 				$this->parserOutput = $contentRenderer->getParserOutput(
 					$content,
 					$this->getTitle(),
-					$revision->getId()
+					$revision
 				);
 			} else {
 				$this->parserOutput = $content->getParserOutput(

--- a/src/MediaWiki/Hooks/LinksUpdateComplete.php
+++ b/src/MediaWiki/Hooks/LinksUpdateComplete.php
@@ -2,7 +2,6 @@
 
 namespace SMW\MediaWiki\Hooks;
 
-use LinksUpdate;
 use SMW\Services\ServicesFactory as ApplicationFactory;
 use SMW\MediaWiki\RevisionGuardAwareTrait;
 use SMW\NamespaceExaminer;
@@ -68,11 +67,11 @@ class LinksUpdateComplete implements HookListener {
 	/**
 	 * @since 1.9
 	 *
-	 * @param LinksUpdate $linksUpdate
+	 * @param LinksUpdate|MediaWiki\Deferred\LinksUpdate\LinksUpdate $linksUpdate
 	 *
 	 * @return true
 	 */
-	public function process( LinksUpdate $linksUpdate ) {
+	public function process( $linksUpdate ) {
 		if ( $this->isReady === false ) {
 			return $this->doAbort();
 		}

--- a/src/SQLStore/QueryEngine/DescriptionInterpreters/SomePropertyInterpreter.php
+++ b/src/SQLStore/QueryEngine/DescriptionInterpreters/SomePropertyInterpreter.php
@@ -205,6 +205,10 @@ class SomePropertyInterpreter implements DescriptionInterpreter {
 				// Can we prevent that? (PERFORMANCE)
 				$query->from = ' INNER JOIN ' .	$connection->tableName( SQLStore::ID_TABLE ) .
 						" AS ids{$query->alias} ON ids{$query->alias}.smw_id={$query->alias}.{$o_id}";
+				$query->fromTables = [ 'ids' . $query->alias => SQLStore::ID_TABLE ];
+				$query->joinConditions = [
+					'ids' . $query->alias => [ 'INNER JOIN', "ids{$query->alias}.smw_id={$query->alias}.{$o_id}" ]
+				];
 				$query->sortfields[$sortkey] = "ids{$query->alias}.smw_sort";
 			}
 		} else { // non-page value description

--- a/src/SQLStore/QueryEngine/QuerySegment.php
+++ b/src/SQLStore/QueryEngine/QuerySegment.php
@@ -88,6 +88,7 @@ class QuerySegment {
 
 	/**
 	 * @var string
+	 * @note This should be only one of these values: 'LEFT', 'LEFT OUTER', 'INNER'.
 	 */
 	public $joinType = '';
 
@@ -113,6 +114,31 @@ class QuerySegment {
 	 * @var string
 	 */
 	public $from = '';
+
+	/**
+	 * @var string[] Array of tables compatible with MediaWiki’s IReadableDatabase::select()
+	 *
+	 * The values are always the table names, and if the index is a string then it is its alias.
+	 * It is not necessary to use $db->tableName() for the table names, this is handled by MediaWiki.
+	 *
+	 * Example:
+	 *  [ 'page', 't0' => 'smw_object_ids' ]
+	 */
+	public $fromTables = [];
+
+	/**
+	 * @var string[][] Array of JOIN conditions created to be compatible with MediaWiki’s IReadableDatabase::select()
+	 * 
+	 * The key in the first array must be a string, and represent the table or alias; the corresponding values
+	 * are a list with index 0 and 1, where the value at index 0 is the the type of JOIN and the value at index 1
+	 * is the condition.
+	 * It is not necessary to use $db->tableName() for the table names, this is handled by MediaWiki.
+	 *
+	 *
+	 * Example:
+	 *   [ 'page' => [ 'LEFT JOIN', 'page_latest=rev_id' ] ]
+	 */
+	public $joinConditions = [];
 
 	/**
 	 * @var string

--- a/src/SQLStore/RedirectStore.php
+++ b/src/SQLStore/RedirectStore.php
@@ -174,21 +174,24 @@ class RedirectStore {
 			}
 
 			$query = [
-				'from' => '',
-				'fields' => ''
+				'from' => [],
+				'fields' => [],
+				'condition' => [],
+				'options' => [],
+				'join' => [],
 			];
 
 			$query['condition'] = [ 'p_id' => $id ];
 
+			$query['from'] = [ $proptable->getName() ];
 			if ( $proptable->usesIdSubject() ) {
-				$query['from'] .= $connection->tableName( $proptable->getName() );
-				$query['from'] .= ' INNER JOIN ';
-				$query['from'] .= $connection->tableName( SQLStore::ID_TABLE ) . ' ON s_id=smw_id';
-				$query['fields'] = 'DISTINCT smw_title AS t,smw_namespace AS ns';
+				$query['from'][] = SQLStore::ID_TABLE;
+				$query['join'] = [ SQLStore::ID_TABLE => [ 'INNER JOIN', 's_id=smw_id' ] ];
+				$query['fields'] = [ 't' => 'smw_title', 'ns' => 'smw_namespace' ];
 			} else {
-				$query['from'] = $connection->tableName( $proptable->getName() );
-				$query['fields'] = 'DISTINCT s_title AS t,s_namespace AS ns';
+				$query['fields'] = [ 't' => 's_title', 'ns' => 's_namespace' ];
 			}
+			$query['options'] = [ 'DISTINCT' ];
 
 			if ( $namespace === SMW_NS_PROPERTY && !$proptable->isFixedPropertyTable() ) {
 				$this->findUpdateJobs( $connection, $query, $jobs );
@@ -317,7 +320,9 @@ class RedirectStore {
 			$query['from'],
 			$query['fields'],
 			$query['condition'],
-			__METHOD__
+			__METHOD__,
+			$query['options'],
+			$query['join']
 		);
 
 		foreach ( $res as $row ) {


### PR DESCRIPTION
MediaWiki 1.42 constrains not to use raw SQL in table names. Almost all calls were already fine except the one ine QueryEngine where JOINed tables are used: these are converted into two parallel variables fromTables and joinConditions compatible with MediaWiki’s select().

Also,
* RedirectStore is converted to a simple JOIN
* TraversalPropertyLookup is converted to a JOIN + Wikimedia\Rdbms\Subquery, as there is no SMW-native equivalent for a subquery.

Issue: #5634

----

**Warning:** These should be merged in separate PRs since they are about different topics:
* the change in `src/MediaWiki/Hooks/LinksUpdateComplete.php`
* the change in `includes/ContentParser.php`
They should be removed before final merge, but included here to have better results in CI.

----

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
	- Enhanced SQL query construction with improved structures for joins and selections.
	- Introduced new properties for managing tables and join conditions in query segments.

- **Bug Fixes**
	- Improved robustness of query processing, especially for nested queries and complex joins.

- **Documentation**
	- Added clarifications and examples for new properties to enhance developer understanding.

- **Refactor**
	- Streamlined SQL query logic for better readability and maintainability across multiple components.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->