### PR TITLE
Update COMPATIBILITY info about Elasticsearch

### DIFF
--- a/docs/COMPATIBILITY.md
+++ b/docs/COMPATIBILITY.md
@@ -336,8 +336,8 @@ Note that MS SQL Server and Oracle are not supported as database backends.
 		<td></td>
 	</tr>
 	<tr>
-		<th><a href="https://www.semantic-mediawiki.org/wiki/Semantic_MediaWiki_4.1.3">4.1.3</a></th>
-		<td>7.10.x</td>
+		<th><a href="https://www.semantic-mediawiki.org/wiki/Semantic_MediaWiki_4.1.3">4.1.3 - 4.2.x</a></th>
+		<td>7.10.2</td>
 		<td>Not supported (TBD)</td>
 		<td><a href="https://github.com/SemanticMediaWiki/SemanticMediaWiki/issues/5611#issuecomment-1962729300">Confirmed to work with ElasticSearch 7.10.2 (MW 1.39)</a></td>
 	</tr>


### PR DESCRIPTION
* Added 4.2.x since it is confirmed working on https://sandbox.semantic-mediawiki.net/wiki/Sp%C3%A9cial:Version
* Switched to 7.10.2 since this is the only version CirrusSearch is compatible with. SMW can probably do more, but let's avoid a mismatch for CirrusSearch

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated compatibility information for Semantic MediaWiki to include versions up to 4.2.x.
	- Refined ElasticSearch compatibility details to specify version 7.10.2.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->