### PR TITLE
Replace DB_MASTER with DB_PRIMARY

### DIFF
--- a/includes/DefaultSettings.php
+++ b/includes/DefaultSettings.php
@@ -175,18 +175,18 @@ return ( function () {
 		# Available DB index as provided by MediaWiki:
 		#
 		# - DB_REPLICA (1.27.4+)
-		# - DB_MASTER
+		# - DB_PRIMARY
 		#
 		# @since 2.5.3
 		##
 		'smwgLocalConnectionConf' => [
 			'mw.db' => [
 				'read'  => DB_REPLICA,
-				'write' => DB_MASTER
+				'write' => DB_PRIMARY
 			],
 			'mw.db.queryengine' => [
 				'read'  => DB_REPLICA,
-				'write' => DB_MASTER
+				'write' => DB_PRIMARY
 			]
 		],
 		##

--- a/maintenance/setupStore.php
+++ b/maintenance/setupStore.php
@@ -109,7 +109,7 @@ class setupStore extends \Maintenance {
 	 * @since 3.0
 	 */
 	public function getConnection() {
-		return $this->getDB( DB_MASTER );
+		return $this->getDB( DB_PRIMARY );
 	}
 
 	/**
@@ -132,7 +132,7 @@ class setupStore extends \Maintenance {
 
 		// #2963 Use the Maintenance DB connection instead and the DB_ADMIN request
 		// to allow to use the admin user/pass, if set
-		$connectionManager->registerCallbackConnection( DB_MASTER, [ $this, 'getConnection' ] );
+		$connectionManager->registerCallbackConnection( DB_PRIMARY, [ $this, 'getConnection' ] );
 
 		$store->setConnectionManager(
 			$connectionManager

--- a/src/MediaWiki/Connection/ConnectionProvider.php
+++ b/src/MediaWiki/Connection/ConnectionProvider.php
@@ -68,7 +68,7 @@ class ConnectionProvider implements IConnectionProvider {
 		// Default configuration
 		$conf = [
 			'read'  => DB_REPLICA,
-			'write' => DB_MASTER
+			'write' => DB_PRIMARY
 		];
 
 		if ( isset( $this->localConnectionConf[$this->provider] ) ) {
@@ -114,8 +114,8 @@ class ConnectionProvider implements IConnectionProvider {
 				'role' => 'developer',
 				'provider' => $this->provider,
 				'conf' => [
-					'read'  => $conf['read'] === DB_REPLICA ? 'DB_REPLICA' : 'DB_MASTER',
-					'write' => $conf['write'] === DB_REPLICA ? 'DB_REPLICA' : 'DB_MASTER',
+					'read'  => $conf['read'] === DB_REPLICA ? 'DB_REPLICA' : 'DB_PRIMARY',
+					'write' => $conf['write'] === DB_REPLICA ? 'DB_REPLICA' : 'DB_PRIMARY',
 				]
 			]
 		);

--- a/src/SQLStore/SQLStoreFactory.php
+++ b/src/SQLStore/SQLStoreFactory.php
@@ -441,7 +441,7 @@ class SQLStoreFactory {
 		$applicationFactory = ApplicationFactory::getInstance();
 		$settings = $applicationFactory->getSettings();
 
-		$connection = $this->store->getConnection( DB_MASTER );
+		$connection = $this->store->getConnection( DB_PRIMARY );
 
 		$tableBuilder = TableBuilder::factory(
 			$connection

--- a/src/SQLStore/TableBuilder/Examiner/CountMapField.php
+++ b/src/SQLStore/TableBuilder/Examiner/CountMapField.php
@@ -59,7 +59,7 @@ class CountMapField {
 			$cliMsgFormatter->firstCol( "Checking smw_countmap field consistency ..." )
 		);
 
-		$connection = $this->store->getConnection( DB_MASTER );
+		$connection = $this->store->getConnection( DB_PRIMARY );
 		$tableName = $connection->tableName( SQLStore::ID_AUXILIARY_TABLE );
 
 		if (

--- a/src/SQLStore/TableBuilder/Examiner/FixedProperties.php
+++ b/src/SQLStore/TableBuilder/Examiner/FixedProperties.php
@@ -88,7 +88,7 @@ class FixedProperties {
 
 		$target_id = (int)$this->fixedProperties[$prop];
 
-		$connection = $this->store->getConnection( DB_MASTER );
+		$connection = $this->store->getConnection( DB_PRIMARY );
 		$this->messageReporter->reportMessage( "   ... reading `$prop` ...\n" );
 
 		$row = $connection->selectRow(

--- a/src/SQLStore/TableBuilder/Examiner/IdBorder.php
+++ b/src/SQLStore/TableBuilder/Examiner/IdBorder.php
@@ -69,7 +69,7 @@ class IdBorder {
 	private function findAndMove( $upperbound, $legacyBound ) {
 		$cliMsgFormatter = new CliMsgFormatter();
 
-		$connection = $this->store->getConnection( DB_MASTER );
+		$connection = $this->store->getConnection( DB_PRIMARY );
 		$row = false;
 		$hasUpperBound = false;
 

--- a/src/SQLStore/TableBuilder/Examiner/PredefinedProperties.php
+++ b/src/SQLStore/TableBuilder/Examiner/PredefinedProperties.php
@@ -82,7 +82,7 @@ class PredefinedProperties {
 	}
 
 	private function doUpdate( $property, $id ) {
-		$connection = $this->store->getConnection( DB_MASTER );
+		$connection = $this->store->getConnection( DB_PRIMARY );
 
 		// Try to find the ID for a non-fixed predefined property
 		if ( $id === null ) {

--- a/src/SQLStore/TableBuilder/Examiner/TouchedField.php
+++ b/src/SQLStore/TableBuilder/Examiner/TouchedField.php
@@ -36,7 +36,7 @@ class TouchedField {
 	 */
 	public function check( array $opts = [] ) {
 		$this->messageReporter->reportMessage( "Checking smw_touched field ...\n" );
-		$connection = $this->store->getConnection( DB_MASTER );
+		$connection = $this->store->getConnection( DB_PRIMARY );
 
 		$row = $connection->selectRow(
 			SQLStore::ID_TABLE,

--- a/src/SQLStore/TableBuilder/TableBuildExaminer.php
+++ b/src/SQLStore/TableBuilder/TableBuildExaminer.php
@@ -67,7 +67,7 @@ class TableBuildExaminer {
 	 */
 	public function getDatabaseInfo(): string {
 		$connection = $this->store->getConnection(
-			DB_MASTER
+			DB_PRIMARY
 		);
 
 		return $connection->getType() . ' (' . $connection->getServerInfo() . ')';
@@ -174,7 +174,7 @@ class TableBuildExaminer {
 	 * @param TableBuilder $tableBuilder
 	 */
 	public function checkOnPostDestruction( ITableBuilder $tableBuilder ) {
-		$connection = $this->store->getConnection( DB_MASTER );
+		$connection = $this->store->getConnection( DB_PRIMARY );
 
 		// Find orphaned tables that have not been removed but were produced and
 		// handled by SMW
@@ -192,7 +192,7 @@ class TableBuildExaminer {
 	}
 
 	private function checkSortField( $log ) {
-		$connection = $this->store->getConnection( DB_MASTER );
+		$connection = $this->store->getConnection( DB_PRIMARY );
 
 		$tableName = $connection->tableName( SQLStore::ID_TABLE );
 		$this->messageReporter->reportMessage( "Checking smw_sortkey, smw_sort fields ...\n" );

--- a/src/SQLStore/TableBuilder/TableSchemaManager.php
+++ b/src/SQLStore/TableBuilder/TableSchemaManager.php
@@ -170,7 +170,7 @@ class TableSchemaManager {
 	}
 
 	private function newEntityIdTable() {
-		$connection = $this->store->getConnection( DB_MASTER );
+		$connection = $this->store->getConnection( DB_PRIMARY );
 
 		// ID_TABLE
 		$table = new Table( SQLStore::ID_TABLE );

--- a/src/Setup.php
+++ b/src/Setup.php
@@ -203,8 +203,8 @@ final class Setup {
 		$connectionManager = $applicationFactory->getConnectionManager();
 
 		$connectionManager->registerConnectionProvider(
-			DB_MASTER,
-			$mwCollaboratorFactory->newLoadBalancerConnectionProvider( DB_MASTER )
+			DB_PRIMARY,
+			$mwCollaboratorFactory->newLoadBalancerConnectionProvider( DB_PRIMARY )
 		);
 
 		$connectionManager->registerConnectionProvider(

--- a/tests/phpunit/Integration/SQLStore/TableBuilder/TableBuilderIntegrationTest.php
+++ b/tests/phpunit/Integration/SQLStore/TableBuilder/TableBuilderIntegrationTest.php
@@ -32,7 +32,7 @@ class TableBuilderIntegrationTest extends DatabaseTestCase {
 		$this->messageReporterFactory = MessageReporterFactory::getInstance();
 
 		$this->tableBuilder = TableBuilder::factory(
-			$this->getStore()->getConnection( DB_MASTER )
+			$this->getStore()->getConnection( DB_PRIMARY )
 		);
 
 		$this->stringValidator = $this->testEnvironment->getUtilityFactory()->newValidatorFactory()->newStringValidator();

--- a/tests/phpunit/Structure/ConfigPreloadTableListPrimaryKeysCompleteTest.php
+++ b/tests/phpunit/Structure/ConfigPreloadTableListPrimaryKeysCompleteTest.php
@@ -33,7 +33,7 @@ class ConfigPreloadTableListPrimaryKeysCompleteTest extends \PHPUnit_Framework_T
 		$tableKeys = $reflectionClass->getConstant( 'PRIMARY_KEYS' );
 
 		$unlistedTables = [];
-		$connection = $store->getConnection( DB_MASTER );
+		$connection = $store->getConnection( DB_PRIMARY );
 
 		$tableSchemaManager = new TableSchemaManager(
 			$store

--- a/tests/phpunit/Utils/Connection/TestDatabaseConnectionProvider.php
+++ b/tests/phpunit/Utils/Connection/TestDatabaseConnectionProvider.php
@@ -23,7 +23,7 @@ class TestDatabaseConnectionProvider implements ConnectionProvider {
 	 *
 	 * @param int $id
 	 */
-	public function __construct( $id = DB_MASTER ) {
+	public function __construct( $id = DB_PRIMARY ) {
 		$this->id = $id;
 	}
 


### PR DESCRIPTION
DB_MASTER was deprecated in MediaWiki 1.36 and removed in MediaWiki 1.43

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated database connection terminology from "master" to "primary" for improved clarity and alignment with modern practices.
  
- **Bug Fixes**
	- Adjusted database connection handling across multiple components to ensure consistent use of the primary database reference.

- **Tests**
	- Modified test setups to utilize the updated primary database connection, ensuring tests reflect the new connection strategy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->