### PR TITLE
Replace DatabaseBase by IDatabase

### DIFF
--- a/src/MediaWiki/Connection/CleanUpTables.php
+++ b/src/MediaWiki/Connection/CleanUpTables.php
@@ -3,6 +3,7 @@
 namespace SMW\MediaWiki\Connection;
 
 use RuntimeException;
+use Wikimedia\Rdbms\IDatabase;
 
 /**
  * @private
@@ -15,7 +16,7 @@ use RuntimeException;
 class CleanUpTables {
 
 	/**
-	 * @var Database
+	 * @var Database|IDatabase
 	 */
 	private $connection;
 
@@ -24,10 +25,8 @@ class CleanUpTables {
 	 */
 	public function __construct( $connection ) {
 		if (
-			!$connection instanceof \SMW\MediaWiki\Database &&
-			!$connection instanceof \Wikimedia\Rdbms\IDatabase &&
-			!$connection instanceof \IDatabase &&
-			!$connection instanceof \DatabaseBase ) {
+			!$connection instanceof Database &&
+			!$connection instanceof IDatabase ) {
 			throw new RuntimeException( "Invalid connection instance!" );
 		}
 

--- a/src/MediaWiki/Connection/Database.php
+++ b/src/MediaWiki/Connection/Database.php
@@ -7,7 +7,9 @@ use Exception;
 use RuntimeException;
 use SMW\Connection\ConnRef;
 use UnexpectedValueException;
+use Wikimedia\Rdbms\Database as MWDatabase;
 use Wikimedia\Rdbms\IDatabase;
+use Wikimedia\Rdbms\Platform\SQLPlatform;
 use Wikimedia\Rdbms\ResultWrapper;
 use Wikimedia\ScopedCallback;
 
@@ -120,7 +122,7 @@ class Database {
 	}
 
 	/**
-	 * @see DatabaseBase::getServerInfo
+	 * @see IDatabase::getServerInfo
 	 *
 	 * @since 3.0
 	 *
@@ -133,7 +135,7 @@ class Database {
 	}
 
 	/**
-	 * @see DatabaseBase::getType
+	 * @see IDatabase::getType
 	 *
 	 * @since 1.9
 	 *
@@ -148,7 +150,7 @@ class Database {
 	}
 
 	/**
-	 * @see DatabaseBase::tableName
+	 * @see IDatabase::tableName
 	 *
 	 * @since 1.9
 	 *
@@ -161,7 +163,7 @@ class Database {
 	}
 
 	/**
-	 * @see DatabaseBase::timestamp
+	 * @see IDatabase::timestamp
 	 *
 	 * @since 3.0
 	 *
@@ -174,7 +176,7 @@ class Database {
 	}
 
 	/**
-	 * @see DatabaseBase::tablePrefix
+	 * @see IDatabase::tablePrefix
 	 *
 	 * @since 3.0
 	 *
@@ -196,7 +198,7 @@ class Database {
 	}
 
 	/**
-	 * @see DatabaseBase::addQuotes
+	 * @see IDatabase::addQuotes
 	 *
 	 * @since 1.9
 	 *
@@ -209,7 +211,7 @@ class Database {
 	}
 
 	/**
-	 * @see DatabaseBase::select
+	 * @see IDatabase::select
 	 *
 	 * @since 1.9
 	 *
@@ -270,7 +272,7 @@ class Database {
 	/**
 	 * Execute a given SQL query on the primary DB.
 	 *
-	 * @see DatabaseBase::query
+	 * @see IDatabase::query
 	 *
 	 * @since 1.9
 	 *
@@ -395,7 +397,7 @@ class Database {
 	}
 
 	/**
-	 * @see DatabaseBase::selectRow
+	 * @see IDatabase::selectRow
 	 *
 	 * @since 1.9
 	 */
@@ -411,7 +413,7 @@ class Database {
 	}
 
 	/**
-	 * @see DatabaseBase::affectedRows
+	 * @see IDatabase::affectedRows
 	 *
 	 * @since 1.9
 	 *
@@ -425,7 +427,7 @@ class Database {
 	 * @note Method was made protected in 1.28, hence the need
 	 * for the DatabaseHelper that copies the functionality.
 	 *
-	 * @see DatabaseBase::makeSelectOptions
+	 * @see SQLPlatform::makeSelectOptions
 	 *
 	 * @since 1.9
 	 *
@@ -438,7 +440,7 @@ class Database {
 	}
 
 	/**
-	 * @see DatabaseBase::nextSequenceValue
+	 * @see removed method IDatabase::nextSequenceValue
 	 *
 	 * @since 1.9
 	 *
@@ -464,7 +466,7 @@ class Database {
 	}
 
 	/**
-	 * @see DatabaseBase::insertId
+	 * @see IDatabase::insertId
 	 *
 	 * @since 1.9
 	 *
@@ -479,7 +481,7 @@ class Database {
 	}
 
 	/**
-	 * @see DatabaseBase::clearFlag
+	 * @see MWDatabase::clearFlag
 	 *
 	 * @since 2.4
 	 */
@@ -488,7 +490,7 @@ class Database {
 	}
 
 	/**
-	 * @see DatabaseBase::getFlag
+	 * @see MWDatabase::getFlag
 	 *
 	 * @since 2.4
 	 */
@@ -497,7 +499,7 @@ class Database {
 	}
 
 	/**
-	 * @see DatabaseBase::setFlag
+	 * @see MWDatabase::setFlag
 	 *
 	 * @since 2.4
 	 */
@@ -510,7 +512,7 @@ class Database {
 	}
 
 	/**
-	 * @see DatabaseBase::insert
+	 * @see IDatabase::insert
 	 *
 	 * @since 1.9
 	 */
@@ -525,7 +527,7 @@ class Database {
 	}
 
 	/**
-	 * @see DatabaseBase::update
+	 * @see IDatabase::update
 	 *
 	 * @since 1.9
 	 */
@@ -540,7 +542,7 @@ class Database {
 	}
 
 	/**
-	 * @see DatabaseBase::upsert
+	 * @see IDatabase::upsert
 	 *
 	 * @since 3.1
 	 */
@@ -555,7 +557,7 @@ class Database {
 	}
 
 	/**
-	 * @see DatabaseBase::delete
+	 * @see IDatabase::delete
 	 *
 	 * @since 1.9
 	 */
@@ -570,7 +572,7 @@ class Database {
 	}
 
 	/**
-	 * @see DatabaseBase::replace
+	 * @see IDatabase::replace
 	 *
 	 * @since 2.5
 	 */
@@ -585,7 +587,7 @@ class Database {
 	}
 
 	/**
-	 * @see DatabaseBase::makeList
+	 * @see IDatabase::makeList
 	 *
 	 * @since 1.9
 	 */
@@ -594,7 +596,7 @@ class Database {
 	}
 
 	/**
-	 * @see DatabaseBase::tableExists
+	 * @see IDatabase::tableExists
 	 *
 	 * @since 1.9
 	 *
@@ -608,7 +610,7 @@ class Database {
 	}
 
 	/**
-	 * @see DatabaseBase::listTables
+	 * @see IDatabase::listTables
 	 *
 	 * @since 3.1
 	 *
@@ -622,7 +624,7 @@ class Database {
 	}
 
 	/**
-	 * @see DatabaseBase::selectField
+	 * @see IDatabase::selectField
 	 *
 	 * @since 1.9.2
 	 */
@@ -631,7 +633,7 @@ class Database {
 	}
 
 	/**
-	 * @see DatabaseBase::estimateRowCount
+	 * @see IDatabase::estimateRowCount
 	 *
 	 * @since 2.1
 	 */

--- a/src/MediaWiki/Connection/LoadBalancerConnectionProvider.php
+++ b/src/MediaWiki/Connection/LoadBalancerConnectionProvider.php
@@ -2,11 +2,11 @@
 
 namespace SMW\MediaWiki\Connection;
 
-use DatabaseBase;
 use Psr\Log\LoggerAwareTrait;
 use RuntimeException;
 use SMW\Connection\ConnectionProvider as IConnectionProvider;
 use SMW\Services\ServicesFactory;
+use Wikimedia\Rdbms\IDatabase;
 
 /**
  * @license GNU GPL v2+
@@ -19,7 +19,7 @@ class LoadBalancerConnectionProvider implements IConnectionProvider {
 	use LoggerAwareTrait;
 
 	/**
-	 * @var DatabaseBase|IDatabase
+	 * @var IDatabase
 	 */
 	private $connection;
 
@@ -84,7 +84,7 @@ class LoadBalancerConnectionProvider implements IConnectionProvider {
 	 *
 	 * @since 1.9
 	 *
-	 * @return DatabaseBase
+	 * @return IDatabase
 	 * @throws RuntimeException
 	 */
 	public function getConnection() {
@@ -102,14 +102,11 @@ class LoadBalancerConnectionProvider implements IConnectionProvider {
 			$this->connection = $this->loadBalancer->getConnection( $this->id, $this->groups, $this->wiki );
 		}
 
-		if (
-			$this->connection instanceof DatabaseBase ||
-			$this->connection instanceof \IDatabase ||
-			$this->connection instanceof \Wikimedia\Rdbms\IDatabase ) {
+		if ( $this->connection instanceof IDatabase ) {
 			return $this->connection;
 		}
 
-		throw new RuntimeException( 'Expected a DatabaseBase or IDatabase instance!' );
+		throw new RuntimeException( 'Expected a IDatabase instance!' );
 	}
 
 	/**

--- a/src/MediaWiki/Connection/OptionsBuilder.php
+++ b/src/MediaWiki/Connection/OptionsBuilder.php
@@ -2,6 +2,8 @@
 
 namespace SMW\MediaWiki\Connection;
 
+use Wikimedia\Rdbms\Platform\SQLPlatform;
+
 /**
  * https://phabricator.wikimedia.org/T147550
  *
@@ -41,7 +43,7 @@ class OptionsBuilder {
 	}
 
 	/**
-	 * @see Database::makeSelectOptions
+	 * @see SQLPlatform::makeSelectOptions
 	 */
 	public static function makeSelectOptions( Database $connection, $options ) {
 		$preLimitTail = $postLimitTail = '';

--- a/src/MediaWiki/Connection/Sequence.php
+++ b/src/MediaWiki/Connection/Sequence.php
@@ -4,6 +4,7 @@ namespace SMW\MediaWiki\Connection;
 
 use SMW\SQLStore\SQLStore;
 use RuntimeException;
+use Wikimedia\Rdbms\IDatabase;
 
 /**
  * @license GNU GPL v2+
@@ -14,7 +15,7 @@ use RuntimeException;
 class Sequence {
 
 	/**
-	 * @var Database
+	 * @var Database|IDatabase
 	 */
 	private $connection;
 
@@ -29,9 +30,7 @@ class Sequence {
 	public function __construct( $connection ) {
 		if (
 			!$connection instanceof Database &&
-			!$connection instanceof DatabaseBase &&
-			!$connection instanceof \IDatabase &&
-			!$connection instanceof \Wikimedia\Rdbms\IDatabase ) {
+			!$connection instanceof IDatabase ) {
 			throw new RuntimeException( "Invalid connection instance!" );
 		}
 

--- a/src/MediaWiki/Search/ExtendedSearchEngine.php
+++ b/src/MediaWiki/Search/ExtendedSearchEngine.php
@@ -3,9 +3,9 @@
 namespace SMW\MediaWiki\Search;
 
 use Content;
-use DatabaseBase;
 use Title;
 use SearchEngine;
+use Wikimedia\Rdbms\IDatabase;
 
 /**
  * Facade to the MediaWiki `SearchEngine` which doesn't allow any factory
@@ -33,7 +33,7 @@ class ExtendedSearchEngine extends SearchEngine {
 	 *
 	 * @since 3.1
 	 */
-	public function __construct( DatabaseBase $connection = null ) {
+	public function __construct( IDatabase $connection = null ) {
 		// It is common practice to avoid construction work in the constructor
 		// but we are unable to define a factory or callable and this is the only
 		// place to create an instance.

--- a/src/MediaWiki/Search/SearchEngineFactory.php
+++ b/src/MediaWiki/Search/SearchEngineFactory.php
@@ -2,7 +2,6 @@
 
 namespace SMW\MediaWiki\Search;
 
-use DatabaseBase;
 use RuntimeException;
 use SearchEngine;
 use SMW\Services\ServicesFactory as ApplicationFactory;
@@ -10,6 +9,7 @@ use SMW\MediaWiki\Search\Exception\SearchDatabaseInvalidTypeException;
 use SMW\MediaWiki\Search\Exception\SearchEngineInvalidTypeException;
 use SMW\MediaWiki\Search\ProfileForm\ProfileForm;
 use SMW\Exception\ClassNotFoundException;
+use Wikimedia\Rdbms\IDatabase;
 
 /**
  * @license GNU GPL v2+
@@ -22,12 +22,12 @@ class SearchEngineFactory {
 	/**
 	 * @since 3.1
 	 *
-	 * @param \DatabaseBase $connection
+	 * @param IDatabase $connection
 	 *
 	 * @return SearchEngine
 	 * @throws SearchEngineInvalidTypeException
 	 */
-	public function newFallbackSearchEngine( DatabaseBase $connection = null ) {
+	public function newFallbackSearchEngine( IDatabase $connection = null ) {
 		$applicationFactory = ApplicationFactory::getInstance();
 		$settings = $applicationFactory->getSettings();
 

--- a/src/SQLStore/Installer/VersionExaminer.php
+++ b/src/SQLStore/Installer/VersionExaminer.php
@@ -7,6 +7,7 @@ use SMW\SetupFile;
 use SMW\Utils\CliMsgFormatter;
 use SMW\Setup;
 use RuntimeException;
+use Wikimedia\Rdbms\IDatabase;
 
 /**
  * @private
@@ -36,10 +37,7 @@ class VersionExaminer {
 	 * @param IDatabase $connection
 	 */
 	public function __construct( $connection ) {
-		if (
-			!$connection instanceof \Wikimedia\Rdbms\IDatabase &&
-			!$connection instanceof \IDatabase &&
-			!$connection instanceof \DatabaseBase ) {
+		if ( !$connection instanceof IDatabase ) {
 			throw new RuntimeException( "Invalid connection instance!" );
 		}
 

--- a/src/SQLStore/TableBuilder/TableBuilder.php
+++ b/src/SQLStore/TableBuilder/TableBuilder.php
@@ -2,12 +2,12 @@
 
 namespace SMW\SQLStore\TableBuilder;
 
-use DatabaseBase;
 use Onoi\MessageReporter\MessageReporter;
 use Onoi\MessageReporter\MessageReporterAware;
 use RuntimeException;
 use SMW\SQLStore\TableBuilder as TableBuilderInterface;
 use SMW\Utils\CliMsgFormatter;
+use Wikimedia\Rdbms\IDatabase;
 
 /**
  * @license GNU GPL v2+
@@ -18,7 +18,7 @@ use SMW\Utils\CliMsgFormatter;
 abstract class TableBuilder implements TableBuilderInterface, MessageReporterAware, MessageReporter {
 
 	/**
-	 * @var DatabaseBase
+	 * @var IDatabase
 	 */
 	protected $connection;
 
@@ -42,7 +42,7 @@ abstract class TableBuilder implements TableBuilderInterface, MessageReporterAwa
 	/**
 	 * @since 2.5
 	 *
-	 * @param DatabaseBase $connection
+	 * @param IDatabase $connection
 	 */
 	protected function __construct( $connection ) {
 		$this->connection = $connection;
@@ -51,16 +51,13 @@ abstract class TableBuilder implements TableBuilderInterface, MessageReporterAwa
 	/**
 	 * @since 2.5
 	 *
-	 * @param DatabaseBase $connection
+	 * @param IDatabase $connection
 	 *
 	 * @return TableBuilder
 	 * @throws RuntimeException
 	 */
 	public static function factory( $connection ) {
-		if (
-			!$connection instanceof \Wikimedia\Rdbms\IDatabase &&
-			!$connection instanceof \IDatabase &&
-			!$connection instanceof \DatabaseBase ) {
+		if ( !$connection instanceof IDatabase ) {
 			throw new RuntimeException( "Invalid connection instance!" );
 		}
 

--- a/tests/phpunit/Elastic/ElasticStoreTest.php
+++ b/tests/phpunit/Elastic/ElasticStoreTest.php
@@ -76,7 +76,7 @@ class ElasticStoreTest extends \PHPUnit_Framework_TestCase {
 			->disableOriginalConstructor()
 			->getMock();
 
-		$database = $this->getMockBuilder( '\DatabaseBase' )
+		$database = $this->getMockBuilder( '\Wikimedia\Rdbms\Database' )
 			->disableOriginalConstructor()
 			->getMock();
 
@@ -163,7 +163,7 @@ class ElasticStoreTest extends \PHPUnit_Framework_TestCase {
 			->disableOriginalConstructor()
 			->getMock();
 
-		$database = $this->getMockBuilder( '\DatabaseBase' )
+		$database = $this->getMockBuilder( '\Wikimedia\Rdbms\Database' )
 			->disableOriginalConstructor()
 			->getMock();
 

--- a/tests/phpunit/Integration/MediaWiki/Import/RedirectPageTest.php
+++ b/tests/phpunit/Integration/MediaWiki/Import/RedirectPageTest.php
@@ -139,7 +139,7 @@ class RedirectPageTest extends DatabaseTestCase {
 		$inSemanticData = $inSemanticDataFetcher->getSemanticData( DIWikiPage::newFromTitle( $main ) );
 
 		// When running sqlite, the database select returns an empty result which
-		// is probably due to some DB-prefix issues in MW's DatabaseBaseSqlite
+		// is probably due to some DB-prefix issues in MW's DatabaseSqlite
 		// implementation and for non-sqlite see #212 / bug 62856
 		if ( $inSemanticData->getProperties() === [] ) {
 			$this->markTestSkipped(

--- a/tests/phpunit/MediaWiki/Connection/CleanUpTablesTest.php
+++ b/tests/phpunit/MediaWiki/Connection/CleanUpTablesTest.php
@@ -21,7 +21,7 @@ class CleanUpTablesTest extends \PHPUnit_Framework_TestCase {
 	private $connection;
 
 	protected function setUp(): void {
-		$this->connection = $this->getMockBuilder( '\DatabaseBase' )
+		$this->connection = $this->getMockBuilder( '\Wikimedia\Rdbms\Database' )
 			->disableOriginalConstructor()
 			->getMock();
 	}
@@ -39,7 +39,7 @@ class CleanUpTablesTest extends \PHPUnit_Framework_TestCase {
 	}
 
 	public function testNonPostgres() {
-		$connection = $this->getMockBuilder( '\DatabaseBase' )
+		$connection = $this->getMockBuilder( '\Wikimedia\Rdbms\Database' )
 			->disableOriginalConstructor()
 			->setMethods( [ 'listTables', 'query', 'tableExists' ] )
 			->getMockForAbstractClass();
@@ -64,7 +64,7 @@ class CleanUpTablesTest extends \PHPUnit_Framework_TestCase {
 	}
 
 	public function testPostgres() {
-		$connection = $this->getMockBuilder( '\DatabaseBase' )
+		$connection = $this->getMockBuilder( '\Wikimedia\Rdbms\Database' )
 			->disableOriginalConstructor()
 			->setMethods( [ 'listTables', 'query', 'getType', 'tableExists' ] )
 			->getMockForAbstractClass();

--- a/tests/phpunit/MediaWiki/Connection/DatabaseTest.php
+++ b/tests/phpunit/MediaWiki/Connection/DatabaseTest.php
@@ -58,7 +58,7 @@ class DatabaseTest extends \PHPUnit_Framework_TestCase {
 	}
 
 	public function testAddQuotesMethod() {
-		$database = $this->getMockBuilder( '\DatabaseBase' )
+		$database = $this->getMockBuilder( '\Wikimedia\Rdbms\Database' )
 			->disableOriginalConstructor()
 			->setMethods( [ 'addQuotes' ] )
 			->getMockForAbstractClass();
@@ -95,7 +95,7 @@ class DatabaseTest extends \PHPUnit_Framework_TestCase {
 	 * @dataProvider dbTypeProvider
 	 */
 	public function testTableNameMethod( $type ) {
-		$database = $this->getMockBuilder( '\DatabaseBase' )
+		$database = $this->getMockBuilder( '\Wikimedia\Rdbms\Database' )
 			->disableOriginalConstructor()
 			->setMethods( [ 'tableName' ] )
 			->getMockForAbstractClass();
@@ -132,7 +132,7 @@ class DatabaseTest extends \PHPUnit_Framework_TestCase {
 			->disableOriginalConstructor()
 			->getMock();
 
-		$database = $this->getMockBuilder( '\DatabaseBase' )
+		$database = $this->getMockBuilder( '\Wikimedia\Rdbms\Database' )
 			->disableOriginalConstructor()
 			->setMethods( [ 'select' ] )
 			->getMockForAbstractClass();
@@ -165,7 +165,7 @@ class DatabaseTest extends \PHPUnit_Framework_TestCase {
 	}
 
 	public function testSelectFieldMethod() {
-		$database = $this->getMockBuilder( '\DatabaseBase' )
+		$database = $this->getMockBuilder( '\Wikimedia\Rdbms\Database' )
 			->disableOriginalConstructor()
 			->setMethods( [ 'selectField' ] )
 			->getMockForAbstractClass();
@@ -206,7 +206,7 @@ class DatabaseTest extends \PHPUnit_Framework_TestCase {
 			->disableOriginalConstructor()
 			->getMock();
 
-		$read = $this->getMockBuilder( '\DatabaseBase' )
+		$read = $this->getMockBuilder( '\Wikimedia\Rdbms\Database' )
 			->disableOriginalConstructor()
 			->setMethods( [ 'getType' ] )
 			->getMockForAbstractClass();
@@ -223,7 +223,7 @@ class DatabaseTest extends \PHPUnit_Framework_TestCase {
 			->method( 'getConnection' )
 			->will( $this->returnValue( $read ) );
 
-		$write = $this->getMockBuilder( '\DatabaseBase' )
+		$write = $this->getMockBuilder( '\Wikimedia\Rdbms\Database' )
 			->disableOriginalConstructor()
 			->setMethods( [ 'query' ] )
 			->getMockForAbstractClass();
@@ -269,7 +269,7 @@ class DatabaseTest extends \PHPUnit_Framework_TestCase {
 	}
 
 	public function testSelectThrowsException() {
-		$database = $this->getMockBuilder( '\DatabaseBase' )
+		$database = $this->getMockBuilder( '\Wikimedia\Rdbms\Database' )
 			->disableOriginalConstructor()
 			->setMethods( [ 'select' ] )
 			->getMockForAbstractClass();
@@ -309,7 +309,7 @@ class DatabaseTest extends \PHPUnit_Framework_TestCase {
 	}
 
 	public function testQueryThrowsException() {
-		$database = $this->getMockBuilder( '\DatabaseBase' )
+		$database = $this->getMockBuilder( '\Wikimedia\Rdbms\Database' )
 			->disableOriginalConstructor()
 			->setMethods( [ 'query' ] )
 			->getMockForAbstractClass();
@@ -512,7 +512,7 @@ class DatabaseTest extends \PHPUnit_Framework_TestCase {
 			->disableOriginalConstructor()
 			->getMock();
 
-		$read = $this->getMockBuilder( '\DatabaseBase' )
+		$read = $this->getMockBuilder( '\Wikimedia\Rdbms\Database' )
 			->disableOriginalConstructor()
 			->getMock();
 
@@ -536,7 +536,7 @@ class DatabaseTest extends \PHPUnit_Framework_TestCase {
 	}
 
 	public function testDoQueryWithAutoCommit() {
-		$database = $this->getMockBuilder( '\DatabaseBase' )
+		$database = $this->getMockBuilder( '\Wikimedia\Rdbms\Database' )
 			->disableOriginalConstructor()
 			->setMethods( [ 'getFlag', 'clearFlag', 'setFlag', 'getType', 'query' ] )
 			->getMockForAbstractClass();

--- a/tests/phpunit/MediaWiki/Connection/LoadBalancerConnectionProviderTest.php
+++ b/tests/phpunit/MediaWiki/Connection/LoadBalancerConnectionProviderTest.php
@@ -2,7 +2,6 @@
 
 namespace SMW\Tests\MediaWiki\Connection;
 
-use DatabaseBase;
 use ReflectionClass;
 use SMW\Tests\PHPUnitCompat;
 use SMW\MediaWiki\Connection\LoadBalancerConnectionProvider;

--- a/tests/phpunit/MediaWiki/Search/ExtendedSearchEngineTest.php
+++ b/tests/phpunit/MediaWiki/Search/ExtendedSearchEngineTest.php
@@ -26,7 +26,7 @@ class ExtendedSearchEngineTest extends \PHPUnit_Framework_TestCase {
 	protected function setUp(): void {
 		$this->testEnvironment = new TestEnvironment();
 
-		$this->connection = $this->getMockBuilder( 'DatabaseBase' )
+		$this->connection = $this->getMockBuilder( '\Wikimedia\Rdbms\Database' )
 			->disableOriginalConstructor()
 			->getMockForAbstractClass();
 	}
@@ -55,7 +55,7 @@ class ExtendedSearchEngineTest extends \PHPUnit_Framework_TestCase {
 			}
 		}
 
-		$connection = $this->getMockBuilder( '\DatabaseBase' )
+		$connection = $this->getMockBuilder( '\Wikimedia\Rdbms\Database' )
 			->disableOriginalConstructor()
 			->setMethods( [ 'getSearchEngine' ] )
 			->getMockForAbstractClass();

--- a/tests/phpunit/MediaWiki/Search/SearchEngineFactoryTest.php
+++ b/tests/phpunit/MediaWiki/Search/SearchEngineFactoryTest.php
@@ -26,7 +26,7 @@ class SearchEngineFactoryTest extends \PHPUnit_Framework_TestCase {
 	protected function setUp(): void {
 		$this->testEnvironment = new TestEnvironment();
 
-		$this->connection = $this->getMockBuilder( 'DatabaseBase' )
+		$this->connection = $this->getMockBuilder( '\Wikimedia\Rdbms\Database' )
 			->disableOriginalConstructor()
 			->getMockForAbstractClass();
 	}
@@ -68,7 +68,7 @@ class SearchEngineFactoryTest extends \PHPUnit_Framework_TestCase {
 			}
 		}
 
-		$connection = $this->getMockBuilder( '\DatabaseBase' )
+		$connection = $this->getMockBuilder( '\Wikimedia\Rdbms\Database' )
 			->disableOriginalConstructor()
 			->setMethods( [ 'getSearchEngine' ] )
 			->getMockForAbstractClass();

--- a/tests/phpunit/SQLStore/Installer/VersionExaminerTest.php
+++ b/tests/phpunit/SQLStore/Installer/VersionExaminerTest.php
@@ -35,7 +35,7 @@ class VersionExaminerTest extends \PHPUnit_Framework_TestCase {
 	}
 
 	public function testCanConstruct() {
-		$connection = $this->getMockBuilder( '\DatabaseBase' )
+		$connection = $this->getMockBuilder( '\Wikimedia\Rdbms\Database' )
 			->disableOriginalConstructor()
 			->getMockForAbstractClass();
 
@@ -46,7 +46,7 @@ class VersionExaminerTest extends \PHPUnit_Framework_TestCase {
 	}
 
 	public function testRequirements() {
-		$connection = $this->getMockBuilder( '\DatabaseBase' )
+		$connection = $this->getMockBuilder( '\Wikimedia\Rdbms\Database' )
 			->disableOriginalConstructor()
 			->setMethods( [ 'getServerInfo' ] )
 			->getMockForAbstractClass();
@@ -76,7 +76,7 @@ class VersionExaminerTest extends \PHPUnit_Framework_TestCase {
 	}
 
 	public function testRequirements_InvalidDefined() {
-		$connection = $this->getMockBuilder( '\DatabaseBase' )
+		$connection = $this->getMockBuilder( '\Wikimedia\Rdbms\Database' )
 			->disableOriginalConstructor()
 			->setMethods( [ 'getServerInfo' ] )
 			->getMockForAbstractClass();
@@ -97,7 +97,7 @@ class VersionExaminerTest extends \PHPUnit_Framework_TestCase {
 	}
 
 	public function testMeetsVersionMinRequirement() {
-		$connection = $this->getMockBuilder( '\DatabaseBase' )
+		$connection = $this->getMockBuilder( '\Wikimedia\Rdbms\Database' )
 			->disableOriginalConstructor()
 			->setMethods( [ 'getServerInfo' ] )
 			->getMockForAbstractClass();
@@ -127,7 +127,7 @@ class VersionExaminerTest extends \PHPUnit_Framework_TestCase {
 	}
 
 	public function testMeetsVersionMinRequirement_FailsMinimumRequirement() {
-		$connection = $this->getMockBuilder( '\DatabaseBase' )
+		$connection = $this->getMockBuilder( '\Wikimedia\Rdbms\Database' )
 			->disableOriginalConstructor()
 			->setMethods( [ 'getServerInfo' ] )
 			->getMockForAbstractClass();

--- a/tests/phpunit/SQLStore/SQLStoreFactoryTest.php
+++ b/tests/phpunit/SQLStore/SQLStoreFactoryTest.php
@@ -190,7 +190,7 @@ class SQLStoreFactoryTest extends \PHPUnit_Framework_TestCase {
 	}
 
 	public function testCanConstructInstaller() {
-		$connection = $this->getMockBuilder( '\DatabaseBase' )
+		$connection = $this->getMockBuilder( '\Wikimedia\Rdbms\Database' )
 			->disableOriginalConstructor()
 			->getMockForAbstractClass();
 

--- a/tests/phpunit/SQLStore/TableBuilder/MySQLTableBuilderTest.php
+++ b/tests/phpunit/SQLStore/TableBuilder/MySQLTableBuilderTest.php
@@ -50,7 +50,7 @@ class MySQLTableBuilderTest extends \PHPUnit_Framework_TestCase {
 	}
 
 	public function testFactoryWithWrongTypeThrowsException() {
-		$connection = $this->getMockBuilder( '\DatabaseBase' )
+		$connection = $this->getMockBuilder( '\Wikimedia\Rdbms\Database' )
 			->disableOriginalConstructor()
 			->getMockForAbstractClass();
 

--- a/tests/phpunit/SQLStore/TableBuilder/TableBuildExaminerTest.php
+++ b/tests/phpunit/SQLStore/TableBuilder/TableBuildExaminerTest.php
@@ -146,7 +146,7 @@ class TableBuildExaminerTest extends \PHPUnit_Framework_TestCase {
 	}
 
 	public function testCheckOnPostDestruction() {
-		$connection = $this->getMockBuilder( '\DatabaseBase' )
+		$connection = $this->getMockBuilder( '\Wikimedia\Rdbms\Database' )
 			->disableOriginalConstructor()
 			->setMethods( [ 'listTables' ] )
 			->getMockForAbstractClass();
@@ -184,7 +184,7 @@ class TableBuildExaminerTest extends \PHPUnit_Framework_TestCase {
 	}
 
 	public function testGetDatabaseInfo() {
-		$connection = $this->getMockBuilder( '\DatabaseBase' )
+		$connection = $this->getMockBuilder( '\Wikimedia\Rdbms\Database' )
 			->disableOriginalConstructor()
 			->setMethods( [ 'getType', 'getServerInfo' ] )
 			->getMockForAbstractClass();

--- a/tests/phpunit/SQLStore/TableBuilder/TableBuilderTest.php
+++ b/tests/phpunit/SQLStore/TableBuilder/TableBuilderTest.php
@@ -19,7 +19,7 @@ class TableBuilderTest extends \PHPUnit_Framework_TestCase {
 	use PHPUnitCompat;
 
 	public function testCanConstructForMySQL() {
-		$connection = $this->getMockBuilder( '\DatabaseBase' )
+		$connection = $this->getMockBuilder( '\Wikimedia\Rdbms\Database' )
 			->disableOriginalConstructor()
 			->getMockForAbstractClass();
 
@@ -34,7 +34,7 @@ class TableBuilderTest extends \PHPUnit_Framework_TestCase {
 	}
 
 	public function testCanConstructForSQLite() {
-		$connection = $this->getMockBuilder( '\DatabaseBase' )
+		$connection = $this->getMockBuilder( '\Wikimedia\Rdbms\Database' )
 			->disableOriginalConstructor()
 			->getMockForAbstractClass();
 
@@ -49,7 +49,7 @@ class TableBuilderTest extends \PHPUnit_Framework_TestCase {
 	}
 
 	public function testCanConstructForPostgres() {
-		$connection = $this->getMockBuilder( '\DatabaseBase' )
+		$connection = $this->getMockBuilder( '\Wikimedia\Rdbms\Database' )
 			->disableOriginalConstructor()
 			->getMockForAbstractClass();
 
@@ -64,7 +64,7 @@ class TableBuilderTest extends \PHPUnit_Framework_TestCase {
 	}
 
 	public function testConstructWithInvalidTypeThrowsException() {
-		$connection = $this->getMockBuilder( '\DatabaseBase' )
+		$connection = $this->getMockBuilder( '\Wikimedia\Rdbms\Database' )
 			->disableOriginalConstructor()
 			->getMockForAbstractClass();
 

--- a/tests/phpunit/Utils/Connection/TestDatabaseConnectionProvider.php
+++ b/tests/phpunit/Utils/Connection/TestDatabaseConnectionProvider.php
@@ -2,7 +2,6 @@
 
 namespace SMW\Tests\Utils\Connection;
 
-use DatabaseBase;
 use SMW\Services\ServicesFactory;
 use SMW\Connection\ConnectionProvider;
 use Wikimedia\Rdbms\IDatabase;

--- a/tests/phpunit/Utils/Connection/TestDatabaseTableBuilder.php
+++ b/tests/phpunit/Utils/Connection/TestDatabaseTableBuilder.php
@@ -8,6 +8,7 @@ use SMW\Connection\ConnectionProvider;
 use SMW\Tests\Utils\PageCreator;
 use SMW\Store;
 use Title;
+use Wikimedia\Rdbms\IDatabase;
 
 /**
  * @license GNU GPL v2+
@@ -133,7 +134,7 @@ class TestDatabaseTableBuilder {
 	/**
 	 * @since  2.0
 	 *
-	 * @return DatabaseBase
+	 * @return IDatabase
 	 */
 	public function getDBConnection() {
 		return $this->connectionProvider->getConnection();

--- a/tests/phpunit/Utils/Mock/MediaWikiMockObjectRepository.php
+++ b/tests/phpunit/Utils/Mock/MediaWikiMockObjectRepository.php
@@ -2,6 +2,9 @@
 
 namespace SMW\Tests\Utils\Mock;
 
+use Wikimedia\Rdbms\Database;
+use Wikimedia\Rdbms\IDatabase;
+
 /**
  * @codeCoverageIgnore
  *
@@ -369,10 +372,10 @@ class MediaWikiMockObjectRepository extends \PHPUnit_Framework_TestCase implemen
 	/**
 	 * @since 1.9
 	 *
-	 * @return DatabaseBase
+	 * @return Database
 	 */
-	public function DatabaseBase() {
-		// DatabaseBase is an abstract class, use setMethods to implement
+	public function Database() {
+		// Database is an abstract class, use setMethods to implement
 		// required abstract methods
 		$requiredAbstractMethods = [
 			'selectField',
@@ -399,20 +402,20 @@ class MediaWikiMockObjectRepository extends \PHPUnit_Framework_TestCase implemen
 
 		$methods = array_unique( array_merge( $requiredAbstractMethods, $this->builder->getInvokedMethods() ) );
 
-		$databaseBase = $this->getMockBuilder( 'DatabaseBase' )
+		$database = $this->getMockBuilder( '\Wikimedia\Rdbms\Database' )
 			->disableOriginalConstructor()
 			->setMethods( $methods )
 			->getMock();
 
 		foreach ( $this->builder->getInvokedMethods() as $method ) {
 
-			$databaseBase->expects( $this->any() )
+			$database->expects( $this->any() )
 				->method( $method )
 				->will( $this->builder->setCallback( $method ) );
 
 		}
 
-		return $databaseBase;
+		return $database;
 	}
 
 	/**


### PR DESCRIPTION
`\DatabaseBase` was an alias of `\Wikimedia\Rdbms\Database` before MW 1.41, and its interface is `\Wikimedia\Rdbms\IDatabase`.

This should help in reducing the number of CI errors on 1.41-1.42.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced type safety for database connections across various components by transitioning from `DatabaseBase` to `IDatabase`.
  
- **Bug Fixes**
	- Updated documentation references to ensure accuracy regarding database methods and interfaces.

- **Tests**
	- Adjusted mock object creation in multiple test files to align with the new `IDatabase` interface, improving test reliability and accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->