### PR TITLE
Replace DatabaseBase by IDatabase (2)

### DIFF
--- a/tests/phpunit/Maintenance/PurgeEntityCacheTest.php
+++ b/tests/phpunit/Maintenance/PurgeEntityCacheTest.php
@@ -10,6 +10,7 @@ use Wikimedia\Rdbms\FakeResultWrapper;
 use SMW\SQLStore\SQLStore;
 use SMW\Tests\TestEnvironment;
 use SMW\DIWikiPage;
+use Wikimedia\Rdbms\Database;
 
 /**
  * @covers \SMW\Maintenance\PurgeEntityCache
@@ -33,7 +34,7 @@ class PurgeEntityCacheTest extends TestCase {
 
 		$this->messageReporter = $this->createMock( MessageReporter::class );
 		$this->store = $this->createMock( SQLStore::class );
-		$this->connection = $this->createMock( \Database::class );
+		$this->connection = $this->createMock( Database::class );
 		$this->entityCache = $this->createMock( EntityCache::class );
 
 		$this->testEnvironment->registerObject( 'Store', $this->store );

--- a/tests/phpunit/MediaWiki/Connection/DatabaseTest.php
+++ b/tests/phpunit/MediaWiki/Connection/DatabaseTest.php
@@ -397,7 +397,7 @@ class DatabaseTest extends \PHPUnit_Framework_TestCase {
 			->disableOriginalConstructor()
 			->getMock();
 
-		$read = $this->getMockBuilder( '\IDatabase' )
+		$read = $this->getMockBuilder( '\Wikimedia\Rdbms\IDatabase' )
 			->disableOriginalConstructor()
 			->getMock();
 
@@ -405,7 +405,7 @@ class DatabaseTest extends \PHPUnit_Framework_TestCase {
 			->method( 'getConnection' )
 			->will( $this->returnValue( $read ) );
 
-		$write = $this->getMockBuilder( '\IDatabase' )
+		$write = $this->getMockBuilder( '\Wikimedia\Rdbms\IDatabase' )
 			->disableOriginalConstructor()
 			->getMock();
 
@@ -452,7 +452,7 @@ class DatabaseTest extends \PHPUnit_Framework_TestCase {
 			->disableOriginalConstructor()
 			->getMock();
 
-		$read = $this->getMockBuilder( '\IDatabase' )
+		$read = $this->getMockBuilder( '\Wikimedia\Rdbms\IDatabase' )
 			->disableOriginalConstructor()
 			->getMock();
 
@@ -460,7 +460,7 @@ class DatabaseTest extends \PHPUnit_Framework_TestCase {
 			->method( 'getConnection' )
 			->will( $this->returnValue( $read ) );
 
-		$write = $this->getMockBuilder( '\IDatabase' )
+		$write = $this->getMockBuilder( '\Wikimedia\Rdbms\IDatabase' )
 			->disableOriginalConstructor()
 			->getMock();
 

--- a/tests/phpunit/MediaWiki/Connection/LoadBalancerConnectionProviderTest.php
+++ b/tests/phpunit/MediaWiki/Connection/LoadBalancerConnectionProviderTest.php
@@ -39,7 +39,7 @@ class LoadBalancerConnectionProviderTest extends \PHPUnit_Framework_TestCase {
 	}
 
 	public function testGetAndReleaseConnection() {
-		$database = $this->getMockBuilder( '\IDatabase' )
+		$database = $this->getMockBuilder( '\Wikimedia\Rdbms\IDatabase' )
 			->disableOriginalConstructor()
 			->getMock();
 
@@ -56,7 +56,7 @@ class LoadBalancerConnectionProviderTest extends \PHPUnit_Framework_TestCase {
 		$connection = $instance->getConnection();
 
 		$this->assertInstanceOf(
-			'\IDatabase',
+			'\Wikimedia\Rdbms\IDatabase',
 			$instance->getConnection()
 		);
 
@@ -68,7 +68,7 @@ class LoadBalancerConnectionProviderTest extends \PHPUnit_Framework_TestCase {
 	}
 
 	public function testGetAndReleaseConnectionRef() {
-		$database = $this->getMockBuilder( '\IDatabase' )
+		$database = $this->getMockBuilder( '\Wikimedia\Rdbms\IDatabase' )
 			->disableOriginalConstructor()
 			->getMock();
 
@@ -83,7 +83,7 @@ class LoadBalancerConnectionProviderTest extends \PHPUnit_Framework_TestCase {
 		$connection = $instance->getConnection();
 
 		$this->assertInstanceOf(
-			'\IDatabase',
+			'\Wikimedia\Rdbms\IDatabase',
 			$instance->getConnection()
 		);
 

--- a/tests/phpunit/Utils/Mock/MediaWikiMockObjectRepository.php
+++ b/tests/phpunit/Utils/Mock/MediaWikiMockObjectRepository.php
@@ -3,7 +3,6 @@
 namespace SMW\Tests\Utils\Mock;
 
 use Wikimedia\Rdbms\Database;
-use Wikimedia\Rdbms\IDatabase;
 
 /**
  * @codeCoverageIgnore


### PR DESCRIPTION
\DatabaseBase was an alias of \Wikimedia\Rdbms\Database before MW 1.41, and its interface is \Wikimedia\Rdbms\IDatabase.