### PR TITLE
Require MediaWiki 1.39

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,17 +16,11 @@ jobs:
     strategy:
       matrix:
         include:
-          - mediawiki_version: '1.35'
-            php_version: 7.4
-            database_type: mysql
-            database_image: "mysql:5.7"
-            coverage: true
-            experimental: false
           - mediawiki_version: '1.39'
             php_version: 8.1
             database_type: mysql
             database_image: "mariadb:11.2"
-            coverage: false
+            coverage: true
             experimental: false
           - mediawiki_version: '1.39'
             php_version: 8.1

--- a/extension.json
+++ b/extension.json
@@ -14,7 +14,7 @@
 	"license-name": "GPL-2.0-or-later",
 	"type": "semantic",
 	"requires": {
-		"MediaWiki": ">= 1.35"
+		"MediaWiki": ">= 1.39"
 	},
 	"MessagesDirs": {
 		"SemanticMediaWiki": [


### PR DESCRIPTION
To prepare breaking changes of #5569 and with the comment of @jaideraf there, here it is a dedicated PR for this.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated the extension to require MediaWiki version 1.39 or higher, enabling access to new features and improvements.
  
- **Bug Fixes**
	- Enhanced testing practices by enabling coverage reporting for MediaWiki version 1.39 during the CI process. 

- **Chores**
	- Removed outdated configurations for MediaWiki version 1.35 from the CI/CD workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->