### PR TITLE
Replace deprecated alias DBError

### DIFF
--- a/src/MediaWiki/Connection/Database.php
+++ b/src/MediaWiki/Connection/Database.php
@@ -2,12 +2,12 @@
 
 namespace SMW\MediaWiki\Connection;
 
-use DBError;
 use Exception;
 use RuntimeException;
 use SMW\Connection\ConnRef;
 use UnexpectedValueException;
 use Wikimedia\Rdbms\Database as MWDatabase;
+use Wikimedia\Rdbms\DBError;
 use Wikimedia\Rdbms\IDatabase;
 use Wikimedia\Rdbms\Platform\SQLPlatform;
 use Wikimedia\Rdbms\ResultWrapper;

--- a/src/SQLStore/PropertyTableIdReferenceDisposer.php
+++ b/src/SQLStore/PropertyTableIdReferenceDisposer.php
@@ -8,6 +8,7 @@ use SMW\DIWikiPage;
 use Onoi\EventDispatcher\EventDispatcherAwareTrait;
 use SMW\Iterators\ResultIterator;
 use SMW\RequestOptions;
+use Wikimedia\Rdbms\DBError;
 
 /**
  * @private
@@ -323,7 +324,7 @@ class PropertyTableIdReferenceDisposer {
 			if ( $this->fulltextTableUsage ) {
 				$tableExists = $this->connection->tableExists( SQLStore::FT_SEARCH_TABLE );
 			}
-		} catch ( \DBError $e ) {
+		} catch ( DBError $e ) {
 			ApplicationFactory::getInstance()->getMediaWikiLogger()->info( __METHOD__ . ' reported: ' . $e->getMessage() );
 		}
 

--- a/tests/phpunit/MediaWiki/Connection/DatabaseTest.php
+++ b/tests/phpunit/MediaWiki/Connection/DatabaseTest.php
@@ -6,6 +6,7 @@ use SMW\Connection\ConnectionProvider;
 use SMW\Connection\ConnRef;
 use SMW\Tests\PHPUnitCompat;
 use SMW\MediaWiki\Connection\Database;
+use Wikimedia\Rdbms\DBError;
 use Wikimedia\Rdbms\FakeResultWrapper;
 use Wikimedia\Rdbms\IDatabase;
 use Wikimedia\Rdbms\IResultWrapper;
@@ -314,7 +315,7 @@ class DatabaseTest extends \PHPUnit_Framework_TestCase {
 			->setMethods( [ 'query' ] )
 			->getMockForAbstractClass();
 
-		$databaseException = new \DBError( $database, 'foo' );
+		$databaseException = new DBError( $database, 'foo' );
 
 		$database->expects( $this->once() )
 			->method( 'query' )


### PR DESCRIPTION
The alias was available from MediaWiki 1.29 to MediaWiki 1.41, removed in MediaWiki 1.42.

This fixes 1 error in tests for 1.42.

NB: I prepared a few PR about maintenance topics for MW 1.42, each one is self-contained to facilitate the review and tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved exception handling to catch specific database errors, enhancing error reporting and troubleshooting.
  
- **Chores**
	- Updated import statements for better clarity and consistency in referencing the `DBError` class.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->