### PR TITLE
Replace deprecated alias LoadBalancer

### DIFF
--- a/src/MediaWiki/Connection/LoadBalancerConnectionProvider.php
+++ b/src/MediaWiki/Connection/LoadBalancerConnectionProvider.php
@@ -7,6 +7,7 @@ use RuntimeException;
 use SMW\Connection\ConnectionProvider as IConnectionProvider;
 use SMW\Services\ServicesFactory;
 use Wikimedia\Rdbms\IDatabase;
+use Wikimedia\Rdbms\ILoadBalancer;
 
 /**
  * @license GNU GPL v2+
@@ -39,7 +40,7 @@ class LoadBalancerConnectionProvider implements IConnectionProvider {
 	private $wiki;
 
 	/**
-	 * @var LoadBalancer
+	 * @var ILoadBalancer
 	 */
 	private $loadBalancer;
 
@@ -75,7 +76,7 @@ class LoadBalancerConnectionProvider implements IConnectionProvider {
 	 *
 	 * @param loadBalancer $loadBalancer
 	 */
-	public function setLoadBalancer( \LoadBalancer $loadBalancer ) {
+	public function setLoadBalancer( ILoadBalancer $loadBalancer ) {
 		$this->loadBalancer = $loadBalancer;
 	}
 

--- a/tests/phpunit/MediaWiki/Connection/LoadBalancerConnectionProviderTest.php
+++ b/tests/phpunit/MediaWiki/Connection/LoadBalancerConnectionProviderTest.php
@@ -6,6 +6,7 @@ use ReflectionClass;
 use SMW\Tests\PHPUnitCompat;
 use SMW\MediaWiki\Connection\LoadBalancerConnectionProvider;
 use SMW\Tests\TestEnvironment;
+use Wikimedia\Rdbms\ILoadBalancer;
 
 /**
  * @covers \SMW\MediaWiki\Connection\LoadBalancerConnectionProvider
@@ -23,7 +24,7 @@ class LoadBalancerConnectionProviderTest extends \PHPUnit_Framework_TestCase {
 	private $loadBalancer;
 
 	protected function setUp(): void {
-		$this->loadBalancer = $this->getMockBuilder( '\LoadBalancer' )
+		$this->loadBalancer = $this->getMockBuilder( ILoadBalancer::class )
 			->disableOriginalConstructor()
 			->getMock();
 
@@ -95,7 +96,7 @@ class LoadBalancerConnectionProviderTest extends \PHPUnit_Framework_TestCase {
 	}
 
 	public function testGetInvalidConnectionFromLoadBalancerThrowsException() {
-		$loadBalancer = $this->getMockBuilder( '\LoadBalancer' )
+		$loadBalancer = $this->getMockBuilder( ILoadBalancer::class )
 			->disableOriginalConstructor()
 			->getMock();
 

--- a/tests/phpunit/Services/MediaWikiServicesContainerBuildTest.php
+++ b/tests/phpunit/Services/MediaWikiServicesContainerBuildTest.php
@@ -3,6 +3,7 @@
 namespace SMW\Tests\Services;
 
 use Onoi\CallbackContainer\CallbackContainerFactory;
+use Wikimedia\Rdbms\ILoadBalancer;
 
 /**
  * @group semantic-mediawiki
@@ -56,7 +57,7 @@ class MediaWikiServicesContainerBuildTest extends \PHPUnit_Framework_TestCase {
 		$provider[] = [
 			'DBLoadBalancer',
 			[],
-			'\LoadBalancer'
+			ILoadBalancer::class
 		];
 
 /*


### PR DESCRIPTION
The alias was available from MediaWiki 1.29 to MediaWiki 1.41, removed in MediaWiki 1.42.

This fixes 3 errors and 1 failure in tests for 1.42.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced abstraction in the Load Balancer connection handling by allowing any implementation of the ILoadBalancer interface.
  
- **Bug Fixes**
	- Improved mock object creation in tests to ensure compliance with the ILoadBalancer interface.

- **Tests**
	- Updated test cases to utilize the ILoadBalancer interface for better type safety and clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->