### PR TITLE
Deprecate method asConnectionRef()

### DIFF
--- a/src/MediaWiki/Connection/LoadBalancerConnectionProvider.php
+++ b/src/MediaWiki/Connection/LoadBalancerConnectionProvider.php
@@ -44,11 +44,6 @@ class LoadBalancerConnectionProvider implements IConnectionProvider {
 	private $loadBalancer;
 
 	/**
-	 * @var boolean
-	 */
-	private $asConnectionRef = true;
-
-	/**
 	 * @since 1.9
 	 *
 	 * @param int $id
@@ -64,10 +59,11 @@ class LoadBalancerConnectionProvider implements IConnectionProvider {
 	/**
 	 * @since 3.1
 	 *
+	 * @deprecated since 5.0
+	 *
 	 * @param boolean $asConnectionRef
 	 */
 	public function asConnectionRef( $asConnectionRef ) {
-		$this->asConnectionRef = $asConnectionRef;
 	}
 
 	/**
@@ -96,11 +92,7 @@ class LoadBalancerConnectionProvider implements IConnectionProvider {
 			$this->initLoadBalancer( $this->wiki );
 		}
 
-		if ( $this->asConnectionRef ) {
-			$this->connection = $this->loadBalancer->getConnectionRef( $this->id, $this->groups, $this->wiki );
-		} else {
-			$this->connection = $this->loadBalancer->getConnection( $this->id, $this->groups, $this->wiki );
-		}
+		$this->connection = $this->loadBalancer->getConnection( $this->id, $this->groups, $this->wiki );
 
 		if ( $this->connection instanceof IDatabase ) {
 			return $this->connection;

--- a/src/MediaWiki/MwCollaboratorFactory.php
+++ b/src/MediaWiki/MwCollaboratorFactory.php
@@ -118,15 +118,16 @@ class MwCollaboratorFactory {
 	/**
 	 * @since 2.1
 	 *
+	 * @param int $connectionType
+	 * @param bool $asConnectionRef Deprecated parameter since 5.0
+	 *
+	 * @note The parameter $asConnectionRef is deprecated since 5.0
+	 *
 	 * @return LoadBalancerConnectionProvider
 	 */
 	public function newLoadBalancerConnectionProvider( $connectionType, $asConnectionRef = true ) {
 		$loadBalancerConnectionProvider = new LoadBalancerConnectionProvider(
 			$connectionType
-		);
-
-		$loadBalancerConnectionProvider->asConnectionRef(
-			$asConnectionRef
 		);
 
 		return $loadBalancerConnectionProvider;

--- a/src/Setup.php
+++ b/src/Setup.php
@@ -209,7 +209,7 @@ final class Setup {
 
 		$connectionManager->registerConnectionProvider(
 			DB_REPLICA,
-			$mwCollaboratorFactory->newLoadBalancerConnectionProvider( DB_REPLICA, false )
+			$mwCollaboratorFactory->newLoadBalancerConnectionProvider( DB_REPLICA )
 		);
 
 		$connectionManager->registerConnectionProvider(

--- a/tests/phpunit/MediaWiki/Connection/LoadBalancerConnectionProviderTest.php
+++ b/tests/phpunit/MediaWiki/Connection/LoadBalancerConnectionProviderTest.php
@@ -51,35 +51,6 @@ class LoadBalancerConnectionProviderTest extends \PHPUnit_Framework_TestCase {
 			DB_REPLICA
 		);
 
-		$instance->asConnectionRef( false );
-
-		$connection = $instance->getConnection();
-
-		$this->assertInstanceOf(
-			'\Wikimedia\Rdbms\IDatabase',
-			$instance->getConnection()
-		);
-
-		$this->assertTrue(
-			$instance->getConnection() === $connection
-		);
-
-		$instance->releaseConnection();
-	}
-
-	public function testGetAndReleaseConnectionRef() {
-		$database = $this->getMockBuilder( '\Wikimedia\Rdbms\IDatabase' )
-			->disableOriginalConstructor()
-			->getMock();
-
-		$this->loadBalancer->expects( $this->once() )
-			->method( 'getConnectionRef' )
-			->will( $this->returnValue( $database ) );
-
-		$instance = new LoadBalancerConnectionProvider(
-			DB_REPLICA
-		);
-
 		$connection = $instance->getConnection();
 
 		$this->assertInstanceOf(
@@ -108,7 +79,6 @@ class LoadBalancerConnectionProviderTest extends \PHPUnit_Framework_TestCase {
 		);
 
 		$instance->setLoadBalancer( $loadBalancer );
-		$instance->asConnectionRef( false );
 
 		$this->expectException( 'RuntimeException' );
 		$instance->getConnection();


### PR DESCRIPTION
Since MW 1.39, `LoadBalancer::getConnectionRef()` is deprecated and returns `LoadBalancer::getConnection()`, so a `DBConnRef` is always returned.

I do not remove the method `LoadBalancerConnectionProvider::asConnectionRef()` to let time to SMW extensions to update their code, idem for the parameter in `MwCollaboratorFactory::newLoadBalancerConnectionProvider()`. I’m not sure if it is the SMW deprecation policy, I may adjust if needed.

The test `LoadBalancerConnectionProviderTest::testGetAndReleaseConnectionRef()` is removed because it became identifical to `testGetAndReleaseConnection()` when the call to `asConnectionRef()` is removed.