### PR TITLE
Declare caller method in tableExists

### DIFF
--- a/src/MediaWiki/Connection/CleanUpTables.php
+++ b/src/MediaWiki/Connection/CleanUpTables.php
@@ -49,7 +49,7 @@ class CleanUpTables {
 
 		foreach ( $tables as $table ) {
 
-			if ( strpos( $table, $tablePrefix ) === false || !$this->connection->tableExists( $table ) ) {
+			if ( strpos( $table, $tablePrefix ) === false || !$this->connection->tableExists( $table, __METHOD__ ) ) {
 				continue;
 			}
 

--- a/src/MediaWiki/Specials/Admin/Supplement/EntityLookupTaskHandler.php
+++ b/src/MediaWiki/Specials/Admin/Supplement/EntityLookupTaskHandler.php
@@ -314,7 +314,7 @@ class EntityLookupTaskHandler extends TaskHandler implements ActionableTask {
 	private function addFulltextInfo( $id, &$references ) {
 		$connection = $this->store->getConnection( 'mw.db' );
 
-		if ( !$connection->tableExists( SQLStore::FT_SEARCH_TABLE ) ) {
+		if ( !$connection->tableExists( SQLStore::FT_SEARCH_TABLE, __METHOD__ ) ) {
 			return;
 		}
 

--- a/src/SQLStore/PropertyTableIdReferenceDisposer.php
+++ b/src/SQLStore/PropertyTableIdReferenceDisposer.php
@@ -322,7 +322,7 @@ class PropertyTableIdReferenceDisposer {
 		// Error: 126 Incorrect key file for table '.\mw@002d25@002d01\smw_ft_search.MYI'; ...
 		try {
 			if ( $this->fulltextTableUsage ) {
-				$tableExists = $this->connection->tableExists( SQLStore::FT_SEARCH_TABLE );
+				$tableExists = $this->connection->tableExists( SQLStore::FT_SEARCH_TABLE, __METHOD__ );
 			}
 		} catch ( DBError $e ) {
 			ApplicationFactory::getInstance()->getMediaWikiLogger()->info( __METHOD__ . ' reported: ' . $e->getMessage() );

--- a/src/SQLStore/TableBuilder/TableBuilder.php
+++ b/src/SQLStore/TableBuilder/TableBuilder.php
@@ -145,7 +145,7 @@ abstract class TableBuilder implements TableBuilderInterface, MessageReporterAwa
 
 		$this->reportMessage( "Checking table $tableName ...\n" );
 
-		if ( $this->connection->tableExists( $tableName ) === false ) { // create new table
+		if ( $this->connection->tableExists( $tableName, __METHOD__ ) === false ) { // create new table
 			$this->reportMessage( "   Table not found, now creating...\n" );
 			$this->doCreateTable( $tableName, $attributes );
 		} else {
@@ -185,7 +185,7 @@ abstract class TableBuilder implements TableBuilderInterface, MessageReporterAwa
 
 		$this->droppedTables[$tableName] = true;
 
-		if ( $this->connection->tableExists( $tableName ) === false ) { // create new table
+		if ( $this->connection->tableExists( $tableName, __METHOD__ ) === false ) { // create new table
 			return $this->reportMessage(
 				$cliMsgFormatter->twoCols( "... $tableName (not found) ...", 'SKIPPED', 3 )
 			);


### PR DESCRIPTION
MW 1.43 issues a warning "SQL query did not specify the caller"

This is only a warning on MW 1.43, mainly during update.php.

I made a small review of other SQL calls in SMW, all others had `__METHOD__`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Enhanced the logic for verifying the existence of database tables, improving reliability in various methods across the application.
  
- **New Features**
	- Updated method signatures to include context for table existence checks, aiding in debugging and logging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->