### PR TITLE
Wrong PSR-4 namespace for one test

### DIFF
--- a/tests/phpunit/MediaWiki/Page/ConceptPageTest.php
+++ b/tests/phpunit/MediaWiki/Page/ConceptPageTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace SMW\MediaWiki\Tests\Page;
+namespace SMW\Tests\MediaWiki\Page;
 
 use SMW\DIWikiPage;
 use SMW\MediaWiki\Page\ConceptPage;


### PR DESCRIPTION
Reported by Composer during dump-autoload (but not visible on the CI, I don’t know why).

There is another warning about `Onoi\Tesa\Tests`, but it requires to adjust filenames and/or namespaces to make it compatible with PSR-4, so in a dedicated PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the namespace declaration for improved organization and alignment with project conventions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->