### PR TITLE
Replace deprecated Title::getRestrictions()

### DIFF
--- a/src/Property/Annotators/EditProtectedPropertyAnnotator.php
+++ b/src/Property/Annotators/EditProtectedPropertyAnnotator.php
@@ -3,6 +3,7 @@
 namespace SMW\Property\Annotators;
 
 use Html;
+use MediaWiki\MediaWikiServices;
 use ParserOutput;
 use SMW\MediaWiki\PageInfoProvider;
 use SMW\Message;
@@ -118,7 +119,8 @@ class EditProtectedPropertyAnnotator extends PropertyAnnotatorDecorator {
 			return false;
 		}
 
-		$restrictions = array_flip( $this->title->getRestrictions( 'edit' ) );
+		$restrictionStore = MediaWikiServices::getInstance()->getRestrictionStore();
+		$restrictions = array_flip( $restrictionStore->getRestrictions( $this->title, 'edit' ) );
 
 		// There could by any edit protections but the `Is edit protected` is
 		// bound to the `smwgEditProtectionRight` setting

--- a/src/Protection/EditProtectionUpdater.php
+++ b/src/Protection/EditProtectionUpdater.php
@@ -2,6 +2,7 @@
 
 namespace SMW\Protection;
 
+use MediaWiki\MediaWikiServices;
 use Psr\Log\LoggerAwareInterface;
 use Psr\Log\LoggerInterface;
 use RequestContext;
@@ -110,7 +111,8 @@ class EditProtectionUpdater implements LoggerAwareInterface {
 			return;
 		}
 
-		$restrictions = array_flip( $title->getRestrictions( 'edit' ) );
+		$restrictionStore = MediaWikiServices::getInstance()->getRestrictionStore();
+		$restrictions = array_flip( $restrictionStore->getRestrictions( $title, 'edit' ) );
 
 		// No `Is edit protected` was found and the restriction doesn't contain
 		// a matchable `editProtectionRight`


### PR DESCRIPTION
This requires MediaWiki 1.37+. This method was deleted in MediaWiki 1.41.

This fixes 2 errors in tests of MW 1.41 and 1.42.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced edit protection logic by integrating with MediaWiki services for improved restriction management.
- **Bug Fixes**
	- Updated methods for fetching edit restrictions to ensure consistency and reliability in edit protection handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->