### PR TITLE
Fix DependencyLinksValidator for MW 1.42.x

### DIFF
--- a/src/SQLStore/QueryDependency/DependencyLinksValidator.php
+++ b/src/SQLStore/QueryDependency/DependencyLinksValidator.php
@@ -116,10 +116,8 @@ class DependencyLinksValidator {
 		// INNER JOIN smw_object_ids AS p ON ((s_id=p.smw_id))
 		// INNER JOIN smw_object_ids AS v ON ((o_id=v.smw_id))
 		// WHERE p.smw_hash = 'xxx' AND (p.smw_iw!=':smw') AND (p.smw_iw!=':smw-delete')
-		$id_table = $connection->tableName( SQLStore::ID_TABLE );
-
 		$rows = $connection->select(
-			[ $proptables[$tableid]->getName(), $id_table . ' AS p', $id_table . ' AS v' ],
+			[ $proptables[$tableid]->getName(), "p" => SQLStore::ID_TABLE, "v" => SQLStore::ID_TABLE ],
 			[
 				'v.smw_id', 'v.smw_subobject', 'v.smw_touched'
 			],
@@ -133,8 +131,8 @@ class DependencyLinksValidator {
 			//	'ORDER BY' => 'v.smw_touched'
 			],
 			[
-				$id_table . ' AS p' => [ 'INNER JOIN', [ 's_id=p.smw_id' ] ],
-				$id_table . ' AS v' => [ 'INNER JOIN', [ 'o_id=v.smw_id' ] ]
+				"p" => [ 'INNER JOIN', [ 's_id=p.smw_id' ] ],
+				"v" => [ 'INNER JOIN', [ 'o_id=v.smw_id' ] ]
 			]
 		);
 
@@ -166,10 +164,8 @@ class DependencyLinksValidator {
 		// INNER JOIN smw_query_links AS p ON ((p.o_id=smw_id))
 		// WHERE p.s_id = '18341' AND (smw_touched > '2019-01-08 17:45:03')
 		// LIMIT 1
-		$links_table = $connection->tableName( SQLStore::QUERY_LINKS_TABLE );
-
 		$row = $connection->selectRow(
-			[ SQLStore::ID_TABLE, $links_table . ' AS p' ],
+			[ SQLStore::ID_TABLE, "p" => SQLStore::QUERY_LINKS_TABLE ],
 			[
 				'smw_id'
 			],
@@ -180,7 +176,7 @@ class DependencyLinksValidator {
 			__METHOD__,
 			[],
 			[
-				$links_table . ' AS p' => [ 'INNER JOIN', [ 'p.o_id=smw_id' ] ],
+				"p" => [ 'INNER JOIN', [ 'p.o_id=smw_id' ] ],
 			]
 		);
 


### PR DESCRIPTION
MW 1.42.x apparently only allows table name aliases to be specified as `"alias" => "table"` pairs.

This PR fixes a crash with MW 1.42.x or later when setting ` $smwgEnabledQueryDependencyLinksStore = true;`. See also [this issuecomment](https://github.com/SemanticMediaWiki/SemanticMediaWiki/issues/5634#issuecomment-2396556344) in #5634.

This is a followup to #5715.

Note that this is my first PR to a MediaWiki extension and my first PHP change in a long time, even though it's quite minimal.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
	- Updated SQL query syntax for improved clarity in table name references.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->