### PR TITLE
type cast limt and offset to int to fix some notices

### DIFF
--- a/src/MediaWiki/MessageBuilder.php
+++ b/src/MediaWiki/MessageBuilder.php
@@ -100,6 +100,8 @@ class MessageBuilder {
 	 * @return string
 	 */
 	public function prevNextToText( Title $title, $limit, $offset, array $query, $isAtTheEnd ) {
+		$limit = (int) $limit;
+		$offset = (int) $offset;
 		if ( class_exists( PagerNavigationBuilder::class ) ) {
 			// MW > 1.39
 			$navBuilder = new PagerNavigationBuilder( RequestContext::getMain() );
@@ -107,7 +109,7 @@ class MessageBuilder {
 				->setPage( $title )
 				->setLinkQuery( [ 'limit' => $limit, 'offset' => $offset ] + $query )
 				->setLimitLinkQueryParam( 'limit' )
-				->setCurrentLimit( $limit )
+				->setCurrentLimit( (int) $limit )
 				->setPrevTooltipMsg( 'prevn-title' )
 				->setNextTooltipMsg( 'nextn-title' )
 				->setLimitTooltipMsg( 'shown-title' );

--- a/src/MediaWiki/Renderer/HtmlFormRenderer.php
+++ b/src/MediaWiki/Renderer/HtmlFormRenderer.php
@@ -437,7 +437,7 @@ class HtmlFormRenderer {
 
 			$resultCount = $instance->getMessageBuilder()
 				->getMessage( 'showingresults' )
-				->numParams( $messageCount, $offset + 1 )
+				->numParams( $messageCount, (int) $offset + 1 )
 				->parse();
 
 			$paging = $instance->getMessageBuilder()->prevNextToText(

--- a/src/MediaWiki/Specials/PageProperty/PageBuilder.php
+++ b/src/MediaWiki/Specials/PageProperty/PageBuilder.php
@@ -85,7 +85,7 @@ class PageBuilder {
 			return Message::get( 'smw_result_noresults', Message::TEXT, Message::USER_LANGUAGE );
 		}
 
-		$limit = $this->options->get( 'limit' );
+		$limit = (int) $this->options->get( 'limit' );
 		$dataValueFactory = DataValueFactory::getInstance();
 
 		$propertyValue = $dataValueFactory->newPropertyValueByLabel(
@@ -147,8 +147,8 @@ class PageBuilder {
 			->withFieldset()
 			->addParagraph( Message::get( 'smw_pp_docu', Message::TEXT, Message::USER_LANGUAGE ) )
 			->addPaging(
-				$this->options->safeGet( 'limit', 20 ),
-				$this->options->safeGet( 'offset', 0 ),
+				(int) $this->options->safeGet( 'limit', 20 ),
+				(int) $this->options->safeGet( 'offset', 0 ),
 				$count )
 			->addHorizontalRule()
 			->openElement( 'div', [ 'class' => 'smw-special-pageproperty-input' ] )

--- a/src/MediaWiki/Specials/SpecialPageProperty.php
+++ b/src/MediaWiki/Specials/SpecialPageProperty.php
@@ -140,8 +140,8 @@ class SpecialPageProperty extends SpecialPage {
 		} else {
 
 			$requestOptions = new RequestOptions();
-			$requestOptions->setLimit( $options->get( 'limit' ) + 1 );
-			$requestOptions->setOffset( $options->get( 'offset' ) );
+			$requestOptions->setLimit( (int) $options->get( 'limit' ) + 1 );
+			$requestOptions->setOffset( (int) $options->get( 'offset' ) );
 			$requestOptions->sort = !SequenceMap::canMap( $propertyValue->getDataItem() );
 
 			// Restrict the request otherwise the entire SemanticData record


### PR DESCRIPTION
type casting for https://github.com/SemanticMediaWiki/SemanticMediaWiki/issues/5736

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Corrected a duplicate parameter declaration in the `prevNextToText` method for improved functionality.
	- Enhanced type safety by ensuring that limit and offset values are consistently cast to integers across various methods.

- **Improvements**
	- Updated method signatures to better reflect parameter usage and enhance clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->