### PR TITLE
Do not skip data update on null edit

### DIFF
--- a/src/DataUpdater.php
+++ b/src/DataUpdater.php
@@ -166,17 +166,7 @@ class DataUpdater {
 	 * @return boolean
 	 */
 	public function isSkippable( Title $title, ?int &$latestRevID = null ) {
-		if ( $this->revisionGuard->isSkippableUpdate( $title, $latestRevID ) ) {
-			return true;
-		}
-
-		$associatedRev = $this->store->getObjectIds()->findAssociatedRev(
-			$title->getDBKey(),
-			$title->getNamespace(),
-			$title->getInterwiki()
-		);
-
-		return $associatedRev == $latestRevID;
+		return $this->revisionGuard->isSkippableUpdate( $title, $latestRevID );
 	}
 
 	/**


### PR DESCRIPTION
Simplify DataUpdater::isSkippable() to not return true if the current revision being generated is also the latest revision, i.e. if it's a null edit - because sometimes you do want SMW data to be refreshed on a null edit, like if any of the property values are dynamic.

Fixes #5740 .