### PR TITLE
[Special:Ask] Trying to access array offset on value of type null

### DIFF
--- a/src/Query/Processor/ParamListProcessor.php
+++ b/src/Query/Processor/ParamListProcessor.php
@@ -87,6 +87,9 @@ class ParamListProcessor {
 			}
 
 			$param = $this->encodeEq( $param );
+			if ( $param === null ) {
+				continue;
+			}
 
 			// #1258 (named_args -> named args)
 			// accept 'name' => 'value' just as '' => 'name=value':


### PR DESCRIPTION
Issue: #5745

In ParamListProcessor.php, line 89, the function call:
`$param = $this->encodeEq( $param );`
sometimes returns null, which later triggers a notice when lines 114 and 116 attempt to access index 0 of an array derived from $param.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved handling of null parameters to enhance data processing and prevent potential errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->