### PR TITLE
fix: create temp table only of not existing yet

### DIFF
--- a/src/SQLStore/TableBuilder/TemporaryTableBuilder.php
+++ b/src/SQLStore/TableBuilder/TemporaryTableBuilder.php
@@ -110,7 +110,7 @@ class TemporaryTableBuilder {
 		}
 
 		// MySQL_ just a temporary table, use INSERT IGNORE later
-		return "CREATE TEMPORARY TABLE " . $tableName . "( id INT UNSIGNED KEY ) ENGINE=MEMORY";
+		return "CREATE TEMPORARY TABLE IF NOT EXISTS " . $tableName . "( id INT UNSIGNED KEY ) ENGINE=MEMORY";
 	}
 
 }


### PR DESCRIPTION
Closes #5714

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Updated the temporary table creation SQL command to include `IF NOT EXISTS`, preventing errors when the table already exists.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->