### PR TITLE
make $baseStore public

### DIFF
--- a/src/SPARQLStore/SPARQLStore.php
+++ b/src/SPARQLStore/SPARQLStore.php
@@ -50,11 +50,14 @@ class SPARQLStore extends Store {
 
 	/**
 	 * Underlying store to use for basic read operations.
+  	 * Public in order to allow result format to access
+    	 * the SQLStore since SPARQLStore is not a subclass of
+	 * SQLStore (different from ElasticStore).
 	 *
 	 * @since 1.8
 	 * @var Store
 	 */
-	private $baseStore;
+	public $baseStore;
 
 	/**
 	 * @since 1.8

--- a/src/SPARQLStore/SPARQLStore.php
+++ b/src/SPARQLStore/SPARQLStore.php
@@ -50,9 +50,7 @@ class SPARQLStore extends Store {
 
 	/**
 	 * Underlying store to use for basic read operations.
-  	 * Public in order to allow result format to access
-    	 * the SQLStore since SPARQLStore is not a subclass of
-	 * SQLStore (different from ElasticStore).
+  	 * Public since 5.0. (https://github.com/SemanticMediaWiki/SemanticMediaWiki/pull/5749)
 	 *
 	 * @since 1.8
 	 * @var Store


### PR DESCRIPTION
in order to allow result format to access the SQLStore since SPARQLStore is not a subclass of SQLStore (different from ElasticStore).

See: #5748 
https://github.com/SemanticMediaWiki/SemanticResultFormats/issues/827

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- The `$baseStore` property in the `SPARQLStore` class is now publicly accessible, allowing for enhanced interaction with result formats and SQLStore.
  
- **Bug Fixes**
	- No bugs reported or fixed in this release.

- **Documentation**
	- Updated documentation to reflect the change in visibility of the `$baseStore` property.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->